### PR TITLE
[BOLT] Skip data-hole filling unless data reordering is enabled

### DIFF
--- a/bolt/include/bolt/Utils/CommandLineOpts.h
+++ b/bolt/include/bolt/Utils/CommandLineOpts.h
@@ -119,6 +119,7 @@ extern llvm::cl::opt<SplitFunctionsStrategy> SplitStrategy;
 enum ProfileFormatKind { PF_Fdata, PF_YAML, PF_PreAgg, PF_PerfScript };
 
 extern llvm::cl::opt<ProfileFormatKind> ProfileFormat;
+extern llvm::cl::list<std::string> ReorderData;
 extern llvm::cl::opt<bool> ShowDensity;
 extern llvm::cl::opt<bool> SplitEH;
 extern llvm::cl::opt<bool> StrictMode;

--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -1540,21 +1540,23 @@ void BinaryContext::processInterproceduralReferences() {
 }
 
 void BinaryContext::postProcessSymbolTable() {
-  fixBinaryDataHoles();
-  bool Valid = true;
-  for (auto &Entry : BinaryDataMap) {
-    BinaryData *BD = Entry.second;
-    if ((BD->getName().starts_with("SYMBOLat") ||
-         BD->getName().starts_with("DATAat")) &&
-        !BD->getParent() && !BD->getSize() && !BD->isAbsolute() &&
-        BD->getSection()) {
-      this->errs() << "BOLT-WARNING: zero-sized top level symbol: " << *BD
-                   << "\n";
-      Valid = false;
+  if (!opts::ReorderData.empty()) {
+    fixBinaryDataHoles();
+    bool Valid = true;
+    for (auto &Entry : BinaryDataMap) {
+      BinaryData *BD = Entry.second;
+      if ((BD->getName().starts_with("SYMBOLat") ||
+           BD->getName().starts_with("DATAat")) &&
+          !BD->getParent() && !BD->getSize() && !BD->isAbsolute() &&
+          BD->getSection()) {
+        this->errs() << "BOLT-WARNING: zero-sized top level symbol: " << *BD
+                     << "\n";
+        Valid = false;
+      }
     }
+    assert(Valid);
+    (void)Valid;
   }
-  assert(Valid);
-  (void)Valid;
   generateSymbolHashes();
 }
 

--- a/bolt/lib/Passes/ReorderData.cpp
+++ b/bolt/lib/Passes/ReorderData.cpp
@@ -16,6 +16,7 @@
 // - estimate temporal locality by looking at CFG?
 
 #include "bolt/Passes/ReorderData.h"
+#include "bolt/Utils/CommandLineOpts.h"
 #include "llvm/ADT/MapVector.h"
 #include <algorithm>
 
@@ -34,13 +35,6 @@ static cl::opt<bool>
     PrintReorderedData("print-reordered-data",
                        cl::desc("print section contents after reordering"),
                        cl::Hidden, cl::cat(BoltCategory));
-
-cl::list<std::string>
-ReorderData("reorder-data",
-  cl::CommaSeparated,
-  cl::desc("list of sections to reorder"),
-  cl::value_desc("section1,section2,section3,..."),
-  cl::cat(BoltOptCategory));
 
 enum ReorderAlgo : char {
   REORDER_COUNT         = 0,

--- a/bolt/lib/Utils/CommandLineOpts.cpp
+++ b/bolt/lib/Utils/CommandLineOpts.cpp
@@ -340,6 +340,10 @@ cl::opt<ProfileFormatKind> ProfileFormat(
                           "perfscript profile format")),
     cl::ZeroOrMore, cl::Hidden, cl::cat(BoltCategory));
 
+cl::list<std::string> ReorderData(
+    "reorder-data", cl::CommaSeparated, cl::desc("list of sections to reorder"),
+    cl::value_desc("section1,section2,section3,..."), cl::cat(BoltOptCategory));
+
 cl::opt<std::string> SaveProfile("w",
                                  cl::desc("save recorded profile to a file"),
                                  cl::cat(BoltOutputCategory));


### PR DESCRIPTION
BinaryContext::postProcessSymbolTable unconditionally called fixBinaryDataHoles(), which walks every allocatable section and, for each gap in its address space, either grows a zero-sized data symbol or creates a synthetic "HOLEat" BinaryData (plus an MCSymbol and GlobalSymbols/BinaryDataMap entries).  This machinery was introduced (0e4d86bf, 2017) for one purpose: to give static data reordering (-reorder-data) a movable object covering every byte of a section. It has no other consumer.

On a large binary, these synthetic objects are live from buildFunctionsCFG through the end of the run and, at the RSS peak (during debug info rewriting), fixBinaryDataHoles accounted for 1669 MB (~1-2%) of peak RSS -- memory spent entirely for a feature that is off by default.

Gate fixBinaryDataHoles() (and the zero-sized-symbol validation loop that presumes it ran) on a non-empty opts::ReorderData, keeping generateSymbolHashes() unconditional.