### PR TITLE
[ORC] Generalize rt::Proxy result mapping to Error / Expected<T> callees

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/Proxy.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/Proxy.h
@@ -50,6 +50,40 @@ private:
 
 template <typename FnT> class Proxy;
 
+namespace detail {
+
+/// Maps a proxy's callee return type to the type delivered to the client, so a
+/// dispatch failure can always be reported alongside the result:
+///
+///          void -> Error
+///         Error -> Error
+///             T -> Expected<T>
+///   Expected<T> -> Expected<T>
+template <typename T> struct ProxyErrorRet {
+  using type = Expected<T>;
+};
+template <> struct ProxyErrorRet<void> {
+  using type = Error;
+};
+template <> struct ProxyErrorRet<Error> {
+  using type = Error;
+};
+template <typename T> struct ProxyErrorRet<Expected<T>> {
+  using type = Expected<T>;
+};
+
+/// Maps a proxy's client-facing return type to the std::promise value type used
+/// by the blocking call operator (working around MSVC's std::promise).
+template <typename T> struct ProxyRetPromise;
+template <> struct ProxyRetPromise<Error> {
+  using type = std::promise<MSVCPError>;
+};
+template <typename T> struct ProxyRetPromise<Expected<T>> {
+  using type = std::promise<MSVCPExpected<T>>;
+};
+
+} // namespace detail
+
 /// Runtime-agnostic interface for invoking an executor-side operation with the
 /// signature RetT(ArgTs...).
 ///
@@ -67,11 +101,11 @@ public:
   /// The result type produced by the executor-side function itself.
   using CalleeRetT = RetT;
 
