### PR TITLE
[lldb] Use StringRef when creating Listeners

### DIFF
--- a/lldb/include/lldb/Utility/Listener.h
+++ b/lldb/include/lldb/Utility/Listener.h
@@ -44,10 +44,10 @@ public:
   // Listeners have to be constructed into shared pointers - at least if you
   // want them to listen to Broadcasters,
 protected:
-  Listener(const char *name);
+  Listener(llvm::StringRef name);
 
 public:
-  static lldb::ListenerSP MakeListener(const char *name);
+  static lldb::ListenerSP MakeListener(llvm::StringRef name);
 
   ~Listener();
 

--- a/lldb/include/lldb/Utility/Listener.h
+++ b/lldb/include/lldb/Utility/Listener.h
@@ -44,7 +44,7 @@ public:
   // Listeners have to be constructed into shared pointers - at least if you
   // want them to listen to Broadcasters,
 protected:
-  Listener(llvm::StringRef name);
+  Listener(std::string name);
 
 public:
   static lldb::ListenerSP MakeListener(llvm::StringRef name);

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -2358,15 +2358,14 @@ bool Debugger::StartEventHandlerThread() {
     // is up and running and listening to events before we return from this
     // function. We do this by listening to events for the
     // eBroadcastBitEventThreadIsListening from the m_sync_broadcaster
-    ConstString full_name("lldb.debugger.event-handler");
-    ListenerSP listener_sp(
-        Listener::MakeListener(full_name.AsCString(nullptr)));
+    llvm::StringRef full_name("lldb.debugger.event-handler");
+    ListenerSP listener_sp(Listener::MakeListener(full_name));
     listener_sp->StartListeningForEvents(&m_sync_broadcaster,
                                          eBroadcastBitEventThreadIsListening);
 
     llvm::StringRef thread_name =
-        full_name.GetLength() < llvm::get_max_thread_name_length()
-            ? full_name.GetStringRef()
+        full_name.size() < llvm::get_max_thread_name_length()
+            ? full_name
             : "dbg.evt-handler";
 
     // Use larger 8MB stack for this thread

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -1365,7 +1365,7 @@ Status Process::ResumeSynchronous(Stream *stream) {
   }
 
   ListenerSP listener_sp(
-      Listener::MakeListener(ResumeSynchronousHijackListenerName.data()));
+      Listener::MakeListener(ResumeSynchronousHijackListenerName));
   HijackProcessEvents(listener_sp);
 
   Status error = PrivateResume();

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -3654,8 +3654,8 @@ Status Target::Launch(ProcessLaunchInfo &launch_info, Stream *stream) {
   // its own hijacking listener or if the process is created by the target
   // manually, without the platform).
   if (!launch_info.GetHijackListener())
-    launch_info.SetHijackListener(Listener::MakeListener(
-        Process::LaunchSynchronousHijackListenerName.data()));
+    launch_info.SetHijackListener(
+        Listener::MakeListener(Process::LaunchSynchronousHijackListenerName));
 
   // If we're not already connected to the process, and if we have a platform
   // that can launch a process for debugging, go ahead and do that here.
@@ -3836,8 +3836,8 @@ Status Target::Attach(ProcessAttachInfo &attach_info, Stream *stream) {
   ListenerSP hijack_listener_sp;
   const bool async = attach_info.GetAsync();
   if (!async) {
-    hijack_listener_sp = Listener::MakeListener(
-        Process::AttachSynchronousHijackListenerName.data());
+    hijack_listener_sp =
+        Listener::MakeListener(Process::AttachSynchronousHijackListenerName);
     attach_info.SetHijackListener(hijack_listener_sp);
   }
 

--- a/lldb/source/Utility/Listener.cpp
+++ b/lldb/source/Utility/Listener.cpp
@@ -18,7 +18,7 @@
 using namespace lldb;
 using namespace lldb_private;
 
-Listener::Listener(const char *name) : m_name(name) {
+Listener::Listener(llvm::StringRef name) : m_name(name.str()) {
   LLDB_LOGF(GetLog(LLDBLog::Object), "%p Listener::Listener('%s')",
             static_cast<void *>(this), m_name.c_str());
 }
@@ -370,6 +370,6 @@ bool Listener::StopListeningForEventSpec(const BroadcasterManagerSP &manager_sp,
                                                        event_spec);
 }
 
-ListenerSP Listener::MakeListener(const char *name) {
+ListenerSP Listener::MakeListener(llvm::StringRef name) {
   return ListenerSP(new Listener(name));
 }

--- a/lldb/source/Utility/Listener.cpp
+++ b/lldb/source/Utility/Listener.cpp
@@ -18,7 +18,7 @@
 using namespace lldb;
 using namespace lldb_private;
 
-Listener::Listener(llvm::StringRef name) : m_name(name.str()) {
+Listener::Listener(std::string name) : m_name(std::move(name)) {
   LLDB_LOGF(GetLog(LLDBLog::Object), "%p Listener::Listener('%s')",
             static_cast<void *>(this), m_name.c_str());
 }
@@ -371,5 +371,5 @@ bool Listener::StopListeningForEventSpec(const BroadcasterManagerSP &manager_sp,
 }
 
 ListenerSP Listener::MakeListener(llvm::StringRef name) {
-  return ListenerSP(new Listener(name));
+  return ListenerSP(new Listener(name.str()));
 }


### PR DESCRIPTION
This is primarily motivated to remove the last ConstString from Debugger.cpp. It would have been possible to write this change without changing Listener, but then I noticed a few places where we would have benefitted from changing the interface.