### PR TITLE
[HLSL][SemanticSignatures] Implement prefix stable packing

### DIFF
--- a/llvm/include/llvm/Frontend/HLSL/SemanticSignaturePacking.h
+++ b/llvm/include/llvm/Frontend/HLSL/SemanticSignaturePacking.h
@@ -33,13 +33,48 @@ static constexpr unsigned MaxSignatureCols = 4;
 static constexpr unsigned MaxClipCullRows = 2;
 static constexpr unsigned MaxGeometryStreams = 4;
 
+/// Denotes the element that could not be packed and why, so that the caller
+/// can report a diagnostic that points at the offending element.
+class SignaturePackingError : public ErrorInfo<SignaturePackingError> {
+public:
+  /// Denotes why an element could not be packed into its signature.
+  enum ErrorKind {
+    /// The element does not fit in the 32 rows of the signature.
+    SignatureOverflow,
+    /// The element does not fit in the two rows that are dedicated to clip and
+    /// cull distances.
+    ClipCullOverflow,
+  };
+
+  LLVM_ABI static char ID;
+
+  SignaturePackingError(ErrorKind Kind, unsigned ElementIndex)
+      : Kind(Kind), ElementIndex(ElementIndex) {}
+
+  ErrorKind getErrorKind() const { return Kind; }
+
+  /// Index into the Elements that were being packed.
+  unsigned getElementIndex() const { return ElementIndex; }
+
+  LLVM_ABI void log(raw_ostream &OS) const override;
+
+  std::error_code convertToErrorCode() const override {
+    return llvm::inconvertibleErrorCode();
+  }
+
+private:
+  ErrorKind Kind;
+  unsigned ElementIndex;
+};
+
 /// Iterates through Elements that belong to the signature described by
 /// ShaderStage and SignatureKind and 'packs' each element into 32 registers
 /// with 4 components by updating their StartRow and StartCol in place. An
 /// element is left unallocated if it is not part of the signature for the
 /// signature type.
 ///
-/// Returns an error if all eligible elements cannot all be placed.
+/// Returns a SignaturePackingError that denotes the first element that cannot
+/// be placed, or success if all eligible elements were placed.
 ///
 /// With the exception of some special cases listed below, the packing
 /// algorithm can be visualised as placing rectangles onto a grid of 32 rows and

--- a/llvm/include/llvm/Frontend/HLSL/SemanticSignaturePacking.h
+++ b/llvm/include/llvm/Frontend/HLSL/SemanticSignaturePacking.h
@@ -90,7 +90,7 @@ static constexpr unsigned MaxGeometryStreams = 4;
 /// most eight components spread over at most two rows; if any element
 /// covers multiple rows, the two dedicated rows must be adjacent. These rules
 /// do not apply when a ClipDistance or CullDistance SemanticKind is categorized
-/// as an arbitrary value for the signature point.
+/// as an arbitrary value.
 ///
 /// Tessellation Factor: An element denoting a tessellation factor that covers
 /// multiple rows is searched for only in the last column.

