### PR TITLE
[ORC] Standardize dylib manager on NativeDylibManager names

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/EPCGenericDylibManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/EPCGenericDylibManager.h
@@ -58,11 +58,6 @@ public:
     ResolveProxy Resolve;
   };
 
-  /// Create an EPCGenericDylibManager instance by looking up the LLVM-style
-  /// SimpleExecutorDylibManager symbol names in the EPC's bootstrap table.
-  static Expected<EPCGenericDylibManager>
-  CreateWithDefaultBootstrapSymbols(ExecutorProcessControl &EPC);
-
   /// Create an EPCGenericDylibManager for the ORC runtime's NativeDylibManager
   /// interface, resolving its symbols in the given JITDylib.
   static Expected<EPCGenericDylibManager> Create(JITDylib &JD);

--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h
@@ -23,10 +23,6 @@ namespace llvm {
 namespace orc {
 namespace rt {
 
-LLVM_ABI extern const char *SimpleExecutorDylibManagerInstanceName;
-LLVM_ABI extern const char *SimpleExecutorDylibManagerOpenWrapperName;
-LLVM_ABI extern const char *SimpleExecutorDylibManagerResolveWrapperName;
-
 LLVM_ABI extern const char *SimpleExecutorMemoryManagerInstanceName;
 LLVM_ABI extern const char *SimpleExecutorMemoryManagerReserveWrapperName;
 LLVM_ABI extern const char *SimpleExecutorMemoryManagerInitializeWrapperName;

--- a/llvm/lib/ExecutionEngine/Orc/EPCGenericDylibManager.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/EPCGenericDylibManager.cpp
@@ -58,29 +58,6 @@ using ResolveSpec =
 
 } // namespace
 
-Expected<EPCGenericDylibManager>
-EPCGenericDylibManager::CreateWithDefaultBootstrapSymbols(
-    ExecutorProcessControl &EPC) {
-  auto &ES = EPC.getExecutionSession();
-  auto &JD = ES.getBootstrapJITDylib();
-  Bindings B;
-  // Instance is the executor-side manager object -- a data symbol passed as the
-  // first argument to each call, not a wrapper to proxy.
-  if (auto Err = lookupAndRecordAddrs(
-          ES, LookupKind::Static, makeJITDylibSearchOrder({&JD}),
-          {{ES.intern(rt::SimpleExecutorDylibManagerInstanceName),
-            &B.Instance}}))
-    return std::move(Err);
-  if (auto Err = rt::buildProxies(
-          JD,
-          rt::proxyInit<OpenSpec>(
-              &B.Open, rt::SimpleExecutorDylibManagerOpenWrapperName),
-          rt::proxyInit<ResolveSpec>(
-              &B.Resolve, rt::SimpleExecutorDylibManagerResolveWrapperName)))
-    return std::move(Err);
-  return EPCGenericDylibManager(ES, std::move(B));
-}
-
 Expected<EPCGenericDylibManager> EPCGenericDylibManager::Create(JITDylib &JD) {
   auto &ES = JD.getExecutionSession();
   Bindings B;

--- a/llvm/lib/ExecutionEngine/Orc/Shared/OrcRTBridge.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Shared/OrcRTBridge.cpp
@@ -14,13 +14,6 @@ namespace llvm {
 namespace orc {
 namespace rt {
 
-const char *SimpleExecutorDylibManagerInstanceName =
-    "__llvm_orc_SimpleExecutorDylibManager_Instance";
-const char *SimpleExecutorDylibManagerOpenWrapperName =
-    "__llvm_orc_SimpleExecutorDylibManager_open_wrapper";
-const char *SimpleExecutorDylibManagerResolveWrapperName =
-    "__llvm_orc_SimpleExecutorDylibManager_resolve_wrapper";
-
 const char *SimpleExecutorMemoryManagerInstanceName =
     "__llvm_orc_SimpleExecutorMemoryManager_Instance";
 const char *SimpleExecutorMemoryManagerReserveWrapperName =

--- a/llvm/lib/ExecutionEngine/Orc/SimpleRemoteEPC.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/SimpleRemoteEPC.cpp
@@ -78,7 +78,7 @@ SimpleRemoteEPC::createDefaultMemoryManager() {
 
 Expected<std::unique_ptr<DylibManager>>
 SimpleRemoteEPC::createDefaultDylibMgr() {
-  auto DM = EPCGenericDylibManager::CreateWithDefaultBootstrapSymbols(*this);
+  auto DM = EPCGenericDylibManager::Create(getExecutionSession());
   if (!DM)
     return DM.takeError();
   return std::make_unique<EPCGenericDylibManager>(std::move(*DM));

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/SimpleExecutorDylibManager.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/SimpleExecutorDylibManager.cpp
@@ -69,18 +69,10 @@ Error SimpleExecutorDylibManager::shutdown() {
 
 void SimpleExecutorDylibManager::addBootstrapSymbols(
     StringMap<ExecutorAddr> &M) {
-  M[rt::SimpleExecutorDylibManagerInstanceName] = ExecutorAddr::fromPtr(this);
-  M[rt::SimpleExecutorDylibManagerOpenWrapperName] =
-      ExecutorAddr::fromPtr(&openWrapper);
-  M[rt::SimpleExecutorDylibManagerResolveWrapperName] =
-      ExecutorAddr::fromPtr(&resolveWrapper);
-
-  // Also provide NativeDylibManager symbols for compatibility with
-  // controllers configured to use the ORC runtime's NativeDylibManager
-  // interface.
-  // FIXME: We should codify a "simple" dylib manager interface and make
-  // SimpleExecutorDylibManager its LLVM-based implementation, and
-  // NativeDylibManager its ORC-runtime implementation.
+  // SimpleExecutorDylibManager is the LLVM-side implementation of the runtime's
+  // NativeDylibManager controller interface, so it publishes its bootstrap
+  // symbols under the NativeDylibManager_* names. The class itself will be
+  // renamed to NativeDylibManager to match in a future cleanup.
   M[rt::NativeDylibManagerInstanceName] = ExecutorAddr::fromPtr(this);
   M[rt::NativeDylibManagerLoadWrapperName] =
       ExecutorAddr::fromPtr(&openWrapper);

--- a/llvm/tools/lli/ForwardingMemoryManager.h
+++ b/llvm/tools/lli/ForwardingMemoryManager.h
@@ -93,23 +93,18 @@ class RemoteResolver : public LegacyJITSymbolResolver {
 public:
   static Expected<std::unique_ptr<RemoteResolver>>
   Create(orc::ExecutionSession &ES) {
-    auto DylibMgr =
-        orc::EPCGenericDylibManager::CreateWithDefaultBootstrapSymbols(
-            ES.getExecutorProcessControl());
+    auto DylibMgr = orc::EPCGenericDylibManager::Create(ES);
     if (!DylibMgr)
       return DylibMgr.takeError();
     auto H = DylibMgr->open("", 0);
     if (!H)
       return H.takeError();
-    return std::make_unique<RemoteResolver>(
-        std::move(*DylibMgr), std::move(*H),
-        std::make_shared<orc::SymbolStringPool>());
+    return std::make_unique<RemoteResolver>(ES, std::move(*DylibMgr),
+                                            std::move(*H));
   }
 
   JITSymbol findSymbol(const std::string &Name) override {
-    // This legacy resolver has no ExecutionSession string pool of its own, so
-    // it interns lookup names into a standalone pool to form the lookup set.
-    orc::SymbolLookupSet LS(SSP->intern(Name),
+    orc::SymbolLookupSet LS(ES.intern(Name),
                             orc::SymbolLookupFlags::WeaklyReferencedSymbol);
     if (auto Syms = DylibMgr.lookup(H, LS)) {
       if (Syms->size() != 1)
@@ -128,14 +123,14 @@ public:
   }
 
 public:
-  RemoteResolver(orc::EPCGenericDylibManager DylibMgr,
-                 orc::tpctypes::DylibHandle H,
-                 std::shared_ptr<orc::SymbolStringPool> SSP)
-      : DylibMgr(std::move(DylibMgr)), H(std::move(H)), SSP(std::move(SSP)) {}
+  RemoteResolver(orc::ExecutionSession &ES,
+                 orc::EPCGenericDylibManager DylibMgr,
+                 orc::tpctypes::DylibHandle H)
+      : ES(ES), DylibMgr(std::move(DylibMgr)), H(std::move(H)) {}
 
+  orc::ExecutionSession &ES;
   orc::EPCGenericDylibManager DylibMgr;
   orc::tpctypes::DylibHandle H;
-  std::shared_ptr<orc::SymbolStringPool> SSP;
 };
 } // namespace llvm
 


### PR DESCRIPTION
The in-tree SimpleExecutorDylibManager now publishes a single controller interface -- the ORC runtime's NativeDylibManager symbol names -- which EPCGenericDylibManager targets, dropping the parallel LLVM-style SimpleExecutorDylibManager_* names and the Create path that used them. Follow-up to the EPCGenericDylibManager proxy refactor, which already routed both name sets through the same code.

Details:

* Remove EPCGenericDylibManager::CreateWithDefaultBootstrapSymbols. SimpleRemoteEPC and lli now construct via Create(ExecutionSession&), which resolves the NativeDylibManager names in the session's bootstrap JITDylib.

* Remove the SimpleExecutorDylibManager{Instance,Open,Resolve} bootstrap-name constants from OrcRTBridge. SimpleExecutorDylibManager previously published both name sets and now publishes only the NativeDylibManager names; a comment records that the class itself will be renamed to NativeDylibManager.

* lli's RemoteResolver interns lookup names into the ExecutionSession lli owns rather than a private SymbolStringPool.