### PR TITLE
[mlir][SPIR-V] Fix swapped select operands in index.floordivs lowering

### DIFF
--- a/mlir/lib/Conversion/IndexToSPIRV/IndexToSPIRV.cpp
+++ b/mlir/lib/Conversion/IndexToSPIRV/IndexToSPIRV.cpp
@@ -228,7 +228,7 @@ struct ConvertIndexFloorDivSPattern final : OpConversionPattern<FloorDivSOp> {
     Value nNonZero = spirv::INotEqualOp::create(rewriter, loc, n, zero);
 
     Value cmp = spirv::LogicalAndOp::create(rewriter, loc, diffSign, nNonZero);
-    rewriter.replaceOpWithNewOp<spirv::SelectOp>(op, cmp, posRes, negRes);
+    rewriter.replaceOpWithNewOp<spirv::SelectOp>(op, cmp, negRes, posRes);
     return success();
   }
 };

--- a/mlir/test/Conversion/IndexToSPIRV/index-to-spirv.mlir
+++ b/mlir/test/Conversion/IndexToSPIRV/index-to-spirv.mlir
@@ -141,7 +141,7 @@ func.func @floordivs(%n: index, %m: index) -> index {
   // CHECK: %[[N_NON_ZERO:.*]] = spirv.INotEqual %[[N]], %[[ZERO]]
 
   // CHECK: %[[CMP:.*]] = spirv.LogicalAnd %[[DIFF_SIGN]], %[[N_NON_ZERO]]
-  // CHECK: %[[RESULT:.*]] = spirv.Select %[[CMP]], %[[POS_RES]], %[[NEG_RES]]
+  // CHECK: %[[RESULT:.*]] = spirv.Select %[[CMP]], %[[NEG_RES]], %[[POS_RES]]
   %result = index.floordivs %n, %m
 
   // %[[RESULTI:.*] = builtin.unrealized_conversion_cast %[[RESULT]]


### PR DESCRIPTION
Fix ConvertIndexFloorDivSPattern to select `negRes` when `cmp` is true

Previously operands were reversed, producing the wrong sign for the floordiv result whenever the negative result branch should've been taken