### PR TITLE
[OpenMP] Delete now unused OMPD_ordered

### DIFF
--- a/clang/lib/Parse/ParseOpenMP.cpp
+++ b/clang/lib/Parse/ParseOpenMP.cpp
@@ -64,7 +64,7 @@ static OpenMPDirectiveKind checkOpenMPDirectiveName(Parser &P,
   unsigned Version = P.getLangOpts().OpenMP;
   auto [D, VR] = getOpenMPDirectiveKindAndVersions(Name);
   // "ORDERED" is parsed as OMPD_ordered_standalone.
-  if (D == Directive::OMPD_ordered || D == Directive::OMPD_ordered_blockassoc)
+  if (D == Directive::OMPD_ordered_blockassoc)
     D = Directive::OMPD_ordered_standalone;
   assert(D == Kind && "Directive kind mismatch");
   // Ignore the case Version > VR.Max: In OpenMP 6.0 all prior spellings

--- a/flang/lib/Parser/openmp-parsers.cpp
+++ b/flang/lib/Parser/openmp-parsers.cpp
@@ -211,8 +211,7 @@ struct OmpDirectiveNameParser {
         OmpDirectiveName n;
         // We can't tell which one "ordered" corresponds to here,
         // so normalize it to OMPD_ordered_standalone.
-        if (nid.second == llvm::omp::Directive::OMPD_ordered ||
-            nid.second == llvm::omp::Directive::OMPD_ordered_blockassoc) {
+        if (nid.second == llvm::omp::Directive::OMPD_ordered_blockassoc) {
           n.v = llvm::omp::Directive::OMPD_ordered_standalone;
         } else {
           n.v = nid.second;

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -910,8 +910,7 @@ void OmpStructureChecker::CheckDirectiveSpelling(
     }
     llvm::StringRef name{llvm::omp::getOpenMPDirectiveName(id, v)};
     auto [kind, versions]{llvm::omp::getOpenMPDirectiveKindAndVersions(name)};
-    if (kind != llvm::omp::Directive::OMPD_ordered &&
-        kind != llvm::omp::Directive::OMPD_ordered_blockassoc &&
+    if (kind != llvm::omp::Directive::OMPD_ordered_blockassoc &&
         kind != llvm::omp::Directive::OMPD_ordered_standalone) {
       assert(kind == id && "Directive kind mismatch");
     }

--- a/llvm/include/llvm/Frontend/OpenMP/OMP.td
+++ b/llvm/include/llvm/Frontend/OpenMP/OMP.td
@@ -1083,19 +1083,6 @@ def OMP_Nothing : Directive<[Spelling<"nothing">]> {
     LM_Identity,
   ];
 }
-def OMP_Ordered : Directive<[Spelling<"ordered">]> {
-  let allowedClauses = [
-    VersionedClause<OMPC_Depend>,
-    VersionedClause<OMPC_Doacross, 52>,
-  ];
-  let allowedOnceClauses = [
-    VersionedClause<OMPC_Simd>,
-    VersionedClause<OMPC_Threads>,
-  ];
-  let association = AS_None;
-  // There is also a block-associated "ordered" directive.
-  let category = CA_Executable;
-}
 def OMP_OrderedStandalone : Directive<[Spelling<"ordered">]> {
   let name = "ordered_standalone";
   let allowedClauses = [

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -8107,7 +8107,7 @@ OpenMPIRBuilder::InsertPointOrErrorTy OpenMPIRBuilder::createOrderedThreadsSimd(
   if (!updateToLocation(Loc))
     return Loc.IP;
 
-  Directive OMPD = Directive::OMPD_ordered;
+  Directive OMPD = Directive::OMPD_ordered_blockassoc;
   Instruction *EntryCall = nullptr;
   Instruction *ExitCall = nullptr;
 

--- a/llvm/unittests/Frontend/OpenMPDirectiveNameParserTest.cpp
+++ b/llvm/unittests/Frontend/OpenMPDirectiveNameParserTest.cpp
@@ -86,8 +86,7 @@ static std::vector<omp::Directive> getDirectiveSet() {
   // use one of them, otherwise the test will fail to instantiate.
   std::vector<omp::Directive> Dirs;
   for (omp::Directive D : llvm::omp::directives()) {
-    if (D == omp::Directive::OMPD_ordered ||
-        D == omp::Directive::OMPD_ordered_blockassoc)
+    if (D == omp::Directive::OMPD_ordered_blockassoc)
       continue;
     Dirs.push_back(D);
   }


### PR DESCRIPTION
It has been replaced by OMPD_ordered_standalone and
OMPD_ordered_blockassoc.