### PR TITLE
[SDPatternMatch] Add m_NU/SWAdd and m_NU/SWAddLike

### DIFF
--- a/llvm/include/llvm/CodeGen/SDPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/SDPatternMatch.h
@@ -828,6 +828,18 @@ inline BinaryOpc_match<LHS, RHS, true> m_Add(const LHS &L, const RHS &R) {
 }
 
 template <typename LHS, typename RHS>
+inline auto m_NUWAdd(const LHS &L, const RHS &R) {
+  return BinaryOpc_match<LHS, RHS, true>(ISD::ADD, L, R,
+                                         SDNodeFlags::NoUnsignedWrap);
+}
+
+template <typename LHS, typename RHS>
+inline auto m_NSWAdd(const LHS &L, const RHS &R) {
+  return BinaryOpc_match<LHS, RHS, true>(ISD::ADD, L, R,
+                                         SDNodeFlags::NoSignedWrap);
+}
+
+template <typename LHS, typename RHS>
 inline BinaryOpc_match<LHS, RHS> m_Sub(const LHS &L, const RHS &R) {
   return BinaryOpc_match<LHS, RHS>(ISD::SUB, L, R);
 }
@@ -856,6 +868,16 @@ inline BinaryOpc_match<LHS, RHS, true> m_DisjointOr(const LHS &L,
 template <typename LHS, typename RHS>
 inline auto m_AddLike(const LHS &L, const RHS &R) {
   return m_AnyOf(m_Add(L, R), m_DisjointOr(L, R));
+}
+
+template <typename LHS, typename RHS>
+inline auto m_NSWAddLike(const LHS &L, const RHS &R) {
+  return m_AnyOf(m_NSWAdd(L, R), m_DisjointOr(L, R));
+}
+
+template <typename LHS, typename RHS>
+inline auto m_NUWAddLike(const LHS &L, const RHS &R) {
+  return m_AnyOf(m_NUWAdd(L, R), m_DisjointOr(L, R));
 }
 
 template <typename LHS, typename RHS>

--- a/llvm/unittests/CodeGen/SelectionDAGPatternMatchTest.cpp
+++ b/llvm/unittests/CodeGen/SelectionDAGPatternMatchTest.cpp
@@ -221,6 +221,10 @@ TEST_F(SelectionDAGPatternMatchTest, matchBinaryOp) {
   SDValue Or  = DAG->getNode(ISD::OR, DL, Int32VT, Op0, Op1);
   SDValue DisOr =
       DAG->getNode(ISD::OR, DL, Int32VT, Op0, Op3, SDNodeFlags::Disjoint);
+  SDValue NUWAdd =
+      DAG->getNode(ISD::ADD, DL, Int32VT, Or, Xor, SDNodeFlags::NoUnsignedWrap);
+  SDValue NSWAdd =
+      DAG->getNode(ISD::ADD, DL, Int32VT, And, Xor, SDNodeFlags::NoSignedWrap);
   SDValue SMax = DAG->getNode(ISD::SMAX, DL, Int32VT, Op0, Op1);
   SDValue SMin = DAG->getNode(ISD::SMIN, DL, Int32VT, Op1, Op0);
   SDValue UMax = DAG->getNode(ISD::UMAX, DL, Int32VT, Op0, Op1);
@@ -320,6 +324,20 @@ TEST_F(SelectionDAGPatternMatchTest, matchBinaryOp) {
   EXPECT_TRUE(sd_match(Add, m_c_BinOp(ISD::ADD, m_Value(), m_Value())));
   EXPECT_TRUE(sd_match(Add, m_Add(m_Value(), m_Value())));
   EXPECT_TRUE(sd_match(Add, m_AddLike(m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(NUWAdd, m_NUWAdd(m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(NSWAdd, m_NSWAdd(m_Value(), m_Value())));
+  EXPECT_FALSE(sd_match(NUWAdd, m_NSWAdd(m_Value(), m_Value())));
+  EXPECT_FALSE(sd_match(NSWAdd, m_NUWAdd(m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(NUWAdd, m_Add(m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(NSWAdd, m_Add(m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(NUWAdd, m_AddLike(m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(NSWAdd, m_AddLike(m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(NUWAdd, m_NUWAddLike(m_Value(), m_Value())));
+  EXPECT_FALSE(sd_match(NSWAdd, m_NUWAddLike(m_Value(), m_Value())));
+  EXPECT_FALSE(sd_match(Add, m_NUWAddLike(m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(NSWAdd, m_NSWAddLike(m_Value(), m_Value())));
+  EXPECT_FALSE(sd_match(NUWAdd, m_NSWAddLike(m_Value(), m_Value())));
+  EXPECT_FALSE(sd_match(Add, m_NSWAddLike(m_Value(), m_Value())));
   EXPECT_TRUE(sd_match(Mul, m_Mul(m_OneUse(m_SpecificOpc(ISD::SUB)),
                                   m_NUses<2>(m_Specific(Add)))));
   EXPECT_TRUE(
@@ -347,6 +365,8 @@ TEST_F(SelectionDAGPatternMatchTest, matchBinaryOp) {
   EXPECT_TRUE(sd_match(DisOr, m_DisjointOr(m_Value(), m_Value())));
   EXPECT_FALSE(sd_match(DisOr, m_Add(m_Value(), m_Value())));
   EXPECT_TRUE(sd_match(DisOr, m_AddLike(m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(DisOr, m_NUWAddLike(m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(DisOr, m_NSWAddLike(m_Value(), m_Value())));
   EXPECT_TRUE(sd_match(
       DisOr, m_BinOp(ISD::OR, m_Value(), m_Value(), SDNodeFlags::Disjoint)));
   EXPECT_TRUE(sd_match(


### PR DESCRIPTION
These are the SDPatternMatch counterpart for `m_NU/SWAdd` and `m_NU/SWAddLike` in IR PatternMatch.