### PR TITLE
[InstCombine] Use DenseMap instead of MapVector (NFC)

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineLoadStoreAlloca.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineLoadStoreAlloca.cpp
@@ -260,7 +260,7 @@ private:
   }
 
   SmallSetVector<Instruction *, 32> UsersToReplace;
-  MapVector<Value *, Value *> WorkMap;
+  DenseMap<Value *, Value *> WorkMap;
   InstCombinerImpl &IC;
   Instruction &Root;
   unsigned FromAS;


### PR DESCRIPTION
WorkMap is accessed only via MapVector::operator[] and lookup.

This patch changes its type to DenseMap to avoid populating the vector
portion of MapVector.
