### PR TITLE
Exclude more libc math C++ builtins from compiler-rt Bazel overlay

### DIFF
--- a/utils/bazel/llvm-project-overlay/compiler-rt/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/compiler-rt/BUILD.bazel
@@ -478,7 +478,28 @@ filegroup(
 
 BUILTINS_LIBC_MATH_EXCLUDES = [
     # Sources requiring COMPILER_RT_USE_LIBC_MATH (e.g. LIBC_NAMESPACE::shared::*).
+    "lib/builtins/adddf3.cpp",
     "lib/builtins/addtf3.cpp",
+    "lib/builtins/addsf3.cpp",
+    "lib/builtins/divdf3.cpp",
+    "lib/builtins/divsf3.cpp",
+    "lib/builtins/divtf3.cpp",
+    "lib/builtins/extenddftf2.cpp",
+    "lib/builtins/extendsfdf2.cpp",
+    "lib/builtins/extendsftf2.cpp",
+    "lib/builtins/extendxftf2.cpp",
+    "lib/builtins/muldf3.cpp",
+    "lib/builtins/mulsf3.cpp",
+    "lib/builtins/multf3.cpp",
+    "lib/builtins/negdf2.cpp",
+    "lib/builtins/negsf2.cpp",
+    "lib/builtins/subdf3.cpp",
+    "lib/builtins/subsf3.cpp",
+    "lib/builtins/subtf3.cpp",
+    "lib/builtins/truncdfsf2.cpp",
+    "lib/builtins/trunctfdf2.cpp",
+    "lib/builtins/trunctfsf2.cpp",
+    "lib/builtins/trunctfxf2.cpp",
 ]
 
 # Source files for portable components of the compiler builtins library.


### PR DESCRIPTION
Building on work in https://github.com/llvm/llvm-project/pull/208861,
adds recently-added additional libc math C++ builtins from the
compiler-rt Bazel overlay.