### PR TITLE
[CAS] Fix build with LLVM_ENABLE_PIC=OFF

### DIFF
--- a/llvm/tools/libCASPluginTest/CMakeLists.txt
+++ b/llvm/tools/libCASPluginTest/CMakeLists.txt
@@ -1,6 +1,7 @@
-if (NOT LLVM_ENABLE_ONDISK_CAS)
-  # The plugin is implemented on top of UnifiedOnDiskCache, which is only
-  # functional when the on-disk CAS is enabled.
+# The plugin is implemented on top of UnifiedOnDiskCache, which is only
+# functional when the on-disk CAS is enabled, and it is only useful as a shared
+# library, which requires PIC objects.
+if (NOT LLVM_ENABLE_ONDISK_CAS OR NOT LLVM_ENABLE_PIC)
   return()
 endif()
 

--- a/llvm/unittests/CAS/CASTestConfig.cpp
+++ b/llvm/unittests/CAS/CASTestConfig.cpp
@@ -9,9 +9,6 @@
 #include "CASTestConfig.h"
 #include "OnDiskCommonUtils.h"
 #include "llvm/CAS/ObjectStore.h"
-#include "llvm/Config/config.h"
-#include "llvm/Support/Compiler.h"
-#include "llvm/Support/Path.h"
 #include "llvm/Support/SHA1.h"
 #include "llvm/Testing/Support/Error.h"
 #include "gtest/gtest.h"
@@ -20,27 +17,6 @@
 using namespace llvm;
 using namespace llvm::cas;
 using namespace llvm::unittest::cas;
