### PR TITLE
[ADT] Avoid generic dispatch in StringRef::split(char)

### DIFF
--- a/llvm/include/llvm/ADT/StringRef.h
+++ b/llvm/include/llvm/ADT/StringRef.h
@@ -734,7 +734,10 @@ public:
   /// \param Separator The character to split on.
   /// \returns The split substrings.
   [[nodiscard]] std::pair<StringRef, StringRef> split(char Separator) const {
-    return split(StringRef(&Separator, 1));
+    size_t Idx = find(Separator);
+    if (Idx == npos)
+      return {*this, StringRef()};
+    return {slice(0, Idx), substr(Idx + 1)};
   }
 
   /// Split into two substrings around the first occurrence of a separator


### PR DESCRIPTION
`StringRef::split(char)` builds a temporary one-byte `StringRef` and delegates
to the generic `split(StringRef)`. For a one-byte needle that path reduces to
`memchr` anyway, but only after an out-of-line call into `libLLVMSupport` and
its needle-dispatch checks, and taking the parameter's address forces the
separator byte to be spilled to the stack at every call site:

```asm
; before                                  ; after
movb $0x2c,0x2f(%rsp)                     call memchr@plt
call <_ZNK4llvm9StringRef4findES0_m>
```

Calling `find(Separator)` directly inlines to a plain `memchr`. The overload
was already restricted to a single-character separator, so behavior is
unchanged. There are ~368 `split('c')` call sites in-tree.

**Performance** (GCC `-O3`, Ryzen 7 3700X; medians of 14 interleaved A/B
rounds): the saving is a fixed ~2.5 ns per call. That is ~1.7x for the common
case of a separator near the front — `Triple.cpp` component splits go
36.7 → 19.8 ns, `CommandLine.cpp` `Arg.split('=')` 6.3 → 3.6 ns — tapering to
1.09x when a 4 KiB haystack contains no separator at all. Old and new code both
bottom out in `memchr`, so no input class regresses.

**Code size** is neutral or better, since the inlined form is smaller than the
temporary-plus-call sequence it replaces: recompiling `Triple.cpp` (11 call
sites) shrinks `.text` 7.0%; `CommandLine.cpp` grows 0.09%.

**Testing:** existing `StringRefTest` `Split`/`Split2`/`SplitLiteral` and all
of `ADTTests` (2168 tests) pass. Additionally cross-checked 7.7M generated
cases byte-for-byte (including result `data()` pointers) against the previous
implementation — covering null `data()`, embedded-NUL and high-bit separators,
and non-NUL-terminated interior slices — clean under
`-fsanitize=address,undefined`.

**AI tool use** (per the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html)):
this patch, its validation, and this description were prepared with the
assistance of Claude Code, and reviewed by the author.
