### PR TITLE
[lldb] Correct architecture comparison for Arm

### DIFF
--- a/lldb/test/API/tools/lldb-server/registers-target-xml-reading/TestGdbRemoteTargetXmlPacket.py
+++ b/lldb/test/API/tools/lldb-server/registers-target-xml-reading/TestGdbRemoteTargetXmlPacket.py
@@ -48,7 +48,7 @@ class TestGdbRemoteTargetXmlPacket(gdbremote_testcase.GdbRemoteTestCaseBase):
         }
         arch: str = self.getArchitecture()
         expected_arch = replaced_arch.get(arch, arch)
-        self.assertIn(architecture.text, expected_arch)
+        self.assertIn(expected_arch, architecture.text)
 
         feature = root.find("feature")
         self.assertIsNotNone(feature)

--- a/lldb/test/API/tools/lldb-server/registers-target-xml-reading/TestGdbRemoteTargetXmlPacket.py
+++ b/lldb/test/API/tools/lldb-server/registers-target-xml-reading/TestGdbRemoteTargetXmlPacket.py
@@ -48,7 +48,7 @@ class TestGdbRemoteTargetXmlPacket(gdbremote_testcase.GdbRemoteTestCaseBase):
         }
         arch: str = self.getArchitecture()
         expected_arch = replaced_arch.get(arch, arch)
-        self.assertIn(expected_arch, architecture.text)
+        self.assertTrue(architecture.text.startswith(expected_arch))
 
         feature = root.find("feature")
         self.assertIsNotNone(feature)


### PR DESCRIPTION
The arm architecture has different variants (arm64, armv8l e.t.c). We only check if it starts with the arm prefix.

Follow up to #210946