### PR TITLE
[AssumptionCache] Remove incorrect assertion from `removeAffectedValues()`

### DIFF
--- a/llvm/lib/Analysis/AssumptionCache.cpp
+++ b/llvm/lib/Analysis/AssumptionCache.cpp
@@ -121,26 +121,6 @@ void AssumptionCache::removeAffectedValues(AssumeInst *CI) {
   SmallVector<AssumptionCache::ResultElem, 16> Affected;
   findAffectedValues(CI, TTI, Affected);
 
-  // If a value appears more than once in an AssumeInst e.g., 'ptr %arg1' in:
-  //     call void @llvm.assume(i1 true)
-  //                   [ "dereferenceable"(ptr %arg1, i64 1),
-  //                     "align"(ptr %arg1, i64 8) ]
-  // it will appear multiple times in Affected, but we may (depending on
-  // how the results in AffectedValues.find_as(AV.Assume) are ordered)
-  // nullify multiple instances of Elem.Assume during one iteration of the
-  // 'for (auto &AV : Affected)' loop below. The next iteration of that for
-  // loop may then find only a match to a different AssumeInst, resulting in
-  // an assertion failure. Avoid this by counting the number of expected
-  // matches.
-#ifndef NDEBUG
-  SmallDenseSet<std::pair<Value *, unsigned>, 16> Seen;
-  DenseMap<Value *, int> ExpectedMatches;
-  for (auto &AV : Affected)
-    if (Seen.insert({AV.Assume, AV.Index}).second &&
-        AffectedValues.find_as(AV.Assume) != AffectedValues.end())
-      ExpectedMatches[AV.Assume]++;
-#endif
-
   for (auto &AV : Affected) {
     auto AVI = AffectedValues.find_as(AV.Assume);
     if (AVI == AffectedValues.end())
@@ -151,30 +131,23 @@ void AssumptionCache::removeAffectedValues(AssumeInst *CI) {
       if (Elem.Assume == CI) {
         Found = true;
         Elem.Assume = nullptr;
-
-#ifndef NDEBUG
-        ExpectedMatches[AV.Assume]--;
-#endif
-        assert(ExpectedMatches[AV.Assume] >= 0);
-        // After ExpectedMatches[AV.Assume] == 0, we still need to iterate
-        // through this loop to determine the value of HasNonnull, to avoid
-        // prematurely calling AffectedValues.erase(AVI).
       }
+
+      // We need to iterate through this loop to determine the value of
+      // HasNonnull, to avoid prematurely calling AffectedValues.erase(AVI).
       HasNonnull |= !!Elem.Assume;
       if (HasNonnull && Found)
         break;
     }
 
-    assert(ExpectedMatches[AV.Assume] == 0 ||
-           Found && "already unregistered or incorrect cache state");
-
-    if (!HasNonnull)
+    if (!Found) {
+      // It may well be the case that we fail to find an affected value in the
+      // cache. In particular, if an assume call is updated via `Use::set`, we
+      // won't be notified that the affected value has changed and the cache
+      // will silently go stale.
+    } else if (!HasNonnull)
       AffectedValues.erase(AVI);
   }
-
-  assert(
-      none_of(Affected, [&](auto &AV) { return ExpectedMatches[AV.Assume]; }) &&
-      "already unregistered or incorrect cache state");
 }
 
 void AssumptionCache::unregisterAssumption(AssumeInst *CI) {

--- a/llvm/lib/Analysis/AssumptionCache.cpp
+++ b/llvm/lib/Analysis/AssumptionCache.cpp
@@ -142,7 +142,7 @@ void AssumptionCache::removeAffectedValues(AssumeInst *CI) {
 
     if (!Found) {
       // It may well be the case that we fail to find an affected value in the
-      // cache. In particular, if an assume call is updated via `Use::set`, we
+      // cache. In particular, if an assume call is updated via `Use::set()`, we
       // won't be notified that the affected value has changed and the cache
       // will silently go stale.
     } else if (!HasNonnull)

--- a/llvm/test/Analysis/AssumptionCache/remove-from-stale-cache.ll
+++ b/llvm/test/Analysis/AssumptionCache/remove-from-stale-cache.ll
@@ -1,0 +1,40 @@
+; RUN: opt < %s -disable-output -passes='no-op-module,loop-rotate,simplifycfg,hotcoldsplit'
+
+; Check that we don't crash on deletion from a stale assumption cache.
+;
+; The no-op module pass initialises the assumption cache, which the SSA updater
+; in `loop-rotate` invalidates it with a call to `Use::set()`. After
+; simplifying the CFG, we're left with a `hotcoldsplit` candidate, leading to a
+; call to `removeAffectedValues()` on a stale cache.
+
+define void @dont_crash(i1 %cond.1) {
+entry:
+  %load = load ptr, ptr null, align 8
+  br i1 %cond.1, label %loop.cond, label %assume
+
+loop.cond:
+  %phi = phi ptr [ null, %loop.body ], [ %load, %entry ]
+  %cond.2 = phi i1 [ false, %loop.body ], [ true, %entry ]
+  br i1 %cond.2, label %loop.body, label %dead
+
+loop.body:
+  call void @llvm.assume(i1 true) [ "nonnull"(ptr %phi) ]
+
+  ; Lengthen code sequence so that `hotcoldsplit` fires (causing the deletion).
+  call void @noise()
+  call void @noise()
+  call void @noise()
+  call void @noise()
+
+  br label %loop.cond
+
+assume:
+  call void @llvm.assume(i1 true) [ "dereferenceable"(ptr %load, i64 8) ]
+  ret void
+
+dead:
+  unreachable
+}
+
+declare void @llvm.assume(i1 noundef)
+declare void @noise()

--- a/llvm/test/Analysis/AssumptionCache/remove-from-stale-cache.ll
+++ b/llvm/test/Analysis/AssumptionCache/remove-from-stale-cache.ll
@@ -2,7 +2,7 @@
 
 ; Check that we don't crash on deletion from a stale assumption cache.
 ;
-; The no-op module pass initialises the assumption cache, which the SSA updater
+; The no-op module pass initialises the assumption cache, while the SSA updater
 ; in `loop-rotate` invalidates it with a call to `Use::set()`. After
 ; simplifying the CFG, we're left with a `hotcoldsplit` candidate, leading to a
 ; call to `removeAffectedValues()` on a stale cache.

--- a/llvm/test/Analysis/AssumptionCache/remove-from-stale-cache.ll
+++ b/llvm/test/Analysis/AssumptionCache/remove-from-stale-cache.ll
@@ -7,13 +7,12 @@
 ; simplifying the CFG, we're left with a `hotcoldsplit` candidate, leading to a
 ; call to `removeAffectedValues()` on a stale cache.
 
-define void @dont_crash(i1 %cond.1) {
+define void @dont_crash(i1 %cond.1, ptr %ptr) {
 entry:
-  %load = load ptr, ptr null, align 8
   br i1 %cond.1, label %loop.cond, label %assume
 
 loop.cond:
-  %phi = phi ptr [ null, %loop.body ], [ %load, %entry ]
+  %phi = phi ptr [ null, %loop.body ], [ %ptr, %entry ]
   %cond.2 = phi i1 [ false, %loop.body ], [ true, %entry ]
   br i1 %cond.2, label %loop.body, label %dead
 
@@ -29,7 +28,7 @@ loop.body:
   br label %loop.cond
 
 assume:
-  call void @llvm.assume(i1 true) [ "dereferenceable"(ptr %load, i64 8) ]
+  call void @llvm.assume(i1 true) [ "dereferenceable"(ptr %ptr, i64 8) ]
   ret void
 
 dead:

--- a/llvm/test/Analysis/AssumptionCache/remove-from-stale-cache.ll
+++ b/llvm/test/Analysis/AssumptionCache/remove-from-stale-cache.ll
@@ -1,13 +1,16 @@
-; RUN: opt < %s -disable-output -passes='no-op-module,loop-rotate,simplifycfg,hotcoldsplit'
+; RUN: opt < %s -disable-output -passes='module(print<assumptions>),loop-rotate,simplifycfg,hotcoldsplit' 2>&1 | FileCheck %s
 
 ; Check that we don't crash on deletion from a stale assumption cache.
 ;
-; The no-op module pass initialises the assumption cache, while the SSA updater
-; in `loop-rotate` invalidates it with a call to `Use::set()`. After
+; The initial module pass initialises the assumption cache, while the SSA
+; updater in `loop-rotate` invalidates it with a call to `Use::set()`. After
 ; simplifying the CFG, we're left with a `hotcoldsplit` candidate, leading to a
 ; call to `removeAffectedValues()` on a stale cache.
 
 define void @dont_crash(i1 %cond.1, ptr %ptr) {
+; CHECK-LABEL: Cached assumptions for function: dont_crash
+; CHECK-NEXT: [ "nonnull"(ptr %phi) ]
+; CHECK-NEXT: [ "dereferenceable"(ptr %ptr, i64 8) ]
 entry:
   br i1 %cond.1, label %loop.cond, label %assume
 

--- a/llvm/test/Analysis/AssumptionCache/remove-from-stale-cache.ll
+++ b/llvm/test/Analysis/AssumptionCache/remove-from-stale-cache.ll
@@ -1,4 +1,4 @@
-; RUN: opt < %s -disable-output -passes='module(print<assumptions>),loop-rotate,simplifycfg,hotcoldsplit' 2>&1 | FileCheck %s
+; RUN: opt < %s -disable-output -passes='no-op-module,loop-rotate,simplifycfg,print<assumptions>,hotcoldsplit' 2>&1 | FileCheck %s
 
 ; Check that we don't crash on deletion from a stale assumption cache.
 ;
@@ -9,7 +9,7 @@
 
 define void @dont_crash(i1 %cond.1, ptr %ptr) {
 ; CHECK-LABEL: Cached assumptions for function: dont_crash
-; CHECK-NEXT: [ "nonnull"(ptr %phi) ]
+; CHECK-NEXT: [ "nonnull"(ptr %ptr) ]
 ; CHECK-NEXT: [ "dereferenceable"(ptr %ptr, i64 8) ]
 entry:
   br i1 %cond.1, label %loop.cond, label %assume


### PR DESCRIPTION
The assertion in `removeAffectedValues()` is trying to enforce that, when we come to remove the affected values of a live assume call, each affected value has a corresponding line in the cache. This may not be the case if the assume call has been modified via a call to `Use::set()`, as our value handles are only notified on deletion and RAUW. We're not worried about this, though, as the cache is conservative.

Remove this assertion and add a comment explaining why we may fail to find.