### PR TITLE
[AIX][SystemZ][Support] Check if file is dir on open instead of read

### DIFF
--- a/llvm/lib/Support/Unix/Path.inc
+++ b/llvm/lib/Support/Unix/Path.inc
@@ -1264,6 +1264,15 @@ Expected<file_t> openNativeFileForRead(const Twine &Name, OpenFlags Flags,
   std::error_code EC = openFileForRead(Name, ResultFD, Flags, RealPath);
   if (EC)
     return errorCodeToError(EC);
+// The underlying operation on these platforms allow opening directories
+// for reading in more cases than other platforms.
+#if defined(__MVS__) || defined(_AIX)
+  struct stat Status;
+  if (fstat(ResultFD, &Status) == -1)
+    return errorCodeToError(errnoAsErrorCode());
+  if (S_ISDIR(Status.st_mode))
+    return errorCodeToError(make_error_code(errc::is_a_directory));
+#endif
   return ResultFD;
 }
 
@@ -1282,15 +1291,6 @@ Expected<size_t> readNativeFile(file_t FD, MutableArrayRef<char> Buf) {
   ssize_t NumRead = sys::RetryAfterSignal(-1, ::read, FD, Buf.data(), Size);
   if (NumRead == -1)
     return errorCodeToError(errnoAsErrorCode());
-// The underlying operation on these platforms allow opening directories
-// for reading in more cases than other platforms.
-#if defined(__MVS__) || defined(_AIX)
-  struct stat Status;
-  if (fstat(FD, &Status) == -1)
-    return errorCodeToError(errnoAsErrorCode());
-  if (S_ISDIR(Status.st_mode))
-    return errorCodeToError(make_error_code(errc::is_a_directory));
-#endif
   return NumRead;
 }
 


### PR DESCRIPTION
See https://github.ibm.com/compiler/llvm-project/commit/678f19f08296fec299438130cf5943714c590b7e for the original change.

This original change would run fstat() on the file at every read().  In the non-error situation that is a lot of redundant checking.  Moving the fstat() check to openNativeFileForRead() will reduce the checks to a minimum and still produce the same error if someone tries to open a directory.