### PR TITLE
[lit] Add dispatch chunking to the worker pool

### DIFF
--- a/llvm/utils/lit/lit/cl_arguments.py
+++ b/llvm/utils/lit/lit/cl_arguments.py
@@ -529,6 +529,20 @@ def parse_args():
         help="Show all features used in the test suite (in XFAIL, UNSUPPORTED and REQUIRES) and exit",
         action="store_true",
     )
+    debug_group.add_argument(
+        "--experimental-dispatch-chunk-size",
+        dest="dispatch_chunk_size",
+        metavar="N",
+        help="EXPERIMENTAL: Hand tests to workers in chunks of N rather than "
+        "one at a time. A chunk goes to a single worker, which runs its tests "
+        "one after another, so the run pays one round trip to that worker for "
+        "the whole chunk instead of one per test. [Default: 1] "
+        "(NOTE: values above 1 require --order=random, stop the run up to N-1 "
+        "tests later than --max-failures and --max-time otherwise would, and "
+        "lose the rest of a chunk when a worker crashes)",
+        type=_positive_int,
+        default=1,
+    )
 
     # LIT is special: environment variables override command line arguments.
     env_args = shlex.split(os.environ.get("LIT_OPTS", ""))
@@ -546,6 +560,14 @@ def parse_args():
     if opts.time_tests is not None and opts.skip_test_time_recording:
         parser.error(
             f"argument --skip-test-time-recording: not allowed with argument {_TIME_TESTS_OPT}"
+        )
+
+    if opts.dispatch_chunk_size > 1 and TestOrder(opts.order) != TestOrder.RANDOM:
+        parser.error(
+            "argument --experimental-dispatch-chunk-size: values above 1 require "
+            "--order=random. Every other order sorts tests of similar duration "
+            "next to each other, so a chunk collects several of the slowest "
+            "tests onto one worker and leaves the rest idle."
         )
 
     # Validate command line options

--- a/llvm/utils/lit/lit/main.py
+++ b/llvm/utils/lit/lit/main.py
@@ -263,7 +263,13 @@ def run_tests(tests, lit_config, opts, discovered_tests):
     display = lit.display.create_display(opts, tests, discovered_tests, workers)
 
     run = lit.run.Run(
-        tests, lit_config, workers, display.update, opts.max_failures, opts.timeout
+        tests,
+        lit_config,
+        workers,
+        display.update,
+        opts.max_failures,
+        opts.timeout,
+        dispatch_chunk_size=opts.dispatch_chunk_size,
     )
 
     display.print_header()

--- a/llvm/utils/lit/lit/run.py
+++ b/llvm/utils/lit/lit/run.py
@@ -1,3 +1,4 @@
+import itertools
 import multiprocessing
 import os
 import platform
@@ -49,7 +50,14 @@ class Run:
     """A concrete, configured testing run."""
 
     def __init__(
-        self, tests, lit_config, workers, progress_callback, max_failures, timeout
+        self,
+        tests,
+        lit_config,
+        workers,
+        progress_callback,
+        max_failures,
+        timeout,
+        dispatch_chunk_size=1,
     ):
         self.tests = tests
         self.lit_config = lit_config
@@ -57,7 +65,9 @@ class Run:
         self.progress_callback = progress_callback
         self.max_failures = max_failures
         self.timeout = timeout
+        self.dispatch_chunk_size = dispatch_chunk_size
         assert workers > 0
+        assert dispatch_chunk_size > 0
 
     def execute(self):
         """
@@ -92,7 +102,7 @@ class Run:
                 if test.result is None:
                     test.setResult(skipped)
 
-    def _abort_executors(self, executors, future_to_test):
+    def _abort_executors(self, executors, future_to_tests):
         """SIGKILL all workers on abort (ctrl-C, --max-failures, --max-time,
         worker crash). Pre-3.14 ProcessPoolExecutor has no force-stop."""
         try:
@@ -103,7 +113,7 @@ class Run:
             # Skipping it is safe because we SIGKILL workers below, so no pending future
             # will ever be dispatched. cancel() on 3.10+ is a clean hint.
             if sys.version_info >= (3, 10):
-                for future in future_to_test:
+                for future in future_to_tests:
                     future.cancel()
             # Killing worker processes can corrupt the executor's queues, which makes it
             # unsafe for its atexit hooks to join their threads. Disable those hooks
@@ -176,12 +186,12 @@ class Run:
             for pool_size in workers_per_pool_list
         ]
 
-        future_to_test = {}
+        future_to_tests = {}
 
         try:
-            self._dispatch_and_wait(executors, future_to_test, deadline)
+            self._dispatch_and_wait(executors, future_to_tests, deadline)
         except BaseException:
-            self._abort_executors(executors, future_to_test)
+            self._abort_executors(executors, future_to_tests)
             raise
         else:
             for ex in executors:
@@ -195,26 +205,27 @@ class Run:
                     ex._call_queue.cancel_join_thread()
                 ex.shutdown(wait=True)
 
-    def _dispatch_and_wait(self, executors, future_to_test, deadline):
+    def _dispatch_and_wait(self, executors, future_to_tests, deadline):
         """Submits tests to executors and collects results as they complete.
 
         Bounds the number of futures outstanding at any time to at most
         window (see SUBMISSION_WINDOW_PER_WORKER), submitting exactly one
-        new test for each one that completes. Submitting every test up
+        new chunk for each one that completes. Submitting every test up
         front floods the executor's wakeup pipe and can deadlock submit()
         against the executor's manager thread on Python <= 3.11.5
