### PR TITLE
[libc] Run tests in matching build configurations only

### DIFF
--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -174,9 +174,6 @@ if(LIBC_TARGET_OS_IS_LINUX)
 endif()
 set(LIBC_KERNEL_HEADERS "${kernel_headers}" CACHE STRING "Path to Linux kernel headers")
 
-set(LIBC_ENABLE_UNITTESTS ON)
-set(LIBC_ENABLE_HERMETIC_TESTS ${LLVM_LIBC_FULL_BUILD})
-
 set(LIBC_CONFIG_JSON_FILE_LIST "")
 
 if(NOT LIBC_CONFIG_PATH)
@@ -297,13 +294,10 @@ endif()
 
 if(LIBC_TARGET_OS_IS_GPU)
   include(prepare_libc_gpu_build)
-  set(LIBC_ENABLE_UNITTESTS OFF)
   find_program(LIBC_LLVM_LINK llvm-link HINTS ${LLVM_TOOLS_BINARY_DIR})
   if(NOT LIBC_LLVM_LINK)
     message(FATAL_ERROR "llvm-link not found in ${LLVM_TOOLS_BINARY_DIR} or system path")
   endif()
-elseif(LIBC_TARGET_OS_IS_BAREMETAL)
-  set(LIBC_ENABLE_UNITTESTS OFF)
 endif()
 
 include(LLVMLibCCheckMPFR)

--- a/libc/cmake/modules/LLVMLibCTestRules.cmake
+++ b/libc/cmake/modules/LLVMLibCTestRules.cmake
@@ -1020,30 +1020,25 @@ endfunction()
 function(add_libc_test test_name)
   cmake_parse_arguments(
     "LIBC_TEST"
-    "UNIT_TEST_ONLY;HERMETIC_TEST_ONLY" # Optional arguments
+    "FULL_BUILD_ONLY;OVERLAY_BUILD_ONLY" # Optional arguments
     "" # Single value arguments
     "" # Multi-value arguments
     ${ARGN}
   )
-  if(LIBC_ENABLE_UNITTESTS AND NOT LIBC_TEST_HERMETIC_TEST_ONLY)
-    _add_libc_unittest(${test_name}.__unit__ ${LIBC_TEST_UNPARSED_ARGUMENTS})
-  endif()
-  if(LIBC_ENABLE_HERMETIC_TESTS AND NOT LIBC_TEST_UNIT_TEST_ONLY)
-    add_libc_hermetic(
-      ${test_name}.__hermetic__
-      LINK_LIBRARIES
-        LibcTest.hermetic
-        LibcDeathTestExecutors.hermetic
-        ${LIBC_TEST_UNPARSED_ARGUMENTS}
-    )
-    get_fq_target_name(${test_name} fq_test_name)
-    if(TARGET ${fq_test_name}.__hermetic__ AND TARGET ${fq_test_name}.__unit__)
-      # Tests like the file tests perform file operations on disk file. If we
-      # don't chain up the unit test and hermetic test, then those tests will
-      # step on each other's files.
-      if(NOT LIBC_TEST_HERMETIC_ONLY)
-        add_dependencies(${fq_test_name}.__hermetic__ ${fq_test_name}.__unit__)
-      endif()
+  if(LLVM_LIBC_FULL_BUILD)
+    if(NOT LIBC_TEST_OVERLAY_BUILD_ONLY)
+      add_libc_hermetic(
+        ${test_name}
+        LINK_LIBRARIES
+          LibcTest.hermetic
+          LibcDeathTestExecutors.hermetic
+          ${LIBC_TEST_UNPARSED_ARGUMENTS}
+      )
+    endif()
+  else()
+    # Overlay mode
+    if(NOT LIBC_TEST_FULL_BUILD_ONLY)
+      _add_libc_unittest(${test_name} ${LIBC_TEST_UNPARSED_ARGUMENTS})
     endif()
   endif()
 endfunction()

--- a/libc/cmake/modules/LLVMLibCTestRules.cmake
+++ b/libc/cmake/modules/LLVMLibCTestRules.cmake
@@ -203,7 +203,7 @@ function(get_object_files_for_test result skipped_entrypoints_list)
         get_target_property(object_file_raw ${dep} "OBJECT_FILE_RAW")
         if(object_file_raw)
           # TODO: Remove this once we stop suffixing the target with ".__internal__"
