### PR TITLE
[CIR][CUDA] Support built-in CUDA texture type

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -391,6 +391,20 @@ def CIR_VPtrType : CIR_Type<"VPtr", "vptr", [
 }
 
 //===----------------------------------------------------------------------===//
+// CUDADeviceTextureType
+//===----------------------------------------------------------------------===//
+
+def CIR_CUDADeviceTextureType :
+    CIR_Type<"CUDADeviceTexture", "cuda_texture"> {
+  let summary = "CUDA device texture reference type";
+  let description = [{
+    `!cir.cuda_texture` represents a CUDA built-in texture reference in CIR.
+    The type preserves texture semantics at the CIR level and is lowered to
+    the target device representation during lowering to LLVM IR.
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // BoolType
 //===----------------------------------------------------------------------===//
 
@@ -968,7 +982,8 @@ def CIR_AnyType : AnyTypeOf<[
   CIR_VoidType, CIR_BoolType, CIR_ArrayType, CIR_VectorType, CIR_IntType,
   CIR_AnyFloatType, CIR_PointerType, CIR_FuncType, CIR_StructType,
   CIR_UnionType,
-  CIR_ComplexType, CIR_VPtrType, CIR_DataMemberType, CIR_MethodType,
+  CIR_ComplexType, CIR_VPtrType, CIR_CUDADeviceTextureType,
+  CIR_DataMemberType, CIR_MethodType,
   CIR_EhTokenType, CIR_CleanupTokenType, CIR_CatchTokenType
 ]>;
 

--- a/clang/lib/CIR/CodeGen/CIRGenCUDANV.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCUDANV.cpp
@@ -119,6 +119,24 @@ public:
         cir::CUDADeviceVarKind::Surface,
     });
   }
+
+  void registerDeviceTex(const VarDecl *vd, cir::GlobalOp &var, bool isExtern) {
+    auto &builder = cgm.getBuilder();
+
+    var->setAttr(cir::CUDAVarRegistrationInfoAttr::getMnemonic(),
+                 cir::CUDAVarRegistrationInfoAttr::get(
+                     builder.getContext(),
+                     getDeviceSideName(cast<NamedDecl>(vd)),
+                     cir::CUDADeviceVarKind::Texture, isExtern,
+                     /*isConstant=*/false,
+                     /*isManaged=*/false));
+
+    deviceVars.push_back({
+        var,
+        vd,
+        cir::CUDADeviceVarKind::Texture,
+    });
+  }
 };
 
 } // namespace
@@ -484,8 +502,10 @@ void CIRGenNVCUDARuntime::handleVarRegistration(const VarDecl *vd,
       registerDeviceSurf(vd, var, !vd->hasDefinition());
 
   } else if (vd->getType()->isCUDADeviceBuiltinTextureType()) {
-    cgm.errorNYI(vd->getSourceRange(),
-                 "handleVarRegistration: Texture registration");
+    // Builtin textures and their template arguments are also registered
+    // with CUDA runtime.
+    if (!vd->hasExternalStorage())
+      registerDeviceTex(vd, var, !vd->hasDefinition());
   }
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
@@ -311,6 +311,10 @@ mlir::Type CIRGenTypes::convertType(QualType type) {
               cgm.getTargetCIRGenInfo().getCUDADeviceBuiltinSurfaceDeviceType())
         return ty;
     } else if (type->isCUDADeviceBuiltinTextureType()) {
+      if (mlir::Type ty =
+              cgm.getTargetCIRGenInfo().getCUDADeviceBuiltinTextureDeviceType())
+        return ty;
+
       assert(!cir::MissingFeatures::cudaTextureType());
     }
   }

--- a/clang/lib/CIR/CodeGen/TargetInfo.h
+++ b/clang/lib/CIR/CodeGen/TargetInfo.h
@@ -70,6 +70,10 @@ public:
     return nullptr;
   }
 
+  virtual mlir::Type getCUDADeviceBuiltinTextureDeviceType() const {
+    return nullptr;
+  }
+
   /// Determine whether a call to an unprototyped functions under
   /// the given calling convention should use the variadic
   /// convention or the non-variadic convention.

