### PR TITLE
[Target] Add shouldDefaultToNewPM flag

### DIFF
--- a/llvm/include/llvm/Target/TargetMachine.h
+++ b/llvm/include/llvm/Target/TargetMachine.h
@@ -502,6 +502,10 @@ public:
                                    inconvertibleErrorCode());
   }
 
+  /// Returns true if frontends should default to using the NewPM for this
+  /// specific target.
+  virtual bool shouldDefaultToNewPM() const { return false; }
+
   /// Returns true if the target is expected to pass all machine verifier
   /// checks. This is a stopgap measure to fix targets one by one. We will
   /// remove this at some point and always enable the verifier when


### PR DESCRIPTION
This will allow for tools like clang/flang/llc to default to the NewPM
for targets that request it.

Future patches will update clang/llc and flip it for targets that have
been fully ported but shouldn't have a large blast radius (like Lanai
and MSP430).

Pursuant to
https://discourse.llvm.org/t/rfc-incrementally-enabling-the-newpm-for-codegen/91410/11.
