### PR TITLE
[InstCombine] Reassociate xor and disjoint or through zext

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -5447,17 +5447,6 @@ Instruction *InstCombinerImpl::visitXor(BinaryOperator &I) {
       Value *X;
       const APInt *C;
 
-      // xor (zext (or disjoint X, C)), RHSC
-      //   -> xor (zext X), RHSC ^ zext(C)
-      if (match(Op0, m_OneUse(m_ZExt(m_OneUse(
-                        m_DisjointOr(m_Value(X), m_APInt(C))))))) {
-        APInt NewC = *RHSC ^ C->zext(RHSC->getBitWidth());
-
-        Value *NewZExt = Builder.CreateZExt(X, Ty);
-        return BinaryOperator::CreateXor(
-            NewZExt, Constant::getIntegerValue(Ty, NewC));
-      }
-
       // (C - X) ^ signmaskC --> (C + signmaskC) - X
       if (RHSC->isSignMask() && match(Op0, m_Sub(m_APInt(C), m_Value(X))))
         return BinaryOperator::CreateSub(ConstantInt::get(Ty, *C + *RHSC), X);

--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -3964,6 +3964,9 @@ Value *InstCombinerImpl::foldDisjointOr(Value *LHS, Value *RHS) {
   if (Value *Res = foldIntegerRepackThroughZExt(LHS, RHS, Builder))
     return Res;
 
+  // For defined inputs, `or disjoint` is equivalent to xor:
+  // or disjoint (zext (xor X, C1)), C2
+  //   -> xor (zext X), C2 ^ zext(C1)
   Value *X;
   Constant *C1, *C2;
   if (match(LHS, m_OneUse(m_ZExt(m_OneUse(

--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -1775,6 +1775,27 @@ static Instruction *foldLogicCastConstant(BinaryOperator &Logic, CastInst *Cast,
   Type *DestTy = Logic.getType();
   Type *SrcTy = Cast->getSrcTy();
 
+  // xor (zext (or disjoint X, NarrowC)), WideC
+  //   -> xor (zext X), WideC ^ zext(NarrowC)
+  if (LogicOpc == Instruction::Xor && SrcTy->isIntegerTy() &&
+      DestTy->isIntegerTy()) {
+    Value *X;
+    ConstantInt *NarrowC, *WideC;
+
+    if (match(C, m_ConstantInt(WideC)) &&
+        match(Cast,
+              m_OneUse(m_ZExt(m_OneUse(
+                  m_c_DisjointOr(m_Value(X), m_ConstantInt(NarrowC))))))) {
+      APInt NewC =
+          WideC->getValue() ^
+          NarrowC->getValue().zext(WideC->getBitWidth());
+
+      Value *NewZExt = IC.Builder.CreateZExt(X, DestTy);
+      return BinaryOperator::CreateXor(NewZExt,
+                                       ConstantInt::get(DestTy, NewC));
+    }
+  }
+
   // Move the logic operation ahead of a zext or sext if the constant is
   // unchanged in the smaller source type. Performing the logic in a smaller
   // type may provide more information to later folds, and the smaller logic

--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -13,6 +13,7 @@
 #include "InstCombineInternal.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/Analysis/CmpInstAnalysis.h"
+#include "llvm/Analysis/ConstantFolding.h"
 #include "llvm/Analysis/FloatingPointPredicateUtils.h"
 #include "llvm/Analysis/InstructionSimplify.h"
 #include "llvm/IR/ConstantRange.h"
@@ -3962,6 +3963,25 @@ Value *InstCombinerImpl::foldDisjointOr(Value *LHS, Value *RHS) {
     return Res;
   if (Value *Res = foldIntegerRepackThroughZExt(LHS, RHS, Builder))
     return Res;
+
+  Value *X;
+  Constant *C1, *C2;
+  if (match(LHS, m_OneUse(m_ZExt(m_OneUse(
+                    m_Xor(m_Value(X), m_Constant(C1)))))) &&
+      match(RHS, m_Constant(C2))) {
+    Type *DestTy = C2->getType();
+    Constant *ExtC1 =
+        ConstantFoldCastOperand(Instruction::ZExt, C1, DestTy, DL);
+    if (!ExtC1)
+      return nullptr;
+
+    Constant *FoldedC = ConstantFoldBinaryOpOperands(
+        Instruction::Xor, C2, ExtC1, DL);
+    if (!FoldedC)
+      return nullptr;
+
+    return Builder.CreateXor(Builder.CreateZExt(X, DestTy), FoldedC);
+  }
 
   return nullptr;
 }

--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -1775,27 +1775,6 @@ static Instruction *foldLogicCastConstant(BinaryOperator &Logic, CastInst *Cast,
   Type *DestTy = Logic.getType();
   Type *SrcTy = Cast->getSrcTy();
 
-  // xor (zext (or disjoint X, NarrowC)), WideC
-  //   -> xor (zext X), WideC ^ zext(NarrowC)
-  if (LogicOpc == Instruction::Xor && SrcTy->isIntegerTy() &&
-      DestTy->isIntegerTy()) {
-    Value *X;
-    ConstantInt *NarrowC, *WideC;
-
-    if (match(C, m_ConstantInt(WideC)) &&
-        match(Cast,
-              m_OneUse(m_ZExt(m_OneUse(
-                  m_c_DisjointOr(m_Value(X), m_ConstantInt(NarrowC))))))) {
-      APInt NewC =
-          WideC->getValue() ^
-          NarrowC->getValue().zext(WideC->getBitWidth());
-
-      Value *NewZExt = IC.Builder.CreateZExt(X, DestTy);
-      return BinaryOperator::CreateXor(NewZExt,
-                                       ConstantInt::get(DestTy, NewC));
-    }
-  }
-
   // Move the logic operation ahead of a zext or sext if the constant is
   // unchanged in the smaller source type. Performing the logic in a smaller
   // type may provide more information to later folds, and the smaller logic
@@ -5467,6 +5446,18 @@ Instruction *InstCombinerImpl::visitXor(BinaryOperator &I) {
     if (match(Op1, m_APInt(RHSC))) {
       Value *X;
       const APInt *C;
+
+      // xor (zext (or disjoint X, C)), RHSC
+      //   -> xor (zext X), RHSC ^ zext(C)
+      if (match(Op0, m_OneUse(m_ZExt(m_OneUse(
+                        m_DisjointOr(m_Value(X), m_APInt(C))))))) {
+        APInt NewC = *RHSC ^ C->zext(RHSC->getBitWidth());
+
+        Value *NewZExt = Builder.CreateZExt(X, Ty);
+        return BinaryOperator::CreateXor(
+            NewZExt, Constant::getIntegerValue(Ty, NewC));
+      }
+
       // (C - X) ^ signmaskC --> (C + signmaskC) - X
       if (RHSC->isSignMask() && match(Op0, m_Sub(m_APInt(C), m_Value(X))))
         return BinaryOperator::CreateSub(ConstantInt::get(Ty, *C + *RHSC), X);

--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -13,7 +13,6 @@
 #include "InstCombineInternal.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/Analysis/CmpInstAnalysis.h"
-#include "llvm/Analysis/ConstantFolding.h"
 #include "llvm/Analysis/FloatingPointPredicateUtils.h"
 #include "llvm/Analysis/InstructionSimplify.h"
 #include "llvm/IR/ConstantRange.h"
@@ -3963,28 +3962,6 @@ Value *InstCombinerImpl::foldDisjointOr(Value *LHS, Value *RHS) {
     return Res;
   if (Value *Res = foldIntegerRepackThroughZExt(LHS, RHS, Builder))
     return Res;
-
-  // For defined inputs, `or disjoint` is equivalent to xor:
-  // or disjoint (zext (xor X, C1)), C2
-  //   -> xor (zext X), C2 ^ zext(C1)
-  Value *X;
-  Constant *C1, *C2;
-  if (match(LHS, m_OneUse(m_ZExt(m_OneUse(
-                    m_Xor(m_Value(X), m_Constant(C1)))))) &&
-      match(RHS, m_Constant(C2))) {
-    Type *DestTy = C2->getType();
-    Constant *ExtC1 =
-        ConstantFoldCastOperand(Instruction::ZExt, C1, DestTy, DL);
-    if (!ExtC1)
-      return nullptr;
-
-    Constant *FoldedC = ConstantFoldBinaryOpOperands(
-        Instruction::Xor, C2, ExtC1, DL);
-    if (!FoldedC)
-      return nullptr;
-
-    return Builder.CreateXor(Builder.CreateZExt(X, DestTy), FoldedC);
-  }
 
   return nullptr;
 }

--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -5446,7 +5446,6 @@ Instruction *InstCombinerImpl::visitXor(BinaryOperator &I) {
     if (match(Op1, m_APInt(RHSC))) {
       Value *X;
       const APInt *C;
-
       // (C - X) ^ signmaskC --> (C + signmaskC) - X
       if (RHSC->isSignMask() && match(Op0, m_Sub(m_APInt(C), m_Value(X))))
         return BinaryOperator::CreateSub(ConstantInt::get(Ty, *C + *RHSC), X);

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -436,9 +436,8 @@ static bool simplifyAssocCastAssoc(BinaryOperator *BinOp1,
     return false;
 
   // `or disjoint` is equivalent to xor.
-  bool IsDisjointOrAsXor =
-      AssocOpcode == Instruction::Xor &&
-      match(BinOp2, m_DisjointOr(m_Value(), m_Value()));
+  bool IsDisjointOrAsXor = AssocOpcode == Instruction::Xor &&
+                           match(BinOp2, m_DisjointOr(m_Value(), m_Value()));
 
   if (BinOp2->getOpcode() != AssocOpcode && !IsDisjointOrAsXor)
     return false;
@@ -464,9 +463,10 @@ static bool simplifyAssocCastAssoc(BinaryOperator *BinOp1,
     return false;
 
   // If the original zext was nneg, it is safe to preserve nneg when
-  // removing an `or disjoint`: a non-negative (X | C) implies X is
-  // also non-negative.
-  bool PreserveNonNeg = IsDisjointOrAsXor && Cast->hasNonNeg();
+  // removing an `or`: a non-negative (X | C) implies X is also
+  // non-negative.
+  bool PreserveNonNeg =
+    Cast->hasNonNeg() && BinOp2->getOpcode() == Instruction::Or;
 
   IC.replaceOperand(*Cast, 0, BinOp2->getOperand(0));
   IC.replaceOperand(*BinOp1, 1, FoldedC);

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -435,12 +435,19 @@ static bool simplifyAssocCastAssoc(BinaryOperator *BinOp1,
   if (!BinOp2 || !BinOp2->hasOneUse())
     return false;
 
-  // `or disjoint` is equivalent to xor.
-  bool IsDisjointOrAsXor = AssocOpcode == Instruction::Xor &&
-                           match(BinOp2, m_DisjointOr(m_Value(), m_Value()));
+  if (BinOp2->getOpcode() != AssocOpcode) {
+    // For defined inputs, `or disjoint` is equivalent to xor.
+    bool IsMixedXorDisjointOr =
+        (AssocOpcode == Instruction::Xor &&
+         match(BinOp2, m_DisjointOr(m_Value(), m_Value()))) ||
+        (BinOp2->getOpcode() == Instruction::Xor &&
+         match(BinOp1, m_DisjointOr(m_Value(), m_Value())));
 
-  if (BinOp2->getOpcode() != AssocOpcode && !IsDisjointOrAsXor)
-    return false;
+    if (!IsMixedXorDisjointOr)
+      return false;
+
+    AssocOpcode = Instruction::Xor;
+  }
 
   Constant *C1, *C2;
   if (!match(BinOp1->getOperand(1), m_Constant(C1)) ||
@@ -462,20 +469,18 @@ static bool simplifyAssocCastAssoc(BinaryOperator *BinOp1,
   if (!FoldedC)
     return false;
 
-  // If the original zext was nneg, it is safe to preserve nneg when
-  // removing an `or`: a non-negative (X | C) implies X is also
-  // non-negative.
+  // A non-negative (X | C) implies that X is also non-negative.
   bool PreserveNonNeg =
-    Cast->hasNonNeg() && BinOp2->getOpcode() == Instruction::Or;
+      Cast->hasNonNeg() && BinOp2->getOpcode() == Instruction::Or;
 
   IC.replaceOperand(*Cast, 0, BinOp2->getOperand(0));
-  IC.replaceOperand(*BinOp1, 1, FoldedC);
-  BinOp1->dropPoisonGeneratingFlags();
   Cast->dropPoisonGeneratingFlags();
 
   if (PreserveNonNeg)
     Cast->setNonNeg();
 
+  Value *NewBinOp = IC.Builder.CreateBinOp(AssocOpcode, Cast, FoldedC);
+  IC.replaceInstUsesWith(*BinOp1, NewBinOp);
   return true;
 }
 
@@ -598,9 +603,8 @@ bool InstCombinerImpl::SimplifyAssociativeOrCommutative(BinaryOperator &I) {
 
     if (I.isAssociative() && I.isCommutative()) {
       if (simplifyAssocCastAssoc(&I, *this)) {
-        Changed = true;
         ++NumReassoc;
-        continue;
+        return true;
       }
 
       // Transform: "(A op B) op C" ==> "(C op A) op B" if "C op A" simplifies.

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -432,7 +432,15 @@ static bool simplifyAssocCastAssoc(BinaryOperator *BinOp1,
 
   auto AssocOpcode = BinOp1->getOpcode();
   auto *BinOp2 = dyn_cast<BinaryOperator>(Cast->getOperand(0));
-  if (!BinOp2 || !BinOp2->hasOneUse() || BinOp2->getOpcode() != AssocOpcode)
+  if (!BinOp2 || !BinOp2->hasOneUse())
+    return false;
+
+  // `or disjoint` is equivalent to xor.
+  bool IsDisjointOrAsXor =
+      AssocOpcode == Instruction::Xor &&
+      match(BinOp2, m_DisjointOr(m_Value(), m_Value()));
+
+  if (BinOp2->getOpcode() != AssocOpcode && !IsDisjointOrAsXor)
     return false;
 
   Constant *C1, *C2;
@@ -455,10 +463,19 @@ static bool simplifyAssocCastAssoc(BinaryOperator *BinOp1,
   if (!FoldedC)
     return false;
 
+  // If the original zext was nneg, it is safe to preserve nneg when
+  // removing an `or disjoint`: a non-negative (X | C) implies X is
+  // also non-negative.
+  bool PreserveNonNeg = IsDisjointOrAsXor && Cast->hasNonNeg();
+
   IC.replaceOperand(*Cast, 0, BinOp2->getOperand(0));
   IC.replaceOperand(*BinOp1, 1, FoldedC);
   BinOp1->dropPoisonGeneratingFlags();
   Cast->dropPoisonGeneratingFlags();
+
+  if (PreserveNonNeg)
+    Cast->setNonNeg();
+
   return true;
 }
 

--- a/llvm/test/Transforms/InstCombine/or.ll
+++ b/llvm/test/Transforms/InstCombine/or.ll
@@ -4,6 +4,7 @@
 
 target datalayout = "e-p:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:32:64-f32:32:32-f64:32:64-v64:64:64-v128:128:128-a0:0:64-f80:128:128-n32:64"
 declare void @use(i32)
+declare void @use_i8(i8)
 
 ; Should be eliminated
 define i32 @test12(i32 %A) {
@@ -2384,5 +2385,75 @@ define i32 @signum_i32_or_wrong_ext(i32 %x) {
   %sgt0 = icmp sgt i32 %x, 0
   %sgt0ext = sext i1 %sgt0 to i32
   %r = or i32 %signbit, %sgt0ext
+  ret i32 %r
+}
+
+; or disjoint(zext(xor X, C1), C2) -> xor(zext(X), C2 ^ zext(C1))
+define i32 @fold_disjoint_or_zext_xor(i8 %x) {
+; CHECK-LABEL: @fold_disjoint_or_zext_xor(
+; CHECK-NEXT:    [[TMP1:%.*]] = and i8 [[X:%.*]], -2
+; CHECK-NEXT:    [[TMP2:%.*]] = xor i8 [[TMP1]], 3
+; CHECK-NEXT:    [[R:%.*]] = zext i8 [[TMP2]] to i32
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %a = xor i8 %x, 2
+  %z = zext i8 %a to i32
+  %r = or disjoint i32 %z, 1
+  ret i32 %r
+}
+
+define <2 x i32> @fold_disjoint_or_zext_xor_splat(<2 x i8> %x) {
+; CHECK-LABEL: @fold_disjoint_or_zext_xor_splat(
+; CHECK-NEXT:    [[TMP1:%.*]] = and <2 x i8> [[X:%.*]], splat (i8 -2)
+; CHECK-NEXT:    [[TMP2:%.*]] = xor <2 x i8> [[TMP1]], splat (i8 3)
+; CHECK-NEXT:    [[R:%.*]] = zext <2 x i8> [[TMP2]] to <2 x i32>
+; CHECK-NEXT:    ret <2 x i32> [[R]]
+;
+  %a = xor <2 x i8> %x, splat (i8 2)
+  %z = zext <2 x i8> %a to <2 x i32>
+  %r = or disjoint <2 x i32> %z, splat (i32 1)
+  ret <2 x i32> %r
+}
+
+define i32 @no_fold_or_zext_xor(i8 %x) {
+; CHECK-LABEL: @no_fold_or_zext_xor(
+; CHECK-NEXT:    [[TMP1:%.*]] = and i8 [[X:%.*]], -2
+; CHECK-NEXT:    [[TMP2:%.*]] = xor i8 [[TMP1]], 3
+; CHECK-NEXT:    [[R:%.*]] = zext i8 [[TMP2]] to i32
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %a = xor i8 %x, 2
+  %z = zext i8 %a to i32
+  %r = or i32 %z, 1
+  ret i32 %r
+}
+
+define i32 @no_fold_disjoint_or_zext_xor_zext_multi_use(i8 %x) {
+; CHECK-LABEL: @no_fold_disjoint_or_zext_xor_zext_multi_use(
+; CHECK-NEXT:    [[A:%.*]] = xor i8 [[X:%.*]], 2
+; CHECK-NEXT:    [[Z:%.*]] = zext i8 [[A]] to i32
+; CHECK-NEXT:    call void @use(i32 [[Z]])
+; CHECK-NEXT:    [[R:%.*]] = or disjoint i32 [[Z]], 1
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %a = xor i8 %x, 2
+  %z = zext i8 %a to i32
+  call void @use(i32 %z)
+  %r = or disjoint i32 %z, 1
+  ret i32 %r
+}
+
+define i32 @no_fold_disjoint_or_zext_xor_inner_multi_use(i8 %x) {
+; CHECK-LABEL: @no_fold_disjoint_or_zext_xor_inner_multi_use(
+; CHECK-NEXT:    [[A:%.*]] = xor i8 [[X:%.*]], 2
+; CHECK-NEXT:    call void @use_i8(i8 [[A]])
+; CHECK-NEXT:    [[TMP1:%.*]] = or i8 [[A]], 1
+; CHECK-NEXT:    [[R:%.*]] = zext i8 [[TMP1]] to i32
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %a = xor i8 %x, 2
+  call void @use_i8(i8 %a)
+  %z = zext i8 %a to i32
+  %r = or disjoint i32 %z, 1
   ret i32 %r
 }

--- a/llvm/test/Transforms/InstCombine/or.ll
+++ b/llvm/test/Transforms/InstCombine/or.ll
@@ -2391,9 +2391,8 @@ define i32 @signum_i32_or_wrong_ext(i32 %x) {
 ; or disjoint(zext(xor X, C1), C2) -> xor(zext(X), C2 ^ zext(C1))
 define i32 @fold_disjoint_or_zext_xor(i8 %x) {
 ; CHECK-LABEL: @fold_disjoint_or_zext_xor(
-; CHECK-NEXT:    [[TMP1:%.*]] = and i8 [[X:%.*]], -2
-; CHECK-NEXT:    [[TMP2:%.*]] = xor i8 [[TMP1]], 3
-; CHECK-NEXT:    [[R:%.*]] = zext i8 [[TMP2]] to i32
+; CHECK-NEXT:    [[TMP1:%.*]] = xor i8 [[X:%.*]], 3
+; CHECK-NEXT:    [[R:%.*]] = zext i8 [[TMP1]] to i32
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %a = xor i8 %x, 2
@@ -2404,9 +2403,8 @@ define i32 @fold_disjoint_or_zext_xor(i8 %x) {
 
 define <2 x i32> @fold_disjoint_or_zext_xor_splat(<2 x i8> %x) {
 ; CHECK-LABEL: @fold_disjoint_or_zext_xor_splat(
-; CHECK-NEXT:    [[TMP1:%.*]] = and <2 x i8> [[X:%.*]], splat (i8 -2)
-; CHECK-NEXT:    [[TMP2:%.*]] = xor <2 x i8> [[TMP1]], splat (i8 3)
-; CHECK-NEXT:    [[R:%.*]] = zext <2 x i8> [[TMP2]] to <2 x i32>
+; CHECK-NEXT:    [[TMP1:%.*]] = xor <2 x i8> [[X:%.*]], splat (i8 3)
+; CHECK-NEXT:    [[R:%.*]] = zext <2 x i8> [[TMP1]] to <2 x i32>
 ; CHECK-NEXT:    ret <2 x i32> [[R]]
 ;
   %a = xor <2 x i8> %x, splat (i8 2)

--- a/llvm/test/Transforms/InstCombine/or.ll
+++ b/llvm/test/Transforms/InstCombine/or.ll
@@ -2413,6 +2413,19 @@ define <2 x i32> @fold_disjoint_or_zext_xor_splat(<2 x i8> %x) {
   ret <2 x i32> %r
 }
 
+; or(zext nneg(or X, C1), C2) -> zext nneg(or X, C1 | trunc(C2))
+define i32 @fold_or_zext_or_nneg(i8 %x) {
+; CHECK-LABEL: @fold_or_zext_or_nneg(
+; CHECK-NEXT:    [[TMP1:%.*]] = or i8 [[X:%.*]], 3
+; CHECK-NEXT:    [[R:%.*]] = zext nneg i8 [[TMP1]] to i32
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %a = or i8 %x, 2
+  %z = zext nneg i8 %a to i32
+  %r = or i32 %z, 1
+  ret i32 %r
+}
+
 define i32 @no_fold_or_zext_xor(i8 %x) {
 ; CHECK-LABEL: @no_fold_or_zext_xor(
 ; CHECK-NEXT:    [[TMP1:%.*]] = and i8 [[X:%.*]], -2

--- a/llvm/test/Transforms/InstCombine/xor.ll
+++ b/llvm/test/Transforms/InstCombine/xor.ll
@@ -1695,7 +1695,7 @@ define i64 @fold_zext_or_disjoint_xor_i32_to_i64(i32 %x) {
 
 define i64 @fold_zext_or_disjoint_xor_nneg(i32 %x) {
 ; CHECK-LABEL: @fold_zext_or_disjoint_xor_nneg(
-; CHECK-NEXT:    [[TMP1:%.*]] = zext i32 [[X:%.*]] to i64
+; CHECK-NEXT:    [[TMP1:%.*]] = zext nneg i32 [[X:%.*]] to i64
 ; CHECK-NEXT:    [[R:%.*]] = xor i64 [[TMP1]], 7640891576939301128
 ; CHECK-NEXT:    ret i64 [[R]]
 ;

--- a/llvm/test/Transforms/InstCombine/xor.ll
+++ b/llvm/test/Transforms/InstCombine/xor.ll
@@ -1670,9 +1670,8 @@ entry:
 
 define i32 @fold_zext_or_disjoint_xor_i8_to_i32(i8 %input) {
 ; CHECK-LABEL: @fold_zext_or_disjoint_xor_i8_to_i32(
-; CHECK-NEXT:    [[INPUT:%.*]] = or disjoint i8 [[INPUT1:%.*]], 10
-; CHECK-NEXT:    [[Z:%.*]] = zext i8 [[INPUT]] to i32
-; CHECK-NEXT:    [[R:%.*]] = xor i32 [[Z]], 257
+; CHECK-NEXT:    [[Z:%.*]] = zext i8 [[INPUT:%.*]] to i32
+; CHECK-NEXT:    [[R:%.*]] = xor i32 [[Z]], 267
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %or = or disjoint i8 %input, 10
@@ -1683,9 +1682,8 @@ define i32 @fold_zext_or_disjoint_xor_i8_to_i32(i8 %input) {
 
 define i64 @fold_zext_or_disjoint_xor_i32_to_i64(i32 %x) {
 ; CHECK-LABEL: @fold_zext_or_disjoint_xor_i32_to_i64(
-; CHECK-NEXT:    [[X:%.*]] = or disjoint i32 [[X1:%.*]], 1
-; CHECK-NEXT:    [[Z:%.*]] = zext i32 [[X]] to i64
-; CHECK-NEXT:    [[R:%.*]] = xor i64 [[Z]], 2611923443488327891
+; CHECK-NEXT:    [[Z:%.*]] = zext i32 [[X:%.*]] to i64
+; CHECK-NEXT:    [[R:%.*]] = xor i64 [[Z]], 2611923443488327890
 ; CHECK-NEXT:    ret i64 [[R]]
 ;
   %or = or disjoint i32 %x, 1
@@ -1696,9 +1694,8 @@ define i64 @fold_zext_or_disjoint_xor_i32_to_i64(i32 %x) {
 
 define i64 @fold_zext_or_disjoint_xor_nneg(i32 %x) {
 ; CHECK-LABEL: @fold_zext_or_disjoint_xor_nneg(
-; CHECK-NEXT:    [[OR:%.*]] = or disjoint i32 [[X:%.*]], 16842752
-; CHECK-NEXT:    [[Z:%.*]] = zext nneg i32 [[OR]] to i64
-; CHECK-NEXT:    [[R:%.*]] = xor i64 [[Z]], 7640891576956012808
+; CHECK-NEXT:    [[TMP1:%.*]] = zext i32 [[X:%.*]] to i64
+; CHECK-NEXT:    [[R:%.*]] = xor i64 [[TMP1]], 7640891576939301128
 ; CHECK-NEXT:    ret i64 [[R]]
 ;
   %or = or disjoint i32 %x, 16842752

--- a/llvm/test/Transforms/InstCombine/xor.ll
+++ b/llvm/test/Transforms/InstCombine/xor.ll
@@ -7,6 +7,7 @@
 declare i32 @llvm.ctlz.i32(i32, i1)
 declare <2 x i8> @llvm.cttz.v2i8(<2 x i8>, i1)
 declare void @use(i8)
+declare void @use_i32(i32)
 
 define i1 @test0(i1 %A) {
 ; CHECK-LABEL: @test0(
@@ -1704,6 +1705,18 @@ define i64 @fold_zext_or_disjoint_xor_nneg(i32 %x) {
   ret i64 %r
 }
 
+define <2 x i32> @fold_zext_or_disjoint_xor_splat_vector(<2 x i8> %x) {
+; CHECK-LABEL: @fold_zext_or_disjoint_xor_splat_vector(
+; CHECK-NEXT:    [[TMP1:%.*]] = zext <2 x i8> [[X:%.*]] to <2 x i32>
+; CHECK-NEXT:    [[R:%.*]] = xor <2 x i32> [[TMP1]], splat (i32 267)
+; CHECK-NEXT:    ret <2 x i32> [[R]]
+;
+  %or = or disjoint <2 x i8> %x, <i8 10, i8 10>
+  %z = zext <2 x i8> %or to <2 x i32>
+  %r = xor <2 x i32> %z, <i32 257, i32 257>
+  ret <2 x i32> %r
+}
+
 define i32 @no_fold_zext_plain_or_xor(i8 %x) {
 ; CHECK-LABEL: @no_fold_zext_plain_or_xor(
 ; CHECK-NEXT:    [[OR:%.*]] = or i8 [[X:%.*]], 2
@@ -1722,16 +1735,14 @@ define i32 @no_fold_zext_multi_use(i8 %x) {
 ; CHECK-NEXT:    [[OR:%.*]] = or disjoint i8 [[X:%.*]], 2
 ; CHECK-NEXT:    [[Z:%.*]] = zext i8 [[OR]] to i32
 ; CHECK-NEXT:    [[R:%.*]] = xor i32 [[Z]], 257
-; CHECK-NEXT:    [[USE:%.*]] = add nuw nsw i32 [[Z]], 1
-; CHECK-NEXT:    [[RESULT:%.*]] = add nuw nsw i32 [[R]], [[USE]]
-; CHECK-NEXT:    ret i32 [[RESULT]]
+; CHECK-NEXT:    call void @use_i32(i32 [[Z]])
+; CHECK-NEXT:    ret i32 [[R]]
 ;
   %or = or disjoint i8 %x, 2
   %z = zext i8 %or to i32
   %r = xor i32 %z, 257
-  %use = add i32 %z, 1
-  %result = add i32 %r, %use
-  ret i32 %result
+  call void @use_i32(i32 %z)
+  ret i32 %r
 }
 
 define i32 @no_fold_inner_or_multi_use(i8 %x) {
@@ -1739,14 +1750,12 @@ define i32 @no_fold_inner_or_multi_use(i8 %x) {
 ; CHECK-NEXT:    [[OR:%.*]] = or disjoint i8 [[X:%.*]], 2
 ; CHECK-NEXT:    [[Z:%.*]] = zext i8 [[OR]] to i32
 ; CHECK-NEXT:    [[R:%.*]] = xor i32 [[Z]], 257
-; CHECK-NEXT:    [[EXTRA:%.*]] = zext i8 [[OR]] to i32
-; CHECK-NEXT:    [[RESULT:%.*]] = add nuw nsw i32 [[R]], [[EXTRA]]
-; CHECK-NEXT:    ret i32 [[RESULT]]
+; CHECK-NEXT:    call void @use(i8 [[OR]])
+; CHECK-NEXT:    ret i32 [[R]]
 ;
   %or = or disjoint i8 %x, 2
   %z = zext i8 %or to i32
   %r = xor i32 %z, 257
-  %extra = zext i8 %or to i32
-  %result = add i32 %r, %extra
-  ret i32 %result
+  call void @use(i8 %or)
+  ret i32 %r
 }

--- a/llvm/test/Transforms/InstCombine/xor.ll
+++ b/llvm/test/Transforms/InstCombine/xor.ll
@@ -1664,3 +1664,92 @@ entry:
   %or = or <2 x i32> %add, %c
   ret <2 x i32> %or
 }
+
+; xor(zext(or disjoint X, NarrowC), WideC) ->
+; xor(zext(X), WideC ^ zext(NarrowC))
+
+define i32 @fold_zext_or_disjoint_xor_i8_to_i32(i8 %input) {
+; CHECK-LABEL: @fold_zext_or_disjoint_xor_i8_to_i32(
+; CHECK-NEXT:    [[INPUT:%.*]] = or disjoint i8 [[INPUT1:%.*]], 10
+; CHECK-NEXT:    [[Z:%.*]] = zext i8 [[INPUT]] to i32
+; CHECK-NEXT:    [[R:%.*]] = xor i32 [[Z]], 257
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %or = or disjoint i8 %input, 10
+  %z = zext i8 %or to i32
+  %r = xor i32 %z, 257
+  ret i32 %r
+}
+
+define i64 @fold_zext_or_disjoint_xor_i32_to_i64(i32 %x) {
+; CHECK-LABEL: @fold_zext_or_disjoint_xor_i32_to_i64(
+; CHECK-NEXT:    [[X:%.*]] = or disjoint i32 [[X1:%.*]], 1
+; CHECK-NEXT:    [[Z:%.*]] = zext i32 [[X]] to i64
+; CHECK-NEXT:    [[R:%.*]] = xor i64 [[Z]], 2611923443488327891
+; CHECK-NEXT:    ret i64 [[R]]
+;
+  %or = or disjoint i32 %x, 1
+  %z = zext i32 %or to i64
+  %r = xor i64 %z, 2611923443488327891
+  ret i64 %r
+}
+
+define i64 @fold_zext_or_disjoint_xor_nneg(i32 %x) {
+; CHECK-LABEL: @fold_zext_or_disjoint_xor_nneg(
+; CHECK-NEXT:    [[OR:%.*]] = or disjoint i32 [[X:%.*]], 16842752
+; CHECK-NEXT:    [[Z:%.*]] = zext nneg i32 [[OR]] to i64
+; CHECK-NEXT:    [[R:%.*]] = xor i64 [[Z]], 7640891576956012808
+; CHECK-NEXT:    ret i64 [[R]]
+;
+  %or = or disjoint i32 %x, 16842752
+  %z = zext nneg i32 %or to i64
+  %r = xor i64 %z, 7640891576956012808
+  ret i64 %r
+}
+
+define i32 @no_fold_zext_plain_or_xor(i8 %x) {
+; CHECK-LABEL: @no_fold_zext_plain_or_xor(
+; CHECK-NEXT:    [[OR:%.*]] = or i8 [[X:%.*]], 2
+; CHECK-NEXT:    [[Z:%.*]] = zext i8 [[OR]] to i32
+; CHECK-NEXT:    [[R:%.*]] = xor i32 [[Z]], 257
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %or = or i8 %x, 2
+  %z = zext i8 %or to i32
+  %r = xor i32 %z, 257
+  ret i32 %r
+}
+
+define i32 @no_fold_zext_multi_use(i8 %x) {
+; CHECK-LABEL: @no_fold_zext_multi_use(
+; CHECK-NEXT:    [[OR:%.*]] = or disjoint i8 [[X:%.*]], 2
+; CHECK-NEXT:    [[Z:%.*]] = zext i8 [[OR]] to i32
+; CHECK-NEXT:    [[R:%.*]] = xor i32 [[Z]], 257
+; CHECK-NEXT:    [[USE:%.*]] = add nuw nsw i32 [[Z]], 1
+; CHECK-NEXT:    [[RESULT:%.*]] = add nuw nsw i32 [[R]], [[USE]]
+; CHECK-NEXT:    ret i32 [[RESULT]]
+;
+  %or = or disjoint i8 %x, 2
+  %z = zext i8 %or to i32
+  %r = xor i32 %z, 257
+  %use = add i32 %z, 1
+  %result = add i32 %r, %use
+  ret i32 %result
+}
+
+define i32 @no_fold_inner_or_multi_use(i8 %x) {
+; CHECK-LABEL: @no_fold_inner_or_multi_use(
+; CHECK-NEXT:    [[OR:%.*]] = or disjoint i8 [[X:%.*]], 2
+; CHECK-NEXT:    [[Z:%.*]] = zext i8 [[OR]] to i32
+; CHECK-NEXT:    [[R:%.*]] = xor i32 [[Z]], 257
+; CHECK-NEXT:    [[EXTRA:%.*]] = zext i8 [[OR]] to i32
+; CHECK-NEXT:    [[RESULT:%.*]] = add nuw nsw i32 [[R]], [[EXTRA]]
+; CHECK-NEXT:    ret i32 [[RESULT]]
+;
+  %or = or disjoint i8 %x, 2
+  %z = zext i8 %or to i32
+  %r = xor i32 %z, 257
+  %extra = zext i8 %or to i32
+  %result = add i32 %r, %extra
+  ret i32 %result
+}


### PR DESCRIPTION
Fold constants across a zero-extension when `xor` and `or disjoint` form an associative XOR chain.

This PR handles both directions:

```text
xor(zext(or disjoint(X, C1)), C2)
  -> xor(zext(X), C2 ^ zext(C1))
```

and:

```text
or disjoint(zext(xor(X, C1)), C2)
  -> xor(zext(X), C2 ^ zext(C1))
```

For defined inputs, `or disjoint` is equivalent to `xor`, so the constants can be combined after zero-extension.

Both forms are handled in `simplifyAssocCastAssoc()`. For mixed `xor` and `or disjoint` cases, the helper selects `xor` as the reassociation opcode and creates a replacement outer instruction instead of modifying the existing one in place. This allows the reverse form to change the outer opcode from `or` to `xor` while keeping the helper's existing `bool` interface.

Both folds require the `zext` and the inner binary operation to have one use.

For the first form, `nneg` is preserved on the replacement `zext`: if `X | C1` is non-negative, then `X` is also non-negative.

For the reverse form, `nneg` is not transferred to `zext(X)`, because `xor(X, C1)` being non-negative does not imply that `X` is non-negative.

Tests cover scalar and splat-vector forms, `nneg` preservation, plain-`or` negative cases, and multi-use restrictions.

Alive2 proofs:
- Combined proofs for both mixed-opcode variants and `nneg` preservation: https://alive2.llvm.org/ce/z/K84sqJ

AI assistance: ChatGPT was used during analysis and implementation discussion. I reviewed and verified the submitted code and tests and understand the changes.

Fixes #214652