### PR TITLE
[BOLT] Report working set size from the heatmap

### DIFF
--- a/bolt/include/bolt/Utils/CommandLineOpts.h
+++ b/bolt/include/bolt/Utils/CommandLineOpts.h
@@ -94,6 +94,7 @@ extern llvm::cl::opt<HeatmapBlockSizes, false, HeatmapBlockSpecParser>
     HeatmapBlock;
 extern llvm::cl::opt<unsigned long long> HeatmapMaxAddress;
 extern llvm::cl::opt<unsigned long long> HeatmapMinAddress;
+extern llvm::cl::opt<int> HeatmapCdfPct;
 extern llvm::cl::opt<bool> HeatmapPrintMappings;
 extern llvm::cl::opt<std::string> HeatmapOutput;
 extern llvm::cl::opt<bool> HotData;

--- a/bolt/lib/Profile/DataAggregator.cpp
+++ b/bolt/lib/Profile/DataAggregator.cpp
@@ -1805,6 +1805,8 @@ std::error_code DataAggregator::printLBRHeatMap() {
       HM.print(opts::HeatmapOutput);
     else
       HM.print(formatv("{0}-{1}", opts::HeatmapOutput, NewBucketSize).str());
+    // Working set only; the table is emitted once, at the finest granularity.
+    HM.printCDF(nulls());
   }
 
   return std::error_code();

--- a/bolt/lib/Profile/Heatmap.cpp
+++ b/bolt/lib/Profile/Heatmap.cpp
@@ -278,15 +278,25 @@ void Heatmap::printCDF(raw_ostream &OS) const {
   double RatioRightInPercent = 100.0 / NumTotalCounts;
   uint64_t RunningCount = 0;
 
+  // Buckets covering the cutoff share of the samples.
+  const uint64_t CutOff = opts::HeatmapCdfPct;
+  assert(CutOff <= 1000000 && "cutoff must be at most 1000000");
+  const uint64_t Target = (NumTotalCounts * CutOff) / 1000000;
+  uint64_t NumBuckets = 0;
+
   OS << "Bucket counts, Size (KB), CDF (%)\n";
   for (uint64_t I = 0; I < Counts.size(); I++) {
     RunningCount += Counts[I];
+    if (!NumBuckets && RunningCount >= Target)
+      NumBuckets = I + 1;
     OS << format("%llu", (I + 1)) << ", "
        << format("%.4f", RatioLeftInKB * (I + 1)) << ", "
        << format("%.4f", RatioRightInPercent * (RunningCount)) << "\n";
   }
 
-  Counts.clear();
+  outs() << "HEATMAP: working set @ bucket size " << BucketSize << " p"
+         << format("%g", CutOff / 10000.0) << "/total: " << NumBuckets << "/"
+         << Counts.size() << '\n';
 }
 
 void Heatmap::printSectionHotness(StringRef FileName) const {

--- a/bolt/lib/Utils/CommandLineOpts.cpp
+++ b/bolt/lib/Utils/CommandLineOpts.cpp
@@ -220,6 +220,12 @@ cl::opt<opts::HeatmapBlockSizes, false, opts::HeatmapBlockSpecParser>
         cl::init(HeatmapBlockSizes{/*Initial*/ 64, /*Zoom-out*/ 4096, 262144}),
         cl::cat(HeatmapCategory));
 
+cl::opt<int> HeatmapCdfPct(
+    "heatmap-cdf-pct", cl::init(990000),
+    cl::desc("Sample CDF cutoff, in millionths, at which to report the working "
+             "set."),
+    cl::value_desc("n"), cl::cat(HeatmapCategory));
+
 cl::opt<unsigned long long> HeatmapMaxAddress(
     "max-address", cl::init(0xffffffff),
     cl::desc("maximum address considered valid for heatmap (default 4GB)"),

--- a/bolt/test/X86/heatmap-preagg.test
+++ b/bolt/test/X86/heatmap-preagg.test
@@ -40,9 +40,13 @@ CHECK-HEATMAP-BAT-1K-NOT: HEATMAP: dumping heatmap with bucket size
 CHECK-HEATMAP: PERF2BOLT: read 81 aggregated brstack entries
 CHECK-HEATMAP: HEATMAP: invalid traces: 1
 CHECK-HEATMAP: HEATMAP: dumping heatmap with bucket size 64
+CHECK-HEATMAP: HEATMAP: working set @ bucket size 64 p99/total: 28/43
 CHECK-HEATMAP: HEATMAP: dumping heatmap with bucket size 128
+CHECK-HEATMAP: HEATMAP: working set @ bucket size 128 p99/total: 16/23
 CHECK-HEATMAP: HEATMAP: dumping heatmap with bucket size 1024
+CHECK-HEATMAP: HEATMAP: working set @ bucket size 1024 p99/total: 3/3
 CHECK-HEATMAP-NOT: HEATMAP: dumping heatmap with bucket size
+CHECK-HEATMAP-NOT: HEATMAP: working set @ bucket size
 
 CHECK-SEC-HOT: Section Name, Begin Address, End Address, Percentage Hotness, Utilization Pct, Partition Score
 CHECK-SEC-HOT-NEXT: .init, 0x401000, 0x40101b, 16.8545, 100.0000, 0.1685


### PR DESCRIPTION
The heatmap produces a CDF (code coverage @ given sample pct), but only
writes it out as a table. Add two things:
1. Recompute CDF with scaled bucket sizes,
2. Log CDF at given sample pct (`-heatmap-cdf-pct` default p99) + total.

This effectively reports the code working set size (p99 and total),
expressed in units that map to uarch sizes: cache line (64B), base page
(4/16/64K), region table (2M), huge page (2M for PMD w/4K base), etc.

Sizes of interest can be specified using `-block-size=size1,size2,...`

Test Plan:
updated heatmap.test

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>