### PR TITLE
Skeleton for OpenMP to SPIR-V compilation

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -7087,10 +7087,16 @@ const ToolChain &Driver::getOffloadToolChain(
                                                        Args);
       break;
     case llvm::Triple::AMDHSA:
-      // For AMDHSA offloading (HIP, OpenMP), use the unified AMDGPUToolChain
-      // This handles both amdgpu-amd-amdhsa and spirv64-amd-amdhsa
+      // For AMDHSA offloading (HIP, OpenMP), use the unified AMDGPUToolChain.
+      // This handles both amdgpu-amd-amdhsa and spirv64-amd-amdhsa.
+      // Exception: an AMDHSA OpenMP target whose architecture is SPIR-V
+      // (e.g. spirv64-amd-amdhsa) targets the AMDGCN-flavored SPIR-V ABI and
+      // requires the SPIR-V OpenMP toolchain rather than the native AMDGPU one.
       // FIXME: This should not key off language or OS.
-      if (Kind == Action::OFK_HIP || Kind == Action::OFK_OpenMP)
+      if (Kind == Action::OFK_OpenMP && Target.isSPIRV())
+        TC = std::make_unique<toolchains::SPIRVOpenMPToolChain>(
+            *this, Target, *HostTC, Args);
+      else if (Kind == Action::OFK_HIP || Kind == Action::OFK_OpenMP)
         TC = std::make_unique<toolchains::AMDGPUToolChain>(*this, Target, Args,
                                                            HostTC.get(), Kind);
       break;

--- a/clang/lib/Driver/ToolChains/SPIRVOpenMP.cpp
+++ b/clang/lib/Driver/ToolChains/SPIRVOpenMP.cpp
@@ -5,31 +5,234 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //==------------------------------------------------------------------------==//
+
 #include "SPIRVOpenMP.h"
-#include "clang/Driver/CommonArgs.h"
+#include "clang/Driver/Compilation.h"
+#include "clang/Driver/Driver.h"
+#include "clang/Driver/InputInfo.h"
+#include "clang/Options/Options.h"
+#include "llvm/Config/llvm-config.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Path.h"
 
 using namespace clang::driver;
 using namespace clang::driver::toolchains;
 using namespace clang::driver::tools;
+using namespace clang;
 using namespace llvm::opt;
 
