### PR TITLE
[AMDGPU][NFC] Explicitly narrow conversions in GlobalISel support code

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUCallLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCallLowering.cpp
@@ -133,8 +133,9 @@ struct AMDGPUIncomingArgHandler : public CallLowering::IncomingValueHandler {
       if (ValTy.isInteger()) {
         MIRBuilder.buildTrunc(ValVReg, Extended);
       } else {
-        auto Trunc = MIRBuilder.buildTrunc(LLT::integer(ValTy.getSizeInBits()),
-                                           Extended);
+        auto Trunc = MIRBuilder.buildTrunc(
+            LLT::integer(static_cast<unsigned>(ValTy.getSizeInBits())),
+            Extended);
         MIRBuilder.buildBitcast(ValVReg, Trunc);
       }
       return;
@@ -168,8 +169,9 @@ struct AMDGPUIncomingArgHandler : public CallLowering::IncomingValueHandler {
       if (ValTy.isInteger()) {
         MIRBuilder.buildTrunc(ValVReg, Extended);
       } else {
-        auto Trunc = MIRBuilder.buildTrunc(LLT::integer(ValTy.getSizeInBits()),
-                                           Extended);
+        auto Trunc = MIRBuilder.buildTrunc(
+            LLT::integer(static_cast<unsigned>(ValTy.getSizeInBits())),
+            Extended);
         MIRBuilder.buildBitcast(ValVReg, Trunc);
       }
       return;
@@ -519,19 +521,19 @@ static void allocateHSAUserSGPRs(CCState &CCInfo,
   if (UserSGPRInfo.hasPrivateSegmentBuffer()) {
     Register PrivateSegmentBufferReg = Info.addPrivateSegmentBuffer(TRI);
     MF.addLiveIn(PrivateSegmentBufferReg, &AMDGPU::SGPR_128RegClass);
-    CCInfo.AllocateReg(PrivateSegmentBufferReg);
+    CCInfo.AllocateReg(static_cast<MCPhysReg>(PrivateSegmentBufferReg));
   }
 
   if (UserSGPRInfo.hasDispatchPtr()) {
     Register DispatchPtrReg = Info.addDispatchPtr(TRI);
     MF.addLiveIn(DispatchPtrReg, &AMDGPU::SGPR_64RegClass);
-    CCInfo.AllocateReg(DispatchPtrReg);
+    CCInfo.AllocateReg(static_cast<MCPhysReg>(DispatchPtrReg));
   }
 
   if (UserSGPRInfo.hasQueuePtr()) {
     Register QueuePtrReg = Info.addQueuePtr(TRI);
     MF.addLiveIn(QueuePtrReg, &AMDGPU::SGPR_64RegClass);
-    CCInfo.AllocateReg(QueuePtrReg);
+    CCInfo.AllocateReg(static_cast<MCPhysReg>(QueuePtrReg));
   }
 
   if (UserSGPRInfo.hasKernargSegmentPtr()) {
@@ -542,25 +544,25 @@ static void allocateHSAUserSGPRs(CCState &CCInfo,
     MRI.addLiveIn(InputPtrReg, VReg);
     B.getMBB().addLiveIn(InputPtrReg);
     B.buildCopy(VReg, InputPtrReg);
-    CCInfo.AllocateReg(InputPtrReg);
+    CCInfo.AllocateReg(static_cast<MCPhysReg>(InputPtrReg));
   }
 
   if (UserSGPRInfo.hasDispatchID()) {
     Register DispatchIDReg = Info.addDispatchID(TRI);
     MF.addLiveIn(DispatchIDReg, &AMDGPU::SGPR_64RegClass);
-    CCInfo.AllocateReg(DispatchIDReg);
+    CCInfo.AllocateReg(static_cast<MCPhysReg>(DispatchIDReg));
   }
 
   if (UserSGPRInfo.hasFlatScratchInit()) {
     Register FlatScratchInitReg = Info.addFlatScratchInit(TRI);
     MF.addLiveIn(FlatScratchInitReg, &AMDGPU::SGPR_64RegClass);
-    CCInfo.AllocateReg(FlatScratchInitReg);
+    CCInfo.AllocateReg(static_cast<MCPhysReg>(FlatScratchInitReg));
   }
 
   if (UserSGPRInfo.hasPrivateSegmentSize()) {
     Register PrivateSegmentSizeReg = Info.addPrivateSegmentSize(TRI);
     MF.addLiveIn(PrivateSegmentSizeReg, &AMDGPU::SGPR_32RegClass);
-    CCInfo.AllocateReg(PrivateSegmentSizeReg);
+    CCInfo.AllocateReg(static_cast<MCPhysReg>(PrivateSegmentSizeReg));
   }
 
   // TODO: Add GridWorkGroupCount user SGPRs when used. For now with HSA we read
@@ -598,7 +600,7 @@ bool AMDGPUCallLowering::lowerFormalArgumentsKernel(
 
     const bool IsByRef = Arg.hasByRefAttr();
     Type *ArgTy = IsByRef ? Arg.getParamByRefType() : Arg.getType();
-    unsigned AllocSize = DL.getTypeAllocSize(ArgTy);
+    unsigned AllocSize = static_cast<unsigned>(DL.getTypeAllocSize(ArgTy));
     if (AllocSize == 0)
       continue;
 
@@ -676,14 +678,14 @@ bool AMDGPUCallLowering::lowerFormalArguments(
   if (UserSGPRInfo.hasImplicitBufferPtr()) {
     Register ImplicitBufferPtrReg = Info->addImplicitBufferPtr(*TRI);
     MF.addLiveIn(ImplicitBufferPtrReg, &AMDGPU::SGPR_64RegClass);
-    CCInfo.AllocateReg(ImplicitBufferPtrReg);
+    CCInfo.AllocateReg(static_cast<MCPhysReg>(ImplicitBufferPtrReg));
   }
 
   // FIXME: This probably isn't defined for mesa
   if (UserSGPRInfo.hasFlatScratchInit() && !Subtarget.isAmdPalOS()) {
     Register FlatScratchInitReg = Info->addFlatScratchInit(*TRI);
     MF.addLiveIn(FlatScratchInitReg, &AMDGPU::SGPR_64RegClass);
-    CCInfo.AllocateReg(FlatScratchInitReg);
+    CCInfo.AllocateReg(static_cast<MCPhysReg>(FlatScratchInitReg));
   }
 
   SmallVector<ArgInfo, 32> SplitArgs;
@@ -797,7 +799,7 @@ bool AMDGPUCallLowering::lowerFormalArguments(
     TLI.allocateSpecialInputVGPRsFixed(CCInfo, MF, *TRI, *Info);
 
     if (!Subtarget.hasFlatScratchEnabled())
-      CCInfo.AllocateReg(Info->getScratchRSrcReg());
+      CCInfo.AllocateReg(static_cast<MCPhysReg>(Info->getScratchRSrcReg()));
     TLI.allocateSpecialInputSGPRs(CCInfo, MF, *TRI, *Info);
   }
 
@@ -828,7 +830,7 @@ bool AMDGPUCallLowering::lowerFormalArguments(
   // the caller's stack. So, whenever we lower formal arguments, we should keep
   // track of this information, since we might lower a tail call in this
   // function later.
-  Info->setBytesInStackArgArea(StackSize);
+  Info->setBytesInStackArgArea(static_cast<unsigned>(StackSize));
 
   // Move back to the end of the basic block.
   B.setMBB(MBB);
@@ -930,7 +932,8 @@ bool AMDGPUCallLowering::passSpecialInputs(MachineIRBuilder &MIRBuilder,
 
     if (OutgoingArg->isRegister()) {
       ArgRegs.emplace_back(OutgoingArg->getRegister(), InputReg);
-      if (!CCInfo.AllocateReg(OutgoingArg->getRegister()))
+      if (!CCInfo.AllocateReg(
+              static_cast<MCPhysReg>(OutgoingArg->getRegister())))
         report_fatal_error("failed to allocate implicit input argument");
     } else {
       LLVM_DEBUG(dbgs() << "Unhandled stack passed implicit input argument\n");
@@ -1032,7 +1035,7 @@ bool AMDGPUCallLowering::passSpecialInputs(MachineIRBuilder &MIRBuilder,
     if (InputReg)
       ArgRegs.emplace_back(OutgoingArg->getRegister(), InputReg);
 
-    if (!CCInfo.AllocateReg(OutgoingArg->getRegister()))
+    if (!CCInfo.AllocateReg(static_cast<MCPhysReg>(OutgoingArg->getRegister())))
       report_fatal_error("failed to allocate implicit input argument");
   } else {
     LLVM_DEBUG(dbgs() << "Unhandled stack passed implicit input argument\n");
@@ -1428,7 +1431,8 @@ bool AMDGPUCallLowering::lowerTailCall(
 
     // The callee will pop the argument stack as a tail call. Thus, we must
     // keep it 16-byte aligned.
-    NumBytes = alignTo(OutInfo.getStackSize(), ST.getStackAlignment());
+    NumBytes = static_cast<unsigned>(
+        alignTo(OutInfo.getStackSize(), ST.getStackAlignment()));
 
     // FPDiff will be negative if this tail call requires more space than we
     // would automatically have in our incoming argument space. Positive if we
@@ -1463,7 +1467,7 @@ bool AMDGPUCallLowering::lowerTailCall(
   // Mark the scratch resource descriptor as allocated so the CC analysis
   // does not assign user arguments to these registers, matching the callee.
   if (!ST.hasFlatScratchEnabled())
-    CCInfo.AllocateReg(FuncInfo->getScratchRSrcReg());
+    CCInfo.AllocateReg(static_cast<MCPhysReg>(FuncInfo->getScratchRSrcReg()));
 
   OutgoingValueAssigner Assigner(AssignFnFixed, AssignFnVarArg);
 
@@ -1674,7 +1678,7 @@ bool AMDGPUCallLowering::lowerCall(MachineIRBuilder &MIRBuilder,
   // does not assign user arguments to these registers, matching the callee.
   if (!ST.hasFlatScratchEnabled()) {
     const SIMachineFunctionInfo *FuncInfo = MF.getInfo<SIMachineFunctionInfo>();
-    CCInfo.AllocateReg(FuncInfo->getScratchRSrcReg());
+    CCInfo.AllocateReg(static_cast<MCPhysReg>(FuncInfo->getScratchRSrcReg()));
   }
 
   // Do the actual argument marshalling.
@@ -1695,7 +1699,7 @@ bool AMDGPUCallLowering::lowerCall(MachineIRBuilder &MIRBuilder,
                               ImplicitArgRegs);
 
   // Get a count of how many bytes are to be pushed on the stack.
-  unsigned NumBytes = CCInfo.getStackSize();
+  unsigned NumBytes = static_cast<unsigned>(CCInfo.getStackSize());
 
   // If Callee is a reg, since it is used by a target specific
   // instruction, it must have a register class matching the

--- a/llvm/lib/Target/AMDGPU/AMDGPUGlobalISelUtils.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUGlobalISelUtils.cpp
@@ -31,9 +31,9 @@ AMDGPU::getBaseWithConstantOffset(MachineRegisterInfo &MRI, Register Reg,
     unsigned Offset;
     const MachineOperand &Op = Def->getOperand(1);
     if (Op.isImm())
-      Offset = Op.getImm();
+      Offset = static_cast<unsigned>(Op.getImm());
     else
-      Offset = Op.getCImm()->getZExtValue();
+      Offset = static_cast<unsigned>(Op.getCImm()->getZExtValue());
 
     return std::pair(Register(), Offset);
   }
@@ -48,18 +48,20 @@ AMDGPU::getBaseWithConstantOffset(MachineRegisterInfo &MRI, Register Reg,
     }
     // TODO: Handle G_OR used for add case
     if (mi_match(Def->getOperand(2).getReg(), MRI, m_ICst(Offset)))
-      return std::pair(Def->getOperand(1).getReg(), Offset);
+      return std::pair(Def->getOperand(1).getReg(),
+                       static_cast<unsigned>(Offset));
 
     // FIXME: matcher should ignore copies
     if (mi_match(Def->getOperand(2).getReg(), MRI, m_Copy(m_ICst(Offset))))
-      return std::pair(Def->getOperand(1).getReg(), Offset);
+      return std::pair(Def->getOperand(1).getReg(),
+                       static_cast<unsigned>(Offset));
   }
 
   Register Base;
   if (ValueTracking && mi_match(Reg, MRI, m_GOr(m_Reg(Base), m_ICst(Offset))) &&
       ValueTracking->maskedValueIsZero(Base,
                                        APInt(32, Offset, /*isSigned=*/true)))
-    return std::pair(Base, Offset);
+    return std::pair(Base, static_cast<unsigned>(Offset));
 
   // Handle G_PTRTOINT (G_PTR_ADD base, const) case
   if (Def->getOpcode() == TargetOpcode::G_PTRTOINT) {
@@ -68,10 +70,12 @@ AMDGPU::getBaseWithConstantOffset(MachineRegisterInfo &MRI, Register Reg,
                  m_GPtrAdd(m_MInstr(Base), m_ICst(Offset)))) {
       // If Base was int converted to pointer, simply return int and offset.
       if (Base->getOpcode() == TargetOpcode::G_INTTOPTR)
-        return std::pair(Base->getOperand(1).getReg(), Offset);
+        return std::pair(Base->getOperand(1).getReg(),
+                         static_cast<unsigned>(Offset));
 
       // Register returned here will be of pointer type.
-      return std::pair(Base->getOperand(0).getReg(), Offset);
+      return std::pair(Base->getOperand(0).getReg(),
+                       static_cast<unsigned>(Offset));
     }
   }
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUPostLegalizerCombiner.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPostLegalizerCombiner.cpp
@@ -215,7 +215,8 @@ bool AMDGPUPostLegalizerCombinerImpl::matchUCharToFloat(
   LLT Ty = MRI.getType(DstReg);
   if (Ty == LLT::scalar(32) || Ty == LLT::scalar(16)) {
     Register SrcReg = MI.getOperand(1).getReg();
-    unsigned SrcSize = MRI.getType(SrcReg).getSizeInBits();
+    unsigned SrcSize =
+        static_cast<unsigned>(MRI.getType(SrcReg).getSizeInBits());
     assert(SrcSize == 16 || SrcSize == 32 || SrcSize == 64);
     const APInt Mask = APInt::getHighBitsSet(SrcSize, SrcSize - 8);
     return Helper.getValueTracking()->maskedValueIsZero(SrcReg, Mask);
@@ -333,9 +334,9 @@ bool AMDGPUPostLegalizerCombinerImpl::matchCvtF32UByteN(
 
     unsigned ShiftOffset = 8 * Offset;
     if (IsShr)
-      ShiftOffset += ShiftAmt;
+      ShiftOffset += static_cast<unsigned>(ShiftAmt);
     else
-      ShiftOffset -= ShiftAmt;
+      ShiftOffset -= static_cast<unsigned>(ShiftAmt);
 
     MatchInfo.CvtVal = Src0;
     MatchInfo.ShiftOffset = ShiftOffset;

--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankCombiner.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankCombiner.cpp
@@ -432,7 +432,8 @@ bool AMDGPURegBankCombinerImpl::combineD16Load(MachineInstr &MI) const {
 
     if (Load->getOpcode() == AMDGPU::G_ZEXTLOAD) {
       const MachineMemOperand *MMO = *Load->memoperands_begin();
-      unsigned LoadSize = MMO->getSizeInBits().getValue();
+      unsigned LoadSize =
+          static_cast<unsigned>(MMO->getSizeInBits().getValue());
       if (LoadSize == 8)
         return applyD16Load(AMDGPU::G_AMDGPU_LOAD_D16_LO_U8, MI, Load, Dst);
       if (LoadSize == 16)
@@ -470,7 +471,8 @@ bool AMDGPURegBankCombinerImpl::combineD16Load(MachineInstr &MI) const {
 
     if (Load->getOpcode() == AMDGPU::G_ZEXTLOAD) {
       const MachineMemOperand *MMO = *Load->memoperands_begin();
-      unsigned LoadSize = MMO->getSizeInBits().getValue();
+      unsigned LoadSize =
+          static_cast<unsigned>(MMO->getSizeInBits().getValue());
       if (LoadSize == 8)
         return applyD16Load(AMDGPU::G_AMDGPU_LOAD_D16_HI_U8, MI, Load, Dst);
       if (LoadSize == 16)

--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeHelper.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeHelper.cpp
@@ -108,7 +108,7 @@ bool RegBankLegalizeHelper::executeInWaterfallLoop(MachineIRBuilder &B,
   const AMDGPU::LaneMaskConstants &LMC = AMDGPU::LaneMaskConstants::get(ST);
 
 #ifndef NDEBUG
-  const int OrigRangeSize = std::distance(BeginIt, EndIt);
+  const int OrigRangeSize = static_cast<int>(std::distance(BeginIt, EndIt));
 #endif
 
   MachineRegisterInfo &MRI = *B.getMRI();
@@ -226,7 +226,7 @@ bool RegBankLegalizeHelper::executeInWaterfallLoop(MachineIRBuilder &B,
       buildReadFirstLane(B, CurrentLaneReg, OpReg, RBI);
 
       // Build the comparison(s), CurrentLaneReg == OpReg.
-      unsigned OpSize = OpTy.getSizeInBits();
+      unsigned OpSize = static_cast<unsigned>(OpTy.getSizeInBits());
       unsigned PartSize = (OpSize % 64 == 0) ? 64 : 32;
       LLT PartTy = LLT::integer(PartSize);
       unsigned NumParts = OpSize / PartSize;
@@ -310,7 +310,8 @@ unsigned RegBankLegalizeHelper::setBufferOffsets(
   if (std::optional<int64_t> Imm =
           getIConstantVRegSExtVal(CombinedOffset, MRI)) {
     uint32_t SOffset, ImmOffset;
-    if (TII.splitMUBUFOffset(*Imm, SOffset, ImmOffset, Alignment)) {
+    if (TII.splitMUBUFOffset(static_cast<uint32_t>(*Imm), SOffset, ImmOffset,
+                             Alignment)) {
       VOffsetReg = B.buildConstant(VgprRB_I32, 0).getReg(0);
       SOffsetReg = B.buildConstant(SgprRB_I32, SOffset).getReg(0);
       InstOffsetVal = ImmOffset;
@@ -378,7 +379,7 @@ bool RegBankLegalizeHelper::splitLoad(MachineInstr &MI,
   Register Base = MI.getOperand(1).getReg();
   LLT PtrTy = MRI.getType(Base);
   const RegisterBank *PtrRB = MRI.getRegBankOrNull(Base);
-  LLT OffsetTy = LLT::integer(PtrTy.getSizeInBits());
+  LLT OffsetTy = LLT::integer(static_cast<unsigned>(PtrTy.getSizeInBits()));
   SmallVector<Register, 4> LoadPartRegs;
 
   unsigned ByteOffset = 0;
@@ -394,7 +395,7 @@ bool RegBankLegalizeHelper::splitLoad(MachineInstr &MI,
     auto *OffsetMMO = MF.getMachineMemOperand(&BaseMMO, ByteOffset, PartTy);
     auto LoadPart = B.buildLoad({DstRB, PartTy}, BasePlusOffset, *OffsetMMO);
     LoadPartRegs.push_back(LoadPart.getReg(0));
-    ByteOffset += PartTy.getSizeInBytes();
+    ByteOffset += static_cast<unsigned>(PartTy.getSizeInBytes());
   }
 
   if (!MergeTy.isValid()) {
@@ -438,7 +439,8 @@ bool RegBankLegalizeHelper::widenLoad(MachineInstr &MI, LLT WideTy,
     auto Unmerge = B.buildUnmerge({DstRB, MergeTy}, WideLoad);
 
     LLT DstTy = MRI.getType(Dst);
-    unsigned NumElts = DstTy.getSizeInBits() / MergeTy.getSizeInBits();
+    unsigned NumElts =
+        static_cast<unsigned>(DstTy.getSizeInBits() / MergeTy.getSizeInBits());
     for (unsigned i = 0; i < NumElts; ++i) {
       MergeTyParts.push_back(Unmerge.getReg(i));
     }
@@ -452,7 +454,7 @@ bool RegBankLegalizeHelper::widenMMOToS32(GAnyLoad &MI) const {
   Register Dst = MI.getDstReg();
   Register Ptr = MI.getPointerReg();
   MachineMemOperand &MMO = MI.getMMO();
-  unsigned MemSize = 8 * MMO.getSize().getValue();
+  unsigned MemSize = static_cast<unsigned>(8 * MMO.getSize().getValue());
 
   MachineMemOperand *WideMMO = B.getMF().getMachineMemOperand(&MMO, 0, S32);
 
@@ -462,7 +464,8 @@ bool RegBankLegalizeHelper::widenMMOToS32(GAnyLoad &MI) const {
     auto Load = B.buildLoad(SgprRB_I32, Ptr, *WideMMO);
 
     if (MI.getOpcode() == G_ZEXTLOAD) {
-      APInt Mask = APInt::getLowBitsSet(S32.getSizeInBits(), MemSize);
+      APInt Mask = APInt::getLowBitsSet(
+          static_cast<unsigned>(S32.getSizeInBits()), MemSize);
       auto MaskCst = B.buildConstant(SgprRB_I32, Mask);
       B.buildAnd(Dst, Load, MaskCst);
     } else {
@@ -637,7 +640,7 @@ bool RegBankLegalizeHelper::lowerSBufToBuf(MachineInstr &MI,
   Register Dst = MI.getOperand(0).getReg();
   LLT Ty = MRI.getType(Dst);
   const RegisterBank *RSrcBank = MRI.getRegBank(MI.getOperand(1).getReg());
-  unsigned LoadSize = Ty.getSizeInBits();
+  unsigned LoadSize = static_cast<unsigned>(Ty.getSizeInBits());
   int NumLoads = 1;
   SmallVector<Register, 4> LoadParts;
   if (LoadSize == 256 || LoadSize == 512) {
@@ -654,7 +657,8 @@ bool RegBankLegalizeHelper::lowerSBufToBuf(MachineInstr &MI,
   int64_t ImmOffset = 0;
   unsigned MMOOffset = setBufferOffsets(B, MI.getOperand(2).getReg(), VOffset,
                                         SOffset, ImmOffset, Alignment);
-  const unsigned MemSize = divideCeil(OrigMMO->getSize().getValue(), NumLoads);
+  const unsigned MemSize = static_cast<unsigned>(
+      divideCeil(OrigMMO->getSize().getValue(), NumLoads));
   MachineMemOperand *BaseMMO = MF.getMachineMemOperand(OrigMMO, 0, MemSize);
   if (MMOOffset != 0)
     BaseMMO = MF.getMachineMemOperand(BaseMMO, MMOOffset, MemSize);
@@ -662,7 +666,7 @@ bool RegBankLegalizeHelper::lowerSBufToBuf(MachineInstr &MI,
   // instead. We can assume that the buffer is unswizzled.
   Register RSrc = MI.getOperand(1).getReg();
   Register VIndex = B.buildConstant(VgprRB_I32, 0).getReg(0);
-  unsigned CachePolicy = MI.getOperand(3).getImm();
+  unsigned CachePolicy = static_cast<unsigned>(MI.getOperand(3).getImm());
   unsigned Opc = AMDGPU::G_AMDGPU_BUFFER_LOAD;
   switch (MI.getOpcode()) {
   case AMDGPU::G_AMDGPU_S_BUFFER_LOAD_SBYTE:
@@ -950,7 +954,7 @@ bool RegBankLegalizeHelper::lowerSplitTo32Select(MachineInstr &MI) {
 
 bool RegBankLegalizeHelper::lowerSplitTo32SExtInReg(MachineInstr &MI) {
   auto Op1 = B.buildUnmerge(VgprRB_I32, MI.getOperand(1).getReg());
-  int Amt = MI.getOperand(2).getImm();
+  int Amt = static_cast<int>(MI.getOperand(2).getImm());
   Register Lo, Hi;
   // Hi|Lo: s sign bit, ?/x bits changed/not changed by sign-extend
   if (Amt <= 32) {
@@ -1335,8 +1339,8 @@ bool RegBankLegalizeHelper::lowerSetRounding(MachineInstr &MI) {
 
   // N.B. The setreg will be later folded into s_round_mode on supported
   // targets.
-  uint32_t BothRoundHwReg =
-      AMDGPU::Hwreg::HwregEncoding::encode(AMDGPU::Hwreg::ID_MODE, 0, 4);
+  uint32_t BothRoundHwReg = static_cast<uint32_t>(
+      AMDGPU::Hwreg::HwregEncoding::encode(AMDGPU::Hwreg::ID_MODE, 0, 4));
   B.buildIntrinsic(Intrinsic::amdgcn_s_setreg, ArrayRef<DstOp>(),
                    /*HasSideEffects=*/true, /*isConvergent=*/false)
       .addImm(static_cast<int16_t>(BothRoundHwReg))
@@ -1351,8 +1355,8 @@ bool RegBankLegalizeHelper::lowerSetRounding(MachineInstr &MI) {
 bool RegBankLegalizeHelper::lowerGetRounding(MachineInstr &MI) {
   Register Dst = MI.getOperand(0).getReg();
 
-  uint32_t BothRoundHwReg =
-      AMDGPU::Hwreg::HwregEncoding::encode(AMDGPU::Hwreg::ID_MODE, 0, 4);
+  uint32_t BothRoundHwReg = static_cast<uint32_t>(
+      AMDGPU::Hwreg::HwregEncoding::encode(AMDGPU::Hwreg::ID_MODE, 0, 4));
   auto GetReg =
       B.buildIntrinsic(Intrinsic::amdgcn_s_getreg, {SgprRB_I32},
                        /*HasSideEffects=*/true, /*isConvergent=*/false)
@@ -1548,13 +1552,14 @@ bool RegBankLegalizeHelper::lower(MachineInstr &MI,
     return lowerSBufToBuf(MI, WFI);
   case SplitLoad: {
     LLT DstTy = MRI.getType(MI.getOperand(0).getReg());
-    unsigned Size = DstTy.getSizeInBits();
+    unsigned Size = static_cast<unsigned>(DstTy.getSizeInBits());
     // Even split to 128-bit loads
     if (Size > 128) {
       LLT B128;
       if (DstTy.isVector()) {
         LLT EltTy = DstTy.getElementType();
-        B128 = LLT::fixed_vector(128 / EltTy.getSizeInBits(), EltTy);
+        B128 = LLT::fixed_vector(
+            static_cast<unsigned>(128 / EltTy.getSizeInBits()), EltTy);
       } else {
         B128 = LLT::integer(128);
       }
@@ -1961,7 +1966,7 @@ LLT RegBankLegalizeHelper::getBTyFromID(RegBankLLTMappingApplyID ID, LLT Ty) {
   case SgprBRC: {
     const SIRegisterInfo *TRI =
         static_cast<const SIRegisterInfo *>(MRI.getTargetRegisterInfo());
-    unsigned LLTSize = Ty.getSizeInBits();
+    unsigned LLTSize = static_cast<unsigned>(Ty.getSizeInBits());
     if (LLTSize >= 32 && TRI->getSGPRClassForBitWidth(LLTSize))
       return Ty;
     return LLT();
@@ -1969,7 +1974,7 @@ LLT RegBankLegalizeHelper::getBTyFromID(RegBankLLTMappingApplyID ID, LLT Ty) {
   case VgprBRC: {
     const SIRegisterInfo *TRI =
         static_cast<const SIRegisterInfo *>(MRI.getTargetRegisterInfo());
-    if (TRI->getSGPRClassForBitWidth(Ty.getSizeInBits()))
+    if (TRI->getSGPRClassForBitWidth(static_cast<unsigned>(Ty.getSizeInBits())))
       return Ty;
     return LLT();
   }
@@ -2187,7 +2192,7 @@ bool RegBankLegalizeHelper::applyMappingDst(
       break;
     }
     case VgprOrAgprAnyTy: {
-      const unsigned NumRegs = Ty.getSizeInBits() / 32;
+      const unsigned NumRegs = static_cast<unsigned>(Ty.getSizeInBits() / 32);
       const RegisterBank *DstRB =
           MFI->selectAGPRFormMFMA(NumRegs) ? AgprRB : VgprRB;
       if (RB == DstRB)
@@ -2419,7 +2424,7 @@ bool RegBankLegalizeHelper::applyMappingSrc(
       break;
     }
     case VgprOrAgprAnyTy: {
-      const unsigned NumRegs = Ty.getSizeInBits() / 32;
+      const unsigned NumRegs = static_cast<unsigned>(Ty.getSizeInBits() / 32);
       const RegisterBank *SrcRB =
           MFI->selectAGPRFormMFMA(NumRegs) ? AgprRB : VgprRB;
       if (RB != SrcRB)

--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeRules.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeRules.cpp
@@ -190,7 +190,7 @@ bool matchUniformityAndLLT(Register Reg, UniformityLLTOpPredicateID UniID,
         static_cast<const SIRegisterInfo *>(MRI.getTargetRegisterInfo());
     // There is no 16 bit SGPR register class. Extra size check is required
     // since getSGPRClassForBitWidth returns SReg_32RegClass for Size 16.
-    unsigned LLTSize = MRI.getType(Reg).getSizeInBits();
+    unsigned LLTSize = static_cast<unsigned>(MRI.getType(Reg).getSizeInBits());
     return LLTSize >= 32 && TRI->getSGPRClassForBitWidth(LLTSize);
   }
   case DivS1:
@@ -280,13 +280,14 @@ bool matchUniformityAndLLT(Register Reg, UniformityLLTOpPredicateID UniID,
     // Check if there is VGPR register class of same size as the LLT.
     const SIRegisterInfo *TRI =
         static_cast<const SIRegisterInfo *>(MRI.getTargetRegisterInfo());
-    return TRI->getSGPRClassForBitWidth(MRI.getType(Reg).getSizeInBits());
+    return TRI->getSGPRClassForBitWidth(
+        static_cast<unsigned>(MRI.getType(Reg).getSizeInBits()));
   }
   case BRC: {
     // Check if there is SGPR and VGPR register class of same size as the LLT.
     const SIRegisterInfo *TRI =
         static_cast<const SIRegisterInfo *>(MRI.getTargetRegisterInfo());
-    unsigned LLTSize = MRI.getType(Reg).getSizeInBits();
+    unsigned LLTSize = static_cast<unsigned>(MRI.getType(Reg).getSizeInBits());
     return LLTSize >= 32 && TRI->getSGPRClassForBitWidth(LLTSize) &&
            TRI->getVGPRClassForBitWidth(LLTSize);
   }
@@ -523,7 +524,7 @@ public:
 
   bool operator()(const MachineInstr &MI) const {
     unsigned Idx = 0;
-    unsigned ResultIdx = Expression.size();
+    unsigned ResultIdx = static_cast<unsigned>(Expression.size());
     bool Result;
     do {
       Result = Expression[Idx].Pred(MI);
@@ -550,8 +551,8 @@ public:
   Predicate operator&&(const Predicate &RHS) const {
     SmallVector<Elt, 8> AndExpression = Expression;
 
-    unsigned RHSSize = RHS.Expression.size();
-    unsigned ResultIdx = Expression.size();
+    unsigned RHSSize = static_cast<unsigned>(RHS.Expression.size());
+    unsigned ResultIdx = static_cast<unsigned>(Expression.size());
     for (unsigned i = 0; i < ResultIdx; ++i) {
       // LHS results in false, whole expression results in false.
       if (i + AndExpression[i].FJumpOffset == ResultIdx)
@@ -566,8 +567,8 @@ public:
   Predicate operator||(const Predicate &RHS) const {
     SmallVector<Elt, 8> OrExpression = Expression;
 
-    unsigned RHSSize = RHS.Expression.size();
-    unsigned ResultIdx = Expression.size();
+    unsigned RHSSize = static_cast<unsigned>(RHS.Expression.size());
+    unsigned ResultIdx = static_cast<unsigned>(Expression.size());
     for (unsigned i = 0; i < ResultIdx; ++i) {
       // LHS results in true, whole expression results in true.
       if (i + OrExpression[i].TJumpOffset == ResultIdx)
@@ -1070,7 +1071,8 @@ RegBankLegalizeRules::RegBankLegalizeRules(const GCNSubtarget &_ST,
 
   Predicate is8Or16BitMMO([](const MachineInstr &MI) -> bool {
     const MachineMemOperand *MMO = *MI.memoperands_begin();
-    const unsigned MemSize = 8 * MMO->getSize().getValue();
+    const unsigned MemSize =
+        static_cast<unsigned>(8 * MMO->getSize().getValue());
     return MemSize == 16 || MemSize == 8;
   });
 


### PR DESCRIPTION
For context, see https://github.com/llvm/llvm-project/issues/215213

This patch handles the following cases:

LLT::getSizeInBits() and LLT::getSizeInBytes() return TypeSize, which is
assigned to 32-bit locals or passed to 32-bit parameters holding a scalar or
vector width in bits. Add a static_cast to make the existing narrowing
conversion explicit. Every one of these is on a fixed-width LLT reached from a
MachineRegisterInfo type query in the AMDGPU legalizer and call-lowering paths,
so the TypeSize is not scalable and the fixed value is a register width of at
most 1024.

CCState::AllocateReg and the argument-lowering interfaces take MCPhysReg
(uint16_t), while the register numbers reaching them are Register or unsigned.
Add a static_cast. These are the fixed ABI input registers
(PrivateSegmentBuffer, DispatchPtr, QueuePtr, KernargSegmentPtr, DispatchID,
FlatScratchInit, WorkGroupID*, and the argument registers), which are physical
by construction -- they are read from SIMachineFunctionInfo's ABI register
assignments, not from virtual register operands.

MachineOperand::getImm() returns int64_t and ConstantInt::getZExtValue() returns
uint64_t; both are assigned to 32-bit locals holding intrinsic and G_* operands.
Add a static_cast to make the existing narrowing conversion explicit.

Container size() returns size_t and is assigned to unsigned locals holding
operand and source counts. Add a static_cast to make the existing narrowing
conversion explicit.

This fixes 51 instances of MSVC warning C4244 and 5 of C4267 ("possible loss of
data") across 6 files in llvm/lib/Target/AMDGPU.

Assisted-by: Claude <noreply@anthropic.com>
