### PR TITLE
[CodeGen] Remove dead declarations

### DIFF
--- a/llvm/include/llvm/CodeGen/CommandFlags.h
+++ b/llvm/include/llvm/CodeGen/CommandFlags.h
@@ -137,9 +137,6 @@ LLVM_ABI bool getEnableStaticDataPartitioning();
 
 LLVM_ABI bool getEnableDebugEntryValues();
 
-LLVM_ABI bool getValueTrackingVariableLocations();
-LLVM_ABI std::optional<bool> getExplicitValueTrackingVariableLocations();
-
 LLVM_ABI bool getForceDwarfFrameSection();
 
 LLVM_ABI bool getXRayFunctionIndex();
@@ -207,10 +204,6 @@ LLVM_ABI void setFunctionAttributes(Function &F, StringRef CPU,
 /// TuneCPU, Features, and command line flags.
 LLVM_ABI void setFunctionAttributes(Module &M, StringRef CPU,
                                     StringRef Features, StringRef TuneCPU = "");
-
-/// Should value-tracking variable locations / instruction referencing be
-/// enabled by default for this triple?
-LLVM_ABI bool getDefaultValueTrackingVariableLocations(const llvm::Triple &T);
 
 /// Creates a TargetMachine instance with the options defined on the command
 /// line. This can be used for tools that do not need further customization of


### PR DESCRIPTION
The corresponding function definitions were removed on Jan 12, 2022 in
commit 6a605b97a2006bd391f129a606483656b7c6fb28.
