### PR TITLE
[MemRef] Document `reinterpret_cast` verifiers

### DIFF
--- a/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
+++ b/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
@@ -1511,6 +1511,12 @@ def MemRef_ReinterpretCastOp
     Consecutive `reinterpret_cast` operations on memref's with static
     dimensions.
 
+    This operation is intended for cases where the user can guarantee the
+    validity of the constructed descriptor. Neither static nor runtime
+    verification check that the resulting descriptor is in-bounds. Accessing
+    memory outside the underlying allocation through the resulting memref is
+    undefined behavior.
+
     We distinguish between *underlying memory* — the sequence of elements as
     they appear in the contiguous memory of the memref — and the
     *strided memref*, which refers to the underlying memory interpreted


### PR DESCRIPTION
Make the loose semantics assumed by `memref.reinterpret_cast` explicit via documentation.