### PR TITLE
[mlir][ArmSME] Enable native ArmSME integration testing on Darwin

### DIFF
--- a/mlir/cmake/modules/MLIRCheckHardwareFeatures.cmake
+++ b/mlir/cmake/modules/MLIRCheckHardwareFeatures.cmake
@@ -2,8 +2,46 @@
 # the moment these are used when configuring MLIR integration tests.
 
 # Checks whether the specified hardware capability is supported by the host
-# Linux system. This is implemented by checking auxiliary vector feature
-# provided by the Linux kernel.
+# Darwin (macOS) system. This is implemented via `sysctl`, which is the
+# Darwin equivalent of Linux's auxiliary vector feature bits. Only the
+# mappings actually needed by callers in this file are provided; unmapped
+# hwcap_spec values conservatively report unsupported.
+#
+# check_hwcap_darwin(
+#   hwcap_spec
+#   output_var
+# )
+function(check_hwcap_darwin hwcap_spec output)
+    if(hwcap_spec STREQUAL "HWCAP2_SME")
+      set(sysctl_name "hw.optional.arm.FEAT_SME")
+    else()
+      message(STATUS "Checking whether ${hwcap_spec} is supported by the host system: FALSE (no Darwin mapping)")
+      set(${output} FALSE PARENT_SCOPE)
+      return()
+    endif()
+
+    execute_process(
+        COMMAND sysctl -n ${sysctl_name}
+        OUTPUT_VARIABLE sysctl_output
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+        RESULT_VARIABLE sysctl_result
+    )
+
+    if(sysctl_result EQUAL 0 AND sysctl_output STREQUAL "1")
+      set(local_result TRUE)
+    else()
+      set(local_result FALSE)
+    endif()
+    message(STATUS "Checking whether ${hwcap_spec} is supported by the host system (via sysctl ${sysctl_name}): ${local_result}")
+    set(${output} ${local_result} PARENT_SCOPE)
+endfunction(check_hwcap_darwin)
+
+# Checks whether the specified hardware capability is supported by the host
+# system. On Linux this is implemented by checking auxiliary vector feature
+# provided by the Linux kernel. On Darwin (macOS) this is implemented via
+# `sysctl` (see check_hwcap_darwin). On other platforms this conservatively
+# reports unsupported.
 #
 # check_hwcap(
 #   hwcap_spec
@@ -21,6 +59,12 @@
 # check_hwcap("HWCAP2_SME" SME_EMULATOR_REQUIRED)
 #
 function(check_hwcap hwcap_spec output)
