### PR TITLE
[libc] Disable hermetic version of printf_core.parser_test

### DIFF
--- a/libc/test/src/__support/printf_core/CMakeLists.txt
+++ b/libc/test/src/__support/printf_core/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_libc_test(
   parser_test
+  UNIT_TEST_ONLY # Fails to link on GPUs
   SUITE
     libc-support-tests
   SRCS


### PR DESCRIPTION
It fails on amdgpu: https://lab.llvm.org/buildbot/#/builders/10/builds/33548

ld.lld: error: undefined symbol: operator delete(void*, unsigned long, std::align_val_t)

This effectively reverts a part of #213852.