### PR TITLE
[analyzer][z3] Fix SMTConstraintManager.h removeDeadBindings

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SMTConstraintManager.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SMTConstraintManager.h
@@ -244,8 +244,7 @@ public:
 
     while (WorkList.size()) {
       SymbolRef Item = WorkList.pop_back_val();
-      auto &SymConstraints = ConstraintsBySym[Item];
-      for (auto Idx : SymConstraints) {
+      for (auto Idx : ConstraintsBySym[Item]) {
         if (RetainedConstraints.test(Idx))
           continue;
 

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SMTConstraintManager.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SMTConstraintManager.h
@@ -226,8 +226,8 @@ public:
 
   ProgramStateRef removeDeadBindings(ProgramStateRef State,
                                      SymbolReaper &SymReaper) override {
-    auto CZ = State->get<ConstraintSMT>();
-    auto &CZFactory = State->get_context<ConstraintSMT>();
+    ConstraintSMTType CZ = State->get<ConstraintSMT>();
+    ConstraintSMTType::Factory &CZFactory = State->get_context<ConstraintSMT>();
     llvm::SmallVector<ConstraintEntry> Constraints(CZ.begin(), CZ.end());
     llvm::DenseMap<SymbolRef, SmallVector<size_t>> ConstraintsBySym;
     llvm::DenseSet<SymbolRef> TraversedSymbols;

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SMTConstraintManager.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SMTConstraintManager.h
@@ -231,7 +231,7 @@ public:
     llvm::SmallVector<ConstraintEntry> Constraints(CZ.begin(), CZ.end());
     llvm::DenseMap<SymbolRef, SmallVector<size_t>> ConstraintsBySym;
     llvm::DenseSet<SymbolRef> TraversedSymbols;
-    SmallVector<SymbolRef> WorkList;
+    llvm::SmallVector<SymbolRef> WorkList;
     llvm::BitVector RelevantConstraints(Constraints.size());
 
     for (size_t Idx = 0; Idx < Constraints.size(); ++Idx) {

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SMTConstraintManager.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SMTConstraintManager.h
@@ -232,7 +232,7 @@ public:
     llvm::DenseMap<SymbolRef, SmallVector<size_t>> ConstraintsBySym;
     llvm::DenseSet<SymbolRef> TraversedSymbols;
     llvm::SmallVector<SymbolRef> WorkList;
-    llvm::BitVector RelevantConstraints(Constraints.size());
+    llvm::BitVector RetainedConstraints(Constraints.size());
 
     for (size_t Idx = 0; Idx < Constraints.size(); ++Idx) {
       for (auto Symbol : Constraints[Idx].first->symbols()) {
@@ -246,10 +246,10 @@ public:
       SymbolRef Item = WorkList.pop_back_val();
       auto &SymConstraints = ConstraintsBySym[Item];
       for (auto Idx : SymConstraints) {
-        if (RelevantConstraints.test(Idx))
+        if (RetainedConstraints.test(Idx))
           continue;
 
-        RelevantConstraints.set(Idx);
+        RetainedConstraints.set(Idx);
 
         for (auto Symbol : Constraints[Idx].first->symbols()) {
           if (TraversedSymbols.insert(Symbol).second)
@@ -259,7 +259,7 @@ public:
     }
 
     for (size_t Idx = 0; Idx < Constraints.size(); ++Idx) {
-      if (!RelevantConstraints.test(Idx))
+      if (!RetainedConstraints.test(Idx))
         CZ = CZFactory.remove(CZ, Constraints[Idx]);
     }
 

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SMTConstraintManager.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SMTConstraintManager.h
@@ -19,6 +19,9 @@
 #include "clang/StaticAnalyzer/Core/PathSensitive/BasicValueFactory.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/RangedConstraintManager.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/SMTConv.h"
+#include "llvm/ADT/BitVector.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
 #include <optional>
 
 typedef llvm::ImmutableSet<
@@ -30,6 +33,7 @@ namespace clang {
 namespace ento {
 
 class SMTConstraintManager : public clang::ento::SimpleConstraintManager {
+  using ConstraintEntry = std::pair<SymbolRef, const llvm::SMTExpr *>;
   mutable llvm::SMTSolverRef Solver = llvm::CreateZ3Solver();
 
 public:
@@ -224,10 +228,39 @@ public:
                                      SymbolReaper &SymReaper) override {
     auto CZ = State->get<ConstraintSMT>();
     auto &CZFactory = State->get_context<ConstraintSMT>();
+    llvm::SmallVector<ConstraintEntry> Constraints(CZ.begin(), CZ.end());
+    llvm::DenseMap<SymbolRef, SmallVector<size_t>> ConstraintsBySym;
+    llvm::DenseSet<SymbolRef> TraversedSymbols;
+    SmallVector<SymbolRef> WorkList;
+    llvm::BitVector RelevantConstraints(Constraints.size());
 
-    for (const auto &Entry : CZ) {
-      if (SymReaper.isDead(Entry.first))
-        CZ = CZFactory.remove(CZ, Entry);
+    for (size_t Idx = 0; Idx < Constraints.size(); ++Idx) {
+      for (auto Symbol : Constraints[Idx].first->symbols()) {
+        if (SymReaper.isLive(Symbol) && TraversedSymbols.insert(Symbol).second)
+          WorkList.push_back(Symbol);
+        ConstraintsBySym[Symbol].push_back(Idx);
+      }
+    }
+
+    while (WorkList.size()) {
+      SymbolRef Item = WorkList.pop_back_val();
+      auto &SymConstraints = ConstraintsBySym[Item];
+      for (auto Idx : SymConstraints) {
+        if (RelevantConstraints.test(Idx))
+          continue;
+
+        RelevantConstraints.set(Idx);
+
+        for (auto Symbol : Constraints[Idx].first->symbols()) {
+          if (TraversedSymbols.insert(Symbol).second)
+            WorkList.push_back(Symbol);
+        }
+      }
+    }
+
+    for (size_t Idx = 0; Idx < Constraints.size(); ++Idx) {
+      if (!RelevantConstraints.test(Idx))
+        CZ = CZFactory.remove(CZ, Constraints[Idx]);
     }
 
     return State->set<ConstraintSMT>(CZ);

--- a/clang/test/Analysis/z3/z3-constraint-liveness.c
+++ b/clang/test/Analysis/z3/z3-constraint-liveness.c
@@ -1,0 +1,13 @@
+// RUN: %clang_analyze_cc1 \
+// RUN:   -analyzer-checker=core,debug.ExprInspection \
+// RUN:   -analyzer-constraints=unsupported-z3 -verify %s
+// REQUIRES: z3
+
+void clang_analyzer_eval(int);
+
+void transitive_constraints(int a, int b, int c) {
+  if (a != b && b == c && c == 42) {
+    clang_analyzer_eval(b == 42); // expected-warning{{TRUE}}
+    clang_analyzer_eval(a != 42); // expected-warning{{TRUE}}
+  }
+}

--- a/clang/test/Analysis/z3/z3-constraint-liveness.c
+++ b/clang/test/Analysis/z3/z3-constraint-liveness.c
@@ -5,7 +5,7 @@
 
 void clang_analyzer_eval(int);
 
-void transitive_constraints(int a, int b, int c) {
+void indirect_constraints(int a, int b, int c) {
   if (a != b && b == c && c == 42) {
     clang_analyzer_eval(b == 42); // expected-warning{{TRUE}}
     clang_analyzer_eval(a != 42); // expected-warning{{TRUE}}


### PR DESCRIPTION
removeDeadBindings did not properly keep track of constraint dependencies, causing still-in-use constraints to be incorrectly removed.

This PR stops constraints that are indirectly related to a live symbol from being removed by removeDeadBindings.

CC: @steakhal

Assisted-by: Codex