### PR TITLE
[libc++] Add missing return 0 to main functions in tests

### DIFF
--- a/libcxx/test/benchmarks/function.bench.cpp
+++ b/libcxx/test/benchmarks/function.bench.cpp
@@ -224,4 +224,6 @@ int main(int argc, char** argv) {
   makeCartesianProductBenchmark<Invoke, AllFunctionTypes>();
   makeCartesianProductBenchmark<InvokeInlined, AllFunctionTypes>();
   benchmark::RunSpecifiedBenchmarks();
+
+  return 0;
 }

--- a/libcxx/test/benchmarks/utc_clock.bench.cpp
+++ b/libcxx/test/benchmarks/utc_clock.bench.cpp
@@ -57,4 +57,6 @@ int main(int argc, char** argv) {
     return 1;
 
   benchmark::RunSpecifiedBenchmarks();
+
+  return 0;
 }

--- a/libcxx/test/libcxx-03/containers/sequences/deque/asan.pass.cpp
+++ b/libcxx/test/libcxx-03/containers/sequences/deque/asan.pass.cpp
@@ -65,4 +65,6 @@ int main(int, char**) {
     assert(false);                // if we got here, ASAN didn't trigger
     ((void)foo);
   }
+
+  return 0;
 }

--- a/libcxx/test/libcxx-03/containers/sequences/vector/asan.pass.cpp
+++ b/libcxx/test/libcxx-03/containers/sequences/vector/asan.pass.cpp
@@ -50,4 +50,6 @@ int main(int, char**) {
     assert(false);                // if we got here, ASAN didn't trigger
     ((void)foo);
   }
+
+  return 0;
 }

--- a/libcxx/test/libcxx-03/memory/uninitialized_allocator_copy.pass.cpp
+++ b/libcxx/test/libcxx-03/memory/uninitialized_allocator_copy.pass.cpp
@@ -64,4 +64,6 @@ int main(int, char**) {
 
   assert(constructed_count == 0);
   assert(max_constructed_count == 14);
+
+  return 0;
 }

--- a/libcxx/test/libcxx/containers/associative/debug.non-strict-weak-ordering.pass.cpp
+++ b/libcxx/test/libcxx/containers/associative/debug.non-strict-weak-ordering.pass.cpp
@@ -127,4 +127,6 @@ int main() {
     }
 #endif
   }
+
+  return 0;
 }

--- a/libcxx/test/libcxx/containers/associative/lower_upper_bound_non_strict_weak_order.pass.cpp
+++ b/libcxx/test/libcxx/containers/associative/lower_upper_bound_non_strict_weak_order.pass.cpp
@@ -148,4 +148,6 @@ int main() {
       }
     }
   }
+
+  return 0;
 }

--- a/libcxx/test/libcxx/containers/sequences/deque/asan.pass.cpp
+++ b/libcxx/test/libcxx/containers/sequences/deque/asan.pass.cpp
@@ -65,4 +65,6 @@ int main(int, char**) {
     assert(false);                // if we got here, ASAN didn't trigger
     ((void)foo);
   }
+
+  return 0;
 }

--- a/libcxx/test/libcxx/containers/sequences/vector/asan.pass.cpp
+++ b/libcxx/test/libcxx/containers/sequences/vector/asan.pass.cpp
@@ -73,4 +73,6 @@ int main(int, char**) {
     assert(false);                // if we got here, ASAN didn't trigger
     ((void)foo);
   }
+
+  return 0;
 }

--- a/libcxx/test/libcxx/input.output/iostream.format/print.fun/output_unicode_windows.pass.cpp
+++ b/libcxx/test/libcxx/input.output/iostream.format/print.fun/output_unicode_windows.pass.cpp
@@ -108,4 +108,6 @@ static void test() {
 int main(int, char**) {
   test_basics();
   test();
+
+  return 0;
 }

--- a/libcxx/test/libcxx/memory/uninitialized_allocator_copy.pass.cpp
+++ b/libcxx/test/libcxx/memory/uninitialized_allocator_copy.pass.cpp
@@ -65,4 +65,6 @@ int main(int, char**) {
 
   assert(constructed_count == 0);
   assert(max_constructed_count == 14);
+
+  return 0;
 }

--- a/libcxx/test/libcxx/ranges/range.adaptors/range.concat/iterator.valueless_by_exception.pass.cpp
+++ b/libcxx/test/libcxx/ranges/range.adaptors/range.concat/iterator.valueless_by_exception.pass.cpp
@@ -656,4 +656,6 @@ int main() {
           [&] { [[maybe_unused]] CIter it3(iter1); }(), "Trying to convert from a valueless iterator of concat_view.");
     }
   }
