### PR TITLE
[lldb] Read immutable literal-section values from the host object file instead of the process

### DIFF
--- a/lldb/include/lldb/Core/Section.h
+++ b/lldb/include/lldb/Core/Section.h
@@ -287,7 +287,8 @@ public:
   /// Return true if this section's bytes in the host object file are guaranteed
   /// identical to its bytes in the running process, so a reader may serve them
   /// from the file instead of issuing a live memory read.  Conservative:
-  /// returns false unless the section is positively known to be immutable.
+  /// returns false unless positively known immutable, so a section that is
+  /// read-only but loader-relocated (e.g. Mach-O __DATA_CONST) returns false.
   bool IsImmutableAfterLoad() const;
 
 protected:

--- a/lldb/include/lldb/Core/Section.h
+++ b/lldb/include/lldb/Core/Section.h
@@ -284,6 +284,12 @@ public:
   /// Returns true if this is a global offset table section.
   bool IsGOTSection() const;
 
+  /// Return true if this section's bytes in the host object file are guaranteed
+  /// identical to its bytes in the running process, so a reader may serve them
+  /// from the file instead of issuing a live memory read.  Conservative:
+  /// returns false unless the section is positively known to be immutable.
+  bool IsImmutableAfterLoad() const;
+
 protected:
   ObjectFile *m_obj_file;   // The object file that data for this section should
                             // be read from

--- a/lldb/source/Core/Section.cpp
+++ b/lldb/source/Core/Section.cpp
@@ -470,6 +470,8 @@ bool Section::IsGOTSection() const {
   return GetObjectFile()->IsGOTSection(*this);
 }
 
+bool Section::IsImmutableAfterLoad() const { return m_readable && !m_writable; }
+
 #pragma mark SectionList
 
 SectionList::SectionList(const SectionList &rhs) : m_sections(rhs.m_sections) {}

--- a/lldb/source/Core/Section.cpp
+++ b/lldb/source/Core/Section.cpp
@@ -470,7 +470,34 @@ bool Section::IsGOTSection() const {
   return GetObjectFile()->IsGOTSection(*this);
 }
 
-bool Section::IsImmutableAfterLoad() const { return m_readable && !m_writable; }
+bool Section::IsImmutableAfterLoad() const {
+  if (m_writable || !m_readable)
+    return false;
+
+  if (m_relocated)
+    return false;
+
+  if (IsGOTSection())
+    return false;
+
+  if (SectionSP parent_sp = GetParent()) {
+    llvm::StringRef seg_name = parent_sp->GetName();
+    if (seg_name == "__DATA_CONST" || seg_name == "__AUTH_CONST")
+      return false;
+  }
+
+  switch (m_type) {
+  case eSectionTypeDataCString:
+  case eSectionTypeData4:
+  case eSectionTypeData8:
+  case eSectionTypeData16:
+    return true;
+  default:
+    break;
+  }
+
+  return false;
+}
 
 #pragma mark SectionList
 

