### PR TITLE
[lldb] Remove ConstString from TypeFormatImpl_EnumType

### DIFF
--- a/lldb/include/lldb/DataFormatters/TypeFormat.h
+++ b/lldb/include/lldb/DataFormatters/TypeFormat.h
@@ -193,16 +193,18 @@ private:
 
 class TypeFormatImpl_EnumType : public TypeFormatImpl {
 public:
-  TypeFormatImpl_EnumType(ConstString type_name = ConstString(""),
+  TypeFormatImpl_EnumType(std::string type_name = "",
                           const TypeFormatImpl::Flags &flags = Flags());
 
   typedef std::shared_ptr<TypeFormatImpl_EnumType> SharedPointer;
 
   ~TypeFormatImpl_EnumType() override;
 
-  ConstString GetTypeName() { return m_enum_type; }
+  const std::string &GetTypeName() { return m_enum_type; }
 
-  void SetTypeName(ConstString enum_type) { m_enum_type = enum_type; }
+  void SetTypeName(std::string enum_type) {
+    m_enum_type = std::move(enum_type);
+  }
 
   TypeFormatImpl::Type GetType() override {
     return TypeFormatImpl::Type::eTypeEnum;
@@ -213,7 +215,7 @@ public:
   std::string GetDescription() override;
 
 protected:
-  ConstString m_enum_type;
+  std::string m_enum_type;
   mutable std::unordered_map<void *, CompilerType> m_types;
 
 private:

--- a/lldb/source/API/SBTypeFormat.cpp
+++ b/lldb/source/API/SBTypeFormat.cpp
@@ -25,8 +25,8 @@ SBTypeFormat::SBTypeFormat(lldb::Format format, uint32_t options)
 }
 
 SBTypeFormat::SBTypeFormat(const char *type, uint32_t options)
-    : m_opaque_sp(TypeFormatImplSP(new TypeFormatImpl_EnumType(
-          ConstString(type ? type : ""), options))) {
+    : m_opaque_sp(TypeFormatImplSP(
+          new TypeFormatImpl_EnumType(type ? type : "", options))) {
   LLDB_INSTRUMENT_VA(this, type, options);
 }
 
@@ -59,8 +59,8 @@ const char *SBTypeFormat::GetTypeName() {
   LLDB_INSTRUMENT_VA(this);
 
   if (IsValid() && m_opaque_sp->GetType() == TypeFormatImpl::Type::eTypeEnum)
-    return ((TypeFormatImpl_EnumType *)m_opaque_sp.get())
-        ->GetTypeName()
+    return ConstString(
+               ((TypeFormatImpl_EnumType *)m_opaque_sp.get())->GetTypeName())
         .AsCString("");
   return "";
 }
@@ -85,7 +85,7 @@ void SBTypeFormat::SetTypeName(const char *type) {
 
   if (CopyOnWrite_Impl(Type::eTypeEnum))
     ((TypeFormatImpl_EnumType *)m_opaque_sp.get())
-        ->SetTypeName(ConstString(type ? type : ""));
+        ->SetTypeName(type ? type : "");
 }
 
 void SBTypeFormat::SetOptions(uint32_t value) {
@@ -177,7 +177,7 @@ bool SBTypeFormat::CopyOnWrite_Impl(Type type) {
         TypeFormatImplSP(new TypeFormatImpl_Format(GetFormat(), GetOptions())));
   else
     SetSP(TypeFormatImplSP(
-        new TypeFormatImpl_EnumType(ConstString(GetTypeName()), GetOptions())));
+        new TypeFormatImpl_EnumType(GetTypeName(), GetOptions())));
 
   return true;
 }

--- a/lldb/source/Commands/CommandObjectType.cpp
+++ b/lldb/source/Commands/CommandObjectType.cpp
@@ -695,7 +695,7 @@ protected:
                       .SetSkipReferences(m_command_options.m_skip_references));
     else
       entry = std::make_shared<TypeFormatImpl_EnumType>(
-          ConstString(m_command_options.m_custom_type_name),
+          m_command_options.m_custom_type_name,
           TypeFormatImpl::Flags()
               .SetCascades(m_command_options.m_cascade)
               .SetSkipPointers(m_command_options.m_skip_pointers)

--- a/lldb/source/DataFormatters/TypeFormat.cpp
+++ b/lldb/source/DataFormatters/TypeFormat.cpp
@@ -137,8 +137,8 @@ std::string TypeFormatImpl_Format::GetDescription() {
 }
 
 TypeFormatImpl_EnumType::TypeFormatImpl_EnumType(
-    ConstString type_name, const TypeFormatImpl::Flags &flags)
-    : TypeFormatImpl(flags), m_enum_type(type_name), m_types() {}
+    std::string type_name, const TypeFormatImpl::Flags &flags)
+    : TypeFormatImpl(flags), m_enum_type(std::move(type_name)), m_types() {}
 
 TypeFormatImpl_EnumType::~TypeFormatImpl_EnumType() = default;
 
@@ -165,7 +165,7 @@ bool TypeFormatImpl_EnumType::FormatObject(ValueObject *valobj,
     if (!target_sp)
       return false;
     const ModuleList &images(target_sp->GetImages());
-    TypeQuery query(m_enum_type.GetStringRef());
+    TypeQuery query(m_enum_type);
     TypeResults results;
     images.FindTypes(nullptr, query, results);
     if (results.GetTypeMap().Empty())
@@ -201,7 +201,8 @@ bool TypeFormatImpl_EnumType::FormatObject(ValueObject *valobj,
 
 std::string TypeFormatImpl_EnumType::GetDescription() {
   StreamString sstr;
-  sstr.Printf("as type %s%s%s%s", m_enum_type.AsCString("<invalid type>"),
+  sstr.Format("as type {0}{1}{2}{3}",
+              llvm::StringRef(m_enum_type).nonEmptyOr("<invalid type>"),
               Cascades() ? "" : " (not cascading)",
               SkipsPointers() ? " (skip pointers)" : "",
               SkipsReferences() ? " (skip references)" : "");


### PR DESCRIPTION
These type names don't need to be in the ConstString pool. If they ever need to be deduplicated in the future, we can evaluate different approaches.