### PR TITLE
[offload][lit] Run unit tests in check-offload if libomptarget isn't built

### DIFF
--- a/offload/test/CMakeLists.txt
+++ b/offload/test/CMakeLists.txt
@@ -65,23 +65,22 @@ configure_lit_site_cfg(
   MAIN_CONFIG
   ${CMAKE_CURRENT_SOURCE_DIR}/unit/lit.cfg.py)
 
+set(CHECK_OFFLOAD_SUITES ${CMAKE_CURRENT_BINARY_DIR}/unit)
+set(CHECK_OFFLOAD_DEPS ${OFFLOAD_TOOLS} LLVMOffload OffloadUnitTests ${LIBOMPTARGET_TESTED_PLUGINS})
+set(CHECK_OFFLOAD_ARGS "")
+
 if(TARGET omptarget)
-  add_offload_testsuite(check-offload
-    "Running offload tests"
-    ${LIBOMPTARGET_LIT_TESTSUITES}
-    ${CMAKE_CURRENT_BINARY_DIR}/unit
-    EXCLUDE_FROM_CHECK_ALL
-    DEPENDS ${OFFLOAD_TOOLS} omptarget ${OMP_DEPEND} ${LIBOMPTARGET_TESTED_PLUGINS}
-      LLVMOffload OffloadUnitTests
-    ARGS ${LIBOMPTARGET_LIT_ARG_LIST})
-else()
-  add_offload_testsuite(check-offload
-    "Running offload tests"
-    ${CMAKE_CURRENT_BINARY_DIR}/unit
-    EXCLUDE_FROM_CHECK_ALL
-    DEPENDS ${OFFLOAD_TOOLS} ${LIBOMPTARGET_TESTED_PLUGINS}
-      LLVMOffload OffloadUnitTests)
+  list(APPEND CHECK_OFFLOAD_SUITES ${LIBOMPTARGET_LIT_TESTSUITES})
+  list(APPEND CHECK_OFFLOAD_DEPS omptarget ${OMP_DEPEND})
+  list(APPEND CHECK_OFFLOAD_ARGS ${LIBOMPTARGET_LIT_ARG_LIST})
 endif()
+
+add_offload_testsuite(check-offload
+    "Running offload tests"
+    ${CHECK_OFFLOAD_SUITES}
+    EXCLUDE_FROM_CHECK_ALL
+    DEPENDS ${CHECK_OFFLOAD_DEPS}
+    ARGS ${CHECK_OFFLOAD_ARGS})
 
 add_lit_testsuite(check-offload-unit "Running offload unittest suites"
   ${CMAKE_CURRENT_BINARY_DIR}/unit

--- a/offload/test/CMakeLists.txt
+++ b/offload/test/CMakeLists.txt
@@ -74,6 +74,13 @@ if(TARGET omptarget)
     DEPENDS ${OFFLOAD_TOOLS} omptarget ${OMP_DEPEND} ${LIBOMPTARGET_TESTED_PLUGINS}
       LLVMOffload OffloadUnitTests
     ARGS ${LIBOMPTARGET_LIT_ARG_LIST})
+else()
+  add_offload_testsuite(check-offload
+    "Running offload tests"
+    ${CMAKE_CURRENT_BINARY_DIR}/unit
+    EXCLUDE_FROM_CHECK_ALL
+    DEPENDS ${OFFLOAD_TOOLS} ${LIBOMPTARGET_TESTED_PLUGINS}
+      LLVMOffload OffloadUnitTests)
 endif()
 
 add_lit_testsuite(check-offload-unit "Running offload unittest suites"


### PR DESCRIPTION
Right now we define no top-level `check-offload` target if `libomptarget` isn't built.
Instead, just define the target to run the unit tests instead instead of running both the unit tests and the `libomptarget` tests we would do if `libomptarget` were built.
It's really useful to have a top-level target to run tests, especially for CI.
This target will be used by our Windows buildbot, as `libomptarget` isn't supported on Windows.
