### PR TITLE
[AMDGPU] Make unsupported libcall legalization a fatal error

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -4348,6 +4348,13 @@ SDValue SITargetLowering::LowerCall(CallLoweringInfo &CLI,
   bool IsSibCall = false;
   MachineFunction &MF = DAG.getMachineFunction();
 
+  if (!CLI.CB) {
+    std::string Msg = "unsupported libcall legalization";
+    if (const auto *G = dyn_cast<ExternalSymbolSDNode>(CLI.Callee))
+      Msg += std::string(" ") + G->getSymbol();
+    report_fatal_error(Twine(Msg), false);
+  }
+
   if (Callee.isUndef() || isNullConstant(Callee)) {
     if (!CLI.IsTailCall) {
       for (ISD::InputArg &Arg : CLI.Ins)
@@ -4361,9 +4368,6 @@ SDValue SITargetLowering::LowerCall(CallLoweringInfo &CLI,
     return lowerUnhandledCall(CLI, InVals,
                               "unsupported call to variadic function ");
   }
-
-  if (!CLI.CB)
-    return lowerUnhandledCall(CLI, InVals, "unsupported libcall legalization");
 
   if (IsTailCall && MF.getTarget().Options.GuaranteedTailCallOpt) {
     return lowerUnhandledCall(CLI, InVals,

--- a/llvm/test/CodeGen/AMDGPU/unsupported-log-f64.ll
+++ b/llvm/test/CodeGen/AMDGPU/unsupported-log-f64.ll
@@ -1,0 +1,17 @@
+; RUN: not llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -filetype=null %s 2>&1 | FileCheck %s
+; RUN: not llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1100 -filetype=null %s 2>&1 | FileCheck %s
+
+; The AMDGPU backend does not support f64 FLOG/FLOG2/FLOG10 lowering.
+; These fall through to a libcall that cannot be formed.  Previously
+; this silently produced a store of zero/poison; ensure it is now a
+; hard error.
+
+; CHECK: LLVM ERROR: unsupported libcall legalization
+
+declare double @llvm.log2.f64(double)
+
+define amdgpu_kernel void @log2_f64(ptr addrspace(1) %out, double %x) {
+  %r = call double @llvm.log2.f64(double %x)
+  store double %r, ptr addrspace(1) %out
+  ret void
+}


### PR DESCRIPTION
When llc is invoked directly on IR containing operations that require a libcall the backend cannot form (e.g. llvm.log2.f64), the legalizer previously emitted a diagnostic but continued compilation, silently producing a store of zero/poison.

This is a corner case that only arises when invoking the instruction selector directly (e.g. via llc); the normal clang toolchain links ROCm device-libs (OCML) which expands these intrinsics at the IR level before codegen is reached.

Upgrade the soft diagnostic to report_fatal_error so that the miscompile is impossible regardless of how the backend is invoked.

Assisted-By: cursor (claude).