### PR TITLE
[CIR] Recognize canonical two-loop iteration domains

### DIFF
--- a/clang/include/clang/CIR/Dialect/Passes.h
+++ b/clang/include/clang/CIR/Dialect/Passes.h
@@ -46,6 +46,7 @@ std::unique_ptr<Pass> createGotoSolverPass();
 std::unique_ptr<Pass> createIdiomRecognizerPass();
 std::unique_ptr<Pass> createLibOptPass();
 std::unique_ptr<Pass> createLibOptPass(clang::ASTContext *astCtx);
+std::unique_ptr<Pass> createLoopOptPass();
 
 void populateCIRPreLoweringPasses(mlir::OpPassManager &pm);
 

--- a/clang/include/clang/CIR/Dialect/Passes.td
+++ b/clang/include/clang/CIR/Dialect/Passes.td
@@ -263,4 +263,40 @@ def CallConvLowering : Pass<"cir-call-conv-lowering", "mlir::ModuleOp"> {
   ];
 }
 
+def LoopOpt : Pass<"cir-loop-opt"> {
+  let summary = "Loop optimizations on structured CIR";
+  let description = [{
+    Driver for loop optimizations that run while `cir.for` still carries the
+    nest structure. Currently detects
+    counted two-loop nests and classifies the shape of the inner iteration
+    space. Detection is syntactic and reports the domain implied by the loop
+    control. Early exits may reduce the executed iteration set.
+    Transformation legality is outside this analysis.
+
+    Under the `test-annotate` option each detected nest's outer loop
+    receives a `cir.loopopt.test` attribute naming the recognized pattern,
+    and no transform is performed. For a nest counted by an `!s32i`
+    variable this reads
+
+    ```mlir
+    } {cir.loopopt.test = {kind = "inner_affine_upper", offset = 0 : i32,
+                           scale = 2 : i32}}
+    ```
+
+    The recognized kinds are `inner_affine_upper`, whose `scale` and
+    `offset` give the inner limit as `scale * outerIV + offset`,
+    `outer_iv_inner_start`, `inner_product_upper` and
+    `invariant_inner_start`. The `scale` and `offset` widths follow the
+    width of the loop counter, so a nest counted by an `!s64i` variable
+    records them as `i64`.
+  }];
+  let constructor = "mlir::createLoopOptPass()";
+  let dependentDialects = ["cir::CIRDialect"];
+  let options = [
+    Option<"testAnnotate", "test-annotate", "bool", /*default=*/"false",
+           "Attach a cir.loopopt.test attribute naming the recognized pattern "
+           "to the outer loop of each detected nest. For lit tests only.">
+  ];
+}
+
 #endif // CLANG_CIR_DIALECT_PASSES_TD

