### PR TITLE
[AMDGPU][NFC] Explicitly narrow conversions in the MC layer

### DIFF
--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUInstPrinter.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUInstPrinter.cpp
@@ -106,7 +106,7 @@ void AMDGPUInstPrinter::printNamedBit(const MCInst *MI, unsigned OpNo,
 void AMDGPUInstPrinter::printOffset(const MCInst *MI, unsigned OpNo,
                                     const MCSubtargetInfo &STI,
                                     raw_ostream &O) {
-  uint32_t Imm = MI->getOperand(OpNo).getImm();
+  uint32_t Imm = static_cast<uint32_t>(MI->getOperand(OpNo).getImm());
   if (Imm != 0) {
     O << " offset:";
 
@@ -122,7 +122,7 @@ void AMDGPUInstPrinter::printOffset(const MCInst *MI, unsigned OpNo,
 void AMDGPUInstPrinter::printFlatOffset(const MCInst *MI, unsigned OpNo,
                                         const MCSubtargetInfo &STI,
                                         raw_ostream &O) {
-  uint32_t Imm = MI->getOperand(OpNo).getImm();
+  uint32_t Imm = static_cast<uint32_t>(MI->getOperand(OpNo).getImm());
   if (Imm != 0) {
     O << " offset:";
 
@@ -266,10 +266,11 @@ void AMDGPUInstPrinter::printScope(int64_t Scope, raw_ostream &O) {
 
 void AMDGPUInstPrinter::printDim(const MCInst *MI, unsigned OpNo,
                                  const MCSubtargetInfo &STI, raw_ostream &O) {
-  unsigned Dim = MI->getOperand(OpNo).getImm();
+  unsigned Dim = static_cast<unsigned>(MI->getOperand(OpNo).getImm());
   O << " dim:SQ_RSRC_IMG_";
 
-  const AMDGPU::MIMGDimInfo *DimInfo = AMDGPU::getMIMGDimInfoByEncoding(Dim);
+  const AMDGPU::MIMGDimInfo *DimInfo =
+      AMDGPU::getMIMGDimInfoByEncoding(static_cast<uint8_t>(Dim));
   if (DimInfo)
     O << AMDGPU::getMIMGDimInfoStr(DimInfo->AsmSuffix);
   else
@@ -298,7 +299,7 @@ void AMDGPUInstPrinter::printSymbolicFormat(const MCInst *MI,
     AMDGPU::getNamedOperandIdx(MI->getOpcode(), AMDGPU::OpName::format);
   assert(OpNo != -1);
 
-  unsigned Val = MI->getOperand(OpNo).getImm();
+  unsigned Val = static_cast<unsigned>(MI->getOperand(OpNo).getImm());
   if (AMDGPU::isGFX10Plus(STI)) {
     if (Val == UFMT_DEFAULT)
       return;
@@ -751,7 +752,7 @@ void AMDGPUInstPrinter::printLiteral64(uint64_t Imm, raw_ostream &O,
 void AMDGPUInstPrinter::printBLGP(const MCInst *MI, unsigned OpNo,
                                   const MCSubtargetInfo &STI,
                                   raw_ostream &O) {
-  unsigned Imm = MI->getOperand(OpNo).getImm();
+  unsigned Imm = static_cast<unsigned>(MI->getOperand(OpNo).getImm());
   if (!Imm)
     return;
 
@@ -862,7 +863,7 @@ void AMDGPUInstPrinter::printRegularOperand(const MCInst *MI, unsigned OpNo,
     case AMDGPU::OPERAND_REG_IMM_V2FP32:
     case MCOI::OPERAND_IMMEDIATE:
     case AMDGPU::OPERAND_INLINE_SPLIT_BARRIER_INT32:
-      printImmediate32(Op.getImm(), STI, O);
+      printImmediate32(static_cast<uint32_t>(Op.getImm()), STI, O);
       break;
     case AMDGPU::OPERAND_REG_IMM_INT64:
     case AMDGPU::OPERAND_REG_INLINE_C_INT64:
@@ -877,15 +878,15 @@ void AMDGPUInstPrinter::printRegularOperand(const MCInst *MI, unsigned OpNo,
       break;
     case AMDGPU::OPERAND_REG_INLINE_C_INT16:
     case AMDGPU::OPERAND_REG_IMM_INT16:
-      printImmediateInt16(Op.getImm(), STI, O);
+      printImmediateInt16(static_cast<uint32_t>(Op.getImm()), STI, O);
       break;
     case AMDGPU::OPERAND_REG_INLINE_C_FP16:
     case AMDGPU::OPERAND_REG_IMM_FP16:
-      printImmediateF16(Op.getImm(), STI, O);
+      printImmediateF16(static_cast<uint32_t>(Op.getImm()), STI, O);
       break;
     case AMDGPU::OPERAND_REG_INLINE_C_BF16:
     case AMDGPU::OPERAND_REG_IMM_BF16:
-      printImmediateBF16(Op.getImm(), STI, O);
+      printImmediateBF16(static_cast<uint32_t>(Op.getImm()), STI, O);
       break;
     case AMDGPU::OPERAND_REG_IMM_V2INT16:
     case AMDGPU::OPERAND_REG_IMM_V2BF16:
@@ -895,7 +896,7 @@ void AMDGPUInstPrinter::printRegularOperand(const MCInst *MI, unsigned OpNo,
     case AMDGPU::OPERAND_REG_INLINE_C_V2INT16:
     case AMDGPU::OPERAND_REG_INLINE_C_V2BF16:
     case AMDGPU::OPERAND_REG_INLINE_C_V2FP16:
-      printImmediateV216(Op.getImm(), OpTy, STI, O);
+      printImmediateV216(static_cast<uint32_t>(Op.getImm()), OpTy, STI, O);
       break;
     case MCOI::OPERAND_UNKNOWN:
     case MCOI::OPERAND_PCREL:
@@ -904,7 +905,7 @@ void AMDGPUInstPrinter::printRegularOperand(const MCInst *MI, unsigned OpNo,
     case MCOI::OPERAND_REGISTER:
       // Disassembler does not fail when operand should not allow immediate
       // operands but decodes them into 32bit immediate operand.
-      printImmediate32(Op.getImm(), STI, O);
+      printImmediate32(static_cast<uint32_t>(Op.getImm()), STI, O);
       O << "/*Invalid immediate*/";
       break;
     default:
@@ -995,7 +996,8 @@ void AMDGPUInstPrinter::printOperandAndFPInputMods(const MCInst *MI,
   if (needsImpliedVcc(Desc, OpNo))
     printDefaultVccOperand(true, STI, O);
 
-  unsigned InputModifiers = MI->getOperand(OpNo).getImm();
+  unsigned InputModifiers =
+      static_cast<unsigned>(MI->getOperand(OpNo).getImm());
 
   // Use 'neg(...)' instead of '-' to avoid ambiguity.
   // This is important for integer literals because
@@ -1048,7 +1050,8 @@ void AMDGPUInstPrinter::printOperandAndIntInputMods(const MCInst *MI,
   if (needsImpliedVcc(Desc, OpNo))
     printDefaultVccOperand(true, STI, O);
 
-  unsigned InputModifiers = MI->getOperand(OpNo).getImm();
+  unsigned InputModifiers =
+      static_cast<unsigned>(MI->getOperand(OpNo).getImm());
   if (InputModifiers & SISrcMods::SEXT)
     O << "sext(";
   printRegularOperand(MI, OpNo + 1, STI, O);
@@ -1075,7 +1078,7 @@ void AMDGPUInstPrinter::printDPP8(const MCInst *MI, unsigned OpNo,
   if (!AMDGPU::isGFX10Plus(STI))
     llvm_unreachable("dpp8 is not supported on ASICs earlier than GFX10");
 
-  unsigned Imm = MI->getOperand(OpNo).getImm();
+  unsigned Imm = static_cast<unsigned>(MI->getOperand(OpNo).getImm());
   O << "dpp8:[" << formatDec(Imm & 0x7);
   for (size_t i = 1; i < 8; ++i) {
     O << ',' << formatDec((Imm >> (3 * i)) & 0x7);
@@ -1088,7 +1091,7 @@ void AMDGPUInstPrinter::printDPPCtrl(const MCInst *MI, unsigned OpNo,
                                      raw_ostream &O) {
   using namespace AMDGPU::DPP;
 
-  unsigned Imm = MI->getOperand(OpNo).getImm();
+  unsigned Imm = static_cast<unsigned>(MI->getOperand(OpNo).getImm());
   const MCInstrDesc &Desc = MII.get(MI->getOpcode());
 
   if (!AMDGPU::isLegalDPALU_DPPControl(STI, Imm) &&
@@ -1179,7 +1182,7 @@ void AMDGPUInstPrinter::printDPPCtrl(const MCInst *MI, unsigned OpNo,
 void AMDGPUInstPrinter::printDppBoundCtrl(const MCInst *MI, unsigned OpNo,
                                           const MCSubtargetInfo &STI,
                                           raw_ostream &O) {
-  unsigned Imm = MI->getOperand(OpNo).getImm();
+  unsigned Imm = static_cast<unsigned>(MI->getOperand(OpNo).getImm());
   if (Imm) {
     O << " bound_ctrl:1";
   }
@@ -1188,7 +1191,7 @@ void AMDGPUInstPrinter::printDppBoundCtrl(const MCInst *MI, unsigned OpNo,
 void AMDGPUInstPrinter::printDppFI(const MCInst *MI, unsigned OpNo,
                                    const MCSubtargetInfo &STI, raw_ostream &O) {
   using namespace llvm::AMDGPU::DPP;
-  unsigned Imm = MI->getOperand(OpNo).getImm();
+  unsigned Imm = static_cast<unsigned>(MI->getOperand(OpNo).getImm());
   if (Imm == DPP_FI_1 || Imm == DPP8_FI_1) {
     O << " fi:1";
   }
@@ -1198,7 +1201,7 @@ void AMDGPUInstPrinter::printSDWASel(const MCInst *MI, unsigned OpNo,
                                      raw_ostream &O) {
   using namespace llvm::AMDGPU::SDWA;
 
-  unsigned Imm = MI->getOperand(OpNo).getImm();
+  unsigned Imm = static_cast<unsigned>(MI->getOperand(OpNo).getImm());
   switch (Imm) {
   case SdwaSel::BYTE_0: O << "BYTE_0"; break;
   case SdwaSel::BYTE_1: O << "BYTE_1"; break;
@@ -1238,7 +1241,7 @@ void AMDGPUInstPrinter::printSDWADstUnused(const MCInst *MI, unsigned OpNo,
   using namespace llvm::AMDGPU::SDWA;
 
   O << "dst_unused:";
-  unsigned Imm = MI->getOperand(OpNo).getImm();
+  unsigned Imm = static_cast<unsigned>(MI->getOperand(OpNo).getImm());
   switch (Imm) {
   case DstUnused::UNUSED_PAD: O << "UNUSED_PAD"; break;
   case DstUnused::UNUSED_SEXT: O << "UNUSED_SEXT"; break;
@@ -1252,7 +1255,7 @@ void AMDGPUInstPrinter::printExpSrcN(const MCInst *MI, unsigned OpNo,
                                      unsigned N) {
   unsigned Opc = MI->getOpcode();
   int EnIdx = AMDGPU::getNamedOperandIdx(Opc, AMDGPU::OpName::en);
-  unsigned En = MI->getOperand(EnIdx).getImm();
+  unsigned En = static_cast<unsigned>(MI->getOperand(EnIdx).getImm());
 
   int ComprIdx = AMDGPU::getNamedOperandIdx(Opc, AMDGPU::OpName::compr);
 
@@ -1343,8 +1346,9 @@ void AMDGPUInstPrinter::printPackedModifier(const MCInst *MI,
       break;
 
     int ModIdx = AMDGPU::getNamedOperandIdx(Opc, SrcMod);
-    Ops[NumOps++] =
-        (ModIdx != -1) ? MI->getOperand(ModIdx).getImm() : DefaultValue;
+    Ops[NumOps++] = (ModIdx != -1)
+                        ? static_cast<int>(MI->getOperand(ModIdx).getImm())
+                        : DefaultValue;
   }
 
   // Some instructions, e.g. v_interp_p2_f16 in GFX9, have src0, src2, but no
@@ -1355,7 +1359,7 @@ void AMDGPUInstPrinter::printPackedModifier(const MCInst *MI,
     int Mod2Idx =
         AMDGPU::getNamedOperandIdx(Opc, AMDGPU::OpName::src2_modifiers);
     assert(Mod2Idx != -1);
-    Ops[NumOps++] = MI->getOperand(Mod2Idx).getImm();
+    Ops[NumOps++] = static_cast<int>(MI->getOperand(Mod2Idx).getImm());
   }
 
   const bool HasDst =
@@ -1372,7 +1376,7 @@ void AMDGPUInstPrinter::printPackedModifier(const MCInst *MI,
           AMDGPU::OpName::src2_modifiers}) {
       int Idx = AMDGPU::getNamedOperandIdx(Opc, OpName);
       if (Idx != -1)
-        Ops[NumOps++] = MI->getOperand(Idx).getImm();
+        Ops[NumOps++] = static_cast<int>(MI->getOperand(Idx).getImm());
       else
         Ops[NumOps++] = DefaultValue;
     }
@@ -1405,7 +1409,7 @@ void AMDGPUInstPrinter::printOpSel(const MCInst *MI, unsigned,
   if (isCvt_F32_Fp8_Bf8_e64(Opc)) {
     auto SrcMod =
         AMDGPU::getNamedOperandIdx(Opc, AMDGPU::OpName::src0_modifiers);
-    unsigned Mod = MI->getOperand(SrcMod).getImm();
+    unsigned Mod = static_cast<unsigned>(MI->getOperand(SrcMod).getImm());
     unsigned Index0 = !!(Mod & SISrcMods::OP_SEL_0);
     unsigned Index1 = !!(Mod & SISrcMods::OP_SEL_1);
     if (Index0 || Index1)
@@ -1554,7 +1558,7 @@ void AMDGPUInstPrinter::printMatrixBScaleFmt(const MCInst *MI, unsigned OpNo,
 void AMDGPUInstPrinter::printInterpSlot(const MCInst *MI, unsigned OpNum,
                                         const MCSubtargetInfo &STI,
                                         raw_ostream &O) {
-  unsigned Imm = MI->getOperand(OpNum).getImm();
+  unsigned Imm = static_cast<unsigned>(MI->getOperand(OpNum).getImm());
   switch (Imm) {
   case 0:
     O << "p10";
@@ -1573,14 +1577,14 @@ void AMDGPUInstPrinter::printInterpSlot(const MCInst *MI, unsigned OpNum,
 void AMDGPUInstPrinter::printInterpAttr(const MCInst *MI, unsigned OpNum,
                                         const MCSubtargetInfo &STI,
                                         raw_ostream &O) {
-  unsigned Attr = MI->getOperand(OpNum).getImm();
+  unsigned Attr = static_cast<unsigned>(MI->getOperand(OpNum).getImm());
   O << "attr" << Attr;
 }
 
 void AMDGPUInstPrinter::printInterpAttrChan(const MCInst *MI, unsigned OpNum,
                                         const MCSubtargetInfo &STI,
                                         raw_ostream &O) {
-  unsigned Chan = MI->getOperand(OpNum).getImm();
+  unsigned Chan = static_cast<unsigned>(MI->getOperand(OpNum).getImm());
   O << '.' << "xyzw"[Chan & 0x3];
 }
 
@@ -1588,7 +1592,7 @@ void AMDGPUInstPrinter::printGPRIdxMode(const MCInst *MI, unsigned OpNo,
                                         const MCSubtargetInfo &STI,
                                         raw_ostream &O) {
   using namespace llvm::AMDGPU::VGPRIndexMode;
-  unsigned Val = MI->getOperand(OpNo).getImm();
+  unsigned Val = static_cast<unsigned>(MI->getOperand(OpNo).getImm());
 
   if ((Val & ~ENABLE_MASK) != 0) {
     O << formatHex(static_cast<uint64_t>(Val));
@@ -1634,7 +1638,7 @@ void AMDGPUInstPrinter::printIfSet(const MCInst *MI, unsigned OpNo,
 void AMDGPUInstPrinter::printOModSI(const MCInst *MI, unsigned OpNo,
                                     const MCSubtargetInfo &STI,
                                     raw_ostream &O) {
-  int Imm = MI->getOperand(OpNo).getImm();
+  int Imm = static_cast<int>(MI->getOperand(OpNo).getImm());
   if (Imm == SIOutMods::MUL2)
     O << " mul:2";
   else if (Imm == SIOutMods::MUL4)
@@ -1648,7 +1652,7 @@ void AMDGPUInstPrinter::printSendMsg(const MCInst *MI, unsigned OpNo,
                                      raw_ostream &O) {
   using namespace llvm::AMDGPU::SendMsg;
 
-  const unsigned Imm16 = MI->getOperand(OpNo).getImm();
+  const unsigned Imm16 = static_cast<unsigned>(MI->getOperand(OpNo).getImm());
 
   uint16_t MsgId;
   uint16_t OpId;
@@ -1725,7 +1729,7 @@ void AMDGPUInstPrinter::printSwizzle(const MCInst *MI, unsigned OpNo,
                                      raw_ostream &O) {
   using namespace llvm::AMDGPU::Swizzle;
 
-  uint16_t Imm = MI->getOperand(OpNo).getImm();
+  uint16_t Imm = static_cast<uint16_t>(MI->getOperand(OpNo).getImm());
   if (Imm == 0) {
     return;
   }
@@ -1808,7 +1812,7 @@ void AMDGPUInstPrinter::printSWaitCnt(const MCInst *MI, unsigned OpNo,
                                       raw_ostream &O) {
   AMDGPU::IsaVersion ISA = AMDGPU::getIsaVersion(STI.getCPU());
 
-  unsigned SImm16 = MI->getOperand(OpNo).getImm();
+  unsigned SImm16 = static_cast<unsigned>(MI->getOperand(OpNo).getImm());
   unsigned Vmcnt, Expcnt, Lgkmcnt;
   decodeWaitcnt(ISA, SImm16, Vmcnt, Expcnt, Lgkmcnt);
 
@@ -1837,13 +1841,15 @@ void AMDGPUInstPrinter::printDepCtr(const MCInst *MI, unsigned OpNo,
   uint64_t Imm16 = MI->getOperand(OpNo).getImm() & 0xffff;
 
   bool HasNonDefaultVal = false;
-  if (isSymbolicDepCtrEncoding(Imm16, HasNonDefaultVal, STI)) {
+  if (isSymbolicDepCtrEncoding(static_cast<unsigned>(Imm16), HasNonDefaultVal,
+                               STI)) {
     int Id = 0;
     StringRef Name;
     unsigned Val;
     bool IsDefault;
     ListSeparator Sep(" ");
-    while (decodeDepCtr(Imm16, Id, Name, Val, IsDefault, STI)) {
+    while (decodeDepCtr(static_cast<unsigned>(Imm16), Id, Name, Val, IsDefault,
+                        STI)) {
       if (!IsDefault || !HasNonDefaultVal)
         O << Sep << Name << '(' << Val << ')';
     }
@@ -1866,7 +1872,7 @@ void AMDGPUInstPrinter::printSDelayALU(const MCInst *MI, unsigned OpNo,
   static const std::array<const char *, 6> InstSkips = {
       "SAME", "NEXT", "SKIP_1", "SKIP_2", "SKIP_3", "SKIP_4"};
 
-  unsigned SImm16 = MI->getOperand(OpNo).getImm();
+  unsigned SImm16 = static_cast<unsigned>(MI->getOperand(OpNo).getImm());
   const char *Prefix = "";
 
   unsigned Value = SImm16 & 0xF;
@@ -1898,7 +1904,7 @@ void AMDGPUInstPrinter::printSDelayALU(const MCInst *MI, unsigned OpNo,
 void AMDGPUInstPrinter::printHwreg(const MCInst *MI, unsigned OpNo,
                                    const MCSubtargetInfo &STI, raw_ostream &O) {
   using namespace llvm::AMDGPU::Hwreg;
-  unsigned Val = MI->getOperand(OpNo).getImm();
+  unsigned Val = static_cast<unsigned>(MI->getOperand(OpNo).getImm());
   auto [Id, Offset, Width] = HwregEncoding::decode(Val);
   StringRef HwRegName = getHwreg(Id, STI);
 
@@ -1916,7 +1922,7 @@ void AMDGPUInstPrinter::printHwreg(const MCInst *MI, unsigned OpNo,
 void AMDGPUInstPrinter::printEndpgm(const MCInst *MI, unsigned OpNo,
                                     const MCSubtargetInfo &STI,
                                     raw_ostream &O) {
-  uint16_t Imm = MI->getOperand(OpNo).getImm();
+  uint16_t Imm = static_cast<uint16_t>(MI->getOperand(OpNo).getImm());
   if (Imm == 0) {
     return;
   }
@@ -1936,7 +1942,7 @@ void AMDGPUInstPrinter::printNamedInt(const MCInst *MI, unsigned OpNo,
 void AMDGPUInstPrinter::printBitOp3(const MCInst *MI, unsigned OpNo,
                                     const MCSubtargetInfo &STI,
                                     raw_ostream &O) {
-  uint8_t Imm = MI->getOperand(OpNo).getImm();
+  uint8_t Imm = static_cast<uint8_t>(MI->getOperand(OpNo).getImm());
   if (!Imm)
     return;
 
@@ -1950,7 +1956,7 @@ void AMDGPUInstPrinter::printBitOp3(const MCInst *MI, unsigned OpNo,
 void AMDGPUInstPrinter::printScaleSel(const MCInst *MI, unsigned OpNo,
                                       const MCSubtargetInfo &STI,
                                       raw_ostream &O) {
-  uint8_t Imm = MI->getOperand(OpNo).getImm();
+  uint8_t Imm = static_cast<uint8_t>(MI->getOperand(OpNo).getImm());
   if (!Imm)
     return;
 

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCCodeEmitter.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCCodeEmitter.cpp
@@ -121,16 +121,17 @@ static void addFixup(SmallVectorImpl<MCFixup> &Fixups, uint32_t Offset,
 template <typename IntTy>
 static uint32_t getIntInlineImmEncoding(IntTy Imm) {
   if (Imm >= 0 && Imm <= 64)
-    return 128 + Imm;
+    return static_cast<uint32_t>(128 + Imm);
 
   if (Imm >= -16 && Imm <= -1)
-    return 192 + std::abs(Imm);
+    return static_cast<uint32_t>(192 + std::abs(Imm));
 
   return 0;
 }
 
 static uint32_t getLit16Encoding(uint16_t Val, const MCSubtargetInfo &STI) {
-  uint16_t IntImm = getIntInlineImmEncoding(static_cast<int16_t>(Val));
+  uint16_t IntImm =
+      static_cast<uint16_t>(getIntInlineImmEncoding(static_cast<int16_t>(Val)));
   if (IntImm != 0)
     return IntImm;
 
@@ -166,7 +167,8 @@ static uint32_t getLit16Encoding(uint16_t Val, const MCSubtargetInfo &STI) {
 }
 
 static uint32_t getLitBF16Encoding(uint16_t Val) {
-  uint16_t IntImm = getIntInlineImmEncoding(static_cast<int16_t>(Val));
+  uint16_t IntImm =
+      static_cast<uint16_t>(getIntInlineImmEncoding(static_cast<int16_t>(Val)));
   if (IntImm != 0)
     return IntImm;
 
@@ -480,7 +482,8 @@ void AMDGPUMCCodeEmitter::encodeInstruction(const MCInst &MI,
       auto OpType =
           static_cast<AMDGPU::OperandType>(Desc.operands()[i].OperandType);
       Imm = AMDGPU::encode32BitLiteral(Imm, OpType, IsLit);
-      support::endian::write<uint32_t>(CB, Imm, llvm::endianness::little);
+      support::endian::write<uint32_t>(CB, static_cast<uint32_t>(Imm),
+                                       llvm::endianness::little);
     }
 
     // Only one literal value allowed
@@ -614,7 +617,7 @@ void AMDGPUMCCodeEmitter::getMachineOpValue(const MCInst &MI,
     Op = Idx | (IsVGPROrAGPR << 8);
     return;
   }
-  unsigned OpNo = &MO - MI.begin();
+  unsigned OpNo = static_cast<unsigned>(&MO - MI.begin());
   getMachineOpValueCommon(MI, MO, OpNo, Op, Fixups, STI);
 }
 

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.cpp
@@ -39,8 +39,8 @@ AMDGPUMCExpr::AMDGPUMCExpr(VariantKind Kind, ArrayRef<const MCExpr *> Args,
   //
   // Will result in an asan failure if allocated on the heap through standard
   // allocation (e.g., through SmallVector's grow).
-  RawArgs = static_cast<const MCExpr **>(
-      Ctx.allocate(sizeof(const MCExpr *) * Args.size()));
+  RawArgs = static_cast<const MCExpr **>(Ctx.allocate(
+      static_cast<unsigned>(sizeof(const MCExpr *) * Args.size())));
   llvm::uninitialized_copy(Args, RawArgs);
   this->Args = ArrayRef<const MCExpr *>(RawArgs, Args.size());
 }
@@ -210,15 +210,22 @@ bool AMDGPUMCExpr::evaluateOccupancy(MCValue &Res,
   if (!Success || !evaluateMCExprs(Args.slice(7, 2), Asm, {NumSGPRs, NumVGPRs}))
     return false;
 
-  unsigned Occupancy = InitOccupancy;
+  unsigned Occupancy = static_cast<unsigned>(InitOccupancy);
   if (NumSGPRs)
-    Occupancy = std::min(Occupancy, IsaInfo::getOccupancyWithNumSGPRs(
-                                        NumSGPRs, MaxWaves, SGPRTotal,
-                                        SGPRGranule, SGPRTrapReserve));
+    Occupancy =
+        std::min(Occupancy, IsaInfo::getOccupancyWithNumSGPRs(
+                                static_cast<unsigned>(NumSGPRs),
+                                static_cast<unsigned>(MaxWaves),
+                                static_cast<unsigned>(SGPRTotal),
+                                static_cast<unsigned>(SGPRGranule),
+                                static_cast<unsigned>(SGPRTrapReserve)));
   if (NumVGPRs)
-    Occupancy = std::min(Occupancy,
-                         IsaInfo::getNumWavesPerEUWithNumVGPRs(
-                             NumVGPRs, Granule, MaxWaves, TargetTotalNumVGPRs));
+    Occupancy =
+        std::min(Occupancy, IsaInfo::getNumWavesPerEUWithNumVGPRs(
+                                static_cast<unsigned>(NumVGPRs),
+                                static_cast<unsigned>(Granule),
+                                static_cast<unsigned>(MaxWaves),
+                                static_cast<unsigned>(TargetTotalNumVGPRs)));
 
   Res = MCValue::get(Occupancy);
   return true;

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUTargetStreamer.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUTargetStreamer.cpp
@@ -1202,7 +1202,7 @@ void AMDGPUTargetELFStreamer::emitAMDGPUInfo(
   auto getOrAddString = [&](StringRef Str) -> uint32_t {
     if (Str.empty())
       return UINT32_MAX;
-    return StrTab.add(Str);
+    return static_cast<uint32_t>(StrTab.add(Str));
   };
 
   auto EmitU32Entry = [&](AMDGPU::InfoKind Kind, uint32_t Val) {

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUAsmUtils.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUAsmUtils.cpp
@@ -136,7 +136,8 @@ int64_t getMsgId(StringRef Name, const MCSubtargetInfo &STI) {
 }
 
 StringRef getMsgName(uint64_t Encoding, const MCSubtargetInfo &STI) {
-  return getNameFromOperandTable(MsgOperands, Encoding, STI);
+  return getNameFromOperandTable(MsgOperands, static_cast<unsigned>(Encoding),
+                                 STI);
 }
 
 int64_t getMsgOpId(int64_t MsgId, StringRef Name, const MCSubtargetInfo &STI) {
@@ -150,8 +151,10 @@ StringRef getMsgOpName(int64_t MsgId, uint64_t Encoding,
   assert(msgRequiresOp(MsgId, STI) && "must have an operand");
 
   if (MsgId == ID_SYSMSG)
-    return getNameFromOperandTable(SysMsgOperands, Encoding, STI);
-  return getNameFromOperandTable(StreamMsgOperands, Encoding, STI);
+    return getNameFromOperandTable(SysMsgOperands,
+                                   static_cast<unsigned>(Encoding), STI);
+  return getNameFromOperandTable(StreamMsgOperands,
+                                 static_cast<unsigned>(Encoding), STI);
 }
 
 } // namespace SendMsg
@@ -172,7 +175,8 @@ int64_t getWaitEventMask(StringRef Name, const MCSubtargetInfo &STI) {
 }
 
 StringRef getWaitEventMaskName(uint64_t Encoding, const MCSubtargetInfo &STI) {
-  return getNameFromOperandTable(WaitEventOperands, Encoding, STI);
+  return getNameFromOperandTable(WaitEventOperands,
+                                 static_cast<unsigned>(Encoding), STI);
 }
 } // namespace WaitEvent
 
@@ -253,7 +257,8 @@ int64_t getHwregId(StringRef Name, const MCSubtargetInfo &STI) {
 }
 
 StringRef getHwreg(uint64_t Encoding, const MCSubtargetInfo &STI) {
-  return getNameFromOperandTable(Operands, Encoding, STI);
+  return getNameFromOperandTable(Operands, static_cast<unsigned>(Encoding),
+                                 STI);
 }
 
 } // namespace Hwreg

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUPALMetadata.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUPALMetadata.cpp
@@ -85,7 +85,8 @@ void AMDGPUPALMetadata::readFromIR(Module &M) {
     auto *Val = mdconst::dyn_extract<ConstantInt>(Tuple->getOperand(I + 1));
     if (!Key || !Val)
       continue;
-    setRegister(Key->getZExtValue(), Val->getZExtValue());
+    setRegister(static_cast<unsigned>(Key->getZExtValue()),
+                static_cast<unsigned>(Val->getZExtValue()));
   }
 }
 
@@ -200,7 +201,7 @@ unsigned AMDGPUPALMetadata::getRegister(unsigned Reg) {
   auto N = It->second;
   if (N.getKind() != msgpack::Type::UInt)
     return 0;
-  return N.getUInt();
+  return static_cast<unsigned>(N.getUInt());
 }
 
 // Set a register in the metadata.
@@ -823,8 +824,8 @@ void AMDGPUPALMetadata::toString(std::string &String) {
     for (auto I = Regs.begin(), E = Regs.end(); I != E; ++I) {
       if (I != Regs.begin())
         Stream << ',';
-      unsigned Reg = I->first.getUInt();
-      unsigned Val = I->second.getUInt();
+      unsigned Reg = static_cast<unsigned>(I->first.getUInt());
+      unsigned Val = static_cast<unsigned>(I->second.getUInt());
       Stream << "0x" << Twine::utohexstr(Reg) << ",0x" << Twine::utohexstr(Val);
     }
     Stream << '\n';
@@ -839,7 +840,9 @@ void AMDGPUPALMetadata::toString(std::string &String) {
   RegsObj = MsgPackDoc.getMapNode();
   for (auto I : OrigRegs) {
     auto Key = I.first;
-    if (StringRef RegName = getRegisterName(Key.getUInt()); !RegName.empty()) {
+    if (StringRef RegName =
+            getRegisterName(static_cast<unsigned>(Key.getUInt()));
+        !RegName.empty()) {
       std::string KeyName = Key.toString();
       KeyName += " (";
       KeyName += RegName;
@@ -1062,7 +1065,7 @@ unsigned AMDGPUPALMetadata::getPALVersion(unsigned idx) {
   if (Version.isEmpty())
     // Default to 2.6 if there's no version info
     return idx ? 6 : 2;
-  return Version.getArray()[idx].getUInt();
+  return static_cast<unsigned>(Version.getArray()[idx].getUInt());
 }
 
 unsigned AMDGPUPALMetadata::getPALMajorVersion() { return getPALVersion(0); }
@@ -1081,7 +1084,7 @@ void AMDGPUPALMetadata::updateHwStageMaximum(unsigned CC, StringRef field,
   if (Node.isEmpty())
     Node = Val;
   else
-    Node = std::max<unsigned>(Node.getUInt(), Val);
+    Node = std::max<unsigned>(static_cast<unsigned>(Node.getUInt()), Val);
 }
 
 // Set the field in a given .hardware_stages entry

--- a/llvm/lib/Target/AMDGPU/Utils/AMDKernelCodeTUtils.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDKernelCodeTUtils.cpp
@@ -439,7 +439,7 @@ bool AMDGPUMCKernelCodeT::ParseKernelCodeT(StringRef ID, MCAsmParser &MCParser,
 
 void AMDGPUMCKernelCodeT::EmitKernelCodeT(raw_ostream &OS, MCContext &Ctx,
                                           PrintHelper Helper) {
-  const int Size = hasMCExprVersionTable().size();
+  const int Size = static_cast<int>(hasMCExprVersionTable().size());
   for (int i = 0; i < Size; ++i) {
     OS << "\t\t";
     if (hasMCExprVersionTable()[i]) {


### PR DESCRIPTION
For context, see https://github.com/llvm/llvm-project/issues/215213

This patch handles the following cases:

MCOperand::getImm() returns int64_t and is passed to the AMDGPUInstPrinter
helpers and to the encode/decode helpers in AMDGPUAsmUtils, which take unsigned,
uint32_t, uint16_t, uint8_t, int or int16_t. Add a static_cast to make the
existing narrowing conversion explicit. Each cast targets the parameter type of
the specific helper being called rather than one common type, because the
helpers deliberately take different widths: the operand fields they decode are
different widths in the encoding.

APInt::getZExtValue() returns uint64_t and is assigned to 32-bit locals holding
immediate operands in AMDGPUMCExpr. Add a static_cast to make the existing
narrowing conversion explicit.

Container size() returns size_t and is assigned to unsigned or int locals
holding operand counts and PAL metadata array lengths. Add a static_cast to make
the existing narrowing conversion explicit.

Values are assigned to the fixed-width fields of the PAL metadata and kernel
descriptor structures, which the ABI defines as 8-, 16- or 32-bit. Add a
static_cast; the field width is the ABI's, not something this patch chooses.

This fixes 62 instances of MSVC warning C4244 and 3 of C4267 ("possible loss of
data") across 7 files in llvm/lib/Target/AMDGPU.

Assisted-by: Claude <noreply@anthropic.com>
