### PR TITLE
[mlir][tosa] Add option to validate function signature during validation

### DIFF
--- a/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.td
@@ -91,7 +91,7 @@ def TosaValidation : Pass<"tosa-validate", "mlir::ModuleOp"> {
              "operand/result datatypes not aligning with the 'Supported Data Types' "
              "sections of the specifciation">,
       Option<"validateFunctionSignature", "validate-function-signature", "bool",
-             /*default=*/"false",
+             /*default=*/"true",
              "Verify if the function signature is valid for TOSA dialect, i.e. all "
              "function arguments and return types are tosa-conformant tensor types">,
    ];

--- a/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.td
@@ -89,7 +89,11 @@ def TosaValidation : Pass<"tosa-validate", "mlir::ModuleOp"> {
              /*default=*/"false",
              "Disable checks for operations that are determined to be invalid due to their "
              "operand/result datatypes not aligning with the 'Supported Data Types' "
-             "sections of the specifciation">
+             "sections of the specifciation">,
+      Option<"validateFunctionSignature", "validate-function-signature", "bool",
+             /*default=*/"false",
+             "Verify if the function signature is valid for TOSA dialect, i.e. all "
+             "function arguments and return types are tosa-conformant tensor types">,
    ];
 }
 

--- a/mlir/lib/Conversion/TosaToLinalg/TosaToLinalgPass.cpp
+++ b/mlir/lib/Conversion/TosaToLinalg/TosaToLinalgPass.cpp
@@ -146,7 +146,8 @@ void mlir::tosa::registerTosaToLinalgPipelines() {
         if (pipelineOpts.validation) {
           validationOptions = TosaValidationOptions{
               /*strictOpSpecAlignment=*/false,
-              /*allowInvalidOpDatatypeCombinations=*/false};
+              /*allowInvalidOpDatatypeCombinations=*/false,
+              /*validateFunctionSignature=*/false};
         }
         tosa::addTosaToLinalgPasses(pm, tosaToLinalgOptions,
                                     tosaToLinalgNamedOptions,

--- a/mlir/lib/Dialect/Tosa/Transforms/TosaValidation.cpp
+++ b/mlir/lib/Dialect/Tosa/Transforms/TosaValidation.cpp
@@ -186,6 +186,7 @@ public:
     this->strictOpSpecAlignment = options.strictOpSpecAlignment;
     this->allowInvalidOpDatatypeCombinations =
         options.allowInvalidOpDatatypeCombinations;
+    this->validateFunctionSignature = options.validateFunctionSignature;
   }
   void runOnOperation() final;
 
@@ -671,7 +672,9 @@ private:
   LogicalResult CheckVariableReadOrWrite(Operation *op);
   LogicalResult validateValidElementType(Operation *op, Type type,
                                          bool allowUnsigned = false);
