### PR TITLE
[SelectionDAG] Proper poison value for 32bit statepoint lowering on unused return

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/StatepointLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/StatepointLowering.cpp
@@ -1108,7 +1108,9 @@ SelectionDAGBuilder::LowerStatepoint(const GCStatepointInst &I,
   if (!GCResultLocality.first && !GCResultLocality.second) {
     // The return value is not needed, just generate a poison value.
     // Note: This covers the void return case.
-    setValue(&I, DAG.getIntPtrConstant(-1, getCurSDLoc()));
+    const auto &TLI = DAG.getTargetLoweringInfo();
+    setValue(&I, DAG.getSignedConstant(-1, getCurSDLoc(),
+                                       TLI.getPointerTy(DAG.getDataLayout())));
     return;
   }
 

--- a/llvm/test/CodeGen/ARM/statepoint-unused-result.ll
+++ b/llvm/test/CodeGen/ARM/statepoint-unused-result.ll
@@ -1,0 +1,13 @@
+; RUN: llc -mtriple=armv7-unknown-linux-gnueabihf -stop-before=finalize-isel < %s | FileCheck %s
+
+declare void @safepoint_poll()
+
+define void @statepoint_unused_result() gc "statepoint-example" {
+; CHECK-LABEL: name: statepoint_unused_result
+; CHECK: STATEPOINT 0, 0, 0, @safepoint_poll
+entry:
+  call token (i64, i32, ptr, i32, i32, ...)
+    @llvm.experimental.gc.statepoint.p0(i64 0, i32 0,
+      ptr elementtype(void ()) @safepoint_poll, i32 0, i32 0, i32 0, i32 0)
+  ret void
+}


### PR DESCRIPTION
I started working on arm32 statepoint support. 
While working on that, I encountered the following issue, generalised to 32bit:
When getIntPtrConstant is called with -1, the uint64_t type ensures it is expanded to 64bit. The 64bit representation (0xFFFFFFFFFFFFFFFF) truncation to 32bit is rejected by APInt.

I considered two possible fixes:
- Using `getAllOnesConstant` 
- Using `getSignedConstant`

I opted for `getSignedConstant`, because it seemed closer to the original intention to me. Result is identical anyway according to my tests.
64bit lowering is not be affected according to my tests.

A test for arm32 is submitted. The test generation was assisted by generative AI. 4 tests unrelated to this changeset fail on this branch.

As I understand it, I need to ping reviewers explicitly, I hope this is correct:
@RKSimon @topperc 