### PR TITLE
[X86] Tidyup atom fpu->gpr costs

### DIFF
--- a/llvm/lib/Target/X86/X86ScheduleAtom.td
+++ b/llvm/lib/Target/X86/X86ScheduleAtom.td
@@ -383,7 +383,7 @@ def  : WriteRes<WriteVecMove,          [AtomPort0]>;
 def  : WriteRes<WriteVecMoveX,        [AtomPort01]>;
 defm : X86WriteResUnsupported<WriteVecMoveY>;
 defm : X86WriteResUnsupported<WriteVecMoveZ>;
-defm : X86WriteRes<WriteVecMoveToGpr,   [AtomPort0], 3, [3], 1>;
+defm : X86WriteRes<WriteVecMoveToGpr,   [AtomPort0], 4, [2], 1>;
 defm : X86WriteRes<WriteVecMoveFromGpr, [AtomPort0], 1, [1], 1>;
 
 defm : AtomWriteResPair<WriteVecALU,       [AtomPort01],  [AtomPort0], 1, 1>;
@@ -462,10 +462,10 @@ defm : X86WriteResPairUnsupported<WritePCmpEStrM>;
 // MOVMSK Instructions.
 ////////////////////////////////////////////////////////////////////////////////
 
-def  : WriteRes<WriteFMOVMSK,    [AtomPort0]> { let Latency = 3; let ReleaseAtCycles = [3]; }
-def  : WriteRes<WriteVecMOVMSK,  [AtomPort0]> { let Latency = 3; let ReleaseAtCycles = [3]; }
+def  : WriteRes<WriteFMOVMSK,    [AtomPort0]> { let Latency = 4; let ReleaseAtCycles = [2]; }
+def  : WriteRes<WriteVecMOVMSK,  [AtomPort0]> { let Latency = 4; let ReleaseAtCycles = [2]; }
 defm : X86WriteResUnsupported<WriteVecMOVMSKY>;
-def  : WriteRes<WriteMMXMOVMSK,  [AtomPort0]> { let Latency = 3; let ReleaseAtCycles = [3]; }
+def  : WriteRes<WriteMMXMOVMSK,  [AtomPort0]> { let Latency = 4; let ReleaseAtCycles = [2]; }
 
 ////////////////////////////////////////////////////////////////////////////////
 // AES instructions.

--- a/llvm/test/tools/llvm-mca/X86/Atom/resources-mmx.s
+++ b/llvm/test/tools/llvm-mca/X86/Atom/resources-mmx.s
@@ -167,11 +167,11 @@ pxor        (%rax), %mm2
 # CHECK-NEXT:  1      5     2.50    *      *      U     emms
 # CHECK-NEXT:  1      1     1.00                        movd	%eax, %mm2
 # CHECK-NEXT:  1      1     1.00    *                   movd	(%rax), %mm2
-# CHECK-NEXT:  1      3     3.00                        movd	%mm0, %ecx
+# CHECK-NEXT:  1      4     2.00                        movd	%mm0, %ecx
 # CHECK-NEXT:  1      1     1.00           *      U     movd	%mm0, (%rax)
 # CHECK-NEXT:  1      1     1.00                        movq	%rax, %mm2
 # CHECK-NEXT:  1      1     1.00    *                   movq	(%rax), %mm2
-# CHECK-NEXT:  1      3     3.00                        movq	%mm0, %rcx
+# CHECK-NEXT:  1      4     2.00                        movq	%mm0, %rcx
 # CHECK-NEXT:  1      1     1.00           *            movq	%mm0, (%rax)
 # CHECK-NEXT:  1      1     1.00                        packsswb	%mm0, %mm2
 # CHECK-NEXT:  1      1     1.00    *                   packsswb	(%rax), %mm2
@@ -276,18 +276,18 @@ pxor        (%rax), %mm2
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]
-# CHECK-NEXT: 106.50 38.50
+# CHECK-NEXT: 104.50 38.50
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    Instructions:
 # CHECK-NEXT: 2.50   2.50   emms
 # CHECK-NEXT: 1.00    -     movd	%eax, %mm2
 # CHECK-NEXT: 1.00    -     movd	(%rax), %mm2
