### PR TITLE
[AMDGPU][NFC] Explicitly narrow conversions in the schedulers

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.h
@@ -176,7 +176,7 @@ private:
 public:
   HardwareUnitInfo() {}
 
-  unsigned size() { return AllSUs.size(); }
+  unsigned size() { return static_cast<unsigned>(AllSUs.size()); }
 
   unsigned getTotalCycles() { return TotalCycles; }
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUExportClustering.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUExportClustering.cpp
@@ -31,7 +31,8 @@ static bool isExport(const SUnit &SU) {
 
 static bool isPositionExport(const SIInstrInfo *TII, SUnit *SU) {
   const MachineInstr *MI = SU->getInstr();
-  unsigned Imm = TII->getNamedOperand(*MI, AMDGPU::OpName::tgt)->getImm();
+  unsigned Imm = static_cast<unsigned>(
+      TII->getNamedOperand(*MI, AMDGPU::OpName::tgt)->getImm());
   return Imm >= AMDGPU::Exp::ET_POS0 && Imm <= AMDGPU::Exp::ET_POS_LAST;
 }
 
@@ -59,7 +60,8 @@ static void buildCluster(ArrayRef<SUnit *> Exports, ScheduleDAGInstrs *DAG) {
   SUnit *ChainHead = Exports.front();
 
   // Now construct cluster from chain by adding new edges.
-  for (unsigned Idx = 0, End = Exports.size() - 1; Idx < End; ++Idx) {
+  for (unsigned Idx = 0, End = static_cast<unsigned>(Exports.size() - 1);
+       Idx < End; ++Idx) {
     SUnit *SUa = Exports[Idx];
     SUnit *SUb = Exports[Idx + 1];
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
@@ -681,7 +681,8 @@ void PipelineSolver::retreatPosition() {
     while (PipelineInstrs[CurrSyncGroupIdx].empty())
       --CurrSyncGroupIdx;
 
-    CurrConflInstNo = PipelineInstrs[CurrSyncGroupIdx].size() - 1;
+    CurrConflInstNo =
+        static_cast<int>(PipelineInstrs[CurrSyncGroupIdx].size() - 1);
   }
 }
 
@@ -926,7 +927,7 @@ bool PipelineSolver::solveGreedy() {
 unsigned PipelineSolver::computeProblemSize() {
   unsigned ProblemSize = 0;
   for (auto &PipeConflicts : PipelineInstrs) {
-    ProblemSize += PipeConflicts.size();
+    ProblemSize += static_cast<unsigned>(PipeConflicts.size());
   }
 
   return ProblemSize;
@@ -1192,18 +1193,19 @@ private:
       if (!SyncPipe.size())
         return false;
 
-      unsigned SuccSize = llvm::count_if(SU->Succs, [](const SDep &Succ) {
-        return Succ.getKind() == SDep::Data;
-      });
+      unsigned SuccSize =
+          static_cast<unsigned>(llvm::count_if(SU->Succs, [](const SDep &Succ) {
+            return Succ.getKind() == SDep::Data;
+          }));
       if (SuccSize >= Size)
         return false;
 
       if (HasIntermediary) {
         for (auto Succ : SU->Succs) {
-          unsigned SuccSize =
+          unsigned SuccSize = static_cast<unsigned>(
               llvm::count_if(Succ.getSUnit()->Succs, [](const SDep &SuccSucc) {
                 return SuccSucc.getKind() == SDep::Data;
-              });
+              }));
           if (SuccSize >= Size)
             return false;
         }
@@ -1232,18 +1234,19 @@ private:
       if (!SyncPipe.size())
         return false;
 
-      unsigned SuccSize = llvm::count_if(SU->Succs, [](const SDep &Succ) {
-        return Succ.getKind() == SDep::Data;
-      });
+      unsigned SuccSize =
+          static_cast<unsigned>(llvm::count_if(SU->Succs, [](const SDep &Succ) {
+            return Succ.getKind() == SDep::Data;
+          }));
       if (SuccSize >= Size)
         return true;
 
       if (HasIntermediary) {
         for (auto Succ : SU->Succs) {
-          unsigned SuccSize =
+          unsigned SuccSize = static_cast<unsigned>(
               llvm::count_if(Succ.getSUnit()->Succs, [](const SDep &SuccSucc) {
                 return SuccSucc.getKind() == SDep::Data;
-              });
+              }));
           if (SuccSize >= Size)
             return true;
         }
@@ -1569,7 +1572,7 @@ bool MFMAExpInterleaveOpt::analyzeDAG(const SIInstrInfo *TII) {
     }
   }
 
-  MFMAPipeCount = MFMAPipeSUs.size();
+  MFMAPipeCount = static_cast<unsigned>(MFMAPipeSUs.size());
 
   assert(TempExp && TempMFMA);
   assert(MFMAPipeCount > 0);
@@ -1614,17 +1617,17 @@ bool MFMAExpInterleaveOpt::analyzeDAG(const SIInstrInfo *TII) {
   }
 
   // The number of bit pack operations that depend on a single V_EXP
-  unsigned PackSuccCount =
+  unsigned PackSuccCount = static_cast<unsigned>(
       llvm::count_if(PackSUs, [this, &TempExp](SUnit *VPack) {
         return DAG->IsReachable(VPack, *TempExp);
-      });
+      }));
 
   // The number of bit pack operations an MFMA depends on
