### PR TITLE
[lldb][test] Give each inline test its own function object

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -263,6 +263,20 @@ def _xfailForVariant(variant_name, expected_fn, bugnumber=None):
         return expectedFailure_impl
 
 
+def FreshTestFunction(src):
+    """Return a private copy of *src* for one generated test class to own.
+
+    Several decorators record their state on the function object they are
+    handed instead of on a wrapper.
+    """
+
+    @wraps(src)
+    def copy(self):
+        return src(self)
+
+    return copy
+
+
 def _skipForVariant(variant_name, expected_fn, bugnumber=None):
     """Mark a test method as skipped for a specific variant dimension.
 

--- a/lldb/packages/Python/lldbsuite/test/lldbinline.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbinline.py
@@ -197,7 +197,9 @@ def MakeInlineTest(__file, __globals, decorators=None, name=None, build_dict=Non
         file_basename = os.path.basename(__file)
         name, _ = os.path.splitext(file_basename)
 
-    test_func = ApplyDecoratorsToFunction(InlineTest._test, decorators)
+    test_func = ApplyDecoratorsToFunction(
+        FreshTestFunction(InlineTest._test), decorators
+    )
     # Build the test case
     test_class = type(
         name, (InlineTest,), dict(test=test_func, name=name, _build_dict=build_dict)


### PR DESCRIPTION
`MakeInlineTest` handed every generated test class the one shared `InlineTest._test` function object, and several decorators record their state on the function object they are handed rather than on a wrapper. Some tests would mutate this state, causing some tests to unexpectedly run with decorators thei weren't annotated with.

Assisted-by: Claude