### PR TITLE
[SystemZ][z/OS] Support emitting common symbols in HLASM

### DIFF
--- a/llvm/include/llvm/MC/MCGOFFStreamer.h
+++ b/llvm/include/llvm/MC/MCGOFFStreamer.h
@@ -38,9 +38,6 @@ public:
 
   void emitCommonSymbol(MCSymbol *Symbol, uint64_t Size,
                         Align ByteAlignment) override;
-
-  static void emitCommonSymbolImpl(MCStreamer *Streamer, MCSymbolGOFF *Symbol,
-                                   uint64_t Size, Align ByteAlignment);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/MC/MCGOFFStreamer.h
+++ b/llvm/include/llvm/MC/MCGOFFStreamer.h
@@ -38,6 +38,9 @@ public:
 
   void emitCommonSymbol(MCSymbol *Symbol, uint64_t Size,
                         Align ByteAlignment) override;
+
+  static void emitCommonSymbolImpl(MCStreamer *Streamer, MCSymbolGOFF *Symbol,
+                                   uint64_t Size, Align ByteAlignment);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/MC/MCSymbolGOFF.h
+++ b/llvm/include/llvm/MC/MCSymbolGOFF.h
@@ -19,8 +19,11 @@
 #include "llvm/MC/MCSectionGOFF.h"
 #include "llvm/MC/MCSymbol.h"
 #include "llvm/MC/MCSymbolTableEntry.h"
