### PR TITLE
[gsymutil] Use scoped printer

### DIFF
--- a/llvm/lib/DebugInfo/GSYM/GsymReader.cpp
+++ b/llvm/lib/DebugInfo/GSYM/GsymReader.cpp
@@ -22,6 +22,7 @@
 #include "llvm/DebugInfo/GSYM/LineTable.h"
 #include "llvm/Support/JSON.h"
 #include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/ScopedPrinter.h"
 
 using namespace llvm;
 using namespace gsym;
@@ -583,121 +584,57 @@ void GsymReader::dumpStatistics(raw_ostream &OS, StatisticsFormat Format,
 
   const std::string UUIDStr = formatGsymUUID(getUUID());
 
+  std::unique_ptr<ScopedPrinter> W;
+  if (Format == StatisticsFormat::JSON)
+    W = std::make_unique<JSONScopedPrinter>(OS, /*PrettyPrint=*/false);
+  else if (Format == StatisticsFormat::PrettyJSON)
+    W = std::make_unique<JSONScopedPrinter>(OS, /*PrettyPrint=*/true);
+  else
+    W = std::make_unique<ScopedPrinter>(OS);
+
+  DictScope Root;
   if (Format == StatisticsFormat::JSON ||
-      Format == StatisticsFormat::PrettyJSON) {
-    json::Object MergedTypes{
-        {"infotype_infolength_count_and_fnsize",
-         static_cast<int64_t>(Merged.InfoTypeInfoLengthCountAndFnSize)},
-        {"size_and_name", static_cast<int64_t>(Merged.SizeAndName)},
-        {"line_table_info", static_cast<int64_t>(Merged.LineTableInfo)},
-        {"inline_info", static_cast<int64_t>(Merged.InlineInfo)},
-        {"call_site_info", static_cast<int64_t>(Merged.CallSiteInfo)},
-        {"merged_func_info", static_cast<int64_t>(Merged.MergedFuncInfo)},
-        {"end_of_list", static_cast<int64_t>(Merged.EndOfList)}};
+      Format == StatisticsFormat::PrettyJSON)
+    Root.setPrinter(*W);
 
-    json::Object FuncTypes{
-        {"size_and_name", static_cast<int64_t>(FI.SizeAndName)},
-        {"line_table_info", static_cast<int64_t>(FI.LineTableInfo)},
-        {"inline_info", static_cast<int64_t>(FI.InlineInfo)},
-        {"call_site_info", static_cast<int64_t>(FI.CallSiteInfo)},
-        {"merged_func_info", static_cast<int64_t>(FI.MergedFuncInfo)},
-        {"end_of_list", static_cast<int64_t>(FI.EndOfList)},
-        {"padding", static_cast<int64_t>(Padding)},
-        {"merged_func_info_type_sizes", std::move(MergedTypes)}};
+  W->printString("path", GSYMPath);
+  W->printString("uuid", UUIDStr);
+  W->printNumber("num_addresses", NumAddresses);
 
-    json::Object ByteSizes{
-        {"file_size", static_cast<int64_t>(FileSize)},
-        {"header", static_cast<int64_t>(HeaderSize)},
-        {"global_data_directory", static_cast<int64_t>(GlobalDataDirSize)},
-        {"uuid_section", static_cast<int64_t>(UUIDSize)},
-        {"padding", static_cast<int64_t>(PaddingSize)},
-        {"address_table", static_cast<int64_t>(AddrTableSize)},
-        {"addr_info_offsets", static_cast<int64_t>(AddrInfoOffsetsSize)},
-        {"file_table", static_cast<int64_t>(FileTableSize)},
-        {"string_table", static_cast<int64_t>(StrtabSize)},
-        {"function_info_data", static_cast<int64_t>(FuncInfoSize)},
-        {"function_info_type_sizes", std::move(FuncTypes)}};
-
-    json::Object Root{{"path", GSYMPath.str()},
-                      {"uuid", UUIDStr},
-                      {"num_addresses", static_cast<int64_t>(NumAddresses)},
-                      {"byte-sizes", std::move(ByteSizes)}};
-
-    json::Value V(std::move(Root));
-    if (Format == StatisticsFormat::PrettyJSON)
-      OS << formatv("{0:2}", V) << "\n";
-    else
-      OS << V << "\n";
-    return;
-  }
-
-  // Text format output.
-  auto Fmt = [](uint64_t Value) {
-    std::string Num = std::to_string(Value);
-    int InsertPosition = Num.length() - 3;
-    while (InsertPosition > 0) {
-      Num.insert(InsertPosition, ",");
-      InsertPosition -= 3;
+  {
+    DictScope ByteSizes(*W, "byte-sizes");
+    W->printNumber("file_size", FileSize);
+    W->printNumber("header", HeaderSize);
+    W->printNumber("global_data_directory", GlobalDataDirSize);
+    W->printNumber("uuid_section", UUIDSize);
+    W->printNumber("padding", PaddingSize);
+    W->printNumber("address_table", AddrTableSize);
+    W->printNumber("addr_info_offsets", AddrInfoOffsetsSize);
+    W->printNumber("file_table", FileTableSize);
+    W->printNumber("string_table", StrtabSize);
+    W->printNumber("function_info_data", FuncInfoSize);
+    {
+      DictScope FuncTypes(*W, "function_info_type_sizes");
+      W->printNumber("size_and_name", FI.SizeAndName);
+      W->printNumber("line_table_info", FI.LineTableInfo);
+      W->printNumber("inline_info", FI.InlineInfo);
+      W->printNumber("call_site_info", FI.CallSiteInfo);
+      W->printNumber("merged_func_info", FI.MergedFuncInfo);
+      W->printNumber("end_of_list", FI.EndOfList);
+      W->printNumber("padding", Padding);
+      {
+        DictScope MergedTypes(*W, "merged_func_info_type_sizes");
+        W->printNumber("infotype_infolength_count_and_fnsize",
+                       Merged.InfoTypeInfoLengthCountAndFnSize);
+        W->printNumber("size_and_name", Merged.SizeAndName);
+        W->printNumber("line_table_info", Merged.LineTableInfo);
+        W->printNumber("inline_info", Merged.InlineInfo);
+        W->printNumber("call_site_info", Merged.CallSiteInfo);
+        W->printNumber("merged_func_info", Merged.MergedFuncInfo);
+        W->printNumber("end_of_list", Merged.EndOfList);
+      }
     }
-    return std::string(std::max((size_t)0, 14 - Num.length()), ' ') + Num;
-  };
-  auto Pct = [&](uint64_t Value) -> std::string {
-    char Buf[16];
-    snprintf(Buf, sizeof(Buf), "(%5.2f%%)", 100.0 * Value / FileSize);
-    return Buf;
-  };
-
-  OS << "GSYM statistics for \"" << GSYMPath << "\":\n";
-  OS << "  UUID:                " << UUIDStr << "\n";
-  OS << "  Number of addresses: " << Fmt(NumAddresses) << "\n";
-  OS << "  File size:           " << Fmt(FileSize) << " bytes\n";
-  OS << "  Header:              " << Fmt(HeaderSize) << " bytes "
-     << Pct(HeaderSize) << "\n";
-  OS << "  Global data dir:     " << Fmt(GlobalDataDirSize) << " bytes "
-     << Pct(GlobalDataDirSize) << "\n";
-  OS << "  UUID section:        " << Fmt(UUIDSize) << " bytes " << Pct(UUIDSize)
-     << "\n";
-  OS << "  Address table:       " << Fmt(AddrTableSize) << " bytes "
-     << Pct(AddrTableSize) << "\n";
-  OS << "  Addr info offsets:   " << Fmt(AddrInfoOffsetsSize) << " bytes "
-     << Pct(AddrInfoOffsetsSize) << "\n";
-  OS << "  File table:          " << Fmt(FileTableSize) << " bytes "
-     << Pct(FileTableSize) << "\n";
-  OS << "  String table:        " << Fmt(StrtabSize) << " bytes "
-     << Pct(StrtabSize) << "\n";
-  OS << "  Function info data:  " << Fmt(FuncInfoSize) << " bytes "
-     << Pct(FuncInfoSize) << "\n";
-  OS << "    Size and name:     " << Fmt(FI.SizeAndName) << " bytes "
-     << Pct(FI.SizeAndName) << "\n";
-  OS << "    Line table info:   " << Fmt(FI.LineTableInfo) << " bytes "
-     << Pct(FI.LineTableInfo) << "\n";
-  OS << "    Inline info:       " << Fmt(FI.InlineInfo) << " bytes "
-     << Pct(FI.InlineInfo) << "\n";
-  OS << "    Call site info:    " << Fmt(FI.CallSiteInfo) << " bytes "
-     << Pct(FI.CallSiteInfo) << "\n";
-  OS << "    End of list:       " << Fmt(FI.EndOfList) << " bytes "
-     << Pct(FI.EndOfList) << "\n";
-  OS << "    Padding:           " << Fmt(Padding) << " bytes " << Pct(Padding)
-     << "\n";
-  OS << "    Merged func info:  " << Fmt(FI.MergedFuncInfo) << " bytes "
-     << Pct(FI.MergedFuncInfo) << "\n";
-  OS << "      InfoType/InfoLength/Count/FnSize: "
-     << Fmt(Merged.InfoTypeInfoLengthCountAndFnSize) << " bytes "
-     << Pct(Merged.InfoTypeInfoLengthCountAndFnSize) << "\n";
-  OS << "      Size and name:   " << Fmt(Merged.SizeAndName) << " bytes "
-     << Pct(Merged.SizeAndName) << "\n";
-  OS << "      Line table info: " << Fmt(Merged.LineTableInfo) << " bytes "
-     << Pct(Merged.LineTableInfo) << "\n";
-  OS << "      Inline info:     " << Fmt(Merged.InlineInfo) << " bytes "
-     << Pct(Merged.InlineInfo) << "\n";
-  OS << "      Call site info:  " << Fmt(Merged.CallSiteInfo) << " bytes "
-     << Pct(Merged.CallSiteInfo) << "\n";
-  OS << "      Merged func info:" << Fmt(Merged.MergedFuncInfo) << " bytes "
-     << Pct(Merged.MergedFuncInfo) << "\n";
-  OS << "      End of list:     " << Fmt(Merged.EndOfList) << " bytes "
-     << Pct(Merged.EndOfList) << "\n";
-  OS << "  Padding:             " << Fmt(PaddingSize) << " bytes "
-     << Pct(PaddingSize) << "\n";
+  }
 }
 
 void GsymReader::dump(raw_ostream &OS, const FunctionInfo &FI,

--- a/llvm/test/tools/llvm-gsymutil/X86/statistics-detailed.yaml
+++ b/llvm/test/tools/llvm-gsymutil/X86/statistics-detailed.yaml
@@ -1,0 +1,255 @@
+# RUN: yaml2obj %s -o %t
+# RUN: llvm-gsymutil --convert %t --merged-functions --dwarf-callsites --output-version=2 -o %t.gsym
+# RUN: llvm-gsymutil --statistics %t.gsym 2>&1 | FileCheck %s --check-prefix=STATS
+# RUN: llvm-gsymutil --statistics=json %t.gsym 2>&1 | FileCheck %s --check-prefix=STATS-JSON
+# RUN: llvm-gsymutil --statistics=pretty-json %t.gsym 2>&1 | FileCheck %s --check-prefix=STATS-PRETTY
+
+# STATS: path: {{.*}}
+# STATS-NEXT: uuid: 01234567-89AB-CDEF-FEDC-BA9876543210
+# STATS-NEXT: num_addresses: 1
+# STATS-NEXT: byte-sizes {
+# STATS-NEXT:   file_size: 473
+# STATS-NEXT:   header: 20
+# STATS-NEXT:   global_data_directory: 140
+# STATS-NEXT:   uuid_section: 16
+# STATS-NEXT:   padding: 8
+# STATS-NEXT:   address_table: 1
+# STATS-NEXT:   addr_info_offsets: 8
+# STATS-NEXT:   file_table: 52
+# STATS-NEXT:   string_table: 43
+# STATS-NEXT:   function_info_data: 185
+# STATS-NEXT:   function_info_type_sizes {
+# STATS-NEXT:     size_and_name: 12
+# STATS-NEXT:     line_table_info: 32
+# STATS-NEXT:     inline_info: 0
+# STATS-NEXT:     call_site_info: 0
+# STATS-NEXT:     merged_func_info: 133
+# STATS-NEXT:     end_of_list: 8
+# STATS-NEXT:     padding: 0
+# STATS-NEXT:     merged_func_info_type_sizes {
+# STATS-NEXT:       infotype_infolength_count_and_fnsize: 16
+# STATS-NEXT:       size_and_name: 12
+# STATS-NEXT:       line_table_info: 32
+# STATS-NEXT:       inline_info: 40
+# STATS-NEXT:       call_site_info: 25
+# STATS-NEXT:       merged_func_info: 0
+# STATS-NEXT:       end_of_list: 8
+# STATS-NEXT:     }
+# STATS-NEXT:   }
+# STATS-NEXT: }
+
+# STATS-JSON: {"path":"{{.*}}","uuid":"01234567-89AB-CDEF-FEDC-BA9876543210","num_addresses":1,"byte-sizes":{"file_size":473,"header":20,"global_data_directory":140,"uuid_section":16,"padding":8,"address_table":1,"addr_info_offsets":8,"file_table":52,"string_table":43,"function_info_data":185,"function_info_type_sizes":{"size_and_name":12,"line_table_info":32,"inline_info":0,"call_site_info":0,"merged_func_info":133,"end_of_list":8,"padding":0,"merged_func_info_type_sizes":{"infotype_infolength_count_and_fnsize":16,"size_and_name":12,"line_table_info":32,"inline_info":40,"call_site_info":25,"merged_func_info":0,"end_of_list":8}}}}
+
+# STATS-PRETTY:      {
+# STATS-PRETTY-NEXT:   "path": "{{.*}}",
+# STATS-PRETTY-NEXT:   "uuid": "01234567-89AB-CDEF-FEDC-BA9876543210",
+# STATS-PRETTY-NEXT:   "num_addresses": 1,
+# STATS-PRETTY-NEXT:   "byte-sizes": {
+# STATS-PRETTY-NEXT:     "file_size": 473,
+# STATS-PRETTY-NEXT:     "header": 20,
+# STATS-PRETTY-NEXT:     "global_data_directory": 140,
+# STATS-PRETTY-NEXT:     "uuid_section": 16,
+# STATS-PRETTY-NEXT:     "padding": 8,
+# STATS-PRETTY-NEXT:     "address_table": 1,
+# STATS-PRETTY-NEXT:     "addr_info_offsets": 8,
+# STATS-PRETTY-NEXT:     "file_table": 52,
+# STATS-PRETTY-NEXT:     "string_table": 43,
+# STATS-PRETTY-NEXT:     "function_info_data": 185,
+# STATS-PRETTY-NEXT:     "function_info_type_sizes": {
+# STATS-PRETTY-NEXT:       "size_and_name": 12,
+# STATS-PRETTY-NEXT:       "line_table_info": 32,
+# STATS-PRETTY-NEXT:       "inline_info": 0,
+# STATS-PRETTY-NEXT:       "call_site_info": 0,
+# STATS-PRETTY-NEXT:       "merged_func_info": 133,
+# STATS-PRETTY-NEXT:       "end_of_list": 8,
+# STATS-PRETTY-NEXT:       "padding": 0,
+# STATS-PRETTY-NEXT:       "merged_func_info_type_sizes": {
+# STATS-PRETTY-NEXT:         "infotype_infolength_count_and_fnsize": 16,
+# STATS-PRETTY-NEXT:         "size_and_name": 12,
+# STATS-PRETTY-NEXT:         "line_table_info": 32,
+# STATS-PRETTY-NEXT:         "inline_info": 40,
+# STATS-PRETTY-NEXT:         "call_site_info": 25,
+# STATS-PRETTY-NEXT:         "merged_func_info": 0,
+# STATS-PRETTY-NEXT:         "end_of_list": 8
+# STATS-PRETTY-NEXT:       }
+# STATS-PRETTY-NEXT:     }
+# STATS-PRETTY-NEXT:   }
+# STATS-PRETTY-NEXT: }
+
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_EXEC
+  Machine:         EM_X86_64
+Sections:
+  - Name:            .note.gnu.build-id
+    Type:            SHT_NOTE
+    Flags:           [ SHF_ALLOC ]
+    Address:         0x0000000000000900
+    AddressAlign:    0x0000000000000004
+    Notes:
+      - Name:            GNU
+        Desc:            0123456789ABCDEFFEDCBA9876543210
+        Type:            0x00000003
+DWARF:
+  debug_str:
+    - ''
+    - /tmp/main.c
+    - main
+    - inline1
+    - dupfunc
+  debug_abbrev:
+    - Table:
+        - Code:            0x00000001
+          Tag:             DW_TAG_compile_unit
+          Children:        DW_CHILDREN_yes
+          Attributes:
+            - Attribute:       DW_AT_name
+              Form:            DW_FORM_strp
+            - Attribute:       DW_AT_low_pc
+              Form:            DW_FORM_addr
+            - Attribute:       DW_AT_high_pc
+              Form:            DW_FORM_data4
+            - Attribute:       DW_AT_language
+              Form:            DW_FORM_data2
+            - Attribute:       DW_AT_stmt_list
+              Form:            DW_FORM_sec_offset
+        - Code:            0x00000002
+          Tag:             DW_TAG_subprogram
+          Children:        DW_CHILDREN_yes
+          Attributes:
+            - Attribute:       DW_AT_name
+              Form:            DW_FORM_strp
+            - Attribute:       DW_AT_low_pc
+              Form:            DW_FORM_addr
+            - Attribute:       DW_AT_high_pc
+              Form:            DW_FORM_data4
+        - Code:            0x00000003
+          Tag:             DW_TAG_inlined_subroutine
+          Children:        DW_CHILDREN_no
+          Attributes:
+            - Attribute:       DW_AT_name
+              Form:            DW_FORM_strp
+            - Attribute:       DW_AT_low_pc
+              Form:            DW_FORM_addr
+            - Attribute:       DW_AT_high_pc
+              Form:            DW_FORM_data4
+            - Attribute:       DW_AT_call_file
+              Form:            DW_FORM_data4
+            - Attribute:       DW_AT_call_line
+              Form:            DW_FORM_data4
+        - Code:            0x00000004
+          Tag:             DW_TAG_call_site
+          Children:        DW_CHILDREN_no
+          Attributes:
+            - Attribute:       DW_AT_call_return_pc
+              Form:            DW_FORM_addr
+        - Code:            0x00000005
+          Tag:             DW_TAG_subprogram
+          Children:        DW_CHILDREN_no
+          Attributes:
+            - Attribute:       DW_AT_name
+              Form:            DW_FORM_strp
+            - Attribute:       DW_AT_low_pc
+              Form:            DW_FORM_addr
+            - Attribute:       DW_AT_high_pc
+              Form:            DW_FORM_data4
+  debug_info:
+    - Version:         4
+      AddrSize:        8
+      Entries:
+        - AbbrCode:        0x00000001
+          Values:
+            - Value:           0x0000000000000001
+            - Value:           0x0000000000001000
+            - Value:           0x0000000000001000
+            - Value:           0x0000000000000004
+            - Value:           0x0000000000000000
+        - AbbrCode:        0x00000002
+          Values:
+            - Value:           0x000000000000000D
+            - Value:           0x0000000000001000
+            - Value:           0x0000000000001000
+        - AbbrCode:        0x00000003
+          Values:
+            - Value:           0x0000000000000012
+            - Value:           0x0000000000001100
+            - Value:           0x0000000000000100
+            - Value:           0x0000000000000001
+            - Value:           0x000000000000000A
+        - AbbrCode:        0x00000004
+          Values:
+            - Value:           0x0000000000001010
+        - AbbrCode:        0x00000000
+        - AbbrCode:        0x00000005
+          Values:
+            - Value:           0x000000000000001A
+            - Value:           0x0000000000001000
+            - Value:           0x0000000000001000
+        - AbbrCode:        0x00000000
+  debug_line:
+    - Length:          96
+      Version:         2
+      PrologueLength:  46
+      MinInstLength:   1
+      DefaultIsStmt:   1
+      LineBase:        251
+      LineRange:       14
+      OpcodeBase:      13
+      StandardOpcodeLengths: [ 0, 1, 1, 1, 1, 0, 0, 0, 1, 0, 0, 1 ]
+      IncludeDirs:
+        - /tmp
+      Files:
+        - Name:            main.c
+          DirIdx:          1
+          ModTime:         0
+          Length:          0
+        - Name:            inline.h
+          DirIdx:          1
+          ModTime:         0
+          Length:          0
+      Opcodes:
+        - Opcode:          DW_LNS_extended_op
+          ExtLen:          9
+          SubOpcode:       DW_LNE_set_address
+          Data:            4096
+        - Opcode:          DW_LNS_advance_line
+          SData:           9
+          Data:            4096
+        - Opcode:          DW_LNS_copy
+          Data:            4096
+        - Opcode:          DW_LNS_advance_pc
+          Data:            256
+        - Opcode:          DW_LNS_set_file
+          Data:            2
+        - Opcode:          DW_LNS_advance_line
+          SData:           10
+          Data:            2
+        - Opcode:          DW_LNS_copy
+          Data:            2
+        - Opcode:          DW_LNS_advance_pc
+          Data:            128
+        - Opcode:          DW_LNS_advance_line
+          SData:           1
+          Data:            128
+        - Opcode:          DW_LNS_copy
+          Data:            128
+        - Opcode:          DW_LNS_advance_pc
+          Data:            128
+        - Opcode:          DW_LNS_set_file
+          Data:            1
+        - Opcode:          DW_LNS_advance_line
+          SData:           -10
+          Data:            1
+        - Opcode:          DW_LNS_copy
+          Data:            1
+        - Opcode:          DW_LNS_advance_pc
+          Data:            3584
+        - Opcode:          DW_LNS_advance_line
+          SData:           1
+          Data:            3584
+        - Opcode:          DW_LNS_extended_op
+          ExtLen:          1
+          SubOpcode:       DW_LNE_end_sequence
+          Data:            3584


### PR DESCRIPTION
668134e8acf10218663a0c33835bd4157ba358c4 introduces some printing, but uses an ad-hoc approach, manually creating output. This patch changes it to use a ScopedPrinter which prevents code duplication as ScopedPrinter automatically handles normal output and (pretty) JSON.

Also add a lit test to ensure that the textual output looks good, not just that the statistics are computed correctly like in the unit test.

Assisted by LLM.