### PR TITLE
[lldb][test] Skip the frame 0 expedite test with an out-of-tree debugserver

### DIFF
--- a/lldb/test/API/macosx/expedited-stack-memory/TestExpeditedStackMemory.py
+++ b/lldb/test/API/macosx/expedited-stack-memory/TestExpeditedStackMemory.py
@@ -47,6 +47,7 @@ class TestExpeditedStackMemory(TestBase):
         stub, producing memory-read packets."""
         self.check_packets_during_backtrace(disable_memory_cache=True)
 
+    @skipIfOutOfTreeDebugserver
     @requireDarwin
     def test_memory_reads_when_examining_frame0_locals(self):
         """Model an IDE stop: walk the whole stack (a backtrace / debug


### PR DESCRIPTION
`test_memory_reads_when_examining_frame0_locals` asserts that examining
frame 0's locals reads no stack memory, which only holds when debugserver
expedites the stopped frame's stack in `jThreadsInfo`.  That is
added in b631e0cbd1c9, so the assertion only holds for an in-tree
debugserver.

The GreenDragon `lldb-cmake-sanitized` bot configures with
`-DLLDB_USE_SYSTEM_DEBUGSERVER=ON`, so it tests against the debugserver
shipped in Xcode.  That one predates the expedite, so test fails:

```
FAIL: test_memory_reads_when_examining_frame0_locals
AssertionError: 2 != 0 : expected NO stack memory reads for frame 0 (its
stack is expedited in jThreadsInfo).
memory reads while examining locals: stack=2 heap=1 other=1 (total=4)
  stack region: [0x16b540000,0x16f53c000)
  stack reads:  [0x16f53ac00,0x16f53ae00), [0x16f53aa00,0x16f53ac00)
```

It adds `@skipIfOutOfTreeDebugserver` to
`test_memory_reads_when_examining_frame0_locals`.  The other three tests
in the file pass there because they only rely on the frame pointer
backchain expedite, which is old enough to be in the shipped debugserver.
