### PR TITLE
[IVDescriptors] Implement MonotonicDescriptor

### DIFF
--- a/llvm/include/llvm/Analysis/IVDescriptors.h
+++ b/llvm/include/llvm/Analysis/IVDescriptors.h
@@ -29,6 +29,7 @@ class PredicatedScalarEvolution;
 class ScalarEvolution;
 class SCEV;
 class SCEVPredicate;
+class SCEVAddRecExpr;
 class StoreInst;
 
 /// These are the kinds of recurrences that we support.
@@ -480,6 +481,44 @@ private:
   SmallVector<Instruction *, 2> RedundantCasts;
   // SCEV predicates checking overflow needed for this induction.
   SmallVector<const SCEVPredicate *, 2> NoWrapPredicates;
+};
+
+/// A struct for saving information about monotonic variables.
+/// Monotonic variable can be considered as a "conditional" induction variable:
+/// its update happens only on loop iterations for which a certain predicate is
+/// satisfied. In this implementation the predicate is represented as an edge in
+/// loop CFG: variable is updated if this edge is executed on current loop
+/// iteration.
+class MonotonicDescriptor {
+public:
+  using Edge = std::pair<BasicBlock *, BasicBlock *>;
+
+  MonotonicDescriptor() = default;
+
+  const SmallPtrSetImpl<PHINode *> &getChain() const { return Chain; }
+  Instruction *getStepInst() const { return StepInst; }
+  Edge getPredicateEdge() const { return PredEdge; }
+  const SCEVAddRecExpr *getExpr() const { return Expr; }
+
+  /// Returns true if \p PN is a monotonic variable in the loop \p L. If \p PN
+  /// is monotonic, the monotonic descriptor \p D will contain the data
+  /// describing this variable.
+  static bool isMonotonicPHI(PHINode *PN, const Loop *L,
+                             MonotonicDescriptor &Desc, ScalarEvolution &SE);
+
+  /// Returns true if \p Val is a monotonic variable in the loop \p L (in this
+  /// case, the value should transitively contain monotonic phi as part of its
+  /// calculation).
+  static bool isMonotonicVal(Value *Val, const Loop *L,
+                             MonotonicDescriptor &Desc, ScalarEvolution &SE);
+
+private:
+  SmallPtrSet<PHINode *, 1> Chain;
+  Instruction *StepInst;
+  Edge PredEdge;
+  const SCEVAddRecExpr *Expr;
+
+  bool setSCEV(const SCEV *NewExpr);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Analysis/IVDescriptors.h
+++ b/llvm/include/llvm/Analysis/IVDescriptors.h
@@ -492,9 +492,11 @@ public:
   MonotonicDescriptor() = default;
 
   MonotonicDescriptor(PHINode *HeaderPHI, PHINode *BackedgePHI,
-                      Instruction *StepInst, const SCEVAddRecExpr *PhiSCEV)
+                      Instruction *StepInst, const SCEV *StartSCEV,
+                      const SCEV *StepSCEV, unsigned SCEVNoWrapFlags)
       : HeaderPHI(HeaderPHI), BackedgePHI(BackedgePHI), StepInst(StepInst),
-        PhiSCEV(PhiSCEV) {}
+        StartSCEV(StartSCEV), StepSCEV(StepSCEV),
+        SCEVNoWrapFlags(SCEVNoWrapFlags) {}
 
   /// Returns true if \p PN is a monotonic variable in the loop \p L. If \p PN
   /// is monotonic, the monotonic descriptor \p D will contain the data
@@ -511,10 +513,16 @@ public:
   /// Returns the instruction that updates the value of the monotonic PHI.
   Instruction *getStepInst() const { return StepInst; }
 
-  /// Returns the expression that represents the monotonic PHI. Note: The
-  /// conditional update is represented with a plain SCEVAddRec. This only holds
-  /// on iterations where the monotonic PHI is updated by StepInst.
-  const SCEVAddRecExpr *getPhiSCEV() const { return PhiSCEV; }
+  /// Returns a SCEV expression for the initial value of the monotonic PHI.
+  const SCEV *getStartSCEV() const { return StartSCEV; }
+
+  /// Returns a SCEV expression for the step of the monotonic PHI. This is
+  /// the value the monotonic PHI increments by on loop iterations where the
+  /// predicate is satisfied.
+  const SCEV *getStepSCEV() const { return StepSCEV; }
+
+  /// Returns the SCEV no-wrap flags that apply to StepInst.
+  unsigned getSCEVNoWrapFlags() const { return SCEVNoWrapFlags; }
 
 private:
   /// The header PHI (this is the PHI described by the descriptor).
@@ -526,9 +534,14 @@ private:
   /// The instruction that updates the value of the monotonic PHI.
   Instruction *StepInst = nullptr;
 
-  /// Expression that represents the monotonic PHI. Within the expression, the
-  /// conditional update is represented as an (unconditional) SCEVAddRec.
-  const SCEVAddRecExpr *PhiSCEV = nullptr;
+  /// SCEV expression representing the start value for the monotonic PHI.
+  const SCEV *StartSCEV = nullptr;
+
+  /// SCEV expression representing the step value for the monotonic PHI.
+  const SCEV *StepSCEV = nullptr;
+
+  /// The SCEV no-wrap flags that apply to StepInst.
+  unsigned SCEVNoWrapFlags = 0;
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Analysis/IVDescriptors.h
+++ b/llvm/include/llvm/Analysis/IVDescriptors.h
@@ -29,7 +29,6 @@ class PredicatedScalarEvolution;
 class ScalarEvolution;
 class SCEV;
 class SCEVPredicate;
-class SCEVAddRecExpr;
 class StoreInst;
 
 /// These are the kinds of recurrences that we support.
@@ -501,8 +500,9 @@ public:
   /// Returns true if \p PN is a monotonic variable in the loop \p L. If \p PN
   /// is monotonic, the monotonic descriptor \p D will contain the data
   /// describing the PHI.
-  static bool isMonotonicPHI(PHINode *PN, const Loop *L,
-                             MonotonicDescriptor &Desc, ScalarEvolution &SE);
+  LLVM_ABI static bool isMonotonicPHI(PHINode *PN, const Loop *L,
+                                      MonotonicDescriptor &Desc,
+                                      ScalarEvolution &SE);
 
   /// Returns the header PHI described by this descriptor.
   PHINode *getHeaderPHI() const { return HeaderPHI; }

--- a/llvm/include/llvm/Analysis/IVDescriptors.h
+++ b/llvm/include/llvm/Analysis/IVDescriptors.h
@@ -486,7 +486,7 @@ private:
 /// A struct for saving information about monotonic variables.
 /// Monotonic variable can be considered as a "conditional" induction variable:
 /// its update happens only on loop iterations for which a certain predicate is
