### PR TITLE
[WebAssembly] Export TLS symbols by default on wasip3

### DIFF
--- a/lld/test/wasm/cooperative-threading.s
+++ b/lld/test/wasm/cooperative-threading.s
@@ -87,8 +87,20 @@ foo:
 # CHECK-NEXT:     - Minimum:         0x2
 # CHECK-NOT:       Shared
 
-# The function table is exported by default.
+# For wasip3 these symbols are unconditionally exported since they're required
+# when dynamic linking.
 # CHECK:      - Type:            EXPORT
+# CHECK:          - Name:            __tls_size
+# CHECK-NEXT:       Kind:            GLOBAL
+# CHECK-NEXT:       Index:           2
+# CHECK-NEXT:     - Name:            __tls_align
+# CHECK-NEXT:       Kind:            GLOBAL
+# CHECK-NEXT:       Index:           3
+# CHECK-NEXT:     - Name:            __wasm_init_tls
+# CHECK-NEXT:       Kind:            FUNCTION
+# CHECK-NEXT:       Index:           2
+
+# The function table is exported by default.
 # CHECK:          - Name:            __indirect_function_table
 # CHECK-NEXT:       Kind:            TABLE
 # CHECK-NEXT:       Index:           0

--- a/lld/wasm/Driver.cpp
+++ b/lld/wasm/Driver.cpp
@@ -1004,6 +1004,13 @@ static void createSyntheticSymbols() {
       ctx.sym.getTLSBase =
           createUndefinedFunction("__wasm_get_tls_base", &getTLSBaseSignature);
       ctx.sym.getTLSBase->markLive();
+
+      // TODO: this might be best to happen up the stack in the Clang driver
+      // and the Rust driver rather than here. For now though this is an easy
+      // place to share code between the two.
+      ctx.sym.tlsSize->forceExport = true;
+      ctx.sym.tlsAlign->forceExport = true;
+      ctx.sym.initTLS->forceExport = true;
     }
   }
 }


### PR DESCRIPTION
This commit is a change to `wasm-ld` to export a number of TLS-related symbols by default on wasip3 targets. Specifically `__tls_base`, `__tls_align`, and `__wasm_init_tls` are all exported by default now. This is required for dynamic linking in wasip3 in `wasm-tools component link` as otherwise there's no way to learn about the TLS size/align/initialization of dynamically linked libraries. For non-dynamic use cases these will still be used internally and it's just that the exports will be dead, but that's a pretty minor cost for now. An eventual component-optimizer would be able to remove these pretty easily.