### PR TITLE
[mlir][tensor] Add a ValueBoundsOpInterface model for tensor.splat

### DIFF
--- a/mlir/lib/Dialect/Tensor/IR/ValueBoundsOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Tensor/IR/ValueBoundsOpInterfaceImpl.cpp
@@ -9,6 +9,7 @@
 #include "mlir/Dialect/Tensor/IR/ValueBoundsOpInterfaceImpl.h"
 
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/Interfaces/ValueBoundsOpInterface.h"
 
 using namespace mlir;
@@ -141,6 +142,20 @@ struct RankOpInterface
   }
 };
 
+struct SplatOpInterface
+    : public ValueBoundsOpInterface::ExternalModel<SplatOpInterface, SplatOp> {
+  void populateBoundsForShapedValueDim(Operation *op, Value value, int64_t dim,
+                                       ValueBoundsConstraintSet &cstr) const {
+    auto splatOp = cast<SplatOp>(op);
+    assert(value == splatOp.getAggregate() && "invalid value");
+
+    RankedTensorType type = splatOp.getType();
+    SmallVector<OpFoldResult> sizes = getMixedValues(
+        type.getShape(), splatOp.getDynamicSizes(), type.getContext());
+    cstr.bound(value)[dim] == sizes[dim];
+  }
+};
+
 } // namespace
 } // namespace tensor
 } // namespace mlir
@@ -159,6 +174,7 @@ void mlir::tensor::registerValueBoundsOpInterfaceExternalModels(
         *ctx);
     tensor::PadOp::attachInterface<tensor::PadOpInterface>(*ctx);
     tensor::RankOp::attachInterface<tensor::RankOpInterface>(*ctx);
+    tensor::SplatOp::attachInterface<tensor::SplatOpInterface>(*ctx);
     // Note: ValueBoundsOpInterface implementation is not required for ops that
     // implement `DestinationStyleOpInterface` (for querying shaped OpResults).
   });

--- a/mlir/test/Dialect/Tensor/value-bounds-op-interface-impl.mlir
+++ b/mlir/test/Dialect/Tensor/value-bounds-op-interface-impl.mlir
@@ -170,6 +170,34 @@ func.func @rank(%t: tensor<5xf32>) -> index {
 
 // -----
 
+// CHECK-LABEL: func @splat(
+//  CHECK-SAME:     %[[sz:[a-zA-Z0-9]+]]: index
+//       CHECK:   %[[c17:.*]] = arith.constant 17 : index
+//       CHECK:   return %[[sz]], %[[c17]]
+func.func @splat(%f: f32, %sz: index) -> (index, index) {
+  %0 = tensor.splat %f[%sz] : tensor<?x17xf32>
+  %1 = "test.reify_bound"(%0) {dim = 0} : (tensor<?x17xf32>) -> (index)
+  %2 = "test.reify_bound"(%0) {dim = 1} : (tensor<?x17xf32>) -> (index)
+  return %1, %2 : index, index
+}
+
+// -----
+
+// A dimension that is dynamic in the result type is mapped to its own size
+// operand, and not to the first one.
+
+// CHECK-LABEL: func @splat_multiple_dynamic_dims(
+//  CHECK-SAME:     %[[sz1:[a-zA-Z0-9]+]]: index, %[[sz2:[a-zA-Z0-9]+]]: index
+//       CHECK:   return %[[sz2]]
+func.func @splat_multiple_dynamic_dims(%f: f32, %sz1: index,
+                                       %sz2: index) -> index {
+  %0 = tensor.splat %f[%sz1, %sz2] : tensor<?x20x?xf32>
+  %1 = "test.reify_bound"(%0) {dim = 2} : (tensor<?x20x?xf32>) -> (index)
+  return %1 : index
+}
+
+// -----
+
 func.func @dynamic_dims_are_equal(%t: tensor<?xf32>) {
   %c0 = arith.constant 0 : index
   %dim0 = tensor.dim %t, %c0 : tensor<?xf32>


### PR DESCRIPTION
Attach ValueBoundsOpInterface model to tensor.splat, mapping each result dimension to its size operand, through `getMixedValues`.

Code generated with Claude Code.