### PR TITLE
[docs] Drop stale "experimental" note for preserve_most

### DIFF
--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -6889,13 +6889,11 @@ rarely executed, whereas ``preserve_most`` function calls are intended to be
 on the hot path and definitely executed a lot. Furthermore ``preserve_most``
 doesn't prevent the inliner from inlining the function call.
 
-This calling convention will be used by a future version of the Objective-C
-runtime and should therefore still be considered experimental at this time.
-Although this convention was created to optimize certain runtime calls to
-the Objective-C runtime, it is not limited to this runtime and might be used
-by other runtimes in the future too. The current implementation only
-supports X86-64 and AArch64, but the intention is to support more architectures
-in the future.
+This convention was created to optimize certain runtime calls to the
+Objective-C runtime, but it is not limited to that runtime; it is also used by
+other runtimes and libraries, such as the Swift runtime and the Linux kernel.
+The current implementation only supports X86-64 and AArch64, but the intention
+is to support more architectures in the future.
   }];
 }
 

--- a/llvm/docs/LangRef.md
+++ b/llvm/docs/LangRef.md
@@ -432,13 +432,10 @@ added in the future:
     on the hot path and definitely executed a lot. Furthermore `preserve_mostcc`
     doesn't prevent the inliner from inlining the function call.
 
-    This calling convention will be used by a future version of the Objective-C
-    runtime and should therefore still be considered experimental at this time.
-    Although this convention was created to optimize certain runtime calls to
-    the Objective-C runtime, it is not limited to this runtime and might be used
-    by other runtimes in the future too. The current implementation only
-    supports X86-64, but the intention is to support more architectures in the
-    future.
+    This convention was created to optimize certain runtime calls to the
+    Objective-C runtime, but it is not limited to that runtime; it is also used
+    by other runtimes and libraries, such as the Swift runtime and the Linux
+    kernel.
 
 "`preserve_allcc`" - The `PreserveAll` calling convention
 :   This calling convention attempts to make the code in the caller even less


### PR DESCRIPTION
The LangRef and Clang attribute docs say preserve_most "will be used by a future version of the Objective-C runtime and should therefore still be considered experimental at this time." That note dates to the convention's introduction in 2014.

It's now used in the swift runtime (swiftlang/swift#85044), [linux kernel](https://github.com/torvalds/linux/blob/c21bb4193868a8de71fc4693fa741e195fdf5d86/include/linux/compiler_types.h#L139-L143), V8 (V8_PRESERVE_MOST), tcmalloc, and protobuf's upb.

Following the precedent of #158637 (which dropped "experimental" from the partial reduction intrinsics): this convention has been used in production for a while and is unlikely to change.

preserve_all is left untouched; its adoption story is much thinner, so its experimental note is arguably still doing honest work.

Addresses part of #178277.