### PR TITLE
[AMDGPU][NFC] Explicitly narrow conversions in SIInstrInfo and peepholes

### DIFF
--- a/llvm/lib/Target/AMDGPU/GCNDPPCombine.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNDPPCombine.cpp
@@ -582,7 +582,7 @@ bool GCNDPPCombine::combineDPPMov(MachineInstr &MovMI) const {
 
   auto *DppCtrl = TII->getNamedOperand(MovMI, AMDGPU::OpName::dpp_ctrl);
   assert(DppCtrl && DppCtrl->isImm());
-  unsigned DppCtrlVal = DppCtrl->getImm();
+  unsigned DppCtrlVal = static_cast<unsigned>(DppCtrl->getImm());
   if ((MovMI.getOpcode() == AMDGPU::V_MOV_B64_DPP_PSEUDO ||
        MovMI.getOpcode() == AMDGPU::V_MOV_B64_dpp)) {
     if (!ST->hasFeature(AMDGPU::FeatureDPALU_DPP)) {
@@ -696,7 +696,8 @@ bool GCNDPPCombine::combineDPPMov(MachineInstr &MovMI) const {
       unsigned OpNo, E = OrigMI.getNumOperands();
       for (OpNo = 1; OpNo < E; OpNo += 2) {
         if (OrigMI.getOperand(OpNo).getReg() == DPPMovReg) {
-          FwdSubReg = OrigMI.getOperand(OpNo + 1).getImm();
+          FwdSubReg =
+              static_cast<unsigned>(OrigMI.getOperand(OpNo + 1).getImm());
           break;
         }
       }

--- a/llvm/lib/Target/AMDGPU/SIFixSGPRCopies.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFixSGPRCopies.cpp
@@ -485,7 +485,7 @@ static bool hoistAndMergeSGPRInits(unsigned Reg,
         Imm = &MO;
     }
     if (Imm)
-      Inits[Imm->getImm()].push_front(&MI);
+      Inits[static_cast<unsigned>(Imm->getImm())].push_front(&MI);
     else
       Clobbers.push_back(&MI);
   }
@@ -891,7 +891,7 @@ bool SIFixSGPRCopies::tryMoveVGPRConstToSGPR(
 
   const TargetRegisterClass *SrcRC =
       MRI->getRegClass(MaybeVGPRConstMO.getReg());
-  unsigned MoveSize = TRI->getRegSizeInBits(*SrcRC);
+  unsigned MoveSize = static_cast<unsigned>(TRI->getRegSizeInBits(*SrcRC));
   unsigned MoveOp =
       MoveSize == 64 ? AMDGPU::S_MOV_B64_IMM_PSEUDO : AMDGPU::S_MOV_B32;
   BuildMI(*BlockToInsertTo, PointToInsertTo, DL, TII->get(MoveOp), DstReg)
@@ -972,7 +972,7 @@ void SIFixSGPRCopies::analyzeVGPRToSGPRCopy(MachineInstr* MI) {
   const TargetRegisterClass *DstRC = TRI->getRegClassForReg(*MRI, DstReg);
 
   V2SCopyInfo Info(getNextVGPRToSGPRCopyId(), MI,
-                   TRI->getRegSizeInBits(*DstRC));
+                   static_cast<unsigned>(TRI->getRegSizeInBits(*DstRC)));
   SmallVector<MachineInstr *, 8> AnalysisWorklist;
   // Needed because the SSA is not a tree but a graph and may have
   // forks and joins. We should not then go same way twice.
@@ -1061,11 +1061,11 @@ bool SIFixSGPRCopies::needToBeConvertedToVALU(V2SCopyInfo *Info) {
                                SiblingCopy->getOperand(1).getSubReg()));
     }
   }
-  Info->SiblingPenalty = SrcRegs.size();
+  Info->SiblingPenalty = static_cast<unsigned>(SrcRegs.size());
 
   unsigned Penalty =
       Info->NumSVCopies + Info->SiblingPenalty + Info->NumReadfirstlanes;
-  unsigned Profit = Info->SChain.size();
+  unsigned Profit = static_cast<unsigned>(Info->SChain.size());
   Info->Score = Penalty > Profit ? 0 : Profit - Penalty;
   Info->NeedToBeConvertedToVALU = Info->Score < 3;
   return Info->NeedToBeConvertedToVALU;
@@ -1167,7 +1167,7 @@ void SIFixSGPRCopies::lowerVGPR2SGPRCopies(MachineFunction &MF) {
     } else {
       auto Result = BuildMI(*MBB, MI, MI->getDebugLoc(),
                             TII->get(AMDGPU::REG_SEQUENCE), DstReg);
-      int N = TRI->getRegSizeInBits(*SrcRC) / 32;
+      int N = static_cast<int>(TRI->getRegSizeInBits(*SrcRC) / 32);
       for (int i = 0; i < N; i++) {
         Register PartialSrc = TII->buildExtractSubReg(
             Result, *MRI, MI->getOperand(1), SrcRC,

--- a/llvm/lib/Target/AMDGPU/SIFoldOperands.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFoldOperands.cpp
@@ -492,7 +492,7 @@ bool SIFoldOperandsImpl::tryFoldImmWithOpSel(MachineInstr *MI, unsigned UseOpNo,
   // If the literal can be inlined as-is, apply it and short-circuit the
   // tests below. The main motivation for this is to avoid unintuitive
   // uses of opsel.
-  if (AMDGPU::isInlinableLiteralV216(ImmVal, OpType)) {
+  if (AMDGPU::isInlinableLiteralV216(static_cast<uint32_t>(ImmVal), OpType)) {
     Old.ChangeToImmediate(ImmVal);
     return true;
   }
@@ -514,7 +514,7 @@ bool SIFoldOperandsImpl::tryFoldImmWithOpSel(MachineInstr *MI, unsigned UseOpNo,
   assert(ModName != AMDGPU::OpName::NUM_OPERAND_NAMES);
   int ModIdx = AMDGPU::getNamedOperandIdx(Opcode, ModName);
   MachineOperand &Mod = MI->getOperand(ModIdx);
-  unsigned ModVal = Mod.getImm();
+  unsigned ModVal = static_cast<unsigned>(Mod.getImm());
 
   uint16_t ImmLo =
       static_cast<uint16_t>(ImmVal >> (ModVal & SISrcMods::OP_SEL_0 ? 16 : 0));
@@ -1011,7 +1011,8 @@ const TargetRegisterClass *SIFoldOperandsImpl::getRegSeqInit(
     MachineOperand &SrcOp = RegSeq.getOperand(I);
     if (SrcOp.getReg().isPhysical())
       return nullptr;
-    unsigned SubRegIdx = RegSeq.getOperand(I + 1).getImm();
+    unsigned SubRegIdx =
+        static_cast<unsigned>(RegSeq.getOperand(I + 1).getImm());
 
     // Only accept reg_sequence with uniform reg class inputs for simplicity.
     const TargetRegisterClass *OpRC = getRegOpRC(*MRI, *TRI, SrcOp);
@@ -1061,7 +1062,7 @@ SIFoldOperandsImpl::isRegSeqSplat(MachineInstr &RegSeq) const {
   bool TryToMatchSplat64 = false;
 
   std::optional<int64_t> Imm;
-  for (unsigned I = 0, E = Defs.size(); I != E; ++I) {
+  for (unsigned I = 0, E = static_cast<unsigned>(Defs.size()); I != E; ++I) {
     const MachineOperand *Op = Defs[I].first;
     if (!Op->isImm()) {
       if (Op->isReg()) {
@@ -1099,7 +1100,7 @@ SIFoldOperandsImpl::isRegSeqSplat(MachineInstr &RegSeq) const {
   // Fallback to recognizing 64-bit splats broken into 32-bit pieces
   // (i.e. recognize every other other element is 0 for 64-bit immediates)
   int64_t SplatVal64;
-  for (unsigned I = 0, E = Defs.size(); I != E; I += 2) {
+  for (unsigned I = 0, E = static_cast<unsigned>(Defs.size()); I != E; I += 2) {
     const MachineOperand *Op0 = Defs[I].first;
     const MachineOperand *Op1 = Defs[I + 1].first;
 
@@ -1118,7 +1119,8 @@ SIFoldOperandsImpl::isRegSeqSplat(MachineInstr &RegSeq) const {
     if (TRI->getSubRegIdxSize(SubReg0) != 32)
       return {};
 
-    int64_t MergedVal = Make_64(Op1->getImm(), Op0->getImm());
+    int64_t MergedVal = Make_64(static_cast<uint32_t>(Op1->getImm()),
+                                static_cast<uint32_t>(Op0->getImm()));
     if (I == 0)
       SplatVal64 = MergedVal;
     else if (SplatVal64 != MergedVal)
@@ -1234,7 +1236,8 @@ bool SIFoldOperandsImpl::foldOperand(
   // uses of REG_SEQUENCE.
   if (UseMI->isRegSequence()) {
     Register RegSeqDstReg = UseMI->getOperand(0).getReg();
-    unsigned RegSeqDstSubReg = UseMI->getOperand(UseOpIdx + 1).getImm();
+    unsigned RegSeqDstSubReg =
+        static_cast<unsigned>(UseMI->getOperand(UseOpIdx + 1).getImm());
 
     int64_t SplatVal;
     const TargetRegisterClass *SplatRC;
@@ -1301,8 +1304,8 @@ bool SIFoldOperandsImpl::foldOperand(
         AMDGPU::hasNamedOperand(Opc, AMDGPU::OpName::vaddr) &&
         !AMDGPU::hasNamedOperand(Opc, AMDGPU::OpName::saddr)) {
       unsigned NewOpc = AMDGPU::getFlatScratchInstSSfromSV(Opc);
-      unsigned CPol =
-          TII->getNamedOperand(*UseMI, AMDGPU::OpName::cpol)->getImm();
+      unsigned CPol = static_cast<unsigned>(
+          TII->getNamedOperand(*UseMI, AMDGPU::OpName::cpol)->getImm());
       if ((CPol & AMDGPU::CPol::SCAL) &&
           !AMDGPU::supportsScaleOffset(*TII, NewOpc))
         return Changed;
@@ -1655,7 +1658,8 @@ bool SIFoldOperandsImpl::tryConstantFoldOp(MachineInstr *MI) const {
   // xor k0, k1 -> v_mov_b32 (k0 ^ k1)
   if (Src0Imm && Src1Imm) {
     int32_t NewImm;
-    if (!evalBinaryInstruction(Opc, NewImm, *Src0Imm, *Src1Imm))
+    if (!evalBinaryInstruction(Opc, NewImm, static_cast<uint32_t>(*Src0Imm),
+                               static_cast<uint32_t>(*Src1Imm)))
       return false;
 
     bool IsSGPR = TRI->isSGPRReg(*MRI, MI->getOperand(0).getReg());
@@ -1916,7 +1920,8 @@ bool SIFoldOperandsImpl::foldCopyToAGPRRegSequence(MachineInstr *CopyMI) const {
 
   for (unsigned I = 1; I != NumRegSeqOperands; I += 2) {
     MachineOperand &RegOp = RegSeq->getOperand(I);
-    unsigned SubRegIdx = RegSeq->getOperand(I + 1).getImm();
+    unsigned SubRegIdx =
+        static_cast<unsigned>(RegSeq->getOperand(I + 1).getImm());
 
     if (RegOp.getSubReg()) {
       // TODO: Handle subregister compose
@@ -2169,10 +2174,10 @@ SIFoldOperandsImpl::isClamp(const MachineInstr &MI) const {
     if (TII->hasModifiersSet(MI, AMDGPU::OpName::omod))
       return nullptr;
 
-    unsigned Src0Mods
-      = TII->getNamedOperand(MI, AMDGPU::OpName::src0_modifiers)->getImm();
-    unsigned Src1Mods
-      = TII->getNamedOperand(MI, AMDGPU::OpName::src1_modifiers)->getImm();
+    unsigned Src0Mods = static_cast<unsigned>(
+        TII->getNamedOperand(MI, AMDGPU::OpName::src0_modifiers)->getImm());
+    unsigned Src1Mods = static_cast<unsigned>(
+        TII->getNamedOperand(MI, AMDGPU::OpName::src1_modifiers)->getImm());
 
     // Having a 0 op_sel_hi would require swizzling the output in the source
     // instruction, which we can't do.
@@ -2449,7 +2454,7 @@ bool SIFoldOperandsImpl::tryFoldRegSequence(MachineInstr &MI) {
   if (Op->getSubReg())
     return false;
 
-  unsigned OpIdx = Op - &UseMI->getOperand(0);
+  unsigned OpIdx = static_cast<unsigned>(Op - &UseMI->getOperand(0));
   const MCInstrDesc &InstDesc = UseMI->getDesc();
   const TargetRegisterClass *OpRC = TII->getRegClass(InstDesc, OpIdx);
   if (!OpRC || !TRI->isVectorSuperClass(OpRC))

--- a/llvm/lib/Target/AMDGPU/SIFormMemoryClauses.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFormMemoryClauses.cpp
@@ -271,8 +271,9 @@ bool SIFormMemoryClausesImpl::run(MachineFunction &MF) {
 
   MaxVGPRs = TRI->getAllocatableSet(MF, &AMDGPU::VGPR_32RegClass).count();
   MaxSGPRs = TRI->getAllocatableSet(MF, &AMDGPU::SGPR_32RegClass).count();
-  unsigned FuncMaxClause = MF.getFunction().getFnAttributeAsParsedInteger(
-      "amdgpu-max-memory-clause", MaxClause);
+  unsigned FuncMaxClause =
+      static_cast<unsigned>(MF.getFunction().getFnAttributeAsParsedInteger(
+          "amdgpu-max-memory-clause", MaxClause));
 
   for (MachineBasicBlock &MBB : MF) {
     GCNDownwardRPTracker RPT(*LIS);

--- a/llvm/lib/Target/AMDGPU/SIInsertHardClauses.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInsertHardClauses.cpp
@@ -195,8 +195,9 @@ public:
     if (!ST->hasHardClauses())
       return false;
 
-    unsigned MaxClauseLength = MF.getFunction().getFnAttributeAsParsedInteger(
-        "amdgpu-hard-clause-length-limit", 255);
+    unsigned MaxClauseLength =
+        static_cast<unsigned>(MF.getFunction().getFnAttributeAsParsedInteger(
+            "amdgpu-hard-clause-length-limit", 255));
     if (HardClauseLengthLimit.getNumOccurrences())
       MaxClauseLength = HardClauseLengthLimit;
     MaxClauseLength = std::min(MaxClauseLength, ST->maxHardClauseLength());

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -430,11 +430,13 @@ bool SIInstrInfo::getMemOperandsWithOffsetWidth(
 
       unsigned EltSize;
       if (LdSt.mayLoad())
-        EltSize = TRI->getRegSizeInBits(*getOpRegClass(LdSt, 0)) / 16;
+        EltSize = static_cast<unsigned>(
+            TRI->getRegSizeInBits(*getOpRegClass(LdSt, 0)) / 16);
       else {
         assert(LdSt.mayStore());
         int Data0Idx = AMDGPU::getNamedOperandIdx(Opc, AMDGPU::OpName::data0);
-        EltSize = TRI->getRegSizeInBits(*getOpRegClass(LdSt, Data0Idx)) / 8;
+        EltSize = static_cast<unsigned>(
+            TRI->getRegSizeInBits(*getOpRegClass(LdSt, Data0Idx)) / 8);
       }
 
       if (isStride64(Opc))
@@ -792,7 +794,7 @@ static void expandSGPRCopy(const SIInstrInfo &TII, MachineBasicBlock &MBB,
     if (AlignedDest && AlignedSrc && (Idx + 1 < BaseIndices.size())) {
       // Can use SGPR64 copy
       unsigned Channel = RI.getChannelFromSubReg(SubIdx);
-      SubIdx = RI.getSubRegFromChannel(Channel, 2);
+      SubIdx = static_cast<int16_t>(RI.getSubRegFromChannel(Channel, 2));
       DestSubReg = RI.getSubReg(DestReg, SubIdx);
       SrcSubReg = RI.getSubReg(SrcReg, SubIdx);
       assert(DestSubReg && SrcSubReg && "Failed to find subregs!");
@@ -825,9 +827,9 @@ void SIInstrInfo::copyPhysReg(MachineBasicBlock &MBB,
                               Register SrcReg, bool KillSrc, bool RenamableDest,
                               bool RenamableSrc) const {
   const TargetRegisterClass *RC = RI.getPhysRegBaseClass(DestReg);
-  unsigned Size = RI.getRegSizeInBits(*RC);
+  unsigned Size = static_cast<unsigned>(RI.getRegSizeInBits(*RC));
   const TargetRegisterClass *SrcRC = RI.getPhysRegBaseClass(SrcReg);
-  unsigned SrcSize = RI.getRegSizeInBits(*SrcRC);
+  unsigned SrcSize = static_cast<unsigned>(RI.getRegSizeInBits(*SrcRC));
 
   // The rest of copyPhysReg assumes Src and Dst size are the same size.
   // TODO-GFX11_16BIT If all true 16 bit instruction patterns are completed can
@@ -847,9 +849,9 @@ void SIInstrInfo::copyPhysReg(MachineBasicBlock &MBB,
         return;
       }
       RC = RI.getPhysRegBaseClass(DestReg);
-      Size = RI.getRegSizeInBits(*RC);
+      Size = static_cast<unsigned>(RI.getRegSizeInBits(*RC));
       SrcRC = RI.getPhysRegBaseClass(SrcReg);
-      SrcSize = RI.getRegSizeInBits(*SrcRC);
+      SrcSize = static_cast<unsigned>(RI.getRegSizeInBits(*SrcRC));
     }
   }
 
@@ -973,8 +975,9 @@ void SIInstrInfo::copyPhysReg(MachineBasicBlock &MBB,
     bool IsAGPRSrc = AMDGPU::AGPR_LO16RegClass.contains(SrcReg);
     bool DstLow = !AMDGPU::isHi16Reg(DestReg, RI);
     bool SrcLow = !AMDGPU::isHi16Reg(SrcReg, RI);
-    MCRegister NewDestReg = RI.get32BitRegister(DestReg);
-    MCRegister NewSrcReg = RI.get32BitRegister(SrcReg);
+    MCRegister NewDestReg =
+        RI.get32BitRegister(static_cast<MCPhysReg>(DestReg));
+    MCRegister NewSrcReg = RI.get32BitRegister(static_cast<MCPhysReg>(SrcReg));
 
     if (IsSGPRDst) {
       if (!IsSGPRSrc) {
@@ -1209,7 +1212,8 @@ bool SIInstrInfo::getConstValDefinedInReg(const MachineInstr &MI,
   case AMDGPU::V_BFREV_B32_e64: {
     const MachineOperand &Src0 = MI.getOperand(1);
     if (Src0.isImm()) {
-      ImmVal = static_cast<int64_t>(reverseBits<int32_t>(Src0.getImm()));
+      ImmVal = static_cast<int64_t>(
+          reverseBits<int32_t>(static_cast<int32_t>(Src0.getImm())));
       return MI.getOperand(0).getReg() == Reg;
     }
 
@@ -1937,9 +1941,9 @@ unsigned SIInstrInfo::getNumWaitStates(const MachineInstr &MI) {
     return 1; // FIXME: Do wait states equal cycles?
 
   case AMDGPU::S_NOP:
-    return MI.getOperand(0).getImm() + 1;
-  // SI_RETURN_TO_EPILOG is a fallthrough to code outside of the function. The
-  // hazard, even if one exist, won't really be visible. Should we handle it?
+    return static_cast<unsigned>(MI.getOperand(0).getImm() + 1);
+    // SI_RETURN_TO_EPILOG is a fallthrough to code outside of the function. The
+    // hazard, even if one exist, won't really be visible. Should we handle it?
   }
 }
 
@@ -2248,7 +2252,7 @@ bool SIInstrInfo::expandPostRAPseudo(MachineInstr &MI) const {
     const MCInstrDesc &OpDesc = get(Opc);
     Register VecReg = MI.getOperand(0).getReg();
     bool IsUndef = MI.getOperand(1).isUndef();
-    unsigned SubReg = MI.getOperand(3).getImm();
+    unsigned SubReg = static_cast<unsigned>(MI.getOperand(3).getImm());
     assert(VecReg == MI.getOperand(1).getReg());
 
     MachineInstrBuilder MIB =
@@ -2258,8 +2262,8 @@ bool SIInstrInfo::expandPostRAPseudo(MachineInstr &MI) const {
             .addReg(VecReg, RegState::ImplicitDefine)
             .addReg(VecReg, RegState::Implicit | getUndefRegState(IsUndef));
 
-    const int ImpDefIdx =
-        OpDesc.getNumOperands() + OpDesc.implicit_uses().size();
+    const int ImpDefIdx = static_cast<int>(OpDesc.getNumOperands() +
+                                           OpDesc.implicit_uses().size());
     const int ImpUseIdx = ImpDefIdx + 1;
     MIB->tieOperands(ImpDefIdx, ImpUseIdx);
     MI.eraseFromParent();
@@ -2283,7 +2287,7 @@ bool SIInstrInfo::expandPostRAPseudo(MachineInstr &MI) const {
     Register VecReg = MI.getOperand(0).getReg();
     bool IsUndef = MI.getOperand(1).isUndef();
     MachineOperand &Idx = MI.getOperand(3);
-    Register SubReg = MI.getOperand(4).getImm();
+    Register SubReg = static_cast<unsigned>(MI.getOperand(4).getImm());
 
     MachineInstr *SetOn = BuildMI(MBB, MI, DL, get(AMDGPU::S_SET_GPR_IDX_ON))
                               .add(Idx)
@@ -2298,8 +2302,8 @@ bool SIInstrInfo::expandPostRAPseudo(MachineInstr &MI) const {
             .addReg(VecReg, RegState::ImplicitDefine)
             .addReg(VecReg, RegState::Implicit | getUndefRegState(IsUndef));
 
-    const int ImpDefIdx =
-        OpDesc.getNumOperands() + OpDesc.implicit_uses().size();
+    const int ImpDefIdx = static_cast<int>(OpDesc.getNumOperands() +
+                                           OpDesc.implicit_uses().size());
     const int ImpUseIdx = ImpDefIdx + 1;
     MIB->tieOperands(ImpDefIdx, ImpUseIdx);
 
@@ -2328,7 +2332,7 @@ bool SIInstrInfo::expandPostRAPseudo(MachineInstr &MI) const {
     Register Dst = MI.getOperand(0).getReg();
     Register VecReg = MI.getOperand(1).getReg();
     bool IsUndef = MI.getOperand(1).isUndef();
-    Register SubReg = MI.getOperand(3).getImm();
+    Register SubReg = static_cast<unsigned>(MI.getOperand(3).getImm());
 
     MachineInstr *SetOn = BuildMI(MBB, MI, DL, get(AMDGPU::S_SET_GPR_IDX_ON))
                               .add(MI.getOperand(2))
@@ -2649,7 +2653,8 @@ SIInstrInfo::expandMovDPP64(MachineInstr &MI) const {
 
   if (ST.hasVMovB64Inst() && ST.hasFeature(AMDGPU::FeatureDPALU_DPP) &&
       AMDGPU::isLegalDPALU_DPPControl(
-          ST, getNamedOperand(MI, AMDGPU::OpName::dpp_ctrl)->getImm())) {
+          ST, static_cast<unsigned>(
+                  getNamedOperand(MI, AMDGPU::OpName::dpp_ctrl)->getImm()))) {
     MI.setDesc(get(AMDGPU::V_MOV_B64_dpp));
     return std::pair(&MI, nullptr);
   }
@@ -2727,8 +2732,8 @@ bool SIInstrInfo::swapSourceModifiers(MachineInstr &MI, MachineOperand &Src0,
   assert(Src1Mods &&
          "All commutable instructions have both src0 and src1 modifiers");
 
-  int Src0ModsVal = Src0Mods->getImm();
-  int Src1ModsVal = Src1Mods->getImm();
+  int Src0ModsVal = static_cast<int>(Src0Mods->getImm());
+  int Src1ModsVal = static_cast<int>(Src1Mods->getImm());
 
   Src1Mods->setImm(Src0ModsVal);
   Src0Mods->setImm(Src1ModsVal);
@@ -3344,7 +3349,7 @@ void SIInstrInfo::insertSelect(MachineBasicBlock &MBB,
 
   MachineRegisterInfo &MRI = MBB.getParent()->getRegInfo();
   const TargetRegisterClass *DstRC = MRI.getRegClass(DstReg);
-  unsigned DstSize = RI.getRegSizeInBits(*DstRC);
+  unsigned DstSize = static_cast<unsigned>(RI.getRegSizeInBits(*DstRC));
 
   if (DstSize == 32) {
     MachineInstr *Select;
@@ -3539,8 +3544,9 @@ void SIInstrInfo::mutateAndCleanupImplicit(MachineInstr &MI,
   // if we replace an s_and_b32 with a copy, we don't need the implicit scc def
   // anymore.
   const MCInstrDesc &Desc = MI.getDesc();
-  unsigned NumOps = Desc.getNumOperands() + Desc.implicit_uses().size() +
-                    Desc.implicit_defs().size();
+  unsigned NumOps = static_cast<unsigned>(Desc.getNumOperands() +
+                                          Desc.implicit_uses().size() +
+                                          Desc.implicit_defs().size());
 
   for (unsigned I = MI.getNumOperands() - 1; I >= NumOps; --I)
     MI.removeOperand(I);
@@ -3660,7 +3666,8 @@ bool SIInstrInfo::foldImmediate(MachineInstr &UseMI, MachineInstr &DefMI,
     if (HasMultipleUses) {
       // TODO: This should fold in more cases with multiple use, but we need to
       // more carefully consider what those uses are.
-      unsigned ImmDefSize = RI.getRegSizeInBits(*MRI->getRegClass(Reg));
+      unsigned ImmDefSize =
+          static_cast<unsigned>(RI.getRegSizeInBits(*MRI->getRegClass(Reg)));
 
       // Avoid breaking up a 64-bit inline immediate into a subregister extract.
       if (UseSubReg != AMDGPU::NoSubRegister && ImmDefSize == 64)
@@ -4016,7 +4023,8 @@ bool SIInstrInfo::checkInstOffsetsDoNotOverlap(const MachineInstr &MIa,
   }
   LocationSize Width0 = MIa.memoperands().front()->getSize();
   LocationSize Width1 = MIb.memoperands().front()->getSize();
-  return offsetsDoNotOverlap(Width0, Offset0, Width1, Offset1);
+  return offsetsDoNotOverlap(Width0, static_cast<int>(Offset0), Width1,
+                             static_cast<int>(Offset1));
 }
 
 bool SIInstrInfo::areMemAccessesTriviallyDisjoint(const MachineInstr &MIa,
@@ -4670,15 +4678,15 @@ bool SIInstrInfo::isInlineConstant(const APInt &Imm) const {
     return true;
 
   case 32:
-    return AMDGPU::isInlinableLiteral32(Imm.getSExtValue(),
-                                        ST.hasInv2PiInlineImm());
+    return AMDGPU::isInlinableLiteral32(
+        static_cast<int32_t>(Imm.getSExtValue()), ST.hasInv2PiInlineImm());
   case 64:
     return AMDGPU::isInlinableLiteral64(Imm.getSExtValue(),
                                         ST.hasInv2PiInlineImm());
   case 16:
-    return ST.has16BitInsts() &&
-           AMDGPU::isInlinableLiteralI16(Imm.getSExtValue(),
-                                         ST.hasInv2PiInlineImm());
+    return ST.has16BitInsts() && AMDGPU::isInlinableLiteralI16(
+                                     static_cast<int32_t>(Imm.getSExtValue()),
+                                     ST.hasInv2PiInlineImm());
   default:
     llvm_unreachable("invalid bitwidth");
   }
@@ -4696,10 +4704,12 @@ bool SIInstrInfo::isInlineConstant(const APFloat &Imm) const {
     return isInlineConstant(IntImm);
   case APFloatBase::S_BFloat:
     return ST.has16BitInsts() &&
-           AMDGPU::isInlinableLiteralBF16(IntImmVal, HasInv2Pi);
+           AMDGPU::isInlinableLiteralBF16(static_cast<int16_t>(IntImmVal),
+                                          HasInv2Pi);
   case APFloatBase::S_IEEEhalf:
     return ST.has16BitInsts() &&
-           AMDGPU::isInlinableLiteralFP16(IntImmVal, HasInv2Pi);
+           AMDGPU::isInlinableLiteralFP16(static_cast<int16_t>(IntImmVal),
+                                          HasInv2Pi);
   }
 }
 
@@ -4744,15 +4754,16 @@ bool SIInstrInfo::isInlineConstant(int64_t Imm, uint8_t OperandType) const {
     return AMDGPU::isInlinableIntLiteral(Imm);
   case AMDGPU::OPERAND_REG_IMM_V2INT16:
   case AMDGPU::OPERAND_REG_INLINE_C_V2INT16:
-    return AMDGPU::isInlinableLiteralV2I16(Imm);
+    return AMDGPU::isInlinableLiteralV2I16(static_cast<uint32_t>(Imm));
   case AMDGPU::OPERAND_REG_IMM_V2FP16:
   case AMDGPU::OPERAND_REG_INLINE_C_V2FP16:
-    return AMDGPU::isInlinableLiteralV2F16(Imm);
+    return AMDGPU::isInlinableLiteralV2F16(static_cast<uint32_t>(Imm));
   case AMDGPU::OPERAND_REG_IMM_V2FP16_SPLAT:
-    return AMDGPU::isPKFMACF16InlineConstant(Imm, ST.isGFX11Plus());
+    return AMDGPU::isPKFMACF16InlineConstant(static_cast<uint32_t>(Imm),
+                                             ST.isGFX11Plus());
   case AMDGPU::OPERAND_REG_IMM_V2BF16:
   case AMDGPU::OPERAND_REG_INLINE_C_V2BF16:
-    return AMDGPU::isInlinableLiteralV2BF16(Imm);
+    return AMDGPU::isInlinableLiteralV2BF16(static_cast<uint32_t>(Imm));
   case AMDGPU::OPERAND_REG_IMM_NOINLINE_V2FP16:
     return false;
   case AMDGPU::OPERAND_REG_IMM_FP16:
@@ -5392,7 +5403,7 @@ bool SIInstrInfo::verifyInstruction(const MachineInstr &MI,
         Opcode == AMDGPU::V_CVT_PK_F32_BF8_sdwa) {
       const MachineOperand *Src0ModsMO =
           getNamedOperand(MI, AMDGPU::OpName::src0_modifiers);
-      unsigned Mods = Src0ModsMO->getImm();
+      unsigned Mods = static_cast<unsigned>(Src0ModsMO->getImm());
       if (Mods & SISrcMods::ABS || Mods & SISrcMods::NEG ||
           Mods & SISrcMods::SEXT) {
         ErrInfo = "sext, abs and neg are not allowed on this instruction";
@@ -5486,7 +5497,8 @@ bool SIInstrInfo::verifyInstruction(const MachineInstr &MI,
       const MachineOperand &Dst = MI.getOperand(DstIdx);
       if (Dst.isReg()) {
         const TargetRegisterClass *DstRC = getOpRegClass(MI, DstIdx);
-        uint32_t DstSize = RI.getRegSizeInBits(*DstRC) / 32;
+        uint32_t DstSize =
+            static_cast<uint32_t>(RI.getRegSizeInBits(*DstRC) / 32);
         if (RegCount > DstSize) {
           ErrInfo = "Image instruction returns too many registers for dst "
                     "register class";
@@ -5659,8 +5671,8 @@ bool SIInstrInfo::verifyInstruction(const MachineInstr &MI,
     const bool IsDst = Desc.getOpcode() == AMDGPU::V_MOVRELD_B32_e32 ||
                        Desc.getOpcode() == AMDGPU::V_MOVRELD_B32_e64;
 
-    const unsigned StaticNumOps =
-        Desc.getNumOperands() + Desc.implicit_uses().size();
+    const unsigned StaticNumOps = static_cast<unsigned>(
+        Desc.getNumOperands() + Desc.implicit_uses().size());
     const unsigned NumImplicitOps = IsDst ? 2 : 1;
 
     // Require additional implicit operands. This allows a fixup done by the
@@ -5746,8 +5758,8 @@ bool SIInstrInfo::verifyInstruction(const MachineInstr &MI,
       const AMDGPU::MIMGInfo *Info = AMDGPU::getMIMGInfo(Opcode);
       const AMDGPU::MIMGBaseOpcodeInfo *BaseOpcode =
           AMDGPU::getMIMGBaseOpcodeInfo(Info->BaseOpcode);
-      const AMDGPU::MIMGDimInfo *Dim =
-          AMDGPU::getMIMGDimInfoByEncoding(DimOp->getImm());
+      const AMDGPU::MIMGDimInfo *Dim = AMDGPU::getMIMGDimInfoByEncoding(
+          static_cast<uint8_t>(DimOp->getImm()));
 
       if (!Dim) {
         ErrInfo = "dim is out of range";
@@ -5795,7 +5807,7 @@ bool SIInstrInfo::verifyInstruction(const MachineInstr &MI,
   if (DppCt) {
     using namespace AMDGPU::DPP;
 
-    unsigned DC = DppCt->getImm();
+    unsigned DC = static_cast<unsigned>(DppCt->getImm());
     if (DC == DppCtrl::DPP_UNUSED1 || DC == DppCtrl::DPP_UNUSED2 ||
         DC == DppCtrl::DPP_UNUSED3 || DC > DppCtrl::DPP_LAST ||
         (DC >= DppCtrl::DPP_UNUSED4_FIRST && DC <= DppCtrl::DPP_UNUSED4_LAST) ||
@@ -6260,7 +6272,7 @@ static unsigned VOP3OpIdxToSrcN(const MachineInstr &MI, unsigned OpIdx) {
   for (auto [I, OpName] : enumerate(OpNames)) {
     int SrcIdx = AMDGPU::getNamedOperandIdx(MI.getOpcode(), OpNames[I]);
     if (static_cast<unsigned>(SrcIdx) == OpIdx)
-      return I;
+      return static_cast<unsigned>(I);
   }
 
   return UINT_MAX;
@@ -6273,7 +6285,7 @@ void SIInstrInfo::legalizeOpWithMove(MachineInstr &MI, unsigned OpIdx) const {
   MachineRegisterInfo &MRI = MBB->getParent()->getRegInfo();
   unsigned RCID = getOpRegClassID(get(MI.getOpcode()).operands()[OpIdx]);
   const TargetRegisterClass *RC = RI.getRegClass(RCID);
-  unsigned Size = RI.getRegSizeInBits(*RC);
+  unsigned Size = static_cast<unsigned>(RI.getRegSizeInBits(*RC));
   unsigned Opcode = (Size == 64) ? AMDGPU::V_MOV_B64_PSEUDO
                     : Size == 16 ? AMDGPU::V_MOV_B16_t16_e64
                                  : AMDGPU::V_MOV_B32_e32;
@@ -6485,7 +6497,7 @@ bool SIInstrInfo::isLegalSingleSGPRReadInstOperand(
   if (ModsIdx == -1)
     return false;
 
-  unsigned Mods = MI.getOperand(ModsIdx).getImm();
+  unsigned Mods = static_cast<unsigned>(MI.getOperand(ModsIdx).getImm());
   bool OpSel = Mods & SISrcMods::OP_SEL_0;
   bool OpSelHi = Mods & SISrcMods::OP_SEL_1;
 
@@ -6500,7 +6512,8 @@ bool SIInstrInfo::isOperandLegal(const MachineInstr &MI, unsigned OpIdx,
   const MCOperandInfo &OpInfo = InstDesc.operands()[OpIdx];
   int64_t RegClass = getOpRegClassID(OpInfo);
   const TargetRegisterClass *DefinedRC =
-      RegClass != -1 ? RI.getRegClass(RegClass) : nullptr;
+      RegClass != -1 ? RI.getRegClass(static_cast<unsigned>(RegClass))
+                     : nullptr;
   if (!MO)
     MO = &MI.getOperand(OpIdx);
 
@@ -6899,7 +6912,7 @@ Register SIInstrInfo::readlaneVGPRToSGPR(
     SRC = RI.getCommonSubClass(SRC, DstRC);
 
   Register DstReg = MRI.createVirtualRegister(SRC);
-  unsigned SubRegs = RI.getRegSizeInBits(*VRC) / 32;
+  unsigned SubRegs = static_cast<unsigned>(RI.getRegSizeInBits(*VRC) / 32);
 
   if (RI.hasAGPRs(VRC)) {
     VRC = RI.getEquivalentVGPRClass(VRC);
@@ -7160,7 +7173,8 @@ static void emitLoadScalarOpsFromVGPRLoop(
   // After the first v_cmpx is emitted, I is updated to point to it
   // so subsequent non-terminators are inserted before all v_cmpx instructions.
   for (auto [Idx, ScalarOp] : enumerate(ScalarOps)) {
-    unsigned RegSize = TRI->getRegSizeInBits(ScalarOp->getReg(), MRI);
+    unsigned RegSize =
+        static_cast<unsigned>(TRI->getRegSizeInBits(ScalarOp->getReg(), MRI));
     unsigned NumSubRegs = RegSize / 32;
     Register VScalarOp = ScalarOp->getReg();
 
@@ -8667,7 +8681,7 @@ void SIInstrInfo::moveToVALUImpl(
       // operand back into the 2 separate ones for bit offset and width.
       assert(OffsetWidthOp.isImm() &&
              "Scalar BFE is only implemented for constant width and offset");
-      uint32_t Imm = OffsetWidthOp.getImm();
+      uint32_t Imm = static_cast<uint32_t>(OffsetWidthOp.getImm());
 
       uint32_t Offset = Imm & 0x3f;               // Extract bits [5:0].
       uint32_t BitWidth = (Imm & 0x7f0000) >> 16; // Extract bits [22:16].
@@ -9432,7 +9446,7 @@ void SIInstrInfo::splitScalar64BitBFE(SIInstrWorklist &Worklist,
   const DebugLoc &DL = Inst.getDebugLoc();
 
   MachineOperand &Dest = Inst.getOperand(0);
-  uint32_t Imm = Inst.getOperand(2).getImm();
+  uint32_t Imm = static_cast<uint32_t>(Inst.getOperand(2).getImm());
   uint32_t Offset = Imm & 0x3f; // Extract bits [5:0].
   uint32_t BitWidth = (Imm & 0x7f0000) >> 16; // Extract bits [22:16].
 
@@ -10390,7 +10404,8 @@ bool SIInstrInfo::isBufferSMRD(const MachineInstr &MI) const {
 bool SIInstrInfo::splitMUBUFOffset(uint32_t Imm, uint32_t &SOffset,
                                    uint32_t &ImmOffset, Align Alignment) const {
   const uint64_t MaxOffset = SIInstrInfo::getMaxMUBUFImmOffset(ST);
-  const uint32_t MaxImm = alignDown(MaxOffset, Alignment.value());
+  const uint32_t MaxImm =
+      static_cast<uint32_t>(alignDown(MaxOffset, Alignment.value()));
   uint32_t Overflow = 0;
 
   if (Imm > MaxImm) {
@@ -10408,10 +10423,12 @@ bool SIInstrInfo::splitMUBUFOffset(uint32_t Imm, uint32_t &SOffset,
       //
       // Atomic operations fail to work correctly when individual address
       // components are unaligned, even if their sum is aligned.
-      uint32_t High = (Imm + Alignment.value()) & ~MaxOffset;
-      uint32_t Low = (Imm + Alignment.value()) & MaxOffset;
+      uint32_t High =
+          static_cast<uint32_t>((Imm + Alignment.value()) & ~MaxOffset);
+      uint32_t Low =
+          static_cast<uint32_t>((Imm + Alignment.value()) & MaxOffset);
       Imm = Low;
-      Overflow = High - Alignment.value();
+      Overflow = static_cast<uint32_t>(High - Alignment.value());
     }
   }
 

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.h
@@ -805,7 +805,7 @@ public:
   static bool isDualSourceBlendEXP(const MachineInstr &MI) {
     if (!isEXP(MI))
       return false;
-    unsigned Target = MI.getOperand(0).getImm();
+    unsigned Target = static_cast<unsigned>(MI.getOperand(0).getImm());
     return Target == AMDGPU::Exp::ET_DUAL_SRC_BLEND0 ||
            Target == AMDGPU::Exp::ET_DUAL_SRC_BLEND1;
   }
@@ -940,7 +940,7 @@ public:
   }
 
   bool isVOP3PMix(const MachineInstr &MI) const {
-    return isVOP3PMix(MI.getOpcode());
+    return isVOP3PMix(static_cast<uint16_t>(MI.getOpcode()));
   }
 
   bool isVOP3PMix(uint16_t Opcode) const {
@@ -1333,8 +1333,9 @@ public:
       unsigned Size = getOpSize(MI, OpIdx);
       assert(Size == 8 || Size == 4);
 
-      uint8_t OpType = (Size == 8) ?
-        AMDGPU::OPERAND_REG_IMM_INT64 : AMDGPU::OPERAND_REG_IMM_INT32;
+      uint8_t OpType =
+          static_cast<uint8_t>((Size == 8) ? AMDGPU::OPERAND_REG_IMM_INT64
+                                           : AMDGPU::OPERAND_REG_IMM_INT32);
       return isInlineConstant(ImmVal, OpType);
     }
 
@@ -1437,7 +1438,8 @@ public:
       return 4;
     }
 
-    return RI.getRegSizeInBits(*RI.getRegClass(getOpRegClassID(OpInfo))) / 8;
+    return static_cast<unsigned>(
+        RI.getRegSizeInBits(*RI.getRegClass(getOpRegClassID(OpInfo))) / 8);
   }
 
   /// This form should usually be preferred since it handles operands
@@ -1449,7 +1451,8 @@ public:
         return RI.getSubRegIdxSize(SubReg) / 8;
       }
     }
-    return RI.getRegSizeInBits(*getOpRegClass(MI, OpNo)) / 8;
+    return static_cast<unsigned>(RI.getRegSizeInBits(*getOpRegClass(MI, OpNo)) /
+                                 8);
   }
 
   /// Legalize the \p OpIndex operand of this instruction by inserting

--- a/llvm/lib/Target/AMDGPU/SILoadStoreOptimizer.cpp
+++ b/llvm/lib/Target/AMDGPU/SILoadStoreOptimizer.cpp
@@ -742,7 +742,7 @@ static AddressRegs getRegs(unsigned Opc, const SIInstrInfo &TII) {
       AMDGPU::OpName RsrcName =
           TII.isMIMG(Opc) ? AMDGPU::OpName::srsrc : AMDGPU::OpName::rsrc;
       int RsrcIdx = AMDGPU::getNamedOperandIdx(Opc, RsrcName);
-      Result.NumVAddrs = RsrcIdx - VAddr0Idx;
+      Result.NumVAddrs = static_cast<unsigned char>(RsrcIdx - VAddr0Idx);
     } else {
       Result.VAddr = true;
     }
@@ -872,7 +872,8 @@ void SILoadStoreOptimizer::CombineInfo::setMI(MachineBasicBlock::iterator MI,
   case S_BUFFER_LOAD_IMM:
   case S_BUFFER_LOAD_SGPR_IMM:
   case S_LOAD_IMM:
-    EltSize = AMDGPU::convertSMRDOffsetUnits(*LSO.STM, 4);
+    EltSize =
+        static_cast<unsigned>(AMDGPU::convertSMRDOffsetUnits(*LSO.STM, 4));
     break;
   default:
     EltSize = 4;
@@ -880,18 +881,20 @@ void SILoadStoreOptimizer::CombineInfo::setMI(MachineBasicBlock::iterator MI,
   }
 
   if (InstClass == MIMG) {
-    DMask = LSO.TII->getNamedOperand(*I, AMDGPU::OpName::dmask)->getImm();
+    DMask = static_cast<unsigned>(
+        LSO.TII->getNamedOperand(*I, AMDGPU::OpName::dmask)->getImm());
     // Offset is not considered for MIMG instructions.
     Offset = 0;
   } else {
     int OffsetIdx = AMDGPU::getNamedOperandIdx(Opc, AMDGPU::OpName::offset);
-    Offset = I->getOperand(OffsetIdx).getImm();
+    Offset = static_cast<unsigned>(I->getOperand(OffsetIdx).getImm());
   }
 
   if (InstClass == TBUFFER_LOAD || InstClass == TBUFFER_STORE) {
-    Format = LSO.TII->getNamedOperand(*I, AMDGPU::OpName::format)->getImm();
+    Format = static_cast<unsigned>(
+        LSO.TII->getNamedOperand(*I, AMDGPU::OpName::format)->getImm());
     const AMDGPU::GcnBufferFormatInfo *Info =
-        AMDGPU::getGcnBufferFormatInfo(Format, *LSO.STM);
+        AMDGPU::getGcnBufferFormatInfo(static_cast<uint8_t>(Format), *LSO.STM);
     EltSize = Info->BitsPerComp / 8;
   }
 
@@ -900,7 +903,8 @@ void SILoadStoreOptimizer::CombineInfo::setMI(MachineBasicBlock::iterator MI,
   if ((InstClass == DS_READ) || (InstClass == DS_WRITE)) {
     Offset &= 0xffff;
   } else if (InstClass != MIMG) {
-    CPol = LSO.TII->getNamedOperand(*I, AMDGPU::OpName::cpol)->getImm();
+    CPol = static_cast<unsigned>(
+        LSO.TII->getNamedOperand(*I, AMDGPU::OpName::cpol)->getImm());
   }
 
   AddressRegs Regs = getRegs(Opc, *LSO.TII);
@@ -991,7 +995,8 @@ SILoadStoreOptimizer::combineKnownAdjacentMMOs(const CombineInfo &CI,
   const MachineMemOperand *MMOa = *CI.I->memoperands_begin();
   const MachineMemOperand *MMOb = *Paired.I->memoperands_begin();
 
-  unsigned Size = MMOa->getSize().getValue() + MMOb->getSize().getValue();
+  unsigned Size = static_cast<unsigned>(MMOa->getSize().getValue() +
+                                        MMOb->getSize().getValue());
 
   // A base pointer for the combined operation is the same as the leading
   // operation's pointer.
@@ -1054,14 +1059,16 @@ static unsigned getBufferFormatWithCompCount(unsigned OldFormat,
     return 0;
 
   const llvm::AMDGPU::GcnBufferFormatInfo *OldFormatInfo =
-      llvm::AMDGPU::getGcnBufferFormatInfo(OldFormat, STI);
+      llvm::AMDGPU::getGcnBufferFormatInfo(static_cast<uint8_t>(OldFormat),
+                                           STI);
   if (!OldFormatInfo)
     return 0;
 
   const llvm::AMDGPU::GcnBufferFormatInfo *NewFormatInfo =
-      llvm::AMDGPU::getGcnBufferFormatInfo(OldFormatInfo->BitsPerComp,
-                                           ComponentCount,
-                                           OldFormatInfo->NumFormat, STI);
+      llvm::AMDGPU::getGcnBufferFormatInfo(
+          static_cast<uint8_t>(OldFormatInfo->BitsPerComp),
+          static_cast<uint8_t>(ComponentCount),
+          static_cast<uint8_t>(OldFormatInfo->NumFormat), STI);
 
   if (!NewFormatInfo)
     return 0;
@@ -1100,9 +1107,11 @@ bool SILoadStoreOptimizer::offsetsCanBeCombined(CombineInfo &CI,
   if (CI.InstClass == TBUFFER_LOAD || CI.InstClass == TBUFFER_STORE) {
 
     const llvm::AMDGPU::GcnBufferFormatInfo *Info0 =
-        llvm::AMDGPU::getGcnBufferFormatInfo(CI.Format, STI);
+        llvm::AMDGPU::getGcnBufferFormatInfo(static_cast<uint8_t>(CI.Format),
+                                             STI);
     const llvm::AMDGPU::GcnBufferFormatInfo *Info1 =
-        llvm::AMDGPU::getGcnBufferFormatInfo(Paired.Format, STI);
+        llvm::AMDGPU::getGcnBufferFormatInfo(
+            static_cast<uint8_t>(Paired.Format), STI);
 
     if (Info0->BitsPerComp != Info1->BitsPerComp ||
         Info0->NumFormat != Info1->NumFormat)
@@ -2521,7 +2530,7 @@ bool SILoadStoreOptimizer::promoteConstantOffsetToImm(
       AM.BaseOffs = Dist;
       if (TLI->isLegalFlatAddressingMode(AM, AS) &&
           (uint32_t)std::abs(Dist) > MaxDist) {
-        MaxDist = std::abs(Dist);
+        MaxDist = static_cast<uint32_t>(std::abs(Dist));
 
         AnchorAddr = MAddrNext;
         AnchorInst = &MINext;
@@ -2558,7 +2567,7 @@ bool SILoadStoreOptimizer::promoteConstantOffsetToImm(
     // Instead of moving up, just re-compute anchor-instruction's base address.
     Register Base = computeBase(MI, AnchorAddr);
 
-    int32_t OffsetDiff = MAddr.Offset - AnchorAddr.Offset;
+    int32_t OffsetDiff = static_cast<int32_t>(MAddr.Offset - AnchorAddr.Offset);
     updateBaseAndOffset(MI, Base, OffsetDiff);
     updateAsyncLDSAddress(MI, OffsetDiff);
     LLVM_DEBUG(dbgs() << "  After promotion: "; MI.dump(););
@@ -2573,7 +2582,8 @@ bool SILoadStoreOptimizer::promoteConstantOffsetToImm(
           (!IsOffsetU16 || isUInt<16>(AM.BaseOffs))) {
         LLVM_DEBUG(dbgs() << "  Promote Offset(" << OtherOffset; dbgs() << ")";
                    OtherMI->dump());
-        int32_t OtherOffsetDiff = OtherOffset - AnchorAddr.Offset;
+        int32_t OtherOffsetDiff =
+            static_cast<int32_t>(OtherOffset - AnchorAddr.Offset);
         updateBaseAndOffset(*OtherMI, Base, OtherOffsetDiff);
         updateAsyncLDSAddress(*OtherMI, OtherOffsetDiff);
         LLVM_DEBUG(dbgs() << "     After promotion: "; OtherMI->dump());
@@ -2599,8 +2609,8 @@ bool SILoadStoreOptimizer::promoteConstantOffsetToImm(
           (!IsOffsetU16 || isUInt<16>(Dist))) {
         LLVM_DEBUG(dbgs() << "  Promote Offset(" << OtherOffset << ")";
                    OtherMI->dump());
-        updateBaseAndOffset(*OtherMI, Base, Dist);
-        updateAsyncLDSAddress(*OtherMI, Dist);
+        updateBaseAndOffset(*OtherMI, Base, static_cast<int32_t>(Dist));
+        updateAsyncLDSAddress(*OtherMI, static_cast<int32_t>(Dist));
         LLVM_DEBUG(dbgs() << "     After promotion: "; OtherMI->dump());
         AnyPromoted = true;
       }
@@ -2671,7 +2681,8 @@ SILoadStoreOptimizer::collectMergeableInsts(
     if (InstClass == TBUFFER_LOAD || InstClass == TBUFFER_STORE) {
       const MachineOperand *Fmt =
           TII->getNamedOperand(MI, AMDGPU::OpName::format);
-      if (!AMDGPU::getGcnBufferFormatInfo(Fmt->getImm(), *STM)) {
+      if (!AMDGPU::getGcnBufferFormatInfo(static_cast<uint8_t>(Fmt->getImm()),
+                                          *STM)) {
         LLVM_DEBUG(dbgs() << "Skip tbuffer with unknown format: " << MI);
         continue;
       }

--- a/llvm/lib/Target/AMDGPU/SIPreEmitPeephole.cpp
+++ b/llvm/lib/Target/AMDGPU/SIPreEmitPeephole.cpp
@@ -527,8 +527,8 @@ bool SIPreEmitPeephole::canUnpackingClobberRegister(const MachineInstr &MI) {
   const MachineOperand *Src0MO = TII->getNamedOperand(MI, AMDGPU::OpName::src0);
   if (Src0MO && Src0MO->isReg()) {
     Register SrcReg0 = Src0MO->getReg();
-    unsigned Src0Mods =
-        TII->getNamedOperand(MI, AMDGPU::OpName::src0_modifiers)->getImm();
+    unsigned Src0Mods = static_cast<unsigned>(
+        TII->getNamedOperand(MI, AMDGPU::OpName::src0_modifiers)->getImm());
     Register HiSrc0Reg = (Src0Mods & SISrcMods::OP_SEL_1)
                              ? TRI->getSubReg(SrcReg0, AMDGPU::sub1)
                              : TRI->getSubReg(SrcReg0, AMDGPU::sub0);
@@ -541,8 +541,8 @@ bool SIPreEmitPeephole::canUnpackingClobberRegister(const MachineInstr &MI) {
   const MachineOperand *Src1MO = TII->getNamedOperand(MI, AMDGPU::OpName::src1);
   if (Src1MO && Src1MO->isReg()) {
     Register SrcReg1 = Src1MO->getReg();
-    unsigned Src1Mods =
-        TII->getNamedOperand(MI, AMDGPU::OpName::src1_modifiers)->getImm();
+    unsigned Src1Mods = static_cast<unsigned>(
+        TII->getNamedOperand(MI, AMDGPU::OpName::src1_modifiers)->getImm());
     Register HiSrc1Reg = (Src1Mods & SISrcMods::OP_SEL_1)
                              ? TRI->getSubReg(SrcReg1, AMDGPU::sub1)
                              : TRI->getSubReg(SrcReg1, AMDGPU::sub0);
@@ -557,8 +557,8 @@ bool SIPreEmitPeephole::canUnpackingClobberRegister(const MachineInstr &MI) {
         TII->getNamedOperand(MI, AMDGPU::OpName::src2);
     if (Src2MO && Src2MO->isReg()) {
       Register SrcReg2 = Src2MO->getReg();
-      unsigned Src2Mods =
-          TII->getNamedOperand(MI, AMDGPU::OpName::src2_modifiers)->getImm();
+      unsigned Src2Mods = static_cast<unsigned>(
+          TII->getNamedOperand(MI, AMDGPU::OpName::src2_modifiers)->getImm());
       Register HiSrc2Reg = (Src2Mods & SISrcMods::OP_SEL_1)
                                ? TRI->getSubReg(SrcReg2, AMDGPU::sub1)
                                : TRI->getSubReg(SrcReg2, AMDGPU::sub0);
@@ -742,10 +742,10 @@ MachineInstrBuilder SIPreEmitPeephole::createUnpackedMI(MachineInstr &I,
                                      : TRI->getSubReg(DstReg, AMDGPU::sub0);
 
   int64_t ClampVal = TII->getNamedOperand(I, AMDGPU::OpName::clamp)->getImm();
-  unsigned Src0Mods =
-      TII->getNamedOperand(I, AMDGPU::OpName::src0_modifiers)->getImm();
-  unsigned Src1Mods =
-      TII->getNamedOperand(I, AMDGPU::OpName::src1_modifiers)->getImm();
+  unsigned Src0Mods = static_cast<unsigned>(
+      TII->getNamedOperand(I, AMDGPU::OpName::src0_modifiers)->getImm());
+  unsigned Src1Mods = static_cast<unsigned>(
+      TII->getNamedOperand(I, AMDGPU::OpName::src1_modifiers)->getImm());
 
   MachineInstrBuilder NewMI = BuildMI(MBB, I, DL, TII->get(UnpackedOpcode));
   NewMI.addDef(UnpackedDstReg); // vdst
@@ -755,8 +755,8 @@ MachineInstrBuilder SIPreEmitPeephole::createUnpackedMI(MachineInstr &I,
   if (AMDGPU::hasNamedOperand(OpCode, AMDGPU::OpName::src2)) {
     const MachineOperand *SrcMO2 =
         TII->getNamedOperand(I, AMDGPU::OpName::src2);
-    unsigned Src2Mods =
-        TII->getNamedOperand(I, AMDGPU::OpName::src2_modifiers)->getImm();
+    unsigned Src2Mods = static_cast<unsigned>(
+        TII->getNamedOperand(I, AMDGPU::OpName::src2_modifiers)->getImm());
     addOperandAndMods(NewMI, Src2Mods, IsHiBits, *SrcMO2);
   }
   NewMI.addImm(ClampVal); // clamp

--- a/llvm/lib/Target/AMDGPU/SIShrinkInstructions.cpp
+++ b/llvm/lib/Target/AMDGPU/SIShrinkInstructions.cpp
@@ -233,9 +233,9 @@ static unsigned canModifyToInlineImmOp32(const SIInstrInfo *TII,
 void SIShrinkInstructions::copyExtraImplicitOps(MachineInstr &NewMI,
                                                 MachineInstr &MI) const {
   MachineFunction &MF = *MI.getMF();
-  for (unsigned i = MI.getDesc().getNumOperands() +
-                    MI.getDesc().implicit_uses().size() +
-                    MI.getDesc().implicit_defs().size(),
+  for (unsigned i = static_cast<unsigned>(MI.getDesc().getNumOperands() +
+                                          MI.getDesc().implicit_uses().size() +
+                                          MI.getDesc().implicit_defs().size()),
                 e = MI.getNumOperands();
        i != e; ++i) {
     const MachineOperand &MO = MI.getOperand(i);
@@ -277,7 +277,7 @@ bool SIShrinkInstructions::shrinkScalarCompare(MachineInstr &MI) const {
       if (!HasUImm) {
         SOPKOpc = (SOPKOpc == AMDGPU::S_CMPK_EQ_U32) ?
           AMDGPU::S_CMPK_EQ_I32 : AMDGPU::S_CMPK_LG_I32;
-        Src1.setImm(SignExtend32(Src1.getImm(), 32));
+        Src1.setImm(SignExtend32(static_cast<uint32_t>(Src1.getImm()), 32));
       }
 
       MI.setDesc(TII->get(SOPKOpc));
@@ -359,7 +359,8 @@ bool SIShrinkInstructions::shrinkMIMG(MachineInstr &MI) const {
   for (unsigned Idx = 0; Idx < EndVAddr; ++Idx) {
     const MachineOperand &Op = MI.getOperand(VAddr0Idx + Idx);
     unsigned Vgpr = TRI->getHWRegIndex(Op.getReg());
-    unsigned Dwords = TRI->getRegSizeInBits(Op.getReg(), *MRI) / 32;
+    unsigned Dwords =
+        static_cast<unsigned>(TRI->getRegSizeInBits(Op.getReg(), *MRI) / 32);
     assert(Dwords > 0 && "Un-implemented for less than 32 bit regs");
 
     if (Idx == 0) {
@@ -384,8 +385,10 @@ bool SIShrinkInstructions::shrinkMIMG(MachineInstr &MI) const {
   // enabled
   int TFEIdx = AMDGPU::getNamedOperandIdx(MI.getOpcode(), AMDGPU::OpName::tfe);
   int LWEIdx = AMDGPU::getNamedOperandIdx(MI.getOpcode(), AMDGPU::OpName::lwe);
-  unsigned TFEVal = (TFEIdx == -1) ? 0 : MI.getOperand(TFEIdx).getImm();
-  unsigned LWEVal = (LWEIdx == -1) ? 0 : MI.getOperand(LWEIdx).getImm();
+  unsigned TFEVal = static_cast<unsigned>(
+      (TFEIdx == -1) ? 0 : MI.getOperand(TFEIdx).getImm());
+  unsigned LWEVal = static_cast<unsigned>(
+      (LWEIdx == -1) ? 0 : MI.getOperand(LWEIdx).getImm());
   int ToUntie = -1;
   if (TFEVal || LWEVal) {
     // TFE/LWE is enabled so we need to deal with an implicit tied operand
@@ -556,7 +559,8 @@ ChangeKind SIShrinkInstructions::shrinkScalarLogicOp(MachineInstr &MI) const {
   MachineOperand *SrcImm = Src1;
 
   if (!SrcImm->isImm() ||
-      AMDGPU::isInlinableLiteral32(SrcImm->getImm(), ST->hasInv2PiInlineImm()))
+      AMDGPU::isInlinableLiteral32(static_cast<int32_t>(SrcImm->getImm()),
+                                   ST->hasInv2PiInlineImm()))
     return ChangeKind::None;
 
   uint32_t Imm = static_cast<uint32_t>(SrcImm->getImm());
@@ -662,9 +666,9 @@ SIShrinkInstructions::getSubRegForIndex(Register Reg, unsigned Sub,
 
 void SIShrinkInstructions::dropInstructionKeepingImpDefs(
     MachineInstr &MI) const {
-  for (unsigned i = MI.getDesc().getNumOperands() +
-                    MI.getDesc().implicit_uses().size() +
-                    MI.getDesc().implicit_defs().size(),
+  for (unsigned i = static_cast<unsigned>(MI.getDesc().getNumOperands() +
+                                          MI.getDesc().implicit_uses().size() +
+                                          MI.getDesc().implicit_defs().size()),
                 e = MI.getNumOperands();
        i != e; ++i) {
     const MachineOperand &Op = MI.getOperand(i);

--- a/llvm/lib/Target/AMDGPU/SIWholeQuadMode.cpp
+++ b/llvm/lib/Target/AMDGPU/SIWholeQuadMode.cpp
@@ -109,9 +109,11 @@ public:
 static raw_ostream &operator<<(raw_ostream &OS, const PrintState &PS) {
 
   static const std::pair<char, const char *> Mapping[] = {
-      std::pair(StateWQM, "WQM"), std::pair(StateStrictWWM, "StrictWWM"),
-      std::pair(StateStrictWQM, "StrictWQM"), std::pair(StateExact, "Exact")};
-  char State = PS.State;
+      {static_cast<char>(StateWQM), "WQM"},
+      {static_cast<char>(StateStrictWWM), "StrictWWM"},
+      {static_cast<char>(StateStrictWQM), "StrictWQM"},
+      {static_cast<char>(StateExact), "Exact"}};
+  char State = static_cast<char>(PS.State);
   for (auto M : Mapping) {
     if (State & M.first) {
       OS << M.second;
@@ -1314,7 +1316,8 @@ void SIWholeQuadMode::processBlock(MachineBasicBlock &MBB, BlockInfo &BI,
   Register SavedWQMReg;
   Register SavedNonStrictReg;
   bool WQMFromExec = IsEntry;
-  char State = (IsEntry || !(BI.InNeeds & StateWQM)) ? StateExact : StateWQM;
+  char State = static_cast<char>(
+      (IsEntry || !(BI.InNeeds & StateWQM)) ? StateExact : StateWQM);
   char NonStrictState = 0;
   const TargetRegisterClass *BoolRC = TRI->getBoolRC();
 


### PR DESCRIPTION
For context, see https://github.com/llvm/llvm-project/issues/215213

This patch handles the following cases:

MachineOperand::getImm() returns int64_t and is passed to helpers and to
MachineInstr builders taking unsigned, uint32_t, int32_t, uint8_t or int16_t.
Add a static_cast to make the existing narrowing conversion explicit. These are
instruction immediates -- buffer and DS offsets, source modifiers, DPP controls,
row masks and hardware register fields -- all of which are encoded fields
narrower than 32 bits.

MachineInstr::getNumOperands() returns unsigned but the operand indices computed
around it come from wider expressions. Add a static_cast to make the existing
narrowing conversion explicit.

Container size() returns size_t and is assigned to unsigned locals holding
operand and clause counts. Add a static_cast to make the existing narrowing
conversion explicit.

MachineInstr::getOpcode() returns unsigned and is passed to the
SIInstrInfo::isVOP3PMix(uint16_t Opcode) overload from the MachineInstr overload
of the same name. Add a static_cast; the uint16_t parameter is pre-existing and
AMDGPU opcode numbers fit in it.

Register values are passed to SIRegisterInfo::get32BitRegister, which takes
MCPhysReg (uint16_t). Add a static_cast. Both sites are in
SIInstrInfo::copyPhysReg, whose DestReg and SrcReg parameters are MCRegister and
physical by that hook's contract, and get32BitRegister both takes and returns
MCPhysReg, so the narrowing is on its argument.

The state enumerators in SIWholeQuadMode's debug printer are assigned to the
char field of a pre-existing "std::pair<char, const char *>" mapping table. Add
a static_cast; the table type is pre-existing and the enumerators are single-bit
flags.

This fixes 100 instances of MSVC warning C4244 and 14 of C4267 ("possible loss
of data") across 11 files in llvm/lib/Target/AMDGPU.

Assisted-by: Claude <noreply@anthropic.com>
