### PR TITLE
[DAGCombine][AArch64][X86] Adjust profitability check on and(anyext, c) -> zext(and) transform

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -3280,6 +3280,12 @@ public:
     return isZExtFree(Val.getValueType(), VT2);
   }
 
+  /// Return true is an anyext is free from FromTy to ToTy. Usually true for
+  /// scalar types when not trying to pack elements into vector lanes.
+  virtual bool isAnyExtFree(EVT FromTy, EVT ToTy) const {
+    return !FromTy.isVector();
+  }
+
   /// Return true if sign-extension from FromTy to ToTy is cheaper than
   /// zero-extension.
   virtual bool isSExtCheaperThanZExt(EVT FromTy, EVT ToTy) const {

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -7917,9 +7917,10 @@ SDValue DAGCombiner::visitAND(SDNode *N) {
     if (DAG.MaskedValueIsZero(N0Op0, Mask))
       return DAG.getNode(ISD::ZERO_EXTEND, DL, VT, N0Op0);
 
-    // fold (and (any_ext V), c) -> (zero_ext (and V, c)) if profitable.
+    // fold (and (any_ext V), c) -> (zero_ext (and V, c)) if profitable, when
+    // the zext is free or the anyext costs the same as the zext.
     if (N1C->getAPIntValue().countLeadingZeros() >= (BitWidth - SrcBitWidth) &&
-        (TLI.isZExtFree(SrcVT, VT) || VT.isVector()) &&
+        (TLI.isZExtFree(SrcVT, VT) || !TLI.isAnyExtFree(SrcVT, VT)) &&
         TLI.isTypeDesirableForOp(ISD::AND, SrcVT) &&
         TLI.isNarrowingProfitable(N, VT, SrcVT))
       return DAG.getNode(ISD::ZERO_EXTEND, DL, VT,

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -7917,9 +7917,9 @@ SDValue DAGCombiner::visitAND(SDNode *N) {
     if (DAG.MaskedValueIsZero(N0Op0, Mask))
       return DAG.getNode(ISD::ZERO_EXTEND, DL, VT, N0Op0);
 
-    // fold (and (any_ext V), c) -> (zero_ext (and (trunc V), c)) if profitable.
+    // fold (and (any_ext V), c) -> (zero_ext (and V, c)) if profitable.
     if (N1C->getAPIntValue().countLeadingZeros() >= (BitWidth - SrcBitWidth) &&
-        TLI.isTruncateFree(VT, SrcVT) && TLI.isZExtFree(SrcVT, VT) &&
+        (TLI.isZExtFree(SrcVT, VT) || VT.isVector()) &&
         TLI.isTypeDesirableForOp(ISD::AND, SrcVT) &&
         TLI.isNarrowingProfitable(N, VT, SrcVT))
       return DAG.getNode(ISD::ZERO_EXTEND, DL, VT,

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -20286,6 +20286,11 @@ ArrayRef<MCPhysReg> AArch64TargetLowering::getRoundingControlRegisters() const {
   return RCRegs;
 }
 
+bool AArch64TargetLowering::isNarrowingProfitable(SDNode *N, EVT SrcVT,
+                                                  EVT DestVT) const {
+  return isTypeLegal(DestVT) && DestVT.isVector();
+}
+
 bool
 AArch64TargetLowering::isDesirableToCommuteWithShift(const SDNode *N,
                                                      CombineLevel Level) const {

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.h
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.h
@@ -296,6 +296,8 @@ public:
   const MCPhysReg *getScratchRegisters(CallingConv::ID CC) const override;
   ArrayRef<MCPhysReg> getRoundingControlRegisters() const override;
 
+  bool isNarrowingProfitable(SDNode *N, EVT SrcVT, EVT DestVT) const override;
+
   /// Returns false if N is a bit extraction pattern of (X >> C) & Mask.
   bool isDesirableToCommuteWithShift(const SDNode *N,
                                      CombineLevel Level) const override;

--- a/llvm/test/CodeGen/AArch64/aarch64-matrix-umull-smull.ll
+++ b/llvm/test/CodeGen/AArch64/aarch64-matrix-umull-smull.ll
@@ -824,7 +824,7 @@ define i64 @red_mla_dup_ext_u8_s8_s64(ptr noalias noundef readonly captures(none
 ; CHECK-SD-NEXT:  .LBB6_10: // %vec.epilog.ph
 ; CHECK-SD-NEXT:    mov w11, w1
 ; CHECK-SD-NEXT:    movi v0.2d, #0000000000000000
-; CHECK-SD-NEXT:    movi v3.2d, #0x000000000000ff
+; CHECK-SD-NEXT:    movi d3, #0x0000ff000000ff
 ; CHECK-SD-NEXT:    sxtb x11, w11
 ; CHECK-SD-NEXT:    fmov d2, x8
 ; CHECK-SD-NEXT:    dup v1.2s, w11
@@ -838,14 +838,11 @@ define i64 @red_mla_dup_ext_u8_s8_s64(ptr noalias noundef readonly captures(none
 ; CHECK-SD-NEXT:    adds x8, x8, #4
 ; CHECK-SD-NEXT:    ushll v4.8h, v4.8b, #0
 ; CHECK-SD-NEXT:    ushll v4.4s, v4.4h, #0
-; CHECK-SD-NEXT:    ushll v5.2d, v4.2s, #0
-; CHECK-SD-NEXT:    ushll2 v4.2d, v4.4s, #0
-; CHECK-SD-NEXT:    and v5.16b, v5.16b, v3.16b
-; CHECK-SD-NEXT:    and v4.16b, v4.16b, v3.16b
-; CHECK-SD-NEXT:    xtn v5.2s, v5.2d
-; CHECK-SD-NEXT:    xtn v4.2s, v4.2d
-; CHECK-SD-NEXT:    smlal v0.2d, v1.2s, v4.2s
-; CHECK-SD-NEXT:    smlal v2.2d, v1.2s, v5.2s
+; CHECK-SD-NEXT:    mov d5, v4.d[1]
+; CHECK-SD-NEXT:    and v4.8b, v4.8b, v3.8b
+; CHECK-SD-NEXT:    smlal v2.2d, v1.2s, v4.2s
+; CHECK-SD-NEXT:    and v5.8b, v5.8b, v3.8b
+; CHECK-SD-NEXT:    smlal v0.2d, v1.2s, v5.2s
 ; CHECK-SD-NEXT:    b.ne .LBB6_11
 ; CHECK-SD-NEXT:  // %bb.12: // %vec.epilog.middle.block
 ; CHECK-SD-NEXT:    add v0.2d, v2.2d, v0.2d

--- a/llvm/test/CodeGen/AArch64/arm64-zip.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-zip.ll
@@ -433,14 +433,14 @@ define <4 x i32> @shuffle_zip2(<4 x i32> %arg) {
 ; CHECK-SD-LABEL: shuffle_zip2:
 ; CHECK-SD:       // %bb.0: // %bb
 ; CHECK-SD-NEXT:    cmtst.4s v0, v0, v0
-; CHECK-SD-NEXT:    uzp1.8h v1, v0, v0
+; CHECK-SD-NEXT:    movi.4h v1, #1
+; CHECK-SD-NEXT:    uzp1.8h v2, v0, v0
 ; CHECK-SD-NEXT:    xtn.4h v0, v0
-; CHECK-SD-NEXT:    xtn.4h v1, v1
-; CHECK-SD-NEXT:    zip2.4h v0, v0, v1
-; CHECK-SD-NEXT:    movi.4s v1, #1
+; CHECK-SD-NEXT:    xtn.4h v2, v2
+; CHECK-SD-NEXT:    zip2.4h v0, v0, v2
 ; CHECK-SD-NEXT:    zip1.4h v0, v0, v0
+; CHECK-SD-NEXT:    and.8b v0, v0, v1
 ; CHECK-SD-NEXT:    ushll.4s v0, v0, #0
-; CHECK-SD-NEXT:    and.16b v0, v0, v1
 ; CHECK-SD-NEXT:    ret
 ;
 ; CHECK-GI-LABEL: shuffle_zip2:

--- a/llvm/test/CodeGen/AArch64/bitcast-extend.ll
+++ b/llvm/test/CodeGen/AArch64/bitcast-extend.ll
@@ -25,10 +25,9 @@ define <4 x i32> @z_i32_v4i32(i32 %x) {
 ; CHECK-SD-LABEL: z_i32_v4i32:
 ; CHECK-SD:       // %bb.0:
 ; CHECK-SD-NEXT:    fmov s0, w0
-; CHECK-SD-NEXT:    movi v1.2d, #0x0000ff000000ff
 ; CHECK-SD-NEXT:    zip1 v0.8b, v0.8b, v0.8b
+; CHECK-SD-NEXT:    bic v0.4h, #255, lsl #8
 ; CHECK-SD-NEXT:    ushll v0.4s, v0.4h, #0
-; CHECK-SD-NEXT:    and v0.16b, v0.16b, v1.16b
 ; CHECK-SD-NEXT:    ret
 ;
 ; CHECK-GI-LABEL: z_i32_v4i32:
@@ -61,16 +60,16 @@ define <4 x i32> @z_i32_v4i32(i32 %x) {
 define <4 x i64> @z_i32_v4i64(i32 %x) {
 ; CHECK-SD-LABEL: z_i32_v4i64:
 ; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    fmov s0, w0
-; CHECK-SD-NEXT:    movi v1.2d, #0x000000000000ff
-; CHECK-SD-NEXT:    mov b2, v0.b[0]
-; CHECK-SD-NEXT:    mov b3, v0.b[2]
-; CHECK-SD-NEXT:    mov v2.b[4], v0.b[1]
-; CHECK-SD-NEXT:    mov v3.b[4], v0.b[3]
-; CHECK-SD-NEXT:    ushll v0.2d, v2.2s, #0
-; CHECK-SD-NEXT:    ushll v2.2d, v3.2s, #0
-; CHECK-SD-NEXT:    and v0.16b, v0.16b, v1.16b
-; CHECK-SD-NEXT:    and v1.16b, v2.16b, v1.16b
+; CHECK-SD-NEXT:    fmov s1, w0
+; CHECK-SD-NEXT:    movi d0, #0x0000ff000000ff
+; CHECK-SD-NEXT:    mov b2, v1.b[0]
+; CHECK-SD-NEXT:    mov b3, v1.b[2]
+; CHECK-SD-NEXT:    mov v2.b[4], v1.b[1]
+; CHECK-SD-NEXT:    mov v3.b[4], v1.b[3]
+; CHECK-SD-NEXT:    and v1.8b, v2.8b, v0.8b
+; CHECK-SD-NEXT:    and v2.8b, v3.8b, v0.8b
+; CHECK-SD-NEXT:    ushll v0.2d, v1.2s, #0
+; CHECK-SD-NEXT:    ushll v1.2d, v2.2s, #0
 ; CHECK-SD-NEXT:    ret
 ;
 ; CHECK-GI-LABEL: z_i32_v4i64:

--- a/llvm/test/CodeGen/AArch64/complex-deinterleaving-crash.ll
+++ b/llvm/test/CodeGen/AArch64/complex-deinterleaving-crash.ll
@@ -35,7 +35,7 @@ define i32 @check_deinterleaving_has_deinterleave(ptr %a) {
 ; CHECK-LABEL: check_deinterleaving_has_deinterleave:
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    movi v0.2d, #0000000000000000
-; CHECK-NEXT:    movi v2.4s, #1
+; CHECK-NEXT:    movi v2.16b, #1
 ; CHECK-NEXT:    add x8, x0, #16
 ; CHECK-NEXT:    movi v1.2d, #0000000000000000
 ; CHECK-NEXT:    movi v4.2d, #0000000000000000
@@ -52,34 +52,20 @@ define i32 @check_deinterleaving_has_deinterleave(ptr %a) {
 ; CHECK-NEXT:    add x8, x8, #32
 ; CHECK-NEXT:    cmeq v17.16b, v17.16b, #0
 ; CHECK-NEXT:    cmeq v18.16b, v18.16b, #0
+; CHECK-NEXT:    and v17.16b, v17.16b, v2.16b
+; CHECK-NEXT:    and v18.16b, v18.16b, v2.16b
 ; CHECK-NEXT:    ushll2 v19.8h, v17.16b, #0
 ; CHECK-NEXT:    ushll v17.8h, v17.8b, #0
 ; CHECK-NEXT:    ushll2 v20.8h, v18.16b, #0
 ; CHECK-NEXT:    ushll v18.8h, v18.8b, #0
-; CHECK-NEXT:    ushll v21.4s, v19.4h, #0
-; CHECK-NEXT:    ushll2 v19.4s, v19.8h, #0
-; CHECK-NEXT:    ushll v22.4s, v17.4h, #0
-; CHECK-NEXT:    ushll2 v17.4s, v17.8h, #0
-; CHECK-NEXT:    ushll2 v23.4s, v20.8h, #0
-; CHECK-NEXT:    ushll v24.4s, v18.4h, #0
-; CHECK-NEXT:    ushll2 v18.4s, v18.8h, #0
-; CHECK-NEXT:    ushll v20.4s, v20.4h, #0
-; CHECK-NEXT:    and v21.16b, v21.16b, v2.16b
-; CHECK-NEXT:    and v19.16b, v19.16b, v2.16b
-; CHECK-NEXT:    and v22.16b, v22.16b, v2.16b
-; CHECK-NEXT:    and v17.16b, v17.16b, v2.16b
-; CHECK-NEXT:    and v23.16b, v23.16b, v2.16b
-; CHECK-NEXT:    and v24.16b, v24.16b, v2.16b
-; CHECK-NEXT:    and v18.16b, v18.16b, v2.16b
-; CHECK-NEXT:    and v20.16b, v20.16b, v2.16b
-; CHECK-NEXT:    add v5.4s, v5.4s, v19.4s
-; CHECK-NEXT:    add v3.4s, v3.4s, v21.4s
-; CHECK-NEXT:    add v1.4s, v1.4s, v22.4s
-; CHECK-NEXT:    add v4.4s, v4.4s, v17.4s
-; CHECK-NEXT:    add v16.4s, v16.4s, v23.4s
-; CHECK-NEXT:    add v6.4s, v6.4s, v24.4s
-; CHECK-NEXT:    add v7.4s, v7.4s, v20.4s
-; CHECK-NEXT:    add v0.4s, v0.4s, v18.4s
+; CHECK-NEXT:    uaddw2 v5.4s, v5.4s, v19.8h
+; CHECK-NEXT:    uaddw v3.4s, v3.4s, v19.4h
+; CHECK-NEXT:    uaddw2 v4.4s, v4.4s, v17.8h
+; CHECK-NEXT:    uaddw v1.4s, v1.4s, v17.4h
+; CHECK-NEXT:    uaddw2 v16.4s, v16.4s, v20.8h
+; CHECK-NEXT:    uaddw v7.4s, v7.4s, v20.4h
+; CHECK-NEXT:    uaddw2 v0.4s, v0.4s, v18.8h
+; CHECK-NEXT:    uaddw v6.4s, v6.4s, v18.4h
 ; CHECK-NEXT:    b.ne .LBB1_1
 ; CHECK-NEXT:  // %bb.2: // %middle.block
 ; CHECK-NEXT:    add v0.4s, v0.4s, v4.4s

--- a/llvm/test/CodeGen/AArch64/extbinopload.ll
+++ b/llvm/test/CodeGen/AArch64/extbinopload.ll
@@ -1365,15 +1365,13 @@ define <4 x i32> @atomic(ptr %p) {
 ; CHECK-LABEL: atomic:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    ldar w8, [x0]
-; CHECK-NEXT:    movi v0.2d, #0x0000ff000000ff
-; CHECK-NEXT:    ldr s1, [x0, #4]
-; CHECK-NEXT:    fmov s2, w8
-; CHECK-NEXT:    ushll v1.8h, v1.8b, #0
-; CHECK-NEXT:    zip1 v2.8b, v2.8b, v0.8b
-; CHECK-NEXT:    ushll v1.4s, v1.4h, #3
-; CHECK-NEXT:    ushll v2.4s, v2.4h, #0
-; CHECK-NEXT:    and v0.16b, v2.16b, v0.16b
-; CHECK-NEXT:    add v0.4s, v0.4s, v1.4s
+; CHECK-NEXT:    ldr s0, [x0, #4]
+; CHECK-NEXT:    fmov s1, w8
+; CHECK-NEXT:    zip1 v1.8b, v1.8b, v0.8b
+; CHECK-NEXT:    ushll v0.8h, v0.8b, #0
+; CHECK-NEXT:    ushll v0.4s, v0.4h, #3
+; CHECK-NEXT:    bic v1.4h, #255, lsl #8
+; CHECK-NEXT:    uaddw v0.4s, v0.4s, v1.4h
 ; CHECK-NEXT:    ret
   %l1b = load atomic float, ptr %p acquire, align 4
   %l1 = bitcast float %l1b to <4 x i8>

--- a/llvm/test/CodeGen/AArch64/neon-extadd.ll
+++ b/llvm/test/CodeGen/AArch64/neon-extadd.ll
@@ -1372,25 +1372,24 @@ define <16 x i32> @i12(<16 x i12> %s0, <16 x i12> %s1) {
 ; CHECK-SD-NEXT:    ldr w9, [sp, #40]
 ; CHECK-SD-NEXT:    fmov s1, w4
 ; CHECK-SD-NEXT:    ldr w10, [sp, #128]
-; CHECK-SD-NEXT:    fmov s3, w0
+; CHECK-SD-NEXT:    fmov s0, w0
 ; CHECK-SD-NEXT:    ldr w11, [sp, #72]
-; CHECK-SD-NEXT:    fmov s0, w8
+; CHECK-SD-NEXT:    fmov s3, w8
 ; CHECK-SD-NEXT:    ldr w8, [sp]
-; CHECK-SD-NEXT:    movi v16.4s, #15, msl #8
 ; CHECK-SD-NEXT:    fmov s5, w10
 ; CHECK-SD-NEXT:    ldr w10, [sp, #104]
 ; CHECK-SD-NEXT:    mov v1.h[1], w5
 ; CHECK-SD-NEXT:    fmov s2, w8
 ; CHECK-SD-NEXT:    ldr w8, [sp, #8]
-; CHECK-SD-NEXT:    mov v3.h[1], w1
-; CHECK-SD-NEXT:    mov v0.h[1], w9
+; CHECK-SD-NEXT:    mov v0.h[1], w1
+; CHECK-SD-NEXT:    mov v3.h[1], w9
 ; CHECK-SD-NEXT:    ldr w9, [sp, #48]
 ; CHECK-SD-NEXT:    mov v2.h[1], w8
 ; CHECK-SD-NEXT:    ldr w8, [sp, #160]
 ; CHECK-SD-NEXT:    mov v1.h[2], w6
-; CHECK-SD-NEXT:    mov v3.h[2], w2
+; CHECK-SD-NEXT:    mov v0.h[2], w2
 ; CHECK-SD-NEXT:    fmov s4, w8
-; CHECK-SD-NEXT:    mov v0.h[2], w9
+; CHECK-SD-NEXT:    mov v3.h[2], w9
 ; CHECK-SD-NEXT:    ldr w9, [sp, #168]
 ; CHECK-SD-NEXT:    ldr w8, [sp, #64]
 ; CHECK-SD-NEXT:    mov v1.h[3], w7
@@ -1398,7 +1397,7 @@ define <16 x i32> @i12(<16 x i12> %s0, <16 x i12> %s1) {
 ; CHECK-SD-NEXT:    ldr w9, [sp, #96]
 ; CHECK-SD-NEXT:    fmov s6, w8
 ; CHECK-SD-NEXT:    ldr w8, [sp, #136]
-; CHECK-SD-NEXT:    mov v3.h[3], w3
+; CHECK-SD-NEXT:    mov v0.h[3], w3
 ; CHECK-SD-NEXT:    fmov s7, w9
 ; CHECK-SD-NEXT:    ldr w9, [sp, #16]
 ; CHECK-SD-NEXT:    mov v6.h[1], w11
@@ -1409,42 +1408,34 @@ define <16 x i32> @i12(<16 x i12> %s0, <16 x i12> %s1) {
 ; CHECK-SD-NEXT:    ldr w11, [sp, #144]
 ; CHECK-SD-NEXT:    mov v7.h[1], w10
 ; CHECK-SD-NEXT:    ldr w10, [sp, #112]
-; CHECK-SD-NEXT:    ushll v1.4s, v1.4h, #0
+; CHECK-SD-NEXT:    bic v1.4h, #240, lsl #8
 ; CHECK-SD-NEXT:    mov v4.h[2], w9
 ; CHECK-SD-NEXT:    ldr w9, [sp, #56]
-; CHECK-SD-NEXT:    ushll v3.4s, v3.4h, #0
+; CHECK-SD-NEXT:    bic v0.4h, #240, lsl #8
 ; CHECK-SD-NEXT:    mov v6.h[2], w8
 ; CHECK-SD-NEXT:    ldr w8, [sp, #24]
 ; CHECK-SD-NEXT:    mov v5.h[2], w11
 ; CHECK-SD-NEXT:    ldr w11, [sp, #120]
-; CHECK-SD-NEXT:    mov v0.h[3], w9
+; CHECK-SD-NEXT:    mov v3.h[3], w9
 ; CHECK-SD-NEXT:    ldr w9, [sp, #152]
 ; CHECK-SD-NEXT:    mov v7.h[2], w10
 ; CHECK-SD-NEXT:    ldr w10, [sp, #88]
 ; CHECK-SD-NEXT:    mov v2.h[3], w8
 ; CHECK-SD-NEXT:    ldr w8, [sp, #184]
-; CHECK-SD-NEXT:    and v1.16b, v1.16b, v16.16b
 ; CHECK-SD-NEXT:    mov v6.h[3], w10
 ; CHECK-SD-NEXT:    mov v5.h[3], w9
 ; CHECK-SD-NEXT:    mov v4.h[3], w8
-; CHECK-SD-NEXT:    ushll v0.4s, v0.4h, #0
+; CHECK-SD-NEXT:    bic v3.4h, #240, lsl #8
 ; CHECK-SD-NEXT:    mov v7.h[3], w11
-; CHECK-SD-NEXT:    ushll v2.4s, v2.4h, #0
-; CHECK-SD-NEXT:    ushll v6.4s, v6.4h, #0
-; CHECK-SD-NEXT:    ushll v5.4s, v5.4h, #0
-; CHECK-SD-NEXT:    and v17.16b, v0.16b, v16.16b
-; CHECK-SD-NEXT:    ushll v4.4s, v4.4h, #0
-; CHECK-SD-NEXT:    and v2.16b, v2.16b, v16.16b
-; CHECK-SD-NEXT:    and v0.16b, v3.16b, v16.16b
-; CHECK-SD-NEXT:    ushll v7.4s, v7.4h, #0
-; CHECK-SD-NEXT:    and v3.16b, v6.16b, v16.16b
-; CHECK-SD-NEXT:    and v5.16b, v5.16b, v16.16b
-; CHECK-SD-NEXT:    and v4.16b, v4.16b, v16.16b
-; CHECK-SD-NEXT:    and v6.16b, v7.16b, v16.16b
-; CHECK-SD-NEXT:    add v0.4s, v0.4s, v3.4s
-; CHECK-SD-NEXT:    add v2.4s, v2.4s, v5.4s
-; CHECK-SD-NEXT:    add v3.4s, v17.4s, v4.4s
-; CHECK-SD-NEXT:    add v1.4s, v1.4s, v6.4s
+; CHECK-SD-NEXT:    bic v2.4h, #240, lsl #8
+; CHECK-SD-NEXT:    bic v6.4h, #240, lsl #8
+; CHECK-SD-NEXT:    bic v5.4h, #240, lsl #8
+; CHECK-SD-NEXT:    bic v4.4h, #240, lsl #8
+; CHECK-SD-NEXT:    bic v7.4h, #240, lsl #8
+; CHECK-SD-NEXT:    uaddl v0.4s, v0.4h, v6.4h
+; CHECK-SD-NEXT:    uaddl v2.4s, v2.4h, v5.4h
+; CHECK-SD-NEXT:    uaddl v3.4s, v3.4h, v4.4h
+; CHECK-SD-NEXT:    uaddl v1.4s, v1.4h, v7.4h
 ; CHECK-SD-NEXT:    ret
 ;
 ; CHECK-GI-LABEL: i12:

--- a/llvm/test/CodeGen/AArch64/neon-partial-reduce-dot-product.ll
+++ b/llvm/test/CodeGen/AArch64/neon-partial-reduce-dot-product.ll
@@ -1592,22 +1592,15 @@ entry:
 define <4 x i32> @partial_reduce_zext_cmp_i8tov4i32(<4 x i32> %acc, <16 x i8> %a, <16 x i8> %b) {
 ; CHECK-NODOT-LABEL: partial_reduce_zext_cmp_i8tov4i32:
 ; CHECK-NODOT:       // %bb.0:
+; CHECK-NODOT-NEXT:    movi v3.16b, #1
 ; CHECK-NODOT-NEXT:    cmeq v1.16b, v1.16b, v2.16b
-; CHECK-NODOT-NEXT:    movi v3.4s, #1
-; CHECK-NODOT-NEXT:    ushll2 v2.8h, v1.16b, #0
-; CHECK-NODOT-NEXT:    ushll v1.8h, v1.8b, #0
-; CHECK-NODOT-NEXT:    ushll v4.4s, v2.4h, #0
-; CHECK-NODOT-NEXT:    ushll2 v5.4s, v1.8h, #0
-; CHECK-NODOT-NEXT:    ushll v1.4s, v1.4h, #0
-; CHECK-NODOT-NEXT:    ushll2 v2.4s, v2.8h, #0
-; CHECK-NODOT-NEXT:    and v4.16b, v4.16b, v3.16b
-; CHECK-NODOT-NEXT:    and v5.16b, v5.16b, v3.16b
 ; CHECK-NODOT-NEXT:    and v1.16b, v1.16b, v3.16b
-; CHECK-NODOT-NEXT:    and v2.16b, v2.16b, v3.16b
-; CHECK-NODOT-NEXT:    add v0.4s, v0.4s, v1.4s
-; CHECK-NODOT-NEXT:    add v1.4s, v5.4s, v4.4s
-; CHECK-NODOT-NEXT:    add v0.4s, v0.4s, v1.4s
-; CHECK-NODOT-NEXT:    add v0.4s, v0.4s, v2.4s
+; CHECK-NODOT-NEXT:    ushll v2.8h, v1.8b, #0
+; CHECK-NODOT-NEXT:    ushll2 v1.8h, v1.16b, #0
+; CHECK-NODOT-NEXT:    uaddw v0.4s, v0.4s, v2.4h
+; CHECK-NODOT-NEXT:    uaddw2 v0.4s, v0.4s, v2.8h
+; CHECK-NODOT-NEXT:    uaddw v0.4s, v0.4s, v1.4h
+; CHECK-NODOT-NEXT:    uaddw2 v0.4s, v0.4s, v1.8h
 ; CHECK-NODOT-NEXT:    ret
 ;
 ; CHECK-DOT-LABEL: partial_reduce_zext_cmp_i8tov4i32:
@@ -1665,39 +1658,23 @@ define <4 x i32> @partial_reduce_sext_cmp_i8tov4i32(<4 x i32> %acc, <16 x i8> %a
 define <2 x i64> @partial_reduce_zext_cmp_i8tov2i64(<2 x i64> %acc, <16 x i8> %a, <16 x i8> %b) {
 ; CHECK-NODOT-LABEL: partial_reduce_zext_cmp_i8tov2i64:
 ; CHECK-NODOT:       // %bb.0:
+; CHECK-NODOT-NEXT:    movi v3.16b, #1
 ; CHECK-NODOT-NEXT:    cmeq v1.16b, v1.16b, v2.16b
-; CHECK-NODOT-NEXT:    mov w8, #1 // =0x1
-; CHECK-NODOT-NEXT:    dup v5.2d, x8
-; CHECK-NODOT-NEXT:    ushll2 v2.8h, v1.16b, #0
-; CHECK-NODOT-NEXT:    ushll v1.8h, v1.8b, #0
+; CHECK-NODOT-NEXT:    and v1.16b, v1.16b, v3.16b
+; CHECK-NODOT-NEXT:    ushll v2.8h, v1.8b, #0
+; CHECK-NODOT-NEXT:    ushll2 v1.8h, v1.16b, #0
 ; CHECK-NODOT-NEXT:    ushll v3.4s, v2.4h, #0
-; CHECK-NODOT-NEXT:    ushll2 v4.4s, v1.8h, #0
-; CHECK-NODOT-NEXT:    ushll v1.4s, v1.4h, #0
 ; CHECK-NODOT-NEXT:    ushll2 v2.4s, v2.8h, #0
-; CHECK-NODOT-NEXT:    ushll v6.2d, v3.2s, #0
-; CHECK-NODOT-NEXT:    ushll2 v7.2d, v4.4s, #0
-; CHECK-NODOT-NEXT:    ushll v4.2d, v4.2s, #0
-; CHECK-NODOT-NEXT:    ushll2 v16.2d, v1.4s, #0
-; CHECK-NODOT-NEXT:    ushll v1.2d, v1.2s, #0
-; CHECK-NODOT-NEXT:    ushll2 v3.2d, v3.4s, #0
-; CHECK-NODOT-NEXT:    ushll2 v17.2d, v2.4s, #0
-; CHECK-NODOT-NEXT:    ushll v2.2d, v2.2s, #0
-; CHECK-NODOT-NEXT:    and v6.16b, v6.16b, v5.16b
-; CHECK-NODOT-NEXT:    and v7.16b, v7.16b, v5.16b
-; CHECK-NODOT-NEXT:    and v4.16b, v4.16b, v5.16b
-; CHECK-NODOT-NEXT:    and v16.16b, v16.16b, v5.16b
-; CHECK-NODOT-NEXT:    and v1.16b, v1.16b, v5.16b
-; CHECK-NODOT-NEXT:    and v3.16b, v3.16b, v5.16b
-; CHECK-NODOT-NEXT:    and v2.16b, v2.16b, v5.16b
-; CHECK-NODOT-NEXT:    add v0.2d, v0.2d, v1.2d
-; CHECK-NODOT-NEXT:    add v1.2d, v16.2d, v4.2d
-; CHECK-NODOT-NEXT:    add v4.2d, v7.2d, v6.2d
-; CHECK-NODOT-NEXT:    and v6.16b, v17.16b, v5.16b
-; CHECK-NODOT-NEXT:    add v0.2d, v0.2d, v1.2d
-; CHECK-NODOT-NEXT:    add v1.2d, v4.2d, v3.2d
-; CHECK-NODOT-NEXT:    add v0.2d, v0.2d, v1.2d
-; CHECK-NODOT-NEXT:    add v1.2d, v2.2d, v6.2d
-; CHECK-NODOT-NEXT:    add v0.2d, v0.2d, v1.2d
+; CHECK-NODOT-NEXT:    uaddw v0.2d, v0.2d, v3.2s
+; CHECK-NODOT-NEXT:    uaddw2 v0.2d, v0.2d, v3.4s
+; CHECK-NODOT-NEXT:    ushll v3.4s, v1.4h, #0
+; CHECK-NODOT-NEXT:    ushll2 v1.4s, v1.8h, #0
+; CHECK-NODOT-NEXT:    uaddw v0.2d, v0.2d, v2.2s
+; CHECK-NODOT-NEXT:    uaddw2 v0.2d, v0.2d, v2.4s
+; CHECK-NODOT-NEXT:    uaddw v0.2d, v0.2d, v3.2s
+; CHECK-NODOT-NEXT:    uaddw2 v0.2d, v0.2d, v3.4s
+; CHECK-NODOT-NEXT:    uaddw v0.2d, v0.2d, v1.2s
+; CHECK-NODOT-NEXT:    uaddw2 v0.2d, v0.2d, v1.4s
 ; CHECK-NODOT-NEXT:    ret
 ;
 ; CHECK-DOT-LABEL: partial_reduce_zext_cmp_i8tov2i64:
@@ -1771,15 +1748,10 @@ define <2 x i64> @partial_reduce_sext_cmp_i8tov2i64(<2 x i64> %acc, <16 x i8> %a
 define <2 x i64> @partial_reduce_zext_cmp_i32tov2i64(<2 x i64> %acc, <4 x i32> %a, <4 x i32> %b) {
 ; CHECK-COMMON-LABEL: partial_reduce_zext_cmp_i32tov2i64:
 ; CHECK-COMMON:       // %bb.0:
+; CHECK-COMMON-NEXT:    movi v3.4s, #1
 ; CHECK-COMMON-NEXT:    cmeq v1.4s, v1.4s, v2.4s
-; CHECK-COMMON-NEXT:    mov w8, #1 // =0x1
-; CHECK-COMMON-NEXT:    dup v2.2d, x8
-; CHECK-COMMON-NEXT:    ushll v3.2d, v1.2s, #0
-; CHECK-COMMON-NEXT:    ushll2 v1.2d, v1.4s, #0
-; CHECK-COMMON-NEXT:    and v3.16b, v3.16b, v2.16b
-; CHECK-COMMON-NEXT:    and v1.16b, v1.16b, v2.16b
-; CHECK-COMMON-NEXT:    add v0.2d, v0.2d, v3.2d
-; CHECK-COMMON-NEXT:    add v0.2d, v0.2d, v1.2d
+; CHECK-COMMON-NEXT:    and v1.16b, v1.16b, v3.16b
+; CHECK-COMMON-NEXT:    uadalp v0.2d, v1.4s
 ; CHECK-COMMON-NEXT:    ret
   %cmp = icmp eq <4 x i32> %a, %b
   %ext = zext <4 x i1> %cmp to <4 x i64>

--- a/llvm/test/CodeGen/AArch64/setcc_knownbits.ll
+++ b/llvm/test/CodeGen/AArch64/setcc_knownbits.ll
@@ -78,11 +78,13 @@ define i1 @lshr_ctlz_undef_cmpeq_one_i64(i64 %in) {
 define i32 @PR17487(i1 %tobool) {
 ; CHECK-SD-LABEL: PR17487:
 ; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    dup v0.2s, w0
+; CHECK-SD-NEXT:    movi v0.2s, #1
+; CHECK-SD-NEXT:    dup v1.2s, w0
 ; CHECK-SD-NEXT:    mov w8, #1 // =0x1
+; CHECK-SD-NEXT:    and v0.8b, v1.8b, v0.8b
 ; CHECK-SD-NEXT:    dup v1.2d, x8
 ; CHECK-SD-NEXT:    ushll v0.2d, v0.2s, #0
-; CHECK-SD-NEXT:    bic v0.16b, v1.16b, v0.16b
+; CHECK-SD-NEXT:    eor v0.16b, v0.16b, v1.16b
 ; CHECK-SD-NEXT:    mov x8, v0.d[1]
 ; CHECK-SD-NEXT:    cmp x8, #1
 ; CHECK-SD-NEXT:    cset w0, ne

--- a/llvm/test/CodeGen/AArch64/vec3-loads-ext-trunc-stores.ll
+++ b/llvm/test/CodeGen/AArch64/vec3-loads-ext-trunc-stores.ll
@@ -40,12 +40,11 @@ define <4 x i32> @load_v3i8_to_4xi32(ptr %src) {
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    ldrb w8, [x0, #2]
 ; CHECK-NEXT:    ldrh w9, [x0]
-; CHECK-NEXT:    movi.2d v1, #0x0000ff000000ff
 ; CHECK-NEXT:    orr w8, w9, w8, lsl #16
 ; CHECK-NEXT:    fmov s0, w8
 ; CHECK-NEXT:    zip1.8b v0, v0, v0
+; CHECK-NEXT:    bic.4h v0, #255, lsl #8
 ; CHECK-NEXT:    ushll.4s v0, v0, #0
-; CHECK-NEXT:    and.16b v0, v0, v1
 ; CHECK-NEXT:    ret
 ;
 ; BE-LABEL: load_v3i8_to_4xi32:
@@ -53,7 +52,6 @@ define <4 x i32> @load_v3i8_to_4xi32(ptr %src) {
 ; BE-NEXT:    sub sp, sp, #16
 ; BE-NEXT:    .cfi_def_cfa_offset 16
 ; BE-NEXT:    ldrh w8, [x0]
-; BE-NEXT:    movi v1.2d, #0x0000ff000000ff
 ; BE-NEXT:    strh w8, [sp, #12]
 ; BE-NEXT:    ldr s0, [sp, #12]
 ; BE-NEXT:    ldrsb w8, [x0, #2]
@@ -61,8 +59,8 @@ define <4 x i32> @load_v3i8_to_4xi32(ptr %src) {
 ; BE-NEXT:    ushll v0.8h, v0.8b, #0
 ; BE-NEXT:    mov v0.h[1], v0.h[1]
 ; BE-NEXT:    mov v0.h[2], w8
+; BE-NEXT:    bic v0.4h, #255, lsl #8
 ; BE-NEXT:    ushll v0.4s, v0.4h, #0
-; BE-NEXT:    and v0.16b, v0.16b, v1.16b
 ; BE-NEXT:    rev64 v0.4s, v0.4s
 ; BE-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
 ; BE-NEXT:    add sp, sp, #16
@@ -78,12 +76,11 @@ define <4 x i32> @load_v3i8_to_4xi32_align_2(ptr %src) {
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    ldrb w8, [x0, #2]
 ; CHECK-NEXT:    ldrh w9, [x0]
-; CHECK-NEXT:    movi.2d v1, #0x0000ff000000ff
 ; CHECK-NEXT:    orr w8, w9, w8, lsl #16
 ; CHECK-NEXT:    fmov s0, w8
 ; CHECK-NEXT:    zip1.8b v0, v0, v0
+; CHECK-NEXT:    bic.4h v0, #255, lsl #8
 ; CHECK-NEXT:    ushll.4s v0, v0, #0
-; CHECK-NEXT:    and.16b v0, v0, v1
 ; CHECK-NEXT:    ret
 ;
 ; BE-LABEL: load_v3i8_to_4xi32_align_2:
@@ -91,7 +88,6 @@ define <4 x i32> @load_v3i8_to_4xi32_align_2(ptr %src) {
 ; BE-NEXT:    sub sp, sp, #16
 ; BE-NEXT:    .cfi_def_cfa_offset 16
 ; BE-NEXT:    ldrh w8, [x0]
-; BE-NEXT:    movi v1.2d, #0x0000ff000000ff
 ; BE-NEXT:    strh w8, [sp, #12]
 ; BE-NEXT:    ldr s0, [sp, #12]
 ; BE-NEXT:    ldrsb w8, [x0, #2]
@@ -99,8 +95,8 @@ define <4 x i32> @load_v3i8_to_4xi32_align_2(ptr %src) {
 ; BE-NEXT:    ushll v0.8h, v0.8b, #0
 ; BE-NEXT:    mov v0.h[1], v0.h[1]
 ; BE-NEXT:    mov v0.h[2], w8
+; BE-NEXT:    bic v0.4h, #255, lsl #8
 ; BE-NEXT:    ushll v0.4s, v0.4h, #0
-; BE-NEXT:    and v0.16b, v0.16b, v1.16b
 ; BE-NEXT:    rev64 v0.4s, v0.4s
 ; BE-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
 ; BE-NEXT:    add sp, sp, #16
@@ -115,20 +111,18 @@ define <4 x i32> @load_v3i8_to_4xi32_align_4(ptr %src) {
 ; CHECK-LABEL: load_v3i8_to_4xi32_align_4:
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    ldr s0, [x0]
-; CHECK-NEXT:    movi.2d v1, #0x0000ff000000ff
 ; CHECK-NEXT:    zip1.8b v0, v0, v0
+; CHECK-NEXT:    bic.4h v0, #255, lsl #8
 ; CHECK-NEXT:    ushll.4s v0, v0, #0
-; CHECK-NEXT:    and.16b v0, v0, v1
 ; CHECK-NEXT:    ret
 ;
 ; BE-LABEL: load_v3i8_to_4xi32_align_4:
 ; BE:       // %bb.0:
 ; BE-NEXT:    ldr s0, [x0]
-; BE-NEXT:    movi v1.2d, #0x0000ff000000ff
 ; BE-NEXT:    rev32 v0.8b, v0.8b
 ; BE-NEXT:    zip1 v0.8b, v0.8b, v0.8b
+; BE-NEXT:    bic v0.4h, #255, lsl #8
 ; BE-NEXT:    ushll v0.4s, v0.4h, #0
-; BE-NEXT:    and v0.16b, v0.16b, v1.16b
 ; BE-NEXT:    rev64 v0.4s, v0.4s
 ; BE-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
 ; BE-NEXT:    ret
@@ -143,12 +137,11 @@ define <4 x i32> @load_v3i8_to_4xi32_const_offset_1(ptr %src) {
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    ldrb w8, [x0, #3]
 ; CHECK-NEXT:    ldurh w9, [x0, #1]
-; CHECK-NEXT:    movi.2d v1, #0x0000ff000000ff
 ; CHECK-NEXT:    orr w8, w9, w8, lsl #16
 ; CHECK-NEXT:    fmov s0, w8
 ; CHECK-NEXT:    zip1.8b v0, v0, v0
+; CHECK-NEXT:    bic.4h v0, #255, lsl #8
 ; CHECK-NEXT:    ushll.4s v0, v0, #0
-; CHECK-NEXT:    and.16b v0, v0, v1
 ; CHECK-NEXT:    ret
 ;
 ; BE-LABEL: load_v3i8_to_4xi32_const_offset_1:
@@ -156,7 +149,6 @@ define <4 x i32> @load_v3i8_to_4xi32_const_offset_1(ptr %src) {
 ; BE-NEXT:    sub sp, sp, #16
 ; BE-NEXT:    .cfi_def_cfa_offset 16
 ; BE-NEXT:    ldurh w8, [x0, #1]
-; BE-NEXT:    movi v1.2d, #0x0000ff000000ff
 ; BE-NEXT:    strh w8, [sp, #12]
 ; BE-NEXT:    ldr s0, [sp, #12]
 ; BE-NEXT:    ldrsb w8, [x0, #3]
@@ -164,8 +156,8 @@ define <4 x i32> @load_v3i8_to_4xi32_const_offset_1(ptr %src) {
 ; BE-NEXT:    ushll v0.8h, v0.8b, #0
 ; BE-NEXT:    mov v0.h[1], v0.h[1]
 ; BE-NEXT:    mov v0.h[2], w8
+; BE-NEXT:    bic v0.4h, #255, lsl #8
 ; BE-NEXT:    ushll v0.4s, v0.4h, #0
-; BE-NEXT:    and v0.16b, v0.16b, v1.16b
 ; BE-NEXT:    rev64 v0.4s, v0.4s
 ; BE-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
 ; BE-NEXT:    add sp, sp, #16
@@ -182,12 +174,11 @@ define <4 x i32> @load_v3i8_to_4xi32_const_offset_3(ptr %src) {
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    ldrb w8, [x0, #5]
 ; CHECK-NEXT:    ldurh w9, [x0, #3]
-; CHECK-NEXT:    movi.2d v1, #0x0000ff000000ff
 ; CHECK-NEXT:    orr w8, w9, w8, lsl #16
 ; CHECK-NEXT:    fmov s0, w8
 ; CHECK-NEXT:    zip1.8b v0, v0, v0
+; CHECK-NEXT:    bic.4h v0, #255, lsl #8
 ; CHECK-NEXT:    ushll.4s v0, v0, #0
-; CHECK-NEXT:    and.16b v0, v0, v1
 ; CHECK-NEXT:    ret
 ;
 ; BE-LABEL: load_v3i8_to_4xi32_const_offset_3:
@@ -195,7 +186,6 @@ define <4 x i32> @load_v3i8_to_4xi32_const_offset_3(ptr %src) {
 ; BE-NEXT:    sub sp, sp, #16
 ; BE-NEXT:    .cfi_def_cfa_offset 16
 ; BE-NEXT:    ldurh w8, [x0, #3]
-; BE-NEXT:    movi v1.2d, #0x0000ff000000ff
 ; BE-NEXT:    strh w8, [sp, #12]
 ; BE-NEXT:    ldr s0, [sp, #12]
 ; BE-NEXT:    ldrsb w8, [x0, #5]
@@ -203,8 +193,8 @@ define <4 x i32> @load_v3i8_to_4xi32_const_offset_3(ptr %src) {
 ; BE-NEXT:    ushll v0.8h, v0.8b, #0
 ; BE-NEXT:    mov v0.h[1], v0.h[1]
 ; BE-NEXT:    mov v0.h[2], w8
+; BE-NEXT:    bic v0.4h, #255, lsl #8
 ; BE-NEXT:    ushll v0.4s, v0.4h, #0
-; BE-NEXT:    and v0.16b, v0.16b, v1.16b
 ; BE-NEXT:    rev64 v0.4s, v0.4s
 ; BE-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
 ; BE-NEXT:    add sp, sp, #16
@@ -222,15 +212,14 @@ define <4 x i32> @volatile_load_v3i8_to_4xi32(ptr %src) {
 ; CHECK-NEXT:    sub sp, sp, #16
 ; CHECK-NEXT:    .cfi_def_cfa_offset 16
 ; CHECK-NEXT:    ldrh w8, [x0]
-; CHECK-NEXT:    movi.2d v1, #0x0000ff000000ff
 ; CHECK-NEXT:    strh w8, [sp, #12]
 ; CHECK-NEXT:    ldr s0, [sp, #12]
 ; CHECK-NEXT:    ldrsb w8, [x0, #2]
 ; CHECK-NEXT:    ushll.8h v0, v0, #0
 ; CHECK-NEXT:    mov.h v0[1], v0[1]
 ; CHECK-NEXT:    mov.h v0[2], w8
+; CHECK-NEXT:    bic.4h v0, #255, lsl #8
 ; CHECK-NEXT:    ushll.4s v0, v0, #0
-; CHECK-NEXT:    and.16b v0, v0, v1
 ; CHECK-NEXT:    add sp, sp, #16
 ; CHECK-NEXT:    ret
 ;
@@ -239,7 +228,6 @@ define <4 x i32> @volatile_load_v3i8_to_4xi32(ptr %src) {
 ; BE-NEXT:    sub sp, sp, #16
 ; BE-NEXT:    .cfi_def_cfa_offset 16
 ; BE-NEXT:    ldrh w8, [x0]
-; BE-NEXT:    movi v1.2d, #0x0000ff000000ff
 ; BE-NEXT:    strh w8, [sp, #12]
 ; BE-NEXT:    ldr s0, [sp, #12]
 ; BE-NEXT:    ldrsb w8, [x0, #2]
@@ -247,8 +235,8 @@ define <4 x i32> @volatile_load_v3i8_to_4xi32(ptr %src) {
 ; BE-NEXT:    ushll v0.8h, v0.8b, #0
 ; BE-NEXT:    mov v0.h[1], v0.h[1]
 ; BE-NEXT:    mov v0.h[2], w8
+; BE-NEXT:    bic v0.4h, #255, lsl #8
 ; BE-NEXT:    ushll v0.4s, v0.4h, #0
-; BE-NEXT:    and v0.16b, v0.16b, v1.16b
 ; BE-NEXT:    rev64 v0.4s, v0.4s
 ; BE-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
 ; BE-NEXT:    add sp, sp, #16
@@ -285,12 +273,11 @@ define <3 x i32> @load_v3i8_zext_to_3xi32(ptr %src) {
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    ldrb w8, [x0, #2]
 ; CHECK-NEXT:    ldrh w9, [x0]
-; CHECK-NEXT:    movi.2d v1, #0x0000ff000000ff
 ; CHECK-NEXT:    orr w8, w9, w8, lsl #16
 ; CHECK-NEXT:    fmov s0, w8
 ; CHECK-NEXT:    zip1.8b v0, v0, v0
+; CHECK-NEXT:    bic.4h v0, #255, lsl #8
 ; CHECK-NEXT:    ushll.4s v0, v0, #0
-; CHECK-NEXT:    and.16b v0, v0, v1
 ; CHECK-NEXT:    ret
 ;
 ; BE-LABEL: load_v3i8_zext_to_3xi32:
@@ -298,15 +285,14 @@ define <3 x i32> @load_v3i8_zext_to_3xi32(ptr %src) {
 ; BE-NEXT:    sub sp, sp, #16
 ; BE-NEXT:    .cfi_def_cfa_offset 16
 ; BE-NEXT:    ldrh w8, [x0]
-; BE-NEXT:    movi v1.2d, #0x0000ff000000ff
 ; BE-NEXT:    strh w8, [sp, #12]
 ; BE-NEXT:    add x8, x0, #2
 ; BE-NEXT:    ldr s0, [sp, #12]
 ; BE-NEXT:    rev32 v0.8b, v0.8b
-; BE-NEXT:    zip1 v0.8b, v0.8b, v0.8b
+; BE-NEXT:    ushll v0.8h, v0.8b, #0
 ; BE-NEXT:    ld1 { v0.b }[4], [x8]
+; BE-NEXT:    bic v0.4h, #255, lsl #8
 ; BE-NEXT:    ushll v0.4s, v0.4h, #0
-; BE-NEXT:    and v0.16b, v0.16b, v1.16b
 ; BE-NEXT:    rev64 v0.4s, v0.4s
 ; BE-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
 ; BE-NEXT:    add sp, sp, #16

--- a/llvm/test/CodeGen/AArch64/vselect-constants.ll
+++ b/llvm/test/CodeGen/AArch64/vselect-constants.ll
@@ -146,9 +146,9 @@ define <4 x i32> @cmp_sel_0_or_minus1_vec(<4 x i32> %x, <4 x i32> %y) {
 define <4 x i32> @sel_1_or_0_vec(<4 x i1> %cond) {
 ; CHECK-LABEL: sel_1_or_0_vec:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    movi v1.4s, #1
+; CHECK-NEXT:    movi v1.4h, #1
+; CHECK-NEXT:    and v0.8b, v0.8b, v1.8b
 ; CHECK-NEXT:    ushll v0.4s, v0.4h, #0
-; CHECK-NEXT:    and v0.16b, v0.16b, v1.16b
 ; CHECK-NEXT:    ret
   %add = select <4 x i1> %cond, <4 x i32> <i32 1, i32 1, i32 1, i32 1>, <4 x i32> <i32 0, i32 0, i32 0, i32 0>
   ret <4 x i32> %add

--- a/llvm/test/CodeGen/AArch64/zext-to-tbl.ll
+++ b/llvm/test/CodeGen/AArch64/zext-to-tbl.ll
@@ -1263,33 +1263,33 @@ define void @zext_v16i4_to_v16i32_in_loop(ptr %src, ptr %dst) {
 ; CHECK-NEXT:    add x8, x8, #16
 ; CHECK-NEXT:    cmp x8, #128
 ; CHECK-NEXT:    ubfx x12, x9, #48, #4
-; CHECK-NEXT:    lsr x10, x9, #52
+; CHECK-NEXT:    ubfx x10, x9, #52, #4
 ; CHECK-NEXT:    ubfx x13, x9, #32, #4
 ; CHECK-NEXT:    ubfx w15, w9, #16, #4
-; CHECK-NEXT:    lsr x11, x9, #36
-; CHECK-NEXT:    lsr w14, w9, #20
+; CHECK-NEXT:    ubfx x11, x9, #36, #4
+; CHECK-NEXT:    ubfx w14, w9, #20, #4
 ; CHECK-NEXT:    fmov s0, w12
 ; CHECK-NEXT:    fmov s1, w13
-; CHECK-NEXT:    lsr w12, w9, #4
+; CHECK-NEXT:    ubfx w12, w9, #4, #4
 ; CHECK-NEXT:    fmov s2, w15
 ; CHECK-NEXT:    mov.h v0[1], w10
 ; CHECK-NEXT:    and w10, w9, #0xf
 ; CHECK-NEXT:    mov.h v1[1], w11
 ; CHECK-NEXT:    fmov s3, w10
-; CHECK-NEXT:    lsr x11, x9, #56
+; CHECK-NEXT:    ubfx x11, x9, #56, #4
 ; CHECK-NEXT:    mov.h v2[1], w14
-; CHECK-NEXT:    lsr x10, x9, #40
+; CHECK-NEXT:    ubfx x10, x9, #40, #4
 ; CHECK-NEXT:    mov.h v3[1], w12
-; CHECK-NEXT:    lsr w12, w9, #24
+; CHECK-NEXT:    ubfx w12, w9, #24, #4
 ; CHECK-NEXT:    mov.h v0[2], w11
-; CHECK-NEXT:    lsr w11, w9, #8
+; CHECK-NEXT:    ubfx w11, w9, #8, #4
 ; CHECK-NEXT:    mov.h v1[2], w10
 ; CHECK-NEXT:    lsr x10, x9, #60
 ; CHECK-NEXT:    mov.h v2[2], w12
-; CHECK-NEXT:    lsr x12, x9, #44
+; CHECK-NEXT:    ubfx x12, x9, #44, #4
 ; CHECK-NEXT:    mov.h v3[2], w11
 ; CHECK-NEXT:    lsr w11, w9, #28
-; CHECK-NEXT:    lsr w9, w9, #12
+; CHECK-NEXT:    ubfx w9, w9, #12, #4
 ; CHECK-NEXT:    mov.h v0[3], w10
 ; CHECK-NEXT:    mov.h v1[3], w12
 ; CHECK-NEXT:    mov.h v2[3], w11
@@ -1298,10 +1298,6 @@ define void @zext_v16i4_to_v16i32_in_loop(ptr %src, ptr %dst) {
 ; CHECK-NEXT:    ushll.4s v1, v1, #0
 ; CHECK-NEXT:    ushll.4s v2, v2, #0
 ; CHECK-NEXT:    ushll.4s v3, v3, #0
-; CHECK-NEXT:    and z0.s, z0.s, #0xf
-; CHECK-NEXT:    and z1.s, z1.s, #0xf
-; CHECK-NEXT:    and z2.s, z2.s, #0xf
-; CHECK-NEXT:    and z3.s, z3.s, #0xf
 ; CHECK-NEXT:    stp q1, q0, [x1, #32]
 ; CHECK-NEXT:    stp q3, q2, [x1], #64
 ; CHECK-NEXT:    b.ne LBB13_1
@@ -1316,53 +1312,51 @@ define void @zext_v16i4_to_v16i32_in_loop(ptr %src, ptr %dst) {
 ; CHECK-BE-NEXT:    ldr x9, [x0, x8]
 ; CHECK-BE-NEXT:    add x8, x8, #16
 ; CHECK-BE-NEXT:    cmp x8, #128
-; CHECK-BE-NEXT:    ubfx w11, w9, #12, #4
+; CHECK-BE-NEXT:    lsr x13, x9, #60
+; CHECK-BE-NEXT:    ubfx w12, w9, #12, #4
 ; CHECK-BE-NEXT:    lsr w14, w9, #28
-; CHECK-BE-NEXT:    lsr w10, w9, #8
-; CHECK-BE-NEXT:    ubfx x15, x9, #44, #4
-; CHECK-BE-NEXT:    lsr w12, w9, #24
-; CHECK-BE-NEXT:    lsr x13, x9, #40
-; CHECK-BE-NEXT:    fmov s0, w11
-; CHECK-BE-NEXT:    lsr x11, x9, #60
-; CHECK-BE-NEXT:    fmov s1, w14
-; CHECK-BE-NEXT:    fmov s2, w15
-; CHECK-BE-NEXT:    fmov s3, w11
-; CHECK-BE-NEXT:    lsr w11, w9, #20
-; CHECK-BE-NEXT:    mov v0.h[1], w10
-; CHECK-BE-NEXT:    lsr x10, x9, #56
-; CHECK-BE-NEXT:    mov v1.h[1], w12
-; CHECK-BE-NEXT:    lsr w12, w9, #4
-; CHECK-BE-NEXT:    mov v2.h[1], w13
-; CHECK-BE-NEXT:    mov v3.h[1], w10
-; CHECK-BE-NEXT:    lsr x10, x9, #36
-; CHECK-BE-NEXT:    mov v0.h[2], w12
-; CHECK-BE-NEXT:    lsr x12, x9, #52
-; CHECK-BE-NEXT:    mov v1.h[2], w11
-; CHECK-BE-NEXT:    mov v2.h[2], w10
-; CHECK-BE-NEXT:    lsr w10, w9, #16
-; CHECK-BE-NEXT:    lsr x11, x9, #32
-; CHECK-BE-NEXT:    mov v3.h[2], w12
-; CHECK-BE-NEXT:    mov v0.h[3], w9
-; CHECK-BE-NEXT:    lsr x9, x9, #48
-; CHECK-BE-NEXT:    mov v1.h[3], w10
-; CHECK-BE-NEXT:    mov v2.h[3], w11
-; CHECK-BE-NEXT:    add x10, x1, #32
+; CHECK-BE-NEXT:    ubfx x16, x9, #56, #4
+; CHECK-BE-NEXT:    ubfx x17, x9, #44, #4
+; CHECK-BE-NEXT:    ubfx w10, w9, #8, #4
+; CHECK-BE-NEXT:    fmov s0, w13
+; CHECK-BE-NEXT:    fmov s1, w12
+; CHECK-BE-NEXT:    fmov s2, w14
+; CHECK-BE-NEXT:    ubfx w11, w9, #24, #4
+; CHECK-BE-NEXT:    fmov s3, w17
+; CHECK-BE-NEXT:    ubfx x15, x9, #40, #4
+; CHECK-BE-NEXT:    ubfx w12, w9, #20, #4
+; CHECK-BE-NEXT:    ubfx x13, x9, #36, #4
+; CHECK-BE-NEXT:    mov v0.h[1], w16
+; CHECK-BE-NEXT:    mov v1.h[1], w10
+; CHECK-BE-NEXT:    mov v2.h[1], w11
+; CHECK-BE-NEXT:    ubfx x11, x9, #52, #4
+; CHECK-BE-NEXT:    ubfx w10, w9, #4, #4
+; CHECK-BE-NEXT:    mov v3.h[1], w15
+; CHECK-BE-NEXT:    mov v0.h[2], w11
+; CHECK-BE-NEXT:    mov v1.h[2], w10
+; CHECK-BE-NEXT:    ubfx x10, x9, #48, #4
+; CHECK-BE-NEXT:    mov v2.h[2], w12
+; CHECK-BE-NEXT:    mov v3.h[2], w13
+; CHECK-BE-NEXT:    and w11, w9, #0xf
+; CHECK-BE-NEXT:    ubfx w12, w9, #16, #4
+; CHECK-BE-NEXT:    ubfx x9, x9, #32, #4
+; CHECK-BE-NEXT:    mov v0.h[3], w10
+; CHECK-BE-NEXT:    mov v1.h[3], w11
+; CHECK-BE-NEXT:    mov v2.h[3], w12
 ; CHECK-BE-NEXT:    mov v3.h[3], w9
 ; CHECK-BE-NEXT:    add x9, x1, #48
-; CHECK-BE-NEXT:    ushll v0.4s, v0.4h, #0
+; CHECK-BE-NEXT:    bic v0.4h, #255, lsl #8
 ; CHECK-BE-NEXT:    ushll v1.4s, v1.4h, #0
 ; CHECK-BE-NEXT:    ushll v2.4s, v2.4h, #0
 ; CHECK-BE-NEXT:    ushll v3.4s, v3.4h, #0
-; CHECK-BE-NEXT:    and z0.s, z0.s, #0xf
-; CHECK-BE-NEXT:    and z1.s, z1.s, #0xf
-; CHECK-BE-NEXT:    and z2.s, z2.s, #0xf
-; CHECK-BE-NEXT:    and z3.s, z3.s, #0xf
-; CHECK-BE-NEXT:    st1 { v0.4s }, [x9]
-; CHECK-BE-NEXT:    add x9, x1, #16
-; CHECK-BE-NEXT:    st1 { v1.4s }, [x10]
-; CHECK-BE-NEXT:    st1 { v3.4s }, [x1]
-; CHECK-BE-NEXT:    add x1, x1, #64
+; CHECK-BE-NEXT:    ushll v0.4s, v0.4h, #0
+; CHECK-BE-NEXT:    st1 { v1.4s }, [x9]
+; CHECK-BE-NEXT:    add x9, x1, #32
 ; CHECK-BE-NEXT:    st1 { v2.4s }, [x9]
+; CHECK-BE-NEXT:    add x9, x1, #16
+; CHECK-BE-NEXT:    st1 { v3.4s }, [x9]
+; CHECK-BE-NEXT:    st1 { v0.4s }, [x1]
+; CHECK-BE-NEXT:    add x1, x1, #64
 ; CHECK-BE-NEXT:    b.ne .LBB13_1
 ; CHECK-BE-NEXT:  // %bb.2: // %exit
 ; CHECK-BE-NEXT:    ret

--- a/llvm/test/CodeGen/AArch64/zext.ll
+++ b/llvm/test/CodeGen/AArch64/zext.ll
@@ -259,11 +259,10 @@ define <3 x i32> @zext_v3i8_v3i32(<3 x i8> %a) {
 ; CHECK-SD-LABEL: zext_v3i8_v3i32:
 ; CHECK-SD:       // %bb.0: // %entry
 ; CHECK-SD-NEXT:    fmov s0, w0
-; CHECK-SD-NEXT:    movi v1.2d, #0x0000ff000000ff
 ; CHECK-SD-NEXT:    mov v0.h[1], w1
 ; CHECK-SD-NEXT:    mov v0.h[2], w2
+; CHECK-SD-NEXT:    bic v0.4h, #255, lsl #8
 ; CHECK-SD-NEXT:    ushll v0.4s, v0.4h, #0
-; CHECK-SD-NEXT:    and v0.16b, v0.16b, v1.16b
 ; CHECK-SD-NEXT:    ret
 ;
 ; CHECK-GI-LABEL: zext_v3i8_v3i32:
@@ -284,17 +283,16 @@ define <3 x i64> @zext_v3i8_v3i64(<3 x i8> %a) {
 ; CHECK-SD-LABEL: zext_v3i8_v3i64:
 ; CHECK-SD:       // %bb.0: // %entry
 ; CHECK-SD-NEXT:    fmov s0, w0
-; CHECK-SD-NEXT:    movi v1.2d, #0x000000000000ff
-; CHECK-SD-NEXT:    fmov s3, w2
-; CHECK-SD-NEXT:    movi v2.2d, #0000000000000000
+; CHECK-SD-NEXT:    movi d1, #0x0000ff000000ff
+; CHECK-SD-NEXT:    fmov s2, w2
 ; CHECK-SD-NEXT:    mov v0.s[1], w1
+; CHECK-SD-NEXT:    and v2.8b, v2.8b, v1.8b
+; CHECK-SD-NEXT:    and v0.8b, v0.8b, v1.8b
+; CHECK-SD-NEXT:    ushll v2.2d, v2.2s, #0
+; CHECK-SD-NEXT:    // kill: def $d2 killed $d2 killed $q2
 ; CHECK-SD-NEXT:    ushll v0.2d, v0.2s, #0
-; CHECK-SD-NEXT:    and v0.16b, v0.16b, v1.16b
-; CHECK-SD-NEXT:    ushll v1.2d, v3.2s, #0
-; CHECK-SD-NEXT:    mov v2.b[0], v1.b[0]
 ; CHECK-SD-NEXT:    mov d1, v0.d[1]
 ; CHECK-SD-NEXT:    // kill: def $d0 killed $d0 killed $q0
-; CHECK-SD-NEXT:    // kill: def $d2 killed $d2 killed $q2
 ; CHECK-SD-NEXT:    ret
 ;
 ; CHECK-GI-LABEL: zext_v3i8_v3i64:
@@ -415,11 +413,10 @@ define <3 x i32> @zext_v3i10_v3i32(<3 x i10> %a) {
 ; CHECK-SD-LABEL: zext_v3i10_v3i32:
 ; CHECK-SD:       // %bb.0: // %entry
 ; CHECK-SD-NEXT:    fmov s0, w0
-; CHECK-SD-NEXT:    movi v1.4s, #3, msl #8
 ; CHECK-SD-NEXT:    mov v0.h[1], w1
 ; CHECK-SD-NEXT:    mov v0.h[2], w2
+; CHECK-SD-NEXT:    bic v0.4h, #252, lsl #8
 ; CHECK-SD-NEXT:    ushll v0.4s, v0.4h, #0
-; CHECK-SD-NEXT:    and v0.16b, v0.16b, v1.16b
 ; CHECK-SD-NEXT:    ret
 ;
 ; CHECK-GI-LABEL: zext_v3i10_v3i32:
@@ -440,14 +437,14 @@ define <3 x i64> @zext_v3i10_v3i64(<3 x i10> %a) {
 ; CHECK-SD-LABEL: zext_v3i10_v3i64:
 ; CHECK-SD:       // %bb.0: // %entry
 ; CHECK-SD-NEXT:    fmov s0, w0
-; CHECK-SD-NEXT:    mov w8, #1023 // =0x3ff
-; CHECK-SD-NEXT:    fmov s1, w2
-; CHECK-SD-NEXT:    dup v2.2d, x8
+; CHECK-SD-NEXT:    movi v1.2s, #3, msl #8
+; CHECK-SD-NEXT:    fmov s2, w2
 ; CHECK-SD-NEXT:    mov v0.s[1], w1
-; CHECK-SD-NEXT:    zip1 v3.2s, v1.2s, v1.2s
+; CHECK-SD-NEXT:    and v2.8b, v2.8b, v1.8b
+; CHECK-SD-NEXT:    and v0.8b, v0.8b, v1.8b
+; CHECK-SD-NEXT:    ushll v2.2d, v2.2s, #0
+; CHECK-SD-NEXT:    // kill: def $d2 killed $d2 killed $q2
 ; CHECK-SD-NEXT:    ushll v0.2d, v0.2s, #0
-; CHECK-SD-NEXT:    and v0.16b, v0.16b, v2.16b
-; CHECK-SD-NEXT:    and v2.8b, v3.8b, v2.8b
 ; CHECK-SD-NEXT:    mov d1, v0.d[1]
 ; CHECK-SD-NEXT:    // kill: def $d0 killed $d0 killed $q0
 ; CHECK-SD-NEXT:    ret
@@ -1055,7 +1052,6 @@ define <16 x i32> @zext_v16i10_v16i32(<16 x i10> %a) {
 ; CHECK-SD-NEXT:    ldr w8, [sp, #48]
 ; CHECK-SD-NEXT:    mov v0.h[1], w1
 ; CHECK-SD-NEXT:    ldr w9, [sp, #16]
-; CHECK-SD-NEXT:    movi v4.4s, #3, msl #8
 ; CHECK-SD-NEXT:    mov v1.h[1], w5
 ; CHECK-SD-NEXT:    mov v2.h[1], w11
 ; CHECK-SD-NEXT:    mov v3.h[1], w10
@@ -1069,14 +1065,14 @@ define <16 x i32> @zext_v16i10_v16i32(<16 x i10> %a) {
 ; CHECK-SD-NEXT:    mov v1.h[3], w7
 ; CHECK-SD-NEXT:    mov v2.h[3], w9
 ; CHECK-SD-NEXT:    mov v3.h[3], w8
+; CHECK-SD-NEXT:    bic v0.4h, #252, lsl #8
+; CHECK-SD-NEXT:    bic v1.4h, #252, lsl #8
+; CHECK-SD-NEXT:    bic v2.4h, #252, lsl #8
+; CHECK-SD-NEXT:    bic v3.4h, #252, lsl #8
 ; CHECK-SD-NEXT:    ushll v0.4s, v0.4h, #0
 ; CHECK-SD-NEXT:    ushll v1.4s, v1.4h, #0
 ; CHECK-SD-NEXT:    ushll v2.4s, v2.4h, #0
 ; CHECK-SD-NEXT:    ushll v3.4s, v3.4h, #0
-; CHECK-SD-NEXT:    and v0.16b, v0.16b, v4.16b
-; CHECK-SD-NEXT:    and v1.16b, v1.16b, v4.16b
-; CHECK-SD-NEXT:    and v2.16b, v2.16b, v4.16b
-; CHECK-SD-NEXT:    and v3.16b, v3.16b, v4.16b
 ; CHECK-SD-NEXT:    ret
 ;
 ; CHECK-GI-LABEL: zext_v16i10_v16i32:
@@ -1127,40 +1123,39 @@ define <16 x i64> @zext_v16i10_v16i64(<16 x i10> %a) {
 ; CHECK-SD-NEXT:    fmov s1, w4
 ; CHECK-SD-NEXT:    ldr s2, [sp]
 ; CHECK-SD-NEXT:    fmov s3, w2
-; CHECK-SD-NEXT:    fmov s4, w0
-; CHECK-SD-NEXT:    ldr s5, [sp, #16]
-; CHECK-SD-NEXT:    ldr s6, [sp, #32]
-; CHECK-SD-NEXT:    ldr s7, [sp, #48]
+; CHECK-SD-NEXT:    fmov s5, w0
 ; CHECK-SD-NEXT:    add x8, sp, #8
-; CHECK-SD-NEXT:    mov v1.s[1], w5
-; CHECK-SD-NEXT:    mov v0.s[1], w7
-; CHECK-SD-NEXT:    add x9, sp, #24
-; CHECK-SD-NEXT:    mov v4.s[1], w1
-; CHECK-SD-NEXT:    mov v3.s[1], w3
-; CHECK-SD-NEXT:    add x10, sp, #40
-; CHECK-SD-NEXT:    add x11, sp, #56
+; CHECK-SD-NEXT:    ldr s6, [sp, #16]
+; CHECK-SD-NEXT:    ldr s7, [sp, #32]
+; CHECK-SD-NEXT:    ldr s16, [sp, #48]
 ; CHECK-SD-NEXT:    ld1 { v2.s }[1], [x8]
-; CHECK-SD-NEXT:    ld1 { v5.s }[1], [x9]
-; CHECK-SD-NEXT:    ld1 { v6.s }[1], [x10]
-; CHECK-SD-NEXT:    ld1 { v7.s }[1], [x11]
-; CHECK-SD-NEXT:    mov w8, #1023 // =0x3ff
-; CHECK-SD-NEXT:    dup v16.2d, x8
-; CHECK-SD-NEXT:    ushll v17.2d, v1.2s, #0
-; CHECK-SD-NEXT:    ushll v18.2d, v0.2s, #0
-; CHECK-SD-NEXT:    ushll v4.2d, v4.2s, #0
-; CHECK-SD-NEXT:    ushll v3.2d, v3.2s, #0
-; CHECK-SD-NEXT:    ushll v2.2d, v2.2s, #0
-; CHECK-SD-NEXT:    ushll v5.2d, v5.2s, #0
-; CHECK-SD-NEXT:    ushll v6.2d, v6.2s, #0
-; CHECK-SD-NEXT:    ushll v7.2d, v7.2s, #0
-; CHECK-SD-NEXT:    and v0.16b, v4.16b, v16.16b
-; CHECK-SD-NEXT:    and v1.16b, v3.16b, v16.16b
-; CHECK-SD-NEXT:    and v4.16b, v2.16b, v16.16b
-; CHECK-SD-NEXT:    and v2.16b, v17.16b, v16.16b
-; CHECK-SD-NEXT:    and v3.16b, v18.16b, v16.16b
-; CHECK-SD-NEXT:    and v5.16b, v5.16b, v16.16b
-; CHECK-SD-NEXT:    and v6.16b, v6.16b, v16.16b
-; CHECK-SD-NEXT:    and v7.16b, v7.16b, v16.16b
+; CHECK-SD-NEXT:    movi v4.2s, #3, msl #8
+; CHECK-SD-NEXT:    mov v1.s[1], w5
+; CHECK-SD-NEXT:    mov v5.s[1], w1
+; CHECK-SD-NEXT:    mov v3.s[1], w3
+; CHECK-SD-NEXT:    mov v0.s[1], w7
+; CHECK-SD-NEXT:    add x8, sp, #24
+; CHECK-SD-NEXT:    add x9, sp, #40
+; CHECK-SD-NEXT:    add x10, sp, #56
+; CHECK-SD-NEXT:    ld1 { v6.s }[1], [x8]
+; CHECK-SD-NEXT:    ld1 { v7.s }[1], [x9]
+; CHECK-SD-NEXT:    ld1 { v16.s }[1], [x10]
+; CHECK-SD-NEXT:    and v2.8b, v2.8b, v4.8b
+; CHECK-SD-NEXT:    and v17.8b, v1.8b, v4.8b
+; CHECK-SD-NEXT:    and v5.8b, v5.8b, v4.8b
+; CHECK-SD-NEXT:    and v3.8b, v3.8b, v4.8b
+; CHECK-SD-NEXT:    and v18.8b, v0.8b, v4.8b
+; CHECK-SD-NEXT:    and v6.8b, v6.8b, v4.8b
+; CHECK-SD-NEXT:    and v7.8b, v7.8b, v4.8b
+; CHECK-SD-NEXT:    and v16.8b, v16.8b, v4.8b
+; CHECK-SD-NEXT:    ushll v4.2d, v2.2s, #0
+; CHECK-SD-NEXT:    ushll v2.2d, v17.2s, #0
+; CHECK-SD-NEXT:    ushll v0.2d, v5.2s, #0
+; CHECK-SD-NEXT:    ushll v1.2d, v3.2s, #0
+; CHECK-SD-NEXT:    ushll v3.2d, v18.2s, #0
+; CHECK-SD-NEXT:    ushll v5.2d, v6.2s, #0
+; CHECK-SD-NEXT:    ushll v6.2d, v7.2s, #0
+; CHECK-SD-NEXT:    ushll v7.2d, v16.2s, #0
 ; CHECK-SD-NEXT:    ret
 ;
 ; CHECK-GI-LABEL: zext_v16i10_v16i64:

--- a/llvm/test/CodeGen/X86/vector-compress.ll
+++ b/llvm/test/CodeGen/X86/vector-compress.ll
@@ -3336,12 +3336,12 @@ define <32 x i16> @test_compress_v32i16(<32 x i16> %vec, <32 x i1> %mask, <32 x 
 ; AVX2-NEXT:    vmovaps %ymm4, {{[0-9]+}}(%rsp)
 ; AVX2-NEXT:    vmovaps %ymm3, (%rsp)
 ; AVX2-NEXT:    vextracti128 $1, %ymm2, %xmm3
-; AVX2-NEXT:    vpmovzxbw {{.*#+}} ymm4 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero,xmm3[4],zero,xmm3[5],zero,xmm3[6],zero,xmm3[7],zero,xmm3[8],zero,xmm3[9],zero,xmm3[10],zero,xmm3[11],zero,xmm3[12],zero,xmm3[13],zero,xmm3[14],zero,xmm3[15],zero
-; AVX2-NEXT:    vpbroadcastd {{.*#+}} ymm5 = [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]
-; AVX2-NEXT:    vpand %ymm5, %ymm4, %ymm4
-; AVX2-NEXT:    vpmovzxbw {{.*#+}} ymm6 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero,xmm2[4],zero,xmm2[5],zero,xmm2[6],zero,xmm2[7],zero,xmm2[8],zero,xmm2[9],zero,xmm2[10],zero,xmm2[11],zero,xmm2[12],zero,xmm2[13],zero,xmm2[14],zero,xmm2[15],zero
-; AVX2-NEXT:    vpand %ymm5, %ymm6, %ymm5
-; AVX2-NEXT:    vpaddw %ymm4, %ymm5, %ymm4
+; AVX2-NEXT:    vpbroadcastd {{.*#+}} xmm4 = [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]
+; AVX2-NEXT:    vpand %xmm4, %xmm3, %xmm5
+; AVX2-NEXT:    vpmovzxbw {{.*#+}} ymm5 = xmm5[0],zero,xmm5[1],zero,xmm5[2],zero,xmm5[3],zero,xmm5[4],zero,xmm5[5],zero,xmm5[6],zero,xmm5[7],zero,xmm5[8],zero,xmm5[9],zero,xmm5[10],zero,xmm5[11],zero,xmm5[12],zero,xmm5[13],zero,xmm5[14],zero,xmm5[15],zero
+; AVX2-NEXT:    vpand %xmm4, %xmm2, %xmm4
+; AVX2-NEXT:    vpmovzxbw {{.*#+}} ymm4 = xmm4[0],zero,xmm4[1],zero,xmm4[2],zero,xmm4[3],zero,xmm4[4],zero,xmm4[5],zero,xmm4[6],zero,xmm4[7],zero,xmm4[8],zero,xmm4[9],zero,xmm4[10],zero,xmm4[11],zero,xmm4[12],zero,xmm4[13],zero,xmm4[14],zero,xmm4[15],zero
+; AVX2-NEXT:    vpaddw %ymm5, %ymm4, %ymm4
 ; AVX2-NEXT:    vextracti128 $1, %ymm4, %xmm5
 ; AVX2-NEXT:    vpaddw %xmm5, %xmm4, %xmm4
 ; AVX2-NEXT:    vpshufd {{.*#+}} xmm5 = xmm4[2,3,2,3]

--- a/llvm/test/CodeGen/X86/vector-zext.ll
+++ b/llvm/test/CodeGen/X86/vector-zext.ll
@@ -2522,8 +2522,8 @@ define <8 x i64> @zext_8i6_to_8i64(i32 %x) nounwind uwtable readnone ssp {
 ; AVX512-NEXT:    vmovd %edi, %xmm0
 ; AVX512-NEXT:    vpbroadcastw %xmm0, %xmm0
 ; AVX512-NEXT:    vpaddw {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0 # [0,1,2,3,4,5,6,7]
+; AVX512-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0
 ; AVX512-NEXT:    vpmovzxwq {{.*#+}} zmm0 = xmm0[0],zero,zero,zero,xmm0[1],zero,zero,zero,xmm0[2],zero,zero,zero,xmm0[3],zero,zero,zero,xmm0[4],zero,zero,zero,xmm0[5],zero,zero,zero,xmm0[6],zero,zero,zero,xmm0[7],zero,zero,zero
-; AVX512-NEXT:    vpandq {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %zmm0, %zmm0
 ; AVX512-NEXT:    retq
 entry:
   %a = trunc i32 %x to i6


### PR DESCRIPTION
This existing fold was using a profitability check that did not work for vector operations. It can be profitable to fold (and (anyext V), c) -> (zext (and V, c)) if it allows the And to work on a narrower type and possibly for the zext to be folded into other operations.

The combine is profitable or equal if the zext is the same cost as a anyext. The old isTruncFree was removed as the value being truncated is a constant. A basic version of isNarrowingProfitable is added for AArch64 to allow vector types to fold providing that the result type is legal.