+namespace clang::driver::tools::SPIRVOpenMP {
+
+std::string Linker::findSpirvTranslator(const llvm::opt::ArgList &Args) const {
+  const ToolChain &TC = getToolChain();
+  const std::string Major = std::to_string(LLVM_VERSION_MAJOR);
+
+  // Prefer the AMD-patched translator that ships with ROCm toolchains.
+  for (const std::string &Candidate :
+       {"amd-llvm-spirv-" + Major, "amd-llvm-spirv",
+        "llvm-spirv-" + Major, "llvm-spirv"}) {
+    std::string Path = TC.GetProgramPath(Candidate.c_str());
+    if (llvm::sys::fs::can_execute(Path))
+      return Path;
+  }
+  // Return the last candidate regardless; the missing-executable error will
+  // surface naturally when the command is executed.
+  return TC.GetProgramPath("llvm-spirv");
+}
+
+void Linker::constructLinkAndEmitSpirvCommand(
+    Compilation &C, const JobAction &JA, const InputInfoList &Inputs,
+    const InputInfo &Output, const llvm::opt::ArgList &Args) const {
+
+  assert(!Inputs.empty() && "Must have at least one input.");
+
+  // Step 1: merge the compiled device bitcode inputs with llvm-link.
+  // The device RTL (libomptarget-spirv.bc) was already absorbed into each
+  // input at the cc1 stage via -mlink-builtin-bitcode; it must not be
+  // re-linked here.
+  const std::string TempBCPath = C.getDriver().GetTemporaryPath(
+      llvm::sys::path::stem(Output.getFilename()), "bc");
+  const char *TempBC = Args.MakeArgString(TempBCPath);
+
+  ArgStringList LinkArgs;
+  for (const InputInfo &Input : Inputs)
+    LinkArgs.push_back(Input.getFilename());
+  for (const Arg *A : Args.filtered(options::OPT_mlink_builtin_bitcode))
+    LinkArgs.push_back(A->getValue());
+
+  SmallString<128> LLVMLinkPath(C.getDriver().Dir);
+  llvm::sys::path::append(LLVMLinkPath, "llvm-link");
+
+  ArgStringList LLVMLinkCmdArgs = {"-o", TempBC};
+  for (const char *Arg : LinkArgs)
+    LLVMLinkCmdArgs.push_back(Arg);
+
+  C.addCommand(std::make_unique<Command>(
+      JA, *this, ResponseFileSupport::None(),
+      Args.MakeArgString(LLVMLinkPath), LLVMLinkCmdArgs, Inputs,
+      InputInfo(&JA, TempBC, TempBC)));
+
+  // Step 2: translate the merged bitcode to SPIR-V.
+  ArgStringList TrArgs;
+  TrArgs.append({"--spirv-max-version=1.6", "--spirv-ext=+all",
+                 "--spirv-allow-unknown-intrinsics",
+                 "--spirv-lower-const-expr",
+                 "--spirv-preserve-auxdata",
+                 "--spirv-debug-info-version=nonsemantic-shader-200",
+                 TempBC, "-o", Output.getFilename()});
+
+  InputInfo TrInput(types::TY_LLVM_BC, TempBC, TempBC);
+  C.addCommand(std::make_unique<Command>(
+      JA, *this, ResponseFileSupport::None(),
+      Args.MakeArgString(findSpirvTranslator(Args)), TrArgs,
+      TrInput, Output));
+}
+
+void Linker::ConstructJob(Compilation &C, const JobAction &JA,
+                          const InputInfo &Output, const InputInfoList &Inputs,
+                          const llvm::opt::ArgList &Args,
+                          const char * /*LinkingOutput*/) const {
+  constructLinkAndEmitSpirvCommand(C, JA, Inputs, Output, Args);
+}
+
+} // namespace clang::driver::tools::SPIRVOpenMP
+
 namespace clang::driver::toolchains {
+
 SPIRVOpenMPToolChain::SPIRVOpenMPToolChain(const Driver &D,
                                            const llvm::Triple &Triple,
                                            const ToolChain &HostToolchain,
                                            const ArgList &Args)
-    : SPIRVToolChain(D, Triple, Args), HostTC(HostToolchain) {}
+    : SPIRVToolChain(D, Triple, Args), HostTC(HostToolchain) {
+  // Ensure the driver binary directory is searched first when locating
+  // offload tools (e.g. llvm-link, amd-llvm-spirv).
+  getProgramPaths().push_back(getDriver().Dir);
+}
 
 void SPIRVOpenMPToolChain::addClangTargetOptions(
     const llvm::opt::ArgList &DriverArgs, llvm::opt::ArgStringList &CC1Args,
     BoundArch BA, Action::OffloadKind DeviceOffloadingKind) const {
 
+  // Forward options the host toolchain has already collected (e.g. target
+  // feature flags that must be visible to the device compilation).
+  HostTC.addClangTargetOptions(DriverArgs, CC1Args, DeviceOffloadingKind);
+
   if (DeviceOffloadingKind != Action::OFK_OpenMP)
     return;
 
+  // Auto-vectorisation passes produce LLVM IR patterns that the SPIR-V
+  // translator cannot handle reliably; disable them for device code.
+  CC1Args.append({"-mllvm", "-vectorize-loops=false",
+                  "-mllvm", "-vectorize-slp=false"});
+
+  // Default to hidden visibility so that device symbols do not accidentally
+  // leak into the host link unless explicitly exported.
+  if (!DriverArgs.hasArg(options::OPT_fvisibility_EQ,
+                         options::OPT_fvisibility_ms_compat))
+    CC1Args.append({"-fvisibility=hidden",
+                    "-fapply-global-visibility-to-externs"});
+
+  // Inject the device RTL at compile time via -mlink-builtin-bitcode so that
+  // it is absorbed during LTO codegen.  This follows the same pattern used by
+  // HIPSPVToolChain and AMDGPUOpenMPToolChain and avoids having to re-link the
+  // library in the separate llvm-link step.
+  for (const BitCodeLibraryInfo &BCLib :
+       getDeviceLibs(DriverArgs, Action::OFK_OpenMP))
+    CC1Args.append({"-mlink-builtin-bitcode",
+                    DriverArgs.MakeArgString(BCLib.Path)});
+}
+
+void SPIRVOpenMPToolChain::addClangWarningOptions(
+    ArgStringList &CC1Args) const {
+  HostTC.addClangWarningOptions(CC1Args);
+}
+
+ToolChain::CXXStdlibType
+SPIRVOpenMPToolChain::GetCXXStdlibType(const ArgList &Args) const {
+  return HostTC.GetCXXStdlibType(Args);
+}
+
+void SPIRVOpenMPToolChain::AddClangSystemIncludeArgs(
+    const ArgList &DriverArgs, ArgStringList &CC1Args) const {
+  HostTC.AddClangSystemIncludeArgs(DriverArgs, CC1Args);
+}
+
+void SPIRVOpenMPToolChain::AddClangCXXStdlibIncludeArgs(
+    const ArgList &Args, ArgStringList &CC1Args) const {
+  HostTC.AddClangCXXStdlibIncludeArgs(Args, CC1Args);
+}
+
+llvm::SmallVector<ToolChain::BitCodeLibraryInfo, 12>
+SPIRVOpenMPToolChain::getDeviceLibs(const llvm::opt::ArgList &DriverArgs,
+                                    Action::OffloadKind) const {
   if (!DriverArgs.hasFlag(options::OPT_offloadlib, options::OPT_no_offloadlib,
                           true))
-    return;
-  addOpenMPDeviceRTL(getDriver(), DriverArgs, CC1Args, "", getTriple(), HostTC);
+    return {};
+
+  // Build the ordered list of directories to search for the device RTL.
+  SmallVector<SmallString<128>, 6> SearchPaths;
+
+  // 1. Explicit user override takes highest priority.
+  if (StringRef UserPath = DriverArgs.getLastArgValue(
+          options::OPT_libomptarget_spirv_bc_path_EQ);
+      !UserPath.empty())
+    SearchPaths.emplace_back(UserPath);
+
+  // 2. ROCm installation lib directory.
+  if (StringRef RocmPath =
+          DriverArgs.getLastArgValue(options::OPT_rocm_path_EQ);
+      !RocmPath.empty()) {
+    SearchPaths.emplace_back(RocmPath);
+    llvm::sys::path::append(SearchPaths.back(), "lib");
+  }
+
+  // 3. Sysroot lib directory.
+  if (!getDriver().SysRoot.empty()) {
+    SearchPaths.emplace_back(getDriver().SysRoot);
+    llvm::sys::path::append(SearchPaths.back(), "lib");
+  }
+
+  // 4. Clang resource lib directory.
+  SearchPaths.emplace_back(getDriver().ResourceDir);
+  llvm::sys::path::append(SearchPaths.back(), "lib");
+
+  // 5. Driver-relative lib directory (e.g. <install>/bin/../lib).
+  SearchPaths.emplace_back(getDriver().Dir);
+  llvm::sys::path::append(SearchPaths.back(), "..", "lib");
+
+  constexpr llvm::StringLiteral BCName = "libomptarget-spirv.bc";
+  for (const auto &Dir : SearchPaths) {
+    SmallString<128> FullPath(Dir);
+    llvm::sys::path::append(FullPath, BCName);
+    if (llvm::sys::fs::exists(FullPath))
+      return {{std::string(FullPath)}};
+  }
+
+  getDriver().Diag(diag::err_drv_omp_offload_target_missingbcruntime)
+      << BCName << "spirv";
+  return {};
 }
+
+SanitizerMask SPIRVOpenMPToolChain::getSupportedSanitizers() const {
+  return HostTC.getSupportedSanitizers();
+}
+
+VersionTuple
+SPIRVOpenMPToolChain::computeMSVCVersion(const Driver *D,
+                                         const ArgList &Args) const {
+  return HostTC.computeMSVCVersion(D, Args);
+}
+
+void SPIRVOpenMPToolChain::adjustDebugInfoKind(
+    llvm::codegenoptions::DebugInfoKind &DebugInfoKind,
+    const llvm::opt::ArgList &) const {
+  // The SPIR-V translator currently aborts on DW_OP_LLVM_convert; suppress
+  // debug info until the SPIR-V backend has full debug support.
+  DebugInfoKind = llvm::codegenoptions::NoDebugInfo;
+}
+
+Tool *SPIRVOpenMPToolChain::buildLinker() const {
+  return new tools::SPIRVOpenMP::Linker(*this);
+}
+
 } // namespace clang::driver::toolchains

