### PR TITLE
[libc++] Make `isfinite`/`isinf`/`isnan`/`isnormal`/`signbit` `constexpr` on Windows

### DIFF
--- a/libcxx/docs/ReleaseNotes/24.rst
+++ b/libcxx/docs/ReleaseNotes/24.rst
@@ -51,6 +51,10 @@ Implemented Papers
 Improvements and New Features
 -----------------------------
 
+- On Windows, ``std::isfinite``, ``std::isinf``, ``std::isnan``, ``std::isnormal`` and ``std::signbit`` are now usable
+  in constant expressions in C++23, as required by P0533R9. They previously resolved to the UCRT's non-``constexpr``
+  declarations (`Github <https://github.com/llvm/llvm-project/issues/214358>`__).
+
 Deprecations and Removals
 -------------------------
 

--- a/libcxx/include/__math/traits.h
+++ b/libcxx/include/__math/traits.h
@@ -214,18 +214,9 @@ isunordered(_A1 __x, _A2 __y) _NOEXCEPT {
 
 #if defined(_LIBCPP_MSVCRT) && _LIBCPP_STD_VER >= 20
 namespace __ucrt {
-// The UCRT declares these as unconstrained, non-constexpr function templates, so it isn't only integer arguments that
-// need handling here: without a candidate of our own, floating-point calls resolve to the UCRT's templates too and
-// std::isfinite & friends stay non-constexpr in C++23, violating P0533R9.
-//
-// Constraining ours on is_arithmetic_v covers both. The UCRT's templates and ours have equivalent
-// parameter-type-lists, so neither is more specialized and the more-constrained one wins ([temp.func.order]), which is
-// the same mechanism the two-argument traits below already rely on.
-//
-// Note that we forward to the __math overloads but intentionally do not pull them into this namespace with a
-// using-declaration: the __math ones are constrained through a defaulted template parameter rather than a
-// requires-clause, so their template-parameter-lists are not equivalent to the UCRT's, neither is more specialized,
-// the more-constrained tiebreak does not apply, and integral calls become ambiguous.
+// The UCRT declares these as unconstrained, non-constexpr function templates.
+// In order to support constexpr addition in P0533R9, libc++ provides constrained overloads for all arithmetic types as
+// a workaround. These overloads are preferred to unconstrained ones.
 
 template <class _A1>
   requires is_arithmetic_v<_A1>

--- a/libcxx/include/__math/traits.h
+++ b/libcxx/include/__math/traits.h
@@ -25,9 +25,27 @@ namespace __math {
 
 // signbit
 
-// The universal C runtime (UCRT) in the WinSDK provides floating point overloads
-// for std::signbit(). By defining our overloads as templates, we can work around
-// this issue as templates are less preferred than non-template functions.
+// The universal C runtime (UCRT) in the WinSDK provides non-template floating point overloads for std::signbit(), and
+// a non-template function can't outrank another non-template function. We used to declare ours as templates so that
+// the UCRT's would win, but that leaves std::signbit non-constexpr in C++23 on Windows, which P0533R9 requires it to
+// be. _LIBCPP_PREFERRED_OVERLOAD makes ours win instead, the same way <math.h> handles fpclassify, which the UCRT
+// declares in exactly the same shape. Without the attribute we fall back to templates, keeping the old behavior.
+#ifdef _LIBCPP_PREFERRED_OVERLOAD
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX23
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_PREFERRED_OVERLOAD bool signbit(float __x) _NOEXCEPT {
+  return __builtin_signbit(__x);
+}
+
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI _LIBCPP_PREFERRED_OVERLOAD bool
+signbit(double __x) _NOEXCEPT {
+  return __builtin_signbit(__x);
+}
+
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI _LIBCPP_PREFERRED_OVERLOAD bool
+signbit(long double __x) _NOEXCEPT {
+  return __builtin_signbit(__x);
+}
+#else
 template <class = void>
 [[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI bool signbit(float __x) _NOEXCEPT {
   return __builtin_signbit(__x);
@@ -42,6 +60,7 @@ template <class = void>
 [[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI bool signbit(long double __x) _NOEXCEPT {
   return __builtin_signbit(__x);
 }
+#endif
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
 [[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI bool signbit(_A1 __x) _NOEXCEPT {
@@ -195,28 +214,41 @@ isunordered(_A1 __x, _A2 __y) _NOEXCEPT {
 
 #if defined(_LIBCPP_MSVCRT) && _LIBCPP_STD_VER >= 20
 namespace __ucrt {
+// The UCRT declares these as unconstrained, non-constexpr function templates, so it isn't only integer arguments that
+// need handling here: without a candidate of our own, floating-point calls resolve to the UCRT's templates too and
+// std::isfinite & friends stay non-constexpr in C++23, violating P0533R9.
+//
+// Constraining ours on is_arithmetic_v covers both. The UCRT's templates and ours have equivalent
+// parameter-type-lists, so neither is more specialized and the more-constrained one wins ([temp.func.order]), which is
+// the same mechanism the two-argument traits below already rely on.
+//
+// Note that we forward to the __math overloads but intentionally do not pull them into this namespace with a
+// using-declaration: the __math ones are constrained through a defaulted template parameter rather than a
+// requires-clause, so their template-parameter-lists are not equivalent to the UCRT's, neither is more specialized,
+// the more-constrained tiebreak does not apply, and integral calls become ambiguous.
+
 template <class _A1>
-  requires is_integral_v<_A1>
-[[nodiscard]] inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI bool isfinite(_A1) noexcept {
-  return true;
+  requires is_arithmetic_v<_A1>
+[[nodiscard]] inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI bool isfinite(_A1 __x) noexcept {
+  return __math::isfinite(__x);
 }
 
 template <class _A1>
-  requires is_integral_v<_A1>
-[[nodiscard]] inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI bool isinf(_A1) noexcept {
-  return false;
+  requires is_arithmetic_v<_A1>
+[[nodiscard]] inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI bool isinf(_A1 __x) noexcept {
+  return __math::isinf(__x);
 }
 
 template <class _A1>
-  requires is_integral_v<_A1>
-[[nodiscard]] inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI bool isnan(_A1) noexcept {
-  return false;
+  requires is_arithmetic_v<_A1>
+[[nodiscard]] inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI bool isnan(_A1 __x) noexcept {
+  return __math::isnan(__x);
 }
 
 template <class _A1>
-  requires is_integral_v<_A1>
+  requires is_arithmetic_v<_A1>
 [[nodiscard]] inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI bool isnormal(_A1 __x) noexcept {
-  return __x != 0;
+  return __math::isnormal(__x);
 }
 
 template <class _A1, class _A2>

--- a/libcxx/include/math.h
+++ b/libcxx/include/math.h
@@ -392,6 +392,7 @@ namespace __math {
 // To workaround this, we use _LIBCPP_PREFERRED_OVERLOAD to make our overloads stronger than those overloads, which is
 // necessary for constexpr addition in C++23. When _LIBCPP_PREFERRED_OVERLOAD is not supported, we use template
 // overloads as a workaround to avoid conflicts.
+// std::__math::signbit in <__math/traits.h> has the same problem and uses the same workaround.
 
 #      ifdef _LIBCPP_PREFERRED_OVERLOAD
 [[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX23
@@ -459,7 +460,9 @@ using std::__math::isunordered;
 
 #      if defined(_LIBCPP_MSVCRT) && _LIBCPP_STD_VER >= 20
 // MS UCRT incorrectly defines some functions in a way not working with integer types. Until C++20, this was worked
-// around by -fdelayed-template-parsing. Since C++20, we can use standard feature "requires" instead.
+// around by -fdelayed-template-parsing. Since C++20, we can use standard feature "requires" instead. The UCRT
+// definitions are also not constexpr, so the __ucrt overloads are constrained on all of is_arithmetic_v rather than
+// just the integer types, which makes them usable in constant expressions as P0533R9 requires since C++23.
 
 // TODO: Remove the workaround once UCRT fixes these functions. Note that this doesn't seem planned as of 2025-07 per
 // https://developercommunity.visualstudio.com/t/10294165.

--- a/libcxx/test/libcxx/numerics/c.math/constexpr-cxx23-clang.pass.cpp
+++ b/libcxx/test/libcxx/numerics/c.math/constexpr-cxx23-clang.pass.cpp
@@ -19,9 +19,6 @@
 // REQUIRES: clang
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
-// We don't control the implementation of these functions on windows
-// UNSUPPORTED: windows
-
 // Missing some math functions.
 // XFAIL: LLVM-LIBC-FIXME
 

--- a/libcxx/test/std/numerics/c.math/isfinite.pass.cpp
+++ b/libcxx/test/std/numerics/c.math/isfinite.pass.cpp
@@ -8,9 +8,6 @@
 
 // bool isfinite(floating-point-type x); // constexpr since C++23
 
-// We don't control the implementation on windows
-// UNSUPPORTED: windows
-
 #include <cassert>
 #include <cmath>
 #include <limits>

--- a/libcxx/test/std/numerics/c.math/isinf.pass.cpp
+++ b/libcxx/test/std/numerics/c.math/isinf.pass.cpp
@@ -8,9 +8,6 @@
 
 // bool isfinite(floating-point-type x); // constexpr since C++23
 
-// We don't control the implementation on windows
-// UNSUPPORTED: windows
-
 #include <cassert>
 #include <cmath>
 #include <limits>

--- a/libcxx/test/std/numerics/c.math/isnan.pass.cpp
+++ b/libcxx/test/std/numerics/c.math/isnan.pass.cpp
@@ -8,9 +8,6 @@
 
 // bool isfinite(floating-point-type x); // constexpr since C++23
 
-// We don't control the implementation on windows
-// UNSUPPORTED: windows
-
 #include <cassert>
 #include <cmath>
 #include <limits>

--- a/libcxx/test/std/numerics/c.math/isnormal.pass.cpp
+++ b/libcxx/test/std/numerics/c.math/isnormal.pass.cpp
@@ -8,9 +8,6 @@
 
 // bool isfinite(floating-point-type x); // constexpr since C++23
 
-// We don't control the implementation on windows
-// UNSUPPORTED: windows
-
 #include <cassert>
 #include <cmath>
 #include <limits>

--- a/libcxx/test/std/numerics/c.math/signbit.pass.cpp
+++ b/libcxx/test/std/numerics/c.math/signbit.pass.cpp
@@ -8,9 +8,6 @@
 
 // bool signbit(floating-point-type x); // constexpr since C++23
 
-// We don't control the implementation on windows
-// UNSUPPORTED: windows
-
 // GCC warns about signbit comparing `bool_v < 0`, which we're testing
 // ADDITIONAL_COMPILE_FLAGS(gcc): -Wno-bool-compare
 


### PR DESCRIPTION
On Windows, libc++ relies on Microsoft UCRT which currently provides non-constexpr overloads for `isfinite`, `isinf`, `isnan`, `isnormal`, and `signbit`. This blocks constexpr addition to `<cmath>` functions in C++23 (P0533R9).

This PR adds workarounds for this, which makes libc++'s constexpr overloads selected whenever possible.
- For `signbit`, `_LIBCPP_PREFERRED_OVERLOAD` is used when it is supported.
- For `isfinite`, `isinf`, `isnan`, and `isnormal`, associated constraints in the workaround versions are changed to use `is_arithmetic_v`, which makes the workaround also cover floating-point types.

Fixes #214358