-        (https://github.com/python/cpython/issues/105829)
+        (https://github.com/python/cpython/issues/105829). window bounds
+        submit() calls, so it is independent of dispatch_chunk_size.
 
-        Mutates future_to_test in place: adds an entry for every test
-        submitted, and removes it once that test's result has been
-        collected. On return, or if this call raises, future_to_test
+        Mutates future_to_tests in place: adds an entry for every chunk
+        submitted, and removes it once that chunk's results have been
+        collected. On return, or if this call raises, future_to_tests
         holds exactly the futures that have not yet been collected, which
         the caller's abort path relies on.
 
         Args:
             executors: The ProcessPoolExecutor pool(s) tests are dispatched to.
-            future_to_test: A dict mapping each in-flight Future to its
-              corresponding Test. Populated and drained by this call.
+            future_to_tests: A dict mapping each in-flight Future to the
+              list of Tests in its chunk. Populated and drained by this call.
             deadline: The absolute time (as returned by time.time()) after
               which the call raises TimeoutError.
 
@@ -231,24 +242,34 @@ class Run:
                     SUBMISSION_WINDOW_PER_WORKER * self.workers,
                 )
             ) or len(self.tests)
+            chunk_size = self.dispatch_chunk_size
             tests_iter = enumerate(self.tests)
             pending = set()
             future_to_index = {}
+            chunk_counter = itertools.count()
 
             def submit_next():
-                """Submits the next not-yet-submitted test, if any.
+                """Submits the next not-yet-submitted chunk of tests, if any.
 
                 Returns:
-                    True if a test was submitted, False if none remained.
+                    True if a chunk was submitted, False if none remained.
                 """
-                for i, test in tests_iter:
-                    ex = executors[i % len(executors)]
-                    future = ex.submit(lit.worker.execute, test)
-                    future_to_test[future] = test
-                    future_to_index[future] = i
-                    pending.add(future)
-                    return True
-                return False
+                chunk = list(itertools.islice(tests_iter, chunk_size))
+                if not chunk:
+                    return False
+                indices, chunk_tests = zip(*chunk)
+                # Round-robin by chunk, not by test index, which would send
+                # every chunk to the same pool whenever chunk_size is a
+                # multiple of len(executors).
+                ex = executors[next(chunk_counter) % len(executors)]
+                if chunk_size == 1:
+                    future = ex.submit(lit.worker.execute, chunk_tests[0])
+                else:
+                    future = ex.submit(lit.worker.execute_batch, list(chunk_tests))
+                future_to_tests[future] = list(chunk_tests)
+                future_to_index[future] = indices[0]
+                pending.add(future)
+                return True
 
             while len(pending) < window and submit_next():
                 pass
@@ -263,17 +284,20 @@ class Run:
                     raise TimeoutError()
                 for future in sorted(done, key=lambda f: future_to_index[f]):
                     del future_to_index[future]
-                    remote_test = future.result()
-                    local_test = future_to_test.pop(future)
-                    self._update_test(local_test, remote_test)
-                    self.progress_callback(remote_test)
-                    if remote_test.isFailure():
-                        self.failures += 1
-                        # max_failures is None or a positive int, never 0
-                        # (cl_arguments.py's _positive_int enforces i > 0),
-                        # so this equality check can't misfire on failures=0.
-                        if self.failures == self.max_failures:
-                            raise MaxFailuresError()
+                    remote_tests = future.result()
+                    if chunk_size == 1:
+                        remote_tests = [remote_tests]
+                    local_tests = future_to_tests.pop(future)
+                    for local_test, remote_test in zip(local_tests, remote_tests):
+                        self._update_test(local_test, remote_test)
+                        self.progress_callback(remote_test)
+                        if remote_test.isFailure():
+                            self.failures += 1
+                            # max_failures is None or a positive int, never 0
+                            # (cl_arguments.py's _positive_int enforces i > 0),
+                            # so this equality check can't misfire on failures=0.
+                            if self.failures == self.max_failures:
+                                raise MaxFailuresError()
                     submit_next()
 
         except BrokenProcessPool as e:

--- a/llvm/utils/lit/lit/worker.py
+++ b/llvm/utils/lit/lit/worker.py
@@ -5,6 +5,8 @@ Exception: in single process mode _execute is called directly.
 For efficiency, we copy all data needed to execute all tests into each worker
 and store it in global variables. This reduces the cost of each task.
 """
+from __future__ import annotations
+
 import contextlib
 import os
 import signal
@@ -47,6 +49,18 @@ def execute(test):
 
     test.setResult(result)
     return test
+
+
+def execute_batch(tests: list[lit.Test.Test]) -> list[lit.Test.Test]:
+    """Runs a batch of tests in one dispatch to a worker process.
+
+    Args:
+        tests: The tests to run.
+
+    Returns:
+        The tests, in the order given, each with its result set.
+    """
+    return [execute(test) for test in tests]
 
 
 # TODO(python3): replace with contextlib.nullcontext


### PR DESCRIPTION
lit submits one test per ProcessPoolExecutor.submit(), so every test pays a pickle round trip out to a worker and back. This adds an opt-in flag that hands N tests to a worker in one dispatch, through a new worker.execute_batch(), so a single round trip covers the whole chunk. It reuses the per-test execute() unchanged, and at the default chunk size of 1 the submit call is the one that was there before, which leaves the shipped path untouched.

Chunks are contiguous slices of the dispatch order, which is why sizes above 1 require --order=random. Under the default --order=smart tests are sorted by descending duration, so a contiguous chunk collects several of the slowest tests onto one worker and leaves the others idle. lit refuses that combination rather than silently running it.

Pools are picked round-robin per chunk rather than by test index, which would otherwise send every chunk to the same pool whenever the chunk size is a multiple of the pool count.

Larger chunks coarsen abort behavior. --max-failures and --max-time stop the run later than they otherwise would, and a worker that crashes loses the rest of its chunk.