### PR TITLE
[AMDGPU][NFC] Explicitly narrow conversions in libcalls, TTI and InstCombine

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUInstCombineIntrinsic.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstCombineIntrinsic.cpp
@@ -718,7 +718,7 @@ static std::optional<unsigned> evalLaneExpr(Value *V, unsigned Lane,
     return std::nullopt;
 
   if (const ConstantInt *CI = dyn_cast<ConstantInt>(V))
-    return CI->getZExtValue();
+    return static_cast<unsigned>(CI->getZExtValue());
 
   if (isThreadID(ST, V))
     return Lane;
@@ -740,7 +740,8 @@ static std::optional<unsigned> evalLaneExpr(Value *V, unsigned Lane,
   Constant *Ops[] = {ConstantInt::get(Ty, *LHS), ConstantInt::get(Ty, *RHS)};
   auto *CI =
       dyn_cast_or_null<ConstantInt>(ConstantFoldInstOperands(BO, Ops, DL));
-  return CI ? std::optional<unsigned>(CI->getZExtValue()) : std::nullopt;
+  return CI ? std::optional<unsigned>(static_cast<unsigned>(CI->getZExtValue()))
+            : std::nullopt;
 }
 
 /// Build the per-lane shuffle map by evaluating Index for every lane in the
@@ -754,7 +755,7 @@ static bool tryBuildShuffleMap(Value *Index, const GCNSubtarget &ST,
     std::optional<unsigned> Val = evalLaneExpr(Index, Lane, ST, DL);
     if (!Val || *Val >= WaveSize)
       return false;
-    Ids[Lane] = *Val;
+    Ids[Lane] = static_cast<uint8_t>(*Val);
   }
   return true;
 }