+
+  return 0;
 }

--- a/libcxx/test/libcxx/strings/basic.string/string.cons/debug.iterator.substr.pass.cpp
+++ b/libcxx/test/libcxx/strings/basic.string/string.cons/debug.iterator.substr.pass.cpp
@@ -46,4 +46,6 @@ int main(int, char**) {
     assert(i[0] == 'l');
     TEST_LIBCPP_ASSERT_FAILURE(i[5], "Attempted to subscript an iterator outside its valid range");
   }
+
+  return 0;
 }

--- a/libcxx/test/libcxx/time/time.zone/time.zone.db/time.zone.db.list/erase_after.pass.cpp
+++ b/libcxx/test/libcxx/time/time.zone/time.zone.db/time.zone.db.list/erase_after.pass.cpp
@@ -68,4 +68,6 @@ int main(int, const char**) {
   assert(std::distance(list.begin(), list.end()) == 2);
   assert(list.front().version == "4");
   assert(it->version == "3");
+
+  return 0;
 }

--- a/libcxx/test/libcxx/utilities/assert.exception_guard.no_exceptions.pass.cpp
+++ b/libcxx/test/libcxx/utilities/assert.exception_guard.no_exceptions.pass.cpp
@@ -19,4 +19,6 @@
 int main(int, char**) {
   TEST_LIBCPP_ASSERT_FAILURE(
       std::__make_exception_guard([] {}), "__exception_guard not completed with exceptions disabled");
+
+  return 0;
 }

--- a/libcxx/test/selftest/pass.cpp/werror.pass.cpp
+++ b/libcxx/test/selftest/pass.cpp/werror.pass.cpp
@@ -19,4 +19,5 @@
 
 int main(int, char**) {
     int foo;
+    return 0;
 }

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.reverse/pstl.reverse_copy.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.reverse/pstl.reverse_copy.pass.cpp
@@ -113,4 +113,6 @@ int main(int, char**) {
         types::for_each(types::forward_iterator_list<int*>{},
                         TestIteratorWithPolicies<types::partial_instantiation<Test, Iter>::template apply>{});
       }});
+
+  return 0;
 }

--- a/libcxx/test/std/algorithms/pstl.exception_handling.pass.cpp
+++ b/libcxx/test/std/algorithms/pstl.exception_handling.pass.cpp
@@ -447,4 +447,6 @@ int main(int, char**) {
       }
     }
   });
+
+  return 0;
 }

--- a/libcxx/test/std/containers/associative/map/map.ops/count1.compile.fail.cpp
+++ b/libcxx/test/std/containers/associative/map/map.ops/count1.compile.fail.cpp
@@ -30,4 +30,6 @@ int main(int, char**) {
 
     TEST_IGNORE_NODISCARD M().count(C2Int{5});
   }
+
+  return 0;
 }

--- a/libcxx/test/std/containers/associative/map/map.ops/count2.compile.fail.cpp
+++ b/libcxx/test/std/containers/associative/map/map.ops/count2.compile.fail.cpp
@@ -30,4 +30,6 @@ int main(int, char**) {
 
     TEST_IGNORE_NODISCARD M().count(C2Int{5});
   }
+
+  return 0;
 }

--- a/libcxx/test/std/containers/associative/map/map.ops/count3.compile.fail.cpp
+++ b/libcxx/test/std/containers/associative/map/map.ops/count3.compile.fail.cpp
@@ -30,4 +30,6 @@ int main(int, char**) {
 
     TEST_IGNORE_NODISCARD M().count(C2Int{5});
   }
+
+  return 0;
 }

