### PR TITLE
libcxx: enable tests against wasi-libc

### DIFF
--- a/.github/workflows/libcxx-pr-conformance-tests.yaml
+++ b/.github/workflows/libcxx-pr-conformance-tests.yaml
@@ -165,7 +165,9 @@ jobs:
           'generic-tsan',
           'generic-ubsan',
           'generic-msan',
-          'bootstrapping-build'
+          'bootstrapping-build',
+          'wasm32-wasip1',
+          'wasm32-wasip1-no-exceptions'
         ]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/libcxx/cmake/caches/WASI.cmake
+++ b/libcxx/cmake/caches/WASI.cmake
@@ -1,0 +1,53 @@
+set(CMAKE_ASM_COMPILER_TARGET "wasm32-wasip1" CACHE STRING "")
+set(CMAKE_CXX_COMPILER_TARGET "wasm32-wasip1" CACHE STRING "")
+set(CMAKE_C_COMPILER_TARGET "wasm32-wasip1" CACHE STRING "")
+set(CMAKE_SYSTEM_NAME Generic CACHE STRING "")
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY CACHE STRING "")
+
+set(COMPILER_RT_BAREMETAL_BUILD ON CACHE BOOL "")
+set(COMPILER_RT_BUILD_LIBFUZZER OFF CACHE BOOL "")
+set(COMPILER_RT_BUILD_PROFILE OFF CACHE BOOL "")
+set(COMPILER_RT_BUILD_SANITIZERS OFF CACHE BOOL "")
+set(COMPILER_RT_BUILD_XRAY OFF CACHE BOOL "")
+set(COMPILER_RT_DEFAULT_TARGET_ONLY ON CACHE BOOL "")
+
+set(LIBCXX_ENABLE_EXCEPTIONS ON CACHE BOOL "")
+set(LIBCXX_ENABLE_FILESYSTEM OFF CACHE BOOL "")
+# The locale base API has no WASI backend, so it falls back to the IBM one.
+set(LIBCXX_ENABLE_LOCALIZATION OFF CACHE BOOL "")
+set(LIBCXX_ENABLE_MONOTONIC_CLOCK ON CACHE BOOL "")
+set(LIBCXX_ENABLE_RTTI ON CACHE BOOL "")
+set(LIBCXX_ENABLE_SHARED OFF CACHE BOOL "")
+set(LIBCXX_ENABLE_STATIC ON CACHE BOOL "")
+set(LIBCXX_ENABLE_THREADS OFF CACHE BOOL "")
+set(LIBCXX_INCLUDE_BENCHMARKS OFF CACHE BOOL "")
+# Long tests are prohibitively slow when run under a WebAssembly interpreter.
+set(LIBCXX_TEST_PARAMS "long_tests=False" CACHE STRING "")
+set(LIBCXX_USE_COMPILER_RT ON CACHE BOOL "")
+
+set(LIBCXXABI_BAREMETAL ON CACHE BOOL "")
+set(LIBCXXABI_ENABLE_EXCEPTIONS ON CACHE BOOL "")
+set(LIBCXXABI_ENABLE_SHARED OFF CACHE BOOL "")
+set(LIBCXXABI_ENABLE_STATIC ON CACHE BOOL "")
+set(LIBCXXABI_ENABLE_STATIC_UNWINDER ON CACHE BOOL "")
+set(LIBCXXABI_ENABLE_THREADS OFF CACHE BOOL "")
+set(LIBCXXABI_USE_COMPILER_RT ON CACHE BOOL "")
+set(LIBCXXABI_USE_LLVM_UNWINDER ON CACHE BOOL "")
+
+set(LIBUNWIND_ENABLE_SHARED OFF CACHE BOOL "")
+set(LIBUNWIND_ENABLE_STATIC ON CACHE BOOL "")
+set(LIBUNWIND_ENABLE_THREADS OFF CACHE BOOL "")
+set(LIBUNWIND_USE_COMPILER_RT ON CACHE BOOL "")
+
+find_program(WASI_RUNTIME wasmkit REQUIRED)
+
+# On embedded platforms that don't support shared library targets, CMake implicitly changes shared
+# library targets to be static library targets. This results in duplicate definitions of the static
+# library targets even though we might not ever build the shared library target, which breaks the
+# build. To work around this, we change the output name of the  shared library target so that it
+# can't conflict with the static library target.
+#
+# This is tracked by https://gitlab.kitware.com/cmake/cmake/-/issues/25759.
+set(LIBCXX_SHARED_OUTPUT_NAME "c++-shared" CACHE STRING "")
+set(LIBCXXABI_SHARED_OUTPUT_NAME "c++abi-shared" CACHE STRING "")
+set(LIBUNWIND_SHARED_OUTPUT_NAME "unwind-shared" CACHE STRING "")