--- a/lldb/source/Core/Value.cpp
+++ b/lldb/source/Core/Value.cpp
@@ -563,8 +563,10 @@ Status Value::GetValueAsData(ExecutionContext *exe_ctx, DataExtractor &data,
         Process *process = exe_ctx->GetProcessPtr();
 
         if (process) {
-          const size_t bytes_read =
-              process->ReadMemory(address, dst, byte_size, error);
+          Address mem_addr(address);
+          const bool force_live_memory = false;
+          const size_t bytes_read = process->GetTarget().ReadMemory(
+              mem_addr, dst, byte_size, error, force_live_memory);
           if (bytes_read != byte_size)
             error = Status::FromErrorStringWithFormat(
                 "read memory from 0x%" PRIx64 " failed (%u of %u bytes read)",

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2141,23 +2141,18 @@ size_t Target::ReadMemory(const Address &addr, void *dst, size_t dst_len,
   std::unique_ptr<uint8_t[]> file_cache_read_buffer;
   size_t file_cache_bytes_read = 0;
 
-  // Read from file cache if read-only section.
+  // Read from file cache if the section is immutable after load.
   if (!force_live_memory && resolved_addr.IsSectionOffset()) {
     SectionSP section_sp(resolved_addr.GetSection());
-    if (section_sp) {
-      auto permissions = Flags(section_sp->GetPermissions());
-      bool is_readonly = !permissions.Test(ePermissionsWritable) &&
-                         permissions.Test(ePermissionsReadable);
-      if (is_readonly) {
-        file_cache_bytes_read =
-            ReadMemoryFromFileCache(resolved_addr, dst, dst_len, error);
-        if (file_cache_bytes_read == dst_len)
-          return file_cache_bytes_read;
-        else if (file_cache_bytes_read > 0) {
-          file_cache_read_buffer =
-              std::make_unique<uint8_t[]>(file_cache_bytes_read);
-          std::memcpy(file_cache_read_buffer.get(), dst, file_cache_bytes_read);
-        }
+    if (section_sp && section_sp->IsImmutableAfterLoad()) {
+      file_cache_bytes_read =
+          ReadMemoryFromFileCache(resolved_addr, dst, dst_len, error);
+      if (file_cache_bytes_read == dst_len)
+        return file_cache_bytes_read;
+      else if (file_cache_bytes_read > 0) {
+        file_cache_read_buffer =
+            std::make_unique<uint8_t[]>(file_cache_bytes_read);
+        std::memcpy(file_cache_read_buffer.get(), dst, file_cache_bytes_read);
       }
     }
   }

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -11,6 +11,7 @@
 #include "lldb/Core/Address.h"
 #include "lldb/Core/Declaration.h"
 #include "lldb/Core/Module.h"
+#include "lldb/Core/Section.h"
 #include "lldb/DataFormatters/DataVisualization.h"
 #include "lldb/DataFormatters/DumpValueObjectOptions.h"
 #include "lldb/DataFormatters/FormatManager.h"
@@ -77,6 +78,20 @@ using namespace lldb;
 using namespace lldb_private;
 
 static std::atomic<user_id_t> g_value_obj_uid{0};
+
+// Clamp a read of an immutable-after-load section to the end of that section,
+// so it doesn't spill into neighbouring bytes that must be read live.
+static uint64_t AdjustPointeeRead(const Address &resolved_addr,
+                                  uint64_t requested_bytes) {
+  SectionSP section_sp = resolved_addr.GetSection();
+  if (!section_sp || !section_sp->IsImmutableAfterLoad())
+    return requested_bytes;
+  addr_t section_size = section_sp->GetByteSize();
+  addr_t off_in_section = resolved_addr.GetOffset();
+  if (off_in_section >= section_size)
+    return requested_bytes;
+  return std::min<uint64_t>(requested_bytes, section_size - off_in_section);
+}
 
 // FIXME: this will return true for vector types whose elements
 // are floats. Audit all usages of this function and call
@@ -746,10 +761,14 @@ size_t ValueObject::GetPointeeData(DataExtractor &data, uint32_t item_idx,
         ExecutionContext exe_ctx(GetExecutionContextRef());
         Target *target = exe_ctx.GetTargetPtr();
         if (target) {
-          heap_buf_ptr->SetByteSize(bytes);
+          SectionSP section_sp = so_addr.GetSection();
+          bool force_live = !section_sp || !section_sp->IsImmutableAfterLoad();
+          uint64_t read_bytes = AdjustPointeeRead(so_addr, bytes);
+          heap_buf_ptr->SetByteSize(read_bytes);
           size_t bytes_read = target->ReadMemory(
-              so_addr, heap_buf_ptr->GetBytes(), bytes, error, true);
+              so_addr, heap_buf_ptr->GetBytes(), read_bytes, error, force_live);
           if (error.Success()) {
+            heap_buf_ptr->SetByteSize(bytes_read);
             data.SetData(data_sp);
             return bytes_read;
           }
@@ -759,13 +778,17 @@ size_t ValueObject::GetPointeeData(DataExtractor &data, uint32_t item_idx,
     case eAddressTypeLoad: {
       ExecutionContext exe_ctx(GetExecutionContextRef());
       if (Target *target = exe_ctx.GetTargetPtr()) {
-        heap_buf_ptr->SetByteSize(bytes);
         Address target_addr;
         target_addr.SetLoadAddress(addr + offset, target);
+        SectionSP section_sp = target_addr.GetSection();
+        bool force_live = !section_sp || !section_sp->IsImmutableAfterLoad();
+        uint64_t read_bytes = AdjustPointeeRead(target_addr, bytes);
+        heap_buf_ptr->SetByteSize(read_bytes);
         size_t bytes_read =
-            target->ReadMemory(target_addr, heap_buf_ptr->GetBytes(), bytes,
-                               error, /*force_live_memory=*/true);
+            target->ReadMemory(target_addr, heap_buf_ptr->GetBytes(),
+                               read_bytes, error, force_live);
         if (error.Success() || bytes_read > 0) {
+          heap_buf_ptr->SetByteSize(bytes_read);
           data.SetData(data_sp);
           return bytes_read;
         }

--- a/lldb/test/API/functionalities/postmortem/elf-core/TestLinuxCore.py
+++ b/lldb/test/API/functionalities/postmortem/elf-core/TestLinuxCore.py
@@ -1245,6 +1245,11 @@ class LinuxCoreTestCase(TestBase):
         self.assertEqual(target.ReadMemory(addr, 7, error), b"_start\0")
         self.assertSuccess(error)
 
+        # Dereferencing reads the pointee via Value::GetValueAsData() instead.
+        deref = var.Dereference()
+        self.assertSuccess(deref.GetError())
+        self.assertEqual(deref.GetValue(), "'_'")
+
     @skipIfLLVMTargetMissing("X86")
     @skipIfWindows
     def test_linux_no_exe(self):

--- a/lldb/test/API/macosx/expedited-stack-memory/TestExpeditedStackMemory.py
+++ b/lldb/test/API/macosx/expedited-stack-memory/TestExpeditedStackMemory.py
@@ -163,6 +163,13 @@ class TestExpeditedStackMemory(TestBase):
             + breakdown,
         )
 
+        # `str` points into __TEXT,__cstring, served from the file.
+        self.assertEqual(
+            other_reads,
+            [],
+            "expected no memory reads outside the stack/heap regions\n" + breakdown,
+        )
+
     # ---- shared scaffolding -------------------------------------------------
 
     def walk_stack(self, per_frame_fn, disable_memory_cache):

--- a/lldb/unittests/Target/MemoryTest.cpp
+++ b/lldb/unittests/Target/MemoryTest.cpp
@@ -16,13 +16,16 @@
 #include "lldb/Core/Module.h"
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Core/Section.h"
+#include "lldb/Core/Value.h"
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Host/HostInfo.h"
 #include "lldb/Target/ABI.h"
+#include "lldb/Target/ExecutionContext.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Utility/ArchSpec.h"
 #include "lldb/Utility/DataBufferHeap.h"
+#include "lldb/Utility/RegisterInfo.h"
 #include "llvm/Testing/Support/Error.h"
 #include "gtest/gtest.h"
 #include <cstdint>
@@ -1116,4 +1119,77 @@ TEST_F(MemoryTest, TestReadImmutableSectionFromFileCacheMachO) {
   CheckImmutableSectionServedFromFile(ArchSpec("x86_64-apple-macosx-"),
                                       kMachOImmutableAndWritableYaml,
                                       "__cstring", "__data");
+}
+
+/// `reg_info` must outlive the returned Value, which only stores a pointer.
+static Value MakeLoadAddressValue(RegisterInfo &reg_info,
+                                  lldb::addr_t load_addr, uint32_t byte_size) {
+  reg_info = RegisterInfo();
+  reg_info.name = "test";
+  reg_info.byte_size = byte_size;
+  reg_info.encoding = lldb::eEncodingUint;
+  reg_info.format = lldb::eFormatHex;
+
+  Value v{Scalar(load_addr)};
+  v.SetContext(Value::ContextType::RegisterInfo, &reg_info);
+  v.SetValueType(Value::ValueType::LoadAddress);
+  return v;
+}
+
+// A writable section is served from the file when the live read comes up short,
+// as with a core file that didn't dump the page.
+TEST_F(MemoryTest, GetValueAsDataFallsBackToFileWhenLiveReadFails) {
+  SubsystemRAII<ObjectFileMachO> subsystems;
+  ImmutableAndWritableModule fixture = CreateImmutableAndWritableModule();
+  ASSERT_TRUE(fixture.writable_sp);
+  auto *process = static_cast<DummyProcess *>(fixture.process_sp.get());
+  process->SetMaxReadSize(0);
+
+  RegisterInfo reg_info;
+  Value v =
+      MakeLoadAddressValue(reg_info, fixture.writable_sp->GetFileAddress(), 5);
+  DataExtractor data;
+  ExecutionContext exe_ctx(fixture.target_sp, /*get_process=*/true);
+  Status status = v.GetValueAsData(&exe_ctx, data, nullptr);
+  ASSERT_TRUE(status.Success()) << status.AsCString();
+  ASSERT_EQ(data.GetByteSize(), 5u);
+  EXPECT_EQ(memcmp(data.GetDataStart(), "hello", 5), 0);
+}
+
+// An immutable section is served from the file even with a live process, a
+// writable one with identical on-disk bytes is not.
+TEST_F(MemoryTest, GetValueAsDataServesImmutableSectionFromFileCache) {
+  SubsystemRAII<ObjectFileMachO> subsystems;
+  ImmutableAndWritableModule fixture = CreateImmutableAndWritableModule();
+  ASSERT_TRUE(fixture.immutable_sp);
+  ASSERT_TRUE(fixture.writable_sp);
+  ASSERT_TRUE(fixture.immutable_sp->IsImmutableAfterLoad());
+  ASSERT_FALSE(fixture.writable_sp->IsImmutableAfterLoad());
+  auto *process = static_cast<DummyProcess *>(fixture.process_sp.get());
+  // Live reads succeed and return 'B', so the decision is observable.
+  process->SetMaxReadSize(4096);
+  process->SetFiller('B');
+  ExecutionContext exe_ctx(fixture.target_sp, /*get_process=*/true);
+
+  {
+    RegisterInfo reg_info;
+    Value v = MakeLoadAddressValue(reg_info,
+                                   fixture.immutable_sp->GetFileAddress(), 5);
+    DataExtractor data;
+    Status status = v.GetValueAsData(&exe_ctx, data, nullptr);
+    ASSERT_TRUE(status.Success()) << status.AsCString();
+    ASSERT_EQ(data.GetByteSize(), 5u);
+    EXPECT_EQ(memcmp(data.GetDataStart(), "hello", 5), 0);
+  }
+
+  {
+    RegisterInfo reg_info;
+    Value v = MakeLoadAddressValue(reg_info,
+                                   fixture.writable_sp->GetFileAddress(), 5);
+    DataExtractor data;
+    Status status = v.GetValueAsData(&exe_ctx, data, nullptr);
+    ASSERT_TRUE(status.Success()) << status.AsCString();
+    ASSERT_EQ(data.GetByteSize(), 5u);
+    EXPECT_EQ(*data.GetDataStart(), 'B');
+  }
 }

--- a/lldb/unittests/Target/MemoryTest.cpp
+++ b/lldb/unittests/Target/MemoryTest.cpp
@@ -922,3 +922,198 @@ LoadCommands:
             12u);
   EXPECT_TRUE(short_error.Fail());
 }
+
+namespace {
+/// A target+process plus a module with one immutable and one writable section,
+/// both loaded at their file addresses and holding identical bytes
+/// (kImmutableCString), so a read reveals which of the two it came from.
+struct ImmutableAndWritableModule {
+  DebuggerSP debugger_sp;
+  TargetSP target_sp;
+  ProcessSP process_sp;
+  SectionSP immutable_sp;
+  SectionSP writable_sp;
+};
+} // namespace
+
+static const char kImmutableCString[] = "hello from func_e";
+
+// One immutable (__TEXT,__cstring) and one writable (__DATA,__data) section,
+// both holding kImmutableCString.
+static constexpr const char *kMachOImmutableAndWritableYaml = R"(
+--- !mach-o
+FileHeader:
+  magic:           0xFEEDFACF
+  cputype:         0x1000007
+  cpusubtype:      0x3
+  filetype:        0x2
+  ncmds:           2
+  sizeofcmds:      392
+  flags:           0x200085
+  reserved:        0x0
+LoadCommands:
+  - cmd:             0x19
+    cmdsize:         152
+    segname:         __TEXT
+    vmaddr:          0x100000000
+    vmsize:          0x1000
+    fileoff:         0
+    filesize:        0x1000
+    maxprot:         5
+    initprot:        5
+    nsects:          1
+    flags:           0
+    Sections:
+      - sectname:        __cstring
+        segname:         __TEXT
+        addr:            0x100000F58
+        size:            18
+        offset:          0xF58
+        align:           0
+        reloff:          0x0
+        nreloc:          0
+        flags:           0x2
+        reserved1:       0x0
+        reserved2:       0x0
+        reserved3:       0x0
+        content:         68656C6C6F2066726F6D2066756E635F6500
+  - cmd:             0x19
+    cmdsize:         152
+    segname:         __DATA
+    vmaddr:          0x100001000
+    vmsize:          0x1000
+    fileoff:         0x1000
+    filesize:        0x1000
+    maxprot:         3
+    initprot:        3
+    nsects:          1
+    flags:           0
+    Sections:
+      - sectname:        __data
+        segname:         __DATA
+        addr:            0x100001000
+        size:            18
+        offset:          0x1000
+        align:           0
+        reloff:          0x0
+        nreloc:          0
+        flags:           0x0
+        reserved1:       0x0
+        reserved2:       0x0
+        reserved3:       0x0
+        content:         68656C6C6F2066726F6D2066756E635F6500
+...
+)";
+
+static ImmutableAndWritableModule CreateImmutableAndWritableModule(
+    const ArchSpec &arch = ArchSpec("x86_64-apple-macosx-"),
+    llvm::StringRef yaml = kMachOImmutableAndWritableYaml,
+    const char *immutable_section = "__cstring",
+    const char *writable_section = "__data") {
+  Platform::SetHostPlatform(PlatformRemoteMacOSX::CreateInstance(true, &arch));
+
+  ImmutableAndWritableModule fixture;
+  fixture.debugger_sp = Debugger::CreateInstance();
+  ArchSpec arch_copy = arch;
+  fixture.target_sp = CreateTarget(fixture.debugger_sp, arch_copy);
+  fixture.process_sp = CreateProcess(fixture.target_sp);
+  if (!fixture.debugger_sp || !fixture.target_sp || !fixture.process_sp) {
+    ADD_FAILURE() << "could not create target/process";
+    return fixture;
+  }
+
+  auto expected_file = TestFile::fromYaml(yaml);
+  if (!expected_file) {
+    ADD_FAILURE() << llvm::toString(expected_file.takeError());
+    return fixture;
+  }
+  ModuleSP module_sp = std::make_shared<Module>(expected_file->moduleSpec());
+  fixture.target_sp->GetImages().Append(module_sp, /*notify=*/false);
+
+  SectionList *sections = module_sp->GetSectionList();
+  if (!sections) {
+    ADD_FAILURE() << "no section list";
+    return fixture;
+  }
+  SectionSP immutable_sp =
+      sections->FindSectionByName(ConstString(immutable_section));
+  SectionSP writable_sp =
+      sections->FindSectionByName(ConstString(writable_section));
+  if (!immutable_sp || !writable_sp) {
+    ADD_FAILURE() << "could not find " << immutable_section << " / "
+                  << writable_section;
+    return fixture;
+  }
+
+  // Load at the file addresses so a load address resolves back to the section,
+  // which the file-cache path requires.
+  if (!fixture.target_sp->SetSectionLoadAddress(
+          immutable_sp, immutable_sp->GetFileAddress()) ||
+      !fixture.target_sp->SetSectionLoadAddress(
+          writable_sp, writable_sp->GetFileAddress())) {
+    ADD_FAILURE() << "could not load the test sections";
+    return fixture;
+  }
+
+  fixture.immutable_sp = immutable_sp;
+  fixture.writable_sp = writable_sp;
+  return fixture;
+}
+
+// Target::ReadMemory serves an immutable read-only section from the host object
+// file, a writable one is still read live.
+static void CheckImmutableSectionServedFromFile(const ArchSpec &arch,
+                                                llvm::StringRef yaml,
+                                                const char *immutable_section,
+                                                const char *writable_section) {
+  ImmutableAndWritableModule fixture = CreateImmutableAndWritableModule(
+      arch, yaml, immutable_section, writable_section);
+  ASSERT_TRUE(fixture.immutable_sp) << immutable_section;
+  ASSERT_TRUE(fixture.writable_sp) << writable_section;
+  ASSERT_TRUE(fixture.immutable_sp->IsImmutableAfterLoad());
+  ASSERT_FALSE(fixture.writable_sp->IsImmutableAfterLoad());
+  TargetSP target_sp = fixture.target_sp;
+  SectionSP immutable_sp = fixture.immutable_sp;
+  SectionSP writable_sp = fixture.writable_sp;
+
+  // Live reads succeed and return 'B', so the decision is observable.
+  DummyProcess *process = static_cast<DummyProcess *>(fixture.process_sp.get());
+  process->SetMaxReadSize(4096);
+  process->SetFiller('B');
+
+  const size_t len = sizeof(kImmutableCString); // includes the trailing NUL
+  Status error;
+
+  // Immutable section: must come from the file, not the 'B' filler.
+  {
+    char buf[64] = {};
+    Address addr;
+    ASSERT_TRUE(
+        target_sp->ResolveLoadAddress(immutable_sp->GetFileAddress(), addr));
+    size_t n = target_sp->ReadMemory(addr, buf, len, error,
+                                     /*force_live_memory=*/false);
+    ASSERT_TRUE(error.Success()) << error.AsCString();
+    EXPECT_EQ(n, len);
+    EXPECT_STREQ(buf, kImmutableCString);
+  }
+
+  // Writable section, same bytes on disk: read live, so we see the filler.
+  {
+    char buf[64] = {};
+    Address addr;
+    ASSERT_TRUE(
+        target_sp->ResolveLoadAddress(writable_sp->GetFileAddress(), addr));
+    size_t n = target_sp->ReadMemory(addr, buf, len, error,
+                                     /*force_live_memory=*/false);
+    ASSERT_TRUE(error.Success()) << error.AsCString();
+    EXPECT_EQ(n, len);
+    EXPECT_EQ(buf[0], 'B');
+  }
+}
+
+TEST_F(MemoryTest, TestReadImmutableSectionFromFileCacheMachO) {
+  SubsystemRAII<ObjectFileMachO> subsystems;
+  CheckImmutableSectionServedFromFile(ArchSpec("x86_64-apple-macosx-"),
+                                      kMachOImmutableAndWritableYaml,
+                                      "__cstring", "__data");
+}


### PR DESCRIPTION
# Summary

`lldb` already has the bytes of a string literal on disk, yet printing a `const char *`
that points into `__TEXT,__cstring` sent gdb-remote memory reads
for the pointee, because both readers that disclose it hard-coded
`force_live_memory = true`.  This stack adds a single predicate for "the object
file's bytes are the process's bytes", makes `Target::ReadMemory`'s object-file
fast path use it, and routes the two value readers through that fast path:

* `frame variable *str` / a `const char *` summary no longer issue live memory
  reads for the literal itself.
* Reading such a value out of a page a core file did not dump now succeeds
  instead of failing with `read memory from 0x... failed (0 of 1 bytes read)`.

# Motivation
A `const char *` is disclosed two ways, and both went live:

* its summary, through `ValueObject::GetPointeeData`, and
* its dereferenced child, through `ValueObjectChild::UpdateValue` ->
  `Value::GetValueAsData`.

Fixing only one of them leaves the round trip in place, so both are fixed here.
`Value::GetValueAsData` is also the path used by `ValueObjectMemory`,
`ValueObjectCast`, `ValueObjectSynthetic`, `ValueObject::GetData` and
`CreateConstantValue`, none of which go through `GetPointeeData`.

Separately, `Value::GetValueAsData` called `Process::ReadMemory()` directly, so
it had no way to fall back to the object file when the process could not
satisfy the read — the core-file case above.

The gate on `Target::ReadMemory`'s object-file fast path was also unsound: it
tested section permissions only (`readable && !writable`), which cannot tell a
literal pool from a section the loader rewrites at load time. It dates back to
`dea8cb4fe314` (2011).

# Commits

1. **`[lldb] Add Section::IsImmutableAfterLoad() and gate Target::ReadMemory on it`**:                                                     introduces the predicate with the existing permission-only body and calls it
   from the fast path. Pure refactor, NFC.
2. **`[lldb] Section::IsImmutableAfterLoad(): add Mach-O section checks`** :
   turns it into a positive test: `false` for writable, relocated and GOT
   sections and for `__DATA_CONST`/`__AUTH_CONST` members, `true` only for                                                                  literal section types (C-string, 4/8/16-byte literals), `false` otherwise.
3. **`[lldb] Read immutable read-only pointees from the host file cache`** :
   `ValueObject::GetPointeeData` derives `force_live` from the resolved section
   instead of hard-coding `true`, and clamps the request to the end of an
   immutable section (`AdjustPointeeRead`) so the fast path can satisfy the
   whole read; the fixed-size NUL-scan chunk otherwise overruns a small literal
   section and forces the read live anyway.
4. **`[lldb] Value::GetValueAsData: read load addresses via Target::ReadMemory`** :
   replaces the direct `Process::ReadMemory()` call with
   `Target::ReadMemory(..., force_live_memory = false)`, which both consults the
   predicate and gives the read a fallback when the process comes up short.
5. **`[lldb] TestExpeditedStackMemory: assert other_reads is empty`** : the test
   already computed the reads that land outside the stack and heap but asserted
   nothing about them; the only contributor was `str`'s literal, so it can now
   assert there are none.

# Behaviour changes
* **The object-file fast path is narrower.** Before, *any* read-only section was
  served from the file when `force_live_memory = false`; now only positively
  immutable literal sections are. Non-literal read-only sections
  (`__TEXT,__const`, `__TEXT,__unwind_info`, ELF `.rodata`) are read live and
 reach the object file only through the existing "process read failed" fallback. That
  is the conservative direction ( the old test could serve stale bytes for a section the loader rewrites) but it does move some reads onto the  wire that previously never got there.
* **A debugger-side `memory write` into a literal pool is no longer reflected in
  printed values**, because nothing invalidates the file-vs-live decision.
  `memory read` still shows the written bytes.
* `Value::GetValueAsData`'s other branch, the one taken when the value carries a
  resolved section address (`file_so_addr.IsValid()`), still passes
  `force_live_memory = true`; only the raw load/file-address branch changed.


# Testing
* `MemoryTest.TestReadImmutableSectionFromFileCacheMachO`, with a live process
  wired to return a filler byte, an immutable section (`__TEXT,__cstring`) is
  served from the object file while a writable section holding identical on-disk                                                           bytes is still read live.
* `MemoryTest.GetValueAsDataServesImmutableSectionFromFileCache`: the same
  file-vs-live distinction through `Value::GetValueAsData`.
* `MemoryTest.GetValueAsDataFallsBackToFileWhenLiveReadFails` : uses the
  *writable* section deliberately, to show the fallback is gated only on the                                                               live read coming up short.
* `TestLinuxCore.py`'s `test_read_only_cstring` now covers the dereference in
  addition to the summary (`frame variable *F` on `altmain2.core` from #139196
  printed an error before, prints `'_'` now).
* `TestExpeditedStackMemory.py` asserts no memory reads outside the stack and
  heap regions, which is the end-to-end proof that neither disclosure path
  touches the wire for a literal.

All three unit tests and both API tests pass locally
(`TargetTests --gtest_filter=MemoryTest.*`, `check-lldb-api` filtered).

# Follow-ups

The predicate `IsImmutableAfterLoad()` is deliberately minimal here. Widening
it is separable work:

* On Mach-O the sound unit is the *segment*: `__TEXT` is `r-x`, takes no dyld
  fixups, and measures byte-identical to the file in live processes. Keying on
  that subsumes the four literal types and picks up `__const`,
  `__objc_methlist`, the `__swift5_*` metadata, unwind info and `__text`.
* Swift type metadata is where that pays: without such a gate, a locals burst
  costs two orders of magnitude more memory reads.
* On ELF this allowlist matches nothing, since `.rodata*` and `swift5_*` all
  classify as `eSectionTypeOther`.
* Invalidating the file-vs-live decision on a debugger-side write would remove
  the `memory write` caveat above.