-  LogicalResult validateOperationElementTypes(Operation *op,
+  LogicalResult validateOperationElementTypes(TosaOp op,
+                                              bool allowUnsigned = false);
+  LogicalResult validateOperationElementTypes(func::FuncOp op,
                                               bool allowUnsigned = false);
 
   SmallVector<
@@ -912,18 +915,18 @@ LogicalResult TosaValidation::levelCheckSize(Operation *op,
                                  << " or below";
     }
 
-    int64_t element_bits = tosa::getBitWidth(getElementTypeOrSelf(type));
-    int64_t element_bytes = std::max(INT64_C(1), element_bits / 8);
-    int64_t size = element_bytes * type.getNumElements();
+    int64_t elementBits = tosa::getBitWidth(getElementTypeOrSelf(type));
+    int64_t elementBytes = std::max(INT64_C(1), elementBits / 8);
+    int64_t size = elementBytes * type.getNumElements();
 
     // According to 1.11. Tensor Definitions of Tosa spec, the value of
     // tensor_size_t is 1 << MAX_LOG2_SIZE) - 1 where MAX_LOG2_SIZE is
     // defined in 1.7. Levels.
     // For each tensor, the number of tensor elements multiplied by the
     // element size in bytes must be representable as a tensor_size_t.
-    const int64_t max_size =
+    const int64_t maxSize =
         (INT64_C(1) << targetEnv.getLevel().MAX_LOG2_SIZE) - 1;
-    if (size > max_size)
+    if (size > maxSize)
       return op->emitOpError()
              << "failed level check: " << operandOrResult
              << " tensor size (in bytes) <= (1 << MAX_LOG2_SIZE - 1)";
@@ -1459,15 +1462,51 @@ LogicalResult TosaValidation::applyErrorIfCheck(Operation *op) {
 }
 
 LogicalResult TosaValidation::applyFunctionSignatureCheck(func::FuncOp op) {
-  const auto isShapeType = [](Type type) { return isa<tosa::shapeType>(type); };
-  if (llvm::any_of(op.getArgumentTypes(), isShapeType))
+  // Require tensor type parameters and results
+  const auto isTensorType = [](Type type) { return isa<TensorType>(type); };
+  if (!llvm::all_of(op.getArgumentTypes(), isTensorType))
     return op.emitOpError()
            << "Function argument types must be a tensor type to be TOSA "
               "compliant, got !tosa.shape type";
-  if (llvm::any_of(op.getResultTypes(), isShapeType))
+  if (!llvm::all_of(op.getResultTypes(), isTensorType))
     return op.emitOpError()
            << "Function return types must be a tensor type to be TOSA "
               "compliant, got !tosa.shape type";
+
+  // Validate element types
+  if (failed(validateOperationElementTypes(op, !strictOpSpecAlignment)))
+    return failure();
+
+  // Level check
+  const TosaLevel tosaLevel = targetEnv.getLevel();
+  for (const auto &[idx, argType] : llvm::enumerate(op.getArgumentTypes())) {
+    const std::string inputDesc = llvm::formatv("input argument {0}", idx);
+    if (failed(levelCheckRank(op, argType, inputDesc, tosaLevel.MAX_RANK)))
+      return failure();
+    if (failed(levelCheckSize(op, argType, inputDesc)))
+      return failure();
+  }
+  for (const auto &[idx, resultType] : llvm::enumerate(op.getResultTypes())) {
+    const std::string resultDesc = llvm::formatv("return value {0}", idx);
+    if (failed(levelCheckRank(op, resultType, resultDesc, tosaLevel.MAX_RANK)))
+      return failure();
+    if (failed(levelCheckSize(op, resultType, resultDesc)))
+      return failure();
+  }
+
+  // Explicitly check for no zero dimensions
+  // Note: This check is not required for TOSA operations since it is mandated
+  // on construction
+  for (const Type &argType :
+       llvm::concat<const Type>(op.getArgumentTypes(), op.getResultTypes())) {
+    if (auto shapedType = dyn_cast<ShapedType>(argType)) {
+      if (llvm::any_of(shapedType.getShape(),
+                       [](int64_t dim) { return dim == 0; }))
+        return op.emitOpError() << "Function argument or return types must not "
+                                   "have zero dimensions";
+    }
+  }
+
   return success();
 }
 
@@ -1508,8 +1547,7 @@ LogicalResult TosaValidation::validateValidElementType(Operation *op, Type type,
 }
 
 LogicalResult
-TosaValidation::validateOperationElementTypes(Operation *op,
-                                              bool allowUnsigned) {
+TosaValidation::validateOperationElementTypes(TosaOp op, bool allowUnsigned) {
   for (Value operand : op->getOperands()) {
     Type elementTy = getElementTypeOrSelf(operand);
     if (failed(validateValidElementType(op, elementTy, allowUnsigned)))
@@ -1522,9 +1560,21 @@ TosaValidation::validateOperationElementTypes(Operation *op,
       return failure();
   }
 
-  if (auto variableOp = dyn_cast<tosa::VariableOp>(op)) {
+  if (auto variableOp = dyn_cast<tosa::VariableOp>(*op)) {
     if (failed(
             validateValidElementType(op, variableOp.getType(), allowUnsigned)))
+      return failure();
+  }
+  return success();
+}
+
+LogicalResult
+TosaValidation::validateOperationElementTypes(func::FuncOp op,
+                                              bool allowUnsigned) {
+  for (const Type &argType :
+       llvm::concat<const Type>(op.getArgumentTypes(), op.getResultTypes())) {
+    const Type elementTy = getElementTypeOrSelf(argType);
+    if (failed(validateValidElementType(op, elementTy, allowUnsigned)))
       return failure();
   }
 
@@ -1545,15 +1595,13 @@ void TosaValidation::runOnOperation() {
   targetEnv = *maybeTargetEnv;
 
   const auto functions = modOp.getOps<func::FuncOp>();
-  if (llvm::any_of(functions, [&](func::FuncOp func) {
+  if (validateFunctionSignature &&
+      llvm::any_of(functions, [&](func::FuncOp func) {
         return failed(applyFunctionSignatureCheck(func));
       }))
     return signalPassFailure();
 
-  modOp.walk([&](Operation *op) {
-    if (op->getDialect() != tosaDialect)
-      return;
-
+  modOp.walk([&](TosaOp op) {
     // validate operator element types:
     // - rescale operator is allowed to have ui8/ui16/ui32
     //   operands/results when strictOpSpecAlignment is false

--- a/mlir/test/Dialect/Tosa/error_if_check.mlir
+++ b/mlir/test/Dialect/Tosa/error_if_check.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s -split-input-file -verify-diagnostics -tosa-attach-target="level=none profiles=pro_int,pro_fp extensions=int16,int4,bf16,fp8e4m3,fp8e5m2,fft,variable,controlflow,dynamic" -tosa-validate="strict-op-spec-alignment"
+// RUN: mlir-opt %s -split-input-file -verify-diagnostics -tosa-attach-target="level=none profiles=pro_int,pro_fp extensions=int16,int4,bf16,fp8e4m3,fp8e5m2,fft,variable,controlflow,dynamic" -tosa-validate="strict-op-spec-alignment validate-function-signature=false"
 
 // -----
 

--- a/mlir/test/Dialect/Tosa/invalid.mlir
+++ b/mlir/test/Dialect/Tosa/invalid.mlir
@@ -2168,21 +2168,6 @@ func.func @test_conv2d_block_scaled(%arg0: tensor<*xf4E2M1FN>, %arg1: tensor<*xf
 
 // -----
 
-// expected-error@+1 {{func.func' op Function argument types must be a tensor type to be TOSA compliant, got !tosa.shape type}}
-func.func @test_shape_func_input(%arg0: !tosa.shape<1>) {
-  return
-}
-
-// -----
-
-// expected-error@+1 {{'func.func' op Function return types must be a tensor type to be TOSA compliant, got !tosa.shape type}}
-func.func @test_shape_func_output() -> !tosa.shape<4> {
-  %cst = tosa.const_shape {values = dense<[1, 2, 3, 4]> : tensor<4xindex>} : () -> !tosa.shape<4>
-  return %cst : !tosa.shape<4>
-}
-
-// -----
-
 func.func @test_cast_f32_plain_fp4(%arg0: tensor<4x32xf32>) -> tensor<4x32xf4E2M1FN> {
   // expected-error@+1 {{'tosa.cast' op illegal: operation operand/result data types did not align with any profile or extension, got (f32,fp4e2m1)}}
   %0 = tosa.cast %arg0 : (tensor<4x32xf32>) -> tensor<4x32xf4E2M1FN>

--- a/mlir/test/Dialect/Tosa/invalid.mlir
+++ b/mlir/test/Dialect/Tosa/invalid.mlir
@@ -4,7 +4,7 @@
 // validation flow.
 //--------------------------------------------------------------------------------------------------
 
-// RUN: mlir-opt %s -split-input-file -verify-diagnostics -tosa-attach-target="specification_version=1.1.draft profiles=pro_int,pro_fp extensions=int16,int4,int64,bf16,fp8e4m3,fp8e5m2,fft,variable,controlflow,doubleround,inexactround,mxfp_conv,shape" -tosa-validate="strict-op-spec-alignment"
+// RUN: mlir-opt %s -split-input-file -verify-diagnostics -tosa-attach-target="specification_version=1.1.draft profiles=pro_int,pro_fp extensions=int16,int4,int64,bf16,fp8e4m3,fp8e5m2,fft,variable,controlflow,doubleround,inexactround,mxfp_conv,shape" -tosa-validate="strict-op-spec-alignment validate-function-signature=false"
 
 
 func.func @test_cast(%arg0: tensor<i1>) -> tensor<5xi32> {

--- a/mlir/test/Dialect/Tosa/invalid_extension.mlir
+++ b/mlir/test/Dialect/Tosa/invalid_extension.mlir
@@ -707,13 +707,13 @@ func.func @test_min_shape() {
 
 // -----
 
-func.func @test_conv2d_block_scaled(%arg0: tensor<*xf4E2M1FN>, %arg1: tensor<*xf8E8M0FNU>, %arg2: tensor<*xf4E2M1FN>, %arg3: tensor<*xf8E8M0FNU>, %arg4: tensor<*xf32>) -> tensor<*xf32> {
+func.func @test_conv2d_block_scaled(%arg0: tensor<1x4x4x64xf4E2M1FN>, %arg1: tensor<1x4x4x2xf8E8M0FNU>, %arg2: tensor<8x1x1x64xf4E2M1FN>, %arg3: tensor<8x1x1x2xf8E8M0FNU>, %arg4: tensor<1xf32>) -> tensor<1x4x4x2xf32> {
   %0 = tosa.const_shape {values = dense<[0, 0, 0, 0]> : tensor<4xindex>} : () -> !tosa.shape<4>
   %1 = tosa.const_shape {values = dense<[1, 1]> : tensor<2xindex>} : () -> !tosa.shape<2>
   %2 = tosa.const_shape {values = dense<[1, 1]> : tensor<2xindex>} : () -> !tosa.shape<2>
   // expected-error@+1 {{'tosa.conv2d_block_scaled' op illegal: requires any of [mxfp_conv] profiles/extensions to be specified in the target environment}}
-  %3 = tosa.conv2d_block_scaled %arg0, %arg1, %arg2, %arg3, %arg4, %0, %1, %2 {block_size = BLOCK_SIZE_32} : (tensor<*xf4E2M1FN>, tensor<*xf8E8M0FNU>, tensor<*xf4E2M1FN>, tensor<*xf8E8M0FNU>, tensor<*xf32>, !tosa.shape<4>, !tosa.shape<2>, !tosa.shape<2>) -> tensor<*xf32>
-  return %3 : tensor<*xf32>
+  %3 = tosa.conv2d_block_scaled %arg0, %arg1, %arg2, %arg3, %arg4, %0, %1, %2 {block_size = BLOCK_SIZE_32} : (tensor<1x4x4x64xf4E2M1FN>, tensor<1x4x4x2xf8E8M0FNU>, tensor<8x1x1x64xf4E2M1FN>, tensor<8x1x1x2xf8E8M0FNU>, tensor<1xf32>, !tosa.shape<4>, !tosa.shape<2>, !tosa.shape<2>) -> tensor<1x4x4x2xf32>
+  return %3 : tensor<1x4x4x2xf32>
 }
 
 // -----

--- a/mlir/test/Dialect/Tosa/level_check.mlir
+++ b/mlir/test/Dialect/Tosa/level_check.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s -split-input-file -verify-diagnostics -tosa-attach-target="profiles=pro_int,pro_fp extensions=dynamic" -tosa-validate
+// RUN: mlir-opt %s -split-input-file -verify-diagnostics -tosa-attach-target="profiles=pro_int,pro_fp extensions=dynamic" -tosa-validate="validate-function-signature=false"
 
 func.func @test_argmax_rank_invalid(%arg0: tensor<1x1x1x1x29x29x4xf32>) -> tensor<1x1x1x1x29x4xi32> {
   // expected-error@+1 {{'tosa.argmax' op failed level check: operand rank(shape) <= MAX_RANK}}

--- a/mlir/test/Dialect/Tosa/tosa-validation-valid.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-validation-valid.mlir
@@ -33,9 +33,9 @@ func.func @test_rescale_output_unsigned(%arg0: tensor<1x1xi8>) -> (tensor<1x1xui
 // -----
 
 // CHECK-LABEL: test_validate_without_tosa
-func.func @test_validate_without_tosa(%arg0: f32) -> f32 {
-  %0 = math.asin %arg0 : f32
-  return %0 : f32
+func.func @test_validate_without_tosa(%arg0: tensor<f32>) -> tensor<f32> {
+  %0 = math.asin %arg0 : tensor<f32>
+  return %0 : tensor<f32>
 }
 
 // -----

--- a/mlir/test/Dialect/Tosa/tosa-validation-validate-func-signature-invalid.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-validation-validate-func-signature-invalid.mlir
@@ -1,0 +1,58 @@
+// RUN: mlir-opt %s -split-input-file -verify-diagnostics -tosa-attach-target="specification_version=1.1.draft profiles=pro_int,pro_fp extensions=shape level=8k" -tosa-validate="strict-op-spec-alignment validate-function-signature"
+
+// expected-error@+1 {{func.func' op Function argument types must be a tensor type to be TOSA compliant, got !tosa.shape type}}
+func.func @test_shape_func_input(%arg0: !tosa.shape<1>) {
+  return
+}
+
+// -----
+
+// expected-error@+1 {{'func.func' op Function return types must be a tensor type to be TOSA compliant, got !tosa.shape type}}
+func.func @test_shape_func_output() -> !tosa.shape<4> {
+  %cst = tosa.const_shape {values = dense<[1, 2, 3, 4]> : tensor<4xindex>} : () -> !tosa.shape<4>
+  return %cst : !tosa.shape<4>
+}
+
+// -----
+
+// expected-error@+1 {{'func.func' op failed level check: input argument 0 rank(shape) <= MAX_RANK}}
+func.func @test_argument_level_check(%arg0: tensor<1x2x3x4x5x6x7x8x9xi8>) {
+  return
+}
+
+// -----
+
+// expected-error@+1 {{'func.func' op failed level check: return value 0 rank(shape) <= MAX_RANK}}
+func.func @test_result_level_check() -> tensor<1x2x3x4x5x6x7x8xi8> {
+  %0 = arith.constant dense<0> : tensor<1x2x3x4x5x6x7x8xi8>
+  return %0 : tensor<1x2x3x4x5x6x7x8xi8>
+}
+
+// -----
+
+// expected-error@+1 {{'func.func' op Function argument or return types must not have zero dimensions}}
+func.func @test_argument_no_zero_dims(%arg0: tensor<1x0xi8>) {
+  return
+}
+
+// -----
+
+// expected-error@+1 {{'func.func' op Function argument or return types must not have zero dimensions}}
+func.func @test_result_level_check() -> tensor<1x0xi8> {
+  %0 = arith.constant dense<0> : tensor<1x0xi8>
+  return %0 : tensor<1x0xi8>
+}
+
+// -----
+
+// expected-error@+1 {{'func.func' op failed level check: unranked tensor}}
+func.func @test_unranked_identity(%arg0: tensor<*xi8>) -> tensor<*xi8> {
+  return %arg0 : tensor<*xi8>
+}
+
+// -----
+
+// expected-error@+1 {{'func.func' op is not profile-aligned: element type 'f64' is not legal}}
+func.func @test_unsupported_element_type(%arg0: tensor<1x2x1x4x5xf64>) -> tensor<1x2x1x4x5xf64> {
+  return %arg0 : tensor<1x2x1x4x5xf64>
+} 

--- a/mlir/test/Dialect/Tosa/tosa-validation-validate-func-signature-valid.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-validation-validate-func-signature-valid.mlir
@@ -1,0 +1,15 @@
+// RUN: mlir-opt %s -split-input-file -verify-diagnostics -tosa-attach-target="specification_version=1.1.draft profiles=pro_int,pro_fp extensions=shape level=8k" -tosa-validate="strict-op-spec-alignment validate-function-signature" | FileCheck %s
+
+// CHECK-LABEL: test_valid_arguments
+func.func @test_valid_arguments(%arg0: tensor<1x2x3x4xi8>, %arg1: tensor<1x2x3xf32>) {
+  return
+}
+
+// -----
+
+// CHECK-LABEL: test_valid_results
+func.func @test_valid_results() -> (tensor<1x2x3x4xi8>, tensor<1x2x3xf32>) {
+  %0 = arith.constant dense<0> : tensor<1x2x3x4xi8>
+  %1 = arith.constant dense<0.0> : tensor<1x2x3xf32>
+  return %0, %1 : tensor<1x2x3x4xi8>, tensor<1x2x3xf32>
+}

--- a/mlir/test/Dialect/Tosa/tosa-validation-version-1p0-invalid.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-validation-version-1p0-invalid.mlir
@@ -190,10 +190,12 @@ func.func @test_cast_fp32_block_scaled(%arg0: tensor<4x32xf32>) -> tensor<4x32x!
 
 // -----
 
-func.func @test_dyanmic_dims(%arg0: tensor<?x8x16xi8>) -> tensor<?x16xi32> {
+func.func @test_dyanmic_dims(%arg0: tensor<1x8x16xi8>) {
+  // expected-error@+1 {{'tosa.identity' op failed level check: result shape dimension cannot be dynamic when targeting TOSA specification version 1.0 or below}}
+  %0 = tosa.identity %arg0 : (tensor<1x8x16xi8>) -> tensor<?x8x16xi8>
   // expected-error@+1 {{'tosa.argmax' op failed level check: operand shape dimension cannot be dynamic when targeting TOSA specification version 1.0 or below}}
-  %0 = tosa.argmax %arg0 { axis = 1 : i32 } : (tensor<?x8x16xi8>) -> tensor<?x16xi32>
-  return %0 : tensor<?x16xi32>
+  %1 = tosa.argmax %0 { axis = 1 : i32 } : (tensor<?x8x16xi8>) -> tensor<?x16xi32>
+  return
 }
 
 // -----
@@ -213,7 +215,7 @@ func.func @test_argmax_int64(%arg0: tensor<1x13x13x5xf32>) -> tensor<1x13x13xi64
 }
 
 // -----
-func.func @test_const_fp6e3m2(%arg0 : index) -> tensor<4xf6E3M2FN> {
+func.func @test_const_fp6e3m2() -> tensor<4xf6E3M2FN> {
   // expected-error@+1 {{'tosa.const' op illegal: requires specification version compatible with 1.1.draft (got 1.0) and requires any of [mxfp] profiles/extensions to be specified in the target environment}}
     %0 = "tosa.const"() {values = dense<[0.0, 0.0, 0.0, 0.0]> : tensor<4xf6E3M2FN>} : () -> tensor<4xf6E3M2FN>
     return %0 : tensor<4xf6E3M2FN>
@@ -255,13 +257,13 @@ func.func @test_cast_to_block_scaled(%arg0: tensor<4x32xf32>) -> (tensor<4x32xf6
 
 // -----
 
-func.func @test_conv2d_block_scaled(%arg0: tensor<*xf4E2M1FN>, %arg1: tensor<*xf8E8M0FNU>, %arg2: tensor<*xf4E2M1FN>, %arg3: tensor<*xf8E8M0FNU>, %arg4: tensor<*xf32>) -> tensor<*xf32> {
+func.func @test_conv2d_block_scaled(%arg0: tensor<1x4x4x64xf4E2M1FN>, %arg1: tensor<1x4x4x2xf8E8M0FNU>, %arg2: tensor<8x1x1x64xf4E2M1FN>, %arg3: tensor<8x1x1x2xf8E8M0FNU>, %arg4: tensor<1xf32>) -> tensor<1x4x4x2xf32> {
   %0 = tosa.const_shape {values = dense<[0, 0, 0, 0]> : tensor<4xindex>} : () -> !tosa.shape<4>
   %1 = tosa.const_shape {values = dense<[1, 1]> : tensor<2xindex>} : () -> !tosa.shape<2>
   %2 = tosa.const_shape {values = dense<[1, 1]> : tensor<2xindex>} : () -> !tosa.shape<2>
   // expected-error@+1 {{'tosa.conv2d_block_scaled' op illegal: requires specification version compatible with 1.1.draft (got 1.0) and requires any of [mxfp_conv] profiles/extensions to be specified in the target environment}}
-  %3 = tosa.conv2d_block_scaled %arg0, %arg1, %arg2, %arg3, %arg4, %0, %1, %2 {block_size = BLOCK_SIZE_32} : (tensor<*xf4E2M1FN>, tensor<*xf8E8M0FNU>, tensor<*xf4E2M1FN>, tensor<*xf8E8M0FNU>, tensor<*xf32>, !tosa.shape<4>, !tosa.shape<2>, !tosa.shape<2>) -> tensor<*xf32>
-  return %3 : tensor<*xf32>
+  %3 = tosa.conv2d_block_scaled %arg0, %arg1, %arg2, %arg3, %arg4, %0, %1, %2 {block_size = BLOCK_SIZE_32} : (tensor<1x4x4x64xf4E2M1FN>, tensor<1x4x4x2xf8E8M0FNU>, tensor<8x1x1x64xf4E2M1FN>, tensor<8x1x1x2xf8E8M0FNU>, tensor<1xf32>, !tosa.shape<4>, !tosa.shape<2>, !tosa.shape<2>) -> tensor<1x4x4x2xf32>
+  return %3 : tensor<1x4x4x2xf32>
 }
 
 // -----


### PR DESCRIPTION
This commit adds a new option to the TOSA validation pass, "validate-function-signature", which allows users to specify whether the function signature should be checked with respect to: use of tensor types (tosa.shape types are not supported at function boundaries), supported data types (currently there is no consideration for the loaded profiles/extensions) and the shape of tensor arguments/return types.