### PR TITLE
[libclc][test] Update cos.cl checks after fneg FP-options fix

### DIFF
--- a/libclc/test/math/cos.cl
+++ b/libclc/test/math/cos.cl
@@ -112,7 +112,7 @@
 // AMDGCN-NEXT:    [[TMP98:%.*]] = or i32 [[TMP97]], [[TMP78]]
 // AMDGCN-NEXT:    [[TMP99:%.*]] = bitcast i32 [[TMP98]] to float
 // AMDGCN-NEXT:    [[TMP100:%.*]] = fmul float [[TMP90]], f0x3FC90FDA
-// AMDGCN-NEXT:    [[TMP101:%.*]] = fneg contract float [[TMP100]]
+// AMDGCN-NEXT:    [[TMP101:%.*]] = fneg float [[TMP100]]
 // AMDGCN-NEXT:    [[TMP102:%.*]] = tail call contract noundef float @llvm.fma.f32(float [[TMP90]], float f0x3FC90FDA, float [[TMP101]])
 // AMDGCN-NEXT:    [[TMP103:%.*]] = tail call contract noundef float @llvm.fma.f32(float [[TMP90]], float f0x33A22168, float [[TMP102]])
 // AMDGCN-NEXT:    [[TMP104:%.*]] = tail call contract noundef float @llvm.fma.f32(float [[TMP99]], float f0x3FC90FDA, float [[TMP103]])


### PR DESCRIPTION
ceaff22ed2c3 ([Clang][CodeGen] Respect FP pragma options for fneg and calls) scopes fneg's fast-math flags to the expression's own FPOptions instead of the ambient IRBuilder state, so one fneg in cos.cl's generated IR no longer carries contract. Regenerate check.