### PR TITLE
[lldb] Validate scripted breakpoint construction

### DIFF
--- a/lldb/include/lldb/Breakpoint/BreakpointResolverScripted.h
+++ b/lldb/include/lldb/Breakpoint/BreakpointResolverScripted.h
@@ -43,6 +43,8 @@ public:
 
   lldb::SearchDepth GetDepth() override;
 
+  const Status &GetError() const { return m_error; }
+
   void GetDescription(Stream *s) override;
 
   lldb::BreakpointLocationSP WasHit(lldb::StackFrameSP frame_sp,

--- a/lldb/include/lldb/Breakpoint/BreakpointResolverScripted.h
+++ b/lldb/include/lldb/Breakpoint/BreakpointResolverScripted.h
@@ -75,8 +75,12 @@ public:
 protected:
   void NotifyBreakpointSet() override;
 private:
-  void CreateImplementationIfNeeded(lldb::BreakpointSP bkpt);
-  void CreateImplementationIfNeeded(Target &target, lldb::BreakpointSP bkpt);
+  /// \param report_errors Broadcast construction failures as debugger
+  /// diagnostics. Callers that propagate \c m_error themselves pass false.
+  void CreateImplementationIfNeeded(lldb::BreakpointSP bkpt,
+                                    bool report_errors = true);
+  void CreateImplementationIfNeeded(Target &target, lldb::BreakpointSP bkpt,
+                                    bool report_errors = true);
   ScriptInterpreter *GetScriptInterpreter();
 
   std::string m_class_name;

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -942,11 +942,11 @@ public:
                    bool request_hardware);
 
   // Use this to create a general breakpoint:
-  lldb::BreakpointSP CreateBreakpoint(lldb::SearchFilterSP &filter_sp,
-                                      lldb::BreakpointResolverSP &resolver_sp,
-                                      bool internal, bool request_hardware,
-                                      bool resolve_indirect_symbols,
-                                      Status *creation_error = nullptr);
+  /// A null breakpoint with no error means the filter or resolver was null.
+  llvm::Expected<lldb::BreakpointSP>
+  CreateBreakpoint(lldb::SearchFilterSP &filter_sp,
+                   lldb::BreakpointResolverSP &resolver_sp, bool internal,
+                   bool request_hardware, bool resolve_indirect_symbols);
 
   // Use this to create a watchpoint:
   lldb::WatchpointSP CreateWatchpoint(lldb::addr_t addr, size_t size,

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -945,7 +945,8 @@ public:
   lldb::BreakpointSP CreateBreakpoint(lldb::SearchFilterSP &filter_sp,
                                       lldb::BreakpointResolverSP &resolver_sp,
                                       bool internal, bool request_hardware,
-                                      bool resolve_indirect_symbols);
+                                      bool resolve_indirect_symbols,
+                                      Status *creation_error = nullptr);
 
   // Use this to create a watchpoint:
   lldb::WatchpointSP CreateWatchpoint(lldb::addr_t addr, size_t size,

--- a/lldb/source/API/SBTarget.cpp
+++ b/lldb/source/API/SBTarget.cpp
@@ -1118,6 +1118,10 @@ lldb::SBBreakpoint SBTarget::BreakpointCreateFromScript(
                                             request_hardware,
                                             obj_sp,
                                             &error);
+    // This entry point has no error out-parameter.
+    if (error.Fail())
+      Debugger::ReportError(error.AsCString(),
+                            target_sp->GetDebugger().GetID());
   }
 
   return sb_bp;

