### PR TITLE
[lldb][test] Remove Python <= 3.6 workaround

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -104,9 +104,7 @@ def _match_decorator_property(expected, actual):
     if isinstance(expected, no_match):
         return not _match_decorator_property(expected.item, actual)
 
-    # Python 3.6 doesn't declare a `re.Pattern` type, get the dynamic type.
-    pattern_type = type(re.compile(""))
-    if isinstance(expected, (pattern_type, str)):
+    if isinstance(expected, (re.Pattern, str)):
         return re.search(expected, actual) is not None
 
     if hasattr(expected, "__iter__"):

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -347,13 +347,10 @@ class ValueCheck:
 
         test_base.assertSuccess(val.GetError())
 
-        # Python 3.6 doesn't declare a `re.Pattern` type, get the dynamic type.
-        pattern_type = type(re.compile(""))
-
         if self.expect_name:
             test_base.assertEqual(self.expect_name, val.GetName(), this_error_msg)
         if self.expect_value:
-            if isinstance(self.expect_value, pattern_type):
+            if isinstance(self.expect_value, re.Pattern):
                 test_base.assertRegex(val.GetValue(), self.expect_value, this_error_msg)
             else:
                 test_base.assertEqual(self.expect_value, val.GetValue(), this_error_msg)
@@ -362,7 +359,7 @@ class ValueCheck:
                 self.expect_type, val.GetDisplayTypeName(), this_error_msg
             )
         if self.expect_summary:
-            if isinstance(self.expect_summary, pattern_type):
+            if isinstance(self.expect_summary, re.Pattern):
                 test_base.assertRegex(
                     val.GetSummary(), self.expect_summary, this_error_msg
                 )


### PR DESCRIPTION
re.Pattern was added in 3.7 and our minimum
is now 3.8.

Python 3.6.15:
>>> import re
>>> re.Pattern
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 're' has no attribute 'Pattern'

Python 3.7.17:
>>> import re
>>> re.Pattern
<class 're.Pattern'>

Python 3.8.20:
>>> import re
>>> re.Pattern
<class 're.Pattern'>

(it does not appear in documentation until 3.11)