### PR TITLE
[lldb][NFC] Use Python3's importlib.reload directly

### DIFF
--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -770,17 +770,9 @@ ScriptInterpreterPythonImpl::ScriptInterpreterPythonImpl(Debugger &debugger)
   RunSimpleString(run_string.GetData());
 
   run_string.Clear();
-  run_string.Printf(
-      "run_one_line (%s, 'import copy, keyword, os, re, sys, uuid, lldb')",
-      m_dictionary_name.c_str());
-  RunSimpleString(run_string.GetData());
-
-  // Reloading modules requires a different syntax in Python 2 and Python 3.
-  // This provides a consistent syntax no matter what version of Python.
-  run_string.Clear();
-  run_string.Printf(
-      "run_one_line (%s, 'from importlib import reload as reload_module')",
-      m_dictionary_name.c_str());
+  run_string.Printf("run_one_line (%s, 'import copy, keyword, os, re, sys, "
+                    "uuid, lldb, importlib')",
+                    m_dictionary_name.c_str());
   RunSimpleString(run_string.GetData());
 
   // WARNING: temporary code that loads Cocoa formatters - this should be done
@@ -2635,10 +2627,10 @@ bool ScriptInterpreterPythonImpl::LoadScriptingModule(
 
   if (was_imported_globally || was_imported_locally) {
     if (!was_imported_locally)
-      command_stream.Printf("import %s ; reload_module(%s)",
+      command_stream.Printf("import %s ; importlib.reload(%s)",
                             module_name.c_str(), module_name.c_str());
     else
-      command_stream.Printf("reload_module(%s)", module_name.c_str());
+      command_stream.Printf("importlib.reload(%s)", module_name.c_str());
   } else
     command_stream.Printf("import %s", module_name.c_str());
 


### PR DESCRIPTION
Instead of importing it as reload_module. That name comes from https://reviews.llvm.org/D15209/
7d2d09842a428bc0b45414ff0f32391a447e048d.
reload_module is what the 2/3 compatibility library "six" called it.

In Python 2 "reload" was a builtin and 3 moved it into importlib. We require 3.8 so we don't need to consider 2 anymore.