### PR TITLE
[DebugInfo] Do not stop after livedebugvars

### DIFF
--- a/llvm/test/CodeGen/X86/debug-spilled-snippet.mir
+++ b/llvm/test/CodeGen/X86/debug-spilled-snippet.mir
@@ -1,4 +1,4 @@
-# RUN: llc -mtriple i386 -start-before=greedy -stop-after=livedebugvars %s -o - | FileCheck %s
+# RUN: llc -mtriple i386 -start-before=greedy -stop-before=x86-asm-printer %s -o - | FileCheck %s
 
 # There should be multiple debug values for this variable after regalloc. The
 # value has been spilled, but we shouldn't lose track of the location because

--- a/llvm/test/DebugInfo/AArch64/dbg-value-i8.ll
+++ b/llvm/test/DebugInfo/AArch64/dbg-value-i8.ll
@@ -1,4 +1,4 @@
-; RUN: llc -stop-after=livedebugvars < %s | FileCheck %s
+; RUN: llc -stop-before=aarch64-asm-printer < %s | FileCheck %s
 ; ModuleID = 'debug_value-i8.bc'
 source_filename = "debug_value.c"
 target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"

--- a/llvm/test/DebugInfo/MSP430/sdagsplit-1.ll
+++ b/llvm/test/DebugInfo/MSP430/sdagsplit-1.ll
@@ -1,4 +1,4 @@
-; RUN: llc %s -stop-after=livedebugvars -o %t
+; RUN: llc %s -stop-before=msp430-asm-printer -o %t
 ; RUN: cat %t | FileCheck %s
 ;
 ; Test that we can emit debug info for large values that are split

--- a/llvm/test/DebugInfo/X86/bbjoin.ll
+++ b/llvm/test/DebugInfo/X86/bbjoin.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=x86_64-apple-macosx10.9.0 %s -stop-after=livedebugvars \
+; RUN: llc -mtriple=x86_64-apple-macosx10.9.0 %s -stop-before=x86-asm-printer \
 ; RUN:   -o - | FileCheck %s
 ; Generated from:
 ; void g(int *);

--- a/llvm/test/DebugInfo/X86/live-debug-vars-nodebug.ll
+++ b/llvm/test/DebugInfo/X86/live-debug-vars-nodebug.ll
@@ -5,10 +5,10 @@
 ; RUN:   -experimental-debug-variable-locations \
 ; RUN:   | FileCheck %s --check-prefix=EXPER-INPUT
 
-; RUN: llc %s -mtriple=x86_64-unknown-unknown -o - -stop-after=livedebugvars \
+; RUN: llc %s -mtriple=x86_64-unknown-unknown -o - -stop-before=x86-asm-printer \
 ; RUN:   | FileCheck %s --check-prefix=OUTPUT
 
-; RUN: llc %s -mtriple=x86_64-unknown-unknown -o - -stop-after=livedebugvars \
+; RUN: llc %s -mtriple=x86_64-unknown-unknown -o - -stop-before=x86-asm-printer \
 ; RUN:   -experimental-debug-variable-locations \
 ; RUN:   | FileCheck %s --check-prefix=OUTPUT
 

--- a/llvm/test/DebugInfo/X86/pr34545.ll
+++ b/llvm/test/DebugInfo/X86/pr34545.ll
@@ -1,9 +1,9 @@
 ; RUN: llc -O1 -filetype=asm -mtriple x86_64-unknown-linux-gnu -mcpu=x86-64 \
-; RUN:    -o - %s -stop-after=livedebugvars \
+; RUN:    -o - %s -stop-before=x86-asm-printer \
 ; RUN:    -experimental-debug-variable-locations=false \
 ; RUN: | FileCheck %s --check-prefixes=CHECK,VARLOCS
 ; RUN: llc -O1 -filetype=asm -mtriple x86_64-unknown-linux-gnu -mcpu=x86-64 \
-; RUN:    -o - %s -stop-after=livedebugvars \
+; RUN:    -o - %s -stop-before=x86-asm-printer \
 ; RUN:    -experimental-debug-variable-locations=true \
 ; RUN: | FileCheck %s --check-prefixes=CHECK,INSTRREF
 

--- a/llvm/test/DebugInfo/X86/sdag-combine.ll
+++ b/llvm/test/DebugInfo/X86/sdag-combine.ll
@@ -1,5 +1,5 @@
-; RUN: llc %s -stop-after=livedebugvars -o - -experimental-debug-variable-locations=false | FileCheck %s --check-prefix=CHECK
-; RUN: llc %s -stop-after=livedebugvars -o - -experimental-debug-variable-locations=true | FileCheck %s --check-prefix=INSTRREF
+; RUN: llc %s -stop-before=x86-asm-printer -o - -experimental-debug-variable-locations=false | FileCheck %s --check-prefix=CHECK
+; RUN: llc %s -stop-before=x86-asm-printer -o - -experimental-debug-variable-locations=true | FileCheck %s --check-prefix=INSTRREF
 source_filename = "/tmp/t.ll"
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-apple-macosx10.13"

--- a/llvm/test/DebugInfo/X86/sdag-legalize-multires.ll
+++ b/llvm/test/DebugInfo/X86/sdag-legalize-multires.ll
@@ -1,4 +1,4 @@
-; RUN: llc -O0 %s -stop-after=livedebugvars -o - | FileCheck %s
+; RUN: llc -O0 %s -stop-before=x86-asm-printer -o - | FileCheck %s
 ; This is a hand-crafted example modified after some Swift compiler output.
 ; Test that SelectionDAG legalization of DAG nodes with two results
 ; transfers debug info correctly.

--- a/llvm/test/DebugInfo/X86/sdagsplit-1.ll
+++ b/llvm/test/DebugInfo/X86/sdagsplit-1.ll
@@ -1,4 +1,4 @@
-; RUN: llc %s -stop-after=livedebugvars -o %t -experimental-debug-variable-locations=true
+; RUN: llc %s -stop-before=x86-asm-printer -o %t -experimental-debug-variable-locations=true
 ; RUN: cat %t | FileCheck %s
 ;
 ; Test that we can emit debug info for large values that are split


### PR DESCRIPTION
livedebugvars is an analysis. We can only -stop-after it inside the LegacyPM due to how the LegacyPM schedules analyses. We cannot stop-after it inside of the NewPM given analyses are dynamically requested within each pass. Instead, just stop before the asm printer given we're after the last livedebugvars analysis which happens pretty late in the pipeline and it doesn't seem like there's a vastly better spot.