### PR TITLE
[ci] Add apple emoji for Darwin build reports

### DIFF
--- a/.ci/generate_test_report_lib.py
+++ b/.ci/generate_test_report_lib.py
@@ -356,14 +356,15 @@ def generate_report_from_files(title, return_code, build_log_files):
 
 def compute_platform_title() -> str:
     logo = {
-        "Windows": ":window: ",
-        "Linux": ":penguin: ",
-        "Darwin": ":green_apple: ",
-    }.get(platform.system(), "")
+        "Windows": ":window:",
+        "Linux": ":penguin:",
+        "Darwin": ":green_apple:",
+    }.get(platform.system())
 
     # On Linux the machine value is x86_64 on Windows it is AMD64.
     if platform.machine() == "x86_64" or platform.machine() == "AMD64":
         arch = "x64"
     else:
         arch = platform.machine()
-    return f"{logo}{platform.system()} {arch} Test Results"
+
+    return f"{logo + ' ' if logo is not None else ''}{platform.system()} {arch} Test Results"

--- a/.ci/generate_test_report_lib.py
+++ b/.ci/generate_test_report_lib.py
@@ -366,5 +366,4 @@ def compute_platform_title() -> str:
         arch = "x64"
     else:
         arch = platform.machine()
-
     return f"{logo + ' ' if logo is not None else ''}{platform.system()} {arch} Test Results"

--- a/.ci/generate_test_report_lib.py
+++ b/.ci/generate_test_report_lib.py
@@ -355,10 +355,15 @@ def generate_report_from_files(title, return_code, build_log_files):
 
 
 def compute_platform_title() -> str:
-    logo = ":window:" if platform.system() == "Windows" else ":penguin:"
+    logo = {
+        "Windows": ":window: ",
+        "Linux": ":penguin: ",
+        "Darwin": ":green_apple: ",
+    }.get(platform.system(), "")
+
     # On Linux the machine value is x86_64 on Windows it is AMD64.
     if platform.machine() == "x86_64" or platform.machine() == "AMD64":
         arch = "x64"
     else:
         arch = platform.machine()
-    return f"{logo} {platform.system()} {arch} Test Results"
+    return f"{logo}{platform.system()} {arch} Test Results"


### PR DESCRIPTION
GitHub has two apples, :apple: which is red and :green_apple: which is green. Red might be mistaken for a failure at a glance if the report has no listed failures, so I chose green.

Also added a fallback path for unhandled systems.