-# CHECK-NEXT: 3.00    -     movd	%mm0, %ecx
+# CHECK-NEXT: 2.00    -     movd	%mm0, %ecx
 # CHECK-NEXT: 1.00    -     movd	%mm0, (%rax)
 # CHECK-NEXT: 1.00    -     movq	%rax, %mm2
 # CHECK-NEXT: 1.00    -     movq	(%rax), %mm2
-# CHECK-NEXT: 3.00    -     movq	%mm0, %rcx
+# CHECK-NEXT: 2.00    -     movq	%mm0, %rcx
 # CHECK-NEXT: 1.00    -     movq	%mm0, (%rax)
 # CHECK-NEXT: 1.00    -     packsswb	%mm0, %mm2
 # CHECK-NEXT: 1.00    -     packsswb	(%rax), %mm2

--- a/llvm/test/tools/llvm-mca/X86/Atom/resources-sse1.s
+++ b/llvm/test/tools/llvm-mca/X86/Atom/resources-sse1.s
@@ -249,7 +249,7 @@ xorps       (%rax), %xmm2
 # CHECK-NEXT:  1      1     1.00    *                   movhps	(%rax), %xmm2
 # CHECK-NEXT:  1      1     1.00           *            movlps	%xmm0, (%rax)
 # CHECK-NEXT:  1      1     1.00    *                   movlps	(%rax), %xmm2
-# CHECK-NEXT:  1      3     3.00                        movmskps	%xmm0, %ecx
+# CHECK-NEXT:  1      4     2.00                        movmskps	%xmm0, %ecx
 # CHECK-NEXT:  1      1     1.00           *            movntps	%xmm0, (%rax)
 # CHECK-NEXT:  1      1     1.00    *      *      U     movntq	%mm0, (%rax)
 # CHECK-NEXT:  1      1     0.50                        movss	%xmm0, %xmm2
@@ -279,7 +279,7 @@ xorps       (%rax), %xmm2
 # CHECK-NEXT:  1      1     1.00    *                   pminsw	(%rax), %mm2
 # CHECK-NEXT:  1      1     0.50                        pminub	%mm0, %mm2
 # CHECK-NEXT:  1      1     1.00    *                   pminub	(%rax), %mm2
-# CHECK-NEXT:  1      3     3.00                        pmovmskb	%mm0, %ecx
+# CHECK-NEXT:  1      4     2.00                        pmovmskb	%mm0, %ecx
 # CHECK-NEXT:  1      4     1.00                        pmulhuw	%mm0, %mm2
 # CHECK-NEXT:  1      4     1.00    *                   pmulhuw	(%rax), %mm2
 # CHECK-NEXT:  1      1     1.00    *      *            prefetcht0	(%rax)
@@ -325,7 +325,7 @@ xorps       (%rax), %xmm2
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]
-# CHECK-NEXT: 747.00 702.00
+# CHECK-NEXT: 745.00 702.00
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    Instructions:
@@ -384,7 +384,7 @@ xorps       (%rax), %xmm2
 # CHECK-NEXT: 1.00    -     movhps	(%rax), %xmm2
 # CHECK-NEXT: 1.00    -     movlps	%xmm0, (%rax)
 # CHECK-NEXT: 1.00    -     movlps	(%rax), %xmm2
-# CHECK-NEXT: 3.00    -     movmskps	%xmm0, %ecx
+# CHECK-NEXT: 2.00    -     movmskps	%xmm0, %ecx
 # CHECK-NEXT: 1.00    -     movntps	%xmm0, (%rax)
 # CHECK-NEXT: 1.00    -     movntq	%mm0, (%rax)
 # CHECK-NEXT: 0.50   0.50   movss	%xmm0, %xmm2
