### PR TITLE
[lldb] Raise error if in-place operators can't modify lldb.value

### DIFF
--- a/lldb/bindings/python/python-extensions.swig
+++ b/lldb/bindings/python/python-extensions.swig
@@ -454,74 +454,81 @@ class value(object):
     def __truediv__(self, other):
         return int(self) / int(other)
 
+    def _set_value(self, val):
+        if not isinstance(val, str):
+            val = str(val)
+        err = SBError()
+        if not self.sbvalue.SetValueFromCString(val, err):
+            raise ValueError(f"Failed to set value: {err.GetCString()}")
+
     def __iadd__(self, other):
         result = self.__add__(other)
-        self.sbvalue.SetValueFromCString (str(result))
+        self._set_value(result)
         return result
 
     def __isub__(self, other):
         result = self.__sub__(other)
-        self.sbvalue.SetValueFromCString (str(result))
+        self._set_value(result)
         return result
 
     def __imul__(self, other):
         result = self.__mul__(other)
-        self.sbvalue.SetValueFromCString (str(result))
+        self._set_value(result)
         return result
 
     def __idiv__(self, other):
         result = self.__div__(other)
-        self.sbvalue.SetValueFromCString (str(result))
+        self._set_value(result)
         return result
 
     def __itruediv__(self, other):
         result = self.__truediv__(other)
-        self.sbvalue.SetValueFromCString (str(result))
+        self._set_value(result)
         return result
 
     def __ifloordiv__(self, other):
         result =  self.__floordiv__(other)
-        self.sbvalue.SetValueFromCString (str(result))
+        self._set_value(result)
         return result
 
     def __imod__(self, other):
         result =  self.__mod__(other)
-        self.sbvalue.SetValueFromCString (str(result))
+        self._set_value(result)
         return result
 
     def __ipow__(self, other):
         result = self.__pow__(other)
-        self.sbvalue.SetValueFromCString (str(result))
+        self._set_value(result)
         return result
 
     def __ipow__(self, other, modulo=None):
         result = self.__pow__(other, modulo)
-        self.sbvalue.SetValueFromCString (str(result))
+        self._set_value(result)
         return result
 
     def __ilshift__(self, other):
         result = self.__lshift__(other)
-        self.sbvalue.SetValueFromCString (str(result))
+        self._set_value(result)
         return result
 
     def __irshift__(self, other):
         result =  self.__rshift__(other)
-        self.sbvalue.SetValueFromCString (str(result))
+        self._set_value(result)
         return result
 
     def __iand__(self, other):
         result =  self.__and__(other)
-        self.sbvalue.SetValueFromCString (str(result))
+        self._set_value(result)
         return result
 
     def __ixor__(self, other):
         result =  self.__xor__(other)
-        self.sbvalue.SetValueFromCString (str(result))
+        self._set_value(result)
         return result
 
     def __ior__(self, other):
         result =  self.__or__(other)
-        self.sbvalue.SetValueFromCString (str(result))
+        self._set_value(result)
         return result
 
     def __neg__(self):

--- a/lldb/test/API/python_api/value/value_wrap/TestValueAPIWrapper.py
+++ b/lldb/test/API/python_api/value/value_wrap/TestValueAPIWrapper.py
@@ -226,13 +226,13 @@ class ValueAPIWrapper(TestBase):
         self.assertEqual(kind, 6)
 
         # Test __itruediv__(other).
-        kind /= 2
-        self.assertEqual(kind, 3)
-        self.assertIsInstance(kind, float)
-        kind = engine.kind
-        # Keeps its value, because we try to set "3.0".
-        # FIXME: Raise error here.
+        with self.assertRaisesRegex(
+            ValueError,
+            r"^Failed to set value: '3\.0' is not a valid integer string value$",
+        ):
+            kind /= 2
         self.assertEqual(kind, 6)
+        self.assertIsInstance(kind, lldb.value)
 
         # Test __ifloordiv__(other).
         kind //= 5


### PR DESCRIPTION
If the underlying value of an `lldb.value` was modified, but `SetValueFromCString` failed, the user wouldn't notice. With this PR, the in-place operators now raise a `ValueError` if we can't set the value.