### PR TITLE
[HIP] Fix OffloadBundler triple when using extra 'llvm' environment

### DIFF
--- a/clang/test/OffloadTools/clang-linker-wrapper/linker-wrapper.c
+++ b/clang/test/OffloadTools/clang-linker-wrapper/linker-wrapper.c
@@ -133,6 +133,31 @@ __attribute__((visibility("protected"), used)) int x;
 // HIP: clang{{.*}} -o [[IMG_GFX908:.+]] -dumpdir a.out.amdgpu9.08.gfx908.img. --target=amdgpu9.08-amd-amdhsa -mcpu=gfx908
 // HIP: clang-offload-bundler{{.*}}-type=o -bundle-align=4096 -compress -compression-level=6 -targets=host-x86_64-unknown-linux-gnu,hip-amdgpu9.0a-amd-amdhsa--gfx90a,hip-amdgpu9.08-amd-amdhsa--gfx908 -input={{/dev/null|NUL}} -input=[[IMG_GFX90A]] -input=[[IMG_GFX908]] -output={{.*}}.hipfb
 
+// The 'amdgpu' architecture is only valid with a subarch, so it is resolved
+// against each image's architecture, including through a target ID's features.
+
+// RUN: llvm-offload-binary -o %t.out \
+// RUN:   --image=file=%t.elf.o,kind=hip,triple=amdgpu-amd-amdhsa,arch=gfx90a:xnack+ \
+// RUN:   --image=file=%t.elf.o,kind=hip,triple=amdgpu-amd-amdhsa,arch=gfx1010
+// RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t.o \
+// RUN:   -fembed-offload-object=%t.out
+// RUN: clang-linker-wrapper --dry-run --host-triple=x86_64-unknown-linux-gnu \
+// RUN:   --linker-path=/usr/bin/ld %t.o -o a.out 2>&1 | FileCheck %s --check-prefix=HIP-SUBARCH
+
+// HIP-SUBARCH: clang-offload-bundler{{.*}}-targets=host-x86_64-unknown-linux-gnu,hip-amdgpu9.0a-amd-amdhsa--gfx90a:xnack+,hip-amdgpu10.10-amd-amdhsa--gfx1010
+
+// The legacy 'amdgcn' spelling is the one valid subarch-less form, so it must be
+// left alone.
+
+// RUN: llvm-offload-binary -o %t-legacy-hip.out \
+// RUN:   --image=file=%t.elf.o,kind=hip,triple=amdgcn-amd-amdhsa,arch=gfx90a
+// RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t-legacy-hip.o \
+// RUN:   -fembed-offload-object=%t-legacy-hip.out
+// RUN: clang-linker-wrapper --dry-run --host-triple=x86_64-unknown-linux-gnu \
+// RUN:   --linker-path=/usr/bin/ld %t-legacy-hip.o -o a.out 2>&1 | FileCheck %s --check-prefix=HIP-LEGACY
+
+// HIP-LEGACY: clang-offload-bundler{{.*}}-targets=host-x86_64-unknown-linux-gnu,hip-amdgcn-amd-amdhsa--gfx90a
+
 // RUN: llvm-offload-binary -o %t.out \
 // RUN:   --image=file=%t.elf.o,kind=openmp,triple=amdgpu9.08-amd-amdhsa,arch=gfx908 \
 // RUN:   --image=file=%t.elf.o,kind=openmp,triple=nvptx64-nvidia-cuda,arch=sm_70

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -52,6 +52,7 @@
 #include "llvm/Support/WithColor.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Target/TargetMachine.h"
+#include "llvm/TargetParser/AMDGPUTargetParser.h"
 #include "llvm/TargetParser/Host.h"
 #include <optional>
 
@@ -431,11 +432,25 @@ namespace amdgcn {
 // Constructs a triple string for clang offload bundler.
 // NOTE: copied from HIPUtility.cpp.
 static std::string normalizeForBundler(const llvm::Triple &T,
-                                       bool HasTargetID) {
-  return HasTargetID ? (T.getArchName() + "-" + T.getVendorName() + "-" +
-                        T.getOSName() + "-" + T.getEnvironmentName())
-                           .str()
-                     : T.normalize(llvm::Triple::CanonicalForm::FOUR_IDENT);
+                                       StringRef TargetID) {
+  // The new 'amdgpu' target is expected to have a subarchitecture. Use the
+  // known architecture if one does not exist.
+  llvm::Triple Normalized = T;
+  if (Normalized.isAMDGCN() &&
+      Normalized.getSubArch() == llvm::Triple::NoSubArch &&
+      Normalized.getArchName() != "amdgcn") {
+    llvm::AMDGPU::GPUKind Kind =
+        llvm::AMDGPU::parseArchAMDGCN(TargetID.split(':').first);
+    if (Kind != llvm::AMDGPU::GK_NONE)
+      Normalized.setArch(llvm::Triple::amdgpu, llvm::AMDGPU::getSubArch(Kind));
+  }
+
+  return !TargetID.empty()
+             ? (Normalized.getArchName() + "-" + Normalized.getVendorName() +
+                "-" + Normalized.getOSName() + "-" +
+                Normalized.getEnvironmentName())
+                   .str()
+             : Normalized.normalize(llvm::Triple::CanonicalForm::FOUR_IDENT);
 }
 
 Expected<StringRef>
@@ -473,8 +488,7 @@ fatbinary(ArrayRef<std::tuple<StringRef, StringRef, StringRef>> InputFiles,
   SmallVector<StringRef> Targets = {
       Saver.save("-targets=host-" + HostTriple.normalize())};
   for (const auto &[File, TripleRef, Arch] : InputFiles) {
-    std::string NormalizedTriple =
-        normalizeForBundler(Triple(TripleRef), !Arch.empty());
+    std::string NormalizedTriple = normalizeForBundler(Triple(TripleRef), Arch);
     Targets.push_back(Saver.save("hip-" + NormalizedTriple + "-" + Arch));
   }
   CmdArgs.push_back(Saver.save(llvm::join(Targets, ",")));


### PR DESCRIPTION
Summary:
COMGr currently rejects `amdgpu-amd-amdhsa` without a subarchitecture.
We know what it is from the architecture argument when constructing
this, so we should append it if a user gets to this path conservatively.