### PR TITLE
[X86][GlobalISel] Map a store of an FP-banked load to the FP bank

### DIFF
--- a/llvm/lib/Target/X86/GISel/X86RegisterBankInfo.cpp
+++ b/llvm/lib/Target/X86/GISel/X86RegisterBankInfo.cpp
@@ -385,6 +385,13 @@ X86RegisterBankInfo::getInstrMapping(const MachineInstr &MI) const {
       break;
     MachineInstr *DefMI = MRI.getVRegDef(VReg);
     bool IsFP = onlyDefinesFP(*DefMI, MRI, TRI);
+    // A load goes to the FP bank as soon as one of its users only uses FP, see
+    // the G_LOAD case above.
+    if (!IsFP && DefMI->getOpcode() == TargetOpcode::G_LOAD)
+      IsFP = any_of(MRI.use_nodbg_instructions(VReg),
+                    [&](const MachineInstr &UseMI) {
+                      return onlyUsesFP(UseMI, MRI, TRI);
+                    });
     getInstrPartialMappingIdxs(MI, MRI, IsFP, OpRegBankIdx);
     break;
   }

--- a/llvm/test/CodeGen/X86/GlobalISel/x87-store-of-fp-load.ll
+++ b/llvm/test/CodeGen/X86/GlobalISel/x87-store-of-fp-load.ll
@@ -1,8 +1,36 @@
 ; RUN: llc < %s -mtriple=x86_64-- -mattr=+x87,-sse,-sse2 -global-isel -global-isel-abort=1 | FileCheck %s --check-prefix=X64
 ; RUN: llc < %s -mtriple=i686-- -mattr=+x87,-sse,-sse2 -global-isel -global-isel-abort=1 | FileCheck %s --check-prefix=X86
 
-; fails with: llc: llvm-project/llvm/lib/Target/X86/X86FloatingPoint.cpp:326: unsigned int getFPReg(const MachineOperand &): Assertion `Reg >= X86::FP0 && Reg <= X86::FP6 && "Expected FP register!"' failed.
 define i32 @store_and_fcmp_f32(ptr %p, ptr %q) nounwind {
+; X64-LABEL: store_and_fcmp_f32:
+; X64:       # %bb.0:
+; X64-NEXT:    fldz
+; X64-NEXT:    flds (%rdi)
+; X64-NEXT:    fsts (%rsi)
+; X64-NEXT:    fucompi %st(1), %st
+; X64-NEXT:    fstp %st(0)
+; X64-NEXT:    sete %al
+; X64-NEXT:    setnp %cl
+; X64-NEXT:    andb %al, %cl
+; X64-NEXT:    movzbl %cl, %eax
+; X64-NEXT:    andl $1, %eax
+; X64-NEXT:    retq
+;
+; X86-LABEL: store_and_fcmp_f32:
+; X86:       # %bb.0:
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X86-NEXT:    fldz
+; X86-NEXT:    flds (%eax)
+; X86-NEXT:    fsts (%ecx)
+; X86-NEXT:    fucompi %st(1), %st
+; X86-NEXT:    fstp %st(0)
+; X86-NEXT:    sete %al
+; X86-NEXT:    setnp %cl
+; X86-NEXT:    andb %al, %cl
+; X86-NEXT:    movzbl %cl, %eax
+; X86-NEXT:    andl $1, %eax
+; X86-NEXT:    retl
   %v = load float, ptr %p
   store float %v, ptr %q
   %c = fcmp oeq float %v, 0.0

--- a/llvm/test/CodeGen/X86/GlobalISel/x87-store-of-fp-load.ll
+++ b/llvm/test/CodeGen/X86/GlobalISel/x87-store-of-fp-load.ll
@@ -1,0 +1,11 @@
+; RUN: llc < %s -mtriple=x86_64-- -mattr=+x87,-sse,-sse2 -global-isel -global-isel-abort=1 | FileCheck %s --check-prefix=X64
+; RUN: llc < %s -mtriple=i686-- -mattr=+x87,-sse,-sse2 -global-isel -global-isel-abort=1 | FileCheck %s --check-prefix=X86
+
+; fails with: llc: llvm-project/llvm/lib/Target/X86/X86FloatingPoint.cpp:326: unsigned int getFPReg(const MachineOperand &): Assertion `Reg >= X86::FP0 && Reg <= X86::FP6 && "Expected FP register!"' failed.
+define i32 @store_and_fcmp_f32(ptr %p, ptr %q) nounwind {
+  %v = load float, ptr %p
+  store float %v, ptr %q
+  %c = fcmp oeq float %v, 0.0
+  %r = zext i1 %c to i32
+  ret i32 %r
+}


### PR DESCRIPTION
`G_LOAD` and `G_STORE` didn't agree when to select the FP regbank, which inserted a PSR -> GPR copy, hitting a "FP register expected" assertion.

Apply the load's rule in the store case as well so the two agree.

Co-authored-by: Claude (Claude-Opus-5) <noreply@anthropic.com>