### PR TITLE
[LiveRegUnits] Avoid accidentally O(n^2) loop in addCalleeSavedRegs (NFC)

### DIFF
--- a/llvm/lib/CodeGen/LiveRegUnits.cpp
+++ b/llvm/lib/CodeGen/LiveRegUnits.cpp
@@ -105,17 +105,8 @@ static void addBlockLiveOuts(LiveRegUnits &LiveUnits,
 static void addCalleeSavedRegs(LiveRegUnits &LiveUnits,
                                const MachineFunction &MF) {
   const MachineRegisterInfo &MRI = MF.getRegInfo();
-  const MachineFrameInfo &MFI = MF.getFrameInfo();
-  for (const MCPhysReg *CSR = MRI.getCalleeSavedRegs(); CSR && *CSR; ++CSR) {
-    const unsigned N = *CSR;
-
-    const auto &CSI = MFI.getCalleeSavedInfo();
-    auto Info =
-        llvm::find_if(CSI, [N](auto Info) { return Info.getReg() == N; });
-    // If we have no info for this callee-saved register, assume it is liveout
-    if (Info == CSI.end() || Info->isRestored())
-      LiveUnits.addReg(N);
-  }
+  for (const MCPhysReg *CSR = MRI.getCalleeSavedRegs(); CSR && *CSR; ++CSR)
+    LiveUnits.addReg(*CSR);
 }
 
 void LiveRegUnits::addPristines(const MachineFunction &MF) {
@@ -153,8 +144,14 @@ void LiveRegUnits::addLiveOuts(const MachineBasicBlock &MBB) {
   // For the return block: Add all callee saved registers.
   if (MBB.isReturnBlock()) {
     const MachineFrameInfo &MFI = MF.getFrameInfo();
-    if (MFI.isCalleeSavedInfoValid())
+    if (MFI.isCalleeSavedInfoValid()) {
       addCalleeSavedRegs(*this, MF);
+      // We assume callee-saved registers without CalleeSavedInfo are liveout.
+      for (const CalleeSavedInfo &Info : MFI.getCalleeSavedInfo()) {
+        if (!Info.isRestored())
+          removeReg(Info.getReg());
+      }
+    }
   }
 }
 


### PR DESCRIPTION
This is a small improvement for `stage1-aarch64-O3`: https://llvm-compile-time-tracker.com/compare.php?from=94af8651da4a1b907a8ea2acb698d72aad3df722&to=ce67ef155e8fc7945a6ec930a12e5762a45fa00b&stat=instructions:u