--- a/libcxx/test/configs/wasm32-wasip1-libc++.cfg.in
+++ b/libcxx/test/configs/wasm32-wasip1-libc++.cfg.in
@@ -1,0 +1,39 @@
+config.substitutions.append(('%{flags}', '--sysroot=@CMAKE_INSTALL_PREFIX@ @WASI_EH_FLAGS@'))
+
+config.substitutions.append(('%{compile_flags}',
+    '-nostdinc++ -I %{include-dir} -I %{target-include-dir} -I %{libcxx-dir}/test/support'
+
+    # wasi-libc gates signals, process clocks and setjmp/longjmp behind these, and
+    # the runtime implements only the standardized exception handling encoding.
+    ' -D_WASI_EMULATED_SIGNAL -D_WASI_EMULATED_PROCESS_CLOCKS'
+    ' -mllvm -wasm-enable-sjlj -mllvm -wasm-use-legacy-eh=false'
+))
+config.substitutions.append(('%{link_flags}',
+    # wasi-libc keeps long double formatting out of libc to save size, so the
+    # archive providing it has to override libc's stubs.
+    '-nodefaultlibs -L %{lib-dir} -lc++ -lc++abi -lc-printscan-long-double'
+    ' -lc -lwasi-emulated-signal -lwasi-emulated-process-clocks -lsetjmp'
+    ' -lclang_rt.builtins'
+
+    # wasm-ld defaults the stack to 64 KiB, far below what tests holding large
+    # objects on it need. Match the 8 MiB a hosted main thread gets.
+    ' -Wl,-z,stack-size=0x800000'
+))
+
+config.executor = (
+    '@LIBCXX_SOURCE_DIR@/utils/wasm.py'
+    ' --runtime @WASI_RUNTIME@')
+config.substitutions.append(('%{exec}',
+    '%{executor}'
+    ' --execdir %{temp}'
+))
+
+import os, site
+site.addsitedir(os.path.join('@LIBCXX_SOURCE_DIR@', 'utils'))
+import libcxx.test.params, libcxx.test.config
+libcxx.test.config.configure(
+    libcxx.test.params.DEFAULT_PARAMETERS,
+    libcxx.test.features.DEFAULT_FEATURES,
+    config,
+    lit_config
+)

--- a/libcxx/test/extensions/clang/clang_modules_include.gen.py
+++ b/libcxx/test/extensions/clang/clang_modules_include.gen.py
@@ -30,6 +30,9 @@
 # TODO: Investigate why this doesn't work on Picolibc once the locale base API is refactored
 # UNSUPPORTED: LIBCXX-PICOLIBC-FIXME
 
+# TODO: Fix the <wchar.h> redefinitions on WASI
+# UNSUPPORTED: LIBCXX-WASI-FIXME
+
 # TODO: Fix seemingly circular inclusion or <wchar.h> on AIX
 # UNSUPPORTED: LIBCXX-AIX-FIXME
 

--- a/libcxx/test/libcxx/assertions/default_verbose_abort.pass.cpp
+++ b/libcxx/test/libcxx/assertions/default_verbose_abort.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// The test needs a SIGABRT handler to run, which WASI does not deliver.
+// XFAIL: LIBCXX-WASI-FIXME
+
 // Test that the default verbose termination function aborts the program.
 // XFAIL: availability-verbose_abort-missing
 

--- a/libcxx/test/libcxx/containers/associative/map/at.abort.pass.cpp
+++ b/libcxx/test/libcxx/containers/associative/map/at.abort.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// The test needs a SIGABRT handler to run, which WASI does not deliver.
+// XFAIL: LIBCXX-WASI-FIXME
+
 // <map>
 
 // class map

--- a/libcxx/test/libcxx/containers/associative/map/at.const.abort.pass.cpp
+++ b/libcxx/test/libcxx/containers/associative/map/at.const.abort.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// The test needs a SIGABRT handler to run, which WASI does not deliver.
+// XFAIL: LIBCXX-WASI-FIXME
+
 // <map>
 
 // class map

--- a/libcxx/test/libcxx/containers/unord/unord.map/at.abort.pass.cpp
+++ b/libcxx/test/libcxx/containers/unord/unord.map/at.abort.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// The test needs a SIGABRT handler to run, which WASI does not deliver.
+// XFAIL: LIBCXX-WASI-FIXME
+
 // <unordered_map>
 
 // class unordered_map

--- a/libcxx/test/libcxx/containers/unord/unord.map/at.const.abort.pass.cpp
+++ b/libcxx/test/libcxx/containers/unord/unord.map/at.const.abort.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// The test needs a SIGABRT handler to run, which WASI does not deliver.
+// XFAIL: LIBCXX-WASI-FIXME
+
 // <unordered_map>
 
 // class unordered_map

--- a/libcxx/test/libcxx/memory/trivial_abi/weak_ptr_ret.pass.cpp
+++ b/libcxx/test/libcxx/memory/trivial_abi/weak_ptr_ret.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// On wasm, structs are returned through a pointer to the caller's storage.
+// XFAIL: LIBCXX-WASI-FIXME
+
 // <memory>
 
 // Test weak_ptr<T> with trivial_abi as return-type.

--- a/libcxx/test/libcxx/strings/basic.string/string.capacity/max_size.pass.cpp
+++ b/libcxx/test/libcxx/strings/basic.string/string.capacity/max_size.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// The test has no expected max_size for wasm.
+// UNSUPPORTED: LIBCXX-WASI-FIXME
+
 // <string>
 
 // This test ensures that the correct max_size() is returned depending on the platform.