--- a/libcxx/test/std/containers/associative/map/map.ops/equal_range1.compile.fail.cpp
+++ b/libcxx/test/std/containers/associative/map/map.ops/equal_range1.compile.fail.cpp
@@ -31,4 +31,6 @@ int main(int, char**) {
 
     TEST_IGNORE_NODISCARD M().equal_range(C2Int{5});
   }
+
+  return 0;
 }

--- a/libcxx/test/std/containers/associative/map/map.ops/equal_range2.compile.fail.cpp
+++ b/libcxx/test/std/containers/associative/map/map.ops/equal_range2.compile.fail.cpp
@@ -31,4 +31,6 @@ int main(int, char**) {
 
     TEST_IGNORE_NODISCARD M().equal_range(C2Int{5});
   }
+
+  return 0;
 }

--- a/libcxx/test/std/containers/associative/map/map.ops/equal_range3.compile.fail.cpp
+++ b/libcxx/test/std/containers/associative/map/map.ops/equal_range3.compile.fail.cpp
@@ -31,4 +31,6 @@ int main(int, char**) {
 
     TEST_IGNORE_NODISCARD M().equal_range(C2Int{5});
   }
+
+  return 0;
 }

--- a/libcxx/test/std/containers/associative/map/map.ops/find1.compile.fail.cpp
+++ b/libcxx/test/std/containers/associative/map/map.ops/find1.compile.fail.cpp
@@ -31,4 +31,6 @@ int main(int, char**) {
 
     TEST_IGNORE_NODISCARD M().find(C2Int{5});
   }
+
+  return 0;
 }

--- a/libcxx/test/std/containers/associative/map/map.ops/find2.compile.fail.cpp
+++ b/libcxx/test/std/containers/associative/map/map.ops/find2.compile.fail.cpp
@@ -31,4 +31,6 @@ int main(int, char**) {
 
     TEST_IGNORE_NODISCARD M().find(C2Int{5});
   }
+
+  return 0;
 }

--- a/libcxx/test/std/containers/associative/map/map.ops/find3.compile.fail.cpp
+++ b/libcxx/test/std/containers/associative/map/map.ops/find3.compile.fail.cpp
@@ -31,4 +31,6 @@ int main(int, char**) {
 
     TEST_IGNORE_NODISCARD M().find(C2Int{5});
   }
+
+  return 0;
 }

--- a/libcxx/test/std/containers/associative/map/map.ops/lower_bound1.compile.fail.cpp
+++ b/libcxx/test/std/containers/associative/map/map.ops/lower_bound1.compile.fail.cpp
@@ -31,4 +31,6 @@ int main(int, char**) {
 
     TEST_IGNORE_NODISCARD M().lower_bound(C2Int{5});
   }
+
+  return 0;
 }

--- a/libcxx/test/std/containers/associative/map/map.ops/lower_bound2.compile.fail.cpp
+++ b/libcxx/test/std/containers/associative/map/map.ops/lower_bound2.compile.fail.cpp
@@ -31,4 +31,6 @@ int main(int, char**) {
 
     TEST_IGNORE_NODISCARD M().lower_bound(C2Int{5});
   }
+
+  return 0;
 }

--- a/libcxx/test/std/containers/associative/map/map.ops/lower_bound3.compile.fail.cpp
+++ b/libcxx/test/std/containers/associative/map/map.ops/lower_bound3.compile.fail.cpp
@@ -31,4 +31,6 @@ int main(int, char**) {
 
     TEST_IGNORE_NODISCARD M().lower_bound(C2Int{5});
   }
+
+  return 0;
 }

--- a/libcxx/test/std/containers/associative/map/map.ops/upper_bound1.compile.fail.cpp
+++ b/libcxx/test/std/containers/associative/map/map.ops/upper_bound1.compile.fail.cpp
@@ -31,4 +31,6 @@ int main(int, char**) {
 
     TEST_IGNORE_NODISCARD M().upper_bound(C2Int{5});
   }
+
+  return 0;
 }

--- a/libcxx/test/std/containers/associative/map/map.ops/upper_bound2.compile.fail.cpp
+++ b/libcxx/test/std/containers/associative/map/map.ops/upper_bound2.compile.fail.cpp
@@ -31,4 +31,6 @@ int main(int, char**) {
 
     TEST_IGNORE_NODISCARD M().upper_bound(C2Int{5});
   }
