### PR TITLE
[CIR] Forward-declare mlir::ModuleOp in CIRGenerator.h

### DIFF
--- a/clang/include/clang/CIR/CIRGenerator.h
+++ b/clang/include/clang/CIR/CIRGenerator.h
@@ -32,6 +32,7 @@ class CIRGenModule;
 
 namespace mlir {
 class MLIRContext;
+class ModuleOp;
 } // namespace mlir
 namespace cir {
 class CIRGenerator : public clang::ASTConsumer {


### PR DESCRIPTION
Add missing forward decl for `CIRGenerator.h` to make it self contained..

```sh
cat<<EOF >> test.cpp
#include "clang/CIR/CIRGenerator.h"

int main() {}
EOF

clang++ -std=c++17 -fsyntax-only test.cpp -I$(brew --prefix llvm)/include/

In file included from test.cpp:2:
/opt/homebrew/opt/llvm/include/clang/CIR/CIRGenerator.h:90:9: error: no type named 'ModuleOp' in namespace 'mlir'
   90 |   mlir::ModuleOp getModule() const;
      |   ~~~~~~^
1 error generated.
```

Found this while trying to create an Clang FrontEnd action in an out-of-tree project.
Went with a forward decl since its already done in the file + recommendations from https://llvm.org/docs/CodingStandards.html#minimal-list-of-includes