### PR TITLE
[AsmPrinter] Emit STT_OBJECT type and size for jump tables

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -3458,12 +3458,19 @@ void AsmPrinter::emitJumpTableImpl(const MachineJumpTableInfo &MJTI,
       OutStreamer->emitLabel(GetJTISymbol(JumpTableIndex, true));
 
     MCSymbol *JTISymbol = GetJTISymbol(JumpTableIndex);
+    if (JTInDiffSection && MAI.hasDotTypeDotSizeDirective())
+      OutStreamer->emitSymbolAttribute(JTISymbol, MCSA_ELF_TypeObject);
     OutStreamer->emitLabel(JTISymbol);
 
     // Defer MCAssembler based constant folding due to a performance issue. The
     // label differences will be evaluated at write time.
     for (const MachineBasicBlock *MBB : JTBBs)
       emitJumpTableEntry(MJTI, MBB, JumpTableIndex);
+
+    if (JTInDiffSection && MAI.hasDotTypeDotSizeDirective())
+      OutStreamer->emitELFSize(
+          JTISymbol, MCConstantExpr::create(
+                         JTBBs.size() * MJTI.getEntrySize(DL), OutContext));
   }
 
   if (EmitJumpTableSizesSection)

--- a/llvm/test/CodeGen/ARM/execute-only.ll
+++ b/llvm/test/CodeGen/ARM/execute-only.ll
@@ -58,6 +58,7 @@ define i32 @jump_table(i32 %c, i32 %a, i32 %b) #0 {
 ; CHECK-T1-NEXT: mov  pc, [[REG_ENTRY]]
 ; CHECK-T1:      .section .rodata,"a",%progbits
 ; CHECK-T1-NEXT: .p2align 2, 0x0
+; CHECK-T1-NEXT: .type	.LJTI1_0,%object
 ; CHECK-T1-NEXT: .LJTI1_0:
 ; CHECK-T1-NEXT: .long
 ; CHECK-T1-NEXT: .long

--- a/llvm/test/CodeGen/RISCV/jumptable-sizes.ll
+++ b/llvm/test/CodeGen/RISCV/jumptable-sizes.ll
@@ -1,0 +1,58 @@
+; RUN: llc -mtriple=riscv32-elf -filetype=obj -code-model=small -verify-machineinstrs < %s \
+; RUN:   | llvm-objdump -t - \
+; RUN:   | FileCheck %s -check-prefixes=RV32I-SMALL
+; RUN: llc -mtriple=riscv32-elf -filetype=obj -code-model=medium -verify-machineinstrs < %s \
+; RUN:   | llvm-objdump -t - \
+; RUN:   | FileCheck %s -check-prefixes=RV32I-MEDIUM
+; RUN: llc -mtriple=riscv32-elf -filetype=obj -relocation-model=pic -verify-machineinstrs < %s \
+; RUN:   | llvm-objdump -t - \
+; RUN:   | FileCheck %s -check-prefixes=RV32I-PIC
+; RUN: llc -mtriple=riscv64-elf -filetype=obj -code-model=small -verify-machineinstrs < %s \
+; RUN:   | llvm-objdump -t - \
+; RUN:   | FileCheck %s -check-prefixes=RV64I-SMALL
+; RUN: llc -mtriple=riscv64-elf -filetype=obj -code-model=medium -verify-machineinstrs < %s \
+; RUN:   | llvm-objdump -t - \
+; RUN:   | FileCheck %s -check-prefixes=RV64I-MEDIUM
+; RUN: llc -mtriple=riscv64-elf -filetype=obj -relocation-model=pic -verify-machineinstrs < %s \
+; RUN:   | llvm-objdump -t - \
+; RUN:   | FileCheck %s -check-prefixes=RV64I-PIC
+
+
+define void @above_threshold(i32 signext %in, ptr %out) nounwind {
+; RV32I-SMALL:  {{[0-9a-f]+}} l     O .rodata        00000018 .LJTI0_0
+; RV32I-MEDIUM: {{[0-9a-f]+}} l     O .rodata        00000018 .LJTI0_0
+; RV32I-PIC:    {{[0-9a-f]+}} l     O .rodata        00000018 .LJTI0_0
+; RV64I-SMALL:  {{[0-9a-f]+}} l     O .rodata        0000000000000018 .LJTI0_0
+; RV64I-MEDIUM: {{[0-9a-f]+}} l     O .rodata        0000000000000030 .LJTI0_0
+; RV64I-PIC:    {{[0-9a-f]+}} l     O .rodata        0000000000000018 .LJTI0_0
+
+entry:
+  switch i32 %in, label %exit [
+    i32 1, label %bb1
+    i32 2, label %bb2
+    i32 3, label %bb3
+    i32 4, label %bb4
+    i32 5, label %bb5
+    i32 6, label %bb6
+  ]
+bb1:
+  store i32 4, ptr %out
+  br label %exit
+bb2:
+  store i32 3, ptr %out
+  br label %exit
+bb3:
+  store i32 2, ptr %out
+  br label %exit
+bb4:
+  store i32 1, ptr %out
+  br label %exit
+bb5:
+  store i32 100, ptr %out
+  br label %exit
+bb6:
+  store i32 200, ptr %out
+  br label %exit
+exit:
+  ret void
+}

