### PR TITLE
[clang][sema] Suppress unsupported 128-bit mode attribute diagnostic for OpenMP device compilation

### DIFF
--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5224,6 +5224,8 @@ void Sema::AddModeAttr(Decl *D, const AttributeCommonInfo &CI,
     NewElemTy = Context.getRealTypeForBitwidth(DestWidth, ExplicitType);
 
   if (NewElemTy.isNull()) {
+    // FIXME: We need to make sure that the target handles correctly the
+    // requested mode.
     // Only emit diagnostic on host for 128-bit mode attribute
     if (!(DestWidth == 128 && getLangOpts().isTargetDevice()))
       Diag(AttrLoc, diag::err_machine_mode) << 1 /*Unsupported*/ << Name;

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5225,9 +5225,7 @@ void Sema::AddModeAttr(Decl *D, const AttributeCommonInfo &CI,
 
   if (NewElemTy.isNull()) {
     // Only emit diagnostic on host for 128-bit mode attribute
-    if (!(DestWidth == 128 &&
-          (getLangOpts().CUDAIsDevice || getLangOpts().SYCLIsDevice ||
-           getLangOpts().OpenMPIsTargetDevice)))
+    if (!(DestWidth == 128 && getLangOpts().isTargetDevice()))
       Diag(AttrLoc, diag::err_machine_mode) << 1 /*Unsupported*/ << Name;
     return;
   }

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5226,7 +5226,8 @@ void Sema::AddModeAttr(Decl *D, const AttributeCommonInfo &CI,
   if (NewElemTy.isNull()) {
     // Only emit diagnostic on host for 128-bit mode attribute
     if (!(DestWidth == 128 &&
-          (getLangOpts().CUDAIsDevice || getLangOpts().SYCLIsDevice)))
+          (getLangOpts().CUDAIsDevice || getLangOpts().SYCLIsDevice ||
+           getLangOpts().OpenMPIsTargetDevice)))
       Diag(AttrLoc, diag::err_machine_mode) << 1 /*Unsupported*/ << Name;
     return;
   }

--- a/clang/test/OpenMP/target_device_float128_mode_attr.c
+++ b/clang/test/OpenMP/target_device_float128_mode_attr.c
@@ -1,0 +1,11 @@
+// Host-side compilation on x86 (no errors expected).
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -aux-triple nvptx64 -fopenmp -x c -fsyntax-only -verify=host %s
+
+// Device-side compilation for targets without 128-bit float/complex support (no errors expected).
+// RUN: %clang_cc1 -triple nvptx64 -aux-triple x86_64-unknown-linux-gnu -fopenmp -fopenmp-is-target-device -x c -fsyntax-only -verify=device %s
+// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -aux-triple x86_64-unknown-linux-gnu -fopenmp -fopenmp-is-target-device -x c -fsyntax-only -verify=device %s
+// RUN: %clang_cc1 -triple spirv64 -aux-triple x86_64-unknown-linux-gnu -fopenmp -fopenmp-is-target-device -x c -fsyntax-only -verify=device %s
+
+// host-no-diagnostics
+// device-no-diagnostics
+typedef _Complex float __cfloat128 __attribute__ ((__mode__ (__TC__)));

--- a/clang/test/OpenMP/target_device_float128_mode_attr.c
+++ b/clang/test/OpenMP/target_device_float128_mode_attr.c
@@ -2,10 +2,21 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -aux-triple nvptx64 -fopenmp -x c -fsyntax-only -verify=host %s
 
 // Device-side compilation for targets without 128-bit float/complex support (no errors expected).
-// RUN: %clang_cc1 -triple nvptx64 -aux-triple x86_64-unknown-linux-gnu -fopenmp -fopenmp-is-target-device -x c -fsyntax-only -verify=device %s
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -aux-triple x86_64-unknown-linux-gnu -fopenmp -fopenmp-is-target-device -x c -fsyntax-only -verify=device %s
-// RUN: %clang_cc1 -triple spirv64 -aux-triple x86_64-unknown-linux-gnu -fopenmp -fopenmp-is-target-device -x c -fsyntax-only -verify=device %s
+// FIXME: The current behavior disables diagnostic for devices unconditionally, but once a way to correctly check
+// for 128-bit support is implemented, we should update this test to expect an error for targets that do not support 128-bit float/complex types.
+
+// RUN: %clang_cc1 -triple nvptx64 -aux-triple x86_64-unknown-linux-gnu -fopenmp -fopenmp-is-target-device -x c -emit-llvm %s -o -  | FileCheck %s
+// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -aux-triple x86_64-unknown-linux-gnu -fopenmp -fopenmp-is-target-device -x c -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spirv64 -aux-triple x86_64-unknown-linux-gnu -fopenmp -fopenmp-is-target-device -x c -emit-llvm %s -o - | FileCheck %s
 
 // host-no-diagnostics
 // device-no-diagnostics
 typedef _Complex float __cfloat128 __attribute__ ((__mode__ (__TC__)));
+
+// FIXME: OpenMP codege seems to be generating incorrectly a pair of 32-bit floats for the 128-bit complex float type.
+// This needs to be updated once the OpenMP codegen is fixed to generate the correct type for 128-bit complex float.
+
+//CHECK: @A = {{.*}}global { float, float } zeroinitializer, align 4
+#pragma omp declare target
+_Complex float A;
+#pragma omp end declare target


### PR DESCRIPTION
 On systems with newer glibc (2.41) when compiling with -fopenmp-targets the device compilation side fails with:

>     /usr/include/x86_64-linux-gnu/bits/floatn.h:83:52: error: unsupported machine mode '__TC__'
>        83 | typedef _Complex float __cfloat128 __attribute__ ((__mode__ (__TC__)));
>           |                                                    ^
 
 Sema::AddModeAttr already avoids diagnosing a 128-bit `mode` attribute  (e.g. __TC__, as used by glibc's __cfloat128) that the target can't represent, but only for CUDA and SYCL device compilation. OpenMP target-device compilation for targets also lacks a 128-bit float/complex representation so we extend the check to cover OpenMPIsTargetDevice as well to avoid the fail.

Assisted by Claude.