### PR TITLE
[lldb] Add accelerator dynamic loader over gdb-remote

### DIFF
--- a/lldb/docs/resources/lldbgdbremote.md
+++ b/lldb/docs/resources/lldbgdbremote.md
@@ -2862,3 +2862,37 @@ STUB REPLIES:  {"disable_bp":true,"auto_resume_native":false,"actions":{"plugin_
 
 **Priority To Implement:** Required for hardware accelerator debugging
 support. Not needed for non-hardware-accelerator debugging.
+
+### jAcceleratorPluginGetDynamicLoaderLibraryInfo
+
+Requests shared library information from an accelerator plugin. The client
+sends this packet when it needs to load or update the accelerator's shared
+library list. This packet requires the `accelerator-plugins+` feature from
+`qSupported`.
+
+```
+LLDB SENDS:    jAcceleratorPluginGetDynamicLoaderLibraryInfo:<json>
+STUB REPLIES:  <json_response>
+```
+
+The request JSON has the following fields:
+
+| Key           | Type   | Description |
+|---------------|--------|-------------|
+| `plugin_name` | string | Name of the accelerator plugin to query. |
+| `full`        | bool   | If true, return all libraries. If false, return only updates since the last query. |
+
+The response JSON has the following fields:
+
+| Key             | Type  | Description |
+|-----------------|-------|-------------|
+| `library_infos` | array | Array of library info objects, each with `pathname`, `load` (bool), and optional `load_address`, `loaded_sections`, `uuid`, `native_memory_address`, `native_memory_size`, `file_offset`, `file_size`. |
+
+Example:
+```
+LLDB SENDS:    jAcceleratorPluginGetDynamicLoaderLibraryInfo:{"plugin_name":"mock","full":true}
+STUB REPLIES:  {"library_infos":[{"pathname":"/usr/lib/libmock_accel.so","load":true,"load_address":2130706432,"loaded_sections":[]}]}
+```
+
+**Priority To Implement:** Required for hardware accelerator debugging
+support. Not needed for non-hardware-accelerator debugging.

--- a/lldb/include/lldb/Core/Module.h
+++ b/lldb/include/lldb/Core/Module.h
@@ -530,6 +530,8 @@ public:
 
   uint64_t GetObjectOffset() const { return m_object_offset; }
 
+  uint64_t GetObjectSize() const { return m_object_size; }
+
   /// Get the object file representation for the current architecture.
   ///
   /// If the object file has not been located or parsed yet, this function
@@ -1076,6 +1078,7 @@ protected:
       m_memory_module_addr; ///< For a Module read from memory,
                             ///  the address it was read from.
   uint64_t m_object_offset = 0;
+  uint64_t m_object_size = 0;
   llvm::sys::TimePoint<> m_object_mod_time;
 
   /// DataExtractor containing the module image, if it was provided at

--- a/lldb/include/lldb/Core/ModuleSpec.h
+++ b/lldb/include/lldb/Core/ModuleSpec.h
@@ -118,6 +118,35 @@ public:
 
   void SetObjectSize(uint64_t object_size) { m_object_size = object_size; }
 
+  /// True if this spec describes a sub-range of its file. The size alone does
+  /// not say: it defaults to the whole file.
+  bool HasObjectFileBounds() const {
+    if (m_object_offset != 0)
+      return true;
+    if (m_object_size == 0)
+      return false;
+    if (m_extractor_sp)
+      return m_object_size != m_extractor_sp->GetByteSize();
+    if (!m_file)
+      return false;
+    const uint64_t file_size = FileSystem::Instance().GetByteSize(m_file);
+    return file_size != 0 && m_object_size != file_size;
+  }
+
+  /// Whether an object at \a candidate_offset of \a candidate_size satisfies
+  /// the bounds this spec asks for. A spec that asks for no particular bounds
+  /// constrains nothing and accepts any candidate.
+  bool MatchesObjectFileSlice(uint64_t candidate_offset,
+                              uint64_t candidate_size) const {
+    if (!HasObjectFileBounds())
+      return true;
+    if (GetObjectOffset() != candidate_offset)
+      return false;
+    if (GetObjectSize() != 0 && GetObjectSize() != candidate_size)
+      return false;
+    return true;
+  }
+
   /// Get the load address of a module in process memory. If the optional
   /// has no value, there is no load address for this module spec.
   std::optional<lldb::addr_t> GetLoadAddress() const { return m_load_addr; }
@@ -277,6 +306,9 @@ public:
         match_module_spec.GetObjectName() != GetObjectName())
       return false;
     if (!FileSpec::Match(match_module_spec.GetFileSpec(), GetFileSpec()))
+      return false;
+    if (!match_module_spec.MatchesObjectFileSlice(GetObjectOffset(),
+                                                  GetObjectSize()))
       return false;
     if (GetPlatformFileSpec() &&
         !FileSpec::Match(match_module_spec.GetPlatformFileSpec(),

--- a/lldb/include/lldb/Host/common/NativeProcessProtocol.h
+++ b/lldb/include/lldb/Host/common/NativeProcessProtocol.h
@@ -14,6 +14,7 @@
 #include "NativeWatchpointList.h"
 #include "lldb/Host/Host.h"
 #include "lldb/Host/MainLoop.h"
+#include "lldb/Utility/AcceleratorGDBRemotePackets.h"
 #include "lldb/Utility/ArchSpec.h"
 #include "lldb/Utility/Iterable.h"
 #include "lldb/Utility/Status.h"
@@ -160,6 +161,14 @@ public:
   virtual llvm::Expected<std::vector<LoadedLibraryInfo>> GetLoadedLibraries() {
     return llvm::createStringError(llvm::inconvertibleErrorCode(),
                                    "Not implemented");
+  }
+
+  /// Answers "jAcceleratorPluginGetDynamicLoaderLibraryInfo" on an accelerator
+  /// connection. std::nullopt if this process does not provide libraries.
+  virtual std::optional<AcceleratorDynamicLoaderResponse>
+  GetAcceleratorDynamicLoaderLibraryInfos(
+      const AcceleratorDynamicLoaderArgs &args) {
+    return std::nullopt;
   }
 
   virtual bool HasPendingLibraryEvents() { return false; }

--- a/lldb/include/lldb/Utility/AcceleratorGDBRemotePackets.h
+++ b/lldb/include/lldb/Utility/AcceleratorGDBRemotePackets.h
@@ -166,6 +166,60 @@ bool fromJSON(const llvm::json::Value &value,
               AcceleratorBreakpointHitResponse &data, llvm::json::Path path);
 llvm::json::Value toJSON(const AcceleratorBreakpointHitResponse &data);
 
+struct AcceleratorSectionInfo {
+  /// Each name is looked up as a child of the previous one, e.g.
+  /// ["PT_LOAD[0]", ".text"].
+  std::vector<std::string> names;
+  uint64_t load_address = 0;
+};
+
+bool fromJSON(const llvm::json::Value &value, AcceleratorSectionInfo &data,
+              llvm::json::Path path);
+llvm::json::Value toJSON(const AcceleratorSectionInfo &data);
+
+struct AcceleratorDynamicLoaderLibraryInfo {
+  std::string pathname;
+  std::optional<std::string> uuid_str;
+  /// False means unload.
+  bool load = true;
+  /// Slides the whole object file. If unset, use \a loaded_sections or the
+  /// file addresses.
+  std::optional<uint64_t> load_address;
+  /// Used when sections load at independent addresses.
+  std::vector<AcceleratorSectionInfo> loaded_sections;
+  /// Where the image can be read in the native process.
+  std::optional<uint64_t> native_memory_address;
+  std::optional<uint64_t> native_memory_size;
+  /// Slice of \a pathname holding the object file, when embedded in a
+  /// container.
+  std::optional<uint64_t> file_offset;
+  std::optional<uint64_t> file_size;
+};
+
+bool fromJSON(const llvm::json::Value &value,
+              AcceleratorDynamicLoaderLibraryInfo &data, llvm::json::Path path);
+llvm::json::Value toJSON(const AcceleratorDynamicLoaderLibraryInfo &data);
+
+/// Arguments for the jAcceleratorPluginGetDynamicLoaderLibraryInfo packet.
+struct AcceleratorDynamicLoaderArgs {
+  std::string plugin_name;
+  /// If false, return only updates since the last query.
+  bool full = true;
+};
+
+bool fromJSON(const llvm::json::Value &value,
+              AcceleratorDynamicLoaderArgs &data, llvm::json::Path path);
+llvm::json::Value toJSON(const AcceleratorDynamicLoaderArgs &data);
+
+/// Response from the jAcceleratorPluginGetDynamicLoaderLibraryInfo packet.
+struct AcceleratorDynamicLoaderResponse {
+  std::vector<AcceleratorDynamicLoaderLibraryInfo> library_infos;
+};
+
+bool fromJSON(const llvm::json::Value &value,
+              AcceleratorDynamicLoaderResponse &data, llvm::json::Path path);
+llvm::json::Value toJSON(const AcceleratorDynamicLoaderResponse &data);
+
 } // namespace lldb_private
 
 #endif // LLDB_UTILITY_ACCELERATORGDBREMOTEPACKETS_H

--- a/lldb/include/lldb/Utility/StringExtractorGDBRemote.h
+++ b/lldb/include/lldb/Utility/StringExtractorGDBRemote.h
@@ -176,6 +176,7 @@ public:
     eServerPacketType_jMultiBreakpoint,
     eServerPacketType_jAcceleratorPluginInitialize,
     eServerPacketType_jAcceleratorPluginBreakpointHit,
+    eServerPacketType_jAcceleratorPluginGetDynamicLoaderLibraryInfo,
 
     eServerPacketType_qMemTags, // read memory tags
     eServerPacketType_QMemTags, // write memory tags

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -153,9 +153,19 @@ Module::Module(const ModuleSpec &module_spec)
     file_size = extractor_sp->GetByteSize();
 
   // First extract all module specifications from the file using the local file
-  // path. If there are no specifications, then don't fill anything in
+  // path. If there are no specifications, then don't fill anything in.
+  //
+  // A spec with bounds describes an object embedded in a larger file, so
+  // enumerate from there. A named object is an archive member: its offset
+  // points into the archive, which only parses from the start, so those still
+  // enumerate the whole file and are picked out by name below.
+  const bool use_explicit_bounds =
+      module_spec.HasObjectFileBounds() && !module_spec.GetObjectName();
   ModuleSpecList modules_specs = ObjectFile::GetModuleSpecifications(
-      module_spec.GetFileSpec(), 0, file_size, extractor_sp);
+      module_spec.GetFileSpec(),
+      use_explicit_bounds ? module_spec.GetObjectOffset() : 0,
+      use_explicit_bounds ? module_spec.GetObjectSize() : file_size,
+      extractor_sp);
   if (modules_specs.GetSize() == 0)
     return;
 
@@ -225,6 +235,7 @@ Module::Module(const ModuleSpec &module_spec)
   // (for mod time in a BSD static archive) of from the matching module
   // specification
   m_object_offset = matching_module_spec.GetObjectOffset();
+  m_object_size = matching_module_spec.GetObjectSize();
   m_object_mod_time = matching_module_spec.GetObjectModificationTime();
 }
 
