### PR TITLE
[LLVMCAS] libCASPluginTest should link libpthread

### DIFF
--- a/llvm/tools/libCASPluginTest/CMakeLists.txt
+++ b/llvm/tools/libCASPluginTest/CMakeLists.txt
@@ -15,4 +15,6 @@ set(SOURCES
 
 set(LLVM_EXPORTED_SYMBOL_FILE ${CMAKE_CURRENT_SOURCE_DIR}/libCASPluginTest.exports)
 
-add_llvm_library(CASPluginTest SHARED ${SOURCES})
+add_llvm_library(CASPluginTest SHARED ${SOURCES}
+  LINK_LIBS ${LLVM_PTHREAD_LIB}
+)


### PR DESCRIPTION
Fix ppc build after #213331. libCASPluginTest should link libpthread
since the mock implementation uses a threadpool.
