### PR TITLE
[AA] Add RunEarly support to createExternalAAWrapperPass

### DIFF
--- a/llvm/include/llvm/Analysis/AliasAnalysis.h
+++ b/llvm/include/llvm/Analysis/AliasAnalysis.h
@@ -1116,7 +1116,8 @@ struct ExternalAAWrapperPass : ImmutablePass {
 /// function, and the AAResults object to populate. This should be used when
 /// setting up a custom pass pipeline to inject a hook into the AA results.
 LLVM_ABI ImmutablePass *createExternalAAWrapperPass(
-    std::function<void(Pass &, Function &, AAResults &)> Callback);
+    std::function<void(Pass &, Function &, AAResults &)> Callback,
+    bool RunEarly = false);
 
 } // end namespace llvm
 

--- a/llvm/lib/Analysis/AliasAnalysis.cpp
+++ b/llvm/lib/Analysis/AliasAnalysis.cpp
@@ -786,8 +786,9 @@ INITIALIZE_PASS(ExternalAAWrapperPass, "external-aa", "External Alias Analysis",
                 false, true)
 
 ImmutablePass *
-llvm::createExternalAAWrapperPass(ExternalAAWrapperPass::CallbackT Callback) {
-  return new ExternalAAWrapperPass(std::move(Callback));
+llvm::createExternalAAWrapperPass(ExternalAAWrapperPass::CallbackT Callback,
+                                  bool RunEarly) {
+  return new ExternalAAWrapperPass(std::move(Callback), RunEarly);
 }
 
 AAResultsWrapperPass::AAResultsWrapperPass() : FunctionPass(ID) {}

--- a/llvm/unittests/Analysis/AliasAnalysisTest.cpp
+++ b/llvm/unittests/Analysis/AliasAnalysisTest.cpp
@@ -425,4 +425,32 @@ TEST_F(AAPassInfraTest, injectExternalAA) {
   EXPECT_TRUE(IsCustomAAQueried);
 }
 
+TEST_F(AAPassInfraTest, injectExternalAABeforeBasicAA) {
+  legacy::PassManager PM;
+
+  bool CallbackRan = false;
+  bool RanBeforeBasicAA = false;
+
+  PM.add(createExternalAAWrapperPass(
+      [&](Pass &, Function &F, AAResults &AAR) {
+        CallbackRan = true;
+
+        Value *Ptr = F.getArg(0);
+        LocationSize Size = LocationSize::beforeOrAfterPointer();
+
+        // Before BasicAA is registered, the empty AAResults must return
+        // MayAlias even when the same pointer is queried against itself.
+        RanBeforeBasicAA =
+            AAR.alias(Ptr, Size, Ptr, Size) == AliasResult::MayAlias;
+      },
+      /*RunEarly=*/true));
+
+  // Force AAResultsWrapperPass to run and construct the AA pipeline.
+  PM.add(new AATestPass());
+  PM.run(*M);
+
+  EXPECT_TRUE(CallbackRan);
+  EXPECT_TRUE(RanBeforeBasicAA);
+}
+
 } // end anonymous namspace


### PR DESCRIPTION
Earlier changes introduced RunEarly to control running external AA passes early/late. Though, it missed to allow registering similarly through createExternalAAWrapperPass API, the patch allows the same. This does break ABI compatibility but having two seems overkill for legacy PM.