### PR TITLE
[CMake][CAS] Do not export CASPluginTest from the install tree

### DIFF
--- a/llvm/tools/libCASPluginTest/CMakeLists.txt
+++ b/llvm/tools/libCASPluginTest/CMakeLists.txt
@@ -15,6 +15,7 @@ set(SOURCES
 
 set(LLVM_EXPORTED_SYMBOL_FILE ${CMAKE_CURRENT_SOURCE_DIR}/libCASPluginTest.exports)
 
-add_llvm_library(CASPluginTest SHARED ${SOURCES}
+# Only loaded by CAS unit tests out of the build tree.
+add_llvm_library(CASPluginTest SHARED BUILDTREE_ONLY ${SOURCES}
   LINK_LIBS ${LLVM_PTHREAD_LIB}
 )


### PR DESCRIPTION
`CASPluginTest` is a unit-test plugin, but it ends up in the installed `LLVMExports.cmake` and in `LLVM_AVAILABLE_LIBS`.
Installs that don't ship `libCASPluginTest` then fail every `find_package(LLVM)` with a `FATAL_ERROR`, so nothing out-of-tree can configure against them.

`BUILDTREE_ONLY` limits the plugin to the build-tree export set. The CAS unit tests load it by a path relative to the test executable, so they keep working.

This is a follow-up to #213331.
Regression found in [Out-of-Tree CI builds](https://github.com/KhronosGroup/SPIRV-LLVM-Translator/actions/runs/31229501194/job/93030341651) of KhronosGroup/SPIRV-LLVM-Translator:
```
CMake Error at /usr/lib/llvm-24/lib/cmake/llvm/LLVMExports.cmake:1944 (message):
  The imported target "CASPluginTest" references the file

     "/usr/lib/llvm-24/lib/libCASPluginTest.so.24.0"

  but this file does not exist. 
```

AI-assisted: Claude Opus 5 (commercial SaaS)