### PR TITLE
[analyzer] Only bind aggregate lifetime sources in LifetimeModeling for annotated functions

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
@@ -177,6 +177,13 @@ static bool hasAnyParamLifetimeAnnotated(const FunctionDecl *FD) {
   return lifetimes::implicitObjectParamIsLifetimeBound(FD);
 }
 
+static SmallVector<const MemRegion *, 4> getRegionsFromSVal(SVal Val,
+                                                            CheckerContext &C) {
+  if (const MemRegion *R = Val.getAsRegion())
+    return {R};
+  return lifetime_modeling::getRegionsFromAggrVal(Val, C);
+}
+
 void LifetimeModeling::checkPostCall(const CallEvent &Call,
                                      CheckerContext &C) const {
   ProgramStateRef State = C.getState();
@@ -202,13 +209,9 @@ void LifetimeModeling::checkPostCall(const CallEvent &Call,
     if (PVD->hasAttr<LifetimeBoundAttr>()) {
       unsigned Idx = PVD->getFunctionScopeIndex();
       SVal Arg = Call.getArgSVal(Idx);
-      if (const MemRegion *ArgValRegion = Arg.getAsRegion()) {
-        State = bindSource(State, RetVal, ArgValRegion);
-      } else {
-        auto AggrRegs = lifetime_modeling::getRegionsFromAggrVal(Arg, C);
-        for (const MemRegion *R : AggrRegs) {
-          State = bindSource(State, RetVal, R);
-        }
+
+      for (const MemRegion *R : getRegionsFromSVal(Arg, C)) {
+        State = bindSource(State, RetVal, R);
       }
     }
   }

--- a/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
@@ -193,8 +193,8 @@ void LifetimeModeling::checkPostCall(const CallEvent &Call,
 
   if (hasAnyParamLifetimeAnnotated(FD)) {
     auto AggrRegs = lifetime_modeling::getRegionsFromAggrVal(RetVal, C);
-    for (const MemRegion *I : AggrRegs) {
-      State = bindSource(State, RetVal, I);
+    for (const MemRegion *R : AggrRegs) {
+      State = bindSource(State, RetVal, R);
     }
   }
 
@@ -202,8 +202,14 @@ void LifetimeModeling::checkPostCall(const CallEvent &Call,
     if (PVD->hasAttr<LifetimeBoundAttr>()) {
       unsigned Idx = PVD->getFunctionScopeIndex();
       SVal Arg = Call.getArgSVal(Idx);
-      if (const MemRegion *ArgValRegion = Arg.getAsRegion())
+      if (const MemRegion *ArgValRegion = Arg.getAsRegion()) {
         State = bindSource(State, RetVal, ArgValRegion);
+      } else {
+        auto AggrRegs = lifetime_modeling::getRegionsFromAggrVal(Arg, C);
+        for (const MemRegion *R : AggrRegs) {
+          State = bindSource(State, RetVal, R);
+        }
+      }
     }
   }
 

--- a/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
@@ -192,8 +192,7 @@ void LifetimeModeling::checkPostCall(const CallEvent &Call,
   SVal RetVal = Call.getReturnValue();
 
   if (hasAnyParamLifetimeAnnotated(FD)) {
-    SmallVector<const MemRegion *, 4> AggrRegs =
-        lifetime_modeling::getRegionsFromAggrVal(RetVal, C);
+    auto AggrRegs = lifetime_modeling::getRegionsFromAggrVal(RetVal, C);
     for (const MemRegion *I : AggrRegs) {
       State = bindSource(State, RetVal, I);
     }

--- a/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
@@ -168,15 +168,13 @@ lifetime_modeling::getRegionsFromAggrVal(SVal Val, CheckerContext &C) {
   return {};
 }
 
-static bool isAnnotated(const FunctionDecl *FD) {
+static bool hasAnyParamLifetimeAnnotated(const FunctionDecl *FD) {
   for (const ParmVarDecl *PVD : FD->parameters()) {
     if (PVD->hasAttr<LifetimeBoundAttr>())
       return true;
   }
 
-  if (lifetimes::implicitObjectParamIsLifetimeBound(FD))
-    return true;
-  return false;
+  return lifetimes::implicitObjectParamIsLifetimeBound(FD);
 }
 
 void LifetimeModeling::checkPostCall(const CallEvent &Call,
@@ -193,7 +191,7 @@ void LifetimeModeling::checkPostCall(const CallEvent &Call,
 
   SVal RetVal = Call.getReturnValue();
 
-  if (isAnnotated(FD)) {
+  if (hasAnyParamLifetimeAnnotated(FD)) {
     SmallVector<const MemRegion *, 4> AggrRegs =
         lifetime_modeling::getRegionsFromAggrVal(RetVal, C);
     for (const MemRegion *I : AggrRegs) {

--- a/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/LifetimeModeling.cpp
@@ -168,6 +168,17 @@ lifetime_modeling::getRegionsFromAggrVal(SVal Val, CheckerContext &C) {
   return {};
 }
 
+static bool isAnnotated(const FunctionDecl *FD) {
+  for (const ParmVarDecl *PVD : FD->parameters()) {
+    if (PVD->hasAttr<LifetimeBoundAttr>())
+      return true;
+  }
+
+  if (lifetimes::implicitObjectParamIsLifetimeBound(FD))
+    return true;
+  return false;
+}
+
 void LifetimeModeling::checkPostCall(const CallEvent &Call,
                                      CheckerContext &C) const {
   ProgramStateRef State = C.getState();
@@ -181,11 +192,13 @@ void LifetimeModeling::checkPostCall(const CallEvent &Call,
     return;
 
   SVal RetVal = Call.getReturnValue();
-  SmallVector<const MemRegion *, 4> AggrRegs =
-      lifetime_modeling::getRegionsFromAggrVal(RetVal, C);
 
-  for (const MemRegion *I : AggrRegs) {
-    State = bindSource(State, RetVal, I);
+  if (isAnnotated(FD)) {
+    SmallVector<const MemRegion *, 4> AggrRegs =
+        lifetime_modeling::getRegionsFromAggrVal(RetVal, C);
+    for (const MemRegion *I : AggrRegs) {
+      State = bindSource(State, RetVal, I);
+    }
   }
 
   for (const ParmVarDecl *PVD : FD->parameters()) {

--- a/clang/test/Analysis/lifetime-bound.cpp
+++ b/clang/test/Analysis/lifetime-bound.cpp
@@ -476,30 +476,24 @@ struct Hold {
   int *ptr;
 };
 
-Hold retPtr(int &x) {
-  return Hold{&x};
-}
-// Even though there is a lifetime error in the function
+Hold takePtr(int &x);
+// Even though there might be a lifetime error in the function
 // UseAfterLifetimeEnd should not emit a warning for this
 // case since there is no annotation present in the code.
-// The warning present in the test comes from core.StackAddressEscape
-// checker.
 Hold return_by_val_no_ann() {
   int num = 4;
-  return retPtr(num);
-  // expected-warning@-1 {{Address of stack memory associated with local variable 'num' returned to caller}}
-  // expected-note@-2    {{Address of stack memory associated with local variable 'num' returned to caller}}
+  return takePtr(num);
 }
 
 int *unwrap(Hold i [[clang::lifetimebound]]) { return i.ptr; }
 
-// FIXME: If an annotated argument is a by-value struct then
-// Arg.getAsRegion() returns null for CompoundVal/LazyCompoundVal
-// and the dangling pointer will not be detected.
 int *arg_aggregate_lifetimebound() {
-  int local_num = 5;
+  int local_num = 5; // expected-note {{'local_num' initialized here}}
   Hold h{&local_num};
   return unwrap(h);
-  // expected-warning@-1 {{Address of stack memory associated with local variable 'local_num' returned to caller}}
-  // expected-note@-2    {{Address of stack memory associated with local variable 'local_num' returned to caller}}
+  // expected-warning@-1 {{Returning value bound to 'local_num' that will go out of scope}}
+  // expected-note@-2    {{Lifetime of 'local_num' ended here}}
+  // expected-note@-3    {{Value's lifetime bound to the lifetime of 'local_num' here}}
+  // expected-warning@-4 {{Address of stack memory associated with local variable 'local_num' returned to caller}}
+  // expected-note@-5    {{Address of stack memory associated with local variable 'local_num' returned to caller}}
 }

--- a/clang/test/Analysis/lifetime-bound.cpp
+++ b/clang/test/Analysis/lifetime-bound.cpp
@@ -476,13 +476,13 @@ struct Hold {
   int *ptr;
 };
 
-Hold takePtr(int &x);
+Hold takeRef(int &x);
 // Even though there might be a lifetime error in the function
 // UseAfterLifetimeEnd should not emit a warning for this
 // case since there is no annotation present in the code.
 Hold return_by_val_no_ann() {
   int num = 4;
-  return takePtr(num);
+  return takeRef(num);
 }
 
 int *unwrap(Hold i [[clang::lifetimebound]]) { return i.ptr; }

--- a/clang/test/Analysis/lifetime-bound.cpp
+++ b/clang/test/Analysis/lifetime-bound.cpp
@@ -471,3 +471,35 @@ IntPtrArr return_array_field_not_yet_detected() {
   // expected-note@-2    {{Address of stack memory associated with local variable 'z' returned to caller}}
   // expected-warning@-3 {{address of stack memory associated with local variable 'z' returned}}
 }
+
+struct Hold {
+  int *ptr;
+};
+
+Hold retPtr(int &x) {
+  return Hold{&x};
+}
+// Even though there is a lifetime error in the function
+// UseAfterLifetimeEnd should not emit a warning for this
+// case since there is no annotation present in the code.
+// The warning present in the test comes from core.StackAddressEscape
+// checker.
+Hold return_by_val_no_ann() {
+  int num = 4;
+  return retPtr(num);
+  // expected-warning@-1 {{Address of stack memory associated with local variable 'num' returned to caller}}
+  // expected-note@-2    {{Address of stack memory associated with local variable 'num' returned to caller}}
+}
+
+int *unwrap(Hold i [[clang::lifetimebound]]) { return i.ptr; }
+
+// FIXME: If an annotated argument is a by-value struct then
+// Arg.getAsRegion() returns null for CompoundVal/LazyCompoundVal
+// and the dangling pointer will not be detected.
+int *arg_aggregate_lifetimebound() {
+  int local_num = 5;
+  Hold h{&local_num};
+  return unwrap(h);
+  // expected-warning@-1 {{Address of stack memory associated with local variable 'local_num' returned to caller}}
+  // expected-note@-2    {{Address of stack memory associated with local variable 'local_num' returned to caller}}
+}


### PR DESCRIPTION
`checkPostCall` in `LifetimeModeling` should only bind aggregate lifetime sources if the code is annotated with `[[clang::lifetimebound]]`. If the code is not annotated then it's `DanglingPtrDeref`'s job to bind aggregate lifetime sources for functions (which will be done in a separate PR).  This PR is stacked on #214589.