### PR TITLE
[lldb] Remove ConstString from DumpValueObjectOptions

### DIFF
--- a/lldb/include/lldb/DataFormatters/DumpValueObjectOptions.h
+++ b/lldb/include/lldb/DataFormatters/DumpValueObjectOptions.h
@@ -48,11 +48,11 @@ public:
     operator bool() { return m_element_count > 0; }
   };
 
-  typedef std::function<bool(ConstString, ConstString,
+  typedef std::function<bool(llvm::StringRef, llvm::StringRef,
                              const DumpValueObjectOptions &, Stream &)>
       DeclPrintingHelper;
 
-  typedef std::function<bool(ConstString)> ChildPrintingDecider;
+  typedef std::function<bool(llvm::StringRef)> ChildPrintingDecider;
 
   static const DumpValueObjectOptions DefaultOptions() {
     static DumpValueObjectOptions g_default_options;

--- a/lldb/source/Commands/CommandObjectFrame.cpp
+++ b/lldb/source/Commands/CommandObjectFrame.cpp
@@ -158,7 +158,7 @@ protected:
 
     result.GetValueObjectList().Append(valobj_sp);
     DumpValueObjectOptions::DeclPrintingHelper helper =
-        [&valobj_sp](ConstString type, ConstString var,
+        [&valobj_sp](llvm::StringRef type, llvm::StringRef var,
                      const DumpValueObjectOptions &opts,
                      Stream &stream) -> bool {
       const ValueObject::GetExpressionPathFormat format = ValueObject::

--- a/lldb/source/Core/DumpRegisterValue.cpp
+++ b/lldb/source/Core/DumpRegisterValue.cpp
@@ -50,9 +50,9 @@ static void dump_type_value(const lldb_private::RegisterTypeFlags &flags_type,
       data_extractor);
   lldb_private::DumpValueObjectOptions dump_options;
   lldb_private::DumpValueObjectOptions::ChildPrintingDecider decider =
-      [](lldb_private::ConstString varname) {
+      [](llvm::StringRef varname) {
         // Unnamed bit-fields are padding that we don't want to show.
-        return varname.GetLength();
+        return varname.size();
       };
   dump_options.SetChildPrintingDecider(decider).SetHideRootType(true);
 


### PR DESCRIPTION
There are 2 uses of ConstString in DumpValueObjectOptions: DeclPrintingHelper and ChildPrintingDecider, both being std::functions. The former takes 2 ConstString arguments and the latter takes just one.

These functions don't really need their arguments (type names, var names, register names) to actually be in a ConstString. For the most part, they are just printing the string out or otherwise analyzing it.