### PR TITLE
Rename Compiler-RT target to compiler-rt in CMake files

### DIFF
--- a/compiler-rt/CMakeLists.txt
+++ b/compiler-rt/CMakeLists.txt
@@ -12,7 +12,7 @@ if("${CMAKE_VERSION}" VERSION_LESS "3.31.0")
     "at least 3.31.0 now to avoid issues in the future.")
 endif()
 
-set(LLVM_SUBPROJECT_TITLE "Compiler-RT")
+set(LLVM_SUBPROJECT_TITLE "compiler-rt")
 
 if(NOT DEFINED LLVM_COMMON_CMAKE_UTILS)
   set(LLVM_COMMON_CMAKE_UTILS ${CMAKE_CURRENT_SOURCE_DIR}/../cmake)

--- a/compiler-rt/cmake/Modules/AddCompilerRT.cmake
+++ b/compiler-rt/cmake/Modules/AddCompilerRT.cmake
@@ -91,7 +91,7 @@ function(add_compiler_rt_object_libraries name)
       ${extra_cflags_${libname}} ${target_flags})
     set_property(TARGET ${libname} APPEND PROPERTY
       COMPILE_DEFINITIONS ${LIB_DEFS})
-    set_target_properties(${libname} PROPERTIES FOLDER "Compiler-RT/Libraries")
+    set_target_properties(${libname} PROPERTIES FOLDER "compiler-rt/Libraries")
     if(APPLE)
       set_target_properties(${libname} PROPERTIES
         OSX_ARCHITECTURES "${LIB_ARCHS_${libname}}")
@@ -110,7 +110,7 @@ endmacro()
 
 function(add_compiler_rt_component name)
   add_custom_target(${name})
-  set_target_properties(${name} PROPERTIES FOLDER "Compiler-RT/Components")
+  set_target_properties(${name} PROPERTIES FOLDER "compiler-rt/Components")
   if(COMMAND runtime_register_component)
     runtime_register_component(${name})
   endif()
@@ -302,7 +302,7 @@ function(add_compiler_rt_runtime name type)
     if(NOT TARGET ${LIB_PARENT_TARGET})
       add_custom_target(${LIB_PARENT_TARGET})
       set_target_properties(${LIB_PARENT_TARGET} PROPERTIES
-                            FOLDER "Compiler-RT/Runtimes")
+                            FOLDER "compiler-rt/Runtimes")
     endif()
   endif()
 
@@ -357,7 +357,7 @@ function(add_compiler_rt_runtime name type)
           DEPENDS ${sources_${libname}}
           COMMENT "Building C object ${output_file_${libname}}")
       add_custom_target(${libname} DEPENDS ${output_dir_${libname}}/${output_file_${libname}})
-      set_target_properties(${libname} PROPERTIES FOLDER "Compiler-RT/Codegenning")
+      set_target_properties(${libname} PROPERTIES FOLDER "compiler-rt/Codegenning")
       install(FILES ${output_dir_${libname}}/${output_file_${libname}}
         DESTINATION ${install_dir_${libname}}
         ${COMPONENT_OPTION})
@@ -387,7 +387,7 @@ function(add_compiler_rt_runtime name type)
     endif()
     set_target_properties(${libname} PROPERTIES
         OUTPUT_NAME ${output_name_${libname}}
-        FOLDER "Compiler-RT/Runtimes")
+        FOLDER "compiler-rt/Runtimes")
     if(LIB_LINK_LIBS)
       target_link_libraries(${libname} PRIVATE ${LIB_LINK_LIBS})
     endif()
@@ -558,7 +558,7 @@ function(add_compiler_rt_test test_suite test_name arch)
     DEPENDS ${TEST_DEPS}
     )
   add_custom_target(T${test_name} DEPENDS "${output_bin}")
-  set_target_properties(T${test_name} PROPERTIES FOLDER "Compiler-RT/Tests")
+  set_target_properties(T${test_name} PROPERTIES FOLDER "compiler-rt/Tests")
 
   # Make the test suite depend on the binary.
   add_dependencies(${test_suite} T${test_name})
@@ -592,7 +592,7 @@ macro(add_compiler_rt_cfg target_name file_name component arch)
     COMPONENT ${component})
   add_dependencies(${component} ${target_name})
 
