### PR TITLE
[AMDGPU] Rewrite undef PHIs with a unique constant value

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPURewriteUndefForPHI.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURewriteUndefForPHI.cpp
@@ -140,23 +140,24 @@ bool rewritePHIs(Function &F, UniformityInfo &UA, DominatorTree *DT) {
       }
       // We only need to replace the undef for the PHI which is merging
       // defined/undefined values from divergent threads.
-      // TODO: We should still be able to replace undef value if the unique
-      // value is a Constant.
-      if (!UniqueDefinedIncoming || Undefs.empty() ||
-          UA.isUniformTerminator(DominateBB->getTerminator()))
+      if (!UniqueDefinedIncoming || Undefs.empty())
         continue;
 
-      // We only replace the undef when DominateBB truly dominates all the
-      // other predecessors with undefined incoming value. Make sure DominateBB
-      // dominates BB so that UniqueDefinedIncoming is available in BB and
-      // afterwards.
-      if (DT->dominates(DominateBB, &BB) && all_of(Undefs, [&](BasicBlock *UD) {
-            return DT->dominates(DominateBB, UD);
-          })) {
-        PHI.replaceAllUsesWith(UniqueDefinedIncoming);
-        ToBeDeleted.push_back(&PHI);
-        Changed = true;
-      }
+      // For non-constant incoming values, require DominateBB to have a
+      // divergent terminator and to dominate BB and every predecessor with an
+      // undefined incoming value. Constants are available everywhere and don't
+      // require these checks.
+      if (!isa<Constant>(UniqueDefinedIncoming) &&
+          (UA.isUniformTerminator(DominateBB->getTerminator()) ||
+           !DT->dominates(DominateBB, &BB) ||
+           any_of(Undefs, [&](BasicBlock *UD) {
+             return !DT->dominates(DominateBB, UD);
+           })))
+        continue;
+
+      PHI.replaceAllUsesWith(UniqueDefinedIncoming);
+      ToBeDeleted.push_back(&PHI);
+      Changed = true;
     }
   }
 

--- a/llvm/test/CodeGen/AMDGPU/rewrite-undef-for-phi.ll
+++ b/llvm/test/CodeGen/AMDGPU/rewrite-undef-for-phi.ll
@@ -24,6 +24,28 @@ end:
   ret float %c2
 }
 
+define amdgpu_ps i32 @constant_defined_on_non_dominating_path(i32 %x) #0 {
+; OPT-LABEL: @constant_defined_on_non_dominating_path(
+; OPT-NEXT:  entry:
+; OPT-NEXT:    [[CC:%.*]] = icmp slt i32 [[X:%.*]], 0
+; OPT-NEXT:    br i1 [[CC]], label [[IF:%.*]], label [[END:%.*]]
+; OPT:       if:
+; OPT-NEXT:    br label [[END]]
+; OPT:       end:
+; OPT-NEXT:    ret i32 42
+;
+entry:
+  %cc = icmp slt i32 %x, 0
+  br i1 %cc, label %if, label %end
+
+if:
+  br label %end
+
+end:
+  %result = phi i32 [ 42, %if ], [ poison, %entry ]
+  ret i32 %result
+}
+
 define amdgpu_ps float @with_uniform_region_inside(float inreg %c, i32 inreg %d, i32 %x) #0 {
 ; OPT-LABEL: @with_uniform_region_inside(
 ; OPT-NEXT:  entry:


### PR DESCRIPTION
Allow AMDGPURewriteUndefForPHI to replace a PHI containing a unique constant value and undef/poison incoming values without requiring the defined predecessor to satisfy the existing divergence and dominance checks.

Constants are available in every block, so the availability checks needed for instruction-defined values do not apply.

The first commit precommits a regression test demonstrating the missing fold.
