### PR TITLE
[InstCombine] Fold comparisons of llvm.usub.sat result with its LHS

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -7743,10 +7743,10 @@ Instruction *InstCombinerImpl::foldICmpCommutative(CmpPredicate Pred,
   const SimplifyQuery Q = SQ.getWithInstruction(&CxtI);
 
   {
-    // For Y != 0:
-    // usub.sat(X, Y) == X  --> X == 0
-    // usub.sat(X, Y) != X  --> X != 0
-    // usub.sat(X, Y) <  X  --> X != 0
+    // For a nonzero constant C:
+    // usub.sat(X, C) == X  --> X == 0
+    // usub.sat(X, C) != X  --> X != 0
+    // usub.sat(X, C) <  X  --> X != 0
     if (match(Op0, m_Intrinsic<Intrinsic::usub_sat>(m_Specific(Op1),
                                                     m_NonZeroInt())) &&
         (CmpInst::isEquality(Pred) || Pred == ICmpInst::ICMP_ULT)) {

--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -3952,7 +3952,6 @@ Instruction *InstCombinerImpl::foldICmpEqIntrinsicWithConstant(
   return nullptr;
 }
 
-/// Fold an icmp with LLVM intrinsics
 static Instruction *
 foldICmpIntrinsicWithIntrinsic(ICmpInst &Cmp,
                                InstCombiner::BuilderTy &Builder) {
@@ -7741,6 +7740,24 @@ Instruction *InstCombinerImpl::foldICmpCommutative(CmpPredicate Pred,
   }
 
   const SimplifyQuery Q = SQ.getWithInstruction(&CxtI);
+
+  {
+    Value *Y;
+    // For Y != 0:
+    // usub.sat(X, Y) == X  --> X == 0
+    // usub.sat(X, Y) != X  --> X != 0
+    // usub.sat(X, Y) <  X  --> X != 0
+    if (match(Op0, m_Intrinsic<Intrinsic::usub_sat>(m_Specific(Op1),
+                                                    m_Value(Y))) &&
+        (CmpInst::isEquality(Pred) || Pred == ICmpInst::ICMP_ULT) &&
+        isKnownNonZero(Y, Q)) {
+      ICmpInst::Predicate NewPred =
+          CmpInst::isEquality(Pred) ? Pred.dropSameSign() : ICmpInst::ICMP_NE;
+      return new ICmpInst(NewPred, Op1,
+                          Constant::getNullValue(Op1->getType()));
+    }
+  }
+
   if (Value *V = foldICmpWithLowBitMaskedVal(Pred, Op0, Op1, Q, *this))
     return replaceInstUsesWith(CxtI, V);
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -7752,8 +7752,7 @@ Instruction *InstCombinerImpl::foldICmpCommutative(CmpPredicate Pred,
         (CmpInst::isEquality(Pred) || Pred == ICmpInst::ICMP_ULT)) {
       ICmpInst::Predicate NewPred =
           CmpInst::isEquality(Pred) ? Pred.dropSameSign() : ICmpInst::ICMP_NE;
-      return new ICmpInst(NewPred, Op1,
-                          Constant::getNullValue(Op1->getType()));
+      return new ICmpInst(NewPred, Op1, Constant::getNullValue(Op1->getType()));
     }
   }
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -3952,6 +3952,7 @@ Instruction *InstCombinerImpl::foldICmpEqIntrinsicWithConstant(
   return nullptr;
 }
 
+/// Fold an icmp with LLVM intrinsics
 static Instruction *
 foldICmpIntrinsicWithIntrinsic(ICmpInst &Cmp,
                                InstCombiner::BuilderTy &Builder) {
@@ -7742,15 +7743,13 @@ Instruction *InstCombinerImpl::foldICmpCommutative(CmpPredicate Pred,
   const SimplifyQuery Q = SQ.getWithInstruction(&CxtI);
 
   {
-    Value *Y;
     // For Y != 0:
     // usub.sat(X, Y) == X  --> X == 0
     // usub.sat(X, Y) != X  --> X != 0
     // usub.sat(X, Y) <  X  --> X != 0
     if (match(Op0, m_Intrinsic<Intrinsic::usub_sat>(m_Specific(Op1),
-                                                    m_Value(Y))) &&
-        (CmpInst::isEquality(Pred) || Pred == ICmpInst::ICMP_ULT) &&
-        isKnownNonZero(Y, Q)) {
+                                                    m_NonZeroInt())) &&
+        (CmpInst::isEquality(Pred) || Pred == ICmpInst::ICMP_ULT)) {
       ICmpInst::Predicate NewPred =
           CmpInst::isEquality(Pred) ? Pred.dropSameSign() : ICmpInst::ICMP_NE;
       return new ICmpInst(NewPred, Op1,

--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -7861,6 +7861,20 @@ Instruction *InstCombinerImpl::foldICmpCommutative(CmpPredicate Pred,
     }
   }
 
+  {
+    // For a nonzero constant C:
+    // usub.sat(X, C) == X  --> X == 0
+    // usub.sat(X, C) != X  --> X != 0
+    // usub.sat(X, C) <  X  --> X != 0
+    if (match(Op0, m_Intrinsic<Intrinsic::usub_sat>(m_Specific(Op1),
+                                                    m_NonZeroInt())) &&
+        (CmpInst::isEquality(Pred) || Pred == ICmpInst::ICMP_ULT)) {
+      ICmpInst::Predicate NewPred =
+          CmpInst::isEquality(Pred) ? Pred.dropSameSign() : ICmpInst::ICMP_NE;
+      return new ICmpInst(NewPred, Op1, Constant::getNullValue(Op1->getType()));
+    }
+  }
+
   const SimplifyQuery Q = SQ.getWithInstruction(&CxtI);
   if (Value *V = foldICmpWithLowBitMaskedVal(Pred, Op0, Op1, Q, *this))
     return replaceInstUsesWith(CxtI, V);

--- a/llvm/test/Transforms/InstCombine/icmp-usub-sat.ll
+++ b/llvm/test/Transforms/InstCombine/icmp-usub-sat.ll
@@ -469,6 +469,17 @@ define i1 @icmp_ult_usub_sat_lhs_nonzero_constant(i64 %x) {
   ret i1 %cmp
 }
 
+define i1 @icmp_samesign_ult_usub_sat_lhs_nonzero_constant(i64 %x) {
+; CHECK-LABEL: define i1 @icmp_samesign_ult_usub_sat_lhs_nonzero_constant
+; CHECK-SAME: (i64 [[X:%.*]]) {
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i64 [[X]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sat = call i64 @llvm.usub.sat.i64(i64 %x, i64 10)
+  %cmp = icmp samesign ult i64 %sat, %x
+  ret i1 %cmp
+}
+
 define i1 @icmp_ne_usub_sat_lhs_nonzero_constant(i64 %x) {
 ; CHECK-LABEL: define i1 @icmp_ne_usub_sat_lhs_nonzero_constant
 ; CHECK-SAME: (i64 [[X:%.*]]) {
@@ -536,6 +547,29 @@ define <2 x i1> @icmp_ult_usub_sat_lhs_nonzero_constant_vector(<2 x i8> %x) {
 ; CHECK-NEXT:    ret <2 x i1> [[CMP]]
 ;
   %sat = call <2 x i8> @llvm.usub.sat.v2i8(<2 x i8> %x, <2 x i8> <i8 10, i8 10>)
+  %cmp = icmp ult <2 x i8> %sat, %x
+  ret <2 x i1> %cmp
+}
+
+define <2 x i1> @icmp_ult_usub_sat_lhs_nonzero_constant_vector_nonsplat(<2 x i8> %x) {
+; CHECK-LABEL: define <2 x i1> @icmp_ult_usub_sat_lhs_nonzero_constant_vector_nonsplat
+; CHECK-SAME: (<2 x i8> [[X:%.*]]) {
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne <2 x i8> [[X]], zeroinitializer
+; CHECK-NEXT:    ret <2 x i1> [[CMP]]
+;
+  %sat = call <2 x i8> @llvm.usub.sat.v2i8(<2 x i8> %x, <2 x i8> <i8 1, i8 10>)
+  %cmp = icmp ult <2 x i8> %sat, %x
+  ret <2 x i1> %cmp
+}
+
+define <2 x i1> @icmp_ult_usub_sat_lhs_zero_constant_vector(<2 x i8> %x) {
+; CHECK-LABEL: define <2 x i1> @icmp_ult_usub_sat_lhs_zero_constant_vector
+; CHECK-SAME: (<2 x i8> [[X:%.*]]) {
+; CHECK-NEXT:    [[SAT:%.*]] = call <2 x i8> @llvm.usub.sat.v2i8(<2 x i8> [[X]], <2 x i8> <i8 1, i8 0>)
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult <2 x i8> [[SAT]], [[X]]
+; CHECK-NEXT:    ret <2 x i1> [[CMP]]
+;
+  %sat = call <2 x i8> @llvm.usub.sat.v2i8(<2 x i8> %x, <2 x i8> <i8 1, i8 0>)
   %cmp = icmp ult <2 x i8> %sat, %x
   ret <2 x i1> %cmp
 }

--- a/llvm/test/Transforms/InstCombine/icmp-usub-sat.ll
+++ b/llvm/test/Transforms/InstCombine/icmp-usub-sat.ll
@@ -425,11 +425,10 @@ define <2 x i1> @icmp_eq_vector_multiuse_negative_equal(<2 x i8> %arg) {
   ret <2 x i1> %cmp
 }
 
-define i1 @icmp_eq_lhs_nonzero_constant(i64 %x) {
-; CHECK-LABEL: define i1 @icmp_eq_lhs_nonzero_constant
+define i1 @icmp_eq_usub_sat_lhs_nonzero_constant(i64 %x) {
+; CHECK-LABEL: define i1 @icmp_eq_usub_sat_lhs_nonzero_constant
 ; CHECK-SAME: (i64 [[X:%.*]]) {
-; CHECK-NEXT:    [[SAT:%.*]] = call i64 @llvm.usub.sat.i64(i64 [[X]], i64 10)
-; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i64 [[SAT]], [[X]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i64 [[X]], 0
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %sat = call i64 @llvm.usub.sat.i64(i64 %x, i64 10)
@@ -437,11 +436,10 @@ define i1 @icmp_eq_lhs_nonzero_constant(i64 %x) {
   ret i1 %cmp
 }
 
-define i1 @icmp_eq_lhs_nonzero_constant_commuted(i64 %x) {
-; CHECK-LABEL: define i1 @icmp_eq_lhs_nonzero_constant_commuted
+define i1 @icmp_eq_usub_sat_lhs_nonzero_constant_commuted(i64 %x) {
+; CHECK-LABEL: define i1 @icmp_eq_usub_sat_lhs_nonzero_constant_commuted
 ; CHECK-SAME: (i64 [[X:%.*]]) {
-; CHECK-NEXT:    [[SAT:%.*]] = call i64 @llvm.usub.sat.i64(i64 [[X]], i64 10)
-; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i64 [[X]], [[SAT]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i64 [[X]], 0
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %sat = call i64 @llvm.usub.sat.i64(i64 %x, i64 10)
@@ -449,11 +447,10 @@ define i1 @icmp_eq_lhs_nonzero_constant_commuted(i64 %x) {
   ret i1 %cmp
 }
 
-define i1 @icmp_ult_lhs_nonzero_constant(i64 %x) {
-; CHECK-LABEL: define i1 @icmp_ult_lhs_nonzero_constant
+define i1 @icmp_ult_usub_sat_lhs_nonzero_constant(i64 %x) {
+; CHECK-LABEL: define i1 @icmp_ult_usub_sat_lhs_nonzero_constant
 ; CHECK-SAME: (i64 [[X:%.*]]) {
-; CHECK-NEXT:    [[SAT:%.*]] = call i64 @llvm.usub.sat.i64(i64 [[X]], i64 10)
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i64 [[SAT]], [[X]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i64 [[X]], 0
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %sat = call i64 @llvm.usub.sat.i64(i64 %x, i64 10)
@@ -461,11 +458,33 @@ define i1 @icmp_ult_lhs_nonzero_constant(i64 %x) {
   ret i1 %cmp
 }
 
-define i1 @icmp_eq_lhs_nonzero_constant_multiuse(i64 %x) {
-; CHECK-LABEL: define i1 @icmp_eq_lhs_nonzero_constant_multiuse
+define i1 @icmp_ne_usub_sat_lhs_nonzero_constant(i64 %x) {
+; CHECK-LABEL: define i1 @icmp_ne_usub_sat_lhs_nonzero_constant
+; CHECK-SAME: (i64 [[X:%.*]]) {
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i64 [[X]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sat = call i64 @llvm.usub.sat.i64(i64 %x, i64 10)
+  %cmp = icmp ne i64 %sat, %x
+  ret i1 %cmp
+}
+
+define i1 @icmp_ugt_usub_sat_lhs_nonzero_constant(i64 %x) {
+; CHECK-LABEL: define i1 @icmp_ugt_usub_sat_lhs_nonzero_constant
+; CHECK-SAME: (i64 [[X:%.*]]) {
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i64 [[X]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sat = call i64 @llvm.usub.sat.i64(i64 %x, i64 10)
+  %cmp = icmp ugt i64 %x, %sat
+  ret i1 %cmp
+}
+
+define i1 @icmp_eq_usub_sat_lhs_nonzero_constant_multiuse(i64 %x) {
+; CHECK-LABEL: define i1 @icmp_eq_usub_sat_lhs_nonzero_constant_multiuse
 ; CHECK-SAME: (i64 [[X:%.*]]) {
 ; CHECK-NEXT:    [[SAT:%.*]] = call i64 @llvm.usub.sat.i64(i64 [[X]], i64 10)
-; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i64 [[SAT]], [[X]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i64 [[X]], 0
 ; CHECK-NEXT:    call void @use.i64(i64 [[SAT]])
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
@@ -475,11 +494,11 @@ define i1 @icmp_eq_lhs_nonzero_constant_multiuse(i64 %x) {
   ret i1 %cmp
 }
 
-define i1 @icmp_ult_lhs_nonzero_constant_multiuse(i64 %x) {
-; CHECK-LABEL: define i1 @icmp_ult_lhs_nonzero_constant_multiuse
+define i1 @icmp_ult_usub_sat_lhs_nonzero_constant_multiuse(i64 %x) {
+; CHECK-LABEL: define i1 @icmp_ult_usub_sat_lhs_nonzero_constant_multiuse
 ; CHECK-SAME: (i64 [[X:%.*]]) {
 ; CHECK-NEXT:    [[SAT:%.*]] = call i64 @llvm.usub.sat.i64(i64 [[X]], i64 10)
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i64 [[SAT]], [[X]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i64 [[X]], 0
 ; CHECK-NEXT:    call void @use.i64(i64 [[SAT]])
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
@@ -489,8 +508,8 @@ define i1 @icmp_ult_lhs_nonzero_constant_multiuse(i64 %x) {
   ret i1 %cmp
 }
 
-define i1 @icmp_eq_lhs_zero_constant(i64 %x) {
-; CHECK-LABEL: define i1 @icmp_eq_lhs_zero_constant
+define i1 @icmp_eq_usub_sat_lhs_zero_constant(i64 %x) {
+; CHECK-LABEL: define i1 @icmp_eq_usub_sat_lhs_zero_constant
 ; CHECK-SAME: (i64 [[X:%.*]]) {
 ; CHECK-NEXT:    ret i1 true
 ;
@@ -499,16 +518,30 @@ define i1 @icmp_eq_lhs_zero_constant(i64 %x) {
   ret i1 %cmp
 }
 
-define <2 x i1> @icmp_ult_lhs_nonzero_constant_vector(<2 x i8> %x) {
-; CHECK-LABEL: define <2 x i1> @icmp_ult_lhs_nonzero_constant_vector
+define <2 x i1> @icmp_ult_usub_sat_lhs_nonzero_constant_vector(<2 x i8> %x) {
+; CHECK-LABEL: define <2 x i1> @icmp_ult_usub_sat_lhs_nonzero_constant_vector
 ; CHECK-SAME: (<2 x i8> [[X:%.*]]) {
-; CHECK-NEXT:    [[SAT:%.*]] = call <2 x i8> @llvm.usub.sat.v2i8(<2 x i8> [[X]], <2 x i8> splat (i8 10))
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ult <2 x i8> [[SAT]], [[X]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne <2 x i8> [[X]], zeroinitializer
 ; CHECK-NEXT:    ret <2 x i1> [[CMP]]
 ;
   %sat = call <2 x i8> @llvm.usub.sat.v2i8(<2 x i8> %x, <2 x i8> <i8 10, i8 10>)
   %cmp = icmp ult <2 x i8> %sat, %x
   ret <2 x i1> %cmp
+}
+
+define i1 @icmp_eq_usub_sat_lhs_known_nonzero_rhs(i64 %x, i64 %y) {
+; CHECK-LABEL: define i1 @icmp_eq_usub_sat_lhs_known_nonzero_rhs
+; CHECK-SAME: (i64 [[X:%.*]], i64 [[Y:%.*]]) {
+; CHECK-NEXT:    [[COND:%.*]] = icmp ne i64 [[Y]], 0
+; CHECK-NEXT:    call void @llvm.assume(i1 [[COND]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i64 [[X]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %cond = icmp ne i64 %y, 0
+  call void @llvm.assume(i1 %cond)
+  %sat = call i64 @llvm.usub.sat.i64(i64 %x, i64 %y)
+  %cmp = icmp eq i64 %sat, %x
+  ret i1 %cmp
 }
 
 declare i8 @llvm.usub.sat.i8(i8, i8)
@@ -520,6 +553,8 @@ declare <2 x i64> @llvm.usub.sat.v2i64(<2 x i64>, <2 x i64>)
 declare <2 x i32> @llvm.usub.sat.v2i32(<2 x i32>, <2 x i32>)
 declare <2 x i16> @llvm.usub.sat.v2i16(<2 x i16>, <2 x i16>)
 declare <2 x i8> @llvm.usub.sat.v2i8(<2 x i8>, <2 x i8>)
+
+declare void @llvm.assume(i1)
 
 declare void @use.i8(i8)
 declare void @use.v2i8(<2 x i8>)

--- a/llvm/test/Transforms/InstCombine/icmp-usub-sat.ll
+++ b/llvm/test/Transforms/InstCombine/icmp-usub-sat.ll
@@ -425,6 +425,92 @@ define <2 x i1> @icmp_eq_vector_multiuse_negative_equal(<2 x i8> %arg) {
   ret <2 x i1> %cmp
 }
 
+define i1 @icmp_eq_lhs_nonzero_constant(i64 %x) {
+; CHECK-LABEL: define i1 @icmp_eq_lhs_nonzero_constant
+; CHECK-SAME: (i64 [[X:%.*]]) {
+; CHECK-NEXT:    [[SAT:%.*]] = call i64 @llvm.usub.sat.i64(i64 [[X]], i64 10)
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i64 [[SAT]], [[X]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sat = call i64 @llvm.usub.sat.i64(i64 %x, i64 10)
+  %cmp = icmp eq i64 %sat, %x
+  ret i1 %cmp
+}
+
+define i1 @icmp_eq_lhs_nonzero_constant_commuted(i64 %x) {
+; CHECK-LABEL: define i1 @icmp_eq_lhs_nonzero_constant_commuted
+; CHECK-SAME: (i64 [[X:%.*]]) {
+; CHECK-NEXT:    [[SAT:%.*]] = call i64 @llvm.usub.sat.i64(i64 [[X]], i64 10)
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i64 [[X]], [[SAT]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sat = call i64 @llvm.usub.sat.i64(i64 %x, i64 10)
+  %cmp = icmp eq i64 %x, %sat
+  ret i1 %cmp
+}
+
+define i1 @icmp_ult_lhs_nonzero_constant(i64 %x) {
+; CHECK-LABEL: define i1 @icmp_ult_lhs_nonzero_constant
+; CHECK-SAME: (i64 [[X:%.*]]) {
+; CHECK-NEXT:    [[SAT:%.*]] = call i64 @llvm.usub.sat.i64(i64 [[X]], i64 10)
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i64 [[SAT]], [[X]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sat = call i64 @llvm.usub.sat.i64(i64 %x, i64 10)
+  %cmp = icmp ult i64 %sat, %x
+  ret i1 %cmp
+}
+
+define i1 @icmp_eq_lhs_nonzero_constant_multiuse(i64 %x) {
+; CHECK-LABEL: define i1 @icmp_eq_lhs_nonzero_constant_multiuse
+; CHECK-SAME: (i64 [[X:%.*]]) {
+; CHECK-NEXT:    [[SAT:%.*]] = call i64 @llvm.usub.sat.i64(i64 [[X]], i64 10)
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i64 [[SAT]], [[X]]
+; CHECK-NEXT:    call void @use.i64(i64 [[SAT]])
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sat = call i64 @llvm.usub.sat.i64(i64 %x, i64 10)
+  %cmp = icmp eq i64 %sat, %x
+  call void @use.i64(i64 %sat)
+  ret i1 %cmp
+}
+
+define i1 @icmp_ult_lhs_nonzero_constant_multiuse(i64 %x) {
+; CHECK-LABEL: define i1 @icmp_ult_lhs_nonzero_constant_multiuse
+; CHECK-SAME: (i64 [[X:%.*]]) {
+; CHECK-NEXT:    [[SAT:%.*]] = call i64 @llvm.usub.sat.i64(i64 [[X]], i64 10)
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i64 [[SAT]], [[X]]
+; CHECK-NEXT:    call void @use.i64(i64 [[SAT]])
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sat = call i64 @llvm.usub.sat.i64(i64 %x, i64 10)
+  %cmp = icmp ult i64 %sat, %x
+  call void @use.i64(i64 %sat)
+  ret i1 %cmp
+}
+
+define i1 @icmp_eq_lhs_zero_constant(i64 %x) {
+; CHECK-LABEL: define i1 @icmp_eq_lhs_zero_constant
+; CHECK-SAME: (i64 [[X:%.*]]) {
+; CHECK-NEXT:    ret i1 true
+;
+  %sat = call i64 @llvm.usub.sat.i64(i64 %x, i64 0)
+  %cmp = icmp eq i64 %sat, %x
+  ret i1 %cmp
+}
+
+define <2 x i1> @icmp_ult_lhs_nonzero_constant_vector(<2 x i8> %x) {
+; CHECK-LABEL: define <2 x i1> @icmp_ult_lhs_nonzero_constant_vector
+; CHECK-SAME: (<2 x i8> [[X:%.*]]) {
+; CHECK-NEXT:    [[SAT:%.*]] = call <2 x i8> @llvm.usub.sat.v2i8(<2 x i8> [[X]], <2 x i8> splat (i8 10))
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult <2 x i8> [[SAT]], [[X]]
+; CHECK-NEXT:    ret <2 x i1> [[CMP]]
+;
+  %sat = call <2 x i8> @llvm.usub.sat.v2i8(<2 x i8> %x, <2 x i8> <i8 10, i8 10>)
+  %cmp = icmp ult <2 x i8> %sat, %x
+  ret <2 x i1> %cmp
+}
+
 declare i8 @llvm.usub.sat.i8(i8, i8)
 declare i16 @llvm.usub.sat.i16(i16, i16)
 declare i32 @llvm.usub.sat.i32(i32, i32)
@@ -437,3 +523,4 @@ declare <2 x i8> @llvm.usub.sat.v2i8(<2 x i8>, <2 x i8>)
 
 declare void @use.i8(i8)
 declare void @use.v2i8(<2 x i8>)
+declare void @use.i64(i64)

--- a/llvm/test/Transforms/InstCombine/icmp-usub-sat.ll
+++ b/llvm/test/Transforms/InstCombine/icmp-usub-sat.ll
@@ -447,6 +447,17 @@ define i1 @icmp_eq_usub_sat_lhs_nonzero_constant_commuted(i64 %x) {
   ret i1 %cmp
 }
 
+define i1 @icmp_samesign_eq_usub_sat_lhs_nonzero_constant(i64 %x) {
+; CHECK-LABEL: define i1 @icmp_samesign_eq_usub_sat_lhs_nonzero_constant
+; CHECK-SAME: (i64 [[X:%.*]]) {
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i64 [[X]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sat = call i64 @llvm.usub.sat.i64(i64 %x, i64 10)
+  %cmp = icmp samesign eq i64 %sat, %x
+  ret i1 %cmp
+}
+
 define i1 @icmp_ult_usub_sat_lhs_nonzero_constant(i64 %x) {
 ; CHECK-LABEL: define i1 @icmp_ult_usub_sat_lhs_nonzero_constant
 ; CHECK-SAME: (i64 [[X:%.*]]) {
@@ -534,7 +545,8 @@ define i1 @icmp_eq_usub_sat_lhs_known_nonzero_rhs(i64 %x, i64 %y) {
 ; CHECK-SAME: (i64 [[X:%.*]], i64 [[Y:%.*]]) {
 ; CHECK-NEXT:    [[COND:%.*]] = icmp ne i64 [[Y]], 0
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[COND]])
-; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i64 [[X]], 0
+; CHECK-NEXT:    [[SAT:%.*]] = call i64 @llvm.usub.sat.i64(i64 [[X]], i64 [[Y]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i64 [[SAT]], [[X]]
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %cond = icmp ne i64 %y, 0

--- a/llvm/test/Transforms/InstCombine/icmp-usub-sat.ll
+++ b/llvm/test/Transforms/InstCombine/icmp-usub-sat.ll
@@ -425,6 +425,185 @@ define <2 x i1> @icmp_eq_vector_multiuse_negative_equal(<2 x i8> %arg) {
   ret <2 x i1> %cmp
 }
 
+; usub.sat(X, C) == X  --> X == 0 (C is nonzero constant)
+define i1 @icmp_eq_usub_sat_lhs_nonzero_constant(i64 %x) {
+; CHECK-LABEL: define i1 @icmp_eq_usub_sat_lhs_nonzero_constant
+; CHECK-SAME: (i64 [[X:%.*]]) {
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i64 [[X]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sat = call i64 @llvm.usub.sat.i64(i64 %x, i64 10)
+  %cmp = icmp eq i64 %sat, %x
+  ret i1 %cmp
+}
+
+; Commuted form: icmp eq X, usub.sat(X, C)  --> X == 0
+define i1 @icmp_eq_usub_sat_lhs_nonzero_constant_commuted(i64 %x) {
+; CHECK-LABEL: define i1 @icmp_eq_usub_sat_lhs_nonzero_constant_commuted
+; CHECK-SAME: (i64 [[X:%.*]]) {
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i64 [[X]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sat = call i64 @llvm.usub.sat.i64(i64 %x, i64 10)
+  %cmp = icmp eq i64 %x, %sat
+  ret i1 %cmp
+}
+
+; samesign form: icmp samesign eq usub.sat(X, C), X  --> X == 0
+define i1 @icmp_samesign_eq_usub_sat_lhs_nonzero_constant(i64 %x) {
+; CHECK-LABEL: define i1 @icmp_samesign_eq_usub_sat_lhs_nonzero_constant
+; CHECK-SAME: (i64 [[X:%.*]]) {
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i64 [[X]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sat = call i64 @llvm.usub.sat.i64(i64 %x, i64 10)
+  %cmp = icmp samesign eq i64 %sat, %x
+  ret i1 %cmp
+}
+
+; usub.sat(X, C) < X  --> X != 0 (ULT is the same as < for unsigned)
+define i1 @icmp_ult_usub_sat_lhs_nonzero_constant(i64 %x) {
+; CHECK-LABEL: define i1 @icmp_ult_usub_sat_lhs_nonzero_constant
+; CHECK-SAME: (i64 [[X:%.*]]) {
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i64 [[X]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sat = call i64 @llvm.usub.sat.i64(i64 %x, i64 10)
+  %cmp = icmp ult i64 %sat, %x
+  ret i1 %cmp
+}
+
+; samesign ULT form
+define i1 @icmp_samesign_ult_usub_sat_lhs_nonzero_constant(i64 %x) {
+; CHECK-LABEL: define i1 @icmp_samesign_ult_usub_sat_lhs_nonzero_constant
+; CHECK-SAME: (i64 [[X:%.*]]) {
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i64 [[X]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sat = call i64 @llvm.usub.sat.i64(i64 %x, i64 10)
+  %cmp = icmp samesign ult i64 %sat, %x
+  ret i1 %cmp
+}
+
+; usub.sat(X, C) != X  --> X != 0
+define i1 @icmp_ne_usub_sat_lhs_nonzero_constant(i64 %x) {
+; CHECK-LABEL: define i1 @icmp_ne_usub_sat_lhs_nonzero_constant
+; CHECK-SAME: (i64 [[X:%.*]]) {
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i64 [[X]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sat = call i64 @llvm.usub.sat.i64(i64 %x, i64 10)
+  %cmp = icmp ne i64 %sat, %x
+  ret i1 %cmp
+}
+
+; X > usub.sat(X, C)  --> X != 0 (UGT commuted)
+define i1 @icmp_ugt_usub_sat_lhs_nonzero_constant(i64 %x) {
+; CHECK-LABEL: define i1 @icmp_ugt_usub_sat_lhs_nonzero_constant
+; CHECK-SAME: (i64 [[X:%.*]]) {
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i64 [[X]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sat = call i64 @llvm.usub.sat.i64(i64 %x, i64 10)
+  %cmp = icmp ugt i64 %x, %sat
+  ret i1 %cmp
+}
+
+; Multiuse: intrinsic is used elsewhere, only icmp is folded
+define i1 @icmp_eq_usub_sat_lhs_nonzero_constant_multiuse(i64 %x) {
+; CHECK-LABEL: define i1 @icmp_eq_usub_sat_lhs_nonzero_constant_multiuse
+; CHECK-SAME: (i64 [[X:%.*]]) {
+; CHECK-NEXT:    [[SAT:%.*]] = call i64 @llvm.usub.sat.i64(i64 [[X]], i64 10)
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i64 [[X]], 0
+; CHECK-NEXT:    call void @use.i64(i64 [[SAT]])
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sat = call i64 @llvm.usub.sat.i64(i64 %x, i64 10)
+  %cmp = icmp eq i64 %sat, %x
+  call void @use.i64(i64 %sat)
+  ret i1 %cmp
+}
+
+; Multiuse ULT
+define i1 @icmp_ult_usub_sat_lhs_nonzero_constant_multiuse(i64 %x) {
+; CHECK-LABEL: define i1 @icmp_ult_usub_sat_lhs_nonzero_constant_multiuse
+; CHECK-SAME: (i64 [[X:%.*]]) {
+; CHECK-NEXT:    [[SAT:%.*]] = call i64 @llvm.usub.sat.i64(i64 [[X]], i64 10)
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i64 [[X]], 0
+; CHECK-NEXT:    call void @use.i64(i64 [[SAT]])
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sat = call i64 @llvm.usub.sat.i64(i64 %x, i64 10)
+  %cmp = icmp ult i64 %sat, %x
+  call void @use.i64(i64 %sat)
+  ret i1 %cmp
+}
+
+; Zero constant: usub.sat(X, 0) == X is always true (negative test)
+define i1 @icmp_eq_usub_sat_lhs_zero_constant(i64 %x) {
+; CHECK-LABEL: define i1 @icmp_eq_usub_sat_lhs_zero_constant
+; CHECK-SAME: (i64 [[X:%.*]]) {
+; CHECK-NEXT:    ret i1 true
+;
+  %sat = call i64 @llvm.usub.sat.i64(i64 %x, i64 0)
+  %cmp = icmp eq i64 %sat, %x
+  ret i1 %cmp
+}
+
+; Vector types
+define <2 x i1> @icmp_ult_usub_sat_lhs_nonzero_constant_vector(<2 x i8> %x) {
+; CHECK-LABEL: define <2 x i1> @icmp_ult_usub_sat_lhs_nonzero_constant_vector
+; CHECK-SAME: (<2 x i8> [[X:%.*]]) {
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne <2 x i8> [[X]], zeroinitializer
+; CHECK-NEXT:    ret <2 x i1> [[CMP]]
+;
+  %sat = call <2 x i8> @llvm.usub.sat.v2i8(<2 x i8> %x, <2 x i8> <i8 10, i8 10>)
+  %cmp = icmp ult <2 x i8> %sat, %x
+  ret <2 x i1> %cmp
+}
+
+; Vector nonsplat constant (all elements nonzero)
+define <2 x i1> @icmp_ult_usub_sat_lhs_nonzero_constant_vector_nonsplat(<2 x i8> %x) {
+; CHECK-LABEL: define <2 x i1> @icmp_ult_usub_sat_lhs_nonzero_constant_vector_nonsplat
+; CHECK-SAME: (<2 x i8> [[X:%.*]]) {
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne <2 x i8> [[X]], zeroinitializer
+; CHECK-NEXT:    ret <2 x i1> [[CMP]]
+;
+  %sat = call <2 x i8> @llvm.usub.sat.v2i8(<2 x i8> %x, <2 x i8> <i8 1, i8 10>)
+  %cmp = icmp ult <2 x i8> %sat, %x
+  ret <2 x i1> %cmp
+}
+
+; Vector with some zero elements (negative test - fold not applicable)
+define <2 x i1> @icmp_ult_usub_sat_lhs_zero_constant_vector(<2 x i8> %x) {
+; CHECK-LABEL: define <2 x i1> @icmp_ult_usub_sat_lhs_zero_constant_vector
+; CHECK-SAME: (<2 x i8> [[X:%.*]]) {
+; CHECK-NEXT:    [[SAT:%.*]] = call <2 x i8> @llvm.usub.sat.v2i8(<2 x i8> [[X]], <2 x i8> <i8 1, i8 0>)
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult <2 x i8> [[SAT]], [[X]]
+; CHECK-NEXT:    ret <2 x i1> [[CMP]]
+;
+  %sat = call <2 x i8> @llvm.usub.sat.v2i8(<2 x i8> %x, <2 x i8> <i8 1, i8 0>)
+  %cmp = icmp ult <2 x i8> %sat, %x
+  ret <2 x i1> %cmp
+}
+
+; Non-constant but known-nonzero RHS via assume (negative test - fold only applies to constants)
+define i1 @icmp_eq_usub_sat_lhs_known_nonzero_rhs(i64 %x, i64 %y) {
+; CHECK-LABEL: define i1 @icmp_eq_usub_sat_lhs_known_nonzero_rhs
+; CHECK-SAME: (i64 [[X:%.*]], i64 [[Y:%.*]]) {
+; CHECK-NEXT:    [[COND:%.*]] = icmp ne i64 [[Y]], 0
+; CHECK-NEXT:    call void @llvm.assume(i1 [[COND]])
+; CHECK-NEXT:    [[SAT:%.*]] = call i64 @llvm.usub.sat.i64(i64 [[X]], i64 [[Y]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i64 [[SAT]], [[X]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %cond = icmp ne i64 %y, 0
+  call void @llvm.assume(i1 %cond)
+  %sat = call i64 @llvm.usub.sat.i64(i64 %x, i64 %y)
+  %cmp = icmp eq i64 %sat, %x
+  ret i1 %cmp
+}
+
 declare i8 @llvm.usub.sat.i8(i8, i8)
 declare i16 @llvm.usub.sat.i16(i16, i16)
 declare i32 @llvm.usub.sat.i32(i32, i32)
@@ -435,5 +614,8 @@ declare <2 x i32> @llvm.usub.sat.v2i32(<2 x i32>, <2 x i32>)
 declare <2 x i16> @llvm.usub.sat.v2i16(<2 x i16>, <2 x i16>)
 declare <2 x i8> @llvm.usub.sat.v2i8(<2 x i8>, <2 x i8>)
 
+declare void @llvm.assume(i1)
+
 declare void @use.i8(i8)
 declare void @use.v2i8(<2 x i8>)
+declare void @use.i64(i64)


### PR DESCRIPTION
Fold comparisons between the result of `llvm.usub.sat(X, C)` and the original
left-hand side when `C` is a nonzero constant.

For `C != 0`:

```llvm
    %sat = call iN @llvm.usub.sat.iN(iN %x, iN C)
    %cmp = icmp eq iN %sat, %x
```

can be folded to:

```llvm
    %cmp = icmp eq iN %x, 0
```

Similarly:

```llvm
    %sat = call iN @llvm.usub.sat.iN(iN %x, iN C)
    %cmp = icmp ult iN %sat, %x
```

can be folded to:

```llvm
    %cmp = icmp ne iN %x, 0
```

This also handles the commuted equality form:

```llvm
    icmp eq iN %x, %sat
```

The fold does not require the intrinsic to have one use, so if the `usub.sat`
result is used elsewhere, only the comparison is canonicalized and the
intrinsic remains live.

Proofs: https://alive2.llvm.org/ce/z/ZmAzBE

Fixes #213832