### PR TITLE
[CodeGenPrepare] Use make_early_inc_range to avoid iterator invalidation.

### DIFF
--- a/llvm/lib/CodeGen/CodeGenPrepare.cpp
+++ b/llvm/lib/CodeGen/CodeGenPrepare.cpp
@@ -7362,7 +7362,7 @@ bool CodeGenPrepare::optimizeExtUses(Instruction *I) {
   DenseMap<BasicBlock *, Instruction *> InsertedTruncs;
 
   bool MadeChange = false;
-  for (Use &U : Src->uses()) {
+  for (Use &U : make_early_inc_range(Src->uses())) {
     Instruction *User = cast<Instruction>(U.getUser());
 
     // Figure out which BB this ext is used in.

--- a/llvm/test/CodeGen/BPF/CORE/offset-reloc-fieldinfo-2-bpfeb.ll
+++ b/llvm/test/CodeGen/BPF/CORE/offset-reloc-fieldinfo-2-bpfeb.ll
@@ -107,7 +107,6 @@ sw.epilog:                                        ; preds = %entry, %sw.bb9, %sw
 }
 
 ; CHECK:             r{{[0-9]+}} = 4
-; CHECK:             r{{[0-9]+}} = 4
 ; CHECK-EB:          r{{[0-9]+}} <<= 41
 ; CHECK64:           r{{[0-9]+}} s>>= 60
 ; CHECK64:           r{{[0-9]+}} >>= 60
@@ -122,11 +121,15 @@ sw.epilog:                                        ; preds = %entry, %sw.bb9, %sw
 
 ; CHECK:             .long   16                      # FieldReloc
 ; CHECK-NEXT:        .long   30                      # Field reloc section string offset=30
-; CHECK-NEXT:        .long   8
+; CHECK-NEXT:        .long   9
 ; CHECK-NEXT:        .long   .Ltmp{{[0-9]+}}
 ; CHECK-NEXT:        .long   2
 ; CHECK-NEXT:        .long   36
 ; CHECK-NEXT:        .long   1
+; CHECK-NEXT:        .long   .Ltmp{{[0-9]+}}
+; CHECK-NEXT:        .long   2
+; CHECK-NEXT:        .long   36
+; CHECK-NEXT:        .long   0
 ; CHECK-NEXT:        .long   .Ltmp{{[0-9]+}}
 ; CHECK-NEXT:        .long   2
 ; CHECK-NEXT:        .long   36

--- a/llvm/test/CodeGen/BPF/CORE/offset-reloc-fieldinfo-2.ll
+++ b/llvm/test/CodeGen/BPF/CORE/offset-reloc-fieldinfo-2.ll
@@ -107,7 +107,6 @@ sw.epilog:                                        ; preds = %entry, %sw.bb9, %sw
 }
 
 ; CHECK:             r{{[0-9]+}} = 4
-; CHECK:             r{{[0-9]+}} = 4
 ; CHECK-EL:          r{{[0-9]+}} <<= 51
 ; CHECK64:           r{{[0-9]+}} s>>= 60
 ; CHECK64:           r{{[0-9]+}} >>= 60
@@ -122,11 +121,15 @@ sw.epilog:                                        ; preds = %entry, %sw.bb9, %sw
 
 ; CHECK:             .long   16                      # FieldReloc
 ; CHECK-NEXT:        .long   30                      # Field reloc section string offset=30
-; CHECK-NEXT:        .long   8
+; CHECK-NEXT:        .long   9
 ; CHECK-NEXT:        .long   .Ltmp{{[0-9]+}}
 ; CHECK-NEXT:        .long   2
 ; CHECK-NEXT:        .long   36
 ; CHECK-NEXT:        .long   1
+; CHECK-NEXT:        .long   .Ltmp{{[0-9]+}}
+; CHECK-NEXT:        .long   2
+; CHECK-NEXT:        .long   36
+; CHECK-NEXT:        .long   0
 ; CHECK-NEXT:        .long   .Ltmp{{[0-9]+}}
 ; CHECK-NEXT:        .long   2
 ; CHECK-NEXT:        .long   36


### PR DESCRIPTION
While iterating users of a {s|z}ext's source operand in optimizeExtUses we explicitly replace the use with a trunc instruction thereby invalidating iterator of the loop. Update the loop to use make_early_inc_range to avoid invalidation.