### PR TITLE
[BOLT] Default heatmap block sizes to cache line, pages and hugepage

### DIFF
--- a/bolt/lib/Utils/CommandLineOpts.cpp
+++ b/bolt/lib/Utils/CommandLineOpts.cpp
@@ -218,10 +218,15 @@ cl::opt<opts::HeatmapBlockSizes, false, opts::HeatmapBlockSpecParser>
     HeatmapBlock(
         "block-size", cl::value_desc("initial_size{,zoom-out_size,...}"),
         cl::desc("heatmap bucket size, optionally followed by zoom-out sizes "
-                 "for coarse-grained heatmaps (default 64B, 4K, 256K)."),
+                 "for coarse-grained heatmaps (default 64, 4K, 16K, 64K, 2M)."),
+        // Cache line, then the page sizes x86-64 and AArch64 actually use
+        // (4K, and 16K/64K on AArch64), then the PMD hugepage above a 4K base
+        // page.
         cl::init(HeatmapBlockSizes{/*Initial*/ {64, "64"},
                                    /*Zoom-out*/ {4096, "4K"},
-                                   {262144, "256K"}}),
+                                   {16384, "16K"},
+                                   {65536, "64K"},
+                                   {2097152, "2M"}}),
         cl::cat(HeatmapCategory));
 
 cl::opt<int> HeatmapCdfPct(


### PR DESCRIPTION
The defaults were 64, 4K, 256K. 4K is the page size only on x86-64 and on
AArch64 kernels built that way; AArch64 also runs 16K and 64K base pages, and
256K corresponds to nothing in particular on either.

Use 64, 4K, 16K, 64K, 2M: the cache line, the three base page sizes in use, and
the PMD hugepage above a 4K base page. Each granularity then maps onto a real
capacity, which is what makes the working set numbers comparable to one -- L1i
lines, iTLB and L2 TLB entries, frontend region-table entries.

Two more granularities cost two more passes over an already-built map, no extra
decoding.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>