### PR TITLE
[clang][Driver] Forward --no-demangle in BareMetal toolchain

### DIFF
--- a/clang/lib/Driver/ToolChains/BareMetal.cpp
+++ b/clang/lib/Driver/ToolChains/BareMetal.cpp
@@ -603,6 +603,9 @@ void baremetal::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   if (auto LTO = TC.getLTOMode(Args); LTO != LTOK_None)
     addLTOOptions(TC, Args, CmdArgs, Output, Inputs, LTO == LTOK_Thin);
 
+  if (Args.hasArg(options::OPT_Z_Xlinker__no_demangle))
+    CmdArgs.push_back("--no-demangle");
+
   AddLinkerInputs(TC, Inputs, Args, CmdArgs, JA);
   TC.addProfileRTLibs(Args, CmdArgs);
 

--- a/clang/test/Driver/Xlinker-args.c
+++ b/clang/test/Driver/Xlinker-args.c
@@ -8,6 +8,10 @@
 
 /// Linux/GNU forwarding lives in linux-ld-args.c.
 
+/// Check that --no-demangle gets forwarded to the baremetal linker.
+// RUN: %clang -target armv6m-none-eabi --gcc-toolchain= -### \
+// RUN:   -Wl,--no-demangle %s 2>&1 | FileCheck -check-prefix=BAREMETAL %s
+
 /// Check that --no-demangle gets forwarded to the mingw linker
 // RUN: %clang -target x86_64-w64-mingw32 -### \
 // RUN:   -Wl,--no-demangle %s 2> %t
@@ -19,6 +23,7 @@
 
 // DARWIN-NOT: --no-demangle
 // DARWIN: "one" "two" "three" "four" "-z" "five" "-r"
+// BAREMETAL: "--no-demangle"
 // MINGW: "--no-demangle"
 // AIX: "-b" "one" "-b" "two"
 


### PR DESCRIPTION
`-Wl,--no-demangle` is rewritten by the driver into the internal
`OPT_Z_Xlinker__no_demangle` option. GNU and MinGW toolchains forward that
option, but the BareMetal linker job did not, so it was silently dropped.

Forward the internal option while constructing the BareMetal linker command.
Add a driver regression test that checks `--no-demangle` is present in the
generated linker invocation. This only affects BareMetal invocations that
explicitly pass this option; default behavior is unchanged.

Tests:
- `build-pr/bin/llvm-lit -v clang/test/Driver/Xlinker-args.c`
- `ninja -C build-pr check-clang-driver`
- `ninja -C build-pr check-clang`

Fixes #174984

Assisted-by: OpenAI Codex