--- a/llvm/test/CodeGen/RISCV/jumptable-sizes.ll
+++ b/llvm/test/CodeGen/RISCV/jumptable-sizes.ll
@@ -1,30 +1,30 @@
 ; RUN: llc -mtriple=riscv32-elf -filetype=obj -code-model=small -verify-machineinstrs < %s \
-; RUN:   | llvm-objdump -t - \
+; RUN:   | llvm-readelf -s - \
 ; RUN:   | FileCheck %s -check-prefixes=RV32I-SMALL
 ; RUN: llc -mtriple=riscv32-elf -filetype=obj -code-model=medium -verify-machineinstrs < %s \
-; RUN:   | llvm-objdump -t - \
+; RUN:   | llvm-readelf -s - \
 ; RUN:   | FileCheck %s -check-prefixes=RV32I-MEDIUM
 ; RUN: llc -mtriple=riscv32-elf -filetype=obj -relocation-model=pic -verify-machineinstrs < %s \
-; RUN:   | llvm-objdump -t - \
+; RUN:   | llvm-readelf -s - \
 ; RUN:   | FileCheck %s -check-prefixes=RV32I-PIC
 ; RUN: llc -mtriple=riscv64-elf -filetype=obj -code-model=small -verify-machineinstrs < %s \
-; RUN:   | llvm-objdump -t - \
+; RUN:   | llvm-readelf -s - \
 ; RUN:   | FileCheck %s -check-prefixes=RV64I-SMALL
 ; RUN: llc -mtriple=riscv64-elf -filetype=obj -code-model=medium -verify-machineinstrs < %s \
-; RUN:   | llvm-objdump -t - \
+; RUN:   | llvm-readelf -s - \
 ; RUN:   | FileCheck %s -check-prefixes=RV64I-MEDIUM
 ; RUN: llc -mtriple=riscv64-elf -filetype=obj -relocation-model=pic -verify-machineinstrs < %s \
-; RUN:   | llvm-objdump -t - \
+; RUN:   | llvm-readelf -s - \
 ; RUN:   | FileCheck %s -check-prefixes=RV64I-PIC
 
 
 define void @above_threshold(i32 signext %in, ptr %out) nounwind {
-; RV32I-SMALL:  {{[0-9a-f]+}} l     O .rodata        00000018 .LJTI0_0
-; RV32I-MEDIUM: {{[0-9a-f]+}} l     O .rodata        00000018 .LJTI0_0
-; RV32I-PIC:    {{[0-9a-f]+}} l     O .rodata        00000018 .LJTI0_0
-; RV64I-SMALL:  {{[0-9a-f]+}} l     O .rodata        0000000000000018 .LJTI0_0
-; RV64I-MEDIUM: {{[0-9a-f]+}} l     O .rodata        0000000000000030 .LJTI0_0
-; RV64I-PIC:    {{[0-9a-f]+}} l     O .rodata        0000000000000018 .LJTI0_0
+; RV32I-SMALL:  24 OBJECT LOCAL DEFAULT [[#]] .LJTI0_0
+; RV32I-MEDIUM: 24 OBJECT LOCAL DEFAULT [[#]] .LJTI0_0
+; RV32I-PIC:    24 OBJECT LOCAL DEFAULT [[#]] .LJTI0_0
+; RV64I-SMALL:  24 OBJECT LOCAL DEFAULT [[#]] .LJTI0_0
+; RV64I-MEDIUM: 48 OBJECT LOCAL DEFAULT [[#]] .LJTI0_0
+; RV64I-PIC:    24 OBJECT LOCAL DEFAULT [[#]] .LJTI0_0
 
 entry:
   switch i32 %in, label %exit [

--- a/llvm/test/CodeGen/X86/pic.ll
+++ b/llvm/test/CodeGen/X86/pic.ll
@@ -223,6 +223,7 @@ bb12:
 ; CHECK-X32:	jmpq	*%rax
 
 ; CHECK:	.p2align 2
+; CHECK-NEXT:	.type	.LJTI7_0,@object
 ; CHECK-NEXT:	.LJTI7_0:
 ; CHECK-I686:	.long	 .LBB7_2@GOTOFF
 ; CHECK-I686:	.long	 .LBB7_8@GOTOFF


### PR DESCRIPTION
Before this change, jump tables placed in a separate section were emitted with no symbol type, leaving them STT_NOTYPE, and with no size in their ELF file.

This change annotates the jump tables with object type and a size when the target supports type/size directives. Jump tables inlined into the function's own section are already covered by that function's symbol, so they are left as-is.

This helps when disassembling a file, to understand that the jump table is a single complete object, rather than the symbol being purely a location. I think this reflects the ELF semantics better.

---

This was prepared with the assistance of AI.