### PR TITLE
[lldb] Report a corefile whose only image is a platform binary

### DIFF
--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -6694,6 +6694,7 @@ bool ObjectFileMachO::LoadCoreFileImages(lldb_private::Process &process) {
                 "ObjectFileMachO::%s binary at 0x%" PRIx64
                 " is a platform binary, has been handled by a Platform plugin.",
                 __FUNCTION__, image.load_address);
+      found_platform_binary = true;
       continue;
     }
 
@@ -6748,8 +6749,9 @@ bool ObjectFileMachO::LoadCoreFileImages(lldb_private::Process &process) {
                       module_sp->GetFileSpec().GetPath().c_str(),
                       uuidstr.c_str());
         }
+        ObjectFile *objfile = module_sp->GetObjectFile();
+        SectionList *sectlist = objfile ? objfile->GetSectionList() : nullptr;
         for (auto name_vmaddr_tuple : image.segment_load_addresses) {
-          SectionList *sectlist = module_sp->GetObjectFile()->GetSectionList();
           if (sectlist) {
             SectionSP sect_sp =
                 sectlist->FindSectionByName(std::get<0>(name_vmaddr_tuple));


### PR DESCRIPTION
found_platform_binary was tested but never assigned, so the early return it guards was dead and LoadCoreFileImages reported failure for a corefile whose only image a Platform plugin had already taken care of. The caller reads that as "no binary found in the metadata" and goes on to scan low memory for a UUID that has no reason to be there.

While here, stop assuming the module has an object file before asking it for its sections. A binary located by an external symbol server is turned into a Module without checking that it parses, and LoadBinaryInTarget guards the same dereference on the other branch.

Assisted-by: Claude