### PR TITLE
[clangd][HLSL] Prevent RootSignature internal identifier leak on hover

### DIFF
--- a/clang-tools-extra/clangd/Hover.cpp
+++ b/clang-tools-extra/clangd/Hover.cpp
@@ -1013,19 +1013,15 @@ std::optional<HoverInfo> getHoverContents(const SelectionTree::Node *N,
 // Generates hover info for attributes.
 std::optional<HoverInfo> getHoverContents(const Attr *A, ParsedAST &AST) {
   HoverInfo HI;
-
-  if (AST.getLangOpts().HLSL && llvm::isa<RootSignatureAttr>(A)) {
-    // We do not use pretty print here because it would expose the internal
-    // string/macro representation instead of the original source attribute.
-    HI.Name = "RootSignature";
-    HI.Documentation = Attr::getDocumentation(A->getKind()).str();
-    return HI;
-  }
-
   HI.Name = A->getSpelling();
   if (A->hasScope())
     HI.LocalScope = A->getScopeName()->getName().str();
-  {
+  // Skip pretty-printing HLSL RootSignature attributes: printPretty()
+  // reconstructs the attribute using the compiler-generated internal
+  // identifier for the expanded macro (__hlsl_rootsig_decl_<hash>) instead
+  // of the original source text, leaking an implementation detail into the
+  // hover tooltip.
+  if (!AST.getLangOpts().HLSL || !llvm::isa<RootSignatureAttr>(A)) {
     llvm::raw_string_ostream OS(HI.Definition);
     A->printPretty(OS, AST.getASTContext().getPrintingPolicy());
   }

--- a/clang-tools-extra/clangd/Hover.cpp
+++ b/clang-tools-extra/clangd/Hover.cpp
@@ -1014,7 +1014,7 @@ std::optional<HoverInfo> getHoverContents(const SelectionTree::Node *N,
 std::optional<HoverInfo> getHoverContents(const Attr *A, ParsedAST &AST) {
   HoverInfo HI;
 
-  if (const auto *RS = llvm::dyn_cast<RootSignatureAttr>(A)) {
+  if (llvm::isa<RootSignatureAttr>(A)) {
     HI.Name = "RootSignature";
     HI.Documentation = Attr::getDocumentation(A->getKind()).str();
     return HI;

--- a/clang-tools-extra/clangd/Hover.cpp
+++ b/clang-tools-extra/clangd/Hover.cpp
@@ -1013,6 +1013,13 @@ std::optional<HoverInfo> getHoverContents(const SelectionTree::Node *N,
 // Generates hover info for attributes.
 std::optional<HoverInfo> getHoverContents(const Attr *A, ParsedAST &AST) {
   HoverInfo HI;
+
+  if (const auto *RS = llvm::dyn_cast<RootSignatureAttr>(A)) {
+    HI.Name = "RootSignature";
+    HI.Documentation = Attr::getDocumentation(A->getKind()).str();
+    return HI;
+  }
+
   HI.Name = A->getSpelling();
   if (A->hasScope())
     HI.LocalScope = A->getScopeName()->getName().str();

--- a/clang-tools-extra/clangd/Hover.cpp
+++ b/clang-tools-extra/clangd/Hover.cpp
@@ -1014,7 +1014,9 @@ std::optional<HoverInfo> getHoverContents(const SelectionTree::Node *N,
 std::optional<HoverInfo> getHoverContents(const Attr *A, ParsedAST &AST) {
   HoverInfo HI;
 
-  if (llvm::isa<RootSignatureAttr>(A)) {
+  if (AST.getLangOpts().HLSL && llvm::isa<RootSignatureAttr>(A)) {
+    // We do not use pretty print here because it would expose the internal
+    // string/macro representation instead of the original source attribute.
     HI.Name = "RootSignature";
     HI.Documentation = Attr::getDocumentation(A->getKind()).str();
     return HI;

--- a/clang-tools-extra/clangd/unittests/HoverTests.cpp
+++ b/clang-tools-extra/clangd/unittests/HoverTests.cpp
@@ -5446,6 +5446,8 @@ TEST(Hover, HLSLRootSignature) {
   auto H = getHover(AST, T.point(), format::getLLVMStyle(), nullptr);
   ASSERT_TRUE(H) << "Hover should have been returned for RootSignature!";
   EXPECT_EQ(H->Name, "RootSignature");
+  EXPECT_EQ(H->Definition.find("__hlsl_rootsig_decl"), std::string::npos)
+      << "Definition leaked internal identifier: " << H->Definition;
 }
 
 } // namespace

--- a/clang-tools-extra/clangd/unittests/HoverTests.cpp
+++ b/clang-tools-extra/clangd/unittests/HoverTests.cpp
@@ -5431,6 +5431,22 @@ TEST(Hover, HLSLRegisterAttributeRange) {
   }
 }
 
+TEST(Hover, HLSLRootSignature) {
+  Annotations T(R"hlsl(
+    #define RS_CBV "CBV(b0)"
+    [^RootSignature(RS_CBV)]
+    void CS_ValidCBV() {}
+  )hlsl");
+
+  TestTU TU = TestTU::withCode(T.code());
+  configureHLSL(TU);
+  auto AST = TU.build();
+  auto H = getHover(AST, T.point(), format::getLLVMStyle(), nullptr);
+  ASSERT_TRUE(H) << "Hover should have been returned for RootSignature!";
+  EXPECT_EQ(H->Name, "RootSignature");
+  EXPECT_EQ(H->Definition, "");
+}
+
 } // namespace
 } // namespace clangd
 } // namespace clang

--- a/clang-tools-extra/clangd/unittests/HoverTests.cpp
+++ b/clang-tools-extra/clangd/unittests/HoverTests.cpp
@@ -5432,11 +5432,13 @@ TEST(Hover, HLSLRegisterAttributeRange) {
 }
 
 TEST(Hover, HLSLRootSignature) {
-  Annotations T(R"hlsl(
-    #define RS_CBV "CBV(b0)"
-    [^RootSignature(RS_CBV)]
-    void CS_ValidCBV() {}
-  )hlsl");
+  Annotations T(
+      R"hlsl(
+        #define RS_CBV "CBV(b0)"
+        [^RootSignature(RS_CBV)]
+        void main() {}
+      )hlsl",
+      Annotations::Markers().setRangeBegin("{{").setRangeEnd("}}"));
 
   TestTU TU = TestTU::withCode(T.code());
   configureHLSL(TU);
@@ -5444,7 +5446,6 @@ TEST(Hover, HLSLRootSignature) {
   auto H = getHover(AST, T.point(), format::getLLVMStyle(), nullptr);
   ASSERT_TRUE(H) << "Hover should have been returned for RootSignature!";
   EXPECT_EQ(H->Name, "RootSignature");
-  EXPECT_EQ(H->Definition, "");
 }
 
 } // namespace


### PR DESCRIPTION
This patch adds a `dyn_cast<RootSignatureAttr>` branch in `getHoverContents` to explicitly set `HI.Name` and `HI.Documentation` for the attribute, skipping the generic `printPretty` path and preventing the internal identifier from leaking. Added a corresponding unit test to verify the behavior.

Fixes #214790