### PR TITLE
[clang][docs] Document single-vector __builtin_shufflevector form

### DIFF
--- a/clang/docs/LanguageExtensions.md
+++ b/clang/docs/LanguageExtensions.md
@@ -3521,6 +3521,8 @@ for the implementation of various target-specific header files like
 
 ```c++
 __builtin_shufflevector(vec1, vec2, index1, index2, ...)
+
+Clang also accepts a single-vector form `__builtin_shufflevector(vec, index1, index2, ...)` that shuffles lanes within `vec` only.
 ```
 
 **Examples**:


### PR DESCRIPTION
Document that `__builtin_shufflevector` also accepts a single-vector form that only lists indices.

Fixes #59678
