### PR TITLE
[llvm][LoopVectorize] Avoid nondeterministic iteration

### DIFF
--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -1417,7 +1417,7 @@ private:
 
   /// Holds the instructions (address computations) that are forced to be
   /// scalarized.
-  DenseMap<ElementCount, SmallPtrSet<Instruction *, 4>> ForcedScalars;
+  DenseMap<ElementCount, SmallSetVector<Instruction *, 4>> ForcedScalars;
 
   /// Returns the expected difference in cost from scalarizing the expression
   /// feeding a predicated instruction \p PredInst. The instructions to


### PR DESCRIPTION
The Transforms/LoopVectorize/AArch64/cmp_cost.ll test fails under
LLVM_RERERSE_ITERATION, because iterating over a SmallPtrSet is
nondeterministic. Addresses part of #214872.