+
+  return 0;
 }

--- a/libcxx/test/std/containers/associative/map/map.ops/upper_bound3.compile.fail.cpp
+++ b/libcxx/test/std/containers/associative/map/map.ops/upper_bound3.compile.fail.cpp
@@ -31,4 +31,6 @@ int main(int, char**) {
 
     TEST_IGNORE_NODISCARD M().upper_bound(C2Int{5});
   }
+
+  return 0;
 }

--- a/libcxx/test/std/containers/associative/multimap/multimap.ops/count1.compile.fail.cpp
+++ b/libcxx/test/std/containers/associative/multimap/multimap.ops/count1.compile.fail.cpp
@@ -28,4 +28,6 @@ int main(int, char**) {
   typedef std::multimap<int, double, transparent_less_no_type> M;
 
   TEST_IGNORE_NODISCARD M().count(C2Int{5});
+
+  return 0;
 }

--- a/libcxx/test/std/containers/associative/multimap/multimap.ops/count2.compile.fail.cpp
+++ b/libcxx/test/std/containers/associative/multimap/multimap.ops/count2.compile.fail.cpp
@@ -28,4 +28,6 @@ int main(int, char**) {
   typedef std::multimap<int, double, transparent_less_private> M;
 
   TEST_IGNORE_NODISCARD M().count(C2Int{5});
+
+  return 0;
 }

--- a/libcxx/test/std/containers/associative/multimap/multimap.ops/count3.compile.fail.cpp
+++ b/libcxx/test/std/containers/associative/multimap/multimap.ops/count3.compile.fail.cpp
@@ -28,4 +28,6 @@ int main(int, char**) {
   typedef std::multimap<int, double, transparent_less_not_a_type> M;
 
   TEST_IGNORE_NODISCARD M().count(C2Int{5});
+
+  return 0;
 }

--- a/libcxx/test/std/containers/associative/multimap/multimap.ops/equal_range1.compile.fail.cpp
+++ b/libcxx/test/std/containers/associative/multimap/multimap.ops/equal_range1.compile.fail.cpp
@@ -29,4 +29,6 @@ int main(int, char**) {
   typedef std::multimap<int, double, transparent_less_no_type> M;
 
   TEST_IGNORE_NODISCARD M().equal_range(C2Int{5});
+
+  return 0;
 }

--- a/libcxx/test/std/containers/associative/multimap/multimap.ops/equal_range2.compile.fail.cpp
+++ b/libcxx/test/std/containers/associative/multimap/multimap.ops/equal_range2.compile.fail.cpp
@@ -31,4 +31,6 @@ int main(int, char**) {
 
     TEST_IGNORE_NODISCARD M().equal_range(C2Int{5});
   }
+
+  return 0;
 }

--- a/libcxx/test/std/containers/associative/multimap/multimap.ops/equal_range3.compile.fail.cpp
+++ b/libcxx/test/std/containers/associative/multimap/multimap.ops/equal_range3.compile.fail.cpp
@@ -31,4 +31,6 @@ int main(int, char**) {
 
     TEST_IGNORE_NODISCARD M().equal_range(C2Int{5});
   }
+
+  return 0;
 }

--- a/libcxx/test/std/containers/associative/multimap/multimap.ops/find1.compile.fail.cpp
+++ b/libcxx/test/std/containers/associative/multimap/multimap.ops/find1.compile.fail.cpp
@@ -31,4 +31,6 @@ int main(int, char**) {
 
     TEST_IGNORE_NODISCARD M().find(C2Int{5});
   }
+
+  return 0;
 }

--- a/libcxx/test/std/containers/associative/multimap/multimap.ops/find2.compile.fail.cpp
+++ b/libcxx/test/std/containers/associative/multimap/multimap.ops/find2.compile.fail.cpp
@@ -31,4 +31,6 @@ int main(int, char**) {
 
     TEST_IGNORE_NODISCARD M().find(C2Int{5});
   }
+
+  return 0;
 }

