### PR TITLE
[libc++] Don't use `copy_file_impl_fstream` when not declared

### DIFF
--- a/libcxx/src/filesystem/operations.cpp
+++ b/libcxx/src/filesystem/operations.cpp
@@ -360,7 +360,7 @@ bool copy_file_impl(FileDescriptor& read_fd, FileDescriptor& write_fd, error_cod
   ec.clear();
   return true;
 }
-#elif defined(_LIBCPP_FILESYSTEM_USE_FSTREAM)
+#elif defined(_LIBCPP_FILESYSTEM_USE_FSTREAM) && defined(_LIBCPP_FILESYSTEM_NEED_FSTREAM)
 bool copy_file_impl(FileDescriptor& read_fd, FileDescriptor& write_fd, error_code& ec) {
   return copy_file_impl_fstream(read_fd, write_fd, ec);
 }


### PR DESCRIPTION
`copy_file_impl_fstream` is declared and defined only under `_LIBCPP_FILESYSTEM_NEED_FSTREAM` (which additionally requires `_LIBCPP_HAS_LOCALIZATION`), and then used in a `copy_file_impl` variant under a disjoint set of conditions. This causes any build that disables localization and elects this variant of `copy_file_impl`, as is currently the case when targeting wasi, to fail with a generic compiler error:

```
error: use of undeclared identifier 'copy_file_impl_fstream'
```

Instead, since this particular `copy_file_impl` implementation merely forwards to `copy_file_impl_fstream`, tweak its gating condition such that the aforementioned configuration hits the dedicated fallback branch, which offers a somewhat clearer error message:

```
#  error "Unknown implementation for copy_file_impl"
```