### PR TITLE
[UnreachableBlockElim] Report changes from block renumbering

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineFunction.h
+++ b/llvm/include/llvm/CodeGen/MachineFunction.h
@@ -937,8 +937,8 @@ public:
   /// recomputes them.  This guarantees that the MBB numbers are sequential,
   /// dense, and match the ordering of the blocks within the function.  If a
   /// specific MachineBasicBlock is specified, only that block and those after
-  /// it are renumbered.
-  void RenumberBlocks(MachineBasicBlock *MBBFrom = nullptr);
+  /// it are renumbered. Returns true if any block number changed.
+  bool RenumberBlocks(MachineBasicBlock *MBBFrom = nullptr);
 
   /// Return an estimate of the function's code size,
   /// taking into account block and function alignment

--- a/llvm/lib/CodeGen/MachineFunction.cpp
+++ b/llvm/lib/CodeGen/MachineFunction.cpp
@@ -386,8 +386,12 @@ void MachineFunction::replaceFrameInstRegister(MCRegister FromReg,
 /// This guarantees that the MBB numbers are sequential, dense, and match the
 /// ordering of the blocks within the function.  If a specific MachineBasicBlock
 /// is specified, only that block and those after it are renumbered.
-void MachineFunction::RenumberBlocks(MachineBasicBlock *MBB) {
-  if (empty()) { MBBNumbering.clear(); return; }
+bool MachineFunction::RenumberBlocks(MachineBasicBlock *MBB) {
+  if (empty()) {
+    bool Changed = !MBBNumbering.empty();
+    MBBNumbering.clear();
+    return Changed;
+  }
   MachineFunction::iterator MBBI, E = end();
   if (MBB == nullptr)
     MBBI = begin();
@@ -399,6 +403,7 @@ void MachineFunction::RenumberBlocks(MachineBasicBlock *MBB) {
   if (MBBI != begin())
     BlockNo = std::prev(MBBI)->getNumber() + 1;
 
+  bool Changed = false;
   for (; MBBI != E; ++MBBI, ++BlockNo) {
     if (MBBI->getNumber() != (int)BlockNo) {
       // Remove use of the old number.
@@ -414,13 +419,16 @@ void MachineFunction::RenumberBlocks(MachineBasicBlock *MBB) {
 
       MBBNumbering[BlockNo] = &*MBBI;
       MBBI->setNumber(BlockNo);
+      Changed = true;
     }
   }
 
   // Okay, all the blocks are renumbered.  If we have compactified the block
   // numbering, shrink MBBNumbering now.
   assert(BlockNo <= MBBNumbering.size() && "Mismatch!");
+  Changed |= BlockNo != MBBNumbering.size();
   MBBNumbering.resize(BlockNo);
+  return Changed;
 }
 
 int64_t MachineFunction::estimateFunctionSizeInBytes() {

--- a/llvm/lib/CodeGen/UnreachableBlockElim.cpp
+++ b/llvm/lib/CodeGen/UnreachableBlockElim.cpp
@@ -234,7 +234,7 @@ bool UnreachableMachineBlockElim::run(MachineFunction &F) {
     }
   }
 
-  F.RenumberBlocks();
+  bool Renumbered = F.RenumberBlocks();
 
-  return (!DeadBlocks.empty() || ModifiedPHI);
+  return (!DeadBlocks.empty() || ModifiedPHI || Renumbered);
 }

--- a/llvm/test/CodeGen/MIR/X86/unreachable-block-elim-renumber-slotindexes.mir
+++ b/llvm/test/CodeGen/MIR/X86/unreachable-block-elim-renumber-slotindexes.mir
@@ -1,0 +1,58 @@
+# RUN: llc -enable-new-pm -x mir -filetype=null %s \
+# RUN:     -passes='function(machine-function(early-tailduplication,print<slot-indexes>))' \
+# RUN:   2>&1 | FileCheck %s --check-prefix=HOLE
+# RUN: llc -enable-new-pm -x mir -filetype=null %s \
+# RUN:     -passes='function(machine-function(early-tailduplication,require<slot-indexes>,unreachable-mbb-elimination,print<slot-indexes>))' \
+# RUN:   2>&1 | FileCheck %s --check-prefix=DENSE
+
+# Holes in the block numbering are legal: tail duplication deletes %bb.1 here
+# and leaves its number unused, so SlotIndexes has an empty range for it.
+# HOLE: %bb.0 [0B;96B)
+# HOLE-NEXT: %bb.1 [invalid;invalid)
+# HOLE-NEXT: %bb.2 [96B;112B)
+# HOLE-NEXT: %bb.3 [112B;160B)
+
+# UnreachableMachineBlockElim compacts that hole via RenumberBlocks() even
+# though it removes nothing itself. SlotIndexes is keyed on block numbers and
+# cannot detect the renumbering, so the pass has to report it as a change and
+# get the cached result invalidated. Otherwise the stale table is reused and
+# %bb.1 resolves to the empty range above, which crashes anything that builds
+# LiveIntervals afterwards.
+# DENSE: %bb.0 [0B;96B)
+# DENSE-NEXT: %bb.1 [96B;112B)
+# DENSE-NEXT: %bb.2 [112B;160B)
+# DENSE-NOT: invalid
+
+--- |
+  target triple = "x86_64-unknown-unknown"
+
+  define void @f(i32 %c, ptr %p) {
+    ret void
+  }
+...
+---
+name:            f
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $edi, $rsi
+
+    %0:gr32 = COPY $edi
+    %1:gr64 = COPY $rsi
+    CMP32ri %0, 1, implicit-def $eflags
+    JCC_1 %bb.2, 4, implicit $eflags
+    JMP_1 %bb.1
+
+  bb.1:
+    successors: %bb.3
+
+    JMP_1 %bb.3
+
+  bb.2:
+    successors: %bb.3
+
+  bb.3:
+    MOV32mi %1, 1, $noreg, 0, $noreg, 42 :: (store (s32))
+    RET64
+...


### PR DESCRIPTION
UnreachableMachineBlockElim compacts that hole via RenumberBlocks() even when it removes nothing itself. SlotIndexes is keyed on block numbers so the pass has to report it as a change and get the cached result invalidated. 

Co-Authored by Opus 5