### PR TITLE
[github] Label llvm/tools/spirv-tools changes as backend:SPIR-V

### DIFF
--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -961,6 +961,7 @@ backend:SPIR-V:
       - llvm/test/CodeGen/SPIRV/**
       - llvm/test/Frontend/HLSL/**
       - llvm/docs/SPIRVUsage.rst
+      - llvm/tools/spirv-tools/**
 
 mlgo:
   - changed-files:


### PR DESCRIPTION
E.g. https://github.com/llvm/llvm-project/pull/214159 PR is missing labels