### PR TITLE
[clang][Lex] Fix conflicting RemoveTopOfLexerStack docs

### DIFF
--- a/clang/include/clang/Lex/Preprocessor.h
+++ b/clang/include/clang/Lex/Preprocessor.h
@@ -1747,7 +1747,7 @@ public:
   /// Pop the current lexer/macro exp off the top of the lexer stack.
   ///
   /// This should only be used in situations where the current state of the
-  /// top-of-stack lexer is known.
+  /// top-of-stack lexer is unknown.
   void RemoveTopOfLexerStack();
 
   /// From the point that this method is called, and until

--- a/clang/lib/Lex/PPLexerChange.cpp
+++ b/clang/lib/Lex/PPLexerChange.cpp
@@ -615,9 +615,6 @@ bool Preprocessor::HandleEndOfTokenLexer(Token &Result) {
   return HandleEndOfFile(Result, true);
 }
 
-/// RemoveTopOfLexerStack - Pop the current lexer/macro exp off the top of the
-/// lexer stack.  This should only be used in situations where the current
-/// state of the top-of-stack lexer is unknown.
 void Preprocessor::RemoveTopOfLexerStack() {
   assert(!IncludeMacroStack.empty() && "Ran out of stack entries to load");
 


### PR DESCRIPTION
Align the header comment with the implementation: this API is for when the top-of-stack lexer state is unknown.

Fixes #53214