### PR TITLE
[C++20] [Modules] Don't set clang module as named module for module duplication check

### DIFF
--- a/clang/lib/Sema/SemaModule.cpp
+++ b/clang/lib/Sema/SemaModule.cpp
@@ -389,6 +389,11 @@ Sema::ActOnModuleDecl(SourceLocation StartLoc, SourceLocation ModuleLoc,
       else if (const ModuleFileName *FileName = M->getASTFileName())
         Diag(M->DefinitionLoc, diag::note_prev_module_definition_from_ast_file)
             << *FileName;
+      // A Clang module or a header unit cannot be used as the current named
+      // module while recovering from it. See clang/test/Modules/GH204632.cppm
+      // for an example.
+      if (!M->isNamedModule())
+        return nullptr;
       Mod = M;
       break;
     }

--- a/clang/test/Modules/GH204632.cppm
+++ b/clang/test/Modules/GH204632.cppm
@@ -1,0 +1,14 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: not %clang_cc1 -std=c++20 -fsyntax-only -fmodules \
+// RUN:   -fmodule-map-file=%t/module.modulemap %t/main.cpp 2>&1 | FileCheck %s
+
+// CHECK: main.cpp:1:15: error: redefinition of module 'M'
+// CHECK: module.modulemap:1:8: note: previously defined here
+// CHECK: 1 error generated.
+
+//--- module.modulemap
+module M {}
+
+//--- main.cpp
+export module M;


### PR DESCRIPTION
Close https://github.com/llvm/llvm-project/issues/204632

Note that the error message is already diagnosed. So we don't need to do additional thing here.