### PR TITLE
[clang][LoongArch] Match GCC ABI handling of integer complex types

### DIFF
--- a/clang/lib/CodeGen/Targets/LoongArch.cpp
+++ b/clang/lib/CodeGen/Targets/LoongArch.cpp
@@ -135,6 +135,12 @@ bool LoongArchABIInfo::detectFARsEligibleStructHelper(
     if (Field1Ty)
       return false;
     QualType EltTy = CTy->getElementType();
+    // Only floating-point complex types (e.g. _Complex float/double) are
+    // eligible to be passed in floating-point argument registers. Complex
+    // integer types (a GNU extension) should be treated like a normal
+    // aggregate and packed into GARs instead.
+    if (!EltTy->isRealFloatingType())
+      return false;
     if (getContext().getTypeSize(EltTy) > FRLen)
       return false;
     Field1Ty = CGT.ConvertType(EltTy);

--- a/clang/test/CodeGen/LoongArch/abi-lp64d.c
+++ b/clang/test/CodeGen/LoongArch/abi-lp64d.c
@@ -501,6 +501,34 @@ struct doublecomplex_s f_doublecomplex_s(struct doublecomplex_s x) {
   return x;
 }
 
+/// A complex integer, or a structure containing just one complex integer
+/// (a GNU extension), is not eligible to be passed in floating-point
+/// registers; it is passed as though it were an aggregate of the same
+/// size, i.e. packed into a single GAR when its size does not exceed
+/// GRLen.
+
+// CHECK-LABEL: define{{.*}} i64 @f_ucharcomplex(i64 %x.coerce)
+unsigned char __complex__ f_ucharcomplex(unsigned char __complex__ x) { return x; }
+
+// CHECK-LABEL: define{{.*}} i64 @f_ushortcomplex(i64 %x.coerce)
+unsigned short __complex__ f_ushortcomplex(unsigned short __complex__ x) { return x; }
+
+struct ucharcomplex_s {
+  unsigned char __complex__ c;
+};
+// CHECK-LABEL: define{{.*}} i64 @f_ucharcomplex_s(i64 %x.coerce)
+struct ucharcomplex_s f_ucharcomplex_s(struct ucharcomplex_s x) {
+  return x;
+}
+
+struct ushortcomplex_s {
+  unsigned short __complex__ c;
+};
+// CHECK-LABEL: define{{.*}} i64 @f_ushortcomplex_s(i64 %x.coerce)
+struct ushortcomplex_s f_ushortcomplex_s(struct ushortcomplex_s x) {
+  return x;
+}
+
 /// Part 5: Variadic arguments.
 
 /// Variadic arguments are passed in GARs in the same manner as named arguments.


### PR DESCRIPTION
GNU integer complex types such as `_Complex unsigned char` and `_Complex unsigned short` were incorrectly recognized as eligible floating-point ABI aggregates by `detectFARsEligibleStructHelper`. When used as a member of a structure, this caused the real and imaginary parts to be expanded into separate general-purpose argument registers.

Integer complex types are not floating-point complex types and should be handled as ordinary aggregates. Restrict the complex-type expansion path to elements with real floating-point types, allowing small integer complex aggregates to be packed into a single general-purpose register, consistent with GCC.

Fixes #214810