### PR TITLE
[CAS][test] Fix the plugin CAS tests in mingw builds

### DIFF
--- a/llvm/unittests/CAS/CASTestConfig.cpp
+++ b/llvm/unittests/CAS/CASTestConfig.cpp
@@ -35,6 +35,9 @@ std::string unittest::cas::getCASPluginPath() {
 #ifndef _WIN32
   std::string LibName = "libCASPluginTest";
   sys::path::append(PathBuf, "lib", LibName + LLVM_PLUGIN_EXT);
+#elif defined(__MINGW32__)
+  std::string LibName = "libCASPluginTest";
+  sys::path::append(PathBuf, "bin", LibName + LLVM_PLUGIN_EXT);
 #else
   std::string LibName = "CASPluginTest";
   sys::path::append(PathBuf, "bin", LibName + LLVM_PLUGIN_EXT);


### PR DESCRIPTION
In mingw build configurations, the plugin is named libCASTestPlugin.dll, while it resides in the bin directory.