### PR TITLE
[mlir][gpu] Don't request C wrappers for private device functions

### DIFF
--- a/mlir/lib/Conversion/GPUToNVVM/LowerGpuOpsToNVVMOps.cpp
+++ b/mlir/lib/Conversion/GPUToNVVM/LowerGpuOpsToNVVMOps.cpp
@@ -511,8 +511,13 @@ struct LowerGpuOpsToNVVMOpsPass final
   void runOnOperation() override {
     gpu::GPUModuleOp m = getOperation();
 
-    // Request C wrapper emission.
+    // Request C wrapper emission for externally visible functions only. A
+    // private function cannot be called from outside its module, so its C
+    // interface wrapper is unreachable and would only anchor the wrapped
+    // function against dead-code elimination.
     for (auto func : m.getOps<func::FuncOp>()) {
+      if (func.isPrivate())
+        continue;
       func->setDiscardableAttr(LLVM::LLVMDialect::getEmitCWrapperAttrName(),
                                UnitAttr::get(&getContext()));
     }

--- a/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
+++ b/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
@@ -744,8 +744,13 @@ struct LowerGpuOpsToROCDLOpsPass final
       m->setDiscardableAttr(LLVM::LLVMDialect::getDataLayoutAttrName(),
                             llvmDataLayout);
     }
-    // Request C wrapper emission.
+    // Request C wrapper emission for externally visible functions only. A
+    // private function cannot be called from outside its module, so its C
+    // interface wrapper is unreachable and would only anchor the wrapped
+    // function against dead-code elimination.
     for (auto func : m.getOps<func::FuncOp>()) {
+      if (func.isPrivate())
+        continue;
       func->setDiscardableAttr(LLVM::LLVMDialect::getEmitCWrapperAttrName(),
                                UnitAttr::get(ctx));
     }

--- a/mlir/test/Conversion/GPUToNVVM/private-func-no-c-interface.mlir
+++ b/mlir/test/Conversion/GPUToNVVM/private-func-no-c-interface.mlir
@@ -1,0 +1,25 @@
+// RUN: mlir-opt %s -convert-gpu-to-nvvm -split-input-file | FileCheck %s
+
+// A private device function cannot be called from outside its module, so it
+// must not be given a C interface wrapper; requesting one would only anchor
+// the function against dead-code elimination.
+gpu.module @kernel_private {
+  // CHECK-LABEL: gpu.module @kernel_private
+  // CHECK-NOT: emit_c_interface
+  // CHECK-NOT: _mlir_ciface_
+  func.func private @helper(%arg0: i64) -> i64 {
+    return %arg0 : i64
+  }
+}
+
+// -----
+
+// A publicly visible device function keeps its C interface wrapper.
+gpu.module @kernel_public {
+  // CHECK-LABEL: gpu.module @kernel_public
+  // CHECK: llvm.emit_c_interface
+  // CHECK: @_mlir_ciface_entry
+  func.func @entry(%arg0: i64) -> i64 {
+    return %arg0 : i64
+  }
+}

--- a/mlir/test/Conversion/GPUToROCDL/private-func-no-c-interface.mlir
+++ b/mlir/test/Conversion/GPUToROCDL/private-func-no-c-interface.mlir
@@ -1,0 +1,25 @@
+// RUN: mlir-opt %s -convert-gpu-to-rocdl -split-input-file | FileCheck %s
+
+// A private device function cannot be called from outside its module, so it
+// must not be given a C interface wrapper; requesting one would only anchor
+// the function against dead-code elimination.
+gpu.module @kernel_private {
+  // CHECK-LABEL: gpu.module @kernel_private
+  // CHECK-NOT: emit_c_interface
+  // CHECK-NOT: _mlir_ciface_
+  func.func private @helper(%arg0: i64) -> i64 {
+    return %arg0 : i64
+  }
+}
+
+// -----
+
+// A publicly visible device function keeps its C interface wrapper.
+gpu.module @kernel_public {
+  // CHECK-LABEL: gpu.module @kernel_public
+  // CHECK: llvm.emit_c_interface
+  // CHECK: @_mlir_ciface_entry
+  func.func @entry(%arg0: i64) -> i64 {
+    return %arg0 : i64
+  }
+}


### PR DESCRIPTION
GPU lowerings attach `llvm.emit_c_interface` to device functions regardless of visibility. This causes private device functions to receive external entry points and prevents such functions from being culled by DCE.

On a real module lowered by a downstream compiler, we measured that unconditional `llvm.emit_c_interface` inflated the generated PTX by 1.8x by keeping unused private functions alive and by 7x for pipelines that also give private functions internal linkage.

This change attaches `llvm.emit_c_interface` only to functions which are not private for both the gpu->nvvm and gpu->rocdl lowerings. No behavior change to existing unit tests, and new tests are added to witness the new behavior for private functions.

Assisted-by: Claude Code