### PR TITLE
[NFC][DWARF] Prefer addSectionLabel

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.cpp
@@ -526,13 +526,8 @@ DIE &DwarfCompileUnit::updateSubprogramScopeDIE(const DISubprogram *SP,
   if (emitFuncLineTableOffsets() && LineTableSym) {
     MCSymbol *Symbol =
         Asm->getObjFileLowering().getDwarfLineSection()->getBeginSymbol();
-    if (isDwoUnit()) {
-      addSectionDelta(*SPDie, dwarf::DW_AT_LLVM_stmt_sequence, LineTableSym,
-                      Symbol);
-    } else {
-      addSectionLabel(*SPDie, dwarf::DW_AT_LLVM_stmt_sequence, LineTableSym,
-                      Symbol);
-    }
+    addSectionLabel(*SPDie, dwarf::DW_AT_LLVM_stmt_sequence, LineTableSym,
+                    Symbol);
   }
 
   // Only include DW_AT_frame_base in full debug info
@@ -648,12 +643,7 @@ void DwarfCompileUnit::addScopeRangeList(DIE &ScopeDIE,
     const TargetLoweringObjectFile &TLOF = Asm->getObjFileLowering();
     const MCSymbol *RangeSectionSym =
         TLOF.getDwarfRangesSection()->getBeginSymbol();
-    if (isDwoUnit())
-      addSectionDelta(ScopeDIE, dwarf::DW_AT_ranges, List.Label,
-                      RangeSectionSym);
-    else
-      addSectionLabel(ScopeDIE, dwarf::DW_AT_ranges, List.Label,
-                      RangeSectionSym);
+    addSectionLabel(ScopeDIE, dwarf::DW_AT_ranges, List.Label, RangeSectionSym);
   }
 }
 

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -1428,28 +1428,17 @@ void DwarfDebug::finalizeModuleInfo() {
     // If compile Unit has macros, emit "DW_AT_macro_info/DW_AT_macros"
     // attribute.
     if (CUNode->getMacros()) {
+      DIE &InfoEntry = useSplitDwarf() ? TheCU.getUnitDie() : U.getUnitDie();
       if (UseDebugMacroSection) {
-        if (useSplitDwarf())
-          TheCU.addSectionDelta(
-              TheCU.getUnitDie(), dwarf::DW_AT_macros, U.getMacroLabelBegin(),
-              TLOF.getDwarfMacroDWOSection()->getBeginSymbol());
-        else {
-          dwarf::Attribute MacrosAttr = getDwarfVersion() >= 5
-                                            ? dwarf::DW_AT_macros
-                                            : dwarf::DW_AT_GNU_macros;
-          U.addSectionLabel(U.getUnitDie(), MacrosAttr, U.getMacroLabelBegin(),
-                            TLOF.getDwarfMacroSection()->getBeginSymbol());
-        }
+        dwarf::Attribute MacrosAttr = getDwarfVersion() >= 5 || useSplitDwarf()
+                                          ? dwarf::DW_AT_macros
+                                          : dwarf::DW_AT_GNU_macros;
+        U.addSectionLabel(InfoEntry, MacrosAttr, U.getMacroLabelBegin(),
+                          TLOF.getDwarfMacroSection()->getBeginSymbol());
       } else {
-        if (useSplitDwarf())
-          TheCU.addSectionDelta(
-              TheCU.getUnitDie(), dwarf::DW_AT_macro_info,
-              U.getMacroLabelBegin(),
-              TLOF.getDwarfMacinfoDWOSection()->getBeginSymbol());
-        else
-          U.addSectionLabel(U.getUnitDie(), dwarf::DW_AT_macro_info,
-                            U.getMacroLabelBegin(),
-                            TLOF.getDwarfMacinfoSection()->getBeginSymbol());
+        U.addSectionLabel(InfoEntry, dwarf::DW_AT_macro_info,
+                          U.getMacroLabelBegin(),
+                          TLOF.getDwarfMacinfoSection()->getBeginSymbol());
       }
     }
   }

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -1439,10 +1439,12 @@ void DwarfDebug::finalizeModuleInfo() {
         CompileUnit.addSectionLabel(CompileUnit.getUnitDie(), MacrosAttr,
                                     U.getMacroLabelBegin(), Section);
       } else {
-        CompileUnit.addSectionLabel(
-            CompileUnit.getUnitDie(), dwarf::DW_AT_macro_info,
-            U.getMacroLabelBegin(),
-            TLOF.getDwarfMacinfoSection()->getBeginSymbol());
+        const MCSymbol *Section =
+            useSplitDwarf() ? TLOF.getDwarfMacinfoDWOSection()->getBeginSymbol()
+                            : TLOF.getDwarfMacinfoSection()->getBeginSymbol();
+        CompileUnit.addSectionLabel(CompileUnit.getUnitDie(),
+                                    dwarf::DW_AT_macro_info,
+                                    U.getMacroLabelBegin(), Section);
       }
     }
   }

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -1428,17 +1428,21 @@ void DwarfDebug::finalizeModuleInfo() {
     // If compile Unit has macros, emit "DW_AT_macro_info/DW_AT_macros"
     // attribute.
     if (CUNode->getMacros()) {
-      DIE &InfoEntry = useSplitDwarf() ? TheCU.getUnitDie() : U.getUnitDie();
+      DwarfCompileUnit &CompileUnit = useSplitDwarf() ? TheCU : U;
       if (UseDebugMacroSection) {
+        const MCSymbol *Section =
+            useSplitDwarf() ? TLOF.getDwarfMacroDWOSection()->getBeginSymbol()
+                            : TLOF.getDwarfMacroSection()->getBeginSymbol();
         dwarf::Attribute MacrosAttr = getDwarfVersion() >= 5 || useSplitDwarf()
                                           ? dwarf::DW_AT_macros
                                           : dwarf::DW_AT_GNU_macros;
-        U.addSectionLabel(InfoEntry, MacrosAttr, U.getMacroLabelBegin(),
-                          TLOF.getDwarfMacroSection()->getBeginSymbol());
+        CompileUnit.addSectionLabel(CompileUnit.getUnitDie(), MacrosAttr,
+                                    U.getMacroLabelBegin(), Section);
       } else {
-        U.addSectionLabel(InfoEntry, dwarf::DW_AT_macro_info,
-                          U.getMacroLabelBegin(),
-                          TLOF.getDwarfMacinfoSection()->getBeginSymbol());
+        CompileUnit.addSectionLabel(
+            CompileUnit.getUnitDie(), dwarf::DW_AT_macro_info,
+            U.getMacroLabelBegin(),
+            TLOF.getDwarfMacinfoSection()->getBeginSymbol());
       }
     }
   }

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
@@ -2129,7 +2129,7 @@ void DwarfUnit::addSectionDelta(DIE &Die, dwarf::Attribute Attribute,
 
 void DwarfUnit::addSectionLabel(DIE &Die, dwarf::Attribute Attribute,
                                 const MCSymbol *Label, const MCSymbol *Sec) {
-  if (Asm->doesDwarfUseRelocationsAcrossSections())
+  if (Asm->doesDwarfUseRelocationsAcrossSections() && !isDwoUnit())
     addLabel(Die, Attribute, DD->getDwarfSectionOffsetForm(), Label);
   else
     addSectionDelta(Die, Attribute, Label, Sec);

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
@@ -2129,6 +2129,8 @@ void DwarfUnit::addSectionDelta(DIE &Die, dwarf::Attribute Attribute,
 
 void DwarfUnit::addSectionLabel(DIE &Die, dwarf::Attribute Attribute,
                                 const MCSymbol *Label, const MCSymbol *Sec) {
+  // If we are in an object file and not a DWO, emit a label. Otherwise we are
+  // in a DWO and we cannot emit relocations, so emit a section delta.
   if (Asm->doesDwarfUseRelocationsAcrossSections() && !isDwoUnit())
     addLabel(Die, Attribute, DD->getDwarfSectionOffsetForm(), Label);
   else

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.h
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.h
@@ -317,7 +317,8 @@ public:
 
   void constructTypeDIE(DIE &Buffer, const DICompositeType *CTy);
 
-  /// Add a Dwarf section label attribute data and value.
+  /// Add a Dwarf section label attribute data and value. If the current unit
+  /// is a DWO, this function will instead emit a section delta.
   void addSectionLabel(DIE &Die, dwarf::Attribute Attribute,
                        const MCSymbol *Label, const MCSymbol *Sec);
 

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.h
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.h
@@ -317,10 +317,6 @@ public:
 
   void constructTypeDIE(DIE &Buffer, const DICompositeType *CTy);
 
-  /// addSectionDelta - Add a label delta attribute data and value.
-  void addSectionDelta(DIE &Die, dwarf::Attribute Attribute, const MCSymbol *Hi,
-                       const MCSymbol *Lo);
-
   /// Add a Dwarf section label attribute data and value.
   void addSectionLabel(DIE &Die, dwarf::Attribute Attribute,
                        const MCSymbol *Label, const MCSymbol *Sec);
@@ -413,6 +409,10 @@ private:
   /// Returns 'true' if the current DwarfVersion is compatible
   /// with the specified \p Version.
   bool isCompatibleWithVersion(uint16_t Version) const;
+
+  /// addSectionDelta - Add a label delta attribute data and value.
+  void addSectionDelta(DIE &Die, dwarf::Attribute Attribute, const MCSymbol *Hi,
+                       const MCSymbol *Lo);
 };
 
 class DwarfTypeUnit final : public DwarfUnit {

--- a/llvm/test/DebugInfo/X86/debug-macro-dwo.ll
+++ b/llvm/test/DebugInfo/X86/debug-macro-dwo.ll
@@ -1,10 +1,11 @@
 ; This test checks emission of .debug_macro.dwo section when
 ; -gdwarf-5 -gsplit-dwarf -fdebug-macro is specified.
 
-; RUN: llc -dwarf-version=5 -O0 -filetype=obj \
-; RUN: -split-dwarf-file=foo.dwo < %s | llvm-dwarfdump -debug-macro -debug-info -debug-line -v - | FileCheck %s
+; RUN: llc -dwarf-version=5 -O0 -filetype=obj -split-dwarf-output=%t.dwo \
+; RUN: -split-dwarf-file=%t.dwo -o %t.o < %s
+; RUN: llvm-dwarfdump -debug-macro -debug-info -debug-line -v %t.dwo | FileCheck %s
 
-; CHECK-LABEL:  .debug_info contents:
+; CHECK-LABEL:  .debug_info.dwo contents:
 ; CHECK: DW_AT_macros [DW_FORM_sec_offset] (0x00000000)
 
 ; CHECK-LABEL:  .debug_macro.dwo contents:


### PR DESCRIPTION
This is a follow-up to a comment on #213128.

addSectionDelta was only called in sites within if statements that would branch on whether or not split DWARF is enabled and then branching to either addSectionDelta or addSectionLabel. Instead we can just make addSectionLabel call addSectionDelta internally if we're in a DwoUnit to make things simpler.

This is obviously NFC for most cases. For macro info, we were previously branching on useSplitDWARF which can differ, but only in the case we are emitting into the skeleton compile unit, which we should not be doing for macro info.