@@ -414,7 +414,7 @@ xorps       (%rax), %xmm2
 # CHECK-NEXT: 1.00    -     pminsw	(%rax), %mm2
 # CHECK-NEXT: 0.50   0.50   pminub	%mm0, %mm2
 # CHECK-NEXT: 1.00    -     pminub	(%rax), %mm2
-# CHECK-NEXT: 3.00    -     pmovmskb	%mm0, %ecx
+# CHECK-NEXT: 2.00    -     pmovmskb	%mm0, %ecx
 # CHECK-NEXT: 1.00    -     pmulhuw	%mm0, %mm2
 # CHECK-NEXT: 1.00    -     pmulhuw	(%rax), %mm2
 # CHECK-NEXT: 1.00    -     prefetcht0	(%rax)

--- a/llvm/test/tools/llvm-mca/X86/Atom/resources-sse2.s
+++ b/llvm/test/tools/llvm-mca/X86/Atom/resources-sse2.s
@@ -480,7 +480,7 @@ xorpd       (%rax), %xmm2
 # CHECK-NEXT:  1      1     1.00    *                   movapd	(%rax), %xmm2
 # CHECK-NEXT:  1      1     1.00                        movd	%eax, %xmm2
 # CHECK-NEXT:  1      1     1.00    *                   movd	(%rax), %xmm2
-# CHECK-NEXT:  1      3     3.00                        movd	%xmm0, %ecx
+# CHECK-NEXT:  1      4     2.00                        movd	%xmm0, %ecx
 # CHECK-NEXT:  1      1     1.00           *            movd	%xmm0, (%rax)
 # CHECK-NEXT:  1      1     0.50                        movdqa	%xmm0, %xmm2
 # CHECK-NEXT:  1      1     1.00           *            movdqa	%xmm0, (%rax)
@@ -493,7 +493,7 @@ xorpd       (%rax), %xmm2
 # CHECK-NEXT:  1      1     1.00    *                   movhpd	(%rax), %xmm2
 # CHECK-NEXT:  1      1     1.00           *            movlpd	%xmm0, (%rax)
 # CHECK-NEXT:  1      1     1.00    *                   movlpd	(%rax), %xmm2
-# CHECK-NEXT:  1      3     3.00                        movmskpd	%xmm0, %ecx
+# CHECK-NEXT:  1      4     2.00                        movmskpd	%xmm0, %ecx
 # CHECK-NEXT:  1      1     1.00           *            movntil	%eax, (%rax)
 # CHECK-NEXT:  1      1     1.00           *            movntiq	%rax, (%rax)
 # CHECK-NEXT:  1      1     1.00           *            movntdq	%xmm0, (%rax)
@@ -501,7 +501,7 @@ xorpd       (%rax), %xmm2
 # CHECK-NEXT:  1      1     0.50                        movq	%xmm0, %xmm2
 # CHECK-NEXT:  1      1     1.00                        movq	%rax, %xmm2
 # CHECK-NEXT:  1      1     1.00    *                   movq	(%rax), %xmm2
-# CHECK-NEXT:  1      3     3.00                        movq	%xmm0, %rcx
+# CHECK-NEXT:  1      4     2.00                        movq	%xmm0, %rcx
 # CHECK-NEXT:  1      1     1.00           *            movq	%xmm0, (%rax)
 # CHECK-NEXT:  1      1     0.50                        movq2dq	%mm0, %xmm2
 # CHECK-NEXT:  1      1     1.00                        movsd	%xmm0, %xmm2
@@ -573,7 +573,7 @@ xorpd       (%rax), %xmm2
 # CHECK-NEXT:  1      1     1.00    *                   pminsw	(%rax), %xmm2
 # CHECK-NEXT:  1      1     0.50                        pminub	%xmm0, %xmm2
 # CHECK-NEXT:  1      1     1.00    *                   pminub	(%rax), %xmm2
-# CHECK-NEXT:  1      3     3.00                        pmovmskb	%xmm0, %ecx
+# CHECK-NEXT:  1      4     2.00                        pmovmskb	%xmm0, %ecx
 # CHECK-NEXT:  1      5     2.00                        pmulhuw	%xmm0, %xmm2
 # CHECK-NEXT:  1      5     2.00    *                   pmulhuw	(%rax), %xmm2
 # CHECK-NEXT:  1      5     2.00                        pmulhw	%xmm0, %xmm2
