### PR TITLE
[lld] strip __swift_FORCE_LOAD_$ dyld fixups in __DATA,__const

### DIFF
--- a/lld/MachO/CMakeLists.txt
+++ b/lld/MachO/CMakeLists.txt
@@ -29,6 +29,7 @@ add_lld_library(lldMachO
   BPSectionOrderer.cpp
   SectionPriorities.cpp
   Sections.cpp
+  StripSwiftForceLoad.cpp
   SymbolTable.cpp
   Symbols.cpp
   SyntheticSections.cpp

--- a/lld/MachO/Config.h
+++ b/lld/MachO/Config.h
@@ -147,6 +147,7 @@ struct Configuration {
   bool dedupSymbolStrings = true;
   bool deadStripDuplicates = false;
   bool omitDebugInfo = false;
+  bool stripSwiftForceLoad = false;
   bool warnDylibInstallName = false;
   bool ignoreOptimizationHints = false;
   bool forceExactCpuSubtypeMatch = false;

--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -16,6 +16,7 @@
 #include "OutputSection.h"
 #include "OutputSegment.h"
 #include "SectionPriorities.h"
+#include "StripSwiftForceLoad.h"
 #include "SymbolTable.h"
 #include "Symbols.h"
 #include "SyntheticSections.h"
@@ -2041,6 +2042,9 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
       args.hasFlag(OPT_deduplicate_strings, OPT_no_deduplicate_strings, true);
   config->dedupSymbolStrings = !args.hasArg(OPT_no_deduplicate_symbol_strings);
   config->deadStripDuplicates = args.hasArg(OPT_dead_strip_duplicates);
+  config->stripSwiftForceLoad =
+      args.hasFlag(OPT_strip_swift_force_load, OPT_no_strip_swift_force_load,
+                   /*Default=*/false);
   config->warnDylibInstallName = args.hasFlag(
       OPT_warn_dylib_install_name, OPT_no_warn_dylib_install_name, false);
   config->ignoreOptimizationHints = args.hasArg(OPT_ignore_optimization_hints);
@@ -2531,6 +2535,8 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
     } else if (config->dedupStrings) {
       foldIdenticalSections(/*onlyCfStrings=*/true);
     }
+
+    stripSwiftForceLoadFixups();
 
     // Write to an output file.
     if (target->wordSize == 8)

--- a/lld/MachO/Options.td
+++ b/lld/MachO/Options.td
@@ -78,6 +78,9 @@ def no_deduplicate_strings: Flag<["--"], "no-deduplicate-strings">,
 def dead_strip_duplicates: Flag<["--"], "dead-strip-duplicates">,
     HelpText<"Do not error on duplicate symbols that will be dead stripped.">,
     Group<grp_lld>;
+defm strip_swift_force_load: BB<"strip-swift-force-load",
+  "Strip the swift FORCE_LOAD sections containing fixups",
+  "Do not strip the the swift FORCE_LOAD sections (default)">, Group<grp_lld>;
 def print_dylib_search: Flag<["--"], "print-dylib-search">,
     HelpText<"Print which paths lld searched when trying to find dylibs">,
     Group<grp_lld>;

--- a/lld/MachO/StripSwiftForceLoad.cpp
+++ b/lld/MachO/StripSwiftForceLoad.cpp
@@ -1,0 +1,74 @@
+//===- ElideSwiftForceLoad.cpp --------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "StripSwiftForceLoad.h"
+
+#include "Config.h"
+#include "InputSection.h"
+#include "OutputSegment.h"
+#include "Symbols.h"
+#include "Target.h"
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/TimeProfiler.h"
+
+using namespace llvm;
+using namespace lld;
+using namespace lld::macho;
+
+static constexpr StringRef forceLoadPrefix = "__swift_FORCE_LOAD_$_";
+
+// Returns true if every byte of `isec` is a pointer slot covered by an UNSIGNED
+// pointer relocation to an imported `__swift_FORCE_LOAD_$_*` symbol, i.e.
+// the section exists only to force-load Swift overlays and holds no other data.
+static bool isSwiftForceLoadSection(const ConcatInputSection *isec) {
+  if (isec->relocs.empty())
+    return false;
+
+  if (isec->getSize() != target->wordSize * isec->relocs.size())
+    return false;
+
+  for (const Relocation &r : isec->relocs) {
+    auto *sym = dyn_cast_if_present<Symbol *>(r.referent);
+    auto *dylibSym = dyn_cast_or_null<DylibSymbol>(sym);
+    if (!dylibSym || dylibSym->isDynamicLookup() ||
+        !dylibSym->getName().starts_with(forceLoadPrefix))
+      return false;
+  }
+  return true;
+}
+
+void macho::stripSwiftForceLoadFixups() {
+  if (!config->stripSwiftForceLoad)
+    return;
+
+  TimeTraceScope timeScope("Strip Swift FORCE_LOAD fixups");
+
+  for (ConcatInputSection *isec : inputSections) {
+    if (isec->shouldOmitFromOutput() || isec->replacement)
+      continue;
+
+    if (isec->getSegName() != segment_names::data ||
+        isec->getName() != section_names::const_)
+      continue;
+
+    // Never drop a section that exports a symbol clients may link against.
+    if (llvm::any_of(isec->symbols, [](const Defined *d) {
+          return d->isExternal() && !d->privateExtern;
+        }))
+      continue;
+
+    if (!isSwiftForceLoadSection(isec))
+      continue;
+
+    isec->live = false;
+    for (Defined *d : isec->symbols)
+      d->used = false;
+  }
+}

--- a/lld/MachO/StripSwiftForceLoad.h
+++ b/lld/MachO/StripSwiftForceLoad.h
@@ -1,0 +1,32 @@
+//===- StripSwiftForceLoad.h ------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLD_MACHO_STRIP_SWIFT_FORCE_LOAD_H
+#define LLD_MACHO_STRIP_SWIFT_FORCE_LOAD_H
+
+namespace lld::macho {
+
+// Drop `__DATA,__const` sections that exist only to force-load Swift overlays.
+//
+// The Swift compiler emits `__swift_FORCE_LOAD_$_swift<overlay>` pointers in
+// `__DATA,__const` that bind to the imported symbol of the same name in a
+// dependent overlay dylib. These pointers are never dereferenced -- they exist
+// only to keep the overlay dylib linked in. When a section consists entirely of
+// such pointers (and is not anchored by any externally visible symbol clients
+// might link against), this pass drops the whole section, reclaiming its bytes
+// and removing the dyld binds.
+//
+// The imported FORCE_LOAD DylibSymbols are intentionally left referenced, so
+// the overlays' LC_LOAD_DYLIB dependencies are preserved.
+//
+// NOTE: Must be run after markLive().
+void stripSwiftForceLoadFixups();
+
+} // namespace lld::macho
+
+#endif

--- a/lld/test/MachO/strip-swift-force-load.s
+++ b/lld/test/MachO/strip-swift-force-load.s
@@ -1,0 +1,112 @@
+# REQUIRES: aarch64
+# RUN: rm -rf %t; split-file %s %t
+
+# RUN: llvm-mc -filetype=obj -triple=arm64-apple-darwin %t/foo.s -o %t/foo.o
+# RUN: llvm-mc -filetype=obj -triple=arm64-apple-darwin %t/pure.s -o %t/pure.o
+# RUN: llvm-mc -filetype=obj -triple=arm64-apple-darwin %t/external.s -o %t/external.o
+# RUN: llvm-mc -filetype=obj -triple=arm64-apple-darwin %t/mixed.s -o %t/mixed.o
+# RUN: %lld -arch arm64 -dylib %t/foo.o -o %t/libFoo.dylib -install_name @rpath/libFoo.dylib
+
+## ---------------------------------------------------------------------------
+## A section that is nothing but a force-load pointer (anchored by a local
+## symbol) is dropped entirely: no bind, and the __const bytes are reclaimed.
+## The overlay dylib dependency is preserved.
+## ---------------------------------------------------------------------------
+# RUN: %lld -arch arm64 -dylib %t/pure.o %t/libFoo.dylib -o %t/pure-noflag.dylib
+# RUN: llvm-objdump --macho --bind %t/pure-noflag.dylib | FileCheck %s --check-prefix=PURE-BIND
+# RUN: llvm-objdump --macho --section-headers %t/pure-noflag.dylib | FileCheck %s --check-prefix=HAS-CONST
+
+# RUN: %lld -arch arm64 -dylib %t/pure.o %t/libFoo.dylib -o %t/pure-flag.dylib --strip-swift-force-load
+# RUN: llvm-objdump --macho --bind %t/pure-flag.dylib | FileCheck %s --check-prefix=NO-FORCE-LOAD
+# RUN: llvm-objdump --macho --section-headers %t/pure-flag.dylib | FileCheck %s --check-prefix=NO-CONST
+# RUN: llvm-otool -L %t/pure-flag.dylib | FileCheck %s --check-prefix=DYLIB
+
+## --no-strip-swift-force-load overrides an earlier --strip-swift-force-load.
+# RUN: %lld -arch arm64 -dylib %t/pure.o %t/libFoo.dylib -o %t/pure-noflag2.dylib --strip-swift-force-load --no-strip-swift-force-load
+# RUN: llvm-objdump --macho --bind %t/pure-noflag2.dylib | FileCheck %s --check-prefix=PURE-BIND
+
+## Dropping still happens under -dead_strip (the section is a no_dead_strip root).
+# RUN: %lld -arch arm64 -dylib -dead_strip %t/pure.o %t/libFoo.dylib -o %t/pure-ds.dylib --strip-swift-force-load
+# RUN: llvm-objdump --macho --bind %t/pure-ds.dylib | FileCheck %s --check-prefix=NO-FORCE-LOAD
+# RUN: llvm-otool -L %t/pure-ds.dylib | FileCheck %s --check-prefix=DYLIB
+
+## -dead_strip_dylibs must not drop the section, the imported FORCE_LOAD symbol
+## stays referenced even though the section holding its fixup is gone.
+# RUN: %lld -arch arm64 -dylib -dead_strip_dylibs %t/pure.o %t/libFoo.dylib -o %t/pure-dsd.dylib --strip-swift-force-load
+# RUN: llvm-objdump --macho --bind %t/pure-dsd.dylib | FileCheck %s --check-prefix=NO-FORCE-LOAD
+# RUN: llvm-objdump --macho --section-headers %t/pure-dsd.dylib | FileCheck %s --check-prefix=NO-CONST
+# RUN: llvm-otool -L %t/pure-dsd.dylib | FileCheck %s --check-prefix=DYLIB
+
+# PURE-BIND:      Bind table:
+# PURE-BIND:      __DATA_CONST __const {{.*}} pointer 0 libFoo __swift_FORCE_LOAD_$_swiftFoo
+# HAS-CONST:      __const
+# NO-FORCE-LOAD-NOT: __swift_FORCE_LOAD_$_swiftFoo
+# NO-CONST-NOT:  __const
+# DYLIB:         libFoo.dylib
+
+## ---------------------------------------------------------------------------
+## A force-load pointer anchored by an externally visible symbol must be kept
+## (clients may link against it), so the bind is NOT stripd.
+## ---------------------------------------------------------------------------
+# RUN: %lld -arch arm64 -dylib %t/external.o %t/libFoo.dylib -o %t/external-flag.dylib --strip-swift-force-load
+# RUN: llvm-objdump --macho --bind %t/external-flag.dylib | FileCheck %s --check-prefix=EXT-BIND
+# RUN: llvm-nm %t/external-flag.dylib | FileCheck %s --check-prefix=EXT-NM
+
+# EXT-BIND:      __DATA_CONST __const {{.*}} pointer 0 libFoo __swift_FORCE_LOAD_$_swiftFoo
+# EXT-NM:        _ext_anchor
+
+## ---------------------------------------------------------------------------
+## A section that mixes a force-load pointer with other data is not pure, so it
+## is left untouched (no per-reloc fallback): the bind remains.
+## ---------------------------------------------------------------------------
+# RUN: %lld -arch arm64 -dylib %t/mixed.o %t/libFoo.dylib -o %t/mixed-flag.dylib --strip-swift-force-load
+# RUN: llvm-objdump --macho --bind %t/mixed-flag.dylib | FileCheck %s --check-prefix=MIX-BIND
+
+# MIX-BIND:      __DATA_CONST __const {{.*}} pointer 0 libFoo __swift_FORCE_LOAD_$_swiftFoo
+
+#--- foo.s
+## Stub overlay dylib exporting the FORCE_LOAD symbol.
+.globl __swift_FORCE_LOAD_$_swiftFoo
+.data
+__swift_FORCE_LOAD_$_swiftFoo:
+  .quad 0
+.subsections_via_symbols
+
+#--- pure.s
+## A __DATA,__const section holding only a force-load pointer, anchored by a
+## compiler-local symbol and marked no_dead_strip (as the Swift compiler does).
+.section __DATA,__const
+.private_extern _pure_anchor
+.globl _pure_anchor
+.weak_definition _pure_anchor
+.p2align 3
+_pure_anchor:
+  .quad __swift_FORCE_LOAD_$_swiftFoo
+.no_dead_strip _pure_anchor
+.subsections_via_symbols
+
+#--- external.s
+## Same shape, but the anchor is exported -- must be preserved.
+.globl _ext_anchor
+.section __DATA,__const
+.p2align 3
+_ext_anchor:
+  .quad __swift_FORCE_LOAD_$_swiftFoo
+.subsections_via_symbols
+
+#--- mixed.s
+## A section mixing a force-load pointer with an unrelated data pointer: not a
+## pure force-load section, so it is left untouched.
+.section __DATA,__const
+.private_extern _mixed_anchor
+.globl _mixed_anchor
+.weak_definition _mixed_anchor
+.p2align 3
+_mixed_anchor:
+  .quad __swift_FORCE_LOAD_$_swiftFoo
+  .quad _some_data
+.no_dead_strip _mixed_anchor
+.data
+_some_data:
+  .quad 0
+.subsections_via_symbols


### PR DESCRIPTION
Add a new flag to optionally strip swift FORCE_LOAD symbol sections, which are used by the compiler to force dylib load commands. This has shown a ~30% reduction in binds for some large applications, with corresponding size reduction for the number of elided pointers.

This is based on a similar ld64 optimisation that removes the fixups for the force load sections:
https://github.com/keith/ld64/blob/37d025c536163da612874999d0ea94a4e4e475e7/src/ld/passes/dylibs.cpp#L385-L389

