### PR TITLE
[OpenMP] Fix race in setupIndirectCallTable

### DIFF
--- a/offload/libomptarget/device.cpp
+++ b/offload/libomptarget/device.cpp
@@ -203,8 +203,9 @@ setupIndirectCallTable(DeviceTy &Device, __tgt_device_image *Image,
   // The IndirectCallTable is on the stack, so we must syncronize to ensure
   // the data is copied before we return.
   if (Device.synchronize(AsyncInfo))
-    return error::createOffloadError(error::ErrorCode::INVALID_BINARY,
-                                     "failed to synchronize after copying data");
+    return error::createOffloadError(
+        error::ErrorCode::INVALID_BINARY,
+        "failed to synchronize after copying data");
 
   return std::pair<void *, uint64_t>(DevicePtr, IndirectCallTable.size());
 }

--- a/offload/libomptarget/device.cpp
+++ b/offload/libomptarget/device.cpp
@@ -200,6 +200,12 @@ setupIndirectCallTable(DeviceTy &Device, __tgt_device_image *Image,
                         AsyncInfo))
     return error::createOffloadError(error::ErrorCode::INVALID_BINARY,
                                      "failed to copy data");
+  // The IndirectCallTable is on the stack, so we must syncronize to ensure
+  // the data is copied before we return.
+  if (Device.synchronize(AsyncInfo))
+    return error::createOffloadError(error::ErrorCode::INVALID_BINARY,
+                                     "failed to synchronize after copying data");
+
   return std::pair<void *, uint64_t>(DevicePtr, IndirectCallTable.size());
 }
 


### PR DESCRIPTION
The IndirectCallTable variable where the table is constructed is a local variable. The copy to the device is right now not synchronized, so the frame where the table resides can be overwritten before the GPU copy has accessed the host data which corrupts the device side table.

Fix it by make it a synchronous operation.