### PR TITLE
[SlotIndexes] Use analysis block numbers (NFC)

### DIFF
--- a/llvm/include/llvm/CodeGen/SlotIndexes.h
+++ b/llvm/include/llvm/CodeGen/SlotIndexes.h
@@ -307,7 +307,7 @@ class raw_ostream;
     using Mi2IndexMap = DenseMap<const MachineInstr *, SlotIndex>;
     Mi2IndexMap mi2iMap;
 
-    /// MBBRanges - Map MBB number to (start, stop) indexes.
+    /// MBBRanges - Map analysis block number to (start, stop) indexes.
     SmallVector<std::pair<SlotIndex, SlotIndex>, 8> MBBRanges;
 
     /// Idx2MBBMap - Sorted list of pairs of index of first instruction
@@ -442,31 +442,15 @@ class raw_ostream;
       }
     }
 
-    /// Return the (start,end) range of the given basic block number.
-    const std::pair<SlotIndex, SlotIndex> &
-    getMBBRange(unsigned Num) const {
-      return MBBRanges[Num];
-    }
-
     /// Return the (start,end) range of the given basic block.
     const std::pair<SlotIndex, SlotIndex> &
     getMBBRange(const MachineBasicBlock *MBB) const {
-      return getMBBRange(MBB->getNumber());
-    }
-
-    /// Returns the first index in the given basic block number.
-    SlotIndex getMBBStartIdx(unsigned Num) const {
-      return getMBBRange(Num).first;
+      return MBBRanges[MBB->getAnalysisNumber()];
     }
 
     /// Returns the first index in the given basic block.
     SlotIndex getMBBStartIdx(const MachineBasicBlock *mbb) const {
       return getMBBRange(mbb).first;
-    }
-
-    /// Returns the index past the last valid index in the given basic block.
-    SlotIndex getMBBEndIdx(unsigned Num) const {
-      return getMBBRange(Num).second;
     }
 
     /// Returns the index past the last valid index in the given basic block.
@@ -630,9 +614,9 @@ class raw_ostream;
       SlotIndex startIdx(startEntry, SlotIndex::Slot_Block);
       SlotIndex endIdx(endEntry, SlotIndex::Slot_Block);
 
-      MBBRanges[prevMBB->getNumber()].second = startIdx;
+      MBBRanges[prevMBB->getAnalysisNumber()].second = startIdx;
 