--- a/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
@@ -14,6 +14,9 @@ add_clang_library(MLIRCIRTransforms
   GotoSolver.cpp
   IdiomRecognizer.cpp
   LibOpt.cpp
+  LoopOpt/LoopAnalysis.cpp
+  LoopOpt/LoopNestPattern.cpp
+  LoopOpt/LoopOptPass.cpp
 
   DEPENDS
   MLIRCIRPassIncGen

--- a/clang/lib/CIR/Dialect/Transforms/LoopOpt/LoopAnalysis.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoopOpt/LoopAnalysis.cpp
@@ -1,0 +1,339 @@
+//===- LoopAnalysis.cpp - Counted loop recognition -----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "LoopAnalysis.h"
+
+#include "llvm/ADT/SmallPtrSet.h"
+
+using namespace cir;
+using namespace cir::loopopt;
+
+// Bounds compile time on pathological expressions.
+static constexpr unsigned kMaxExprDepth = 16;
+
+bool cir::loopopt::isOrdinaryAccess(cir::LoadOp load) {
+  return !load.getIsVolatile() && !load.getMemOrder();
+}
+
+bool cir::loopopt::isOrdinaryAccess(cir::StoreOp store) {
+  return !store.getIsVolatile() && !store.getMemOrder();
+}
+
+bool cir::loopopt::isSaturating(mlir::Operation *op) {
+  if (auto add = mlir::dyn_cast<cir::AddOp>(op))
+    return add.getSaturated();
+  if (auto sub = mlir::dyn_cast<cir::SubOp>(op))
+    return sub.getSaturated();
+  return false;
+}
+
+bool cir::loopopt::isOrdinaryLoadOfSlotIn(mlir::Value value, mlir::Value slot,
+                                          mlir::Operation *scope) {
+  auto load = value.getDefiningOp<cir::LoadOp>();
+  return load && isOrdinaryAccess(load) && load.getAddr() == slot &&
+         scope->isAncestor(load);
+}
+
+static mlir::FailureOr<llvm::APSInt> evalConstant(mlir::Value value,
+                                                  unsigned depth);
+
+static bool compatible(const llvm::APSInt &lhs, const llvm::APSInt &rhs) {
+  return lhs.getBitWidth() == rhs.getBitWidth() &&
+         lhs.isUnsigned() == rhs.isUnsigned();
+}
+
+mlir::FailureOr<llvm::APSInt>
+cir::loopopt::checkedAdd(const llvm::APSInt &lhs, const llvm::APSInt &rhs) {
+  if (!compatible(lhs, rhs))
+    return mlir::failure();
+  bool overflow = false;
+  llvm::APInt result = lhs.isUnsigned() ? lhs.uadd_ov(rhs, overflow)
+                                        : lhs.sadd_ov(rhs, overflow);
+  if (overflow)
+    return mlir::failure();
+  return llvm::APSInt(result, lhs.isUnsigned());
+}
+
+mlir::FailureOr<llvm::APSInt>
+cir::loopopt::checkedSub(const llvm::APSInt &lhs, const llvm::APSInt &rhs) {
+  if (!compatible(lhs, rhs))
+    return mlir::failure();
+  bool overflow = false;
+  llvm::APInt result = lhs.isUnsigned() ? lhs.usub_ov(rhs, overflow)
+                                        : lhs.ssub_ov(rhs, overflow);
+  if (overflow)
+    return mlir::failure();
+  return llvm::APSInt(result, lhs.isUnsigned());
+}
+
+mlir::FailureOr<llvm::APSInt>
+cir::loopopt::checkedMul(const llvm::APSInt &lhs, const llvm::APSInt &rhs) {
+  if (!compatible(lhs, rhs))
+    return mlir::failure();
+  bool overflow = false;
+  llvm::APInt result = lhs.isUnsigned() ? lhs.umul_ov(rhs, overflow)
+                                        : lhs.smul_ov(rhs, overflow);
+  if (overflow)
+    return mlir::failure();
+  return llvm::APSInt(result, lhs.isUnsigned());
+}
+
+// Apply an integer operation with the type's own width and signedness,
+// failing on any result the type cannot represent.
+static mlir::FailureOr<llvm::APSInt> applyChecked(mlir::Operation *op,
+                                                  const llvm::APSInt &lhs,
+                                                  const llvm::APSInt &rhs) {
+  if (mlir::isa<cir::AddOp>(op))
+    return checkedAdd(lhs, rhs);
+  if (mlir::isa<cir::SubOp>(op))
+    return checkedSub(lhs, rhs);
+  if (mlir::isa<cir::MulOp>(op))
+    return checkedMul(lhs, rhs);
+  if (mlir::isa<cir::DivOp>(op)) {
+    if (!compatible(lhs, rhs) || rhs.isZero())
+      return mlir::failure();
+    bool overflow = false;
+    llvm::APInt result =
+        lhs.isUnsigned() ? lhs.udiv(rhs) : lhs.sdiv_ov(rhs, overflow);
+    if (overflow)
+      return mlir::failure();
+    return llvm::APSInt(result, lhs.isUnsigned());
+  }
+  return mlir::failure();
+}
+
+static mlir::FailureOr<llvm::APSInt> evalConstant(mlir::Value value,
+                                                  unsigned depth) {
+  if (depth > kMaxExprDepth)
+    return mlir::failure();
+  auto intType = mlir::dyn_cast<cir::IntType>(value.getType());
+  if (!intType)
+    return mlir::failure();
+  mlir::Operation *def = value.getDefiningOp();
+  if (!def)
+    return mlir::failure();
+
+  if (auto constOp = mlir::dyn_cast<cir::ConstantOp>(def)) {
+    auto intAttr = mlir::dyn_cast<cir::IntAttr>(constOp.getValue());
+    if (!intAttr)
+      return mlir::failure();
+    return llvm::APSInt(intAttr.getValue(), intType.isUnsigned());
+  }
+
+  if (!mlir::isa<cir::AddOp, cir::SubOp, cir::MulOp, cir::DivOp>(def) ||
+      isSaturating(def))
+    return mlir::failure();
+  mlir::FailureOr<llvm::APSInt> lhs =
+      evalConstant(def->getOperand(0), depth + 1);
+  mlir::FailureOr<llvm::APSInt> rhs =
+      evalConstant(def->getOperand(1), depth + 1);
+  if (mlir::failed(lhs) || mlir::failed(rhs))
+    return mlir::failure();
+  return applyChecked(def, *lhs, *rhs);
+}
+
+mlir::FailureOr<llvm::APSInt>
+cir::loopopt::evaluateConstantIntExpr(mlir::Value value) {
+  return evalConstant(value, /*depth=*/0);
+}
+
+bool cir::loopopt::isSupportedControlOp(mlir::Operation *op) {
+  if (auto load = mlir::dyn_cast<cir::LoadOp>(op))
+    return isOrdinaryAccess(load) &&
+           mlir::isa<cir::IntType>(load.getResult().getType());
+  if (auto constOp = mlir::dyn_cast<cir::ConstantOp>(op))
+    return mlir::isa<cir::IntAttr>(constOp.getValue());
+  if (mlir::isa<cir::AddOp, cir::SubOp, cir::MulOp>(op))
+    return !isSaturating(op) &&
+           mlir::isa<cir::IntType>(op->getResult(0).getType());
+  // A divide is in the vocabulary only when it folds to a constant.
+  if (mlir::isa<cir::DivOp>(op))
+    return mlir::succeeded(evaluateConstantIntExpr(op->getResult(0)));
+  return false;
+}
+
+// Collect the backward slice within block. Values defined outside block
+// remain opaque for pattern-specific analysis.
+static void collectSliceInBlock(mlir::Value value, mlir::Block &block,
+                                llvm::SmallPtrSetImpl<mlir::Operation *> &out) {
+  llvm::SmallVector<mlir::Value, 8> worklist{value};
+  while (!worklist.empty()) {
+    mlir::Operation *def = worklist.pop_back_val().getDefiningOp();
+    if (!def || def->getBlock() != &block || !out.insert(def).second)
+      continue;
+    for (mlir::Value operand : def->getOperands())
+      worklist.push_back(operand);
+  }
+}
+
+static bool
+sliceReadsSlot(const llvm::SmallPtrSetImpl<mlir::Operation *> &slice,
+               mlir::Value slot) {
+  for (mlir::Operation *op : slice)
+    if (auto load = mlir::dyn_cast<cir::LoadOp>(op))
+      if (load.getAddr() == slot)
+        return true;
+  return false;
+}
+
+// Every write to the slot must be the matched step store or sit outside the
+// loop. The alloca use list is complete, so this pass also proves the
+// address never escapes.
+static bool slotWritesAreOnlyTheStep(mlir::Value ivSlot, cir::StoreOp stepStore,
+                                     cir::ForOp forOp) {
+  for (mlir::Operation *user : ivSlot.getUsers()) {
+    if (mlir::isa<cir::LoadOp>(user))
+      continue;
+    auto store = mlir::dyn_cast<cir::StoreOp>(user);
+    if (!store || store.getAddr() != ivSlot)
+      return false;
+    if (store != stepStore && forOp->isAncestor(store))
+      return false;
+  }
+  return true;
+}
+
+// Require one ordinary initialization store in the loop's parent block
+// before the loop. General reaching definitions need dominance analysis.
+static cir::StoreOp getInitStore(mlir::Value ivSlot, cir::ForOp forOp) {
+  cir::StoreOp init;
+  for (mlir::Operation *user : ivSlot.getUsers()) {
+    auto store = mlir::dyn_cast<cir::StoreOp>(user);
+    if (!store || forOp->isAncestor(store))
+      continue;
+    if (store->getBlock() != forOp->getBlock() ||
+        !store->isBeforeInBlock(forOp) || !isOrdinaryAccess(store) || init)
+      return {};
+    init = store;
+  }
+  return init;
+}
+
+// The recorded predicate reads as if the induction variable were the left
+// operand, so swapping compare operands swaps the recorded kind.
+static cir::CmpOpKind normalizeToIvOnLhs(cir::CmpOpKind kind) {
+  switch (kind) {
+  case cir::CmpOpKind::lt:
+    return cir::CmpOpKind::gt;
+  case cir::CmpOpKind::gt:
+    return cir::CmpOpKind::lt;
+  case cir::CmpOpKind::le:
+    return cir::CmpOpKind::ge;
+  case cir::CmpOpKind::ge:
+    return cir::CmpOpKind::le;
+  default:
+    return kind;
+  }
+}
+
+// Split the exit test around the induction variable and prove the condition
+// region computes nothing else.
+static mlir::FailureOr<ControlComparison>
+matchControlComparison(cir::ForOp forOp, mlir::Value ivSlot) {
+  mlir::Region &cond = forOp.getCond();
+  if (!cond.hasOneBlock())
+    return mlir::failure();
+  mlir::Block &condBlock = cond.front();
+  auto condOp = mlir::dyn_cast<cir::ConditionOp>(condBlock.getTerminator());
+  if (!condOp)
+    return mlir::failure();
+  // The compare must be rebuilt inside the condition region on every
+  // iteration. One hoisted before the loop is evaluated only once.
+  auto cmp = condOp.getCondition().getDefiningOp<cir::CmpOp>();
+  if (!cmp || cmp->getBlock() != &condBlock)
+    return mlir::failure();
+
+  llvm::SmallPtrSet<mlir::Operation *, 8> lhsSlice, rhsSlice;
+  collectSliceInBlock(cmp.getLhs(), condBlock, lhsSlice);
+  collectSliceInBlock(cmp.getRhs(), condBlock, rhsSlice);
+  bool lhsReadsIv = sliceReadsSlot(lhsSlice, ivSlot);
+  bool rhsReadsIv = sliceReadsSlot(rhsSlice, ivSlot);
+  // Exactly one side must vary with the induction variable.
+  if (lhsReadsIv == rhsReadsIv)
+    return mlir::failure();
+
+  ControlComparison result;
+  if (lhsReadsIv) {
+    result = {cmp.getLhs(), cmp.getRhs(), cmp.getKind()};
+  } else {
+    result = {cmp.getRhs(), cmp.getLhs(), normalizeToIvOnLhs(cmp.getKind())};
+  }
+
+  // The region may compute the two compare operands and nothing else, using
+  // only the supported vocabulary.
+  for (mlir::Operation &op : condBlock) {
+    if (&op == cmp.getOperation() || &op == condOp.getOperation())
+      continue;
+    if (!lhsSlice.contains(&op) && !rhsSlice.contains(&op))
+      return mlir::failure();
+    if (!isSupportedControlOp(&op))
+      return mlir::failure();
+  }
+  return result;
+}
+
+mlir::FailureOr<CountedLoop> cir::loopopt::matchCountedLoop(cir::ForOp forOp) {
+  // Match the frontend unit-step form exactly. The four operations are a
+  // load, an increment or decrement, a store, and a yield.
+  mlir::Region &step = forOp.getStep();
+  if (!step.hasOneBlock() || step.front().getOperations().size() != 4)
+    return mlir::failure();
+  auto stepLoad = mlir::dyn_cast<cir::LoadOp>(&step.front().front());
+  if (!stepLoad || !isOrdinaryAccess(stepLoad))
+    return mlir::failure();
+  mlir::Operation *update = stepLoad->getNextNode();
+  if (!mlir::isa<cir::IncOp, cir::DecOp>(update) ||
+      update->getOperand(0) != stepLoad.getResult())
+    return mlir::failure();
+  StepDirection direction = mlir::isa<cir::IncOp>(update)
+                                ? StepDirection::Increment
+                                : StepDirection::Decrement;
+  auto stepStore = mlir::dyn_cast<cir::StoreOp>(update->getNextNode());
+  if (!stepStore || !isOrdinaryAccess(stepStore) ||
+      stepStore.getValue() != update->getResult(0) ||
+      stepStore.getAddr() != stepLoad.getAddr())
+    return mlir::failure();
+  auto stepYield = mlir::dyn_cast<cir::YieldOp>(stepStore->getNextNode());
+  if (!stepYield || stepYield->getNumOperands() != 0)
+    return mlir::failure();
+  mlir::Value ivSlot = stepStore.getAddr();
+  if (!ivSlot.getDefiningOp<cir::AllocaOp>())
+    return mlir::failure();
+
+  mlir::FailureOr<ControlComparison> condition =
+      matchControlComparison(forOp, ivSlot);
+  if (mlir::failed(condition))
+    return mlir::failure();
+
+  if (!slotWritesAreOnlyTheStep(ivSlot, stepStore, forOp))
+    return mlir::failure();
+
+  cir::StoreOp initStore = getInitStore(ivSlot, forOp);
+  if (!initStore)
+    return mlir::failure();
+
+  return CountedLoop{forOp, ivSlot, initStore.getValue(), *condition,
+                     direction};
+}
+
+cir::ForOp cir::loopopt::getSingleInnerFor(cir::ForOp forOp) {
+  cir::ForOp inner;
+  bool multiple = false;
+  // Ancestry is checked against any loop op, so a for wrapped in scopes is
+  // found and a for inside a nested while is not claimed. The walk never
+  // visits forOp itself.
+  forOp.getBody().walk([&](cir::ForOp candidate) {
+    if (candidate->getParentOfType<cir::LoopOpInterface>() !=
+        mlir::cast<cir::LoopOpInterface>(forOp.getOperation()))
+      return;
+    if (inner)
+      multiple = true;
+    inner = candidate;
+  });
+  return multiple ? cir::ForOp{} : inner;
+}

--- a/clang/lib/CIR/Dialect/Transforms/LoopOpt/LoopAnalysis.h
+++ b/clang/lib/CIR/Dialect/Transforms/LoopOpt/LoopAnalysis.h
@@ -1,0 +1,98 @@
+//===- LoopAnalysis.h - Counted loop recognition ----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Recognizes canonical CIR loop-control shapes. The analysis identifies the
+// induction slot, initialization, condition, and unit step. The induction
+// slot must not escape and may be written inside the loop only by the
+// matched step.
+//
+// Body control flow and unrelated effects are not analyzed. The reported
+// domain is implied by the loop control. Legality is outside this analysis.
+// The trip count is not proven fixed here, because the non-induction side of
+// the exit test may still move. The classifiers in LoopNestPattern.h settle
+// that.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CLANG_LIB_CIR_DIALECT_TRANSFORMS_LOOPOPT_LOOPANALYSIS_H
+#define CLANG_LIB_CIR_DIALECT_TRANSFORMS_LOOPOPT_LOOPANALYSIS_H
+
+#include "mlir/Support/LogicalResult.h"
+#include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include "llvm/ADT/APSInt.h"
+
+namespace cir {
+namespace loopopt {
+
+enum class StepDirection { Increment, Decrement };
+
+/// The exit test split around the induction variable. ivDependentExpr is the
+/// whole side that reads it, such as `j` or `j * i`. nonIvExpr may read an
+/// enclosing loop's variable but not this one's. The predicate reads as
+/// though ivDependentExpr were on the left, so `n > j` is recorded as
+/// `j < n`.
+struct ControlComparison {
+  mlir::Value ivDependentExpr;
+  mlir::Value nonIvExpr;
+  cir::CmpOpKind predicate;
+};
+
+/// A loop that runs its exit compare every iteration and advances one slot
+/// by exactly one unit step, with no other write to that slot inside the
+/// loop.
+struct CountedLoop {
+  cir::ForOp forOp;
+  mlir::Value ivSlot;
+
+  mlir::Value initialExpr;
+
+  ControlComparison condition;
+
+  StepDirection direction;
+};
+
+/// True for a load or store that is neither volatile nor atomic.
+bool isOrdinaryAccess(cir::LoadOp load);
+bool isOrdinaryAccess(cir::StoreOp store);
+
+/// True for an add or subtract that clamps instead of wrapping.
+bool isSaturating(mlir::Operation *op);
+
+/// True for the operations a loop control expression may be built from.
+/// These are an integer constant, an ordinary load, non-saturating add,
+/// subtract and multiply, and a divide that folds to a constant. Casts are
+/// not supported.
+bool isSupportedControlOp(mlir::Operation *op);
+
+/// Fold an integer expression built from constants, preserving width and
+/// signedness. Overflow, division by zero and any unsupported operation fail
+/// rather than wrap or guess.
+mlir::FailureOr<llvm::APSInt> evaluateConstantIntExpr(mlir::Value value);
+
+/// Integer arithmetic that fails on overflow or on mismatched operands.
+mlir::FailureOr<llvm::APSInt> checkedAdd(const llvm::APSInt &lhs,
+                                         const llvm::APSInt &rhs);
+mlir::FailureOr<llvm::APSInt> checkedSub(const llvm::APSInt &lhs,
+                                         const llvm::APSInt &rhs);
+mlir::FailureOr<llvm::APSInt> checkedMul(const llvm::APSInt &lhs,
+                                         const llvm::APSInt &rhs);
+
+bool isOrdinaryLoadOfSlotIn(mlir::Value value, mlir::Value slot,
+                            mlir::Operation *scope);
+
+mlir::FailureOr<CountedLoop> matchCountedLoop(cir::ForOp forOp);
+
+/// The sole cir.for whose nearest enclosing loop is forOp. Looks through
+/// scopes and ignores loops nested under another loop. Null when the body
+/// holds no such loop, or more than one.
+cir::ForOp getSingleInnerFor(cir::ForOp forOp);
+
+} // namespace loopopt
+} // namespace cir
+
+#endif // CLANG_LIB_CIR_DIALECT_TRANSFORMS_LOOPOPT_LOOPANALYSIS_H

--- a/clang/lib/CIR/Dialect/Transforms/LoopOpt/LoopNestPattern.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoopOpt/LoopNestPattern.cpp
@@ -1,0 +1,394 @@
+//===- LoopNestPattern.cpp - Loop nest classification ---------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "LoopNestPattern.h"
+
+#include "llvm/ADT/SmallPtrSet.h"
+
+using namespace cir;
+using namespace cir::loopopt;
+
+// Bounds compile time on pathological expressions.
+static constexpr unsigned kMaxExprDepth = 16;
+
+// Two values may only be compared or combined when they agree on width and
+// signedness. The frontend guarantees that within one expression, but not
+// across the separately emitted parts of a nest.
+static bool sameForm(const llvm::APSInt &lhs, const llvm::APSInt &rhs) {
+  return lhs.getBitWidth() == rhs.getBitWidth() &&
+         lhs.isUnsigned() == rhs.isUnsigned();
+}
+
+static llvm::APSInt like(const llvm::APSInt &model, int64_t value) {
+  return llvm::APSInt(
+      llvm::APInt(model.getBitWidth(), value, /*isSigned=*/true),
+      model.isUnsigned());
+}
+
+static mlir::FailureOr<llvm::APSInt> constantOfType(mlir::Type type,
+                                                    int64_t value) {
+  auto intType = mlir::dyn_cast<cir::IntType>(type);
+  if (!intType)
+    return mlir::failure();
+  return llvm::APSInt(llvm::APInt(intType.getWidth(), value, /*isSigned=*/true),
+                      intType.isUnsigned());
+}
+
+// Two limits are the same limit when they are the same value, or when both
+// fold to the same number. The frontend emits a separate constant for each
+// mention of a bound, so identity alone would miss the common case.
+static bool limitsEquivalent(mlir::Value lhs, mlir::Value rhs) {
+  if (lhs == rhs)
+    return true;
+  mlir::FailureOr<llvm::APSInt> lhsValue = evaluateConstantIntExpr(lhs);
+  mlir::FailureOr<llvm::APSInt> rhsValue = evaluateConstantIntExpr(rhs);
+  if (mlir::failed(lhsValue) || mlir::failed(rhsValue))
+    return false;
+  return sameForm(*lhsValue, *rhsValue) && *lhsValue == *rhsValue;
+}
+
+namespace {
+/// An expression read as `coefficient * outerIV + offset`. A coefficient of
+/// zero means the expression does not read the outer induction variable.
+struct AffineTerm {
+  llvm::APSInt coefficient;
+  llvm::APSInt offset;
+};
+} // namespace
+
+static mlir::FailureOr<AffineTerm>
+matchAffineTerm(mlir::Value expr, mlir::Value outerIvSlot, cir::ForOp outerFor,
+                unsigned &ivLoads, unsigned depth) {
+  if (depth > kMaxExprDepth)
+    return mlir::failure();
+
+  // A subexpression that folds contributes only an offset. This is what
+  // collapses limits the frontend leaves unfolded, such as n - k.
+  if (mlir::FailureOr<llvm::APSInt> folded = evaluateConstantIntExpr(expr);
+      mlir::succeeded(folded)) {
+    mlir::FailureOr<llvm::APSInt> zero = constantOfType(expr.getType(), 0);
+    if (mlir::failed(zero))
+      return mlir::failure();
+    return AffineTerm{*zero, *folded};
+  }
+
+  mlir::Operation *def = expr.getDefiningOp();
+  if (!def)
+    return mlir::failure();
+
+  if (mlir::isa<cir::LoadOp>(def)) {
+    // The read has to happen inside the outer loop, so it observes the
+    // current iteration rather than a value snapshotted before the nest.
+    if (!isOrdinaryLoadOfSlotIn(expr, outerIvSlot, outerFor.getOperation()))
+      return mlir::failure();
+    mlir::FailureOr<llvm::APSInt> one = constantOfType(expr.getType(), 1);
+    mlir::FailureOr<llvm::APSInt> zero = constantOfType(expr.getType(), 0);
+    if (mlir::failed(one) || mlir::failed(zero))
+      return mlir::failure();
+    ++ivLoads;
+    return AffineTerm{*one, *zero};
+  }
+
+  // Checked here as well as in the condition vocabulary, because an affine
+  // limit may be computed outside the condition block.
+  if (!mlir::isa<cir::AddOp, cir::SubOp, cir::MulOp>(def) || isSaturating(def))
+    return mlir::failure();
+  mlir::FailureOr<AffineTerm> lhs = matchAffineTerm(
+      def->getOperand(0), outerIvSlot, outerFor, ivLoads, depth + 1);
+  mlir::FailureOr<AffineTerm> rhs = matchAffineTerm(
+      def->getOperand(1), outerIvSlot, outerFor, ivLoads, depth + 1);
+  if (mlir::failed(lhs) || mlir::failed(rhs))
+    return mlir::failure();
+
+  mlir::FailureOr<llvm::APSInt> coefficient = mlir::failure();
+  mlir::FailureOr<llvm::APSInt> offset = mlir::failure();
+  if (mlir::isa<cir::AddOp>(def)) {
+    coefficient = checkedAdd(lhs->coefficient, rhs->coefficient);
+    offset = checkedAdd(lhs->offset, rhs->offset);
+  } else if (mlir::isa<cir::SubOp>(def)) {
+    coefficient = checkedSub(lhs->coefficient, rhs->coefficient);
+    offset = checkedSub(lhs->offset, rhs->offset);
+  } else {
+    // Only one factor may vary, otherwise the expression is not affine.
+    bool lhsIsConstant = lhs->coefficient.isZero();
+    bool rhsIsConstant = rhs->coefficient.isZero();
+    if (!lhsIsConstant && !rhsIsConstant)
+      return mlir::failure();
+    coefficient = lhsIsConstant ? checkedMul(rhs->coefficient, lhs->offset)
+                                : checkedMul(lhs->coefficient, rhs->offset);
+    offset = checkedMul(lhs->offset, rhs->offset);
+  }
+  if (mlir::failed(coefficient) || mlir::failed(offset))
+    return mlir::failure();
+  return AffineTerm{*coefficient, *offset};
+}
+
+// Read expr as a positive affine function of the outer induction variable,
+// normalized to coefficient * outerIV + offset.
+static mlir::FailureOr<AffineOuterIVRelation>
+matchAffineInSlot(mlir::Value expr, mlir::Value outerIvSlot,
+                  cir::ForOp outerFor) {
+  unsigned ivLoads = 0;
+  mlir::FailureOr<AffineTerm> term =
+      matchAffineTerm(expr, outerIvSlot, outerFor, ivLoads, /*depth=*/0);
+  if (mlir::failed(term))
+    return mlir::failure();
+  // Require exactly one mention of the outer variable, so a repeated form
+  // such as i + i is not recognized.
+  if (ivLoads != 1)
+    return mlir::failure();
+  if (term->coefficient.isZero() || term->coefficient.isNegative())
+    return mlir::failure();
+  return AffineOuterIVRelation{term->coefficient, term->offset};
+}
+
+static mlir::Value resolveInvariantSource(mlir::Value slot, cir::ForOp loop,
+                                          mlir::Operation *use,
+                                          mlir::DominanceInfo &dominance) {
+  if (!slot.getDefiningOp<cir::AllocaOp>())
+    return {};
+
+  // The alloca use list is complete. Require one ordinary store and only
+  // ordinary loads to prove that the stored argument remains fixed.
+  cir::StoreOp writer;
+  for (mlir::Operation *user : slot.getUsers()) {
+    if (auto load = mlir::dyn_cast<cir::LoadOp>(user)) {
+      if (!isOrdinaryAccess(load) || load.getAddr() != slot)
+        return {};
+      continue;
+    }
+    auto store = mlir::dyn_cast<cir::StoreOp>(user);
+    if (!store || store.getAddr() != slot || store.getValue() == slot)
+      return {};
+    if (!isOrdinaryAccess(store) || writer)
+      return {};
+    writer = store;
+  }
+  if (!writer || loop->isAncestor(writer))
+    return {};
+  if (!dominance.dominates(writer.getOperation(), use) ||
+      !dominance.dominates(writer.getOperation(), loop.getOperation()))
+    return {};
+
+  // Only function arguments are recognized as invariant sources.
+  auto argument = mlir::dyn_cast<mlir::BlockArgument>(writer.getValue());
+  if (!argument || !mlir::isa<cir::FuncOp>(argument.getOwner()->getParentOp()))
+    return {};
+  return argument;
+}
+
+static bool isIncreasingStrictLess(const CountedLoop &loop) {
+  return loop.direction == StepDirection::Increment &&
+         loop.condition.predicate == cir::CmpOpKind::lt;
+}
+
+// Every recognized domain is reasoned about with signed arithmetic, so an
+// unsigned counter is left unrecognized rather than assumed to behave.
+static bool hasSignedControlType(const CountedLoop &loop) {
+  auto type =
+      mlir::dyn_cast<cir::IntType>(loop.condition.ivDependentExpr.getType());
+  return type && type.isSigned();
+}
+
+static bool comparesDirectIv(const CountedLoop &loop) {
+  cir::ForOp forOp = loop.forOp;
+  return isOrdinaryLoadOfSlotIn(loop.condition.ivDependentExpr, loop.ivSlot,
+                                forOp.getOperation());
+}
+
+// The loop counts from a known value up to a known value, over at least one
+// iteration.
+static mlir::FailureOr<std::pair<llvm::APSInt, llvm::APSInt>>
+constantDomain(const CountedLoop &loop) {
+  mlir::FailureOr<llvm::APSInt> first =
+      evaluateConstantIntExpr(loop.initialExpr);
+  mlir::FailureOr<llvm::APSInt> limit =
+      evaluateConstantIntExpr(loop.condition.nonIvExpr);
+  if (mlir::failed(first) || mlir::failed(limit) || !sameForm(*first, *limit))
+    return mlir::failure();
+  if (!(*first < *limit))
+    return mlir::failure();
+  return std::make_pair(*first, *limit);
+}
+
+static bool startsAtZero(const CountedLoop &loop) {
+  mlir::FailureOr<llvm::APSInt> first =
+      evaluateConstantIntExpr(loop.initialExpr);
+  return mlir::succeeded(first) && first->isZero();
+}
+
+// Shared entry conditions for every pattern. Both loops count up under a
+// strict less-than over signed values, and the outer loop compares its own
+// variable directly. Each pattern decides separately whether it also needs a
+// constant outer range.
+static bool matchCommonPreconditions(const CountedLoop &outer,
+                                     const CountedLoop &inner) {
+  return isIncreasingStrictLess(outer) && isIncreasingStrictLess(inner) &&
+         hasSignedControlType(outer) && hasSignedControlType(inner) &&
+         comparesDirectIv(outer);
+}
+
+static mlir::FailureOr<LoopNestPattern>
+matchInnerAffineUpper(const CountedLoop &outer, const CountedLoop &inner) {
+  if (!comparesDirectIv(inner))
+    return mlir::failure();
+  // The outer range is needed here to bound the inner limit.
+  mlir::FailureOr<std::pair<llvm::APSInt, llvm::APSInt>> outerDomain =
+      constantDomain(outer);
+  if (mlir::failed(outerDomain))
+    return mlir::failure();
+
+  mlir::FailureOr<AffineOuterIVRelation> affine =
+      matchAffineInSlot(inner.condition.nonIvExpr, outer.ivSlot, outer.forOp);
+  if (mlir::failed(affine) || !startsAtZero(inner))
+    return mlir::failure();
+
+  // The limit is evaluated once per outer iteration, so it has to stay
+  // representable across the whole outer range.
+  const llvm::APSInt &first = outerDomain->first;
+  const llvm::APSInt &limit = outerDomain->second;
+  if (!sameForm(affine->coefficient, first))
+    return mlir::failure();
+  mlir::FailureOr<llvm::APSInt> last = checkedSub(limit, like(limit, 1));
+  if (mlir::failed(last))
+    return mlir::failure();
+  auto evaluateAt = [&](const llvm::APSInt &point) {
+    mlir::FailureOr<llvm::APSInt> scaled =
+        checkedMul(affine->coefficient, point);
+    if (mlir::failed(scaled))
+      return mlir::FailureOr<llvm::APSInt>(mlir::failure());
+    return checkedAdd(*scaled, affine->offset);
+  };
+  if (mlir::failed(evaluateAt(first)) || mlir::failed(evaluateAt(*last)))
+    return mlir::failure();
+
+  return LoopNestPattern{outer, inner, LoopNestPatternKind::InnerAffineUpper,
+                         *affine};
+}
+
+// No constant outer range is required here. Demanding one would drop the
+// middle pair of a symmetric triple nest. The shared limit keeps both loops
+// counted, since it folds to a constant or is one value computed outside
+// them.
+static mlir::FailureOr<LoopNestPattern>
+matchOuterIVInnerStart(const CountedLoop &outer, const CountedLoop &inner) {
+  if (!comparesDirectIv(inner))
+    return mlir::failure();
+
+  // The inner loop walks from the current outer value to the shared limit.
+  cir::ForOp outerFor = outer.forOp;
+  if (!isOrdinaryLoadOfSlotIn(inner.initialExpr, outer.ivSlot,
+                              outerFor.getOperation()))
+    return mlir::failure();
+  if (!limitsEquivalent(outer.condition.nonIvExpr, inner.condition.nonIvExpr))
+    return mlir::failure();
+
+  return LoopNestPattern{outer, inner, LoopNestPatternKind::OuterIVInnerStart,
+                         std::nullopt};
+}
+
+static mlir::FailureOr<LoopNestPattern>
+matchInnerProductUpper(const CountedLoop &outer, const CountedLoop &inner) {
+  // The outer range is needed here to bound the largest product computed.
+  mlir::FailureOr<std::pair<llvm::APSInt, llvm::APSInt>> outerDomain =
+      constantDomain(outer);
+  if (mlir::failed(outerDomain))
+    return mlir::failure();
+
+  // Exactly the product of the two counters, in either operand order, with
+  // nothing else folded in.
+  auto product = inner.condition.ivDependentExpr.getDefiningOp<cir::MulOp>();
+  if (!product)
+    return mlir::failure();
+  mlir::Value lhs = product.getLhs();
+  mlir::Value rhs = product.getRhs();
+  cir::ForOp outerFor = outer.forOp;
+  cir::ForOp innerFor = inner.forOp;
+  bool innerThenOuter =
+      isOrdinaryLoadOfSlotIn(lhs, inner.ivSlot, innerFor.getOperation()) &&
+      isOrdinaryLoadOfSlotIn(rhs, outer.ivSlot, outerFor.getOperation());
+  bool outerThenInner =
+      isOrdinaryLoadOfSlotIn(rhs, inner.ivSlot, innerFor.getOperation()) &&
+      isOrdinaryLoadOfSlotIn(lhs, outer.ivSlot, outerFor.getOperation());
+  if (!innerThenOuter && !outerThenInner)
+    return mlir::failure();
+
+  if (!startsAtZero(inner))
+    return mlir::failure();
+  // A strictly positive outer start keeps the product increasing with the
+  // inner counter, so the loop is still counted.
+  if (!outerDomain->first.isStrictlyPositive())
+    return mlir::failure();
+
+  // The product is compared against the same constant the outer loop stops
+  // at. At termination, j * i < N + i. Since i <= N - 1, require N + (N - 1)
+  // to remain representable.
+  mlir::FailureOr<llvm::APSInt> productLimit =
+      evaluateConstantIntExpr(inner.condition.nonIvExpr);
+  if (mlir::failed(productLimit) ||
+      !sameForm(*productLimit, outerDomain->second) ||
+      *productLimit != outerDomain->second)
+    return mlir::failure();
+  mlir::FailureOr<llvm::APSInt> largestOuter =
+      checkedSub(outerDomain->second, like(outerDomain->second, 1));
+  if (mlir::failed(largestOuter) ||
+      mlir::failed(checkedAdd(*productLimit, *largestOuter)))
+    return mlir::failure();
+
+  return LoopNestPattern{outer, inner, LoopNestPatternKind::InnerProductUpper,
+                         std::nullopt};
+}
+
+static mlir::FailureOr<LoopNestPattern>
+matchInvariantInnerStart(const CountedLoop &outer, const CountedLoop &inner,
+                         mlir::DominanceInfo &dominance) {
+  if (!comparesDirectIv(inner))
+    return mlir::failure();
+  // No shared limit ties the two loops together, so each limit has to be
+  // known fixed on its own.
+  if (mlir::failed(constantDomain(outer)) ||
+      mlir::failed(evaluateConstantIntExpr(inner.condition.nonIvExpr)))
+    return mlir::failure();
+
+  // Requiring the start to be a proven invariant read, never a constant,
+  // keeps ordinary rectangular nests out of this pattern.
+  cir::ForOp outerFor = outer.forOp;
+  auto start = inner.initialExpr.getDefiningOp<cir::LoadOp>();
+  if (!start || !isOrdinaryAccess(start) || !outerFor->isAncestor(start))
+    return mlir::failure();
+  if (!resolveInvariantSource(start.getAddr(), outerFor, start.getOperation(),
+                              dominance))
+    return mlir::failure();
+
+  return LoopNestPattern{outer, inner, LoopNestPatternKind::InvariantInnerStart,
+                         std::nullopt};
+}
+
+mlir::FailureOr<LoopNestPattern>
+cir::loopopt::matchLoopNestPattern(const CountedLoop &outer,
+                                   const CountedLoop &inner,
+                                   mlir::DominanceInfo &dominance) {
+  // Both loops must count up under a strict less-than over signed values,
+  // and the outer loop must compare its own variable. Settled once here
+  // rather than in each matcher.
+  if (!matchCommonPreconditions(outer, inner))
+    return mlir::failure();
+  if (mlir::FailureOr<LoopNestPattern> pattern =
+          matchInnerAffineUpper(outer, inner);
+      mlir::succeeded(pattern))
+    return pattern;
+  if (mlir::FailureOr<LoopNestPattern> pattern =
+          matchOuterIVInnerStart(outer, inner);
+      mlir::succeeded(pattern))
+    return pattern;
+  if (mlir::FailureOr<LoopNestPattern> pattern =
+          matchInnerProductUpper(outer, inner);
+      mlir::succeeded(pattern))
+    return pattern;
+  return matchInvariantInnerStart(outer, inner, dominance);
+}

--- a/clang/lib/CIR/Dialect/Transforms/LoopOpt/LoopNestPattern.h
+++ b/clang/lib/CIR/Dialect/Transforms/LoopOpt/LoopNestPattern.h
@@ -1,0 +1,77 @@
+//===- LoopNestPattern.h - Loop nest classification -------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Classification of a counted two-loop nest into the iteration domain shapes
+// the CIR loop optimizer knows how to reason about.
+//
+// Classification is syntactic. It reports the domain implied by the loop
+// control. Early exits may reduce the executed iteration set. Everything
+// else belongs to legality, including perfect nesting, reachability and the
+// memory the body touches.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CLANG_LIB_CIR_DIALECT_TRANSFORMS_LOOPOPT_LOOPNESTPATTERN_H
+#define CLANG_LIB_CIR_DIALECT_TRANSFORMS_LOOPOPT_LOOPNESTPATTERN_H
+
+#include "LoopAnalysis.h"
+
+#include "mlir/IR/Dominance.h"
+
+#include <optional>
+
+namespace cir {
+namespace loopopt {
+
+/// How the inner loop's iteration space relates to the outer loop.
+enum class LoopNestPatternKind {
+  /// The inner limit is an affine function of the outer induction variable,
+  /// for example `j < i`, `j < i + k` or `j < 2 * i`.
+  InnerAffineUpper,
+
+  /// The inner loop starts at the outer induction variable and both loops
+  /// share an upper limit, for example `for (j = i; j < n; ++j)`.
+  OuterIVInnerStart,
+
+  /// The inner limit compares the product of both induction variables
+  /// against a constant, for example `j * i < n`.
+  InnerProductUpper,
+
+  /// The inner loop starts at a value that is fixed for the whole nest, so
+  /// the iteration space is rectangular but not constant.
+  InvariantInnerStart
+};
+
+/// The inner limit written as `coefficient * outerIV + offset`.
+struct AffineOuterIVRelation {
+  llvm::APSInt coefficient;
+  llvm::APSInt offset;
+};
+
+/// For InnerAffineUpper, `affine` stores the normalized relation. It is
+/// empty for all other kinds.
+struct LoopNestPattern {
+  CountedLoop outer;
+  CountedLoop inner;
+  LoopNestPatternKind kind;
+
+  std::optional<AffineOuterIVRelation> affine;
+};
+
+/// Classify a counted pair, failing when it matches no known shape. inner
+/// must be the loop getSingleInnerFor returns for outer. The dominance info
+/// must cover both loops and any definition the matcher inspects, such as
+/// the store behind an invariant start.
+mlir::FailureOr<LoopNestPattern>
+matchLoopNestPattern(const CountedLoop &outer, const CountedLoop &inner,
+                     mlir::DominanceInfo &dominance);
+
+} // namespace loopopt
+} // namespace cir
+
+#endif // CLANG_LIB_CIR_DIALECT_TRANSFORMS_LOOPOPT_LOOPNESTPATTERN_H

--- a/clang/lib/CIR/Dialect/Transforms/LoopOpt/LoopOptPass.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoopOpt/LoopOptPass.cpp
@@ -1,0 +1,110 @@
+//===- LoopOptPass.cpp - Driver for CIR loop optimizations ----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Detection layer for CIR loop optimizations. Transforms plug into
+// runOnOperation below.
+//
+//===----------------------------------------------------------------------===//
+
+#include "LoopNestPattern.h"
+
+#include "../PassDetail.h"
+#include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include "clang/CIR/Dialect/Passes.h"
+#include "llvm/Support/TimeProfiler.h"
+
+using namespace mlir;
+using namespace cir::loopopt;
+
+namespace mlir {
+#define GEN_PASS_DEF_LOOPOPT
+#include "clang/CIR/Dialect/Passes.h.inc"
+} // namespace mlir
+
+namespace {
+
+constexpr llvm::StringLiteral kTestAttr = "cir.loopopt.test";
+
+llvm::StringRef getPatternName(LoopNestPatternKind kind) {
+  switch (kind) {
+  case LoopNestPatternKind::InnerAffineUpper:
+    return "inner_affine_upper";
+  case LoopNestPatternKind::OuterIVInnerStart:
+    return "outer_iv_inner_start";
+  case LoopNestPatternKind::InnerProductUpper:
+    return "inner_product_upper";
+  case LoopNestPatternKind::InvariantInnerStart:
+    return "invariant_inner_start";
+  }
+  llvm_unreachable("unhandled LoopNestPatternKind");
+}
+
+struct LoopOptPass : public impl::LoopOptBase<LoopOptPass> {
+  using LoopOptBase::LoopOptBase;
+  void runOnOperation() override;
+};
+
+} // namespace
+
+void LoopOptPass::runOnOperation() {
+  // Nothing consumes the recognized nests yet, so outside the test option
+  // there is no reason to walk the loops.
+  // FIXME: Transforms run here.
+  if (!testAnnotate) {
+    markAllAnalysesPreserved();
+    return;
+  }
+
+  llvm::TimeTraceScope scope("Loop Nest Classification");
+
+  // The matcher inspects the invariant start's defining store, which may sit
+  // outside both loops, so this dominance info has to cover the whole root.
+  mlir::DominanceInfo dominance(getOperation());
+  mlir::Builder builder(&getContext());
+  // Affine parameters are recorded at the width of the loop counter they came
+  // from, because a counter wider than 64 bits may have parameters that do not
+  // fit in an i64.
+  auto counterWidthAttr = [&](const llvm::APSInt &value) {
+    return builder.getIntegerAttr(builder.getIntegerType(value.getBitWidth()),
+                                  value);
+  };
+
+  // Attribute updates are safe during this walk. A mutating consumer must
+  // re-match or select non-overlapping nests because adjacent pairs share a
+  // loop.
+  getOperation()->walk([&](cir::ForOp forOp) {
+    mlir::FailureOr<CountedLoop> outer = matchCountedLoop(forOp);
+    if (mlir::failed(outer))
+      return;
+    cir::ForOp innerFor = getSingleInnerFor(forOp);
+    if (!innerFor)
+      return;
+    mlir::FailureOr<CountedLoop> inner = matchCountedLoop(innerFor);
+    if (mlir::failed(inner))
+      return;
+    mlir::FailureOr<LoopNestPattern> nest =
+        matchLoopNestPattern(*outer, *inner, dominance);
+    if (mlir::failed(nest))
+      return;
+
+    llvm::SmallVector<mlir::NamedAttribute, 3> fields;
+    fields.emplace_back(builder.getStringAttr("kind"),
+                        builder.getStringAttr(getPatternName(nest->kind)));
+    if (nest->affine) {
+      fields.emplace_back(builder.getStringAttr("scale"),
+                          counterWidthAttr(nest->affine->coefficient));
+      fields.emplace_back(builder.getStringAttr("offset"),
+                          counterWidthAttr(nest->affine->offset));
+    }
+    forOp->setAttr(kTestAttr, builder.getDictionaryAttr(fields));
+  });
+}
+
+std::unique_ptr<Pass> mlir::createLoopOptPass() {
+  return std::make_unique<LoopOptPass>();
+}

--- a/clang/test/CIR/Transforms/loop-opt-affine-upper.cir
+++ b/clang/test/CIR/Transforms/loop-opt-affine-upper.cir
@@ -1,0 +1,548 @@
+// RUN: cir-opt %s --cir-loop-opt=test-annotate=true -o - | FileCheck %s
+
+!s128i = !cir.int<s, 128>
+!s32i = !cir.int<s, 32>
+!s64i = !cir.int<s, 64>
+
+module {
+
+  // CHECK-LABEL: cir.func @limit_k_plus_i
+  // CHECK-NOT: cir.loopopt.test
+  // CHECK: } {cir.loopopt.test = {kind = "inner_affine_upper", offset = 64 : i32, scale = 1 : i32}}
+  // CHECK-NEXT: cir.return
+  cir.func @limit_k_plus_i() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<1> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<64> : !s32i
+      %5 = cir.cmp lt %3, %4 : !s32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.const #cir.int<0> : !s32i
+      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.const #cir.int<64> : !s32i
+        %6 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+        %7 = cir.add nsw %5, %6 : !s32i
+        %8 = cir.cmp lt %4, %7 : !s32i
+        cir.condition(%8)
+      } body {
+        cir.yield
+      } step {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.inc nsw %4 : !s32i
+        cir.store align(4) %5, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.inc nsw %3 : !s32i
+      cir.store align(4) %4, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @limit_i_times_2
+  // CHECK-NOT: cir.loopopt.test
+  // CHECK: } {cir.loopopt.test = {kind = "inner_affine_upper", offset = 0 : i32, scale = 2 : i32}}
+  // CHECK-NEXT: cir.return
+  cir.func @limit_i_times_2() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<1> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<64> : !s32i
+      %5 = cir.cmp lt %3, %4 : !s32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.const #cir.int<0> : !s32i
+      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+        %6 = cir.const #cir.int<2> : !s32i
+        %7 = cir.mul nsw %5, %6 : !s32i
+        %8 = cir.cmp lt %4, %7 : !s32i
+        cir.condition(%8)
+      } body {
+        cir.yield
+      } step {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.inc nsw %4 : !s32i
+        cir.store align(4) %5, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.inc nsw %3 : !s32i
+      cir.store align(4) %4, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @limit_folded_offset
+  // CHECK-NOT: cir.loopopt.test
+  // CHECK: } {cir.loopopt.test = {kind = "inner_affine_upper", offset = 64 : i32, scale = 1 : i32}}
+  // CHECK-NEXT: cir.return
+  cir.func @limit_folded_offset() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<1> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<64> : !s32i
+      %5 = cir.cmp lt %3, %4 : !s32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.const #cir.int<0> : !s32i
+      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+        %6 = cir.const #cir.int<80> : !s32i
+        %7 = cir.const #cir.int<16> : !s32i
+        %8 = cir.sub nsw %6, %7 : !s32i
+        %9 = cir.add nsw %5, %8 : !s32i
+        %10 = cir.cmp lt %4, %9 : !s32i
+        cir.condition(%10)
+      } body {
+        cir.yield
+      } step {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.inc nsw %4 : !s32i
+        cir.store align(4) %5, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.inc nsw %3 : !s32i
+      cir.store align(4) %4, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @inner_cmp_reversed
+  // CHECK-NOT: cir.loopopt.test
+  // CHECK: } {cir.loopopt.test = {kind = "inner_affine_upper", offset = 0 : i32, scale = 1 : i32}}
+  // CHECK-NEXT: cir.return
+  cir.func @inner_cmp_reversed() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<1> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<64> : !s32i
+      %5 = cir.cmp lt %3, %4 : !s32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.const #cir.int<0> : !s32i
+      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %6 = cir.cmp gt %4, %5 : !s32i
+        cir.condition(%6)
+      } body {
+        cir.yield
+      } step {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.inc nsw %4 : !s32i
+        cir.store align(4) %5, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.inc nsw %3 : !s32i
+      cir.store align(4) %4, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @wide_i128_scale_and_offset
+  // CHECK-NOT: cir.loopopt.test
+  // CHECK: } {cir.loopopt.test = {kind = "inner_affine_upper", offset = 25000000000000000000 : i128, scale = 16000000000000000000 : i128}}
+  // CHECK-NEXT: }
+  // CHECK-NEXT: cir.return
+  cir.func @wide_i128_scale_and_offset() {
+    cir.scope {
+      %0 = cir.alloca "i" align(16) init : !cir.ptr<!s128i>
+      %1 = cir.const #cir.int<0> : !s128i
+      cir.store align(16) %1, %0 : !s128i, !cir.ptr<!s128i>
+      cir.for : cond {
+        %2 = cir.load align(16) %0 : !cir.ptr<!s128i>, !s128i
+        %3 = cir.const #cir.int<2> : !s128i
+        %4 = cir.cmp lt %2, %3 : !s128i
+        cir.condition(%4)
+      } body {
+        cir.scope {
+          %2 = cir.alloca "j" align(16) init : !cir.ptr<!s128i>
+          %3 = cir.const #cir.int<0> : !s128i
+          cir.store align(16) %3, %2 : !s128i, !cir.ptr<!s128i>
+          cir.for : cond {
+            %4 = cir.load align(16) %2 : !cir.ptr<!s128i>, !s128i
+            %5 = cir.load align(16) %0 : !cir.ptr<!s128i>, !s128i
+            %6 = cir.const #cir.int<4000000000> : !s128i
+            %7 = cir.const #cir.int<4000000000> : !s128i
+            %8 = cir.mul nsw %6, %7 : !s128i
+            %9 = cir.mul nsw %5, %8 : !s128i
+            %10 = cir.const #cir.int<5000000000> : !s128i
+            %11 = cir.const #cir.int<5000000000> : !s128i
+            %12 = cir.mul nsw %10, %11 : !s128i
+            %13 = cir.add nsw %9, %12 : !s128i
+            %14 = cir.cmp lt %4, %13 : !s128i
+            cir.condition(%14)
+          } body {
+            cir.yield
+          } step {
+            %4 = cir.load align(16) %2 : !cir.ptr<!s128i>, !s128i
+            %5 = cir.inc nsw %4 : !s128i
+            cir.store align(16) %5, %2 : !s128i, !cir.ptr<!s128i>
+            cir.yield
+          }
+        }
+        cir.yield
+      } step {
+        %2 = cir.load align(16) %0 : !cir.ptr<!s128i>, !s128i
+        %3 = cir.inc nsw %2 : !s128i
+        cir.store align(16) %3, %0 : !s128i, !cir.ptr<!s128i>
+        cir.yield
+      }
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @limit_nonlinear_i_times_i
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @limit_nonlinear_i_times_i() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<1> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<64> : !s32i
+      %5 = cir.cmp lt %3, %4 : !s32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.const #cir.int<0> : !s32i
+      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+        %6 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+        %7 = cir.mul nsw %5, %6 : !s32i
+        %8 = cir.cmp lt %4, %7 : !s32i
+        cir.condition(%8)
+      } body {
+        cir.yield
+      } step {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.inc nsw %4 : !s32i
+        cir.store align(4) %5, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.inc nsw %3 : !s32i
+      cir.store align(4) %4, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @limit_repeated_outer_iv
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @limit_repeated_outer_iv() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<1> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<64> : !s32i
+      %5 = cir.cmp lt %3, %4 : !s32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.const #cir.int<0> : !s32i
+      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+        %6 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+        %7 = cir.add nsw %5, %6 : !s32i
+        %8 = cir.cmp lt %4, %7 : !s32i
+        cir.condition(%8)
+      } body {
+        cir.yield
+      } step {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.inc nsw %4 : !s32i
+        cir.store align(4) %5, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.inc nsw %3 : !s32i
+      cir.store align(4) %4, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @limit_zero_coefficient
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @limit_zero_coefficient() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<1> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<64> : !s32i
+      %5 = cir.cmp lt %3, %4 : !s32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.const #cir.int<0> : !s32i
+      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.const #cir.int<0> : !s32i
+        %6 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+        %7 = cir.mul nsw %5, %6 : !s32i
+        %8 = cir.cmp lt %4, %7 : !s32i
+        cir.condition(%8)
+      } body {
+        cir.yield
+      } step {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.inc nsw %4 : !s32i
+        cir.store align(4) %5, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.inc nsw %3 : !s32i
+      cir.store align(4) %4, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @limit_runtime_div
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @limit_runtime_div() {
+    %n = cir.alloca "n" align(4) init : !cir.ptr<!s32i>
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<1> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<64> : !s32i
+      %5 = cir.cmp lt %3, %4 : !s32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.const #cir.int<0> : !s32i
+      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+        %6 = cir.load align(4) %n : !cir.ptr<!s32i>, !s32i
+        %7 = cir.div %5, %6 : !s32i
+        %8 = cir.cmp lt %4, %7 : !s32i
+        cir.condition(%8)
+      } body {
+        cir.yield
+      } step {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.inc nsw %4 : !s32i
+        cir.store align(4) %5, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.inc nsw %3 : !s32i
+      cir.store align(4) %4, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @limit_cast
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @limit_cast() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(8) init : !cir.ptr<!s64i>
+    %2 = cir.const #cir.int<1> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<64> : !s32i
+      %5 = cir.cmp lt %3, %4 : !s32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.const #cir.int<0> : !s64i
+      cir.store align(8) %3, %1 : !s64i, !cir.ptr<!s64i>
+      cir.for : cond {
+        %4 = cir.load align(8) %1 : !cir.ptr<!s64i>, !s64i
+        %5 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+        %6 = cir.cast integral %5 : !s32i -> !s64i
+        %7 = cir.cmp lt %4, %6 : !s64i
+        cir.condition(%7)
+      } body {
+        cir.yield
+      } step {
+        %4 = cir.load align(8) %1 : !cir.ptr<!s64i>, !s64i
+        %5 = cir.inc nsw %4 : !s64i
+        cir.store align(8) %5, %1 : !s64i, !cir.ptr<!s64i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.inc nsw %3 : !s32i
+      cir.store align(4) %4, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @limit_hoisted_outer_load
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @limit_hoisted_outer_load() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<1> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+    cir.for : cond {
+      %4 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %5 = cir.const #cir.int<64> : !s32i
+      %6 = cir.cmp lt %4, %5 : !s32i
+      cir.condition(%6)
+    } body {
+      %4 = cir.const #cir.int<0> : !s32i
+      cir.store align(4) %4, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %5 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %6 = cir.cmp lt %5, %3 : !s32i
+        cir.condition(%6)
+      } body {
+        cir.yield
+      } step {
+        %5 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %6 = cir.inc nsw %5 : !s32i
+        cir.store align(4) %6, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %4 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %5 = cir.inc nsw %4 : !s32i
+      cir.store align(4) %5, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @saturating_intermediate_not_affine
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @saturating_intermediate_not_affine() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<1> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<64> : !s32i
+      %5 = cir.cmp lt %3, %4 : !s32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.const #cir.int<0> : !s32i
+      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+        %6 = cir.const #cir.int<2147483647> : !s32i
+        %7 = cir.add sat %5, %6 : !s32i
+        %8 = cir.sub %7, %6 : !s32i
+        %9 = cir.cmp lt %4, %8 : !s32i
+        cir.condition(%9)
+      } body {
+        cir.yield
+      } step {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.inc nsw %4 : !s32i
+        cir.store align(4) %5, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.inc nsw %3 : !s32i
+      cir.store align(4) %4, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @affine_endpoint_overflows
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @affine_endpoint_overflows() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<1> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<1000000> : !s32i
+      %5 = cir.cmp lt %3, %4 : !s32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.const #cir.int<0> : !s32i
+      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+        %6 = cir.const #cir.int<100000> : !s32i
+        %7 = cir.mul nsw %5, %6 : !s32i
+        %8 = cir.cmp lt %4, %7 : !s32i
+        cir.condition(%8)
+      } body {
+        cir.yield
+      } step {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.inc nsw %4 : !s32i
+        cir.store align(4) %5, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.inc nsw %3 : !s32i
+      cir.store align(4) %4, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+}

--- a/clang/test/CIR/Transforms/loop-opt-counted-loop.cir
+++ b/clang/test/CIR/Transforms/loop-opt-counted-loop.cir
@@ -1,0 +1,606 @@
+// RUN: cir-opt %s --cir-loop-opt=test-annotate=true -o - | FileCheck %s
+// RUN: cir-opt %s --cir-loop-opt -o - | FileCheck %s --check-prefix=NOOP
+
+// NOOP: cir.func @counted_pair()
+// NOOP-NOT: cir.loopopt.test
+
+!s32i = !cir.int<s, 32>
+!u32i = !cir.int<u, 32>
+
+module {
+
+  // CHECK-LABEL: cir.func @counted_pair
+  // CHECK-NOT: cir.loopopt.test
+  // CHECK: } {cir.loopopt.test = {kind = "inner_affine_upper", offset = 0 : i32, scale = 1 : i32}}
+  // CHECK-NEXT: cir.return
+  cir.func @counted_pair() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<1> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<64> : !s32i
+      %5 = cir.cmp lt %3, %4 : !s32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.const #cir.int<0> : !s32i
+      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+        %6 = cir.cmp lt %4, %5 : !s32i
+        cir.condition(%6)
+      } body {
+        cir.yield
+      } step {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.inc nsw %4 : !s32i
+        cir.store align(4) %5, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.inc nsw %3 : !s32i
+      cir.store align(4) %4, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @both_operands_read_iv
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @both_operands_read_iv() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<1> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<64> : !s32i
+      %5 = cir.cmp lt %3, %4 : !s32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.const #cir.int<0> : !s32i
+      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %6 = cir.const #cir.int<1> : !s32i
+        %7 = cir.add nsw %5, %6 : !s32i
+        %8 = cir.cmp lt %4, %7 : !s32i
+        cir.condition(%8)
+      } body {
+        cir.yield
+      } step {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.inc nsw %4 : !s32i
+        cir.store align(4) %5, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.inc nsw %3 : !s32i
+      cir.store align(4) %4, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @cmp_hoisted_out_of_cond_region
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @cmp_hoisted_out_of_cond_region() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<1> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<64> : !s32i
+      %5 = cir.cmp lt %3, %4 : !s32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.const #cir.int<0> : !s32i
+      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
+      %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+      %5 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %6 = cir.cmp lt %4, %5 : !s32i
+      cir.for : cond {
+        cir.condition(%6)
+      } body {
+        cir.yield
+      } step {
+        %7 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %8 = cir.inc nsw %7 : !s32i
+        cir.store align(4) %8, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.inc nsw %3 : !s32i
+      cir.store align(4) %4, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @iv_address_escapes
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @iv_address_escapes() {
+    %p = cir.alloca "p" align(8) init : !cir.ptr<!cir.ptr<!s32i>>
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<1> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<64> : !s32i
+      %5 = cir.cmp lt %3, %4 : !s32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.const #cir.int<0> : !s32i
+      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+        %6 = cir.cmp lt %4, %5 : !s32i
+        cir.condition(%6)
+      } body {
+        cir.store align(8) %1, %p : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>
+        cir.yield
+      } step {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.inc nsw %4 : !s32i
+        cir.store align(4) %5, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.inc nsw %3 : !s32i
+      cir.store align(4) %4, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @iv_written_in_body
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @iv_written_in_body() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<1> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<64> : !s32i
+      %5 = cir.cmp lt %3, %4 : !s32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.const #cir.int<0> : !s32i
+      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+        %6 = cir.cmp lt %4, %5 : !s32i
+        cir.condition(%6)
+      } body {
+        %4 = cir.const #cir.int<5> : !s32i
+        cir.store align(4) %4, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      } step {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.inc nsw %4 : !s32i
+        cir.store align(4) %5, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.inc nsw %3 : !s32i
+      cir.store align(4) %4, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @step_double_inc
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @step_double_inc() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<1> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<64> : !s32i
+      %5 = cir.cmp lt %3, %4 : !s32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.const #cir.int<0> : !s32i
+      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+        %6 = cir.cmp lt %4, %5 : !s32i
+        cir.condition(%6)
+      } body {
+        cir.yield
+      } step {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.inc nsw %4 : !s32i
+        %6 = cir.inc nsw %5 : !s32i
+        cir.store align(4) %6, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.inc nsw %3 : !s32i
+      cir.store align(4) %4, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @body_early_exit_is_detected
+  // CHECK-NOT: cir.loopopt.test
+  // CHECK: } {cir.loopopt.test = {kind = "inner_affine_upper", offset = 0 : i32, scale = 1 : i32}}
+  // CHECK-NEXT: cir.return
+  cir.func @body_early_exit_is_detected() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<1> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<64> : !s32i
+      %5 = cir.cmp lt %3, %4 : !s32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.const #cir.int<0> : !s32i
+      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+        %6 = cir.cmp lt %4, %5 : !s32i
+        cir.condition(%6)
+      } body {
+        cir.break
+      } step {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.inc nsw %4 : !s32i
+        cir.store align(4) %5, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.inc nsw %3 : !s32i
+      cir.store align(4) %4, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @two_inner_loops
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @two_inner_loops() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<1> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<64> : !s32i
+      %5 = cir.cmp lt %3, %4 : !s32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.const #cir.int<0> : !s32i
+      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+        %6 = cir.cmp lt %4, %5 : !s32i
+        cir.condition(%6)
+      } body {
+        cir.yield
+      } step {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.inc nsw %4 : !s32i
+        cir.store align(4) %5, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+        %6 = cir.cmp lt %4, %5 : !s32i
+        cir.condition(%6)
+      } body {
+        cir.yield
+      } step {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.inc nsw %4 : !s32i
+        cir.store align(4) %5, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.inc nsw %3 : !s32i
+      cir.store align(4) %4, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @step_decrement
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @step_decrement() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<1> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<64> : !s32i
+      %5 = cir.cmp lt %3, %4 : !s32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.const #cir.int<0> : !s32i
+      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+        %6 = cir.cmp lt %4, %5 : !s32i
+        cir.condition(%6)
+      } body {
+        cir.yield
+      } step {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.dec nsw %4 : !s32i
+        cir.store align(4) %5, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.inc nsw %3 : !s32i
+      cir.store align(4) %4, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @inner_j_le_i
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @inner_j_le_i() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<1> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<64> : !s32i
+      %5 = cir.cmp lt %3, %4 : !s32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.const #cir.int<0> : !s32i
+      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+        %6 = cir.cmp le %4, %5 : !s32i
+        cir.condition(%6)
+      } body {
+        cir.yield
+      } step {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.inc nsw %4 : !s32i
+        cir.store align(4) %5, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.inc nsw %3 : !s32i
+      cir.store align(4) %4, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @outer_domain_is_empty
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @outer_domain_is_empty() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<1> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<1> : !s32i
+      %5 = cir.cmp lt %3, %4 : !s32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.const #cir.int<0> : !s32i
+      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+        %6 = cir.cmp lt %4, %5 : !s32i
+        cir.condition(%6)
+      } body {
+        cir.yield
+      } step {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.inc nsw %4 : !s32i
+        cir.store align(4) %5, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.inc nsw %3 : !s32i
+      cir.store align(4) %4, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @volatile_iv_step
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @volatile_iv_step() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<1> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<64> : !s32i
+      %5 = cir.cmp lt %3, %4 : !s32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.const #cir.int<0> : !s32i
+      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+        %6 = cir.cmp lt %4, %5 : !s32i
+        cir.condition(%6)
+      } body {
+        cir.yield
+      } step {
+        %4 = cir.load volatile %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.inc nsw %4 : !s32i
+        cir.store align(4) %5, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.inc nsw %3 : !s32i
+      cir.store align(4) %4, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @atomic_bound
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @atomic_bound() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<1> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<64> : !s32i
+      %5 = cir.cmp lt %3, %4 : !s32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.const #cir.int<0> : !s32i
+      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.load align(4) atomic(seq_cst) %0 : !cir.ptr<!s32i>, !s32i
+        %6 = cir.cmp lt %4, %5 : !s32i
+        cir.condition(%6)
+      } body {
+        cir.yield
+      } step {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.inc nsw %4 : !s32i
+        cir.store align(4) %5, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.inc nsw %3 : !s32i
+      cir.store align(4) %4, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @step_break_terminator
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @step_break_terminator() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<1> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<64> : !s32i
+      %5 = cir.cmp lt %3, %4 : !s32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.const #cir.int<0> : !s32i
+      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+        %6 = cir.cmp lt %4, %5 : !s32i
+        cir.condition(%6)
+      } body {
+        cir.yield
+      } step {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.inc nsw %4 : !s32i
+        cir.store align(4) %5, %1 : !s32i, !cir.ptr<!s32i>
+        cir.break
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.inc nsw %3 : !s32i
+      cir.store align(4) %4, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @unsigned_counter
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @unsigned_counter() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!u32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!u32i>
+    %2 = cir.const #cir.int<1> : !u32i
+    cir.store align(4) %2, %0 : !u32i, !cir.ptr<!u32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!u32i>, !u32i
+      %4 = cir.const #cir.int<64> : !u32i
+      %5 = cir.cmp lt %3, %4 : !u32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.const #cir.int<0> : !u32i
+      cir.store align(4) %3, %1 : !u32i, !cir.ptr<!u32i>
+      cir.for : cond {
+        %4 = cir.load align(4) %1 : !cir.ptr<!u32i>, !u32i
+        %5 = cir.load align(4) %0 : !cir.ptr<!u32i>, !u32i
+        %6 = cir.cmp lt %4, %5 : !u32i
+        cir.condition(%6)
+      } body {
+        cir.yield
+      } step {
+        %4 = cir.load align(4) %1 : !cir.ptr<!u32i>, !u32i
+        %5 = cir.inc nsw %4 : !u32i
+        cir.store align(4) %5, %1 : !u32i, !cir.ptr<!u32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!u32i>, !u32i
+      %4 = cir.inc nsw %3 : !u32i
+      cir.store align(4) %4, %0 : !u32i, !cir.ptr<!u32i>
+      cir.yield
+    }
+    cir.return
+  }
+}

--- a/clang/test/CIR/Transforms/loop-opt-dependent-start.cir
+++ b/clang/test/CIR/Transforms/loop-opt-dependent-start.cir
@@ -1,0 +1,245 @@
+// RUN: cir-opt %s --cir-loop-opt=test-annotate=true -o - | FileCheck %s
+
+!s32i = !cir.int<s, 32>
+!s64i = !cir.int<s, 64>
+
+module {
+  cir.global external @A = #cir.zero : !cir.array<!cir.array<!cir.double x 1024> x 1024>
+
+  // CHECK-LABEL: cir.func @folded_equivalent_limits
+  // CHECK-NOT: cir.loopopt.test
+  // CHECK: } {cir.loopopt.test = {kind = "outer_iv_inner_start"}}
+  // CHECK-NEXT: cir.return
+  cir.func @folded_equivalent_limits() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<0> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<64> : !s32i
+      %5 = cir.cmp lt %3, %4 : !s32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.const #cir.int<128> : !s32i
+        %6 = cir.const #cir.int<2> : !s32i
+        %7 = cir.div %5, %6 : !s32i
+        %8 = cir.cmp lt %4, %7 : !s32i
+        cir.condition(%8)
+      } body {
+        cir.yield
+      } step {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.inc nsw %4 : !s32i
+        cir.store align(4) %5, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.inc nsw %3 : !s32i
+      cir.store align(4) %4, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @sym_triple_both_pairs_detected
+  // CHECK: %[[I:.*]] = cir.alloca "i"
+  // CHECK: %[[J:.*]] = cir.alloca "j"
+  // CHECK: %[[K:.*]] = cir.alloca "k"
+  // CHECK-NOT: cir.loopopt.test
+  // CHECK: cir.store align(4) %{{.*}}, %[[J]] : !s32i, !cir.ptr<!s32i>
+  // CHECK-NEXT: cir.yield
+  // CHECK-NEXT: } {cir.loopopt.test = {kind = "outer_iv_inner_start"}}
+  // CHECK: cir.store align(4) %{{.*}}, %[[I]] : !s32i, !cir.ptr<!s32i>
+  // CHECK-NEXT: cir.yield
+  // CHECK-NEXT: } {cir.loopopt.test = {kind = "outer_iv_inner_start"}}
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @sym_triple_both_pairs_detected() {
+    cir.scope {
+      %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+      %1 = cir.const #cir.int<0> : !s32i
+      cir.store align(4) %1, %0 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %2 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+        %3 = cir.const #cir.int<64> : !s32i
+        %4 = cir.cmp lt %2, %3 : !s32i
+        cir.condition(%4)
+      } body {
+        cir.scope {
+          %2 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+          %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+          cir.store align(4) %3, %2 : !s32i, !cir.ptr<!s32i>
+          cir.for : cond {
+            %4 = cir.load align(4) %2 : !cir.ptr<!s32i>, !s32i
+            %5 = cir.const #cir.int<64> : !s32i
+            %6 = cir.cmp lt %4, %5 : !s32i
+            cir.condition(%6)
+          } body {
+            cir.scope {
+              %4 = cir.alloca "k" align(4) init : !cir.ptr<!s32i>
+              %5 = cir.load align(4) %2 : !cir.ptr<!s32i>, !s32i
+              cir.store align(4) %5, %4 : !s32i, !cir.ptr<!s32i>
+              cir.for : cond {
+                %6 = cir.load align(4) %4 : !cir.ptr<!s32i>, !s32i
+                %7 = cir.const #cir.int<64> : !s32i
+                %8 = cir.cmp lt %6, %7 : !s32i
+                cir.condition(%8)
+              } body {
+                %6 = cir.const #cir.fp<1.000000e+00> : !cir.double
+                %7 = cir.load align(4) %4 : !cir.ptr<!s32i>, !s32i
+                %8 = cir.cast integral %7 : !s32i -> !s64i
+                %9 = cir.load align(4) %2 : !cir.ptr<!s32i>, !s32i
+                %10 = cir.cast integral %9 : !s32i -> !s64i
+                %11 = cir.get_global @A : !cir.ptr<!cir.array<!cir.array<!cir.double x 1024> x 1024>>
+                %12 = cir.get_element %11[%10 : !s64i] : !cir.ptr<!cir.array<!cir.array<!cir.double x 1024> x 1024>> -> !cir.ptr<!cir.array<!cir.double x 1024>>
+                %13 = cir.get_element %12[%8 : !s64i] : !cir.ptr<!cir.array<!cir.double x 1024>> -> !cir.ptr<!cir.double>
+                cir.store align(8) %6, %13 : !cir.double, !cir.ptr<!cir.double>
+                cir.yield
+              } step {
+                %6 = cir.load align(4) %4 : !cir.ptr<!s32i>, !s32i
+                %7 = cir.inc nsw %6 : !s32i
+                cir.store align(4) %7, %4 : !s32i, !cir.ptr<!s32i>
+                cir.yield
+              }
+            }
+            cir.yield
+          } step {
+            %4 = cir.load align(4) %2 : !cir.ptr<!s32i>, !s32i
+            %5 = cir.inc nsw %4 : !s32i
+            cir.store align(4) %5, %2 : !s32i, !cir.ptr<!s32i>
+            cir.yield
+          }
+        }
+        cir.yield
+      } step {
+        %2 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+        %3 = cir.inc nsw %2 : !s32i
+        cir.store align(4) %3, %0 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @limits_differ
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @limits_differ() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<0> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<1024> : !s32i
+      %5 = cir.cmp lt %3, %4 : !s32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.const #cir.int<512> : !s32i
+        %6 = cir.cmp lt %4, %5 : !s32i
+        cir.condition(%6)
+      } body {
+        cir.yield
+      } step {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.inc nsw %4 : !s32i
+        cir.store align(4) %5, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.inc nsw %3 : !s32i
+      cir.store align(4) %4, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @start_outer_iv_plus_one
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @start_outer_iv_plus_one() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<0> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<64> : !s32i
+      %5 = cir.cmp lt %3, %4 : !s32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<1> : !s32i
+      %5 = cir.add nsw %3, %4 : !s32i
+      cir.store align(4) %5, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %6 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %7 = cir.const #cir.int<64> : !s32i
+        %8 = cir.cmp lt %6, %7 : !s32i
+        cir.condition(%8)
+      } body {
+        cir.yield
+      } step {
+        %6 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %7 = cir.inc nsw %6 : !s32i
+        cir.store align(4) %7, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.inc nsw %3 : !s32i
+      cir.store align(4) %4, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @start_read_before_outer
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @start_read_before_outer() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<0> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+    cir.for : cond {
+      %4 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %5 = cir.const #cir.int<64> : !s32i
+      %6 = cir.cmp lt %4, %5 : !s32i
+      cir.condition(%6)
+    } body {
+      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.const #cir.int<64> : !s32i
+        %6 = cir.cmp lt %4, %5 : !s32i
+        cir.condition(%6)
+      } body {
+        cir.yield
+      } step {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.inc nsw %4 : !s32i
+        cir.store align(4) %5, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %4 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %5 = cir.inc nsw %4 : !s32i
+      cir.store align(4) %5, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+}

--- a/clang/test/CIR/Transforms/loop-opt-frontend.c
+++ b/clang/test/CIR/Transforms/loop-opt-frontend.c
@@ -1,0 +1,83 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: cir-opt %t.cir --cir-loop-opt=test-annotate=true -o - \
+// RUN:   | FileCheck %s --implicit-check-not=cir.loopopt.test
+
+#define N 1024
+#define K 64
+
+double A[N][N], B[N][N], C[N][N];
+long AL[N][N];
+
+// CHECK-LABEL: cir.func{{.*}} @tri_upper_bound
+// CHECK: {cir.loopopt.test = {kind = "inner_affine_upper", offset = 0 : i32, scale = 1 : i32}}
+void tri_upper_bound(void) {
+  for (int i = 1; i < N; i++)
+    for (int j = 0; j < i; j++)
+      B[j][i] = A[j][i] * 3.0;
+}
+
+// CHECK-LABEL: cir.func{{.*}} @tri_fill
+// CHECK: {cir.loopopt.test = {kind = "inner_affine_upper", offset = 0 : i32, scale = 1 : i32}}
+void tri_fill(void) {
+  for (int i = 1; i < N; i++)
+    for (int j = 0; j < i; j++)
+      B[j][i] = 0.0;
+}
+
+// CHECK-LABEL: cir.func{{.*}} @tri_ldlt_update
+// CHECK: {cir.loopopt.test = {kind = "inner_affine_upper", offset = 0 : i32, scale = 1 : i32}}
+void tri_ldlt_update(void) {
+  for (int i = 1; i < N; i++)
+    for (int j = 0; j < i; j++)
+      B[j][i] = B[j][i] - A[j][i] * C[j][i];
+}
+
+// CHECK-LABEL: cir.func{{.*}} @tri_addk_bound
+// CHECK: {cir.loopopt.test = {kind = "inner_affine_upper", offset = 64 : i32, scale = 1 : i32}}
+void tri_addk_bound(void) {
+  for (int i = 0; i < N - K; i++)
+    for (int j = 0; j < i + K; j++)
+      B[j][i] = A[j][i] * 3.0;
+}
+
+// CHECK-LABEL: cir.func{{.*}} @tri_variant_2i
+// CHECK: {cir.loopopt.test = {kind = "inner_affine_upper", offset = 0 : i32, scale = 2 : i32}}
+void tri_variant_2i(void) {
+  for (int i = 1; i < N / 2; i++)
+    for (int j = 0; j < 2 * i; j++)
+      B[j][i] = A[j][i] * 3.0;
+}
+
+// CHECK-LABEL: cir.func{{.*}} @tri_lower_start
+// CHECK: {cir.loopopt.test = {kind = "outer_iv_inner_start"}}
+void tri_lower_start(void) {
+  for (int i = 0; i < N; i++)
+    for (int j = i; j < N; j++)
+      B[i][j] = A[j][i] + C[j][i];
+}
+
+// CHECK-LABEL: cir.func{{.*}} @tri_mul_bound
+// CHECK: {cir.loopopt.test = {kind = "inner_product_upper"}}
+void tri_mul_bound(void) {
+  for (int i = 1; i < N; i++)
+    for (int j = 0; j * i < N; j++)
+      B[j][i] = A[j][i] * 3.0;
+}
+
+// CHECK-LABEL: cir.func{{.*}} @tri_arg_start
+// CHECK: {cir.loopopt.test = {kind = "invariant_inner_start"}}
+long tri_arg_start(long lo) {
+  long s = 0;
+  for (long i = 0; i < N; i++)
+    for (long j = lo; j < N; j++)
+      s += AL[j][i];
+  return s;
+}
+
+// CHECK-LABEL: cir.func{{.*}} @rectangular
+// CHECK-NOT: cir.loopopt.test
+void rectangular(long lo) {
+  for (int i = 0; i < N; i++)
+    for (int j = 0; j < N; j++)
+      AL[i][j] = lo;
+}

--- a/clang/test/CIR/Transforms/loop-opt-invariant-start.cir
+++ b/clang/test/CIR/Transforms/loop-opt-invariant-start.cir
@@ -1,0 +1,294 @@
+// RUN: cir-opt %s --cir-loop-opt=test-annotate=true -o - | FileCheck %s
+
+!s64i = !cir.int<s, 64>
+
+module {
+  cir.global external @BL = #cir.zero : !cir.array<!cir.array<!s64i x 64> x 64>
+  cir.global external @lo_g = #cir.int<0> : !s64i
+
+  // CHECK-LABEL: cir.func @argument_start
+  // CHECK-NOT: cir.loopopt.test
+  // CHECK: } {cir.loopopt.test = {kind = "invariant_inner_start"}}
+  // CHECK-NEXT: }
+  // CHECK-NEXT: cir.return
+  cir.func @argument_start(%arg0: !s64i) {
+    %0 = cir.alloca "lo" align(8) init : !cir.ptr<!s64i>
+    cir.store %arg0, %0 : !s64i, !cir.ptr<!s64i>
+    cir.scope {
+      %1 = cir.alloca "i" align(8) init : !cir.ptr<!s64i>
+      %2 = cir.const #cir.int<0> : !s64i
+      cir.store align(8) %2, %1 : !s64i, !cir.ptr<!s64i>
+      cir.for : cond {
+        %3 = cir.load align(8) %1 : !cir.ptr<!s64i>, !s64i
+        %4 = cir.const #cir.int<64> : !s64i
+        %5 = cir.cmp lt %3, %4 : !s64i
+        cir.condition(%5)
+      } body {
+        cir.scope {
+          %3 = cir.alloca "j" align(8) init : !cir.ptr<!s64i>
+          %4 = cir.load align(8) %0 : !cir.ptr<!s64i>, !s64i
+          cir.store align(8) %4, %3 : !s64i, !cir.ptr<!s64i>
+          cir.for : cond {
+            %5 = cir.load align(8) %3 : !cir.ptr<!s64i>, !s64i
+            %6 = cir.const #cir.int<64> : !s64i
+            %7 = cir.cmp lt %5, %6 : !s64i
+            cir.condition(%7)
+          } body {
+            %5 = cir.const #cir.int<7> : !s64i
+            %6 = cir.load align(8) %3 : !cir.ptr<!s64i>, !s64i
+            %7 = cir.load align(8) %1 : !cir.ptr<!s64i>, !s64i
+            %8 = cir.get_global @BL : !cir.ptr<!cir.array<!cir.array<!s64i x 64> x 64>>
+            %9 = cir.get_element %8[%7 : !s64i] : !cir.ptr<!cir.array<!cir.array<!s64i x 64> x 64>> -> !cir.ptr<!cir.array<!s64i x 64>>
+            %10 = cir.get_element %9[%6 : !s64i] : !cir.ptr<!cir.array<!s64i x 64>> -> !cir.ptr<!s64i>
+            cir.store align(8) %5, %10 : !s64i, !cir.ptr<!s64i>
+            cir.yield
+          } step {
+            %5 = cir.load align(8) %3 : !cir.ptr<!s64i>, !s64i
+            %6 = cir.inc nsw %5 : !s64i
+            cir.store align(8) %6, %3 : !s64i, !cir.ptr<!s64i>
+            cir.yield
+          }
+        }
+        cir.yield
+      } step {
+        %3 = cir.load align(8) %1 : !cir.ptr<!s64i>, !s64i
+        %4 = cir.inc nsw %3 : !s64i
+        cir.store align(8) %4, %1 : !s64i, !cir.ptr<!s64i>
+        cir.yield
+      }
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @arg_start_written_in_loop
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @arg_start_written_in_loop(%arg0: !s64i) {
+    %0 = cir.alloca "lo" align(8) init : !cir.ptr<!s64i>
+    cir.store %arg0, %0 : !s64i, !cir.ptr<!s64i>
+    cir.scope {
+      %1 = cir.alloca "i" align(8) init : !cir.ptr<!s64i>
+      %2 = cir.const #cir.int<0> : !s64i
+      cir.store align(8) %2, %1 : !s64i, !cir.ptr<!s64i>
+      cir.for : cond {
+        %3 = cir.load align(8) %1 : !cir.ptr<!s64i>, !s64i
+        %4 = cir.const #cir.int<64> : !s64i
+        %5 = cir.cmp lt %3, %4 : !s64i
+        cir.condition(%5)
+      } body {
+        cir.scope {
+          %3 = cir.alloca "j" align(8) init : !cir.ptr<!s64i>
+          %4 = cir.load align(8) %0 : !cir.ptr<!s64i>, !s64i
+          cir.store align(8) %4, %3 : !s64i, !cir.ptr<!s64i>
+          cir.for : cond {
+            %5 = cir.load align(8) %3 : !cir.ptr<!s64i>, !s64i
+            %6 = cir.const #cir.int<64> : !s64i
+            %7 = cir.cmp lt %5, %6 : !s64i
+            cir.condition(%7)
+          } body {
+            %5 = cir.load align(8) %3 : !cir.ptr<!s64i>, !s64i
+            cir.store align(8) %5, %0 : !s64i, !cir.ptr<!s64i>
+            cir.yield
+          } step {
+            %5 = cir.load align(8) %3 : !cir.ptr<!s64i>, !s64i
+            %6 = cir.inc nsw %5 : !s64i
+            cir.store align(8) %6, %3 : !s64i, !cir.ptr<!s64i>
+            cir.yield
+          }
+        }
+        cir.yield
+      } step {
+        %3 = cir.load align(8) %1 : !cir.ptr<!s64i>, !s64i
+        %4 = cir.inc nsw %3 : !s64i
+        cir.store align(8) %4, %1 : !s64i, !cir.ptr<!s64i>
+        cir.yield
+      }
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @arg_start_address_escapes
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @arg_start_address_escapes(%arg0: !s64i) {
+    %0 = cir.alloca "lo" align(8) init : !cir.ptr<!s64i>
+    %p = cir.alloca "p" align(8) init : !cir.ptr<!cir.ptr<!s64i>>
+    cir.store %arg0, %0 : !s64i, !cir.ptr<!s64i>
+    cir.store align(8) %0, %p : !cir.ptr<!s64i>, !cir.ptr<!cir.ptr<!s64i>>
+    cir.scope {
+      %1 = cir.alloca "i" align(8) init : !cir.ptr<!s64i>
+      %2 = cir.const #cir.int<0> : !s64i
+      cir.store align(8) %2, %1 : !s64i, !cir.ptr<!s64i>
+      cir.for : cond {
+        %3 = cir.load align(8) %1 : !cir.ptr<!s64i>, !s64i
+        %4 = cir.const #cir.int<64> : !s64i
+        %5 = cir.cmp lt %3, %4 : !s64i
+        cir.condition(%5)
+      } body {
+        cir.scope {
+          %3 = cir.alloca "j" align(8) init : !cir.ptr<!s64i>
+          %4 = cir.load align(8) %0 : !cir.ptr<!s64i>, !s64i
+          cir.store align(8) %4, %3 : !s64i, !cir.ptr<!s64i>
+          cir.for : cond {
+            %5 = cir.load align(8) %3 : !cir.ptr<!s64i>, !s64i
+            %6 = cir.const #cir.int<64> : !s64i
+            %7 = cir.cmp lt %5, %6 : !s64i
+            cir.condition(%7)
+          } body {
+            cir.yield
+          } step {
+            %5 = cir.load align(8) %3 : !cir.ptr<!s64i>, !s64i
+            %6 = cir.inc nsw %5 : !s64i
+            cir.store align(8) %6, %3 : !s64i, !cir.ptr<!s64i>
+            cir.yield
+          }
+        }
+        cir.yield
+      } step {
+        %3 = cir.load align(8) %1 : !cir.ptr<!s64i>, !s64i
+        %4 = cir.inc nsw %3 : !s64i
+        cir.store align(8) %4, %1 : !s64i, !cir.ptr<!s64i>
+        cir.yield
+      }
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @volatile_start
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @volatile_start(%arg0: !s64i) {
+    %0 = cir.alloca "lo" align(8) init : !cir.ptr<!s64i>
+    cir.store %arg0, %0 : !s64i, !cir.ptr<!s64i>
+    cir.scope {
+      %1 = cir.alloca "i" align(8) init : !cir.ptr<!s64i>
+      %2 = cir.const #cir.int<0> : !s64i
+      cir.store align(8) %2, %1 : !s64i, !cir.ptr<!s64i>
+      cir.for : cond {
+        %3 = cir.load align(8) %1 : !cir.ptr<!s64i>, !s64i
+        %4 = cir.const #cir.int<64> : !s64i
+        %5 = cir.cmp lt %3, %4 : !s64i
+        cir.condition(%5)
+      } body {
+        cir.scope {
+          %3 = cir.alloca "j" align(8) init : !cir.ptr<!s64i>
+          %4 = cir.load volatile %0 : !cir.ptr<!s64i>, !s64i
+          cir.store align(8) %4, %3 : !s64i, !cir.ptr<!s64i>
+          cir.for : cond {
+            %5 = cir.load align(8) %3 : !cir.ptr<!s64i>, !s64i
+            %6 = cir.const #cir.int<64> : !s64i
+            %7 = cir.cmp lt %5, %6 : !s64i
+            cir.condition(%7)
+          } body {
+            cir.yield
+          } step {
+            %5 = cir.load align(8) %3 : !cir.ptr<!s64i>, !s64i
+            %6 = cir.inc nsw %5 : !s64i
+            cir.store align(8) %6, %3 : !s64i, !cir.ptr<!s64i>
+            cir.yield
+          }
+        }
+        cir.yield
+      } step {
+        %3 = cir.load align(8) %1 : !cir.ptr<!s64i>, !s64i
+        %4 = cir.inc nsw %3 : !s64i
+        cir.store align(8) %4, %1 : !s64i, !cir.ptr<!s64i>
+        cir.yield
+      }
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @global_start_not_provable
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @global_start_not_provable() {
+    cir.scope {
+      %0 = cir.alloca "i" align(8) init : !cir.ptr<!s64i>
+      %1 = cir.const #cir.int<0> : !s64i
+      cir.store align(8) %1, %0 : !s64i, !cir.ptr<!s64i>
+      cir.for : cond {
+        %2 = cir.load align(8) %0 : !cir.ptr<!s64i>, !s64i
+        %3 = cir.const #cir.int<64> : !s64i
+        %4 = cir.cmp lt %2, %3 : !s64i
+        cir.condition(%4)
+      } body {
+        cir.scope {
+          %2 = cir.alloca "j" align(8) init : !cir.ptr<!s64i>
+          %3 = cir.get_global @lo_g : !cir.ptr<!s64i>
+          %4 = cir.load align(8) %3 : !cir.ptr<!s64i>, !s64i
+          cir.store align(8) %4, %2 : !s64i, !cir.ptr<!s64i>
+          cir.for : cond {
+            %5 = cir.load align(8) %2 : !cir.ptr<!s64i>, !s64i
+            %6 = cir.const #cir.int<64> : !s64i
+            %7 = cir.cmp lt %5, %6 : !s64i
+            cir.condition(%7)
+          } body {
+            cir.yield
+          } step {
+            %5 = cir.load align(8) %2 : !cir.ptr<!s64i>, !s64i
+            %6 = cir.inc nsw %5 : !s64i
+            cir.store align(8) %6, %2 : !s64i, !cir.ptr<!s64i>
+            cir.yield
+          }
+        }
+        cir.yield
+      } step {
+        %2 = cir.load align(8) %0 : !cir.ptr<!s64i>, !s64i
+        %3 = cir.inc nsw %2 : !s64i
+        cir.store align(8) %3, %0 : !s64i, !cir.ptr<!s64i>
+        cir.yield
+      }
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @start_from_local_not_argument
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @start_from_local_not_argument(%arg0: !s64i) {
+    %0 = cir.alloca "lo" align(8) init : !cir.ptr<!s64i>
+    %1 = cir.alloca "other" align(8) init : !cir.ptr<!s64i>
+    %2 = cir.alloca "start" align(8) init : !cir.ptr<!s64i>
+    cir.store %arg0, %0 : !s64i, !cir.ptr<!s64i>
+    %3 = cir.load align(8) %0 : !cir.ptr<!s64i>, !s64i
+    %4 = cir.const #cir.int<1> : !s64i
+    %5 = cir.add nsw %3, %4 : !s64i
+    cir.store align(8) %5, %1 : !s64i, !cir.ptr<!s64i>
+    %6 = cir.load align(8) %1 : !cir.ptr<!s64i>, !s64i
+    cir.store align(8) %6, %2 : !s64i, !cir.ptr<!s64i>
+    cir.scope {
+      %7 = cir.alloca "i" align(8) init : !cir.ptr<!s64i>
+      %8 = cir.const #cir.int<0> : !s64i
+      cir.store align(8) %8, %7 : !s64i, !cir.ptr<!s64i>
+      cir.for : cond {
+        %9 = cir.load align(8) %7 : !cir.ptr<!s64i>, !s64i
+        %10 = cir.const #cir.int<64> : !s64i
+        %11 = cir.cmp lt %9, %10 : !s64i
+        cir.condition(%11)
+      } body {
+        cir.scope {
+          %9 = cir.alloca "j" align(8) init : !cir.ptr<!s64i>
+          %10 = cir.load align(8) %2 : !cir.ptr<!s64i>, !s64i
+          cir.store align(8) %10, %9 : !s64i, !cir.ptr<!s64i>
+          cir.for : cond {
+            %11 = cir.load align(8) %9 : !cir.ptr<!s64i>, !s64i
+            %12 = cir.const #cir.int<64> : !s64i
+            %13 = cir.cmp lt %11, %12 : !s64i
+            cir.condition(%13)
+          } body {
+            cir.yield
+          } step {
+            %11 = cir.load align(8) %9 : !cir.ptr<!s64i>, !s64i
+            %12 = cir.inc nsw %11 : !s64i
+            cir.store align(8) %12, %9 : !s64i, !cir.ptr<!s64i>
+            cir.yield
+          }
+        }
+        cir.yield
+      } step {
+        %9 = cir.load align(8) %7 : !cir.ptr<!s64i>, !s64i
+        %10 = cir.inc nsw %9 : !s64i
+        cir.store align(8) %10, %7 : !s64i, !cir.ptr<!s64i>
+        cir.yield
+      }
+    }
+    cir.return
+  }
+
+}

--- a/clang/test/CIR/Transforms/loop-opt-product-bound.cir
+++ b/clang/test/CIR/Transforms/loop-opt-product-bound.cir
@@ -1,0 +1,336 @@
+// RUN: cir-opt %s --cir-loop-opt=test-annotate=true -o - | FileCheck %s
+
+!s8i = !cir.int<s, 8>
+!s32i = !cir.int<s, 32>
+!s64i = !cir.int<s, 64>
+
+module {
+  cir.global external @A = #cir.zero : !cir.array<!cir.array<!cir.double x 1024> x 1024>
+  cir.global external @B = #cir.zero : !cir.array<!cir.array<!cir.double x 1024> x 1024>
+
+  // CHECK-LABEL: cir.func @product_swapped_factors()
+  // CHECK-NOT: cir.loopopt.test
+  // CHECK: } {cir.loopopt.test = {kind = "inner_product_upper"}}
+  // CHECK-NEXT: cir.return
+  cir.func @product_swapped_factors() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<1> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<1024> : !s32i
+      %5 = cir.cmp lt %3, %4 : !s32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.const #cir.int<0> : !s32i
+      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %6 = cir.mul nsw %4, %5 : !s32i
+        %7 = cir.const #cir.int<1024> : !s32i
+        %8 = cir.cmp lt %6, %7 : !s32i
+        cir.condition(%8)
+      } body {
+        cir.yield
+      } step {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.inc nsw %4 : !s32i
+        cir.store align(4) %5, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.inc nsw %3 : !s32i
+      cir.store align(4) %4, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @product_of_affine_outer()
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @product_of_affine_outer() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<1> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<1024> : !s32i
+      %5 = cir.cmp lt %3, %4 : !s32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.const #cir.int<0> : !s32i
+      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+        %6 = cir.const #cir.int<1> : !s32i
+        %7 = cir.add nsw %5, %6 : !s32i
+        %8 = cir.mul nsw %4, %7 : !s32i
+        %9 = cir.const #cir.int<1024> : !s32i
+        %10 = cir.cmp lt %8, %9 : !s32i
+        cir.condition(%10)
+      } body {
+        cir.yield
+      } step {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.inc nsw %4 : !s32i
+        cir.store align(4) %5, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.inc nsw %3 : !s32i
+      cir.store align(4) %4, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @product_of_inner_squared()
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @product_of_inner_squared() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<1> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<1024> : !s32i
+      %5 = cir.cmp lt %3, %4 : !s32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.const #cir.int<0> : !s32i
+      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %6 = cir.mul nsw %4, %5 : !s32i
+        %7 = cir.const #cir.int<1024> : !s32i
+        %8 = cir.cmp lt %6, %7 : !s32i
+        cir.condition(%8)
+      } body {
+        cir.yield
+      } step {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.inc nsw %4 : !s32i
+        cir.store align(4) %5, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.inc nsw %3 : !s32i
+      cir.store align(4) %4, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @outer_start_not_positive()
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @outer_start_not_positive() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<0> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<1024> : !s32i
+      %5 = cir.cmp lt %3, %4 : !s32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.const #cir.int<0> : !s32i
+      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+        %6 = cir.mul nsw %4, %5 : !s32i
+        %7 = cir.const #cir.int<1024> : !s32i
+        %8 = cir.cmp lt %6, %7 : !s32i
+        cir.condition(%8)
+      } body {
+        cir.yield
+      } step {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.inc nsw %4 : !s32i
+        cir.store align(4) %5, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.inc nsw %3 : !s32i
+      cir.store align(4) %4, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @limits_differ()
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @limits_differ() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<1> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<1024> : !s32i
+      %5 = cir.cmp lt %3, %4 : !s32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.const #cir.int<0> : !s32i
+      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+        %6 = cir.mul nsw %4, %5 : !s32i
+        %7 = cir.const #cir.int<2048> : !s32i
+        %8 = cir.cmp lt %6, %7 : !s32i
+        cir.condition(%8)
+      } body {
+        cir.yield
+      } step {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.inc nsw %4 : !s32i
+        cir.store align(4) %5, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.inc nsw %3 : !s32i
+      cir.store align(4) %4, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @inner_init_not_zero()
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @inner_init_not_zero() {
+    %0 = cir.alloca "i" align(4) init : !cir.ptr<!s32i>
+    %1 = cir.alloca "j" align(4) init : !cir.ptr<!s32i>
+    %2 = cir.const #cir.int<1> : !s32i
+    cir.store align(4) %2, %0 : !s32i, !cir.ptr<!s32i>
+    cir.for : cond {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.const #cir.int<1024> : !s32i
+      %5 = cir.cmp lt %3, %4 : !s32i
+      cir.condition(%5)
+    } body {
+      %3 = cir.const #cir.int<1> : !s32i
+      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+        %6 = cir.mul nsw %4, %5 : !s32i
+        %7 = cir.const #cir.int<1024> : !s32i
+        %8 = cir.cmp lt %6, %7 : !s32i
+        cir.condition(%8)
+      } body {
+        cir.yield
+      } step {
+        %4 = cir.load align(4) %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.inc nsw %4 : !s32i
+        cir.store align(4) %5, %1 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(4) %0 : !cir.ptr<!s32i>, !s32i
+      %4 = cir.inc nsw %3 : !s32i
+      cir.store align(4) %4, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @product_i8_limit64_fits
+  // CHECK-NOT: cir.loopopt.test
+  // CHECK: } {cir.loopopt.test = {kind = "inner_product_upper"}}
+  // CHECK-NEXT: cir.return
+  cir.func @product_i8_limit64_fits() {
+    %0 = cir.alloca "i" align(1) init : !cir.ptr<!s8i>
+    %1 = cir.alloca "j" align(1) init : !cir.ptr<!s8i>
+    %2 = cir.const #cir.int<1> : !s8i
+    cir.store align(1) %2, %0 : !s8i, !cir.ptr<!s8i>
+    cir.for : cond {
+      %3 = cir.load align(1) %0 : !cir.ptr<!s8i>, !s8i
+      %4 = cir.const #cir.int<64> : !s8i
+      %5 = cir.cmp lt %3, %4 : !s8i
+      cir.condition(%5)
+    } body {
+      %3 = cir.const #cir.int<0> : !s8i
+      cir.store align(1) %3, %1 : !s8i, !cir.ptr<!s8i>
+      cir.for : cond {
+        %4 = cir.load align(1) %1 : !cir.ptr<!s8i>, !s8i
+        %5 = cir.load align(1) %0 : !cir.ptr<!s8i>, !s8i
+        %6 = cir.mul nsw %4, %5 : !s8i
+        %7 = cir.const #cir.int<64> : !s8i
+        %8 = cir.cmp lt %6, %7 : !s8i
+        cir.condition(%8)
+      } body {
+        cir.yield
+      } step {
+        %4 = cir.load align(1) %1 : !cir.ptr<!s8i>, !s8i
+        %5 = cir.inc nsw %4 : !s8i
+        cir.store align(1) %5, %1 : !s8i, !cir.ptr<!s8i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(1) %0 : !cir.ptr<!s8i>, !s8i
+      %4 = cir.inc nsw %3 : !s8i
+      cir.store align(1) %4, %0 : !s8i, !cir.ptr<!s8i>
+      cir.yield
+    }
+    cir.return
+  }
+
+  // CHECK-LABEL: cir.func @product_i8_limit65_overflows
+  // CHECK-NOT: cir.loopopt.test
+  cir.func @product_i8_limit65_overflows() {
+    %0 = cir.alloca "i" align(1) init : !cir.ptr<!s8i>
+    %1 = cir.alloca "j" align(1) init : !cir.ptr<!s8i>
+    %2 = cir.const #cir.int<1> : !s8i
+    cir.store align(1) %2, %0 : !s8i, !cir.ptr<!s8i>
+    cir.for : cond {
+      %3 = cir.load align(1) %0 : !cir.ptr<!s8i>, !s8i
+      %4 = cir.const #cir.int<65> : !s8i
+      %5 = cir.cmp lt %3, %4 : !s8i
+      cir.condition(%5)
+    } body {
+      %3 = cir.const #cir.int<0> : !s8i
+      cir.store align(1) %3, %1 : !s8i, !cir.ptr<!s8i>
+      cir.for : cond {
+        %4 = cir.load align(1) %1 : !cir.ptr<!s8i>, !s8i
+        %5 = cir.load align(1) %0 : !cir.ptr<!s8i>, !s8i
+        %6 = cir.mul nsw %4, %5 : !s8i
+        %7 = cir.const #cir.int<65> : !s8i
+        %8 = cir.cmp lt %6, %7 : !s8i
+        cir.condition(%8)
+      } body {
+        cir.yield
+      } step {
+        %4 = cir.load align(1) %1 : !cir.ptr<!s8i>, !s8i
+        %5 = cir.inc nsw %4 : !s8i
+        cir.store align(1) %5, %1 : !s8i, !cir.ptr<!s8i>
+        cir.yield
+      }
+      cir.yield
+    } step {
+      %3 = cir.load align(1) %0 : !cir.ptr<!s8i>, !s8i
+      %4 = cir.inc nsw %3 : !s8i
+      cir.store align(1) %4, %0 : !s8i, !cir.ptr<!s8i>
+      cir.yield
+    }
+    cir.return
+  }
+}

--- a/clang/tools/cir-opt/cir-opt.cpp
+++ b/clang/tools/cir-opt/cir-opt.cpp
@@ -77,6 +77,10 @@ int main(int argc, char **argv) {
   });
 
   ::mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
+    return mlir::createLoopOptPass();
+  });
+
+  ::mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
     return mlir::createCallConvLoweringPass();
   });
 


### PR DESCRIPTION
Eight loop nests were found where LLVM declines to interchange because it cannot read the inner loop structure, even though its own dependence analysis succeeds first. While cir.for still carries the nest and the bounds are visible operations, the same structure is straightforward to read.

This adds recognition of counted loops and classification of a nest of two of them into four domain families. inner_affine_upper records the inner limit as scale times the outer induction variable plus offset. outer_iv_inner_start covers an inner loop that starts at the outer counter and shares its limit. inner_product_upper covers a product of both counters compared against a constant. invariant_inner_start covers a start proven fixed for the whole nest. The eight nests map onto these four.

Recognition identifies the induction slot, its initialization, the exit test and a unit step. The slot must not escape and may be written inside the loop only by the matched step. Control expressions come from a small vocabulary and fold with checked arithmetic, so overflow, division by zero and saturating operations fail rather than yield a wrong domain.

What is reported is the domain the loop control implies, and nothing about the body. Three of the nests share one loop control and differ only in what they compute, so they classify alike, and a loop that can leave early is still recognized with the domain its control spells out. Deciding what an early exit, a memory dependence or a perfect nest means for a rewrite belongs to a legality layer above this one. Dependence, alias analysis, legality and transformation are all outside this change, and the pass performs no transformation.

Under test-annotate each recognized nest records a cir.loopopt.test attribute naming its family, which is how the classification is validated. Without that option the IR is unchanged.