### PR TITLE
[ADT][Reassociate] Invalidate stale UniformityInfo entries on instruction erase

### DIFF
--- a/llvm/include/llvm/ADT/GenericUniformityImpl.h
+++ b/llvm/include/llvm/ADT/GenericUniformityImpl.h
@@ -404,6 +404,10 @@ public:
     return DivergentTermBlocks.contains(&B);
   }
 
+  /// Call before erasing \p V, or a later instruction reusing its address
+  /// may be misclassified as uniform.
+  void forgetValue(ConstValueRefT V) { UniformValues.erase(V); }
+
   void print(raw_ostream &Out) const;
 
   /// Print divergent arguments and return true if any were found.
@@ -1315,6 +1319,12 @@ bool GenericUniformityInfo<ContextT>::isDivergentAtUse(const UseT &U) const {
 template <typename ContextT>
 bool GenericUniformityInfo<ContextT>::hasDivergentTerminator(const BlockT &B) {
   return DA && DA->hasDivergentTerminator(B);
+}
+
+template <typename ContextT>
+void GenericUniformityInfo<ContextT>::forgetValue(ConstValueRefT V) {
+  if (DA)
+    DA->forgetValue(V);
 }
 
 /// \brief T helper function for printing.

--- a/llvm/include/llvm/ADT/GenericUniformityInfo.h
+++ b/llvm/include/llvm/ADT/GenericUniformityInfo.h
@@ -87,6 +87,10 @@ public:
 
   bool hasDivergentTerminator(const BlockT &B);
 
+  /// Call before erasing \p V, or a later instruction reusing its address
+  /// may be misclassified as uniform.
+  void forgetValue(ConstValueRefT V);
+
   void print(raw_ostream &Out) const;
 
   iterator_range<TemporalDivergenceTuple *> getTemporalDivergenceList() const;

--- a/llvm/lib/Transforms/Scalar/Reassociate.cpp
+++ b/llvm/lib/Transforms/Scalar/Reassociate.cpp
@@ -2061,6 +2061,8 @@ void ReassociatePass::RecursivelyEraseDeadInsts(Instruction *I,
   ValueRankMap.erase(I);
   Insts.remove(I);
   RedoInsts.remove(I);
+  if (UA)
+    UA->forgetValue(I);
   llvm::salvageDebugInfo(*I);
   I->eraseFromParent();
   for (auto *Op : Ops)
@@ -2078,6 +2080,8 @@ void ReassociatePass::EraseInst(Instruction *I) {
   // Erase the dead instruction.
   ValueRankMap.erase(I);
   RedoInsts.remove(I);
+  if (UA)
+    UA->forgetValue(I);
   llvm::salvageDebugInfo(*I);
   I->eraseFromParent();
   // Optimize its operands.


### PR DESCRIPTION
`GenericUniformityAnalysisImpl::UniformValues` never removes an entry when its value is erased. Reassociate keeps one `UniformityInfo` for the whole pass while creating and deleting instructions, so a new instruction can reuse a freed one's address and inherit its stale "uniform" verdict instead of the documented divergent default. This makes rank-boosting depend on heap addresses

Add `forgetValue()` (following the same idea as `ScalarEvolution::forgetValue`) and call it at Reassociate two erase sites

As a result of this issue we have a side effect that is reproducible on https://github.com/llvm/llvm-project/pull/214624: nondeterministic operand ordering in Reassociate output, because a newly-created instruction can spuriously be classified "uniform" instead of the documented default of divergent depending on whether the allocator happened to reuse a freed instruction address

That leads to nondeterministic optimized IR, which is what made __clang_hip_math.hip in the mentioned patch FileCheck output flaky (mul operands reordered from run to run for the SPIR-V target)