### PR TITLE
[lldb][AArch64] Detect type for many registers with a single function

### DIFF
--- a/lldb/source/Plugins/Process/Utility/RegisterTypeDetector_arm64.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterTypeDetector_arm64.cpp
@@ -308,7 +308,8 @@ void Arm64RegisterTypeDetector::UpdateRegisterInfo(const RegisterInfo *reg_info,
     // It is possible that a register is all extension dependent fields, and
     // none of them are present.
     if (reg.m_type)
-      search_registers.push_back({reg.m_name, reg.m_type});
+      for (auto reg_name : reg.m_names)
+        search_registers.push_back({reg_name, reg.m_type});
   }
 
   // Walk register information while there are registers we know need

--- a/lldb/source/Plugins/Process/Utility/RegisterTypeDetector_arm64.h
+++ b/lldb/source/Plugins/Process/Utility/RegisterTypeDetector_arm64.h
@@ -75,26 +75,26 @@ private:
                                        uint64_t hwcap3);
 
   struct RegisterEntry {
-    RegisterEntry(llvm::StringRef name, DetectorFn detector)
-        : m_name(name), m_type(nullptr), m_detector(detector) {}
+    RegisterEntry(const std::vector<llvm::StringRef> &names,
+                  DetectorFn detector)
+        : m_names(names), m_type(nullptr), m_detector(detector) {}
 
-    llvm::StringRef m_name;
+    std::vector<llvm::StringRef> m_names;
     // A raw pointer to the top level type. This pointer's lifetime is managed
     // by a unique pointer of the same value in m_detected_types.
     const RegisterType *m_type;
     DetectorFn m_detector;
-  } m_registers[9] = {
-      RegisterEntry("cpsr", &Arm64RegisterTypeDetector::DetectCPSRType),
-      RegisterEntry("fpsr", &Arm64RegisterTypeDetector::DetectFPSRType),
-      RegisterEntry("fpcr", &Arm64RegisterTypeDetector::DetectFPCRType),
-      RegisterEntry("mte_ctrl", &Arm64RegisterTypeDetector::DetectMTECtrlType),
-      RegisterEntry("svcr", &Arm64RegisterTypeDetector::DetectSVCRType),
-      RegisterEntry("fpmr", &Arm64RegisterTypeDetector::DetectFPMRType),
-      RegisterEntry("gcs_features_enabled",
+  } m_registers[8] = {
+      RegisterEntry({"cpsr"}, &Arm64RegisterTypeDetector::DetectCPSRType),
+      RegisterEntry({"fpsr"}, &Arm64RegisterTypeDetector::DetectFPSRType),
+      RegisterEntry({"fpcr"}, &Arm64RegisterTypeDetector::DetectFPCRType),
+      RegisterEntry({"mte_ctrl"},
+                    &Arm64RegisterTypeDetector::DetectMTECtrlType),
+      RegisterEntry({"svcr"}, &Arm64RegisterTypeDetector::DetectSVCRType),
+      RegisterEntry({"fpmr"}, &Arm64RegisterTypeDetector::DetectFPMRType),
+      RegisterEntry({"gcs_features_enabled", "gcs_features_locked"},
                     &Arm64RegisterTypeDetector::DetectGCSFeaturesType),
-      RegisterEntry("gcs_features_locked",
-                    &Arm64RegisterTypeDetector::DetectGCSFeaturesType),
-      RegisterEntry("por_el0", &Arm64RegisterTypeDetector::DetectPOREL0Type),
+      RegisterEntry({"por_el0"}, &Arm64RegisterTypeDetector::DetectPOREL0Type),
   };
 
   // Becomes true once field detection has been run for all registers.


### PR DESCRIPTION
It was pointed out during review of https://github.com/llvm/llvm-project/pull/214515
that the type for the 2 GCS registers will be created twice.
Each one will have the same ID so we will only emit one and
the other goes unused.

To account for this, and the possibility of not just 2 but N
registers later, I've changed the name in the register entry
to a list of names.

So for the 2 GCS registers we only do detection once, and both
of them will refer to the same instance of the type.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>