### PR TITLE
[AMDGPU][NFC] Explicitly narrow conversions in AMDGPUBaseInfo

### DIFF
--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -313,8 +313,9 @@ unsigned getCompletionActionImplicitArgPosition(unsigned CodeObjectVersion) {
 
 int getMIMGOpcode(unsigned BaseOpcode, unsigned MIMGEncoding,
                   unsigned VDataDwords, unsigned VAddrDwords) {
-  const MIMGInfo *Info =
-      getMIMGOpcodeHelper(BaseOpcode, MIMGEncoding, VDataDwords, VAddrDwords);
+  const MIMGInfo *Info = getMIMGOpcodeHelper(BaseOpcode, MIMGEncoding,
+                                             static_cast<uint8_t>(VDataDwords),
+                                             static_cast<uint8_t>(VAddrDwords));
   return Info ? Info->Opcode : -1;
 }
 
@@ -325,9 +326,9 @@ const MIMGBaseOpcodeInfo *getMIMGBaseOpcode(unsigned Opc) {
 
 int getMaskedMIMGOp(unsigned Opc, unsigned NewChannels) {
   const MIMGInfo *OrigInfo = getMIMGInfo(Opc);
-  const MIMGInfo *NewInfo =
-      getMIMGOpcodeHelper(OrigInfo->BaseOpcode, OrigInfo->MIMGEncoding,
-                          NewChannels, OrigInfo->VAddrDwords);
+  const MIMGInfo *NewInfo = getMIMGOpcodeHelper(
+      OrigInfo->BaseOpcode, OrigInfo->MIMGEncoding,
+      static_cast<uint8_t>(NewChannels), OrigInfo->VAddrDwords);
   return NewInfo ? NewInfo->Opcode : -1;
 }
 
@@ -487,8 +488,8 @@ int getMTBUFBaseOpcode(unsigned Opc) {
 }
 
 int getMTBUFOpcode(unsigned BaseOpc, unsigned Elements) {
-  const MTBUFInfo *Info =
-      getMTBUFInfoFromBaseOpcodeAndElements(BaseOpc, Elements);
+  const MTBUFInfo *Info = getMTBUFInfoFromBaseOpcodeAndElements(
+      BaseOpc, static_cast<uint8_t>(Elements));
   return Info ? Info->Opcode : -1;
 }
 
@@ -518,8 +519,8 @@ int getMUBUFBaseOpcode(unsigned Opc) {
 }
 
 int getMUBUFOpcode(unsigned BaseOpc, unsigned Elements) {
-  const MUBUFInfo *Info =
-      getMUBUFInfoFromBaseOpcodeAndElements(BaseOpc, Elements);
+  const MUBUFInfo *Info = getMUBUFInfoFromBaseOpcodeAndElements(
+      BaseOpc, static_cast<uint8_t>(Elements));
   return Info ? Info->Opcode : -1;
 }
 
@@ -701,7 +702,7 @@ CanBeVOPD getCanBeVOPD(unsigned Opc, unsigned EncodingFamily, bool VOPD3) {
     return {false, false};
   unsigned Key =
       (Info->VOPDOp << 5) | (EncodingFamily << 1) | (VOPD3 ? 1u : 0u);
-  const VOPDXYInfo *XYInfo = getVOPDXYInfo(Key);
+  const VOPDXYInfo *XYInfo = getVOPDXYInfo(static_cast<uint16_t>(Key));
   if (!XYInfo)
     return {false, false};
   return {XYInfo->IsX, XYInfo->IsY};
@@ -888,16 +889,17 @@ int getVOPDFull(unsigned OpX, unsigned OpY, unsigned EncodingFamily,
                 bool VOPD3) {
   bool IsConvertibleToBitOp = VOPD3 ? getBitOp2(OpY) : 0;
   OpY = IsConvertibleToBitOp ? (unsigned)AMDGPU::V_BITOP3_B32_e64 : OpY;
-  const VOPDInfo *Info =
-      getVOPDInfoFromComponentOpcodes(OpX, OpY, EncodingFamily, VOPD3);
+  const VOPDInfo *Info = getVOPDInfoFromComponentOpcodes(
+      static_cast<uint8_t>(OpX), static_cast<uint8_t>(OpY),
+      static_cast<uint8_t>(EncodingFamily), VOPD3);
   return Info ? Info->Opcode : -1;
 }
 
 std::pair<unsigned, unsigned> getVOPDComponents(unsigned VOPDOpcode) {
   const VOPDInfo *Info = getVOPDOpcodeHelper(VOPDOpcode);
   assert(Info);
-  const auto *OpX = getVOPDBaseFromComponent(Info->OpX);
-  const auto *OpY = getVOPDBaseFromComponent(Info->OpY);
+  const auto *OpX = getVOPDBaseFromComponent(static_cast<uint8_t>(Info->OpX));
+  const auto *OpY = getVOPDBaseFromComponent(static_cast<uint8_t>(Info->OpY));
   assert(OpX && OpY);
   return {OpX->BaseVOP, OpY->BaseVOP};
 }
@@ -1979,7 +1981,7 @@ static int encodeCustomOperandVal(const CustomOperandVal &Op,
                                   int64_t InputVal) {
   if (InputVal < 0 || InputVal > Op.Max)
     return OPR_VAL_INVALID;
-  return Op.encode(InputVal);
+  return Op.encode(static_cast<unsigned>(InputVal));
 }
 
 static int encodeCustomOperand(const CustomOperandVal *Opr, int Size,
@@ -2405,7 +2407,7 @@ bool msgSupportsStream(int64_t MsgId, int64_t OpId,
 
 void decodeMsg(unsigned Val, uint16_t &MsgId, uint16_t &OpId,
                uint16_t &StreamId, const MCSubtargetInfo &STI) {
-  MsgId = Val & getMsgIdMask(STI);
+  MsgId = static_cast<uint16_t>(Val & getMsgIdMask(STI));
   if (isGFX11Plus(STI)) {
     OpId = 0;
     StreamId = 0;
@@ -2453,7 +2455,8 @@ bool msgDoesNotUseM0(int64_t MsgId, const MCSubtargetInfo &STI) {
 //===----------------------------------------------------------------------===//
 
 unsigned getInitialPSInputAddr(const Function &F) {
-  return F.getFnAttributeAsParsedInteger("InitialPSInputAddr", 0);
+  return static_cast<unsigned>(
+      F.getFnAttributeAsParsedInteger("InitialPSInputAddr", 0));
 }
 
 bool getHasColorExport(const Function &F) {
@@ -2468,8 +2471,8 @@ bool getHasDepthExport(const Function &F) {
 }
 
 unsigned getDynamicVGPRBlockSize(const Function &F) {
-  unsigned BlockSize =
-      F.getFnAttributeAsParsedInteger("amdgpu-dynamic-vgpr-block-size", 0);
+  unsigned BlockSize = static_cast<unsigned>(
+      F.getFnAttributeAsParsedInteger("amdgpu-dynamic-vgpr-block-size", 0));
 
   if (BlockSize == 16 || BlockSize == 32)
     return BlockSize;
@@ -3548,17 +3551,17 @@ convertSetRegImmToVgprMSBs(unsigned Imm, unsigned Simm16,
 std::optional<unsigned> convertSetRegImmToVgprMSBs(const MachineInstr &MI,
                                                    bool HasSetregVGPRMSBFixup) {
   assert(MI.getOpcode() == AMDGPU::S_SETREG_IMM32_B32);
-  return convertSetRegImmToVgprMSBs(MI.getOperand(0).getImm(),
-                                    MI.getOperand(1).getImm(),
-                                    HasSetregVGPRMSBFixup);
+  return convertSetRegImmToVgprMSBs(
+      static_cast<unsigned>(MI.getOperand(0).getImm()),
+      static_cast<unsigned>(MI.getOperand(1).getImm()), HasSetregVGPRMSBFixup);
 }
 
 std::optional<unsigned> convertSetRegImmToVgprMSBs(const MCInst &MI,
                                                    bool HasSetregVGPRMSBFixup) {
   assert(MI.getOpcode() == AMDGPU::S_SETREG_IMM32_B32_gfx12);
-  return convertSetRegImmToVgprMSBs(MI.getOperand(0).getImm(),
-                                    MI.getOperand(1).getImm(),
-                                    HasSetregVGPRMSBFixup);
+  return convertSetRegImmToVgprMSBs(
+      static_cast<unsigned>(MI.getOperand(0).getImm()),
+      static_cast<unsigned>(MI.getOperand(1).getImm()), HasSetregVGPRMSBFixup);
 }
 
 std::pair<const AMDGPU::OpName *, const AMDGPU::OpName *>

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
@@ -354,7 +354,9 @@ struct EncodingField {
   constexpr EncodingField(ValueType Value) : Value(Value) {}
 
   constexpr uint64_t encode() const { return Value; }
-  static ValueType decode(uint64_t Encoded) { return Encoded; }
+  static ValueType decode(uint64_t Encoded) {
+    return static_cast<ValueType>(Encoded);
+  }
 };
 
 // Represents a single bit in an encoded value.
@@ -374,7 +376,7 @@ template <typename... Fields> struct EncodingFields {
 };
 
 LLVM_READONLY
-inline bool hasNamedOperand(uint64_t Opcode, OpName NamedIdx) {
+inline bool hasNamedOperand(uint32_t Opcode, OpName NamedIdx) {
   return getNamedOperandIdx(Opcode, NamedIdx) != -1;
 }
 
@@ -1181,7 +1183,9 @@ using HwregOffset = EncodingField<10, 6>;
 struct HwregSize : EncodingField<15, 11, 32> {
   using EncodingField::EncodingField;
   constexpr uint64_t encode() const { return Value - 1; }
-  static ValueType decode(uint64_t Encoded) { return Encoded + 1; }
+  static ValueType decode(uint64_t Encoded) {
+    return static_cast<ValueType>(Encoded + 1);
+  }
 };
 
 using HwregEncoding = EncodingFields<HwregId, HwregOffset, HwregSize>;


### PR DESCRIPTION
For context, see https://github.com/llvm/llvm-project/issues/215213

This patch handles the following cases:

EncodingField::decode takes a uint64_t argument and returns it as a narrow
ValueType. Add a static_cast to make the existing narrowing conversion explicit.
The one line at AMDGPUBaseInfo.h:357 is diagnosed once per template
instantiation of EncodingField, all from that single source location;
HwregSize::decode overrides it and is a second such location.

Change the hasNamedOperand parameter Opcode from uint64_t to uint32_t to match
the type of getNamedOperandIdx, which it immediately forwards to. Every caller
already passes an unsigned opcode, so no call site changes and no new conversion
appears at any of them.

The searchable-table lookups generated into AMDGPUGenSearchableTables.inc take
uint8_t/uint16_t key parameters, while the hand-written wrappers around them
take unsigned. Add explicit narrowing conversions at the call. One source line
can hold several such arguments -- getVOPDInfoFromComponentOpcodes alone needs
three -- so the number of casts is larger than the number of warnings. The keys
are opcode enumerators, encoding-family numbers and element counts, all bounded
well below the width of the key type, so this is NFC.

MachineOperand::getImm() and MCOperand::getImm() return int64_t and are passed
to helpers taking unsigned. Add a static_cast to make the existing narrowing
conversion explicit. The operands are S_SETREG_IMM32_B32 immediates, which the
assert on the line above pins to that opcode and which the ISA defines as 32-bit
and 16-bit fields.

Function::getFnAttributeAsParsedInteger returns uint64_t and is assigned to
32-bit locals in getInitialPSInputAddr and getDynamicVGPRBlockSize. Add a
static_cast to make the existing narrowing conversion explicit.

Widening those two return types to 64 bits was considered and rejected. It would
relocate the narrowing rather than remove it, and the narrow type is the correct
one in both cases. getInitialPSInputAddr feeds
SIMachineFunctionInfo::PSInputAddr, which is unsigned, is serialised through
MIR as unsigned, and models the 32-bit SPI_PS_INPUT_ADDR register.
getDynamicVGPRBlockSize is immediately compared against 16 and 32 and returns 0
for anything else.

This fixes 19 instances of MSVC warning C4244 ("possible loss of data") in
llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.{cpp,h}.

Assisted-by: Claude <noreply@anthropic.com>
