### PR TITLE
[AMDGPU] Check operand for split barrier in both assembler and disassembler

### DIFF
--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -10839,4 +10839,11 @@ bool AMDGPUOperand::isEndpgm() const { return isImmTy(ImmTyEndpgm); }
 // Split Barrier
 //===----------------------------------------------------------------------===//
 
-bool AMDGPUOperand::isSplitBarrier() const { return isInlinableImm(MVT::i32); }
+bool AMDGPUOperand::isSplitBarrier() const {
+  if (!isImm())
+    return false;
+
+  int64_t Imm = getImm();
+  return isUInt<5>(Imm) || (AMDGPU::Barrier::CLUSTER_TRAP <= Imm &&
+                            Imm <= AMDGPU::Barrier::WORKGROUP);
+}

--- a/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.cpp
+++ b/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.cpp
@@ -2259,6 +2259,15 @@ MCOperand AMDGPUDisassembler::decodeBoolReg(const MCInst &Inst,
 
 MCOperand AMDGPUDisassembler::decodeSplitBarrier(const MCInst &Inst,
                                                  unsigned Val) const {
+  using namespace AMDGPU::EncValues;
+  constexpr unsigned M0Encoding = 125;
+  bool IsValidBarrier =
+      Val == M0Encoding ||
+      (INLINE_INTEGER_C_MIN <= Val && Val < INLINE_INTEGER_C_MIN + 32) ||
+      (INLINE_INTEGER_C_POSITIVE_MAX < Val &&
+       Val <= INLINE_INTEGER_C_POSITIVE_MAX + 4);
+  if (!IsValidBarrier)
+    return MCOperand();
   return decodeSrcOp(Inst, 32, Val);
 }
 

--- a/llvm/test/MC/AMDGPU/gfx12_err.s
+++ b/llvm/test/MC/AMDGPU/gfx12_err.s
@@ -118,6 +118,18 @@ s_prefetch_inst s[14:15], 0xffffff, m0, 7
 s_endpgm_ordered_ps_done
 // GFX12-ERR: :[[@LINE-1]]:{{[0-9]+}}: error: instruction not supported on this GPU
 
+s_barrier_signal 32
+// GFX12-ERR: :[[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+s_barrier_signal -5
+// GFX12-ERR: :[[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+s_barrier_signal 125
+// GFX12-ERR: :[[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
+s_barrier_signal 0.5
+// GFX12-ERR: :[[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+
 s_alloc_vgpr v0
 // GFX12-ERR: :[[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
 

--- a/llvm/test/MC/AMDGPU/gfx13_asm_sop1.s
+++ b/llvm/test/MC/AMDGPU/gfx13_asm_sop1.s
@@ -78,7 +78,7 @@
 //      s_barrier_signal_isfirst <BARRIER-ID>
 //      s_get_barrier_state <SREG32>, m0
 //      s_get_barrier_state s0, 0
-//      s_get_barrier_state s0, 0.5
+//      s_get_barrier_state s0, 31
 //      s_barrier_init m0
 //      s_barrier_join <BARRIER-ID>
 //      s_wakeup_barrier 1
@@ -156,7 +156,7 @@
 //  <BARRIER-ID>=
 //      m0
 //      0
-//      0.5
+//      31
 //
 //  <OPS-32-64>=
 //      <SREG32>, s[0:1]
@@ -2448,8 +2448,8 @@ s_barrier_signal m0
 s_barrier_signal 0
 // GFX13: s_barrier_signal 0                      ; encoding: [0x80,0x4e,0x80,0xbe]
 
-s_barrier_signal 0.5
-// GFX13: s_barrier_signal 0.5                    ; encoding: [0xf0,0x4e,0x80,0xbe]
+s_barrier_signal 31
+// GFX13: s_barrier_signal 31                     ; encoding: [0x9f,0x4e,0x80,0xbe]
 
 s_barrier_signal_isfirst m0
 // GFX13: s_barrier_signal_isfirst m0             ; encoding: [0x7d,0x4f,0x80,0xbe]
@@ -2457,8 +2457,8 @@ s_barrier_signal_isfirst m0
 s_barrier_signal_isfirst 0
 // GFX13: s_barrier_signal_isfirst 0              ; encoding: [0x80,0x4f,0x80,0xbe]
 
-s_barrier_signal_isfirst 0.5
-// GFX13: s_barrier_signal_isfirst 0.5            ; encoding: [0xf0,0x4f,0x80,0xbe]
+s_barrier_signal_isfirst 31
+// GFX13: s_barrier_signal_isfirst 31             ; encoding: [0x9f,0x4f,0x80,0xbe]
 
 s_get_barrier_state s105, m0
 // GFX13: s_get_barrier_state s105, m0            ; encoding: [0x7d,0x50,0xe9,0xbe]
@@ -2478,8 +2478,8 @@ s_get_barrier_state null, m0
 s_get_barrier_state s0, 0
 // GFX13: s_get_barrier_state s0, 0               ; encoding: [0x80,0x50,0x80,0xbe]
 
-s_get_barrier_state s0, 0.5
-// GFX13: s_get_barrier_state s0, 0.5             ; encoding: [0xf0,0x50,0x80,0xbe]
+s_get_barrier_state s0, 31
+// GFX13: s_get_barrier_state s0, 31              ; encoding: [0x9f,0x50,0x80,0xbe]
 
 s_barrier_init m0
 // GFX13: s_barrier_init m0                       ; encoding: [0x7d,0x51,0x80,0xbe]
@@ -2490,8 +2490,8 @@ s_barrier_join m0
 s_barrier_join 0
 // GFX13: s_barrier_join 0                        ; encoding: [0x80,0x52,0x80,0xbe]
 
-s_barrier_join 0.5
-// GFX13: s_barrier_join 0.5                      ; encoding: [0xf0,0x52,0x80,0xbe]
+s_barrier_join 31
+// GFX13: s_barrier_join 31                       ; encoding: [0x9f,0x52,0x80,0xbe]
 
 s_wakeup_barrier 1
 // GFX13: s_wakeup_barrier 1                      ; encoding: [0x81,0x57,0x80,0xbe]

--- a/llvm/test/MC/Disassembler/AMDGPU/decode-err.txt
+++ b/llvm/test/MC/Disassembler/AMDGPU/decode-err.txt
@@ -2,6 +2,7 @@
 # RUN: llvm-mc -triple=amdgpu11.00 -disassemble -show-encoding < %s | FileCheck -check-prefixes=W32 %s
 # RUN: llvm-mc -triple=amdgpu11.00 -mattr=+wavefrontsize64 -disassemble -show-encoding < %s 2>&1 | FileCheck -check-prefixes=W64 %s
 # RUN: llvm-mc -triple=amdgpu12.00 -disassemble -filetype=null < %s 2>&1 | FileCheck -check-prefix=GFX12-ERR %s
+# RUN: llvm-mc -triple=amdgpu12.50 -disassemble -filetype=null < %s 2>&1 | FileCheck -check-prefix=GFX1250-ERR %s
 
 # GCN-ERR: [[@LINE+1]]:1: warning: invalid instruction encoding
 0xdf,0x00,0x00,0x02
@@ -9,6 +10,16 @@
 # this is s_waitcnt_vscnt exec_hi, 0x1234, which is valid on gfx11, but not on gfx12
 # GFX12-ERR: [[@LINE+1]]:1: warning: invalid instruction encoding
 0x34,0x12,0x7f,0xbc
+
+# GFX1250-ERR: [[@LINE+1]]:1: warning: invalid instruction encoding
+0xa0,0x4e,0x80,0xbe
+
+# GFX1250-ERR: [[@LINE+1]]:1: warning: invalid instruction encoding
+0xc5,0x4e,0x80,0xbe
+
+# Literal constants are invalid for split barrier operands.
+# GFX1250-ERR: [[@LINE+1]]:1: warning: invalid instruction encoding
+0xff,0x4e,0x80,0xbe,0xbe,0x00,0x00,0x00
 
 # W32: v_dual_add_f32 v5, 0xaf123456, v2 :: v_dual_fmaak_f32 v6, v3, v1, 0xaf123456 ; encoding: [0xff,0x04,0x02,0xc9,0x03,0x03,0x06,0x05,0x56,0x34,0x12,0xaf]
 # W64: [[@LINE+1]]:1: warning: invalid instruction encoding


### PR DESCRIPTION
Fixes #214910.

---

This PR was assisted by AI but I reviewed all the changes.