### PR TITLE
[AMDGPU][NFC] Explicitly narrow conversions in frame and register handling

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUMachineFunctionInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUMachineFunctionInfo.cpp
@@ -102,7 +102,7 @@ unsigned AMDGPUMachineFunctionInfo::allocateLDSGlobal(const DataLayout &DL,
       if (!BarAddr)
         llvm_unreachable("named barrier should have an assigned address");
       Entry.first->second = BarAddr.value();
-      unsigned BarCnt = GV.getGlobalSize(DL) / 16;
+      unsigned BarCnt = static_cast<unsigned>(GV.getGlobalSize(DL) / 16);
       recordNumNamedBarriers(BarAddr.value(), BarCnt);
       return BarAddr.value();
     }
@@ -130,7 +130,8 @@ unsigned AMDGPUMachineFunctionInfo::allocateLDSGlobal(const DataLayout &DL,
         // section, and not within some other non-absolute-address object
         // allocated here, but the extra error detection is minimal and we would
         // have to pass the Function around or cache the attribute value.
-        uint32_t ObjectEnd = ObjectStart + GV.getGlobalSize(DL);
+        uint32_t ObjectEnd =
+            static_cast<uint32_t>(ObjectStart + GV.getGlobalSize(DL));
         if (ObjectEnd > StaticLDSSize) {
           report_fatal_error(
               "Absolute address LDS variable outside of static frame");
@@ -144,18 +145,20 @@ unsigned AMDGPUMachineFunctionInfo::allocateLDSGlobal(const DataLayout &DL,
     /// TODO: We should sort these to minimize wasted space due to alignment
     /// padding. Currently the padding is decided by the first encountered use
     /// during lowering.
-    Offset = StaticLDSSize = alignTo(StaticLDSSize, Alignment);
+    Offset = StaticLDSSize =
+        static_cast<uint32_t>(alignTo(StaticLDSSize, Alignment));
 
-    StaticLDSSize += GV.getGlobalSize(DL);
+    StaticLDSSize += static_cast<uint32_t>(GV.getGlobalSize(DL));
 
     // Align LDS size to trailing, e.g. for aligning dynamic shared memory
-    LDSSize = alignTo(StaticLDSSize, Trailing);
+    LDSSize = static_cast<uint32_t>(alignTo(StaticLDSSize, Trailing));
   } else {
     assert(GV.getAddressSpace() == AMDGPUAS::REGION_ADDRESS &&
            "expected region address space");
 
-    Offset = StaticGDSSize = alignTo(StaticGDSSize, Alignment);
-    StaticGDSSize += GV.getGlobalSize(DL);
+    Offset = StaticGDSSize =
+        static_cast<uint32_t>(alignTo(StaticGDSSize, Alignment));
+    StaticGDSSize += static_cast<uint32_t>(GV.getGlobalSize(DL));
 
     // FIXME: Apply alignment of dynamic GDS
     GDSSize = StaticGDSSize;
@@ -174,7 +177,7 @@ AMDGPUMachineFunctionInfo::getLDSKernelIdMetadata(const Function &F) {
             mdconst::extract<ConstantInt>(MD->getOperand(0))) {
       uint64_t ZExt = KnownSize->getZExtValue();
       if (ZExt <= UINT32_MAX) {
-        return ZExt;
+        return static_cast<unsigned>(ZExt);
       }
     }
   }
@@ -193,7 +196,7 @@ AMDGPUMachineFunctionInfo::getLDSAbsoluteAddress(const GlobalValue &GV) {
   if (const APInt *V = AbsSymRange->getSingleElement()) {
     std::optional<uint64_t> ZExt = V->tryZExtValue();
     if (ZExt && (*ZExt <= UINT32_MAX)) {
-      return *ZExt;
+      return static_cast<unsigned>(*ZExt);
     }
   }
 
@@ -211,7 +214,7 @@ void AMDGPUMachineFunctionInfo::setDynLDSAlign(const Function &F,
   if (Alignment <= DynLDSAlign)
     return;
 
-  LDSSize = alignTo(StaticLDSSize, Alignment);
+  LDSSize = static_cast<uint32_t>(alignTo(StaticLDSSize, Alignment));
   DynLDSAlign = Alignment;
 
   // If there is a dynamic LDS variable associated with this function F, every

--- a/llvm/lib/Target/AMDGPU/GCNNSAReassign.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNNSAReassign.cpp
@@ -112,7 +112,7 @@ char &llvm::GCNNSAReassignID = GCNNSAReassignLegacy::ID;
 
 bool GCNNSAReassignImpl::tryAssignRegisters(
     SmallVectorImpl<LiveInterval *> &Intervals, unsigned StartReg) const {
-  unsigned NumRegs = Intervals.size();
+  unsigned NumRegs = static_cast<unsigned>(Intervals.size());
 
   for (unsigned N = 0; N < NumRegs; ++N)
     if (VRM->hasPhys(Intervals[N]->reg()))
@@ -145,7 +145,7 @@ bool GCNNSAReassignImpl::canAssign(unsigned StartReg, unsigned NumRegs) const {
 
 bool GCNNSAReassignImpl::scavengeRegs(
     SmallVectorImpl<LiveInterval *> &Intervals) const {
-  unsigned NumRegs = Intervals.size();
+  unsigned NumRegs = static_cast<unsigned>(Intervals.size());
 
   if (NumRegs > MaxNumVGPRs)
     return false;

--- a/llvm/lib/Target/AMDGPU/GCNRewritePartialRegUses.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNRewritePartialRegUses.cpp
@@ -257,7 +257,7 @@ GCNRewritePartialRegUsesImpl::getRegClassWithShiftedSubregs(
   unsigned MinNumBits = std::numeric_limits<unsigned>::max();
   for (unsigned ClassID : ClassMask.set_bits()) {
     auto *RC = TRI->getRegClass(ClassID);
-    unsigned NumBits = TRI->getRegSizeInBits(*RC);
+    unsigned NumBits = static_cast<unsigned>(TRI->getRegSizeInBits(*RC));
     if (NumBits < MinNumBits) {
       MinNumBits = NumBits;
       MinRC = RC;
@@ -438,7 +438,7 @@ bool GCNRewritePartialRegUsesImpl::run(MachineFunction &MF) {
   TII = MF.getSubtarget().getInstrInfo();
   bool Changed = false;
   for (size_t I = 0, E = MRI->getNumVirtRegs(); I < E; ++I) {
-    Changed |= rewriteReg(Register::index2VirtReg(I));
+    Changed |= rewriteReg(Register::index2VirtReg(static_cast<unsigned>(I)));
   }
   return Changed;
 }

--- a/llvm/lib/Target/AMDGPU/SIFrameLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFrameLowering.cpp
@@ -76,7 +76,7 @@ static MCCFIInstruction createScaledCFAInPrivateWave(const GCNSubtarget &ST,
 
   SmallString<20> Block;
   raw_svector_ostream OSBlock(Block);
-  encodeDwarfRegisterLocation(DwarfStackPtrReg, OSBlock);
+  encodeDwarfRegisterLocation(static_cast<int>(DwarfStackPtrReg), OSBlock);
   OSBlock << uint8_t(dwarf::DW_OP_deref_size) << uint8_t(SGPRByteSize)
           << uint8_t(dwarf::DW_OP_lit0 + WavefrontSizeLog2)
           << uint8_t(dwarf::DW_OP_shl)
@@ -103,16 +103,17 @@ void SIFrameLowering::emitDefCFA(MachineBasicBlock &MBB,
   const GCNSubtarget &ST = MF.getSubtarget<GCNSubtarget>();
   const SIRegisterInfo *TRI = ST.getRegisterInfo();
 
-  int64_t DwarfStackPtrReg = TRI->getDwarfRegNum(StackPtrReg, false);
+  int64_t DwarfStackPtrReg =
+      static_cast<unsigned>(TRI->getDwarfRegNum(StackPtrReg, false));
   MCCFIInstruction CFIInst =
       ST.hasFlatScratchEnabled()
           ? createScaledCFAInPrivateWave(ST, DwarfStackPtrReg)
           : (AspaceAlreadyDefined
                  ? MCCFIInstruction::createLLVMDefAspaceCfa(
-                       nullptr, DwarfStackPtrReg, 0,
+                       nullptr, static_cast<unsigned>(DwarfStackPtrReg), 0,
                        dwarf::DW_ASPACE_LLVM_AMDGPU_private_wave, SMLoc())
-                 : MCCFIInstruction::createDefCfaRegister(nullptr,
-                                                          DwarfStackPtrReg));
+                 : MCCFIInstruction::createDefCfaRegister(
+                       nullptr, static_cast<unsigned>(DwarfStackPtrReg)));
   buildCFI(MBB, MBBI, DL, CFIInst, Flags);
 }
 
@@ -346,15 +347,16 @@ class PrologEpilogSGPRSpillBuilder {
 
     initLiveUnits(LiveUnits, TRI, FuncInfo, MF, MBB, MI, /*IsProlog*/ true);
 
-    MCPhysReg TmpVGPR = findScratchNonCalleeSaveRegister(
-        MRI, LiveUnits, AMDGPU::VGPR_32RegClass);
+    MCPhysReg TmpVGPR = static_cast<MCPhysReg>(findScratchNonCalleeSaveRegister(
+        MRI, LiveUnits, AMDGPU::VGPR_32RegClass));
     if (!TmpVGPR)
       report_fatal_error("failed to find free scratch register");
 
     auto BuildCFI = [&](Register Reg) {
       TFI->buildCFI(MBB, MI, DL,
                     MCCFIInstruction::createOffset(
-                        nullptr, MCRI->getDwarfRegNum(Reg, false),
+                        nullptr,
+                        static_cast<unsigned>(MCRI->getDwarfRegNum(Reg, false)),
                         MFI.getObjectOffset(FI) * ST.getWavefrontSize()));
     };
     MCRegister CFISuperReg = getCFISuperReg();
@@ -415,9 +417,9 @@ class PrologEpilogSGPRSpillBuilder {
             MBB, MI, DL,
             MCCFIInstruction::createRegister(
                 nullptr,
-                MCRI->getDwarfRegNum(
-                    CFISuperReg ? CFISuperReg : SuperReg.asMCReg(), false),
-                MCRI->getDwarfRegNum(DstReg, false)));
+                static_cast<unsigned>(MCRI->getDwarfRegNum(
+                    CFISuperReg ? CFISuperReg : SuperReg.asMCReg(), false)),
+                static_cast<unsigned>(MCRI->getDwarfRegNum(DstReg, false))));
       } else if (isExec(CFISuperReg)) {
         assert(NumSubRegs == 2 && "EXEC larger than 64-bit");
         TFI->buildCFIForRegToSGPRPairSpill(MBB, MI, DL, CFISuperReg, DstReg);
@@ -425,10 +427,13 @@ class PrologEpilogSGPRSpillBuilder {
         for (unsigned I = 0; I < NumSubRegs; ++I) {
           MCRegister SrcSubReg = TRI.getSubReg(SuperReg, SplitParts[I]);
           MCRegister DstSubReg = TRI.getSubReg(DstReg, DstSplitParts[I]);
-          TFI->buildCFI(MBB, MI, DL,
-                        MCCFIInstruction::createRegister(
-                            nullptr, MCRI->getDwarfRegNum(SrcSubReg, false),
-                            MCRI->getDwarfRegNum(DstSubReg, false)));
+          TFI->buildCFI(
+              MBB, MI, DL,
+              MCCFIInstruction::createRegister(
+                  nullptr,
+                  static_cast<unsigned>(MCRI->getDwarfRegNum(SrcSubReg, false)),
+                  static_cast<unsigned>(
+                      MCRI->getDwarfRegNum(DstSubReg, false))));
         }
       }
     }
@@ -439,8 +444,8 @@ class PrologEpilogSGPRSpillBuilder {
     const GCNSubtarget &ST = MF.getSubtarget<GCNSubtarget>();
 
     initLiveUnits(LiveUnits, TRI, FuncInfo, MF, MBB, MI, /*IsProlog*/ false);
-    MCPhysReg TmpVGPR = findScratchNonCalleeSaveRegister(
-        MRI, LiveUnits, AMDGPU::VGPR_32RegClass);
+    MCPhysReg TmpVGPR = static_cast<MCPhysReg>(findScratchNonCalleeSaveRegister(
+        MRI, LiveUnits, AMDGPU::VGPR_32RegClass));
     if (!TmpVGPR)
       report_fatal_error("failed to find free scratch register");
 
@@ -499,7 +504,8 @@ public:
         NeedsFrameMoves(MF.needsFrameMoves()) {
     const TargetRegisterClass *RC = TRI.getPhysRegBaseClass(SuperReg);
     SplitParts = TRI.getRegSplitParts(RC, EltSize);
-    NumSubRegs = SplitParts.empty() ? 1 : SplitParts.size();
+    NumSubRegs =
+        static_cast<unsigned>(SplitParts.empty() ? 1 : SplitParts.size());
 
     assert(SuperReg != AMDGPU::M0 && "m0 should never spill");
   }
@@ -591,7 +597,8 @@ void SIFrameLowering::emitEntryFunctionFlatScratchInit(
     unsigned Offset =
         MF.getFunction().getCallingConv() == CallingConv::AMDGPU_CS ? 16 : 0;
     const GCNSubtarget &Subtarget = MF.getSubtarget<GCNSubtarget>();
-    unsigned EncodedOffset = AMDGPU::convertSMRDOffsetUnits(Subtarget, Offset);
+    unsigned EncodedOffset = static_cast<unsigned>(
+        AMDGPU::convertSMRDOffsetUnits(Subtarget, Offset));
     BuildMI(MBB, I, DL, LoadDwordX2, FlatScrInit)
         .addReg(FlatScrInit)
         .addImm(EncodedOffset) // offset
@@ -792,7 +799,8 @@ void SIFrameLowering::emitEntryFunctionPrologue(MachineFunction &MF,
     // Unwinding halts when the return address (PC) is undefined.
     buildCFI(MBB, I, DL,
              MCCFIInstruction::createUndefined(
-                 nullptr, TRI->getDwarfRegNum(AMDGPU::PC_REG, false)));
+                 nullptr, static_cast<unsigned>(
+                              TRI->getDwarfRegNum(AMDGPU::PC_REG, false))));
   }
 
   Register PreloadedScratchWaveOffsetReg = MFI->getPreloadedReg(
@@ -864,7 +872,8 @@ void SIFrameLowering::emitEntryFunctionPrologue(MachineFunction &MF,
   }
   assert(ScratchWaveOffsetReg || !PreloadedScratchWaveOffsetReg);
 
-  unsigned Offset = FrameInfo.getStackSize() * getScratchScaleFactor(ST);
+  unsigned Offset = static_cast<unsigned>(FrameInfo.getStackSize() *
+                                          getScratchScaleFactor(ST));
   if (!mayReserveScratchForCWSR(MF)) {
     if (hasFP(MF)) {
       Register FPReg = MFI->getFrameOffsetReg();
@@ -887,12 +896,12 @@ void SIFrameLowering::emitEntryFunctionPrologue(MachineFunction &MF,
     assert(hasFP(MF));
     Register FPReg = MFI->getFrameOffsetReg();
     assert(FPReg != AMDGPU::FP_REG);
-    unsigned VGPRSize = llvm::alignTo(
+    unsigned VGPRSize = static_cast<unsigned>(llvm::alignTo(
         (ST.getAddressableNumVGPRs(MFI->getDynamicVGPRBlockSize()) -
          AMDGPU::IsaInfo::getVGPRAllocGranule(ST,
                                               MFI->getDynamicVGPRBlockSize())) *
             4,
-        FrameInfo.getMaxAlign());
+        FrameInfo.getMaxAlign()));
     MFI->setScratchReservedForDynamicVGPRs(VGPRSize);
 
     BuildMI(MBB, I, DL, TII->get(AMDGPU::GET_STACK_BASE), FPReg);
@@ -941,8 +950,8 @@ void SIFrameLowering::emitEntryFunctionPrologue(MachineFunction &MF,
     // Set REPLAY_MODE (bit 25) in MODE register to enable multi-group XNACK
     // replay. This aligns hardware behavior with the compiler's s_wait_xcnt
     // insertion logic, which assumes multi-group mode by default.
-    unsigned RegEncoding =
-        AMDGPU::Hwreg::HwregEncoding::encode(AMDGPU::Hwreg::ID_MODE, 25, 1);
+    unsigned RegEncoding = static_cast<unsigned>(
+        AMDGPU::Hwreg::HwregEncoding::encode(AMDGPU::Hwreg::ID_MODE, 25, 1));
     BuildMI(MBB, I, DL, TII->get(AMDGPU::S_SETREG_IMM32_B32))
         .addImm(1)
         .addImm(RegEncoding);
@@ -980,7 +989,8 @@ void SIFrameLowering::emitEntryFunctionScratchRsrcRegSetup(
         16, Align(4));
     unsigned Offset = Fn.getCallingConv() == CallingConv::AMDGPU_CS ? 16 : 0;
     const GCNSubtarget &Subtarget = MF.getSubtarget<GCNSubtarget>();
-    unsigned EncodedOffset = AMDGPU::convertSMRDOffsetUnits(Subtarget, Offset);
+    unsigned EncodedOffset = static_cast<unsigned>(
+        AMDGPU::convertSMRDOffsetUnits(Subtarget, Offset));
     BuildMI(MBB, I, DL, LoadDwordX4, ScratchRsrcReg)
       .addReg(Rsrc01)
       .addImm(EncodedOffset) // offset
@@ -1135,7 +1145,8 @@ void SIFrameLowering::emitPrologueEntryCFI(MachineBasicBlock &MBB,
       return;
     if (IsCalleeSaved.test(Reg) || !MRI.isPhysRegModified(Reg))
       return;
-    MCRegister DwarfReg = MCRI->getDwarfRegNum(Reg, false);
+    MCRegister DwarfReg =
+        static_cast<unsigned>(MCRI->getDwarfRegNum(Reg, false));
     buildCFI(MBB, MBBI, DL,
              MCCFIInstruction::createUndefined(nullptr, DwarfReg));
   };
@@ -1234,10 +1245,12 @@ void SIFrameLowering::emitCSRSpillStores(
                            VGPR, FI, FrameReg);
           if (NeedsFrameMoves) {
             // We spill the entire VGPR, so we can get away with just cfi_offset
-            buildCFI(MBB, MBBI, DL,
-                     MCCFIInstruction::createOffset(
-                         nullptr, MCRI->getDwarfRegNum(VGPR, false),
-                         MFI.getObjectOffset(FI) * ST.getWavefrontSize()));
+            buildCFI(
+                MBB, MBBI, DL,
+                MCCFIInstruction::createOffset(
+                    nullptr,
+                    static_cast<unsigned>(MCRI->getDwarfRegNum(VGPR, false)),
+                    MFI.getObjectOffset(FI) * ST.getWavefrontSize()));
           }
         }
       };
@@ -1304,13 +1317,13 @@ void SIFrameLowering::emitCSRSpillStores(
   FuncInfo->getAllScratchSGPRCopyDstRegs(ScratchSGPRs);
   if (!ScratchSGPRs.empty()) {
     for (MachineBasicBlock &MBB : MF) {
-      for (MCPhysReg Reg : ScratchSGPRs)
+      for (Register Reg : ScratchSGPRs)
         MBB.addLiveIn(Reg);
 
       MBB.sortUniqueLiveIns();
     }
     if (!LiveUnits.empty()) {
-      for (MCPhysReg Reg : ScratchSGPRs)
+      for (Register Reg : ScratchSGPRs)
         LiveUnits.addReg(Reg);
     }
   }
@@ -1453,7 +1466,7 @@ void SIFrameLowering::emitPrologue(MachineFunction &MF,
 
   bool HasFP = false;
   bool HasBP = false;
-  uint32_t NumBytes = MFI.getStackSize();
+  uint32_t NumBytes = static_cast<uint32_t>(MFI.getStackSize());
   uint32_t RoundedSize = NumBytes;
 
   // Functions that never return don't need to save and restore the FP or BP.
@@ -1506,7 +1519,7 @@ void SIFrameLowering::emitPrologue(MachineFunction &MF,
   }
 
   if (HasFP) {
-    const unsigned Alignment = MFI.getMaxAlign().value();
+    const unsigned Alignment = static_cast<unsigned>(MFI.getMaxAlign().value());
 
     RoundedSize += Alignment;
     if (LiveUnits.empty()) {
@@ -1614,10 +1627,11 @@ void SIFrameLowering::emitEpilogue(MachineFunction &MF,
     MBBI = MBB.getFirstTerminator();
   }
 
-  uint32_t NumBytes = MFI.getStackSize();
-  uint32_t RoundedSize = FuncInfo->isStackRealigned()
-                             ? NumBytes + MFI.getMaxAlign().value()
-                             : NumBytes;
+  uint32_t NumBytes = static_cast<uint32_t>(MFI.getStackSize());
+  uint32_t RoundedSize =
+      FuncInfo->isStackRealigned()
+          ? static_cast<uint32_t>(NumBytes + MFI.getMaxAlign().value())
+          : NumBytes;
   const Register StackPtrReg = FuncInfo->getStackPtrOffsetReg();
   Register FramePtrReg = FuncInfo->getFrameOffsetReg();
   bool FPSaved = FuncInfo->hasPrologEpilogSGPRSpillEntry(FramePtrReg);
@@ -2235,7 +2249,7 @@ bool SIFrameLowering::allocateScavengingFrameIndexesNearIncomingSP(
                                AMDGPU::FlatAddrSpace::FlatScratch))
       return false;
   } else {
-    if (TII->isLegalMUBUFImmOffset(MaxOffset))
+    if (TII->isLegalMUBUFImmOffset(static_cast<unsigned>(MaxOffset)))
       return false;
   }
 
@@ -2540,12 +2554,12 @@ MachineInstr *SIFrameLowering::buildCFIForVRegToVRegSpill(
   const MCRegisterInfo &MCRI = *MF.getContext().getRegisterInfo();
   const GCNSubtarget &ST = MF.getSubtarget<GCNSubtarget>();
 
-  MCRegister MaskReg = MCRI.getDwarfRegNum(
-      ST.isWave32() ? AMDGPU::EXEC_LO : AMDGPU::EXEC, false);
+  MCRegister MaskReg = static_cast<unsigned>(MCRI.getDwarfRegNum(
+      ST.isWave32() ? AMDGPU::EXEC_LO : AMDGPU::EXEC, false));
   auto CFIInst = MCCFIInstruction::createLLVMVectorRegisterMask(
-      nullptr, MCRI.getDwarfRegNum(Reg, false),
-      MCRI.getDwarfRegNum(RegCopy, false), VGPRLaneBitSize, MaskReg,
-      ST.getWavefrontSize());
+      nullptr, static_cast<unsigned>(MCRI.getDwarfRegNum(Reg, false)),
+      static_cast<unsigned>(MCRI.getDwarfRegNum(RegCopy, false)),
+      VGPRLaneBitSize, MaskReg, ST.getWavefrontSize());
   return buildCFI(MBB, MBBI, DL, std::move(CFIInst));
 }
 
@@ -2556,8 +2570,10 @@ MachineInstr *SIFrameLowering::buildCFIForSGPRToVGPRSpill(
   const MachineFunction &MF = *MBB.getParent();
   const MCRegisterInfo &MCRI = *MF.getContext().getRegisterInfo();
 
-  int DwarfSGPR = MCRI.getDwarfRegNum(SGPR, false);
-  int DwarfVGPR = MCRI.getDwarfRegNum(VGPR, false);
+  int DwarfSGPR =
+      static_cast<int>(static_cast<unsigned>(MCRI.getDwarfRegNum(SGPR, false)));
+  int DwarfVGPR =
+      static_cast<int>(static_cast<unsigned>(MCRI.getDwarfRegNum(VGPR, false)));
   assert(DwarfSGPR != -1 && DwarfVGPR != -1);
   assert(Lane != -1 && "Expected a lane to be present");
 
@@ -2580,7 +2596,8 @@ MachineInstr *SIFrameLowering::buildCFIForSGPRToVGPRSpill(
   const MachineFunction &MF = *MBB.getParent();
   const MCRegisterInfo &MCRI = *MF.getContext().getRegisterInfo();
 
-  int DwarfSGPR = MCRI.getDwarfRegNum(SGPR, false);
+  int DwarfSGPR =
+      static_cast<int>(static_cast<unsigned>(MCRI.getDwarfRegNum(SGPR, false)));
   assert(DwarfSGPR != -1);
 
   // Build a CFI instruction that represents a SGPR spilled to multiple lanes of
@@ -2588,7 +2605,8 @@ MachineInstr *SIFrameLowering::buildCFIForSGPRToVGPRSpill(
 
   SmallVector<MCCFIInstruction::VectorRegisterWithLane> VGPRs;
   for (SIRegisterInfo::SpilledReg Spill : VGPRSpills) {
-    int DwarfVGPR = MCRI.getDwarfRegNum(Spill.VGPR, false);
+    int DwarfVGPR = static_cast<int>(
+        static_cast<unsigned>(MCRI.getDwarfRegNum(Spill.VGPR, false)));
     assert(DwarfVGPR != -1);
     assert(Spill.hasLane() && "Expected a lane to be present");
     VGPRs.push_back(
@@ -2607,7 +2625,9 @@ MachineInstr *SIFrameLowering::buildCFIForSGPRToVMEMSpill(
   const MCRegisterInfo &MCRI = *MF.getContext().getRegisterInfo();
   return buildCFI(MBB, MBBI, DL,
                   llvm::MCCFIInstruction::createOffset(
-                      nullptr, MCRI.getDwarfRegNum(SGPR, false), Offset));
+                      nullptr,
+                      static_cast<unsigned>(MCRI.getDwarfRegNum(SGPR, false)),
+                      Offset));
 }
 
 MachineInstr *SIFrameLowering::buildCFIForVGPRToVMEMSpill(
@@ -2617,11 +2637,12 @@ MachineInstr *SIFrameLowering::buildCFIForVGPRToVMEMSpill(
   const MCRegisterInfo &MCRI = *MF.getContext().getRegisterInfo();
   const GCNSubtarget &ST = MF.getSubtarget<GCNSubtarget>();
 
-  int DwarfVGPR = MCRI.getDwarfRegNum(VGPR, false);
+  int DwarfVGPR =
+      static_cast<int>(static_cast<unsigned>(MCRI.getDwarfRegNum(VGPR, false)));
   assert(DwarfVGPR != -1);
 
-  MCRegister MaskReg = MCRI.getDwarfRegNum(
-      ST.isWave32() ? AMDGPU::EXEC_LO : AMDGPU::EXEC, false);
+  MCRegister MaskReg = static_cast<unsigned>(MCRI.getDwarfRegNum(
+      ST.isWave32() ? AMDGPU::EXEC_LO : AMDGPU::EXEC, false));
   auto CFIInst = MCCFIInstruction::createLLVMVectorOffset(
       nullptr, DwarfVGPR, VGPRLaneBitSize, MaskReg, ST.getWavefrontSize(),
       Offset);
@@ -2638,9 +2659,12 @@ MachineInstr *SIFrameLowering::buildCFIForRegToSGPRPairSpill(
   MCRegister SGPR0 = TRI.getSubReg(SGPRPair, AMDGPU::sub0);
   MCRegister SGPR1 = TRI.getSubReg(SGPRPair, AMDGPU::sub1);
 
-  int DwarfReg = TRI.getDwarfRegNum(Reg, false);
-  int DwarfSGPR0 = TRI.getDwarfRegNum(SGPR0, false);
-  int DwarfSGPR1 = TRI.getDwarfRegNum(SGPR1, false);
+  int DwarfReg =
+      static_cast<int>(static_cast<unsigned>(TRI.getDwarfRegNum(Reg, false)));
+  int DwarfSGPR0 =
+      static_cast<int>(static_cast<unsigned>(TRI.getDwarfRegNum(SGPR0, false)));
+  int DwarfSGPR1 =
+      static_cast<int>(static_cast<unsigned>(TRI.getDwarfRegNum(SGPR1, false)));
   assert(DwarfReg != -1 && DwarfSGPR0 != -1 && DwarfSGPR1 != -1);
 
   auto CFIInst = MCCFIInstruction::createLLVMRegisterPair(
@@ -2653,7 +2677,8 @@ MachineInstr *SIFrameLowering::buildCFIForSameValue(
     const DebugLoc &DL, MCRegister Reg) const {
   const MachineFunction &MF = *MBB.getParent();
   const MCRegisterInfo &MCRI = *MF.getContext().getRegisterInfo();
-  int DwarfReg = MCRI.getDwarfRegNum(Reg, /*isEH=*/false);
+  int DwarfReg = static_cast<int>(
+      static_cast<unsigned>(MCRI.getDwarfRegNum(Reg, /*isEH=*/false)));
   auto CFIInst = MCCFIInstruction::createSameValue(nullptr, DwarfReg);
   return buildCFI(MBB, MBBI, DL, std::move(CFIInst));
 }

--- a/llvm/lib/Target/AMDGPU/SILowerI1Copies.cpp
+++ b/llvm/lib/Target/AMDGPU/SILowerI1Copies.cpp
@@ -337,7 +337,7 @@ private:
       }
     }
 
-    unsigned Level = CommonDominators.size();
+    unsigned Level = static_cast<unsigned>(CommonDominators.size());
     while (!Stack.empty()) {
       MachineBasicBlock *MBB = Stack.pop_back_val();
       if (!PDT.dominates(VisitedPostDom, MBB))
@@ -391,7 +391,7 @@ insertUndefLaneMask(MachineBasicBlock *MBB, MachineRegisterInfo *MRI,
 static bool isVRegCompatibleReg(const SIRegisterInfo &TRI,
                                 const MachineRegisterInfo &MRI,
                                 Register Reg) {
-  unsigned Size = TRI.getRegSizeInBits(Reg, MRI);
+  unsigned Size = static_cast<unsigned>(TRI.getRegSizeInBits(Reg, MRI));
   return Size == 1 || Size == 32;
 }
 #endif

--- a/llvm/lib/Target/AMDGPU/SILowerSGPRSpills.cpp
+++ b/llvm/lib/Target/AMDGPU/SILowerSGPRSpills.cpp
@@ -264,9 +264,9 @@ bool SILowerSGPRSpills::spillCalleeSavedRegs(
         }
 
         const TargetRegisterClass *RC = TRI->getMinimalPhysRegClass(Reg);
-        int JunkFI = MFI.CreateStackObject(TRI->getSpillSize(*RC),
-                                           TRI->getSpillAlign(*RC), true,
-                                           nullptr, TRI->getSpillStackID(*RC));
+        int JunkFI = MFI.CreateStackObject(
+            TRI->getSpillSize(*RC), TRI->getSpillAlign(*RC), true, nullptr,
+            static_cast<uint8_t>(TRI->getSpillStackID(*RC)));
 
         CSI.emplace_back(Reg, JunkFI);
         CalleeSavedFIs.push_back(JunkFI);
@@ -278,9 +278,9 @@ bool SILowerSGPRSpills::spillCalleeSavedRegs(
     // can be emitted appropriately.
     if (SpillRetAddrReg) {
       const TargetRegisterClass *RC = TRI->getMinimalPhysRegClass(RetAddrReg);
-      int JunkFI =
-          MFI.CreateStackObject(TRI->getSpillSize(*RC), TRI->getSpillAlign(*RC),
-                                true, nullptr, TRI->getSpillStackID(*RC));
+      int JunkFI = MFI.CreateStackObject(
+          TRI->getSpillSize(*RC), TRI->getSpillAlign(*RC), true, nullptr,
+          static_cast<uint8_t>(TRI->getSpillStackID(*RC)));
       CSI.push_back(CalleeSavedInfo(RetAddrReg, JunkFI));
       CalleeSavedFIs.push_back(JunkFI);
     }

--- a/llvm/lib/Target/AMDGPU/SIMachineFunctionInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIMachineFunctionInfo.cpp
@@ -180,8 +180,9 @@ SIMachineFunctionInfo::SIMachineFunctionInfo(const Function &F,
   if (!S.empty())
     S.consumeInteger(0, HighBitsOf32BitAddress);
 
-  MaxMemoryClusterDWords = F.getFnAttributeAsParsedInteger(
-      "amdgpu-max-memory-cluster-dwords", DefaultMemoryClusterDWordsLimit);
+  MaxMemoryClusterDWords =
+      static_cast<unsigned>(F.getFnAttributeAsParsedInteger(
+          "amdgpu-max-memory-cluster-dwords", DefaultMemoryClusterDWordsLimit));
 
   // On GFX908, in order to guarantee copying between AGPRs, we need a scratch
   // VGPR available at all times. For now, reserve highest available VGPR. After
@@ -333,7 +334,7 @@ void SIMachineFunctionInfo::splitWWMSpillRegisters(
     SmallVectorImpl<std::pair<Register, int>> &ScratchRegs) const {
   const MCPhysReg *CSRegs = MF.getRegInfo().getCalleeSavedRegs();
   for (auto &Reg : WWMSpills) {
-    if (isCalleeSavedReg(CSRegs, Reg.first))
+    if (isCalleeSavedReg(CSRegs, static_cast<MCPhysReg>(Reg.first)))
       CalleeSavedRegs.push_back(Reg);
     else
       ScratchRegs.push_back(Reg);
@@ -355,7 +356,7 @@ void SIMachineFunctionInfo::shiftWwmVGPRsToLowestRange(
     BitVector &SavedVGPRs) {
   const SIRegisterInfo *TRI = MF.getSubtarget<GCNSubtarget>().getRegisterInfo();
   MachineRegisterInfo &MRI = MF.getRegInfo();
-  for (unsigned I = 0, E = WWMVGPRs.size(); I < E; ++I) {
+  for (unsigned I = 0, E = static_cast<unsigned>(WWMVGPRs.size()); I < E; ++I) {
     Register Reg = WWMVGPRs[I];
     Register NewReg =
         TRI->findUnusedRegister(MRI, &AMDGPU::VGPR_32RegClass, MF);
@@ -374,7 +375,8 @@ void SIMachineFunctionInfo::shiftWwmVGPRsToLowestRange(
     // lanes while spilling special SGPRs like FP, BP, etc. during PEI.
     auto *RegItr = llvm::find(SpillPhysVGPRs, Reg);
     if (RegItr != SpillPhysVGPRs.end()) {
-      unsigned Idx = std::distance(SpillPhysVGPRs.begin(), RegItr);
+      unsigned Idx =
+          static_cast<unsigned>(std::distance(SpillPhysVGPRs.begin(), RegItr));
       SpillPhysVGPRs[Idx] = NewReg;
 
       // For replacing registers used in the CFI instructions.
@@ -460,7 +462,7 @@ bool SIMachineFunctionInfo::allocateSGPRSpillToVGPRLane(
   MachineFrameInfo &FrameInfo = MF.getFrameInfo();
   unsigned WaveSize = ST.getWavefrontSize();
 
-  unsigned Size = FrameInfo.getObjectSize(FI);
+  unsigned Size = static_cast<unsigned>(FrameInfo.getObjectSize(FI));
   unsigned NumLanes = Size / 4;
 
   if (NumLanes > WaveSize)
@@ -507,7 +509,7 @@ bool SIMachineFunctionInfo::allocateVGPRSpillToAGPR(MachineFunction &MF,
   if (!Spill.Lanes.empty())
     return Spill.FullyAllocated;
 
-  unsigned Size = FrameInfo.getObjectSize(FI);
+  unsigned Size = static_cast<unsigned>(FrameInfo.getObjectSize(FI));
   unsigned NumLanes = Size / 4;
   Spill.Lanes.resize(NumLanes, AMDGPU::NoRegister);
 
@@ -614,11 +616,11 @@ int SIMachineFunctionInfo::getScavengeFI(MachineFrameInfo &MFI,
 
 MCPhysReg SIMachineFunctionInfo::getNextUserSGPR() const {
   assert(NumSystemSGPRs == 0 && "System SGPRs must be added after user SGPRs");
-  return AMDGPU::SGPR0 + NumUserSGPRs;
+  return static_cast<MCPhysReg>(AMDGPU::SGPR0 + NumUserSGPRs);
 }
 
 MCPhysReg SIMachineFunctionInfo::getNextSystemSGPR() const {
-  return AMDGPU::SGPR0 + NumUserSGPRs + NumSystemSGPRs;
+  return static_cast<MCPhysReg>(AMDGPU::SGPR0 + NumUserSGPRs + NumSystemSGPRs);
 }
 
 void SIMachineFunctionInfo::MRI_NoteNewVirtualRegister(Register Reg) {
@@ -739,8 +741,10 @@ yaml::SIMachineFunctionInfo::SIMachineFunctionInfo(
       WaveLimiter(MFI.needsWaveLimiter()),
       HasSpilledSGPRs(MFI.hasSpilledSGPRs()),
       HasSpilledVGPRs(MFI.hasSpilledVGPRs()),
-      NumWaveDispatchSGPRs(MFI.getNumWaveDispatchSGPRs()),
-      NumWaveDispatchVGPRs(MFI.getNumWaveDispatchVGPRs()),
+      NumWaveDispatchSGPRs(
+          static_cast<uint16_t>(MFI.getNumWaveDispatchSGPRs())),
+      NumWaveDispatchVGPRs(
+          static_cast<uint16_t>(MFI.getNumWaveDispatchVGPRs())),
       HighBitsOf32BitAddress(MFI.get32BitAddressHighBits()),
       Occupancy(MFI.getOccupancy()),
       ScratchRSrcReg(regToString(MFI.getScratchRSrcReg(), TRI)),

--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
@@ -147,7 +147,8 @@ struct SGPRSpillBuilder {
         IsWave32(IsWave32) {
     const TargetRegisterClass *RC = TRI.getPhysRegBaseClass(SuperReg);
     SplitParts = TRI.getRegSplitParts(RC, EltSize);
-    NumSubRegs = SplitParts.empty() ? 1 : SplitParts.size();
+    NumSubRegs =
+        static_cast<unsigned>(SplitParts.empty() ? 1 : SplitParts.size());
 
     if (IsWave32) {
       ExecReg = AMDGPU::EXEC_LO;
@@ -382,7 +383,7 @@ SIRegisterInfo::SIRegisterInfo(const GCNSubtarget &ST)
         unsigned MaxNumParts = 1024 / Size; // Maximum register is 1024 bits.
         Vec.resize(MaxNumParts);
       }
-      Vec[Pos] = Idx;
+      Vec[Pos] = static_cast<int16_t>(Idx);
     }
   };
 
@@ -401,7 +402,7 @@ SIRegisterInfo::SIRegisterInfo(const GCNSubtarget &ST)
       unsigned TableIdx = Width - 1;
       assert(TableIdx < SubRegFromChannelTable.size());
       assert(Offset < SubRegFromChannelTable[TableIdx].size());
-      SubRegFromChannelTable[TableIdx][Offset] = Idx;
+      SubRegFromChannelTable[TableIdx][Offset] = static_cast<uint16_t>(Idx);
     }
   };
 
@@ -661,7 +662,8 @@ BitVector SIRegisterInfo::getReservedRegs(const MachineFunction &MF) const {
   unsigned TotalNumSGPRs = AMDGPU::SGPR_32RegClass.getNumRegs();
   for (const TargetRegisterClass &RC : regclasses()) {
     if (RC.isBaseClass() && isSGPRClass(&RC)) {
-      unsigned NumRegs = divideCeil(getRegSizeInBits(RC), 32);
+      unsigned NumRegs =
+          static_cast<unsigned>(divideCeil(getRegSizeInBits(RC), 32));
       for (MCPhysReg Reg : RC) {
         unsigned Index = getHWRegIndex(Reg);
         if (Index + NumRegs > MaxNumSGPRs && Index < TotalNumSGPRs &&
@@ -723,7 +725,8 @@ BitVector SIRegisterInfo::getReservedRegs(const MachineFunction &MF) const {
 
   for (const TargetRegisterClass &RC : regclasses()) {
     if (RC.isBaseClass() && isVGPRClass(&RC)) {
-      unsigned NumRegs = divideCeil(getRegSizeInBits(RC), 32);
+      unsigned NumRegs =
+          static_cast<unsigned>(divideCeil(getRegSizeInBits(RC), 32));
       for (MCPhysReg Reg : RC) {
         unsigned Index = getHWRegIndex(Reg);
         if (Index + NumRegs > MaxNumVGPRs)
@@ -737,7 +740,8 @@ BitVector SIRegisterInfo::getReservedRegs(const MachineFunction &MF) const {
     MaxNumAGPRs = 0;
   for (const TargetRegisterClass &RC : regclasses()) {
     if (RC.isBaseClass() && isAGPRClass(&RC)) {
-      unsigned NumRegs = divideCeil(getRegSizeInBits(RC), 32);
+      unsigned NumRegs =
+          static_cast<unsigned>(divideCeil(getRegSizeInBits(RC), 32));
       for (MCPhysReg Reg : RC) {
         unsigned Index = getHWRegIndex(Reg);
         if (Index + NumRegs > MaxNumAGPRs)
@@ -928,7 +932,7 @@ bool SIRegisterInfo::needsFrameBaseReg(MachineInstr *MI, int64_t Offset) const {
 
   const SIInstrInfo *TII = ST.getInstrInfo();
   if (SIInstrInfo::isMUBUF(*MI))
-    return !TII->isLegalMUBUFImmOffset(FullOffset);
+    return !TII->isLegalMUBUFImmOffset(static_cast<unsigned>(FullOffset));
 
   return !TII->isLegalFLATOffset(FullOffset, AMDGPUAS::PRIVATE_ADDRESS,
                                  AMDGPU::FlatAddrSpace::FlatScratch);
@@ -1109,7 +1113,8 @@ void SIRegisterInfo::resolveFrameIndex(MachineInstr &MI, Register BaseReg,
   assert(SOffset->isImm() && SOffset->getImm() == 0);
 #endif
 
-  assert(TII->isLegalMUBUFImmOffset(NewOffset) && "offset should be legal");
+  assert(TII->isLegalMUBUFImmOffset(static_cast<unsigned>(NewOffset)) &&
+         "offset should be legal");
 
   FIOp->ChangeToRegister(BaseReg, false);
   OffsetOp->setImm(NewOffset);
@@ -1137,7 +1142,7 @@ bool SIRegisterInfo::isFrameOffsetLegal(const MachineInstr *MI,
 
   const SIInstrInfo *TII = ST.getInstrInfo();
   if (SIInstrInfo::isMUBUF(*MI))
-    return TII->isLegalMUBUFImmOffset(NewOffset);
+    return TII->isLegalMUBUFImmOffset(static_cast<unsigned>(NewOffset));
 
   return TII->isLegalFLATOffset(NewOffset, AMDGPUAS::PRIVATE_ADDRESS,
                                 AMDGPU::FlatAddrSpace::FlatScratch);
@@ -1716,7 +1721,7 @@ void SIRegisterInfo::buildSpillLoadStore(
   bool IsOffsetLegal =
       IsFlat ? TII->isLegalFLATOffset(MaxOffset, AMDGPUAS::PRIVATE_ADDRESS,
                                       AMDGPU::FlatAddrSpace::FlatScratch)
-             : TII->isLegalMUBUFImmOffset(MaxOffset);
+             : TII->isLegalMUBUFImmOffset(static_cast<unsigned>(MaxOffset));
   if (!IsOffsetLegal || (IsFlat && !SOffset && !ST.hasFlatScratchSTMode())) {
     SOffset = MCRegister();
 
@@ -3412,7 +3417,8 @@ bool SIRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator MI,
 
             // TODO: Fold if use instruction is another add of a constant.
             if (IsVOP2 ||
-                AMDGPU::isInlinableLiteral32(Offset, ST.hasInv2PiInlineImm())) {
+                AMDGPU::isInlinableLiteral32(static_cast<int32_t>(Offset),
+                                             ST.hasInv2PiInlineImm())) {
               // FIXME: This can fail
               MIB.addImm(Offset);
               MIB.addReg(ScaledReg, RegState::Kill);
@@ -3489,8 +3495,8 @@ bool SIRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator MI,
               // to wavespace. We can right shift after the computation to
               // get back to the desired per-lane value. We are using the
               // mad_u32_u24 primarily as an add with no carry out clobber.
-              bool IsInlinableLiteral =
-                  AMDGPU::isInlinableLiteral32(Offset, ST.hasInv2PiInlineImm());
+              bool IsInlinableLiteral = AMDGPU::isInlinableLiteral32(
+                  static_cast<int32_t>(Offset), ST.hasInv2PiInlineImm());
               if (!IsInlinableLiteral) {
                 BuildMI(*MBB, MI, DL, TII->get(AMDGPU::V_MOV_B32_e32),
                         TmpResultReg)
@@ -3568,7 +3574,7 @@ bool SIRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator MI,
           TII->getNamedOperand(*MI, AMDGPU::OpName::offset)->getImm();
       int64_t NewOffset = OldImm + Offset;
 
-      if (TII->isLegalMUBUFImmOffset(NewOffset) &&
+      if (TII->isLegalMUBUFImmOffset(static_cast<unsigned>(NewOffset)) &&
           buildMUBUFOffsetLoadStore(ST, FrameInfo, MI, Index, NewOffset)) {
         MI->eraseFromParent();
         return true;
@@ -3912,7 +3918,7 @@ bool SIRegisterInfo::isSGPRReg(const MachineRegisterInfo &MRI,
 
 const TargetRegisterClass *
 SIRegisterInfo::getEquivalentVGPRClass(const TargetRegisterClass *SRC) const {
-  unsigned Size = getRegSizeInBits(*SRC);
+  unsigned Size = static_cast<unsigned>(getRegSizeInBits(*SRC));
 
   switch (SRC->getID()) {
   default:
@@ -3930,7 +3936,7 @@ SIRegisterInfo::getEquivalentVGPRClass(const TargetRegisterClass *SRC) const {
 
 const TargetRegisterClass *
 SIRegisterInfo::getEquivalentAGPRClass(const TargetRegisterClass *SRC) const {
-  unsigned Size = getRegSizeInBits(*SRC);
+  unsigned Size = static_cast<unsigned>(getRegSizeInBits(*SRC));
   const TargetRegisterClass *ARC = getAGPRClassForBitWidth(Size);
   assert(ARC && "Invalid register class size");
   return ARC;
@@ -3938,7 +3944,7 @@ SIRegisterInfo::getEquivalentAGPRClass(const TargetRegisterClass *SRC) const {
 
 const TargetRegisterClass *
 SIRegisterInfo::getEquivalentAVClass(const TargetRegisterClass *SRC) const {
-  unsigned Size = getRegSizeInBits(*SRC);
+  unsigned Size = static_cast<unsigned>(getRegSizeInBits(*SRC));
   const TargetRegisterClass *ARC = getVectorSuperClassForBitWidth(Size);
   assert(ARC && "Invalid register class size");
   return ARC;
@@ -3946,7 +3952,7 @@ SIRegisterInfo::getEquivalentAVClass(const TargetRegisterClass *SRC) const {
 
 const TargetRegisterClass *
 SIRegisterInfo::getEquivalentSGPRClass(const TargetRegisterClass *VRC) const {
-  unsigned Size = getRegSizeInBits(*VRC);
+  unsigned Size = static_cast<unsigned>(getRegSizeInBits(*VRC));
   if (Size == 32)
     return &AMDGPU::SGPR_32RegClass;
   const TargetRegisterClass *SRC = getSGPRClassForBitWidth(Size);
@@ -4127,7 +4133,7 @@ bool SIRegisterInfo::getRegAllocationHints(Register VirtReg,
     if (PairedPhys)
       // isLo(Paired) is implicitly true here from the API of
       // getMatchingSuperReg.
-      Hints.push_back(PairedPhys);
+      Hints.push_back(static_cast<unsigned short>(PairedPhys));
     return false;
   }
   case AMDGPURI::Size16: {
@@ -4142,7 +4148,7 @@ bool SIRegisterInfo::getRegAllocationHints(Register VirtReg,
 
     // First prefer the paired physreg.
     if (PairedPhys)
-      Hints.push_back(PairedPhys);
+      Hints.push_back(static_cast<unsigned short>(PairedPhys));
     else {
       // Add all the lo16 physregs.
       // When the Paired operand has not yet been assigned a physreg it is
@@ -4276,12 +4282,13 @@ MCPhysReg SIRegisterInfo::get32BitRegister(MCPhysReg Reg) const {
   for (const TargetRegisterClass *RC :
        {&AMDGPU::VGPR_32RegClass, &AMDGPU::SReg_32RegClass,
         &AMDGPU::AGPR_32RegClass}) {
-    if (MCPhysReg Super = getMatchingSuperReg(Reg, AMDGPU::lo16, RC))
+    if (MCPhysReg Super =
+            static_cast<MCPhysReg>(getMatchingSuperReg(Reg, AMDGPU::lo16, RC)))
       return Super;
   }
-  if (MCPhysReg Super = getMatchingSuperReg(Reg, AMDGPU::hi16,
-                                            &AMDGPU::VGPR_32RegClass)) {
-      return Super;
+  if (MCPhysReg Super = static_cast<MCPhysReg>(
+          getMatchingSuperReg(Reg, AMDGPU::hi16, &AMDGPU::VGPR_32RegClass))) {
+    return Super;
   }
 
   return AMDGPU::NoRegister;
@@ -4292,12 +4299,14 @@ bool SIRegisterInfo::isProperlyAlignedRC(const TargetRegisterClass &RC) const {
     return true;
 
   if (isVGPRClass(&RC))
-    return RC.hasSuperClassEq(getVGPRClassForBitWidth(getRegSizeInBits(RC)));
-  if (isAGPRClass(&RC))
-    return RC.hasSuperClassEq(getAGPRClassForBitWidth(getRegSizeInBits(RC)));
-  if (isVectorSuperClass(&RC))
     return RC.hasSuperClassEq(
-        getVectorSuperClassForBitWidth(getRegSizeInBits(RC)));
+        getVGPRClassForBitWidth(static_cast<unsigned>(getRegSizeInBits(RC))));
+  if (isAGPRClass(&RC))
+    return RC.hasSuperClassEq(
+        getAGPRClassForBitWidth(static_cast<unsigned>(getRegSizeInBits(RC))));
+  if (isVectorSuperClass(&RC))
+    return RC.hasSuperClassEq(getVectorSuperClassForBitWidth(
+        static_cast<unsigned>(getRegSizeInBits(RC))));
 
   assert(&RC != &AMDGPU::VS_64RegClass);
 

--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.h
@@ -373,7 +373,8 @@ public:
 
   const TargetRegisterClass *
   getRegClassForTypeOnBank(LLT Ty, const RegisterBank &Bank) const {
-    return getRegClassForSizeOnBank(Ty.getSizeInBits(), Bank);
+    return getRegClassForSizeOnBank(static_cast<unsigned>(Ty.getSizeInBits()),
+                                    Bank);
   }
 
   const TargetRegisterClass *
@@ -503,8 +504,8 @@ public:
     return AMDGPUGenRegisterInfo::getSpillWeightScaleFactor(RC) *
            ((RC == &AMDGPU::VGPR_32_Lo256RegClass ||
              RC == &AMDGPU::VReg_64_Lo256_Align2RegClass)
-                ? 2.0
-                : 1.0);
+                ? 2.0f
+                : 1.0f);
   }
 };
 


### PR DESCRIPTION
For context, see https://github.com/llvm/llvm-project/issues/215213

This patch handles the following cases:

Frame offsets and object sizes are int64_t or uint64_t (MachineFrameInfo) and
are assigned to 32-bit locals or passed to 32-bit parameters. Add a static_cast
to make the existing narrowing conversion explicit. These are scratch offsets
within one function's frame, which the scratch instruction encodings already
limit to well under 2^32.

Register values are stored into MCPhysReg (uint16_t): the register-allocation
hint list in SIRegisterInfo::getRegAllocationHints, the MCPhysReg locals of
SIRegisterInfo::get32BitRegister and SIFrameLowering, and the callee-saved and
user-SGPR queries in SIMachineFunctionInfo. Add a static_cast. Each of these
values is physical -- the hint sites take a subreg or superreg of a register
already established as physical (Paired.isPhysical() or VRM->getPhys(Paired) on
the lines above), get32BitRegister both takes and returns MCPhysReg, and the
others are scratch or ABI registers.

Container size() returns size_t and is assigned to unsigned or int locals
holding spill-slot and register-tuple counts. Add a static_cast to make the
existing narrowing conversion explicit.

Bit-field and fixed-width members of SIMachineFunctionInfo and the register-info
tables are declared uint8_t, uint16_t or uint32_t and assigned from wider
values. Add a static_cast; the field widths are pre-existing and deliberate.

This fixes 85 instances of MSVC warning C4244 and 7 of C4267 ("possible loss of
data") across 9 files in llvm/lib/Target/AMDGPU.

Assisted-by: Claude <noreply@anthropic.com>
