### PR TITLE
[NVPTX][AsmPrinter] Allow fp128 aggregate types in NVPTX backend

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
@@ -2229,8 +2229,6 @@ void NVPTXAsmPrinter::bufferLEByte(const Constant *CPV, int Bytes,
   case Type::BFloatTyID:
   case Type::FloatTyID:
   case Type::DoubleTyID:
-  // An fp128 only reaches here as an aggregate element; a scalar one is
-  // emitted by bufferAggregateConstant itself.
   case Type::FP128TyID:
     AddIntToBuffer(cast<ConstantFP>(CPV)->getValueAPF().bitcastToAPInt());
     break;

--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
@@ -2229,6 +2229,9 @@ void NVPTXAsmPrinter::bufferLEByte(const Constant *CPV, int Bytes,
   case Type::BFloatTyID:
   case Type::FloatTyID:
   case Type::DoubleTyID:
+  // An fp128 only reaches here as an aggregate element; a scalar one is
+  // emitted by bufferAggregateConstant itself.
+  case Type::FP128TyID:
     AddIntToBuffer(cast<ConstantFP>(CPV)->getValueAPF().bitcastToAPInt());
     break;
 

--- a/llvm/test/CodeGen/NVPTX/fp128-global.ll
+++ b/llvm/test/CodeGen/NVPTX/fp128-global.ll
@@ -1,0 +1,27 @@
+; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_20 | FileCheck %s
+; RUN: %if ptxas %{ llc < %s -mtriple=nvptx64 -mcpu=sm_20 | %ptxas-verify %}
+
+; fp128 globals are lowered to byte arrays. An fp128 nested in an aggregate is
+; buffered one element at a time, and that per-element path must emit the same
+; 16 little-endian bytes as a scalar fp128.
+
+; CHECK-DAG: .visible .global .align 16 .b8 array_nonzero[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 63};
+@array_nonzero = global [1 x fp128] [fp128 0xL00000000000000003FFF000000000000]
+
+; CHECK-DAG: .visible .global .align 16 .b8 array_multi[32] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 63, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64};
+@array_multi = global [2 x fp128] [fp128 0xL00000000000000003FFF000000000000, fp128 0xL00000000000000004000000000000000]
+
+; Trailing zeros of the struct's tail padding are trimmed by the printer.
+; CHECK-DAG: .visible .global .align 16 .b8 struct_nonzero[32] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 0, 64, 7};
+%struct.WithFloat128 = type { fp128, i32 }
+@struct_nonzero = global %struct.WithFloat128 { fp128 0xL00000000000000004000800000000000, i32 7 }
+
+; A scalar fp128 is emitted by bufferAggregateConstant, and an all-zero
+; initializer is caught before the per-element path, so neither depends on fp128
+; being handled in bufferLEByte.
+
+; CHECK-DAG: .visible .global .align 16 .b8 scalar_nonzero[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 63};
+@scalar_nonzero = global fp128 0xL00000000000000003FFF000000000000
+
+; CHECK-DAG: .visible .global .align 16 .b8 array_zero[16];
+@array_zero = global [1 x fp128] zeroinitializer

--- a/llvm/test/CodeGen/NVPTX/fp128-global.ll
+++ b/llvm/test/CodeGen/NVPTX/fp128-global.ll
@@ -16,10 +16,6 @@
 %struct.WithFloat128 = type { fp128, i32 }
 @struct_nonzero = global %struct.WithFloat128 { fp128 0xL00000000000000004000800000000000, i32 7 }
 
-; A scalar fp128 is emitted by bufferAggregateConstant, and an all-zero
-; initializer is caught before the per-element path, so neither depends on fp128
-; being handled in bufferLEByte.
-
 ; CHECK-DAG: .visible .global .align 16 .b8 scalar_nonzero[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 63};
 @scalar_nonzero = global fp128 0xL00000000000000003FFF000000000000
 


### PR DESCRIPTION
Fixes an issue where aggregate types containing fp128 non-zero elements would cause "unsupported type" due to missing case in bufferLEByte. Adds fp128-global.ll test.