-/// satisfied.
+/// satisfied. The step of the monotonic variable must be loop-invariant.
 class MonotonicDescriptor {
 public:
   MonotonicDescriptor() = default;

--- a/llvm/include/llvm/Analysis/IVDescriptors.h
+++ b/llvm/include/llvm/Analysis/IVDescriptors.h
@@ -486,39 +486,49 @@ private:
 /// A struct for saving information about monotonic variables.
 /// Monotonic variable can be considered as a "conditional" induction variable:
 /// its update happens only on loop iterations for which a certain predicate is
-/// satisfied. In this implementation the predicate is represented as an edge in
-/// loop CFG: variable is updated if this edge is executed on current loop
-/// iteration.
+/// satisfied.
 class MonotonicDescriptor {
 public:
-  using Edge = std::pair<BasicBlock *, BasicBlock *>;
-
   MonotonicDescriptor() = default;
 
-  const SmallPtrSetImpl<PHINode *> &getChain() const { return Chain; }
-  Instruction *getStepInst() const { return StepInst; }
-  Edge getPredicateEdge() const { return PredEdge; }
-  const SCEVAddRecExpr *getExpr() const { return Expr; }
+  MonotonicDescriptor(PHINode *HeaderPHI, PHINode *BackedgePHI,
+                      Instruction *StepInst, const SCEVAddRecExpr *PhiSCEV)
+      : HeaderPHI(HeaderPHI), BackedgePHI(BackedgePHI), StepInst(StepInst),
+        PhiSCEV(PhiSCEV) {}
 
   /// Returns true if \p PN is a monotonic variable in the loop \p L. If \p PN
   /// is monotonic, the monotonic descriptor \p D will contain the data
-  /// describing this variable.
+  /// describing the PHI.
   static bool isMonotonicPHI(PHINode *PN, const Loop *L,
                              MonotonicDescriptor &Desc, ScalarEvolution &SE);
 
-  /// Returns true if \p Val is a monotonic variable in the loop \p L (in this
-  /// case, the value should transitively contain monotonic phi as part of its
-  /// calculation).
-  static bool isMonotonicVal(Value *Val, const Loop *L,
-                             MonotonicDescriptor &Desc, ScalarEvolution &SE);
+  /// Returns the header PHI described by this descriptor.
+  PHINode *getHeaderPHI() const { return HeaderPHI; }
+
+  /// Returns the backedge PHI that selects between StepInst and the HeaderPHI.
+  PHINode *getBackedgePHI() const { return BackedgePHI; }
+
+  /// Returns the instruction that updates the value of the monotonic PHI.
+  Instruction *getStepInst() const { return StepInst; }
+
+  /// Returns the expression that represents the monotonic PHI. Note: The
+  /// conditional update is represented with a plain SCEVAddRec. This only holds
+  /// on iterations where the monotonic PHI is updated by StepInst.
+  const SCEVAddRecExpr *getPhiSCEV() const { return PhiSCEV; }
 
 private:
-  SmallPtrSet<PHINode *, 1> Chain;
-  Instruction *StepInst;
-  Edge PredEdge;
-  const SCEVAddRecExpr *Expr;
+  /// The header PHI (this is the PHI described by the descriptor).
+  PHINode *HeaderPHI = nullptr;
 
-  bool setSCEV(const SCEV *NewExpr);
+  /// The backedge PHI that selects between StepInst and the HeaderPHI.
+  PHINode *BackedgePHI = nullptr;
+
+  /// The instruction that updates the value of the monotonic PHI.
+  Instruction *StepInst = nullptr;
+
+  /// Expression that represents the monotonic PHI. Within the expression, the
+  /// conditional update is represented as an (unconditional) SCEVAddRec.
+  const SCEVAddRecExpr *PhiSCEV = nullptr;
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Analysis/IVDescriptors.h
+++ b/llvm/include/llvm/Analysis/IVDescriptors.h
@@ -490,13 +490,6 @@ class MonotonicDescriptor {
 public:
   MonotonicDescriptor() = default;
 
-  MonotonicDescriptor(PHINode *HeaderPHI, PHINode *BackedgePHI,
-                      Instruction *StepInst, const SCEV *StartSCEV,
-                      const SCEV *StepSCEV, unsigned SCEVNoWrapFlags)
-      : HeaderPHI(HeaderPHI), BackedgePHI(BackedgePHI), StepInst(StepInst),
-        StartSCEV(StartSCEV), StepSCEV(StepSCEV),
-        SCEVNoWrapFlags(SCEVNoWrapFlags) {}
-
   /// Returns true if \p PN is a monotonic variable in the loop \p L. If \p PN
   /// is monotonic, the monotonic descriptor \p D will contain the data
   /// describing the PHI.
@@ -525,6 +518,13 @@ public:
   unsigned getSCEVNoWrapFlags() const { return SCEVNoWrapFlags; }
 
 private:
+  MonotonicDescriptor(PHINode *HeaderPHI, PHINode *BackedgePHI,
+                      Instruction *StepInst, const SCEV *StartSCEV,
+                      const SCEV *StepSCEV, unsigned SCEVNoWrapFlags)
+      : HeaderPHI(HeaderPHI), BackedgePHI(BackedgePHI), StepInst(StepInst),
+        StartSCEV(StartSCEV), StepSCEV(StepSCEV),
+        SCEVNoWrapFlags(SCEVNoWrapFlags) {}
+
   /// The header PHI (this is the PHI described by the descriptor).
   PHINode *HeaderPHI = nullptr;
 

--- a/llvm/lib/Analysis/IVDescriptors.cpp
+++ b/llvm/lib/Analysis/IVDescriptors.cpp
@@ -1696,3 +1696,124 @@ bool InductionDescriptor::isInductionPHI(
                           /*InductionBinOp=*/nullptr, /*Casts=*/nullptr, Preds);
   return true;
 }
+
+bool MonotonicDescriptor::setSCEV(const SCEV *NewExpr) {
+  auto *AddRec = dyn_cast<SCEVAddRecExpr>(NewExpr);
+  if (!AddRec || !AddRec->isAffine())
+    return false;
+  Expr = AddRec;
+  return true;
+}
+
+// Recognize monotonic phi variable by matching the following pattern:
+// loop_header:
+//   %monotonic_phi = [%start, %preheader], [%chain_phi0, %latch]
+//
+// step_bb:
+//   %step = add/gep %monotonic_phi, %step_val
+//
+// bbN:
+//   %chain_phiN = [%monotonic_phi, ], [%step, ]
+//
+// ...
+//
+// bb1:
+//   %chain_phi1 = [%monotonic_phi, ], [%chain_phi2, ]
+//
+// latch:
+//   %chain_phi0 = [%monotonic_phi, %pred], [%chain_phi1, %pred]
+//
+// For this pattern, monotonic phi is described by {%start, +, %step} recurrence
+// and predicate is CFG edge %step_bb -> %bbN.
+bool MonotonicDescriptor::isMonotonicPHI(PHINode *PN, const Loop *L,
+                                         MonotonicDescriptor &Desc,
+                                         ScalarEvolution &SE) {
+  if (!PN->getType()->isIntOrPtrTy() || PN->getParent() != L->getHeader())
+    return false;
+  auto *BackEdgeInst =
+      dyn_cast<PHINode>(PN->getIncomingValueForBlock(L->getLoopLatch()));
+  if (!BackEdgeInst)
+    return false;
+  PHINode *PHIChain = BackEdgeInst;
+  std::optional<std::pair<Edge, Value *>> Inc;
+  while (PHIChain) {
+    Desc.Chain.insert(PHIChain);
+    PHINode *NextPHIChain = nullptr;
+    for (auto [Block, Incoming] :
+         zip_equal(PHIChain->blocks(), PHIChain->incoming_values())) {
+      if (Incoming == PN)
+        continue;
+      if (!Incoming->hasOneUse())
+        return false;
+      if (auto *IncomingPHI = dyn_cast<PHINode>(Incoming)) {
+        if (NextPHIChain)
+          return false;
+        NextPHIChain = IncomingPHI;
+        continue;
+      }
+      if (Inc || NextPHIChain)
+        return false;
+      Inc = std::make_pair(Edge{Block, PHIChain->getParent()}, Incoming.get());
+    }
+    PHIChain = NextPHIChain;
+  }
+  if (!Inc)
+    return false;
+  auto [PredEdge, StepOp] = *Inc;
+  auto *StepInst = dyn_cast<Instruction>(StepOp);
+  if (!StepInst)
+    return false;
+  Desc.StepInst = StepInst;
+  Desc.PredEdge = PredEdge;
+
+  // Construct SCEVAddRec for this value.
+  Value *Start = PN->getIncomingValueForBlock(L->getLoopPreheader());
+
+  Value *Step = nullptr;
+  bool StepMatch =
+      PN->getType()->isPointerTy()
+          ? match(StepInst, m_PtrAdd(m_Specific(PN), m_Value(Step)))
+          : match(StepInst, m_Add(m_Specific(PN), m_Value(Step)));
+  if (!StepMatch || !L->isLoopInvariant(Step))
+    return false;
+
+  SCEV::NoWrapFlags WrapFlags = SCEV::FlagAnyWrap;
+  if (auto *GEP = dyn_cast<GEPOperator>(StepInst)) {
+    if (GEP->hasNoUnsignedWrap())
+      WrapFlags = ScalarEvolution::setFlags(WrapFlags, SCEV::FlagNUW);
+    if (GEP->hasNoUnsignedSignedWrap())
+      WrapFlags = ScalarEvolution::setFlags(WrapFlags, SCEV::FlagNSW);
+  } else if (auto *OBO = dyn_cast<OverflowingBinaryOperator>(StepInst)) {
+    if (OBO->hasNoUnsignedWrap())
+      WrapFlags = ScalarEvolution::setFlags(WrapFlags, SCEV::FlagNUW);
+    if (OBO->hasNoSignedWrap())
+      WrapFlags = ScalarEvolution::setFlags(WrapFlags, SCEV::FlagNSW);
+  }
+
+  return Desc.setSCEV(
+      SE.getAddRecExpr(SE.getSCEV(Start), SE.getSCEV(Step), L, WrapFlags));
+}
+
+bool MonotonicDescriptor::isMonotonicVal(Value *Val, const Loop *L,
+                                         MonotonicDescriptor &Desc,
+                                         ScalarEvolution &SE) {
+  if (!Val->getType()->isIntOrPtrTy() || L->isLoopInvariant(Val))
+    return false;
+  auto *CurInst = cast<Instruction>(Val);
+
+  auto LoopVariantVal = [&](Value *V, bool AllowRepeats) {
+    return L->isLoopInvariant(V) ? nullptr : cast<Instruction>(V);
+  };
+
+  while (!isa<PHINode>(CurInst)) {
+    CurInst = find_singleton<Instruction>(CurInst->operands(), LoopVariantVal);
+    if (!CurInst)
+      return false;
+  };
+
+  if (!isMonotonicPHI(cast<PHINode>(CurInst), L, Desc, SE))
+    return false;
+
+  ValueToSCEVMapTy Map{{CurInst, Desc.getExpr()}};
+  return Desc.setSCEV(SCEVParameterRewriter::rewrite(SE.getSCEV(Val), SE, Map));
+}

--- a/llvm/lib/Analysis/IVDescriptors.cpp
+++ b/llvm/lib/Analysis/IVDescriptors.cpp
@@ -1697,9 +1697,9 @@ bool InductionDescriptor::isInductionPHI(
   return true;
 }
 
-// Recognize monotonic phi variable by matching the following pattern:
+// Recognize a monotonic PHI variable by matching the following pattern:
 // loop_header:
-//   %monotonic_phi = phi [ %start, %preheader ], [ %chain_phi0, %latch ]
+//   %monotonic_phi = phi [ %start, %preheader ], [ %latch_phi, %latch ]
 //   br i1 %do_step, label %step_bb, label %latch
 //
 // step_bb:
@@ -1707,36 +1707,38 @@ bool InductionDescriptor::isInductionPHI(
 //   br label %latch
 //
 // latch:
-//   %chain_phi0 = phi [ %monotonic_phi, %loop_header ], [ %step, %step_bb ]
+//   %latch_phi = phi [ %monotonic_phi, %loop_header ], [ %step, %step_bb ]
 //   br label %loop_header
-//
-// For this pattern, monotonic phi is described by {%start, +, %step}
-// recurrence and predicate is CFG edge %step_bb -> %latch.
 bool MonotonicDescriptor::isMonotonicPHI(PHINode *HeaderPHI, const Loop *L,
                                          MonotonicDescriptor &Desc,
                                          ScalarEvolution &SE) {
-  if (!L->getLoopPreheader() || !HeaderPHI->getType()->isIntOrPtrTy() ||
+  BasicBlock *Preheader = L->getLoopPreheader();
+  if (!Preheader)
+    return false;
+
+  BasicBlock *Latch = L->getLoopLatch();
+  if (!Latch || !HeaderPHI->getType()->isIntOrPtrTy() ||
       HeaderPHI->getParent() != L->getHeader())
     return false;
+
   auto *BackedgePHI =
-      dyn_cast<PHINode>(HeaderPHI->getIncomingValueForBlock(L->getLoopLatch()));
+      dyn_cast<PHINode>(HeaderPHI->getIncomingValueForBlock(Latch));
   if (!BackedgePHI)
     return false;
 
   // Ensure the only users of the backedge PHI are outside the loop or the
   // header PHI.
-  bool BackedgeValueUsesValid = all_of(BackedgePHI->users(), [&](User *U) {
+  for (User *U : BackedgePHI->users()) {
     auto *UI = dyn_cast<Instruction>(U);
-    return UI == HeaderPHI || (UI && !L->contains(UI));
-  });
-  if (!BackedgeValueUsesValid)
-    return false;
+    if (UI && UI != HeaderPHI && L->contains(UI))
+      return false;
+  }
 
   // Find the step operation used to increment the value of the monotonic PHI.
   // TODO: Support chains of PHIs.
   Value *StepOp = find_singleton<Value>(
       BackedgePHI->incoming_values(),
-      [&](Use &Incoming, bool /*AllowRepeasts*/) {
+      [&](Use &Incoming, bool /*AllowRepeats*/) {
         return Incoming != HeaderPHI ? Incoming.get() : nullptr;
       });
   if (!StepOp || !StepOp->hasOneUse())
@@ -1746,8 +1748,6 @@ bool MonotonicDescriptor::isMonotonicPHI(PHINode *HeaderPHI, const Loop *L,
   if (!StepInst)
     return false;
 
-  Value *Start = HeaderPHI->getIncomingValueForBlock(L->getLoopPreheader());
-
   Value *Step = nullptr;
   bool StepMatch =
       HeaderPHI->getType()->isPointerTy()
@@ -1756,28 +1756,35 @@ bool MonotonicDescriptor::isMonotonicPHI(PHINode *HeaderPHI, const Loop *L,
   if (!StepMatch || !L->isLoopInvariant(Step))
     return false;
 
-  SCEV::NoWrapFlags WrapFlags = SCEV::FlagAnyWrap;
+  // Ensure GEP offsets are extended to the size of the PHI.
+  const SCEV *StepSCEV = SE.getTruncateOrSignExtend(
+      SE.getSCEV(Step), SE.getEffectiveSCEVType(HeaderPHI->getType()));
+
+  if (StepSCEV->isZero())
+    return false;
+
+  Value *Start = HeaderPHI->getIncomingValueForBlock(Preheader);
+  const SCEV *StartSCEV = SE.getSCEV(Start);
+
+  assert(StepSCEV->getType() == StepSCEV->getType());
+
+  SCEV::NoWrapFlags NoWrapFlags = SCEV::FlagAnyWrap;
   if (auto *GEP = dyn_cast<GEPOperator>(StepInst)) {
     if (GEP->hasNoUnsignedWrap())
-      WrapFlags = ScalarEvolution::setFlags(WrapFlags, SCEV::FlagNUW);
+      NoWrapFlags = ScalarEvolution::setFlags(NoWrapFlags, SCEV::FlagNUW);
     if (GEP->hasNoUnsignedSignedWrap())
-      WrapFlags = ScalarEvolution::setFlags(WrapFlags, SCEV::FlagNSW);
+      NoWrapFlags = ScalarEvolution::setFlags(NoWrapFlags, SCEV::FlagNSW);
   } else if (auto *OBO = dyn_cast<OverflowingBinaryOperator>(StepInst)) {
     if (OBO->hasNoUnsignedWrap())
-      WrapFlags = ScalarEvolution::setFlags(WrapFlags, SCEV::FlagNUW);
+      NoWrapFlags = ScalarEvolution::setFlags(NoWrapFlags, SCEV::FlagNUW);
     if (OBO->hasNoSignedWrap())
-      WrapFlags = ScalarEvolution::setFlags(WrapFlags, SCEV::FlagNSW);
+      NoWrapFlags = ScalarEvolution::setFlags(NoWrapFlags, SCEV::FlagNSW);
   }
-
-  const SCEV *PhiSCEV =
-      SE.getAddRecExpr(SE.getSCEV(Start), SE.getSCEV(Step), L, WrapFlags);
-  const SCEVAddRecExpr *PhiAddRec = dyn_cast<SCEVAddRecExpr>(PhiSCEV);
-  if (!PhiAddRec || !PhiAddRec->isAffine())
-    return false;
 
   LLVM_DEBUG(dbgs() << "LV: Found a monotonic phi: HeaderPHI: " << *HeaderPHI
                     << ", StepInst: " << *StepInst << "\n");
 
-  Desc = MonotonicDescriptor(HeaderPHI, BackedgePHI, StepInst, PhiAddRec);
+  Desc = MonotonicDescriptor(HeaderPHI, BackedgePHI, StepInst, StartSCEV,
+                             StepSCEV, to_underlying(NoWrapFlags));
   return true;
 }

--- a/llvm/lib/Analysis/IVDescriptors.cpp
+++ b/llvm/lib/Analysis/IVDescriptors.cpp
@@ -1715,7 +1715,7 @@ bool InductionDescriptor::isInductionPHI(
 bool MonotonicDescriptor::isMonotonicPHI(PHINode *HeaderPHI, const Loop *L,
                                          MonotonicDescriptor &Desc,
                                          ScalarEvolution &SE) {
-  if (!HeaderPHI->getType()->isIntOrPtrTy() ||
+  if (!L->getLoopPreheader() || !HeaderPHI->getType()->isIntOrPtrTy() ||
       HeaderPHI->getParent() != L->getHeader())
     return false;
   auto *BackedgePHI =
@@ -1734,16 +1734,15 @@ bool MonotonicDescriptor::isMonotonicPHI(PHINode *HeaderPHI, const Loop *L,
 
   // Find the step operation used to increment the value of the monotonic PHI.
   // TODO: Support chains of PHIs.
-  Value *StepOp = nullptr;
-  for (Use &Incoming : BackedgePHI->incoming_values()) {
-    if (Incoming == HeaderPHI)
-      continue;
-    if (StepOp || !Incoming->hasOneUse())
-      return {};
-    StepOp = Incoming;
-  }
+  Value *StepOp = find_singleton<Value>(
+      BackedgePHI->incoming_values(),
+      [&](Use &Incoming, bool /*AllowRepeasts*/) {
+        return Incoming != HeaderPHI ? Incoming.get() : nullptr;
+      });
+  if (!StepOp || !StepOp->hasOneUse())
+    return false;
 
-  auto *StepInst = dyn_cast_if_present<Instruction>(StepOp);
+  auto *StepInst = dyn_cast<Instruction>(StepOp);
   if (!StepInst)
     return false;
 

--- a/llvm/lib/Analysis/IVDescriptors.cpp
+++ b/llvm/lib/Analysis/IVDescriptors.cpp
@@ -1766,14 +1766,13 @@ bool MonotonicDescriptor::isMonotonicPHI(PHINode *HeaderPHI, const Loop *L,
   Value *Start = HeaderPHI->getIncomingValueForBlock(Preheader);
   const SCEV *StartSCEV = SE.getSCEV(Start);
 
-  assert(StepSCEV->getType() == StepSCEV->getType());
-
   SCEV::NoWrapFlags NoWrapFlags = SCEV::FlagAnyWrap;
   if (auto *GEP = dyn_cast<GEPOperator>(StepInst)) {
-    if (GEP->hasNoUnsignedWrap())
+    // With NUSW, we can add NUW if the step is non-negative. We can't add NSW
+    // as the base address is unsigned.
+    if (GEP->hasNoUnsignedWrap() ||
+        (GEP->hasNoUnsignedSignedWrap() && SE.isKnownNonNegative(StepSCEV)))
       NoWrapFlags = ScalarEvolution::setFlags(NoWrapFlags, SCEV::FlagNUW);
-    if (GEP->hasNoUnsignedSignedWrap())
-      NoWrapFlags = ScalarEvolution::setFlags(NoWrapFlags, SCEV::FlagNSW);
   } else if (auto *OBO = dyn_cast<OverflowingBinaryOperator>(StepInst)) {
     if (OBO->hasNoUnsignedWrap())
       NoWrapFlags = ScalarEvolution::setFlags(NoWrapFlags, SCEV::FlagNUW);

--- a/llvm/lib/Analysis/IVDescriptors.cpp
+++ b/llvm/lib/Analysis/IVDescriptors.cpp
@@ -1697,83 +1697,63 @@ bool InductionDescriptor::isInductionPHI(
   return true;
 }
 
-bool MonotonicDescriptor::setSCEV(const SCEV *NewExpr) {
-  auto *AddRec = dyn_cast<SCEVAddRecExpr>(NewExpr);
-  if (!AddRec || !AddRec->isAffine())
-    return false;
-  Expr = AddRec;
-  return true;
-}
-
 // Recognize monotonic phi variable by matching the following pattern:
 // loop_header:
-//   %monotonic_phi = [%start, %preheader], [%chain_phi0, %latch]
+//   %monotonic_phi = phi [ %start, %preheader ], [ %chain_phi0, %latch ]
+//   br i1 %do_step, label %step_bb, label %latch
 //
 // step_bb:
 //   %step = add/gep %monotonic_phi, %step_val
-//
-// bbN:
-//   %chain_phiN = [%monotonic_phi, ], [%step, ]
-//
-// ...
-//
-// bb1:
-//   %chain_phi1 = [%monotonic_phi, ], [%chain_phi2, ]
+//   br label %latch
 //
 // latch:
-//   %chain_phi0 = [%monotonic_phi, %pred], [%chain_phi1, %pred]
+//   %chain_phi0 = phi [ %monotonic_phi, %loop_header ], [ %step, %step_bb ]
+//   br label %loop_header
 //
-// For this pattern, monotonic phi is described by {%start, +, %step} recurrence
-// and predicate is CFG edge %step_bb -> %bbN.
-bool MonotonicDescriptor::isMonotonicPHI(PHINode *PN, const Loop *L,
+// For this pattern, monotonic phi is described by {%start, +, %step}
+// recurrence and predicate is CFG edge %step_bb -> %latch.
+bool MonotonicDescriptor::isMonotonicPHI(PHINode *HeaderPHI, const Loop *L,
                                          MonotonicDescriptor &Desc,
                                          ScalarEvolution &SE) {
-  if (!PN->getType()->isIntOrPtrTy() || PN->getParent() != L->getHeader())
+  if (!HeaderPHI->getType()->isIntOrPtrTy() ||
+      HeaderPHI->getParent() != L->getHeader())
     return false;
-  auto *BackEdgeInst =
-      dyn_cast<PHINode>(PN->getIncomingValueForBlock(L->getLoopLatch()));
-  if (!BackEdgeInst)
+  auto *BackedgePHI =
+      dyn_cast<PHINode>(HeaderPHI->getIncomingValueForBlock(L->getLoopLatch()));
+  if (!BackedgePHI)
     return false;
-  PHINode *PHIChain = BackEdgeInst;
-  std::optional<std::pair<Edge, Value *>> Inc;
-  while (PHIChain) {
-    Desc.Chain.insert(PHIChain);
-    PHINode *NextPHIChain = nullptr;
-    for (auto [Block, Incoming] :
-         zip_equal(PHIChain->blocks(), PHIChain->incoming_values())) {
-      if (Incoming == PN)
-        continue;
-      if (!Incoming->hasOneUse())
-        return false;
-      if (auto *IncomingPHI = dyn_cast<PHINode>(Incoming)) {
-        if (NextPHIChain)
-          return false;
-        NextPHIChain = IncomingPHI;
-        continue;
-      }
-      if (Inc || NextPHIChain)
-        return false;
-      Inc = std::make_pair(Edge{Block, PHIChain->getParent()}, Incoming.get());
-    }
-    PHIChain = NextPHIChain;
+
+  // Ensure the only users of the backedge PHI are outside the loop or the
+  // header PHI.
+  bool BackedgeValueUsesValid = all_of(BackedgePHI->users(), [&](User *U) {
+    auto *UI = dyn_cast<Instruction>(U);
+    return UI == HeaderPHI || (UI && !L->contains(UI));
+  });
+  if (!BackedgeValueUsesValid)
+    return false;
+
+  // Find the step operation used to increment the value of the monotonic PHI.
+  // TODO: Support chains of PHIs.
+  Value *StepOp = nullptr;
+  for (Use &Incoming : BackedgePHI->incoming_values()) {
+    if (Incoming == HeaderPHI)
+      continue;
+    if (StepOp || !Incoming->hasOneUse())
+      return {};
+    StepOp = Incoming;
   }
-  if (!Inc)
-    return false;
-  auto [PredEdge, StepOp] = *Inc;
-  auto *StepInst = dyn_cast<Instruction>(StepOp);
+
+  auto *StepInst = dyn_cast_if_present<Instruction>(StepOp);
   if (!StepInst)
     return false;
-  Desc.StepInst = StepInst;
-  Desc.PredEdge = PredEdge;
 
-  // Construct SCEVAddRec for this value.
-  Value *Start = PN->getIncomingValueForBlock(L->getLoopPreheader());
+  Value *Start = HeaderPHI->getIncomingValueForBlock(L->getLoopPreheader());
 
   Value *Step = nullptr;
   bool StepMatch =
-      PN->getType()->isPointerTy()
-          ? match(StepInst, m_PtrAdd(m_Specific(PN), m_Value(Step)))
-          : match(StepInst, m_Add(m_Specific(PN), m_Value(Step)));
+      HeaderPHI->getType()->isPointerTy()
+          ? match(StepInst, m_PtrAdd(m_Specific(HeaderPHI), m_Value(Step)))
+          : match(StepInst, m_c_Add(m_Specific(HeaderPHI), m_Value(Step)));
   if (!StepMatch || !L->isLoopInvariant(Step))
     return false;
 
@@ -1790,30 +1770,15 @@ bool MonotonicDescriptor::isMonotonicPHI(PHINode *PN, const Loop *L,
       WrapFlags = ScalarEvolution::setFlags(WrapFlags, SCEV::FlagNSW);
   }
 
-  return Desc.setSCEV(
-      SE.getAddRecExpr(SE.getSCEV(Start), SE.getSCEV(Step), L, WrapFlags));
-}
-
-bool MonotonicDescriptor::isMonotonicVal(Value *Val, const Loop *L,
-                                         MonotonicDescriptor &Desc,
-                                         ScalarEvolution &SE) {
-  if (!Val->getType()->isIntOrPtrTy() || L->isLoopInvariant(Val))
-    return false;
-  auto *CurInst = cast<Instruction>(Val);
-
-  auto LoopVariantVal = [&](Value *V, bool AllowRepeats) {
-    return L->isLoopInvariant(V) ? nullptr : cast<Instruction>(V);
-  };
-
-  while (!isa<PHINode>(CurInst)) {
-    CurInst = find_singleton<Instruction>(CurInst->operands(), LoopVariantVal);
-    if (!CurInst)
-      return false;
-  };
-
-  if (!isMonotonicPHI(cast<PHINode>(CurInst), L, Desc, SE))
+  const SCEV *PhiSCEV =
+      SE.getAddRecExpr(SE.getSCEV(Start), SE.getSCEV(Step), L, WrapFlags);
+  const SCEVAddRecExpr *PhiAddRec = dyn_cast<SCEVAddRecExpr>(PhiSCEV);
+  if (!PhiAddRec || !PhiAddRec->isAffine())
     return false;
 
-  ValueToSCEVMapTy Map{{CurInst, Desc.getExpr()}};
-  return Desc.setSCEV(SCEVParameterRewriter::rewrite(SE.getSCEV(Val), SE, Map));
+  LLVM_DEBUG(dbgs() << "LV: Found a monotonic phi: HeaderPHI: " << *HeaderPHI
+                    << ", StepInst: " << *StepInst << "\n");
+
+  Desc = MonotonicDescriptor(HeaderPHI, BackedgePHI, StepInst, PhiAddRec);
+  return true;
 }

--- a/llvm/lib/Analysis/IVDescriptors.cpp
+++ b/llvm/lib/Analysis/IVDescriptors.cpp
@@ -1729,8 +1729,8 @@ bool MonotonicDescriptor::isMonotonicPHI(PHINode *HeaderPHI, const Loop *L,
   // Ensure the only users of the backedge PHI are outside the loop or the
   // header PHI.
   for (User *U : BackedgePHI->users()) {
-    auto *UI = dyn_cast<Instruction>(U);
-    if (UI && UI != HeaderPHI && L->contains(UI))
+    auto *UI = cast<Instruction>(U);
+    if (UI != HeaderPHI && L->contains(UI))
       return false;
   }
 

--- a/llvm/unittests/Analysis/IVDescriptorsTest.cpp
+++ b/llvm/unittests/Analysis/IVDescriptorsTest.cpp
@@ -10,6 +10,7 @@
 #include "llvm/Analysis/AssumptionCache.h"
 #include "llvm/Analysis/LoopInfo.h"
 #include "llvm/Analysis/ScalarEvolution.h"
+#include "llvm/Analysis/ScalarEvolutionExpressions.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/AsmParser/Parser.h"
 #include "llvm/IR/Dominators.h"
@@ -429,4 +430,156 @@ TEST(IVDescriptorsTest, InvariantStoreNoSCEV) {
                              RecurrenceDescriptor::isReductionPHI(Phi, L, Rdx);
                          EXPECT_FALSE(IsRdxPhi);
                        });
+}
+
+TEST(IVDescriptorsTest, MonotonicIntVar) {
+  // Parse the module.
+  LLVMContext Context;
+
+  std::unique_ptr<Module> M =
+      parseIR(Context,
+              R"(define void @foo(ptr %dst, i1 %cond, i64 %n) {
+entry:
+  br label %for.body
+
+for.body:
+  %i = phi i64 [ 0, %entry ], [ %i.next, %for.inc ]
+  %monotonic = phi i32 [ 0, %entry ], [ %monotonic.next, %for.inc ]
+  br i1 %cond, label %if.then, label %for.inc
+
+if.then:
+  %inc = add nsw i32 %monotonic, 1
+  %monotonic.prom = sext i32 %monotonic to i64
+  %arrayidx = getelementptr inbounds i32, ptr %dst, i64 %monotonic.prom
+  br label %for.inc
+
+for.inc:
+  %monotonic.next = phi i32 [ %inc, %if.then ], [ %monotonic, %for.body ]
+  %i.next = add nuw nsw i64 %i, 1
+  %exitcond.not = icmp eq i64 %i.next, %n
+  br i1 %exitcond.not, label %for.end, label %for.body
+
+for.end:
+  ret void
+})");
+
+  runWithLoopInfoAndSE(
+      *M, "foo", [&](Function &F, LoopInfo &LI, ScalarEvolution &SE) {
+        Function::iterator FI = F.begin();
+        // First basic block is entry - skip it.
+        BasicBlock *Header = &*(++FI);
+        assert(Header->getName() == "for.body");
+        Loop *L = LI.getLoopFor(Header);
+        EXPECT_NE(L, nullptr);
+        BasicBlock::iterator BBI = Header->begin();
+        assert((&*BBI)->getName() == "i");
+        PHINode *Phi = dyn_cast<PHINode>(&*(++BBI));
+        assert(Phi->getName() == "monotonic");
+        BasicBlock *IfThen = &*(++FI);
+        assert(IfThen->getName() == "if.then");
+        BBI = IfThen->begin();
+        Instruction *StepInst = &*BBI;
+        assert(StepInst->getName() == "inc");
+        Instruction *ExtInst = &*(++BBI);
+        assert(ExtInst->getName() == "monotonic.prom");
+        Instruction *GEPInst = &*(++BBI);
+        assert(GEPInst->getName() == "arrayidx");
+        BasicBlock *IfEnd = &*(++FI);
+        assert(IfEnd->getName() == "for.inc");
+        auto *ChainPhi = dyn_cast<PHINode>(&*(IfEnd->begin()));
+        assert(ChainPhi->getName() == "monotonic.next");
+        // Check %monotonic descriptor.
+        MonotonicDescriptor Desc;
+        bool IsMonotonicPhi =
+            MonotonicDescriptor::isMonotonicPHI(Phi, L, Desc, SE);
+        EXPECT_TRUE(IsMonotonicPhi);
+        auto &PhiChain = Desc.getChain();
+        EXPECT_TRUE(PhiChain.size() == 1 && PhiChain.contains(ChainPhi));
+        EXPECT_EQ(Desc.getStepInst(), StepInst);
+        EXPECT_EQ(Desc.getPredicateEdge(),
+                  MonotonicDescriptor::Edge(IfThen, IfEnd));
+        auto *StartSCEV = SE.getConstant(Phi->getType(), 0);
+        auto *StepSCEV = SE.getConstant(Phi->getType(), 1);
+        EXPECT_EQ(Desc.getExpr(),
+                  SE.getAddRecExpr(StartSCEV, StepSCEV, L, SCEV::FlagNW));
+        // Check %arrayidx descriptor.
+        bool IsMonotonicVal =
+            MonotonicDescriptor::isMonotonicVal(GEPInst, L, Desc, SE);
+        EXPECT_TRUE(IsMonotonicVal);
+        // Chain, StepInst and PredicateEdge are the same with %monotonic.
+        auto &ValChain = Desc.getChain();
+        EXPECT_TRUE(ValChain.size() == 1 && ValChain.contains(ChainPhi));
+        EXPECT_EQ(Desc.getStepInst(), StepInst);
+        EXPECT_EQ(Desc.getPredicateEdge(),
+                  MonotonicDescriptor::Edge(IfThen, IfEnd));
+        StartSCEV = SE.getSCEV(F.getArg(0));
+        StepSCEV = SE.getConstant(StartSCEV->getType(), 4);
+        EXPECT_EQ(Desc.getExpr(),
+                  SE.getAddRecExpr(StartSCEV, StepSCEV, L, SCEV::FlagNW));
+      });
+}
+
+TEST(IVDescriptorsTest, MonotonicPtrVar) {
+  // Parse the module.
+  LLVMContext Context;
+
+  std::unique_ptr<Module> M =
+      parseIR(Context,
+              R"(define void @foo(ptr %start, i1 %cond, i64 %n) {
+entry:
+  br label %for.body
+
+for.body:
+  %i = phi i64 [ 0, %entry ], [ %i.next, %for.inc ]
+  %monotonic = phi ptr [ %start, %entry ], [ %monotonic.next, %for.inc ]
+  br i1 %cond, label %if.then, label %for.inc
+
+if.then:
+  %inc = getelementptr inbounds i8, ptr %monotonic, i64 4
+  br label %for.inc
+
+for.inc:
+  %monotonic.next = phi ptr [ %inc, %if.then ], [ %monotonic, %for.body ]
+  %i.next = add nuw nsw i64 %i, 1
+  %exitcond.not = icmp eq i64 %i.next, %n
+  br i1 %exitcond.not, label %for.end, label %for.body
+
+for.end:
+  ret void
+})");
+
+  runWithLoopInfoAndSE(
+      *M, "foo", [&](Function &F, LoopInfo &LI, ScalarEvolution &SE) {
+        Function::iterator FI = F.begin();
+        // First basic block is entry - skip it.
+        BasicBlock *Header = &*(++FI);
+        assert(Header->getName() == "for.body");
+        Loop *L = LI.getLoopFor(Header);
+        EXPECT_NE(L, nullptr);
+        BasicBlock::iterator BBI = Header->begin();
+        assert((&*BBI)->getName() == "i");
+        PHINode *Phi = dyn_cast<PHINode>(&*(++BBI));
+        assert(Phi->getName() == "monotonic");
+        BasicBlock *IfThen = &*(++FI);
+        assert(IfThen->getName() == "if.then");
+        Instruction *StepInst = &*(IfThen->begin());
+        assert(StepInst->getName() == "inc");
+        BasicBlock *IfEnd = &*(++FI);
+        assert(IfEnd->getName() == "for.inc");
+        auto *ChainPhi = dyn_cast<PHINode>(&*(IfEnd->begin()));
+        assert(ChainPhi->getName() == "monotonic.next");
+        MonotonicDescriptor Desc;
+        bool IsMonotonicPhi =
+            MonotonicDescriptor::isMonotonicPHI(Phi, L, Desc, SE);
+        EXPECT_TRUE(IsMonotonicPhi);
+        auto &Chain = Desc.getChain();
+        EXPECT_TRUE(Chain.size() == 1 && Chain.contains(ChainPhi));
+        EXPECT_EQ(Desc.getStepInst(), StepInst);
+        EXPECT_EQ(Desc.getPredicateEdge(),
+                  MonotonicDescriptor::Edge(IfThen, IfEnd));
+        auto *StartSCEV = SE.getSCEV(F.getArg(0));
+        auto *StepSCEV = SE.getConstant(StartSCEV->getType(), 4);
+        EXPECT_EQ(Desc.getExpr(),
+                  SE.getAddRecExpr(StartSCEV, StepSCEV, L, SCEV::FlagNW));
+      });
 }

--- a/llvm/unittests/Analysis/IVDescriptorsTest.cpp
+++ b/llvm/unittests/Analysis/IVDescriptorsTest.cpp
@@ -438,26 +438,25 @@ TEST(IVDescriptorsTest, MonotonicIntVar) {
 
   std::unique_ptr<Module> M =
       parseIR(Context,
-              R"(define void @foo(ptr %dst, i1 %cond, i64 %n) {
+              R"(define void @foo(ptr %dst, i1 %cond, i32 %n) {
 entry:
   br label %for.body
 
 for.body:
-  %i = phi i64 [ 0, %entry ], [ %i.next, %for.inc ]
+  %i = phi i32 [ 0, %entry ], [ %i.next, %for.inc ]
   %monotonic = phi i32 [ 0, %entry ], [ %monotonic.next, %for.inc ]
   br i1 %cond, label %if.then, label %for.inc
 
 if.then:
   %inc = add nsw i32 %monotonic, 1
-  %monotonic.prom = sext i32 %monotonic to i64
-  %arrayidx = getelementptr inbounds i32, ptr %dst, i64 %monotonic.prom
+  %arrayidx = getelementptr inbounds i32, ptr %dst, i32 %monotonic
   store i32 10, ptr %arrayidx, align 4
   br label %for.inc
 
 for.inc:
   %monotonic.next = phi i32 [ %inc, %if.then ], [ %monotonic, %for.body ]
-  %i.next = add nuw nsw i64 %i, 1
-  %exitcond.not = icmp eq i64 %i.next, %n
+  %i.next = add i32 %i, 1
+  %exitcond.not = icmp eq i32 %i.next, %n
   br i1 %exitcond.not, label %for.end, label %for.body
 
 for.end:
@@ -473,8 +472,9 @@ for.end:
         Loop *L = LI.getLoopFor(Header);
         EXPECT_NE(L, nullptr);
         BasicBlock::iterator BBI = Header->begin();
-        assert((&*BBI)->getName() == "i");
-        PHINode *Phi = dyn_cast<PHINode>(&*(++BBI));
+        PHINode *Induction = cast<PHINode>(&*BBI);
+        assert(Induction->getName() == "i");
+        PHINode *Phi = cast<PHINode>(&*(++BBI));
         assert(Phi->getName() == "monotonic");
         BasicBlock *IfThen = &*(++FI);
         assert(IfThen->getName() == "if.then");
@@ -487,10 +487,15 @@ for.end:
             MonotonicDescriptor::isMonotonicPHI(Phi, L, Desc, SE);
         EXPECT_TRUE(IsMonotonicPhi);
         EXPECT_EQ(Desc.getStepInst(), StepInst);
-        auto *StartSCEV = SE.getConstant(Phi->getType(), 0);
-        auto *StepSCEV = SE.getConstant(Phi->getType(), 1);
-        EXPECT_EQ(Desc.getPhiSCEV(),
-                  SE.getAddRecExpr(StartSCEV, StepSCEV, L, SCEV::FlagNW));
+        // Check the wrap flags for %i (the normal induction) don't include NSW.
+        // Note: `Induction` has the same start/step as the monotonic induction.
+        const SCEV *OrigInSCEV = SE.getSCEV(Induction);
+        auto *AR = cast<SCEVAddRecExpr>(OrigInSCEV);
+        EXPECT_EQ(AR->getNoWrapFlags(), SCEV::FlagNUW | SCEV::FlagNW);
+        // Check the expressions and wrap flags for the monotonic induction.
+        EXPECT_EQ(SCEV::NoWrapFlags(Desc.getSCEVNoWrapFlags()), SCEV::FlagNSW);
+        EXPECT_EQ(Desc.getStartSCEV(), AR->getStart());
+        EXPECT_EQ(Desc.getStepSCEV(), AR->getStepRecurrence(SE));
       });
 }
 
@@ -510,7 +515,7 @@ for.body:
   br i1 %cond, label %if.then, label %for.inc
 
 if.then:
-  %inc = getelementptr inbounds i8, ptr %monotonic, i64 4
+  %inc = getelementptr inbounds i8, ptr %monotonic, i32 4
   br label %for.inc
 
 for.inc:
@@ -533,7 +538,7 @@ for.end:
         EXPECT_NE(L, nullptr);
         BasicBlock::iterator BBI = Header->begin();
         assert((&*BBI)->getName() == "i");
-        PHINode *Phi = dyn_cast<PHINode>(&*(++BBI));
+        PHINode *Phi = cast<PHINode>(&*(++BBI));
         assert(Phi->getName() == "monotonic");
         BasicBlock *IfThen = &*(++FI);
         assert(IfThen->getName() == "if.then");
@@ -546,8 +551,9 @@ for.end:
         EXPECT_EQ(Desc.getStepInst(), StepInst);
         auto *StartSCEV = SE.getSCEV(F.getArg(0));
         auto *StepSCEV = SE.getConstant(StartSCEV->getType(), 4);
-        EXPECT_EQ(Desc.getPhiSCEV(),
-                  SE.getAddRecExpr(StartSCEV, StepSCEV, L, SCEV::FlagNW));
+        EXPECT_EQ(Desc.getStartSCEV(), StartSCEV);
+        EXPECT_EQ(Desc.getStepSCEV(), StepSCEV);
+        EXPECT_EQ(SCEV::NoWrapFlags(Desc.getSCEVNoWrapFlags()), SCEV::FlagNSW);
       });
 }
 
@@ -595,7 +601,7 @@ for.end:
         EXPECT_NE(L, nullptr);
         BasicBlock::iterator BBI = Header->begin();
         assert((&*BBI)->getName() == "i");
-        PHINode *Phi = dyn_cast<PHINode>(&*(++BBI));
+        PHINode *Phi = cast<PHINode>(&*(++BBI));
         assert(Phi->getName() == "monotonic");
         BasicBlock *IfThen = &*(++FI);
         assert(IfThen->getName() == "if.then");

--- a/llvm/unittests/Analysis/IVDescriptorsTest.cpp
+++ b/llvm/unittests/Analysis/IVDescriptorsTest.cpp
@@ -451,6 +451,7 @@ if.then:
   %inc = add nsw i32 %monotonic, 1
   %monotonic.prom = sext i32 %monotonic to i64
   %arrayidx = getelementptr inbounds i32, ptr %dst, i64 %monotonic.prom
+  store i32 10, ptr %arrayidx, align 4
   br label %for.inc
 
 for.inc:
@@ -486,35 +487,15 @@ for.end:
         assert(GEPInst->getName() == "arrayidx");
         BasicBlock *IfEnd = &*(++FI);
         assert(IfEnd->getName() == "for.inc");
-        auto *ChainPhi = dyn_cast<PHINode>(&*(IfEnd->begin()));
-        assert(ChainPhi->getName() == "monotonic.next");
         // Check %monotonic descriptor.
         MonotonicDescriptor Desc;
         bool IsMonotonicPhi =
             MonotonicDescriptor::isMonotonicPHI(Phi, L, Desc, SE);
         EXPECT_TRUE(IsMonotonicPhi);
-        auto &PhiChain = Desc.getChain();
-        EXPECT_TRUE(PhiChain.size() == 1 && PhiChain.contains(ChainPhi));
         EXPECT_EQ(Desc.getStepInst(), StepInst);
-        EXPECT_EQ(Desc.getPredicateEdge(),
-                  MonotonicDescriptor::Edge(IfThen, IfEnd));
         auto *StartSCEV = SE.getConstant(Phi->getType(), 0);
         auto *StepSCEV = SE.getConstant(Phi->getType(), 1);
-        EXPECT_EQ(Desc.getExpr(),
-                  SE.getAddRecExpr(StartSCEV, StepSCEV, L, SCEV::FlagNW));
-        // Check %arrayidx descriptor.
-        bool IsMonotonicVal =
-            MonotonicDescriptor::isMonotonicVal(GEPInst, L, Desc, SE);
-        EXPECT_TRUE(IsMonotonicVal);
-        // Chain, StepInst and PredicateEdge are the same with %monotonic.
-        auto &ValChain = Desc.getChain();
-        EXPECT_TRUE(ValChain.size() == 1 && ValChain.contains(ChainPhi));
-        EXPECT_EQ(Desc.getStepInst(), StepInst);
-        EXPECT_EQ(Desc.getPredicateEdge(),
-                  MonotonicDescriptor::Edge(IfThen, IfEnd));
-        StartSCEV = SE.getSCEV(F.getArg(0));
-        StepSCEV = SE.getConstant(StartSCEV->getType(), 4);
-        EXPECT_EQ(Desc.getExpr(),
+        EXPECT_EQ(Desc.getPhiSCEV(),
                   SE.getAddRecExpr(StartSCEV, StepSCEV, L, SCEV::FlagNW));
       });
 }
@@ -566,20 +547,14 @@ for.end:
         assert(StepInst->getName() == "inc");
         BasicBlock *IfEnd = &*(++FI);
         assert(IfEnd->getName() == "for.inc");
-        auto *ChainPhi = dyn_cast<PHINode>(&*(IfEnd->begin()));
-        assert(ChainPhi->getName() == "monotonic.next");
         MonotonicDescriptor Desc;
         bool IsMonotonicPhi =
             MonotonicDescriptor::isMonotonicPHI(Phi, L, Desc, SE);
         EXPECT_TRUE(IsMonotonicPhi);
-        auto &Chain = Desc.getChain();
-        EXPECT_TRUE(Chain.size() == 1 && Chain.contains(ChainPhi));
         EXPECT_EQ(Desc.getStepInst(), StepInst);
-        EXPECT_EQ(Desc.getPredicateEdge(),
-                  MonotonicDescriptor::Edge(IfThen, IfEnd));
         auto *StartSCEV = SE.getSCEV(F.getArg(0));
         auto *StepSCEV = SE.getConstant(StartSCEV->getType(), 4);
-        EXPECT_EQ(Desc.getExpr(),
+        EXPECT_EQ(Desc.getPhiSCEV(),
                   SE.getAddRecExpr(StartSCEV, StepSCEV, L, SCEV::FlagNW));
       });
 }

--- a/llvm/unittests/Analysis/IVDescriptorsTest.cpp
+++ b/llvm/unittests/Analysis/IVDescriptorsTest.cpp
@@ -553,7 +553,7 @@ for.end:
         auto *StepSCEV = SE.getConstant(StartSCEV->getType(), 4);
         EXPECT_EQ(Desc.getStartSCEV(), StartSCEV);
         EXPECT_EQ(Desc.getStepSCEV(), StepSCEV);
-        EXPECT_EQ(SCEV::NoWrapFlags(Desc.getSCEVNoWrapFlags()), SCEV::FlagNSW);
+        EXPECT_EQ(SCEV::NoWrapFlags(Desc.getSCEVNoWrapFlags()), SCEV::FlagNUW);
       });
 }
 

--- a/llvm/unittests/Analysis/IVDescriptorsTest.cpp
+++ b/llvm/unittests/Analysis/IVDescriptorsTest.cpp
@@ -481,12 +481,6 @@ for.end:
         BBI = IfThen->begin();
         Instruction *StepInst = &*BBI;
         assert(StepInst->getName() == "inc");
-        Instruction *ExtInst = &*(++BBI);
-        assert(ExtInst->getName() == "monotonic.prom");
-        Instruction *GEPInst = &*(++BBI);
-        assert(GEPInst->getName() == "arrayidx");
-        BasicBlock *IfEnd = &*(++FI);
-        assert(IfEnd->getName() == "for.inc");
         // Check %monotonic descriptor.
         MonotonicDescriptor Desc;
         bool IsMonotonicPhi =
@@ -545,8 +539,6 @@ for.end:
         assert(IfThen->getName() == "if.then");
         Instruction *StepInst = &*(IfThen->begin());
         assert(StepInst->getName() == "inc");
-        BasicBlock *IfEnd = &*(++FI);
-        assert(IfEnd->getName() == "for.inc");
         MonotonicDescriptor Desc;
         bool IsMonotonicPhi =
             MonotonicDescriptor::isMonotonicPHI(Phi, L, Desc, SE);
@@ -556,5 +548,64 @@ for.end:
         auto *StepSCEV = SE.getConstant(StartSCEV->getType(), 4);
         EXPECT_EQ(Desc.getPhiSCEV(),
                   SE.getAddRecExpr(StartSCEV, StepSCEV, L, SCEV::FlagNW));
+      });
+}
+
+TEST(IVDescriptorsTest, InvalidMonotonicExtraStep) {
+  // Parse the module.
+  LLVMContext Context;
+
+  std::unique_ptr<Module> M =
+      parseIR(Context,
+              R"(define void @foo(ptr %dst, i1 %cond, i1 %cond2, i64 %n) {
+entry:
+  br label %for.body
+
+for.body:
+  %i = phi i64 [ 0, %entry ], [ %i.next, %for.inc ]
+  %monotonic = phi i32 [ 0, %entry ], [ %monotonic.next, %for.inc ]
+  br i1 %cond, label %if.then, label %for.inc
+
+if.then:
+  %inc = add nsw i32 %monotonic, 1
+  %monotonic.prom = sext i32 %monotonic to i64
+  %arrayidx = getelementptr inbounds i32, ptr %dst, i64 %monotonic.prom
+  store i32 10, ptr %arrayidx, align 4
+  br i1 %cond2, label %if.then1, label %for.inc
+if.then1:
+  %inc2 = add nsw i32 %monotonic, 2
+  br label %for.inc
+for.inc:
+  %monotonic.next = phi i32 [ %inc, %if.then ], [ %inc2, %if.then1 ], [ %monotonic, %for.body ]
+  %i.next = add nuw nsw i64 %i, 1
+  %exitcond.not = icmp eq i64 %i.next, %n
+  br i1 %exitcond.not, label %for.end, label %for.body
+
+for.end:
+  ret void
+})");
+
+  runWithLoopInfoAndSE(
+      *M, "foo", [&](Function &F, LoopInfo &LI, ScalarEvolution &SE) {
+        Function::iterator FI = F.begin();
+        // First basic block is entry - skip it.
+        BasicBlock *Header = &*(++FI);
+        assert(Header->getName() == "for.body");
+        Loop *L = LI.getLoopFor(Header);
+        EXPECT_NE(L, nullptr);
+        BasicBlock::iterator BBI = Header->begin();
+        assert((&*BBI)->getName() == "i");
+        PHINode *Phi = dyn_cast<PHINode>(&*(++BBI));
+        assert(Phi->getName() == "monotonic");
+        BasicBlock *IfThen = &*(++FI);
+        assert(IfThen->getName() == "if.then");
+        BBI = IfThen->begin();
+        Instruction *StepInst = &*BBI;
+        assert(StepInst->getName() == "inc");
+        // Check %monotonic descriptor.
+        MonotonicDescriptor Desc;
+        bool IsMonotonicPhi =
+            MonotonicDescriptor::isMonotonicPHI(Phi, L, Desc, SE);
+        EXPECT_FALSE(IsMonotonicPhi);
       });
 }

