### PR TITLE
[VPlan] Verify hoist point when hoisting previous value of a recurrence.

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
@@ -792,13 +792,14 @@ static bool hoistPreviousBeforeFORUsers(VPFirstOrderRecurrencePHIRecipe *FOR,
     if (!HoistPoint || VPDT.properlyDominates(R, HoistPoint))
       HoistPoint = R;
   }
-  assert(all_of(FOR->users(),
-                [&VPDT, HoistPoint](VPUser *U) {
-                  auto *R = cast<VPRecipeBase>(U);
-                  return HoistPoint == R ||
-                         VPDT.properlyDominates(HoistPoint, R);
-                }) &&
-         "HoistPoint must dominate all users of FOR");
+  // Dominance is only a partial order, so the users of FOR may not have a
+  // single user dominating all others. Bail out in that case.
+  if (!HoistPoint || HoistPoint->isPhi() ||
+      any_of(FOR->users(), [&VPDT, HoistPoint](VPUser *U) {
+        auto *R = cast<VPRecipeBase>(U);
+        return HoistPoint != R && !VPDT.properlyDominates(HoistPoint, R);
+      }))
+    return false;
 
   auto NeedsHoisting = [HoistPoint, &VPDT,
                         &Visited](VPValue *HoistCandidateV) -> VPRecipeBase * {
@@ -846,6 +847,13 @@ static bool hoistPreviousBeforeFORUsers(VPFirstOrderRecurrencePHIRecipe *FOR,
       }
     }
   }
+
+  // Moving a candidate to HoistPoint keeps it dominating its other users only
+  // if HoistPoint dominates the candidate's current position.
+  if (any_of(HoistCandidates, [&VPDT, HoistPoint](VPRecipeBase *R) {
+        return !VPDT.properlyDominates(HoistPoint, R);
+      }))
+    return false;
 
   // Order recipes to hoist by dominance so earlier instructions are processed
   // first.

--- a/llvm/test/Transforms/LoopVectorize/first-order-recurrence-chains.ll
+++ b/llvm/test/Transforms/LoopVectorize/first-order-recurrence-chains.ll
@@ -1147,3 +1147,225 @@ End:
   %res.2 = fadd double %res.1, %for.3
   ret double %res.2
 }
