### PR TITLE
[AArch64] Improve lowering of pure fixed-length partial add reductions.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -34874,13 +34874,9 @@ AArch64TargetLowering::LowerPARTIAL_REDUCE_MLA(SDValue Op,
       (OpVT.is64BitVector() || OpVT.is128BitVector()) &&
       ResultVT.getScalarSizeInBits() == OpVT.getScalarSizeInBits() * 2 &&
       ResultVT.getVectorNumElements() * 2 == OpVT.getVectorNumElements()) {
-    // A pure partial reduction can lower to a [SU]ADALP.
-    if (isOneVector(RHS)) {
-      bool IsUnsigned = Op.getOpcode() == ISD::PARTIAL_REDUCE_UMLA;
-      unsigned Opc = IsUnsigned ? AArch64ISD::UADDLP : AArch64ISD::SADDLP;
-      return DAG.getNode(ISD::ADD, DL, ResultVT, Acc,
-                         DAG.getNode(Opc, DL, ResultVT, LHS));
-    }
+    // A pure partial reduction can lower to [SU]ADALP via patterns.
+    if (isOneVector(RHS))
+      return Op;
     // Otherwise, expand operations without efficient SVE lowering.
     if (OpVT.getScalarType() == MVT::i8 &&
         !(Subtarget->isSVEorStreamingSVEAvailable() &&

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -1538,6 +1538,18 @@ AArch64TargetLowering::AArch64TargetLowering(const TargetMachine &TM,
     for (MVT VT : { MVT::v16f16, MVT::v8f32, MVT::v4f64 })
       setOperationAction(ISD::FADD, VT, Custom);
 
+    // Two-way integer ``pure'' add reductions lower to a [SU]ADALP.
+    {
+      static const unsigned MLAOps[] = {ISD::PARTIAL_REDUCE_SMLA,
+                                        ISD::PARTIAL_REDUCE_UMLA};
+      setPartialReduceMLAAction(MLAOps, MVT::v4i16, MVT::v8i8, Custom);
+      setPartialReduceMLAAction(MLAOps, MVT::v2i32, MVT::v4i16, Custom);
+      setPartialReduceMLAAction(MLAOps, MVT::v1i64, MVT::v2i32, Custom);
+      setPartialReduceMLAAction(MLAOps, MVT::v8i16, MVT::v16i8, Custom);
+      setPartialReduceMLAAction(MLAOps, MVT::v4i32, MVT::v8i16, Custom);
+      setPartialReduceMLAAction(MLAOps, MVT::v2i64, MVT::v4i32, Custom);
+    }
+
     if (Subtarget->hasDotProd()) {
       static const unsigned MLAOps[] = {ISD::PARTIAL_REDUCE_SMLA,
                                         ISD::PARTIAL_REDUCE_UMLA};
@@ -34854,6 +34866,33 @@ AArch64TargetLowering::LowerPARTIAL_REDUCE_MLA(SDValue Op,
   EVT ResultVT = Op.getValueType();
   EVT OrigResultVT = ResultVT;
   EVT OpVT = LHS.getValueType();
+
+  // Two-way fixed-length integer add reductions.
+  if ((Op.getOpcode() == ISD::PARTIAL_REDUCE_UMLA ||
+       Op.getOpcode() == ISD::PARTIAL_REDUCE_SMLA) &&
+      Subtarget->isNeonAvailable() && ResultVT.isFixedLengthVector() &&
+      ResultVT.getScalarSizeInBits() == OpVT.getScalarSizeInBits() * 2 &&
+      ResultVT.getVectorNumElements() * 2 == OpVT.getVectorNumElements() &&
+      (OpVT.getSizeInBits() == 64 || OpVT.getSizeInBits() == 128)) {
+    // A pure partial reduction can lower to a [SU]ADALP.
+    if (isOneVector(RHS)) {
+      bool IsUnsigned = Op.getOpcode() == ISD::PARTIAL_REDUCE_UMLA;
+      unsigned Opc = IsUnsigned ? AArch64ISD::UADDLP : AArch64ISD::SADDLP;
+      return DAG.getNode(ISD::ADD, DL, ResultVT, Acc,
+                         DAG.getNode(Opc, DL, ResultVT, LHS));
+    }
+    // Otherwise, expand operations without efficient SVE lowering.
+    if (OpVT.getScalarType() == MVT::i8 &&
+        !(Subtarget->isSVEorStreamingSVEAvailable() &&
+          (Subtarget->hasSVE2p3() || Subtarget->hasSME2p3())))
+      return SDValue();
+    if (OpVT.getScalarType() == MVT::i16 &&
+        !(Subtarget->isSVEorStreamingSVEAvailable() &&
+          (Subtarget->hasSVE2p1() || Subtarget->hasSME2())))
+      return SDValue();
+    if (OpVT.getScalarType() == MVT::i32)
+      return SDValue();
+  }
 
   // We can handle this case natively by accumulating into a wider
   // zero-padded vector.

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -34870,10 +34870,10 @@ AArch64TargetLowering::LowerPARTIAL_REDUCE_MLA(SDValue Op,
   // Two-way fixed-length integer add reductions.
   if ((Op.getOpcode() == ISD::PARTIAL_REDUCE_UMLA ||
        Op.getOpcode() == ISD::PARTIAL_REDUCE_SMLA) &&
-      Subtarget->isNeonAvailable() && ResultVT.isFixedLengthVector() &&
+      Subtarget->isNeonAvailable() &&
+      (OpVT.is64BitVector() || OpVT.is128BitVector()) &&
       ResultVT.getScalarSizeInBits() == OpVT.getScalarSizeInBits() * 2 &&
-      ResultVT.getVectorNumElements() * 2 == OpVT.getVectorNumElements() &&
-      (OpVT.getSizeInBits() == 64 || OpVT.getSizeInBits() == 128)) {
+      ResultVT.getVectorNumElements() * 2 == OpVT.getVectorNumElements()) {
     // A pure partial reduction can lower to a [SU]ADALP.
     if (isOneVector(RHS)) {
       bool IsUnsigned = Op.getOpcode() == ISD::PARTIAL_REDUCE_UMLA;

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -6078,6 +6078,22 @@ defm URSQRTE: SIMDTwoVectorS<1, 1, 0b11100, "ursqrte", int_aarch64_neon_ursqrte>
 defm USQADD : SIMDTwoVectorBHSDTied<1, 0b00011, "usqadd",int_aarch64_neon_usqadd>;
 defm XTN    : SIMDMixedTwoVector<0, 0b10010, "xtn", trunc>;
 
+// Patterns for plain partial add reductions, which lower to [SU]ADALP.
+multiclass SelectVectorPartialReduceAdd<ValueType DstVT, ValueType SrcVT, dag immOneV> {
+  def : Pat<(DstVT (partial_reduce_smla DstVT:$Acc, SrcVT:$Input, (SrcVT immOneV))),
+            (!cast<Instruction>("SADALP" # SrcVT # "_" # DstVT) $Acc, $Input)>;
+
+  def : Pat<(DstVT (partial_reduce_umla DstVT:$Acc, SrcVT:$Input, (SrcVT immOneV))),
+            (!cast<Instruction>("UADALP" # SrcVT # "_" # DstVT) $Acc, $Input)>;
+}
+
+defm : SelectVectorPartialReduceAdd<v4i16, v8i8, (AArch64movi (i32 1))>;
+defm : SelectVectorPartialReduceAdd<v2i32, v4i16, (AArch64movi_shift (i32 1), (i32 0))>;
+defm : SelectVectorPartialReduceAdd<v1i64, v2i32, (AArch64movi_shift (i32 1), (i32 0))>;
+defm : SelectVectorPartialReduceAdd<v8i16, v16i8, (AArch64movi (i32 1))>;
+defm : SelectVectorPartialReduceAdd<v4i32, v8i16, (AArch64movi_shift (i32 1), (i32 0))>;
+defm : SelectVectorPartialReduceAdd<v2i64, v4i32, (AArch64movi_shift (i32 1), (i32 0))>;
+
 def : Pat<(v4f16  (AArch64rev32 V64:$Rn)),  (REV32v4i16 V64:$Rn)>;
 def : Pat<(v4f16  (AArch64rev64 V64:$Rn)),  (REV64v4i16 V64:$Rn)>;
 def : Pat<(v4bf16 (AArch64rev32 V64:$Rn)),  (REV32v4i16 V64:$Rn)>;

--- a/llvm/test/CodeGen/AArch64/neon-partial-reduce-dot-product.ll
+++ b/llvm/test/CodeGen/AArch64/neon-partial-reduce-dot-product.ll
@@ -1791,8 +1791,7 @@ define <2 x i64> @partial_reduce_sext_cmp_i32tov2i64(<2 x i64> %acc, <4 x i32> %
 ; CHECK-COMMON-LABEL: partial_reduce_sext_cmp_i32tov2i64:
 ; CHECK-COMMON:       // %bb.0:
 ; CHECK-COMMON-NEXT:    cmeq v1.4s, v1.4s, v2.4s
-; CHECK-COMMON-NEXT:    saddw v0.2d, v0.2d, v1.2s
-; CHECK-COMMON-NEXT:    saddw2 v0.2d, v0.2d, v1.4s
+; CHECK-COMMON-NEXT:    sadalp v0.2d, v1.4s
 ; CHECK-COMMON-NEXT:    ret
   %cmp = icmp eq <4 x i32> %a, %b
   %ext = sext <4 x i1> %cmp to <4 x i64>

--- a/llvm/test/CodeGen/AArch64/neon-partial-reduce-dot-product.ll
+++ b/llvm/test/CodeGen/AArch64/neon-partial-reduce-dot-product.ll
@@ -8,10 +8,8 @@ define <4 x i32> @udot(<4 x i32> %acc, <16 x i8> %u, <16 x i8> %s) {
 ; CHECK-NODOT:       // %bb.0:
 ; CHECK-NODOT-NEXT:    umull v3.8h, v2.8b, v1.8b
 ; CHECK-NODOT-NEXT:    umull2 v1.8h, v2.16b, v1.16b
-; CHECK-NODOT-NEXT:    uaddw v0.4s, v0.4s, v3.4h
-; CHECK-NODOT-NEXT:    uaddw2 v0.4s, v0.4s, v3.8h
-; CHECK-NODOT-NEXT:    uaddw v0.4s, v0.4s, v1.4h
-; CHECK-NODOT-NEXT:    uaddw2 v0.4s, v0.4s, v1.8h
+; CHECK-NODOT-NEXT:    uadalp v0.4s, v3.8h
+; CHECK-NODOT-NEXT:    uadalp v0.4s, v1.8h
 ; CHECK-NODOT-NEXT:    ret
 ;
 ; CHECK-DOT-LABEL: udot:
@@ -44,10 +42,8 @@ define <4 x i32> @udot_in_loop(ptr %p1, ptr %p2){
 ; CHECK-NODOT-NEXT:    umull v4.8h, v2.8b, v3.8b
 ; CHECK-NODOT-NEXT:    umull2 v2.8h, v2.16b, v3.16b
 ; CHECK-NODOT-NEXT:    cmp x8, #16
-; CHECK-NODOT-NEXT:    uaddw v1.4s, v1.4s, v4.4h
-; CHECK-NODOT-NEXT:    uaddw2 v1.4s, v1.4s, v4.8h
-; CHECK-NODOT-NEXT:    uaddw v1.4s, v1.4s, v2.4h
-; CHECK-NODOT-NEXT:    uaddw2 v1.4s, v1.4s, v2.8h
+; CHECK-NODOT-NEXT:    uadalp v1.4s, v4.8h
+; CHECK-NODOT-NEXT:    uadalp v1.4s, v2.8h
 ; CHECK-NODOT-NEXT:    b.ne .LBB1_1
 ; CHECK-NODOT-NEXT:  // %bb.2: // %end
 ; CHECK-NODOT-NEXT:    ret
@@ -109,16 +105,9 @@ define <2 x i32> @udot_narrow(<2 x i32> %acc, <8 x i8> %u, <8 x i8> %s) {
 ; CHECK-NODOT-LABEL: udot_narrow:
 ; CHECK-NODOT:       // %bb.0:
 ; CHECK-NODOT-NEXT:    umull v1.8h, v2.8b, v1.8b
-; CHECK-NODOT-NEXT:    // kill: def $d0 killed $d0 def $q0
-; CHECK-NODOT-NEXT:    ushll v2.4s, v1.4h, #0
-; CHECK-NODOT-NEXT:    uaddw v0.4s, v0.4s, v1.4h
-; CHECK-NODOT-NEXT:    ushll2 v3.4s, v1.8h, #0
+; CHECK-NODOT-NEXT:    uadalp v0.2s, v1.4h
 ; CHECK-NODOT-NEXT:    mov d1, v1.d[1]
-; CHECK-NODOT-NEXT:    mov d2, v2.d[1]
-; CHECK-NODOT-NEXT:    add v0.2s, v2.2s, v0.2s
-; CHECK-NODOT-NEXT:    mov d2, v3.d[1]
-; CHECK-NODOT-NEXT:    uaddw v0.4s, v0.4s, v1.4h
-; CHECK-NODOT-NEXT:    add v0.2s, v2.2s, v0.2s
+; CHECK-NODOT-NEXT:    uadalp v0.2s, v1.4h
 ; CHECK-NODOT-NEXT:    ret
 ;
 ; CHECK-DOT-LABEL: udot_narrow:
@@ -142,10 +131,8 @@ define <4 x i32> @sdot(<4 x i32> %acc, <16 x i8> %u, <16 x i8> %s) {
 ; CHECK-NODOT:       // %bb.0:
 ; CHECK-NODOT-NEXT:    smull v3.8h, v2.8b, v1.8b
 ; CHECK-NODOT-NEXT:    smull2 v1.8h, v2.16b, v1.16b
-; CHECK-NODOT-NEXT:    saddw v0.4s, v0.4s, v3.4h
-; CHECK-NODOT-NEXT:    saddw2 v0.4s, v0.4s, v3.8h
-; CHECK-NODOT-NEXT:    saddw v0.4s, v0.4s, v1.4h
-; CHECK-NODOT-NEXT:    saddw2 v0.4s, v0.4s, v1.8h
+; CHECK-NODOT-NEXT:    sadalp v0.4s, v3.8h
+; CHECK-NODOT-NEXT:    sadalp v0.4s, v1.8h
 ; CHECK-NODOT-NEXT:    ret
 ;
 ; CHECK-DOT-LABEL: sdot:
@@ -168,16 +155,9 @@ define <2 x i32> @sdot_narrow(<2 x i32> %acc, <8 x i8> %u, <8 x i8> %s) {
 ; CHECK-NODOT-LABEL: sdot_narrow:
 ; CHECK-NODOT:       // %bb.0:
 ; CHECK-NODOT-NEXT:    smull v1.8h, v2.8b, v1.8b
-; CHECK-NODOT-NEXT:    // kill: def $d0 killed $d0 def $q0
-; CHECK-NODOT-NEXT:    sshll v2.4s, v1.4h, #0
-; CHECK-NODOT-NEXT:    saddw v0.4s, v0.4s, v1.4h
-; CHECK-NODOT-NEXT:    sshll2 v3.4s, v1.8h, #0
+; CHECK-NODOT-NEXT:    sadalp v0.2s, v1.4h
 ; CHECK-NODOT-NEXT:    mov d1, v1.d[1]
-; CHECK-NODOT-NEXT:    mov d2, v2.d[1]
-; CHECK-NODOT-NEXT:    add v0.2s, v2.2s, v0.2s
-; CHECK-NODOT-NEXT:    mov d2, v3.d[1]
-; CHECK-NODOT-NEXT:    saddw v0.4s, v0.4s, v1.4h
-; CHECK-NODOT-NEXT:    add v0.2s, v2.2s, v0.2s
+; CHECK-NODOT-NEXT:    sadalp v0.2s, v1.4h
 ; CHECK-NODOT-NEXT:    ret
 ;
 ; CHECK-DOT-LABEL: sdot_narrow:
@@ -908,16 +888,9 @@ define <2 x i32> @udot_no_bin_op_narrow(<2 x i32> %acc, <8 x i8> %a){
 ; CHECK-NODOT-LABEL: udot_no_bin_op_narrow:
 ; CHECK-NODOT:       // %bb.0:
 ; CHECK-NODOT-NEXT:    ushll v1.8h, v1.8b, #0
-; CHECK-NODOT-NEXT:    // kill: def $d0 killed $d0 def $q0
-; CHECK-NODOT-NEXT:    ushll v2.4s, v1.4h, #0
-; CHECK-NODOT-NEXT:    uaddw v0.4s, v0.4s, v1.4h
-; CHECK-NODOT-NEXT:    ushll2 v3.4s, v1.8h, #0
+; CHECK-NODOT-NEXT:    uadalp v0.2s, v1.4h
 ; CHECK-NODOT-NEXT:    mov d1, v1.d[1]
-; CHECK-NODOT-NEXT:    mov d2, v2.d[1]
-; CHECK-NODOT-NEXT:    add v0.2s, v2.2s, v0.2s
-; CHECK-NODOT-NEXT:    mov d2, v3.d[1]
-; CHECK-NODOT-NEXT:    uaddw v0.4s, v0.4s, v1.4h
-; CHECK-NODOT-NEXT:    add v0.2s, v2.2s, v0.2s
+; CHECK-NODOT-NEXT:    uadalp v0.2s, v1.4h
 ; CHECK-NODOT-NEXT:    ret
 ;
 ; CHECK-DOT-LABEL: udot_no_bin_op_narrow:
@@ -940,16 +913,9 @@ define <2 x i32> @sdot_no_bin_op_narrow(<2 x i32> %acc, <8 x i8> %a){
 ; CHECK-NODOT-LABEL: sdot_no_bin_op_narrow:
 ; CHECK-NODOT:       // %bb.0:
 ; CHECK-NODOT-NEXT:    sshll v1.8h, v1.8b, #0
-; CHECK-NODOT-NEXT:    // kill: def $d0 killed $d0 def $q0
-; CHECK-NODOT-NEXT:    sshll v2.4s, v1.4h, #0
-; CHECK-NODOT-NEXT:    saddw v0.4s, v0.4s, v1.4h
-; CHECK-NODOT-NEXT:    sshll2 v3.4s, v1.8h, #0
+; CHECK-NODOT-NEXT:    sadalp v0.2s, v1.4h
 ; CHECK-NODOT-NEXT:    mov d1, v1.d[1]
-; CHECK-NODOT-NEXT:    mov d2, v2.d[1]
-; CHECK-NODOT-NEXT:    add v0.2s, v2.2s, v0.2s
-; CHECK-NODOT-NEXT:    mov d2, v3.d[1]
-; CHECK-NODOT-NEXT:    saddw v0.4s, v0.4s, v1.4h
-; CHECK-NODOT-NEXT:    add v0.2s, v2.2s, v0.2s
+; CHECK-NODOT-NEXT:    sadalp v0.2s, v1.4h
 ; CHECK-NODOT-NEXT:    ret
 ;
 ; CHECK-DOT-LABEL: sdot_no_bin_op_narrow:
@@ -1050,8 +1016,7 @@ define <4 x i32> @not_udot(<4 x i32> %acc, <8 x i8> %u, <8 x i8> %s) #0{
 ; CHECK-COMMON-LABEL: not_udot:
 ; CHECK-COMMON:       // %bb.0:
 ; CHECK-COMMON-NEXT:    umull v1.8h, v2.8b, v1.8b
-; CHECK-COMMON-NEXT:    uaddw v0.4s, v0.4s, v1.4h
-; CHECK-COMMON-NEXT:    uaddw2 v0.4s, v0.4s, v1.8h
+; CHECK-COMMON-NEXT:    uadalp v0.4s, v1.8h
 ; CHECK-COMMON-NEXT:    ret
   %u.wide = zext <8 x i8> %u to <8 x i32>
   %s.wide = zext <8 x i8> %s to <8 x i32>
@@ -1483,26 +1448,13 @@ define <2 x i32> @udot_v16i8tov2i32(<2 x i32> %acc, <16 x i8> %input) {
 ; CHECK-NODOT-LABEL: udot_v16i8tov2i32:
 ; CHECK-NODOT:       // %bb.0: // %entry
 ; CHECK-NODOT-NEXT:    ushll v2.8h, v1.8b, #0
-; CHECK-NODOT-NEXT:    // kill: def $d0 killed $d0 def $q0
 ; CHECK-NODOT-NEXT:    ushll2 v1.8h, v1.16b, #0
-; CHECK-NODOT-NEXT:    ushll v3.4s, v2.4h, #0
-; CHECK-NODOT-NEXT:    uaddw v0.4s, v0.4s, v2.4h
-; CHECK-NODOT-NEXT:    ushll2 v4.4s, v2.8h, #0
+; CHECK-NODOT-NEXT:    uadalp v0.2s, v2.4h
 ; CHECK-NODOT-NEXT:    mov d2, v2.d[1]
-; CHECK-NODOT-NEXT:    mov d3, v3.d[1]
-; CHECK-NODOT-NEXT:    add v0.2s, v3.2s, v0.2s
-; CHECK-NODOT-NEXT:    mov d3, v4.d[1]
-; CHECK-NODOT-NEXT:    uaddw v0.4s, v0.4s, v2.4h
-; CHECK-NODOT-NEXT:    ushll v2.4s, v1.4h, #0
-; CHECK-NODOT-NEXT:    add v0.2s, v3.2s, v0.2s
-; CHECK-NODOT-NEXT:    mov d2, v2.d[1]
-; CHECK-NODOT-NEXT:    ushll2 v3.4s, v1.8h, #0
-; CHECK-NODOT-NEXT:    uaddw v0.4s, v0.4s, v1.4h
+; CHECK-NODOT-NEXT:    uadalp v0.2s, v2.4h
+; CHECK-NODOT-NEXT:    uadalp v0.2s, v1.4h
 ; CHECK-NODOT-NEXT:    mov d1, v1.d[1]
-; CHECK-NODOT-NEXT:    add v0.2s, v2.2s, v0.2s
-; CHECK-NODOT-NEXT:    mov d2, v3.d[1]
-; CHECK-NODOT-NEXT:    uaddw v0.4s, v0.4s, v1.4h
-; CHECK-NODOT-NEXT:    add v0.2s, v2.2s, v0.2s
+; CHECK-NODOT-NEXT:    uadalp v0.2s, v1.4h
 ; CHECK-NODOT-NEXT:    ret
 ;
 ; CHECK-DOT-LABEL: udot_v16i8tov2i32:

--- a/llvm/test/CodeGen/AArch64/sve-fixed-length-partial-reduce.ll
+++ b/llvm/test/CodeGen/AArch64/sve-fixed-length-partial-reduce.ll
@@ -12,33 +12,14 @@ target triple = "aarch64"
 
 define <8 x i16> @two_way_i8_i16_vl128(ptr %accptr, ptr %uptr, ptr %sptr) {
 ;
-; NEON-LABEL: two_way_i8_i16_vl128:
-; NEON:       // %bb.0:
-; NEON-NEXT:    ldr q0, [x0]
-; NEON-NEXT:    ldr q1, [x1]
-; NEON-NEXT:    ldr q2, [x2]
-; NEON-NEXT:    umlal v0.8h, v2.8b, v1.8b
-; NEON-NEXT:    umlal2 v0.8h, v2.16b, v1.16b
-; NEON-NEXT:    ret
-;
-; SVE-LABEL: two_way_i8_i16_vl128:
-; SVE:       // %bb.0:
-; SVE-NEXT:    ldr q0, [x0]
-; SVE-NEXT:    ldr q1, [x1]
-; SVE-NEXT:    ldr q2, [x2]
-; SVE-NEXT:    umlal v0.8h, v2.8b, v1.8b
-; SVE-NEXT:    umlal2 v0.8h, v2.16b, v1.16b
-; SVE-NEXT:    ret
-;
-; SVE2-LABEL: two_way_i8_i16_vl128:
-; SVE2:       // %bb.0:
-; SVE2-NEXT:    ldr q0, [x0]
-; SVE2-NEXT:    ldr q1, [x1]
-; SVE2-NEXT:    ldr q2, [x2]
-; SVE2-NEXT:    umlalb z0.h, z2.b, z1.b
-; SVE2-NEXT:    umlalt z0.h, z2.b, z1.b
-; SVE2-NEXT:    // kill: def $q0 killed $q0 killed $z0
-; SVE2-NEXT:    ret
+; COMMON-LABEL: two_way_i8_i16_vl128:
+; COMMON:       // %bb.0:
+; COMMON-NEXT:    ldr q0, [x0]
+; COMMON-NEXT:    ldr q1, [x1]
+; COMMON-NEXT:    ldr q2, [x2]
+; COMMON-NEXT:    umlal v0.8h, v2.8b, v1.8b
+; COMMON-NEXT:    umlal2 v0.8h, v2.16b, v1.16b
+; COMMON-NEXT:    ret
 ;
 ; SME-LABEL: two_way_i8_i16_vl128:
 ; SME:       // %bb.0:
@@ -60,40 +41,16 @@ define <8 x i16> @two_way_i8_i16_vl128(ptr %accptr, ptr %uptr, ptr %sptr) {
 
 define <16 x i16> @two_way_i8_i16_vl128_double_width(ptr %accptr, ptr %uptr, ptr %sptr) {
 ;
-; NEON-LABEL: two_way_i8_i16_vl128_double_width:
-; NEON:       // %bb.0:
-; NEON-NEXT:    ldp q0, q1, [x0]
-; NEON-NEXT:    ldp q2, q3, [x1]
-; NEON-NEXT:    ldp q4, q5, [x2]
-; NEON-NEXT:    umlal v0.8h, v4.8b, v2.8b
-; NEON-NEXT:    umlal v1.8h, v5.8b, v3.8b
-; NEON-NEXT:    umlal2 v0.8h, v4.16b, v2.16b
-; NEON-NEXT:    umlal2 v1.8h, v5.16b, v3.16b
-; NEON-NEXT:    ret
-;
-; SVE-LABEL: two_way_i8_i16_vl128_double_width:
-; SVE:       // %bb.0:
-; SVE-NEXT:    ldp q0, q1, [x0]
-; SVE-NEXT:    ldp q2, q3, [x1]
-; SVE-NEXT:    ldp q4, q5, [x2]
-; SVE-NEXT:    umlal v0.8h, v4.8b, v2.8b
-; SVE-NEXT:    umlal v1.8h, v5.8b, v3.8b
-; SVE-NEXT:    umlal2 v0.8h, v4.16b, v2.16b
-; SVE-NEXT:    umlal2 v1.8h, v5.16b, v3.16b
-; SVE-NEXT:    ret
-;
-; SVE2-LABEL: two_way_i8_i16_vl128_double_width:
-; SVE2:       // %bb.0:
-; SVE2-NEXT:    ldp q0, q1, [x0]
-; SVE2-NEXT:    ldp q3, q2, [x1]
-; SVE2-NEXT:    ldp q5, q4, [x2]
-; SVE2-NEXT:    umlalb z0.h, z5.b, z3.b
-; SVE2-NEXT:    umlalb z1.h, z4.b, z2.b
-; SVE2-NEXT:    umlalt z0.h, z5.b, z3.b
-; SVE2-NEXT:    umlalt z1.h, z4.b, z2.b
-; SVE2-NEXT:    // kill: def $q0 killed $q0 killed $z0
-; SVE2-NEXT:    // kill: def $q1 killed $q1 killed $z1
-; SVE2-NEXT:    ret
+; COMMON-LABEL: two_way_i8_i16_vl128_double_width:
+; COMMON:       // %bb.0:
+; COMMON-NEXT:    ldp q0, q1, [x0]
+; COMMON-NEXT:    ldp q3, q2, [x1]
+; COMMON-NEXT:    ldp q5, q4, [x2]
+; COMMON-NEXT:    umlal v0.8h, v5.8b, v3.8b
+; COMMON-NEXT:    umlal v1.8h, v4.8b, v2.8b
+; COMMON-NEXT:    umlal2 v0.8h, v5.16b, v3.16b
+; COMMON-NEXT:    umlal2 v1.8h, v4.16b, v2.16b
+; COMMON-NEXT:    ret
 ;
 ; SME-LABEL: two_way_i8_i16_vl128_double_width:
 ; SME:       // %bb.0:
@@ -121,12 +78,12 @@ define <16 x i16> @two_way_i8_i16_vl256(ptr %accptr, ptr %uptr, ptr %sptr) vscal
 ; NEON-LABEL: two_way_i8_i16_vl256:
 ; NEON:       // %bb.0:
 ; NEON-NEXT:    ldp q0, q1, [x0]
-; NEON-NEXT:    ldp q2, q3, [x1]
-; NEON-NEXT:    ldp q4, q5, [x2]
-; NEON-NEXT:    umlal v0.8h, v4.8b, v2.8b
-; NEON-NEXT:    umlal v1.8h, v5.8b, v3.8b
-; NEON-NEXT:    umlal2 v0.8h, v4.16b, v2.16b
-; NEON-NEXT:    umlal2 v1.8h, v5.16b, v3.16b
+; NEON-NEXT:    ldp q3, q2, [x1]
+; NEON-NEXT:    ldp q5, q4, [x2]
+; NEON-NEXT:    umlal v0.8h, v5.8b, v3.8b
+; NEON-NEXT:    umlal v1.8h, v4.8b, v2.8b
+; NEON-NEXT:    umlal2 v0.8h, v5.16b, v3.16b
+; NEON-NEXT:    umlal2 v1.8h, v4.16b, v2.16b
 ; NEON-NEXT:    ret
 ;
 ; SVE-LABEL: two_way_i8_i16_vl256:
@@ -186,33 +143,14 @@ define <16 x i16> @two_way_i8_i16_vl256(ptr %accptr, ptr %uptr, ptr %sptr) vscal
 
 define <4 x i32> @two_way_i16_i32_vl128(ptr %accptr, ptr %uptr, ptr %sptr) {
 ;
-; NEON-LABEL: two_way_i16_i32_vl128:
-; NEON:       // %bb.0:
-; NEON-NEXT:    ldr q0, [x0]
-; NEON-NEXT:    ldr q1, [x1]
-; NEON-NEXT:    ldr q2, [x2]
-; NEON-NEXT:    umlal v0.4s, v2.4h, v1.4h
-; NEON-NEXT:    umlal2 v0.4s, v2.8h, v1.8h
-; NEON-NEXT:    ret
-;
-; SVE-LABEL: two_way_i16_i32_vl128:
-; SVE:       // %bb.0:
-; SVE-NEXT:    ldr q0, [x0]
-; SVE-NEXT:    ldr q1, [x1]
-; SVE-NEXT:    ldr q2, [x2]
-; SVE-NEXT:    umlal v0.4s, v2.4h, v1.4h
-; SVE-NEXT:    umlal2 v0.4s, v2.8h, v1.8h
-; SVE-NEXT:    ret
-;
-; SVE2-LABEL: two_way_i16_i32_vl128:
-; SVE2:       // %bb.0:
-; SVE2-NEXT:    ldr q0, [x0]
-; SVE2-NEXT:    ldr q1, [x1]
-; SVE2-NEXT:    ldr q2, [x2]
-; SVE2-NEXT:    umlalb z0.s, z2.h, z1.h
-; SVE2-NEXT:    umlalt z0.s, z2.h, z1.h
-; SVE2-NEXT:    // kill: def $q0 killed $q0 killed $z0
-; SVE2-NEXT:    ret
+; COMMON-LABEL: two_way_i16_i32_vl128:
+; COMMON:       // %bb.0:
+; COMMON-NEXT:    ldr q0, [x0]
+; COMMON-NEXT:    ldr q1, [x1]
+; COMMON-NEXT:    ldr q2, [x2]
+; COMMON-NEXT:    umlal v0.4s, v2.4h, v1.4h
+; COMMON-NEXT:    umlal2 v0.4s, v2.8h, v1.8h
+; COMMON-NEXT:    ret
 ;
 ; SME-LABEL: two_way_i16_i32_vl128:
 ; SME:       // %bb.0:
@@ -234,40 +172,16 @@ define <4 x i32> @two_way_i16_i32_vl128(ptr %accptr, ptr %uptr, ptr %sptr) {
 
 define <8 x i32> @two_way_i16_i32_vl128_double_width(ptr %accptr, ptr %uptr, ptr %sptr) {
 ;
-; NEON-LABEL: two_way_i16_i32_vl128_double_width:
-; NEON:       // %bb.0:
-; NEON-NEXT:    ldp q0, q1, [x0]
-; NEON-NEXT:    ldp q2, q3, [x1]
-; NEON-NEXT:    ldp q4, q5, [x2]
-; NEON-NEXT:    umlal v0.4s, v4.4h, v2.4h
-; NEON-NEXT:    umlal v1.4s, v5.4h, v3.4h
-; NEON-NEXT:    umlal2 v0.4s, v4.8h, v2.8h
-; NEON-NEXT:    umlal2 v1.4s, v5.8h, v3.8h
-; NEON-NEXT:    ret
-;
-; SVE-LABEL: two_way_i16_i32_vl128_double_width:
-; SVE:       // %bb.0:
-; SVE-NEXT:    ldp q0, q1, [x0]
-; SVE-NEXT:    ldp q2, q3, [x1]
-; SVE-NEXT:    ldp q4, q5, [x2]
-; SVE-NEXT:    umlal v0.4s, v4.4h, v2.4h
-; SVE-NEXT:    umlal v1.4s, v5.4h, v3.4h
-; SVE-NEXT:    umlal2 v0.4s, v4.8h, v2.8h
-; SVE-NEXT:    umlal2 v1.4s, v5.8h, v3.8h
-; SVE-NEXT:    ret
-;
-; SVE2-LABEL: two_way_i16_i32_vl128_double_width:
-; SVE2:       // %bb.0:
-; SVE2-NEXT:    ldp q0, q1, [x0]
-; SVE2-NEXT:    ldp q3, q2, [x1]
-; SVE2-NEXT:    ldp q5, q4, [x2]
-; SVE2-NEXT:    umlalb z0.s, z5.h, z3.h
-; SVE2-NEXT:    umlalb z1.s, z4.h, z2.h
-; SVE2-NEXT:    umlalt z0.s, z5.h, z3.h
-; SVE2-NEXT:    umlalt z1.s, z4.h, z2.h
-; SVE2-NEXT:    // kill: def $q0 killed $q0 killed $z0
-; SVE2-NEXT:    // kill: def $q1 killed $q1 killed $z1
-; SVE2-NEXT:    ret
+; COMMON-LABEL: two_way_i16_i32_vl128_double_width:
+; COMMON:       // %bb.0:
+; COMMON-NEXT:    ldp q0, q1, [x0]
+; COMMON-NEXT:    ldp q3, q2, [x1]
+; COMMON-NEXT:    ldp q5, q4, [x2]
+; COMMON-NEXT:    umlal v0.4s, v5.4h, v3.4h
+; COMMON-NEXT:    umlal v1.4s, v4.4h, v2.4h
+; COMMON-NEXT:    umlal2 v0.4s, v5.8h, v3.8h
+; COMMON-NEXT:    umlal2 v1.4s, v4.8h, v2.8h
+; COMMON-NEXT:    ret
 ;
 ; SME-LABEL: two_way_i16_i32_vl128_double_width:
 ; SME:       // %bb.0:
@@ -295,12 +209,12 @@ define <8 x i32> @two_way_i16_i32_vl256(ptr %accptr, ptr %uptr, ptr %sptr) vscal
 ; NEON-LABEL: two_way_i16_i32_vl256:
 ; NEON:       // %bb.0:
 ; NEON-NEXT:    ldp q0, q1, [x0]
-; NEON-NEXT:    ldp q2, q3, [x1]
-; NEON-NEXT:    ldp q4, q5, [x2]
-; NEON-NEXT:    umlal v0.4s, v4.4h, v2.4h
-; NEON-NEXT:    umlal v1.4s, v5.4h, v3.4h
-; NEON-NEXT:    umlal2 v0.4s, v4.8h, v2.8h
-; NEON-NEXT:    umlal2 v1.4s, v5.8h, v3.8h
+; NEON-NEXT:    ldp q3, q2, [x1]
+; NEON-NEXT:    ldp q5, q4, [x2]
+; NEON-NEXT:    umlal v0.4s, v5.4h, v3.4h
+; NEON-NEXT:    umlal v1.4s, v4.4h, v2.4h
+; NEON-NEXT:    umlal2 v0.4s, v5.8h, v3.8h
+; NEON-NEXT:    umlal2 v1.4s, v4.8h, v2.8h
 ; NEON-NEXT:    ret
 ;
 ; SVE-LABEL: two_way_i16_i32_vl256:
@@ -360,33 +274,14 @@ define <8 x i32> @two_way_i16_i32_vl256(ptr %accptr, ptr %uptr, ptr %sptr) vscal
 
 define <2 x i64> @two_way_i32_i64_vl128(ptr %accptr, ptr %uptr, ptr %sptr) {
 ;
-; NEON-LABEL: two_way_i32_i64_vl128:
-; NEON:       // %bb.0:
-; NEON-NEXT:    ldr q0, [x0]
-; NEON-NEXT:    ldr q1, [x1]
-; NEON-NEXT:    ldr q2, [x2]
-; NEON-NEXT:    umlal v0.2d, v2.2s, v1.2s
-; NEON-NEXT:    umlal2 v0.2d, v2.4s, v1.4s
-; NEON-NEXT:    ret
-;
-; SVE-LABEL: two_way_i32_i64_vl128:
-; SVE:       // %bb.0:
-; SVE-NEXT:    ldr q0, [x0]
-; SVE-NEXT:    ldr q1, [x1]
-; SVE-NEXT:    ldr q2, [x2]
-; SVE-NEXT:    umlal v0.2d, v2.2s, v1.2s
-; SVE-NEXT:    umlal2 v0.2d, v2.4s, v1.4s
-; SVE-NEXT:    ret
-;
-; SVE2-LABEL: two_way_i32_i64_vl128:
-; SVE2:       // %bb.0:
-; SVE2-NEXT:    ldr q0, [x0]
-; SVE2-NEXT:    ldr q1, [x1]
-; SVE2-NEXT:    ldr q2, [x2]
-; SVE2-NEXT:    umlalb z0.d, z2.s, z1.s
-; SVE2-NEXT:    umlalt z0.d, z2.s, z1.s
-; SVE2-NEXT:    // kill: def $q0 killed $q0 killed $z0
-; SVE2-NEXT:    ret
+; COMMON-LABEL: two_way_i32_i64_vl128:
+; COMMON:       // %bb.0:
+; COMMON-NEXT:    ldr q0, [x0]
+; COMMON-NEXT:    ldr q1, [x1]
+; COMMON-NEXT:    ldr q2, [x2]
+; COMMON-NEXT:    umlal v0.2d, v2.2s, v1.2s
+; COMMON-NEXT:    umlal2 v0.2d, v2.4s, v1.4s
+; COMMON-NEXT:    ret
 ;
 ; SME-LABEL: two_way_i32_i64_vl128:
 ; SME:       // %bb.0:
@@ -408,40 +303,16 @@ define <2 x i64> @two_way_i32_i64_vl128(ptr %accptr, ptr %uptr, ptr %sptr) {
 
 define <4 x i64> @two_way_i32_i64_vl128_double_width(ptr %accptr, ptr %uptr, ptr %sptr) {
 ;
-; NEON-LABEL: two_way_i32_i64_vl128_double_width:
-; NEON:       // %bb.0:
-; NEON-NEXT:    ldp q0, q1, [x0]
-; NEON-NEXT:    ldp q2, q3, [x1]
-; NEON-NEXT:    ldp q4, q5, [x2]
-; NEON-NEXT:    umlal v0.2d, v4.2s, v2.2s
-; NEON-NEXT:    umlal v1.2d, v5.2s, v3.2s
-; NEON-NEXT:    umlal2 v0.2d, v4.4s, v2.4s
-; NEON-NEXT:    umlal2 v1.2d, v5.4s, v3.4s
-; NEON-NEXT:    ret
-;
-; SVE-LABEL: two_way_i32_i64_vl128_double_width:
-; SVE:       // %bb.0:
-; SVE-NEXT:    ldp q0, q1, [x0]
-; SVE-NEXT:    ldp q2, q3, [x1]
-; SVE-NEXT:    ldp q4, q5, [x2]
-; SVE-NEXT:    umlal v0.2d, v4.2s, v2.2s
-; SVE-NEXT:    umlal v1.2d, v5.2s, v3.2s
-; SVE-NEXT:    umlal2 v0.2d, v4.4s, v2.4s
-; SVE-NEXT:    umlal2 v1.2d, v5.4s, v3.4s
-; SVE-NEXT:    ret
-;
-; SVE2-LABEL: two_way_i32_i64_vl128_double_width:
-; SVE2:       // %bb.0:
-; SVE2-NEXT:    ldp q0, q1, [x0]
-; SVE2-NEXT:    ldp q3, q2, [x1]
-; SVE2-NEXT:    ldp q5, q4, [x2]
-; SVE2-NEXT:    umlalb z0.d, z5.s, z3.s
-; SVE2-NEXT:    umlalb z1.d, z4.s, z2.s
-; SVE2-NEXT:    umlalt z0.d, z5.s, z3.s
-; SVE2-NEXT:    umlalt z1.d, z4.s, z2.s
-; SVE2-NEXT:    // kill: def $q0 killed $q0 killed $z0
-; SVE2-NEXT:    // kill: def $q1 killed $q1 killed $z1
-; SVE2-NEXT:    ret
+; COMMON-LABEL: two_way_i32_i64_vl128_double_width:
+; COMMON:       // %bb.0:
+; COMMON-NEXT:    ldp q0, q1, [x0]
+; COMMON-NEXT:    ldp q3, q2, [x1]
+; COMMON-NEXT:    ldp q5, q4, [x2]
+; COMMON-NEXT:    umlal v0.2d, v5.2s, v3.2s
+; COMMON-NEXT:    umlal v1.2d, v4.2s, v2.2s
+; COMMON-NEXT:    umlal2 v0.2d, v5.4s, v3.4s
+; COMMON-NEXT:    umlal2 v1.2d, v4.4s, v2.4s
+; COMMON-NEXT:    ret
 ;
 ; SME-LABEL: two_way_i32_i64_vl128_double_width:
 ; SME:       // %bb.0:
@@ -469,12 +340,12 @@ define <4 x i64> @two_way_i32_i64_vl256(ptr %accptr, ptr %uptr, ptr %sptr) vscal
 ; NEON-LABEL: two_way_i32_i64_vl256:
 ; NEON:       // %bb.0:
 ; NEON-NEXT:    ldp q0, q1, [x0]
-; NEON-NEXT:    ldp q2, q3, [x1]
-; NEON-NEXT:    ldp q4, q5, [x2]
-; NEON-NEXT:    umlal v0.2d, v4.2s, v2.2s
-; NEON-NEXT:    umlal v1.2d, v5.2s, v3.2s
-; NEON-NEXT:    umlal2 v0.2d, v4.4s, v2.4s
-; NEON-NEXT:    umlal2 v1.2d, v5.4s, v3.4s
+; NEON-NEXT:    ldp q3, q2, [x1]
+; NEON-NEXT:    ldp q5, q4, [x2]
+; NEON-NEXT:    umlal v0.2d, v5.2s, v3.2s
+; NEON-NEXT:    umlal v1.2d, v4.2s, v2.2s
+; NEON-NEXT:    umlal2 v0.2d, v5.4s, v3.4s
+; NEON-NEXT:    umlal2 v1.2d, v4.4s, v2.4s
 ; NEON-NEXT:    ret
 ;
 ; SVE-LABEL: two_way_i32_i64_vl256:
@@ -902,28 +773,24 @@ define <2 x i64> @four_way_i16_i64_vl128(ptr %accptr, ptr %uptr, ptr %sptr) {
 ;
 ; NEON-LABEL: four_way_i16_i64_vl128:
 ; NEON:       // %bb.0:
-; NEON-NEXT:    ldr q0, [x1]
-; NEON-NEXT:    ldr q1, [x2]
-; NEON-NEXT:    ldr q3, [x0]
-; NEON-NEXT:    umull v2.4s, v1.4h, v0.4h
-; NEON-NEXT:    umull2 v0.4s, v1.8h, v0.8h
-; NEON-NEXT:    uaddw v3.2d, v3.2d, v2.2s
-; NEON-NEXT:    uaddw2 v1.2d, v3.2d, v2.4s
-; NEON-NEXT:    uaddw v1.2d, v1.2d, v0.2s
-; NEON-NEXT:    uaddw2 v0.2d, v1.2d, v0.4s
+; NEON-NEXT:    ldr q1, [x1]
+; NEON-NEXT:    ldr q2, [x2]
+; NEON-NEXT:    ldr q0, [x0]
+; NEON-NEXT:    umull v3.4s, v2.4h, v1.4h
+; NEON-NEXT:    umull2 v1.4s, v2.8h, v1.8h
+; NEON-NEXT:    uadalp v0.2d, v3.4s
+; NEON-NEXT:    uadalp v0.2d, v1.4s
 ; NEON-NEXT:    ret
 ;
 ; SVE-LABEL: four_way_i16_i64_vl128:
 ; SVE:       // %bb.0:
-; SVE-NEXT:    ldr q0, [x1]
-; SVE-NEXT:    ldr q1, [x2]
-; SVE-NEXT:    ldr q3, [x0]
-; SVE-NEXT:    umull v2.4s, v1.4h, v0.4h
-; SVE-NEXT:    umull2 v0.4s, v1.8h, v0.8h
-; SVE-NEXT:    uaddw v3.2d, v3.2d, v2.2s
-; SVE-NEXT:    uaddw2 v1.2d, v3.2d, v2.4s
-; SVE-NEXT:    uaddw v1.2d, v1.2d, v0.2s
-; SVE-NEXT:    uaddw2 v0.2d, v1.2d, v0.4s
+; SVE-NEXT:    ldr q1, [x1]
+; SVE-NEXT:    ldr q2, [x2]
+; SVE-NEXT:    ldr q0, [x0]
+; SVE-NEXT:    umull v3.4s, v2.4h, v1.4h
+; SVE-NEXT:    umull2 v1.4s, v2.8h, v1.8h
+; SVE-NEXT:    uadalp v0.2d, v3.4s
+; SVE-NEXT:    uadalp v0.2d, v1.4s
 ; SVE-NEXT:    ret
 ;
 ; SVE2-LABEL: four_way_i16_i64_vl128:


### PR DESCRIPTION
These can lower to [SU]ADALP, rather than a [SU]ADDW{2} pair or variations thereof (https://godbolt.org/z/dqYs8r84K).