--- a/libcxx/test/std/containers/associative/multimap/multimap.ops/find3.compile.fail.cpp
+++ b/libcxx/test/std/containers/associative/multimap/multimap.ops/find3.compile.fail.cpp
@@ -31,4 +31,6 @@ int main(int, char**) {
 
     TEST_IGNORE_NODISCARD M().find(C2Int{5});
   }
+
+  return 0;
 }

--- a/libcxx/test/std/containers/associative/multimap/multimap.ops/lower_bound1.compile.fail.cpp
+++ b/libcxx/test/std/containers/associative/multimap/multimap.ops/lower_bound1.compile.fail.cpp
@@ -31,4 +31,6 @@ int main(int, char**) {
 
     TEST_IGNORE_NODISCARD M().lower_bound(C2Int{5});
   }
+
+  return 0;
 }

--- a/libcxx/test/std/containers/associative/multimap/multimap.ops/lower_bound2.compile.fail.cpp
+++ b/libcxx/test/std/containers/associative/multimap/multimap.ops/lower_bound2.compile.fail.cpp
@@ -31,4 +31,6 @@ int main(int, char**) {
 
     TEST_IGNORE_NODISCARD M().lower_bound(C2Int{5});
   }
+
+  return 0;
 }

--- a/libcxx/test/std/containers/associative/multimap/multimap.ops/lower_bound3.compile.fail.cpp
+++ b/libcxx/test/std/containers/associative/multimap/multimap.ops/lower_bound3.compile.fail.cpp
@@ -31,4 +31,6 @@ int main(int, char**) {
 
     TEST_IGNORE_NODISCARD M().lower_bound(C2Int{5});
   }
+
+  return 0;
 }

--- a/libcxx/test/std/containers/associative/multimap/multimap.ops/upper_bound1.compile.fail.cpp
+++ b/libcxx/test/std/containers/associative/multimap/multimap.ops/upper_bound1.compile.fail.cpp
@@ -31,4 +31,6 @@ int main(int, char**) {
 
     TEST_IGNORE_NODISCARD M().upper_bound(C2Int{5});
   }
+
+  return 0;
 }

--- a/libcxx/test/std/containers/associative/multimap/multimap.ops/upper_bound2.compile.fail.cpp
+++ b/libcxx/test/std/containers/associative/multimap/multimap.ops/upper_bound2.compile.fail.cpp
@@ -31,4 +31,6 @@ int main(int, char**) {
 
     TEST_IGNORE_NODISCARD M().upper_bound(C2Int{5});
   }
+
+  return 0;
 }

--- a/libcxx/test/std/containers/associative/multimap/multimap.ops/upper_bound3.compile.fail.cpp
+++ b/libcxx/test/std/containers/associative/multimap/multimap.ops/upper_bound3.compile.fail.cpp
@@ -31,4 +31,6 @@ int main(int, char**) {
 
     TEST_IGNORE_NODISCARD M().upper_bound(C2Int{5});
   }
+
+  return 0;
 }

--- a/libcxx/test/std/containers/sequences/vector/vector.capacity/reserve_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.capacity/reserve_exceptions.pass.cpp
@@ -303,4 +303,6 @@ int main(int, char**) {
 #if TEST_STD_VER >= 11
   test_move_ctor_exceptions();
 #endif
+
+  return 0;
 }

--- a/libcxx/test/std/containers/sequences/vector/vector.capacity/resize_size_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.capacity/resize_size_exceptions.pass.cpp
@@ -391,4 +391,6 @@ int main(int, char**) {
 #if TEST_STD_VER >= 11
   test_move_ctor_exceptions();
 #endif
+
+  return 0;
 }

--- a/libcxx/test/std/containers/sequences/vector/vector.capacity/resize_size_value_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.capacity/resize_size_value_exceptions.pass.cpp
@@ -228,4 +228,6 @@ void test_copy_ctor_exceptions() {
 int main(int, char**) {
   test_allocation_exceptions();
   test_copy_ctor_exceptions();
+
+  return 0;
 }

--- a/libcxx/test/std/input.output/syncstream/osyncstream/members/emit.pass.cpp
+++ b/libcxx/test/std/input.output/syncstream/osyncstream/members/emit.pass.cpp
@@ -42,4 +42,6 @@ int main(int, char**) {
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
   test<wchar_t>();
 #endif
+
+  return 0;
 }

--- a/libcxx/test/std/re/re.submatch/re.submatch.members/swap.pass.cpp
+++ b/libcxx/test/std/re/re.submatch/re.submatch.members/swap.pass.cpp
@@ -73,4 +73,6 @@ int main(int, char**) {
     ASSERT_NOEXCEPT(sm1.swap(sm2));
   }
 #endif
+
+  return 0;
 }

