### PR TITLE
[Clang][Driver] Accept `--offload-jobs` without parallel work

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5495,18 +5495,13 @@ static void claimAndDiagnoseOffloadJobs(const Driver &D, const ArgList &Args) {
 }
 
 static void markOffloadDeviceCC1JobsForParallelExecution(Compilation &C) {
-  bool FoundCandidate = false;
   for (auto &Job : C.getJobs()) {
     if (!isOffloadDeviceCC1JobCandidate(Job))
       continue;
 
     Job.setOffloadDeviceParallelJobGroup(
         getOffloadDeviceCC1ParallelJobGroup(Job));
-    FoundCandidate = true;
   }
-
-  if (FoundCandidate)
-    claimAndDiagnoseOffloadJobs(C.getDriver(), C.getArgs());
 }
 
 void Driver::BuildJobs(Compilation &C) const {
@@ -5610,6 +5605,8 @@ void Driver::BuildJobs(Compilation &C) const {
       J.InProcess = false;
 
   markOffloadDeviceCC1JobsForParallelExecution(C);
+  if (C.getActiveOffloadKinds() != Action::OFK_None)
+    claimAndDiagnoseOffloadJobs(*this, C.getArgs());
 
   if (CCPrintProcessStats) {
     C.setPostCallback([=](const Command &Cmd, int Res) {

--- a/clang/test/Driver/offload-parallel-device-cc1.cu
+++ b/clang/test/Driver/offload-parallel-device-cc1.cu
@@ -2,6 +2,11 @@
 // REQUIRES: nvptx-registered-target, lld
 
 // RUN: rm -rf %t && mkdir -p %t
+// RUN: not %clang -x c++ --offload-jobs=1 -Werror -fsyntax-only %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=NOOFFLOAD %s
+// NOOFFLOAD: argument unused during compilation: '--offload-jobs=1'
+// RUN: %clang -x hip --target=x86_64-unknown-linux-gnu -nogpuinc -nogpulib \
+// RUN:   --offload-arch=gfx900 --offload-jobs=1 -Werror -E %s -o %t/hip.i
 // RUN: %clang -x hip --target=x86_64-unknown-linux-gnu \
 // RUN:   -nostdinc -nogpuinc -nohipwrapperinc -nogpulib \
 // RUN:   --offload-arch=gfx900 --offload-arch=gfx906 --offload-jobs=2 \
@@ -18,5 +23,5 @@
 // RUN:   --cuda-device-only -S %s 2>&1 | FileCheck -check-prefix=INVJOBS %s
 // INVJOBS: clang: error: invalid integral value '0x4' in '--offload-jobs=0x4'
 
-// Empty source file. RUN lines are execution smoke tests for the driver
-// path that runs independent offload device cc1 jobs through --offload-jobs.
+// Empty source file. RUN lines test --offload-jobs with and without
+// independent offload device cc1 jobs.


### PR DESCRIPTION
Clang reported `--offload-jobs` as unused when an active offload compilation had no device work that could run in parallel. CMake tests compiler options with `-Werror`, so this warning made HIP/offload option detection fail. It also caused unnecessary build errors and CMake workarounds in projects targeting one or several GPU architectures.

`--offload-jobs` sets the maximum number of parallel jobs, not a required number. An offload compilation with fewer jobs, including zero or one, is valid and should not produce an unused argument warning. A normal C++ compilation without offloading still reports the option as unused; CMake should probe it using a HIP/offload compilation.

Claim and validate the option whenever offloading is active, independently of whether parallel device jobs are found. Keep job discovery responsible only for marking work that can run in parallel.