### PR TITLE
[libc] Process words in inline_strcmp 8 bytes at a time

### DIFF
--- a/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
+++ b/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
@@ -119,6 +119,7 @@ function(_get_compile_options_from_config output_var)
     libc_add_definition(config_options "LIBC_QSORT_IMPL=${LIBC_CONF_QSORT_IMPL}")
   endif()
 
+  libc_add_definition(config_options "LIBC_COPT_STRING_COMPARE_IMPL=${LIBC_CONF_STRING_COMPARE_IMPL}")
   libc_add_definition(config_options "LIBC_COPT_STRING_LENGTH_IMPL=${LIBC_CONF_STRING_LENGTH_IMPL}")
   libc_add_definition(config_options "LIBC_COPT_FIND_FIRST_CHARACTER_IMPL=${LIBC_CONF_FIND_FIRST_CHARACTER_IMPL}")
 

--- a/libc/config/config.json
+++ b/libc/config/config.json
@@ -98,6 +98,10 @@
       "value": "element",
       "doc": "Selects the implementation for string-length: 'element', 'word', 'clang_vector', or 'arch_vector'."
     },
+    "LIBC_CONF_STRING_COMPARE_IMPL": {
+      "value": "element",
+      "doc": "Implementation for strcmp/strcmpcase"
+    },
     "LIBC_CONF_FIND_FIRST_CHARACTER_IMPL": {
       "value": "element",
       "doc": "Selects the implementation for find-first-character-related functions: 'element', 'word', 'clang_vector', or 'arch_vector'."

--- a/libc/src/string/memory_utils/inline_strcmp.h
+++ b/libc/src/string/memory_utils/inline_strcmp.h
@@ -19,6 +19,7 @@ namespace LIBC_NAMESPACE_DECL {
 
 constexpr int PAGE_MASK = 4095;
 constexpr int PAGE_SAFE_OFFSET = 4088;
+constexpr int BLOCK_SIZE = sizeof(uint64_t);
 
 LIBC_INLINE uint64_t is_null_terminated(uint64_t v) {
   return (v - 0x0101010101010101ULL) & ~v & 0x8080808080808080ULL;
@@ -34,15 +35,18 @@ template <typename Comp>
 LIBC_INLINE constexpr int inline_strcmp(const char *left, const char *right,
                                         Comp &&comp) {
   // Page boundry check fallback to generic version
+#if defined(LIBC_COPT_STRING_COMPARE_IMPL)
   if (LIBC_UNLIKELY((reinterpret_cast<uintptr_t>(left) & PAGE_MASK) >
                         PAGE_SAFE_OFFSET ||
                     (reinterpret_cast<uintptr_t>(right) & PAGE_MASK) >
                         PAGE_SAFE_OFFSET)) {
+#endif
     for (; *left && !comp(*left, *right); ++left, ++right)
       ;
     return comp(static_cast<unsigned char>(*left),
                 static_cast<unsigned char>(*right));
   }
+#if defined(LIBC_COPT_STRING_COMPARE_IMPL)
   while (1) {
     uint64_t val1 = load(left);
     uint64_t val2 = load(right);
@@ -51,24 +55,28 @@ LIBC_INLINE constexpr int inline_strcmp(const char *left, const char *right,
     // Check for character mismatch or null terminator
     uint64_t zero_or_diff = diff | null_mask;
     if (zero_or_diff != 0) {
-      size_t byte_pos = __builtin_ctzll(zero_or_diff) >> 3;
+      size_t byte_pos = __builtin_ctzll(zero_or_diff) / BLOCK_SIZE;
       unsigned char c1 = static_cast<unsigned char>(left[byte_pos]);
       unsigned char c2 = static_cast<unsigned char>(right[byte_pos]);
       return comp(c1, c2);
     }
-    left += 8;
-    right += 8;
+    left += BLOCK_SIZE;
+    right += BLOCK_SIZE;
   }
 }
+#endif
 
 template <typename Comp>
 LIBC_INLINE constexpr int inline_strncmp(const char *left, const char *right,
                                          size_t n, Comp &&comp) {
   if (n == 0)
     return 0;
-
-  if (LIBC_UNLIKELY((reinterpret_cast<uintptr_t>(left) & 4095) > 4088 ||
-                    (reinterpret_cast<uintptr_t>(right) & 4095) > 4088)) {
+#if defined(LIBC_COPT_STRING_COMPARE_IMPL)
+  if (LIBC_UNLIKELY((reinterpret_cast<uintptr_t>(left) & PAGE_MASK) >
+                        PAGE_SAFE_OFFSET ||
+                    (reinterpret_cast<uintptr_t>(right) & PAGE_MASK) >
+                        PAGE_SAFE_OFFSET)) {
+#endif
     for (; n > 1; --n, ++left, ++right) {
       char lc = *left;
       if (!comp(lc, '\0') || comp(lc, *right))
@@ -77,10 +85,9 @@ LIBC_INLINE constexpr int inline_strncmp(const char *left, const char *right,
     return comp(static_cast<unsigned char>(*left),
                 static_cast<unsigned char>(*right));
   }
-
-  constexpr size_t block_size = sizeof(uint64_t) / 8;
-  for (; n >= block_size;
-       n -= block_size, left += block_size, right += block_size) {
+#if defined(LIBC_COPT_STRING_COMPARE_IMPL)
+  for (; n >= BLOCK_SIZE;
+       n -= BLOCK_SIZE, left += BLOCK_SIZE, right += BLOCK_SIZE) {
     uint64_t val1 = load(left);
     uint64_t val2 = load(right);
     uint64_t diff = val1 ^ val2;
@@ -88,7 +95,7 @@ LIBC_INLINE constexpr int inline_strncmp(const char *left, const char *right,
 
     uint64_t zero_or_diff = diff | null_mask;
     if (zero_or_diff != 0) {
-      size_t byte_pos = __builtin_ctzll(zero_or_diff) >> 3;
+      size_t byte_pos = __builtin_ctzll(zero_or_diff) / BLOCK_SIZE;
       // If the difference happens past 'n' remaining bytes, they are equal up
       // to n
       if (byte_pos >= n)
@@ -107,7 +114,7 @@ LIBC_INLINE constexpr int inline_strncmp(const char *left, const char *right,
   return comp(static_cast<unsigned char>(*left),
               static_cast<unsigned char>(*right));
 }
-
+#endif
 } // namespace LIBC_NAMESPACE_DECL
 
 #endif // LLVM_LIBC_SRC_STRING_MEMORY_UTILS_INLINE_STRCMP_H

--- a/libc/src/string/memory_utils/inline_strcmp.h
+++ b/libc/src/string/memory_utils/inline_strcmp.h
@@ -9,20 +9,51 @@
 #ifndef LLVM_LIBC_SRC_STRING_MEMORY_UTILS_INLINE_STRCMP_H
 #define LLVM_LIBC_SRC_STRING_MEMORY_UTILS_INLINE_STRCMP_H
 
-#include "src/__support/macros/attributes.h" // LIBC_INLINE
-#include "src/__support/macros/config.h"     // LIBC_NAMESPACE_DECL
+#include "src/__support/macros/attributes.h"   // LIBC_INLINE
+#include "src/__support/macros/config.h"       // LIBC_NAMESPACE_DECL
+#include "src/__support/macros/optimization.h" // LIBC_UNLIKELY
 #include <stddef.h>
+#include <stdint.h>
 
 namespace LIBC_NAMESPACE_DECL {
+
+LIBC_INLINE uint64_t is_null_terminated(uint64_t v) {
+  return (v - 0x0101010101010101ULL) & ~v & 0x8080808080808080ULL;
+}
+
+LIBC_INLINE uint64_t load(const char *ptr) {
+  uint64_t val{0};
+  __builtin_memcpy(&val, ptr, sizeof(uint64_t));
+  return val;
+}
 
 template <typename Comp>
 LIBC_INLINE constexpr int inline_strcmp(const char *left, const char *right,
                                         Comp &&comp) {
-  // TODO: Look at benefits for comparing words at a time.
-  for (; *left && !comp(*left, *right); ++left, ++right)
-    ;
-  return comp(*reinterpret_cast<const unsigned char *>(left),
-              *reinterpret_cast<const unsigned char *>(right));
+  // Page boundry check fallback to generic version
+  if (LIBC_UNLIKELY((reinterpret_cast<uintptr_t>(left) & 4095) > 4088 ||
+                    (reinterpret_cast<uintptr_t>(right) & 4095) > 4088)) {
+    for (; *left && !comp(*left, *right); ++left, ++right)
+      ;
+    return comp(static_cast<unsigned char>(*left),
+                static_cast<unsigned char>(*right));
+  }
+  while (1) {
+    uint64_t val1 = load(left);
+    uint64_t val2 = load(right);
+    uint64_t diff = val1 ^ val2;
+    uint64_t null_mask = is_null_terminated(val1);
+    // Check for character mismatch or null terminator
+    uint64_t zero_or_diff = diff | null_mask;
+    if (zero_or_diff != 0) {
+      size_t byte_pos = __builtin_ctzll(zero_or_diff) >> 3;
+      unsigned char c1 = static_cast<unsigned char>(left[byte_pos]);
+      unsigned char c2 = static_cast<unsigned char>(right[byte_pos]);
+      return comp(c1, c2);
+    }
+    left += 8;
+    right += 8;
+  }
 }
 
 template <typename Comp>
@@ -31,14 +62,43 @@ LIBC_INLINE constexpr int inline_strncmp(const char *left, const char *right,
   if (n == 0)
     return 0;
 
-  // TODO: Look at benefits for comparing words at a time.
-  for (; n > 1; --n, ++left, ++right) {
+  if (LIBC_UNLIKELY((reinterpret_cast<uintptr_t>(left) & 4095) > 4088 ||
+                    (reinterpret_cast<uintptr_t>(right) & 4095) > 4088)) {
+    for (; n > 1; --n, ++left, ++right) {
+      char lc = *left;
+      if (!comp(lc, '\0') || comp(lc, *right))
+        break;
+    }
+    return comp(static_cast<unsigned char>(*left),
+                static_cast<unsigned char>(*right));
+  }
+
+  for (; n >= 8; n -= 8, left += 8, right += 8) {
+    uint64_t val1 = load(left);
+    uint64_t val2 = load(right);
+    uint64_t diff = val1 ^ val2;
+    uint64_t null_mask = is_null_terminated(val1);
+
+    uint64_t zero_or_diff = diff | null_mask;
+    if (zero_or_diff != 0) {
+      size_t byte_pos = __builtin_ctzll(zero_or_diff) >> 3;
+      // If the difference happens past 'n' remaining bytes, they are equal up
+      // to n
+      if (byte_pos >= n)
+        return 0;
+      unsigned char c1 = static_cast<unsigned char>(left[byte_pos]);
+      unsigned char c2 = static_cast<unsigned char>(right[byte_pos]);
+      return comp(c1, c2);
+    }
+  }
+  // Handle remaining 8 bytes if not found in the first loop
+  for (; n > 1; n--, ++left, ++right) {
     char lc = *left;
     if (!comp(lc, '\0') || comp(lc, *right))
       break;
   }
-  return comp(*reinterpret_cast<const unsigned char *>(left),
-              *reinterpret_cast<const unsigned char *>(right));
+  return comp(static_cast<unsigned char>(*left),
+              static_cast<unsigned char>(*right));
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/string/memory_utils/inline_strcmp.h
+++ b/libc/src/string/memory_utils/inline_strcmp.h
@@ -17,6 +17,9 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
+constexpr int PAGE_MASK = 4095;
+constexpr int PAGE_SAFE_OFFSET = 4088;
+
 LIBC_INLINE uint64_t is_null_terminated(uint64_t v) {
   return (v - 0x0101010101010101ULL) & ~v & 0x8080808080808080ULL;
 }
@@ -31,8 +34,10 @@ template <typename Comp>
 LIBC_INLINE constexpr int inline_strcmp(const char *left, const char *right,
                                         Comp &&comp) {
   // Page boundry check fallback to generic version
-  if (LIBC_UNLIKELY((reinterpret_cast<uintptr_t>(left) & 4095) > 4088 ||
-                    (reinterpret_cast<uintptr_t>(right) & 4095) > 4088)) {
+  if (LIBC_UNLIKELY((reinterpret_cast<uintptr_t>(left) & PAGE_MASK) >
+                        PAGE_SAFE_OFFSET ||
+                    (reinterpret_cast<uintptr_t>(right) & PAGE_MASK) >
+                        PAGE_SAFE_OFFSET)) {
     for (; *left && !comp(*left, *right); ++left, ++right)
       ;
     return comp(static_cast<unsigned char>(*left),
@@ -73,7 +78,9 @@ LIBC_INLINE constexpr int inline_strncmp(const char *left, const char *right,
                 static_cast<unsigned char>(*right));
   }
 
-  for (; n >= 8; n -= 8, left += 8, right += 8) {
+  constexpr size_t block_size = sizeof(uint64_t) / 8;
+  for (; n >= block_size;
+       n -= block_size, left += block_size, right += block_size) {
     uint64_t val1 = load(left);
     uint64_t val2 = load(right);
     uint64_t diff = val1 ^ val2;


### PR DESCRIPTION
Check 8 bytes at a time for strcmp and strncmp by loading
the string to a uint64_t variable then checking for null
termination and any potential mismatches between the two strings.

With this SWAR technique it was roughly 35% faster than
glibc on smaller sub 64 bytes strings, tested on zen 2
with -O3 but march was set to the default x86_64 and the
compiler was gcc 16.1
