### PR TITLE
[libc++] Disable -Werror when running historical benchmarks

### DIFF
--- a/libcxx/utils/ci/lnt/run-benchmarks
+++ b/libcxx/utils/ci/lnt/run-benchmarks
@@ -171,6 +171,7 @@ def main(argv):
                             '--param', f'compiler={args.compiler}',
                             '--param', 'optimization=speed',
                             '--param', 'std=c++26',
+                            '--param', 'enable_werror=False', # older versions of the library trigger new warnings, don't fail
                             artifacts / 'benchmarks/libcxx/test/benchmarks']
         if args.spec_dir is not None:
             cmd += ['--param', f'spec_dir={args.spec_dir}']


### PR DESCRIPTION
Older versions of the library trigger warnigns that were introduced in newer versions of Clang. That's expected, and building with -Werror simply causes the test suite to fail when it would run fine, with warnings.