### PR TITLE
[lld][MachO][NFC] Remove redundant size checks

### DIFF
--- a/lld/MachO/ICF.cpp
+++ b/lld/MachO/ICF.cpp
@@ -100,11 +100,7 @@ bool ICF::equalsConstant(const ConcatInputSection *ia,
   // We can only fold within the same OutputSection.
   if (ia->parent != ib->parent)
     return false;
-  if (ia->data.size() != ib->data.size())
-    return false;
   if (ia->data != ib->data)
-    return false;
-  if (ia->relocs.size() != ib->relocs.size())
     return false;
   auto f = [](const Relocation &ra, const Relocation &rb) {
     if (ra.type != rb.type)


### PR DESCRIPTION
`ArrayRef::equals()` already has a size check, so we don't need to check `data.size()`
https://github.com/llvm/llvm-project/blob/2ad7d474a13e9c10d9d9d1046383f0e9cd7d859c/llvm/include/llvm/ADT/ArrayRef.h#L177-L179

Also, `llvm::equal()` just calls `std::equal()` which has a size check too.
https://cppreference.net/cpp/algorithm/equal.html