### PR TITLE
[SCEV] Consolidate NoWrapFlags (NFC)

### DIFF
--- a/llvm/include/llvm/Analysis/ScalarEvolution.h
+++ b/llvm/include/llvm/Analysis/ScalarEvolution.h
@@ -90,6 +90,14 @@ LLVM_ABI extern bool VerifySCEV;
 /// either implies NW. For convenience, NW will be set for a recurrence
 /// whenever either NUW or NSW are set.
 ///
+/// If Signed is a function that takes an n-bit tuple and maps to the
+/// integer domain as the tuples value interpreted as twos complement,
+/// and Unsigned a function that takes an n-bit tuple and maps to the
+/// integer domain as the base two value of input tuple, then a + b
+/// has NUSW iff:
+///
+/// 0 <= Unsigned(a) + Signed(b) < 2^n
+///
 /// We require that the flag on a SCEV apply to the entire scope in which
 /// that SCEV is defined.  A SCEV's scope is set of locations dominated by
 /// a defining location, which is in turn described by the following rules:
@@ -110,9 +118,9 @@ LLVM_ABI extern bool VerifySCEV;
 enum class SCEVNoWrapFlags {
   FlagAnyWrap = 0,     // No guarantee.
   FlagNW = (1 << 0),   // No self-wrap.
-  FlagNUW = (1 << 1),  // No unsigned wrap.
-  FlagNSW = (1 << 2),  // No signed wrap.
-  FlagNUSW = (1 << 3), // No unsigned signed wrap.
+  FlagNUSW = (1 << 1), // No unsigned signed wrap.
+  FlagNUW = (1 << 2),  // No unsigned wrap.
+  FlagNSW = (1 << 3),  // No signed wrap.
   NoWrapMask = (1 << 4) - 1,
   LLVM_MARK_AS_BITMASK_ENUM(/*LargestValue=*/NoWrapMask)
 };
@@ -295,9 +303,9 @@ public:
   using NoWrapFlags = SCEVNoWrapFlags;
   static constexpr auto FlagAnyWrap = SCEVNoWrapFlags::FlagAnyWrap;
   static constexpr auto FlagNW = SCEVNoWrapFlags::FlagNW;
+  static constexpr auto FlagNUSW = SCEVNoWrapFlags::FlagNUSW;
   static constexpr auto FlagNUW = SCEVNoWrapFlags::FlagNUW;
   static constexpr auto FlagNSW = SCEVNoWrapFlags::FlagNSW;
