### PR TITLE
[mlir][EmitC] Make function name placeholder optional in `wrap-emitc-func-in-class`

### DIFF
--- a/mlir/include/mlir/Dialect/EmitC/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/EmitC/Transforms/Passes.td
@@ -59,8 +59,8 @@ def WrapFuncInClassPass : Pass<"wrap-emitc-func-in-class", "ModuleOp"> {
       "matching the input function.">,
       Option<"classNameFormat", "class-name-format", "std::string",
       /*default=*/[{"{}Class"}],
-      "Format string for the generated class name where '{}' "
-      "is replaced with the function name.">
+      "Format string for the generated class name where the function name "
+      "placeholder '{}' is optional.">
   ];
 }
 

--- a/mlir/lib/Dialect/EmitC/Transforms/WrapFuncInClass.cpp
+++ b/mlir/lib/Dialect/EmitC/Transforms/WrapFuncInClass.cpp
@@ -77,8 +77,8 @@ public:
   LogicalResult matchAndRewrite(FuncOp funcOp,
                                 PatternRewriter &rewriter) const override {
 
-    std::string className =
-        llvm::formatv(classNameFormat.c_str(), funcOp.getName());
+    std::string className = llvm::formatv(
+        /*Validate=*/false, classNameFormat.c_str(), funcOp.getName());
     ClassOp newClassOp = ClassOp::create(rewriter, funcOp.getLoc(), className);
 
     SmallVector<std::pair<StringAttr, TypeAttr>> fields;
@@ -152,8 +152,8 @@ private:
   /// function.
   std::string funcName;
 
-  /// Format string used to create the wrapper class name where '{}' is
-  /// replaced with the original function name.
+  /// Format string used to create the wrapper class name where the
+  /// function-name placeholder '{}' is optional.
   std::string classNameFormat;
 
   /// Map of FuncOp and the GlobalOps it uses which need to be moved into the

--- a/mlir/test/Dialect/EmitC/wrap-func-in-class-static-name.mlir
+++ b/mlir/test/Dialect/EmitC/wrap-func-in-class-static-name.mlir
@@ -1,0 +1,14 @@
+// RUN: mlir-opt %s -wrap-emitc-func-in-class=class-name-format=StaticName | FileCheck %s
+
+/// Tests that wrap-emitc-func-in-class works with a static class name format
+/// that does not contain a placeholder for the function name.
+
+emitc.func @foo() {
+  emitc.return
+}
+
+// CHECK: emitc.class @StaticName {
+// CHECK:   emitc.func @"operator()"() {
+// CHECK:     return
+// CHECK:   }
+// CHECK: }


### PR DESCRIPTION
Allow `class-name-format` in `wrap-emitc-func-in-class` to accept format strings without a `{}` by disabling format validation in `llvm::formatv`. Prevents assertion failures.