### PR TITLE
release-tasks: Disable lit publishing for release candidates

### DIFF
--- a/.github/workflows/release-tasks.yml
+++ b/.github/workflows/release-tasks.yml
@@ -103,6 +103,7 @@ jobs:
       id-token: write # Requred for pypi publishing
     needs:
       - validate-tag
+    if: ${{ !contains(inputs.release-version, 'rc') }}
     environment: pypi
     steps:
       - name: Checkout LLVM

--- a/.github/workflows/release-tasks.yml
+++ b/.github/workflows/release-tasks.yml
@@ -103,7 +103,7 @@ jobs:
       id-token: write # Requred for pypi publishing
     needs:
       - validate-tag
-    if: ${{ !contains(inputs.release-version, 'rc') }}
+    if: ${{ !contains(needs.validate-tag.outputs.release-version, 'rc') }}
     environment: pypi
     steps:
       - name: Checkout LLVM


### PR DESCRIPTION
There is no rc in the lit version string, so release candidates get published using the non-rc version number.