### PR TITLE
[bazel][libc] Update path to syscall.h for darwin aarch64

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -2741,7 +2741,7 @@ libc_support_library(
         ],
         "@platforms//os:macos": [
             "src/__support/OSUtil/darwin/syscall.h",
-            "src/__support/OSUtil/darwin/arm/syscall.h",
+            "src/__support/OSUtil/darwin/aarch64/syscall.h",
         ],
         "@platforms//os:windows": [],
     }),


### PR DESCRIPTION
This file was moved in bfd7024b0d665de02abbfc7b16f593020d2c12c9.