### PR TITLE
[SPIR-V] Fix getArg() assert on pointer constants in variadic call arguments

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -2373,6 +2373,8 @@ void SPIRVEmitIntrinsicsImpl::insertPtrCastOrAssignTypeInstr(Instruction *I,
       // However, we may have assumptions about the formal argument's type and
       // may have a need to insert a ptr cast for the actual parameter of this
       // call.
+      if (OpIdx >= CalledF->arg_size())
+        continue;
       Argument *CalledArg = CalledF->getArg(OpIdx);
       if (!GR->findDeducedElementType(CalledArg))
         continue;

--- a/llvm/test/CodeGen/SPIRV/printf-vararg-ptr.ll
+++ b/llvm/test/CodeGen/SPIRV/printf-vararg-ptr.ll
@@ -1,0 +1,19 @@
+; Check that a pointer constant passed in a variadic argument position does not
+; crash when the callee declares fewer formal parameters than the call site.
+
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; CHECK: %[[#ExtImport:]] = OpExtInstImport "OpenCL.std"
+; CHECK: OpExtInst %[[#]] %[[#ExtImport]] printf
+
+@.fmt = private unnamed_addr addrspace(2) constant [3 x i8] c"%s\00"
+@.arg = private unnamed_addr addrspace(2) constant [2 x i8] c"a\00"
+
+define spir_kernel void @foo() {
+entry:
+  %r = call spir_func i32 (ptr addrspace(2), ...) @_Z18__spirv_ocl_printfPU3AS2Kcz(ptr addrspace(2) @.fmt, ptr addrspace(2) @.arg)
+  ret void
+}
+
+declare dso_local spir_func i32 @_Z18__spirv_ocl_printfPU3AS2Kcz(ptr addrspace(2), ...)


### PR DESCRIPTION
`insertPtrCastOrAssignTypeInstr` bounds its loop by the call's operand count but indexes the callee's declared formal parameters, so a variadic callee passed a pointer constant in a variadic position trips `getArg() out of range!`. This is long standing: it reproduces on LLVM 22 too, and needs only `llc`.

```llvm
@.fmt = private unnamed_addr addrspace(2) constant [3 x i8] c"%s\00"
@.arg = private unnamed_addr addrspace(2) constant [2 x i8] c"a\00"

define spir_kernel void @foo() {
entry:
  %r = call spir_func i32 (ptr addrspace(2), ...) @_Z18__spirv_ocl_printfPU3AS2Kcz(ptr addrspace(2) @.fmt, ptr addrspace(2) @.arg)
  ret void
}

declare dso_local spir_func i32 @_Z18__spirv_ocl_printfPU3AS2Kcz(ptr addrspace(2), ...)
```

`llc -mtriple=spirv64-unknown-unknown t.ll -o /dev/null` asserts in `SPIRV emit intrinsics`. OpenCL `printf("%s", ...)` hits this in practice.

Fix: skip operands that have no matching formal parameter.
