### PR TITLE
[mlir][NFC] Remove internal linkage from core header function templates

### DIFF
--- a/mlir/include/mlir/Bytecode/BytecodeImplementation.h
+++ b/mlir/include/mlir/Bytecode/BytecodeImplementation.h
@@ -443,8 +443,8 @@ public:
 
 /// Helper for resource handle reading that returns LogicalResult.
 template <typename T, typename... Ts>
-static LogicalResult readResourceHandle(DialectBytecodeReader &reader,
-                                        FailureOr<T> &value, Ts &&...params) {
+LogicalResult readResourceHandle(DialectBytecodeReader &reader,
+                                 FailureOr<T> &value, Ts &&...params) {
   FailureOr<T> handle = reader.readResourceHandle<T>();
   if (failed(handle))
     return failure();

--- a/mlir/include/mlir/IR/AffineMap.h
+++ b/mlir/include/mlir/IR/AffineMap.h
@@ -694,8 +694,8 @@ SmallVector<T> applyPermutationMap(AffineMap map, llvm::ArrayRef<T> source) {
 /// Calculates maximum dimension and symbol positions from the expressions
 /// in `exprsLists` and stores them in `maxDim` and `maxSym` respectively.
 template <typename AffineExprContainer>
-static void getMaxDimAndSymbol(ArrayRef<AffineExprContainer> exprsList,
-                               int64_t &maxDim, int64_t &maxSym) {
+void getMaxDimAndSymbol(ArrayRef<AffineExprContainer> exprsList,
+                        int64_t &maxDim, int64_t &maxSym) {
   for (const auto &exprs : exprsList) {
     for (auto expr : exprs) {
       expr.walk([&maxDim, &maxSym](AffineExpr e) {

--- a/mlir/include/mlir/IR/OpDefinition.h
+++ b/mlir/include/mlir/IR/OpDefinition.h
@@ -1607,8 +1607,8 @@ using detect_has_any_fold_trait =
 /// Returns the result of folding a trait that implements a `foldTrait` function
 /// that is specialized for operations that have a single result.
 template <typename Trait>
-static std::enable_if_t<detect_has_single_result_fold_trait<Trait>::value,
-                        LogicalResult>
+std::enable_if_t<detect_has_single_result_fold_trait<Trait>::value,
+                 LogicalResult>
 foldTrait(Operation *op, ArrayRef<Attribute> operands,
           SmallVectorImpl<OpFoldResult> &results) {
   assert(op->hasTrait<OpTrait::OneResult>() &&
@@ -1629,7 +1629,7 @@ foldTrait(Operation *op, ArrayRef<Attribute> operands,
 /// Returns the result of folding a trait that implements a generalized
 /// `foldTrait` function that is supports any operation type.
 template <typename Trait>
-static std::enable_if_t<detect_has_fold_trait<Trait>::value, LogicalResult>
+std::enable_if_t<detect_has_fold_trait<Trait>::value, LogicalResult>
 foldTrait(Operation *op, ArrayRef<Attribute> operands,
           SmallVectorImpl<OpFoldResult> &results) {
   // If a previous trait has already been folded and replaced this operation, we
@@ -1637,8 +1637,7 @@ foldTrait(Operation *op, ArrayRef<Attribute> operands,
   return results.empty() ? Trait::foldTrait(op, operands, results) : failure();
 }
 template <typename Trait>
-static inline std::enable_if_t<!detect_has_any_fold_trait<Trait>::value,
-                               LogicalResult>
+inline std::enable_if_t<!detect_has_any_fold_trait<Trait>::value, LogicalResult>
 foldTrait(Operation *, ArrayRef<Attribute>, SmallVectorImpl<OpFoldResult> &) {
   return failure();
 }
@@ -1646,8 +1645,8 @@ foldTrait(Operation *, ArrayRef<Attribute>, SmallVectorImpl<OpFoldResult> &) {
 /// Given a tuple type containing a set of traits, return the result of folding
 /// the given operation.
 template <typename... Ts>
-static LogicalResult foldTraits(Operation *op, ArrayRef<Attribute> operands,
-                                SmallVectorImpl<OpFoldResult> &results) {
+LogicalResult foldTraits(Operation *op, ArrayRef<Attribute> operands,
+                         SmallVectorImpl<OpFoldResult> &results) {
   return success((succeeded(foldTrait<Ts>(op, operands, results)) || ...));
 }
 

--- a/mlir/include/mlir/IR/PDLPatternMatch.h.inc
+++ b/mlir/include/mlir/IR/PDLPatternMatch.h.inc
@@ -642,8 +642,8 @@ void assertArgs(PatternRewriter &rewriter, ArrayRef<PDLValue> values,
 
 /// Store a single result within the result list.
 template <typename T>
-static LogicalResult processResults(PatternRewriter &rewriter,
-                                    PDLResultList &results, T &&value) {
+LogicalResult processResults(PatternRewriter &rewriter, PDLResultList &results,
+                             T &&value) {
   ProcessPDLValue<T>::processAsResult(rewriter, results,
                                       std::forward<T>(value));
   return success();
@@ -651,9 +651,8 @@ static LogicalResult processResults(PatternRewriter &rewriter,
 
 /// Store a std::pair<> as individual results within the result list.
 template <typename T1, typename T2>
-static LogicalResult processResults(PatternRewriter &rewriter,
-                                    PDLResultList &results,
-                                    std::pair<T1, T2> &&pair) {
+LogicalResult processResults(PatternRewriter &rewriter, PDLResultList &results,
+                             std::pair<T1, T2> &&pair) {
   if (failed(processResults(rewriter, results, std::move(pair.first))) ||
       failed(processResults(rewriter, results, std::move(pair.second))))
     return failure();
@@ -662,9 +661,8 @@ static LogicalResult processResults(PatternRewriter &rewriter,
 
 /// Store a std::tuple<> as individual results within the result list.
 template <typename... Ts>
-static LogicalResult processResults(PatternRewriter &rewriter,
-                                    PDLResultList &results,
-                                    std::tuple<Ts...> &&tuple) {
+LogicalResult processResults(PatternRewriter &rewriter, PDLResultList &results,
+                             std::tuple<Ts...> &&tuple) {
   auto applyFn = [&](auto &&...args) {
     return (succeeded(processResults(rewriter, results, std::move(args))) &&
             ...);
@@ -679,9 +677,8 @@ inline LogicalResult processResults(PatternRewriter &rewriter,
   return result;
 }
 template <typename T>
-static LogicalResult processResults(PatternRewriter &rewriter,
-                                    PDLResultList &results,
-                                    FailureOr<T> &&result) {
+LogicalResult processResults(PatternRewriter &rewriter, PDLResultList &results,
+                             FailureOr<T> &&result) {
   if (failed(result))
     return failure();
   return processResults(rewriter, results, std::move(*result));

--- a/mlir/include/mlir/Pass/PassOptions.h
+++ b/mlir/include/mlir/Pass/PassOptions.h
@@ -57,11 +57,11 @@ using has_stream_operator = llvm::is_detected<has_stream_operator_trait, T>;
 
 /// Utility methods for printing option values.
 template <typename ParserT>
-static void printOptionValue(raw_ostream &os, const bool &value) {
+void printOptionValue(raw_ostream &os, const bool &value) {
   os << (value ? StringRef("true") : StringRef("false"));
 }
 template <typename ParserT>
-static void printOptionValue(raw_ostream &os, const std::string &str) {
+void printOptionValue(raw_ostream &os, const std::string &str) {
   // Check if the string needs to be escaped before writing it to the ostream.
   const size_t spaceIndex = str.find_first_of(' ');
   const size_t escapeIndex =
@@ -75,7 +75,7 @@ static void printOptionValue(raw_ostream &os, const std::string &str) {
     os << "}";
 }
 template <typename ParserT, typename DataT>
-static void printOptionValue(raw_ostream &os, const DataT &value) {
+void printOptionValue(raw_ostream &os, const DataT &value) {
   if constexpr (has_stream_operator<DataT>::value)
     os << value;
   else


### PR DESCRIPTION
These are more of the cases fixed alongside #208001, which enabled -Wunused-template under -Wall. Each template is `static` in a widely included header, so clang warns in every TU that includes it without instantiating it. Dropping `static` gives them vague linkage and silences the warning.