### PR TITLE
[AMDGPU][NFC] Explicitly narrow conversions in asm printing and MIR formatting

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
@@ -378,7 +378,7 @@ void AMDGPUAsmPrinter::emitGlobalVariable(const GlobalVariable *GV) {
     emitVisibility(GVSym, GV->getVisibility(), !GV->isDeclaration());
     emitLinkage(GV, GVSym);
     auto *TS = getTargetStreamer();
-    TS->emitAMDGPULDS(GVSym, Size, Alignment);
+    TS->emitAMDGPULDS(GVSym, static_cast<unsigned>(Size), Alignment);
     return;
   }
 
@@ -539,7 +539,8 @@ void AMDGPUAsmPrinter::validateMCResourceInfo(Function &F) {
       const SIMachineFunctionInfo &MFI = *MF->getInfo<SIMachineFunctionInfo>();
       unsigned MaxWaves = MFI.getMaxWavesPerEU();
       uint64_t TotalNumVgpr =
-          getTotalNumVGPRs(STM.hasGFX90AInsts(), NumAgpr, NumVgpr);
+          getTotalNumVGPRs(STM.hasGFX90AInsts(), static_cast<int32_t>(NumAgpr),
+                           static_cast<int32_t>(NumVgpr));
       uint64_t NumVGPRsForWavesPerEU =
           std::max({TotalNumVgpr, (uint64_t)1,
                     (uint64_t)STM.getMinNumVGPRs(
@@ -576,7 +577,7 @@ static void appendTypeEncoding(std::string &Enc, Type *Ty, const DataLayout &DL,
     Enc += 'v';
     return;
   }
-  unsigned Bits = DL.getTypeSizeInBits(Ty);
+  unsigned Bits = static_cast<unsigned>(DL.getTypeSizeInBits(Ty));
   // Zero-sized non-void types (e.g. `{}` or `[0 x i8]`) consume no ABI
   // registers. For returns, emit the same no-result marker as void so the
   // parameter encoding still has an explicit return-type prefix.
@@ -1769,7 +1770,7 @@ void AMDGPUAsmPrinter::emitPALFunctionMetadata(const MachineFunction &MF) {
   auto *MD = getTargetStreamer()->getPALMetadata();
   const MachineFrameInfo &MFI = MF.getFrameInfo();
   StringRef FnName = MF.getFunction().getName();
-  MD->setFunctionScratchSize(FnName, MFI.getStackSize());
+  MD->setFunctionScratchSize(FnName, static_cast<unsigned>(MFI.getStackSize()));
   const GCNSubtarget &ST = MF.getSubtarget<GCNSubtarget>();
   MCContext &Ctx = MF.getContext();
 
@@ -1866,7 +1867,8 @@ void AMDGPUAsmPrinter::getAmdKernelCode(AMDGPUMCKernelCodeT &Out,
   // kernarg_segment_alignment is specified as log of the alignment.
   // The minimum alignment is 16.
   // FIXME: The metadata treats the minimum as 4?
-  Out.kernarg_segment_alignment = Log2(std::max(Align(16), MaxKernArgAlign));
+  Out.kernarg_segment_alignment =
+      static_cast<uint8_t>(Log2(std::max(Align(16), MaxKernArgAlign)));
 }
 
 bool AMDGPUAsmPrinter::PrintAsmOperand(const MachineInstr *MI, unsigned OpNo,

--- a/llvm/lib/Target/AMDGPU/AMDGPUHSAMetadataStreamer.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUHSAMetadataStreamer.cpp
@@ -375,9 +375,9 @@ void MetadataStreamerMsgPackV4::emitKernelArg(
     Arg[".type_name"] = Arg.getDocument()->getNode(TypeName, /*Copy=*/true);
   auto Size = DL.getTypeAllocSize(Ty);
   Arg[".size"] = Arg.getDocument()->getNode(Size);
-  Offset = alignTo(Offset, Alignment);
+  Offset = static_cast<unsigned>(alignTo(Offset, Alignment));
   Arg[".offset"] = Arg.getDocument()->getNode(Offset);
-  Offset += Size;
+  Offset += static_cast<unsigned>(Size);
   Arg[".value_kind"] = Arg.getDocument()->getNode(ValueKind, /*Copy=*/true);
   if (PointeeAlign)
     Arg[".pointee_align"] = Arg.getDocument()->getNode(PointeeAlign->value());
@@ -424,7 +424,8 @@ void MetadataStreamerMsgPackV4::emitHiddenKernelArgs(
   auto &DL = M->getDataLayout();
   auto *Int64Ty = Type::getInt64Ty(Func.getContext());
 
-  Offset = alignTo(Offset, ST.getAlignmentForImplicitArgPtr());
+  Offset = static_cast<unsigned>(
+      alignTo(Offset, ST.getAlignmentForImplicitArgPtr()));
 
   if (HiddenArgNumBytes >= 8)
     emitKernelArg(DL, Int64Ty, Align(8), "hidden_global_offset_x", Offset,
@@ -633,7 +634,8 @@ void MetadataStreamerMsgPackV5::emitHiddenKernelArgs(
   auto *Int32Ty = Type::getInt32Ty(Func.getContext());
   auto *Int16Ty = Type::getInt16Ty(Func.getContext());
 
-  Offset = alignTo(Offset, ST.getAlignmentForImplicitArgPtr());
+  Offset = static_cast<unsigned>(
+      alignTo(Offset, ST.getAlignmentForImplicitArgPtr()));
   emitKernelArg(DL, Int32Ty, Align(4), "hidden_block_count_x", Offset, Args);
   emitKernelArg(DL, Int32Ty, Align(4), "hidden_block_count_y", Offset, Args);
   emitKernelArg(DL, Int32Ty, Align(4), "hidden_block_count_z", Offset, Args);

--- a/llvm/lib/Target/AMDGPU/AMDGPUMCInstLower.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUMCInstLower.cpp
@@ -91,8 +91,8 @@ bool AMDGPUMCInstLower::lowerOperand(const MachineOperand &MO,
     SmallString<128> SymbolName;
     AP.getNameWithPrefix(SymbolName, GV);
     MCSymbol *Sym = Ctx.getOrCreateSymbol(SymbolName);
-    const MCExpr *Expr =
-        MCSymbolRefExpr::create(Sym, getSpecifier(MO.getTargetFlags()), Ctx);
+    const MCExpr *Expr = MCSymbolRefExpr::create(
+        Sym, static_cast<uint16_t>(getSpecifier(MO.getTargetFlags())), Ctx);
     int64_t Offset = MO.getOffset();
     if (Offset != 0) {
       Expr = MCBinaryExpr::createAdd(Expr,
@@ -103,15 +103,15 @@ bool AMDGPUMCInstLower::lowerOperand(const MachineOperand &MO,
   }
   case MachineOperand::MO_ExternalSymbol: {
     MCSymbol *Sym = Ctx.getOrCreateSymbol(StringRef(MO.getSymbolName()));
-    const MCExpr *Expr =
-        MCSymbolRefExpr::create(Sym, getSpecifier(MO.getTargetFlags()), Ctx);
+    const MCExpr *Expr = MCSymbolRefExpr::create(
+        Sym, static_cast<uint16_t>(getSpecifier(MO.getTargetFlags())), Ctx);
     MCOp = MCOperand::createExpr(Expr);
     return true;
   }
   case MachineOperand::MO_BlockAddress: {
     MCSymbol *Sym = AP.GetBlockAddressSymbol(MO.getBlockAddress());
-    const MCSymbolRefExpr *Expr =
-        MCSymbolRefExpr::create(Sym, getSpecifier(MO.getTargetFlags()), Ctx);
+    const MCSymbolRefExpr *Expr = MCSymbolRefExpr::create(
+        Sym, static_cast<uint16_t>(getSpecifier(MO.getTargetFlags())), Ctx);
     assert(MO.getOffset() == 0);
     MCOp = MCOperand::createExpr(Expr);
     return true;
@@ -171,7 +171,8 @@ void AMDGPUMCInstLower::lowerT16D16Helper(const MachineInstr *MI,
     const MachineOperand &MO = MI->getOperand(I);
     MCOperand MCOp;
     if (I == VDstOrVDataIdx)
-      MCOp = MCOperand::createReg(TRI.get32BitRegister(MIVDstOrVData.getReg()));
+      MCOp = MCOperand::createReg(
+          TRI.get32BitRegister(static_cast<MCPhysReg>(MIVDstOrVData.getReg())));
     else
       lowerOperand(MO, MCOp);
     OutMI.addOperand(MCOp);
@@ -211,7 +212,8 @@ void AMDGPUMCInstLower::lowerT16FmaMixFP16(const MachineInstr *MI,
     const MachineOperand &MO = MI->getOperand(I);
     MCOperand MCOp;
     if (I == VDstIdx)
-      MCOp = MCOperand::createReg(TRI.get32BitRegister(VDst.getReg()));
+      MCOp = MCOperand::createReg(
+          TRI.get32BitRegister(static_cast<MCPhysReg>(VDst.getReg())));
     else
       lowerOperand(MO, MCOp);
     OutMI.addOperand(MCOp);
@@ -457,7 +459,7 @@ void AMDGPUAsmPrinter::emitInstruction(const MachineInstr *MI) {
         V = AMDGPU::convertSetRegImmToVgprMSBs(*MI,
                                                STI.hasSetregVGPRMSBFixup());
       else
-        V = MI->getOperand(0).getImm() & 0xff;
+        V = static_cast<unsigned>(MI->getOperand(0).getImm() & 0xff);
       if (V.has_value())
         OutStreamer->AddComment(
             " msbs: dst=" + Twine(*V >> 6) + " src0=" + Twine(*V & 3) +

--- a/llvm/lib/Target/AMDGPU/AMDGPUMIRFormatter.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUMIRFormatter.cpp
@@ -38,7 +38,7 @@ StringLiteral LgkmcntName = "Lgkmcnt";
 StringLiteral LoadcntName = "Loadcnt";
 StringLiteral DscntName = "Dscnt";
 
-void AMDGPUMIRFormatter::printSWaitAluImm(uint64_t Imm, raw_ostream &OS) const {
+void AMDGPUMIRFormatter::printSWaitAluImm(unsigned Imm, raw_ostream &OS) const {
   bool NonePrinted = true;
   ListSeparator Delim(SWaitAluDelim);
   auto PrintFieldIfNotMax = [&](StringRef Descr, uint64_t Num, unsigned Max) {
@@ -69,7 +69,7 @@ void AMDGPUMIRFormatter::printSWaitAluImm(uint64_t Imm, raw_ostream &OS) const {
     OS << AllOff;
 }
 
-void AMDGPUMIRFormatter::printSWaitcntImm(uint64_t Imm, raw_ostream &OS) const {
+void AMDGPUMIRFormatter::printSWaitcntImm(unsigned Imm, raw_ostream &OS) const {
   const AMDGPU::IsaVersion &Version = AMDGPU::getIsaVersion(STI.getCPU());
   bool NonePrinted = true;
   ListSeparator Delim(SWaitAluDelim);
@@ -90,7 +90,7 @@ void AMDGPUMIRFormatter::printSWaitcntImm(uint64_t Imm, raw_ostream &OS) const {
     OS << AllOff;
 }
 
-void AMDGPUMIRFormatter::printSWaitLoadcntDscntImm(uint64_t Imm,
+void AMDGPUMIRFormatter::printSWaitLoadcntDscntImm(unsigned Imm,
                                                    raw_ostream &OS) const {
   const AMDGPU::IsaVersion &Version = AMDGPU::getIsaVersion(STI.getCPU());
   bool NonePrinted = true;
@@ -116,13 +116,13 @@ void AMDGPUMIRFormatter::printImm(raw_ostream &OS, const MachineInstr &MI,
   switch (MI.getOpcode()) {
   case AMDGPU::S_WAITCNT:
   case AMDGPU::S_WAITCNT_soft:
-    printSWaitcntImm(Imm, OS);
+    printSWaitcntImm(static_cast<unsigned>(Imm), OS);
     break;
   case AMDGPU::S_WAIT_LOADCNT_DSCNT:
-    printSWaitLoadcntDscntImm(Imm, OS);
+    printSWaitLoadcntDscntImm(static_cast<unsigned>(Imm), OS);
     break;
   case AMDGPU::S_WAITCNT_DEPCTR:
-    printSWaitAluImm(Imm, OS);
+    printSWaitAluImm(static_cast<unsigned>(Imm), OS);
     break;
   case AMDGPU::S_DELAY_ALU:
     assert(OpIdx == 0);
@@ -247,13 +247,13 @@ bool AMDGPUMIRFormatter::parseSWaitcntImmMnemonic(
     unsigned Max;
     if (Name == VmcntName) {
       Max = AMDGPU::getVmcntBitMask(Version);
-      Vmcnt = Num;
+      Vmcnt = static_cast<unsigned>(Num);
     } else if (Name == ExpcntName) {
       Max = AMDGPU::getExpcntBitMask(Version);
-      Expcnt = Num;
+      Expcnt = static_cast<unsigned>(Num);
     } else if (Name == LgkmcntName) {
       Max = AMDGPU::getLgkmcntBitMask(Version);
-      Lgkmcnt = Num;
+      Lgkmcnt = static_cast<unsigned>(Num);
     } else {
       return ErrorCallback(NamePos, "invalid counter name");
     }
@@ -312,10 +312,10 @@ bool AMDGPUMIRFormatter::parseSWaitLoadcntDscntImmMnemonic(
     unsigned Max;
     if (Name == LoadcntName) {
       Max = AMDGPU::getLoadcntBitMask(Version);
-      Loadcnt = Num;
+      Loadcnt = static_cast<unsigned>(Num);
     } else if (Name == DscntName) {
       Max = AMDGPU::getDscntBitMask(Version);
-      Dscnt = Num;
+      Dscnt = static_cast<unsigned>(Num);
     } else {
       return ErrorCallback(NamePos, "invalid counter name");
     }
@@ -380,26 +380,33 @@ bool AMDGPUMIRFormatter::parseSWaitAluImmMnemonic(
     unsigned Max;
     if (Name == VaVdstName) {
       Max = AMDGPU::DepCtr::getVaVdstBitMask();
-      Imm = AMDGPU::DepCtr::encodeFieldVaVdst(Imm, Num);
+      Imm = AMDGPU::DepCtr::encodeFieldVaVdst(static_cast<unsigned>(Imm),
+                                              static_cast<unsigned>(Num));
     } else if (Name == VmVsrcName) {
       Max = AMDGPU::DepCtr::getVmVsrcBitMask();
-      Imm = AMDGPU::DepCtr::encodeFieldVmVsrc(Imm, Num);
+      Imm = AMDGPU::DepCtr::encodeFieldVmVsrc(static_cast<unsigned>(Imm),
+                                              static_cast<unsigned>(Num));
     } else if (Name == VaSdstName) {
       Max = AMDGPU::DepCtr::getVaSdstBitMask();
-      Imm = AMDGPU::DepCtr::encodeFieldVaSdst(Imm, Num);
+      Imm = AMDGPU::DepCtr::encodeFieldVaSdst(static_cast<unsigned>(Imm),
+                                              static_cast<unsigned>(Num));
     } else if (Name == VaSsrcName) {
       Max = AMDGPU::DepCtr::getVaSsrcBitMask();
-      Imm = AMDGPU::DepCtr::encodeFieldVaSsrc(Imm, Num);
+      Imm = AMDGPU::DepCtr::encodeFieldVaSsrc(static_cast<unsigned>(Imm),
+                                              static_cast<unsigned>(Num));
     } else if (Name == HoldCntName) {
       const AMDGPU::IsaVersion &Version = AMDGPU::getIsaVersion(STI.getCPU());
       Max = AMDGPU::DepCtr::getHoldCntBitMask(Version);
-      Imm = AMDGPU::DepCtr::encodeFieldHoldCnt(Imm, Num, Version);
+      Imm = AMDGPU::DepCtr::encodeFieldHoldCnt(
+          static_cast<unsigned>(Imm), static_cast<unsigned>(Num), Version);
     } else if (Name == VaVccName) {
       Max = AMDGPU::DepCtr::getVaVccBitMask();
-      Imm = AMDGPU::DepCtr::encodeFieldVaVcc(Imm, Num);
+      Imm = AMDGPU::DepCtr::encodeFieldVaVcc(static_cast<unsigned>(Imm),
+                                             static_cast<unsigned>(Num));
     } else if (Name == SaSdstName) {
       Max = AMDGPU::DepCtr::getSaSdstBitMask();
-      Imm = AMDGPU::DepCtr::encodeFieldSaSdst(Imm, Num);
+      Imm = AMDGPU::DepCtr::encodeFieldSaSdst(static_cast<unsigned>(Imm),
+                                              static_cast<unsigned>(Num));
     } else {
       return ErrorCallback(NamePos, "invalid counter name");
     }

--- a/llvm/lib/Target/AMDGPU/AMDGPUMIRFormatter.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUMIRFormatter.h
@@ -51,11 +51,11 @@ public:
 private:
   const MCSubtargetInfo &STI;
   /// Prints the string to represent s_wait_alu immediate value.
-  void printSWaitAluImm(uint64_t Imm, raw_ostream &OS) const;
+  void printSWaitAluImm(unsigned Imm, raw_ostream &OS) const;
   /// Prints the string to represent s_waitcnt immediate value.
-  void printSWaitcntImm(uint64_t Imm, raw_ostream &OS) const;
+  void printSWaitcntImm(unsigned Imm, raw_ostream &OS) const;
   /// Prints the string to represent s_wait_loadcnt_dscnt immediate value.
-  void printSWaitLoadcntDscntImm(uint64_t Imm, raw_ostream &OS) const;
+  void printSWaitLoadcntDscntImm(unsigned Imm, raw_ostream &OS) const;
   /// Print the string to represent s_delay_alu immediate value
   void printSDelayAluImm(int64_t Imm, llvm::raw_ostream &OS) const;
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUResourceUsageAnalysis.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUResourceUsageAnalysis.cpp
@@ -247,7 +247,8 @@ AMDGPUResourceUsageAnalysisImpl::analyzeResourceUsage(
         if (MI.isCall() || MI.isMetaInstruction())
           continue;
 
-        unsigned Width = divideCeil(TRI.getRegSizeInBits(*RC), 32);
+        unsigned Width =
+            static_cast<unsigned>(divideCeil(TRI.getRegSizeInBits(*RC), 32));
         unsigned HWReg = TRI.getHWRegIndex(Reg);
         int MaxUsed = HWReg + Width - 1;
         MaxVGPR = std::max(MaxUsed, MaxVGPR);

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -2130,10 +2130,10 @@ bool GCNTargetMachine::parseMachineFunctionInfo(
     // Create a diagnostic for a the register string literal.
     const MemoryBuffer &Buffer =
         *PFS.SM->getMemoryBuffer(PFS.SM->getMainFileID());
-    Error = SMDiagnostic(*PFS.SM, SMLoc(), Buffer.getBufferIdentifier(), 1,
-                         RegName.Value.size(), SourceMgr::DK_Error,
-                         "incorrect register class for field", RegName.Value,
-                         {}, {});
+    Error = SMDiagnostic(
+        *PFS.SM, SMLoc(), Buffer.getBufferIdentifier(), 1,
+        static_cast<int>(RegName.Value.size()), SourceMgr::DK_Error,
+        "incorrect register class for field", RegName.Value, {}, {});
     SourceRange = RegName.SourceRange;
     return true;
   };


### PR DESCRIPTION
For context, see https://github.com/llvm/llvm-project/issues/215213

This patch handles the following cases:

AMDGPUMIRFormatter::printSWaitAluImm, printSWaitcntImm and
printSWaitLoadcntDscntImm took the encoding as uint64_t and then handed it to
twelve decode helpers (DepCtr::decodeField* and decodeVmcnt / decodeExpcnt /
decodeLgkmcnt / decodeLoadcnt / decodeDscnt) that all take unsigned. Change the
parameter type of these three functions to unsigned. They are AMDGPU-private
helpers called only from printImm, so the conversion happens once per call at
the single caller instead of twelve times inside; three signature changes remove
twelve warnings. The values are s_waitcnt / s_delay_alu encodings, which are
16-bit immediate fields.

MachineOperand::getImm() returns int64_t and is passed to encodeField* helpers
and to MCOperand::createImm consumers taking unsigned or int32_t. Add a
static_cast to make the existing narrowing conversion explicit.

Register values are passed to MCOperand::createReg and to
SIRegisterInfo::get32BitRegister, which take MCPhysReg (uint16_t). Add a
static_cast. These are physical registers: the values come from
AMDGPUMCInstLower after register allocation, and get32BitRegister both takes and
returns MCPhysReg, so the narrowing is on its argument.

MCSymbolRefExpr::create takes the relocation specifier as MCExpr::Spec. Spec is
protected, so static_cast<MCExpr::Spec> does not compile; the value is cast to
uint16_t, the type Spec is defined as. No target declares its Specifier enum
with an explicit underlying type, so this narrowing exists in every backend, not
only AMDGPU.

alignTo returns common_uint<U, V> and Align::value() returns uint64_t; both are
assigned to 32-bit metadata and kernel-descriptor fields. Add a static_cast. The
fields are the 32-bit kernarg_segment_alignment and implicit-argument offsets
defined by the code object ABI.

This fixes 39 instances of MSVC warning C4244 and 1 of C4267 ("possible loss of
data") across 7 files in llvm/lib/Target/AMDGPU.

The three MIRFormatter signature changes introduce no new conversion at any call
site.

Assisted-by: Claude <noreply@anthropic.com>
