### PR TITLE
[JITLink] Notify memory managers on JITLinkDylib destruction

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/JITLink/JITLinkDylib.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/JITLinkDylib.h
@@ -13,23 +13,36 @@
 #ifndef LLVM_EXECUTIONENGINE_JITLINK_JITLINKDYLIB_H
 #define LLVM_EXECUTIONENGINE_JITLINK_JITLINKDYLIB_H
 
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Compiler.h"
+
 #include <string>
 
-namespace llvm {
-namespace jitlink {
+namespace llvm::jitlink {
 
-class JITLinkDylib {
+class JITLinkMemoryManager;
+
+/// Represents a JITDylib as seen by JITLink.
+class LLVM_ABI JITLinkDylib {
 public:
   JITLinkDylib(std::string Name) : Name(std::move(Name)) {}
+
+  ~JITLinkDylib();
 
   /// Get the name for this JITLinkDylib.
   const std::string &getName() const { return Name; }
 
+  /// Register a JITLinkMemoryManager to be notified when this JITLinkDylib
+  /// is destroyed.
+  void notifyOnDestruction(JITLinkMemoryManager &MemMgr) {
+    ToNotifyOnDestruction.push_back(&MemMgr);
+  }
+
 private:
   std::string Name;
+  SmallVector<JITLinkMemoryManager *> ToNotifyOnDestruction;
 };
 
-} // end namespace jitlink
-} // end namespace llvm
+} // namespace llvm::jitlink
 
 #endif // LLVM_EXECUTIONENGINE_JITLINK_JITLINKDYLIB_H

--- a/llvm/include/llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h
@@ -202,6 +202,15 @@ public:
     Allocs.push_back(std::move(Alloc));
     return deallocate(std::move(Allocs));
   }
+
+  /// Called when a JITLinkDylib that this manager previously registered
+  /// with (via JITLinkDylib::notifyOnDestruction) is being destroyed.
+  ///
+  /// May be used to free resources held on behalf of the JITLinkDylib (e.g.
+  /// reserved address ranges). The JITLinkDylib is guaranteed not to make
+  /// any further use of those resources after this call returns, so
+  /// clean-up may be deferred and completed asynchronously.
+  virtual void notifyDestroying(JITLinkDylib &JD) {}
 };
 
 /// BasicLayout simplifies the implementation of JITLinkMemoryManagers.

--- a/llvm/lib/ExecutionEngine/JITLink/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/JITLink/CMakeLists.txt
@@ -7,6 +7,7 @@ add_llvm_component_library(LLVMJITLink
   DWARFRecordSectionSplitter.cpp
   EHFrameSupport.cpp
   JITLink.cpp
+  JITLinkDylib.cpp
   JITLinkGeneric.cpp
   JITLinkMemoryManager.cpp
 

--- a/llvm/lib/ExecutionEngine/JITLink/JITLinkDylib.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/JITLinkDylib.cpp
@@ -1,0 +1,19 @@
+//===-------------------------- JITLinkDylib.cpp --------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ExecutionEngine/JITLink/JITLinkDylib.h"
+#include "llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h"
+
+namespace llvm::jitlink {
+
+JITLinkDylib::~JITLinkDylib() {
+  for (JITLinkMemoryManager *MemMgr : ToNotifyOnDestruction)
+    MemMgr->notifyDestroying(*this);
+}
+
+} // namespace llvm::jitlink

--- a/llvm/unittests/ExecutionEngine/JITLink/CMakeLists.txt
+++ b/llvm/unittests/ExecutionEngine/JITLink/CMakeLists.txt
@@ -13,6 +13,7 @@ add_llvm_unittest(JITLinkTests
     AArch64Tests.cpp
     COFFLinkGraphTests.cpp
     EHFrameSupportTests.cpp
+    JITLinkDylibTest.cpp
     JITLinkTestUtils.cpp
     LinkGraphTests.cpp
     MachOLinkGraphTests.cpp

--- a/llvm/unittests/ExecutionEngine/JITLink/JITLinkDylibTest.cpp
+++ b/llvm/unittests/ExecutionEngine/JITLink/JITLinkDylibTest.cpp
@@ -1,0 +1,68 @@
+//===--- JITLinkDylibTest.cpp - Test JITLinkDylib and notifications ------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ExecutionEngine/JITLink/JITLinkDylib.h"
+#include "llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+using namespace llvm::jitlink;
+
+namespace {
+
+class RecordingMemoryManager : public JITLinkMemoryManager {
+public:
+  void allocate(const JITLinkDylib *JD, LinkGraph &G,
+                OnAllocatedFunction OnAllocated) override {
+    llvm_unreachable("Not used by this test");
+  }
+
+  void deallocate(std::vector<FinalizedAlloc> Allocs,
+                  OnDeallocatedFunction OnDeallocated) override {
+    llvm_unreachable("Not used by this test");
+  }
+
+  using JITLinkMemoryManager::deallocate;
+
+  void notifyDestroying(JITLinkDylib &JD) override {
+    NotifiedName = JD.getName();
+    ++NotifyCount;
+  }
+
+  unsigned NotifyCount = 0;
+  std::string NotifiedName;
+};
+
+} // namespace
+
+TEST(JITLinkDylibTest, GetName) {
+  JITLinkDylib JD("foo");
+  EXPECT_EQ(JD.getName(), "foo");
+}
+
+TEST(JITLinkDylibTest, MemoryManagerNotifiedOnDestruction) {
+  RecordingMemoryManager MemMgr;
+  {
+    JITLinkDylib JD("foo");
+    JD.notifyOnDestruction(MemMgr);
+    EXPECT_EQ(MemMgr.NotifyCount, 0U);
+  }
+  EXPECT_EQ(MemMgr.NotifyCount, 1U);
+  EXPECT_EQ(MemMgr.NotifiedName, "foo");
+}
+
+TEST(JITLinkDylibTest, MultipleMemoryManagersAllNotified) {
+  RecordingMemoryManager MemMgr1, MemMgr2;
+  {
+    JITLinkDylib JD("foo");
+    JD.notifyOnDestruction(MemMgr1);
+    JD.notifyOnDestruction(MemMgr2);
+  }
+  EXPECT_EQ(MemMgr1.NotifyCount, 1U);
+  EXPECT_EQ(MemMgr2.NotifyCount, 1U);
+}


### PR DESCRIPTION
Add JITLinkDylib::notifyOnDestruction so a JITLinkMemoryManager can register to be told when a JITLinkDylib it served is being torn down, giving it a chance to release resources held on the dylib's behalf (e.g. reserved address ranges). Notification may be handled asynchronously: once notifyDestroying is called, the JITLinkDylib is guaranteed not to make further use of those resources.