@@ -1470,6 +1481,9 @@ bool Module::MatchesModuleSpec(const ModuleSpec &module_ref) {
 
   const FileSpec &platform_file_spec = module_ref.GetPlatformFileSpec();
   if (!FileSpec::Match(platform_file_spec, GetPlatformFileSpec()))
+    return false;
+
+  if (!module_ref.MatchesObjectFileSlice(m_object_offset, m_object_size))
     return false;
 
   const ArchSpec &arch = module_ref.GetArchitecture();

--- a/lldb/source/Plugins/DynamicLoader/AcceleratorGDBRemote/CMakeLists.txt
+++ b/lldb/source/Plugins/DynamicLoader/AcceleratorGDBRemote/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_lldb_library(lldbPluginDynamicLoaderAcceleratorGDBRemote PLUGIN
+  DynamicLoaderAcceleratorGDBRemote.cpp
+
+  LINK_LIBS
+    lldbCore
+    lldbHost
+    lldbSymbol
+    lldbTarget
+    lldbUtility
+    lldbPluginProcessGDBRemote
+  LINK_COMPONENTS
+    Support
+  )

--- a/lldb/source/Plugins/DynamicLoader/AcceleratorGDBRemote/DynamicLoaderAcceleratorGDBRemote.cpp
+++ b/lldb/source/Plugins/DynamicLoader/AcceleratorGDBRemote/DynamicLoaderAcceleratorGDBRemote.cpp
@@ -1,0 +1,156 @@
+//===-- DynamicLoaderAcceleratorGDBRemote.cpp ----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "DynamicLoaderAcceleratorGDBRemote.h"
+#include "Plugins/Process/gdb-remote/ProcessGDBRemote.h"
+#include "lldb/Core/Module.h"
+#include "lldb/Core/PluginManager.h"
+#include "lldb/Core/Section.h"
+#include "lldb/Target/Target.h"
+#include "lldb/Utility/LLDBLog.h"
+#include "lldb/Utility/Log.h"
+
+using namespace lldb;
+using namespace lldb_private;
+using namespace lldb_private::process_gdb_remote;
+
+LLDB_PLUGIN_DEFINE(DynamicLoaderAcceleratorGDBRemote)
+
+DynamicLoader *
+DynamicLoaderAcceleratorGDBRemote::CreateInstance(Process *process,
+                                                  bool force) {
+  // The library list comes from the accelerator's GDB server.
+  if (process->GetPluginName() != ProcessGDBRemote::GetPluginNameStatic())
+    return nullptr;
+  if (force)
+    return new DynamicLoaderAcceleratorGDBRemote(process);
+
+  const llvm::Triple &triple =
+      process->GetTarget().GetArchitecture().GetTriple();
+  if (triple.isAMDGPU() || triple.isNVPTX())
+    return new DynamicLoaderAcceleratorGDBRemote(process);
+  return nullptr;
+}
+
+DynamicLoaderAcceleratorGDBRemote::DynamicLoaderAcceleratorGDBRemote(
+    Process *process)
+    : DynamicLoader(process) {}
+
+void DynamicLoaderAcceleratorGDBRemote::DidAttach() {
+  LoadModulesFromGDBServer(/*full=*/true);
+}
+
+void DynamicLoaderAcceleratorGDBRemote::DidLaunch() {
+  LoadModulesFromGDBServer(/*full=*/true);
+}
+
+bool DynamicLoaderAcceleratorGDBRemote::LoadModulesFromGDBServer(bool full) {
+  Log *log = GetLog(LLDBLog::DynamicLoader);
+
+  // Safe: CreateInstance only builds this loader for a ProcessGDBRemote.
+  ProcessGDBRemote *gdb_process = static_cast<ProcessGDBRemote *>(m_process);
+  AcceleratorDynamicLoaderArgs args;
+  args.full = full;
+
+  Target &target = m_process->GetTarget();
+  ModuleList loaded_module_list;
+  std::optional<AcceleratorDynamicLoaderResponse> response =
+      gdb_process->GetGDBRemote().GetAcceleratorDynamicLoaderLibraryInfos(args);
+  if (!response) {
+    LLDB_LOG(log, "failed to get dynamic loader info from the GDB server");
+    return false;
+  }
+
+  for (const AcceleratorDynamicLoaderLibraryInfo &info :
+       response->library_infos) {
+    UUID uuid;
+    if (info.uuid_str)
+      uuid.SetFromStringRef(*info.uuid_str);
+
+    // Either a whole file, or a slice of a containing file.
+    ModuleSpec module_spec(FileSpec(info.pathname), uuid);
+    if (info.file_offset)
+      module_spec.SetObjectOffset(*info.file_offset);
+    if (info.file_size)
+      module_spec.SetObjectSize(*info.file_size);
+
+    if (!info.load) {
+      ModuleList matching_module_list;
+      target.GetImages().FindModules(module_spec, matching_module_list);
+      matching_module_list.ForEach(
+          [this](const ModuleSP &module_sp) -> IterationAction {
+            UnloadSections(module_sp);
+            return IterationAction::Continue;
+          });
+      continue;
+    }
+
+    ModuleSP module_sp = target.GetOrCreateModule(module_spec, /*notify=*/true);
+    if (!module_sp)
+      continue;
+
+    bool changed = false;
+    if (info.load_address) {
+      module_sp->SetLoadAddress(target, *info.load_address,
+                                /*value_is_offset=*/true, changed);
+    } else if (!info.loaded_sections.empty()) {
+      for (const AcceleratorSectionInfo &sect : info.loaded_sections) {
+        if (sect.names.empty())
+          continue;
+        SectionSP section_sp;
+        for (const std::string &name : sect.names) {
+          ConstString section_name(name);
+          if (section_sp)
+            section_sp =
+                section_sp->GetChildren().FindSectionByName(section_name);
+          else
+            section_sp =
+                module_sp->GetSectionList()->FindSectionByName(section_name);
+          if (!section_sp)
+            break;
+        }
+        if (section_sp)
+          changed |= target.SetSectionLoadAddress(section_sp, sect.load_address,
+                                                  /*warn_multiple=*/true);
+      }
+    } else {
+      // No slide: load at the file addresses.
+      module_sp->SetLoadAddress(target, 0, /*value_is_offset=*/true, changed);
+    }
+
+    if (changed)
+      loaded_module_list.AppendIfNeeded(module_sp);
+  }
+
+  target.ModulesDidLoad(loaded_module_list);
+  return true;
+}
+
+ThreadPlanSP DynamicLoaderAcceleratorGDBRemote::GetStepThroughTrampolinePlan(
+    Thread &thread, bool stop_others) {
+  return ThreadPlanSP();
+}
+
+Status DynamicLoaderAcceleratorGDBRemote::CanLoadImage() {
+  return Status::FromErrorString("can't load images on accelerator targets");
+}
+
+void DynamicLoaderAcceleratorGDBRemote::Initialize() {
+  PluginManager::RegisterPlugin(GetPluginNameStatic(),
+                                GetPluginDescriptionStatic(), CreateInstance);
+}
+
+void DynamicLoaderAcceleratorGDBRemote::Terminate() {
+  PluginManager::UnregisterPlugin(CreateInstance);
+}
+
+llvm::StringRef
+DynamicLoaderAcceleratorGDBRemote::GetPluginDescriptionStatic() {
+  return "Dynamic loader plug-in that gets shared library loads/unloads from "
+         "an lldb-server accelerator plugin.";
+}

--- a/lldb/source/Plugins/DynamicLoader/AcceleratorGDBRemote/DynamicLoaderAcceleratorGDBRemote.h
+++ b/lldb/source/Plugins/DynamicLoader/AcceleratorGDBRemote/DynamicLoaderAcceleratorGDBRemote.h
@@ -1,0 +1,46 @@
+//===-- DynamicLoaderAcceleratorGDBRemote.h -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_SOURCE_PLUGINS_DYNAMICLOADER_ACCELERATORGDBREMOTE_DYNAMICLOADERACCELERATORGDBREMOTE_H
+#define LLDB_SOURCE_PLUGINS_DYNAMICLOADER_ACCELERATORGDBREMOTE_DYNAMICLOADERACCELERATORGDBREMOTE_H
+
+#include "lldb/Target/DynamicLoader.h"
+
+/// Dynamic loader for accelerator (e.g. GPU) targets.
+///
+/// Accelerators don't set a rendezvous breakpoint the way SVR4 loaders do;
+/// their runtime tells the lldb-server plugin when libraries load or unload.
+/// This loader asks the server for that list via
+/// "jAcceleratorPluginGetDynamicLoaderLibraryInfo".
+class DynamicLoaderAcceleratorGDBRemote : public lldb_private::DynamicLoader {
+public:
+  DynamicLoaderAcceleratorGDBRemote(lldb_private::Process *process);
+
+  static void Initialize();
+  static void Terminate();
+  static llvm::StringRef GetPluginNameStatic() {
+    return "accelerator-gdb-remote";
+  }
+  static llvm::StringRef GetPluginDescriptionStatic();
+  static lldb_private::DynamicLoader *
+  CreateInstance(lldb_private::Process *process, bool force);
+
+  void DidAttach() override;
+  void DidLaunch() override;
+  lldb::ThreadPlanSP GetStepThroughTrampolinePlan(lldb_private::Thread &thread,
+                                                  bool stop_others) override;
+  lldb_private::Status CanLoadImage() override;
+
+  llvm::StringRef GetPluginName() override { return GetPluginNameStatic(); }
+
+private:
+  /// Returns true if the server answered the packet.
+  bool LoadModulesFromGDBServer(bool full);
+};
+
+#endif // LLDB_SOURCE_PLUGINS_DYNAMICLOADER_ACCELERATORGDBREMOTE_DYNAMICLOADERACCELERATORGDBREMOTE_H

--- a/lldb/source/Plugins/DynamicLoader/CMakeLists.txt
+++ b/lldb/source/Plugins/DynamicLoader/CMakeLists.txt
@@ -5,6 +5,7 @@ set_property(DIRECTORY PROPERTY LLDB_TOLERATED_PLUGIN_DEPENDENCIES
   TypeSystem
 )
 
+add_subdirectory(AcceleratorGDBRemote)
 add_subdirectory(Darwin-Kernel)
 add_subdirectory(FreeBSD-Kernel)
 add_subdirectory(MacOSX-DYLD)

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
@@ -300,6 +300,29 @@ GDBRemoteCommunicationClient::AcceleratorBreakpointHit(
       response.GetStringRef(), llvm::toString(hit_response.takeError()));
 }
 
