### PR TITLE
[libc++] Include range access headers in `<optional>` only since C++26

### DIFF
--- a/libcxx/include/optional
+++ b/libcxx/include/optional
@@ -275,12 +275,14 @@ namespace std {
 // [optional.syn]
 #  include <compare>
 
+#  if _LIBCPP_STD_VER >= 26
 // [iterator.range]
-#  include <__iterator/access.h>
-#  include <__iterator/data.h>
-#  include <__iterator/empty.h>
-#  include <__iterator/reverse_access.h>
-#  include <__iterator/size.h>
+#    include <__iterator/access.h>
+#    include <__iterator/data.h>
+#    include <__iterator/empty.h>
+#    include <__iterator/reverse_access.h>
+#    include <__iterator/size.h>
+#  endif // _LIBCPP_STD_VER >= 26
 
 #  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #    pragma GCC system_header

--- a/libcxx/test/std/iterators/iterator.range/mandatory_inclusions.gen.py
+++ b/libcxx/test/std/iterators/iterator.range/mandatory_inclusions.gen.py
@@ -51,11 +51,13 @@ headers = list(
     )
 )
 
+
 def get_standard_mode_threshold(header):
     if header == "optional":
-        return "26" # `optional` is a range only since C++26 via P3168R2.
+        return "26"  # `optional` is a range only since C++26 via P3168R2.
     else:
-        return "0" # Other related components are ranges at first.
+        return "0"  # Other related components are ranges at first.
+
 
 for header in headers:
     print(

--- a/libcxx/test/std/iterators/iterator.range/mandatory_inclusions.gen.py
+++ b/libcxx/test/std/iterators/iterator.range/mandatory_inclusions.gen.py
@@ -51,6 +51,12 @@ headers = list(
     )
 )
 
+def get_standard_mode_threshold(header):
+    if header == "optional":
+        return "26" # `optional` is a range only since C++26 via P3168R2.
+    else:
+        return "0" # Other related components are ranges at first.
+
 for header in headers:
     print(
         f"""\
@@ -81,6 +87,7 @@ struct Container {{
 }};
 
 int main(int, char**)  {{
+#if TEST_STD_VER >= {get_standard_mode_threshold(header)}
   {{
     Container c;
     const auto& cc = c;
@@ -174,6 +181,7 @@ int main(int, char**)  {{
     assert(std::ssize(cil) == 3);
 #endif
   }}
+#endif
 
   return 0;
 }}


### PR DESCRIPTION
Inclusions of internal range access headers address LWG4131 which patches P3168R2 "Give `std::optional` Range Support". As P3168R2 is certainly a new feature in C++26, these includes are unnecessary in old modes.

It was reported that these increased the size of `<optional>` by ~8%, so probably it is better to avoid such cost in old modes.