### PR TITLE
[analyzer] Remove getRegionName from LifetimeModeling and its dependent checkers

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/DanglingPtrDeref.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/DanglingPtrDeref.cpp
@@ -71,7 +71,8 @@ void DanglingPtrDeref::reportUseAfterScope(const MemRegion *Region,
                                            CheckerContext &C) const {
   auto BR = std::make_unique<PathSensitiveBugReport>(
       BugMsg,
-      (llvm::Twine("Use of ") + lifetime_modeling::getRegionName(Region) +
+      (llvm::Twine("Use of ") +
+       Region->getDescriptiveName(/*UseQuotes=*/true, /*AllowFallback=*/true) +
        " after its lifetime ended."),
       N);
   BR->addVisitor<DanglingPtrDerefBRVisitor>(Region);
@@ -103,7 +104,8 @@ DanglingPtrDerefBRVisitor::VisitNode(const ExplodedNode *N,
       S, BRC.getSourceManager(), N->getStackFrame());
   return std::make_shared<PathDiagnosticEventPiece>(
       Pos,
-      (lifetime_modeling::getRegionName(SourceRegion) +
+      (SourceRegion->getDescriptiveName(/*UseQuotes=*/true,
+                                        /*AllowFallback=*/true) +
        llvm::Twine(" is destroyed here"))
           .str(),
       true);

--- a/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
@@ -92,14 +92,6 @@ static ProgramStateRef bindSource(ProgramStateRef State, SVal RetVal,
   return State;
 }
 
-std::string lifetime_modeling::getRegionName(const MemRegion *Reg) {
-  // FIXME: Once the checker supports heap allocation, more region kinds
-  // should be handled to produce the correct descriptive name.
-  if (const std::string RegName = Reg->getDescriptiveName(); !RegName.empty())
-    return RegName;
-  return "the region";
-}
-
 void LifetimeModeling::checkPostCall(const CallEvent &Call,
                                      CheckerContext &C) const {
   ProgramStateRef State = C.getState();

--- a/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.h
+++ b/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.h
@@ -18,10 +18,6 @@ bool isDeallocated(ProgramStateRef State, const MemRegion *Region);
 
 /// Returns true if \p Val is a key in the LifetimeBoundMap.
 bool isBoundToLifetimeSource(ProgramStateRef State, SVal Val);
-
-/// Returns the descriptive name of the memory region or a placeholder if a
-/// descriptive name cannot be constructed for it.
-std::string getRegionName(const MemRegion *Reg);
 } // namespace clang::ento::lifetime_modeling
 
 #endif // LLVM_CLANG_LIB_STATICANALYZER_CHECKERS_LIFETIMEMODELING_H

--- a/clang/lib/StaticAnalyzer/Checkers/UseAfterLifetimeEnd.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/UseAfterLifetimeEnd.cpp
@@ -99,7 +99,8 @@ void UseAfterLifetimeEnd::reportDanglingSource(const MemRegion *Source,
   auto BR = std::make_unique<PathSensitiveBugReport>(
       BugMsg,
       (llvm::Twine("Returning value bound to ") +
-       lifetime_modeling::getRegionName(Source) + " that will go out of scope"),
+       Source->getDescriptiveName(/*UseQuotes=*/true, /*AllowFallback=*/true) +
+       " that will go out of scope"),
       N);
 
   if (SourceRange Range = getRegionDeclRange(Source); Range.isValid())
@@ -146,7 +147,9 @@ UseAfterLifetimeEndBRVisitor::VisitNode(const ExplodedNode *N,
   auto Piece = createSourcePiece(
       N, BRC,
       (llvm::Twine("Value's lifetime bound to the lifetime of ") +
-       lifetime_modeling::getRegionName(SourceRegion) + " here")
+       SourceRegion->getDescriptiveName(/*UseQuotes=*/true,
+                                        /*AllowFallback=*/true) +
+       " here")
           .str());
   return Piece;
 }
@@ -155,11 +158,13 @@ PathDiagnosticPieceRef
 UseAfterLifetimeEndBRVisitor::getEndPath(const ExplodedNode *N,
                                          BugReporterContext &BRC,
                                          PathSensitiveBugReport &BR) {
-  auto Piece = createSourcePiece(
-      N, BRC,
-      (llvm::Twine("Lifetime of ") +
-       lifetime_modeling::getRegionName(SourceRegion) + " ended here")
-          .str());
+  auto Piece =
+      createSourcePiece(N, BRC,
+                        (llvm::Twine("Lifetime of ") +
+                         SourceRegion->getDescriptiveName(
+                             /*UseQuotes=*/true, /*AllowFallback=*/true) +
+                         " ended here")
+                            .str());
   return Piece;
 }
 


### PR DESCRIPTION
In #211552 `MemRegion::getDescriptiveName` got generalized and now has an `AllowFallback` functionality which makes it possible to remove `getRegionName()` from the modeling checker and from both of the dependent checkers (`UseAfterLifetimeEnd` and `DanglingPtrDeref`).