### PR TITLE
[flang] Reject module-scope fir.alloca

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -93,6 +93,9 @@ def fir_AllocaOp : fir_Op<"alloca", [
     an optional name.  The allocation may have a dynamic repetition count
     for allocating a sequence of locations for the specified type.
 
+    A `fir.alloca` cannot be defined directly in a `builtin.module` because
+    module scope does not provide a stack allocation context.
+
     ```
       %c = ... : i64
       %x = fir.alloca i32

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -93,8 +93,8 @@ def fir_AllocaOp : fir_Op<"alloca", [
     an optional name.  The allocation may have a dynamic repetition count
     for allocating a sequence of locations for the specified type.
 
-    A `fir.alloca` cannot be defined directly in a `builtin.module` because
-    module scope does not provide a stack allocation context.
+    A `fir.alloca` requires an ancestor operation with the
+    `AutomaticAllocationScope` trait to provide its stack allocation context.
 
     ```
       %c = ... : i64

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -93,8 +93,8 @@ def fir_AllocaOp : fir_Op<"alloca", [
     an optional name.  The allocation may have a dynamic repetition count
     for allocating a sequence of locations for the specified type.
 
-    A `fir.alloca` requires an ancestor operation with the
-    `AutomaticAllocationScope` trait to provide its stack allocation context.
+    A `fir.alloca` cannot be defined directly in a `builtin.module` because
+    module scope does not provide a stack allocation context.
 
     ```
       %c = ... : i64

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -382,6 +382,8 @@ void fir::AllocaOp::print(mlir::OpAsmPrinter &p) {
 }
 
 llvm::LogicalResult fir::AllocaOp::verify() {
+  if (mlir::isa_and_nonnull<mlir::ModuleOp>((*this)->getParentOp()))
+    return emitOpError("must not be defined at module scope");
   llvm::SmallVector<llvm::StringRef> visited;
   if (verifyInType(getInType(), visited, numShapeOperands()))
     return emitOpError("invalid type for allocation");

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -382,8 +382,9 @@ void fir::AllocaOp::print(mlir::OpAsmPrinter &p) {
 }
 
 llvm::LogicalResult fir::AllocaOp::verify() {
-  if (mlir::isa_and_nonnull<mlir::ModuleOp>((*this)->getParentOp()))
-    return emitOpError("must not be defined at module scope");
+  if (!(*this)->getParentWithTrait<mlir::OpTrait::AutomaticAllocationScope>())
+    return emitOpError(
+        "requires an ancestor op with AutomaticAllocationScope trait");
   llvm::SmallVector<llvm::StringRef> visited;
   if (verifyInType(getInType(), visited, numShapeOperands()))
     return emitOpError("invalid type for allocation");

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -382,9 +382,8 @@ void fir::AllocaOp::print(mlir::OpAsmPrinter &p) {
 }
 
 llvm::LogicalResult fir::AllocaOp::verify() {
-  if (!(*this)->getParentWithTrait<mlir::OpTrait::AutomaticAllocationScope>())
-    return emitOpError(
-        "requires an ancestor op with AutomaticAllocationScope trait");
+  if (mlir::isa_and_nonnull<mlir::ModuleOp>((*this)->getParentOp()))
+    return emitOpError("must not be defined at module scope");
   llvm::SmallVector<llvm::StringRef> visited;
   if (verifyInType(getInType(), visited, numShapeOperands()))
     return emitOpError("invalid type for allocation");

--- a/flang/test/Fir/invalid.fir
+++ b/flang/test/Fir/invalid.fir
@@ -1,5 +1,10 @@
 // RUN: fir-opt -split-input-file -verify-diagnostics --strict-fir-volatile-verifier %s
 
+// expected-error@+1{{'fir.alloca' op must not be defined at module scope}}
+%0 = fir.alloca i32 {adapt.valuebyref}
+
+// -----
+
 // expected-error@+1{{custom op 'fir.string_lit' must have character type}}
 %0 = fir.string_lit "Hello, World!"(13) : !fir.int<32>
 

--- a/flang/test/Fir/invalid.fir
+++ b/flang/test/Fir/invalid.fir
@@ -1,6 +1,6 @@
 // RUN: fir-opt -split-input-file -verify-diagnostics --strict-fir-volatile-verifier %s
 
-// expected-error@+1{{'fir.alloca' op requires an ancestor op with AutomaticAllocationScope trait}}
+// expected-error@+1{{'fir.alloca' op must not be defined at module scope}}
 %0 = fir.alloca i32 {adapt.valuebyref}
 
 // -----

--- a/flang/test/Fir/invalid.fir
+++ b/flang/test/Fir/invalid.fir
@@ -1,6 +1,6 @@
 // RUN: fir-opt -split-input-file -verify-diagnostics --strict-fir-volatile-verifier %s
 
-// expected-error@+1{{'fir.alloca' op must not be defined at module scope}}
+// expected-error@+1{{'fir.alloca' op requires an ancestor op with AutomaticAllocationScope trait}}
 %0 = fir.alloca i32 {adapt.valuebyref}
 
 // -----


### PR DESCRIPTION
`fir.alloca` represents a stack allocation, but its verifier currently accepts operations placed directly in a `builtin.module`. During FIR-to-LLVM conversion,  `AllocaOpConversion::matchAndRewrite` calls `getBlockForAllocaInsert`, which performs a `dyn_cast` to `OutlineableOpenMPOpInterface` on the alloca's parent op.

For a module-level alloca the expected parent function/block does not exist and the cast/assert fails.

This patch rejectsdirect module-scope `fir.alloca` operations during FIR verification.

Assisted-by: codex