-  set_target_properties(${target_name} PROPERTIES FOLDER "Compiler-RT Misc")
+  set_target_properties(${target_name} PROPERTIES FOLDER "compiler-rt Misc")
 endmacro()
 
 # Builds custom version of libc++ and installs it in <prefix>.
@@ -628,7 +628,7 @@ macro(add_custom_libcxx name prefix)
     COMMENT "Clobbering ${name} build directories"
     USES_TERMINAL
     )
-  set_target_properties(${name}-clear PROPERTIES FOLDER "Compiler-RT/Metatargets")
+  set_target_properties(${name}-clear PROPERTIES FOLDER "compiler-rt/Metatargets")
 
   add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${name}-clobber-stamp
@@ -640,7 +640,7 @@ macro(add_custom_libcxx name prefix)
 
   add_custom_target(${name}-clobber
     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${name}-clobber-stamp)
-  set_target_properties(${name}-clobber PROPERTIES FOLDER "Compiler-RT/Metatargets")
+  set_target_properties(${name}-clobber PROPERTIES FOLDER "compiler-rt/Metatargets")
 
   set(PASSTHROUGH_VARIABLES
     ANDROID

--- a/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
@@ -339,7 +339,7 @@ macro(darwin_add_builtin_library name suffix)
 
   list(APPEND ${LIB_OS}_${suffix}_libs ${libname})
   list(APPEND ${LIB_OS}_${suffix}_lipo_flags -arch ${arch} $<TARGET_FILE:${libname}>)
-  set_target_properties(${libname} PROPERTIES FOLDER "Compiler-RT/Libraries")
+  set_target_properties(${libname} PROPERTIES FOLDER "compiler-rt/Libraries")
 endmacro()
 
 function(darwin_lipo_libs name)
@@ -358,7 +358,7 @@ function(darwin_lipo_libs name)
       )
     add_custom_target(${name}
       DEPENDS ${LIB_OUTPUT_DIR}/lib${name}.a)
-    set_target_properties(${name} PROPERTIES FOLDER "Compiler-RT/Misc")
+    set_target_properties(${name} PROPERTIES FOLDER "compiler-rt/Misc")
     add_dependencies(${LIB_PARENT_TARGET} ${name})
 
     if(CMAKE_CONFIGURATION_TYPES)

--- a/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
@@ -591,9 +591,9 @@ function(add_compiler_rt_install_targets name)
                               -DCMAKE_INSTALL_DO_STRIP=1
                               -P "${CMAKE_BINARY_DIR}/cmake_install.cmake")
     set_target_properties(install-${ARG_PARENT_TARGET} PROPERTIES
-                          FOLDER "Compiler-RT/Installation")
+                          FOLDER "compiler-rt/Installation")
     set_target_properties(install-${ARG_PARENT_TARGET}-stripped PROPERTIES
-                          FOLDER "Compiler-RT/Installation")
+                          FOLDER "compiler-rt/Installation")
     add_dependencies(install-compiler-rt install-${ARG_PARENT_TARGET})
     add_dependencies(install-compiler-rt-stripped install-${ARG_PARENT_TARGET}-stripped)
   endif()

--- a/compiler-rt/cmake/base-config-ix.cmake
+++ b/compiler-rt/cmake/base-config-ix.cmake
@@ -41,13 +41,13 @@ endif()
 add_custom_target(compiler-rt ALL)
 add_custom_target(install-compiler-rt)
 add_custom_target(install-compiler-rt-stripped)
-set_property(TARGET compiler-rt PROPERTY FOLDER "Compiler-RT/Metatargets")
+set_property(TARGET compiler-rt PROPERTY FOLDER "compiler-rt/Metatargets")
 set_property(
   TARGET
     install-compiler-rt
     install-compiler-rt-stripped
   PROPERTY
-    FOLDER "Compiler-RT/Installation"
+    FOLDER "compiler-rt/Installation"
 )
 
 # Setting these variables from an LLVM build is sufficient that compiler-rt can

--- a/compiler-rt/include/CMakeLists.txt
+++ b/compiler-rt/include/CMakeLists.txt
@@ -82,7 +82,7 @@ endforeach( f )
 
 add_custom_target(compiler-rt-headers ALL DEPENDS ${out_files})
 add_dependencies(compiler-rt compiler-rt-headers)
