### PR TITLE
[libc] Fix Atan2f128 and add tests for all versions

### DIFF
--- a/libc/src/__support/math/atan2f128.h
+++ b/libc/src/__support/math/atan2f128.h
@@ -97,7 +97,7 @@ LIBC_INLINE float128 atan2f128(float128 y, float128 x) {
   constexpr DFloat128 PI_OVER_4 = {Sign::POS, -128,
                                    0xc90fdaa2'2168c234'c4c6628b'80dc1cd1_u128};
   constexpr DFloat128 THREE_PI_OVER_4 = {
-      Sign::POS, -128, 0x96cbe3f9'990e91a7'9394c9e8'a0a5159d_u128};
+      Sign::POS, -126, 0x96cbe3f9'990e91a7'9394c9e8'a0a5159d_u128};
 
   // Adjustment for constant term:
   //   CONST_ADJ[x_sign][y_sign][recip]

--- a/libc/test/src/math/smoke/atan2_test.cpp
+++ b/libc/test/src/math/smoke/atan2_test.cpp
@@ -13,6 +13,24 @@
 using LlvmLibcAtan2Test = LIBC_NAMESPACE::testing::FPTest<double>;
 
 TEST_F(LlvmLibcAtan2Test, SpecialNumbers) {
+  constexpr double PI = 0x1.921fb54442d18p+1;
+  constexpr double PI_OVER_2 = 0x1.921fb54442d18p+0;
+  constexpr double PI_OVER_4 = 0x1.921fb54442d18p-1;
+  constexpr double THREE_PI_OVER_4 = 0x1.2d97c7f3321d2p+1;
+
+  EXPECT_FP_EQ(PI, LIBC_NAMESPACE::atan2(zero, neg_zero));
+  EXPECT_FP_EQ(-PI, LIBC_NAMESPACE::atan2(neg_zero, neg_zero));
+  EXPECT_FP_EQ(PI, LIBC_NAMESPACE::atan2(zero, neg_inf));
+  EXPECT_FP_EQ(-PI, LIBC_NAMESPACE::atan2(neg_zero, neg_inf));
+  EXPECT_FP_EQ(PI_OVER_2, LIBC_NAMESPACE::atan2(inf, zero));
+  EXPECT_FP_EQ(PI_OVER_2, LIBC_NAMESPACE::atan2(inf, neg_zero));
+  EXPECT_FP_EQ(-PI_OVER_2, LIBC_NAMESPACE::atan2(neg_inf, zero));
+  EXPECT_FP_EQ(-PI_OVER_2, LIBC_NAMESPACE::atan2(neg_inf, neg_zero));
+  EXPECT_FP_EQ(PI_OVER_4, LIBC_NAMESPACE::atan2(inf, inf));
+  EXPECT_FP_EQ(-PI_OVER_4, LIBC_NAMESPACE::atan2(neg_inf, inf));
+  EXPECT_FP_EQ(THREE_PI_OVER_4, LIBC_NAMESPACE::atan2(inf, neg_inf));
+  EXPECT_FP_EQ(-THREE_PI_OVER_4, LIBC_NAMESPACE::atan2(neg_inf, neg_inf));
+
   EXPECT_FP_EQ_WITH_EXCEPTION(aNaN, LIBC_NAMESPACE::atan2(sNaN, sNaN),
                               FE_INVALID);
   EXPECT_MATH_ERRNO(0);

--- a/libc/test/src/math/smoke/atan2f128_test.cpp
+++ b/libc/test/src/math/smoke/atan2f128_test.cpp
@@ -19,14 +19,15 @@ TEST_F(LlvmLibcAtan2f128Test, SpecialNumbers) {
   EXPECT_FP_EQ_ALL_ROUNDING(neg_zero,
                             LIBC_NAMESPACE::atan2f128(neg_zero, zero));
   EXPECT_FP_EQ_ALL_ROUNDING(zero, LIBC_NAMESPACE::atan2f128(1.0, inf));
-  EXPECT_FP_EQ_ALL_ROUNDING(0x1.2d97c7f3321d234f272993d1414ap+1q,
-                            LIBC_NAMESPACE::atan2f128(inf, neg_inf));
   EXPECT_FP_EQ_ALL_ROUNDING(neg_zero, LIBC_NAMESPACE::atan2f128(-1.0, inf));
 
   float128 x = 0x1.ffffffffffffffffffffffffffe7p1q;
   float128 y = 0x1.fffffffffffffffffffffffffff2p1q;
   float128 r = 0x1.921fb54442d18469898cc51701b3p-1q;
   EXPECT_FP_EQ(r, LIBC_NAMESPACE::atan2f128(x, y));
+
+  EXPECT_FP_EQ(0x1.2d97c7f3321d234f272993d1414ap+1q,
+               LIBC_NAMESPACE::atan2f128(inf, neg_inf));
 
   x = -0x1.f122e07fff556143p+3524q;
   y = 0x1.f122e07fff55615b75p+6316q;

--- a/libc/test/src/math/smoke/atan2f128_test.cpp
+++ b/libc/test/src/math/smoke/atan2f128_test.cpp
@@ -13,11 +13,28 @@
 using LlvmLibcAtan2f128Test = LIBC_NAMESPACE::testing::FPTest<float128>;
 
 TEST_F(LlvmLibcAtan2f128Test, SpecialNumbers) {
+  constexpr float128 PI = 0x1.921fb54442d18469898cc51701b8p+1q;
+  constexpr float128 PI_OVER_2 = 0x1.921fb54442d18469898cc51701b8p+0q;
+  constexpr float128 PI_OVER_4 = 0x1.921fb54442d18469898cc51701b8p-1q;
+  constexpr float128 THREE_PI_OVER_4 = 0x1.2d97c7f3321d234f272993d1414ap+1q;
+
+  EXPECT_FP_EQ_ALL_ROUNDING(zero, LIBC_NAMESPACE::atan2f128(zero, inf));
+  EXPECT_FP_EQ_ALL_ROUNDING(neg_zero, LIBC_NAMESPACE::atan2f128(neg_zero, inf));
+  EXPECT_FP_EQ(PI, LIBC_NAMESPACE::atan2f128(zero, neg_zero));
+  EXPECT_FP_EQ(-PI, LIBC_NAMESPACE::atan2f128(neg_zero, neg_zero));
+  EXPECT_FP_EQ(PI, LIBC_NAMESPACE::atan2f128(zero, neg_inf));
+  EXPECT_FP_EQ(-PI, LIBC_NAMESPACE::atan2f128(neg_zero, neg_inf));
+  EXPECT_FP_EQ(PI_OVER_2, LIBC_NAMESPACE::atan2f128(inf, zero));
+  EXPECT_FP_EQ(PI_OVER_2, LIBC_NAMESPACE::atan2f128(inf, neg_zero));
+  EXPECT_FP_EQ(-PI_OVER_2, LIBC_NAMESPACE::atan2f128(neg_inf, zero));
+  EXPECT_FP_EQ(-PI_OVER_2, LIBC_NAMESPACE::atan2f128(neg_inf, neg_zero));
+  EXPECT_FP_EQ(PI_OVER_4, LIBC_NAMESPACE::atan2f128(inf, inf));
+  EXPECT_FP_EQ(-PI_OVER_4, LIBC_NAMESPACE::atan2f128(neg_inf, inf));
+  EXPECT_FP_EQ(THREE_PI_OVER_4, LIBC_NAMESPACE::atan2f128(inf, neg_inf));
+  EXPECT_FP_EQ(-THREE_PI_OVER_4, LIBC_NAMESPACE::atan2f128(neg_inf, neg_inf));
+
   EXPECT_FP_EQ_ALL_ROUNDING(aNaN, LIBC_NAMESPACE::atan2f128(aNaN, zero));
   EXPECT_FP_EQ_ALL_ROUNDING(aNaN, LIBC_NAMESPACE::atan2f128(1.0, aNaN));
-  EXPECT_FP_EQ_ALL_ROUNDING(zero, LIBC_NAMESPACE::atan2f128(zero, zero));
-  EXPECT_FP_EQ_ALL_ROUNDING(neg_zero,
-                            LIBC_NAMESPACE::atan2f128(neg_zero, zero));
   EXPECT_FP_EQ_ALL_ROUNDING(zero, LIBC_NAMESPACE::atan2f128(1.0, inf));
   EXPECT_FP_EQ_ALL_ROUNDING(neg_zero, LIBC_NAMESPACE::atan2f128(-1.0, inf));
 
@@ -25,9 +42,6 @@ TEST_F(LlvmLibcAtan2f128Test, SpecialNumbers) {
   float128 y = 0x1.fffffffffffffffffffffffffff2p1q;
   float128 r = 0x1.921fb54442d18469898cc51701b3p-1q;
   EXPECT_FP_EQ(r, LIBC_NAMESPACE::atan2f128(x, y));
-
-  EXPECT_FP_EQ(0x1.2d97c7f3321d234f272993d1414ap+1q,
-               LIBC_NAMESPACE::atan2f128(inf, neg_inf));
 
   x = -0x1.f122e07fff556143p+3524q;
   y = 0x1.f122e07fff55615b75p+6316q;

--- a/libc/test/src/math/smoke/atan2f128_test.cpp
+++ b/libc/test/src/math/smoke/atan2f128_test.cpp
@@ -19,6 +19,8 @@ TEST_F(LlvmLibcAtan2f128Test, SpecialNumbers) {
   EXPECT_FP_EQ_ALL_ROUNDING(neg_zero,
                             LIBC_NAMESPACE::atan2f128(neg_zero, zero));
   EXPECT_FP_EQ_ALL_ROUNDING(zero, LIBC_NAMESPACE::atan2f128(1.0, inf));
+  EXPECT_FP_EQ_ALL_ROUNDING(0x1.2d97c7f3321d234f272993d1414ap+1q,
+                            LIBC_NAMESPACE::atan2f128(inf, neg_inf));
   EXPECT_FP_EQ_ALL_ROUNDING(neg_zero, LIBC_NAMESPACE::atan2f128(-1.0, inf));
 
   float128 x = 0x1.ffffffffffffffffffffffffffe7p1q;

--- a/libc/test/src/math/smoke/atan2f16_test.cpp
+++ b/libc/test/src/math/smoke/atan2f16_test.cpp
@@ -20,6 +20,29 @@ static constexpr float16 neg_one =
         .get_val();
 
 TEST_F(LlvmLibcAtan2f16Test, SpecialNumbers) {
+  constexpr float16 PI = static_cast<float16>(0x1.92p+1);
+  constexpr float16 PI_OVER_2 = static_cast<float16>(0x1.92p+0);
+  constexpr float16 PI_OVER_4 = static_cast<float16>(0x1.92p-1);
+  constexpr float16 THREE_PI_OVER_4 = static_cast<float16>(0x1.2d8p+1);
+
+  EXPECT_FP_EQ(PI, LIBC_NAMESPACE::atan2f16(zero, neg_zero));
+  EXPECT_FP_EQ(-PI, LIBC_NAMESPACE::atan2f16(neg_zero, neg_zero));
+  EXPECT_FP_EQ(PI, LIBC_NAMESPACE::atan2f16(zero, neg_inf));
+  EXPECT_FP_EQ(-PI, LIBC_NAMESPACE::atan2f16(neg_zero, neg_inf));
+  EXPECT_FP_EQ(PI_OVER_2, LIBC_NAMESPACE::atan2f16(inf, zero));
+  EXPECT_FP_EQ(PI_OVER_2, LIBC_NAMESPACE::atan2f16(inf, neg_zero));
+  EXPECT_FP_EQ(-PI_OVER_2, LIBC_NAMESPACE::atan2f16(neg_inf, zero));
+  EXPECT_FP_EQ(-PI_OVER_2, LIBC_NAMESPACE::atan2f16(neg_inf, neg_zero));
+  EXPECT_FP_EQ(PI_OVER_4, LIBC_NAMESPACE::atan2f16(inf, inf));
+  EXPECT_FP_EQ(-PI_OVER_4, LIBC_NAMESPACE::atan2f16(neg_inf, inf));
+  EXPECT_FP_EQ(THREE_PI_OVER_4, LIBC_NAMESPACE::atan2f16(inf, neg_inf));
+  EXPECT_FP_EQ(-THREE_PI_OVER_4, LIBC_NAMESPACE::atan2f16(neg_inf, neg_inf));
+
+  EXPECT_FP_EQ_ALL_ROUNDING(aNaN, LIBC_NAMESPACE::atan2f16(aNaN, zero));
+  EXPECT_FP_EQ_ALL_ROUNDING(aNaN, LIBC_NAMESPACE::atan2f16(1.0, aNaN));
+  EXPECT_FP_EQ_ALL_ROUNDING(zero, LIBC_NAMESPACE::atan2f16(1.0, inf));
+  EXPECT_FP_EQ_ALL_ROUNDING(neg_zero, LIBC_NAMESPACE::atan2f16(-1.0, inf));
+
   EXPECT_FP_EQ_WITH_EXCEPTION(aNaN, LIBC_NAMESPACE::atan2f16(sNaN, sNaN),
                               FE_INVALID);
   EXPECT_MATH_ERRNO(0);

--- a/libc/test/src/math/smoke/atan2f_test.cpp
+++ b/libc/test/src/math/smoke/atan2f_test.cpp
@@ -15,6 +15,24 @@
 using LlvmLibcAtan2fTest = LIBC_NAMESPACE::testing::FPTest<float>;
 
 TEST_F(LlvmLibcAtan2fTest, SpecialNumbers) {
+  constexpr float PI = 0x1.921fb6p+1f;
+  constexpr float PI_OVER_2 = 0x1.921fb6p+0f;
+  constexpr float PI_OVER_4 = 0x1.921fb6p-1f;
+  constexpr float THREE_PI_OVER_4 = 0x1.2d97c8p+1f;
+
+  EXPECT_FP_EQ(PI, LIBC_NAMESPACE::atan2f(zero, neg_zero));
+  EXPECT_FP_EQ(-PI, LIBC_NAMESPACE::atan2f(neg_zero, neg_zero));
+  EXPECT_FP_EQ(PI, LIBC_NAMESPACE::atan2f(zero, neg_inf));
+  EXPECT_FP_EQ(-PI, LIBC_NAMESPACE::atan2f(neg_zero, neg_inf));
+  EXPECT_FP_EQ(PI_OVER_2, LIBC_NAMESPACE::atan2f(inf, zero));
+  EXPECT_FP_EQ(PI_OVER_2, LIBC_NAMESPACE::atan2f(inf, neg_zero));
+  EXPECT_FP_EQ(-PI_OVER_2, LIBC_NAMESPACE::atan2f(neg_inf, zero));
+  EXPECT_FP_EQ(-PI_OVER_2, LIBC_NAMESPACE::atan2f(neg_inf, neg_zero));
+  EXPECT_FP_EQ(PI_OVER_4, LIBC_NAMESPACE::atan2f(inf, inf));
+  EXPECT_FP_EQ(-PI_OVER_4, LIBC_NAMESPACE::atan2f(neg_inf, inf));
+  EXPECT_FP_EQ(THREE_PI_OVER_4, LIBC_NAMESPACE::atan2f(inf, neg_inf));
+  EXPECT_FP_EQ(-THREE_PI_OVER_4, LIBC_NAMESPACE::atan2f(neg_inf, neg_inf));
+
   EXPECT_FP_EQ_WITH_EXCEPTION(aNaN, LIBC_NAMESPACE::atan2f(sNaN, sNaN),
                               FE_INVALID);
   EXPECT_MATH_ERRNO(0);


### PR DESCRIPTION
It fixes the THREE_PI_OVER_4 value in atan2f128 and adds a small smoke test against the failure.
The result or comparison value is directly taken from the failure while comparing with core math :
```CPP
FAIL x=inf y=-inf ref=0x1.2d97c7f3321d234f272993d1414ap+1 z=0x1.2d97c7f3321d234f272993d1414ap-1
```

Additionally it adds some more smoke tests for all atan2 versions.