--- a/clang/lib/CIR/CodeGen/Targets/NVPTX.cpp
+++ b/clang/lib/CIR/CodeGen/Targets/NVPTX.cpp
@@ -77,6 +77,10 @@ public:
     return cir::IntType::get(&getABIInfo().cgt.getMLIRContext(), 64,
                              /*isSigned=*/true);
   }
+
+  mlir::Type getCUDADeviceBuiltinTextureDeviceType() const override {
+    return cir::CUDADeviceTextureType::get(&getABIInfo().cgt.getMLIRContext());
+  }
 };
 
 } // namespace

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -3694,6 +3694,9 @@ static void prepareTypeConverter(mlir::LLVMTypeConverter &converter,
     assert(!cir::MissingFeatures::addressSpace());
     return mlir::LLVM::LLVMPointerType::get(type.getContext());
   });
+  converter.addConversion([&](cir::CUDADeviceTextureType type) -> mlir::Type {
+    return mlir::IntegerType::get(type.getContext(), 64);
+  });
   converter.addConversion([&](cir::ArrayType type) -> mlir::Type {
     mlir::Type ty =
         convertTypeForMemory(converter, dataLayout, type.getElementType());

--- a/clang/test/CIR/CodeGenCUDA/texture.cu
+++ b/clang/test/CIR/CodeGenCUDA/texture.cu
@@ -1,0 +1,26 @@
+// REQUIRES: x86-registered-target
+// REQUIRES: nvptx-registered-target
+// RUN: %clang_cc1 -fclangir -std=c++11 -fcuda-is-device -triple nvptx64-nvidia-cuda -emit-cir -o - %s | FileCheck --check-prefix=CIR-DEVICE %s
+// RUN: %clang_cc1 -fclangir -std=c++11 -fcuda-is-device -triple nvptx64-nvidia-cuda -emit-llvm -o - %s | FileCheck --check-prefix=LLVM-DEVICE %s
+// RUN: %clang_cc1 -std=c++11 -fcuda-is-device -triple nvptx64-nvidia-cuda -emit-llvm -o - %s | FileCheck --check-prefix=OGCG-DEVICE %s
+
+struct textureReference {
+  int desc;
+};
+
+enum ReadMode {
+  ElementType = 0,
+  NormalizedFloat = 1
+};
+
+template <typename T, int dim = 1, ReadMode mode = ElementType>
+struct __attribute__((device_builtin_texture_type)) texture
+    : public textureReference {};
+
+texture<float, 2, NormalizedFloat> tex;
+
+// CIR-DEVICE: cir.global external target_address_space(1) @tex = #cir.undef : !cir.cuda_texture
+
+// CIR now matches OG CodeGen and emits undef for CUDA shadow variables.
+// LLVM-DEVICE: @tex ={{.*}} addrspace(1) externally_initialized global i64 undef
+// OGCG-DEVICE: @tex ={{.*}} addrspace(1) externally_initialized global i64 undef


### PR DESCRIPTION
Related: #179278

This patch adds initial support for CUDA built-in texture types in CIR for device-side compilation.

CUDA texture references are lowered to the NVPTX device-handle representation (`i64`), matching existing Clang CodeGen behavior.

## Changes

- Add `getCUDADeviceBuiltinTextureDeviceType()` target hook to `TargetCIRGenInfo`
- Implement NVPTX texture lowering in `NVPTXTargetCIRGenInfo`
- Handle CUDA built-in texture types in `CIRGenTypes::convertType`
- Add initial CUDA texture variable registration bookkeeping in `CIRGenNVCUDARuntime`
- Add CIR CUDA test coverage for device-side texture lowering

## Notes

- This patch implements initial device-side texture type lowering support
- Full CUDA runtime texture registration remains unsupported
- Texture registration metadata such as texture type and normalized mode is left for follow-up work
- TBAA handling for surface/texture types is left for follow-up work