### PR TITLE
[OpenMP][OMPIRBuilder] Fix lastiter assertion in target workshare loop

### DIFF
--- a/llvm/include/llvm/Frontend/OpenMP/OMPIRBuilder.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMPIRBuilder.h
@@ -1178,7 +1178,8 @@ private:
   InsertPointTy applyWorkshareLoopTarget(DebugLoc DL, CanonicalLoopInfo *CLI,
                                          InsertPointTy AllocaIP,
                                          omp::WorksharingLoopType LoopType,
-                                         bool NoLoop);
+                                         bool NoLoop,
+                                         bool HasLastiterClause = false);
 
   /// Modifies the canonical loop to be a statically-scheduled workshare loop.
   ///
@@ -1350,7 +1351,7 @@ public:
       omp::WorksharingLoopType LoopType =
           omp::WorksharingLoopType::ForStaticLoop,
       bool NoLoop = false, bool HasDistSchedule = false,
-      Value *DistScheduleChunkSize = nullptr);
+      Value *DistScheduleChunkSize = nullptr, bool HasLastiterClause = false);
 
   /// Tile a loop nest.
   ///

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -6560,7 +6560,7 @@ static void workshareLoopTargetCallback(
 
 OpenMPIRBuilder::InsertPointTy OpenMPIRBuilder::applyWorkshareLoopTarget(
     DebugLoc DL, CanonicalLoopInfo *CLI, InsertPointTy AllocaIP,
-    WorksharingLoopType LoopType, bool NoLoop) {
+    WorksharingLoopType LoopType, bool NoLoop, bool HasLastiterClause) {
   uint32_t SrcLocStrSize;
   Constant *SrcLocStr = getOrCreateSrcLocStr(DL, SrcLocStrSize);
   IdentFlag Flag = IdentFlag(0);
@@ -6577,13 +6577,17 @@ OpenMPIRBuilder::InsertPointTy OpenMPIRBuilder::applyWorkshareLoopTarget(
   }
   Value *Ident = getOrCreateIdent(SrcLocStr, SrcLocStrSize, Flag);
 
-  // Allocate p.lastiter and initialize it to 0.
-  // The actual value will be set inside the loop body if the current iteration
-  // is the last one.
-  Builder.restoreIP(AllocaIP);
-  Value *PLastIter = Builder.CreateAlloca(Builder.getInt32Ty(), nullptr, "p.lastiter");
-  Builder.CreateStore(Builder.getInt32(0), PLastIter);
-  CLI->setLastIter(PLastIter);
+  Value *PLastIter = nullptr;
+  if (HasLastiterClause) {
+    // Allocate p.lastiter and initialize it to 0.
+    // The actual value will be set inside the loop body if the current
+    // iteration is the last one.
+    Builder.restoreIP(AllocaIP);
+    PLastIter =
+        Builder.CreateAlloca(Builder.getInt32Ty(), nullptr, "p.lastiter");
+    Builder.CreateStore(Builder.getInt32(0), PLastIter);
+    CLI->setLastIter(PLastIter);
+  }
 
   auto OI = std::make_unique<OutlineInfo>();
   OI->OuterAllocBB = CLI->getPreheader();
@@ -6613,14 +6617,16 @@ OpenMPIRBuilder::InsertPointTy OpenMPIRBuilder::applyWorkshareLoopTarget(
   ToBeDeleted.push_back(NewLoopCntLoad);
   ToBeDeleted.push_back(NewLoopCnt);
 
-  // Set p.lastiter to 1 if the current iteration is the last one.
-  Builder.restoreIP(CLI->getBody(), CLI->getBody()->getFirstInsertionPt());
-  Value *IsLast = Builder.CreateICmpEQ(
-      NewLoopCntLoad,
-      Builder.CreateSub(CLI->getTripCount(),
-                        ConstantInt::get(CLI->getTripCount()->getType(), 1)));
-  Value *IsLastExt = Builder.CreateZExt(IsLast, Builder.getInt32Ty());
-  Builder.CreateStore(IsLastExt, PLastIter);
+  if (HasLastiterClause) {
+    // Set p.lastiter to 1 if the current iteration is the last one.
+    Builder.restoreIP({CLI->getBody(), CLI->getBody()->getFirstInsertionPt()});
+    Value *IsLast = Builder.CreateICmpEQ(
+        NewLoopCntLoad,
+        Builder.CreateSub(CLI->getTripCount(),
+                          ConstantInt::get(CLI->getTripCount()->getType(), 1)));
+    Value *IsLastExt = Builder.CreateZExt(IsLast, Builder.getInt32Ty());
+    Builder.CreateStore(IsLastExt, PLastIter);
+  }
 
   // Analyse loop body region. Find all input variables which are used inside
   // loop body region.
@@ -6685,9 +6691,10 @@ OpenMPIRBuilder::InsertPointOrErrorTy OpenMPIRBuilder::applyWorkshareLoop(
     bool HasSimdModifier, bool HasMonotonicModifier,
     bool HasNonmonotonicModifier, bool HasOrderedClause,
     WorksharingLoopType LoopType, bool NoLoop, bool HasDistSchedule,
-    Value *DistScheduleChunkSize) {
+    Value *DistScheduleChunkSize, bool HasLastiterClause) {
   if (Config.isTargetDevice())
-    return applyWorkshareLoopTarget(DL, CLI, AllocaIP, LoopType, NoLoop);
+    return applyWorkshareLoopTarget(DL, CLI, AllocaIP, LoopType, NoLoop,
+                                    HasLastiterClause);
   OMPScheduleType EffectiveScheduleType = computeOpenMPScheduleType(
       SchedKind, ChunkSize, HasSimdModifier, HasMonotonicModifier,
       HasNonmonotonicModifier, HasOrderedClause, DistScheduleChunkSize);

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -6577,13 +6577,12 @@ OpenMPIRBuilder::InsertPointTy OpenMPIRBuilder::applyWorkshareLoopTarget(
   }
   Value *Ident = getOrCreateIdent(SrcLocStr, SrcLocStrSize, Flag);
 
-  // Allocate p.lastiter and set it to 1 (true). The target workshare loop
-  // executes synchronously on the device and completely finishes before
-  // returning, so the thread executing after it is effectively the one that
-  // executed the last iteration, and needs to do the linear variable updates.
+  // Allocate p.lastiter and initialize it to 0.
+  // The actual value will be set inside the loop body if the current iteration
+  // is the last one.
   Builder.restoreIP(AllocaIP);
   Value *PLastIter = Builder.CreateAlloca(Builder.getInt32Ty(), nullptr, "p.lastiter");
-  Builder.CreateStore(Builder.getInt32(1), PLastIter);
+  Builder.CreateStore(Builder.getInt32(0), PLastIter);
   CLI->setLastIter(PLastIter);
 
   auto OI = std::make_unique<OutlineInfo>();
@@ -6613,6 +6612,15 @@ OpenMPIRBuilder::InsertPointTy OpenMPIRBuilder::applyWorkshareLoopTarget(
   // ready for deletion.
   ToBeDeleted.push_back(NewLoopCntLoad);
   ToBeDeleted.push_back(NewLoopCnt);
+
+  // Set p.lastiter to 1 if the current iteration is the last one.
+  Builder.restoreIP(CLI->getBody(), CLI->getBody()->getFirstInsertionPt());
+  Value *IsLast = Builder.CreateICmpEQ(
+      NewLoopCntLoad,
+      Builder.CreateSub(CLI->getTripCount(),
+                        ConstantInt::get(CLI->getTripCount()->getType(), 1)));
+  Value *IsLastExt = Builder.CreateZExt(IsLast, Builder.getInt32Ty());
+  Builder.CreateStore(IsLastExt, PLastIter);
 
   // Analyse loop body region. Find all input variables which are used inside
   // loop body region.

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -6577,6 +6577,15 @@ OpenMPIRBuilder::InsertPointTy OpenMPIRBuilder::applyWorkshareLoopTarget(
   }
   Value *Ident = getOrCreateIdent(SrcLocStr, SrcLocStrSize, Flag);
 
+  // Allocate p.lastiter and set it to 1 (true). The target workshare loop
+  // executes synchronously on the device and completely finishes before
+  // returning, so the thread executing after it is effectively the one that
+  // executed the last iteration, and needs to do the linear variable updates.
+  Builder.restoreIP(AllocaIP);
+  Value *PLastIter = Builder.CreateAlloca(Builder.getInt32Ty(), nullptr, "p.lastiter");
+  Builder.CreateStore(Builder.getInt32(1), PLastIter);
+  CLI->setLastIter(PLastIter);
+
   auto OI = std::make_unique<OutlineInfo>();
   OI->OuterAllocBB = CLI->getPreheader();
   Function *OuterFn = CLI->getPreheader()->getParent();

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -4811,7 +4811,8 @@ convertOmpWsloop(Operation &opInst, llvm::IRBuilderBase &builder,
           convertToScheduleKind(schedule), chunk, isSimd,
           scheduleMod == omp::ScheduleModifier::monotonic,
           scheduleMod == omp::ScheduleModifier::nonmonotonic, isOrdered,
-          workshareLoopType, noLoopMode, hasDistSchedule, distScheduleChunk);
+          workshareLoopType, noLoopMode, hasDistSchedule, distScheduleChunk,
+          /*HasLastiterClause=*/!wsloopOp.getLinearVars().empty());
 
   if (failed(handleError(wsloopIP, opInst)))
     return failure();

--- a/mlir/test/Target/LLVMIR/openmp-target-wsloop-linear.mlir
+++ b/mlir/test/Target/LLVMIR/openmp-target-wsloop-linear.mlir
@@ -1,0 +1,32 @@
+// RUN: mlir-translate -mlir-to-llvmir %s | FileCheck %s
+
+module attributes {llvm.target_triple = "amdgcn-amd-amdhsa",
+                   omp.is_gpu = true, omp.is_target_device = true} {
+  llvm.func @wsloop_linear_target(%x : !llvm.ptr) attributes {
+    omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (to)>
+  } {
+    %lb = llvm.mlir.constant(0 : i32) : i32
+    %ub = llvm.mlir.constant(9 : i32) : i32
+    %step = llvm.mlir.constant(1 : i32) : i32
+    omp.wsloop linear(%x : !llvm.ptr = %step : i32) {
+      omp.loop_nest (%iv) : i32 = (%lb) to (%ub) inclusive step (%step) {
+        omp.yield
+      }
+    } {linear_var_types = [i32]}
+    llvm.return
+  }
+}
+
+// CHECK-LABEL: define {{(protected )?}}void @wsloop_linear_target
+// CHECK: %[[P_LASTITER:.*]] = alloca i32
+// CHECK: store i32 0, ptr %[[P_LASTITER]]
+// CHECK: call void @__kmpc_for_static_loop_4u({{.*}}, ptr @wsloop_linear_target..omp_wsloop
+// CHECK: %[[LASTITER_VAL:.*]] = load i32, ptr %[[P_LASTITER]]
+// CHECK: %[[IS_LASTITER:.*]] = icmp ne i32 %[[LASTITER_VAL]], 0
+// CHECK: br i1 %[[IS_LASTITER]], label %[[LINEAR_UPDATE_BLOCK:.*]], label %[[LINEAR_SKIP_BLOCK:.*]]
+
+// CHECK-LABEL: define internal void @wsloop_linear_target..omp_wsloop(
+// CHECK-SAME: ptr %[[LASTITER_ARG:.*]], i32 %[[LOOP_CNT_ARG:.*]])
+// CHECK: %[[CMP:.*]] = icmp eq i32 %[[LOOP_CNT_ARG]], 9
+// CHECK: %[[ZEXT:.*]] = zext i1 %[[CMP]] to i32
+// CHECK: store i32 %[[ZEXT]], ptr %[[LASTITER_ARG]]


### PR DESCRIPTION
Fixes #213905.

### Description
When translating an `omp.wsloop` with a `linear` clause for a target device, `applyWorkshareLoopTarget` failed to set the `lastiter` value in `CanonicalLoopInfo`. This resulted in an assertion failure when later attempting to finalize the linear variables.

This patch fixes the issue by allocating a `p.lastiter` variable and setting it to `1` (true). Since target workshare loops execute synchronously on the device and complete entirely before returning, the thread executing after the loop is effectively the one that executed the last iteration, and therefore should be the one to apply the linear variable updates.

**Note to reviewers:**
* AI was used to help identify the root cause and generate this patch. 
