### PR TITLE
[DAGCombiner] Don't create illegal types in visitSRL

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -11880,12 +11880,14 @@ SDValue DAGCombiner::visitSRL(SDNode *N) {
         SDValue LastElt = BV.getOperand(NumElts - 1);
         assert(LastElt.getScalarValueSizeInBits() >= EltSizeInBits &&
                "Expected BUILD_VECTOR operand as wide as element type");
-        LastElt = DAG.getBitcast(LastElt.getValueType().changeTypeToInteger(),
-                                 LastElt);
-        SDValue Ext = DAG.getZExtOrTrunc(LastElt, DL, VT);
-        APInt Mask = APInt::getLowBitsSet(VT.getSizeInBits(), EltSizeInBits);
-        return DAG.getNode(ISD::AND, DL, VT, Ext,
-                           DAG.getConstant(Mask, DL, VT));
+        EVT IntEltVT = LastElt.getValueType().changeTypeToInteger();
+        if (!LegalTypes || TLI.isTypeLegal(IntEltVT)) {
+          LastElt = DAG.getBitcast(IntEltVT, LastElt);
+          SDValue Ext = DAG.getZExtOrTrunc(LastElt, DL, VT);
+          APInt Mask = APInt::getLowBitsSet(VT.getSizeInBits(), EltSizeInBits);
+          return DAG.getNode(ISD::AND, DL, VT, Ext,
+                             DAG.getConstant(Mask, DL, VT));
+        }
       }
     }
   }


### PR DESCRIPTION
Besides what's fixed in #205074, the srl(bitcast(build_vector)) fold added in #181412 has another way to create an illegal type: the bitcast to LastElt.getValueType().changeTypeToInteger() is itself illegal when, for example, LastElt is f16 and i16 is not a legal type.

Unfortunately, this happens in a downstream target so no testcase.