### PR TITLE
workflows/release-binaries: Fixup Windows version string for release candidates

### DIFF
--- a/.github/workflows/release-binaries-all.yml
+++ b/.github/workflows/release-binaries-all.yml
@@ -108,11 +108,7 @@ jobs:
         # We use ubuntu-22.04 rather than the latest version to make the built
         # binaries more portable (eg functional aginast older glibc).
         runs-on:
-          - ubuntu-22.04
-          - ubuntu-22.04-arm
-          - macos-14
           - windows-2022
-          - windows-11-arm
 
     uses: ./.github/workflows/release-binaries.yml
     with:

--- a/.github/workflows/release-binaries-all.yml
+++ b/.github/workflows/release-binaries-all.yml
@@ -108,7 +108,11 @@ jobs:
         # We use ubuntu-22.04 rather than the latest version to make the built
         # binaries more portable (eg functional aginast older glibc).
         runs-on:
+          - ubuntu-22.04
+          - ubuntu-22.04-arm
+          - macos-14
           - windows-2022
+          - windows-11-arm
 
     uses: ./.github/workflows/release-binaries.yml
     with:

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -120,6 +120,7 @@ jobs:
           # so we need to fixup the version number for release candidates.
           release_version="$LLVM_VERSION_MAJOR.0.0.$(cut -d c -f2 <<< $release_version)"
         fi
+        echo RELEASE VERSION: $release_version
 
         if [ -n "${{ inputs.upload }}" ]; then
           upload="${{ inputs.upload }}"

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -115,6 +115,8 @@ jobs:
           ref="$GITHUB_SHA"
         fi
 
+        echo RELEASE VERSION: $release_version
+        grep 'rc' <<< $release_version
         if [ "$RUNNER_OS" = "Windows" ] && grep 'rc' <<< $release_version; then
           # The Wix installer generator does not support strings in the version number,
           # so we need to fixup the version number for release candidates.

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -108,6 +108,7 @@ jobs:
         else
           if [ "$RUNNER_OS" = "Windows" ]; then
             release_version="$LLVM_VERSION_FROM_SOURCE"
+            release_version-"23.0.0.2"
           else
             release_version="${{ (github.event_name == 'pull_request' && format('PR{0}', github.event.pull_request.number)) || 'CI'}}-$GITHUB_SHA"
           fi

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -108,7 +108,7 @@ jobs:
         else
           if [ "$RUNNER_OS" = "Windows" ]; then
             release_version="$LLVM_VERSION_FROM_SOURCE"
-            release_version-"23.0.0.2"
+            release_version="23.0.0.2"
           else
             release_version="${{ (github.event_name == 'pull_request' && format('PR{0}', github.event.pull_request.number)) || 'CI'}}-$GITHUB_SHA"
           fi

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -115,10 +115,10 @@ jobs:
           ref="$GITHUB_SHA"
         fi
 
-        if [ "$RUNNER_OS" = "Windows" ] && grep 'rc' <<< $release_version; then
+        if [ "$RUNNER_OS" = "Windows" ] && grep -q 'rc' <<< "$release_version"; then
           # The Wix installer generator does not support strings in the version number,
           # so we need to fixup the version number for release candidates.
-          # For Example: 23.1.0-rc2 will be come 23.0.0.2
+          # For Example: 23.1.0-rc2 will become 23.0.0.2
           release_version="$LLVM_VERSION_MAJOR.0.0.$(cut -d c -f2 <<< $release_version)"
         fi
 

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -90,6 +90,7 @@ jobs:
       id: vars
       env:
         LLVM_VERSION_FROM_SOURCE: ${{ steps.version-from-source.outputs.full-no-suffix }}
+        LLVM_VERSION_MAJOR: ${{ steps.version-from-source.outputs.major }}
         INPUTS_RUNS_ON: ${{ inputs.runs-on }}
       shell: bash
       # In order for the test-release.sh script to run correctly, the LLVM
@@ -108,12 +109,18 @@ jobs:
         else
           if [ "$RUNNER_OS" = "Windows" ]; then
             release_version="$LLVM_VERSION_FROM_SOURCE"
-            release_version="23.0.0.2"
           else
             release_version="${{ (github.event_name == 'pull_request' && format('PR{0}', github.event.pull_request.number)) || 'CI'}}-$GITHUB_SHA"
           fi
           ref="$GITHUB_SHA"
         fi
+
+        if [ "$RUNNER_OS" = "Windows" ] && grep 'rc' <<< $release_version; then
+          # The Wix installer generator does not support strings in the version number,
+          # so we need to fixup the version number for release candidates.
+          release_version="$LLVM_VERSION_MAJOR.0.0.$(cut -d c -f2 <<< $release_version)"
+        fi
+
         if [ -n "${{ inputs.upload }}" ]; then
           upload="${{ inputs.upload }}"
         else

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -384,7 +384,9 @@ jobs:
       - name: Upload Artifacts
         uses: $/.github/workflows/upload-release-artifact
         with:
-          release-version: ${{ needs.prepare.outputs.release-version }}
+          # We need to use the inputs.release-version here, because on Windows we
+          # need to fixup the rc version that's stored in needs.prepare.outputs.release-version
+          release-version: ${{ inputs.release-version }}
           artifact-id: ${{ needs.build-release-package.outputs.artifact-id }}
           attestation-name: ${{ needs.prepare.outputs.attestation-name }}
           digest: ${{ needs.build-release-package.outputs.digest }}

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -386,7 +386,7 @@ jobs:
         with:
           # We need to use the inputs.release-version here, because on Windows we
           # need to fixup the rc version that's stored in needs.prepare.outputs.release-version
-          release-version: ${{ inputs.release-version }}
+          release-version: ${{ inputs.release-version || needs.prepare.outputs.release-version }}
           artifact-id: ${{ needs.build-release-package.outputs.artifact-id }}
           attestation-name: ${{ needs.prepare.outputs.attestation-name }}
           digest: ${{ needs.build-release-package.outputs.digest }}

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -115,14 +115,12 @@ jobs:
           ref="$GITHUB_SHA"
         fi
 
-        echo RELEASE VERSION: $release_version
-        grep 'rc' <<< $release_version
         if [ "$RUNNER_OS" = "Windows" ] && grep 'rc' <<< $release_version; then
           # The Wix installer generator does not support strings in the version number,
           # so we need to fixup the version number for release candidates.
+          # For Example: 23.1.0-rc2 will be come 23.0.0.2
           release_version="$LLVM_VERSION_MAJOR.0.0.$(cut -d c -f2 <<< $release_version)"
         fi
-        echo RELEASE VERSION: $release_version
 
         if [ -n "${{ inputs.upload }}" ]; then
           upload="${{ inputs.upload }}"


### PR DESCRIPTION
The Wix installer does not support version strings with characters, so we cannot use the -rc version strings on Windows.  In order to work around this, we change the version on the Windows builds from X.1.0-rcZ to X.0.0.Z.