### PR TITLE
[lldb] Don't resolve dynamic type info if no named type exists

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CommonABIRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CommonABIRuntime.cpp
@@ -17,10 +17,12 @@ using namespace lldb_private;
 
 CommonABIRuntime::CommonABIRuntime(Process *process) : m_process(process) {}
 
-lldb::TypeSP
-CommonABIRuntime::LookupTypeByName(llvm::StringRef type_name,
-                                   lldb::ModuleSP preferred_module) const {
+lldb::TypeSP CommonABIRuntime::LookupTypeByName(llvm::StringRef type_name,
+                                                lldb::ModuleSP preferred_module,
+                                                bool &any_found) const {
   Log *log = GetLog(LLDBLog::Object);
+
+  any_found = false;
 
   ConstString const_lookup_name(type_name);
   TypeList class_types;
@@ -52,6 +54,7 @@ CommonABIRuntime::LookupTypeByName(llvm::StringRef type_name,
     LLDB_LOG(log, "Failed to find '{0}'", type_name);
     return {};
   }
+  any_found = true;
 
   if (class_types.GetSize() == 1) {
     type_sp = class_types.GetTypeAtIndex(0);

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CommonABIRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CommonABIRuntime.h
@@ -22,8 +22,14 @@ public:
 protected:
   CommonABIRuntime(Process *process);
 
+  /// Find a type by its name, preferably in `preferred_module`.
+  ///
+  /// `any_found` will be set to `true` if any type with the name is found.
+  /// Even if a type with the name was found, this function may return an empty
+  /// `TypeSP` if the type is not a C++ type.
   lldb::TypeSP LookupTypeByName(llvm::StringRef type_name,
-                                lldb::ModuleSP preferred_module) const;
+                                lldb::ModuleSP preferred_module,
+                                bool &any_found) const;
 
 protected:
   Process *m_process;

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/ItaniumABIRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/ItaniumABIRuntime.cpp
@@ -55,8 +55,13 @@ ItaniumABIRuntime::GetTypeInfo(ValueObject &in_value,
       lookup_name.append(class_name.data(), class_name.size());
 
       type_info.SetName(class_name);
+      bool any_found = false;
       TypeSP type_sp = LookupTypeByName(
-          class_name, vtable_info.symbol->CalculateSymbolContextModule());
+          class_name, vtable_info.symbol->CalculateSymbolContextModule(),
+          any_found);
+      if (!any_found)
+        return TypeAndOrName(); // Type is not dynamic.
+
       if (type_sp) {
         LLDB_LOGF(log,
                   "0x%16.16" PRIx64


### PR DESCRIPTION
Intends to fix the failure from https://github.com/llvm/llvm-project/pull/212013#issuecomment-5220617065.

I overlooked that the original code returned an empty `TypeAndOrName` if no type with the specified name was found: https://github.com/llvm/llvm-project/blob/9b1218ce69e06a22699bc196888fc0396d989c81/lldb/source/Plugins/LanguageRuntime/CPlusPlus/ItaniumABIRuntime.cpp#L84-L88

In my PR, I always returned a `TypeAndOrName` with a name set. With this change, we only set return a non-empty `TypeAndOrName` if there was any type with the specified name.