--- a/llvm/include/llvm/Frontend/HLSL/SemanticSignaturePacking.h
+++ b/llvm/include/llvm/Frontend/HLSL/SemanticSignaturePacking.h
@@ -30,6 +30,7 @@ enum class SemanticSignatureKind {
 
 static constexpr unsigned MaxSignatureRows = 32;
 static constexpr unsigned MaxSignatureCols = 4;
+static constexpr unsigned MaxClipCullRows = 2;
 
 /// Iterates through Elements that belong to the signature described by
 /// ShaderStage and SignatureKind and 'packs' each element into 32 registers

--- a/llvm/include/llvm/Frontend/HLSL/SemanticSignaturePacking.h
+++ b/llvm/include/llvm/Frontend/HLSL/SemanticSignaturePacking.h
@@ -28,6 +28,70 @@ enum class SemanticSignatureKind {
   PatchConstOrPrim,
 };
 
+/// Iterates through Elements that belong to the signature described by
+/// ShaderStage and SignatureKind and 'packs' each element into 32 registers
+/// with 4 components by updating their StartRow and StartCol in place. An
+/// element is left unallocated if it is not part of the signature for the
+/// signature type.
+///
+/// Returns an error if all eligible elements cannot all be placed.
+///
+/// With the exception of some special cases listed below, the packing
+/// algorithm can be visualised as placing rectangles onto a grid of 32 rows and
+/// 4 cols, where each element is placed at the first compatible row and can't
+/// be moved after. So each SemanticSignatureElement will cover the rectangle
+/// defined by its position of (StartCol, StartRow) and size of (Cols, Rows).
+///
+/// For example:
+///
+/// struct Foo {
+///   float3   A[3] : A;
+///   float1x2 B    : B; // column-major
+///   float2   C    : C;
+///   float    D    : D;
+/// };
+///
+/// Packs into:
+/// reg0: A[0].xyz | B[0][0].w
+/// reg1: A[1].xyz | B[0][1].w
+/// reg2: A[2].xyz | D.w
+/// reg3: C.xy     | unused.zw
+///
+/// As we can see, elements can be co-packed into the same register (row), this
+/// is restricted by the following:
+///
+/// Interpolation Mode: An element may only be placed in a row if its
+/// InterpMode is equivalent to all other non-Undefined InterpModes. This
+/// implies that if all InterpModes are undefined then it can be placed.
+///
+/// Component Width: An element may only be placed in a row if its CompType's
+/// bitwidth is equivalent. This is only applicable when UseNative16BitTypes is
+/// set and so half/float16_t/int16_t have a different bitwidth.
+///
+/// Component Order: An element may only be placed in a row if all existing
+/// elements have a lesser or equal semantic category, defined as follows:
+/// an arbitrary value (Foo) < a system value (SV_RenderTargetArrayIndex)
+/// < a system generated value (SV_PrimitiveID). These are internally
+/// categorized and are dependent on the ShaderStage and SignatureKind.
+///
+/// Dynamic Indexing: An element that covers more than one row may be indexed
+/// dynamically, which makes every row it covers dynamically indexable. System
+/// values and system generated values may not be placed in such a row.
+///
+/// Special Cases:
+///
+/// Clip and Cull Distances: Elements categorized as clip or cull distances are
+/// packed only with each other into dedicated rows. Together they may use at
+/// most eight components spread over at most two rows; if any element
+/// covers multiple rows, the two dedicated rows must be adjacent. These rules
+/// do not apply when a ClipDistance or CullDistance SemanticKind is categorized
+/// as an arbitrary value for the signature point.
+///
+/// Tessellation Factor: An element denoting a tessellation factor that covers
+/// multiple rows is searched for only in the last column.
+///
+/// Geometry Streams: For a geometry shader output signature, elements that
+/// carry different GSStream values are packed into independent grids.
 LLVM_ABI Error
 packSignaturePrefixStable(MutableArrayRef<SemanticSignatureElement> Elements,
                           Triple::EnvironmentType ShaderStage,

--- a/llvm/include/llvm/Frontend/HLSL/SemanticSignaturePacking.h
+++ b/llvm/include/llvm/Frontend/HLSL/SemanticSignaturePacking.h
@@ -31,6 +31,7 @@ enum class SemanticSignatureKind {
 static constexpr unsigned MaxSignatureRows = 32;
 static constexpr unsigned MaxSignatureCols = 4;
 static constexpr unsigned MaxClipCullRows = 2;
+static constexpr unsigned MaxGeometryStreams = 4;
 
 /// Iterates through Elements that belong to the signature described by
 /// ShaderStage and SignatureKind and 'packs' each element into 32 registers

--- a/llvm/include/llvm/Frontend/HLSL/SemanticSignaturePacking.h
+++ b/llvm/include/llvm/Frontend/HLSL/SemanticSignaturePacking.h
@@ -28,6 +28,9 @@ enum class SemanticSignatureKind {
   PatchConstOrPrim,
 };
 
+static constexpr unsigned MaxSignatureRows = 32;
+static constexpr unsigned MaxSignatureCols = 4;
+
 /// Iterates through Elements that belong to the signature described by
 /// ShaderStage and SignatureKind and 'packs' each element into 32 registers
 /// with 4 components by updating their StartRow and StartCol in place. An
@@ -92,11 +95,10 @@ enum class SemanticSignatureKind {
 ///
 /// Geometry Streams: For a geometry shader output signature, elements that
 /// carry different GSStream values are packed into independent grids.
-LLVM_ABI Error
-packSignaturePrefixStable(MutableArrayRef<SemanticSignatureElement> Elements,
-                          Triple::EnvironmentType ShaderStage,
-                          SemanticSignatureKind SignatureKind,
-                          bool UseNative16BitTypes);
+LLVM_ABI Error packSignaturePrefixStable(
+    MutableArrayRef<SemanticSignatureElement> Elements,
+    Triple::EnvironmentType ShaderStage, SemanticSignatureKind SignatureKind,
+    bool UseNative16BitTypes);
 
 } // namespace llvm::hlsl
 

--- a/llvm/include/llvm/Frontend/HLSL/SemanticSignaturePacking.h
+++ b/llvm/include/llvm/Frontend/HLSL/SemanticSignaturePacking.h
@@ -1,0 +1,39 @@
+//===- SemanticSignaturePacking.h - HLSL signature packing helpers -------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file This file declares helpers for packing HLSL semantic signatures.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_FRONTEND_HLSL_SEMANTICSIGNATUREPACKING_H
+#define LLVM_FRONTEND_HLSL_SEMANTICSIGNATUREPACKING_H
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/Frontend/HLSL/SemanticSignatures.h"
+#include "llvm/Support/Compiler.h"
+#include "llvm/Support/Error.h"
+#include "llvm/TargetParser/Triple.h"
+
+namespace llvm::hlsl {
+
+/// Identifies which signature associated with an entry point is being packed.
+enum class SemanticSignatureKind {
+  Input,
+  Output,
+  PatchConstOrPrim,
+};
+
+LLVM_ABI Error
+packSignaturePrefixStable(MutableArrayRef<SemanticSignatureElement> Elements,
+                          Triple::EnvironmentType ShaderStage,
+                          SemanticSignatureKind SignatureKind,
+                          bool UseNative16BitTypes);
+
+} // namespace llvm::hlsl
+
+#endif // LLVM_FRONTEND_HLSL_SEMANTICSIGNATUREPACKING_H

--- a/llvm/lib/Frontend/HLSL/CMakeLists.txt
+++ b/llvm/lib/Frontend/HLSL/CMakeLists.txt
@@ -5,6 +5,7 @@ add_llvm_component_library(LLVMFrontendHLSL
   HLSLRootSignature.cpp
   RootSignatureMetadata.cpp
   RootSignatureValidations.cpp
+  SemanticSignaturePacking.cpp
   SemanticSignatures.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/llvm/lib/Frontend/HLSL/SemanticSignaturePacking.cpp
+++ b/llvm/lib/Frontend/HLSL/SemanticSignaturePacking.cpp
@@ -227,8 +227,8 @@ getSemanticCategory(dxbc::PSV::SemanticKind SemanticKind,
     return SemanticCategory::NotPacked;
 
   // Semantics that are not yet supported by the frontend. As each semantic is
-  // added to the frontend, it should be moved out of this list and into the
-  // categorization above.
+  // added to the frontend and correctly gated in SemaHLSL, it should be moved
+  // out of this list and into the categorization above.
   case dxbc::PSV::SemanticKind::InstanceID:
   case dxbc::PSV::SemanticKind::ViewPortArrayIndex:
   case dxbc::PSV::SemanticKind::OutputControlPointID:

--- a/llvm/lib/Frontend/HLSL/SemanticSignaturePacking.cpp
+++ b/llvm/lib/Frontend/HLSL/SemanticSignaturePacking.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Frontend/HLSL/SemanticSignaturePacking.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/bit.h"
 #include <algorithm>
@@ -21,10 +22,19 @@
 using namespace llvm;
 using namespace llvm::hlsl;
 
-static constexpr StringLiteral SignatureOverflowMessage =
-    "signature elements do not fit in 32 rows";
-static constexpr StringLiteral ClipCullOverflowMessage =
-    "clip/cull elements do not fit in two rows";
+char SignaturePackingError::ID;
+
+void SignaturePackingError::log(raw_ostream &OS) const {
+  switch (Kind) {
+  case SignatureOverflow:
+    OS << "signature elements do not fit in 32 rows";
+    break;
+  case ClipCullOverflow:
+    OS << "clip/cull elements do not fit in two rows";
+    break;
+  }
+  OS << " (element " << ElementIndex << ")";
+}
 
 namespace {
 
@@ -332,10 +342,11 @@ static void placeAt(MutableArrayRef<SignatureRow> Rows, unsigned StartRow,
   }
 }
 
-// Packs Element into the first rows that it fits into.
-static Error packElement(SemanticSignatureElement &Element,
-                         MutableArrayRef<SignatureRow> Rows,
-                         const ElementPlacement &Placement) {
+// Packs Element into the first rows that it fits into. Returns whether it was
+// placed.
+static bool packElement(SemanticSignatureElement &Element,
+                        MutableArrayRef<SignatureRow> Rows,
+                        const ElementPlacement &Placement) {
   for (unsigned StartRow = 0; StartRow + Placement.Rows <= Rows.size();
        ++StartRow) {
     std::optional<uint8_t> ColumnMask = canPlaceAt(Rows, StartRow, Placement);
@@ -344,9 +355,9 @@ static Error packElement(SemanticSignatureElement &Element,
     placeAt(Rows, StartRow, Placement, *ColumnMask);
     Element.StartRow = StartRow;
     Element.StartCol = getStartColumn(*ColumnMask);
-    return Error::success();
+    return true;
   }
-  return createStringError(SignatureOverflowMessage);
+  return false;
 }
 
 // A clip/cull grid row is backed by a whole reserved signature row.
@@ -381,29 +392,31 @@ reserveNextClipCullRows(MutableArrayRef<SignatureRow> Rows,
 // Reserves the whole signature rows that back the clip/cull grid rows that the
 // element is packed into. Existing rows cannot be moved without breaking
 // prefix stability, so an indexed element requires them to be adjacent.
-static Error reserveClipCullSignatureRows(
-    MutableArrayRef<SignatureRow> SignatureRows, ClipCullState &State,
-    const ElementPlacement &Placement, unsigned NewRowsUsed) {
+static std::optional<SignaturePackingError::ErrorKind>
+reserveClipCullSignatureRows(MutableArrayRef<SignatureRow> SignatureRows,
+                             ClipCullState &State,
+                             const ElementPlacement &Placement,
+                             unsigned NewRowsUsed) {
   if (Placement.Rows == 1) {
     const ElementPlacement Reservation = getClipCullReservation(Placement, 1);
     for (unsigned Row = State.RowsUsed; Row < NewRowsUsed; ++Row) {
       std::optional<unsigned> StartRow =
           reserveNextClipCullRows(SignatureRows, Reservation);
       if (!StartRow)
-        return createStringError(SignatureOverflowMessage);
+        return SignaturePackingError::SignatureOverflow;
       State.SignatureRows[Row] = *StartRow;
     }
-    return Error::success();
+    return std::nullopt;
   }
 
   if (State.RowsUsed == 0) {
     std::optional<unsigned> StartRow = reserveNextClipCullRows(
         SignatureRows, getClipCullReservation(Placement, MaxClipCullRows));
     if (!StartRow)
-      return createStringError(SignatureOverflowMessage);
+      return SignaturePackingError::SignatureOverflow;
     State.SignatureRows[0] = *StartRow;
     State.SignatureRows[1] = *StartRow + 1;
-    return Error::success();
+    return std::nullopt;
   }
 
   if (State.RowsUsed == 1) {
@@ -411,20 +424,20 @@ static Error reserveClipCullSignatureRows(
     if (StartRow >= SignatureRows.size() ||
         !reserveClipCullRows(SignatureRows, StartRow,
                              getClipCullReservation(Placement, 1)))
-      return createStringError(SignatureOverflowMessage);
+      return SignaturePackingError::SignatureOverflow;
     State.SignatureRows[1] = StartRow;
-    return Error::success();
+    return std::nullopt;
   }
 
   if (State.SignatureRows[0] + 1 != State.SignatureRows[1])
-    return createStringError(ClipCullOverflowMessage);
-  return Error::success();
+    return SignaturePackingError::ClipCullOverflow;
+  return std::nullopt;
 }
 
-static Error packClipCullElement(SemanticSignatureElement &Element,
-                                 MutableArrayRef<SignatureRow> SignatureRows,
-                                 ClipCullState &State,
-                                 const ElementPlacement &Placement) {
+static std::optional<SignaturePackingError::ErrorKind>
+packClipCullElement(SemanticSignatureElement &Element,
+                    MutableArrayRef<SignatureRow> SignatureRows,
+                    ClipCullState &State, const ElementPlacement &Placement) {
   std::optional<uint8_t> ColumnMask;
   unsigned ClipCullStartRow = 0;
   while (ClipCullStartRow + Placement.Rows <= MaxClipCullRows) {
@@ -434,18 +447,19 @@ static Error packClipCullElement(SemanticSignatureElement &Element,
     ClipCullStartRow += 1;
   }
   if (!ColumnMask)
-    return createStringError(ClipCullOverflowMessage);
+    return SignaturePackingError::ClipCullOverflow;
 
   const unsigned NewRowsUsed = ClipCullStartRow + Placement.Rows;
-  if (Error E = reserveClipCullSignatureRows(SignatureRows, State, Placement,
-                                             NewRowsUsed))
-    return E;
+  if (std::optional<SignaturePackingError::ErrorKind> Kind =
+          reserveClipCullSignatureRows(SignatureRows, State, Placement,
+                                       NewRowsUsed))
+    return Kind;
 
   placeAt(State.Rows, ClipCullStartRow, Placement, *ColumnMask);
   State.RowsUsed = std::max(State.RowsUsed, NewRowsUsed);
   Element.StartRow = State.SignatureRows[ClipCullStartRow];
   Element.StartCol = getStartColumn(*ColumnMask);
-  return Error::success();
+  return std::nullopt;
 }
 
 Error llvm::hlsl::packSignaturePrefixStable(
@@ -462,7 +476,7 @@ Error llvm::hlsl::packSignaturePrefixStable(
   SmallVector<std::array<SignatureRow, MaxSignatureRows>, 1> Rows(StreamCount);
   SmallVector<ClipCullState, 1> ClipCullStates(StreamCount);
 
-  for (SemanticSignatureElement &Element : Elements) {
+  for (const auto &[Index, Element] : enumerate(Elements)) {
     assert(Element.StartRow == UnallocatedRow &&
            Element.StartCol == UnallocatedCol && "already allocated?");
     assert(Element.Rows > 0 && Element.Rows <= MaxSignatureRows &&
@@ -487,16 +501,20 @@ Error llvm::hlsl::packSignaturePrefixStable(
     case SemanticCategory::NotPacked:
       continue;
     case SemanticCategory::CullClip:
-      if (Error E = packClipCullElement(Element, StreamRows,
-                                        ClipCullStates[StreamIndex], Placement))
-        return E;
+      if (std::optional<SignaturePackingError::ErrorKind> Kind =
+              packClipCullElement(Element, StreamRows,
+                                  ClipCullStates[StreamIndex], Placement))
+        return make_error<SignaturePackingError>(*Kind,
+                                                 static_cast<unsigned>(Index));
       continue;
     case SemanticCategory::TessFactor:
     case SemanticCategory::Arbitrary:
     case SemanticCategory::SystemValue:
     case SemanticCategory::SystemGeneratedValue:
-      if (Error E = packElement(Element, StreamRows, Placement))
-        return E;
+      if (!packElement(Element, StreamRows, Placement))
+        return make_error<SignaturePackingError>(
+            SignaturePackingError::SignatureOverflow,
+            static_cast<unsigned>(Index));
       continue;
     }
   }

--- a/llvm/lib/Frontend/HLSL/SemanticSignaturePacking.cpp
+++ b/llvm/lib/Frontend/HLSL/SemanticSignaturePacking.cpp
@@ -14,6 +14,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/bit.h"
+#include "llvm/Support/ErrorHandling.h"
 #include <algorithm>
 #include <array>
 #include <cassert>
@@ -132,36 +133,47 @@ getSemanticCategory(dxbc::PSV::SemanticKind SemanticKind,
   case dxbc::PSV::SemanticKind::Arbitrary:
     switch (ShaderStage) {
     case Triple::EnvironmentType::Vertex:
+      // A vertex shader input element is laid out by the input assembler and
+      // not by this algorithm.
       return IsOutput ? SemanticCategory::Arbitrary
                       : SemanticCategory::NotPacked;
     case Triple::EnvironmentType::Hull:
     case Triple::EnvironmentType::Domain:
       return SemanticCategory::Arbitrary;
     case Triple::EnvironmentType::Geometry:
-      return IsPatchConstOrPrim ? SemanticCategory::NotPacked
-                                : SemanticCategory::Arbitrary;
+      assert(!IsPatchConstOrPrim && "a geometry shader has no patch constant "
+                                    "or primitive signature");
+      return SemanticCategory::Arbitrary;
     case Triple::EnvironmentType::Pixel:
-      return IsInput ? SemanticCategory::Arbitrary
-                     : SemanticCategory::NotPacked;
+      assert(IsInput && "an arbitrary semantic is not valid in a pixel shader "
+                        "output");
+      return SemanticCategory::Arbitrary;
     case Triple::EnvironmentType::Mesh:
-      return IsInput ? SemanticCategory::NotPacked
-                     : SemanticCategory::Arbitrary;
+      // A mesh shader has no input signature.
+      assert(!IsInput && "an arbitrary semantic is not valid in a mesh shader "
+                         "input");
+      return SemanticCategory::Arbitrary;
     default:
-      return SemanticCategory::NotPacked;
+      llvm_unreachable("arbitrary semantic is invalid for the shader stage");
     }
 
   case dxbc::PSV::SemanticKind::Position:
-    if (ShaderStage == Triple::EnvironmentType::Vertex)
+    switch (ShaderStage) {
+    case Triple::EnvironmentType::Vertex:
       return IsInput ? SemanticCategory::Arbitrary
                      : SemanticCategory::SystemValue;
-    return ShaderStage == Triple::EnvironmentType::Pixel && IsInput
-               ? SemanticCategory::SystemValue
-               : SemanticCategory::NotPacked;
+    case Triple::EnvironmentType::Pixel:
+      assert(IsInput && "position is not valid in a pixel shader output");
+      return SemanticCategory::SystemValue;
+    default:
+      llvm_unreachable("position semantic is not supported for the "
+                       "shader stage");
+    }
 
   case dxbc::PSV::SemanticKind::VertexID:
-    return ShaderStage == Triple::EnvironmentType::Vertex && IsInput
-               ? SemanticCategory::SystemValue
-               : SemanticCategory::NotPacked;
+    assert(ShaderStage == Triple::EnvironmentType::Vertex && IsInput &&
+           "vertex id is only valid in a vertex shader input");
+    return SemanticCategory::SystemValue;
 
   case dxbc::PSV::SemanticKind::RenderTargetArrayIndex:
     return SemanticCategory::SystemValue;
@@ -180,15 +192,22 @@ getSemanticCategory(dxbc::PSV::SemanticKind SemanticKind,
       return IsPatchConstOrPrim ? SemanticCategory::Arbitrary
                                 : SemanticCategory::CullClip;
     case Triple::EnvironmentType::Geometry:
-      return IsPatchConstOrPrim ? SemanticCategory::NotPacked
-                                : SemanticCategory::CullClip;
+      assert(!IsPatchConstOrPrim && "a geometry shader has no patch constant "
+                                    "or primitive signature");
+      return SemanticCategory::CullClip;
     case Triple::EnvironmentType::Pixel:
-      return IsInput ? SemanticCategory::CullClip : SemanticCategory::NotPacked;
+      assert(IsInput && "a clip/cull distance semantic is not valid in a pixel "
+                        "shader output");
+      return SemanticCategory::CullClip;
     case Triple::EnvironmentType::Mesh:
-      return IsOutput ? SemanticCategory::CullClip
-                      : SemanticCategory::NotPacked;
+      // A mesh shader has no input signature and a clip/cull distance is a
+      // vertex and not a primitive attribute.
+      assert(IsOutput && "a clip/cull distance semantic is only valid in a "
+                         "mesh shader output");
+      return SemanticCategory::CullClip;
     default:
-      return SemanticCategory::NotPacked;
+      llvm_unreachable("clip/cull distance semantic is invalid for the "
+                       "shader stage");
     }
 
   case dxbc::PSV::SemanticKind::TessFactor:
@@ -198,9 +217,8 @@ getSemanticCategory(dxbc::PSV::SemanticKind SemanticKind,
     return Rows > 1 ? SemanticCategory::TessFactor
                     : SemanticCategory::SystemValue;
 
-  // Semantics that are not packed into a signature register, either because
-  // they are accessed through a dedicated intrinsic, or because their location
-  // is not assigned by this algorithm.
+  // Semantics that are accessed through a dedicated intrinsic and so do not
+  // reserve any signature space.
   case dxbc::PSV::SemanticKind::SampleIndex:
   case dxbc::PSV::SemanticKind::DispatchThreadID:
   case dxbc::PSV::SemanticKind::GroupID:
@@ -208,11 +226,28 @@ getSemanticCategory(dxbc::PSV::SemanticKind SemanticKind,
   case dxbc::PSV::SemanticKind::GroupThreadID:
     return SemanticCategory::NotPacked;
 
-  // As each semantic is added to the frontend, it should be added to this
-  // categorization
-  default:
-    return SemanticCategory::NotPacked;
+  // Semantics that are not yet supported by the frontend. As each semantic is
+  // added to the frontend, it should be moved out of this list and into the
+  // categorization above.
+  case dxbc::PSV::SemanticKind::InstanceID:
+  case dxbc::PSV::SemanticKind::ViewPortArrayIndex:
+  case dxbc::PSV::SemanticKind::OutputControlPointID:
+  case dxbc::PSV::SemanticKind::DomainLocation:
+  case dxbc::PSV::SemanticKind::GSInstanceID:
+  case dxbc::PSV::SemanticKind::Coverage:
+  case dxbc::PSV::SemanticKind::InnerCoverage:
+  case dxbc::PSV::SemanticKind::Target:
+  case dxbc::PSV::SemanticKind::Depth:
+  case dxbc::PSV::SemanticKind::DepthLessEqual:
+  case dxbc::PSV::SemanticKind::DepthGreaterEqual:
+  case dxbc::PSV::SemanticKind::StencilRef:
+  case dxbc::PSV::SemanticKind::ViewID:
+  case dxbc::PSV::SemanticKind::Barycentrics:
+  case dxbc::PSV::SemanticKind::ShadingRate:
+  case dxbc::PSV::SemanticKind::CullPrimitive:
+    llvm_unreachable("semantic kind is not supported by the frontend");
   }
+  llvm_unreachable("invalid semantic kind");
 }
 
 static unsigned getComponentWidth(dxil::ElementType ComponentType,

--- a/llvm/lib/Frontend/HLSL/SemanticSignaturePacking.cpp
+++ b/llvm/lib/Frontend/HLSL/SemanticSignaturePacking.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Frontend/HLSL/SemanticSignaturePacking.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/bit.h"
 #include <algorithm>
 #include <array>
@@ -458,9 +459,8 @@ Error llvm::hlsl::packSignaturePrefixStable(
           ? MaxGeometryStreams
           : 1;
 
-  std::array<std::array<SignatureRow, MaxSignatureRows>, MaxGeometryStreams>
-      Rows;
-  std::array<ClipCullState, MaxGeometryStreams> ClipCullStates;
+  SmallVector<std::array<SignatureRow, MaxSignatureRows>, 1> Rows(StreamCount);
+  SmallVector<ClipCullState, 1> ClipCullStates(StreamCount);
 
   for (SemanticSignatureElement &Element : Elements) {
     assert(Element.StartRow == UnallocatedRow &&

--- a/llvm/lib/Frontend/HLSL/SemanticSignaturePacking.cpp
+++ b/llvm/lib/Frontend/HLSL/SemanticSignaturePacking.cpp
@@ -12,6 +12,7 @@
 
 #include "llvm/Frontend/HLSL/SemanticSignaturePacking.h"
 #include "llvm/ADT/bit.h"
+#include <algorithm>
 #include <array>
 #include <cassert>
 #include <optional>
@@ -24,6 +25,40 @@ static constexpr StringLiteral SignatureOverflowMessage =
 
 namespace {
 
+// The range of rows covered by a dynamically indexable element. Only an
+// element that covers multiple rows is dynamically indexable, so a single row
+// element has an empty range.
+struct IndexedRowRange {
+  uint8_t Begin = 0;
+  uint8_t End = 0;
+
+  static IndexedRowRange of(unsigned StartRow, unsigned RowCount) {
+    if (RowCount < 2)
+      return {};
+    return {static_cast<uint8_t>(StartRow),
+            static_cast<uint8_t>(StartRow + RowCount)};
+  }
+
+  bool isEmpty() const { return Begin == End; }
+
+  // An empty range is contained by every range.
+  bool contains(IndexedRowRange Other) const {
+    return Other.isEmpty() || (Begin <= Other.Begin && Other.End <= End);
+  }
+
+  IndexedRowRange unionWith(IndexedRowRange Other) const {
+    if (isEmpty())
+      return Other;
+    if (Other.isEmpty())
+      return *this;
+    return {std::min(Begin, Other.Begin), std::max(End, Other.End)};
+  }
+
+  bool operator==(IndexedRowRange Other) const {
+    return Begin == Other.Begin && End == Other.End;
+  }
+};
+
 // Categories are ordered by the component order they must be packed in, so an
 // element may only be co-packed to the right of a lesser or equal category.
 enum class SemanticCategory {
@@ -35,6 +70,8 @@ enum class SemanticCategory {
 
 struct SignatureRow {
   uint8_t OccupiedColumns = 0;
+  IndexedRowRange IndexedRange;
+  bool IndexedRangeFixed = false;
   unsigned ComponentWidth = 0;
   dxbc::PSV::InterpolationMode InterpMode =
       dxbc::PSV::InterpolationMode::Undefined;
@@ -100,9 +137,25 @@ static unsigned getComponentWidth(dxil::ElementType ComponentType,
   }
 }
 
-// Returns whether Placement may be co-packed into a Row that it covers.
+// Returns whether Placement may be co-packed into a Row that it covers, where
+// IndexedRange is the range of rows that it is dynamically indexed over.
 static bool canCoPack(const SignatureRow &Row,
-                      const ElementPlacement &Placement) {
+                      const ElementPlacement &Placement,
+                      IndexedRowRange IndexedRange) {
+  const bool IsSystemValue =
+      Placement.Category == SemanticCategory::SystemValue ||
+      Placement.Category == SemanticCategory::SystemGeneratedValue;
+
+  // A system value is never dynamically indexable, so it cannot be placed in a
+  // row that is.
+  if (IsSystemValue && !Row.IndexedRange.isEmpty())
+    return false;
+
+  // A row whose indexed range is fixed only accepts elements that are indexed
+  // within that range.
+  if (Row.IndexedRangeFixed && !Row.IndexedRange.contains(IndexedRange))
+    return false;
+
   if (Row.OccupiedColumns && Row.ComponentWidth != Placement.ComponentWidth)
     return false;
   if (Row.InterpMode != dxbc::PSV::InterpolationMode::Undefined &&
@@ -118,10 +171,12 @@ static bool canCoPack(const SignatureRow &Row,
 static std::optional<uint8_t> canPlaceAt(ArrayRef<SignatureRow> Rows,
                                          unsigned StartRow,
                                          const ElementPlacement &Placement) {
+  const IndexedRowRange IndexedRange =
+      IndexedRowRange::of(StartRow, Placement.Rows);
   uint8_t OccupiedColumns = 0;
   for (unsigned ElementRow = 0; ElementRow != Placement.Rows; ++ElementRow) {
     const SignatureRow &Row = Rows[StartRow + ElementRow];
-    if (!canCoPack(Row, Placement))
+    if (!canCoPack(Row, Placement, IndexedRange))
       return std::nullopt;
     OccupiedColumns |= Row.OccupiedColumns;
   }
@@ -138,6 +193,8 @@ static std::optional<uint8_t> canPlaceAt(ArrayRef<SignatureRow> Rows,
 
 static void placeAt(MutableArrayRef<SignatureRow> Rows, unsigned StartRow,
                     const ElementPlacement &Placement, uint8_t ColumnMask) {
+  const IndexedRowRange IndexedRange =
+      IndexedRowRange::of(StartRow, Placement.Rows);
   for (unsigned ElementRow = 0; ElementRow != Placement.Rows; ++ElementRow) {
     SignatureRow &Row = Rows[StartRow + ElementRow];
     const uint8_t PreviousOccupiedColumns = Row.OccupiedColumns;
@@ -149,6 +206,13 @@ static void placeAt(MutableArrayRef<SignatureRow> Rows, unsigned StartRow,
     // Non-overlapping masks compare according to their rightmost set bit.
     if (!PreviousOccupiedColumns || ColumnMask > PreviousOccupiedColumns)
       Row.RightmostCategory = Placement.Category;
+
+    Row.IndexedRange = Row.IndexedRange.unionWith(IndexedRange);
+    if (Placement.Category == SemanticCategory::SystemValue ||
+        Placement.Category == SemanticCategory::SystemGeneratedValue) {
+      assert(Row.IndexedRange == IndexedRange && "incompatible index range");
+      Row.IndexedRangeFixed = true;
+    }
   }
 }
 

--- a/llvm/lib/Frontend/HLSL/SemanticSignaturePacking.cpp
+++ b/llvm/lib/Frontend/HLSL/SemanticSignaturePacking.cpp
@@ -22,6 +22,8 @@ using namespace llvm::hlsl;
 
 static constexpr StringLiteral SignatureOverflowMessage =
     "signature elements do not fit in 32 rows";
+static constexpr StringLiteral ClipCullOverflowMessage =
+    "clip/cull elements do not fit in two rows";
 
 namespace {
 
@@ -66,6 +68,7 @@ enum class SemanticCategory {
   Arbitrary,
   SystemValue,
   SystemGeneratedValue,
+  CullClip,
   TessFactor,
 };
 
@@ -89,6 +92,15 @@ struct ElementPlacement {
   SemanticCategory Category;
 };
 
+// Clip/cull elements are first packed into an independent two-row grid. Each
+// row used in that grid maps to a whole reserved row in the signature.
+struct ClipCullState {
+  std::array<SignatureRow, MaxClipCullRows> Rows;
+  std::array<unsigned, MaxClipCullRows> SignatureRows = {UnallocatedRow,
+                                                         UnallocatedRow};
+  unsigned RowsUsed = 0;
+};
+
 } // namespace
 
 static uint8_t getStartColumn(uint8_t ColumnMask) {
@@ -97,7 +109,9 @@ static uint8_t getStartColumn(uint8_t ColumnMask) {
 }
 
 static SemanticCategory
-getSemanticCategory(dxbc::PSV::SemanticKind SemanticKind, unsigned Rows) {
+getSemanticCategory(dxbc::PSV::SemanticKind SemanticKind,
+                    Triple::EnvironmentType ShaderStage,
+                    SemanticSignatureKind SignatureKind, unsigned Rows) {
   switch (SemanticKind) {
   case dxbc::PSV::SemanticKind::Arbitrary:
     return SemanticCategory::Arbitrary;
@@ -107,6 +121,27 @@ getSemanticCategory(dxbc::PSV::SemanticKind SemanticKind, unsigned Rows) {
   case dxbc::PSV::SemanticKind::PrimitiveID:
   case dxbc::PSV::SemanticKind::IsFrontFace:
     return SemanticCategory::SystemGeneratedValue;
+  case dxbc::PSV::SemanticKind::ClipDistance:
+  case dxbc::PSV::SemanticKind::CullDistance:
+    if ((ShaderStage == Triple::EnvironmentType::Vertex &&
+         SignatureKind == SemanticSignatureKind::Input) ||
+        ((ShaderStage == Triple::EnvironmentType::Hull ||
+          ShaderStage == Triple::EnvironmentType::Domain) &&
+         SignatureKind == SemanticSignatureKind::PatchConstOrPrim))
+      return SemanticCategory::Arbitrary;
+    if ((ShaderStage == Triple::EnvironmentType::Vertex &&
+         SignatureKind == SemanticSignatureKind::Output) ||
+        ((ShaderStage == Triple::EnvironmentType::Hull ||
+          ShaderStage == Triple::EnvironmentType::Domain) &&
+         SignatureKind != SemanticSignatureKind::PatchConstOrPrim) ||
+        (ShaderStage == Triple::EnvironmentType::Geometry &&
+         SignatureKind == SemanticSignatureKind::Input) ||
+        (ShaderStage == Triple::EnvironmentType::Pixel &&
+         SignatureKind == SemanticSignatureKind::Input) ||
+        (ShaderStage == Triple::EnvironmentType::Mesh &&
+         SignatureKind == SemanticSignatureKind::Output))
+      return SemanticCategory::CullClip;
+    return SemanticCategory::NotPacked;
   case dxbc::PSV::SemanticKind::TessFactor:
   case dxbc::PSV::SemanticKind::InsideTessFactor:
     // Only a tess factor that covers multiple rows is dynamically indexable
@@ -258,10 +293,111 @@ static Error packElement(SemanticSignatureElement &Element,
   return createStringError(SignatureOverflowMessage);
 }
 
+// A clip/cull grid row is backed by a whole reserved signature row.
+static ElementPlacement
+getClipCullReservation(const ElementPlacement &Placement, unsigned RowCount) {
+  ElementPlacement Reservation = Placement;
+  Reservation.Rows = RowCount;
+  Reservation.Cols = MaxSignatureCols;
+  return Reservation;
+}
+
+static bool reserveClipCullRows(MutableArrayRef<SignatureRow> Rows,
+                                unsigned StartRow,
+                                const ElementPlacement &Reservation) {
+  std::optional<uint8_t> ColumnMask = canPlaceAt(Rows, StartRow, Reservation);
+  if (!ColumnMask)
+    return false;
+  placeAt(Rows, StartRow, Reservation, *ColumnMask);
+  return true;
+}
+
+static std::optional<unsigned>
+reserveNextClipCullRows(MutableArrayRef<SignatureRow> Rows,
+                        const ElementPlacement &Reservation) {
+  for (unsigned StartRow = 0; StartRow + Reservation.Rows <= Rows.size();
+       ++StartRow)
+    if (reserveClipCullRows(Rows, StartRow, Reservation))
+      return StartRow;
+  return std::nullopt;
+}
+
+// Reserves the whole signature rows that back the clip/cull grid rows that the
+// element is packed into. Existing rows cannot be moved without breaking
+// prefix stability, so an indexed element requires them to be adjacent.
+static Error reserveClipCullSignatureRows(
+    MutableArrayRef<SignatureRow> SignatureRows, ClipCullState &State,
+    const ElementPlacement &Placement, unsigned NewRowsUsed) {
+  if (Placement.Rows == 1) {
+    const ElementPlacement Reservation = getClipCullReservation(Placement, 1);
+    for (unsigned Row = State.RowsUsed; Row < NewRowsUsed; ++Row) {
+      std::optional<unsigned> StartRow =
+          reserveNextClipCullRows(SignatureRows, Reservation);
+      if (!StartRow)
+        return createStringError(SignatureOverflowMessage);
+      State.SignatureRows[Row] = *StartRow;
+    }
+    return Error::success();
+  }
+
+  if (State.RowsUsed == 0) {
+    std::optional<unsigned> StartRow = reserveNextClipCullRows(
+        SignatureRows, getClipCullReservation(Placement, MaxClipCullRows));
+    if (!StartRow)
+      return createStringError(SignatureOverflowMessage);
+    State.SignatureRows[0] = *StartRow;
+    State.SignatureRows[1] = *StartRow + 1;
+    return Error::success();
+  }
+
+  if (State.RowsUsed == 1) {
+    const unsigned StartRow = State.SignatureRows[0] + 1;
+    if (StartRow >= SignatureRows.size() ||
+        !reserveClipCullRows(SignatureRows, StartRow,
+                             getClipCullReservation(Placement, 1)))
+      return createStringError(SignatureOverflowMessage);
+    State.SignatureRows[1] = StartRow;
+    return Error::success();
+  }
+
+  if (State.SignatureRows[0] + 1 != State.SignatureRows[1])
+    return createStringError(ClipCullOverflowMessage);
+  return Error::success();
+}
+
+static Error packClipCullElement(SemanticSignatureElement &Element,
+                                 MutableArrayRef<SignatureRow> SignatureRows,
+                                 ClipCullState &State,
+                                 const ElementPlacement &Placement) {
+  std::optional<uint8_t> ColumnMask;
+  unsigned ClipCullStartRow = 0;
+  while (ClipCullStartRow + Placement.Rows <= MaxClipCullRows) {
+    ColumnMask = canPlaceAt(State.Rows, ClipCullStartRow, Placement);
+    if (ColumnMask)
+      break;
+    ClipCullStartRow += 1;
+  }
+  if (!ColumnMask)
+    return createStringError(ClipCullOverflowMessage);
+
+  const unsigned NewRowsUsed = ClipCullStartRow + Placement.Rows;
+  if (Error E = reserveClipCullSignatureRows(SignatureRows, State, Placement,
+                                             NewRowsUsed))
+    return E;
+
+  placeAt(State.Rows, ClipCullStartRow, Placement, *ColumnMask);
+  State.RowsUsed = std::max(State.RowsUsed, NewRowsUsed);
+  Element.StartRow = State.SignatureRows[ClipCullStartRow];
+  Element.StartCol = getStartColumn(*ColumnMask);
+  return Error::success();
+}
+
 Error llvm::hlsl::packSignaturePrefixStable(
-    MutableArrayRef<SemanticSignatureElement> Elements, Triple::EnvironmentType,
-    SemanticSignatureKind, bool UseNative16BitTypes) {
+    MutableArrayRef<SemanticSignatureElement> Elements,
+    Triple::EnvironmentType ShaderStage, SemanticSignatureKind SignatureKind,
+    bool UseNative16BitTypes) {
   std::array<SignatureRow, MaxSignatureRows> Rows;
+  ClipCullState ClipCull;
   for (SemanticSignatureElement &Element : Elements) {
     assert(Element.StartRow == UnallocatedRow &&
            Element.StartCol == UnallocatedCol && "already allocated?");
@@ -272,15 +408,27 @@ Error llvm::hlsl::packSignaturePrefixStable(
 
     const unsigned ComponentWidth =
         getComponentWidth(Element.CompType, UseNative16BitTypes);
-    const SemanticCategory Category =
-        getSemanticCategory(Element.SemanticKind, Element.Rows);
-    if (Category == SemanticCategory::NotPacked)
-      continue;
+    const SemanticCategory Category = getSemanticCategory(
+        Element.SemanticKind, ShaderStage, SignatureKind, Element.Rows);
     const ElementPlacement Placement = {Element.Rows, Element.Cols,
                                         ComponentWidth, Element.InterpMode,
                                         Category};
-    if (Error E = packElement(Element, Rows, Placement))
-      return E;
+
+    switch (Category) {
+    case SemanticCategory::NotPacked:
+      continue;
+    case SemanticCategory::CullClip:
+      if (Error E = packClipCullElement(Element, Rows, ClipCull, Placement))
+        return E;
+      continue;
+    case SemanticCategory::TessFactor:
+    case SemanticCategory::Arbitrary:
+    case SemanticCategory::SystemValue:
+    case SemanticCategory::SystemGeneratedValue:
+      if (Error E = packElement(Element, Rows, Placement))
+        return E;
+      continue;
+    }
   }
 
   return Error::success();

--- a/llvm/lib/Frontend/HLSL/SemanticSignaturePacking.cpp
+++ b/llvm/lib/Frontend/HLSL/SemanticSignaturePacking.cpp
@@ -396,8 +396,17 @@ Error llvm::hlsl::packSignaturePrefixStable(
     MutableArrayRef<SemanticSignatureElement> Elements,
     Triple::EnvironmentType ShaderStage, SemanticSignatureKind SignatureKind,
     bool UseNative16BitTypes) {
-  std::array<SignatureRow, MaxSignatureRows> Rows;
-  ClipCullState ClipCull;
+  // Only a geometry shader output signature packs its streams independently.
+  const unsigned StreamCount =
+      ShaderStage == Triple::EnvironmentType::Geometry &&
+              SignatureKind == SemanticSignatureKind::Output
+          ? MaxGeometryStreams
+          : 1;
+
+  std::array<std::array<SignatureRow, MaxSignatureRows>, MaxGeometryStreams>
+      Rows;
+  std::array<ClipCullState, MaxGeometryStreams> ClipCullStates;
+
   for (SemanticSignatureElement &Element : Elements) {
     assert(Element.StartRow == UnallocatedRow &&
            Element.StartCol == UnallocatedCol && "already allocated?");
@@ -405,6 +414,8 @@ Error llvm::hlsl::packSignaturePrefixStable(
            "signature element must have between 1 and 32 rows");
     assert(Element.Cols > 0 && Element.Cols <= MaxSignatureCols &&
            "signature element must have between 1 and 4 columns");
+    assert(Element.GSStream < StreamCount &&
+           "signature element has an unexpected geometry stream");
 
     const unsigned ComponentWidth =
         getComponentWidth(Element.CompType, UseNative16BitTypes);
@@ -414,18 +425,22 @@ Error llvm::hlsl::packSignaturePrefixStable(
                                         ComponentWidth, Element.InterpMode,
                                         Category};
 
+    const unsigned StreamIndex = StreamCount == 1 ? 0 : Element.GSStream;
+    MutableArrayRef<SignatureRow> StreamRows = Rows[StreamIndex];
+
     switch (Category) {
     case SemanticCategory::NotPacked:
       continue;
     case SemanticCategory::CullClip:
-      if (Error E = packClipCullElement(Element, Rows, ClipCull, Placement))
+      if (Error E = packClipCullElement(Element, StreamRows,
+                                        ClipCullStates[StreamIndex], Placement))
         return E;
       continue;
     case SemanticCategory::TessFactor:
     case SemanticCategory::Arbitrary:
     case SemanticCategory::SystemValue:
     case SemanticCategory::SystemGeneratedValue:
-      if (Error E = packElement(Element, Rows, Placement))
+      if (Error E = packElement(Element, StreamRows, Placement))
         return E;
       continue;
     }

--- a/llvm/lib/Frontend/HLSL/SemanticSignaturePacking.cpp
+++ b/llvm/lib/Frontend/HLSL/SemanticSignaturePacking.cpp
@@ -112,46 +112,95 @@ static SemanticCategory
 getSemanticCategory(dxbc::PSV::SemanticKind SemanticKind,
                     Triple::EnvironmentType ShaderStage,
                     SemanticSignatureKind SignatureKind, unsigned Rows) {
+  const bool IsInput = SignatureKind == SemanticSignatureKind::Input;
+  const bool IsOutput = SignatureKind == SemanticSignatureKind::Output;
+  const bool IsPatchConstOrPrim =
+      SignatureKind == SemanticSignatureKind::PatchConstOrPrim;
+
   switch (SemanticKind) {
   case dxbc::PSV::SemanticKind::Arbitrary:
-    return SemanticCategory::Arbitrary;
+    switch (ShaderStage) {
+    case Triple::EnvironmentType::Vertex:
+      return IsOutput ? SemanticCategory::Arbitrary
+                      : SemanticCategory::NotPacked;
+    case Triple::EnvironmentType::Hull:
+    case Triple::EnvironmentType::Domain:
+      return SemanticCategory::Arbitrary;
+    case Triple::EnvironmentType::Geometry:
+      return IsPatchConstOrPrim ? SemanticCategory::NotPacked
+                                : SemanticCategory::Arbitrary;
+    case Triple::EnvironmentType::Pixel:
+      return IsInput ? SemanticCategory::Arbitrary
+                     : SemanticCategory::NotPacked;
+    case Triple::EnvironmentType::Mesh:
+      return IsInput ? SemanticCategory::NotPacked
+                     : SemanticCategory::Arbitrary;
+    default:
+      return SemanticCategory::NotPacked;
+    }
+
   case dxbc::PSV::SemanticKind::Position:
+    if (ShaderStage == Triple::EnvironmentType::Vertex)
+      return IsInput ? SemanticCategory::Arbitrary
+                     : SemanticCategory::SystemValue;
+    return ShaderStage == Triple::EnvironmentType::Pixel && IsInput
+               ? SemanticCategory::SystemValue
+               : SemanticCategory::NotPacked;
+
+  case dxbc::PSV::SemanticKind::VertexID:
+    return ShaderStage == Triple::EnvironmentType::Vertex && IsInput
+               ? SemanticCategory::SystemValue
+               : SemanticCategory::NotPacked;
+
   case dxbc::PSV::SemanticKind::RenderTargetArrayIndex:
     return SemanticCategory::SystemValue;
+
   case dxbc::PSV::SemanticKind::PrimitiveID:
   case dxbc::PSV::SemanticKind::IsFrontFace:
     return SemanticCategory::SystemGeneratedValue;
+
   case dxbc::PSV::SemanticKind::ClipDistance:
   case dxbc::PSV::SemanticKind::CullDistance:
-    if ((ShaderStage == Triple::EnvironmentType::Vertex &&
-         SignatureKind == SemanticSignatureKind::Input) ||
-        ((ShaderStage == Triple::EnvironmentType::Hull ||
-          ShaderStage == Triple::EnvironmentType::Domain) &&
-         SignatureKind == SemanticSignatureKind::PatchConstOrPrim))
-      return SemanticCategory::Arbitrary;
-    if ((ShaderStage == Triple::EnvironmentType::Vertex &&
-         SignatureKind == SemanticSignatureKind::Output) ||
-        ((ShaderStage == Triple::EnvironmentType::Hull ||
-          ShaderStage == Triple::EnvironmentType::Domain) &&
-         SignatureKind != SemanticSignatureKind::PatchConstOrPrim) ||
-        (ShaderStage == Triple::EnvironmentType::Geometry &&
-         SignatureKind == SemanticSignatureKind::Input) ||
-        (ShaderStage == Triple::EnvironmentType::Pixel &&
-         SignatureKind == SemanticSignatureKind::Input) ||
-        (ShaderStage == Triple::EnvironmentType::Mesh &&
-         SignatureKind == SemanticSignatureKind::Output))
-      return SemanticCategory::CullClip;
-    return SemanticCategory::NotPacked;
+    switch (ShaderStage) {
+    case Triple::EnvironmentType::Vertex:
+      return IsInput ? SemanticCategory::Arbitrary : SemanticCategory::CullClip;
+    case Triple::EnvironmentType::Hull:
+    case Triple::EnvironmentType::Domain:
+      return IsPatchConstOrPrim ? SemanticCategory::Arbitrary
+                                : SemanticCategory::CullClip;
+    case Triple::EnvironmentType::Geometry:
+      return IsPatchConstOrPrim ? SemanticCategory::NotPacked
+                                : SemanticCategory::CullClip;
+    case Triple::EnvironmentType::Pixel:
+      return IsInput ? SemanticCategory::CullClip : SemanticCategory::NotPacked;
+    case Triple::EnvironmentType::Mesh:
+      return IsOutput ? SemanticCategory::CullClip
+                      : SemanticCategory::NotPacked;
+    default:
+      return SemanticCategory::NotPacked;
+    }
+
   case dxbc::PSV::SemanticKind::TessFactor:
   case dxbc::PSV::SemanticKind::InsideTessFactor:
     // Only a tess factor that covers multiple rows is dynamically indexable
     // and needs to be reserved in the last column.
     return Rows > 1 ? SemanticCategory::TessFactor
                     : SemanticCategory::SystemValue;
+
+  // Semantics that are not packed into a signature register, either because
+  // they are accessed through a dedicated intrinsic, or because their location
+  // is not assigned by this algorithm.
   case dxbc::PSV::SemanticKind::SampleIndex:
+  case dxbc::PSV::SemanticKind::DispatchThreadID:
+  case dxbc::PSV::SemanticKind::GroupID:
+  case dxbc::PSV::SemanticKind::GroupIndex:
+  case dxbc::PSV::SemanticKind::GroupThreadID:
     return SemanticCategory::NotPacked;
+
+  // As each semantic is added to the frontend, it should be added to this
+  // categorization
   default:
-    return SemanticCategory::Arbitrary;
+    return SemanticCategory::NotPacked;
   }
 }
 
@@ -206,13 +255,19 @@ static bool canCoPack(const SignatureRow &Row,
 
   if (Row.OccupiedColumns && Row.ComponentWidth != Placement.ComponentWidth)
     return false;
+
   if (Row.InterpMode != dxbc::PSV::InterpolationMode::Undefined &&
       Row.InterpMode != Placement.InterpMode)
     return false;
+
+  // Elements are packed in category order, so an element may not be placed to
+  // the left of a greater category. An indexed tess factor is an exception as
+  // it is reserved in the last column.
   if (Row.OccupiedColumns && Placement.Category < Row.RightmostCategory &&
       !(Placement.Category == SemanticCategory::Arbitrary &&
         Row.RightmostCategory == SemanticCategory::TessFactor))
     return false;
+
   return true;
 }
 

--- a/llvm/lib/Frontend/HLSL/SemanticSignaturePacking.cpp
+++ b/llvm/lib/Frontend/HLSL/SemanticSignaturePacking.cpp
@@ -66,6 +66,7 @@ enum class SemanticCategory {
   Arbitrary,
   SystemValue,
   SystemGeneratedValue,
+  TessFactor,
 };
 
 struct SignatureRow {
@@ -96,7 +97,7 @@ static uint8_t getStartColumn(uint8_t ColumnMask) {
 }
 
 static SemanticCategory
-getSemanticCategory(dxbc::PSV::SemanticKind SemanticKind) {
+getSemanticCategory(dxbc::PSV::SemanticKind SemanticKind, unsigned Rows) {
   switch (SemanticKind) {
   case dxbc::PSV::SemanticKind::Arbitrary:
     return SemanticCategory::Arbitrary;
@@ -106,6 +107,12 @@ getSemanticCategory(dxbc::PSV::SemanticKind SemanticKind) {
   case dxbc::PSV::SemanticKind::PrimitiveID:
   case dxbc::PSV::SemanticKind::IsFrontFace:
     return SemanticCategory::SystemGeneratedValue;
+  case dxbc::PSV::SemanticKind::TessFactor:
+  case dxbc::PSV::SemanticKind::InsideTessFactor:
+    // Only a tess factor that covers multiple rows is dynamically indexable
+    // and needs to be reserved in the last column.
+    return Rows > 1 ? SemanticCategory::TessFactor
+                    : SemanticCategory::SystemValue;
   case dxbc::PSV::SemanticKind::SampleIndex:
     return SemanticCategory::NotPacked;
   default:
@@ -156,12 +163,20 @@ static bool canCoPack(const SignatureRow &Row,
   if (Row.IndexedRangeFixed && !Row.IndexedRange.contains(IndexedRange))
     return false;
 
+  // A tess factor fixes the indexed range of the rows it is reserved in, so it
+  // may only extend the range that those rows already have.
+  if (Placement.Category == SemanticCategory::TessFactor &&
+      !IndexedRange.contains(Row.IndexedRange))
+    return false;
+
   if (Row.OccupiedColumns && Row.ComponentWidth != Placement.ComponentWidth)
     return false;
   if (Row.InterpMode != dxbc::PSV::InterpolationMode::Undefined &&
       Row.InterpMode != Placement.InterpMode)
     return false;
-  if (Row.OccupiedColumns && Placement.Category < Row.RightmostCategory)
+  if (Row.OccupiedColumns && Placement.Category < Row.RightmostCategory &&
+      !(Placement.Category == SemanticCategory::Arbitrary &&
+        Row.RightmostCategory == SemanticCategory::TessFactor))
     return false;
   return true;
 }
@@ -179,6 +194,15 @@ static std::optional<uint8_t> canPlaceAt(ArrayRef<SignatureRow> Rows,
     if (!canCoPack(Row, Placement, IndexedRange))
       return std::nullopt;
     OccupiedColumns |= Row.OccupiedColumns;
+  }
+
+  // An indexed tess factor is reserved in the last column so that other
+  // elements can still be co-packed into the rows that it covers.
+  if (Placement.Category == SemanticCategory::TessFactor) {
+    constexpr uint8_t LastColumn = 1U << (MaxSignatureCols - 1);
+    if (Placement.Cols != 1 || (OccupiedColumns & LastColumn))
+      return std::nullopt;
+    return LastColumn;
   }
 
   for (unsigned StartCol = 0; StartCol + Placement.Cols <= MaxSignatureCols;
@@ -209,7 +233,8 @@ static void placeAt(MutableArrayRef<SignatureRow> Rows, unsigned StartRow,
 
     Row.IndexedRange = Row.IndexedRange.unionWith(IndexedRange);
     if (Placement.Category == SemanticCategory::SystemValue ||
-        Placement.Category == SemanticCategory::SystemGeneratedValue) {
+        Placement.Category == SemanticCategory::SystemGeneratedValue ||
+        Placement.Category == SemanticCategory::TessFactor) {
       assert(Row.IndexedRange == IndexedRange && "incompatible index range");
       Row.IndexedRangeFixed = true;
     }
@@ -247,7 +272,8 @@ Error llvm::hlsl::packSignaturePrefixStable(
 
     const unsigned ComponentWidth =
         getComponentWidth(Element.CompType, UseNative16BitTypes);
-    const SemanticCategory Category = getSemanticCategory(Element.SemanticKind);
+    const SemanticCategory Category =
+        getSemanticCategory(Element.SemanticKind, Element.Rows);
     if (Category == SemanticCategory::NotPacked)
       continue;
     const ElementPlacement Placement = {Element.Rows, Element.Cols,

--- a/llvm/lib/Frontend/HLSL/SemanticSignaturePacking.cpp
+++ b/llvm/lib/Frontend/HLSL/SemanticSignaturePacking.cpp
@@ -1,0 +1,22 @@
+//===- SemanticSignaturePacking.cpp - HLSL signature packing helpers -----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file This file implements helpers for packing HLSL semantic signatures.
+///
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Frontend/HLSL/SemanticSignaturePacking.h"
+
+using namespace llvm;
+using namespace llvm::hlsl;
+
+Error llvm::hlsl::packSignaturePrefixStable(
+    MutableArrayRef<SemanticSignatureElement>, Triple::EnvironmentType,
+    SemanticSignatureKind, bool) {
+  return Error::success();
+}

--- a/llvm/lib/Frontend/HLSL/SemanticSignaturePacking.cpp
+++ b/llvm/lib/Frontend/HLSL/SemanticSignaturePacking.cpp
@@ -24,11 +24,21 @@ static constexpr StringLiteral SignatureOverflowMessage =
 
 namespace {
 
+// Categories are ordered by the component order they must be packed in, so an
+// element may only be co-packed to the right of a lesser or equal category.
+enum class SemanticCategory {
+  NotPacked,
+  Arbitrary,
+  SystemValue,
+  SystemGeneratedValue,
+};
+
 struct SignatureRow {
   uint8_t OccupiedColumns = 0;
   unsigned ComponentWidth = 0;
   dxbc::PSV::InterpolationMode InterpMode =
       dxbc::PSV::InterpolationMode::Undefined;
+  SemanticCategory RightmostCategory = SemanticCategory::Arbitrary;
 };
 
 // Everything the packing rules need to know about the element that is being
@@ -38,6 +48,7 @@ struct ElementPlacement {
   unsigned Cols;
   unsigned ComponentWidth;
   dxbc::PSV::InterpolationMode InterpMode;
+  SemanticCategory Category;
 };
 
 } // namespace
@@ -45,6 +56,24 @@ struct ElementPlacement {
 static uint8_t getStartColumn(uint8_t ColumnMask) {
   assert(ColumnMask != 0 && "expected at least one occupied column");
   return countr_zero(ColumnMask);
+}
+
+static SemanticCategory
+getSemanticCategory(dxbc::PSV::SemanticKind SemanticKind) {
+  switch (SemanticKind) {
+  case dxbc::PSV::SemanticKind::Arbitrary:
+    return SemanticCategory::Arbitrary;
+  case dxbc::PSV::SemanticKind::Position:
+  case dxbc::PSV::SemanticKind::RenderTargetArrayIndex:
+    return SemanticCategory::SystemValue;
+  case dxbc::PSV::SemanticKind::PrimitiveID:
+  case dxbc::PSV::SemanticKind::IsFrontFace:
+    return SemanticCategory::SystemGeneratedValue;
+  case dxbc::PSV::SemanticKind::SampleIndex:
+    return SemanticCategory::NotPacked;
+  default:
+    return SemanticCategory::Arbitrary;
+  }
 }
 
 static unsigned getComponentWidth(dxil::ElementType ComponentType,
@@ -79,6 +108,8 @@ static bool canCoPack(const SignatureRow &Row,
   if (Row.InterpMode != dxbc::PSV::InterpolationMode::Undefined &&
       Row.InterpMode != Placement.InterpMode)
     return false;
+  if (Row.OccupiedColumns && Placement.Category < Row.RightmostCategory)
+    return false;
   return true;
 }
 
@@ -109,11 +140,15 @@ static void placeAt(MutableArrayRef<SignatureRow> Rows, unsigned StartRow,
                     const ElementPlacement &Placement, uint8_t ColumnMask) {
   for (unsigned ElementRow = 0; ElementRow != Placement.Rows; ++ElementRow) {
     SignatureRow &Row = Rows[StartRow + ElementRow];
-    if (!Row.OccupiedColumns)
+    const uint8_t PreviousOccupiedColumns = Row.OccupiedColumns;
+    if (!PreviousOccupiedColumns)
       Row.ComponentWidth = Placement.ComponentWidth;
     Row.OccupiedColumns |= ColumnMask;
     if (Row.InterpMode == dxbc::PSV::InterpolationMode::Undefined)
       Row.InterpMode = Placement.InterpMode;
+    // Non-overlapping masks compare according to their rightmost set bit.
+    if (!PreviousOccupiedColumns || ColumnMask > PreviousOccupiedColumns)
+      Row.RightmostCategory = Placement.Category;
   }
 }
 
@@ -148,8 +183,12 @@ Error llvm::hlsl::packSignaturePrefixStable(
 
     const unsigned ComponentWidth =
         getComponentWidth(Element.CompType, UseNative16BitTypes);
+    const SemanticCategory Category = getSemanticCategory(Element.SemanticKind);
+    if (Category == SemanticCategory::NotPacked)
+      continue;
     const ElementPlacement Placement = {Element.Rows, Element.Cols,
-                                        ComponentWidth, Element.InterpMode};
+                                        ComponentWidth, Element.InterpMode,
+                                        Category};
     if (Error E = packElement(Element, Rows, Placement))
       return E;
   }

--- a/llvm/lib/Frontend/HLSL/SemanticSignaturePacking.cpp
+++ b/llvm/lib/Frontend/HLSL/SemanticSignaturePacking.cpp
@@ -26,6 +26,18 @@ namespace {
 
 struct SignatureRow {
   uint8_t OccupiedColumns = 0;
+  unsigned ComponentWidth = 0;
+  dxbc::PSV::InterpolationMode InterpMode =
+      dxbc::PSV::InterpolationMode::Undefined;
+};
+
+// Everything the packing rules need to know about the element that is being
+// placed. It applies to every row that the element covers.
+struct ElementPlacement {
+  unsigned Rows;
+  unsigned Cols;
+  unsigned ComponentWidth;
+  dxbc::PSV::InterpolationMode InterpMode;
 };
 
 } // namespace
@@ -35,36 +47,97 @@ static uint8_t getStartColumn(uint8_t ColumnMask) {
   return countr_zero(ColumnMask);
 }
 
-static std::optional<uint8_t> canPlaceElement(ArrayRef<SignatureRow> Rows,
-                                              unsigned StartRow,
-                                              unsigned RowCount,
-                                              unsigned ColumnCount) {
-  uint8_t OccupiedColumns = 0;
-  for (unsigned ElementRow = 0; ElementRow != RowCount; ++ElementRow)
-    OccupiedColumns |= Rows[StartRow + ElementRow].OccupiedColumns;
+static unsigned getComponentWidth(dxil::ElementType ComponentType,
+                                  bool UseNative16BitTypes) {
+  assert(ComponentType != dxil::ElementType::I64 &&
+         ComponentType != dxil::ElementType::U64 &&
+         ComponentType != dxil::ElementType::F64 &&
+         ComponentType != dxil::ElementType::SNormF64 &&
+         ComponentType != dxil::ElementType::UNormF64 &&
+         "64-bit types cannot be used in a signature");
 
-  for (unsigned StartCol = 0; StartCol + ColumnCount <= MaxSignatureCols;
+  switch (ComponentType) {
+  case dxil::ElementType::F16:
+  case dxil::ElementType::I16:
+  case dxil::ElementType::U16:
+  case dxil::ElementType::SNormF16:
+  case dxil::ElementType::UNormF16:
+    // Without native 16-bit types these are min-precision types that occupy a
+    // whole 32-bit component.
+    return UseNative16BitTypes ? 16 : 32;
+  default:
+    // A boolean is loaded and stored as a 32-bit value.
+    return 32;
+  }
+}
+
+// Returns whether Placement may be co-packed into a Row that it covers.
+static bool canCoPack(const SignatureRow &Row,
+                      const ElementPlacement &Placement) {
+  if (Row.OccupiedColumns && Row.ComponentWidth != Placement.ComponentWidth)
+    return false;
+  if (Row.InterpMode != dxbc::PSV::InterpolationMode::Undefined &&
+      Row.InterpMode != Placement.InterpMode)
+    return false;
+  return true;
+}
+
+// Returns the columns that Placement would occupy if it was placed at StartRow,
+// or nullopt if it cannot be placed there.
+static std::optional<uint8_t> canPlaceAt(ArrayRef<SignatureRow> Rows,
+                                         unsigned StartRow,
+                                         const ElementPlacement &Placement) {
+  uint8_t OccupiedColumns = 0;
+  for (unsigned ElementRow = 0; ElementRow != Placement.Rows; ++ElementRow) {
+    const SignatureRow &Row = Rows[StartRow + ElementRow];
+    if (!canCoPack(Row, Placement))
+      return std::nullopt;
+    OccupiedColumns |= Row.OccupiedColumns;
+  }
+
+  for (unsigned StartCol = 0; StartCol + Placement.Cols <= MaxSignatureCols;
        ++StartCol) {
     const uint8_t ColumnMask =
-        static_cast<uint8_t>(((1U << ColumnCount) - 1U) << StartCol);
+        static_cast<uint8_t>(((1U << Placement.Cols) - 1U) << StartCol);
     if (!(OccupiedColumns & ColumnMask))
       return ColumnMask;
   }
   return std::nullopt;
 }
 
-static void placeElement(MutableArrayRef<SignatureRow> Rows, unsigned StartRow,
-                         unsigned RowCount, uint8_t ColumnMask) {
-  for (unsigned ElementRow = 0; ElementRow != RowCount; ++ElementRow)
-    Rows[StartRow + ElementRow].OccupiedColumns |= ColumnMask;
+static void placeAt(MutableArrayRef<SignatureRow> Rows, unsigned StartRow,
+                    const ElementPlacement &Placement, uint8_t ColumnMask) {
+  for (unsigned ElementRow = 0; ElementRow != Placement.Rows; ++ElementRow) {
+    SignatureRow &Row = Rows[StartRow + ElementRow];
+    if (!Row.OccupiedColumns)
+      Row.ComponentWidth = Placement.ComponentWidth;
+    Row.OccupiedColumns |= ColumnMask;
+    if (Row.InterpMode == dxbc::PSV::InterpolationMode::Undefined)
+      Row.InterpMode = Placement.InterpMode;
+  }
+}
+
+// Packs Element into the first rows that it fits into.
+static Error packElement(SemanticSignatureElement &Element,
+                         MutableArrayRef<SignatureRow> Rows,
+                         const ElementPlacement &Placement) {
+  for (unsigned StartRow = 0; StartRow + Placement.Rows <= Rows.size();
+       ++StartRow) {
+    std::optional<uint8_t> ColumnMask = canPlaceAt(Rows, StartRow, Placement);
+    if (!ColumnMask)
+      continue;
+    placeAt(Rows, StartRow, Placement, *ColumnMask);
+    Element.StartRow = StartRow;
+    Element.StartCol = getStartColumn(*ColumnMask);
+    return Error::success();
+  }
+  return createStringError(SignatureOverflowMessage);
 }
 
 Error llvm::hlsl::packSignaturePrefixStable(
     MutableArrayRef<SemanticSignatureElement> Elements, Triple::EnvironmentType,
     SemanticSignatureKind, bool UseNative16BitTypes) {
-  (void)UseNative16BitTypes;
-
-  std::array<SignatureRow, MaxSignatureRows> Rows{};
+  std::array<SignatureRow, MaxSignatureRows> Rows;
   for (SemanticSignatureElement &Element : Elements) {
     assert(Element.StartRow == UnallocatedRow &&
            Element.StartCol == UnallocatedCol && "already allocated?");
@@ -73,23 +146,12 @@ Error llvm::hlsl::packSignaturePrefixStable(
     assert(Element.Cols > 0 && Element.Cols <= MaxSignatureCols &&
            "signature element must have between 1 and 4 columns");
 
-    bool Placed = false;
-    for (unsigned StartRow = 0; StartRow + Element.Rows <= MaxSignatureRows;
-         ++StartRow) {
-      std::optional<uint8_t> ColumnMask =
-          canPlaceElement(Rows, StartRow, Element.Rows, Element.Cols);
-      if (!ColumnMask)
-        continue;
-
-      placeElement(Rows, StartRow, Element.Rows, *ColumnMask);
-      Element.StartRow = StartRow;
-      Element.StartCol = getStartColumn(*ColumnMask);
-      Placed = true;
-      break;
-    }
-
-    if (!Placed)
-      return createStringError(SignatureOverflowMessage);
+    const unsigned ComponentWidth =
+        getComponentWidth(Element.CompType, UseNative16BitTypes);
+    const ElementPlacement Placement = {Element.Rows, Element.Cols,
+                                        ComponentWidth, Element.InterpMode};
+    if (Error E = packElement(Element, Rows, Placement))
+      return E;
   }
 
   return Error::success();

--- a/llvm/lib/Frontend/HLSL/SemanticSignaturePacking.cpp
+++ b/llvm/lib/Frontend/HLSL/SemanticSignaturePacking.cpp
@@ -11,12 +11,86 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Frontend/HLSL/SemanticSignaturePacking.h"
+#include "llvm/ADT/bit.h"
+#include <array>
+#include <cassert>
+#include <optional>
 
 using namespace llvm;
 using namespace llvm::hlsl;
 
+static constexpr StringLiteral SignatureOverflowMessage =
+    "signature elements do not fit in 32 rows";
+
+namespace {
+
+struct SignatureRow {
+  uint8_t OccupiedColumns = 0;
+};
+
+} // namespace
+
+static uint8_t getStartColumn(uint8_t ColumnMask) {
+  assert(ColumnMask != 0 && "expected at least one occupied column");
+  return countr_zero(ColumnMask);
+}
+
+static std::optional<uint8_t> canPlaceElement(ArrayRef<SignatureRow> Rows,
+                                              unsigned StartRow,
+                                              unsigned RowCount,
+                                              unsigned ColumnCount) {
+  uint8_t OccupiedColumns = 0;
+  for (unsigned ElementRow = 0; ElementRow != RowCount; ++ElementRow)
+    OccupiedColumns |= Rows[StartRow + ElementRow].OccupiedColumns;
+
+  for (unsigned StartCol = 0; StartCol + ColumnCount <= MaxSignatureCols;
+       ++StartCol) {
+    const uint8_t ColumnMask =
+        static_cast<uint8_t>(((1U << ColumnCount) - 1U) << StartCol);
+    if (!(OccupiedColumns & ColumnMask))
+      return ColumnMask;
+  }
+  return std::nullopt;
+}
+
+static void placeElement(MutableArrayRef<SignatureRow> Rows, unsigned StartRow,
+                         unsigned RowCount, uint8_t ColumnMask) {
+  for (unsigned ElementRow = 0; ElementRow != RowCount; ++ElementRow)
+    Rows[StartRow + ElementRow].OccupiedColumns |= ColumnMask;
+}
+
 Error llvm::hlsl::packSignaturePrefixStable(
-    MutableArrayRef<SemanticSignatureElement>, Triple::EnvironmentType,
-    SemanticSignatureKind, bool) {
+    MutableArrayRef<SemanticSignatureElement> Elements, Triple::EnvironmentType,
+    SemanticSignatureKind, bool UseNative16BitTypes) {
+  (void)UseNative16BitTypes;
+
+  std::array<SignatureRow, MaxSignatureRows> Rows{};
+  for (SemanticSignatureElement &Element : Elements) {
+    assert(Element.StartRow == UnallocatedRow &&
+           Element.StartCol == UnallocatedCol && "already allocated?");
+    assert(Element.Rows > 0 && Element.Rows <= MaxSignatureRows &&
+           "signature element must have between 1 and 32 rows");
+    assert(Element.Cols > 0 && Element.Cols <= MaxSignatureCols &&
+           "signature element must have between 1 and 4 columns");
+
+    bool Placed = false;
+    for (unsigned StartRow = 0; StartRow + Element.Rows <= MaxSignatureRows;
+         ++StartRow) {
+      std::optional<uint8_t> ColumnMask =
+          canPlaceElement(Rows, StartRow, Element.Rows, Element.Cols);
+      if (!ColumnMask)
+        continue;
+
+      placeElement(Rows, StartRow, Element.Rows, *ColumnMask);
+      Element.StartRow = StartRow;
+      Element.StartCol = getStartColumn(*ColumnMask);
+      Placed = true;
+      break;
+    }
+
+    if (!Placed)
+      return createStringError(SignatureOverflowMessage);
+  }
+
   return Error::success();
 }

--- a/llvm/unittests/Frontend/CMakeLists.txt
+++ b/llvm/unittests/Frontend/CMakeLists.txt
@@ -17,6 +17,7 @@ add_llvm_unittest(LLVMFrontendTests
   HLSLBindingTest.cpp
   HLSLRootSignatureDumpTest.cpp
   HLSLSemanticSignatureMetadataTest.cpp
+  HLSLSemanticSignaturePackingTest.cpp
   OpenACCTest.cpp
   OpenMPContextTest.cpp
   OpenMPIRBuilderTest.cpp

--- a/llvm/unittests/Frontend/HLSLSemanticSignaturePackingTest.cpp
+++ b/llvm/unittests/Frontend/HLSLSemanticSignaturePackingTest.cpp
@@ -21,11 +21,6 @@ namespace {
 
 class HLSLSemanticSignaturePackingTest : public testing::Test {
 protected:
-  static constexpr StringRef SignatureOverflowMessage =
-      "signature elements do not fit in 32 rows";
-  static constexpr StringRef ClipCullOverflowMessage =
-      "clip/cull elements do not fit in two rows";
-
   struct ElementConfig {
     dxbc::PSV::SemanticKind SemanticKind;
     uint32_t Rows;
@@ -114,9 +109,16 @@ protected:
     }
   }
 
-  void expectPackingError(const TestConfig &Config, StringRef Message) {
+  void expectPackingError(const TestConfig &Config,
+                          SignaturePackingError::ErrorKind ExpectedKind,
+                          unsigned ExpectedElementIndex) {
     SmallVector<SemanticSignatureElement> Elements = makeSignature(Config);
-    EXPECT_THAT_ERROR(pack(Elements, Config), FailedWithMessage(Message));
+    Error E = pack(Elements, Config);
+    ASSERT_TRUE(E.isA<SignaturePackingError>());
+    handleAllErrors(std::move(E), [&](const SignaturePackingError &PackingErr) {
+      EXPECT_EQ(PackingErr.getErrorKind(), ExpectedKind);
+      EXPECT_EQ(PackingErr.getElementIndex(), ExpectedElementIndex);
+    });
   }
 };
 
@@ -1080,7 +1082,9 @@ TEST_F(HLSLSemanticSignaturePackingTest, RejectsSignatureOverflow) {
                                /*Cols=*/MaxSignatureCols,
                                dxil::ElementType::F32,
                                dxbc::PSV::InterpolationMode::Linear});
-  expectPackingError(Config, SignatureOverflowMessage);
+  // The last element is the one that no longer fits.
+  expectPackingError(Config, SignaturePackingError::SignatureOverflow,
+                     /*ExpectedElementIndex=*/MaxSignatureRows);
 }
 
 TEST_F(HLSLSemanticSignaturePackingTest, RejectsOverflowFromComponentOrdering) {
@@ -1110,7 +1114,9 @@ TEST_F(HLSLSemanticSignaturePackingTest, RejectsOverflowFromComponentOrdering) {
     Config.Elements.push_back({dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1,
                                /*Cols=*/3, dxil::ElementType::I32,
                                dxbc::PSV::InterpolationMode::Constant});
-  expectPackingError(Config, SignatureOverflowMessage);
+  // The last element is the one that no longer fits.
+  expectPackingError(Config, SignaturePackingError::SignatureOverflow,
+                     /*ExpectedElementIndex=*/MaxSignatureRows);
 }
 
 TEST_F(HLSLSemanticSignaturePackingTest, RejectsClipCullOverflow) {
@@ -1126,7 +1132,8 @@ TEST_F(HLSLSemanticSignaturePackingTest, RejectsClipCullOverflow) {
         dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
        {dxbc::PSV::SemanticKind::ClipDistance, /*Rows=*/1, /*Cols=*/3,
         dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear}});
-  expectPackingError(Config, ClipCullOverflowMessage);
+  expectPackingError(Config, SignaturePackingError::ClipCullOverflow,
+                     /*ExpectedElementIndex=*/2);
 }
 
 TEST_F(HLSLSemanticSignaturePackingTest, RejectsUnpackableClipCull) {
@@ -1142,7 +1149,8 @@ TEST_F(HLSLSemanticSignaturePackingTest, RejectsUnpackableClipCull) {
         dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
        {dxbc::PSV::SemanticKind::ClipDistance, /*Rows=*/1, /*Cols=*/2,
         dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear}});
-  expectPackingError(Config, ClipCullOverflowMessage);
+  expectPackingError(Config, SignaturePackingError::ClipCullOverflow,
+                     /*ExpectedElementIndex=*/2);
 }
 
 } // namespace

--- a/llvm/unittests/Frontend/HLSLSemanticSignaturePackingTest.cpp
+++ b/llvm/unittests/Frontend/HLSLSemanticSignaturePackingTest.cpp
@@ -220,6 +220,29 @@ TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableIndexedRanges) {
                  {/*Row=*/2, /*Col=*/0}});
 }
 
+TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableTessFactors) {
+  // Indexed tess factors are reserved in the last column of their rows so that
+  // arbitrary values can still be co-packed into the same rows.
+
+  // struct PatchConstants {
+  //   float TessFactor[2] : SV_TessFactor;
+  //   float3 Data[2]      : DATA;
+  // };
+  TestConfig Config(
+      Triple::EnvironmentType::Hull, SemanticSignatureKind::PatchConstOrPrim,
+      /*UseNative16BitTypes=*/false,
+      {{dxbc::PSV::SemanticKind::TessFactor, /*Rows=*/2, /*Cols=*/1,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Undefined},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/2, /*Cols=*/3,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Undefined}});
+
+  // Expected layout:
+  // reg0: Data[0].xyz | TessFactor[0].w
+  // reg1: Data[1].xyz | TessFactor[1].w
+  expectPacking(Config, /*ExpectedRows=*/2,
+                {{/*Row=*/0, /*Col=*/3}, {/*Row=*/0, /*Col=*/0}});
+}
+
 TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableWhenAppended) {
   // Appending an element to a signature never moves the elements declared
   // before it; the appended element is only packed into the space they left.
@@ -625,6 +648,57 @@ TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableIndexedAfterSystemValue) {
   // reg2: A[1].xyz   | unused.w
   expectPacking(Config, /*ExpectedRows=*/3,
                 {{/*Row=*/0, /*Col=*/0}, {/*Row=*/1, /*Col=*/0}});
+}
+
+TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableSingleRowTessFactor) {
+  // A single row tess factor is not dynamically indexable and is packed like
+  // any other system value, rather than being reserved in the last column.
+
+  // struct PatchConstants {
+  //   float TessFactor : SV_TessFactor;
+  //   float3 Data      : DATA;
+  // };
+  TestConfig Config(
+      Triple::EnvironmentType::Hull, SemanticSignatureKind::PatchConstOrPrim,
+      /*UseNative16BitTypes=*/false,
+      {{dxbc::PSV::SemanticKind::TessFactor, /*Rows=*/1, /*Cols=*/1,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Undefined},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/3,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Undefined}});
+
+  // Expected layout:
+  // reg0: TessFactor.x | unused.yzw
+  // reg1: Data.xyz     | unused.w
+  expectPacking(Config, /*ExpectedRows=*/2,
+                {{/*Row=*/0, /*Col=*/0}, {/*Row=*/1, /*Col=*/0}});
+}
+
+TEST_F(HLSLSemanticSignaturePackingTest,
+       PrefixStableIndexedTessFactorAfterIndexedElement) {
+  // An indexed tess factor may only be placed in rows whose indexed range is
+  // contained by its own, so it cannot be packed into the rows of the wider
+  // indexed range of Data.
+
+  // struct PatchConstants {
+  //   float3 Data[3]      : DATA;
+  //   float TessFactor[2] : SV_TessFactor;
+  // };
+  TestConfig Config(
+      Triple::EnvironmentType::Hull, SemanticSignatureKind::PatchConstOrPrim,
+      /*UseNative16BitTypes=*/false,
+      {{dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/3, /*Cols=*/3,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Undefined},
+       {dxbc::PSV::SemanticKind::TessFactor, /*Rows=*/2, /*Cols=*/1,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Undefined}});
+
+  // Expected layout:
+  // reg0: Data[0].xyz | unused.w
+  // reg1: Data[1].xyz | unused.w
+  // reg2: Data[2].xyz | unused.w
+  // reg3: unused.xyz  | TessFactor[0].w
+  // reg4: unused.xyz  | TessFactor[1].w
+  expectPacking(Config, /*ExpectedRows=*/5,
+                {{/*Row=*/0, /*Col=*/0}, {/*Row=*/3, /*Col=*/3}});
 }
 
 TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableFillsAllRows) {

--- a/llvm/unittests/Frontend/HLSLSemanticSignaturePackingTest.cpp
+++ b/llvm/unittests/Frontend/HLSLSemanticSignaturePackingTest.cpp
@@ -21,6 +21,9 @@ namespace {
 
 class HLSLSemanticSignaturePackingTest : public testing::Test {
 protected:
+  static constexpr StringRef SignatureOverflowMessage =
+      "signature elements do not fit in 32 rows";
+
   struct ElementConfig {
     dxbc::PSV::SemanticKind SemanticKind;
     uint32_t Rows;
@@ -108,43 +111,142 @@ protected:
   }
 };
 
-TEST_F(HLSLSemanticSignaturePackingTest, CreatesSignatureFromConfig) {
+//===----------------------------------------------------------------------===//
+// Valid packing tests
+//===----------------------------------------------------------------------===//
+
+TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableEmptySignature) {
+  // A signature without any elements uses no registers.
+
+  // struct VSOut {};
+  TestConfig Config(Triple::EnvironmentType::Vertex,
+                    SemanticSignatureKind::Output,
+                    /*UseNative16BitTypes=*/false, {});
+
+  // Expected layout: no registers are used.
+  expectPacking(Config, /*ExpectedRows=*/0, {});
+}
+
+TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableDeclarationOrder) {
+  // Elements are visited in declaration order and are co-packed into a
+  // register whenever the register has room left for them.
+
+  // struct VSOut {
+  //   float Fog      : FOG;
+  //   float Alpha    : COLOR0;
+  //   float2 Position : SV_Position;
+  // };
   TestConfig Config(
       Triple::EnvironmentType::Vertex, SemanticSignatureKind::Output,
-      /*UseNative16BitTypes=*/true,
-      {{dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/2,
+      /*UseNative16BitTypes=*/false,
+      {{dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/1,
         dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
-       {dxbc::PSV::SemanticKind::Position, /*Rows=*/2, /*Cols=*/3,
-        dxil::ElementType::F16, dxbc::PSV::InterpolationMode::Constant}});
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/1,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::Position, /*Rows=*/1, /*Cols=*/2,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear}});
 
-  EXPECT_EQ(Config.ShaderStage, Triple::EnvironmentType::Vertex);
-  EXPECT_EQ(Config.SignatureKind, SemanticSignatureKind::Output);
-  EXPECT_TRUE(Config.UseNative16BitTypes);
+  // Expected layout:
+  // reg0: Fog.x | Alpha.y | Position.zw
+  expectPacking(
+      Config, /*ExpectedRows=*/1,
+      {{/*Row=*/0, /*Col=*/0}, {/*Row=*/0, /*Col=*/1}, {/*Row=*/0, /*Col=*/2}});
+}
+
+TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableWhenAppended) {
+  // Appending an element to a signature never moves the elements declared
+  // before it; the appended element is only packed into the space they left.
+
+  // struct Prefix {
+  //   float3 A : A;
+  //   float2 B : B;
+  // };
+  TestConfig PrefixConfig(
+      Triple::EnvironmentType::Vertex, SemanticSignatureKind::Output,
+      /*UseNative16BitTypes=*/false,
+      {{dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/3,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/2,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear}});
+
+  // Expected layout:
+  // reg0: A.xyz | unused.w
+  // reg1: B.xy  | unused.zw
+  expectPacking(PrefixConfig, /*ExpectedRows=*/2,
+                {{/*Row=*/0, /*Col=*/0}, {/*Row=*/1, /*Col=*/0}});
+
+  // struct Extended {
+  //   float3 A : A;
+  //   float2 B : B;
+  //   float C  : C;
+  // };
+  TestConfig ExtendedConfig = PrefixConfig;
+  ExtendedConfig.Elements.push_back(
+      {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/1,
+       dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear});
+
+  // Expected layout:
+  // reg0: A.xyz | C.w
+  // reg1: B.xy  | unused.zw
+  //
+  // C is packed into the gap A left behind, and A and B keep the locations
+  // they were given in Prefix.
+  expectPacking(
+      ExtendedConfig, /*ExpectedRows=*/2,
+      {{/*Row=*/0, /*Col=*/0}, {/*Row=*/1, /*Col=*/0}, {/*Row=*/0, /*Col=*/3}});
+}
+
+//===----------------------------------------------------------------------===//
+// Boundary and stability tests
+//===----------------------------------------------------------------------===//
+
+TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableFillsAllRows) {
+  // A signature may use all 32 rows.
+
+  // struct VSOut {
+  //   float4 A0  : A0;
+  //   ...
+  //   float4 A31 : A31;
+  // };
+  TestConfig Config(Triple::EnvironmentType::Vertex,
+                    SemanticSignatureKind::Output,
+                    /*UseNative16BitTypes=*/false, {});
+  for (unsigned I = 0; I != MaxSignatureRows; ++I)
+    Config.Elements.push_back({dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1,
+                               /*Cols=*/MaxSignatureCols,
+                               dxil::ElementType::F32,
+                               dxbc::PSV::InterpolationMode::Linear});
 
   SmallVector<SemanticSignatureElement> Elements = makeSignature(Config);
-  ASSERT_EQ(Elements.size(), 2u);
+  ASSERT_THAT_ERROR(pack(Elements, Config), Succeeded());
 
-  EXPECT_EQ(Elements[0].SigId, 0u);
-  EXPECT_EQ(Elements[0].SemanticName, "TEST");
-  EXPECT_EQ(Elements[0].CompType, dxil::ElementType::F32);
-  EXPECT_EQ(Elements[0].SemanticKind, dxbc::PSV::SemanticKind::Arbitrary);
-  EXPECT_EQ(Elements[0].SemanticIndices, SmallVector<uint32_t>({0}));
-  EXPECT_EQ(Elements[0].InterpMode, dxbc::PSV::InterpolationMode::Linear);
-  EXPECT_EQ(Elements[0].Rows, 1u);
-  EXPECT_EQ(Elements[0].Cols, 2u);
-  EXPECT_EQ(Elements[0].StartRow, UnallocatedRow);
-  EXPECT_EQ(Elements[0].StartCol, UnallocatedCol);
-  EXPECT_EQ(Elements[0].UsageMask, 0u);
-  EXPECT_EQ(Elements[0].DynIndexMask, 0u);
-  EXPECT_EQ(Elements[0].GSStream, 0u);
+  for (unsigned I = 0; I != MaxSignatureRows; ++I) {
+    EXPECT_EQ(Elements[I].StartRow, I) << "element " << I;
+    EXPECT_EQ(Elements[I].StartCol, 0u) << "element " << I;
+  }
+}
 
-  EXPECT_EQ(Elements[1].SigId, 1u);
-  EXPECT_EQ(Elements[1].SemanticKind, dxbc::PSV::SemanticKind::Position);
-  EXPECT_EQ(Elements[1].CompType, dxil::ElementType::F16);
-  EXPECT_EQ(Elements[1].InterpMode, dxbc::PSV::InterpolationMode::Constant);
-  EXPECT_EQ(Elements[1].SemanticIndices, SmallVector<uint32_t>({0, 1}));
-  EXPECT_EQ(Elements[1].Rows, 2u);
-  EXPECT_EQ(Elements[1].Cols, 3u);
+//===----------------------------------------------------------------------===//
+// Packing error tests
+//===----------------------------------------------------------------------===//
+
+TEST_F(HLSLSemanticSignaturePackingTest, RejectsSignatureOverflow) {
+  // A signature that requires more than 32 rows cannot be packed.
+
+  // struct VSOut {
+  //   float4 A0  : A0;
+  //   ...
+  //   float4 A32 : A32;
+  // };
+  TestConfig Config(Triple::EnvironmentType::Vertex,
+                    SemanticSignatureKind::Output,
+                    /*UseNative16BitTypes=*/false, {});
+  for (unsigned I = 0; I != MaxSignatureRows + 1; ++I)
+    Config.Elements.push_back({dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1,
+                               /*Cols=*/MaxSignatureCols,
+                               dxil::ElementType::F32,
+                               dxbc::PSV::InterpolationMode::Linear});
+  expectPackingError(Config, SignatureOverflowMessage);
 }
 
 } // namespace

--- a/llvm/unittests/Frontend/HLSLSemanticSignaturePackingTest.cpp
+++ b/llvm/unittests/Frontend/HLSLSemanticSignaturePackingTest.cpp
@@ -185,6 +185,41 @@ TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableSystemValueOrdering) {
       {{/*Row=*/0, /*Col=*/0}, {/*Row=*/0, /*Col=*/1}, {/*Row=*/0, /*Col=*/2}});
 }
 
+TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableIndexedRanges) {
+  // An element with multiple rows occupies the same columns of a contiguous
+  // range of rows, and other elements may be co-packed into the columns those
+  // rows have left. A system value cannot be placed in a dynamically indexable
+  // row, so Position starts a new register.
+
+  // struct VSOut {
+  //   float2 A[2]    : A;
+  //   float B[2]     : B;
+  //   float C        : C;
+  //   float Position : SV_Position;
+  // };
+  TestConfig Config(
+      Triple::EnvironmentType::Vertex, SemanticSignatureKind::Output,
+      /*UseNative16BitTypes=*/false,
+      {{dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/2, /*Cols=*/2,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/2, /*Cols=*/1,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/1,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::Position, /*Rows=*/1, /*Cols=*/1,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear}});
+
+  // Expected layout:
+  // reg0: A[0].xy | B[0].z | C.w
+  // reg1: A[1].xy | B[1].z | unused.w
+  // reg2: Position.x | unused.yzw
+  expectPacking(Config, /*ExpectedRows=*/3,
+                {{/*Row=*/0, /*Col=*/0},
+                 {/*Row=*/0, /*Col=*/2},
+                 {/*Row=*/0, /*Col=*/3},
+                 {/*Row=*/2, /*Col=*/0}});
+}
+
 TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableWhenAppended) {
   // Appending an element to a signature never moves the elements declared
   // before it; the appended element is only packed into the space they left.
@@ -562,6 +597,34 @@ TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableSkipsUnpackedElements) {
   // reg0: A.xy | B.zw
   expectPacking(Config, /*ExpectedRows=*/1,
                 {{/*Row=*/0, /*Col=*/0}, Unallocated, {/*Row=*/0, /*Col=*/2}});
+}
+
+//===----------------------------------------------------------------------===//
+// Dynamic indexing tests
+//===----------------------------------------------------------------------===//
+
+TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableIndexedAfterSystemValue) {
+  // A multi-row element is dynamically indexable, so it may not share any of
+  // its rows with a system value, and it requires contiguous rows.
+
+  // struct VSOut {
+  //   float Position : SV_Position;
+  //   float3 A[2]    : A;
+  // };
+  TestConfig Config(
+      Triple::EnvironmentType::Vertex, SemanticSignatureKind::Output,
+      /*UseNative16BitTypes=*/false,
+      {{dxbc::PSV::SemanticKind::Position, /*Rows=*/1, /*Cols=*/1,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/2, /*Cols=*/3,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear}});
+
+  // Expected layout:
+  // reg0: Position.x | unused.yzw
+  // reg1: A[0].xyz   | unused.w
+  // reg2: A[1].xyz   | unused.w
+  expectPacking(Config, /*ExpectedRows=*/3,
+                {{/*Row=*/0, /*Col=*/0}, {/*Row=*/1, /*Col=*/0}});
 }
 
 TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableFillsAllRows) {

--- a/llvm/unittests/Frontend/HLSLSemanticSignaturePackingTest.cpp
+++ b/llvm/unittests/Frontend/HLSLSemanticSignaturePackingTest.cpp
@@ -37,6 +37,11 @@ protected:
     uint8_t Col;
   };
 
+  // Denotes an element that is expected to be left unallocated because it is
+  // not part of the packed signature.
+  static constexpr ExpectedLocation Unallocated = {UnallocatedRow,
+                                                   UnallocatedCol};
+
   struct TestConfig {
     Triple::EnvironmentType ShaderStage;
     SemanticSignatureKind SignatureKind;
@@ -148,6 +153,33 @@ TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableDeclarationOrder) {
 
   // Expected layout:
   // reg0: Fog.x | Alpha.y | Position.zw
+  expectPacking(
+      Config, /*ExpectedRows=*/1,
+      {{/*Row=*/0, /*Col=*/0}, {/*Row=*/0, /*Col=*/1}, {/*Row=*/0, /*Col=*/2}});
+}
+
+TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableSystemValueOrdering) {
+  // System values may be co-packed to the right of arbitrary values, and a
+  // system generated value may be co-packed to the right of both.
+
+  // struct PSIn {
+  //   uint A             : A;
+  //   uint RTIndex       : SV_RenderTargetArrayIndex;
+  //   uint PrimitiveID   : SV_PrimitiveID;
+  // };
+  TestConfig Config(
+      Triple::EnvironmentType::Pixel, SemanticSignatureKind::Input,
+      /*UseNative16BitTypes=*/false,
+      {{dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/1,
+        dxil::ElementType::U32, dxbc::PSV::InterpolationMode::Constant},
+       {dxbc::PSV::SemanticKind::RenderTargetArrayIndex, /*Rows=*/1,
+        /*Cols=*/1, dxil::ElementType::U32,
+        dxbc::PSV::InterpolationMode::Constant},
+       {dxbc::PSV::SemanticKind::PrimitiveID, /*Rows=*/1, /*Cols=*/1,
+        dxil::ElementType::U32, dxbc::PSV::InterpolationMode::Constant}});
+
+  // Expected layout:
+  // reg0: A.x | RTIndex.y | PrimitiveID.z | unused.w
   expectPacking(
       Config, /*ExpectedRows=*/1,
       {{/*Row=*/0, /*Col=*/0}, {/*Row=*/0, /*Col=*/1}, {/*Row=*/0, /*Col=*/2}});
@@ -451,6 +483,87 @@ TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableDistinctInterpModes) {
 // Boundary and stability tests
 //===----------------------------------------------------------------------===//
 
+//===----------------------------------------------------------------------===//
+// Component ordering tests
+//===----------------------------------------------------------------------===//
+
+TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableArbitraryNotRightOfSV) {
+  // Arbitrary values may never be placed to the right of a system value in the
+  // same register, so B cannot co-pack with Position even though there is
+  // space for it.
+
+  // struct VSOut {
+  //   float2 Position : SV_Position;
+  //   float2 A        : A;
+  // };
+  TestConfig Config(
+      Triple::EnvironmentType::Vertex, SemanticSignatureKind::Output,
+      /*UseNative16BitTypes=*/false,
+      {{dxbc::PSV::SemanticKind::Position, /*Rows=*/1, /*Cols=*/2,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/2,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear}});
+
+  // Expected layout:
+  // reg0: Position.xy | unused.zw
+  // reg1: A.xy        | unused.zw
+  expectPacking(Config, /*ExpectedRows=*/2,
+                {{/*Row=*/0, /*Col=*/0}, {/*Row=*/1, /*Col=*/0}});
+}
+
+TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableSGVIsRightmost) {
+  // Nothing may be placed to the right of a system generated value, so both A
+  // and RTIndex are pushed into the next register.
+
+  // struct PSIn {
+  //   bool IsFrontFace : SV_IsFrontFace;
+  //   uint A           : A;
+  //   uint RTIndex     : SV_RenderTargetArrayIndex;
+  // };
+  TestConfig Config(
+      Triple::EnvironmentType::Pixel, SemanticSignatureKind::Input,
+      /*UseNative16BitTypes=*/false,
+      {{dxbc::PSV::SemanticKind::IsFrontFace, /*Rows=*/1, /*Cols=*/1,
+        dxil::ElementType::I1, dxbc::PSV::InterpolationMode::Constant},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/1,
+        dxil::ElementType::U32, dxbc::PSV::InterpolationMode::Constant},
+       {dxbc::PSV::SemanticKind::RenderTargetArrayIndex, /*Rows=*/1,
+        /*Cols=*/1, dxil::ElementType::U32,
+        dxbc::PSV::InterpolationMode::Constant}});
+
+  // Expected layout:
+  // reg0: IsFrontFace.x | unused.yzw
+  // reg1: A.x | RTIndex.y | unused.zw
+  expectPacking(
+      Config, /*ExpectedRows=*/2,
+      {{/*Row=*/0, /*Col=*/0}, {/*Row=*/1, /*Col=*/0}, {/*Row=*/1, /*Col=*/1}});
+}
+
+TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableSkipsUnpackedElements) {
+  // Semantics that are accessed through a dedicated intrinsic are left
+  // unallocated and do not reserve any signature space.
+
+  // struct PSIn {
+  //   float2 A         : A;
+  //   uint SampleIndex : SV_SampleIndex;
+  //   float2 B         : B;
+  // };
+  TestConfig Config(
+      Triple::EnvironmentType::Pixel, SemanticSignatureKind::Input,
+      /*UseNative16BitTypes=*/false,
+      {{dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/2,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::SampleIndex, /*Rows=*/1, /*Cols=*/1,
+        dxil::ElementType::U32, dxbc::PSV::InterpolationMode::Constant},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/2,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear}});
+
+  // Expected layout:
+  // reg0: A.xy | B.zw
+  expectPacking(Config, /*ExpectedRows=*/1,
+                {{/*Row=*/0, /*Col=*/0}, Unallocated, {/*Row=*/0, /*Col=*/2}});
+}
+
 TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableFillsAllRows) {
   // A signature may use all 32 rows.
 
@@ -497,6 +610,36 @@ TEST_F(HLSLSemanticSignaturePackingTest, RejectsSignatureOverflow) {
                                /*Cols=*/MaxSignatureCols,
                                dxil::ElementType::F32,
                                dxbc::PSV::InterpolationMode::Linear});
+  expectPackingError(Config, SignatureOverflowMessage);
+}
+
+TEST_F(HLSLSemanticSignaturePackingTest, RejectsOverflowFromComponentOrdering) {
+  // Nothing may be placed to the right of a system generated value, so
+  // declaring one first leaves the rest of its register unusable by the
+  // arbitrary values that follow, and they no longer fit in 32 rows. Every
+  // element here shares an interpolation mode and a data width, so component
+  // ordering is the only reason the signature overflows.
+  //
+  // Note that the optimal algorithm packs the arbitrary values into reg0 to
+  // reg31 first and backfills IsFrontFace into reg0.w, so the very same
+  // signature does fit when it is packed optimally.
+
+  // struct PSIn {
+  //   nointerpolation bool IsFrontFace : SV_IsFrontFace;
+  //   nointerpolation int3 A0          : A0;
+  //   ...
+  //   nointerpolation int3 A31         : A31;
+  // };
+  TestConfig Config(Triple::EnvironmentType::Pixel,
+                    SemanticSignatureKind::Input,
+                    /*UseNative16BitTypes=*/false,
+                    {{dxbc::PSV::SemanticKind::IsFrontFace, /*Rows=*/1,
+                      /*Cols=*/1, dxil::ElementType::I1,
+                      dxbc::PSV::InterpolationMode::Constant}});
+  for (unsigned I = 0; I != MaxSignatureRows; ++I)
+    Config.Elements.push_back({dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1,
+                               /*Cols=*/3, dxil::ElementType::I32,
+                               dxbc::PSV::InterpolationMode::Constant});
   expectPackingError(Config, SignatureOverflowMessage);
 }
 

--- a/llvm/unittests/Frontend/HLSLSemanticSignaturePackingTest.cpp
+++ b/llvm/unittests/Frontend/HLSLSemanticSignaturePackingTest.cpp
@@ -23,6 +23,8 @@ class HLSLSemanticSignaturePackingTest : public testing::Test {
 protected:
   static constexpr StringRef SignatureOverflowMessage =
       "signature elements do not fit in 32 rows";
+  static constexpr StringRef ClipCullOverflowMessage =
+      "clip/cull elements do not fit in two rows";
 
   struct ElementConfig {
     dxbc::PSV::SemanticKind SemanticKind;
@@ -701,6 +703,266 @@ TEST_F(HLSLSemanticSignaturePackingTest,
                 {{/*Row=*/0, /*Col=*/0}, {/*Row=*/3, /*Col=*/3}});
 }
 
+//===----------------------------------------------------------------------===//
+// Clip/cull tests
+//===----------------------------------------------------------------------===//
+
+TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableClipCull) {
+  // struct VSOut {
+  //   float3 First         : First;
+  //   float  Clip0         : SV_ClipDistance0;
+  //   float3 Cull1         : SV_CullDistance1;
+  //   float  Cull0         : SV_CullDistance0;
+  //   float2 Clip1         : SV_ClipDistance1;
+  //   float  WithFirst     : WithFirst;
+  //   float  AfterClipCull : AfterClipCull;
+  // };
+  TestConfig Config(
+      Triple::EnvironmentType::Vertex, SemanticSignatureKind::Output,
+      /*UseNative16BitTypes=*/false,
+      {{dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/3,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::ClipDistance, /*Rows=*/1, /*Cols=*/1,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::CullDistance, /*Rows=*/1, /*Cols=*/3,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::CullDistance, /*Rows=*/1, /*Cols=*/1,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::ClipDistance, /*Rows=*/1, /*Cols=*/2,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/1,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/1,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear}});
+
+  // Expected layout:
+  // reg0: First.xyz       | WithFirst.w
+  // reg1: Clip0.x         | Cull1.yzw
+  // reg2: Cull0.x         | Clip1.yz | unused.w
+  // reg3: AfterClipCull.x | unused.yzw
+  expectPacking(Config, /*ExpectedRows=*/4,
+                {{/*Row=*/0, /*Col=*/0},
+                 {/*Row=*/1, /*Col=*/0},
+                 {/*Row=*/1, /*Col=*/1},
+                 {/*Row=*/2, /*Col=*/0},
+                 {/*Row=*/2, /*Col=*/1},
+                 {/*Row=*/0, /*Col=*/3},
+                 {/*Row=*/3, /*Col=*/0}});
+}
+
+TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableIndexedClipCull) {
+  // struct VSOut {
+  //   float3 First         : First;
+  //   float  Clip0         : SV_ClipDistance0;
+  //   float2 Cull1[2]      : SV_CullDistance1;
+  //   float  Clip1         : SV_ClipDistance1;
+  //   float  WithFirst     : WithFirst;
+  //   float  AfterClipCull : AfterClipCull;
+  // };
+  TestConfig Config(
+      Triple::EnvironmentType::Vertex, SemanticSignatureKind::Output,
+      /*UseNative16BitTypes=*/false,
+      {{dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/3,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::ClipDistance, /*Rows=*/1, /*Cols=*/1,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::CullDistance, /*Rows=*/2, /*Cols=*/2,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::ClipDistance, /*Rows=*/1, /*Cols=*/1,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/1,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/1,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear}});
+
+  // Expected layout:
+  // reg0: First.xyz       | WithFirst.w
+  // reg1: Clip0.x         | Cull1[0].yz | Clip1.w
+  // reg2: unused.x        | Cull1[1].yz | unused.w
+  // reg3: AfterClipCull.x | unused.yzw
+  expectPacking(Config, /*ExpectedRows=*/4,
+                {{/*Row=*/0, /*Col=*/0},
+                 {/*Row=*/1, /*Col=*/0},
+                 {/*Row=*/1, /*Col=*/1},
+                 {/*Row=*/1, /*Col=*/3},
+                 {/*Row=*/0, /*Col=*/3},
+                 {/*Row=*/3, /*Col=*/0}});
+}
+
+TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableMultipleIndexedClipCull) {
+  // struct VSOut {
+  //   float3 First         : First;
+  //   float  Clip0         : SV_ClipDistance0;
+  //   float2 Cull1[2]      : SV_CullDistance1;
+  //   float  Clip1[2]      : SV_ClipDistance1;
+  //   float  WithFirst     : WithFirst;
+  //   float  AfterClipCull : AfterClipCull;
+  // };
+  TestConfig Config(
+      Triple::EnvironmentType::Vertex, SemanticSignatureKind::Output,
+      /*UseNative16BitTypes=*/false,
+      {{dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/3,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::ClipDistance, /*Rows=*/1, /*Cols=*/1,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::CullDistance, /*Rows=*/2, /*Cols=*/2,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::ClipDistance, /*Rows=*/2, /*Cols=*/1,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/1,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/1,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear}});
+
+  // Expected layout:
+  // reg0: First.xyz       | WithFirst.w
+  // reg1: Clip0.x         | Cull1[0].yz | Clip1[0].w
+  // reg2: unused.x        | Cull1[1].yz | Clip1[1].w
+  // reg3: AfterClipCull.x | unused.yzw
+  expectPacking(Config, /*ExpectedRows=*/4,
+                {{/*Row=*/0, /*Col=*/0},
+                 {/*Row=*/1, /*Col=*/0},
+                 {/*Row=*/1, /*Col=*/1},
+                 {/*Row=*/1, /*Col=*/3},
+                 {/*Row=*/0, /*Col=*/3},
+                 {/*Row=*/3, /*Col=*/0}});
+}
+
+TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableClipCullFillsTwoRows) {
+  // Clip and cull distances may use a combined maximum of eight components
+  // spread over two registers.
+
+  // struct VSOut {
+  //   float4 Clip0 : SV_ClipDistance0;
+  //   float4 Cull0 : SV_CullDistance0;
+  // };
+  TestConfig Config(
+      Triple::EnvironmentType::Vertex, SemanticSignatureKind::Output,
+      /*UseNative16BitTypes=*/false,
+      {{dxbc::PSV::SemanticKind::ClipDistance, /*Rows=*/1, /*Cols=*/4,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::CullDistance, /*Rows=*/1, /*Cols=*/4,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear}});
+
+  // Expected layout:
+  // reg0: Clip0.xyzw
+  // reg1: Cull0.xyzw
+  expectPacking(Config, /*ExpectedRows=*/MaxClipCullRows,
+                {{/*Row=*/0, /*Col=*/0}, {/*Row=*/1, /*Col=*/0}});
+}
+
+TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableSeparatesClipCullRows) {
+  // Non-indexed clip and cull distance registers do not need to be adjacent.
+  // Elements declared between them may separate their reserved registers while
+  // the clip/cull elements continue to count toward the common two-register
+  // limit.
+
+  // struct VSOut {
+  //   float3 Clip0 : SV_ClipDistance0;
+  //   float4 A[30] : A;
+  //   float3 Cull0 : SV_CullDistance0;
+  // };
+  TestConfig Config(
+      Triple::EnvironmentType::Vertex, SemanticSignatureKind::Output,
+      /*UseNative16BitTypes=*/false,
+      {{dxbc::PSV::SemanticKind::ClipDistance, /*Rows=*/1, /*Cols=*/3,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/30, /*Cols=*/4,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::CullDistance, /*Rows=*/1, /*Cols=*/3,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear}});
+
+  // Expected layout:
+  // reg0:     Clip0.xyz | unused.w
+  // reg1-30:  A[0-29].xyzw
+  // reg31:    Cull0.xyz | unused.w
+  expectPacking(Config, /*ExpectedRows=*/MaxSignatureRows,
+                {{/*Row=*/0, /*Col=*/0},
+                 {/*Row=*/1, /*Col=*/0},
+                 {/*Row=*/31, /*Col=*/0}});
+}
+
+TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableClipCullAsArbitrary) {
+  // Clip and cull distances are arbitrary values in a patch constant
+  // signature, so the two register limit does not apply to them.
+
+  // struct PatchConstants {
+  //   float3 Clip0 : SV_ClipDistance0;
+  //   float3 Clip1 : SV_ClipDistance1;
+  //   float3 Cull0 : SV_CullDistance0;
+  // };
+  TestConfig Config(
+      Triple::EnvironmentType::Hull, SemanticSignatureKind::PatchConstOrPrim,
+      /*UseNative16BitTypes=*/false,
+      {{dxbc::PSV::SemanticKind::ClipDistance, /*Rows=*/1, /*Cols=*/3,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Undefined},
+       {dxbc::PSV::SemanticKind::ClipDistance, /*Rows=*/1, /*Cols=*/3,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Undefined},
+       {dxbc::PSV::SemanticKind::CullDistance, /*Rows=*/1, /*Cols=*/3,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Undefined}});
+
+  // Expected layout:
+  // reg0: Clip0.xyz | unused.w
+  // reg1: Clip1.xyz | unused.w
+  // reg2: Cull0.xyz | unused.w
+  expectPacking(
+      Config, /*ExpectedRows=*/3,
+      {{/*Row=*/0, /*Col=*/0}, {/*Row=*/1, /*Col=*/0}, {/*Row=*/2, /*Col=*/0}});
+}
+
+TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableClipCullWhenAppended) {
+  // Clip and cull distances reserve whole registers ahead of the elements that
+  // follow them, so appending elements does not move them either, not even
+  // when the appended elements are clip/cull values themselves.
+
+  // struct Prefix {
+  //   float3 First    : First;
+  //   float  Clip0    : SV_ClipDistance0;
+  //   float2 Cull1[2] : SV_CullDistance1;
+  // };
+  TestConfig PrefixConfig(
+      Triple::EnvironmentType::Vertex, SemanticSignatureKind::Output,
+      /*UseNative16BitTypes=*/false,
+      {{dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/3,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::ClipDistance, /*Rows=*/1, /*Cols=*/1,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::CullDistance, /*Rows=*/2, /*Cols=*/2,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear}});
+
+  // Expected layout:
+  // reg0: First.xyz | unused.w
+  // reg1: Clip0.x   | Cull1[0].yz | unused.w
+  // reg2: unused.x  | Cull1[1].yz | unused.w
+  expectPacking(
+      PrefixConfig, /*ExpectedRows=*/3,
+      {{/*Row=*/0, /*Col=*/0}, {/*Row=*/1, /*Col=*/0}, {/*Row=*/1, /*Col=*/1}});
+
+  TestConfig ExtendedConfig = PrefixConfig;
+  ExtendedConfig.Elements.push_back(
+      {dxbc::PSV::SemanticKind::ClipDistance, /*Rows=*/1, /*Cols=*/1,
+       dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear});
+  ExtendedConfig.Elements.push_back(
+      {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/1,
+       dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear});
+  ExtendedConfig.Elements.push_back(
+      {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/1,
+       dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear});
+
+  // Expected layout:
+  // reg0: First.xyz       | WithFirst.w
+  // reg1: Clip0.x         | Cull1[0].yz | Clip1.w
+  // reg2: unused.x        | Cull1[1].yz | unused.w
+  // reg3: AfterClipCull.x | unused.yzw
+  expectPacking(ExtendedConfig, /*ExpectedRows=*/4,
+                {{/*Row=*/0, /*Col=*/0},
+                 {/*Row=*/1, /*Col=*/0},
+                 {/*Row=*/1, /*Col=*/1},
+                 {/*Row=*/1, /*Col=*/3},
+                 {/*Row=*/0, /*Col=*/3},
+                 {/*Row=*/3, /*Col=*/0}});
+}
+
 TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableFillsAllRows) {
   // A signature may use all 32 rows.
 
@@ -778,6 +1040,38 @@ TEST_F(HLSLSemanticSignaturePackingTest, RejectsOverflowFromComponentOrdering) {
                                /*Cols=*/3, dxil::ElementType::I32,
                                dxbc::PSV::InterpolationMode::Constant});
   expectPackingError(Config, SignatureOverflowMessage);
+}
+
+TEST_F(HLSLSemanticSignaturePackingTest, RejectsClipCullOverflow) {
+  // Clip and cull distances may use at most eight components, shared between
+  // them, so nine components cannot be packed.
+
+  TestConfig Config(
+      Triple::EnvironmentType::Vertex, SemanticSignatureKind::Output,
+      /*UseNative16BitTypes=*/false,
+      {{dxbc::PSV::SemanticKind::ClipDistance, /*Rows=*/1, /*Cols=*/3,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::CullDistance, /*Rows=*/1, /*Cols=*/3,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::ClipDistance, /*Rows=*/1, /*Cols=*/3,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear}});
+  expectPackingError(Config, ClipCullOverflowMessage);
+}
+
+TEST_F(HLSLSemanticSignaturePackingTest, RejectsUnpackableClipCull) {
+  // These clip and cull distances fit in eight components, but they cannot be
+  // split across the two registers available to them.
+
+  TestConfig Config(
+      Triple::EnvironmentType::Vertex, SemanticSignatureKind::Output,
+      /*UseNative16BitTypes=*/false,
+      {{dxbc::PSV::SemanticKind::ClipDistance, /*Rows=*/1, /*Cols=*/3,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::CullDistance, /*Rows=*/1, /*Cols=*/3,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::ClipDistance, /*Rows=*/1, /*Cols=*/2,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear}});
+  expectPackingError(Config, ClipCullOverflowMessage);
 }
 
 } // namespace

--- a/llvm/unittests/Frontend/HLSLSemanticSignaturePackingTest.cpp
+++ b/llvm/unittests/Frontend/HLSLSemanticSignaturePackingTest.cpp
@@ -196,6 +196,257 @@ TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableWhenAppended) {
       {{/*Row=*/0, /*Col=*/0}, {/*Row=*/1, /*Col=*/0}, {/*Row=*/0, /*Col=*/3}});
 }
 
+TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableGeneralPacking) {
+  // Native 16-bit types are enabled.
+  // struct PSIn {
+  //   float16_t2 A : A;
+  //   float2 B     : B;
+  //   float16_t3 C : C;
+  //   float2 D     : D;
+  //   int E        : E;
+  //   float16_t2 F : F;
+  //   float16_t G  : G;
+  // };
+  TestConfig Config(
+      Triple::EnvironmentType::Pixel, SemanticSignatureKind::Input,
+      /*UseNative16BitTypes=*/true,
+      {{dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/2,
+        dxil::ElementType::F16, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/2,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/3,
+        dxil::ElementType::F16, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/2,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/1,
+        dxil::ElementType::I32, dxbc::PSV::InterpolationMode::Constant},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/2,
+        dxil::ElementType::F16, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/1,
+        dxil::ElementType::F16, dxbc::PSV::InterpolationMode::Linear}});
+
+  // Expected layout:
+  // reg0: A.xy | F.zw
+  // reg1: B.xy | D.zw
+  // reg2: C.xyz | G.w
+  // reg3: E.x | unused.yzw
+  expectPacking(Config, /*ExpectedRows=*/4,
+                {{/*Row=*/0, /*Col=*/0},
+                 {/*Row=*/1, /*Col=*/0},
+                 {/*Row=*/2, /*Col=*/0},
+                 {/*Row=*/1, /*Col=*/2},
+                 {/*Row=*/3, /*Col=*/0},
+                 {/*Row=*/0, /*Col=*/2},
+                 {/*Row=*/2, /*Col=*/3}});
+}
+
+TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableNative16BitWidth) {
+  // struct VSOut {
+  //   float16_t2 A : A;
+  //   float2 B     : B;
+  //   float16_t2 C : C;
+  // };
+  TestConfig Config(
+      Triple::EnvironmentType::Vertex, SemanticSignatureKind::Output,
+      /*UseNative16BitTypes=*/true,
+      {{dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/2,
+        dxil::ElementType::F16, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/2,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/2,
+        dxil::ElementType::F16, dxbc::PSV::InterpolationMode::Linear}});
+
+  // Expected layout:
+  // reg0: A.xy | C.zw
+  // reg1: B.xy | unused.zw
+  expectPacking(
+      Config, /*ExpectedRows=*/2,
+      {{/*Row=*/0, /*Col=*/0}, {/*Row=*/1, /*Col=*/0}, {/*Row=*/0, /*Col=*/2}});
+}
+
+TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableInterpolationMode) {
+  // struct VSOut {
+  //   float2 A                : A;
+  //   nointerpolation float2 B : B;
+  //   float2 C                : C;
+  // };
+  TestConfig Config(
+      Triple::EnvironmentType::Vertex, SemanticSignatureKind::Output,
+      /*UseNative16BitTypes=*/false,
+      {{dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/2,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/2,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Constant},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/2,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear}});
+
+  // Expected layout:
+  // reg0: A.xy | C.zw
+  // reg1: B.xy | unused.zw
+  expectPacking(
+      Config, /*ExpectedRows=*/2,
+      {{/*Row=*/0, /*Col=*/0}, {/*Row=*/1, /*Col=*/0}, {/*Row=*/0, /*Col=*/2}});
+}
+
+TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableCompatible16BitTypes) {
+  // struct VSOut {
+  //   nointerpolation int16_t A    : A;
+  //   nointerpolation float16_t3 B : B;
+  // };
+  TestConfig Config(
+      Triple::EnvironmentType::Vertex, SemanticSignatureKind::Output,
+      /*UseNative16BitTypes=*/true,
+      {{dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/1,
+        dxil::ElementType::I16, dxbc::PSV::InterpolationMode::Constant},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/3,
+        dxil::ElementType::F16, dxbc::PSV::InterpolationMode::Constant}});
+
+  // Expected layout:
+  // reg0: A.x | B.yzw
+  expectPacking(Config, /*ExpectedRows=*/1,
+                {{/*Row=*/0, /*Col=*/0}, {/*Row=*/0, /*Col=*/1}});
+}
+
+TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableNormalized16BitTypes) {
+  // A normalized 16-bit type has the same component width as any other 16-bit
+  // type, so it co-packs with them but not with a 32-bit type.
+
+  // struct VSOut {
+  //   nointerpolation snorm half A : A;
+  //   nointerpolation float16_t B  : B;
+  //   nointerpolation float C      : C;
+  // };
+  TestConfig Config(
+      Triple::EnvironmentType::Vertex, SemanticSignatureKind::Output,
+      /*UseNative16BitTypes=*/true,
+      {{dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/1,
+        dxil::ElementType::SNormF16, dxbc::PSV::InterpolationMode::Constant},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/1,
+        dxil::ElementType::F16, dxbc::PSV::InterpolationMode::Constant},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/1,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Constant}});
+
+  // Expected layout:
+  // reg0: A.x | B.y | unused.zw
+  // reg1: C.x | unused.yzw
+  expectPacking(
+      Config, /*ExpectedRows=*/2,
+      {{/*Row=*/0, /*Col=*/0}, {/*Row=*/0, /*Col=*/1}, {/*Row=*/1, /*Col=*/0}});
+}
+
+TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableMinPrecisionWidth) {
+  // Without native 16-bit types, 16-bit types are min-precision types which
+  // occupy a full 32-bit component, so they co-pack with 32-bit types. This is
+  // the same signature as PrefixStableNative16BitWidth, which packs
+  // differently.
+
+  // struct VSOut {
+  //   min16float2 A : A;
+  //   float2 B      : B;
+  //   min16float2 C : C;
+  // };
+  TestConfig Config(
+      Triple::EnvironmentType::Vertex, SemanticSignatureKind::Output,
+      /*UseNative16BitTypes=*/false,
+      {{dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/2,
+        dxil::ElementType::F16, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/2,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/2,
+        dxil::ElementType::F16, dxbc::PSV::InterpolationMode::Linear}});
+
+  // Expected layout:
+  // reg0: A.xy | B.zw
+  // reg1: C.xy | unused.zw
+  expectPacking(
+      Config, /*ExpectedRows=*/2,
+      {{/*Row=*/0, /*Col=*/0}, {/*Row=*/0, /*Col=*/2}, {/*Row=*/1, /*Col=*/0}});
+}
+
+TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableUndefinedInterpMode) {
+  // An undefined interpolation mode does not constrain a register, but the
+  // first defined mode packed into it does.
+
+  // struct VSOut {
+  //   float2 A                : A; // undefined interpolation mode
+  //   float B                 : B; // linear
+  //   nointerpolation float C : C; // nointerpolation
+  // };
+  TestConfig Config(
+      Triple::EnvironmentType::Vertex, SemanticSignatureKind::Output,
+      /*UseNative16BitTypes=*/false,
+      {{dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/2,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Undefined},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/1,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/1,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Constant}});
+
+  // Expected layout:
+  // reg0: A.xy | B.z | unused.w
+  // reg1: C.x  | unused.yzw
+  expectPacking(
+      Config, /*ExpectedRows=*/2,
+      {{/*Row=*/0, /*Col=*/0}, {/*Row=*/0, /*Col=*/2}, {/*Row=*/1, /*Col=*/0}});
+}
+
+TEST_F(HLSLSemanticSignaturePackingTest,
+       PrefixStableUndefinedInterpModeAfterDefined) {
+  // Once a register has a defined interpolation mode, an element with an
+  // undefined mode cannot be packed into it.
+
+  // struct VSOut {
+  //   float2 A : A; // linear
+  //   float2 B : B; // undefined interpolation mode
+  //   float2 C : C; // linear
+  // };
+  TestConfig Config(
+      Triple::EnvironmentType::Vertex, SemanticSignatureKind::Output,
+      /*UseNative16BitTypes=*/false,
+      {{dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/2,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/2,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Undefined},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/2,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear}});
+
+  // Expected layout:
+  // reg0: A.xy | C.zw
+  // reg1: B.xy | unused.zw
+  expectPacking(
+      Config, /*ExpectedRows=*/2,
+      {{/*Row=*/0, /*Col=*/0}, {/*Row=*/1, /*Col=*/0}, {/*Row=*/0, /*Col=*/2}});
+}
+
+TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableDistinctInterpModes) {
+  // Every distinct interpolation mode requires its own register, including
+  // modes that only differ by their centroid or noperspective qualifier.
+
+  // struct VSOut {
+  //   float2 A               : A;
+  //   centroid float2 B      : B;
+  //   noperspective float2 C : C;
+  // };
+  TestConfig Config(
+      Triple::EnvironmentType::Vertex, SemanticSignatureKind::Output,
+      /*UseNative16BitTypes=*/false,
+      {{dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/2,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/2,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::LinearCentroid},
+       {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/2,
+        dxil::ElementType::F32,
+        dxbc::PSV::InterpolationMode::LinearNoperspective}});
+
+  // Expected layout:
+  // reg0: A.xy | unused.zw
+  // reg1: B.xy | unused.zw
+  // reg2: C.xy | unused.zw
+  expectPacking(
+      Config, /*ExpectedRows=*/3,
+      {{/*Row=*/0, /*Col=*/0}, {/*Row=*/1, /*Col=*/0}, {/*Row=*/2, /*Col=*/0}});
+}
+
 //===----------------------------------------------------------------------===//
 // Boundary and stability tests
 //===----------------------------------------------------------------------===//

--- a/llvm/unittests/Frontend/HLSLSemanticSignaturePackingTest.cpp
+++ b/llvm/unittests/Frontend/HLSLSemanticSignaturePackingTest.cpp
@@ -1,0 +1,150 @@
+//===- HLSLSemanticSignaturePackingTest.cpp -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Frontend/HLSL/SemanticSignaturePacking.h"
+#include "llvm/TargetParser/Triple.h"
+#include "llvm/Testing/Support/Error.h"
+#include "gtest/gtest.h"
+#include <algorithm>
+#include <initializer_list>
+
+using namespace llvm;
+using namespace llvm::hlsl;
+
+namespace {
+
+class HLSLSemanticSignaturePackingTest : public testing::Test {
+protected:
+  struct ElementConfig {
+    dxbc::PSV::SemanticKind SemanticKind;
+    uint32_t Rows;
+    uint8_t Cols;
+    dxil::ElementType CompType;
+    dxbc::PSV::InterpolationMode InterpMode;
+  };
+
+  struct ExpectedLocation {
+    uint32_t Row;
+    uint8_t Col;
+  };
+
+  struct TestConfig {
+    Triple::EnvironmentType ShaderStage;
+    SemanticSignatureKind SignatureKind;
+    bool UseNative16BitTypes;
+    SmallVector<ElementConfig> Elements;
+
+    TestConfig(Triple::EnvironmentType ShaderStage,
+               SemanticSignatureKind SignatureKind, bool UseNative16BitTypes,
+               std::initializer_list<ElementConfig> Elements)
+        : ShaderStage(ShaderStage), SignatureKind(SignatureKind),
+          UseNative16BitTypes(UseNative16BitTypes), Elements(Elements) {}
+  };
+
+  SmallVector<SemanticSignatureElement>
+  makeSignature(const TestConfig &Config) {
+    SmallVector<SemanticSignatureElement> Elements;
+    for (const ElementConfig &Element : Config.Elements) {
+      SmallVector<uint32_t> SemanticIndices;
+      for (uint32_t Row = 0; Row != Element.Rows; ++Row)
+        SemanticIndices.push_back(Row);
+
+      Elements.push_back(SemanticSignatureElement{
+          /*SigId=*/static_cast<uint32_t>(Elements.size()),
+          /*SemanticName=*/"TEST",
+          /*CompType=*/Element.CompType,
+          /*SemanticKind=*/Element.SemanticKind,
+          /*SemanticIndices=*/std::move(SemanticIndices),
+          /*InterpMode=*/Element.InterpMode,
+          /*Rows=*/Element.Rows,
+          /*Cols=*/Element.Cols,
+          /*StartRow=*/UnallocatedRow,
+          /*StartCol=*/UnallocatedCol,
+          /*UsageMask=*/0,
+          /*DynIndexMask=*/0,
+          /*GSStream=*/0,
+      });
+    }
+    return Elements;
+  }
+
+  Error pack(SmallVectorImpl<SemanticSignatureElement> &Elements,
+             const TestConfig &Config) {
+    return packSignaturePrefixStable(Elements, Config.ShaderStage,
+                                     Config.SignatureKind,
+                                     Config.UseNative16BitTypes);
+  }
+
+  void expectPacking(const TestConfig &Config, unsigned ExpectedRows,
+                     std::initializer_list<ExpectedLocation> Locations) {
+    SmallVector<SemanticSignatureElement> Elements = makeSignature(Config);
+    ASSERT_EQ(Elements.size(), Locations.size());
+
+    ASSERT_THAT_ERROR(pack(Elements, Config), Succeeded());
+
+    unsigned Rows = 0;
+    for (const SemanticSignatureElement &Element : Elements)
+      if (Element.isAllocated())
+        Rows = std::max(Rows, Element.StartRow + Element.Rows);
+    EXPECT_EQ(Rows, ExpectedRows);
+
+    unsigned Index = 0;
+    for (ExpectedLocation Location : Locations) {
+      EXPECT_EQ(Elements[Index].StartRow, Location.Row) << "element " << Index;
+      EXPECT_EQ(Elements[Index].StartCol, Location.Col) << "element " << Index;
+      ++Index;
+    }
+  }
+
+  void expectPackingError(const TestConfig &Config, StringRef Message) {
+    SmallVector<SemanticSignatureElement> Elements = makeSignature(Config);
+    EXPECT_THAT_ERROR(pack(Elements, Config), FailedWithMessage(Message));
+  }
+};
+
+TEST_F(HLSLSemanticSignaturePackingTest, CreatesSignatureFromConfig) {
+  TestConfig Config(
+      Triple::EnvironmentType::Vertex, SemanticSignatureKind::Output,
+      /*UseNative16BitTypes=*/true,
+      {{dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/2,
+        dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear},
+       {dxbc::PSV::SemanticKind::Position, /*Rows=*/2, /*Cols=*/3,
+        dxil::ElementType::F16, dxbc::PSV::InterpolationMode::Constant}});
+
+  EXPECT_EQ(Config.ShaderStage, Triple::EnvironmentType::Vertex);
+  EXPECT_EQ(Config.SignatureKind, SemanticSignatureKind::Output);
+  EXPECT_TRUE(Config.UseNative16BitTypes);
+
+  SmallVector<SemanticSignatureElement> Elements = makeSignature(Config);
+  ASSERT_EQ(Elements.size(), 2u);
+
+  EXPECT_EQ(Elements[0].SigId, 0u);
+  EXPECT_EQ(Elements[0].SemanticName, "TEST");
+  EXPECT_EQ(Elements[0].CompType, dxil::ElementType::F32);
+  EXPECT_EQ(Elements[0].SemanticKind, dxbc::PSV::SemanticKind::Arbitrary);
+  EXPECT_EQ(Elements[0].SemanticIndices, SmallVector<uint32_t>({0}));
+  EXPECT_EQ(Elements[0].InterpMode, dxbc::PSV::InterpolationMode::Linear);
+  EXPECT_EQ(Elements[0].Rows, 1u);
+  EXPECT_EQ(Elements[0].Cols, 2u);
+  EXPECT_EQ(Elements[0].StartRow, UnallocatedRow);
+  EXPECT_EQ(Elements[0].StartCol, UnallocatedCol);
+  EXPECT_EQ(Elements[0].UsageMask, 0u);
+  EXPECT_EQ(Elements[0].DynIndexMask, 0u);
+  EXPECT_EQ(Elements[0].GSStream, 0u);
+
+  EXPECT_EQ(Elements[1].SigId, 1u);
+  EXPECT_EQ(Elements[1].SemanticKind, dxbc::PSV::SemanticKind::Position);
+  EXPECT_EQ(Elements[1].CompType, dxil::ElementType::F16);
+  EXPECT_EQ(Elements[1].InterpMode, dxbc::PSV::InterpolationMode::Constant);
+  EXPECT_EQ(Elements[1].SemanticIndices, SmallVector<uint32_t>({0, 1}));
+  EXPECT_EQ(Elements[1].Rows, 2u);
+  EXPECT_EQ(Elements[1].Cols, 3u);
+}
+
+} // namespace

--- a/llvm/unittests/Frontend/HLSLSemanticSignaturePackingTest.cpp
+++ b/llvm/unittests/Frontend/HLSLSemanticSignaturePackingTest.cpp
@@ -542,10 +542,6 @@ TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableDistinctInterpModes) {
 }
 
 //===----------------------------------------------------------------------===//
-// Boundary and stability tests
-//===----------------------------------------------------------------------===//
-
-//===----------------------------------------------------------------------===//
 // Component ordering tests
 //===----------------------------------------------------------------------===//
 
@@ -626,6 +622,42 @@ TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableSkipsUnpackedElements) {
                 {{/*Row=*/0, /*Col=*/0}, Unallocated, {/*Row=*/0, /*Col=*/2}});
 }
 
+TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableSupportedSignatures) {
+  struct SignatureCase {
+    Triple::EnvironmentType ShaderStage;
+    SemanticSignatureKind SignatureKind;
+  };
+  static constexpr SignatureCase Cases[] = {
+      {Triple::EnvironmentType::Vertex, SemanticSignatureKind::Output},
+      {Triple::EnvironmentType::Hull, SemanticSignatureKind::Input},
+      {Triple::EnvironmentType::Hull, SemanticSignatureKind::Output},
+      {Triple::EnvironmentType::Hull, SemanticSignatureKind::PatchConstOrPrim},
+      {Triple::EnvironmentType::Domain, SemanticSignatureKind::Input},
+      {Triple::EnvironmentType::Domain, SemanticSignatureKind::Output},
+      {Triple::EnvironmentType::Domain,
+       SemanticSignatureKind::PatchConstOrPrim},
+      {Triple::EnvironmentType::Geometry, SemanticSignatureKind::Input},
+      {Triple::EnvironmentType::Geometry, SemanticSignatureKind::Output},
+      {Triple::EnvironmentType::Pixel, SemanticSignatureKind::Input},
+      {Triple::EnvironmentType::Mesh, SemanticSignatureKind::Output},
+      {Triple::EnvironmentType::Mesh, SemanticSignatureKind::PatchConstOrPrim},
+  };
+
+  for (const SignatureCase &Case : Cases) {
+    SCOPED_TRACE(testing::Message()
+                 << "stage " << static_cast<unsigned>(Case.ShaderStage)
+                 << ", signature "
+                 << static_cast<unsigned>(Case.SignatureKind));
+    TestConfig Config(
+        Case.ShaderStage, Case.SignatureKind,
+        /*UseNative16BitTypes=*/false,
+        {{dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1, /*Cols=*/1,
+          dxil::ElementType::F32, dxbc::PSV::InterpolationMode::Linear}});
+
+    expectPacking(Config, /*ExpectedRows=*/1, {{/*Row=*/0, /*Col=*/0}});
+  }
+}
+
 //===----------------------------------------------------------------------===//
 // Dynamic indexing tests
 //===----------------------------------------------------------------------===//
