### PR TITLE
[HIP][Test] Fix hip-include-path.hip fail when AMDGPU isn't in LLVM_TARGETS_TO_BUILD

### DIFF
--- a/clang/test/Driver/hip-include-path.hip
+++ b/clang/test/Driver/hip-include-path.hip
@@ -1,4 +1,5 @@
 // UNSUPPORTED: system-windows
+// REQUIRES: amdgpu-registered-target
 
 // RUN: %clang -c -### --target=x86_64-unknown-linux-gnu --cuda-gpu-arch=gfx900 \
 // RUN:   -std=c++11 --rocm-path=%S/Inputs/rocm -nogpulib %s 2>&1 \


### PR DESCRIPTION
Fix test error `Unknown command line argument '-amdgpu-internalize-symbols'` when AMDGPU isn't in LLVM_TARGETS_TO_BUILD.

The test starts failing after 9bbd728946da which adds -fsyntax-only that invokes -cc1 for the amdgcn-amd-amdhsa target and passes `-mllvm -amdgpu-internalize-symbols` to AMDGPUToolChain.