### PR TITLE
[GVN] Use SmallDenseSet for visited node tracking

### DIFF
--- a/llvm/lib/Transforms/Scalar/GVN.cpp
+++ b/llvm/lib/Transforms/Scalar/GVN.cpp
@@ -3092,7 +3092,7 @@ bool GVNPass::propagateEquality(
     Value *LHS, Value *RHS,
     const std::variant<BasicBlockEdge, Instruction *> &Root) {
   SmallVector<std::pair<Value*, Value*>, 4> Worklist;
-  DenseSet<std::pair<Value *, Value *>> Visited;
+  SmallDenseSet<std::pair<Value *, Value *>, 4> Visited;
   Worklist.push_back(std::make_pair(LHS, RHS));
   bool Changed = false;
   SmallVector<const BasicBlock *> DominatedBlocks;


### PR DESCRIPTION
Commit 0a321f38147f ("[GVN] Track visited nodes in equality propagation to avoid OOM (#212265)", 2026-08-05) caused some compilation time regressions.  Use a SmallDenseSet to mitigate the impact of that change.