@@ -764,7 +765,7 @@ static bool tryBuildShuffleMap(Value *Index, const GCNSubtarget &ST,
 template <unsigned Period>
 static bool hasPeriodicLayout(ArrayRef<uint8_t> Ids) {
   static_assert(isPowerOf2_32(Period), "Period must be a power of two");
-  for (unsigned I = Period, E = Ids.size(); I < E; ++I)
+  for (unsigned I = Period, E = static_cast<unsigned>(Ids.size()); I < E; ++I)
     if (Ids[I] != Ids[I % Period] + (I & ~(Period - 1)))
       return false;
   return true;
@@ -1111,7 +1112,7 @@ tryOptimizeShufflePattern(InstCombiner &IC, IntrinsicInst &II,
       std::optional<unsigned> Val = evalLaneExpr(Index, Lane, ST, DL);
       if (!Val || (*Val & 3) || (*Val >> 2) >= WaveSize)
         return std::nullopt;
-      Ids[Lane] = *Val >> 2;
+      Ids[Lane] = static_cast<uint8_t>(*Val >> 2);
     }
   } else {
     if (!tryBuildShuffleMap(Index, ST, Ids, DL))
@@ -1434,7 +1435,7 @@ GCNTTIImpl::instCombineIntrinsic(InstCombiner &IC, IntrinsicInst &II) const {
 
     ConstantInt *CWidth = dyn_cast<ConstantInt>(II.getArgOperand(2));
     if (CWidth) {
-      Width = CWidth->getZExtValue();
+      Width = static_cast<unsigned>(CWidth->getZExtValue());
       if ((Width & (IntSize - 1)) == 0) {
         return IC.replaceInstUsesWith(II, ConstantInt::getNullValue(Ty));
       }
@@ -1449,7 +1450,7 @@ GCNTTIImpl::instCombineIntrinsic(InstCombiner &IC, IntrinsicInst &II) const {
     unsigned Offset;
     ConstantInt *COffset = dyn_cast<ConstantInt>(II.getArgOperand(1));
     if (COffset) {
-      Offset = COffset->getZExtValue();
+      Offset = static_cast<unsigned>(COffset->getZExtValue());
       if (Offset >= IntSize) {
         return IC.replaceOperand(
             II, 1,
@@ -1487,7 +1488,7 @@ GCNTTIImpl::instCombineIntrinsic(InstCombiner &IC, IntrinsicInst &II) const {
   case Intrinsic::amdgcn_exp_row:
   case Intrinsic::amdgcn_exp_compr: {
     ConstantInt *En = cast<ConstantInt>(II.getArgOperand(1));
-    unsigned EnBits = En->getZExtValue();
+    unsigned EnBits = static_cast<unsigned>(En->getZExtValue());
     if (EnBits == 0xf)
       break; // All inputs enabled.
 
@@ -1909,7 +1910,8 @@ GCNTTIImpl::instCombineIntrinsic(InstCombiner &IC, IntrinsicInst &II) const {
 
     auto *MsgImm = cast<ConstantInt>(II.getArgOperand(0));
     uint16_t MsgId, OpId, StreamId;
-    decodeMsg(MsgImm->getZExtValue(), MsgId, OpId, StreamId, *ST);
+    decodeMsg(static_cast<unsigned>(MsgImm->getZExtValue()), MsgId, OpId,
+              StreamId, *ST);
 
     if (!msgDoesNotUseM0(MsgId, *ST))
       break;
@@ -2044,8 +2046,10 @@ GCNTTIImpl::instCombineIntrinsic(InstCombiner &IC, IntrinsicInst &II) const {
       break;
     }
 
-    unsigned Exponent = FSrcInt.extractBitsAsZExtValue(11, 52);
-    unsigned SegmentVal = Cseg->getValue().trunc(5).getZExtValue();
+    unsigned Exponent =
+        static_cast<unsigned>(FSrcInt.extractBitsAsZExtValue(11, 52));
+    unsigned SegmentVal =
+        static_cast<unsigned>(Cseg->getValue().trunc(5).getZExtValue());
     unsigned Shift = SegmentVal * 53;
     if (Exponent > 1077)
       Shift += Exponent - 1077;
@@ -2226,8 +2230,8 @@ GCNTTIImpl::instCombineIntrinsic(InstCombiner &IC, IntrinsicInst &II) const {
     };
 
     bool MadeChange = false;
-    unsigned Src0NumElts = getFormatNumRegs(CBSZ);
-    unsigned Src1NumElts = getFormatNumRegs(BLGP);
+    unsigned Src0NumElts = getFormatNumRegs(static_cast<unsigned>(CBSZ));
+    unsigned Src1NumElts = getFormatNumRegs(static_cast<unsigned>(BLGP));
 
     // Depending on the used format, fewer registers are required so shrink the
     // vector type.
@@ -2262,14 +2266,16 @@ GCNTTIImpl::instCombineIntrinsic(InstCombiner &IC, IntrinsicInst &II) const {
   case Intrinsic::amdgcn_wmma_scale16_f32_16x16x128_f8f6f4: {
     Value *Src0 = II.getArgOperand(1);
     Value *Src1 = II.getArgOperand(3);
-    unsigned FmtA = cast<ConstantInt>(II.getArgOperand(0))->getZExtValue();
+    unsigned FmtA = static_cast<unsigned>(
+        cast<ConstantInt>(II.getArgOperand(0))->getZExtValue());
     uint64_t FmtB = cast<ConstantInt>(II.getArgOperand(2))->getZExtValue();
     auto *Src0Ty = cast<FixedVectorType>(Src0->getType());
     auto *Src1Ty = cast<FixedVectorType>(Src1->getType());
 
     bool MadeChange = false;
     unsigned Src0NumElts = AMDGPU::wmmaScaleF8F6F4FormatToNumRegs(FmtA);
-    unsigned Src1NumElts = AMDGPU::wmmaScaleF8F6F4FormatToNumRegs(FmtB);
+    unsigned Src1NumElts =
+        AMDGPU::wmmaScaleF8F6F4FormatToNumRegs(static_cast<unsigned>(FmtB));
 
     // Depending on the used format, fewer registers are required so shrink the
     // vector type.
@@ -2378,7 +2384,7 @@ static Value *simplifyAMDGCNMemoryIntrinsicDemanded(InstCombiner &IC,
         DemandedElts &= ~((1 << UnusedComponentsAtFront) - 1);
         auto *Offset = Args[OffsetIdx];
         unsigned SingleComponentSizeInBits =
-            IC.getDataLayout().getTypeSizeInBits(EltTy);
+            static_cast<unsigned>(IC.getDataLayout().getTypeSizeInBits(EltTy));
         unsigned OffsetAdd =
             UnusedComponentsAtFront * SingleComponentSizeInBits / 8;
         auto *OffsetAddVal = ConstantInt::get(Offset->getType(), OffsetAdd);

--- a/llvm/lib/Target/AMDGPU/AMDGPULibCalls.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULibCalls.cpp
@@ -562,7 +562,7 @@ bool AMDGPULibCalls::fold_read_write_pipe(CallInst *CI, IRBuilder<> &B,
   if (!PacketSize || !PacketAlign)
     return false;
 
-  unsigned Size = PacketSize->getZExtValue();
+  unsigned Size = static_cast<unsigned>(PacketSize->getZExtValue());
   Align Alignment = PacketAlign->getAlignValue();
   if (Alignment != Size)
     return false;
@@ -1134,7 +1134,8 @@ bool AMDGPULibCalls::fold_pow(FPMathOperator *FPOp, IRBuilder<> &B,
   nval = Exp2Call;
 
   if (needcopysign) {
-    Type* nTyS = B.getIntNTy(eltType->getPrimitiveSizeInBits());
+    Type *nTyS =
+        B.getIntNTy(static_cast<unsigned>(eltType->getPrimitiveSizeInBits()));
     Type *nTy = FPOp->getType()->getWithNewType(nTyS);
     Value *opr_n = FPOp->getOperand(1);
     if (opr_n->getType()->getScalarType()->isIntegerTy())
@@ -1720,12 +1721,12 @@ bool AMDGPULibCalls::fold_sincos(FPMathOperator *FPOp, IRBuilder<> &B,
   // Merge the sin and cos. For OpenCL 2.0, there may only be a generic pointer
   // implementation. Prefer the private form if available.
   AMDGPULibFunc SinCosLibFuncPrivate(AMDGPULibFunc::EI_SINCOS, fInfo);
-  SinCosLibFuncPrivate.getLeads()[0].PtrKind =
-      AMDGPULibFunc::getEPtrKindFromAddrSpace(AMDGPUAS::PRIVATE_ADDRESS);
+  SinCosLibFuncPrivate.getLeads()[0].PtrKind = static_cast<unsigned char>(
+      AMDGPULibFunc::getEPtrKindFromAddrSpace(AMDGPUAS::PRIVATE_ADDRESS));
 
   AMDGPULibFunc SinCosLibFuncGeneric(AMDGPULibFunc::EI_SINCOS, fInfo);
-  SinCosLibFuncGeneric.getLeads()[0].PtrKind =
-      AMDGPULibFunc::getEPtrKindFromAddrSpace(AMDGPUAS::FLAT_ADDRESS);
+  SinCosLibFuncGeneric.getLeads()[0].PtrKind = static_cast<unsigned char>(
+      AMDGPULibFunc::getEPtrKindFromAddrSpace(AMDGPUAS::FLAT_ADDRESS));
 
   FunctionCallee FSinCosPrivate = getFunction(M, SinCosLibFuncPrivate);
   FunctionCallee FSinCosGeneric = getFunction(M, SinCosLibFuncGeneric);

--- a/llvm/lib/Target/AMDGPU/AMDGPULibFunc.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULibFunc.cpp
@@ -455,7 +455,8 @@ AMDGPULibFunc::Param ParamIterator::getNextParam() {
       case AMDGPUAS::GLOBAL_ADDRESS: AS = AMDGPUAS::LOCAL_ADDRESS; break;
       case AMDGPUAS::LOCAL_ADDRESS:  AS = AMDGPUAS::GLOBAL_ADDRESS; break;
       }
-      P.PtrKind = AMDGPULibFunc::getEPtrKindFromAddrSpace(AS);
+      P.PtrKind = static_cast<unsigned char>(
+          AMDGPULibFunc::getEPtrKindFromAddrSpace(AS));
       P.PtrKind |= AMDGPULibFunc::CONST;
       break;
     }
@@ -548,7 +549,7 @@ static int parseVecSize(StringRef& mangledName) {
   size_t const Len = eatNumber(mangledName);
   switch (Len) {
   case 2: case 3: case 4: case 8: case 16:
-    return Len;
+    return static_cast<int>(Len);
   default:
     break;
   }
@@ -617,14 +618,14 @@ bool ItaniumParamParser::parseItaniumParam(StringRef& param,
 
   // parse vector size
   if (eatTerm(param,"Dv")) {
-    res.VectorSize = parseVecSize(param);
+    res.VectorSize = static_cast<unsigned char>(parseVecSize(param));
     if (res.VectorSize==1 || !eatTerm(param, '_')) return false;
   }
 
   // parse type
   char const TC = param.front();
   if (isDigit(TC)) {
-    res.ArgType =
+    res.ArgType = static_cast<unsigned char>(
         StringSwitch<AMDGPULibFunc::EType>(eatLengthPrefixedName(param))
             .StartsWith("ocl_image1d_array", AMDGPULibFunc::IMG1DA)
             .StartsWith("ocl_image1d_buffer", AMDGPULibFunc::IMG1DB)
@@ -634,7 +635,7 @@ bool ItaniumParamParser::parseItaniumParam(StringRef& param,
             .StartsWith("ocl_image3d", AMDGPULibFunc::IMG3D)
             .Case("ocl_event", AMDGPULibFunc::DUMMY)
             .Case("ocl_sampler", AMDGPULibFunc::DUMMY)
-            .Default(AMDGPULibFunc::DUMMY);
+            .Default(AMDGPULibFunc::DUMMY));
   } else {
     drop_front(param);
     switch (TC) {
@@ -893,7 +894,7 @@ AMDGPULibFuncBase::Param AMDGPULibFuncBase::Param::getFromTy(Type *Ty,
                                                              bool Signed) {
   Param P;
   if (FixedVectorType *VT = dyn_cast<FixedVectorType>(Ty)) {
-    P.VectorSize = VT->getNumElements();
+    P.VectorSize = static_cast<unsigned char>(VT->getNumElements());
     Ty = VT->getElementType();
   }
 
@@ -910,16 +911,20 @@ AMDGPULibFuncBase::Param AMDGPULibFuncBase::Param::getFromTy(Type *Ty,
   case Type::IntegerTyID:
     switch (cast<IntegerType>(Ty)->getBitWidth()) {
     case 8:
-      P.ArgType = Signed ? AMDGPULibFunc::I8 : AMDGPULibFunc::U8;
+      P.ArgType = static_cast<unsigned char>(Signed ? AMDGPULibFunc::I8
+                                                    : AMDGPULibFunc::U8);
       break;
     case 16:
-      P.ArgType = Signed ? AMDGPULibFunc::I16 : AMDGPULibFunc::U16;
+      P.ArgType = static_cast<unsigned char>(Signed ? AMDGPULibFunc::I16
+                                                    : AMDGPULibFunc::U16);
       break;
     case 32:
-      P.ArgType = Signed ? AMDGPULibFunc::I32 : AMDGPULibFunc::U32;
+      P.ArgType = static_cast<unsigned char>(Signed ? AMDGPULibFunc::I32
+                                                    : AMDGPULibFunc::U32);
       break;
     case 64:
-      P.ArgType = Signed ? AMDGPULibFunc::I64 : AMDGPULibFunc::U64;
+      P.ArgType = static_cast<unsigned char>(Signed ? AMDGPULibFunc::I64
+                                                    : AMDGPULibFunc::U64);
       break;
     default:
       llvm_unreachable("unhandled libcall argument type");

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.cpp
@@ -115,8 +115,8 @@ void AMDGPUTTIImpl::getUnrollingPreferences(
     Loop *L, ScalarEvolution &SE, TTI::UnrollingPreferences &UP,
     OptimizationRemarkEmitter *ORE) const {
   const Function &F = *L->getHeader()->getParent();
-  UP.Threshold =
-      F.getFnAttributeAsParsedInteger("amdgpu-unroll-threshold", 300);
+  UP.Threshold = static_cast<unsigned>(
+      F.getFnAttributeAsParsedInteger("amdgpu-unroll-threshold", 300));
   UP.MaxCount = std::numeric_limits<unsigned>::max();
   UP.Partial = true;
 
@@ -147,7 +147,8 @@ void AMDGPUTTIImpl::getUnrollingPreferences(
         // We will also use the supplied value for PartialThreshold for now.
         // We may introduce additional metadata if it becomes necessary in the
         // future.
-        UP.Threshold = MetaThresholdValue->getSExtValue();
+        UP.Threshold =
+            static_cast<unsigned>(MetaThresholdValue->getSExtValue());
         UP.PartialThreshold = UP.Threshold;
         ThresholdPrivate = std::min(ThresholdPrivate, UP.Threshold);
         ThresholdLocal = std::min(ThresholdLocal, UP.Threshold);
@@ -508,7 +509,7 @@ bool GCNTTIImpl::getTgtMemIntrinsic(IntrinsicInst *Inst,
     if (!Ordering || !Volatile)
       return false; // Invalid.
 
-    unsigned OrderingVal = Ordering->getZExtValue();
+    unsigned OrderingVal = static_cast<unsigned>(Ordering->getZExtValue());
     if (OrderingVal > static_cast<unsigned>(AtomicOrdering::SequentiallyConsistent))
       return false;
 
@@ -1019,8 +1020,8 @@ InstructionCost GCNTTIImpl::getVectorInstrCost(
   switch (Opcode) {
   case Instruction::ExtractElement:
   case Instruction::InsertElement: {
-    unsigned EltSize
-      = DL.getTypeSizeInBits(cast<VectorType>(ValTy)->getElementType());
+    unsigned EltSize = static_cast<unsigned>(
+        DL.getTypeSizeInBits(cast<VectorType>(ValTy)->getElementType()));
     // Dynamic indexing isn't free and is best avoided.
     if (Index == ~0u)
       return 2;
@@ -1347,7 +1348,8 @@ InstructionCost GCNTTIImpl::getShuffleCost(TTI::ShuffleKind Kind,
 
   Kind = improveShuffleKindFromMask(Kind, Mask, SrcTy, Index, SubTp);
 
-  unsigned ScalarSize = DL.getTypeSizeInBits(SrcTy->getElementType());
+  unsigned ScalarSize =
+      static_cast<unsigned>(DL.getTypeSizeInBits(SrcTy->getElementType()));
   if (ST->getGeneration() >= AMDGPUSubtarget::VOLCANIC_ISLANDS &&
       (ScalarSize == 16 || ScalarSize == 8)) {
     // Larger vector widths may require additional instructions, but are
@@ -1463,7 +1465,7 @@ InstructionCost GCNTTIImpl::getShuffleCost(TTI::ShuffleKind Kind,
             Regs.push_back(Reg);
         }
         if (Regs.size() >= 2)
-          Cost += Regs.size() - 1;
+          Cost += static_cast<unsigned>(Regs.size() - 1);
         else if (!Aligned)
           Cost += 1;
       }
@@ -1512,8 +1514,8 @@ bool GCNTTIImpl::isProfitableToSinkOperands(Instruction *I,
 
     if (auto *Shuffle = dyn_cast<ShuffleVectorInst>(Op.get())) {
 
-      unsigned EltSize = DL.getTypeSizeInBits(
-          cast<VectorType>(Shuffle->getType())->getElementType());
+      unsigned EltSize = static_cast<unsigned>(DL.getTypeSizeInBits(
+          cast<VectorType>(Shuffle->getType())->getElementType()));
 
       // For i32 (or greater) shufflevectors, these will be lowered into a
       // series of insert / extract elements, which will be coalesced away.
@@ -1626,10 +1628,12 @@ static unsigned adjustInliningThresholdUsingCallee(const CallBase *CB,
 
   // The penalty cost is computed relative to the cost of instructions and does
   // not model any storage costs.
-  adjustThreshold += std::max(0, SGPRsInUse - NrOfSGPRUntilSpill) *
-                     ArgStackCost.getValue() * InlineConstants::getInstrCost();
-  adjustThreshold += std::max(0, VGPRsInUse - NrOfVGPRUntilSpill) *
-                     ArgStackCost.getValue() * InlineConstants::getInstrCost();
+  adjustThreshold += static_cast<unsigned>(
+      std::max(0, SGPRsInUse - NrOfSGPRUntilSpill) * ArgStackCost.getValue() *
+      InlineConstants::getInstrCost());
+  adjustThreshold += static_cast<unsigned>(
+      std::max(0, VGPRsInUse - NrOfVGPRUntilSpill) * ArgStackCost.getValue() *
+      InlineConstants::getInstrCost());
   return adjustThreshold;
 }
 
@@ -1656,7 +1660,7 @@ static unsigned getCallArgsTotalAllocaSize(const CallBase *CB,
       continue;
 
     if (auto Size = AI->getAllocationSize(DL))
-      AllocaSize += Size->getFixedValue();
+      AllocaSize += static_cast<unsigned>(Size->getFixedValue());
   }
   return AllocaSize;
 }
@@ -1715,8 +1719,8 @@ unsigned GCNTTIImpl::getCallerAllocaCost(const CallBase *CB,
     return 0;
 
   // Attribute the bonus proportionally to the alloca size
-  unsigned AllocaThresholdBonus =
-      (Threshold * ArgAllocaSize->getFixedValue()) / AllocaSize;
+  unsigned AllocaThresholdBonus = static_cast<unsigned>(
+      (Threshold * ArgAllocaSize->getFixedValue()) / AllocaSize);
 
   return AllocaThresholdBonus;
 }


### PR DESCRIPTION
For context, see https://github.com/llvm/llvm-project/issues/215213

This patch handles the following cases:

AMDGPULibFunc::Param packs ArgType, VectorSize and PtrKind into unsigned char
fields, so assigning an EType enumerator, an address-space-derived pointer kind
or a vector element count to them narrows. Add a static_cast rather than
widening the fields: the packing is deliberate and the enumerators and element
counts are far below 256.

ConstantInt::getZExtValue() returns uint64_t and is assigned to 32-bit locals
holding intrinsic immediate operands. Add a static_cast to make the existing
narrowing conversion explicit. These are amdgcn intrinsic arguments whose ranges
are pinned by the intrinsic definitions and by the range checks on the
surrounding lines.

std::optional<unsigned> is constructed from a uint64_t getZExtValue() result, so
the narrowing happens inside std::optional's constructor and MSVC reports it
against <optional>. Add the static_cast at the LLVM instantiation site. This one
only became visible after the sibling site 20 lines above was fixed, because
MSVC prints the instantiation chain for the first occurrence only.

Function::getFnAttributeAsParsedInteger returns uint64_t and is assigned to the
32-bit unroll Threshold. Add a static_cast; the attribute is an unroll threshold
compared against int-typed cost values.

DataLayout::getTypeSizeInBits returns TypeSize and container size() returns
size_t; both are assigned to 32-bit locals holding element widths and counts in
the cost model. Add a static_cast to make the existing narrowing conversion
explicit.

This fixes 35 instances of MSVC warning C4244 and 3 of C4267 ("possible loss of
data") across 4 files in llvm/lib/Target/AMDGPU.

Assisted-by: Claude <noreply@anthropic.com>
