### PR TITLE
[TargetParser] Recognize legacy GNU/Hurd triples

### DIFF
--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -1190,6 +1190,19 @@ std::string Triple::normalize(StringRef Str, CanonicalForm Form) {
   SmallVector<StringRef, 4> Components;
   Str.split(Components, '-');
 
+  // GNU/Hurd's config.guess output predates LLVM's canonical Hurd triple and
+  // uses the three-component forms *-unknown-gnu and *-pc-gnu.  Keep this
+  // special case narrow so triples such as x86_64-unknown-linux-gnu retain
+  // their normal interpretation.
+  bool IsGNUHurd = false;
+  if (Components.size() == 3 &&
+      (Components[1] == "unknown" || Components[1] == "pc") &&
+      Components[2].starts_with("gnu")) {
+    StringRef Version = Components[2].drop_front(strlen("gnu"));
+    IsGNUHurd = Version.empty() ||
+                Version.find_first_not_of("0123456789.") == StringRef::npos;
+  }
+
   // If the first component corresponds to a known architecture, preferentially
   // use it for the architecture.  If the second component corresponds to a
   // known vendor, preferentially use it for the vendor, etc.  This avoids silly
@@ -1326,6 +1339,12 @@ std::string Triple::normalize(StringRef Str, CanonicalForm Form) {
   if (Found[0] && !Found[1] && !Found[2] && Found[3] &&
       Components[1] == "none" && Components[2].empty())
     std::swap(Components[1], Components[2]);
+
+  if (IsGNUHurd) {
+    Components.resize(4);
+    Components[2] = "hurd";
+    OS = Triple::Hurd;
+  }
 
   // Replace empty components with "unknown" value.
   for (StringRef &C : Components)

--- a/llvm/unittests/TargetParser/TripleTest.cpp
+++ b/llvm/unittests/TargetParser/TripleTest.cpp
@@ -2091,6 +2091,14 @@ TEST(TripleTest, Normalization) {
             Triple::normalize("i386-mingw32")); // i386-pc-mingw32
   EXPECT_EQ("x86_64-unknown-linux-gnu",
             Triple::normalize("x86_64-linux-gnu")); // x86_64-pc-linux-gnu
+  EXPECT_EQ("x86_64-unknown-hurd-gnu",
+            Triple::normalize("x86_64-unknown-gnu"));
+  EXPECT_EQ("i686-unknown-hurd-gnu",
+            Triple::normalize("i686-unknown-gnu"));
+  EXPECT_EQ("i686-pc-hurd-gnu",
+            Triple::normalize("i686-pc-gnu"));
+  EXPECT_EQ("x86_64-unknown-hurd-gnu0.9",
+            Triple::normalize("x86_64-unknown-gnu0.9"));
   EXPECT_EQ("i486-unknown-linux-gnu",
             Triple::normalize("i486-linux-gnu")); // i486-pc-linux-gnu
   EXPECT_EQ("i386-redhat-linux",


### PR DESCRIPTION
Fixes #214440

### Summary

The bundled LLVM config.guess emits GNU/Hurd hosts using the legacy `*-unknown-gnu` and `*-pc-gnu` spellings. Triple normalization currently treats those as an unknown OS with a GNU environment, which makes `llvm-config --host-target` report a freestanding target.

Recognize only those legacy vendor forms as GNU/Hurd, preserve version suffixes such as `gnu0.9`, and leave ordinary triples such as `x86_64-unknown-linux-gnu` unchanged.

### Validation

- `TargetParserTests --gtest_filter=TripleTest.Normalization`
- Full `TargetParserTests`: 689 passed, 4 host-specific tests skipped on macOS
- Built `llvm-config` with `LLVM_HOST_TRIPLE=x86_64-unknown-gnu`; `--host-target` reports `x86_64-unknown-hurd-gnu`
- `git diff --check`

This change was written with OpenAI Codex assistance. I reviewed the implementation, regression tests, and validation as the human contributor before submitting it; the commit includes the project `Assisted-by: OpenAI Codex` trailer.