### PR TITLE
[libc] Enable unistd.h on linux/arm and aarch64

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -376,6 +376,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.alarm
     libc.src.unistd.access
     libc.src.unistd.chdir
+    libc.src.unistd.chown
     libc.src.unistd.close
     libc.src.unistd.dup
     libc.src.unistd.dup2
@@ -396,6 +397,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.getppid
     libc.src.unistd.getsid
     libc.src.unistd.gettid
+    libc.src.unistd.getgid
     libc.src.unistd.getuid
     libc.src.unistd.isatty
     libc.src.unistd.link

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -211,6 +211,51 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.sys.time.setitimer
     libc.src.sys.time.getitimer
 
+    # unistd.h entrypoints
+    libc.src.unistd.alarm
+    libc.src.unistd.access
+    libc.src.unistd.chdir
+    libc.src.unistd.chown
+    libc.src.unistd.close
+    libc.src.unistd.dup
+    libc.src.unistd.dup2
+    libc.src.unistd.dup3
+    libc.src.unistd.execve
+    libc.src.unistd.faccessat
+    libc.src.unistd.fchdir
+    libc.src.unistd.fchown
+    libc.src.unistd.fsync
+    libc.src.unistd.ftruncate
+    libc.src.unistd.getcwd
+    libc.src.unistd.getentropy
+    libc.src.unistd.geteuid
+    libc.src.unistd.gethostname
+    libc.src.unistd.getpagesize
+    libc.src.unistd.getpid
+    libc.src.unistd.getppid
+    libc.src.unistd.getsid
+    libc.src.unistd.gettid
+    libc.src.unistd.getgid
+    libc.src.unistd.getuid
+    libc.src.unistd.isatty
+    libc.src.unistd.link
+    libc.src.unistd.linkat
+    libc.src.unistd.lseek
+    libc.src.unistd.pipe
+    libc.src.unistd.pipe2
+    libc.src.unistd.read
+    libc.src.unistd.readlink
+    libc.src.unistd.readlinkat
+    libc.src.unistd.rmdir
+    libc.src.unistd.setsid
+    libc.src.unistd.symlink
+    libc.src.unistd.symlinkat
+    libc.src.unistd.sysconf
+    libc.src.unistd.truncate
+    libc.src.unistd.unlink
+    libc.src.unistd.unlinkat
+    libc.src.unistd.write
+
     # wctype.h entrypoints
     libc.src.wctype.iswalpha
     libc.src.wctype.iswgraph

--- a/libc/config/linux/arm/headers.txt
+++ b/libc/config/linux/arm/headers.txt
@@ -22,10 +22,12 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.strings
     libc.include.pwd
     libc.include.uchar
+    libc.include.unistd
     libc.include.wchar
     libc.include.wctype
     libc.include.sys_param
     libc.include.sys_personality
+    libc.include.sys_unistd
     # Disabled due to epoll_wait syscalls not being available on this platform.
     # libc.include.sys_epoll
 )


### PR DESCRIPTION
This enables the unistd.h header and all functional entry points for
linux/arm. I've disabled a handful of functions which do not work
because of 32-vs-64 bit mismatches (in file offsets and times). In
theory these should work in full build mode, but we don't have bot
coverage for this config, so I'm not enabling them anywhere. This is
also why I'm not enabling full-build-only entry points which are enabled
on other architectures.

While comparing the unistd entry point lists across architectures, I noticed
that linux/aarch64 was missing chown and getgid. I've added those as well.

Assisted by Gemini.