### PR TITLE
[flang][OpenMP] Mark declare target on use-associated module variables

### DIFF
--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -6906,6 +6906,55 @@ void Fortran::lower::genOpenMPDeclarativeConstruct(
   genNestedEvaluations(converter, eval);
 }
 
+/// Mark a declare target module variable that is use-associated from another
+/// unit. No directive is parsed here, so \c markDeclareTarget never reaches it
+/// and the declaration would be internalized for the device.
+static void markUseAssociatedDeclareTarget(lower::AbstractConverter &converter,
+                                           const lower::pft::Variable &var) {
+  if (!var.isGlobal())
+    return;
+
+  const semantics::Symbol &ultimate = var.getSymbol().GetUltimate();
+  const auto *details = ultimate.detailsIf<semantics::ObjectEntityDetails>();
+  if (!details)
+    return;
+
+  const auto &clauses = details->ompDeclTarget();
+  if (!clauses.count())
+    return;
+
+  mlir::ModuleOp mod = converter.getFirOpBuilder().getModule();
+  mlir::Operation *op = mod.lookupSymbol(converter.mangleName(ultimate));
+  if (!op)
+    return;
+
+  auto declareTargetOp = llvm::dyn_cast<mlir::omp::DeclareTargetInterface>(op);
+  if (!declareTargetOp || declareTargetOp.isDeclareTarget())
+    return;
+
+  // Declarations only: a definition is marked later by markDeclareTarget with
+  // the clauses as written, and it skips an already marked operation.
+  for (mlir::Region &region : op->getRegions())
+    if (!region.empty())
+      return;
+
+  // `enter` and `to` lower identically.
+  mlir::omp::DeclareTargetCaptureClause captureClause =
+      clauses.test(llvm::omp::Clause::OMPC_link)
+          ? mlir::omp::DeclareTargetCaptureClause::link
+          : mlir::omp::DeclareTargetCaptureClause::to;
+
+  mlir::omp::DeclareTargetDeviceType deviceType =
+      mlir::omp::DeclareTargetDeviceType::any;
+  if (const std::optional<common::OmpDeviceType> &dt =
+          details->ompDeclTargetDeviceType())
+    deviceType = toMLIRDeclareTargetDeviceType(*dt);
+
+  // automap is a modifier, not a clause, so it is not recoverable here.
+  declareTargetOp.setDeclareTarget(deviceType, captureClause,
+                                   /*automap=*/false);
+}
+
 void Fortran::lower::genOpenMPSymbolProperties(
     lower::AbstractConverter &converter, const lower::pft::Variable &var) {
   assert(var.hasSymbol() && "Expecting Symbol");
@@ -6917,8 +6966,10 @@ void Fortran::lower::genOpenMPSymbolProperties(
   if (sym.test(semantics::Symbol::Flag::OmpThreadprivate))
     lower::genThreadprivateOp(converter, var);
 
-  if (sym.test(semantics::Symbol::Flag::OmpDeclareTarget))
+  if (sym.test(semantics::Symbol::Flag::OmpDeclareTarget)) {
     lower::genDeclareTargetIntGlobal(converter, var);
+    markUseAssociatedDeclareTarget(converter, var);
+  }
 }
 
 void Fortran::lower::genGroupprivateOp(lower::AbstractConverter &converter,

--- a/flang/test/Lower/OpenMP/declare-target-modfile.f90
+++ b/flang/test/Lower/OpenMP/declare-target-modfile.f90
@@ -1,0 +1,28 @@
+! Cross-TU propagation of `declare target` on a module variable via .mod files.
+
+! RUN: rm -rf %t && split-file %s %t
+! RUN: %flang_fc1 -emit-hlfir -fopenmp -module-dir %t %t/m.f90 -o - > /dev/null
+! RUN: %flang_fc1 -emit-hlfir -fopenmp -J %t %t/use.f90 -o - | FileCheck %s
+
+! The consumer only USE-associates the module. Its declaration must still carry
+! omp.declare_target, recovered from the .mod file, or it is internalized for
+! the device and the definition is lost.
+
+!--- m.f90
+module dt_mod
+  implicit none
+  integer :: dt_x
+  !$omp declare target(dt_x)
+end module dt_mod
+
+!--- use.f90
+subroutine use_dt_mod(out)
+  use dt_mod
+  implicit none
+  integer, intent(out) :: out
+  !$omp target map(tofrom: out)
+    out = dt_x
+  !$omp end target
+end subroutine use_dt_mod
+
+! CHECK: fir.global @_QMdt_modEdt_x {omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (to), automap = false>} : i32


### PR DESCRIPTION
Fixes #214586.

A module variable marked `!$omp declare target` keeps its `OmpDeclareTarget` flag when it is use-associated into another translation unit, and the `.mod` file records the directive. But no declare target directive is parsed in that unit, so neither `markDeclareTarget` call site (`symbolAndClause` and `deferredDeclareTargets`) reaches it, and the global is emitted with no `omp.declare_target`.

`HostOpFiltering` then treats it as an ordinary host global and gives it internal linkage for the device:

```llvm
; consuming TU, --offload-device-only -O0
@_QMmod_aEnsz = internal addrspace(1) global i32 undef
```

so a `declare target` routine in that TU reads an uninitialized private copy instead of the definition, and `target update to(...)` has no effect on it. At -O2 the load from an `internal undef` global folds away, the dependent store is removed, and the `intent(out)` dummy becomes `readnone`. No diagnostic; the program computes wrong results. The issue has a three-file reproducer and a same-TU control that passes.

`genOpenMPSymbolProperties` already tests the flag and is reached for the use-associated variable, but its declare target branch calls `genDeclareTargetIntGlobal`, which starts with `if (!var.isGlobal())` and only materializes a `GlobalOp` for main program SAVE variables, so a module variable falls through unmarked.

This marks the declaration from the capture clause and device type recorded on the defining symbol.

Only globals **without an initializer body** are marked. A global defined in this unit is marked later by `markDeclareTarget` with the clauses as written; marking it here first would discard them, because `markDeclareTarget` leaves an already marked operation alone. That is not hypothetical -- an earlier version of this patch gated on `isDeclareTarget()` instead and regressed `Lower/OpenMP/declare-target-automap.f90`, because the main program global is not yet marked at this point.

`automap` is a modifier rather than a clause, so it is not in the symbol's clause set and cannot be recovered for a use-associated symbol; `false` is passed. That is a gap, though the current behaviour for such a variable is a silent wrong answer.

### Testing

- New `flang/test/Lower/OpenMP/declare-target-modfile.f90`, modelled on the existing `groupprivate-modfile.f90` cross-TU pattern. Verified it fails without the change and passes with it.
- `mlir/test/Dialect/OpenMP`, `mlir/test/Target/LLVMIR`, `flang/test/Lower/OpenMP`, `flang/test/Integration/OpenMP`, `flang/test/Transforms`, `flang/test/Fir`, `flang/test/Semantics/OpenMP`: 1921 tests, no regressions.
- The issue's reproducer runs correctly on gfx90a (MI250X), returning 42 instead of the host sentinel.

Developed and tested at 785fd14fa94e. The first revision failed to build on main: it named the
clause-set type as `WithOmpDeclarative::OmpClauseSet`, which is `llvm::omp::ClauseSet` there. It is
the same `EnumSet` instantiation either way, so `auto` is used and the behaviour is unchanged.

cc @skatrak
