### PR TITLE
[DebugInfo] Add DWARFUnit::clearDWO()

### DIFF
--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFUnit.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFUnit.h
@@ -461,6 +461,16 @@ public:
                : getUnitDIE(ExtractUnitDIEOnly);
   }
 
+  /// Return the split unit this skeleton unit currently owns, or null if its
+  /// DWO context is not open.
+  DWARFUnit *getDWO() const { return DWO.get(); }
+
+  /// Release the DWO context owned by this skeleton unit, freeing the memory
+  /// held by its DWARFContext and parsed unit vector. This is safe to call once
+  /// the split-unit debug info has been fully processed; a subsequent
+  /// parseDWO() will transparently re-open it on demand.
+  void clearDWO() { DWO.reset(); }
+
   const char *getCompilationDir();
   std::optional<uint64_t> getDWOId() {
     extractDIEsIfNeeded(/*CUDieOnly*/ true);

--- a/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
@@ -1025,7 +1025,7 @@ void DWARFContext::dump(
     for (const auto &U : Units) {
       // For dumping of DWOs, remember if unit is already holding its context in
       // memory
-      const bool HadDWO = U->getDWO();
+      bool HadDWO = U->getDWO();
       if (DumpOffset) {
         U->getDIEForOffset(*DumpOffset)
             .dump(OS, 0, DumpOpts.noImplicitRecursion());

--- a/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
@@ -1021,8 +1021,12 @@ void DWARFContext::dump(
 
   auto dumpDebugInfo = [&](const char *Name, unit_iterator_range Units) {
     OS << '\n' << Name << " contents:\n";
-    if (auto DumpOffset = DumpOffsets[DIDT_ID_DebugInfo])
-      for (const auto &U : Units) {
+    std::optional<uint64_t> DumpOffset = DumpOffsets[DIDT_ID_DebugInfo];
+    for (const auto &U : Units) {
+      // For dumping of DWOs, remember if unit is already holding its context in
+      // memory
+      const bool HadDWO = U->getDWO();
+      if (DumpOffset) {
         U->getDIEForOffset(*DumpOffset)
             .dump(OS, 0, DumpOpts.noImplicitRecursion());
         DWARFDie CUDie = U->getUnitDIE(false);
@@ -1032,10 +1036,18 @@ void DWARFContext::dump(
               ->getDIEForOffset(*DumpOffset)
               .dump(OS, 0, DumpOpts.noImplicitRecursion());
         }
-      }
-    else
-      for (const auto &U : Units)
+      } else {
         U->dump(OS, DumpOpts);
+      }
+      // If our dump caused a new context for the non-skeleton unit in a DWO to
+      // be freshly opened, release it now. We won't re-use it. This avoids
+      // holding a lot of unnecessary anon memory while streaming through
+      // multiple DWOs (OTOH DWP is shared ctx, so better not to drop it
+      // otherwise it will be immediately reopened by the next non-skeleton CU).
+      const DWARFUnit *DWO = U->getDWO();
+      if (!HadDWO && DWO && !DWO->getContext().isDWP())
+        U->clearDWO();
+    }
   };
   if ((DumpType & DIDT_DebugInfo)) {
     if (Explicit || getNumCompileUnits())

--- a/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
+++ b/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
@@ -492,11 +492,20 @@ static void filterByName(
     filterDieNames(CU.get());
     if (DumpNonSkeleton) {
       // If we have split DWARF, then recurse down into the .dwo files as well.
+      // Matching DIEs are printed as they are found and nothing here outlives
+      // them, so the split unit can be released instead of keeping every .dwo
+      // context resident until the end of the search.
+      const bool HadDWO = CU->getDWO();
       DWARFDie CUDie = CU->getUnitDIE(false);
       DWARFDie CUNonSkeletonDie = CU->getNonSkeletonUnitDIE(false);
       // If we have a DWO file, we need to search it as well
       if (CUNonSkeletonDie && CUDie != CUNonSkeletonDie)
         filterDieNames(CUNonSkeletonDie.getDwarfUnit());
+      const DWARFUnit *DWO = CU->getDWO();
+      // Don't release a DWP context -- it is the same for every non-skeleton CU
+      // and we benefit from keeping it resident to avoid the re-parse.
+      if (!HadDWO && DWO && !DWO->getContext().isDWP())
+        CU->clearDWO();
     }
   }
 }


### PR DESCRIPTION
Add DWARFUnit::clearDWO() so a skeleton unit can drop the DWO context it owns without being destroyed itself. Also add DWARFUnit::getDWO() to answer, without creating a new one, if that skeleton CU is currently caching a DWO context.

For example, BOLT opened a DWARFContext for every .dwo during readDebugInfo and kept them all alive until teardown. On large split-DWARF targets that is tens of GiB held
resident. clearDWO()/getDWO() expose to users DWARFUnit's caching capacity, allowing them to spontaneously drop the cache/look it up/re-load it for memory management. To demonstrate this, in llvm-dwarfdump we now make use of the same technique to avoid ballooning peak RSS when dumping binaries with dwos. Whenever --debug-info --dwo is used, during the loop dumping non-skeleton DIEs, we clearDWO as soon as we're done with that unit. Testing on a large binary, this was shown to reduce peakRSS from 50GB to 590MB.