### PR TITLE
[libsycl] Fix sycl-ls build on Windows

### DIFF
--- a/libsycl/tools/sycl-ls/CMakeLists.txt
+++ b/libsycl/tools/sycl-ls/CMakeLists.txt
@@ -24,6 +24,9 @@ if (WIN32)
   # - LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR (0x100)
   # - LOAD_LIBRARY_SEARCH_SYSTEM32     (0x800)
   target_link_options(sycl-ls PRIVATE LINKER:/DEPENDENTLOADFLAG:0x900)
+  # We need exceptions, but they are disabled by default for clang-cl, so
+  # enable them.
+  target_compile_options(sycl-ls PRIVATE /EHsc)
 endif()
 install(TARGETS sycl-ls
   RUNTIME DESTINATION "bin" COMPONENT sycl-ls)


### PR DESCRIPTION
`cl` seems to have exceptions enabled by default and works fine, but `clang-cl` doesn't, so it errors about `try` being used even though exceptions are disabled.
I found this trying to enable our Windows CI buildbot.