### PR TITLE
[TableGen][NFC] Explicitly narrow ULEB128 values in generated decodeInstruction

### DIFF
--- a/llvm/test/TableGen/DecoderEmitter/DecoderEmitterBitwidthSpecialization.td
+++ b/llvm/test/TableGen/DecoderEmitter/DecoderEmitterBitwidthSpecialization.td
@@ -131,7 +131,8 @@ def Inst3 : Instruction16Bit<3> {
 
 // CHECK-SPECIALIZE-NO-TABLE-LABEL:   template <typename InsnType>
 // CHECK-SPECIALIZE-NO-TABLE-NEXT:    decodeInstruction
-// CHECK-SPECIALIZE-NO-TABLE:         uint32_t BitWidth = decodeULEB128AndIncUnsafe(Ptr);
+// CHECK-SPECIALIZE-NO-TABLE:         uint32_t BitWidth =
+// CHECK-SPECIALIZE-NO-TABLE-NEXT:    static_cast<uint32_t>(decodeULEB128AndIncUnsafe(Ptr));
 // CHECK-SPECIALIZE-NO-TABLE-NEXT:    assert(InsnBitWidth<InsnType> == BitWidth &&
 
 // -----------------------------------------------------------------------------
@@ -185,5 +186,6 @@ def Inst3 : Instruction16Bit<3> {
 
 // CHECK-SPECIALIZE-TABLE-LABEL:    template <typename InsnType>
 // CHECK-SPECIALIZE-TABLE-NEXT:     decodeInstruction
-// CHECK-SPECIALIZE-TABLE:          uint32_t BitWidth = decodeULEB128AndIncUnsafe(Ptr);
+// CHECK-SPECIALIZE-TABLE:          uint32_t BitWidth =
+// CHECK-SPECIALIZE-TABLE-NEXT:     static_cast<uint32_t>(decodeULEB128AndIncUnsafe(Ptr));
 // CHECK-SPECIALIZE-TABLE-NEXT:     assert(InsnBitWidth<InsnType> == BitWidth &&

--- a/llvm/utils/TableGen/DecoderEmitter.cpp
+++ b/llvm/utils/TableGen/DecoderEmitter.cpp
@@ -1081,7 +1081,8 @@ static DecodeStatus decodeInstruction(const uint8_t DecodeTable[], MCInst &MI,
     // Fail with a fatal error if decoder table's bitwidth does not match
     // `InsnType` bitwidth.
     OS << R"(
-  [[maybe_unused]] uint32_t BitWidth = decodeULEB128AndIncUnsafe(Ptr);
+  [[maybe_unused]] uint32_t BitWidth =
+      static_cast<uint32_t>(decodeULEB128AndIncUnsafe(Ptr));
   assert(InsnBitWidth<InsnType> == BitWidth &&
          "Table and instruction bitwidth mismatch");
 )";
@@ -1099,7 +1100,8 @@ static DecodeStatus decodeInstruction(const uint8_t DecodeTable[], MCInst &MI,
              << (int)DecoderOp << '\n';
       return MCDisassembler::Fail;
     case OPC_Scope: {
-      unsigned NumToSkip = decodeULEB128AndIncUnsafe(Ptr);
+      unsigned NumToSkip =
+          static_cast<unsigned>(decodeULEB128AndIncUnsafe(Ptr));
       const uint8_t *SkipTo = Ptr + NumToSkip;
       ScopeStack.push_back(SkipTo);
       LLVM_DEBUG(dbgs() << Loc << ": OPC_Scope(" << SkipTo - DecodeTable
@@ -1108,7 +1110,7 @@ static DecodeStatus decodeInstruction(const uint8_t DecodeTable[], MCInst &MI,
     }
     case OPC_SwitchField: {
       // Decode the start value.
-      unsigned Start = decodeULEB128AndIncUnsafe(Ptr);
+      unsigned Start = static_cast<unsigned>(decodeULEB128AndIncUnsafe(Ptr));
       unsigned Len = *Ptr++;)";
   if (IsVarLenInst)
     OS << "\n      makeUp(insn, Start + Len);";
@@ -1118,7 +1120,7 @@ static DecodeStatus decodeInstruction(const uint8_t DecodeTable[], MCInst &MI,
       unsigned CaseSize;
       while (true) {
         CaseValue = decodeULEB128AndIncUnsafe(Ptr);
-        CaseSize = decodeULEB128AndIncUnsafe(Ptr);
+        CaseSize = static_cast<unsigned>(decodeULEB128AndIncUnsafe(Ptr));
         if (FieldValue == CaseValue || !CaseSize)
           break;
         Ptr += CaseSize;
@@ -1132,7 +1134,7 @@ static DecodeStatus decodeInstruction(const uint8_t DecodeTable[], MCInst &MI,
     }
     case OPC_CheckField: {
       // Decode the start value.
-      unsigned Start = decodeULEB128AndIncUnsafe(Ptr);
+      unsigned Start = static_cast<unsigned>(decodeULEB128AndIncUnsafe(Ptr));
       unsigned Len = *Ptr;)";
   if (IsVarLenInst)
     OS << "\n      makeUp(insn, Start + Len);";
@@ -1156,7 +1158,7 @@ static DecodeStatus decodeInstruction(const uint8_t DecodeTable[], MCInst &MI,
     OS << R"(
     case OPC_CheckPredicate: {
       // Decode the Predicate Index value.
-      unsigned PIdx = decodeULEB128AndIncUnsafe(Ptr);
+      unsigned PIdx = static_cast<unsigned>(decodeULEB128AndIncUnsafe(Ptr));
       // Check the predicate.
       bool Failed = !checkDecoderPredicate(PIdx, Bits);
 
@@ -1170,8 +1172,9 @@ static DecodeStatus decodeInstruction(const uint8_t DecodeTable[], MCInst &MI,
   OS << R"(
     case OPC_Decode: {
       // Decode the Opcode value.
-      unsigned Opc = decodeULEB128AndIncUnsafe(Ptr);
-      unsigned DecodeIdx = decodeULEB128AndIncUnsafe(Ptr);
+      unsigned Opc = static_cast<unsigned>(decodeULEB128AndIncUnsafe(Ptr));
+      unsigned DecodeIdx =
+          static_cast<unsigned>(decodeULEB128AndIncUnsafe(Ptr));
 
       MI.clear();
       MI.setOpcode(Opc);


### PR DESCRIPTION
This patch handles the following case:

decodeULEB128AndIncUnsafe returns uint64_t, and the decodeInstruction function
emitted by the TableGen disassembler backend assigns that result to locals
declared unsigned or uint32_t. Add a static_cast at each of the eight sites to
make the existing narrowing conversion explicit.

The narrow declarations are deliberate and the values are bounded at
table-construction time, so the conversions are NFC:

  BitWidth    is compared against InsnBitWidth<InsnType>, a uint32_t
  Opc         feeds MCInst::setOpcode(unsigned), bounded by the instr count
  Start       feeds fieldFromInstruction(insn, unsigned Start, unsigned Len)
  NumToSkip,
  CaseSize,
  DecodeIdx   are offsets into the decoder table, bounded by its size
  PIdx        indexes the predicate list

Widening the locals to uint64_t instead was considered and rejected: it does not
remove the conversions, it moves them one line down to the APIs listed above.
Supporting evidence that the narrow declarations are intentional is that
PositiveMask and NegativeMask in the same emitted function are already declared
uint64_t and produce no warning; the two values that genuinely are 64-bit
quantities were declared correctly and the rest are narrow by design.

BitWidth gets static_cast<uint32_t> rather than static_cast<unsigned> to match
its own declared type and InsnBitWidth<InsnType>.

This patch changes the string literals in the TableGen disassembler backend
(DecoderEmitter.cpp), so it regenerates *GenDisassemblerTables.inc for every
target.

This fixes 8 instances of MSVC warning C4244 ("possible loss of data") reported
in AMDGPUGenDisassemblerTables.inc, and the corresponding instances in every
other target's disassembler tables. All 8 are in the emitted decodeInstruction
function and are independent of the decoder callback signatures, which are
per-target and are the subject of a separate patch.

NumToSkip and DecodeIdx are emitted across two lines because the single-line
form is 81 columns once the cast is added. This changes the emitted text that
DecoderEmitterBitwidthSpecialization.td pins, so its CHECK lines are updated.

Assisted-by: Claude <noreply@anthropic.com>
