### PR TITLE
[AMDGPU][GISel] Allow SGPR scales for amdgcn_cvt_scalef32_pk_bf16_fp8 etc.

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeRules.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeRules.cpp
@@ -2302,12 +2302,14 @@ RegBankLegalizeRules::RegBankLegalizeRules(const GCNSubtarget &_ST,
        amdgcn_cvt_scalef32_pk_bf16_fp8, amdgcn_cvt_scalef32_pk_bf16_bf8},
       Standard)
       .Div(V2S16, {{VgprV2S16}, {IntrId, Vgpr32, Vgpr32}})
+      .Uni(V2S16, {{UniInVgprV2S16}, {IntrId, Sgpr32, Sgpr32}})
       .Uni(V2S16, {{UniInVgprV2S16}, {IntrId, Vgpr32, Vgpr32}});
 
   addRulesForIOpcs(
       {amdgcn_cvt_scalef32_pk32_f32_fp6, amdgcn_cvt_scalef32_pk32_f32_bf6},
       Standard)
       .Any({{DivV32S32}, {{VgprV32S32}, {IntrId, VgprV6S32, Vgpr32}}})
+      .Any({{UniV32S32}, {{UniInVgprV32S32}, {IntrId, VgprV6S32, Sgpr32}}})
       .Any({{UniV32S32}, {{UniInVgprV32S32}, {IntrId, VgprV6S32, Vgpr32}}});
 
   addRulesForIOpcs(
@@ -2315,6 +2317,7 @@ RegBankLegalizeRules::RegBankLegalizeRules(const GCNSubtarget &_ST,
        amdgcn_cvt_scalef32_pk32_bf16_fp6, amdgcn_cvt_scalef32_pk32_bf16_bf6},
       Standard)
       .Any({{DivV32S16}, {{VgprV32S16}, {IntrId, VgprV6S32, Vgpr32}}})
