### PR TITLE
[RegAlloc] Add a hook for default target specific CSR cost scale

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
@@ -866,9 +866,18 @@ public:
   /// Allow the target to override the cost of using a callee-saved register for
   /// the first time. Default value of 0 means we will use a callee-saved
   /// register if it is available.
-  virtual unsigned getCSRFirstUseCost() const { return 0; }
+  virtual unsigned getCSRFirstUseCost(const MachineFunction &MF) const {
+    return 0;
+  }
   /// FIXME: We should deprecate this usage.
   virtual unsigned getCSRCost() const { return 0; }
+
+  /// Scale the CSRFirstUseCost with this number.
+  /// The scale is a percentage (e.g., 30 means 30% of the base cost).
+  /// Target can tune and override this default value.
+  virtual unsigned getCSRCostScale(const MachineFunction &MF) const {
+    return 30;
+  }
 
   /// Returns true if the target requires (and can make use of) the register
   /// scavenger.

--- a/llvm/lib/CodeGen/RegAllocGreedy.cpp
+++ b/llvm/lib/CodeGen/RegAllocGreedy.cpp
@@ -2452,11 +2452,16 @@ void RAGreedy::initializeCSRCost() {
     }
   } else {
     uint64_t EntryFreq = MBFI->getEntryFreq().getFrequency();
-    CSRCost = BlockFrequency(TRI->getCSRFirstUseCost() * EntryFreq);
-    if (CSRCostScale < 100)
-      CSRCost *= BranchProbability(CSRCostScale, 100);
+    CSRCost = BlockFrequency(TRI->getCSRFirstUseCost(*MF) * EntryFreq);
+    unsigned Scale = TRI->getCSRCostScale(*MF);
+    // Command line specified CSRCostScale can override target's default value.
+    if (CSRCostScale.getNumOccurrences())
+      Scale = CSRCostScale;
+
+    if (Scale < 100)
+      CSRCost *= BranchProbability(Scale, 100);
     else
-      CSRCost /= BranchProbability(100, CSRCostScale);
+      CSRCost /= BranchProbability(100, Scale);
   }
 }
 

--- a/llvm/lib/Target/AArch64/AArch64RegisterInfo.h
+++ b/llvm/lib/Target/AArch64/AArch64RegisterInfo.h
@@ -60,7 +60,7 @@ public:
     // cold path instead of using a callee-saved register.
     return 5;
   }
-  unsigned getCSRFirstUseCost() const override {
+  unsigned getCSRFirstUseCost(const MachineFunction &MF) const override {
     // The cost of 2 means push and pop for each CSR.
     return 2;
   }


### PR DESCRIPTION
Callee saved register optimization needs a scale number (in percentage) to tune the callee saved register cost. The optimal scale number depends on ISA, micro architecture and other factors. So targets can use this hook to set a target specific optimal number.

This pr is split from pr188609 and was originally proposed by @williamweixiao in pr202007.