### PR TITLE
[Flang][OpenMP] Remove forced close mapping for descriptor in USM

### DIFF
--- a/flang/lib/Optimizer/OpenMP/MapInfoFinalization.cpp
+++ b/flang/lib/Optimizer/OpenMP/MapInfoFinalization.cpp
@@ -855,11 +855,6 @@ class MapInfoFinalizationPass
                  ? MapFlags::close
                  : MapFlags::always;
 
-    // For unified_shared_memory, we additionally add `CLOSE` on the descriptor
-    // to ensure device-local placement where required by tests relying on USM +
-    // close semantics.
-    if (moduleRequiresUSM(target->getParentOfType<mlir::ModuleOp>()))
-      flags |= MapFlags::close;
     return flags;
   }
 

--- a/flang/test/Lower/OpenMP/usm-descriptor-close-map.f90
+++ b/flang/test/Lower/OpenMP/usm-descriptor-close-map.f90
@@ -1,0 +1,35 @@
+! RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=50 %s -o - | FileCheck %s
+
+! Verify that we appropriately apply the close map type to the descriptor when it is
+! explicitly specified and that we do not strip it needlessly in USM or otherwise add
+! it to the descriptor implicitly like we used to.
+
+module usm_descriptor_close_map
+  !$omp requires unified_shared_memory
+contains
+
+! CHECK-LABEL: func.func @_QMusm_descriptor_close_mapPusm_only
+! CHECK: %[[DECL:.*]]:2 = hlfir.declare %{{.*}} {fortran_attrs = #fir.var_attrs<pointer>, {{.*}}Epoint"}
+! CHECK: %[[BOX_OFF:.*]] = fir.box_offset %[[DECL]]#1 base_addr : (!fir.ref<!fir.box<!fir.ptr<i32>>>) -> !fir.llvm_ptr<!fir.ref<i32>>
+! CHECK: %[[MEMBER:.*]] = omp.map.info var_ptr(%[[DECL]]#1 : !fir.ref<!fir.box<!fir.ptr<i32>>>, !fir.box<!fir.ptr<i32>>) map_clauses(tofrom) capture(ByRef) var_ptr_ptr(%[[BOX_OFF]] : !fir.llvm_ptr<!fir.ref<i32>>, i32) -> !fir.llvm_ptr<!fir.ref<i32>> {name = ""}
+! CHECK: %[[DESC_MAP:.*]] = omp.map.info var_ptr(%[[DECL]]#1 : !fir.ref<!fir.box<!fir.ptr<i32>>>, !fir.box<!fir.ptr<i32>>) map_clauses(always, to) capture(ByRef) members(%[[MEMBER]] : [0] : !fir.llvm_ptr<!fir.ref<i32>>) -> !fir.ref<!fir.box<!fir.ptr<i32>>> {name = "point"}
+  subroutine usm_only(point)
+    integer, pointer :: point
+    !$omp target map(tofrom: point)
+    point = 1
+    !$omp end target
+  end subroutine
+
+! CHECK-LABEL: func.func @_QMusm_descriptor_close_mapPusm_explicit_close
+! CHECK: %[[DECL:.*]]:2 = hlfir.declare %{{.*}} {fortran_attrs = #fir.var_attrs<pointer>, {{.*}}Epoint"}
+! CHECK: %[[BOX_OFF:.*]] = fir.box_offset %[[DECL]]#1 base_addr : (!fir.ref<!fir.box<!fir.ptr<i32>>>) -> !fir.llvm_ptr<!fir.ref<i32>>
+! CHECK: %[[MEMBER:.*]] = omp.map.info var_ptr(%[[DECL]]#1 : !fir.ref<!fir.box<!fir.ptr<i32>>>, !fir.box<!fir.ptr<i32>>) map_clauses(close, tofrom) capture(ByRef) var_ptr_ptr(%[[BOX_OFF]] : !fir.llvm_ptr<!fir.ref<i32>>, i32) -> !fir.llvm_ptr<!fir.ref<i32>> {name = ""}
+! CHECK: %[[DESC_MAP:.*]] = omp.map.info var_ptr(%[[DECL]]#1 : !fir.ref<!fir.box<!fir.ptr<i32>>>, !fir.box<!fir.ptr<i32>>) map_clauses(close, to) capture(ByRef) members(%[[MEMBER]] : [0] : !fir.llvm_ptr<!fir.ref<i32>>) -> !fir.ref<!fir.box<!fir.ptr<i32>>> {name = "point"}
+  subroutine usm_explicit_close(point)
+    integer, pointer :: point
+    !$omp target map(close, tofrom: point)
+    point = 1
+    !$omp end target
+  end subroutine
+
+end module


### PR DESCRIPTION
This was added originally to solve an issue with pointer checking on USM devices (usm_map_close.f90 in the fortran offload tests) but no longer appears to be required.

None the less, this isn't a fix we can keep around, we cannot force close mapping on things, we should only carry it over if a user specifies it (done so above). As if we force it onto the descriptor, then on USM architectures in USM mode we're actually inflicting the user with unwanted and unrequested host to device transfers. As we're saying we want the descriptor to be placed in memory as close to the device as possible (so device memory). We shouldn't make the assumption this is what a user wishes, especially when they can now refine there mappings to specify what they want done with the descriptor.

So, removing this as a performance and correctness optimization now that it no longer appears to be required for the usm_map_close.f90 test on at least a fully USM enabled system like gfx942.

There's a few other cases like this in MapInfoFinalization I think that may need a similar revision.