### PR TITLE
[lldb] Pass a Target to Platform::GetSharedModule

### DIFF
--- a/lldb/include/lldb/Target/Platform.h
+++ b/lldb/include/lldb/Target/Platform.h
@@ -304,17 +304,15 @@ public:
   /// \param[in] module_spec
   ///     The ModuleSpec of a binary to find.
   ///
-  /// \param[in] process
-  ///     A Process.
+  /// \param[in] target
+  ///     The Target the binary is being located for. Its settings guide the
+  ///     search, and it may not have a Process yet.
   ///
   /// \param[out] module_sp
   ///     A Module that matches the ModuleSpec, if one is found.
   ///
-  /// \param[in] module_search_paths_ptr
-  ///     Locations to possibly look for a binary that matches the ModuleSpec.
-  ///
   /// \param[out] old_modules
-  ///     Existing Modules in the Process' Target image list which match
+  ///     Existing Modules in the Target's image list which match
   ///     the FileSpec.
   ///
   /// \param[out] did_create_ptr
@@ -327,11 +325,9 @@ public:
   /// \return
   ///     The Status object for any errors found while searching for
   ///     the binary.
-  virtual Status
-  GetSharedModule(const ModuleSpec &module_spec, Process *process,
-                  lldb::ModuleSP &module_sp,
-                  llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules,
-                  bool *did_create_ptr);
+  virtual Status GetSharedModule(
+      const ModuleSpec &module_spec, Target &target, lldb::ModuleSP &module_sp,
+      llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules, bool *did_create_ptr);
 
   void CallLocateModuleCallbackIfSet(const ModuleSpec &module_spec,
                                      lldb::ModuleSP &module_sp,
@@ -1137,7 +1133,10 @@ protected:
 private:
   typedef std::function<Status(const ModuleSpec &)> ModuleResolver;
 
-  Status GetRemoteSharedModule(const ModuleSpec &module_spec, Process *process,
+  /// \param[in] target
+  ///     The Target the binary is being located for, or nullptr when the
+  ///     lookup is not on behalf of one.
+  Status GetRemoteSharedModule(const ModuleSpec &module_spec, Target *target,
                                lldb::ModuleSP &module_sp,
                                const ModuleResolver &module_resolver,
                                bool *did_create_ptr);

--- a/lldb/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
+++ b/lldb/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
@@ -811,7 +811,7 @@ bool DynamicLoaderDarwinKernel::KextImageInfo::LoadImageUsingMemoryModule(
       // system.
       PlatformSP platform_sp(target.GetPlatform());
       if (platform_sp) {
-        platform_sp->GetSharedModule(module_spec, process, m_module_sp, nullptr,
+        platform_sp->GetSharedModule(module_spec, target, m_module_sp, nullptr,
                                      nullptr);
       }
 

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformAppleSimulator.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformAppleSimulator.cpp
@@ -417,12 +417,12 @@ Status PlatformAppleSimulator::GetSymbolFile(const FileSpec &platform_file,
 }
 
 Status PlatformAppleSimulator::GetSharedModule(
-    const ModuleSpec &module_spec, Process *process, ModuleSP &module_sp,
+    const ModuleSpec &module_spec, Target &target, ModuleSP &module_sp,
     llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules, bool *did_create_ptr) {
 
   Status error;
-  error = GetModuleFromSharedCaches(module_spec, process, module_sp,
-                                    old_modules, did_create_ptr);
+  error = GetModuleFromSharedCaches(module_spec, target, module_sp, old_modules,
+                                    did_create_ptr);
   if (module_sp)
     return error;
 

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformAppleSimulator.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformAppleSimulator.h
@@ -87,7 +87,7 @@ public:
   std::vector<ArchSpec>
   GetSupportedArchitectures(const ArchSpec &process_host_arch) override;
 
-  Status GetSharedModule(const ModuleSpec &module_spec, Process *process,
+  Status GetSharedModule(const ModuleSpec &module_spec, Target &target,
                          lldb::ModuleSP &module_sp,
                          llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules,
                          bool *did_create_ptr) override;

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -343,7 +343,7 @@ Status PlatformDarwin::ResolveSymbolFile(Target &target,
 }
 
 Status PlatformDarwin::GetSharedModule(
-    const ModuleSpec &module_spec, Process *process, ModuleSP &module_sp,
+    const ModuleSpec &module_spec, Target &target, ModuleSP &module_sp,
     llvm::SmallVectorImpl<ModuleSP> *old_modules, bool *did_create_ptr) {
   Status error;
   module_sp.reset();
@@ -353,21 +353,17 @@ Status PlatformDarwin::GetSharedModule(
     // module first.
     if (m_remote_platform_sp) {
       error = m_remote_platform_sp->GetSharedModule(
-          module_spec, process, module_sp, old_modules, did_create_ptr);
+          module_spec, target, module_sp, old_modules, did_create_ptr);
     }
   }
 
   if (!module_sp) {
     // Fall back to the local platform and find the file locally
-    error = Platform::GetSharedModule(module_spec, process, module_sp,
+    error = Platform::GetSharedModule(module_spec, target, module_sp,
                                       old_modules, did_create_ptr);
 
     const FileSpec &platform_file = module_spec.GetFileSpec();
-    // Get module search paths from the target if available.
-    TargetSP target_sp = module_spec.GetTargetSP();
-    FileSpecList module_search_paths;
-    if (target_sp)
-      module_search_paths = target_sp->GetExecutableSearchPaths();
+    FileSpecList module_search_paths = target.GetExecutableSearchPaths();
     if (!module_sp && !module_search_paths.IsEmpty() && platform_file) {
       // We can try to pull off part of the file path up to the bundle
       // directory level and try any module search paths...
@@ -377,7 +373,7 @@ Status PlatformDarwin::GetSharedModule(
           ModuleSpec new_module_spec(module_spec);
           new_module_spec.GetFileSpec() = bundle_directory;
           if (Host::ResolveExecutableInBundle(new_module_spec.GetFileSpec())) {
-            Status new_error(Platform::GetSharedModule(new_module_spec, process,
+            Status new_error(Platform::GetSharedModule(new_module_spec, target,
                                                        module_sp, old_modules,
                                                        did_create_ptr));
 
@@ -405,7 +401,7 @@ Status PlatformDarwin::GetSharedModule(
                 ModuleSpec new_module_spec(module_spec);
                 new_module_spec.GetFileSpec() = new_file_spec;
                 Status new_error(Platform::GetSharedModule(
-                    new_module_spec, process, module_sp, old_modules,
+                    new_module_spec, target, module_sp, old_modules,
                     did_create_ptr));
 
                 if (module_sp) {
@@ -424,13 +420,14 @@ Status PlatformDarwin::GetSharedModule(
   return error;
 }
 Status PlatformDarwin::GetModuleFromSharedCaches(
-    const ModuleSpec &module_spec, Process *process, ModuleSP &module_sp,
+    const ModuleSpec &module_spec, Target &target, ModuleSP &module_sp,
     llvm::SmallVectorImpl<ModuleSP> *old_modules, bool *did_create_ptr) {
   Status err;
 
   SymbolSharedCacheUse sc_mode =
       ModuleList::GetGlobalModuleListProperties().GetSharedCacheBinaryLoading();
   SharedCacheImageInfo image_info;
+  Process *process = target.GetProcessSP().get();
   if (process && process->GetDynamicLoader()) {
     addr_t sc_base_addr;
     UUID sc_uuid;
@@ -1362,13 +1359,10 @@ PlatformDarwin::LaunchProcess(lldb_private::ProcessLaunchInfo &launch_info) {
 }
 
 lldb_private::Status PlatformDarwin::FindBundleBinaryInExecSearchPaths(
-    const ModuleSpec &module_spec, Process *process, ModuleSP &module_sp,
+    const ModuleSpec &module_spec, Target &target, ModuleSP &module_sp,
     llvm::SmallVectorImpl<ModuleSP> *old_modules, bool *did_create_ptr) {
   const FileSpec &platform_file = module_spec.GetFileSpec();
-  TargetSP target_sp = module_spec.GetTargetSP();
-  FileSpecList module_search_paths;
-  if (target_sp)
-    module_search_paths = target_sp->GetExecutableSearchPaths();
+  FileSpecList module_search_paths = target.GetExecutableSearchPaths();
   // See if the file is present in any of the module_search_paths
   // directories.
   if (!module_sp && !module_search_paths.IsEmpty() && platform_file) {
@@ -1419,9 +1413,8 @@ lldb_private::Status PlatformDarwin::FindBundleBinaryInExecSearchPaths(
         if (FileSystem::Instance().Exists(path_to_try)) {
           ModuleSpec new_module_spec(module_spec);
           new_module_spec.GetFileSpec() = path_to_try;
-          Status new_error(Platform::GetSharedModule(new_module_spec, process,
-                                                     module_sp, old_modules,
-                                                     did_create_ptr));
+          Status new_error(Platform::GetSharedModule(
+              new_module_spec, target, module_sp, old_modules, did_create_ptr));
 
           if (module_sp) {
             module_sp->SetPlatformFileSpec(path_to_try);

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
@@ -73,16 +73,14 @@ public:
 
   bool IsSymbolFileTrusted(Module &module) override;
 
-  Status GetSharedModule(const ModuleSpec &module_spec, Process *process,
+  Status GetSharedModule(const ModuleSpec &module_spec, Target &target,
                          lldb::ModuleSP &module_sp,
                          llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules,
                          bool *did_create_ptr) override;
 
-  Status
-  GetModuleFromSharedCaches(const ModuleSpec &module_spec, Process *process,
-                            lldb::ModuleSP &module_sp,
-                            llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules,
-                            bool *did_create_ptr);
+  Status GetModuleFromSharedCaches(
+      const ModuleSpec &module_spec, Target &target, lldb::ModuleSP &module_sp,
+      llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules, bool *did_create_ptr);
 
   size_t GetSoftwareBreakpointTrapOpcode(Target &target,
                                          BreakpointSite *bp_site) override;
@@ -225,8 +223,7 @@ protected:
                                              XcodeSDK::Type sdk_type);
 
   Status FindBundleBinaryInExecSearchPaths(
-      const ModuleSpec &module_spec, Process *process,
-      lldb::ModuleSP &module_sp,
+      const ModuleSpec &module_spec, Target &target, lldb::ModuleSP &module_sp,
       llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules, bool *did_create_ptr);
 
   // The OSType where lldb is running.

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinDevice.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinDevice.cpp
@@ -272,7 +272,7 @@ BringInRemoteFile(Platform *platform,
 lldb_private::Status PlatformDarwinDevice::GetSharedModuleWithLocalCache(
     const lldb_private::ModuleSpec &module_spec, lldb::ModuleSP &module_sp,
     llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules, bool *did_create_ptr,
-    Process *process) {
+    Target &target) {
 
   Log *log = GetLog(LLDBLog::Platform);
   LLDB_LOG(log,
@@ -289,8 +289,8 @@ lldb_private::Status PlatformDarwinDevice::GetSharedModuleWithLocalCache(
   Status err;
 
   if (CheckLocalSharedCache()) {
-    err = GetModuleFromSharedCaches(module_spec, process, module_sp,
-                                    old_modules, did_create_ptr);
+    err = GetModuleFromSharedCaches(module_spec, target, module_sp, old_modules,
+                                    did_create_ptr);
     if (module_sp)
       return err;
   }

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinDevice.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinDevice.h
@@ -27,7 +27,7 @@ protected:
   virtual Status GetSharedModuleWithLocalCache(
       const ModuleSpec &module_spec, lldb::ModuleSP &module_sp,
       llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules, bool *did_create_ptr,
-      lldb_private::Process *process);
+      Target &target);
 
   struct SDKDirectoryInfo {
     SDKDirectoryInfo(const FileSpec &sdk_dir_spec, llvm::StringRef dirname_str);

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp
@@ -666,9 +666,11 @@ bool PlatformDarwinKernel::KerneldSYMHasNoSiblingBinary(
   if (kernel_dsym.GetFileNameExtension() != g_dsym_suffix)
     return false;
 
+  // Chop off the '.dSYM' extension. A FileSpec owns its filename storage, so
+  // the new name has to be copied out before it can be assigned back.
+  std::string binary_filename(kernel_dsym.GetFileNameStrippingExtension());
   FileSpec binary_filespec = kernel_dsym;
-  // Chop off the '.dSYM' extension on the filename
-  binary_filespec.SetFilename(binary_filespec.GetFileNameStrippingExtension());
+  binary_filespec.SetFilename(binary_filename);
 
   // Is there a binary next to this this?  Then return false.
   if (FileSystem::Instance().Exists(binary_filespec))
@@ -717,7 +719,7 @@ void PlatformDarwinKernel::UpdateKextandKernelsLocalScan() {
 }
 
 Status PlatformDarwinKernel::GetSharedModule(
-    const ModuleSpec &module_spec, Process *process, ModuleSP &module_sp,
+    const ModuleSpec &module_spec, Target &target, ModuleSP &module_sp,
     llvm::SmallVectorImpl<ModuleSP> *old_modules, bool *did_create_ptr) {
   Status error;
   module_sp.reset();
@@ -731,25 +733,25 @@ Status PlatformDarwinKernel::GetSharedModule(
     // DynamicLoaderDarwinKernel uses the magic name mach_kernel,
     // UUID search can get here with no name - and it may be a kernel.
     if (kext_bundle_id == "mach_kernel" || kext_bundle_id.empty()) {
-      error = GetSharedModuleKernel(module_spec, process, module_sp,
-                                    old_modules, did_create_ptr);
+      error = GetSharedModuleKernel(module_spec, target, module_sp, old_modules,
+                                    did_create_ptr);
       if (error.Success() && module_sp) {
         return error;
       }
     } else {
-      return GetSharedModuleKext(module_spec, process, module_sp, old_modules,
+      return GetSharedModuleKext(module_spec, target, module_sp, old_modules,
                                  did_create_ptr);
     }
   }
 
   // Give the generic methods, including possibly calling into DebugSymbols
   // framework on macOS systems, a chance.
-  return PlatformDarwin::GetSharedModule(module_spec, process, module_sp,
+  return PlatformDarwin::GetSharedModule(module_spec, target, module_sp,
                                          old_modules, did_create_ptr);
 }
 
 Status PlatformDarwinKernel::GetSharedModuleKext(
-    const ModuleSpec &module_spec, Process *process, ModuleSP &module_sp,
+    const ModuleSpec &module_spec, Target &target, ModuleSP &module_sp,
     llvm::SmallVectorImpl<ModuleSP> *old_modules, bool *did_create_ptr) {
   Status error;
   module_sp.reset();
@@ -776,7 +778,7 @@ Status PlatformDarwinKernel::GetSharedModuleKext(
 
   // Give the generic methods, including possibly calling into  DebugSymbols
   // framework on macOS systems, a chance.
-  error = PlatformDarwin::GetSharedModule(module_spec, process, module_sp,
+  error = PlatformDarwin::GetSharedModule(module_spec, target, module_sp,
                                           old_modules, did_create_ptr);
   if (error.Success() && module_sp.get()) {
     return error;
@@ -786,7 +788,7 @@ Status PlatformDarwinKernel::GetSharedModuleKext(
 }
 
 Status PlatformDarwinKernel::GetSharedModuleKernel(
-    const ModuleSpec &module_spec, Process *process, ModuleSP &module_sp,
+    const ModuleSpec &module_spec, Target &target, ModuleSP &module_sp,
     llvm::SmallVectorImpl<ModuleSP> *old_modules, bool *did_create_ptr) {
   assert(module_sp.get() == nullptr);
   UpdateKextandKernelsLocalScan();
@@ -805,8 +807,7 @@ Status PlatformDarwinKernel::GetSharedModuleKernel(
         // way it ends up in the index), but it might be a
         // .dSYM.yaa that needs to be expanded, don't just
         // append ".dSYM" to the filename for the SymbolFile.
-        FileSpecList search_paths =
-            process->GetTarget().GetDebugFileSearchPaths();
+        FileSpecList search_paths = target.GetDebugFileSearchPaths();
         FileSpec dsym_fspec = PluginManager::LocateExecutableSymbolFile(
             kern_spec, search_paths, module_sp->GetSymbolLocatorStatistics());
         if (FileSystem::Instance().Exists(dsym_fspec))
@@ -840,7 +841,7 @@ Status PlatformDarwinKernel::GetSharedModuleKernel(
 
   // Give the generic methods, including possibly calling into DebugSymbols
   // framework on macOS systems, a chance.
-  return PlatformDarwin::GetSharedModule(module_spec, process, module_sp,
+  return PlatformDarwin::GetSharedModule(module_spec, target, module_sp,
                                          old_modules, did_create_ptr);
 }
 

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.h
@@ -58,7 +58,7 @@ public:
 
   void GetStatus(Stream &strm) override;
 
-  Status GetSharedModule(const ModuleSpec &module_spec, Process *process,
+  Status GetSharedModule(const ModuleSpec &module_spec, Target &target,
                          lldb::ModuleSP &module_sp,
                          llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules,
                          bool *did_create_ptr) override;
@@ -139,16 +139,14 @@ protected:
   static std::vector<FileSpec>
   GetDWARFBinaryInDSYMBundle(const FileSpec &dsym_bundle);
 
-  Status GetSharedModuleKext(const ModuleSpec &module_spec, Process *process,
+  Status GetSharedModuleKext(const ModuleSpec &module_spec, Target &target,
                              lldb::ModuleSP &module_sp,
                              llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules,
                              bool *did_create_ptr);
 
-  Status
-  GetSharedModuleKernel(const ModuleSpec &module_spec, Process *process,
-                        lldb::ModuleSP &module_sp,
-                        llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules,
-                        bool *did_create_ptr);
+  Status GetSharedModuleKernel(
+      const ModuleSpec &module_spec, Target &target, lldb::ModuleSP &module_sp,
+      llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules, bool *did_create_ptr);
 
   Status ExamineKextForMatchingUUID(const FileSpec &kext_bundle_path,
                                     const UUID &uuid, const ArchSpec &arch,

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformMacOSX.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformMacOSX.cpp
@@ -176,11 +176,11 @@ PlatformMacOSX::GetSupportedArchitectures(const ArchSpec &process_host_arch) {
 }
 
 lldb_private::Status PlatformMacOSX::GetSharedModule(
-    const lldb_private::ModuleSpec &module_spec, Process *process,
+    const lldb_private::ModuleSpec &module_spec, Target &target,
     lldb::ModuleSP &module_sp,
     llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules, bool *did_create_ptr) {
   Status error = GetSharedModuleWithLocalCache(
-      module_spec, module_sp, old_modules, did_create_ptr, process);
+      module_spec, module_sp, old_modules, did_create_ptr, target);
 
   if (module_sp) {
     if (module_spec.GetArchitecture().GetCore() ==
@@ -195,7 +195,7 @@ lldb_private::Status PlatformMacOSX::GetSharedModule(
         bool did_create = false;
         Status x86_64_error = GetSharedModuleWithLocalCache(
             module_spec_x86_64, x86_64_module_sp, &old_x86_64_modules,
-            &did_create, process);
+            &did_create, target);
         if (x86_64_module_sp && x86_64_module_sp->GetObjectFile()) {
           module_sp = x86_64_module_sp;
           if (old_modules)
@@ -210,7 +210,7 @@ lldb_private::Status PlatformMacOSX::GetSharedModule(
   }
 
   if (!module_sp) {
-    error = FindBundleBinaryInExecSearchPaths(module_spec, process, module_sp,
+    error = FindBundleBinaryInExecSearchPaths(module_spec, target, module_sp,
                                               old_modules, did_create_ptr);
   }
   return error;

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformMacOSX.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformMacOSX.h
@@ -46,7 +46,7 @@ public:
 
   llvm::StringRef GetPluginName() override { return GetPluginNameStatic(); }
 
-  Status GetSharedModule(const ModuleSpec &module_spec, Process *process,
+  Status GetSharedModule(const ModuleSpec &module_spec, Target &target,
                          lldb::ModuleSP &module_sp,
                          llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules,
                          bool *did_create_ptr) override;

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteDarwinDevice.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteDarwinDevice.cpp
@@ -157,7 +157,7 @@ Status PlatformRemoteDarwinDevice::GetSymbolFile(const FileSpec &platform_file,
 }
 
 Status PlatformRemoteDarwinDevice::GetSharedModule(
-    const ModuleSpec &module_spec, Process *process, ModuleSP &module_sp,
+    const ModuleSpec &module_spec, Target &target, ModuleSP &module_sp,
     llvm::SmallVectorImpl<ModuleSP> *old_modules, bool *did_create_ptr) {
   // For iOS, the SDK files are all cached locally on the host system. So first
   // we ask for the file in the cached SDK, then we attempt to get a shared
@@ -262,7 +262,7 @@ Status PlatformRemoteDarwinDevice::GetSharedModule(
   // This may not be an SDK-related module.  Try whether we can bring in the
   // thing to our local cache.
   error = GetSharedModuleWithLocalCache(module_spec, module_sp, old_modules,
-                                        did_create_ptr, process);
+                                        did_create_ptr, target);
   if (error.Success())
     return error;
 
@@ -270,7 +270,7 @@ Status PlatformRemoteDarwinDevice::GetSharedModule(
   // directories.
   if (!module_sp)
     error = PlatformDarwin::FindBundleBinaryInExecSearchPaths(
-        module_spec, process, module_sp, old_modules, did_create_ptr);
+        module_spec, target, module_sp, old_modules, did_create_ptr);
 
   if (error.Success())
     return error;

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteDarwinDevice.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteDarwinDevice.h
@@ -45,7 +45,7 @@ public:
   virtual Status GetSymbolFile(const FileSpec &platform_file,
                                const UUID *uuid_ptr, FileSpec &local_file);
 
-  Status GetSharedModule(const ModuleSpec &module_spec, Process *process,
+  Status GetSharedModule(const ModuleSpec &module_spec, Target &target,
                          lldb::ModuleSP &module_sp,
                          llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules,
                          bool *did_create_ptr) override;

--- a/lldb/source/Target/Platform.cpp
+++ b/lldb/source/Target/Platform.cpp
@@ -257,7 +257,7 @@ Platform::LocateExecutableScriptingResources(Target *target, Module &module,
 }
 
 Status Platform::GetSharedModule(
-    const ModuleSpec &module_spec, Process *process, ModuleSP &module_sp,
+    const ModuleSpec &module_spec, Target &target, ModuleSP &module_sp,
     llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules, bool *did_create_ptr) {
   if (IsHost())
     // Note: module_search_paths_ptr functionality is now handled internally
@@ -293,7 +293,7 @@ Status Platform::GetSharedModule(
     return error;
   };
 
-  return GetRemoteSharedModule(module_spec, process, module_sp, resolver,
+  return GetRemoteSharedModule(module_spec, &target, module_sp, resolver,
                                did_create_ptr);
 }
 
@@ -1542,7 +1542,7 @@ Status Platform::GetCachedExecutable(ModuleSpec &module_spec,
                                      lldb::ModuleSP &module_sp) {
   FileSpec platform_spec = module_spec.GetFileSpec();
   Status error = GetRemoteSharedModule(
-      module_spec, nullptr, module_sp,
+      module_spec, /*target=*/nullptr, module_sp,
       [&](const ModuleSpec &spec) {
         return Platform::ResolveExecutable(spec, module_sp);
       },
@@ -1556,7 +1556,7 @@ Status Platform::GetCachedExecutable(ModuleSpec &module_spec,
 }
 
 Status Platform::GetRemoteSharedModule(const ModuleSpec &module_spec,
-                                       Process *process,
+                                       Target *target,
                                        lldb::ModuleSP &module_sp,
                                        const ModuleResolver &module_resolver,
                                        bool *did_create_ptr) {
@@ -1564,7 +1564,7 @@ Status Platform::GetRemoteSharedModule(const ModuleSpec &module_spec,
   ModuleSpec resolved_module_spec;
   ArchSpec process_host_arch;
   bool got_module_spec = false;
-  if (process) {
+  if (Process *process = target ? target->GetProcessSP().get() : nullptr) {
     process_host_arch = process->GetSystemArchitecture();
     // Try to get module information from the process
     if (process->GetModuleSpec(module_spec.GetFileSpec(),

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2541,8 +2541,7 @@ ModuleSP Target::GetOrCreateModule(const ModuleSpec &orig_module_spec,
         // module in the shared module cache.
         if (m_platform_sp) {
           error = m_platform_sp->GetSharedModule(
-              module_spec, m_process_sp.get(), module_sp, &old_modules,
-              &did_create_module);
+              module_spec, *this, module_sp, &old_modules, &did_create_module);
         } else {
           error = Status::FromErrorString("no platform is currently set");
         }

--- a/lldb/test/API/macosx/load-kext/TestLoadKext.py
+++ b/lldb/test/API/macosx/load-kext/TestLoadKext.py
@@ -3,6 +3,8 @@ Test loading of a kext binary.
 """
 
 
+import os
+
 import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
@@ -25,3 +27,36 @@ class LoadKextTestCase(TestBase):
         self.assertEqual(target.GetNumModules(), 1)
         mod = target.GetModuleAtIndex(0)
         self.assertEqual(mod.GetFileSpec().GetFilename(), "mykext")
+
+    @skipUnlessDarwin
+    def test_kernel_lookup_by_uuid_without_a_process(self):
+        """Search the darwin-kernel platform for a kernel before there is a
+        process to search on behalf of."""
+
+        # PlatformDarwinKernel only indexes a kernel binary that has a .dSYM
+        # sibling, and only that branch goes looking for a symbol file.
+        kernel_dir = self.getBuildArtifact("kernels")
+        lldbutil.mkdir_p(kernel_dir)
+        kernel = os.path.join(kernel_dir, "kernel.test")
+        self.yaml2obj("mykext.yaml", kernel)
+        lldbutil.mkdir_p(kernel + ".dSYM")
+
+        self.runCmd(
+            "settings set platform.plugin.darwin-kernel.kext-directories " + kernel_dir
+        )
+        self.runCmd("platform select darwin-kernel")
+
+        def cleanup():
+            self.runCmd("platform select host")
+            self.runCmd("settings clear platform.plugin.darwin-kernel.kext-directories")
+
+        self.addTearDownHook(cleanup)
+
+        target = self.dbg.CreateTarget("")
+        self.assertTrue(target.IsValid())
+
+        # A UUID with no file name reaches the kernel branch of
+        # PlatformDarwinKernel::GetSharedModule, which matches the binary above
+        # and then searches for its symbols. There is no process here, and the
+        # search must not need one.
+        target.AddModule(None, None, "17A97B33-09B7-3195-9408-DBD965D578A5")


### PR DESCRIPTION
PlatformDarwinKernel::GetSharedModuleKernel unconditionally dereferenced the process to reach the target's debug file search paths. The Process * is the wrong thing to be threading through Platform::GetSharedModule. Refactor Platform::GetSharedModule to take a `Target &` and get the process from the target if we really need it.