### PR TITLE
[BOLT] Support runtime libraries built as thin archives

### DIFF
--- a/bolt/lib/RuntimeLibs/RuntimeLibrary.cpp
+++ b/bolt/lib/RuntimeLibs/RuntimeLibrary.cpp
@@ -95,9 +95,10 @@ void RuntimeLibrary::loadLibrary(StringRef LibPath, BOLTLinker &Linker,
   file_magic Magic = identify_magic(B->getBuffer());
 
   if (Magic == file_magic::archive) {
-    Error Err = Error::success();
-    object::Archive Archive(B->getMemBufferRef(), Err);
-    for (const object::Archive::Child &C : Archive.children(Err)) {
+    std::unique_ptr<object::Archive> Archive;
+    Error Err = object::Archive::create(B->getMemBufferRef()).moveInto(Archive);
+    check_error(std::move(Err), B->getBufferIdentifier());
+    for (const object::Archive::Child &C : Archive->children(Err)) {
       std::unique_ptr<object::Binary> Bin = cantFail(C.getAsBinary());
       if (object::ObjectFile *Obj = dyn_cast<object::ObjectFile>(&*Bin))
         Linker.loadObject(Obj->getMemoryBufferRef(), MapSections);

--- a/bolt/test/CMakeLists.txt
+++ b/bolt/test/CMakeLists.txt
@@ -35,6 +35,7 @@ list(APPEND BOLT_TEST_DEPS
   FileCheck
   llc
   lld
+  llvm-ar
   llvm-config
   llvm-bolt
   llvm-bolt-binary-analysis

--- a/bolt/test/lit.cfg.py
+++ b/bolt/test/lit.cfg.py
@@ -96,9 +96,11 @@ llvm_bolt_args = []
 
 if config.libbolt_rt_instr:
     llvm_bolt_args.append(f"--runtime-instrumentation-lib={config.libbolt_rt_instr}")
+    config.substitutions.append(("%libbolt_rt_instr", config.libbolt_rt_instr))
 
 if config.libbolt_rt_hugify:
     llvm_bolt_args.append(f"--runtime-hugify-lib={config.libbolt_rt_hugify}")
+    config.substitutions.append(("%libbolt_rt_hugify", config.libbolt_rt_hugify))
 
 tools = [
     ToolSubst("llc", unresolved="fatal"),
@@ -114,6 +116,7 @@ tools = [
     ToolSubst("llvm-bat-dump", unresolved="fatal"),
     ToolSubst("perf2bolt", unresolved="fatal"),
     ToolSubst("yaml2obj", unresolved="fatal"),
+    ToolSubst("llvm-ar", unresolved="fatal"),
     ToolSubst("llvm-mc", unresolved="fatal"),
     ToolSubst("llvm-nm", unresolved="fatal"),
     ToolSubst("llvm-objdump", unresolved="fatal"),

--- a/bolt/test/runtime/thin-archive.c
+++ b/bolt/test/runtime/thin-archive.c
@@ -1,0 +1,22 @@
+// Test that BOLT can consume thin archives for runtime libraries.
+
+// REQUIRES: system-linux,bolt-runtime
+
+// RUN: rm -rf %t && mkdir -p %t/objects
+
+// RUN: cd %t/objects && llvm-ar x %libbolt_rt_instr
+// RUN: cd %t && llvm-ar rcT libbolt_rt_instr.a objects/*
+// RUN: file %t/libbolt_rt_instr.a | FileCheck %s --check-prefix=CHECK-THIN
+// CHECK-THIN: thin archive
+
+// RUN: %clang %cflags -no-pie -Wl,-q -o %t/exe %s
+// RUN: llvm-bolt -o %t/exe.bolt %t/exe \
+// RUN:     --instrument --instrumentation-file=%t/exe.fdata \
+// RUN:     --runtime-instrumentation-lib=%t/libbolt_rt_instr.a
+// RUN: %t/exe.bolt
+// RUN: cat %t/exe.fdata | FileCheck %s
+// CHECK: main 0 0 1
+
+#include <stdio.h>
+
+int main(int argc, char *argv[]) { puts("thin archive test"); }


### PR DESCRIPTION
In some configurations, BOLT runtime libraries may be built as thin archive. Use the more generic `Archive::create` to handle these.