### PR TITLE
[AMDGPU][NFC] Explicitly narrow conversions in .td files

### DIFF
--- a/llvm/lib/Target/AMDGPU/FLATInstructions.td
+++ b/llvm/lib/Target/AMDGPU/FLATInstructions.td
@@ -2554,7 +2554,7 @@ defm : ScratchFLATLoadPats_D16 <SCRATCH_LOAD_SHORT_D16, load_d16_lo_private, v2f
 } // End OtherPredicates = [HasFlatScratchInsts,HasFlatScratchEnabled]
 
 def PrefetchLoc: SDNodeXForm<timm, [{
-  uint32_t V = N->getZExtValue();
+  uint32_t V = static_cast<uint32_t>(N->getZExtValue());
   V = (AMDGPU::CPol::SCOPE_MASK - (V & AMDGPU::CPol::SCOPE_MASK)) << AMDGPU::CPol::SCOPE_SHIFT;
   if (!Subtarget->hasSafeCUPrefetch())
     V = std::max(V, (uint32_t)AMDGPU::CPol::SCOPE_SE); // CU scope is unsafe

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.td
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.td
@@ -940,7 +940,7 @@ def VOP3PModsNegs : SDNodeXForm<timm, [{
 }]>;
 
 def VOP3PModsNegAbs : SDNodeXForm<timm, [{
-  unsigned Val = N->getZExtValue();
+  unsigned Val = static_cast<unsigned>(N->getZExtValue());
   unsigned Mods = SISrcMods::OP_SEL_1; // default: none
   if (Val == 1) // neg
     Mods ^= SISrcMods::NEG;
@@ -1015,7 +1015,7 @@ class build_vector_fpimm_pos_zero_v2<VTVec vec> : PatLeaf<
                      (vec.ElementType fpimm_pos_zero)))>;
 
 def MFMALdScaleXForm : SDNodeXForm<timm, [{
-  unsigned Val = N->getZExtValue();
+  unsigned Val = static_cast<unsigned>(N->getZExtValue());
   unsigned New = 0;
   if (Val & 0x1)
     New |= SISrcMods::OP_SEL_0;

--- a/llvm/lib/Target/AMDGPU/SIInstructions.td
+++ b/llvm/lib/Target/AMDGPU/SIInstructions.td
@@ -4402,11 +4402,11 @@ defm : BFMPatterns <i32, DivergentBinFrag<shl>, DivergentBinFrag<add>, V_BFM_B32
 // Bitfield extract patterns
 
 def IMMZeroBasedBitfieldMask : ImmLeaf <i32, [{
-  return isMask_32(Imm);
+  return isMask_32(static_cast<uint32_t>(Imm));
 }]>;
 
 def IMMZeroBasedBitfieldMask16 : ImmLeaf <i16, [{
-  return isUInt<16>(Imm) && isMask_32(Imm);
+  return isUInt<16>(Imm) && isMask_32(static_cast<uint32_t>(Imm));
 }]>;
 
 def IMMCountTrailingOnes : SDNodeXForm<imm, [{

--- a/llvm/lib/Target/AMDGPU/SMInstructions.td
+++ b/llvm/lib/Target/AMDGPU/SMInstructions.td
@@ -874,7 +874,7 @@ def SMRDBufferSgprImm : ComplexPattern<iPTR, 2, "SelectSMRDBufferSgprImm">;
 class SMRDAlignedLoadPat<PatFrag Op> : PatFrag <(ops node:$ptr), (Op node:$ptr), [{
   // Returns true if it is a single dword load or naturally aligned multi-dword load.
   LoadSDNode *Ld = cast<LoadSDNode>(N);
-  unsigned Size = Ld->getMemoryVT().getStoreSize();
+  TypeSize Size = Ld->getMemoryVT().getStoreSize();
   return Size <= 4 || Ld->getAlign().value() >= Size;
 }]> {
   let GISelPredicateCode = [{

--- a/llvm/lib/Target/AMDGPU/VOP3Instructions.td
+++ b/llvm/lib/Target/AMDGPU/VOP3Instructions.td
@@ -733,12 +733,12 @@ class VOP3_CVT_SR_F8_ByteSel_Profile<ValueType SrcVT, bit _HasClamp = 0> :
 }
 
 def IsPow2Plus1: PatLeaf<(i32 imm), [{
-  uint32_t V = N->getZExtValue();
+  uint32_t V = static_cast<uint32_t>(N->getZExtValue());
   return isPowerOf2_32(V - 1);
 }]>;
 
 def Log2_32: SDNodeXForm<imm, [{
-  uint32_t V = N->getZExtValue();
+  uint32_t V = static_cast<uint32_t>(N->getZExtValue());
   return CurDAG->getTargetConstant(Log2_32(V - 1), SDLoc(N), MVT::i32);
 }]>;
 
@@ -1145,7 +1145,7 @@ def gi_opsel_i1timm : GICustomOperandRenderer<"renderOpSelTImm">,
   GISDNodeXFormEquiv<opsel_i1timm>;
 
 class SrcAndDstSelToOpSelXForm<int modifier_idx, bit dest_sel> : SDNodeXForm<timm, [{
-  unsigned Val = N->getZExtValue();
+  unsigned Val = static_cast<unsigned>(N->getZExtValue());
   unsigned New = 0;
   if (}] # modifier_idx # [{ == 0) {
     New = (}] # dest_sel # [{ == 1) ? ((Val & 0x1) ? (SISrcMods::OP_SEL_0 | SISrcMods::DST_OP_SEL) : SISrcMods::DST_OP_SEL)
@@ -1195,7 +1195,7 @@ def gi_SrcSelToOpSelXForm : GICustomOperandRenderer<"renderSrcSelToOpSelXForm">,
   GISDNodeXFormEquiv<SrcSelToOpSelXForm>;
 
 def DstSelToOpSel3XForm : SDNodeXForm<timm, [{
-  uint32_t V = N->getZExtValue();
+  uint32_t V = static_cast<uint32_t>(N->getZExtValue());
   return CurDAG->getTargetConstant(
       (V & 0x2) ? SISrcMods::DST_OP_SEL : SISrcMods::NONE,
       SDLoc(N), MVT::i32);


### PR DESCRIPTION
For context, see https://github.com/llvm/llvm-project/issues/215213

This patch fixes MSVC warning C4244 ("possible loss of data") reported in the generated tables `AMDGPUGenDAGISel.inc` and `AMDGPUGenGlobalISel.inc`. 

Assisted-by: Claude <noreply@anthropic.com>