--- a/lldb/source/Breakpoint/Breakpoint.cpp
+++ b/lldb/source/Breakpoint/Breakpoint.cpp
@@ -202,7 +202,7 @@ lldb::BreakpointSP Breakpoint::CreateFromStructuredData(
       target.CreateBreakpoint(filter_sp, resolver_sp, false, hardware, true);
   if (!bp_or_err) {
     error = Status::FromErrorStringWithFormatv(
-        "Error creating breakpoint from data: {0}.",
+        "error creating breakpoint from data: {0}.",
         llvm::toString(bp_or_err.takeError()));
     return {};
   }

--- a/lldb/source/Breakpoint/Breakpoint.cpp
+++ b/lldb/source/Breakpoint/Breakpoint.cpp
@@ -198,13 +198,15 @@ lldb::BreakpointSP Breakpoint::CreateFromStructuredData(
   success = breakpoint_dict->GetValueForKeyAsBoolean(
       Breakpoint::GetKey(OptionNames::Hardware), hardware);
 
-  result_sp = target.CreateBreakpoint(filter_sp, resolver_sp, false, hardware,
-                                      true, &create_error);
-  if (create_error.Fail()) {
+  llvm::Expected<BreakpointSP> bp_or_err =
+      target.CreateBreakpoint(filter_sp, resolver_sp, false, hardware, true);
+  if (!bp_or_err) {
     error = Status::FromErrorStringWithFormatv(
-        "Error creating breakpoint from data: {0}.", create_error);
+        "Error creating breakpoint from data: {0}.",
+        llvm::toString(bp_or_err.takeError()));
     return {};
   }
+  result_sp = *bp_or_err;
 
   if (result_sp && options_up) {
     result_sp->m_options = *options_up;

--- a/lldb/source/Breakpoint/Breakpoint.cpp
+++ b/lldb/source/Breakpoint/Breakpoint.cpp
@@ -198,8 +198,13 @@ lldb::BreakpointSP Breakpoint::CreateFromStructuredData(
   success = breakpoint_dict->GetValueForKeyAsBoolean(
       Breakpoint::GetKey(OptionNames::Hardware), hardware);
 
-  result_sp =
-      target.CreateBreakpoint(filter_sp, resolver_sp, false, hardware, true);
+  result_sp = target.CreateBreakpoint(filter_sp, resolver_sp, false, hardware,
+                                      true, &create_error);
+  if (create_error.Fail()) {
+    error = Status::FromErrorStringWithFormatv(
+        "Error creating breakpoint from data: {0}.", create_error);
+    return {};
+  }
 
   if (result_sp && options_up) {
     result_sp->m_options = *options_up;

--- a/lldb/source/Breakpoint/BreakpointResolverScripted.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverScripted.cpp
@@ -49,9 +49,6 @@ void BreakpointResolverScripted::CreateImplementationIfNeeded(
     return;
   }
 
-  if (m_class_name.empty())
-    return;
-
   if (!breakpoint_sp)
     return;
 
@@ -62,6 +59,11 @@ void BreakpointResolverScripted::CreateImplementationIfNeeded(
 
 void BreakpointResolverScripted::CreateImplementationIfNeeded(
     Target &target, BreakpointSP breakpoint_sp) {
+  if (m_class_name.empty()) {
+    m_error = Status::FromErrorString("scripted breakpoint class is empty");
+    return;
+  }
+
   if (m_interface_sp) {
     if (!m_breakpoint_sent && breakpoint_sp) {
       m_interface_sp->SetBreakpoint(breakpoint_sp);
@@ -72,8 +74,11 @@ void BreakpointResolverScripted::CreateImplementationIfNeeded(
 
   ScriptInterpreter *script_interp =
       target.GetDebugger().GetScriptInterpreter();
-  if (!script_interp)
+  if (!script_interp) {
+    m_error = Status::FromErrorString(
+        "scripted breakpoint requires a script interpreter");
     return;
+  }
 
   if (!m_interface_sp)
     m_interface_sp = script_interp->CreateScriptedBreakpointInterface();

--- a/lldb/source/Breakpoint/BreakpointResolverScripted.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverScripted.cpp
@@ -36,7 +36,7 @@ BreakpointResolverScripted::BreakpointResolverScripted(
 }
 
 void BreakpointResolverScripted::CreateImplementationIfNeeded(
-    BreakpointSP breakpoint_sp) {
+    BreakpointSP breakpoint_sp, bool report_errors) {
   // This version has to be called with a valid breakpoint_sp
   // But the interface might have been made before we sent the breakpoint to
   // the interface.  If so, do that here:
@@ -54,11 +54,15 @@ void BreakpointResolverScripted::CreateImplementationIfNeeded(
 
   TargetSP target_sp = breakpoint_sp->GetTargetSP();
   if (target_sp)
-    CreateImplementationIfNeeded(*target_sp.get(), breakpoint_sp);
+    CreateImplementationIfNeeded(*target_sp.get(), breakpoint_sp,
+                                 report_errors);
 }
 
 void BreakpointResolverScripted::CreateImplementationIfNeeded(
-    Target &target, BreakpointSP breakpoint_sp) {
+    Target &target, BreakpointSP breakpoint_sp, bool report_errors) {
+  // Don't let a stale failure reject a later success.
+  m_error.Clear();
+
   if (m_class_name.empty()) {
     m_error = Status::FromErrorString("scripted breakpoint class is empty");
     return;
@@ -101,10 +105,11 @@ void BreakpointResolverScripted::CreateImplementationIfNeeded(
   if (!obj_or_err) {
     m_interface_sp.reset();
     std::string msg = llvm::toString(obj_or_err.takeError());
-    Debugger::ReportError(
-        llvm::formatv("failed to create BreakpointResolverScripted: {0}", msg)
-            .str(),
-        target.GetDebugger().GetID());
+    if (report_errors)
+      Debugger::ReportError(
+          llvm::formatv("failed to create BreakpointResolverScripted: {0}", msg)
+              .str(),
+          target.GetDebugger().GetID());
     m_error = Status(msg);
     return;
   }
@@ -133,7 +138,7 @@ bool BreakpointResolverScripted::OverridesResolver(
 }
 
 void BreakpointResolverScripted::NotifyBreakpointSet() {
-  CreateImplementationIfNeeded(GetBreakpoint());
+  CreateImplementationIfNeeded(GetBreakpoint(), /*report_errors=*/false);
 }
 
 BreakpointResolverSP BreakpointResolverScripted::CreateFromStructuredData(

--- a/lldb/source/Commands/CommandObjectBreakpoint.cpp
+++ b/lldb/source/Commands/CommandObjectBreakpoint.cpp
@@ -1425,7 +1425,7 @@ protected:
         &(m_options.m_files), false, m_options.m_hardware,
         m_python_class_options.GetStructuredData(), &error);
     if (error.Fail()) {
-      result.AppendErrorWithFormat("error creating scripted breakpoint: %s",
+      result.AppendErrorWithFormat("cannot create scripted breakpoint: %s",
                                    error.AsCString());
       return;
     }
@@ -1973,7 +1973,7 @@ protected:
           &(m_options.m_filenames), false, m_options.m_hardware,
           m_python_class_options.GetStructuredData(), &error);
       if (error.Fail()) {
-        result.AppendErrorWithFormat("Error creating scripted breakpoint: %s",
+        result.AppendErrorWithFormat("cannot create scripted breakpoint: %s",
                                      error.AsCString());
         return;
       }

--- a/lldb/source/Commands/CommandObjectBreakpoint.cpp
+++ b/lldb/source/Commands/CommandObjectBreakpoint.cpp
@@ -1425,9 +1425,8 @@ protected:
         &(m_options.m_files), false, m_options.m_hardware,
         m_python_class_options.GetStructuredData(), &error);
     if (error.Fail()) {
-      result.AppendErrorWithFormat(
-          "error setting extra exception arguments: %s", error.AsCString());
-      target->RemoveBreakpointByID(bp_sp->GetID());
+      result.AppendErrorWithFormat("error creating scripted breakpoint: %s",
+                                   error.AsCString());
       return;
     }
 
@@ -1974,9 +1973,8 @@ protected:
           &(m_options.m_filenames), false, m_options.m_hardware,
           m_python_class_options.GetStructuredData(), &error);
       if (error.Fail()) {
-        result.AppendErrorWithFormat(
-            "Error setting extra exception arguments: %s", error.AsCString());
-        target->RemoveBreakpointByID(bp_sp->GetID());
+        result.AppendErrorWithFormat("Error creating scripted breakpoint: %s",
+                                     error.AsCString());
         return;
       }
     } break;

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.cpp
@@ -32,6 +32,8 @@
 #include "lldb/Target/StackFrameRecognizer.h"
 #include "lldb/Target/ThreadPlanRunToAddress.h"
 #include "lldb/Target/ThreadPlanStepInRange.h"
+#include "lldb/Utility/LLDBLog.h"
+#include "lldb/Utility/Log.h"
 #include "lldb/Utility/Timer.h"
 
 using namespace lldb;
@@ -659,8 +661,15 @@ lldb::BreakpointSP CPPLanguageRuntime::CreateExceptionBreakpoint(
   SearchFilterSP filter_sp(CreateExceptionSearchFilter());
   const bool hardware = false;
   const bool resolve_indirect_functions = false;
-  return target.CreateBreakpoint(filter_sp, exception_resolver_sp, is_internal,
-                                 hardware, resolve_indirect_functions);
+  llvm::Expected<BreakpointSP> bp_or_err =
+      target.CreateBreakpoint(filter_sp, exception_resolver_sp, is_internal,
+                              hardware, resolve_indirect_functions);
+  if (!bp_or_err) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Breakpoints), bp_or_err.takeError(),
+                   "Failed to create exception breakpoint: {0}");
+    return {};
+  }
+  return *bp_or_err;
 }
 
 void CPPLanguageRuntime::SetExceptionBreakpoints() {

--- a/lldb/source/Target/LanguageRuntime.cpp
+++ b/lldb/source/Target/LanguageRuntime.cpp
@@ -12,6 +12,8 @@
 #include "lldb/Interpreter/CommandInterpreter.h"
 #include "lldb/Target/Language.h"
 #include "lldb/Target/Target.h"
+#include "lldb/Utility/LLDBLog.h"
+#include "lldb/Utility/Log.h"
 
 using namespace lldb;
 using namespace lldb_private;
@@ -231,9 +233,15 @@ BreakpointSP LanguageRuntime::CreateExceptionBreakpoint(
       new ExceptionSearchFilter(target.shared_from_this(), language));
   bool hardware = false;
   bool resolve_indirect_functions = false;
-  BreakpointSP exc_breakpt_sp(
+  llvm::Expected<BreakpointSP> bp_or_err =
       target.CreateBreakpoint(filter_sp, resolver_sp, is_internal, hardware,
-                              resolve_indirect_functions));
+                              resolve_indirect_functions);
+  if (!bp_or_err) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Breakpoints), bp_or_err.takeError(),
+                   "Failed to create exception breakpoint: {0}");
+    return {};
+  }
+  BreakpointSP exc_breakpt_sp = *bp_or_err;
   if (exc_breakpt_sp) {
     if (auto precond = GetExceptionPrecondition(language, throw_bp))
       exc_breakpt_sp->SetPrecondition(precond);

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -485,6 +485,17 @@ lldb_private::Target::CreateBreakpointAtUserEntry(Status &error) {
   return bp_sp;
 }
 
+/// Unwrap a breakpoint creation result for callers that have no error channel
+/// of their own.
+static BreakpointSP
+TakeBreakpointOrLog(llvm::Expected<BreakpointSP> bp_or_err) {
+  if (bp_or_err)
+    return *bp_or_err;
+  LLDB_LOG_ERROR(GetLog(LLDBLog::Breakpoints), bp_or_err.takeError(),
+                 "Failed to create breakpoint: {0}");
+  return {};
+}
+
 BreakpointSP Target::CreateSourceRegexBreakpoint(
     const FileSpecList *containingModules,
     const FileSpecList *source_file_spec_list,
@@ -499,7 +510,8 @@ BreakpointSP Target::CreateSourceRegexBreakpoint(
       nullptr, std::move(source_regex), function_names,
       !static_cast<bool>(move_to_nearest_code)));
 
-  return CreateBreakpoint(filter_sp, resolver_sp, internal, hardware, true);
+  return TakeBreakpointOrLog(
+      CreateBreakpoint(filter_sp, resolver_sp, internal, hardware, true));
 }
 
 BreakpointSP Target::CreateBreakpoint(const FileSpecList *containingModules,
@@ -557,7 +569,8 @@ BreakpointSP Target::CreateBreakpoint(const FileSpecList *containingModules,
 
   BreakpointResolverSP resolver_sp(new BreakpointResolverFileLine(
       nullptr, offset, skip_prologue, location_spec, removed_prefix_opt));
-  return CreateBreakpoint(filter_sp, resolver_sp, internal, hardware, true);
+  return TakeBreakpointOrLog(
+      CreateBreakpoint(filter_sp, resolver_sp, internal, hardware, true));
 }
 
 BreakpointSP Target::CreateBreakpoint(lldb::addr_t addr, bool internal,
@@ -587,7 +600,8 @@ BreakpointSP Target::CreateBreakpoint(const Address &addr, bool internal,
           shared_from_this());
   BreakpointResolverSP resolver_sp =
       std::make_shared<BreakpointResolverAddress>(nullptr, addr);
-  return CreateBreakpoint(filter_sp, resolver_sp, internal, hardware, false);
+  return TakeBreakpointOrLog(
+      CreateBreakpoint(filter_sp, resolver_sp, internal, hardware, false));
 }
 
 lldb::BreakpointSP
@@ -600,8 +614,8 @@ Target::CreateAddressInModuleBreakpoint(lldb::addr_t file_addr, bool internal,
   BreakpointResolverSP resolver_sp =
       std::make_shared<BreakpointResolverAddress>(nullptr, Address(file_addr),
                                                   file_spec);
-  return CreateBreakpoint(filter_sp, resolver_sp, internal, request_hardware,
-                          false);
+  return TakeBreakpointOrLog(CreateBreakpoint(filter_sp, resolver_sp, internal,
+                                              request_hardware, false));
 }
 
 BreakpointSP Target::CreateBreakpoint(
@@ -623,7 +637,8 @@ BreakpointSP Target::CreateBreakpoint(
     BreakpointResolverSP resolver_sp(new BreakpointResolverName(
         nullptr, func_name, func_name_type_mask, language, Breakpoint::Exact,
         offset, offset_is_insn_count, skip_prologue));
-    bp_sp = CreateBreakpoint(filter_sp, resolver_sp, internal, hardware, true);
+    bp_sp = TakeBreakpointOrLog(
+        CreateBreakpoint(filter_sp, resolver_sp, internal, hardware, true));
   }
   return bp_sp;
 }
@@ -649,7 +664,8 @@ Target::CreateBreakpoint(const FileSpecList *containingModules,
     BreakpointResolverSP resolver_sp(
         new BreakpointResolverName(nullptr, func_names, func_name_type_mask,
                                    language, offset, skip_prologue));
-    bp_sp = CreateBreakpoint(filter_sp, resolver_sp, internal, hardware, true);
+    bp_sp = TakeBreakpointOrLog(
+        CreateBreakpoint(filter_sp, resolver_sp, internal, hardware, true));
   }
   return bp_sp;
 }
@@ -679,7 +695,8 @@ Target::CreateBreakpoint(const FileSpecList *containingModules,
         nullptr, func_names, num_names, func_name_type_mask, language, offset,
         skip_prologue));
     resolver_sp->SetOffset(offset);
-    bp_sp = CreateBreakpoint(filter_sp, resolver_sp, internal, hardware, true);
+    bp_sp = TakeBreakpointOrLog(
+        CreateBreakpoint(filter_sp, resolver_sp, internal, hardware, true));
   }
   return bp_sp;
 }
@@ -753,7 +770,8 @@ BreakpointSP Target::CreateFuncRegexBreakpoint(
   BreakpointResolverSP resolver_sp(new BreakpointResolverName(
       nullptr, std::move(func_regex), requested_language, 0, skip));
 
-  return CreateBreakpoint(filter_sp, resolver_sp, internal, hardware, true);
+  return TakeBreakpointOrLog(
+      CreateBreakpoint(filter_sp, resolver_sp, internal, hardware, true));
 }
 
 lldb::BreakpointSP
@@ -779,6 +797,9 @@ lldb::BreakpointSP Target::CreateScriptedBreakpoint(
     const FileSpecList *containingSourceFiles, bool internal,
     bool request_hardware, StructuredData::ObjectSP extra_args_sp,
     Status *creation_error) {
+  if (creation_error)
+    creation_error->Clear();
+
   SearchFilterSP filter_sp;
 
   lldb::SearchDepth depth = lldb::eSearchDepthTarget;
@@ -802,17 +823,23 @@ lldb::BreakpointSP Target::CreateScriptedBreakpoint(
   BreakpointResolverSP resolver_sp =
       std::make_shared<BreakpointResolverScripted>(
           nullptr, class_name, depth, StructuredDataImpl(extra_args_sp));
-  return CreateBreakpoint(filter_sp, resolver_sp, internal, request_hardware,
-                          true, creation_error);
+  llvm::Expected<BreakpointSP> bp_or_err = CreateBreakpoint(
+      filter_sp, resolver_sp, internal, request_hardware, true);
+  if (bp_or_err)
+    return *bp_or_err;
+
+  Status error = Status::FromError(bp_or_err.takeError());
+  if (creation_error)
+    *creation_error = std::move(error);
+  else
+    Debugger::ReportError(error.AsCString(), GetDebugger().GetID());
+  return {};
 }
 
-BreakpointSP Target::CreateBreakpoint(SearchFilterSP &filter_sp,
-                                      BreakpointResolverSP &resolver_sp,
-                                      bool internal, bool request_hardware,
-                                      bool resolve_indirect_symbols,
-                                      Status *creation_error) {
-  if (creation_error)
-    creation_error->Clear();
+llvm::Expected<BreakpointSP>
+Target::CreateBreakpoint(SearchFilterSP &filter_sp,
+                         BreakpointResolverSP &resolver_sp, bool internal,
+                         bool request_hardware, bool resolve_indirect_symbols) {
   BreakpointSP bp_sp;
   if (filter_sp && resolver_sp) {
     // Now check whether there are any "Breakpoint Overrides" registered, and
@@ -830,11 +857,8 @@ BreakpointSP Target::CreateBreakpoint(SearchFilterSP &filter_sp,
     resolver_sp->SetBreakpoint(bp_sp);
     if (auto *scripted_resolver =
             llvm::dyn_cast<BreakpointResolverScripted>(resolver_sp.get());
-        scripted_resolver && scripted_resolver->GetError().Fail()) {
-      if (creation_error)
-        *creation_error = scripted_resolver->GetError().Clone();
-      return {};
-    }
+        scripted_resolver && scripted_resolver->GetError().Fail())
+      return scripted_resolver->GetError().ToError();
     AddBreakpoint(bp_sp, internal);
   }
   return bp_sp;
@@ -1422,7 +1446,7 @@ Status Target::CreateBreakpointsFromFile(const FileSpec &file,
         shared_from_this(), bkpt_data_sp, error);
     if (!error.Success()) {
       error = Status::FromErrorStringWithFormat(
-          "Error restoring breakpoint %zu from %s: %s.", i,
+          "Error restoring breakpoint %zu from %s: %s", i,
           file.GetPath().c_str(), error.AsCString());
       return error;
     }

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -75,6 +75,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/SetVector.h"
+#include "llvm/Support/Casting.h"
 #include "llvm/Support/ErrorExtras.h"
 #include "llvm/Support/ThreadPool.h"
 
@@ -798,15 +799,20 @@ lldb::BreakpointSP Target::CreateScriptedBreakpoint(
         shared_from_this());
   }
 
-  BreakpointResolverSP resolver_sp(new BreakpointResolverScripted(
-      nullptr, class_name, depth, StructuredDataImpl(extra_args_sp)));
-  return CreateBreakpoint(filter_sp, resolver_sp, internal, false, true);
+  BreakpointResolverSP resolver_sp =
+      std::make_shared<BreakpointResolverScripted>(
+          nullptr, class_name, depth, StructuredDataImpl(extra_args_sp));
+  return CreateBreakpoint(filter_sp, resolver_sp, internal, request_hardware,
+                          true, creation_error);
 }
 
 BreakpointSP Target::CreateBreakpoint(SearchFilterSP &filter_sp,
                                       BreakpointResolverSP &resolver_sp,
                                       bool internal, bool request_hardware,
-                                      bool resolve_indirect_symbols) {
+                                      bool resolve_indirect_symbols,
+                                      Status *creation_error) {
+  if (creation_error)
+    creation_error->Clear();
   BreakpointSP bp_sp;
   if (filter_sp && resolver_sp) {
     // Now check whether there are any "Breakpoint Overrides" registered, and
@@ -822,6 +828,13 @@ BreakpointSP Target::CreateBreakpoint(SearchFilterSP &filter_sp,
     bp_sp.reset(new Breakpoint(*this, filter_sp, resolver_sp, hardware,
                                resolve_indirect_symbols));
     resolver_sp->SetBreakpoint(bp_sp);
+    if (auto *scripted_resolver =
+            llvm::dyn_cast<BreakpointResolverScripted>(resolver_sp.get());
+        scripted_resolver && scripted_resolver->GetError().Fail()) {
+      if (creation_error)
+        *creation_error = scripted_resolver->GetError().Clone();
+      return {};
+    }
     AddBreakpoint(bp_sp, internal);
   }
   return bp_sp;

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -1446,7 +1446,7 @@ Status Target::CreateBreakpointsFromFile(const FileSpec &file,
         shared_from_this(), bkpt_data_sp, error);
     if (!error.Success()) {
       error = Status::FromErrorStringWithFormat(
-          "Error restoring breakpoint %zu from %s: %s", i,
+          "error restoring breakpoint %zu from %s: %s", i,
           file.GetPath().c_str(), error.AsCString());
       return error;
     }

--- a/lldb/test/API/functionalities/breakpoint/scripted_bkpt/TestScriptedResolver.py
+++ b/lldb/test/API/functionalities/breakpoint/scripted_bkpt/TestScriptedResolver.py
@@ -83,6 +83,44 @@ class TestScriptedResolver(TestBase):
         self.assertTrue(overridden.IsHardware())
         self.assertEqual(initial_count + 1, target.GetNumBreakpoints())
 
+    def test_scripted_resolver_error_reported_once(self):
+        """Each entry point reports a construction failure through exactly one
+        channel: the command prints it, the SB API broadcasts it."""
+        self.build()
+        target = self.make_target_and_import()
+        extra_args = self.make_extra_args()
+        broadcaster = self.dbg.GetBroadcaster()
+        listener = lldbutil.start_listening_from(
+            broadcaster, lldb.SBDebugger.eBroadcastBitError
+        )
+
+        self.expect(
+            "breakpoint set -P resolver.DoesNotExist",
+            error=True,
+            substrs=["Could not find script class: resolver.DoesNotExist"],
+        )
+        self.assertFalse(
+            listener.GetNextEvent(lldb.SBEvent()),
+            "the command reports the error, so nothing should be broadcast",
+        )
+
+        target.BreakpointCreateFromScript(
+            "resolver.DoesNotExist",
+            extra_args,
+            lldb.SBFileSpecList(),
+            lldb.SBFileSpecList(),
+            False,
+        )
+        event = lldbutil.fetch_next_event(self, listener, broadcaster)
+        message = lldb.SBDebugger.GetDiagnosticFromEvent(event).GetValueForKey(
+            "message"
+        )
+        self.assertIn("resolver.DoesNotExist", message.GetStringValue(4096))
+        self.assertFalse(
+            listener.GetNextEvent(lldb.SBEvent()),
+            "the SB path should broadcast exactly one diagnostic",
+        )
+
     def make_target_and_import(self):
         target = self.make_target()
         self.import_resolver_script()

--- a/lldb/test/API/functionalities/breakpoint/scripted_bkpt/TestScriptedResolver.py
+++ b/lldb/test/API/functionalities/breakpoint/scripted_bkpt/TestScriptedResolver.py
@@ -42,7 +42,6 @@ class TestScriptedResolver(TestBase):
         self.build()
         self.do_test_copy_from_dummy_target()
 
-    @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24528")
     def test_scripted_resolver_creation(self):
         self.build()
         target = self.make_target_and_import()

--- a/lldb/test/API/functionalities/breakpoint/scripted_bkpt/TestScriptedResolver.py
+++ b/lldb/test/API/functionalities/breakpoint/scripted_bkpt/TestScriptedResolver.py
@@ -60,7 +60,7 @@ class TestScriptedResolver(TestBase):
             "breakpoint set -P resolver.DoesNotExist",
             error=True,
             substrs=[
-                "Error creating scripted breakpoint",
+                "cannot create scripted breakpoint",
                 "Could not find script class: resolver.DoesNotExist",
             ],
         )

--- a/lldb/test/API/functionalities/breakpoint/scripted_bkpt/TestScriptedResolver.py
+++ b/lldb/test/API/functionalities/breakpoint/scripted_bkpt/TestScriptedResolver.py
@@ -42,6 +42,48 @@ class TestScriptedResolver(TestBase):
         self.build()
         self.do_test_copy_from_dummy_target()
 
+    @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24528")
+    def test_scripted_resolver_creation(self):
+        self.build()
+        target = self.make_target_and_import()
+        extra_args = self.make_extra_args()
+        module_list = lldb.SBFileSpecList()
+        file_list = lldb.SBFileSpecList()
+        initial_count = target.GetNumBreakpoints()
+
+        failed = target.BreakpointCreateFromScript(
+            "resolver.DoesNotExist", extra_args, module_list, file_list, False
+        )
+        self.assertFalse(failed.IsValid())
+        self.assertEqual(initial_count, target.GetNumBreakpoints())
+
+        self.expect(
+            "breakpoint set -P resolver.DoesNotExist",
+            error=True,
+            substrs=[
+                "Error creating scripted breakpoint",
+                "Could not find script class: resolver.DoesNotExist",
+            ],
+        )
+        self.assertEqual(initial_count, target.GetNumBreakpoints())
+
+        error = lldb.SBError()
+        target.AddBreakpointOverride(
+            "resolver.OverrideResolver",
+            "scripted resolver override",
+            lldb.eResolverPython,
+            extra_args,
+            error,
+        )
+        self.assertSuccess(error)
+
+        overridden = target.BreakpointCreateFromScript(
+            "resolver.DoesNotExist", extra_args, module_list, file_list, True
+        )
+        self.assertTrue(overridden.IsValid())
+        self.assertTrue(overridden.IsHardware())
+        self.assertEqual(initial_count + 1, target.GetNumBreakpoints())
+
     def make_target_and_import(self):
         target = self.make_target()
         self.import_resolver_script()

--- a/lldb/test/API/functionalities/breakpoint/scripted_bkpt/resolver.py
+++ b/lldb/test/API/functionalities/breakpoint/scripted_bkpt/resolver.py
@@ -51,6 +51,15 @@ class Resolver:
     def get_short_help(self):
         return "I am a python breakpoint resolver"
 
+
+class OverrideResolver(Resolver):
+    def set_breakpoint(self, bkpt):
+        self.bkpt = bkpt
+
+    def overrides_resolver(self, target, initial_resolver):
+        return True
+
+
 class ResolverModuleDepth(Resolver):
     def __get_depth__(self):
         return lldb.eSearchDepthModule

--- a/lldb/test/API/functionalities/breakpoint/serialize/TestBreakpointSerialization.py
+++ b/lldb/test/API/functionalities/breakpoint/serialize/TestBreakpointSerialization.py
@@ -49,6 +49,42 @@ class BreakpointSerialization(TestBase):
         self.setup_targets_and_cleanup()
         self.do_check_extra_args()
 
+    def test_missing_scripted_resolver_deserialization(self):
+        self.build()
+        self.setup_targets_and_cleanup()
+
+        script_name = os.path.join(self.getSourceDir(), "resolver.py")
+        self.runCmd("command script import " + script_name)
+        breakpoint = self.orig_target.BreakpointCreateFromScript(
+            "resolver.Resolver",
+            lldb.SBStructuredData(),
+            lldb.SBFileSpecList(),
+            lldb.SBFileSpecList(),
+        )
+        self.assertTrue(breakpoint.IsValid())
+
+        breakpoints = lldb.SBBreakpointList(self.orig_target)
+        error = self.orig_target.BreakpointsWriteToFile(
+            self.bkpts_file_spec, breakpoints
+        )
+        self.assertSuccess(error)
+        with open(self.bkpts_file_path, encoding="utf-8") as breakpoints_file:
+            serialized = json.load(breakpoints_file)
+        serialized[0]["Breakpoint"]["BKPTResolver"]["Options"][
+            "PythonClass"
+        ] = "resolver.DoesNotExist"
+        with open(self.bkpts_file_path, "w", encoding="utf-8") as breakpoints_file:
+            json.dump(serialized, breakpoints_file)
+
+        restored = lldb.SBBreakpointList(self.copy_target)
+        error = self.copy_target.BreakpointsCreateFromFile(
+            self.bkpts_file_spec, restored
+        )
+        self.assertFailure(error)
+        self.assertIn("resolver.DoesNotExist", error.GetCString())
+        self.assertEqual(0, restored.GetSize())
+        self.assertEqual(0, self.copy_target.GetNumBreakpoints())
+
     def test_resolver_serialization(self):
         """Test that breakpoint resolvers contain the expected information"""
         self.build()

--- a/lldb/test/API/functionalities/scripted_extensions/TestScriptedExtensionsDiagnostics.py
+++ b/lldb/test/API/functionalities/scripted_extensions/TestScriptedExtensionsDiagnostics.py
@@ -118,8 +118,9 @@ class TestScriptedExtensionsDiagnostics(TestBase):
     # ------------------------------------------------------------------
     # BreakpointResolverScripted - reports via
     # BreakpointResolverScripted::CreateImplementationIfNeeded.
-    # `m_error` is set but never surfaced to the user, so ReportError is
-    # the only user-visible channel.
+    # Target::CreateBreakpoint also propagates `m_error` back to its caller,
+    # but CopyForBreakpoint has no return channel, so ReportError stays the
+    # general diagnostic channel.
     # ------------------------------------------------------------------
 
     def test_scripted_breakpoint_resolver_init_failure(self):


### PR DESCRIPTION
Setting a breakpoint on a Python resolver class that does not exist quietly succeeds today. The resolver records the failure internally, but nothing ever reads it, so `breakpoint set -P`, `SBTarget::BreakpointCreateFromScript`, and breakpoint deserialization all hand back a breakpoint that can never resolve.

This change checks that status before adding the breakpoint and reports the error instead. The check runs after breakpoint overrides are applied, so an override can still take over a class LLDB could not load. This also makes `Target::CreateScriptedBreakpoint` honor `request_hardware`, which it was ignoring.