### PR TITLE
[AMDGPU][NFC] Explicitly narrow conversions in the instruction selector

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
@@ -401,7 +401,7 @@ static unsigned getLogicalBitOpcode(unsigned Opc, bool Is64) {
 
 bool AMDGPUInstructionSelector::selectG_AND_OR_XOR(MachineInstr &I) const {
   Register DstReg = I.getOperand(0).getReg();
-  unsigned Size = RBI.getSizeInBits(DstReg, *MRI, TRI);
+  unsigned Size = static_cast<unsigned>(RBI.getSizeInBits(DstReg, *MRI, TRI));
 
   const RegisterBank *DstRB = RBI.getRegBank(DstReg, *MRI, TRI);
   if (DstRB->getID() != AMDGPU::SGPRRegBankID &&
@@ -430,7 +430,7 @@ bool AMDGPUInstructionSelector::selectG_ADD_SUB(MachineInstr &I) const {
   if (Ty.isVector())
     return false;
 
-  unsigned Size = Ty.getSizeInBits();
+  unsigned Size = static_cast<unsigned>(Ty.getSizeInBits());
   const RegisterBank *DstRB = RBI.getRegBank(DstReg, *MRI, TRI);
   const bool IsSALU = DstRB->getID() == AMDGPU::SGPRRegBankID;
   const bool Sub = I.getOpcode() == TargetOpcode::G_SUB;
@@ -623,11 +623,11 @@ bool AMDGPUInstructionSelector::selectG_EXTRACT(MachineInstr &I) const {
   Register SrcReg = I.getOperand(1).getReg();
   LLT DstTy = MRI->getType(DstReg);
   LLT SrcTy = MRI->getType(SrcReg);
-  const unsigned SrcSize = SrcTy.getSizeInBits();
-  unsigned DstSize = DstTy.getSizeInBits();
+  const unsigned SrcSize = static_cast<unsigned>(SrcTy.getSizeInBits());
+  unsigned DstSize = static_cast<unsigned>(DstTy.getSizeInBits());
 
   // TODO: Should handle any multiple of 32 offset.
-  unsigned Offset = I.getOperand(2).getImm();
+  unsigned Offset = static_cast<unsigned>(I.getOperand(2).getImm());
   if (Offset % 32 != 0 || DstSize > 128)
     return false;
 
@@ -775,7 +775,8 @@ bool AMDGPUInstructionSelector::selectS16MergeToWide(MachineInstr &MI) const {
   MachineBasicBlock *BB = MI.getParent();
   const DebugLoc &DL = MI.getDebugLoc();
   Register DstReg = MI.getOperand(0).getReg();
-  const unsigned DstSize = MRI->getType(DstReg).getSizeInBits();
+  const unsigned DstSize =
+      static_cast<unsigned>(MRI->getType(DstReg).getSizeInBits());
   const RegisterBank *DstBank = RBI.getRegBank(DstReg, *MRI, TRI);
   const unsigned NumSrc = MI.getNumOperands() - 1;
 
@@ -797,7 +798,7 @@ bool AMDGPUInstructionSelector::selectS16MergeToWide(MachineInstr &MI) const {
     return false;
   ArrayRef<int16_t> SubRegs = TRI.getRegSplitParts(DstRC, /*EltSize=*/4);
   auto MIB = BuildMI(*BB, MI, DL, TII.get(TargetOpcode::REG_SEQUENCE), DstReg);
-  for (unsigned I = 0, E = S32Regs.size(); I != E; ++I)
+  for (unsigned I = 0, E = static_cast<unsigned>(S32Regs.size()); I != E; ++I)
     MIB.addReg(S32Regs[I]).addImm(SubRegs[I]);
 
   MI.eraseFromParent();
@@ -810,7 +811,7 @@ bool AMDGPUInstructionSelector::selectG_MERGE_VALUES(MachineInstr &MI) const {
   LLT DstTy = MRI->getType(DstReg);
   LLT SrcTy = MRI->getType(MI.getOperand(1).getReg());
 
-  const unsigned SrcSize = SrcTy.getSizeInBits();
+  const unsigned SrcSize = static_cast<unsigned>(SrcTy.getSizeInBits());
   if (SrcSize < 32) {
     // Handle s32 <- G_MERGE_VALUES s16, s16
     if (SrcSize == 16 && DstTy.getSizeInBits() == 32 &&
@@ -834,7 +835,7 @@ bool AMDGPUInstructionSelector::selectG_MERGE_VALUES(MachineInstr &MI) const {
 
   const DebugLoc &DL = MI.getDebugLoc();
   const RegisterBank *DstBank = RBI.getRegBank(DstReg, *MRI, TRI);
-  const unsigned DstSize = DstTy.getSizeInBits();
+  const unsigned DstSize = static_cast<unsigned>(DstTy.getSizeInBits());
   const TargetRegisterClass *DstRC =
       TRI.getRegClassForSizeOnBank(DstSize, *DstBank);
   if (!DstRC)
@@ -872,8 +873,8 @@ bool AMDGPUInstructionSelector::selectG_UNMERGE_VALUES(MachineInstr &MI) const {
   LLT DstTy = MRI->getType(DstReg0);
   LLT SrcTy = MRI->getType(SrcReg);
 
-  const unsigned DstSize = DstTy.getSizeInBits();
-  const unsigned SrcSize = SrcTy.getSizeInBits();
+  const unsigned DstSize = static_cast<unsigned>(DstTy.getSizeInBits());
+  const unsigned SrcSize = static_cast<unsigned>(SrcTy.getSizeInBits());
   const DebugLoc &DL = MI.getDebugLoc();
   const RegisterBank *SrcBank = RBI.getRegBank(SrcReg, *MRI, TRI);
 
@@ -921,7 +922,7 @@ bool AMDGPUInstructionSelector::selectG_BUILD_VECTOR(MachineInstr &MI) const {
   Register Src0 = MI.getOperand(1).getReg();
   Register Src1 = MI.getOperand(2).getReg();
   LLT SrcTy = MRI->getType(Src0);
-  const unsigned SrcSize = SrcTy.getSizeInBits();
+  const unsigned SrcSize = static_cast<unsigned>(SrcTy.getSizeInBits());
 
   // BUILD_VECTOR with >=32 bits source is handled by MERGE_VALUE.
   if (MI.getOpcode() == AMDGPU::G_BUILD_VECTOR && SrcSize >= 32) {
@@ -1017,8 +1018,9 @@ bool AMDGPUInstructionSelector::selectG_INSERT(MachineInstr &I) const {
   Register Src1Reg = I.getOperand(2).getReg();
   LLT Src1Ty = MRI->getType(Src1Reg);
 
-  unsigned DstSize = MRI->getType(DstReg).getSizeInBits();
-  unsigned InsSize = Src1Ty.getSizeInBits();
+  unsigned DstSize =
+      static_cast<unsigned>(MRI->getType(DstReg).getSizeInBits());
+  unsigned InsSize = static_cast<unsigned>(Src1Ty.getSizeInBits());
 
   int64_t Offset = I.getOperand(3).getImm();
 
@@ -1030,7 +1032,8 @@ bool AMDGPUInstructionSelector::selectG_INSERT(MachineInstr &I) const {
   if (InsSize > 128)
     return false;
 
-  unsigned SubReg = TRI.getSubRegFromChannel(Offset / 32, InsSize / 32);
+  unsigned SubReg = TRI.getSubRegFromChannel(static_cast<unsigned>(Offset / 32),
+                                             InsSize / 32);
   if (SubReg == AMDGPU::NoSubRegister)
     return false;
 
@@ -1171,8 +1174,9 @@ bool AMDGPUInstructionSelector::selectWritelane(MachineInstr &MI) const {
 
     // If the value written is an inline immediate, we can get away without a
     // copy to m0.
-    if (ConstVal && AMDGPU::isInlinableLiteral32(ConstVal->Value.getSExtValue(),
-                                                 STI.hasInv2PiInlineImm())) {
+    if (ConstVal && AMDGPU::isInlinableLiteral32(
+                        static_cast<int32_t>(ConstVal->Value.getSExtValue()),
+                        STI.hasInv2PiInlineImm())) {
       MIB.addImm(ConstVal->Value.getSExtValue());
       MIB.addReg(LaneSelect);
     } else {
@@ -1218,7 +1222,7 @@ bool AMDGPUInstructionSelector::selectDivScale(MachineInstr &MI) const {
 
   Register Numer = MI.getOperand(3).getReg();
   Register Denom = MI.getOperand(4).getReg();
-  unsigned ChooseDenom = MI.getOperand(5).getImm();
+  unsigned ChooseDenom = static_cast<unsigned>(MI.getOperand(5).getImm());
 
   Register Src0 = ChooseDenom != 0 ? Numer : Denom;
 
@@ -1578,7 +1582,7 @@ bool AMDGPUInstructionSelector::selectG_ICMP_or_FCMP(MachineInstr &I) const {
   const DebugLoc &DL = I.getDebugLoc();
 
   Register SrcReg = I.getOperand(2).getReg();
-  unsigned Size = RBI.getSizeInBits(SrcReg, *MRI, TRI);
+  unsigned Size = static_cast<unsigned>(RBI.getSizeInBits(SrcReg, *MRI, TRI));
 
   auto Pred = (CmpInst::Predicate)I.getOperand(1).getPredicate();
 
@@ -1640,7 +1644,7 @@ bool AMDGPUInstructionSelector::selectIntrinsicCmp(MachineInstr &I) const {
   MachineBasicBlock *BB = I.getParent();
   const DebugLoc &DL = I.getDebugLoc();
   Register SrcReg = I.getOperand(2).getReg();
-  unsigned Size = RBI.getSizeInBits(SrcReg, *MRI, TRI);
+  unsigned Size = static_cast<unsigned>(RBI.getSizeInBits(SrcReg, *MRI, TRI));
 
   // i1 inputs are not supported in GlobalISel.
   if (Size == 1)
@@ -1726,7 +1730,8 @@ bool AMDGPUInstructionSelector::selectBallot(MachineInstr &I) const {
   const DebugLoc &DL = I.getDebugLoc();
   Register DstReg = I.getOperand(0).getReg();
   Register SrcReg = I.getOperand(2).getReg();
-  const unsigned BallotSize = MRI->getType(DstReg).getSizeInBits();
+  const unsigned BallotSize =
+      static_cast<unsigned>(MRI->getType(DstReg).getSizeInBits());
   const unsigned WaveSize = STI.getWavefrontSize();
 
   // In the common case, the return type matches the wave size.
@@ -1847,7 +1852,7 @@ bool AMDGPUInstructionSelector::selectReturnAddress(MachineInstr &I) const {
 
   MachineOperand &Dst = I.getOperand(0);
   Register DstReg = Dst.getReg();
-  unsigned Depth = I.getOperand(2).getImm();
+  unsigned Depth = static_cast<unsigned>(I.getOperand(2).getImm());
 
   const TargetRegisterClass *RC
     = TRI.getConstrainedRegClassForOperand(Dst, *MRI);
@@ -1899,7 +1904,7 @@ bool AMDGPUInstructionSelector::selectDSOrderedIntrinsic(
   MachineFunction *MF = MBB->getParent();
   const DebugLoc &DL = MI.getDebugLoc();
 
-  unsigned IndexOperand = MI.getOperand(7).getImm();
+  unsigned IndexOperand = static_cast<unsigned>(MI.getOperand(7).getImm());
   bool WaveRelease = MI.getOperand(8).getImm() != 0;
   bool WaveDone = MI.getOperand(9).getImm() != 0;
 
@@ -2023,7 +2028,8 @@ bool AMDGPUInstructionSelector::selectDSGWSIntrinsic(MachineInstr &MI,
     // default -1 only set the low 16-bits, we could leave it as-is and add 1 to
     // the immediate offset.
 
-    ImmOffset = OffsetDef->getOperand(1).getCImm()->getZExtValue();
+    ImmOffset = static_cast<unsigned>(
+        OffsetDef->getOperand(1).getCImm()->getZExtValue());
     BuildMI(*MBB, &MI, DL, TII.get(AMDGPU::S_MOV_B32), AMDGPU::M0)
       .addImm(0);
   } else {
@@ -2206,7 +2212,8 @@ bool AMDGPUInstructionSelector::selectImageIntrinsic(
                     TFE, LWE, IsTexFail))
     return false;
 
-  const int Flags = MI.getOperand(ArgOffset + Intr->NumArgs).getImm();
+  const int Flags =
+      static_cast<int>(MI.getOperand(ArgOffset + Intr->NumArgs).getImm());
   const bool IsA16 = (Flags & 1) != 0;
   const bool IsG16 = (Flags & 2) != 0;
 
@@ -2238,13 +2245,14 @@ bool AMDGPUInstructionSelector::selectImageIntrinsic(
       NumVDataDwords = Is64Bit ? 2 : 1;
     }
   } else {
-    DMask = MI.getOperand(ArgOffset + Intr->DMaskIndex).getImm();
+    DMask = static_cast<unsigned>(
+        MI.getOperand(ArgOffset + Intr->DMaskIndex).getImm());
     DMaskLanes = BaseOpcode->Gather4 ? 4 : llvm::popcount(DMask);
 
     if (BaseOpcode->Store) {
       VDataIn = MI.getOperand(1).getReg();
       VDataTy = MRI->getType(VDataIn);
-      NumVDataDwords = (VDataTy.getSizeInBits() + 31) / 32;
+      NumVDataDwords = static_cast<int>((VDataTy.getSizeInBits() + 31) / 32);
     } else if (BaseOpcode->NoReturn) {
       NumVDataDwords = 0;
     } else {
@@ -2268,7 +2276,8 @@ bool AMDGPUInstructionSelector::selectImageIntrinsic(
   // TODO: Check this in verifier.
   assert((!IsTexFail || DMaskLanes >= 1) && "should have legalized this");
 
-  unsigned CPol = MI.getOperand(ArgOffset + Intr->CachePolicyIndex).getImm();
+  unsigned CPol = static_cast<unsigned>(
+      MI.getOperand(ArgOffset + Intr->CachePolicyIndex).getImm());
   // Keep GLC only when the atomic's result is actually used.
   if (BaseOpcode->Atomic && !BaseOpcode->NoReturn)
     CPol |= AMDGPU::CPol::GLC;
@@ -2289,7 +2298,8 @@ bool AMDGPUInstructionSelector::selectImageIntrinsic(
       break;
 
     ++NumVAddrRegs;
-    NumVAddrDwords += (MRI->getType(Addr).getSizeInBits() + 31) / 32;
+    NumVAddrDwords +=
+        static_cast<int>((MRI->getType(Addr).getSizeInBits() + 31) / 32);
   }
 
   // The legalizer preprocessed the intrinsic arguments. If we aren't using
@@ -2429,7 +2439,7 @@ bool AMDGPUInstructionSelector::selectDSBvhStackIntrinsic(
   Register Addr = MI.getOperand(3).getReg();
   Register Data0 = MI.getOperand(4).getReg();
   Register Data1 = MI.getOperand(5).getReg();
-  unsigned Offset = MI.getOperand(6).getImm();
+  unsigned Offset = static_cast<unsigned>(MI.getOperand(6).getImm());
 
   unsigned Opc;
   switch (cast<GIntrinsic>(MI).getIntrinsicID()) {
@@ -2550,7 +2560,7 @@ bool AMDGPUInstructionSelector::selectG_SELECT(MachineInstr &I) const {
   const DebugLoc &DL = I.getDebugLoc();
 
   Register DstReg = I.getOperand(0).getReg();
-  unsigned Size = RBI.getSizeInBits(DstReg, *MRI, TRI);
+  unsigned Size = static_cast<unsigned>(RBI.getSizeInBits(DstReg, *MRI, TRI));
   assert(Size <= 32 || Size == 64);
   const MachineOperand &CCOp = I.getOperand(1);
   Register CCReg = CCOp.getReg();
@@ -2613,8 +2623,8 @@ bool AMDGPUInstructionSelector::selectG_TRUNC(MachineInstr &I) const {
 
   const bool IsVALU = DstRB->getID() == AMDGPU::VGPRRegBankID;
 
-  unsigned DstSize = DstTy.getSizeInBits();
-  unsigned SrcSize = SrcTy.getSizeInBits();
+  unsigned DstSize = static_cast<unsigned>(DstTy.getSizeInBits());
+  unsigned SrcSize = static_cast<unsigned>(SrcTy.getSizeInBits());
 
   const TargetRegisterClass *SrcRC =
       TRI.getRegClassForSizeOnBank(SrcSize, *SrcRB);
@@ -2761,9 +2771,10 @@ bool AMDGPUInstructionSelector::selectG_SZA_EXT(MachineInstr &I) const {
 
   const LLT DstTy = MRI->getType(DstReg);
   const LLT SrcTy = MRI->getType(SrcReg);
-  const unsigned SrcSize = I.getOpcode() == AMDGPU::G_SEXT_INREG ?
-    I.getOperand(2).getImm() : SrcTy.getSizeInBits();
-  const unsigned DstSize = DstTy.getSizeInBits();
+  const unsigned SrcSize = I.getOpcode() == AMDGPU::G_SEXT_INREG
+                               ? static_cast<unsigned>(I.getOperand(2).getImm())
+                               : static_cast<unsigned>(SrcTy.getSizeInBits());
+  const unsigned DstSize = static_cast<unsigned>(DstTy.getSizeInBits());
   if (!DstTy.isScalar())
     return false;
 
@@ -3446,7 +3457,8 @@ bool AMDGPUInstructionSelector::selectG_EXTRACT_VECTOR_ELT(
 
   unsigned SubReg;
   std::tie(IdxReg, SubReg) = computeIndirectRegIndex(
-      *MRI, TRI, SrcRC, IdxReg, DstTy.getSizeInBits() / 8, *VT);
+      *MRI, TRI, SrcRC, IdxReg,
+      static_cast<unsigned>(DstTy.getSizeInBits() / 8), *VT);
 
   if (SrcRB->getID() == AMDGPU::SGPRRegBankID) {
     if (DstTy.getSizeInBits() != 32 && !Is64)
@@ -3476,8 +3488,8 @@ bool AMDGPUInstructionSelector::selectG_EXTRACT_VECTOR_ELT(
     return true;
   }
 
-  const MCInstrDesc &GPRIDXDesc =
-      TII.getIndirectGPRIDXPseudo(TRI.getRegSizeInBits(*SrcRC), true);
+  const MCInstrDesc &GPRIDXDesc = TII.getIndirectGPRIDXPseudo(
+      static_cast<unsigned>(TRI.getRegSizeInBits(*SrcRC)), true);
   BuildMI(*BB, MI, DL, GPRIDXDesc, DstReg)
       .addReg(SrcReg)
       .addReg(IdxReg)
@@ -3497,8 +3509,8 @@ bool AMDGPUInstructionSelector::selectG_INSERT_VECTOR_ELT(
 
   LLT VecTy = MRI->getType(DstReg);
   LLT ValTy = MRI->getType(ValReg);
-  unsigned VecSize = VecTy.getSizeInBits();
-  unsigned ValSize = ValTy.getSizeInBits();
+  unsigned VecSize = static_cast<unsigned>(VecTy.getSizeInBits());
+  unsigned ValSize = static_cast<unsigned>(ValTy.getSizeInBits());
 
   const RegisterBank *VecRB = RBI.getRegBank(VecReg, *MRI, TRI);
   const RegisterBank *ValRB = RBI.getRegBank(ValReg, *MRI, TRI);
@@ -3549,8 +3561,8 @@ bool AMDGPUInstructionSelector::selectG_INSERT_VECTOR_ELT(
     return true;
   }
 
-  const MCInstrDesc &GPRIDXDesc =
-      TII.getIndirectGPRIDXPseudo(TRI.getRegSizeInBits(*VecRC), false);
+  const MCInstrDesc &GPRIDXDesc = TII.getIndirectGPRIDXPseudo(
+      static_cast<unsigned>(TRI.getRegSizeInBits(*VecRC)), false);
   BuildMI(*BB, MI, DL, GPRIDXDesc, DstReg)
       .addReg(VecReg)
       .addReg(ValReg)
@@ -3578,7 +3590,7 @@ bool AMDGPUInstructionSelector::selectBufferLoadLds(MachineInstr &MI) const {
   if (!Subtarget->hasVMemToLDSLoad())
     return false;
   unsigned Opc;
-  unsigned Size = MI.getOperand(3).getImm();
+  unsigned Size = static_cast<unsigned>(MI.getOperand(3).getImm());
   Intrinsic::ID IntrinsicID = cast<GIntrinsic>(MI).getIntrinsicID();
 
   // The struct intrinsic variants add one additional operand over raw.
@@ -3662,7 +3674,7 @@ bool AMDGPUInstructionSelector::selectBufferLoadLds(MachineInstr &MI) const {
   MIB.add(MI.getOperand(5 + OpOffset)); // soffset
   MIB.add(MI.getOperand(6 + OpOffset)); // imm offset
   bool IsGFX12Plus = AMDGPU::isGFX12Plus(STI);
-  unsigned Aux = MI.getOperand(7 + OpOffset).getImm();
+  unsigned Aux = static_cast<unsigned>(MI.getOperand(7 + OpOffset).getImm());
   MIB.addImm(Aux & (IsGFX12Plus ? AMDGPU::CPol::ALL
                                 : AMDGPU::CPol::ALL_pregfx12)); // cpol
   MIB.addImm(
@@ -3791,7 +3803,7 @@ bool AMDGPUInstructionSelector::selectGlobalLoadLds(MachineInstr &MI) const{
     return false;
 
   unsigned Opc;
-  unsigned Size = MI.getOperand(3).getImm();
+  unsigned Size = static_cast<unsigned>(MI.getOperand(3).getImm());
   Intrinsic::ID IntrinsicID = cast<GIntrinsic>(MI).getIntrinsicID();
 
   switch (Size) {
@@ -3861,7 +3873,7 @@ bool AMDGPUInstructionSelector::selectGlobalLoadLds(MachineInstr &MI) const{
 
   MIB.add(MI.getOperand(4)); // offset
 
-  unsigned Aux = MI.getOperand(5).getImm();
+  unsigned Aux = static_cast<unsigned>(MI.getOperand(5).getImm());
   MIB.addImm(Aux & ~AMDGPU::CPol::VIRTUAL_BITS); // cpol
   MIB.addImm(isAsyncLDSDMA(IntrinsicID));
 
@@ -3933,7 +3945,8 @@ bool AMDGPUInstructionSelector::selectBVHIntersectRayIntrinsic(
     MachineInstr &MI) const {
   unsigned OpcodeOpIdx =
       MI.getOpcode() == AMDGPU::G_AMDGPU_BVH_INTERSECT_RAY ? 1 : 3;
-  MI.setDesc(TII.get(MI.getOperand(OpcodeOpIdx).getImm()));
+  MI.setDesc(
+      TII.get(static_cast<unsigned>(MI.getOperand(OpcodeOpIdx).getImm())));
   MI.removeOperand(OpcodeOpIdx);
   MI.addImplicitDefUseOperands(*MI.getMF());
   constrainSelectedInstRegOperands(MI, TII, TRI, RBI);
@@ -4110,7 +4123,7 @@ bool AMDGPUInstructionSelector::selectWaveShuffleIntrin(
   Register IdxReg = MI.getOperand(3).getReg();
 
   const LLT DstTy = MRI->getType(DstReg);
-  unsigned DstSize = DstTy.getSizeInBits();
+  unsigned DstSize = static_cast<unsigned>(DstTy.getSizeInBits());
   const RegisterBank *DstRB = RBI.getRegBank(DstReg, *MRI, TRI);
   const TargetRegisterClass *DstRC =
       TRI.getRegClassForSizeOnBank(DstSize, *DstRB);
@@ -4313,7 +4326,7 @@ static std::pair<unsigned, uint8_t> BitOp3_Op(Register R,
     if (!getOperandBits(LHS, LHSBits) ||
         !getOperandBits(RHS, RHSBits)) {
       Src = std::move(Backup);
-      return std::make_pair(0, 0);
+      return {};
     }
 
     // Recursion is naturally limited by the size of the operand vector.
@@ -4421,7 +4434,7 @@ static std::pair<unsigned, uint8_t> BitOp3_Op(Register R,
     break;
   }
   default:
-    return std::make_pair(0, 0);
+    return {};
   }
 
   uint8_t TTbl;
@@ -4921,8 +4934,10 @@ static bool isTruncHalf(const MachineInstr *MI,
   if (MI->getOpcode() != AMDGPU::G_TRUNC)
     return false;
 
-  unsigned DstSize = MRI.getType(MI->getOperand(0).getReg()).getSizeInBits();
-  unsigned SrcSize = MRI.getType(MI->getOperand(1).getReg()).getSizeInBits();
+  unsigned DstSize = static_cast<unsigned>(
+      MRI.getType(MI->getOperand(0).getReg()).getSizeInBits());
+  unsigned SrcSize = static_cast<unsigned>(
+      MRI.getType(MI->getOperand(1).getReg()).getSizeInBits());
   return DstSize * 2 == SrcSize;
 }
 
@@ -4936,8 +4951,9 @@ static bool isLshrHalf(const MachineInstr *MI, const MachineRegisterInfo &MRI) {
   std::optional<ValueAndVReg> ShiftAmt;
   if (mi_match(MI->getOperand(0).getReg(), MRI,
                m_GLShr(m_Reg(ShiftSrc), m_GCst(ShiftAmt)))) {
-    unsigned SrcSize = MRI.getType(MI->getOperand(1).getReg()).getSizeInBits();
-    unsigned Shift = ShiftAmt->Value.getZExtValue();
+    unsigned SrcSize = static_cast<unsigned>(
+        MRI.getType(MI->getOperand(1).getReg()).getSizeInBits());
+    unsigned Shift = static_cast<unsigned>(ShiftAmt->Value.getZExtValue());
     return Shift * 2 == SrcSize;
   }
   return false;
@@ -4953,8 +4969,9 @@ static bool isShlHalf(const MachineInstr *MI, const MachineRegisterInfo &MRI) {
   std::optional<ValueAndVReg> ShiftAmt;
   if (mi_match(MI->getOperand(0).getReg(), MRI,
                m_GShl(m_Reg(ShiftSrc), m_GCst(ShiftAmt)))) {
-    unsigned SrcSize = MRI.getType(MI->getOperand(1).getReg()).getSizeInBits();
-    unsigned Shift = ShiftAmt->Value.getZExtValue();
+    unsigned SrcSize = static_cast<unsigned>(
+        MRI.getType(MI->getOperand(1).getReg()).getSizeInBits());
+    unsigned Shift = static_cast<unsigned>(ShiftAmt->Value.getZExtValue());
     return Shift * 2 == SrcSize;
   }
   return false;
@@ -5302,8 +5319,8 @@ getLastSameOrNeg(Register Reg, const MachineRegisterInfo &MRI, SearchOptions SO,
 
 static bool isSameBitWidth(Register Reg1, Register Reg2,
                            const MachineRegisterInfo &MRI) {
-  unsigned Width1 = MRI.getType(Reg1).getSizeInBits();
-  unsigned Width2 = MRI.getType(Reg2).getSizeInBits();
+  unsigned Width1 = static_cast<unsigned>(MRI.getType(Reg1).getSizeInBits());
+  unsigned Width2 = static_cast<unsigned>(MRI.getType(Reg2).getSizeInBits());
   return Width1 == Width2;
 }
 
@@ -5394,8 +5411,8 @@ std::pair<Register, unsigned> AMDGPUInstructionSelector::selectVOP3PModsImpl(
     return {Stat.first, Mods};
   }
 
-  for (int I = StatlistHi.size() - 1; I >= 0; I--) {
-    for (int J = StatlistLo.size() - 1; J >= 0; J--) {
+  for (int I = static_cast<int>(StatlistHi.size()) - 1; I >= 0; I--) {
+    for (int J = static_cast<int>(StatlistLo.size()) - 1; J >= 0; J--) {
       if (StatlistHi[I].first == StatlistLo[J].first &&
           isValidToPack(StatlistHi[I].second, StatlistLo[J].second,
                         StatlistHi[I].first, RootReg, TII, MRI))
@@ -5714,7 +5731,7 @@ AMDGPUInstructionSelector::selectSWMMACIndex8(MachineOperand &Root) const {
   if (mi_match(Src, *MRI, m_GLShr(m_Reg(ShiftSrc), m_GCst(ShiftAmt))) &&
       MRI->getType(ShiftSrc).getSizeInBits() == 32 &&
       ShiftAmt->Value.getZExtValue() % 8 == 0) {
-    Key = ShiftAmt->Value.getZExtValue() / 8;
+    Key = static_cast<unsigned>(ShiftAmt->Value.getZExtValue() / 8);
     Src = ShiftSrc;
   }
 
@@ -6066,7 +6083,7 @@ std::pair<Register, int> AMDGPUInstructionSelector::selectFlatOffsetImpl(
   if (!TII.isLegalFLATOffset(ConstOffset, AddrSpace, FlatVariant))
     return Default;
 
-  return std::pair(PtrBase, ConstOffset);
+  return std::pair(PtrBase, static_cast<unsigned>(ConstOffset));
 }
 
 InstructionSelector::ComplexRendererFns
@@ -6269,7 +6286,7 @@ AMDGPUInstructionSelector::selectGlobalSAddrCPol(MachineOperand &Root) const {
   // We are assuming CPol is always the last operand of the intrinsic.
   auto PassedCPol =
       I.getOperand(I.getNumOperands() - 1).getImm() & ~AMDGPU::CPol::SCAL;
-  return selectGlobalSAddr(Root, PassedCPol);
+  return selectGlobalSAddr(Root, static_cast<unsigned>(PassedCPol));
 }
 
 InstructionSelector::ComplexRendererFns
@@ -6279,7 +6296,7 @@ AMDGPUInstructionSelector::selectGlobalSAddrCPolM0(MachineOperand &Root) const {
   // We are assuming CPol is second from last operand of the intrinsic.
   auto PassedCPol =
       I.getOperand(I.getNumOperands() - 2).getImm() & ~AMDGPU::CPol::SCAL;
-  return selectGlobalSAddr(Root, PassedCPol);
+  return selectGlobalSAddr(Root, static_cast<unsigned>(PassedCPol));
 }
 
 InstructionSelector::ComplexRendererFns
@@ -6295,7 +6312,7 @@ AMDGPUInstructionSelector::selectGlobalSAddrNoIOffset(
   // We are assuming CPol is always the last operand of the intrinsic.
   auto PassedCPol =
       I.getOperand(I.getNumOperands() - 1).getImm() & ~AMDGPU::CPol::SCAL;
-  return selectGlobalSAddr(Root, PassedCPol, false);
+  return selectGlobalSAddr(Root, static_cast<unsigned>(PassedCPol), false);
 }
 
 InstructionSelector::ComplexRendererFns
@@ -6306,7 +6323,7 @@ AMDGPUInstructionSelector::selectGlobalSAddrNoIOffsetM0(
   // We are assuming CPol is second from last operand of the intrinsic.
   auto PassedCPol =
       I.getOperand(I.getNumOperands() - 2).getImm() & ~AMDGPU::CPol::SCAL;
-  return selectGlobalSAddr(Root, PassedCPol, false);
+  return selectGlobalSAddr(Root, static_cast<unsigned>(PassedCPol), false);
 }
 
 InstructionSelector::ComplexRendererFns
@@ -6505,7 +6522,7 @@ AMDGPUInstructionSelector::selectMUBUFScratchOffen(MachineOperand &Root) const {
   std::tie(PtrBase, ConstOffset, std::ignore) =
       getPtrBaseWithConstantOffset(VAddr, *MRI);
   if (ConstOffset != 0) {
-    if (TII.isLegalMUBUFImmOffset(ConstOffset) &&
+    if (TII.isLegalMUBUFImmOffset(static_cast<unsigned>(ConstOffset)) &&
         (!STI.privateMemoryResourceIsRangeChecked() ||
          VT->signBitIsZero(PtrBase))) {
       const MachineInstr *PtrBaseDef = MRI->getVRegDef(PtrBase);
@@ -6702,7 +6719,7 @@ AMDGPUInstructionSelector::selectMUBUFScratchOffset(
   if (mi_match(Reg, *MRI,
                m_GPtrAdd(m_Reg(BasePtr),
                          m_any_of(m_ICst(Offset), m_Copy(m_ICst(Offset)))))) {
-    if (!TII.isLegalMUBUFImmOffset(Offset))
+    if (!TII.isLegalMUBUFImmOffset(static_cast<unsigned>(Offset)))
       return {};
     MachineInstr *BasePtrDef = getDefIgnoringCopies(BasePtr, *MRI);
     Register WaveBase = getWaveAddress(BasePtrDef);
@@ -6721,7 +6738,7 @@ AMDGPUInstructionSelector::selectMUBUFScratchOffset(
   }
 
   if (!mi_match(Root.getReg(), *MRI, m_ICst(Offset)) ||
-      !TII.isLegalMUBUFImmOffset(Offset))
+      !TII.isLegalMUBUFImmOffset(static_cast<unsigned>(Offset)))
     return {};
 
   return {{
@@ -6748,7 +6765,7 @@ AMDGPUInstructionSelector::selectDS1Addr1OffsetImpl(MachineOperand &Root) const 
   if (Offset) {
     if (isDSOffsetLegal(PtrBase, Offset)) {
       // (add n0, c0)
-      return std::pair(PtrBase, Offset);
+      return std::pair(PtrBase, static_cast<unsigned>(Offset));
     }
   } else if (RootDef->getOpcode() == AMDGPU::G_SUB) {
     // TODO
@@ -6812,7 +6829,7 @@ AMDGPUInstructionSelector::selectDSReadWrite2Impl(MachineOperand &Root,
     int64_t OffsetValue1 = Offset + Size;
     if (isDSOffset2Legal(PtrBase, OffsetValue0, OffsetValue1, Size)) {
       // (add n0, c0)
-      return std::pair(PtrBase, OffsetValue0 / Size);
+      return std::pair(PtrBase, static_cast<unsigned>(OffsetValue0 / Size));
     }
   } else if (RootDef->getOpcode() == AMDGPU::G_SUB) {
     // TODO
@@ -6962,7 +6979,7 @@ bool AMDGPUInstructionSelector::shouldUseAddr64(MUBUFAddressData Addr) const {
 /// component.
 void AMDGPUInstructionSelector::splitIllegalMUBUFOffset(
   MachineIRBuilder &B, Register &SOffset, int64_t &ImmOffset) const {
-  if (TII.isLegalMUBUFImmOffset(ImmOffset))
+  if (TII.isLegalMUBUFImmOffset(static_cast<unsigned>(ImmOffset)))
     return;
 
   // Illegal offset, store it in soffset.
@@ -7650,7 +7667,7 @@ void AMDGPUInstructionSelector::renderVOP3PModsNegs(MachineInstrBuilder &MIB,
 void AMDGPUInstructionSelector::renderVOP3PModsNegAbs(MachineInstrBuilder &MIB,
                                                       const MachineInstr &MI,
                                                       int OpIdx) const {
-  unsigned Val = MI.getOperand(OpIdx).getImm();
+  unsigned Val = static_cast<unsigned>(MI.getOperand(OpIdx).getImm());
   unsigned Mods = SISrcMods::OP_SEL_1; // default: none
   if (Val == 1) // neg
     Mods ^= SISrcMods::NEG;
@@ -7664,7 +7681,7 @@ void AMDGPUInstructionSelector::renderVOP3PModsNegAbs(MachineInstrBuilder &MIB,
 void AMDGPUInstructionSelector::renderPrefetchLoc(MachineInstrBuilder &MIB,
                                                   const MachineInstr &MI,
                                                   int OpIdx) const {
-  uint32_t V = MI.getOperand(2).getImm();
+  uint32_t V = static_cast<uint32_t>(MI.getOperand(2).getImm());
   V = (AMDGPU::CPol::SCOPE_MASK - (V & AMDGPU::CPol::SCOPE_MASK))
       << AMDGPU::CPol::SCOPE_SHIFT;
   if (!Subtarget->hasSafeCUPrefetch())
@@ -7675,7 +7692,7 @@ void AMDGPUInstructionSelector::renderPrefetchLoc(MachineInstrBuilder &MIB,
 /// Convert from 2-bit value to enum values used for op_sel* source modifiers.
 void AMDGPUInstructionSelector::renderScaledMAIIntrinsicOperand(
     MachineInstrBuilder &MIB, const MachineInstr &MI, int OpIdx) const {
-  unsigned Val = MI.getOperand(OpIdx).getImm();
+  unsigned Val = static_cast<unsigned>(MI.getOperand(OpIdx).getImm());
   unsigned New = 0;
   if (Val & 0x1)
     New |= SISrcMods::OP_SEL_0;


### PR DESCRIPTION
For context, see https://github.com/llvm/llvm-project/issues/215213

This patch handles the following cases:

LLT::getSizeInBits() returns TypeSize, which is assigned to 32-bit locals or
passed to 32-bit parameters holding a register width in bits. Add a static_cast
to make the existing narrowing conversion explicit. These are fixed-width LLTs
read from MachineRegisterInfo, so the value is a register width of at most 1024
and the conversion is NFC.

MachineOperand::getImm() returns int64_t and APInt::getZExtValue() returns
uint64_t; both are assigned to 32-bit locals holding intrinsic operands, buffer
offsets, DS offsets and image-dimension fields. Add a static_cast to make the
existing narrowing conversion explicit.

Container size() returns size_t and is assigned to unsigned or int locals
holding operand counts. Add a static_cast to make the existing narrowing
conversion explicit.

Note that the immediate offsets are cast where they are read into the 32-bit
locals the selector already uses, and where they are consumed by an interface
that is already 32-bit (the buffer and DS addressing helpers, for example
SIInstrInfo::isLegalMUBUFImmOffset(unsigned)), not by widening the local.
Widening them to int64_t would be the larger change and would relocate the
conversion into those interfaces; it is not done here.

This fixes 64 instances of MSVC warning C4244 and 3 of C4267 ("possible loss of
data") in llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp.

Assisted-by: Claude <noreply@anthropic.com>
