### PR TITLE
[SandboxVec][Scheduler][NFC] ReadyListContainer::contains() is now constant time

### DIFF
--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Scheduler.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Scheduler.h
@@ -21,10 +21,10 @@
 #ifndef LLVM_TRANSFORMS_VECTORIZE_SANDBOXVECTORIZER_SCHEDULER_H
 #define LLVM_TRANSFORMS_VECTORIZE_SANDBOXVECTORIZER_SCHEDULER_H
 
+#include "llvm/ADT/PriorityQueue.h"
 #include "llvm/SandboxIR/Instruction.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.h"
-#include <queue>
 #include <variant>
 
 namespace llvm::sandboxir {
@@ -59,7 +59,9 @@ class ReadyListContainer {
   /// These have to be modeled in the ready list for correctness.
   /// This means that the list will hold back nodes that need to meet such
   /// unmodeled dependencies.
-  std::priority_queue<DGNode *, std::vector<DGNode *>, PriorityCmp> List;
+  PriorityQueue<DGNode *, SmallVector<DGNode *, 32>, PriorityCmp> List;
+  /// Helper set for O(1) lookups.
+  SmallDenseSet<DGNode *, 32> Set;
 
 public:
   ReadyListContainer() : List(Cmp) {}
@@ -69,40 +71,51 @@ public:
     assert(!contains(N) && "Node already exists in ready list!");
 #endif
     List.push(N);
+    Set.insert(N);
+    assert(List.size() == Set.size() && "List and Set out-of-sync!");
   }
   DGNode *pop() {
     auto *Back = List.top();
     List.pop();
+    Set.erase(Back);
+    assert(List.size() == Set.size() && "List and Set out-of-sync!");
     return Back;
   }
-  bool empty() const { return List.empty(); }
-  void clear() { List = {}; }
-  bool contains(DGNode *N) const {
-    // TODO: We should update the data structure to make this O(1).
-    auto ListCopy = List;
-    while (!ListCopy.empty()) {
-      DGNode *Top = ListCopy.top();
-      if (Top == N)
-        return true;
-      ListCopy.pop();
-    }
-    return false;
+  bool empty() const {
+    assert(List.empty() == Set.empty() && "List and Set out-of-sync!");
+    return List.empty();
   }
-  /// \Removes \p N if found in the ready list.
+  void clear() {
+    List.clear();
+    Set.clear();
+  }
+  bool contains(DGNode *N) const {
+#ifndef NDEBUG
+    // TODO: We should eventually remove this check.
+    auto ListContains = [this](DGNode *N) {
+      auto ListCopy = List;
+      while (!ListCopy.empty()) {
+        DGNode *Top = ListCopy.top();
+        if (Top == N)
+          return true;
+        ListCopy.pop();
+      }
+      return false;
+    };
+    assert(ListContains(N) == Set.contains(N) && "List and Set out-of-sync!");
+#endif
+    return Set.contains(N);
+  }
+  /// \Removes \p N if found in the ready list. Note: this is linear time!
   void remove(DGNode *N) {
-    // TODO: Use a more efficient data-structure for the ready list because the
-    // priority queue does not support fast removals.
-    SmallVector<DGNode *, 8> Keep;
-    Keep.reserve(List.size());
-    while (!List.empty()) {
-      auto *Top = List.top();
-      List.pop();
-      if (Top == N)
-        break;
-      Keep.push_back(Top);
+    auto It = Set.find(N);
+    if (It != Set.end()) {
+      Set.erase(It);
+      // TODO: Use a more efficient data-structure for the ready list because
+      // the priority queue does not support fast removals.
+      List.erase_one(N);
+      assert(List.size() == Set.size() && "List and Set out-of-sync!");
     }
-    for (auto *KeepN : Keep)
-      List.push(KeepN);
   }
 #ifndef NDEBUG
   void dump(raw_ostream &OS) const;


### PR DESCRIPTION
This patch changes the ReadyListContainer in two ways:
1. It adds a set for fast lookups
2. It replaces std::priority_queue with llvm::PriorityQueue because the latter implements an erase function (`erase_one`).