@@ -704,10 +736,6 @@ TEST_F(HLSLSemanticSignaturePackingTest,
   expectPacking(Config, /*ExpectedRows=*/5,
                 {{/*Row=*/0, /*Col=*/0}, {/*Row=*/3, /*Col=*/3}});
 }
-
-//===----------------------------------------------------------------------===//
-// Clip/cull tests
-//===----------------------------------------------------------------------===//
 
 TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableClipCull) {
   // struct VSOut {
@@ -829,6 +857,47 @@ TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableMultipleIndexedClipCull) {
                  {/*Row=*/0, /*Col=*/3},
                  {/*Row=*/3, /*Col=*/0}});
 }
+
+TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableGeometryStreams) {
+  // Each geometry shader output stream is packed into its own signature, so
+  // elements of different streams never share a register. The reported number
+  // of rows is the maximum used by any single stream.
+
+  // struct Stream0 {
+  //   float4 A : A;
+  //   float2 C : C;
+  // };
+  // struct Stream1 {
+  //   float4 B : B;
+  // };
+  // void GSMain(inout PointStream<Stream0> S0, inout PointStream<Stream1> S1);
+  //
+  // Elements are declared in the order A, B, C.
+  TestConfig Config(Triple::EnvironmentType::Geometry,
+                    SemanticSignatureKind::Output,
+                    /*UseNative16BitTypes=*/false,
+                    {{dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1,
+                      /*Cols=*/4, dxil::ElementType::F32,
+                      dxbc::PSV::InterpolationMode::Linear, /*GSStream=*/0},
+                     {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1,
+                      /*Cols=*/4, dxil::ElementType::F32,
+                      dxbc::PSV::InterpolationMode::Linear, /*GSStream=*/1},
+                     {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1,
+                      /*Cols=*/2, dxil::ElementType::F32,
+                      dxbc::PSV::InterpolationMode::Linear, /*GSStream=*/0}});
+
+  // Expected layout:
+  // stream0 reg0: A.xyzw
+  // stream0 reg1: C.xy | unused.zw
+  // stream1 reg0: B.xyzw
+  expectPacking(
+      Config, /*ExpectedRows=*/2,
+      {{/*Row=*/0, /*Col=*/0}, {/*Row=*/0, /*Col=*/0}, {/*Row=*/1, /*Col=*/0}});
+}
+
+//===----------------------------------------------------------------------===//
+// Boundary and stability tests
+//===----------------------------------------------------------------------===//
 
 TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableClipCullFillsTwoRows) {
   // Clip and cull distances may use a combined maximum of eight components
@@ -963,43 +1032,6 @@ TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableClipCullWhenAppended) {
                  {/*Row=*/1, /*Col=*/3},
                  {/*Row=*/0, /*Col=*/3},
                  {/*Row=*/3, /*Col=*/0}});
