### PR TITLE
[lldb] Support loading an object file that is a slice of another file

### DIFF
--- a/lldb/include/lldb/Core/Module.h
+++ b/lldb/include/lldb/Core/Module.h
@@ -530,6 +530,8 @@ public:
 
   uint64_t GetObjectOffset() const { return m_object_offset; }
 
+  uint64_t GetObjectSize() const { return m_object_size; }
+
   /// Get the object file representation for the current architecture.
   ///
   /// If the object file has not been located or parsed yet, this function
@@ -1076,6 +1078,7 @@ protected:
       m_memory_module_addr; ///< For a Module read from memory,
                             ///  the address it was read from.
   uint64_t m_object_offset = 0;
+  uint64_t m_object_size = 0;
   llvm::sys::TimePoint<> m_object_mod_time;
 
   /// DataExtractor containing the module image, if it was provided at

--- a/lldb/include/lldb/Core/ModuleSpec.h
+++ b/lldb/include/lldb/Core/ModuleSpec.h
@@ -118,6 +118,35 @@ public:
 
   void SetObjectSize(uint64_t object_size) { m_object_size = object_size; }
 
+  /// True if this spec describes a sub-range of its file. The size alone does
+  /// not say: it defaults to the whole file.
+  bool HasObjectFileBounds() const {
+    if (m_object_offset != 0)
+      return true;
+    if (m_object_size == 0)
+      return false;
+    if (m_extractor_sp)
+      return m_object_size != m_extractor_sp->GetByteSize();
+    if (!m_file)
+      return false;
+    const uint64_t file_size = FileSystem::Instance().GetByteSize(m_file);
+    return file_size != 0 && m_object_size != file_size;
+  }
+
+  /// Whether an object at \a candidate_offset of \a candidate_size satisfies
+  /// the bounds this spec asks for. A spec that asks for no particular bounds
+  /// constrains nothing and accepts any candidate.
+  bool MatchesObjectFileSlice(uint64_t candidate_offset,
+                              uint64_t candidate_size) const {
+    if (!HasObjectFileBounds())
+      return true;
+    if (GetObjectOffset() != candidate_offset)
+      return false;
+    if (GetObjectSize() != 0 && GetObjectSize() != candidate_size)
+      return false;
+    return true;
+  }
+
   /// Get the load address of a module in process memory. If the optional
   /// has no value, there is no load address for this module spec.
   std::optional<lldb::addr_t> GetLoadAddress() const { return m_load_addr; }
@@ -277,6 +306,9 @@ public:
         match_module_spec.GetObjectName() != GetObjectName())
       return false;
     if (!FileSpec::Match(match_module_spec.GetFileSpec(), GetFileSpec()))
+      return false;
+    if (!match_module_spec.MatchesObjectFileSlice(GetObjectOffset(),
+                                                  GetObjectSize()))
       return false;
     if (GetPlatformFileSpec() &&
         !FileSpec::Match(match_module_spec.GetPlatformFileSpec(),

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -153,9 +153,19 @@ Module::Module(const ModuleSpec &module_spec)
     file_size = extractor_sp->GetByteSize();
 
   // First extract all module specifications from the file using the local file
-  // path. If there are no specifications, then don't fill anything in
+  // path. If there are no specifications, then don't fill anything in.
+  //
+  // A spec with bounds describes an object embedded in a larger file, so
+  // enumerate from there. A named object is an archive member: its offset
+  // points into the archive, which only parses from the start, so those still
+  // enumerate the whole file and are picked out by name below.
+  const bool use_explicit_bounds =
+      module_spec.HasObjectFileBounds() && !module_spec.GetObjectName();
   ModuleSpecList modules_specs = ObjectFile::GetModuleSpecifications(
-      module_spec.GetFileSpec(), 0, file_size, extractor_sp);
+      module_spec.GetFileSpec(),
+      use_explicit_bounds ? module_spec.GetObjectOffset() : 0,
+      use_explicit_bounds ? module_spec.GetObjectSize() : file_size,
+      extractor_sp);
   if (modules_specs.GetSize() == 0)
     return;
 
@@ -225,6 +235,7 @@ Module::Module(const ModuleSpec &module_spec)
   // (for mod time in a BSD static archive) of from the matching module
   // specification
   m_object_offset = matching_module_spec.GetObjectOffset();
+  m_object_size = matching_module_spec.GetObjectSize();
   m_object_mod_time = matching_module_spec.GetObjectModificationTime();
 }
 
