### PR TITLE
[lldb][Windows] Fix value API tests

### DIFF
--- a/lldb/test/API/python_api/value/Makefile
+++ b/lldb/test/API/python_api/value/Makefile
@@ -1,3 +1,8 @@
 C_SOURCES := main.c
 
+ifeq "$(OS)" "Windows_NT"
+	# Embed a symbol table in the executable.
+	LD_EXTRAS := -Wl,/debug:symtab
+endif
+
 include Makefile.rules

--- a/lldb/test/API/python_api/value/TestValueAPI.py
+++ b/lldb/test/API/python_api/value/TestValueAPI.py
@@ -19,7 +19,6 @@ class ValueAPITestCase(TestBase):
         # Find the line number to of function 'c'.
         self.line = line_number("main.c", "// Break at this line")
 
-    @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24772")
     def test(self):
         """Exercise some SBValue APIs."""
         d = {"EXE": self.exe_name}

--- a/lldb/test/API/python_api/value/change_values/TestChangeValueAPI.py
+++ b/lldb/test/API/python_api/value/change_values/TestChangeValueAPI.py
@@ -22,7 +22,6 @@ class ChangeValueAPITestCase(TestBase):
         self.end_line = line_number("main.c", "// Set a breakpoint here at the end")
 
     @expectedFlakeyLinux("llvm.org/pr25652")
-    @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24772")
     @skipIfWasm  # Wasm exposes no stack pointer register
     def test_change_value(self):
         """Exercise the SBValue::SetValueFromCString API."""

--- a/lldb/test/API/python_api/value/change_values/main.c
+++ b/lldb/test/API/python_api/value/change_values/main.c
@@ -22,9 +22,12 @@ int main ()
   ptr->fourth_val = false;
 
   // Stop here and set values
+  bool for_breakpoint = ptr->fourth_val + val;
+
   printf("Val - %d Mine - %d, %d, %llu, %d. Ptr - %d, %d, %llu, %d\n", val,
          mine.first_val, mine.second_val, mine.third_val, mine.fourth_val,
          ptr->first_val, ptr->second_val, ptr->third_val, ptr->fourth_val);
+  fflush(stdout);
 
   // Stop here and check values
   printf ("This is just another call which we won't make it over %d.", val);


### PR DESCRIPTION
This removes the XFAILs for the value API tests.

- For `lldb/test/API/python_api/value/TestValueAPI.py`, we need to pass `/debug:symtab` to the linker to get a symbol table. Symbols are "hidden" by default. PDB works around this in the publics stream. For DWARF, we need `/debug:symtab`. An alternative is to use `/debug:dwarf` which also enables this.
- For `lldb/test/API/python_api/value/change_values/TestChangeValueAPI.py` there were two issues. First, the stdout wasn't available when we stopped at a breakpoint. Adding a `fflush(stdout)` fixes this.
  Secondly, the breakpoint was created where the inputs to `printf` were already evaluated. I added another assignment where we set the breakpoint.

  The added `fflush` might also help with this being flakey on Linux (#26026).

Closes #25146