### PR TITLE
[Support] ScopedPrinter: support pretty-printing JSON

### DIFF
--- a/llvm/include/llvm/Support/JSON.h
+++ b/llvm/include/llvm/Support/JSON.h
@@ -984,8 +984,9 @@ class OStream {
  public:
   using Block = llvm::function_ref<void()>;
   // If IndentSize is nonzero, output is pretty-printed.
-  explicit OStream(llvm::raw_ostream &OS, unsigned IndentSize = 0)
-      : OS(OS), IndentSize(IndentSize) {
+  explicit OStream(llvm::raw_ostream &OS, unsigned IndentSize = 0,
+                   unsigned IndentLevel = 0)
+      : OS(OS), IndentSize(IndentSize), Indent(IndentSize * IndentLevel) {
     Stack.emplace_back();
   }
   ~OStream() {
@@ -1084,7 +1085,7 @@ private:
   llvm::StringRef PendingComment;
   llvm::raw_ostream &OS;
   unsigned IndentSize;
-  unsigned Indent = 0;
+  unsigned Indent;
 };
 
 /// Serializes this Value to JSON, writing it to the provided stream.

--- a/llvm/include/llvm/Support/ScopedPrinter.h
+++ b/llvm/include/llvm/Support/ScopedPrinter.h
@@ -399,6 +399,15 @@ public:
     printString(Label, to_string(Value));
   }
 
+  virtual void printObject(StringRef Label, const json::Value &Value) {
+    std::string PrettyValue;
+    raw_string_ostream PrettyStream(PrettyValue);
+    json::OStream(PrettyStream, 2, getIndentLevel()).value(Value);
+    startLine() << Label << ": "
+                << PrettyValue.substr(PrettyValue.find_first_not_of(" "))
+                << "\n";
+  }
+
   virtual void objectBegin() { scopedBegin('{'); }
 
   virtual void objectBegin(StringRef Label) { scopedBegin(Label, '{'); }
@@ -669,6 +678,10 @@ public:
   void printString(StringRef Value) override { JOS.value(Value); }
 
   void printString(StringRef Label, StringRef Value) override {
+    JOS.attribute(Label, Value);
+  }
+
+  void printObject(StringRef Label, const json::Value &Value) override {
     JOS.attribute(Label, Value);
   }
 

--- a/llvm/unittests/Support/ScopedPrinterTest.cpp
+++ b/llvm/unittests/Support/ScopedPrinterTest.cpp
@@ -1174,6 +1174,38 @@ TEST_F(ScopedPrinterTest, PrintObject) {
   verifyAll(ExpectedOut, JSONExpectedOut, PrintFunc);
 }
 
+TEST_F(ScopedPrinterTest, PrintJSONObject) {
+  auto PrintFunc = [](ScopedPrinter &W) {
+    W.printObject("Object",
+                  json::Value(json::Object(
+                      {{"Key", "Value"}, {"Key2", json::Array{1, 1, 2, 3}}})));
+  };
+
+  const char *ExpectedOut = R"(Object: {
+  "Key": "Value",
+  "Key2": [
+    1,
+    1,
+    2,
+    3
+  ]
+}
+)";
+
+  const char *JSONExpectedOut = R"({
+  "Object": {
+    "Key": "Value",
+    "Key2": [
+      1,
+      1,
+      2,
+      3
+    ]
+  }
+})";
+  verifyAll(ExpectedOut, JSONExpectedOut, PrintFunc);
+}
+
 TEST_F(ScopedPrinterTest, StartLine) {
   auto PrintFunc = [](ScopedPrinter &W) {
     W.startLine() << "|";


### PR DESCRIPTION
Add a specific printObject implementation for JSON values. For the default ScopedPrinter this supports printing with the existing indentation level. For JSONScopedPrinter it prints a raw attribute with no special handling.

I intend to use this for forthcoming support for FDO packakaging metadata support in readobj.