### PR TITLE
[ORC] Reimplement EPCGenericDylibManager on RTBridge proxies

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/EPCGenericDylibManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/EPCGenericDylibManager.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Implements dylib loading and searching by making calls to
-// ExecutorProcessControl::callWrapper.
+// Implements dylib loading and searching by calling executor-side wrapper
+// functions through rt::Proxy objects.
 //
 // This simplifies the implementaton of new ExecutorProcessControl instances,
 // as this implementation will always work (at the cost of some performance
@@ -20,6 +20,7 @@
 
 #include "llvm/ExecutionEngine/Orc/DylibManager.h"
 #include "llvm/ExecutionEngine/Orc/ExecutorProcessControl.h"
+#include "llvm/ExecutionEngine/Orc/RTBridge/Proxy.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorSymbolDef.h"
 #include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
 #include "llvm/ExecutionEngine/Orc/Shared/SimpleRemoteEPCUtils.h"
@@ -33,11 +34,28 @@ class SymbolLookupSet;
 
 class LLVM_ABI EPCGenericDylibManager : public DylibManager {
 public:
-  /// Function addresses for memory access.
-  struct SymbolAddrs {
+  /// Proxy for the executor-side dylib-open function. Given the manager
+  /// instance address, a path and mode flags it returns a handle to the opened
+  /// dylib.
+  using OpenProxy = rt::Proxy<Expected<tpctypes::DylibHandle>(
+      ExecutorAddr, StringRef, uint64_t)>;
+
+  /// Proxy for the executor-side symbol-resolution function. Given the manager
+  /// instance address, a dylib handle and a lookup set it returns the resolved
+  /// addresses.
+  using ResolveProxy = rt::Proxy<Expected<tpctypes::LookupResult>(
+      ExecutorAddr, ExecutorAddr, SymbolLookupSet)>;
+
+  /// The resolved controller-side handle to an executor-side dylib manager: the
+  /// address of the manager instance (passed as the first argument to each
+  /// call) plus the proxies for its functions. These are protocol-agnostic: the
+  /// Create methods populate them for the runtime's SPS controller interface,
+  /// but a client targeting a different protocol can build its own Bindings and
+  /// pass them to the constructor.
+  struct Bindings {
     ExecutorAddr Instance;
-    ExecutorAddr Open;
-    ExecutorAddr Resolve;
+    OpenProxy Open;
+    ResolveProxy Resolve;
   };
 
   /// Create an EPCGenericDylibManager instance by looking up the LLVM-style
@@ -45,23 +63,19 @@ public:
   static Expected<EPCGenericDylibManager>
   CreateWithDefaultBootstrapSymbols(ExecutorProcessControl &EPC);
 
-  /// Create an EPCGenericDylibManager using the given implementation symbol
-  /// names. These will be looked up in the given JITDylib.
-  static Expected<EPCGenericDylibManager>
-  Create(JITDylib &JD, rt::SimpleExecutorDylibManagerSymbolNames SNs =
-                           rt::orc_rt_NativeDylibManagerSPSSymbols);
+  /// Create an EPCGenericDylibManager for the ORC runtime's NativeDylibManager
+  /// interface, resolving its symbols in the given JITDylib.
+  static Expected<EPCGenericDylibManager> Create(JITDylib &JD);
 
-  /// Create an EPCGenericDylibManager using the given implementation symbol
-  /// names. These will be looked up in the given ExecutionSession's bootstrap
+  /// Create an EPCGenericDylibManager for the ORC runtime's NativeDylibManager
+  /// interface, resolving its symbols in the given ExecutionSession's bootstrap
   /// JITDylib.
-  static Expected<EPCGenericDylibManager>
-  Create(ExecutionSession &ES, rt::SimpleExecutorDylibManagerSymbolNames SNs =
-                                   rt::orc_rt_NativeDylibManagerSPSSymbols);
+  static Expected<EPCGenericDylibManager> Create(ExecutionSession &ES);
 
-  /// Create an EPCGenericDylibManager instance from a given set of function
-  /// addrs.
-  EPCGenericDylibManager(ExecutorProcessControl &EPC, SymbolAddrs SAs)
-      : EPC(EPC), SAs(SAs) {}
+  /// Create an EPCGenericDylibManager instance from a given set of
+  /// dylib-manager bindings.
+  EPCGenericDylibManager(ExecutionSession &ES, Bindings B)
+      : ES(ES), B(std::move(B)) {}
 
   /// Loads the dylib with the given name.
   Expected<tpctypes::DylibHandle> open(StringRef Path, uint64_t Mode);
@@ -75,24 +89,11 @@ public:
     return RF.get();
   }
 
-  /// Looks up symbols within the given dylib.
-  Expected<tpctypes::LookupResult> lookup(tpctypes::DylibHandle H,
-                                          const RemoteSymbolLookupSet &Lookup) {
-    std::promise<MSVCPExpected<tpctypes::LookupResult>> RP;
-    auto RF = RP.get_future();
-    lookupAsync(H, Lookup, [&RP](auto R) { RP.set_value(std::move(R)); });
-    return RF.get();
-  }
-
   using SymbolLookupCompleteFn =
       unique_function<void(Expected<tpctypes::LookupResult>)>;
 
   /// Looks up symbols within the given dylib.
   void lookupAsync(tpctypes::DylibHandle H, const SymbolLookupSet &Lookup,
-                   SymbolLookupCompleteFn Complete);
-
-  /// Looks up symbols within the given dylib.
-  void lookupAsync(tpctypes::DylibHandle H, const RemoteSymbolLookupSet &Lookup,
                    SymbolLookupCompleteFn Complete);
 
   /// Load the dynamic library at the given path and return a handle to it.
@@ -106,8 +107,8 @@ public:
                      DylibManager::SymbolLookupCompleteFn Complete) override;
 
 private:
