### PR TITLE
[clang][Parser] Reject qualified __super specifiers

### DIFF
--- a/clang/lib/Parse/ParseExprCXX.cpp
+++ b/clang/lib/Parse/ParseExprCXX.cpp
@@ -153,7 +153,8 @@ bool Parser::ParseOptionalCXXScopeSpecifier(
     }
   }
 
-  if (Tok.is(tok::kw___super)) {
+  if (Tok.is(tok::kw___super) &&
+      (!HasScopeSpecifier || NextToken().isNot(tok::coloncolon))) {
     SourceLocation SuperLoc = ConsumeToken();
     if (!Tok.is(tok::coloncolon)) {
       Diag(Tok.getLocation(), diag::err_expected_coloncolon_after_super);

--- a/clang/test/SemaCXX/MicrosoftSuper.cpp
+++ b/clang/test/SemaCXX/MicrosoftSuper.cpp
@@ -156,3 +156,7 @@ struct A : B {
   void f() { int a = this->__super::a; }
 };
 }
+
+struct InvalidGlobalQualifier : Base1 {
+  ::__super::; // expected-error {{expected unqualified-id}}
+};

--- a/clang/test/SemaCXX/MicrosoftSuper.cpp
+++ b/clang/test/SemaCXX/MicrosoftSuper.cpp
@@ -158,5 +158,8 @@ struct A : B {
 }
 
 struct InvalidGlobalQualifier : Base1 {
-  ::__super::; // expected-error {{expected unqualified-id}}
+  // A parser that drops the global qualifier is left with the valid
+  // declaration `__super::XXX x;` and accepts this line silently; expecting
+  // a diagnostic here catches that even in builds without assertions.
+  ::__super::XXX x; // expected-error {{expected unqualified-id}}
 };


### PR DESCRIPTION
`ParseOptionalCXXScopeSpecifier` accepts a leading global `::` and then recognises `__super::` as though the scope specifier were still empty. `MakeMicrosoftSuper` replaces the semantic representation but appends its locations to the existing global-qualifier buffer, so the two disagree: an assertions build trips the range invariant at `DeclSpec.cpp:93`, and a release build silently discards the global qualifier. `::__super::T x;` under `-fms-compatibility` reproduces both.

Recognise a complete `__super::` scope only when no qualifier has been accumulated yet; ordinary qualified-id parsing then rejects `::__super::` with a single `expected unqualified-id` diagnostic. Malformed `::__super` without a trailing `::` still reaches the existing recovery path and keeps its more specific diagnostic.

The added test in `clang/test/SemaCXX/MicrosoftSuper.cpp` uses the issue reproducer and fails on unpatched builds in both modes: release accepts it silently, assertions aborts.

Fixes #212988.

## Tool use

Per the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html): AI
tools were involved throughout the preparation of this change. I am the author
and accountable for the contribution.

Assisted-by: OpenAI Codex
Assisted-by: Claude Code
Assisted-by: Kimi
Assisted-by: DeepSeek
