### PR TITLE
LangRef: mention that willreturn can cause time-traveling UB

### DIFF
--- a/llvm/docs/LangRef.md
+++ b/llvm/docs/LangRef.md
@@ -2496,6 +2496,12 @@ fn -> other_fn -> other_fn ; fn is norecurse
     If an invocation of an annotated function does not return control back
     to a point in the call stack, the behavior is undefined.
 
+    If the annotated function has observable behavior (such as I/O or a volatile
+    access), note that the annotation can cause UB to time-travel around such
+    behavior, i.e., code that is after the function can cause UB to occur before
+    the observable behavior of the function. See the {doc}`UB documentation
+    <UndefinedBehavior>` for further details.
+
 `nosync`
 :   This function attribute indicates that the function does not introduce any
     *synchronizes-with* edges in the sense of the memory model.

--- a/llvm/docs/UndefinedBehavior.rst
+++ b/llvm/docs/UndefinedBehavior.rst
@@ -83,7 +83,8 @@ most of the supported architectures.
 
 Time Travel
 -----------
-Immediate UB in LLVM IR allows the so-called time travelling. What this means
+When using the ``willreturn`` attribute,
+immediate UB in LLVM IR allows the so-called time travelling. What this means
 is that if a program triggers UB, then we are not required to preserve any of
 its observable behavior, including I/O.
 For example, the following function triggers UB after calling ``printf``:
@@ -105,6 +106,9 @@ optimize the function to simply:
       unreachable
     }
 
+Without ``willreturn``, UB in LLVM will never exhibit time-traveling. This means
+frontends can avoid time-traveling UB by only putting ``willreturn`` on
+functions without observable behavior.
 
 Deferred UB
 ===========


### PR DESCRIPTION
I think with #192992, the only remaining possible source of time-traveling UB in LLVM are `willreturn` annotations emitted by the frontend. So let's add a note about that.

I think ideally we'd also say somewhere "UB cannot time-travel except if you put `willreturn` on a function that has observable behavior", but I am not sure what would be a good place for that.

Cc @nikic @dtcxzyw @gonzalobg 