### PR TITLE
[flang] To fix LIT test that AIX does not emit comdat.

### DIFF
--- a/flang/test/Lower/MIF/coarray_dealloc_not_alloc.f90
+++ b/flang/test/Lower/MIF/coarray_dealloc_not_alloc.f90
@@ -1,6 +1,6 @@
 ! RUN: %flang_fc1 -emit-llvm -fcoarray %s -o - 2>&1 | FileCheck %s --check-prefix=LLVM
 
-! LLVM: @_QFB1Ekk_coarray_handle = linkonce global %_QM__fortran_builtinsT__builtin_prif_coarray_handle_type zeroinitializer, comdat
+! LLVM: @_QFB1Ekk_coarray_handle = linkonce global %_QM__fortran_builtinsT__builtin_prif_coarray_handle_type zeroinitializer{{.*}}
 
 ! LLVM-LABEL:  @_QQmain()
 ! LLVM:  call void @_QMprifPprif_deallocate_coarray(ptr @_QFB1Ekk_coarray_handle, ptr null, ptr null, ptr null)
@@ -11,4 +11,3 @@ integer :: kk
 allocatable :: kk(:)[:]
 endblock
 end
-


### PR DESCRIPTION
PR #213890 added this new LIT test.
However, AIX uses XCOFF and does not emit COFF COMDAT.