### PR TITLE
[clang-format] Restore expression precedence for enum assignments

### DIFF
--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -3437,7 +3437,7 @@ private:
           Current->isOneOf(Keywords.kw_in, Keywords.kw_as)) {
         return prec::Relational;
       }
-      if (Current->isOneOf(TT_BinaryOperator, tok::comma))
+      if (Current->isOneOf(TT_BinaryOperator, TT_EnumEqual, tok::comma))
         return Current->getPrecedence();
       if (Current->isOneOf(tok::period, tok::arrow) &&
           Current->isNot(TT_TrailingReturnArrow)) {

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -2898,6 +2898,17 @@ TEST_F(FormatTest, ShortEnums) {
                Style);
 }
 
+TEST_F(FormatTest, WrapsEnumInitializers) {
+  verifyFormat("enum {\n"
+               "  MyEnum =\n"
+               "      aaaaaaaaaaaaaaa + bbbbbbbbbbbbbbb\n"
+               "};",
+               "enum {\n"
+               "  MyEnum = aaaaaaaaaaaaaaa + bbbbbbbbbbbbbbb\n"
+               "};",
+               getLLVMStyleWithColumns(40));
+}
+
 TEST_F(FormatTest, ShortCompoundRequirement) {
   constexpr StringRef Code("template <typename T>\n"
                            "concept c = requires(T x) {\n"


### PR DESCRIPTION
0f37c48d459d introduced `TT_EnumEqual` so enum assignments could be aligned independently, but omitted the new type from `ExpressionParser::getCurrentPrecedence`. Wrapped enumerator initializers thereby lost their assignment-precedence fake parens and their continuation indent (regression in v23 vs v22): the operand after the break lands at the enumerator's two-space indent instead of the continuation indent.

Treat `TT_EnumEqual` like the other binary operators when building the expression structure. `getPrecedence()` still yields `prec::Assignment` from the underlying `tok::equal`, and the specialised type stays available to the enum-alignment pass. The regression test pins the exact input and output.

Fixes #212796.

## Tool use

Per the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html): AI
tools were involved throughout the preparation of this change. I am the author
and accountable for the contribution.

Assisted-by: OpenAI Codex
Assisted-by: Claude Code
Assisted-by: Kimi
Assisted-by: DeepSeek