-  /// The result type delivered to the client: Expected<RetT>, or Error when
-  /// RetT is void, so that dispatch failures can be reported alongside the
-  /// result.
-  using ErrorRetT =
-      std::conditional_t<std::is_void_v<RetT>, Error, Expected<RetT>>;
+  /// The result type delivered to the client: Error when the callee returns
+  /// void or Error, otherwise Expected<T> (with Expected<T> callees flattened
+  /// rather than nested), so that dispatch failures can be reported alongside
+  /// the result.
+  using ErrorRetT = typename detail::ProxyErrorRet<RetT>::type;
 
   using DispatchFn = void (*)(unique_function<void(ErrorRetT)> OnComplete,
                               ExecutionSession &ES, ExecutorAddr Callee,
@@ -110,9 +144,7 @@ public:
   /// Invoke the operation with the given Args, blocking until its result (or an
   /// error) is available.
   ErrorRetT operator()(ExecutionSession &ES, const ArgTs &...Args) const {
-    using PromiseValT = std::conditional_t<std::is_void_v<RetT>, MSVCPError,
-                                           MSVCPExpected<RetT>>;
-    std::promise<PromiseValT> P;
+    typename detail::ProxyRetPromise<ErrorRetT>::type P;
     auto F = P.get_future();
     this->operator()(
         [P = std::move(P)](ErrorRetT R) mutable { P.set_value(std::move(R)); },

--- a/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/SPS/ProxySpecs.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/SPS/ProxySpecs.h
@@ -32,8 +32,17 @@ class ProxySpec;
 template <typename ProxyT, typename SPSSigT, const char *DefaultName,
           typename RetT, typename... ArgTs>
 class ProxySpec<ProxyT, SPSSigT, DefaultName, RetT(ArgTs...)> {
+
   using CalleeRetT = typename ProxyT::CalleeRetT;
   using ErrorRetT = typename ProxyT::ErrorRetT;
+
+  static void consumeResult(Error &Err) { consumeError(std::move(Err)); }
+
+  template <typename T> static void consumeResult(T &V) {}
+
+  template <typename T> static void consumeResult(Expected<T> &E) {
+    consumeError(E.takeError());
+  }
 
 public:
   static constexpr const char *Name = DefaultName;
@@ -51,8 +60,12 @@ public:
           CalleeAddr,
           [OnComplete = std::move(OnComplete)](Error SerErr,
                                                CalleeRetT Result) mutable {
-            if (SerErr)
+            if (SerErr) {
+              consumeResult(Result);
               return OnComplete(std::move(SerErr));
+            }
+            // For an Error/Expected callee this forwards the callee's own
+            // result; for a plain value it is wrapped into Expected.
             return OnComplete(std::move(Result));
           },
           Args...);

--- a/llvm/unittests/ExecutionEngine/Orc/ProxyTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/ProxyTest.cpp
@@ -53,6 +53,41 @@ using AddOneProxy = rt::Proxy<int32_t(int32_t)>;
 constexpr AddOneProxy::DispatchFn AddOneDispatch =
     &inProcessDispatch<int32_t, int32_t>;
 
+// Callee returning Error: fails iff ShouldFail. Exercises the Error -> Error
+// mapping.
+Error maybeFail(bool ShouldFail) {
+  if (ShouldFail)
+    return make_error<StringError>("requested failure",
+                                   inconvertibleErrorCode());
+  return Error::success();
+}
+using MaybeFailProxy = rt::Proxy<Error(bool)>;
+constexpr MaybeFailProxy::DispatchFn MaybeFailDispatch =
+    &inProcessDispatch<Error, bool>;
+
+// Callee returning Expected<T>: fails iff Arg is negative, else returns Arg
+// + 1. Exercises the Expected<T> -> Expected<T> (flattening) mapping.
+Expected<int32_t> addOneOrFail(int32_t Arg) {
+  if (Arg < 0)
+    return make_error<StringError>("negative argument",
+                                   inconvertibleErrorCode());
+  return Arg + 1;
+}
+using AddOneOrFailProxy = rt::Proxy<Expected<int32_t>(int32_t)>;
+constexpr AddOneOrFailProxy::DispatchFn AddOneOrFailDispatch =
+    &inProcessDispatch<Expected<int32_t>, int32_t>;
+
+// The callee return type maps to the client-facing (ErrorRetT) type as:
+//          void -> Error
+//         Error -> Error
+//             T -> Expected<T>
+//   Expected<T> -> Expected<T>
+static_assert(std::is_same_v<rt::Proxy<void(int)>::ErrorRetT, Error>);
+static_assert(std::is_same_v<rt::Proxy<Error(int)>::ErrorRetT, Error>);
+static_assert(std::is_same_v<rt::Proxy<int(int)>::ErrorRetT, Expected<int>>);
+static_assert(
+    std::is_same_v<rt::Proxy<Expected<int>(int)>::ErrorRetT, Expected<int>>);
+
 // A minimal ProxySpec-shaped type (static dispatch + Name) for exercising the
 // proxyInit / buildProxies client path without depending on a protocol.
 struct AddOneSpec {
@@ -251,6 +286,49 @@ TEST(ProxyTest, BuildProxiesWeaklyReferencedAbsent) {
       ES, rt::proxyInit<AddOneSpec>(
               &Call, SymbolLookupFlags::WeaklyReferencedSymbol)));
   EXPECT_FALSE(static_cast<bool>(Call));
+
+  cantFail(ES.endSession());
+}
+
+// A callee returning Error delivers its result as Error (not Expected<Error>),
+// through both call operators, for both success and failure.
+TEST(ProxyTest, ErrorReturn) {
+  ExecutionSession ES(cantFail(SelfExecutorProcessControl::Create()));
+
+  MaybeFailProxy Call(MaybeFailDispatch, ExecutorAddr::fromPtr(maybeFail));
+
+  EXPECT_THAT_ERROR(Call(ES, false), Succeeded());
+  EXPECT_THAT_ERROR(Call(ES, true), Failed());
+
+  std::promise<MSVCPError> P;
+  auto F = P.get_future();
+  Call([&](Error E) { P.set_value(std::move(E)); }, ES, true);
+  EXPECT_THAT_ERROR(Error(F.get()), Failed());
+
+  cantFail(ES.endSession());
+}
+
+// A callee returning Expected<T> delivers its result flattened as Expected<T>
+// (not Expected<Expected<T>>): the callee's value or error passes through
+// directly.
+TEST(ProxyTest, ExpectedReturn) {
+  ExecutionSession ES(cantFail(SelfExecutorProcessControl::Create()));
+
+  AddOneOrFailProxy Call(AddOneOrFailDispatch,
+                         ExecutorAddr::fromPtr(addOneOrFail));
+
+  Expected<int32_t> R = Call(ES, 41);
+  ASSERT_THAT_EXPECTED(R, Succeeded());
+  EXPECT_EQ(*R, 42);
+
+  EXPECT_THAT_EXPECTED(Call(ES, -1), Failed());
+
+  std::promise<MSVCPExpected<int32_t>> P;
+  auto F = P.get_future();
+  Call([&](Expected<int32_t> RA) { P.set_value(std::move(RA)); }, ES, 41);
+  Expected<int32_t> RAsync = F.get();
+  ASSERT_THAT_EXPECTED(RAsync, Succeeded());
+  EXPECT_EQ(*RAsync, 42);
 
   cantFail(ES.endSession());
 }

--- a/llvm/unittests/ExecutionEngine/Orc/SPSProxiesTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/SPSProxiesTest.cpp
@@ -207,3 +207,74 @@ TEST(SPSProxiesTest, Int32VoidSync) {
 
   cantFail(ES.endSession());
 }
+
+// Executor-side wrapper returning Error: fails iff its bool argument is true.
+static CWrapperFunctionBuffer errorFnWrapper(const char *ArgData,
+                                             size_t ArgSize) {
+  return WrapperFunction<SPSError(bool)>::handle(
+             ArgData, ArgSize,
+             [](bool ShouldFail) -> Error {
+               if (ShouldFail)
+                 return make_error<StringError>("requested failure",
+                                                inconvertibleErrorCode());
+               return Error::success();
+             })
+      .release();
+}
+
+inline constexpr char ErrorFnCIName[] = "test_sps_error_fn";
+using ErrorFnProxy = rt::Proxy<Error(bool)>;
+using ErrorFnProxySpec =
+    sps::ProxySpec<ErrorFnProxy, SPSError(bool), ErrorFnCIName>;
+
+// Exercises the Error -> Error mapping across the SPS boundary, including a
+// failure reported by the executor-side function itself.
+TEST(SPSProxiesTest, ErrorReturn) {
+  ExecutionSession ES(cantFail(SelfExecutorProcessControl::Create()));
+
+  ErrorFnProxy Call(ErrorFnProxySpec::dispatch,
+                    ExecutorAddr::fromPtr(errorFnWrapper));
+
+  EXPECT_THAT_ERROR(Call(ES, false), Succeeded());
+  EXPECT_THAT_ERROR(Call(ES, true), Failed());
+
+  cantFail(ES.endSession());
+}
+
+// Executor-side wrapper returning Expected<int32_t>: fails iff its argument is
+// negative, else returns the argument plus one.
+static CWrapperFunctionBuffer expectedFnWrapper(const char *ArgData,
+                                                size_t ArgSize) {
+  return WrapperFunction<SPSExpected<int32_t>(int32_t)>::handle(
+             ArgData, ArgSize,
+             [](int32_t X) -> Expected<int32_t> {
+               if (X < 0)
+                 return make_error<StringError>("negative argument",
+                                                inconvertibleErrorCode());
+               return X + 1;
+             })
+      .release();
+}
+
+inline constexpr char ExpectedFnCIName[] = "test_sps_expected_fn";
+using ExpectedFnProxy = rt::Proxy<Expected<int32_t>(int32_t)>;
+using ExpectedFnProxySpec =
+    sps::ProxySpec<ExpectedFnProxy, SPSExpected<int32_t>(int32_t),
+                   ExpectedFnCIName>;
+
+// Exercises the Expected<T> -> Expected<T> (flattening) mapping across the SPS
+// boundary, for both the value and the executor-reported-error cases.
+TEST(SPSProxiesTest, ExpectedReturn) {
+  ExecutionSession ES(cantFail(SelfExecutorProcessControl::Create()));
+
+  ExpectedFnProxy Call(ExpectedFnProxySpec::dispatch,
+                       ExecutorAddr::fromPtr(expectedFnWrapper));
+
+  Expected<int32_t> R = Call(ES, 41);
+  ASSERT_THAT_EXPECTED(R, Succeeded());
+  EXPECT_EQ(*R, 42);
+
+  EXPECT_THAT_EXPECTED(Call(ES, -1), Failed());
+
+  cantFail(ES.endSession());
+}


### PR DESCRIPTION
Previously a Proxy's callee return type RetT mapped to the client-facing result (ErrorRetT) as: void -> Error, everything else -> Expected<RetT>. That could not represent a callee whose own result is fallible: an Error-returning callee became Expected<Error>, and an Expected<T> callee became Expected<Expected<T>>.

Generalize the mapping to:
  void        -> Error
  Error       -> Error
  T           -> Expected<T>
  Expected<T> -> Expected<T>   (flattened, not nested)

so a dispatch failure and the callee's own error collapse into a single Error/Expected<T>. The SPS ProxySpec dispatch handles the new cases, forwarding an Error/Expected callee's own result and, on a dispatch failure, discarding the (unproduced) placeholder result before reporting the error.

This is a pure generalization in support of upcoming work that needs to proxy APIs returning Error or Expected<T>.

Adds ProxyTest and SPSProxiesTest coverage for the Error and Expected<T> cases, plus static_asserts pinning the type mapping.