-  ExecutorProcessControl &EPC;
-  SymbolAddrs SAs;
+  ExecutionSession &ES;
+  Bindings B;
 };
 
 } // end namespace orc

--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h
@@ -64,18 +64,13 @@ struct SimpleExecutorMemoryManagerSymbolNames {
 extern const LLVM_ABI SimpleExecutorMemoryManagerSymbolNames
     orc_rt_SimpleNativeMemoryMapSPSSymbols;
 
-/// Symbol names for dylib management implementation.
-/// FIXME: We should find a better home for this struct.
-struct SimpleExecutorDylibManagerSymbolNames {
-  StringRef InstanceName;
-  StringRef OpenName;
-  StringRef ResolveName;
-};
-
-/// Default symbol names for the ORC runtime's NativeDylibManager SPS
-/// interface.
-extern const LLVM_ABI SimpleExecutorDylibManagerSymbolNames
-    orc_rt_NativeDylibManagerSPSSymbols;
+/// Symbol names for the ORC runtime's NativeDylibManager SPS interface.
+inline constexpr char NativeDylibManagerInstanceName[] =
+    "orc_rt_ci_NativeDylibManager_Instance";
+inline constexpr char NativeDylibManagerLoadWrapperName[] =
+    "orc_rt_ci_sps_NativeDylibManager_load";
+inline constexpr char NativeDylibManagerLookupWrapperName[] =
+    "orc_rt_ci_sps_NativeDylibManager_lookup";
 
 /// Symbol names for the ORC runtime's StandaloneMachOUnwindInfoRegistrar
 /// SPS interface.

--- a/llvm/lib/ExecutionEngine/Orc/EPCGenericDylibManager.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/EPCGenericDylibManager.cpp
@@ -10,6 +10,7 @@
 
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/LookupAndRecordAddrs.h"
+#include "llvm/ExecutionEngine/Orc/RTBridge/SPS/ProxySpecs.h"
 #include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
 #include "llvm/ExecutionEngine/Orc/Shared/SimpleRemoteEPCUtils.h"
 
@@ -17,6 +18,8 @@ namespace llvm {
 namespace orc {
 namespace shared {
 
+// Serialize a local SymbolLookupSet directly as an SPSRemoteSymbolLookupSet,
+// avoiding a std::string copy of each (potentially large) symbol name.
 template <>
 class SPSSerializationTraits<SPSRemoteSymbolLookupSetElement,
                              SymbolLookupSet::value_type> {
@@ -42,84 +45,72 @@ public:
 
 } // end namespace shared
 
+namespace {
+
+using OpenSpec =
+    rt::sps::ProxySpec<EPCGenericDylibManager::OpenProxy,
+                       rt::SPSSimpleExecutorDylibManagerOpenSignature,
+                       rt::NativeDylibManagerLoadWrapperName>;
+using ResolveSpec =
+    rt::sps::ProxySpec<EPCGenericDylibManager::ResolveProxy,
+                       rt::SPSSimpleExecutorDylibManagerResolveSignature,
+                       rt::NativeDylibManagerLookupWrapperName>;
+
+} // namespace
+
 Expected<EPCGenericDylibManager>
 EPCGenericDylibManager::CreateWithDefaultBootstrapSymbols(
     ExecutorProcessControl &EPC) {
-  SymbolAddrs SAs;
-  if (auto Err = EPC.getBootstrapSymbols(
-          {{SAs.Instance, rt::SimpleExecutorDylibManagerInstanceName},
-           {SAs.Open, rt::SimpleExecutorDylibManagerOpenWrapperName},
-           {SAs.Resolve, rt::SimpleExecutorDylibManagerResolveWrapperName}}))
-    return std::move(Err);
-  return EPCGenericDylibManager(EPC, std::move(SAs));
-}
-
-Expected<EPCGenericDylibManager>
-EPCGenericDylibManager::Create(JITDylib &JD,
-                               rt::SimpleExecutorDylibManagerSymbolNames SNs) {
-  auto &ES = JD.getExecutionSession();
-  SymbolAddrs SAs;
+  auto &ES = EPC.getExecutionSession();
+  auto &JD = ES.getBootstrapJITDylib();
+  Bindings B;
+  // Instance is the executor-side manager object -- a data symbol passed as the
+  // first argument to each call, not a wrapper to proxy.
   if (auto Err = lookupAndRecordAddrs(
           ES, LookupKind::Static, makeJITDylibSearchOrder({&JD}),
-          {
-              {ES.intern(SNs.InstanceName), &SAs.Instance},
-              {ES.intern(SNs.OpenName), &SAs.Open},
-              {ES.intern(SNs.ResolveName), &SAs.Resolve},
-          }))
+          {{ES.intern(rt::SimpleExecutorDylibManagerInstanceName),
+            &B.Instance}}))
     return std::move(Err);
-  return EPCGenericDylibManager(ES.getExecutorProcessControl(), std::move(SAs));
+  if (auto Err = rt::buildProxies(
+          JD,
+          rt::proxyInit<OpenSpec>(
+              &B.Open, rt::SimpleExecutorDylibManagerOpenWrapperName),
+          rt::proxyInit<ResolveSpec>(
+              &B.Resolve, rt::SimpleExecutorDylibManagerResolveWrapperName)))
+    return std::move(Err);
+  return EPCGenericDylibManager(ES, std::move(B));
+}
+
+Expected<EPCGenericDylibManager> EPCGenericDylibManager::Create(JITDylib &JD) {
+  auto &ES = JD.getExecutionSession();
+  Bindings B;
+  // Instance is the executor-side manager object -- a data symbol passed as the
+  // first argument to each call, not a wrapper to proxy.
+  if (auto Err = lookupAndRecordAddrs(
+          ES, LookupKind::Static, makeJITDylibSearchOrder({&JD}),
+          {{ES.intern(rt::NativeDylibManagerInstanceName), &B.Instance}}))
+    return std::move(Err);
+  // The proxies resolve to the specs' default (NativeDylibManager) names.
+  if (auto Err = rt::buildProxies(JD, rt::proxyInit<OpenSpec>(&B.Open),
+                                  rt::proxyInit<ResolveSpec>(&B.Resolve)))
+    return std::move(Err);
+  return EPCGenericDylibManager(ES, std::move(B));
 }
 
 Expected<EPCGenericDylibManager>
-EPCGenericDylibManager::Create(ExecutionSession &ES,
-                               rt::SimpleExecutorDylibManagerSymbolNames SNs) {
-  return Create(ES.getBootstrapJITDylib(), std::move(SNs));
+EPCGenericDylibManager::Create(ExecutionSession &ES) {
+  return Create(ES.getBootstrapJITDylib());
 }
 
 Expected<tpctypes::DylibHandle> EPCGenericDylibManager::open(StringRef Path,
                                                              uint64_t Mode) {
-  Expected<tpctypes::DylibHandle> H((ExecutorAddr()));
-  if (auto Err =
-          EPC.callSPSWrapper<rt::SPSSimpleExecutorDylibManagerOpenSignature>(
-              SAs.Open, H, SAs.Instance, Path, Mode))
-    return std::move(Err);
-  return H;
+  return B.Open(ES, B.Instance, Path, Mode);
 }
 
 void EPCGenericDylibManager::lookupAsync(tpctypes::DylibHandle H,
                                          const SymbolLookupSet &Lookup,
                                          SymbolLookupCompleteFn Complete) {
-  EPC.callSPSWrapperAsync<rt::SPSSimpleExecutorDylibManagerResolveSignature>(
-      SAs.Resolve,
-      [Complete = std::move(Complete)](
-          Error SerializationErr,
-          Expected<std::vector<std::optional<ExecutorAddr>>> Result) mutable {
-        if (SerializationErr) {
-          cantFail(Result.takeError());
-          Complete(std::move(SerializationErr));
-          return;
-        }
-        Complete(std::move(Result));
-      },
-      SAs.Instance, H, Lookup);
-}
-
-void EPCGenericDylibManager::lookupAsync(tpctypes::DylibHandle H,
-                                         const RemoteSymbolLookupSet &Lookup,
-                                         SymbolLookupCompleteFn Complete) {
-  EPC.callSPSWrapperAsync<rt::SPSSimpleExecutorDylibManagerResolveSignature>(
-      SAs.Resolve,
-      [Complete = std::move(Complete)](
-          Error SerializationErr,
-          Expected<std::vector<std::optional<ExecutorAddr>>> Result) mutable {
-        if (SerializationErr) {
-          cantFail(Result.takeError());
-          Complete(std::move(SerializationErr));
-          return;
-        }
-        Complete(std::move(Result));
-      },
-      SAs.Instance, H, Lookup);
+  B.Resolve(std::move(Complete), ES, B.Instance, H, Lookup);
 }
 
 Expected<tpctypes::DylibHandle>

--- a/llvm/lib/ExecutionEngine/Orc/Shared/OrcRTBridge.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Shared/OrcRTBridge.cpp
@@ -63,13 +63,6 @@ const SimpleExecutorMemoryManagerSymbolNames
         "orc_rt_ci_sps_SimpleNativeMemoryMap_releaseMultiple",
 };
 
-const SimpleExecutorDylibManagerSymbolNames
-    orc_rt_NativeDylibManagerSPSSymbols = {
-        "orc_rt_ci_NativeDylibManager_Instance",
-        "orc_rt_ci_sps_NativeDylibManager_load",
-        "orc_rt_ci_sps_NativeDylibManager_lookup",
-};
-
 const MachOUnwindInfoRegistrarSymbolNames
     orc_rt_MachOUnwindInfoRegistrarSPSSymbols = {
         "orc_rt_ci_aa_sps_MachOUnwindInfoRegistrar_registerSections",

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/SimpleExecutorDylibManager.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/SimpleExecutorDylibManager.cpp
@@ -75,18 +75,17 @@ void SimpleExecutorDylibManager::addBootstrapSymbols(
   M[rt::SimpleExecutorDylibManagerResolveWrapperName] =
       ExecutorAddr::fromPtr(&resolveWrapper);
 
-  {
-    // Also provide NativeDylibManager symbols for compatibility with
-    // controllers configured to use the ORC runtime's NativeDylibManager
-    // interface.
-    // FIXME: We should codify a "simple" dylib manager interface and make
-    // SimpleExecutorDylibManager its LLVM-based implementation, and
-    // NativeDylibManager its ORC-runtime implementation.
-    const auto &SNs = rt::orc_rt_NativeDylibManagerSPSSymbols;
-    M[SNs.InstanceName] = ExecutorAddr::fromPtr(this);
-    M[SNs.OpenName] = ExecutorAddr::fromPtr(&openWrapper);
-    M[SNs.ResolveName] = ExecutorAddr::fromPtr(&resolveWrapper);
-  }
+  // Also provide NativeDylibManager symbols for compatibility with
+  // controllers configured to use the ORC runtime's NativeDylibManager
+  // interface.
+  // FIXME: We should codify a "simple" dylib manager interface and make
+  // SimpleExecutorDylibManager its LLVM-based implementation, and
+  // NativeDylibManager its ORC-runtime implementation.
+  M[rt::NativeDylibManagerInstanceName] = ExecutorAddr::fromPtr(this);
+  M[rt::NativeDylibManagerLoadWrapperName] =
+      ExecutorAddr::fromPtr(&openWrapper);
+  M[rt::NativeDylibManagerLookupWrapperName] =
+      ExecutorAddr::fromPtr(&resolveWrapper);
 }
 
 llvm::orc::shared::CWrapperFunctionBuffer

--- a/llvm/tools/lli/ForwardingMemoryManager.h
+++ b/llvm/tools/lli/ForwardingMemoryManager.h
@@ -13,7 +13,9 @@
 #ifndef LLVM_TOOLS_LLI_FORWARDINGMEMORYMANAGER_H
 #define LLVM_TOOLS_LLI_FORWARDINGMEMORYMANAGER_H
 
+#include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/EPCGenericDylibManager.h"
+#include "llvm/ExecutionEngine/Orc/SymbolStringPool.h"
 #include "llvm/ExecutionEngine/RTDyldMemoryManager.h"
 
 namespace llvm {
@@ -90,22 +92,26 @@ private:
 class RemoteResolver : public LegacyJITSymbolResolver {
 public:
   static Expected<std::unique_ptr<RemoteResolver>>
-  Create(orc::ExecutorProcessControl &EPC) {
+  Create(orc::ExecutionSession &ES) {
     auto DylibMgr =
-        orc::EPCGenericDylibManager::CreateWithDefaultBootstrapSymbols(EPC);
+        orc::EPCGenericDylibManager::CreateWithDefaultBootstrapSymbols(
+            ES.getExecutorProcessControl());
     if (!DylibMgr)
       return DylibMgr.takeError();
     auto H = DylibMgr->open("", 0);
     if (!H)
       return H.takeError();
-    return std::make_unique<RemoteResolver>(std::move(*DylibMgr),
-                                            std::move(*H));
+    return std::make_unique<RemoteResolver>(
+        std::move(*DylibMgr), std::move(*H),
+        std::make_shared<orc::SymbolStringPool>());
   }
 
   JITSymbol findSymbol(const std::string &Name) override {
-    orc::RemoteSymbolLookupSet R;
-    R.push_back({std::move(Name), false});
-    if (auto Syms = DylibMgr.lookup(H, R)) {
+    // This legacy resolver has no ExecutionSession string pool of its own, so
+    // it interns lookup names into a standalone pool to form the lookup set.
+    orc::SymbolLookupSet LS(SSP->intern(Name),
+                            orc::SymbolLookupFlags::WeaklyReferencedSymbol);
+    if (auto Syms = DylibMgr.lookup(H, LS)) {
       if (Syms->size() != 1)
         return make_error<StringError>("Unexpected remote lookup result",
                                        inconvertibleErrorCode());
@@ -123,11 +129,13 @@ public:
 
 public:
   RemoteResolver(orc::EPCGenericDylibManager DylibMgr,
-                 orc::tpctypes::DylibHandle H)
-      : DylibMgr(std::move(DylibMgr)), H(std::move(H)) {}
+                 orc::tpctypes::DylibHandle H,
+                 std::shared_ptr<orc::SymbolStringPool> SSP)
+      : DylibMgr(std::move(DylibMgr)), H(std::move(H)), SSP(std::move(SSP)) {}
 
   orc::EPCGenericDylibManager DylibMgr;
   orc::tpctypes::DylibHandle H;
+  std::shared_ptr<orc::SymbolStringPool> SSP;
 };
 } // namespace llvm
 

--- a/llvm/tools/lli/lli.cpp
+++ b/llvm/tools/lli/lli.cpp
@@ -701,7 +701,7 @@ int main(int argc, char **argv, char * const *envp) {
     abort();
   } else {
     // else == "if (RemoteMCJIT)"
-    std::unique_ptr<orc::ExecutorProcessControl> EPC = ExitOnErr(launchRemote());
+    orc::ExecutionSession ES(ExitOnErr(launchRemote()));
 
     // Remote target MCJIT doesn't (yet) support static constructors. No reason
     // it couldn't. This is a limitation of the LLI implementation, not the
@@ -710,7 +710,7 @@ int main(int argc, char **argv, char * const *envp) {
     // Create a remote memory manager.
     auto RemoteMM = ExitOnErr(
         orc::EPCGenericRTDyldMemoryManager::CreateWithDefaultBootstrapSymbols(
-            *EPC));
+            ES.getExecutorProcessControl()));
 
     // Forward MCJIT's memory manager calls to the remote memory manager.
     static_cast<ForwardingMemoryManager*>(RTDyldMM)->setMemMgr(
@@ -718,7 +718,7 @@ int main(int argc, char **argv, char * const *envp) {
 
     // Forward MCJIT's symbol resolution calls to the remote.
     static_cast<ForwardingMemoryManager *>(RTDyldMM)->setResolver(
-        ExitOnErr(RemoteResolver::Create(*EPC)));
+        ExitOnErr(RemoteResolver::Create(ES)));
     // Grab the target address of the JIT'd main function on the remote and call
     // it.
     // FIXME: argv and envp handling.
@@ -727,7 +727,7 @@ int main(int argc, char **argv, char * const *envp) {
     EE->finalizeObject();
     LLVM_DEBUG(dbgs() << "Executing '" << EntryFn->getName() << "' at 0x"
                       << format("%llx", Entry.getValue()) << "\n");
-    Result = ExitOnErr(EPC->runAsMain(Entry, {}));
+    Result = ExitOnErr(ES.getExecutorProcessControl().runAsMain(Entry, {}));
 
     // Like static constructors, the remote target MCJIT support doesn't handle
     // this yet. It could. FIXME.
@@ -738,7 +738,7 @@ int main(int argc, char **argv, char * const *envp) {
     EE.reset();
 
     // Signal the remote target that we're done JITing.
-    ExitOnErr(EPC->disconnect());
+    ExitOnErr(ES.endSession());
   }
 
   return Result;

--- a/llvm/unittests/ExecutionEngine/Orc/EPCGenericDylibManagerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/EPCGenericDylibManagerTest.cpp
@@ -32,21 +32,19 @@ TEST(EPCGenericDylibManagerTest, CreateFromExecutionSession) {
     }
   };
 
-  auto &SNs = rt::orc_rt_NativeDylibManagerSPSSymbols;
-
   ExecutorAddr InstanceAddr(1), OpenAddr(2), ResolveAddr(3);
 
   StringMap<ExecutorAddr> BootstrapSyms;
-  BootstrapSyms[SNs.InstanceName] = InstanceAddr;
-  BootstrapSyms[SNs.OpenName] = OpenAddr;
-  BootstrapSyms[SNs.ResolveName] = ResolveAddr;
+  BootstrapSyms[rt::NativeDylibManagerInstanceName] = InstanceAddr;
+  BootstrapSyms[rt::NativeDylibManagerLoadWrapperName] = OpenAddr;
+  BootstrapSyms[rt::NativeDylibManagerLookupWrapperName] = ResolveAddr;
 
   auto SSP = std::make_shared<SymbolStringPool>();
   auto EPC =
       std::make_unique<EPCWithBootstrapSymbols>(SSP, std::move(BootstrapSyms));
   ExecutionSession ES(std::move(EPC));
 
-  auto Result = EPCGenericDylibManager::Create(ES, SNs);
+  auto Result = EPCGenericDylibManager::Create(ES);
   EXPECT_THAT_EXPECTED(Result, Succeeded());
 
   cantFail(ES.endSession());


### PR DESCRIPTION
Reimplement EPCGenericDylibManager's open/resolve operations using rt::Proxy objects rather than direct ExecutorProcessControl::callSPSWrapper* calls, bringing it in line with the other RTBridge-based executor accessors. Behavior is unchanged; the public open/lookup surface is the same aside from the removals noted below.

Implementation details:

* The SymbolAddrs struct (three ExecutorAddrs) becomes Bindings: the manager instance address plus rt::Proxy handles for open and resolve. Bindings members are protocol-agnostic, so a client can build their own for another protocol and pass them to the constructor; Create resolves them via buildProxies against a JITDylib / the bootstrap JITDylib.

* open/resolve return SPSExpected, so this relies on the proxy layer's Error/Expected support to deliver a single flattened Expected, replacing the hand-written (Error, Expected) unpacking in lookupAsync.

* The SimpleExecutorDylibManagerSymbolNames struct (and its orc_rt_NativeDylibManagerSPSSymbols instance) is removed: buildProxies already gives default-but-overridable lookup names. The NativeDylibManager interface names become shared constants in OrcRTBridge.h; Create uses them as the proxy defaults and CreateWithDefaultBootstrapSymbols overrides with the LLVM-style SimpleExecutorDylibManager names.

* Resolution uses a single proxy over SymbolLookupSet, serialized directly to the remote lookup-set form (no std::string copy per symbol name). The RemoteSymbolLookupSet lookup/lookupAsync overloads are removed; their only in-tree user, lli's RemoteResolver, now interns names into a standalone SymbolStringPool to build a SymbolLookupSet.