### PR TITLE
[lldb][AArch64] Remove size from type detector entries

### DIFF
--- a/lldb/source/Plugins/Process/Utility/RegisterTypeDetector_arm64.h
+++ b/lldb/source/Plugins/Process/Utility/RegisterTypeDetector_arm64.h
@@ -75,7 +75,7 @@ private:
                                        uint64_t hwcap3);
 
   struct RegisterEntry {
-    RegisterEntry(llvm::StringRef name, unsigned size, DetectorFn detector)
+    RegisterEntry(llvm::StringRef name, DetectorFn detector)
         : m_name(name), m_type(nullptr), m_detector(detector) {}
 
     llvm::StringRef m_name;
@@ -84,18 +84,17 @@ private:
     const RegisterType *m_type;
     DetectorFn m_detector;
   } m_registers[9] = {
-      RegisterEntry("cpsr", 4, &Arm64RegisterTypeDetector::DetectCPSRType),
-      RegisterEntry("fpsr", 4, &Arm64RegisterTypeDetector::DetectFPSRType),
-      RegisterEntry("fpcr", 4, &Arm64RegisterTypeDetector::DetectFPCRType),
-      RegisterEntry("mte_ctrl", 8,
-                    &Arm64RegisterTypeDetector::DetectMTECtrlType),
-      RegisterEntry("svcr", 8, &Arm64RegisterTypeDetector::DetectSVCRType),
-      RegisterEntry("fpmr", 8, &Arm64RegisterTypeDetector::DetectFPMRType),
-      RegisterEntry("gcs_features_enabled", 8,
+      RegisterEntry("cpsr", &Arm64RegisterTypeDetector::DetectCPSRType),
+      RegisterEntry("fpsr", &Arm64RegisterTypeDetector::DetectFPSRType),
+      RegisterEntry("fpcr", &Arm64RegisterTypeDetector::DetectFPCRType),
+      RegisterEntry("mte_ctrl", &Arm64RegisterTypeDetector::DetectMTECtrlType),
+      RegisterEntry("svcr", &Arm64RegisterTypeDetector::DetectSVCRType),
+      RegisterEntry("fpmr", &Arm64RegisterTypeDetector::DetectFPMRType),
+      RegisterEntry("gcs_features_enabled",
                     &Arm64RegisterTypeDetector::DetectGCSFeaturesType),
-      RegisterEntry("gcs_features_locked", 8,
+      RegisterEntry("gcs_features_locked",
                     &Arm64RegisterTypeDetector::DetectGCSFeaturesType),
-      RegisterEntry("por_el0", 8, &Arm64RegisterTypeDetector::DetectPOREL0Type),
+      RegisterEntry("por_el0", &Arm64RegisterTypeDetector::DetectPOREL0Type),
   };
 
   // Becomes true once field detection has been run for all registers.


### PR DESCRIPTION
This was passed to the constructor but goes unused.
The detector functions know the size of the type
they're creating already.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>