### PR TITLE
[clangd][HLSL] Separate statement and declaration attributes code complete in [...]

### DIFF
--- a/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
+++ b/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
@@ -5163,6 +5163,55 @@ TEST(CompletionTest, FuzzyMatchMacro) {
   }
 }
 
+static void configureHLSL(TestTU &TU, bool EnableMatrix = false) {
+  TU.Filename = "TestTU.hlsl";
+  TU.ExtraArgs.push_back("-x");
+  TU.ExtraArgs.push_back("hlsl");
+  if (EnableMatrix)
+    TU.ExtraArgs.push_back("-fenable-matrix");
+  TU.ExtraArgs.push_back("--target=dxil-pc-shadermodel6.3-library");
+}
+
+TEST(CompletionTest, HLSLBracketAttributes) {
+  Annotations DeclContext(R"hlsl(
+    [^]
+    void main() {}
+  )hlsl");
+
+  TestTU TUDecl = TestTU::withCode(DeclContext.code());
+  configureHLSL(TUDecl);
+  auto ResultsDecl = completions(TUDecl, DeclContext.point());
+
+  EXPECT_THAT(ResultsDecl.Completions,
+              Contains(Field(&CodeCompletion::Name, "numthreads")));
+  EXPECT_THAT(ResultsDecl.Completions,
+              Contains(Field(&CodeCompletion::Name, "WaveSize")));
+  EXPECT_THAT(ResultsDecl.Completions,
+              Not(Contains(Field(&CodeCompletion::Name, "unroll"))));
+  EXPECT_THAT(ResultsDecl.Completions,
+              Not(Contains(Field(&CodeCompletion::Name, "SV_Target"))));
+
+  Annotations StmtContext(R"hlsl(
+    void main() {
+      [^]
+      for (int i = 0; i < 4; i++) {}
+    }
+  )hlsl");
+
+  TestTU TUStmt = TestTU::withCode(StmtContext.code());
+  configureHLSL(TUStmt);
+  auto ResultsStmt = completions(TUStmt, StmtContext.point());
+
+  EXPECT_THAT(ResultsStmt.Completions,
+              Contains(Field(&CodeCompletion::Name, "unroll")));
+  EXPECT_THAT(ResultsStmt.Completions,
+              Contains(Field(&CodeCompletion::Name, "loop")));
+  EXPECT_THAT(ResultsStmt.Completions,
+              Not(Contains(Field(&CodeCompletion::Name, "numthreads"))));
+  EXPECT_THAT(ResultsStmt.Completions,
+              Not(Contains(Field(&CodeCompletion::Name, "SV_Target"))));
+}
+
 } // namespace
 } // namespace clangd
 } // namespace clang

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -2338,7 +2338,7 @@ private:
   }
 
   bool MaybeParseMicrosoftAttributes(ParsedAttributes &Attrs,
-                                     bool IsStmtContext = false) {
+                                     bool IsStmtContext) {
     bool AttrsParsed = false;
     if ((getLangOpts().MicrosoftExt || getLangOpts().HLSL) &&
         Tok.is(tok::l_square)) {

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -2337,7 +2337,8 @@ private:
     return false;
   }
 
-  bool MaybeParseMicrosoftAttributes(ParsedAttributes &Attrs, bool IsStmtContext = false) {
+  bool MaybeParseMicrosoftAttributes(ParsedAttributes &Attrs,
+                                     bool IsStmtContext = false) {
     bool AttrsParsed = false;
     if ((getLangOpts().MicrosoftExt || getLangOpts().HLSL) &&
         Tok.is(tok::l_square)) {
@@ -3133,7 +3134,8 @@ private:
   ///             ms-attribute[opt]
   ///             ms-attribute ms-attribute-seq
   /// \endverbatim
-  void ParseMicrosoftAttributes(ParsedAttributes &Attrs, bool IsStmtContext = false);
+  void ParseMicrosoftAttributes(ParsedAttributes &Attrs,
+                                bool IsStmtContext = false);
 
   void ParseMicrosoftInheritanceClassAttributes(ParsedAttributes &attrs);
   void ParseNullabilityClassAttributes(ParsedAttributes &attrs);

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -2337,12 +2337,12 @@ private:
     return false;
   }
 
-  bool MaybeParseMicrosoftAttributes(ParsedAttributes &Attrs) {
+  bool MaybeParseMicrosoftAttributes(ParsedAttributes &Attrs, bool IsStmtContext = false) {
     bool AttrsParsed = false;
     if ((getLangOpts().MicrosoftExt || getLangOpts().HLSL) &&
         Tok.is(tok::l_square)) {
       ParsedAttributes AttrsWithRange(AttrFactory);
-      ParseMicrosoftAttributes(AttrsWithRange);
+      ParseMicrosoftAttributes(AttrsWithRange, IsStmtContext);
       AttrsParsed = !AttrsWithRange.empty();
       Attrs.takeAllAppendingFrom(AttrsWithRange);
     }
@@ -3133,7 +3133,7 @@ private:
   ///             ms-attribute[opt]
   ///             ms-attribute ms-attribute-seq
   /// \endverbatim
-  void ParseMicrosoftAttributes(ParsedAttributes &Attrs);
+  void ParseMicrosoftAttributes(ParsedAttributes &Attrs, bool IsStmtContext = false);
 
   void ParseMicrosoftInheritanceClassAttributes(ParsedAttributes &attrs);
   void ParseNullabilityClassAttributes(ParsedAttributes &attrs);

--- a/clang/include/clang/Sema/SemaCodeCompletion.h
+++ b/clang/include/clang/Sema/SemaCodeCompletion.h
@@ -234,6 +234,11 @@ public:
   void CodeCompleteIncludedFile(llvm::StringRef Dir, bool IsAngled);
   void CodeCompleteNaturalLanguage();
   void CodeCompleteAvailabilityPlatformName();
+  void CodeCompleteHLSLAttributes(
+      llvm::ArrayRef<AttributeCommonInfo::Syntax> Syntaxes,
+      std::optional<ParsedAttr::Kind> RestrictToKind = std::nullopt,
+      bool RequireStmt = false,
+      std::optional<ParsedAttr::Kind> ExcludeKind = std::nullopt);
   void
   GatherGlobalCodeCompletions(CodeCompletionAllocator &Allocator,
                               CodeCompletionTUInfo &CCTUInfo,

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -6161,7 +6161,7 @@ bool Parser::isConstructorDeclarator(bool IsUnqualified, bool DeductionGuide,
 
   // Optionally skip Microsoft attributes.
   ParsedAttributes Attrs(AttrFactory);
-  MaybeParseMicrosoftAttributes(Attrs);
+  MaybeParseMicrosoftAttributes(Attrs, /*IsStmtContext=*/false);
 
   // Check whether the next token(s) are part of a declaration
   // specifier, in which case we have the start of a parameter and,
@@ -7654,7 +7654,7 @@ void Parser::ParseParameterDeclarationClause(
       MaybeParseCXX11Attributes(ArgDeclAttrs);
 
       // Skip any Microsoft attributes before a param.
-      MaybeParseMicrosoftAttributes(ArgDeclSpecAttrs);
+      MaybeParseMicrosoftAttributes(ArgDeclSpecAttrs, /*IsStmtContext=*/false);
     }
 
     SourceLocation DSStart = Tok.getLocation();

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -2791,7 +2791,7 @@ Parser::DeclGroupPtrTy Parser::ParseCXXClassMemberDeclaration(
 
   while (MaybeParseCXX11Attributes(DeclAttrs) ||
          MaybeParseGNUAttributes(DeclSpecAttrs, &CommonLateParsedAttrs) ||
-         MaybeParseMicrosoftAttributes(DeclSpecAttrs))
+         MaybeParseMicrosoftAttributes(DeclSpecAttrs, /*IsStmtContext=*/false))
     ;
 
   SourceLocation DeclStart;

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -4921,7 +4921,7 @@ void Parser::ParseHLSLRootSignatureAttributeArgs(ParsedAttributes &Attrs) {
                  ParsedAttr::Form::Microsoft());
 }
 
-void Parser::ParseMicrosoftAttributes(ParsedAttributes &Attrs) {
+void Parser::ParseMicrosoftAttributes(ParsedAttributes &Attrs, bool IsStmtContext) {
   assert(Tok.is(tok::l_square) && "Not a Microsoft attribute list");
 
   SourceLocation StartLoc = Tok.getLocation();
@@ -4937,10 +4937,17 @@ void Parser::ParseMicrosoftAttributes(ParsedAttributes &Attrs) {
                 StopAtSemi | StopBeforeMatch | StopAtCodeCompletion);
       if (Tok.is(tok::code_completion)) {
         cutOffParsing();
-        Actions.CodeCompletion().CodeCompleteAttribute(
-            AttributeCommonInfo::AS_Microsoft,
-            SemaCodeCompletion::AttributeCompletion::Attribute,
-            /*Scope=*/nullptr);
+        if (getLangOpts().HLSL) {
+          Actions.CodeCompletion().CodeCompleteHLSLAttributes(
+              {AttributeCommonInfo::AS_Microsoft}, /*Kind=*/std::nullopt,
+              /*RequireStmt=*/IsStmtContext,
+              /*ExcludeKind=*/ParsedAttr::AT_HLSLParsedSemantic);
+        } else {
+            Actions.CodeCompletion().CodeCompleteAttribute(
+                AttributeCommonInfo::AS_Microsoft,
+                SemaCodeCompletion::AttributeCompletion::Attribute,
+              /*Scope=*/nullptr);
+          }
         break;
       }
       if (Tok.isNot(tok::identifier)) // ']', but also eof

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -4921,7 +4921,8 @@ void Parser::ParseHLSLRootSignatureAttributeArgs(ParsedAttributes &Attrs) {
                  ParsedAttr::Form::Microsoft());
 }
 
-void Parser::ParseMicrosoftAttributes(ParsedAttributes &Attrs, bool IsStmtContext) {
+void Parser::ParseMicrosoftAttributes(ParsedAttributes &Attrs,
+                                      bool IsStmtContext) {
   assert(Tok.is(tok::l_square) && "Not a Microsoft attribute list");
 
   SourceLocation StartLoc = Tok.getLocation();
@@ -4943,11 +4944,11 @@ void Parser::ParseMicrosoftAttributes(ParsedAttributes &Attrs, bool IsStmtContex
               /*RequireStmt=*/IsStmtContext,
               /*ExcludeKind=*/ParsedAttr::AT_HLSLParsedSemantic);
         } else {
-            Actions.CodeCompletion().CodeCompleteAttribute(
-                AttributeCommonInfo::AS_Microsoft,
-                SemaCodeCompletion::AttributeCompletion::Attribute,
+          Actions.CodeCompletion().CodeCompleteAttribute(
+              AttributeCommonInfo::AS_Microsoft,
+              SemaCodeCompletion::AttributeCompletion::Attribute,
               /*Scope=*/nullptr);
-          }
+        }
         break;
       }
       if (Tok.isNot(tok::identifier)) // ']', but also eof

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -73,7 +73,7 @@ StmtResult Parser::ParseStatementOrDeclaration(StmtVector &Stmts,
     MaybeParseGNUAttributes(GNUOrMSAttrs);
 
   if (getLangOpts().HLSL)
-    MaybeParseMicrosoftAttributes(GNUOrMSAttrs);
+    MaybeParseMicrosoftAttributes(GNUOrMSAttrs, /*IsStmtContext=*/true);
 
   StmtResult Res = ParseStatementOrDeclarationAfterAttributes(
       Stmts, StmtCtx, TrailingElseLoc, CXX11Attrs, GNUOrMSAttrs,

--- a/clang/lib/Parse/ParseTentative.cpp
+++ b/clang/lib/Parse/ParseTentative.cpp
@@ -1764,7 +1764,7 @@ Parser::TPResult Parser::TryParseParameterDeclarationClause(
       return TPResult::True;
 
     ParsedAttributes attrs(AttrFactory);
-    MaybeParseMicrosoftAttributes(attrs);
+    MaybeParseMicrosoftAttributes(attrs, /*IsStmtContext=*/false);
 
     // decl-specifier-seq
     // A parameter-declaration's initializer must be preceded by an '=', so

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -1056,7 +1056,7 @@ Parser::DeclGroupPtrTy Parser::ParseDeclOrFunctionDefInternal(
   DS.takeAttributesAppendingingFrom(DeclSpecAttrs);
 
   ParsedTemplateInfo TemplateInfo;
-  MaybeParseMicrosoftAttributes(DS.getAttributes());
+  MaybeParseMicrosoftAttributes(DS.getAttributes(), /*IsStmtContext=*/false);
   // Parse the common declaration-specifiers piece.
   ParseDeclarationSpecifiers(DS, TemplateInfo, AS,
                              DeclSpecContext::DSC_top_level);

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -10728,6 +10728,43 @@ void SemaCodeCompletion::GatherGlobalCodeCompletions(
                  Builder.data() + Builder.size());
 }
 
+void SemaCodeCompletion::CodeCompleteHLSLAttributes(
+    llvm::ArrayRef<AttributeCommonInfo::Syntax> Syntaxes,
+    std::optional<ParsedAttr::Kind> RestrictToKind,
+    bool RequireStmt,
+    std::optional<ParsedAttr::Kind> ExcludeKind) {
+  ResultBuilder Results(SemaRef, CodeCompleter->getAllocator(),
+                        CodeCompleter->getCodeCompletionTUInfo(),
+                        CodeCompletionContext::CCC_Attribute);
+
+  for (const auto *A : ParsedAttrInfo::getAllBuiltin()) {
+    if (!A->acceptsLangOpts(getLangOpts()))
+      continue;
+    if (RestrictToKind && A->AttrKind != *RestrictToKind)
+      continue;
+    if (ExcludeKind && A->AttrKind == *ExcludeKind)
+      continue;
+    if (A->IsStmt != RequireStmt)
+      continue;
+
+    for (const auto &S : A->Spellings) {
+      if (!llvm::is_contained(Syntaxes, S.Syntax))
+        continue;
+
+      CodeCompletionBuilder CCB(Results.getAllocator(),
+                                Results.getCodeCompletionTUInfo());
+      CCB.AddTypedTextChunk(
+          Results.getAllocator().CopyString(S.NormalizedFullName));
+      Results.AddResult(CodeCompletionResult(CCB.TakeString(), CCP_Keyword));
+    }
+  }
+
+  HandleCodeCompleteResults(&SemaRef, CodeCompleter,
+                            Results.getCompletionContext(), Results.data(),
+                            Results.size());
+}
+
+
 SemaCodeCompletion::SemaCodeCompletion(Sema &S,
                                        CodeCompleteConsumer *CompletionConsumer)
     : SemaBase(S), CodeCompleter(CompletionConsumer),

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -10730,8 +10730,7 @@ void SemaCodeCompletion::GatherGlobalCodeCompletions(
 
 void SemaCodeCompletion::CodeCompleteHLSLAttributes(
     llvm::ArrayRef<AttributeCommonInfo::Syntax> Syntaxes,
-    std::optional<ParsedAttr::Kind> RestrictToKind,
-    bool RequireStmt,
+    std::optional<ParsedAttr::Kind> RestrictToKind, bool RequireStmt,
     std::optional<ParsedAttr::Kind> ExcludeKind) {
   ResultBuilder Results(SemaRef, CodeCompleter->getAllocator(),
                         CodeCompleter->getCodeCompletionTUInfo(),
@@ -10763,7 +10762,6 @@ void SemaCodeCompletion::CodeCompleteHLSLAttributes(
                             Results.getCompletionContext(), Results.data(),
                             Results.size());
 }
-
 
 SemaCodeCompletion::SemaCodeCompletion(Sema &S,
                                        CodeCompleteConsumer *CompletionConsumer)


### PR DESCRIPTION
This PR addresses the issue where code completion inside `[...]` in HLSL mixed statement and declaration attributes.

Previously, `ParseMicrosoftAttributes` called `CodeCompleteAttribute(AS_Microsoft)` without threading the `IsStmt `context, causing statement attributes (like `[unroll]`) and declaration attributes (like `[numthreads]`) to appear together, alongside semantic annotations (like `SV_Target`).

Fixes #214792 