### PR TITLE
[CodeGen][AArch64][MachineOutliner] Track HasStackArguments in CallSiteInfo for the outliner

### DIFF
--- a/llvm/include/llvm/CodeGen/MIRYamlMapping.h
+++ b/llvm/include/llvm/CodeGen/MIRYamlMapping.h
@@ -495,6 +495,22 @@ struct MachineInstrLoc {
   }
 };
 
+template <>
+struct ScalarEnumerationTraits<
+    MachineFunction::CallSiteInfo::StackArgumentsStatus> {
+  static void
+  enumeration(IO &YamlIO,
+              MachineFunction::CallSiteInfo::StackArgumentsStatus &Value) {
+    YamlIO.enumCase(
+        Value, "unknown",
+        MachineFunction::CallSiteInfo::StackArgumentsStatus::Unknown);
+    YamlIO.enumCase(Value, "yes",
+                    MachineFunction::CallSiteInfo::StackArgumentsStatus::Yes);
+    YamlIO.enumCase(Value, "no",
+                    MachineFunction::CallSiteInfo::StackArgumentsStatus::No);
+  }
+};
+
 /// Serializable representation of CallSiteInfo.
 struct CallSiteInfo {
   // Representation of call argument and register which is used to
@@ -512,6 +528,9 @@ struct CallSiteInfo {
   std::vector<ArgRegPair> ArgForwardingRegs;
   /// Numeric callee type identifiers for the callgraph section.
   std::vector<uint64_t> CalleeTypeIds;
+  /// Whether the call has arguments on the stack.
+  MachineFunction::CallSiteInfo::StackArgumentsStatus HasStackArguments =
+      MachineFunction::CallSiteInfo::StackArgumentsStatus::Unknown;
 
   bool operator==(const CallSiteInfo &Other) const {
     return CallLocation.BlockNum == Other.CallLocation.BlockNum &&
@@ -542,6 +561,12 @@ template <> struct MappingTraits<CallSiteInfo> {
     YamlIO.mapOptional("fwdArgRegs", CSInfo.ArgForwardingRegs,
                        std::vector<CallSiteInfo::ArgRegPair>());
     YamlIO.mapOptional("calleeTypeIds", CSInfo.CalleeTypeIds);
+    if (!YamlIO.outputting() ||
+        CSInfo.HasStackArguments !=
+            MachineFunction::CallSiteInfo::StackArgumentsStatus::Unknown)
+      YamlIO.mapOptional(
+          "hasStackArguments", CSInfo.HasStackArguments,
+          MachineFunction::CallSiteInfo::StackArgumentsStatus::Unknown);
   }
 
   static const bool flow = true;

--- a/llvm/include/llvm/CodeGen/MachineFunction.h
+++ b/llvm/include/llvm/CodeGen/MachineFunction.h
@@ -533,6 +533,11 @@ public:
     /// or definition of the target function and might be indirect.
     MDNode *CallTarget = nullptr;
 
+    enum class StackArgumentsStatus { Unknown, Yes, No };
+
+    /// Whether this call passes arguments on the stack.
+    StackArgumentsStatus HasStackArguments = StackArgumentsStatus::Unknown;
+
     CallSiteInfo() = default;
 
     /// Extracts the numeric type id from the CallBase's callee_type Metadata,
@@ -1505,6 +1510,11 @@ public:
   /// is used when we are replacing one call instruction with another one to
   /// the same callee.
   void moveAdditionalCallInfo(const MachineInstr *Old, const MachineInstr *New);
+
+  /// Reconcile the call site info of \p Survivor with that of \p Victim when
+  /// the two identical call instructions are merged into one.
+  void mergeCallSiteInfo(const MachineInstr *Survivor,
+                         const MachineInstr *Victim);
 
   unsigned getNewDebugInstrNum() {
     return ++DebugInstrNumberingCount;

--- a/llvm/include/llvm/Target/TargetOptions.h
+++ b/llvm/include/llvm/Target/TargetOptions.h
@@ -134,9 +134,10 @@ public:
         EnableStaticDataPartitioning(false), SupportsDefaultOutlining(false),
         EnableDefaultMachineVerifier(true), EmitAddrsig(false),
         BBAddrMap(false), EmitCallGraphSection(false), EmitCallSiteInfo(false),
-        SupportsDebugEntryValues(false), EnableDebugEntryValues(false),
-        ValueTrackingVariableLocations(false), ForceDwarfFrameSection(false),
-        XRayFunctionIndex(true), DebugStrictDwarf(false), Hotpatch(false),
+        EmitCodeGenCallSiteInfo(false), SupportsDebugEntryValues(false),
+        EnableDebugEntryValues(false), ValueTrackingVariableLocations(false),
+        ForceDwarfFrameSection(false), XRayFunctionIndex(true),
+        DebugStrictDwarf(false), Hotpatch(false),
         PPCGenScalarMASSEntries(false), JMCInstrument(false),
         EnableCFIFixup(false), MisExpect(false), XCOFFReadOnlyPointers(false),
         VerifyArgABICompliance(true) {}
@@ -298,6 +299,10 @@ public:
   /// info, and it is restricted only to optimized code. This can be used for
   /// something else, so that should be controlled in the frontend.
   unsigned EmitCallSiteInfo : 1;
+
+  /// Enables call site info production for codegen purposes.
+  unsigned EmitCodeGenCallSiteInfo : 1;
+
   /// Set if the target supports the debug entry values by default.
   unsigned SupportsDebugEntryValues : 1;
   /// When set to true, the EnableDebugEntryValues option forces production

--- a/llvm/lib/CodeGen/BranchFolding.cpp
+++ b/llvm/lib/CodeGen/BranchFolding.cpp
@@ -910,6 +910,8 @@ void BranchFolder::mergeCommonTails(unsigned commonTailIndex) {
       }
       assert(MI.isIdenticalTo(*Pos) && "Expected matching MIIs!");
       DL = DebugLoc::getMergedLocation(DL, Pos->getDebugLoc());
+      if (MI.shouldUpdateAdditionalCallInfo())
+        MBB->getParent()->mergeCallSiteInfo(&MI, &*Pos);
       NextCommonInsts[i] = ++Pos;
     }
     MI.setDebugLoc(DL);

--- a/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
@@ -534,12 +534,14 @@ bool MIRParserImpl::initializeCallSiteInfo(
       }
     }
 
-    if (TM.Options.EmitCallSiteInfo || TM.Options.EmitCallGraphSection)
+    if (TM.Options.EmitCallSiteInfo || TM.Options.EmitCodeGenCallSiteInfo ||
+        TM.Options.EmitCallGraphSection)
       MF.addCallSiteInfo(&*CallI, std::move(CSInfo));
   }
 
   if (!YamlMF.CallSitesInfo.empty() &&
-      !(TM.Options.EmitCallSiteInfo || TM.Options.EmitCallGraphSection))
+      !(TM.Options.EmitCallSiteInfo || TM.Options.EmitCodeGenCallSiteInfo ||
+        TM.Options.EmitCallGraphSection))
     return error("call site info provided but not used");
   return false;
 }

