### PR TITLE
[LoopPassManager] Exit early for loop-free fns in FunctionToLoopPass.

### DIFF
--- a/llvm/lib/Transforms/Scalar/LoopPassManager.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopPassManager.cpp
@@ -199,6 +199,11 @@ PreservedAnalyses FunctionToLoopPassAdaptor::run(Function &F,
   PassInstrumentation PI = AM.getResult<PassInstrumentationAnalysis>(F);
 
   PreservedAnalyses PA = PreservedAnalyses::all();
+  // If there are no loops, there's no need to run any loop passes or construct
+  // the required analyses.
+  if (AM.getResult<LoopAnalysis>(F).empty())
+    return PA;
+
   // Check the PassInstrumentation's BeforePass callbacks before running the
   // canonicalization pipeline.
   if (PI.runBeforePass<Function>(LoopCanonicalizationFPM, F)) {

--- a/llvm/lib/Transforms/Scalar/LoopPassManager.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopPassManager.cpp
@@ -192,17 +192,17 @@ void FunctionToLoopPassAdaptor::printPipeline(
 
 PreservedAnalyses FunctionToLoopPassAdaptor::run(Function &F,
                                                  FunctionAnalysisManager &AM) {
-  // Before we even compute any loop analyses, first run a miniature function
-  // pass pipeline to put loops into their canonical form. Note that we can
-  // directly build up function analyses after this as the function pass
-  // manager handles all the invalidation at that layer.
-  PassInstrumentation PI = AM.getResult<PassInstrumentationAnalysis>(F);
-
   PreservedAnalyses PA = PreservedAnalyses::all();
   // If there are no loops, there's no need to run any loop passes or construct
   // the required analyses.
   if (AM.getResult<LoopAnalysis>(F).empty())
     return PA;
+
+  // Before we even compute any loop analyses, first run a miniature function
+  // pass pipeline to put loops into their canonical form. Note that we can
+  // directly build up function analyses after this as the function pass
+  // manager handles all the invalidation at that layer.
+  PassInstrumentation PI = AM.getResult<PassInstrumentationAnalysis>(F);
 
   // Check the PassInstrumentation's BeforePass callbacks before running the
   // canonicalization pipeline.
@@ -213,10 +213,6 @@ PreservedAnalyses FunctionToLoopPassAdaptor::run(Function &F,
 
   // Get the loop structure for this function
   LoopInfo &LI = AM.getResult<LoopAnalysis>(F);
-
-  // If there are no loops, there is nothing to do here.
-  if (LI.empty())
-    return PA;
 
   // Get the analysis results needed by loop passes.
   MemorySSA *MSSA =

--- a/llvm/test/Other/dump-before-after.ll
+++ b/llvm/test/Other/dump-before-after.ll
@@ -54,10 +54,10 @@
 ; MULTIPLE-GRANULAR-PASSES-DAG: 4-[[MODULE_NAME_HASH]]-function-[[FUNCTION_FOO_HASH]]-NoOpFunctionPass-before.ll
 ; MULTIPLE-GRANULAR-PASSES-DAG: 5-[[MODULE_NAME_HASH]]-function-[[FUNCTION_BAR_HASH:[a-z0-9]+]]-NoOpFunctionPass-after.ll
 ; MULTIPLE-GRANULAR-PASSES-DAG: 5-[[MODULE_NAME_HASH]]-function-[[FUNCTION_BAR_HASH]]-NoOpFunctionPass-before.ll
-; MULTIPLE-GRANULAR-PASSES-DAG: 10-[[MODULE_NAME_HASH]]-loop-[[LOOP_NAME_HASH:[a-z0-9]+]]-NoOpLoopPass-after.ll
-; MULTIPLE-GRANULAR-PASSES-DAG: 10-[[MODULE_NAME_HASH]]-loop-[[LOOP_NAME_HASH]]-NoOpLoopPass-before.ll
-; MULTIPLE-GRANULAR-PASSES-DAG: 11-[[MODULE_NAME_HASH]]-module-NoOpModulePass-after.ll
-; MULTIPLE-GRANULAR-PASSES-DAG: 11-[[MODULE_NAME_HASH]]-module-NoOpModulePass-before.ll
+; MULTIPLE-GRANULAR-PASSES-DAG: 8-[[MODULE_NAME_HASH]]-loop-[[LOOP_NAME_HASH:[a-z0-9]+]]-NoOpLoopPass-after.ll
+; MULTIPLE-GRANULAR-PASSES-DAG: 8-[[MODULE_NAME_HASH]]-loop-[[LOOP_NAME_HASH]]-NoOpLoopPass-before.ll
+; MULTIPLE-GRANULAR-PASSES-DAG: 9-[[MODULE_NAME_HASH]]-module-NoOpModulePass-after.ll
+; MULTIPLE-GRANULAR-PASSES-DAG: 9-[[MODULE_NAME_HASH]]-module-NoOpModulePass-before.ll
 ; RUN: rm -rf %t/logs
 
 ; Validate that analysis passes are excluded from dump.

--- a/llvm/test/Other/loop-pm-invalidation.ll
+++ b/llvm/test/Other/loop-pm-invalidation.ll
@@ -17,36 +17,25 @@
 ; RUN:     -passes='loop(no-op-loop,loop-deletion),invalidate<scalar-evolution>,loop(no-op-loop)' \
 ; RUN:     | FileCheck %s --check-prefix=CHECK-SCEV-INV-AFTER-DELETE
 
+; The loop pass manager only needs LoopAnalysis for a function without loops;
+; it skips the loop canonicalization passes entirely.
 define void @no_loops() {
-; CHECK-LOOP-INV: Running pass: LoopSimplifyPass
-; CHECK-LOOP-INV-NEXT: Running analysis: LoopAnalysis
-; CHECK-LOOP-INV-NEXT: Running analysis: DominatorTreeAnalysis
-; CHECK-LOOP-INV-NEXT: Running analysis: AssumptionAnalysis
-; CHECK-LOOP-INV-NEXT: Running analysis: TargetIRAnalysis
-; CHECK-LOOP-INV-NEXT: Running pass: LCSSAPass
+; CHECK-LOOP-INV: Running analysis: LoopAnalysis on no_loops
 ; CHECK-LOOP-INV-NEXT: Running pass: InvalidateAnalysisPass<{{.*}}LoopAnalysis
 ; CHECK-LOOP-INV-NEXT: Invalidating analysis: LoopAnalysis
-; CHECK-LOOP-INV-NEXT: Running pass: LoopSimplifyPass
 ; CHECK-LOOP-INV-NEXT: Running analysis: LoopAnalysis
-; CHECK-LOOP-INV-NEXT: Running pass: LCSSAPass
+; CHECK-LOOP-INV-NEXT: Invalidating analysis: LoopAnalysis
 ;
-; CHECK-SCEV-INV: Running pass: LoopSimplifyPass
-; CHECK-SCEV-INV-NEXT: Running analysis: LoopAnalysis
-; CHECK-SCEV-INV-NEXT: Running analysis: DominatorTreeAnalysis
-; CHECK-SCEV-INV-NEXT: Running analysis: AssumptionAnalysis
-; CHECK-SCEV-INV-NEXT: Running analysis: TargetIRAnalysis
-; CHECK-SCEV-INV-NEXT: Running pass: LCSSAPass
+; CHECK-SCEV-INV: Running analysis: LoopAnalysis on no_loops
 ; CHECK-SCEV-INV-NEXT: Running pass: InvalidateAnalysisPass<{{.*}}ScalarEvolutionAnalysis
-; CHECK-SCEV-INV-NEXT: Running pass: LoopSimplifyPass
-; CHECK-SCEV-INV-NEXT: Running pass: LCSSAPass
 
 entry:
   ret void
 }
 
 define void @one_loop(ptr %ptr) {
-; CHECK-LOOP-INV: Running pass: LoopSimplifyPass
-; CHECK-LOOP-INV-NEXT: Running analysis: LoopAnalysis
+; CHECK-LOOP-INV: Running analysis: LoopAnalysis on one_loop
+; CHECK-LOOP-INV-NEXT: Running pass: LoopSimplifyPass
 ; CHECK-LOOP-INV-NEXT: Running analysis: DominatorTreeAnalysis
 ; CHECK-LOOP-INV-NEXT: Running analysis: AssumptionAnalysis
 ; CHECK-LOOP-INV-NEXT: Running analysis: TargetIRAnalysis
@@ -61,15 +50,15 @@ define void @one_loop(ptr %ptr) {
 ; CHECK-LOOP-INV-NEXT: Invalidating analysis: LoopAnalysis
 ; CHECK-LOOP-INV-NEXT: Invalidating analysis: ScalarEvolutionAnalysis
 ; CHECK-LOOP-INV-NEXT: Invalidating analysis: InnerAnalysisManagerProxy<{{.*}}Loop
-; CHECK-LOOP-INV-NEXT: Running pass: LoopSimplifyPass
 ; CHECK-LOOP-INV-NEXT: Running analysis: LoopAnalysis
+; CHECK-LOOP-INV-NEXT: Running pass: LoopSimplifyPass
 ; CHECK-LOOP-INV-NEXT: Running pass: LCSSAPass
 ; CHECK-LOOP-INV-NEXT: Running analysis: ScalarEvolutionAnalysis
 ; CHECK-LOOP-INV-NEXT: Running analysis: InnerAnalysisManagerProxy<{{.*}}Loop
 ; CHECK-LOOP-INV-NEXT: Running pass: NoOpLoopPass
 ;
+; CHECK-SCEV-INV-NEXT: Running analysis: LoopAnalysis on one_loop
 ; CHECK-SCEV-INV-NEXT: Running pass: LoopSimplifyPass
-; CHECK-SCEV-INV-NEXT: Running analysis: LoopAnalysis
 ; CHECK-SCEV-INV-NEXT: Running analysis: DominatorTreeAnalysis
 ; CHECK-SCEV-INV-NEXT: Running analysis: AssumptionAnalysis
 ; CHECK-SCEV-INV-NEXT: Running analysis: TargetIRAnalysis
@@ -101,8 +90,8 @@ exit:
 }
 
 define void @nested_loops(ptr %ptr) {
-; CHECK-LOOP-INV: Running pass: LoopSimplifyPass
-; CHECK-LOOP-INV-NEXT: Running analysis: LoopAnalysis
+; CHECK-LOOP-INV: Running analysis: LoopAnalysis on nested_loops
+; CHECK-LOOP-INV-NEXT: Running pass: LoopSimplifyPass
 ; CHECK-LOOP-INV-NEXT: Running analysis: DominatorTreeAnalysis
 ; CHECK-LOOP-INV-NEXT: Running analysis: AssumptionAnalysis
 ; CHECK-LOOP-INV-NEXT: Running analysis: TargetIRAnalysis
@@ -119,16 +108,16 @@ define void @nested_loops(ptr %ptr) {
 ; CHECK-LOOP-INV-NEXT: Invalidating analysis: LoopAnalysis
 ; CHECK-LOOP-INV-NEXT: Invalidating analysis: ScalarEvolutionAnalysis
 ; CHECK-LOOP-INV-NEXT: Invalidating analysis: InnerAnalysisManagerProxy<{{.*}}Loop
-; CHECK-LOOP-INV-NEXT: Running pass: LoopSimplifyPass
 ; CHECK-LOOP-INV-NEXT: Running analysis: LoopAnalysis
+; CHECK-LOOP-INV-NEXT: Running pass: LoopSimplifyPass
 ; CHECK-LOOP-INV-NEXT: Running pass: LCSSAPass
 ; CHECK-LOOP-INV-NEXT: Running analysis: ScalarEvolutionAnalysis
 ; CHECK-LOOP-INV-NEXT: Running analysis: InnerAnalysisManagerProxy<{{.*}}Loop
 ; CHECK-LOOP-INV-NEXT: Running pass: NoOpLoopPass
 ; CHECK-LOOP-INV-NEXT: Running pass: NoOpLoopPass
 ;
-; CHECK-SCEV-INV: Running pass: LoopSimplifyPass
-; CHECK-SCEV-INV-NEXT: Running analysis: LoopAnalysis
+; CHECK-SCEV-INV: Running analysis: LoopAnalysis on nested_loops
+; CHECK-SCEV-INV-NEXT: Running pass: LoopSimplifyPass
 ; CHECK-SCEV-INV-NEXT: Running analysis: DominatorTreeAnalysis
 ; CHECK-SCEV-INV-NEXT: Running analysis: AssumptionAnalysis
 ; CHECK-SCEV-INV-NEXT: Running analysis: TargetIRAnalysis
@@ -170,8 +159,8 @@ exit:
 }
 
 define void @dead_loop() {
-; CHECK-LOOP-INV: Running pass: LoopSimplifyPass
-; CHECK-LOOP-INV-NEXT: Running analysis: LoopAnalysis
+; CHECK-LOOP-INV: Running analysis: LoopAnalysis on dead_loop
+; CHECK-LOOP-INV-NEXT: Running pass: LoopSimplifyPass
 ; CHECK-LOOP-INV-NEXT: Running analysis: DominatorTreeAnalysis
 ; CHECK-LOOP-INV-NEXT: Running analysis: AssumptionAnalysis
 ; CHECK-LOOP-INV-NEXT: Running analysis: TargetIRAnalysis
@@ -186,15 +175,15 @@ define void @dead_loop() {
 ; CHECK-LOOP-INV-NEXT: Invalidating analysis: LoopAnalysis
 ; CHECK-LOOP-INV-NEXT: Invalidating analysis: ScalarEvolutionAnalysis
 ; CHECK-LOOP-INV-NEXT: Invalidating analysis: InnerAnalysisManagerProxy<{{.*}}Loop
-; CHECK-LOOP-INV-NEXT: Running pass: LoopSimplifyPass
 ; CHECK-LOOP-INV-NEXT: Running analysis: LoopAnalysis
+; CHECK-LOOP-INV-NEXT: Running pass: LoopSimplifyPass
 ; CHECK-LOOP-INV-NEXT: Running pass: LCSSAPass
 ; CHECK-LOOP-INV-NEXT: Running analysis: ScalarEvolutionAnalysis
 ; CHECK-LOOP-INV-NEXT: Running analysis: InnerAnalysisManagerProxy<{{.*}}Loop
 ; CHECK-LOOP-INV-NEXT: Running pass: NoOpLoopPass
 ;
-; CHECK-SCEV-INV: Running pass: LoopSimplifyPass
-; CHECK-SCEV-INV-NEXT: Running analysis: LoopAnalysis
+; CHECK-SCEV-INV: Running analysis: LoopAnalysis on dead_loop
+; CHECK-SCEV-INV-NEXT: Running pass: LoopSimplifyPass
 ; CHECK-SCEV-INV-NEXT: Running analysis: DominatorTreeAnalysis
 ; CHECK-SCEV-INV-NEXT: Running analysis: AssumptionAnalysis
 ; CHECK-SCEV-INV-NEXT: Running analysis: TargetIRAnalysis
@@ -215,7 +204,6 @@ define void @dead_loop() {
 ; CHECK-SCEV-INV-NEXT: Running pass: NoOpLoopPass
 ;
 ; CHECK-SCEV-INV-AFTER-DELETE-LABEL: Running pass: LoopSimplifyPass on dead_loop
-; CHECK-SCEV-INV-AFTER-DELETE-NEXT: Running analysis: LoopAnalysis
 ; CHECK-SCEV-INV-AFTER-DELETE-NEXT: Running analysis: DominatorTreeAnalysis
 ; CHECK-SCEV-INV-AFTER-DELETE-NEXT: Running analysis: AssumptionAnalysis
 ; CHECK-SCEV-INV-AFTER-DELETE-NEXT: Running analysis: TargetIRAnalysis
@@ -230,8 +218,9 @@ define void @dead_loop() {
 ; CHECK-SCEV-INV-AFTER-DELETE-NEXT: Running pass: InvalidateAnalysisPass<{{.*}}ScalarEvolutionAnalysis
 ; CHECK-SCEV-INV-AFTER-DELETE-NEXT: Invalidating analysis: ScalarEvolutionAnalysis
 ; CHECK-SCEV-INV-AFTER-DELETE-NEXT: Invalidating analysis: InnerAnalysisManagerProxy<{{.*}}Loop
-; CHECK-SCEV-INV-AFTER-DELETE-NEXT: Running pass: LoopSimplifyPass
-; CHECK-SCEV-INV-AFTER-DELETE-NEXT: Running pass: LCSSAPass
+; The loop has been deleted, so the second loop pass manager sees a loop-free
+; function and skips the canonicalization passes.
+; CHECK-SCEV-INV-AFTER-DELETE-NOT: Running pass:
 
 entry:
   br label %l0.header

--- a/llvm/test/Other/new-pm-defaults.ll
+++ b/llvm/test/Other/new-pm-defaults.ll
@@ -157,8 +157,8 @@
 ; CHECK-O23-NEXT: Running pass: ConstraintEliminationPass
 ; CHECK-O23-NEXT: Running analysis: LoopAnalysis
 ; CHECK-O23-NEXT: Running analysis: ScalarEvolutionAnalysis
-; CHECK-O-NEXT: Running pass: LoopSimplifyPass
 ; CHECK-O1-NEXT: Running analysis: LoopAnalysis
+; CHECK-O-NEXT: Running pass: LoopSimplifyPass
 ; CHECK-O-NEXT: Running pass: LCSSAPass
 ; CHECK-O1-NEXT: Running analysis: ScalarEvolutionAnalysis
 ; CHECK-O-NEXT: Running analysis: InnerAnalysisManagerProxy

--- a/llvm/test/Other/new-pm-thinlto-postlink-defaults.ll
+++ b/llvm/test/Other/new-pm-thinlto-postlink-defaults.ll
@@ -97,8 +97,8 @@
 ; CHECK-O23-NEXT: Running pass: ConstraintEliminationPass
 ; CHECK-O23-NEXT: Running analysis: LoopAnalysis
 ; CHECK-O23-NEXT: Running analysis: ScalarEvolutionAnalysis
-; CHECK-O-NEXT: Running pass: LoopSimplifyPass
 ; CHECK-O1-NEXT: Running analysis: LoopAnalysis
+; CHECK-O-NEXT: Running pass: LoopSimplifyPass
 ; CHECK-O-NEXT: Running pass: LCSSAPass
 ; CHECK-O1-NEXT: Running analysis: ScalarEvolutionAnalysis
 ; CHECK-O-NEXT: Running analysis: InnerAnalysisManagerProxy

--- a/llvm/test/Other/new-pm-thinlto-postlink-pgo-defaults.ll
+++ b/llvm/test/Other/new-pm-thinlto-postlink-pgo-defaults.ll
@@ -85,8 +85,8 @@
 ; CHECK-O23-NEXT: Running pass: ConstraintEliminationPass
 ; CHECK-O23-NEXT: Running analysis: LoopAnalysis on foo
 ; CHECK-O23-NEXT: Running analysis: ScalarEvolutionAnalysis
-; CHECK-O-NEXT: Running pass: LoopSimplifyPass
 ; CHECK-O1-NEXT: Running analysis: LoopAnalysis on foo
+; CHECK-O-NEXT: Running pass: LoopSimplifyPass
 ; CHECK-O-NEXT: Running pass: LCSSAPass
 ; CHECK-O1-NEXT: Running analysis: ScalarEvolutionAnalysis
 ; CHECK-O-NEXT: Running analysis: InnerAnalysisManagerProxy

--- a/llvm/test/Other/new-pm-thinlto-postlink-samplepgo-defaults.ll
+++ b/llvm/test/Other/new-pm-thinlto-postlink-samplepgo-defaults.ll
@@ -92,8 +92,8 @@
 ; CHECK-O23-NEXT: Running pass: ConstraintEliminationPass
 ; CHECK-O23-NEXT: Running analysis: LoopAnalysis on foo
 ; CHECK-O23-NEXT: Running analysis: ScalarEvolutionAnalysis
-; CHECK-O-NEXT: Running pass: LoopSimplifyPass
 ; CHECK-O1-NEXT: Running analysis: LoopAnalysis on foo
+; CHECK-O-NEXT: Running pass: LoopSimplifyPass
 ; CHECK-O-NEXT: Running pass: LCSSAPass
 ; CHECK-O1-NEXT: Running analysis: ScalarEvolutionAnalysis
 ; CHECK-O-NEXT: Running analysis: InnerAnalysisManagerProxy

--- a/llvm/test/Other/new-pm-thinlto-prelink-defaults.ll
+++ b/llvm/test/Other/new-pm-thinlto-prelink-defaults.ll
@@ -123,8 +123,8 @@
 ; CHECK-O23-NEXT: Running pass: ConstraintEliminationPass
 ; CHECK-O23-NEXT: Running analysis: LoopAnalysis
 ; CHECK-O23-NEXT: Running analysis: ScalarEvolutionAnalysis
-; CHECK-O-NEXT: Running pass: LoopSimplifyPass
 ; CHECK-O1-NEXT: Running analysis: LoopAnalysis
+; CHECK-O-NEXT: Running pass: LoopSimplifyPass
 ; CHECK-O-NEXT: Running pass: LCSSAPass
 ; CHECK-O1-NEXT: Running analysis: ScalarEvolutionAnalysis
 ; CHECK-O-NEXT: Running analysis: InnerAnalysisManagerProxy

--- a/llvm/test/Other/new-pm-thinlto-prelink-pgo-defaults.ll
+++ b/llvm/test/Other/new-pm-thinlto-prelink-pgo-defaults.ll
@@ -132,8 +132,8 @@
 ; CHECK-O23-NEXT: Running pass: ConstraintEliminationPass
 ; CHECK-O23-NEXT: Running analysis: LoopAnalysis on foo
 ; CHECK-O23-NEXT: Running analysis: ScalarEvolutionAnalysis
-; CHECK-O-NEXT: Running pass: LoopSimplifyPass
 ; CHECK-O1-NEXT: Running analysis: LoopAnalysis on foo
+; CHECK-O-NEXT: Running pass: LoopSimplifyPass
 ; CHECK-O-NEXT: Running pass: LCSSAPass
 ; CHECK-O1-NEXT: Running analysis: ScalarEvolutionAnalysis
 ; CHECK-O-NEXT: Running analysis: InnerAnalysisManagerProxy

--- a/llvm/test/Other/new-pm-thinlto-prelink-samplepgo-defaults.ll
+++ b/llvm/test/Other/new-pm-thinlto-prelink-samplepgo-defaults.ll
@@ -97,8 +97,8 @@
 ; CHECK-O23-NEXT: Running pass: ConstraintEliminationPass
 ; CHECK-O23-NEXT: Running analysis: LoopAnalysis on foo
 ; CHECK-O23-NEXT: Running analysis: ScalarEvolutionAnalysis
-; CHECK-O-NEXT: Running pass: LoopSimplifyPass
 ; CHECK-O1-NEXT: Running analysis: LoopAnalysis on foo
+; CHECK-O-NEXT: Running pass: LoopSimplifyPass
 ; CHECK-O-NEXT: Running pass: LCSSAPass
 ; CHECK-O1-NEXT: Running analysis: ScalarEvolutionAnalysis
 ; CHECK-O-NEXT: Running analysis: InnerAnalysisManagerProxy

--- a/llvm/test/Other/print-at-pass-number.ll
+++ b/llvm/test/Other/print-at-pass-number.ll
@@ -34,8 +34,21 @@ bb4:                                              ; preds = %bb1
   ret i32 %add3
 }
 
+; The loop pass adaptor only runs the loop canonicalization passes for functions
+; that contain loops, so @baz needs a loop of its own to get any passes run on
+; it.
 define i32 @baz(i32 %arg) {
-  ret i32 0;
+bb:
+  br label %bb1
+
+bb1:                                              ; preds = %bb1, %bb
+  %phi = phi i32 [ 0, %bb ], [ %add, %bb1 ]
+  %add = add i32 %phi, 1
+  %icmp = icmp slt i32 %phi, %arg
+  br i1 %icmp, label %bb1, label %bb4
+
+bb4:                                              ; preds = %bb1
+  ret i32 %add
 }
 
 ; NUMBER:  Running pass 1 LoopSimplifyPass on bar
@@ -44,8 +57,13 @@ define i32 @baz(i32 %arg) {
 ; NUMBER-NEXT: Running pass 4 LoopDeletionPass on loop %bb1 in function bar
 ; NUMBER-NEXT: Running pass 5 LoopSimplifyPass on baz
 ; NUMBER-NEXT: Running pass 6 LCSSAPass on baz
+; NUMBER-NEXT: Running pass 7 IndVarSimplifyPass on loop %bb1 in function baz
+; NUMBER-NEXT: Running pass 8 LoopDeletionPass on loop %bb1 in function baz
 ; NUMBER-NOT: Running pass
 
 ; NUMBER-FILTERED: Running pass 1 LoopSimplifyPass on baz
 ; NUMBER-FILTERED-NEXT: Running pass 2 LCSSAPass on baz
+; NUMBER-FILTERED-NEXT: Running pass 3 IndVarSimplifyPass on loop %bb1 in function baz
+; NUMBER-FILTERED-NEXT: Running pass 4 LoopDeletionPass on loop %bb1 in function baz
+; NUMBER-FILTERED-NOT: Running pass
 

--- a/llvm/test/Transforms/LoopRotate/pr35210.ll
+++ b/llvm/test/Transforms/LoopRotate/pr35210.ll
@@ -7,8 +7,8 @@
 
 ; CHECK: Running pass: ADCEPass on f
 ; CHECK-NEXT: Running analysis: PostDominatorTreeAnalysis on f
-; CHECK-NEXT: Running pass: LoopSimplifyPass on f
 ; CHECK-NEXT: Running analysis: LoopAnalysis on f
+; CHECK-NEXT: Running pass: LoopSimplifyPass on f
 ; CHECK-NEXT: Running analysis: DominatorTreeAnalysis on f
 ; CHECK-NEXT: Running analysis: AssumptionAnalysis on f
 ; CHECK-NEXT: Running analysis: TargetIRAnalysis on f
@@ -25,8 +25,8 @@
 
 ; MSSA: Running pass: ADCEPass on f
 ; MSSA-NEXT: Running analysis: PostDominatorTreeAnalysis on f
-; MSSA-NEXT: Running pass: LoopSimplifyPass on f
 ; MSSA-NEXT: Running analysis: LoopAnalysis on f
+; MSSA-NEXT: Running pass: LoopSimplifyPass on f
 ; MSSA-NEXT: Running analysis: DominatorTreeAnalysis on f
 ; MSSA-NEXT: Running analysis: AssumptionAnalysis on f
 ; MSSA-NEXT: Running analysis: TargetIRAnalysis on f


### PR DESCRIPTION
FunctionToLoopPassAdopter::run is a no-op for loop-free functions, but still requires retrieving all required analyses for the loop pass manager.

Avoiding this for loop-free functions can reduce compile-time, with the amount of saving depending on the type of workload:

CTMark reduces by -0.04% to -0.06% depending on exact config, Clang-stage2 -0.13%

https://llvm-compile-time-tracker.com/compare.php?from=2f9775ad49bf8eb0d4a54592d40652df3e4f38dd&to=a37331c186f90da56a4c945f96813c816bedbbc6&stat=instructions:u