### PR TITLE
[VPlan] Expand negated add operands as a subtract in VPSCEVExpander.

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
@@ -864,11 +864,10 @@ VPValue *VPSCEVExpander::tryToExpand(const SCEV *S) {
     return Builder.getPlan().getOrAddLiveIn(cast<SCEVUnknown>(S)->getValue());
   case scVScale:
     return Builder.createVScale(S->getType(), DL);
-  case scAddExpr:
-  case scMulExpr: {
-    auto *NAry = cast<SCEVNAryExpr>(S);
-    VPIRFlags::WrapFlagsTy WrapFlags(NAry->hasNoUnsignedWrap(),
-                                     NAry->hasNoSignedWrap());
+  case scAddExpr: {
+    auto *AddE = cast<SCEVAddExpr>(S);
+    VPIRFlags::WrapFlagsTy WrapFlags(AddE->hasNoUnsignedWrap(),
+                                     AddE->hasNoSignedWrap());
 
     // Expanded poiner SCEVAddExpr as a ptradd of the pointer base and the
     // integer offset, matching SCEVExpander.
@@ -885,22 +884,18 @@ VPValue *VPSCEVExpander::tryToExpand(const SCEV *S) {
       return Builder.createNoWrapPtrAdd(Base, Offset, GEPFlags, DL);
     }
 
-    bool IsAdd = isa<SCEVAddExpr>(S);
-    unsigned Opcode = IsAdd ? Instruction::Add : Instruction::Mul;
     // Non-constant-negative add operands are expanded negated and subtracted
     // from the running result below, instead of being negated and added.
-    auto UseSubtract = [IsAdd](const SCEV *Op) {
-      return IsAdd && Op->isNonConstantNegative();
+    auto UseSubtract = [](const SCEV *Op) {
+      return Op->isNonConstantNegative();
     };
     // Iterate in reverse so that constants are emitted last, and move the
     // subtracted operands last, matching SCEVExpander's LoopCompare, so that
     // they don't start the running result.
-    SmallVector<const SCEV *, 2> SCEVOps(reverse(NAry->operands()));
-    if (IsAdd) {
-      stable_sort(SCEVOps, [&](const SCEV *L, const SCEV *R) {
-        return !UseSubtract(L) && UseSubtract(R);
-      });
-    }
+    SmallVector<const SCEV *, 2> SCEVOps(reverse(AddE->operands()));
+    stable_sort(SCEVOps, [&](const SCEV *L, const SCEV *R) {
+      return !UseSubtract(L) && UseSubtract(R);
+    });
     SmallVector<VPValue *, 2> Ops;
     for (const SCEV *Op : SCEVOps) {
       // The first operand starts the result, so it is never subtracted.
@@ -922,8 +917,26 @@ VPValue *VPSCEVExpander::tryToExpand(const SCEV *S) {
                                              {/*HasNUW=*/false, HasNSW}, DL);
         continue;
       }
-      Result =
-          Builder.createOverflowingOp(Opcode, {Result, OpV}, WrapFlags, DL);
+      Result = Builder.createOverflowingOp(Instruction::Add, {Result, OpV},
+                                           WrapFlags, DL);
+    }
+    return Result;
+  }
+  case scMulExpr: {
+    auto *MulE = cast<SCEVMulExpr>(S);
+    VPIRFlags::WrapFlagsTy WrapFlags(MulE->hasNoUnsignedWrap(),
+                                     MulE->hasNoSignedWrap());
+    SmallVector<VPValue *, 2> Ops;
+    for (const SCEV *Op : reverse(MulE->operands())) {
+      VPValue *OpV = tryToExpand(Op);
+      if (!OpV)
+        return nullptr;
+      Ops.push_back(OpV);
+    }
+    VPValue *Result = Ops.front();
+    for (VPValue *OpV : drop_begin(Ops)) {
+      Result = Builder.createOverflowingOp(Instruction::Mul, {Result, OpV},
+                                           WrapFlags, DL);
     }
     return Result;
   }

--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
@@ -889,7 +889,8 @@ VPValue *VPSCEVExpander::tryToExpand(const SCEV *S) {
     unsigned Opcode = IsAdd ? Instruction::Add : Instruction::Mul;
     // Iterate in reverse so that constants are emitted last. For adds, sort
     // non-constant-negative operands last, matching SCEVExpander's LoopCompare,
-    // so that they are accumulated into the result rather than starting it.
+    // so that they are negated and subtracted from the running result rather
+    // than starting it.
     SmallVector<const SCEV *, 2> SCEVOps(reverse(NAry->operands()));
     if (IsAdd)
       stable_sort(SCEVOps, [](const SCEV *L, const SCEV *R) {
@@ -897,14 +898,28 @@ VPValue *VPSCEVExpander::tryToExpand(const SCEV *S) {
       });
     SmallVector<VPValue *, 2> Ops;
     for (const SCEV *Op : SCEVOps) {
-      VPValue *OpV = tryToExpand(Op);
+      // Expand the negation of the operands that are subtracted below.
+      bool Negate = IsAdd && !Ops.empty() && Op->isNonConstantNegative();
+      VPValue *OpV = tryToExpand(Negate ? SE.getNegativeSCEV(Op) : Op);
       if (!OpV)
         return nullptr;
       Ops.push_back(OpV);
     }
     VPValue *Result = Ops.front();
-    for (VPValue *Op : drop_begin(Ops))
-      Result = Builder.createOverflowingOp(Opcode, {Result, Op}, WrapFlags, DL);
+    for (auto [Op, OpV] : drop_begin(zip_equal(SCEVOps, Ops))) {
+      if (IsAdd && Op->isNonConstantNegative()) {
+        // Result + (-Op) = Result - Op unless negating Op overflows. This saves
+        // a extra multiply for the negation and allows carrying over the NSW
+        // flag from the SCEV expression.
+        bool HasNSW =
+            WrapFlags.HasNSW && !SE.getSignedRangeMin(Op).isMinSignedValue();
+        Result = Builder.createOverflowingOp(Instruction::Sub, {Result, OpV},
+                                             {/*HasNUW=*/false, HasNSW}, DL);
+      } else {
+        Result =
+            Builder.createOverflowingOp(Opcode, {Result, OpV}, WrapFlags, DL);
+      }
+    }
     return Result;
   }
   case scUDivExpr: {

--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
@@ -887,19 +887,24 @@ VPValue *VPSCEVExpander::tryToExpand(const SCEV *S) {
 
     bool IsAdd = isa<SCEVAddExpr>(S);
     unsigned Opcode = IsAdd ? Instruction::Add : Instruction::Mul;
-    // Iterate in reverse so that constants are emitted last. For adds, sort
-    // non-constant-negative operands last, matching SCEVExpander's LoopCompare,
-    // so that they are negated and subtracted from the running result rather
-    // than starting it.
+    // Non-constant-negative add operands are expanded negated and subtracted
+    // from the running result below, instead of being negated and added.
+    auto UseSubtract = [IsAdd](const SCEV *Op) {
+      return IsAdd && Op->isNonConstantNegative();
+    };
+    // Iterate in reverse so that constants are emitted last, and move the
+    // subtracted operands last, matching SCEVExpander's LoopCompare, so that
+    // they don't start the running result.
     SmallVector<const SCEV *, 2> SCEVOps(reverse(NAry->operands()));
-    if (IsAdd)
-      stable_sort(SCEVOps, [](const SCEV *L, const SCEV *R) {
-        return !L->isNonConstantNegative() && R->isNonConstantNegative();
+    if (IsAdd) {
+      stable_sort(SCEVOps, [&](const SCEV *L, const SCEV *R) {
+        return !UseSubtract(L) && UseSubtract(R);
       });
+    }
     SmallVector<VPValue *, 2> Ops;
     for (const SCEV *Op : SCEVOps) {
-      // Expand the negation of the operands that are subtracted below.
-      bool Negate = IsAdd && !Ops.empty() && Op->isNonConstantNegative();
+      // The first operand starts the result, so it is never subtracted.
+      bool Negate = !Ops.empty() && UseSubtract(Op);
       VPValue *OpV = tryToExpand(Negate ? SE.getNegativeSCEV(Op) : Op);
       if (!OpV)
         return nullptr;
@@ -907,18 +912,18 @@ VPValue *VPSCEVExpander::tryToExpand(const SCEV *S) {
     }
     VPValue *Result = Ops.front();
     for (auto [Op, OpV] : drop_begin(zip_equal(SCEVOps, Ops))) {
-      if (IsAdd && Op->isNonConstantNegative()) {
-        // Result + (-Op) = Result - Op unless negating Op overflows. This saves
-        // a extra multiply for the negation and allows carrying over the NSW
-        // flag from the SCEV expression.
+      if (UseSubtract(Op)) {
+        // Result + (-Op) == Result - Op, which saves the multiply for the
+        // negation. NSW only transfers if negating Op cannot overflow, see
+        // ScalarEvolution::getMinusSCEV.
         bool HasNSW =
             WrapFlags.HasNSW && !SE.getSignedRangeMin(Op).isMinSignedValue();
         Result = Builder.createOverflowingOp(Instruction::Sub, {Result, OpV},
                                              {/*HasNUW=*/false, HasNSW}, DL);
-      } else {
-        Result =
-            Builder.createOverflowingOp(Opcode, {Result, OpV}, WrapFlags, DL);
+        continue;
       }
+      Result =
+          Builder.createOverflowingOp(Opcode, {Result, OpV}, WrapFlags, DL);
     }
     return Result;
   }

--- a/llvm/test/Transforms/LoopVectorize/VPlan/expand-scev.ll
+++ b/llvm/test/Transforms/LoopVectorize/VPlan/expand-scev.ll
@@ -294,7 +294,7 @@ define i32 @mul_by_signed_min_expanded_to_shl(i1 %a) {
 ; CHECK-NEXT:    IR   %sub = sub i32 %rem.neg, 1
 ; CHECK-NEXT:    IR   %shl = shl i32 %sub, 31
 ; CHECK-NEXT:    EMIT vp<[[VP2:%[0-9]+]]> = shl nuw ir<%rem.neg>, ir<31>
-; CHECK-NEXT:    EMIT vp<[[VP3:%[0-9]+]]> = add ir<-2147483547>, vp<[[VP2]]>
+; CHECK-NEXT:    EMIT vp<[[VP3:%[0-9]+]]> = sub ir<-2147483547>, vp<[[VP2]]>
 ; CHECK-NEXT:    EMIT vp<%min.iters.check> = icmp ult vp<[[VP3]]>, ir<4>
 ; CHECK-NEXT:    EMIT branch-on-cond vp<%min.iters.check>
 ; CHECK-NEXT:  Successor(s): ir-bb<scalar.ph>, vector.ph

--- a/llvm/test/Transforms/LoopVectorize/VPlan/expand-scev.ll
+++ b/llvm/test/Transforms/LoopVectorize/VPlan/expand-scev.ll
@@ -657,6 +657,38 @@ exit:
   ret void
 }
 
+; The trip count is (-1 * %x) + (-3 * %y), i.e. all operands are non-constant
+; negative. The first operand starts the running result, so it must not be
+; expanded negated, even though it is subtracted from below.
+define void @scev_add_all_operands_negative(ptr %dst, i64 %x, i64 %y) mustprogress {
+; CHECK-LABEL: VPlan for loop in 'scev_add_all_operands_negative'
+; CHECK:  VPlan 'Final VPlan for VF={4},UF={1}' {
+; CHECK-EMPTY:
+; CHECK-NEXT:  ir-bb<entry>:
+; CHECK-NEXT:    IR   %end = mul i64 %y, -3
+; CHECK-NEXT:    EMIT vp<[[VP2:%[0-9]+]]> = sub ir<0>, ir<%x>
+; CHECK-NEXT:    EMIT vp<[[VP3:%[0-9]+]]> = mul ir<%y>, ir<3>
+; CHECK-NEXT:    EMIT vp<[[VP4:%[0-9]+]]> = sub vp<[[VP2]]>, vp<[[VP3]]>
+; CHECK-NEXT:    EMIT vp<%min.iters.check> = icmp ult vp<[[VP4]]>, ir<4>
+; CHECK-NEXT:    EMIT branch-on-cond vp<%min.iters.check>
+; CHECK-NEXT:  Successor(s): ir-bb<scalar.ph>, vector.ph
+;
+entry:
+  %end = mul i64 %y, -3
+  br label %loop
+
+loop:
+  %iv = phi i64 [ %x, %entry ], [ %iv.next, %loop ]
+  %gep = getelementptr i32, ptr %dst, i64 %iv
+  store i32 0, ptr %gep, align 4
+  %iv.next = add nsw i64 %iv, 1
+  %ec = icmp eq i64 %iv.next, %end
+  br i1 %ec, label %exit, label %loop
+
+exit:
+  ret void
+}
+
 !0 = distinct !{!0, !1, !2}
 !1 = !{!"llvm.loop.vectorize.scalable.enable"}
 !2 = !{!"llvm.loop.vectorize.width", i32 4}

--- a/llvm/test/Transforms/LoopVectorize/cast-induction.ll
+++ b/llvm/test/Transforms/LoopVectorize/cast-induction.ll
@@ -422,10 +422,8 @@ define i64 @induction_cast_chain_cleared_by_dce(i64 %n, i64 %mask.init) {
 ; VF4-NEXT:    [[TMP3:%.*]] = add nuw nsw i64 [[MASK]], 1
 ; VF4-NEXT:    [[TMP0:%.*]] = add nuw nsw i64 [[MASK]], 2
 ; VF4-NEXT:    [[TMP2:%.*]] = call i64 @llvm.smax.i64(i64 [[N]], i64 [[TMP0]])
-; VF4-NEXT:    [[TMP21:%.*]] = lshr i64 [[MASK_INIT]], 32
-; VF4-NEXT:    [[TMP22:%.*]] = mul i64 [[TMP21]], -4294967296
 ; VF4-NEXT:    [[TMP23:%.*]] = add i64 [[TMP2]], -1
-; VF4-NEXT:    [[TMP1:%.*]] = add i64 [[TMP23]], [[TMP22]]
+; VF4-NEXT:    [[TMP1:%.*]] = sub i64 [[TMP23]], [[MASK]]
 ; VF4-NEXT:    [[MIN_ITERS_CHECK:%.*]] = icmp ult i64 [[TMP1]], 4
 ; VF4-NEXT:    br i1 [[MIN_ITERS_CHECK]], label %[[SCALAR_PH:.*]], label %[[VECTOR_SCEVCHECK:.*]]
 ; VF4:       [[VECTOR_SCEVCHECK]]:
@@ -492,10 +490,8 @@ define i64 @induction_cast_chain_cleared_by_dce(i64 %n, i64 %mask.init) {
 ; IC2-NEXT:    [[TMP3:%.*]] = add nuw nsw i64 [[MASK]], 1
 ; IC2-NEXT:    [[TMP0:%.*]] = add nuw nsw i64 [[MASK]], 2
 ; IC2-NEXT:    [[TMP2:%.*]] = call i64 @llvm.smax.i64(i64 [[N]], i64 [[TMP0]])
-; IC2-NEXT:    [[TMP23:%.*]] = lshr i64 [[MASK_INIT]], 32
-; IC2-NEXT:    [[TMP24:%.*]] = mul i64 [[TMP23]], -4294967296
 ; IC2-NEXT:    [[TMP25:%.*]] = add i64 [[TMP2]], -1
-; IC2-NEXT:    [[TMP1:%.*]] = add i64 [[TMP25]], [[TMP24]]
+; IC2-NEXT:    [[TMP1:%.*]] = sub i64 [[TMP25]], [[MASK]]
 ; IC2-NEXT:    [[MIN_ITERS_CHECK:%.*]] = icmp ult i64 [[TMP1]], 2
 ; IC2-NEXT:    br i1 [[MIN_ITERS_CHECK]], label %[[SCALAR_PH:.*]], label %[[VECTOR_SCEVCHECK:.*]]
 ; IC2:       [[VECTOR_SCEVCHECK]]:

--- a/llvm/test/Transforms/LoopVectorize/hoist-and-sink-mem-ops-with-invariant-pointers.ll
+++ b/llvm/test/Transforms/LoopVectorize/hoist-and-sink-mem-ops-with-invariant-pointers.ll
@@ -212,8 +212,8 @@ define void @load_store_noalias_via_tbaa(ptr %p, ptr %q, ptr %n) {
 ; CHECK-NEXT:    [[P6:%.*]] = ptrtoaddr ptr [[P]] to i64
 ; CHECK-NEXT:    [[N5:%.*]] = ptrtoaddr ptr [[N]] to i64
 ; CHECK-NEXT:    [[TMP17:%.*]] = mul i64 [[N5]], 3074457345618258603
-; CHECK-NEXT:    [[TMP1:%.*]] = mul i64 [[P6]], -3074457345618258603
-; CHECK-NEXT:    [[TMP2:%.*]] = add i64 [[TMP17]], [[TMP1]]
+; CHECK-NEXT:    [[TMP1:%.*]] = mul i64 [[P6]], 3074457345618258603
+; CHECK-NEXT:    [[TMP2:%.*]] = sub i64 [[TMP17]], [[TMP1]]
 ; CHECK-NEXT:    [[TMP3:%.*]] = lshr i64 [[TMP2]], 2
 ; CHECK-NEXT:    [[TMP4:%.*]] = add nuw nsw i64 [[TMP3]], 1
 ; CHECK-NEXT:    [[MIN_ITERS_CHECK:%.*]] = icmp ult i64 [[TMP4]], 4

--- a/llvm/test/Transforms/LoopVectorize/nested-loops-scev-expansion.ll
+++ b/llvm/test/Transforms/LoopVectorize/nested-loops-scev-expansion.ll
@@ -128,13 +128,12 @@ define void @pr49900(i32 %x, ptr %ptr) {
 ; CHECK-NEXT:    [[TMP30:%.*]] = add i32 [[IV_1]], [[TMP17]]
 ; CHECK-NEXT:    [[TMP18:%.*]] = add i32 [[TMP30]], 26
 ; CHECK-NEXT:    [[UMAX:%.*]] = call i32 @llvm.umax.i32(i32 [[TMP18]], i32 65536)
-; CHECK-NEXT:    [[TMP31:%.*]] = mul i32 [[TMP16]], -13
 ; CHECK-NEXT:    [[TMP34:%.*]] = add i32 [[UMAX]], -26
 ; CHECK-NEXT:    [[TMP20:%.*]] = sub i32 [[TMP34]], [[IV_1]]
-; CHECK-NEXT:    [[TMP33:%.*]] = add i32 [[TMP20]], [[TMP31]]
+; CHECK-NEXT:    [[TMP33:%.*]] = sub i32 [[TMP20]], [[TMP17]]
 ; CHECK-NEXT:    [[UMIN1:%.*]] = call i32 @llvm.umin.i32(i32 [[TMP33]], i32 1)
 ; CHECK-NEXT:    [[TMP23:%.*]] = sub i32 [[TMP20]], [[UMIN1]]
-; CHECK-NEXT:    [[TMP32:%.*]] = add i32 [[TMP23]], [[TMP31]]
+; CHECK-NEXT:    [[TMP32:%.*]] = sub i32 [[TMP23]], [[TMP17]]
 ; CHECK-NEXT:    [[TMP25:%.*]] = udiv i32 [[TMP32]], 13
 ; CHECK-NEXT:    [[TMP35:%.*]] = add i32 [[UMIN1]], [[TMP25]]
 ; CHECK-NEXT:    [[TMP26:%.*]] = add i32 [[TMP35]], 1

--- a/llvm/test/Transforms/LoopVectorize/trip-count-expansion-may-introduce-ub.ll
+++ b/llvm/test/Transforms/LoopVectorize/trip-count-expansion-may-introduce-ub.ll
@@ -985,8 +985,8 @@ define i64 @multi_exit_4_exit_count_with_urem_by_constant_in_latch(ptr %dst, i64
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[SMAX:%.*]] = call i64 @llvm.smax.i64(i64 [[N]], i64 0)
 ; CHECK-NEXT:    [[TMP4:%.*]] = udiv i64 [[N]], 42
-; CHECK-NEXT:    [[TMP5:%.*]] = mul i64 [[TMP4]], -42
-; CHECK-NEXT:    [[TMP6:%.*]] = add i64 [[N]], [[TMP5]]
+; CHECK-NEXT:    [[TMP5:%.*]] = mul nuw i64 [[TMP4]], 42
+; CHECK-NEXT:    [[TMP6:%.*]] = sub i64 [[N]], [[TMP5]]
 ; CHECK-NEXT:    [[TMP0:%.*]] = call i64 @llvm.smax.i64(i64 [[TMP6]], i64 0)
 ; CHECK-NEXT:    [[UMIN:%.*]] = call i64 @llvm.umin.i64(i64 [[SMAX]], i64 [[TMP0]])
 ; CHECK-NEXT:    [[TMP1:%.*]] = add nuw i64 [[UMIN]], 1


### PR DESCRIPTION
Update VPSCEVExpander to try to expand adds of negative values as
subtract, instead of adding the negated operand. This matches IR
SCEVExpander behavior and improves expansions slightly.

It also avoids regressions when expanding more expressions.

Alive2 Proof: https://alive2.llvm.org/ce/z/Emgeqv

Depends on https://github.com/llvm/llvm-project/pull/215252 (included in PR)