### PR TITLE
Fix FreeBSD LTO Kernel build

### DIFF
--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -7603,10 +7603,12 @@ Error ModuleSummaryIndexBitcodeReader::parseModule() {
         // v1 GLOBALVAR: [pointer type, isconst,     initid,       linkage, ...]
         // v1 FUNCTION:  [type,         callingconv, isproto,      linkage, ...]
         // v1 ALIAS:     [alias type,   addrspace,   aliasee val#, linkage, ...]
+        // v1 IFUNC:     [ifunc type,   addrspace,   resolver val#,linkage, ...]
         // v2: [strtab offset, strtab size, v1]
         case bitc::MODULE_CODE_GLOBALVAR:
         case bitc::MODULE_CODE_FUNCTION:
-        case bitc::MODULE_CODE_ALIAS: {
+        case bitc::MODULE_CODE_ALIAS:
+        case bitc::MODULE_CODE_IFUNC: {
           StringRef Name;
           ArrayRef<uint64_t> GVRecord;
           std::tie(Name, GVRecord) = readNameFromStrtab(Record);

--- a/llvm/lib/IR/Globals.cpp
+++ b/llvm/lib/IR/Globals.cpp
@@ -126,7 +126,10 @@ std::optional<GlobalValue::GUID> GlobalValue::getGUIDIfAssigned() const {
   // current properties.
   // TODO: Maybe we should use a more robust check for intrinsics than just
   // matching on the name?
-  if (isDeclaration() || isa<GlobalAlias>(this) ||
+  // GlobalAlias and GlobalIFunc are not GlobalObjects and so cannot carry
+  // GUID metadata (see getGUIDMetadata()); always compute their GUID
+  // on the fly.
+  if (isDeclaration() || isa<GlobalAlias>(this) || isa<GlobalIFunc>(this) ||
       getName().starts_with("llvm.")) {
     return GlobalValue::getGUIDAssumingExternalLinkage(getGlobalIdentifier());
   }


### PR DESCRIPTION
Previously, both clang 21 and 24 would crash/abort when either `-flto=thin` or `-flto=full` was passed to the FreeBSD kernel build flags. This fixes two separate issues, one at link time and one when compiling `pmap.c`.

Assisted-by: Claude Sonnet 5