+      .Any({{UniV32S16}, {{UniInVgprV32S16}, {IntrId, VgprV6S32, Sgpr32}}})
       .Any({{UniV32S16}, {{UniInVgprV32S16}, {IntrId, VgprV6S32, Vgpr32}}});
 
   addRulesForIOpcs(

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.cvt.scalef32.pk.gfx950.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.cvt.scalef32.pk.gfx950.ll
@@ -1106,11 +1106,11 @@ define <32 x half> @test_cvt_scalef32_pk32_f16_fp6_sl(<6 x i32> inreg %src) {
 ; GFX950-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-GISEL-NEXT:    s_mov_b32 s4, s16
 ; GFX950-GISEL-NEXT:    s_mov_b32 s5, s17
+; GFX950-GISEL-NEXT:    s_mov_b32 s6, 0x42c80000
 ; GFX950-GISEL-NEXT:    v_mov_b64_e32 v[20:21], s[4:5]
 ; GFX950-GISEL-NEXT:    v_mov_b64_e32 v[18:19], s[2:3]
 ; GFX950-GISEL-NEXT:    v_mov_b64_e32 v[16:17], s[0:1]
-; GFX950-GISEL-NEXT:    v_mov_b32_e32 v22, 0x42c80000
-; GFX950-GISEL-NEXT:    v_cvt_scalef32_pk32_f16_fp6 v[0:15], v[16:21], v22
+; GFX950-GISEL-NEXT:    v_cvt_scalef32_pk32_f16_fp6 v[0:15], v[16:21], s6
 ; GFX950-GISEL-NEXT:    s_setpc_b64 s[30:31]
   %ret = tail call <32 x half> @llvm.amdgcn.cvt.scalef32.pk32.f16.fp6(<6 x i32> %src, float 100.0)
   ret <32 x half> %ret
@@ -1165,11 +1165,11 @@ define <32 x bfloat> @test_cvt_scalef32_pk32_bf16_fp6_sl(<6 x i32> inreg %src) {
 ; GFX950-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-GISEL-NEXT:    s_mov_b32 s4, s16
 ; GFX950-GISEL-NEXT:    s_mov_b32 s5, s17
+; GFX950-GISEL-NEXT:    s_mov_b32 s6, 0x42c80000
 ; GFX950-GISEL-NEXT:    v_mov_b64_e32 v[20:21], s[4:5]
 ; GFX950-GISEL-NEXT:    v_mov_b64_e32 v[18:19], s[2:3]
 ; GFX950-GISEL-NEXT:    v_mov_b64_e32 v[16:17], s[0:1]
-; GFX950-GISEL-NEXT:    v_mov_b32_e32 v22, 0x42c80000
-; GFX950-GISEL-NEXT:    v_cvt_scalef32_pk32_bf16_fp6 v[0:15], v[16:21], v22
+; GFX950-GISEL-NEXT:    v_cvt_scalef32_pk32_bf16_fp6 v[0:15], v[16:21], s6
 ; GFX950-GISEL-NEXT:    s_setpc_b64 s[30:31]
   %ret = tail call <32 x bfloat> @llvm.amdgcn.cvt.scalef32.pk32.bf16.fp6(<6 x i32> %src, float 100.0)
   ret <32 x bfloat> %ret
@@ -1224,11 +1224,11 @@ define <32 x half> @test_cvt_scalef32_pk32_f16_bf6_sl(<6 x i32> inreg %src) {
 ; GFX950-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-GISEL-NEXT:    s_mov_b32 s4, s16
 ; GFX950-GISEL-NEXT:    s_mov_b32 s5, s17
+; GFX950-GISEL-NEXT:    s_mov_b32 s6, 0x42c80000
 ; GFX950-GISEL-NEXT:    v_mov_b64_e32 v[20:21], s[4:5]
 ; GFX950-GISEL-NEXT:    v_mov_b64_e32 v[18:19], s[2:3]
 ; GFX950-GISEL-NEXT:    v_mov_b64_e32 v[16:17], s[0:1]
-; GFX950-GISEL-NEXT:    v_mov_b32_e32 v22, 0x42c80000
-; GFX950-GISEL-NEXT:    v_cvt_scalef32_pk32_f16_bf6 v[0:15], v[16:21], v22
+; GFX950-GISEL-NEXT:    v_cvt_scalef32_pk32_f16_bf6 v[0:15], v[16:21], s6
 ; GFX950-GISEL-NEXT:    s_setpc_b64 s[30:31]
   %ret = tail call <32 x half> @llvm.amdgcn.cvt.scalef32.pk32.f16.bf6(<6 x i32> %src, float 100.0)
   ret <32 x half> %ret
@@ -1283,11 +1283,11 @@ define <32 x bfloat> @test_cvt_scalef32_pk32_bf16_bf6_sl(<6 x i32> inreg %src) {
 ; GFX950-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-GISEL-NEXT:    s_mov_b32 s4, s16
 ; GFX950-GISEL-NEXT:    s_mov_b32 s5, s17
+; GFX950-GISEL-NEXT:    s_mov_b32 s6, 0x42c80000
 ; GFX950-GISEL-NEXT:    v_mov_b64_e32 v[20:21], s[4:5]
 ; GFX950-GISEL-NEXT:    v_mov_b64_e32 v[18:19], s[2:3]
 ; GFX950-GISEL-NEXT:    v_mov_b64_e32 v[16:17], s[0:1]
-; GFX950-GISEL-NEXT:    v_mov_b32_e32 v22, 0x42c80000
-; GFX950-GISEL-NEXT:    v_cvt_scalef32_pk32_bf16_bf6 v[0:15], v[16:21], v22
+; GFX950-GISEL-NEXT:    v_cvt_scalef32_pk32_bf16_bf6 v[0:15], v[16:21], s6
 ; GFX950-GISEL-NEXT:    s_setpc_b64 s[30:31]
   %ret = tail call <32 x bfloat> @llvm.amdgcn.cvt.scalef32.pk32.bf16.bf6(<6 x i32> %src, float 100.0)
   ret <32 x bfloat> %ret
@@ -2761,11 +2761,11 @@ define <32 x half> @test_cvt_scalef32_pk32_f16_fp6_sl_inreg_src(<6 x i32> inreg 
 ; GFX950-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-GISEL-NEXT:    s_mov_b32 s4, s16
 ; GFX950-GISEL-NEXT:    s_mov_b32 s5, s17
+; GFX950-GISEL-NEXT:    s_mov_b32 s6, 0x42c80000
 ; GFX950-GISEL-NEXT:    v_mov_b64_e32 v[20:21], s[4:5]
 ; GFX950-GISEL-NEXT:    v_mov_b64_e32 v[18:19], s[2:3]
 ; GFX950-GISEL-NEXT:    v_mov_b64_e32 v[16:17], s[0:1]
-; GFX950-GISEL-NEXT:    v_mov_b32_e32 v22, 0x42c80000
-; GFX950-GISEL-NEXT:    v_cvt_scalef32_pk32_f16_fp6 v[0:15], v[16:21], v22
+; GFX950-GISEL-NEXT:    v_cvt_scalef32_pk32_f16_fp6 v[0:15], v[16:21], s6
 ; GFX950-GISEL-NEXT:    s_setpc_b64 s[30:31]
   %ret = tail call <32 x half> @llvm.amdgcn.cvt.scalef32.pk32.f16.fp6(<6 x i32> %src, float 100.0)
   ret <32 x half> %ret
@@ -2819,11 +2819,11 @@ define <32 x bfloat> @test_cvt_scalef32_pk32_bf16_fp6_sl_inreg_src(<6 x i32> inr
 ; GFX950-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-GISEL-NEXT:    s_mov_b32 s4, s16
 ; GFX950-GISEL-NEXT:    s_mov_b32 s5, s17
+; GFX950-GISEL-NEXT:    s_mov_b32 s6, 0x42c80000
 ; GFX950-GISEL-NEXT:    v_mov_b64_e32 v[20:21], s[4:5]
 ; GFX950-GISEL-NEXT:    v_mov_b64_e32 v[18:19], s[2:3]
 ; GFX950-GISEL-NEXT:    v_mov_b64_e32 v[16:17], s[0:1]
-; GFX950-GISEL-NEXT:    v_mov_b32_e32 v22, 0x42c80000
-; GFX950-GISEL-NEXT:    v_cvt_scalef32_pk32_bf16_fp6 v[0:15], v[16:21], v22
+; GFX950-GISEL-NEXT:    v_cvt_scalef32_pk32_bf16_fp6 v[0:15], v[16:21], s6
 ; GFX950-GISEL-NEXT:    s_setpc_b64 s[30:31]
   %ret = tail call <32 x bfloat> @llvm.amdgcn.cvt.scalef32.pk32.bf16.fp6(<6 x i32> %src, float 100.0)
   ret <32 x bfloat> %ret
@@ -2904,11 +2904,11 @@ define <32 x half> @test_cvt_scalef32_pk32_f16_bf6_sl_inreg_src(<6 x i32> inreg 
 ; GFX950-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-GISEL-NEXT:    s_mov_b32 s4, s16
 ; GFX950-GISEL-NEXT:    s_mov_b32 s5, s17
+; GFX950-GISEL-NEXT:    s_mov_b32 s6, 0x42c80000
 ; GFX950-GISEL-NEXT:    v_mov_b64_e32 v[20:21], s[4:5]
 ; GFX950-GISEL-NEXT:    v_mov_b64_e32 v[18:19], s[2:3]
 ; GFX950-GISEL-NEXT:    v_mov_b64_e32 v[16:17], s[0:1]
-; GFX950-GISEL-NEXT:    v_mov_b32_e32 v22, 0x42c80000
-; GFX950-GISEL-NEXT:    v_cvt_scalef32_pk32_f16_bf6 v[0:15], v[16:21], v22
+; GFX950-GISEL-NEXT:    v_cvt_scalef32_pk32_f16_bf6 v[0:15], v[16:21], s6
 ; GFX950-GISEL-NEXT:    s_setpc_b64 s[30:31]
   %ret = tail call <32 x half> @llvm.amdgcn.cvt.scalef32.pk32.f16.bf6(<6 x i32> %src, float 100.0)
   ret <32 x half> %ret
@@ -2962,11 +2962,11 @@ define <32 x bfloat> @test_cvt_scalef32_pk32_bf16_bf6_sl_inreg_src(<6 x i32> inr
 ; GFX950-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-GISEL-NEXT:    s_mov_b32 s4, s16
 ; GFX950-GISEL-NEXT:    s_mov_b32 s5, s17
+; GFX950-GISEL-NEXT:    s_mov_b32 s6, 0x42c80000
 ; GFX950-GISEL-NEXT:    v_mov_b64_e32 v[20:21], s[4:5]
 ; GFX950-GISEL-NEXT:    v_mov_b64_e32 v[18:19], s[2:3]
 ; GFX950-GISEL-NEXT:    v_mov_b64_e32 v[16:17], s[0:1]
-; GFX950-GISEL-NEXT:    v_mov_b32_e32 v22, 0x42c80000
-; GFX950-GISEL-NEXT:    v_cvt_scalef32_pk32_bf16_bf6 v[0:15], v[16:21], v22
+; GFX950-GISEL-NEXT:    v_cvt_scalef32_pk32_bf16_bf6 v[0:15], v[16:21], s6
 ; GFX950-GISEL-NEXT:    s_setpc_b64 s[30:31]
   %ret = tail call <32 x bfloat> @llvm.amdgcn.cvt.scalef32.pk32.bf16.bf6(<6 x i32> %src, float 100.0)
   ret <32 x bfloat> %ret


### PR DESCRIPTION
Also amdgcn_cvt_scalef32_pk_bf16_bf8,
amdgcn_cvt_scalef32_pk32_f32_fp6, amdgcn_cvt_scalef32_pk32_f32_bf6, amdgcn_cvt_scalef32_pk32_f16_fp6, amdgcn_cvt_scalef32_pk32_f16_bf6, amdgcn_cvt_scalef32_pk32_bf16_fp6, amdgcn_cvt_scalef32_pk32_bf16_bf6