### PR TITLE
[mlir][bufferization] Bufferize all edges to a repeated successor

### DIFF
--- a/mlir/include/mlir/Dialect/Bufferization/Transforms/Bufferize.h
+++ b/mlir/include/mlir/Dialect/Bufferization/Transforms/Bufferize.h
@@ -51,7 +51,7 @@ LogicalResult bufferizeOp(Operation *op, const BufferizationOptions &options,
 
 /// Bufferize the signature of `block` and its callers (i.e., ops that have the
 /// given block as a successor). All block argument types are changed to memref
-/// types. All corresponding operands of all callers  are wrapped in
+/// types. All corresponding operands of all callers are wrapped in
 /// bufferization.to_buffer ops. All uses of bufferized tensor block arguments
 /// are wrapped in bufferization.to_tensor ops.
 ///

--- a/mlir/lib/Dialect/Bufferization/Transforms/Bufferize.cpp
+++ b/mlir/lib/Dialect/Bufferization/Transforms/Bufferize.cpp
@@ -447,18 +447,18 @@ bufferization::bufferizeBlockSignature(Block *block, RewriterBase &rewriter,
     }
   }
 
-  // Bufferize callers of the block.
-  for (Operation *op : block->getUsers()) {
+  // Bufferize callers of the block. Iterate BlockOperands so each successor
+  // edge is handled once, including when one branch op targets this block more
+  // than once.
+  for (BlockOperand &blockOperand : block->getUses()) {
+    Operation *op = blockOperand.getOwner();
     auto branchOp = dyn_cast<BranchOpInterface>(op);
     if (!branchOp)
       return op->emitOpError("cannot bufferize ops with block references that "
                              "do not implement BranchOpInterface");
 
-    auto it = llvm::find(op->getSuccessors(), block);
-    assert(it != op->getSuccessors().end() && "could find successor");
-    int64_t successorIdx = std::distance(op->getSuccessors().begin(), it);
-
-    SuccessorOperands operands = branchOp.getSuccessorOperands(successorIdx);
+    SuccessorOperands operands =
+        branchOp.getSuccessorOperands(blockOperand.getOperandNumber());
     SmallVector<Value> newOperands;
     for (auto [operand, type] :
          llvm::zip(operands.getForwardedOperands(), newTypes)) {

--- a/mlir/test/Dialect/ControlFlow/one-shot-bufferize.mlir
+++ b/mlir/test/Dialect/ControlFlow/one-shot-bufferize.mlir
@@ -70,3 +70,27 @@ func.func @looping_branches() -> tensor<5xf32> {
 // CHECK: return %[[arg2]]
   func.return %arg2 : tensor<5xf32>
 }
+
+// -----
+
+// Both successors of the cond_br target the same block with different
+// forwarded tensors. Both edges must be bufferized.
+// CHECK-NO-FUNC-LABEL: func @cond_br_repeated_successor(
+//  CHECK-NO-FUNC-SAME:     %[[t1:.*]]: tensor<5xf32>, %[[t2:.*]]: tensor<5xf32>
+//  CHECK-NO-FUNC-DAG:      %[[m1:.*]] = bufferization.to_buffer %[[t1]]
+//  CHECK-NO-FUNC-DAG:      %[[m2:.*]] = bufferization.to_buffer %[[t2]]
+//  CHECK-NO-FUNC:          %[[r:.*]] = scf.execute_region -> memref<5xf32, strided<[?], offset: ?>> {
+//  CHECK-NO-FUNC:            cf.cond_br %{{.*}}, ^[[block:.*]](%[[m1]] : {{.*}}), ^[[block]](%[[m2]] : {{.*}})
+//  CHECK-NO-FUNC:          ^[[block]](%[[arg:.*]]: memref<5xf32, strided<[?], offset: ?>>):
+//  CHECK-NO-FUNC:            scf.yield %[[arg]]
+//  CHECK-NO-FUNC:          }
+//  CHECK-NO-FUNC:          return
+func.func @cond_br_repeated_successor(%t1: tensor<5xf32>, %t2: tensor<5xf32>,
+                                      %c: i1) {
+  %0 = scf.execute_region -> tensor<5xf32> {
+    cf.cond_br %c, ^bb1(%t1 : tensor<5xf32>), ^bb1(%t2 : tensor<5xf32>)
+  ^bb1(%arg1 : tensor<5xf32>):
+    scf.yield %arg1 : tensor<5xf32>
+  }
+  return
+}


### PR DESCRIPTION
bufferizeBlockSignature only rewrote the first successor index that matched the target block. Branch ops such as cf.cond_br can list the same destination more than once, but the later edges were left as tensors and broke multi-block bufferization.

Now we simply iterate the block's BlockOperands so each successor edge is handled once.