### PR TITLE
[Bazel] Fix HTTP linking with MinGW Clang

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -4859,7 +4859,15 @@ cc_library(
     hdrs = glob(["include/llvm/HTTP/*.h"]),
     includes = ["include"],
     linkopts = select({
-        "@platforms//os:windows": [
+        ":is_windows_clang_mingw": [
+            "-lcrypt32",
+            "-lwinhttp",
+        ],
+        ":is_windows_clang_cl": [
+            "crypt32.lib",
+            "winhttp.lib",
+        ],
+        ":is_windows_msvc": [
             "crypt32.lib",
             "winhttp.lib",
         ],


### PR DESCRIPTION
The `//llvm:HTTP` Bazel target passes the MSVC-style `crypt32.lib` and `winhttp.lib` names to every Windows compiler. Clang in GNU driver mode treats those names as input paths, so MinGW builds fail instead of resolving the WinHTTP and CryptoAPI import libraries.

Assisted-by: OpenAI Codex.
