### PR TITLE
[clang][Sema] Check exported default constructors in nested classes

### DIFF
--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -6387,8 +6387,22 @@ static void checkForMultipleExportedDefaultConstructors(Sema &S,
   if (!S.Context.getTargetInfo().getCXXABI().isMicrosoft())
     return;
 
+  if (Class->isInvalidDecl())
+    return;
+
   CXXConstructorDecl *LastExportedDefaultCtor = nullptr;
   for (Decl *Member : Class->decls()) {
+    // Nested classes finish delayed default argument parsing with the outermost
+    // class, so check each nested definition and class template pattern here.
+    CXXRecordDecl *NestedClass = dyn_cast<CXXRecordDecl>(Member);
+    if (auto *NestedTemplate = dyn_cast<ClassTemplateDecl>(Member))
+      NestedClass = NestedTemplate->getTemplatedDecl();
+    if (NestedClass) {
+      if (NestedClass->isThisDeclarationADefinition())
+        checkForMultipleExportedDefaultConstructors(S, NestedClass);
+      continue;
+    }
+
     // Look for exported default constructors.
     auto *CD = dyn_cast<CXXConstructorDecl>(Member);
     if (!CD || !CD->isDefaultConstructor())

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -6393,11 +6393,8 @@ static void checkForMultipleExportedDefaultConstructors(Sema &S,
   CXXConstructorDecl *LastExportedDefaultCtor = nullptr;
   for (Decl *Member : Class->decls()) {
     // Nested classes finish delayed default argument parsing with the outermost
-    // class, so check each nested definition and class template pattern here.
-    CXXRecordDecl *NestedClass = dyn_cast<CXXRecordDecl>(Member);
-    if (auto *NestedTemplate = dyn_cast<ClassTemplateDecl>(Member))
-      NestedClass = NestedTemplate->getTemplatedDecl();
-    if (NestedClass) {
+    // class, so check each nested definition here.
+    if (auto *NestedClass = dyn_cast<CXXRecordDecl>(Member)) {
       if (NestedClass->isThisDeclarationADefinition())
         checkForMultipleExportedDefaultConstructors(S, NestedClass);
       continue;

--- a/clang/test/CodeGenCXX/dllexport-ctor-closure-nested.cpp
+++ b/clang/test/CodeGenCXX/dllexport-ctor-closure-nested.cpp
@@ -18,3 +18,14 @@ struct __declspec(dllexport) CtorClosureOuter {
 
 // CHECK-LABEL: $"??1HasImplicitDtor1@@QAE@XZ" = comdat any
 // CHECK-LABEL: define weak_odr dso_local dllexport x86_thiscallcc void @"??_FCtorClosureInner@CtorClosureOuter@@QAEXXZ"({{.*}}) {{#[0-9]+}} comdat
+
+// Member-level dllexport on a nested default constructor needs constructor
+// closure default arguments before the enclosing class is emitted.
+struct MemberExportedCtorClosureOuter {
+  struct MemberExportedCtorClosureInner {
+    __declspec(dllexport) MemberExportedCtorClosureInner(
+        const HasImplicitDtor1 &v = {}) {}
+  };
+};
+
+// CHECK-LABEL: define weak_odr dso_local dllexport x86_thiscallcc void @"??_FMemberExportedCtorClosureInner@MemberExportedCtorClosureOuter@@QAEXXZ"({{.*}}) {{#[0-9]+}} comdat

--- a/clang/test/PCH/dllexport-default-arg-closure.cpp
+++ b/clang/test/PCH/dllexport-default-arg-closure.cpp
@@ -20,6 +20,15 @@ struct __declspec(dllexport) Foo {
 // CHECK: define weak_odr dso_local dllexport void @"??_FFoo@@QEAAXXZ"(ptr{{.*}})
 // CHECK:   call noundef ptr @"??0Foo@@QEAA@W4E@0@@Z"(ptr {{.*}}, i32 noundef 0)
 
+struct PCHMemberExportOuter {
+  struct Inner {
+    enum E { E0 } e;
+    __declspec(dllexport) Inner(E e = E0) : e(e) {}
+  };
+};
+
+// CHECK: define weak_odr dso_local dllexport void @"??_FInner@PCHMemberExportOuter@@QEAAXXZ"(ptr{{.*}})
+
 #else
 
 

--- a/clang/test/SemaCXX/default-arg-closures.cpp
+++ b/clang/test/SemaCXX/default-arg-closures.cpp
@@ -25,6 +25,15 @@ struct DependentDefaultCopyArg {
 struct HasMember {
   enum { member = 0 };
 };
+
+template <typename T>
+struct NestedDependentDefaultCtorArg {
+  struct Inner {
+    __declspec(dllexport) Inner(int n = T::member) {}
+  };
+};
+NestedDependentDefaultCtorArg<HasMember>::Inner ValidNestedDependentArg;
+
 void UseDependentArg() { throw DependentDefaultCopyArg<HasMember>(); }
 
 void ErrorInDependentArg() {

--- a/clang/test/SemaCXX/dllexport.cpp
+++ b/clang/test/SemaCXX/dllexport.cpp
@@ -746,6 +746,20 @@ struct ClassTemplateWithMultipleDefaultCtors {
   __declspec(dllexport) ClassTemplateWithMultipleDefaultCtors(int = 30, ...) {} // ms-note{{declared here}}
 };
 
+struct ClassWithNestedMultipleDefaultCtors {
+  struct Nested {
+    __declspec(dllexport) Nested(int = 40) {}      // ms-error{{'__declspec(dllexport)' cannot be applied to more than one default constructor}}
+    __declspec(dllexport) Nested(int = 30, ...) {} // ms-note{{declared here}}
+  };
+};
+
+struct ClassWithNestedClassTemplateMultipleDefaultCtors {
+  template <typename T> struct Nested {
+    __declspec(dllexport) Nested(int = 40) {}      // ms-error{{'__declspec(dllexport)' cannot be applied to more than one default constructor}}
+    __declspec(dllexport) Nested(int = 30, ...) {} // ms-note{{declared here}}
+  };
+};
+
 template <typename T> struct HasDefaults {
   HasDefaults(int x = sizeof(T)) {} // ms-error {{invalid application of 'sizeof'}}
 };

--- a/clang/test/SemaCXX/dllexport.cpp
+++ b/clang/test/SemaCXX/dllexport.cpp
@@ -753,6 +753,13 @@ struct ClassWithNestedMultipleDefaultCtors {
   };
 };
 
+struct ClassWithNestedObviousMultipleDefaultCtors {
+  struct Nested {
+    __declspec(dllexport) Nested() {}    // ms-error{{'__declspec(dllexport)' cannot be applied to more than one default constructor}}
+    __declspec(dllexport) Nested(...) {} // ms-note{{declared here}}
+  };
+};
+
 template <typename T> struct HasDefaults {
   HasDefaults(int x = sizeof(T)) {} // ms-error {{invalid application of 'sizeof'}}
 };

--- a/clang/test/SemaCXX/dllexport.cpp
+++ b/clang/test/SemaCXX/dllexport.cpp
@@ -759,6 +759,19 @@ struct ClassWithNestedClassTemplateMultipleDefaultCtors {
     __declspec(dllexport) Nested(int = 30, ...) {} // ms-note{{declared here}}
   };
 };
+template struct ClassWithNestedClassTemplateMultipleDefaultCtors::Nested<int>;
+template struct ClassWithNestedClassTemplateMultipleDefaultCtors::Nested<double>;
+
+template <typename T>
+struct ClassTemplateWithNestedClassTemplateMultipleDefaultCtors {
+  __declspec(dllexport)
+  ClassTemplateWithNestedClassTemplateMultipleDefaultCtors(int = 40) {}
+  template <typename R> struct Nested {
+    __declspec(dllexport) Nested(int = 30) {}      // ms-error{{'__declspec(dllexport)' cannot be applied to more than one default constructor}}
+    __declspec(dllexport) Nested(int = 20, ...) {} // ms-note{{declared here}}
+  };
+};
+template struct ClassTemplateWithNestedClassTemplateMultipleDefaultCtors<int>;
 
 template <typename T> struct HasDefaults {
   HasDefaults(int x = sizeof(T)) {} // ms-error {{invalid application of 'sizeof'}}

--- a/clang/test/SemaCXX/dllexport.cpp
+++ b/clang/test/SemaCXX/dllexport.cpp
@@ -753,26 +753,6 @@ struct ClassWithNestedMultipleDefaultCtors {
   };
 };
 
-struct ClassWithNestedClassTemplateMultipleDefaultCtors {
-  template <typename T> struct Nested {
-    __declspec(dllexport) Nested(int = 40) {}      // ms-error{{'__declspec(dllexport)' cannot be applied to more than one default constructor}}
-    __declspec(dllexport) Nested(int = 30, ...) {} // ms-note{{declared here}}
-  };
-};
-template struct ClassWithNestedClassTemplateMultipleDefaultCtors::Nested<int>;
-template struct ClassWithNestedClassTemplateMultipleDefaultCtors::Nested<double>;
-
-template <typename T>
-struct ClassTemplateWithNestedClassTemplateMultipleDefaultCtors {
-  __declspec(dllexport)
-  ClassTemplateWithNestedClassTemplateMultipleDefaultCtors(int = 40) {}
-  template <typename R> struct Nested {
-    __declspec(dllexport) Nested(int = 30) {}      // ms-error{{'__declspec(dllexport)' cannot be applied to more than one default constructor}}
-    __declspec(dllexport) Nested(int = 20, ...) {} // ms-note{{declared here}}
-  };
-};
-template struct ClassTemplateWithNestedClassTemplateMultipleDefaultCtors<int>;
-
 template <typename T> struct HasDefaults {
   HasDefaults(int x = sizeof(T)) {} // ms-error {{invalid application of 'sizeof'}}
 };


### PR DESCRIPTION
Teach Clang to check exported default constructors declared in nested classes. This prepares Microsoft ABI constructor closures for non-dependent nested classes before CodeGen.

This fixes a failure seen when compiling PyTorch on Windows. An exported nested
class with defaults for every constructor parameter caused Clang to emit its
constructor closure without cached default arguments and assert in
MicrosoftCXXABI.cpp.

Assisted by: GPT-5.6 Sol