### PR TITLE
[lld][MachO][NFC] Move config->icfLevel dereference out of loops

### DIFF
--- a/lld/MachO/ICF.cpp
+++ b/lld/MachO/ICF.cpp
@@ -415,13 +415,13 @@ void ICF::run() {
       isec->icfEqClass[(icfPass + 1) % 2] = hash | (1ull << 31);
     });
   }
-
+  const bool useSafeThunks = config->icfLevel == ICFLevel::safe_thunks;
   llvm::stable_sort(
-      icfInputs, [](const ConcatInputSection *a, const ConcatInputSection *b) {
+      icfInputs, [&](const ConcatInputSection *a, const ConcatInputSection *b) {
         // When using safe_thunks, ensure that we first sort by icfEqClass and
         // then by keepUnique (descending). This guarantees that within an
         // equivalence class, the keepUnique inputs are always first.
-        if (config->icfLevel == ICFLevel::safe_thunks)
+        if (useSafeThunks)
           if (a->icfEqClass[0] == b->icfEqClass[0])
             return a->keepUnique > b->keepUnique;
         return a->icfEqClass[0] < b->icfEqClass[0];
@@ -446,7 +446,7 @@ void ICF::run() {
   // When using safe_thunks, we need to create thunks for all keepUnique
   // functions that can be deduplicated. Since we're creating / adding new
   // InputSections, we can't paralellize this.
-  if (config->icfLevel == ICFLevel::safe_thunks)
+  if (useSafeThunks)
     forEachClassRange(0, icfInputs.size(), [&](size_t begin, size_t end) {
       applySafeThunksToRange(begin, end);
     });
@@ -459,11 +459,10 @@ void ICF::run() {
     // thunks. For all other ICF levels, directly merge the functions.
 
     ConcatInputSection *beginIsec = icfInputs[begin];
-    bool useSafeThunks =
-        config->icfLevel == ICFLevel::safe_thunks && isCodeSection(beginIsec);
     for (size_t i = begin + 1; i < end; ++i) {
       // Skip keepUnique inputs when using safe_thunks (already handled above)
-      if (useSafeThunks && icfInputs[i]->keepUnique) {
+      if (useSafeThunks && isCodeSection(beginIsec) &&
+          icfInputs[i]->keepUnique) {
         // Assert keepUnique sections are either small or replaced with thunks.
         assert(!icfInputs[i]->live ||
                icfInputs[i]->data.size() <= target->getICFSafeThunkSize());


### PR DESCRIPTION
`config->icfLevel` was being dereferenced in inside `stable_sort()` and `forEachClass()`, which runs for each `InputSection`. Move the check outside the loops since it is constant.