### PR TITLE
[lldb-dap] Increase the evaluate timeout.

### DIFF
--- a/lldb/tools/lldb-dap/Handler/EvaluateRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/EvaluateRequestHandler.cpp
@@ -15,6 +15,8 @@
 #include "Protocol/ProtocolRequests.h"
 #include "Protocol/ProtocolTypes.h"
 #include "RequestHandler.h"
+#include "lldb/API/SBExpressionOptions.h"
+#include "lldb/API/SBLanguageRuntime.h"
 #include "lldb/lldb-enumerations.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
@@ -23,7 +25,26 @@ using namespace llvm;
 using namespace lldb_dap;
 using namespace lldb_dap::protocol;
 
-namespace lldb_dap {
+static lldb::LanguageType GetLanguage(lldb::SBDebugger &debugger) {
+  const lldb::SBStructuredData string_result =
+      debugger.GetSetting("target.language");
+
+  return lldb::SBLanguageRuntime::GetLanguageTypeFromString(
+      GetStringValue(string_result).c_str());
+}
+
+static lldb::DynamicValueType
+GetPreferDynamicValue(lldb::SBDebugger &debugger) {
+  const lldb::SBStructuredData string_result =
+      debugger.GetSetting("target.prefer-dynamic-value");
+
+  return llvm::StringSwitch<lldb::DynamicValueType>(
+             GetStringValue(string_result))
+      .Case("no-dynamic-values", lldb::eNoDynamicValues)
+      .Case("run-target", lldb::eDynamicCanRunTarget)
+      .Case("no-run-target", lldb::eDynamicDontRunTarget)
+      .Default(lldb::eDynamicDontRunTarget);
+}
 
 static bool RunExpressionAsLLDBCommand(DAP &dap, lldb::SBFrame &frame,
                                        std::string &expression,
@@ -50,24 +71,39 @@ static lldb::SBValue EvaluateVariableExpression(lldb::SBTarget &target,
                                                 bool run_as_expression) {
   const char *expression_cstr = expression.c_str();
 
-  lldb::SBValue value;
+  // First, try resolving as a variable path (e.g. 'foo->bar' finds 'bar'). This
+  // is more reliable than the expression parser in many cases and is faster.
   if (frame) {
-    // Check if it is a variable or an expression path for a variable. i.e.
-    // 'foo->bar' finds the 'bar' variable. It is more reliable than the
-    // expression parser in many cases and it is faster.
-    value = frame.GetValueForVariablePath(
+    const lldb::SBValue value = frame.GetValueForVariablePath(
         expression_cstr, lldb::eDynamicDontRunTarget, lldb::eDILModeLegacy);
-    if (value || !run_as_expression)
+    if (value)
       return value;
-
-    return frame.EvaluateExpression(expression_cstr);
   }
 
-  if (run_as_expression)
-    value = target.EvaluateExpression(expression_cstr);
+  if (!run_as_expression)
+    return lldb::SBValue{};
 
-  return value;
+  // Fall back to full expression evaluation.
+  lldb::SBDebugger debugger = target.GetDebugger();
+  lldb::SBExpressionOptions options;
+  options.SetUnwindOnError(true);
+  options.SetIgnoreBreakpoints(true);
+  options.SetFetchDynamicValue(GetPreferDynamicValue(debugger));
+  constexpr auto evaluate_timeout_us = lldb_dap::k_evaluate_timeout_ms * 1000;
+  options.SetTimeoutInMicroSeconds(evaluate_timeout_us);
+
+  if (frame) {
+    lldb::LanguageType eval_language = GetLanguage(debugger);
+    if (eval_language == lldb::eLanguageTypeUnknown)
+      eval_language = frame.GuessLanguage();
+    options.SetLanguage(eval_language);
+
+    return frame.EvaluateExpression(expression_cstr, options);
+  }
+  return target.EvaluateExpression(expression_cstr, options);
 }
+
+namespace lldb_dap {
 
 /// Evaluates the given expression in the context of a stack frame.
 ///

--- a/lldb/tools/lldb-dap/JSONUtils.cpp
+++ b/lldb/tools/lldb-dap/JSONUtils.cpp
@@ -124,7 +124,8 @@ TryCreateAutoSummaryForContainer(lldb::SBValue &v) {
     return std::nullopt;
   /// As this operation can be potentially slow, we limit the total time spent
   /// fetching children to a few ms.
-  const auto max_evaluation_time = std::chrono::milliseconds(10);
+  constexpr auto max_evaluation_time =
+      std::chrono::milliseconds(lldb_dap::k_evaluate_timeout_ms / 10);
   /// We don't want to generate a extremely long summary string, so we limit its
   /// length.
   const size_t max_length = 32;

--- a/lldb/tools/lldb-dap/LLDBUtils.h
+++ b/lldb/tools/lldb-dap/LLDBUtils.h
@@ -27,6 +27,11 @@
 #include <string>
 
 namespace lldb_dap {
+#ifdef LLDB_CONFIGURATION_DEBUG
+inline constexpr uint32_t k_evaluate_timeout_ms = 500 * 10;
+#else
+inline constexpr uint32_t k_evaluate_timeout_ms = 500;
+#endif // LLDB_CONFIGURATION_DEBUG
 
 /// Run a list of LLDB commands in the LLDB command interpreter.
 ///


### PR DESCRIPTION
Fix the flakiness in the DAP_evaluate test.
Depending on how fast the machine is the auto summary test will fail because the summary for all the children is not generated. 

Match the existing evaluate defaults and Increase the timeout.
Auto summary timeout.
Release: 10ms -> 50ms
Debug:   10ms -> 500ms

Evaluate timeout.
Release: 500ms -> 500ms
Debug:   500ms -> 5000ms