### PR TITLE
[clang][bytecode] Handle invalid lambda static invokers better

### DIFF
--- a/clang/lib/AST/ByteCode/Function.cpp
+++ b/clang/lib/AST/ByteCode/Function.cpp
@@ -39,9 +39,10 @@ Function::Function(Program &P, FunctionDeclTy Source, unsigned ArgSize,
     } else if (const auto *MD = dyn_cast<CXXMethodDecl>(F)) {
       ExplicitThisPointer = MD->isExplicitObjectMemberFunction();
       Virtual = MD->isVirtual();
-      if (IsLambdaStaticInvoker)
+      if (IsLambdaStaticInvoker) {
         Kind = FunctionKind::LambdaStaticInvoker;
-      else if (clang::isLambdaCallOperator(F))
+        Constexpr = true;
+      } else if (clang::isLambdaCallOperator(F))
         Kind = FunctionKind::LambdaCallOperator;
       else if (MD->isCopyAssignmentOperator() || MD->isMoveAssignmentOperator())
         Kind = FunctionKind::CopyOrMoveOperator;

--- a/clang/lib/AST/ByteCode/Function.h
+++ b/clang/lib/AST/ByteCode/Function.h
@@ -178,7 +178,7 @@ public:
   SourceInfo getSource(CodePtr PC) const;
 
   /// Checks if the function is valid to call.
-  bool isValid() const { return IsValid || isLambdaStaticInvoker(); }
+  bool isValid() const { return IsValid; }
 
   /// Checks if the function is virtual.
   bool isVirtual() const { return Virtual; };

--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -1153,10 +1153,6 @@ static bool CheckCallable(InterpState &S, CodePtr OpPC, const Function *F) {
     return false;
   }
 
-  // Implicitly constexpr.
-  if (F->isLambdaStaticInvoker())
-    return true;
-
   return diagnoseCallableDecl(S, OpPC, DiagDecl);
 }
 

--- a/clang/test/AST/ByteCode/invalid.cpp
+++ b/clang/test/AST/ByteCode/invalid.cpp
@@ -241,3 +241,9 @@ namespace InheritedCtor {
 
   SS ss{42};
 }
+
+namespace InvalidStaticInvoker {
+  auto foo = [](bar) { int j; return j; }; // both-error {{unknown type name 'bar'}}
+  constexpr int (*baz)(int) = foo;
+  int i = baz(42);
+}


### PR DESCRIPTION
Instead of marking it as valid, mark it as constexpr, which means it won't be valid unless it actually has valid code attached.