### PR TITLE
[SPIR-V] Put deduced function pointer types in CodeSectionINTEL

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVPreLegalizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPreLegalizer.cpp
@@ -746,9 +746,13 @@ generateAssignInstrs(MachineFunction &MF, SPIRVGlobalRegistry *GR,
         Register Reg = MI.getOperand(1).getReg();
         MIB.setInsertPt(*MI.getParent(), MI.getIterator());
         Type *ElementTy = getMDOperandAsType(MI.getOperand(2).getMetadata(), 0);
-        SPIRVTypeInst AssignedPtrType = GR->getOrCreateSPIRVPointerType(
-            ElementTy, MI,
-            addressSpaceToStorageClass(MI.getOperand(3).getImm(), *ST));
+        auto SC = addressSpaceToStorageClass(MI.getOperand(3).getImm(), *ST);
+        if (SC == SPIRV::StorageClass::Function &&
+            isa<FunctionType>(ElementTy) &&
+            ST->canUseExtension(SPIRV::Extension::SPV_INTEL_function_pointers))
+          SC = SPIRV::StorageClass::CodeSectionINTEL;
+        SPIRVTypeInst AssignedPtrType =
+            GR->getOrCreateSPIRVPointerType(ElementTy, MI, SC);
         // The intrinsic also carries vector-of-pointer values produced by
         // scalarized vector GEPs; wrap the pointer in OpTypeVector to match
         // the vreg's LLT.

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_function_pointers/fp-select.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_function_pointers/fp-select.ll
@@ -1,0 +1,31 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_function_pointers %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_function_pointers %s -o - -filetype=obj | spirv-val %}
+
+; A function pointer lives in the CodeSectionINTEL storage class, so a select
+; between two of them has operands and a result of that same pointer type.
+
+; CHECK-DAG: OpName %[[#BAR:]] "bar"
+; CHECK-DAG: OpName %[[#BAZ:]] "baz"
+; CHECK-DAG: %[[#I32:]] = OpTypeInt 32 0
+; CHECK-DAG: %[[#FNTY:]] = OpTypeFunction %[[#I32]] %[[#I32]] %[[#I32]]
+; CHECK-DAG: %[[#FPTY:]] = OpTypePointer CodeSectionINTEL %[[#FNTY]]
+; CHECK-DAG: %[[#BARFP:]] = OpConstantFunctionPointerINTEL %[[#FPTY]] %[[#BAR]]
+; CHECK-DAG: %[[#BAZFP:]] = OpConstantFunctionPointerINTEL %[[#FPTY]] %[[#BAZ]]
+; CHECK: %[[#FP:]] = OpSelect %[[#FPTY]] %[[#]] %[[#BARFP]] %[[#BAZFP]]
+; CHECK: OpFunctionPointerCallINTEL %[[#I32]] %[[#FP]]
+
+define spir_func i32 @caller(i1 %c, i32 %a, i32 %b) {
+  %fp = select i1 %c, ptr @bar, ptr @baz
+  %r = call spir_func i32 %fp(i32 %a, i32 %b)
+  ret i32 %r
+}
+
+define spir_func i32 @bar(i32 %a, i32 %b) {
+  %s = add i32 %a, %b
+  ret i32 %s
+}
+
+define spir_func i32 @baz(i32 %a, i32 %b) {
+  %s = mul i32 %a, %b
+  ret i32 %s
+}

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_function_pointers/fp_const.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_function_pointers/fp_const.ll
@@ -21,8 +21,8 @@
 ; CHECK: %[[Cast1:.*]] = OpBitcast %[[TyPtrPtrFun]] %[[Var]]
 ; CHECK: %[[Cast2:.*]] = OpBitcast %[[TyPtrPtrFunCodeSection]] %[[Cast1]]
 ; CHECK: OpStore %[[Cast2]] %[[ConstFunFp]] Aligned 4
-; CHECK: %[[Cast3:.*]] = OpBitcast %[[TyPtrPtrFun]] %[[Var]]
-; CHECK: %[[FP:.*]] = OpLoad %[[TyPtrFun]] %[[Cast3]] Aligned 4
+; CHECK: %[[Cast3:.*]] = OpBitcast %[[TyPtrPtrFunCodeSection]] %[[Var]]
+; CHECK: %[[FP:.*]] = OpLoad %[[TyPtrFunCodeSection]] %[[Cast3]] Aligned 4
 ; CHECK: OpFunctionPointerCallINTEL %[[TyInt64]] %[[FP]] %[[#]]
 ; CHECK: OpFunctionEnd
 

--- a/llvm/test/CodeGen/SPIRV/pointers/fun-with-aggregate-arg-in-const-init.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/fun-with-aggregate-arg-in-const-init.ll
@@ -56,7 +56,7 @@
 ; CHECK-DAG: %[[#I32Const2:]] = OpConstant %[[#Int32Ty]] 2
 ; CHECK-DAG: %[[#I32Const1:]] = OpConstant %[[#Int32Ty]] 1
 ; CHECK-DAG: %[[#I32Const0:]] = OpConstantNull %[[#Int32Ty]]
-; CHECK-DAG: %[[#GlobalFnPtrPtrTy:]] = OpTypePointer CrossWorkgroup %[[#FnPtrTy]]
+; CHECK-DAG: %[[#GlobalFnPtrPtrTy:]] = OpTypePointer CrossWorkgroup %[[#IntelFnPtrTy]]
 %t_half = type { half }
 %struct.anon = type { ptr, ptr, ptr }
 
@@ -93,14 +93,14 @@ entry:
 ; CHECK-DAG: %[[#fStruct]] = OpFunction %[[#VoidTy]] None %[[#TestFnTy]]
 ; CHECK-DAG: %[[#fnStructCast0:]] = OpBitcast %[[#GlobalInt8PtrPtrTy]] %[[#fnstruct]]
 ; CHECK: %[[#fnStructCast1:]] = OpBitcast %[[#GlobalFnPtrPtrTy]] %[[#fnStructCast0]]
-; CHECK: %[[#f0Load:]] = OpLoad %[[#FnPtrTy]] %[[#fnStructCast1]]
+; CHECK: %[[#f0Load:]] = OpLoad %[[#IntelFnPtrTy]] %[[#fnStructCast1]]
 ; CHECK: %[[#fnStructCast2:]] = OpBitcast %[[#GlobalStructWithPtrPtrTy]] %[[#fnstruct]]
 ; CHECK: %[[#f1GEP:]] = OpInBoundsPtrAccessChain %[[#GlobalInt8PtrPtrTy]] %[[#fnStructCast2]] %[[#I32Const0]] %[[#I32Const1]]
 ; CHECK: %[[#f1GEPCast:]] = OpBitcast %[[#GlobalFnPtrPtrTy]] %[[#f1GEP]]
-; CHECK: %[[#f1Load:]] = OpLoad %[[#FnPtrTy]] %[[#f1GEPCast]]
+; CHECK: %[[#f1Load:]] = OpLoad %[[#IntelFnPtrTy]] %[[#f1GEPCast]]
 ; CHECK: %[[#f2GEP:]] = OpInBoundsPtrAccessChain %[[#GlobalInt8PtrPtrTy]] %[[#fnStructCast2]] %[[#I32Const0]] %[[#I32Const2]]
 ; CHECK: %[[#f2GEPCast:]] = OpBitcast %[[#GlobalFnPtrPtrTy]] %[[#f2GEP]]
-; CHECK: %[[#f2Load:]] = OpLoad %[[#FnPtrTy]] %[[#f2GEPCast]]
+; CHECK: %[[#f2Load:]] = OpLoad %[[#IntelFnPtrTy]] %[[#f2GEPCast]]
 ; CHECK: %{{.*}} = OpFunctionPointerCallINTEL %[[#t_halfTy]] %[[#f0Load]]
 ; CHECK: %{{.*}} = OpFunctionPointerCallINTEL %[[#t_halfTy]] %[[#f1Load]]
 ; CHECK: %{{.*}} = OpFunctionPointerCallINTEL %[[#t_halfTy]] %[[#f2Load]]


### PR DESCRIPTION
e78503c4f017 made G_GLOBAL_VALUE give a function the CodeSectionINTEL storage class, but spv_assign_ptr_type kept mapping a deduced function pointer to the default address space, so a value derived from a function pointer got the Function storage class instead. A select between two function pointers then hit mismatched operand and result types and asserted in selectSelect. The spv_ptrcast path already applies this rule, so mirror it in spv_assign_ptr_type and keep an explicit address space such as generic untouched.

Loads of a function pointer now yield a CodeSectionINTEL pointer, which is the type OpConstantFunctionPointerINTEL produces and OpFunctionPointerCallINTEL consumes.