--- a/llvm/unittests/Analysis/IVDescriptorsTest.cpp
+++ b/llvm/unittests/Analysis/IVDescriptorsTest.cpp
@@ -14,6 +14,7 @@
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/AsmParser/Parser.h"
 #include "llvm/IR/Dominators.h"
+#include "llvm/IR/InstIterator.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/SourceMgr.h"
 #include "gtest/gtest.h"
@@ -432,6 +433,13 @@ TEST(IVDescriptorsTest, InvariantStoreNoSCEV) {
                        });
 }
 
+static Instruction *getInstructionByName(Function &F, StringRef Name) {
+  for (auto &I : instructions(F))
+    if (I.getName() == Name)
+      return &I;
+  llvm_unreachable("Expected to find instruction!");
+}
+
 TEST(IVDescriptorsTest, MonotonicIntVar) {
   // Parse the module.
   LLVMContext Context;
@@ -471,22 +479,21 @@ for.end:
         assert(Header->getName() == "for.body");
         Loop *L = LI.getLoopFor(Header);
         EXPECT_NE(L, nullptr);
-        BasicBlock::iterator BBI = Header->begin();
-        PHINode *Induction = cast<PHINode>(&*BBI);
-        assert(Induction->getName() == "i");
-        PHINode *Phi = cast<PHINode>(&*(++BBI));
-        assert(Phi->getName() == "monotonic");
-        BasicBlock *IfThen = &*(++FI);
-        assert(IfThen->getName() == "if.then");
-        BBI = IfThen->begin();
-        Instruction *StepInst = &*BBI;
-        assert(StepInst->getName() == "inc");
+
+        Instruction *Induction = getInstructionByName(F, "i");
+        Instruction *Phi = getInstructionByName(F, "monotonic");
+        Instruction *BackedgePhi = getInstructionByName(F, "monotonic.next");
+        Instruction *StepInst = getInstructionByName(F, "inc");
+
         // Check %monotonic descriptor.
         MonotonicDescriptor Desc;
-        bool IsMonotonicPhi =
-            MonotonicDescriptor::isMonotonicPHI(Phi, L, Desc, SE);
+        bool IsMonotonicPhi = MonotonicDescriptor::isMonotonicPHI(
+            cast<PHINode>(Phi), L, Desc, SE);
         EXPECT_TRUE(IsMonotonicPhi);
+        EXPECT_EQ(Desc.getHeaderPHI(), Phi);
+        EXPECT_EQ(Desc.getBackedgePHI(), BackedgePhi);
         EXPECT_EQ(Desc.getStepInst(), StepInst);
+
         // Check the wrap flags for %i (the normal induction) don't include NSW.
         // Note: `Induction` has the same start/step as the monotonic induction.
         const SCEV *OrigInSCEV = SE.getSCEV(Induction);
@@ -536,18 +543,18 @@ for.end:
         assert(Header->getName() == "for.body");
         Loop *L = LI.getLoopFor(Header);
         EXPECT_NE(L, nullptr);
-        BasicBlock::iterator BBI = Header->begin();
-        assert((&*BBI)->getName() == "i");
-        PHINode *Phi = cast<PHINode>(&*(++BBI));
-        assert(Phi->getName() == "monotonic");
-        BasicBlock *IfThen = &*(++FI);
-        assert(IfThen->getName() == "if.then");
-        Instruction *StepInst = &*(IfThen->begin());
-        assert(StepInst->getName() == "inc");
+
+        Instruction *Phi = getInstructionByName(F, "monotonic");
+        Instruction *BackedgePhi = getInstructionByName(F, "monotonic.next");
+        Instruction *StepInst = getInstructionByName(F, "inc");
+
         MonotonicDescriptor Desc;
-        bool IsMonotonicPhi =
-            MonotonicDescriptor::isMonotonicPHI(Phi, L, Desc, SE);
+        bool IsMonotonicPhi = MonotonicDescriptor::isMonotonicPHI(
+            cast<PHINode>(Phi), L, Desc, SE);
         EXPECT_TRUE(IsMonotonicPhi);
+
+        EXPECT_EQ(Desc.getHeaderPHI(), Phi);
+        EXPECT_EQ(Desc.getBackedgePHI(), BackedgePhi);
         EXPECT_EQ(Desc.getStepInst(), StepInst);
         auto *StartSCEV = SE.getSCEV(F.getArg(0));
         auto *StepSCEV = SE.getConstant(StartSCEV->getType(), 4);
@@ -599,19 +606,63 @@ for.end:
         assert(Header->getName() == "for.body");
         Loop *L = LI.getLoopFor(Header);
         EXPECT_NE(L, nullptr);
-        BasicBlock::iterator BBI = Header->begin();
-        assert((&*BBI)->getName() == "i");
-        PHINode *Phi = cast<PHINode>(&*(++BBI));
-        assert(Phi->getName() == "monotonic");
-        BasicBlock *IfThen = &*(++FI);
-        assert(IfThen->getName() == "if.then");
-        BBI = IfThen->begin();
-        Instruction *StepInst = &*BBI;
-        assert(StepInst->getName() == "inc");
+
+        Instruction *Phi = getInstructionByName(F, "monotonic");
+
         // Check %monotonic descriptor.
         MonotonicDescriptor Desc;
-        bool IsMonotonicPhi =
-            MonotonicDescriptor::isMonotonicPHI(Phi, L, Desc, SE);
+        bool IsMonotonicPhi = MonotonicDescriptor::isMonotonicPHI(
+            cast<PHINode>(Phi), L, Desc, SE);
         EXPECT_FALSE(IsMonotonicPhi);
+      });
+}
+
+TEST(IVDescriptorsTest, MonotonicPhiNegativeStep) {
+  // Parse the module.
+  LLVMContext Context;
+
+  std::unique_ptr<Module> M =
+      parseIR(Context,
+              R"(define void @foo(ptr %dst, i1 %cond, i32 %n) {
+entry:
+  br label %for.body
+
+for.body:
+  %i = phi i32 [ 0, %entry ], [ %i.next, %for.inc ]
+  %monotonic = phi i32 [ 0, %entry ], [ %monotonic.next, %for.inc ]
+  br i1 %cond, label %if.then, label %for.inc
+
+if.then:
+  %dec = add nsw i32 %monotonic, -1
+  %arrayidx = getelementptr inbounds i32, ptr %dst, i32 %monotonic
+  store i32 10, ptr %arrayidx, align 4
+  br label %for.inc
+
+for.inc:
+  %monotonic.next = phi i32 [ %dec, %if.then ], [ %monotonic, %for.body ]
+  %i.next = add i32 %i, 1
+  %exitcond.not = icmp eq i32 %i.next, %n
+  br i1 %exitcond.not, label %for.end, label %for.body
+
+for.end:
+  ret void
+})");
+
+  runWithLoopInfoAndSE(
+      *M, "foo", [&](Function &F, LoopInfo &LI, ScalarEvolution &SE) {
+        Function::iterator FI = F.begin();
+        // First basic block is entry - skip it.
+        BasicBlock *Header = &*(++FI);
+        assert(Header->getName() == "for.body");
+        Loop *L = LI.getLoopFor(Header);
+        EXPECT_NE(L, nullptr);
+
+        Instruction *Phi = getInstructionByName(F, "monotonic");
+
+        // Check %monotonic descriptor.
+        MonotonicDescriptor Desc;
+        bool IsMonotonicPhi = MonotonicDescriptor::isMonotonicPHI(
+            cast<PHINode>(Phi), L, Desc, SE);
+        EXPECT_TRUE(IsMonotonicPhi);
       });
 }

