### PR TITLE
workflows/release-asset-audit: Limit token to current repository

### DIFF
--- a/.github/workflows/release-asset-audit.yml
+++ b/.github/workflows/release-asset-audit.yml
@@ -67,6 +67,7 @@ jobs:
           client-id: ${{ secrets.LLVM_TOKEN_GENERATOR_CLIENT_ID }}
           private-key: ${{ secrets.LLVM_TOKEN_GENERATOR_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.repository }}
           permission-contents: read
           permission-issues: write
       - name: "File Issue"


### PR DESCRIPTION
The token had access to all llvm repositories which was unnecessary since it was only used for llvm-project.

https://github.com/llvm/llvm-project/security/code-scanning/1865