### PR TITLE
[SandboxVec][Legality] Fix a warning when build with GCC (NFC)

### DIFF
--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Legality.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Legality.h
@@ -183,7 +183,7 @@ public:
 
 /// Base class for results with reason.
 class LegalityResultWithReason : public LegalityResult {
-  [[maybe_unused]] ResultReason Reason;
+  ResultReason Reason;
   LegalityResultWithReason(LegalityResultID ID, ResultReason Reason)
       : LegalityResult(ID), Reason(Reason) {}
   friend class Pack; // For constructor.


### PR DESCRIPTION
Remove `maybe_unused` attribute from ResultReason member, beacuse it used in `getReason` method. This PR fixes:

llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Legality.h:186:33: error: ‘maybe_unused’ attribute ignored [-Werror=attributes]
  186 |   [[maybe_unused]] ResultReason Reason;
      |                                 ^~~~~~