@@ -681,7 +681,7 @@ xorpd       (%rax), %xmm2
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]
-# CHECK-NEXT: 1366.00 1226.00
+# CHECK-NEXT: 1362.00 1226.00
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    Instructions:
@@ -758,7 +758,7 @@ xorpd       (%rax), %xmm2
 # CHECK-NEXT: 1.00    -     movapd	(%rax), %xmm2
 # CHECK-NEXT: 1.00    -     movd	%eax, %xmm2
 # CHECK-NEXT: 1.00    -     movd	(%rax), %xmm2
-# CHECK-NEXT: 3.00    -     movd	%xmm0, %ecx
+# CHECK-NEXT: 2.00    -     movd	%xmm0, %ecx
 # CHECK-NEXT: 1.00    -     movd	%xmm0, (%rax)
 # CHECK-NEXT: 0.50   0.50   movdqa	%xmm0, %xmm2
 # CHECK-NEXT: 1.00    -     movdqa	%xmm0, (%rax)
@@ -771,7 +771,7 @@ xorpd       (%rax), %xmm2
 # CHECK-NEXT: 1.00    -     movhpd	(%rax), %xmm2
 # CHECK-NEXT: 1.00    -     movlpd	%xmm0, (%rax)
 # CHECK-NEXT: 1.00    -     movlpd	(%rax), %xmm2
-# CHECK-NEXT: 3.00    -     movmskpd	%xmm0, %ecx
+# CHECK-NEXT: 2.00    -     movmskpd	%xmm0, %ecx
 # CHECK-NEXT: 1.00    -     movntil	%eax, (%rax)
 # CHECK-NEXT: 1.00    -     movntiq	%rax, (%rax)
 # CHECK-NEXT: 1.00    -     movntdq	%xmm0, (%rax)
@@ -779,7 +779,7 @@ xorpd       (%rax), %xmm2
 # CHECK-NEXT: 0.50   0.50   movq	%xmm0, %xmm2
 # CHECK-NEXT: 1.00    -     movq	%rax, %xmm2
 # CHECK-NEXT: 1.00    -     movq	(%rax), %xmm2
-# CHECK-NEXT: 3.00    -     movq	%xmm0, %rcx
+# CHECK-NEXT: 2.00    -     movq	%xmm0, %rcx
 # CHECK-NEXT: 1.00    -     movq	%xmm0, (%rax)
 # CHECK-NEXT: 0.50   0.50   movq2dq	%mm0, %xmm2
 # CHECK-NEXT: 1.00    -     movsd	%xmm0, %xmm2
@@ -851,7 +851,7 @@ xorpd       (%rax), %xmm2
 # CHECK-NEXT: 1.00    -     pminsw	(%rax), %xmm2
 # CHECK-NEXT: 0.50   0.50   pminub	%xmm0, %xmm2
 # CHECK-NEXT: 1.00    -     pminub	(%rax), %xmm2
-# CHECK-NEXT: 3.00    -     pmovmskb	%xmm0, %ecx
+# CHECK-NEXT: 2.00    -     pmovmskb	%xmm0, %ecx
 # CHECK-NEXT: 2.00    -     pmulhuw	%xmm0, %xmm2
 # CHECK-NEXT: 2.00    -     pmulhuw	(%rax), %xmm2
 # CHECK-NEXT: 2.00    -     pmulhw	%xmm0, %xmm2


### PR DESCRIPTION
These had matching high latency and throughput numbers, which suggest they hadn't been updated since the itinerary conversion.

Confirmed with Agner, uops.info and instlatx64 which report a consistent throughput of 2cy, latency seems to be about 4cy (uops.info just says <= 6cy)

Noticed while trying to confirm #214191 vector reduction costs for atom type cpus, and llvm-mca was reporting some very odd numbers for bonnell.