### PR TITLE
[SPIR-V] Set MIB insert point before widened type lookup in widenSignSensitiveOps

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVPreLegalizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPreLegalizer.cpp
@@ -573,12 +573,12 @@ static void widenSignSensitiveOps(MachineFunction &MF, SPIRVGlobalRegistry *GR,
                            MachineInstr &MI) -> Register {
     unsigned NewW = widenBitWidthToNextPow2(OldW);
     LLT NewLLT = LLT::scalar(NewW);
+    MIB.setInsertPt(*MI.getParent(), MI.getIterator());
     SPIRVTypeInst SpvTy = GR->getOrCreateSPIRVIntegerType(NewW, MIB);
     Register SExted = MRI.createGenericVirtualRegister(NewLLT);
     GR->assignSPIRVTypeToVReg(SpvTy, SExted, MF);
     MRI.setRegClass(SExted, GR->getRegClass(SpvTy));
     MRI.setType(Reg, NewLLT);
-    MIB.setInsertPt(*MI.getParent(), MI.getIterator());
     MIB.buildSExtInReg(SExted, Reg, OldW);
     return SExted;
   };

--- a/llvm/test/CodeGen/SPIRV/legalization/signed-narrow-int.ll
+++ b/llvm/test/CodeGen/SPIRV/legalization/signed-narrow-int.ll
@@ -251,6 +251,26 @@ define spir_kernel void @trunc_i8_to_i4_icmp_slt(i8 %a, i8 %b, ptr addrspace(1) 
 }
 
 ; ----------------------------------------------------------------------------
+; CHECK: OpFunction
+; CHECK: %[[#GA:]] = OpLoad %[[#I32]]
+; CHECK: %[[#GB:]] = OpLoad %[[#I32]]
+; CHECK: %[[#SHLA8:]] = OpShiftLeftLogical %[[#I32]] %[[#GA]] %[[#K8]]
+; CHECK: %[[#SXA8:]] = OpShiftRightArithmetic %[[#I32]] %[[#SHLA8]] %[[#K8]]
+; CHECK: %[[#SHLB8:]] = OpShiftLeftLogical %[[#I32]] %[[#GB]] %[[#K8]]
+; CHECK: %[[#SXB8:]] = OpShiftRightArithmetic %[[#I32]] %[[#SHLB8]] %[[#K8]]
+; CHECK: OpSDiv %[[#I32]] %[[#SXA8]] %[[#SXB8]]
+@ga = global i24 0
+@gb = global i24 0
+@out24 = global i24 0
+define spir_kernel void @sdiv_i24_from_globals() {
+  %a = load i24, ptr @ga
+  %b = load i24, ptr @gb
+  %r = sdiv i24 %a, %b
+  store i24 %r, ptr @out24
+  ret void
+}
+
+; ----------------------------------------------------------------------------
 ; Negative test: unsigned compare must NOT emit sign-extension shifts.
 ; CHECK: OpFunction
 ; CHECK: %[[#X7:]] = OpFunctionParameter


### PR DESCRIPTION
Fix an assertion crash (release: null-MBB walk) when a sub-pow2 sign-sensitive op has no preceding G_TRUNC to set the insert point