### PR TITLE
[ExtractAPI] Deterministically emit macros

### DIFF
--- a/clang/lib/ExtractAPI/ExtractAPIConsumer.cpp
+++ b/clang/lib/ExtractAPI/ExtractAPIConsumer.cpp
@@ -287,8 +287,15 @@ public:
       : Ctx(Ctx), SM(SM), API(API), PP(PP) {}
 
   void EndOfMainFile() override {
-    for (const auto &M : PP.macros()) {
-      auto *II = M.getFirst();
+    SmallVector<const IdentifierInfo *> Macros;
+    for (const auto &M : PP.macros())
+      Macros.push_back(M.getFirst());
+    llvm::sort(Macros,
+               [](const IdentifierInfo *LHS, const IdentifierInfo *RHS) {
+                 return LHS->getName() < RHS->getName();
+               });
+
+    for (const auto *II : Macros) {
       auto MD = PP.getMacroDefinition(II);
       auto *MI = MD.getMacroInfo();
 

--- a/clang/test/ExtractAPI/macros.c
+++ b/clang/test/ExtractAPI/macros.c
@@ -354,5 +354,13 @@
 // FUNGNU-NEXT:   "FUNGNU"
 // FUNGNU-NEXT: ]
 
+// RUN: FileCheck %s --input-file %t/output.symbols.json --check-prefix ORDER
+// ORDER: "!testLabel": "c:@macro@FUN"
+// ORDER: "!testLabel": "c:@macro@FUNC99"
+// ORDER: "!testLabel": "c:@macro@FUNGNU"
+// ORDER: "!testLabel": "c:@macro@HELLO"
+// ORDER: "!testLabel": "c:@macro@MACRO_FUN"
+// ORDER: "!testLabel": "c:@macro@WORLD"
+
 // expected-no-diagnostics
 


### PR DESCRIPTION
Macros are processed by iterating over the preprocessor's stored `DenseMap`, which is pointer-keyed with `IdentifierInfo`. This map is not ordered, leading to the contents of the symbol graph changing across runs with identical inputs. Sort macros lexicographically by name to ensure consistent output.

rdar://184545768