+#include "llvm/Support/Alignment.h"
 
 namespace llvm {
+
+class MCContext;
 
 class MCSymbolGOFF : public MCSymbol {
 
@@ -91,6 +94,10 @@ public:
   }
 
   LLVM_ABI bool setSymbolAttribute(MCSymbolAttr Attribute);
+
+  /// Return the PR section to use when emitting this symbol as a common symbol.
+  LLVM_ABI MCSectionGOFF *getSectionForCommonSymbol(MCContext &Ctx,
+                                                    Align ByteAlignment);
 
   bool isInEDSection() const {
     return isInSection() && static_cast<MCSectionGOFF &>(getSection()).isED();

--- a/llvm/lib/MC/MCGOFFStreamer.cpp
+++ b/llvm/lib/MC/MCGOFFStreamer.cpp
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/MC/MCGOFFStreamer.h"
-#include "llvm/BinaryFormat/GOFF.h"
 #include "llvm/MC/MCAsmBackend.h"
 #include "llvm/MC/MCAssembler.h"
 #include "llvm/MC/MCCodeEmitter.h"
@@ -73,38 +72,16 @@ bool MCGOFFStreamer::emitSymbolAttribute(MCSymbol *Sym,
   return static_cast<MCSymbolGOFF *>(Sym)->setSymbolAttribute(Attribute);
 }
 
-void MCGOFFStreamer::emitCommonSymbolImpl(MCStreamer *Streamer,
-                                          MCSymbolGOFF *Symbol, uint64_t Size,
-                                          Align ByteAlignment) {
-  MCSectionGOFF *SD = Streamer->getContext().getGOFFSection(
-      SectionKind::getMetadata(), Symbol->getName(),
-      GOFF::SDAttr{GOFF::ESD_TA_Unspecified, GOFF::ESD_BSC_Unspecified});
-
-  MCSectionGOFF *ED = Streamer->getContext().getGOFFSection(
-      SectionKind::getMetadata(), GOFF::CLASS_WSA,
-      GOFF::EDAttr{false, GOFF::ESD_RMODE_64, GOFF::ESD_NS_Parts,
-                   GOFF::ESD_TS_ByteOriented, GOFF::ESD_BA_Merge,
-                   GOFF::ESD_LB_Deferred, GOFF::ESD_RQ_0, 0},
-      SD);
-  ED->setAlignment(ByteAlignment);
-
-  MCSectionGOFF *Section = Streamer->getContext().getGOFFSection(
-      SectionKind::getBSS(), Symbol->getName(),
-      GOFF::PRAttr{false, GOFF::ESD_EXE_DATA, GOFF::ESD_LT_XPLink,
-                   Symbol->getBindingScope(), 0},
-      ED);
-
-  Streamer->pushSection();
-  Streamer->switchSection(Section);
-  Streamer->emitLabel(Symbol);
-  Streamer->emitZeros(Size);
-  Streamer->popSection();
-}
-
 void MCGOFFStreamer::emitCommonSymbol(MCSymbol *S, uint64_t Size,
                                       Align ByteAlignment) {
   auto *Symbol = static_cast<MCSymbolGOFF *>(S);
-  emitCommonSymbolImpl(this, Symbol, Size, ByteAlignment);
+  MCSectionGOFF *Section =
+      Symbol->getSectionForCommonSymbol(getContext(), ByteAlignment);
+  pushSection();
+  switchSection(Section);
+  emitLabel(Symbol);
+  emitZeros(Size);
+  popSection();
 }
 
 MCStreamer *llvm::createGOFFStreamer(MCContext &Context,

--- a/llvm/lib/MC/MCGOFFStreamer.cpp
+++ b/llvm/lib/MC/MCGOFFStreamer.cpp
@@ -73,15 +73,14 @@ bool MCGOFFStreamer::emitSymbolAttribute(MCSymbol *Sym,
   return static_cast<MCSymbolGOFF *>(Sym)->setSymbolAttribute(Attribute);
 }
 
-void MCGOFFStreamer::emitCommonSymbol(MCSymbol *S, uint64_t Size,
-                                      Align ByteAlignment) {
-  auto *Symbol = static_cast<MCSymbolGOFF *>(S);
-
-  MCSectionGOFF *SD = getContext().getGOFFSection(
+void MCGOFFStreamer::emitCommonSymbolImpl(MCStreamer *Streamer,
+                                          MCSymbolGOFF *Symbol, uint64_t Size,
+                                          Align ByteAlignment) {
+  MCSectionGOFF *SD = Streamer->getContext().getGOFFSection(
       SectionKind::getMetadata(), Symbol->getName(),
       GOFF::SDAttr{GOFF::ESD_TA_Unspecified, GOFF::ESD_BSC_Unspecified});
 
-  MCSectionGOFF *ED = getContext().getGOFFSection(
+  MCSectionGOFF *ED = Streamer->getContext().getGOFFSection(
       SectionKind::getMetadata(), GOFF::CLASS_WSA,
       GOFF::EDAttr{false, GOFF::ESD_RMODE_64, GOFF::ESD_NS_Parts,
                    GOFF::ESD_TS_ByteOriented, GOFF::ESD_BA_Merge,
@@ -89,17 +88,23 @@ void MCGOFFStreamer::emitCommonSymbol(MCSymbol *S, uint64_t Size,
       SD);
   ED->setAlignment(ByteAlignment);
 
-  MCSectionGOFF *Section = getContext().getGOFFSection(
+  MCSectionGOFF *Section = Streamer->getContext().getGOFFSection(
       SectionKind::getBSS(), Symbol->getName(),
       GOFF::PRAttr{false, GOFF::ESD_EXE_DATA, GOFF::ESD_LT_XPLink,
                    Symbol->getBindingScope(), 0},
       ED);
 
-  pushSection();
-  switchSection(Section);
-  emitLabel(Symbol);
-  emitZeros(Size);
-  popSection();
+  Streamer->pushSection();
+  Streamer->switchSection(Section);
+  Streamer->emitLabel(Symbol);
+  Streamer->emitZeros(Size);
+  Streamer->popSection();
+}
+
+void MCGOFFStreamer::emitCommonSymbol(MCSymbol *S, uint64_t Size,
+                                      Align ByteAlignment) {
+  auto *Symbol = static_cast<MCSymbolGOFF *>(S);
+  emitCommonSymbolImpl(this, Symbol, Size, ByteAlignment);
 }
 
 MCStreamer *llvm::createGOFFStreamer(MCContext &Context,

--- a/llvm/lib/MC/MCSymbolGOFF.cpp
+++ b/llvm/lib/MC/MCSymbolGOFF.cpp
@@ -8,9 +8,32 @@
 
 #include "llvm/MC/MCSymbolGOFF.h"
 #include "llvm/BinaryFormat/GOFF.h"
+#include "llvm/MC/MCContext.h"
+#include "llvm/Support/Alignment.h"
 #include "llvm/Support/ErrorHandling.h"
 
 using namespace llvm;
+
+MCSectionGOFF *MCSymbolGOFF::getSectionForCommonSymbol(MCContext &Ctx,
+                                                       Align ByteAlignment) {
+  MCSectionGOFF *SD = Ctx.getGOFFSection(
+      SectionKind::getMetadata(), getName(),
+      GOFF::SDAttr{GOFF::ESD_TA_Unspecified, GOFF::ESD_BSC_Unspecified});
+
+  MCSectionGOFF *ED = Ctx.getGOFFSection(
+      SectionKind::getMetadata(), GOFF::CLASS_WSA,
+      GOFF::EDAttr{false, GOFF::ESD_RMODE_64, GOFF::ESD_NS_Parts,
+                   GOFF::ESD_TS_ByteOriented, GOFF::ESD_BA_Merge,
+                   GOFF::ESD_LB_Deferred, GOFF::ESD_RQ_0, 0},
+      SD);
+  ED->setAlignment(ByteAlignment);
+
+  return Ctx.getGOFFSection(SectionKind::getBSS(), getName(),
+                            GOFF::PRAttr{false, GOFF::ESD_EXE_DATA,
+                                         GOFF::ESD_LT_XPLink, getBindingScope(),
+                                         0},
+                            ED);
+}
 
 bool MCSymbolGOFF::setSymbolAttribute(MCSymbolAttr Attribute) {
   switch (Attribute) {

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZHLASMAsmStreamer.cpp
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZHLASMAsmStreamer.cpp
@@ -491,6 +491,12 @@ bool SystemZHLASMAsmStreamer::emitSymbolAttribute(MCSymbol *Sym,
   return static_cast<MCSymbolGOFF *>(Sym)->setSymbolAttribute(Attribute);
 }
 
+void SystemZHLASMAsmStreamer::emitCommonSymbol(MCSymbol *S, uint64_t Size,
+                                               Align ByteAlignment) {
+  auto *Symbol = static_cast<MCSymbolGOFF *>(S);
+  MCGOFFStreamer::emitCommonSymbolImpl(this, Symbol, Size, ByteAlignment);
+}
+
 void SystemZHLASMAsmStreamer::emitRawTextImpl(StringRef String) {
   String.consume_back("\n");
   OS << String;

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZHLASMAsmStreamer.cpp
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZHLASMAsmStreamer.cpp
@@ -10,8 +10,6 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/BinaryFormat/GOFF.h"
 #include "llvm/MC/MCExpr.h"
-#include "llvm/MC/MCGOFFAttributes.h"
-#include "llvm/MC/MCGOFFStreamer.h"
 #include "llvm/MC/MCSectionGOFF.h"
 #include "llvm/MC/MCSymbolGOFF.h"
 #include "llvm/Support/Casting.h"
@@ -494,7 +492,13 @@ bool SystemZHLASMAsmStreamer::emitSymbolAttribute(MCSymbol *Sym,
 void SystemZHLASMAsmStreamer::emitCommonSymbol(MCSymbol *S, uint64_t Size,
                                                Align ByteAlignment) {
   auto *Symbol = static_cast<MCSymbolGOFF *>(S);
-  MCGOFFStreamer::emitCommonSymbolImpl(this, Symbol, Size, ByteAlignment);
+  MCSectionGOFF *Section =
+      Symbol->getSectionForCommonSymbol(getContext(), ByteAlignment);
+  pushSection();
+  switchSection(Section);
+  emitLabel(Symbol, SMLoc());
+  emitZeros(Size);
+  popSection();
 }
 
 void SystemZHLASMAsmStreamer::emitRawTextImpl(StringRef String) {

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZHLASMAsmStreamer.h
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZHLASMAsmStreamer.h
@@ -101,7 +101,7 @@ public:
   bool emitSymbolAttribute(MCSymbol *Symbol, MCSymbolAttr Attribute) override;
 
   void emitCommonSymbol(MCSymbol *Symbol, uint64_t Size,
-                        Align ByteAlignment) override {}
+                        Align ByteAlignment) override;
 
   void emitZerofill(MCSection *Section, MCSymbol *Symbol = nullptr,
                     uint64_t Size = 0, Align ByteAlignment = Align(1),

--- a/llvm/test/CodeGen/SystemZ/zos-common-global.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-common-global.ll
@@ -1,7 +1,12 @@
 ; RUN: llc <%s --mtriple s390x-ibm-zos --filetype=obj | \
 ; RUN:   od -Ax -tx1 -v | FileCheck --ignore-case %s
+; RUN: llc <%s --mtriple s390x-ibm-zos | FileCheck --check-prefix CHECK-ASM %s
 
 @x = common global i32 0, align 4
+
+; CHECK-ASM: x CSECT
+; CHECK-ASM: C_WSA64 CATTR ALIGN(2),FILL(0),DEFLOAD,NOTEXECUTABLE,RMODE(64),PART(x)
+; CHECK-ASM: x XATTR LINKAGE(XPLINK),REFERENCE(DATA),SCOPE(EXPORT)
 
 ; ESD record, type SD.
 ; The name is x.


### PR DESCRIPTION
This is a follow-up to #210179. It reuses the logic to emit common symbols in HLASM, too.