### PR TITLE
[Clang] Accept vector types in the atomic builtins

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -172,6 +172,14 @@ features cannot lower the translation-unit ABI level;
 
 - Clang now allows GNU computed `goto` extension in `constexpr` functions, matching the relaxed
   `constexpr` function body rules introduced in C++23.
+- The `__atomic`, `__c11_atomic`, `__hip_atomic`, `__opencl_atomic` and
+  `__scoped_atomic` builtins now accept vector types. The operation is performed
+  elementwise by a single atomic instruction. The arithmetic operations require
+  the vector to have a power-of-two size of at most 16 bytes, as they cannot be
+  lowered to a libcall. As a result, an atomic load or store of a
+  vector, such as one written with `_Atomic` or with `#pragma omp atomic`, is now
+  emitted with the vector type rather than an integer of the same size. This
+  does not change the generated code.
 
 ### New Compiler Flags
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9708,6 +9708,10 @@ def err_atomic_op_needs_atomic_int : Error<
 def err_atomic_op_needs_atomic_fp
     : Error<"address argument to atomic operation must be a pointer to "
             "%select{|atomic }0floating point type (%1 invalid)">;
+def err_atomic_op_needs_supported_vector
+    : Error<"address argument to atomic operation must be a pointer to a "
+            "vector with a power-of-two size of at most %0 bytes "
+            "(%1 invalid)">;
 def warn_atomic_op_has_invalid_memory_order : Warning<
   "%select{|success |failure }0memory order argument to atomic operation is invalid">,
   InGroup<DiagGroup<"atomic-memory-ordering">>;

