### PR TITLE
[Clang] Add missing colons to Preprocessor lit test

### DIFF
--- a/clang/test/Preprocessor/line-directive-output.c
+++ b/clang/test/Preprocessor/line-directive-output.c
@@ -81,13 +81,13 @@ extern int z;
 // CHECK: # 1 "c:\moo\zar\haz.h"
 #line 1 "c:\moo\zar\haz.h"
 
-// CHECK # 1 "original\x12source.c"
+// CHECK: # 1 "original\x12source.c"
 # 1 "original\x12source.c"
 
-// CHECK # 1 "original\u1234"
+// CHECK: # 1 "original\u1234"
 # 1 "original\u1234"
 
-// CHECK # 1 "original\u{1234}"
+// CHECK: # 1 "original\u{1234}"
 # 1 "original\u{1234}"
 
 # 1 "system.h" 3


### PR DESCRIPTION
PR #211512 introduced new lit tests that are missing colons. This PR adds them back so the lit tests introduced actually run.