### PR TITLE
[Clang][OpenCL] Make FP_ILOGBNAN configurable

### DIFF
--- a/clang/lib/Headers/opencl-c-base.h
+++ b/clang/lib/Headers/opencl-c-base.h
@@ -185,7 +185,16 @@ typedef double double16 __attribute__((ext_vector_type(16)));
 #define NAN as_float(INT_MAX)
 
 #define FP_ILOGB0    INT_MIN
+
+/**
+ * The OpenCL C spec allows the implementation to choose the value of the
+ * FP_ILOGBNAN macro between INT_MIN and INT_MAX.
+ */
+#ifdef __OPENCL_FP_ILOGBNAN_MIN
+#define FP_ILOGBNAN  INT_MIN
+#else
 #define FP_ILOGBNAN  INT_MAX
+#endif
 
 #define FLT_DIG 6
 #define FLT_MANT_DIG 24


### PR DESCRIPTION
The OpenCL C spec allows the implementation to choose the value of the
`FP_ILOGBNAN` macro between `INT_MIN` and `INT_MAX`. This patch makes the
value configurable by introducing a new macro `__OPENCL_FP_ILOGBNAN_MIN`.
The default value is unchanged and is set to `INT_MAX`. If the new macro
is defined, the value of `FP_ILOGBNAN` will be set to `INT_MIN`.

This change makes the OpenCL C headers similar to the LLVM `libc`, that
also has the `FP_ILOGBNAN` macro configurable.