### PR TITLE
[Clang] Fix -Wunused-variable in #211482

### DIFF
--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -2965,12 +2965,12 @@ ImplicitAllocationArguments::ImplicitAllocationArguments(
       PassAlignment(alignedAllocationModeFromBool(AlignArg)),
       IsMSVCCompatibilityFallback(IsMSVCCompatibilityFallback),
       ArgumentCount(0) {
-  ASTContext &Ctx = SemaRef.getASTContext();
   if (TypeIdentityArg) {
     assert(SemaRef.isStdTypeIdentity(TypeIdentityArg->getType(), nullptr));
     ImplicitArguments[ArgumentCount++] = TypeIdentityArg;
   }
   assert(SizeArg);
+  [[maybe_unused]] ASTContext &Ctx = SemaRef.getASTContext();
   assert(Ctx.hasSameType(SizeArg->getType(), Ctx.getSizeType()));
   ImplicitArguments[ArgumentCount++] = SizeArg;
   if (AlignArg) {


### PR DESCRIPTION
This is only used in asserts, so fails in a release build without asserts with -Werror -Wunused-variable with the latest clang.