### PR TITLE
[mlir][vector] Support masked ops in the transfer permutation lowerings

### DIFF
--- a/mlir/lib/Dialect/Vector/Transforms/LowerVectorTransfer.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/LowerVectorTransfer.cpp
@@ -97,9 +97,6 @@ struct TransferReadPermutationLowering
     // TODO: support 0-d corner case.
     if (op.getTransferRank() == 0)
       return rewriter.notifyMatchFailure(op, "0-d corner case not supported");
-    // TODO: Support transfer_read inside MaskOp case.
-    if (maskOp)
-      return rewriter.notifyMatchFailure(op, "Masked case not supported");
 
     SmallVector<unsigned> permutation;
     AffineMap map = op.getPermutationMap();
@@ -135,15 +132,28 @@ struct TransferReadPermutationLowering
     // Generate new transfer_read operation.
     VectorType newReadType = VectorType::get(
         newVectorShape, op.getVectorType().getElementType(), newScalableDims);
-    Value newRead = vector::TransferReadOp::create(
+    Operation *newRead = vector::TransferReadOp::create(
         rewriter, op.getLoc(), newReadType, op.getBase(), op.getIndices(),
         AffineMapAttr::get(newMap), op.getPadding(), op.getMask(),
         newInBoundsAttr);
 
-    // Transpose result of transfer_read.
     SmallVector<int64_t> transposePerm(permutation.begin(), permutation.end());
-    return vector::TransposeOp::create(rewriter, op.getLoc(), newRead,
-                                       transposePerm)
+
+    // Re-apply an enclosing vector.mask. Its mask is indexed in memory order
+    // and needs no transpose; its passthru follows the vector and does.
+    if (maskOp) {
+      Value passthru = maskOp.getPassthru();
+      if (passthru)
+        passthru =
+            vector::TransposeOp::create(rewriter, op.getLoc(), passthru,
+                                        invertPermutationVector(transposePerm));
+      newRead =
+          vector::maskOperation(rewriter, newRead, maskOp.getMask(), passthru);
+    }
+
+    // Transpose result of transfer_read.
+    return vector::TransposeOp::create(rewriter, op.getLoc(),
+                                       newRead->getResult(0), transposePerm)
         .getResult();
   }
 };
@@ -175,9 +185,6 @@ struct TransferWritePermutationLowering
     // TODO: support 0-d corner case.
     if (op.getTransferRank() == 0)
       return rewriter.notifyMatchFailure(op, "0-d corner case not supported");
-    // TODO: Support transfer_write inside MaskOp case.
-    if (maskOp)
-      return rewriter.notifyMatchFailure(op, "Masked case not supported");
 
     SmallVector<unsigned> permutation;
     AffineMap map = op.getPermutationMap();
@@ -213,8 +220,15 @@ struct TransferWritePermutationLowering
     auto newWrite = vector::TransferWriteOp::create(
         rewriter, op.getLoc(), newVec, op.getBase(), op.getIndices(),
         AffineMapAttr::get(newMap), op.getMask(), newInBoundsAttr);
+
+    // Re-apply an enclosing vector.mask. Its mask is indexed in memory order,
+    // so transposing the written vector leaves it unchanged.
+    Operation *rewritten = newWrite;
+    if (maskOp)
+      rewritten = vector::maskOperation(rewriter, newWrite, maskOp.getMask());
+
     if (newWrite.hasPureTensorSemantics())
-      return newWrite.getResult();
+      return rewritten->getResult(0);
     // In the memref case there's no return value. Use empty value to signal
     // success.
     return Value();

--- a/mlir/lib/Dialect/Vector/Transforms/LowerVectorTransfer.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/LowerVectorTransfer.cpp
@@ -139,8 +139,8 @@ struct TransferReadPermutationLowering
 
     SmallVector<int64_t> transposePerm(permutation.begin(), permutation.end());
 
