### PR TITLE
[ORC] Make RTBridge Callers value types; add buildCallers

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/Calls.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/Calls.h
@@ -19,6 +19,7 @@
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/FunctionExtras.h"
+#include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MSVCErrorWorkarounds.h"
@@ -28,11 +29,22 @@
 #include <string>
 #include <type_traits>
 
-namespace llvm::orc {
+namespace llvm::orc::rt {
 
-class ExecutionSession;
+class CallerBase {
+public:
+  CallerBase() = default;
+  CallerBase(ExecutorAddr CalleeAddr) : CalleeAddr(CalleeAddr) {}
 
-namespace rt {
+  /// Returns the address of the callee in the executor.
+  const ExecutorAddr &calleeAddr() const { return CalleeAddr; }
+
+  /// Evaluates to true if the callee is non-null.
+  explicit operator bool() const { return !!CalleeAddr; }
+
+private:
+  ExecutorAddr CalleeAddr;
+};
 
 template <typename FnT> class Caller;
 
@@ -46,7 +58,8 @@ template <typename FnT> class Caller;
 /// A Caller abstracts over how the operation is dispatched to the executor.
 /// Concrete implementations (e.g. rt::sps::Caller) supply the dispatch
 /// mechanism.
-template <typename RetT, typename... ArgTs> class Caller<RetT(ArgTs...)> {
+template <typename RetT, typename... ArgTs>
+class Caller<RetT(ArgTs...)> : public CallerBase {
 public:
   using FnType = RetT(ArgTs...);
 
@@ -58,42 +71,105 @@ public:
   using ErrorRetT =
       std::conditional_t<std::is_void_v<RetT>, Error, Expected<RetT>>;
 
-  Caller(ExecutionSession &ES, ExecutorAddr CalleeAddr)
-      : ES(ES), CalleeAddr(CalleeAddr) {}
+  using DispatchFn = void (*)(unique_function<void(ErrorRetT)> OnComplete,
+                              ExecutionSession &ES, ExecutorAddr Callee,
+                              const ArgTs &...Args);
 
-  virtual ~Caller() = default;
+  Caller() = default;
+  Caller(DispatchFn Dispatch, ExecutorAddr CalleeAddr)
+      : CallerBase(CalleeAddr), Dispatch(Dispatch) {}
 
-  /// Returns the ExecutionSession on which this call will be made.
-  ExecutionSession &executionSession() const { return ES; }
+  static Expected<Caller> Create(DispatchFn Dispatch, JITDylib &JD,
+                                 StringRef Name, SymbolLookupFlags LF) {
+    auto &ES = JD.getExecutionSession();
+    if (auto CalleeSyms = ES.lookup(makeJITDylibSearchOrder(&JD),
+                                    SymbolLookupSet{ES.intern(Name), LF})) {
+      if (!CalleeSyms->empty())
+        return Caller(Dispatch, CalleeSyms->begin()->second.getAddress());
+      assert(LF == SymbolLookupFlags::WeaklyReferencedSymbol);
+      return Caller();
+    } else
+      return CalleeSyms.takeError();
+  }
 
-  /// Returns the address of the callee in the executor.
-  const ExecutorAddr &calleeAddr() const { return CalleeAddr; }
-
-  /// Evaluates to true if the callee is non-null.
-  explicit operator bool() const { return !!CalleeAddr; }
+  static Expected<Caller> Create(DispatchFn Dispatch, ExecutionSession &ES,
+                                 StringRef Name, SymbolLookupFlags LF) {
+    return Create(Dispatch, ES.getBootstrapJITDylib(), Name, LF);
+  }
 
   /// Asynchronously invoke the operation with the given Args, delivering its
   /// result (or an error) to OnComplete.
-  virtual void operator()(unique_function<void(ErrorRetT)> OnComplete,
-                          ArgTs... Args) = 0;
+  void operator()(unique_function<void(ErrorRetT)> OnComplete,
+                  ExecutionSession &ES, const ArgTs &...Args) const {
+    assert(Dispatch && "Caller's Dispatch member is not set");
+    Dispatch(std::move(OnComplete), ES, calleeAddr(), Args...);
+  }
 
   /// Invoke the operation with the given Args, blocking until its result (or an
   /// error) is available.
-  ErrorRetT operator()(ArgTs... Args) {
+  ErrorRetT operator()(ExecutionSession &ES, const ArgTs &...Args) const {
     using PromiseValT = std::conditional_t<std::is_void_v<RetT>, MSVCPError,
                                            MSVCPExpected<RetT>>;
     std::promise<PromiseValT> P;
     auto F = P.get_future();
     this->operator()(
         [P = std::move(P)](ErrorRetT R) mutable { P.set_value(std::move(R)); },
-        std::move(Args)...);
+        ES, Args...);
     return F.get();
   }
 
 private:
-  ExecutionSession &ES;
-  ExecutorAddr CalleeAddr;
+  DispatchFn Dispatch = nullptr;
 };
+
+template <typename FnT> struct CallerInit {
+  Caller<FnT> *C = nullptr;
+  typename Caller<FnT>::DispatchFn Dispatch = nullptr;
+  StringRef Name;
+  SymbolLookupFlags LookupFlags = SymbolLookupFlags::RequiredSymbol;
+};
+
+template <typename FnT>
+CallerInit<FnT>
+callerInit(Caller<FnT> *C, typename Caller<FnT>::DispatchFn Dispatch,
+           StringRef Name,
+           SymbolLookupFlags LookupFlags = SymbolLookupFlags::RequiredSymbol) {
+  return {C, Dispatch, Name, LookupFlags};
+}
+
+template <typename CallerSpecT, typename FnT>
+CallerInit<FnT>
+callerInit(Caller<FnT> *C,
+           SymbolLookupFlags LookupFlags = SymbolLookupFlags::RequiredSymbol) {
+  return {C, CallerSpecT::dispatch, CallerSpecT::Name, LookupFlags};
+}
+
+template <typename CallerSpecT, typename FnT>
+CallerInit<FnT>
+callerInit(Caller<FnT> *C, StringRef Name,
+           SymbolLookupFlags LookupFlags = SymbolLookupFlags::RequiredSymbol) {
+  return {C, CallerSpecT::dispatch, Name, LookupFlags};
+}
+
+/// buildCallers base case.
+inline Error buildCallers(JITDylib &JD) { return Error::success(); }
+
+/// buildCallers: Given an ExecutionSession, use BootstrapJITDylib.
+template <typename... FnTs>
+Error buildCallers(ExecutionSession &ES, CallerInit<FnTs>... CIs) {
+  return buildCallers(ES.getBootstrapJITDylib(), CIs...);
+}
+
+/// Build a sequence of callers from their respective caller-builders.
+template <typename FnT, typename... FnTs>
+Error buildCallers(JITDylib &JD, CallerInit<FnT> CI, CallerInit<FnTs>... CIs) {
+  if (auto COrErr =
+          Caller<FnT>::Create(CI.Dispatch, JD, CI.Name, CI.LookupFlags))
+    *CI.C = std::move(*COrErr);
+  else
+    return COrErr.takeError();
+  return buildCallers(JD, CIs...);
+}
 
 /// Runtime-agnostic interface for running a main-like function
 /// (int(int argc, char *argv[])) in the executor.
@@ -125,7 +201,6 @@ using Int32VoidCaller = Caller<int32_t(ExecutorAddr)>;
 /// WARNING: This Caller is experimental and may be removed.
 using Int32Int32Caller = Caller<int32_t(ExecutorAddr, int32_t)>;
 
-} // namespace rt
-} // namespace llvm::orc
+} // namespace llvm::orc::rt
 
 #endif // LLVM_EXECUTIONENGINE_ORC_RTBRIDGE_CALLS_H

--- a/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/SPS/Calls.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/SPS/Calls.h
@@ -19,74 +19,30 @@
 
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/RTBridge/Calls.h"
-#include "llvm/ExecutionEngine/Orc/Shared/WrapperFunctionUtils.h"
 
 namespace llvm::orc::rt::sps {
 
-/// Implements the rt::Caller interface BaseT by calling an executor-side SPS
-/// wrapper function, using SPSSigT to encode the arguments and decode the
-/// result.
-///
-/// The wrapper is a controller-interface (CI) entry point named CIName: a
-/// wrapper function (byte blob in, byte blob out) that the runtime exposes to
-/// the controller. SPSSigT is the Simple Packed Serialization signature used to
-/// encode the argument blob and decode the result blob; it must be compatible
-/// with BaseT's FnType. CIName must have static storage duration (e.g. an
-/// inline constexpr char[]).
-///
-/// The FnType parameter is deduced from BaseT and should not be supplied
-/// explicitly; the primary template is left undefined so that only the
-/// RetT(ArgTs...) specialization can be instantiated.
-template <typename BaseT, typename SPSSigT, const char *CINameV,
-          typename FnType = typename BaseT::FnType>
-class Caller;
+template <typename CallerT, typename SPSSigT, const char *DefaultName,
+          typename FnType = typename CallerT::FnType>
+class CallerSpec;
 
-template <typename BaseT, typename SPSSigT, const char *CINameV, typename RetT,
-          typename... ArgTs>
-class Caller<BaseT, SPSSigT, CINameV, RetT(ArgTs...)> : public BaseT {
-  using CalleeRetT = typename BaseT::CalleeRetT;
-  using ErrorRetT = typename BaseT::ErrorRetT;
+template <typename CallerT, typename SPSSigT, const char *DefaultName,
+          typename RetT, typename... ArgTs>
+class CallerSpec<CallerT, SPSSigT, DefaultName, RetT(ArgTs...)> {
+  using CalleeRetT = typename CallerT::CalleeRetT;
+  using ErrorRetT = typename CallerT::ErrorRetT;
 
 public:
-  /// Name of the controller-interface wrapper this caller targets.
-  static constexpr const char *CIName = CINameV;
+  static constexpr const char *Name = DefaultName;
 
-  using BaseT::BaseT;
-  using BaseT::operator();
-
-  /// Look the wrapper up in the executor's bootstrap JITDylib and build a
-  /// caller for it.
-  static Expected<Caller>
-  Create(ExecutionSession &ES,
-         SymbolLookupFlags SLF = SymbolLookupFlags::RequiredSymbol,
-         const char *Name = CIName) {
-    if (auto CalleeSyms =
-            ES.lookup(makeJITDylibSearchOrder(&ES.getBootstrapJITDylib()),
-                      SymbolLookupSet{ES.intern(Name), SLF})) {
-      if (!CalleeSyms->empty())
-        return Caller(ES, CalleeSyms->begin()->second.getAddress());
-      assert(SLF == SymbolLookupFlags::WeaklyReferencedSymbol);
-      return Caller(ES, ExecutorAddr());
-    } else
-      return CalleeSyms.takeError();
-  }
-
-  /// Asynchronously call the SPS wrapper at CalleeAddr with the given Args,
-  /// delivering the result (or an error) to OnComplete. Serialization failures
-  /// are reported through OnComplete's error channel.
-  static void callAsync(unique_function<void(ErrorRetT)> OnComplete,
-                        ExecutionSession &ES, ExecutorAddr CalleeAddr,
-                        const ArgTs &...Args) {
-    using namespace llvm::orc::shared;
+  static void dispatch(unique_function<void(ErrorRetT)> OnComplete,
+                       ExecutionSession &ES, ExecutorAddr CalleeAddr,
+                       const ArgTs &...Args) {
     if constexpr (std::is_void_v<CalleeRetT>) {
       // Void result: the executor-side function produces no value, so the only
       // thing to report is the dispatch error (success if the call ran).
-      ES.callSPSWrapperAsync<SPSSigT>(
-          CalleeAddr,
-          [OnComplete = std::move(OnComplete)](Error SerErr) mutable {
-            OnComplete(std::move(SerErr));
-          },
-          Args...);
+      ES.callSPSWrapperAsync<SPSSigT>(CalleeAddr, std::move(OnComplete),
+                                      Args...);
     } else {
       ES.callSPSWrapperAsync<SPSSigT>(
           CalleeAddr,
@@ -94,17 +50,10 @@ public:
                                                CalleeRetT Result) mutable {
             if (SerErr)
               return OnComplete(std::move(SerErr));
-            else
-              return OnComplete(std::move(Result));
+            return OnComplete(std::move(Result));
           },
           Args...);
     }
-  }
-
-  void operator()(unique_function<void(ErrorRetT)> OnComplete,
-                  ArgTs... Args) override {
-    callAsync(std::move(OnComplete), this->executionSession(),
-              this->calleeAddr(), Args...);
   }
 };
 
@@ -113,30 +62,32 @@ using CallMainSPSSig = int64_t(shared::SPSExecutorAddr,
 inline constexpr char CallMainCIName[] = "orc_rt_ci_sps_call_main";
 /// SPS caller for rt::MainCaller: runs a main-like function
 /// (int(int argc, char *argv[])) in the executor.
-using MainCaller = Caller<rt::MainCaller, CallMainSPSSig, CallMainCIName>;
+using MainCallerSpec =
+    CallerSpec<rt::MainCaller, CallMainSPSSig, CallMainCIName>;
 
 using CallVoidVoidSPSSig = void(shared::SPSExecutorAddr);
 inline constexpr char CallVoidVoidCIName[] = "orc_rt_ci_sps_call_void_void";
 /// SPS caller for rt::VoidVoidCaller: runs a void() function in the executor.
 /// WARNING: This Caller is experimental and may be removed.
-using VoidVoidCaller =
-    Caller<rt::VoidVoidCaller, CallVoidVoidSPSSig, CallVoidVoidCIName>;
+using VoidVoidCallerSpec =
+    CallerSpec<rt::VoidVoidCaller, CallVoidVoidSPSSig, CallVoidVoidCIName>;
 
 using CallInt32VoidSPSSig = int32_t(shared::SPSExecutorAddr);
 inline constexpr char CallInt32VoidCIName[] = "orc_rt_ci_sps_call_int32_void";
 /// SPS caller for rt::Int32VoidCaller: runs an int32_t() function in the
 /// executor.
 /// WARNING: This Caller is experimental and may be removed.
-using Int32VoidCaller =
-    Caller<rt::Int32VoidCaller, CallInt32VoidSPSSig, CallInt32VoidCIName>;
+using Int32VoidCallerSpec =
+    CallerSpec<rt::Int32VoidCaller, CallInt32VoidSPSSig, CallInt32VoidCIName>;
 
 using CallInt32Int32SPSSig = int32_t(shared::SPSExecutorAddr, int32_t);
 inline constexpr char CallInt32Int32CIName[] = "orc_rt_ci_sps_call_int32_int32";
 /// SPS caller for rt::Int32Int32Caller: runs an int32_t(int32_t) function in
 /// the executor.
 /// WARNING: This Caller is experimental and may be removed.
-using Int32Int32Caller =
-    Caller<rt::Int32Int32Caller, CallInt32Int32SPSSig, CallInt32Int32CIName>;
+using Int32Int32CallerSpec =
+    CallerSpec<rt::Int32Int32Caller, CallInt32Int32SPSSig,
+               CallInt32Int32CIName>;
 
 } // namespace llvm::orc::rt::sps
 

--- a/llvm/lib/ExecutionEngine/Orc/COFFPlatform.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/COFFPlatform.cpp
@@ -663,13 +663,14 @@ Error COFFPlatform::runBootstrapInitializers(JDBootstrapState &BState) {
 Error COFFPlatform::runBootstrapSubsectionInitializers(JDBootstrapState &BState,
                                                        StringRef Start,
                                                        StringRef End) {
-  auto CallInitializer = rt::sps::Int32VoidCaller::Create(ES);
-  if (!CallInitializer)
-    return CallInitializer.takeError();
+  rt::Int32VoidCaller CallInitializer;
+  if (auto Err = rt::buildCallers(
+          ES, rt::callerInit<rt::sps::Int32VoidCallerSpec>(&CallInitializer)))
+    return Err;
   for (auto &Initializer : BState.Initializers)
     if (Initializer.first >= Start && Initializer.first <= End &&
         Initializer.second) {
-      auto Res = (*CallInitializer)(Initializer.second);
+      auto Res = CallInitializer(ES, Initializer.second);
       if (!Res)
         return Res.takeError();
     }
@@ -735,10 +736,11 @@ Error COFFPlatform::runSymbolIfExists(JITDylib &PlatformJD,
       ES, LookupKind::Static, makeJITDylibSearchOrder(&PlatformJD),
       {{ES.intern(SymbolName), &jit_function}});
   if (!AfterCLookupErr) {
-    auto CallFn = rt::sps::Int32VoidCaller::Create(ES);
-    if (!CallFn)
-      return CallFn.takeError();
-    auto Res = (*CallFn)(jit_function);
+    rt::Int32VoidCaller CallFn;
+    if (auto Err = rt::buildCallers(
+            ES, rt::callerInit<rt::sps::Int32VoidCallerSpec>(&CallFn)))
+      return Err;
+    auto Res = CallFn(ES, jit_function);
     if (!Res)
       return Res.takeError();
     return Error::success();

--- a/llvm/lib/ExecutionEngine/Orc/COFFVCRuntimeSupport.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/COFFVCRuntimeSupport.cpp
@@ -124,27 +124,26 @@ Error COFFVCRuntimeBootstrapper::initializeStaticVCRuntime(JITDylib &JD) {
             &jit_scrt_initialize_default_local_stdio_options}}))
     return Err;
 
-  auto CallInt32Void = rt::sps::Int32VoidCaller::Create(ES);
-  if (!CallInt32Void)
-    return CallInt32Void.takeError();
+  rt::Int32VoidCaller CallInt32Void;
+  rt::Int32Int32Caller CallInt32Int32;
+  if (auto Err = buildCallers(
+          ES, rt::callerInit<rt::sps::Int32VoidCallerSpec>(&CallInt32Void),
+          rt::callerInit<rt::sps::Int32Int32CallerSpec>(&CallInt32Int32)))
+    return Err;
 
-  auto CallInt32Int32 = rt::sps::Int32Int32Caller::Create(ES);
-  if (!CallInt32Int32)
-    return CallInt32Int32.takeError();
-
-  auto R = (*CallInt32Int32)(jit_scrt_initialize, 0);
+  auto R = CallInt32Int32(ES, jit_scrt_initialize, 0);
   if (!R)
     return R.takeError();
 
   if (auto Err =
-          (*CallInt32Void)(jit_scrt_dllmain_before_initialize_c).takeError())
+          CallInt32Void(ES, jit_scrt_dllmain_before_initialize_c).takeError())
     return Err;
 
-  if (auto Err = (*CallInt32Void)(jit_scrt_initialize_type_info).takeError())
+  if (auto Err = CallInt32Void(ES, jit_scrt_initialize_type_info).takeError())
     return Err;
 
   if (auto Err =
-          (*CallInt32Void)(jit_scrt_initialize_default_local_stdio_options)
+          CallInt32Void(ES, jit_scrt_initialize_default_local_stdio_options)
               .takeError())
     return Err;
 

--- a/llvm/unittests/ExecutionEngine/Orc/SPSCallersTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/SPSCallersTest.cpp
@@ -23,10 +23,15 @@
 using namespace llvm;
 using namespace llvm::orc;
 using namespace llvm::orc::shared;
-using llvm::orc::rt::sps::Int32Int32Caller;
-using llvm::orc::rt::sps::Int32VoidCaller;
-using llvm::orc::rt::sps::MainCaller;
-using llvm::orc::rt::sps::VoidVoidCaller;
+
+// rt::* are the runtime-agnostic caller handles; rt::sps::*Spec are the SPS
+// caller specs that supply each caller's dispatch function and
+// controller-interface name.
+namespace sps = llvm::orc::rt::sps;
+using llvm::orc::rt::Int32Int32Caller;
+using llvm::orc::rt::Int32VoidCaller;
+using llvm::orc::rt::MainCaller;
+using llvm::orc::rt::VoidVoidCaller;
 
 // Test "main" function. Returns argc plus the length of the first element of
 // argv (if argv is non-empty). Does not inspect argv entries beyond the first.
@@ -59,21 +64,22 @@ static CWrapperFunctionBuffer callMainWrapper(const char *ArgData,
 TEST(SPSCallersTest, CallMainSyncViaDirectConstruction) {
   ExecutionSession ES(cantFail(SelfExecutorProcessControl::Create()));
 
-  MainCaller CallMain(ES, ExecutorAddr::fromPtr(callMainWrapper));
+  MainCaller CallMain(sps::MainCallerSpec::dispatch,
+                      ExecutorAddr::fromPtr(callMainWrapper));
   ExecutorAddr MainAddr = ExecutorAddr::fromPtr(testMain);
 
   std::vector<std::string> Args;
-  Expected<int64_t> R0 = CallMain(MainAddr, Args);
+  Expected<int64_t> R0 = CallMain(ES, MainAddr, Args);
   ASSERT_THAT_EXPECTED(R0, Succeeded());
   EXPECT_EQ(*R0, 0); // argc == 0, no argv[0].
 
   Args = {"hello"};
-  Expected<int64_t> R1 = CallMain(MainAddr, Args);
+  Expected<int64_t> R1 = CallMain(ES, MainAddr, Args);
   ASSERT_THAT_EXPECTED(R1, Succeeded());
   EXPECT_EQ(*R1, 1 + 5); // argc == 1, strlen("hello") == 5.
 
   Args = {"a", "bb"};
-  Expected<int64_t> R2 = CallMain(MainAddr, Args);
+  Expected<int64_t> R2 = CallMain(ES, MainAddr, Args);
   ASSERT_THAT_EXPECTED(R2, Succeeded());
   EXPECT_EQ(*R2, 2 + 1); // argc == 2, strlen("a") == 1.
 
@@ -83,12 +89,13 @@ TEST(SPSCallersTest, CallMainSyncViaDirectConstruction) {
 TEST(SPSCallersTest, CallMainAsyncViaCallOperator) {
   ExecutionSession ES(cantFail(SelfExecutorProcessControl::Create()));
 
-  MainCaller CallMain(ES, ExecutorAddr::fromPtr(callMainWrapper));
+  MainCaller CallMain(sps::MainCallerSpec::dispatch,
+                      ExecutorAddr::fromPtr(callMainWrapper));
 
   std::vector<std::string> Args = {"foo", "bar"};
   std::promise<MSVCPExpected<int64_t>> P;
   auto F = P.get_future();
-  CallMain([&](Expected<int64_t> R) { P.set_value(std::move(R)); },
+  CallMain([&](Expected<int64_t> R) { P.set_value(std::move(R)); }, ES,
            ExecutorAddr::fromPtr(testMain), Args);
 
   Expected<int64_t> R = F.get();
@@ -98,51 +105,19 @@ TEST(SPSCallersTest, CallMainAsyncViaCallOperator) {
   cantFail(ES.endSession());
 }
 
-TEST(SPSCallersTest, CallMainThroughRTInterface) {
+// operator bool reflects whether the caller has a non-null callee address, and
+// calleeAddr() returns the address the caller was constructed with.
+TEST(SPSCallersTest, OperatorBoolAndAccessors) {
   ExecutionSession ES(cantFail(SelfExecutorProcessControl::Create()));
 
-  MainCaller CallMain(ES, ExecutorAddr::fromPtr(callMainWrapper));
+  ExecutorAddr CalleeAddr = ExecutorAddr::fromPtr(callMainWrapper);
+  MainCaller CallMain(sps::MainCallerSpec::dispatch, CalleeAddr);
+  EXPECT_TRUE(static_cast<bool>(CallMain));
+  EXPECT_EQ(CallMain.calleeAddr(), CalleeAddr);
 
-  // Drive the caller through the runtime-agnostic rt::MainCaller interface to
-  // exercise the virtual dispatch path (and to guard the interface's public
-  // accessibility).
-  rt::MainCaller &Base = CallMain;
-  ExecutorAddr MainAddr = ExecutorAddr::fromPtr(testMain);
-
-  // Synchronous call operator (inherited from rt::MainCaller).
-  std::vector<std::string> Args = {"hello"};
-  Expected<int64_t> RSync = Base(MainAddr, Args);
-  ASSERT_THAT_EXPECTED(RSync, Succeeded());
-  EXPECT_EQ(*RSync, 1 + 5); // argc == 1, strlen("hello") == 5.
-
-  // Asynchronous call operator (virtual).
-  std::promise<MSVCPExpected<int64_t>> P;
-  auto F = P.get_future();
-  Base([&](Expected<int64_t> R) { P.set_value(std::move(R)); }, MainAddr, Args);
-  Expected<int64_t> RAsync = F.get();
-  ASSERT_THAT_EXPECTED(RAsync, Succeeded());
-  EXPECT_EQ(*RAsync, 1 + 5);
-
-  cantFail(ES.endSession());
-}
-
-TEST(SPSCallersTest, CreateLooksUpCallMainInBootstrapJD) {
-  ExecutionSession ES(cantFail(SelfExecutorProcessControl::Create()));
-
-  // Register the call-main wrapper in the bootstrap JITDylib under the name
-  // MainCaller::Create looks for.
-  auto &BootstrapJD = ES.getBootstrapJITDylib();
-  cantFail(BootstrapJD.define(absoluteSymbols(
-      {{ES.intern(MainCaller::CIName),
-        {ExecutorAddr::fromPtr(callMainWrapper), JITSymbolFlags::Exported}}})));
-
-  Expected<MainCaller> CallMain = MainCaller::Create(ES);
-  ASSERT_THAT_EXPECTED(CallMain, Succeeded());
-
-  std::vector<std::string> Args = {"x", "y", "z"};
-  Expected<int64_t> R = (*CallMain)(ExecutorAddr::fromPtr(testMain), Args);
-  ASSERT_THAT_EXPECTED(R, Succeeded());
-  EXPECT_EQ(*R, 3 + 1); // argc == 3, strlen("x") == 1.
+  // A default-constructed caller has a null callee address and is falsey.
+  MainCaller NullCall;
+  EXPECT_FALSE(static_cast<bool>(NullCall));
 
   cantFail(ES.endSession());
 }
@@ -183,19 +158,20 @@ static CWrapperFunctionBuffer callInt32Int32Wrapper(const char *ArgData,
 TEST(SPSCallersTest, VoidVoidSyncAndAsync) {
   ExecutionSession ES(cantFail(SelfExecutorProcessControl::Create()));
 
-  VoidVoidCaller Call(ES, ExecutorAddr::fromPtr(callVoidVoidWrapper));
+  VoidVoidCaller Call(sps::VoidVoidCallerSpec::dispatch,
+                      ExecutorAddr::fromPtr(callVoidVoidWrapper));
   ExecutorAddr TargetAddr = ExecutorAddr::fromPtr(voidVoidTarget);
 
   // Synchronous: the call operator returns Error, not Expected<T>.
   VoidVoidCallCount = 0;
-  EXPECT_THAT_ERROR(Call(TargetAddr), Succeeded());
+  EXPECT_THAT_ERROR(Call(ES, TargetAddr), Succeeded());
   EXPECT_EQ(VoidVoidCallCount, 1);
 
   // Asynchronous: the result is delivered as an Error.
   VoidVoidCallCount = 0;
   std::promise<MSVCPError> P;
   auto F = P.get_future();
-  Call([&](Error Err) { P.set_value(std::move(Err)); }, TargetAddr);
+  Call([&](Error Err) { P.set_value(std::move(Err)); }, ES, TargetAddr);
   EXPECT_THAT_ERROR(Error(F.get()), Succeeded());
   EXPECT_EQ(VoidVoidCallCount, 1);
 
@@ -203,28 +179,15 @@ TEST(SPSCallersTest, VoidVoidSyncAndAsync) {
 }
 
 // Exercises a non-void caller with an argument (so argument forwarding through
-// the pack is covered), and the Create / bootstrap lookup path for a caller
-// other than MainCaller.
-TEST(SPSCallersTest, Int32Int32SyncAndCreate) {
+// the pack is covered).
+TEST(SPSCallersTest, Int32Int32Sync) {
   ExecutionSession ES(cantFail(SelfExecutorProcessControl::Create()));
 
-  Int32Int32Caller Call(ES, ExecutorAddr::fromPtr(callInt32Int32Wrapper));
-  Expected<int32_t> RDirect = Call(ExecutorAddr::fromPtr(int32Int32Target), 21);
-  ASSERT_THAT_EXPECTED(RDirect, Succeeded());
-  EXPECT_EQ(*RDirect, 42); // 21 * 2.
-
-  auto &BootstrapJD = ES.getBootstrapJITDylib();
-  cantFail(BootstrapJD.define(
-      absoluteSymbols({{ES.intern(Int32Int32Caller::CIName),
-                        {ExecutorAddr::fromPtr(callInt32Int32Wrapper),
-                         JITSymbolFlags::Exported}}})));
-
-  Expected<Int32Int32Caller> CreatedCall = Int32Int32Caller::Create(ES);
-  ASSERT_THAT_EXPECTED(CreatedCall, Succeeded());
-  Expected<int32_t> RCreated =
-      (*CreatedCall)(ExecutorAddr::fromPtr(int32Int32Target), 21);
-  ASSERT_THAT_EXPECTED(RCreated, Succeeded());
-  EXPECT_EQ(*RCreated, 42); // 21 * 2.
+  Int32Int32Caller Call(sps::Int32Int32CallerSpec::dispatch,
+                        ExecutorAddr::fromPtr(callInt32Int32Wrapper));
+  Expected<int32_t> R = Call(ES, ExecutorAddr::fromPtr(int32Int32Target), 21);
+  ASSERT_THAT_EXPECTED(R, Succeeded());
+  EXPECT_EQ(*R, 42); // 21 * 2.
 
   cantFail(ES.endSession());
 }
@@ -249,28 +212,48 @@ static CWrapperFunctionBuffer callInt32VoidWrapper(const char *ArgData,
 TEST(SPSCallersTest, Int32VoidSync) {
   ExecutionSession ES(cantFail(SelfExecutorProcessControl::Create()));
 
-  Int32VoidCaller Call(ES, ExecutorAddr::fromPtr(callInt32VoidWrapper));
-  Expected<int32_t> R = Call(ExecutorAddr::fromPtr(int32VoidTarget));
+  Int32VoidCaller Call(sps::Int32VoidCallerSpec::dispatch,
+                       ExecutorAddr::fromPtr(callInt32VoidWrapper));
+  Expected<int32_t> R = Call(ES, ExecutorAddr::fromPtr(int32VoidTarget));
   ASSERT_THAT_EXPECTED(R, Succeeded());
   EXPECT_EQ(*R, 42);
 
   cantFail(ES.endSession());
 }
 
-// operator bool reflects whether the caller has a non-null callee address, and
-// the accessors return the values the caller was constructed with.
-TEST(SPSCallersTest, OperatorBoolAndAccessors) {
+// Create looks the callee up by name in the bootstrap JITDylib and binds a
+// usable caller to it (required-symbol, present).
+TEST(SPSCallersTest, CreateLooksUpCallMainInBootstrapJD) {
   ExecutionSession ES(cantFail(SelfExecutorProcessControl::Create()));
 
-  ExecutorAddr CalleeAddr = ExecutorAddr::fromPtr(callMainWrapper);
-  MainCaller CallMain(ES, CalleeAddr);
-  EXPECT_TRUE(static_cast<bool>(CallMain));
-  EXPECT_EQ(CallMain.calleeAddr(), CalleeAddr);
-  EXPECT_EQ(&CallMain.executionSession(), &ES);
+  auto &BootstrapJD = ES.getBootstrapJITDylib();
+  cantFail(BootstrapJD.define(absoluteSymbols(
+      {{ES.intern(sps::MainCallerSpec::Name),
+        {ExecutorAddr::fromPtr(callMainWrapper), JITSymbolFlags::Exported}}})));
 
-  // A caller with a null callee address is falsey.
-  MainCaller NullCall(ES, ExecutorAddr());
-  EXPECT_FALSE(static_cast<bool>(NullCall));
+  Expected<MainCaller> CallMain = MainCaller::Create(
+      sps::MainCallerSpec::dispatch, ES, sps::MainCallerSpec::Name,
+      SymbolLookupFlags::RequiredSymbol);
+  ASSERT_THAT_EXPECTED(CallMain, Succeeded());
+
+  std::vector<std::string> Args = {"x", "y", "z"};
+  Expected<int64_t> R = (*CallMain)(ES, ExecutorAddr::fromPtr(testMain), Args);
+  ASSERT_THAT_EXPECTED(R, Succeeded());
+  EXPECT_EQ(*R, 3 + 1); // argc == 3, strlen("x") == 1.
+
+  cantFail(ES.endSession());
+}
+
+// A required (default) Create against a missing symbol fails, rather than
+// yielding a null caller as the weakly-referenced form does.
+TEST(SPSCallersTest, CreateRequiredAbsentFails) {
+  ExecutionSession ES(cantFail(SelfExecutorProcessControl::Create()));
+
+  // Nothing is defined for the call-main name in the bootstrap JITDylib.
+  Expected<MainCaller> CallMain = MainCaller::Create(
+      sps::MainCallerSpec::dispatch, ES, sps::MainCallerSpec::Name,
+      SymbolLookupFlags::RequiredSymbol);
+  EXPECT_THAT_EXPECTED(CallMain, Failed());
 
   cantFail(ES.endSession());
 }
@@ -280,9 +263,9 @@ TEST(SPSCallersTest, OperatorBoolAndAccessors) {
 TEST(SPSCallersTest, CreateWeaklyReferencedAbsent) {
   ExecutionSession ES(cantFail(SelfExecutorProcessControl::Create()));
 
-  // Nothing is defined for MainCaller::CIName in the bootstrap JITDylib.
-  Expected<MainCaller> CallMain =
-      MainCaller::Create(ES, SymbolLookupFlags::WeaklyReferencedSymbol);
+  Expected<MainCaller> CallMain = MainCaller::Create(
+      sps::MainCallerSpec::dispatch, ES, sps::MainCallerSpec::Name,
+      SymbolLookupFlags::WeaklyReferencedSymbol);
   ASSERT_THAT_EXPECTED(CallMain, Succeeded());
   EXPECT_FALSE(static_cast<bool>(*CallMain));
   EXPECT_EQ(CallMain->calleeAddr(), ExecutorAddr());
@@ -298,33 +281,38 @@ TEST(SPSCallersTest, CreateWeaklyReferencedPresent) {
   auto &BootstrapJD = ES.getBootstrapJITDylib();
   ExecutorAddr CalleeAddr = ExecutorAddr::fromPtr(callMainWrapper);
   cantFail(BootstrapJD.define(
-      absoluteSymbols({{ES.intern(MainCaller::CIName),
+      absoluteSymbols({{ES.intern(sps::MainCallerSpec::Name),
                         {CalleeAddr, JITSymbolFlags::Exported}}})));
 
-  Expected<MainCaller> CallMain =
-      MainCaller::Create(ES, SymbolLookupFlags::WeaklyReferencedSymbol);
+  Expected<MainCaller> CallMain = MainCaller::Create(
+      sps::MainCallerSpec::dispatch, ES, sps::MainCallerSpec::Name,
+      SymbolLookupFlags::WeaklyReferencedSymbol);
   ASSERT_THAT_EXPECTED(CallMain, Succeeded());
   EXPECT_TRUE(static_cast<bool>(*CallMain));
   EXPECT_EQ(CallMain->calleeAddr(), CalleeAddr);
 
-  // The resolved caller is usable.
-  std::vector<std::string> Args = {"a", "bb"};
-  Expected<int64_t> R = (*CallMain)(ExecutorAddr::fromPtr(testMain), Args);
-  ASSERT_THAT_EXPECTED(R, Succeeded());
-  EXPECT_EQ(*R, 2 + 1); // argc == 2, strlen("a") == 1.
-
   cantFail(ES.endSession());
 }
 
-// A required (default) Create against a missing symbol fails, rather than
-// yielding a null caller as the weakly-referenced form does.
-TEST(SPSCallersTest, CreateRequiredAbsentFails) {
+// buildCallers resolves a caller from the bootstrap JITDylib via its builder,
+// exercising the callerInit / buildCallers client entry point.
+TEST(SPSCallersTest, BuildCallersResolvesFromBootstrap) {
   ExecutionSession ES(cantFail(SelfExecutorProcessControl::Create()));
 
-  // Nothing is defined for MainCaller::CIName in the bootstrap JITDylib, and
-  // the default lookup requires the symbol.
-  Expected<MainCaller> CallMain = MainCaller::Create(ES);
-  EXPECT_THAT_EXPECTED(CallMain, Failed());
+  auto &BootstrapJD = ES.getBootstrapJITDylib();
+  cantFail(BootstrapJD.define(absoluteSymbols(
+      {{ES.intern(sps::MainCallerSpec::Name),
+        {ExecutorAddr::fromPtr(callMainWrapper), JITSymbolFlags::Exported}}})));
+
+  MainCaller CallMain;
+  cantFail(
+      rt::buildCallers(ES, rt::callerInit<sps::MainCallerSpec>(&CallMain)));
+  ASSERT_TRUE(static_cast<bool>(CallMain));
+
+  std::vector<std::string> Args = {"hi"};
+  Expected<int64_t> R = CallMain(ES, ExecutorAddr::fromPtr(testMain), Args);
+  ASSERT_THAT_EXPECTED(R, Succeeded());
+  EXPECT_EQ(*R, 1 + 2); // argc == 1, strlen("hi") == 2.
 
   cantFail(ES.endSession());
 }


### PR DESCRIPTION
rt::Caller was an abstract base with a per-protocol subclass (rt::sps::Caller), so holding one polymorphically meant a vtable and a heap allocation, and each caller stored an ExecutionSession reference.

Replace that with a value type: rt::Caller<Sig> holds a callee address and a dispatch function pointer (CallerBase provides the address, operator bool, and calleeAddr()). The serialization/dispatch protocol is erased behind the function pointer instead of a class hierarchy, so callers are copyable, carry no vtable or heap allocation, can be stored inline, and take the ExecutionSession at the call rather than storing it. This lets non-templated generic code hold and invoke callers without knowing the protocol.

rt::sps::CallerSpec supplies a caller's dispatch function and controller-interface name; the named specs (MainCallerSpec, VoidVoidCallerSpec, ...) replace the previous rt::sps caller subclasses.

Add buildCallers / callerInit to resolve a set of callers by name from the bootstrap JITDylib in a single call, and migrate the in-tree users (COFFPlatform, COFFVCRuntimeSupport) to it. Rewrite SPSCallersTest for the new API.