### PR TITLE
[OpenMP] Create separate directives for two variants of ORDERED

### DIFF
--- a/clang/lib/Parse/ParseOpenMP.cpp
+++ b/clang/lib/Parse/ParseOpenMP.cpp
@@ -63,6 +63,13 @@ static OpenMPDirectiveKind checkOpenMPDirectiveName(Parser &P,
                                                     StringRef Name) {
   unsigned Version = P.getLangOpts().OpenMP;
   auto [D, VR] = getOpenMPDirectiveKindAndVersions(Name);
+  // There are multiple kinds corresponding to "ordered", and it's
+  // unspecified which one we get, so normalize it to OMPD_ordered.
+  if (D == Directive::OMPD_ordered_blockassoc ||
+      D == Directive::OMPD_ordered_standalone)
+    D = OMPD_ordered;
+  if (Kind == Directive::OMPD_ordered_standalone)
+    Kind = OMPD_ordered;
   assert(D == Kind && "Directive kind mismatch");
   // Ignore the case Version > VR.Max: In OpenMP 6.0 all prior spellings
   // are explicitly allowed.

--- a/llvm/include/llvm/Frontend/OpenMP/OMP.td
+++ b/llvm/include/llvm/Frontend/OpenMP/OMP.td
@@ -1096,6 +1096,24 @@ def OMP_Ordered : Directive<[Spelling<"ordered">]> {
   // There is also a block-associated "ordered" directive.
   let category = CA_Executable;
 }
+def OMP_OrderedStandalone : Directive<[Spelling<"ordered">]> {
+  let name = "ordered_standalone";
+  let allowedClauses = [
+    VersionedClause<OMPC_Depend>,
+    VersionedClause<OMPC_Doacross, 52>,
+  ];
+  let association = AS_None;
+  let category = CA_Executable;
+}
+def OMP_OrderedBlockassoc : Directive<[Spelling<"ordered">]> {
+  let name = "ordered_blockassoc";
+  let allowedOnceClauses = [
+    VersionedClause<OMPC_Simd>,
+    VersionedClause<OMPC_Threads>,
+  ];
+  let association = AS_Block;
+  let category = CA_Executable;
+}
 def OMP_Parallel : Directive<[Spelling<"parallel">]> {
   let allowedClauses = [
     VersionedClause<OMPC_Allocate, 50>,

--- a/llvm/unittests/Frontend/OpenMPDirectiveNameParserTest.cpp
+++ b/llvm/unittests/Frontend/OpenMPDirectiveNameParserTest.cpp
@@ -81,9 +81,21 @@ getParamName1(const testing::TestParamInfo<Tokenize::ParamType> &Info) {
   return prepareParamName(Name);
 }
 
+static std::vector<omp::Directive> getDirectiveSet() {
+  // The variants of the ORDERED construct share the same spelling, so only
+  // use one of them, otherwise the test will fail to instantiate.
+  std::vector<omp::Directive> Dirs;
+  for (omp::Directive D : llvm::omp::directives()) {
+    if (D == omp::Directive::OMPD_ordered ||
+        D == omp::Directive::OMPD_ordered_blockassoc)
+      continue;
+    Dirs.push_back(D);
+  }
+  return Dirs;
+}
+
 INSTANTIATE_TEST_SUITE_P(DirectiveNameParserTest, Tokenize,
-                         testing::ValuesIn(llvm::omp::directives()),
-                         getParamName1);
+                         testing::ValuesIn(getDirectiveSet()), getParamName1);
 
 // Test parsing of valid names.
 
@@ -122,7 +134,7 @@ getParamName2(const testing::TestParamInfo<ParseValid::ParamType> &Info) {
 
 INSTANTIATE_TEST_SUITE_P(
     DirectiveNameParserTest, ParseValid,
-    testing::Combine(testing::ValuesIn(llvm::omp::directives()),
+    testing::Combine(testing::ValuesIn(getDirectiveSet()),
                      testing::ValuesIn(omp::getOpenMPVersions())),
     getParamName2);
 


### PR DESCRIPTION
The ORDERED directive comes in two flavors, standalone and block-
associated. Create two different directive ids, one for each kind.
This will allow a more precise connection between the directive id
and its properties.

This does not remove OMPD_ordered, nor does it change clang or
flang beyond the minimum required to keep working as before.