### PR TITLE
[lldb] Fix incorrect formatv format strings in logging

### DIFF
--- a/lldb/source/Breakpoint/BreakpointResolver.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolver.cpp
@@ -424,7 +424,7 @@ BreakpointLocationSP BreakpointResolver::AddLocation(Address loc_addr,
     if (!expected_instructions) {
       LLDB_LOG_ERROR(GetLog(LLDBLog::Breakpoints),
                      expected_instructions.takeError(),
-                     "error: Unable to read instructions at address 0x{0:x}",
+                     "error: Unable to read instructions at address {1:x}: {0}",
                      loc_addr.GetLoadAddress(&target));
       return BreakpointLocationSP();
     }
@@ -433,7 +433,7 @@ BreakpointLocationSP BreakpointResolver::AddLocation(Address loc_addr,
     if (!instructions ||
         instructions->GetInstructionList().GetSize() != m_offset) {
       LLDB_LOG(GetLog(LLDBLog::Breakpoints),
-               "error: Unable to read {0} instructions at address 0x{1:x}",
+               "error: Unable to read {0} instructions at address {1:x}",
                m_offset, loc_addr.GetLoadAddress(&target));
       return BreakpointLocationSP();
     }

--- a/lldb/source/Core/Telemetry.cpp
+++ b/lldb/source/Core/Telemetry.cpp
@@ -175,7 +175,7 @@ void TelemetryManager::DispatchClientTelemetry(
 
   if (llvm::Error er = dispatch(&client_info))
     LLDB_LOG_ERROR(GetLog(LLDBLog::Object), std::move(er),
-                   "Failed to dispatch client telemetry");
+                   "Failed to dispatch client telemetry: {0}");
 }
 
 class NoOpTelemetryManager : public TelemetryManager {

--- a/lldb/source/DataFormatters/TypeSynthetic.cpp
+++ b/lldb/source/DataFormatters/TypeSynthetic.cpp
@@ -356,7 +356,7 @@ BytecodeSyntheticChildren::FrontEnd::CalculateNumChildren() {
 
   if (data.size() == 0) {
     char message[] = "@get_num_children returned empty data stack";
-    LLDB_LOG(GetLog(LLDBLog::DataFormatters), message);
+    LLDB_LOG(GetLog(LLDBLog::DataFormatters), "{0}", message);
     return llvm::createStringError(message);
   }
 
@@ -419,7 +419,7 @@ BytecodeSyntheticChildren::FrontEnd::GetIndexOfChildWithName(ConstString name) {
 
   if (data.size() == 0) {
     char message[] = "@get_child_index returned empty data stack";
-    LLDB_LOG(GetLog(LLDBLog::DataFormatters), message);
+    LLDB_LOG(GetLog(LLDBLog::DataFormatters), "{0}", message);
     return llvm::createStringError(message);
   }
 

--- a/lldb/source/Expression/Materializer.cpp
+++ b/lldb/source/Expression/Materializer.cpp
@@ -1220,7 +1220,7 @@ public:
 
     const lldb::addr_t load_addr = process_address + m_offset;
 
-    LLDB_LOG(log, "EntitySymbol::Materialize [address = {0}, m_symbol = {1}]",
+    LLDB_LOG(log, "EntitySymbol::Materialize [address = {0:x}, m_symbol = {1}]",
              (uint64_t)load_addr, m_symbol.GetName());
 
     const Address sym_address = m_symbol.GetAddress();

--- a/lldb/source/Plugins/ABI/LoongArch/ABISysV_loongarch.cpp
+++ b/lldb/source/Plugins/ABI/LoongArch/ABISysV_loongarch.cpp
@@ -167,7 +167,7 @@ static bool UpdateRegister(RegisterContext *reg_ctx,
 
   const RegisterInfo *reg_info = reg_ctx->GetRegisterInfo(reg_kind, reg_num);
 
-  LLDB_LOG(log, "Writing {0}: 0x{1:x}", reg_info->name,
+  LLDB_LOG(log, "Writing {0}: {1:x}", reg_info->name,
            static_cast<uint64_t>(value));
   if (!reg_ctx->WriteRegisterFromUnsigned(reg_info, value)) {
     LLDB_LOG(log, "Writing {0}: failed", reg_info->name);

--- a/lldb/source/Plugins/ABI/RISCV/ABISysV_riscv.cpp
+++ b/lldb/source/Plugins/ABI/RISCV/ABISysV_riscv.cpp
@@ -178,7 +178,7 @@ static bool UpdateRegister(RegisterContext *reg_ctx,
 
   const RegisterInfo *reg_info = reg_ctx->GetRegisterInfo(reg_kind, reg_num);
 
-  LLDB_LOG(log, "Writing {0}: 0x{1:x}", reg_info->name,
+  LLDB_LOG(log, "Writing {0}: {1:x}", reg_info->name,
            static_cast<uint64_t>(value));
   if (!reg_ctx->WriteRegisterFromUnsigned(reg_info, value)) {
     LLDB_LOG(log, "Writing {0}: failed", reg_info->name);
@@ -224,11 +224,11 @@ bool ABISysV_riscv::PrepareTrivialCall(Thread &thread, addr_t sp,
   for (auto [idx, arg] : enumerate(args)) {
     const RegisterInfo *reg_info = reg_ctx_sp->GetRegisterInfo(
         eRegisterKindGeneric, LLDB_REGNUM_GENERIC_ARG1 + idx);
-    LLDB_LOG(log, "About to write arg{0} (0x{1:x}) into {2}", idx, arg,
+    LLDB_LOG(log, "About to write arg{0} ({1:x}) into {2}", idx, arg,
              reg_info->name);
 
     if (!reg_ctx_sp->WriteRegisterFromUnsigned(reg_info, arg)) {
-      LLDB_LOG(log, "Failed to write arg{0} (0x{1:x}) into {2}", idx, arg,
+      LLDB_LOG(log, "Failed to write arg{0} ({1:x}) into {2}", idx, arg,
                reg_info->name);
       return false;
     }

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangASTSource.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangASTSource.cpp
@@ -1265,7 +1265,7 @@ void ClangASTSource::FindObjCPropertyAndIvarDecls(NameSearchContext &context) {
       break;
 
     LLDB_LOG(log,
-             "CAS::FOPD[{0:x}] trying module "
+             "CAS::FOPD trying module "
              "(ObjCInterfaceDecl*){0:x}/(ASTContext*){1:x}...",
              interface_decl_from_modules.decl,
              &interface_decl_from_modules->getASTContext());
@@ -1309,7 +1309,7 @@ void ClangASTSource::FindObjCPropertyAndIvarDecls(NameSearchContext &context) {
       break;
 
     LLDB_LOG(log,
-             "CAS::FOPD[{0:x}] trying runtime "
+             "CAS::FOPD trying runtime "
              "(ObjCInterfaceDecl*){0:x}/(ASTContext*){1:x}...",
              interface_decl_from_runtime.decl,
              &interface_decl_from_runtime->getASTContext());
@@ -1426,7 +1426,7 @@ void ClangASTSource::CompleteNamespaceMap(
       namespace_map->push_back(std::pair<lldb::ModuleSP, CompilerDeclContext>(
           image, found_namespace_decl));
 
-      LLDB_LOG(log, "  CMN[{0}] Found namespace {0} in module {1}", name,
+      LLDB_LOG(log, "  CMN Found namespace {0} in module {1}", name,
                image->GetFileSpec().GetFilename());
     }
   }

--- a/lldb/source/Plugins/ExpressionParser/Clang/IRForTarget.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/IRForTarget.cpp
@@ -432,7 +432,7 @@ bool IRForTarget::RewriteObjCConstString(llvm::GlobalVariable *ns_str,
       return false;
     }
 
-    LLDB_LOG(log, "Found CFStringCreateWithBytes at {0}",
+    LLDB_LOG(log, "Found CFStringCreateWithBytes at {0:x}",
              CFStringCreateWithBytes_addr);
 
     // Build the function type:
@@ -807,7 +807,7 @@ bool IRForTarget::RewriteObjCSelector(Instruction *selector_load) {
     if (sel_registerName_addr == LLDB_INVALID_ADDRESS || missing_weak)
       return false;
 
-    LLDB_LOG(log, "Found sel_registerName at {0}", sel_registerName_addr);
+    LLDB_LOG(log, "Found sel_registerName at {0:x}", sel_registerName_addr);
 
     // Build the function type: struct objc_selector
     // *sel_registerName(uint8_t*)
@@ -1094,7 +1094,7 @@ bool IRForTarget::HandleSymbol(Value *symbol) {
     return false;
   }
 
-  LLDB_LOG(log, "Found \"{0}\" at {1}", name, symbol_addr);
+  LLDB_LOG(log, "Found \"{0}\" at {1:x}", name, symbol_addr);
 
   Type *symbol_type = symbol->getType();
 
@@ -1151,7 +1151,7 @@ bool IRForTarget::HandleObjCClass(Value *classlist_reference) {
   lldb::addr_t class_ptr =
       m_decl_map->GetSymbolAddress(name_cstr, lldb::eSymbolTypeObjCClass);
 
-  LLDB_LOG(log, "Found reference to Objective-C class {0} ({1})", name,
+  LLDB_LOG(log, "Found reference to Objective-C class {0} ({1:x})", name,
            (unsigned long long)class_ptr);
 
   if (class_ptr == LLDB_INVALID_ADDRESS)

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.cpp
@@ -780,7 +780,7 @@ void ClassDescriptorV2::iVarsStorage::fill(AppleObjCRuntimeV2 &runtime,
         m_ivars.push_back(
             {ConstString(name), ivar_type, size, offset_scalar.SInt()});
       } else
-        LLDB_LOG_VERBOSE(log, "offset_ptr = {0:x} --> read fail, read = %{1}",
+        LLDB_LOG_VERBOSE(log, "offset_ptr = {0:x} --> read fail, read = {1}",
                          offset_ptr, read);
     }
     return stop_loop;

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCDeclVendor.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCDeclVendor.cpp
@@ -591,7 +591,7 @@ uint32_t AppleObjCDeclVendor::FindDecls(ConstString name, bool append,
   if (log) {
     clang::QualType new_iface_type = ast_ctx.getObjCInterfaceType(iface_decl);
 
-    LLDB_LOG(log, "AOCTV::FT Created {0} (isa 0x{1:x})",
+    LLDB_LOG(log, "AOCTV::FT Created {0} (isa {1:x})",
              new_iface_type.getAsString(), (uint64_t)isa);
   }
 

--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
@@ -206,8 +206,9 @@ void ObjectFileXCOFF::ParseSymtab(Symtab &lldb_symtab) {
 
     llvm::Expected<llvm::StringRef> name_or_err = xcoff_sym_ref.getName();
     if (!name_or_err) {
-      LLDB_LOG_ERROR(log, name_or_err.takeError(),
-                     "Unable to extract name from the xcoff symbol ref object");
+      LLDB_LOG_ERROR(
+          log, name_or_err.takeError(),
+          "Unable to extract name from the xcoff symbol ref object: {0}");
       continue;
     }
 
@@ -230,7 +231,7 @@ void ObjectFileXCOFF::ParseSymtab(Symtab &lldb_symtab) {
       auto aux_csect_or_err = xcoff_sym_ref.getXCOFFCsectAuxRef();
       if (!aux_csect_or_err) {
         LLDB_LOG_ERROR(log, aux_csect_or_err.takeError(),
-                       "Unable to access xcoff csect aux ref object");
+                       "Unable to access xcoff csect aux ref object: {0}");
         continue;
       }
 
@@ -276,7 +277,7 @@ void ObjectFileXCOFF::ParseSymtab(Symtab &lldb_symtab) {
         symbol_ref.getType();
     if (!sym_type_or_err) {
       LLDB_LOG_ERROR(log, sym_type_or_err.takeError(),
-                     "Unable to access xcoff symbol type");
+                     "Unable to access xcoff symbol type: {0}");
       continue;
     }
 

--- a/lldb/source/Plugins/Process/AIX/NativeProcessAIX.cpp
+++ b/lldb/source/Plugins/Process/AIX/NativeProcessAIX.cpp
@@ -81,7 +81,7 @@ NativeProcessAIX::Manager::Launch(ProcessLaunchInfo &launch_info,
   assert(wpid == pid);
   UNUSED_IF_ASSERT_DISABLED(wpid);
   if (!WIFSTOPPED(wstatus)) {
-    LLDB_LOG(log, "Could not sync with inferior process: wstatus={1}",
+    LLDB_LOG(log, "Could not sync with inferior process: wstatus={0}",
              WaitStatus::Decode(wstatus));
     return llvm::createStringError("could not sync with inferior process");
   }

--- a/lldb/source/Plugins/Process/FreeBSD/NativeProcessFreeBSD.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD/NativeProcessFreeBSD.cpp
@@ -90,7 +90,7 @@ NativeProcessFreeBSD::Manager::Launch(ProcessLaunchInfo &launch_info,
   assert(wpid == pid);
   UNUSED_IF_ASSERT_DISABLED(wpid);
   if (!WIFSTOPPED(wstatus)) {
-    LLDB_LOG(log, "Could not sync with inferior process: wstatus={1}",
+    LLDB_LOG(log, "Could not sync with inferior process: wstatus={0}",
              WaitStatus::Decode(wstatus));
     return llvm::createStringError("could not sync with inferior process");
   }

--- a/lldb/source/Plugins/Process/Linux/IntelPTMultiCoreTrace.cpp
+++ b/lldb/source/Plugins/Process/Linux/IntelPTMultiCoreTrace.cpp
@@ -91,7 +91,8 @@ void IntelPTMultiCoreTrace::ProcessDidStop() {
   ForEachCore([](cpu_id_t cpu_id, IntelPTSingleBufferTrace &core_trace) {
     if (Error err = core_trace.Pause()) {
       LLDB_LOG_ERROR(GetLog(POSIXLog::Trace), std::move(err),
-                     "Unable to pause the core trace for core {0}", cpu_id);
+                     "Unable to pause the core trace for core {1}: {0}",
+                     cpu_id);
     }
   });
 }
@@ -100,7 +101,8 @@ void IntelPTMultiCoreTrace::ProcessWillResume() {
   ForEachCore([](cpu_id_t cpu_id, IntelPTSingleBufferTrace &core_trace) {
     if (Error err = core_trace.Resume()) {
       LLDB_LOG_ERROR(GetLog(POSIXLog::Trace), std::move(err),
-                     "Unable to resume the core trace for core {0}", cpu_id);
+                     "Unable to resume the core trace for core {1}: {0}",
+                     cpu_id);
     }
   });
 }

--- a/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
@@ -285,7 +285,7 @@ NativeProcessLinux::Manager::Launch(ProcessLaunchInfo &launch_info,
   assert(wpid == pid);
   UNUSED_IF_ASSERT_DISABLED(wpid);
   if (!WIFSTOPPED(wstatus)) {
-    LLDB_LOG(log, "Could not sync with inferior process: wstatus={1}",
+    LLDB_LOG(log, "Could not sync with inferior process: wstatus={0}",
              WaitStatus::Decode(wstatus));
     return llvm::createStringError("could not sync with inferior process");
   }
@@ -1093,7 +1093,7 @@ Status NativeProcessLinux::Signal(int signo) {
   Status error;
 
   Log *log = GetLog(POSIXLog::Process);
-  LLDB_LOG(log, "sending signal {0} ({1}) to pid {1}", signo,
+  LLDB_LOG(log, "sending signal {0} ({1}) to pid {2}", signo,
            Host::GetSignalAsCString(signo), GetID());
 
   if (kill(GetID(), signo))

--- a/lldb/source/Plugins/Process/NetBSD/NativeProcessNetBSD.cpp
+++ b/lldb/source/Plugins/Process/NetBSD/NativeProcessNetBSD.cpp
@@ -76,7 +76,7 @@ NativeProcessNetBSD::Manager::Launch(ProcessLaunchInfo &launch_info,
   assert(wpid == pid);
   (void)wpid;
   if (!WIFSTOPPED(wstatus)) {
-    LLDB_LOG(log, "Could not sync with inferior process: wstatus={1}",
+    LLDB_LOG(log, "Could not sync with inferior process: wstatus={0}",
              WaitStatus::Decode(wstatus));
     return llvm::createStringError("could not sync with inferior process");
   }

--- a/lldb/source/Plugins/Process/Windows/Common/ProcessDebugger.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessDebugger.cpp
@@ -437,7 +437,7 @@ Status ProcessDebugger::DeallocateMemory(lldb::addr_t vm_addr) {
 
   Log *log = GetLog(WindowsLog::Memory);
   llvm::sys::ScopedLock lock(m_mutex);
-  LLDB_LOG(log, "attempting to deallocate bytes at address {0}", vm_addr);
+  LLDB_LOG(log, "attempting to deallocate bytes at address {0:x}", vm_addr);
 
   if (!m_session_data) {
     result = Status::FromErrorString(
@@ -541,7 +541,7 @@ Status ProcessDebugger::GetMemoryRegionInfo(lldb::addr_t vm_addr,
   }
 
   LLDB_LOG_VERBOSE(log,
-                   "Memory region info for address {0}: readable={1}, "
+                   "Memory region info for address {0:x}: readable={1}, "
                    "executable={2}, writable={3}",
                    vm_addr, info.GetReadable(), info.GetExecutable(),
                    info.GetWritable());

--- a/lldb/source/Plugins/Process/gdb-remote/ThreadGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ThreadGDBRemote.cpp
@@ -40,7 +40,7 @@ ThreadGDBRemote::ThreadGDBRemote(Process &process, lldb::tid_t tid)
       m_queue_serial_number(LLDB_INVALID_QUEUE_ID),
       m_associated_with_libdispatch_queue(eLazyBoolCalculate) {
   Log *log = GetLog(GDBRLog::Thread);
-  LLDB_LOG(log, "this = {0}, pid = {1}, tid = {2}", this, process.GetID(),
+  LLDB_LOG(log, "this = {0}, pid = {1}, tid = {2:x}", this, process.GetID(),
            GetID());
   // At this point we can clone reg_info for architectures supporting
   // run-time update to register sizes and offsets..
@@ -55,7 +55,7 @@ ThreadGDBRemote::ThreadGDBRemote(Process &process, lldb::tid_t tid)
 ThreadGDBRemote::~ThreadGDBRemote() {
   ProcessSP process_sp(GetProcess());
   Log *log = GetLog(GDBRLog::Thread);
-  LLDB_LOG(log, "this = {0}, pid = {1}, tid = {2}", this,
+  LLDB_LOG(log, "this = {0}, pid = {1}, tid = {2:x}", this,
            process_sp ? process_sp->GetID() : LLDB_INVALID_PROCESS_ID, GetID());
   DestroyThread();
 }

--- a/lldb/source/Plugins/SymbolFile/DWARF/DebugNamesDWARFIndex.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DebugNamesDWARFIndex.cpp
@@ -311,7 +311,7 @@ getParentChain(Entry entry,
       // Bad data.
       LLDB_LOG_ERROR(
           GetLog(DWARFLog::Lookups), parent.takeError(),
-          "Failed to extract parent entry from a non-empty IDX_parent");
+          "Failed to extract parent entry from a non-empty IDX_parent: {0}");
       return std::nullopt;
     }
 

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -695,7 +695,7 @@ void TypeSystemClang::CreateASTContext() {
             m_target_triple)
             .str();
 
-    LLDB_LOG(GetLog(LLDBLog::Expressions), err.c_str());
+    LLDB_LOG(GetLog(LLDBLog::Expressions), "{0}", err);
 
     static std::once_flag s_uninitialized_target_warning;
     Debugger::ReportWarning(std::move(err), /*debugger_id=*/std::nullopt,

--- a/lldb/source/Target/ScriptedThreadPlan.cpp
+++ b/lldb/source/Target/ScriptedThreadPlan.cpp
@@ -109,7 +109,7 @@ bool ScriptedThreadPlan::ShouldStop(Event *event_ptr) {
     auto should_stop_or_err = m_interface->ShouldStop(event_ptr);
     if (!should_stop_or_err) {
       LLDB_LOG_ERROR(GetLog(LLDBLog::Thread), should_stop_or_err.takeError(),
-                     "Can't call ScriptedThreadPlan::ShouldStop.");
+                     "Can't call ScriptedThreadPlan::ShouldStop: {0}");
       SetPlanComplete(false);
     } else
       should_stop = *should_stop_or_err;
@@ -126,7 +126,7 @@ bool ScriptedThreadPlan::IsPlanStale() {
     auto is_stale_or_err = m_interface->IsStale();
     if (!is_stale_or_err) {
       LLDB_LOG_ERROR(GetLog(LLDBLog::Thread), is_stale_or_err.takeError(),
-                     "Can't call ScriptedThreadPlan::IsStale.");
+                     "Can't call ScriptedThreadPlan::IsStale: {0}");
       SetPlanComplete(false);
     } else
       is_stale = *is_stale_or_err;
@@ -144,7 +144,7 @@ bool ScriptedThreadPlan::DoPlanExplainsStop(Event *event_ptr) {
     if (!explains_stop_or_error) {
       LLDB_LOG_ERROR(GetLog(LLDBLog::Thread),
                      explains_stop_or_error.takeError(),
-                     "Can't call ScriptedThreadPlan::ExplainsStop.");
+                     "Can't call ScriptedThreadPlan::ExplainsStop: {0}");
       SetPlanComplete(false);
     } else
       explains_stop = *explains_stop_or_error;

--- a/lldb/source/Target/SectionLoadList.cpp
+++ b/lldb/source/Target/SectionLoadList.cpp
@@ -184,7 +184,7 @@ bool SectionLoadList::SetSectionUnloaded(const lldb::SectionSP &section_sp,
     }
     LLDB_LOG(log,
              "SectionLoadList::{0} (section = {1:x} ({2}.{3}), load_addr = "
-             "0x{4,16:x})",
+             "{4:x16})",
              __FUNCTION__, static_cast<void *>(section_sp.get()),
              module_name.c_str(), section_sp->GetName(), load_addr);
   }

--- a/lldb/source/Target/StackFrameList.cpp
+++ b/lldb/source/Target/StackFrameList.cpp
@@ -105,7 +105,7 @@ bool SyntheticStackFrameList::FetchFramesUpTo(
       if (!frame_or_err) {
         // Provider returned error - we've reached the end.
         LLDB_LOG_ERROR(GetLog(LLDBLog::Thread), frame_or_err.takeError(),
-                       "Frame provider reached end at index {0}: {1}", idx);
+                       "Frame provider reached end at index {1}: {0}", idx);
         SetAllFramesFetched();
         break;
       }

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2988,7 +2988,7 @@ ExpressionResults Target::EvaluateExpression(
             GetScratchTypeSystemForLanguage(eLanguageTypeC);
     if (auto err = type_system_or_err.takeError()) {
       LLDB_LOG_ERROR(GetLog(LLDBLog::Target), std::move(err),
-                     "Unable to get scratch type system");
+                     "Unable to get scratch type system: {0}");
     } else {
       auto ts = *type_system_or_err;
       if (!ts)

--- a/lldb/source/Target/Thread.cpp
+++ b/lldb/source/Target/Thread.cpp
@@ -1469,7 +1469,7 @@ void Thread::PushProviderFrameList(StackFrameListSP frames) {
   HostThread current(Host::GetCurrentThread());
   auto &stack = m_active_frame_providers_by_thread[current];
   LLDB_LOG(GetLog(LLDBLog::Thread),
-           "Thread::PushProviderFrameList: tid = 0x{0:x}, depth = {1} -> {2}",
+           "Thread::PushProviderFrameList: tid = {0:x}, depth = {1} -> {2}",
            GetID(), stack.size(), stack.size() + 1);
   stack.push_back(std::move(frames));
 }
@@ -1481,7 +1481,7 @@ void Thread::PopProviderFrameList() {
   size_t pre_pop_depth =
       (it != m_active_frame_providers_by_thread.end()) ? it->second.size() : 0;
   LLDB_LOG(GetLog(LLDBLog::Thread),
-           "Thread::PopProviderFrameList: tid = 0x{0:x}, depth = {1} -> {2}",
+           "Thread::PopProviderFrameList: tid = {0:x}, depth = {1} -> {2}",
            GetID(), pre_pop_depth, pre_pop_depth ? pre_pop_depth - 1 : 0);
   assert(it != m_active_frame_providers_by_thread.end() && !it->second.empty());
   if (it == m_active_frame_providers_by_thread.end() || it->second.empty())
@@ -1621,7 +1621,7 @@ StackFrameListSP Thread::GetStackFrameList() {
           *this, input_frames, m_prev_frames_sp, true, last_provider, last_id);
     } else {
       LLDB_LOG(GetLog(LLDBLog::Thread),
-               "Missing frame provider (id = {0}) in Thread #{1:x}}", last_id,
+               "Missing frame provider (id = {0}) in Thread #{1:x}", last_id,
                GetID());
     }
   }


### PR DESCRIPTION
Common mistakes include:

- LLDB_LOG_ERROR passes the error as argument zero.
- Wrong or missing indices.
- A literal 0x in front of a hex field.
- A stray % or } next to a replacement field.
- Bracketed indices left behind after refactors.
- Hex styles dropped in earlier LLDB_LOGF conversions.

Assisted-by: Claude