### PR TITLE
[X86] Reject scaling a parenthesized subexpression containing a register

### DIFF
--- a/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
+++ b/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
@@ -461,6 +461,17 @@ private:
     SMLoc OffsetOperatorLoc;
     AsmTypeInfo CurType;
 
+    // Registers are tracked as base, index and scale rather than through the
+    // infix calculator, so a register inside parentheses that the parentheses
+    // are then scaled by loses the scale entirely. Track enough to reject
+    // those forms instead of assembling something the user did not write.
+    SmallVector<bool, 4> ParenHasReg;
+    // Did the parenthesised group that just closed contain a register?
+    bool ClosedParenHadReg = false;
+    // Depth of the innermost group that is itself an operand of * / or %,
+    // counting from one. Zero when no enclosing group is one.
+    unsigned MulParenDepth = 0;
+
     bool setSymRef(const MCExpr *Val, StringRef ID, StringRef &ErrMsg) {
       if (Sym) {
         ErrMsg = "cannot use more than one symbol in memory operand";
@@ -812,6 +823,12 @@ private:
     }
     bool onRegister(MCRegister Reg, StringRef &ErrMsg) {
       IntelExprState CurrState = State;
+      if (MulParenDepth) {
+        ErrMsg = "cannot multiply a subexpression containing a register";
+        return true;
+      }
+      if (!ParenHasReg.empty())
+        ParenHasReg.back() = true;
       switch (State) {
       default:
         State = IES_ERROR;
@@ -945,7 +962,11 @@ private:
       PrevState = CurrState;
       return false;
     }
-    void onStar() {
+    bool onStar(StringRef &ErrMsg) {
+      if (State == IES_RPAREN && ClosedParenHadReg) {
+        ErrMsg = "cannot multiply a subexpression containing a register";
+        return true;
+      }
       PrevState = State;
       switch (State) {
       default:
@@ -958,8 +979,13 @@ private:
         IC.pushOperator(IC_MULTIPLY);
         break;
       }
+      return false;
     }
-    void onDivide() {
+    bool onDivide(StringRef &ErrMsg) {
+      if (State == IES_RPAREN && ClosedParenHadReg) {
+        ErrMsg = "cannot divide a subexpression containing a register";
+        return true;
+      }
       PrevState = State;
       switch (State) {
       default:
@@ -971,8 +997,14 @@ private:
         IC.pushOperator(IC_DIVIDE);
         break;
       }
+      return false;
     }
-    void onMod() {
+    bool onMod(StringRef &ErrMsg) {
+      if (State == IES_RPAREN && ClosedParenHadReg) {
+        ErrMsg = "cannot take the remainder of a subexpression containing a "
+                 "register";
+        return true;
+      }
       PrevState = State;
       switch (State) {
       default:
@@ -984,6 +1016,7 @@ private:
         IC.pushOperator(IC_MOD);
         break;
       }
+      return false;
     }
     bool onLBrac() {
       if (BracCount)
@@ -1050,8 +1083,19 @@ private:
       PrevState = CurrState;
       return false;
     }
-    void onLParen() {
+    bool onLParen(StringRef &ErrMsg) {
       IntelExprState CurrState = State;
+      // A register can only be scaled by an immediate, so "reg * (...)" has
+      // nowhere to put the result.
+      if ((State == IES_MULTIPLY || State == IES_DIVIDE || State == IES_MOD) &&
+          PrevState == IES_REGISTER) {
+        ErrMsg = "scale must be an immediate";
+        return true;
+      }
+      if ((State == IES_MULTIPLY || State == IES_DIVIDE || State == IES_MOD) &&
+          !MulParenDepth)
+        MulParenDepth = ParenHasReg.size() + 1;
+      ParenHasReg.push_back(false);
       switch (State) {
       default:
         State = IES_ERROR;
@@ -1081,9 +1125,17 @@ private:
         break;
       }
       PrevState = CurrState;
+      return false;
     }
     bool onRParen(StringRef &ErrMsg) {
       IntelExprState CurrState = State;
+      if (!ParenHasReg.empty()) {
+        ClosedParenHadReg = ParenHasReg.pop_back_val();
+        if (ClosedParenHadReg && !ParenHasReg.empty())
+          ParenHasReg.back() = true;
+      }
+      if (MulParenDepth > ParenHasReg.size())
+        MulParenDepth = 0;
       switch (State) {
       default:
         State = IES_ERROR;
@@ -1896,7 +1948,11 @@ bool X86AsmParser::ParseIntelNamedOperator(StringRef Name,
   } else if (Name.equals_insensitive("and")) {
     SM.onAnd();
   } else if (Name.equals_insensitive("mod")) {
-    SM.onMod();
+    StringRef ErrMsg;
+    if (SM.onMod(ErrMsg)) {
+      ParseError = Error(getTok().getLoc(), ErrMsg);
+      return true;
+    }
   } else if (Name.equals_insensitive("offset")) {
     SMLoc OffsetLoc = getTok().getLoc();
     const MCExpr *Val = nullptr;
@@ -2219,9 +2275,18 @@ bool X86AsmParser::ParseIntelExpression(IntelExprStateMachine &SM, SMLoc &End) {
         return Error(SM.getErrorLoc(getTok().getLoc()), ErrMsg);
       break;
     case AsmToken::Tilde:   SM.onNot(); break;
-    case AsmToken::Star:    SM.onStar(); break;
-    case AsmToken::Slash:   SM.onDivide(); break;
-    case AsmToken::Percent: SM.onMod(); break;
+    case AsmToken::Star:
+      if (SM.onStar(ErrMsg))
+        return Error(SM.getErrorLoc(Tok.getLoc()), ErrMsg);
+      break;
+    case AsmToken::Slash:
+      if (SM.onDivide(ErrMsg))
+        return Error(SM.getErrorLoc(Tok.getLoc()), ErrMsg);
+      break;
+    case AsmToken::Percent:
+      if (SM.onMod(ErrMsg))
+        return Error(SM.getErrorLoc(Tok.getLoc()), ErrMsg);
+      break;
     case AsmToken::Pipe:    SM.onOr(); break;
     case AsmToken::Caret:   SM.onXor(); break;
     case AsmToken::Amp:     SM.onAnd(); break;
@@ -2239,7 +2304,10 @@ bool X86AsmParser::ParseIntelExpression(IntelExprStateMachine &SM, SMLoc &End) {
         return Error(SM.getErrorLoc(Tok.getLoc()), ErrMsg);
       }
       break;
-    case AsmToken::LParen:  SM.onLParen(); break;
+    case AsmToken::LParen:
+      if (SM.onLParen(ErrMsg))
+        return Error(SM.getErrorLoc(Tok.getLoc()), ErrMsg);
+      break;
     case AsmToken::RParen:
       if (SM.onRParen(ErrMsg)) {
         return Error(SM.getErrorLoc(Tok.getLoc()), ErrMsg);

--- a/llvm/test/MC/X86/intel-syntax-invalid-scale.s
+++ b/llvm/test/MC/X86/intel-syntax-invalid-scale.s
@@ -29,3 +29,28 @@
 // CHECK-NEXT:     lea rax, [rax - rdx]
 // CHECK-NEXT:                   ^
     lea rax, [rax - rdx]
+
+// Registers are tracked separately from the expression evaluator, so scaling a
+// parenthesised group holding one used to drop the scale silently rather than
+// reject the expression.
+
+// CHECK: [[#@LINE+3]]:27: error: cannot multiply a subexpression containing a register
+// CHECK-NEXT:     lea rax, [(rdi + rdx) * 4]
+// CHECK-NEXT:                           ^
+    lea rax, [(rdi + rdx) * 4]
+// CHECK: [[#@LINE+3]]:20: error: cannot multiply a subexpression containing a register
+// CHECK-NEXT:     lea rax, [4 * (rdi + rdx)]
+// CHECK-NEXT:                    ^
+    lea rax, [4 * (rdi + rdx)]
+// CHECK: [[#@LINE+3]]:21: error: cannot multiply a subexpression containing a register
+// CHECK-NEXT:     lea rax, [(rdi) * 4]
+// CHECK-NEXT:                     ^
+    lea rax, [(rdi) * 4]
+// CHECK: [[#@LINE+3]]:21: error: scale must be an immediate
+// CHECK-NEXT:     lea rax, [rdi * (1 + 1)]
+// CHECK-NEXT:                     ^
+    lea rax, [rdi * (1 + 1)]
+// CHECK: [[#@LINE+3]]:25: error: cannot divide a subexpression containing a register
+// CHECK-NEXT:     lea rax, [(4 * rdi) / 2]
+// CHECK-NEXT:                         ^
+    lea rax, [(4 * rdi) / 2]

--- a/llvm/test/MC/X86/intel-syntax.s
+++ b/llvm/test/MC/X86/intel-syntax.s
@@ -919,3 +919,19 @@ lea eax, [esp+eax]
 vpgatherdq ymm0, [rdi+xmm1], ymm2
 // CHECK: vpgatherdq      %ymm2, (%rdi,%xmm1), %ymm0
 vpgatherdq ymm0, [xmm1+rdi], ymm2
+
+// Parentheses around a register are fine as long as the group itself is not
+// scaled, including when the scale sits inside the parentheses.
+
+// CHECK: leaq (%rax), %rdi
+    lea rdi, [(rax)]
+// CHECK: leaq 4(%rax), %rdi
+    lea rdi, [(rax + 4)]
+// CHECK: leaq (%rax,%rdi), %rdi
+    lea rdi, [(rax + rdi)]
+// CHECK: leaq (%rax,%rdi,4), %rdi
+    lea rdi, [rax + (rdi*4)]
+// CHECK: leaq 3(,%rax,4), %rdi
+    lea rdi, [rax*4 + (1+2)]
+// CHECK: leaq 3(,%rax,4), %rdi
+    lea rdi, [(1+2) + rax*4]


### PR DESCRIPTION
In Intel syntax, scaling a parenthesised subexpression that contains a register silently drops the scale:

```asm
.intel_syntax noprefix
lea rdi, [4 * (rax + rdi)]
lea rdi, [(rax + rdi) * 4]
```
```
leaq	(%rax,%rdi), %rdi
leaq	(%rax,%rdi), %rdi
```

Both assemble as though the `* 4` were not written. GNU as gets these right. Two related forms assert rather than misassemble:

```asm
lea rdi, [(rax) * 4]
lea rdi, [rax * (1 + 1)]
```
```
Assertion failed: Op1.first == IC_IMM && Op2.first == IC_IMM &&
"Multiply operation with an immediate and a register!"
```

Registers are tracked as base, index and scale rather than through the infix calculator, so once one has been folded into the state machine the parentheses around it have nothing left to apply a scale to. The state machine now tracks whether an open group contains a register, and whether a group is itself an operand of `*`, `/` or `%`, and rejects that combination instead of assembling something the user did not write.

```
[(rdi + rdx) * 4]   error: cannot multiply a subexpression containing a register
[4 * (rdi + rdx)]   error: cannot multiply a subexpression containing a register
[(rdi) * 4]         error: cannot multiply a subexpression containing a register
[rdi * (1 + 1)]     error: scale must be an immediate
[(4 * rdi) / 2]     error: cannot divide a subexpression containing a register
```

Parentheses around registers keep working everywhere they did before, including when the scale sits inside them, and I have added those as positive tests so the diagnostic does not get widened by accident later.

```
[(rax)]             leaq (%rax), %rdi
[(rax + 4)]         leaq 4(%rax), %rdi
[(rax + rdi)]       leaq (%rax,%rdi), %rdi
[rax + (rdi*4)]     leaq (%rax,%rdi,4), %rdi
[rax*4 + (1+2)]     leaq 3(,%rax,4), %rdi
[(1+2) + rax*4]     leaq 3(,%rax,4), %rdi
```

Two notes on scope. The issue only mentions `*`, but `/` and `%` lose the scale the same way, so they get the same treatment, and that pulled in the MASM `MOD` named operator so `ParseIntelNamedOperator` changed too. Making the diagnostics reachable also meant giving `onStar`, `onDivide`, `onMod` and `onLParen` the error-returning signature that `onRParen` already had, which is most of the diff.

This rejects these forms rather than implementing them, which #150427 offers as an acceptable outcome. If you would rather the parser handled them properly instead, say so and I will do that instead. I have not marked the issue as fixed for that reason.

Relates to #150427
