### PR TITLE
[CAS][test] Disable plugin CAS tests with HWASAN

### DIFF
--- a/llvm/unittests/CAS/CASTestConfig.cpp
+++ b/llvm/unittests/CAS/CASTestConfig.cpp
@@ -10,6 +10,7 @@
 #include "OnDiskCommonUtils.h"
 #include "llvm/CAS/ObjectStore.h"
 #include "llvm/Config/config.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/SHA1.h"
 #include "llvm/Testing/Support/Error.h"
@@ -129,6 +130,11 @@ INSTANTIATE_TEST_SUITE_P(SHA1, CustomHasherOnDiskCASTest,
                          ::testing::Values(CustomHasherParam{
                              sha1Digest, "SHA1", sizeof(SHA1HashType)}));
 
+// HWASan does not tag the globals of a dlopen'ed library with glibc, so the
+// plugin faults as soon as it touches one of its own globals.
+// FIXME: Re-enable once https://github.com/llvm/llvm-project/issues/57206 is
+// fixed.
+#if !LLVM_HWADDRESS_SANITIZER_BUILD
 static CASTestingEnv createPlugin(int I) {
   unittest::TempDir Temp("plugin-cas", /*Unique=*/true);
   std::optional<
@@ -144,6 +150,7 @@ static CASTestingEnv createPlugin(int I) {
                        std::move(Temp)};
 }
 INSTANTIATE_TEST_SUITE_P(PluginCAS, CASTest, ::testing::Values(createPlugin));
+#endif
 
 #else
 void unittest::cas::setMaxOnDiskCASMappingSize() {}

--- a/llvm/unittests/CAS/PluginCASTest.cpp
+++ b/llvm/unittests/CAS/PluginCASTest.cpp
@@ -15,6 +15,7 @@
 #include "CASTestConfig.h"
 #include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/ObjectStore.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Testing/Support/Error.h"
 #include "llvm/Testing/Support/SupportHelpers.h"
@@ -23,6 +24,12 @@
 using namespace llvm;
 using namespace llvm::cas;
 using namespace llvm::unittest::cas;
+
+// HWASan does not tag the globals of a dlopen'ed library with glibc, so the
+// plugin faults as soon as it touches one of its own globals.
+// FIXME: Re-enable once https://github.com/llvm/llvm-project/issues/57206 is
+// fixed.
+#if !LLVM_HWADDRESS_SANITIZER_BUILD
 
 TEST(PluginCASTest, isMaterialized) {
   unittest::TempDir Temp("plugin-cas", /*Unique=*/true);
@@ -89,3 +96,5 @@ TEST(PluginCASTest, isMaterialized) {
     EXPECT_TRUE(IsMaterialized);
   }
 }
+
+#endif /* !LLVM_HWADDRESS_SANITIZER_BUILD */


### PR DESCRIPTION
HWASan does not tag the globals of a dlopen'ed library on Linux/glibc,
so libCASPluginTest.so traps on the first access to one of its own
globals (https://github.com/llvm/llvm-project/issues/57206).

Disables PluginCASTest.isMaterialized and the PluginCAS instantiation of
CASTest, both introduced in #213331, under HWASAN. This matches what
a0e402d41fad did for DynamicLibraryTest for the same underlying issue.
