### PR TITLE
[clang][ASTMatchers] Fix `hasArraySize` crash without a size expression

### DIFF
--- a/clang-tools-extra/docs/ReleaseNotes.md
+++ b/clang-tools-extra/docs/ReleaseNotes.md
@@ -102,6 +102,10 @@ infrastructure are described first, followed by tool-specific sections.
 
 #### Changes in existing checks
 
+- Fixed a crash in {doc}`bugprone-misplaced-operator-in-strlen-in-alloc
+  <clang-tidy/checks/bugprone/misplaced-operator-in-strlen-in-alloc>` when
+  checking an array new expression without a size expression.
+
 - Fixed a crash in {doc}`bugprone-std-namespace-modification
   <clang-tidy/checks/bugprone/std-namespace-modification>` when checking
   lambda closure types used as template arguments.

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/misplaced-operator-in-strlen-in-alloc-no-crash.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/misplaced-operator-in-strlen-in-alloc-no-crash.cpp
@@ -1,0 +1,4 @@
+// RUN: %check_clang_tidy -expect-clang-tidy-error %s bugprone-misplaced-operator-in-strlen-in-alloc %t
+
+void *f() { return new int[](); }
+// CHECK-MESSAGES: :[[@LINE-1]]:24: error: cannot determine allocated array size from initializer [clang-diagnostic-error]

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/misplaced-operator-in-strlen-in-alloc-no-crash.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/misplaced-operator-in-strlen-in-alloc-no-crash.cpp
@@ -2,3 +2,7 @@
 
 void *f() { return new int[](); }
 // CHECK-MESSAGES: :[[@LINE-1]]:24: error: cannot determine allocated array size from initializer [clang-diagnostic-error]
+
+template <int... Is> void g() {
+  new int[]{Is...};
+}

--- a/clang/include/clang/ASTMatchers/ASTMatchers.h
+++ b/clang/include/clang/ASTMatchers/ASTMatchers.h
@@ -8652,8 +8652,8 @@ AST_MATCHER_P(CXXNewExpr, hasAnyPlacementArg, internal::Matcher<Expr>,
 /// cxxNewExpr(hasArraySize(integerLiteral(equals(10))))
 ///   matches the expression 'new MyClass[10]'.
 AST_MATCHER_P(CXXNewExpr, hasArraySize, internal::Matcher<Expr>, InnerMatcher) {
-  return Node.isArray() && *Node.getArraySize() &&
-         InnerMatcher.matches(**Node.getArraySize(), Finder, Builder);
+  const auto ArraySize = Node.getArraySize();
+  return ArraySize && InnerMatcher.matches(**ArraySize, Finder, Builder);
 }
 
 /// Matches a class declaration that is defined.

--- a/clang/include/clang/ASTMatchers/ASTMatchers.h
+++ b/clang/include/clang/ASTMatchers/ASTMatchers.h
@@ -8652,7 +8652,7 @@ AST_MATCHER_P(CXXNewExpr, hasAnyPlacementArg, internal::Matcher<Expr>,
 /// cxxNewExpr(hasArraySize(integerLiteral(equals(10))))
 ///   matches the expression 'new MyClass[10]'.
 AST_MATCHER_P(CXXNewExpr, hasArraySize, internal::Matcher<Expr>, InnerMatcher) {
-  const auto ArraySize = Node.getArraySize();
+  const std::optional<const Expr *> ArraySize = Node.getArraySize();
   return ArraySize && InnerMatcher.matches(**ArraySize, Finder, Builder);
 }
 


### PR DESCRIPTION
CXXNewExpr::getArraySize() returns std::nullopt even when isArray() is true, e.g. when there is no array size expression, as in 'new int[]()'. The hasArraySize matcher dereferenced the optional unconditionally, triggering undefined behavior (an assertion failure in assert-enabled builds). Check the optional for engagement before matching.

Since getArraySize() already returns std::nullopt when isArray() is false, the redundant isArray() check can be dropped.

Add a clang-tidy regression test that runs clang-tidy on a translation unit containing 'new int[]()', which emits a compiler diagnostic but must not crash the tool, and document the fix in the release notes.

Fixes #214281