### PR TITLE
[AMDGPU] Suppress OpenCL rewriting of printf where it is not linked

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUPrintfRuntimeBinding.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPrintfRuntimeBinding.cpp
@@ -428,9 +428,12 @@ bool AMDGPUPrintfRuntimeBindingImpl::lowerPrintfForGpu(Module &M) {
 }
 
 bool AMDGPUPrintfRuntimeBindingImpl::run(Module &M) {
+  if (M.getModuleFlag("openmp") ||
+      M.getTargetTriple().getEnvironment() == Triple::LLVM)
+    return false;
+
   auto *PrintfFunction = M.getFunction("printf");
-  if (!PrintfFunction || !PrintfFunction->isDeclaration() ||
-      M.getModuleFlag("openmp"))
+  if (!PrintfFunction || !PrintfFunction->isDeclaration())
     return false;
 
   // Verify the signature of the printf function and skip if it isn't correct.

--- a/llvm/test/CodeGen/AMDGPU/printf-runtime-binding-disabled.ll
+++ b/llvm/test/CodeGen/AMDGPU/printf-runtime-binding-disabled.ll
@@ -1,0 +1,30 @@
+; RUN: split-file %s %t
+; RUN: opt -mtriple=amdgcn-amd-amdhsa -passes=amdgpu-printf-runtime-binding -S < %t/openmp.ll | FileCheck %s
+; RUN: opt -mtriple=amdgcn-amd-amdhsa-llvm -passes=amdgpu-printf-runtime-binding -S < %t/llvm-env.ll | FileCheck %s
+
+; CHECK-LABEL: define void @test(
+; CHECK: call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @format.str, i32 %n)
+; CHECK-NOT: __printf_alloc
+
+;--- openmp.ll
+@format.str = private unnamed_addr addrspace(4) constant [8 x i8] c"arst %d\00", align 1
+
+define void @test(i32 %n) {
+  %call = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @format.str, i32 %n)
+  ret void
+}
+
+declare i32 @printf(ptr addrspace(4), ...)
+
+!llvm.module.flags = !{!0}
+!0 = !{i32 7, !"openmp", i32 51}
+
+;--- llvm-env.ll
+@format.str = private unnamed_addr addrspace(4) constant [8 x i8] c"arst %d\00", align 1
+
+define void @test(i32 %n) {
+  %call = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @format.str, i32 %n)
+  ret void
+}
+
+declare i32 @printf(ptr addrspace(4), ...)


### PR DESCRIPTION
Summary:
This triple intentionally does not link this library so this will always
be unresolved. We already suppress this for OpenMP so this should be
fine.
