### PR TITLE
[HLSL] Use the right memory scope on atomic instructions

### DIFF
--- a/clang/lib/CodeGen/CGHLSLBuiltins.cpp
+++ b/clang/lib/CodeGen/CGHLSLBuiltins.cpp
@@ -320,8 +320,8 @@ static Value *handleInterlockedOp(CodeGenFunction &CGF, const CallExpr *E,
   assert(E->getArg(1)->getType()->isIntegerType() &&
          "Intrinsic InterlockedOp value operand must be an integer");
 
-  // Vulkan forbids the CrossDevice scope a scopeless atomic maps to, so pin
-  // the memory scope: Workgroup for groupshared, Device for everything else.
+  // Scopeless atomics will default to CrossDevice, which is illegal in Vulkan.
+  // Set the memory scope: Workgroup for groupshared, otherwise Device.
   StringRef ScopeName = DestLV.getAddressSpace() == LangAS::hlsl_groupshared
                             ? "workgroup"
                             : "device";

--- a/clang/lib/CodeGen/CGHLSLBuiltins.cpp
+++ b/clang/lib/CodeGen/CGHLSLBuiltins.cpp
@@ -320,8 +320,16 @@ static Value *handleInterlockedOp(CodeGenFunction &CGF, const CallExpr *E,
   assert(E->getArg(1)->getType()->isIntegerType() &&
          "Intrinsic InterlockedOp value operand must be an integer");
 
+  // Vulkan forbids the CrossDevice scope a scopeless atomic maps to, so pin
+  // the memory scope: Workgroup for groupshared, Device for everything else.
+  StringRef ScopeName = DestLV.getAddressSpace() == LangAS::hlsl_groupshared
+                            ? "workgroup"
+                            : "device";
+  llvm::SyncScope::ID SSID =
+      CGF.getLLVMContext().getOrInsertSyncScopeID(ScopeName);
+
   llvm::AtomicRMWInst *Call = CGF.Builder.CreateAtomicRMW(
-      Op, DestAddr, Val, llvm::AtomicOrdering::Monotonic);
+      Op, DestAddr, Val, llvm::AtomicOrdering::Monotonic, SSID);
 
   // The 3-arg overload writes the old value (the RMW's return value) into
   // the `original_value` reference parameter.

--- a/clang/test/CodeGenHLSL/builtins/InterlockedAdd.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/InterlockedAdd.hlsl
@@ -14,45 +14,45 @@ groupshared int64_t  gs_i64;
 groupshared uint64_t gs_u64;
 
 // CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_int_2arg
-// DXCHECK:  atomicrmw add ptr addrspace(3) {{.*}}@gs_i32{{.*}}, i32 %{{.*}} monotonic
-// SPVCHECK: atomicrmw add ptr addrspace(3) {{.*}}@gs_i32{{.*}}, i32 %{{.*}} monotonic
+// DXCHECK:  atomicrmw add ptr addrspace(3) {{.*}}@gs_i32{{.*}}, i32 %{{.*}} syncscope("workgroup") monotonic
+// SPVCHECK: atomicrmw add ptr addrspace(3) {{.*}}@gs_i32{{.*}}, i32 %{{.*}} syncscope("workgroup") monotonic
 export void test_int_2arg(int v) {
   InterlockedAdd(gs_i32, v);
 }
 
 // CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_uint_2arg
-// DXCHECK:  atomicrmw add ptr addrspace(3) {{.*}}@gs_u32{{.*}}, i32 %{{.*}} monotonic
-// SPVCHECK: atomicrmw add ptr addrspace(3) {{.*}}@gs_u32{{.*}}, i32 %{{.*}} monotonic
+// DXCHECK:  atomicrmw add ptr addrspace(3) {{.*}}@gs_u32{{.*}}, i32 %{{.*}} syncscope("workgroup") monotonic
+// SPVCHECK: atomicrmw add ptr addrspace(3) {{.*}}@gs_u32{{.*}}, i32 %{{.*}} syncscope("workgroup") monotonic
 export void test_uint_2arg(uint v) {
   InterlockedAdd(gs_u32, v);
 }
 
 // CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_int_3arg
-// DXCHECK:  %[[R:.*]] = atomicrmw add ptr addrspace(3) {{.*}}@gs_i32{{.*}}, i32 %{{.*}} monotonic
-// SPVCHECK: %[[R:.*]] = atomicrmw add ptr addrspace(3) {{.*}}@gs_i32{{.*}}, i32 %{{.*}} monotonic
+// DXCHECK:  %[[R:.*]] = atomicrmw add ptr addrspace(3) {{.*}}@gs_i32{{.*}}, i32 %{{.*}} syncscope("workgroup") monotonic
+// SPVCHECK: %[[R:.*]] = atomicrmw add ptr addrspace(3) {{.*}}@gs_i32{{.*}}, i32 %{{.*}} syncscope("workgroup") monotonic
 // CHECK:    store i32 %[[R]], ptr {{.*}}
 export void test_int_3arg(int v, out int orig) {
   InterlockedAdd(gs_i32, v, orig);
 }
 
 // CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_uint_3arg
-// DXCHECK:  %[[R:.*]] = atomicrmw add ptr addrspace(3) {{.*}}@gs_u32{{.*}}, i32 %{{.*}} monotonic
-// SPVCHECK: %[[R:.*]] = atomicrmw add ptr addrspace(3) {{.*}}@gs_u32{{.*}}, i32 %{{.*}} monotonic
+// DXCHECK:  %[[R:.*]] = atomicrmw add ptr addrspace(3) {{.*}}@gs_u32{{.*}}, i32 %{{.*}} syncscope("workgroup") monotonic
+// SPVCHECK: %[[R:.*]] = atomicrmw add ptr addrspace(3) {{.*}}@gs_u32{{.*}}, i32 %{{.*}} syncscope("workgroup") monotonic
 // CHECK:    store i32 %[[R]], ptr {{.*}}
 export void test_uint_3arg(uint v, out uint orig) {
   InterlockedAdd(gs_u32, v, orig);
 }
 
 // CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_int64_2arg
-// DXCHECK:  atomicrmw add ptr addrspace(3) {{.*}}@gs_i64{{.*}}, i64 %{{.*}} monotonic
-// SPVCHECK: atomicrmw add ptr addrspace(3) {{.*}}@gs_i64{{.*}}, i64 %{{.*}} monotonic
+// DXCHECK:  atomicrmw add ptr addrspace(3) {{.*}}@gs_i64{{.*}}, i64 %{{.*}} syncscope("workgroup") monotonic
+// SPVCHECK: atomicrmw add ptr addrspace(3) {{.*}}@gs_i64{{.*}}, i64 %{{.*}} syncscope("workgroup") monotonic
 export void test_int64_2arg(int64_t v) {
   InterlockedAdd(gs_i64, v);
 }
 
 // CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_uint64_3arg
-// DXCHECK:  %[[R:.*]] = atomicrmw add ptr addrspace(3) {{.*}}@gs_u64{{.*}}, i64 %{{.*}} monotonic
-// SPVCHECK: %[[R:.*]] = atomicrmw add ptr addrspace(3) {{.*}}@gs_u64{{.*}}, i64 %{{.*}} monotonic
+// DXCHECK:  %[[R:.*]] = atomicrmw add ptr addrspace(3) {{.*}}@gs_u64{{.*}}, i64 %{{.*}} syncscope("workgroup") monotonic
+// SPVCHECK: %[[R:.*]] = atomicrmw add ptr addrspace(3) {{.*}}@gs_u64{{.*}}, i64 %{{.*}} syncscope("workgroup") monotonic
 // CHECK:    store i64 %[[R]], ptr {{.*}}
 export void test_uint64_3arg(uint64_t v, out uint64_t orig) {
   InterlockedAdd(gs_u64, v, orig);

--- a/clang/test/CodeGenHLSL/builtins/InterlockedOr-SPIRV-scope.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/InterlockedOr-SPIRV-scope.hlsl
@@ -1,0 +1,17 @@
+// RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -triple \
+// RUN:   spirv1.6-unknown-vulkan1.3-compute %s -S -o - | FileCheck %s
+
+// An Interlocked op on a groupshared destination must use the Workgroup scope
+// (2), not CrossDevice (which the backend emits as OpConstantNull).
+
+groupshared uint gs;
+
+// CHECK-DAG: %[[#UINT:]] = OpTypeInt 32 0
+// CHECK-DAG: %[[#WORKGROUP:]] = OpConstant %[[#UINT]] 2
+// CHECK: OpAtomicOr %[[#UINT]] %[[#]] %[[#WORKGROUP]] %[[#]] %[[#]]
+// CHECK-NOT: OpConstantNull
+
+[numthreads(1,1,1)]
+void main() {
+  InterlockedOr(gs, 1);
+}

--- a/clang/test/CodeGenHLSL/builtins/InterlockedOr.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/InterlockedOr.hlsl
@@ -14,45 +14,45 @@ groupshared int64_t  gs_i64;
 groupshared uint64_t gs_u64;
 
 // CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_int_2arg
-// DXCHECK:  atomicrmw or ptr addrspace(3) {{.*}}@gs_i32{{.*}}, i32 %{{.*}} monotonic
-// SPVCHECK: atomicrmw or ptr addrspace(3) {{.*}}@gs_i32{{.*}}, i32 %{{.*}} monotonic
+// DXCHECK:  atomicrmw or ptr addrspace(3) {{.*}}@gs_i32{{.*}}, i32 %{{.*}} syncscope("workgroup") monotonic
+// SPVCHECK: atomicrmw or ptr addrspace(3) {{.*}}@gs_i32{{.*}}, i32 %{{.*}} syncscope("workgroup") monotonic
 export void test_int_2arg(int v) {
   InterlockedOr(gs_i32, v);
 }
 
 // CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_uint_2arg
-// DXCHECK:  atomicrmw or ptr addrspace(3) {{.*}}@gs_u32{{.*}}, i32 %{{.*}} monotonic
-// SPVCHECK: atomicrmw or ptr addrspace(3) {{.*}}@gs_u32{{.*}}, i32 %{{.*}} monotonic
+// DXCHECK:  atomicrmw or ptr addrspace(3) {{.*}}@gs_u32{{.*}}, i32 %{{.*}} syncscope("workgroup") monotonic
+// SPVCHECK: atomicrmw or ptr addrspace(3) {{.*}}@gs_u32{{.*}}, i32 %{{.*}} syncscope("workgroup") monotonic
 export void test_uint_2arg(uint v) {
   InterlockedOr(gs_u32, v);
 }
 
 // CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_int_3arg
-// DXCHECK:  %[[R:.*]] = atomicrmw or ptr addrspace(3) {{.*}}@gs_i32{{.*}}, i32 %{{.*}} monotonic
-// SPVCHECK: %[[R:.*]] = atomicrmw or ptr addrspace(3) {{.*}}@gs_i32{{.*}}, i32 %{{.*}} monotonic
+// DXCHECK:  %[[R:.*]] = atomicrmw or ptr addrspace(3) {{.*}}@gs_i32{{.*}}, i32 %{{.*}} syncscope("workgroup") monotonic
+// SPVCHECK: %[[R:.*]] = atomicrmw or ptr addrspace(3) {{.*}}@gs_i32{{.*}}, i32 %{{.*}} syncscope("workgroup") monotonic
 // CHECK:    store i32 %[[R]], ptr {{.*}}
 export void test_int_3arg(int v, out int orig) {
   InterlockedOr(gs_i32, v, orig);
 }
 
 // CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_uint_3arg
-// DXCHECK:  %[[R:.*]] = atomicrmw or ptr addrspace(3) {{.*}}@gs_u32{{.*}}, i32 %{{.*}} monotonic
-// SPVCHECK: %[[R:.*]] = atomicrmw or ptr addrspace(3) {{.*}}@gs_u32{{.*}}, i32 %{{.*}} monotonic
+// DXCHECK:  %[[R:.*]] = atomicrmw or ptr addrspace(3) {{.*}}@gs_u32{{.*}}, i32 %{{.*}} syncscope("workgroup") monotonic
+// SPVCHECK: %[[R:.*]] = atomicrmw or ptr addrspace(3) {{.*}}@gs_u32{{.*}}, i32 %{{.*}} syncscope("workgroup") monotonic
 // CHECK:    store i32 %[[R]], ptr {{.*}}
 export void test_uint_3arg(uint v, out uint orig) {
   InterlockedOr(gs_u32, v, orig);
 }
 
 // CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_int64_2arg
-// DXCHECK:  atomicrmw or ptr addrspace(3) {{.*}}@gs_i64{{.*}}, i64 %{{.*}} monotonic
-// SPVCHECK: atomicrmw or ptr addrspace(3) {{.*}}@gs_i64{{.*}}, i64 %{{.*}} monotonic
+// DXCHECK:  atomicrmw or ptr addrspace(3) {{.*}}@gs_i64{{.*}}, i64 %{{.*}} syncscope("workgroup") monotonic
+// SPVCHECK: atomicrmw or ptr addrspace(3) {{.*}}@gs_i64{{.*}}, i64 %{{.*}} syncscope("workgroup") monotonic
 export void test_int64_2arg(int64_t v) {
   InterlockedOr(gs_i64, v);
 }
 
 // CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_uint64_3arg
-// DXCHECK:  %[[R:.*]] = atomicrmw or ptr addrspace(3) {{.*}}@gs_u64{{.*}}, i64 %{{.*}} monotonic
-// SPVCHECK: %[[R:.*]] = atomicrmw or ptr addrspace(3) {{.*}}@gs_u64{{.*}}, i64 %{{.*}} monotonic
+// DXCHECK:  %[[R:.*]] = atomicrmw or ptr addrspace(3) {{.*}}@gs_u64{{.*}}, i64 %{{.*}} syncscope("workgroup") monotonic
+// SPVCHECK: %[[R:.*]] = atomicrmw or ptr addrspace(3) {{.*}}@gs_u64{{.*}}, i64 %{{.*}} syncscope("workgroup") monotonic
 // CHECK:    store i64 %[[R]], ptr {{.*}}
 export void test_uint64_3arg(uint64_t v, out uint64_t orig) {
   InterlockedOr(gs_u64, v, orig);

--- a/clang/test/CodeGenHLSL/builtins/InterlockedXor.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/InterlockedXor.hlsl
@@ -6,7 +6,7 @@
 // RUN:   spirv-pc-vulkan-library %s -emit-llvm -disable-llvm-passes -o - | \
 // RUN:   FileCheck %s --check-prefixes=CHECK,SPVCHECK
 
-// Test basic lowering of HLSL InterlockedXor to `atomicrmw or monotonic`.
+// Test basic lowering of HLSL InterlockedXor to `atomicrmw xor monotonic`.
 
 groupshared int  gs_i32;
 groupshared uint gs_u32;
@@ -14,45 +14,45 @@ groupshared int64_t  gs_i64;
 groupshared uint64_t gs_u64;
 
 // CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_int_2arg
-// DXCHECK:  atomicrmw xor ptr addrspace(3) {{.*}}@gs_i32{{.*}}, i32 %{{.*}} monotonic
-// SPVCHECK: atomicrmw xor ptr addrspace(3) {{.*}}@gs_i32{{.*}}, i32 %{{.*}} monotonic
+// DXCHECK:  atomicrmw xor ptr addrspace(3) {{.*}}@gs_i32{{.*}}, i32 %{{.*}} syncscope("workgroup") monotonic
+// SPVCHECK: atomicrmw xor ptr addrspace(3) {{.*}}@gs_i32{{.*}}, i32 %{{.*}} syncscope("workgroup") monotonic
 export void test_int_2arg(int v) {
   InterlockedXor(gs_i32, v);
 }
 
 // CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_uint_2arg
-// DXCHECK:  atomicrmw xor ptr addrspace(3) {{.*}}@gs_u32{{.*}}, i32 %{{.*}} monotonic
-// SPVCHECK: atomicrmw xor ptr addrspace(3) {{.*}}@gs_u32{{.*}}, i32 %{{.*}} monotonic
+// DXCHECK:  atomicrmw xor ptr addrspace(3) {{.*}}@gs_u32{{.*}}, i32 %{{.*}} syncscope("workgroup") monotonic
+// SPVCHECK: atomicrmw xor ptr addrspace(3) {{.*}}@gs_u32{{.*}}, i32 %{{.*}} syncscope("workgroup") monotonic
 export void test_uint_2arg(uint v) {
   InterlockedXor(gs_u32, v);
 }
 
 // CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_int_3arg
-// DXCHECK:  %[[R:.*]] = atomicrmw xor ptr addrspace(3) {{.*}}@gs_i32{{.*}}, i32 %{{.*}} monotonic
-// SPVCHECK: %[[R:.*]] = atomicrmw xor ptr addrspace(3) {{.*}}@gs_i32{{.*}}, i32 %{{.*}} monotonic
+// DXCHECK:  %[[R:.*]] = atomicrmw xor ptr addrspace(3) {{.*}}@gs_i32{{.*}}, i32 %{{.*}} syncscope("workgroup") monotonic
+// SPVCHECK: %[[R:.*]] = atomicrmw xor ptr addrspace(3) {{.*}}@gs_i32{{.*}}, i32 %{{.*}} syncscope("workgroup") monotonic
 // CHECK:    store i32 %[[R]], ptr {{.*}}
 export void test_int_3arg(int v, out int orig) {
   InterlockedXor(gs_i32, v, orig);
 }
 
 // CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_uint_3arg
-// DXCHECK:  %[[R:.*]] = atomicrmw xor ptr addrspace(3) {{.*}}@gs_u32{{.*}}, i32 %{{.*}} monotonic
-// SPVCHECK: %[[R:.*]] = atomicrmw xor ptr addrspace(3) {{.*}}@gs_u32{{.*}}, i32 %{{.*}} monotonic
+// DXCHECK:  %[[R:.*]] = atomicrmw xor ptr addrspace(3) {{.*}}@gs_u32{{.*}}, i32 %{{.*}} syncscope("workgroup") monotonic
+// SPVCHECK: %[[R:.*]] = atomicrmw xor ptr addrspace(3) {{.*}}@gs_u32{{.*}}, i32 %{{.*}} syncscope("workgroup") monotonic
 // CHECK:    store i32 %[[R]], ptr {{.*}}
 export void test_uint_3arg(uint v, out uint orig) {
   InterlockedXor(gs_u32, v, orig);
 }
 
 // CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_int64_2arg
-// DXCHECK:  atomicrmw xor ptr addrspace(3) {{.*}}@gs_i64{{.*}}, i64 %{{.*}} monotonic
-// SPVCHECK: atomicrmw xor ptr addrspace(3) {{.*}}@gs_i64{{.*}}, i64 %{{.*}} monotonic
+// DXCHECK:  atomicrmw xor ptr addrspace(3) {{.*}}@gs_i64{{.*}}, i64 %{{.*}} syncscope("workgroup") monotonic
+// SPVCHECK: atomicrmw xor ptr addrspace(3) {{.*}}@gs_i64{{.*}}, i64 %{{.*}} syncscope("workgroup") monotonic
 export void test_int64_2arg(int64_t v) {
   InterlockedXor(gs_i64, v);
 }
 
 // CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_uint64_3arg
-// DXCHECK:  %[[R:.*]] = atomicrmw xor ptr addrspace(3) {{.*}}@gs_u64{{.*}}, i64 %{{.*}} monotonic
-// SPVCHECK: %[[R:.*]] = atomicrmw xor ptr addrspace(3) {{.*}}@gs_u64{{.*}}, i64 %{{.*}} monotonic
+// DXCHECK:  %[[R:.*]] = atomicrmw xor ptr addrspace(3) {{.*}}@gs_u64{{.*}}, i64 %{{.*}} syncscope("workgroup") monotonic
+// SPVCHECK: %[[R:.*]] = atomicrmw xor ptr addrspace(3) {{.*}}@gs_u64{{.*}}, i64 %{{.*}} syncscope("workgroup") monotonic
 // CHECK:    store i64 %[[R]], ptr {{.*}}
 export void test_uint64_3arg(uint64_t v, out uint64_t orig) {
   InterlockedXor(gs_u64, v, orig);

--- a/clang/test/CodeGenHLSL/builtins/RWBuffer-Interlocked.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/RWBuffer-Interlocked.hlsl
@@ -18,17 +18,17 @@ RWBuffer<int> Out : register(u0);
 
 // CHECK-LABEL: define void @main
 // DXCHECK:  %[[PTR1:.*]] = call {{.*}} @llvm.dx.resource.getpointer.p0.tdx.TypedBuffer_i32_1_0_1t.i32(target("dx.TypedBuffer", i32, 1, 0, 1) %{{.*}}, i32 %{{.*}})
-// DXCHECK:  atomicrmw add ptr %[[PTR1]], i32 1 monotonic
+// DXCHECK:  atomicrmw add ptr %[[PTR1]], i32 1 syncscope("device") monotonic
 // DXCHECK:  %[[PTR2:.*]] = call {{.*}} @llvm.dx.resource.getpointer.p0.tdx.TypedBuffer_i32_1_0_1t.i32(target("dx.TypedBuffer", i32, 1, 0, 1) %{{.*}}, i32 %{{.*}})
-// DXCHECK:  atomicrmw or ptr %[[PTR2]], i32 1 monotonic
+// DXCHECK:  atomicrmw or ptr %[[PTR2]], i32 1 syncscope("device") monotonic
 // DXCHECK:  %[[PTR3:.*]] = call {{.*}} @llvm.dx.resource.getpointer.p0.tdx.TypedBuffer_i32_1_0_1t.i32(target("dx.TypedBuffer", i32, 1, 0, 1) %{{.*}}, i32 %{{.*}})
-// DXCHECK:  atomicrmw xor ptr %[[PTR3]], i32 1 monotonic
+// DXCHECK:  atomicrmw xor ptr %[[PTR3]], i32 1 syncscope("device") monotonic
 // SPVCHECK: %[[PTR1:.*]] = call {{.*}} @llvm.spv.resource.getpointer.{{.*}}(target("spirv.{{Image|SignedImage}}", i32, {{.*}}) %{{.*}}, i32 %{{.*}})
-// SPVCHECK: atomicrmw add ptr addrspace(11) %[[PTR1]], i32 1 monotonic
+// SPVCHECK: atomicrmw add ptr addrspace(11) %[[PTR1]], i32 1 syncscope("device") monotonic
 // SPVCHECK: %[[PTR2:.*]] = call {{.*}} @llvm.spv.resource.getpointer.{{.*}}(target("spirv.{{Image|SignedImage}}", i32, {{.*}}) %{{.*}}, i32 %{{.*}})
-// SPVCHECK: atomicrmw or ptr addrspace(11) %[[PTR2]], i32 1 monotonic
+// SPVCHECK: atomicrmw or ptr addrspace(11) %[[PTR2]], i32 1 syncscope("device") monotonic
 // SPVCHECK: %[[PTR3:.*]] = call {{.*}} @llvm.spv.resource.getpointer.{{.*}}(target("spirv.{{Image|SignedImage}}", i32, {{.*}}) %{{.*}}, i32 %{{.*}})
-// SPVCHECK: atomicrmw xor ptr addrspace(11) %[[PTR3]], i32 1 monotonic
+// SPVCHECK: atomicrmw xor ptr addrspace(11) %[[PTR3]], i32 1 syncscope("device") monotonic
 [shader("compute")]
 [numthreads(1,1,1)]
 void main(uint3 id : SV_DispatchThreadID) {

--- a/clang/test/CodeGenHLSL/builtins/RWByteAddressBuffer-InterlockedAdd.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/RWByteAddressBuffer-InterlockedAdd.hlsl
@@ -16,10 +16,10 @@ RWByteAddressBuffer BAB : register(u0);
 // CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_bab_int_2arg
 // DXCHECK:  %[[HANDLE:.*]] = load target("dx.RawBuffer", i8, 1, 0), ptr {{.*}}
 // DXCHECK:  %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_0t.i32(target("dx.RawBuffer", i8, 1, 0) %[[HANDLE]], i32 %{{.*}})
-// DXCHECK:  atomicrmw add ptr %[[PTR]], i32 %{{.*}} monotonic
+// DXCHECK:  atomicrmw add ptr %[[PTR]], i32 %{{.*}} syncscope("device") monotonic
 // SPVCHECK: %[[HANDLE:.*]] = load target("spirv.VulkanBuffer", [0 x i8], 12, 1), ptr {{.*}}
 // SPVCHECK: %[[PTR:.*]] = call ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0i8_12_1t.i32(target("spirv.VulkanBuffer", [0 x i8], 12, 1) %[[HANDLE]], i32 %{{.*}})
-// SPVCHECK: atomicrmw add ptr addrspace(11) %[[PTR]], i32 %{{.*}} monotonic
+// SPVCHECK: atomicrmw add ptr addrspace(11) %[[PTR]], i32 %{{.*}} syncscope("device") monotonic
 export void test_bab_int_2arg(uint off, int v) {
   BAB.InterlockedAdd(off, v);
 }
@@ -27,11 +27,11 @@ export void test_bab_int_2arg(uint off, int v) {
 // CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_bab_uint_3arg
 // DXCHECK:  %[[HANDLE:.*]] = load target("dx.RawBuffer", i8, 1, 0), ptr {{.*}}
 // DXCHECK:  %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_0t.i32(target("dx.RawBuffer", i8, 1, 0) %[[HANDLE]], i32 %{{.*}})
-// DXCHECK:  %[[R:.*]] = atomicrmw add ptr %[[PTR]], i32 %{{.*}} monotonic
+// DXCHECK:  %[[R:.*]] = atomicrmw add ptr %[[PTR]], i32 %{{.*}} syncscope("device") monotonic
 // DXCHECK:  store i32 %[[R]], ptr {{.*}}
 // SPVCHECK: %[[HANDLE:.*]] = load target("spirv.VulkanBuffer", [0 x i8], 12, 1), ptr {{.*}}
 // SPVCHECK: %[[PTR:.*]] = call ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0i8_12_1t.i32(target("spirv.VulkanBuffer", [0 x i8], 12, 1) %[[HANDLE]], i32 %{{.*}})
-// SPVCHECK: %[[R:.*]] = atomicrmw add ptr addrspace(11) %[[PTR]], i32 %{{.*}} monotonic
+// SPVCHECK: %[[R:.*]] = atomicrmw add ptr addrspace(11) %[[PTR]], i32 %{{.*}} syncscope("device") monotonic
 // SPVCHECK: store i32 %[[R]], ptr {{.*}}
 export void test_bab_uint_3arg(uint off, uint v, out uint orig) {
   BAB.InterlockedAdd(off, v, orig);
@@ -40,10 +40,10 @@ export void test_bab_uint_3arg(uint off, uint v, out uint orig) {
 // CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_bab_int64_2arg
 // DXCHECK:  %[[HANDLE:.*]] = load target("dx.RawBuffer", i8, 1, 0), ptr {{.*}}
 // DXCHECK:  %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_0t.i32(target("dx.RawBuffer", i8, 1, 0) %[[HANDLE]], i32 %{{.*}})
-// DXCHECK:  atomicrmw add ptr %[[PTR]], i64 %{{.*}} monotonic
+// DXCHECK:  atomicrmw add ptr %[[PTR]], i64 %{{.*}} syncscope("device") monotonic
 // SPVCHECK: %[[HANDLE:.*]] = load target("spirv.VulkanBuffer", [0 x i8], 12, 1), ptr {{.*}}
 // SPVCHECK: %[[PTR:.*]] = call ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0i8_12_1t.i32(target("spirv.VulkanBuffer", [0 x i8], 12, 1) %[[HANDLE]], i32 %{{.*}})
-// SPVCHECK: atomicrmw add ptr addrspace(11) %[[PTR]], i64 %{{.*}} monotonic
+// SPVCHECK: atomicrmw add ptr addrspace(11) %[[PTR]], i64 %{{.*}} syncscope("device") monotonic
 export void test_bab_int64_2arg(uint off, int64_t v) {
   BAB.InterlockedAdd64(off, v);
 }
@@ -51,11 +51,11 @@ export void test_bab_int64_2arg(uint off, int64_t v) {
 // CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_bab_uint64_3arg
 // DXCHECK:  %[[HANDLE:.*]] = load target("dx.RawBuffer", i8, 1, 0), ptr {{.*}}
 // DXCHECK:  %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_0t.i32(target("dx.RawBuffer", i8, 1, 0) %[[HANDLE]], i32 %{{.*}})
-// DXCHECK:  %[[R:.*]] = atomicrmw add ptr %[[PTR]], i64 %{{.*}} monotonic
+// DXCHECK:  %[[R:.*]] = atomicrmw add ptr %[[PTR]], i64 %{{.*}} syncscope("device") monotonic
 // DXCHECK:  store i64 %[[R]], ptr {{.*}}
 // SPVCHECK: %[[HANDLE:.*]] = load target("spirv.VulkanBuffer", [0 x i8], 12, 1), ptr {{.*}}
 // SPVCHECK: %[[PTR:.*]] = call ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0i8_12_1t.i32(target("spirv.VulkanBuffer", [0 x i8], 12, 1) %[[HANDLE]], i32 %{{.*}})
-// SPVCHECK: %[[R:.*]] = atomicrmw add ptr addrspace(11) %[[PTR]], i64 %{{.*}} monotonic
+// SPVCHECK: %[[R:.*]] = atomicrmw add ptr addrspace(11) %[[PTR]], i64 %{{.*}} syncscope("device") monotonic
 // SPVCHECK: store i64 %[[R]], ptr {{.*}}
 export void test_bab_uint64_3arg(uint off, uint64_t v, out uint64_t orig) {
   BAB.InterlockedAdd64(off, v, orig);

--- a/clang/test/CodeGenHLSL/builtins/RWByteAddressBuffer-InterlockedOr.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/RWByteAddressBuffer-InterlockedOr.hlsl
@@ -16,10 +16,10 @@ RWByteAddressBuffer BAB : register(u0);
 // CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_bab_int_2arg
 // DXCHECK:  %[[HANDLE:.*]] = load target("dx.RawBuffer", i8, 1, 0), ptr {{.*}}
 // DXCHECK:  %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_0t.i32(target("dx.RawBuffer", i8, 1, 0) %[[HANDLE]], i32 %{{.*}})
-// DXCHECK:  atomicrmw or ptr %[[PTR]], i32 %{{.*}} monotonic
+// DXCHECK:  atomicrmw or ptr %[[PTR]], i32 %{{.*}} syncscope("device") monotonic
 // SPVCHECK: %[[HANDLE:.*]] = load target("spirv.VulkanBuffer", [0 x i8], 12, 1), ptr {{.*}}
 // SPVCHECK: %[[PTR:.*]] = call ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0i8_12_1t.i32(target("spirv.VulkanBuffer", [0 x i8], 12, 1) %[[HANDLE]], i32 %{{.*}})
-// SPVCHECK: atomicrmw or ptr addrspace(11) %[[PTR]], i32 %{{.*}} monotonic
+// SPVCHECK: atomicrmw or ptr addrspace(11) %[[PTR]], i32 %{{.*}} syncscope("device") monotonic
 export void test_bab_int_2arg(uint off, int v) {
   BAB.InterlockedOr(off, v);
 }
@@ -27,11 +27,11 @@ export void test_bab_int_2arg(uint off, int v) {
 // CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_bab_uint_3arg
 // DXCHECK:  %[[HANDLE:.*]] = load target("dx.RawBuffer", i8, 1, 0), ptr {{.*}}
 // DXCHECK:  %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_0t.i32(target("dx.RawBuffer", i8, 1, 0) %[[HANDLE]], i32 %{{.*}})
-// DXCHECK:  %[[R:.*]] = atomicrmw or ptr %[[PTR]], i32 %{{.*}} monotonic
+// DXCHECK:  %[[R:.*]] = atomicrmw or ptr %[[PTR]], i32 %{{.*}} syncscope("device") monotonic
 // DXCHECK:  store i32 %[[R]], ptr {{.*}}
 // SPVCHECK: %[[HANDLE:.*]] = load target("spirv.VulkanBuffer", [0 x i8], 12, 1), ptr {{.*}}
 // SPVCHECK: %[[PTR:.*]] = call ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0i8_12_1t.i32(target("spirv.VulkanBuffer", [0 x i8], 12, 1) %[[HANDLE]], i32 %{{.*}})
-// SPVCHECK: %[[R:.*]] = atomicrmw or ptr addrspace(11) %[[PTR]], i32 %{{.*}} monotonic
+// SPVCHECK: %[[R:.*]] = atomicrmw or ptr addrspace(11) %[[PTR]], i32 %{{.*}} syncscope("device") monotonic
 // SPVCHECK: store i32 %[[R]], ptr {{.*}}
 export void test_bab_uint_3arg(uint off, uint v, out uint orig) {
   BAB.InterlockedOr(off, v, orig);
@@ -40,10 +40,10 @@ export void test_bab_uint_3arg(uint off, uint v, out uint orig) {
 // CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_bab_int64_2arg
 // DXCHECK:  %[[HANDLE:.*]] = load target("dx.RawBuffer", i8, 1, 0), ptr {{.*}}
 // DXCHECK:  %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_0t.i32(target("dx.RawBuffer", i8, 1, 0) %[[HANDLE]], i32 %{{.*}})
-// DXCHECK:  atomicrmw or ptr %[[PTR]], i64 %{{.*}} monotonic
+// DXCHECK:  atomicrmw or ptr %[[PTR]], i64 %{{.*}} syncscope("device") monotonic
 // SPVCHECK: %[[HANDLE:.*]] = load target("spirv.VulkanBuffer", [0 x i8], 12, 1), ptr {{.*}}
 // SPVCHECK: %[[PTR:.*]] = call ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0i8_12_1t.i32(target("spirv.VulkanBuffer", [0 x i8], 12, 1) %[[HANDLE]], i32 %{{.*}})
-// SPVCHECK: atomicrmw or ptr addrspace(11) %[[PTR]], i64 %{{.*}} monotonic
+// SPVCHECK: atomicrmw or ptr addrspace(11) %[[PTR]], i64 %{{.*}} syncscope("device") monotonic
 export void test_bab_int64_2arg(uint off, int64_t v) {
   BAB.InterlockedOr64(off, v);
 }
@@ -51,11 +51,11 @@ export void test_bab_int64_2arg(uint off, int64_t v) {
 // CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_bab_uint64_3arg
 // DXCHECK:  %[[HANDLE:.*]] = load target("dx.RawBuffer", i8, 1, 0), ptr {{.*}}
 // DXCHECK:  %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_0t.i32(target("dx.RawBuffer", i8, 1, 0) %[[HANDLE]], i32 %{{.*}})
-// DXCHECK:  %[[R:.*]] = atomicrmw or ptr %[[PTR]], i64 %{{.*}} monotonic
+// DXCHECK:  %[[R:.*]] = atomicrmw or ptr %[[PTR]], i64 %{{.*}} syncscope("device") monotonic
 // DXCHECK:  store i64 %[[R]], ptr {{.*}}
 // SPVCHECK: %[[HANDLE:.*]] = load target("spirv.VulkanBuffer", [0 x i8], 12, 1), ptr {{.*}}
 // SPVCHECK: %[[PTR:.*]] = call ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0i8_12_1t.i32(target("spirv.VulkanBuffer", [0 x i8], 12, 1) %[[HANDLE]], i32 %{{.*}})
-// SPVCHECK: %[[R:.*]] = atomicrmw or ptr addrspace(11) %[[PTR]], i64 %{{.*}} monotonic
+// SPVCHECK: %[[R:.*]] = atomicrmw or ptr addrspace(11) %[[PTR]], i64 %{{.*}} syncscope("device") monotonic
 // SPVCHECK: store i64 %[[R]], ptr {{.*}}
 export void test_bab_uint64_3arg(uint off, uint64_t v, out uint64_t orig) {
   BAB.InterlockedOr64(off, v, orig);

--- a/clang/test/CodeGenHLSL/builtins/RWByteAddressBuffer-InterlockedXor.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/RWByteAddressBuffer-InterlockedXor.hlsl
@@ -16,10 +16,10 @@ RWByteAddressBuffer BAB : register(u0);
 // CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_bab_int_2arg
 // DXCHECK:  %[[HANDLE:.*]] = load target("dx.RawBuffer", i8, 1, 0), ptr {{.*}}
 // DXCHECK:  %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_0t.i32(target("dx.RawBuffer", i8, 1, 0) %[[HANDLE]], i32 %{{.*}})
-// DXCHECK:  atomicrmw xor ptr %[[PTR]], i32 %{{.*}} monotonic
+// DXCHECK:  atomicrmw xor ptr %[[PTR]], i32 %{{.*}} syncscope("device") monotonic
 // SPVCHECK: %[[HANDLE:.*]] = load target("spirv.VulkanBuffer", [0 x i8], 12, 1), ptr {{.*}}
 // SPVCHECK: %[[PTR:.*]] = call ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0i8_12_1t.i32(target("spirv.VulkanBuffer", [0 x i8], 12, 1) %[[HANDLE]], i32 %{{.*}})
-// SPVCHECK: atomicrmw xor ptr addrspace(11) %[[PTR]], i32 %{{.*}} monotonic
+// SPVCHECK: atomicrmw xor ptr addrspace(11) %[[PTR]], i32 %{{.*}} syncscope("device") monotonic
 export void test_bab_int_2arg(uint off, int v) {
   BAB.InterlockedXor(off, v);
 }
@@ -27,11 +27,11 @@ export void test_bab_int_2arg(uint off, int v) {
 // CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_bab_uint_3arg
 // DXCHECK:  %[[HANDLE:.*]] = load target("dx.RawBuffer", i8, 1, 0), ptr {{.*}}
 // DXCHECK:  %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_0t.i32(target("dx.RawBuffer", i8, 1, 0) %[[HANDLE]], i32 %{{.*}})
-// DXCHECK:  %[[R:.*]] = atomicrmw xor ptr %[[PTR]], i32 %{{.*}} monotonic
+// DXCHECK:  %[[R:.*]] = atomicrmw xor ptr %[[PTR]], i32 %{{.*}} syncscope("device") monotonic
 // DXCHECK:  store i32 %[[R]], ptr {{.*}}
 // SPVCHECK: %[[HANDLE:.*]] = load target("spirv.VulkanBuffer", [0 x i8], 12, 1), ptr {{.*}}
 // SPVCHECK: %[[PTR:.*]] = call ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0i8_12_1t.i32(target("spirv.VulkanBuffer", [0 x i8], 12, 1) %[[HANDLE]], i32 %{{.*}})
-// SPVCHECK: %[[R:.*]] = atomicrmw xor ptr addrspace(11) %[[PTR]], i32 %{{.*}} monotonic
+// SPVCHECK: %[[R:.*]] = atomicrmw xor ptr addrspace(11) %[[PTR]], i32 %{{.*}} syncscope("device") monotonic
 // SPVCHECK: store i32 %[[R]], ptr {{.*}}
 export void test_bab_uint_3arg(uint off, uint v, out uint orig) {
   BAB.InterlockedXor(off, v, orig);
@@ -40,10 +40,10 @@ export void test_bab_uint_3arg(uint off, uint v, out uint orig) {
 // CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_bab_int64_2arg
 // DXCHECK:  %[[HANDLE:.*]] = load target("dx.RawBuffer", i8, 1, 0), ptr {{.*}}
 // DXCHECK:  %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_0t.i32(target("dx.RawBuffer", i8, 1, 0) %[[HANDLE]], i32 %{{.*}})
-// DXCHECK:  atomicrmw xor ptr %[[PTR]], i64 %{{.*}} monotonic
+// DXCHECK:  atomicrmw xor ptr %[[PTR]], i64 %{{.*}} syncscope("device") monotonic
 // SPVCHECK: %[[HANDLE:.*]] = load target("spirv.VulkanBuffer", [0 x i8], 12, 1), ptr {{.*}}
 // SPVCHECK: %[[PTR:.*]] = call ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0i8_12_1t.i32(target("spirv.VulkanBuffer", [0 x i8], 12, 1) %[[HANDLE]], i32 %{{.*}})
-// SPVCHECK: atomicrmw xor ptr addrspace(11) %[[PTR]], i64 %{{.*}} monotonic
+// SPVCHECK: atomicrmw xor ptr addrspace(11) %[[PTR]], i64 %{{.*}} syncscope("device") monotonic
 export void test_bab_int64_2arg(uint off, int64_t v) {
   BAB.InterlockedXor64(off, v);
 }
@@ -51,11 +51,11 @@ export void test_bab_int64_2arg(uint off, int64_t v) {
 // CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_bab_uint64_3arg
 // DXCHECK:  %[[HANDLE:.*]] = load target("dx.RawBuffer", i8, 1, 0), ptr {{.*}}
 // DXCHECK:  %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_0t.i32(target("dx.RawBuffer", i8, 1, 0) %[[HANDLE]], i32 %{{.*}})
-// DXCHECK:  %[[R:.*]] = atomicrmw xor ptr %[[PTR]], i64 %{{.*}} monotonic
+// DXCHECK:  %[[R:.*]] = atomicrmw xor ptr %[[PTR]], i64 %{{.*}} syncscope("device") monotonic
 // DXCHECK:  store i64 %[[R]], ptr {{.*}}
 // SPVCHECK: %[[HANDLE:.*]] = load target("spirv.VulkanBuffer", [0 x i8], 12, 1), ptr {{.*}}
 // SPVCHECK: %[[PTR:.*]] = call ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0i8_12_1t.i32(target("spirv.VulkanBuffer", [0 x i8], 12, 1) %[[HANDLE]], i32 %{{.*}})
-// SPVCHECK: %[[R:.*]] = atomicrmw xor ptr addrspace(11) %[[PTR]], i64 %{{.*}} monotonic
+// SPVCHECK: %[[R:.*]] = atomicrmw xor ptr addrspace(11) %[[PTR]], i64 %{{.*}} syncscope("device") monotonic
 // SPVCHECK: store i64 %[[R]], ptr {{.*}}
 export void test_bab_uint64_3arg(uint off, uint64_t v, out uint64_t orig) {
   BAB.InterlockedXor64(off, v, orig);

--- a/clang/test/CodeGenHLSL/builtins/RasterizerOrderedByteAddressBuffer-InterlockedAdd.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/RasterizerOrderedByteAddressBuffer-InterlockedAdd.hlsl
@@ -13,7 +13,7 @@ RasterizerOrderedByteAddressBuffer ROVB : register(u1);
 // CHECK-LABEL: define void @{{.*}}test_rovb_int_2arg
 // DXCHECK: %[[HANDLE:.*]] = load target("dx.RawBuffer", i8, 1, 1), ptr {{.*}}
 // DXCHECK: %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_1t.i32(target("dx.RawBuffer", i8, 1, 1) %[[HANDLE]], i32 %{{.*}})
-// DXCHECK: atomicrmw add ptr %[[PTR]], i32 %{{.*}} monotonic
+// DXCHECK: atomicrmw add ptr %[[PTR]], i32 %{{.*}} syncscope("device") monotonic
 export void test_rovb_int_2arg(uint off, int v) {
   ROVB.InterlockedAdd(off, v);
 }
@@ -21,7 +21,7 @@ export void test_rovb_int_2arg(uint off, int v) {
 // CHECK-LABEL: define void @{{.*}}test_rovb_uint_3arg
 // DXCHECK: %[[HANDLE:.*]] = load target("dx.RawBuffer", i8, 1, 1), ptr {{.*}}
 // DXCHECK: %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_1t.i32(target("dx.RawBuffer", i8, 1, 1) %[[HANDLE]], i32 %{{.*}})
-// DXCHECK: %[[R:.*]] = atomicrmw add ptr %[[PTR]], i32 %{{.*}} monotonic
+// DXCHECK: %[[R:.*]] = atomicrmw add ptr %[[PTR]], i32 %{{.*}} syncscope("device") monotonic
 // DXCHECK: store i32 %[[R]], ptr {{.*}}
 export void test_rovb_uint_3arg(uint off, uint v, out uint orig) {
   ROVB.InterlockedAdd(off, v, orig);
@@ -30,7 +30,7 @@ export void test_rovb_uint_3arg(uint off, uint v, out uint orig) {
 // CHECK-LABEL: define void @{{.*}}test_rovb_int64_2arg
 // DXCHECK: %[[HANDLE:.*]] = load target("dx.RawBuffer", i8, 1, 1), ptr {{.*}}
 // DXCHECK: %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_1t.i32(target("dx.RawBuffer", i8, 1, 1) %[[HANDLE]], i32 %{{.*}})
-// DXCHECK: atomicrmw add ptr %[[PTR]], i64 %{{.*}} monotonic
+// DXCHECK: atomicrmw add ptr %[[PTR]], i64 %{{.*}} syncscope("device") monotonic
 export void test_rovb_int64_2arg(uint off, int64_t v) {
   ROVB.InterlockedAdd64(off, v);
 }
@@ -38,7 +38,7 @@ export void test_rovb_int64_2arg(uint off, int64_t v) {
 // CHECK-LABEL: define void @{{.*}}test_rovb_uint64_3arg
 // DXCHECK: %[[HANDLE:.*]] = load target("dx.RawBuffer", i8, 1, 1), ptr {{.*}}
 // DXCHECK: %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_1t.i32(target("dx.RawBuffer", i8, 1, 1) %[[HANDLE]], i32 %{{.*}})
-// DXCHECK: %[[R:.*]] = atomicrmw add ptr %[[PTR]], i64 %{{.*}} monotonic
+// DXCHECK: %[[R:.*]] = atomicrmw add ptr %[[PTR]], i64 %{{.*}} syncscope("device") monotonic
 // DXCHECK: store i64 %[[R]], ptr {{.*}}
 export void test_rovb_uint64_3arg(uint off, uint64_t v, out uint64_t orig) {
   ROVB.InterlockedAdd64(off, v, orig);

--- a/clang/test/CodeGenHLSL/builtins/RasterizerOrderedByteAddressBuffer-InterlockedOr.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/RasterizerOrderedByteAddressBuffer-InterlockedOr.hlsl
@@ -13,7 +13,7 @@ RasterizerOrderedByteAddressBuffer ROVB : register(u1);
 // CHECK-LABEL: define void @{{.*}}test_rovb_int_2arg
 // DXCHECK: %[[HANDLE:.*]] = load target("dx.RawBuffer", i8, 1, 1), ptr {{.*}}
 // DXCHECK: %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_1t.i32(target("dx.RawBuffer", i8, 1, 1) %[[HANDLE]], i32 %{{.*}})
-// DXCHECK: atomicrmw or ptr %[[PTR]], i32 %{{.*}} monotonic
+// DXCHECK: atomicrmw or ptr %[[PTR]], i32 %{{.*}} syncscope("device") monotonic
 export void test_rovb_int_2arg(uint off, int v) {
   ROVB.InterlockedOr(off, v);
 }
@@ -21,7 +21,7 @@ export void test_rovb_int_2arg(uint off, int v) {
 // CHECK-LABEL: define void @{{.*}}test_rovb_uint_3arg
 // DXCHECK: %[[HANDLE:.*]] = load target("dx.RawBuffer", i8, 1, 1), ptr {{.*}}
 // DXCHECK: %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_1t.i32(target("dx.RawBuffer", i8, 1, 1) %[[HANDLE]], i32 %{{.*}})
-// DXCHECK: %[[R:.*]] = atomicrmw or ptr %[[PTR]], i32 %{{.*}} monotonic
+// DXCHECK: %[[R:.*]] = atomicrmw or ptr %[[PTR]], i32 %{{.*}} syncscope("device") monotonic
 // DXCHECK: store i32 %[[R]], ptr {{.*}}
 export void test_rovb_uint_3arg(uint off, uint v, out uint orig) {
   ROVB.InterlockedOr(off, v, orig);
@@ -30,7 +30,7 @@ export void test_rovb_uint_3arg(uint off, uint v, out uint orig) {
 // CHECK-LABEL: define void @{{.*}}test_rovb_int64_2arg
 // DXCHECK: %[[HANDLE:.*]] = load target("dx.RawBuffer", i8, 1, 1), ptr {{.*}}
 // DXCHECK: %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_1t.i32(target("dx.RawBuffer", i8, 1, 1) %[[HANDLE]], i32 %{{.*}})
-// DXCHECK: atomicrmw or ptr %[[PTR]], i64 %{{.*}} monotonic
+// DXCHECK: atomicrmw or ptr %[[PTR]], i64 %{{.*}} syncscope("device") monotonic
 export void test_rovb_int64_2arg(uint off, int64_t v) {
   ROVB.InterlockedOr64(off, v);
 }
@@ -38,7 +38,7 @@ export void test_rovb_int64_2arg(uint off, int64_t v) {
 // CHECK-LABEL: define void @{{.*}}test_rovb_uint64_3arg
 // DXCHECK: %[[HANDLE:.*]] = load target("dx.RawBuffer", i8, 1, 1), ptr {{.*}}
 // DXCHECK: %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_1t.i32(target("dx.RawBuffer", i8, 1, 1) %[[HANDLE]], i32 %{{.*}})
-// DXCHECK: %[[R:.*]] = atomicrmw or ptr %[[PTR]], i64 %{{.*}} monotonic
+// DXCHECK: %[[R:.*]] = atomicrmw or ptr %[[PTR]], i64 %{{.*}} syncscope("device") monotonic
 // DXCHECK: store i64 %[[R]], ptr {{.*}}
 export void test_rovb_uint64_3arg(uint off, uint64_t v, out uint64_t orig) {
   ROVB.InterlockedOr64(off, v, orig);

--- a/clang/test/CodeGenHLSL/builtins/RasterizerOrderedByteAddressBuffer-InterlockedXor.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/RasterizerOrderedByteAddressBuffer-InterlockedXor.hlsl
@@ -13,7 +13,7 @@ RasterizerOrderedByteAddressBuffer ROVB : register(u1);
 // CHECK-LABEL: define void @{{.*}}test_rovb_int_2arg
 // DXCHECK: %[[HANDLE:.*]] = load target("dx.RawBuffer", i8, 1, 1), ptr {{.*}}
 // DXCHECK: %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_1t.i32(target("dx.RawBuffer", i8, 1, 1) %[[HANDLE]], i32 %{{.*}})
-// DXCHECK: atomicrmw xor ptr %[[PTR]], i32 %{{.*}} monotonic
+// DXCHECK: atomicrmw xor ptr %[[PTR]], i32 %{{.*}} syncscope("device") monotonic
 export void test_rovb_int_2arg(uint off, int v) {
   ROVB.InterlockedXor(off, v);
 }
@@ -21,7 +21,7 @@ export void test_rovb_int_2arg(uint off, int v) {
 // CHECK-LABEL: define void @{{.*}}test_rovb_uint_3arg
 // DXCHECK: %[[HANDLE:.*]] = load target("dx.RawBuffer", i8, 1, 1), ptr {{.*}}
 // DXCHECK: %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_1t.i32(target("dx.RawBuffer", i8, 1, 1) %[[HANDLE]], i32 %{{.*}})
-// DXCHECK: %[[R:.*]] = atomicrmw xor ptr %[[PTR]], i32 %{{.*}} monotonic
+// DXCHECK: %[[R:.*]] = atomicrmw xor ptr %[[PTR]], i32 %{{.*}} syncscope("device") monotonic
 // DXCHECK: store i32 %[[R]], ptr {{.*}}
 export void test_rovb_uint_3arg(uint off, uint v, out uint orig) {
   ROVB.InterlockedXor(off, v, orig);
@@ -30,7 +30,7 @@ export void test_rovb_uint_3arg(uint off, uint v, out uint orig) {
 // CHECK-LABEL: define void @{{.*}}test_rovb_int64_2arg
 // DXCHECK: %[[HANDLE:.*]] = load target("dx.RawBuffer", i8, 1, 1), ptr {{.*}}
 // DXCHECK: %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_1t.i32(target("dx.RawBuffer", i8, 1, 1) %[[HANDLE]], i32 %{{.*}})
-// DXCHECK: atomicrmw xor ptr %[[PTR]], i64 %{{.*}} monotonic
+// DXCHECK: atomicrmw xor ptr %[[PTR]], i64 %{{.*}} syncscope("device") monotonic
 export void test_rovb_int64_2arg(uint off, int64_t v) {
   ROVB.InterlockedXor64(off, v);
 }
@@ -38,7 +38,7 @@ export void test_rovb_int64_2arg(uint off, int64_t v) {
 // CHECK-LABEL: define void @{{.*}}test_rovb_uint64_3arg
 // DXCHECK: %[[HANDLE:.*]] = load target("dx.RawBuffer", i8, 1, 1), ptr {{.*}}
 // DXCHECK: %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_1t.i32(target("dx.RawBuffer", i8, 1, 1) %[[HANDLE]], i32 %{{.*}})
-// DXCHECK: %[[R:.*]] = atomicrmw xor ptr %[[PTR]], i64 %{{.*}} monotonic
+// DXCHECK: %[[R:.*]] = atomicrmw xor ptr %[[PTR]], i64 %{{.*}} syncscope("device") monotonic
 // DXCHECK: store i64 %[[R]], ptr {{.*}}
 export void test_rovb_uint64_3arg(uint off, uint64_t v, out uint64_t orig) {
   ROVB.InterlockedXor64(off, v, orig);


### PR DESCRIPTION
Atomic instructions have incorrect memory scope, and spirv-val diagnoses with validation errors.
The memory scope is left unassigned (OpConstantNull) and is scopeless, and so it is interpreted as `CrossDevice`.
Instead, we need the scope to be `Workgroup` if the atomic is operating on a groupshared variable, or `Device` otherwise.
This PR changes the memory scope assignment to be one of the two legal choices, rather than leaving the scope unset and the resulting value being interpreted to the illegal `CrossDevice` variant.
Regression test was added to verify this scope operand is set.

spirv-val will still fail due to one more issue, but it is out of scope and is left to a separate PR.

Assisted by: Github Copilot
Fixes: https://github.com/llvm/llvm-project/issues/214591