### PR TITLE
[tsan] Use pass options for ThreadSanitizerPass (NFC)

### DIFF
--- a/llvm/include/llvm/Transforms/Instrumentation/ThreadSanitizer.h
+++ b/llvm/include/llvm/Transforms/Instrumentation/ThreadSanitizer.h
@@ -34,8 +34,7 @@ struct ThreadSanitizerOptions {
 class ThreadSanitizerPass : public RequiredPassInfoMixin<ThreadSanitizerPass> {
 public:
   LLVM_ABI
-  ThreadSanitizerPass(const ThreadSanitizerOptions &Options = {})
-      : Options(Options) {}
+  ThreadSanitizerPass(ThreadSanitizerOptions Options = {});
   LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
 
 private:

--- a/llvm/include/llvm/Transforms/Instrumentation/ThreadSanitizer.h
+++ b/llvm/include/llvm/Transforms/Instrumentation/ThreadSanitizer.h
@@ -20,13 +20,26 @@ namespace llvm {
 class Function;
 class Module;
 
+struct ThreadSanitizerOptions {
+  bool InstrumentMemoryAccesses = true;
+  bool InstrumentAtomics = true;
+  bool InstrumentMemIntrinsics = true;
+};
+
 /// A function pass for tsan instrumentation.
 ///
 /// Instruments functions to detect race conditions reads. This function pass
 /// inserts calls to runtime library functions. If the functions aren't declared
 /// yet, the pass inserts the declarations. Otherwise the existing globals are
-struct ThreadSanitizerPass : public RequiredPassInfoMixin<ThreadSanitizerPass> {
+class ThreadSanitizerPass : public RequiredPassInfoMixin<ThreadSanitizerPass> {
+public:
+  LLVM_ABI
+  ThreadSanitizerPass(const ThreadSanitizerOptions &Options = {})
+      : Options(Options) {}
   LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
+
+private:
+  ThreadSanitizerOptions Options;
 };
 
 /// A module pass for tsan instrumentation.

--- a/llvm/lib/Transforms/Instrumentation/ThreadSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/ThreadSanitizer.cpp
@@ -185,6 +185,16 @@ void insertModuleCtor(Module &M) {
 }
 }  // namespace
 
+ThreadSanitizerPass::ThreadSanitizerPass(ThreadSanitizerOptions Options)
+    : Options(Options) {
+  if (ClInstrumentMemoryAccesses.getNumOccurrences() > 0)
+    this->Options.InstrumentMemoryAccesses = ClInstrumentMemoryAccesses;
+  if (ClInstrumentAtomics.getNumOccurrences() > 0)
+    this->Options.InstrumentAtomics = ClInstrumentAtomics;
+  if (ClInstrumentMemIntrinsics.getNumOccurrences() > 0)
+    this->Options.InstrumentMemIntrinsics = ClInstrumentMemIntrinsics;
+}
+
 PreservedAnalyses ThreadSanitizerPass::run(Function &F,
                                            FunctionAnalysisManager &FAM) {
   ThreadSanitizer TSan(Options);
@@ -551,21 +561,19 @@ bool ThreadSanitizer::sanitizeFunction(Function &F,
   // (e.g. variables that do not escape, etc).
 
   // Instrument memory accesses only if we want to report bugs in the function.
-  if (ClInstrumentMemoryAccesses && Options.InstrumentMemoryAccesses &&
-      SanitizeFunction)
+  if (Options.InstrumentMemoryAccesses && SanitizeFunction)
     for (const auto &II : AllLoadsAndStores) {
       Res |= instrumentLoadOrStore(II, DL);
     }
 
   // Instrument atomic memory accesses in any case (they can be used to
   // implement synchronization).
-  if (ClInstrumentAtomics && Options.InstrumentAtomics)
+  if (Options.InstrumentAtomics)
     for (auto *Inst : AtomicAccesses) {
       Res |= instrumentAtomic(Inst, DL);
     }
 
-  if (ClInstrumentMemIntrinsics && Options.InstrumentMemIntrinsics &&
-      SanitizeFunction)
+  if (Options.InstrumentMemIntrinsics && SanitizeFunction)
     for (auto *Inst : MemIntrinCalls) {
       Res |= instrumentMemIntrinsic(Inst);
     }

--- a/llvm/lib/Transforms/Instrumentation/ThreadSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/ThreadSanitizer.cpp
@@ -109,7 +109,7 @@ namespace {
 /// ensures the __tsan_init function is in the list of global constructors for
 /// the module.
 struct ThreadSanitizer {
-  ThreadSanitizer() {
+  ThreadSanitizer(ThreadSanitizerOptions Options) : Options(Options) {
     // Check options and warn user.
     if (ClInstrumentReadBeforeWrite && ClCompoundReadBeforeWrite) {
       errs()
@@ -172,6 +172,7 @@ private:
   FunctionCallee TsanVptrUpdate;
   FunctionCallee TsanVptrLoad;
   FunctionCallee MemmoveFn, MemcpyFn, MemsetFn;
+  ThreadSanitizerOptions Options;
 };
 
 void insertModuleCtor(Module &M) {
@@ -186,7 +187,7 @@ void insertModuleCtor(Module &M) {
 
 PreservedAnalyses ThreadSanitizerPass::run(Function &F,
                                            FunctionAnalysisManager &FAM) {
-  ThreadSanitizer TSan;
+  ThreadSanitizer TSan(Options);
   if (TSan.sanitizeFunction(F, FAM.getResult<TargetLibraryAnalysis>(F)))
     return PreservedAnalyses::none();
   return PreservedAnalyses::all();
@@ -550,19 +551,21 @@ bool ThreadSanitizer::sanitizeFunction(Function &F,
   // (e.g. variables that do not escape, etc).
 
   // Instrument memory accesses only if we want to report bugs in the function.
-  if (ClInstrumentMemoryAccesses && SanitizeFunction)
+  if (ClInstrumentMemoryAccesses && Options.InstrumentMemoryAccesses &&
+      SanitizeFunction)
     for (const auto &II : AllLoadsAndStores) {
       Res |= instrumentLoadOrStore(II, DL);
     }
 
   // Instrument atomic memory accesses in any case (they can be used to
   // implement synchronization).
-  if (ClInstrumentAtomics)
+  if (ClInstrumentAtomics && Options.InstrumentAtomics)
     for (auto *Inst : AtomicAccesses) {
       Res |= instrumentAtomic(Inst, DL);
     }
 
-  if (ClInstrumentMemIntrinsics && SanitizeFunction)
+  if (ClInstrumentMemIntrinsics && Options.InstrumentMemIntrinsics &&
+      SanitizeFunction)
     for (auto *Inst : MemIntrinCalls) {
       Res |= instrumentMemIntrinsic(Inst);
     }


### PR DESCRIPTION
This adds pass options similar for the ThreadSanitizerPass, similar as is done for the AddressSanitizerPass and MemorySanitizerPass.

This splits #212748 (pending RFC) into smaller pieces, but can land  regardless of the new sanitizer.