--- a/libcxx/test/std/strings/basic.string/string.capacity/shrink_to_fit.explicit_instantiation.sh.cpp
+++ b/libcxx/test/std/strings/basic.string/string.capacity/shrink_to_fit.explicit_instantiation.sh.cpp
@@ -55,5 +55,7 @@ extern template class std::basic_string<char16, string16_char_traits>;
 int main(int, char**) {
   std::basic_string<char16, string16_char_traits> s;
   s.shrink_to_fit();
+
+  return 0;
 }
 #endif

--- a/libcxx/test/std/text/text_encoding/text_encoding.members/text_encoding.aliases_view/index.pass.cpp
+++ b/libcxx/test/std/text/text_encoding/text_encoding.members/text_encoding.aliases_view/index.pass.cpp
@@ -34,4 +34,6 @@ constexpr bool test() {
 int main(int, char**) {
   test();
   static_assert(test());
+
+  return 0;
 }

--- a/libcxx/test/std/utilities/charconv/charconv.msvc/test.cpp
+++ b/libcxx/test/std/utilities/charconv/charconv.msvc/test.cpp
@@ -1080,4 +1080,6 @@ int main(int argc, char** argv) {
     } else if (ms > 30'000) {
         puts("That was slow. Consider tuning PrefixesToTest and FractionBits to test fewer cases.");
     }
+
+    return 0;
 }

--- a/libcxx/test/std/utilities/memory/allocator.uses/allocator.uses.construction/make_obj_using_allocator.pass.cpp
+++ b/libcxx/test/std/utilities/memory/allocator.uses/allocator.uses.construction/make_obj_using_allocator.pass.cpp
@@ -140,4 +140,6 @@ constexpr bool test() {
 int main(int, char**) {
   test();
   static_assert(test());
+
+  return 0;
 }

--- a/libcxx/test/std/utilities/memory/allocator.uses/allocator.uses.construction/uninitialized_construct_using_allocator.pass.cpp
+++ b/libcxx/test/std/utilities/memory/allocator.uses/allocator.uses.construction/uninitialized_construct_using_allocator.pass.cpp
@@ -186,4 +186,6 @@ constexpr bool test() {
 int main(int, char**) {
   test();
   static_assert(test());
+
+  return 0;
 }

--- a/libcxx/test/std/utilities/memory/allocator.uses/allocator.uses.construction/uses_allocator_construction_args.pass.cpp
+++ b/libcxx/test/std/utilities/memory/allocator.uses/allocator.uses.construction/uses_allocator_construction_args.pass.cpp
@@ -253,4 +253,6 @@ constexpr bool test() {
 int main(int, char**) {
   test();
   static_assert(test());
+
+  return 0;
 }

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/ref_t.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/ref_t.pass.cpp
@@ -72,4 +72,6 @@ constexpr bool tests() {
 int main(int, char**) {
   static_assert(tests());
   tests();
+
+  return 0;
 }

--- a/libcxx/test/std/utilities/variant/variant.variant/variant.assign/copy.verify.cpp
+++ b/libcxx/test/std/utilities/variant/variant.variant/variant.assign/copy.verify.cpp
@@ -29,4 +29,6 @@ int main(int, char**)
     std::variant<NotCopyConstructible> v1;
     std::variant<NotCopyConstructible> v2(v); // expected-error {{call to implicitly-deleted copy constructor of 'std::variant<NotCopyConstructible>'}}
     v1 = v; // expected-error-re {{object of type 'std:{{.*}}:variant<NotCopyConstructible>' cannot be assigned because its copy assignment operator is implicitly deleted}}
+
+    return 0;
 }


### PR DESCRIPTION
The libc++ test suite requires main() to explicitly return a value, since freestanding support requires it.