+
+; %for.2's users are in blocks that don't dominate each other. Sinking the
+; stores is not possible and after sinking %or out of the header for %for.1
+; there is no user of %for.2 dominating all its other users, so there is no
+; valid hoist point for %or.
+define void @test_chained_first_order_recurrences_users_in_incomparable_blocks(ptr noalias %A, ptr noalias %B, ptr noalias %C, i64 %n) {
+; CHECK-LABEL: define void @test_chained_first_order_recurrences_users_in_incomparable_blocks(
+; CHECK-SAME: ptr noalias [[A:%.*]], ptr noalias [[B:%.*]], ptr noalias [[C:%.*]], i64 [[N:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*]]:
+; CHECK-NEXT:    br label %[[LOOP:.*]]
+; CHECK:       [[LOOP]]:
+; CHECK-NEXT:    [[IV:%.*]] = phi i64 [ 0, %[[ENTRY]] ], [ [[IV_NEXT:%.*]], %[[LOOP_LATCH:.*]] ]
+; CHECK-NEXT:    [[FOR_1:%.*]] = phi i32 [ 0, %[[ENTRY]] ], [ [[PREV:%.*]], %[[LOOP_LATCH]] ]
+; CHECK-NEXT:    [[FOR_2:%.*]] = phi i32 [ 0, %[[ENTRY]] ], [ [[OR:%.*]], %[[LOOP_LATCH]] ]
+; CHECK-NEXT:    [[OR]] = or i32 [[FOR_1]], 3
+; CHECK-NEXT:    [[T:%.*]] = trunc i64 [[IV]] to i32
+; CHECK-NEXT:    [[GEP_C:%.*]] = getelementptr inbounds i32, ptr [[C]], i64 [[IV]]
+; CHECK-NEXT:    [[C:%.*]] = load i32, ptr [[GEP_C]], align 4
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[C]], 0
+; CHECK-NEXT:    br i1 [[CMP]], label %[[THEN:.*]], label %[[ELSE:.*]]
+; CHECK:       [[THEN]]:
+; CHECK-NEXT:    [[GEP_A:%.*]] = getelementptr inbounds i32, ptr [[A]], i64 [[IV]]
+; CHECK-NEXT:    store i32 [[FOR_2]], ptr [[GEP_A]], align 4
+; CHECK-NEXT:    br label %[[MERGE:.*]]
+; CHECK:       [[ELSE]]:
+; CHECK-NEXT:    [[GEP_B:%.*]] = getelementptr inbounds i32, ptr [[B]], i64 [[IV]]
+; CHECK-NEXT:    store i32 [[FOR_2]], ptr [[GEP_B]], align 4
+; CHECK-NEXT:    br label %[[MERGE]]
+; CHECK:       [[MERGE]]:
+; CHECK-NEXT:    [[PREV]] = mul i32 [[T]], [[T]]
+; CHECK-NEXT:    br label %[[LOOP_LATCH]]
+; CHECK:       [[LOOP_LATCH]]:
+; CHECK-NEXT:    [[IV_NEXT]] = add i64 [[IV]], 1
+; CHECK-NEXT:    [[EC:%.*]] = icmp eq i64 [[IV_NEXT]], [[N]]
+; CHECK-NEXT:    br i1 [[EC]], label %[[EXIT:.*]], label %[[LOOP]]
+; CHECK:       [[EXIT]]:
+; CHECK-NEXT:    ret void
+;
+entry:
+  br label %loop
+
+loop:
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %loop.latch ]
+  %for.1 = phi i32 [ 0, %entry ], [ %prev, %loop.latch ]
+  %for.2 = phi i32 [ 0, %entry ], [ %or, %loop.latch ]
+  %or = or i32 %for.1, 3
+  %t = trunc i64 %iv to i32
+  %gep.c = getelementptr inbounds i32, ptr %C, i64 %iv
+  %c = load i32, ptr %gep.c, align 4
+  %cmp = icmp sgt i32 %c, 0
+  br i1 %cmp, label %then, label %else
+
+then:
+  %gep.a = getelementptr inbounds i32, ptr %A, i64 %iv
+  store i32 %for.2, ptr %gep.a, align 4
+  br label %merge
+
+else:
+  %gep.b = getelementptr inbounds i32, ptr %B, i64 %iv
+  store i32 %for.2, ptr %gep.b, align 4
+  br label %merge
+
+merge:
+  %prev = mul i32 %t, %t
+  br label %loop.latch
+
+loop.latch:
+  %iv.next = add i64 %iv, 1
+  %ec = icmp eq i64 %iv.next, %n
+  br i1 %ec, label %exit, label %loop
+
+exit:
+  ret void
+}
+
+; Same as above, but %for.2 has a single user. After sinking %or out of the
+; header for %for.1, %or is in a block incomparable to the block of %for.2's
+; user, so hoisting %or would break dominance for %or's other users.
+define void @test_chained_first_order_recurrences_hoist_into_incomparable_block(ptr noalias %A, ptr noalias %B, ptr noalias %C, i64 %n) {
+; CHECK-LABEL: define void @test_chained_first_order_recurrences_hoist_into_incomparable_block(
+; CHECK-SAME: ptr noalias [[A:%.*]], ptr noalias [[B:%.*]], ptr noalias [[C:%.*]], i64 [[N:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*]]:
+; CHECK-NEXT:    br label %[[LOOP:.*]]
+; CHECK:       [[LOOP]]:
+; CHECK-NEXT:    [[IV:%.*]] = phi i64 [ 0, %[[ENTRY]] ], [ [[IV_NEXT:%.*]], %[[LOOP_LATCH:.*]] ]
+; CHECK-NEXT:    [[FOR_1:%.*]] = phi i32 [ 0, %[[ENTRY]] ], [ [[PREV:%.*]], %[[LOOP_LATCH]] ]
+; CHECK-NEXT:    [[FOR_2:%.*]] = phi i32 [ 0, %[[ENTRY]] ], [ [[OR:%.*]], %[[LOOP_LATCH]] ]
+; CHECK-NEXT:    [[OR]] = or i32 [[FOR_1]], 3
+; CHECK-NEXT:    [[T:%.*]] = trunc i64 [[IV]] to i32
+; CHECK-NEXT:    [[GEP_C:%.*]] = getelementptr inbounds i32, ptr [[C]], i64 [[IV]]
+; CHECK-NEXT:    [[C:%.*]] = load i32, ptr [[GEP_C]], align 4
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[C]], 0
+; CHECK-NEXT:    br i1 [[CMP]], label %[[THEN:.*]], label %[[ELSE:.*]]
+; CHECK:       [[THEN]]:
+; CHECK-NEXT:    [[GEP_A:%.*]] = getelementptr inbounds i32, ptr [[A]], i64 [[IV]]
+; CHECK-NEXT:    store i32 [[FOR_2]], ptr [[GEP_A]], align 4
+; CHECK-NEXT:    br label %[[MERGE:.*]]
+; CHECK:       [[ELSE]]:
+; CHECK-NEXT:    [[GEP_B:%.*]] = getelementptr inbounds i32, ptr [[B]], i64 [[IV]]
+; CHECK-NEXT:    store i32 42, ptr [[GEP_B]], align 4
+; CHECK-NEXT:    br label %[[MERGE]]
+; CHECK:       [[MERGE]]:
+; CHECK-NEXT:    [[PREV]] = mul i32 [[T]], [[T]]
+; CHECK-NEXT:    br label %[[LOOP_LATCH]]
+; CHECK:       [[LOOP_LATCH]]:
+; CHECK-NEXT:    [[IV_NEXT]] = add i64 [[IV]], 1
+; CHECK-NEXT:    [[EC:%.*]] = icmp eq i64 [[IV_NEXT]], [[N]]
+; CHECK-NEXT:    br i1 [[EC]], label %[[EXIT:.*]], label %[[LOOP]]
+; CHECK:       [[EXIT]]:
+; CHECK-NEXT:    ret void
+;
+entry:
+  br label %loop
+
+loop:
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %loop.latch ]
+  %for.1 = phi i32 [ 0, %entry ], [ %prev, %loop.latch ]
+  %for.2 = phi i32 [ 0, %entry ], [ %or, %loop.latch ]
+  %or = or i32 %for.1, 3
+  %t = trunc i64 %iv to i32
+  %gep.c = getelementptr inbounds i32, ptr %C, i64 %iv
+  %c = load i32, ptr %gep.c, align 4
+  %cmp = icmp sgt i32 %c, 0
+  br i1 %cmp, label %then, label %else
+
+then:
+  %gep.a = getelementptr inbounds i32, ptr %A, i64 %iv
+  store i32 %for.2, ptr %gep.a, align 4
+  br label %merge
+
+else:
+  %gep.b = getelementptr inbounds i32, ptr %B, i64 %iv
+  store i32 42, ptr %gep.b, align 4
+  br label %merge
+
+merge:
+  %prev = mul i32 %t, %t
+  br label %loop.latch
+
+loop.latch:
+  %iv.next = add i64 %iv, 1
+  %ec = icmp eq i64 %iv.next, %n
+  br i1 %ec, label %exit, label %loop
+
+exit:
+  ret void
+}
+
+; %for.2 is used by the %for.3 phi and by the store in %then. The %for.3 phi
+; dominates the store, so it is selected as hoist point, but hoisting recipes
+; before it would place them before the header phis.
+define void @test_chained_first_order_recurrences_hoist_point_is_phi(ptr noalias %A, ptr noalias %B, ptr noalias %C, i64 %n) {
+; CHECK-LABEL: define void @test_chained_first_order_recurrences_hoist_point_is_phi(
+; CHECK-SAME: ptr noalias [[A:%.*]], ptr noalias [[B:%.*]], ptr noalias [[C:%.*]], i64 [[N:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*]]:
+; CHECK-NEXT:    br label %[[LOOP:.*]]
+; CHECK:       [[LOOP]]:
+; CHECK-NEXT:    [[IV:%.*]] = phi i64 [ 0, %[[ENTRY]] ], [ [[IV_NEXT:%.*]], %[[LOOP_LATCH:.*]] ]
+; CHECK-NEXT:    [[FOR_1:%.*]] = phi i32 [ 0, %[[ENTRY]] ], [ [[PREV:%.*]], %[[LOOP_LATCH]] ]
+; CHECK-NEXT:    [[FOR_2:%.*]] = phi i32 [ 0, %[[ENTRY]] ], [ [[OR:%.*]], %[[LOOP_LATCH]] ]
+; CHECK-NEXT:    [[FOR_3:%.*]] = phi i32 [ 0, %[[ENTRY]] ], [ [[FOR_2]], %[[LOOP_LATCH]] ]
+; CHECK-NEXT:    [[OR]] = or i32 [[FOR_1]], 3
+; CHECK-NEXT:    [[T:%.*]] = trunc i64 [[IV]] to i32
+; CHECK-NEXT:    [[GEP_C:%.*]] = getelementptr inbounds i32, ptr [[C]], i64 [[IV]]
+; CHECK-NEXT:    [[C:%.*]] = load i32, ptr [[GEP_C]], align 4
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[C]], 0
+; CHECK-NEXT:    br i1 [[CMP]], label %[[THEN:.*]], label %[[ELSE:.*]]
+; CHECK:       [[THEN]]:
+; CHECK-NEXT:    [[GEP_A:%.*]] = getelementptr inbounds i32, ptr [[A]], i64 [[IV]]
+; CHECK-NEXT:    store i32 [[FOR_2]], ptr [[GEP_A]], align 4
+; CHECK-NEXT:    br label %[[MERGE:.*]]
+; CHECK:       [[ELSE]]:
+; CHECK-NEXT:    [[GEP_B:%.*]] = getelementptr inbounds i32, ptr [[B]], i64 [[IV]]
+; CHECK-NEXT:    store i32 [[FOR_3]], ptr [[GEP_B]], align 4
+; CHECK-NEXT:    br label %[[MERGE]]
+; CHECK:       [[MERGE]]:
+; CHECK-NEXT:    [[PREV]] = mul i32 [[T]], [[T]]
+; CHECK-NEXT:    br label %[[LOOP_LATCH]]
+; CHECK:       [[LOOP_LATCH]]:
+; CHECK-NEXT:    [[IV_NEXT]] = add i64 [[IV]], 1
+; CHECK-NEXT:    [[EC:%.*]] = icmp eq i64 [[IV_NEXT]], [[N]]
+; CHECK-NEXT:    br i1 [[EC]], label %[[EXIT:.*]], label %[[LOOP]]
+; CHECK:       [[EXIT]]:
+; CHECK-NEXT:    ret void
+;
+entry:
+  br label %loop
+
+loop:
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %loop.latch ]
+  %for.1 = phi i32 [ 0, %entry ], [ %prev, %loop.latch ]
+  %for.2 = phi i32 [ 0, %entry ], [ %or, %loop.latch ]
+  %for.3 = phi i32 [ 0, %entry ], [ %for.2, %loop.latch ]
+  %or = or i32 %for.1, 3
+  %t = trunc i64 %iv to i32
+  %gep.c = getelementptr inbounds i32, ptr %C, i64 %iv
+  %c = load i32, ptr %gep.c, align 4
+  %cmp = icmp sgt i32 %c, 0
+  br i1 %cmp, label %then, label %else
+
+then:
+  %gep.a = getelementptr inbounds i32, ptr %A, i64 %iv
+  store i32 %for.2, ptr %gep.a, align 4
+  br label %merge
+
+else:
+  %gep.b = getelementptr inbounds i32, ptr %B, i64 %iv
+  store i32 %for.3, ptr %gep.b, align 4
+  br label %merge
+
+merge:
+  %prev = mul i32 %t, %t
+  br label %loop.latch
+
+loop.latch:
+  %iv.next = add i64 %iv, 1
+  %ec = icmp eq i64 %iv.next, %n
+  br i1 %ec, label %exit, label %loop
+
+exit:
+  ret void
+}


### PR DESCRIPTION
tryToSinkOrHoistRecurrenceUsers processes the fixed-order recurrences of a loop one at a time and updates the plan for each of them. Once the plan has been updated for one recurrence, the properties hoistPreviousBeforeFORUsers relies on may no longer hold for the recurrences processed later

Convert dominance assertion that does not hold in all cases (added test cases) to a bail out, to a crash on the added test.