### PR TITLE
[NFC] Add missing <cmath> and <limits> includes across llvm, mlir, lldb, flang, and bolt

### DIFF
--- a/bolt/lib/Passes/SplitFunctions.cpp
+++ b/bolt/lib/Passes/SplitFunctions.cpp
@@ -22,6 +22,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/FormatVariadic.h"
 #include <algorithm>
+#include <cmath>
 #include <iterator>
 #include <memory>
 #include <numeric>

--- a/flang/lib/Optimizer/CodeGen/Target.cpp
+++ b/flang/lib/Optimizer/CodeGen/Target.cpp
@@ -17,6 +17,7 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/TypeRange.h"
 #include "llvm/ADT/TypeSwitch.h"
+#include <cmath>
 
 #define DEBUG_TYPE "flang-codegen-target"
 

--- a/lldb/source/Plugins/Language/ObjC/Cocoa.cpp
+++ b/lldb/source/Plugins/Language/ObjC/Cocoa.cpp
@@ -30,6 +30,7 @@
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/bit.h"
 #include "llvm/Support/ErrorExtras.h"
+#include <cmath>
 
 using namespace lldb;
 using namespace lldb_private;

--- a/llvm/lib/Transforms/Utils/Debugify.cpp
+++ b/llvm/lib/Transforms/Utils/Debugify.cpp
@@ -29,6 +29,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/JSON.h"
+#include <cmath>
 #include <optional>
 #if LLVM_ENABLE_DEBUGLOC_TRACKING_ORIGIN
 // We need the Signals header to operate on stacktraces if we're using DebugLoc

--- a/llvm/lib/Transforms/Utils/LowerMemIntrinsics.cpp
+++ b/llvm/lib/Transforms/Utils/LowerMemIntrinsics.cpp
@@ -18,6 +18,7 @@
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
 #include "llvm/Transforms/Utils/LoopUtils.h"
+#include <cmath>
 #include <limits>
 #include <optional>
 

--- a/llvm/tools/llvm-dwarfdump/Statistics.cpp
+++ b/llvm/tools/llvm-dwarfdump/Statistics.cpp
@@ -15,6 +15,8 @@
 #include "llvm/DebugInfo/DWARF/LowLevel/DWARFExpression.h"
 #include "llvm/Object/ObjectFile.h"
 #include "llvm/Support/JSON.h"
+#include <cmath>
+#include <limits>
 
 #define DEBUG_TYPE "dwarfdump"
 using namespace llvm;

--- a/llvm/tools/llvm-exegesis/lib/Analysis.cpp
+++ b/llvm/tools/llvm-exegesis/lib/Analysis.cpp
@@ -12,6 +12,7 @@
 #include "llvm/MC/MCAsmInfo.h"
 #include "llvm/MC/MCTargetOptions.h"
 #include "llvm/Support/FormatVariadic.h"
+#include <cmath>
 #include <limits>
 #include <vector>
 

--- a/llvm/tools/llvm-exegesis/lib/ResultAggregator.cpp
+++ b/llvm/tools/llvm-exegesis/lib/ResultAggregator.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "ResultAggregator.h"
+#include <cmath>
 
 namespace llvm {
 namespace exegesis {

--- a/llvm/tools/llvm-exegesis/lib/SchedClassResolution.cpp
+++ b/llvm/tools/llvm-exegesis/lib/SchedClassResolution.cpp
@@ -13,6 +13,7 @@
 #include "llvm/MCA/Support.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/FormatVariadic.h"
+#include <cmath>
 #include <vector>
 
 #define DEBUG_TYPE "exegesis-sched-class-resolution"

--- a/mlir/include/mlir/Dialect/Quant/Utils/UniformSupport.h
+++ b/mlir/include/mlir/Dialect/Quant/Utils/UniformSupport.h
@@ -9,6 +9,7 @@
 #ifndef MLIR_DIALECT_QUANT_UTILS_UNIFORMSUPPORT_H_
 #define MLIR_DIALECT_QUANT_UTILS_UNIFORMSUPPORT_H_
 
+#include <cmath>
 #include <utility>
 
 #include "mlir/Dialect/Quant/IR/QuantTypes.h"

--- a/mlir/lib/Dialect/LLVMIR/IR/NVVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/NVVMDialect.cpp
@@ -38,6 +38,7 @@
 #include "llvm/Support/NVPTXAddrSpace.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cassert>
+#include <cmath>
 #include <optional>
 #include <string>
 

--- a/mlir/lib/Target/LLVMIR/Dialect/NVVM/NVVMToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/NVVM/NVVMToLLVMIRTranslation.cpp
@@ -22,6 +22,7 @@
 #include "llvm/IR/IntrinsicsNVPTX.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/NVVMAttributes.h"
+#include <cmath>
 
 using namespace mlir;
 using namespace mlir::LLVM;


### PR DESCRIPTION
This is basically a continuation of https://github.com/llvm/llvm-project/pull/214349...

This change adds missing `#include <cmath>` and `#include <limits>` headers to several files across `llvm`, `mlir`, `lldb`, `flang`, and `bolt`.

In commit https://github.com/llvm/llvm-project/commit/ada3786e91ca2058f3ac8255a024c12ae7d263ee, `<random>` stopped transitively pulling in the top-level `<cmath>` header in favor of internal granular `<__math/...>` headers.
Multiple files across the codebase were implicitly relying on transitive `<cmath>` inclusions from headers like `llvm/Support/RandomNumberGenerator.h` and other headers that pull in `<random>`. I'm explicitly adding the missing dependency.

### Affected Files
* **bolt**: `bolt/lib/Passes/SplitFunctions.cpp` (`std::pow`)
* **flang**: `flang/lib/Optimizer/CodeGen/Target.cpp` (`std::ceil`)
* **lldb**: `lldb/source/Plugins/Language/ObjC/Cocoa.cpp` (`std::floor`)
* **llvm**:
  * `llvm/lib/Transforms/Utils/Debugify.cpp` (`std::log10`)
  * `llvm/lib/Transforms/Utils/LowerMemIntrinsics.cpp` (`std::round`)
  * `llvm/tools/llvm-dwarfdump/Statistics.cpp` (`std::round`, `std::numeric_limits`)
  * `llvm/tools/llvm-exegesis/lib/Analysis.cpp` (`std::sqrt`)
  * `llvm/tools/llvm-exegesis/lib/ResultAggregator.cpp` (`std::ceil`)
  * `llvm/tools/llvm-exegesis/lib/SchedClassResolution.cpp` (`std::round`)
* **mlir**:
  * `mlir/include/mlir/Dialect/Quant/Utils/UniformSupport.h` (`std::round`)
  * `mlir/lib/Dialect/LLVMIR/IR/NVVMDialect.cpp` (`std::log2`)
  * `mlir/lib/Target/LLVMIR/Dialect/NVVM/NVVMToLLVMIRTranslation.cpp` (`std::log2`)