### PR TITLE
[SPARC] Fix %hi/%lo of absolute expressions in PIC mode

### DIFF
--- a/llvm/lib/Target/Sparc/MCTargetDesc/SparcAsmBackend.cpp
+++ b/llvm/lib/Target/Sparc/MCTargetDesc/SparcAsmBackend.cpp
@@ -64,8 +64,11 @@ static unsigned adjustFixupValue(unsigned Kind, uint64_t Value) {
   case ELF::R_SPARC_HIX22:
     return (~Value >> 10) & 0x3fffff;
 
+  // In PIC mode the parser may map %hi to PC22/GOT22. An operand that folds to
+  // an absolute value emits no relocation and needs the %hi encoding.
   case ELF::R_SPARC_PC22:
   case ELF::R_SPARC_HI22:
+  case ELF::R_SPARC_GOT22:
   case ELF::R_SPARC_LM22:
     return (Value >> 10) & 0x3fffff;
 
@@ -80,6 +83,7 @@ static unsigned adjustFixupValue(unsigned Kind, uint64_t Value) {
 
   case ELF::R_SPARC_PC10:
   case ELF::R_SPARC_LO10:
+  case ELF::R_SPARC_GOT10:
     return Value & 0x3ff;
 
   case ELF::R_SPARC_H44:

--- a/llvm/test/MC/Sparc/Relocations/absolute-hi-lo.s
+++ b/llvm/test/MC/Sparc/Relocations/absolute-hi-lo.s
@@ -1,0 +1,35 @@
+# RUN: llvm-mc -triple=sparcv9 -filetype=obj %s | llvm-objdump -dr - | FileCheck %s --implicit-check-not=R_SPARC
+# RUN: llvm-mc -triple=sparcv9 --position-independent -filetype=obj %s | llvm-objdump -dr - | FileCheck %s --implicit-check-not=R_SPARC
+
+# CHECK-LABEL: <abs>:
+# CHECK-NEXT:  sethi 0x48d15, %l5
+# CHECK-NEXT:  or %l5, 0x278, %l5
+# CHECK-NEXT:  sethi 0x3fb72e, %o0
+# CHECK-NEXT:  xor %o0, 0x298, %o0
+# CHECK-NEXT:  sethi 0x21d950, %o1
+# CHECK-NEXT:  or %o1, 0x321, %o1
+# CHECK-NEXT:  sethi 0x4, %o2
+# CHECK-NEXT:  or %o2, 0x234, %o2
+# CHECK-NEXT:  sethi 0x48d15, %o3
+# CHECK-NEXT:  or %o3, 0x278, %o3
+
+defined = 0xfedcba98
+
+.globl abs
+abs:
+  sethi %hi(0x12345678), %l5
+  or %l5, %lo(0x12345678), %l5
+  sethi %hi(defined), %o0
+  xor %o0, %lo(defined), %o0
+  sethi %hi(forward), %o1
+  or %o1, %lo(forward), %o1
+  sethi %hi(.Lend-.Lbegin), %o2
+  or %o2, %lo(.Lend-.Lbegin), %o2
+  set 0x12345678, %o3
+
+forward = 0x87654321
+
+.data
+.Lbegin:
+  .space 0x1234
+.Lend:

--- a/llvm/test/MC/Sparc/Relocations/relocation-specifier.s
+++ b/llvm/test/MC/Sparc/Relocations/relocation-specifier.s
@@ -57,6 +57,20 @@ or %o1, %pc10(sym), %o1
 sethi %pc22(main), %o1
 or %o1, %pc10(main), %o1
 
+## GNU as has no %got operators, so these do not round-trip through ASM output.
+# ASM:      sethi %hi(sym), %o1
+# ASM-NEXT: or %o1, %lo(sym), %o1
+# ASM-NEXT: ld [%l7+sym], %o2
+# OBJDUMP:      sethi 0x0, %o1
+# OBJDUMP-NEXT:   R_SPARC_GOT22 sym
+# OBJDUMP-NEXT: or %o1, 0x0, %o1
+# OBJDUMP-NEXT:   R_SPARC_GOT10 sym
+# OBJDUMP-NEXT: ld [%l7], %o2
+# OBJDUMP-NEXT:   R_SPARC_GOT13 sym
+sethi %got22(sym), %o1
+or %o1, %got10(sym), %o1
+ld [%l7 + %got13(sym)], %o2
+
 # ASM:      sethi %hh(sym), %l0
 # ASM-NEXT: sethi %hh(sym), %l0
 # ASM-NEXT: or %g1, %hm(sym), %g3


### PR DESCRIPTION
adjustPICRelocation maps %hi/%lo to GOT22/PC22 or GOT10/PC10 at parse
time, before the operand is known to be absolute. adjustFixupValue has
no case for the GOT types, so an absolute operand encodes the unshifted
value:

Encode %got22/%got10 like %hi/%lo. Also drop them as input syntax; GNU
as has no such operators.