### PR TITLE
[scudo] Add check to verify locking is correct.

### DIFF
--- a/compiler-rt/lib/scudo/standalone/linux.cpp
+++ b/compiler-rt/lib/scudo/standalone/linux.cpp
@@ -129,9 +129,15 @@ void HybridMutex::lockSlow() {
             nullptr, nullptr, 0);
     V = atomic_exchange(&M, Sleeping, memory_order_acquire);
   }
+
+  if (SCUDO_DEBUG)
+    assertHeldImpl();
 }
 
 void HybridMutex::unlock() {
+  if (SCUDO_DEBUG)
+    assertHeldImpl();
+
   if (atomic_fetch_sub(&M, 1U, memory_order_release) != Locked) {
     atomic_store(&M, Unlocked, memory_order_release);
     syscall(SYS_futex, reinterpret_cast<uptr>(&M), FUTEX_WAKE_PRIVATE, 1,

--- a/compiler-rt/lib/scudo/standalone/primary32.h
+++ b/compiler-rt/lib/scudo/standalone/primary32.h
@@ -271,11 +271,13 @@ template <typename Config> void SizeClassAllocator32<Config>::unmapTestOnly() {
   uptr MinRegionIndex = NumRegions, MaxRegionIndex = 0;
   for (uptr I = 0; I < NumClasses; I++) {
     SizeClassInfo *Sci = getSizeClassInfo(I);
-    ScopedLock L(Sci->Mutex);
-    if (Sci->MinRegionIndex < MinRegionIndex)
-      MinRegionIndex = Sci->MinRegionIndex;
-    if (Sci->MaxRegionIndex > MaxRegionIndex)
-      MaxRegionIndex = Sci->MaxRegionIndex;
+    {
+      ScopedLock L(Sci->Mutex);
+      if (Sci->MinRegionIndex < MinRegionIndex)
+        MinRegionIndex = Sci->MinRegionIndex;
+      if (Sci->MaxRegionIndex > MaxRegionIndex)
+        MaxRegionIndex = Sci->MaxRegionIndex;
+    }
     *Sci = {};
   }
 


### PR DESCRIPTION
Added checks that at the end of lockSlow, the lock is held and when doing an unlock, the lock is held.

This found a bug in primary32.h:unmapTestOnly where the lock is not held, so fixed that.