### PR TITLE
[LoopInfo] Do not enqueue unreachable nodes; fix infinite loop

### DIFF
--- a/llvm/include/llvm/Support/GenericLoopInfoImpl.h
+++ b/llvm/include/llvm/Support/GenericLoopInfoImpl.h
@@ -664,7 +664,7 @@ void LoopInfoBase<BlockT, LoopT>::analyze(
       // Whatever reaches a latch without passing the header is in the loop.
       for (unsigned I = 0; I != Worklist.size(); ++I)
         for (BlockT *Pred : inverse_children<BlockT *>(Worklist[I]))
-          //  Do not enqueue any unreachable nodes
+          // Do not enqueue any unreachable nodes.
           if (Blocks[num(Pred)])
             enqueue(Pred);
       // Without a backedge the header forms no loop at all.

--- a/llvm/include/llvm/Support/GenericLoopInfoImpl.h
+++ b/llvm/include/llvm/Support/GenericLoopInfoImpl.h
@@ -664,7 +664,9 @@ void LoopInfoBase<BlockT, LoopT>::analyze(
       // Whatever reaches a latch without passing the header is in the loop.
       for (unsigned I = 0; I != Worklist.size(); ++I)
         for (BlockT *Pred : inverse_children<BlockT *>(Worklist[I]))
-          enqueue(Pred);
+          //  Do not enqueue any unreachable nodes
+          if (Blocks[num(Pred)])
+            enqueue(Pred);
       // Without a backedge the header forms no loop at all.
       Info[H].Pos = HasBackedge ? IsHeader : OffPath;
       // Partition the header's blocks: the loop keeps the ones the traversal

--- a/llvm/unittests/Analysis/LoopInfoTest.cpp
+++ b/llvm/unittests/Analysis/LoopInfoTest.cpp
@@ -1646,3 +1646,45 @@ TEST(LoopInfoTest, TokenLCSSA) {
         InnerLoop->isRecursivelyLCSSAForm(DT, LI, /*IgnoreTokens*/ false));
   });
 }
+
+TEST(LoopInfoTest, UnreachableBlock) {
+  const char *ModuleStr =
+      "define void @irreducible_loop(i1 %c1, i1 %c2) {\n"
+      "dummy:\n"
+      "  br label %entry\n"
+      "entry:\n"
+      "  br i1 %c1, label %loop1, label %side_entry\n"
+      "dead_block:\n"
+      "  br label %latch1\n"
+      "loop1:\n"
+      "  br i1 %c2, label %body1, label %mid\n"
+      "body1:\n"
+      "  br label %latch1\n"
+      "latch1:\n"
+      "  br label %loop1\n"
+      "mid:\n"
+      "  br label %latch2\n"
+      "latch2:\n"
+      "  br label %loop1\n"
+      "side_entry:\n"
+      "  br label %mid\n"
+      "}\n";
+
+  LLVMContext Context;
+  SMDiagnostic Err;
+  std::unique_ptr<Module> M = parseAssemblyString(ModuleStr, Err, Context);
+  ASSERT_TRUE(M);
+  Function *F = M->getFunction("irreducible_loop");
+  ASSERT_TRUE(F);
+
+  // Delete 'dummy' block so that block 0 is deleted and no block in the CFG has index 0.
+  BasicBlock *Dummy = &F->getEntryBlock();
+  Dummy->eraseFromParent();
+
+  DominatorTree DT(*F);
+  // This used to hang infinitely in analyze() due to an unvisited block reaching a latch.
+  LoopInfo LI(DT);
+
+  // Basic verification that a loop was found.
+  EXPECT_FALSE(LI.empty());
+}

--- a/llvm/unittests/Analysis/LoopInfoTest.cpp
+++ b/llvm/unittests/Analysis/LoopInfoTest.cpp
@@ -1648,27 +1648,26 @@ TEST(LoopInfoTest, TokenLCSSA) {
 }
 
 TEST(LoopInfoTest, UnreachableBlock) {
-  const char *ModuleStr =
-      "define void @irreducible_loop(i1 %c1, i1 %c2) {\n"
-      "dummy:\n"
-      "  br label %entry\n"
-      "entry:\n"
-      "  br i1 %c1, label %loop1, label %side_entry\n"
-      "dead_block:\n"
-      "  br label %latch1\n"
-      "loop1:\n"
-      "  br i1 %c2, label %body1, label %mid\n"
-      "body1:\n"
-      "  br label %latch1\n"
-      "latch1:\n"
-      "  br label %loop1\n"
-      "mid:\n"
-      "  br label %latch2\n"
-      "latch2:\n"
-      "  br label %loop1\n"
-      "side_entry:\n"
-      "  br label %mid\n"
-      "}\n";
+  const char *ModuleStr = "define void @irreducible_loop(i1 %c1, i1 %c2) {\n"
+                          "dummy:\n"
+                          "  br label %entry\n"
+                          "entry:\n"
+                          "  br i1 %c1, label %loop1, label %side_entry\n"
+                          "dead_block:\n"
+                          "  br label %latch1\n"
+                          "loop1:\n"
+                          "  br i1 %c2, label %body1, label %mid\n"
+                          "body1:\n"
+                          "  br label %latch1\n"
+                          "latch1:\n"
+                          "  br label %loop1\n"
+                          "mid:\n"
+                          "  br label %latch2\n"
+                          "latch2:\n"
+                          "  br label %loop1\n"
+                          "side_entry:\n"
+                          "  br label %mid\n"
+                          "}\n";
 
   LLVMContext Context;
   SMDiagnostic Err;
@@ -1677,12 +1676,14 @@ TEST(LoopInfoTest, UnreachableBlock) {
   Function *F = M->getFunction("irreducible_loop");
   ASSERT_TRUE(F);
 
-  // Delete 'dummy' block so that block 0 is deleted and no block in the CFG has index 0.
+  // Delete 'dummy' block so that block 0 is deleted and no block in the CFG has
+  // index 0.
   BasicBlock *Dummy = &F->getEntryBlock();
   Dummy->eraseFromParent();
 
   DominatorTree DT(*F);
-  // This used to hang infinitely in analyze() due to an unvisited block reaching a latch.
+  // This used to hang infinitely in analyze() due to an unvisited block
+  // reaching a latch.
   LoopInfo LI(DT);
 
   // Basic verification that a loop was found.


### PR DESCRIPTION
Before this patch, we were enqueing unreachable nodes reaching into the latch nodes. Since unreachable nodes haven't been visited in the original DFS algorithm, we end up in an infinite loop within enqueue

This patch restores isReachableFromEntry() check from now removed discoverAndMapSubloop(). This should avoid infinite loop.

It's a regression from #212000 (5d582e4003b1cab59900d16fa3db9c3a9d16b462)