### PR TITLE
[clang-tidy] Fix `cppcoreguidelines-use-enum-class` anonymous enum bug

### DIFF
--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/UseEnumClassCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/UseEnumClassCheck.cpp
@@ -26,10 +26,10 @@ void UseEnumClassCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
 }
 
 void UseEnumClassCheck::registerMatchers(MatchFinder *Finder) {
-  const auto EnumDecl =
-      IgnoreUnscopedEnumsInClasses
-          ? enumDecl(unless(isScoped()), unless(hasParent(recordDecl())))
-          : enumDecl(unless(isScoped()));
+  const auto EnumDecl = IgnoreUnscopedEnumsInClasses
+                            ? enumDecl(unless(isScoped()), unless(hasName("")),
+                                       unless(hasParent(recordDecl())))
+                            : enumDecl(unless(isScoped()), unless(hasName("")));
   Finder->addMatcher(EnumDecl.bind("unscoped_enum"), this);
 }
 

--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/UseEnumClassCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/UseEnumClassCheck.cpp
@@ -10,6 +10,14 @@
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 
 using namespace clang::ast_matchers;
+using namespace clang::ast_matchers::internal;
+
+namespace {
+// FIXME: The matcher 'hasName(Name)' asserts that its argument 'Name' is
+// nonempty. Perhaps remove that assertion and replace 'isUnnamed()' with
+// 'hasName("")'.
+AST_MATCHER(clang::EnumDecl, isUnnamed) { return Node.getName().empty(); }
+} // namespace
 
 namespace clang::tidy::cppcoreguidelines {
 
@@ -27,9 +35,9 @@ void UseEnumClassCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
 
 void UseEnumClassCheck::registerMatchers(MatchFinder *Finder) {
   const auto EnumDecl = IgnoreUnscopedEnumsInClasses
-                            ? enumDecl(unless(isScoped()), unless(hasName("")),
+                            ? enumDecl(unless(isScoped()), unless(isUnnamed()),
                                        unless(hasParent(recordDecl())))
-                            : enumDecl(unless(isScoped()), unless(hasName("")));
+                            : enumDecl(unless(isScoped()), unless(isUnnamed()));
   Finder->addMatcher(EnumDecl.bind("unscoped_enum"), this);
 }
 

--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/UseEnumClassCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/UseEnumClassCheck.cpp
@@ -12,14 +12,13 @@
 using namespace clang::ast_matchers;
 using namespace clang::ast_matchers::internal;
 
+namespace clang::tidy::cppcoreguidelines {
 namespace {
 // FIXME: The matcher 'hasName(Name)' asserts that its argument 'Name' is
 // nonempty. Perhaps remove that assertion and replace 'isUnnamed()' with
 // 'hasName("")'.
-AST_MATCHER(clang::EnumDecl, isUnnamed) { return Node.getName().empty(); }
+AST_MATCHER(EnumDecl, isUnnamed) { return Node.getName().empty(); }
 } // namespace
-
-namespace clang::tidy::cppcoreguidelines {
 
 UseEnumClassCheck::UseEnumClassCheck(StringRef Name, ClangTidyContext *Context)
     : ClangTidyCheck(Name, Context),

--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/UseEnumClassCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/UseEnumClassCheck.cpp
@@ -28,8 +28,8 @@ void UseEnumClassCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
 void UseEnumClassCheck::registerMatchers(MatchFinder *Finder) {
   const auto EnumDecl =
       IgnoreUnscopedEnumsInClasses
-          ? enumDecl(unless(isScoped()), unless(hasParent(recordDecl())))
-          : enumDecl(unless(isScoped()));
+          ? enumDecl(unless(isScoped()), unless(hasName("")), unless(hasParent(recordDecl())))
+          : enumDecl(unless(isScoped()), unless(hasName("")));
   Finder->addMatcher(EnumDecl.bind("unscoped_enum"), this);
 }
 

--- a/clang-tools-extra/docs/ReleaseNotes.md
+++ b/clang-tools-extra/docs/ReleaseNotes.md
@@ -144,6 +144,9 @@ infrastructure are described first, followed by tool-specific sections.
   <clang-tidy/checks/readability/use-std-min-max>` check by fixing spurious
   trailing semicolons and lost comments when the `if` body has no braces.
 
+- Fixed {doc}`cppcoreguidelines-use-enum-class
+  <clang-tidy/checks/cppcoreguidelines/use-enum-class>` suggesting `enum class` for unnamed enums (which is ill-formed).
+
 #### Removed checks
 
 - Removed the deprecated `zircon-temporary-objects` check. Users should migrate to

--- a/clang-tools-extra/docs/ReleaseNotes.md
+++ b/clang-tools-extra/docs/ReleaseNotes.md
@@ -121,6 +121,9 @@ infrastructure are described first, followed by tool-specific sections.
 - Improved {doc}`cppcoreguidelines-pro-type-member-init
   <clang-tidy/checks/cppcoreguidelines/pro-type-member-init>` check by treating
   `std::array` the same as built-in arrays when `IgnoreArrays` option is enabled.
+  
+- Fixed {doc}`cppcoreguidelines-use-enum-class
+  <clang-tidy/checks/cppcoreguidelines/use-enum-class>` suggesting `enum class` for unnamed enums (which is ill-formed).
 
 - Improved {doc}`misc-redundant-expression
   <clang-tidy/checks/misc/redundant-expression>` by fixing false positives in
@@ -143,9 +146,6 @@ infrastructure are described first, followed by tool-specific sections.
 - Improved {doc}`readability-use-std-min-max
   <clang-tidy/checks/readability/use-std-min-max>` check by fixing spurious
   trailing semicolons and lost comments when the `if` body has no braces.
-
-- Fixed {doc}`cppcoreguidelines-use-enum-class
-  <clang-tidy/checks/cppcoreguidelines/use-enum-class>` suggesting `enum class` for unnamed enums (which is ill-formed).
 
 #### Removed checks
 

--- a/clang-tools-extra/docs/ReleaseNotes.md
+++ b/clang-tools-extra/docs/ReleaseNotes.md
@@ -122,8 +122,8 @@ infrastructure are described first, followed by tool-specific sections.
   <clang-tidy/checks/cppcoreguidelines/pro-type-member-init>` check by treating
   `std::array` the same as built-in arrays when `IgnoreArrays` option is enabled.
   
-- Fixed {doc}`cppcoreguidelines-use-enum-class
-  <clang-tidy/checks/cppcoreguidelines/use-enum-class>` suggesting `enum class` for unnamed enums (which is ill-formed).
+- Improved {doc}`cppcoreguidelines-use-enum-class
+  <clang-tidy/checks/cppcoreguidelines/use-enum-class>` check by omitting unnamed enums from the `enum class` requirement, as previously the check suggested users an ill-formed fix.
 
 - Improved {doc}`misc-redundant-expression
   <clang-tidy/checks/misc/redundant-expression>` by fixing false positives in

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/use-enum-class.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/use-enum-class.rst
@@ -4,7 +4,8 @@ cppcoreguidelines-use-enum-class
 ================================
 
 Finds unscoped (non-class) ``enum`` declarations and suggests using
-``enum class`` instead.
+``enum class`` instead. Unnamed enum are ignored and will be handled by check implementing `Enum.6
+<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#enum6-avoid-unnamed-enumerations>`_.
 
 This check implements `Enum.3
 <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#renum-class>`_

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/use-enum-class.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/use-enum-class.cpp
@@ -60,3 +60,5 @@ enum ForwardE : int;
 enum class ForwardEC : int;
 
 enum struct ForwardES : int;
+
+enum { A };


### PR DESCRIPTION
`UseEnumClassCheck::registerMatchers` implementing `cppcoreguidelines-use-enum-class` didn't check for empty enum names and suggested erroneous "fix" to make anonymous enums `class enum`, which is ill-defined, fix this.

Fixes #215328