--- a/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
@@ -534,6 +534,7 @@ bool MIRParserImpl::initializeCallSiteInfo(
       }
     }
 
+    CSInfo.HasStackArguments = YamlCSInfo.HasStackArguments;
     if (TM.Options.EmitCallSiteInfo || TM.Options.EmitCodeGenCallSiteInfo ||
         TM.Options.EmitCallGraphSection)
       MF.addCallSiteInfo(&*CallI, std::move(CSInfo));

--- a/llvm/lib/CodeGen/MIRPrinter.cpp
+++ b/llvm/lib/CodeGen/MIRPrinter.cpp
@@ -560,18 +560,18 @@ static void convertCallSiteObjects(yaml::MachineFunction &YMF,
         std::distance(CallI->getParent()->instr_begin(), CallI);
     YmlCS.CallLocation = CallLocation;
 
-    auto [ArgRegPairs, CalleeTypeIds, _] = CallSiteInfo;
     // Construct call arguments and theirs forwarding register info.
-    for (auto ArgReg : ArgRegPairs) {
+    for (auto ArgReg : CallSiteInfo.ArgRegPairs) {
       yaml::CallSiteInfo::ArgRegPair YmlArgReg;
       YmlArgReg.ArgNo = ArgReg.ArgNo;
       printRegMIR(ArgReg.Reg, YmlArgReg.Reg, TRI);
       YmlCS.ArgForwardingRegs.emplace_back(YmlArgReg);
     }
     // Get type ids.
-    for (auto *CalleeTypeId : CalleeTypeIds) {
+    for (auto *CalleeTypeId : CallSiteInfo.CalleeTypeIds) {
       YmlCS.CalleeTypeIds.push_back(CalleeTypeId->getZExtValue());
     }
+    YmlCS.HasStackArguments = CallSiteInfo.HasStackArguments;
     YMF.CallSitesInfo.push_back(std::move(YmlCS));
   }
 

--- a/llvm/lib/CodeGen/MachineFunction.cpp
+++ b/llvm/lib/CodeGen/MachineFunction.cpp
@@ -989,7 +989,9 @@ MachineFunction::getCallSiteInfo(const MachineInstr *MI) {
   assert(MI->isCandidateForAdditionalCallInfo() &&
          "Call site info refers only to call (MI) candidates");
 
-  if (!Target.Options.EmitCallSiteInfo && !Target.Options.EmitCallGraphSection)
+  if (!Target.Options.EmitCallSiteInfo &&
+      !Target.Options.EmitCodeGenCallSiteInfo &&
+      !Target.Options.EmitCallGraphSection)
     return CallSitesInfo.end();
   return CallSitesInfo.find(MI);
 }

--- a/llvm/lib/CodeGen/MachineFunction.cpp
+++ b/llvm/lib/CodeGen/MachineFunction.cpp
@@ -1071,6 +1071,26 @@ void MachineFunction::moveAdditionalCallInfo(const MachineInstr *Old,
   }
 }
 
+void MachineFunction::mergeCallSiteInfo(const MachineInstr *Survivor,
+                                        const MachineInstr *Victim) {
+  assert(Survivor->shouldUpdateAdditionalCallInfo() &&
+         Victim->shouldUpdateAdditionalCallInfo() &&
+         "Call info refers only to call (MI) candidates or "
+         "candidates inside bundles");
+
+  CallSiteInfoMap::iterator SurvivorCSIt =
+      getCallSiteInfo(getCallInstr(Survivor));
+  if (SurvivorCSIt == CallSitesInfo.end())
+    return;
+
+  CallSiteInfoMap::iterator VictimCSIt = getCallSiteInfo(getCallInstr(Victim));
+  if (VictimCSIt == CallSitesInfo.end() ||
+      VictimCSIt->second.HasStackArguments !=
+          SurvivorCSIt->second.HasStackArguments)
+    SurvivorCSIt->second.HasStackArguments =
+        CallSiteInfo::StackArgumentsStatus::Unknown;
+}
+
 void MachineFunction::setDebugInstrNumberingCount(unsigned Num) {
   DebugInstrNumberingCount = Num;
 }

--- a/llvm/lib/CodeGen/SelectionDAG/ScheduleDAGSDNodes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/ScheduleDAGSDNodes.cpp
@@ -886,6 +886,7 @@ EmitSchedule(MachineBasicBlock::iterator &InsertPos) {
 
     if (MI->isCandidateForAdditionalCallInfo()) {
       if (DAG->getTarget().Options.EmitCallSiteInfo ||
+          DAG->getTarget().Options.EmitCodeGenCallSiteInfo ||
           DAG->getTarget().Options.EmitCallGraphSection)
         MF.addCallSiteInfo(MI, DAG->getCallSiteInfo(Node));
 

--- a/llvm/lib/CodeGen/TargetPassConfig.cpp
+++ b/llvm/lib/CodeGen/TargetPassConfig.cpp
@@ -152,6 +152,9 @@ static cl::opt<RunOutliner> EnableMachineOutliner(
         clEnumValN(RunOutliner::NeverOutline, "never", "Disable all outlining"),
         // Sentinel value for unspecified option.
         clEnumValN(RunOutliner::AlwaysOutline, "", "")));
+static cl::opt<bool> EmitCodeGenCallSiteInfo(
+    "emit-codegen-call-site-info", cl::Hidden,
+    cl::desc("Emit call site info for codegen purposes"));
 static cl::opt<bool> EnableGlobalMergeFunc(
     "enable-global-merge-func", cl::Hidden,
     cl::desc("Enable global merge functions that are based on hash function"));
@@ -630,6 +633,9 @@ TargetPassConfig::TargetPassConfig(TargetMachine &TM, PassManagerBase &PM)
 
   if (EnableGlobalISelAbort.getNumOccurrences())
     TM.Options.GlobalISelAbort = EnableGlobalISelAbort;
+
+  if (EmitCodeGenCallSiteInfo.getNumOccurrences())
+    TM.Options.EmitCodeGenCallSiteInfo = EmitCodeGenCallSiteInfo;
 
   setStartStopPasses();
 }

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -10368,6 +10368,11 @@ AArch64TargetLowering::LowerCall(CallLoweringInfo &CLI,
   // Get a count of how many bytes are to be pushed on the stack.
   unsigned NumBytes = CCInfo.getStackSize();
 
+  if (DAG.getTarget().Options.EmitCodeGenCallSiteInfo)
+    CSInfo.HasStackArguments =
+        NumBytes > 0 ? MachineFunction::CallSiteInfo::StackArgumentsStatus::Yes
+                     : MachineFunction::CallSiteInfo::StackArgumentsStatus::No;
+
   if (IsSibCall) {
     // Since we're not changing the ABI to make this a tail call, the memory
     // operands are already available in the caller's incoming argument space.

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -11043,12 +11043,6 @@ AArch64InstrInfo::getOutliningTypeImpl(const MachineModuleInfo &MMI,
   // stack. Thus, if we outline, say, half the parameters for a function call
   // plus the call, then we'll break the callee's expectations for the layout
   // of the stack.
-  //
-  // FIXME: Allow calls to functions which construct a stack frame, as long
-  // as they don't access arguments on the stack.
-  // FIXME: Figure out some way to analyze functions defined in other modules.
-  // We should be able to compute the memory usage based on the IR calling
-  // convention, even if we can't see the definition.
   if (MI.isCall()) {
     // Get the function associated with the call. Look at each operand and find
     // the one that represents the callee and get its name.
@@ -11073,6 +11067,17 @@ AArch64InstrInfo::getOutliningTypeImpl(const MachineModuleInfo &MMI,
     if (MI.getOpcode() == AArch64::BLR ||
         MI.getOpcode() == AArch64::BLRNoIP || MI.getOpcode() == AArch64::BL)
       UnknownCallOutlineType = outliner::InstrType::LegalTerminator;
+
+    // If this call passes no stack arguments per call site info, it is safe to
+    // outline non-terminally.
+    if (UnknownCallOutlineType == outliner::InstrType::LegalTerminator) {
+      const MachineFunction &MF = *MI.getParent()->getParent();
+      auto CSInfo = MF.getCallSitesInfo().find(&MI);
+      if (CSInfo != MF.getCallSitesInfo().end() &&
+          CSInfo->second.HasStackArguments ==
+              MachineFunction::CallSiteInfo::StackArgumentsStatus::No)
+        return outliner::InstrType::Legal;
+    }
 
     if (!Callee)
       return UnknownCallOutlineType;

--- a/llvm/test/CodeGen/AArch64/call-site-info-has-stack-args-tail-merge.ll
+++ b/llvm/test/CodeGen/AArch64/call-site-info-has-stack-args-tail-merge.ll
@@ -1,0 +1,75 @@
+; RUN: llc -mtriple=aarch64-linux-gnu -emit-codegen-call-site-info < %s -stop-after=branch-folder -o - | FileCheck %s
+
+; Tail merging can fold two identical-looking call instructions from different
+; call sites into one. The surviving call then stands for both call sites, so
+; its HasStackArguments info must be the conservative merge of both entries.
+
+declare void @vararg(i32, ...)
+
+; Conflicting entries merge to unknown.
+; CHECK-LABEL: name: merge_conflicting
+; CHECK: callSites:
+; CHECK-NEXT: - { bb: {{[0-9]+}}, offset: {{[0-9]+}}, fwdArgRegs: [] }
+; CHECK: BL @vararg
+; CHECK-NOT: BL @vararg
+define void @merge_conflicting(i1 %c) {
+entry:
+  br i1 %c, label %with_stack, label %without_stack
+
+with_stack:
+  call void (i32, ...) @vararg(i32 1, i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7, i64 8)
+  br label %done
+
+without_stack:
+  call void (i32, ...) @vararg(i32 1, i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7)
+  br label %done
+
+done:
+  ret void
+}
+
+; Agreeing entries survive the merge: no + no stays no.
+; CHECK-LABEL: name: merge_agreeing_no_stack
+; CHECK: callSites:
+; CHECK-NEXT: - { bb: {{[0-9]+}}, offset: {{[0-9]+}}, fwdArgRegs: [], hasStackArguments:
+; CHECK-NEXT: no }
+; CHECK: BL @vararg
+; CHECK-NOT: BL @vararg
+define void @merge_agreeing_no_stack(i1 %c, i32 %a, i32 %b) {
+entry:
+  br i1 %c, label %left, label %right
+
+left:
+  call void (i32, ...) @vararg(i32 %a, i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7)
+  br label %done
+
+right:
+  call void (i32, ...) @vararg(i32 %b, i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7)
+  br label %done
+
+done:
+  ret void
+}
+
+; Agreeing entries survive the merge: yes + yes stays yes.
+; CHECK-LABEL: name: merge_agreeing_on_stack
+; CHECK: callSites:
+; CHECK-NEXT: - { bb: {{[0-9]+}}, offset: {{[0-9]+}}, fwdArgRegs: [], hasStackArguments:
+; CHECK-NEXT: yes }
+; CHECK: BL @vararg
+; CHECK-NOT: BL @vararg
+define void @merge_agreeing_on_stack(i1 %c, i64 %a, i64 %b) {
+entry:
+  br i1 %c, label %left, label %right
+
+left:
+  call void (i32, ...) @vararg(i32 1, i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7, i64 %a)
+  br label %done
+
+right:
+  call void (i32, ...) @vararg(i32 1, i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7, i64 %b)
+  br label %done
+
+done:
+  ret void
+}

--- a/llvm/test/CodeGen/AArch64/call-site-info-has-stack-args.ll
+++ b/llvm/test/CodeGen/AArch64/call-site-info-has-stack-args.ll
@@ -1,0 +1,67 @@
+; RUN: llc -mtriple=aarch64-apple-darwin -emit-codegen-call-site-info < %s -stop-before=finalize-isel -o - | FileCheck %s
+
+; Verify that HasStackArguments is correctly set in CallSiteInfo.
+
+declare void @no_stack_args(i32, i32)
+declare void @has_stack_args(i64, i64, i64, i64, i64, i64, i64, i64, i64)
+declare void @vararg(i32, ...)
+
+; CHECK-LABEL: name: test_no_stack_args
+; CHECK: callSites:
+; CHECK:   hasStackArguments:
+; CHECK-NEXT: no
+define void @test_no_stack_args() {
+  call void @no_stack_args(i32 1, i32 2)
+  ret void
+}
+
+; CHECK-LABEL: name: test_has_stack_args
+; CHECK: callSites:
+; CHECK:   hasStackArguments:
+; CHECK-NEXT: yes
+define void @test_has_stack_args() {
+  call void @has_stack_args(i64 0, i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7, i64 8)
+  ret void
+}
+
+; CHECK-LABEL: name: test_vararg
+; CHECK: callSites:
+; CHECK:   hasStackArguments:
+; CHECK-NEXT: yes
+define void @test_vararg() {
+  call void (i32, ...) @vararg(i32 1, i32 2, i32 3)
+  ret void
+}
+
+; CHECK-LABEL: name: test_vararg_no_stack_args
+; CHECK: callSites:
+; CHECK:   hasStackArguments:
+; CHECK-NEXT: no
+define void @test_vararg_no_stack_args() {
+  call void (i32, ...) @vararg(i32 1)
+  ret void
+}
+
+; A sibling tail call leaves its stack arguments in the caller's incoming
+; argument area and allocates no outgoing stack itself, but it still passes
+; arguments on the stack.
+
+; CHECK-LABEL: name: test_tail_call_stack_args
+; CHECK: callSites:
+; CHECK:   hasStackArguments:
+; CHECK-NEXT: yes
+; CHECK: TCRETURNdi @has_stack_args
+define void @test_tail_call_stack_args(i64 %a, i64 %b, i64 %c, i64 %d, i64 %e, i64 %f, i64 %g, i64 %h, i64 %i) {
+  tail call void @has_stack_args(i64 %a, i64 %b, i64 %c, i64 %d, i64 %e, i64 %f, i64 %g, i64 %h, i64 %i)
+  ret void
+}
+
+; CHECK-LABEL: name: test_tail_call_no_stack_args
+; CHECK: callSites:
+; CHECK:   hasStackArguments:
+; CHECK-NEXT: no
+; CHECK: TCRETURNdi @no_stack_args
+define void @test_tail_call_no_stack_args(i32 %a, i32 %b) {
+  tail call void @no_stack_args(i32 %a, i32 %b)
+  ret void
+}

--- a/llvm/test/CodeGen/AArch64/machine-outliner-call-site-info-vararg.ll
+++ b/llvm/test/CodeGen/AArch64/machine-outliner-call-site-info-vararg.ll
@@ -1,0 +1,176 @@
+; A call to a vararg function that passes no variadic arguments has no stack
+; arguments, so with call site info it can be outlined non-terminally. This is
+; preferred over the callee's frame info, and it also applies to external
+; vararg callees whose definition is not visible.
+
+; RUN: split-file %s %t
+
+; RUN: llc -mtriple=aarch64-apple-darwin -enable-machine-outliner -emit-codegen-call-site-info < %t/local-no-stack.ll | FileCheck %t/local-no-stack.ll
+; RUN: llc -mtriple=aarch64-apple-darwin -enable-machine-outliner -emit-codegen-call-site-info=false < %t/local-no-stack.ll | FileCheck %t/local-no-stack.ll --check-prefix=OFF
+
+; RUN: llc -mtriple=aarch64-apple-darwin -enable-machine-outliner -emit-codegen-call-site-info < %t/local-on-stack.ll | FileCheck %t/local-on-stack.ll
+; RUN: llc -mtriple=aarch64-apple-darwin -enable-machine-outliner -emit-codegen-call-site-info=false < %t/local-on-stack.ll | FileCheck %t/local-on-stack.ll
+
+; RUN: llc -mtriple=aarch64-apple-darwin -enable-machine-outliner -emit-codegen-call-site-info < %t/external-no-stack.ll | FileCheck %t/external-no-stack.ll
+; RUN: llc -mtriple=aarch64-apple-darwin -enable-machine-outliner -emit-codegen-call-site-info=false < %t/external-no-stack.ll | FileCheck %t/external-no-stack.ll --check-prefix=OFF
+
+; RUN: llc -mtriple=aarch64-apple-darwin -enable-machine-outliner -emit-codegen-call-site-info < %t/external-on-stack.ll | FileCheck %t/external-on-stack.ll
+; RUN: llc -mtriple=aarch64-apple-darwin -enable-machine-outliner -emit-codegen-call-site-info=false < %t/external-on-stack.ll | FileCheck %t/external-on-stack.ll
+
+;--- local-no-stack.ll
+
+@g = external global i32
+
+declare void @llvm.va_start(ptr)
+declare void @llvm.va_end(ptr)
+
+define internal void @local_vararg(i32 %n, ...) minsize {
+entry:
+  %ap = alloca ptr
+  call void @llvm.va_start(ptr %ap)
+  %v = va_arg ptr %ap, i32
+  store volatile i32 %v, ptr @g
+  call void @llvm.va_end(ptr %ap)
+  ret void
+}
+
+; CHECK-LABEL: _call_local_no_stack_1:
+; CHECK:       bl [[OUTLINED:_OUTLINED_FUNCTION_[0-9]+]]
+
+; CHECK:       [[OUTLINED]]:
+; CHECK:       bl _local_vararg
+
+; OFF-LABEL: _call_local_no_stack_1:
+; OFF:        bl [[OUTLINED:_OUTLINED_FUNCTION_[0-9]+]]
+
+; OFF:        [[OUTLINED]]:
+; OFF:        b _local_vararg
+
+define void @call_local_no_stack_1() minsize {
+  store volatile i32 1, ptr @g
+  call void (i32, ...) @local_vararg(i32 7)
+  store volatile i32 2, ptr @g
+  ret void
+}
+define void @call_local_no_stack_2() minsize {
+  store volatile i32 1, ptr @g
+  call void (i32, ...) @local_vararg(i32 7)
+  store volatile i32 2, ptr @g
+  ret void
+}
+define void @call_local_no_stack_3() minsize {
+  store volatile i32 1, ptr @g
+  call void (i32, ...) @local_vararg(i32 7)
+  store volatile i32 2, ptr @g
+  ret void
+}
+
+;--- local-on-stack.ll
+
+@g = external global i32
+
+declare void @llvm.va_start(ptr)
+declare void @llvm.va_end(ptr)
+
+define internal void @local_vararg(i32 %n, ...) minsize {
+entry:
+  %ap = alloca ptr
+  call void @llvm.va_start(ptr %ap)
+  %v = va_arg ptr %ap, i32
+  store volatile i32 %v, ptr @g
+  call void @llvm.va_end(ptr %ap)
+  ret void
+}
+
+; CHECK-LABEL: _call_local_on_stack_1:
+; CHECK:       bl [[OUTLINED:_OUTLINED_FUNCTION_[0-9]+]]
+
+; CHECK:       [[OUTLINED]]:
+; CHECK:       b _local_vararg
+
+define void @call_local_on_stack_1() minsize {
+  store volatile i32 1, ptr @g
+  call void (i32, ...) @local_vararg(i32 7, i64 0, i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7, i64 8)
+  store volatile i32 2, ptr @g
+  ret void
+}
+define void @call_local_on_stack_2() minsize {
+  store volatile i32 1, ptr @g
+  call void (i32, ...) @local_vararg(i32 7, i64 0, i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7, i64 8)
+  store volatile i32 2, ptr @g
+  ret void
+}
+define void @call_local_on_stack_3() minsize {
+  store volatile i32 1, ptr @g
+  call void (i32, ...) @local_vararg(i32 7, i64 0, i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7, i64 8)
+  store volatile i32 2, ptr @g
+  ret void
+}
+
+;--- external-no-stack.ll
+
+@g = external global i32
+
+declare void @external_vararg(i32, ...)
+
+; CHECK-LABEL: _call_external_no_stack_1:
+; CHECK:       bl [[OUTLINED:_OUTLINED_FUNCTION_[0-9]+]]
+
+; CHECK:       [[OUTLINED]]:
+; CHECK:       bl _external_vararg
+
+; OFF-LABEL: _call_external_no_stack_1:
+; OFF:        bl [[OUTLINED:_OUTLINED_FUNCTION_[0-9]+]]
+
+; OFF:        [[OUTLINED]]:
+; OFF:        b _external_vararg
+
+define void @call_external_no_stack_1() minsize {
+  store volatile i32 1, ptr @g
+  call void (i32, ...) @external_vararg(i32 7)
+  store volatile i32 2, ptr @g
+  ret void
+}
+define void @call_external_no_stack_2() minsize {
+  store volatile i32 1, ptr @g
+  call void (i32, ...) @external_vararg(i32 7)
+  store volatile i32 2, ptr @g
+  ret void
+}
+define void @call_external_no_stack_3() minsize {
+  store volatile i32 1, ptr @g
+  call void (i32, ...) @external_vararg(i32 7)
+  store volatile i32 2, ptr @g
+  ret void
+}
+
+;--- external-on-stack.ll
+
+@g = external global i32
+
+declare void @external_vararg(i32, ...)
+
+; CHECK-LABEL: _call_external_on_stack_1:
+; CHECK:       bl [[OUTLINED:_OUTLINED_FUNCTION_[0-9]+]]
+
+; CHECK:       [[OUTLINED]]:
+; CHECK:       b _external_vararg
+
+define void @call_external_on_stack_1() minsize {
+  store volatile i32 1, ptr @g
+  call void (i32, ...) @external_vararg(i32 7, i64 0, i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7, i64 8)
+  store volatile i32 2, ptr @g
+  ret void
+}
+define void @call_external_on_stack_2() minsize {
+  store volatile i32 1, ptr @g
+  call void (i32, ...) @external_vararg(i32 7, i64 0, i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7, i64 8)
+  store volatile i32 2, ptr @g
+  ret void
+}
+define void @call_external_on_stack_3() minsize {
+  store volatile i32 1, ptr @g
+  call void (i32, ...) @external_vararg(i32 7, i64 0, i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7, i64 8)
+  store volatile i32 2, ptr @g
+  ret void
+}

--- a/llvm/test/CodeGen/AArch64/machine-outliner-call-site-info.ll
+++ b/llvm/test/CodeGen/AArch64/machine-outliner-call-site-info.ll
@@ -1,0 +1,170 @@
+; Test how the machine outliner handles calls depending on call site info: a
+; call known to have no stack arguments may be outlined non-terminally, while a
+; call with stack arguments (or no call site info) may only end an outlined
+; function.
+
+; RUN: split-file %s %t
+
+; RUN: llc -mtriple=aarch64-apple-darwin -enable-machine-outliner -emit-codegen-call-site-info < %t/direct.ll | FileCheck %t/direct.ll
+; RUN: llc -mtriple=aarch64-apple-darwin -enable-machine-outliner -emit-codegen-call-site-info=false < %t/direct.ll | FileCheck %t/direct.ll --check-prefix=OFF
+
+; RUN: llc -mtriple=aarch64-apple-darwin -enable-machine-outliner -emit-codegen-call-site-info < %t/indirect.ll | FileCheck %t/indirect.ll
+; RUN: llc -mtriple=aarch64-apple-darwin -enable-machine-outliner -emit-codegen-call-site-info=false < %t/indirect.ll | FileCheck %t/indirect.ll --check-prefix=OFF
+
+; RUN: llc -mtriple=aarch64-apple-darwin -enable-machine-outliner -emit-codegen-call-site-info < %t/stack.ll | FileCheck %t/stack.ll
+; RUN: llc -mtriple=aarch64-apple-darwin -enable-machine-outliner -emit-codegen-call-site-info=false < %t/stack.ll | FileCheck %t/stack.ll
+
+; RUN: llc -mtriple=aarch64-apple-darwin -enable-machine-outliner -emit-codegen-call-site-info < %t/indirect-stack.ll | FileCheck %t/indirect-stack.ll
+; RUN: llc -mtriple=aarch64-apple-darwin -enable-machine-outliner -emit-codegen-call-site-info=false < %t/indirect-stack.ll | FileCheck %t/indirect-stack.ll
+
+;--- direct.ll
+
+@g = external global i32
+
+declare void @no_stack_args()
+
+; CHECK-LABEL: _fn1:
+; CHECK:       bl [[OUTLINED:_OUTLINED_FUNCTION_[0-9]+]]
+
+; CHECK:       [[OUTLINED]]:
+; CHECK:       bl _no_stack_args
+
+; OFF-LABEL: _fn1:
+; OFF:        bl [[OUTLINED:_OUTLINED_FUNCTION_[0-9]+]]
+
+; OFF:        [[OUTLINED]]:
+; OFF:        b _no_stack_args
+
+define void @fn1() minsize {
+entry:
+  store volatile i32 1, ptr @g
+  call void @no_stack_args()
+  store volatile i32 2, ptr @g
+  ret void
+}
+
+define void @fn2() minsize {
+entry:
+  store volatile i32 1, ptr @g
+  call void @no_stack_args()
+  store volatile i32 2, ptr @g
+  ret void
+}
+
+define void @fn3() minsize {
+entry:
+  store volatile i32 1, ptr @g
+  call void @no_stack_args()
+  store volatile i32 2, ptr @g
+  ret void
+}
+
+;--- indirect.ll
+
+@g = external global i32
+
+; CHECK-LABEL: _indirect1:
+; CHECK:       bl [[OUTLINED:_OUTLINED_FUNCTION_[0-9]+]]
+
+; CHECK:       [[OUTLINED]]:
+; CHECK:       blr x{{[0-9]+}}
+
+; OFF-LABEL: _indirect1:
+; OFF:        bl [[OUTLINED:_OUTLINED_FUNCTION_[0-9]+]]
+
+; OFF:        [[OUTLINED]]:
+; OFF:        br x{{[0-9]+}}
+
+define void @indirect1(ptr %fptr) minsize {
+entry:
+  %v = load volatile i32, ptr @g
+  call void %fptr()
+  %v2 = load volatile i32, ptr @g
+  ret void
+}
+
+define void @indirect2(ptr %fptr) minsize {
+entry:
+  %v = load volatile i32, ptr @g
+  call void %fptr()
+  %v2 = load volatile i32, ptr @g
+  ret void
+}
+
+define void @indirect3(ptr %fptr) minsize {
+entry:
+  %v = load volatile i32, ptr @g
+  call void %fptr()
+  %v2 = load volatile i32, ptr @g
+  ret void
+}
+
+;--- stack.ll
+
+@g = external global i32
+
+declare void @has_stack_args(i64, i64, i64, i64, i64, i64, i64, i64, i64)
+
+; CHECK-LABEL: _stack1:
+; CHECK:       bl [[OUTLINED:_OUTLINED_FUNCTION_[0-9]+]]
+
+; CHECK:       [[OUTLINED]]:
+; CHECK:       b _has_stack_args
+
+define void @stack1() minsize {
+entry:
+  store volatile i32 1, ptr @g
+  call void @has_stack_args(i64 0, i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7, i64 8)
+  store volatile i32 2, ptr @g
+  ret void
+}
+
+define void @stack2() minsize {
+entry:
+  store volatile i32 1, ptr @g
+  call void @has_stack_args(i64 0, i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7, i64 8)
+  store volatile i32 2, ptr @g
+  ret void
+}
+
+define void @stack3() minsize {
+entry:
+  store volatile i32 1, ptr @g
+  call void @has_stack_args(i64 0, i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7, i64 8)
+  store volatile i32 2, ptr @g
+  ret void
+}
+
+;--- indirect-stack.ll
+
+@g = external global i32
+
+; CHECK-LABEL: _indirect_stack1:
+; CHECK:       bl [[OUTLINED:_OUTLINED_FUNCTION_[0-9]+]]
+
+; CHECK:       [[OUTLINED]]:
+; CHECK:       br x{{[0-9]+}}
+
+define void @indirect_stack1(ptr %fptr) minsize {
+entry:
+  %v = load volatile i32, ptr @g
+  call void %fptr(i64 0, i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7, i64 8)
+  %v2 = load volatile i32, ptr @g
+  ret void
+}
+
+define void @indirect_stack2(ptr %fptr) minsize {
+entry:
+  %v = load volatile i32, ptr @g
+  call void %fptr(i64 0, i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7, i64 8)
+  %v2 = load volatile i32, ptr @g
+  ret void
+}
+
+define void @indirect_stack3(ptr %fptr) minsize {
+entry:
+  %v = load volatile i32, ptr @g
+  call void %fptr(i64 0, i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7, i64 8)
+  %v2 = load volatile i32, ptr @g
+  ret void
+}

--- a/llvm/test/CodeGen/X86/emit-codegen-call-site-info.ll
+++ b/llvm/test/CodeGen/X86/emit-codegen-call-site-info.ll
@@ -1,0 +1,15 @@
+; RUN: llc -mtriple=x86_64-linux-gnu -emit-codegen-call-site-info %s -o - -stop-before=finalize-isel | FileCheck %s --check-prefix=ON
+; RUN: llc -mtriple=x86_64-linux-gnu -emit-codegen-call-site-info=false %s -o - -stop-before=finalize-isel | FileCheck %s --check-prefix=OFF
+
+; ON: callSites:
+; ON-NEXT:   - {
+; OFF: callSites:       []
+
+define i32 @caller(i32 %a, i32 %b, i32 %c) {
+entry:
+  %add = add nsw i32 %b, %a
+  %call = tail call i32 @callee(i32 %add, i32 %c, i32 10)
+  ret i32 %call
+}
+
+declare i32 @callee(i32, i32, i32)


### PR DESCRIPTION
Add a HasStackArguments field to CallSiteInfo to record whether a call
passes arguments on the stack. It is populated only when
EmitCodeGenCallSiteInfo is enabled; otherwise it stays Unknown to keep
downstream optimizations conservative.

Teach AArch64 call lowering to emit the status based on NumBytes, and
the AArch64 machine outliner to consume it to treat calls without stack
arguments as Legal, allowing them to appear in the middle of outlined
sequences.

Two identical-looking call instructions from different call sites can be
merged into one, the surviving call then stands for both call sites. Add
MachineFunction::mergeCallSiteInfo to reconcile the surviving entry:
HasStackArguments is kept only when the merged call sites agree.

Depends on #206668.