-set_target_properties(compiler-rt-headers PROPERTIES FOLDER "Compiler-RT/Resources")
+set_target_properties(compiler-rt-headers PROPERTIES FOLDER "compiler-rt/Resources")
 
 # Install sanitizer headers.
 install(FILES ${SANITIZER_HEADERS}

--- a/compiler-rt/lib/asan/tests/CMakeLists.txt
+++ b/compiler-rt/lib/asan/tests/CMakeLists.txt
@@ -120,15 +120,15 @@ append_list_if(COMPILER_RT_HAS_LIBLOG log ASAN_UNITTEST_NOINST_LIBS)
 
 # Main AddressSanitizer unit tests.
 add_custom_target(AsanUnitTests)
-set_target_properties(AsanUnitTests PROPERTIES FOLDER "Compiler-RT/Tests")
+set_target_properties(AsanUnitTests PROPERTIES FOLDER "compiler-rt/Tests")
 
 # AddressSanitizer unit tests with dynamic runtime (on platforms where it's
 # not the default).
 add_custom_target(AsanDynamicUnitTests)
-set_target_properties(AsanDynamicUnitTests PROPERTIES FOLDER "Compiler-RT/Tests")
+set_target_properties(AsanDynamicUnitTests PROPERTIES FOLDER "compiler-rt/Tests")
 # ASan benchmarks (not actively used now).
 add_custom_target(AsanBenchmarks)
-set_target_properties(AsanBenchmarks PROPERTIES FOLDER "Compiler-RT/Tests")
+set_target_properties(AsanBenchmarks PROPERTIES FOLDER "compiler-rt/Tests")
 
 set(ASAN_NOINST_TEST_SOURCES
   ${COMPILER_RT_GTEST_SOURCE}
@@ -291,7 +291,7 @@ if(COMPILER_RT_CAN_EXECUTE_TESTS AND NOT ANDROID)
     add_library(${ASAN_TEST_RUNTIME} STATIC ${ASAN_TEST_RUNTIME_OBJECTS})
     set_target_properties(${ASAN_TEST_RUNTIME} PROPERTIES
       ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-      FOLDER "Compiler-RT/Tests/Runtime")
+      FOLDER "compiler-rt/Tests/Runtime")
 
     add_asan_tests(${arch} ${ASAN_TEST_RUNTIME} KIND "-inline")
     add_asan_tests(${arch} ${ASAN_TEST_RUNTIME} KIND "-calls"

--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -1020,7 +1020,7 @@ set(ve_SOURCES
 set(m68k_SOURCES ${GENERIC_SOURCES})
 
 add_custom_target(builtins)
-set_target_properties(builtins PROPERTIES FOLDER "Compiler-RT/Metatargets")
+set_target_properties(builtins PROPERTIES FOLDER "compiler-rt/Metatargets")
 
 option(COMPILER_RT_ENABLE_SOFTWARE_INT128
   "Enable the int128 builtin routines for all targets."

--- a/compiler-rt/lib/ctx_profile/tests/CMakeLists.txt
+++ b/compiler-rt/lib/ctx_profile/tests/CMakeLists.txt
@@ -62,7 +62,7 @@ macro (add_ctx_profile_tests_for_arch arch)
   add_library(${CTX_PROFILE_TEST_RUNTIME} STATIC ${CTX_PROFILE_TEST_RUNTIME_OBJECTS})
   set_target_properties(${CTX_PROFILE_TEST_RUNTIME} PROPERTIES
     ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    FOLDER "Compiler-RT Runtime tests")
+    FOLDER "compiler-rt Runtime tests")
   set(CTX_PROFILE_TEST_OBJECTS)
   generate_compiler_rt_tests(CTX_PROFILE_TEST_OBJECTS
     CtxProfileUnitTests "CtxProfile-${arch}-UnitTest" ${arch}
@@ -75,7 +75,7 @@ macro (add_ctx_profile_tests_for_arch arch)
 endmacro()
 
 add_custom_target(CtxProfileUnitTests)
-set_target_properties(CtxProfileUnitTests PROPERTIES FOLDER "Compiler-RT Tests")
+set_target_properties(CtxProfileUnitTests PROPERTIES FOLDER "compiler-rt Tests")
 if(COMPILER_RT_CAN_EXECUTE_TESTS AND COMPILER_RT_DEFAULT_TARGET_ARCH IN_LIST CTX_PROFILE_SUPPORTED_ARCH)
   # CtxProfile unit tests are only run on the host machine.
   foreach(arch ${COMPILER_RT_DEFAULT_TARGET_ARCH})

--- a/compiler-rt/lib/fuzzer/tests/CMakeLists.txt
+++ b/compiler-rt/lib/fuzzer/tests/CMakeLists.txt
@@ -12,10 +12,10 @@ if (APPLE)
 endif()
 
 add_custom_target(FuzzerUnitTests)
-set_target_properties(FuzzerUnitTests PROPERTIES FOLDER "Compiler-RT/Tests")
+set_target_properties(FuzzerUnitTests PROPERTIES FOLDER "compiler-rt/Tests")
 
 add_custom_target(FuzzedDataProviderUnitTests)
-set_target_properties(FuzzedDataProviderUnitTests PROPERTIES FOLDER "Compiler-RT/Tests")
+set_target_properties(FuzzedDataProviderUnitTests PROPERTIES FOLDER "compiler-rt/Tests")
 
 set(LIBFUZZER_UNITTEST_LINK_FLAGS ${COMPILER_RT_UNITTEST_LINK_FLAGS})
 list(APPEND LIBFUZZER_UNITTEST_LINK_FLAGS --driver-mode=g++)
@@ -79,7 +79,7 @@ if(COMPILER_RT_DEFAULT_TARGET_ARCH IN_LIST FUZZER_SUPPORTED_ARCH)
     ${LIBFUZZER_TEST_RUNTIME_OBJECTS})
   set_target_properties(${LIBFUZZER_TEST_RUNTIME} PROPERTIES
     ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    FOLDER "Compiler-RT/Tests/Runtime")
+    FOLDER "compiler-rt/Tests/Runtime")
 
   if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND
      COMPILER_RT_LIBCXX_PATH AND

--- a/compiler-rt/lib/gwp_asan/tests/CMakeLists.txt
+++ b/compiler-rt/lib/gwp_asan/tests/CMakeLists.txt
@@ -37,7 +37,7 @@ set(GWP_ASAN_UNIT_TEST_HEADERS
   harness.h)
 
 add_custom_target(GwpAsanUnitTests)
-set_target_properties(GwpAsanUnitTests PROPERTIES FOLDER "Compiler-RT/Tests")
+set_target_properties(GwpAsanUnitTests PROPERTIES FOLDER "compiler-rt/Tests")
 
 set(GWP_ASAN_UNITTEST_LINK_FLAGS
   ${COMPILER_RT_UNITTEST_LINK_FLAGS} -ldl
@@ -69,7 +69,7 @@ if(COMPILER_RT_DEFAULT_TARGET_ARCH IN_LIST GWP_ASAN_SUPPORTED_ARCH)
 
   set_target_properties(${GWP_ASAN_TEST_RUNTIME} PROPERTIES
     ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    FOLDER "Compiler-RT/Tests/Runtime")
+    FOLDER "compiler-rt/Tests/Runtime")
 
   set(GwpAsanTestObjects)
   generate_compiler_rt_tests(GwpAsanTestObjects

--- a/compiler-rt/lib/interception/tests/CMakeLists.txt
+++ b/compiler-rt/lib/interception/tests/CMakeLists.txt
@@ -81,7 +81,7 @@ macro(add_interceptor_lib library)
   add_library(${library} STATIC ${ARGN})
   set_target_properties(${library} PROPERTIES
     ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    FOLDER "Compiler-RT/Tests/Runtime")
+    FOLDER "compiler-rt/Tests/Runtime")
 endmacro()
 
 function(get_interception_lib_for_arch arch lib)
@@ -96,7 +96,7 @@ endfunction()
 # Interception unit tests testsuite.
 add_custom_target(InterceptionUnitTests)
 set_target_properties(InterceptionUnitTests PROPERTIES
-  FOLDER "Compiler-RT/Tests")
+  FOLDER "compiler-rt/Tests")
 
 # Adds interception tests for architecture.
 macro(add_interception_tests_for_arch arch)

--- a/compiler-rt/lib/memprof/tests/CMakeLists.txt
+++ b/compiler-rt/lib/memprof/tests/CMakeLists.txt
@@ -66,7 +66,7 @@ macro(add_memprof_tests_for_arch arch)
   add_library(${MEMPROF_TEST_RUNTIME} STATIC ${MEMPROF_TEST_RUNTIME_OBJECTS})
   set_target_properties(${MEMPROF_TEST_RUNTIME} PROPERTIES
     ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    FOLDER "Compiler-RT/Tests/Runtime")
+    FOLDER "compiler-rt/Tests/Runtime")
   set(MEMPROF_TEST_OBJECTS)
   generate_compiler_rt_tests(MEMPROF_TEST_OBJECTS
     MemProfUnitTests "MemProf-${arch}-UnitTest" ${arch}
@@ -80,7 +80,7 @@ endmacro()
 
 # MemProf unit tests testsuite.
 add_custom_target(MemProfUnitTests)
-set_target_properties(MemProfUnitTests PROPERTIES FOLDER "Compiler-RT/Tests")
+set_target_properties(MemProfUnitTests PROPERTIES FOLDER "compiler-rt/Tests")
 if(COMPILER_RT_CAN_EXECUTE_TESTS AND COMPILER_RT_DEFAULT_TARGET_ARCH IN_LIST MEMPROF_SUPPORTED_ARCH)
   # MemProf unit tests are only run on the host machine.
   foreach(arch ${COMPILER_RT_DEFAULT_TARGET_ARCH})

--- a/compiler-rt/lib/orc/tests/CMakeLists.txt
+++ b/compiler-rt/lib/orc/tests/CMakeLists.txt
@@ -4,11 +4,11 @@ include_directories(..)
 
 # Unit tests target.
 add_custom_target(OrcRTUnitTests)
-set_target_properties(OrcRTUnitTests PROPERTIES FOLDER "Compiler-RT/Tests")
+set_target_properties(OrcRTUnitTests PROPERTIES FOLDER "compiler-rt/Tests")
 
 # Testing tools target.
 add_custom_target(OrcRTTools)
-set_target_properties(OrcRTTools PROPERTIES FOLDER "Compiler-RT/Tools")
+set_target_properties(OrcRTTools PROPERTIES FOLDER "compiler-rt/Tools")
 
 set(ORC_UNITTEST_CFLAGS
 # FIXME: This should be set for all unit tests.
@@ -22,7 +22,7 @@ function(add_orc_lib library)
   add_library(${library} STATIC ${ARGN})
   set_target_properties(${library} PROPERTIES
     ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    FOLDER "Compiler-RT/Tests/Runtime")
+    FOLDER "compiler-rt/Tests/Runtime")
 endfunction()
 
 function(get_orc_lib_for_arch arch lib)

--- a/compiler-rt/lib/rtsan/tests/CMakeLists.txt
+++ b/compiler-rt/lib/rtsan/tests/CMakeLists.txt
@@ -29,7 +29,7 @@ set(RTSAN_UNITTEST_HEADERS
     rtsan_test_utilities.h)
 
 add_custom_target(RtsanUnitTests)
-set_target_properties(RtsanUnitTests PROPERTIES FOLDER "Compiler-RT Tests")
+set_target_properties(RtsanUnitTests PROPERTIES FOLDER "compiler-rt Tests")
 
 set(RTSAN_UNITTEST_LINK_FLAGS
   ${COMPILER_RT_UNITTEST_LINK_FLAGS}
@@ -111,7 +111,7 @@ foreach(arch ${RTSAN_TEST_ARCH})
   add_library(${RTSAN_TEST_RUNTIME} STATIC ${RTSAN_TEST_RUNTIME_OBJECTS})
   set_target_properties(${RTSAN_TEST_RUNTIME} PROPERTIES
       ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-      FOLDER "Compiler-RT Runtime tests")
+      FOLDER "compiler-rt Runtime tests")
 
   set(RtsanNoInstTestObjects)
   generate_compiler_rt_tests(RtsanNoInstTestObjects

--- a/compiler-rt/lib/sanitizer_common/tests/CMakeLists.txt
+++ b/compiler-rt/lib/sanitizer_common/tests/CMakeLists.txt
@@ -147,7 +147,7 @@ macro(add_sanitizer_common_lib library)
   add_library(${library} STATIC ${ARGN})
   set_target_properties(${library} PROPERTIES
     ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    FOLDER "Compiler-RT/Tests/Runtime")
+    FOLDER "compiler-rt/Tests/Runtime")
 endmacro()
 
 function(get_sanitizer_common_lib_for_arch arch lib)
@@ -161,7 +161,7 @@ endfunction()
 
 # Sanitizer_common unit tests testsuite.
 add_custom_target(SanitizerUnitTests)
-set_target_properties(SanitizerUnitTests PROPERTIES FOLDER "Compiler-RT/Tests")
+set_target_properties(SanitizerUnitTests PROPERTIES FOLDER "compiler-rt/Tests")
 
 # Adds sanitizer tests for architecture.
 macro(add_sanitizer_tests_for_arch arch)

--- a/compiler-rt/lib/sanitizer_ignorelists/CMakeLists.txt
+++ b/compiler-rt/lib/sanitizer_ignorelists/CMakeLists.txt
@@ -24,7 +24,7 @@ foreach(file_name ${SANITIZER_IGNORELIST_FILES})
 endforeach()
 
 add_custom_target(sanitizer-ignorelist-files DEPENDS ${sanitizer_ignorelist_outputs})
-set_target_properties(sanitizer-ignorelist-files PROPERTIES FOLDER "Compiler-RT/Resources")
+set_target_properties(sanitizer-ignorelist-files PROPERTIES FOLDER "compiler-rt/Resources")
 add_dependencies(sanitizer-ignorelists sanitizer-ignorelist-files)
 
 # Install in the Clang resource directory. No -stripped variant: the ignorelists
@@ -40,6 +40,6 @@ add_custom_target(install-sanitizer-ignorelists
           -DCMAKE_INSTALL_COMPONENT=sanitizer-ignorelists
           -P "${CMAKE_BINARY_DIR}/cmake_install.cmake")
 set_target_properties(install-sanitizer-ignorelists PROPERTIES
-  FOLDER "Compiler-RT/Installation")
+  FOLDER "compiler-rt/Installation")
 add_dependencies(install-compiler-rt install-sanitizer-ignorelists)
 add_dependencies(install-compiler-rt-stripped install-sanitizer-ignorelists)