--- a/clang/lib/CIR/CodeGen/CIRGenAtomic.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenAtomic.cpp
@@ -326,9 +326,8 @@ bool AtomicInfo::emitMemSetZeroIfNecessary() const {
 /// floating point operands.  TODO: Allow compare-and-exchange and FP - see
 /// comment in CIRGenAtomicExpandPass.cpp.
 static bool shouldCastToInt(mlir::Type valueTy, bool cmpxchg) {
-  // The atomic operations act on a vector directly, which is required for the
-  // elementwise arithmetic operations. cmpxchg has no vector form, so it is
-  // still handled as an integer of the same size.
+  // The atomic operations act on a vector directly, but cmpxchg has no vector
+  // form, so it is still handled as an integer.
   if (isa<cir::VectorType>(valueTy))
     return cmpxchg;
   if (cir::isAnyFloatingPointType(valueTy))

--- a/clang/lib/CIR/CodeGen/CIRGenAtomic.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenAtomic.cpp
@@ -326,6 +326,11 @@ bool AtomicInfo::emitMemSetZeroIfNecessary() const {
 /// floating point operands.  TODO: Allow compare-and-exchange and FP - see
 /// comment in CIRGenAtomicExpandPass.cpp.
 static bool shouldCastToInt(mlir::Type valueTy, bool cmpxchg) {
+  // The atomic operations act on a vector directly, which is required for the
+  // elementwise arithmetic operations. cmpxchg has no vector form, so it is
+  // still handled as an integer of the same size.
+  if (isa<cir::VectorType>(valueTy))
+    return cmpxchg;
   if (cir::isAnyFloatingPointType(valueTy))
     return isa<cir::FP80Type>(valueTy) || cmpxchg;
   return !isa<cir::IntType>(valueTy) && !isa<cir::PointerType>(valueTy);

--- a/clang/lib/CodeGen/CGAtomic.cpp
+++ b/clang/lib/CodeGen/CGAtomic.cpp
@@ -21,6 +21,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/Intrinsics.h"
+#include "llvm/Support/MathExtras.h"
 
 using namespace clang;
 using namespace CodeGen;
@@ -529,7 +530,7 @@ static llvm::Value *EmitPostAtomicMinMax(CGBuilderTy &Builder,
                                          bool IsSigned,
                                          llvm::Value *OldVal,
                                          llvm::Value *RHS) {
-  const bool IsFP = OldVal->getType()->isFloatingPointTy();
+  const bool IsFP = OldVal->getType()->isFPOrFPVectorTy();
 
   if (IsFP) {
     llvm::Intrinsic::ID IID = (Op == AtomicExpr::AO__atomic_max_fetch ||
@@ -566,6 +567,13 @@ static void EmitAtomicOp(CodeGenFunction &CGF, AtomicExpr *E, Address Dest,
   llvm::AtomicRMWInst::BinOp Op = llvm::AtomicRMWInst::Add;
   bool PostOpMinMax = false;
   unsigned PostOp = 0;
+
+  // Atomic operations on a vector are performed elementwise, so it is the
+  // element type which selects between the integer and the floating point
+  // form of an operation.
+  QualType ElemTy = E->getValueType();
+  if (const auto *VecTy = ElemTy->getAs<VectorType>())
+    ElemTy = VecTy->getElementType();
 
   switch (E->getOp()) {
   case AtomicExpr::AO__c11_atomic_init:
@@ -666,30 +674,30 @@ static void EmitAtomicOp(CodeGenFunction &CGF, AtomicExpr *E, Address Dest,
 
   case AtomicExpr::AO__atomic_add_fetch:
   case AtomicExpr::AO__scoped_atomic_add_fetch:
-    PostOp = E->getValueType()->isFloatingType() ? llvm::Instruction::FAdd
-                                                 : llvm::Instruction::Add;
+    PostOp = ElemTy->isFloatingType() ? llvm::Instruction::FAdd
+                                      : llvm::Instruction::Add;
     [[fallthrough]];
   case AtomicExpr::AO__c11_atomic_fetch_add:
   case AtomicExpr::AO__hip_atomic_fetch_add:
   case AtomicExpr::AO__opencl_atomic_fetch_add:
   case AtomicExpr::AO__atomic_fetch_add:
   case AtomicExpr::AO__scoped_atomic_fetch_add:
-    Op = E->getValueType()->isFloatingType() ? llvm::AtomicRMWInst::FAdd
-                                             : llvm::AtomicRMWInst::Add;
+    Op = ElemTy->isFloatingType() ? llvm::AtomicRMWInst::FAdd
+                                  : llvm::AtomicRMWInst::Add;
     break;
 
   case AtomicExpr::AO__atomic_sub_fetch:
   case AtomicExpr::AO__scoped_atomic_sub_fetch:
-    PostOp = E->getValueType()->isFloatingType() ? llvm::Instruction::FSub
-                                                 : llvm::Instruction::Sub;
+    PostOp = ElemTy->isFloatingType() ? llvm::Instruction::FSub
+                                      : llvm::Instruction::Sub;
     [[fallthrough]];
   case AtomicExpr::AO__c11_atomic_fetch_sub:
   case AtomicExpr::AO__hip_atomic_fetch_sub:
   case AtomicExpr::AO__opencl_atomic_fetch_sub:
   case AtomicExpr::AO__atomic_fetch_sub:
   case AtomicExpr::AO__scoped_atomic_fetch_sub:
-    Op = E->getValueType()->isFloatingType() ? llvm::AtomicRMWInst::FSub
-                                             : llvm::AtomicRMWInst::Sub;
+    Op = ElemTy->isFloatingType() ? llvm::AtomicRMWInst::FSub
+                                  : llvm::AtomicRMWInst::Sub;
     break;
 
   case AtomicExpr::AO__atomic_min_fetch:
@@ -701,23 +709,22 @@ static void EmitAtomicOp(CodeGenFunction &CGF, AtomicExpr *E, Address Dest,
   case AtomicExpr::AO__opencl_atomic_fetch_min:
   case AtomicExpr::AO__atomic_fetch_min:
   case AtomicExpr::AO__scoped_atomic_fetch_min:
-    Op = E->getValueType()->isFloatingType()
-             ? llvm::AtomicRMWInst::FMin
-             : (E->getValueType()->isSignedIntegerType()
-                    ? llvm::AtomicRMWInst::Min
-                    : llvm::AtomicRMWInst::UMin);
+    Op = ElemTy->isFloatingType() ? llvm::AtomicRMWInst::FMin
+                                  : (ElemTy->isSignedIntegerType()
+                                         ? llvm::AtomicRMWInst::Min
+                                         : llvm::AtomicRMWInst::UMin);
     break;
 
   case AtomicExpr::AO__atomic_fetch_fminimum:
   case AtomicExpr::AO__scoped_atomic_fetch_fminimum:
-    assert(E->getValueType()->isFloatingType() &&
+    assert(ElemTy->isFloatingType() &&
            "fminimum operations only support floating-point types");
     Op = llvm::AtomicRMWInst::FMinimum;
     break;
 
   case AtomicExpr::AO__atomic_fetch_fminimum_num:
   case AtomicExpr::AO__scoped_atomic_fetch_fminimum_num:
-    assert(E->getValueType()->isFloatingType() &&
+    assert(ElemTy->isFloatingType() &&
            "fminimum_num operations only support floating-point types");
     Op = llvm::AtomicRMWInst::FMinimumNum;
     break;
@@ -731,23 +738,22 @@ static void EmitAtomicOp(CodeGenFunction &CGF, AtomicExpr *E, Address Dest,
   case AtomicExpr::AO__opencl_atomic_fetch_max:
   case AtomicExpr::AO__atomic_fetch_max:
   case AtomicExpr::AO__scoped_atomic_fetch_max:
-    Op = E->getValueType()->isFloatingType()
-             ? llvm::AtomicRMWInst::FMax
-             : (E->getValueType()->isSignedIntegerType()
-                    ? llvm::AtomicRMWInst::Max
-                    : llvm::AtomicRMWInst::UMax);
+    Op = ElemTy->isFloatingType() ? llvm::AtomicRMWInst::FMax
+                                  : (ElemTy->isSignedIntegerType()
+                                         ? llvm::AtomicRMWInst::Max
+                                         : llvm::AtomicRMWInst::UMax);
     break;
 
   case AtomicExpr::AO__atomic_fetch_fmaximum:
   case AtomicExpr::AO__scoped_atomic_fetch_fmaximum:
-    assert(E->getValueType()->isFloatingType() &&
+    assert(ElemTy->isFloatingType() &&
            "fmaximum operations only support floating-point types");
     Op = llvm::AtomicRMWInst::FMaximum;
     break;
 
   case AtomicExpr::AO__atomic_fetch_fmaximum_num:
   case AtomicExpr::AO__scoped_atomic_fetch_fmaximum_num:
-    assert(E->getValueType()->isFloatingType() &&
+    assert(ElemTy->isFloatingType() &&
            "fmaximum_num operations only support floating-point types");
     Op = llvm::AtomicRMWInst::FMaximumNum;
     break;
@@ -840,8 +846,8 @@ static void EmitAtomicOp(CodeGenFunction &CGF, AtomicExpr *E, Address Dest,
   llvm::Value *Result = RMWI;
   if (PostOpMinMax)
     Result = EmitPostAtomicMinMax(CGF.Builder, E->getOp(),
-                                  E->getValueType()->isSignedIntegerType(),
-                                  RMWI, LoadVal1);
+                                  ElemTy->isSignedIntegerType(), RMWI,
+                                  LoadVal1);
   else if (PostOp)
     Result = CGF.Builder.CreateBinOp((llvm::Instruction::BinaryOps)PostOp, RMWI,
                                      LoadVal1);
@@ -868,6 +874,13 @@ EmitValToTemp(CodeGenFunction &CGF, Expr *E) {
 /// floating point operands.  TODO: Allow compare-and-exchange and FP - see
 /// comment in AtomicExpandPass.cpp.
 static bool shouldCastToInt(llvm::Type *ValTy, bool CmpXchg) {
+  // The atomic instructions operate on a vector directly, which is required for
+  // the elementwise arithmetic operations. cmpxchg has no vector form, and a
+  // vector whose size is not a power of two is not a valid atomic operand, so
+  // both are still handled as an integer of the enclosing atomic type's size.
+  if (auto *VecTy = dyn_cast<llvm::FixedVectorType>(ValTy))
+    return CmpXchg ||
+           !llvm::isPowerOf2_64(VecTy->getPrimitiveSizeInBits().getFixedValue());
   if (ValTy->isFloatingPointTy())
     return ValTy->isX86_FP80Ty() || CmpXchg;
   return !ValTy->isIntegerTy() && !ValTy->isPointerTy();
@@ -1571,10 +1584,11 @@ RValue AtomicInfo::ConvertToValueOrAtomic(llvm::Value *Val,
                                           SourceLocation Loc, bool AsValue,
                                           bool CmpXchg) const {
   // Try not to in some easy cases.
-  assert((Val->getType()->isIntegerTy() || Val->getType()->isPointerTy() ||
-          Val->getType()->isIEEELikeFPTy()) &&
-         "Expected integer, pointer or floating point value when converting "
-         "result.");
+  llvm::Type *ValScalarTy = Val->getType()->getScalarType();
+  assert((ValScalarTy->isIntegerTy() || ValScalarTy->isPointerTy() ||
+          ValScalarTy->isIEEELikeFPTy()) &&
+         "Expected integer, pointer or floating point value, or a vector "
+         "thereof, when converting result.");
   if (getEvaluationKind() == TEK_Scalar &&
       (((!LVal.isBitField() ||
          LVal.getBitFieldInfo().Size == ValueSizeInBits) &&

--- a/clang/lib/CodeGen/CGAtomic.cpp
+++ b/clang/lib/CodeGen/CGAtomic.cpp
@@ -568,9 +568,8 @@ static void EmitAtomicOp(CodeGenFunction &CGF, AtomicExpr *E, Address Dest,
   bool PostOpMinMax = false;
   unsigned PostOp = 0;
 
-  // Atomic operations on a vector are performed elementwise, so it is the
-  // element type which selects between the integer and the floating point
-  // form of an operation.
+  // A vector is operated on elementwise, so its element type selects between
+  // the integer and the floating point form of an operation.
   QualType ElemTy = E->getValueType();
   if (const auto *VecTy = ElemTy->getAs<VectorType>())
     ElemTy = VecTy->getElementType();
@@ -873,10 +872,9 @@ EmitValToTemp(CodeGenFunction &CGF, Expr *E) {
 /// floating point operands.  TODO: Allow compare-and-exchange and FP - see
 /// comment in AtomicExpandPass.cpp.
 static bool shouldCastToInt(llvm::Type *ValTy, bool CmpXchg) {
-  // The atomic instructions operate on a vector directly, which is required for
-  // the elementwise arithmetic operations. cmpxchg has no vector form, and a
-  // vector whose size is not a power of two is not a valid atomic operand, so
-  // both are still handled as an integer of the enclosing atomic type's size.
+  // The atomic instructions operate on a vector directly. cmpxchg has no vector
+  // form, and a vector whose size is not a power of two is not a valid atomic
+  // operand, so both are still handled as an integer.
   if (auto *VecTy = dyn_cast<llvm::FixedVectorType>(ValTy))
     return CmpXchg || !llvm::isPowerOf2_64(
                           VecTy->getPrimitiveSizeInBits().getFixedValue());

--- a/clang/lib/CodeGen/CGAtomic.cpp
+++ b/clang/lib/CodeGen/CGAtomic.cpp
@@ -709,10 +709,10 @@ static void EmitAtomicOp(CodeGenFunction &CGF, AtomicExpr *E, Address Dest,
   case AtomicExpr::AO__opencl_atomic_fetch_min:
   case AtomicExpr::AO__atomic_fetch_min:
   case AtomicExpr::AO__scoped_atomic_fetch_min:
-    Op = ElemTy->isFloatingType() ? llvm::AtomicRMWInst::FMin
-                                  : (ElemTy->isSignedIntegerType()
-                                         ? llvm::AtomicRMWInst::Min
-                                         : llvm::AtomicRMWInst::UMin);
+    Op = ElemTy->isFloatingType()
+             ? llvm::AtomicRMWInst::FMin
+             : (ElemTy->isSignedIntegerType() ? llvm::AtomicRMWInst::Min
+                                              : llvm::AtomicRMWInst::UMin);
     break;
 
   case AtomicExpr::AO__atomic_fetch_fminimum:
@@ -738,10 +738,10 @@ static void EmitAtomicOp(CodeGenFunction &CGF, AtomicExpr *E, Address Dest,
   case AtomicExpr::AO__opencl_atomic_fetch_max:
   case AtomicExpr::AO__atomic_fetch_max:
   case AtomicExpr::AO__scoped_atomic_fetch_max:
-    Op = ElemTy->isFloatingType() ? llvm::AtomicRMWInst::FMax
-                                  : (ElemTy->isSignedIntegerType()
-                                         ? llvm::AtomicRMWInst::Max
-                                         : llvm::AtomicRMWInst::UMax);
+    Op = ElemTy->isFloatingType()
+             ? llvm::AtomicRMWInst::FMax
+             : (ElemTy->isSignedIntegerType() ? llvm::AtomicRMWInst::Max
+                                              : llvm::AtomicRMWInst::UMax);
     break;
 
   case AtomicExpr::AO__atomic_fetch_fmaximum:
@@ -845,9 +845,8 @@ static void EmitAtomicOp(CodeGenFunction &CGF, AtomicExpr *E, Address Dest,
   // determine the value which was written.
   llvm::Value *Result = RMWI;
   if (PostOpMinMax)
-    Result = EmitPostAtomicMinMax(CGF.Builder, E->getOp(),
-                                  ElemTy->isSignedIntegerType(), RMWI,
-                                  LoadVal1);
+    Result = EmitPostAtomicMinMax(
+        CGF.Builder, E->getOp(), ElemTy->isSignedIntegerType(), RMWI, LoadVal1);
   else if (PostOp)
     Result = CGF.Builder.CreateBinOp((llvm::Instruction::BinaryOps)PostOp, RMWI,
                                      LoadVal1);
@@ -879,8 +878,8 @@ static bool shouldCastToInt(llvm::Type *ValTy, bool CmpXchg) {
   // vector whose size is not a power of two is not a valid atomic operand, so
   // both are still handled as an integer of the enclosing atomic type's size.
   if (auto *VecTy = dyn_cast<llvm::FixedVectorType>(ValTy))
-    return CmpXchg ||
-           !llvm::isPowerOf2_64(VecTy->getPrimitiveSizeInBits().getFixedValue());
+    return CmpXchg || !llvm::isPowerOf2_64(
+                          VecTy->getPrimitiveSizeInBits().getFixedValue());
   if (ValTy->isFloatingPointTy())
     return ValTy->isX86_FP80Ty() || CmpXchg;
   return !ValTy->isIntegerTy() && !ValTy->isPointerTy();

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -5335,6 +5335,15 @@ ExprResult Sema::BuildAtomicExpr(SourceRange CallRange, SourceRange ExprRange,
     // trivial type errors.
     auto IsAllowedValueType = [&](QualType ValType,
                                   unsigned AllowedType) -> bool {
+      // Atomic operations on a vector are performed elementwise, so it is the
+      // element type which decides whether the operation is well-formed. A
+      // vector of _Bool is rejected outright, as its elements are not
+      // individually addressable.
+      if (const auto *VecTy = ValType->getAs<VectorType>()) {
+        if (VecTy->getElementType()->isBooleanType())
+          return false;
+        ValType = VecTy->getElementType();
+      }
       bool IsX87LongDouble =
           ValType->isSpecificBuiltinType(BuiltinType::LongDouble) &&
           &Context.getTargetInfo().getLongDoubleFormat() ==
@@ -5366,6 +5375,26 @@ ExprResult Sema::BuildAtomicExpr(SourceRange CallRange, SourceRange ExprRange,
       Diag(ExprRange.getBegin(), DID)
           << IsC11 << Ptr->getType() << Ptr->getSourceRange();
       return ExprError();
+    }
+    // An arithmetic operation on a vector is always emitted as a single
+    // atomicrmw instruction; unlike the other forms there is no libcall to fall
+    // back on for a size which cannot be handled inline. The size of the vector
+    // itself is checked here, as the type holding it is padded out when the
+    // element count is not a power of two.
+    if (Form == Arithmetic) {
+      if (const auto *VecTy = ValType->getAs<VectorType>()) {
+        // The largest size EmitAtomicExpr() emits without a libcall.
+        constexpr unsigned MaxVectorSizeInBytes = 16;
+        uint64_t VecSizeInBits = Context.getTypeSize(VecTy->getElementType()) *
+                                 VecTy->getNumElements();
+        if (!llvm::isPowerOf2_64(VecSizeInBits) ||
+            VecSizeInBits > MaxVectorSizeInBytes * Context.getCharWidth()) {
+          Diag(ExprRange.getBegin(), diag::err_atomic_op_needs_supported_vector)
+              << MaxVectorSizeInBytes << Ptr->getType()
+              << Ptr->getSourceRange();
+          return ExprError();
+        }
+      }
     }
     if (IsC11 && ValType->isPointerType() &&
         RequireCompleteType(Ptr->getBeginLoc(), ValType->getPointeeType(),
@@ -5635,7 +5664,10 @@ ExprResult Sema::BuildAtomicExpr(SourceRange CallRange, SourceRange ExprRange,
                 ? 0
                 : 1);
 
-  if (ValType->isBitIntType()) {
+  QualType BitIntCandidateTy = ValType;
+  if (const auto *VecTy = ValType->getAs<VectorType>())
+    BitIntCandidateTy = VecTy->getElementType();
+  if (BitIntCandidateTy->isBitIntType()) {
     Diag(Ptr->getExprLoc(), diag::err_atomic_builtin_bit_int_prohibit);
     return ExprError();
   }

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -5335,10 +5335,8 @@ ExprResult Sema::BuildAtomicExpr(SourceRange CallRange, SourceRange ExprRange,
     // trivial type errors.
     auto IsAllowedValueType = [&](QualType ValType,
                                   unsigned AllowedType) -> bool {
-      // Atomic operations on a vector are performed elementwise, so it is the
-      // element type which decides whether the operation is well-formed. A
-      // vector of _Bool is rejected outright, as its elements are not
-      // individually addressable.
+      // A vector is operated on elementwise, so its element type decides. The
+      // elements of a vector of _Bool are not individually addressable.
       if (const auto *VecTy = ValType->getAs<VectorType>()) {
         if (VecTy->getElementType()->isBooleanType())
           return false;
@@ -5376,14 +5374,11 @@ ExprResult Sema::BuildAtomicExpr(SourceRange CallRange, SourceRange ExprRange,
           << IsC11 << Ptr->getType() << Ptr->getSourceRange();
       return ExprError();
     }
-    // An arithmetic operation on a vector is always emitted as a single
-    // atomicrmw instruction; unlike the other forms there is no libcall to fall
-    // back on for a size which cannot be handled inline. The size of the vector
-    // itself is checked here, as the type holding it is padded out when the
-    // element count is not a power of two.
+    // An arithmetic operation always becomes an atomicrmw, with no libcall to
+    // fall back on. The size is computed from the elements, as the type
+    // holding them is padded when their count is not a power of two.
     if (Form == Arithmetic) {
       if (const auto *VecTy = ValType->getAs<VectorType>()) {
-        // The largest size EmitAtomicExpr() emits without a libcall.
         constexpr unsigned MaxVectorSizeInBytes = 16;
         uint64_t VecSizeInBits = Context.getTypeSize(VecTy->getElementType()) *
                                  VecTy->getNumElements();

--- a/clang/test/CodeGen/atomic-ops-vector.c
+++ b/clang/test/CodeGen/atomic-ops-vector.c
@@ -1,0 +1,95 @@
+// RUN: %clang_cc1 %s -emit-llvm -o - -triple=x86_64-unknown-linux-gnu \
+// RUN:   -target-feature +cx16 -Wno-atomic-alignment \
+// RUN:   | FileCheck --check-prefixes=CHECK,X64 %s
+// RUN: %clang_cc1 %s -emit-llvm -o - -triple=amdgcn-amd-amdhsa \
+// RUN:   -Wno-atomic-alignment | FileCheck --check-prefixes=CHECK,AMDGCN %s
+
+// Atomic operations on a vector are performed elementwise by a single atomic
+// instruction, rather than being bitcast to an integer of the same size.
+
+typedef _Float16 half2 __attribute__((ext_vector_type(2)));
+typedef __bf16 bfloat2 __attribute__((ext_vector_type(2)));
+typedef float float2 __attribute__((ext_vector_type(2)));
+typedef float float3 __attribute__((ext_vector_type(3)));
+typedef int int2 __attribute__((ext_vector_type(2)));
+
+// CHECK-LABEL: @test_load(
+half2 test_load(half2 *p) {
+  // CHECK: load atomic <2 x half>, ptr {{.*}} monotonic
+  return __atomic_load_n(p, __ATOMIC_RELAXED);
+}
+
+// CHECK-LABEL: @test_store(
+void test_store(half2 *p, half2 v) {
+  // CHECK: store atomic <2 x half> {{.*}}, ptr {{.*}} monotonic
+  __atomic_store_n(p, v, __ATOMIC_RELAXED);
+}
+
+// CHECK-LABEL: @test_exchange(
+half2 test_exchange(half2 *p, half2 v) {
+  // CHECK: atomicrmw xchg ptr {{.*}}, <2 x half> {{.*}} monotonic
+  return __atomic_exchange_n(p, v, __ATOMIC_RELAXED);
+}
+
+// CHECK-LABEL: @test_fetch_add_half2(
+half2 test_fetch_add_half2(half2 *p, half2 v) {
+  // CHECK: atomicrmw fadd ptr {{.*}}, <2 x half> {{.*}} monotonic
+  return __atomic_fetch_add(p, v, __ATOMIC_RELAXED);
+}
+
+// CHECK-LABEL: @test_fetch_add_bfloat2(
+bfloat2 test_fetch_add_bfloat2(bfloat2 *p, bfloat2 v) {
+  // CHECK: atomicrmw fadd ptr {{.*}}, <2 x bfloat> {{.*}} monotonic
+  return __atomic_fetch_add(p, v, __ATOMIC_RELAXED);
+}
+
+// CHECK-LABEL: @test_add_fetch_float2(
+float2 test_add_fetch_float2(float2 *p, float2 v) {
+  // CHECK: atomicrmw fadd ptr {{.*}}, <2 x float> {{.*}} monotonic
+  // CHECK: fadd <2 x float>
+  return __atomic_add_fetch(p, v, __ATOMIC_RELAXED);
+}
+
+// CHECK-LABEL: @test_fetch_fmaximum_float2(
+float2 test_fetch_fmaximum_float2(float2 *p, float2 v) {
+  // CHECK: atomicrmw fmaximum ptr {{.*}}, <2 x float> {{.*}} monotonic
+  return __atomic_fetch_fmaximum(p, v, __ATOMIC_RELAXED);
+}
+
+// CHECK-LABEL: @test_max_fetch_int2(
+int2 test_max_fetch_int2(int2 *p, int2 v) {
+  // CHECK: atomicrmw max ptr {{.*}}, <2 x i32> {{.*}} monotonic
+  // CHECK: icmp sgt <2 x i32>
+  // CHECK: select <2 x i1>
+  return __atomic_max_fetch(p, v, __ATOMIC_RELAXED);
+}
+
+// CHECK-LABEL: @test_nand_fetch_int2(
+int2 test_nand_fetch_int2(int2 *p, int2 v) {
+  // CHECK: atomicrmw nand ptr {{.*}}, <2 x i32> {{.*}} monotonic
+  // CHECK: and <2 x i32>
+  // CHECK: xor <2 x i32>
+  return __atomic_nand_fetch(p, v, __ATOMIC_RELAXED);
+}
+
+// CHECK-LABEL: @test_c11_fetch_add(
+half2 test_c11_fetch_add(_Atomic(half2) *p, half2 v) {
+  // CHECK: atomicrmw fadd ptr {{.*}}, <2 x half> {{.*}} monotonic
+  return __c11_atomic_fetch_add(p, v, __ATOMIC_RELAXED);
+}
+
+// CHECK-LABEL: @test_scoped_fetch_add(
+half2 test_scoped_fetch_add(half2 *p, half2 v) {
+  // X64: atomicrmw fadd ptr {{.*}}, <2 x half> {{.*}} monotonic
+  // AMDGCN: atomicrmw fadd ptr {{.*}}, <2 x half> {{.*}} syncscope("agent") monotonic
+  return __scoped_atomic_fetch_add(p, v, __ATOMIC_RELAXED,
+                                   __MEMORY_SCOPE_DEVICE);
+}
+
+// A vector whose size is not a power of two is not a valid atomic operand, so
+// it is still accessed as an integer of the size of the type holding it.
+// CHECK-LABEL: @test_load_float3(
+float3 test_load_float3(float3 *p) {
+  // CHECK: load atomic i128, ptr {{.*}} monotonic
+  return __atomic_load_n(p, __ATOMIC_RELAXED);
+}

--- a/clang/test/CodeGen/atomic-ops-vector.c
+++ b/clang/test/CodeGen/atomic-ops-vector.c
@@ -4,9 +4,6 @@
 // RUN: %clang_cc1 %s -emit-llvm -o - -triple=amdgcn-amd-amdhsa \
 // RUN:   -Wno-atomic-alignment | FileCheck --check-prefixes=CHECK,AMDGCN %s
 
-// Atomic operations on a vector are performed elementwise by a single atomic
-// instruction, rather than being bitcast to an integer of the same size.
-
 typedef _Float16 half2 __attribute__((ext_vector_type(2)));
 typedef __bf16 bfloat2 __attribute__((ext_vector_type(2)));
 typedef float float2 __attribute__((ext_vector_type(2)));
@@ -86,8 +83,7 @@ half2 test_scoped_fetch_add(half2 *p, half2 v) {
                                    __MEMORY_SCOPE_DEVICE);
 }
 
-// A vector whose size is not a power of two is not a valid atomic operand, so
-// it is still accessed as an integer of the size of the type holding it.
+// A vector whose size is not a power of two is still accessed as an integer.
 // CHECK-LABEL: @test_load_float3(
 float3 test_load_float3(float3 *p) {
   // CHECK: load atomic i128, ptr {{.*}} monotonic

--- a/clang/test/OpenMP/atomic_read_codegen.c
+++ b/clang/test/OpenMP/atomic_read_codegen.c
@@ -231,8 +231,8 @@ int main(void) {
 // CHECK: store double
 #pragma omp atomic read
   cdv = llx;
-// CHECK: [[I128VAL:%.+]] = load atomic i128, ptr @{{.+}} monotonic, align 16
-// CHECK: store i128 [[I128VAL]], ptr [[LDTEMP:%.+]]
+// CHECK: [[VECVAL:%.+]] = load atomic <4 x i32>, ptr @{{.+}} monotonic, align 16
+// CHECK: store <4 x i32> [[VECVAL]], ptr [[LDTEMP:%.+]]
 // CHECK: [[LD:%.+]] = load <4 x i32>, ptr [[LDTEMP]]
 // CHECK: extractelement <4 x i32> [[LD]]
 // CHECK: store i8
@@ -318,8 +318,8 @@ int main(void) {
 // CHECK: store x86_fp80
 #pragma omp atomic read acquire
   ldv = bfx4_packed.b;
-// CHECK: [[LD:%.+]] = load atomic i64, ptr @{{.+}} monotonic, align 8
-// CHECK: store i64 [[LD]], ptr [[LDTEMP:%.+]]
+// CHECK: [[VECVAL:%.+]] = load atomic <2 x float>, ptr @{{.+}} monotonic, align 8
+// CHECK: store <2 x float> [[VECVAL]], ptr [[LDTEMP:%.+]]
 // CHECK: [[LD:%.+]] = load <2 x float>, ptr [[LDTEMP]]
 // CHECK: extractelement <2 x float> [[LD]]
 // CHECK: store i64

--- a/clang/test/Sema/atomic-ops-vector.c
+++ b/clang/test/Sema/atomic-ops-vector.c
@@ -1,0 +1,65 @@
+// RUN: %clang_cc1 %s -verify -fsyntax-only -triple=x86_64-unknown-linux-gnu -std=c11
+// RUN: %clang_cc1 %s -verify -fsyntax-only -triple=amdgcn-amd-amdhsa -std=c11
+
+// Atomic builtins accept vector types; the operation is performed elementwise
+// by a single atomicrmw instruction.
+
+typedef _Float16 half2 __attribute__((ext_vector_type(2)));
+typedef __bf16 bfloat2 __attribute__((ext_vector_type(2)));
+typedef float float2 __attribute__((ext_vector_type(2)));
+typedef float float3 __attribute__((ext_vector_type(3)));
+typedef float float8 __attribute__((ext_vector_type(8)));
+typedef int int2 __attribute__((ext_vector_type(2)));
+typedef unsigned int uint4 __attribute__((ext_vector_type(4)));
+typedef _Bool bool8 __attribute__((ext_vector_type(8)));
+typedef _BitInt(16) bitint2 __attribute__((ext_vector_type(2)));
+
+void test_gnu(half2 *h2, bfloat2 *b2, float2 *f2, int2 *i2, uint4 *u4) {
+  (void)__atomic_load_n(h2, __ATOMIC_RELAXED);
+  __atomic_store_n(h2, *h2, __ATOMIC_RELAXED);
+  (void)__atomic_exchange_n(h2, *h2, __ATOMIC_RELAXED);
+
+  (void)__atomic_fetch_add(h2, *h2, __ATOMIC_RELAXED);
+  (void)__atomic_fetch_add(b2, *b2, __ATOMIC_RELAXED);
+  (void)__atomic_fetch_sub(f2, *f2, __ATOMIC_RELAXED);
+  (void)__atomic_add_fetch(f2, *f2, __ATOMIC_RELAXED);
+  (void)__atomic_fetch_min(f2, *f2, __ATOMIC_RELAXED);
+  (void)__atomic_max_fetch(i2, *i2, __ATOMIC_RELAXED);
+  (void)__atomic_fetch_fmaximum(f2, *f2, __ATOMIC_RELAXED);
+  (void)__atomic_fetch_and(i2, *i2, __ATOMIC_RELAXED);
+  (void)__atomic_or_fetch(u4, *u4, __ATOMIC_RELAXED);
+  (void)__atomic_nand_fetch(i2, *i2, __ATOMIC_RELAXED);
+
+  // The integer operations still reject a vector of floating point elements.
+  (void)__atomic_fetch_and(f2, *f2, __ATOMIC_RELAXED); // expected-error {{must be a pointer to integer}}
+  // The f-prefixed operations still reject a vector of integer elements.
+  (void)__atomic_fetch_fminimum(i2, *i2, __ATOMIC_RELAXED); // expected-error {{must be a pointer to floating point type}}
+}
+
+void test_c11(_Atomic(half2) *h2, half2 h2v, _Atomic(int2) *i2, int2 i2v) {
+  (void)__c11_atomic_load(h2, __ATOMIC_RELAXED);
+  __c11_atomic_store(h2, h2v, __ATOMIC_RELAXED);
+  (void)__c11_atomic_exchange(h2, h2v, __ATOMIC_RELAXED);
+  (void)__c11_atomic_fetch_add(h2, h2v, __ATOMIC_RELAXED);
+  (void)__c11_atomic_fetch_sub(h2, h2v, __ATOMIC_RELAXED);
+  (void)__c11_atomic_fetch_xor(i2, i2v, __ATOMIC_RELAXED);
+}
+
+void test_scoped(half2 *h2, int2 *i2) {
+  (void)__scoped_atomic_load_n(h2, __ATOMIC_RELAXED, __MEMORY_SCOPE_SYSTEM);
+  __scoped_atomic_store_n(h2, *h2, __ATOMIC_RELAXED, __MEMORY_SCOPE_WRKGRP);
+  (void)__scoped_atomic_fetch_add(h2, *h2, __ATOMIC_RELAXED,
+                                  __MEMORY_SCOPE_DEVICE);
+  (void)__scoped_atomic_fetch_or(i2, *i2, __ATOMIC_RELAXED,
+                                 __MEMORY_SCOPE_DEVICE);
+}
+
+void test_unsupported(float3 *f3, float8 *f8, bool8 *b8, bitint2 *bi2) {
+  // A vector whose size is not a power of two cannot be an atomic operand.
+  (void)__atomic_fetch_add(f3, *f3, __ATOMIC_RELAXED); // expected-error {{must be a pointer to a vector with a power-of-two size of at most 16 bytes}}
+  // A vector larger than the largest atomic emitted inline would need a
+  // libcall, and there is no libcall for the arithmetic operations.
+  (void)__atomic_fetch_add(f8, *f8, __ATOMIC_RELAXED); // expected-error {{must be a pointer to a vector with a power-of-two size of at most 16 bytes}}
+  (void)__atomic_fetch_add(b8, *b8, __ATOMIC_RELAXED); // expected-error {{must be a pointer to integer, pointer or supported floating point type}}
+  (void)__atomic_fetch_add(bi2, *bi2, __ATOMIC_RELAXED); // expected-error {{argument to atomic builtin of type '_BitInt' is not supported}}
+}

--- a/clang/test/Sema/atomic-ops-vector.c
+++ b/clang/test/Sema/atomic-ops-vector.c
@@ -1,9 +1,6 @@
 // RUN: %clang_cc1 %s -verify -fsyntax-only -triple=x86_64-unknown-linux-gnu -std=c11
 // RUN: %clang_cc1 %s -verify -fsyntax-only -triple=amdgcn-amd-amdhsa -std=c11
 
-// Atomic builtins accept vector types; the operation is performed elementwise
-// by a single atomicrmw instruction.
-
 typedef _Float16 half2 __attribute__((ext_vector_type(2)));
 typedef __bf16 bfloat2 __attribute__((ext_vector_type(2)));
 typedef float float2 __attribute__((ext_vector_type(2)));
@@ -30,9 +27,7 @@ void test_gnu(half2 *h2, bfloat2 *b2, float2 *f2, int2 *i2, uint4 *u4) {
   (void)__atomic_or_fetch(u4, *u4, __ATOMIC_RELAXED);
   (void)__atomic_nand_fetch(i2, *i2, __ATOMIC_RELAXED);
 
-  // The integer operations still reject a vector of floating point elements.
   (void)__atomic_fetch_and(f2, *f2, __ATOMIC_RELAXED); // expected-error {{must be a pointer to integer}}
-  // The f-prefixed operations still reject a vector of integer elements.
   (void)__atomic_fetch_fminimum(i2, *i2, __ATOMIC_RELAXED); // expected-error {{must be a pointer to floating point type}}
 }
 
@@ -55,10 +50,7 @@ void test_scoped(half2 *h2, int2 *i2) {
 }
 
 void test_unsupported(float3 *f3, float8 *f8, bool8 *b8, bitint2 *bi2) {
-  // A vector whose size is not a power of two cannot be an atomic operand.
   (void)__atomic_fetch_add(f3, *f3, __ATOMIC_RELAXED); // expected-error {{must be a pointer to a vector with a power-of-two size of at most 16 bytes}}
-  // A vector larger than the largest atomic emitted inline would need a
-  // libcall, and there is no libcall for the arithmetic operations.
   (void)__atomic_fetch_add(f8, *f8, __ATOMIC_RELAXED); // expected-error {{must be a pointer to a vector with a power-of-two size of at most 16 bytes}}
   (void)__atomic_fetch_add(b8, *b8, __ATOMIC_RELAXED); // expected-error {{must be a pointer to integer, pointer or supported floating point type}}
   (void)__atomic_fetch_add(bi2, *bi2, __ATOMIC_RELAXED); // expected-error {{argument to atomic builtin of type '_BitInt' is not supported}}


### PR DESCRIPTION
Fixes #213237 

I look into the issue. After my findings, the issue #213237 is that,  LLVM IR has supported vector operands on `atomicrmw`, but Clang rejects them before any IR is ever emitted, so the capability is unreachable from source. Anything like `__scoped_atomic_fetch_add` on a `half2` fails with "address argument to atomic operation must be a pointer to integer, pointer or supported floating point type", and the same goes for the `__atomic`, `__call_atomic`, `__hip_atomic` and `__opencl_atomic` spellings. This matters in AMDGPU, where `global_atomic_pk_add_f16` and `global_atomic_pk_add_bf16` are real instructions that the backend already selects from `atomicrmw fadd <2 x half>` - I think the only ways to reach them are inline `asm` or per-lane atomics that throw away  the packed operations. So the root cause according to me is that : `IsAllowedValueType` in `BuildAtomicExpr` tests `isIntegerType()` , `isPointerType()`, and `isFloatingType()` directly on the value type, but all three are false for a `vectorType` , as a result every vector falls through to return false. 

To fix this I check the element type instead, since an atomic operation on a vector is performed elementwise, the same way the verifier states the rule one layer done with `isFPOrVectorTy()` / `isIntOrIntVectorTy()`. Vectors of `__Bool` stay rejected because their elements are not individually addressable. `CodeGen` had two assumptions that had to move with it - the `atomicrmw` opcode was chosen from `getValueType() -> isFloatingType()`, which would have quietely picked the integer Add for a vector of floats , so I hoisted an `ElmTy` once at the top of `EmitAtomicOp` and switched the cases over to it, and `shouldCastToInt` `bitcast` every non scalar operand to `iN`, which is required for `cmpxchg` (no vector form in IR) and harmless for load/store, but wrong for arithmetic, where an `add` on an `i32` propagates carries accross the lanes of a `<2 x i16>`. Arithmetic is also the one family with no `libcall` fallback -- `EmitAtomicExpr` hits an `llvm_unreachable` on that path -- so `sema` now diagnoses vectors that can't be emitted inline rather than crashing on `float3` or `float8`. I mirrored the same `shouldCastToInt` rule in `CIRGentomic.cpp` so ClangIR dosen't silently diverge, added `sema` and `CodeGen` tests, and also updated four CHECK lines `atomic_read_codegen.c` where an `OpenMP` atomic read of a vector global now loads the vector type directly instead of round-tripping through an integer. I verified all tests passed.

Assisted by Claude