### PR TITLE
[libc] (Re)skip tests failing after #213860

### DIFF
--- a/libc/test/include/CMakeLists.txt
+++ b/libc/test/include/CMakeLists.txt
@@ -113,6 +113,7 @@ add_libc_test(
     sched_test.cpp
   DEPENDS
     libc.include.sched
+    libc.src.sched.sched_getscheduler
 )
 
 add_libc_test(

--- a/libc/test/src/string/memory_utils/CMakeLists.txt
+++ b/libc/test/src/string/memory_utils/CMakeLists.txt
@@ -1,20 +1,25 @@
-# This test currently uses too much memory to be made hermetic.
-add_libc_test(
-  utils_test
-  SUITE
-    libc-string-tests
-  SRCS
-    op_tests.cpp
-    utils_test.cpp
-  COMPILE_OPTIONS
-    ${LIBC_COMPILE_OPTIONS_NATIVE}
-  DEPENDS
-    libc.hdr.stdint_proxy
-    libc.src.__support.CPP.array
-    libc.src.__support.CPP.cstddef
-    libc.src.__support.CPP.span
-    libc.src.__support.macros.properties.os
-    libc.src.__support.macros.properties.types
-    libc.src.__support.macros.sanitizer
-    libc.src.string.memory_utils.memory_utils
-)
+# Targets with implemented src/string/memory_utils/op_XXX.h specializations.
+if(LIBC_TARGET_ARCHITECTURE_IS_AARCH64 OR
+   LIBC_TARGET_ARCHITECTURE_IS_X86_64 OR
+   LIBC_TARGET_ARCHITECTURE_IS_X86 OR
+   LIBC_TARGET_ARCHITECTURE_IS_ANY_RISCV)
+  add_libc_test(
+    utils_test
+    SUITE
+      libc-string-tests
+    SRCS
+      op_tests.cpp
+      utils_test.cpp
+    COMPILE_OPTIONS
+      ${LIBC_COMPILE_OPTIONS_NATIVE}
+    DEPENDS
+      libc.hdr.stdint_proxy
+      libc.src.__support.CPP.array
+      libc.src.__support.CPP.cstddef
+      libc.src.__support.CPP.span
+      libc.src.__support.macros.properties.os
+      libc.src.__support.macros.properties.types
+      libc.src.__support.macros.sanitizer
+      libc.src.string.memory_utils.memory_utils
+  )
+endif()


### PR DESCRIPTION
(At least) two tests enabled by #213860 are failing on the amdgpu bot (which only runs hermetic tests).  This patch skips them, but it a different way, so that they keep running in hermetic mode on supported targets.

For the sched_test, I add a dependency on the sched_getscheduler target (used in the test) to trigger the auto-skipping logic.

The memory utils test fails due to a missing cmp_is_expensive specialization, so I enable the test only on targets which have them (listing targets explicitly).