--- a/clang/lib/Driver/ToolChains/SPIRVOpenMP.h
+++ b/clang/lib/Driver/ToolChains/SPIRVOpenMP.h
@@ -10,20 +10,102 @@
 #define LLVM_CLANG_LIB_DRIVER_TOOLCHAINS_SPIRV_OPENMP_H
 
 #include "SPIRV.h"
+#include "clang/Driver/Compilation.h"
 #include "clang/Driver/Tool.h"
 #include "clang/Driver/ToolChain.h"
 
-namespace clang::driver::toolchains {
+namespace clang {
+namespace driver {
+namespace tools {
+namespace SPIRVOpenMP {
+
+/// Links device bitcode files with llvm-link and then translates the result
+/// to SPIR-V via amd-llvm-spirv (or a versioned/fallback llvm-spirv).
+class LLVM_LIBRARY_VISIBILITY Linker final : public Tool {
+public:
+  Linker(const ToolChain &TC)
+      : Tool("SPIRVOpenMP::Linker", "spirv-omp-link", TC) {}
+
+  bool hasIntegratedCPP() const override { return false; }
+  bool isLinkJob() const override { return true; }
+
+  void ConstructJob(Compilation &C, const JobAction &JA,
+                    const InputInfo &Output, const InputInfoList &Inputs,
+                    const llvm::opt::ArgList &TCArgs,
+                    const char *LinkingOutput) const override;
+
+private:
+  /// Builds two chained commands:
+  ///   1. llvm-link  — merge all input bitcode files (+ device RTL) into one.
+  ///   2. amd-llvm-spirv (or llvm-spirv) — translate the merged BC to SPIR-V.
+  void constructLinkAndEmitSpirvCommand(
+      Compilation &C, const JobAction &JA, const InputInfoList &Inputs,
+      const InputInfo &Output, const llvm::opt::ArgList &Args) const;
+
+  /// Returns the path to the best available SPIR-V translator binary, trying
+  /// versioned AMD-specific names before falling back to the generic one.
+  std::string findSpirvTranslator(const llvm::opt::ArgList &Args) const;
+};
+
+} // namespace SPIRVOpenMP
+} // namespace tools
+
+namespace toolchains {
+
+/// Toolchain for compiling OpenMP device code to AMDGCN-flavored SPIR-V.
+///
+/// Inherits basic SPIR-V toolchain infrastructure from SPIRVToolChain and
+/// delegates host-specific queries (include paths, warnings, C++ stdlib, etc.)
+/// to the accompanying host toolchain.
 class LLVM_LIBRARY_VISIBILITY SPIRVOpenMPToolChain : public SPIRVToolChain {
 public:
   SPIRVOpenMPToolChain(const Driver &D, const llvm::Triple &Triple,
-                       const ToolChain &HostTC, const llvm::opt::ArgList &Args);
+                       const ToolChain &HostTC,
+                       const llvm::opt::ArgList &Args);
+
+  const llvm::Triple *getAuxTriple() const override {
+    return &HostTC.getTriple();
+  }
 
   void addClangTargetOptions(
       const llvm::opt::ArgList &DriverArgs, llvm::opt::ArgStringList &CC1Args,
       BoundArch BA, Action::OffloadKind DeviceOffloadingKind) const override;
 
+  void addClangWarningOptions(
+      llvm::opt::ArgStringList &CC1Args) const override;
+
+  CXXStdlibType GetCXXStdlibType(
+      const llvm::opt::ArgList &Args) const override;
+
+  void AddClangSystemIncludeArgs(
+      const llvm::opt::ArgList &DriverArgs,
+      llvm::opt::ArgStringList &CC1Args) const override;
+
+  void AddClangCXXStdlibIncludeArgs(
+      const llvm::opt::ArgList &Args,
+      llvm::opt::ArgStringList &CC1Args) const override;
+
+  llvm::SmallVector<BitCodeLibraryInfo, 12>
+  getDeviceLibs(const llvm::opt::ArgList &Args,
+                Action::OffloadKind DeviceOffloadKind) const override;
+
+  SanitizerMask getSupportedSanitizers() const override;
+
+  VersionTuple computeMSVCVersion(const Driver *D,
+                                  const llvm::opt::ArgList &Args) const override;
+
+  void adjustDebugInfoKind(
+      llvm::codegenoptions::DebugInfoKind &DebugInfoKind,
+      const llvm::opt::ArgList &Args) const override;
+
   const ToolChain &HostTC;
+
+protected:
+  Tool *buildLinker() const override;
 };
-} // namespace clang::driver::toolchains
-#endif
+
+} // namespace toolchains
+} // namespace driver
+} // namespace clang
+
+#endif // LLVM_CLANG_LIB_DRIVER_TOOLCHAINS_SPIRV_OPENMP_H


### PR DESCRIPTION
Expand SPIRVOpenMPToolChain into OpenMP device toolchain for AMDGCN-flavored SPIR-V targets. Adds getDeviceLibs for libomptarget-spirv.bc discovery, vectorisation and visibility flags in addClangTargetOptions, and routes spirv64-amd-amdhsa targets through SPIRVOpenMPToolChain in Driver.

Assisted by AI.