### PR TITLE
[libc] Fix HermeticTestUtils signature of operator delete

### DIFF
--- a/libc/test/UnitTest/HermeticTestUtils.cpp
+++ b/libc/test/UnitTest/HermeticTestUtils.cpp
@@ -144,6 +144,6 @@ enum class align_val_t : size_t {};
 
 void operator delete(void *ptr, std::align_val_t) noexcept { free(ptr); }
 
-void operator delete(void *ptr, unsigned int, std::align_val_t) noexcept {
+void operator delete(void *ptr, size_t, std::align_val_t) noexcept {
   free(ptr);
 }

--- a/libc/test/src/__support/printf_core/CMakeLists.txt
+++ b/libc/test/src/__support/printf_core/CMakeLists.txt
@@ -1,6 +1,5 @@
 add_libc_test(
   parser_test
-  UNIT_TEST_ONLY # Fails to link on GPUs
   SUITE
     libc-support-tests
   SRCS


### PR DESCRIPTION
The signed-and-aligned version should take a size_t. It was added to support rv32 #67457, where it worked presumably because size_t is defined as `unsigned int`.

This should fix printf_core.parser_test on amdgpu, which failed to link because it generated a call to the operator (while other targets do not). I did not try this with a GPU build, but I've verified this fixes the same error in x86 builds (when deleting an overaligned struct).