--- a/compiler-rt/lib/scudo/standalone/tests/CMakeLists.txt
+++ b/compiler-rt/lib/scudo/standalone/tests/CMakeLists.txt
@@ -2,7 +2,7 @@ include_directories(..)
 
 add_custom_target(ScudoUnitTests)
 set_target_properties(ScudoUnitTests PROPERTIES
-  FOLDER "Compiler-RT Tests")
+  FOLDER "compiler-rt Tests")
 
 set(SCUDO_UNITTEST_CFLAGS
   ${COMPILER_RT_UNITTEST_CFLAGS}

--- a/compiler-rt/lib/stats/CMakeLists.txt
+++ b/compiler-rt/lib/stats/CMakeLists.txt
@@ -4,7 +4,7 @@ set(STATS_HEADERS
 include_directories(..)
 
 add_custom_target(stats)
-set_target_properties(stats PROPERTIES FOLDER "Compiler-RT/Metatargets")
+set_target_properties(stats PROPERTIES FOLDER "compiler-rt/Metatargets")
 
 if(APPLE)
   set(STATS_LIB_FLAVOR SHARED)

--- a/compiler-rt/lib/tsan/CMakeLists.txt
+++ b/compiler-rt/lib/tsan/CMakeLists.txt
@@ -36,7 +36,7 @@ if(COMPILER_RT_LIBCXX_PATH AND
   endforeach()
 
   add_custom_target(libcxx_tsan DEPENDS ${libcxx_tsan_deps})
-  set_target_properties(libcxx_tsan PROPERTIES FOLDER "Compiler-RT/Metatargets")
+  set_target_properties(libcxx_tsan PROPERTIES FOLDER "compiler-rt/Metatargets")
 endif()
 
 if(COMPILER_RT_INCLUDE_TESTS)

--- a/compiler-rt/lib/tsan/dd/CMakeLists.txt
+++ b/compiler-rt/lib/tsan/dd/CMakeLists.txt
@@ -20,7 +20,7 @@ append_list_if(COMPILER_RT_HAS_LIBRT rt DD_LINKLIBS)
 append_list_if(COMPILER_RT_HAS_LIBPTHREAD pthread DD_LINKLIBS)
 
 add_custom_target(dd)
-set_target_properties(dd PROPERTIES FOLDER "Compiler-RT/Metatargets")
+set_target_properties(dd PROPERTIES FOLDER "compiler-rt/Metatargets")
 
 # Deadlock detector is currently supported on 64-bit Linux only.
 if(CAN_TARGET_x86_64 AND UNIX AND NOT APPLE AND NOT ANDROID)

--- a/compiler-rt/lib/tsan/rtl/CMakeLists.txt
+++ b/compiler-rt/lib/tsan/rtl/CMakeLists.txt
@@ -168,7 +168,7 @@ if(APPLE)
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../go
     COMMENT "Checking TSan Go runtime..."
     VERBATIM)
-  set_target_properties(GotsanRuntimeCheck PROPERTIES FOLDER "Compiler-RT/Misc")
+  set_target_properties(GotsanRuntimeCheck PROPERTIES FOLDER "compiler-rt/Misc")
 else()
   foreach(arch ${TSAN_SUPPORTED_ARCH})
     if(arch STREQUAL "x86_64")

--- a/compiler-rt/lib/tsan/tests/CMakeLists.txt
+++ b/compiler-rt/lib/tsan/tests/CMakeLists.txt
@@ -2,7 +2,7 @@ include_directories(../rtl)
 
 add_custom_target(TsanUnitTests)
 set_target_properties(TsanUnitTests PROPERTIES
-  FOLDER "Compiler-RT Tests")
+  FOLDER "compiler-rt Tests")
 
 set(TSAN_UNITTEST_CFLAGS
   ${COMPILER_RT_UNITTEST_CFLAGS}

--- a/compiler-rt/lib/xray/tests/CMakeLists.txt
+++ b/compiler-rt/lib/xray/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 include_directories(..)
 
 add_custom_target(XRayUnitTests)
-set_target_properties(XRayUnitTests PROPERTIES FOLDER "Compiler-RT/Tests")
+set_target_properties(XRayUnitTests PROPERTIES FOLDER "compiler-rt/Tests")
 
 # Sanity check XRAY_ALL_SOURCE_FILES_ABS_PATHS
 list(LENGTH XRAY_ALL_SOURCE_FILES_ABS_PATHS XASFAP_LENGTH)
@@ -34,7 +34,7 @@ function(add_xray_lib library)
   add_library(${library} STATIC ${ARGN})
   set_target_properties(${library} PROPERTIES
     ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    FOLDER "Compiler-RT/Tests/Runtime")
+    FOLDER "compiler-rt/Tests/Runtime")
 endfunction()
 
 function(get_xray_lib_for_arch arch lib)

--- a/compiler-rt/test/CMakeLists.txt
+++ b/compiler-rt/test/CMakeLists.txt
@@ -176,7 +176,7 @@ endif()
 # introduce a rule to run to run all of them.
 get_property(LLVM_COMPILER_RT_LIT_DEPENDS GLOBAL PROPERTY LLVM_COMPILER_RT_LIT_DEPENDS)
 add_custom_target(compiler-rt-test-depends)
-set_target_properties(compiler-rt-test-depends PROPERTIES FOLDER "Compiler-RT/Tests")
+set_target_properties(compiler-rt-test-depends PROPERTIES FOLDER "compiler-rt/Tests")
 if(LLVM_COMPILER_RT_LIT_DEPENDS)
   add_dependencies(compiler-rt-test-depends ${LLVM_COMPILER_RT_LIT_DEPENDS})
 endif()

--- a/compiler-rt/test/ctx_profile/CMakeLists.txt
+++ b/compiler-rt/test/ctx_profile/CMakeLists.txt
@@ -38,4 +38,4 @@ endforeach()
 add_lit_testsuite(check-ctx_profile "Running the Contextual Profiler tests"
   ${CTX_PROFILE_TESTSUITES}
   DEPENDS ${CTX_PROFILE_TEST_DEPS})
-set_target_properties(check-ctx_profile PROPERTIES FOLDER "Compiler-RT Misc")
+set_target_properties(check-ctx_profile PROPERTIES FOLDER "compiler-rt Misc")

--- a/compiler-rt/test/rtsan/CMakeLists.txt
+++ b/compiler-rt/test/rtsan/CMakeLists.txt
@@ -40,4 +40,4 @@ endif()
 add_lit_testsuite(check-rtsan "Running the Rtsan tests"
   ${RTSAN_TESTSUITES}
   DEPENDS ${RTSAN_TEST_DEPS})
-set_target_properties(check-rtsan PROPERTIES FOLDER "Compiler-RT Misc")
+set_target_properties(check-rtsan PROPERTIES FOLDER "compiler-rt Misc")

--- a/compiler-rt/test/scudo/standalone/CMakeLists.txt
+++ b/compiler-rt/test/scudo/standalone/CMakeLists.txt
@@ -16,4 +16,4 @@ add_lit_testsuite(check-scudo_standalone
   DEPENDS ${SCUDO_STANDALONE_TEST_DEPS})
 
 set_target_properties(check-scudo_standalone
-  PROPERTIES FOLDER "Compiler-RT Tests")
+  PROPERTIES FOLDER "compiler-rt Tests")