+std::optional<AcceleratorDynamicLoaderResponse>
+GDBRemoteCommunicationClient::GetAcceleratorDynamicLoaderLibraryInfos(
+    const AcceleratorDynamicLoaderArgs &args) {
+  StreamGDBRemote packet;
+  packet.PutCString("jAcceleratorPluginGetDynamicLoaderLibraryInfo:");
+  packet.PutAsJSON(args, /*hex_ascii=*/false);
+
+  StringExtractorGDBRemote response;
+  if (SendPacketAndWaitForResponse(packet.GetString(), response) !=
+          PacketResult::Success ||
+      response.IsErrorResponse())
+    return std::nullopt;
+
+  llvm::Expected<AcceleratorDynamicLoaderResponse> parsed =
+      llvm::json::parse<AcceleratorDynamicLoaderResponse>(
+          response.Peek(), "AcceleratorDynamicLoaderResponse");
+  if (!parsed) {
+    llvm::consumeError(parsed.takeError());
+    return std::nullopt;
+  }
+  return *parsed;
+}
+
 bool GDBRemoteCommunicationClient::QueryNoAckModeSupported() {
   if (m_supports_not_sending_acks == eLazyBoolCalculate) {
     m_send_acks = true;

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.h
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.h
@@ -377,6 +377,11 @@ public:
   llvm::Expected<AcceleratorBreakpointHitResponse>
   AcceleratorBreakpointHit(const AcceleratorBreakpointHitArgs &args);
 
+  /// Returns std::nullopt if the packet failed or the response did not parse.
+  std::optional<AcceleratorDynamicLoaderResponse>
+  GetAcceleratorDynamicLoaderLibraryInfos(
+      const AcceleratorDynamicLoaderArgs &args);
+
   LazyBool SupportsAllocDeallocMemory() // const
   {
     // Uncomment this to have lldb pretend the debug server doesn't respond to

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
@@ -233,6 +233,11 @@ void GDBRemoteCommunicationServerLLGS::RegisterPacketHandlers() {
           eServerPacketType_jAcceleratorPluginBreakpointHit,
       &GDBRemoteCommunicationServerLLGS::
           Handle_jAcceleratorPluginBreakpointHit);
+  RegisterMemberFunctionHandler(
+      StringExtractorGDBRemote::
+          eServerPacketType_jAcceleratorPluginGetDynamicLoaderLibraryInfo,
+      &GDBRemoteCommunicationServerLLGS::
+          Handle_jAcceleratorPluginGetDynamicLoaderLibraryInfo);
 
   RegisterMemberFunctionHandler(StringExtractorGDBRemote::eServerPacketType_g,
                                 &GDBRemoteCommunicationServerLLGS::Handle_g);
@@ -4638,6 +4643,34 @@ GDBRemoteCommunicationServerLLGS::Handle_jAcceleratorPluginBreakpointHit(
       StreamGDBRemote response;
       response.PutAsJSON(*bp_response, /*hex_ascii=*/false);
       return SendPacketNoLock(response.GetString());
+    }
+  }
+  return SendErrorResponse(
+      Status::FromErrorString("unknown accelerator plugin name"));
+}
+
+GDBRemoteCommunication::PacketResult GDBRemoteCommunicationServerLLGS::
+    Handle_jAcceleratorPluginGetDynamicLoaderLibraryInfo(
+        StringExtractorGDBRemote &packet) {
+  packet.ConsumeFront("jAcceleratorPluginGetDynamicLoaderLibraryInfo:");
+  llvm::Expected<AcceleratorDynamicLoaderArgs> args =
+      llvm::json::parse<AcceleratorDynamicLoaderArgs>(
+          packet.Peek(), "AcceleratorDynamicLoaderArgs");
+  if (!args)
+    return SendErrorResponse(args.takeError());
+
+  for (std::unique_ptr<lldb_server::LLDBServerAcceleratorPlugin> &plugin_up :
+       m_accelerator_plugins) {
+    if (plugin_up->GetPluginName() == args->plugin_name) {
+      std::optional<AcceleratorDynamicLoaderResponse> response =
+          plugin_up->GetDynamicLoaderLibraryInfos(*args);
+      if (response) {
+        StreamGDBRemote stream;
+        stream.PutAsJSON(*response, /*hex_ascii=*/false);
+        return SendPacketNoLock(stream.GetString());
+      }
+      return SendErrorResponse(
+          Status::FromErrorString("no dynamic loader info available"));
     }
   }
   return SendErrorResponse(

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
@@ -4659,20 +4659,35 @@ GDBRemoteCommunication::PacketResult GDBRemoteCommunicationServerLLGS::
   if (!args)
     return SendErrorResponse(args.takeError());
 
-  for (std::unique_ptr<lldb_server::LLDBServerAcceleratorPlugin> &plugin_up :
-       m_accelerator_plugins) {
-    if (plugin_up->GetPluginName() == args->plugin_name) {
-      std::optional<AcceleratorDynamicLoaderResponse> response =
-          plugin_up->GetDynamicLoaderLibraryInfos(*args);
-      if (response) {
-        StreamGDBRemote stream;
-        stream.PutAsJSON(*response, /*hex_ascii=*/false);
-        return SendPacketNoLock(stream.GetString());
+  // On the native connection, forward to the named accelerator plugin.
+  if (!m_accelerator_plugins.empty()) {
+    for (std::unique_ptr<lldb_server::LLDBServerAcceleratorPlugin> &plugin_up :
+         m_accelerator_plugins) {
+      if (plugin_up->GetPluginName() == args->plugin_name) {
+        std::optional<AcceleratorDynamicLoaderResponse> response =
+            plugin_up->GetDynamicLoaderLibraryInfos(*args);
+        if (response) {
+          StreamGDBRemote stream;
+          stream.PutAsJSON(*response, /*hex_ascii=*/false);
+          return SendPacketNoLock(stream.GetString());
+        }
+        return SendErrorResponse(
+            Status::FromErrorString("no dynamic loader info available"));
       }
-      return SendErrorResponse(
-          Status::FromErrorString("no dynamic loader info available"));
     }
+    return SendErrorResponse(
+        Status::FromErrorString("unknown accelerator plugin name"));
   }
-  return SendErrorResponse(
-      Status::FromErrorString("unknown accelerator plugin name"));
+
+  // On the accelerator connection, ask the process directly.
+  if (!m_current_process)
+    return SendErrorResponse(Status::FromErrorString("no current process"));
+  std::optional<AcceleratorDynamicLoaderResponse> response =
+      m_current_process->GetAcceleratorDynamicLoaderLibraryInfos(*args);
+  if (!response)
+    return SendErrorResponse(
+        Status::FromErrorString("dynamic loader library info not supported"));
+  StreamGDBRemote stream;
+  stream.PutAsJSON(*response, /*hex_ascii=*/false);
+  return SendPacketNoLock(stream.GetString());
 }

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.h
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.h
@@ -302,6 +302,9 @@ protected:
   PacketResult
   Handle_jAcceleratorPluginBreakpointHit(StringExtractorGDBRemote &packet);
 
+  PacketResult Handle_jAcceleratorPluginGetDynamicLoaderLibraryInfo(
+      StringExtractorGDBRemote &packet);
+
   void SetCurrentThreadID(lldb::tid_t tid);
 
   lldb::tid_t GetCurrentThreadID() const;

--- a/lldb/source/Plugins/Process/gdb-remote/LLDBServerAcceleratorPlugin.h
+++ b/lldb/source/Plugins/Process/gdb-remote/LLDBServerAcceleratorPlugin.h
@@ -47,6 +47,11 @@ public:
                               ++m_accelerator_action_identifier);
   }
 
+  virtual std::optional<AcceleratorDynamicLoaderResponse>
+  GetDynamicLoaderLibraryInfos(const AcceleratorDynamicLoaderArgs &args) {
+    return std::nullopt;
+  }
+
 protected:
   GDBServer &m_native_gdb_server;
   MainLoop &m_native_main_loop;

--- a/lldb/source/Utility/AcceleratorGDBRemotePackets.cpp
+++ b/lldb/source/Utility/AcceleratorGDBRemotePackets.cpp
@@ -142,4 +142,63 @@ json::Value toJSON(const AcceleratorBreakpointHitResponse &data) {
   return obj;
 }
 
+bool fromJSON(const Value &value, AcceleratorSectionInfo &data, Path path) {
+  ObjectMapper o(value, path);
+  return o && o.map("names", data.names) &&
+         o.map("load_address", data.load_address);
+}
+
+json::Value toJSON(const AcceleratorSectionInfo &data) {
+  return Object{{"names", data.names},
+                {"load_address", static_cast<int64_t>(data.load_address)}};
+}
+
+bool fromJSON(const Value &value, AcceleratorDynamicLoaderLibraryInfo &data,
+              Path path) {
+  ObjectMapper o(value, path);
+  return o && o.map("pathname", data.pathname) &&
+         o.mapOptional("uuid", data.uuid_str) && o.map("load", data.load) &&
+         o.mapOptional("load_address", data.load_address) &&
+         o.mapOptional("loaded_sections", data.loaded_sections) &&
+         o.mapOptional("native_memory_address", data.native_memory_address) &&
+         o.mapOptional("native_memory_size", data.native_memory_size) &&
+         o.mapOptional("file_offset", data.file_offset) &&
+         o.mapOptional("file_size", data.file_size);
+}
+
+json::Value toJSON(const AcceleratorDynamicLoaderLibraryInfo &data) {
+  return Object{
+      {"pathname", data.pathname},
+      {"uuid", data.uuid_str},
+      {"load", data.load},
+      {"load_address", data.load_address},
+      {"loaded_sections", data.loaded_sections},
+      {"native_memory_address", data.native_memory_address},
+      {"native_memory_size", data.native_memory_size},
+      {"file_offset", data.file_offset},
+      {"file_size", data.file_size},
+  };
+}
+
+bool fromJSON(const Value &value, AcceleratorDynamicLoaderArgs &data,
+              Path path) {
+  ObjectMapper o(value, path);
+  return o && o.map("plugin_name", data.plugin_name) &&
+         o.map("full", data.full);
+}
+
+json::Value toJSON(const AcceleratorDynamicLoaderArgs &data) {
+  return Object{{"plugin_name", data.plugin_name}, {"full", data.full}};
+}
+
+bool fromJSON(const Value &value, AcceleratorDynamicLoaderResponse &data,
+              Path path) {
+  ObjectMapper o(value, path);
+  return o && o.map("library_infos", data.library_infos);
+}
+
+json::Value toJSON(const AcceleratorDynamicLoaderResponse &data) {
+  return Object{{"library_infos", data.library_infos}};
+}
+
 } // namespace lldb_private

--- a/lldb/source/Utility/StringExtractorGDBRemote.cpp
+++ b/lldb/source/Utility/StringExtractorGDBRemote.cpp
@@ -338,6 +338,8 @@ StringExtractorGDBRemote::GetServerPacketType() const {
       return eServerPacketType_jAcceleratorPluginInitialize;
     if (PACKET_STARTS_WITH("jAcceleratorPluginBreakpointHit:"))
       return eServerPacketType_jAcceleratorPluginBreakpointHit;
+    if (PACKET_STARTS_WITH("jAcceleratorPluginGetDynamicLoaderLibraryInfo:"))
+      return eServerPacketType_jAcceleratorPluginGetDynamicLoaderLibraryInfo;
     break;
 
   case 'v':

--- a/lldb/test/API/accelerator/dynamic_loader/TestAcceleratorDynamicLoader.py
+++ b/lldb/test/API/accelerator/dynamic_loader/TestAcceleratorDynamicLoader.py
@@ -1,0 +1,153 @@
+"""
+Test the accelerator dynamic loader against a mock GDB server.
+
+The loader is selected for accelerator architectures debugged over gdb-remote.
+It then asks the server for the loaded libraries via
+jAcceleratorPluginGetDynamicLoaderLibraryInfo and loads them into the target.
+"""
+
+import json
+import os
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.gdbclientutils import *
+from lldbsuite.test.lldbgdbclient import GDBRemoteTestBase
+
+DYLD_PACKET = "jAcceleratorPluginGetDynamicLoaderLibraryInfo:"
+
+
+class AcceleratorResponder(MockGDBServerResponder):
+    """Serves a fixed set of library infos, and counts how often it is asked."""
+
+    def __init__(self, library_infos):
+        MockGDBServerResponder.__init__(self)
+        self.library_infos = library_infos
+        self.dyld_queries = 0
+
+    def qSupported(self, client_supported):
+        return super().qSupported(client_supported) + ";qXfer:features:read+"
+
+    def qXferRead(self, obj, annex, offset, length):
+        # An accelerator architecture has no built-in register set in lldb.
+        if obj == "features" and annex == "target.xml":
+            return (
+                """<?xml version="1.0"?>
+                <target version="1.0">
+                  <feature name="org.llvm.accelerator">
+                    <reg name="pc" bitsize="64" regnum="0" type="code_ptr" group="general"/>
+                  </feature>
+                </target>""",
+                False,
+            )
+        return None, False
+
+    def readRegisters(self):
+        return "00" * 8
+
+    def other(self, packet):
+        if packet.startswith(DYLD_PACKET):
+            self.dyld_queries += 1
+            # "}" is the gdb-remote escape character.
+            return escape_binary(
+                json.dumps({"library_infos": self.library_infos}, separators=(",", ":"))
+            )
+        return ""
+
+
+class TestAcceleratorDynamicLoader(GDBRemoteTestBase):
+    def make_library(self):
+        """Build the library object file the server will report."""
+        path = self.getBuildArtifact("accelerator_lib.so")
+        self.yaml2obj("accelerator_lib.yaml", path)
+        return path
+
+    def make_container(self, outer_path):
+        """Embed a library in a larger file, as llvm-objcopy would when adding
+        it to a container. Returns the container path and the (offset, size) of
+        the embedded object.
+
+        The embedded object puts .text at a different address than the outer
+        one, so the assertions fail if the slice is ignored and the container is
+        parsed from offset 0."""
+        embedded_path = self.getBuildArtifact("embedded_lib.so")
+        self.yaml2obj("embedded_lib.yaml", embedded_path)
+        with open(outer_path, "rb") as f:
+            outer_bytes = f.read()
+        with open(embedded_path, "rb") as f:
+            embedded_bytes = f.read()
+        # The container must itself be a valid object file.
+        prefix = outer_bytes + b"\x00" * ((-len(outer_bytes)) % 0x1000)
+        container_path = self.getBuildArtifact("container.bin")
+        with open(container_path, "wb") as f:
+            f.write(prefix)
+            f.write(embedded_bytes)
+        return container_path, len(prefix), len(embedded_bytes)
+
+    def find_module(self, target, path):
+        basename = os.path.basename(path)
+        for i in range(target.GetNumModules()):
+            module = target.GetModuleAtIndex(i)
+            if module.GetFileSpec().GetFilename() == basename:
+                return module
+        return None
+
+    def connect_accelerator(self, library_infos):
+        self.server.responder = AcceleratorResponder(library_infos)
+        target = self.createTarget("accelerator.yaml")
+        process = self.connect(target)
+        self.assertTrue(process.IsValid(), "Process is valid")
+        return target
+
+    def assert_text_loaded_at(self, target, module, expected):
+        section = module.FindSection(".text")
+        self.assertTrue(section.IsValid(), "library should have a .text section")
+        self.assertEqual(section.GetLoadAddress(target), expected)
+
+    def test_whole_file_library(self):
+        """A library given as a whole file is loaded at the reported address."""
+        lib = self.make_library()
+        target = self.connect_accelerator(
+            [{"pathname": lib, "load": True, "load_address": 0x10000000}]
+        )
+
+        module = self.find_module(target, lib)
+        self.assertIsNotNone(module, "library should be loaded into the target")
+        # load_address slides the file, so .text (file address 0x1000) lands
+        # 0x1000 past the base.
+        self.assert_text_loaded_at(target, module, 0x10001000)
+
+    def test_library_in_container(self):
+        """A library embedded in a container file is located by offset/size."""
+        lib = self.make_library()
+        container, offset, size = self.make_container(lib)
+        target = self.connect_accelerator(
+            [
+                {
+                    "pathname": container,
+                    "load": True,
+                    "load_address": 0x20000000,
+                    "file_offset": offset,
+                    "file_size": size,
+                }
+            ]
+        )
+
+        module = self.find_module(target, container)
+        self.assertIsNotNone(module, "embedded library should be loaded")
+        # The embedded object has .text at 0x3000; the outer one has it at
+        # 0x1000, so this only holds if the slice was used.
+        self.assert_text_loaded_at(target, module, 0x20003000)
+
+    def test_not_selected_for_host_target(self):
+        """The loader is not used for a non-accelerator architecture."""
+        self.server.responder = AcceleratorResponder([])
+        target = self.createTarget("host.yaml")
+        process = self.connect(target)
+        self.assertTrue(process.IsValid(), "Process is valid")
+
+        self.assertEqual(
+            self.server.responder.dyld_queries,
+            0,
+            "a host target must not query the accelerator dynamic loader",
+        )

--- a/lldb/test/API/accelerator/dynamic_loader/accelerator.yaml
+++ b/lldb/test/API/accelerator/dynamic_loader/accelerator.yaml
@@ -1,0 +1,21 @@
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_EXEC
+  Machine:         EM_AMDGPU
+  OSABI:           ELFOSABI_AMDGPU_HSA
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x1000
+    AddressAlign:    0x1000
+    Content:         "00000000"
+ProgramHeaders:
+  - Type:            PT_LOAD
+    Flags:           [ PF_X, PF_R ]
+    VAddr:           0x1000
+    Align:           0x1000
+    FirstSec:        .text
+    LastSec:         .text

--- a/lldb/test/API/accelerator/dynamic_loader/accelerator_lib.yaml
+++ b/lldb/test/API/accelerator/dynamic_loader/accelerator_lib.yaml
@@ -1,0 +1,21 @@
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_DYN
+  Machine:         EM_AMDGPU
+  OSABI:           ELFOSABI_AMDGPU_HSA
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x1000
+    AddressAlign:    0x1000
+    Content:         "00000000"
+ProgramHeaders:
+  - Type:            PT_LOAD
+    Flags:           [ PF_X, PF_R ]
+    VAddr:           0x1000
+    Align:           0x1000
+    FirstSec:        .text
+    LastSec:         .text

--- a/lldb/test/API/accelerator/dynamic_loader/embedded_lib.yaml
+++ b/lldb/test/API/accelerator/dynamic_loader/embedded_lib.yaml
@@ -1,0 +1,21 @@
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_DYN
+  Machine:         EM_AMDGPU
+  OSABI:           ELFOSABI_AMDGPU_HSA
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x3000
+    AddressAlign:    0x1000
+    Content:         "00000000"
+ProgramHeaders:
+  - Type:            PT_LOAD
+    Flags:           [ PF_X, PF_R ]
+    VAddr:           0x3000
+    Align:           0x1000
+    FirstSec:        .text
+    LastSec:         .text

--- a/lldb/test/API/accelerator/dynamic_loader/host.yaml
+++ b/lldb/test/API/accelerator/dynamic_loader/host.yaml
@@ -1,0 +1,20 @@
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_EXEC
+  Machine:         EM_X86_64
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x1000
+    AddressAlign:    0x1000
+    Content:         "c3"
+ProgramHeaders:
+  - Type:            PT_LOAD
+    Flags:           [ PF_X, PF_R ]
+    VAddr:           0x1000
+    Align:           0x1000
+    FirstSec:        .text
+    LastSec:         .text

--- a/lldb/test/API/accelerator/mock/TestMockAcceleratorPackets.py
+++ b/lldb/test/API/accelerator/mock/TestMockAcceleratorPackets.py
@@ -186,3 +186,28 @@ class MockAcceleratorPacketsTestCase(gdbremote_testcase.GdbRemoteTestCaseBase):
             connect_info["connect_url"],
         )
         self.assertTrue(connect_info["synchronous"])
+
+    @add_test_categories(["llgs"])
+    def test_jAcceleratorPluginGetDynamicLoaderLibraryInfo(self):
+        self.build()
+        self.set_inferior_startup_launch()
+        self.prep_debug_monitor_and_inferior()
+
+        self.add_qSupported_packets()
+        self.expect_gdbremote_sequence()
+
+        dyld_args = {"plugin_name": "mock", "full": True}
+        dyld_json = json.dumps(dyld_args, separators=(",", ":"))
+        escaped_json = escape_binary(dyld_json)
+        response = self.send_and_decode_json(
+            "jAcceleratorPluginGetDynamicLoaderLibraryInfo:" + escaped_json
+        )
+
+        self.assertIn("library_infos", response)
+        libs = response["library_infos"]
+        self.assertGreater(len(libs), 0)
+
+        lib = libs[0]
+        self.assertEqual(lib["pathname"], "/path/to/lib.so")
+        self.assertTrue(lib["load"])
+        self.assertEqual(lib["load_address"], 0x7F000000)

--- a/lldb/test/API/python_api/module_slice/TestModuleSlice.py
+++ b/lldb/test/API/python_api/module_slice/TestModuleSlice.py
@@ -1,0 +1,104 @@
+"""
+Test adding a module that is a slice of a containing file.
+
+A HIP binary carries its device code inside a section of the host executable,
+reported to the debugger as a file path plus a byte offset and size. A
+ModuleSpec with those bounds has to read the embedded object, not the file.
+"""
+
+import binascii
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+
+# A host executable carrying a device code object in a .hip_fatbin section.
+FAT_BINARY_YAML = """\
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_EXEC
+  Machine:         EM_X86_64
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x1000
+    AddressAlign:    0x1000
+    Content:         "c3"
+  - Name:            .hip_fatbin
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC ]
+    AddressAlign:    0x1000
+    Content:         "%s"
+"""
+
+
+class ModuleSliceTestCase(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def make_gpu_code_object(self):
+        path = self.getBuildArtifact("gpu_code_object.so")
+        self.yaml2obj("gpu_code_object.yaml", path)
+        return path
+
+    def make_fat_binary(self, gpu_path):
+        """Embed the device code object the way a HIP binary carries it."""
+        with open(gpu_path, "rb") as f:
+            content = binascii.hexlify(f.read()).decode()
+        yaml_path = self.getBuildArtifact("fat_binary.yaml")
+        with open(yaml_path, "w") as f:
+            f.write(FAT_BINARY_YAML % content)
+        container = self.getBuildArtifact("fat_binary")
+        self.yaml2obj(yaml_path, container)
+        return container
+
+    def fatbin_section_range(self, container):
+        """Locate the embedded code object by the bounds of its section."""
+        target = self.dbg.CreateTarget("")
+        spec = lldb.SBModuleSpec()
+        spec.SetFileSpec(lldb.SBFileSpec(container))
+        module = target.AddModule(spec)
+        self.assertTrue(module.IsValid(), "the host executable should load")
+
+        section = module.FindSection(".hip_fatbin")
+        self.assertTrue(section.IsValid(), "host binary should have .hip_fatbin")
+        offset, size = section.GetFileOffset(), section.GetFileByteSize()
+        self.dbg.DeleteTarget(target)
+        return offset, size
+
+    def text_file_address(self, module):
+        section = module.FindSection(".text")
+        self.assertTrue(section.IsValid(), "module should have a .text section")
+        return section.GetFileAddress()
+
+    def test_code_object_in_fat_binary(self):
+        """The code object inside a .hip_fatbin section is read, not the host."""
+        gpu = self.make_gpu_code_object()
+        container = self.make_fat_binary(gpu)
+        offset, size = self.fatbin_section_range(container)
+
+        target = self.dbg.CreateTarget("")
+        spec = lldb.SBModuleSpec()
+        spec.SetFileSpec(lldb.SBFileSpec(container))
+        spec.SetObjectOffset(offset)
+        spec.SetObjectSize(size)
+
+        module = target.AddModule(spec)
+        self.assertTrue(module.IsValid(), "the code object should load")
+        # The device code object has .text at 0x3000, the host at 0x1000.
+        self.assertEqual(self.text_file_address(module), 0x3000)
+
+    def test_whole_file(self):
+        """Without an object offset the containing file itself is read."""
+        gpu = self.make_gpu_code_object()
+        container = self.make_fat_binary(gpu)
+
+        target = self.dbg.CreateTarget("")
+        spec = lldb.SBModuleSpec()
+        spec.SetFileSpec(lldb.SBFileSpec(container))
+
+        module = target.AddModule(spec)
+        self.assertTrue(module.IsValid(), "the host executable should load")
+        self.assertEqual(self.text_file_address(module), 0x1000)

--- a/lldb/test/API/python_api/module_slice/gpu_code_object.yaml
+++ b/lldb/test/API/python_api/module_slice/gpu_code_object.yaml
@@ -1,0 +1,20 @@
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_DYN
+  Machine:         EM_X86_64
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x3000
+    AddressAlign:    0x1000
+    Content:         "c3"
+ProgramHeaders:
+  - Type:            PT_LOAD
+    Flags:           [ PF_X, PF_R ]
+    VAddr:           0x3000
+    Align:           0x1000
+    FirstSec:        .text
+    LastSec:         .text

--- a/lldb/tools/lldb-server/Plugins/Accelerator/Mock/LLDBServerMockAcceleratorPlugin.cpp
+++ b/lldb/tools/lldb-server/Plugins/Accelerator/Mock/LLDBServerMockAcceleratorPlugin.cpp
@@ -220,3 +220,15 @@ LLDBServerMockAcceleratorPlugin::CreateConnection() {
   info.synchronous = true;
   return info;
 }
+
+std::optional<AcceleratorDynamicLoaderResponse>
+LLDBServerMockAcceleratorPlugin::GetDynamicLoaderLibraryInfos(
+    const AcceleratorDynamicLoaderArgs &args) {
+  AcceleratorDynamicLoaderResponse response;
+  AcceleratorDynamicLoaderLibraryInfo lib;
+  lib.pathname = "/path/to/lib.so";
+  lib.load = true;
+  lib.load_address = 0x7f000000;
+  response.library_infos.push_back(std::move(lib));
+  return response;
+}

--- a/lldb/tools/lldb-server/Plugins/Accelerator/Mock/LLDBServerMockAcceleratorPlugin.h
+++ b/lldb/tools/lldb-server/Plugins/Accelerator/Mock/LLDBServerMockAcceleratorPlugin.h
@@ -34,6 +34,9 @@ public:
   llvm::Expected<AcceleratorBreakpointHitResponse>
   BreakpointWasHit(AcceleratorBreakpointHitArgs &args) override;
 
+  std::optional<AcceleratorDynamicLoaderResponse> GetDynamicLoaderLibraryInfos(
+      const AcceleratorDynamicLoaderArgs &args) override;
+
 private:
   // Lazily bring up the mock accelerator GDB server and return its connection
   // info. Called on the connection breakpoint hit, so inferiors that never

--- a/lldb/tools/lldb-server/Plugins/Accelerator/Mock/ProcessMockAccelerator.cpp
+++ b/lldb/tools/lldb-server/Plugins/Accelerator/Mock/ProcessMockAccelerator.cpp
@@ -110,3 +110,15 @@ ProcessMockAccelerator::GetFileLoadAddress(const llvm::StringRef &file_name,
                                            lldb::addr_t &load_addr) {
   return Status::FromErrorString("unimplemented");
 }
+
+std::optional<AcceleratorDynamicLoaderResponse>
+ProcessMockAccelerator::GetAcceleratorDynamicLoaderLibraryInfos(
+    const AcceleratorDynamicLoaderArgs &args) {
+  AcceleratorDynamicLoaderResponse response;
+  AcceleratorDynamicLoaderLibraryInfo info;
+  info.pathname = "/path/to/lib.so";
+  info.load = true;
+  info.load_address = 0x10000000;
+  response.library_infos.push_back(std::move(info));
+  return response;
+}

--- a/lldb/tools/lldb-server/Plugins/Accelerator/Mock/ProcessMockAccelerator.h
+++ b/lldb/tools/lldb-server/Plugins/Accelerator/Mock/ProcessMockAccelerator.h
@@ -60,6 +60,10 @@ public:
   Status GetFileLoadAddress(const llvm::StringRef &file_name,
                             lldb::addr_t &load_addr) override;
 
+  std::optional<AcceleratorDynamicLoaderResponse>
+  GetAcceleratorDynamicLoaderLibraryInfos(
+      const AcceleratorDynamicLoaderArgs &args) override;
+
 private:
   mutable ArchSpec m_arch;
 };

--- a/lldb/unittests/Utility/AcceleratorGDBRemotePacketsTest.cpp
+++ b/lldb/unittests/Utility/AcceleratorGDBRemotePacketsTest.cpp
@@ -244,3 +244,84 @@ TEST(AcceleratorGDBRemotePacketsTest, AcceleratorActionsWithoutConnectInfo) {
   ASSERT_THAT_EXPECTED(deserialized, Succeeded());
   EXPECT_FALSE(deserialized->connect_info.has_value());
 }
+
+TEST(AcceleratorGDBRemotePacketsTest, AcceleratorSectionInfo) {
+  AcceleratorSectionInfo section;
+  section.names = {"PT_LOAD[0]", ".text"};
+  section.load_address = 0x400000;
+
+  Expected<AcceleratorSectionInfo> deserialized = roundtripJSON(section);
+  ASSERT_THAT_EXPECTED(deserialized, Succeeded());
+  EXPECT_EQ(section.names, deserialized->names);
+  EXPECT_EQ(section.load_address, deserialized->load_address);
+}
+
+TEST(AcceleratorGDBRemotePacketsTest, AcceleratorDynamicLoaderLibraryInfo) {
+  AcceleratorDynamicLoaderLibraryInfo lib;
+  lib.pathname = "/usr/lib/libgpu.so";
+  lib.uuid_str = "AABBCCDD";
+  lib.load = true;
+  lib.load_address = 0x7f000000;
+  lib.native_memory_address = 0x1000;
+  lib.native_memory_size = 0x2000;
+  lib.file_offset = 4096;
+  lib.file_size = 8192;
+
+  AcceleratorSectionInfo section;
+  section.names = {".text"};
+  section.load_address = 0x7f001000;
+  lib.loaded_sections.push_back(std::move(section));
+
+  Expected<AcceleratorDynamicLoaderLibraryInfo> deserialized =
+      roundtripJSON(lib);
+  ASSERT_THAT_EXPECTED(deserialized, Succeeded());
+  EXPECT_EQ(lib.pathname, deserialized->pathname);
+  EXPECT_EQ(lib.uuid_str, deserialized->uuid_str);
+  EXPECT_EQ(lib.load, deserialized->load);
+  EXPECT_EQ(lib.load_address, deserialized->load_address);
+  EXPECT_EQ(lib.native_memory_address, deserialized->native_memory_address);
+  EXPECT_EQ(lib.native_memory_size, deserialized->native_memory_size);
+  EXPECT_EQ(lib.file_offset, deserialized->file_offset);
+  EXPECT_EQ(lib.file_size, deserialized->file_size);
+  ASSERT_EQ(1u, deserialized->loaded_sections.size());
+  EXPECT_EQ(0x7f001000u, deserialized->loaded_sections[0].load_address);
+}
+
+TEST(AcceleratorGDBRemotePacketsTest, AcceleratorDynamicLoaderArgs) {
+  AcceleratorDynamicLoaderArgs args;
+  args.plugin_name = "mock";
+  args.full = true;
+
+  Expected<AcceleratorDynamicLoaderArgs> deserialized = roundtripJSON(args);
+  ASSERT_THAT_EXPECTED(deserialized, Succeeded());
+  EXPECT_EQ(args.plugin_name, deserialized->plugin_name);
+  EXPECT_EQ(args.full, deserialized->full);
+}
+
+TEST(AcceleratorGDBRemotePacketsTest, AcceleratorDynamicLoaderResponse) {
+  AcceleratorDynamicLoaderResponse response;
+  AcceleratorDynamicLoaderLibraryInfo lib;
+  lib.pathname = "/path/to/lib.so";
+  lib.load = true;
+  response.library_infos.push_back(std::move(lib));
+
+  Expected<AcceleratorDynamicLoaderResponse> deserialized =
+      roundtripJSON(response);
+  ASSERT_THAT_EXPECTED(deserialized, Succeeded());
+  ASSERT_EQ(1u, deserialized->library_infos.size());
+  EXPECT_EQ("/path/to/lib.so", deserialized->library_infos[0].pathname);
+  EXPECT_TRUE(deserialized->library_infos[0].load);
+}
+
+TEST(AcceleratorGDBRemotePacketsTest, DynamicLoaderLibraryInfoOptionalFields) {
+  // A server with no per-section addresses can omit "loaded_sections".
+  Expected<AcceleratorDynamicLoaderLibraryInfo> deserialized =
+      json::parse<AcceleratorDynamicLoaderLibraryInfo>(
+          R"({"pathname":"/path/to/lib.so","load":true})",
+          "AcceleratorDynamicLoaderLibraryInfo");
+  ASSERT_THAT_EXPECTED(deserialized, Succeeded());
+  EXPECT_EQ("/path/to/lib.so", deserialized->pathname);
+  EXPECT_TRUE(deserialized->load);
+  EXPECT_TRUE(deserialized->loaded_sections.empty());
+  EXPECT_FALSE(deserialized->load_address.has_value());
+}


### PR DESCRIPTION
This is PR3 in the stack to support dyld for accelerator plugins.

- Adds DynamicLoaderAcceleratorGDBRemote, which asks the accelerator's gdb server for
its loaded libraries via jAcceleratorPluginGetDynamicLoaderLibraryInfo and loads them
  into the target. 
- Selected for AMDGPU and NVPTX targets debugged over gdb-remote,

This depends on the 2 prior PRs

1. **#214873** — `[lldb] Support loading an object file that is a slice of another file`
     Core `Module`/`ModuleSpec` support for an object file embedded in a larger
     one. Independent of the accelerator work; a HIP binary is just the motivating
     case.
  2. **#214564** — `[lldb-server] Add dynamic loader support to accelerator plugin protocol`
     The `jAcceleratorPluginGetDynamicLoaderLibraryInfo` packet, its JSON types,
     the LLGS handler, and the mock plugin implementation. Server side only.
