### PR TITLE
[libsycl] Run unittests using lit

### DIFF
--- a/libsycl/cmake/Modules/AddUnitTest.cmake
+++ b/libsycl/cmake/Modules/AddUnitTest.cmake
@@ -8,15 +8,9 @@ function(add_sycl_unittest test_name)
   target_compile_definitions(${test_name}
                               PRIVATE _LIBSYCL_BUILDING_LIBRARY)
 
-    add_custom_target(check-sycl-${test_name}
-        ${CMAKE_COMMAND} -E env
-        ${CMAKE_CURRENT_BINARY_DIR}/${test_name}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-        DEPENDS
-        ${test_name}
-    )
-
-  add_dependencies(check-sycl-unittests check-sycl-${test_name})
+  # Use a common suffix so the test executables can be discovered and run by
+  # lit's GoogleTest format (see unittests/lit.cfg.py).
+  set_target_properties(${test_name} PROPERTIES OUTPUT_NAME ${test_name}.unittests)
 
   target_link_libraries(${test_name}
     PRIVATE

--- a/libsycl/unittests/CMakeLists.txt
+++ b/libsycl/unittests/CMakeLists.txt
@@ -2,7 +2,7 @@ include(AddUnitTest)
 
 add_custom_target(LibsyclUnitTests)
 
-add_custom_target(check-sycl-unittests)
+set_target_properties(LibsyclUnitTests PROPERTIES FOLDER "libsycl/Tests/Unit")
 
 add_subdirectory(mock)
 add_subdirectory(device_selector)
@@ -10,3 +10,17 @@ add_subdirectory(event)
 add_subdirectory(platform)
 add_subdirectory(program_manager)
 add_subdirectory(queue)
+
+# The unit test executables are GoogleTest binaries that are discovered and run
+# by lit, mirroring how liboffload runs its unit tests.
+set(LIBSYCL_UNITTEST_DIR ${CMAKE_CURRENT_BINARY_DIR})
+configure_lit_site_cfg(
+  ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
+  ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
+  MAIN_CONFIG
+  ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py)
+
+add_lit_testsuite(check-sycl-unittests "Running libsycl unit tests"
+  ${CMAKE_CURRENT_BINARY_DIR}
+  EXCLUDE_FROM_CHECK_ALL
+  DEPENDS LibsyclUnitTests libsycl-toolchain)

--- a/libsycl/unittests/lit.cfg.py
+++ b/libsycl/unittests/lit.cfg.py
@@ -1,0 +1,38 @@
+# -*- Python -*-
+
+# Configuration file for the 'lit' test runner.
+
+import os
+
+import lit.formats
+
+# name: The name of this test suite.
+config.name = "SYCL-Unit"
+
+# suffixes: A list of file extensions to treat as test files.
+config.suffixes = []
+
+
+def prepend_executable_path(path):
+    old_path = config.environment.get("PATH")
+    config.environment["PATH"] = (
+        f"{path}{os.path.pathsep}{old_path}" if old_path else path
+    )
+
+
+# Windows doesn't have rpath so make sure the runtime deps for the unittest
+# executables, such as the SYCL runtime library and LLVMOffload.dll, are found.
+# The DLLs are placed in the compiler bin dir and the library dir.
+if config.operating_system == "Windows":
+    if config.bin_dir:
+        prepend_executable_path(config.bin_dir)
+    if config.library_dir:
+        prepend_executable_path(config.library_dir)
+
+# test_source_root: The root path where tests are located.
+# test_exec_root: The root path where tests should be run.
+config.test_exec_root = config.unittest_dir
+config.test_source_root = config.test_exec_root
+
+# testFormat: The test format to use to interpret tests.
+config.test_format = lit.formats.GoogleTest(config.llvm_build_mode, ".unittests")

--- a/libsycl/unittests/lit.site.cfg.py.in
+++ b/libsycl/unittests/lit.site.cfg.py.in
@@ -1,0 +1,10 @@
+@LIT_SITE_CFG_IN_HEADER@
+
+config.unittest_dir = "@LIBSYCL_UNITTEST_DIR@"
+config.llvm_build_mode = lit_config.substitute("@LLVM_BUILD_MODE@")
+config.bin_dir = "@LLVM_TOOLS_BINARY_DIR@"
+config.library_dir = "@LIBSYCL_LIBRARY_DIR@"
+config.operating_system = "@CMAKE_SYSTEM_NAME@"
+
+# Let the main config do the real work.
+lit_config.load_config(config, "@CMAKE_CURRENT_SOURCE_DIR@/lit.cfg.py")


### PR DESCRIPTION
Execute the libsycl unittests using `lit`, and set `PATH` to be correct on Windows.

The motiviation for this change is we need to add the compiler bin and lib directories to `PATH` on Windows as Linux relies on `rpath` which doesn't exist on Windows, and it's much easier to do that in `lit`.

This matches what `liboffload` does for their unit tests, see [here](https://github.com/llvm/llvm-project/blob/main/offload/test/unit/lit.cfg.py).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>