### PR TITLE
[llvm-mc][AsmParser] Fix Source location for undefined directional labels.

### DIFF
--- a/llvm/lib/MC/MCParser/AsmParser.cpp
+++ b/llvm/lib/MC/MCParser/AsmParser.cpp
@@ -1050,16 +1050,14 @@ bool AsmParser::Run(bool NoInitialTextSection, bool NoFinalize) {
 
         if (Sym && Sym->isTemporary() && !Sym->isVariable() &&
             !Sym->isDefined()) {
-          // To fix this issue, I introduced a `DenseMap` mechanism
-          // into the `AsmParser` private variable group to track the correct
-          // assembly syntax groups.
+          // Report the error at the first reference to the temporary symbol.
           SMLoc ErrorLoc = getTok().getLoc();
           auto It = LocalSymbolLocs.find(Sym);
           if (It != LocalSymbolLocs.end())
-              ErrorLoc = It->second;
+            ErrorLoc = It->second;
 
           printError(ErrorLoc, "assembler local symbol '" + Sym->getName() +
-                                 "' not defined");
+                                   "' not defined");
         }
       }
     }
@@ -1255,11 +1253,8 @@ bool AsmParser::parsePrimaryExpr(const MCExpr *&Res, SMLoc &EndLoc,
                                                    : SymbolName);
 
     // Store in the mapping table.
-    LocalSymbolLocs.try_emplace(Sym, FirstTokenLoc);
-
-    // If it is a local symbol, record the location of its first reference.
-    if (Sym->isTemporary()) {
-        Sym = getContext().parseSymbol(MAI.isHLASM() ? SymbolName.upper() : SymbolName);
+    if (Sym && Sym->isTemporary()) {
+      LocalSymbolLocs.try_emplace(Sym, FirstTokenLoc);
     }
 
     // If this is an absolute variable reference, substitute it now to preserve

--- a/llvm/lib/MC/MCParser/AsmParser.cpp
+++ b/llvm/lib/MC/MCParser/AsmParser.cpp
@@ -13,6 +13,7 @@
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallString.h"
@@ -180,6 +181,9 @@ private:
 
   // Is alt macro mode enabled.
   bool AltMacroMode = false;
+
+  // Retrieve all temporary symbols in assembly syntax.
+  DenseMap<const MCSymbol *, SMLoc> LocalSymbolLocs;
 
 protected:
   virtual bool parseStatement(ParseStatementInfo &Info,
@@ -1043,13 +1047,20 @@ bool AsmParser::Run(bool NoInitialTextSection, bool NoFinalize) {
         // Variable symbols may not be marked as defined, so check those
         // explicitly. If we know it's a variable, we have a definition for
         // the purposes of this check.
+
         if (Sym && Sym->isTemporary() && !Sym->isVariable() &&
-            !Sym->isDefined())
-          // FIXME: We would really like to refer back to where the symbol was
-          // first referenced for a source location. We need to add something
-          // to track that. Currently, we just point to the end of the file.
-          printError(getTok().getLoc(), "assembler local symbol '" +
-                                            Sym->getName() + "' not defined");
+            !Sym->isDefined()) {
+          // To fix this issue, I introduced a `DenseMap` mechanism
+          // into the `AsmParser` private variable group to track the correct
+          // assembly syntax groups.
+          SMLoc ErrorLoc = getTok().getLoc();
+          auto It = LocalSymbolLocs.find(Sym);
+          if (It != LocalSymbolLocs.end())
+              ErrorLoc = It->second;
+
+          printError(ErrorLoc, "assembler local symbol '" + Sym->getName() +
+                                 "' not defined");
+        }
       }
     }
 
@@ -1242,6 +1253,14 @@ bool AsmParser::parsePrimaryExpr(const MCExpr *&Res, SMLoc &EndLoc,
     if (!Sym)
       Sym = getContext().parseSymbol(MAI.isHLASM() ? SymbolName.upper()
                                                    : SymbolName);
+
+    // Store in the mapping table.
+    LocalSymbolLocs.try_emplace(Sym, FirstTokenLoc);
+
+    // If it is a local symbol, record the location of its first reference.
+    if (Sym->isTemporary()) {
+        Sym = getContext().parseSymbol(MAI.isHLASM() ? SymbolName.upper() : SymbolName);
+    }
 
     // If this is an absolute variable reference, substitute it now to preserve
     // semantics in the face of reassignment.

--- a/llvm/test/MC/AsmParser/undef-local-symbol-loc.s
+++ b/llvm/test/MC/AsmParser/undef-local-symbol-loc.s
@@ -1,0 +1,10 @@
+# RUN: not llvm-mc -triple=x86_64-apple-macos %s 2>&1 | FileCheck %s
+
+.text
+.globl _foo
+_foo:
+# CHECK: :[[#@LINE+2]]:9: error: assembler local symbol 'Ltmp_undefined' not defined
+# CHECK-NEXT:   jmp Ltmp_undefined
+    jmp Ltmp_undefined
+    nop
+    jmp Ltmp_undefined


### PR DESCRIPTION
This is a sub-PR split from #214396 (part 1/4).  

## Description:  

Fixed an issue where the `AsmParser` module failed to accurately display the line number and corresponding error location when it encountered an undefined symbol.

## Solution:  

Previously, when an error occurred, the corresponding line of the error could not be correctly captured. To fix this issue, I introduced a `DenseMap` mechanism into the `AsmParser` private variable group to record the correct assembly syntax groups.  

## Test case:  
```bash
$ ./build/bin/llvm-lit -v ./llvm/test/MC/AsmParser/undef-local-symbol-loc.s
-- Testing: 1 tests, 1 workers --
PASS: LLVM :: MC/AsmParser/undef-local-symbol-loc.s (1 of 1)

Testing Time: 0.14s

Total Discovered Tests: 1
  Passed: 1 (100.00%)
```