### PR TITLE
[PAC][ELF] Make non-preemptible IFUNC GOT assertion an error and extend

### DIFF
--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -1245,6 +1245,14 @@ static bool handleNonPreemptibleIfunc(Ctx &ctx, Symbol &sym, uint16_t flags) {
   // Skip unreferenced non-preemptible ifunc.
   if (!(flags & (NEEDS_GOT | NEEDS_PLT | HAS_DIRECT_RELOC)))
     return true;
+  // We only support one kind of GOT entry, and IPLT entries currently always
+  // use non-AUTH GOT entries.
+  if ((flags & NEEDS_GOT) && (flags & NEEDS_GOT_AUTH)) {
+    auto diag = Err(ctx);
+    diag << "AUTH GOT entry for non-preemptible ifunc '" << sym.getName()
+         << "' requested, but R_AARCH64_AUTH_IRELATIVE is not supported yet";
+    return true;
+  }
 
   sym.isInIplt = true;
 
@@ -1267,11 +1275,8 @@ static bool handleNonPreemptibleIfunc(Ctx &ctx, Symbol &sym, uint16_t flags) {
     // don't try to call the PLT as if it were an ifunc resolver.
     d.type = STT_FUNC;
 
-    if (flags & NEEDS_GOT) {
-      assert(!(flags & NEEDS_GOT_AUTH) &&
-             "R_AARCH64_AUTH_IRELATIVE is not supported yet");
+    if (flags & NEEDS_GOT)
       addGotEntry(ctx, sym);
-    }
   } else if (flags & NEEDS_GOT) {
     // Redirect GOT accesses to point to the Igot.
     sym.gotInIgot = true;

--- a/lld/test/ELF/aarch64-gnu-ifunc-nonpreemptible-pauth.s
+++ b/lld/test/ELF/aarch64-gnu-ifunc-nonpreemptible-pauth.s
@@ -1,0 +1,21 @@
+# REQUIRES: aarch64
+# RUN: llvm-mc -filetype=obj -triple=aarch64 --defsym direct=0 %s -o %t.o
+# RUN: not ld.lld %t.o -o %t 2>&1 | FileCheck %s
+# RUN: llvm-mc -filetype=obj -triple=aarch64 --defsym direct=1 %s -o %t.direct.o
+# RUN: not ld.lld %t.direct.o -o %t.direct 2>&1 | FileCheck %s
+
+# CHECK: error: AUTH GOT entry for non-preemptible ifunc 'ifunc' requested, but R_AARCH64_AUTH_IRELATIVE is not supported yet
+
+.globl ifunc
+.type ifunc, @gnu_indirect_function
+ifunc:
+  ret
+
+.globl _start
+.type _start, @function
+_start:
+  adrp x0, :got_auth:ifunc
+  ldr x1, [x0, :got_auth_lo12:ifunc]
+.if direct == 1
+  adrp x2, ifunc
+.endif


### PR DESCRIPTION
Support for R_AARCH64_AUTH_IRELATIVE is not yet present in LLD, but we accept various input that would give rise to needing it. For the direct reloc case, replaceWithDefined asserts (rather than give an error message) this was not requested, whilst for the non-direct reloc case it silently ignores which GOT type was requested. In the latter case, and the former when assertions are disabled, this results in mis-linking the object, producing one with a non-AUTH GOT entry, that would presumably then fail the AUTDA operation in any user of it (aside from the IPLT entry generated by LLD).

Fixes: 417d2d7ce694 ("[PAC][lld][AArch64][ELF] Support signed GOT (#113815)")