-  static constexpr auto FlagNUSW = SCEVNoWrapFlags::FlagNUSW;
   static constexpr auto NoWrapMask = SCEVNoWrapFlags::NoWrapMask;
 
   explicit SCEV(const FoldingSetNodeIDRef ID, SCEVTypes SCEVTy,
@@ -500,36 +508,6 @@ public:
 /// have more than X iterations.
 class LLVM_ABI SCEVWrapPredicate final : public SCEVPredicate {
 public:
-  /// Similar to SCEV::NoWrapFlags, but with slightly different semantics
-  /// for FlagNUSW. The increment is considered to be signed, and a + b
-  /// (where b is the increment) is considered to wrap if:
-  ///    zext(a + b) != zext(a) + sext(b)
-  ///
-  /// If Signed is a function that takes an n-bit tuple and maps to the
-  /// integer domain as the tuples value interpreted as twos complement,
-  /// and Unsigned a function that takes an n-bit tuple and maps to the
-  /// integer domain as the base two value of input tuple, then a + b
-  /// has IncrementNUSW iff:
-  ///
-  /// 0 <= Unsigned(a) + Signed(b) < 2^n
-  ///
-  /// The IncrementNSSW flag has identical semantics with SCEV::FlagNSW.
-  ///
-  /// Note that the IncrementNUSW flag is not commutative: if base + inc
-  /// has IncrementNUSW, then inc + base doesn't neccessarily have this
-  /// property. The reason for this is that this is used for sign/zero
-  /// extending affine AddRec SCEV expressions when a SCEVWrapPredicate is
-  /// assumed. A {base,+,inc} expression is already non-commutative with
-  /// regards to base and inc, since it is interpreted as:
-  ///     (((base + inc) + inc) + inc) ...
-  enum IncrementWrapFlags {
-    IncrementAnyWrap = 0,     // No guarantee.
-    IncrementNUSW = (1 << 0), // No unsigned with signed increment wrap.
-    IncrementNSSW = (1 << 1), // No signed with signed increment wrap
-                              // (equivalent with SCEV::NSW)
-    IncrementNoWrapMask = (1 << 2) - 1
-  };
-
   /// Returns the set of SCEVWrapPredicate no wrap flags implied by a
   /// SCEVAddRecExpr.
   [[nodiscard]] static SCEVNoWrapFlags getImpliedFlags(const SCEVAddRecExpr *AR,

--- a/llvm/include/llvm/Analysis/ScalarEvolution.h
+++ b/llvm/include/llvm/Analysis/ScalarEvolution.h
@@ -108,13 +108,32 @@ LLVM_ABI extern bool VerifySCEV;
 /// at runtime.  A SCEV being defined does not require the existence of any
 /// instruction within the defined scope.
 enum class SCEVNoWrapFlags {
-  FlagAnyWrap = 0,    // No guarantee.
-  FlagNW = (1 << 0),  // No self-wrap.
-  FlagNUW = (1 << 1), // No unsigned wrap.
-  FlagNSW = (1 << 2), // No signed wrap.
-  NoWrapMask = (1 << 3) - 1,
+  FlagAnyWrap = 0,     // No guarantee.
+  FlagNW = (1 << 0),   // No self-wrap.
+  FlagNUW = (1 << 1),  // No unsigned wrap.
+  FlagNSW = (1 << 2),  // No signed wrap.
+  FlagNUSW = (1 << 3), // No unsigned signed wrap.
+  NoWrapMask = (1 << 4) - 1,
   LLVM_MARK_AS_BITMASK_ENUM(/*LargestValue=*/NoWrapMask)
 };
+
+/// Convenient NoWrapFlags manipulation.
+[[nodiscard]] inline SCEVNoWrapFlags maskFlags(SCEVNoWrapFlags Flags,
+                                               SCEVNoWrapFlags Mask) {
+  return Flags & Mask;
+}
+[[nodiscard]] inline SCEVNoWrapFlags setFlags(SCEVNoWrapFlags Flags,
+                                              SCEVNoWrapFlags OnFlags) {
+  return Flags | OnFlags;
+}
+[[nodiscard]] inline SCEVNoWrapFlags clearFlags(SCEVNoWrapFlags Flags,
+                                                SCEVNoWrapFlags OffFlags) {
+  return Flags & ~OffFlags;
+}
+[[nodiscard]] inline bool hasFlags(SCEVNoWrapFlags Flags,
+                                   SCEVNoWrapFlags TestFlags) {
+  return TestFlags == maskFlags(Flags, TestFlags);
+}
 
 class SCEV;
 
@@ -278,6 +297,7 @@ public:
   static constexpr auto FlagNW = SCEVNoWrapFlags::FlagNW;
   static constexpr auto FlagNUW = SCEVNoWrapFlags::FlagNUW;
   static constexpr auto FlagNSW = SCEVNoWrapFlags::FlagNSW;
+  static constexpr auto FlagNUSW = SCEVNoWrapFlags::FlagNUSW;
   static constexpr auto NoWrapMask = SCEVNoWrapFlags::NoWrapMask;
 
   explicit SCEV(const FoldingSetNodeIDRef ID, SCEVTypes SCEVTy,
@@ -510,50 +530,21 @@ public:
     IncrementNoWrapMask = (1 << 2) - 1
   };
 
-  /// Convenient IncrementWrapFlags manipulation methods.
-  [[nodiscard]] static SCEVWrapPredicate::IncrementWrapFlags
-  clearFlags(SCEVWrapPredicate::IncrementWrapFlags Flags,
-             SCEVWrapPredicate::IncrementWrapFlags OffFlags) {
-    assert((Flags & IncrementNoWrapMask) == Flags && "Invalid flags value!");
-    assert((OffFlags & IncrementNoWrapMask) == OffFlags &&
-           "Invalid flags value!");
-    return (SCEVWrapPredicate::IncrementWrapFlags)(Flags & ~OffFlags);
-  }
-
-  [[nodiscard]] static SCEVWrapPredicate::IncrementWrapFlags
-  maskFlags(SCEVWrapPredicate::IncrementWrapFlags Flags, int Mask) {
-    assert((Flags & IncrementNoWrapMask) == Flags && "Invalid flags value!");
-    assert((Mask & IncrementNoWrapMask) == Mask && "Invalid mask value!");
-
-    return (SCEVWrapPredicate::IncrementWrapFlags)(Flags & Mask);
-  }
-
-  [[nodiscard]] static SCEVWrapPredicate::IncrementWrapFlags
-  setFlags(SCEVWrapPredicate::IncrementWrapFlags Flags,
-           SCEVWrapPredicate::IncrementWrapFlags OnFlags) {
-    assert((Flags & IncrementNoWrapMask) == Flags && "Invalid flags value!");
-    assert((OnFlags & IncrementNoWrapMask) == OnFlags &&
-           "Invalid flags value!");
-
-    return (SCEVWrapPredicate::IncrementWrapFlags)(Flags | OnFlags);
-  }
-
   /// Returns the set of SCEVWrapPredicate no wrap flags implied by a
   /// SCEVAddRecExpr.
-  [[nodiscard]] static SCEVWrapPredicate::IncrementWrapFlags
-  getImpliedFlags(const SCEVAddRecExpr *AR, ScalarEvolution &SE);
+  [[nodiscard]] static SCEVNoWrapFlags getImpliedFlags(const SCEVAddRecExpr *AR,
+                                                       ScalarEvolution &SE);
 
 private:
   const SCEVAddRecExpr *AR;
-  IncrementWrapFlags Flags;
+  SCEVNoWrapFlags Flags;
 
 public:
   explicit SCEVWrapPredicate(const FoldingSetNodeIDRef ID,
-                             const SCEVAddRecExpr *AR,
-                             IncrementWrapFlags Flags);
+                             const SCEVAddRecExpr *AR, SCEVNoWrapFlags Flags);
 
   /// Returns the set assumed no overflow flags.
-  IncrementWrapFlags getFlags() const { return Flags; }
+  SCEVNoWrapFlags getFlags() const { return Flags; }
 
   /// Implementation of the SCEVPredicate interface
   const SCEVAddRecExpr *getExpr() const;
@@ -634,25 +625,6 @@ public:
     DoesNotDominateBlock,  ///< The SCEV does not dominate the block.
     DominatesBlock,        ///< The SCEV dominates the block.
     ProperlyDominatesBlock ///< The SCEV properly dominates the block.
-  };
-
-  /// Convenient NoWrapFlags manipulation. TODO: Replace with & operator of
-  /// enum class.
-  [[nodiscard]] static SCEV::NoWrapFlags maskFlags(SCEV::NoWrapFlags Flags,
-                                                   SCEV::NoWrapFlags Mask) {
-    return Flags & Mask;
-  }
-  [[nodiscard]] static SCEV::NoWrapFlags setFlags(SCEV::NoWrapFlags Flags,
-                                                  SCEV::NoWrapFlags OnFlags) {
-    return Flags | OnFlags;
-  }
-  [[nodiscard]] static SCEV::NoWrapFlags
-  clearFlags(SCEV::NoWrapFlags Flags, SCEV::NoWrapFlags OffFlags) {
-    return Flags & ~OffFlags;
-  }
-  [[nodiscard]] static bool hasFlags(SCEV::NoWrapFlags Flags,
-                                     SCEV::NoWrapFlags TestFlags) {
-    return TestFlags == maskFlags(Flags, TestFlags);
   };
 
   LLVM_ABI ScalarEvolution(Function &F, TargetLibraryInfo &TLI,
@@ -1520,9 +1492,8 @@ public:
                                                     const SCEV *LHS,
                                                     const SCEV *RHS);
 
-  LLVM_ABI const SCEVPredicate *
-  getWrapPredicate(const SCEVAddRecExpr *AR,
-                   SCEVWrapPredicate::IncrementWrapFlags AddedFlags);
+  LLVM_ABI const SCEVPredicate *getWrapPredicate(const SCEVAddRecExpr *AR,
+                                                 SCEVNoWrapFlags AddedFlags);
 
   /// Re-writes the SCEV according to the Predicates in \p A.
   LLVM_ABI const SCEV *rewriteUsingPredicate(const SCEV *S, const Loop *L,
@@ -2674,8 +2645,7 @@ public:
               SmallVectorImpl<const SCEVPredicate *> *WrapPredsAdded = nullptr);
 
   /// Returns true if we've statically proved that V doesn't wrap.
-  LLVM_ABI bool hasNoOverflow(Value *V,
-                              SCEVWrapPredicate::IncrementWrapFlags Flags);
+  LLVM_ABI bool hasNoOverflow(Value *V, SCEVNoWrapFlags Flags);
 
   /// Returns the ScalarEvolution analysis used.
   ScalarEvolution *getSE() const { return &SE; }

--- a/llvm/include/llvm/Analysis/ScalarEvolutionExpressions.h
+++ b/llvm/include/llvm/Analysis/ScalarEvolutionExpressions.h
@@ -371,7 +371,7 @@ public:
   /// to make it easier to propagate flags.
   void setNoWrapFlags(NoWrapFlags Flags) {
     if (any(Flags & (FlagNUW | FlagNSW)))
-      Flags = ScalarEvolution::setFlags(Flags, FlagNW);
+      Flags = setFlags(Flags, FlagNW);
     SubclassData |= static_cast<unsigned short>(Flags);
   }
 

--- a/llvm/lib/Analysis/LoopAccessAnalysis.cpp
+++ b/llvm/lib/Analysis/LoopAccessAnalysis.cpp
@@ -1041,7 +1041,7 @@ isNoWrap(PredicatedScalarEvolution &PSE, const SCEVAddRecExpr *AR, Value *Ptr,
   if (any(AR->getNoWrapFlags(SCEV::NoWrapMask)))
     return true;
 
-  if (Ptr && PSE.hasNoOverflow(Ptr, SCEVWrapPredicate::IncrementNUSW))
+  if (Ptr && PSE.hasNoOverflow(Ptr, SCEV::FlagNUSW))
     return true;
 
   // An nusw getelementptr that is an AddRec cannot wrap. If it would wrap,
@@ -1079,9 +1079,8 @@ isNoWrap(PredicatedScalarEvolution &PSE, const SCEVAddRecExpr *AR, Value *Ptr,
 
   if (Ptr && Predicates) {
     ScalarEvolution &SE = *PSE.getSE();
-    SCEVWrapPredicate::IncrementWrapFlags Flags = SCEVWrapPredicate::clearFlags(
-        SCEVWrapPredicate::IncrementNUSW,
-        SCEVWrapPredicate::getImpliedFlags(AR, SE));
+    SCEVNoWrapFlags Flags =
+        clearFlags(SCEV::FlagNUSW, SCEVWrapPredicate::getImpliedFlags(AR, SE));
     Predicates->push_back(SE.getWrapPredicate(AR, Flags));
     LLVM_DEBUG(dbgs() << "LAA: Pointer may wrap:\n"
                       << "LAA:   Pointer: " << *Ptr << "\n"

--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -1382,8 +1382,7 @@ static const SCEV *getPreStartForExtend(const SCEVAddRecExpr *AR, Type *Ty,
   // `Step`:
 
   // 1. NSW/NUW flags on the step increment.
-  auto PreStartFlags =
-    ScalarEvolution::maskFlags(SA->getNoWrapFlags(), SCEV::FlagNUW);
+  auto PreStartFlags = maskFlags(SA->getNoWrapFlags(), SCEV::FlagNUW);
   const SCEV *PreStart = SE->getAddExpr(DiffOps, PreStartFlags);
   const SCEVAddRecExpr *PreAR = dyn_cast<SCEVAddRecExpr>(
       SE->getAddRecExpr(PreStart, Step, L, SCEV::FlagAnyWrap));
@@ -2427,9 +2426,9 @@ ScalarEvolution::getStrengthenedNoWrapFlagsFromBinOp(
   SCEV::NoWrapFlags Flags = SCEV::NoWrapFlags::FlagAnyWrap;
 
   if (OBO->hasNoUnsignedWrap())
-    Flags = ScalarEvolution::setFlags(Flags, SCEV::FlagNUW);
+    Flags = setFlags(Flags, SCEV::FlagNUW);
   if (OBO->hasNoSignedWrap())
-    Flags = ScalarEvolution::setFlags(Flags, SCEV::FlagNSW);
+    Flags = setFlags(Flags, SCEV::FlagNSW);
 
   bool Deduced = false;
 
@@ -2458,13 +2457,13 @@ ScalarEvolution::getStrengthenedNoWrapFlagsFromBinOp(
       UseContextForNoWrapFlagInference ? dyn_cast<Instruction>(OBO) : nullptr;
   if (!OBO->hasNoUnsignedWrap() &&
       willNotOverflow(Opcode, /* Signed */ false, LHS, RHS, CtxI)) {
-    Flags = ScalarEvolution::setFlags(Flags, SCEV::FlagNUW);
+    Flags = setFlags(Flags, SCEV::FlagNUW);
     Deduced = true;
   }
 
   if (CanUseNSW && !OBO->hasNoSignedWrap() &&
       willNotOverflow(Opcode, /* Signed */ true, LHS, RHS, CtxI)) {
-    Flags = ScalarEvolution::setFlags(Flags, SCEV::FlagNSW);
+    Flags = setFlags(Flags, SCEV::FlagNSW);
     Deduced = true;
   }
 
@@ -2490,8 +2489,7 @@ static SCEV::NoWrapFlags StrengthenNoWrapFlags(ScalarEvolution *SE,
   assert(CanAnalyze && "don't call from other places!");
 
   SCEV::NoWrapFlags SignOrUnsignMask = SCEV::FlagNUW | SCEV::FlagNSW;
-  SCEV::NoWrapFlags SignOrUnsignWrap =
-      ScalarEvolution::maskFlags(Flags, SignOrUnsignMask);
+  SCEV::NoWrapFlags SignOrUnsignWrap = maskFlags(Flags, SignOrUnsignMask);
 
   // If FlagNSW is true and all the operands are non-negative, infer FlagNUW.
   auto IsKnownNonNegative = [&](SCEVUse U) {
@@ -2499,9 +2497,9 @@ static SCEV::NoWrapFlags StrengthenNoWrapFlags(ScalarEvolution *SE,
   };
 
   if (SignOrUnsignWrap == SCEV::FlagNSW && all_of(Ops, IsKnownNonNegative))
-    Flags = ScalarEvolution::setFlags(Flags, SignOrUnsignMask);
+    Flags = setFlags(Flags, SignOrUnsignMask);
 
-  SignOrUnsignWrap = ScalarEvolution::maskFlags(Flags, SignOrUnsignMask);
+  SignOrUnsignWrap = maskFlags(Flags, SignOrUnsignMask);
 
   if (SignOrUnsignWrap != SignOrUnsignMask &&
       (Type == scAddExpr || Type == scMulExpr) && Ops.size() == 2 &&
@@ -2525,7 +2523,7 @@ static SCEV::NoWrapFlags StrengthenNoWrapFlags(ScalarEvolution *SE,
       auto NSWRegion = ConstantRange::makeGuaranteedNoWrapRegion(
           Opcode, C, OBO::NoSignedWrap);
       if (NSWRegion.contains(SE->getSignedRange(Ops[1])))
-        Flags = ScalarEvolution::setFlags(Flags, SCEV::FlagNSW);
+        Flags = setFlags(Flags, SCEV::FlagNSW);
     }
 
     // (A <opcode> C) --> (A <opcode> C)<nuw> if the op doesn't unsign overflow.
@@ -2533,26 +2531,25 @@ static SCEV::NoWrapFlags StrengthenNoWrapFlags(ScalarEvolution *SE,
       auto NUWRegion = ConstantRange::makeGuaranteedNoWrapRegion(
           Opcode, C, OBO::NoUnsignedWrap);
       if (NUWRegion.contains(SE->getUnsignedRange(Ops[1])))
-        Flags = ScalarEvolution::setFlags(Flags, SCEV::FlagNUW);
+        Flags = setFlags(Flags, SCEV::FlagNUW);
     }
   }
 
   // <0,+,nonnegative><nw> is also nuw
   // TODO: Add corresponding nsw case
-  if (Type == scAddRecExpr && ScalarEvolution::hasFlags(Flags, SCEV::FlagNW) &&
-      !ScalarEvolution::hasFlags(Flags, SCEV::FlagNUW) && Ops.size() == 2 &&
-      Ops[0]->isZero() && IsKnownNonNegative(Ops[1]))
-    Flags = ScalarEvolution::setFlags(Flags, SCEV::FlagNUW);
+  if (Type == scAddRecExpr && hasFlags(Flags, SCEV::FlagNW) &&
+      !hasFlags(Flags, SCEV::FlagNUW) && Ops.size() == 2 && Ops[0]->isZero() &&
+      IsKnownNonNegative(Ops[1]))
+    Flags = setFlags(Flags, SCEV::FlagNUW);
 
   // both (udiv X, Y) * Y and Y * (udiv X, Y) are always NUW
-  if (Type == scMulExpr && !ScalarEvolution::hasFlags(Flags, SCEV::FlagNUW) &&
-      Ops.size() == 2) {
+  if (Type == scMulExpr && !hasFlags(Flags, SCEV::FlagNUW) && Ops.size() == 2) {
     if (auto *UDiv = dyn_cast<SCEVUDivExpr>(Ops[0]))
       if (UDiv->getOperand(1) == Ops[1])
-        Flags = ScalarEvolution::setFlags(Flags, SCEV::FlagNUW);
+        Flags = setFlags(Flags, SCEV::FlagNUW);
     if (auto *UDiv = dyn_cast<SCEVUDivExpr>(Ops[1]))
       if (UDiv->getOperand(1) == Ops[0])
-        Flags = ScalarEvolution::setFlags(Flags, SCEV::FlagNUW);
+        Flags = setFlags(Flags, SCEV::FlagNUW);
   }
 
   return Flags;
@@ -2712,19 +2709,16 @@ const SCEV *ScalarEvolution::getAddExpr(SmallVectorImpl<SCEVUse> &Ops,
       APInt ConstAdd = C1 + C2;
       auto AddFlags = AddExpr->getNoWrapFlags();
       // Adding a smaller constant is NUW if the original AddExpr was NUW.
-      if (ScalarEvolution::hasFlags(AddFlags, SCEV::FlagNUW) &&
-          ConstAdd.ule(C1)) {
-        PreservedFlags =
-            ScalarEvolution::setFlags(PreservedFlags, SCEV::FlagNUW);
+      if (hasFlags(AddFlags, SCEV::FlagNUW) && ConstAdd.ule(C1)) {
+        PreservedFlags = setFlags(PreservedFlags, SCEV::FlagNUW);
       }
 
       // Adding a constant with the same sign and small magnitude is NSW, if the
       // original AddExpr was NSW.
-      if (ScalarEvolution::hasFlags(AddFlags, SCEV::FlagNSW) &&
+      if (hasFlags(AddFlags, SCEV::FlagNSW) &&
           C1.isSignBitSet() == ConstAdd.isSignBitSet() &&
           ConstAdd.abs().ule(C1.abs())) {
-        PreservedFlags =
-            ScalarEvolution::setFlags(PreservedFlags, SCEV::FlagNSW);
+        PreservedFlags = setFlags(PreservedFlags, SCEV::FlagNSW);
       }
 
       if (PreservedFlags != SCEV::FlagAnyWrap) {
@@ -5507,9 +5501,10 @@ static const Loop *isIntegerLoopHeaderPHI(const PHINode *PN, LoopInfo &LI) {
 //    will return the pair {NewAddRec, SmallPredsVec} where:
 //         NewAddRec = {%Start,+,%Step}
 //         SmallPredsVec = {P1, P2, P3} as follows:
-//           P1(WrapPred): AR: {trunc(%Start),+,(trunc %Step)}<nsw> Flags: <nssw>
-//           P2(EqualPred): %Start == (sext i32 (trunc i64 %Start to i32) to i64)
-//           P3(EqualPred): %Step == (sext i32 (trunc i64 %Step to i32) to i64)
+//           P1(WrapPred): AR: {trunc(%Start),+,(trunc %Step)}<nsw> Flags: <nsw>
+//           P2(EqualPred): %Start == (sext i32 (trunc i64 %Start to i32) to
+//           i64) P3(EqualPred): %Step == (sext i32 (trunc i64 %Step to i32) to
+//           i64)
 //    The returned pair means that SymbolicPHI can be rewritten into NewAddRec
 //    under the predicates {P1,P2,P3}.
 //    This predicated rewrite will be cached in PredicatedSCEVRewrites:
@@ -5671,9 +5666,7 @@ ScalarEvolution::createAddRecFromPHIWithCastsImpl(const SCEVUnknown *SymbolicPHI
   //  If PHISCEV is a constant, then P1 degenerates into P2 or P3, so we don't
   // add P1.
   if (const auto *AR = dyn_cast<SCEVAddRecExpr>(PHISCEV)) {
-    SCEVWrapPredicate::IncrementWrapFlags AddedFlags =
-        Signed ? SCEVWrapPredicate::IncrementNSSW
-               : SCEVWrapPredicate::IncrementNUSW;
+    SCEVNoWrapFlags AddedFlags = Signed ? SCEV::FlagNSW : SCEV::FlagNUSW;
     const SCEVPredicate *AddRecPred = getWrapPredicate(AR, AddedFlags);
     Predicates.push_back(AddRecPred);
   }
@@ -5715,7 +5708,7 @@ ScalarEvolution::createAddRecFromPHIWithCastsImpl(const SCEVUnknown *SymbolicPHI
   }
 
   // The Step is always Signed (because the overflow checks are either
-  // NSSW or NUSW)
+  // NSW or NUSW)
   const SCEV *AccumExtended = getExtendedExpr(Accum, /*CreateSignExtend=*/true);
   if (PredIsKnownFalse(Accum, AccumExtended)) {
     LLVM_DEBUG(dbgs() << "P3 is compile-time false\n";);
@@ -7226,9 +7219,9 @@ ScalarEvolution::getRangeForAffineAR(const SCEV *Start, const SCEV *Step,
 
   SCEV::NoWrapFlags Flags = SCEV::FlagAnyWrap;
   if (NUW)
-    Flags = ScalarEvolution::setFlags(Flags, SCEV::FlagNUW);
+    Flags = setFlags(Flags, SCEV::FlagNUW);
   if (NSW1 && NSW2)
-    Flags = ScalarEvolution::setFlags(Flags, SCEV::FlagNSW);
+    Flags = setFlags(Flags, SCEV::FlagNSW);
 
   // Finally, intersect signed and unsigned ranges.
   return {SR.intersectWith(UR, ConstantRange::Smallest), Flags};
@@ -7424,12 +7417,12 @@ SCEV::NoWrapFlags ScalarEvolution::getNoWrapFlagsFromUB(const Value *V) {
   SCEV::NoWrapFlags Flags = SCEV::FlagAnyWrap;
   if (auto *PDI = dyn_cast<PossiblyDisjointInst>(BinOp);
       PDI && PDI->isDisjoint()) {
-    Flags = ScalarEvolution::setFlags(SCEV::FlagNUW, SCEV::FlagNSW);
+    Flags = setFlags(SCEV::FlagNUW, SCEV::FlagNSW);
   } else {
     if (BinOp->hasNoUnsignedWrap())
-      Flags = ScalarEvolution::setFlags(Flags, SCEV::FlagNUW);
+      Flags = setFlags(Flags, SCEV::FlagNUW);
     if (BinOp->hasNoSignedWrap())
-      Flags = ScalarEvolution::setFlags(Flags, SCEV::FlagNSW);
+      Flags = setFlags(Flags, SCEV::FlagNSW);
   }
   if (Flags == SCEV::FlagAnyWrap)
     return SCEV::FlagAnyWrap;
@@ -15204,14 +15197,14 @@ ScalarEvolution::getComparePredicate(const ICmpInst::Predicate Pred,
   return Eq;
 }
 
-const SCEVPredicate *ScalarEvolution::getWrapPredicate(
-    const SCEVAddRecExpr *AR,
-    SCEVWrapPredicate::IncrementWrapFlags AddedFlags) {
+const SCEVPredicate *
+ScalarEvolution::getWrapPredicate(const SCEVAddRecExpr *AR,
+                                  SCEVNoWrapFlags AddedFlags) {
   FoldingSetNodeID ID;
   // Unique this node based on the arguments
   ID.AddInteger(SCEVPredicate::P_Wrap);
   ID.AddPointer(AR);
-  ID.AddInteger(AddedFlags);
+  ID.AddInteger(static_cast<int>(AddedFlags));
   void *IP = nullptr;
   if (const auto *S = UniquePreds.FindNodeOrInsertPos(ID, IP))
     return S;
@@ -15266,7 +15259,7 @@ public:
       // flag. Add the nusw flag as an assumption that we could make.
       const SCEV *Step = AR->getStepRecurrence(SE);
       Type *Ty = Expr->getType();
-      if (addOverflowAssumption(AR, SCEVWrapPredicate::IncrementNUSW))
+      if (addOverflowAssumption(AR, SCEV::FlagNUSW))
         return SE.getAddRecExpr(SE.getZeroExtendExpr(AR->getStart(), Ty),
                                 SE.getSignExtendExpr(Step, Ty), L,
                                 AR->getNoWrapFlags());
@@ -15279,10 +15272,10 @@ public:
     const SCEVAddRecExpr *AR = dyn_cast<SCEVAddRecExpr>(Operand);
     if (AR && AR->getLoop() == L && AR->isAffine()) {
       // This couldn't be folded because the operand didn't have the nsw
-      // flag. Add the nssw flag as an assumption that we could make.
+      // flag. Add the nsw flag as an assumption that we could make.
       const SCEV *Step = AR->getStepRecurrence(SE);
       Type *Ty = Expr->getType();
-      if (addOverflowAssumption(AR, SCEVWrapPredicate::IncrementNSSW))
+      if (addOverflowAssumption(AR, SCEV::FlagNSW))
         return SE.getAddRecExpr(SE.getSignExtendExpr(AR->getStart(), Ty),
                                 SE.getSignExtendExpr(Step, Ty), L,
                                 AR->getNoWrapFlags());
@@ -15307,7 +15300,7 @@ private:
   }
 
   bool addOverflowAssumption(const SCEVAddRecExpr *AR,
-                             SCEVWrapPredicate::IncrementWrapFlags AddedFlags) {
+                             SCEVNoWrapFlags AddedFlags) {
     auto *A = SE.getWrapPredicate(AR, AddedFlags);
     return addOverflowAssumption(A);
   }
@@ -15366,7 +15359,7 @@ const SCEVAddRecExpr *ScalarEvolution::convertSCEVToAddRecWithPredicates(
   // versioned loop will never execute.
   for (const SCEVPredicate *Pred : TransformPreds) {
     auto *WrapPred = dyn_cast<SCEVWrapPredicate>(Pred);
-    if (!WrapPred || WrapPred->getFlags() != SCEVWrapPredicate::IncrementNSSW)
+    if (!WrapPred || WrapPred->getFlags() != SCEV::FlagNSW)
       continue;
 
     const SCEVAddRecExpr *AddRecToCheck = WrapPred->getExpr();
@@ -15430,7 +15423,7 @@ void SCEVComparePredicate::print(raw_ostream &OS, unsigned Depth) const {
 
 SCEVWrapPredicate::SCEVWrapPredicate(const FoldingSetNodeIDRef ID,
                                      const SCEVAddRecExpr *AR,
-                                     IncrementWrapFlags Flags)
+                                     SCEVNoWrapFlags Flags)
     : SCEVPredicate(ID, P_Wrap), AR(AR), Flags(Flags) {}
 
 const SCEVAddRecExpr *SCEVWrapPredicate::getExpr() const { return AR; }
@@ -15444,8 +15437,7 @@ bool SCEVWrapPredicate::implies(const SCEVPredicate *N,
   if (Op->AR == AR)
     return true;
 
-  if (Flags != SCEVWrapPredicate::IncrementNSSW &&
-      Flags != SCEVWrapPredicate::IncrementNUSW)
+  if (Flags != SCEV::FlagNSW && Flags != SCEV::FlagNUSW)
     return false;
 
   const SCEV *Start = AR->getStart();
@@ -15457,7 +15449,7 @@ bool SCEVWrapPredicate::implies(const SCEVPredicate *N,
   if (Start->getType()->isPointerTy() && Start->getType() != OpStart->getType())
     return false;
 
-  // NUSW/NSSW on a wider-type AddRec does not imply the same on a
+  // NUSW/NSW on a wider-type AddRec does not imply the same on a
   // narrower-type AddRec.
   if (SE.getTypeSizeInBits(AR->getType()) >
       SE.getTypeSizeInBits(Op->AR->getType()))
@@ -15469,12 +15461,12 @@ bool SCEVWrapPredicate::implies(const SCEVPredicate *N,
     return false;
 
   // If both steps are positive, this implies N, if N's start and step are
-  // ULE/SLE (for NSUW/NSSW) than this'.
+  // ULE/SLE (for NSUW/NSW) than this'.
   Type *WiderTy = SE.getWiderType(Step->getType(), OpStep->getType());
   Step = SE.getNoopOrZeroExtend(Step, WiderTy);
   OpStep = SE.getNoopOrZeroExtend(OpStep, WiderTy);
 
-  bool IsNUW = Flags == SCEVWrapPredicate::IncrementNUSW;
+  bool IsNUW = Flags == SCEV::FlagNUSW;
   OpStart = IsNUW ? SE.getNoopOrZeroExtend(OpStart, WiderTy)
                   : SE.getNoopOrSignExtend(OpStart, WiderTy);
   Start = IsNUW ? SE.getNoopOrZeroExtend(Start, WiderTy)
@@ -15485,40 +15477,39 @@ bool SCEVWrapPredicate::implies(const SCEVPredicate *N,
 }
 
 bool SCEVWrapPredicate::isAlwaysTrue() const {
-  SCEV::NoWrapFlags ScevFlags = AR->getNoWrapFlags();
-  IncrementWrapFlags IFlags = Flags;
+  SCEVNoWrapFlags ScevFlags = AR->getNoWrapFlags();
+  SCEVNoWrapFlags IFlags = Flags;
 
-  if (ScalarEvolution::setFlags(ScevFlags, SCEV::FlagNSW) == ScevFlags)
-    IFlags = clearFlags(IFlags, IncrementNSSW);
+  if (setFlags(ScevFlags, SCEV::FlagNSW) == ScevFlags)
+    IFlags = clearFlags(IFlags, SCEV::FlagNSW);
 
-  return IFlags == IncrementAnyWrap;
+  return IFlags == SCEV::FlagAnyWrap;
 }
 
 void SCEVWrapPredicate::print(raw_ostream &OS, unsigned Depth) const {
   OS.indent(Depth) << *getExpr() << " Added Flags: ";
-  if (SCEVWrapPredicate::IncrementNUSW & getFlags())
+  if (any(SCEV::FlagNUSW & getFlags()))
     OS << "<nusw>";
-  if (SCEVWrapPredicate::IncrementNSSW & getFlags())
-    OS << "<nssw>";
+  if (any(SCEV::FlagNSW & getFlags()))
+    OS << "<nsw>";
   OS << "\n";
 }
 
-SCEVWrapPredicate::IncrementWrapFlags
-SCEVWrapPredicate::getImpliedFlags(const SCEVAddRecExpr *AR,
-                                   ScalarEvolution &SE) {
-  IncrementWrapFlags ImpliedFlags = IncrementAnyWrap;
-  SCEV::NoWrapFlags StaticFlags = AR->getNoWrapFlags();
+SCEVNoWrapFlags SCEVWrapPredicate::getImpliedFlags(const SCEVAddRecExpr *AR,
+                                                   ScalarEvolution &SE) {
+  SCEVNoWrapFlags ImpliedFlags = SCEV::FlagAnyWrap;
+  SCEVNoWrapFlags StaticFlags = AR->getNoWrapFlags();
 
-  // We can safely transfer the NSW flag as NSSW.
-  if (ScalarEvolution::setFlags(StaticFlags, SCEV::FlagNSW) == StaticFlags)
-    ImpliedFlags = IncrementNSSW;
+  // We can safely transfer the NSW flag.
+  if (setFlags(StaticFlags, SCEV::FlagNSW) == StaticFlags)
+    ImpliedFlags = SCEV::FlagNSW;
 
-  if (ScalarEvolution::setFlags(StaticFlags, SCEV::FlagNUW) == StaticFlags) {
+  if (setFlags(StaticFlags, SCEV::FlagNUW) == StaticFlags) {
     // If the increment is positive, the SCEV NUW flag will also imply the
     // WrapPredicate NUSW flag.
     if (const auto *Step = dyn_cast<SCEVConstant>(AR->getStepRecurrence(SE)))
       if (Step->getValue()->getValue().isNonNegative())
-        ImpliedFlags = setFlags(ImpliedFlags, IncrementNUSW);
+        ImpliedFlags = setFlags(ImpliedFlags, SCEV::FlagNUSW);
   }
 
   return ImpliedFlags;
@@ -15708,16 +15699,14 @@ void PredicatedScalarEvolution::updateGeneration() {
   }
 }
 
-bool PredicatedScalarEvolution::hasNoOverflow(
-    Value *V, SCEVWrapPredicate::IncrementWrapFlags Flags) {
+bool PredicatedScalarEvolution::hasNoOverflow(Value *V, SCEVNoWrapFlags Flags) {
   const auto *AR = dyn_cast<SCEVAddRecExpr>(getSCEV(V));
   if (!AR)
     return false;
 
-  Flags = SCEVWrapPredicate::clearFlags(
-      Flags, SCEVWrapPredicate::getImpliedFlags(AR, SE));
+  Flags = clearFlags(Flags, SCEVWrapPredicate::getImpliedFlags(AR, SE));
 
-  return Flags == SCEVWrapPredicate::IncrementAnyWrap;
+  return Flags == SCEV::FlagAnyWrap;
 }
 
 const SCEVAddRecExpr *PredicatedScalarEvolution::getAsAddRec(
@@ -16335,9 +16324,9 @@ const SCEV *ScalarEvolution::LoopGuards::rewrite(const SCEV *Expr) const {
         : SCEVRewriteVisitor(SE), Map(Guards.RewriteMap),
           NotEqual(Guards.NotEqual) {
       if (Guards.PreserveNUW)
-        FlagMask = ScalarEvolution::setFlags(FlagMask, SCEV::FlagNUW);
+        FlagMask = setFlags(FlagMask, SCEV::FlagNUW);
       if (Guards.PreserveNSW)
-        FlagMask = ScalarEvolution::setFlags(FlagMask, SCEV::FlagNSW);
+        FlagMask = setFlags(FlagMask, SCEV::FlagNSW);
     }
 
     const SCEV *visitAddRecExpr(const SCEVAddRecExpr *Expr) { return Expr; }
@@ -16420,9 +16409,8 @@ const SCEV *ScalarEvolution::LoopGuards::rewrite(const SCEV *Expr) const {
           const SCEV *Add =
               SE.getAddExpr(Expr->getOperand(1), Expr->getOperand(2));
           if (const SCEV *Rewritten = RewriteSubtraction(Add))
-            return SE.getAddExpr(
-                Expr->getOperand(0), Rewritten,
-                ScalarEvolution::maskFlags(Expr->getNoWrapFlags(), FlagMask));
+            return SE.getAddExpr(Expr->getOperand(0), Rewritten,
+                                 maskFlags(Expr->getNoWrapFlags(), FlagMask));
           if (const SCEV *S = Map.lookup(Add))
             return SE.getAddExpr(Expr->getOperand(0), S);
         }
@@ -16454,10 +16442,10 @@ const SCEV *ScalarEvolution::LoopGuards::rewrite(const SCEV *Expr) const {
       }
       // We are only replacing operands with equivalent values, so transfer the
       // flags from the original expression.
-      return !Changed ? Expr
-                      : SE.getAddExpr(Operands,
-                                      ScalarEvolution::maskFlags(
-                                          Expr->getNoWrapFlags(), FlagMask));
+      return !Changed
+                 ? Expr
+                 : SE.getAddExpr(Operands,
+                                 maskFlags(Expr->getNoWrapFlags(), FlagMask));
     }
 
     const SCEV *visitMulExpr(const SCEVMulExpr *Expr) {
@@ -16470,10 +16458,10 @@ const SCEV *ScalarEvolution::LoopGuards::rewrite(const SCEV *Expr) const {
       }
       // We are only replacing operands with equivalent values, so transfer the
       // flags from the original expression.
-      return !Changed ? Expr
-                      : SE.getMulExpr(Operands,
-                                      ScalarEvolution::maskFlags(
-                                          Expr->getNoWrapFlags(), FlagMask));
+      return !Changed
+                 ? Expr
+                 : SE.getMulExpr(Operands,
+                                 maskFlags(Expr->getNoWrapFlags(), FlagMask));
     }
   };
 

--- a/llvm/lib/Transforms/Utils/ScalarEvolutionExpander.cpp
+++ b/llvm/lib/Transforms/Utils/ScalarEvolutionExpander.cpp
@@ -690,7 +690,7 @@ Value *SCEVExpander::visitMulExpr(SCEVUseT<const SCEVMulExpr *> S) {
         auto NWFlags = S.getNoWrapFlags();
         // clear nsw flag if shl will produce poison value.
         if (RHS->logBase2() == RHS->getBitWidth() - 1)
-          NWFlags = ScalarEvolution::clearFlags(NWFlags, SCEV::FlagNSW);
+          NWFlags = clearFlags(NWFlags, SCEV::FlagNSW);
         Prod = InsertBinop(Instruction::Shl, Prod,
                            ConstantInt::get(Ty, RHS->logBase2()), NWFlags,
                            /*IsSafeToHoist*/ true);
@@ -842,10 +842,10 @@ bool SCEVExpander::hoistIVInc(Instruction *IncV, Instruction *InsertPos,
     if (auto *OBO = dyn_cast<OverflowingBinaryOperator>(I))
       if (auto Flags = SE.getStrengthenedNoWrapFlagsFromBinOp(OBO)) {
         auto *BO = cast<BinaryOperator>(I);
-        BO->setHasNoUnsignedWrap(
-            ScalarEvolution::maskFlags(*Flags, SCEV::FlagNUW) == SCEV::FlagNUW);
-        BO->setHasNoSignedWrap(
-            ScalarEvolution::maskFlags(*Flags, SCEV::FlagNSW) == SCEV::FlagNSW);
+        BO->setHasNoUnsignedWrap(maskFlags(*Flags, SCEV::FlagNUW) ==
+                                 SCEV::FlagNUW);
+        BO->setHasNoSignedWrap(maskFlags(*Flags, SCEV::FlagNSW) ==
+                               SCEV::FlagNSW);
       }
   };
 
@@ -1764,10 +1764,9 @@ void SCEVExpander::dropPoisonGeneratingAnnotationsAndReinfer(
   if (auto *OBO = dyn_cast<OverflowingBinaryOperator>(I))
     if (auto Flags = SE.getStrengthenedNoWrapFlagsFromBinOp(OBO)) {
       auto *BO = cast<BinaryOperator>(I);
-      BO->setHasNoUnsignedWrap(
-          ScalarEvolution::maskFlags(*Flags, SCEV::FlagNUW) == SCEV::FlagNUW);
-      BO->setHasNoSignedWrap(
-          ScalarEvolution::maskFlags(*Flags, SCEV::FlagNSW) == SCEV::FlagNSW);
+      BO->setHasNoUnsignedWrap(maskFlags(*Flags, SCEV::FlagNUW) ==
+                               SCEV::FlagNUW);
+      BO->setHasNoSignedWrap(maskFlags(*Flags, SCEV::FlagNSW) == SCEV::FlagNSW);
     }
   if (auto *NNI = dyn_cast<PossiblyNonNegInst>(I)) {
     auto *Src = NNI->getOperand(0);
@@ -2398,11 +2397,11 @@ Value *SCEVExpander::expandWrapPredicate(const SCEVWrapPredicate *Pred,
   Value *NSSWCheck = nullptr, *NUSWCheck = nullptr;
 
   // Add a check for NUSW
-  if (Pred->getFlags() & SCEVWrapPredicate::IncrementNUSW)
+  if (any(Pred->getFlags() & SCEV::FlagNUSW))
     NUSWCheck = generateOverflowCheck(A, IP, false);
 
   // Add a check for NSSW
-  if (Pred->getFlags() & SCEVWrapPredicate::IncrementNSSW)
+  if (any(Pred->getFlags() & SCEV::FlagNSW))
     NSSWCheck = generateOverflowCheck(A, IP, true);
 
   if (NUSWCheck && NSSWCheck)

--- a/llvm/lib/Transforms/Utils/SimplifyIndVar.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyIndVar.cpp
@@ -820,10 +820,8 @@ bool SimplifyIndvar::strengthenOverflowingOperation(BinaryOperator *BO,
   if (!Flags)
     return false;
 
-  BO->setHasNoUnsignedWrap(ScalarEvolution::maskFlags(*Flags, SCEV::FlagNUW) ==
-                           SCEV::FlagNUW);
-  BO->setHasNoSignedWrap(ScalarEvolution::maskFlags(*Flags, SCEV::FlagNSW) ==
-                         SCEV::FlagNSW);
+  BO->setHasNoUnsignedWrap(maskFlags(*Flags, SCEV::FlagNUW) == SCEV::FlagNUW);
+  BO->setHasNoSignedWrap(maskFlags(*Flags, SCEV::FlagNSW) == SCEV::FlagNSW);
 
   // The getStrengthenedNoWrapFlagsFromBinOp() check inferred additional nowrap
   // flags on addrecs while performing zero/sign extensions. We could call

--- a/llvm/test/Analysis/LoopAccessAnalysis/loop-invariant-dep-with-backedge-taken-count.ll
+++ b/llvm/test/Analysis/LoopAccessAnalysis/loop-invariant-dep-with-backedge-taken-count.ll
@@ -190,7 +190,7 @@ define void @test_btc_is_unknown_value(ptr %a, i32 %N) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Non vectorizable stores to invariant address were not found in loop.
 ; CHECK-NEXT:      SCEV assumptions:
-; CHECK-NEXT:      {0,+,1}<nuw><%loop> Added Flags: <nssw>
+; CHECK-NEXT:      {0,+,1}<nuw><%loop> Added Flags: <nsw>
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Expressions re-written:
 ; CHECK-NEXT:      [PSE] %gep = getelementptr i32, ptr %a, i32 %iv:

--- a/llvm/test/Analysis/LoopAccessAnalysis/nssw-predicate-implied.ll
+++ b/llvm/test/Analysis/LoopAccessAnalysis/nssw-predicate-implied.ll
@@ -25,7 +25,7 @@ define void @wrap_check_iv.3_implies_iv.2(i32 noundef %N, ptr %dst, ptr %src) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Non vectorizable stores to invariant address were not found in loop.
 ; CHECK-NEXT:      SCEV assumptions:
-; CHECK-NEXT:      {0,+,3}<%loop> Added Flags: <nssw>
+; CHECK-NEXT:      {0,+,3}<%loop> Added Flags: <nsw>
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Expressions re-written:
 ; CHECK-NEXT:      [PSE] %gep.iv.2 = getelementptr inbounds i32, ptr %src, i64 %ext.iv.2:
@@ -80,7 +80,7 @@ define void @wrap_check_iv.3_implies_iv.2_different_start(i32 noundef %N, ptr %d
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Non vectorizable stores to invariant address were not found in loop.
 ; CHECK-NEXT:      SCEV assumptions:
-; CHECK-NEXT:      {2,+,2}<%loop> Added Flags: <nssw>
+; CHECK-NEXT:      {2,+,2}<%loop> Added Flags: <nsw>
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Expressions re-written:
 ; CHECK-NEXT:      [PSE] %gep.iv.2 = getelementptr inbounds i32, ptr %src, i64 %ext.iv.2:
@@ -135,7 +135,7 @@ define void @wrap_check_iv.3_implies_iv.2_predicates_added_in_different_order(i3
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Non vectorizable stores to invariant address were not found in loop.
 ; CHECK-NEXT:      SCEV assumptions:
-; CHECK-NEXT:      {0,+,3}<%loop> Added Flags: <nssw>
+; CHECK-NEXT:      {0,+,3}<%loop> Added Flags: <nsw>
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Expressions re-written:
 ; CHECK-NEXT:      [PSE] %gep.iv.3 = getelementptr inbounds i32, ptr %src, i64 %ext.iv.3:
@@ -189,8 +189,8 @@ define void @wrap_check_iv.3_does_not_implies_iv.2_due_to_start(i32 noundef %N, 
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Non vectorizable stores to invariant address were not found in loop.
 ; CHECK-NEXT:      SCEV assumptions:
-; CHECK-NEXT:      {0,+,3}<%loop> Added Flags: <nssw>
-; CHECK-NEXT:      {10,+,2}<%loop> Added Flags: <nssw>
+; CHECK-NEXT:      {0,+,3}<%loop> Added Flags: <nsw>
+; CHECK-NEXT:      {10,+,2}<%loop> Added Flags: <nsw>
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Expressions re-written:
 ; CHECK-NEXT:      [PSE] %gep.iv.2 = getelementptr inbounds i32, ptr %src, i64 %ext.iv.2:
@@ -244,8 +244,8 @@ define void @wrap_check_iv.3_does_not_imply_iv.2_due_to_start_negative(i32 nound
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Non vectorizable stores to invariant address were not found in loop.
 ; CHECK-NEXT:      SCEV assumptions:
-; CHECK-NEXT:      {-1,+,3}<%loop> Added Flags: <nssw>
-; CHECK-NEXT:      {0,+,2}<%loop> Added Flags: <nssw>
+; CHECK-NEXT:      {-1,+,3}<%loop> Added Flags: <nsw>
+; CHECK-NEXT:      {0,+,2}<%loop> Added Flags: <nsw>
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Expressions re-written:
 ; CHECK-NEXT:      [PSE] %gep.iv.2 = getelementptr inbounds i32, ptr %src, i64 %ext.iv.2:
@@ -299,8 +299,8 @@ define void @wrap_check_iv.3_does_not_imply_iv.2_due_to_negative_step(i32 nounde
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Non vectorizable stores to invariant address were not found in loop.
 ; CHECK-NEXT:      SCEV assumptions:
-; CHECK-NEXT:      {0,+,-1}<%loop> Added Flags: <nssw>
-; CHECK-NEXT:      {0,+,2}<%loop> Added Flags: <nssw>
+; CHECK-NEXT:      {0,+,-1}<%loop> Added Flags: <nsw>
+; CHECK-NEXT:      {0,+,2}<%loop> Added Flags: <nsw>
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Expressions re-written:
 ; CHECK-NEXT:      [PSE] %gep.iv.2 = getelementptr inbounds i32, ptr %src, i64 %ext.iv.2:
@@ -357,8 +357,8 @@ define void @wider_i32_nssw_does_not_imply_narrower_i8_nssw(ptr %dst, ptr %src, 
 ; CHECK-NEXT:      Non vectorizable stores to invariant address were not found in loop.
 ; CHECK-NEXT:      SCEV assumptions:
 ; CHECK-NEXT:      Equal predicate: (zext i1 (trunc i32 %N to i1) to i32) == 0
-; CHECK-NEXT:      {0,+,2}<%loop> Added Flags: <nssw>
-; CHECK-NEXT:      {0,+,1}<%loop> Added Flags: <nssw>
+; CHECK-NEXT:      {0,+,2}<%loop> Added Flags: <nsw>
+; CHECK-NEXT:      {0,+,1}<%loop> Added Flags: <nsw>
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Expressions re-written:
 ; CHECK-NEXT:      [PSE] %gep.dst = getelementptr inbounds i32, ptr %dst, i64 %ext.iv.1:
@@ -411,7 +411,7 @@ define void @narrower_i8_nssw_implies_wider_i32_nssw(ptr %dst, ptr %src, i32 %N)
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Non vectorizable stores to invariant address were not found in loop.
 ; CHECK-NEXT:      SCEV assumptions:
-; CHECK-NEXT:      {0,+,2}<%loop> Added Flags: <nssw>
+; CHECK-NEXT:      {0,+,2}<%loop> Added Flags: <nsw>
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Expressions re-written:
 ; CHECK-NEXT:      [PSE] %gep.dst = getelementptr inbounds i32, ptr %dst, i64 %ext.iv.1:

--- a/llvm/test/Analysis/LoopAccessAnalysis/symbolic-stride.ll
+++ b/llvm/test/Analysis/LoopAccessAnalysis/symbolic-stride.ll
@@ -475,7 +475,7 @@ define void @unknown_stride_equalto_tc(i32 %N, ptr %A, ptr %B, i32 %j)  {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Non vectorizable stores to invariant address were not found in loop.
 ; CHECK-NEXT:      SCEV assumptions:
-; CHECK-NEXT:      {%j,+,%N}<%loop> Added Flags: <nssw>
+; CHECK-NEXT:      {%j,+,%N}<%loop> Added Flags: <nsw>
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Expressions re-written:
 ; CHECK-NEXT:      [PSE] %arrayidx = getelementptr inbounds i16, ptr %B, i32 %add:
@@ -526,7 +526,7 @@ define void @unknown_stride_equalto_zext_tc(i16 zeroext %N, ptr %A, ptr %B, i32 
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Non vectorizable stores to invariant address were not found in loop.
 ; CHECK-NEXT:      SCEV assumptions:
-; CHECK-NEXT:      {%j,+,(zext i16 %N to i32)}<nw><%loop> Added Flags: <nssw>
+; CHECK-NEXT:      {%j,+,(zext i16 %N to i32)}<nw><%loop> Added Flags: <nsw>
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Expressions re-written:
 ; CHECK-NEXT:      [PSE] %arrayidx = getelementptr inbounds i16, ptr %B, i32 %add:
@@ -577,7 +577,7 @@ define void @unknown_stride_equalto_sext_tc(i16 %N, ptr %A, ptr %B, i32 %j) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Non vectorizable stores to invariant address were not found in loop.
 ; CHECK-NEXT:      SCEV assumptions:
-; CHECK-NEXT:      {%j,+,(sext i16 %N to i32)}<nw><%loop> Added Flags: <nssw>
+; CHECK-NEXT:      {%j,+,(sext i16 %N to i32)}<nw><%loop> Added Flags: <nsw>
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Expressions re-written:
 ; CHECK-NEXT:      [PSE] %arrayidx = getelementptr inbounds i16, ptr %B, i32 %add:
@@ -628,7 +628,7 @@ define void @unknown_stride_equalto_trunc_tc(i64 %N, ptr %A, ptr %B, i32 %j) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Non vectorizable stores to invariant address were not found in loop.
 ; CHECK-NEXT:      SCEV assumptions:
-; CHECK-NEXT:      {%j,+,(trunc i64 %N to i32)}<nw><%loop> Added Flags: <nssw>
+; CHECK-NEXT:      {%j,+,(trunc i64 %N to i32)}<nw><%loop> Added Flags: <nsw>
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Expressions re-written:
 ; CHECK-NEXT:      [PSE] %arrayidx = getelementptr inbounds i16, ptr %B, i32 %add:

--- a/llvm/test/Analysis/LoopAccessAnalysis/wrapping-pointer-versioning.ll
+++ b/llvm/test/Analysis/LoopAccessAnalysis/wrapping-pointer-versioning.ll
@@ -175,7 +175,7 @@ define void @f3(ptr noalias %a, ptr noalias %b, i64 %N) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Non vectorizable stores to invariant address were not found in loop.
 ; CHECK-NEXT:      SCEV assumptions:
-; CHECK-NEXT:      {0,+,2}<%for.body> Added Flags: <nssw>
+; CHECK-NEXT:      {0,+,2}<%for.body> Added Flags: <nsw>
 ; CHECK-NEXT:      {%a,+,4}<%for.body> Added Flags: <nusw>
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Expressions re-written:
@@ -232,7 +232,7 @@ define void @f4(ptr noalias %a, ptr noalias %b, i64 %N) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Non vectorizable stores to invariant address were not found in loop.
 ; CHECK-NEXT:      SCEV assumptions:
-; CHECK-NEXT:      {(2 * (trunc i64 %N to i32)),+,-2}<%for.body> Added Flags: <nssw>
+; CHECK-NEXT:      {(2 * (trunc i64 %N to i32)),+,-2}<%for.body> Added Flags: <nsw>
 ; CHECK-NEXT:      {((2 * (sext i32 (2 * (trunc i64 %N to i32)) to i64))<nsw> + %a),+,-4}<%for.body> Added Flags: <nusw>
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Expressions re-written:
@@ -292,7 +292,7 @@ define void @f5(ptr noalias %a, ptr noalias %b, i64 %N) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Non vectorizable stores to invariant address were not found in loop.
 ; CHECK-NEXT:      SCEV assumptions:
-; CHECK-NEXT:      {(2 * (trunc i64 %N to i32)),+,-2}<%for.body> Added Flags: <nssw>
+; CHECK-NEXT:      {(2 * (trunc i64 %N to i32)),+,-2}<%for.body> Added Flags: <nsw>
 ; CHECK-EMPTY:
 ; CHECK-NEXT:      Expressions re-written:
 ; CHECK-NEXT:      [PSE] %arrayidxA = getelementptr inbounds i16, ptr %a, i32 %mul:

--- a/llvm/test/Analysis/ScalarEvolution/finite-trip-count.ll
+++ b/llvm/test/Analysis/ScalarEvolution/finite-trip-count.ll
@@ -58,13 +58,13 @@ define void @sle_pre_inc_infinite(i32 %len) {
 ; CHECK-NEXT:  Loop %for.body: Unpredictable symbolic max backedge-taken count.
 ; CHECK-NEXT:  Loop %for.body: Predicated backedge-taken count is (0 smax (1 + (sext i32 %len to i64))<nsw>)
 ; CHECK-NEXT:   Predicates:
-; CHECK-NEXT:      {0,+,1}<%for.body> Added Flags: <nssw>
+; CHECK-NEXT:      {0,+,1}<%for.body> Added Flags: <nsw>
 ; CHECK-NEXT:  Loop %for.body: Predicated constant max backedge-taken count is i64 2147483648
 ; CHECK-NEXT:   Predicates:
-; CHECK-NEXT:      {0,+,1}<%for.body> Added Flags: <nssw>
+; CHECK-NEXT:      {0,+,1}<%for.body> Added Flags: <nsw>
 ; CHECK-NEXT:  Loop %for.body: Predicated symbolic max backedge-taken count is (0 smax (1 + (sext i32 %len to i64))<nsw>)
 ; CHECK-NEXT:   Predicates:
-; CHECK-NEXT:      {0,+,1}<%for.body> Added Flags: <nssw>
+; CHECK-NEXT:      {0,+,1}<%for.body> Added Flags: <nsw>
 ;
 entry:
   br label %for.body

--- a/llvm/test/Analysis/ScalarEvolution/ne-overflow.ll
+++ b/llvm/test/Analysis/ScalarEvolution/ne-overflow.ll
@@ -319,15 +319,15 @@ define void @test_sext(i64 %N) mustprogress {
 ; CHECK-NEXT:  Loop %for.body: Unpredictable symbolic max backedge-taken count.
 ; CHECK-NEXT:  Loop %for.body: Predicated backedge-taken count is (%N /u 2)
 ; CHECK-NEXT:   Predicates:
-; CHECK-NEXT:      {0,+,2}<%for.body> Added Flags: <nssw>
+; CHECK-NEXT:      {0,+,2}<%for.body> Added Flags: <nsw>
 ; CHECK-NEXT:      Equal predicate: (zext i1 (trunc i64 %N to i1) to i64) == 0
 ; CHECK-NEXT:  Loop %for.body: Predicated constant max backedge-taken count is i64 9223372036854775807
 ; CHECK-NEXT:   Predicates:
-; CHECK-NEXT:      {0,+,2}<%for.body> Added Flags: <nssw>
+; CHECK-NEXT:      {0,+,2}<%for.body> Added Flags: <nsw>
 ; CHECK-NEXT:      Equal predicate: (zext i1 (trunc i64 %N to i1) to i64) == 0
 ; CHECK-NEXT:  Loop %for.body: Predicated symbolic max backedge-taken count is (%N /u 2)
 ; CHECK-NEXT:   Predicates:
-; CHECK-NEXT:      {0,+,2}<%for.body> Added Flags: <nssw>
+; CHECK-NEXT:      {0,+,2}<%for.body> Added Flags: <nsw>
 ; CHECK-NEXT:      Equal predicate: (zext i1 (trunc i64 %N to i1) to i64) == 0
 ;
 entry:
@@ -352,17 +352,17 @@ define void @test_zext_of_sext(i64 %N) mustprogress {
 ; CHECK-NEXT:  Loop %for.body: Unpredictable symbolic max backedge-taken count.
 ; CHECK-NEXT:  Loop %for.body: Predicated backedge-taken count is (%N /u 2)
 ; CHECK-NEXT:   Predicates:
-; CHECK-NEXT:      {0,+,2}<%for.body> Added Flags: <nssw>
+; CHECK-NEXT:      {0,+,2}<%for.body> Added Flags: <nsw>
 ; CHECK-NEXT:      {0,+,2}<%for.body> Added Flags: <nusw>
 ; CHECK-NEXT:      Equal predicate: (zext i1 (trunc i64 %N to i1) to i64) == 0
 ; CHECK-NEXT:  Loop %for.body: Predicated constant max backedge-taken count is i64 9223372036854775807
 ; CHECK-NEXT:   Predicates:
-; CHECK-NEXT:      {0,+,2}<%for.body> Added Flags: <nssw>
+; CHECK-NEXT:      {0,+,2}<%for.body> Added Flags: <nsw>
 ; CHECK-NEXT:      {0,+,2}<%for.body> Added Flags: <nusw>
 ; CHECK-NEXT:      Equal predicate: (zext i1 (trunc i64 %N to i1) to i64) == 0
 ; CHECK-NEXT:  Loop %for.body: Predicated symbolic max backedge-taken count is (%N /u 2)
 ; CHECK-NEXT:   Predicates:
-; CHECK-NEXT:      {0,+,2}<%for.body> Added Flags: <nssw>
+; CHECK-NEXT:      {0,+,2}<%for.body> Added Flags: <nsw>
 ; CHECK-NEXT:      {0,+,2}<%for.body> Added Flags: <nusw>
 ; CHECK-NEXT:      Equal predicate: (zext i1 (trunc i64 %N to i1) to i64) == 0
 ;
@@ -423,15 +423,15 @@ define void @test_sext_offset(i64 %N) mustprogress {
 ; CHECK-NEXT:  Loop %for.body: Unpredictable symbolic max backedge-taken count.
 ; CHECK-NEXT:  Loop %for.body: Predicated backedge-taken count is ((-21 + %N) /u 2)
 ; CHECK-NEXT:   Predicates:
-; CHECK-NEXT:      {0,+,2}<%for.body> Added Flags: <nssw>
+; CHECK-NEXT:      {0,+,2}<%for.body> Added Flags: <nsw>
 ; CHECK-NEXT:      Equal predicate: (zext i1 (true + (trunc i64 %N to i1)) to i64) == 0
 ; CHECK-NEXT:  Loop %for.body: Predicated constant max backedge-taken count is i64 9223372036854775807
 ; CHECK-NEXT:   Predicates:
-; CHECK-NEXT:      {0,+,2}<%for.body> Added Flags: <nssw>
+; CHECK-NEXT:      {0,+,2}<%for.body> Added Flags: <nsw>
 ; CHECK-NEXT:      Equal predicate: (zext i1 (true + (trunc i64 %N to i1)) to i64) == 0
 ; CHECK-NEXT:  Loop %for.body: Predicated symbolic max backedge-taken count is ((-21 + %N) /u 2)
 ; CHECK-NEXT:   Predicates:
-; CHECK-NEXT:      {0,+,2}<%for.body> Added Flags: <nssw>
+; CHECK-NEXT:      {0,+,2}<%for.body> Added Flags: <nsw>
 ; CHECK-NEXT:      Equal predicate: (zext i1 (true + (trunc i64 %N to i1)) to i64) == 0
 ;
 entry:

--- a/llvm/test/Analysis/ScalarEvolution/pr117133.ll
+++ b/llvm/test/Analysis/ScalarEvolution/pr117133.ll
@@ -72,13 +72,13 @@ define i64 @test_poisonous(i64 %a, i32 %n) {
 ; CHECK-NEXT:  Loop %loop.body: Unpredictable symbolic max backedge-taken count.
 ; CHECK-NEXT:  Loop %loop.body: Predicated backedge-taken count is (-1 + (1 smax (1 + (sext i32 %n to i64))<nsw>))<nsw>
 ; CHECK-NEXT:   Predicates:
-; CHECK-NEXT:      {1,+,1}<%loop.body> Added Flags: <nssw>
+; CHECK-NEXT:      {1,+,1}<%loop.body> Added Flags: <nsw>
 ; CHECK-NEXT:  Loop %loop.body: Predicated constant max backedge-taken count is i64 2147483647
 ; CHECK-NEXT:   Predicates:
-; CHECK-NEXT:      {1,+,1}<%loop.body> Added Flags: <nssw>
+; CHECK-NEXT:      {1,+,1}<%loop.body> Added Flags: <nsw>
 ; CHECK-NEXT:  Loop %loop.body: Predicated symbolic max backedge-taken count is (-1 + (1 smax (1 + (sext i32 %n to i64))<nsw>))<nsw>
 ; CHECK-NEXT:   Predicates:
-; CHECK-NEXT:      {1,+,1}<%loop.body> Added Flags: <nssw>
+; CHECK-NEXT:      {1,+,1}<%loop.body> Added Flags: <nsw>
 ;
 entry:
   br label %loop.body

--- a/llvm/test/Analysis/ScalarEvolution/predicated-trip-count.ll
+++ b/llvm/test/Analysis/ScalarEvolution/predicated-trip-count.ll
@@ -35,7 +35,13 @@ define void @test1(i32 %N, i32 %M) {
 ; CHECK-NEXT:  Loop %bb3: Unpredictable symbolic max backedge-taken count.
 ; CHECK-NEXT:  Loop %bb3: Predicated backedge-taken count is (1 + (-1 smax %M))
 ; CHECK-NEXT:   Predicates:
-; CHECK-NEXT:      {0,+,1}<%bb3> Added Flags: <nssw>
+; CHECK-NEXT:      {0,+,1}<%bb3> Added Flags: <nsw>
+; CHECK-NEXT:  Loop %bb3: Predicated constant max backedge-taken count is i32 -2147483648
+; CHECK-NEXT:   Predicates:
+; CHECK-NEXT:      {0,+,1}<%bb3> Added Flags: <nsw>
+; CHECK-NEXT:  Loop %bb3: Predicated symbolic max backedge-taken count is (1 + (-1 smax %M))
+; CHECK-NEXT:   Predicates:
+; CHECK-NEXT:      {0,+,1}<%bb3> Added Flags: <nsw>
 ;
 entry:
   br label %bb3
@@ -102,7 +108,13 @@ define void @test2(i32 %N, i32 %M, i16 %Start) {
 ; CHECK-NEXT:  Loop %bb3: Unpredictable symbolic max backedge-taken count.
 ; CHECK-NEXT:  Loop %bb3: Predicated backedge-taken count is (1 + (sext i16 %Start to i32) + (-1 * ((1 + (sext i16 %Start to i32))<nsw> smin %M)))
 ; CHECK-NEXT:   Predicates:
-; CHECK-NEXT:      {%Start,+,-1}<%bb3> Added Flags: <nssw>
+; CHECK-NEXT:      {%Start,+,-1}<%bb3> Added Flags: <nsw>
+; CHECK-NEXT:  Loop %bb3: Predicated constant max backedge-taken count is i32 -2147450880
+; CHECK-NEXT:   Predicates:
+; CHECK-NEXT:      {%Start,+,-1}<%bb3> Added Flags: <nsw>
+; CHECK-NEXT:  Loop %bb3: Predicated symbolic max backedge-taken count is (1 + (sext i16 %Start to i32) + (-1 * ((1 + (sext i16 %Start to i32))<nsw> smin %M)))
+; CHECK-NEXT:   Predicates:
+; CHECK-NEXT:      {%Start,+,-1}<%bb3> Added Flags: <nsw>
 ;
 entry:
   br label %bb3

--- a/llvm/test/Analysis/ScalarEvolution/trip-count-implied-addrec.ll
+++ b/llvm/test/Analysis/ScalarEvolution/trip-count-implied-addrec.ll
@@ -60,13 +60,13 @@ define void @nw_implies_nsw(i16 %n) mustprogress {
 ; CHECK-NEXT:  Loop %for.body: Unpredictable symbolic max backedge-taken count.
 ; CHECK-NEXT:  Loop %for.body: Predicated backedge-taken count is (128 + (-128 smax %n))
 ; CHECK-NEXT:   Predicates:
-; CHECK-NEXT:      {-128,+,1}<%for.body> Added Flags: <nssw>
+; CHECK-NEXT:      {-128,+,1}<%for.body> Added Flags: <nsw>
 ; CHECK-NEXT:  Loop %for.body: Predicated constant max backedge-taken count is i16 -32641
 ; CHECK-NEXT:   Predicates:
-; CHECK-NEXT:      {-128,+,1}<%for.body> Added Flags: <nssw>
+; CHECK-NEXT:      {-128,+,1}<%for.body> Added Flags: <nsw>
 ; CHECK-NEXT:  Loop %for.body: Predicated symbolic max backedge-taken count is (128 + (-128 smax %n))
 ; CHECK-NEXT:   Predicates:
-; CHECK-NEXT:      {-128,+,1}<%for.body> Added Flags: <nssw>
+; CHECK-NEXT:      {-128,+,1}<%for.body> Added Flags: <nsw>
 ;
 entry:
   br label %for.body

--- a/llvm/unittests/Analysis/ScalarEvolutionTest.cpp
+++ b/llvm/unittests/Analysis/ScalarEvolutionTest.cpp
@@ -442,17 +442,15 @@ TEST_F(ScalarEvolutionsTest, SCEVAddExpr) {
   EXPECT_EQ(AddWithNSW_NUW->getNumOperands(), 3u);
   EXPECT_EQ(AddWithNSW_NUW->getNoWrapFlags(), SCEV::FlagAnyWrap);
 
-  const SCEV *AddWithNSWNUW =
-      SE.getAddExpr(SE.getSCEV(A2), SE.getSCEV(A4),
-                    ScalarEvolution::setFlags(SCEV::FlagNUW, SCEV::FlagNSW));
+  const SCEV *AddWithNSWNUW = SE.getAddExpr(
+      SE.getSCEV(A2), SE.getSCEV(A4), setFlags(SCEV::FlagNUW, SCEV::FlagNSW));
   auto *AddWithNSWNUW_NUW = cast<SCEVAddExpr>(
       SE.getAddExpr(AddWithNSWNUW, SE.getSCEV(A5), SCEV::FlagNUW));
   EXPECT_EQ(AddWithNSWNUW_NUW->getNumOperands(), 3u);
   EXPECT_EQ(AddWithNSWNUW_NUW->getNoWrapFlags(), SCEV::FlagNUW);
 
-  auto *AddWithNSW_NSWNUW = cast<SCEVAddExpr>(
-      SE.getAddExpr(AddWithNSW, SE.getSCEV(A6),
-                    ScalarEvolution::setFlags(SCEV::FlagNUW, SCEV::FlagNSW)));
+  auto *AddWithNSW_NSWNUW = cast<SCEVAddExpr>(SE.getAddExpr(
+      AddWithNSW, SE.getSCEV(A6), setFlags(SCEV::FlagNUW, SCEV::FlagNSW)));
   EXPECT_EQ(AddWithNSW_NSWNUW->getNumOperands(), 3u);
   EXPECT_EQ(AddWithNSW_NSWNUW->getNoWrapFlags(), SCEV::FlagAnyWrap);
 }


### PR DESCRIPTION
Eliminate IncrementWrapFlags, which is a poor copy of SCEV::NoWrapFlags where we eliminate NSSW = NSW, and add NUSW to the new structure, as it has different semantics. This initial patch has been kept simple, but has a clear rationale: all flags in the new SCEV::NoWrapFlags can be used in SCEVWrapPredicates. The next step is to eliminate the unclear SCEVWrapPredicates::getImpliedFlags and PSE::hasNoOverflow, both of whom have the sole LoopAccessAnalysis user.