### PR TITLE
[AMDGPU][NFC] Explicitly narrow conversions in SIISelLowering

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -1209,7 +1209,7 @@ MVT SITargetLowering::getRegisterTypeForCallingConv(LLVMContext &Context,
 
   if (VT.isVector()) {
     EVT ScalarVT = VT.getScalarType();
-    unsigned Size = ScalarVT.getSizeInBits();
+    unsigned Size = static_cast<unsigned>(ScalarVT.getSizeInBits());
     if (Size == 16) {
       return Subtarget->has16BitInsts()
                  ? MVT::getVectorVT(ScalarVT.getSimpleVT(), 2)
@@ -1239,7 +1239,7 @@ unsigned SITargetLowering::getNumRegistersForCallingConv(LLVMContext &Context,
   if (VT.isVector()) {
     unsigned NumElts = VT.getVectorNumElements();
     EVT ScalarVT = VT.getScalarType();
-    unsigned Size = ScalarVT.getSizeInBits();
+    unsigned Size = static_cast<unsigned>(ScalarVT.getSizeInBits());
 
     // FIXME: Should probably promote 8-bit vectors to i16.
     if (Size == 16)
@@ -1251,7 +1251,7 @@ unsigned SITargetLowering::getNumRegistersForCallingConv(LLVMContext &Context,
     if (Size > 32)
       return NumElts * ((Size + 31) / 32);
   } else if (VT.getSizeInBits() > 32)
-    return (VT.getSizeInBits() + 31) / 32;
+    return static_cast<unsigned>((VT.getSizeInBits() + 31) / 32);
 
   return TargetLowering::getNumRegistersForCallingConv(Context, CC, VT);
 }
@@ -1262,7 +1262,7 @@ unsigned SITargetLowering::getVectorTypeBreakdownForCallingConv(
   if (CC != CallingConv::AMDGPU_KERNEL && VT.isVector()) {
     unsigned NumElts = VT.getVectorNumElements();
     EVT ScalarVT = VT.getScalarType();
-    unsigned Size = ScalarVT.getSizeInBits();
+    unsigned Size = static_cast<unsigned>(ScalarVT.getSizeInBits());
     // FIXME: We should fix the ABI to be the same on targets without 16-bit
     // support, but unless we can properly handle 3-vectors, it will be still be
     // inconsistent.
@@ -1405,7 +1405,8 @@ static unsigned getIntrMemWidth(unsigned IntrID) {
 static AtomicOrdering parseAtomicOrderingCABIArg(const CallBase &CI,
                                                  unsigned ArgIdx) {
   Value *OrderingArg = CI.getArgOperand(ArgIdx);
-  unsigned Ord = cast<ConstantInt>(OrderingArg)->getZExtValue();
+  unsigned Ord =
+      static_cast<unsigned>(cast<ConstantInt>(OrderingArg)->getZExtValue());
   switch (AtomicOrderingCABI(Ord)) {
   case AtomicOrderingCABI::acquire:
     return AtomicOrdering::Acquire;
@@ -1486,8 +1487,8 @@ void SITargetLowering::getTgtMemIntrinsic(SmallVectorImpl<IntrinsicInfo> &Infos,
         if (!BaseOpcode->Gather4) {
           // If this isn't a gather, we may have excess loaded elements in the
           // IR type. Check the dmask for the real number of elements loaded.
-          unsigned DMask =
-              cast<ConstantInt>(CI.getArgOperand(0))->getZExtValue();
+          unsigned DMask = static_cast<unsigned>(
+              cast<ConstantInt>(CI.getArgOperand(0))->getZExtValue());
           MaxNumLanes = DMask == 0 ? 1 : llvm::popcount(DMask);
         }
 
@@ -1507,7 +1508,8 @@ void SITargetLowering::getTgtMemIntrinsic(SmallVectorImpl<IntrinsicInfo> &Infos,
 
       Type *DataTy = CI.getArgOperand(0)->getType();
       if (RsrcIntr->IsImage) {
-        unsigned DMask = cast<ConstantInt>(CI.getArgOperand(1))->getZExtValue();
+        unsigned DMask = static_cast<unsigned>(
+            cast<ConstantInt>(CI.getArgOperand(1))->getZExtValue());
         unsigned DMaskLanes = DMask == 0 ? 1 : llvm::popcount(DMask);
         Info.memVT = memVTFromLoadIntrData(*this, MF.getDataLayout(), DataTy,
                                            DMaskLanes);
@@ -1543,7 +1545,8 @@ void SITargetLowering::getTgtMemIntrinsic(SmallVectorImpl<IntrinsicInfo> &Infos,
       case Intrinsic::amdgcn_struct_buffer_load_async_lds:
       case Intrinsic::amdgcn_struct_ptr_buffer_load_lds:
       case Intrinsic::amdgcn_struct_ptr_buffer_load_async_lds: {
-        unsigned Width = cast<ConstantInt>(CI.getArgOperand(2))->getZExtValue();
+        unsigned Width = static_cast<unsigned>(
+            cast<ConstantInt>(CI.getArgOperand(2))->getZExtValue());
 
         // Entry 0: Load from buffer.
         // Don't set an offset, since the pointer value always represents the
@@ -1558,8 +1561,9 @@ void SITargetLowering::getTgtMemIntrinsic(SmallVectorImpl<IntrinsicInfo> &Infos,
         Info.memVT = EVT::getIntegerVT(
             CI.getContext(), Width * 8 * Subtarget->getWavefrontSize());
         Info.ptrVal = CI.getArgOperand(1); // LDS destination pointer
-        Info.offset = cast<ConstantInt>(CI.getArgOperand(CI.arg_size() - 2))
-                          ->getZExtValue();
+        Info.offset = static_cast<int>(
+            cast<ConstantInt>(CI.getArgOperand(CI.arg_size() - 2))
+                ->getZExtValue());
         Info.fallbackAddressSpace = AMDGPUAS::LOCAL_ADDRESS;
         Info.flags = Flags | MachineMemOperand::MOStore;
         Infos.push_back(Info);
@@ -1706,7 +1710,7 @@ void SITargetLowering::getTgtMemIntrinsic(SmallVectorImpl<IntrinsicInfo> &Infos,
     Info.align.reset();
     Info.flags = MachineMemOperand::MOLoad;
     Info.order = parseAtomicOrderingCABIArg(CI, 1);
-    Info.ssid = parseSyncscopeMDArg(CI, 2);
+    Info.ssid = static_cast<SyncScope::ID>(parseSyncscopeMDArg(CI, 2));
     Infos.push_back(Info);
     return;
   }
@@ -1719,7 +1723,7 @@ void SITargetLowering::getTgtMemIntrinsic(SmallVectorImpl<IntrinsicInfo> &Infos,
     Info.align.reset();
     Info.flags = (MachineMemOperand::MOLoad | MOCooperative);
     Info.order = parseAtomicOrderingCABIArg(CI, 1);
-    Info.ssid = parseSyncscopeMDArg(CI, 2);
+    Info.ssid = static_cast<SyncScope::ID>(parseSyncscopeMDArg(CI, 2));
     Infos.push_back(Info);
     return;
   }
@@ -1732,7 +1736,7 @@ void SITargetLowering::getTgtMemIntrinsic(SmallVectorImpl<IntrinsicInfo> &Infos,
     Info.align.reset();
     Info.flags = (MachineMemOperand::MOStore | MOCooperative);
     Info.order = parseAtomicOrderingCABIArg(CI, 2);
-    Info.ssid = parseSyncscopeMDArg(CI, 3);
+    Info.ssid = static_cast<SyncScope::ID>(parseSyncscopeMDArg(CI, 3));
     Infos.push_back(Info);
     return;
   }
@@ -1774,7 +1778,8 @@ void SITargetLowering::getTgtMemIntrinsic(SmallVectorImpl<IntrinsicInfo> &Infos,
     Info.opc = ISD::INTRINSIC_VOID;
     Info.memVT = EVT::getIntegerVT(CI.getContext(), getIntrMemWidth(IntrID));
     Info.ptrVal = CI.getArgOperand(0); // Global pointer
-    Info.offset = cast<ConstantInt>(CI.getArgOperand(2))->getSExtValue();
+    Info.offset = static_cast<int>(
+        cast<ConstantInt>(CI.getArgOperand(2))->getSExtValue());
     Info.flags = Flags | MachineMemOperand::MOLoad;
     Infos.push_back(Info);
 
@@ -1792,7 +1797,8 @@ void SITargetLowering::getTgtMemIntrinsic(SmallVectorImpl<IntrinsicInfo> &Infos,
     Info.opc = ISD::INTRINSIC_VOID;
     Info.memVT = EVT::getIntegerVT(CI.getContext(), getIntrMemWidth(IntrID));
     Info.ptrVal = CI.getArgOperand(1); // LDS pointer
-    Info.offset = cast<ConstantInt>(CI.getArgOperand(2))->getSExtValue();
+    Info.offset = static_cast<int>(
+        cast<ConstantInt>(CI.getArgOperand(2))->getSExtValue());
     Info.flags = Flags | MachineMemOperand::MOLoad;
     Infos.push_back(Info);
 
@@ -1828,7 +1834,8 @@ void SITargetLowering::getTgtMemIntrinsic(SmallVectorImpl<IntrinsicInfo> &Infos,
   case Intrinsic::amdgcn_load_async_to_lds:
   case Intrinsic::amdgcn_global_load_lds:
   case Intrinsic::amdgcn_global_load_async_lds: {
-    unsigned Width = cast<ConstantInt>(CI.getArgOperand(2))->getZExtValue();
+    unsigned Width = static_cast<unsigned>(
+        cast<ConstantInt>(CI.getArgOperand(2))->getZExtValue());
     auto *Aux = cast<ConstantInt>(CI.getArgOperand(CI.arg_size() - 1));
     bool IsVolatile = Aux->getZExtValue() & AMDGPU::CPol::VOLATILE;
     if (IsVolatile)
@@ -1838,7 +1845,8 @@ void SITargetLowering::getTgtMemIntrinsic(SmallVectorImpl<IntrinsicInfo> &Infos,
     Info.opc = ISD::INTRINSIC_VOID;
     Info.memVT = EVT::getIntegerVT(CI.getContext(), Width * 8);
     Info.ptrVal = CI.getArgOperand(0); // Source pointer
-    Info.offset = cast<ConstantInt>(CI.getArgOperand(3))->getSExtValue();
+    Info.offset = static_cast<int>(
+        cast<ConstantInt>(CI.getArgOperand(3))->getSExtValue());
     Info.flags = Flags | MachineMemOperand::MOLoad;
     Infos.push_back(Info);
 
@@ -2017,7 +2025,7 @@ bool SITargetLowering::isLegalMUBUFAddressingMode(const AddrMode &AM) const {
   // implemented as mubuf instructions with offen bit set, so slightly
   // different than the normal addr64.
   const SIInstrInfo *TII = Subtarget->getInstrInfo();
-  if (!TII->isLegalMUBUFImmOffset(AM.BaseOffs))
+  if (!TII->isLegalMUBUFImmOffset(static_cast<unsigned>(AM.BaseOffs)))
     return false;
 
   // FIXME: Since we can split immediate into soffset and immediate offset,
@@ -2350,8 +2358,9 @@ bool SITargetLowering::allowsMisalignedMemoryAccessesImpl(
 bool SITargetLowering::allowsMisalignedMemoryAccesses(
     EVT VT, unsigned AddrSpace, Align Alignment, MachineMemOperand::Flags Flags,
     unsigned *IsFast) const {
-  return allowsMisalignedMemoryAccessesImpl(VT.getSizeInBits(), AddrSpace,
-                                            Alignment, Flags, IsFast);
+  return allowsMisalignedMemoryAccessesImpl(
+      static_cast<unsigned>(VT.getSizeInBits()), AddrSpace, Alignment, Flags,
+      IsFast);
 }
 
 EVT SITargetLowering::getOptimalMemOpType(
@@ -2530,7 +2539,8 @@ SDValue SITargetLowering::convertArgType(SelectionDAG &DAG, EVT VT, EVT MemVT,
       Val = getFPExtOrFPRound(DAG, Val, SL, VT);
     } else {
       assert(!MemVT.isVector());
-      EVT IntVT = EVT::getIntegerVT(*DAG.getContext(), MemVT.getSizeInBits());
+      EVT IntVT = EVT::getIntegerVT(
+          *DAG.getContext(), static_cast<unsigned>(MemVT.getSizeInBits()));
       SDValue Cast = DAG.getBitcast(IntVT, Val);
       Val = DAG.getAnyExtOrTrunc(Cast, SL, VT);
     }
@@ -2631,8 +2641,8 @@ SDValue SITargetLowering::lowerStackParameter(SelectionDAG &DAG,
     return DAG.getFrameIndex(FrameIdx, MVT::i32);
   }
 
-  unsigned ArgOffset = VA.getLocMemOffset();
-  unsigned ArgSize = VA.getValVT().getStoreSize();
+  unsigned ArgOffset = static_cast<unsigned>(VA.getLocMemOffset());
+  unsigned ArgSize = static_cast<unsigned>(VA.getValVT().getStoreSize());
 
   int FI = MFI.CreateFixedObject(ArgSize, ArgOffset, true);
 
@@ -2851,7 +2861,8 @@ static void processPSInputArgs(SmallVectorImpl<ISD::InputArg> &Splits,
                                ArrayRef<ISD::InputArg> Ins, BitVector &Skipped,
                                FunctionType *FType,
                                SIMachineFunctionInfo *Info) {
-  for (unsigned I = 0, E = Ins.size(), PSInputNum = 0; I != E; ++I) {
+  for (unsigned I = 0, E = static_cast<unsigned>(Ins.size()), PSInputNum = 0;
+       I != E; ++I) {
     const ISD::InputArg *Arg = &Ins[I];
 
     assert((!Arg->VT.isVector() || Arg->VT.getScalarSizeInBits() == 16) &&
@@ -2904,7 +2915,7 @@ void SITargetLowering::allocateSpecialEntryInputVGPRs(
     Register Reg = AMDGPU::VGPR0;
     MRI.setType(MF.addLiveIn(Reg, &AMDGPU::VGPR_32RegClass), S32);
 
-    CCInfo.AllocateReg(Reg);
+    CCInfo.AllocateReg(static_cast<MCPhysReg>(Reg));
     unsigned Mask =
         (Subtarget->hasPackedTID() && Info.hasWorkItemIDY()) ? 0x3ff : ~0u;
     Info.setWorkItemIDX(ArgDescriptor::createRegister(Reg, Mask));
@@ -2919,7 +2930,7 @@ void SITargetLowering::allocateSpecialEntryInputVGPRs(
       unsigned Reg = AMDGPU::VGPR1;
       MRI.setType(MF.addLiveIn(Reg, &AMDGPU::VGPR_32RegClass), S32);
 
-      CCInfo.AllocateReg(Reg);
+      CCInfo.AllocateReg(static_cast<MCPhysReg>(Reg));
       Info.setWorkItemIDY(ArgDescriptor::createRegister(Reg));
     }
   }
@@ -2933,7 +2944,7 @@ void SITargetLowering::allocateSpecialEntryInputVGPRs(
       unsigned Reg = AMDGPU::VGPR2;
       MRI.setType(MF.addLiveIn(Reg, &AMDGPU::VGPR_32RegClass), S32);
 
-      CCInfo.AllocateReg(Reg);
+      CCInfo.AllocateReg(static_cast<MCPhysReg>(Reg));
       Info.setWorkItemIDZ(ArgDescriptor::createRegister(Reg));
     }
   }
@@ -2954,11 +2965,11 @@ static ArgDescriptor allocateVGPR32Input(CCState &CCInfo, unsigned Mask = ~0u,
     // Spill to stack required.
     int64_t Offset = CCInfo.AllocateStack(4, Align(4));
 
-    return ArgDescriptor::createStack(Offset, Mask);
+    return ArgDescriptor::createStack(static_cast<unsigned>(Offset), Mask);
   }
 
   unsigned Reg = ArgVGPRs[RegIdx];
-  Reg = CCInfo.AllocateReg(Reg);
+  Reg = CCInfo.AllocateReg(static_cast<MCPhysReg>(Reg));
   assert(Reg != AMDGPU::NoRegister);
 
   MachineFunction &MF = CCInfo.getMachineFunction();
@@ -2976,7 +2987,7 @@ static ArgDescriptor allocateSGPR32InputImpl(CCState &CCInfo,
     report_fatal_error("ran out of SGPRs for arguments");
 
   unsigned Reg = ArgSGPRs[RegIdx];
-  Reg = CCInfo.AllocateReg(Reg);
+  Reg = CCInfo.AllocateReg(static_cast<MCPhysReg>(Reg));
   assert(Reg != AMDGPU::NoRegister);
 
   MachineFunction &MF = CCInfo.getMachineFunction();
@@ -2990,7 +3001,7 @@ static ArgDescriptor allocateSGPR32InputImpl(CCState &CCInfo,
 static void allocateFixedSGPRInputImpl(CCState &CCInfo,
                                        const TargetRegisterClass *RC,
                                        MCRegister Reg) {
-  Reg = CCInfo.AllocateReg(Reg);
+  Reg = CCInfo.AllocateReg(static_cast<MCPhysReg>(Reg));
   assert(Reg != AMDGPU::NoRegister);
   MachineFunction &MF = CCInfo.getMachineFunction();
   MF.addLiveIn(Reg, RC);
@@ -3093,32 +3104,32 @@ void SITargetLowering::allocateHSAUserSGPRs(CCState &CCInfo,
   if (UserSGPRInfo.hasImplicitBufferPtr()) {
     Register ImplicitBufferPtrReg = Info.addImplicitBufferPtr(TRI);
     MF.addLiveIn(ImplicitBufferPtrReg, &AMDGPU::SGPR_64RegClass);
-    CCInfo.AllocateReg(ImplicitBufferPtrReg);
+    CCInfo.AllocateReg(static_cast<MCPhysReg>(ImplicitBufferPtrReg));
   }
 
   // FIXME: How should these inputs interact with inreg / custom SGPR inputs?
   if (UserSGPRInfo.hasPrivateSegmentBuffer()) {
     Register PrivateSegmentBufferReg = Info.addPrivateSegmentBuffer(TRI);
     MF.addLiveIn(PrivateSegmentBufferReg, &AMDGPU::SGPR_128RegClass);
-    CCInfo.AllocateReg(PrivateSegmentBufferReg);
+    CCInfo.AllocateReg(static_cast<MCPhysReg>(PrivateSegmentBufferReg));
   }
 
   if (UserSGPRInfo.hasDispatchPtr()) {
     Register DispatchPtrReg = Info.addDispatchPtr(TRI);
     MF.addLiveIn(DispatchPtrReg, &AMDGPU::SGPR_64RegClass);
-    CCInfo.AllocateReg(DispatchPtrReg);
+    CCInfo.AllocateReg(static_cast<MCPhysReg>(DispatchPtrReg));
   }
 
   if (UserSGPRInfo.hasQueuePtr()) {
     Register QueuePtrReg = Info.addQueuePtr(TRI);
     MF.addLiveIn(QueuePtrReg, &AMDGPU::SGPR_64RegClass);
-    CCInfo.AllocateReg(QueuePtrReg);
+    CCInfo.AllocateReg(static_cast<MCPhysReg>(QueuePtrReg));
   }
 
   if (UserSGPRInfo.hasKernargSegmentPtr()) {
     MachineRegisterInfo &MRI = MF.getRegInfo();
     Register InputPtrReg = Info.addKernargSegmentPtr(TRI);
-    CCInfo.AllocateReg(InputPtrReg);
+    CCInfo.AllocateReg(static_cast<MCPhysReg>(InputPtrReg));
 
     Register VReg = MF.addLiveIn(InputPtrReg, &AMDGPU::SGPR_64RegClass);
     MRI.setType(VReg, LLT::pointer(AMDGPUAS::CONSTANT_ADDRESS, 64));
@@ -3127,19 +3138,19 @@ void SITargetLowering::allocateHSAUserSGPRs(CCState &CCInfo,
   if (UserSGPRInfo.hasDispatchID()) {
     Register DispatchIDReg = Info.addDispatchID(TRI);
     MF.addLiveIn(DispatchIDReg, &AMDGPU::SGPR_64RegClass);
-    CCInfo.AllocateReg(DispatchIDReg);
+    CCInfo.AllocateReg(static_cast<MCPhysReg>(DispatchIDReg));
   }
 
   if (UserSGPRInfo.hasFlatScratchInit() && !getSubtarget()->isAmdPalOS()) {
     Register FlatScratchInitReg = Info.addFlatScratchInit(TRI);
     MF.addLiveIn(FlatScratchInitReg, &AMDGPU::SGPR_64RegClass);
-    CCInfo.AllocateReg(FlatScratchInitReg);
+    CCInfo.AllocateReg(static_cast<MCPhysReg>(FlatScratchInitReg));
   }
 
   if (UserSGPRInfo.hasPrivateSegmentSize()) {
     Register PrivateSegmentSizeReg = Info.addPrivateSegmentSize(TRI);
     MF.addLiveIn(PrivateSegmentSizeReg, &AMDGPU::SGPR_32RegClass);
-    CCInfo.AllocateReg(PrivateSegmentSizeReg);
+    CCInfo.AllocateReg(static_cast<MCPhysReg>(PrivateSegmentSizeReg));
   }
 
   // TODO: Add GridWorkGroupCount user SGPRs when used. For now with HSA we read
@@ -3176,18 +3187,18 @@ void SITargetLowering::allocatePreloadKernArgSGPRs(
       assert(ArgLocs[ArgIdx].isMemLoc());
       auto &ArgLoc = ArgLocs[InIdx];
       const Align KernelArgBaseAlign = Align(16);
-      unsigned ArgOffset = ArgLoc.getLocMemOffset();
+      unsigned ArgOffset = static_cast<unsigned>(ArgLoc.getLocMemOffset());
       Align Alignment = commonAlignment(KernelArgBaseAlign, ArgOffset);
-      unsigned NumAllocSGPRs =
-          alignTo(ArgLoc.getLocVT().getFixedSizeInBits(), 32) / 32;
+      unsigned NumAllocSGPRs = static_cast<unsigned>(
+          alignTo(ArgLoc.getLocVT().getFixedSizeInBits(), 32) / 32);
 
       // Fix alignment for hidden arguments.
       if (Arg.hasAttribute("amdgpu-hidden-argument")) {
         if (!AlignedForImplictArgs) {
-          ImplicitArgOffset =
+          ImplicitArgOffset = static_cast<unsigned>(
               alignTo(LastExplicitArgOffset,
                       Subtarget->getAlignmentForImplicitArgPtr()) -
-              LastExplicitArgOffset;
+              LastExplicitArgOffset);
           AlignedForImplictArgs = true;
         }
         ArgOffset += ImplicitArgOffset;
@@ -3220,7 +3231,7 @@ void SITargetLowering::allocatePreloadKernArgSGPRs(
       for (auto &Reg : *PreloadRegs) {
         assert(Reg);
         MF.addLiveIn(Reg, RC);
-        CCInfo.AllocateReg(Reg);
+        CCInfo.AllocateReg(static_cast<MCPhysReg>(Reg));
       }
 
       LastExplicitArgOffset = NumAllocSGPRs * 4 + ArgOffset;
@@ -3235,7 +3246,7 @@ void SITargetLowering::allocateLDSKernelId(CCState &CCInfo, MachineFunction &MF,
   if (Info.hasLDSKernelId()) {
     Register Reg = Info.addLDSKernelId();
     MF.addLiveIn(Reg, &AMDGPU::SGPR_32RegClass);
-    CCInfo.AllocateReg(Reg);
+    CCInfo.AllocateReg(static_cast<MCPhysReg>(Reg));
   }
 }
 
@@ -3263,7 +3274,7 @@ void SITargetLowering::allocateSystemSGPRs(CCState &CCInfo, MachineFunction &MF,
     for (unsigned i = NumRequiredSystemSGPRs + CurrentUserSGPRs; i < 16; ++i) {
       Register Reg = Info.addReservedUserSGPR();
       MF.addLiveIn(Reg, &AMDGPU::SGPR_32RegClass);
-      CCInfo.AllocateReg(Reg);
+      CCInfo.AllocateReg(static_cast<MCPhysReg>(Reg));
     }
   }
 
@@ -3271,26 +3282,26 @@ void SITargetLowering::allocateSystemSGPRs(CCState &CCInfo, MachineFunction &MF,
     if (Info.hasWorkGroupIDX()) {
       Register Reg = Info.addWorkGroupIDX();
       MF.addLiveIn(Reg, &AMDGPU::SGPR_32RegClass);
-      CCInfo.AllocateReg(Reg);
+      CCInfo.AllocateReg(static_cast<MCPhysReg>(Reg));
     }
 
     if (Info.hasWorkGroupIDY()) {
       Register Reg = Info.addWorkGroupIDY();
       MF.addLiveIn(Reg, &AMDGPU::SGPR_32RegClass);
-      CCInfo.AllocateReg(Reg);
+      CCInfo.AllocateReg(static_cast<MCPhysReg>(Reg));
     }
 
     if (Info.hasWorkGroupIDZ()) {
       Register Reg = Info.addWorkGroupIDZ();
       MF.addLiveIn(Reg, &AMDGPU::SGPR_32RegClass);
-      CCInfo.AllocateReg(Reg);
+      CCInfo.AllocateReg(static_cast<MCPhysReg>(Reg));
     }
   }
 
   if (Info.hasWorkGroupInfo()) {
     Register Reg = Info.addWorkGroupInfo();
     MF.addLiveIn(Reg, &AMDGPU::SGPR_32RegClass);
-    CCInfo.AllocateReg(Reg);
+    CCInfo.AllocateReg(static_cast<MCPhysReg>(Reg));
   }
 
   if (Info.hasPrivateSegmentWaveByteOffset()) {
@@ -3311,7 +3322,7 @@ void SITargetLowering::allocateSystemSGPRs(CCState &CCInfo, MachineFunction &MF,
       PrivateSegmentWaveByteOffsetReg = Info.addPrivateSegmentWaveByteOffset();
 
     MF.addLiveIn(PrivateSegmentWaveByteOffsetReg, &AMDGPU::SGPR_32RegClass);
-    CCInfo.AllocateReg(PrivateSegmentWaveByteOffsetReg);
+    CCInfo.AllocateReg(static_cast<MCPhysReg>(PrivateSegmentWaveByteOffsetReg));
   }
 
   assert(!Subtarget->hasUserSGPRInit16BugInWave32() || IsShader ||
@@ -3470,7 +3481,7 @@ SDValue SITargetLowering::LowerFormalArguments(
 
   SmallVector<ISD::InputArg, 16> Splits;
   SmallVector<CCValAssign, 16> ArgLocs;
-  BitVector Skipped(Ins.size());
+  BitVector Skipped(static_cast<unsigned>(Ins.size()));
   CCState CCInfo(CallConv, isVarArg, DAG.getMachineFunction(), ArgLocs,
                  *DAG.getContext());
 
@@ -3557,7 +3568,7 @@ SDValue SITargetLowering::LowerFormalArguments(
 
     // FIXME: Sink this into allocateSpecialInputSGPRs
     if (!Subtarget->hasFlatScratchEnabled())
-      CCInfo.AllocateReg(Info->getScratchRSrcReg());
+      CCInfo.AllocateReg(static_cast<MCPhysReg>(Info->getScratchRSrcReg()));
 
     allocateSpecialInputSGPRs(CCInfo, MF, *TRI, *Info);
   }
@@ -3592,8 +3603,9 @@ SDValue SITargetLowering::LowerFormalArguments(
   // kern arg offset.
   const Align KernelArgBaseAlign = Align(16);
 
-  for (unsigned i = IsWholeWaveFunc ? 1 : 0, e = Ins.size(), ArgIdx = 0; i != e;
-       ++i) {
+  for (unsigned i = IsWholeWaveFunc ? 1 : 0,
+                e = static_cast<unsigned>(Ins.size()), ArgIdx = 0;
+       i != e; ++i) {
     const ISD::InputArg &Arg = Ins[i];
     if ((Arg.isOrigArg() && Skipped[Arg.getOrigArgIndex()]) || IsError) {
       InVals.push_back(DAG.getPOISON(Arg.VT));
@@ -3665,8 +3677,9 @@ SDValue SITargetLowering::LowerFormalArguments(
             const TargetRegisterClass *RC = MRI.getRegClass(VReg);
             NewArg = DAG.getCopyFromReg(
                 Chain, DL, VReg,
-                EVT::getIntegerVT(*DAG.getContext(),
-                                  TRI->getRegSizeInBits(*RC)));
+                EVT::getIntegerVT(
+                    *DAG.getContext(),
+                    static_cast<unsigned>(TRI->getRegSizeInBits(*RC))));
 
           } else {
             // If the kernarg alignment does not match the alignment of the SGPR
@@ -3679,10 +3692,10 @@ SDValue SITargetLowering::LowerFormalArguments(
               Copy = DAG.getCopyFromReg(Chain, DL, VReg, MVT::i32);
               Elts.push_back(Copy);
             }
-            NewArg =
-                DAG.getBuildVector(EVT::getVectorVT(*DAG.getContext(), MVT::i32,
-                                                    PreloadRegs.size()),
-                                   DL, Elts);
+            NewArg = DAG.getBuildVector(
+                EVT::getVectorVT(*DAG.getContext(), MVT::i32,
+                                 static_cast<unsigned>(PreloadRegs.size())),
+                DL, Elts);
           }
 
           // If the argument was preloaded to multiple consecutive 32-bit
@@ -3692,8 +3705,8 @@ SDValue SITargetLowering::LowerFormalArguments(
           // MemVT and just do a bitcast. If MemVT is less than 32-bits we add a
           // truncate since we cannot preload to less than a single SGPR and the
           // MemVT may be smaller.
-          EVT MemVTInt =
-              EVT::getIntegerVT(*DAG.getContext(), MemVT.getSizeInBits());
+          EVT MemVTInt = EVT::getIntegerVT(
+              *DAG.getContext(), static_cast<unsigned>(MemVT.getSizeInBits()));
           if (MemVT.bitsLT(NewArg.getSimpleValueType()))
             NewArg = DAG.getNode(ISD::TRUNCATE, DL, MemVTInt, NewArg);
 
@@ -3782,7 +3795,7 @@ SDValue SITargetLowering::LowerFormalArguments(
   if (IsEntryFunc)
     allocateSystemSGPRs(CCInfo, MF, *Info, CallConv, IsGraphics);
 
-  unsigned StackArgSize = CCInfo.getStackSize();
+  unsigned StackArgSize = static_cast<unsigned>(CCInfo.getStackSize());
   Info->setBytesInStackArgArea(StackArgSize);
 
   return Chains.empty() ? Chain
@@ -3853,8 +3866,9 @@ SITargetLowering::LowerReturn(SDValue Chain, CallingConv::ID CallConv,
   SDValue ReadFirstLane =
       DAG.getTargetConstant(Intrinsic::amdgcn_readfirstlane, DL, MVT::i32);
   // Copy the result values into the output registers.
-  for (unsigned I = 0, RealRVLocIdx = 0, E = RVLocs.size(); I != E;
-       ++I, ++RealRVLocIdx) {
+  for (unsigned I = 0, RealRVLocIdx = 0,
+                E = static_cast<unsigned>(RVLocs.size());
+       I != E; ++I, ++RealRVLocIdx) {
     CCValAssign &VA = RVLocs[I];
     assert(VA.isRegLoc() && "Can only return in registers!");
     // TODO: Partially return in registers if return values don't fit.
@@ -4053,11 +4067,12 @@ void SITargetLowering::passSpecialInputs(
 
     if (OutgoingArg->isRegister()) {
       RegsToPass.emplace_back(OutgoingArg->getRegister(), InputReg);
-      if (!CCInfo.AllocateReg(OutgoingArg->getRegister()))
+      if (!CCInfo.AllocateReg(
+              static_cast<MCPhysReg>(OutgoingArg->getRegister())))
         report_fatal_error("failed to allocate implicit input argument");
     } else {
-      unsigned SpecialArgOffset =
-          CCInfo.AllocateStack(ArgVT.getStoreSize(), Align(4));
+      unsigned SpecialArgOffset = static_cast<unsigned>(CCInfo.AllocateStack(
+          static_cast<unsigned>(ArgVT.getStoreSize()), Align(4)));
       SDValue ArgStore =
           storeStackInputValue(DAG, DL, Chain, InputReg, SpecialArgOffset);
       MemOpChains.push_back(ArgStore);
@@ -4145,9 +4160,10 @@ void SITargetLowering::passSpecialInputs(
     if (InputReg)
       RegsToPass.emplace_back(OutgoingArg->getRegister(), InputReg);
 
-    CCInfo.AllocateReg(OutgoingArg->getRegister());
+    CCInfo.AllocateReg(static_cast<MCPhysReg>(OutgoingArg->getRegister()));
   } else {
-    unsigned SpecialArgOffset = CCInfo.AllocateStack(4, Align(4));
+    unsigned SpecialArgOffset =
+        static_cast<unsigned>(CCInfo.AllocateStack(4, Align(4)));
     if (InputReg) {
       SDValue ArgStore =
           storeStackInputValue(DAG, DL, Chain, InputReg, SpecialArgOffset);
@@ -4417,12 +4433,12 @@ SDValue SITargetLowering::LowerCall(CallLoweringInfo &CLI,
   // Mark the scratch resource descriptor as allocated so the CC analysis
   // does not assign user arguments to these registers, matching the callee.
   if (!Subtarget->hasFlatScratchEnabled())
-    CCInfo.AllocateReg(Info->getScratchRSrcReg());
+    CCInfo.AllocateReg(static_cast<MCPhysReg>(Info->getScratchRSrcReg()));
 
   CCInfo.AnalyzeCallOperands(Outs, AssignFn);
 
   // Get a count of how many bytes are to be pushed on the stack.
-  unsigned NumBytes = CCInfo.getStackSize();
+  unsigned NumBytes = static_cast<unsigned>(CCInfo.getStackSize());
 
   if (IsSibCall) {
     // Since we're not changing the ABI to make this a tail call, the memory
@@ -4460,12 +4476,12 @@ SDValue SITargetLowering::LowerCall(CallLoweringInfo &CLI,
     }
   }
 
-  const unsigned NumSpecialInputs = RegsToPass.size();
+  const unsigned NumSpecialInputs = static_cast<unsigned>(RegsToPass.size());
 
   MVT PtrVT = MVT::i32;
 
   // Walk the register/memloc assignments, inserting copies/loads.
-  for (unsigned i = 0, e = ArgLocs.size(); i != e; ++i) {
+  for (unsigned i = 0, e = static_cast<unsigned>(ArgLocs.size()); i != e; ++i) {
     CCValAssign &VA = ArgLocs[i];
     SDValue Arg = OutVals[i];
 
@@ -4500,7 +4516,7 @@ SDValue SITargetLowering::LowerCall(CallLoweringInfo &CLI,
       SDValue DstAddr;
       MachinePointerInfo DstInfo;
 
-      unsigned LocMemOffset = VA.getLocMemOffset();
+      unsigned LocMemOffset = static_cast<unsigned>(VA.getLocMemOffset());
       int32_t Offset = LocMemOffset;
 
       SDValue PtrOff = DAG.getConstant(Offset, DL, PtrVT);
@@ -4508,8 +4524,10 @@ SDValue SITargetLowering::LowerCall(CallLoweringInfo &CLI,
 
       if (IsTailCall) {
         ISD::ArgFlagsTy Flags = Outs[i].Flags;
-        unsigned OpSize = Flags.isByVal() ? Flags.getByValSize()
-                                          : VA.getValVT().getStoreSize();
+        unsigned OpSize =
+            Flags.isByVal()
+                ? Flags.getByValSize()
+                : static_cast<unsigned>(VA.getValVT().getStoreSize());
 
         // FIXME: We can have better than the minimum byval required alignment.
         Alignment =
@@ -4815,8 +4833,8 @@ SDValue SITargetLowering::lowerGET_ROUNDING(SDValue Op,
   SDLoc SL(Op);
   assert(Op.getValueType() == MVT::i32);
 
-  uint32_t BothRoundHwReg =
-      AMDGPU::Hwreg::HwregEncoding::encode(AMDGPU::Hwreg::ID_MODE, 0, 4);
+  uint32_t BothRoundHwReg = static_cast<uint32_t>(
+      AMDGPU::Hwreg::HwregEncoding::encode(AMDGPU::Hwreg::ID_MODE, 0, 4));
   SDValue GetRoundBothImm = DAG.getTargetConstant(BothRoundHwReg, SL, MVT::i32);
 
   SDValue IntrinID =
@@ -4955,8 +4973,8 @@ SDValue SITargetLowering::lowerSET_ROUNDING(SDValue Op,
   // targets.
   SDValue IntrinID =
       DAG.getTargetConstant(Intrinsic::amdgcn_s_setreg, SL, MVT::i32);
-  uint32_t BothRoundHwReg =
-      AMDGPU::Hwreg::HwregEncoding::encode(AMDGPU::Hwreg::ID_MODE, 0, 4);
+  uint32_t BothRoundHwReg = static_cast<uint32_t>(
+      AMDGPU::Hwreg::HwregEncoding::encode(AMDGPU::Hwreg::ID_MODE, 0, 4));
   SDValue RoundBothImm = DAG.getTargetConstant(BothRoundHwReg, SL, MVT::i32);
 
   SDValue SetReg =
@@ -5017,11 +5035,11 @@ SDValue SITargetLowering::lowerGET_FPENV(SDValue Op, SelectionDAG &DAG) const {
   if (Op.getValueType() != MVT::i64)
     return Op;
 
-  uint32_t ModeHwReg =
-      AMDGPU::Hwreg::HwregEncoding::encode(AMDGPU::Hwreg::ID_MODE, 0, 23);
+  uint32_t ModeHwReg = static_cast<uint32_t>(
+      AMDGPU::Hwreg::HwregEncoding::encode(AMDGPU::Hwreg::ID_MODE, 0, 23));
   SDValue ModeHwRegImm = DAG.getTargetConstant(ModeHwReg, SL, MVT::i32);
-  uint32_t TrapHwReg =
-      AMDGPU::Hwreg::HwregEncoding::encode(AMDGPU::Hwreg::ID_TRAPSTS, 0, 5);
+  uint32_t TrapHwReg = static_cast<uint32_t>(
+      AMDGPU::Hwreg::HwregEncoding::encode(AMDGPU::Hwreg::ID_TRAPSTS, 0, 5));
   SDValue TrapHwRegImm = DAG.getTargetConstant(TrapHwReg, SL, MVT::i32);
 
   SDVTList VTList = DAG.getVTList(MVT::i32, MVT::Other);
@@ -5060,11 +5078,11 @@ SDValue SITargetLowering::lowerSET_FPENV(SDValue Op, SelectionDAG &DAG) const {
   NewTrapReg = DAG.getNode(ISD::INTRINSIC_WO_CHAIN, SL, MVT::i32,
                            ReadFirstLaneID, NewTrapReg);
 
-  unsigned ModeHwReg =
-      AMDGPU::Hwreg::HwregEncoding::encode(AMDGPU::Hwreg::ID_MODE, 0, 23);
+  unsigned ModeHwReg = static_cast<unsigned>(
+      AMDGPU::Hwreg::HwregEncoding::encode(AMDGPU::Hwreg::ID_MODE, 0, 23));
   SDValue ModeHwRegImm = DAG.getTargetConstant(ModeHwReg, SL, MVT::i32);
-  unsigned TrapHwReg =
-      AMDGPU::Hwreg::HwregEncoding::encode(AMDGPU::Hwreg::ID_TRAPSTS, 0, 5);
+  unsigned TrapHwReg = static_cast<unsigned>(
+      AMDGPU::Hwreg::HwregEncoding::encode(AMDGPU::Hwreg::ID_TRAPSTS, 0, 5));
   SDValue TrapHwRegImm = DAG.getTargetConstant(TrapHwReg, SL, MVT::i32);
 
   SDValue IntrinID =
@@ -5209,8 +5227,9 @@ SITargetLowering::emitGWSMemViolTestLoop(MachineInstr &MI,
 
   MachineBasicBlock::iterator I = LoopBB->end();
 
-  const unsigned EncodedReg = AMDGPU::Hwreg::HwregEncoding::encode(
-      AMDGPU::Hwreg::ID_TRAPSTS, AMDGPU::Hwreg::OFFSET_MEM_VIOL, 1);
+  const unsigned EncodedReg =
+      static_cast<unsigned>(AMDGPU::Hwreg::HwregEncoding::encode(
+          AMDGPU::Hwreg::ID_TRAPSTS, AMDGPU::Hwreg::OFFSET_MEM_VIOL, 1));
 
   // Clear TRAP_STS.MEM_VIOL
   BuildMI(*LoopBB, LoopBB->begin(), DL, TII->get(AMDGPU::S_SETREG_IMM32_B32))
@@ -5388,7 +5407,7 @@ static std::pair<unsigned, int>
 computeIndirectRegAndOffset(const SIRegisterInfo &TRI,
                             const TargetRegisterClass *SuperRC, unsigned VecReg,
                             int Offset) {
-  int NumElts = TRI.getRegSizeInBits(*SuperRC) / 32;
+  int NumElts = static_cast<int>(TRI.getRegSizeInBits(*SuperRC) / 32);
 
   // Skip out of bounds offsets, or else we would end up using an undefined
   // register.
@@ -5451,7 +5470,8 @@ static MachineBasicBlock *emitIndirectSrc(MachineInstr &MI,
   Register Dst = MI.getOperand(0).getReg();
   const MachineOperand *Idx = TII->getNamedOperand(MI, AMDGPU::OpName::idx);
   Register SrcReg = TII->getNamedOperand(MI, AMDGPU::OpName::src)->getReg();
-  int Offset = TII->getNamedOperand(MI, AMDGPU::OpName::offset)->getImm();
+  int Offset = static_cast<int>(
+      TII->getNamedOperand(MI, AMDGPU::OpName::offset)->getImm());
 
   const TargetRegisterClass *VecRC = MRI.getRegClass(SrcReg);
   const TargetRegisterClass *IdxRC = MRI.getRegClass(Idx->getReg());
@@ -5473,8 +5493,8 @@ static MachineBasicBlock *emitIndirectSrc(MachineInstr &MI,
       // optimization pass.
       Register Idx = getIndirectSGPRIdx(TII, MRI, MI, Offset);
 
-      const MCInstrDesc &GPRIDXDesc =
-          TII->getIndirectGPRIDXPseudo(TRI.getRegSizeInBits(*VecRC), true);
+      const MCInstrDesc &GPRIDXDesc = TII->getIndirectGPRIDXPseudo(
+          static_cast<unsigned>(TRI.getRegSizeInBits(*VecRC)), true);
       BuildMI(MBB, I, DL, GPRIDXDesc, Dst)
           .addReg(SrcReg)
           .addReg(Idx)
@@ -5508,8 +5528,8 @@ static MachineBasicBlock *emitIndirectSrc(MachineInstr &MI,
   MachineBasicBlock *LoopBB = InsPt->getParent();
 
   if (UseGPRIdxMode) {
-    const MCInstrDesc &GPRIDXDesc =
-        TII->getIndirectGPRIDXPseudo(TRI.getRegSizeInBits(*VecRC), true);
+    const MCInstrDesc &GPRIDXDesc = TII->getIndirectGPRIDXPseudo(
+        static_cast<unsigned>(TRI.getRegSizeInBits(*VecRC)), true);
 
     BuildMI(*LoopBB, InsPt, DL, GPRIDXDesc, Dst)
         .addReg(SrcReg)
@@ -5538,7 +5558,8 @@ static MachineBasicBlock *emitIndirectDst(MachineInstr &MI,
   const MachineOperand *SrcVec = TII->getNamedOperand(MI, AMDGPU::OpName::src);
   const MachineOperand *Idx = TII->getNamedOperand(MI, AMDGPU::OpName::idx);
   const MachineOperand *Val = TII->getNamedOperand(MI, AMDGPU::OpName::val);
-  int Offset = TII->getNamedOperand(MI, AMDGPU::OpName::offset)->getImm();
+  int Offset = static_cast<int>(
+      TII->getNamedOperand(MI, AMDGPU::OpName::offset)->getImm());
   const TargetRegisterClass *VecRC = MRI.getRegClass(SrcVec->getReg());
   const TargetRegisterClass *IdxRC = MRI.getRegClass(Idx->getReg());
 
@@ -5573,8 +5594,8 @@ static MachineBasicBlock *emitIndirectDst(MachineInstr &MI,
     if (UseGPRIdxMode) {
       Register Idx = getIndirectSGPRIdx(TII, MRI, MI, Offset);
 
-      const MCInstrDesc &GPRIDXDesc =
-          TII->getIndirectGPRIDXPseudo(TRI.getRegSizeInBits(*VecRC), false);
+      const MCInstrDesc &GPRIDXDesc = TII->getIndirectGPRIDXPseudo(
+          static_cast<unsigned>(TRI.getRegSizeInBits(*VecRC)), false);
       BuildMI(MBB, I, DL, GPRIDXDesc, Dst)
           .addReg(SrcVec->getReg())
           .add(*Val)
@@ -5584,7 +5605,7 @@ static MachineBasicBlock *emitIndirectDst(MachineInstr &MI,
       setM0ToIndexFromSGPR(TII, MRI, MI, Offset);
 
       const MCInstrDesc &MovRelDesc = TII->getIndirectRegWriteMovRelPseudo(
-          TRI.getRegSizeInBits(*VecRC), 32, false);
+          static_cast<unsigned>(TRI.getRegSizeInBits(*VecRC)), 32, false);
       BuildMI(MBB, I, DL, MovRelDesc, Dst)
           .addReg(SrcVec->getReg())
           .add(*Val)
@@ -5608,8 +5629,8 @@ static MachineBasicBlock *emitIndirectDst(MachineInstr &MI,
   MachineBasicBlock *LoopBB = InsPt->getParent();
 
   if (UseGPRIdxMode) {
-    const MCInstrDesc &GPRIDXDesc =
-        TII->getIndirectGPRIDXPseudo(TRI.getRegSizeInBits(*VecRC), false);
+    const MCInstrDesc &GPRIDXDesc = TII->getIndirectGPRIDXPseudo(
+        static_cast<unsigned>(TRI.getRegSizeInBits(*VecRC)), false);
 
     BuildMI(*LoopBB, InsPt, DL, GPRIDXDesc, Dst)
         .addReg(PhiReg)
@@ -5618,7 +5639,7 @@ static MachineBasicBlock *emitIndirectDst(MachineInstr &MI,
         .addImm(SubReg);
   } else {
     const MCInstrDesc &MovRelDesc = TII->getIndirectRegWriteMovRelPseudo(
-        TRI.getRegSizeInBits(*VecRC), 32, false);
+        static_cast<unsigned>(TRI.getRegSizeInBits(*VecRC)), 32, false);
     BuildMI(*LoopBB, InsPt, DL, MovRelDesc, Dst)
         .addReg(PhiReg)
         .add(*Val)
@@ -7303,7 +7324,7 @@ SITargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
       if (SetRoundOp || SetDenormOp) {
         MachineInstr *Def = MRI.getVRegDef(MI.getOperand(0).getReg());
         if (Def && Def->isMoveImmediate() && Def->getOperand(1).isImm()) {
-          unsigned ImmVal = Def->getOperand(1).getImm();
+          unsigned ImmVal = static_cast<unsigned>(Def->getOperand(1).getImm());
           if (SetRoundOp) {
             BuildMI(*BB, MI, MI.getDebugLoc(), TII->get(SetRoundOp))
                 .addImm(ImmVal & 0xf);
@@ -7927,7 +7948,7 @@ SDValue SITargetLowering::lowerIntrinsicLoad(MemSDNode *M, bool IsFormat,
 static SDValue lowerICMPIntrinsic(const SITargetLowering &TLI, SDNode *N,
                                   SelectionDAG &DAG) {
   EVT VT = N->getValueType(0);
-  unsigned CondCode = N->getConstantOperandVal(3);
+  unsigned CondCode = static_cast<unsigned>(N->getConstantOperandVal(3));
   if (!ICmpInst::isIntPredicate(static_cast<ICmpInst::Predicate>(CondCode)))
     return DAG.getPOISON(VT);
 
@@ -7962,7 +7983,7 @@ static SDValue lowerFCMPIntrinsic(const SITargetLowering &TLI, SDNode *N,
                                   SelectionDAG &DAG) {
   EVT VT = N->getValueType(0);
 
-  unsigned CondCode = N->getConstantOperandVal(3);
+  unsigned CondCode = static_cast<unsigned>(N->getConstantOperandVal(3));
   if (!FCmpInst::isFPPredicate(static_cast<FCmpInst::Predicate>(CondCode)))
     return DAG.getPOISON(VT);
 
@@ -8036,8 +8057,8 @@ static SDValue emitRemovedIntrinsicError(SelectionDAG &DAG, const SDLoc &DL,
 static SDValue lowerLaneOp(const SITargetLowering &TLI, SDNode *N,
                            SelectionDAG &DAG) {
   EVT VT = N->getValueType(0);
-  unsigned ValSize = VT.getSizeInBits();
-  unsigned IID = N->getConstantOperandVal(0);
+  unsigned ValSize = static_cast<unsigned>(VT.getSizeInBits());
+  unsigned IID = static_cast<unsigned>(N->getConstantOperandVal(0));
   bool IsPermLane16 = IID == Intrinsic::amdgcn_permlane16 ||
                       IID == Intrinsic::amdgcn_permlanex16;
   bool IsSetInactive = IID == Intrinsic::amdgcn_set_inactive ||
@@ -8053,7 +8074,8 @@ static SDValue lowerLaneOp(const SITargetLowering &TLI, SDNode *N,
   unsigned SplitSize = 32;
   if (IID == Intrinsic::amdgcn_update_dpp && (ValSize % 64 == 0) &&
       ST->hasDPALU_DPP() &&
-      AMDGPU::isLegalDPALU_DPPControl(*ST, N->getConstantOperandVal(3)))
+      AMDGPU::isLegalDPALU_DPPControl(
+          *ST, static_cast<unsigned>(N->getConstantOperandVal(3))))
     SplitSize = 64;
 
   auto createLaneOp = [&DAG, &SL, N, IID](SDValue Src0, SDValue Src1,
@@ -8195,8 +8217,8 @@ static SDValue lowerLaneOp(const SITargetLowering &TLI, SDNode *N,
     case MVT::i16:
     case MVT::f16:
     case MVT::bf16: {
-      unsigned SubVecNumElt =
-          SplitSize / VT.getVectorElementType().getSizeInBits();
+      unsigned SubVecNumElt = static_cast<unsigned>(
+          SplitSize / VT.getVectorElementType().getSizeInBits());
       MVT SubVecVT = MVT::getVectorVT(EltTy, SubVecNumElt);
       SmallVector<SDValue, 4> Pieces;
       SDValue Src0SubVec, Src1SubVec, Src2SubVec;
@@ -8338,7 +8360,7 @@ void SITargetLowering::ReplaceNodeResults(SDNode *N,
     return;
   }
   case ISD::INTRINSIC_WO_CHAIN: {
-    unsigned IID = N->getConstantOperandVal(0);
+    unsigned IID = static_cast<unsigned>(N->getConstantOperandVal(0));
     switch (IID) {
     case Intrinsic::amdgcn_wave_reduce_min:
     case Intrinsic::amdgcn_wave_reduce_umin:
@@ -9332,7 +9354,8 @@ SDValue SITargetLowering::LowerINLINEASM(SDValue Op, SelectionDAG &DAG) const {
   unsigned NumVals = 0;
   for (unsigned I = InlineAsm::Op_FirstOperand; I < NumOps - 1;
        I += 1 + NumVals) {
-    const InlineAsm::Flag Flags(Op.getConstantOperandVal(I));
+    const InlineAsm::Flag Flags(
+        static_cast<uint32_t>(Op.getConstantOperandVal(I)));
     NumVals = Flags.getNumOperandRegisters();
 
     unsigned RCID;
@@ -9487,8 +9510,8 @@ SDValue SITargetLowering::lowerADDRSPACECAST(SDValue Op,
            Op.getConstantOperandVal(0) ==
                Intrinsic::amdgcn_addrspacecast_nonnull);
     Src = Op->getOperand(1);
-    SrcAS = Op->getConstantOperandVal(2);
-    DestAS = Op->getConstantOperandVal(3);
+    SrcAS = static_cast<unsigned>(Op->getConstantOperandVal(2));
+    DestAS = static_cast<unsigned>(Op->getConstantOperandVal(3));
     IsNonNull = true;
   }
 
@@ -9515,7 +9538,8 @@ SDValue SITargetLowering::lowerADDRSPACECAST(SDValue Op,
       if (IsNonNull || isKnownNonNull(Op, DAG, TM, SrcAS))
         return Ptr;
 
-      unsigned NullVal = AMDGPU::getNullPointerValue(DestAS);
+      unsigned NullVal =
+          static_cast<unsigned>(AMDGPU::getNullPointerValue(DestAS));
       SDValue SegmentNullPtr = DAG.getConstant(NullVal, SL, MVT::i32);
       SDValue NonNull = DAG.getSetCC(SL, MVT::i1, Src, FlatNullPtr, ISD::SETNE);
 
@@ -9566,7 +9590,8 @@ SDValue SITargetLowering::lowerADDRSPACECAST(SDValue Op,
       if (IsNonNull || isKnownNonNull(Op, DAG, TM, SrcAS))
         return CvtPtr;
 
-      unsigned NullVal = AMDGPU::getNullPointerValue(SrcAS);
+      unsigned NullVal =
+          static_cast<unsigned>(AMDGPU::getNullPointerValue(SrcAS));
       SDValue SegmentNullPtr = DAG.getConstant(NullVal, SL, MVT::i32);
 
       SDValue NonNull =
@@ -9613,7 +9638,7 @@ SDValue SITargetLowering::lowerINSERT_SUBVECTOR(SDValue Op,
   EVT InsVT = Ins.getValueType();
   EVT EltVT = VecVT.getVectorElementType();
   unsigned InsNumElts = InsVT.getVectorNumElements();
-  unsigned IdxVal = Idx->getAsZExtVal();
+  unsigned IdxVal = static_cast<unsigned>(Idx->getAsZExtVal());
   SDLoc SL(Op);
 
   if (EltVT.getScalarSizeInBits() == 16 && IdxVal % 2 == 0) {
@@ -9661,8 +9686,8 @@ SDValue SITargetLowering::lowerINSERT_VECTOR_ELT(SDValue Op,
   SDValue Idx = Op.getOperand(2);
   EVT VecVT = Vec.getValueType();
   EVT EltVT = VecVT.getVectorElementType();
-  unsigned VecSize = VecVT.getSizeInBits();
-  unsigned EltSize = EltVT.getSizeInBits();
+  unsigned VecSize = static_cast<unsigned>(VecVT.getSizeInBits());
+  unsigned EltSize = static_cast<unsigned>(EltVT.getSizeInBits());
   SDLoc SL(Op);
 
   // Specially handle the case of v4i16 with static indexing.
@@ -9679,7 +9704,7 @@ SDValue SITargetLowering::lowerINSERT_VECTOR_ELT(SDValue Op,
     SDValue LoVec = DAG.getNode(ISD::BITCAST, SL, MVT::v2i16, LoHalf);
     SDValue HiVec = DAG.getNode(ISD::BITCAST, SL, MVT::v2i16, HiHalf);
 
-    unsigned Idx = KIdx->getZExtValue();
+    unsigned Idx = static_cast<unsigned>(KIdx->getZExtValue());
     bool InsertLo = Idx < 2;
     SDValue InsHalf = DAG.getNode(
         ISD::INSERT_VECTOR_ELT, SL, MVT::v2i16, InsertLo ? LoVec : HiVec,
@@ -9742,7 +9767,7 @@ SDValue SITargetLowering::lowerEXTRACT_VECTOR_ELT(SDValue Op,
   SDValue Vec = Op.getOperand(0);
   SDValue Idx = Op.getOperand(1);
   EVT VecVT = Vec.getValueType();
-  unsigned VecSize = VecVT.getSizeInBits();
+  unsigned VecSize = static_cast<unsigned>(VecVT.getSizeInBits());
   EVT EltVT = VecVT.getVectorElementType();
 
   DAGCombinerInfo DCI(DAG, AfterLegalizeVectorOps, true, nullptr);
@@ -9817,7 +9842,7 @@ SDValue SITargetLowering::lowerEXTRACT_VECTOR_ELT(SDValue Op,
     Vec = DAG.getAnyExtOrTrunc(Src, SL, IntVT);
   }
 
-  unsigned EltSize = EltVT.getSizeInBits();
+  unsigned EltSize = static_cast<unsigned>(EltVT.getSizeInBits());
   assert(isPowerOf2_32(EltSize));
 
   SDValue ScaleFactor = DAG.getConstant(Log2_32(EltSize), SL, MVT::i32);
@@ -10019,7 +10044,8 @@ SDValue SITargetLowering::lowerBUILD_VECTOR(SDValue Op,
   // Split into 2-element chunks.
   const unsigned NumParts = VT.getVectorNumElements() / 2;
   EVT PartVT = MVT::getVectorVT(VT.getVectorElementType().getSimpleVT(), 2);
-  MVT PartIntVT = MVT::getIntegerVT(PartVT.getSizeInBits());
+  MVT PartIntVT =
+      MVT::getIntegerVT(static_cast<unsigned>(PartVT.getSizeInBits()));
 
   SmallVector<SDValue> Casts;
   for (unsigned P = 0; P < NumParts; ++P) {
@@ -10240,7 +10266,7 @@ static SDValue getBuildDwordsVector(SelectionDAG &DAG, SDLoc DL,
                                     ArrayRef<SDValue> Elts) {
   assert(!Elts.empty());
   MVT Type;
-  unsigned NumElts = Elts.size();
+  unsigned NumElts = static_cast<unsigned>(Elts.size());
 
   if (NumElts <= 12) {
     Type = MVT::getVectorVT(MVT::f32, NumElts);
@@ -10257,7 +10283,7 @@ static SDValue getBuildDwordsVector(SelectionDAG &DAG, SDLoc DL,
       Elt = DAG.getBitcast(MVT::f32, Elt);
     VecElts[i] = Elt;
   }
-  for (unsigned i = Elts.size(); i < NumElts; ++i)
+  for (unsigned i = static_cast<unsigned>(Elts.size()); i < NumElts; ++i)
     VecElts[i] = DAG.getPOISON(MVT::f32);
 
   if (NumElts == 1)
@@ -10487,7 +10513,8 @@ SDValue SITargetLowering::lowerImage(SDValue Op,
       NumVDataDwords = Is64Bit ? 2 : 1;
     }
   } else {
-    DMask = Op->getConstantOperandVal(ArgOffset + Intr->DMaskIndex);
+    DMask = static_cast<unsigned>(
+        Op->getConstantOperandVal(ArgOffset + Intr->DMaskIndex));
     DMaskLanes = BaseOpcode->Gather4 ? 4 : llvm::popcount(DMask);
 
     if (BaseOpcode->Store) {
@@ -10508,7 +10535,8 @@ SDValue SITargetLowering::lowerImage(SDValue Op,
         VData = handleD16VData(VData, DAG, true);
       }
 
-      NumVDataDwords = (VData.getValueType().getSizeInBits() + 31) / 32;
+      NumVDataDwords =
+          static_cast<int>((VData.getValueType().getSizeInBits() + 31) / 32);
     } else if (!BaseOpcode->NoReturn) {
       // Work out the num dwords based on the dmask popcount and underlying type
       // and whether packing is supported.
@@ -10716,7 +10744,8 @@ SDValue SITargetLowering::lowerImage(SDValue Op,
     }
   }
 
-  unsigned CPol = Op.getConstantOperandVal(ArgOffset + Intr->CachePolicyIndex);
+  unsigned CPol = static_cast<unsigned>(
+      Op.getConstantOperandVal(ArgOffset + Intr->CachePolicyIndex));
   // Keep GLC only when the atomic's result is actually used.
   if (BaseOpcode->Atomic && !BaseOpcode->NoReturn)
     CPol |= AMDGPU::CPol::GLC;
@@ -10775,8 +10804,8 @@ SDValue SITargetLowering::lowerImage(SDValue Op,
   if (isa<MemSDNode>(Op))
     Ops.push_back(Op.getOperand(0)); // chain
 
-  int NumVAddrDwords =
-      UseNSA ? VAddrs.size() : VAddr.getValueType().getSizeInBits() / 32;
+  int NumVAddrDwords = static_cast<int>(
+      UseNSA ? VAddrs.size() : VAddr.getValueType().getSizeInBits() / 32);
   int Opcode = -1;
 
   if (IsGFX13) {
@@ -10947,7 +10976,7 @@ SDValue SITargetLowering::lowerSBuffer(EVT VT, EVT MemVT, SDLoc DL,
                    NumLoads > 1 ? Align(16 * NumLoads) : Align(4));
 
   uint64_t InstOffset = Ops[5]->getAsZExtVal();
-  unsigned LoadSize = LoadVT.getStoreSize();
+  unsigned LoadSize = static_cast<unsigned>(LoadVT.getStoreSize());
   for (unsigned i = 0; i < NumLoads; ++i) {
     Ops[5] = DAG.getTargetConstant(InstOffset + 16 * i, DL, MVT::i32);
     MachineMemOperand *LoadMMO = MF.getMachineMemOperand(MMO, 16 * i, LoadSize);
@@ -11042,8 +11071,8 @@ SDValue SITargetLowering::lowerFromFP8(SDValue Op, bool IsBF8,
   // Pack the two i8 lanes into the integer type the packed HW node reads. The
   // f16 form takes i16 and the f32 form takes i32. v2i8 bitcasts to i16
   // directly and the f32 node reads the low half of an any-extended i32.
-  EVT PackedVT =
-      EVT::getIntegerVT(*DAG.getContext(), DstVT.getScalarSizeInBits());
+  EVT PackedVT = EVT::getIntegerVT(
+      *DAG.getContext(), static_cast<unsigned>(DstVT.getScalarSizeInBits()));
   SDValue AsI16 = DAG.getNode(ISD::BITCAST, SL, MVT::i16, Src);
   SDValue Packed = DAG.getAnyExtOrTrunc(AsI16, SL, PackedVT);
   return DAG.getNode(Opc, SL, DstVT, Packed);
@@ -11086,7 +11115,7 @@ SDValue SITargetLowering::LowerINTRINSIC_WO_CHAIN(SDValue Op,
 
   EVT VT = Op.getValueType();
   SDLoc DL(Op);
-  unsigned IntrinsicID = Op.getConstantOperandVal(0);
+  unsigned IntrinsicID = static_cast<unsigned>(Op.getConstantOperandVal(0));
 
   // TODO: Should this propagate fast-math-flags?
 
@@ -11330,7 +11359,7 @@ SDValue SITargetLowering::LowerINTRINSIC_WO_CHAIN(SDValue Op,
     return DAG.getConstant(MF.getSubtarget<GCNSubtarget>().getWavefrontSize(),
                            SDLoc(Op), MVT::i32);
   case Intrinsic::amdgcn_s_buffer_load: {
-    unsigned CPol = Op.getConstantOperandVal(3);
+    unsigned CPol = static_cast<unsigned>(Op.getConstantOperandVal(3));
     // s_buffer_load, because of how it's optimized, can't be volatile
     // so reject ones with the volatile bit set.
     if (CPol & ~((Subtarget->getGeneration() >= AMDGPUSubtarget::GFX12)
@@ -11723,7 +11752,7 @@ SITargetLowering::lowerStructBufferAtomicIntrin(SDValue Op, SelectionDAG &DAG,
 
 SDValue SITargetLowering::LowerINTRINSIC_W_CHAIN(SDValue Op,
                                                  SelectionDAG &DAG) const {
-  unsigned IntrID = Op.getConstantOperandVal(1);
+  unsigned IntrID = static_cast<unsigned>(Op.getConstantOperandVal(1));
   SDLoc DL(Op);
 
   switch (IntrID) {
@@ -11733,9 +11762,9 @@ SDValue SITargetLowering::LowerINTRINSIC_W_CHAIN(SDValue Op,
     SDValue Chain = M->getOperand(0);
     SDValue M0 = M->getOperand(2);
     SDValue Value = M->getOperand(3);
-    unsigned IndexOperand = M->getConstantOperandVal(7);
-    unsigned WaveRelease = M->getConstantOperandVal(8);
-    unsigned WaveDone = M->getConstantOperandVal(9);
+    unsigned IndexOperand = static_cast<unsigned>(M->getConstantOperandVal(7));
+    unsigned WaveRelease = static_cast<unsigned>(M->getConstantOperandVal(8));
+    unsigned WaveDone = static_cast<unsigned>(M->getConstantOperandVal(9));
 
     unsigned OrderedCountIndex = IndexOperand & 0x3f;
     IndexOperand &= ~0x3f;
@@ -11791,7 +11820,7 @@ SDValue SITargetLowering::LowerINTRINSIC_W_CHAIN(SDValue Op,
                                    M->getMemOperand());
   }
   case Intrinsic::amdgcn_ptr_s_buffer_load: {
-    unsigned CPol = Op.getConstantOperandVal(4);
+    unsigned CPol = static_cast<unsigned>(Op.getConstantOperandVal(4));
     if (CPol & ~((Subtarget->getGeneration() >= AMDGPUSubtarget::GFX12)
                      ? AMDGPU::CPol::ALL
                      : AMDGPU::CPol::ALL_pregfx12))
@@ -12231,8 +12260,9 @@ SDValue SITargetLowering::LowerINTRINSIC_W_CHAIN(SDValue Op,
         Ops.append(16 - Ops.size(), Undef);
       }
       assert(Ops.size() >= 8 && Ops.size() <= 12);
-      SDValue MergedOps =
-          DAG.getBuildVector(MVT::getVectorVT(MVT::i32, Ops.size()), DL, Ops);
+      SDValue MergedOps = DAG.getBuildVector(
+          MVT::getVectorVT(MVT::i32, static_cast<unsigned>(Ops.size())), DL,
+          Ops);
       Ops.clear();
       Ops.push_back(MergedOps);
     }
@@ -12382,7 +12412,8 @@ SDValue SITargetLowering::getMemIntrinsicNode(unsigned Opcode, const SDLoc &DL,
   assert(VTList.NumVTs == 2 || VTList.NumVTs == 3);
   bool IsTFE = VTList.NumVTs == 3;
   if (IsTFE) {
-    unsigned NumValueDWords = divideCeil(VT.getSizeInBits(), 32);
+    unsigned NumValueDWords =
+        static_cast<unsigned>(divideCeil(VT.getSizeInBits(), 32));
     unsigned NumOpDWords = NumValueDWords + 1;
     EVT OpDWordsVT = EVT::getVectorVT(C, MVT::i32, NumOpDWords);
     SDVTList OpDWordsVTList = DAG.getVTList(OpDWordsVT, VTList.VTs[2]);
@@ -12463,7 +12494,7 @@ SDValue SITargetLowering::handleD16VData(SDValue VData, SelectionDAG &DAG,
     }
     if ((NumElements % 2) == 1) {
       // Handle v3i16
-      unsigned I = Elts.size() / 2;
+      unsigned I = static_cast<unsigned>(Elts.size() / 2);
       SDValue Pair = DAG.getBuildVector(MVT::v2i16, DL,
                                         {Elts[I * 2], DAG.getPOISON(MVT::i16)});
       SDValue IntPair = DAG.getNode(ISD::BITCAST, DL, MVT::i32, Pair);
@@ -12474,20 +12505,21 @@ SDValue SITargetLowering::handleD16VData(SDValue VData, SelectionDAG &DAG,
     PackedElts.resize(Elts.size(), DAG.getPOISON(MVT::i32));
 
     // Build final vector
-    EVT VecVT =
-        EVT::getVectorVT(*DAG.getContext(), MVT::i32, PackedElts.size());
+    EVT VecVT = EVT::getVectorVT(*DAG.getContext(), MVT::i32,
+                                 static_cast<unsigned>(PackedElts.size()));
     return DAG.getBuildVector(VecVT, DL, PackedElts);
   }
 
   if (NumElements == 3) {
-    EVT IntStoreVT =
-        EVT::getIntegerVT(*DAG.getContext(), StoreVT.getStoreSizeInBits());
+    EVT IntStoreVT = EVT::getIntegerVT(
+        *DAG.getContext(), static_cast<unsigned>(StoreVT.getStoreSizeInBits()));
     SDValue IntVData = DAG.getNode(ISD::BITCAST, DL, IntStoreVT, VData);
 
     EVT WidenedStoreVT = EVT::getVectorVT(
         *DAG.getContext(), StoreVT.getVectorElementType(), NumElements + 1);
-    EVT WidenedIntVT = EVT::getIntegerVT(*DAG.getContext(),
-                                         WidenedStoreVT.getStoreSizeInBits());
+    EVT WidenedIntVT = EVT::getIntegerVT(
+        *DAG.getContext(),
+        static_cast<unsigned>(WidenedStoreVT.getStoreSizeInBits()));
     SDValue ZExt = DAG.getNode(ISD::ZERO_EXTEND, DL, WidenedIntVT, IntVData);
     return DAG.getNode(ISD::BITCAST, DL, WidenedStoreVT, ZExt);
   }
@@ -12513,7 +12545,7 @@ SDValue SITargetLowering::LowerINTRINSIC_VOID(SDValue Op,
                                               SelectionDAG &DAG) const {
   SDLoc DL(Op);
   SDValue Chain = Op.getOperand(0);
-  unsigned IntrinsicID = Op.getConstantOperandVal(1);
+  unsigned IntrinsicID = static_cast<unsigned>(Op.getConstantOperandVal(1));
 
   switch (IntrinsicID) {
   case Intrinsic::amdgcn_exp_compr: {
@@ -12730,7 +12762,7 @@ SDValue SITargetLowering::LowerINTRINSIC_VOID(SDValue Op,
     unsigned OpOffset = HasVIndex ? 1 : 0;
     SDValue VOffset = Op.getOperand(5 + OpOffset);
     bool HasVOffset = !isNullConstant(VOffset);
-    unsigned Size = Op->getConstantOperandVal(4);
+    unsigned Size = static_cast<unsigned>(Op->getConstantOperandVal(4));
 
     switch (Size) {
     default:
@@ -12789,7 +12821,8 @@ SDValue SITargetLowering::LowerINTRINSIC_VOID(SDValue Op,
     Ops.push_back(Op.getOperand(6 + OpOffset)); // soffset
     Ops.push_back(Op.getOperand(7 + OpOffset)); // imm offset
     bool IsGFX12Plus = AMDGPU::isGFX12Plus(*Subtarget);
-    unsigned Aux = Op.getConstantOperandVal(8 + OpOffset);
+    unsigned Aux =
+        static_cast<unsigned>(Op.getConstantOperandVal(8 + OpOffset));
     Ops.push_back(DAG.getTargetConstant(
         Aux & (IsGFX12Plus ? AMDGPU::CPol::ALL : AMDGPU::CPol::ALL_pregfx12),
         DL, MVT::i8)); // cpol
@@ -12820,7 +12853,7 @@ SDValue SITargetLowering::LowerINTRINSIC_VOID(SDValue Op,
       return SDValue();
 
     unsigned Opc;
-    unsigned Size = Op->getConstantOperandVal(4);
+    unsigned Size = static_cast<unsigned>(Op->getConstantOperandVal(4));
     switch (Size) {
     default:
       return SDValue();
@@ -12881,7 +12914,7 @@ SDValue SITargetLowering::LowerINTRINSIC_VOID(SDValue Op,
 
     Ops.push_back(Op.getOperand(5));  // Offset
 
-    unsigned Aux = Op.getConstantOperandVal(6);
+    unsigned Aux = static_cast<unsigned>(Op.getConstantOperandVal(6));
     Ops.push_back(DAG.getTargetConstant(Aux & ~AMDGPU::CPol::VIRTUAL_BITS, DL,
                                         MVT::i32)); // CPol
     Ops.push_back(
@@ -13104,7 +13137,7 @@ SITargetLowering::splitBufferOffsets(SDValue Offset, SelectionDAG &DAG) const {
   }
 
   if (C1) {
-    unsigned ImmOffset = C1->getZExtValue();
+    unsigned ImmOffset = static_cast<unsigned>(C1->getZExtValue());
     // If the immediate value is too big for the immoffset field, put only bits
     // that would normally fit in the immoffset field. The remaining value that
     // is copied/added for the voffset field is a large power of 2, and it
@@ -13146,7 +13179,7 @@ void SITargetLowering::setBufferOffsets(SDValue CombinedOffset,
   const SIInstrInfo *TII = getSubtarget()->getInstrInfo();
   SDLoc DL(CombinedOffset);
   if (auto *C = dyn_cast<ConstantSDNode>(CombinedOffset)) {
-    uint32_t Imm = C->getZExtValue();
+    uint32_t Imm = static_cast<uint32_t>(C->getZExtValue());
     uint32_t SOffset, ImmOffset;
     if (TII->splitMUBUFOffset(Imm, SOffset, ImmOffset, Alignment)) {
       Offsets[0] = DAG.getConstant(0, DL, MVT::i32);
@@ -13163,7 +13196,7 @@ void SITargetLowering::setBufferOffsets(SDValue CombinedOffset,
     SDValue N0 = CombinedOffset.getOperand(0);
     SDValue N1 = CombinedOffset.getOperand(1);
     uint32_t SOffset, ImmOffset;
-    int Offset = cast<ConstantSDNode>(N1)->getSExtValue();
+    int Offset = static_cast<int>(cast<ConstantSDNode>(N1)->getSExtValue());
     if (Offset >= 0 && (!CheckNUW || isNoUnsignedWrap(CombinedOffset)) &&
         TII->splitMUBUFOffset(Offset, SOffset, ImmOffset, Alignment)) {
       Offsets[0] = N0;
@@ -13373,7 +13406,8 @@ SDValue SITargetLowering::widenLoad(LoadSDNode *Ld,
       Ld->getOffset(), Ld->getPointerInfo(), MVT::i32, Ld->getAlign(),
       Ld->getMemOperand()->getFlags(), Ld->getAAInfo()); // Drop ranges
 
-  EVT TruncVT = EVT::getIntegerVT(*DAG.getContext(), MemVT.getSizeInBits());
+  EVT TruncVT = EVT::getIntegerVT(*DAG.getContext(),
+                                  static_cast<unsigned>(MemVT.getSizeInBits()));
   if (MemVT.isFloatingPoint()) {
     assert(Ld->getExtensionType() == ISD::NON_EXTLOAD &&
            "unexpected fp extload");
@@ -13392,7 +13426,8 @@ SDValue SITargetLowering::widenLoad(LoadSDNode *Ld,
   }
 
   EVT VT = Ld->getValueType(0);
-  EVT IntVT = EVT::getIntegerVT(*DAG.getContext(), VT.getSizeInBits());
+  EVT IntVT = EVT::getIntegerVT(*DAG.getContext(),
+                                static_cast<unsigned>(VT.getSizeInBits()));
 
   DCI.AddToWorklist(Cvt.getNode());
 
@@ -13540,8 +13575,9 @@ SDValue SITargetLowering::LowerLOAD(SDValue Op, SelectionDAG &DAG) const {
   } else if (AS == AMDGPUAS::LOCAL_ADDRESS || AS == AMDGPUAS::REGION_ADDRESS) {
     unsigned Fast = 0;
     auto Flags = Load->getMemOperand()->getFlags();
-    if (allowsMisalignedMemoryAccessesImpl(MemVT.getSizeInBits(), AS,
-                                           Load->getAlign(), Flags, &Fast) &&
+    if (allowsMisalignedMemoryAccessesImpl(
+            static_cast<unsigned>(MemVT.getSizeInBits()), AS, Load->getAlign(),
+            Flags, &Fast) &&
         Fast > 1)
       return SDValue();
 
@@ -13869,7 +13905,8 @@ SDValue SITargetLowering::LowerFDIV32(SDValue Op, SelectionDAG &DAG) const {
       DAG.getNode(ISD::FNEG, SL, MVT::f32, DenominatorScaled, Flags);
 
   using namespace AMDGPU::Hwreg;
-  const unsigned Denorm32Reg = HwregEncoding::encode(ID_MODE, 4, 2);
+  const unsigned Denorm32Reg =
+      static_cast<unsigned>(HwregEncoding::encode(ID_MODE, 4, 2));
   const SDValue BitField = DAG.getTargetConstant(Denorm32Reg, SL, MVT::i32);
 
   const MachineFunction &MF = DAG.getMachineFunction();
@@ -14155,8 +14192,9 @@ SDValue SITargetLowering::LowerSTORE(SDValue Op, SelectionDAG &DAG) const {
   } else if (AS == AMDGPUAS::LOCAL_ADDRESS || AS == AMDGPUAS::REGION_ADDRESS) {
     unsigned Fast = 0;
     auto Flags = Store->getMemOperand()->getFlags();
-    if (allowsMisalignedMemoryAccessesImpl(VT.getSizeInBits(), AS,
-                                           Store->getAlign(), Flags, &Fast) &&
+    if (allowsMisalignedMemoryAccessesImpl(
+            static_cast<unsigned>(VT.getSizeInBits()), AS, Store->getAlign(),
+            Flags, &Fast) &&
         Fast > 1)
       return SDValue();
 
@@ -14736,7 +14774,7 @@ bool llvm::isBoolSGPR(SDValue V) {
   case ISD::UMULO:
     return V.getResNo() == 1;
   case ISD::INTRINSIC_WO_CHAIN: {
-    unsigned IntrinsicID = V.getConstantOperandVal(0);
+    unsigned IntrinsicID = static_cast<unsigned>(V.getConstantOperandVal(0));
     switch (IntrinsicID) {
     case Intrinsic::amdgcn_is_shared:
     case Intrinsic::amdgcn_is_private:
@@ -14787,7 +14825,7 @@ static uint32_t getPermuteMask(SDValue V) {
   if (!N1)
     return ~0;
 
-  uint32_t C = N1->getZExtValue();
+  uint32_t C = static_cast<uint32_t>(N1->getZExtValue());
 
   switch (V.getOpcode()) {
   default:
@@ -14845,7 +14883,7 @@ SDValue SITargetLowering::performAndCombine(SDNode *N,
     if (getSubtarget()->hasSDWA() && LHS->getOpcode() == ISD::SRL &&
         (Bits == 8 || Bits == 16) && isShiftedMask_64(Mask) && !(Mask & 1)) {
       if (auto *CShift = dyn_cast<ConstantSDNode>(LHS->getOperand(1))) {
-        unsigned Shift = CShift->getZExtValue();
+        unsigned Shift = static_cast<unsigned>(CShift->getZExtValue());
         unsigned NB = CRHS->getAPIntValue().countr_zero();
         unsigned Offset = NB + Shift;
         if ((Offset & (Bits - 1)) == 0) { // Starts at a byte or word boundary.
@@ -14867,7 +14905,7 @@ SDValue SITargetLowering::performAndCombine(SDNode *N,
     // and (perm x, y, c1), c2 -> perm x, y, permute_mask(c1, c2)
     if (LHS.hasOneUse() && LHS.getOpcode() == AMDGPUISD::PERM &&
         isa<ConstantSDNode>(LHS.getOperand(2))) {
-      uint32_t Sel = getConstantPermuteMask(Mask);
+      uint32_t Sel = getConstantPermuteMask(static_cast<uint32_t>(Mask));
       if (!Sel)
         return SDValue();
 
@@ -15120,7 +15158,7 @@ calculateByteProvider(const SDValue &Op, unsigned Index, unsigned Depth,
   if (Depth > 6)
     return std::nullopt;
 
-  unsigned BitWidth = Op.getScalarValueSizeInBits();
+  unsigned BitWidth = static_cast<unsigned>(Op.getScalarValueSizeInBits());
   if (BitWidth % 8 != 0)
     return std::nullopt;
   if (Index > BitWidth / 8 - 1)
@@ -15159,7 +15197,7 @@ calculateByteProvider(const SDValue &Op, unsigned Index, unsigned Depth,
     if (!BitMaskOp)
       return std::nullopt;
 
-    uint32_t BitMask = BitMaskOp->getZExtValue();
+    uint32_t BitMask = static_cast<uint32_t>(BitMaskOp->getZExtValue());
     // Bits we expect for our StartingIndex
     uint32_t IndexMask = 0xFF << (Index * 8);
 
@@ -15198,7 +15236,8 @@ calculateByteProvider(const SDValue &Op, unsigned Index, unsigned Depth,
     uint64_t BytesProvided = BitsProvided / 8;
     SDValue NextOp = Op.getOperand(NewIndex >= BytesProvided ? 0 : 1);
     NewIndex %= BytesProvided;
-    return calculateByteProvider(NextOp, NewIndex, Depth + 1, StartingIndex);
+    return calculateByteProvider(NextOp, static_cast<unsigned>(NewIndex),
+                                 Depth + 1, StartingIndex);
   }
 
   case ISD::SRA:
@@ -15248,7 +15287,8 @@ calculateByteProvider(const SDValue &Op, unsigned Index, unsigned Depth,
     // of interest is Index - ByteShift of the src
     return Index < ByteShift
                ? ByteProvider<SDValue>::getConstantZero()
-               : calculateByteProvider(Op.getOperand(0), Index - ByteShift,
+               : calculateByteProvider(Op.getOperand(0),
+                                       static_cast<unsigned>(Index - ByteShift),
                                        Depth + 1, StartingIndex);
   }
   case ISD::ANY_EXTEND:
@@ -15261,12 +15301,13 @@ calculateByteProvider(const SDValue &Op, unsigned Index, unsigned Depth,
       return std::nullopt;
 
     SDValue NarrowOp = Op->getOperand(0);
-    unsigned NarrowBitWidth = NarrowOp.getValueSizeInBits();
+    unsigned NarrowBitWidth =
+        static_cast<unsigned>(NarrowOp.getValueSizeInBits());
     if (Op->getOpcode() == ISD::SIGN_EXTEND_INREG ||
         Op->getOpcode() == ISD::AssertZext ||
         Op->getOpcode() == ISD::AssertSext) {
       auto *VTSign = cast<VTSDNode>(Op->getOperand(1));
-      NarrowBitWidth = VTSign->getVT().getSizeInBits();
+      NarrowBitWidth = static_cast<unsigned>(VTSign->getVT().getSizeInBits());
     }
     if (NarrowBitWidth % 8 != 0)
       return std::nullopt;
@@ -15304,7 +15345,8 @@ calculateByteProvider(const SDValue &Op, unsigned Index, unsigned Depth,
   case ISD::LOAD: {
     auto *L = cast<LoadSDNode>(Op.getNode());
 
-    unsigned NarrowBitWidth = L->getMemoryVT().getSizeInBits();
+    unsigned NarrowBitWidth =
+        static_cast<unsigned>(L->getMemoryVT().getSizeInBits());
     if (NarrowBitWidth % 8 != 0)
       return std::nullopt;
     uint64_t NarrowByteWidth = NarrowBitWidth / 8;
@@ -15341,7 +15383,8 @@ calculateByteProvider(const SDValue &Op, unsigned Index, unsigned Depth,
     auto VecIdx = IdxOp->getZExtValue();
     auto ScalarSize = Op.getScalarValueSizeInBits();
     if (ScalarSize < 32)
-      Index = ScalarSize == 8 ? VecIdx : VecIdx * 2 + Index;
+      Index =
+          static_cast<unsigned>(ScalarSize == 8 ? VecIdx : VecIdx * 2 + Index);
     return calculateSrcByte(ScalarSize >= 32 ? Op : Op.getOperand(0),
                             StartingIndex, Index);
   }
@@ -15482,12 +15525,14 @@ static SDValue getDWordFromOffset(SelectionDAG &DAG, SDLoc SL, SDValue Src,
                                 : NumElements - NormalizedTrunc;
 
     SmallVector<SDValue, 4> VecSrcs;
-    DAG.ExtractVectorElements(Src, VecSrcs, DWordOffset * NumElementsIn32,
-                              NumAvailElements);
+    DAG.ExtractVectorElements(
+        Src, VecSrcs, static_cast<unsigned>(DWordOffset * NumElementsIn32),
+        static_cast<unsigned>(NumAvailElements));
 
     Ret = DAG.getBuildVector(
-        MVT::getVectorVT(MVT::getIntegerVT(ScalarTySize), NumAvailElements), SL,
-        VecSrcs);
+        MVT::getVectorVT(MVT::getIntegerVT(static_cast<unsigned>(ScalarTySize)),
+                         static_cast<unsigned>(NumAvailElements)),
+        SL, VecSrcs);
     return Ret = DAG.getBitcastedAnyExtOrTrunc(Ret, SL, MVT::i32);
   }
 
@@ -15518,7 +15563,8 @@ static SDValue matchPERM(SDNode *N, TargetLowering::DAGCombinerInfo &DCI) {
   if (PermNodes.size() != 4)
     return SDValue();
 
-  std::pair<unsigned, unsigned> FirstSrc(0, PermNodes[0].SrcOffset / 4);
+  std::pair<unsigned, unsigned> FirstSrc(
+      0, static_cast<unsigned>(PermNodes[0].SrcOffset / 4));
   std::optional<std::pair<unsigned, unsigned>> SecondSrc;
   uint64_t PermMask = 0x00000000;
   for (size_t i = 0; i < PermNodes.size(); i++) {
@@ -15537,7 +15583,8 @@ static SDValue matchPERM(SDNode *N, TargetLowering::DAGCombinerInfo &DCI) {
           return SDValue();
 
       // Set the index of the second distinct Src node
-      SecondSrc = {i, PermNodes[i].SrcOffset / 4};
+      SecondSrc = {static_cast<unsigned>(i),
+                   static_cast<unsigned>(PermNodes[i].SrcOffset / 4)};
       assert(!(PermNodes[SecondSrc->first].Src->getValueSizeInBits() % 8));
       SrcByteAdjust = 0;
     }
@@ -15632,7 +15679,8 @@ SDValue SITargetLowering::performOrCombine(SDNode *N,
   if (isa<ConstantSDNode>(RHS) && LHS.hasOneUse() &&
       LHS.getOpcode() == AMDGPUISD::PERM &&
       isa<ConstantSDNode>(LHS.getOperand(2))) {
-    uint32_t Sel = getConstantPermuteMask(N->getConstantOperandVal(1));
+    uint32_t Sel = getConstantPermuteMask(
+        static_cast<uint32_t>(N->getConstantOperandVal(1)));
     if (!Sel)
       return SDValue();
 
@@ -15896,12 +15944,13 @@ SITargetLowering::performZeroOrAnyExtendCombine(SDNode *N,
   uint32_t PermMask = 0x0c0c0c0c;
   if (V0) {
     V0 = DAG.getBitcastedAnyExtOrTrunc(V0, DL, MVT::i32);
-    PermMask = (PermMask & ~0xFF) | (BP0->SrcOffset + 4);
+    PermMask = static_cast<uint32_t>((PermMask & ~0xFF) | (BP0->SrcOffset + 4));
   }
 
   if (V1) {
     V1 = DAG.getBitcastedAnyExtOrTrunc(V1, DL, MVT::i32);
-    PermMask = (PermMask & ~(0xFF << 8)) | (BP1->SrcOffset << 8);
+    PermMask = static_cast<uint32_t>((PermMask & ~(0xFF << 8)) |
+                                     (BP1->SrcOffset << 8));
   }
 
   return DAG.getNode(AMDGPUISD::PERM, DL, MVT::i32, V0, V1,
@@ -16201,7 +16250,7 @@ bool SITargetLowering::isCanonicalized(SelectionDAG &DAG, SDValue Op,
     return false;
   }
   case ISD::INTRINSIC_WO_CHAIN: {
-    unsigned IntrinsicID = Op.getConstantOperandVal(0);
+    unsigned IntrinsicID = static_cast<unsigned>(Op.getConstantOperandVal(0));
     // TODO: Handle more intrinsics
     switch (IntrinsicID) {
     case Intrinsic::amdgcn_cvt_pkrtz:
@@ -16710,7 +16759,8 @@ SDValue SITargetLowering::performMinMaxCombine(SDNode *N,
       sd_match(Op0,
                m_IntrinsicWOChain<Intrinsic::amdgcn_sffbh>(m_Value(FfbhSrc))) &&
       sd_match(Op1, m_ConstInt(Clamp))) {
-    unsigned BitWidth = FfbhSrc.getValueType().getScalarSizeInBits();
+    unsigned BitWidth =
+        static_cast<unsigned>(FfbhSrc.getValueType().getScalarSizeInBits());
     if (Clamp >= BitWidth) {
       KnownBits Known = DAG.computeKnownBits(FfbhSrc);
       if (Known.isNonZero() && Known.Zero.getBoolValue())
@@ -16893,7 +16943,7 @@ bool SITargetLowering::shouldExpandVectorDynExt(SDNode *N) const {
   SDValue Vec = N->getOperand(0);
   EVT VecVT = Vec.getValueType();
   EVT EltVT = VecVT.getVectorElementType();
-  unsigned EltSize = EltVT.getSizeInBits();
+  unsigned EltSize = static_cast<unsigned>(EltVT.getSizeInBits());
   unsigned NumElem = VecVT.getVectorNumElements();
 
   return SITargetLowering::shouldExpandVectorDynExt(
@@ -16910,8 +16960,8 @@ SITargetLowering::performExtractVectorEltCombine(SDNode *N,
   EVT VecEltVT = VecVT.getVectorElementType();
   EVT ResVT = N->getValueType(0);
 
-  unsigned VecSize = VecVT.getSizeInBits();
-  unsigned VecEltSize = VecEltVT.getSizeInBits();
+  unsigned VecSize = static_cast<unsigned>(VecVT.getSizeInBits());
+  unsigned VecEltSize = static_cast<unsigned>(VecEltVT.getSizeInBits());
 
   if ((Vec.getOpcode() == ISD::FNEG || Vec.getOpcode() == ISD::FABS) &&
       allUsesHaveSourceMods(N)) {
@@ -17033,7 +17083,7 @@ SITargetLowering::performExtractVectorEltCombine(SDNode *N,
       VecSize > 32 && VecSize % 32 == 0 && Idx) {
     EVT NewVT = getEquivalentMemType(*DAG.getContext(), VecVT);
 
-    unsigned BitIndex = Idx->getZExtValue() * VecEltSize;
+    unsigned BitIndex = static_cast<unsigned>(Idx->getZExtValue() * VecEltSize);
     unsigned EltIdx = BitIndex / 32;
     unsigned LeftoverBitIdx = BitIndex % 32;
     SDLoc SL(N);
@@ -17283,7 +17333,7 @@ SDValue SITargetLowering::tryFoldToMad64_32(SDNode *N,
   if (!N->isDivergent() && Subtarget->hasSMulHi())
     return SDValue();
 
-  unsigned NumBits = VT.getScalarSizeInBits();
+  unsigned NumBits = static_cast<unsigned>(VT.getScalarSizeInBits());
   if (NumBits <= 32 || NumBits > 64)
     return SDValue();
 
@@ -17500,7 +17550,8 @@ static void placeSources(ByteProvider<SDValue> &Src0,
 
       auto *Match = llvm::find_if(Srcs, MatchesFirst);
       if (Match != Srcs.end()) {
-        Match->PermMask = addPermMasks(FirstMask, Match->PermMask);
+        Match->PermMask = addPermMasks(static_cast<unsigned>(FirstMask),
+                                       static_cast<unsigned>(Match->PermMask));
         FirstGroup = I;
         break;
       }
@@ -17513,7 +17564,8 @@ static void placeSources(ByteProvider<SDValue> &Src0,
       };
       auto *Match = llvm::find_if(Srcs, MatchesSecond);
       if (Match != Srcs.end()) {
-        Match->PermMask = addPermMasks(SecondMask, Match->PermMask);
+        Match->PermMask = addPermMasks(static_cast<unsigned>(SecondMask),
+                                       static_cast<unsigned>(Match->PermMask));
       } else
         Srcs.push_back({*BPP.second.Src, SecondMask, BPP.second.SrcOffset / 4});
       return;
@@ -17543,7 +17595,8 @@ static SDValue resolveSources(SelectionDAG &DAG, SDLoc SL,
   // If we just have one source, just permute it accordingly.
   if (Srcs.size() == 1) {
     auto *Elt = Srcs.begin();
-    auto EltOp = getDWordFromOffset(DAG, SL, Elt->SrcOp, Elt->DWordOffset);
+    auto EltOp = getDWordFromOffset(DAG, SL, Elt->SrcOp,
+                                    static_cast<unsigned>(Elt->DWordOffset));
 
     // v_perm will produce the original value
     if (Elt->PermMask == 0x3020100)
@@ -17565,16 +17618,18 @@ static SDValue resolveSources(SelectionDAG &DAG, SDLoc SL,
     auto SecondMask = SecondElt->PermMask;
 
     unsigned FirstCs = FirstMask & 0x0c0c0c0c;
-    unsigned FirstPlusFour = FirstMask | 0x04040404;
+    unsigned FirstPlusFour = static_cast<unsigned>(FirstMask | 0x04040404);
     // 0x0c + 0x04 = 0x10, so anding with 0x0F will produced 0x00 for any
     // original 0x0C.
     FirstMask = (FirstPlusFour & 0x0F0F0F0F) | FirstCs;
 
-    auto PermMask = addPermMasks(FirstMask, SecondMask);
-    auto FirstVal =
-        getDWordFromOffset(DAG, SL, FirstElt->SrcOp, FirstElt->DWordOffset);
+    auto PermMask = addPermMasks(static_cast<unsigned>(FirstMask),
+                                 static_cast<unsigned>(SecondMask));
+    auto FirstVal = getDWordFromOffset(
+        DAG, SL, FirstElt->SrcOp, static_cast<unsigned>(FirstElt->DWordOffset));
     auto SecondVal =
-        getDWordFromOffset(DAG, SL, SecondElt->SrcOp, SecondElt->DWordOffset);
+        getDWordFromOffset(DAG, SL, SecondElt->SrcOp,
+                           static_cast<unsigned>(SecondElt->DWordOffset));
 
     Perms.push_back(DAG.getNode(AMDGPUISD::PERM, SL, MVT::i32, FirstVal,
                                 SecondVal,
@@ -17589,7 +17644,8 @@ static SDValue resolveSources(SelectionDAG &DAG, SDLoc SL,
     // source node.
     if (SecondElt == Srcs.end()) {
       auto EltOp =
-          getDWordFromOffset(DAG, SL, FirstElt->SrcOp, FirstElt->DWordOffset);
+          getDWordFromOffset(DAG, SL, FirstElt->SrcOp,
+                             static_cast<unsigned>(FirstElt->DWordOffset));
 
       Perms.push_back(
           DAG.getNode(AMDGPUISD::PERM, SL, MVT::i32, EltOp, EltOp,
@@ -17808,7 +17864,7 @@ SDValue SITargetLowering::performAddCombine(SDNode *N,
           UniqueEntries = false;
           break;
         }
-        SrcBytes.push_back(NextByte);
+        SrcBytes.push_back(static_cast<unsigned>(NextByte));
       }
 
       if (UniqueEntries) {
@@ -17816,11 +17872,13 @@ SDValue SITargetLowering::performAddCombine(SDNode *N,
 
         auto *FirstElt = Src0s.begin();
         auto FirstEltOp =
-            getDWordFromOffset(DAG, SL, FirstElt->SrcOp, FirstElt->DWordOffset);
+            getDWordFromOffset(DAG, SL, FirstElt->SrcOp,
+                               static_cast<unsigned>(FirstElt->DWordOffset));
 
         auto *SecondElt = Src1s.begin();
-        auto SecondEltOp = getDWordFromOffset(DAG, SL, SecondElt->SrcOp,
-                                              SecondElt->DWordOffset);
+        auto SecondEltOp =
+            getDWordFromOffset(DAG, SL, SecondElt->SrcOp,
+                               static_cast<unsigned>(SecondElt->DWordOffset));
 
         Src0 = DAG.getBitcastedAnyExtOrTrunc(FirstEltOp, SL,
                                              MVT::getIntegerVT(32));
@@ -18030,7 +18088,8 @@ SDValue SITargetLowering::performSubCombine(SDNode *N,
       if (SignExt.getOpcode() == ISD::SRA && SignExt.getOperand(0) == X) {
         ConstantSDNode *ShiftAmt =
             dyn_cast<ConstantSDNode>(SignExt.getOperand(1));
-        unsigned BitWidth = X.getValueType().getScalarSizeInBits();
+        unsigned BitWidth =
+            static_cast<unsigned>(X.getValueType().getScalarSizeInBits());
         if (ShiftAmt && ShiftAmt->getZExtValue() == BitWidth - 1)
           return DAG.getNode(ISD::CTLS, SL, VT, X);
       }
@@ -18777,9 +18836,9 @@ SITargetLowering::performCvtF32UByteNCombine(SDNode *N,
 
       unsigned ShiftOffset = 8 * Offset;
       if (Shift.getOpcode() == ISD::SHL)
-        ShiftOffset -= C->getZExtValue();
+        ShiftOffset -= static_cast<unsigned>(C->getZExtValue());
       else
-        ShiftOffset += C->getZExtValue();
+        ShiftOffset += static_cast<unsigned>(C->getZExtValue());
 
       if (ShiftOffset < 32 && (ShiftOffset % 8) == 0) {
         return DAG.getNode(AMDGPUISD::CVT_F32_UBYTE0 + ShiftOffset / 8, SL,
@@ -19105,7 +19164,8 @@ SDNode *SITargetLowering::adjustWritemask(MachineSDNode *&Node,
   unsigned Lane = 0;
   unsigned DmaskIdx =
       AMDGPU::getNamedOperandIdx(Opcode, AMDGPU::OpName::dmask) - 1;
-  unsigned OldDmask = Node->getConstantOperandVal(DmaskIdx);
+  unsigned OldDmask =
+      static_cast<unsigned>(Node->getConstantOperandVal(DmaskIdx));
   unsigned NewDmask = 0;
   unsigned TFEIdx = AMDGPU::getNamedOperandIdx(Opcode, AMDGPU::OpName::tfe) - 1;
   unsigned LWEIdx = AMDGPU::getNamedOperandIdx(Opcode, AMDGPU::OpName::lwe) - 1;
@@ -19143,7 +19203,7 @@ SDNode *SITargetLowering::adjustWritemask(MachineSDNode *&Node,
     // Note that subregs are packed, i.e. Lane==0 is the first bit set
     // in OldDmask, so it can be any of X,Y,Z,W; Lane==1 is the second bit
     // set, etc.
-    Lane = SubIdx2Lane(User->getConstantOperandVal(1));
+    Lane = SubIdx2Lane(static_cast<unsigned>(User->getConstantOperandVal(1)));
     if (Lane == ~0u)
       return Node;
 
@@ -19422,9 +19482,9 @@ void SITargetLowering::AddMemOpInit(MachineInstr &MI) const {
     if (!TFE && !LWE) // intersect_ray
       return;
 
-    unsigned TFEVal = TFE ? TFE->getImm() : 0;
-    unsigned LWEVal = LWE ? LWE->getImm() : 0;
-    unsigned D16Val = D16 ? D16->getImm() : 0;
+    unsigned TFEVal = static_cast<unsigned>(TFE ? TFE->getImm() : 0);
+    unsigned LWEVal = static_cast<unsigned>(LWE ? LWE->getImm() : 0);
+    unsigned D16Val = static_cast<unsigned>(D16 ? D16->getImm() : 0);
 
     if (!TFEVal && !LWEVal)
       return;
@@ -19439,7 +19499,7 @@ void SITargetLowering::AddMemOpInit(MachineInstr &MI) const {
     // check that dmask operand is found.
     assert(MO_Dmask && "Expected dmask operand in instruction");
 
-    unsigned dmask = MO_Dmask->getImm();
+    unsigned dmask = static_cast<unsigned>(MO_Dmask->getImm());
     // Determine the number of active lanes taking into account the
     // Gather4 special case
     unsigned ActiveLanes = TII->isGather4(MI) ? 4 : llvm::popcount(dmask);
@@ -19453,12 +19513,12 @@ void SITargetLowering::AddMemOpInit(MachineInstr &MI) const {
     // reported correctly.
     const TargetRegisterClass *DstRC = TII->getRegClass(MI.getDesc(), DstIdx);
 
-    uint32_t DstSize = TRI.getRegSizeInBits(*DstRC) / 32;
+    uint32_t DstSize = static_cast<uint32_t>(TRI.getRegSizeInBits(*DstRC) / 32);
     if (DstSize < InitIdx)
       return;
   } else if (TII->isMUBUF(MI) && AMDGPU::getMUBUFTfe(MI.getOpcode())) {
     const TargetRegisterClass *DstRC = TII->getRegClass(MI.getDesc(), DstIdx);
-    InitIdx = TRI.getRegSizeInBits(*DstRC) / 32;
+    InitIdx = static_cast<unsigned>(TRI.getRegSizeInBits(*DstRC) / 32);
   } else {
     return;
   }
@@ -19618,7 +19678,7 @@ SITargetLowering::getRegForInlineAsmConstraint(const TargetRegisterInfo *TRI_,
     // (size 0): `call void asm "", "v"({} poison)`-
     if (VT == MVT::Other)
       return TargetLowering::getRegForInlineAsmConstraint(TRI, Constraint, VT);
-    const unsigned BitWidth = VT.getSizeInBits();
+    const unsigned BitWidth = static_cast<unsigned>(VT.getSizeInBits());
     switch (Constraint[0]) {
     default:
       return TargetLowering::getRegForInlineAsmConstraint(TRI, Constraint, VT);
@@ -19673,7 +19733,7 @@ SITargetLowering::getRegForInlineAsmConstraint(const TargetRegisterInfo *TRI_,
       break;
     }
   } else if (Constraint == "VA" && Subtarget->hasGFX90AInsts()) {
-    const unsigned BitWidth = VT.getSizeInBits();
+    const unsigned BitWidth = static_cast<unsigned>(VT.getSizeInBits());
     switch (BitWidth) {
     case 16:
       RC = &AMDGPU::AV_32RegClass;
@@ -19805,7 +19865,8 @@ void SITargetLowering::LowerAsmOperandForConstraint(SDValue Op,
     uint64_t Val;
     if (getAsmOperandConstVal(Op, Val) &&
         checkAsmConstraintVal(Op, Constraint, Val)) {
-      Val = clearUnusedBits(Val, Op.getScalarValueSizeInBits());
+      Val = clearUnusedBits(
+          Val, static_cast<unsigned>(Op.getScalarValueSizeInBits()));
       Ops.push_back(DAG.getTargetConstant(Val, SDLoc(Op), MVT::i64));
     }
   } else {
@@ -19814,7 +19875,7 @@ void SITargetLowering::LowerAsmOperandForConstraint(SDValue Op,
 }
 
 bool SITargetLowering::getAsmOperandConstVal(SDValue Op, uint64_t &Val) const {
-  unsigned Size = Op.getScalarValueSizeInBits();
+  unsigned Size = static_cast<unsigned>(Op.getScalarValueSizeInBits());
   if (Size > 64)
     return false;
 
@@ -19860,7 +19921,8 @@ bool SITargetLowering::checkAsmConstraintVal(SDValue Op, StringRef Constraint,
     case 'B':
       return isInt<32>(Val);
     case 'C':
-      return isUInt<32>(clearUnusedBits(Val, Op.getScalarValueSizeInBits())) ||
+      return isUInt<32>(clearUnusedBits(
+                 Val, static_cast<unsigned>(Op.getScalarValueSizeInBits()))) ||
              AMDGPU::isInlinableIntLiteral(Val);
     default:
       break;
@@ -19881,7 +19943,8 @@ bool SITargetLowering::checkAsmConstraintVal(SDValue Op, StringRef Constraint,
 
 bool SITargetLowering::checkAsmConstraintValA(SDValue Op, uint64_t Val,
                                               unsigned MaxSize) const {
-  unsigned Size = std::min<unsigned>(Op.getScalarValueSizeInBits(), MaxSize);
+  unsigned Size = std::min<unsigned>(
+      static_cast<unsigned>(Op.getScalarValueSizeInBits()), MaxSize);
   bool HasInv2Pi = Subtarget->hasInv2PiInlineImm();
   if (Size == 16) {
     MVT VT = Op.getSimpleValueType();
@@ -19889,20 +19952,27 @@ bool SITargetLowering::checkAsmConstraintValA(SDValue Op, uint64_t Val,
     default:
       return false;
     case MVT::i16:
-      return AMDGPU::isInlinableLiteralI16(Val, HasInv2Pi);
+      return AMDGPU::isInlinableLiteralI16(static_cast<int32_t>(Val),
+                                           HasInv2Pi);
     case MVT::f16:
-      return AMDGPU::isInlinableLiteralFP16(Val, HasInv2Pi);
+      return AMDGPU::isInlinableLiteralFP16(static_cast<int16_t>(Val),
+                                            HasInv2Pi);
     case MVT::bf16:
-      return AMDGPU::isInlinableLiteralBF16(Val, HasInv2Pi);
+      return AMDGPU::isInlinableLiteralBF16(static_cast<int16_t>(Val),
+                                            HasInv2Pi);
     case MVT::v2i16:
-      return AMDGPU::getInlineEncodingV2I16(Val).has_value();
+      return AMDGPU::getInlineEncodingV2I16(static_cast<uint32_t>(Val))
+          .has_value();
     case MVT::v2f16:
-      return AMDGPU::getInlineEncodingV2F16(Val).has_value();
+      return AMDGPU::getInlineEncodingV2F16(static_cast<uint32_t>(Val))
+          .has_value();
     case MVT::v2bf16:
-      return AMDGPU::getInlineEncodingV2BF16(Val).has_value();
+      return AMDGPU::getInlineEncodingV2BF16(static_cast<uint32_t>(Val))
+          .has_value();
     }
   }
-  if ((Size == 32 && AMDGPU::isInlinableLiteral32(Val, HasInv2Pi)) ||
+  if ((Size == 32 &&
+       AMDGPU::isInlinableLiteral32(static_cast<int32_t>(Val), HasInv2Pi)) ||
       (Size == 64 && AMDGPU::isInlinableLiteral64(Val, HasInv2Pi)))
     return true;
   return false;
@@ -20033,7 +20103,7 @@ void SITargetLowering::computeKnownBitsForTargetNode(const SDValue Op,
   unsigned Opc = Op.getOpcode();
   switch (Opc) {
   case ISD::INTRINSIC_WO_CHAIN: {
-    unsigned IID = Op.getConstantOperandVal(0);
+    unsigned IID = static_cast<unsigned>(Op.getConstantOperandVal(0));
     switch (IID) {
     case Intrinsic::amdgcn_mbcnt_lo:
     case Intrinsic::amdgcn_mbcnt_hi: {
@@ -20081,12 +20151,12 @@ static void knownBitsForSBFE(const MachineInstr &MI, GISelValueTracking &VT,
 
   unsigned Src1Cst = 0;
   if (Src1.isImm()) {
-    Src1Cst = Src1.getImm();
+    Src1Cst = static_cast<unsigned>(Src1.getImm());
   } else if (Src1.isReg()) {
     auto Cst = getIConstantVRegValWithLookThrough(Src1.getReg(), MRI);
     if (!Cst)
       return;
-    Src1Cst = Cst->Value.getZExtValue();
+    Src1Cst = static_cast<unsigned>(Cst->Value.getZExtValue());
   } else {
     return;
   }
@@ -20265,7 +20335,7 @@ Align SITargetLowering::getPrefLoopAlignment(MachineLoop *ML) const {
     // If inner loop block is aligned assume in average half of the alignment
     // size to be added as nops.
     if (MBB != Header)
-      LoopSize += MBB->getAlignment().value() / 2;
+      LoopSize += static_cast<unsigned>(MBB->getAlignment().value() / 2);
 
     for (const MachineInstr &MI : *MBB) {
       LoopSize += TII->getInstSizeInBytes(MI);
@@ -20375,9 +20445,11 @@ bool SITargetLowering::isSDNodeSourceOfDivergence(const SDNode *N,
   case ISD::CALLSEQ_END:
     return true;
   case ISD::INTRINSIC_WO_CHAIN:
-    return AMDGPU::isIntrinsicSourceOfDivergence(N->getConstantOperandVal(0));
+    return AMDGPU::isIntrinsicSourceOfDivergence(
+        static_cast<unsigned>(N->getConstantOperandVal(0)));
   case ISD::INTRINSIC_W_CHAIN:
-    return AMDGPU::isIntrinsicSourceOfDivergence(N->getConstantOperandVal(1));
+    return AMDGPU::isIntrinsicSourceOfDivergence(
+        static_cast<unsigned>(N->getConstantOperandVal(1)));
   case AMDGPUISD::ATOMIC_CMP_SWAP:
   case AMDGPUISD::BUFFER_ATOMIC_SWAP:
   case AMDGPUISD::BUFFER_ATOMIC_ADD:

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.h
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.h
@@ -382,8 +382,9 @@ public:
       unsigned *IsFast = nullptr) const override {
     if (IsFast)
       *IsFast = 0;
-    return allowsMisalignedMemoryAccessesImpl(Ty.getSizeInBits(), AddrSpace,
-                                              Alignment, Flags, IsFast);
+    return allowsMisalignedMemoryAccessesImpl(
+        static_cast<unsigned>(Ty.getSizeInBits()), AddrSpace, Alignment, Flags,
+        IsFast);
   }
 
   bool allowsMisalignedMemoryAccesses(


### PR DESCRIPTION
For context, see https://github.com/llvm/llvm-project/issues/215213

This patch handles the following cases:

EVT::getSizeInBits(), getScalarSizeInBits(), getStoreSize() and
getValueSizeInBits() return TypeSize and are assigned to 32-bit locals holding
type and element widths. Add a static_cast to make the existing narrowing
conversion explicit. AMDGPU has no scalable vector types, so these are all
fixed-width and the value is a type width of at most 1024.

ConstantSDNode::getZExtValue() and getSExtValue() return uint64_t and int64_t
and are assigned to 32-bit locals holding intrinsic operands, offsets, lane
indices and address spaces. Add a static_cast to make the existing narrowing
conversion explicit.

Register values are passed to CCState::AllocateReg, MachineFunction::addLiveIn
and the argument-lowering helpers, which take MCPhysReg (uint16_t). Add a
static_cast. These are the ABI argument and special-purpose input registers,
physical by construction: they come from SIMachineFunctionInfo's ABI register
assignments and from the calling-convention tables, not from virtual register
operands.

Container size() returns size_t and is assigned to unsigned locals holding
operand, argument and return-value counts. Add a static_cast to make the
existing narrowing conversion explicit.

The synchronisation-scope name lookup result is assigned to SyncScope::ID, which
is uint8_t. Add a static_cast; SyncScope::ID is an LLVM-wide typedef and the
AMDGPU scopes are a handful of registered names.

This is the largest patch in the series by warning count, but every case falls
into one of the shapes above; there is no site here that needed a different kind
of fix.

This fixes 191 instances of MSVC warning C4244 and 13 of C4267 ("possible loss
of data") in llvm/lib/Target/AMDGPU/SIISelLowering.{cpp,h}.

Assisted-by: Claude <noreply@anthropic.com>
