### PR TITLE
[llvm][test][CGPluginTest] Fix missing `plugins` in test requirements

### DIFF
--- a/llvm/test/Other/codegen-plugin-loading.ll
+++ b/llvm/test/Other/codegen-plugin-loading.ll
@@ -1,5 +1,5 @@
 ; RUN: llc -load %llvmshlibdir/CGTestPlugin%pluginext %s -o - | FileCheck %s
-; REQUIRES: native, system-linux, llvm-dylib
+; REQUIRES: native, system-linux, llvm-dylib, plugins
 
 ; CHECK: CodeGen Test Pass running on main
 define void @main() {


### PR DESCRIPTION
CGTestPlugin.so is only built when LLVM_ENABLE_PLUGINS is ON, so under this configuration the test will still run but without llc able to load the plugin and emit the expected message:
- LLVM_LINK_LLVM_DYLIB=ON (`llvm-dylib` set)
- LLVM_ENABLE_PLUGINS=OFF (`plugins` unset)

This changes the test so that it's only run when CGTestPlugin.so would have been built and is marked unsupported otherwise.