-          if(fq_target_name STREQUAL "libc.test.include.issignaling_c_test.__unit__" OR fq_target_name STREQUAL "libc.test.include.iscanonical_c_test.__unit__")
+          if(fq_target_name STREQUAL "libc.test.include.issignaling_c_test" OR fq_target_name STREQUAL "libc.test.include.iscanonical_c_test")
             string(REPLACE ".__internal__" "" object_file_raw ${object_file_raw})
           endif()
           list(APPEND dep_obj ${object_file_raw})

--- a/libc/docs/full_host_build.md
+++ b/libc/docs/full_host_build.md
@@ -67,13 +67,13 @@ To run a specific unit test for a function, you can target it directly using its
 full name:
 
 ```sh
-ninja -C build libc.test.src.<HEADER>.<FUNCTION>_test.__unit__
+ninja -C build libc.test.src.<HEADER>.<FUNCTION>_test
 ```
 
 For example, to run the test for `isalpha` in `ctype.h`:
 
 ```sh
-ninja -C build libc.test.src.ctype.isalpha_test.__unit__
+ninja -C build libc.test.src.ctype.isalpha_test
 ```
 
 ## Building Documentation

--- a/libc/docs/getting_started.md
+++ b/libc/docs/getting_started.md
@@ -52,7 +52,7 @@ ninja -C build libc libm check-libc
 To run a specific test, such as `isalpha` in `ctype.h`:
 
 ```sh
-ninja -C build libc.test.src.ctype.isalpha_test.__unit__
+ninja -C build libc.test.src.ctype.isalpha_test
 ```
 
 ## 4. Verify with Hello World

--- a/libc/src/math/docs/add_math_function.md
+++ b/libc/src/math/docs/add_math_function.md
@@ -217,20 +217,20 @@ implementation (which is very often glibc).
 
 - Build and Run a specific unit test:
 ```
-  $ ninja libc.test.src.math.<func>_test.__unit__
-  $ projects/libc/test/src/math/libc.test.src.math.<func>_test.__unit__
+  $ ninja libc.test.src.math.<func>_test
+  $ projects/libc/test/src/math/libc.test.src.math.<func>_test
 ```
 
 - Build and Run shared math test:
 ```
-  $ ninja libc.test.shared.shared_math_test.__unit__
-  $ projects/libc/test/shared/libc.test.shared.shared_math_test.__unit__
+  $ ninja libc.test.shared.shared_math_test
+  $ projects/libc/test/shared/libc.test.shared.shared_math_test
 ```
 
 - Build and Run exhaustive test (might take hours to run):
 ```
-  $ ninja libc.test.src.math.exhaustive.<func>_test.__unit__
-  $ projects/libc/test/src/math/exhaustive/libc.test.src.math.exhaustive.<func>_test.__unit__
+  $ ninja libc.test.src.math.exhaustive.<func>_test
+  $ projects/libc/test/src/math/exhaustive/libc.test.src.math.exhaustive.<func>_test
 ```
 
 - Build and Run performance test:

--- a/libc/test/CMakeLists.txt
+++ b/libc/test/CMakeLists.txt
@@ -37,12 +37,8 @@ if(TARGET check-hdrgen)
   add_dependencies(check-libc check-hdrgen)
 endif()
 
-if(LIBC_ENABLE_UNITTESTS AND NOT LIBC_TEST_HERMETIC_TEST_ONLY)
-  add_dependencies(check-libc-build libc-unit-tests-build)
-endif()
-if(LIBC_ENABLE_HERMETIC_TESTS AND NOT LIBC_TEST_UNIT_TEST_ONLY)
-  add_dependencies(check-libc-build libc-hermetic-tests-build)
-endif()
+add_dependencies(check-libc-build libc-unit-tests-build)
+add_dependencies(check-libc-build libc-hermetic-tests-build)
 
 add_subdirectory(UnitTest)
 

--- a/libc/test/include/CMakeLists.txt
+++ b/libc/test/include/CMakeLists.txt
@@ -538,7 +538,7 @@ function(add_header_test target_name source_file deps std_mode)
     add_libc_test(
       ${target_name}
       C_TEST
-      HERMETIC_TEST_ONLY
+      FULL_BUILD_ONLY
       SUITE
         libc_include_tests
       SRCS

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -816,7 +816,7 @@ TEST(LlvmLibcSharedMathTest, AllBFloat16) {
                                   bfloat16(0.0), bfloat16(0.0)));
   EXPECT_FP_EQ(bfloat16(1.0), LIBC_NAMESPACE::shared::sqrtbf16(bfloat16(1.0)));
   // TODO: This test case just failed only when building with gcc-13 and only
