### PR TITLE
[clang][Lex] Fix ambiguous reference to Token error

### DIFF
--- a/clang/lib/Lex/Lexer.cpp
+++ b/clang/lib/Lex/Lexer.cpp
@@ -4699,8 +4699,8 @@ bool Lexer::LexDependencyDirectiveToken(Token &Result) {
   const char *DDTokPtr = BufferStart + DDTok.Offset;
   if (ParsingFilename && *DDTokPtr == '<') {
     Result.startToken();
-    Result.setFlag((Token::TokenFlags)DDTok.Flags);
-    Result.clearFlag(Token::NeedsCleaning);
+    Result.setFlag((clang::Token::TokenFlags)DDTok.Flags);
+    Result.clearFlag(clang::Token::NeedsCleaning);
     BufferPtr = DDTokPtr;
     if (!LexAngledStringLiteral(Result, BufferPtr + 1)) {
       convertDependencyDirectiveToken(DDTok, Result);


### PR DESCRIPTION
At least with GCC 11.4.0 this is deemed an error.

Fixes: 56dc58dc2550 ("[Clang][Preprocessor] Unify header-name lookahead for import and include (#191004)")