### PR TITLE
[MLIR] Restore std::cout formatting state in the Vulkan runtime

### DIFF
--- a/mlir/lib/ExecutionEngine/VulkanRuntime.cpp
+++ b/mlir/lib/ExecutionEngine/VulkanRuntime.cpp
@@ -211,8 +211,13 @@ LogicalResult VulkanRuntime::run() {
             VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT),
         "vkGetQueryPoolResults");
     float microsec = (timestamps[1] - timestamps[0]) * timestampPeriod / 1000;
+    // std::setprecision is sticky on the stream, so save and restore the
+    // caller's formatting state rather than leaving it changed.
+    std::ios formatState(nullptr);
+    formatState.copyfmt(std::cout);
     std::cout << "Compute shader execution time: " << std::setprecision(3)
               << microsec << "us\n";
+    std::cout.copyfmt(formatState);
   }
 
   std::cout << "Command buffer submit time: " << submitDuration.count()


### PR DESCRIPTION
`std::setprecision` modifies the stream itself rather than a single insertion, so it stays in effect until something changes it back. The Vulkan runtime sets it to 3 while printing the compute shader execution time and never restores it, so every float printed afterwards, including by RunnerUtils, comes out with three significant digits. A memref holding 858.5 prints as 858 after a kernel launch even though the stored bits are unchanged.

Save the formatting state with `copyfmt` before the timing line and restore it after.

Fixes #211992