### PR TITLE
[ExtractAPI] Skip parsing function bodies

### DIFF
--- a/clang/lib/ExtractAPI/ExtractAPIConsumer.cpp
+++ b/clang/lib/ExtractAPI/ExtractAPIConsumer.cpp
@@ -448,6 +448,9 @@ ExtractAPIAction::CreateASTConsumer(CompilerInstance &CI, StringRef InFile) {
 }
 
 bool ExtractAPIAction::PrepareToExecuteAction(CompilerInstance &CI) {
+  // Public API can never be inside function bodies, so skip parsing them.
+  CI.getFrontendOpts().SkipFunctionBodies = true;
+
   auto &Inputs = CI.getFrontendOpts().Inputs;
   if (Inputs.empty())
     return true;


### PR DESCRIPTION
Public API can never be defined in function bodies, since that would make the type function-local only. The symbol graph must not contain any such symbols as they cannot be used by a downstream consumer. Skip parsing function bodies in ExtractAPI. This also addresses cases where inlinable functions sometimes had their local types erroneously included in the symbol graph due to the definition being retained in the PCM file.

rdar://181241162