--- a/libcxx/test/std/containers/container.adaptors/container.adaptors.format/format.functions.format.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/container.adaptors.format/format.functions.format.pass.cpp
@@ -6,6 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// wasi-libc does not provide mkstemp, which the test support header uses to
+// create temporary files.
+// UNSUPPORTED: LIBCXX-WASI-FIXME
+
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME

--- a/libcxx/test/std/containers/container.adaptors/container.adaptors.format/format.functions.vformat.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/container.adaptors.format/format.functions.vformat.pass.cpp
@@ -6,6 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// wasi-libc does not provide mkstemp, which the test support header uses to
+// create temporary files.
+// UNSUPPORTED: LIBCXX-WASI-FIXME
+
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME

--- a/libcxx/test/std/depr/depr.c.headers/fenv_h.compile.pass.cpp
+++ b/libcxx/test/std/depr/depr.c.headers/fenv_h.compile.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// wasi-libc does not define the floating point environment macros.
+// UNSUPPORTED: LIBCXX-WASI-FIXME
+
 // Picolibc does not define some of the floating point environment macros for
 // arm platforms without hardware floating point support.
 // UNSUPPORTED: LIBCXX-PICOLIBC-FIXME

--- a/libcxx/test/std/depr/depr.c.headers/stdint_h.pass.cpp
+++ b/libcxx/test/std/depr/depr.c.headers/stdint_h.pass.cpp
@@ -6,6 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// wasi-libc defines WINT_MIN and WINT_MAX as unsigned, while the compiler
+// makes wint_t signed for wasm.
+// XFAIL: LIBCXX-WASI-FIXME
+
 // test <stdint.h>
 
 #include <stdint.h>

--- a/libcxx/test/std/depr/depr.c.headers/stdio_h.compile.pass.cpp
+++ b/libcxx/test/std/depr/depr.c.headers/stdio_h.compile.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// wasi-libc does not define L_tmpnam or TMP_MAX, and has no tmpfile.
+// UNSUPPORTED: LIBCXX-WASI-FIXME
+
 // Missing some functions/macros.
 // XFAIL: LLVM-LIBC-FIXME
 

--- a/libcxx/test/std/diagnostics/syserr/syserr.errcat/syserr.errcat.objects/generic_category.pass.cpp
+++ b/libcxx/test/std/diagnostics/syserr/syserr.errcat/syserr.errcat.objects/generic_category.pass.cpp
@@ -6,6 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// wasi-libc's strerror returns a message for unknown errors that this test
+// does not accept.
+// XFAIL: LIBCXX-WASI-FIXME
+
 // <system_error>
 
 // class error_category

--- a/libcxx/test/std/diagnostics/syserr/syserr.errcat/syserr.errcat.objects/system_category.pass.cpp
+++ b/libcxx/test/std/diagnostics/syserr/syserr.errcat/syserr.errcat.objects/system_category.pass.cpp
@@ -6,6 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// wasi-libc's strerror returns a message for unknown errors that this test
+// does not accept.
+// XFAIL: LIBCXX-WASI-FIXME
+
 // Investigate why we get an assertion failure with LLVM libc.
 // XFAIL: LLVM-LIBC-FIXME
 

--- a/libcxx/test/std/language.support/cstdint/cstdint.syn/cstdint.pass.cpp
+++ b/libcxx/test/std/language.support/cstdint/cstdint.syn/cstdint.pass.cpp
@@ -6,6 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// wasi-libc defines WINT_MIN and WINT_MAX as unsigned, while the compiler
+// makes wint_t signed for wasm.
+// XFAIL: LIBCXX-WASI-FIXME
+
 // test <cstdint>
 
 #include <cstdint>

--- a/libcxx/test/std/numerics/cfenv/cfenv.syn/cfenv.pass.cpp
+++ b/libcxx/test/std/numerics/cfenv/cfenv.syn/cfenv.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// wasi-libc does not define the floating point environment macros.
+// UNSUPPORTED: LIBCXX-WASI-FIXME
+
 // Picolibc does not define some of the floating point environment macros for
 // arm platforms without hardware floating point support.
 // UNSUPPORTED: LIBCXX-PICOLIBC-FIXME

--- a/libcxx/test/std/utilities/format/format.range/format.range.fmtmap/format.functions.format.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.range/format.range.fmtmap/format.functions.format.pass.cpp
@@ -6,6 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// wasi-libc does not provide mkstemp, which the test support header uses to
+// create temporary files.
+// UNSUPPORTED: LIBCXX-WASI-FIXME
+
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME

--- a/libcxx/test/std/utilities/format/format.range/format.range.fmtmap/format.functions.vformat.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.range/format.range.fmtmap/format.functions.vformat.pass.cpp
@@ -6,6 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// wasi-libc does not provide mkstemp, which the test support header uses to
+// create temporary files.
+// UNSUPPORTED: LIBCXX-WASI-FIXME
+
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME

