### PR TITLE
workflows/release-task: Stop uploading lit to test.pypi.org

### DIFF
--- a/.github/workflows/release-tasks.yml
+++ b/.github/workflows/release-tasks.yml
@@ -143,12 +143,6 @@ jobs:
           path: |
             llvm/utils/lit/dist
 
-      - name: Upload lit to test.pypi.org
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          packages-dir: llvm/utils/lit/dist/
-
       - name: Upload lit to pypi.org
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:


### PR DESCRIPTION
The gh-action-pypi-publish action only supports being run once per job.  Running it twice results in the second upload always failing. Rather than trying to create a complicated job structure to support uploading to test.pypi.org and pypi.org, we just remove the test.pypi.org upload for now.