--- a/compiler-rt/test/tsan/CMakeLists.txt
+++ b/compiler-rt/test/tsan/CMakeLists.txt
@@ -132,7 +132,7 @@ endif()
 add_lit_testsuite(check-tsan "Running ThreadSanitizer tests"
   ${TSAN_TESTSUITES}
   DEPENDS ${TSAN_TEST_DEPS})
-set_target_properties(check-tsan PROPERTIES FOLDER "Compiler-RT Tests")
+set_target_properties(check-tsan PROPERTIES FOLDER "compiler-rt Tests")
 
 if(COMPILER_RT_TSAN_HAS_STATIC_RUNTIME)
   add_lit_testsuite(check-tsan-dynamic "Running the ThreadSanitizer tests with dynamic runtime"

--- a/compiler-rt/test/tysan/CMakeLists.txt
+++ b/compiler-rt/test/tysan/CMakeLists.txt
@@ -27,4 +27,4 @@ add_lit_testsuite(check-tysan "Running the TypeSanitizer tests"
   ${TYSAN_TESTSUITES}
   DEPENDS ${TYSAN_TEST_DEPS}
   )
-set_target_properties(check-tysan PROPERTIES FOLDER "Compiler-RT Misc")
+set_target_properties(check-tysan PROPERTIES FOLDER "compiler-rt Misc")

--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -159,7 +159,7 @@ function(builtin_default_target compiler_rt_path)
                                                 SANITIZER
                            USE_TOOLCHAIN
                            TARGET_TRIPLE ${LLVM_TARGET_TRIPLE}
-                           FOLDER "Compiler-RT"
+                           FOLDER "compiler-rt"
                            ${EXTRA_ARGS})
 endfunction()
 
