### PR TITLE
[SandboxVec][DAG][NFC] Replace UnscheduledSuccs/Preds with a single variable

### DIFF
--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.h
@@ -149,10 +149,10 @@ protected:
   // TODO: Use a PointerIntPair for SubclassID and I.
   /// For isa/dyn_cast etc.
   DGNodeID SubclassID;
-  /// The number of unscheduled successors. Optional represents whether the
-  /// value is meaningless, e.g., after a node gets scheduled.
-  std::optional<unsigned> UnscheduledSuccs = 0;
-  std::optional<unsigned> UnscheduledPreds = 0;
+  /// The number of unscheduled successors (predecessors) depending on the
+  /// scheduling direction. Optional represents whether the value is
+  /// meaningless, e.g., after a node gets scheduled.
+  std::optional<unsigned> UnscheduledDeps = 0;
   /// This is true if this node has been scheduled.
   bool Scheduled = false;
   /// The scheduler bundle that this node belongs to.
@@ -173,49 +173,35 @@ public:
   DGNode(const DGNode &Other) = delete;
   virtual ~DGNode();
   /// \Returns the number of unscheduled successors.
-  unsigned getNumUnscheduledSuccs() const {
-    assert((bool)UnscheduledSuccs && "Invalid UnscheduledSuccs!");
-    return *UnscheduledSuccs;
-  }
-  /// \Returns the number of unscheduled predecessors.
-  unsigned getNumUnscheduledPreds() const {
-    assert((bool)UnscheduledPreds && "Invalid UnscheduledPreds!");
-    return *UnscheduledPreds;
+  unsigned getNumUnscheduledDeps() const {
+    assert((bool)UnscheduledDeps && "Invalid UnscheduledDeps!");
+    return *UnscheduledDeps;
   }
 #ifndef NDEBUG
-  /// \returns true unscheduled successors contains valid data (for testing).
-  bool validUnscheduledSuccs() const { return (bool)UnscheduledSuccs; }
-  /// \returns true unscheduled predecessors contains valid data (for testing).
-  bool validUnscheduledPreds() const { return (bool)UnscheduledPreds; }
+  /// \returns true if unscheduled successors(predecessors) contains valid data
+  /// (for testing).
+  bool validUnscheduledDeps() const { return (bool)UnscheduledDeps; }
 #endif
   // TODO: Make this private?
-  void decrUnscheduledSuccs() {
-    assert(*UnscheduledSuccs > 0 && "Counting error!");
-    --*UnscheduledSuccs;
+  void decrUnscheduledDeps() {
+    assert(*UnscheduledDeps > 0 && "Counting error!");
+    --*UnscheduledDeps;
   }
-  void incrUnscheduledSuccs() { ++*UnscheduledSuccs; }
-  void decrUnscheduledPreds() {
-    assert(*UnscheduledPreds > 0 && "Counting error!");
-    --*UnscheduledPreds;
-  }
-  void incrUnscheduledPreds() { ++*UnscheduledPreds; }
+  void incrUnscheduledDeps() { ++*UnscheduledDeps; }
 
   void resetScheduleState() {
-    UnscheduledSuccs = 0;
-    UnscheduledPreds = 0;
+    UnscheduledDeps = 0;
     Scheduled = false;
   }
   /// \Returns true if all dependent successors (or predecessors during top-down
   /// scheduling) have been scheduled.
-  bool readyBottomUp() const { return UnscheduledSuccs == 0; }
-  bool readyTopDown() const { return UnscheduledPreds == 0; }
+  bool ready() const { return UnscheduledDeps == 0; }
   /// \Returns true if this node has been scheduled.
   bool scheduled() const { return Scheduled; }
   void setScheduled() {
     Scheduled = true;
-    // UnscheduledSuccs is meaningless from this point on, so prohibit its use.
-    UnscheduledSuccs = std::nullopt;
-    UnscheduledPreds = std::nullopt;
+    // UnscheduledDeps is meaningless from this point on, so prohibit its use.
+    UnscheduledDeps = std::nullopt;
   }
   /// \Returns the scheduling bundle that this node belongs to, or nullptr.
   SchedBundle *getSchedBundle() const { return SB; }
@@ -384,33 +370,40 @@ public:
   MemDGNode *getPrevNode() const { return PrevMemN; }
   /// \Returns the next Mem DGNode in instruction order.
   MemDGNode *getNextNode() const { return NextMemN; }
+
+  // TODO: addMemPred() and removeMemPred() should be private.
   /// Adds the mem dependency edge PredN->this. This also increments the
-  /// UnscheduledSuccs counter of the predecessor if this node has not been
+  /// UnscheduledDeps counter of the predecessor if this node has not been
   /// scheduled.
-  void addMemPred(MemDGNode *PredN) {
+  void addMemPred(MemDGNode *PredN, SchedDirection Dir) {
     [[maybe_unused]] auto Inserted = MemPreds.insert(PredN).second;
     assert(Inserted && "PredN already exists!");
     assert(PredN != this && "Trying to add a dependency to self!");
     PredN->MemSuccs.insert(this);
     if (!Scheduled) {
       if (!PredN->Scheduled) {
-        PredN->incrUnscheduledSuccs();
-        incrUnscheduledPreds();
+        if (Dir == SchedDirection::BottomUp)
+          PredN->incrUnscheduledDeps();
+        else
+          incrUnscheduledDeps();
       }
     }
   }
   /// Removes the memory dependency PredN->this. This also updates the
   /// UnscheduledSuccs counter of PredN if this node has not been scheduled.
-  void removeMemPred(MemDGNode *PredN) {
+  void removeMemPred(MemDGNode *PredN, SchedDirection Dir) {
     MemPreds.erase(PredN);
     PredN->MemSuccs.erase(this);
     if (!Scheduled) {
       if (!PredN->Scheduled) {
-        PredN->decrUnscheduledSuccs();
-        decrUnscheduledPreds();
+        if (Dir == SchedDirection::BottomUp)
+          PredN->decrUnscheduledDeps();
+        else
+          decrUnscheduledDeps();
       }
     }
   }
+
   /// \Returns true if there is a memory dependency N->this.
   bool hasMemPred(DGNode *N) const {
     if (auto *MN = dyn_cast<MemDGNode>(N))

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Scheduler.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Scheduler.h
@@ -158,10 +158,7 @@ public:
   LLVM_ABI void cluster(BasicBlock::iterator Where);
   /// \Returns true if all nodes in the bundle are ready.
   bool ready(SchedDirection Dir) const {
-    return all_of(Nodes, [Dir](const auto *N) {
-      return Dir == SchedDirection::BottomUp ? N->readyBottomUp()
-                                             : N->readyTopDown();
-    });
+    return all_of(Nodes, [](const auto *N) { return N->ready(); });
   }
 #ifndef NDEBUG
   void dump(raw_ostream &OS) const;

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.cpp
@@ -154,8 +154,12 @@ DGNode::~DGNode() {
 
 #ifndef NDEBUG
 void DGNode::print(raw_ostream &OS, bool PrintDeps) const {
-  OS << *I << " USuccs:" << UnscheduledSuccs << " UPreds:" << UnscheduledPreds
-     << " Sched:" << Scheduled << "\n";
+  OS << *I << " Unsched:";
+  if (UnscheduledDeps)
+    OS << UnscheduledDeps;
+  else
+    OS << "N/A";
+  OS << " Sched:" << Scheduled << "\n";
 }
 void DGNode::dump() const { print(dbgs()); }
 void MemDGNode::print(raw_ostream &OS, bool PrintDeps) const {
@@ -304,7 +308,7 @@ void DependencyGraph::scanAndAddDeps(MemDGNode &DstN,
   for (MemDGNode &SrcN : reverse(SrcScanRange)) {
     Instruction *SrcI = SrcN.getInstruction();
     if (hasDep(SrcI, DstI))
-      DstN.addMemPred(&SrcN);
+      DstN.addMemPred(&SrcN, Dir);
   }
 }
 
@@ -331,11 +335,13 @@ void DependencyGraph::setDefUseUnscheduledSuccs(
       auto *OpN = getNode(OpI);
       if (OpN == nullptr)
         continue;
-      OpN->incrUnscheduledSuccs();
+      if (Dir == SchedDirection::BottomUp)
+        OpN->incrUnscheduledDeps();
       if (!OpN->scheduled())
         ++CntUnschedPreds;
     }
-    getNode(&I)->UnscheduledPreds = CntUnschedPreds;
+    if (Dir == SchedDirection::TopDown)
+      getNode(&I)->UnscheduledDeps = CntUnschedPreds;
   }
 
   // Now handle the cross-interval edges.
@@ -368,11 +374,13 @@ void DependencyGraph::setDefUseUnscheduledSuccs(
       if (!TopInterval.contains(OpI))
         continue;
       if (!OpN->scheduled()) {
-        OpN->incrUnscheduledSuccs();
+        if (Dir == SchedDirection::BottomUp)
+          OpN->incrUnscheduledDeps();
         ++CntUnscheduledPreds;
       }
     }
-    *BotN->UnscheduledPreds += CntUnscheduledPreds;
+    if (Dir == SchedDirection::TopDown)
+      *BotN->UnscheduledDeps += CntUnscheduledPreds;
   }
 }
 
@@ -584,11 +592,11 @@ void DependencyGraph::notifyEraseInstr(Instruction *I) {
     // Drop the memory dependencies from both predecessors and successors.
     while (!MemN->memPreds().empty()) {
       auto *PredN = *MemN->memPreds().begin();
-      MemN->removeMemPred(PredN);
+      MemN->removeMemPred(PredN, Dir);
     }
     while (!MemN->memSuccs().empty()) {
       auto *SuccN = *MemN->memSuccs().begin();
-      SuccN->removeMemPred(MemN);
+      SuccN->removeMemPred(MemN, Dir);
     }
     // NOTE: The unscheduled succs for MemNodes get updated be setMemPred().
   } else {
@@ -596,10 +604,10 @@ void DependencyGraph::notifyEraseInstr(Instruction *I) {
     if (!N->scheduled()) {
       for (auto *PredN : N->preds(*this))
         if (!PredN->scheduled())
-          PredN->decrUnscheduledSuccs();
+          PredN->decrUnscheduledDeps();
       for (auto *SuccN : N->succs(*this))
         /// TODO: Does the successor also need to be guarded?
-        SuccN->decrUnscheduledPreds();
+        SuccN->decrUnscheduledDeps();
     }
   }
   // Finally erase the Node.
@@ -628,23 +636,23 @@ void DependencyGraph::notifySetUse(const Use &U, Value *NewSrc) {
   // NewSrc if needed.
   if (auto *CurrSrcI = dyn_cast<Instruction>(U.get())) {
     if (auto *CurrSrcN = getNode(CurrSrcI)) {
-      // If CurrSrcN is scheduled there is no point in updating UnscheduleSuccs.
+      // If CurrSrcN is scheduled there is no point in updating UnscheduledDeps.
       if (!CurrSrcN->scheduled()) {
         if (Dir == SchedDirection::BottomUp)
-          CurrSrcN->decrUnscheduledSuccs();
+          CurrSrcN->decrUnscheduledDeps();
         else
-          UserN->decrUnscheduledPreds();
+          UserN->decrUnscheduledDeps();
       }
     }
   }
   if (auto *NewSrcI = dyn_cast<Instruction>(NewSrc)) {
     if (auto *NewSrcN = getNode(NewSrcI)) {
-      // If CurrSrcN is scheduled there is no point in updating UnscheduleSuccs.
+      // If CurrSrcN is scheduled there is no point in updating UnscheduleDeps.
       if (!NewSrcN->scheduled()) {
         if (Dir == SchedDirection::BottomUp)
-          NewSrcN->incrUnscheduledSuccs();
+          NewSrcN->incrUnscheduledDeps();
         else
-          UserN->incrUnscheduledPreds();
+          UserN->incrUnscheduledDeps();
       }
     }
   }

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Scheduler.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Scheduler.cpp
@@ -98,16 +98,16 @@ void Scheduler::scheduleAndUpdateReadyList(SchedBundle &Bndl) {
     switch (Dir) {
     case SchedDirection::BottomUp: {
       for (auto *DepN : N->preds(DAG)) {
-        DepN->decrUnscheduledSuccs();
-        if (DepN->readyBottomUp() && !DepN->scheduled())
+        DepN->decrUnscheduledDeps();
+        if (DepN->ready() && !DepN->scheduled())
           ReadyList.insert(DepN);
       }
       break;
     }
     case SchedDirection::TopDown: {
       for (auto *DepN : N->succs(DAG)) {
-        DepN->decrUnscheduledPreds();
-        if (DepN->readyTopDown() && !DepN->scheduled())
+        DepN->decrUnscheduledDeps();
+        if (DepN->ready() && !DepN->scheduled())
           ReadyList.insert(DepN);
       }
       break;
@@ -141,12 +141,12 @@ void Scheduler::notifyCreateInstr(Instruction *I) {
     if (Dir == SchedDirection::BottomUp) {
       for (auto *PredN : N->preds(DAG)) {
         ReadyList.remove(PredN);
-        PredN->incrUnscheduledSuccs();
+        PredN->incrUnscheduledDeps();
       }
     } else {
       for (auto *SuccN : N->succs(DAG)) {
         ReadyList.remove(SuccN);
-        SuccN->incrUnscheduledPreds();
+        SuccN->incrUnscheduledDeps();
       }
     }
   }
@@ -322,13 +322,13 @@ void Scheduler::trimSchedule(ArrayRef<Instruction *> Instrs) {
       // Recompute UnscheduledSuccs for nodes not only in ResetIntvl but even
       // for nodes above the top of schedule.
       for (auto *PredN : N->preds(DAG))
-        PredN->incrUnscheduledSuccs();
+        PredN->incrUnscheduledDeps();
     } else {
       assert(Dir == SchedDirection::TopDown);
       // Recompute UnscheduledPreds for nodes not only in ResetIntvl but even
       // for nodes below the bottom of schedule.
       for (auto *SuccN : N->succs(DAG))
-        SuccN->incrUnscheduledPreds();
+        SuccN->incrUnscheduledDeps();
     }
   }
 
@@ -342,8 +342,7 @@ void Scheduler::trimSchedule(ArrayRef<Instruction *> Instrs) {
           : Interval<Instruction>(TopI, DAG.getInterval().bottom());
   for (Instruction &I : RefillIntvl) {
     auto *N = DAG.getNode(&I);
-    if (Dir == SchedDirection::BottomUp ? N->readyBottomUp()
-                                        : N->readyTopDown())
+    if (N->ready())
       ReadyList.insert(N);
   }
 }
@@ -412,9 +411,7 @@ bool Scheduler::trySchedule(ArrayRef<Instruction *> Instrs) {
       auto *N = DAG.getNode(&I);
       if (N->scheduled())
         continue;
-      bool IsReady = Dir == SchedDirection::BottomUp ? N->readyBottomUp()
-                                                     : N->readyTopDown();
-      if (IsReady && !ReadyList.contains(N))
+      if (N->ready() && !ReadyList.contains(N))
         ReadyList.insert(N);
     }
     // Try schedule all nodes until we can schedule Instrs back-to-back.

--- a/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/DependencyGraphTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/DependencyGraphTest.cpp
@@ -265,16 +265,16 @@ define void @foo(ptr %ptr, i8 %v0, i8 %v1) {
   // Check memSuccs().
   EXPECT_THAT(N0->memSuccs(), testing::ElementsAre(N1));
 
-  // Check UnscheduledSuccs.
-  EXPECT_EQ(N0->getNumUnscheduledSuccs(), 1u); // N1
-  EXPECT_EQ(N1->getNumUnscheduledSuccs(), 0u);
-  EXPECT_EQ(N2->getNumUnscheduledSuccs(), 0u);
+  // Check UnscheduledDeps.
+  EXPECT_EQ(N0->getNumUnscheduledDeps(), 1u); // N1
+  EXPECT_EQ(N1->getNumUnscheduledDeps(), 0u);
+  EXPECT_EQ(N2->getNumUnscheduledDeps(), 0u);
 
-  // Check decrUnscheduledSuccs.
-  N0->decrUnscheduledSuccs();
-  EXPECT_EQ(N0->getNumUnscheduledSuccs(), 0u);
+  // Check decrUnscheduledDeps.
+  N0->decrUnscheduledDeps();
+  EXPECT_EQ(N0->getNumUnscheduledDeps(), 0u);
 #ifndef NDEBUG
-  EXPECT_DEATH(N0->decrUnscheduledSuccs(), ".*Counting.*");
+  EXPECT_DEATH(N0->decrUnscheduledDeps(), ".*Counting.*");
 #endif // NDEBUG
 
   // Check scheduled(), setScheduled().
@@ -306,16 +306,16 @@ define void @foo(ptr %ptr, i8 %v0, i8 %v1) {
 
   // Check removeMemPred().
   EXPECT_FALSE(N0->memSuccs().empty());
-  EXPECT_EQ(N0->getNumUnscheduledSuccs(), 1u);
-  N1->removeMemPred(N0);
+  EXPECT_EQ(N0->getNumUnscheduledDeps(), 1u);
+  N1->removeMemPred(N0, BottomUp);
   EXPECT_TRUE(N1->memPreds().empty());
-  EXPECT_EQ(N0->getNumUnscheduledSuccs(), 0u);
+  EXPECT_EQ(N0->getNumUnscheduledDeps(), 0u);
 
   // Check addMemPred().
-  N1->addMemPred(N0);
+  N1->addMemPred(N0, BottomUp);
   EXPECT_THAT(N1->memPreds(), testing::UnorderedElementsAre(N0));
   EXPECT_THAT(N0->memSuccs(), testing::UnorderedElementsAre(N1));
-  EXPECT_THAT(N0->getNumUnscheduledSuccs(), 1u);
+  EXPECT_THAT(N0->getNumUnscheduledDeps(), 1u);
 }
 
 TEST_F(DependencyGraphTest, Preds) {
@@ -362,12 +362,12 @@ define i8 @foo(i8 %v0, i8 %v1) {
   EXPECT_THAT(RetN->succs(DAG), testing::ElementsAre());
 
   // Check UnscheduledSuccs.
-  EXPECT_EQ(AddN0->getNumUnscheduledSuccs(), 1u); // AddN2
-  EXPECT_EQ(AddN1->getNumUnscheduledSuccs(), 2u); // AddN2, CallN
-  EXPECT_EQ(AddN2->getNumUnscheduledSuccs(), 2u); // StN, RetN
-  EXPECT_EQ(CallN->getNumUnscheduledSuccs(), 2u); // StN, StN
-  EXPECT_EQ(StN->getNumUnscheduledSuccs(), 0u);
-  EXPECT_EQ(RetN->getNumUnscheduledSuccs(), 0u);
+  EXPECT_EQ(AddN0->getNumUnscheduledDeps(), 1u); // AddN2
+  EXPECT_EQ(AddN1->getNumUnscheduledDeps(), 2u); // AddN2, CallN
+  EXPECT_EQ(AddN2->getNumUnscheduledDeps(), 2u); // StN, RetN
+  EXPECT_EQ(CallN->getNumUnscheduledDeps(), 2u); // StN, StN
+  EXPECT_EQ(StN->getNumUnscheduledDeps(), 0u);
+  EXPECT_EQ(RetN->getNumUnscheduledDeps(), 0u);
 }
 
 // Make sure we don't get null predecessors even if they are outside the DAG.
@@ -873,9 +873,7 @@ define void @foo(ptr %ptr, i8 %v1, i8 %v2, i8 %v3, i8 %v4, i8 %v5) {
     EXPECT_EQ(DAG.getInterval().bottom(), S3);
     [[maybe_unused]] auto *S3N = cast<sandboxir::MemDGNode>(DAG.getNode(S3));
     // Check UnscheduledSuccs.
-    EXPECT_EQ(S3N->getNumUnscheduledSuccs(), 0u);
-    // Check UnscheduledPreds.
-    EXPECT_EQ(S3N->getNumUnscheduledPreds(), 0u);
+    EXPECT_EQ(S3N->getNumUnscheduledDeps(), 0u);
   }
   {
     // Scenario 2: Extend below
@@ -888,13 +886,9 @@ define void @foo(ptr %ptr, i8 %v1, i8 %v2, i8 %v3, i8 %v4, i8 %v5) {
     EXPECT_TRUE(S5N->hasMemPred(S4N));
     EXPECT_TRUE(S5N->hasMemPred(S3N));
     // Check UnscheduledSuccs.
-    EXPECT_EQ(S3N->getNumUnscheduledSuccs(), 2u); // S4N, S5N
-    EXPECT_EQ(S4N->getNumUnscheduledSuccs(), 1u); // S5N
-    EXPECT_EQ(S5N->getNumUnscheduledSuccs(), 0u);
-    // Check UnscheduledPreds.
-    EXPECT_EQ(S3N->getNumUnscheduledPreds(), 0u);
-    EXPECT_EQ(S4N->getNumUnscheduledPreds(), 1u); // S3N
-    EXPECT_EQ(S5N->getNumUnscheduledPreds(), 2u); // S3N, S4N
+    EXPECT_EQ(S3N->getNumUnscheduledDeps(), 2u); // S4N, S5N
+    EXPECT_EQ(S4N->getNumUnscheduledDeps(), 1u); // S5N
+    EXPECT_EQ(S5N->getNumUnscheduledDeps(), 0u);
   }
   {
     // Scenario 3: Extend above
@@ -921,17 +915,11 @@ define void @foo(ptr %ptr, i8 %v1, i8 %v2, i8 %v3, i8 %v4, i8 %v5) {
     EXPECT_TRUE(S5N->hasMemPred(S1N));
 
     // Check UnscheduledSuccs.
-    EXPECT_EQ(S1N->getNumUnscheduledSuccs(), 4u); // S2N, S3N, S4N, S5N
-    EXPECT_EQ(S2N->getNumUnscheduledSuccs(), 3u); // S3N, S4N, S5N
-    EXPECT_EQ(S3N->getNumUnscheduledSuccs(), 2u); // S4N, S5N
-    EXPECT_EQ(S4N->getNumUnscheduledSuccs(), 1u); // S5N
-    EXPECT_EQ(S5N->getNumUnscheduledSuccs(), 0u);
-    // Check UnscheduledPreds.
-    EXPECT_EQ(S1N->getNumUnscheduledPreds(), 0u);
-    EXPECT_EQ(S2N->getNumUnscheduledPreds(), 1u); // S1N
-    EXPECT_EQ(S3N->getNumUnscheduledPreds(), 2u); // S1N, S2N
-    EXPECT_EQ(S4N->getNumUnscheduledPreds(), 3u); // S1N, S2N, S3N
-    EXPECT_EQ(S5N->getNumUnscheduledPreds(), 4u); // S1N, S2N, S3N, S4N
+    EXPECT_EQ(S1N->getNumUnscheduledDeps(), 4u); // S2N, S3N, S4N, S5N
+    EXPECT_EQ(S2N->getNumUnscheduledDeps(), 3u); // S3N, S4N, S5N
+    EXPECT_EQ(S3N->getNumUnscheduledDeps(), 2u); // S4N, S5N
+    EXPECT_EQ(S4N->getNumUnscheduledDeps(), 1u); // S5N
+    EXPECT_EQ(S5N->getNumUnscheduledDeps(), 0u);
   }
 
   {
@@ -943,7 +931,87 @@ define void @foo(ptr %ptr, i8 %v1, i8 %v2, i8 %v3, i8 %v4, i8 %v5) {
 
     DAG.extend({S1, S1});
     auto *S1N = cast<sandboxir::MemDGNode>(DAG.getNode(S1));
-    EXPECT_EQ(S1N->getNumUnscheduledSuccs(), 0u); // S2 is scheduled
+    EXPECT_EQ(S1N->getNumUnscheduledDeps(), 0u); // S2 is scheduled
+  }
+}
+
+TEST_F(DependencyGraphTest, ExtendTopDown) {
+  parseIR(C, R"IR(
+define void @foo(ptr %ptr, i8 %v1, i8 %v2, i8 %v3, i8 %v4, i8 %v5) {
+  store i8 %v1, ptr %ptr
+  store i8 %v2, ptr %ptr
+  store i8 %v3, ptr %ptr
+  store i8 %v4, ptr %ptr
+  store i8 %v5, ptr %ptr
+  ret void
+}
+)IR");
+  llvm::Function *LLVMF = &*M->getFunction("foo");
+  sandboxir::Context Ctx(C);
+  auto *F = Ctx.createFunction(LLVMF);
+  auto *BB = &*F->begin();
+  auto It = BB->begin();
+  auto *S1 = cast<sandboxir::StoreInst>(&*It++);
+  auto *S2 = cast<sandboxir::StoreInst>(&*It++);
+  auto *S3 = cast<sandboxir::StoreInst>(&*It++);
+  auto *S4 = cast<sandboxir::StoreInst>(&*It++);
+  auto *S5 = cast<sandboxir::StoreInst>(&*It++);
+  sandboxir::DependencyGraph DAG(TopDown, getAA(*LLVMF), Ctx);
+  {
+    // Scenario 1: Build new DAG
+    auto NewIntvl = DAG.extend({S3, S3});
+    EXPECT_EQ(NewIntvl, sandboxir::Interval<sandboxir::Instruction>(S3, S3));
+    EXPECT_EQ(DAG.getInterval().top(), S3);
+    EXPECT_EQ(DAG.getInterval().bottom(), S3);
+    [[maybe_unused]] auto *S3N = cast<sandboxir::MemDGNode>(DAG.getNode(S3));
+    // Check UnscheduledSuccs.
+    EXPECT_EQ(S3N->getNumUnscheduledDeps(), 0u);
+  }
+  {
+    // Scenario 2: Extend below
+    auto NewIntvl = DAG.extend({S5, S5});
+    EXPECT_EQ(NewIntvl, sandboxir::Interval<sandboxir::Instruction>(S4, S5));
+    auto *S3N = cast<sandboxir::MemDGNode>(DAG.getNode(S3));
+    auto *S4N = cast<sandboxir::MemDGNode>(DAG.getNode(S4));
+    auto *S5N = cast<sandboxir::MemDGNode>(DAG.getNode(S5));
+    EXPECT_TRUE(S4N->hasMemPred(S3N));
+    EXPECT_TRUE(S5N->hasMemPred(S4N));
+    EXPECT_TRUE(S5N->hasMemPred(S3N));
+    // Check UnscheduledPreds.
+    EXPECT_EQ(S3N->getNumUnscheduledDeps(), 0u);
+    EXPECT_EQ(S4N->getNumUnscheduledDeps(), 1u); // S3N
+    EXPECT_EQ(S5N->getNumUnscheduledDeps(), 2u); // S3N, S4N
+  }
+  {
+    // Scenario 3: Extend above
+    auto NewIntvl = DAG.extend({S1, S2});
+    EXPECT_EQ(NewIntvl, sandboxir::Interval<sandboxir::Instruction>(S1, S2));
+    auto *S1N = cast<sandboxir::MemDGNode>(DAG.getNode(S1));
+    auto *S2N = cast<sandboxir::MemDGNode>(DAG.getNode(S2));
+    auto *S3N = cast<sandboxir::MemDGNode>(DAG.getNode(S3));
+    auto *S4N = cast<sandboxir::MemDGNode>(DAG.getNode(S4));
+    auto *S5N = cast<sandboxir::MemDGNode>(DAG.getNode(S5));
+
+    EXPECT_TRUE(S2N->hasMemPred(S1N));
+
+    EXPECT_TRUE(S3N->hasMemPred(S2N));
+    EXPECT_TRUE(S3N->hasMemPred(S1N));
+
+    EXPECT_TRUE(S4N->hasMemPred(S3N));
+    EXPECT_TRUE(S4N->hasMemPred(S2N));
+    EXPECT_TRUE(S4N->hasMemPred(S1N));
+
+    EXPECT_TRUE(S5N->hasMemPred(S4N));
+    EXPECT_TRUE(S5N->hasMemPred(S3N));
+    EXPECT_TRUE(S5N->hasMemPred(S2N));
+    EXPECT_TRUE(S5N->hasMemPred(S1N));
+
+    // Check UnscheduledPreds.
+    EXPECT_EQ(S1N->getNumUnscheduledDeps(), 0u);
+    EXPECT_EQ(S2N->getNumUnscheduledDeps(), 1u); // S1N
+    EXPECT_EQ(S3N->getNumUnscheduledDeps(), 2u); // S1N, S2N
+    EXPECT_EQ(S4N->getNumUnscheduledDeps(), 3u); // S1N, S2N, S3N
+    EXPECT_EQ(S5N->getNumUnscheduledDeps(), 4u); // S1N, S2N, S3N, S4N
   }
   {
     // Check UnscheduledPreds when a node is scheduled
@@ -954,7 +1022,7 @@ define void @foo(ptr %ptr, i8 %v1, i8 %v2, i8 %v3, i8 %v4, i8 %v5) {
 
     DAG.extend({S2, S2});
     auto *S2N = cast<sandboxir::MemDGNode>(DAG.getNode(S2));
-    EXPECT_EQ(S2N->getNumUnscheduledPreds(), 0u); // S1 is scheduled
+    EXPECT_EQ(S2N->getNumUnscheduledDeps(), 0u); // S1 is scheduled
   }
 }
 
@@ -1052,12 +1120,9 @@ define void @foo(ptr %ptr, i8 %v1, i8 %v2, i8 %v3, i8 %v4, i8 %arg) {
   auto *S1MemN = cast<sandboxir::MemDGNode>(DAG.getNode(S1));
   auto *S2MemN = cast<sandboxir::MemDGNode>(DAG.getNode(S2));
   auto *S3MemN = cast<sandboxir::MemDGNode>(DAG.getNode(S3));
-  EXPECT_EQ(S1MemN->getNumUnscheduledSuccs(), 2u);
-  EXPECT_EQ(S2MemN->getNumUnscheduledSuccs(), 1u);
-  EXPECT_EQ(S3MemN->getNumUnscheduledSuccs(), 0u);
-  EXPECT_EQ(S1MemN->getNumUnscheduledPreds(), 0u);
-  EXPECT_EQ(S2MemN->getNumUnscheduledPreds(), 1u);
-  EXPECT_EQ(S3MemN->getNumUnscheduledPreds(), 2u);
+  EXPECT_EQ(S1MemN->getNumUnscheduledDeps(), 2u);
+  EXPECT_EQ(S2MemN->getNumUnscheduledDeps(), 1u);
+  EXPECT_EQ(S3MemN->getNumUnscheduledDeps(), 0u);
   S2->eraseFromParent();
   // Check that the DAG Node for S2 no longer exists.
   auto *DeletedN = DAG.getNode(S2);
@@ -1066,9 +1131,7 @@ define void @foo(ptr %ptr, i8 %v1, i8 %v2, i8 %v3, i8 %v4, i8 %arg) {
   EXPECT_THAT(S3MemN->preds(DAG), testing::UnorderedElementsAre(S1MemN));
   EXPECT_THAT(S1MemN->succs(DAG), testing::UnorderedElementsAre(S3MemN));
   // Also check that UnscheduledSuccs was updated for S1.
-  EXPECT_EQ(S1MemN->getNumUnscheduledSuccs(), 1u);
-  // Also check that UnscheduledPreds was updated for S3.
-  EXPECT_EQ(S3MemN->getNumUnscheduledPreds(), 1u);
+  EXPECT_EQ(S1MemN->getNumUnscheduledDeps(), 1u);
 
   // Check the MemDGNode chain.
   EXPECT_EQ(S1MemN->getNextNode(), S3MemN);
@@ -1107,20 +1170,15 @@ define void @foo(ptr %ptr, i8 %v1, i8 %v2, i8 %v3) {
   auto *S1MemN = cast<sandboxir::MemDGNode>(DAG.getNode(S1));
   auto *S2MemN = cast<sandboxir::MemDGNode>(DAG.getNode(S2));
   auto *S3MemN = cast<sandboxir::MemDGNode>(DAG.getNode(S3));
-  EXPECT_EQ(S1MemN->getNumUnscheduledSuccs(), 2u);
-  EXPECT_EQ(S2MemN->getNumUnscheduledSuccs(), 1u);
-  EXPECT_EQ(S3MemN->getNumUnscheduledSuccs(), 0u);
-  EXPECT_EQ(S1MemN->getNumUnscheduledPreds(), 0u);
-  EXPECT_EQ(S2MemN->getNumUnscheduledPreds(), 1u);
-  EXPECT_EQ(S3MemN->getNumUnscheduledPreds(), 2u);
+  EXPECT_EQ(S1MemN->getNumUnscheduledDeps(), 2u);
+  EXPECT_EQ(S2MemN->getNumUnscheduledDeps(), 1u);
+  EXPECT_EQ(S3MemN->getNumUnscheduledDeps(), 0u);
   // Mark S2 as scheduled and erase it.
   S2MemN->setScheduled();
   S2->eraseFromParent();
   EXPECT_EQ(DAG.getNode(S2), nullptr);
   // Check that we did not update S1's UnscheduledSuccs
-  EXPECT_EQ(S1MemN->getNumUnscheduledSuccs(), 2u);
-  // Check that we did not update S3's UnscheduledPreds
-  EXPECT_EQ(S3MemN->getNumUnscheduledPreds(), 2u);
+  EXPECT_EQ(S1MemN->getNumUnscheduledDeps(), 2u);
 }
 
 TEST_F(DependencyGraphTest, MoveInstrCallback) {
@@ -1260,34 +1318,34 @@ define void @foo(i8 %v0, i8 %v1) {
   DAG.extend({Add0, Add1});
   auto *N0 = DAG.getNode(Add0);
 
-  EXPECT_EQ(N0->getNumUnscheduledSuccs(), 1u);
+  EXPECT_EQ(N0->getNumUnscheduledDeps(), 1u);
   // Now change %add1 operand to not use %add0.
   Add1->setOperand(0, Arg0);
-  EXPECT_EQ(N0->getNumUnscheduledSuccs(), 0u);
+  EXPECT_EQ(N0->getNumUnscheduledDeps(), 0u);
   // Restore it: %add0 is now used by %add1.
   Add1->setOperand(0, Add0);
-  EXPECT_EQ(N0->getNumUnscheduledSuccs(), 1u);
+  EXPECT_EQ(N0->getNumUnscheduledDeps(), 1u);
 
   // RAUW
   Add0->replaceAllUsesWith(Arg0);
-  EXPECT_EQ(N0->getNumUnscheduledSuccs(), 0u);
+  EXPECT_EQ(N0->getNumUnscheduledDeps(), 0u);
   // Restore it: %add0 is now used by %add1.
   Add1->setOperand(0, Add0);
-  EXPECT_EQ(N0->getNumUnscheduledSuccs(), 1u);
+  EXPECT_EQ(N0->getNumUnscheduledDeps(), 1u);
 
   // RUWIf
   Add0->replaceUsesWithIf(Arg0, [](const auto &U) { return true; });
-  EXPECT_EQ(N0->getNumUnscheduledSuccs(), 0u);
+  EXPECT_EQ(N0->getNumUnscheduledDeps(), 0u);
   // Restore it: %add0 is now used by %add1.
   Add1->setOperand(0, Add0);
-  EXPECT_EQ(N0->getNumUnscheduledSuccs(), 1u);
+  EXPECT_EQ(N0->getNumUnscheduledDeps(), 1u);
 
   // RUOW
   Add1->replaceUsesOfWith(Add0, Arg0);
-  EXPECT_EQ(N0->getNumUnscheduledSuccs(), 0u);
+  EXPECT_EQ(N0->getNumUnscheduledDeps(), 0u);
   // Restore it: %add0 is now used by %add1.
   Add1->setOperand(0, Add0);
-  EXPECT_EQ(N0->getNumUnscheduledSuccs(), 1u);
+  EXPECT_EQ(N0->getNumUnscheduledDeps(), 1u);
 }
 
 // Setting a Use with a setOperand(), RUW, RAUW etc. can add/remove use-def
@@ -1312,34 +1370,34 @@ define void @foo(i8 %v0, i8 %v1) {
   DAG.extend({Add0, Add1});
   auto *N1 = DAG.getNode(Add1);
 
-  EXPECT_EQ(N1->getNumUnscheduledPreds(), 1u);
+  EXPECT_EQ(N1->getNumUnscheduledDeps(), 1u);
   // Now change %add1 operand to not use %add0.
   Add1->setOperand(0, Arg0);
-  EXPECT_EQ(N1->getNumUnscheduledPreds(), 0u);
+  EXPECT_EQ(N1->getNumUnscheduledDeps(), 0u);
   // Restore it: %add0 is now used by %add1.
   Add1->setOperand(0, Add0);
-  EXPECT_EQ(N1->getNumUnscheduledPreds(), 1u);
+  EXPECT_EQ(N1->getNumUnscheduledDeps(), 1u);
 
   // RAUW
   Add0->replaceAllUsesWith(Arg0);
-  EXPECT_EQ(N1->getNumUnscheduledPreds(), 0u);
+  EXPECT_EQ(N1->getNumUnscheduledDeps(), 0u);
   // Restore it: %add0 is now used by %add1.
   Add1->setOperand(0, Add0);
-  EXPECT_EQ(N1->getNumUnscheduledPreds(), 1u);
+  EXPECT_EQ(N1->getNumUnscheduledDeps(), 1u);
 
   // RUWIf
   Add0->replaceUsesWithIf(Arg0, [](const auto &U) { return true; });
-  EXPECT_EQ(N1->getNumUnscheduledPreds(), 0u);
+  EXPECT_EQ(N1->getNumUnscheduledDeps(), 0u);
   // Restore it: %add0 is now used by %add1.
   Add1->setOperand(0, Add0);
-  EXPECT_EQ(N1->getNumUnscheduledPreds(), 1u);
+  EXPECT_EQ(N1->getNumUnscheduledDeps(), 1u);
 
   // RUOW
   Add1->replaceUsesOfWith(Add0, Arg0);
-  EXPECT_EQ(N1->getNumUnscheduledPreds(), 0u);
+  EXPECT_EQ(N1->getNumUnscheduledDeps(), 0u);
   // Restore it: %add0 is now used by %add1.
   Add1->setOperand(0, Add0);
-  EXPECT_EQ(N1->getNumUnscheduledPreds(), 1u);
+  EXPECT_EQ(N1->getNumUnscheduledDeps(), 1u);
 }
 
 // Make sure we maintain the unscheduled succs when the use-def edges cross the
@@ -1367,20 +1425,20 @@ define void @foo(i8 %v0, i8 %v1) {
   DAG.extend({Add0, Add1});
   auto *Add0N = DAG.getNode(Add0);
   EXPECT_EQ(DAG.getNode(ExtUser), nullptr);
-  EXPECT_EQ(Add0N->getNumUnscheduledSuccs(), 1u);
+  EXPECT_EQ(Add0N->getNumUnscheduledDeps(), 1u);
 
   // Adding the use Add0->ExtUser shouldn't change Add's unscheduled succs.
   ExtUser->setOperand(0, Add0);
-  EXPECT_EQ(Add0N->getNumUnscheduledSuccs(), 1u);
+  EXPECT_EQ(Add0N->getNumUnscheduledDeps(), 1u);
   ExtUser->setOperand(0, Arg0);
-  EXPECT_EQ(Add0N->getNumUnscheduledSuccs(), 1u);
+  EXPECT_EQ(Add0N->getNumUnscheduledDeps(), 1u);
 
   // Same with RUOW.
   ExtUser->replaceUsesOfWith(Arg0, Add0);
   EXPECT_EQ(ExtUser->getOperand(0), Add0);
-  EXPECT_EQ(Add0N->getNumUnscheduledSuccs(), 1u);
+  EXPECT_EQ(Add0N->getNumUnscheduledDeps(), 1u);
   ExtUser->setOperand(0, Arg0);
-  EXPECT_EQ(Add0N->getNumUnscheduledSuccs(), 1u);
+  EXPECT_EQ(Add0N->getNumUnscheduledDeps(), 1u);
 }
 
 // Make sure we don't change the unscheduled preds when the use-def edges cross
@@ -1407,25 +1465,25 @@ define void @foo(i8 %v0, i8 %v1) {
   DAG.extend({Add0});
   auto *Add0N = DAG.getNode(Add0);
   EXPECT_EQ(DAG.getNode(ExtOp), nullptr);
-  EXPECT_EQ(Add0N->getNumUnscheduledPreds(), 0u);
+  EXPECT_EQ(Add0N->getNumUnscheduledDeps(), 0u);
 
   // Adding def-use ExtOp->Add0 shouldn't change Add0's unscheduled preds.
   Add0->setOperand(1, ExtOp);
-  EXPECT_EQ(Add0N->getNumUnscheduledPreds(), 0u);
+  EXPECT_EQ(Add0N->getNumUnscheduledDeps(), 0u);
   Add0->setOperand(0, Arg0);
-  EXPECT_EQ(Add0N->getNumUnscheduledPreds(), 0u);
+  EXPECT_EQ(Add0N->getNumUnscheduledDeps(), 0u);
 
   // Same with RUOW.
   Add0->replaceUsesOfWith(Arg1, ExtOp);
   EXPECT_EQ(Add0->getOperand(1), ExtOp);
-  EXPECT_EQ(Add0N->getNumUnscheduledPreds(), 0u);
+  EXPECT_EQ(Add0N->getNumUnscheduledDeps(), 0u);
   Add0->setOperand(1, Arg1);
-  EXPECT_EQ(Add0N->getNumUnscheduledPreds(), 0u);
+  EXPECT_EQ(Add0N->getNumUnscheduledDeps(), 0u);
 }
 
 // Don't udpate the unscheduled succs and preds if nodes have already been
 // scheduled.
-TEST_F(DependencyGraphTest, MaintainUnscheduledSuccsWhenScheduled) {
+TEST_F(DependencyGraphTest, MaintainUnscheduledDepsWhenScheduledBottomUp) {
   parseIR(C, R"IR(
 define void @foo(i8 %v0) {
   %add0 = add i8 %v0, 0
@@ -1449,47 +1507,85 @@ define void @foo(i8 %v0) {
   auto *Add1N = DAG.getNode(Add1);
   // Mark Add0N and Add1N as scheduled.
 #ifndef NDEBUG
-  EXPECT_TRUE(Add0N->validUnscheduledSuccs());
-  EXPECT_TRUE(Add0N->validUnscheduledPreds());
+  EXPECT_TRUE(Add0N->validUnscheduledDeps());
 #endif
   Add0N->setScheduled();
 #ifndef NDEBUG
-  EXPECT_FALSE(Add0N->validUnscheduledSuccs());
-  EXPECT_DEATH(Add0N->getNumUnscheduledSuccs(), ".*");
-  EXPECT_FALSE(Add0N->validUnscheduledPreds());
-  EXPECT_DEATH(Add0N->getNumUnscheduledPreds(), ".*");
+  EXPECT_FALSE(Add0N->validUnscheduledDeps());
+  EXPECT_DEATH(Add0N->getNumUnscheduledDeps(), ".*");
 #endif
 
 #ifndef NDEBUG
-  EXPECT_TRUE(Add1N->validUnscheduledSuccs());
-  EXPECT_TRUE(Add1N->validUnscheduledPreds());
+  EXPECT_TRUE(Add1N->validUnscheduledDeps());
 #endif
   Add1N->setScheduled();
 #ifndef NDEBUG
-  EXPECT_FALSE(Add1N->validUnscheduledSuccs());
-  EXPECT_DEATH(Add1N->getNumUnscheduledSuccs(), ".*");
-  EXPECT_FALSE(Add1N->validUnscheduledPreds());
-  EXPECT_DEATH(Add1N->getNumUnscheduledPreds(), ".*");
+  EXPECT_FALSE(Add1N->validUnscheduledDeps());
+  EXPECT_DEATH(Add1N->getNumUnscheduledDeps(), ".*");
 #endif
 
   // Change Modify's operand and make sure we won't update Add0N's or Add1N's
   // unscheduled succs.
   Modify->setOperand(0, Add1);
 #ifndef NDEBUG
-  EXPECT_FALSE(Add0N->validUnscheduledSuccs());
-  EXPECT_DEATH(Add0N->getNumUnscheduledSuccs(), ".*");
-  EXPECT_FALSE(Add1N->validUnscheduledSuccs());
-  EXPECT_DEATH(Add1N->getNumUnscheduledSuccs(), ".*");
+  EXPECT_FALSE(Add0N->validUnscheduledDeps());
+  EXPECT_DEATH(Add0N->getNumUnscheduledDeps(), ".*");
+  EXPECT_FALSE(Add1N->validUnscheduledDeps());
+  EXPECT_DEATH(Add1N->getNumUnscheduledDeps(), ".*");
+#endif
+}
+
+// Don't udpate the unscheduled succs and preds if nodes have already been
+// scheduled.
+TEST_F(DependencyGraphTest, MaintainUnscheduledSuccsWhenScheduled) {
+  parseIR(C, R"IR(
+define void @foo(i8 %v0) {
+  %add0 = add i8 %v0, 0
+  %add1 = add i8 %v0, 1
+  %modify = add i8 %add0, 1
+  ret void
+}
+)IR");
+  llvm::Function *LLVMF = &*M->getFunction("foo");
+  sandboxir::Context Ctx(C);
+  auto *F = Ctx.createFunction(LLVMF);
+  auto *BB = &*F->begin();
+  auto It = BB->begin();
+  auto *Add0 = cast<sandboxir::BinaryOperator>(&*It++);
+  auto *Add1 = cast<sandboxir::BinaryOperator>(&*It++);
+  auto *Modify = cast<sandboxir::BinaryOperator>(&*It++);
+  // DAG contains all Add0, Add1 and Modify
+  sandboxir::DependencyGraph DAG(TopDown, getAA(*LLVMF), Ctx);
+  DAG.extend({Add0, Add1, Modify});
+  auto *Add0N = DAG.getNode(Add0);
+  auto *Add1N = DAG.getNode(Add1);
+  // Mark Add0N and Add1N as scheduled.
+#ifndef NDEBUG
+  EXPECT_TRUE(Add0N->validUnscheduledDeps());
+#endif
+  Add0N->setScheduled();
+#ifndef NDEBUG
+  EXPECT_FALSE(Add0N->validUnscheduledDeps());
+  EXPECT_DEATH(Add0N->getNumUnscheduledDeps(), ".*");
+#endif
+
+#ifndef NDEBUG
+  EXPECT_TRUE(Add1N->validUnscheduledDeps());
+#endif
+  Add1N->setScheduled();
+#ifndef NDEBUG
+  EXPECT_FALSE(Add1N->validUnscheduledDeps());
+  EXPECT_DEATH(Add1N->getNumUnscheduledDeps(), ".*");
 #endif
 
   // Create a def-use edge Add0->Add1 and make sure Add0N's and Add1N's
   // unscheduled preds are still invalid.
   Add1->setOperand(1, Add0);
 #ifndef NDEBUG
-  EXPECT_FALSE(Add0N->validUnscheduledPreds());
-  EXPECT_DEATH(Add0N->getNumUnscheduledPreds(), ".*");
-  EXPECT_FALSE(Add1N->validUnscheduledPreds());
-  EXPECT_DEATH(Add1N->getNumUnscheduledPreds(), ".*");
+  EXPECT_FALSE(Add0N->validUnscheduledDeps());
+  EXPECT_DEATH(Add0N->getNumUnscheduledDeps(), ".*");
+  EXPECT_FALSE(Add1N->validUnscheduledDeps());
+  EXPECT_DEATH(Add1N->getNumUnscheduledDeps(), ".*");
 #endif
 }
 
@@ -1517,18 +1613,18 @@ define void @foo(i8 %v0) {
   auto *Add0N = DAG.getNode(Add0);
   auto *Add1N = DAG.getNode(Add1);
   auto *ModifyN = DAG.getNode(Modify);
-  EXPECT_EQ(Add0N->getNumUnscheduledSuccs(), 1u);
+  EXPECT_EQ(Add0N->getNumUnscheduledDeps(), 1u);
   // Mark Modify as scheduled and decrement Add1N's unscheduled succs.
   ModifyN->setScheduled();
-  Add0N->decrUnscheduledSuccs();
-  EXPECT_EQ(Add0N->getNumUnscheduledSuccs(), 0u);
-  EXPECT_EQ(Add1N->getNumUnscheduledSuccs(), 0u);
+  Add0N->decrUnscheduledDeps();
+  EXPECT_EQ(Add0N->getNumUnscheduledDeps(), 0u);
+  EXPECT_EQ(Add1N->getNumUnscheduledDeps(), 0u);
 
   // Change Modify's operand and make sure that this won't update Add0N's or
   // Add1N's unscheduled succs because ModifyN is "scheduled".
   Modify->setOperand(0, Add1);
-  EXPECT_EQ(Add0N->getNumUnscheduledSuccs(), 0u);
-  EXPECT_EQ(Add1N->getNumUnscheduledSuccs(), 0u);
+  EXPECT_EQ(Add0N->getNumUnscheduledDeps(), 0u);
+  EXPECT_EQ(Add1N->getNumUnscheduledDeps(), 0u);
 }
 
 // Don't udpate the unscheduled preds if the operand is scheduled.
@@ -1547,18 +1643,18 @@ define void @foo(i8 %v0) {
   auto It = BB->begin();
   auto *Sched = cast<sandboxir::BinaryOperator>(&*It++);
   auto *Add0 = cast<sandboxir::BinaryOperator>(&*It++);
-  sandboxir::DependencyGraph DAG(BottomUp, getAA(*LLVMF), Ctx);
+  sandboxir::DependencyGraph DAG(TopDown, getAA(*LLVMF), Ctx);
   DAG.extend({Sched, Add0});
   auto *SchedN = DAG.getNode(Sched);
   auto *Add0N = DAG.getNode(Add0);
-  EXPECT_EQ(Add0N->getNumUnscheduledPreds(), 0u);
+  EXPECT_EQ(Add0N->getNumUnscheduledDeps(), 0u);
   // Mark SchedN as scheduled
   SchedN->setScheduled();
 
   // Change Add0's operand and make sure that this won't update Add0N's
   // unscheduled preds because SchedN is "scheduled".
   Add0->setOperand(0, Sched);
-  EXPECT_EQ(Add0N->getNumUnscheduledPreds(), 0u);
+  EXPECT_EQ(Add0N->getNumUnscheduledDeps(), 0u);
 }
 
 // When erasing a non-mem instruction we must not touch the UnscheduledSuccs
@@ -1586,8 +1682,8 @@ define void @foo(i8 %v0) {
   DAG.extend({PredSched, N});
   auto *PredSchedN = DAG.getNode(PredSched);
   auto *PredUnschedN = DAG.getNode(PredUnsched);
-  EXPECT_EQ(PredSchedN->getNumUnscheduledSuccs(), 1u);
-  EXPECT_EQ(PredUnschedN->getNumUnscheduledSuccs(), 1u);
+  EXPECT_EQ(PredSchedN->getNumUnscheduledDeps(), 1u);
+  EXPECT_EQ(PredUnschedN->getNumUnscheduledDeps(), 1u);
 
   // Mark one of N's predecessors as scheduled. Its UnscheduledSuccs becomes
   // std::nullopt.
@@ -1598,8 +1694,8 @@ define void @foo(i8 %v0) {
   // update the counter of the unscheduled predecessor.
   N->eraseFromParent();
   EXPECT_EQ(DAG.getNode(N), nullptr);
-  EXPECT_EQ(PredUnschedN->getNumUnscheduledSuccs(), 0u);
+  EXPECT_EQ(PredUnschedN->getNumUnscheduledDeps(), 0u);
 #ifndef NDEBUG
-  EXPECT_FALSE(PredSchedN->validUnscheduledSuccs());
+  EXPECT_FALSE(PredSchedN->validUnscheduledDeps());
 #endif
 }

--- a/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/SchedulerTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/SchedulerTest.cpp
@@ -892,8 +892,7 @@ define void @foo(ptr noalias %ptr, ptr noalias %ptr1, ptr noalias %ptr2) {
   auto &DAG = sandboxir::SchedulerInternalsAttorney::getDAG(Sched);
   DAG.extend({L0});
   auto *L0N = DAG.getNode(L0);
-  EXPECT_EQ(L0N->getNumUnscheduledSuccs(), 0u);
-  EXPECT_EQ(L0N->getNumUnscheduledPreds(), 0u);
+  EXPECT_EQ(L0N->getNumUnscheduledDeps(), 0u);
   // We should have DAG nodes for all instructions at this point
 
   // Now create a new instruction below S0.
@@ -904,12 +903,11 @@ define void @foo(ptr noalias %ptr, ptr noalias %ptr1, ptr noalias %ptr2) {
   auto *NewS1N = DAG.getNode(NewS1);
   EXPECT_TRUE(NewS1N->scheduled());
 #ifndef NDEBUG
-  // NewS1N is scheduled so unscheduled preds/succs are irrelevant.
-  EXPECT_FALSE(NewS1N->validUnscheduledPreds());
-  EXPECT_FALSE(NewS1N->validUnscheduledSuccs());
+  // NewS1N is scheduled so unscheduled deps are irrelevant.
+  EXPECT_FALSE(NewS1N->validUnscheduledDeps());
 #endif
-  // Check that L0's UnscheduledSuccs are still == 0 since NewS1 is "scheduled".
-  EXPECT_EQ(L0N->getNumUnscheduledSuccs(), 0u);
+  // Check that L0's UnscheduledDeps are still == 0 since NewS1 is "scheduled".
+  EXPECT_EQ(L0N->getNumUnscheduledDeps(), 0u);
 
   // Now create a new instruction above S0.
   sandboxir::StoreInst *NewS2 =
@@ -919,8 +917,7 @@ define void @foo(ptr noalias %ptr, ptr noalias %ptr1, ptr noalias %ptr2) {
   auto *NewS2N = DAG.getNode(NewS2);
   EXPECT_FALSE(NewS2N->scheduled());
   // Check that L0's UnscheduledSuccs got updated because of NewS2.
-  EXPECT_EQ(L0N->getNumUnscheduledSuccs(), 1u);
-  EXPECT_EQ(NewS2N->getNumUnscheduledPreds(), 0u);
+  EXPECT_EQ(L0N->getNumUnscheduledDeps(), 1u);
 
   sandboxir::ReadyListContainer ReadyList;
   // Check empty().


### PR DESCRIPTION
This is a cleanup patch that replaces the two DAG node unscheduled dependency counters (that is UnscheduledSuccs and UnscheduledPreds) with a single one named UnscheduledDeps.

The reasoning is that scheduling operates on one direction at a time so if we are scheduling bottom-up then we only need the unscheduled successors, and if we schedule top-down then we only need the unscheduled predecessors.