### PR TITLE
[compiler-rt][pgo] Guard coroutine profile test on <coroutine> header availability

### DIFF
--- a/compiler-rt/test/profile/instrprof-coroutine-profile.cpp
+++ b/compiler-rt/test/profile/instrprof-coroutine-profile.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: coroutines
 // RUN: %clangxx_pgogen -std=c++20 -O2 -o %t %s
 // RUN: env LLVM_PROFILE_FILE=%t.profraw %run %t
 // RUN: llvm-profdata show -function=foo -counts %t.profraw | FileCheck %s

--- a/compiler-rt/test/profile/lit.cfg.py
+++ b/compiler-rt/test/profile/lit.cfg.py
@@ -186,6 +186,20 @@ if config.android:
 if config.have_curl:
     config.available_features.add("curl")
 
+# Detect whether the C++ standard library used by %clangxx_pgogen actually
+# ships a usable <coroutine> header (e.g. libstdc++ before GCC 10 lacks it),
+# since --driver-mode=g++ makes clang resolve headers the way the host g++
+# would rather than always using libc++.
+cmd = subprocess.Popen(
+    (build_invocation(clang_cxxflags) + " -std=c++20 -fsyntax-only -x c++ -").split(),
+    stdin=subprocess.PIPE,
+    stdout=subprocess.DEVNULL,
+    stderr=subprocess.DEVNULL,
+)
+cmd.communicate(b"#include <coroutine>\n")
+if cmd.returncode == 0:
+    config.available_features.add("coroutines")
+
 if config.target_os in ("AIX", "Darwin", "Linux"):
     config.available_features.add("continuous-mode")
 


### PR DESCRIPTION
instrprof-coroutine-profile.cpp (added in 2f4043eb92f7) unconditionally includes <coroutine>, but %clangxx_pgogen builds via --driver-mode=g++, which resolves the C++ standard library the way the host g++ would rather than always via libc++. On toolchains where libstdc++ predates GCC 10 (e.g. GCC 8.5.0), <coroutine> is not found, and the test fails to compile with "fatal error: 'coroutine' file not found".

Add a "coroutines" lit feature that probes for a working <coroutine> header via the same substitution the test uses, and require it.