--- a/libcxx/test/std/utilities/format/format.range/format.range.fmtset/format.functions.format.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.range/format.range.fmtset/format.functions.format.pass.cpp
@@ -6,6 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// wasi-libc does not provide mkstemp, which the test support header uses to
+// create temporary files.
+// UNSUPPORTED: LIBCXX-WASI-FIXME
+
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME

--- a/libcxx/test/std/utilities/format/format.range/format.range.fmtset/format.functions.vformat.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.range/format.range.fmtset/format.functions.vformat.pass.cpp
@@ -6,6 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// wasi-libc does not provide mkstemp, which the test support header uses to
+// create temporary files.
+// UNSUPPORTED: LIBCXX-WASI-FIXME
+
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME

--- a/libcxx/test/std/utilities/format/format.range/format.range.fmtstr/format.functions.format.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.range/format.range.fmtstr/format.functions.format.pass.cpp
@@ -6,6 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// wasi-libc does not provide mkstemp, which the test support header uses to
+// create temporary files.
+// UNSUPPORTED: LIBCXX-WASI-FIXME
+
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME

--- a/libcxx/test/std/utilities/format/format.range/format.range.fmtstr/format.functions.vformat.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.range/format.range.fmtstr/format.functions.vformat.pass.cpp
@@ -6,6 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// wasi-libc does not provide mkstemp, which the test support header uses to
+// create temporary files.
+// UNSUPPORTED: LIBCXX-WASI-FIXME
+
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME

--- a/libcxx/test/std/utilities/format/format.range/format.range.fmtstr/format.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.range/format.range.fmtstr/format.pass.cpp
@@ -6,6 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// wasi-libc does not provide mkstemp, which the test support header uses to
+// create temporary files.
+// UNSUPPORTED: LIBCXX-WASI-FIXME
+
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
 // <format>

--- a/libcxx/test/std/utilities/format/format.range/format.range.fmtstr/parse.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.range/format.range.fmtstr/parse.pass.cpp
@@ -6,6 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// wasi-libc does not provide mkstemp, which the test support header uses to
+// create temporary files.
+// UNSUPPORTED: LIBCXX-WASI-FIXME
+
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
 // <format>

--- a/libcxx/test/std/utilities/format/format.range/format.range.formatter/format.functions.format.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.range/format.range.formatter/format.functions.format.pass.cpp
@@ -6,6 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// wasi-libc does not provide mkstemp, which the test support header uses to
+// create temporary files.
+// UNSUPPORTED: LIBCXX-WASI-FIXME
+
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME

--- a/libcxx/test/std/utilities/format/format.range/format.range.formatter/format.functions.vformat.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.range/format.range.formatter/format.functions.vformat.pass.cpp
@@ -6,6 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// wasi-libc does not provide mkstemp, which the test support header uses to
+// create temporary files.
+// UNSUPPORTED: LIBCXX-WASI-FIXME
+
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME

