### PR TITLE
[BOLT] Parse .eh_frame CFI programs on demand to reduce memory

### DIFF
--- a/bolt/include/bolt/Core/Exceptions.h
+++ b/bolt/include/bolt/Core/Exceptions.h
@@ -15,14 +15,14 @@
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/DebugInfo/DWARF/DWARFDataExtractor.h"
+#include "llvm/DebugInfo/DWARF/DWARFDebugFrame.h"
 #include "llvm/Support/Error.h"
 #include <cstdint>
 #include <map>
+#include <memory>
 #include <vector>
 
 namespace llvm {
-
-class DWARFDebugFrame;
 
 namespace dwarf {
 class FDE;
@@ -37,9 +37,22 @@ class BinaryFunction;
 /// BinaryFunction, as well as rewriting CFI sections.
 class CFIReaderWriter {
 public:
-  explicit CFIReaderWriter(BinaryContext &BC, const DWARFDebugFrame &EHFrame);
+  /// Construct from an .eh_frame that has been parsed for its frame index only
+  /// (see DWARFDebugFrame::parse with ParseCFIProgram=false). \p EHFrameData is
+  /// the extractor over the same .eh_frame contents, retained so that each
+  /// function's CFI program can be parsed on demand in fillCFIInfoFor().
+  CFIReaderWriter(BinaryContext &BC, std::unique_ptr<DWARFDebugFrame> EHFrame,
+                  DWARFDataExtractor EHFrameData);
 
   bool fillCFIInfoFor(BinaryFunction &Function) const;
+
+  /// Release the parsed .eh_frame index once no more CFI needs to be read
+  /// (i.e. after disassembly). generateEHFrameHeader() operates on frames
+  /// passed to it and does not depend on this state.
+  void releaseFrameData() {
+    FDEs.clear();
+    EHFrame.reset();
+  }
 
   /// Generate .eh_frame_hdr from old and new .eh_frame sections.
   ///
@@ -58,6 +71,11 @@ public:
 
 private:
   BinaryContext &BC;
+  /// The .eh_frame parsed for its index only (no CFI instruction programs).
+  std::unique_ptr<DWARFDebugFrame> EHFrame;
+  /// Extractor over the .eh_frame contents, used to parse individual CFI
+  /// programs on demand in fillCFIInfoFor().
+  DWARFDataExtractor EHFrameData;
   FDEsMap FDEs;
 };
 

--- a/bolt/lib/Core/Exceptions.cpp
+++ b/bolt/lib/Core/Exceptions.cpp
@@ -463,10 +463,11 @@ void BinaryFunction::updateEHRanges() {
 const uint8_t DWARF_CFI_PRIMARY_OPCODE_MASK = 0xc0;
 
 CFIReaderWriter::CFIReaderWriter(BinaryContext &BC,
-                                 const DWARFDebugFrame &EHFrame)
-    : BC(BC) {
+                                 std::unique_ptr<DWARFDebugFrame> Frame,
+                                 DWARFDataExtractor Data)
+    : BC(BC), EHFrame(std::move(Frame)), EHFrameData(std::move(Data)) {
   // Prepare FDEs for fast lookup
-  for (const dwarf::FrameEntry &Entry : EHFrame.entries()) {
+  for (const dwarf::FrameEntry &Entry : EHFrame->entries()) {
     const auto *CurFDE = dyn_cast<dwarf::FDE>(&Entry);
     // Skip CIEs.
     if (!CurFDE)
@@ -682,13 +683,30 @@ bool CFIReaderWriter::fillCFIInfoFor(BinaryFunction &Function) const {
     return true;
   };
 
-  for (const CFIProgram::Instruction &Instr : CurFDE.getLinkedCIE()->cfis())
-    if (!decodeFrameInstruction(Instr))
+  // The CFI instruction programs were not decoded during the initial
+  // (index-only) parse of .eh_frame. Parse the CIE's and this FDE's programs on
+  // demand now, so that only the functions we actually process pay the cost and
+  // the decoded instructions are discarded as soon as they are consumed.
+  const Triple::ArchType Arch = BC.TheTriple->getArch();
+  auto decodeProgram = [&](const dwarf::FrameEntry &Entry) -> bool {
+    DWARFDataExtractor Data = EHFrameData;
+    CFIProgram Program(CodeAlignment, DataAlignment, Arch);
+    uint64_t CFIOffset = Entry.getCFIStartOffset();
+    if (Error E = Program.parse(Data, &CFIOffset, Entry.getEndOffset())) {
+      consumeError(std::move(E));
       return false;
+    }
+    for (const CFIProgram::Instruction &Instr : Program)
+      if (!decodeFrameInstruction(Instr))
+        return false;
+    return true;
+  };
 
-  for (const CFIProgram::Instruction &Instr : CurFDE.cfis())
-    if (!decodeFrameInstruction(Instr))
-      return false;
+  if (!decodeProgram(*CurFDE.getLinkedCIE()))
+    return false;
+
+  if (!decodeProgram(CurFDE))
+    return false;
 
   return true;
 }

--- a/bolt/lib/Core/Exceptions.cpp
+++ b/bolt/lib/Core/Exceptions.cpp
@@ -463,10 +463,11 @@ void BinaryFunction::updateEHRanges() {
 const uint8_t DWARF_CFI_PRIMARY_OPCODE_MASK = 0xc0;
 
 CFIReaderWriter::CFIReaderWriter(BinaryContext &BC,
-                                 const DWARFDebugFrame &EHFrame)
-    : BC(BC) {
+                                 std::unique_ptr<DWARFDebugFrame> Frame,
+                                 DWARFDataExtractor Data)
+    : BC(BC), EHFrame(std::move(Frame)), EHFrameData(std::move(Data)) {
   // Prepare FDEs for fast lookup
-  for (const dwarf::FrameEntry &Entry : EHFrame.entries()) {
+  for (const dwarf::FrameEntry &Entry : EHFrame->entries()) {
     const auto *CurFDE = dyn_cast<dwarf::FDE>(&Entry);
     // Skip CIEs.
     if (!CurFDE)
@@ -682,13 +683,41 @@ bool CFIReaderWriter::fillCFIInfoFor(BinaryFunction &Function) const {
     return true;
   };
 
-  for (const CFIProgram::Instruction &Instr : CurFDE.getLinkedCIE()->cfis())
-    if (!decodeFrameInstruction(Instr))
-      return false;
+  // The CFI instruction programs were not decoded during the initial
+  // (index-only) parse of .eh_frame. Parse the CIE's and this FDE's programs on
+  // demand now, so that only the functions we actually process pay the cost and
+  // the decoded instructions are discarded as soon as they are consumed.
+  const Triple::ArchType Arch = BC.TheTriple->getArch();
+  auto decodeInstructions = [&](const CFIProgram &Program) {
+    for (const CFIProgram::Instruction &Instr : Program)
+      if (!decodeFrameInstruction(Instr))
+        return false;
+    return true;
+  };
+  auto decodeProgram = [&](const dwarf::FrameEntry &Entry) -> bool {
+    // An entry that carries no offset to parse from already holds its decoded
+    // program: either the section was parsed eagerly, or the entry has no
+    // instructions at all.
+    const std::optional<uint64_t> CFIStartOffset =
+        Entry.getUnparsedCFIStartOffset();
+    if (!CFIStartOffset)
+      return decodeInstructions(Entry.cfis());
 
-  for (const CFIProgram::Instruction &Instr : CurFDE.cfis())
-    if (!decodeFrameInstruction(Instr))
+    DWARFDataExtractor Data = EHFrameData;
+    CFIProgram Program(CodeAlignment, DataAlignment, Arch);
+    uint64_t CFIOffset = *CFIStartOffset;
+    if (Error E = Program.parse(Data, &CFIOffset, Entry.getEndOffset())) {
+      consumeError(std::move(E));
       return false;
+    }
+    return decodeInstructions(Program);
+  };
+
+  if (!decodeProgram(*CurFDE.getLinkedCIE()))
+    return false;
+
+  if (!decodeProgram(CurFDE))
+    return false;
 
   return true;
 }

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -2500,11 +2500,22 @@ Error RewriteInstance::readSpecialSections() {
     BC->outs() << "BOLT-INFO: enabling " << (opts::StrictMode ? "strict " : "")
                << "relocation mode\n";
 
-  // Read EH frame for function boundaries info.
-  Expected<const DWARFDebugFrame *> EHFrameOrError = BC->DwCtx->getEHFrame();
-  if (!EHFrameOrError)
-    report_error("expected valid eh_frame section", EHFrameOrError.takeError());
-  CFIRdWrt.reset(new CFIReaderWriter(*BC, *EHFrameOrError.get()));
+  // Read EH frame for function boundaries info. Parse only the frame index
+  // (FDE addresses/ranges); the CFI instruction programs are parsed on demand
+  // per function during disassembly (see CFIReaderWriter::fillCFIInfoFor) so we
+  // never materialize every function's CFI program at once. We parse our own
+  // DWARFDebugFrame instead of DwCtx->getEHFrame() so that the (fully parsed)
+  // frame is not cached in the DWARF context for the lifetime of the run.
+  const DWARFObject &DObj = BC->DwCtx->getDWARFObj();
+  const DWARFSection &EHFrameSection = DObj.getEHFrameSection();
+  DWARFDataExtractor EHFrameData(
+      DObj, EHFrameSection, BC->DwCtx->isLittleEndian(), DObj.getAddressSize());
+  auto EHFrame = std::make_unique<DWARFDebugFrame>(
+      BC->DwCtx->getArch(), /*IsEH=*/true, EHFrameSection.Address);
+  if (Error E = EHFrame->parse(EHFrameData, /*ParseCFIProgram=*/false))
+    report_error("expected valid eh_frame section", std::move(E));
+  CFIRdWrt.reset(
+      new CFIReaderWriter(*BC, std::move(EHFrame), std::move(EHFrameData)));
 
   processSectionMetadata();
 
@@ -4056,6 +4067,10 @@ void RewriteInstance::disassembleFunctions() {
           Function.parseLSDA(LSDAData, LSDASection->getAddress()));
     }
   }
+
+  // CFI programs and the FDE index are only needed while disassembling; release
+  // them now so they don't occupy memory for the rest of the pipeline.
+  CFIRdWrt->releaseFrameData();
 }
 
 void RewriteInstance::buildFunctionsCFG() {

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -2494,11 +2494,22 @@ Error RewriteInstance::readSpecialSections() {
     BC->outs() << "BOLT-INFO: enabling " << (opts::StrictMode ? "strict " : "")
                << "relocation mode\n";
 
-  // Read EH frame for function boundaries info.
-  Expected<const DWARFDebugFrame *> EHFrameOrError = BC->DwCtx->getEHFrame();
-  if (!EHFrameOrError)
-    report_error("expected valid eh_frame section", EHFrameOrError.takeError());
-  CFIRdWrt.reset(new CFIReaderWriter(*BC, *EHFrameOrError.get()));
+  // Read EH frame for function boundaries info. Parse only the frame index
+  // (FDE addresses/ranges); the CFI instruction programs are parsed on demand
+  // per function during disassembly (see CFIReaderWriter::fillCFIInfoFor) so we
+  // never materialize every function's CFI program at once. We parse our own
+  // DWARFDebugFrame instead of DwCtx->getEHFrame() so that the (fully parsed)
+  // frame is not cached in the DWARF context for the lifetime of the run.
+  const DWARFObject &DObj = BC->DwCtx->getDWARFObj();
+  const DWARFSection &EHFrameSection = DObj.getEHFrameSection();
+  DWARFDataExtractor EHFrameData(
+      DObj, EHFrameSection, BC->DwCtx->isLittleEndian(), DObj.getAddressSize());
+  auto EHFrame = std::make_unique<DWARFDebugFrame>(
+      BC->DwCtx->getArch(), /*IsEH=*/true, EHFrameSection.Address);
+  if (Error E = EHFrame->parse(EHFrameData, /*ParseCFIProgram=*/false))
+    report_error("expected valid eh_frame section", std::move(E));
+  CFIRdWrt.reset(
+      new CFIReaderWriter(*BC, std::move(EHFrame), std::move(EHFrameData)));
 
   processSectionMetadata();
 
@@ -4037,6 +4048,10 @@ void RewriteInstance::disassembleFunctions() {
           Function.parseLSDA(LSDAData, LSDASection->getAddress()));
     }
   }
+
+  // CFI programs and the FDE index are only needed while disassembling; release
+  // them now so they don't occupy memory for the rest of the pipeline.
+  CFIRdWrt->releaseFrameData();
 }
 
 void RewriteInstance::buildFunctionsCFG() {


### PR DESCRIPTION
BOLT read the entire .eh_frame up front via DwCtx->getEHFrame(), which parses and caches the CFI instruction program of every CIE/FDE in the binary for the whole run. On a large binary, this dominated file-object discovery: CFIProgram::parse accounted for ~6.5 GB and the cached DWARFDebugFrame ~6.9 GB of live memory. Yet the CFI programs are only consumed in CFIReaderWriter::fillCFIInfoFor, and only for the functions BOLT actually disassembles. discoverFileObjects itself needs nothing but each FDE's address and range for function-boundary checks.

Here we parse .eh_frame for its index only, and decode each function's CFI program on demand, lazily, only for the functions that really need it. In a large binary, DWARFDebugFrame::parse drops from 6922.2 MB to 587.6 MB, the residual being the lightweight FDE/CIE index (entries without instruction programs), and readSpecialSections falls from 7078.7 MB to 738.6 MB on the tested binary for which BOLT's RSS is about 80-120GB.