### PR TITLE
[lldb] Remove duplicate declarations after merge

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CommonABIRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CommonABIRuntime.h
@@ -63,11 +63,6 @@ protected:
   void SetDynamicTypeInfo(const lldb_private::Address &vtable_addr,
                           const TypeAndOrName &type_info);
 
-  TypeAndOrName GetDynamicTypeInfo(const lldb_private::Address &vtable_addr);
-
-  void SetDynamicTypeInfo(const lldb_private::Address &vtable_addr,
-                          const TypeAndOrName &type_info);
-
 protected:
   Process *m_process;
   std::mutex m_mutex;


### PR DESCRIPTION
I'm not sure why Git decided to add two duplicate declarations when merging #212015, but this removes the duplicate ones.