### PR TITLE
[libc++] IWYU `<optional>` include in system_error.cpp

### DIFF
--- a/libcxx/src/system_error.cpp
+++ b/libcxx/src/system_error.cpp
@@ -8,13 +8,13 @@
 
 #include <__assert>
 #include <__config>
+#include <__optional/optional.h>
 #include <__system_error/throw_system_error.h>
 #include <__verbose_abort>
 #include <cerrno>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <optional>
 #include <string.h>
 #include <string>
 #include <system_error>


### PR DESCRIPTION
- Avoids having to recompile the library if only `optional<T&>` is modified.