-
-// See llvm/utils/unittest/UnitTestMain/TestMain.cpp
-extern const char *TestMainArgv0;
-
-// Just a reachable symbol to ease resolving of the executable's path.
-static std::string TestStringArg1("castest-string-arg1");
-
-std::string unittest::cas::getCASPluginPath() {
-  std::string Executable =
-      sys::fs::getMainExecutable(TestMainArgv0, &TestStringArg1);
-  llvm::SmallString<256> PathBuf(sys::path::parent_path(
-      sys::path::parent_path(sys::path::parent_path(Executable))));
-#ifndef _WIN32
-  std::string LibName = "libCASPluginTest";
-  sys::path::append(PathBuf, "lib", LibName + LLVM_PLUGIN_EXT);
-#else
-  std::string LibName = "CASPluginTest";
-  sys::path::append(PathBuf, "bin", LibName + LLVM_PLUGIN_EXT);
-#endif
-  return std::string(PathBuf);
-}
 
 Expected<ObjectID> CustomHasherOnDiskCASTest::store(OnDiskGraphDB &DB,
                                                     StringRef Data,
@@ -129,28 +105,6 @@ static void sha1Digest(ArrayRef<ArrayRef<uint8_t>> Refs, ArrayRef<char> Data,
 INSTANTIATE_TEST_SUITE_P(SHA1, CustomHasherOnDiskCASTest,
                          ::testing::Values(CustomHasherParam{
                              sha1Digest, "SHA1", sizeof(SHA1HashType)}));
-
-// HWASan does not tag the globals of a dlopen'ed library with glibc, so the
-// plugin faults as soon as it touches one of its own globals.
-// FIXME: Re-enable once https://github.com/llvm/llvm-project/issues/57206 is
-// fixed.
-#if !LLVM_HWADDRESS_SANITIZER_BUILD
-static CASTestingEnv createPlugin(int I) {
-  unittest::TempDir Temp("plugin-cas", /*Unique=*/true);
-  std::optional<
-      std::pair<std::shared_ptr<ObjectStore>, std::shared_ptr<ActionCache>>>
-      DBs;
-  EXPECT_THAT_ERROR(createPluginCASDatabases(getCASPluginPath(), Temp.path(),
-                                             /*PluginArgs=*/{})
-                        .moveInto(DBs),
-                    Succeeded());
-  if (!DBs)
-    return CASTestingEnv{nullptr, nullptr, std::move(Temp)};
-  return CASTestingEnv{std::move(DBs->first), std::move(DBs->second),
-                       std::move(Temp)};
-}
-INSTANTIATE_TEST_SUITE_P(PluginCAS, CASTest, ::testing::Values(createPlugin));
-#endif
 
 #else
 void unittest::cas::setMaxOnDiskCASMappingSize() {}

--- a/llvm/unittests/CAS/CASTestConfig.h
+++ b/llvm/unittests/CAS/CASTestConfig.h
@@ -44,10 +44,6 @@ struct CASTestingEnv {
 
 void setMaxOnDiskCASMappingSize();
 
-/// \returns the path of the libCASPluginTest dynamic library, which implements
-/// the CAS plugin API for testing purposes.
-std::string getCASPluginPath();
-
 // Test fixture for on-disk data base tests.
 class OnDiskCASTest : public ::testing::Test {
 protected:

--- a/llvm/unittests/CAS/CMakeLists.txt
+++ b/llvm/unittests/CAS/CMakeLists.txt
@@ -6,17 +6,27 @@ set(ONDISK_CAS_TEST_SOURCES
   OnDiskDataAllocatorTest.cpp
   OnDiskKeyValueDBTest.cpp
   OnDiskTrieRawHashMapTest.cpp
-  PluginCASTest.cpp
   ProgramTest.cpp
   UnifiedOnDiskCacheTest.cpp
   )
 
+set(PLUGIN_CAS_TEST_SOURCES
+  PluginCASTest.cpp
+  )
+
 set(LLVM_OPTIONAL_SOURCES
   ${ONDISK_CAS_TEST_SOURCES}
+  ${PLUGIN_CAS_TEST_SOURCES}
   )
 
 if (NOT LLVM_ENABLE_ONDISK_CAS)
   unset(ONDISK_CAS_TEST_SOURCES)
+endif()
+
+# The plugin tests need the libCASPluginTest shared library, which is not
+# always built (it requires the on-disk CAS and PIC).
+if (NOT TARGET CASPluginTest)
+  unset(PLUGIN_CAS_TEST_SOURCES)
 endif()
 
 set(LLVM_LINK_COMPONENTS
@@ -33,10 +43,11 @@ add_llvm_unittest(CASTests
   OnDiskCommonUtils.cpp
 
   ${ONDISK_CAS_TEST_SOURCES}
+  ${PLUGIN_CAS_TEST_SOURCES}
   )
 
 target_link_libraries(CASTests PRIVATE LLVMTestingSupport)
 
-if (LLVM_ENABLE_ONDISK_CAS)
+if (TARGET CASPluginTest)
   add_dependencies(CASTests CASPluginTest)
 endif()

--- a/llvm/unittests/CAS/PluginCASTest.cpp
+++ b/llvm/unittests/CAS/PluginCASTest.cpp
@@ -15,6 +15,7 @@
 #include "CASTestConfig.h"
 #include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/ObjectStore.h"
+#include "llvm/Config/config.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Testing/Support/Error.h"
@@ -30,6 +31,42 @@ using namespace llvm::unittest::cas;
 // FIXME: Re-enable once https://github.com/llvm/llvm-project/issues/57206 is
 // fixed.
 #if !LLVM_HWADDRESS_SANITIZER_BUILD
+
+extern const char *TestMainArgv0;
+static std::string TestStringArg1("castest-string-arg1");
+
+/// \returns the path of the libCASPluginTest dynamic library, which implements
+/// the CAS plugin API for testing purposes.
+static std::string getCASPluginPath() {
+  std::string Executable =
+      sys::fs::getMainExecutable(TestMainArgv0, &TestStringArg1);
+  llvm::SmallString<256> PathBuf(sys::path::parent_path(
+      sys::path::parent_path(sys::path::parent_path(Executable))));
+#ifndef _WIN32
+  std::string LibName = "libCASPluginTest";
+  sys::path::append(PathBuf, "lib", LibName + LLVM_PLUGIN_EXT);
+#else
+  std::string LibName = "CASPluginTest";
+  sys::path::append(PathBuf, "bin", LibName + LLVM_PLUGIN_EXT);
+#endif
+  return std::string(PathBuf);
+}
+
+static CASTestingEnv createPlugin(int I) {
+  unittest::TempDir Temp("plugin-cas", /*Unique=*/true);
+  std::optional<
+      std::pair<std::shared_ptr<ObjectStore>, std::shared_ptr<ActionCache>>>
+      DBs;
+  EXPECT_THAT_ERROR(createPluginCASDatabases(getCASPluginPath(), Temp.path(),
+                                             /*PluginArgs=*/{})
+                        .moveInto(DBs),
+                    Succeeded());
+  if (!DBs)
+    return CASTestingEnv{nullptr, nullptr, std::move(Temp)};
+  return CASTestingEnv{std::move(DBs->first), std::move(DBs->second),
+                       std::move(Temp)};
+}
+INSTANTIATE_TEST_SUITE_P(PluginCAS, CASTest, ::testing::Values(createPlugin));
 
 TEST(PluginCASTest, isMaterialized) {
   unittest::TempDir Temp("plugin-cas", /*Unique=*/true);


### PR DESCRIPTION
libCASPluginTest, added in #213331, is a shared library, which cannot be
built without PIC. Skip it and the tests that need it in that case.
