### PR TITLE
Fix Objective-C selector registration in clang-repl MachO runtime

### DIFF
--- a/compiler-rt/lib/orc/macho_platform.cpp
+++ b/compiler-rt/lib/orc/macho_platform.cpp
@@ -29,6 +29,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+#include <dlfcn.h>
 
 #define DEBUG_TYPE "macho_platform"
 
@@ -73,6 +74,33 @@ extern "C" int __unw_remove_find_dynamic_unwind_sections(
     ORC_RT_WEAK_IMPORT;
 
 namespace {
+
+using ObjCMapImagesFn = void (*)(unsigned, const char *const[],
+                                 const mach_header *const[]);
+using ObjCLoadImageFn = void (*)(const char *, const mach_header *);
+
+static ObjCMapImagesFn resolveObjCMapImages() {
+  if (_objc_map_images)
+    return _objc_map_images;
+  return reinterpret_cast<ObjCMapImagesFn>(
+      dlsym(RTLD_DEFAULT, "_objc_map_images"));
+}
+
+static ObjCLoadImageFn resolveObjCLoadImage() {
+  if (_objc_load_image)
+    return _objc_load_image;
+  return reinterpret_cast<ObjCLoadImageFn>(
+      dlsym(RTLD_DEFAULT, "_objc_load_image"));
+}
+
+struct objc_selector;
+using SEL = objc_selector *;
+using SelRegisterNameFn = SEL (*)(const char *);
+
+static SelRegisterNameFn resolveSelRegisterName() {
+  return reinterpret_cast<SelRegisterNameFn>(
+      dlsym(RTLD_DEFAULT, "sel_registerName"));
+}
 
 struct MachOJITDylibDepInfo {
   bool Sealed = false;
@@ -201,6 +229,7 @@ private:
     UnwindSectionsMap UnwindSections;
     RecordSectionsTracker<void (*)()> ModInitsSections;
     RecordSectionsTracker<char> ObjCRuntimeRegistrationObjects;
+    RecordSectionsTracker<char> ObjCSelRefsSections;
 
     bool referenced() const {
       return LinkedAgainstRefCount != 0 || DlRefCount != 0;
@@ -605,6 +634,8 @@ Error MachOPlatformRuntimeState::registerObjectPlatformSections(
         return Err;
     } else if (KV.first == "__llvm_jitlink_ObjCRuntimeRegistrationObject")
       JDS->ObjCRuntimeRegistrationObjects.add(KV.second.toSpan<char>());
+    else if (KV.first == "__DATA,__objc_selrefs")
+      JDS->ObjCSelRefsSections.add(KV.second.toSpan<char>());
     else if (KV.first == "__DATA,__mod_init_func")
       JDS->ModInitsSections.add(KV.second.toSpan<void (*)()>());
     else {
@@ -686,7 +717,9 @@ Error MachOPlatformRuntimeState::deregisterObjectPlatformSections(
         return Err;
     } else if (KV.first == "__llvm_jitlink_ObjCRuntimeRegistrationObject")
       JDS->ObjCRuntimeRegistrationObjects.removeIfPresent(KV.second);
-    else if (KV.first == "__DATA,__mod_init_func")
+      else if (KV.first == "__DATA,__objc_selrefs")
+      JDS->ObjCSelRefsSections.removeIfPresent(KV.second);
+      else if (KV.first == "__DATA,__mod_init_func")
       JDS->ModInitsSections.removeIfPresent(KV.second);
     else {
       // Should this be a warning instead?
@@ -1013,21 +1046,47 @@ Error MachOPlatformRuntimeState::registerObjCRegistrationObjects(
   if (RegObjBases.empty())
     return Error::success();
 
-  if (!_objc_map_images || !_objc_load_image)
+  auto SelRegisterName = reinterpret_cast<SelRegisterNameFn>(
+      dlsym(RTLD_DEFAULT, "sel_registerName"));
+
+  if (!SelRegisterName)
+    return make_error<StringError>(
+        "Could not register Objective-C / Swift metadata: sel_registerName "
+        "not found");
+
+  JDS.ObjCSelRefsSections.processNewSections(
+      [&](span<char> SelRefSection) {
+        if (SelRefSection.size() % sizeof(SEL) != 0)
+          return;
+
+        auto *SelRefs = reinterpret_cast<SEL *>(SelRefSection.data());
+        size_t Count = SelRefSection.size() / sizeof(SEL);
+
+        for (size_t I = 0; I != Count; ++I) {
+          if (!SelRefs[I])
+            continue;
+          SelRefs[I] = SelRegisterName(
+              reinterpret_cast<const char *>(SelRefs[I]));
+        }
+      });
+
+  auto ObjCMapImages = resolveObjCMapImages();
+  auto ObjCLoadImage = resolveObjCLoadImage();
+
+  if (!ObjCMapImages || !ObjCLoadImage)
     return make_error<StringError>(
         "Could not register Objective-C / Swift metadata: _objc_map_images / "
         "_objc_load_image not found");
 
-  // Release the lock while calling out to libobjc in case +load methods cause
-  // reentering the orc runtime.
   JDStatesLock.unlock();
   std::vector<char *> Paths;
   Paths.resize(RegObjBases.size());
-  _objc_map_images(RegObjBases.size(), Paths.data(),
-                   reinterpret_cast<mach_header **>(RegObjBases.data()));
+  ObjCMapImages(RegObjBases.size(), Paths.data(),
+                reinterpret_cast<const mach_header *const *>(
+                    RegObjBases.data()));
 
   for (void *RegObjBase : RegObjBases)
-    _objc_load_image(nullptr, reinterpret_cast<mach_header *>(RegObjBase));
+    ObjCLoadImage(nullptr, reinterpret_cast<mach_header *>(RegObjBase));
   JDStatesLock.lock();
 
   return Error::success();

--- a/llvm/lib/ExecutionEngine/Orc/MachOPlatform.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/MachOPlatform.cpp
@@ -1400,7 +1400,8 @@ Error MachOPlatform::MachOPlatformPlugin::registerObjectPlatformSections(
   // If any platform sections were found then add an allocation action to call
   // the registration function.
   StringRef PlatformSections[] = {MachOModInitFuncSectionName,
-                                  ObjCRuntimeObjectSectionName};
+                                  ObjCRuntimeObjectSectionName,
+                                  MachOObjCSelRefsSectionName};
 
   for (auto &SecName : PlatformSections) {
     auto *Sec = G.findSectionByName(SecName);
@@ -1412,7 +1413,7 @@ Error MachOPlatform::MachOPlatformPlugin::registerObjectPlatformSections(
 
     MachOPlatformSecs.push_back({SecName, R.getRange()});
   }
-
+  
   std::optional<std::tuple<SmallVector<ExecutorAddrRange>, ExecutorAddrRange,
                            ExecutorAddrRange>>
       UnwindInfo;


### PR DESCRIPTION
Description

This pr addresses Objective-C message-send failures in clang-repl on
the MachO path, where JIT-emitted selector references could remain
unregistered and eventually trigger unrecognized selector crashes.

Related to #213425

The change covers two possible failure points:

- It makes Objective-C runtime symbol resolution more robust by
  falling back to `dlsym` for `_objc_map_images`, `_objc_load_image`,
  and `sel_registerName`.
- It explicitly tracks `__objc_selrefs` and canonicalizes those
  selector references before ObjC image registration, so the runtime
  sees canonical Objective-C selector pointers instead of raw JIT-side
  references.

Either one of these changes could be the real root cause. I included
both because the failure is macOS-specific and I could not fully
validate the runtime behavior from my Linux environment. The
maintainer should test this on macOS with the original clang-repl
reproducer and confirm whether one change is sufficient or whether
both are needed.

This should bring the JIT path closer to normal macOS loading
behavior and help Objective-C message sends resolve correctly.

Testing

The compiler-rt file shows no local editor diagnostics errors. This
only reflects static analysis in the editor and does not confirm the
edited logic behaves correctly at runtime, or that compiler-rt builds
successfully end to end. Full build and runtime validation still
needs to be done on macOS.