### PR TITLE
IR: Add Module::getLongDoubleFormat helper

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -1411,12 +1411,8 @@ void CodeGenModule::Release() {
     else if (flt == &llvm::APFloat::IEEEsingle())
       Format = llvm::LongDoubleFormat::IEEEsingle;
 
-    if (Format) {
-      getModule().addModuleFlag(
-          llvm::Module::Error, "long-double-type",
-          llvm::MDString::get(VMContext,
-                              llvm::getLongDoubleFormatName(*Format)));
-    }
+    if (Format)
+      getModule().setLongDoubleFormat(*Format);
   }
 
   if (getTriple().isOSzOS()) {

--- a/llvm/include/llvm/IR/Module.h
+++ b/llvm/include/llvm/IR/Module.h
@@ -1050,6 +1050,18 @@ public:
   /// @}
 
   /// @}
+  /// @name Utility functions for querying the long double format
+  /// @{
+
+  /// Returns the long double format from the "long-double-type" module flag,
+  /// or the triple default when the flag is absent.
+  LongDoubleFormat getLongDoubleFormat() const;
+
+  /// Set the long double format.
+  void setLongDoubleFormat(LongDoubleFormat Format);
+  /// @}
+
+  /// @}
   /// @name Utility function for querying the floating-point ABI
   /// @{
 

--- a/llvm/lib/IR/Module.cpp
+++ b/llvm/lib/IR/Module.cpp
@@ -682,6 +682,22 @@ void Module::setCodeModel(CodeModel::Model CL) {
   addModuleFlag(ModFlagBehavior::Error, "Code Model", CL);
 }
 
+LongDoubleFormat Module::getLongDoubleFormat() const {
+  if (auto *Val =
+          dyn_cast_or_null<MDString>(getModuleFlag("long-double-type"))) {
+    if (std::optional<LongDoubleFormat> Format =
+            parseLongDoubleFormat(Val->getString()))
+      return *Format;
+  }
+
+  return getTargetTriple().getDefaultLongDoubleFormat();
+}
+
+void Module::setLongDoubleFormat(LongDoubleFormat Format) {
+  addModuleFlag(ModFlagBehavior::Error, "long-double-type",
+                MDString::get(getContext(), getLongDoubleFormatName(Format)));
+}
+
 FloatABI::ABIType Module::getFloatABI() const {
   if (auto *Val = dyn_cast_or_null<MDString>(getModuleFlag("float-abi")))
     return FloatABI::parseABIType(Val->getString()).value_or(FloatABI::Default);

--- a/llvm/unittests/IR/ModuleTest.cpp
+++ b/llvm/unittests/IR/ModuleTest.cpp
@@ -103,30 +103,6 @@ TEST(ModuleTest, setModuleFlagInt) {
   EXPECT_EQ(Val2, A2->getZExtValue());
 }
 
-TEST(ModuleTest, getLongDoubleFormat) {
-  LLVMContext Context;
-
-  // With no module flag, falls back to the triple's default long double format.
-  Module MX86("x86", Context);
-  MX86.setTargetTriple(Triple("x86_64-unknown-linux-gnu"));
-  EXPECT_EQ(LongDoubleFormat::X87DoubleExtended, MX86.getLongDoubleFormat());
-
-  Module MPPC("ppc", Context);
-  MPPC.setTargetTriple(Triple("powerpc64-unknown-linux-gnu"));
-  EXPECT_EQ(LongDoubleFormat::PPCDoubleDouble, MPPC.getLongDoubleFormat());
-
-  // An explicit module flag overrides the triple default.
-  MX86.setLongDoubleFormat(LongDoubleFormat::IEEEquad);
-  EXPECT_EQ(LongDoubleFormat::IEEEquad, MX86.getLongDoubleFormat());
-
-  // The flag is the string-valued "long-double-type" flag emitted by clang.
-  Module MFlag("flag", Context);
-  MFlag.setTargetTriple(Triple("x86_64-unknown-linux-gnu"));
-  MFlag.addModuleFlag(Module::Error, "long-double-type",
-                      MDString::get(Context, "fp128"));
-  EXPECT_EQ(LongDoubleFormat::IEEEquad, MFlag.getLongDoubleFormat());
-}
-
 TEST(ModuleTest, setModuleFlagTwoMod) {
   LLVMContext Context;
   Module MA("MA", Context);

--- a/llvm/unittests/IR/ModuleTest.cpp
+++ b/llvm/unittests/IR/ModuleTest.cpp
@@ -103,6 +103,30 @@ TEST(ModuleTest, setModuleFlagInt) {
   EXPECT_EQ(Val2, A2->getZExtValue());
 }
 
+TEST(ModuleTest, getLongDoubleFormat) {
+  LLVMContext Context;
+
+  // With no module flag, falls back to the triple's default long double format.
+  Module MX86("x86", Context);
+  MX86.setTargetTriple(Triple("x86_64-unknown-linux-gnu"));
+  EXPECT_EQ(LongDoubleFormat::X87DoubleExtended, MX86.getLongDoubleFormat());
+
+  Module MPPC("ppc", Context);
+  MPPC.setTargetTriple(Triple("powerpc64-unknown-linux-gnu"));
+  EXPECT_EQ(LongDoubleFormat::PPCDoubleDouble, MPPC.getLongDoubleFormat());
+
+  // An explicit module flag overrides the triple default.
+  MX86.setLongDoubleFormat(LongDoubleFormat::IEEEquad);
+  EXPECT_EQ(LongDoubleFormat::IEEEquad, MX86.getLongDoubleFormat());
+
+  // The flag is the string-valued "long-double-type" flag emitted by clang.
+  Module MFlag("flag", Context);
+  MFlag.setTargetTriple(Triple("x86_64-unknown-linux-gnu"));
+  MFlag.addModuleFlag(Module::Error, "long-double-type",
+                      MDString::get(Context, "fp128"));
+  EXPECT_EQ(LongDoubleFormat::IEEEquad, MFlag.getLongDoubleFormat());
+}
+
 TEST(ModuleTest, setModuleFlagTwoMod) {
   LLVMContext Context;
   Module MA("MA", Context);


### PR DESCRIPTION
Add a helper function to return the effective long double type
for a module, accounting for the "long-double-type" module flag,
and defaulting to the triple's default.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>