### PR TITLE
[compiler-rt][Bazel] Support profile runtime on macOS and iOS

### DIFF
--- a/utils/bazel/llvm-project-overlay/compiler-rt/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/compiler-rt/BUILD.bazel
@@ -11,18 +11,24 @@ package(
 
 licenses(["notice"])
 
+POSIX_PROFILE_DEFINES = [
+    "COMPILER_RT_HAS_ATOMICS=1",
+    "COMPILER_RT_HAS_FCNTL_LCK=1",
+    "COMPILER_RT_HAS_UNAME=1",
+]
+
 cc_library(
     name = "config",
     defines = select({
-        "@platforms//os:linux": [
-            "COMPILER_RT_HAS_ATOMICS=1",
-            "COMPILER_RT_HAS_FCNTL_LCK=1",
-            "COMPILER_RT_HAS_UNAME=1",
-        ],
+        "@platforms//os:ios": POSIX_PROFILE_DEFINES,
+        "@platforms//os:linux": POSIX_PROFILE_DEFINES,
+        "@platforms//os:macos": POSIX_PROFILE_DEFINES,
         # Will raise error unless supported platforms.
     }),
     target_compatible_with = select({
+        "@platforms//os:ios": [],
         "@platforms//os:linux": [],
+        "@platforms//os:macos": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
 )


### PR DESCRIPTION
## Summary

- Allow the Bazel `compiler-rt:profile` target on macOS and iOS.
- Reuse the POSIX feature defines already used for Linux.
- Keep other target platforms explicitly incompatible.

## Problem

The Bazel profile runtime is currently restricted to Linux by its `config`
dependency. Explicit macOS and iOS builds therefore fail during analysis even
though these platforms provide the atomics, `fcntl` locking, and `uname`
features selected by the CMake build.

## Testing

- Confirmed the unpatched current `main` rejects both the host macOS target and
  `@build_bazel_apple_support//platforms:ios_arm64` as incompatible.
- Built `@llvm-project//compiler-rt:profile` for host macOS.
- Built it for `@build_bazel_apple_support//platforms:ios_arm64`; `aquery`
  confirms an `arm64-apple-ios` compile and all three feature defines.
- Compiled an instrumented macOS program with current Clang, linked the Bazel
  profile runtime, ran it, and read its counters with current `llvm-profdata`.
- Compiled and linked the equivalent arm64 iOS executable with no unresolved
  profile-runtime symbols.
- Verified an explicit tvOS request remains incompatible rather than exposing
  its unsupported GCDA `fork()` path.
- `buildifier` 8.2.1 check.