--- a/llvm/unittests/Analysis/IVDescriptorsTest.cpp
+++ b/llvm/unittests/Analysis/IVDescriptorsTest.cpp
@@ -617,31 +617,29 @@ for.end:
       });
 }
 
-TEST(IVDescriptorsTest, MonotonicPhiNegativeStep) {
+TEST(IVDescriptorsTest, MonotonicPhiNegativeStepPtrVar) {
   // Parse the module.
   LLVMContext Context;
 
   std::unique_ptr<Module> M =
       parseIR(Context,
-              R"(define void @foo(ptr %dst, i1 %cond, i32 %n) {
+              R"(define void @foo(ptr %start, i1 %cond, i64 %n) {
 entry:
   br label %for.body
 
 for.body:
-  %i = phi i32 [ 0, %entry ], [ %i.next, %for.inc ]
-  %monotonic = phi i32 [ 0, %entry ], [ %monotonic.next, %for.inc ]
+  %i = phi i64 [ 0, %entry ], [ %i.next, %for.inc ]
+  %monotonic = phi ptr [ %start, %entry ], [ %monotonic.next, %for.inc ]
   br i1 %cond, label %if.then, label %for.inc
 
 if.then:
-  %dec = add nsw i32 %monotonic, -1
-  %arrayidx = getelementptr inbounds i32, ptr %dst, i32 %monotonic
-  store i32 10, ptr %arrayidx, align 4
+  %dec = getelementptr nusw i8, ptr %monotonic, i32 -4
   br label %for.inc
 
 for.inc:
-  %monotonic.next = phi i32 [ %dec, %if.then ], [ %monotonic, %for.body ]
-  %i.next = add i32 %i, 1
-  %exitcond.not = icmp eq i32 %i.next, %n
+  %monotonic.next = phi ptr [ %dec, %if.then ], [ %monotonic, %for.body ]
+  %i.next = add nuw nsw i64 %i, 1
+  %exitcond.not = icmp eq i64 %i.next, %n
   br i1 %exitcond.not, label %for.end, label %for.body
 
 for.end:
@@ -658,11 +656,24 @@ for.end:
         EXPECT_NE(L, nullptr);
 
         Instruction *Phi = getInstructionByName(F, "monotonic");
+        Instruction *BackedgePhi = getInstructionByName(F, "monotonic.next");
+        Instruction *StepInst = getInstructionByName(F, "dec");
 
-        // Check %monotonic descriptor.
         MonotonicDescriptor Desc;
         bool IsMonotonicPhi = MonotonicDescriptor::isMonotonicPHI(
             cast<PHINode>(Phi), L, Desc, SE);
         EXPECT_TRUE(IsMonotonicPhi);
+
+        EXPECT_EQ(Desc.getHeaderPHI(), Phi);
+        EXPECT_EQ(Desc.getBackedgePHI(), BackedgePhi);
+        EXPECT_EQ(Desc.getStepInst(), StepInst);
+        auto *StartSCEV = SE.getSCEV(F.getArg(0));
+        auto *StepSCEV = SE.getConstant(StartSCEV->getType(), -4);
+        EXPECT_EQ(Desc.getStartSCEV(), StartSCEV);
+        EXPECT_EQ(Desc.getStepSCEV(), StepSCEV);
+
+        // Check we don't add `nuw` when we have a negative GEP step.
+        EXPECT_EQ(SCEV::NoWrapFlags(Desc.getSCEVNoWrapFlags()),
+                  SCEV::FlagAnyWrap);
       });
 }


### PR DESCRIPTION
RFC link: https://discourse.llvm.org/t/rfc-loop-vectorization-of-compress-store-expand-load-patterns/86442

"Monotonic" variable is similar to induction variable, but its value is updated under some condition, e.g.:
```
int idx = 0;
for(int i = 0; i < n; ++i) {
  // some uses of idx
  if (cond)
    ++idx;
}
```
In this example, `i` is induction variable and `idx` is monotonic variable: it's updated only when cond == true. In LLVM IR, this looks like:
```
loop_header:
  %monotonic_phi = phi [ %start, %preheader ], [ %update, %latch ]
  br i1 %do_step, label %step_bb, label %latch

step_bb:
  %step = add/gep %monotonic_phi, %step_val
  br label %latch

latch:
  %update = phi [ %monotonic_phi, %loop_header ], [ %step, %step_bb ]
  br label %loop_header
```

This initial patch only matches the case where `%update` directly selects between the `%monotonic_phi` or the step. We also limit the descriptor to only matching cases where all users of the `%monotonic_phi` are loads/stores that can be mapped to expandloads or compresstores. 

This is a continuation Sergey Kachkov's patch (#140720).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>