### PR TITLE
[libc++][NFC] Rename job in benchmark cron

### DIFF
--- a/.github/workflows/libcxx-benchmark-cron.yml
+++ b/.github/workflows/libcxx-benchmark-cron.yml
@@ -73,7 +73,7 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.select-machines.outputs.matrix) }}
       fail-fast: false
-    name: ${{ matrix.machine }}
+    name: "Request ${{ matrix.machine }}"
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     env:


### PR DESCRIPTION
To avoid appearing as if the job is running the actual benchmarks.