### PR TITLE
[compiler-rt][Darwin] Drop i386 slice for builtins on modern SDKs

### DIFF
--- a/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
@@ -111,6 +111,18 @@ function(darwin_test_archs os valid_archs)
   endif()
 
   set(archs ${ARGN})
+
+  # Disable building for i386 for macOS SDK >= 10.15. The SDK doesn't support
+  # linking for i386 and the corresponding OS doesn't allow running macOS i386
+  # binaries.
+  if ("${os}" STREQUAL "osx")
+    find_darwin_sdk_version(macosx_sdk_version "macosx")
+    if ("${macosx_sdk_version}" VERSION_GREATER 10.15 OR "${macosx_sdk_version}" VERSION_EQUAL 10.15)
+      message(STATUS "Disabling i386 slice for ${valid_archs}")
+      list(REMOVE_ITEM archs "i386")
+    endif()
+  endif()
+
   if(NOT TEST_COMPILE_ONLY)
     message(STATUS "Finding valid architectures for ${os}...")
     set(SIMPLE_C ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/src.c)
@@ -120,17 +132,6 @@ function(darwin_test_archs os valid_archs)
     foreach(flag ${DARWIN_${os}_LINK_FLAGS})
       set(os_linker_flags "${os_linker_flags} ${flag}")
     endforeach()
-
-    # Disable building for i386 for macOS SDK >= 10.15. The SDK doesn't support
-    # linking for i386 and the corresponding OS doesn't allow running macOS i386
-    # binaries.
-    if ("${os}" STREQUAL "osx")
-      find_darwin_sdk_version(macosx_sdk_version "macosx")
-      if ("${macosx_sdk_version}" VERSION_GREATER 10.15 OR "${macosx_sdk_version}" VERSION_EQUAL 10.15)
-        message(STATUS "Disabling i386 slice for ${valid_archs}")
-        list(REMOVE_ITEM archs "i386")
-      endif()
-    endif()
   endif()
 
   # The simple program will build for x86_64h on the simulator because it is


### PR DESCRIPTION
The SDK >= 10.15 i386-removal in darwin_test_archs was gated by `if(NOT TEST_COMPILE_ONLY)`, so it never fired for the builtins config, which sets TEST_COMPILE_ONLY=On. `-arch i386` still compiles fine on current SDKs — ld is the only stage that rejects it — so the compile-only probe kept i386 in DARWIN_osx_BUILTIN_ARCHS, and downstream `strip` on the resulting fat archives fails on Xcode 27 with "ld: linking for i386 is no longer supported".

Hoist the check above the guard so it applies to both the runtime and builtin arch probes.