### PR TITLE
[OpenMP] Fix a crash when a predefined allocator is not declared.

### DIFF
--- a/clang/lib/Sema/SemaOpenMP.cpp
+++ b/clang/lib/Sema/SemaOpenMP.cpp
@@ -17551,7 +17551,6 @@ static bool findOMPAllocatorHandleT(Sema &S, SourceLocation Loc,
   }
   QualType AllocatorHandleEnumTy = PT.get();
   AllocatorHandleEnumTy.addConst();
-  Stack->setOMPAllocatorHandleT(AllocatorHandleEnumTy);
 
   // Fill the predefined allocator map.
   bool ErrorFound = false;
@@ -17587,6 +17586,11 @@ static bool findOMPAllocatorHandleT(Sema &S, SourceLocation Loc,
         << "omp_allocator_handle_t";
     return false;
   }
+
+  // Record the type only now. It is what tells a later call that the map above
+  // is ready to be read, so setting it before the map is filled would let that
+  // call proceed on a map this one gave up on halfway through.
+  Stack->setOMPAllocatorHandleT(AllocatorHandleEnumTy);
 
   return true;
 }

--- a/clang/test/OpenMP/allocate_missing_predefined_allocator.cpp
+++ b/clang/test/OpenMP/allocate_missing_predefined_allocator.cpp
@@ -1,0 +1,20 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -verify -fopenmp -ferror-limit 100 -o - %s -Wuninitialized
+
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -verify -fopenmp-simd -ferror-limit 100 -o - %s -Wuninitialized
+
+// omp_allocator_handle_t is declared but the predefined allocators are not, so
+// every directive naming an allocator has to be diagnosed.
+
+typedef void **omp_allocator_handle_t;
+extern const omp_allocator_handle_t omp_const_mem_alloc;
+extern const omp_allocator_handle_t omp_pteam_mem_alloc;
+
+int a, b;
+#pragma omp allocate(a) allocator(omp_const_mem_alloc) // expected-error {{'omp_allocator_handle_t' type not found; include <omp.h>}}
+#pragma omp allocate(b) allocator(omp_pteam_mem_alloc) // expected-error {{'omp_allocator_handle_t' type not found; include <omp.h>}}
+
+void foo(int *r) {
+  int x = 0;
+#pragma omp parallel private(x) allocate(omp_const_mem_alloc : x) // expected-error {{'omp_allocator_handle_t' type not found; include <omp.h>}}
+  *r = x;
+}

--- a/clang/test/OpenMP/allocate_missing_predefined_allocator_enum.cpp
+++ b/clang/test/OpenMP/allocate_missing_predefined_allocator_enum.cpp
@@ -1,0 +1,20 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -verify -fopenmp -ferror-limit 100 -o - %s -Wuninitialized
+
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -verify -fopenmp-simd -ferror-limit 100 -o - %s -Wuninitialized
+
+// omp_allocator_handle_t is declared as an enum but the predefined allocators
+// are not, so every directive naming an allocator has to be diagnosed. The
+// allocator named here is a handle of the user's own and the directives are in
+// a function body rather than at file scope.
+
+typedef enum omp_allocator_handle_t {
+  omp_default_mem_alloc = 1,
+  __omp_allocator_handle_t_max__ = __UINTPTR_MAX__
+} omp_allocator_handle_t;
+
+void foo() {
+  omp_allocator_handle_t my_handle;
+  int A[2];
+#pragma omp allocate(A) allocator(my_handle) // expected-error {{'omp_allocator_handle_t' type not found; include <omp.h>}}
+#pragma omp allocate(A) allocator(my_handle) // expected-error {{'omp_allocator_handle_t' type not found; include <omp.h>}}
+}


### PR DESCRIPTION
`findOMPAllocatorHandleT()` records `omp_allocator_handle_t` before it fills the table of predefined allocators, but that type is also what it tests on entry to decide the table is already built. So when a translation unit declares the type without declaring every predefined allocator, the first call gives up partway through the table and reports an error, while the next one takes the early exit and reports success. `getAllocatorKind()` then walks the abandoned table and dereferences a null allocator.

A single directive naming an allocator was therefore diagnosed, but a second one crashed clang. Code that includes <omp.h> declares all of them and never sees this.

Record the type once the table is known to be complete.

Fixes #157868 and #215277.