### PR TITLE
[OpenMP] Fix reduction helper debug location

### DIFF
--- a/clang/lib/CodeGen/CGOpenMPRuntimeGPU.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntimeGPU.cpp
@@ -1825,6 +1825,18 @@ void CGOpenMPRuntimeGPU::emitReduction(
       auto *CurFn = CGF.CurFn;
       CGF.CurFn = NewFunc;
 
+      // The combiner is emitted into a helper function created by
+      // OpenMPIRBuilder which has no DISubprogram of its own. Emitting debug
+      // locations here would attach the enclosing function's scope to
+      // instructions living in a different function, which is invalid IR (the
+      // Verifier only catches it once the helper is inlined into a function
+      // that does have a DISubprogram). Suppress debug locations for the
+      // duration, matching the other OpenMPIRBuilder-generated reduction
+      // helpers.
+      llvm::DebugLoc SavedDebugLoc = CGF.Builder.getCurrentDebugLocation();
+      CGF.Builder.SetCurrentDebugLocation(llvm::DebugLoc());
+      CGF.disableDebugInfo();
+
       *LHSPtr = CGF.GetAddrOfLocalVar(
                        cast<VarDecl>(cast<DeclRefExpr>(LHSExprs[I])->getDecl()))
                     .emitRawPointer(CGF);
@@ -1836,6 +1848,8 @@ void CGOpenMPRuntimeGPU::emitReduction(
                                   cast<DeclRefExpr>(LHSExprs[I]),
                                   cast<DeclRefExpr>(RHSExprs[I]));
 
+      CGF.enableDebugInfo();
+      CGF.Builder.SetCurrentDebugLocation(SavedDebugLoc);
       CGF.CurFn = CurFn;
 
       return InsertPointTy(CGF.Builder.GetInsertBlock(),

--- a/clang/lib/CodeGen/CGOpenMPRuntimeGPU.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntimeGPU.cpp
@@ -1825,14 +1825,9 @@ void CGOpenMPRuntimeGPU::emitReduction(
       auto *CurFn = CGF.CurFn;
       CGF.CurFn = NewFunc;
 
-      // The combiner is emitted into a helper function created by
-      // OpenMPIRBuilder which has no DISubprogram of its own. Emitting debug
-      // locations here would attach the enclosing function's scope to
-      // instructions living in a different function, which is invalid IR (the
-      // Verifier only catches it once the helper is inlined into a function
-      // that does have a DISubprogram). Suppress debug locations for the
-      // duration, matching the other OpenMPIRBuilder-generated reduction
-      // helpers.
+      // The helper has no DISubprogram of its own, so a debug location here
+      // would name the enclosing function's scope, which is invalid IR.
+      // Suppress them, as the other OpenMPIRBuilder-generated helpers do.
       llvm::DebugLoc SavedDebugLoc = CGF.Builder.getCurrentDebugLocation();
       CGF.Builder.SetCurrentDebugLocation(llvm::DebugLoc());
       CGF.disableDebugInfo();

--- a/clang/test/OpenMP/target_reduction_debug_codegen.c
+++ b/clang/test/OpenMP/target_reduction_debug_codegen.c
@@ -1,0 +1,41 @@
+// RUN: %clang_cc1 -verify -fopenmp -x c -triple x86_64-unknown-linux-gnu \
+// RUN:   -fopenmp-targets=amdgpu-amd-amdhsa -debug-info-kind=limited \
+// RUN:   -emit-llvm-bc %s -o %t-host.bc
+// RUN: %clang_cc1 -verify -fopenmp -x c -triple amdgpu-amd-amdhsa \
+// RUN:   -fopenmp-targets=amdgpu-amd-amdhsa -fopenmp-is-target-device \
+// RUN:   -fopenmp-host-ir-file-path %t-host.bc -debug-info-kind=limited \
+// RUN:   -emit-llvm %s -o - | FileCheck %s
+
+// expected-no-diagnostics
+
+// The reduction combiners are emitted into helper functions created by
+// OpenMPIRBuilder that have no DISubprogram of their own. They must therefore
+// not carry any debug locations: a !dbg there would name the scope of the
+// enclosing outlined function, which is invalid IR. The Verifier cannot see
+// this while the helper has no DISubprogram, so it only surfaced once the
+// helper was inlined into the kernel, as an assertion in LexicalScopes.
+//
+// If these helpers ever gain a DISubprogram of their own, the checks below
+// should be relaxed to require that the scope describes the helper itself.
+
+void foo() {
+  int T = 0;
+#pragma omp target teams distribute parallel for reduction(+ : T)
+  for (int i = 0; i < 1024; ++i)
+    T += i;
+}
+
+// Sanity check that debug info is being emitted at all: the outlined function
+// does have a DISubprogram attached.
+// CHECK: define internal void @{{.*}}_debug__(
+// CHECK-SAME: !dbg ![[#]]
+
+// The teams-level and the parallel-level combiner. Neither may reference a
+// debug location anywhere in its body.
+// CHECK:     define internal void @"{{.*}}_omp$reduction$reduction_func"(
+// CHECK-NOT:   !dbg
+// CHECK:       ret void
+
+// CHECK:     define internal void @"{{.*}}_omp$reduction$reduction_func"(
+// CHECK-NOT:   !dbg
+// CHECK:       ret void

--- a/clang/test/OpenMP/target_reduction_debug_codegen.c
+++ b/clang/test/OpenMP/target_reduction_debug_codegen.c
@@ -34,8 +34,8 @@ void foo() {
 // debug location anywhere in its body.
 // CHECK:     define internal void @"{{.*}}_omp$reduction$reduction_func"(
 // CHECK-NOT:   !dbg
-// CHECK:       ret void
+// CHECK:     }
 
 // CHECK:     define internal void @"{{.*}}_omp$reduction$reduction_func"(
 // CHECK-NOT:   !dbg
-// CHECK:       ret void
+// CHECK:     }


### PR DESCRIPTION
Don't attach parent func debug loc to instructions in helper func. Fix invalid IR uncovered by
https://github.com/llvm/llvm-project/pull/211566.

Fixes https://github.com/llvm/llvm-project/issues/215297.

Claude assisted with this patch.