### PR TITLE
[lldb][minidump] Skip the new minidump tests on ARM

### DIFF
--- a/lldb/test/API/functionalities/process_save_core_minidump/partial_read/TestProcessSaveCoreMinidumpPartialRead.py
+++ b/lldb/test/API/functionalities/process_save_core_minidump/partial_read/TestProcessSaveCoreMinidumpPartialRead.py
@@ -43,6 +43,7 @@ class ProcessSaveCoreMinidumpPartialReadTestCase(TestBase):
         self.assertTrue(memory64_list_found, "minidump has no Memory64List stream")
 
     @skipUnlessPlatform(["linux"])
+    @skipIf(archs=["arm$"])
     def test_save_core_range_with_unreadable_tail(self):
         self.build()
         exe = self.getBuildArtifact("a.out")

--- a/lldb/test/API/functionalities/process_save_core_minidump/size_mismatch/TestProcessSaveCoreMinidumpSizeMismatch.py
+++ b/lldb/test/API/functionalities/process_save_core_minidump/size_mismatch/TestProcessSaveCoreMinidumpSizeMismatch.py
@@ -51,6 +51,7 @@ class ProcessSaveCoreMinidumpSizeMismatchTestCase(TestBase):
 
     @skipUnlessPlatform(["linux"])
     @skipIf(hostoslist=["windows"])
+    @skipIf(archs=["arm$"])
     def test_memory64_datasize_matches_written_bytes(self):
         self.build()
         exe = self.getBuildArtifact("a.out")


### PR DESCRIPTION
Apparently, the new tests introduced by #212641 and #212861 use features
not supported on ARM.

Example:
```
FAIL: test_save_core_range_with_unreadable_tail_dwarf (TestProcessSaveCoreMinidumpPartialRead.ProcessSaveCoreMinidumpPartialReadTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File ".../lldbtest.py", line 2171, in test_method
    return attrvalue(self)
  File ".../TestProcessSaveCoreMinidumpPartialRead.py", line 78, in test_save_core_range_with_unreadable_tail
    self.assertSuccess(process.SaveCore(options))
  File ".../lldbtest.py", line 3045, in assertSuccess
    self.fail(self._formatMessage(msg, "'{}' is not success".format(error)))
AssertionError: 'architecture arm not supported.' is not success
Config=arm-/home/tcwg-buildbot/worker/lldb-arm-ubuntu/build/bin/clang
```