### PR TITLE
[lldb][test] Mark some tests as requiring Clang

### DIFF
--- a/lldb/test/API/commands/frame/var/TestFrameVar.py
+++ b/lldb/test/API/commands/frame/var/TestFrameVar.py
@@ -170,6 +170,7 @@ class TestFrameVar(TestBase):
 
     @skipIfRemote
     @skipIfWindows  # Windows can't set breakpoints by name 'main' in this case.
+    @skipIf(compiler=no_match("clang"))
     def test_gline_tables_only(self):
         """
         Test that if we build a binary with "-gline-tables-only" that we can

--- a/lldb/test/API/lang/cpp/abi_tag_structors/TestAbiTagStructors.py
+++ b/lldb/test/API/lang/cpp/abi_tag_structors/TestAbiTagStructors.py
@@ -17,6 +17,7 @@ class AbiTagStructorsTestCase(TestBase):
         compiler_version=["<", "22"],
         bugnumber="Required Clang flag not supported",
     )
+    @skipIf(compiler=no_match("clang"))
     @expectedFailureAll(oslist=["windows"])
     @skipIfWasm  # no expression evaluation
     def test_with_structor_linkage_names(self):
@@ -76,6 +77,7 @@ class AbiTagStructorsTestCase(TestBase):
         )
 
     @expectedFailureAll(oslist=["windows"])
+    @skipIf(compiler=no_match("clang"))
     def test_no_structor_linkage_names(self):
         """
         Test that without linkage names on structor declarations we can't call
@@ -123,12 +125,14 @@ class AbiTagStructorsTestCase(TestBase):
         )
 
     @skipIf(compiler="clang", compiler_version=["<", "22"])
+    @skipIf(compiler=no_match("clang"))
     @expectedFailureAll(oslist=["windows"])
     @skipIfWasm  # no expression evaluation
     def test_nested_with_structor_linkage_names(self):
         self.build(dictionary={"CXXFLAGS_EXTRAS": "-gstructor-decl-linkage-names"})
         self.do_nested_structor_test()
 
+    @skipIf(compiler=no_match("clang"))
     @expectedFailureAll(oslist=["windows"])
     @skipIfWasm  # no expression evaluation
     def test_nested_no_structor_linkage_names(self):

--- a/lldb/test/API/lang/cpp/template-alias/TestTemplateAlias.py
+++ b/lldb/test/API/lang/cpp/template-alias/TestTemplateAlias.py
@@ -23,6 +23,7 @@ class TestTemplateAlias(TestBase):
         self.expect_expr("cbf1", result_type="Container<int>")
 
     @skipIf(compiler="clang", compiler_version=["<", "21"])
+    @skipIf(compiler=no_match("clang"))
     @expectedFailureAll(
         bugnumber="LLDB doesn't reconstruct template alias names from template parameters"
     )
@@ -32,6 +33,7 @@ class TestTemplateAlias(TestBase):
         )
 
     @skipIf(compiler="clang", compiler_version=["<", "21"])
+    @skipIf(compiler=no_match("clang"))
     def test_tag_alias_no_simple(self):
         self.do_test(
             dict(
@@ -40,6 +42,7 @@ class TestTemplateAlias(TestBase):
         )
 
     @skipIf(compiler="clang", compiler_version=["<", "21"])
+    @skipIf(compiler=no_match("clang"))
     def test_no_tag_alias_simple(self):
         self.do_test(
             dict(
@@ -48,6 +51,7 @@ class TestTemplateAlias(TestBase):
         )
 
     @skipIf(compiler="clang", compiler_version=["<", "21"])
+    @skipIf(compiler=no_match("clang"))
     def test_no_tag_alias_no_simple(self):
         self.do_test(
             dict(


### PR DESCRIPTION
As they use clang specific debug information options.