+    if(APPLE)
+      check_hwcap_darwin(${hwcap_spec} local_output)
+      set(${output} ${local_output} PARENT_SCOPE)
+      return()
+    endif()
+
     set(hwcap_test_src
       [====[
       #include <asm/hwcap.h>

--- a/mlir/cmake/modules/MLIRCheckHardwareFeatures.cmake
+++ b/mlir/cmake/modules/MLIRCheckHardwareFeatures.cmake
@@ -1,27 +1,16 @@
 # A collection of helper CMake functions to detect hardware capabilities. At
 # the moment these are used when configuring MLIR integration tests.
 
-# Checks whether the specified hardware capability is supported by the host
-# Darwin (macOS) system. This is implemented via `sysctl`, which is the
-# Darwin equivalent of Linux's auxiliary vector feature bits. Only the
-# mappings actually needed by callers in this file are provided; unmapped
-# hwcap_spec values conservatively report unsupported.
+# Checks whether SME is supported by the host Darwin (macOS) system. This is
+# implemented via `sysctl`, since Darwin has no equivalent of Linux's
+# auxiliary vector feature bits (hwcap).
 #
-# check_hwcap_darwin(
-#   hwcap_spec
+# check_sme_support_on_darwin(
 #   output_var
 # )
-function(check_hwcap_darwin hwcap_spec output)
-    if(hwcap_spec STREQUAL "HWCAP2_SME")
-      set(sysctl_name "hw.optional.arm.FEAT_SME")
-    else()
-      message(STATUS "Checking whether ${hwcap_spec} is supported by the host system: FALSE (no Darwin mapping)")
-      set(${output} FALSE PARENT_SCOPE)
-      return()
-    endif()
-
+function(check_sme_support_on_darwin output)
     execute_process(
-        COMMAND sysctl -n ${sysctl_name}
+        COMMAND sysctl -n hw.optional.arm.FEAT_SME
         OUTPUT_VARIABLE sysctl_output
         OUTPUT_STRIP_TRAILING_WHITESPACE
         ERROR_QUIET
@@ -33,15 +22,13 @@ function(check_hwcap_darwin hwcap_spec output)
     else()
       set(local_result FALSE)
     endif()
-    message(STATUS "Checking whether ${hwcap_spec} is supported by the host system (via sysctl ${sysctl_name}): ${local_result}")
+    message(STATUS "Checking whether SME is supported by the host system (via sysctl hw.optional.arm.FEAT_SME): ${local_result}")
     set(${output} ${local_result} PARENT_SCOPE)
-endfunction(check_hwcap_darwin)
+endfunction(check_sme_support_on_darwin)
 
 # Checks whether the specified hardware capability is supported by the host
-# system. On Linux this is implemented by checking auxiliary vector feature
-# provided by the Linux kernel. On Darwin (macOS) this is implemented via
-# `sysctl` (see check_hwcap_darwin). On other platforms this conservatively
-# reports unsupported.
+# Linux system. This is implemented by checking auxiliary vector feature
+# provided by the Linux kernel.
 #
 # check_hwcap(
 #   hwcap_spec
@@ -59,12 +46,6 @@ endfunction(check_hwcap_darwin)
 # check_hwcap("HWCAP2_SME" SME_EMULATOR_REQUIRED)
 #
 function(check_hwcap hwcap_spec output)
-    if(APPLE)
-      check_hwcap_darwin(${hwcap_spec} local_output)
-      set(${output} ${local_output} PARENT_SCOPE)
-      return()
-    endif()
-
     set(hwcap_test_src
       [====[
       #include <asm/hwcap.h>
@@ -132,7 +113,16 @@ function(check_emulator mlir_e2e_tests hwcap_spec emulator_exec)
     return()
   endif()
 
-  check_hwcap(${hwcap_spec} emulator_not_required)
+  if(APPLE AND hwcap_spec STREQUAL "HWCAP2_SME")
+    check_sme_support_on_darwin(emulator_not_required)
+  elseif(APPLE)
+    # No Darwin mapping for anything other than SME (yet); conservatively
+    # assume an emulator is required.
+    set(emulator_not_required FALSE)
+  else()
+    check_hwcap(${hwcap_spec} emulator_not_required)
+  endif()
+
   if (${emulator_not_required})
     return()
   endif()

--- a/mlir/test/Integration/Dialect/Linalg/CPU/ArmSME/fill-2d.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/ArmSME/fill-2d.mlir
@@ -5,7 +5,7 @@
 // RUN:   -test-lower-to-arm-sme -test-lower-to-llvm | \
 // RUN: %mcr_aarch64_cmd \
 // RUN:   -e=entry -entry-point-result=void \
-// RUN:   -march=aarch64 -mattr="+sve,+sme" \
+// RUN:   -march=aarch64 -mattr="+sme" \
 // RUN:   -shared-libs=%native_mlir_runner_utils,%native_mlir_c_runner_utils,%native_arm_sme_abi_shlib | \
 // RUN: FileCheck %s
 

--- a/mlir/test/Integration/Dialect/Linalg/CPU/ArmSME/matmul-transpose-a.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/ArmSME/matmul-transpose-a.mlir
@@ -4,7 +4,7 @@
 // RUN:   -test-lower-to-arm-sme -test-lower-to-llvm | \
 // RUN: %mcr_aarch64_cmd \
 // RUN:   -e=main -entry-point-result=void \
-// RUN:   -march=aarch64 -mattr="+sve,+sme" \
+// RUN:   -march=aarch64 -mattr="+sme" \
 // RUN:   -shared-libs=%native_mlir_runner_utils,%native_mlir_c_runner_utils,%native_arm_sme_abi_shlib | \
 // RUN: FileCheck %s
 

--- a/mlir/test/Integration/Dialect/Linalg/CPU/ArmSME/matmul.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/ArmSME/matmul.mlir
@@ -3,7 +3,7 @@
 // RUN:   -test-lower-to-arm-sme -test-lower-to-llvm | \
 // RUN: %mcr_aarch64_cmd \
 // RUN:   -e=main -entry-point-result=void \
-// RUN:   -march=aarch64 -mattr="+sve,+sme" \
+// RUN:   -march=aarch64 -mattr="+sme" \
 // RUN:   -shared-libs=%native_mlir_runner_utils,%native_mlir_c_runner_utils,%native_arm_sme_abi_shlib | \
 // RUN: FileCheck %s
 

--- a/mlir/test/Integration/Dialect/Linalg/CPU/ArmSME/multi-tile-matmul-mixed-types.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/ArmSME/multi-tile-matmul-mixed-types.mlir
@@ -1,3 +1,5 @@
+// REQUIRES: arm-emulator
+
 // RUN: mlir-opt %s \
 // RUN:   -transform-interpreter -test-transform-dialect-erase-schedule  \
 // RUN:   -one-shot-bufferize="bufferize-function-boundaries" -canonicalize \

--- a/mlir/test/Integration/Dialect/Linalg/CPU/ArmSME/multi-tile-matmul.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/ArmSME/multi-tile-matmul.mlir
@@ -1,3 +1,5 @@
+// REQUIRES: arm-emulator
+
 // RUN: mlir-opt %s \
 // RUN:   -transform-interpreter -test-transform-dialect-erase-schedule  \
 // RUN:   -one-shot-bufferize="bufferize-function-boundaries" -canonicalize \

--- a/mlir/test/Integration/Dialect/Linalg/CPU/ArmSME/pack-unpack-mmt4d.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/ArmSME/pack-unpack-mmt4d.mlir
@@ -123,7 +123,7 @@ func.func private @matmul(%A: tensor<7x16xf32>, %B: tensor<16x13xf32>, %C: tenso
 // Implements packing for the A matrix (LHS) in matrix multiplication. The
 // inner tile size for dim M is "scalable": 8 * vscale.
 //===----------------------------------------------------------------------===//
-func.func private @pack_lhs(%A: tensor<7x16xf32>) -> tensor<1x16x?x1xf32> {
+func.func private @pack_lhs(%A: tensor<7x16xf32>) -> tensor<1x16x?x1xf32> attributes {llvm.arm_streaming} {
   %pad = arith.constant 0.0 : f32
 
   %vs = vector.vscale
@@ -146,7 +146,7 @@ func.func private @pack_lhs(%A: tensor<7x16xf32>) -> tensor<1x16x?x1xf32> {
 // Implements packing for the B matrix (RHS) in matrix multiplication. The
 // inner tile size for dim N is "scalable": 8 * vscale.
 //===----------------------------------------------------------------------===//
-func.func private @pack_rhs(%B: tensor<16x13xf32>) ->  tensor<?x16x?x1xf32> {
+func.func private @pack_rhs(%B: tensor<16x13xf32>) ->  tensor<?x16x?x1xf32> attributes {llvm.arm_streaming} {
   %pad = arith.constant 0.0 : f32
 
   // Compute the outer tile size.
@@ -173,7 +173,7 @@ func.func private @pack_rhs(%B: tensor<16x13xf32>) ->  tensor<?x16x?x1xf32> {
 // Implements packing for the C matrix (accumulator) in matrix multiplication.
 // The inner tile sizes are "scalable": 8 * vscale, 8 * vscale
 //===----------------------------------------------------------------------===//
-func.func private @pack_acc(%C: tensor<7x13xf32>) -> tensor<1x?x?x?xf32> {
+func.func private @pack_acc(%C: tensor<7x13xf32>) -> tensor<1x?x?x?xf32> attributes {llvm.arm_streaming} {
   %pad = arith.constant 0.0 : f32
 
   // Compute the outer tile size.
@@ -199,7 +199,7 @@ func.func private @pack_acc(%C: tensor<7x13xf32>) -> tensor<1x?x?x?xf32> {
 // Implements unpacking for the C matrix (accumulator) in matrix
 // multiplication. The inner tile sizes are "scalable": 8 * vscale, 8 * vscale
 //===----------------------------------------------------------------------===//
-func.func private @unpack_acc(%C_packed: tensor<1x?x?x?xf32>) -> tensor<7x13xf32> {
+func.func private @unpack_acc(%C_packed: tensor<1x?x?x?xf32>) -> tensor<7x13xf32> attributes {llvm.arm_streaming} {
   %vs = vector.vscale
   %c8 = arith.constant 8 : index
   %vs_c8 = arith.muli %vs, %c8 : index

--- a/mlir/test/Integration/Dialect/Linalg/CPU/ArmSME/use-too-many-tiles.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/ArmSME/use-too-many-tiles.mlir
@@ -2,7 +2,7 @@
 // RUN:   -test-lower-to-arm-sme -test-lower-to-llvm -verify-diagnostics | \
 // RUN: %mcr_aarch64_cmd \
 // RUN:   -e=main -entry-point-result=void \
-// RUN:   -march=aarch64 -mattr="+sve,+sme" \
+// RUN:   -march=aarch64 -mattr="+sme" \
 // RUN:   -shared-libs=%native_mlir_runner_utils,%native_mlir_c_runner_utils,%native_arm_sme_abi_shlib | \
 // RUN: FileCheck %s
 

--- a/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/load-store-128-bit-tile.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/load-store-128-bit-tile.mlir
@@ -1,7 +1,7 @@
 // DEFINE: %{entry_point} = test_load_store_zaq0
 // DEFINE: %{compile} = mlir-opt %s -test-lower-to-arm-sme -test-lower-to-llvm
 // DEFINE: %{run} = %mcr_aarch64_cmd \
-// DEFINE:  -march=aarch64 -mattr=+sve,+sme \
+// DEFINE:  -march=aarch64 -mattr=+sme \
 // DEFINE:  -e %{entry_point} -entry-point-result=void \
 // DEFINE:  -shared-libs=%native_mlir_runner_utils,%native_mlir_c_runner_utils,%native_arm_sme_abi_shlib
 
@@ -24,7 +24,7 @@ func.func @vector_copy_i128(%src: memref<?x?xi128>, %dst: memref<?x?xi128>) {
   return
 }
 
-func.func @test_load_store_zaq0() {
+func.func @test_load_store_zaq0() attributes {llvm.arm_locally_streaming} {
   %c0 = arith.constant 0 : index
   %min_elts_q = arith.constant 1 : index
   %bytes_per_128_bit = arith.constant 16 : index

--- a/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/load-vertical.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/load-vertical.mlir
@@ -1,7 +1,7 @@
 // DEFINE: %{entry_point} = entry
 // DEFINE: %{compile} = mlir-opt %s -test-lower-to-arm-sme -test-lower-to-llvm
 // DEFINE: %{run} = %mcr_aarch64_cmd \
-// DEFINE:   -march=aarch64 -mattr=+sve,+sme \
+// DEFINE:   -march=aarch64 -mattr=+sme \
 // DEFINE:   -e %{entry_point} -entry-point-result=void \
 // DEFINE:   -shared-libs=%native_mlir_runner_utils,%native_mlir_c_runner_utils,%native_arm_sme_abi_shlib
 

--- a/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/multi-tile-transpose.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/multi-tile-transpose.mlir
@@ -1,3 +1,5 @@
+// REQUIRES: arm-emulator
+
 // RUN: mlir-opt %s -test-lower-to-arm-sme -test-lower-to-llvm | \
 // RUN: %mcr_aarch64_cmd \
 // RUN:   -e=main -entry-point-result=void \

--- a/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/outerproduct-f16f16f32.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/outerproduct-f16f16f32.mlir
@@ -1,3 +1,5 @@
+// REQUIRES: arm-emulator
+
 // DEFINE: %{opts} =
 // DEFINE: %{entry} = main
 // DEFINE: %{compile} = mlir-opt %s \

--- a/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/outerproduct-f32.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/outerproduct-f32.mlir
@@ -2,7 +2,7 @@
 // DEFINE: %{compile} = mlir-opt %s \
 // DEFINE:   -test-lower-to-arm-sme -test-lower-to-llvm -o %t
 // DEFINE: %{run} = %mcr_aarch64_cmd %t \
-// DEFINE:   -march=aarch64 -mattr=+sve,+sme \
+// DEFINE:   -march=aarch64 -mattr=+sme \
 // DEFINE:   -e %{entry_point} -entry-point-result=void \
 // DEFINE:   -shared-libs=%native_mlir_runner_utils,%native_mlir_c_runner_utils,%native_arm_sme_abi_shlib
 

--- a/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/outerproduct-f64.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/outerproduct-f64.mlir
@@ -2,7 +2,7 @@
 // DEFINE: %{compile} = mlir-opt %s \
 // DEFINE:   -test-lower-to-arm-sme -test-lower-to-llvm -o %t
 // DEFINE: %{run} = %mcr_aarch64_cmd %t \
-// DEFINE:   -march=aarch64 -mattr=+sve,+sme-f64f64 \
+// DEFINE:   -march=aarch64 -mattr=+sme,+sme-f64f64 \
 // DEFINE:   -e %{entry_point} -entry-point-result=void \
 // DEFINE:   -shared-libs=%native_mlir_runner_utils,%native_mlir_c_runner_utils,%native_arm_sme_abi_shlib
 

--- a/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/outerproduct-i8i8i32.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/outerproduct-i8i8i32.mlir
@@ -1,3 +1,5 @@
+// REQUIRES: arm-emulator
+
 // DEFINE: %{entry} = main
 // DEFINE: %{compile} = mlir-opt %s -test-lower-to-arm-sme -test-lower-to-llvm
 // DEFINE: %{run} = %mcr_aarch64_cmd \

--- a/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/ssve.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/ssve.mlir
@@ -1,7 +1,7 @@
 // DEFINE: %{entry_point} = entry
 // DEFINE: %{compile} = mlir-opt %s -test-lower-to-llvm
 // DEFINE: %{run} = %mcr_aarch64_cmd \
-// DEFINE:  -march=aarch64 -mattr=+sve,+sme \
+// DEFINE:  -march=aarch64 -mattr=+sme \
 // DEFINE:  -e %{entry_point} -entry-point-result=i32 \
 // DEFINE:  -shared-libs=%native_mlir_runner_utils,%native_mlir_c_runner_utils
 
@@ -10,7 +10,7 @@
 // RUN: %{compile} | %{run} | FileCheck %s
 
 // VLA memcopy in streaming mode.
-func.func @streaming_kernel_copy(%src : memref<?xi64>, %dst : memref<?xi64>, %size : index) attributes {arm_streaming} {
+func.func @streaming_kernel_copy(%src : memref<?xi64>, %dst : memref<?xi64>, %size : index) attributes {llvm.arm_streaming} {
   %c0 = arith.constant 0 : index
   %c2 = arith.constant 2 : index
   %vscale = vector.vscale

--- a/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/tile-fill.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/tile-fill.mlir
@@ -1,6 +1,6 @@
 // RUN: mlir-opt %s -test-lower-to-arm-sme -test-lower-to-llvm | \
 // RUN: %mcr_aarch64_cmd \
-// RUN:  -march=aarch64 -mattr=+sve,+sme \
+// RUN:  -march=aarch64 -mattr=+sme \
 // RUN:  -e entry -entry-point-result=i32 \
 // RUN:  -shared-libs=%native_mlir_runner_utils,%native_mlir_c_runner_utils,%native_arm_sme_abi_shlib | \
 // RUN: FileCheck %s

--- a/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/transfer-read-2d.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/transfer-read-2d.mlir
@@ -1,7 +1,7 @@
 // DEFINE: %{entry_point} = entry
 // DEFINE: %{compile} = mlir-opt %s -test-lower-to-arm-sme -test-lower-to-llvm
 // DEFINE: %{run} = %mcr_aarch64_cmd \
-// DEFINE:  -march=aarch64 -mattr=+sve,+sme \
+// DEFINE:  -march=aarch64 -mattr=+sme \
 // DEFINE:  -e %{entry_point} -entry-point-result=void \
 // DEFINE:  -shared-libs=%native_mlir_runner_utils,%native_mlir_c_runner_utils,%native_arm_sme_abi_shlib
 

--- a/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/transfer-write-2d.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/transfer-write-2d.mlir
@@ -1,7 +1,7 @@
 // DEFINE: %{entry_point} = entry
 // DEFINE: %{compile} = mlir-opt %s -test-lower-to-arm-sme -test-lower-to-llvm
 // DEFINE: %{run} = %mcr_aarch64_cmd \
-// DEFINE:  -march=aarch64 -mattr=+sve,+sme \
+// DEFINE:  -march=aarch64 -mattr=+sme \
 // DEFINE:  -e %{entry_point} -entry-point-result=void \
 // DEFINE:  -shared-libs=%native_mlir_runner_utils,%native_mlir_c_runner_utils,%native_arm_sme_abi_shlib
 

--- a/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/transpose.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/transpose.mlir
@@ -1,7 +1,7 @@
 // DEFINE: %{entry_point} = entry
 // DEFINE: %{compile} = mlir-opt %s -test-lower-to-arm-sme -test-lower-to-llvm
 // DEFINE: %{run} = %mcr_aarch64_cmd \
-// DEFINE:   -march=aarch64 -mattr=+sve,+sme \
+// DEFINE:   -march=aarch64 -mattr=+sme \
 // DEFINE:   -e %{entry_point} -entry-point-result=void \
 // DEFINE:   -shared-libs=%native_mlir_runner_utils,%native_mlir_c_runner_utils,%native_arm_sme_abi_shlib
 

--- a/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/vector-load-store.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/vector-load-store.mlir
@@ -1,7 +1,7 @@
 // DEFINE: %{entry_point} = za0_d_f64
 // DEFINE: %{compile} = mlir-opt %s -test-lower-to-arm-sme -test-lower-to-llvm
 // DEFINE: %{run} = %mcr_aarch64_cmd \
-// DEFINE:  -march=aarch64 -mattr=+sve,+sme \
+// DEFINE:  -march=aarch64 -mattr=+sme \
 // DEFINE:  -e %{entry_point} -entry-point-result=i32 \
 // DEFINE:  -shared-libs=%native_mlir_runner_utils,%native_mlir_c_runner_utils,%native_arm_sme_abi_shlib
 

--- a/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/vector-ops.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/vector-ops.mlir
@@ -1,7 +1,7 @@
 // DEFINE: %{entry_point} = entry
 // DEFINE: %{compile} = mlir-opt %s -test-lower-to-arm-sme -test-lower-to-llvm
 // DEFINE: %{run} = %mcr_aarch64_cmd \
-// DEFINE:  -march=aarch64 -mattr=+sve,+sme \
+// DEFINE:  -march=aarch64 -mattr=+sme \
 // DEFINE:  -e %{entry_point} -entry-point-result=i32 \
 // DEFINE:  -shared-libs=%native_mlir_runner_utils,%native_mlir_c_runner_utils,%native_arm_sme_abi_shlib
 


### PR DESCRIPTION


`MLIR_RUN_ARM_SME_TESTS=ON` could not exercise ArmSME integration tests on real Apple Silicon SME hardware:

1. `check_hwcap` only detects CPU features via Linux's `getauxval()`/`hwcap.h`, so it always required an emulator on Darwin, even with real SME hardware present.
2. With `+sve` enabled, LLVM lowers `vector.vscale` to a bare `cntd`/`cntb`, illegal outside streaming mode. Apple Silicon doesn't expose base (non-streaming) SVE at EL0, so this traps (see #204853).
3. Some functions computing `vector.vscale` directly had no (or an incorrectly unprefixed) streaming attribute, which is required for legal `vscale` codegen and is silently dropped during `func.func` to `llvm.func` conversion unless `llvm.`-prefixed (see #190864).
4. 6 tests force a specific streaming vector length via `setArmSVLBits`/`setArmVLBits`, which isn't possible on real hardware (SVL is fixed per core).

**Changes**

- Add `check_hwcap_darwin` (`sysctl`-based), used by `check_hwcap` on Darwin.
- Drop `+sve` from the mattr of the 15 tests that don't need it. `FeatureSME` doesn't imply `FeatureSVE`, so `-mattr=+sme` is enough.
- Add `attributes {llvm.arm_streaming}` / `{llvm.arm_locally_streaming}` to the functions in `pack-unpack-mmt4d.mlir`, `load-store-128-bit-tile.mlir`, and `ssve.mlir` that compute `vector.vscale` directly.
- Mark the 6 VL-forcing tests `REQUIRES: arm-emulator`, matching the existing tag on `test-setArmSVLBits.mlir`.

---

Verified on an M4 Pro: **16/22** ArmSME integration tests pass natively, **6** correctly skip without an emulator, **0** are XFAIL.

I leveraged AI to work on this PR.
