### PR TITLE
[libc] Disable read() on linux/arm

### DIFF
--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -248,7 +248,6 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.lseek
     libc.src.unistd.pipe
     libc.src.unistd.pipe2
-    libc.src.unistd.read
     libc.src.unistd.readlink
     libc.src.unistd.readlinkat
     libc.src.unistd.rmdir


### PR DESCRIPTION
The read test fails under qemu
(https://lab.llvm.org/buildbot/#/builders/215/builds/26997). This reverts a tiny part of #214429.