### PR TITLE
[NFC][analyzer] Refactor processCFGBlockEntrance

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
@@ -266,8 +266,6 @@ class NodeBuilder {
 protected:
   const NodeBuilderContext &C;
 
-  bool HasGeneratedNodes = false;
-
   /// The frontier set - a set of nodes which need to be propagated after
   /// the builder dies.
   ExplodedNodeSet &Frontier;
@@ -324,8 +322,6 @@ public:
   }
 
   const ExplodedNodeSet &getResults() const { return Frontier; }
-
-  bool hasGeneratedNodes() const { return HasGeneratedNodes; }
 
   void takeNodes(const ExplodedNodeSet &S) {
     for (const auto I : S)

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
@@ -388,7 +388,8 @@ public:
                             ExplodedNode *Pred, ExplodedNodeSet &Dst);
 
   /// Called by CoreEngine when processing the entrance of a CFGBlock.
-  void processCFGBlockEntrance(const BlockEntrance &BE, NodeBuilder &Builder,
+  /// Returns true if it has generated a new node.
+  bool processCFGBlockEntrance(const BlockEntrance &BE, NodeBuilder &Builder,
                                ExplodedNode *Pred);
 
   void runCheckersForBlockEntrance(const BlockEntrance &Entrance,

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
@@ -388,9 +388,9 @@ public:
                             ExplodedNode *Pred, ExplodedNodeSet &Dst);
 
   /// Called by CoreEngine when processing the entrance of a CFGBlock.
-  /// Returns true if it has generated a new node.
-  bool processCFGBlockEntrance(const BlockEntrance &BE, NodeBuilder &Builder,
-                               ExplodedNode *Pred);
+  /// Returns nullptr or a node descending from Pred.
+  ExplodedNode *processCFGBlockEntrance(const BlockEntrance &BE,
+                                        ExplodedNode *Pred);
 
   void runCheckersForBlockEntrance(const BlockEntrance &Entrance,
                                    ExplodedNode *Pred, ExplodedNodeSet &Dst);

--- a/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
@@ -327,10 +327,10 @@ void CoreEngine::HandleBlockEdge(const BlockEdge &L, ExplodedNode *Pred) {
   BlockEntrance BE(L.getSrc(), L.getDst(), Pred->getStackFrame());
   ExplodedNodeSet DstNodes;
   NodeBuilder Builder(Pred, DstNodes, ExprEng.getBuilderContext());
-  ExprEng.processCFGBlockEntrance(BE, Builder, Pred);
+  bool HasGeneratedNodes = ExprEng.processCFGBlockEntrance(BE, Builder, Pred);
 
   // Auto-generate a node.
-  if (!Builder.hasGeneratedNodes()) {
+  if (!HasGeneratedNodes) {
     Builder.generateNode(BE, Pred->State, Pred);
   }
 
@@ -681,7 +681,6 @@ void CoreEngine::enqueueEndOfFunction(ExplodedNodeSet &Set, const ReturnStmt *RS
 ExplodedNode *NodeBuilder::generateNode(const ProgramPoint &Loc,
                                         ProgramStateRef State,
                                         ExplodedNode *FromN, bool MarkAsSink) {
-  HasGeneratedNodes = true;
   Frontier.erase(FromN);
   ExplodedNode *N = C.getEngine().makeNode(Loc, State, FromN, MarkAsSink);
 

--- a/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
@@ -326,7 +326,7 @@ void CoreEngine::HandleBlockEdge(const BlockEdge &L, ExplodedNode *Pred) {
   // Call into the ExprEngine to process entering the CFGBlock.
   BlockEntrance BE(L.getSrc(), L.getDst(), Pred->getStackFrame());
   ExplodedNodeSet DstNodes;
-  NodeBuilder Builder(Pred, DstNodes, ExprEng.getBuilderContext());
+  NodeBuilder Builder(DstNodes, ExprEng.getBuilderContext());
   bool HasGeneratedNodes = ExprEng.processCFGBlockEntrance(BE, Builder, Pred);
 
   // Auto-generate a node.

--- a/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
@@ -329,9 +329,8 @@ void CoreEngine::HandleBlockEdge(const BlockEdge &L, ExplodedNode *Pred) {
 
   ExplodedNodeSet CheckerNodes;
 
-  if (Processed && !Processed->isSink()) {
+  if (Processed)
     ExprEng.runCheckersForBlockEntrance(BE, Processed, CheckerNodes);
-  }
 
   // Enqueue nodes onto the worklist.
   enqueue(CheckerNodes);

--- a/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
@@ -325,18 +325,12 @@ void CoreEngine::HandleBlockEdge(const BlockEdge &L, ExplodedNode *Pred) {
 
   // Call into the ExprEngine to process entering the CFGBlock.
   BlockEntrance BE(L.getSrc(), L.getDst(), Pred->getStackFrame());
-  ExplodedNodeSet DstNodes;
-  NodeBuilder Builder(DstNodes, ExprEng.getBuilderContext());
-  bool HasGeneratedNodes = ExprEng.processCFGBlockEntrance(BE, Builder, Pred);
-
-  // Auto-generate a node.
-  if (!HasGeneratedNodes) {
-    Builder.generateNode(BE, Pred->State, Pred);
-  }
+  ExplodedNode *Processed = ExprEng.processCFGBlockEntrance(BE, Pred);
 
   ExplodedNodeSet CheckerNodes;
-  for (auto *N : DstNodes) {
-    ExprEng.runCheckersForBlockEntrance(BE, N, CheckerNodes);
+
+  if (Processed && !Processed->isSink()) {
+    ExprEng.runCheckersForBlockEntrance(BE, Processed, CheckerNodes);
   }
 
   // Enqueue nodes onto the worklist.

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -2390,9 +2390,10 @@ bool ExprEngine::replayWithoutInlining(ExplodedNode *N,
 }
 
 /// Block entrance.  (Update counters).
-void ExprEngine::processCFGBlockEntrance(const BlockEntrance &BE,
+bool ExprEngine::processCFGBlockEntrance(const BlockEntrance &BE,
                                          NodeBuilder &Builder,
                                          ExplodedNode *Pred) {
+  bool HasGeneratedNodes = false;
   // If we reach a loop which has a known bound (and meets
   // other constraints) then consider completely unrolling it.
   if(AMgr.options.ShouldUnrollLoops) {
@@ -2402,15 +2403,16 @@ void ExprEngine::processCFGBlockEntrance(const BlockEntrance &BE,
       ProgramStateRef NewState = updateLoopStack(Term, AMgr.getASTContext(),
                                                  Pred, maxBlockVisitOnPath);
       if (NewState != Pred->getState()) {
+        HasGeneratedNodes = true;
         ExplodedNode *UpdatedNode = Builder.generateNode(BE, NewState, Pred);
         if (!UpdatedNode)
-          return;
+          return HasGeneratedNodes;
         Pred = UpdatedNode;
       }
     }
     // Is we are inside an unrolled loop then no need the check the counters.
     if(isUnrolledState(Pred->getState()))
-      return;
+      return HasGeneratedNodes;
   }
 
   // If this block is terminated by a loop and it has already been visited the
@@ -2420,7 +2422,7 @@ void ExprEngine::processCFGBlockEntrance(const BlockEntrance &BE,
       AMgr.options.ShouldWidenLoops) {
     const Stmt *Term = getCurrBlock()->getTerminatorStmt();
     if (!isa_and_nonnull<ForStmt, WhileStmt, DoStmt, CXXForRangeStmt>(Term))
-      return;
+      return HasGeneratedNodes;
 
     // Widen.
     const StackFrame *SF = Pred->getStackFrame();
@@ -2433,14 +2435,16 @@ void ExprEngine::processCFGBlockEntrance(const BlockEntrance &BE,
     // Here we just pass the the first CFG element in the block.
     ProgramStateRef WidenedState = getWidenedLoopState(
         Pred->getState(), SF, BlockCount, *getCurrBlock()->ref_begin());
+    HasGeneratedNodes = true;
     Builder.generateNode(BE, WidenedState, Pred);
-    return;
+    return HasGeneratedNodes;
   }
 
   // FIXME: Refactor this into a checker.
   if (BlockCount >= AMgr.options.maxBlockVisitOnPath) {
     static SimpleProgramPointTag Tag(TagProviderName, "Block count exceeded");
     const ProgramPoint TaggedLoc = BE.withTag(&Tag);
+    HasGeneratedNodes = true;
     const ExplodedNode *Sink =
         Builder.generateSink(TaggedLoc, Pred->getState(), Pred);
 
@@ -2462,7 +2466,7 @@ void ExprEngine::processCFGBlockEntrance(const BlockEntrance &BE,
       // the list. Replay should almost never fail. Use the stats to catch it
       // if it does.
       if ((!AMgr.options.NoRetryExhausted && replayWithoutInlining(Pred, SF)))
-        return;
+        return HasGeneratedNodes;
       NumMaxBlockCountReachedInInlined++;
     } else
       NumMaxBlockCountReached++;
@@ -2470,6 +2474,7 @@ void ExprEngine::processCFGBlockEntrance(const BlockEntrance &BE,
     // Make sink nodes as exhausted(for stats) only if retry failed.
     Engine.blocksExhausted.push_back(std::make_pair(BE, Sink));
   }
+  return HasGeneratedNodes;
 }
 
 void ExprEngine::runCheckersForBlockEntrance(const BlockEntrance &Entrance,

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -2407,10 +2407,9 @@ ExplodedNode *ExprEngine::processCFGBlockEntrance(const BlockEntrance &BE,
                                                  Pred, maxBlockVisitOnPath);
       if (NewState != Pred->getState()) {
         HasGeneratedNodes = true;
-        ExplodedNode *UpdatedNode = Engine.makeNode(BE, NewState, Pred);
-        if (!UpdatedNode)
+        Pred = Engine.makeNode(BE, NewState, Pred);
+        if (!Pred)
           return nullptr;
-        Pred = UpdatedNode;
       }
     }
     // Is we are inside an unrolled loop then no need the check the counters.

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -2442,10 +2442,8 @@ ExplodedNode *ExprEngine::processCFGBlockEntrance(const BlockEntrance &BE,
     return HasGeneratedNodes ? Pred : MakeDefaultNode();
 
   static SimpleProgramPointTag Tag(TagProviderName, "Block count exceeded");
-  const ProgramPoint TaggedLoc = BE.withTag(&Tag);
-  HasGeneratedNodes = true;
-  const ExplodedNode *Sink =
-      Engine.makeNode(TaggedLoc, Pred->getState(), Pred, /*MarkAsSink=*/true);
+  const ExplodedNode *Sink = Engine.makeNode(BE.withTag(&Tag), Pred->getState(),
+                                             Pred, /*MarkAsSink=*/true);
 
   if (!SF->inTopFrame()) {
     // FIXME: This will unconditionally prevent inlining this function (even

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -2393,6 +2393,7 @@ bool ExprEngine::replayWithoutInlining(ExplodedNode *N,
 ExplodedNode *ExprEngine::processCFGBlockEntrance(const BlockEntrance &BE,
                                                   ExplodedNode *Pred) {
   const StackFrame *SF = Pred->getStackFrame();
+  const Stmt *Term = getCurrBlock()->getTerminatorStmt();
   bool HasGeneratedNodes = false;
   auto MakeDefaultNode = [BE, &Engine = Engine, OriginalPred = Pred]() {
     return Engine.makeNode(BE, OriginalPred->getState(), OriginalPred);
@@ -2402,7 +2403,6 @@ ExplodedNode *ExprEngine::processCFGBlockEntrance(const BlockEntrance &BE,
   // other constraints) then consider completely unrolling it.
   if(AMgr.options.ShouldUnrollLoops) {
     unsigned maxBlockVisitOnPath = AMgr.options.maxBlockVisitOnPath;
-    const Stmt *Term = getCurrBlock()->getTerminatorStmt();
     if (Term) {
       ProgramStateRef NewState = updateLoopStack(Term, AMgr.getASTContext(),
                                                  Pred, maxBlockVisitOnPath);
@@ -2423,7 +2423,6 @@ ExplodedNode *ExprEngine::processCFGBlockEntrance(const BlockEntrance &BE,
   unsigned int BlockCount = getNumVisitedCurrent();
   if (BlockCount == AMgr.options.maxBlockVisitOnPath - 1 &&
       AMgr.options.ShouldWidenLoops) {
-    const Stmt *Term = getCurrBlock()->getTerminatorStmt();
     if (!isa_and_nonnull<ForStmt, WhileStmt, DoStmt, CXXForRangeStmt>(Term))
       return HasGeneratedNodes ? Pred : MakeDefaultNode();
 

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -2395,15 +2395,13 @@ ExplodedNode *ExprEngine::processCFGBlockEntrance(const BlockEntrance &BE,
   const StackFrame *SF = Pred->getStackFrame();
   const Stmt *Term = getCurrBlock()->getTerminatorStmt();
   ProgramStateRef State = Pred->getState();
+  unsigned MaxBlockVisit = AMgr.options.maxBlockVisitOnPath;
 
   // If we reach a loop which has a known bound (and meets
   // other constraints) then consider completely unrolling it.
   if(AMgr.options.ShouldUnrollLoops) {
-    unsigned maxBlockVisitOnPath = AMgr.options.maxBlockVisitOnPath;
-    if (Term) {
-      State = updateLoopStack(Term, AMgr.getASTContext(), Pred,
-                              maxBlockVisitOnPath);
-    }
+    if (Term)
+      State = updateLoopStack(Term, AMgr.getASTContext(), Pred, MaxBlockVisit);
     // Is we are inside an unrolled loop then no need the check the counters.
     if (isUnrolledState(State))
       return Engine.makeNode(BE, State, Pred);
@@ -2412,8 +2410,7 @@ ExplodedNode *ExprEngine::processCFGBlockEntrance(const BlockEntrance &BE,
   // If this block is terminated by a loop and it has already been visited the
   // maximum number of times, widen the loop.
   unsigned int BlockCount = getNumVisitedCurrent();
-  if (BlockCount == AMgr.options.maxBlockVisitOnPath - 1 &&
-      AMgr.options.ShouldWidenLoops) {
+  if (BlockCount == MaxBlockVisit - 1 && AMgr.options.ShouldWidenLoops) {
     if (!isa_and_nonnull<ForStmt, WhileStmt, DoStmt, CXXForRangeStmt>(Term))
       return Engine.makeNode(BE, State, Pred);
 
@@ -2436,7 +2433,7 @@ ExplodedNode *ExprEngine::processCFGBlockEntrance(const BlockEntrance &BE,
     return Engine.makeNode(BE, WidenedState, Pred);
   }
 
-  if (BlockCount < AMgr.options.maxBlockVisitOnPath)
+  if (BlockCount < MaxBlockVisit)
     return Engine.makeNode(BE, State, Pred);
 
   if (State != Pred->getState()) {

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -2390,10 +2390,13 @@ bool ExprEngine::replayWithoutInlining(ExplodedNode *N,
 }
 
 /// Block entrance.  (Update counters).
-bool ExprEngine::processCFGBlockEntrance(const BlockEntrance &BE,
-                                         NodeBuilder &Builder,
-                                         ExplodedNode *Pred) {
+ExplodedNode *ExprEngine::processCFGBlockEntrance(const BlockEntrance &BE,
+                                                  ExplodedNode *Pred) {
   bool HasGeneratedNodes = false;
+  auto MakeDefaultNode = [BE, &Engine = Engine, OriginalPred = Pred]() {
+    return Engine.makeNode(BE, OriginalPred->getState(), OriginalPred);
+  };
+
   // If we reach a loop which has a known bound (and meets
   // other constraints) then consider completely unrolling it.
   if(AMgr.options.ShouldUnrollLoops) {
@@ -2404,15 +2407,15 @@ bool ExprEngine::processCFGBlockEntrance(const BlockEntrance &BE,
                                                  Pred, maxBlockVisitOnPath);
       if (NewState != Pred->getState()) {
         HasGeneratedNodes = true;
-        ExplodedNode *UpdatedNode = Builder.generateNode(BE, NewState, Pred);
+        ExplodedNode *UpdatedNode = Engine.makeNode(BE, NewState, Pred);
         if (!UpdatedNode)
-          return HasGeneratedNodes;
+          return nullptr;
         Pred = UpdatedNode;
       }
     }
     // Is we are inside an unrolled loop then no need the check the counters.
     if(isUnrolledState(Pred->getState()))
-      return HasGeneratedNodes;
+      return HasGeneratedNodes ? Pred : MakeDefaultNode();
   }
 
   // If this block is terminated by a loop and it has already been visited the
@@ -2422,7 +2425,7 @@ bool ExprEngine::processCFGBlockEntrance(const BlockEntrance &BE,
       AMgr.options.ShouldWidenLoops) {
     const Stmt *Term = getCurrBlock()->getTerminatorStmt();
     if (!isa_and_nonnull<ForStmt, WhileStmt, DoStmt, CXXForRangeStmt>(Term))
-      return HasGeneratedNodes;
+      return HasGeneratedNodes ? Pred : MakeDefaultNode();
 
     // Widen.
     const StackFrame *SF = Pred->getStackFrame();
@@ -2435,9 +2438,7 @@ bool ExprEngine::processCFGBlockEntrance(const BlockEntrance &BE,
     // Here we just pass the the first CFG element in the block.
     ProgramStateRef WidenedState = getWidenedLoopState(
         Pred->getState(), SF, BlockCount, *getCurrBlock()->ref_begin());
-    HasGeneratedNodes = true;
-    Builder.generateNode(BE, WidenedState, Pred);
-    return HasGeneratedNodes;
+    return Engine.makeNode(BE, WidenedState, Pred);
   }
 
   // FIXME: Refactor this into a checker.
@@ -2446,7 +2447,7 @@ bool ExprEngine::processCFGBlockEntrance(const BlockEntrance &BE,
     const ProgramPoint TaggedLoc = BE.withTag(&Tag);
     HasGeneratedNodes = true;
     const ExplodedNode *Sink =
-        Builder.generateSink(TaggedLoc, Pred->getState(), Pred);
+        Engine.makeNode(TaggedLoc, Pred->getState(), Pred, /*MarkAsSink=*/true);
 
     const StackFrame *SF = Pred->getStackFrame();
     if (!SF->inTopFrame()) {
@@ -2466,15 +2467,17 @@ bool ExprEngine::processCFGBlockEntrance(const BlockEntrance &BE,
       // the list. Replay should almost never fail. Use the stats to catch it
       // if it does.
       if ((!AMgr.options.NoRetryExhausted && replayWithoutInlining(Pred, SF)))
-        return HasGeneratedNodes;
+        return nullptr;
       NumMaxBlockCountReachedInInlined++;
     } else
       NumMaxBlockCountReached++;
 
     // Make sink nodes as exhausted(for stats) only if retry failed.
     Engine.blocksExhausted.push_back(std::make_pair(BE, Sink));
+
+    return nullptr;
   }
-  return HasGeneratedNodes;
+  return HasGeneratedNodes ? Pred : MakeDefaultNode();
 }
 
 void ExprEngine::runCheckersForBlockEntrance(const BlockEntrance &Entrance,

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -2441,43 +2441,42 @@ ExplodedNode *ExprEngine::processCFGBlockEntrance(const BlockEntrance &BE,
     return Engine.makeNode(BE, WidenedState, Pred);
   }
 
-  // FIXME: Refactor this into a checker.
-  if (BlockCount >= AMgr.options.maxBlockVisitOnPath) {
-    static SimpleProgramPointTag Tag(TagProviderName, "Block count exceeded");
-    const ProgramPoint TaggedLoc = BE.withTag(&Tag);
-    HasGeneratedNodes = true;
-    const ExplodedNode *Sink =
-        Engine.makeNode(TaggedLoc, Pred->getState(), Pred, /*MarkAsSink=*/true);
+  if (BlockCount < AMgr.options.maxBlockVisitOnPath)
+    return HasGeneratedNodes ? Pred : MakeDefaultNode();
 
-    const StackFrame *SF = Pred->getStackFrame();
-    if (!SF->inTopFrame()) {
-      // FIXME: This will unconditionally prevent inlining this function (even
-      // from other entry points), which is not a reasonable heuristic: even if
-      // we reached max block count on this particular execution path, there
-      // may be other execution paths (especially with other parametrizations)
-      // where the analyzer can reach the end of the function (so there is no
-      // natural reason to avoid inlining it). However, disabling this would
-      // significantly increase the analysis time (because more entry points
-      // would exhaust their allocated budget), so it must be compensated by a
-      // different (more reasonable) reduction of analysis scope.
-      Engine.FunctionSummaries->markShouldNotInline(SF->getDecl());
+  static SimpleProgramPointTag Tag(TagProviderName, "Block count exceeded");
+  const ProgramPoint TaggedLoc = BE.withTag(&Tag);
+  HasGeneratedNodes = true;
+  const ExplodedNode *Sink =
+      Engine.makeNode(TaggedLoc, Pred->getState(), Pred, /*MarkAsSink=*/true);
 
-      // Re-run the call evaluation without inlining it, by storing the
-      // no-inlining policy in the state and enqueuing the new work item on
-      // the list. Replay should almost never fail. Use the stats to catch it
-      // if it does.
-      if ((!AMgr.options.NoRetryExhausted && replayWithoutInlining(Pred, SF)))
-        return nullptr;
-      NumMaxBlockCountReachedInInlined++;
-    } else
-      NumMaxBlockCountReached++;
+  const StackFrame *SF = Pred->getStackFrame();
+  if (!SF->inTopFrame()) {
+    // FIXME: This will unconditionally prevent inlining this function (even
+    // from other entry points), which is not a reasonable heuristic: even if
+    // we reached max block count on this particular execution path, there
+    // may be other execution paths (especially with other parametrizations)
+    // where the analyzer can reach the end of the function (so there is no
+    // natural reason to avoid inlining it). However, disabling this would
+    // significantly increase the analysis time (because more entry points
+    // would exhaust their allocated budget), so it must be compensated by a
+    // different (more reasonable) reduction of analysis scope.
+    Engine.FunctionSummaries->markShouldNotInline(SF->getDecl());
 
-    // Make sink nodes as exhausted(for stats) only if retry failed.
-    Engine.blocksExhausted.push_back(std::make_pair(BE, Sink));
+    // Re-run the call evaluation without inlining it, by storing the
+    // no-inlining policy in the state and enqueuing the new work item on
+    // the list. Replay should almost never fail. Use the stats to catch it
+    // if it does.
+    if ((!AMgr.options.NoRetryExhausted && replayWithoutInlining(Pred, SF)))
+      return nullptr;
+    NumMaxBlockCountReachedInInlined++;
+  } else
+    NumMaxBlockCountReached++;
 
-    return nullptr;
-  }
-  return HasGeneratedNodes ? Pred : MakeDefaultNode();
+  // Make sink nodes as exhausted(for stats) only if retry failed.
+  Engine.blocksExhausted.push_back(std::make_pair(BE, Sink));
+
+  return nullptr;
 }
 
 void ExprEngine::runCheckersForBlockEntrance(const BlockEntrance &Entrance,

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -2397,9 +2397,9 @@ ExplodedNode *ExprEngine::processCFGBlockEntrance(const BlockEntrance &BE,
   ProgramStateRef State = Pred->getState();
   unsigned MaxBlockVisit = AMgr.options.maxBlockVisitOnPath;
 
-  // If we reach a loop which has a known bound (and meets
-  // other constraints) then consider completely unrolling it.
-  if(AMgr.options.ShouldUnrollLoops) {
+  // If we reach a loop which has a known bound (and meets other constraints)
+  // then consider completely unrolling it.
+  if (AMgr.options.ShouldUnrollLoops) {
     if (Term)
       State = updateLoopStack(Term, AMgr.getASTContext(), Pred, MaxBlockVisit);
     // Is we are inside an unrolled loop then no need the check the counters.
@@ -2433,8 +2433,11 @@ ExplodedNode *ExprEngine::processCFGBlockEntrance(const BlockEntrance &BE,
     return Engine.makeNode(BE, WidenedState, Pred);
   }
 
+  // If we did not reach MaxBlockVisitOnPath, continue the analysis normally.
   if (BlockCount < MaxBlockVisit)
     return Engine.makeNode(BE, State, Pred);
+
+  // ... otherwise, discard this execution path.
 
   if (State != Pred->getState()) {
     // TODO: This intermediate transition is very likely to be irrelevant,
@@ -2464,7 +2467,7 @@ ExplodedNode *ExprEngine::processCFGBlockEntrance(const BlockEntrance &BE,
     // no-inlining policy in the state and enqueuing the new work item on
     // the list. Replay should almost never fail. Use the stats to catch it
     // if it does.
-    if ((!AMgr.options.NoRetryExhausted && replayWithoutInlining(Pred, SF)))
+    if (!AMgr.options.NoRetryExhausted && replayWithoutInlining(Pred, SF))
       return nullptr;
     NumMaxBlockCountReachedInInlined++;
   } else

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -2392,6 +2392,7 @@ bool ExprEngine::replayWithoutInlining(ExplodedNode *N,
 /// Block entrance.  (Update counters).
 ExplodedNode *ExprEngine::processCFGBlockEntrance(const BlockEntrance &BE,
                                                   ExplodedNode *Pred) {
+  const StackFrame *SF = Pred->getStackFrame();
   bool HasGeneratedNodes = false;
   auto MakeDefaultNode = [BE, &Engine = Engine, OriginalPred = Pred]() {
     return Engine.makeNode(BE, OriginalPred->getState(), OriginalPred);
@@ -2426,9 +2427,6 @@ ExplodedNode *ExprEngine::processCFGBlockEntrance(const BlockEntrance &BE,
     if (!isa_and_nonnull<ForStmt, WhileStmt, DoStmt, CXXForRangeStmt>(Term))
       return HasGeneratedNodes ? Pred : MakeDefaultNode();
 
-    // Widen.
-    const StackFrame *SF = Pred->getStackFrame();
-
     // FIXME:
     // We cannot use the CFG element from the via `ExprEngine::getCFGElementRef`
     // since we are currently at the block entrance and the current reference
@@ -2449,7 +2447,6 @@ ExplodedNode *ExprEngine::processCFGBlockEntrance(const BlockEntrance &BE,
   const ExplodedNode *Sink =
       Engine.makeNode(TaggedLoc, Pred->getState(), Pred, /*MarkAsSink=*/true);
 
-  const StackFrame *SF = Pred->getStackFrame();
   if (!SF->inTopFrame()) {
     // FIXME: This will unconditionally prevent inlining this function (even
     // from other entry points), which is not a reasonable heuristic: even if

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -2394,28 +2394,19 @@ ExplodedNode *ExprEngine::processCFGBlockEntrance(const BlockEntrance &BE,
                                                   ExplodedNode *Pred) {
   const StackFrame *SF = Pred->getStackFrame();
   const Stmt *Term = getCurrBlock()->getTerminatorStmt();
-  bool HasGeneratedNodes = false;
-  auto MakeDefaultNode = [BE, &Engine = Engine, OriginalPred = Pred]() {
-    return Engine.makeNode(BE, OriginalPred->getState(), OriginalPred);
-  };
+  ProgramStateRef State = Pred->getState();
 
   // If we reach a loop which has a known bound (and meets
   // other constraints) then consider completely unrolling it.
   if(AMgr.options.ShouldUnrollLoops) {
     unsigned maxBlockVisitOnPath = AMgr.options.maxBlockVisitOnPath;
     if (Term) {
-      ProgramStateRef NewState = updateLoopStack(Term, AMgr.getASTContext(),
-                                                 Pred, maxBlockVisitOnPath);
-      if (NewState != Pred->getState()) {
-        HasGeneratedNodes = true;
-        Pred = Engine.makeNode(BE, NewState, Pred);
-        if (!Pred)
-          return nullptr;
-      }
+      State = updateLoopStack(Term, AMgr.getASTContext(), Pred,
+                              maxBlockVisitOnPath);
     }
     // Is we are inside an unrolled loop then no need the check the counters.
-    if(isUnrolledState(Pred->getState()))
-      return HasGeneratedNodes ? Pred : MakeDefaultNode();
+    if (isUnrolledState(State))
+      return Engine.makeNode(BE, State, Pred);
   }
 
   // If this block is terminated by a loop and it has already been visited the
@@ -2424,7 +2415,15 @@ ExplodedNode *ExprEngine::processCFGBlockEntrance(const BlockEntrance &BE,
   if (BlockCount == AMgr.options.maxBlockVisitOnPath - 1 &&
       AMgr.options.ShouldWidenLoops) {
     if (!isa_and_nonnull<ForStmt, WhileStmt, DoStmt, CXXForRangeStmt>(Term))
-      return HasGeneratedNodes ? Pred : MakeDefaultNode();
+      return Engine.makeNode(BE, State, Pred);
+
+    if (State != Pred->getState()) {
+      // TODO: This intermediate transition is very likely to be irrelevant,
+      // remove it in a follow-up change.
+      Pred = Engine.makeNode(BE, State, Pred);
+      if (!Pred)
+        return nullptr;
+    }
 
     // FIXME:
     // We cannot use the CFG element from the via `ExprEngine::getCFGElementRef`
@@ -2433,16 +2432,24 @@ ExplodedNode *ExprEngine::processCFGBlockEntrance(const BlockEntrance &BE,
     // block, but the terminator cannot be referred as a CFG element.
     // Here we just pass the the first CFG element in the block.
     ProgramStateRef WidenedState = getWidenedLoopState(
-        Pred->getState(), SF, BlockCount, *getCurrBlock()->ref_begin());
+        State, SF, BlockCount, *getCurrBlock()->ref_begin());
     return Engine.makeNode(BE, WidenedState, Pred);
   }
 
   if (BlockCount < AMgr.options.maxBlockVisitOnPath)
-    return HasGeneratedNodes ? Pred : MakeDefaultNode();
+    return Engine.makeNode(BE, State, Pred);
+
+  if (State != Pred->getState()) {
+    // TODO: This intermediate transition is very likely to be irrelevant,
+    // remove it in a follow-up change.
+    Pred = Engine.makeNode(BE, State, Pred);
+    if (!Pred)
+      return nullptr;
+  }
 
   static SimpleProgramPointTag Tag(TagProviderName, "Block count exceeded");
-  const ExplodedNode *Sink = Engine.makeNode(BE.withTag(&Tag), Pred->getState(),
-                                             Pred, /*MarkAsSink=*/true);
+  const ExplodedNode *Sink =
+      Engine.makeNode(BE.withTag(&Tag), State, Pred, /*MarkAsSink=*/true);
 
   if (!SF->inTopFrame()) {
     // FIXME: This will unconditionally prevent inlining this function (even


### PR DESCRIPTION
This commit tries to untangle the logic of `ExprEngine::processCFGBlockExampe` (which handles the loop unrolling, the loop widening and the `MaxBlockVisitOnPath` limit). This was the only place that used the method `NodeBuilder::hasGeneratedNodes()`, and with that, it was able to set up remarkably convoluted logic despite the fact that the `Frontier` of this `NodeBuilder` always contained at most one node.

This is part of my commit series that gradually removes `NodeBuilder`s from the analyzer engine.

As this is an NFC change, I kept that this method can create two `ExplodedNode`s in two rare corner cases (when the loop unrolling state update is followed by either a loop widening step or a "block count exceeded" sink creation). 

The removal of these extra nodes could theoretically perturb the behavior of the analyzer (because it changes the number of nodes in the graph), but I'm pretty sure that there is no logic that concretely looks for these (fortunately non-tagged) nodes, so I intend to remove them in a follow-up commit.

In addition to the removal of the NodeBuilder I also performed some minor code quality improvements in this method.

------

Note for reviewers: I separated the PR into multiple commits; you should probably do the review commit-by-commit. (Some of my commits may be a bit tricky even if you consider them alone -- I tried to make them as simple as possible, but I wasn't able to do more than this.)