### PR TITLE
[SLP] Fix SmallVector<VFInfo> static assertion in SLPCompatibilityAnalysis

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer/SLPCompatibilityAnalysis.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer/SLPCompatibilityAnalysis.cpp
@@ -612,7 +612,7 @@ InstructionsState getSameOpcode(ArrayRef<Value *> VL,
   // Check for one alternate opcode from another BinaryOperator.
   // TODO - generalize to support all operators (types, calls etc.).
   Intrinsic::ID BaseID = 0;
-  SmallVector<VFInfo> BaseMappings;
+  SmallVector<VFInfo, 4> BaseMappings;
   if (auto *CallBase = dyn_cast<CallInst>(MainOp)) {
     BaseID = getVectorIntrinsicIDForCall(CallBase, &TLI);
     BaseMappings = VFDatabase(*CallBase).getMappings(*CallBase);
@@ -723,7 +723,8 @@ InstructionsState getSameOpcode(ArrayRef<Value *> VL,
         if (ID != BaseID && Equivalent == Intrinsic::not_intrinsic)
           return InstructionsState::invalid();
         if (!ID) {
-          SmallVector<VFInfo> Mappings = VFDatabase(*Call).getMappings(*Call);
+          SmallVector<VFInfo, 4> Mappings =
+              VFDatabase(*Call).getMappings(*Call);
           if (Mappings.size() != BaseMappings.size() ||
               Mappings.front().ISA != BaseMappings.front().ISA ||
               Mappings.front().ScalarName != BaseMappings.front().ScalarName ||


### PR DESCRIPTION
sizeof(VFInfo) is 280 bytes, exceeding SmallVector's default 256-byte inline-storage limit, which trips a static_assert in debug builds. Explicitly specify an inline element count of 4, matching the existing convention used elsewhere for SmallVector<VFInfo, N> (e.g. Intel_SLPVectorizer.cpp, VectorUtils.h).
Guilty commit: fb831c73635a