### PR TITLE
[MC] Make pseudo-probe divisions ordering stable

### DIFF
--- a/llvm/lib/MC/MCPseudoProbe.cpp
+++ b/llvm/lib/MC/MCPseudoProbe.cpp
@@ -216,9 +216,12 @@ void MCPseudoProbeSections::emit(MCObjectStreamer *MCOS) {
     Vec.emplace_back(ProbeSec.first, &ProbeSec.second);
   for (auto I : llvm::enumerate(MCOS->getAssembler()))
     I.value().setOrdinal(I.index());
-  llvm::sort(Vec, [](auto A, auto B) {
-    return A.first->getSection().getOrdinal() <
-           B.first->getSection().getOrdinal();
+  llvm::sort(Vec, [](const auto &A, const auto &B) {
+    const auto AOrdinal = A.first->getSection().getOrdinal();
+    const auto BOrdinal = B.first->getSection().getOrdinal();
+    if (AOrdinal != BOrdinal)
+      return AOrdinal < BOrdinal;
+    return A.first->getName() < B.first->getName();
   });
   for (auto [FuncSym, RootPtr] : Vec) {
     const auto &Root = *RootPtr;

--- a/llvm/lib/MC/MCPseudoProbe.cpp
+++ b/llvm/lib/MC/MCPseudoProbe.cpp
@@ -217,11 +217,8 @@ void MCPseudoProbeSections::emit(MCObjectStreamer *MCOS) {
   for (auto I : llvm::enumerate(MCOS->getAssembler()))
     I.value().setOrdinal(I.index());
   llvm::sort(Vec, [](const auto &A, const auto &B) {
-    const auto AOrdinal = A.first->getSection().getOrdinal();
-    const auto BOrdinal = B.first->getSection().getOrdinal();
-    if (AOrdinal != BOrdinal)
-      return AOrdinal < BOrdinal;
-    return A.first->getName() < B.first->getName();
+return std::make_pair(A.first->getSection().getOrdinal(), A.first->getName()) <
+         std::make_pair(B.first->getSection().getOrdinal(), B.first->getName());
   });
   for (auto [FuncSym, RootPtr] : Vec) {
     const auto &Root = *RootPtr;

--- a/llvm/lib/MC/MCPseudoProbe.cpp
+++ b/llvm/lib/MC/MCPseudoProbe.cpp
@@ -217,8 +217,10 @@ void MCPseudoProbeSections::emit(MCObjectStreamer *MCOS) {
   for (auto I : llvm::enumerate(MCOS->getAssembler()))
     I.value().setOrdinal(I.index());
   llvm::sort(Vec, [](const auto &A, const auto &B) {
-return std::make_pair(A.first->getSection().getOrdinal(), A.first->getName()) <
-         std::make_pair(B.first->getSection().getOrdinal(), B.first->getName());
+    return std::make_pair(A.first->getSection().getOrdinal(),
+                          A.first->getName()) <
+           std::make_pair(B.first->getSection().getOrdinal(),
+                          B.first->getName());
   });
   for (auto [FuncSym, RootPtr] : Vec) {
     const auto &Root = *RootPtr;

--- a/llvm/test/MC/ELF/pseudoprobe-order.s
+++ b/llvm/test/MC/ELF/pseudoprobe-order.s
@@ -1,0 +1,30 @@
+# RUN: rm -rf %t && split-file %s %t
+# RUN: llvm-mc -triple=x86_64 -filetype=obj %t/forward.s -o %t/forward.o
+# RUN: llvm-mc -triple=x86_64 -filetype=obj %t/reverse.s -o %t/reverse.o
+# RUN: cmp %t/forward.o %t/reverse.o
+
+#--- forward.s
+.text
+.globl z_func
+.type z_func,@function
+z_func:
+  nop
+.globl a_func
+.type a_func,@function
+a_func:
+  nop
+.pseudoprobe 1 1 0 0 z_func
+.pseudoprobe 2 1 0 0 a_func
+
+#--- reverse.s
+.text
+.globl z_func
+.type z_func,@function
+z_func:
+  nop
+.globl a_func
+.type a_func,@function
+a_func:
+  nop
+.pseudoprobe 2 1 0 0 a_func
+.pseudoprobe 1 1 0 0 z_func

--- a/llvm/test/MC/ELF/pseudoprobe-order.s
+++ b/llvm/test/MC/ELF/pseudoprobe-order.s
@@ -1,3 +1,4 @@
+# Test that pseudo-probe output does not depend on probe insertion order.
 # RUN: rm -rf %t && split-file %s %t
 # RUN: llvm-mc -triple=x86_64 -filetype=obj %t/forward.s -o %t/forward.o
 # RUN: llvm-mc -triple=x86_64 -filetype=obj %t/reverse.s -o %t/reverse.o


### PR DESCRIPTION
**Problem**

`MCPseudoProbeSections::emit` sorts probe divisions only by section ordinal. 

Functions sharing a section will have a nondeterministic `unordered_map` iteration order, producing *different .pseudo_probe bytes for identical inputs.*

**Solution**


Use the function symbol name as a stable tie-breaker when section ordinals match.

 Add an MC regression test that reverses pseudo-probe insertion order and requires byte-identical object files.