### PR TITLE
[Flang][OpenMP] Tweak offload tests to work on generic architectures

### DIFF
--- a/offload/test/offloading/fortran/declare-target-common-block-main.f90
+++ b/offload/test/offloading/fortran/declare-target-common-block-main.f90
@@ -5,7 +5,7 @@
 ! larger Fortran applications like Nekbone and SPEC benchmarks.
 ! REQUIRES: flang, amdgpu
 
-! RUN: %flang -c -fopenmp -fopenmp-targets=%target_triple --offload-arch=gfx90a \
+! RUN: %flang -c -fopenmp -fopenmp-targets=%target_triple --offload-arch=native \
 ! RUN:   %S/../../Inputs/declare-target-common-block-sub.f90 -o declare-target-common-block-sub.o
 ! RUN: %libomptarget-compile-fortran-generic declare-target-common-block-sub.o
 ! RUN: %t | %fcheck-generic

--- a/offload/test/offloading/fortran/target-use-dev-ptr.f90
+++ b/offload/test/offloading/fortran/target-use-dev-ptr.f90
@@ -2,8 +2,8 @@
 ! addresses are maintained across target boundaries
 ! REQUIRES: clang, flang, amdgcn-amd-amdhsa
 
-! RUN: %clang -c -fopenmp -fopenmp-targets=amdgpu-amd-amdhsa \
-! RUN:   %S/../../Inputs/target-use-dev-ptr.c -o target-use-dev-ptr_c.o
+! RUN: %clang-generic -c %S/../../Inputs/target-use-dev-ptr.c \
+! RUN:   -o target-use-dev-ptr_c.o
 ! RUN: %libomptarget-compile-fortran-generic target-use-dev-ptr_c.o
 ! RUN: %t | %fcheck-generic
 

--- a/offload/test/offloading/fortran/usm_map_close.f90
+++ b/offload/test/offloading/fortran/usm_map_close.f90
@@ -2,8 +2,8 @@
 ! near/on device when utilised in USM mode.
 ! REQUIRES: clang, flang, amdgpu
 
-! RUN: %clang -c -fopenmp -fopenmp-targets=amdgpu-amd-amdhsa \
-! RUN:   %S/../../Inputs/target-use-dev-ptr.c -o target-use-dev-ptr_c.o
+! RUN: %clang-generic -c %S/../../Inputs/target-use-dev-ptr.c \
+! RUN:   -o target-use-dev-ptr_c.o
 ! RUN: %libomptarget-compile-fortran-generic target-use-dev-ptr_c.o
 ! RUN: env HSA_XNACK=1 \
 ! RUN: %libomptarget-run-generic | %fcheck-generic


### PR DESCRIPTION
Using the amdgcn arch directly in the object compilation makes these tests a little unportable, even to some AMD systems e.g gfx942 which utilises an APU, will fail to find kernels if we compile the additional include/link file like this. Which is a rather unsual result in itself, as the extra files don't actually have device code. Regardless, the extra files are helper utility functions that can be compiled with the generic command as opposed to a target device command.

The secondary test case is the same, but opting to test another less restrictive method than using the inbuilt generic command as it does contain code that in theory is device code via declare target.