@@ -1470,6 +1481,9 @@ bool Module::MatchesModuleSpec(const ModuleSpec &module_ref) {
 
   const FileSpec &platform_file_spec = module_ref.GetPlatformFileSpec();
   if (!FileSpec::Match(platform_file_spec, GetPlatformFileSpec()))
+    return false;
+
+  if (!module_ref.MatchesObjectFileSlice(m_object_offset, m_object_size))
     return false;
 
   const ArchSpec &arch = module_ref.GetArchitecture();

--- a/lldb/test/API/python_api/module_slice/TestModuleSlice.py
+++ b/lldb/test/API/python_api/module_slice/TestModuleSlice.py
@@ -1,0 +1,104 @@
+"""
+Test adding a module that is a slice of a containing file.
+
+A HIP binary carries its device code inside a section of the host executable,
+reported to the debugger as a file path plus a byte offset and size. A
+ModuleSpec with those bounds has to read the embedded object, not the file.
+"""
+
+import binascii
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+
+# A host executable carrying a device code object in a .hip_fatbin section.
+FAT_BINARY_YAML = """\
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_EXEC
+  Machine:         EM_X86_64
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x1000
+    AddressAlign:    0x1000
+    Content:         "c3"
+  - Name:            .hip_fatbin
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC ]
+    AddressAlign:    0x1000
+    Content:         "%s"
+"""
+
+
+class ModuleSliceTestCase(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def make_gpu_code_object(self):
+        path = self.getBuildArtifact("gpu_code_object.so")
+        self.yaml2obj("gpu_code_object.yaml", path)
+        return path
+
+    def make_fat_binary(self, gpu_path):
+        """Embed the device code object the way a HIP binary carries it."""
+        with open(gpu_path, "rb") as f:
+            content = binascii.hexlify(f.read()).decode()
+        yaml_path = self.getBuildArtifact("fat_binary.yaml")
+        with open(yaml_path, "w") as f:
+            f.write(FAT_BINARY_YAML % content)
+        container = self.getBuildArtifact("fat_binary")
+        self.yaml2obj(yaml_path, container)
+        return container
+
+    def fatbin_section_range(self, container):
+        """Locate the embedded code object by the bounds of its section."""
+        target = self.dbg.CreateTarget("")
+        spec = lldb.SBModuleSpec()
+        spec.SetFileSpec(lldb.SBFileSpec(container))
+        module = target.AddModule(spec)
+        self.assertTrue(module.IsValid(), "the host executable should load")
+
+        section = module.FindSection(".hip_fatbin")
+        self.assertTrue(section.IsValid(), "host binary should have .hip_fatbin")
+        offset, size = section.GetFileOffset(), section.GetFileByteSize()
+        self.dbg.DeleteTarget(target)
+        return offset, size
+
+    def text_file_address(self, module):
+        section = module.FindSection(".text")
+        self.assertTrue(section.IsValid(), "module should have a .text section")
+        return section.GetFileAddress()
+
+    def test_code_object_in_fat_binary(self):
+        """The code object inside a .hip_fatbin section is read, not the host."""
+        gpu = self.make_gpu_code_object()
+        container = self.make_fat_binary(gpu)
+        offset, size = self.fatbin_section_range(container)
+
+        target = self.dbg.CreateTarget("")
+        spec = lldb.SBModuleSpec()
+        spec.SetFileSpec(lldb.SBFileSpec(container))
+        spec.SetObjectOffset(offset)
+        spec.SetObjectSize(size)
+
+        module = target.AddModule(spec)
+        self.assertTrue(module.IsValid(), "the code object should load")
+        # The device code object has .text at 0x3000, the host at 0x1000.
+        self.assertEqual(self.text_file_address(module), 0x3000)
+
+    def test_whole_file(self):
+        """Without an object offset the containing file itself is read."""
+        gpu = self.make_gpu_code_object()
+        container = self.make_fat_binary(gpu)
+
+        target = self.dbg.CreateTarget("")
+        spec = lldb.SBModuleSpec()
+        spec.SetFileSpec(lldb.SBFileSpec(container))
+
+        module = target.AddModule(spec)
+        self.assertTrue(module.IsValid(), "the host executable should load")
+        self.assertEqual(self.text_file_address(module), 0x1000)

--- a/lldb/test/API/python_api/module_slice/gpu_code_object.yaml
+++ b/lldb/test/API/python_api/module_slice/gpu_code_object.yaml
@@ -1,0 +1,20 @@
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_DYN
+  Machine:         EM_X86_64
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x3000
+    AddressAlign:    0x1000
+    Content:         "c3"
+ProgramHeaders:
+  - Type:            PT_LOAD
+    Flags:           [ PF_X, PF_R ]
+    VAddr:           0x3000
+    Align:           0x1000
+    FirstSec:        .text
+    LastSec:         .text


### PR DESCRIPTION

Teach module loading logic, how to handle the when the module is a slice of another file, which is described by a offset and size. 

This is a common pattern in GPU usecases and where the modules are in a separate section inside a file. 

Add the tests.