### PR TITLE
[lld][ELF] Add option to prevent debuginfo tombstoning

### DIFF
--- a/lld/ELF/Config.h
+++ b/lld/ELF/Config.h
@@ -371,6 +371,7 @@ struct Config {
   bool gnuUnique;
   bool ignoreDataAddressEquality;
   bool ignoreFunctionAddressEquality;
+  bool keepFoldedDebugInfo;
   bool ltoCSProfileGenerate;
   bool ltoPGOWarnMismatch;
   bool ltoDebugPassManager;

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -1471,6 +1471,8 @@ static void readConfigs(Ctx &ctx, opt::InputArgList &args) {
   ctx.arg.ignoreFunctionAddressEquality =
       args.hasArg(OPT_ignore_function_address_equality);
   ctx.arg.init = args.getLastArgValue(OPT_init, "_init");
+  ctx.arg.keepFoldedDebugInfo = args.hasFlag(
+      OPT_keep_folded_debug_info, OPT_no_keep_folded_debug_info, false);
   ctx.arg.ltoAAPipeline = args.getLastArgValue(OPT_lto_aa_pipeline);
   ctx.arg.ltoCSProfileGenerate = args.hasArg(OPT_lto_cs_profile_generate);
   ctx.arg.ltoCSProfileFile = args.getLastArgValue(OPT_lto_cs_profile_file);

--- a/lld/ELF/InputSection.cpp
+++ b/lld/ELF/InputSection.cpp
@@ -1131,7 +1131,7 @@ void InputSection::relocateNonAlloc(Ctx &ctx, uint8_t *buf,
       //
       // TODO To reduce disruption, we use 0 instead of -1 as the tombstone
       // value. Enable -1 in a future release.
-      if (!ds || (ds->folded && !isDebugLine)) {
+      if (!ds || (!ctx.arg.keepFoldedDebugInfo && ds->folded && !isDebugLine)) {
         // If -z dead-reloc-in-nonalloc= is specified, respect it.
         uint64_t value = SignExtend64<bits>(*tombstone);
         // For a 32-bit local TU reference in .debug_names, X86_64::relocate

--- a/lld/ELF/Options.td
+++ b/lld/ELF/Options.td
@@ -315,6 +315,10 @@ defm init: Eq<"init", "Specify an initializer function">,
 
 defm just_symbols: Eq<"just-symbols", "Just link symbols">;
 
+defm keep_folded_debug_info: BB<"keep-folded-debug-info",
+  "Preserve debug information for folded symbols",
+  "Tombstone relocations referencing folded symbols (default)">;
+
 defm keep_unique: Eq<"keep-unique", "Do not fold this symbol during ICF">;
 
 def library: JoinedOrSeparate<["-"], "l">, MetaVarName<"<libname>">,

--- a/lld/test/ELF/debug-dead-reloc-icf.s
+++ b/lld/test/ELF/debug-dead-reloc-icf.s
@@ -8,8 +8,13 @@
 # RUN: ld.lld --icf=all %t.o -o %t
 # RUN: llvm-objdump -s %t | FileCheck %s
 
+# RUN: ld.lld %t.o --icf=all --keep-folded-debug-info -o %t.kept
+# RUN: llvm-objdump -s %t.kept | FileCheck %s --check-prefix=KEPT
+
 # CHECK:      Contents of section .debug_info:
 # CHECK-NEXT:  0000 {{[0-9a-f]+}}000 00000000 00000000 00000000
+# KEPT:       Contents of section .debug_info:
+# KEPT-NEXT:   0000 [[ADDR:[0-9a-f]+]] 00000000 [[ADDR]] 00000000
 # CHECK:      Contents of section .debug_line:
 # CHECK-NEXT:  0000 [[ADDR:[0-9a-f]+]] 00000000
 # CHECK-SAME:                                   [[ADDR]] 00000000


### PR DESCRIPTION
There is some tooling that supports dealing with merged functions produced by ICF (multiple debuginfo entries per address), such as llvm-gsymutil. Other tooling is also likely to support this in the future. Given that, add an option to disable linker tombstoning so these tools have the additional information they need to work with ICF.

This is somewhat equivalent to `--keep-icf-stabs` in the MachO port of lld.