### PR TITLE
[offload] Fix unittests on Windows

### DIFF
--- a/offload/test/unit/lit.cfg.py
+++ b/offload/test/unit/lit.cfg.py
@@ -33,6 +33,11 @@ if config.bin_llvm_tools_dir:
 if config.cuda_path:
     prepend_executable_path(f"{config.cuda_path}{os.path.sep}bin")
 
+# Windows doesn't have rpath so make sure runtime deps for the unittest
+# executable, such as LLVMOffload.dll, are found.
+if config.operating_system == "Windows" and config.library_dir:
+    prepend_executable_path(config.library_dir)
+
 # test_source_root: The root path where tests are located.
 # test_exec_root: The root path where tests should be run.
 config.test_exec_root = config.unittest_dir

--- a/offload/test/unit/lit.site.cfg.in
+++ b/offload/test/unit/lit.site.cfg.in
@@ -5,6 +5,7 @@ config.unittest_dir = "@OFFLOAD_UNITTEST_DIR@"
 config.llvm_build_mode = lit_config.substitute("@LLVM_BUILD_MODE@")
 config.bin_llvm_tools_dir = "@LLVM_TOOLS_BINARY_DIR@"
 config.cuda_path = "@CUDA_ROOT@"
+config.operating_system = "@CMAKE_SYSTEM_NAME@"
 
 # Let the main config do the real work.
 lit_config.load_config(config, "@CMAKE_CURRENT_SOURCE_DIR@/unit/lit.cfg.py")


### PR DESCRIPTION
Right now everything fails because it can't find `LLVMOffload.dll`. 
We handle this for e2e tests [here](https://github.com/llvm/llvm-project/blob/main/offload/test/lit.cfg#L212), but not for the unit tests.