### PR TITLE
[libc][NFC] Add FieldTokenizer and FlatFileDatabase

### DIFF
--- a/libc/src/pwd/CMakeLists.txt
+++ b/libc/src/pwd/CMakeLists.txt
@@ -45,19 +45,28 @@ add_entrypoint_object(
 add_object_library(
   pwd_utils
   HDRS
+    field_tokenizer.h
+    flat_file_db.h
     pwd_utils.h
   SRCS
     pwd_utils.cpp
   DEPENDS
     libc.hdr.errno_macros
     libc.hdr.stdio_macros
+    libc.hdr.types.gid_t
+    libc.hdr.types.size_t
     libc.hdr.types.struct_passwd
+    libc.hdr.types.uid_t
     libc.src.string.string_utils
+    libc.src.__support.CPP.functional
+    libc.src.__support.CPP.optional
     libc.src.__support.CPP.span
+    libc.src.__support.CPP.string_view
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
     libc.src.__support.ctype_utils
     libc.src.__support.error_or
     libc.src.__support.str_to_integer
+    libc.src.__support.macros.attributes
     libc.src.__support.macros.config
 )

--- a/libc/src/pwd/field_tokenizer.h
+++ b/libc/src/pwd/field_tokenizer.h
@@ -25,39 +25,36 @@ namespace pwd {
 
 // In-place field tokenizer for delimited database records.
 class FieldTokenizer {
-  char *data_ptr;
-  size_t data_len;
+  cpp::span<char> data;
   char separator;
 
 public:
   LIBC_INLINE constexpr explicit FieldTokenizer(cpp::span<char> buf,
                                                 char sep = ':')
-      : data_ptr(buf.data()), data_len(buf.size()), separator(sep) {}
+      : data(buf), separator(sep) {}
 
   // Extracts the next null-terminated field.
   LIBC_INLINE cpp::optional<cpp::span<char>> next_field() {
-    if (data_len == 0)
+    if (data.empty())
       return cpp::nullopt;
 
-    cpp::string_view sv(data_ptr, data_len);
+    cpp::string_view sv(data.data(), data.size());
     size_t pos = sv.find_first_of(separator);
 
     // If a delimiter was found, replace it with a null terminator and return
     // the field.
     if (pos != cpp::string_view::npos) {
-      data_ptr[pos] = '\0';
-      auto field = cpp::span<char>(data_ptr, pos + 1);
-      data_ptr += pos + 1;
-      data_len -= pos + 1;
+      data[pos] = '\0';
+      auto field = data.first(pos + 1);
+      data = data.subspan(pos + 1);
       return field;
     }
 
     // If null-terminated without delimiters, return the remaining span as the
     // final field.
-    if (cpp::span<char>(data_ptr, data_len).back() == '\0') {
-      auto field = cpp::span<char>(data_ptr, data_len);
-      data_ptr += data_len;
-      data_len = 0;
+    if (data.back() == '\0') {
+      auto field = data;
+      data = cpp::span<char>();
       return field;
     }
 

--- a/libc/src/pwd/field_tokenizer.h
+++ b/libc/src/pwd/field_tokenizer.h
@@ -1,0 +1,72 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// In-place field tokenizer for colon-separated flat database files.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_PWD_FIELD_TOKENIZER_H
+#define LLVM_LIBC_SRC_PWD_FIELD_TOKENIZER_H
+
+#include "src/__support/CPP/optional.h"
+#include "src/__support/CPP/span.h"
+#include "src/__support/CPP/string_view.h"
+#include "src/__support/macros/attributes.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+namespace pwd {
+
+// In-place field tokenizer for delimited database records.
+class FieldTokenizer {
+  char *data_ptr;
+  size_t data_len;
+  char separator;
+
+public:
+  LIBC_INLINE constexpr explicit FieldTokenizer(cpp::span<char> buf,
+                                                char sep = ':')
+      : data_ptr(buf.data()), data_len(buf.size()), separator(sep) {}
+
+  // Extracts the next null-terminated field.
+  LIBC_INLINE cpp::optional<cpp::span<char>> next_field() {
+    if (data_len == 0)
+      return cpp::nullopt;
+
+    cpp::string_view sv(data_ptr, data_len);
+    size_t pos = sv.find_first_of(separator);
+
+    // If a delimiter was found, replace it with a null terminator and return
+    // the field.
+    if (pos != cpp::string_view::npos) {
+      data_ptr[pos] = '\0';
+      auto field = cpp::span<char>(data_ptr, pos + 1);
+      data_ptr += pos + 1;
+      data_len -= pos + 1;
+      return field;
+    }
+
+    // If null-terminated without delimiters, return the remaining span as the
+    // final field.
+    if (cpp::span<char>(data_ptr, data_len).back() == '\0') {
+      auto field = cpp::span<char>(data_ptr, data_len);
+      data_ptr += data_len;
+      data_len = 0;
+      return field;
+    }
+
+    // Otherwise, no more fields remain.
+    return cpp::nullopt;
+  }
+};
+
+} // namespace pwd
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_PWD_FIELD_TOKENIZER_H

--- a/libc/src/pwd/flat_file_db.h
+++ b/libc/src/pwd/flat_file_db.h
@@ -1,0 +1,200 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Generic flat-file database template engine.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_PWD_FLAT_FILE_DB_H
+#define LLVM_LIBC_SRC_PWD_FLAT_FILE_DB_H
+
+#include "hdr/errno_macros.h"
+#include "hdr/stdio_macros.h"
+#include "hdr/types/size_t.h"
+#include "src/__support/CPP/functional.h"
+#include "src/__support/CPP/span.h"
+#include "src/__support/File/file.h"
+#include "src/__support/error_or.h"
+#include "src/__support/macros/attributes.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+namespace pwd {
+
+struct ReadLineResult {
+  size_t bytes_read;
+  bool truncated;
+};
+
+// Forward declaration of record parser for flat database files.
+template <typename EntryType>
+bool parse_line(cpp::span<char> line, EntryType *entry);
+
+// Generic flat colon-delimited database engine.
+template <typename EntryType> class FlatFileDatabase {
+public:
+  using Matcher = cpp::function<bool(const EntryType &)>;
+
+private:
+  const char *file_path;
+  File *file = nullptr;
+
+  // Reads a single line from the given file into the provided buffer, stripping
+  // any trailing '\n' and ensuring the result is null-terminated.
+  // Note: POSIX getline/getdelim cannot be used here because user database
+  // lookups (including reentrant _r variants) must operate in-place within a
+  // fixed, bounded buffer without dynamic heap allocations or realloc.
+  LIBC_INLINE static ErrorOr<ReadLineResult> read_line(File *f,
+                                                       cpp::span<char> buf) {
+    if (!f || buf.size() < 2)
+      return Error(EINVAL);
+
+    f->lock();
+    size_t bytes_read = 0;
+    FileIOResult result(0);
+    bool truncated = false;
+
+    for (char &ch : buf.first(buf.size() - 1)) {
+      result = f->read_unlocked(&ch, 1);
+      if (result.has_error()) {
+        f->unlock();
+        return Error(result.error);
+      }
+      if (result.value != 1)
+        break;
+      ++bytes_read;
+      if (ch == '\n')
+        break;
+    }
+
+    auto read_span = buf.first(bytes_read);
+    if (result.value == 1 && !read_span.empty() && read_span.back() != '\n') {
+      truncated = true;
+      char c = '\0';
+      while (true) {
+        result = f->read_unlocked(&c, 1);
+        if (result.has_error()) {
+          f->unlock();
+          return Error(result.error);
+        }
+        if (result.value != 1 || c == '\n')
+          break;
+      }
+    }
+
+    bool has_error = f->error_unlocked();
+    f->unlock();
+
+    if (has_error)
+      return Error(EIO);
+
+    // If the line ended with a newline, strip it.
+    if (!read_span.empty() && read_span.back() == '\n')
+      --bytes_read;
+
+    buf[bytes_read] = '\0';
+    return ReadLineResult{bytes_read, truncated};
+  }
+
+public:
+  LIBC_INLINE constexpr explicit FlatFileDatabase(const char *path)
+      : file_path(path) {}
+
+  // Sets or overrides the file path for database operations.
+  LIBC_INLINE void set_path(const char *path) {
+    if (!path)
+      return;
+    if (file) {
+      file->close();
+      file = nullptr;
+    }
+    file_path = path;
+  }
+
+  // Opens or rewinds the database file stream.
+  LIBC_INLINE ErrorOr<void> setdb() {
+    if (!file) {
+      auto result = openfile(file_path, "r");
+      if (!result.has_value())
+        return Error(result.error());
+      file = result.value();
+      return {};
+    }
+    auto result = file->seek(0, SEEK_SET);
+    if (!result.has_value())
+      return Error(result.error());
+    return {};
+  }
+
+  // Closes the database file stream.
+  LIBC_INLINE ErrorOr<void> enddb() {
+    if (file) {
+      int result = file->close();
+      file = nullptr;
+      if (result != 0)
+        return Error(result);
+    }
+    return {};
+  }
+
+  // Reads and parses the next record from the database. Returns true if an
+  // entry was read, false if EOF was reached, or an Error on failure.
+  LIBC_INLINE ErrorOr<bool> getnext(EntryType *entry, cpp::span<char> buffer) {
+    if (!entry)
+      return Error(EINVAL);
+
+    if (!file) {
+      auto res = setdb();
+      if (!res.has_value())
+        return Error(res.error());
+    }
+
+    auto result = read_line(file, buffer);
+    if (!result.has_value())
+      return Error(result.error());
+
+    ReadLineResult res = result.value();
+    if (res.bytes_read == 0)
+      return false; // EOF
+
+    if (res.truncated)
+      return Error(ERANGE);
+
+    if (parse_line(buffer.first(res.bytes_read + 1), entry))
+      return true;
+
+    return Error(EINVAL);
+  }
+
+  // Searches for a record matching a given predicate.
+  LIBC_INLINE ErrorOr<bool> lookup(Matcher matcher, EntryType *entry,
+                                   cpp::span<char> buffer) {
+    if (!entry)
+      return Error(EINVAL);
+
+    auto res = setdb();
+    if (!res.has_value())
+      return Error(res.error());
+
+    while (true) {
+      auto next_res = getnext(entry, buffer);
+      if (!next_res.has_value())
+        return Error(next_res.error());
+      if (!next_res.value())
+        return false; // EOF without match
+      if (matcher(*entry))
+        return true;
+    }
+  }
+};
+
+} // namespace pwd
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_PWD_FLAT_FILE_DB_H

--- a/libc/src/pwd/flat_file_db.h
+++ b/libc/src/pwd/flat_file_db.h
@@ -172,7 +172,8 @@ public:
     return Error(EINVAL);
   }
 
-  // Searches for a record matching a given predicate.
+  // Searches for a record matching a given predicate. Returns true if the
+  // entry was found, false if it's missing, or an Error if lookup failed.
   LIBC_INLINE ErrorOr<bool> lookup(Matcher matcher, EntryType *entry,
                                    cpp::span<char> buffer) {
     if (!entry)

--- a/libc/src/pwd/pwd_utils.cpp
+++ b/libc/src/pwd/pwd_utils.cpp
@@ -13,12 +13,10 @@
 
 #include "src/pwd/pwd_utils.h"
 #include "hdr/errno_macros.h"
-#include "hdr/stdio_macros.h"
 #include "hdr/types/struct_passwd.h"
 #include "src/__support/CPP/span.h"
-#include "src/__support/File/file.h"
-#include "src/__support/ctype_utils.h"
-#include "src/__support/str_to_integer.h"
+#include "src/__support/macros/attributes.h"
+#include "src/pwd/flat_file_db.h"
 #include "src/string/string_utils.h"
 
 #ifndef LIBC_COPT_PWD_FILE_PATH
@@ -26,183 +24,44 @@
 #endif
 
 namespace LIBC_NAMESPACE_DECL {
-namespace internal {
+namespace pwd {
 
 ErrorOr<struct passwd> parse_passwd_line(char *line) {
   if (!line)
     return Error(EINVAL);
 
   struct passwd pwd;
-  char *context = line;
-
-  pwd.pw_name = string_token<false>(nullptr, ":", &context);
-  if (!pwd.pw_name)
-    return Error(EINVAL);
-
-  pwd.pw_passwd = string_token<false>(nullptr, ":", &context);
-  if (!pwd.pw_passwd)
-    return Error(EINVAL);
-
-  char *uid_str = string_token<false>(nullptr, ":", &context);
-  if (!uid_str || !isdigit(uid_str[0]))
-    return Error(EINVAL);
-  auto uid_res = strtointeger<uid_t>(uid_str, 10);
-  if (uid_res.has_error() || uid_res.parsed_len == 0 ||
-      uid_str[uid_res.parsed_len] != '\0')
-    return Error(EINVAL);
-  pwd.pw_uid = uid_res.value;
-
-  char *gid_str = string_token<false>(nullptr, ":", &context);
-  if (!gid_str || !isdigit(gid_str[0]))
-    return Error(EINVAL);
-  auto gid_res = strtointeger<gid_t>(gid_str, 10);
-  if (gid_res.has_error() || gid_res.parsed_len == 0 ||
-      gid_str[gid_res.parsed_len] != '\0')
-    return Error(EINVAL);
-  pwd.pw_gid = gid_res.value;
-
-  pwd.pw_gecos = string_token<false>(nullptr, ":", &context);
-  if (!pwd.pw_gecos)
-    return Error(EINVAL);
-
-  pwd.pw_dir = string_token<false>(nullptr, ":", &context);
-  if (!pwd.pw_dir)
-    return Error(EINVAL);
-
-  pwd.pw_shell = string_token<false>(nullptr, ":", &context);
-  if (!pwd.pw_shell)
+  size_t len = internal::string_length(line);
+  if (!parse_line(cpp::span<char>(line, len + 1), &pwd))
     return Error(EINVAL);
 
   return pwd;
 }
 
-} // namespace internal
+} // namespace pwd
 
 namespace passwd {
 
-static File *pwd_file = nullptr;
-static const char *pwd_file_path = LIBC_COPT_PWD_FILE_PATH;
+static LIBC_CONSTINIT pwd::FlatFileDatabase<struct passwd>
+    db(LIBC_COPT_PWD_FILE_PATH);
 // Note: These static buffers are process-global and NOT protected by a mutex
 // at this stage. POSIX getpwent is non-reentrant.
 static char line_buffer[1024];
 static struct passwd pwd_entry;
 
-void TESTONLY_set_passwd_path(const char *path) {
-  if (!path)
-    return;
-  if (pwd_file) {
-    pwd_file->close();
-    pwd_file = nullptr;
-  }
-  pwd_file_path = path;
-}
+void TESTONLY_set_passwd_path(const char *path) { db.set_path(path); }
 
-ErrorOr<void> open() {
-  if (!pwd_file) {
-    auto result = openfile(pwd_file_path, "r");
-    if (!result.has_value())
-      return Error(result.error());
-    pwd_file = result.value();
-  } else {
-    auto result = pwd_file->seek(0, SEEK_SET);
-    if (!result.has_value())
-      return Error(result.error());
-  }
-  return {};
-}
+ErrorOr<void> open() { return db.setdb(); }
 
-ErrorOr<void> close() {
-  if (pwd_file) {
-    int result = pwd_file->close();
-    pwd_file = nullptr;
-    if (result != 0)
-      return Error(result);
-  }
-  return {};
-}
-
-struct ReadLineResult {
-  size_t bytes_read;
-  bool truncated;
-};
-
-// Reads a line from the given file into buf.
-static ErrorOr<ReadLineResult> read_line(File *f, cpp::span<char> buf) {
-  if (!f || buf.empty())
-    return Error(EINVAL);
-
-  f->lock();
-  size_t bytes_read = 0;
-  FileIOResult result(0);
-  bool truncated = false;
-
-  for (char &ch : buf.first(buf.size() - 1)) {
-    result = f->read_unlocked(&ch, 1);
-    if (result.has_error()) {
-      f->unlock();
-      return Error(result.error);
-    }
-    if (result.value != 1)
-      break;
-    ++bytes_read;
-    if (ch == '\n')
-      break;
-  }
-
-  if (result.value == 1 && bytes_read > 0 && buf[bytes_read - 1] != '\n') {
-    truncated = true;
-    char c = '\0';
-    while (true) {
-      result = f->read_unlocked(&c, 1);
-      if (result.has_error()) {
-        f->unlock();
-        return Error(result.error);
-      }
-      if (result.value != 1 || c == '\n')
-        break;
-    }
-  }
-
-  bool has_error = f->error_unlocked();
-  f->unlock();
-
-  if (has_error)
-    return Error(EIO);
-
-  buf[bytes_read] = '\0';
-  return ReadLineResult{bytes_read, truncated};
-}
+ErrorOr<void> close() { return db.enddb(); }
 
 ErrorOr<struct passwd *> read_next() {
-  if (!pwd_file) {
-    auto result = open();
-    if (!result.has_value())
-      return Error(result.error());
-  }
-
-  while (true) {
-    auto result = read_line(pwd_file, line_buffer);
-    if (!result.has_value())
-      return Error(result.error());
-
-    ReadLineResult res = result.value();
-    if (res.bytes_read == 0)
-      return nullptr;
-
-    if (res.truncated)
-      return Error(EINVAL);
-
-    size_t len = res.bytes_read;
-    if (len > 0 && line_buffer[len - 1] == '\n')
-      line_buffer[len - 1] = '\0';
-
-    auto passwd_or = internal::parse_passwd_line(line_buffer);
-    if (!passwd_or.has_value())
-      return Error(passwd_or.error());
-
-    pwd_entry = passwd_or.value();
-    return &pwd_entry;
-  }
+  auto res = db.getnext(&pwd_entry, line_buffer);
+  if (!res.has_value())
+    return Error(res.error());
+  if (!res.value())
+    return nullptr;
+  return &pwd_entry;
 }
 
 } // namespace passwd

--- a/libc/src/pwd/pwd_utils.h
+++ b/libc/src/pwd/pwd_utils.h
@@ -7,24 +7,91 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// Declarations of helper functions for pwd.
+/// Declarations of helper functions and parser for pwd.
 ///
 //===----------------------------------------------------------------------===//
 
 #ifndef LLVM_LIBC_SRC_PWD_PWD_UTILS_H
 #define LLVM_LIBC_SRC_PWD_PWD_UTILS_H
 
+#include "hdr/errno_macros.h"
+#include "hdr/types/gid_t.h"
 #include "hdr/types/struct_passwd.h"
+#include "hdr/types/uid_t.h"
+#include "src/__support/CPP/span.h"
+#include "src/__support/ctype_utils.h"
 #include "src/__support/error_or.h"
+#include "src/__support/macros/attributes.h"
 #include "src/__support/macros/config.h"
+#include "src/__support/str_to_integer.h"
+#include "src/pwd/field_tokenizer.h"
+#include "src/pwd/flat_file_db.h"
+#include "src/string/string_utils.h"
 
 namespace LIBC_NAMESPACE_DECL {
-namespace internal {
+namespace pwd {
+
+// Parses a colon-separated line in-place into a struct passwd.
+template <>
+LIBC_INLINE bool parse_line<struct passwd>(cpp::span<char> line,
+                                           struct passwd *pwd) {
+  if (line.empty() || !pwd)
+    return false;
+
+  FieldTokenizer tokenizer(line);
+
+  auto name = tokenizer.next_field();
+  if (!name)
+    return false;
+  pwd->pw_name = name->data();
+
+  auto passwd = tokenizer.next_field();
+  if (!passwd)
+    return false;
+  pwd->pw_passwd = passwd->data();
+
+  auto uid_str = tokenizer.next_field();
+  if (!uid_str || uid_str->empty() || !internal::isdigit(uid_str->front()))
+    return false;
+  auto uid_res = internal::strtointeger<uid_t>(uid_str->data(), 10);
+  if (uid_res.has_error() || uid_res.parsed_len <= 0 ||
+      static_cast<size_t>(uid_res.parsed_len) >= uid_str->size() ||
+      (*uid_str)[uid_res.parsed_len] != '\0')
+    return false;
+  pwd->pw_uid = uid_res.value;
+
+  auto gid_str = tokenizer.next_field();
+  if (!gid_str || gid_str->empty() || !internal::isdigit(gid_str->front()))
+    return false;
+  auto gid_res = internal::strtointeger<gid_t>(gid_str->data(), 10);
+  if (gid_res.has_error() || gid_res.parsed_len <= 0 ||
+      static_cast<size_t>(gid_res.parsed_len) >= gid_str->size() ||
+      (*gid_str)[gid_res.parsed_len] != '\0')
+    return false;
+  pwd->pw_gid = gid_res.value;
+
+  auto gecos = tokenizer.next_field();
+  if (!gecos)
+    return false;
+  pwd->pw_gecos = gecos->data();
+
+  auto dir = tokenizer.next_field();
+  if (!dir)
+    return false;
+  pwd->pw_dir = dir->data();
+
+  auto shell = tokenizer.next_field();
+  if (!shell)
+    return false;
+  pwd->pw_shell = shell->data();
+
+  return true;
+}
 
 // Parses a colon-separated password database line into a struct passwd.
 ErrorOr<struct passwd> parse_passwd_line(char *line);
 
-} // namespace internal
+} // namespace pwd
 
 namespace passwd {
 

--- a/libc/test/src/pwd/CMakeLists.txt
+++ b/libc/test/src/pwd/CMakeLists.txt
@@ -5,6 +5,33 @@ if(NOT TARGET libc.src.pwd.pwd_utils)
 endif()
 
 add_libc_test(
+  field_tokenizer_test
+  SUITE
+    libc_pwd_unittests
+  SRCS
+    field_tokenizer_test.cpp
+  DEPENDS
+    libc.src.__support.CPP.span
+    libc.src.pwd.pwd_utils
+)
+
+add_libc_test(
+  flat_file_db_test
+  SUITE
+    libc_pwd_unittests
+  SRCS
+    flat_file_db_test.cpp
+  DEPENDS
+    libc.hdr.errno_macros
+    libc.src.__support.CPP.span
+    libc.src.__support.File.file
+    libc.src.__support.File.platform_file
+    libc.src.pwd.pwd_utils
+    libc.src.stdio.remove
+    libc.src.string.string_utils
+)
+
+add_libc_test(
   pwd_utils_test
   SUITE
     libc_pwd_unittests
@@ -23,6 +50,7 @@ add_libc_test(
   SRCS
     getpwent_test.cpp
   DEPENDS
+    libc.hdr.errno_macros
     libc.hdr.types.struct_passwd
     libc.src.__support.File.file
     libc.src.__support.File.platform_file

--- a/libc/test/src/pwd/field_tokenizer_test.cpp
+++ b/libc/test/src/pwd/field_tokenizer_test.cpp
@@ -1,0 +1,150 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Unit tests for FieldTokenizer.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/__support/CPP/span.h"
+#include "src/pwd/field_tokenizer.h"
+#include "test/UnitTest/Test.h"
+
+TEST(LlvmLibcFieldTokenizerTest, StandardPasswdLine) {
+  char line[] = "root:x:0:0:root:/root:/bin/bash";
+  LIBC_NAMESPACE::pwd::FieldTokenizer tokenizer(
+      LIBC_NAMESPACE::cpp::span<char>(line, sizeof(line)));
+
+  auto f1 = tokenizer.next_field();
+  ASSERT_TRUE(f1.has_value());
+  ASSERT_STREQ(f1->data(), "root");
+
+  auto f2 = tokenizer.next_field();
+  ASSERT_TRUE(f2.has_value());
+  ASSERT_STREQ(f2->data(), "x");
+
+  auto f3 = tokenizer.next_field();
+  ASSERT_TRUE(f3.has_value());
+  ASSERT_STREQ(f3->data(), "0");
+
+  auto f4 = tokenizer.next_field();
+  ASSERT_TRUE(f4.has_value());
+  ASSERT_STREQ(f4->data(), "0");
+
+  auto f5 = tokenizer.next_field();
+  ASSERT_TRUE(f5.has_value());
+  ASSERT_STREQ(f5->data(), "root");
+
+  auto f6 = tokenizer.next_field();
+  ASSERT_TRUE(f6.has_value());
+  ASSERT_STREQ(f6->data(), "/root");
+
+  auto f7 = tokenizer.next_field();
+  ASSERT_TRUE(f7.has_value());
+  ASSERT_STREQ(f7->data(), "/bin/bash");
+
+  auto f8 = tokenizer.next_field();
+  ASSERT_FALSE(f8.has_value());
+}
+
+TEST(LlvmLibcFieldTokenizerTest, EmptyFields) {
+  char line[] = "a::c:";
+  LIBC_NAMESPACE::pwd::FieldTokenizer tokenizer(
+      LIBC_NAMESPACE::cpp::span<char>(line, sizeof(line)));
+
+  auto f1 = tokenizer.next_field();
+  ASSERT_TRUE(f1.has_value());
+  ASSERT_STREQ(f1->data(), "a");
+
+  auto f2 = tokenizer.next_field();
+  ASSERT_TRUE(f2.has_value());
+  ASSERT_STREQ(f2->data(), "");
+
+  auto f3 = tokenizer.next_field();
+  ASSERT_TRUE(f3.has_value());
+  ASSERT_STREQ(f3->data(), "c");
+
+  auto f4 = tokenizer.next_field();
+  ASSERT_TRUE(f4.has_value());
+  ASSERT_STREQ(f4->data(), "");
+
+  auto f5 = tokenizer.next_field();
+  ASSERT_FALSE(f5.has_value());
+}
+
+TEST(LlvmLibcFieldTokenizerTest, LeadingAndConsecutiveSeparators) {
+  char line[] = ":first::last";
+  LIBC_NAMESPACE::pwd::FieldTokenizer tokenizer(
+      LIBC_NAMESPACE::cpp::span<char>(line, sizeof(line)));
+
+  auto f1 = tokenizer.next_field();
+  ASSERT_TRUE(f1.has_value());
+  ASSERT_STREQ(f1->data(), "");
+
+  auto f2 = tokenizer.next_field();
+  ASSERT_TRUE(f2.has_value());
+  ASSERT_STREQ(f2->data(), "first");
+
+  auto f3 = tokenizer.next_field();
+  ASSERT_TRUE(f3.has_value());
+  ASSERT_STREQ(f3->data(), "");
+
+  auto f4 = tokenizer.next_field();
+  ASSERT_TRUE(f4.has_value());
+  ASSERT_STREQ(f4->data(), "last");
+
+  auto f5 = tokenizer.next_field();
+  ASSERT_FALSE(f5.has_value());
+}
+
+TEST(LlvmLibcFieldTokenizerTest, SingleField) {
+  char line[] = "single";
+  LIBC_NAMESPACE::pwd::FieldTokenizer tokenizer(
+      LIBC_NAMESPACE::cpp::span<char>(line, sizeof(line)));
+
+  auto f1 = tokenizer.next_field();
+  ASSERT_TRUE(f1.has_value());
+  ASSERT_STREQ(f1->data(), "single");
+
+  auto f2 = tokenizer.next_field();
+  ASSERT_FALSE(f2.has_value());
+}
+
+TEST(LlvmLibcFieldTokenizerTest, EmptyBuffer) {
+  char line[] = "";
+  LIBC_NAMESPACE::pwd::FieldTokenizer tokenizer(
+      LIBC_NAMESPACE::cpp::span<char>(line, sizeof(line)));
+
+  auto f1 = tokenizer.next_field();
+  ASSERT_TRUE(f1.has_value());
+  ASSERT_STREQ(f1->data(), "");
+
+  auto f2 = tokenizer.next_field();
+  ASSERT_FALSE(f2.has_value());
+}
+
+TEST(LlvmLibcFieldTokenizerTest, CustomSeparator) {
+  char line[] = "foo,bar,baz";
+  LIBC_NAMESPACE::pwd::FieldTokenizer tokenizer(
+      LIBC_NAMESPACE::cpp::span<char>(line, sizeof(line)), ',');
+
+  auto f1 = tokenizer.next_field();
+  ASSERT_TRUE(f1.has_value());
+  ASSERT_STREQ(f1->data(), "foo");
+
+  auto f2 = tokenizer.next_field();
+  ASSERT_TRUE(f2.has_value());
+  ASSERT_STREQ(f2->data(), "bar");
+
+  auto f3 = tokenizer.next_field();
+  ASSERT_TRUE(f3.has_value());
+  ASSERT_STREQ(f3->data(), "baz");
+
+  auto f4 = tokenizer.next_field();
+  ASSERT_FALSE(f4.has_value());
+}

--- a/libc/test/src/pwd/flat_file_db_test.cpp
+++ b/libc/test/src/pwd/flat_file_db_test.cpp
@@ -1,0 +1,178 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Unit tests for FlatFileDatabase.
+///
+//===----------------------------------------------------------------------===//
+
+#include "hdr/errno_macros.h"
+#include "src/__support/CPP/span.h"
+#include "src/__support/File/file.h"
+#include "src/pwd/field_tokenizer.h"
+#include "src/pwd/flat_file_db.h"
+#include "src/stdio/remove.h"
+#include "src/string/string_utils.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
+#include "test/UnitTest/ErrnoSetterMatcher.h"
+#include "test/UnitTest/Test.h"
+
+namespace {
+
+struct SimpleTestEntry {
+  const char *key;
+  const char *val;
+};
+
+class HermeticFile {
+  char path[256];
+
+public:
+  HermeticFile(const char *file_path, const char *content) {
+    LIBC_NAMESPACE::internal::strlcpy(path, file_path, sizeof(path));
+
+    auto file_or = LIBC_NAMESPACE::openfile(path, "w");
+    if (file_or.has_value()) {
+      auto *f = file_or.value();
+      size_t len = LIBC_NAMESPACE::internal::string_length(content);
+      f->write(content, len);
+      f->close();
+    }
+  }
+
+  ~HermeticFile() { LIBC_NAMESPACE::remove(path); }
+
+  const char *get_path() const { return path; }
+};
+
+class LlvmLibcFlatFileDbTest
+    : public LIBC_NAMESPACE::testing::ErrnoCheckingTest {};
+
+} // namespace
+
+namespace LIBC_NAMESPACE_DECL {
+namespace pwd {
+
+template <>
+inline bool parse_line<SimpleTestEntry>(cpp::span<char> line,
+                                        SimpleTestEntry *entry) {
+  if (line.empty() || !entry)
+    return false;
+  FieldTokenizer tokenizer(line);
+  auto k = tokenizer.next_field();
+  if (!k)
+    return false;
+  entry->key = k->data();
+
+  auto v = tokenizer.next_field();
+  if (!v)
+    return false;
+  entry->val = v->data();
+
+  return true;
+}
+
+} // namespace pwd
+} // namespace LIBC_NAMESPACE_DECL
+
+TEST_F(LlvmLibcFlatFileDbTest, GetNextAndLookup) {
+  const char *content = "user1:secret1\nuser2:secret2\n";
+  HermeticFile test_file(libc_make_test_file_path("flat_db_test.test"),
+                         content);
+
+  LIBC_NAMESPACE::pwd::FlatFileDatabase<SimpleTestEntry> db(
+      test_file.get_path());
+  char buffer[128];
+  SimpleTestEntry entry;
+
+  // First record
+  auto r1 = db.getnext(&entry, buffer);
+  ASSERT_TRUE(r1.has_value());
+  ASSERT_TRUE(r1.value());
+  ASSERT_STREQ(entry.key, "user1");
+  ASSERT_STREQ(entry.val, "secret1");
+
+  // Second record
+  auto r2 = db.getnext(&entry, buffer);
+  ASSERT_TRUE(r2.has_value());
+  ASSERT_TRUE(r2.value());
+  ASSERT_STREQ(entry.key, "user2");
+  ASSERT_STREQ(entry.val, "secret2");
+
+  // EOF
+  auto r3 = db.getnext(&entry, buffer);
+  ASSERT_TRUE(r3.has_value());
+  ASSERT_FALSE(r3.value());
+
+  // Rewind and lookup
+  db.setdb();
+  auto matcher = [](const SimpleTestEntry &e) {
+    return LIBC_NAMESPACE::cpp::string_view(e.key) == "user2";
+  };
+  auto lookup_res = db.lookup(matcher, &entry, buffer);
+  ASSERT_TRUE(lookup_res.has_value());
+  ASSERT_TRUE(lookup_res.value());
+  ASSERT_STREQ(entry.key, "user2");
+  ASSERT_STREQ(entry.val, "secret2");
+
+  db.enddb();
+}
+
+TEST_F(LlvmLibcFlatFileDbTest, LookupNotFound) {
+  const char *content = "foo:bar\n";
+  HermeticFile test_file(libc_make_test_file_path("flat_db_not_found.test"),
+                         content);
+
+  LIBC_NAMESPACE::pwd::FlatFileDatabase<SimpleTestEntry> db(
+      test_file.get_path());
+  char buffer[128];
+  SimpleTestEntry entry;
+
+  auto matcher = [](const SimpleTestEntry &e) {
+    return LIBC_NAMESPACE::cpp::string_view(e.key) == "nonexistent";
+  };
+  auto lookup_res = db.lookup(matcher, &entry, buffer);
+  ASSERT_TRUE(lookup_res.has_value());
+  ASSERT_FALSE(lookup_res.value());
+
+  db.enddb();
+}
+
+TEST_F(LlvmLibcFlatFileDbTest, TruncatedLineReturnsErange) {
+  const char *content = "verylongkeyname:verylongvaluename\n";
+  HermeticFile test_file(libc_make_test_file_path("flat_db_trunc.test"),
+                         content);
+
+  LIBC_NAMESPACE::pwd::FlatFileDatabase<SimpleTestEntry> db(
+      test_file.get_path());
+  char small_buffer[8];
+  SimpleTestEntry entry;
+
+  auto res = db.getnext(&entry, small_buffer);
+  ASSERT_FALSE(res.has_value());
+  ASSERT_EQ(res.error(), ERANGE);
+
+  db.enddb();
+}
+
+TEST_F(LlvmLibcFlatFileDbTest, MalformedLineReturnsEinval) {
+  const char *content = "invalid_line_without_delimiter\n";
+  HermeticFile test_file(libc_make_test_file_path("flat_db_malformed.test"),
+                         content);
+
+  LIBC_NAMESPACE::pwd::FlatFileDatabase<SimpleTestEntry> db(
+      test_file.get_path());
+  char buffer[128];
+  SimpleTestEntry entry;
+
+  auto res = db.getnext(&entry, buffer);
+  ASSERT_FALSE(res.has_value());
+  ASSERT_EQ(res.error(), EINVAL);
+
+  db.enddb();
+}

--- a/libc/test/src/pwd/getpwent_test.cpp
+++ b/libc/test/src/pwd/getpwent_test.cpp
@@ -11,6 +11,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "hdr/errno_macros.h"
 #include "hdr/types/struct_passwd.h"
 #include "src/__support/File/file.h"
 #include "src/__support/libc_errno.h"

--- a/libc/test/src/pwd/pwd_utils_test.cpp
+++ b/libc/test/src/pwd/pwd_utils_test.cpp
@@ -18,7 +18,7 @@
 
 TEST(LlvmLibcPwdTest, ParsePasswdLine_Success) {
   char line[] = "root:x:0:0:root:/root:/bin/bash";
-  auto res = LIBC_NAMESPACE::internal::parse_passwd_line(line);
+  auto res = LIBC_NAMESPACE::pwd::parse_passwd_line(line);
   ASSERT_TRUE(res.has_value());
   struct passwd pwd = res.value();
   ASSERT_STREQ(pwd.pw_name, "root");
@@ -32,7 +32,7 @@ TEST(LlvmLibcPwdTest, ParsePasswdLine_Success) {
 
 TEST(LlvmLibcPwdTest, ParsePasswdLine_EmptyFields) {
   char line[] = "root::0:0::/root:";
-  auto res = LIBC_NAMESPACE::internal::parse_passwd_line(line);
+  auto res = LIBC_NAMESPACE::pwd::parse_passwd_line(line);
   ASSERT_TRUE(res.has_value());
   struct passwd pwd = res.value();
   ASSERT_STREQ(pwd.pw_name, "root");
@@ -46,59 +46,59 @@ TEST(LlvmLibcPwdTest, ParsePasswdLine_EmptyFields) {
 
 TEST(LlvmLibcPwdTest, ParsePasswdLine_InvalidNumeric) {
   char line1[] = "root:x:abc:0:root:/root:/bin/bash";
-  auto res1 = LIBC_NAMESPACE::internal::parse_passwd_line(line1);
+  auto res1 = LIBC_NAMESPACE::pwd::parse_passwd_line(line1);
   ASSERT_FALSE(res1.has_value());
   ASSERT_EQ(res1.error(), EINVAL);
 
   char line2[] = "root:x:0:def:root:/root:/bin/bash";
-  auto res2 = LIBC_NAMESPACE::internal::parse_passwd_line(line2);
+  auto res2 = LIBC_NAMESPACE::pwd::parse_passwd_line(line2);
   ASSERT_FALSE(res2.has_value());
   ASSERT_EQ(res2.error(), EINVAL);
 
   char line3[] = "root:x:-1:0:root:/root:/bin/bash";
-  auto res3 = LIBC_NAMESPACE::internal::parse_passwd_line(line3);
+  auto res3 = LIBC_NAMESPACE::pwd::parse_passwd_line(line3);
   ASSERT_FALSE(res3.has_value());
   ASSERT_EQ(res3.error(), EINVAL);
 
   char line4[] = "root:x:0:-1:root:/root:/bin/bash";
-  auto res4 = LIBC_NAMESPACE::internal::parse_passwd_line(line4);
+  auto res4 = LIBC_NAMESPACE::pwd::parse_passwd_line(line4);
   ASSERT_FALSE(res4.has_value());
   ASSERT_EQ(res4.error(), EINVAL);
 }
 
 TEST(LlvmLibcPwdTest, ParsePasswdLine_MissingFields) {
   char line[] = "root:x:0:0:root:/root";
-  auto res = LIBC_NAMESPACE::internal::parse_passwd_line(line);
+  auto res = LIBC_NAMESPACE::pwd::parse_passwd_line(line);
   ASSERT_FALSE(res.has_value());
   ASSERT_EQ(res.error(), EINVAL);
 }
 
 TEST(LlvmLibcPwdTest, ParsePasswdLine_NullInput) {
-  auto res = LIBC_NAMESPACE::internal::parse_passwd_line(nullptr);
+  auto res = LIBC_NAMESPACE::pwd::parse_passwd_line(nullptr);
   ASSERT_FALSE(res.has_value());
   ASSERT_EQ(res.error(), EINVAL);
 }
 
 TEST(LlvmLibcPwdTest, ParsePasswdLine_TrailingGarbage) {
   char line1[] = "root:x:0a:0:root:/root:/bin/bash";
-  auto res1 = LIBC_NAMESPACE::internal::parse_passwd_line(line1);
+  auto res1 = LIBC_NAMESPACE::pwd::parse_passwd_line(line1);
   ASSERT_FALSE(res1.has_value());
   ASSERT_EQ(res1.error(), EINVAL);
 
   char line2[] = "root:x:0:0b:root:/root:/bin/bash";
-  auto res2 = LIBC_NAMESPACE::internal::parse_passwd_line(line2);
+  auto res2 = LIBC_NAMESPACE::pwd::parse_passwd_line(line2);
   ASSERT_FALSE(res2.has_value());
   ASSERT_EQ(res2.error(), EINVAL);
 }
 
 TEST(LlvmLibcPwdTest, ParsePasswdLine_Overflow) {
   char line1[] = "root:x:4294967296:0:root:/root:/bin/bash";
-  auto res1 = LIBC_NAMESPACE::internal::parse_passwd_line(line1);
+  auto res1 = LIBC_NAMESPACE::pwd::parse_passwd_line(line1);
   ASSERT_FALSE(res1.has_value());
   ASSERT_EQ(res1.error(), EINVAL);
 
   char line2[] = "root:x:0:4294967296:root:/root:/bin/bash";
-  auto res2 = LIBC_NAMESPACE::internal::parse_passwd_line(line2);
+  auto res2 = LIBC_NAMESPACE::pwd::parse_passwd_line(line2);
   ASSERT_FALSE(res2.has_value());
   ASSERT_EQ(res2.error(), EINVAL);
 }


### PR DESCRIPTION
Refactored the pwd database backend to separate file stream mechanics from record parsing using generic FlatFileDatabase and FieldTokenizer template engines.

POSIX user and group database queries must operate without dynamic heap allocations (ruling out getline/getdelim) and service both static process state (getpwent) and user-supplied reentrant buffers (getpwnam_r).

To satisfy these requirements with zero runtime overhead:

* Implemented FieldTokenizer to provide safe, in-place span tokenisation without pointer arithmetic or index-tracking hazards.
* Implemented FlatFileDatabase<EntryType> to encapsulate file lifecycle (setdb, enddb, getnext) and predicate-based linear search (lookup) parameterized directly on record types and free parse_line functions.
* Refactored PasswdParser into free parse_line and updated process-global passwd state to use FlatFileDatabase<struct passwd>.

This establishes the common scanning and search engine that will be reused directly by reentrant user lookups (getpwnam_r, getpwuid_r) and the upcoming group database subsystem (getgrent, getgrnam, getgrgid).

Assisted-by: Automated tooling, human reviewed.