### PR TITLE
[HIP] Add libhipcxx to the default header search path

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -485,6 +485,12 @@ features cannot lower the translation-unit ABI level;
 
 #### CUDA/HIP Language Changes
 
+- HIP compilations now add the `include/libhipcxx` directory from the selected
+  ROCm installation to the header search path when it exists. This allows
+  libhipcxx headers to be included with paths such as `<cuda/std/atomic>`.
+  The `-nogpuinc` option disables this path together with the other HIP include
+  paths.
+
 #### CUDA Support
 
 #### AIX Support

--- a/clang/lib/Driver/ToolChains/AMDGPU.cpp
+++ b/clang/lib/Driver/ToolChains/AMDGPU.cpp
@@ -593,6 +593,12 @@ void RocmInstallationDetector::AddHIPIncludeArgs(const ArgList &DriverArgs,
 
   CC1Args.push_back("-idirafter");
   CC1Args.push_back(DriverArgs.MakeArgString(getIncludePath()));
+  SmallString<128> LibHipCxxPath(getIncludePath());
+  llvm::sys::path::append(LibHipCxxPath, "libhipcxx");
+  if (D.getVFS().exists(LibHipCxxPath)) {
+    CC1Args.push_back("-idirafter");
+    CC1Args.push_back(DriverArgs.MakeArgString(LibHipCxxPath));
+  }
   if (UsesRuntimeWrapper)
     CC1Args.append({"-include", "__clang_hip_runtime_wrapper.h"});
   if (HasHipStdPar)

--- a/clang/test/Driver/Inputs/rocm/include/libhipcxx/cuda/std/atomic
+++ b/clang/test/Driver/Inputs/rocm/include/libhipcxx/cuda/std/atomic
@@ -1,0 +1,1 @@
+// This file makes the mock libhipcxx include directory discoverable.

--- a/clang/test/Driver/hip-include-path.hip
+++ b/clang/test/Driver/hip-include-path.hip
@@ -16,10 +16,26 @@
 // RUN:   -std=c++11 --rocm-path=%S/Inputs/rocm --no-offload-inc -nogpulib --offload-inc %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=COMMON,CLANG,HIP -DRESOURCE_DIR=%clang-resource-dir %s
 
+// RUN: %clang -c -### --target=x86_64-unknown-linux-gnu --cuda-gpu-arch=gfx900 \
+// RUN:   -std=c++11 --rocm-path=%S/Inputs/rocm -nogpulib -nostdinc++ %s 2>&1 \
+// RUN:   | FileCheck -check-prefixes=COMMON,CLANG,HIP -DRESOURCE_DIR=%clang-resource-dir %s
+
+// RUN: %clang -fsyntax-only --target=x86_64-unknown-linux-gnu \
+// RUN:   --cuda-gpu-arch=gfx900 -std=c++11 --rocm-path=%S/Inputs/rocm \
+// RUN:   -nogpulib -nohipwrapperinc %s
+
+// RUN: %clang -c -### --target=x86_64-unknown-linux-gnu --cuda-gpu-arch=gfx900 \
+// RUN:   -std=c++11 --rocm-path=%S/Inputs/rocm-invalid -nogpulib %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=NOLIBHIPCXX %s
+
+// NOLIBHIPCXX: "-idirafter" "{{[^"]*}}Inputs/rocm-invalid/include"
+// NOLIBHIPCXX-NOT: "{{.*}}Inputs/rocm-invalid/include/libhipcxx"
+
 // COMMON-LABEL: "{{[^"]*}}clang{{[^"]*}}" "-cc1"
 // CLANG-SAME: "-internal-isystem" "[[RESOURCE_DIR]]/include/cuda_wrappers"
 // NOCLANG-NOT: "[[RESOURCE_DIR]]/include/cuda_wrappers"
 // HIP-SAME: "-idirafter" "{{[^"]*}}Inputs/rocm/include"
+// HIP-SAME: "-idirafter" "{{[^"]*}}Inputs/rocm/include/libhipcxx"
 // HIP-SAME: "-include" "__clang_hip_runtime_wrapper.h"
 // NOHIP-NOT: "-include" "__clang_hip_runtime_wrapper.h"
 // skip check of standard C++ include path
@@ -31,6 +47,7 @@
 // CLANG-SAME: "-internal-isystem" "[[RESOURCE_DIR]]/include/cuda_wrappers"
 // NOCLANG-NOT: "[[RESOURCE_DIR]]/include/cuda_wrappers"
 // HIP-SAME: "-idirafter" "{{[^"]*}}Inputs/rocm/include"
+// HIP-SAME: "-idirafter" "{{[^"]*}}Inputs/rocm/include/libhipcxx"
 // HIP-SAME: "-include" "__clang_hip_runtime_wrapper.h"
 // NOHIP-NOT: "-include" "__clang_hip_runtime_wrapper.h"
 // skip check of standard C++ include path
@@ -46,6 +63,7 @@
 // ROCM35-NOT: "[[RESOURCE_DIR]]/include/cuda_wrappers"
 // ROCM35-SAME: "-internal-isystem" "[[RESOURCE_DIR]]"
 // ROCM35-SAME: "-idirafter" "{{[^"]*}}Inputs/rocm/include"
+// ROCM35-SAME: "-idirafter" "{{[^"]*}}Inputs/rocm/include/libhipcxx"
 // ROCM35-NOT: "-include" "__clang_hip_runtime_wrapper.h"
 // skip check of standard C++ include path
 // ROCM35-SAME: "-internal-isystem" "[[RESOURCE_DIR]]/include"
@@ -59,3 +77,5 @@
 
 // HOSTINC-LABEL: "{{[^"]*}}clang{{[^"]*}}" "-cc1" "-triple" "amdgcn-amd-amdhsa"
 // HOSTINC: "-internal-externc-isystem" "{{[^"]*}}Inputs/basic_linux_tree/usr/include"
+
+#include <cuda/std/atomic>


### PR DESCRIPTION
libhipcxx provides C++ library support for HIP device code, similar to
libcudacxx for CUDA. CUDA toolchains make libcudacxx available through the
toolkit include path by default. HIP users should likewise be able to
include libhipcxx headers without an installation-specific include option.

Add include/libhipcxx from the selected ROCm installation when the
directory exists. It follows the same search order and controls as the
other HIP include paths.