### PR TITLE
[docs] Fill empty Dynamically adding command line options section

### DIFF
--- a/llvm/docs/CommandLine.md
+++ b/llvm/docs/CommandLine.md
@@ -1703,6 +1703,7 @@ TODO: complete this section
 
 ### Dynamically adding command line options
 
-```{todo}
-TODO: fill in this section
-```
+Options declared with `cl::opt` (and related classes) are registered via
+static constructors. When a shared library containing such options is loaded,
+those options become available to the command-line parser automatically; see
+also {ref}dynamically loaded options.


### PR DESCRIPTION
Replace the empty TODO with a short description of how `cl::opt` options from loaded libraries are registered.

Fixes #46366