@@ -183,7 +183,7 @@ function(builtin_register_target compiler_rt_path name)
                                       ${COMMON_CMAKE_ARGS}
                                       ${${name}_extra_args}
                            USE_TOOLCHAIN
-                           FOLDER "Compiler-RT"
+                           FOLDER "compiler-rt"
                            ${EXTRA_ARGS} ${ARG_EXTRA_ARGS})
 endfunction()
 
@@ -214,7 +214,7 @@ if(compiler_rt_path)
     add_custom_target(install-builtins-stripped)
     set_target_properties(
       builtins install-builtins install-builtins-stripped
-      PROPERTIES FOLDER "Compiler-RT"
+      PROPERTIES FOLDER "compiler-rt"
     )
   endif()
 
@@ -715,7 +715,7 @@ if(build_runtimes)
         add_custom_target(check-builtins)
         set_target_properties(
           check-builtins
-          PROPERTIES FOLDER "Compiler-RT"
+          PROPERTIES FOLDER "compiler-rt"
         )
       endif()
       if(LLVM_RUNTIME_DISTRIBUTION_COMPONENTS)


### PR DESCRIPTION
Visual Studio 2026 has trouble generating valid solutions for projects with mismatching directory names.
The change renames the Compiler-RT target to match the directory name "compiler-rt" in all CMake files.