### PR TITLE
[clang][StaticAnalysis] Fix an false negative bug in handling '__builtin*overflow'

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/BuiltinFunctionChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/BuiltinFunctionChecker.cpp
@@ -43,12 +43,15 @@ QualType getSufficientTypeForOverflowOp(CheckerContext &C,
   unsigned BitWidth =
       std::max(ACtx.getIntWidth(Arg1Ty), ACtx.getIntWidth(Arg2Ty));
 
-  // A signed type with doubled bit width may not be enough for their
-  // multiplication result only when both operands are unsigned. In other
-  // words, we use a signed type if either operand is signed. Additionally,
-  // subtraction always needs a signed result. (Subtracting a negative
-  // operand falls into the prior case, so it is still fine with a signed
-  // result type. Excluding the case of 1-bit signed integer tho.)
+  // A signed type with doubled bits may not be large enough to hold the
+  // multiplication result when both operands are unsigned. In other
+  // words, if either operand is signed, a signed type with twice the bits is
+  // sufficient.
+  //
+  // Additionally, subtraction always needs a signed result. Note that
+  // subtracting a negative operand falls into the prior case, so it is still
+  // safe with a signed result type. A signed 1-bit integer is not allowed in
+  // Clang.
   bool UseSigned = Op == BO_Sub || Arg1Ty->isSignedIntegerType() ||
                    Arg2Ty->isSignedIntegerType();
   return ACtx.getBitIntType(/*Unsigned=*/!UseSigned, BitWidth * 2);

--- a/clang/lib/StaticAnalyzer/Checkers/BuiltinFunctionChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/BuiltinFunctionChecker.cpp
@@ -24,6 +24,7 @@
 #include "clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/CheckerHelpers.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/SVals.h"
+#include <algorithm>
 
 using namespace clang;
 using namespace ento;
@@ -31,13 +32,26 @@ using namespace taint;
 
 namespace {
 
-QualType getSufficientTypeForOverflowOp(CheckerContext &C, const QualType &T) {
-  // Calling a builtin with a non-integer type result produces compiler error.
-  assert(T->isIntegerType());
+/// \return an integer type that is large enough for the binary operation on the
+/// operands of \p Arg1Ty and \p Arg2Ty, respectively.
+QualType getSufficientTypeForOverflowOp(CheckerContext &C,
+                                        BinaryOperator::Opcode Op,
+                                        QualType Arg1Ty, QualType Arg2Ty) {
+  assert(Arg1Ty->isIntegerType() && Arg2Ty->isIntegerType());
 
   ASTContext &ACtx = C.getASTContext();
-  unsigned BitWidth = ACtx.getIntWidth(T);
-  return ACtx.getBitIntType(T->isUnsignedIntegerType(), BitWidth * 2);
+  unsigned BitWidth =
+      std::max(ACtx.getIntWidth(Arg1Ty), ACtx.getIntWidth(Arg2Ty));
+
+  // A signed type with doubled bit width may not be enough for their
+  // multiplication result only when both operands are unsigned. In other
+  // words, we use a signed type if either operand is signed. Additionally,
+  // subtraction always needs a signed result. (Subtracting a negative
+  // operand falls into the prior case, so it is still fine with a signed
+  // result type. Excluding the case of 1-bit signed integer tho.)
+  bool UseSigned = Op == BO_Sub || Arg1Ty->isSignedIntegerType() ||
+                   Arg2Ty->isSignedIntegerType();
+  return ACtx.getBitIntType(/*Unsigned=*/!UseSigned, BitWidth * 2);
 }
 
 QualType getOverflowBuiltinResultType(const CallEvent &Call) {
@@ -206,8 +220,11 @@ void BuiltinFunctionChecker::handleOverflowBuiltin(const CallEvent &Call,
 
   SVal Arg1 = Call.getArgSVal(0);
   SVal Arg2 = Call.getArgSVal(1);
+  QualType Arg1Ty = Call.getArgExpr(0)->getType();
+  QualType Arg2Ty = Call.getArgExpr(1)->getType();
 
-  QualType SufficientlyWideTy = getSufficientTypeForOverflowOp(C, ResultType);
+  QualType SufficientlyWideTy =
+      getSufficientTypeForOverflowOp(C, Op, Arg1Ty, Arg2Ty);
   assert(!SufficientlyWideTy.isNull());
 
   SVal RetValMax = SVB.evalBinOp(State, Op, Arg1, Arg2, SufficientlyWideTy);

--- a/clang/test/Analysis/builtin_overflow.c
+++ b/clang/test/Analysis/builtin_overflow.c
@@ -220,7 +220,6 @@ void test_add_overflow_scratch_type_too_narrow(void) {
   int a = 32767, b = 32767;
   signed char res;
   
-  // This is a false negative. 32767 + 32767 == 65534, which does not
-  // fit in a signed char ([-128, 127]), so this should evaluate to TRUE.
+  // 32767 + 32767 == 65534, which does not fit in a signed char ([-128, 127]), so this evaluates to TRUE.
   clang_analyzer_eval(__builtin_add_overflow(a, b, &res)); // expected-warning {{TRUE}}
 }

--- a/clang/test/Analysis/builtin_overflow.c
+++ b/clang/test/Analysis/builtin_overflow.c
@@ -215,3 +215,12 @@ void test_add_overflow_s111(void) {
 
   clang_analyzer_warnIfReached(); // no-warning: we always get an overflow, thus choose the other branch
 }
+
+void test_add_overflow_scratch_type_too_narrow(void) {
+  int a = 32767, b = 32767;
+  signed char res;
+  
+  // This is a false negative. 32767 + 32767 == 65534, which does not
+  // fit in a signed char ([-128, 127]), so this should evaluate to TRUE.
+  clang_analyzer_eval(__builtin_add_overflow(a, b, &res)); // expected-warning {{TRUE}}
+}


### PR DESCRIPTION
For a binary operation 'A op B' and a result type 'T', these builtins return true/false for whether the operation's result is a value 'T' cannot hold. CSA models this by computing the operation's result in a temporary type and comparing it against the bounds of 'T'.  However, the temporary type is only twice as wide as 'T', not the operands. When either operand is wider than 'T's doubled width, the result of 'A op B' can silently wrap around before the comparison, producing a false negative.

The solution is to find the proper type to temporarily hold the result of 'A op B' from types of 'A' and 'B'.

rdar://184263112