### PR TITLE
[AMDGPU][NFC] Explicitly narrow conversions in subtarget and analysis passes

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUHWEvents.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUHWEvents.cpp
@@ -166,7 +166,8 @@ static HWEvents getEventsForImpl(const MachineInstr &Inst,
   }
 
   if (SIInstrInfo::isEXP(Inst)) {
-    unsigned Imm = TII.getNamedOperand(Inst, AMDGPU::OpName::tgt)->getImm();
+    unsigned Imm = static_cast<unsigned>(
+        TII.getNamedOperand(Inst, AMDGPU::OpName::tgt)->getImm());
     if (Imm >= AMDGPU::Exp::ET_PARAM0 && Imm <= AMDGPU::Exp::ET_PARAM31)
       return HWEvents::EXP_PARAM_ACCESS;
     if (Imm >= AMDGPU::Exp::ET_POS0 && Imm <= AMDGPU::Exp::ET_POS_LAST)

--- a/llvm/lib/Target/AMDGPU/AMDGPUMachineModuleInfo.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUMachineModuleInfo.h
@@ -125,9 +125,9 @@ public:
         [&](SyncScope::ID SSID) -> std::optional<std::pair<unsigned, bool>> {
       for (auto [I, Cross, One] : llvm::enumerate(CrossAS, OneAS)) {
         if (Cross == SSID)
-          return std::make_pair(I, false);
+          return std::make_pair(static_cast<unsigned>(I), false);
         if (One == SSID)
-          return std::make_pair(I, true);
+          return std::make_pair(static_cast<unsigned>(I), true);
       }
       return std::nullopt;
     };

--- a/llvm/lib/Target/AMDGPU/AMDGPUNextUseAnalysis.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUNextUseAnalysis.cpp
@@ -675,7 +675,8 @@ private:
   InstrIdTy calcSize(const MachineBasicBlock *BB) const {
     InstrIdTy Size = BB->size();
     if (!Cfg.CountPhis)
-      Size -= std::distance(BB->begin(), BB->getFirstNonPHI());
+      Size -= static_cast<InstrIdTy>(
+          std::distance(BB->begin(), BB->getFirstNonPHI()));
     return Size;
   }
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUPerfHintAnalysis.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPerfHintAnalysis.cpp
@@ -221,7 +221,8 @@ AMDGPUPerfHintAnalysis::FuncInfo *AMDGPUPerfHint::visit(const Function &F) {
     unsigned UsedGlobalLoadsInBB = 0;
     for (auto &I : B) {
       if (const Type *Ty = getMemoryInstrPtrAndType(&I).second) {
-        unsigned Size = divideCeil(Ty->getPrimitiveSizeInBits(), 32);
+        unsigned Size =
+            static_cast<unsigned>(divideCeil(Ty->getPrimitiveSizeInBits(), 32));
         // TODO: Check if the global load and its user are close to each other
         // instead (Or do this analysis in GCNSchedStrategy?).
         if (isGlobalLoadUsedInBB(I))
@@ -267,7 +268,8 @@ AMDGPUPerfHintAnalysis::FuncInfo *AMDGPUPerfHint::visit(const Function &F) {
     }
 
     if (!FI.HasDenseGlobalMemAcc) {
-      unsigned GlobalMemAccPercentage = UsedGlobalLoadsInBB * 100 / B.size();
+      unsigned GlobalMemAccPercentage =
+          static_cast<unsigned>(UsedGlobalLoadsInBB * 100 / B.size());
       if (GlobalMemAccPercentage > 50) {
         LLVM_DEBUG(dbgs() << "[HasDenseGlobalMemAcc] Set to true since "
                           << B.getName() << " has " << GlobalMemAccPercentage

--- a/llvm/lib/Target/AMDGPU/AMDGPUSubtarget.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUSubtarget.cpp
@@ -231,7 +231,8 @@ AMDGPUSubtarget::getReqdWorkGroupSize(const Function &Kernel,
                                       unsigned Dim) const {
   auto *Node = Kernel.getMetadata("reqd_work_group_size");
   if (Node && Node->getNumOperands() == 3)
-    return mdconst::extract<ConstantInt>(Node->getOperand(Dim))->getZExtValue();
+    return static_cast<unsigned>(
+        mdconst::extract<ConstantInt>(Node->getOperand(Dim))->getZExtValue());
   return std::nullopt;
 }
 
@@ -240,12 +241,12 @@ bool AMDGPUSubtarget::hasWavefrontsEvenlySplittingXDim(
   auto *Node = F.getMetadata("reqd_work_group_size");
   if (!Node || Node->getNumOperands() != 3)
     return false;
-  unsigned XLen =
-      mdconst::extract<ConstantInt>(Node->getOperand(0))->getZExtValue();
-  unsigned YLen =
-      mdconst::extract<ConstantInt>(Node->getOperand(1))->getZExtValue();
-  unsigned ZLen =
-      mdconst::extract<ConstantInt>(Node->getOperand(2))->getZExtValue();
+  unsigned XLen = static_cast<unsigned>(
+      mdconst::extract<ConstantInt>(Node->getOperand(0))->getZExtValue());
+  unsigned YLen = static_cast<unsigned>(
+      mdconst::extract<ConstantInt>(Node->getOperand(1))->getZExtValue());
+  unsigned ZLen = static_cast<unsigned>(
+      mdconst::extract<ConstantInt>(Node->getOperand(2))->getZExtValue());
 
   bool Is1D = YLen <= 1 && ZLen <= 1;
   bool IsXLargeEnough =
@@ -361,8 +362,8 @@ unsigned AMDGPUSubtarget::getImplicitArgNumBytes(const Function &F) const {
   const Module *M = F.getParent();
   unsigned NBytes =
       AMDGPU::getAMDHSACodeObjectVersion(*M) >= AMDGPU::AMDHSA_COV5 ? 256 : 56;
-  return F.getFnAttributeAsParsedInteger("amdgpu-implicitarg-num-bytes",
-                                         NBytes);
+  return static_cast<unsigned>(
+      F.getFnAttributeAsParsedInteger("amdgpu-implicitarg-num-bytes", NBytes));
 }
 
 uint64_t AMDGPUSubtarget::getExplicitKernArgSize(const Function &F,
@@ -409,7 +410,7 @@ unsigned AMDGPUSubtarget::getKernArgSegmentSize(const Function &F,
   }
 
   // Being able to dereference past the end is useful for emitting scalar loads.
-  return alignTo(TotalSize, 4);
+  return static_cast<unsigned>(alignTo(TotalSize, 4));
 }
 
 AMDGPUDwarfFlavour AMDGPUSubtarget::getAMDGPUDwarfFlavour() const {

--- a/llvm/lib/Target/AMDGPU/GCNSubtarget.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSubtarget.cpp
@@ -540,8 +540,8 @@ unsigned GCNSubtarget::getBaseMaxNumSGPRs(
 
   // Check if maximum number of SGPRs was explicitly requested using
   // "amdgpu-num-sgpr" attribute.
-  unsigned Requested =
-      F.getFnAttributeAsParsedInteger("amdgpu-num-sgpr", MaxNumSGPRs);
+  unsigned Requested = static_cast<unsigned>(
+      F.getFnAttributeAsParsedInteger("amdgpu-num-sgpr", MaxNumSGPRs));
 
   if (Requested != MaxNumSGPRs) {
     // Make sure requested value does not violate subtarget's specifications.
@@ -621,7 +621,8 @@ unsigned GCNSubtarget::getBaseMaxNumVGPRs(
   // Check if maximum number of VGPRs was explicitly requested using
   // "amdgpu-num-vgpr" attribute.
 
-  unsigned Requested = F.getFnAttributeAsParsedInteger("amdgpu-num-vgpr", Max);
+  unsigned Requested = static_cast<unsigned>(
+      F.getFnAttributeAsParsedInteger("amdgpu-num-vgpr", Max));
   if (Requested != Max && hasGFX90AInsts())
     Requested *= 2;
 
@@ -710,8 +711,8 @@ GCNSubtarget::getMaxNumVectorRegs(const Function &F) const {
 static const MachineOperand *
 getVOP3PSourceModifierFromOpIdx(const MachineInstr &UseI, int UseOpIdx,
                                 const SIInstrInfo &InstrInfo) {
-  AMDGPU::OpName UseName =
-      AMDGPU::getOperandIdxName(UseI.getOpcode(), UseOpIdx);
+  AMDGPU::OpName UseName = AMDGPU::getOperandIdxName(
+      UseI.getOpcode(), static_cast<int16_t>(UseOpIdx));
   switch (UseName) {
   case AMDGPU::OpName::src0:
     return InstrInfo.getNamedOperand(UseI, AMDGPU::OpName::src0_modifiers);
@@ -887,8 +888,8 @@ unsigned GCNSubtarget::getNSAThreshold(const MachineFunction &MF) const {
   if (NSAThreshold.getNumOccurrences() > 0)
     return std::max(NSAThreshold.getValue(), 2u);
 
-  int Value = MF.getFunction().getFnAttributeAsParsedInteger(
-      "amdgpu-nsa-threshold", -1);
+  int Value = static_cast<int>(MF.getFunction().getFnAttributeAsParsedInteger(
+      "amdgpu-nsa-threshold", -1));
   if (Value > 0)
     return std::max(Value, 2);
 

--- a/llvm/lib/Target/AMDGPU/MCA/AMDGPUCustomBehaviour.cpp
+++ b/llvm/lib/Target/AMDGPU/MCA/AMDGPUCustomBehaviour.cpp
@@ -47,7 +47,7 @@ void AMDGPUInstrPostProcess::postProcessInstruction(Instruction &Inst,
 // which are lost during the MCInst -> mca::Instruction lowering.
 void AMDGPUInstrPostProcess::processWaitCnt(Instruction &Inst,
                                             const MCInst &MCI) {
-  for (int Idx = 0, N = MCI.size(); Idx < N; Idx++) {
+  for (int Idx = 0, N = static_cast<int>(MCI.size()); Idx < N; Idx++) {
     MCAOperand Op;
     const MCOperand &MCOp = MCI.getOperand(Idx);
     if (MCOp.isReg()) {
@@ -207,16 +207,16 @@ void AMDGPUCustomBehaviour::computeWaitCnt(const InstRef &IR, unsigned &Vmcnt,
     // for each case. There are more clever ways to avoid this
     // extra switch and anyone can feel free to implement one of them.
     case AMDGPU::S_WAITCNT_EXPCNT_gfx10:
-      Expcnt = OpImm->getImm();
+      Expcnt = static_cast<unsigned>(OpImm->getImm());
       break;
     case AMDGPU::S_WAITCNT_LGKMCNT_gfx10:
-      Lgkmcnt = OpImm->getImm();
+      Lgkmcnt = static_cast<unsigned>(OpImm->getImm());
       break;
     case AMDGPU::S_WAITCNT_VMCNT_gfx10:
-      Vmcnt = OpImm->getImm();
+      Vmcnt = static_cast<unsigned>(OpImm->getImm());
       break;
     case AMDGPU::S_WAITCNT_VSCNT_gfx10:
-      Vscnt = OpImm->getImm();
+      Vscnt = static_cast<unsigned>(OpImm->getImm());
       break;
     }
     return;
@@ -224,7 +224,7 @@ void AMDGPUCustomBehaviour::computeWaitCnt(const InstRef &IR, unsigned &Vmcnt,
   case AMDGPU::S_WAITCNT_gfx10:
   case AMDGPU::S_WAITCNT_gfx6_gfx7:
   case AMDGPU::S_WAITCNT_vi:
-    unsigned WaitCnt = Inst.getOperand(0)->getImm();
+    unsigned WaitCnt = static_cast<unsigned>(Inst.getOperand(0)->getImm());
     AMDGPU::decodeWaitcnt(IV, WaitCnt, Vmcnt, Expcnt, Lgkmcnt);
     return;
   }
@@ -246,7 +246,7 @@ void AMDGPUCustomBehaviour::generateWaitCntInfo() {
 
   for (const auto &EN : llvm::enumerate(SrcMgr.getInstructions())) {
     const std::unique_ptr<Instruction> &Inst = EN.value();
-    unsigned Index = EN.index();
+    unsigned Index = static_cast<unsigned>(EN.index());
     unsigned Opcode = Inst->getOpcode();
     const MCInstrDesc &MCID = MCII.get(Opcode);
     if (SIInstrFlags::isDS(MCID) && SIInstrFlags::usesLGKM_CNT(MCID)) {


### PR DESCRIPTION
For context, see https://github.com/llvm/llvm-project/issues/215213

This patch handles the following cases:

Function::getFnAttributeAsParsedInteger returns uint64_t and is assigned to
32-bit locals or passed to 32-bit parameters, for "amdgpu-num-sgpr",
"amdgpu-num-vgpr", "amdgpu-implicitarg-num-bytes" and "amdgpu-nsa-threshold".
Add a static_cast to make the existing narrowing conversion explicit. The
destination type is the one the surrounding code already works in:
getBaseMaxNumSGPRs discards a requested value that exceeds
getMaxNumSGPRs(WavesPerEU.first, false) and returns
std::min(MaxNumSGPRs - ReservedNumSGPRs, MaxAddressableNumSGPRs);
getBaseMaxNumVGPRs returns std::clamp(Requested, Min, Max). The other two are
not clamped: getNSAThreshold uses the value only as a threshold, taking
std::max(Value, 2) when it is positive, and getImplicitArgNumBytes returns it
as the function's unsigned result. For those two the cast records the narrowing
that the unsigned return type already implied, rather than one the code bounds.

ConstantInt::getZExtValue() returns uint64_t and is assigned to 32-bit locals
holding reqd_work_group_size metadata operands, in getReqdWorkGroupSize and
hasWavefrontsEvenlySplittingXDim. Add a static_cast to make the existing
narrowing conversion explicit. This is NFC because the narrowing is already in
the interface: getReqdWorkGroupSize is declared std::optional<unsigned>
(AMDGPUSubtarget.h:87), so the value is truncated at that point with or without
the cast. Note that the IR verifier does not bound these operands to 32 bits;
it only checks Value.getActiveBits() <= 64, with the diagnostic
"reqd_work_group_size operands must fit in 64 bits" (llvm/lib/IR/Verifier.cpp).

MachineOperand::getImm() and MCAOperand::getImm() return int64_t and are passed
to helpers taking unsigned: the export target compared against
AMDGPU::Exp::ET_PARAM0/ET_PARAM31 in AMDGPUHWEvents, and the s_waitcnt fields
that the MCA custom behaviour hands to AMDGPU::decodeWaitcnt. Add a static_cast
to make the existing narrowing conversion explicit.

std::distance, container size() and llvm::enumerate indices return signed or
unsigned 64-bit types and are assigned to int or unsigned locals holding
instruction indices within a basic block, an MCInst operand count and an index
into the MCA instruction list. Add a static_cast to make the existing narrowing
conversion explicit. In AMDGPUNextUseAnalysis the destination is InstrIdTy,
which is "using InstrIdTy = unsigned" (AMDGPUNextUseAnalysis.cpp:280) and is the
type the surrounding instruction-numbering maps are declared with.

divideCeil and alignTo return uint64_t and are assigned to unsigned locals in
AMDGPUPerfHintAnalysis and to the unsigned result of getKernArgSegmentSize. Add
a static_cast to make the existing narrowing conversion explicit.

AMDGPU::getOperandIdxName is generated by TableGen with the signature
"OpName getOperandIdxName(uint32_t Opcode, int16_t Idx)"
(llvm/utils/TableGen/InstrInfoEmitter.cpp), so the narrow parameter is the
operand index and the opcode needs no conversion. In
getVOP3PSourceModifierFromOpIdx the index is cast to int16_t at the call. It is
NFC because the only caller is getEffectiveSubRegIdx, which passes
Op.getOperandNo() after returning early unless InstrInfo.isVOP3P(I) holds, so
the value is an operand number within a single VOP3P instruction -- an
order-of-ten index, nowhere near the range of int16_t.

This fixes 17 instances of MSVC warning C4244 and 3 of C4267 ("possible loss of
data") across 7 files in llvm/lib/Target/AMDGPU.

One note for review: AMDGPUMachineModuleInfo.h had the same llvm::enumerate
index narrowing on two adjacent lines but only one produced a warning in this
configuration. Both are cast; leaving the neighbour would read as an oversight.

Assisted-by: Claude <noreply@anthropic.com>
