### PR TITLE
Fix: [lit] builtin cat/diff spawn-fallback leaked PYTHONPATH into later RUN lines

### DIFF
--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -668,9 +668,14 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper):
 
         builtin_fn = pipeline_builtins.get(args[0])
         use_inproc = _should_run_inproc(builtin_fn, not_crash, cmd_shenv, shenv)
+        # PYTHONPATH override for the builtin-command spawn-fallback below,
+        # applied only to the one subprocess.Popen call for this command
+        # (not to cmd_shenv.env) so it doesn't leak into later RUN lines
+        # that share cmd_shenv.
+        popen_pythonpath_override = None
         if not use_inproc and args[0] in builtin_commands:
             args.insert(0, sys.executable)
-            cmd_shenv.env["PYTHONPATH"] = os.path.dirname(os.path.abspath(__file__))
+            popen_pythonpath_override = os.path.dirname(os.path.abspath(__file__))
             args[1] = os.path.join(builtin_commands_dir, args[1] + ".py")
 
 
@@ -786,6 +791,10 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper):
             old_umask = -1
             if cmd_shenv.umask != -1:
                 old_umask = os.umask(cmd_shenv.umask)
+            popen_env = cmd_shenv.env
+            if popen_pythonpath_override is not None:
+                popen_env = dict(cmd_shenv.env)
+                popen_env["PYTHONPATH"] = popen_pythonpath_override
             procs.append(
                 subprocess.Popen(
                     args,
@@ -794,7 +803,7 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper):
                     stdin=stdin,
                     stdout=stdout,
                     stderr=stderr,
-                    env=cmd_shenv.env,
+                    env=popen_env,
                     close_fds=kUseCloseFDs,
                     universal_newlines=True,
                     errors="replace",

--- a/llvm/utils/lit/tests/unit/TestRunner.py
+++ b/llvm/utils/lit/tests/unit/TestRunner.py
@@ -3,16 +3,23 @@
 # END.
 
 
+import os
 import os.path
 import platform
+import shutil
+import tempfile
 import unittest
 
 import lit.discovery
 import lit.LitConfig
 import lit.Test as Test
+import lit.TestRunner
+from lit.ShellEnvironment import ShellEnvironment
+from lit.ShUtil import ShParser
 from lit.TestRunner import (
     ParserKind,
     IntegratedTestKeywordParser,
+    executeShCmd,
     parseIntegratedTestScript,
 )
 
@@ -380,6 +387,65 @@ class TestApplySubtitutions(unittest.TestCase):
                 self.fail("applySubstitutions should have raised an exception")
             except AssertionError:
                 pass
+
+
+class TestBuiltinSpawnFallbackPythonPath(unittest.TestCase):
+    """Regression test for https://github.com/llvm/llvm-project/issues/191131:
+
+    The spawn-fallback path used for builtin 'cat'/'diff' commands (taken
+    when the command can't run in-process, e.g. because it's wrapped in
+    'not --crash') must not permanently mutate the shared
+    ShellEnvironment's PYTHONPATH, or it leaks into every later RUN line
+    that shares the same shell environment.
+
+    Forcing this path normally requires the 'not --crash' wrapper, which
+    in turn requires the real 'not' helper binary that ships with a full
+    LLVM/Clang build -- unavailable in a pure-Python test environment.
+    Instead, this test drives the real executeShCmd()/_executeShCmd() path
+    for a plain 'cat' command (so cmd_shenv is the pipeline's own shenv,
+    exactly as it is for 'not --crash') and monkeypatches only the
+    use-in-process decision (lit.TestRunner._should_run_inproc) to return
+    False, so the real spawn-fallback code -- the code under test -- still
+    runs unmodified and unmocked.
+    """
+
+    def test_cat_spawn_fallback_does_not_leak_pythonpath(self):
+        tmpdir = tempfile.mkdtemp()
+        try:
+            input_path = os.path.join(tmpdir, "input.txt")
+            with open(input_path, "w") as f:
+                f.write("hello\n")
+
+            env = dict(os.environ)
+            sentinel = "sentinel-pythonpath-value"
+            env["PYTHONPATH"] = sentinel
+            shenv = ShellEnvironment(tmpdir, env)
+
+            # Shell-quote the path so ShParser doesn't treat any backslashes
+            # (e.g. on Windows) as escape characters.
+            cmd = ShParser('cat "%s"' % input_path.replace("\\", "\\\\")).parse()
+
+            original_should_run_inproc = lit.TestRunner._should_run_inproc
+            lit.TestRunner._should_run_inproc = lambda *args, **kwargs: False
+            try:
+                results = []
+                exitCode, timeoutInfo = executeShCmd(cmd, shenv, results)
+            finally:
+                lit.TestRunner._should_run_inproc = original_should_run_inproc
+
+            self.assertEqual(timeoutInfo, None)
+            self.assertEqual(exitCode, 0)
+            self.assertEqual(len(results), 1)
+            self.assertEqual(results[0].stdout, "hello\n")
+
+            # The bug: the spawn-fallback path used to mutate
+            # cmd_shenv.env["PYTHONPATH"] in place, and here cmd_shenv is
+            # shenv itself (no 'env'/'not' prefix forked a private copy),
+            # so that would corrupt PYTHONPATH for every subsequent RUN
+            # line sharing this ShellEnvironment.
+            self.assertEqual(shenv.env["PYTHONPATH"], sentinel)
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Replaced the in-place mutation with a value captured locally (popen_pythonpath_override) at the point the builtin-command args are rewritten. Immediately before the subprocess.Popen call, build popen_env: if the override is set, popen_env is a shallow copy of cmd_shenv.env with PYTHONPATH overridden (built after any ulimit-related env additions, so those are preserved too); otherwise popen_env is cmd_shenv.env unchanged. Popen now uses env=popen_env. cmd_shenv.env itself is never mutated by this path, so it is unaffected for subsequent RUN lines. No public API changes, no changes to _run_inproc_stage, no unrelated refactoring.

## Problem
llvm/llvm-project issue reference: llvm/llvm-project#191131 - lit mishandles set PYTHONPATH

## Root Cause
Confirmed the discovery hypothesis: in llvm/utils/lit/lit/TestRunner.py, the spawn-fallback branch for builtin cat/diff (`if not use_inproc and args[0] in builtin_commands:`) did `cmd_shenv.env["PYTHONPATH"] = os.path.dirname(...)`, mutating the env dict in place. cmd_shenv is often literally the same object as the pipeline's shared shenv (assigned via `cmd_shenv = shenv` per command, only forked into a private copy for a per-command 'env' prefix), and that same dict is later passed directly to subprocess.Popen(..., env=cmd_shenv.env) with nothing restoring the prior value, so every later RUN line in the same lit test sharing that ShellEnvironment saw the clobbered PYTHONPATH.

## Testing
PASS: all 9 FileCheck-independent lit self-tests pass with the fix applied (including the new regression test); verified the new test genuinely catches the regression by reverting only TestRunner.py (keeping the test) and re-running -- it failed with AssertionError showing PYTHONPATH corrupted to lit's own source dir. The broader FileCheck-based lit suite (e.g. shtest-cat.py, shtest-env-positive.py, pass-env.py) was NOT run locally because the FileCheck binary is not available in this environment (no C++ LLVM/Clang build, and downloading a prebuilt/third-party FileCheck was explicitly forbidden); LLVM's own CI will exercise that broader suite once a PR is opened.

## Related Issue
llvm/llvm-project#191131 - lit mishandles set PYTHONPATH

> [!INFO]
> 🤖 This PR was prepared with AI assistance (Claude, via an autonomous engineering workflow with human review and approval gates). The fix was independently reviewed and manually verified by a human before submission. The broader FileCheck-based lit test suite was not run locally (no official FileCheck binary available in the preparation environment); LLVM CI will exercise it after this PR is opened.

Fixes #191131
