### PR TITLE
[DirectX] Warn when !llvm.ident is missing during metadata translation

### DIFF
--- a/llvm/lib/Target/DirectX/DXILTranslateMetadata.cpp
+++ b/llvm/lib/Target/DirectX/DXILTranslateMetadata.cpp
@@ -535,6 +535,13 @@ static void translateGlobalMetadata(Module &M, DXILResourceMap &DRM,
   emitValidatorVersionMD(M, MMDI);
   emitShaderModelVersionMD(M, MMDI);
   emitDXILVersionTupleMD(M, MMDI);
+
+  // !llvm.ident is a frontend responsibility (Clang/DXC/LDC emits it).
+  // Warn if the frontend forgot to emit it; do not synthesize one here.
+  if (!M.getNamedMetadata("llvm.ident"))
+    reportError(M, "missing !llvm.ident metadata; frontend should emit it",
+                DS_Warning);
+
   NamedMDNode *NamedResourceMD = emitResourceMetadata(M, DRM, DRTM);
   auto *ResourceMD =
       (NamedResourceMD != nullptr) ? NamedResourceMD->getOperand(0) : nullptr;

--- a/llvm/test/CodeGen/DirectX/Metadata/llvm-ident.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/llvm-ident.ll
@@ -1,0 +1,35 @@
+; RUN: split-file %s %t
+; RUN: opt -S --dxil-translate-metadata %t/present.ll 2>&1 | FileCheck %t/present.ll
+; RUN: opt -S --dxil-translate-metadata %t/missing.ll 2>&1 | FileCheck %t/missing.ll
+
+; Test that !llvm.ident is preserved when a frontend emits it, and that
+; a warning is produced when it is absent.
+
+;--- present.ll
+
+; CHECK-NOT: missing !llvm.ident
+; CHECK-DAG: !llvm.ident = !{![[#IDENT:]]}
+; CHECK-DAG: ![[#IDENT]] = !{!"frontend v1.0"}
+
+target triple = "dxil-pc-shadermodel6.6-compute"
+
+define void @CSMain() #0 {
+  ret void
+}
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
+
+!llvm.ident = !{!0}
+!0 = !{!"frontend v1.0"}
+
+;--- missing.ll
+
+; CHECK: warning: {{.*}}missing !llvm.ident metadata; frontend should emit it
+
+target triple = "dxil-pc-shadermodel6.6-compute"
+
+define void @CSMain() #0 {
+  ret void
+}
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }


### PR DESCRIPTION
`!llvm.ident` is a frontend requirement for the DirectX target: Clang and DXC always emit it, and certain hardware drivers (e.g. NVIDIA RTX series) depend on its presence during `CreateComputePipelineState`. Without it, DXIL containers can pass `dxv` validation cleanly while causing runtime driver crashes during PSO creation.

`DXILTranslateMetadata` currently passes `!llvm.ident` through when present via `CompatibleNamedModuleMDs`. This patch adds a diagnostic warning when `!llvm.ident` is absent to alert frontend authors targeting DXIL.

### Changes
- Emits a diagnostic warning in `DXILTranslateMetadata` if `!llvm.ident` is missing from the module.
- Adds lit test coverage in `llvm/test/CodeGen/DirectX/Metadata/llvm-ident.ll`.