### PR TITLE
[clang] Don't mark a field invalid for unparsed in-class member initializer.

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -467,6 +467,11 @@ features cannot lower the translation-unit ABI level;
 - Fixed friend declarations sometimes making non-visible default arguments
   incorrectly visible to default argument redefinition checks across modules.
 
+- Fixed handling of SFINAE failures for expressions which depend on in-class
+  member initializers of templates which are not yet parsed. An example is
+  using ``__is_constructible`` on a nested class template inside the definition
+  of the containing class. (#GH215166)
+
 #### Bug Fixes to AST Handling
 
 - Fixed a non-deterministic ordering of unused local typedefs that made

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -5903,7 +5903,6 @@ ExprResult Sema::BuildCXXDefaultInitExpr(SourceLocation Loc, FieldDecl *Field) {
       if (!Pattern->hasInClassInitializer() ||
           InstantiateInClassInitializer(Loc, Field, Pattern,
                                         getTemplateInstantiationArgs(Field))) {
-        Field->setInvalidDecl();
         return ExprError();
       }
     }

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -3912,7 +3912,6 @@ bool Sema::InstantiateInClassInitializer(
         << OutermostClass << Pattern;
     Diag(Pattern->getEndLoc(),
          diag::note_default_member_initializer_not_yet_parsed);
-    Instantiation->setInvalidDecl();
     return true;
   }
 

--- a/clang/test/SemaCXX/cxx11-default-member-initializers.cpp
+++ b/clang/test/SemaCXX/cxx11-default-member-initializers.cpp
@@ -17,6 +17,20 @@ namespace PR31692 {
   static_assert(__is_constructible(A::X), "");
 }
 
+namespace PR215166 {
+  // Same as above, but with a class template.
+  struct A {
+    template<typename T> struct X { int n = 0; };
+    X<int> x;
+    // Trigger construction of X<int>() from a SFINAE context. This must not mark
+    // any part of X<int> as invalid.
+    static_assert(!__is_constructible(X<int>), "");
+    // Check that X<int>::n is not marked invalid.
+    double &r = x.n; // expected-error {{non-const lvalue reference to type 'double' cannot bind to a value of unrelated type 'int'}}
+  };
+  // A::X can now be default-constructed.
+  static_assert(__is_constructible(A::X<int>), "");
+}
 
 struct S {
 } constexpr s;


### PR DESCRIPTION
We delay parsing of in-class member initializers until the end of the outermost class declaration. It is an error for code to try to use that initializer before it's parsed.  However, sometimes that error can be suppressed by an SFINAE context.  Since we aren't sure a user-visible error will be emitted, don't mark the field invalid.

Fixes https://github.com/llvm/llvm-project/issues/215166 .