-  unsigned PackPredCount =
+  unsigned PackPredCount = static_cast<unsigned>(
       llvm::count_if((*TempMFMA)->Preds, [&isBitPack](SDep &Pred) {
         auto Opc = Pred.getSUnit()->getInstr()->getOpcode();
         return isBitPack(Opc);
-      });
+      }));
 
   auto *PackPred = llvm::find_if((*TempMFMA)->Preds, [&isBitPack](SDep &Pred) {
     auto Opc = Pred.getSUnit()->getInstr()->getOpcode();
@@ -1637,19 +1640,19 @@ bool MFMAExpInterleaveOpt::analyzeDAG(const SIInstrInfo *TII) {
   MFMAEnablement = 0;
   ExpRequirement = 0;
   // How many MFMAs depend on a single bit pack operation
-  MFMAEnablement =
+  MFMAEnablement = static_cast<unsigned>(
       llvm::count_if(PackPred->getSUnit()->Succs, [&TII](SDep &Succ) {
         return TII->isMFMAorWMMA(*Succ.getSUnit()->getInstr());
-      });
+      }));
 
   // The number of MFMAs that depend on a single V_EXP
   MFMAEnablement *= PackSuccCount;
 
   // The number of V_EXPs required to resolve all dependencies for an MFMA
-  ExpRequirement =
+  ExpRequirement = static_cast<unsigned>(
       llvm::count_if(ExpPipeCands, [this, &PackPred](SUnit *ExpBase) {
         return DAG->IsReachable(PackPred->getSUnit(), ExpBase);
-      });
+      }));
 
   ExpRequirement *= PackPredCount;
   return true;
@@ -2118,7 +2121,7 @@ private:
         auto Op = Elt->getInstr()->getOperand(0);
         auto Size =
             TRI.getRegSizeInBits(*TRI.getRegClassForOperandReg(MRI, Op));
