### PR TITLE
[Clang-Tidy] Support lambda's init captures in `readability-identifier-naming`.

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.cpp
@@ -94,6 +94,7 @@ namespace readability {
     m(LocalConstantPointer) \
     m(LocalPointer) \
     m(LocalVariable) \
+    m(LambdaCapture) \
     m(StaticConstexprVariable) \
     m(StaticConstant) \
     m(StaticVariable) \
@@ -1521,6 +1522,9 @@ StyleKind IdentifierNamingCheck::findStyleKindForField(
 StyleKind IdentifierNamingCheck::findStyleKindForVar(
     const VarDecl *Var, QualType Type,
     ArrayRef<std::optional<NamingStyle>> NamingStyles) const {
+  if (Var->isInitCapture() && NamingStyles[SK_LambdaCapture])
+    return SK_LambdaCapture;
+
   if (Var->isConstexpr()) {
     if (Var->isStaticDataMember() && NamingStyles[SK_ClassConstexpr])
       return SK_ClassConstexpr;

--- a/clang-tools-extra/docs/ReleaseNotes.md
+++ b/clang-tools-extra/docs/ReleaseNotes.md
@@ -144,7 +144,7 @@ infrastructure are described first, followed by tool-specific sections.
 - Improved {doc}`cppcoreguidelines-pro-type-member-init
   <clang-tidy/checks/cppcoreguidelines/pro-type-member-init>` check by treating
   `std::array` the same as built-in arrays when `IgnoreArrays` option is enabled.
-  
+
 - Improved {doc}`cppcoreguidelines-use-enum-class
   <clang-tidy/checks/cppcoreguidelines/use-enum-class>` check by omitting unnamed enums from the `enum class` requirement, as previously the check suggested users an ill-formed fix.
 
@@ -199,6 +199,10 @@ infrastructure are described first, followed by tool-specific sections.
 
   - Fixed {option}`DefaultHungarianPrefix` being incorrectly diagnosed as an
     invalid option.
+
+  - Added support for naming lambda init-captures (e.g. `[Captured = Var]`) via
+    the new `LambdaCapture` options. Simple, non-init captures continue to follow
+    the naming style of the variable they capture.
 
 - Improved {doc}`readability-named-parameter
   <clang-tidy/checks/readability/named-parameter>` check by ignoring

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/identifier-naming.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/identifier-naming.rst
@@ -159,6 +159,9 @@ The available options are summarized below:
    :option:`GlobalVariableHungarianPrefix`
  - :option:`InlineNamespaceCase`, :option:`InlineNamespacePrefix`,
    :option:`InlineNamespaceSuffix`, :option:`InlineNamespaceIgnoredRegexp`
+ - :option:`LambdaCaptureCase`, :option:`LambdaCapturePrefix`,
+   :option:`LambdaCaptureSuffix`, :option:`LambdaCaptureIgnoredRegexp`,
+   :option:`LambdaCaptureHungarianPrefix`
  - :option:`LocalConstexprVariableCase`,
    :option:`LocalConstexprVariablePrefix`,
    :option:`LocalConstexprVariableSuffix`,
@@ -1490,6 +1493,63 @@ After:
     ...
     }
     } // namespace FOO_NS
+
+.. option:: LambdaCaptureCase
+
+    When defined, the check will ensure lambda init-capture names (e.g.
+    ``Captured`` in ``[Captured = Var]``) conform to the selected casing.
+    A simple, non-init capture (e.g. ``[Var]`` or ``[&Var]``) refers to the
+    same declaration as ``Var`` itself, so it keeps following whichever
+    naming style applies to ``Var``'s own declaration instead.
+
+.. option:: LambdaCapturePrefix
+
+    When defined, the check will ensure lambda init-capture names will add
+    the prefix with the given value (regardless of casing).
+
+.. option:: LambdaCaptureIgnoredRegexp
+
+    Identifier naming checks won't be enforced for lambda init-capture names
+    matching this regular expression.
+
+.. option:: LambdaCaptureSuffix
+
+    When defined, the check will ensure lambda init-capture names will add
+    the suffix with the given value (regardless of casing).
+
+.. option:: LambdaCaptureHungarianPrefix
+
+    When enabled, the check ensures that the declared identifier will
+    have a Hungarian notation prefix based on the declared type.
+
+For example using values of:
+
+   - LambdaCaptureCase of ``CamelCase``
+   - LambdaCapturePrefix of ``c_``
+
+Identifies and/or transforms lambda init-capture names as follows:
+
+Before:
+
+.. code-block:: c++
+
+    void foo() {
+      int local_variable = 0;
+      auto lambda = [captured_value = local_variable]() {
+        return captured_value;
+      };
+    }
+
+After:
+
+.. code-block:: c++
+
+    void foo() {
+      int local_variable = 0;
+      auto lambda = [c_CapturedValue = local_variable]() {
+        return c_CapturedValue;
+      };
+    }
 
 .. option:: LocalConstexprVariableCase
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming-lambda-capture.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming-lambda-capture.cpp
@@ -1,0 +1,45 @@
+// RUN: %check_clang_tidy -std=c++14-or-later %s readability-identifier-naming %t -- \
+// RUN:   -config='{CheckOptions: { \
+// RUN:     readability-identifier-naming.LambdaCaptureCase: CamelCase, \
+// RUN:     readability-identifier-naming.LambdaCapturePrefix: 'c_', \
+// RUN:     readability-identifier-naming.LocalVariableCase: lower_case, \
+// RUN:   }}'
+
+void goodInitCapture() {
+  int local_variable = 0;
+  auto lambda = [c_LocalVariable = local_variable]() {
+    return c_LocalVariable;
+  };
+  (void)lambda();
+}
+
+void badInitCapture() {
+  int local_variable = 0;
+  auto lambda = [captured_value = local_variable]() {
+    return captured_value;
+  };
+  // CHECK-MESSAGES: :[[@LINE-3]]:18: warning: invalid case style for lambda capture 'captured_value' [readability-identifier-naming]
+  // CHECK-FIXES: auto lambda = [c_CapturedValue = local_variable]() {
+  // CHECK-FIXES-NEXT: return c_CapturedValue;
+  (void)lambda();
+}
+
+// Simple (non-init) explicit captures reuse the *same* VarDecl as the
+// outer declaration, so they must keep following LocalVariable's style,
+// not LambdaCapture, and must not gain the 'c_' prefix.
+void simpleCapturesUseLocalVariableStyle() {
+  int local_variable = 0;
+  auto by_copy = [local_variable]() { return local_variable; };
+  auto by_ref = [&local_variable]() { return local_variable; };
+  (void)by_copy();
+  (void)by_ref();
+}
+
+void badLocalVariableCapturedSimply() {
+  int LocalVariable = 0;
+  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for local variable 'LocalVariable' [readability-identifier-naming]
+  // CHECK-FIXES: int local_variable = 0;
+  auto lambda = [LocalVariable]() { return LocalVariable; };
+  // CHECK-FIXES: auto lambda = [local_variable]() { return local_variable; };
+  (void)lambda();
+}


### PR DESCRIPTION
Add an ability to declare a custom rules for lambda's init-captures. It recently came up in some of the discussions and people find it useful to to have rules for those types of identifiers.