### PR TITLE
[clang] Mark -Wlarge-by-value-copy diagnostics DefaultIgnore

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -548,10 +548,10 @@ def warn_import_implementation_partition_unit_in_interface_unit : Warning<
 
 def warn_parameter_size: Warning<
   "%0 is a large (%1 bytes) pass-by-value argument; "
-  "pass it by reference instead ?">, InGroup<LargeByValueCopy>;
+  "pass it by reference instead ?">, InGroup<LargeByValueCopy>, DefaultIgnore;
 def warn_return_value_size: Warning<
   "return value of %0 is a large (%1 bytes) pass-by-value object; "
-  "pass it by reference instead ?">, InGroup<LargeByValueCopy>;
+  "pass it by reference instead ?">, InGroup<LargeByValueCopy>, DefaultIgnore;
 def warn_return_value_udt: Warning<
   "%0 has C-linkage specified, but returns user-defined type %1 which is "
   "incompatible with C">, InGroup<ReturnTypeCLinkage>;


### PR DESCRIPTION
These warnings only fire when a size threshold is provided, so they should not be documented as enabled by default.

Fixes #37523