-        NumBits += Size;
+        NumBits += static_cast<int>(Size);
       }
 
       if (NumBits < 128) {
@@ -2242,7 +2245,7 @@ bool MFMASmallGemmSingleWaveOpt::applyIGLPStrategy(
   }
 
   if (IsInitial) {
-    DSWWithPermCount = DSWithPerms.size();
+    DSWWithPermCount = static_cast<unsigned>(DSWithPerms.size());
     auto *I = DSWithPerms.begin();
     auto *E = DSWithPerms.end();
 
@@ -2824,9 +2827,9 @@ void IGroupLPDAGMutation::initSchedGroupBarrierPipelineStage(
     std::vector<SUnit>::reverse_iterator RIter) {
   MachineInstr &SGB = *RIter->getInstr();
   assert(SGB.getOpcode() == AMDGPU::SCHED_GROUP_BARRIER);
-  int32_t SGMask = SGB.getOperand(0).getImm();
-  int32_t Size = SGB.getOperand(1).getImm();
-  int32_t SyncID = SGB.getOperand(2).getImm();
+  int32_t SGMask = static_cast<int32_t>(SGB.getOperand(0).getImm());
+  int32_t Size = static_cast<int32_t>(SGB.getOperand(1).getImm());
+  int32_t SyncID = static_cast<int32_t>(SGB.getOperand(2).getImm());
 
   Size++; // Make room for the SCHED_GROUP_BARRIER instruction
   auto &SG = SyncedSchedGroups[SyncID].emplace_back((SchedGroupMask)SGMask,

--- a/llvm/lib/Target/AMDGPU/GCNMinRegStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNMinRegStrategy.cpp
@@ -101,7 +101,7 @@ int GCNMinRegScheduler::getReadySuccessors(const SUnit *SU) const {
 }
 
 int GCNMinRegScheduler::getNotReadySuccessors(const SUnit *SU) const {
-  return SU->Succs.size() - getReadySuccessors(SU);
+  return static_cast<int>(SU->Succs.size() - getReadySuccessors(SU));
 }
 
 template <typename Calc>
@@ -132,7 +132,7 @@ unsigned GCNMinRegScheduler::findMax(unsigned Num, Calc C) {
 
 GCNMinRegScheduler::Candidate* GCNMinRegScheduler::pickCandidate() {
   do {
-    unsigned Num = RQ.size();
+    unsigned Num = static_cast<unsigned>(RQ.size());
     if (Num == 1) break;
 
     LLVM_DEBUG(dbgs() << "\nSelecting max priority candidates among " << Num
@@ -162,7 +162,7 @@ GCNMinRegScheduler::Candidate* GCNMinRegScheduler::pickCandidate() {
     });
     if (Num == 1) break;
 
-    Num = Num ? Num : RQ.size();
+    Num = static_cast<unsigned>(Num ? Num : RQ.size());
     LLVM_DEBUG(
         dbgs()
         << "\nCan't find best candidate, selecting in program order among "

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -1205,9 +1205,9 @@ void GCNScheduleDAGMILive::finalizeSchedule() {
   // GCNScheduleDAGMILive::schedule().
   LiveIns.resize(Regions.size());
   Pressure.resize(Regions.size());
-  RegionsWithHighRP.resize(Regions.size());
-  RegionsWithExcessRP.resize(Regions.size());
-  RegionsWithIGLPInstrs.resize(Regions.size());
+  RegionsWithHighRP.resize(static_cast<unsigned>(Regions.size()));
+  RegionsWithExcessRP.resize(static_cast<unsigned>(Regions.size()));
+  RegionsWithIGLPInstrs.resize(static_cast<unsigned>(Regions.size()));
   RegionsWithHighRP.reset();
   RegionsWithExcessRP.reset();
   RegionsWithIGLPInstrs.reset();
@@ -1385,7 +1385,7 @@ bool RewriteMFMAFormStage::initGCNSchedStage() {
   if (!ST.hasGFX90AInsts() || MFI.getMinWavesPerEU() > 1)
     return false;
 
-  RegionsWithExcessArchVGPR.resize(DAG.Regions.size());
+  RegionsWithExcessArchVGPR.resize(static_cast<unsigned>(DAG.Regions.size()));
   RegionsWithExcessArchVGPR.reset();
   for (unsigned Region = 0; Region < DAG.Regions.size(); Region++) {
     GCNRegPressure PressureBefore = DAG.Pressure[Region];
@@ -1584,7 +1584,7 @@ bool PreRARematStage::initGCNSchedStage() {
     Cand.init(RegIdx, FreqInfo, Remater, DAG);
     Cand.update(TargetRegions, RPTargets, FreqInfo, !TargetOcc);
     if (!Cand.hasNullScore())
-      CandidateOrder.push_back(Candidates.size() - 1);
+      CandidateOrder.push_back(static_cast<unsigned>(Candidates.size() - 1));
   }
 
   if (TargetOcc) {
@@ -1599,7 +1599,7 @@ bool PreRARematStage::initGCNSchedStage() {
 
   // Rematerialize registers in successive rounds until all RP targets are
   // satisifed or until we run out of rematerialization candidates.
-  BitVector RecomputeRP(DAG.Regions.size());
+  BitVector RecomputeRP(static_cast<unsigned>(DAG.Regions.size()));
   for (;;) {
     RecomputeRP.reset();
 
@@ -1781,7 +1781,8 @@ bool GCNSchedStage::initGCNRegion() {
   if (DAG.RegionBegin->getParent() != CurrentMBB)
     setupNewBlock();
 
-  unsigned NumRegionInstrs = std::distance(DAG.begin(), DAG.end());
+  unsigned NumRegionInstrs =
+      static_cast<unsigned>(std::distance(DAG.begin(), DAG.end()));
   DAG.enterRegion(CurrentMBB, DAG.begin(), DAG.end(), NumRegionInstrs);
 
   // Skip regions with 1 schedulable instruction.
@@ -2555,7 +2556,7 @@ int64_t RewriteMFMAFormStage::getRewriteCost(
             : 1;
 
     const TargetRegisterClass *RC = DAG.MRI.getRegClass(DefReg);
-    CopyCost += RC->getCopyCost() * DefFreq;
+    CopyCost += static_cast<unsigned>(RC->getCopyCost() * DefFreq);
   }
 
   // Account for CopyForUse copies in each block that the register is used.
@@ -2565,7 +2566,7 @@ int64_t RewriteMFMAFormStage::getRewriteCost(
 
     for (Register UseReg : UseRegs) {
       const TargetRegisterClass *RC = DAG.MRI.getRegClass(UseReg);
-      CopyCost += RC->getCopyCost() * UseFreq;
+      CopyCost += static_cast<unsigned>(RC->getCopyCost() * UseFreq);
     }
   }
 
@@ -2965,7 +2966,8 @@ bool PreRARematStage::setObjective() {
   unsigned MaxSGPRs = ST.getMaxNumSGPRs(F);
   unsigned MaxVGPRs = ST.getMaxNumVGPRs(F);
   bool HasVectorRegisterExcess = false;
-  for (unsigned I = 0, E = DAG.Regions.size(); I != E; ++I) {
+  for (unsigned I = 0, E = static_cast<unsigned>(DAG.Regions.size()); I != E;
+       ++I) {
     const GCNRegPressure &RP = DAG.Pressure[I];
     GCNRPTarget &Target = RPTargets.emplace_back(MaxSGPRs, MaxVGPRs, MF, RP);
     if (!Target.satisfied())
@@ -2987,7 +2989,7 @@ bool PreRARematStage::setObjective() {
     for (auto [I, Target] : enumerate(RPTargets)) {
       Target.setTarget(MaxSGPRs, MaxVGPRs);
       if (!Target.satisfied())
-        TargetRegions.set(I);
+        TargetRegions.set(static_cast<unsigned>(I));
     }
   }
 
@@ -3009,7 +3011,7 @@ PreRARematStage::ScoredRemat::FreqInfo::FreqInfo(
   MachineBranchProbabilityInfo MBPI;
   MachineBlockFrequencyInfo MBFI(MF, MBPI, *DAG.MLI);
 
-  const unsigned NumRegions = DAG.Regions.size();
+  const unsigned NumRegions = static_cast<unsigned>(DAG.Regions.size());
   MinFreq = MBFI.getEntryFreq().getFrequency();
   MaxFreq = 0;
   Regions.reserve(NumRegions);
@@ -3039,7 +3041,7 @@ void PreRARematStage::ScoredRemat::init(RegisterIdx RegIdx,
                                         const Rematerializer &Remater,
                                         GCNScheduleDAGMILive &DAG) {
   this->RegIdx = RegIdx;
-  const unsigned NumRegions = DAG.Regions.size();
+  const unsigned NumRegions = static_cast<unsigned>(DAG.Regions.size());
   LiveIn.resize(NumRegions);
   LiveOut.resize(NumRegions);
   Live.resize(NumRegions);

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
@@ -772,10 +772,11 @@ public:
   bool shouldRevertScheduling(unsigned WavesAfter) override;
 
   PreRARematStage(GCNSchedStageID StageID, GCNScheduleDAGMILive &DAG)
-      : GCNSchedStage(StageID, DAG), TargetRegions(DAG.Regions.size()),
-        RescheduleRegions(DAG.Regions.size()),
+      : GCNSchedStage(StageID, DAG),
+        TargetRegions(static_cast<unsigned>(DAG.Regions.size())),
+        RescheduleRegions(static_cast<unsigned>(DAG.Regions.size())),
         Remater(MF, DAG.Regions, *DAG.LIS) {
-    const unsigned NumRegions = DAG.Regions.size();
+    const unsigned NumRegions = static_cast<unsigned>(DAG.Regions.size());
     RPTargets.reserve(NumRegions);
   }
 };

--- a/llvm/lib/Target/AMDGPU/GCNVOPDUtils.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNVOPDUtils.cpp
@@ -441,7 +441,7 @@ struct VOPDPairingMutation : ScheduleDAGMutation {
       return;
     }
 
-    BitVector VOPDCapable(DAG->SUnits.size());
+    BitVector VOPDCapable(static_cast<unsigned>(DAG->SUnits.size()));
     unsigned IIdx = 0;
     // Pre-compute whether each individual instruction can be VOPD
     for (auto ISUI = DAG->SUnits.begin(), E = DAG->SUnits.end(); ISUI != E;
@@ -458,10 +458,10 @@ struct VOPDPairingMutation : ScheduleDAGMutation {
     // Cache collected load predecessors.
     // For VOPDCapable nodes, this caches collectLoads with StopAtLoads=true
     // For loads, this caches collectLoads with StopAtLoads=false
-    BitVector LoadPredsComputed(DAG->SUnits.size());
+    BitVector LoadPredsComputed(static_cast<unsigned>(DAG->SUnits.size()));
     SmallVector<SmallPtrSet<SUnit *, 8>> LoadPredsCache(DAG->SUnits.size());
 
-    BitVector Scratch(DAG->SUnits.size());
+    BitVector Scratch(static_cast<unsigned>(DAG->SUnits.size()));
     for (auto ISUI = DAG->SUnits.begin(), E = DAG->SUnits.end(); ISUI != E;
          ++ISUI, ++IIdx) {
       if (!VOPDCapable[IIdx])

--- a/llvm/lib/Target/AMDGPU/SIMachineScheduler.cpp
+++ b/llvm/lib/Target/AMDGPU/SIMachineScheduler.cpp
@@ -174,7 +174,7 @@ static bool tryGreater(int TryVal, int CandVal,
 // SIScheduleBlock //
 
 void SIScheduleBlock::addUnit(SUnit *SU) {
-  NodeNum2Index[SU->NodeNum] = SUnits.size();
+  NodeNum2Index[SU->NodeNum] = static_cast<unsigned>(SUnits.size());
   SUnits.push_back(SU);
 }
 
@@ -625,7 +625,7 @@ bool SIScheduleBlockCreator::isSUInBlock(SUnit *SU, unsigned ID) {
 }
 
 void SIScheduleBlockCreator::colorHighLatenciesAlone() {
-  unsigned DAGSize = DAG->SUnits.size();
+  unsigned DAGSize = static_cast<unsigned>(DAG->SUnits.size());
 
   for (unsigned i = 0, e = DAGSize; i != e; ++i) {
     SUnit *SU = &DAG->SUnits[i];
@@ -646,7 +646,7 @@ hasDataDependencyPred(const SUnit &SU, const SUnit &FromSU) {
 }
 
 void SIScheduleBlockCreator::colorHighLatenciesGroups() {
-  unsigned DAGSize = DAG->SUnits.size();
+  unsigned DAGSize = static_cast<unsigned>(DAG->SUnits.size());
   unsigned NumHighLatencies = 0;
   unsigned GroupSize;
   int Color = NextReservedID;
@@ -766,7 +766,7 @@ void SIScheduleBlockCreator::colorHighLatenciesGroups() {
 }
 
 void SIScheduleBlockCreator::colorComputeReservedDependencies() {
-  unsigned DAGSize = DAG->SUnits.size();
+  unsigned DAGSize = static_cast<unsigned>(DAG->SUnits.size());
   std::map<std::set<unsigned>, unsigned> ColorCombinations;
 
   CurrentTopDownReservedDependencyColoring.clear();
@@ -880,7 +880,7 @@ void SIScheduleBlockCreator::colorAccordingToReservedDependencies() {
 }
 
 void SIScheduleBlockCreator::colorEndsAccordingToDependencies() {
-  unsigned DAGSize = DAG->SUnits.size();
+  unsigned DAGSize = static_cast<unsigned>(DAG->SUnits.size());
   std::vector<int> PendingColoring = CurrentColoring;
 
   assert(DAGSize >= 1 &&
@@ -927,7 +927,7 @@ void SIScheduleBlockCreator::colorEndsAccordingToDependencies() {
 
 
 void SIScheduleBlockCreator::colorForceConsecutiveOrderInGroup() {
-  unsigned DAGSize = DAG->SUnits.size();
+  unsigned DAGSize = static_cast<unsigned>(DAG->SUnits.size());
   unsigned PreviousColor;
   std::set<unsigned> SeenColors;
 
@@ -960,7 +960,7 @@ void SIScheduleBlockCreator::colorForceConsecutiveOrderInGroup() {
 }
 
 void SIScheduleBlockCreator::colorMergeConstantLoadsNextGroup() {
-  unsigned DAGSize = DAG->SUnits.size();
+  unsigned DAGSize = static_cast<unsigned>(DAG->SUnits.size());
 
   for (unsigned SUNum : DAG->BottomUpIndex2SU) {
     SUnit *SU = &DAG->SUnits[SUNum];
@@ -986,7 +986,7 @@ void SIScheduleBlockCreator::colorMergeConstantLoadsNextGroup() {
 }
 
 void SIScheduleBlockCreator::colorMergeIfPossibleNextGroup() {
-  unsigned DAGSize = DAG->SUnits.size();
+  unsigned DAGSize = static_cast<unsigned>(DAG->SUnits.size());
 
   for (unsigned SUNum : DAG->BottomUpIndex2SU) {
     SUnit *SU = &DAG->SUnits[SUNum];
@@ -1007,7 +1007,7 @@ void SIScheduleBlockCreator::colorMergeIfPossibleNextGroup() {
 }
 
 void SIScheduleBlockCreator::colorMergeIfPossibleNextGroupOnlyForReserved() {
-  unsigned DAGSize = DAG->SUnits.size();
+  unsigned DAGSize = static_cast<unsigned>(DAG->SUnits.size());
 
   for (unsigned SUNum : DAG->BottomUpIndex2SU) {
     SUnit *SU = &DAG->SUnits[SUNum];
@@ -1028,7 +1028,7 @@ void SIScheduleBlockCreator::colorMergeIfPossibleNextGroupOnlyForReserved() {
 }
 
 void SIScheduleBlockCreator::colorMergeIfPossibleSmallGroupsToNextGroup() {
-  unsigned DAGSize = DAG->SUnits.size();
+  unsigned DAGSize = static_cast<unsigned>(DAG->SUnits.size());
   std::map<unsigned, unsigned> ColorCount;
 
   for (unsigned SUNum : DAG->BottomUpIndex2SU) {
@@ -1067,7 +1067,7 @@ void SIScheduleBlockCreator::cutHugeBlocks() {
 }
 
 void SIScheduleBlockCreator::regroupNoUserInstructions() {
-  unsigned DAGSize = DAG->SUnits.size();
+  unsigned DAGSize = static_cast<unsigned>(DAG->SUnits.size());
   int GroupID = NextNonReservedID++;
 
   for (unsigned SUNum : DAG->BottomUpIndex2SU) {
@@ -1135,7 +1135,7 @@ void SIScheduleBlockCreator::colorExports() {
 }
 
 void SIScheduleBlockCreator::createBlocksForVariant(SISchedulerBlockCreatorVariant BlockVariant) {
-  unsigned DAGSize = DAG->SUnits.size();
+  unsigned DAGSize = static_cast<unsigned>(DAG->SUnits.size());
   std::map<unsigned,unsigned> RealID;
 
   CurrentBlocks.clear();
@@ -1172,7 +1172,7 @@ void SIScheduleBlockCreator::createBlocksForVariant(SISchedulerBlockCreatorVaria
     unsigned Color = CurrentColoring[SU->NodeNum];
     auto [It, Inserted] = RealID.try_emplace(Color);
     if (Inserted) {
-      int ID = CurrentBlocks.size();
+      int ID = static_cast<int>(CurrentBlocks.size());
       BlockPtrs.push_back(std::make_unique<SIScheduleBlock>(DAG, this, ID));
       CurrentBlocks.push_back(BlockPtrs.rbegin()->get());
       It->second = ID;
@@ -1226,7 +1226,7 @@ nextIfDebug(MachineBasicBlock::iterator I,
 }
 
 void SIScheduleBlockCreator::topologicalSort() {
-  unsigned DAGSize = CurrentBlocks.size();
+  unsigned DAGSize = static_cast<unsigned>(CurrentBlocks.size());
   std::vector<int> WorkList;
 
   LLVM_DEBUG(dbgs() << "Topological Sort\n");
@@ -1238,7 +1238,7 @@ void SIScheduleBlockCreator::topologicalSort() {
 
   for (unsigned i = 0, e = DAGSize; i != e; ++i) {
     SIScheduleBlock *Block = CurrentBlocks[i];
-    unsigned Degree = Block->getSuccs().size();
+    unsigned Degree = static_cast<unsigned>(Block->getSuccs().size());
     TopDownBlock2Index[i] = Degree;
     if (Degree == 0) {
       WorkList.push_back(i);
@@ -1274,7 +1274,7 @@ void SIScheduleBlockCreator::topologicalSort() {
 }
 
 void SIScheduleBlockCreator::scheduleInsideBlocks() {
-  unsigned DAGSize = CurrentBlocks.size();
+  unsigned DAGSize = static_cast<unsigned>(CurrentBlocks.size());
 
   LLVM_DEBUG(dbgs() << "\nScheduling Blocks\n\n");
 
@@ -1336,7 +1336,7 @@ void SIScheduleBlockCreator::scheduleInsideBlocks() {
 
   LLVM_DEBUG(dbgs() << "Restoring MI Pos\n");
   // Restore old ordering (which prevents a LIS->handleMove bug).
-  for (unsigned i = PosOld.size(), e = 0; i != e; --i) {
+  for (unsigned i = static_cast<unsigned>(PosOld.size()), e = 0; i != e; --i) {
     MachineBasicBlock::iterator POld = PosOld[i-1];
     MachineBasicBlock::iterator PNew = PosNew[i-1];
     if (PNew != POld) {
@@ -1355,7 +1355,7 @@ void SIScheduleBlockCreator::scheduleInsideBlocks() {
 }
 
 void SIScheduleBlockCreator::fillStats() {
-  unsigned DAGSize = CurrentBlocks.size();
+  unsigned DAGSize = static_cast<unsigned>(CurrentBlocks.size());
 
   for (unsigned i = 0, e = DAGSize; i != e; ++i) {
     int BlockIndice = TopDownIndex2Block[i];
@@ -1434,14 +1434,14 @@ SIScheduleBlockScheduler::SIScheduleBlockScheduler(SIScheduleDAGMI *DAG,
   BlockNumPredsLeft.resize(Blocks.size());
   BlockNumSuccsLeft.resize(Blocks.size());
 
-  for (unsigned i = 0, e = Blocks.size(); i != e; ++i) {
+  for (unsigned i = 0, e = static_cast<unsigned>(Blocks.size()); i != e; ++i) {
     SIScheduleBlock *Block = Blocks[i];
-    BlockNumPredsLeft[i] = Block->getPreds().size();
-    BlockNumSuccsLeft[i] = Block->getSuccs().size();
+    BlockNumPredsLeft[i] = static_cast<unsigned>(Block->getPreds().size());
+    BlockNumSuccsLeft[i] = static_cast<unsigned>(Block->getSuccs().size());
   }
 
 #ifndef NDEBUG
-  for (unsigned i = 0, e = Blocks.size(); i != e; ++i) {
+  for (unsigned i = 0, e = static_cast<unsigned>(Blocks.size()); i != e; ++i) {
     SIScheduleBlock *Block = Blocks[i];
     assert(Block->getID() == i);
   }
@@ -1454,7 +1454,8 @@ SIScheduleBlockScheduler::SIScheduleBlockScheduler(SIScheduleDAGMI *DAG,
   // producing registers consumed in another
   // scheduling region.
   for (VirtRegOrUnit VRegOrUnit : DAG->getOutRegs()) {
-    for (unsigned i = 0, e = Blocks.size(); i != e; ++i) {
+    for (unsigned i = 0, e = static_cast<unsigned>(Blocks.size()); i != e;
+         ++i) {
       // Do reverse traversal
       int ID = BlocksStruct.TopDownIndex2Block[Blocks.size()-1-i];
       SIScheduleBlock *Block = Blocks[ID];
@@ -1489,7 +1490,7 @@ SIScheduleBlockScheduler::SIScheduleBlockScheduler(SIScheduleDAGMI *DAG,
     }
   }
 
-  for (unsigned i = 0, e = Blocks.size(); i != e; ++i) {
+  for (unsigned i = 0, e = static_cast<unsigned>(Blocks.size()); i != e; ++i) {
     SIScheduleBlock *Block = Blocks[i];
     if (BlockNumPredsLeft[i] == 0) {
       ReadyBlocks.push_back(Block);
@@ -1589,7 +1590,8 @@ SIScheduleBlock *SIScheduleBlockScheduler::pickBlock() {
     TryCand.VGPRUsageDiff =
       checkRegUsageImpact(TryCand.Block->getInRegs(),
           TryCand.Block->getOutRegs())[AMDGPU::RegisterPressureSets::VGPR_32];
-    TryCand.NumSuccessors = TryCand.Block->getSuccs().size();
+    TryCand.NumSuccessors =
+        static_cast<unsigned>(TryCand.Block->getSuccs().size());
     TryCand.NumHighLatencySuccessors =
       TryCand.Block->getNumHighLatencySuccessors();
     TryCand.LastPosHighLatParentScheduled =
@@ -1764,11 +1766,12 @@ void SIScheduleDAGMI::topologicalSort() {
 // and the corresponding wavefront count), that would
 // try to merge groups of loads if it make sense, etc
 void SIScheduleDAGMI::moveLowLatencies() {
-   unsigned DAGSize = SUnits.size();
-   int LastLowLatencyUser = -1;
-   int LastLowLatencyPos = -1;
+  unsigned DAGSize = static_cast<unsigned>(SUnits.size());
+  int LastLowLatencyUser = -1;
+  int LastLowLatencyPos = -1;
 
-   for (unsigned i = 0, e = ScheduledSUnits.size(); i != e; ++i) {
+  for (unsigned i = 0, e = static_cast<unsigned>(ScheduledSUnits.size());
+       i != e; ++i) {
     SUnit *SU = &SUnits[ScheduledSUnits[i]];
     bool IsLowLatencyUser = false;
     unsigned MinPos = 0;
@@ -1831,7 +1834,7 @@ void SIScheduleDAGMI::moveLowLatencies() {
 }
 
 void SIScheduleDAGMI::restoreSULinksLeft() {
-  for (unsigned i = 0, e = SUnits.size(); i != e; ++i) {
+  for (unsigned i = 0, e = static_cast<unsigned>(SUnits.size()); i != e; ++i) {
     SUnits[i].isScheduled = false;
     SUnits[i].WeakPredsLeft = SUnitsLinksBackup[i].WeakPredsLeft;
     SUnits[i].NumPredsLeft = SUnitsLinksBackup[i].NumPredsLeft;
@@ -1905,7 +1908,7 @@ void SIScheduleDAGMI::schedule()
       bool OffsetIsScalable;
       if (SITII->getMemOperandWithOffset(*SU->getInstr(), BaseLatOp, OffLatReg,
                                          OffsetIsScalable, TRI))
-        LowLatencyOffset[i] = OffLatReg;
+        LowLatencyOffset[i] = static_cast<unsigned>(OffLatReg);
     } else if (SITII->isHighLatencyDef(SU->getInstr()->getOpcode()))
       IsHighLatencySU[i] = 1;
   }

--- a/llvm/lib/Target/AMDGPU/SIMachineScheduler.h
+++ b/llvm/lib/Target/AMDGPU/SIMachineScheduler.h
@@ -132,7 +132,7 @@ public:
   // This is approximative.
   // Ideally should take into accounts some instructions (rcp, etc)
   // are 4 times slower.
-  int getCost() { return SUnits.size(); }
+  int getCost() { return static_cast<int>(SUnits.size()); }
 
   // The block Predecessors and Successors must be all registered
   // before fastSchedule().


### PR DESCRIPTION
For context, see https://github.com/llvm/llvm-project/issues/215213

This patch handles the following cases:

Container size() returns size_t and is assigned to unsigned or int locals and
fields holding SUnit indices, scheduling-region indices, block sizes and
instruction-group counts. Add a static_cast to make the existing narrowing
conversion explicit. These index containers of SUnits and MachineInstrs within
one function, which the MachineScheduler already indexes with unsigned
(SUnit::NodeNum is unsigned), so unsigned is the right type and the conversion
is NFC.

This is the one patch in the series dominated by C4267 rather than C4244: 54 of
its 71 warnings are container sizes.

MachineOperand::getImm() returns int64_t and is assigned to int32_t locals
holding IGLP mutation opcodes and export targets. Add a static_cast to make the
existing narrowing conversion explicit.

std::distance over a scheduling region returns ptrdiff_t and is assigned to
unsigned or int locals. Add a static_cast to make the existing narrowing
conversion explicit.

This fixes 17 instances of MSVC warning C4244 and 54 of C4267 ("possible loss of
data") across 9 files in llvm/lib/Target/AMDGPU.

Assisted-by: Claude <noreply@anthropic.com>