-  //   for `ninja libc.test.shared.shared_math_test.__unit__.__NO_FMA_OPT
+  //   for `ninja libc.test.shared.shared_math_test.__NO_FMA_OPT
   //   Other gcc versions or other sub-targets work fine.
   //   https://github.com/llvm/llvm-project/issues/199332
   // #ifndef LIBC_TYPES_LONG_DOUBLE_IS_DOUBLE_DOUBLE

--- a/libc/test/src/CMakeLists.txt
+++ b/libc/test/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 function(add_fp_unittest name)
   cmake_parse_arguments(
     "MATH_UNITTEST"
-    "NEED_MPFR;NEED_MPC;UNIT_TEST_ONLY;HERMETIC_TEST_ONLY" # Optional arguments
+    "NEED_MPFR;NEED_MPC;FULL_BUILD_ONLY;OVERLAY_BUILD_ONLY" # Optional arguments
     "" # Single value arguments
     "LINK_LIBRARIES;DEPENDS" # Multi-value arguments
     ${ARGN}
@@ -23,16 +23,16 @@ function(add_fp_unittest name)
     endif()
   endif()
 
-  if(MATH_UNITTEST_HERMETIC_TEST_ONLY)
-    set(test_type HERMETIC_TEST_ONLY)
-  elseif(MATH_UNITTEST_UNIT_TEST_ONLY)
-    set(test_type UNIT_TEST_ONLY)
+  if(MATH_UNITTEST_FULL_BUILD_ONLY)
+    set(test_type FULL_BUILD_ONLY)
+  elseif(MATH_UNITTEST_OVERLAY_BUILD_ONLY)
+    set(test_type OVERLAY_BUILD_ONLY)
   endif()
   if(MATH_UNITTEST_NEED_MPFR)
-    if(MATH_UNITTEST_HERMETIC_TEST_ONLY)
-      message(FATAL_ERROR "Hermetic math test cannot require MPFR.")
+    if(MATH_UNITTEST_FULL_BUILD_ONLY)
+      message(FATAL_ERROR "Full-build math test cannot require MPFR.")
     endif()
-    set(test_type UNIT_TEST_ONLY)
+    set(test_type OVERLAY_BUILD_ONLY)
     list(APPEND MATH_UNITTEST_LINK_LIBRARIES libcMPFRWrapper -lmpfr -lgmp)
     if(NOT(LIBC_TARGET_OS_IS_DARWIN) AND NOT(LIBC_TARGET_OS_IS_FREEBSD))
       # macOS/FreeBSD does not have libatomic.

--- a/libc/test/src/__support/CMakeLists.txt
+++ b/libc/test/src/__support/CMakeLists.txt
@@ -81,7 +81,6 @@ if(LLVM_LIBC_FULL_BUILD AND NOT LIBC_TARGET_OS_IS_GPU)
     DEPENDS
       libc.src.__support.CPP.span
       libc.src.__support.freelist_heap
-    UNIT_TEST_ONLY
   )
 endif()
 

--- a/libc/test/src/__support/File/CMakeLists.txt
+++ b/libc/test/src/__support/File/CMakeLists.txt
@@ -40,7 +40,7 @@ foreach(target IN LISTS platform_file_targets)
   if(TARGET libc.src.__support.File.${target})
     add_libc_test(
       ${target}_test
-      HERMETIC_TEST_ONLY
+      FULL_BUILD_ONLY
       SUITE
         libc-support-tests
       SRCS

--- a/libc/test/src/stdio/CMakeLists.txt
+++ b/libc/test/src/stdio/CMakeLists.txt
@@ -199,9 +199,6 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.stdio.fopen
     libc.src.stdio.fread
   )
-  # This is to be used for tests which write to libc's platform streams
-  # under full build but write to system-lib's streams otherwise.
-  set(hermetic_test_only HERMETIC_TEST_ONLY)
 else()
   # Else in overlay mode they use the system's FILE.
   libc_set_definition(use_system_file "LIBC_COPT_STDIO_USE_SYSTEM_FILE")