-    // Re-apply an enclosing vector.mask. Its mask is indexed in memory order
-    // and needs no transpose; its passthru follows the vector and does.
+    // Re-apply an enclosing vector.mask. Its mask is indexed in memory order,
+    // so only the passthru has to be transposed.
     if (maskOp) {
       Value passthru = maskOp.getPassthru();
       if (passthru)

--- a/mlir/test/Dialect/Vector/vector-transfer-permutation-lowering.mlir
+++ b/mlir/test/Dialect/Vector/vector-transfer-permutation-lowering.mlir
@@ -362,6 +362,34 @@ func.func @xfer_read_minor_identity_transposed_masked_scalable(
   return %res : vector<8x[4]x2xf32>
 }
 
+// The permutation is a rotation rather than a swap, so the passthru transpose
+// is not its own inverse.
+// CHECK-LABEL: func @xfer_read_minor_identity_transposed_masked_with_passthru(
+//  CHECK-SAME:   %[[DEST:.*]]: tensor<?x?x?xf32>,
+//  CHECK-SAME:   %[[MASK:.*]]: vector<3x4x2xi1>,
+//  CHECK-SAME:   %[[PASSTHRU:.*]]: vector<2x3x4xf32>,
+//  CHECK-SAME:   %[[IDX:.*]]: index
+//       CHECK:   %[[PT:.*]] = vector.transpose %[[PASSTHRU]], [1, 2, 0] : vector<2x3x4xf32> to vector<3x4x2xf32>
+//       CHECK:   %[[T_READ:.*]] = vector.mask %[[MASK]], %[[PT]] { vector.transfer_read %[[DEST]]{{.*}} : tensor<?x?x?xf32>, vector<3x4x2xf32> } : vector<3x4x2xi1> -> vector<3x4x2xf32>
+//       CHECK:   vector.transpose %[[T_READ]], [2, 0, 1] : vector<3x4x2xf32> to vector<2x3x4xf32>
+func.func @xfer_read_minor_identity_transposed_masked_with_passthru(
+    %dest: tensor<?x?x?xf32>,
+    %mask: vector<3x4x2xi1>,
+    %passthru: vector<2x3x4xf32>,
+    %idx: index) -> (vector<2x3x4xf32>) {
+
+  %pad = arith.constant 0.000000e+00 : f32
+
+  %res = vector.mask %mask, %passthru {
+    vector.transfer_read %dest[%idx, %idx, %idx], %pad {
+      in_bounds = [true, true, true],
+      permutation_map = affine_map<(d0, d1, d2) -> (d2, d0, d1)>
+    } : tensor<?x?x?xf32>, vector<2x3x4xf32>
+  } : vector<3x4x2xi1> -> vector<2x3x4xf32>
+
+  return %res : vector<2x3x4xf32>
+}
+
 ///----------------------------------------------------------------------------------------
 /// [Pattern: TransferOpReduceRank]
 ///

--- a/mlir/test/Dialect/Vector/vector-transfer-permutation-lowering.mlir
+++ b/mlir/test/Dialect/Vector/vector-transfer-permutation-lowering.mlir
@@ -81,10 +81,12 @@ func.func @xfer_write_minor_identity_transposed_with_mask_scalable(
   return
 }
 
-// Masked version is not supported
-
 // CHECK-LABEL:   func.func @xfer_write_minor_identity_transposed_map_masked
-// CHECK-NOT: vector.transpose
+// CHECK-SAME:      %[[VEC:.*]]: vector<4x8xi16>,
+// CHECK-SAME:      %[[MEM:.*]]: memref<2x2x8x4xi16>,
+// CHECK-SAME:      %[[MASK:.*]]: vector<8x4xi1>
+// CHECK:           %[[TR:.*]] = vector.transpose %[[VEC]], [1, 0] : vector<4x8xi16> to vector<8x4xi16>
+// CHECK:           vector.mask %[[MASK]] { vector.transfer_write %[[TR]], %[[MEM]]{{.*}} {in_bounds = [true, true]} : vector<8x4xi16>, memref<2x2x8x4xi16> } : vector<8x4xi1>
 func.func @xfer_write_minor_identity_transposed_map_masked(
     %vec: vector<4x8xi16>,
     %mem: memref<2x2x8x4xi16>,
@@ -315,14 +317,12 @@ func.func @xfer_read_minor_identity_transposed_with_mask_scalable(
   return %res : vector<8x[4]x2xf32>
 }
 
-// Masked version is not supported
-
 // CHECK-LABEL: func @xfer_read_minor_identity_transposed_masked(
 //  CHECK-SAME:   %[[DEST:.*]]: tensor<?x?xf32>,
 //  CHECK-SAME:   %[[MASK:.*]]: vector<2x4xi1>
 //  CHECK-SAME:   %[[IDX:.*]]: index
-//   CHECK-NOT:   vector.transpose
-//       CHECK:   vector.mask %[[MASK]] { vector.transfer_read %[[DEST]]{{.*}}: tensor<?x?xf32>, vector<8x4x2xf32> } : vector<2x4xi1> -> vector<8x4x2xf32>
+//       CHECK:   %[[T_READ:.*]] = vector.mask %[[MASK]] { vector.transfer_read %[[DEST]]{{.*}}: tensor<?x?xf32>, vector<8x2x4xf32> } : vector<2x4xi1> -> vector<8x2x4xf32>
+//       CHECK:   vector.transpose %[[T_READ]], [0, 2, 1] : vector<8x2x4xf32> to vector<8x4x2xf32>
 func.func @xfer_read_minor_identity_transposed_masked(
     %dest: tensor<?x?xf32>,
     %mask: vector<2x4xi1>,
@@ -343,8 +343,8 @@ func.func @xfer_read_minor_identity_transposed_masked(
 // CHECK-LABEL:  func.func @xfer_read_minor_identity_transposed_masked_scalable(
 //  CHECK-SAME:    %[[DEST:.*]]: tensor<?x?xf32>,
 //  CHECK-SAME:    %[[MASK:.*]]: vector<2x[4]xi1>
-//   CHECK-NOT:    vector.transpose
-//       CHECK:    %[[T_READ:.*]] = vector.mask %[[MASK]] { vector.transfer_read %[[DEST]]{{.*}} : tensor<?x?xf32>, vector<8x[4]x2xf32> } : vector<2x[4]xi1> -> vector<8x[4]x2xf32>
+//       CHECK:    %[[T_READ:.*]] = vector.mask %[[MASK]] { vector.transfer_read %[[DEST]]{{.*}} : tensor<?x?xf32>, vector<8x2x[4]xf32> } : vector<2x[4]xi1> -> vector<8x2x[4]xf32>
+//       CHECK:    vector.transpose %[[T_READ]], [0, 2, 1] : vector<8x2x[4]xf32> to vector<8x[4]x2xf32>
 func.func @xfer_read_minor_identity_transposed_masked_scalable(
   %dest: tensor<?x?xf32>,
   %mask: vector<2x[4]xi1>,


### PR DESCRIPTION
`LowerVectorTransfer.cpp` builds its patterns on `MaskableOpRewritePattern`,
whose purpose is to let a pattern rewrite an op sitting inside a `vector.mask`
region, but every one of them declines to:

```cpp
// TODO: Support transfer_read inside MaskOp case.
if (maskOp)
  return rewriter.notifyMatchFailure(op, "Masked case not supported");
```

This turns that path on for `TransferReadPermutationLowering` and
`TransferWritePermutationLowering`.

The mask itself needs no adjustment, which is the part worth checking. Per
`inferTransferOpMaskType`, a transfer op's mask is not indexed like the
transferred vector: its shape is the vector shape mapped back through the
inverse of the permutation map, so it is indexed in memory order. Both
rewrites only reorder the vector -- one transposes the result of a read, the
other transposes the value handed to a write -- and neither changes which
memory dimensions are touched. The existing tests show this directly: the
write case keeps its `vector<8x4xi1>` mask and the read case its
`vector<2x4xi1>`. A passthru does follow the vector, since its type is the
result type, so on the read side it is permuted along with the result.

Three existing tests therefore change from "not lowered" to lowered. The four
other `..._masked` tests in that file belong to
`TransferWriteNonPermutationLowering` and `TransferOpReduceRank` and are
unchanged. Those two are left for a follow-up: one adds unit dimensions and
the other drops leading broadcast dimensions, so in both cases the mask does
need a transformation. The remaining two patterns cannot support masking at
all, as they target `vector.load` and `vector.store`, which have no mask
operand.

Note that #200703 also touches these functions, dropping their 0-d guards.
The changes are independent, but they sit on adjacent lines, so whichever
lands second will need a trivial rebase.
