### PR TITLE
[mlir][tensor] Add a ValueBoundsOpInterface model for tensor.concat

### DIFF
--- a/mlir/lib/Dialect/Tensor/IR/ValueBoundsOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Tensor/IR/ValueBoundsOpInterfaceImpl.cpp
@@ -52,6 +52,32 @@ struct CollapseShapeOpInterface
   }
 };
 
+struct ConcatOpInterface
+    : public ValueBoundsOpInterface::ExternalModel<ConcatOpInterface,
+                                                   ConcatOp> {
+  void populateBoundsForShapedValueDim(Operation *op, Value value, int64_t dim,
+                                       ValueBoundsConstraintSet &cstr) const {
+    auto concatOp = cast<ConcatOp>(op);
+    assert(value == concatOp.getResult() && "invalid value");
+
+    ValueRange inputs = concatOp.getInputs();
+    if (dim != static_cast<int64_t>(concatOp.getDim())) {
+      // All inputs have the same size as the result in a dimension that is not
+      // concatenated. Relate the result to every input: relating it to a single
+      // input loses the bound when that input is the unbounded one.
+      for (Value input : inputs)
+        cstr.bound(value)[dim] == cstr.getExpr(input, dim);
+      return;
+    }
+
+    // The concatenated dimension is the sum of the input sizes.
+    AffineExpr sum = cstr.getExpr(inputs.front(), dim);
+    for (Value input : inputs.drop_front())
+      sum = sum + cstr.getExpr(input, dim);
+    cstr.bound(value)[dim] == sum;
+  }
+};
+
 struct DimOpInterface
     : public ValueBoundsOpInterface::ExternalModel<DimOpInterface, DimOp> {
   void populateBoundsForIndexValue(Operation *op, Value value,
@@ -151,6 +177,7 @@ void mlir::tensor::registerValueBoundsOpInterfaceExternalModels(
     tensor::CastOp::attachInterface<tensor::CastOpInterface>(*ctx);
     tensor::CollapseShapeOp::attachInterface<tensor::CollapseShapeOpInterface>(
         *ctx);
+    tensor::ConcatOp::attachInterface<tensor::ConcatOpInterface>(*ctx);
     tensor::DimOp::attachInterface<tensor::DimOpInterface>(*ctx);
     tensor::EmptyOp::attachInterface<tensor::EmptyOpInterface>(*ctx);
     tensor::ExpandShapeOp::attachInterface<tensor::ExpandShapeOpInterface>(

--- a/mlir/test/Dialect/Tensor/value-bounds-op-interface-impl.mlir
+++ b/mlir/test/Dialect/Tensor/value-bounds-op-interface-impl.mlir
@@ -30,6 +30,59 @@ func.func @cast_unranked(%t: tensor<*xf32>) -> index {
 
 // -----
 
+//       CHECK: #[[$MAP:.+]] = affine_map<()[s0, s1] -> (s0 + s1)>
+// CHECK-LABEL: func @concat(
+//  CHECK-SAME:     %[[t0:[a-zA-Z0-9]+]]: tensor<?x4xf32>, %[[t1:[a-zA-Z0-9]+]]: tensor<?x4xf32>
+//       CHECK:   %[[dim0:.*]] = tensor.dim %[[t0]]
+//       CHECK:   %[[dim1:.*]] = tensor.dim %[[t1]]
+//       CHECK:   %[[sum:.*]] = affine.apply #[[$MAP]]()[%[[dim0]], %[[dim1]]]
+//       CHECK:   return %[[sum]]
+func.func @concat(%t0: tensor<?x4xf32>, %t1: tensor<?x4xf32>) -> index {
+  %0 = tensor.concat dim(0) %t0, %t1
+      : (tensor<?x4xf32>, tensor<?x4xf32>) -> tensor<?x4xf32>
+  %1 = "test.reify_bound"(%0) {dim = 0} : (tensor<?x4xf32>) -> (index)
+  return %1 : index
+}
+
+// -----
+
+// The size of a dimension that is not concatenated is the same in the result
+// and in every input. The first input is dynamic in dimension 1, so the
+// constant size can only come from the second one.
+
+// CHECK-LABEL: func @concat_non_concatenated_dim(
+//       CHECK:   %[[c4:.*]] = arith.constant 4 : index
+//       CHECK:   return %[[c4]]
+func.func @concat_non_concatenated_dim(%t0: tensor<?x?xf32>,
+                                       %t1: tensor<?x4xf32>) -> index {
+  %0 = tensor.concat dim(0) %t0, %t1
+      : (tensor<?x?xf32>, tensor<?x4xf32>) -> tensor<?x?xf32>
+  %1 = "test.reify_bound"(%0) {dim = 1, constant} : (tensor<?x?xf32>) -> (index)
+  return %1 : index
+}
+
+// -----
+
+// Every input is dynamic in a dimension that is not concatenated, so the size
+// of the result is the size of any of them. The bound is reified in terms of
+// the first input.
+
+// CHECK-LABEL: func @concat_non_concatenated_dim_dynamic(
+//  CHECK-SAME:     %[[t0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+//       CHECK:   %[[c1:.*]] = arith.constant 1 : index
+//       CHECK:   %[[dim:.*]] = tensor.dim %[[t0]], %[[c1]]
+//       CHECK:   return %[[dim]]
+func.func @concat_non_concatenated_dim_dynamic(%t0: tensor<?x?xf32>,
+                                               %t1: tensor<?x?xf32>,
+                                               %t2: tensor<?x?xf32>) -> index {
+  %0 = tensor.concat dim(0) %t0, %t1, %t2
+      : (tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
+  %1 = "test.reify_bound"(%0) {dim = 1} : (tensor<?x?xf32>) -> (index)
+  return %1 : index
+}
+
+// -----
+
 // CHECK-LABEL: func @dim(
 //  CHECK-SAME:     %[[t:.*]]: tensor<?xf32>
 //       CHECK:   %[[dim:.*]] = tensor.dim %[[t]]


### PR DESCRIPTION
Attach ValueBoundsOpInterface model to tensor.concat. The result has the same size as the inputs in every dimension except the concatenated one, whose size is the sum of the input sizes.

The verifier makes all inputs equal in a dimension that is not concatenated, so relate the result to all of them. Relating it to the first input alone loses the bound when that input is the unbounded one, which makes the result depend on operand order.

Code generated with Claude Code.