### PR TITLE
[Offload][AMDGPU] Add env var to control device-to-device memory access

### DIFF
--- a/offload/plugins-nextgen/amdgpu/src/rtl.cpp
+++ b/offload/plugins-nextgen/amdgpu/src/rtl.cpp
@@ -2275,9 +2275,11 @@ struct AMDGPUDeviceTy : public GenericDeviceTy, AMDGenericDeviceTy {
         OMPX_StreamBusyWait("LIBOMPTARGET_AMDGPU_STREAM_BUSYWAIT", 2000000),
         OMPX_UseMultipleSdmaEngines(
             "LIBOMPTARGET_AMDGPU_USE_MULTIPLE_SDMA_ENGINES", false),
-        OMPX_ApuMaps("OMPX_APU_MAPS", false), AMDGPUStreamManager(*this, Agent),
-        AMDGPUEventManager(*this), AMDGPUSignalManager(*this), Agent(Agent),
-        HostDevice(HostDevice) {}
+        OMPX_ApuMaps("OMPX_APU_MAPS", false),
+        OMPX_EnableDevice2DeviceMemAccess(
+            "LIBOMPTARGET_AMDGPU_ENABLE_DEVICE_TO_DEVICE_MEM_ACCESS", false),
+        AMDGPUStreamManager(*this, Agent), AMDGPUEventManager(*this),
+        AMDGPUSignalManager(*this), Agent(Agent), HostDevice(HostDevice) {}
 
   ~AMDGPUDeviceTy() {}
 
@@ -3690,6 +3692,12 @@ private:
   /// automatic zero-copy behavior on non-APU GPUs.
   BoolEnvar OMPX_ApuMaps;
 
+  /// Determines whether we call the HSA API to make device memory allocations
+  /// accessible from other agents, so that device-to-device memory copies are
+  /// possible. Host and shared allocations are always made accessible from all
+  /// agents. Default is disabled.
+  BoolEnvar OMPX_EnableDevice2DeviceMemAccess;
+
   /// Stream manager for AMDGPU streams.
   AMDGPUStreamManagerTy AMDGPUStreamManager;
 
@@ -4514,10 +4522,12 @@ Expected<void *> AMDGPUDeviceTy::allocate(size_t Size, void *,
   if (auto Err = MemoryPool->allocate(Size, &Alloc, Alignment))
     return std::move(Err);
 
-  if (Alloc) {
+  if (Alloc && (Kind == TARGET_ALLOC_HOST || Kind == TARGET_ALLOC_SHARED ||
+                OMPX_EnableDevice2DeviceMemAccess)) {
     // Get a list of agents that can access this memory pool. Inherently
-    // necessary for host or shared allocations Also enabled for device memory
-    // to allow device to device memcpy
+    // necessary for host or shared allocations. Also enabled for device memory
+    // to allow device to device memcpy, but only when
+    // LIBOMPTARGET_AMDGPU_ENABLE_DEVICE_TO_DEVICE_MEM_ACCESS is set.
     llvm::SmallVector<hsa_agent_t> Agents;
     llvm::copy_if(static_cast<AMDGPUPluginTy &>(Plugin).getKernelAgents(),
                   std::back_inserter(Agents), [&](hsa_agent_t Agent) {

--- a/offload/test/offloading/d2d_memcpy.c
+++ b/offload/test/offloading/d2d_memcpy.c
@@ -1,9 +1,9 @@
 // RUN: %libomptarget-compile-generic && \
-// RUN: env OMP_MAX_ACTIVE_LEVELS=2 %libomptarget-run-generic | \
-// RUN: %fcheck-generic -allow-empty
+// RUN: env %if amdgpu %{ LIBOMPTARGET_AMDGPU_ENABLE_DEVICE_TO_DEVICE_MEM_ACCESS=1 %} \
+// RUN: OMP_MAX_ACTIVE_LEVELS=2 %libomptarget-run-generic | %fcheck-generic -allow-empty
 // RUN: %libomptarget-compileopt-generic && \
-// RUN: env OMP_MAX_ACTIVE_LEVELS=2 %libomptarget-run-generic | \
-// RUN: %fcheck-generic -allow-empty
+// RUN: env %if amdgpu %{ LIBOMPTARGET_AMDGPU_ENABLE_DEVICE_TO_DEVICE_MEM_ACCESS=1 %} \
+// RUN: OMP_MAX_ACTIVE_LEVELS=2 %libomptarget-run-generic | %fcheck-generic -allow-empty
 // XFAIL: intelgpu
 
 #include <assert.h>

--- a/offload/test/offloading/d2d_memcpy_sync.c
+++ b/offload/test/offloading/d2d_memcpy_sync.c
@@ -1,6 +1,7 @@
 // RUN: %libomptarget-compile-generic && \
-// RUN: env LIBOMPTARGET_AMDGPU_MAX_ASYNC_COPY_BYTES=0 %libomptarget-run-generic | \
-// RUN: %fcheck-generic -allow-empty
+// RUN: env LIBOMPTARGET_AMDGPU_MAX_ASYNC_COPY_BYTES=0 \
+// RUN: LIBOMPTARGET_AMDGPU_ENABLE_DEVICE_TO_DEVICE_MEM_ACCESS=1 \
+// RUN: %libomptarget-run-generic | %fcheck-generic -allow-empty
 // REQUIRES: amdgcn-amd-amdhsa
 
 #include <assert.h>


### PR DESCRIPTION
Added LIBOMPTARGET_AMDGPU_ENABLE_DEVICE_TO_DEVICE_MEM_ACCESS environment
variable and made device-to-device memory access opt-in (previously enabled w/o any control).

Rationale: Do not pay for overhead unless the feature is needed.
