### PR TITLE
[docs] Remove TOCs from Clang docs to prepare for Furo migration

### DIFF
--- a/clang/Maintainers.md
+++ b/clang/Maintainers.md
@@ -5,9 +5,6 @@ This file is a list of the
 for Clang. The list of current Clang Area Team members can be found
 [here](https://github.com/llvm/llvm-project/blob/main/clang/AreaTeamMembers.txt).
 
-```{contents} Table of Contents
-:depth: 2
-```
 
 # Active Maintainers
 

--- a/clang/docs/AMDGPUSupport.md
+++ b/clang/docs/AMDGPUSupport.md
@@ -1,6 +1,3 @@
-```{contents}
-:local: true
-```
 
 # AMDGPU Support
 

--- a/clang/docs/AddressSanitizer.md
+++ b/clang/docs/AddressSanitizer.md
@@ -1,8 +1,5 @@
 # AddressSanitizer
 
-```{contents}
-:local: true
-```
 
 ## Introduction
 

--- a/clang/docs/AllocToken.md
+++ b/clang/docs/AllocToken.md
@@ -1,8 +1,5 @@
 # Allocation Tokens
 
-```{contents}
-:local: true
-```
 
 ## Introduction
 

--- a/clang/docs/AutomaticReferenceCounting.md
+++ b/clang/docs/AutomaticReferenceCounting.md
@@ -65,9 +65,6 @@
 
 # Objective-C Automatic Reference Counting (ARC)
 
-```{contents}
-:local: true
-```
 
 (arc.meta)=
 

--- a/clang/docs/Block-ABI-Apple.md
+++ b/clang/docs/Block-ABI-Apple.md
@@ -1,8 +1,5 @@
 # Block Implementation Specification
 
-```{contents}
-:local: true
-```
 
 ## History
 

--- a/clang/docs/BlockLanguageSpec.md
+++ b/clang/docs/BlockLanguageSpec.md
@@ -3,9 +3,6 @@
 
 # Language Specification for Blocks
 
-```{contents}
-:local: true
-```
 
 ## Revisions
 

--- a/clang/docs/BoundsSafety.md
+++ b/clang/docs/BoundsSafety.md
@@ -1,8 +1,5 @@
 # `-fbounds-safety`: Enforcing bounds safety for C
 
-```{contents}
-:local:
-```
 
 ## Overview
 

--- a/clang/docs/BoundsSafetyAdoptionGuide.md
+++ b/clang/docs/BoundsSafetyAdoptionGuide.md
@@ -1,8 +1,5 @@
 # Adoption Guide for `-fbounds-safety`
 
-```{contents}
-:local: true
-```
 
 ## Where to get `-fbounds-safety`
 

--- a/clang/docs/BoundsSafetyImplPlans.md
+++ b/clang/docs/BoundsSafetyImplPlans.md
@@ -1,8 +1,5 @@
 # Implementation plans for `-fbounds-safety`
 
-```{contents}
-:local: true
-```
 
 (bounds-safety-current-upstream-status)=
 ## Current status of `-fbounds-safety` support in upstream Clang

--- a/clang/docs/CIR/ABILowering.md
+++ b/clang/docs/CIR/ABILowering.md
@@ -1,8 +1,5 @@
 # ClangIR ABI Lowering Design Document
 
-```{contents}
-:local: true
-```
 
 ## Introduction
 

--- a/clang/docs/CIR/CleanupAndEHDesign.md
+++ b/clang/docs/CIR/CleanupAndEHDesign.md
@@ -1,8 +1,5 @@
 # ClangIR Cleanup and Exception Handling Design
 
-```{contents}
-:local: true
-```
 
 ## Overview
 

--- a/clang/docs/CIR/CodeDuplication.md
+++ b/clang/docs/CIR/CodeDuplication.md
@@ -1,8 +1,5 @@
 # ClangIR Code Duplication Roadmap
 
-```{contents}
-:local: true
-```
 
 ## Introduction
 

--- a/clang/docs/CXXTypeAwareAllocators.md
+++ b/clang/docs/CXXTypeAwareAllocators.md
@@ -1,8 +1,5 @@
 # C++ Type Aware Allocators
 
-```{contents}
-:local: true
-```
 
 ## Introduction
 

--- a/clang/docs/ClangLinkerWrapper.md
+++ b/clang/docs/ClangLinkerWrapper.md
@@ -1,8 +1,5 @@
 # Clang Linker Wrapper
 
-```{contents}
-:local:
-```
 
 ## Introduction
 

--- a/clang/docs/ClangNVLinkWrapper.md
+++ b/clang/docs/ClangNVLinkWrapper.md
@@ -1,8 +1,5 @@
 # Clang nvlink Wrapper
 
-```{contents}
-:local:
-```
 
 ## Introduction
 

--- a/clang/docs/ClangOffloadBundler.md
+++ b/clang/docs/ClangOffloadBundler.md
@@ -1,8 +1,5 @@
 # Clang Offload Bundler
 
-```{contents}
-:local:
-```
 
 ## Introduction
 

--- a/clang/docs/ClangSYCLLinker.md
+++ b/clang/docs/ClangSYCLLinker.md
@@ -1,8 +1,5 @@
 # Clang SYCL Linker
 
-```{contents}
-:local:
-```
 
 ## Introduction
 

--- a/clang/docs/ClangTransformerTutorial.md
+++ b/clang/docs/ClangTransformerTutorial.md
@@ -2,9 +2,6 @@
 
 A tutorial on how to write a source-to-source translation tool using Clang Transformer.
 
-```{contents}
-:local:
-```
 
 ## What is Clang Transformer?
 

--- a/clang/docs/ConstantInterpreter.md
+++ b/clang/docs/ConstantInterpreter.md
@@ -1,8 +1,5 @@
 # Constant Interpreter
 
-```{contents}
-:local: true
-```
 
 ## Introduction
 

--- a/clang/docs/ControlFlowIntegrity.md
+++ b/clang/docs/ControlFlowIntegrity.md
@@ -6,9 +6,6 @@
 ControlFlowIntegrityDesign
 ```
 
-```{contents}
-:local: true
-```
 
 ## Introduction
 

--- a/clang/docs/DataFlowSanitizer.md
+++ b/clang/docs/DataFlowSanitizer.md
@@ -6,9 +6,6 @@
 DataFlowSanitizerDesign
 ```
 
-```{contents}
-:local: true
-```
 
 ## Introduction
 

--- a/clang/docs/DebuggingCoroutines.md
+++ b/clang/docs/DebuggingCoroutines.md
@@ -1,8 +1,5 @@
 # Debugging C++ Coroutines
 
-```{contents}
-:local: true
-```
 
 ## Introduction
 

--- a/clang/docs/DriverInternals.md
+++ b/clang/docs/DriverInternals.md
@@ -1,8 +1,5 @@
 # Driver Design & Internals
 
-```{contents}
-:local:
-```
 
 ## Introduction
 
@@ -19,9 +16,6 @@ interface which is compatible with the gcc driver.
 Although the driver is part of and driven by the Clang project, it is
 logically a separate tool which shares many of the same goals as Clang:
 
-```{contents} Features
-:local:
-```
 
 ### GCC Compatibility
 
@@ -66,10 +60,6 @@ monolithic task.
 
 ## Internal Design and Implementation
 
-```{contents}
-:depth: 1
-:local:
-```
 
 ### Internals Introduction
 

--- a/clang/docs/FAQ.md
+++ b/clang/docs/FAQ.md
@@ -1,8 +1,5 @@
 # Frequently Asked Questions (FAQ)
 
-```{contents}
-:local: true
-```
 
 ## Driver
 

--- a/clang/docs/FunctionEffectAnalysis.md
+++ b/clang/docs/FunctionEffectAnalysis.md
@@ -1,9 +1,5 @@
 # Function Effect Analysis
 
-```{contents}
-:depth: 3
-:local:
-```
 
 ## Introduction
 

--- a/clang/docs/HIPSupport.md
+++ b/clang/docs/HIPSupport.md
@@ -15,9 +15,6 @@
 ```{role} good
 ```
 
-```{contents}
-:local:
-```
 
 # HIP Support
 

--- a/clang/docs/HLSL/AvailabilityDiagnostics.md
+++ b/clang/docs/HLSL/AvailabilityDiagnostics.md
@@ -1,8 +1,5 @@
 # HLSL Availability Diagnostics
 
-```{contents}
-:local: true
-```
 
 ## Introduction
 

--- a/clang/docs/HLSL/EntryFunctions.md
+++ b/clang/docs/HLSL/EntryFunctions.md
@@ -1,8 +1,5 @@
 # HLSL Entry Functions
 
-```{contents}
-:local: true
-```
 
 ## Usage
 

--- a/clang/docs/HLSL/ExpectedDifferences.md
+++ b/clang/docs/HLSL/ExpectedDifferences.md
@@ -1,8 +1,5 @@
 # Expected Differences vs DXC and FXC
 
-```{contents}
-:local: true
-```
 
 ## Introduction
 

--- a/clang/docs/HLSL/FunctionCalls.md
+++ b/clang/docs/HLSL/FunctionCalls.md
@@ -1,8 +1,5 @@
 # HLSL Function Calls
 
-```{contents}
-:local: true
-```
 
 ## Introduction
 

--- a/clang/docs/HLSL/HLSLIRReference.md
+++ b/clang/docs/HLSL/HLSLIRReference.md
@@ -1,8 +1,5 @@
 # HLSL IR Reference
 
-```{contents}
-:local: true
-```
 
 ## Introduction
 

--- a/clang/docs/HLSL/HLSLSupport.md
+++ b/clang/docs/HLSL/HLSLSupport.md
@@ -1,8 +1,5 @@
 # HLSL Support
 
-```{contents}
-:local: true
-```
 
 ## Introduction
 

--- a/clang/docs/HLSL/ResourceTypes.md
+++ b/clang/docs/HLSL/ResourceTypes.md
@@ -1,8 +1,5 @@
 # HLSL Resource Types
 
-```{contents}
-:local: true
-```
 
 ## Introduction
 

--- a/clang/docs/HardwareAssistedAddressSanitizer.md
+++ b/clang/docs/HardwareAssistedAddressSanitizer.md
@@ -1,8 +1,5 @@
 # Hardware-assisted AddressSanitizer
 
-```{contents}
-:local: true
-```
 
 ## Introduction
 

--- a/clang/docs/InternalsManual.md
+++ b/clang/docs/InternalsManual.md
@@ -1,8 +1,5 @@
 # "Clang" CFE Internals Manual
 
-```{contents}
-:local:
-```
 
 ## Introduction
 

--- a/clang/docs/LLVMExceptionHandlingCodeGen.md
+++ b/clang/docs/LLVMExceptionHandlingCodeGen.md
@@ -1,8 +1,5 @@
 # LLVM IR Generation for EH and Cleanups
 
-```{contents}
-:local: true
-```
 
 ## Overview
 

--- a/clang/docs/LLVMExceptionHandlingCodeGen.rst
+++ b/clang/docs/LLVMExceptionHandlingCodeGen.rst
@@ -2,9 +2,6 @@
 LLVM IR Generation for EH and Cleanups
 ========================================
 
-.. contents::
-   :local:
-
 Overview
 ========
 

--- a/clang/docs/LanguageExtensions.md
+++ b/clang/docs/LanguageExtensions.md
@@ -1,9 +1,5 @@
 # Clang Language Extensions
 
-```{contents}
-:depth: 1
-:local: true
-```
 
 ```{toctree}
 :hidden: true

--- a/clang/docs/LeakSanitizer.md
+++ b/clang/docs/LeakSanitizer.md
@@ -1,8 +1,5 @@
 # LeakSanitizer
 
-```{contents}
-:local: true
-```
 
 ## Introduction
 

--- a/clang/docs/LibASTImporter.md
+++ b/clang/docs/LibASTImporter.md
@@ -8,9 +8,6 @@ to the Clang AST <IntroductionToTheClangAST>` if you want to learn more
 about how the AST is structured.
 Knowledge about {doc}`matching the Clang AST <LibASTMatchers>` and the [reference for the matchers](https://clang.llvm.org/docs/LibASTMatchersReference.html) are also useful.
 
-```{contents}
-:local:
-```
 
 ## Introduction
 

--- a/clang/docs/LifetimeSafety.md
+++ b/clang/docs/LifetimeSafety.md
@@ -1,8 +1,5 @@
 # Lifetime Safety Analysis
 
-```{contents}
-:local: true
-```
 
 ## Introduction
 

--- a/clang/docs/MatrixTypes.md
+++ b/clang/docs/MatrixTypes.md
@@ -1,8 +1,5 @@
 # Matrix Types
 
-```{contents}
-:local: true
-```
 
 (matrixtypes)=
 

--- a/clang/docs/MatrixTypes.rst
+++ b/clang/docs/MatrixTypes.rst
@@ -2,9 +2,6 @@
 Matrix Types
 ==================
 
-.. contents::
-   :local:
-
 .. _matrixtypes:
 
 Clang provides a C/C++ language extension that allows users to directly express

--- a/clang/docs/MemorySanitizer.md
+++ b/clang/docs/MemorySanitizer.md
@@ -1,8 +1,5 @@
 # MemorySanitizer
 
-```{contents}
-:local: true
-```
 
 ## Introduction
 

--- a/clang/docs/MisExpect.md
+++ b/clang/docs/MisExpect.md
@@ -1,7 +1,5 @@
 # Misexpect
 
-```{contents}
-```
 
 ```{toctree}
 :maxdepth: 1

--- a/clang/docs/Modules.md
+++ b/clang/docs/Modules.md
@@ -1,8 +1,5 @@
 # Modules
 
-```{contents}
-:local:
-```
 
 ## Introduction
 

--- a/clang/docs/OffloadingDesign.md
+++ b/clang/docs/OffloadingDesign.md
@@ -1,8 +1,5 @@
 # Offloading Design & Internals
 
-```{contents}
-:local: true
-```
 
 ## Introduction
 

--- a/clang/docs/OffloadingDesign.rst
+++ b/clang/docs/OffloadingDesign.rst
@@ -2,9 +2,6 @@
 Offloading Design & Internals
 =============================
 
-.. contents::
-   :local:
-
 Introduction
 ============
 

--- a/clang/docs/OpenCLSupport.md
+++ b/clang/docs/OpenCLSupport.md
@@ -6,9 +6,6 @@
 </style>
 ```
 
-```{contents}
-:local:
-```
 
 # OpenCL Support
 

--- a/clang/docs/OpenMPSupport.md
+++ b/clang/docs/OpenMPSupport.md
@@ -15,9 +15,6 @@
 ```{role} good
 ```
 
-```{contents}
-:local:
-```
 
 # OpenMP Support
 

--- a/clang/docs/OverflowBehaviorTypes.md
+++ b/clang/docs/OverflowBehaviorTypes.md
@@ -1,8 +1,5 @@
 # OverflowBehaviorTypes
 
-```{contents}
-:local:
-```
 
 ## Introduction
 

--- a/clang/docs/PCHInternals.md
+++ b/clang/docs/PCHInternals.md
@@ -1,8 +1,5 @@
 # Precompiled Header and Modules Internals
 
-```{contents}
-:local: true
-```
 
 This document describes the design and implementation of Clang's precompiled
 headers (PCH) and modules. If you are interested in the end-user view, please

--- a/clang/docs/PCHInternals.rst
+++ b/clang/docs/PCHInternals.rst
@@ -2,9 +2,6 @@
 Precompiled Header and Modules Internals
 ========================================
 
-.. contents::
-   :local:
-
 This document describes the design and implementation of Clang's precompiled
 headers (PCH) and modules.  If you are interested in the end-user view, please
 see the :ref:`User's Manual <usersmanual-precompiled-headers>`.

--- a/clang/docs/PointerAuthentication.md
+++ b/clang/docs/PointerAuthentication.md
@@ -1,8 +1,5 @@
 # Pointer Authentication
 
-```{contents}
-:local:
-```
 
 ## Introduction
 

--- a/clang/docs/RISCVSupport.md
+++ b/clang/docs/RISCVSupport.md
@@ -1,8 +1,5 @@
 # RISC-V Support
 
-```{contents}
-:local: true
-```
 
 ## Intrinsic Detection Macros
 

--- a/clang/docs/RealtimeSanitizer.md
+++ b/clang/docs/RealtimeSanitizer.md
@@ -1,8 +1,5 @@
 # RealtimeSanitizer
 
-```{contents}
-:local: true
-```
 
 ## Introduction
 

--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -12,10 +12,6 @@ myst:
 {#clang-release-releasenotestitle}
 # Clang {{ (('(In-Progress) ' if env.app.tags.has('PreRelease') else '') ~ 'Release Notes') if env.config.project == 'Clang' else '|ReleaseNotesTitle|' }}
 
-```{contents}
-:depth: 2
-:local:
-```
 
 Written by the [LLVM Team](https://llvm.org/)
 

--- a/clang/docs/SYCLSupport.md
+++ b/clang/docs/SYCLSupport.md
@@ -1,8 +1,5 @@
 # SYCL Compiler and Runtime architecture design
 
-```{contents}
-:local:
-```
 
 ## Introduction
 

--- a/clang/docs/SafeBuffers.md
+++ b/clang/docs/SafeBuffers.md
@@ -1,8 +1,5 @@
 # C++ Safe Buffers
 
-```{contents}
-:local: true
-```
 
 ## Introduction
 

--- a/clang/docs/SafeStack.md
+++ b/clang/docs/SafeStack.md
@@ -1,8 +1,5 @@
 # SafeStack
 
-```{contents}
-:local:
-```
 
 ## Introduction
 

--- a/clang/docs/SanitizerCoverage.md
+++ b/clang/docs/SanitizerCoverage.md
@@ -1,8 +1,5 @@
 # SanitizerCoverage
 
-```{contents}
-:local:
-```
 
 ## Introduction
 

--- a/clang/docs/SanitizerSpecialCaseList.md
+++ b/clang/docs/SanitizerSpecialCaseList.md
@@ -1,8 +1,5 @@
 # Sanitizer special case list
 
-```{contents}
-:local:
-```
 
 ## Introduction
 

--- a/clang/docs/SanitizerStats.md
+++ b/clang/docs/SanitizerStats.md
@@ -1,8 +1,5 @@
 # SanitizerStats
 
-```{contents}
-:local:
-```
 
 ## Introduction
 

--- a/clang/docs/ShadowCallStack.md
+++ b/clang/docs/ShadowCallStack.md
@@ -1,8 +1,5 @@
 # ShadowCallStack
 
-```{contents}
-:local:
-```
 
 ## Introduction
 

--- a/clang/docs/SourceBasedCodeCoverage.md
+++ b/clang/docs/SourceBasedCodeCoverage.md
@@ -1,8 +1,5 @@
 # Source-based Code Coverage
 
-```{contents}
-:local:
-```
 
 ## Introduction
 

--- a/clang/docs/StandardCPlusPlusModules.md
+++ b/clang/docs/StandardCPlusPlusModules.md
@@ -1,8 +1,5 @@
 # Standard C++ Modules
 
-```{contents}
-:local:
-```
 
 ## Introduction
 

--- a/clang/docs/StructureProtection.md
+++ b/clang/docs/StructureProtection.md
@@ -1,8 +1,5 @@
 # Structure Protection
 
-```{contents}
-:local:
-```
 
 ## Introduction
 

--- a/clang/docs/ThinLTO.md
+++ b/clang/docs/ThinLTO.md
@@ -1,8 +1,5 @@
 # ThinLTO
 
-```{contents}
-:local:
-```
 
 ## Introduction
 

--- a/clang/docs/Toolchain.md
+++ b/clang/docs/Toolchain.md
@@ -1,9 +1,5 @@
 # Assembling a Complete Toolchain
 
-```{contents}
-:depth: 2
-:local: true
-```
 
 ## Introduction
 

--- a/clang/docs/TypeSanitizer.md
+++ b/clang/docs/TypeSanitizer.md
@@ -1,8 +1,5 @@
 # TypeSanitizer
 
-```{contents}
-:local: true
-```
 
 ## Introduction
 

--- a/clang/docs/UndefinedBehaviorSanitizer.md
+++ b/clang/docs/UndefinedBehaviorSanitizer.md
@@ -1,8 +1,5 @@
 # UndefinedBehaviorSanitizer
 
-```{contents}
-:local:
-```
 
 ## Introduction
 

--- a/clang/docs/UsersManual.md
+++ b/clang/docs/UsersManual.md
@@ -1,8 +1,5 @@
 # Clang Compiler User's Manual
 
-```{contents}
-:local:
-```
 
 ## Introduction
 

--- a/clang/docs/WarningSuppressionMappings.md
+++ b/clang/docs/WarningSuppressionMappings.md
@@ -1,8 +1,5 @@
 # Warning suppression mappings
 
-```{contents}
-:local: true
-```
 
 ## Introduction
 

--- a/clang/docs/analyzer/checkers.md
+++ b/clang/docs/analyzer/checkers.md
@@ -10,9 +10,6 @@ These checkers are under development and are switched off by default. They may c
 
 The {ref}`debug-checkers` package contains checkers for analyzer developers for debugging purposes.
 
-```{contents} Table of Contents
-:depth: 4
-```
 
 (default-checkers)=
 

--- a/clang/docs/analyzer/developer-docs/DebugChecks.md
+++ b/clang/docs/analyzer/developer-docs/DebugChecks.md
@@ -1,8 +1,5 @@
 # Debug Checks
 
-```{contents}
-:local: true
-```
 
 The analyzer contains a number of checkers which can aid in debugging. Enable
 them by using the "-analyzer-checker=" flag, followed by the name of the

--- a/clang/docs/analyzer/user-docs/Annotations.md
+++ b/clang/docs/analyzer/user-docs/Annotations.md
@@ -18,9 +18,6 @@ Note that attributes that are labeled **Clang-specific** are not
 recognized by GCC. Their use can be conditioned using preprocessor macros
 (examples included on this page).
 
-```{contents}
-:local: true
-```
 
 ## General Purpose Annotations
 

--- a/clang/docs/analyzer/user-docs/CrossTranslationUnit.md
+++ b/clang/docs/analyzer/user-docs/CrossTranslationUnit.md
@@ -4,9 +4,6 @@ Normally, static analysis works in the boundary of one translation unit (TU).
 However, with additional steps and configuration we can enable the analysis to inline the definition of a function from
 another TU.
 
-```{contents}
-:local: true
-```
 
 ## Overview
 

--- a/clang/docs/analyzer/user-docs/FAQ.md
+++ b/clang/docs/analyzer/user-docs/FAQ.md
@@ -1,8 +1,5 @@
 # FAQ and How to Deal with Common False Positives
 
-```{contents}
-:local: true
-```
 
 ## Custom Assertions
 

--- a/clang/docs/analyzer/user-docs/TaintAnalysisConfiguration.md
+++ b/clang/docs/analyzer/user-docs/TaintAnalysisConfiguration.md
@@ -9,9 +9,6 @@ The checker also provides a configuration interface for extending the default se
 by providing a configuration file to the in [YAML](http://llvm.org/docs/YamlIO.html#introduction-to-yaml) format.
 This documentation describes the syntax of the configuration file and gives the informal semantics of the configuration options.
 
-```{contents}
-:local: true
-```
 
 (clangsa-taint-configuration-overview)=
 

--- a/clang/docs/analyzer/user-docs/UsingWithXCode.md
+++ b/clang/docs/analyzer/user-docs/UsingWithXCode.md
@@ -1,8 +1,5 @@
 # Running the analyzer within Xcode
 
-```{contents}
-:local: true
-```
 
 Since Xcode 3.2, users have been able to run the static analyzer [directly within Xcode](https://developer.apple.com/library/ios/recipes/xcode_help-source_editor/chapters/Analyze.html#//apple_ref/doc/uid/TP40009975-CH4-SW1).
 

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -32,9 +32,6 @@ def GlobalDocumentation {
 
 # Attributes in Clang
 
-```{contents}
-:local: true
-```
 
 ```{program} clang
 ```

--- a/clang/include/clang/Basic/BuiltinsAMDGPUDocs.td
+++ b/clang/include/clang/Basic/BuiltinsAMDGPUDocs.td
@@ -27,10 +27,6 @@ def GlobalDocumentation {
 AMDGPU Builtins
 ===============
 
-.. contents::
-   :local:
-   :depth: 2
-
 This document describes the AMDGPU target-specific builtins available in Clang.
 Most of these builtins provide direct access to AMDGPU hardware instructions
 and intrinsics.

--- a/clang/include/clang/Basic/DiagnosticDocs.td
+++ b/clang/include/clang/Basic/DiagnosticDocs.td
@@ -68,8 +68,6 @@ def GlobalDocumentation {
 =========================
 Diagnostic flags in Clang
 =========================
-.. contents::
-   :local:
 
 Introduction
 ============

--- a/clang/include/clang/Basic/DiagnosticDocs.td
+++ b/clang/include/clang/Basic/DiagnosticDocs.td
@@ -53,10 +53,6 @@ table.docutils tr + tr {
 
 # Diagnostic flags in Clang
 
-:::{contents}
-:local:
-:::
-
 ## Introduction
 
 This page lists the diagnostic flags currently supported by Clang.

--- a/clang/include/clang/Options/ClangOptionDocs.td
+++ b/clang/include/clang/Options/ClangOptionDocs.td
@@ -16,8 +16,6 @@ def GlobalDocumentation {
 =====================================
 Clang command line argument reference
 =====================================
-.. contents::
-   :local:
 
 Introduction
 ============


### PR DESCRIPTION
This is a mechanical change generated by `utils/docs/remove_page_tocs.py`. In case of conflicts, which are likely, due to the ongoing markdown migration (#201242), this script can be re-run to regenerate the change. I'm creating a separate PR for it to minimize the diff on the functional changes for the furo PR.