@@ -225,7 +222,6 @@ add_libc_test(
 
 add_libc_test(
   printf_test
-  ${hermetic_test_only}
   SUITE
     libc_stdio_unittests
   SRCS
@@ -282,7 +278,6 @@ add_libc_test(
 
 add_libc_test(
   vprintf_test
-  ${hermetic_test_only}
   SUITE
     libc_stdio_unittests
   SRCS
@@ -384,7 +379,6 @@ add_libc_test(
 
 add_libc_test(
   puts_test
-  HERMETIC_TEST_ONLY # writes to libc's stdout
   SUITE
     libc_stdio_unittests
   SRCS
@@ -395,7 +389,6 @@ add_libc_test(
 
 add_libc_test(
   perror_test
-  HERMETIC_TEST_ONLY # writes to libc's stderr
   SUITE
     libc_stdio_unittests
   SRCS
@@ -407,7 +400,6 @@ add_libc_test(
 
 add_libc_test(
   fputs_test
-  HERMETIC_TEST_ONLY # writes to libc's stdout and stderr
   SUITE
     libc_stdio_unittests
   SRCS
@@ -420,7 +412,6 @@ add_libc_test(
 
 add_libc_test(
   fputc_test
-  HERMETIC_TEST_ONLY # writes to libc's stdout and stderr
   SUITE
     libc_stdio_unittests
   SRCS

--- a/libc/test/src/stdlib/CMakeLists.txt
+++ b/libc/test/src/stdlib/CMakeLists.txt
@@ -585,7 +585,6 @@ if((LIBC_TARGET_OS_IS_BAREMETAL OR LIBC_TARGET_OS_IS_GPU) AND
   NOT LIBC_TARGET_ARCHITECTURE_IS_NVPTX)
   add_libc_test(
     malloc_test
-    HERMETIC_TEST_ONLY
     SUITE
       libc-stdlib-tests
     SRCS

--- a/libc/test/src/unistd/CMakeLists.txt
+++ b/libc/test/src/unistd/CMakeLists.txt
@@ -688,7 +688,6 @@ add_libc_test(
 
 add_libc_test(
   getopt_test
-  HERMETIC_TEST_ONLY # Uses libc's own stderr
   SUITE
     libc_unistd_unittests
   SRCS

--- a/libc/utils/libctest/__init__.py
+++ b/libc/utils/libctest/__init__.py
@@ -12,8 +12,7 @@ Lit test format for LLVM libc unit tests.
 This format extends lit.formats.ExecutableTest to discover pre-built test
 executables in the build directory. Test executables are expected to follow
 the naming pattern used by add_libc_test():
-  libc.test.src.<category>.<test_name>.__unit__.__build__
-  libc.test.src.<category>.<test_name>.__hermetic__.__build__
+  libc.test.src.<category>.<test_name>.__build__
 """
 
 from .format import LibcTest

--- a/libc/utils/libctest/format.py
+++ b/libc/utils/libctest/format.py
@@ -70,10 +70,8 @@ class LibcTest(lit.formats.ExecutableTest):
         Recognized patterns (all must end with .__build__, optionally followed
         by .exe on Windows):
           libc.test.src.<category>.<test_name>.__build__
-          libc.test.src.<category>.<test_name>.__unit__[.<opts>...].__build__
-          libc.test.src.<category>.<test_name>.__hermetic__[.<opts>...].__build__
-          libc.test.include.<test_name>.__unit__[.<opts>...].__build__
-          libc.test.include.<test_name>.__hermetic__[.<opts>...].__build__
+          libc.test.src.<category>.<test_name>[.<opts>...].__build__
+          libc.test.include.<test_name>[.<opts>...].__build__
           libc.test.integration.<category>.<test_name>.__build__
         """
         test_name = filename
@@ -85,8 +83,7 @@ class LibcTest(lit.formats.ExecutableTest):
         if test_name.startswith("libc.test.src."):
             pass  # Accept all src tests ending in .__build__
         elif test_name.startswith("libc.test.include."):
-            if ".__unit__." not in test_name and ".__hermetic__." not in test_name:
-                return False
+            pass  # Accept all include tests ending in .__build__
         elif test_name.startswith("libc.test.integration."):
             pass  # Accept all integration tests ending in .__build__
         elif test_name.startswith("libc.test.shared."):


### PR DESCRIPTION
This patch sets it up so that unit tests only run in overlay mode (this is the new change), while hermetic tests only run in the full build mode (this has always been the case). Running the unit tests in full build mode was an inconsistent configuration because we were building code that expects to be run with our own startup code, but then we did not link that into the unit test.

With this change, it does not make much sense to distinguish between unit and hermetic tests, as one can think of it just as a "test", which runs using whatever is the current build configuration. As such, this patch removes the use of the unit/hermetic test terminology from the most obvious place -- the add_libc_test macro. UNIT_TEST_ONLY and HERMETIC_TEST_ONLY are replaced by OVERLAY_BUILD_ONLY and FULL_BUILD_ONLY, respectively. Since there will only ever be one kind of a test in a given build, the tests also lose the __unit__ and __hermetic__ suffixes.

This also means that tests depending on the MPFR library will not be run in full build mode -- one has to use overylay mode for that. Apart from that, this does not have impact on test coverage as we currently don't have other UNIT_TEST_ONLY tests.