### PR TITLE
[ORC] Reimplement EPCGenericMemoryAccess on RTBridge proxies

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/EPCGenericMemoryAccess.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/EPCGenericMemoryAccess.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Implements the MemoryAccess interface by making calls to
-// ExecutorProcessControl::callWrapperAsync.
+// Implements the MemoryAccess interface by calling executor-side wrapper
+// functions through rt::Proxy objects.
 //
 // This simplifies the implementaton of new ExecutorProcessControl instances,
 // as this implementation will always work (at the cost of some performance
@@ -20,188 +20,130 @@
 
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/MemoryAccess.h"
+#include "llvm/ExecutionEngine/Orc/RTBridge/SPS/ProxySpecs.h"
 
 namespace llvm {
 namespace orc {
 
 class EPCGenericMemoryAccess : public MemoryAccess {
 public:
-  /// Function addresses for memory access.
-  struct FuncAddrs {
-    ExecutorAddr WriteUInt8s;
-    ExecutorAddr WriteUInt16s;
-    ExecutorAddr WriteUInt32s;
-    ExecutorAddr WriteUInt64s;
-    ExecutorAddr WritePointers;
-    ExecutorAddr WriteBuffers;
-    ExecutorAddr ReadUInt8s;
-    ExecutorAddr ReadUInt16s;
-    ExecutorAddr ReadUInt32s;
-    ExecutorAddr ReadUInt64s;
-    ExecutorAddr ReadPointers;
-    ExecutorAddr ReadBuffers;
-    ExecutorAddr ReadStrings;
+  /// Proxies for the executor-side memory-access functions. These are
+  /// protocol-agnostic: EPCGenericMemoryAccess::Create populates them for the
+  /// runtime's SPS controller interface, but a client targeting a different
+  /// protocol can build its own Funcs and pass them to the constructor.
+  struct Funcs {
+    rt::MemWriteUInt8sProxy WriteUInt8s;
+    rt::MemWriteUInt16sProxy WriteUInt16s;
+    rt::MemWriteUInt32sProxy WriteUInt32s;
+    rt::MemWriteUInt64sProxy WriteUInt64s;
+    rt::MemWritePointersProxy WritePointers;
+    rt::MemWriteBuffersProxy WriteBuffers;
+    rt::MemReadUInt8sProxy ReadUInt8s;
+    rt::MemReadUInt16sProxy ReadUInt16s;
+    rt::MemReadUInt32sProxy ReadUInt32s;
+    rt::MemReadUInt64sProxy ReadUInt64s;
+    rt::MemReadPointersProxy ReadPointers;
+    rt::MemReadBuffersProxy ReadBuffers;
+    rt::MemReadStringsProxy ReadStrings;
   };
 
-  /// Create an EPCGenericMemoryAccess instance from a given set of
-  /// function addrs.
-  EPCGenericMemoryAccess(ExecutionSession &ES, FuncAddrs FAs)
-      : ES(ES), FAs(FAs) {}
+  /// Create an EPCGenericMemoryAccess instance that reaches the memory-access
+  /// wrappers in ES's bootstrap JITDylib via the runtime's SPS controller
+  /// interface.
+  static Expected<std::unique_ptr<MemoryAccess>> Create(ExecutionSession &ES) {
+    namespace sps = rt::sps;
+    Funcs Fns;
+    if (auto Err = rt::buildProxies(
+            ES, rt::proxyInit<sps::MemWriteUInt8sProxySpec>(&Fns.WriteUInt8s),
+            rt::proxyInit<sps::MemWriteUInt16sProxySpec>(&Fns.WriteUInt16s),
+            rt::proxyInit<sps::MemWriteUInt32sProxySpec>(&Fns.WriteUInt32s),
+            rt::proxyInit<sps::MemWriteUInt64sProxySpec>(&Fns.WriteUInt64s),
+            rt::proxyInit<sps::MemWritePointersProxySpec>(&Fns.WritePointers),
+            rt::proxyInit<sps::MemWriteBuffersProxySpec>(&Fns.WriteBuffers),
+            rt::proxyInit<sps::MemReadUInt8sProxySpec>(&Fns.ReadUInt8s),
+            rt::proxyInit<sps::MemReadUInt16sProxySpec>(&Fns.ReadUInt16s),
+            rt::proxyInit<sps::MemReadUInt32sProxySpec>(&Fns.ReadUInt32s),
+            rt::proxyInit<sps::MemReadUInt64sProxySpec>(&Fns.ReadUInt64s),
+            rt::proxyInit<sps::MemReadPointersProxySpec>(&Fns.ReadPointers),
+            rt::proxyInit<sps::MemReadBuffersProxySpec>(&Fns.ReadBuffers),
+            rt::proxyInit<sps::MemReadStringsProxySpec>(&Fns.ReadStrings)))
+      return std::move(Err);
+    return std::make_unique<EPCGenericMemoryAccess>(ES, std::move(Fns));
+  }
+
+  /// Create an EPCGenericMemoryAccess instance from a given set of memory
+  /// access proxies.
+  EPCGenericMemoryAccess(ExecutionSession &ES, Funcs Fns)
+      : ES(ES), Fns(std::move(Fns)) {}
 
   void writeUInt8sAsync(ArrayRef<tpctypes::UInt8Write> Ws,
                         WriteResultFn OnWriteComplete) override {
-    using namespace shared;
-    ES.callSPSWrapperAsync<void(SPSSequence<SPSMemoryAccessUInt8Write>)>(
-        FAs.WriteUInt8s, std::move(OnWriteComplete), Ws);
+    Fns.WriteUInt8s(std::move(OnWriteComplete), ES, Ws);
   }
 
   void writeUInt16sAsync(ArrayRef<tpctypes::UInt16Write> Ws,
                          WriteResultFn OnWriteComplete) override {
-    using namespace shared;
-    ES.callSPSWrapperAsync<void(SPSSequence<SPSMemoryAccessUInt16Write>)>(
-        FAs.WriteUInt16s, std::move(OnWriteComplete), Ws);
+    Fns.WriteUInt16s(std::move(OnWriteComplete), ES, Ws);
   }
 
   void writeUInt32sAsync(ArrayRef<tpctypes::UInt32Write> Ws,
                          WriteResultFn OnWriteComplete) override {
-    using namespace shared;
-    ES.callSPSWrapperAsync<void(SPSSequence<SPSMemoryAccessUInt32Write>)>(
-        FAs.WriteUInt32s, std::move(OnWriteComplete), Ws);
+    Fns.WriteUInt32s(std::move(OnWriteComplete), ES, Ws);
   }
 
   void writeUInt64sAsync(ArrayRef<tpctypes::UInt64Write> Ws,
                          WriteResultFn OnWriteComplete) override {
-    using namespace shared;
-    ES.callSPSWrapperAsync<void(SPSSequence<SPSMemoryAccessUInt64Write>)>(
-        FAs.WriteUInt64s, std::move(OnWriteComplete), Ws);
+    Fns.WriteUInt64s(std::move(OnWriteComplete), ES, Ws);
   }
 
   void writePointersAsync(ArrayRef<tpctypes::PointerWrite> Ws,
                           WriteResultFn OnWriteComplete) override {
-    using namespace shared;
-    ES.callSPSWrapperAsync<void(SPSSequence<SPSMemoryAccessPointerWrite>)>(
-        FAs.WritePointers, std::move(OnWriteComplete), Ws);
+    Fns.WritePointers(std::move(OnWriteComplete), ES, Ws);
   }
 
   void writeBuffersAsync(ArrayRef<tpctypes::BufferWrite> Ws,
                          WriteResultFn OnWriteComplete) override {
-    using namespace shared;
-    ES.callSPSWrapperAsync<void(SPSSequence<SPSMemoryAccessBufferWrite>)>(
-        FAs.WriteBuffers, std::move(OnWriteComplete), Ws);
+    Fns.WriteBuffers(std::move(OnWriteComplete), ES, Ws);
   }
 
   void readUInt8sAsync(ArrayRef<ExecutorAddr> Rs,
                        OnReadUIntsCompleteFn<uint8_t> OnComplete) override {
-    using namespace shared;
-    ES.callSPSWrapperAsync<SPSSequence<uint8_t>(SPSSequence<SPSExecutorAddr>)>(
-        FAs.ReadUInt8s,
-        [OnComplete = std::move(OnComplete)](
-            Error Err, ReadUIntsResult<uint8_t> Result) mutable {
-          if (Err)
-            OnComplete(std::move(Err));
-          else
-            OnComplete(std::move(Result));
-        },
-        Rs);
+    Fns.ReadUInt8s(std::move(OnComplete), ES, Rs);
   }
 
   void readUInt16sAsync(ArrayRef<ExecutorAddr> Rs,
                         OnReadUIntsCompleteFn<uint16_t> OnComplete) override {
-    using namespace shared;
-    ES.callSPSWrapperAsync<SPSSequence<uint16_t>(SPSSequence<SPSExecutorAddr>)>(
-        FAs.ReadUInt16s,
-        [OnComplete = std::move(OnComplete)](
-            Error Err, ReadUIntsResult<uint16_t> Result) mutable {
-          if (Err)
-            OnComplete(std::move(Err));
-          else
-            OnComplete(std::move(Result));
-        },
-        Rs);
+    Fns.ReadUInt16s(std::move(OnComplete), ES, Rs);
   }
 
   void readUInt32sAsync(ArrayRef<ExecutorAddr> Rs,
                         OnReadUIntsCompleteFn<uint32_t> OnComplete) override {
-    using namespace shared;
-    ES.callSPSWrapperAsync<SPSSequence<uint32_t>(SPSSequence<SPSExecutorAddr>)>(
-        FAs.ReadUInt32s,
-        [OnComplete = std::move(OnComplete)](
-            Error Err, ReadUIntsResult<uint32_t> Result) mutable {
-          if (Err)
-            OnComplete(std::move(Err));
-          else
-            OnComplete(std::move(Result));
-        },
-        Rs);
+    Fns.ReadUInt32s(std::move(OnComplete), ES, Rs);
   }
 
   void readUInt64sAsync(ArrayRef<ExecutorAddr> Rs,
                         OnReadUIntsCompleteFn<uint64_t> OnComplete) override {
-    using namespace shared;
-    ES.callSPSWrapperAsync<SPSSequence<uint64_t>(SPSSequence<SPSExecutorAddr>)>(
-        FAs.ReadUInt64s,
-        [OnComplete = std::move(OnComplete)](
-            Error Err, ReadUIntsResult<uint64_t> Result) mutable {
-          if (Err)
-            OnComplete(std::move(Err));
-          else
-            OnComplete(std::move(Result));
-        },
-        Rs);
+    Fns.ReadUInt64s(std::move(OnComplete), ES, Rs);
   }
 
   void readPointersAsync(ArrayRef<ExecutorAddr> Rs,
                          OnReadPointersCompleteFn OnComplete) override {
-    using namespace shared;
-    using SPSSig = SPSSequence<SPSExecutorAddr>(SPSSequence<SPSExecutorAddr>);
-    ES.callSPSWrapperAsync<SPSSig>(
-        FAs.ReadPointers,
-        [OnComplete = std::move(OnComplete)](
-            Error Err, ReadPointersResult Result) mutable {
-          if (Err)
-            OnComplete(std::move(Err));
-          else
-            OnComplete(std::move(Result));
-        },
-        Rs);
+    Fns.ReadPointers(std::move(OnComplete), ES, Rs);
   }
 
   void readBuffersAsync(ArrayRef<ExecutorAddrRange> Rs,
                         OnReadBuffersCompleteFn OnComplete) override {
-    using namespace shared;
-    using SPSSig =
-        SPSSequence<SPSSequence<uint8_t>>(SPSSequence<SPSExecutorAddrRange>);
-    ES.callSPSWrapperAsync<SPSSig>(
-        FAs.ReadBuffers,
-        [OnComplete = std::move(OnComplete)](Error Err,
-                                             ReadBuffersResult Result) mutable {
-          if (Err)
-            OnComplete(std::move(Err));
-          else
-            OnComplete(std::move(Result));
-        },
-        Rs);
+    Fns.ReadBuffers(std::move(OnComplete), ES, Rs);
   }
 
   void readStringsAsync(ArrayRef<ExecutorAddr> Rs,
                         OnReadStringsCompleteFn OnComplete) override {
-    using namespace shared;
-    using SPSSig = SPSSequence<SPSString>(SPSSequence<SPSExecutorAddr>);
-    ES.callSPSWrapperAsync<SPSSig>(
-        FAs.ReadStrings,
-        [OnComplete = std::move(OnComplete)](Error Err,
-                                             ReadStringsResult Result) mutable {
-          if (Err)
-            OnComplete(std::move(Err));
-          else
-            OnComplete(std::move(Result));
-        },
-        Rs);
+    Fns.ReadStrings(std::move(OnComplete), ES, Rs);
   }
 
 private:
   ExecutionSession &ES;
-  FuncAddrs FAs;
+  Funcs Fns;
 };
 
 } // end namespace orc

--- a/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/Proxy.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/Proxy.h
@@ -21,6 +21,7 @@
 #include "llvm/ADT/FunctionExtras.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
+#include "llvm/ExecutionEngine/Orc/Shared/TargetProcessControlTypes.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MSVCErrorWorkarounds.h"
 
@@ -28,6 +29,7 @@
 #include <future>
 #include <string>
 #include <type_traits>
+#include <vector>
 
 namespace llvm::orc::rt {
 
@@ -200,6 +202,30 @@ using CallInt32VoidProxy = Proxy<int32_t(ExecutorAddr)>;
 ///
 /// WARNING: This Proxy is experimental and may be removed.
 using CallInt32Int32Proxy = Proxy<int32_t(ExecutorAddr, int32_t)>;
+
+/// Runtime-agnostic interfaces for the memory-access operations. Unlike the
+/// Call* proxies above, these target wrappers that perform the operation
+/// directly, so they take the operation's data arguments rather than a callee
+/// address.
+using MemWriteUInt8sProxy = Proxy<void(ArrayRef<tpctypes::UInt8Write>)>;
+using MemWriteUInt16sProxy = Proxy<void(ArrayRef<tpctypes::UInt16Write>)>;
+using MemWriteUInt32sProxy = Proxy<void(ArrayRef<tpctypes::UInt32Write>)>;
+using MemWriteUInt64sProxy = Proxy<void(ArrayRef<tpctypes::UInt64Write>)>;
+using MemWritePointersProxy = Proxy<void(ArrayRef<tpctypes::PointerWrite>)>;
+using MemWriteBuffersProxy = Proxy<void(ArrayRef<tpctypes::BufferWrite>)>;
+using MemReadUInt8sProxy = Proxy<std::vector<uint8_t>(ArrayRef<ExecutorAddr>)>;
+using MemReadUInt16sProxy =
+    Proxy<std::vector<uint16_t>(ArrayRef<ExecutorAddr>)>;
+using MemReadUInt32sProxy =
+    Proxy<std::vector<uint32_t>(ArrayRef<ExecutorAddr>)>;
+using MemReadUInt64sProxy =
+    Proxy<std::vector<uint64_t>(ArrayRef<ExecutorAddr>)>;
+using MemReadPointersProxy =
+    Proxy<std::vector<ExecutorAddr>(ArrayRef<ExecutorAddr>)>;
+using MemReadBuffersProxy =
+    Proxy<std::vector<std::vector<uint8_t>>(ArrayRef<ExecutorAddrRange>)>;
+using MemReadStringsProxy =
+    Proxy<std::vector<std::string>(ArrayRef<ExecutorAddr>)>;
 
 } // namespace llvm::orc::rt
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/SPS/ProxySpecs.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/SPS/ProxySpecs.h
@@ -19,6 +19,9 @@
 
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/RTBridge/Proxy.h"
+#include "llvm/ExecutionEngine/Orc/Shared/TargetProcessControlTypes.h"
+
+#include <cstdint>
 
 namespace llvm::orc::rt::sps {
 
@@ -88,6 +91,106 @@ inline constexpr char CallInt32Int32CIName[] = "orc_rt_ci_sps_call_int32_int32";
 using CallInt32Int32ProxySpec =
     ProxySpec<rt::CallInt32Int32Proxy, CallInt32Int32SPSSig,
               CallInt32Int32CIName>;
+
+// Memory-access proxies. Unlike the Call* proxies above, these target wrappers
+// that perform the operation directly, so they take the operation's data
+// arguments and no callee address.
+
+using MemWriteUInt8sSPSSig =
+    void(shared::SPSSequence<shared::SPSMemoryAccessUInt8Write>);
+inline constexpr char MemWriteUInt8sCIName[] = "orc_rt_ci_sps_mem_write_uint8s";
+using MemWriteUInt8sProxySpec =
+    ProxySpec<rt::MemWriteUInt8sProxy, MemWriteUInt8sSPSSig,
+              MemWriteUInt8sCIName>;
+
+using MemWriteUInt16sSPSSig =
+    void(shared::SPSSequence<shared::SPSMemoryAccessUInt16Write>);
+inline constexpr char MemWriteUInt16sCIName[] =
+    "orc_rt_ci_sps_mem_write_uint16s";
+using MemWriteUInt16sProxySpec =
+    ProxySpec<rt::MemWriteUInt16sProxy, MemWriteUInt16sSPSSig,
+              MemWriteUInt16sCIName>;
+
+using MemWriteUInt32sSPSSig =
+    void(shared::SPSSequence<shared::SPSMemoryAccessUInt32Write>);
+inline constexpr char MemWriteUInt32sCIName[] =
+    "orc_rt_ci_sps_mem_write_uint32s";
+using MemWriteUInt32sProxySpec =
+    ProxySpec<rt::MemWriteUInt32sProxy, MemWriteUInt32sSPSSig,
+              MemWriteUInt32sCIName>;
+
+using MemWriteUInt64sSPSSig =
+    void(shared::SPSSequence<shared::SPSMemoryAccessUInt64Write>);
+inline constexpr char MemWriteUInt64sCIName[] =
+    "orc_rt_ci_sps_mem_write_uint64s";
+using MemWriteUInt64sProxySpec =
+    ProxySpec<rt::MemWriteUInt64sProxy, MemWriteUInt64sSPSSig,
+              MemWriteUInt64sCIName>;
+
+using MemWritePointersSPSSig =
+    void(shared::SPSSequence<shared::SPSMemoryAccessPointerWrite>);
+inline constexpr char MemWritePointersCIName[] =
+    "orc_rt_ci_sps_mem_write_pointers";
+using MemWritePointersProxySpec =
+    ProxySpec<rt::MemWritePointersProxy, MemWritePointersSPSSig,
+              MemWritePointersCIName>;
+
+using MemWriteBuffersSPSSig =
+    void(shared::SPSSequence<shared::SPSMemoryAccessBufferWrite>);
+inline constexpr char MemWriteBuffersCIName[] =
+    "orc_rt_ci_sps_mem_write_buffers";
+using MemWriteBuffersProxySpec =
+    ProxySpec<rt::MemWriteBuffersProxy, MemWriteBuffersSPSSig,
+              MemWriteBuffersCIName>;
+
+using MemReadUInt8sSPSSig =
+    shared::SPSSequence<uint8_t>(shared::SPSSequence<shared::SPSExecutorAddr>);
+inline constexpr char MemReadUInt8sCIName[] = "orc_rt_ci_sps_mem_read_uint8s";
+using MemReadUInt8sProxySpec =
+    ProxySpec<rt::MemReadUInt8sProxy, MemReadUInt8sSPSSig, MemReadUInt8sCIName>;
+
+using MemReadUInt16sSPSSig =
+    shared::SPSSequence<uint16_t>(shared::SPSSequence<shared::SPSExecutorAddr>);
+inline constexpr char MemReadUInt16sCIName[] = "orc_rt_ci_sps_mem_read_uint16s";
+using MemReadUInt16sProxySpec =
+    ProxySpec<rt::MemReadUInt16sProxy, MemReadUInt16sSPSSig,
+              MemReadUInt16sCIName>;
+
+using MemReadUInt32sSPSSig =
+    shared::SPSSequence<uint32_t>(shared::SPSSequence<shared::SPSExecutorAddr>);
+inline constexpr char MemReadUInt32sCIName[] = "orc_rt_ci_sps_mem_read_uint32s";
+using MemReadUInt32sProxySpec =
+    ProxySpec<rt::MemReadUInt32sProxy, MemReadUInt32sSPSSig,
+              MemReadUInt32sCIName>;
+
+using MemReadUInt64sSPSSig =
+    shared::SPSSequence<uint64_t>(shared::SPSSequence<shared::SPSExecutorAddr>);
+inline constexpr char MemReadUInt64sCIName[] = "orc_rt_ci_sps_mem_read_uint64s";
+using MemReadUInt64sProxySpec =
+    ProxySpec<rt::MemReadUInt64sProxy, MemReadUInt64sSPSSig,
+              MemReadUInt64sCIName>;
+
+using MemReadPointersSPSSig = shared::SPSSequence<shared::SPSExecutorAddr>(
+    shared::SPSSequence<shared::SPSExecutorAddr>);
+inline constexpr char MemReadPointersCIName[] =
+    "orc_rt_ci_sps_mem_read_pointers";
+using MemReadPointersProxySpec =
+    ProxySpec<rt::MemReadPointersProxy, MemReadPointersSPSSig,
+              MemReadPointersCIName>;
+
+using MemReadBuffersSPSSig = shared::SPSSequence<shared::SPSSequence<uint8_t>>(
+    shared::SPSSequence<shared::SPSExecutorAddrRange>);
+inline constexpr char MemReadBuffersCIName[] = "orc_rt_ci_sps_mem_read_buffers";
+using MemReadBuffersProxySpec =
+    ProxySpec<rt::MemReadBuffersProxy, MemReadBuffersSPSSig,
+              MemReadBuffersCIName>;
+
+using MemReadStringsSPSSig = shared::SPSSequence<shared::SPSString>(
+    shared::SPSSequence<shared::SPSExecutorAddr>);
+inline constexpr char MemReadStringsCIName[] = "orc_rt_ci_sps_mem_read_strings";
+using MemReadStringsProxySpec =
+    ProxySpec<rt::MemReadStringsProxy, MemReadStringsSPSSig,
+              MemReadStringsCIName>;
 
 } // namespace llvm::orc::rt::sps
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h
@@ -41,21 +41,6 @@ LLVM_ABI extern const char
     *ExecutorSharedMemoryMapperServiceDeinitializeWrapperName;
 LLVM_ABI extern const char *ExecutorSharedMemoryMapperServiceReleaseWrapperName;
 
-LLVM_ABI extern const char *MemoryWriteUInt8sWrapperName;
-LLVM_ABI extern const char *MemoryWriteUInt16sWrapperName;
-LLVM_ABI extern const char *MemoryWriteUInt32sWrapperName;
-LLVM_ABI extern const char *MemoryWriteUInt64sWrapperName;
-LLVM_ABI extern const char *MemoryWritePointersWrapperName;
-LLVM_ABI extern const char *MemoryWriteBuffersWrapperName;
-
-LLVM_ABI extern const char *MemoryReadUInt8sWrapperName;
-LLVM_ABI extern const char *MemoryReadUInt16sWrapperName;
-LLVM_ABI extern const char *MemoryReadUInt32sWrapperName;
-LLVM_ABI extern const char *MemoryReadUInt64sWrapperName;
-LLVM_ABI extern const char *MemoryReadPointersWrapperName;
-LLVM_ABI extern const char *MemoryReadBuffersWrapperName;
-LLVM_ABI extern const char *MemoryReadStringsWrapperName;
-
 LLVM_ABI extern const char *RegisterEHFrameSectionAllocActionName;
 LLVM_ABI extern const char *DeregisterEHFrameSectionAllocActionName;
 

--- a/llvm/lib/ExecutionEngine/Orc/InProcessEPC.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/InProcessEPC.cpp
@@ -170,23 +170,7 @@ Expected<std::unique_ptr<DylibManager>> InProcessEPC::createDefaultDylibMgr() {
 Expected<std::unique_ptr<MemoryAccess>>
 InProcessEPC::createDefaultMemoryAccess() {
   // FIXME: Should actually use in-process for this.
-  EPCGenericMemoryAccess::FuncAddrs FAs;
-  if (auto Err = getBootstrapSymbols(
-          {{FAs.WriteUInt8s, rt::MemoryWriteUInt8sWrapperName},
-           {FAs.WriteUInt16s, rt::MemoryWriteUInt16sWrapperName},
-           {FAs.WriteUInt32s, rt::MemoryWriteUInt32sWrapperName},
-           {FAs.WriteUInt64s, rt::MemoryWriteUInt64sWrapperName},
-           {FAs.WriteBuffers, rt::MemoryWriteBuffersWrapperName},
-           {FAs.WritePointers, rt::MemoryWritePointersWrapperName},
-           {FAs.ReadUInt8s, rt::MemoryReadUInt8sWrapperName},
-           {FAs.ReadUInt16s, rt::MemoryReadUInt16sWrapperName},
-           {FAs.ReadUInt32s, rt::MemoryReadUInt32sWrapperName},
-           {FAs.ReadUInt64s, rt::MemoryReadUInt64sWrapperName},
-           {FAs.ReadBuffers, rt::MemoryReadBuffersWrapperName},
-           {FAs.ReadStrings, rt::MemoryReadStringsWrapperName}}))
-    return std::move(Err);
-
-  return std::make_unique<EPCGenericMemoryAccess>(getExecutionSession(), FAs);
+  return EPCGenericMemoryAccess::Create(getExecutionSession());
 }
 
 Error InProcessEPC::disconnect() {

--- a/llvm/lib/ExecutionEngine/Orc/Shared/OrcRTBridge.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Shared/OrcRTBridge.cpp
@@ -43,34 +43,6 @@ const char *ExecutorSharedMemoryMapperServiceDeinitializeWrapperName =
 const char *ExecutorSharedMemoryMapperServiceReleaseWrapperName =
     "__llvm_orc_ExecutorSharedMemoryMapperService_Release";
 
-const char *MemoryWriteUInt8sWrapperName =
-    "__llvm_orc_bootstrap_mem_write_uint8s_wrapper";
-const char *MemoryWriteUInt16sWrapperName =
-    "__llvm_orc_bootstrap_mem_write_uint16s_wrapper";
-const char *MemoryWriteUInt32sWrapperName =
-    "__llvm_orc_bootstrap_mem_write_uint32s_wrapper";
-const char *MemoryWriteUInt64sWrapperName =
-    "__llvm_orc_bootstrap_mem_write_uint64s_wrapper";
-const char *MemoryWritePointersWrapperName =
-    "__llvm_orc_bootstrap_mem_write_pointers_wrapper";
-const char *MemoryWriteBuffersWrapperName =
-    "__llvm_orc_bootstrap_mem_write_buffers_wrapper";
-
-const char *MemoryReadUInt8sWrapperName =
-    "__llvm_orc_bootstrap_mem_read_uint8s_wrapper";
-const char *MemoryReadUInt16sWrapperName =
-    "__llvm_orc_bootstrap_mem_read_uint16s_wrapper";
-const char *MemoryReadUInt32sWrapperName =
-    "__llvm_orc_bootstrap_mem_read_uint32s_wrapper";
-const char *MemoryReadUInt64sWrapperName =
-    "__llvm_orc_bootstrap_mem_read_uint64s_wrapper";
-const char *MemoryReadPointersWrapperName =
-    "__llvm_orc_bootstrap_mem_read_pointers_wrapper";
-const char *MemoryReadBuffersWrapperName =
-    "__llvm_orc_bootstrap_mem_read_buffers_wrapper";
-const char *MemoryReadStringsWrapperName =
-    "__llvm_orc_bootstrap_mem_read_strings_wrapper";
-
 const char *RegisterEHFrameSectionAllocActionName =
     "llvm_orc_registerEHFrameAllocAction";
 const char *DeregisterEHFrameSectionAllocActionName =

--- a/llvm/lib/ExecutionEngine/Orc/SimpleRemoteEPC.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/SimpleRemoteEPC.cpp
@@ -86,23 +86,7 @@ SimpleRemoteEPC::createDefaultDylibMgr() {
 
 Expected<std::unique_ptr<MemoryAccess>>
 SimpleRemoteEPC::createDefaultMemoryAccess() {
-  EPCGenericMemoryAccess::FuncAddrs FAs;
-  if (auto Err = getBootstrapSymbols(
-          {{FAs.WriteUInt8s, rt::MemoryWriteUInt8sWrapperName},
-           {FAs.WriteUInt16s, rt::MemoryWriteUInt16sWrapperName},
-           {FAs.WriteUInt32s, rt::MemoryWriteUInt32sWrapperName},
-           {FAs.WriteUInt64s, rt::MemoryWriteUInt64sWrapperName},
-           {FAs.WriteBuffers, rt::MemoryWriteBuffersWrapperName},
-           {FAs.WritePointers, rt::MemoryWritePointersWrapperName},
-           {FAs.ReadUInt8s, rt::MemoryReadUInt8sWrapperName},
-           {FAs.ReadUInt16s, rt::MemoryReadUInt16sWrapperName},
-           {FAs.ReadUInt32s, rt::MemoryReadUInt32sWrapperName},
-           {FAs.ReadUInt64s, rt::MemoryReadUInt64sWrapperName},
-           {FAs.ReadBuffers, rt::MemoryReadBuffersWrapperName},
-           {FAs.ReadStrings, rt::MemoryReadStringsWrapperName}}))
-    return std::move(Err);
-
-  return std::make_unique<EPCGenericMemoryAccess>(getExecutionSession(), FAs);
+  return EPCGenericMemoryAccess::Create(getExecutionSession());
 }
 
 Error SimpleRemoteEPC::disconnect() {

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/OrcRTBootstrap.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/OrcRTBootstrap.cpp
@@ -157,36 +157,34 @@ runAsInt32Int32FunctionWrapper(const char *ArgData, size_t ArgSize) {
 }
 
 void addTo(StringMap<ExecutorAddr> &M) {
-  M[rt::MemoryWriteUInt8sWrapperName] = ExecutorAddr::fromPtr(
+  M[rt::sps::MemWriteUInt8sCIName] = ExecutorAddr::fromPtr(
       &writeUIntsWrapper<tpctypes::UInt8Write,
                          shared::SPSMemoryAccessUInt8Write>);
-  M[rt::MemoryWriteUInt16sWrapperName] = ExecutorAddr::fromPtr(
+  M[rt::sps::MemWriteUInt16sCIName] = ExecutorAddr::fromPtr(
       &writeUIntsWrapper<tpctypes::UInt16Write,
                          shared::SPSMemoryAccessUInt16Write>);
-  M[rt::MemoryWriteUInt32sWrapperName] = ExecutorAddr::fromPtr(
+  M[rt::sps::MemWriteUInt32sCIName] = ExecutorAddr::fromPtr(
       &writeUIntsWrapper<tpctypes::UInt32Write,
                          shared::SPSMemoryAccessUInt32Write>);
-  M[rt::MemoryWriteUInt64sWrapperName] = ExecutorAddr::fromPtr(
+  M[rt::sps::MemWriteUInt64sCIName] = ExecutorAddr::fromPtr(
       &writeUIntsWrapper<tpctypes::UInt64Write,
                          shared::SPSMemoryAccessUInt64Write>);
-  M[rt::MemoryWritePointersWrapperName] =
+  M[rt::sps::MemWritePointersCIName] =
       ExecutorAddr::fromPtr(&writePointersWrapper);
-  M[rt::MemoryWriteBuffersWrapperName] =
+  M[rt::sps::MemWriteBuffersCIName] =
       ExecutorAddr::fromPtr(&writeBuffersWrapper);
-  M[rt::MemoryReadUInt8sWrapperName] =
+  M[rt::sps::MemReadUInt8sCIName] =
       ExecutorAddr::fromPtr(&readUIntsWrapper<uint8_t>);
-  M[rt::MemoryReadUInt16sWrapperName] =
+  M[rt::sps::MemReadUInt16sCIName] =
       ExecutorAddr::fromPtr(&readUIntsWrapper<uint16_t>);
-  M[rt::MemoryReadUInt32sWrapperName] =
+  M[rt::sps::MemReadUInt32sCIName] =
       ExecutorAddr::fromPtr(&readUIntsWrapper<uint32_t>);
-  M[rt::MemoryReadUInt64sWrapperName] =
+  M[rt::sps::MemReadUInt64sCIName] =
       ExecutorAddr::fromPtr(&readUIntsWrapper<uint64_t>);
-  M[rt::MemoryReadPointersWrapperName] =
+  M[rt::sps::MemReadPointersCIName] =
       ExecutorAddr::fromPtr(&readPointersWrapper);
-  M[rt::MemoryReadBuffersWrapperName] =
-      ExecutorAddr::fromPtr(&readBuffersWrapper);
-  M[rt::MemoryReadStringsWrapperName] =
-      ExecutorAddr::fromPtr(&readStringsWrapper);
+  M[rt::sps::MemReadBuffersCIName] = ExecutorAddr::fromPtr(&readBuffersWrapper);
+  M[rt::sps::MemReadStringsCIName] = ExecutorAddr::fromPtr(&readStringsWrapper);
   M[rt::sps::CallMainCIName] = ExecutorAddr::fromPtr(&runAsMainWrapper);
   M[rt::sps::CallInt32VoidCIName] =
       ExecutorAddr::fromPtr(&runAsInt32VoidFunctionWrapper);

--- a/llvm/unittests/ExecutionEngine/Orc/EPCGenericMemoryAccessTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/EPCGenericMemoryAccessTest.cpp
@@ -8,7 +8,9 @@
 
 #include "OrcTestCommon.h"
 
+#include "llvm/ExecutionEngine/Orc/AbsoluteSymbols.h"
 #include "llvm/ExecutionEngine/Orc/EPCGenericMemoryAccess.h"
+#include "llvm/ExecutionEngine/Orc/RTBridge/SPS/ProxySpecs.h"
 #include "llvm/ExecutionEngine/Orc/SelfExecutorProcessControl.h"
 #include "llvm/Testing/Support/Error.h"
 
@@ -119,26 +121,48 @@ public:
     ES = std::make_unique<ExecutionSession>(
         cantFail(SelfExecutorProcessControl::Create()));
 
-    EPCGenericMemoryAccess::FuncAddrs FAs;
-    FAs.WriteUInt8s = ExecutorAddr::fromPtr(
-        &testWriteUInts<tpctypes::UInt8Write, SPSMemoryAccessUInt8Write>);
-    FAs.WriteUInt16s = ExecutorAddr::fromPtr(
-        &testWriteUInts<tpctypes::UInt16Write, SPSMemoryAccessUInt16Write>);
-    FAs.WriteUInt32s = ExecutorAddr::fromPtr(
-        &testWriteUInts<tpctypes::UInt32Write, SPSMemoryAccessUInt32Write>);
-    FAs.WriteUInt64s = ExecutorAddr::fromPtr(
-        &testWriteUInts<tpctypes::UInt64Write, SPSMemoryAccessUInt64Write>);
-    FAs.WritePointers = ExecutorAddr::fromPtr(&testWritePointers);
-    FAs.WriteBuffers = ExecutorAddr::fromPtr(&testWriteBuffers);
-    FAs.ReadUInt8s = ExecutorAddr::fromPtr(&testReadUInts<uint8_t>);
-    FAs.ReadUInt16s = ExecutorAddr::fromPtr(&testReadUInts<uint16_t>);
-    FAs.ReadUInt32s = ExecutorAddr::fromPtr(&testReadUInts<uint32_t>);
-    FAs.ReadUInt64s = ExecutorAddr::fromPtr(&testReadUInts<uint64_t>);
-    FAs.ReadPointers = ExecutorAddr::fromPtr(&testReadPointers);
-    FAs.ReadBuffers = ExecutorAddr::fromPtr(&testReadBuffers);
-    FAs.ReadStrings = ExecutorAddr::fromPtr(&testReadStrings);
+    // Register the test wrappers in the bootstrap JITDylib under the SPS
+    // controller-interface names, so that EPCGenericMemoryAccess::Create
+    // resolves its proxies to them.
+    namespace sps = rt::sps;
+    auto Exported = JITSymbolFlags::Exported;
+    cantFail(ES->getBootstrapJITDylib().define(absoluteSymbols(
+        {{ES->intern(sps::MemWriteUInt8sCIName),
+          {ExecutorAddr::fromPtr(&testWriteUInts<tpctypes::UInt8Write,
+                                                 SPSMemoryAccessUInt8Write>),
+           Exported}},
+         {ES->intern(sps::MemWriteUInt16sCIName),
+          {ExecutorAddr::fromPtr(&testWriteUInts<tpctypes::UInt16Write,
+                                                 SPSMemoryAccessUInt16Write>),
+           Exported}},
+         {ES->intern(sps::MemWriteUInt32sCIName),
+          {ExecutorAddr::fromPtr(&testWriteUInts<tpctypes::UInt32Write,
+                                                 SPSMemoryAccessUInt32Write>),
+           Exported}},
+         {ES->intern(sps::MemWriteUInt64sCIName),
+          {ExecutorAddr::fromPtr(&testWriteUInts<tpctypes::UInt64Write,
+                                                 SPSMemoryAccessUInt64Write>),
+           Exported}},
+         {ES->intern(sps::MemWritePointersCIName),
+          {ExecutorAddr::fromPtr(&testWritePointers), Exported}},
+         {ES->intern(sps::MemWriteBuffersCIName),
+          {ExecutorAddr::fromPtr(&testWriteBuffers), Exported}},
+         {ES->intern(sps::MemReadUInt8sCIName),
+          {ExecutorAddr::fromPtr(&testReadUInts<uint8_t>), Exported}},
+         {ES->intern(sps::MemReadUInt16sCIName),
+          {ExecutorAddr::fromPtr(&testReadUInts<uint16_t>), Exported}},
+         {ES->intern(sps::MemReadUInt32sCIName),
+          {ExecutorAddr::fromPtr(&testReadUInts<uint32_t>), Exported}},
+         {ES->intern(sps::MemReadUInt64sCIName),
+          {ExecutorAddr::fromPtr(&testReadUInts<uint64_t>), Exported}},
+         {ES->intern(sps::MemReadPointersCIName),
+          {ExecutorAddr::fromPtr(&testReadPointers), Exported}},
+         {ES->intern(sps::MemReadBuffersCIName),
+          {ExecutorAddr::fromPtr(&testReadBuffers), Exported}},
+         {ES->intern(sps::MemReadStringsCIName),
+          {ExecutorAddr::fromPtr(&testReadStrings), Exported}}})));
 
-    MemAccess = std::make_unique<EPCGenericMemoryAccess>(*ES, FAs);
+    MemAccess = cantFail(EPCGenericMemoryAccess::Create(*ES));
   }
 
   ~EPCGenericMemoryAccessTest() override { cantFail(ES->endSession()); }


### PR DESCRIPTION
Move EPCGenericMemoryAccess off ExecutionSession::callSPSWrapperAsync and onto rt::Proxy objects. The FuncAddrs struct (13 ExecutorAddrs) becomes Funcs (13 rt::Proxy members), and each access method collapses to a single proxy call: the ProxySpec's dispatch now handles argument serialization and the (Error, Result) -> Expected result plumbing that was previously open-coded in each method.

Funcs members are protocol-agnostic rt::Proxy values, so a client can populate a Funcs for a different protocol and pass it to the (public) constructor. A new static Create(ES) provides the SPS convenience path, resolving the proxies from the bootstrap JITDylib. The proxy types are named once as rt::Mem*Proxy aliases in Proxy.h (beside the existing Call*Proxy aliases) and reused by both the Funcs struct and the memory-access ProxySpecs added to RTBridge/SPS/ProxySpecs.h. InProcessEPC and SimpleRemoteEPC now just call EPCGenericMemoryAccess::Create.

The executor-side wrappers registered by OrcRTBootstrap move to the runtime's controller-interface names (orc_rt_ci_sps_mem_*), matching the SPS controller interface that Create resolves against, so the in-tree executor and controller agree on the same names. The now-dead Memory*WrapperName constants are removed from OrcRTBridge.