### PR TITLE
Validate EXT byte-index immediates

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrFormats.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrFormats.td
@@ -7686,8 +7686,8 @@ multiclass SIMDWideThreeVectorBHS<bit U, bits<4> opc, string asm,
 //----------------------------------------------------------------------------
 
 class BaseSIMDBitwiseExtract<bit size, RegisterOperand regtype, ValueType vty,
-                             string asm, string kind>
-  : I<(outs regtype:$Rd), (ins regtype:$Rn, regtype:$Rm, i32imm:$imm), asm,
+                             Operand immtype, string asm, string kind>
+  : I<(outs regtype:$Rd), (ins regtype:$Rn, regtype:$Rm, immtype:$imm), asm,
       "{\t$Rd" # kind # ", $Rn" # kind # ", $Rm" # kind # ", $imm" #
       "|" # kind # "\t$Rd, $Rn, $Rm, $imm}", "",
       [(set (vty regtype:$Rd),
@@ -7710,10 +7710,10 @@ class BaseSIMDBitwiseExtract<bit size, RegisterOperand regtype, ValueType vty,
 
 
 multiclass SIMDBitwiseExtract<string asm> {
-  def v8i8  : BaseSIMDBitwiseExtract<0, V64, v8i8, asm, ".8b"> {
+  def v8i8  : BaseSIMDBitwiseExtract<0, V64, v8i8, imm32_0_7, asm, ".8b"> {
     let imm{3} = 0;
   }
-  def v16i8 : BaseSIMDBitwiseExtract<1, V128, v16i8, asm, ".16b">;
+  def v16i8 : BaseSIMDBitwiseExtract<1, V128, v16i8, imm32_0_15, asm, ".16b">;
 }
 
 //----------------------------------------------------------------------------

--- a/llvm/test/MC/AArch64/neon-diagnostics.s
+++ b/llvm/test/MC/AArch64/neon-diagnostics.s
@@ -6418,6 +6418,21 @@
 // CHECK-ERROR:         ext v0.2d, v1.2d, v2.2d, #0x0
 // CHECK-ERROR:                ^
 
+        // Symbolic operands are not valid byte-index immediates.
+        ext v0.8b, v1.8b, v2.8b, f0
+// CHECK-ERROR: [[@LINE-1]]:34: error: immediate must be an integer in range [0, 7].
+        ext v0.16b, v1.16b, v2.16b, f0
+// CHECK-ERROR: [[@LINE-1]]:37: error: immediate must be an integer in range [0, 15].
+        ext v0.8b, v1.8b, v2.8b, NaN
+// CHECK-ERROR: [[@LINE-1]]:34: error: immediate must be an integer in range [0, 7].
+        ext v0.8b, v1.8b, v2.8b, Inf
+// CHECK-ERROR: [[@LINE-1]]:34: error: immediate must be an integer in range [0, 7].
+
+        // Out-of-range byte-index immediates must be rejected.
+        ext v0.8b, v1.8b, v2.8b, #8
+// CHECK-ERROR: [[@LINE-1]]:34: error: immediate must be an integer in range [0, 7].
+        ext v0.16b, v1.16b, v2.16b, #16
+// CHECK-ERROR: [[@LINE-1]]:37: error: immediate must be an integer in range [0, 15].
 
 //----------------------------------------------------------------------
 // Permutation with 3 vectors

--- a/llvm/test/MC/AArch64/neon-extract.s
+++ b/llvm/test/MC/AArch64/neon-extract.s
@@ -8,6 +8,10 @@
 
         ext v0.8b, v1.8b, v2.8b, #0x3
         ext v0.16b, v1.16b, v2.16b, #0x3
+        ext v0.8b, v1.8b, v2.8b, #7
+        ext v0.16b, v1.16b, v2.16b, #15
 
 // CHECK: ext	v0.8b, v1.8b, v2.8b, #{{0x3|3}}  // encoding: [0x20,0x18,0x02,0x2e]
 // CHECK: ext	v0.16b, v1.16b, v2.16b, #{{0x3|3}} // encoding: [0x20,0x18,0x02,0x6e]
+// CHECK: ext	v0.8b, v1.8b, v2.8b, #7  // encoding: [0x20,0x38,0x02,0x2e]
+// CHECK: ext	v0.16b, v1.16b, v2.16b, #15 // encoding: [0x20,0x78,0x02,0x6e]


### PR DESCRIPTION
This fixes operand validation for AArch64 EXT instructions.

Symbolic operands such as f0, NaN, and Inf, as well as out-of-range byte-index immediates, could previously reach encoding paths that expect valid integer immediates. This could cause assertion failures in assertions-enabled builds or incorrect encodings when assertions were disabled.

The patch uses the appropriate immediate operand ranges for the .8b and .16b forms so invalid operands are rejected during parsing.

Regression tests cover symbolic operands, out-of-range immediates, and the valid boundary values #7 and #15.

Testing:

* llvm/test/MC/AArch64/neon-diagnostics.s
* llvm/test/MC/AArch64/neon-extract.s

Fixes #185361

The SCVTF/UCVTF portion originally included in this PR is now covered by #213490 and was removed after rebasing onto current main.