### PR TITLE
[mlir] Fix `path` usage in unit test site config

### DIFF
--- a/mlir/test/Unit/lit.site.cfg.py.in
+++ b/mlir/test/Unit/lit.site.cfg.py.in
@@ -2,9 +2,9 @@
 
 import sys
 
-config.llvm_tools_dir = lit_config.substitute(path("@LLVM_TOOLS_DIR@"))
+config.llvm_tools_dir = lit_config.substitute(path(r"@LLVM_TOOLS_DIR@"))
 config.llvm_build_mode = lit_config.substitute("@LLVM_BUILD_MODE@")
-config.mlir_obj_root = path("@MLIR_BINARY_DIR@")
+config.mlir_obj_root = path(r"@MLIR_BINARY_DIR@")
 
 # Let the main config do the real work.
 lit_config.load_config(


### PR DESCRIPTION
The argument is supposed to be a raw string, so that Windows paths don't
get mis-interpreted as escape sequences. I introduced this mistake in
https://github.com/llvm/llvm-project/pull/212406, and CI caught the
issue for the top-level site config but not the unit test one. Fix it
there as well for consistency and to prevent any future issues.
