### PR TITLE
[TailRecElim] Fix miscompile of returns using a non-eliminated recursive call

### DIFF
--- a/llvm/lib/Transforms/Scalar/TailRecursionElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/TailRecursionElimination.cpp
@@ -437,27 +437,11 @@ static bool isUnaryAccumulatorRecurrence(Instruction *I) {
   return isa<ConstantInt>(I->getOperand(1));
 }
 
-// Return true if V is a recursive call to F or an instruction directly using
-// the result of one. A depth-1 check is enough here: the value feeding a
-// return either uses the recursive call as an immediate operand (the
-// accumulator instruction, or the PHI merging it with the base case), or it
-// is rejected by findBaseCaseRetConstant below as a non-constant anyway.
-static bool usesRecursiveCall(Value *V, Function &F) {
-  auto IsRecursiveCall = [&F](Value *V) {
-    auto *CI = dyn_cast<CallInst>(V);
-    return CI && CI->getCalledFunction() == &F;
-  };
-  if (IsRecursiveCall(V))
-    return true;
-  auto *I = dyn_cast<Instruction>(V);
-  return I && llvm::any_of(I->operands(), IsRecursiveCall);
-}
-
-// Find the base-case return value for function F: examine all return
-// instructions, skipping those whose return value depends on a recursive call
-// to F (that value differs for each iteration of the recursion). If the
-// remaining returns yield exactly one distinct constant, return it; otherwise
-// return nullptr to indicate failure.
+// Find the base-case return value for function F, given the accumulator
+// recursion instruction AccRecInstr that is about to be eliminated. Every
+// return other than the one fed by AccRecInstr survives the transformation and
+// will be rewritten to return the accumulator, so all of them have to yield the
+// same base-case constant. Return that constant, or nullptr on failure.
 //
 // FIXME: There is a room for improvement here in the future, e.g., consider
 // non-constant values and multiple base cases -- e.g., we want to be able to
@@ -469,7 +453,8 @@ static bool usesRecursiveCall(Value *V, Function &F) {
 //  return f(x-1) << 1;
 // }
 // ```
-static Constant *findBaseCaseRetConstant(Function &F) {
+static Constant *findBaseCaseRetConstant(Function &F,
+                                         Instruction *AccRecInstr) {
   Constant *BaseCaseVal = nullptr;
 
   for (BasicBlock &BB : F) {
@@ -478,9 +463,16 @@ static Constant *findBaseCaseRetConstant(Function &F) {
       continue;
 
     Value *RV = RI->getReturnValue();
-    if (usesRecursiveCall(RV, F))
+
+    // This is the recursive case being turned into a loop: the return goes
+    // away along with AccRecInstr.
+    if (RV == AccRecInstr)
       continue;
 
+    // Anything else has to be the base case. In particular a return still
+    // computing from a recursive call (e.g. a second recursion site that is
+    // not eliminated) must be rejected: returning the accumulator in its place
+    // would drop that computation.
     auto *C = dyn_cast<Constant>(RV);
     if (!C)
       return nullptr;
@@ -516,7 +508,7 @@ static Constant *canTransformAccumulatorRecursion(Instruction *I,
 
     // findTRECandidate guarantees CI is a recursive call to its own
     // function, so scan the enclosing function for the base-case return.
-    AccInitVal = findBaseCaseRetConstant(*CI->getFunction());
+    AccInitVal = findBaseCaseRetConstant(*CI->getFunction(), /*AccRecInstr=*/I);
     if (!AccInitVal)
       return nullptr;
   } else {

--- a/llvm/test/Transforms/TailCallElim/shl-accumulator-opt.ll
+++ b/llvm/test/Transforms/TailCallElim/shl-accumulator-opt.ll
@@ -186,3 +186,56 @@ if.end:
   %shl = shl i32 %tmp, 1
   br label %common.ret
 }
+
+; Negative test: a second, non-eliminable return computed from a recursive call
+; must not be rewritten to return the accumulator.
+; int f6(int x) {
+;   if (x == 0) return 1;
+;   if (x == 5) return f6(x-1) - 3; // neither associative nor unary-composable
+;   return f6(x-1) << 1;
+; }
+define i32 @test_neg_other_recursive_ret(i32 %x) {
+; CHECK-LABEL: define i32 @test_neg_other_recursive_ret(
+; CHECK-SAME: i32 [[X:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[X]], 0
+; CHECK-NEXT:    br i1 [[CMP]], label %[[BASE:.*]], label %[[IF_END:.*]]
+; CHECK:       [[BASE]]:
+; CHECK-NEXT:    ret i32 1
+; CHECK:       [[IF_END]]:
+; CHECK-NEXT:    [[CMP2:%.*]] = icmp eq i32 [[X]], 5
+; CHECK-NEXT:    br i1 [[CMP2]], label %[[OTHER:.*]], label %[[REC:.*]]
+; CHECK:       [[REC]]:
+; CHECK-NEXT:    [[SUB:%.*]] = add nsw i32 [[X]], -1
+; CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @test_neg_other_recursive_ret(i32 [[SUB]])
+; CHECK-NEXT:    [[SHL:%.*]] = shl i32 [[CALL]], 1
+; CHECK-NEXT:    ret i32 [[SHL]]
+; CHECK:       [[OTHER]]:
+; CHECK-NEXT:    [[SUB2:%.*]] = add nsw i32 [[X]], -1
+; CHECK-NEXT:    [[CALL2:%.*]] = tail call i32 @test_neg_other_recursive_ret(i32 [[SUB2]])
+; CHECK-NEXT:    [[RES:%.*]] = sub i32 [[CALL2]], 3
+; CHECK-NEXT:    ret i32 [[RES]]
+;
+entry:
+  %cmp = icmp eq i32 %x, 0
+  br i1 %cmp, label %base, label %if.end
+
+base:
+  ret i32 1
+
+if.end:
+  %cmp2 = icmp eq i32 %x, 5
+  br i1 %cmp2, label %other, label %rec
+
+rec:
+  %sub = add nsw i32 %x, -1
+  %call = tail call i32 @test_neg_other_recursive_ret(i32 %sub)
+  %shl = shl i32 %call, 1
+  ret i32 %shl
+
+other:
+  %sub2 = add nsw i32 %x, -1
+  %call2 = tail call i32 @test_neg_other_recursive_ret(i32 %sub2)
+  %res = sub i32 %call2, 3
+  ret i32 %res
+}


### PR DESCRIPTION
`findBaseCaseRetConstant`, added in #181331, skips every return whose value is computed from a recursive call, assuming such returns disappear together with the call being eliminated. Only one call site is turned into a loop, though, so a return fed by a *different* recursive call survives, and `cleanupAndFinalize` then rewrites it to return the accumulator, dropping its computation:
```c
int f(int x) {
  if (x == 0) return 1;
  if (x == 5) return f(x-1) - 3;   // survives
  return f(x-1) << 1;              // eliminated
}
```
`f(6)` returns `2` instead of `26`.

Only the return fed by the accumulator instruction being eliminated is skipped now. Any other non-constant return makes the transformation bail out.

AI was used to work on this PR.