### PR TITLE
[lldb/test] Retry the remote platform connection in dotest

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -31,6 +31,7 @@ import signal
 import subprocess
 import sys
 import tempfile
+import time
 
 # Third-party modules
 import unittest
@@ -1135,14 +1136,31 @@ def run_suite():
             platform_connect_options = lldb.SBPlatformConnectOptions(
                 configuration.lldb_platform_url
             )
-            err = lldb.remote_platform.ConnectRemote(platform_connect_options)
+            # Connecting to a remote platform through a port forward can fail
+            # transiently while the connection itself is perfectly healthy, so
+            # retry a few times before giving up. Every attempt is reported, and
+            # a device that is genuinely unreachable still fails quickly with the
+            # same error on each attempt, so this doesn't hide a broken device.
+            max_connect_attempts = 4
+            for attempt in range(1, max_connect_attempts + 1):
+                err = lldb.remote_platform.ConnectRemote(platform_connect_options)
+                if err.Success():
+                    break
+                print(
+                    "error: failed to connect to remote platform using URL "
+                    "'%s': %s (attempt %d of %d)"
+                    % (
+                        configuration.lldb_platform_url,
+                        err,
+                        attempt,
+                        max_connect_attempts,
+                    )
+                )
+                if attempt < max_connect_attempts:
+                    time.sleep(attempt)
             if err.Success():
                 print("Connected.")
             else:
-                print(
-                    "error: failed to connect to remote platform using URL '%s': %s"
-                    % (configuration.lldb_platform_url, err)
-                )
                 exitTestSuite(1)
         else:
             configuration.lldb_platform_url = None


### PR DESCRIPTION
Connecting to a remote platform through port forwarding can fail transiently even when the device and the tunnel are healthy, which aborts the entire test suite run before a single test executes.

Retry the `ConnectRemote` call a few times with a short backoff before giving up. Each failed attempt is still printed with its attempt number, and a device that is genuinely unreachable fails with the same error on every attempt and then exits as before, so this does not mask a broken connection, it only adds a few seconds in that case.