### PR TITLE
[CodeGen] Cache `shouldOptimizeForSize()` when computing spill weights

### DIFF
--- a/llvm/include/llvm/CodeGen/CalcSpillWeights.h
+++ b/llvm/include/llvm/CodeGen/CalcSpillWeights.h
@@ -10,6 +10,7 @@
 #define LLVM_CODEGEN_CALCSPILLWEIGHTS_H
 
 #include "llvm/CodeGen/SlotIndexes.h"
+#include <optional>
 
 namespace llvm {
 
@@ -50,6 +51,12 @@ class VirtRegMap;
     const MachineLoopInfo &Loops;
     ProfileSummaryInfo *PSI;
     const MachineBlockFrequencyInfo &MBFI;
+
+    /// Memoized llvm::shouldOptimizeForSize(&MF, PSI, &MBFI).
+    std::optional<bool> CachedOptForSize;
+
+    /// Lazily computes and caches the above.
+    bool getCachedOptimizeForSize();
 
     /// Returns true if Reg of live interval LI is used in instruction with many
     /// operands like STATEPOINT.

--- a/llvm/include/llvm/CodeGen/LiveIntervals.h
+++ b/llvm/include/llvm/CodeGen/LiveIntervals.h
@@ -130,6 +130,17 @@ public:
                                        const MachineBasicBlock *MBB,
                                        ProfileSummaryInfo *PSI = nullptr);
 
+  /// Variants taking a precomputed \p OptForSize rather than deriving it from a
+  /// ProfileSummaryInfo.
+  LLVM_ABI static float getSpillWeight(bool isDef, bool isUse,
+                                       const MachineBlockFrequencyInfo *MBFI,
+                                       const MachineInstr &MI, bool OptForSize);
+
+  LLVM_ABI static float getSpillWeight(bool isDef, bool isUse,
+                                       const MachineBlockFrequencyInfo *MBFI,
+                                       const MachineBasicBlock *MBB,
+                                       bool OptForSize);
+
   LiveInterval &getInterval(Register Reg) {
     if (hasInterval(Reg))
       return *VirtRegIntervals[Reg.id()];

--- a/llvm/lib/CodeGen/CalcSpillWeights.cpp
+++ b/llvm/lib/CodeGen/CalcSpillWeights.cpp
@@ -15,6 +15,7 @@
 #include "llvm/CodeGen/MachineLoopInfo.h"
 #include "llvm/CodeGen/MachineOperand.h"
 #include "llvm/CodeGen/MachineRegisterInfo.h"
+#include "llvm/CodeGen/MachineSizeOpts.h"
 #include "llvm/CodeGen/StackMaps.h"
 #include "llvm/CodeGen/TargetInstrInfo.h"
 #include "llvm/CodeGen/TargetRegisterInfo.h"
@@ -29,6 +30,12 @@
 using namespace llvm;
 
 #define DEBUG_TYPE "calcspillweights"
+
+bool VirtRegAuxInfo::getCachedOptimizeForSize() {
+  if (!CachedOptForSize.has_value())
+    CachedOptForSize = PSI && llvm::shouldOptimizeForSize(&MF, PSI, &MBFI);
+  return *CachedOptForSize;
+}
 
 void VirtRegAuxInfo::calculateSpillWeightsAndHints() {
   LLVM_DEBUG(dbgs() << "********** Compute Spill Weights **********\n"
@@ -318,7 +325,8 @@ float VirtRegAuxInfo::weightCalcHelper(LiveInterval &LI) {
       // Calculate instr weight.
       bool Reads, Writes;
       std::tie(Reads, Writes) = MI->readsWritesVirtualRegister(LI.reg());
-      Weight = LiveIntervals::getSpillWeight(Writes, Reads, &MBFI, *MI, PSI);
+      Weight = LiveIntervals::getSpillWeight(Writes, Reads, &MBFI, *MI,
+                                             getCachedOptimizeForSize());
 
       // Give extra weight to what looks like a loop induction variable update.
       if (Writes && IsExiting && LIS.isLiveOutOfMBB(LI, MBB))

--- a/llvm/lib/CodeGen/LiveIntervals.cpp
+++ b/llvm/lib/CodeGen/LiveIntervals.cpp
@@ -912,11 +912,25 @@ float LiveIntervals::getSpillWeight(bool isDef, bool isUse,
                                     const MachineBlockFrequencyInfo *MBFI,
                                     const MachineBasicBlock *MBB,
                                     ProfileSummaryInfo *PSI) {
-  float Weight = isDef + isUse;
   const auto *MF = MBB->getParent();
+  return getSpillWeight(isDef, isUse, MBFI, MBB,
+                        PSI && llvm::shouldOptimizeForSize(MF, PSI, MBFI));
+}
+
+float LiveIntervals::getSpillWeight(bool isDef, bool isUse,
+                                    const MachineBlockFrequencyInfo *MBFI,
+                                    const MachineInstr &MI, bool OptForSize) {
+  return getSpillWeight(isDef, isUse, MBFI, MI.getParent(), OptForSize);
+}
+
+float LiveIntervals::getSpillWeight(bool isDef, bool isUse,
+                                    const MachineBlockFrequencyInfo *MBFI,
+                                    const MachineBasicBlock *MBB,
+                                    bool OptForSize) {
+  float Weight = isDef + isUse;
   // When optimizing for size we only consider the codesize impact of spilling
   // the register, not the runtime impact.
-  if (PSI && llvm::shouldOptimizeForSize(MF, PSI, MBFI))
+  if (OptForSize)
     return Weight;
   return Weight * MBFI->getBlockFreqRelativeToEntryBlock(MBB);
 }


### PR DESCRIPTION
`VirtRegAuxInfo::weightCalcHelper()` calls LiveIntervals::getSpillWeight() once per use/def operand of every virtual register, and `getSpillWeight()` evaluates `(PSI && llvm::shouldOptimizeForSize(MF, PSI, MBFI))` repeatedly. `shouldOptimizeForSize` is expensive: `O(#operands * #blocks)`. 

We had a function with 20k blocks, and this inefficient repeated query caused severe delay, the function took 30+ minutes to build. 

Since the result is the same for every query in this MF, and `VirtRegAuxInfo` already holds `MF`, `PSI` and `MBFI`, all fixed for the lifetime of the object, so the value is provably invariant across every `getSpillWeight()` call it makes. We should cache it.