### PR TITLE
[clang-tidy][docs] Normalize fuchsia check documentation links

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/fuchsia/default-arguments-calls.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/fuchsia/default-arguments-calls.md
@@ -19,4 +19,4 @@ foo();  // warning
 foo(0); // no warning
 ```
 
-See the features disallowed in Fuchsia at <https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en>
+See the features disallowed in Fuchsia at <https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx>

--- a/clang-tools-extra/docs/clang-tidy/checks/fuchsia/default-arguments-declarations.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/fuchsia/default-arguments-declarations.md
@@ -13,4 +13,4 @@ int foo(int value = 5) { return value; }
 
 will cause a warning.
 
-See the features disallowed in Fuchsia at <https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en>
+See the features disallowed in Fuchsia at <https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx>

--- a/clang-tools-extra/docs/clang-tidy/checks/fuchsia/multiple-inheritance.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/fuchsia/multiple-inheritance.md
@@ -6,5 +6,5 @@
 The `fuchsia-multiple-inheritance` check is an alias, please See
 {doc}`misc-multiple-inheritance <../misc/multiple-inheritance>` for details.
 
-See the features disallowed in Fuchsia at <https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en>
+See the features disallowed in Fuchsia at <https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx>
 

--- a/clang-tools-extra/docs/clang-tidy/checks/fuchsia/overloaded-operator.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/fuchsia/overloaded-operator.md
@@ -15,4 +15,4 @@ B &operator=(const B &Other);  // No warning
 B &operator=(B &&Other) // No warning
 ```
 
-See the features disallowed in Fuchsia at <https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en>
+See the features disallowed in Fuchsia at <https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx>

--- a/clang-tools-extra/docs/clang-tidy/checks/fuchsia/statically-constructed-objects.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/fuchsia/statically-constructed-objects.rst
@@ -40,4 +40,4 @@ For example:
   extern int get_i();
   static C c3(get_i());// Warning, as the constructor is dynamically initialized
 
-See the features disallowed in Fuchsia at https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en
+See the features disallowed in Fuchsia at https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx

--- a/clang-tools-extra/docs/clang-tidy/checks/fuchsia/temporary-objects.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/fuchsia/temporary-objects.rst
@@ -51,3 +51,5 @@ Options
 
    A semi-colon-separated list of fully-qualified names of C++ classes that
    should not be constructed as temporaries. Default is empty string.
+
+See the features disallowed in Fuchsia at https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx

--- a/clang-tools-extra/docs/clang-tidy/checks/fuchsia/trailing-return.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/fuchsia/trailing-return.rst
@@ -32,4 +32,4 @@ Exceptions are made for lambdas and ``decltype`` specifiers:
   }
 
 
-See the features disallowed in Fuchsia at https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en
+See the features disallowed in Fuchsia at https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx

--- a/clang-tools-extra/docs/clang-tidy/checks/fuchsia/virtual-inheritance.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/fuchsia/virtual-inheritance.md
@@ -11,4 +11,4 @@ For example, classes should not be defined with virtual inheritance:
 class B : public virtual A {};   // warning
 ```
 
-See the features disallowed in Fuchsia at <https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en>
+See the features disallowed in Fuchsia at <https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx>


### PR DESCRIPTION
Use stable fuchsia.dev URLs without `?hl=en` and add the missing reference on `fuchsia-temporary-objects`.

Fixes #62334
