### PR TITLE
[clang][Sema] Merge GNU diagnostic attributes by semantic spelling

### DIFF
--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -4056,12 +4056,10 @@ static void handleInitPriorityAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
 
 ErrorAttr *Sema::mergeErrorAttr(Decl *D, const AttributeCommonInfo &CI,
                                 StringRef NewUserDiagnostic) {
+  auto *NewAttr = ::new (Context) ErrorAttr(Context, CI, NewUserDiagnostic);
   if (const auto *EA = D->getAttr<ErrorAttr>()) {
-    std::string NewAttr = CI.getNormalizedFullName();
-    assert((NewAttr == "error" || NewAttr == "warning") &&
-           "unexpected normalized full name");
-    bool Match = (EA->isError() && NewAttr == "error") ||
-                 (EA->isWarning() && NewAttr == "warning");
+    bool Match = (EA->isError() && NewAttr->isError()) ||
+                 (EA->isWarning() && NewAttr->isWarning());
     if (!Match) {
       Diag(EA->getLocation(), diag::err_attributes_are_not_compatible)
           << CI << EA
@@ -4076,7 +4074,7 @@ ErrorAttr *Sema::mergeErrorAttr(Decl *D, const AttributeCommonInfo &CI,
     }
     D->dropAttr<ErrorAttr>();
   }
-  return ::new (Context) ErrorAttr(Context, CI, NewUserDiagnostic);
+  return NewAttr;
 }
 
 FormatAttr *Sema::mergeFormatAttr(Decl *D, const AttributeCommonInfo &CI,

--- a/clang/test/Sema/gh212467.c
+++ b/clang/test/Sema/gh212467.c
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -std=c23 -fsyntax-only -verify %s
+// expected-no-diagnostics
+
+[[gnu::warning("same")]]
+[[gnu::warning("same")]]
+void same_warning(void);
+
+[[gnu::error("same")]]
+[[gnu::error("same")]]
+void same_error(void);
+
+[[gnu::warning("same")]]
+__attribute__((warning("same"))) void mixed_warning(void);
+
+__attribute__((error("same")))
+[[gnu::error("same")]] void reverse_mixed_error(void);

--- a/clang/test/SemaCXX/gh212467.cpp
+++ b/clang/test/SemaCXX/gh212467.cpp
@@ -1,0 +1,23 @@
+// RUN: %clang_cc1 -std=c++11 -fsyntax-only -verify %s
+
+[[gnu::warning("same")]]
+[[gnu::warning("same")]]
+void same_warning();
+
+[[gnu::warning("one")]] // expected-note {{previous attribute is here}}
+[[gnu::warning("two")]] // expected-warning {{attribute 'gnu::warning' is already applied with different arguments}}
+void different_warning();
+
+[[gnu::error("same")]]
+[[gnu::error("same")]]
+void same_error();
+
+[[gnu::error("one")]]   // expected-error {{'gnu::warning' and 'gnu::error' attributes are not compatible}}
+[[gnu::warning("two")]] // expected-note {{conflicting attribute is here}}
+void conflicting();
+
+[[gnu::warning("same")]]
+__attribute__((warning("same"))) void mixed_syntax();
+
+__attribute__((warning("same")))
+[[gnu::warning("same")]] void reverse_mixed_syntax();


### PR DESCRIPTION
`mergeErrorAttr` decides whether an incoming diagnostic attribute is an error or a warning by string-comparing `getNormalizedFullName()`, but a C++11 namespaced GNU spelling normalises to `gnu::warning`/`gnu::error`, not the bare name the comparison expects. Two `[[gnu::warning]]` attributes on one declaration abort an assertions build in `SemaDeclAttr.cpp`; a release build rejects identical C23 attributes as incompatible, so the bug changes which code is accepted, not just debug builds.

Construct the generated `ErrorAttr` first and use its semantic `isError()`/`isWarning()` predicates, which deliberately group the GNU, C++11 and C23 spellings while retaining the same-kind, differing-message, and error-versus-warning merge behaviour. A second commit adds a C23 regression test; between them the tests cover duplicate warnings and errors, differing messages, an incompatible error/warning pair, and both orders of mixed spellings.

Fixes #212467.

## Tool use

Per the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html): AI
tools were involved throughout the preparation of this change. I am the author
and accountable for the contribution.

Assisted-by: OpenAI Codex
Assisted-by: Claude Code
Assisted-by: Kimi
Assisted-by: DeepSeek
