### PR TITLE
[GlobalISel][NFC] Explicitly narrow conversions in two combine rules

### DIFF
--- a/llvm/include/llvm/Target/GlobalISel/Combine.td
+++ b/llvm/include/llvm/Target/GlobalISel/Combine.td
@@ -276,7 +276,9 @@ def sext_inreg_to_zext_inreg : GICombineRule<
       [{
         unsigned BitWidth = MRI.getType(${src}.getReg()).getScalarSizeInBits();
         return Helper.getValueTracking()->maskedValueIsZero(${src}.getReg(),
-                 APInt::getOneBitSet(BitWidth, ${imm}.getImm() - 1)); }]),
+                 APInt::getOneBitSet(
+                     BitWidth,
+                     static_cast<unsigned>(${imm}.getImm() - 1))); }]),
     (apply [{
       Helper.getBuilder().setInstrAndDebugLoc(*${root});
       Helper.getBuilder().buildZExtInReg(${dst}, ${src}, ${imm}.getImm());
@@ -995,7 +997,7 @@ def merge_unmerge : GICombineRule<
              return false;
 
            // Check counts match.
-           unsigned NumMergeSrcs = ${merge_srcs}.size();
+           unsigned NumMergeSrcs = static_cast<unsigned>(${merge_srcs}.size());
            unsigned NumUnmergeDefs = UnmergeMI->getNumDefs();
            if (NumMergeSrcs != NumUnmergeDefs)
              return false;


### PR DESCRIPTION
This patch handles the following cases:

In sext_inreg_to_zext_inreg, MachineOperand::getImm() returns int64_t while
APInt::getOneBitSet takes an unsigned bit number. Add a static_cast to make the
existing narrowing conversion explicit. The value is a G_SEXT_INREG immediate,
which is a bit position within the scalar type whose width was read into
BitWidth on the line above, so it cannot exceed unsigned.

In merge_unmerge, the variadic operand list ${merge_srcs} expands to
getRemainingOperands(*State.MIs[0], 1), which returns ArrayRef<MachineOperand>
(GIMatchTableExecutor.h), so .size() is size_t and is assigned to an unsigned
local. Add a static_cast to make the existing narrowing conversion explicit. The
value is a MachineInstr operand count, which is itself unsigned
(MachineInstr::getNumOperands), so it cannot exceed unsigned.

Both conversions are therefore NFC.

This patch changes the C++ match code of GICombineRules, which is copied by
TableGen verbatim into the generated combiner tables. It is a shared file, so it
regenerates the GICombiner tables of every target that uses these rules rather
than just one backend; that is why it is a separate patch from the AMDGPU .td
changes.

This fixes 2 instances of MSVC warning C4244 and 2 of C4267 ("possible loss of
data"). They are reported in the generated tables rather than in hand-written
sources: AMDGPUGenPreLegalizeGICombiner.inc and
AMDGPUGenPostLegalizeGICombiner.inc, from 2 source lines emitted into 2 tables.

Assisted-by: Claude <noreply@anthropic.com>
