### PR TITLE
[OpenACC/OpenMP/Parser] Teach ParseCXXInlineMethods about pragmas

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -367,6 +367,7 @@ features cannot lower the translation-unit ABI level;
   non-type template parameter. (#GH212351)
 - Fixed an assertion crash when instantiating a nested requirement with an invalid constraint. (#GH213575)
 - Clang now defines the GCC-compatible predefined macro `__SIG_ATOMIC_TYPE__`. (#GH213895)
+- Fixed a bug where a stray closing curley brace in an OpenMP/OpenACC pragma could cause pragma parsing issues when inside of a member function. (#GH214195)
 
 #### Bug Fixes to Compiler Builtins
 

--- a/clang/lib/Parse/ParseCXXInlineMethods.cpp
+++ b/clang/lib/Parse/ParseCXXInlineMethods.cpp
@@ -870,6 +870,27 @@ bool Parser::ConsumeAndStoreUntil(tok::TokenKind T1, tok::TokenKind T2,
       // Ran out of tokens.
       return false;
 
+    case tok::annot_pragma_openacc:
+    case tok::annot_pragma_openmp:
+    case tok::annot_attr_openmp: {
+      // Ignore any tokens inside of a OMP/OpenACC pragma, as these should just
+      // be taken as 1.
+      tok::TokenKind EndKind = Tok.is(tok::annot_pragma_openacc)
+                                   ? tok::annot_pragma_openacc_end
+                                   : tok::annot_pragma_openmp_end;
+      Toks.push_back(Tok);
+      ConsumeAnnotationToken();
+      while (Tok.isNot(EndKind) && Tok.isNot(tok::eof)) {
+        Toks.push_back(Tok);
+        ConsumeAnyToken();
+      }
+      if (Tok.is(EndKind)) {
+        Toks.push_back(Tok);
+        ConsumeAnnotationToken();
+      }
+      break;
+    }
+
     case tok::l_paren:
       // Recursively consume properly-nested parens.
       Toks.push_back(Tok);

--- a/clang/test/OpenMP/gh214195.cpp
+++ b/clang/test/OpenMP/gh214195.cpp
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 %s -verify -fopenmp
+
+struct Type {
+  void foo() {
+#pragma omp parallel private(bar })
+    // expected-error@-1{{use of undeclared identifier 'bar'}}
+    // expected-error@+1{{expected statement}}
+  }
+};

--- a/clang/test/ParserOpenACC/parse-constructs.cpp
+++ b/clang/test/ParserOpenACC/parse-constructs.cpp
@@ -58,3 +58,10 @@ void foo() {
   auto y = [](){};
 #pragma acc routine (x) seq
 }
+
+struct GH214195 {
+  void foo() {
+#pragma acc cache(bar })
+    // expected-error@-1{{use of undeclared identifier 'bar'}}
+  }
+};


### PR DESCRIPTION
Both OMP and OpenACC count on being able to reach their end-annotation token in order to properly recover from errors/leave the parser in good shape.  This works well for 'free' functions.

However, when we do a pre-parse so we can delay-evaluate member functions, a stray end-brace can end up matching the end of the function.  As a result, the examples in the test would have that brace ending with an EOF, which confused both of the pragma languages.

This patch teaches the ParseCXXInlineMethods functionality to ignore any braces/etc inside of a OpenACC/OpenMP pragma for the purposes of matching, since these shouldn't count towards that scoping anyway.

Fixes: #214195