-      assert(unsigned(mbb->getNumber()) == MBBRanges.size() &&
+      assert(unsigned(mbb->getAnalysisNumber()) == MBBRanges.size() &&
              "Blocks must be added in order");
       MBBRanges.push_back(std::make_pair(startIdx, endIdx));
       idx2MBBMap.push_back(IdxMBBPair(startIdx, mbb));

--- a/llvm/lib/CodeGen/InterferenceCache.cpp
+++ b/llvm/lib/CodeGen/InterferenceCache.cpp
@@ -129,8 +129,9 @@ bool InterferenceCache::Entry::valid(LiveIntervalUnion *LIUArray,
 }
 
 void InterferenceCache::Entry::update(unsigned MBBNum) {
+  MachineBasicBlock *MBB = MF->getBlockNumbered(MBBNum);
   SlotIndex Start, Stop;
-  std::tie(Start, Stop) = Indexes->getMBBRange(MBBNum);
+  std::tie(Start, Stop) = Indexes->getMBBRange(MBB);
 
   // Use advanceTo only when possible.
   if (PrevPos != Start) {
@@ -149,8 +150,7 @@ void InterferenceCache::Entry::update(unsigned MBBNum) {
     PrevPos = Start;
   }
 
-  MachineFunction::const_iterator MFI =
-      MF->getBlockNumbered(MBBNum)->getIterator();
+  MachineFunction::const_iterator MFI = MBB->getIterator();
   BlockInterference *BI = &Blocks[MBBNum];
   ArrayRef<SlotIndex> RegMaskSlots;
   ArrayRef<const uint32_t*> RegMaskBits;
@@ -206,7 +206,7 @@ void InterferenceCache::Entry::update(unsigned MBBNum) {
     BI = &Blocks[MBBNum];
     if (BI->Tag == Tag)
       return;
-    std::tie(Start, Stop) = Indexes->getMBBRange(MBBNum);
+    std::tie(Start, Stop) = Indexes->getMBBRange(&*MFI);
   }
 
   // Check for last interference in block.

--- a/llvm/lib/CodeGen/LiveRangeCalc.cpp
+++ b/llvm/lib/CodeGen/LiveRangeCalc.cpp
@@ -283,13 +283,14 @@ bool LiveRangeCalc::findReachingDefs(LiveRange &LR, MachineBasicBlock &UseMBB,
     assert(TheVNI != nullptr && TheVNI != &UndefVNI);
     LiveRangeUpdater Updater(&LR);
     for (unsigned BN : WorkList) {
+      MachineBasicBlock *MBB = MF->getBlockNumbered(BN);
       SlotIndex Start, End;
-      std::tie(Start, End) = Indexes->getMBBRange(BN);
+      std::tie(Start, End) = Indexes->getMBBRange(MBB);
       // Trim the live range in UseMBB.
       if (BN == UseMBBNum && Use.isValid())
         End = Use;
       else
-        Map[MF->getBlockNumbered(BN)] = LiveOutPair(TheVNI, nullptr);
+        Map[MBB] = LiveOutPair(TheVNI, nullptr);
       Updater.add(Start, End, TheVNI);
     }
     return true;

--- a/llvm/lib/CodeGen/RegAllocGreedy.cpp
+++ b/llvm/lib/CodeGen/RegAllocGreedy.cpp
@@ -764,7 +764,7 @@ bool RAGreedy::addSplitConstraints(InterferenceCache::Cursor Intf,
 
     // Interference for the live-in value.
     if (BI.LiveIn) {
-      if (Intf.first() <= Indexes->getMBBStartIdx(BC.Number)) {
+      if (Intf.first() <= Indexes->getMBBStartIdx(BI.MBB)) {
         BC.Entry = SpillPlacement::MustSpill;
         ++Ins;
       } else if (Intf.first() < BI.FirstInstr) {
@@ -844,9 +844,9 @@ bool RAGreedy::addThroughConstraints(InterferenceCache::Cursor Intf,
     Register Reg = SA->getParent().reg();
     auto InsertPt = MBB->SkipPHIsLabelsAndDebug(MBB->begin(), Reg);
     SlotIndex InsertIdx = InsertPt == MBB->end()
-                              ? Indexes->getMBBEndIdx(Number)
+                              ? Indexes->getMBBEndIdx(MBB)
                               : LIS->getInstructionIndex(*InsertPt);
-    if (Intf.first() <= Indexes->getMBBStartIdx(Number) ||
+    if (Intf.first() <= Indexes->getMBBStartIdx(MBB) ||
         SlotIndex::isEarlierInstr(Intf.first(), InsertIdx))
       BCS[B].Entry = SpillPlacement::MustSpill;
     else

--- a/llvm/lib/CodeGen/SlotIndexes.cpp
+++ b/llvm/lib/CodeGen/SlotIndexes.cpp
@@ -85,7 +85,7 @@ void SlotIndexes::analyze(MachineFunction &fn) {
          "MachineInstr -> Index mapping non-empty at initial numbering?");
 
   unsigned index = 0;
-  MBBRanges.resize(mf->getNumBlockIDs());
+  MBBRanges.resize(mf->getMaxAnalysisBlockNumber());
   idx2MBBMap.reserve(mf->size());
 
   indexList.push_back(*createEntry(nullptr, index));
@@ -110,8 +110,8 @@ void SlotIndexes::analyze(MachineFunction &fn) {
     // We insert one blank instructions between basic blocks.
     indexList.push_back(*createEntry(nullptr, index += SlotIndex::InstrDist));
 
-    MBBRanges[MBB.getNumber()].first = blockStartIndex;
-    MBBRanges[MBB.getNumber()].second = SlotIndex(&indexList.back(),
+    MBBRanges[MBB.getAnalysisNumber()].first = blockStartIndex;
+    MBBRanges[MBB.getAnalysisNumber()].second = SlotIndex(&indexList.back(),
                                                    SlotIndex::Slot_Block);
     idx2MBBMap.push_back(IdxMBBPair(blockStartIndex, &MBB));
   }
@@ -280,9 +280,9 @@ void SlotIndexes::print(raw_ostream &OS) const {
       OS << '\n';
   }
 
-  for (unsigned i = 0, e = MBBRanges.size(); i != e; ++i)
-    OS << "%bb." << i << "\t[" << MBBRanges[i].first << ';'
-       << MBBRanges[i].second << ")\n";
+  for (const MachineBasicBlock &MBB : *mf)
+    OS << printMBBReference(MBB) << "\t[" << getMBBStartIdx(&MBB) << ';'
+       << getMBBEndIdx(&MBB) << ")\n";
 }
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)

--- a/llvm/lib/CodeGen/SlotIndexes.cpp
+++ b/llvm/lib/CodeGen/SlotIndexes.cpp
@@ -111,8 +111,8 @@ void SlotIndexes::analyze(MachineFunction &fn) {
     indexList.push_back(*createEntry(nullptr, index += SlotIndex::InstrDist));
 
     MBBRanges[MBB.getAnalysisNumber()].first = blockStartIndex;
-    MBBRanges[MBB.getAnalysisNumber()].second = SlotIndex(&indexList.back(),
-                                                   SlotIndex::Slot_Block);
+    MBBRanges[MBB.getAnalysisNumber()].second =
+        SlotIndex(&indexList.back(), SlotIndex::Slot_Block);
     idx2MBBMap.push_back(IdxMBBPair(blockStartIndex, &MBB));
   }
 

--- a/llvm/lib/CodeGen/SplitKit.cpp
+++ b/llvm/lib/CodeGen/SplitKit.cpp
@@ -1676,8 +1676,9 @@ void SplitEditor::splitSingleBlock(const SplitAnalysis::BlockInfo &BI) {
 void SplitEditor::splitLiveThroughBlock(unsigned MBBNum,
                                         unsigned IntvIn, SlotIndex LeaveBefore,
                                         unsigned IntvOut, SlotIndex EnterAfter){
+  MachineBasicBlock *MBB = VRM.getMachineFunction().getBlockNumbered(MBBNum);
   SlotIndex Start, Stop;
-  std::tie(Start, Stop) = LIS.getSlotIndexes()->getMBBRange(MBBNum);
+  std::tie(Start, Stop) = LIS.getSlotIndexes()->getMBBRange(MBB);
 
   LLVM_DEBUG(dbgs() << "%bb." << MBBNum << " [" << Start << ';' << Stop
                     << ") intf " << LeaveBefore << '-' << EnterAfter
@@ -1688,8 +1689,6 @@ void SplitEditor::splitLiveThroughBlock(unsigned MBBNum,
   assert((!LeaveBefore || LeaveBefore < Stop) && "Interference after block");
   assert((!IntvIn || !LeaveBefore || LeaveBefore > Start) && "Impossible intf");
   assert((!EnterAfter || EnterAfter >= Start) && "Interference before block");
-
-  MachineBasicBlock *MBB = VRM.getMachineFunction().getBlockNumbered(MBBNum);
 
   if (!IntvOut) {
     LLVM_DEBUG(dbgs() << ", spill on entry.\n");


### PR DESCRIPTION
These numbers are more stable than normal block numbers allowing the analysis to be preserved across transformations that renumber block but do not otherwise change the CFG. 