-}
-
-TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableGeometryStreams) {
-  // Each geometry shader output stream is packed into its own signature, so
-  // elements of different streams never share a register. The reported number
-  // of rows is the maximum used by any single stream.
-
-  // struct Stream0 {
-  //   float4 A : A;
-  //   float2 C : C;
-  // };
-  // struct Stream1 {
-  //   float4 B : B;
-  // };
-  // void GSMain(inout PointStream<Stream0> S0, inout PointStream<Stream1> S1);
-  //
-  // Elements are declared in the order A, B, C.
-  TestConfig Config(Triple::EnvironmentType::Geometry,
-                    SemanticSignatureKind::Output,
-                    /*UseNative16BitTypes=*/false,
-                    {{dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1,
-                      /*Cols=*/4, dxil::ElementType::F32,
-                      dxbc::PSV::InterpolationMode::Linear, /*GSStream=*/0},
-                     {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1,
-                      /*Cols=*/4, dxil::ElementType::F32,
-                      dxbc::PSV::InterpolationMode::Linear, /*GSStream=*/1},
-                     {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1,
-                      /*Cols=*/2, dxil::ElementType::F32,
-                      dxbc::PSV::InterpolationMode::Linear, /*GSStream=*/0}});
-
-  // Expected layout:
-  // stream0 reg0: A.xyzw
-  // stream0 reg1: C.xy | unused.zw
-  // stream1 reg0: B.xyzw
-  expectPacking(
-      Config, /*ExpectedRows=*/2,
-      {{/*Row=*/0, /*Col=*/0}, {/*Row=*/0, /*Col=*/0}, {/*Row=*/1, /*Col=*/0}});
 }
 
 TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableFillsAllRows) {

--- a/llvm/unittests/Frontend/HLSLSemanticSignaturePackingTest.cpp
+++ b/llvm/unittests/Frontend/HLSLSemanticSignaturePackingTest.cpp
@@ -32,6 +32,8 @@ protected:
     uint8_t Cols;
     dxil::ElementType CompType;
     dxbc::PSV::InterpolationMode InterpMode;
+    // Only meaningful for geometry shader output signatures.
+    uint32_t GSStream = 0;
   };
 
   struct ExpectedLocation {
@@ -78,7 +80,7 @@ protected:
           /*StartCol=*/UnallocatedCol,
           /*UsageMask=*/0,
           /*DynIndexMask=*/0,
-          /*GSStream=*/0,
+          /*GSStream=*/Element.GSStream,
       });
     }
     return Elements;
