### PR TITLE
DAG: Gracefully diagnose missing lrint/llrint/lround/llround libcall

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeIntegerTypes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeIntegerTypes.cpp
@@ -4570,11 +4570,21 @@ void DAGTypeLegalizer::ExpandIntRes_XROUND_XRINT(SDNode *N, SDValue &Lo,
 
   EVT RetVT = N->getValueType(0);
 
+  RTLIB::LibcallImpl LCImpl = DAG.getLibcalls().getLibcallImpl(LC);
+  if (LCImpl == RTLIB::Unsupported) {
+    DAG.getContext()->emitError(Twine("no libcall available for ") +
+                                N->getOperationName(&DAG));
+    SDValue Poison = DAG.getPOISON(N->getValueType(0));
+    SplitInteger(Poison, Lo, Hi);
+    if (N->isStrictFPOpcode())
+      ReplaceValueWith(SDValue(N, 1), N->getOperand(0));
+    return;
+  }
+
   TargetLowering::MakeLibCallOptions CallOptions;
   CallOptions.setIsSigned(true);
-  std::pair<SDValue, SDValue> Tmp = TLI.makeLibCall(DAG, LC, RetVT,
-                                                    Op, CallOptions, dl,
-                                                    Chain);
+  std::pair<SDValue, SDValue> Tmp =
+      TLI.makeLibCall(DAG, LCImpl, RetVT, Op, CallOptions, dl, Chain);
   SplitInteger(Tmp.first, Lo, Hi);
 
   if (N->isStrictFPOpcode())

--- a/llvm/test/CodeGen/X86/xrint-no-libcall-error.ll
+++ b/llvm/test/CodeGen/X86/xrint-no-libcall-error.ll
@@ -1,0 +1,28 @@
+; RUN: not llc -mtriple=i686-unknown-unknown -filetype=null %s 2>&1 | FileCheck %s
+
+; Make sure these missing libcalls emit a proper diagnostic rather
+; than fatal erroring.
+
+; CHECK: error: no libcall available for llrint
+define i64 @test_llrint_ppcf128(ppc_fp128 %x) nounwind {
+  %r = call i64 @llvm.llrint.i64.ppcf128(ppc_fp128 %x)
+  ret i64 %r
+}
+
+; CHECK: error: no libcall available for llround
+define i64 @test_llround_ppcf128(ppc_fp128 %x) nounwind {
+  %r = call i64 @llvm.llround.i64.ppcf128(ppc_fp128 %x)
+  ret i64 %r
+}
+
+; CHECK: error: no libcall available for strict_llrint
+define i64 @test_strict_llrint_ppcf128(ppc_fp128 %x) nounwind strictfp {
+  %r = call i64 @llvm.experimental.constrained.llrint.i64.ppcf128(ppc_fp128 %x, metadata !"round.tonearest", metadata !"fpexcept.strict")
+  ret i64 %r
+}
+
+; CHECK: error: no libcall available for strict_llround
+define i64 @test_strict_llround_ppcf128(ppc_fp128 %x) nounwind strictfp {
+  %r = call i64 @llvm.experimental.constrained.llround.i64.ppcf128(ppc_fp128 %x, metadata !"fpexcept.strict")
+  ret i64 %r
+}


### PR DESCRIPTION
Avoid hitting the fatal error in makeLibCall by emitting a diagnostic
if the library call is unsupported.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>