### PR TITLE
[HIP] Remove device compilation from include path test

### DIFF
--- a/clang/test/Driver/hip-include-path.hip
+++ b/clang/test/Driver/hip-include-path.hip
@@ -20,10 +20,6 @@
 // RUN:   -std=c++11 --rocm-path=%S/Inputs/rocm -nogpulib -nostdinc++ %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=COMMON,CLANG,HIP -DRESOURCE_DIR=%clang-resource-dir %s
 
-// RUN: %clang -fsyntax-only --target=x86_64-unknown-linux-gnu \
-// RUN:   --cuda-gpu-arch=gfx900 -std=c++11 --rocm-path=%S/Inputs/rocm \
-// RUN:   -nogpulib -nohipwrapperinc %s
-
 // RUN: %clang -c -### --target=x86_64-unknown-linux-gnu --cuda-gpu-arch=gfx900 \
 // RUN:   -std=c++11 --rocm-path=%S/Inputs/rocm-invalid -nogpulib %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=NOLIBHIPCXX %s
@@ -77,5 +73,3 @@
 
 // HOSTINC-LABEL: "{{[^"]*}}clang{{[^"]*}}" "-cc1" "-triple" "amdgcn-amd-amdhsa"
 // HOSTINC: "-internal-externc-isystem" "{{[^"]*}}Inputs/basic_linux_tree/usr/include"
-
-#include <cuda/std/atomic>


### PR DESCRIPTION
The libhipcxx test checks the include paths produced by the driver. It
also ran a HIP device compilation, which requires the AMDGPU target and
fails in builds that do not enable it.

Remove the compilation and keep the driver command checks enabled in
all builds.

Buildbot failure: https://lab.llvm.org/buildbot/#/builders/225/builds/14729
