### PR TITLE
[libc] Relax read errno check

### DIFF
--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -248,6 +248,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.lseek
     libc.src.unistd.pipe
     libc.src.unistd.pipe2
+    libc.src.unistd.read
     libc.src.unistd.readlink
     libc.src.unistd.readlinkat
     libc.src.unistd.rmdir

--- a/libc/test/src/unistd/read_write_test.cpp
+++ b/libc/test/src/unistd/read_write_test.cpp
@@ -43,15 +43,15 @@ TEST_F(LlvmLibcUniStd, WriteFails) {
 }
 
 TEST_F(LlvmLibcUniStd, ReadFails) {
+  using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::any_of;
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
 
-#ifdef LIBC_TEST_UNDER_EMULATOR
-  // QEMU returns EFAULT instead of EBADF when reading into a nullptr.
   char buf[1];
   EXPECT_THAT(LIBC_NAMESPACE::read(-1, buf, 1), Fails<ssize_t>(EBADF));
-#else
-  EXPECT_THAT(LIBC_NAMESPACE::read(-1, nullptr, 1), Fails<ssize_t>(EBADF));
-#endif
   EXPECT_THAT(LIBC_NAMESPACE::read(0, reinterpret_cast<void *>(-1), 1),
               Fails<ssize_t>(EFAULT));
+  EXPECT_THAT(LIBC_NAMESPACE::read(-1, nullptr, 1),
+              Fails<ssize_t>(any_of(
+                  EBADF, EFAULT)) // Depending on what gets checked first.
+  );
 }


### PR DESCRIPTION
read_write_test was failing on the libc-arm32-qemu-debian-dbg bot due to a different errno number. Even though the test has a qemu branch, it did not kick in because the bot does not set CMAKE_CROSSCOMPILING_EMULATOR (I assume the tests get run via binfmt_misc).

While we could fix this in the bot config, and the different error *might* be considered a qemu bug, I don't think this is particularly relevant for this test, as we're merely forwarding the error number from the kernel (as such, the errno expectation is more of a test for the kernel that for libc). I think this okay to relax the check to expect one of the two reasonable error messages.