### PR TITLE
[Docs][AMDGPU] fully specify volatile accesses in the memory model

### DIFF
--- a/llvm/docs/AMDGPUMemoryModel.md
+++ b/llvm/docs/AMDGPUMemoryModel.md
@@ -210,6 +210,31 @@ side-effects are made available at "workgroup" scope. In other words, the scope
 for atomicity is not always the same as the scope for availability/visibility.
 ```
 
+### volatile Accesses
+
+```llvm
+store volatile ..., ptr addrspace(N) %addr
+%value = load volatile ..., ptr addrspace(N) %addr
+```
+
+A non-atomic `volatile` access results in a *store-available* or *load-visible*
+operation with the widest scope supported by its address space:
+
+- "system" scope for `addrspace(1)` (global) and `addrspace(0)` (generic), and
+- "workgroup" scope for `addrspace(3)` (local), since local memory is not
+  observable beyond its workgroup.
+
+A `volatile` atomic access is not widened in this way. Its availability and
+visibility remain limited to its `syncscope`, as described for atomic accesses
+above.
+
+```{note}
+The availability and visibility of volatile accesses is specific to AMDGPU, and
+orthogonal to the {ref}`base semantics defined in LLVM IR<volatile>`. This fully
+specifies the behavior that the {ref}`LLVM memory model<memmodel>` otherwise
+leaves target-dependent for `volatile` accesses.
+```
+
 (amdgpu-av-metadata)=
 
 ### !"amdgcn-av" metadata


### PR DESCRIPTION
A non-atomic volatile access on AMDGPU includes store-available or load-visible
semantics at the widest scope supported by its address space:

- system scope for global/generic,
- workgroup scope for local (LDS)

An atomic volatile access has the same availability and visibility as its atomic
non-volatile variant.

Previous Reference: 2f499b9

This fully specifies the behavior that the LLVM memory model leaves
target-dependent, matching the implementation in SIMemoryLegalizer. 

Assisted-By: Claude Opus 4.8