### PR TITLE
[AMDGPU][NFC] Explicitly narrow conversions in SelectionDAG lowering

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
@@ -134,7 +134,7 @@ static SDValue emitRegSequence(llvm::SelectionDAG &CurDAG, unsigned DstRegClass,
                                ArrayRef<unsigned> SubRegClass,
                                const SDLoc &DL) {
   assert(Elts.size() == SubRegClass.size() && "array size mismatch");
-  unsigned NumElts = Elts.size();
+  unsigned NumElts = static_cast<unsigned>(Elts.size());
   SmallVector<SDValue, 17> Ops(2 * NumElts + 1);
   Ops[0] = (CurDAG.getTargetConstant(DstRegClass, DL, MVT::i32));
   for (unsigned i = 0; i < NumElts; ++i) {
@@ -422,12 +422,12 @@ const TargetRegisterClass *AMDGPUDAGToDAGISel::getOperandRegClass(SDNode *N,
     return Subtarget->getRegisterInfo()->getRegClass(RegClass);
   }
   case AMDGPU::REG_SEQUENCE: {
-    unsigned RCID = N->getConstantOperandVal(0);
+    unsigned RCID = static_cast<unsigned>(N->getConstantOperandVal(0));
     const TargetRegisterClass *SuperRC =
         Subtarget->getRegisterInfo()->getRegClass(RCID);
 
     SDValue SubRegOp = N->getOperand(OpNo + 1);
-    unsigned SubRegIdx = SubRegOp->getAsZExtVal();
+    unsigned SubRegIdx = static_cast<unsigned>(SubRegOp->getAsZExtVal());
     return Subtarget->getRegisterInfo()->getSubClassWithSubReg(SuperRC,
                                                               SubRegIdx);
   }
@@ -522,7 +522,7 @@ void AMDGPUDAGToDAGISel::SelectBuildVector(SDNode *N, unsigned RegClassID) {
       CurDAG->isConstantValueOfAnyType(SDValue(N, 0))) {
     uint64_t C = 0;
     bool AllConst = true;
-    unsigned EltSize = EltVT.getSizeInBits();
+    unsigned EltSize = static_cast<unsigned>(EltVT.getSizeInBits());
     for (unsigned I = 0; I < NumVectorElts; ++I) {
       SDValue Op = N->getOperand(I);
       if (Op.isUndef()) {
@@ -556,7 +556,7 @@ void AMDGPUDAGToDAGISel::SelectBuildVector(SDNode *N, unsigned RegClassID) {
   RegSeqArgs[0] = CurDAG->getTargetConstant(RegClassID, DL, MVT::i32);
   bool IsRegSeq = true;
   unsigned NOps = N->getNumOperands();
-  unsigned EltSizeInRegs = EltVT.getSizeInBits() / 32;
+  unsigned EltSizeInRegs = static_cast<unsigned>(EltVT.getSizeInBits() / 32);
   assert(IsGCN || EltSizeInRegs == 1);
   for (unsigned i = 0; i < NOps; i++) {
     // XXX: Why is this here?
@@ -746,7 +746,8 @@ void AMDGPUDAGToDAGISel::Select(SDNode *N) {
     const SIRegisterInfo *TRI = Subtarget->getRegisterInfo();
     EVT EltTy = VT.getVectorElementType();
     assert(EltTy.bitsEq(MVT::i32) || EltTy.bitsEq(MVT::i64));
-    unsigned VecInBits = NumVectorElts * EltTy.getScalarSizeInBits();
+    unsigned VecInBits =
+        static_cast<unsigned>(NumVectorElts * EltTy.getScalarSizeInBits());
     const TargetRegisterClass *RegClass =
         N->isDivergent() ? TRI->getDefaultVectorSuperClassForBitWidth(VecInBits)
                          : SIRegisterInfo::getSGPRClassForBitWidth(VecInBits);
@@ -820,8 +821,8 @@ void AMDGPUDAGToDAGISel::Select(SDNode *N) {
 
     bool Signed = Opc == AMDGPUISD::BFE_I32;
 
-    uint32_t OffsetVal = Offset->getZExtValue();
-    uint32_t WidthVal = Width->getZExtValue();
+    uint32_t OffsetVal = static_cast<uint32_t>(Offset->getZExtValue());
+    uint32_t WidthVal = static_cast<uint32_t>(Width->getZExtValue());
 
     ReplaceNode(N, getBFE32(Signed, SDLoc(N), N->getOperand(0), OffsetVal,
                             WidthVal));
@@ -1329,7 +1330,7 @@ bool AMDGPUDAGToDAGISel::SelectDS1Addr1Offset(SDValue Addr, SDValue &Base,
     SDValue N0 = Addr.getOperand(0);
     SDValue N1 = Addr.getOperand(1);
     ConstantSDNode *C1 = cast<ConstantSDNode>(N1);
-    if (isDSOffsetLegal(N0, C1->getSExtValue())) {
+    if (isDSOffsetLegal(N0, static_cast<unsigned>(C1->getSExtValue()))) {
       // (add n0, c0)
       Base = N0;
       Offset = CurDAG->getTargetConstant(C1->getZExtValue(), DL, MVT::i16);
@@ -1339,7 +1340,7 @@ bool AMDGPUDAGToDAGISel::SelectDS1Addr1Offset(SDValue Addr, SDValue &Base,
     // sub C, x -> add (sub 0, x), C
     if (const ConstantSDNode *C = dyn_cast<ConstantSDNode>(Addr.getOperand(0))) {
       int64_t ByteOffset = C->getSExtValue();
-      if (isDSOffsetLegal(SDValue(), ByteOffset)) {
+      if (isDSOffsetLegal(SDValue(), static_cast<unsigned>(ByteOffset))) {
         SDValue Zero = CurDAG->getTargetConstant(0, DL, MVT::i32);
 
         // XXX - This is kind of hacky. Create a dummy sub node so we can check
@@ -1348,7 +1349,7 @@ bool AMDGPUDAGToDAGISel::SelectDS1Addr1Offset(SDValue Addr, SDValue &Base,
         SDValue Sub = CurDAG->getNode(ISD::SUB, DL, MVT::i32,
                                       Zero, Addr.getOperand(1));
 
-        if (isDSOffsetLegal(Sub, ByteOffset)) {
+        if (isDSOffsetLegal(Sub, static_cast<unsigned>(ByteOffset))) {
           SmallVector<SDValue, 3> Opnds;
           Opnds.push_back(Zero);
           Opnds.push_back(Addr.getOperand(1));
@@ -1378,7 +1379,8 @@ bool AMDGPUDAGToDAGISel::SelectDS1Addr1Offset(SDValue Addr, SDValue &Base,
 
     SDLoc DL(Addr);
 
-    if (isDSOffsetLegal(SDValue(), CAddr->getZExtValue())) {
+    if (isDSOffsetLegal(SDValue(),
+                        static_cast<unsigned>(CAddr->getZExtValue()))) {
       SDValue Zero = CurDAG->getTargetConstant(0, DL, MVT::i32);
       MachineSDNode *MovZero = CurDAG->getMachineNode(AMDGPU::V_MOV_B32_e32,
                                  DL, MVT::i32, Zero);
@@ -1508,7 +1510,7 @@ bool AMDGPUDAGToDAGISel::SelectDSReadWrite2(SDValue Addr, SDValue &Base,
     SDValue N0 = Addr.getOperand(0);
     SDValue N1 = Addr.getOperand(1);
     ConstantSDNode *C1 = cast<ConstantSDNode>(N1);
-    unsigned OffsetValue0 = C1->getZExtValue();
+    unsigned OffsetValue0 = static_cast<unsigned>(C1->getZExtValue());
     unsigned OffsetValue1 = OffsetValue0 + Size;
 
     // (add n0, c0)
@@ -1522,7 +1524,7 @@ bool AMDGPUDAGToDAGISel::SelectDSReadWrite2(SDValue Addr, SDValue &Base,
     // sub C, x -> add (sub 0, x), C
     if (const ConstantSDNode *C =
             dyn_cast<ConstantSDNode>(Addr.getOperand(0))) {
-      unsigned OffsetValue0 = C->getZExtValue();
+      unsigned OffsetValue0 = static_cast<unsigned>(C->getZExtValue());
       unsigned OffsetValue1 = OffsetValue0 + Size;
 
       if (isDSOffset2Legal(SDValue(), OffsetValue0, OffsetValue1, Size)) {
@@ -1559,7 +1561,7 @@ bool AMDGPUDAGToDAGISel::SelectDSReadWrite2(SDValue Addr, SDValue &Base,
       }
     }
   } else if (const ConstantSDNode *CAddr = dyn_cast<ConstantSDNode>(Addr)) {
-    unsigned OffsetValue0 = CAddr->getZExtValue();
+    unsigned OffsetValue0 = static_cast<unsigned>(CAddr->getZExtValue());
     unsigned OffsetValue1 = OffsetValue0 + Size;
 
     if (isDSOffset2Legal(SDValue(), OffsetValue0, OffsetValue1, Size)) {
@@ -1653,7 +1655,7 @@ bool AMDGPUDAGToDAGISel::SelectMUBUF(SDValue Addr, SDValue &Ptr, SDValue &VAddr,
   }
 
   const SIInstrInfo *TII = Subtarget->getInstrInfo();
-  if (TII->isLegalMUBUFImmOffset(C1->getZExtValue())) {
+  if (TII->isLegalMUBUFImmOffset(static_cast<unsigned>(C1->getZExtValue()))) {
     // Legal offset for instruction.
     Offset = CurDAG->getTargetConstant(C1->getZExtValue(), DL, MVT::i32);
     return true;
@@ -1762,7 +1764,7 @@ bool AMDGPUDAGToDAGISel::SelectMUBUFScratchOffen(SDNode *Parent,
     // MUBUF vaddr, but not on older subtargets which can only do this if the
     // sign bit is known 0.
     const SIInstrInfo *TII = Subtarget->getInstrInfo();
-    if (TII->isLegalMUBUFImmOffset(C1) &&
+    if (TII->isLegalMUBUFImmOffset(static_cast<unsigned>(C1)) &&
         (!Subtarget->privateMemoryResourceIsRangeChecked() ||
          CurDAG->SignBitIsZero(N0))) {
       std::tie(VAddr, SOffset) = foldFrameIndex(N0);
@@ -1810,14 +1812,16 @@ bool AMDGPUDAGToDAGISel::SelectMUBUFScratchOffset(SDNode *Parent,
   if (Addr.getOpcode() == ISD::ADD) {
     // Add (CopyFromReg <sgpr>) <constant>
     CAddr = dyn_cast<ConstantSDNode>(Addr.getOperand(1));
-    if (!CAddr || !TII->isLegalMUBUFImmOffset(CAddr->getZExtValue()))
+    if (!CAddr || !TII->isLegalMUBUFImmOffset(
+                      static_cast<unsigned>(CAddr->getZExtValue())))
       return false;
     if (!IsCopyFromSGPR(*TRI, Addr.getOperand(0)))
       return false;
 
     SOffset = Addr.getOperand(0);
   } else if ((CAddr = dyn_cast<ConstantSDNode>(Addr)) &&
-             TII->isLegalMUBUFImmOffset(CAddr->getZExtValue())) {
+             TII->isLegalMUBUFImmOffset(
+                 static_cast<unsigned>(CAddr->getZExtValue()))) {
     // <constant>
     SOffset = CurDAG->getTargetConstant(0, DL, MVT::i32);
   } else {
@@ -2750,8 +2754,8 @@ void AMDGPUDAGToDAGISel::SelectS_BFEFromShifts(SDNode *N) {
   ConstantSDNode *C = dyn_cast<ConstantSDNode>(N->getOperand(1));
 
   if (B && C) {
-    uint32_t BVal = B->getZExtValue();
-    uint32_t CVal = C->getZExtValue();
+    uint32_t BVal = static_cast<uint32_t>(B->getZExtValue());
+    uint32_t CVal = static_cast<uint32_t>(C->getZExtValue());
 
     if (0 < BVal && BVal <= CVal && CVal < 32) {
       bool Signed = N->getOpcode() == ISD::SRA;
@@ -2774,8 +2778,8 @@ void AMDGPUDAGToDAGISel::SelectS_BFE(SDNode *N) {
       ConstantSDNode *Mask = dyn_cast<ConstantSDNode>(N->getOperand(1));
 
       if (Shift && Mask) {
-        uint32_t ShiftVal = Shift->getZExtValue();
-        uint32_t MaskVal = Mask->getZExtValue();
+        uint32_t ShiftVal = static_cast<uint32_t>(Shift->getZExtValue());
+        uint32_t MaskVal = static_cast<uint32_t>(Mask->getZExtValue());
 
         if (isMask_32(MaskVal)) {
           uint32_t WidthVal = llvm::popcount(MaskVal);
@@ -2795,8 +2799,9 @@ void AMDGPUDAGToDAGISel::SelectS_BFE(SDNode *N) {
       ConstantSDNode *Mask = dyn_cast<ConstantSDNode>(And->getOperand(1));
 
       if (Shift && Mask) {
-        uint32_t ShiftVal = Shift->getZExtValue();
-        uint32_t MaskVal = Mask->getZExtValue() >> ShiftVal;
+        uint32_t ShiftVal = static_cast<uint32_t>(Shift->getZExtValue());
+        uint32_t MaskVal =
+            static_cast<uint32_t>(Mask->getZExtValue() >> ShiftVal);
 
         if (isMask_32(MaskVal)) {
           uint32_t WidthVal = llvm::popcount(MaskVal);
@@ -2827,9 +2832,10 @@ void AMDGPUDAGToDAGISel::SelectS_BFE(SDNode *N) {
     if (!Amt)
       break;
 
-    unsigned Width = cast<VTSDNode>(N->getOperand(1))->getVT().getSizeInBits();
+    unsigned Width = static_cast<unsigned>(
+        cast<VTSDNode>(N->getOperand(1))->getVT().getSizeInBits());
     ReplaceNode(N, getBFE32(true, SDLoc(N), Src.getOperand(0),
-                            Amt->getZExtValue(), Width));
+                            static_cast<uint32_t>(Amt->getZExtValue()), Width));
     return;
   }
   }
@@ -3012,7 +3018,8 @@ void AMDGPUDAGToDAGISel::SelectDSAppendConsume(SDNode *N, unsigned IntrID) {
     SDValue PtrOffset = Ptr.getOperand(1);
 
     const APInt &OffsetVal = PtrOffset->getAsAPIntVal();
-    if (isDSOffsetLegal(PtrBase, OffsetVal.getZExtValue())) {
+    if (isDSOffsetLegal(PtrBase,
+                        static_cast<unsigned>(OffsetVal.getZExtValue()))) {
       N = glueCopyToM0(N, PtrBase);
       Offset = CurDAG->getTargetConstant(OffsetVal, SDLoc(), MVT::i32);
     }
@@ -3140,10 +3147,10 @@ void AMDGPUDAGToDAGISel::SelectDS_GWS(SDNode *N, unsigned IntrID) {
     // default -1 only set the low 16-bits, we could leave it as-is and add 1 to
     // the immediate offset.
     glueCopyToM0(N, CurDAG->getTargetConstant(0, SL, MVT::i32));
-    ImmOffset = ConstOffset->getZExtValue();
+    ImmOffset = static_cast<int>(ConstOffset->getZExtValue());
   } else {
     if (CurDAG->isBaseWithConstantOffset(BaseOffset)) {
-      ImmOffset = BaseOffset.getConstantOperandVal(1);
+      ImmOffset = static_cast<int>(BaseOffset.getConstantOperandVal(1));
       BaseOffset = BaseOffset.getOperand(0);
     }
 
@@ -3263,7 +3270,7 @@ void AMDGPUDAGToDAGISel::SelectInterpP1F16(SDNode *N) {
 }
 
 void AMDGPUDAGToDAGISel::SelectINTRINSIC_W_CHAIN(SDNode *N) {
-  unsigned IntrID = N->getConstantOperandVal(1);
+  unsigned IntrID = static_cast<unsigned>(N->getConstantOperandVal(1));
   switch (IntrID) {
   case Intrinsic::amdgcn_ds_append:
   case Intrinsic::amdgcn_ds_consume: {
@@ -3289,7 +3296,7 @@ void AMDGPUDAGToDAGISel::SelectINTRINSIC_W_CHAIN(SDNode *N) {
 }
 
 void AMDGPUDAGToDAGISel::SelectINTRINSIC_WO_CHAIN(SDNode *N) {
-  unsigned IntrID = N->getConstantOperandVal(0);
+  unsigned IntrID = static_cast<unsigned>(N->getConstantOperandVal(0));
   unsigned Opcode = AMDGPU::INSTRUCTION_LIST_END;
   SDNode *ConvGlueNode = N->getGluedNode();
   if (ConvGlueNode) {
@@ -3362,7 +3369,7 @@ void AMDGPUDAGToDAGISel::SelectINTRINSIC_WO_CHAIN(SDNode *N) {
 }
 
 void AMDGPUDAGToDAGISel::SelectINTRINSIC_VOID(SDNode *N) {
-  unsigned IntrID = N->getConstantOperandVal(1);
+  unsigned IntrID = static_cast<unsigned>(N->getConstantOperandVal(1));
   switch (IntrID) {
   case Intrinsic::amdgcn_ds_gws_init:
   case Intrinsic::amdgcn_ds_gws_barrier:
@@ -3652,7 +3659,7 @@ bool AMDGPUDAGToDAGISel::SelectVOP3PMods(SDValue In, SDValue &Src,
         Mods |= SISrcMods::OP_SEL_1;
     }
 
-    unsigned VecSize = Src.getValueSizeInBits();
+    unsigned VecSize = static_cast<unsigned>(Src.getValueSizeInBits());
     Lo = stripExtractLoElt(Lo);
     Hi = stripExtractLoElt(Hi);
 
@@ -3713,7 +3720,8 @@ bool AMDGPUDAGToDAGISel::SelectVOP3PMods(SDValue In, SDValue &Src,
     if (VecSize == 64 && Lo == Hi && isa<ConstantFPSDNode>(Lo)) {
       uint64_t Lit = cast<ConstantFPSDNode>(Lo)->getValueAPF()
                       .bitcastToAPInt().getZExtValue();
-      if (AMDGPU::isInlinableLiteral32(Lit, Subtarget->hasInv2PiInlineImm())) {
+      if (AMDGPU::isInlinableLiteral32(static_cast<int32_t>(Lit),
+                                       Subtarget->hasInv2PiInlineImm())) {
         Src = CurDAG->getTargetConstant(Lit, SDLoc(In), MVT::i64);
         SrcMods = CurDAG->getTargetConstant(Mods, SDLoc(In), MVT::i32);
         return true;
@@ -3802,7 +3810,7 @@ bool AMDGPUDAGToDAGISel::SelectWMMAOpSelVOP3PMods(SDValue In,
   assert(C->getAPIntValue().getBitWidth() == 1 && "expected i1 value");
 
   unsigned Mods = SISrcMods::OP_SEL_1;
-  unsigned SrcVal = C->getZExtValue();
+  unsigned SrcVal = static_cast<unsigned>(C->getZExtValue());
   if (SrcVal == 1)
     Mods |= SISrcMods::OP_SEL_0;
 
@@ -4067,12 +4075,14 @@ bool AMDGPUDAGToDAGISel::SelectWMMAVISrc(SDValue In, SDValue &Src) const {
     if (SDValue Splat = BV->getSplatValue(&UndefElements))
       if (isInlineImmediate(Splat.getNode())) {
         if (const ConstantSDNode *C = dyn_cast<ConstantSDNode>(Splat)) {
-          unsigned Imm = C->getAPIntValue().getSExtValue();
+          unsigned Imm =
+              static_cast<unsigned>(C->getAPIntValue().getSExtValue());
           Src = CurDAG->getTargetConstant(Imm, SDLoc(In), MVT::i32);
           return true;
         }
         if (const ConstantFPSDNode *C = dyn_cast<ConstantFPSDNode>(Splat)) {
-          unsigned Imm = C->getValueAPF().bitcastToAPInt().getSExtValue();
+          unsigned Imm = static_cast<unsigned>(
+              C->getValueAPF().bitcastToAPInt().getSExtValue());
           Src = CurDAG->getTargetConstant(Imm, SDLoc(In), MVT::i32);
           return true;
         }
@@ -4154,7 +4164,7 @@ bool AMDGPUDAGToDAGISel::SelectSWMMACIndex8(SDValue In, SDValue &Src,
     ConstantSDNode *ShiftAmt = dyn_cast<ConstantSDNode>(In.getOperand(1));
     if (ShiftSrc.getValueType().getSizeInBits() == 32 && ShiftAmt &&
         ShiftAmt->getZExtValue() % 8 == 0) {
-      Key = ShiftAmt->getZExtValue() / 8;
+      Key = static_cast<unsigned>(ShiftAmt->getZExtValue() / 8);
       Src = ShiftSrc;
     }
   }
@@ -4458,7 +4468,7 @@ static std::pair<unsigned, uint8_t> BitOp3_Op(SDValue In,
     if (!getOperandBits(LHS, LHSBits) ||
         !getOperandBits(RHS, RHSBits)) {
       Src = std::move(Backup);
-      return std::make_pair(0, 0);
+      return {};
     }
 
     // Recursion is naturally limited by the size of the operand vector.
@@ -4567,7 +4577,7 @@ static std::pair<unsigned, uint8_t> BitOp3_Op(SDValue In,
     break;
   }
   default:
-    return std::make_pair(0, 0);
+    return {};
   }
 
   uint8_t TTbl;

--- a/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.h
@@ -34,12 +34,13 @@ static inline bool getConstantValue(SDValue N, uint32_t &Out) {
   }
 
   if (const ConstantSDNode *C = dyn_cast<ConstantSDNode>(N)) {
-    Out = C->getAPIntValue().getSExtValue();
+    Out = static_cast<uint32_t>(C->getAPIntValue().getSExtValue());
     return true;
   }
 
   if (const ConstantFPSDNode *C = dyn_cast<ConstantFPSDNode>(N)) {
-    Out = C->getValueAPF().bitcastToAPInt().getSExtValue();
+    Out =
+        static_cast<uint32_t>(C->getValueAPF().bitcastToAPInt().getSExtValue());
     return true;
   }
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
@@ -40,7 +40,7 @@ static cl::opt<bool> AMDGPUBypassSlowDiv(
 
 // Find a larger type to do a load / store of a vector with.
 EVT AMDGPUTargetLowering::getEquivalentMemType(LLVMContext &Ctx, EVT VT) {
-  unsigned StoreSize = VT.getStoreSizeInBits();
+  unsigned StoreSize = static_cast<unsigned>(VT.getStoreSizeInBits());
   if (StoreSize <= 32)
     return EVT::getIntegerVT(Ctx, StoreSize);
 
@@ -805,7 +805,7 @@ EVT AMDGPUTargetLowering::getTypeForExtReturn(LLVMContext &Context, EVT VT,
   assert(!VT.isVector() && "only scalar expected");
 
   // Round to the next multiple of 32-bits.
-  unsigned Size = VT.getSizeInBits();
+  unsigned Size = static_cast<unsigned>(VT.getSizeInBits());
   if (Size <= 32)
     return MVT::i32;
   return EVT::getIntegerVT(Context, 32 * ((Size + 31) / 32));
@@ -839,7 +839,7 @@ bool AMDGPUTargetLowering::shouldReduceLoadWidth(
   if (!TargetLoweringBase::shouldReduceLoadWidth(N, ExtTy, NewVT, ByteOffset))
     return false;
 
-  unsigned NewSize = NewVT.getStoreSizeInBits();
+  unsigned NewSize = static_cast<unsigned>(NewVT.getStoreSizeInBits());
 
   // If we are reducing to a 32-bit load or a smaller multi-dword load,
   // this is always better.
@@ -847,7 +847,7 @@ bool AMDGPUTargetLowering::shouldReduceLoadWidth(
     return true;
 
   EVT OldVT = N->getValueType(0);
-  unsigned OldSize = OldVT.getStoreSizeInBits();
+  unsigned OldSize = static_cast<unsigned>(OldVT.getStoreSizeInBits());
 
   MemSDNode *MN = cast<MemSDNode>(N);
   unsigned AS = MN->getAddressSpace();
@@ -881,8 +881,8 @@ bool AMDGPUTargetLowering::isLoadBitCastBeneficial(EVT LoadTy, EVT CastTy,
   if (LoadTy.getScalarType() == MVT::i32)
     return false;
 
-  unsigned LScalarSize = LoadTy.getScalarSizeInBits();
-  unsigned CastScalarSize = CastTy.getScalarSizeInBits();
+  unsigned LScalarSize = static_cast<unsigned>(LoadTy.getScalarSizeInBits());
+  unsigned CastScalarSize = static_cast<unsigned>(CastTy.getScalarSizeInBits());
 
   if ((LScalarSize >= CastScalarSize) && (CastScalarSize < 32))
     return false;
@@ -910,11 +910,11 @@ bool AMDGPUTargetLowering::isSDNodeAlwaysUniform(const SDNode *N) const {
   case ISD::TokenFactor:
     return true;
   case ISD::INTRINSIC_WO_CHAIN: {
-    unsigned IntrID = N->getConstantOperandVal(0);
+    unsigned IntrID = static_cast<unsigned>(N->getConstantOperandVal(0));
     return AMDGPU::isIntrinsicAlwaysUniform(IntrID);
   }
   case ISD::INTRINSIC_W_CHAIN: {
-    unsigned IntrID = N->getConstantOperandVal(1);
+    unsigned IntrID = static_cast<unsigned>(N->getConstantOperandVal(1));
     return AMDGPU::isIntrinsicAlwaysUniform(IntrID);
   }
   case ISD::LOAD:
@@ -999,8 +999,8 @@ bool AMDGPUTargetLowering::aggressivelyPreferBuildVectorSources(EVT VecVT) const
 bool AMDGPUTargetLowering::isTruncateFree(EVT Source, EVT Dest) const {
   // Truncate is just accessing a subregister.
 
-  unsigned SrcSize = Source.getSizeInBits();
-  unsigned DestSize = Dest.getSizeInBits();
+  unsigned SrcSize = static_cast<unsigned>(Source.getSizeInBits());
+  unsigned DestSize = static_cast<unsigned>(Dest.getSizeInBits());
 
   return DestSize < SrcSize && DestSize % 32 == 0 ;
 }
@@ -1254,7 +1254,7 @@ void AMDGPUTargetLowering::analyzeFormalArgumentsCompute(
     ComputeValueVTs(*this, DL, BaseArgTy, ValueVTs, /*MemVTs=*/nullptr,
                     &Offsets, ArgOffset);
 
-    for (unsigned Value = 0, NumValues = ValueVTs.size();
+    for (unsigned Value = 0, NumValues = static_cast<unsigned>(ValueVTs.size());
          Value != NumValues; ++Value) {
       uint64_t BasePartOffset = Offsets[Value];
 
@@ -1288,7 +1288,8 @@ void AMDGPUTargetLowering::analyzeFormalArgumentsCompute(
         // We have an extended type, like i65.
         MemVT = RegisterVT;
       } else {
-        unsigned MemoryBits = ArgVT.getStoreSizeInBits() / NumRegs;
+        unsigned MemoryBits =
+            static_cast<unsigned>(ArgVT.getStoreSizeInBits() / NumRegs);
         assert(ArgVT.getStoreSizeInBits() % NumRegs == 0);
         if (RegisterVT.isInteger()) {
           MemVT = EVT::getIntegerVT(State.getContext(), MemoryBits);
@@ -1323,7 +1324,7 @@ void AMDGPUTargetLowering::analyzeFormalArgumentsCompute(
                                                BasePartOffset + PartOffset,
                                                MemVT.getSimpleVT(),
                                                CCValAssign::Full));
-        PartOffset += MemVT.getStoreSize();
+        PartOffset += static_cast<unsigned>(MemVT.getStoreSize());
       }
     }
   }
@@ -1554,7 +1555,8 @@ SDValue AMDGPUTargetLowering::LowerGlobalAddress(AMDGPUMachineFunctionInfo *MFI,
       llvm_unreachable("named barrier should have an assigned address");
     if (Address) {
       if (IsNamedBarrier) {
-        unsigned BarCnt = cast<GlobalVariable>(GV)->getGlobalSize(DL) / 16;
+        unsigned BarCnt = static_cast<unsigned>(
+            cast<GlobalVariable>(GV)->getGlobalSize(DL) / 16);
         MFI->recordNumNamedBarriers(Address.value(), BarCnt);
       }
       // A constant byte offset (e.g. from a GEP into an array of named
@@ -1606,7 +1608,8 @@ SDValue AMDGPUTargetLowering::LowerCONCAT_VECTORS(SDValue Op,
 
   EVT VT = Op.getValueType();
   if (VT.getVectorElementType().getSizeInBits() < 32) {
-    unsigned OpBitSize = Op.getOperand(0).getValueType().getSizeInBits();
+    unsigned OpBitSize =
+        static_cast<unsigned>(Op.getOperand(0).getValueType().getSizeInBits());
     if (OpBitSize >= 32 && OpBitSize % 32 == 0) {
       unsigned NewNumElt = OpBitSize / 32;
       EVT NewEltVT = (NewNumElt == 1) ? MVT::i32
@@ -1638,7 +1641,7 @@ SDValue AMDGPUTargetLowering::LowerEXTRACT_SUBVECTOR(SDValue Op,
                                                      SelectionDAG &DAG) const {
   SDLoc SL(Op);
   SmallVector<SDValue, 8> Args;
-  unsigned Start = Op.getConstantOperandVal(1);
+  unsigned Start = static_cast<unsigned>(Op.getConstantOperandVal(1));
   EVT VT = Op.getValueType();
   EVT SrcVT = Op.getOperand(0).getValueType();
 
@@ -1833,7 +1836,7 @@ AMDGPUTargetLowering::getSplitDestVTs(const EVT &VT, SelectionDAG &DAG) const {
   EVT LoVT, HiVT;
   EVT EltVT = VT.getVectorElementType();
   unsigned NumElts = VT.getVectorNumElements();
-  unsigned LoNumElts = PowerOf2Ceil((NumElts + 1) / 2);
+  unsigned LoNumElts = static_cast<unsigned>(PowerOf2Ceil((NumElts + 1) / 2));
   LoVT = EVT::getVectorVT(*DAG.getContext(), EltVT, LoNumElts);
   HiVT = NumElts - LoNumElts == 1
              ? EltVT
@@ -1907,7 +1910,7 @@ SDValue AMDGPUTargetLowering::SplitVectorLoad(const SDValue Op,
   std::tie(LoMemVT, HiMemVT) = getSplitDestVTs(MemVT, DAG);
   std::tie(Lo, Hi) = splitVector(Op, SL, LoVT, HiVT, DAG);
 
-  unsigned Size = LoMemVT.getStoreSize();
+  unsigned Size = static_cast<unsigned>(LoMemVT.getStoreSize());
   Align BaseAlign = Load->getAlign();
   Align HiAlign = commonAlignment(BaseAlign, Size);
 
@@ -2001,7 +2004,7 @@ SDValue AMDGPUTargetLowering::SplitVectorStore(SDValue Op,
 
   const MachinePointerInfo &SrcValue = Store->getMemOperand()->getPointerInfo();
   Align BaseAlign = Store->getAlign();
-  unsigned Size = LoMemVT.getStoreSize();
+  unsigned Size = static_cast<unsigned>(LoMemVT.getStoreSize());
   Align HiAlign = commonAlignment(BaseAlign, Size);
 
   SDValue LoStore =
@@ -2042,7 +2045,7 @@ SDValue AMDGPUTargetLowering::LowerDIVREMToFloat(SDValue Op, SelectionDAG &DAG,
     RHSSignBits = RHSKnown.countMinLeadingZeros();
   }
 
-  unsigned BitSize = VT.getSizeInBits();
+  unsigned BitSize = static_cast<unsigned>(VT.getSizeInBits());
   unsigned SignBits = std::min(LHSSignBits, RHSSignBits);
   unsigned DivBits = BitSize - SignBits;
   if (Sign)
@@ -2284,7 +2287,7 @@ void AMDGPUTargetLowering::LowerUDIVREM64(SDValue Op,
   SDValue DIV_Hi = DAG.getSelectCC(DL, RHS_Hi, Zero, DIV_Part, Zero, ISD::SETEQ);
   SDValue DIV_Lo = Zero;
 
-  const unsigned halfBitWidth = HalfVT.getSizeInBits();
+  const unsigned halfBitWidth = static_cast<unsigned>(HalfVT.getSizeInBits());
 
   for (unsigned i = 0; i < halfBitWidth; ++i) {
     const unsigned bitPos = halfBitWidth - i - 1;
@@ -2631,7 +2634,7 @@ static bool valueIsKnownNeverF32Denorm(SDValue Src) {
   case AMDGPUISD::EXP:
     return true;
   case ISD::INTRINSIC_WO_CHAIN: {
-    unsigned IntrinsicID = Src.getConstantOperandVal(0);
+    unsigned IntrinsicID = static_cast<unsigned>(Src.getConstantOperandVal(0));
     switch (IntrinsicID) {
     case Intrinsic::amdgcn_frexp_mant:
     case Intrinsic::amdgcn_log:
@@ -3917,14 +3920,20 @@ SDValue AMDGPUTargetLowering::LowerFP_TO_INT_SAT(const SDValue Op,
     // Then, clamp at the saturation width using either i16 or i32 instructions
     if (OpOpcode == ISD::FP_TO_SINT_SAT) {
       SDValue MinConst = DAG.getConstant(
-          APInt::getSignedMaxValue(SatWidth).sext(ResultWidth), DL, ResultVT);
+          APInt::getSignedMaxValue(static_cast<unsigned>(SatWidth))
+              .sext(static_cast<unsigned>(ResultWidth)),
+          DL, ResultVT);
       SDValue MaxConst = DAG.getConstant(
-          APInt::getSignedMinValue(SatWidth).sext(ResultWidth), DL, ResultVT);
+          APInt::getSignedMinValue(static_cast<unsigned>(SatWidth))
+              .sext(static_cast<unsigned>(ResultWidth)),
+          DL, ResultVT);
       SDValue MinVal = DAG.getNode(ISD::SMIN, DL, ResultVT, FpToInt, MinConst);
       IntSatVal = DAG.getNode(ISD::SMAX, DL, ResultVT, MinVal, MaxConst);
     } else {
-      SDValue MinConst = DAG.getConstant(
-          APInt::getMaxValue(SatWidth).zext(ResultWidth), DL, ResultVT);
+      SDValue MinConst =
+          DAG.getConstant(APInt::getMaxValue(static_cast<unsigned>(SatWidth))
+                              .zext(static_cast<unsigned>(ResultWidth)),
+                          DL, ResultVT);
       IntSatVal = DAG.getNode(ISD::UMIN, DL, ResultVT, FpToInt, MinConst);
     }
 
@@ -4015,7 +4024,7 @@ static SDValue simplifyMul24(SDNode *Node24,
   SDValue RHS = IsIntrin ? Node24->getOperand(2) : Node24->getOperand(1);
   unsigned NewOpcode = Node24->getOpcode();
   if (IsIntrin) {
-    unsigned IID = Node24->getConstantOperandVal(0);
+    unsigned IID = static_cast<unsigned>(Node24->getConstantOperandVal(0));
     switch (IID) {
     case Intrinsic::amdgcn_mul_i24:
       NewOpcode = AMDGPUISD::MUL_I24;
@@ -4034,7 +4043,8 @@ static SDValue simplifyMul24(SDNode *Node24,
     }
   }
 
-  APInt Demanded = APInt::getLowBitsSet(LHS.getValueSizeInBits(), 24);
+  APInt Demanded =
+      APInt::getLowBitsSet(static_cast<unsigned>(LHS.getValueSizeInBits()), 24);
 
   // First try to simplify using SimplifyMultipleUseDemandedBits which allows
   // the operands to have other uses, but will only perform simplifications that
@@ -4091,7 +4101,7 @@ bool AMDGPUTargetLowering::shouldCombineMemoryType(EVT VT) const {
   if (!VT.isByteSized())
     return false;
 
-  unsigned Size = VT.getStoreSize();
+  unsigned Size = static_cast<unsigned>(VT.getStoreSize());
 
   if ((Size == 1 || Size == 2 || Size == 4) && !VT.isVector())
     return false;
@@ -4117,7 +4127,7 @@ SDValue AMDGPUTargetLowering::performLoadCombine(SDNode *N,
   SelectionDAG &DAG = DCI.DAG;
   EVT VT = LN->getMemoryVT();
 
-  unsigned Size = VT.getStoreSize();
+  unsigned Size = static_cast<unsigned>(VT.getStoreSize());
   Align Alignment = LN->getAlign();
   if (Alignment < Size && isTypeLegal(VT)) {
     unsigned IsFast;
@@ -4167,7 +4177,7 @@ SDValue AMDGPUTargetLowering::performStoreCombine(SDNode *N,
     return SDValue();
 
   EVT VT = SN->getMemoryVT();
-  unsigned Size = VT.getStoreSize();
+  unsigned Size = static_cast<unsigned>(VT.getStoreSize());
 
   SDLoc SL(N);
   SelectionDAG &DAG = DCI.DAG;
@@ -4239,7 +4249,7 @@ SDValue AMDGPUTargetLowering::performAssertSZExtCombine(SDNode *N,
 
 SDValue AMDGPUTargetLowering::performIntrinsicWOChainCombine(
   SDNode *N, DAGCombinerInfo &DCI) const {
-  unsigned IID = N->getConstantOperandVal(0);
+  unsigned IID = static_cast<unsigned>(N->getConstantOperandVal(0));
   switch (IID) {
   case Intrinsic::amdgcn_mul_i24:
   case Intrinsic::amdgcn_mul_u24:
@@ -4309,7 +4319,7 @@ SDValue AMDGPUTargetLowering::performShlCombine(SDNode *N,
 
   unsigned RHSVal;
   if (CRHS) {
-    RHSVal = CRHS->getZExtValue();
+    RHSVal = static_cast<unsigned>(CRHS->getZExtValue());
     if (!RHSVal)
       return LHS;
 
@@ -4428,7 +4438,7 @@ SDValue AMDGPUTargetLowering::performSraCombine(SDNode *N,
       DAG.getConstant(TargetScalarType.getSizeInBits() - 1, SL, TargetType);
   SDValue ShiftAmt;
   if (CRHS) {
-    unsigned RHSVal = CRHS->getZExtValue();
+    unsigned RHSVal = static_cast<unsigned>(CRHS->getZExtValue());
     ShiftAmt = DAG.getConstant(RHSVal - TargetScalarType.getSizeInBits(), SL,
                                TargetType);
   } else if (Known.getMinValue().getZExtValue() ==
@@ -4514,7 +4524,7 @@ SDValue AMDGPUTargetLowering::performSrlCombine(SDNode *N,
   unsigned RHSVal;
 
   if (CRHS) {
-    RHSVal = CRHS->getZExtValue();
+    RHSVal = static_cast<unsigned>(CRHS->getZExtValue());
 
     // fold (srl (and x, c1 << c2), c2) -> (and (srl(x, c2), c1)
     // this improves the ability to match BFE patterns in isel.
@@ -4638,8 +4648,8 @@ SDValue AMDGPUTargetLowering::performTruncateCombine(
       SDValue BV = stripBitcast(Src.getOperand(0));
       if (BV.getOpcode() == ISD::BUILD_VECTOR) {
         EVT SrcEltVT = BV.getOperand(0).getValueType();
-        unsigned SrcEltSize = SrcEltVT.getSizeInBits();
-        unsigned BitIndex = K->getZExtValue();
+        unsigned SrcEltSize = static_cast<unsigned>(SrcEltVT.getSizeInBits());
+        unsigned BitIndex = static_cast<unsigned>(K->getZExtValue());
         unsigned PartIndex = BitIndex / SrcEltSize;
 
         if (PartIndex * SrcEltSize == BitIndex &&
@@ -4673,7 +4683,9 @@ SDValue AMDGPUTargetLowering::performTruncateCombine(
       // - For right shift, do it if ShiftAmt <= (32 - Size) to avoid
       //   losing information stored in the high bits when truncating.
       const unsigned MaxCstSize =
-          (Src.getOpcode() == ISD::SHL) ? 31 : (32 - VT.getScalarSizeInBits());
+          (Src.getOpcode() == ISD::SHL)
+              ? 31
+              : static_cast<unsigned>(32 - VT.getScalarSizeInBits());
       if (Known.getMaxValue().ule(MaxCstSize)) {
         EVT MidVT = VT.isVector() ?
           EVT::getVectorVT(*DAG.getContext(), MVT::i32,
@@ -4740,7 +4752,7 @@ SDValue AMDGPUTargetLowering::performMulCombine(SDNode *N,
   if (!N->isDivergent())
     return SDValue();
 
-  unsigned Size = VT.getSizeInBits();
+  unsigned Size = static_cast<unsigned>(VT.getSizeInBits());
   if (VT.isVector() || Size > 64)
     return SDValue();
 
@@ -5720,18 +5732,14 @@ SDValue AMDGPUTargetLowering::PerformDAGCombine(SDNode *N,
 
     if (ConstantSDNode *CVal = dyn_cast<ConstantSDNode>(BitsFrom)) {
       if (Signed) {
-        return constantFoldBFE<int32_t>(DAG,
-                                        CVal->getSExtValue(),
-                                        OffsetVal,
-                                        WidthVal,
-                                        DL);
+        return constantFoldBFE<int32_t>(
+            DAG, static_cast<int32_t>(CVal->getSExtValue()), OffsetVal,
+            WidthVal, DL);
       }
 
-      return constantFoldBFE<uint32_t>(DAG,
-                                       CVal->getZExtValue(),
-                                       OffsetVal,
-                                       WidthVal,
-                                       DL);
+      return constantFoldBFE<uint32_t>(
+          DAG, static_cast<uint32_t>(CVal->getZExtValue()), OffsetVal, WidthVal,
+          DL);
     }
 
     if ((OffsetVal + WidthVal) >= 32 &&
@@ -5893,7 +5901,8 @@ SDValue AMDGPUTargetLowering::loadStackInputValue(SelectionDAG &DAG,
                                                   int64_t Offset) const {
   MachineFunction &MF = DAG.getMachineFunction();
   MachineFrameInfo &MFI = MF.getFrameInfo();
-  int FI = getOrCreateFixedStackObject(MFI, VT.getStoreSize(), Offset);
+  int FI = getOrCreateFixedStackObject(
+      MFI, static_cast<unsigned>(VT.getStoreSize()), Offset);
 
   auto SrcPtrInfo = MachinePointerInfo::getStack(MF, Offset);
   SDValue Ptr = DAG.getFrameIndex(FI, MVT::i32);
@@ -5951,13 +5960,16 @@ uint32_t AMDGPUTargetLowering::getImplicitParameterOffset(
       alignTo(ExplicitKernArgSize, Alignment) + ExplicitArgOffset;
   switch (Param) {
   case FIRST_IMPLICIT:
-    return ArgOffset;
+    return static_cast<uint32_t>(ArgOffset);
   case PRIVATE_BASE:
-    return ArgOffset + AMDGPU::ImplicitArg::PRIVATE_BASE_OFFSET;
+    return static_cast<uint32_t>(ArgOffset +
+                                 AMDGPU::ImplicitArg::PRIVATE_BASE_OFFSET);
   case SHARED_BASE:
-    return ArgOffset + AMDGPU::ImplicitArg::SHARED_BASE_OFFSET;
+    return static_cast<uint32_t>(ArgOffset +
+                                 AMDGPU::ImplicitArg::SHARED_BASE_OFFSET);
   case QUEUE_PTR:
-    return ArgOffset + AMDGPU::ImplicitArg::QUEUE_PTR_OFFSET;
+    return static_cast<uint32_t>(ArgOffset +
+                                 AMDGPU::ImplicitArg::QUEUE_PTR_OFFSET);
   }
   llvm_unreachable("unexpected implicit parameter type");
 }
@@ -6062,7 +6074,7 @@ void AMDGPUTargetLowering::computeKnownBitsForTargetNode(
   case AMDGPUISD::MUL_I24: {
     KnownBits LHSKnown = DAG.computeKnownBits(Op.getOperand(0), Depth + 1);
     KnownBits RHSKnown = DAG.computeKnownBits(Op.getOperand(1), Depth + 1);
-    unsigned BitWidth = Op.getScalarValueSizeInBits();
+    unsigned BitWidth = static_cast<unsigned>(Op.getScalarValueSizeInBits());
 
     // Sign/Zero extend from 24 bits.
     if (Opc == AMDGPUISD::MUL_I24) {
@@ -6090,7 +6102,7 @@ void AMDGPUTargetLowering::computeKnownBitsForTargetNode(
 
     KnownBits LHSKnown = DAG.computeKnownBits(Op.getOperand(0), Depth + 1);
     KnownBits RHSKnown = DAG.computeKnownBits(Op.getOperand(1), Depth + 1);
-    unsigned Sel = CMask->getZExtValue();
+    unsigned Sel = static_cast<unsigned>(CMask->getZExtValue());
 
     for (unsigned I = 0; I < 32; I += 8) {
       unsigned SelBits = Sel & 0xff;
@@ -6151,7 +6163,7 @@ void AMDGPUTargetLowering::computeKnownBitsForTargetNode(
     break;
   }
   case ISD::INTRINSIC_WO_CHAIN: {
-    unsigned IID = Op.getConstantOperandVal(0);
+    unsigned IID = static_cast<unsigned>(Op.getConstantOperandVal(0));
     switch (IID) {
     case Intrinsic::amdgcn_workitem_id_x:
     case Intrinsic::amdgcn_workitem_id_y:
@@ -6344,7 +6356,7 @@ bool AMDGPUTargetLowering::isKnownNeverNaNForTargetNode(
     return SNaN;
   }
   case ISD::INTRINSIC_WO_CHAIN: {
-    unsigned IntrinsicID = Op.getConstantOperandVal(0);
+    unsigned IntrinsicID = static_cast<unsigned>(Op.getConstantOperandVal(0));
     // TODO: Handle more intrinsics
     switch (IntrinsicID) {
     case Intrinsic::amdgcn_cubeid:


### PR DESCRIPTION
For context, see https://github.com/llvm/llvm-project/issues/215213

This patch handles the following cases:

ConstantSDNode::getZExtValue() and getSExtValue() return uint64_t and int64_t
and are assigned to 32-bit locals or passed to 32-bit parameters holding
immediate operands, shift amounts, offsets and lane indices. Add a static_cast
to make the existing narrowing conversion explicit. The values come from nodes
whose value type is i32 or narrower, or from intrinsic arguments the intrinsic
definition bounds, so the conversion is NFC.

EVT::getSizeInBits(), getScalarSizeInBits(), getStoreSize() and
getValueSizeInBits() return TypeSize and are assigned to 32-bit locals holding
element and vector widths. Add a static_cast to make the existing narrowing
conversion explicit. All of these are on non-scalable EVTs -- AMDGPU has no
scalable vector types -- so the fixed value is a type width of at most 1024.

Container size() returns size_t and is assigned to unsigned locals holding
operand counts. Add a static_cast to make the existing narrowing conversion
explicit.

This fixes 89 instances of MSVC warning C4244 and 2 of C4267 ("possible loss of
data") across 3 files in llvm/lib/Target/AMDGPU.

Assisted-by: Claude <noreply@anthropic.com>
