### PR TITLE
[HLSL][Driver][SPIRV] Add -fspv-use-legacy-buffer-matrix-order flag

### DIFF
--- a/clang/include/clang/Basic/Builtins.td
+++ b/clang/include/clang/Basic/Builtins.td
@@ -5317,15 +5317,9 @@ def HLSLResourceGetPointerTyped : Builtin {
   let Prototype = "void(...)";
 }
 
-def HLSLResourceLoadTyped : LangBuiltin<"HLSL_LANG"> {
-  let Spellings = ["__builtin_hlsl_resource_load_typed"];
-  let Attributes = [NoThrow, CustomTypeChecking];
-  let Prototype = "void(...)";
-}
-
-def HLSLResourceStoreTyped : LangBuiltin<"HLSL_LANG"> {
-  let Spellings = ["__builtin_hlsl_resource_store_typed"];
-  let Attributes = [NoThrow, CustomTypeChecking];
+def HLSLMaybeTransposeMatrix : LangBuiltin<"HLSL_LANG"> {
+  let Spellings = ["__builtin_hlsl_maybe_transpose_matrix"];
+  let Attributes = [NoThrow, Const, CustomTypeChecking];
   let Prototype = "void(...)";
 }
 

--- a/clang/include/clang/Basic/Builtins.td
+++ b/clang/include/clang/Basic/Builtins.td
@@ -5317,6 +5317,18 @@ def HLSLResourceGetPointerTyped : Builtin {
   let Prototype = "void(...)";
 }
 
+def HLSLResourceLoadTyped : LangBuiltin<"HLSL_LANG"> {
+  let Spellings = ["__builtin_hlsl_resource_load_typed"];
+  let Attributes = [NoThrow, CustomTypeChecking];
+  let Prototype = "void(...)";
+}
+
+def HLSLResourceStoreTyped : LangBuiltin<"HLSL_LANG"> {
+  let Spellings = ["__builtin_hlsl_resource_store_typed"];
+  let Attributes = [NoThrow, CustomTypeChecking];
+  let Prototype = "void(...)";
+}
+
 def HLSLResourceLoadWithStatus : LangBuiltin<"HLSL_LANG"> {
   let Spellings = ["__builtin_hlsl_resource_load_with_status"];
   let Attributes = [NoThrow];

--- a/clang/include/clang/Basic/Builtins.td
+++ b/clang/include/clang/Basic/Builtins.td
@@ -5318,7 +5318,7 @@ def HLSLResourceGetPointerTyped : Builtin {
 }
 
 def HLSLMaybeTransposeMatrix : LangBuiltin<"HLSL_LANG"> {
-  let Spellings = ["__builtin_hlsl_maybe_transpose_matrix"];
+  let Spellings = ["__builtin_hlsl_transpose_if_memory_is_row_major"];
   let Attributes = [NoThrow, Const, CustomTypeChecking];
   let Prototype = "void(...)";
 }

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -250,6 +250,7 @@ ENUM_LANGOPT(HLSLVersion, HLSLLangStd, 16, HLSL_Unset, NotCompatible, "HLSL Vers
 LANGOPT(HLSLStrictAvailability, 1, 0, NotCompatible,
         "Strict availability diagnostic mode for HLSL built-in functions.")
 LANGOPT(HLSLSpvUseUnknownImageFormat, 1, 0, NotCompatible, "For storage images and texel buffers, sets the default format to 'Unknown' when not specified via the `vk::image_format` attribute. If this option is not used, the format is inferred from the resource's data type.")
+LANGOPT(HLSLSpvUseLegacyBufferMatrixOrder, 1, 0, NotCompatible, "Assume the legacy matrix order (row major) when accessing raw buffers (e.g. ByteAddressBuffer). Defaults to column major.")
 LANGOPT(HLSLSpvEnableMaximalReconvergence, 1, 0, NotCompatible, "Enables the MaximallyReconvergesKHR execution mode for this module. This ensures that control flow reconverges at well-defined merge points as defined by the Vulkan spec.")
 LANGOPT(HLSLSpvPreserveInterface, 1, 0, NotCompatible, "Preserve entry-point interface variables from dead-code elimination.")
 LANGOPT(EmitLogicalPointer, 1, 0, NotCompatible, "Allow emitting structured GEP/alloca intrinsics instead of normal GEP/alloca instructions.")

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -10038,6 +10038,15 @@ def fhlsl_spv_use_unknown_image_format
                "from the resource's data type.">,
       MarshallingInfoFlag<LangOpts<"HLSLSpvUseUnknownImageFormat">>;
 
+def fhlsl_spv_use_legacy_buffer_matrix_order
+    : Flag<["-"], "fspv-use-legacy-buffer-matrix-order">,
+      Group<dxc_Group>,
+      Visibility<[CC1Option, DXCOption]>,
+      HelpText<"Assume the legacy matrix order (row major) when accessing "
+               "raw buffers (e.g. ByteAddressBuffer). Defaults to column "
+               "major.">,
+      MarshallingInfoFlag<LangOpts<"HLSLSpvUseLegacyBufferMatrixOrder">>;
+
 def fhlsl_spv_enable_maximal_reconvergence
     : Flag<["-"], "fspv-enable-maximal-reconvergence">,
       Group<dxc_Group>,

--- a/clang/lib/CodeGen/CGHLSLBuiltins.cpp
+++ b/clang/lib/CodeGen/CGHLSLBuiltins.cpp
@@ -665,74 +665,20 @@ Value *CodeGenFunction::EmitHLSLBuiltinExpr(unsigned BuiltinID,
     CI->setCallingConv(IntrFn->getCallingConv());
     return CI;
   }
-  case Builtin::BI__builtin_hlsl_resource_load_typed: {
-    Value *HandleOp = EmitScalarExpr(E->getArg(0));
-    Value *IndexOp = EmitScalarExpr(E->getArg(1));
+  case Builtin::BI__builtin_hlsl_maybe_transpose_matrix: {
+    Value *ValueOp = EmitScalarExpr(E->getArg(0));
+    const auto *MatTy = E->getArg(0)->getType()->getAs<ConstantMatrixType>();
+    if (!MatTy || !CGM.getTriple().isSPIRV() ||
+        !getLangOpts().HLSLSpvUseLegacyBufferMatrixOrder)
+      return ValueOp;
 
-    QualType ElemQTy = E->getType();
-    QualType PtrQTy = getContext().getPointerType(
-        getContext().getAddrSpaceQualType(ElemQTy, LangAS::hlsl_device));
-    llvm::Type *PtrTy = ConvertType(PtrQTy);
-    llvm::Type *ElemTy = ConvertType(ElemQTy);
-
-    llvm::Function *IntrFn = llvm::Intrinsic::getOrInsertDeclaration(
-        &CGM.getModule(),
-        CGM.getHLSLRuntime().getCreateResourceGetPointerIntrinsic(),
-        {PtrTy, HandleOp->getType(), IndexOp->getType()});
-    llvm::CallInst *Ptr = EmitRuntimeCall(IntrFn, {HandleOp, IndexOp});
-    Ptr->setCallingConv(IntrFn->getCallingConv());
-
-    Address Addr(Ptr, ElemTy, getContext().getTypeAlignInChars(ElemQTy));
-    Value *Loaded = Builder.CreateLoad(Addr);
-
-    // Legacy row-major buffer order loads the transposed shape; transpose back.
-    if (const auto *MatTy = ElemQTy->getAs<ConstantMatrixType>()) {
-      const HLSLAttributedResourceType *RT = getRequiredHandleType(E, 0);
-      if (RT->isRaw() && CGM.getTriple().isSPIRV() &&
-          getLangOpts().HLSLSpvUseLegacyBufferMatrixOrder) {
-        llvm::MatrixBuilder MB(Builder);
-        Loaded = MB.CreateMatrixTranspose(Loaded, MatTy->getNumColumns(),
-                                          MatTy->getNumRows());
-      }
-    }
-    return Loaded;
-  }
-  case Builtin::BI__builtin_hlsl_resource_store_typed: {
-    // Value is evaluated before Handle/Index to match the IR shape of the
-    // other (non-templated) Store overloads.
-    Value *ValueOp = EmitScalarExpr(E->getArg(2));
-    Value *HandleOp = EmitScalarExpr(E->getArg(0));
-    Value *IndexOp = EmitScalarExpr(E->getArg(1));
-
-    QualType ElemQTy = E->getArg(2)->getType();
-
-    // See the load_typed case above.
-    if (const auto *MatTy = ElemQTy->getAs<ConstantMatrixType>()) {
-      const HLSLAttributedResourceType *RT = getRequiredHandleType(E, 0);
-      if (RT->isRaw() && CGM.getTriple().isSPIRV() &&
-          getLangOpts().HLSLSpvUseLegacyBufferMatrixOrder) {
-        llvm::MatrixBuilder MB(Builder);
-        ValueOp = MB.CreateMatrixTranspose(ValueOp, MatTy->getNumRows(),
-                                           MatTy->getNumColumns());
-      }
-    }
-
-    QualType PtrQTy = getContext().getPointerType(
-        getContext().getAddrSpaceQualType(ElemQTy, LangAS::hlsl_device));
-    llvm::Type *PtrTy = ConvertType(PtrQTy);
-
-    llvm::Function *IntrFn = llvm::Intrinsic::getOrInsertDeclaration(
-        &CGM.getModule(),
-        CGM.getHLSLRuntime().getCreateResourceGetPointerIntrinsic(),
-        {PtrTy, HandleOp->getType(), IndexOp->getType()});
-    llvm::CallInst *Ptr = EmitRuntimeCall(IntrFn, {HandleOp, IndexOp});
-    Ptr->setCallingConv(IntrFn->getCallingConv());
-
-    Address Addr(Ptr, ValueOp->getType(),
-                 getContext().getTypeAlignInChars(ElemQTy));
-    // Returning the (void-typed) store instruction, rather than nullptr,
-    // signals to the caller that this builtin was handled.
-    return Builder.CreateStore(ValueOp, Addr);
+    bool IsLoad =
+        E->getArg(1)->EvaluateKnownConstInt(getContext()).getBoolValue();
+    unsigned Rows = MatTy->getNumRows();
+    unsigned Columns = MatTy->getNumColumns();
+    llvm::MatrixBuilder MB(Builder);
+    return IsLoad ? MB.CreateMatrixTranspose(ValueOp, Columns, Rows)
+                  : MB.CreateMatrixTranspose(ValueOp, Rows, Columns);
   }
   case Builtin::BI__builtin_hlsl_resource_sample: {
     Value *HandleOp = EmitScalarExpr(E->getArg(0));

--- a/clang/lib/CodeGen/CGHLSLBuiltins.cpp
+++ b/clang/lib/CodeGen/CGHLSLBuiltins.cpp
@@ -666,8 +666,15 @@ Value *CodeGenFunction::EmitHLSLBuiltinExpr(unsigned BuiltinID,
     return CI;
   }
   case Builtin::BI__builtin_hlsl_maybe_transpose_matrix: {
-    Value *ValueOp = EmitScalarExpr(E->getArg(0));
-    const auto *MatTy = E->getArg(0)->getType()->getAs<ConstantMatrixType>();
+    const Expr *ValueExpr = E->getArg(0);
+    if (hasAggregateEvaluationKind(ValueExpr->getType())) {
+      EmitAnyExprToMem(ValueExpr, ReturnValue.getAddress(),
+                       ValueExpr->getType().getQualifiers(), /*IsInit=*/true);
+      return ReturnValue.getAddress().getBasePointer();
+    }
+
+    Value *ValueOp = EmitScalarExpr(ValueExpr);
+    const auto *MatTy = ValueExpr->getType()->getAs<ConstantMatrixType>();
     if (!MatTy || !CGM.getTriple().isSPIRV() ||
         !getLangOpts().HLSLSpvUseLegacyBufferMatrixOrder)
       return ValueOp;

--- a/clang/lib/CodeGen/CGHLSLBuiltins.cpp
+++ b/clang/lib/CodeGen/CGHLSLBuiltins.cpp
@@ -665,6 +665,75 @@ Value *CodeGenFunction::EmitHLSLBuiltinExpr(unsigned BuiltinID,
     CI->setCallingConv(IntrFn->getCallingConv());
     return CI;
   }
+  case Builtin::BI__builtin_hlsl_resource_load_typed: {
+    Value *HandleOp = EmitScalarExpr(E->getArg(0));
+    Value *IndexOp = EmitScalarExpr(E->getArg(1));
+
+    QualType ElemQTy = E->getType();
+    QualType PtrQTy = getContext().getPointerType(
+        getContext().getAddrSpaceQualType(ElemQTy, LangAS::hlsl_device));
+    llvm::Type *PtrTy = ConvertType(PtrQTy);
+    llvm::Type *ElemTy = ConvertType(ElemQTy);
+
+    llvm::Function *IntrFn = llvm::Intrinsic::getOrInsertDeclaration(
+        &CGM.getModule(),
+        CGM.getHLSLRuntime().getCreateResourceGetPointerIntrinsic(),
+        {PtrTy, HandleOp->getType(), IndexOp->getType()});
+    llvm::CallInst *Ptr = EmitRuntimeCall(IntrFn, {HandleOp, IndexOp});
+    Ptr->setCallingConv(IntrFn->getCallingConv());
+
+    Address Addr(Ptr, ElemTy, getContext().getTypeAlignInChars(ElemQTy));
+    Value *Loaded = Builder.CreateLoad(Addr);
+
+    // Legacy row-major buffer order loads the transposed shape; transpose back.
+    if (const auto *MatTy = ElemQTy->getAs<ConstantMatrixType>()) {
+      const HLSLAttributedResourceType *RT = getRequiredHandleType(E, 0);
+      if (RT->isRaw() && CGM.getTriple().isSPIRV() &&
+          getLangOpts().HLSLSpvUseLegacyBufferMatrixOrder) {
+        llvm::MatrixBuilder MB(Builder);
+        Loaded = MB.CreateMatrixTranspose(Loaded, MatTy->getNumColumns(),
+                                          MatTy->getNumRows());
+      }
+    }
+    return Loaded;
+  }
+  case Builtin::BI__builtin_hlsl_resource_store_typed: {
+    // Value is evaluated before Handle/Index to match the IR shape of the
+    // other (non-templated) Store overloads.
+    Value *ValueOp = EmitScalarExpr(E->getArg(2));
+    Value *HandleOp = EmitScalarExpr(E->getArg(0));
+    Value *IndexOp = EmitScalarExpr(E->getArg(1));
+
+    QualType ElemQTy = E->getArg(2)->getType();
+
+    // See the load_typed case above.
+    if (const auto *MatTy = ElemQTy->getAs<ConstantMatrixType>()) {
+      const HLSLAttributedResourceType *RT = getRequiredHandleType(E, 0);
+      if (RT->isRaw() && CGM.getTriple().isSPIRV() &&
+          getLangOpts().HLSLSpvUseLegacyBufferMatrixOrder) {
+        llvm::MatrixBuilder MB(Builder);
+        ValueOp = MB.CreateMatrixTranspose(ValueOp, MatTy->getNumRows(),
+                                           MatTy->getNumColumns());
+      }
+    }
+
+    QualType PtrQTy = getContext().getPointerType(
+        getContext().getAddrSpaceQualType(ElemQTy, LangAS::hlsl_device));
+    llvm::Type *PtrTy = ConvertType(PtrQTy);
+
+    llvm::Function *IntrFn = llvm::Intrinsic::getOrInsertDeclaration(
+        &CGM.getModule(),
+        CGM.getHLSLRuntime().getCreateResourceGetPointerIntrinsic(),
+        {PtrTy, HandleOp->getType(), IndexOp->getType()});
+    llvm::CallInst *Ptr = EmitRuntimeCall(IntrFn, {HandleOp, IndexOp});
+    Ptr->setCallingConv(IntrFn->getCallingConv());
+
+    Address Addr(Ptr, ValueOp->getType(),
+                 getContext().getTypeAlignInChars(ElemQTy));
+    // Returning the (void-typed) store instruction, rather than nullptr,
+    // signals to the caller that this builtin was handled.
+    return Builder.CreateStore(ValueOp, Addr);
+  }
   case Builtin::BI__builtin_hlsl_resource_sample: {
     Value *HandleOp = EmitScalarExpr(E->getArg(0));
     Value *SamplerOp = EmitScalarExpr(E->getArg(1));

--- a/clang/lib/CodeGen/CGHLSLBuiltins.cpp
+++ b/clang/lib/CodeGen/CGHLSLBuiltins.cpp
@@ -675,8 +675,7 @@ Value *CodeGenFunction::EmitHLSLBuiltinExpr(unsigned BuiltinID,
 
     Value *ValueOp = EmitScalarExpr(ValueExpr);
     const auto *MatTy = ValueExpr->getType()->getAs<ConstantMatrixType>();
-    if (!MatTy ||
-        !getLangOpts().HLSLSpvUseLegacyBufferMatrixOrder)
+    if (!MatTy || !getLangOpts().HLSLSpvUseLegacyBufferMatrixOrder)
       return ValueOp;
 
     bool IsLoad =

--- a/clang/lib/CodeGen/CGHLSLBuiltins.cpp
+++ b/clang/lib/CodeGen/CGHLSLBuiltins.cpp
@@ -665,7 +665,7 @@ Value *CodeGenFunction::EmitHLSLBuiltinExpr(unsigned BuiltinID,
     CI->setCallingConv(IntrFn->getCallingConv());
     return CI;
   }
-  case Builtin::BI__builtin_hlsl_maybe_transpose_matrix: {
+  case Builtin::BI__builtin_hlsl_transpose_if_memory_is_row_major: {
     const Expr *ValueExpr = E->getArg(0);
     if (hasAggregateEvaluationKind(ValueExpr->getType())) {
       EmitAnyExprToMem(ValueExpr, ReturnValue.getAddress(),
@@ -675,7 +675,7 @@ Value *CodeGenFunction::EmitHLSLBuiltinExpr(unsigned BuiltinID,
 
     Value *ValueOp = EmitScalarExpr(ValueExpr);
     const auto *MatTy = ValueExpr->getType()->getAs<ConstantMatrixType>();
-    if (!MatTy || !CGM.getTriple().isSPIRV() ||
+    if (!MatTy ||
         !getLangOpts().HLSLSpvUseLegacyBufferMatrixOrder)
       return ValueOp;
 

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -3972,6 +3972,7 @@ static void RenderHLSLOptions(const Driver &D, const ArgList &Args,
       options::OPT_fdx_rootsignature_define,
       options::OPT_fdx_rootsignature_version,
       options::OPT_fhlsl_spv_use_unknown_image_format,
+      options::OPT_fhlsl_spv_use_legacy_buffer_matrix_order,
       options::OPT_fhlsl_spv_enable_maximal_reconvergence,
       options::OPT_fhlsl_spv_preserve_interface};
   if (!types::isHLSL(InputType))

--- a/clang/lib/Driver/ToolChains/HLSL.cpp
+++ b/clang/lib/Driver/ToolChains/HLSL.cpp
@@ -533,6 +533,15 @@ HLSLToolChain::TranslateArgs(const DerivedArgList &Args, BoundArch BA,
       continue;
     }
 
+    if (A->getOption().getID() ==
+            options::OPT_fhlsl_spv_use_legacy_buffer_matrix_order &&
+        getArch() != llvm::Triple::spirv) {
+      getDriver().Diag(diag::err_drv_argument_only_allowed_with)
+          << A->getAsString(Args) << "-spirv";
+      A->claim();
+      continue;
+    }
+
     if (A->getOption().getID() == options::OPT_enable_16bit_types) {
       // Translate -enable-16bit-types into -fnative-half-type and
       // -fnative-int16-type

--- a/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
+++ b/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
@@ -2470,7 +2470,7 @@ BuiltinTypeDeclBuilder::addLoadWithStatusFunction(DeclarationName &Name,
 
 BuiltinTypeDeclBuilder &BuiltinTypeDeclBuilder::addHandleAccessFunction(
     DeclarationName &Name, bool IsConstReturn, bool IsRef, QualType IndexTy,
-  QualType ElemTy, bool TransposeResult) {
+    QualType ElemTy, bool TransposeResult) {
   assert(!Record->isCompleteDefinition() && "record is already complete");
   ASTContext &AST = SemaRef.getASTContext();
   using PH = BuiltinTypeMethodBuilder::PlaceHolder;
@@ -2534,8 +2534,8 @@ BuiltinTypeDeclBuilder::addStoreFunction(DeclarationName &Name, bool IsConst,
 
   MMB.addParam("Index", AST.UnsignedIntTy).addParam("Value", ValueTy);
   if (TransposeArg)
-    MMB.callBuiltin("__builtin_hlsl_transpose_if_memory_is_row_major", ValueTy, PH::_1,
-                    getConstantIntExpr(0));
+    MMB.callBuiltin("__builtin_hlsl_transpose_if_memory_is_row_major", ValueTy,
+                    PH::_1, getConstantIntExpr(0));
   MMB.callBuiltin("__builtin_hlsl_resource_getpointer_typed", ElemPtrTy,
                   PH::Handle, PH::_0, ValueTy)
       .dereference(PH::LastStmt)

--- a/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
+++ b/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
@@ -1686,8 +1686,7 @@ BuiltinTypeDeclBuilder::addByteAddressBufferLoadMethods() {
   AddLoads("Load3", AST.getExtVectorType(AST.UnsignedIntTy, 3));
   AddLoads("Load4", AST.getExtVectorType(AST.UnsignedIntTy, 4));
 
-  // Templated Load<T>() needs buffer-order-aware handling for matrix T; see
-  // __builtin_hlsl_resource_load_typed in CGHLSLBuiltins.cpp.
+  // Templated Load<T>() needs buffer-order-aware handling for matrix T.
   {
     IdentifierInfo &II = AST.Idents.get("Load", tok::TokenKind::identifier);
     DeclarationName Load(&II);
@@ -2478,10 +2477,16 @@ BuiltinTypeDeclBuilder::addRawBufferGenericLoadFunction(DeclarationName &Name) {
   BuiltinTypeMethodBuilder MMB(*this, Name, QualType(), /*IsConst=*/true);
   QualType ElemTy = MMB.addTemplateTypeParam("element_type");
   MMB.ReturnTy = ElemTy;
+  QualType AddrSpaceElemTy =
+      AST.getAddrSpaceQualType(ElemTy, LangAS::hlsl_device);
+  QualType ElemPtrTy = AST.getPointerType(AddrSpaceElemTy);
 
   return MMB.addParam("Index", AST.UnsignedIntTy)
-      .callBuiltin("__builtin_hlsl_resource_load_typed", ElemTy, PH::Handle,
-                   PH::_0, ElemTy)
+      .callBuiltin("__builtin_hlsl_resource_getpointer_typed", ElemPtrTy,
+                   PH::Handle, PH::_0, ElemTy)
+      .dereference(PH::LastStmt)
+      .callBuiltin("__builtin_hlsl_maybe_transpose_matrix", ElemTy,
+                   PH::LastStmt, getConstantIntExpr(1))
       .finalize();
 }
 
@@ -2494,11 +2499,18 @@ BuiltinTypeDeclBuilder::addRawBufferGenericStoreFunction(
 
   BuiltinTypeMethodBuilder MMB(*this, Name, AST.VoidTy, /*IsConst=*/false);
   QualType ElemTy = MMB.addTemplateTypeParam("element_type");
+  QualType AddrSpaceElemTy =
+      AST.getAddrSpaceQualType(ElemTy, LangAS::hlsl_device);
+  QualType ElemPtrTy = AST.getPointerType(AddrSpaceElemTy);
 
   return MMB.addParam("Index", AST.UnsignedIntTy)
       .addParam("Value", ElemTy)
-      .callBuiltin("__builtin_hlsl_resource_store_typed", AST.VoidTy,
-                   PH::Handle, PH::_0, PH::_1)
+      .callBuiltin("__builtin_hlsl_maybe_transpose_matrix", ElemTy, PH::_1,
+                   getConstantIntExpr(0))
+      .callBuiltin("__builtin_hlsl_resource_getpointer_typed", ElemPtrTy,
+                   PH::Handle, PH::_0, ElemTy)
+      .dereference(PH::LastStmt)
+      .assign(PH::LastStmt, PH::LastStmt)
       .finalize();
 }
 

--- a/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
+++ b/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
@@ -1690,7 +1690,7 @@ BuiltinTypeDeclBuilder::addByteAddressBufferLoadMethods() {
   {
     IdentifierInfo &II = AST.Idents.get("Load", tok::TokenKind::identifier);
     DeclarationName Load(&II);
-    addRawBufferGenericLoadFunction(Load);
+    addRawBufferTypedLoadFunction(Load);
     addLoadWithStatusFunction(Load, AST.DependentTy);
   }
 
@@ -1719,7 +1719,7 @@ BuiltinTypeDeclBuilder::addByteAddressBufferStoreMethods() {
   {
     IdentifierInfo &II = AST.Idents.get("Store", tok::TokenKind::identifier);
     DeclarationName Store(&II);
-    addRawBufferGenericStoreFunction(Store);
+    addRawBufferTypedStoreFunction(Store);
   }
 
   return *this;
@@ -2466,7 +2466,7 @@ BuiltinTypeDeclBuilder::addLoadWithStatusFunction(DeclarationName &Name,
 }
 
 BuiltinTypeDeclBuilder &
-BuiltinTypeDeclBuilder::addRawBufferGenericLoadFunction(DeclarationName &Name) {
+BuiltinTypeDeclBuilder::addRawBufferTypedLoadFunction(DeclarationName &Name) {
   assert(!Record->isCompleteDefinition() && "record is already complete");
   ASTContext &AST = SemaRef.getASTContext();
   using PH = BuiltinTypeMethodBuilder::PlaceHolder;
@@ -2491,8 +2491,7 @@ BuiltinTypeDeclBuilder::addRawBufferGenericLoadFunction(DeclarationName &Name) {
 }
 
 BuiltinTypeDeclBuilder &
-BuiltinTypeDeclBuilder::addRawBufferGenericStoreFunction(
-    DeclarationName &Name) {
+BuiltinTypeDeclBuilder::addRawBufferTypedStoreFunction(DeclarationName &Name) {
   assert(!Record->isCompleteDefinition() && "record is already complete");
   ASTContext &AST = SemaRef.getASTContext();
   using PH = BuiltinTypeMethodBuilder::PlaceHolder;

--- a/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
+++ b/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
@@ -1690,7 +1690,9 @@ BuiltinTypeDeclBuilder::addByteAddressBufferLoadMethods() {
   {
     IdentifierInfo &II = AST.Idents.get("Load", tok::TokenKind::identifier);
     DeclarationName Load(&II);
-    addRawBufferTypedLoadFunction(Load);
+    addHandleAccessFunction(Load, /*IsConstReturn=*/false, /*IsRef=*/false,
+                            AST.UnsignedIntTy, AST.DependentTy,
+                            /*TransposeResult=*/true);
     addLoadWithStatusFunction(Load, AST.DependentTy);
   }
 
@@ -1719,7 +1721,8 @@ BuiltinTypeDeclBuilder::addByteAddressBufferStoreMethods() {
   {
     IdentifierInfo &II = AST.Idents.get("Store", tok::TokenKind::identifier);
     DeclarationName Store(&II);
-    addRawBufferTypedStoreFunction(Store);
+    addStoreFunction(Store, /*IsConst=*/false, AST.DependentTy,
+                     /*TransposeArg=*/true);
   }
 
   return *this;
@@ -2465,57 +2468,9 @@ BuiltinTypeDeclBuilder::addLoadWithStatusFunction(DeclarationName &Name,
   return MMB.finalize();
 }
 
-BuiltinTypeDeclBuilder &
-BuiltinTypeDeclBuilder::addRawBufferTypedLoadFunction(DeclarationName &Name) {
-  assert(!Record->isCompleteDefinition() && "record is already complete");
-  ASTContext &AST = SemaRef.getASTContext();
-  using PH = BuiltinTypeMethodBuilder::PlaceHolder;
-
-  // The empty QualType is a placeholder. The actual return type is set below
-  // once the template parameter is created. This method is always const;
-  // it does not rebind the resource handle.
-  BuiltinTypeMethodBuilder MMB(*this, Name, QualType(), /*IsConst=*/true);
-  QualType ElemTy = MMB.addTemplateTypeParam("element_type");
-  MMB.ReturnTy = ElemTy;
-  QualType AddrSpaceElemTy =
-      AST.getAddrSpaceQualType(ElemTy, LangAS::hlsl_device);
-  QualType ElemPtrTy = AST.getPointerType(AddrSpaceElemTy);
-
-  return MMB.addParam("Index", AST.UnsignedIntTy)
-      .callBuiltin("__builtin_hlsl_resource_getpointer_typed", ElemPtrTy,
-                   PH::Handle, PH::_0, ElemTy)
-      .dereference(PH::LastStmt)
-      .callBuiltin("__builtin_hlsl_maybe_transpose_matrix", ElemTy,
-                   PH::LastStmt, getConstantIntExpr(1))
-      .finalize();
-}
-
-BuiltinTypeDeclBuilder &
-BuiltinTypeDeclBuilder::addRawBufferTypedStoreFunction(DeclarationName &Name) {
-  assert(!Record->isCompleteDefinition() && "record is already complete");
-  ASTContext &AST = SemaRef.getASTContext();
-  using PH = BuiltinTypeMethodBuilder::PlaceHolder;
-
-  BuiltinTypeMethodBuilder MMB(*this, Name, AST.VoidTy, /*IsConst=*/false);
-  QualType ElemTy = MMB.addTemplateTypeParam("element_type");
-  QualType AddrSpaceElemTy =
-      AST.getAddrSpaceQualType(ElemTy, LangAS::hlsl_device);
-  QualType ElemPtrTy = AST.getPointerType(AddrSpaceElemTy);
-
-  return MMB.addParam("Index", AST.UnsignedIntTy)
-      .addParam("Value", ElemTy)
-      .callBuiltin("__builtin_hlsl_maybe_transpose_matrix", ElemTy, PH::_1,
-                   getConstantIntExpr(0))
-      .callBuiltin("__builtin_hlsl_resource_getpointer_typed", ElemPtrTy,
-                   PH::Handle, PH::_0, ElemTy)
-      .dereference(PH::LastStmt)
-      .assign(PH::LastStmt, PH::LastStmt)
-      .finalize();
-}
-
 BuiltinTypeDeclBuilder &BuiltinTypeDeclBuilder::addHandleAccessFunction(
     DeclarationName &Name, bool IsConstReturn, bool IsRef, QualType IndexTy,
-    QualType ElemTy) {
+  QualType ElemTy, bool TransposeResult) {
   assert(!Record->isCompleteDefinition() && "record is already complete");
   ASTContext &AST = SemaRef.getASTContext();
   using PH = BuiltinTypeMethodBuilder::PlaceHolder;
@@ -2555,12 +2510,16 @@ BuiltinTypeDeclBuilder &BuiltinTypeDeclBuilder::addHandleAccessFunction(
     MMB.callBuiltin("__builtin_hlsl_resource_getpointer", ElemPtrTy, PH::Handle,
                     PH::_0);
 
-  return MMB.dereference(PH::LastStmt).finalize();
+  MMB.dereference(PH::LastStmt);
+  if (TransposeResult)
+    MMB.callBuiltin("__builtin_hlsl_maybe_transpose_matrix", ElemTy,
+                    PH::LastStmt, getConstantIntExpr(1));
+  return MMB.finalize();
 }
 
 BuiltinTypeDeclBuilder &
 BuiltinTypeDeclBuilder::addStoreFunction(DeclarationName &Name, bool IsConst,
-                                         QualType ValueTy) {
+                                         QualType ValueTy, bool TransposeArg) {
   assert(!Record->isCompleteDefinition() && "record is already complete");
   ASTContext &AST = SemaRef.getASTContext();
   using PH = BuiltinTypeMethodBuilder::PlaceHolder;
@@ -2573,13 +2532,15 @@ BuiltinTypeDeclBuilder::addStoreFunction(DeclarationName &Name, bool IsConst,
       AST.getAddrSpaceQualType(ValueTy, LangAS::hlsl_device);
   QualType ElemPtrTy = AST.getPointerType(AddrSpaceElemTy);
 
-  return MMB.addParam("Index", AST.UnsignedIntTy)
-      .addParam("Value", ValueTy)
-      .callBuiltin("__builtin_hlsl_resource_getpointer_typed", ElemPtrTy,
-                   PH::Handle, PH::_0, ValueTy)
+  MMB.addParam("Index", AST.UnsignedIntTy).addParam("Value", ValueTy);
+  if (TransposeArg)
+    MMB.callBuiltin("__builtin_hlsl_maybe_transpose_matrix", ValueTy, PH::_1,
+                    getConstantIntExpr(0));
+  MMB.callBuiltin("__builtin_hlsl_resource_getpointer_typed", ElemPtrTy,
+                  PH::Handle, PH::_0, ValueTy)
       .dereference(PH::LastStmt)
-      .assign(PH::LastStmt, PH::_1)
-      .finalize();
+      .assign(PH::LastStmt, TransposeArg ? PH::LastStmt : PH::_1);
+  return MMB.finalize();
 }
 
 BuiltinTypeDeclBuilder &

--- a/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
+++ b/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
@@ -1671,13 +1671,14 @@ BuiltinTypeDeclBuilder::addByteAddressBufferLoadMethods() {
 
   ASTContext &AST = SemaRef.getASTContext();
 
-  auto AddLoads = [&](StringRef MethodName, QualType ReturnType) {
+  auto AddLoads = [&](StringRef MethodName, QualType ReturnType,
+                      bool TransposeResult = false) {
     IdentifierInfo &II = AST.Idents.get(MethodName, tok::TokenKind::identifier);
     DeclarationName Load(&II);
 
     addHandleAccessFunction(Load,
                             /*IsConstReturn=*/false, /*IsRef=*/false,
-                            AST.UnsignedIntTy, ReturnType);
+                            AST.UnsignedIntTy, ReturnType, TransposeResult);
     addLoadWithStatusFunction(Load, ReturnType);
   };
 
@@ -1687,14 +1688,7 @@ BuiltinTypeDeclBuilder::addByteAddressBufferLoadMethods() {
   AddLoads("Load4", AST.getExtVectorType(AST.UnsignedIntTy, 4));
 
   // Templated Load<T>() needs buffer-order-aware handling for matrix T.
-  {
-    IdentifierInfo &II = AST.Idents.get("Load", tok::TokenKind::identifier);
-    DeclarationName Load(&II);
-    addHandleAccessFunction(Load, /*IsConstReturn=*/false, /*IsRef=*/false,
-                            AST.UnsignedIntTy, AST.DependentTy,
-                            /*TransposeResult=*/true);
-    addLoadWithStatusFunction(Load, AST.DependentTy);
-  }
+  AddLoads("Load", AST.DependentTy, /*TransposeResult=*/true);
 
   return *this;
 }
@@ -1705,11 +1699,12 @@ BuiltinTypeDeclBuilder::addByteAddressBufferStoreMethods() {
 
   ASTContext &AST = SemaRef.getASTContext();
 
-  auto AddStore = [&](StringRef MethodName, QualType ValueType) {
+  auto AddStore = [&](StringRef MethodName, QualType ValueType,
+                      bool TransposeArg = false) {
     IdentifierInfo &II = AST.Idents.get(MethodName, tok::TokenKind::identifier);
     DeclarationName Store(&II);
 
-    addStoreFunction(Store, /*IsConst=*/false, ValueType);
+    addStoreFunction(Store, /*IsConst=*/false, ValueType, TransposeArg);
   };
 
   AddStore("Store", AST.UnsignedIntTy);
@@ -1718,12 +1713,7 @@ BuiltinTypeDeclBuilder::addByteAddressBufferStoreMethods() {
   AddStore("Store4", AST.getExtVectorType(AST.UnsignedIntTy, 4));
 
   // Templated Store<T>(); see addByteAddressBufferLoadMethods() above.
-  {
-    IdentifierInfo &II = AST.Idents.get("Store", tok::TokenKind::identifier);
-    DeclarationName Store(&II);
-    addStoreFunction(Store, /*IsConst=*/false, AST.DependentTy,
-                     /*TransposeArg=*/true);
-  }
+  AddStore("Store", AST.DependentTy, /*TransposeArg=*/true);
 
   return *this;
 }

--- a/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
+++ b/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
@@ -2512,7 +2512,7 @@ BuiltinTypeDeclBuilder &BuiltinTypeDeclBuilder::addHandleAccessFunction(
 
   MMB.dereference(PH::LastStmt);
   if (TransposeResult)
-    MMB.callBuiltin("__builtin_hlsl_maybe_transpose_matrix", ElemTy,
+    MMB.callBuiltin("__builtin_hlsl_transpose_if_memory_is_row_major", ElemTy,
                     PH::LastStmt, getConstantIntExpr(1));
   return MMB.finalize();
 }
@@ -2534,7 +2534,7 @@ BuiltinTypeDeclBuilder::addStoreFunction(DeclarationName &Name, bool IsConst,
 
   MMB.addParam("Index", AST.UnsignedIntTy).addParam("Value", ValueTy);
   if (TransposeArg)
-    MMB.callBuiltin("__builtin_hlsl_maybe_transpose_matrix", ValueTy, PH::_1,
+    MMB.callBuiltin("__builtin_hlsl_transpose_if_memory_is_row_major", ValueTy, PH::_1,
                     getConstantIntExpr(0));
   MMB.callBuiltin("__builtin_hlsl_resource_getpointer_typed", ElemPtrTy,
                   PH::Handle, PH::_0, ValueTy)

--- a/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
+++ b/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
@@ -1685,7 +1685,16 @@ BuiltinTypeDeclBuilder::addByteAddressBufferLoadMethods() {
   AddLoads("Load2", AST.getExtVectorType(AST.UnsignedIntTy, 2));
   AddLoads("Load3", AST.getExtVectorType(AST.UnsignedIntTy, 3));
   AddLoads("Load4", AST.getExtVectorType(AST.UnsignedIntTy, 4));
-  AddLoads("Load", AST.DependentTy); // Templated version
+
+  // Templated Load<T>() needs buffer-order-aware handling for matrix T; see
+  // __builtin_hlsl_resource_load_typed in CGHLSLBuiltins.cpp.
+  {
+    IdentifierInfo &II = AST.Idents.get("Load", tok::TokenKind::identifier);
+    DeclarationName Load(&II);
+    addRawBufferGenericLoadFunction(Load);
+    addLoadWithStatusFunction(Load, AST.DependentTy);
+  }
+
   return *this;
 }
 
@@ -1706,7 +1715,13 @@ BuiltinTypeDeclBuilder::addByteAddressBufferStoreMethods() {
   AddStore("Store2", AST.getExtVectorType(AST.UnsignedIntTy, 2));
   AddStore("Store3", AST.getExtVectorType(AST.UnsignedIntTy, 3));
   AddStore("Store4", AST.getExtVectorType(AST.UnsignedIntTy, 4));
-  AddStore("Store", AST.DependentTy); // Templated version
+
+  // Templated Store<T>(); see addByteAddressBufferLoadMethods() above.
+  {
+    IdentifierInfo &II = AST.Idents.get("Store", tok::TokenKind::identifier);
+    DeclarationName Store(&II);
+    addRawBufferGenericStoreFunction(Store);
+  }
 
   return *this;
 }
@@ -2449,6 +2464,42 @@ BuiltinTypeDeclBuilder::addLoadWithStatusFunction(DeclarationName &Name,
                     PH::Handle, PH::_0, PH::_1);
 
   return MMB.finalize();
+}
+
+BuiltinTypeDeclBuilder &
+BuiltinTypeDeclBuilder::addRawBufferGenericLoadFunction(DeclarationName &Name) {
+  assert(!Record->isCompleteDefinition() && "record is already complete");
+  ASTContext &AST = SemaRef.getASTContext();
+  using PH = BuiltinTypeMethodBuilder::PlaceHolder;
+
+  // The empty QualType is a placeholder. The actual return type is set below
+  // once the template parameter is created. This method is always const;
+  // it does not rebind the resource handle.
+  BuiltinTypeMethodBuilder MMB(*this, Name, QualType(), /*IsConst=*/true);
+  QualType ElemTy = MMB.addTemplateTypeParam("element_type");
+  MMB.ReturnTy = ElemTy;
+
+  return MMB.addParam("Index", AST.UnsignedIntTy)
+      .callBuiltin("__builtin_hlsl_resource_load_typed", ElemTy, PH::Handle,
+                   PH::_0, ElemTy)
+      .finalize();
+}
+
+BuiltinTypeDeclBuilder &
+BuiltinTypeDeclBuilder::addRawBufferGenericStoreFunction(
+    DeclarationName &Name) {
+  assert(!Record->isCompleteDefinition() && "record is already complete");
+  ASTContext &AST = SemaRef.getASTContext();
+  using PH = BuiltinTypeMethodBuilder::PlaceHolder;
+
+  BuiltinTypeMethodBuilder MMB(*this, Name, AST.VoidTy, /*IsConst=*/false);
+  QualType ElemTy = MMB.addTemplateTypeParam("element_type");
+
+  return MMB.addParam("Index", AST.UnsignedIntTy)
+      .addParam("Value", ElemTy)
+      .callBuiltin("__builtin_hlsl_resource_store_typed", AST.VoidTy,
+                   PH::Handle, PH::_0, PH::_1)
+      .finalize();
 }
 
 BuiltinTypeDeclBuilder &BuiltinTypeDeclBuilder::addHandleAccessFunction(

--- a/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.h
+++ b/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.h
@@ -143,10 +143,8 @@ public:
                             QualType ReturnTy = QualType());
   BuiltinTypeDeclBuilder &addStoreFunction(DeclarationName &Name, bool IsConst,
                                            QualType ValueType);
-  BuiltinTypeDeclBuilder &
-  addRawBufferGenericLoadFunction(DeclarationName &Name);
-  BuiltinTypeDeclBuilder &
-  addRawBufferGenericStoreFunction(DeclarationName &Name);
+  BuiltinTypeDeclBuilder &addRawBufferTypedLoadFunction(DeclarationName &Name);
+  BuiltinTypeDeclBuilder &addRawBufferTypedStoreFunction(DeclarationName &Name);
   BuiltinTypeDeclBuilder &
   addByteAddressBufferInterlockedMethod(StringRef MethodName, QualType ValueTy,
                                         StringRef BuiltinName);

--- a/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.h
+++ b/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.h
@@ -137,14 +137,14 @@ public:
   BuiltinTypeDeclBuilder &addHandleAccessFunction(DeclarationName &Name,
                                                   bool IsConstReturn,
                                                   bool IsRef, QualType IndexTy,
-                                                  QualType ElemTy = QualType());
+                                                  QualType ElemTy = QualType(),
+                                                  bool TransposeResult = false);
   BuiltinTypeDeclBuilder &
   addLoadWithStatusFunction(DeclarationName &Name,
                             QualType ReturnTy = QualType());
   BuiltinTypeDeclBuilder &addStoreFunction(DeclarationName &Name, bool IsConst,
-                                           QualType ValueType);
-  BuiltinTypeDeclBuilder &addRawBufferTypedLoadFunction(DeclarationName &Name);
-  BuiltinTypeDeclBuilder &addRawBufferTypedStoreFunction(DeclarationName &Name);
+                                           QualType ValueType,
+                                           bool TransposeArg = false);
   BuiltinTypeDeclBuilder &
   addByteAddressBufferInterlockedMethod(StringRef MethodName, QualType ValueTy,
                                         StringRef BuiltinName);

--- a/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.h
+++ b/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.h
@@ -144,6 +144,10 @@ public:
   BuiltinTypeDeclBuilder &addStoreFunction(DeclarationName &Name, bool IsConst,
                                            QualType ValueType);
   BuiltinTypeDeclBuilder &
+  addRawBufferGenericLoadFunction(DeclarationName &Name);
+  BuiltinTypeDeclBuilder &
+  addRawBufferGenericStoreFunction(DeclarationName &Name);
+  BuiltinTypeDeclBuilder &
   addByteAddressBufferInterlockedMethod(StringRef MethodName, QualType ValueTy,
                                         StringRef BuiltinName);
   BuiltinTypeDeclBuilder &addAppendMethod();

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -4287,6 +4287,43 @@ bool SemaHLSL::CheckBuiltinFunctionCall(unsigned BuiltinID, CallExpr *TheCall) {
 
     break;
   }
+  case Builtin::BI__builtin_hlsl_resource_load_typed: {
+    if (SemaRef.checkArgCount(TheCall, 3) ||
+        CheckResourceHandle(&SemaRef, TheCall, 0) ||
+        CheckIndexType(&SemaRef, TheCall, 1))
+      return true;
+
+    QualType ReturnType = TheCall->getArg(2)->getType();
+    assert(ReturnType->isPointerType() &&
+           "expected pointer type for the third argument");
+    ReturnType = ReturnType->getPointeeType();
+
+    // Reject array types
+    if (ReturnType->isArrayType())
+      return SemaRef.Diag(
+          cast<FunctionDecl>(SemaRef.CurContext)->getPointOfInstantiation(),
+          diag::err_invalid_use_of_array_type);
+
+    TheCall->setType(ReturnType);
+
+    break;
+  }
+  case Builtin::BI__builtin_hlsl_resource_store_typed: {
+    if (SemaRef.checkArgCount(TheCall, 3) ||
+        CheckResourceHandle(&SemaRef, TheCall, 0) ||
+        CheckIndexType(&SemaRef, TheCall, 1))
+      return true;
+
+    // Reject array types
+    if (TheCall->getArg(2)->getType()->isArrayType())
+      return SemaRef.Diag(
+          cast<FunctionDecl>(SemaRef.CurContext)->getPointOfInstantiation(),
+          diag::err_invalid_use_of_array_type);
+
+    TheCall->setType(SemaRef.getASTContext().VoidTy);
+
+    break;
+  }
   case Builtin::BI__builtin_hlsl_resource_load_with_status: {
     if (SemaRef.checkArgCount(TheCall, 3) ||
         CheckResourceHandle(&SemaRef, TheCall, 0) ||

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -4287,7 +4287,7 @@ bool SemaHLSL::CheckBuiltinFunctionCall(unsigned BuiltinID, CallExpr *TheCall) {
 
     break;
   }
-  case Builtin::BI__builtin_hlsl_maybe_transpose_matrix: {
+  case Builtin::BI__builtin_hlsl_transpose_if_memory_is_row_major: {
     if (SemaRef.checkArgCount(TheCall, 2) ||
         CheckArgTypeMatches(&SemaRef, TheCall->getArg(1),
                             SemaRef.getASTContext().IntTy))

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -4287,40 +4287,13 @@ bool SemaHLSL::CheckBuiltinFunctionCall(unsigned BuiltinID, CallExpr *TheCall) {
 
     break;
   }
-  case Builtin::BI__builtin_hlsl_resource_load_typed: {
-    if (SemaRef.checkArgCount(TheCall, 3) ||
-        CheckResourceHandle(&SemaRef, TheCall, 0) ||
-        CheckIndexType(&SemaRef, TheCall, 1))
+  case Builtin::BI__builtin_hlsl_maybe_transpose_matrix: {
+    if (SemaRef.checkArgCount(TheCall, 2) ||
+        CheckArgTypeMatches(&SemaRef, TheCall->getArg(1),
+                            SemaRef.getASTContext().IntTy))
       return true;
 
-    QualType ReturnType = TheCall->getArg(2)->getType();
-    assert(ReturnType->isPointerType() &&
-           "expected pointer type for the third argument");
-    ReturnType = ReturnType->getPointeeType();
-
-    // Reject array types
-    if (ReturnType->isArrayType())
-      return SemaRef.Diag(
-          cast<FunctionDecl>(SemaRef.CurContext)->getPointOfInstantiation(),
-          diag::err_invalid_use_of_array_type);
-
-    TheCall->setType(ReturnType);
-
-    break;
-  }
-  case Builtin::BI__builtin_hlsl_resource_store_typed: {
-    if (SemaRef.checkArgCount(TheCall, 3) ||
-        CheckResourceHandle(&SemaRef, TheCall, 0) ||
-        CheckIndexType(&SemaRef, TheCall, 1))
-      return true;
-
-    // Reject array types
-    if (TheCall->getArg(2)->getType()->isArrayType())
-      return SemaRef.Diag(
-          cast<FunctionDecl>(SemaRef.CurContext)->getPointOfInstantiation(),
-          diag::err_invalid_use_of_array_type);
-
-    TheCall->setType(SemaRef.getASTContext().VoidTy);
+    TheCall->setType(TheCall->getArg(0)->getType());
 
     break;
   }

--- a/clang/test/AST/HLSL/ByteAddressBuffers-AST.hlsl
+++ b/clang/test/AST/HLSL/ByteAddressBuffers-AST.hlsl
@@ -298,6 +298,9 @@ RESOURCE Buffer;
 // CHECK-LOAD-NEXT: ParmVarDecl {{.*}} Index 'unsigned int'
 // CHECK-LOAD-NEXT: CompoundStmt
 // CHECK-LOAD-NEXT: ReturnStmt
+// CHECK-LOAD-NEXT: CStyleCastExpr {{.*}} 'element_type' <Dependent>
+// CHECK-LOAD-NEXT: CallExpr {{.*}} '<dependent type>'
+// CHECK-LOAD-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_maybe_transpose_matrix' 'void (...) noexcept'
 // CHECK-LOAD-NEXT: UnaryOperator {{.*}} 'hlsl_device element_type' lvalue prefix '*' cannot overflow
 // CHECK-LOAD-NEXT: CStyleCastExpr {{.*}} 'hlsl_device element_type *' <Dependent>
 // CHECK-LOAD-NEXT: CallExpr {{.*}} '<dependent type>'
@@ -306,6 +309,7 @@ RESOURCE Buffer;
 // CHECK-LOAD-NEXT: CXXThisExpr {{.*}} 'const hlsl::[[RESOURCE]]' lvalue implicit this
 // CHECK-LOAD-NEXT: DeclRefExpr {{.*}} 'unsigned int' lvalue ParmVar {{.*}} 'Index' 'unsigned int'
 // CHECK-LOAD-NEXT: CXXScalarValueInitExpr {{.*}} 'element_type *'
+// CHECK-LOAD-NEXT: IntegerLiteral {{.*}} 'int' 1
 // CHECK-LOAD-NEXT: AlwaysInlineAttr {{.*}} Implicit always_inline
 
 // CHECK-LOAD: CXXMethodDecl {{.*}} Load 'element_type (unsigned int, out unsigned int)
@@ -410,7 +414,11 @@ RESOURCE Buffer;
 // CHECK-STORE-NEXT: CXXThisExpr {{.*}} 'hlsl::[[RESOURCE]]' lvalue implicit this
 // CHECK-STORE-NEXT: DeclRefExpr {{.*}} 'unsigned int' lvalue ParmVar {{.*}} 'Index' 'unsigned int'
 // CHECK-STORE-NEXT: CXXScalarValueInitExpr {{.*}} 'element_type *'
+// CHECK-STORE-NEXT: CStyleCastExpr {{.*}} 'element_type' <Dependent>
+// CHECK-STORE-NEXT: CallExpr {{.*}} '<dependent type>'
+// CHECK-STORE-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_maybe_transpose_matrix' 'void (...) noexcept'
 // CHECK-STORE-NEXT: DeclRefExpr {{.*}} 'element_type' lvalue ParmVar {{.*}} 'Value' 'element_type'
+// CHECK-STORE-NEXT: IntegerLiteral {{.*}} 'int' 0
 // CHECK-STORE-NEXT: AlwaysInlineAttr {{.*}} Implicit always_inline
 
 // GetDimensions method

--- a/clang/test/AST/HLSL/ByteAddressBuffers-AST.hlsl
+++ b/clang/test/AST/HLSL/ByteAddressBuffers-AST.hlsl
@@ -300,7 +300,7 @@ RESOURCE Buffer;
 // CHECK-LOAD-NEXT: ReturnStmt
 // CHECK-LOAD-NEXT: CStyleCastExpr {{.*}} 'element_type' <Dependent>
 // CHECK-LOAD-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-LOAD-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_maybe_transpose_matrix' 'void (...) noexcept'
+// CHECK-LOAD-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_transpose_if_memory_is_row_major' 'void (...) noexcept'
 // CHECK-LOAD-NEXT: UnaryOperator {{.*}} 'hlsl_device element_type' lvalue prefix '*' cannot overflow
 // CHECK-LOAD-NEXT: CStyleCastExpr {{.*}} 'hlsl_device element_type *' <Dependent>
 // CHECK-LOAD-NEXT: CallExpr {{.*}} '<dependent type>'
@@ -416,7 +416,7 @@ RESOURCE Buffer;
 // CHECK-STORE-NEXT: CXXScalarValueInitExpr {{.*}} 'element_type *'
 // CHECK-STORE-NEXT: CStyleCastExpr {{.*}} 'element_type' <Dependent>
 // CHECK-STORE-NEXT: CallExpr {{.*}} '<dependent type>'
-// CHECK-STORE-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_maybe_transpose_matrix' 'void (...) noexcept'
+// CHECK-STORE-NEXT: DeclRefExpr {{.*}} '<builtin fn type>' Function {{.*}} '__builtin_hlsl_transpose_if_memory_is_row_major' 'void (...) noexcept'
 // CHECK-STORE-NEXT: DeclRefExpr {{.*}} 'element_type' lvalue ParmVar {{.*}} 'Value' 'element_type'
 // CHECK-STORE-NEXT: IntegerLiteral {{.*}} 'int' 0
 // CHECK-STORE-NEXT: AlwaysInlineAttr {{.*}} Implicit always_inline

--- a/clang/test/CodeGenHLSL/resources/ByteAddressBuffers-matrix-legacy-order.hlsl
+++ b/clang/test/CodeGenHLSL/resources/ByteAddressBuffers-matrix-legacy-order.hlsl
@@ -1,0 +1,37 @@
+// RUN: %clang_cc1 -triple spirv-unknown-vulkan-library -finclude-default-header \
+// RUN:   -emit-llvm -disable-llvm-passes -o - %s | FileCheck %s --check-prefixes=CHECK,DEFAULT
+// RUN: %clang_cc1 -triple spirv-unknown-vulkan-library -finclude-default-header \
+// RUN:   -fspv-use-legacy-buffer-matrix-order -emit-llvm -disable-llvm-passes -o - %s \
+// RUN:   | FileCheck %s --check-prefixes=CHECK,LEGACY
+
+// Raw buffers carry no layout information. By default, a matrix read from or
+// written to a raw buffer is assumed to be stored in column-major order,
+// matching the native in-register representation, so no reordering is
+// needed. -fspv-use-legacy-buffer-matrix-order assumes the raw bytes are
+// stored in row-major order instead, which requires transposing the loaded
+// (or, before storing, the to-be-stored) value.
+
+ByteAddressBuffer Buf : register(t0);
+RWByteAddressBuffer RWBuf : register(u0);
+
+export float2x3 TestLoad() {
+  return Buf.Load<float2x3>(0);
+}
+
+// CHECK-LABEL: define {{.*}} <6 x float> @{{.*}}ByteAddressBuffer4LoadIu11matrix_typeILj2ELj3EfEEET_j
+// CHECK: [[LOADED:%.*]] = load <6 x float>, ptr addrspace(11) %{{.*}}
+// DEFAULT-NOT: call {{.*}} @llvm.matrix.transpose
+// DEFAULT: ret <6 x float> [[LOADED]]
+// LEGACY: [[TRANSPOSED:%.*]] = call {{.*}} <6 x float> @llvm.matrix.transpose.v6f32(<6 x float> [[LOADED]], i32 3, i32 2)
+// LEGACY: ret <6 x float> [[TRANSPOSED]]
+
+export void TestStore(float2x3 M) {
+  RWBuf.Store<float2x3>(0, M);
+}
+
+// CHECK-LABEL: define {{.*}} void @{{.*}}RWByteAddressBuffer5StoreIu11matrix_typeILj2ELj3EfEEEvjT_
+// CHECK: [[VALUE:%.*]] = load <6 x float>, ptr %Value.addr
+// DEFAULT-NOT: call {{.*}} @llvm.matrix.transpose
+// DEFAULT: store <6 x float> [[VALUE]], ptr addrspace(11) %{{.*}}
+// LEGACY: [[TRANSPOSED:%.*]] = call {{.*}} <6 x float> @llvm.matrix.transpose.v6f32(<6 x float> [[VALUE]], i32 2, i32 3)
+// LEGACY: store <6 x float> [[TRANSPOSED]], ptr addrspace(11) %{{.*}}

--- a/clang/test/Driver/dxc_fspv_use_legacy_buffer_matrix_order.hlsl
+++ b/clang/test/Driver/dxc_fspv_use_legacy_buffer_matrix_order.hlsl
@@ -1,0 +1,17 @@
+// Verify that -fspv-use-legacy-buffer-matrix-order is accepted by the driver
+// and forwarded to cc1 as -fspv-use-legacy-buffer-matrix-order.
+// RUN: %clang_dxc -spirv -Tlib_6_7 -fspv-use-legacy-buffer-matrix-order -### %s 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=CHECK-LEGACY
+// CHECK-LEGACY: "-fspv-use-legacy-buffer-matrix-order"
+
+// Without the flag, -fspv-use-legacy-buffer-matrix-order must not appear in
+// cc1 args.
+// RUN: %clang_dxc -spirv -Tlib_6_7 -### %s 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=CHECK-NO-LEGACY
+// CHECK-NO-LEGACY-NOT: "-fspv-use-legacy-buffer-matrix-order"
+
+// The flag requires -spirv.
+// RUN: not %clang_dxc -Tlib_6_7 -fspv-use-legacy-buffer-matrix-order -### %s 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=CHECK-NO-SPIRV
+// CHECK-NO-SPIRV: error: invalid argument '-fspv-use-legacy-buffer-matrix-order' only allowed with '-spirv'
+


### PR DESCRIPTION
fixes https://github.com/llvm/llvm-project/issues/136941

This flag, mirroring DXC, opts into assuming row-major buffer bytes instead, for compatibility with legacy shaders.

Outside of the driver change the raw buffers carry no layout metadata, so matrix values loaded/stored via ByteAddressBuffer::Load<T>/Store<T> are ambiguous (native layout is column-major).

- New __builtin_hlsl_resource_load_typed/store_typed builtins for the templated ByteAddressBuffer Load<T>/Store<T> overloads
- CodeGen transposes matrix values via llvm.matrix.transpose when the flag is set and the target is SPIR-V
- Plumb flag from driver -> cc1 -> new LangOpts bit

Assisted by Claude Sonnet 5 via CoPilot