### PR TITLE
[lldb][test] Improve error for C++ compiler detection and improve docs

### DIFF
--- a/lldb/docs/resources/build.md
+++ b/lldb/docs/resources/build.md
@@ -263,6 +263,12 @@ $ cmake -G Ninja \
     <path to root of llvm source tree>
 ```
 
+:::{note}
+`LLDB_TEST_COMPILER` points to a single compiler. It is expected that this is
+the C compiler and that the C++ compiler's name can be inferred from the name
+of the C compiler.
+:::
+
 It is strongly recommend to use a release build for the compiler to speed up
 test execution.
 

--- a/lldb/packages/Python/lldbsuite/test/builders/builder.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/builder.py
@@ -149,10 +149,18 @@ class Builder:
             "xcrun clang": "xcrun clang++",
         }
         # Determine the C++ compiler based on the given compiler path/command.
-        cxx_type = cxx_types.get(compiler)
-        if cxx_type is None:
+        try:
+            cxx_type = cxx_types[compiler]
+        except KeyError:
             # If that did not work, then use the inferred cc_type.
-            cxx_type = cxx_types.get(cc_type, cxx_type)
+            try:
+                cxx_type = cxx_types[cc_type]
+            except KeyError:
+                err = "Could not infer C++ compiler name from "
+                if compiler is not None:
+                    err += f'compiler name "{compiler}" or '
+                err += f'compiler type "{cc_type}"'
+                raise RuntimeError(err)
 
         cc_dir = cc_path.parent
 

--- a/lldb/test/API/CMakeLists.txt
+++ b/lldb/test/API/CMakeLists.txt
@@ -89,7 +89,7 @@ else()
 endif()
 
 set(LLDB_TEST_EXECUTABLE "${LLDB_DEFAULT_TEST_EXECUTABLE}" CACHE PATH "lldb executable used for testing")
-set(LLDB_TEST_COMPILER "${LLDB_DEFAULT_TEST_COMPILER}" CACHE PATH "C Compiler to use for building LLDB test inferiors")
+set(LLDB_TEST_COMPILER "${LLDB_DEFAULT_TEST_COMPILER}" CACHE PATH "C Compiler to use for building LLDB test inferiors (the C++ compiler will be inferred from this)")
 set(LLDB_TEST_DSYMUTIL "${LLDB_DEFAULT_TEST_DSYMUTIL}" CACHE PATH "dsymutil used for generating dSYM bundles")
 set(LLDB_TEST_MAKE "${LLDB_DEFAULT_TEST_MAKE}" CACHE PATH "make tool used for building test executables")
 set(LLDB_TEST_RESOURCE_DIR "" CACHE PATH "Clang resource directory for cross-compiling test inferiors")


### PR DESCRIPTION
I did not realise that LLDB_TEST_COMPILER should be the C compiler, so I got:
    cxx = cc_dir / (cc_prefix + cxx_type + cc_ext)
TypeError: can only concatenate str (not "NoneType") to str Config=aarch64-/usr/bin/g++

I have simplified the logic and added a more informative error: 
RuntimeError: Could not infer C++ compiler name from compiler type "g++"

Added a note to the documentation.

The CMake description does say "C compiler", but it's easy to gloss over that so I extended that to say how we get the C++ compiler.