### PR TITLE
[clang][Headers] Fix typo in documentation of cpuid.h

### DIFF
--- a/clang/lib/Headers/cpuid.h
+++ b/clang/lib/Headers/cpuid.h
@@ -286,16 +286,16 @@
 /// This intrinsic corresponds to the <c> CPUID </c> instruction.
 ///
 /// \param __leaf
-///    \a __leaf can be either 0x0 or 0x8000000. If \a __leaf == 0x0, the
+///    \a __leaf can be either 0x0 or 0x80000000. If \a __leaf == 0x0, the
 ///    highest supported value for basic \c CPUID information is returned.
-///    If \a __leaf == 0x8000000, the highest supported value for extended
+///    If \a __leaf == 0x80000000, the highest supported value for extended
 ///    \c CPUID information is returned.
 /// \param __sig
 ///    If the \a __sig pointer is non-null, the first four bytes of the
 ///    signature (as found in the \c EBX register) are returned in the
 ///    location pointed to by \a __sig.
-/// \returns Returns 0 if \c CPUID is supported; otherwise returns the value
-///    that \c CPUID returns in the \c EAX register.
+/// \returns Returns 0 if \c CPUID is not supported; otherwise returns the
+///    value that \c CPUID returns in the \c EAX register.
 static __inline unsigned int __get_cpuid_max (unsigned int __leaf,
                                               unsigned int *__sig)
 {


### PR DESCRIPTION
Fix extended leaf hex value from 0x8000000 to 0x80000000 in the doxygen comment for __get_cpuid_max, and correct the description of its return value behavior when CPUID is unsupported.