### PR TITLE
[lldb] Fix MSVC warnings about missing return values

### DIFF
--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
@@ -137,6 +137,9 @@ llvm::Expected<uint32_t> lldb_private::formatters::
   case VectorLayout::Size:
     return GetNumChildren(m_finish);
   }
+
+  assert(false && "invalid vector layout");
+  return llvm::createStringError("invalid vector layout");
 }
 
 lldb::ValueObjectSP

--- a/lldb/tools/lldb-dap/Protocol/ProtocolEvents.cpp
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolEvents.cpp
@@ -90,6 +90,9 @@ static llvm::json::Value toJSON(const StoppedReason &SR) {
   case eStoppedReasonInstructionBreakpoint:
     return "instruction breakpoint";
   }
+
+  assert(false && "invalid StopReason");
+  return "";
 }
 
 llvm::json::Value toJSON(const StoppedEventBody &SEB) {


### PR DESCRIPTION
MSVC warns with [C4715](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4715) about missing returns in functions where a `switch` over and enum handles all names enumerators, because the enum could hold unnamed values.  For example, given an `enum class Foo { Bar, Baz }` a function handles both `Bar` and `Baz` by returning a value, Clang and GCC won't issue warnings, but MSVC will. 

This handles the cases in the two locations I found.