### PR TITLE
[mlir][MemRef] Add ViewLikeOpInterface to memref.transpose

### DIFF
--- a/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
+++ b/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
@@ -2409,6 +2409,7 @@ def SubViewOp : MemRef_OpWithOffsetSizesAndStrides<"subview", [
 def MemRef_TransposeOp : MemRef_Op<"transpose", [
     DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
     DeclareOpInterfaceMethods<MemorySpaceCastConsumerOpInterface>,
+    DeclareOpInterfaceMethods<ViewLikeOpInterface>,
     Pure]>,
     Arguments<(ins AnyStridedMemRef:$in, AffineMapAttr:$permutation)>,
     Results<(outs AnyStridedMemRef)> {

--- a/mlir/lib/Dialect/MemRef/IR/MemRefOps.cpp
+++ b/mlir/lib/Dialect/MemRef/IR/MemRefOps.cpp
@@ -3803,6 +3803,8 @@ static MemRefType inferTransposeResultType(MemRefType memRefType,
           StridedLayoutAttr::get(memRefType.getContext(), offset, strides));
 }
 
+Value TransposeOp::getViewSource() { return getIn(); }
+
 void TransposeOp::build(OpBuilder &b, OperationState &result, Value in,
                         AffineMapAttr permutation,
                         ArrayRef<NamedAttribute> attrs) {

--- a/mlir/test/Dialect/MemRef/ops.mlir
+++ b/mlir/test/Dialect/MemRef/ops.mlir
@@ -663,3 +663,9 @@ func.func @memref_transpose_map(%src : memref<?x?xf32>) -> memref<?x?xf32, affin
   %dst = memref.transpose %src (i, j) -> (j, i) : memref<?x?xf32> to memref<?x?xf32, affine_map<(d0, d1)[s0] -> (d1 * s0 + d0)>>
   return %dst : memref<?x?xf32, affine_map<(d0, d1)[s0] -> (d1 * s0 + d0)>>
 }
+
+// CHECK-LABEL: func @memref_transpose_map_with_memory_space
+func.func @memref_transpose_map_with_memory_space(%src : memref<?x?xf32, 1>) -> memref<?x?xf32, affine_map<(d0, d1)[s0] -> (d1 * s0 + d0)>, 1> {
+  %dst = memref.transpose %src (i, j) -> (j, i) : memref<?x?xf32, 1> to memref<?x?xf32, affine_map<(d0, d1)[s0] -> (d1 * s0 + d0)>, 1>
+  return %dst : memref<?x?xf32, affine_map<(d0, d1)[s0] -> (d1 * s0 + d0)>, 1>
+}


### PR DESCRIPTION
**memref.transpose** is a view-producing op but does not implement **ViewLikeOpInterface**, unlike _memref.subview, memref.cast, memref.expand_shape, memref.collapse_shape_, and _memref.reinterpret_cast_. This causes generic passes that walk view chains via ViewLikeOpInterface to silently skip transpose ops, producing incorrect results.

This patch adds `ViewLikeOpInterface` to `MemRef_TransposeOp` and implements `getViewSource()` to return the input memref, matching the behaviour of the other view-like ops.

Also adds a round-trip test covering a transpose that carries a non-default memory space, which is the case that motivated the fix.

`ninja check-mlir` passes locally with no regressions.

**AI tool usage:** The code change (interface declaration, `getViewSource()` implementation, and test) was authored by me. An AI assistant was used to help draft the commit message and this PR description, and to run the local build and test suite.

