### PR TITLE
[CI] Enable reverse iteration in the AArch64 Linux premerge job

### DIFF
--- a/.ci/monolithic-linux.sh
+++ b/.ci/monolithic-linux.sh
@@ -70,6 +70,7 @@ cmake -S "${MONOREPO_ROOT}"/llvm -B "${BUILD_DIR}" \
       -D CMAKE_EXE_LINKER_FLAGS="-no-pie" \
       -D LLVM_ENABLE_WERROR=ON \
       -D LLVM_BINUTILS_INCDIR=/usr \
+      -D LLVM_REVERSE_ITERATION="${LLVM_REVERSE_ITERATION:-OFF}" \
       "${runtime_cmake_args[@]}"
 
 start-group "ninja"

--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -67,6 +67,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Reversing the iteration order of unordered containers on one
+          # configuration to add nuance.
+          LLVM_REVERSE_ITERATION: ${{ (startsWith(matrix.runs-on, 'depot-ubuntu-24.04-arm') && 'ON') || 'OFF' }}
         run: |
           git config --global --add safe.directory '*'
 


### PR DESCRIPTION
To catch code with depends on container iteration order. In 2026 has
already merged fixes triggered by it: 7f703cabf728 (MLIR SSA-value
completion order), 0b3afd35c41d (MLIR SROA alloca order), and
f5e2c5ddcec7 (a clang test).

Reverse iteration is exercised only by the reverse-iteration post-commit
buildbot (https://lab.llvm.org/buildbot/#/builders/110), which has not
been green since at least May 2026.