--- a/libcxx/utils/ci/build-wasi-libc.sh
+++ b/libcxx/utils/ci/build-wasi-libc.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# ===----------------------------------------------------------------------===##
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# ===----------------------------------------------------------------------===##
+
+set -e
+
+PROGNAME="$(basename "${0}")"
+
+function error() { printf "error: %s\n" "$*" >&2; exit 1; }
+
+function usage() {
+cat <<EOF
+Usage:
+${PROGNAME} [options]
+
+[-h|--help]                  Display this help and exit.
+
+--build-dir <DIR>            Path to the directory to use for building.
+
+--install-dir <DIR>          Path to the directory to install the sysroot to.
+
+--target <TRIPLE>            WASI target triple to build the sysroot for, for
+                             example wasm32-wasip1.
+
+--source-dir <DIR>           Path to an existing wasi-libc checkout to build.
+                             When omitted, a known good version is downloaded.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case ${1} in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --build-dir)
+            build_dir="${2}"
+            shift; shift
+            ;;
+        --install-dir)
+            install_dir="${2}"
+            shift; shift
+            ;;
+        --target)
+            target="${2}"
+            shift; shift
+            ;;
+        --source-dir)
+            source_dir="${2}"
+            shift; shift
+            ;;
+        *)
+            error "Unknown argument '${1}'"
+            ;;
+    esac
+done
+
+for arg in build_dir install_dir target; do
+    if [ -z ${!arg+x} ]; then
+        error "Missing required argument '--${arg//_/-}'"
+    elif [ "${!arg}" == "" ]; then
+        error "Argument to --${arg//_/-} must not be empty"
+    fi
+done
+
+CMAKE="${CMAKE:-cmake}"
+wasi_libc_build_dir="${build_dir}/wasi-libc-build"
+
+if [ -z ${source_dir+x} ]; then
+    echo "--- Downloading wasi-libc"
+    source_dir="${build_dir}/wasi-libc-source"
+    mkdir -p "${source_dir}"
+    wasi_libc_commit="2fc32bc81b9f07f8d9525edea59bfbaf760c06d6"
+    curl -L "https://github.com/WebAssembly/wasi-libc/archive/${wasi_libc_commit}.zip" --output "${source_dir}/wasi-libc.zip"
+    unzip -q "${source_dir}/wasi-libc.zip" -d "${source_dir}"
+    mv "${source_dir}/wasi-libc-${wasi_libc_commit}"/* "${source_dir}"
+    rm -rf "${source_dir}/wasi-libc-${wasi_libc_commit}"
+fi
+
+echo "--- Building wasi-libc"
+# CMake's compiler probe would link an executable, which needs the sysroot this
+# script is about to create.
+#
+# Shared libraries are left out because wasi-libc downloads a prebuilt
+# compiler-rt from wasi-sdk to link libc.so with.
+${CMAKE} \
+  -S "${source_dir}" \
+  -B "${wasi_libc_build_dir}" \
+  -GNinja \
+  ${NINJA:+-DCMAKE_MAKE_PROGRAM=${NINJA}} \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_C_COMPILER="${CC:-cc}" \
+  -DCMAKE_C_COMPILER_TARGET="${target}" \
+  -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY \
+  -DCMAKE_INSTALL_PREFIX="${install_dir}" \
+  -DTARGET_TRIPLE="${target}" \
+  -DBUILD_SHARED=OFF \
+  -DBUILD_TESTS=OFF
+
+${CMAKE} --build "${wasi_libc_build_dir}"
+${CMAKE} --install "${wasi_libc_build_dir}"

--- a/libcxx/utils/ci/install-wasmkit.sh
+++ b/libcxx/utils/ci/install-wasmkit.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# ===----------------------------------------------------------------------===##
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# ===----------------------------------------------------------------------===##
+
+set -e
+
+PROGNAME="$(basename "${0}")"
+
+function error() { printf "error: %s\n" "$*" >&2; exit 1; }
+
+function usage() {
+cat <<EOF
+Usage:
+${PROGNAME} [options]
+
+[-h|--help]                  Display this help and exit.
+
+--install-dir <DIR>          Path to the directory to install the runtime to.
+                             The runtime is installed as <DIR>/wasmkit.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case ${1} in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --install-dir)
+            install_dir="${2}"
+            shift; shift
+            ;;
+        *)
+            error "Unknown argument '${1}'"
+            ;;
+    esac
+done
+
+if [ -z ${install_dir+x} ]; then
+    error "Missing required argument '--install-dir'"
+elif [ "${install_dir}" == "" ]; then
+    error "Argument to --install-dir must not be empty"
+fi
+
+wasmkit_version="0.3.1"
+
+case "$(uname -s)-$(uname -m)" in
+    Darwin-arm64)  asset="wasmkit-arm64-apple-macos" ;;
+    Darwin-x86_64) asset="wasmkit-x86_64-apple-macos" ;;
+    Linux-aarch64) asset="wasmkit-aarch64-swift-linux-musl" ;;
+    Linux-x86_64)  asset="wasmkit-x86_64-swift-linux-musl" ;;
+    *)             error "No WasmKit release is published for $(uname -s) $(uname -m)" ;;
+esac
+
+echo "--- Downloading WasmKit"
+mkdir -p "${install_dir}"
+curl -L "https://github.com/swiftwasm/WasmKit/releases/download/${wasmkit_version}/${asset}.tar.gz" \
+    --output "${install_dir}/wasmkit.tar.gz"
+tar -xzf "${install_dir}/wasmkit.tar.gz" -C "${install_dir}" --strip-components=1

--- a/libcxx/utils/ci/run-buildbot
+++ b/libcxx/utils/ci/run-buildbot
@@ -249,6 +249,63 @@ function test-armv7m-picolibc() {
     check-runtimes
 }
 
+function test-wasm32-wasip1() {
+    clean
+
+    step "Building wasi-libc from source"
+    ${MONOREPO_ROOT}/libcxx/utils/ci/build-wasi-libc.sh \
+        --build-dir "${BUILD_DIR}" \
+        --install-dir "${INSTALL_DIR}" \
+        --target wasm32-wasip1
+
+    if [ -z ${WASM_RUNTIME+x} ]; then
+        step "Installing WasmKit"
+        ${MONOREPO_ROOT}/libcxx/utils/ci/install-wasmkit.sh \
+            --install-dir "${BUILD_DIR}/wasmkit"
+        WASM_RUNTIME="${BUILD_DIR}/wasmkit/wasmkit"
+    fi
+
+    step "Generating CMake for compiler-rt"
+    flags="--sysroot=${INSTALL_DIR} ${WASI_EH_FLAGS}"
+    # The cache file requires WASI_RUNTIME even here, where nothing runs tests.
+    ${CMAKE} \
+        -S "${MONOREPO_ROOT}/compiler-rt" \
+        -B "${BUILD_DIR}/compiler-rt" \
+        -GNinja \
+        ${MAKE_PROGRAM} \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}" \
+        -DCMAKE_C_FLAGS="${flags}" \
+        -DCMAKE_CXX_FLAGS="${flags}" \
+        -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON \
+        -DWASI_RUNTIME="${WASM_RUNTIME}" \
+        "${@}"
+
+    step "Generating CMake for libc++"
+    generate-cmake-base \
+        -DLLVM_ENABLE_RUNTIMES="${WASI_RUNTIMES}" \
+        -DLIBCXX_CXX_ABI=libcxxabi \
+        -DLIBCXX_TEST_CONFIG="wasm32-wasip1-libc++.cfg.in" \
+        -DLIBCXXABI_TEST_CONFIG="wasm32-wasip1-libc++abi.cfg.in" \
+        -DCMAKE_C_FLAGS="${flags}" \
+        -DCMAKE_CXX_FLAGS="${flags}" \
+        -DWASI_RUNTIME="${WASM_RUNTIME}" \
+        -DWASI_EH_FLAGS="${WASI_EH_FLAGS}" \
+        "${@}"
+
+    step "Installing compiler-rt"
+    ${NINJA} -vC "${BUILD_DIR}/compiler-rt" install
+    # compiler-rt normalizes the target triple, so its libraries land next to,
+    # rather than in, the sysroot directory wasi-libc installed to.
+    mv "${INSTALL_DIR}/lib/wasm32-unknown-wasip1"/* "${INSTALL_DIR}/lib/wasm32-wasip1"
+
+    step "Running the libc++ tests"
+    ${NINJA} -vC "${BUILD_DIR}" check-cxx
+
+    step "Running the libc++abi tests"
+    ${NINJA} -vC "${BUILD_DIR}" check-cxxabi
+}
+
 case "${BUILDER}" in
 check-generated-output)
     # `! foo` doesn't work properly with `set -e`, use `! foo || false` instead.
@@ -737,6 +794,27 @@ armv7m-picolibc-no-exceptions)
         -C "${MONOREPO_ROOT}/libcxx/cmake/caches/Armv7M-picolibc.cmake" \
         -DLIBCXXABI_ENABLE_EXCEPTIONS=OFF \
         -DLIBCXXABI_ENABLE_STATIC_UNWINDER=OFF \
+        -DLIBCXX_ENABLE_EXCEPTIONS=OFF \
+        -DLIBCXX_ENABLE_RTTI=OFF
+;;
+wasm32-wasip1)
+    # libc++abi's personality routine needs the wasm entry points in libunwind's
+    # Unwind-wasm.c. Building libunwind for wasm warns about a zero sized
+    # unw_context_t and about thread_local.
+    WASI_RUNTIMES="libcxx;libcxxabi;libunwind"
+    WASI_EH_FLAGS="-fwasm-exceptions -mllvm -wasm-use-legacy-eh=false"
+    test-wasm32-wasip1 \
+        -C "${MONOREPO_ROOT}/libcxx/cmake/caches/WASI.cmake" \
+        -DLIBUNWIND_ENABLE_WERROR=NO
+;;
+wasm32-wasip1-no-exceptions)
+    WASI_RUNTIMES="libcxx;libcxxabi"
+    WASI_EH_FLAGS=""
+    test-wasm32-wasip1 \
+        -C "${MONOREPO_ROOT}/libcxx/cmake/caches/WASI.cmake" \
+        -DLIBCXXABI_ENABLE_EXCEPTIONS=OFF \
+        -DLIBCXXABI_ENABLE_STATIC_UNWINDER=OFF \
+        -DLIBCXXABI_USE_LLVM_UNWINDER=OFF \
         -DLIBCXX_ENABLE_EXCEPTIONS=OFF \
         -DLIBCXX_ENABLE_RTTI=OFF
 ;;

--- a/libcxx/utils/libcxx/test/features/platform.py
+++ b/libcxx/utils/libcxx/test/features/platform.py
@@ -102,6 +102,10 @@ features = [
         ),
     ),
     Feature(
+        name="LIBCXX-WASI-FIXME",
+        when=lambda cfg: "__wasi__" in compilerMacros(cfg),
+    ),
+    Feature(
         name="LIBCXX-AMDGPU-FIXME",
         when=lambda cfg: "__AMDGPU__" in compilerMacros(cfg),
     ),

--- a/libcxx/utils/wasm.py
+++ b/libcxx/utils/wasm.py
@@ -31,7 +31,9 @@ def main():
     args = parser.parse_args()
 
     if not shutil.which(args.runtime):
-        sys.exit(f"Failed to find a WASI runtime from --runtime value: '{args.runtime}'")
+        sys.exit(
+            f"Failed to find a WASI runtime from --runtime value: '{args.runtime}'"
+        )
 
     if not os.path.exists(args.test_binary):
         sys.exit(f"Expected argument to be a test executable: '{args.test_binary}'")

--- a/libcxx/utils/wasm.py
+++ b/libcxx/utils/wasm.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# ===----------------------------------------------------------------------===##
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# ===----------------------------------------------------------------------===##
+
+"""wasm.py is a utility for running a WebAssembly program under a WASI runtime.
+
+It forwards command line arguments and environment variables to the program and
+returns the program's error code.
+"""
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--runtime", type=str, required=True)
+    parser.add_argument("--execdir", type=str, required=True)
+    parser.add_argument("--env", type=str, action="append", default=[])
+    parser.add_argument("--dir", dest="dirs", type=str, action="append", default=[])
+    parser.add_argument("test_binary")
+    parser.add_argument("test_args", nargs=argparse.ZERO_OR_MORE, default=[])
+    args = parser.parse_args()
+
+    if not shutil.which(args.runtime):
+        sys.exit(f"Failed to find a WASI runtime from --runtime value: '{args.runtime}'")
+
+    if not os.path.exists(args.test_binary):
+        sys.exit(f"Expected argument to be a test executable: '{args.test_binary}'")
+
+    # WASI resolves a path against the preopened directory whose name it starts
+    # with, so tests need the execution directory granted both as '.' for the
+    # relative paths they use and under its absolute name for %t paths.
+    execdir = os.path.abspath(args.execdir)
+    commandline = [args.runtime, "run", "--dir", ".", "--dir", execdir]
+    for directory in args.dirs:
+        commandline += ["--dir", directory]
+    for env in args.env:
+        commandline += ["--env", env]
+    commandline += [args.test_binary, *args.test_args]
+
+    return subprocess.call(commandline, cwd=execdir)
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/libcxxabi/src/cxa_personality.cpp
+++ b/libcxxabi/src/cxa_personality.cpp
@@ -721,7 +721,7 @@ static void scan_eh_tab(scan_results &results, _Unwind_Action actions,
                                  ? (const uint8_t*)funcStart
                                  : (const uint8_t*)readEncodedPointer(&lsda, lpStartEncoding, base);
 #if defined(__USING_SJLJ_EXCEPTIONS__) || defined(__WASM_EXCEPTIONS__)
-    (void)lpStart;  // When using SjLj/Wasm exceptions, lpStart is never used
+    (void)lpStart; // When using SjLj/Wasm exceptions, lpStart is never used
 #endif
     uint8_t ttypeEncoding = *lsda++;
     if (ttypeEncoding != DW_EH_PE_omit)

--- a/libcxxabi/src/cxa_personality.cpp
+++ b/libcxxabi/src/cxa_personality.cpp
@@ -720,6 +720,9 @@ static void scan_eh_tab(scan_results &results, _Unwind_Action actions,
     const uint8_t* lpStart = lpStartEncoding == DW_EH_PE_omit
                                  ? (const uint8_t*)funcStart
                                  : (const uint8_t*)readEncodedPointer(&lsda, lpStartEncoding, base);
+#if defined(__USING_SJLJ_EXCEPTIONS__) || defined(__WASM_EXCEPTIONS__)
+    (void)lpStart;  // When using SjLj/Wasm exceptions, lpStart is never used
+#endif
     uint8_t ttypeEncoding = *lsda++;
     if (ttypeEncoding != DW_EH_PE_omit)
     {

--- a/libcxxabi/test/backtrace_test.pass.cpp
+++ b/libcxxabi/test/backtrace_test.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// libunwind's wasm implementation does not provide _Unwind_Backtrace.
+// UNSUPPORTED: LIBCXX-WASI-FIXME
+
 // UNSUPPORTED: no-exceptions
 
 // VE only supports SjLj and doesn't provide _Unwind_Backtrace.

--- a/libcxxabi/test/configs/wasm32-wasip1-libc++abi.cfg.in
+++ b/libcxxabi/test/configs/wasm32-wasip1-libc++abi.cfg.in
@@ -1,0 +1,41 @@
+lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
+
+config.substitutions.append(('%{flags}', '--sysroot=@CMAKE_INSTALL_PREFIX@ @WASI_EH_FLAGS@'))
+
+config.substitutions.append(('%{compile_flags}',
+    '-nostdinc++ -I %{include} -I %{cxx-include} -I %{cxx-target-include} %{maybe-include-libunwind} -I %{libcxx}/test/support -I %{libcxx}/src -D_LIBCPP_ENABLE_CXX17_REMOVED_UNEXPECTED_FUNCTIONS'
+
+    # wasi-libc gates signals, process clocks and setjmp/longjmp behind these, and
+    # the runtime implements only the standardized exception handling encoding.
+    ' -D_WASI_EMULATED_SIGNAL -D_WASI_EMULATED_PROCESS_CLOCKS'
+    ' -mllvm -wasm-enable-sjlj -mllvm -wasm-use-legacy-eh=false'
+))
+config.substitutions.append(('%{link_flags}',
+    # wasi-libc keeps long double formatting out of libc to save size, so the
+    # archive providing it has to override libc's stubs.
+    '-nodefaultlibs -L %{lib} -lc++ -lc++abi -lc-printscan-long-double'
+    ' -lc -lwasi-emulated-signal -lwasi-emulated-process-clocks -lsetjmp'
+    ' -lclang_rt.builtins'
+
+    # wasm-ld defaults the stack to 64 KiB, far below what tests holding large
+    # objects on it need. Match the 8 MiB a hosted main thread gets.
+    ' -Wl,-z,stack-size=0x800000'
+))
+
+config.executor = (
+    '@LIBCXXABI_LIBCXX_PATH@/utils/wasm.py'
+    ' --runtime @WASI_RUNTIME@')
+config.substitutions.append(('%{exec}',
+    '%{executor}'
+    ' --execdir %{temp}'
+))
+
+import os, site
+site.addsitedir(os.path.join('@LIBCXXABI_LIBCXX_PATH@', 'utils'))
+import libcxx.test.params, libcxx.test.config
+libcxx.test.config.configure(
+    libcxx.test.params.DEFAULT_PARAMETERS,
+    libcxx.test.features.DEFAULT_FEATURES,
+    config,
+    lit_config
+)

--- a/libcxxabi/test/cxa_call_terminate.pass.cpp
+++ b/libcxxabi/test/cxa_call_terminate.pass.cpp
@@ -6,6 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Whether the stack unwinds before std::terminate runs for an exception escaping
+// noexcept is implementation-defined. Wasm unwinds, so no exception is current
+// once terminate runs.
+// XFAIL: LIBCXX-WASI-FIXME
+
 // UNSUPPORTED: no-exceptions
 
 // We're testing the diagnosed behaviour here.

--- a/libcxxabi/test/forced_unwind1.pass.cpp
+++ b/libcxxabi/test/forced_unwind1.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// libunwind's wasm implementation does not provide _Unwind_ForcedUnwind.
+// UNSUPPORTED: LIBCXX-WASI-FIXME
+
 // _Unwind_ForcedUnwind raised exception can be caught by catch (...) and be
 // rethrown. If not rethrown, exception_cleanup will be called.
 

--- a/libcxxabi/test/forced_unwind2.pass.cpp
+++ b/libcxxabi/test/forced_unwind2.pass.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// libunwind's wasm implementation does not provide _Unwind_ForcedUnwind.
+// UNSUPPORTED: LIBCXX-WASI-FIXME
+
 // Forced unwinding causes std::terminate when going through noexcept.
 
 // UNSUPPORTED: no-exceptions, c++03

--- a/libcxxabi/test/test_vector3.pass.cpp
+++ b/libcxxabi/test/test_vector3.pass.cpp
@@ -6,6 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Whether the stack unwinds before std::terminate runs for an exception with no
+// handler is implementation-defined. Wasm unwinds, so the cleanup this test
+// expects to be skipped runs.
+// XFAIL: LIBCXX-WASI-FIXME
+
 // UNSUPPORTED: no-exceptions
 
 #include "cxxabi.h"

--- a/libunwind/src/config.h
+++ b/libunwind/src/config.h
@@ -71,17 +71,16 @@
 #endif
 
 #if defined(_LIBUNWIND_HIDE_SYMBOLS)
-  // The CMake file passes -fvisibility=hidden to control ELF/Mach-O visibility.
-  #define _LIBUNWIND_EXPORT
-  #define _LIBUNWIND_HIDDEN
+// The CMake file passes -fvisibility=hidden to control ELF/Mach-O visibility.
+#define _LIBUNWIND_EXPORT
+#define _LIBUNWIND_HIDDEN
+#elif !defined(__ELF__) && !defined(__MACH__) && !defined(_AIX) &&             \
+    !defined(__wasm__)
+#define _LIBUNWIND_EXPORT __declspec(dllexport)
+#define _LIBUNWIND_HIDDEN
 #else
-  #if !defined(__ELF__) && !defined(__MACH__) && !defined(_AIX) && !defined(__wasm__)
-    #define _LIBUNWIND_EXPORT __declspec(dllexport)
-    #define _LIBUNWIND_HIDDEN
-  #else
-    #define _LIBUNWIND_EXPORT __attribute__((visibility("default")))
-    #define _LIBUNWIND_HIDDEN __attribute__((visibility("hidden")))
-  #endif
+#define _LIBUNWIND_EXPORT __attribute__((visibility("default")))
+#define _LIBUNWIND_HIDDEN __attribute__((visibility("hidden")))
 #endif
 
 #define STR(a) #a

--- a/libunwind/src/config.h
+++ b/libunwind/src/config.h
@@ -75,7 +75,7 @@
   #define _LIBUNWIND_EXPORT
   #define _LIBUNWIND_HIDDEN
 #else
-  #if !defined(__ELF__) && !defined(__MACH__) && !defined(_AIX)
+  #if !defined(__ELF__) && !defined(__MACH__) && !defined(_AIX) && !defined(__wasm__)
     #define _LIBUNWIND_EXPORT __declspec(dllexport)
     #define _LIBUNWIND_HIDDEN
   #else


### PR DESCRIPTION
libc++ has no WebAssembly test coverage. This adds two builders, `wasm32-wasip1` and `wasm32-wasip1-no-exceptions`.

Tests that wasi-libc or the wasm ABI cannot satisfy carry a new `LIBCXX-WASI-FIXME` feature, following the existing picolibc and AIX markers.

Two source changes are included:

- `libunwind/src/config.h` no longer marks symbols `dllexport` on wasm.
- `libcxxabi/src/cxa_personality.cpp` suppresses an unused-variable warning for `lpStart`, matching the existing suppression for `callSiteEncoding`.
