### PR TITLE
[PowerPC] Handle native 128-bit PPC32 arguments

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -4288,6 +4288,8 @@ SDValue PPCTargetLowering::LowerFormalArguments_32SVR4(
           break;
         case MVT::v2f64:
         case MVT::v2i64:
+        case MVT::v1i128:
+        case MVT::f128:
           RC = &PPC::VRRCRegClass;
           break;
       }

--- a/llvm/test/CodeGen/PowerPC/ppc32-vsx-fp128-args.ll
+++ b/llvm/test/CodeGen/PowerPC/ppc32-vsx-fp128-args.ll
@@ -1,0 +1,23 @@
+; RUN: llc -mtriple=powerpc-unknown-linux-gnu -mattr=+vsx -verify-machineinstrs < %s | FileCheck %s --check-prefix=BE-VSX
+; RUN: llc -mtriple=powerpcle-unknown-linux-gnu -mattr=+vsx -verify-machineinstrs < %s | FileCheck %s --check-prefix=LE-VSX
+; RUN: llc -mtriple=powerpc-unknown-linux-gnu -mcpu=pwr8 -verify-machineinstrs < %s | FileCheck %s --check-prefix=P8
+
+; Check that 128-bit scalar and single-element vector arguments assigned to
+; AltiVec registers can be lowered for the 32-bit SVR4 ABI.
+
+define void @store_fp128(fp128 %x, ptr %p) {
+; BE-VSX-LABEL:     store_fp128:
+; BE-VSX:           stxvw4x 34,
+; LE-VSX-LABEL:     store_fp128:
+; LE-VSX:           xxswapd
+; LE-VSX:           stxvd2x
+  store fp128 %x, ptr %p, align 16
+  ret void
+}
+
+define void @store_v1i128(<1 x i128> %x, ptr %p) {
+; P8-LABEL: store_v1i128:
+; P8:       stxvw4x 34,
+  store <1 x i128> %x, ptr %p, align 16
+  ret void
+}


### PR DESCRIPTION
The PPC32 SVR4 calling convention assigns native `fp128` — and, on P8+, native `<1 x i128>` — arguments to AltiVec registers V2–V13, but the formal-argument switch in `LowerFormalArguments_32SVR4` handled neither type, so an assertions build reaches `llvm_unreachable` compiling a function that takes `fp128` with `+vsx`, or `<1 x i128>` with `-mcpu=pwr8`. The omission dates to the 2018 `fp128` parameter-passing work (a26f3be4546a), which added the calling-convention rules but updated and tested only PPC64 formal lowering; later predicate broadening made the PPC32 path reachable.

Add the two missing cases. The target already registers both types with `PPC::VRRCRegClass` — the same class PPC64 formal lowering uses — and PPC32 outgoing calls and returns already work via generic register copies, so no calling-convention assignment or ABI layout changes. The regression tests cover big- and little-endian PPC32 VSX `fp128` and P8 `<1 x i128>` under `-verify-machineinstrs`, checking the values originate in V2.

Fixes #213355.

## Scope note

While verifying this fix, two adjacent pre-existing gaps turned up on PPC32
with `-mcpu=pwr8`, filed separately as #214991: `v1i128` has no stack
fallback in `CC_PPC32_SVR4` (thirteen fixed `v1i128` arguments fail with
"unable to allocate function argument"), and variadic `v1i128` has no
assignment at all (an assertions build aborts in call lowering; release
`llc` generates code that omits the operand). Both reproduce identically
with and without this patch, which only adds the missing formal-lowering
register-class cases.

## Tool use

Per the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html): AI
tools were involved throughout the preparation of this change. I am the author
and accountable for the contribution.

Assisted-by: OpenAI Codex
Assisted-by: Claude Code
Assisted-by: Kimi
Assisted-by: DeepSeek
