### PR TITLE
[analyzer] Add aggregate lifetime source binding to DanglingPtrDeref

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/DanglingPtrDeref.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/DanglingPtrDeref.cpp
@@ -59,6 +59,14 @@ void DanglingPtrDeref::checkPostCall(const CallEvent &Call,
     return;
 
   for (unsigned Idx = 0; Idx < Call.getNumArgs(); Idx++) {
+    SmallVector<const MemRegion *, 4> AggrRegs =
+        lifetime_modeling::getRegionsFromAggrVal(Call.getArgSVal(Idx), C);
+    for (const MemRegion *I : AggrRegs) {
+      if (lifetime_modeling::isDeallocated(State, I))
+        if (ExplodedNode *N = C.generateNonFatalErrorNode())
+          reportUseAfterScope(I, Call.getArgExpr(Idx), N, C);
+    }
+
     if (const MemRegion *ArgRegion = Call.getArgSVal(Idx).getAsRegion())
       if (lifetime_modeling::isDeallocated(State, ArgRegion))
         if (ExplodedNode *N = C.generateNonFatalErrorNode())


### PR DESCRIPTION
Unannotated code is unhandled since #214824 restricts binding oof aggregate lifetime sources in `LifetimeModeling` only for annotated code. By binding aggregate lifetime sources in `DanglingPtrDeref` for unannotated code closes the gap in #214824. This PR is stacked on #214824