### PR TITLE
[mlir] Remove dead declarations in VectorRewritePatterns.h

### DIFF
--- a/mlir/include/mlir/Dialect/Vector/Transforms/VectorRewritePatterns.h
+++ b/mlir/include/mlir/Dialect/Vector/Transforms/VectorRewritePatterns.h
@@ -414,21 +414,6 @@ void populateMemRefFlattenAndVectorNarrowTypeEmulationPatterns(
     arith::NarrowTypeEmulationConverter &typeConverter,
     RewritePatternSet &patterns);
 
-/// Rewrite a vector `bitcast(trunci)` to use a more efficient sequence of
-/// vector operations comprising `shuffle` and `bitwise` ops.
-/// Warning: these patterns currently only work for little endian targets.
-FailureOr<Value> rewriteBitCastOfTruncI(RewriterBase &rewriter,
-                                        vector::BitCastOp bitCastOp,
-                                        arith::TruncIOp truncOp,
-                                        vector::BroadcastOp maybeBroadcastOp);
-
-/// Rewrite a vector `ext(bitcast)` to use a more efficient sequence of
-/// vector operations comprising `shuffle` and `bitwise` ops.
-/// Warning: these patterns currently only work for little endian targets.
-FailureOr<Value> rewriteExtOfBitCast(RewriterBase &rewriter, Operation *extOp,
-                                     vector::BitCastOp bitCastOp,
-                                     vector::BroadcastOp maybeBroadcastOp);
-
 /// Appends patterns for rewriting vector operations over narrow types with
 /// ops over wider types.
 /// Warning: these patterns currently only work for little endian targets.


### PR DESCRIPTION
rewriteBitCastOfTruncI and rewriteExtOfBitCast were introduced on
September 18, 2023 in commits bf7c490ab73a22620c3d7790c09bfb11b669e51b
and 04ba475e85cb97e9006a130855b76479b5149f47, respectively, without
corresponding function definitions.