@@ -961,6 +963,43 @@ TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableClipCullWhenAppended) {
                  {/*Row=*/1, /*Col=*/3},
                  {/*Row=*/0, /*Col=*/3},
                  {/*Row=*/3, /*Col=*/0}});
+}
+
+TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableGeometryStreams) {
+  // Each geometry shader output stream is packed into its own signature, so
+  // elements of different streams never share a register. The reported number
+  // of rows is the maximum used by any single stream.
+
+  // struct Stream0 {
+  //   float4 A : A;
+  //   float2 C : C;
+  // };
+  // struct Stream1 {
+  //   float4 B : B;
+  // };
+  // void GSMain(inout PointStream<Stream0> S0, inout PointStream<Stream1> S1);
+  //
+  // Elements are declared in the order A, B, C.
+  TestConfig Config(Triple::EnvironmentType::Geometry,
+                    SemanticSignatureKind::Output,
+                    /*UseNative16BitTypes=*/false,
+                    {{dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1,
+                      /*Cols=*/4, dxil::ElementType::F32,
+                      dxbc::PSV::InterpolationMode::Linear, /*GSStream=*/0},
+                     {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1,
+                      /*Cols=*/4, dxil::ElementType::F32,
+                      dxbc::PSV::InterpolationMode::Linear, /*GSStream=*/1},
+                     {dxbc::PSV::SemanticKind::Arbitrary, /*Rows=*/1,
+                      /*Cols=*/2, dxil::ElementType::F32,
+                      dxbc::PSV::InterpolationMode::Linear, /*GSStream=*/0}});
+
+  // Expected layout:
+  // stream0 reg0: A.xyzw
+  // stream0 reg1: C.xy | unused.zw
+  // stream1 reg0: B.xyzw
+  expectPacking(
+      Config, /*ExpectedRows=*/2,
+      {{/*Row=*/0, /*Col=*/0}, {/*Row=*/0, /*Col=*/0}, {/*Row=*/1, /*Col=*/0}});
 }
 
 TEST_F(HLSLSemanticSignaturePackingTest, PrefixStableFillsAllRows) {


### PR DESCRIPTION
This change implements prefix stable packing as described in https://github.com/llvm/llvm-project/issues/204889 and the linked references.

Additionally it adds the relevant existing semantics in the front-end to the packing categorization so that they are packed correctly. Future semantics added will have to add their definition here in a similar manner.

Care has been taken to break up this change into incremental commits that should be easier to review, unfortunately I don't think the pr can be broken down into those smaller increments as individual independent changes.

Resolves: https://github.com/llvm/llvm-project/issues/204889

Assisted by: Claude Opus 5 and GPT-5.6 Sol