### PR TITLE
[lldb] Print "version -v" keys in alphabetical order

### DIFF
--- a/lldb/source/Commands/CommandObjectVersion.cpp
+++ b/lldb/source/Commands/CommandObjectVersion.cpp
@@ -41,27 +41,34 @@ static void dump(const StructuredData::Array &array, Stream &s) {
   s << '[' << llvm::join(values, ", ") << ']';
 }
 
-// The default dump output is too verbose.
 static void dump(const StructuredData::Dictionary &config, Stream &s) {
+  // Dump the keys in alphabetical order.
+  llvm::SmallVector<llvm::StringRef> keys;
+  keys.reserve(config.GetSize());
   config.ForEach(
-      [&](llvm::StringRef key, StructuredData::Object *object) -> bool {
-        assert(object);
-
-        StructuredData::Dictionary *value_dict = object->GetAsDictionary();
-        assert(value_dict);
-
-        StructuredData::ObjectSP value_sp = value_dict->GetValueForKey("value");
-        assert(value_sp);
-
-        s << "  " << key << ": ";
-        if (StructuredData::Boolean *boolean = value_sp->GetAsBoolean())
-          s << (boolean->GetValue() ? "yes" : "no");
-        else if (StructuredData::Array *array = value_sp->GetAsArray())
-          dump(*array, s);
-        s << '\n';
-
+      [&keys](llvm::StringRef key, StructuredData::Object *) -> bool {
+        keys.push_back(key);
         return true;
       });
+  llvm::sort(keys);
+
+  for (auto key : keys) {
+    StructuredData::ObjectSP object = config.GetValueForKey(key);
+    assert(object);
+
+    StructuredData::Dictionary *value_dict = object->GetAsDictionary();
+    assert(value_dict);
+
+    StructuredData::ObjectSP value_sp = value_dict->GetValueForKey("value");
+    assert(value_sp);
+
+    s << "  " << key << ": ";
+    if (StructuredData::Boolean *boolean = value_sp->GetAsBoolean())
+      s << (boolean->GetValue() ? "yes" : "no");
+    else if (StructuredData::Array *array = value_sp->GetAsArray())
+      dump(*array, s);
+    s << '\n';
+  }
 }
 
 void CommandObjectVersion::DoExecute(Args &args, CommandReturnObject &result) {

--- a/lldb/test/Shell/Commands/command-version.test
+++ b/lldb/test/Shell/Commands/command-version.test
@@ -1,6 +1,7 @@
 RUN: %lldb -b -o 'version -v' | FileCheck %s
 
 CHECK: lldb version
-CHECK: xml: {{yes|no}}
+# Configuration keys should be printed in alphabetical order.
 CHECK: python: {{yes|no}}
 CHECK: targets: [{{.*}}]
+CHECK: xml: {{yes|no}}


### PR DESCRIPTION
On https://github.com/llvm/llvm-project/pull/215074, they are building lldb with LLVM_REVERSE_ITERATION enabled.

This caused lldb/test/Shell/Commands/command-version.test to fail because the keys came out in a different order.

I could just fix the test by using CHECK-DAG instead, but I thought it would be nice to print them in a fixed order instead. 
Then you can compare between copies of lldb without having to sort them first.

I've implemented that in the command as we don't seem to give any ordering guarantee for StructuredData::Dictionary and likely don't want to at this point.

Example output:
```
(lldb) version -v
lldb version 24.0.0git (https://github.com/llvm/llvm-project.git revision 3e9127ba3a056a787e76d155274e05e
3d5f76861)
  clang revision 3e9127ba3a056a787e76d155274e05e3d5f76861
  llvm revision 3e9127ba3a056a787e76d155274e05e3d5f76861
  curl: no
  curses: yes
  editline: yes
  editline_wchar: yes
  lua: no
  lzma: yes
  python: yes
  targets: [AArch64, <...>]
  xml: yes
  zlib: yes
```