### PR TITLE
[lld][COFF] Fix IMAGE_COMDAT_SELECT_LARGEST replacement

### DIFF
--- a/lld/COFF/Chunks.cpp
+++ b/lld/COFF/Chunks.cpp
@@ -33,7 +33,8 @@ using llvm::support::ulittle32_t;
 namespace lld::coff {
 
 SectionChunk::SectionChunk(ObjFile *f, const coff_section *h, Kind k)
-    : Chunk(k), file(f), header(h), repl(this) {
+    : Chunk(k), file(f), header(h), keepUnique(false), discardedByCOMDAT(false),
+      replaceableCOMDAT(false), repl(this) {
   // Initialize relocs.
   if (file)
     setRelocs(file->getCOFFObj()->getRelocations(header));
@@ -527,6 +528,27 @@ void SectionChunk::addAssociative(SectionChunk *child) {
   assert(prev->assocChildren == next);
   prev->assocChildren = child;
   child->assocChildren = next;
+  child->replaceableCOMDAT = isInReplaceableCOMDATGroup();
+
+  // An associative section can be discovered after its parent has already
+  // lost a same-object LARGEST competition.
+  if (discardedByCOMDAT) {
+    child->live = false;
+    child->discardedByCOMDAT = true;
+  }
+}
+
+void SectionChunk::discardCOMDATGroup() {
+  assert(selection != IMAGE_COMDAT_SELECT_ASSOCIATIVE &&
+         "an associative COMDAT cannot be discarded as a group leader");
+
+  live = false;
+  discardedByCOMDAT = true;
+
+  for (SectionChunk &child : children()) {
+    child.live = false;
+    child.discardedByCOMDAT = true;
+  }
 }
 
 static uint8_t getBaserelType(const coff_relocation &rel,

--- a/lld/COFF/Chunks.h
+++ b/lld/COFF/Chunks.h
@@ -294,6 +294,24 @@ public:
   // and its children are treated as a group by the garbage collector.
   void addAssociative(SectionChunk *child);
 
+  // Secondary definitions in ANY/LARGEST groups are provisional until all
+  // competing groups have been seen. This also applies to definitions in
+  // associative children.
+  bool isInReplaceableCOMDATGroup() const { return replaceableCOMDAT; }
+
+  void setSelection(llvm::COFF::COMDATType value) {
+    selection = value;
+    if (value == llvm::COFF::IMAGE_COMDAT_SELECT_ANY ||
+        value == llvm::COFF::IMAGE_COMDAT_SELECT_LARGEST)
+      replaceableCOMDAT = true;
+  }
+
+  // Permanently discard a superseded COMDAT group, including its
+  // associative sections.
+  void discardCOMDATGroup();
+
+  bool isDiscardedByCOMDAT() const { return discardedByCOMDAT; }
+
   StringRef getDebugName() const;
 
   // True if this is a codeview debug info chunk. These will not be laid out in
@@ -383,7 +401,16 @@ public:
 
   // Whether this section needs to be kept distinct from other sections during
   // ICF. This is set by the driver using address-significance tables.
-  bool keepUnique = false;
+  bool keepUnique : 1;
+
+  // True if this section was permanently discarded when its COMDAT group lost
+  // selection or deferred symbol replay.
+  bool discardedByCOMDAT : 1;
+
+  // True for an associative child whose leader uses ANY/LARGEST selection.
+  // Keeping this as a bit of section state avoids increasing SectionChunk's
+  // size with a parent pointer.
+  bool replaceableCOMDAT : 1;
 
   // The COMDAT selection if this is a COMDAT chunk.
   llvm::COFF::COMDATType selection = (llvm::COFF::COMDATType)0;
@@ -991,7 +1018,7 @@ public:
     // Comdats from LTO files can't be fully treated as regular comdats
     // at this point; we don't know what size or contents they are going to
     // have, so we can't do proper checking of such aspects of them.
-    chunk.selection = llvm::COFF::IMAGE_COMDAT_SELECT_ANY;
+    chunk.setSelection(llvm::COFF::IMAGE_COMDAT_SELECT_ANY);
   }
 
   SectionChunk chunk;

--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -2753,6 +2753,44 @@ void LinkerDriver::linkerMain(ArrayRef<const char *> argsArr) {
         ;
   });
 
+  // Complete COMDAT selection before resolving references and providers from
+  // replaceable groups. Extracted archive members can contribute more such
+  // groups, so continue until neither phase schedules another input file.
+  auto hasDeferredCOMDATWork = [&] {
+    bool result = false;
+    ctx.forEachSymtab(
+        [&](SymbolTable &symtab) { result |= symtab.hasDeferredCOMDATWork(); });
+    return result;
+  };
+
+  auto resolveDeferredCOMDATs = [&](bool parsePendingInputs, bool final) {
+    // Pending inputs can themselves introduce replaceable COMDATs, so the
+    // caller decides whether the input queue must be drained before checking
+    // the cheap no-work fast path.
+    if (parsePendingInputs)
+      run();
+    if (!hasDeferredCOMDATWork())
+      return;
+
+    // References from a replaceable group are provisional too. Publishing
+    // them can irreversibly extract an archive member, so wait until the
+    // current input-producing phase has completed.
+    if (!final)
+      return;
+
+    for (;;) {
+      ctx.forEachSymtab(
+          [](SymbolTable &symtab) { symtab.resolveDeferredReferences(); });
+      if (run())
+        continue;
+      ctx.forEachSymtab(
+          [](SymbolTable &symtab) { symtab.finalizeDeferredSymbols(); });
+      if (!run())
+        return;
+    }
+  };
+  resolveDeferredCOMDATs(/*parsePendingInputs=*/true, /*final=*/false);
+
   if (config->autoImport || config->stdcallFixup) {
     // MinGW specific.
     // Load any further object files that might be needed for doing automatic
@@ -2774,9 +2812,27 @@ void LinkerDriver::linkerMain(ArrayRef<const char *> argsArr) {
     // If it ends up pulling in more object files from static libraries,
     // (and maybe doing more stdcall fixups along the way), this would need
     // to loop these two calls.
-    ctx.forEachSymtab([](SymbolTable &symtab) { symtab.loadMinGWSymbols(); });
-    run();
+    if (config->stdcallFixup) {
+      ctx.forEachSymtab([](SymbolTable &symtab) {
+        symtab.loadMinGWSymbols(/*loadStdcallFixups=*/true,
+                                /*loadAutoImports=*/false);
+      });
+      run();
+      // A stdcall archive member can change the prevailing COMDAT before
+      // automatic-import references are published.
+      resolveDeferredCOMDATs(/*parsePendingInputs=*/false, /*final=*/false);
+    }
+    if (config->autoImport) {
+      ctx.forEachSymtab([](SymbolTable &symtab) {
+        symtab.loadMinGWSymbols(/*loadStdcallFixups=*/false,
+                                /*loadAutoImports=*/true);
+      });
+      run();
+    }
   }
+
+  // MinGW automatic import and stdcall fixups can load additional inputs.
+  resolveDeferredCOMDATs(/*parsePendingInputs=*/false, /*final=*/true);
 
   // At this point, we should not have any symbols that cannot be resolved.
   // If we are going to do codegen for link-time optimization, check for
@@ -2818,9 +2874,26 @@ void LinkerDriver::linkerMain(ArrayRef<const char *> argsArr) {
   if (config->emit != EmitKind::Obj || config->thinLTOIndexOnly)
     return;
 
-  // If we generated native object files from bitcode files, this resolves
-  // references to the symbols we use from them.
-  run();
+  // Native LTO output can contain the same provisional COMDAT reference
+  // patterns as ordinary objects.
+  resolveDeferredCOMDATs(/*parsePendingInputs=*/true, /*final=*/true);
+
+  // Parsing records side-table entries before replaceable COMDAT selection is
+  // globally final. Commit those effects now, after the last input-producing
+  // fixed point and before GC, ICF, PDB, resources, or EC thunk processing can
+  // observe them. Debug dependency discovery can enqueue PDB inputs; drain
+  // those inputs and repeat in case a malformed dependency is another object.
+  for (size_t finalizedObjFiles = 0;;) {
+    while (finalizedObjFiles != ctx.objFileInstances.size())
+      ctx.objFileInstances[finalizedObjFiles++]->finalizeCOMDATSideEffects();
+    if (run()) {
+      resolveDeferredCOMDATs(/*parsePendingInputs=*/false, /*final=*/false);
+      continue;
+    }
+    resolveDeferredCOMDATs(/*parsePendingInputs=*/false, /*final=*/true);
+    if (finalizedObjFiles == ctx.objFileInstances.size())
+      break;
+  }
 
   // Apply symbol renames for -wrap.
   ctx.forEachSymtab([](SymbolTable &symtab) {

--- a/lld/COFF/InputFiles.cpp
+++ b/lld/COFF/InputFiles.cpp
@@ -15,6 +15,7 @@
 #include "SymbolTable.h"
 #include "Symbols.h"
 #include "lld/Common/DWARF.h"
+#include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/BinaryFormat/COFF.h"
@@ -72,54 +73,21 @@ const COFFSyncStream &coff::operator<<(const COFFSyncStream &s,
   return s << toString(f);
 }
 
-/// Checks that Source is compatible with being a weak alias to Target.
-/// If Source is Undefined and has no weak alias set, makes it a weak
-/// alias to Target.
-static void checkAndSetWeakAlias(SymbolTable &symtab, InputFile *f,
-                                 Symbol *source, Symbol *target,
-                                 bool isAntiDep) {
-  if (auto *u = dyn_cast<Undefined>(source)) {
-    if (u->weakAlias && u->weakAlias != target) {
-      // Ignore duplicated anti-dependency symbols.
-      if (isAntiDep)
-        return;
-      if (!u->isAntiDep) {
-        // Weak aliases as produced by GCC are named in the form
-        // .weak.<weaksymbol>.<othersymbol>, where <othersymbol> is the name
-        // of another symbol emitted near the weak symbol.
-        if (symtab.ctx.config.allowDuplicateWeak) {
-          auto isAbsZero = [](Symbol *sym) -> bool {
-            return isa<DefinedAbsolute>(sym) &&
-                   dyn_cast<DefinedAbsolute>(sym)->getVA() == 0;
-          };
-          // If the alias we had points at absolute zero, and we get another
-          // weak symbol which isn't absolute zero, prefer that one.
-          if (isAbsZero(u->weakAlias) && !isAbsZero(target)) {
-            u->setWeakAlias(target, isAntiDep);
-          }
-          return;
-        }
-        symtab.reportDuplicate(source, f);
-      }
-    }
-    u->setWeakAlias(target, isAntiDep);
-  }
-}
-
 static bool ignoredSymbolName(StringRef name) {
   return name == "@feat.00" || name == "@comp.id";
 }
 
 static coff_symbol_generic *cloneSymbol(COFFSymbolRef sym) {
+  // COFF symbol tables are byte-addressed. Copy out of the object buffer
+  // instead of forming a potentially unaligned typed lvalue into it.
   if (sym.isBigObj()) {
-    auto *copy = make<coff_symbol32>(
-        *reinterpret_cast<const coff_symbol32 *>(sym.getRawPtr()));
-    return reinterpret_cast<coff_symbol_generic *>(copy);
-  } else {
-    auto *copy = make<coff_symbol16>(
-        *reinterpret_cast<const coff_symbol16 *>(sym.getRawPtr()));
+    auto *copy = make<coff_symbol32>();
+    memcpy(copy, sym.getRawPtr(), sizeof(*copy));
     return reinterpret_cast<coff_symbol_generic *>(copy);
   }
+  auto *copy = make<coff_symbol16>();
+  memcpy(copy, sym.getRawPtr(), sizeof(*copy));
+  return reinterpret_cast<coff_symbol_generic *>(copy);
 }
 
 // Skip importing DllMain thunks from import libraries.
@@ -274,9 +242,10 @@ lld::coff::getArchiveMembers(COFFLinkerContext &ctx, Archive *file) {
   return v;
 }
 
-ObjFile::ObjFile(SymbolTable &symtab, COFFObjectFile *coffObj, bool lazy)
+ObjFile::ObjFile(SymbolTable &symtab, COFFObjectFile *coffObj, bool lazy,
+                 bool isLTOOutput)
     : InputFile(symtab, ObjectKind, coffObj->getMemoryBufferRef(), lazy),
-      coffObj(coffObj) {}
+      coffObj(coffObj), isLTOOutput(isLTOOutput) {}
 
 std::unique_ptr<COFFObjectFile>
 ObjFile::createCOFFObject(COFFLinkerContext &ctx, MemoryBufferRef m) {
@@ -293,9 +262,9 @@ ObjFile::createCOFFObject(COFFLinkerContext &ctx, MemoryBufferRef m) {
 }
 
 ObjFile *ObjFile::create(COFFLinkerContext &ctx, COFFObjectFile *coffObj,
-                         bool lazy) {
+                         bool lazy, bool isLTOOutput) {
   return make<ObjFile>(ctx.getSymtab(MachineTypes(coffObj->getMachine())),
-                       coffObj, lazy);
+                       coffObj, lazy, isLTOOutput);
 }
 
 void ObjFile::parseLazy() {
@@ -316,36 +285,42 @@ void ObjFile::parseLazy() {
   }
 }
 
-struct ECMapEntry {
-  ulittle32_t src;
-  ulittle32_t dst;
-  ulittle32_t type;
-};
+static constexpr size_t ecMapEntrySize = 3 * sizeof(uint32_t);
 
-void ObjFile::initializeECThunks() {
+void ObjFile::processECThunks() {
   for (SectionChunk *chunk : hybmpChunks) {
-    if (chunk->getContents().size() % sizeof(ECMapEntry)) {
-      Err(symtab.ctx) << "Invalid .hybmp chunk size "
-                      << chunk->getContents().size();
+    ArrayRef<uint8_t> contents = chunk->getContents();
+    if (contents.size() % ecMapEntrySize) {
+      Err(symtab.ctx) << "Invalid .hybmp chunk size " << contents.size();
       continue;
     }
 
-    const uint8_t *end =
-        chunk->getContents().data() + chunk->getContents().size();
-    for (const uint8_t *iter = chunk->getContents().data(); iter != end;
-         iter += sizeof(ECMapEntry)) {
-      auto entry = reinterpret_cast<const ECMapEntry *>(iter);
-      switch (entry->type) {
+    for (size_t offset = 0; offset != contents.size();
+         offset += ecMapEntrySize) {
+      const uint8_t *entry = contents.data() + offset;
+      uint32_t src = read32le(entry);
+      uint32_t dst = read32le(entry + sizeof(uint32_t));
+      uint32_t type = read32le(entry + 2 * sizeof(uint32_t));
+
+      Symbol *srcSym = getSymbol(src);
+      Symbol *dstSym = getSymbol(dst);
+      if (!srcSym || !dstSym) {
+        Err(symtab.ctx) << "Invalid .hybmp symbol index " << src << " -> "
+                        << dst;
+        continue;
+      }
+
+      switch (type) {
       case Arm64ECThunkType::Entry:
-        symtab.addEntryThunk(getSymbol(entry->src), getSymbol(entry->dst));
+        symtab.addEntryThunk(srcSym, dstSym);
         break;
       case Arm64ECThunkType::Exit:
-        symtab.addExitThunk(getSymbol(entry->src), getSymbol(entry->dst));
+        symtab.addExitThunk(srcSym, dstSym);
         break;
       case Arm64ECThunkType::GuestExit:
         break;
       default:
-        Warn(symtab.ctx) << "Ignoring unknown EC thunk type " << entry->type;
+        Warn(symtab.ctx) << "Ignoring unknown EC thunk type " << type;
       }
     }
   }
@@ -355,9 +330,30 @@ void ObjFile::parse() {
   // Read section and symbol tables.
   initializeChunks();
   initializeSymbols();
+}
+
+void ObjFile::finalizeCOMDATSideEffects() {
+  auto removeDiscarded = [](std::vector<SectionChunk *> &chunks) {
+    llvm::erase_if(chunks, [](SectionChunk *chunk) {
+      return chunk->isDiscardedByCOMDAT();
+    });
+  };
+
+  // Side tables are populated while COMDAT selection is still provisional.
+  // Commit them only after the global ANY/LARGEST fixed point, so every later
+  // consumer observes the same state as if losing groups had never existed.
+  removeDiscarded(debugChunks);
+  removeDiscarded(resourceChunks);
+  removeDiscarded(sxDataChunks);
+  removeDiscarded(guardFidChunks);
+  removeDiscarded(guardIATChunks);
+  removeDiscarded(guardLJmpChunks);
+  removeDiscarded(guardEHContChunks);
+  removeDiscarded(hybmpChunks);
+
   initializeFlags();
   initializeDependencies();
-  initializeECThunks();
+  processECThunks();
 }
 
 const coff_section *ObjFile::getSection(uint32_t i) {
@@ -367,23 +363,27 @@ const coff_section *ObjFile::getSection(uint32_t i) {
   return *sec;
 }
 
-// We set SectionChunk pointers in the SparseChunks vector to this value
-// temporarily to mark comdat sections as having an unknown resolution. As we
-// walk the object file's symbol table, once we visit either a leader symbol or
-// an associative section definition together with the parent comdat's leader,
-// we set the pointer to either nullptr (to mark the section as discarded) or a
-// valid SectionChunk for that section.
-static SectionChunk *const pendingComdat = reinterpret_cast<SectionChunk *>(1);
-
+// Pending COMDAT state is kept separately from sparseChunks. This avoids an
+// integer-derived pointer sentinel and makes malformed indices safe to reject
+// before they can be used as vector indexes.
 void ObjFile::initializeChunks() {
   uint32_t numSections = coffObj->getNumberOfSections();
-  sparseChunks.resize(numSections + 1);
-  for (uint32_t i = 1; i < numSections + 1; ++i) {
+  if (numSections == ~uint32_t{0})
+    Fatal(symtab.ctx) << toString(this) << ": too many sections";
+
+  size_t sectionSlots = static_cast<size_t>(numSections) + 1;
+  sparseChunks.resize(sectionSlots);
+  for (uint32_t i = 1; i <= numSections; ++i) {
     const coff_section *sec = getSection(i);
-    if (sec->Characteristics & IMAGE_SCN_LNK_COMDAT)
-      sparseChunks[i] = pendingComdat;
-    else
+    if (sec->Characteristics & IMAGE_SCN_LNK_COMDAT) {
+      if (!hasCOMDATSections) {
+        hasCOMDATSections = true;
+        comdatSectionStates.resize(sectionSlots);
+      }
+      setCOMDATSectionState(i, PendingCOMDAT);
+    } else {
       sparseChunks[i] = readSection(i, nullptr, "");
+    }
   }
 }
 
@@ -399,19 +399,34 @@ SectionChunk *ObjFile::readSection(uint32_t sectionNumber,
     Fatal(symtab.ctx) << "getSectionName failed: #" << sectionNumber << ": "
                       << e.takeError();
 
-  if (name == ".drectve") {
+  if (name == ".drectve" && !(sec->Characteristics & IMAGE_SCN_LNK_COMDAT)) {
     ArrayRef<uint8_t> data;
     cantFail(coffObj->getSectionContents(sec, data));
-    directives = StringRef((const char *)data.data(), data.size());
+    directiveSections.emplace_back(
+        sectionNumber,
+        StringRef(reinterpret_cast<const char *>(data.data()), data.size()));
     return nullptr;
   }
 
   if (name == ".llvm_addrsig") {
+    // Addrsig and call-graph records contain object-wide symbol indexes; their
+    // formats have no selected-COMDAT provenance to commit later.
+    if (sec->Characteristics & IMAGE_SCN_LNK_COMDAT) {
+      Err(symtab.ctx) << toString(this)
+                      << ": .llvm_addrsig cannot be a COMDAT section";
+      return nullptr;
+    }
     addrsigSec = sec;
     return nullptr;
   }
 
   if (name == ".llvm.call-graph-profile") {
+    if (sec->Characteristics & IMAGE_SCN_LNK_COMDAT) {
+      Err(symtab.ctx)
+          << toString(this)
+          << ": .llvm.call-graph-profile cannot be a COMDAT section";
+      return nullptr;
+    }
     callgraphSec = sec;
     return nullptr;
   }
@@ -442,6 +457,25 @@ SectionChunk *ObjFile::readSection(uint32_t sectionNumber,
     c = make<SectionChunk>(this, sec);
   if (def)
     c->checksum = def->CheckSum;
+
+  if (name == ".drectve") {
+    // Clang can emit ASan linker directives in a COMDAT. NODUPLICATES cannot
+    // lose silently. For ANY, process only the prevailing candidate and
+    // require every duplicate candidate to be equivalent.
+    if (!def || (def->Selection != IMAGE_COMDAT_SELECT_ANY &&
+                 def->Selection != IMAGE_COMDAT_SELECT_NODUPLICATES)) {
+      Err(symtab.ctx) << toString(this)
+                      << ": COMDAT .drectve must use selection type ANY or "
+                         "NODUPLICATES";
+      return c;
+    }
+    ArrayRef<uint8_t> data;
+    cantFail(coffObj->getSectionContents(sec, data));
+    directiveSections.emplace_back(
+        sectionNumber,
+        StringRef(reinterpret_cast<const char *>(data.data()), data.size()));
+    return c;
+  }
 
   // CodeView sections are stored to a different vector because they are not
   // linked in the regular manner.
@@ -485,8 +519,27 @@ void ObjFile::readAssociativeDefinition(
 void ObjFile::readAssociativeDefinition(COFFSymbolRef sym,
                                         const coff_aux_section_definition *def,
                                         uint32_t parentIndex) {
-  SectionChunk *parent = sparseChunks[parentIndex];
   int32_t sectionNumber = sym.getSectionNumber();
+  if (sectionNumber <= 0 ||
+      static_cast<uint32_t>(sectionNumber) >= sparseChunks.size()) {
+    Err(symtab.ctx) << toString(this)
+                    << ": associative comdat refers to invalid section "
+                    << sectionNumber;
+    return;
+  }
+
+  if (parentIndex == 0 || parentIndex >= sparseChunks.size()) {
+    StringRef name = check(coffObj->getSymbolName(sym));
+    Err(symtab.ctx) << toString(this) << ": associative comdat " << name
+                    << " (sec " << sectionNumber
+                    << ") has invalid reference to section index "
+                    << parentIndex;
+    clearCOMDATSectionState(sectionNumber, PendingCOMDAT);
+    setCOMDATSectionState(sectionNumber, DiscardedCOMDAT);
+    return;
+  }
+
+  SectionChunk *parent = sparseChunks[parentIndex];
 
   auto diag = [&]() {
     StringRef name = check(coffObj->getSymbolName(sym));
@@ -501,13 +554,17 @@ void ObjFile::readAssociativeDefinition(COFFSymbolRef sym,
                     << " (sec " << parentIndex << ")";
   };
 
-  if (parent == pendingComdat) {
+  if (isPendingCOMDATSection(parentIndex)) {
     // This can happen if an associative comdat refers to another associative
     // comdat that appears after it (invalid per COFF spec) or to a section
     // without any symbols.
     diag();
+    clearCOMDATSectionState(sectionNumber, PendingCOMDAT);
+    setCOMDATSectionState(sectionNumber, DiscardedCOMDAT);
     return;
   }
+
+  clearCOMDATSectionState(sectionNumber, PendingCOMDAT);
 
   // Check whether the parent is prevailing. If it is, so are we, and we read
   // the section; otherwise mark it as discarded.
@@ -515,11 +572,13 @@ void ObjFile::readAssociativeDefinition(COFFSymbolRef sym,
     SectionChunk *c = readSection(sectionNumber, def, "");
     sparseChunks[sectionNumber] = c;
     if (c) {
-      c->selection = IMAGE_COMDAT_SELECT_ASSOCIATIVE;
+      c->setSelection(IMAGE_COMDAT_SELECT_ASSOCIATIVE);
       parent->addAssociative(c);
     }
   } else {
     sparseChunks[sectionNumber] = nullptr;
+    if (isDiscardedCOMDATSection(parentIndex))
+      setCOMDATSectionState(sectionNumber, DiscardedCOMDAT);
   }
 }
 
@@ -554,13 +613,19 @@ void ObjFile::maybeAssociateSEHForMingw(
   }
 }
 
-Symbol *ObjFile::createRegular(COFFSymbolRef sym) {
-  SectionChunk *sc = sparseChunks[sym.getSectionNumber()];
+LLVM_ATTRIBUTE_ALWAYS_INLINE Symbol *
+ObjFile::createRegular(COFFSymbolRef sym, uint32_t symbolIndex,
+                       uint32_t sectionNumber) {
+  SectionChunk *sc = sparseChunks[sectionNumber];
   if (sym.isExternal()) {
     StringRef name = check(coffObj->getSymbolName(sym));
-    if (sc)
-      return symtab.addRegular(this, name, sym.getGeneric(), sc,
-                               sym.getValue());
+    if (sc && !sc->isDiscardedByCOMDAT()) {
+      Symbol *symbol =
+          symtab.addRegular(this, name, sym.getGeneric(), sc, sym.getValue());
+      if (sc->isInReplaceableCOMDATGroup() && sc->sym != symbol)
+        recordCOMDATDefinition(sectionNumber, symbolIndex);
+      return symbol;
+    }
     // For MinGW symbols named .weak.* that point to a discarded section,
     // don't create an Undefined symbol. If nothing ever refers to the symbol,
     // everything should be fine. If something actually refers to the symbol
@@ -568,7 +633,8 @@ Symbol *ObjFile::createRegular(COFFSymbolRef sym) {
     // references at the end.
     if (symtab.ctx.config.mingw && name.starts_with(".weak."))
       return nullptr;
-    return symtab.addUndefined(name, this, false);
+
+    return symtab.addDiscardedDefinition(name);
   }
   if (sc) {
     const coff_symbol_generic *symGen = sym.getGeneric();
@@ -583,14 +649,68 @@ Symbol *ObjFile::createRegular(COFFSymbolRef sym) {
   return nullptr;
 }
 
+LLVM_ATTRIBUTE_ALWAYS_INLINE void
+ObjFile::recordCOMDATDefinition(uint32_t sectionNumber, uint32_t symbolIndex) {
+  // Most COMDAT objects have no secondary definitions. Avoid a section-sized
+  // head array until there is actually something to record.
+  if (comdatDefinitionHeads.empty()) {
+    comdatDefinitionHeads.assign(sparseChunks.size(), noCOMDATDefinition);
+    comdatDefinitions.reserve(sparseChunks.size());
+  }
+
+  if (LLVM_UNLIKELY(comdatDefinitions.size() >= noCOMDATDefinition))
+    Fatal(symtab.ctx) << toString(this) << ": too many COMDAT definitions";
+
+  uint32_t node = static_cast<uint32_t>(comdatDefinitions.size());
+  comdatDefinitions.push_back(
+      {symbolIndex, comdatDefinitionHeads[sectionNumber]});
+  comdatDefinitionHeads[sectionNumber] = node;
+}
+
 void ObjFile::initializeSymbols() {
   uint32_t numSymbols = coffObj->getNumberOfSymbols();
   symbols.resize(numSymbols);
+
+  // Reference-origin tracking is needed only when this object can publish a
+  // definition that may later disappear with an ANY/LARGEST group. Avoid the
+  // relocation pass completely for ordinary objects.
+  bool deferCOMDATReferences = false;
+  if (hasCOMDATSections) {
+    for (uint32_t i = 0; i < numSymbols; ++i) {
+      COFFSymbolRef sym = check(coffObj->getSymbol(i));
+      if (const coff_aux_section_definition *def = sym.getSectionDefinition())
+        if (def->Selection == IMAGE_COMDAT_SELECT_ANY ||
+            def->Selection == IMAGE_COMDAT_SELECT_LARGEST) {
+          deferCOMDATReferences = true;
+          break;
+        }
+      i += sym.getNumberOfAuxSymbols();
+    }
+  }
 
   SmallVector<std::pair<Symbol *, const coff_aux_weak_external *>, 8>
       weakAliases;
   std::vector<uint32_t> pendingIndexes;
   pendingIndexes.reserve(numSymbols);
+  SmallVector<uint32_t, 16> undefinedIndexes;
+  SmallBitVector primarySymbolIndexes;
+  SmallBitVector externallyDefinedSections(isLTOOutput ? sparseChunks.size()
+                                                       : 0);
+
+  // Most symbol indexes can be validated from the populated symbols vector.
+  // Build the primary-index map only when a null entry must be distinguished
+  // from an auxiliary record, or before inspecting an ARM64EC weak target.
+  auto getPrimarySymbolIndexes = [&]() -> const SmallBitVector & {
+    if (!primarySymbolIndexes.empty())
+      return primarySymbolIndexes;
+    primarySymbolIndexes.resize(numSymbols);
+    for (uint32_t i = 0; i < numSymbols; ++i) {
+      primarySymbolIndexes.set(i);
+      COFFSymbolRef sym = check(coffObj->getSymbol(i));
+      i += sym.getNumberOfAuxSymbols();
+    }
+    return primarySymbolIndexes;
+  };
 
   DenseMap<StringRef, uint32_t> prevailingSectionMap;
   std::vector<const coff_aux_section_definition *> comdatDefs(
@@ -600,10 +720,31 @@ void ObjFile::initializeSymbols() {
   for (uint32_t i = 0; i < numSymbols; ++i) {
     COFFSymbolRef coffSym = check(coffObj->getSymbol(i));
     bool prevailingComdat;
+    Symbol *definition = nullptr;
     if (coffSym.isUndefined()) {
-      symbols[i] = createUndefined(coffSym, false);
+      symbols[i] = createUndefined(coffSym, false, !deferCOMDATReferences);
+      if (deferCOMDATReferences)
+        undefinedIndexes.push_back(i);
     } else if (coffSym.isWeakExternal()) {
       auto aux = coffSym.getAux<coff_aux_weak_external>();
+      bool inspectArm64ECTarget =
+          isArm64EC(getMachineType()) &&
+          aux->Characteristics == IMAGE_WEAK_EXTERN_ANTI_DEPENDENCY;
+      if (aux->TagIndex >= numSymbols ||
+          (inspectArm64ECTarget &&
+           !getPrimarySymbolIndexes().test(aux->TagIndex))) {
+        Err(ctx) << toString(this)
+                 << ": weak external has invalid target symbol index "
+                 << aux->TagIndex;
+        // Keep the malformed weak external as an undefined symbol so parsing
+        // can continue without ever indexing the invalid target.
+        symbols[i] = createUndefined(coffSym, true, !deferCOMDATReferences);
+        if (deferCOMDATReferences)
+          undefinedIndexes.push_back(i);
+
+        i += coffSym.getNumberOfAuxSymbols();
+        continue;
+      }
       bool overrideLazy = true;
 
       // On ARM64EC, external function calls emit a pair of weak-dependency
@@ -611,8 +752,7 @@ void ObjFile::initializeSymbols() {
       // (instead of a single undefined func symbol, which would be emitted on
       // other targets). Allow such aliases to be overridden by lazy archive
       // symbols, just as we would for undefined symbols.
-      if (isArm64EC(getMachineType()) &&
-          aux->Characteristics == IMAGE_WEAK_EXTERN_ANTI_DEPENDENCY) {
+      if (inspectArm64ECTarget) {
         COFFSymbolRef targetSym = check(coffObj->getSymbol(aux->TagIndex));
         if (!targetSym.isAnyUndefined()) {
           // If the target is defined, it may be either a guess exit thunk or
@@ -628,11 +768,17 @@ void ObjFile::initializeSymbols() {
           overrideLazy = false;
         }
       }
-      symbols[i] = createUndefined(coffSym, overrideLazy);
+      symbols[i] =
+          createUndefined(coffSym, overrideLazy, !deferCOMDATReferences);
+      if (deferCOMDATReferences)
+        undefinedIndexes.push_back(i);
       weakAliases.emplace_back(symbols[i], aux);
     } else if (std::optional<Symbol *> optSym =
-                   createDefined(coffSym, comdatDefs, prevailingComdat)) {
-      symbols[i] = *optSym;
+                   createDefined(coffSym, i, comdatDefs, prevailingComdat)) {
+      definition = *optSym;
+      symbols[i] = prevailingComdat
+                       ? symtab.canonicalizeDeferredCOMDATSymbol(definition)
+                       : definition;
       if (ctx.config.mingw && prevailingComdat)
         recordPrevailingSymbolForMingw(coffSym, prevailingSectionMap);
     } else {
@@ -649,6 +795,18 @@ void ObjFile::initializeSymbols() {
     i += coffSym.getNumberOfAuxSymbols();
   }
 
+  if (isLTOOutput) {
+    for (uint32_t i = 0; i < numSymbols; ++i) {
+      COFFSymbolRef sym = check(coffObj->getSymbol(i));
+      int32_t sectionNumber = sym.getSectionNumber();
+      if (sym.isExternal() && sectionNumber > 0 &&
+          static_cast<uint32_t>(sectionNumber) <
+              externallyDefinedSections.size())
+        externallyDefinedSections.set(sectionNumber);
+      i += sym.getNumberOfAuxSymbols();
+    }
+  }
+
   for (uint32_t i : pendingIndexes) {
     COFFSymbolRef sym = check(coffObj->getSymbol(i));
     if (const coff_aux_section_definition *def = sym.getSectionDefinition()) {
@@ -657,74 +815,287 @@ void ObjFile::initializeSymbols() {
       else if (ctx.config.mingw)
         maybeAssociateSEHForMingw(sym, def, prevailingSectionMap);
     }
-    if (sparseChunks[sym.getSectionNumber()] == pendingComdat) {
+    uint32_t sectionNumber = sym.getSectionNumber();
+    if (isPendingCOMDATSection(sectionNumber)) {
       StringRef name = check(coffObj->getSymbolName(sym));
       Log(ctx) << "comdat section " << name
                << " without leader and unassociated, discarding";
+      clearCOMDATSectionState(sectionNumber, PendingCOMDAT);
+      setCOMDATSectionState(sectionNumber, DiscardedCOMDAT);
+      setCOMDATSectionState(sectionNumber, UnassociatedCOMDAT);
       continue;
     }
-    symbols[i] = createRegular(sym);
+    symbols[i] = createRegular(sym, i, sectionNumber);
   }
 
   for (auto &kv : weakAliases) {
     Symbol *sym = kv.first;
     const coff_aux_weak_external *aux = kv.second;
-    checkAndSetWeakAlias(symtab, this, sym, symbols[aux->TagIndex],
-                         aux->Characteristics ==
-                             IMAGE_WEAK_EXTERN_ANTI_DEPENDENCY);
+
+    // TagIndex is a raw COFF symbol-table index. Reject auxiliary records, but
+    // allow valid primary symbols whose Symbol entry disappeared with a
+    // discarded COMDAT.
+    Symbol *target = symbols[aux->TagIndex];
+    if (!target && !getPrimarySymbolIndexes().test(aux->TagIndex)) {
+      Err(ctx) << toString(this)
+               << ": weak external has invalid target symbol index "
+               << aux->TagIndex;
+      continue;
+    }
+
+    if (!target)
+      continue;
+
+    symtab.addWeakAlias(this, sym, target,
+                        aux->Characteristics ==
+                            IMAGE_WEAK_EXTERN_ANTI_DEPENDENCY);
   }
+
+  // Attribute references to their originating sections. References from
+  // provisional ANY/LARGEST groups are activated only after COMDAT selection
+  // is final; this lets a losing group drop its otherwise-unresolved symbols.
+  if (deferCOMDATReferences) {
+    SmallBitVector relocatedIndexes(numSymbols);
+    for (uint32_t i = 1, e = coffObj->getNumberOfSections() + 1; i != e; ++i) {
+      SectionChunk *chunk = sparseChunks[i];
+      bool pending = isPendingCOMDATSection(i);
+      bool discarded = isDiscardedCOMDATSection(i);
+      bool unassociated = isUnassociatedCOMDATSection(i);
+      if ((!chunk || pending) && !discarded)
+        continue;
+
+      bool active = chunk && !pending && !chunk->isDiscardedByCOMDAT();
+      bool deferSection = active && chunk->isInReplaceableCOMDATGroup();
+      bool anonymousLTOCOMDAT = isLTOOutput && deferSection && !chunk->live &&
+                                !externallyDefinedSections.test(i);
+
+      bool preserveLTOUnwindReferences = false;
+      if (isLTOOutput && ((!active && unassociated) || anonymousLTOCOMDAT)) {
+        StringRef name = check(coffObj->getSectionName(getSection(i)));
+        preserveLTOUnwindReferences =
+            name == ".xdata" || name.starts_with(".xdata$");
+      }
+
+      // An unreferenced COMDAT emitted by LTO is dead by default and cannot
+      // justify loading another bitcode archive member after code generation.
+      // Unwind data is the exception because GC does not traverse it.
+      bool publishReferences = active || preserveLTOUnwindReferences;
+      if (anonymousLTOCOMDAT && !preserveLTOUnwindReferences)
+        publishReferences = false;
+      if (deferSection && publishReferences)
+        symtab.deferSectionReferences(chunk);
+
+      // Build relocatedIndexes and publish references from permanent sections
+      // in the same walk. Losing or still-provisional COMDAT sections only
+      // contribute to relocatedIndexes; a winning provisional section is
+      // replayed later by resolveDeferredReferences().
+      ArrayRef<coff_relocation> relocations =
+          chunk ? chunk->getRelocs() : coffObj->getRelocations(getSection(i));
+      for (const coff_relocation &rel : relocations) {
+        uint32_t index = rel.SymbolTableIndex;
+        if (index >= numSymbols) {
+          Err(ctx) << toString(this)
+                   << ": relocation refers to invalid symbol index " << index;
+          continue;
+        }
+        Symbol *symbol = symbols[index];
+        if (!symbol && !getPrimarySymbolIndexes().test(index)) {
+          Err(ctx) << toString(this)
+                   << ": relocation refers to invalid symbol index " << index;
+          continue;
+        }
+        relocatedIndexes.set(index);
+
+        // A discarded COMDAT no longer participates in the link. Native LTO
+        // output is the exception: code generation can introduce a late
+        // undefined reference in an unassociated unwind COMDAT. Preserve that
+        // reference so a bitcode archive provider is diagnosed as being
+        // loaded after LTO rather than silently omitted.
+        if (!publishReferences)
+          continue;
+
+        // A valid primary symbol may have no Symbol entry after its section was
+        // discarded. There is no global reference to publish in that case.
+        if (!symbol)
+          continue;
+
+        if (!deferSection)
+          symtab.addReference(symbol);
+      }
+    }
+
+    // Preserve the historical meaning of an undefined symbol-table entry with
+    // no relocation: it is still a real object-level reference.
+    for (uint32_t index : undefinedIndexes)
+      if (!relocatedIndexes.test(index))
+        symtab.addUnrelocatedReference(symbols[index]);
+  }
+
+  // A larger COMDAT may have removed definitions for which an earlier provider
+  // was ignored. Reconsider those providers only after all symbols in this
+  // file have had a chance to define the same names.
+  symtab.resolveDeferredSymbols();
+
+  // COMDAT sections are materialized while reading symbols, after ordinary
+  // sections have already been read. Restore object section order before the
+  // driver parses options whose effects can depend on argument order.
+  llvm::sort(directiveSections);
+  for (const auto &entry : directiveSections) {
+    StringRef contents = entry.second;
+    if (!directivesStorage.empty())
+      directivesStorage.push_back(' ');
+    directivesStorage.append(contents.data(), contents.size());
+  }
+  directives = directivesStorage;
 
   // Free the memory used by sparseChunks now that symbol loading is finished.
   decltype(sparseChunks)().swap(sparseChunks);
 }
 
-Symbol *ObjFile::createUndefined(COFFSymbolRef sym, bool overrideLazy) {
+Symbol *ObjFile::createUndefined(COFFSymbolRef sym, bool overrideLazy,
+                                 bool markReference) {
   StringRef name = check(coffObj->getSymbolName(sym));
-  Symbol *s = symtab.addUndefined(name, this, overrideLazy);
+  Symbol *s = symtab.addUndefined(name, this, overrideLazy, markReference);
 
   // Add an anti-dependency alias for undefined AMD64 symbols on the ARM64EC
   // target.
   if (symtab.isEC() && getMachineType() == AMD64) {
-    auto u = dyn_cast<Undefined>(s);
-    if (u && !u->weakAlias) {
-      if (std::optional<std::string> mangledName =
-              getArm64ECMangledFunctionName(name)) {
-        Symbol *m = symtab.addUndefined(saver().save(*mangledName), this,
-                                        /*overrideLazy=*/false);
-        u->setWeakAlias(m, /*antiDep=*/true);
-      }
+    if (std::optional<std::string> mangledName =
+            getArm64ECMangledFunctionName(name)) {
+      Symbol *m = symtab.addUndefined(saver().save(*mangledName), this,
+                                      /*overrideLazy=*/false, markReference);
+      symtab.addWeakAlias(this, s, m, /*isAntiDep=*/true);
     }
   }
   return s;
 }
 
-static const coff_aux_section_definition *findSectionDef(COFFObjectFile *obj,
-                                                         int32_t section) {
-  uint32_t numSymbols = obj->getNumberOfSymbols();
+const coff_aux_section_definition *ObjFile::findSectionDef(int32_t section) {
+  uint32_t numSymbols = coffObj->getNumberOfSymbols();
   for (uint32_t i = 0; i < numSymbols; ++i) {
-    COFFSymbolRef sym = check(obj->getSymbol(i));
-    if (sym.getSectionNumber() != section)
-      continue;
-    if (const coff_aux_section_definition *def = sym.getSectionDefinition())
-      return def;
+    COFFSymbolRef sym = check(coffObj->getSymbol(i));
+    if (sym.getSectionNumber() == section)
+      if (const coff_aux_section_definition *def = sym.getSectionDefinition())
+        return def;
+    i += sym.getNumberOfAuxSymbols();
   }
   return nullptr;
 }
 
-void ObjFile::handleComdatSelection(
-    COFFSymbolRef sym, COMDATType &selection, bool &prevailing,
-    DefinedRegular *leader,
-    const llvm::object::coff_aux_section_definition *def) {
-  if (prevailing)
-    return;
-  // There's already an existing comdat for this symbol: `Leader`.
-  // Use the comdats's selection field to determine if the new
-  // symbol in `Sym` should be discarded, produce a duplicate symbol
-  // error, etc.
+void ObjFile::discardCOMDATGroup(SectionChunk *leader) {
+  assert(leader->file == this &&
+         "COMDAT leader belongs to a different object file");
+  leader->discardCOMDATGroup();
 
+  auto discardDefinitions = [&](SectionChunk *chunk) {
+    uint32_t sectionNumber = chunk->getSectionNumber();
+    if (sectionNumber >= comdatDefinitionHeads.size())
+      return;
+
+    uint32_t node = comdatDefinitionHeads[sectionNumber];
+    comdatDefinitionHeads[sectionNumber] = noCOMDATDefinition;
+    while (node != noCOMDATDefinition) {
+      COMDATDefinition &definition = comdatDefinitions[node];
+      node = definition.next;
+      Symbol *symbol = symbols[definition.symbolIndex];
+      auto *defined = dyn_cast<DefinedRegular>(symbol);
+      if (!defined || !defined->data || defined->file != this ||
+          defined->getChunk() != chunk)
+        continue;
+
+      bool hasUndefinedReference = defined->hasUndefinedReference;
+      StringRef name = defined->getName();
+      Undefined *undefined = replaceSymbol<Undefined>(defined, name);
+      // A definition in a superseded group must disappear from symbol-table
+      // consumers such as MinGW auto-export. Keep it unresolved only if an
+      // actual reference to it was observed.
+      undefined->isUsedInRegularObj = hasUndefinedReference;
+      symtab.restoreDeferredSymbolState(undefined);
+    }
+  };
+
+  discardDefinitions(leader);
+  for (SectionChunk &child : leader->children())
+    discardDefinitions(&child);
+}
+
+bool ObjFile::handleDirectiveCOMDATSelection(SectionChunk *newChunk,
+                                             COMDATType selection,
+                                             DefinedRegular *leader) {
+  SectionChunk *leaderChunk = leader->getChunk();
+  if (leaderChunk->getSectionName() != ".drectve" &&
+      newChunk->getSectionName() != ".drectve")
+    return false;
+
+  if (selection == IMAGE_COMDAT_SELECT_NODUPLICATES) {
+    symtab.reportDuplicate(leader, this);
+  } else if (selection != IMAGE_COMDAT_SELECT_ANY ||
+             leaderChunk->getSectionName() != newChunk->getSectionName() ||
+             leaderChunk->getContents() != newChunk->getContents()) {
+    Err(symtab.ctx) << toString(this)
+                    << ": COMDAT .drectve candidates must use selection type "
+                       "ANY and have identical contents";
+  }
+  return true;
+}
+
+SectionChunk *ObjFile::handleComdatSelection(
+    COFFSymbolRef sym, COMDATType &selection, DefinedRegular *leader,
+    const llvm::object::coff_aux_section_definition *def) {
+  SectionChunk *leaderChunk = leader->getChunk();
+  if (!mergeComdatSelectionTypes(selection, leader))
+    return nullptr;
+
+  if (leaderChunk->getSectionName() == ".drectve") {
+    SectionChunk candidate(this, getSection(sym));
+    handleDirectiveCOMDATSelection(&candidate, selection, leader);
+    return nullptr;
+  }
+
+  switch (selection) {
+  case IMAGE_COMDAT_SELECT_NODUPLICATES:
+    symtab.reportDuplicate(leader, this);
+    break;
+  case IMAGE_COMDAT_SELECT_ANY:
+    break;
+  case IMAGE_COMDAT_SELECT_SAME_SIZE:
+    if (leaderChunk->getSize() != getSection(sym)->SizeOfRawData) {
+      if (!symtab.ctx.config.mingw) {
+        symtab.reportDuplicate(leader, this);
+      } else {
+        const coff_aux_section_definition *leaderDef = nullptr;
+        if (leaderChunk->file)
+          leaderDef = leaderChunk->file->findSectionDef(
+              leaderChunk->getSectionNumber());
+        if (!leaderDef || !def || leaderDef->Length != def->Length)
+          symtab.reportDuplicate(leader, this);
+      }
+    }
+    break;
+  case IMAGE_COMDAT_SELECT_EXACT_MATCH: {
+    SectionChunk newChunk(this, getSection(sym));
+    if (leaderChunk->getContents() != newChunk.getContents())
+      symtab.reportDuplicate(leader, this, &newChunk, sym.getValue());
+    break;
+  }
+  case IMAGE_COMDAT_SELECT_ASSOCIATIVE:
+    llvm_unreachable("createDefined not called for associative comdats");
+  case IMAGE_COMDAT_SELECT_LARGEST:
+    if (leaderChunk->getSize() < getSection(sym)->SizeOfRawData)
+      return leaderChunk;
+    break;
+  case IMAGE_COMDAT_SELECT_NEWEST:
+    llvm_unreachable("should have been rejected earlier");
+  }
+  return nullptr;
+}
+
+bool ObjFile::mergeComdatSelectionTypes(COMDATType &selection,
+                                        DefinedRegular *leader) {
   SectionChunk *leaderChunk = leader->getChunk();
   COMDATType leaderSelection = leaderChunk->selection;
   COFFLinkerContext &ctx = symtab.ctx;
+  bool persistSelection = false;
 
   assert(leader->data && "Comdat leader without SectionChunk?");
   if (isa<BitcodeFile>(leader->file)) {
@@ -741,6 +1112,7 @@ void ObjFile::handleComdatSelection(
     // "largest" when building with /GR. To be able to link object files
     // compiled with each flag, "any" and "largest" are merged as "largest".
     leaderSelection = selection = IMAGE_COMDAT_SELECT_LARGEST;
+    persistSelection = true;
   }
 
   // GCCs __declspec(selectany) doesn't actually pick "any" but "same size as".
@@ -752,6 +1124,7 @@ void ObjFile::handleComdatSelection(
                            (selection == IMAGE_COMDAT_SELECT_SAME_SIZE &&
                             leaderSelection == IMAGE_COMDAT_SELECT_ANY))) {
     leaderSelection = selection = IMAGE_COMDAT_SELECT_SAME_SIZE;
+    persistSelection = true;
   }
 
   // Other than that, comdat selections must match.  This is a bit more
@@ -763,11 +1136,36 @@ void ObjFile::handleComdatSelection(
   // (This behavior matches ModuleLinker::getComdatResult().)
   if (selection != leaderSelection) {
     Log(ctx) << "conflicting comdat type for " << symtab.printSymbol(leader)
-             << ": " << (int)leaderSelection << " in " << leader->getFile()
-             << " and " << (int)selection << " in " << this;
+             << ": " << static_cast<int>(leaderSelection) << " in "
+             << leader->getFile() << " and " << static_cast<int>(selection)
+             << " in " << this;
     symtab.reportDuplicate(leader, this);
-    return;
+    return false;
   }
+  // Compatibility merges are properties of the COMDAT group, not just of
+  // this pair of candidates. Preserve the strongest selection so subsequent
+  // candidates are compared using the already-merged semantics.
+  if (persistSelection)
+    leaderChunk->setSelection(leaderSelection);
+  return true;
+}
+
+SectionChunk *
+ObjFile::handleComdatSelection(SectionChunk *newChunk, COMDATType &selection,
+                               DefinedRegular *leader, uint32_t newValue,
+                               const coff_aux_section_definition *def) {
+  // There's already an existing comdat for this symbol: `Leader`.
+  // Use the comdats's selection field to determine if the new
+  // symbol in `Sym` should be discarded, produce a duplicate symbol
+  // error, etc.
+  if (!mergeComdatSelectionTypes(selection, leader))
+    return nullptr;
+
+  SectionChunk *leaderChunk = leader->getChunk();
+  COFFLinkerContext &ctx = symtab.ctx;
+
+  if (handleDirectiveCOMDATSelection(newChunk, selection, leader))
+    return nullptr;
 
   switch (selection) {
   case IMAGE_COMDAT_SELECT_NODUPLICATES:
@@ -779,27 +1177,28 @@ void ObjFile::handleComdatSelection(
     break;
 
   case IMAGE_COMDAT_SELECT_SAME_SIZE:
-    if (leaderChunk->getSize() != getSection(sym)->SizeOfRawData) {
+    if (leaderChunk->getSize() != newChunk->getSize()) {
       if (!ctx.config.mingw) {
         symtab.reportDuplicate(leader, this);
       } else {
         const coff_aux_section_definition *leaderDef = nullptr;
         if (leaderChunk->file)
-          leaderDef = findSectionDef(leaderChunk->file->getCOFFObj(),
-                                     leaderChunk->getSectionNumber());
-        if (!leaderDef || leaderDef->Length != def->Length)
+          leaderDef = leaderChunk->file->findSectionDef(
+              leaderChunk->getSectionNumber());
+        if (!def)
+          def = findSectionDef(newChunk->getSectionNumber());
+        if (!leaderDef || !def || leaderDef->Length != def->Length)
           symtab.reportDuplicate(leader, this);
       }
     }
     break;
 
   case IMAGE_COMDAT_SELECT_EXACT_MATCH: {
-    SectionChunk newChunk(this, getSection(sym));
     // link.exe only compares section contents here and doesn't complain
     // if the two comdat sections have e.g. different alignment.
     // Match that.
-    if (leaderChunk->getContents() != newChunk.getContents())
-      symtab.reportDuplicate(leader, this, &newChunk, sym.getValue());
+    if (leaderChunk->getContents() != newChunk->getContents())
+      symtab.reportDuplicate(leader, this, newChunk, newValue);
     break;
   }
 
@@ -811,29 +1210,19 @@ void ObjFile::handleComdatSelection(
     llvm_unreachable("createDefined not called for associative comdats");
 
   case IMAGE_COMDAT_SELECT_LARGEST:
-    if (leaderChunk->getSize() < getSection(sym)->SizeOfRawData) {
-      // Replace the existing comdat symbol with the new one.
-      StringRef name = check(coffObj->getSymbolName(sym));
-      // FIXME: This is incorrect: With /opt:noref, the previous sections
-      // make it into the final executable as well. Correct handling would
-      // be to undo reading of the whole old section that's being replaced,
-      // or doing one pass that determines what the final largest comdat
-      // is for all IMAGE_COMDAT_SELECT_LARGEST comdats and then reading
-      // only the largest one.
-      replaceSymbol<DefinedRegular>(leader, this, name, /*IsCOMDAT*/ true,
-                                    /*IsExternal*/ true, sym.getGeneric(),
-                                    nullptr);
-      prevailing = true;
-    }
+    if (leaderChunk->getSize() < newChunk->getSize())
+      return leaderChunk;
     break;
 
   case IMAGE_COMDAT_SELECT_NEWEST:
     llvm_unreachable("should have been rejected earlier");
   }
+
+  return nullptr;
 }
 
-std::optional<Symbol *> ObjFile::createDefined(
-    COFFSymbolRef sym,
+LLVM_ATTRIBUTE_ALWAYS_INLINE std::optional<Symbol *> ObjFile::createDefined(
+    COFFSymbolRef sym, uint32_t symbolIndex,
     std::vector<const coff_aux_section_definition *> &comdatDefs,
     bool &prevailing) {
   prevailing = false;
@@ -916,8 +1305,38 @@ std::optional<Symbol *> ObjFile::createDefined(
   // Handle comdat leader.
   if (const coff_aux_section_definition *def = comdatDefs[sectionNumber]) {
     comdatDefs[sectionNumber] = nullptr;
-    DefinedRegular *leader;
+    if (def->Selection < static_cast<int>(IMAGE_COMDAT_SELECT_NODUPLICATES) ||
+        // Intentionally ends at IMAGE_COMDAT_SELECT_LARGEST: link.exe
+        // doesn't understand IMAGE_COMDAT_SELECT_NEWEST either.
+        def->Selection > static_cast<int>(IMAGE_COMDAT_SELECT_LARGEST)) {
+      Fatal(ctx) << "unknown comdat type "
+                 << std::to_string(static_cast<int>(def->Selection)) << " for "
+                 << getName() << " in " << toString(this);
+    }
 
+    const coff_section *sec = getSection(sectionNumber);
+    StringRef sectionName = check(coffObj->getSectionName(sec));
+    if (sectionName == ".llvm_addrsig" ||
+        sectionName == ".llvm.call-graph-profile") {
+      Err(ctx) << toString(this) << ": " << sectionName
+               << " cannot be a COMDAT section";
+      clearCOMDATSectionState(sectionNumber, PendingCOMDAT);
+      sparseChunks[sectionNumber] = nullptr;
+      setCOMDATSectionState(sectionNumber, DiscardedCOMDAT);
+      return nullptr;
+    }
+    bool filtered =
+        (sec->Characteristics & IMAGE_SCN_LNK_REMOVE) ||
+        ctx.config.discardSection.contains(sectionName) ||
+        (!ctx.config.includeDwarfChunks && sectionName.starts_with(".debug_"));
+    if (filtered) {
+      clearCOMDATSectionState(sectionNumber, PendingCOMDAT);
+      sparseChunks[sectionNumber] = nullptr;
+      setCOMDATSectionState(sectionNumber, DiscardedCOMDAT);
+      return nullptr;
+    }
+
+    DefinedRegular *leader;
     if (sym.isExternal()) {
       std::tie(leader, prevailing) =
           symtab.addComdat(this, getName(), sym.getGeneric());
@@ -927,36 +1346,42 @@ std::optional<Symbol *> ObjFile::createDefined(
       prevailing = true;
     }
 
-    if (def->Selection < (int)IMAGE_COMDAT_SELECT_NODUPLICATES ||
-        // Intentionally ends at IMAGE_COMDAT_SELECT_LARGEST: link.exe
-        // doesn't understand IMAGE_COMDAT_SELECT_NEWEST either.
-        def->Selection > (int)IMAGE_COMDAT_SELECT_LARGEST) {
-      Fatal(ctx) << "unknown comdat type "
-                 << std::to_string((int)def->Selection) << " for " << getName()
-                 << " in " << toString(this);
-    }
     COMDATType selection = (COMDATType)def->Selection;
+    SectionChunk *replacedChunk = nullptr;
 
-    if (leader->isCOMDAT)
-      handleComdatSelection(sym, selection, prevailing, leader, def);
+    if (!prevailing && leader->isCOMDAT) {
+      replacedChunk = handleComdatSelection(sym, selection, leader, def);
+      prevailing = replacedChunk != nullptr;
+    }
 
+    clearCOMDATSectionState(sectionNumber, PendingCOMDAT);
     if (prevailing) {
       SectionChunk *c = readSection(sectionNumber, def, getName());
       sparseChunks[sectionNumber] = c;
       if (!c)
         return nullptr;
-      c->sym = cast<DefinedRegular>(leader);
-      c->selection = selection;
-      cast<DefinedRegular>(leader)->data = &c->repl;
+      if (replacedChunk) {
+        // Commit the replacement only after the new section has been read
+        // successfully.
+        replacedChunk->file->discardCOMDATGroup(replacedChunk);
+
+        leader = replaceSymbol<DefinedRegular>(
+            leader, this, getName(), /*IsCOMDAT=*/true,
+            /*IsExternal=*/true, sym.getGeneric(), nullptr);
+      }
+      c->sym = leader;
+      c->setSelection(selection);
+      leader->data = &c->repl;
     } else {
       sparseChunks[sectionNumber] = nullptr;
+      setCOMDATSectionState(sectionNumber, DiscardedCOMDAT);
     }
     return leader;
   }
 
   // Prepare to handle the comdat leader symbol by setting the section's
   // ComdatDefs pointer if we encounter a non-associative comdat.
-  if (sparseChunks[sectionNumber] == pendingComdat) {
+  if (isPendingCOMDATSection(sectionNumber)) {
     if (const coff_aux_section_definition *def = sym.getSectionDefinition()) {
       if (def->Selection != IMAGE_COMDAT_SELECT_ASSOCIATIVE)
         comdatDefs[sectionNumber] = def;
@@ -964,7 +1389,7 @@ std::optional<Symbol *> ObjFile::createDefined(
     return std::nullopt;
   }
 
-  return createRegular(sym);
+  return createRegular(sym, symbolIndex, sectionNumber);
 }
 
 MachineTypes ObjFile::getMachineType() const {
@@ -1402,10 +1827,14 @@ void BitcodeFile::parse() {
   llvm::StringSaver &saver = lld::saver();
 
   std::vector<std::pair<Symbol *, bool>> comdat(obj->getComdatTable().size());
-  for (size_t i = 0; i != obj->getComdatTable().size(); ++i)
+  std::vector<Symbol *> deferredComdatLeaders(comdat.size());
+  for (size_t i = 0; i != obj->getComdatTable().size(); ++i) {
     // FIXME: Check nodeduplicate
-    comdat[i] =
-        symtab.addComdat(this, saver.save(obj->getComdatTable()[i].first));
+    StringRef name = saver.save(obj->getComdatTable()[i].first);
+    comdat[i] = symtab.addComdat(this, name);
+    if (symtab.find(name) != comdat[i].first)
+      deferredComdatLeaders[i] = comdat[i].first;
+  }
   for (const lto::InputFile::Symbol &objSym : obj->symbols()) {
     StringRef symName = saver.save(objSym.getName());
     int comdatIndex = objSym.getComdatIndex();
@@ -1439,16 +1868,24 @@ void BitcodeFile::parse() {
       sym = symtab.addUndefined(symName, this, true);
       std::string fallback = std::string(objSym.getCOFFWeakExternalFallback());
       Symbol *alias = symtab.addUndefined(saver.save(fallback));
-      checkAndSetWeakAlias(symtab, this, sym, alias, false);
+      symtab.addWeakAlias(this, sym, alias, false);
     } else if (comdatIndex != -1) {
       if (symName == obj->getComdatTable()[comdatIndex].first) {
-        sym = comdat[comdatIndex].first;
-        if (cast<DefinedRegular>(sym)->data == nullptr)
-          cast<DefinedRegular>(sym)->data = &fakeSC->repl;
+        Symbol *leader = comdat[comdatIndex].first;
+        if (cast<DefinedRegular>(leader)->data == nullptr)
+          cast<DefinedRegular>(leader)->data = &fakeSC->repl;
+        // File-local symbol arrays should always point at the canonical
+        // SymbolTable slot. The private deferred provider remains available
+        // through the COMDAT state above for selection/replay.
+        sym = symtab.canonicalizeDeferredCOMDATSymbol(leader);
       } else if (comdat[comdatIndex].second) {
-        sym = symtab.addRegular(this, symName, nullptr, fakeSC);
+        if (Symbol *leader = deferredComdatLeaders[comdatIndex])
+          sym = symtab.addDeferredComdatRegular(this, symName, fakeSC,
+                                                objSym.isWeak(), leader);
+        else
+          sym = symtab.addRegular(this, symName, nullptr, fakeSC);
       } else {
-        sym = symtab.addUndefined(symName, this, false);
+        sym = symtab.addDiscardedDefinition(symName);
       }
     } else {
       sym =
@@ -1464,7 +1901,10 @@ void BitcodeFile::parse() {
 void BitcodeFile::parseLazy() {
   for (const lto::InputFile::Symbol &sym : obj->symbols())
     if (!sym.isUndefined()) {
-      symtab.addLazyObject(this, sym.getName());
+      // The LTO input owns its symbol-name storage and is moved into the LTO
+      // engine before native output is parsed. Keep lazy symbol-table keys
+      // alive across that move so the native definitions find the same slot.
+      symtab.addLazyObject(this, saver().save(sym.getName()));
       if (!lazy)
         return;
     }

--- a/lld/COFF/InputFiles.h
+++ b/lld/COFF/InputFiles.h
@@ -14,6 +14,8 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallBitVector.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/BinaryFormat/Magic.h"
 #include "llvm/Object/Archive.h"
@@ -48,10 +50,11 @@ std::vector<MemoryBufferRef> getArchiveMembers(COFFLinkerContext &,
 using llvm::COFF::IMAGE_FILE_MACHINE_UNKNOWN;
 using llvm::COFF::MachineTypes;
 using llvm::object::Archive;
-using llvm::object::COFFObjectFile;
-using llvm::object::COFFSymbolRef;
+using llvm::object::coff_aux_section_definition;
 using llvm::object::coff_import_header;
 using llvm::object::coff_section;
+using llvm::object::COFFObjectFile;
+using llvm::object::COFFSymbolRef;
 
 class Chunk;
 class Defined;
@@ -137,13 +140,14 @@ private:
 class ObjFile : public InputFile {
 public:
   static ObjFile *create(COFFLinkerContext &ctx, COFFObjectFile *coffObj,
-                         bool lazy = false);
+                         bool lazy = false, bool isLTOOutput = false);
   static ObjFile *create(COFFLinkerContext &ctx, MemoryBufferRef mb,
-                         bool lazy = false) {
+                         bool lazy = false, bool isLTOOutput = false) {
     return ObjFile::create(ctx, ObjFile::createCOFFObject(ctx, mb).release(),
-                           lazy);
+                           lazy, isLTOOutput);
   }
-  explicit ObjFile(SymbolTable &symtab, COFFObjectFile *coffObj, bool lazy);
+  explicit ObjFile(SymbolTable &symtab, COFFObjectFile *coffObj, bool lazy,
+                   bool isLTOOutput);
 
   static std::unique_ptr<COFFObjectFile>
   createCOFFObject(COFFLinkerContext &ctx, MemoryBufferRef mb);
@@ -151,6 +155,7 @@ public:
   static bool classof(const InputFile *f) { return f->kind() == ObjectKind; }
   void parse() override;
   void parseLazy();
+  void finalizeCOMDATSideEffects();
   MachineTypes getMachineType() const override;
   ArrayRef<Chunk *> getChunks() { return chunks; }
   ArrayRef<SectionChunk *> getDebugChunks() { return debugChunks; }
@@ -165,9 +170,11 @@ public:
 
   ArrayRef<uint8_t> getDebugSection(StringRef secName);
 
-  // Returns a Symbol object for the symbolIndex'th symbol in the
-  // underlying object file.
+  // Returns a Symbol object for the symbolIndex'th symbol in the underlying
+  // object file, or nullptr if a malformed relocation uses an invalid index.
   Symbol *getSymbol(uint32_t symbolIndex) {
+    if (symbolIndex >= symbols.size())
+      return nullptr;
     return symbols[symbolIndex];
   }
 
@@ -234,7 +241,21 @@ public:
                                                 uint32_t sectionIndex);
 
 private:
-  const coff_section* getSection(uint32_t i);
+  friend class SymbolTable;
+
+  void discardCOMDATGroup(SectionChunk *leader);
+  void recordCOMDATDefinition(uint32_t sectionNumber, uint32_t symbolIndex);
+  const coff_aux_section_definition *findSectionDef(int32_t section);
+  bool handleDirectiveCOMDATSelection(SectionChunk *newChunk,
+                                      llvm::COFF::COMDATType selection,
+                                      DefinedRegular *leader);
+  SectionChunk *handleComdatSelection(SectionChunk *newChunk,
+                                      llvm::COFF::COMDATType &selection,
+                                      DefinedRegular *leader, uint32_t newValue,
+                                      const coff_aux_section_definition *def);
+  bool mergeComdatSelectionTypes(llvm::COFF::COMDATType &selection,
+                                 DefinedRegular *leader);
+  const coff_section *getSection(uint32_t i);
   const coff_section *getSection(COFFSymbolRef sym) {
     return getSection(sym.getSectionNumber());
   }
@@ -245,7 +266,7 @@ private:
   void initializeSymbols();
   void initializeFlags();
   void initializeDependencies();
-  void initializeECThunks();
+  void processECThunks();
 
   SectionChunk *
   readSection(uint32_t sectionNumber,
@@ -269,24 +290,24 @@ private:
       COFFSymbolRef sym, const llvm::object::coff_aux_section_definition *def,
       const llvm::DenseMap<StringRef, uint32_t> &prevailingSectionMap);
 
-  // Given a new symbol Sym with comdat selection Selection, if the new
-  // symbol is not (yet) Prevailing and the existing comdat leader set to
-  // Leader, emits a diagnostic if the new symbol and its selection doesn't
-  // match the existing symbol and its selection. If either old or new
-  // symbol have selection IMAGE_COMDAT_SELECT_LARGEST, Sym might replace
-  // the existing leader. In that case, Prevailing is set to true.
-  void
+  // Given a non-prevailing symbol Sym with COMDAT selection Selection,
+  // determine whether it replaces the current prevailing COMDAT leader. If a
+  // new IMAGE_COMDAT_SELECT_LARGEST candidate prevails, the previously
+  // prevailing chunk is returned. Otherwise, returns nullptr.
+  SectionChunk *
   handleComdatSelection(COFFSymbolRef sym, llvm::COFF::COMDATType &selection,
-                        bool &prevailing, DefinedRegular *leader,
+                        DefinedRegular *leader,
                         const llvm::object::coff_aux_section_definition *def);
 
   std::optional<Symbol *>
-  createDefined(COFFSymbolRef sym,
+  createDefined(COFFSymbolRef sym, uint32_t symbolIndex,
                 std::vector<const llvm::object::coff_aux_section_definition *>
                     &comdatDefs,
                 bool &prevailingComdat);
-  Symbol *createRegular(COFFSymbolRef sym);
-  Symbol *createUndefined(COFFSymbolRef sym, bool overrideLazy);
+  Symbol *createRegular(COFFSymbolRef sym, uint32_t symbolIndex,
+                        uint32_t sectionNumber);
+  Symbol *createUndefined(COFFSymbolRef sym, bool overrideLazy,
+                          bool markReference);
 
   std::unique_ptr<COFFObjectFile> coffObj;
 
@@ -313,6 +334,12 @@ private:
 
   std::vector<SectionChunk *> hybmpChunks;
 
+  // Ordinary sections are read before COMDAT selection. Record prevailing
+  // .drectve contents with their section numbers and concatenate them in
+  // object section order after symbol initialization.
+  SmallVector<std::pair<uint32_t, StringRef>, 2> directiveSections;
+  std::string directivesStorage;
+
   // This vector contains a list of all symbols defined or referenced by this
   // file. They are indexed such that you can get a Symbol by symbol
   // index. Nonexistent indices (which are occupied by auxiliary
@@ -321,10 +348,65 @@ private:
 
   // This vector contains the same chunks as Chunks, but they are
   // indexed such that you can get a SectionChunk by section index.
-  // Nonexistent section indices are filled with null pointers.
-  // (Because section number is 1-based, the first slot is always a
-  // null pointer.) This vector is only valid during initialization.
+  // Nonexistent section indices (including COMDATs that are still pending)
+  // are null. The state bit vectors below disambiguate those cases. This vector
+  // is only valid during initialization.
   std::vector<SectionChunk *> sparseChunks;
+
+  // Pending and rejected COMDAT sections are tracked separately from
+  // sparseChunks so no fabricated pointer value is needed as a sentinel. This
+  // array is allocated only for objects that contain COMDAT sections and is
+  // valid only during initialization.
+  enum COMDATSectionState : uint8_t {
+    PendingCOMDAT = 1,
+    DiscardedCOMDAT = 2,
+    UnassociatedCOMDAT = 4,
+  };
+  std::vector<uint8_t> comdatSectionStates;
+
+  bool hasCOMDATSectionState(uint32_t section, COMDATSectionState state) const {
+    return section < comdatSectionStates.size() &&
+           (comdatSectionStates[section] & state);
+  }
+  void setCOMDATSectionState(uint32_t section, COMDATSectionState state) {
+    comdatSectionStates[section] |= state;
+  }
+  void clearCOMDATSectionState(uint32_t section, COMDATSectionState state) {
+    comdatSectionStates[section] &= ~state;
+  }
+
+  bool isPendingCOMDATSection(uint32_t section) const {
+    return hasCOMDATSectionState(section, PendingCOMDAT);
+  }
+  bool isDiscardedCOMDATSection(uint32_t section) const {
+    return hasCOMDATSectionState(section, DiscardedCOMDAT);
+  }
+  bool isUnassociatedCOMDATSection(uint32_t section) const {
+    return hasCOMDATSectionState(section, UnassociatedCOMDAT);
+  }
+
+  struct COMDATDefinition {
+    uint32_t symbolIndex;
+    uint32_t next;
+  };
+  static constexpr uint32_t noCOMDATDefinition = ~uint32_t{0};
+
+  // External definitions are kept in one flat journal and indexed by COFF
+  // section number. The head array itself is allocated lazily when a
+  // replaceable group actually records a secondary definition.
+  llvm::SmallVector<uint32_t, 0> comdatDefinitionHeads;
+  llvm::SmallVector<COMDATDefinition, 0> comdatDefinitions;
+
+  // Set while sparseChunks is created so initializeSymbols does not need to
+  // rescan the section array merely to decide whether a COMDAT pre-scan is
+  // necessary.
+  bool hasCOMDATSections = false;
+
+  // True for a native object produced by the current link's LTO compilation.
+  // Undefined symbols emitted only during code generation are late references
+  // and must remain visible even when their compiler-generated unwind section
+  // is an unassociated COMDAT.
+  bool isLTOOutput = false;
 
   DWARFCache *dwarf = nullptr;
 };

--- a/lld/COFF/LTO.cpp
+++ b/lld/COFF/LTO.cpp
@@ -283,7 +283,8 @@ std::vector<InputFile *> BitcodeCompiler::compile() {
     if (llvm::is_contained(ctx.config.saveTempsArgs, "prelink") || emitASM)
       saveBuffer(buf[i].second, ltoObjName);
     if (!emitASM)
-      ret.push_back(ObjFile::create(ctx, MemoryBufferRef(objBuf, ltoObjName)));
+      ret.push_back(ObjFile::create(ctx, MemoryBufferRef(objBuf, ltoObjName),
+                                    /*lazy=*/false, /*isLTOOutput=*/true));
   }
 
   return ret;

--- a/lld/COFF/MarkLive.cpp
+++ b/lld/COFF/MarkLive.cpp
@@ -31,11 +31,11 @@ void markLive(COFFLinkerContext &ctx) {
   // sections alive.
   for (Chunk *c : ctx.driver.getChunks())
     if (auto *sc = dyn_cast<SectionChunk>(c))
-      if (sc->live && !sc->isDWARF())
+      if (sc->live && !sc->isDiscardedByCOMDAT() && !sc->isDWARF())
         worklist.push_back(sc);
 
   auto enqueue = [&](SectionChunk *c) {
-    if (c->live)
+    if (c->isDiscardedByCOMDAT() || c->live)
       return;
     c->live = true;
     worklist.push_back(c);

--- a/lld/COFF/SymbolTable.cpp
+++ b/lld/COFF/SymbolTable.cpp
@@ -21,6 +21,7 @@
 #include "llvm/IR/Mangler.h"
 #include "llvm/LTO/LTO.h"
 #include "llvm/Object/COFFModuleDefinition.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/GlobPattern.h"
 #include "llvm/Support/Parallel.h"
@@ -244,17 +245,31 @@ void SymbolTable::reportUndefinedSymbol(const UndefinedDiag &undefDiag) {
   }
 }
 
-void SymbolTable::loadMinGWSymbols() {
+void SymbolTable::loadMinGWSymbols(bool loadStdcallFixups,
+                                   bool loadAutoImports) {
+  SmallPtrSet<Symbol *, 8> seen;
   std::vector<Symbol *> undefs;
+  auto addUndefined = [&](Symbol *sym) {
+    auto *undef = dyn_cast_or_null<Undefined>(sym);
+    if (!undef || undef->getWeakAlias() || !seen.insert(sym).second)
+      return;
+    undefs.push_back(sym);
+  };
   for (auto &i : symMap) {
     Symbol *sym = i.second;
-    auto *undef = dyn_cast<Undefined>(sym);
-    if (!undef)
-      continue;
-    if (undef->getWeakAlias())
-      continue;
-    undefs.push_back(sym);
+    if (sym->hasUndefinedReference)
+      addUndefined(sym);
   }
+
+  // References from replaceable COMDAT groups are provisional until the
+  // final prevailing group is known. Let the MinGW fixup pass inspect them so
+  // that it can load a provider which may affect COMDAT selection, but do not
+  // publish them through markReferenced(). If their group survives, they are
+  // attributed normally by resolveDeferredReferences().
+  for (SectionChunk *chunk : deferredReferenceChunks)
+    if (!chunk->isDiscardedByCOMDAT())
+      for (Symbol *sym : chunk->symbols())
+        addUndefined(sym);
 
   for (auto sym : undefs) {
     auto *undef = dyn_cast<Undefined>(sym);
@@ -264,7 +279,7 @@ void SymbolTable::loadMinGWSymbols() {
       continue;
     StringRef name = undef->getName();
 
-    if (machine == I386 && ctx.config.stdcallFixup) {
+    if (loadStdcallFixups && machine == I386 && ctx.config.stdcallFixup) {
       // Check if we can resolve an undefined decorated symbol by finding
       // the intended target as an undecorated symbol (only with a leading
       // underscore).
@@ -297,7 +312,7 @@ void SymbolTable::loadMinGWSymbols() {
       }
     }
 
-    if (ctx.config.autoImport) {
+    if (loadAutoImports && ctx.config.autoImport) {
       if (name.starts_with("__imp_"))
         continue;
       // If we have an undefined symbol, but we have a lazy symbol we could
@@ -430,7 +445,10 @@ void SymbolTable::reportUnresolvable() {
   for (auto &i : symMap) {
     Symbol *sym = i.second;
     auto *undef = dyn_cast<Undefined>(sym);
-    if (!undef || sym->deferUndefined)
+    // Definitions from discarded COMDATs are represented as Undefined so
+    // that they no longer participate in symbol-table consumers. Do not
+    // diagnose them unless a real undefined reference was also observed.
+    if (!undef || !sym->hasUndefinedReference || sym->deferUndefined)
       continue;
     if (undef->getWeakAlias())
       continue;
@@ -525,19 +543,17 @@ void SymbolTable::resolveRemainingUndefines(std::vector<Undefined *> &aliases) {
 }
 
 std::pair<Symbol *, bool> SymbolTable::insert(StringRef name) {
-  bool inserted = false;
   Symbol *&sym = symMap[CachedHashStringRef(name)];
-  if (!sym) {
-    sym = reinterpret_cast<Symbol *>(make<SymbolUnion>());
-    sym->isUsedInRegularObj = false;
-    sym->pendingArchiveLoad = false;
-    sym->canInline = true;
-    inserted = true;
+  if (sym)
+    return {sym, false};
 
-    if (isEC() && name.starts_with("EXP+"))
-      expSymbols.push_back(sym);
-  }
-  return {sym, inserted};
+  // Give the symbol slot a valid dynamic type immediately. Besides making the
+  // default state explicit, this ensures replaceSymbol() never reads fields
+  // through a pointer to storage in which no Symbol object exists yet.
+  sym = new (make<SymbolUnion>()) Undefined(name);
+  if (isEC() && name.starts_with("EXP+"))
+    expSymbols.push_back(sym);
+  return {sym, true};
 }
 
 std::pair<Symbol *, bool> SymbolTable::insert(StringRef name, InputFile *file) {
@@ -685,15 +701,667 @@ void SymbolTable::initializeSameAddressThunks() {
 }
 
 Symbol *SymbolTable::addUndefined(StringRef name, InputFile *f,
-                                  bool overrideLazy) {
-  auto [s, wasInserted] = insert(name, f);
-  if (wasInserted || (s->isLazy() && overrideLazy)) {
-    replaceSymbol<Undefined>(s, name);
+                                  bool overrideLazy, bool markReference) {
+  Symbol *s = markReference ? insert(name, f).first : insert(name).first;
+  if (markReference)
+    s->hasUndefinedReference = true;
+
+  if (!s->isLazy())
     return s;
-  }
-  if (s->isLazy())
+
+  if (overrideLazy)
+    return replaceSymbol<Undefined>(s, name);
+
+  if (markReference)
     forceLazy(s);
   return s;
+}
+
+Symbol *SymbolTable::addDiscardedDefinition(StringRef name) {
+  return insert(name).first;
+}
+
+Symbol *SymbolTable::canonicalizeDeferredCOMDATSymbol(Symbol *symbol) const {
+  if (Symbol *source = deferredComdatLeaderSources.lookup(symbol))
+    return source;
+  return symbol;
+}
+
+bool SymbolTable::hasDeferredCOMDATWork() const {
+  return !deferredSymbols.empty() || !deferredSymbolSources.empty() ||
+         !deferredSymbolsToResolve.empty() ||
+         !deferredReferenceChunks.empty() || !deferredDuplicates.empty();
+}
+
+static bool mayBeReplacedByLargerCOMDAT(Symbol *s) {
+  auto *d = dyn_cast<DefinedRegular>(s);
+  // Bitcode definitions use shared fake ANY chunks for all symbols, not just
+  // members of a replaceable COMDAT. Treating those chunks as provisional
+  // would defer unrelated strong/weak resolution and can mark multiple LTO
+  // definitions as prevailing.
+  if (!d || !d->data || !isa<ObjFile>(d->file))
+    return false;
+  SectionChunk *chunk = d->getChunk();
+  if (chunk->sym == d)
+    return false;
+  return chunk->isInReplaceableCOMDATGroup();
+}
+
+static bool shouldReplaceWeakAlias(SymbolTable &symtab, InputFile *f,
+                                   Symbol *source, Symbol *currentTarget,
+                                   bool currentIsAntiDep, Symbol *target,
+                                   bool isAntiDep) {
+  if (currentTarget && currentTarget != target) {
+    // Ignore duplicated anti-dependency symbols.
+    if (isAntiDep)
+      return false;
+    if (!currentIsAntiDep) {
+      // Weak aliases as produced by GCC are named in the form
+      // .weak.<weaksymbol>.<othersymbol>, where <othersymbol> is the name of
+      // another symbol emitted near the weak symbol.
+      if (symtab.ctx.config.allowDuplicateWeak) {
+        auto isAbsZero = [](Symbol *sym) -> bool {
+          auto *absolute = dyn_cast<DefinedAbsolute>(sym);
+          return absolute && absolute->getVA() == 0;
+        };
+        // If the alias we had points at absolute zero, and we get another weak
+        // symbol which isn't absolute zero, prefer that one.
+        return isAbsZero(currentTarget) && !isAbsZero(target);
+      }
+      symtab.reportDuplicate(source, f);
+    }
+  }
+  return true;
+}
+
+void SymbolTable::addWeakAlias(InputFile *f, Symbol *source, Symbol *target,
+                               bool isAntiDep) {
+  auto *u = dyn_cast<Undefined>(source);
+  if (!u) {
+    // A definition suppresses weak aliases. Remember every alias for a regular
+    // definition that may later be discarded with its COMDAT group. If that
+    // happens, replaying the aliases in input order preserves the usual
+    // conflict diagnostics and allowDuplicateWeak precedence.
+    if (mayBeReplacedByLargerCOMDAT(source))
+      deferredWeakAliases[source].suppressed.push_back({f, target, isAntiDep});
+    return;
+  }
+
+  if (shouldReplaceWeakAlias(*this, f, source, u->weakAlias, u->isAntiDep,
+                             target, isAntiDep)) {
+    u->setWeakAlias(target, isAntiDep);
+    if (source->hasUndefinedReference && u->isECAlias(machine))
+      markReferenced(target);
+  }
+}
+
+void SymbolTable::markReferenced(Symbol *symbol, bool forceLazyProvider) {
+  bool wasReferenced = symbol->hasUndefinedReference;
+  symbol->hasUndefinedReference = true;
+  symbol->isUsedInRegularObj = true;
+  if (forceLazyProvider && symbol->isLazy() && !symbol->pendingArchiveLoad)
+    forceLazy(symbol);
+  if (!wasReferenced)
+    if (auto *undefined = dyn_cast<Undefined>(symbol);
+        undefined && undefined->weakAlias && undefined->isECAlias(machine))
+      markReferenced(undefined->weakAlias, forceLazyProvider);
+}
+
+void SymbolTable::addReference(Symbol *symbol) {
+  if (symbol)
+    markReferenced(symbol);
+}
+
+void SymbolTable::deferSectionReferences(SectionChunk *chunk) {
+  if (!chunk->isDiscardedByCOMDAT())
+    deferredReferenceChunks.push_back(chunk);
+}
+
+void SymbolTable::addUnrelocatedReference(Symbol *symbol) {
+  if (symbol)
+    markReferenced(symbol);
+}
+
+void SymbolTable::resolveDeferredReferences() {
+  SmallVector<SectionChunk *, 0> chunks;
+  chunks.swap(deferredReferenceChunks);
+  for (SectionChunk *chunk : chunks) {
+    if (chunk->isDiscardedByCOMDAT())
+      continue;
+    for (Symbol *symbol : chunk->symbols())
+      if (symbol)
+        markReferenced(symbol);
+  }
+}
+
+void SymbolTable::finalizeDeferredSymbols() {
+  SmallVector<Symbol *, 0> sources;
+  sources.swap(deferredSymbolSources);
+  replayDeferredSources(sources, /*importThunks=*/false, /*final=*/true);
+  replayDeferredSources(sources, /*importThunks=*/true, /*final=*/true);
+  assert(deferredSymbols.empty() && "deferred providers were not replayed");
+  deferredProviders.clear();
+  updateDeferredImportLiveness();
+
+  SmallVector<DeferredDuplicate, 0> duplicates;
+  duplicates.swap(deferredDuplicates);
+  for (const DeferredDuplicate &duplicate : duplicates)
+    if (!duplicate.chunk->isDiscardedByCOMDAT())
+      reportDuplicate(duplicate.existing, duplicate.newFile, duplicate.chunk,
+                      duplicate.sectionOffset);
+}
+
+void SymbolTable::restoreDeferredSymbolState(Undefined *source) {
+  if (deferredWeakAliases.empty() && deferredSymbols.empty())
+    return;
+
+  auto it = deferredWeakAliases.find(source);
+  if (it != deferredWeakAliases.end()) {
+    DeferredWeakAliases aliases = std::move(it->second);
+    deferredWeakAliases.erase(it);
+    if (aliases.initialTarget)
+      source->setWeakAlias(aliases.initialTarget, aliases.initialIsAntiDep);
+    for (const DeferredWeakAlias &alias : aliases.suppressed)
+      addWeakAlias(alias.file, source, alias.target, alias.isAntiDep);
+  }
+
+  if (deferredSymbols.contains(source) &&
+      deferredSymbolsQueued.insert(source).second)
+    deferredSymbolsToResolve.push_back(source);
+}
+
+Symbol *SymbolTable::cloneDeferredSymbol(Symbol *symbol) {
+  switch (symbol->kind()) {
+  case Symbol::DefinedRegularKind:
+    llvm_unreachable("regular deferred providers use descriptors");
+  case Symbol::DefinedCommonKind:
+    return make<DefinedCommon>(*cast<DefinedCommon>(symbol));
+  case Symbol::DefinedLocalImportKind:
+    return make<DefinedLocalImport>(*cast<DefinedLocalImport>(symbol));
+  case Symbol::DefinedImportThunkKind: {
+    auto *thunk = cast<DefinedImportThunk>(symbol);
+    auto *copy = make<DefinedImportThunk>(*thunk);
+    deferredImportThunks[copy] = {thunk->wrappedSym->file,
+                                  thunk->wrappedSym->getName()};
+    return copy;
+  }
+  case Symbol::DefinedImportDataKind:
+    return make<DefinedImportData>(*cast<DefinedImportData>(symbol));
+  case Symbol::DefinedAbsoluteKind:
+    return make<DefinedAbsolute>(*cast<DefinedAbsolute>(symbol));
+  case Symbol::DefinedSyntheticKind:
+    return make<DefinedSynthetic>(*cast<DefinedSynthetic>(symbol));
+  case Symbol::LazyArchiveKind:
+    return make<LazyArchive>(*cast<LazyArchive>(symbol));
+  case Symbol::LazyObjectKind:
+    return make<LazyObject>(*cast<LazyObject>(symbol));
+  case Symbol::LazyDLLSymbolKind:
+    return make<LazyDLLSymbol>(*cast<LazyDLLSymbol>(symbol));
+  case Symbol::UndefinedKind:
+    llvm_unreachable("an undefined symbol is not a deferred provider");
+  }
+  llvm_unreachable("unknown deferred symbol kind");
+}
+
+void SymbolTable::appendDeferredProvider(Symbol *source,
+                                         DeferredProvider provider) {
+  auto [it, inserted] = deferredSymbols.try_emplace(source);
+  if (inserted)
+    deferredSymbolSources.push_back(source);
+
+  if (deferredProviders.size() >= noDeferredProvider)
+    Fatal(ctx) << "too many deferred COMDAT providers";
+  DeferredProviderId id =
+      static_cast<DeferredProviderId>(deferredProviders.size());
+  deferredProviders.push_back(provider);
+  DeferredSourceState &state = it->second;
+  if (state.last == noDeferredProvider)
+    state.first = id;
+  else
+    deferredProviders[state.last].next = id;
+  state.last = id;
+}
+
+void SymbolTable::deferDefinedSymbol(Symbol *source, Symbol *provider,
+                                     bool isUsedInRegularObj, Symbol *parent) {
+  provider->isUsedInRegularObj = isUsedInRegularObj;
+  if (auto *common = dyn_cast<DefinedCommon>(provider))
+    if (CommonChunk *chunk = common->getChunk())
+      chunk->live = false;
+  if (auto *data = dyn_cast<DefinedImportData>(provider)) {
+    deferredImportFiles.insert(data->file);
+    data->file->live = false;
+  }
+  if (auto *thunk = dyn_cast<DefinedImportThunk>(provider)) {
+    thunk->getChunk()->live = false;
+    auto it = deferredImportThunks.find(provider);
+    assert(it != deferredImportThunks.end() &&
+           "deferred import thunk has no import metadata");
+    deferredImportFiles.insert(it->second.file);
+  }
+
+  DeferredProvider deferred;
+  deferred.symbol = provider;
+  deferred.parent = parent;
+  appendDeferredProvider(source, deferred);
+}
+
+void SymbolTable::deferRegularSymbol(Symbol *source, InputFile *file,
+                                     const coff_symbol_generic *coffSym,
+                                     SectionChunk *chunk, uint32_t value,
+                                     bool isWeak, Symbol *parent) {
+  DeferredProvider provider;
+  provider.regularFile = file;
+  provider.regularSym = coffSym;
+  provider.regularChunk = chunk;
+  provider.parent = parent;
+  provider.regularValue = value;
+  provider.isRegular = true;
+  provider.regularIsWeak = isWeak;
+  appendDeferredProvider(source, provider);
+}
+
+template <typename T>
+static void updateDeferredImportField(T *&field, const Symbol *source,
+                                      const Symbol *provider, T *selected) {
+  // ImportFile caches derived pointers into replaceable SymbolUnion storage.
+  // Compare addresses without dereferencing an object whose lifetime may have
+  // ended in replaceSymbol().
+  const void *address = field;
+  if (address == source || address == provider)
+    field = selected;
+}
+
+void SymbolTable::replayDeferredSymbol(Symbol *source,
+                                       DeferredProviderId providerId) {
+  DeferredProvider &deferred = deferredProviders[providerId];
+  if (Symbol *parent = deferred.parent) {
+    auto selection = deferredComdatSelections.find(parent);
+    assert(selection != deferredComdatSelections.end() &&
+           "deferred COMDAT child replayed before its leader");
+    if (!selection->second)
+      return;
+  }
+
+  StringRef name = source->getName();
+  if (deferred.isRegular) {
+    if (deferred.regularChunk && deferred.regularChunk->isDiscardedByCOMDAT())
+      return;
+    addRegular(deferred.regularFile, name, deferred.regularSym,
+               deferred.regularChunk, deferred.regularValue,
+               deferred.regularIsWeak);
+    return;
+  }
+
+  Symbol *provider = deferred.symbol;
+  assert(provider && "non-regular deferred provider has no symbol payload");
+  switch (provider->kind()) {
+  case Symbol::DefinedRegularKind: {
+    auto *regular = cast<DefinedRegular>(provider);
+    SectionChunk *chunk = regular->data ? regular->getChunk() : nullptr;
+    if (chunk && chunk->isDiscardedByCOMDAT())
+      return;
+    const coff_symbol_generic *coffSym = nullptr;
+    uint32_t value = 0;
+    if (isa<ObjFile>(regular->file)) {
+      coffSym = regular->getCOFFSymbol().getGeneric();
+      value = regular->getValue();
+    }
+    if (regular->isCOMDAT) {
+      auto recordSelection = [&](bool selected) {
+        deferredComdatSelections[provider] = selected;
+        if (!selected)
+          return;
+        if (Symbol *old = selectedDeferredComdats.lookup(source))
+          deferredComdatSelections[old] = false;
+        selectedDeferredComdats[source] = provider;
+      };
+
+      if (!isa<DefinedRegular>(source)) {
+        replaceSymbol<DefinedRegular>(source, *regular);
+        if (chunk && isa<ObjFile>(regular->file))
+          chunk->sym = cast<DefinedRegular>(source);
+        recordSelection(true);
+      } else {
+        auto *existing = cast<DefinedRegular>(source);
+        auto *file = dyn_cast_or_null<ObjFile>(regular->file);
+        if (!existing->isCOMDAT) {
+          reportDuplicate(source, regular->file, chunk, value);
+          if (chunk && file)
+            file->discardCOMDATGroup(chunk);
+          recordSelection(false);
+        } else if (chunk && file) {
+          COMDATType selection = chunk->selection;
+          if (SectionChunk *replaced = file->handleComdatSelection(
+                  chunk, selection, existing, value, /*def=*/nullptr)) {
+            replaced->file->discardCOMDATGroup(replaced);
+            replaceSymbol<DefinedRegular>(source, *regular);
+            chunk->setSelection(selection);
+            chunk->sym = cast<DefinedRegular>(source);
+            recordSelection(true);
+          } else {
+            file->discardCOMDATGroup(chunk);
+            recordSelection(false);
+          }
+        } else {
+          recordSelection(false);
+        }
+      }
+      deferredComdatLeaderSources.erase(provider);
+      return;
+    }
+    addRegular(regular->file, name, coffSym, chunk, value, regular->isWeak);
+    return;
+  }
+  case Symbol::DefinedCommonKind: {
+    auto *common = cast<DefinedCommon>(provider);
+    const coff_symbol_generic *coffSym = nullptr;
+    if (isa<ObjFile>(common->file))
+      coffSym = common->getCOFFSymbol().getGeneric();
+    addCommon(common->file, name, common->getSize(), coffSym,
+              common->getChunk());
+    return;
+  }
+  case Symbol::DefinedImportDataKind: {
+    auto *data = cast<DefinedImportData>(provider);
+    DefinedImportData *selected =
+        addImportData(name, data->file, data->location);
+    if (selected && selected->file != data->file)
+      selected = nullptr;
+    updateDeferredImportField(data->file->impSym, source, provider, selected);
+    updateDeferredImportField(data->file->impECSym, source, provider, selected);
+    updateDeferredImportField(data->file->auxImpCopySym, source, provider,
+                              selected);
+    return;
+  }
+  case Symbol::DefinedImportThunkKind: {
+    auto *thunk = cast<DefinedImportThunk>(provider);
+    auto infoIt = deferredImportThunks.find(provider);
+    assert(infoIt != deferredImportThunks.end() &&
+           "deferred import thunk replay has no import metadata");
+    DeferredImportThunk info = infoIt->second;
+    deferredImportThunks.erase(infoIt);
+    auto *importData =
+        dyn_cast_or_null<DefinedImportData>(find(info.importName));
+    if (importData && importData->file != info.file)
+      importData = nullptr;
+    Defined *selected =
+        importData ? addImportThunk(name, importData, thunk->getChunk())
+                   : nullptr;
+    if (selected &&
+        (!isa<DefinedImportThunk>(selected) ||
+         cast<DefinedImportThunk>(selected)->wrappedSym->file != info.file))
+      selected = nullptr;
+    thunk->getChunk()->live = selected && !ctx.config.doGC;
+    updateDeferredImportField(info.file->thunkSym, source, provider, selected);
+    updateDeferredImportField(info.file->auxThunkSym, source, provider,
+                              selected);
+    if (info.file->impchkThunk == thunk->getChunk()) {
+      if (selected)
+        info.file->impchkThunk->sym = selected;
+      else
+        info.file->impchkThunk = nullptr;
+    }
+    return;
+  }
+  case Symbol::DefinedAbsoluteKind:
+    addAbsolute(name, cast<DefinedAbsolute>(provider)->getVA());
+    return;
+  case Symbol::DefinedSyntheticKind:
+    addSynthetic(name, cast<DefinedSynthetic>(provider)->getChunk());
+    return;
+  case Symbol::DefinedLocalImportKind:
+    if (isa<Undefined>(source) || source->isLazy())
+      replaceSymbol<DefinedLocalImport>(source,
+                                        *cast<DefinedLocalImport>(provider));
+    else
+      reportDuplicate(source, nullptr);
+    return;
+  case Symbol::LazyArchiveKind: {
+    auto *lazy = cast<LazyArchive>(provider);
+    addLazyArchive(lazy->file, lazy->sym);
+    return;
+  }
+  case Symbol::LazyObjectKind: {
+    auto *lazy = cast<LazyObject>(provider);
+    addLazyObject(lazy->file, name);
+    return;
+  }
+  case Symbol::LazyDLLSymbolKind: {
+    auto *lazy = cast<LazyDLLSymbol>(provider);
+    addLazyDLLSymbol(lazy->file, lazy->sym, name);
+    return;
+  }
+  case Symbol::UndefinedKind:
+    llvm_unreachable("an undefined symbol is not a deferred provider");
+  }
+  llvm_unreachable("unknown deferred symbol kind");
+}
+
+void SymbolTable::replayDeferredSources(ArrayRef<Symbol *> sources,
+                                        bool importThunks, bool final) {
+  auto isComdatLeader = [&](DeferredProviderId id) {
+    Symbol *provider = deferredProviders[id].symbol;
+    auto *regular = dyn_cast_or_null<DefinedRegular>(provider);
+    return regular && regular->isCOMDAT;
+  };
+  auto isImportThunk = [&](DeferredProviderId id) {
+    return isa_and_nonnull<DefinedImportThunk>(deferredProviders[id].symbol);
+  };
+  auto canReplay = [&](Symbol *source) {
+    return final || isa<Undefined>(source) ||
+           !mayBeReplacedByLargerCOMDAT(source);
+  };
+
+  auto replayProviders = [&](Symbol *source, bool replayComdatLeaders) {
+    auto deferred = deferredSymbols.find(source);
+    if (deferred == deferredSymbols.end() || !canReplay(source))
+      return;
+
+    DeferredSourceState state = deferred->second;
+    DeferredProviderId replayFirst = noDeferredProvider;
+    DeferredProviderId replayLast = noDeferredProvider;
+    DeferredProviderId remainingFirst = noDeferredProvider;
+    DeferredProviderId remainingLast = noDeferredProvider;
+
+    auto append = [&](DeferredProviderId id, DeferredProviderId &first,
+                      DeferredProviderId &last) {
+      if (last == noDeferredProvider)
+        first = id;
+      else
+        deferredProviders[last].next = id;
+      last = id;
+    };
+
+    for (DeferredProviderId id = state.first; id != noDeferredProvider;) {
+      assert(id < deferredProviders.size() &&
+             "deferred provider list contains an invalid id");
+      DeferredProvider &provider = deferredProviders[id];
+      DeferredProviderId next = provider.next;
+      Symbol *parent = provider.parent;
+      bool awaitsParent = parent && !deferredComdatSelections.contains(parent);
+      if (isImportThunk(id) != importThunks ||
+          isComdatLeader(id) != replayComdatLeaders ||
+          (!replayComdatLeaders && awaitsParent))
+        append(id, remainingFirst, remainingLast);
+      else
+        append(id, replayFirst, replayLast);
+      id = next;
+    }
+
+    if (remainingLast != noDeferredProvider)
+      deferredProviders[remainingLast].next = noDeferredProvider;
+    if (replayLast != noDeferredProvider)
+      deferredProviders[replayLast].next = noDeferredProvider;
+
+    if (remainingFirst == noDeferredProvider) {
+      deferredSymbols.erase(deferred);
+    } else {
+      deferred->second.first = remainingFirst;
+      deferred->second.last = remainingLast;
+    }
+
+    if (replayFirst == noDeferredProvider)
+      return;
+
+    replayingDeferredSymbols = true;
+    for (DeferredProviderId id = replayFirst; id != noDeferredProvider;) {
+      DeferredProviderId next = deferredProviders[id].next;
+      replayDeferredSymbol(source, id);
+      id = next;
+    }
+    replayingDeferredSymbols = false;
+    updateDeferredCommonLiveness(replayFirst, source);
+    if (!deferredSymbols.contains(source))
+      deferredWeakAliases.erase(source);
+  };
+
+  auto hasComdatLeader = [&](const DeferredSourceState &state) {
+    for (DeferredProviderId id = state.first; id != noDeferredProvider;
+         id = deferredProviders[id].next)
+      if (isComdatLeader(id))
+        return true;
+    return false;
+  };
+
+  // Collect leader sources first. The common no-dependency case should not pay
+  // for a DenseMap or graph arrays.
+  SmallVector<Symbol *, 8> leaderSources;
+  SmallPtrSet<Symbol *, 8> leaderSourceSet;
+  if (!importThunks) {
+    for (Symbol *source : sources) {
+      auto deferred = deferredSymbols.find(source);
+      if (deferred == deferredSymbols.end())
+        continue;
+      if (canReplay(source) && hasComdatLeader(deferred->second) &&
+          leaderSourceSet.insert(source).second)
+        leaderSources.push_back(source);
+    }
+  }
+
+  auto getDependency = [&](Symbol *source) -> Symbol * {
+    Symbol *dependency = nullptr;
+    if (auto *regular = dyn_cast<DefinedRegular>(source);
+        regular && regular->data) {
+      SectionChunk *chunk = regular->getChunk();
+      if (chunk->isInReplaceableCOMDATGroup() && chunk->sym != regular)
+        dependency = chunk->sym;
+    }
+    if (Symbol *dependencySource =
+            deferredComdatLeaderSources.lookup(dependency))
+      dependency = dependencySource;
+    return dependency;
+  };
+
+  if (!leaderSources.empty()) {
+    bool hasDependencies = false;
+    for (Symbol *source : leaderSources) {
+      Symbol *dependency = getDependency(source);
+      if (dependency && leaderSourceSet.contains(dependency)) {
+        hasDependencies = true;
+        break;
+      }
+    }
+
+    if (!hasDependencies) {
+      for (Symbol *source : leaderSources)
+        replayProviders(source, /*replayComdatLeaders=*/true);
+    } else {
+      if (leaderSources.size() >= noDeferredProvider)
+        Fatal(ctx) << "too many deferred COMDAT leader sources";
+
+      DenseMap<Symbol *, uint32_t> leaderIndex;
+      leaderIndex.reserve(leaderSources.size());
+      for (uint32_t i = 0; i != leaderSources.size(); ++i)
+        leaderIndex.try_emplace(leaderSources[i], i);
+
+      static constexpr uint32_t noLeader = ~uint32_t{0};
+      SmallVector<uint32_t, 0> firstChild(leaderSources.size(), noLeader);
+      SmallVector<uint32_t, 0> lastChild(leaderSources.size(), noLeader);
+      SmallVector<uint32_t, 0> nextSibling(leaderSources.size(), noLeader);
+      SmallVector<uint32_t, 8> worklist;
+
+      for (uint32_t i = 0; i != leaderSources.size(); ++i) {
+        Symbol *dependency = getDependency(leaderSources[i]);
+        auto dependencyIt = leaderIndex.find(dependency);
+        if (!dependency || dependencyIt == leaderIndex.end()) {
+          worklist.push_back(i);
+          continue;
+        }
+
+        uint32_t parent = dependencyIt->second;
+        if (lastChild[parent] == noLeader)
+          firstChild[parent] = i;
+        else
+          nextSibling[lastChild[parent]] = i;
+        lastChild[parent] = i;
+      }
+
+      SmallVector<uint8_t, 0> replayed(leaderSources.size(), 0);
+      for (size_t i = 0; i != worklist.size(); ++i) {
+        uint32_t sourceIndex = worklist[i];
+        if (replayed[sourceIndex])
+          continue;
+        replayed[sourceIndex] = 1;
+        replayProviders(leaderSources[sourceIndex],
+                        /*replayComdatLeaders=*/true);
+
+        for (uint32_t child = firstChild[sourceIndex]; child != noLeader;
+             child = nextSibling[child])
+          worklist.push_back(child);
+      }
+
+      // Cyclic dependencies cannot be topologically ordered. Preserve input
+      // order for every source that was not reached from a root.
+      for (uint32_t i = 0; i != leaderSources.size(); ++i)
+        if (!replayed[i])
+          replayProviders(leaderSources[i], /*replayComdatLeaders=*/true);
+    }
+  }
+
+  // Leader selection is now final, so child providers can be published in one
+  // linear pass.
+  for (Symbol *source : sources)
+    replayProviders(source, /*replayComdatLeaders=*/false);
+}
+
+void SymbolTable::updateDeferredCommonLiveness(DeferredProviderId firstProvider,
+                                               Symbol *source) {
+  CommonChunk *selected = nullptr;
+  if (auto *common = dyn_cast<DefinedCommon>(source))
+    selected = common->getChunk();
+  for (DeferredProviderId id = firstProvider; id != noDeferredProvider;
+       id = deferredProviders[id].next) {
+    const DeferredProvider &deferred = deferredProviders[id];
+    if (deferred.isRegular)
+      continue;
+    Symbol *provider = deferred.symbol;
+    if (auto *common = dyn_cast<DefinedCommon>(provider))
+      if (CommonChunk *chunk = common->getChunk())
+        chunk->live = chunk == selected;
+  }
+}
+
+void SymbolTable::updateDeferredImportLiveness() {
+  for (ImportFile *file : deferredImportFiles) {
+    auto isSelected = [&](DefinedImportData *symbol) {
+      return symbol && isa<DefinedImportData>(symbol) && symbol->file == file;
+    };
+    bool selected = isSelected(file->impSym);
+    if (isArm64EC(file->getMachineType()))
+      selected = selected && isSelected(file->impECSym) &&
+                 isSelected(file->auxImpCopySym);
+    file->live = selected && !ctx.config.doGC;
+  }
+}
+
+void SymbolTable::resolveDeferredSymbols() {
+  SmallVector<Symbol *, 0> symbols;
+  symbols.swap(deferredSymbolsToResolve);
+  deferredSymbolsQueued.clear();
+  replayDeferredSources(symbols, /*importThunks=*/false, /*final=*/false);
+  replayDeferredSources(symbols, /*importThunks=*/true, /*final=*/false);
+  updateDeferredImportLiveness();
 }
 
 Symbol *SymbolTable::addGCRoot(StringRef name, bool aliasEC) {
@@ -754,6 +1422,8 @@ bool checkLazyECPair(SymbolTable *symtab, StringRef name, InputFile *f) {
   Symbol *sym = symtab->find(pairName);
   if (!sym)
     return true;
+  if (mayBeReplacedByLargerCOMDAT(sym))
+    return true;
   if (sym->pendingArchiveLoad)
     return false;
   if (auto u = dyn_cast<Undefined>(sym))
@@ -768,9 +1438,13 @@ void SymbolTable::addLazyArchive(ArchiveFile *f, const Archive::Symbol &sym) {
   StringRef name = sym.getName();
   if (isEC() && !checkLazyECPair<LazyArchive>(this, name, f))
     return;
-  auto [s, wasInserted] = insert(name);
-  if (wasInserted) {
+  Symbol *s = insert(name).first;
+  if (isa<Undefined>(s) && !s->hasUndefinedReference) {
     replaceSymbol<LazyArchive>(s, f, sym);
+    return;
+  }
+  if (!replayingDeferredSymbols && mayBeReplacedByLargerCOMDAT(s)) {
+    deferDefinedSymbol(s, make<LazyArchive>(f, sym), false);
     return;
   }
   auto *u = dyn_cast<Undefined>(s);
@@ -784,9 +1458,13 @@ void SymbolTable::addLazyObject(InputFile *f, StringRef n) {
   assert(f->lazy);
   if (isEC() && !checkLazyECPair<LazyObject>(this, n, f))
     return;
-  auto [s, wasInserted] = insert(n, f);
-  if (wasInserted) {
+  Symbol *s = insert(n, f).first;
+  if (isa<Undefined>(s) && !s->hasUndefinedReference) {
     replaceSymbol<LazyObject>(s, f, n);
+    return;
+  }
+  if (!replayingDeferredSymbols && mayBeReplacedByLargerCOMDAT(s)) {
+    deferDefinedSymbol(s, make<LazyObject>(f, n), false);
     return;
   }
   auto *u = dyn_cast<Undefined>(s);
@@ -799,9 +1477,13 @@ void SymbolTable::addLazyObject(InputFile *f, StringRef n) {
 
 void SymbolTable::addLazyDLLSymbol(DLLFile *f, DLLFile::Symbol *sym,
                                    StringRef n) {
-  auto [s, wasInserted] = insert(n);
-  if (wasInserted) {
+  Symbol *s = insert(n).first;
+  if (isa<Undefined>(s) && !s->hasUndefinedReference) {
     replaceSymbol<LazyDLLSymbol>(s, f, sym, n);
+    return;
+  }
+  if (!replayingDeferredSymbols && mayBeReplacedByLargerCOMDAT(s)) {
+    deferDefinedSymbol(s, make<LazyDLLSymbol>(f, sym, n), false);
     return;
   }
   auto *u = dyn_cast<Undefined>(s);
@@ -876,6 +1558,10 @@ void SymbolTable::reportDuplicate(Symbol *existing, InputFile *newFile,
 Symbol *SymbolTable::addAbsolute(StringRef n, COFFSymbolRef sym) {
   auto [s, wasInserted] = insert(n, nullptr);
   s->isUsedInRegularObj = true;
+  if (!replayingDeferredSymbols && mayBeReplacedByLargerCOMDAT(s)) {
+    deferDefinedSymbol(s, make<DefinedAbsolute>(ctx, n, sym), true);
+    return s;
+  }
   if (wasInserted || isa<Undefined>(s) || s->isLazy())
     replaceSymbol<DefinedAbsolute>(s, ctx, n, sym);
   else if (auto *da = dyn_cast<DefinedAbsolute>(s)) {
@@ -889,6 +1575,10 @@ Symbol *SymbolTable::addAbsolute(StringRef n, COFFSymbolRef sym) {
 Symbol *SymbolTable::addAbsolute(StringRef n, uint64_t va) {
   auto [s, wasInserted] = insert(n, nullptr);
   s->isUsedInRegularObj = true;
+  if (!replayingDeferredSymbols && mayBeReplacedByLargerCOMDAT(s)) {
+    deferDefinedSymbol(s, make<DefinedAbsolute>(ctx, n, va), true);
+    return s;
+  }
   if (wasInserted || isa<Undefined>(s) || s->isLazy())
     replaceSymbol<DefinedAbsolute>(s, ctx, n, va);
   else if (auto *da = dyn_cast<DefinedAbsolute>(s)) {
@@ -912,24 +1602,132 @@ Symbol *SymbolTable::addSynthetic(StringRef n, Chunk *c) {
 Symbol *SymbolTable::addRegular(InputFile *f, StringRef n,
                                 const coff_symbol_generic *sym, SectionChunk *c,
                                 uint32_t sectionOffset, bool isWeak) {
-  auto [s, wasInserted] = insert(n, f);
-  if (wasInserted || !isa<DefinedRegular>(s) || s->isWeak)
-    replaceSymbol<DefinedRegular>(s, f, n, /*IsCOMDAT*/ false,
-                                  /*IsExternal*/ true, sym, c, isWeak);
-  else if (!isWeak)
-    reportDuplicate(s, f, c, sectionOffset);
+  Symbol *s = insert(n, f).first;
+  if (auto *undefined = dyn_cast<Undefined>(s);
+      undefined && !undefined->weakAlias)
+    return replaceSymbol<DefinedRegular>(s, f, n, /*IsCOMDAT=*/false,
+                                         /*IsExternal=*/true, sym, c, isWeak);
+
+  if (replayingDeferredSymbols) {
+    if (!isa<DefinedRegular>(s) || s->isWeak)
+      return replaceSymbol<DefinedRegular>(s, f, n, /*IsCOMDAT=*/false,
+                                           /*IsExternal=*/true, sym, c, isWeak);
+    if (!isWeak)
+      reportDuplicate(s, f, c, sectionOffset);
+    return s;
+  }
+
+  bool provisional =
+      isa<ObjFile>(f) && c && c->isInReplaceableCOMDATGroup() && c->sym != s;
+  bool existingProvisional = mayBeReplacedByLargerCOMDAT(s);
+
+  // Keep the normal symbol insertion path compact. In particular, a new
+  // secondary COMDAT definition normally replaces an unaliased Undefined and
+  // needs no deferred state at all.
+  if (LLVM_LIKELY(!existingProvisional && !provisional)) {
+    if (!isa<DefinedRegular>(s) || s->isWeak)
+      return replaceSymbol<DefinedRegular>(s, f, n, /*IsCOMDAT=*/false,
+                                           /*IsExternal=*/true, sym, c, isWeak);
+    if (!isWeak)
+      reportDuplicate(s, f, c, sectionOffset);
+    return s;
+  }
+
+  return addRegularWithDeferredCOMDAT(f, n, sym, c, sectionOffset, isWeak, s,
+                                      provisional, existingProvisional);
+}
+
+LLVM_ATTRIBUTE_NOINLINE Symbol *SymbolTable::addRegularWithDeferredCOMDAT(
+    InputFile *f, StringRef n, const coff_symbol_generic *sym, SectionChunk *c,
+    uint32_t sectionOffset, bool isWeak, Symbol *s, bool provisional,
+    bool existingProvisional) {
+  assert(!replayingDeferredSymbols && (provisional || existingProvisional) &&
+         "deferred COMDAT path requires a provisional definition");
+
+  // Replacing an undefined symbol destroys its selected weak alias. Preserve
+  // that state only when the replacement can itself be discarded later.
+  if (provisional) {
+    if (auto *undefined = dyn_cast<Undefined>(s);
+        undefined && undefined->weakAlias) {
+      auto [it, inserted] = deferredWeakAliases.try_emplace(s);
+      if (inserted) {
+        it->second.initialTarget = undefined->weakAlias;
+        it->second.initialIsAntiDep = undefined->isAntiDep;
+      }
+    }
+  }
+
+  // If a provider was registered before this provisional definition, retain
+  // it before replacing the symbol-table slot. DefinedRegular providers stay
+  // in the slot (the normal first-definition rule) and therefore cannot be
+  // lost when this group is discarded.
+  if (provisional && !isa<Undefined>(s) &&
+      (!isa<DefinedRegular>(s) || s->isWeak)) {
+    if (auto *regular = dyn_cast<DefinedRegular>(s)) {
+      const coff_symbol_generic *providerSym = nullptr;
+      uint32_t providerValue = 0;
+      if (isa<ObjFile>(regular->file)) {
+        providerSym = regular->getCOFFSymbol().getGeneric();
+        providerValue = regular->getValue();
+      }
+      deferRegularSymbol(s, regular->file, providerSym,
+                         regular->data ? regular->getChunk() : nullptr,
+                         providerValue, regular->isWeak);
+    } else {
+      deferDefinedSymbol(s, cloneDeferredSymbol(s), s->isUsedInRegularObj);
+    }
+  }
+
+  // A permanent strong regular/COMDAT provider that precedes the provisional
+  // group remains the prevailing definition. Delay its duplicate diagnostic
+  // until we know whether the new group survives. If the existing definition
+  // is itself provisional, retain the new provider below: the existing group
+  // may be discarded by a later LARGEST selection.
+  if (provisional && isa<DefinedRegular>(s) && !s->isWeak &&
+      !existingProvisional) {
+    deferredDuplicates.push_back({c, s, f, sectionOffset});
+    return s;
+  }
+
+  if (existingProvisional) {
+    deferRegularSymbol(s, f, sym, c, sectionOffset, isWeak);
+    return s;
+  }
+
+  if (!isa<DefinedRegular>(s) || s->isWeak) {
+    s = replaceSymbol<DefinedRegular>(s, f, n, /*IsCOMDAT=*/false,
+                                      /*IsExternal=*/true, sym, c, isWeak);
+  } else {
+    if (!isWeak)
+      reportDuplicate(s, f, c, sectionOffset);
+  }
   return s;
+}
+
+Symbol *SymbolTable::addDeferredComdatRegular(BitcodeFile *f, StringRef n,
+                                              SectionChunk *c, bool isWeak,
+                                              Symbol *comdatLeader) {
+  Symbol *source = insert(n, f).first;
+  deferRegularSymbol(source, f, /*coffSym=*/nullptr, c, /*value=*/0, isWeak,
+                     comdatLeader);
+  return source;
 }
 
 std::pair<DefinedRegular *, bool>
 SymbolTable::addComdat(InputFile *f, StringRef n,
                        const coff_symbol_generic *sym) {
-  auto [s, wasInserted] = insert(n, f);
-  if (wasInserted || !isa<DefinedRegular>(s)) {
-    replaceSymbol<DefinedRegular>(s, f, n, /*IsCOMDAT*/ true,
-                                  /*IsExternal*/ true, sym, nullptr);
-    return {cast<DefinedRegular>(s), true};
+  Symbol *s = insert(n, f).first;
+  if (!replayingDeferredSymbols && mayBeReplacedByLargerCOMDAT(s)) {
+    auto *provider = make<DefinedRegular>(f, n, /*IsCOMDAT=*/true,
+                                          /*IsExternal=*/true, sym, nullptr);
+    deferredComdatLeaderSources[provider] = s;
+    deferDefinedSymbol(s, provider, !isa<BitcodeFile>(f));
+    return {provider, true};
   }
+  if (!isa<DefinedRegular>(s))
+    return {replaceSymbol<DefinedRegular>(s, f, n, /*IsCOMDAT=*/true,
+                                          /*IsExternal=*/true, sym, nullptr),
+            true};
   auto *existingSymbol = cast<DefinedRegular>(s);
   if (!existingSymbol->isCOMDAT)
     reportDuplicate(s, f);
@@ -939,11 +1737,16 @@ SymbolTable::addComdat(InputFile *f, StringRef n,
 Symbol *SymbolTable::addCommon(InputFile *f, StringRef n, uint64_t size,
                                const coff_symbol_generic *sym, CommonChunk *c) {
   auto [s, wasInserted] = insert(n, f);
-  if (wasInserted || !isa<DefinedCOFF>(s))
+  if (!replayingDeferredSymbols && mayBeReplacedByLargerCOMDAT(s)) {
+    deferDefinedSymbol(s, make<DefinedCommon>(f, n, size, sym, c), true);
+    return s;
+  }
+  if (wasInserted || !isa<DefinedCOFF>(s)) {
     replaceSymbol<DefinedCommon>(s, f, n, size, sym, c);
-  else if (auto *dc = dyn_cast<DefinedCommon>(s))
+  } else if (auto *dc = dyn_cast<DefinedCommon>(s)) {
     if (size > dc->getSize())
       replaceSymbol<DefinedCommon>(s, f, n, size, sym, c);
+  }
   return s;
 }
 
@@ -951,6 +1754,11 @@ DefinedImportData *SymbolTable::addImportData(StringRef n, ImportFile *f,
                                               Chunk *&location) {
   auto [s, wasInserted] = insert(n, nullptr);
   s->isUsedInRegularObj = true;
+  if (!replayingDeferredSymbols && mayBeReplacedByLargerCOMDAT(s)) {
+    auto *provider = make<DefinedImportData>(n, f, location);
+    deferDefinedSymbol(s, provider, true);
+    return provider;
+  }
   if (wasInserted || isa<Undefined>(s) || s->isLazy()) {
     replaceSymbol<DefinedImportData>(s, n, f, location);
     return cast<DefinedImportData>(s);
@@ -964,6 +1772,12 @@ Defined *SymbolTable::addImportThunk(StringRef name, DefinedImportData *id,
                                      ImportThunkChunk *chunk) {
   auto [s, wasInserted] = insert(name, nullptr);
   s->isUsedInRegularObj = true;
+  if (!replayingDeferredSymbols && mayBeReplacedByLargerCOMDAT(s)) {
+    auto *provider = make<DefinedImportThunk>(ctx, name, id, chunk);
+    deferredImportThunks[provider] = {id->file, id->getName()};
+    deferDefinedSymbol(s, provider, true);
+    return provider;
+  }
   if (wasInserted || isa<Undefined>(s) || s->isLazy()) {
     replaceSymbol<DefinedImportThunk>(s, ctx, name, id, chunk);
     return cast<Defined>(s);
@@ -1413,6 +2227,8 @@ void SymbolTable::resolveAlternateNames() {
     StringRef to = pair.second;
     Symbol *sym = find(from);
     if (!sym)
+      continue;
+    if (!sym->hasUndefinedReference)
       continue;
     if (auto *u = dyn_cast<Undefined>(sym)) {
       if (u->weakAlias) {

--- a/lld/COFF/SymbolTable.h
+++ b/lld/COFF/SymbolTable.h
@@ -15,6 +15,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace llvm {
@@ -75,7 +76,7 @@ public:
 
   // Load lazy objects that are needed for MinGW automatic import and for
   // doing stdcall fixups.
-  void loadMinGWSymbols();
+  void loadMinGWSymbols(bool loadStdcallFixups, bool loadAutoImports);
   bool handleMinGWAutomaticImport(Symbol *sym, StringRef name);
 
   // Returns a symbol for a given name. Returns a nullptr if not found.
@@ -120,7 +121,22 @@ public:
   Symbol *addSynthetic(StringRef n, Chunk *c);
   Symbol *addAbsolute(StringRef n, uint64_t va);
 
-  Symbol *addUndefined(StringRef name, InputFile *f, bool overrideLazy);
+  Symbol *addUndefined(StringRef name, InputFile *f, bool overrideLazy,
+                       bool markReference = true);
+  // Registers a definition from a discarded section without creating a
+  // reference or forcing a lazy provider.
+  Symbol *addDiscardedDefinition(StringRef name);
+  Symbol *canonicalizeDeferredCOMDATSymbol(Symbol *symbol) const;
+  bool hasDeferredCOMDATWork() const;
+  void addWeakAlias(InputFile *f, Symbol *source, Symbol *target,
+                    bool isAntiDep);
+  void addReference(Symbol *symbol);
+  void deferSectionReferences(SectionChunk *chunk);
+  void addUnrelocatedReference(Symbol *symbol);
+  void resolveDeferredReferences();
+  void finalizeDeferredSymbols();
+  void restoreDeferredSymbolState(Undefined *source);
+  void resolveDeferredSymbols();
   void addLazyArchive(ArchiveFile *f, const Archive::Symbol &sym);
   void addLazyObject(InputFile *f, StringRef n);
   void addLazyDLLSymbol(DLLFile *f, DLLFile::Symbol *sym, StringRef n);
@@ -129,6 +145,8 @@ public:
                      const llvm::object::coff_symbol_generic *s = nullptr,
                      SectionChunk *c = nullptr, uint32_t sectionOffset = 0,
                      bool isWeak = false);
+  Symbol *addDeferredComdatRegular(BitcodeFile *f, StringRef n, SectionChunk *c,
+                                   bool isWeak, Symbol *comdatLeader);
   std::pair<DefinedRegular *, bool>
   addComdat(InputFile *f, StringRef n,
             const llvm::object::coff_symbol_generic *s = nullptr);
@@ -206,6 +224,73 @@ public:
   std::string printSymbol(Symbol *sym) const;
 
 private:
+  struct DeferredWeakAlias {
+    InputFile *file;
+    Symbol *target;
+    bool isAntiDep;
+  };
+  struct DeferredWeakAliases {
+    Symbol *initialTarget = nullptr;
+    bool initialIsAntiDep = false;
+    llvm::SmallVector<DeferredWeakAlias, 2> suppressed;
+  };
+  struct DeferredDuplicate {
+    SectionChunk *chunk;
+    Symbol *existing;
+    InputFile *newFile;
+    uint32_t sectionOffset;
+  };
+  struct DeferredImportThunk {
+    ImportFile *file;
+    StringRef importName;
+  };
+
+  using DeferredProviderId = uint32_t;
+  static constexpr DeferredProviderId noDeferredProvider = ~uint32_t{0};
+
+  // Deferred regular definitions are represented directly by their replay
+  // inputs. Other provider kinds keep their existing stable Symbol object as
+  // payload. COMDAT leaders intentionally remain materialized symbols because
+  // SectionChunk::sym and selection state use their identity while parsing.
+  struct DeferredProvider {
+    Symbol *symbol = nullptr;
+    InputFile *regularFile = nullptr;
+    const llvm::object::coff_symbol_generic *regularSym = nullptr;
+    SectionChunk *regularChunk = nullptr;
+    Symbol *parent = nullptr;
+    uint32_t regularValue = 0;
+    DeferredProviderId next = noDeferredProvider;
+    bool isRegular = false;
+    bool regularIsWeak = false;
+  };
+
+  struct DeferredSourceState {
+    DeferredProviderId first = noDeferredProvider;
+    DeferredProviderId last = noDeferredProvider;
+  };
+
+  void deferDefinedSymbol(Symbol *source, Symbol *provider,
+                          bool isUsedInRegularObj, Symbol *parent = nullptr);
+  void deferRegularSymbol(Symbol *source, InputFile *file,
+                          const llvm::object::coff_symbol_generic *coffSym,
+                          SectionChunk *chunk, uint32_t value, bool isWeak,
+                          Symbol *parent = nullptr);
+  void appendDeferredProvider(Symbol *source, DeferredProvider provider);
+  Symbol *cloneDeferredSymbol(Symbol *symbol);
+  void replayDeferredSymbol(Symbol *source, DeferredProviderId providerId);
+  void replayDeferredSources(ArrayRef<Symbol *> sources, bool importThunks,
+                             bool final);
+  Symbol *
+  addRegularWithDeferredCOMDAT(InputFile *file, StringRef name,
+                               const llvm::object::coff_symbol_generic *coffSym,
+                               SectionChunk *chunk, uint32_t sectionOffset,
+                               bool isWeak, Symbol *existing, bool provisional,
+                               bool existingProvisional);
+  void updateDeferredCommonLiveness(DeferredProviderId firstProvider,
+                                    Symbol *source);
+  void updateDeferredImportLiveness();
+  void markReferenced(Symbol *symbol, bool forceLazyProvider = true);
+
   /// Given a name without "__imp_" prefix, returns a defined symbol
   /// with the "__imp_" prefix, if it exists.
   Defined *impSymbol(StringRef name);
@@ -218,6 +303,20 @@ private:
   std::vector<Symbol *> getSymsWithPrefix(StringRef prefix);
 
   llvm::DenseMap<llvm::CachedHashStringRef, Symbol *> symMap;
+  llvm::DenseMap<Symbol *, DeferredWeakAliases> deferredWeakAliases;
+  llvm::DenseMap<Symbol *, DeferredSourceState> deferredSymbols;
+  llvm::SmallVector<DeferredProvider, 0> deferredProviders;
+  llvm::SmallVector<Symbol *, 0> deferredSymbolSources;
+  llvm::SmallVector<Symbol *, 0> deferredSymbolsToResolve;
+  llvm::SmallPtrSet<Symbol *, 8> deferredSymbolsQueued;
+  llvm::SmallVector<SectionChunk *, 0> deferredReferenceChunks;
+  llvm::SmallVector<DeferredDuplicate, 0> deferredDuplicates;
+  llvm::DenseMap<Symbol *, DeferredImportThunk> deferredImportThunks;
+  llvm::DenseMap<Symbol *, Symbol *> deferredComdatLeaderSources;
+  llvm::DenseMap<Symbol *, bool> deferredComdatSelections;
+  llvm::DenseMap<Symbol *, Symbol *> selectedDeferredComdats;
+  llvm::SmallPtrSet<ImportFile *, 8> deferredImportFiles;
+  bool replayingDeferredSymbols = false;
   std::unique_ptr<BitcodeCompiler> lto;
   std::vector<std::pair<Symbol *, Symbol *>> entryThunks;
   llvm::DenseMap<Symbol *, Symbol *> exitThunks;

--- a/lld/COFF/Symbols.cpp
+++ b/lld/COFF/Symbols.cpp
@@ -81,8 +81,10 @@ InputFile *Symbol::getFile() {
 }
 
 bool Symbol::isLive() const {
-  if (auto *r = dyn_cast<DefinedRegular>(this))
-    return r->getChunk()->live;
+  if (auto *r = dyn_cast<DefinedRegular>(this)) {
+    SectionChunk *c = r->getChunk();
+    return c->live && !c->isDiscardedByCOMDAT();
+  }
   if (auto *imp = dyn_cast<DefinedImportData>(this))
     return imp->file->live;
   if (auto *imp = dyn_cast<DefinedImportThunk>(this))

--- a/lld/COFF/Symbols.h
+++ b/lld/COFF/Symbols.h
@@ -107,9 +107,10 @@ protected:
   explicit Symbol(Kind k, StringRef n = "")
       : symbolKind(k), isExternal(true), isCOMDAT(false),
         writtenToSymtab(false), isUsedInRegularObj(false),
-        pendingArchiveLoad(false), isGCRoot(false), isRuntimePseudoReloc(false),
-        deferUndefined(false), canInline(true), isWeak(false), isAntiDep(false),
-        nameSize(n.size()), nameData(n.empty() ? nullptr : n.data()) {
+        hasUndefinedReference(false), pendingArchiveLoad(false),
+        isGCRoot(false), isRuntimePseudoReloc(false), deferUndefined(false),
+        canInline(true), isWeak(false), isAntiDep(false), nameSize(n.size()),
+        nameData(n.empty() ? nullptr : n.data()) {
     assert((!n.empty() || k <= LastDefinedCOFFKind) &&
            "If the name is empty, the Symbol must be a DefinedCOFF.");
   }
@@ -127,6 +128,11 @@ public:
 
   // True if this symbol was referenced by a regular (non-bitcode) object.
   unsigned isUsedInRegularObj : 1;
+
+  // True if an actual undefined reference to this symbol was observed.
+  // Unlike isUsedInRegularObj, this is not set merely because a regular object
+  // defines the symbol.
+  unsigned hasUndefinedReference : 1;
 
   // True if we've seen both a lazy and an undefined symbol with this symbol
   // name, which means that we have enqueued an archive member load and should
@@ -518,19 +524,22 @@ union SymbolUnion {
 };
 
 template <typename T, typename... ArgT>
-void replaceSymbol(Symbol *s, ArgT &&... arg) {
+T *replaceSymbol(Symbol *s, ArgT &&...arg) {
   static_assert(std::is_trivially_destructible<T>(),
                 "Symbol types must be trivially destructible");
-  static_assert(sizeof(T) <= sizeof(SymbolUnion), "Symbol too small");
+  static_assert(sizeof(T) <= sizeof(SymbolUnion), "SymbolUnion too small");
   static_assert(alignof(T) <= alignof(SymbolUnion),
                 "SymbolUnion not aligned enough");
   assert(static_cast<Symbol *>(static_cast<T *>(nullptr)) == nullptr &&
          "Not a Symbol");
   bool canInline = s->canInline;
   bool isUsedInRegularObj = s->isUsedInRegularObj;
-  new (s) T(std::forward<ArgT>(arg)...);
-  s->canInline = canInline;
-  s->isUsedInRegularObj = isUsedInRegularObj;
+  bool hasUndefinedReference = s->hasUndefinedReference;
+  T *replacement = new (s) T(std::forward<ArgT>(arg)...);
+  replacement->canInline = canInline;
+  replacement->isUsedInRegularObj = isUsedInRegularObj;
+  replacement->hasUndefinedReference = hasUndefinedReference;
+  return replacement;
 }
 } // namespace coff
 

--- a/lld/test/COFF/comdat-directive-multiple-groups.test
+++ b/lld/test/COFF/comdat-directive-multiple-groups.test
@@ -1,0 +1,80 @@
+# REQUIRES: x86
+
+# RUN: yaml2obj %s -o %t.obj
+# RUN: lld-link /dll /noentry /nodefaultlib %t.obj /out:%t.dll
+# RUN: llvm-readobj --coff-exports %t.dll | FileCheck %s
+
+# CHECK-DAG: Name: foo
+# CHECK-DAG: Name: bar
+
+--- !COFF
+header:
+  Machine: IMAGE_FILE_MACHINE_AMD64
+sections:
+  - Name: .text
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE,
+                       IMAGE_SCN_MEM_READ ]
+    Alignment: 1
+    SectionData: C3C3
+  - Name: .drectve
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_LNK_COMDAT,
+                       IMAGE_SCN_MEM_READ ]
+    Alignment: 1
+    SectionData: 202F6578706F72743A666F6F
+  - Name: .drectve
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_LNK_COMDAT,
+                       IMAGE_SCN_MEM_READ ]
+    Alignment: 1
+    SectionData: 202F6578706F72743A626172
+symbols:
+  - Name: .drectve
+    Value: 0
+    SectionNumber: 2
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length: 12
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum: 0
+      Number: 2
+      Selection: IMAGE_COMDAT_SELECT_ANY
+  - Name: directive_group_a
+    Value: 0
+    SectionNumber: 2
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+  - Name: .drectve
+    Value: 0
+    SectionNumber: 3
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length: 12
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum: 0
+      Number: 3
+      Selection: IMAGE_COMDAT_SELECT_ANY
+  - Name: directive_group_b
+    Value: 0
+    SectionNumber: 3
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+  - Name: foo
+    Value: 0
+    SectionNumber: 1
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+  - Name: bar
+    Value: 1
+    SectionNumber: 1
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+...

--- a/lld/test/COFF/comdat-directive-preserve-other-group.test
+++ b/lld/test/COFF/comdat-directive-preserve-other-group.test
@@ -1,0 +1,118 @@
+# REQUIRES: x86
+
+# A losing duplicate .drectve must not clear directives already contributed by
+# another prevailing group in the same object.
+
+# RUN: split-file %s %t.dir
+# RUN: yaml2obj %t.dir/a.yaml -o %t.a.obj
+# RUN: yaml2obj %t.dir/b.yaml -o %t.b.obj
+# RUN: lld-link /dll /noentry /nodefaultlib %t.a.obj %t.b.obj /out:%t.dll
+# RUN: llvm-readobj --coff-exports %t.dll | FileCheck %s
+
+# CHECK-DAG: Name: first
+# CHECK-DAG: Name: second
+
+#--- a.yaml
+--- !COFF
+header:
+  Machine: IMAGE_FILE_MACHINE_AMD64
+sections:
+  - Name: .text
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE,
+                       IMAGE_SCN_MEM_READ ]
+    SectionData: C3
+  - Name: .drectve
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_LNK_COMDAT,
+                       IMAGE_SCN_MEM_READ ]
+    SectionData: 202F6578706F72743A6669727374
+symbols:
+  - Name: .drectve
+    Value: 0
+    SectionNumber: 2
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length: 14
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum: 1
+      Number: 2
+      Selection: IMAGE_COMDAT_SELECT_ANY
+  - Name: group_x
+    Value: 0
+    SectionNumber: 2
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+  - Name: first
+    Value: 0
+    SectionNumber: 1
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+...
+
+#--- b.yaml
+--- !COFF
+header:
+  Machine: IMAGE_FILE_MACHINE_AMD64
+sections:
+  - Name: .text
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE,
+                       IMAGE_SCN_MEM_READ ]
+    SectionData: C3C3
+  - Name: .drectve
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_LNK_COMDAT,
+                       IMAGE_SCN_MEM_READ ]
+    SectionData: 202F6578706F72743A7365636F6E64
+  - Name: .drectve
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_LNK_COMDAT,
+                       IMAGE_SCN_MEM_READ ]
+    SectionData: 202F6578706F72743A6669727374
+symbols:
+  - Name: .drectve
+    Value: 0
+    SectionNumber: 2
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length: 15
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum: 2
+      Number: 2
+      Selection: IMAGE_COMDAT_SELECT_ANY
+  - Name: group_y
+    Value: 0
+    SectionNumber: 2
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+  - Name: .drectve
+    Value: 0
+    SectionNumber: 3
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length: 14
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum: 1
+      Number: 3
+      Selection: IMAGE_COMDAT_SELECT_ANY
+  - Name: group_x
+    Value: 0
+    SectionNumber: 3
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+  - Name: second
+    Value: 1
+    SectionNumber: 1
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+...

--- a/lld/test/COFF/comdat-directive-same-object.test
+++ b/lld/test/COFF/comdat-directive-same-object.test
@@ -1,0 +1,76 @@
+# REQUIRES: x86
+
+# Two identical ANY .drectve candidates in one object share ObjFile::directives.
+# Discarding the duplicate must not clear the prevailing candidate's options.
+
+# RUN: yaml2obj %s -o %t.obj
+# RUN: lld-link /dll /noentry /nodefaultlib %t.obj /out:%t.dll
+# RUN: llvm-readobj --coff-exports %t.dll | FileCheck %s
+
+# CHECK: Name: exported
+
+--- !COFF
+header:
+  Machine: IMAGE_FILE_MACHINE_AMD64
+sections:
+  - Name: .text
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE,
+                       IMAGE_SCN_MEM_READ ]
+    Alignment: 1
+    SectionData: C3
+  - Name: .drectve
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_LNK_COMDAT,
+                       IMAGE_SCN_MEM_READ ]
+    Alignment: 1
+    SectionData: 202F6578706F72743A6578706F72746564
+  - Name: .drectve
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_LNK_COMDAT,
+                       IMAGE_SCN_MEM_READ ]
+    Alignment: 1
+    SectionData: 202F6578706F72743A6578706F72746564
+symbols:
+  - Name: .drectve
+    Value: 0
+    SectionNumber: 2
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length: 17
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum: 2322545713
+      Number: 2
+      Selection: IMAGE_COMDAT_SELECT_ANY
+  - Name: directive_group
+    Value: 0
+    SectionNumber: 2
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+  - Name: .drectve
+    Value: 0
+    SectionNumber: 3
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length: 17
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum: 2322545713
+      Number: 3
+      Selection: IMAGE_COMDAT_SELECT_ANY
+  - Name: directive_group
+    Value: 0
+    SectionNumber: 3
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+  - Name: exported
+    Value: 0
+    SectionNumber: 1
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+...

--- a/lld/test/COFF/comdat-directive-section-order.test
+++ b/lld/test/COFF/comdat-directive-section-order.test
@@ -1,0 +1,62 @@
+# REQUIRES: x86
+
+# Ordinary .drectve sections are read before COMDAT sections are selected, but
+# their contents must still be presented to the driver in object section order.
+
+# RUN: yaml2obj %s -o %t.obj
+# RUN: lld-link /dll /noentry /nodefaultlib /verbose %t.obj /out:%t.dll 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=ORDER
+# RUN: llvm-readobj --coff-exports %t.dll | FileCheck %s
+
+# ORDER: Directives: {{.*}}: /export:first /export:second
+# CHECK-DAG: Name: first
+# CHECK-DAG: Name: second
+
+--- !COFF
+header:
+  Machine: IMAGE_FILE_MACHINE_AMD64
+sections:
+  - Name: .drectve
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_LNK_COMDAT,
+                       IMAGE_SCN_MEM_READ ]
+    SectionData: 202F6578706F72743A6669727374
+  - Name: .drectve
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_MEM_READ ]
+    SectionData: 202F6578706F72743A7365636F6E64
+  - Name: .text
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE,
+                       IMAGE_SCN_MEM_READ ]
+    SectionData: C3C3
+symbols:
+  - Name: .drectve
+    Value: 0
+    SectionNumber: 1
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length: 14
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum: 1
+      Number: 1
+      Selection: IMAGE_COMDAT_SELECT_ANY
+  - Name: directive_group
+    Value: 0
+    SectionNumber: 1
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+  - Name: first
+    Value: 0
+    SectionNumber: 3
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+  - Name: second
+    Value: 1
+    SectionNumber: 3
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+...

--- a/lld/test/COFF/comdat-selection-any-largest-secondary.s
+++ b/lld/test/COFF/comdat-selection-any-largest-secondary.s
@@ -1,0 +1,111 @@
+# REQUIRES: x86
+#
+# ANY and LARGEST are merged as LARGEST for MSVC compatibility. Secondary
+# definitions must follow the same group decision and suppressed lazy providers
+# must be replayed when the group that hid them loses.
+#
+# RUN: split-file %s %t.dir
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/any-small.s -o %t.any-small.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/any-large.s -o %t.any-large.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/largest-small.s -o %t.largest-small.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/largest-large.s -o %t.largest-large.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/same-size-small.s -o %t.same-size-small.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/provider.s -o %t.provider.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/root.s -o %t.root.obj
+# RUN: llvm-lib -machine:amd64 -out:%t.provider.lib %t.provider.obj
+#
+# ANY first, larger LARGEST second.
+# RUN: lld-link /entry:entry /subsystem:console /nodefaultlib /opt:noref \
+# RUN:   %t.any-small.obj %t.provider.lib %t.largest-large.obj %t.root.obj \
+# RUN:   /map:%t.any-largest.map /out:%t.any-largest.exe
+# RUN: FileCheck %s --check-prefix=PROVIDER < %t.any-largest.map
+# RUN: llvm-objdump -s %t.any-largest.exe | FileCheck %s --check-prefix=LARGE
+#
+# LARGEST first, larger ANY second. The compatibility merge must still use
+# size, not input order.
+# RUN: lld-link /entry:entry /subsystem:console /nodefaultlib /opt:noref \
+# RUN:   %t.largest-small.obj %t.provider.lib %t.any-large.obj %t.root.obj \
+# RUN:   /map:%t.largest-any.map /out:%t.largest-any.exe
+# RUN: FileCheck %s --check-prefix=PROVIDER < %t.largest-any.map
+# RUN: llvm-objdump -s %t.largest-any.exe | FileCheck %s --check-prefix=LARGE
+#
+# The ANY/LARGEST promotion must persist for later candidates. Without that,
+# the third ANY candidate is incorrectly compared as ANY/ANY and loses.
+# RUN: lld-link /entry:entry /subsystem:console /nodefaultlib /opt:noref \
+# RUN:   %t.any-small.obj %t.largest-small.obj %t.any-large.obj \
+# RUN:   %t.provider.lib %t.root.obj \
+# RUN:   /out:%t.any-largest-any.exe
+# RUN: llvm-objdump -s %t.any-largest-any.exe | \
+# RUN:   FileCheck %s --check-prefix=LARGE
+#
+# MinGW's ANY/SAME_SIZE compatibility promotion is likewise group state. The
+# later, differently-sized ANY candidate must diagnose a size mismatch.
+# RUN: not lld-link /lldmingw /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.any-small.obj %t.same-size-small.obj %t.any-large.obj \
+# RUN:   %t.provider.lib %t.root.obj \
+# RUN:   /out:%t.any-same-any.exe 2>&1 | FileCheck %s --check-prefix=SAME-SIZE
+#
+# PROVIDER: only_loser{{.*}}provider.obj
+# LARGE: 44444444
+# LARGE-NOT: 11111111
+# SAME-SIZE: duplicate symbol: leader
+#
+#--- any-small.s
+        .section .text$mix, "xr", discard, leader
+        .globl leader
+leader:
+        .byte 0x11
+        .globl only_loser
+only_loser:
+        .long 0x11111111
+#
+#--- any-large.s
+        .section .text$mix, "xr", discard, leader
+        .globl leader
+leader:
+        .space 32, 0x44
+#
+#--- largest-small.s
+        .section .text$mix, "xr", largest, leader
+        .globl leader
+leader:
+        .byte 0x11
+        .globl only_loser
+only_loser:
+        .long 0x11111111
+#
+#--- largest-large.s
+        .section .text$mix, "xr", largest, leader
+        .globl leader
+leader:
+        .space 32, 0x44
+#
+#--- same-size-small.s
+        .section .text$mix, "xr", same_size, leader
+        .globl leader
+leader:
+        .byte 0x11
+        .globl only_loser
+only_loser:
+        .long 0x11111111
+#
+#--- provider.s
+        .section .rdata$provider, "dr"
+        .globl only_loser
+only_loser:
+        .long 0x77777777
+#
+#--- root.s
+        .text
+        .globl entry
+entry:
+        leaq leader(%rip), %rax
+        movl only_loser(%rip), %ecx
+        retq

--- a/lld/test/COFF/comdat-selection-associative-largest.s
+++ b/lld/test/COFF/comdat-selection-associative-largest.s
@@ -1,45 +1,51 @@
 # REQUIRES: x86
 
-# Tests handling of several comdats with "largest" selection type that each
-# has an associative comdat.
+# Test IMAGE_COMDAT_SELECT_LARGEST with multiple associative sections.
+# Only the final largest leader and all of its associative sections must be
+# emitted, independent of input order and section-GC configuration.
 
-# Create obj files.
-# RUN: sed -e s/TYPE/.byte/  -e s/SIZE/1/ %s | llvm-mc -triple x86_64-pc-win32 -filetype=obj -o %t.1.obj
-# RUN: sed -e s/TYPE/.short/ -e s/SIZE/2/ %s | llvm-mc -triple x86_64-pc-win32 -filetype=obj -o %t.2.obj
-# RUN: sed -e s/TYPE/.long/  -e s/SIZE/4/ %s | llvm-mc -triple x86_64-pc-win32 -filetype=obj -o %t.4.obj
+# RUN: sed -e s/TYPE/.byte/ -e s/SIZE/1/ %s | \
+# RUN:   llvm-mc -triple x86_64-pc-win32 -filetype=obj -o %t.1.obj
+# RUN: sed -e s/TYPE/.short/ -e s/SIZE/2/ %s | \
+# RUN:   llvm-mc -triple x86_64-pc-win32 -filetype=obj -o %t.2.obj
+# RUN: sed -e s/TYPE/.long/ -e s/SIZE/4/ %s | \
+# RUN:   llvm-mc -triple x86_64-pc-win32 -filetype=obj -o %t.4.obj
 
-        .section .text$ac, "", associative, symbol
-assocsym:
-        .long SIZE
+        .section .text$aa, "", associative, symbol
+        .byte SIZE, 0xaa, 0xaa, 0xaa
+
+        .section .text$ab, "", associative, symbol
+        .byte SIZE, 0xbb, 0xbb, 0xbb
 
         .section .text$nm, "", largest, symbol
         .globl symbol
 symbol:
         TYPE SIZE
 
-# Pass the obj files in different orders and check that only the associative
-# comdat of the largest obj file makes it into the output, independent of
-# the order of the obj files on the command line.
+# Exercise successive replacements, a losing candidate before a replacement,
+# and the largest candidate arriving first. The default is /opt:ref, so use the
+# two GC modes explicitly instead of testing the default separately.
 
-# FIXME: Make these pass when /opt:noref is passed.
+# RUN: lld-link /opt:ref /include:symbol /dll /noentry /nodefaultlib \
+# RUN:   %t.1.obj %t.2.obj %t.4.obj /out:%t.ref.124.exe
+# RUN: llvm-objdump -s %t.ref.124.exe | FileCheck --check-prefix=LARGEST4 %s
+# RUN: lld-link /opt:noref /include:symbol /dll /noentry /nodefaultlib \
+# RUN:   %t.1.obj %t.2.obj %t.4.obj /out:%t.noref.124.exe
+# RUN: llvm-objdump -s %t.noref.124.exe | FileCheck --check-prefix=LARGEST4 %s
 
-# RUN: lld-link /include:symbol /dll /noentry /nodefaultlib %t.1.obj %t.2.obj %t.4.obj /out:%t.exe
-# RUN: llvm-objdump -s %t.exe | FileCheck --check-prefix=ALL124 %s
-# ALL124: Contents of section .text:
-# ALL124:   180001000 04000000 04000000 ....
+# RUN: lld-link /opt:ref /include:symbol /dll /noentry /nodefaultlib \
+# RUN:   %t.2.obj %t.1.obj %t.4.obj /out:%t.ref.214.exe
+# RUN: llvm-objdump -s %t.ref.214.exe | FileCheck --check-prefix=LARGEST4 %s
+# RUN: lld-link /opt:noref /include:symbol /dll /noentry /nodefaultlib \
+# RUN:   %t.2.obj %t.1.obj %t.4.obj /out:%t.noref.214.exe
+# RUN: llvm-objdump -s %t.noref.214.exe | FileCheck --check-prefix=LARGEST4 %s
 
-# RUN: lld-link /include:symbol /dll /noentry /nodefaultlib %t.4.obj %t.2.obj %t.1.obj /out:%t.exe
-# RUN: llvm-objdump -s %t.exe | FileCheck --check-prefix=ALL421 %s
-# ALL421: Contents of section .text:
-# ALL421:   180001000 04000000 04000000 ....
+# RUN: lld-link /opt:ref /include:symbol /dll /noentry /nodefaultlib \
+# RUN:   %t.4.obj %t.2.obj %t.1.obj /out:%t.ref.421.exe
+# RUN: llvm-objdump -s %t.ref.421.exe | FileCheck --check-prefix=LARGEST4 %s
+# RUN: lld-link /opt:noref /include:symbol /dll /noentry /nodefaultlib \
+# RUN:   %t.4.obj %t.2.obj %t.1.obj /out:%t.noref.421.exe
+# RUN: llvm-objdump -s %t.noref.421.exe | FileCheck --check-prefix=LARGEST4 %s
 
-# RUN: lld-link /include:symbol /dll /noentry /nodefaultlib %t.2.obj %t.4.obj %t.1.obj /out:%t.exe
-# RUN: llvm-objdump -s %t.exe | FileCheck --check-prefix=ALL241 %s
-# ALL241: Contents of section .text:
-# ALL241:   180001000 04000000 04000000 ....
-
-# RUN: lld-link /include:symbol /dll /noentry /nodefaultlib %t.2.obj %t.1.obj /out:%t.exe
-# RUN: llvm-objdump -s %t.exe | FileCheck --check-prefix=JUST21 %s
-# JUST21: Contents of section .text:
-# JUST21:   180001000 02000000 0200 ....
-
+# LARGEST4: Contents of section .text:
+# LARGEST4-NEXT:  180001000 04aaaaaa 04bbbbbb 04000000

--- a/lld/test/COFF/comdat-selection-largest-alternatename.s
+++ b/lld/test/COFF/comdat-selection-largest-alternatename.s
@@ -1,0 +1,99 @@
+# REQUIRES: x86
+
+# A secondary definition that disappears with a losing LARGEST group is an
+# Undefined type-state placeholder, not a reference. It must not activate an
+# /alternatename fallback or extract its archive member. A genuine relocation
+# to the same name must still activate the fallback. Both properties are input
+# order independent and apply to command-line and .drectve aliases.
+
+# RUN: split-file %s %t.dir
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/small.s -o %t.small.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/large.s -o %t.large.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/root.s -o %t.root.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/root-ref.s -o %t.root-ref.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/provider.s -o %t.provider.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/directive.s -o %t.directive.obj
+# RUN: llvm-ar --format=coff rcsD %t.provider.lib %t.provider.obj
+
+# RUN: lld-link /entry:entry /subsystem:console /nodefaultlib /opt:ref \
+# RUN:   /alternatename:foo=bar %t.small.obj %t.large.obj %t.root.obj \
+# RUN:   %t.provider.lib /out:%t.no-ref-small-first.exe
+# RUN: llvm-objdump -s %t.no-ref-small-first.exe | \
+# RUN:   FileCheck %s --check-prefix=NO-BAR
+# RUN: lld-link /entry:entry /subsystem:console /nodefaultlib /opt:ref \
+# RUN:   /alternatename:foo=bar %t.large.obj %t.small.obj %t.root.obj \
+# RUN:   %t.provider.lib /out:%t.no-ref-large-first.exe
+# RUN: llvm-objdump -s %t.no-ref-large-first.exe | \
+# RUN:   FileCheck %s --check-prefix=NO-BAR
+
+# RUN: lld-link /entry:entry /subsystem:console /nodefaultlib /opt:ref \
+# RUN:   /alternatename:foo=bar %t.small.obj %t.large.obj %t.root-ref.obj \
+# RUN:   %t.provider.lib /out:%t.ref-small-first.exe
+# RUN: llvm-objdump -s %t.ref-small-first.exe | FileCheck %s --check-prefix=BAR
+# RUN: lld-link /entry:entry /subsystem:console /nodefaultlib /opt:ref \
+# RUN:   /alternatename:foo=bar %t.large.obj %t.small.obj %t.root-ref.obj \
+# RUN:   %t.provider.lib /out:%t.ref-large-first.exe
+# RUN: llvm-objdump -s %t.ref-large-first.exe | FileCheck %s --check-prefix=BAR
+
+# RUN: lld-link /entry:entry /subsystem:console /nodefaultlib /opt:ref \
+# RUN:   %t.directive.obj %t.small.obj %t.large.obj %t.root.obj \
+# RUN:   %t.provider.lib /out:%t.directive-no-ref.exe
+# RUN: llvm-objdump -s %t.directive-no-ref.exe | \
+# RUN:   FileCheck %s --check-prefix=NO-BAR
+# RUN: lld-link /entry:entry /subsystem:console /nodefaultlib /opt:ref \
+# RUN:   %t.directive.obj %t.small.obj %t.large.obj %t.root-ref.obj \
+# RUN:   %t.provider.lib /out:%t.directive-ref.exe
+# RUN: llvm-objdump -s %t.directive-ref.exe | FileCheck %s --check-prefix=BAR
+
+# NO-BAR: Contents of section .text:
+# NO-BAR-NOT: 42424242
+# BAR: Contents of section .text:
+# BAR: 42424242
+
+#--- small.s
+        .section .text$leader, "xr", largest, leader
+        .globl leader
+leader:
+        retq
+        .globl foo
+foo:
+        retq
+
+#--- large.s
+        .section .text$leader, "xr", largest, leader
+        .globl leader
+leader:
+        .space 16, 0x90
+        retq
+
+#--- root.s
+        .text
+        .globl entry
+entry:
+        callq leader
+        retq
+
+#--- root-ref.s
+        .text
+        .globl entry
+entry:
+        callq leader
+        callq foo
+        retq
+
+#--- provider.s
+        .text
+        .globl bar
+bar:
+        .long 0x42424242
+        retq
+
+#--- directive.s
+        .section .drectve, "yn"
+        .ascii " /alternatename:foo=bar"

--- a/lld/test/COFF/comdat-selection-largest-analysis-metadata.s
+++ b/lld/test/COFF/comdat-selection-largest-analysis-metadata.s
@@ -1,0 +1,86 @@
+# REQUIRES: x86
+
+# Object-level addrsig and call-graph entries that name only a discarded
+# secondary definition must have no observable ICF, GC, or layout effect.
+# Exercise discard equivalence in both input orders.
+
+# RUN: split-file %s %t.dir
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/small.s -o %t.small.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/large.s -o %t.large.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/root.s -o %t.root.obj
+# RUN: lld-link /entry:entry /subsystem:console /nodefaultlib /opt:ref \
+# RUN:   /opt:icf \
+# RUN:   /debug:symtab %t.large.obj %t.root.obj /out:%t.winner.exe
+# RUN: lld-link /entry:entry /subsystem:console /nodefaultlib /opt:ref \
+# RUN:   /opt:icf \
+# RUN:   /debug:symtab %t.small.obj %t.large.obj %t.root.obj \
+# RUN:   /out:%t.small-first.exe
+# RUN: lld-link /entry:entry /subsystem:console /nodefaultlib /opt:ref \
+# RUN:   /opt:icf \
+# RUN:   /debug:symtab %t.large.obj %t.small.obj %t.root.obj \
+# RUN:   /out:%t.large-first.exe
+# RUN: llvm-nm --numeric-sort %t.winner.exe > %t.winner.nm
+# RUN: llvm-nm --numeric-sort %t.small-first.exe > %t.small-first.nm
+# RUN: llvm-nm --numeric-sort %t.large-first.exe > %t.large-first.nm
+# RUN: cmp %t.winner.nm %t.small-first.nm
+# RUN: cmp %t.winner.nm %t.large-first.nm
+# RUN: FileCheck %s < %t.winner.nm
+
+# CHECK: [[FOLD:[0-9a-f]+]] T fold_a
+# CHECK-NEXT: [[FOLD]] T fold_b
+# CHECK: T ordered_b
+# CHECK-NOT: loser_only
+
+#--- small.s
+        .section .text$leader,"xr",largest,leader
+        .globl leader
+leader:
+        retq
+        .globl loser_only
+loser_only:
+        retq
+
+        .addrsig
+        .addrsig_sym loser_only
+        .cg_profile loser_only, ordered_b, 1000000
+
+#--- large.s
+        .section .text$leader,"xr",largest,leader
+        .globl leader
+leader:
+        .space 16, 0x90
+        retq
+
+#--- root.s
+        .text
+        .globl entry
+entry:
+        callq leader
+        callq fold_a
+        callq fold_b
+        callq ordered_b
+        retq
+
+        .addrsig
+
+        .section .text,"xr",one_only,fold_a
+        .globl fold_a
+fold_a:
+        nop
+        retq
+
+        .section .text,"xr",one_only,fold_b
+        .globl fold_b
+fold_b:
+        nop
+        retq
+
+        .section .text,"xr",one_only,ordered_b
+        .globl ordered_b
+ordered_b:
+        nop
+        nop
+        retq

--- a/lld/test/COFF/comdat-selection-largest-archive.s
+++ b/lld/test/COFF/comdat-selection-largest-archive.s
@@ -1,0 +1,103 @@
+# REQUIRES: x86
+
+# Test loaded archive members containing competing largest COMDATs. Unique force
+# symbols ensure that both members are extracted in the lazy-archive cases.
+# /wholearchive exercises the same selection when every member is loaded.
+
+# RUN: split-file %s %t.dir
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/small.s -o %t.small.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/large.s -o %t.large.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/reference-small.s -o %t.reference-small.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/reference-provider.s -o %t.reference-provider.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/reference-root.s -o %t.reference-root.obj
+# RUN: llvm-lib -machine:amd64 -out:%t.small-large.lib %t.small.obj %t.large.obj
+# RUN: llvm-lib -machine:amd64 -out:%t.large-small.lib %t.large.obj %t.small.obj
+# RUN: llvm-lib -machine:amd64 -out:%t.reference-provider.lib \
+# RUN:   %t.reference-provider.obj
+
+# RUN: lld-link /opt:noref /include:force_small /include:force_large \
+# RUN:   /dll /noentry /nodefaultlib %t.small-large.lib \
+# RUN:   /out:%t.lazy.small-large.exe
+# RUN: llvm-objdump -s %t.lazy.small-large.exe | FileCheck %s
+
+# RUN: lld-link /opt:noref /include:force_large /include:force_small \
+# RUN:   /dll /noentry /nodefaultlib %t.large-small.lib \
+# RUN:   /out:%t.lazy.large-small.exe
+# RUN: llvm-objdump -s %t.lazy.large-small.exe | FileCheck %s
+
+# RUN: lld-link /opt:noref /dll /noentry /nodefaultlib \
+# RUN:   /wholearchive:%t.small-large.lib /out:%t.whole.small-large.exe
+# RUN: llvm-objdump -s %t.whole.small-large.exe | FileCheck %s
+
+# RUN: lld-link /opt:noref /dll /noentry /nodefaultlib \
+# RUN:   /wholearchive:%t.large-small.lib /out:%t.whole.large-small.exe
+# RUN: llvm-objdump -s %t.whole.large-small.exe | FileCheck %s
+
+# Archive extraction is intentionally monotonic. A reference from the current
+# winner may extract a member which then replaces that winner with a larger
+# COMDAT; the already extracted member remains part of the link.
+# RUN: lld-link /opt:noref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.reference-small.obj %t.reference-provider.lib \
+# RUN:   %t.reference-root.obj /out:%t.reference-extraction.exe
+# RUN: llvm-objdump -s %t.reference-extraction.exe | \
+# RUN:   FileCheck --check-prefix=REFERENCE-EXTRACTION %s
+
+# CHECK: Contents of section .text:
+# CHECK-NEXT:  180001000 44444444
+
+# REFERENCE-EXTRACTION: Contents of section .text:
+# REFERENCE-EXTRACTION: 44444444 44444444 44444444 44444444
+# REFERENCE-EXTRACTION: Contents of section .rdata:
+# REFERENCE-EXTRACTION: aaaaaaaa
+
+#--- small.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .byte 0x11
+
+        .section .rdata$force, "dr"
+        .globl force_small
+force_small:
+        .byte 1
+
+#--- large.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .long 0x44444444
+
+        .section .rdata$force, "dr"
+        .globl force_large
+force_large:
+        .byte 4
+
+#--- reference-small.s
+        .section .text$largest, "xr", largest, reference_leader
+        .globl reference_leader
+reference_leader:
+        callq reference_provider
+        retq
+
+#--- reference-provider.s
+        .section .text$largest, "xr", largest, reference_leader
+        .globl reference_leader
+reference_leader:
+        .space 32, 0x44
+
+        .section .rdata$provider, "dr"
+        .globl reference_provider
+reference_provider:
+        .long 0xaaaaaaaa
+
+#--- reference-root.s
+        .text
+        .globl entry
+entry:
+        leaq reference_leader(%rip), %rax
+        retq

--- a/lld/test/COFF/comdat-selection-largest-arm.s
+++ b/lld/test/COFF/comdat-selection-largest-arm.s
@@ -1,0 +1,34 @@
+# REQUIRES: arm
+
+# RUN: split-file %s %t.dir
+# RUN: llvm-mc -triple thumbv7-pc-windows-msvc -filetype=obj \
+# RUN:   %t.dir/small.s -o %t.small.obj
+# RUN: llvm-mc -triple thumbv7-pc-windows-msvc -filetype=obj \
+# RUN:   %t.dir/large.s -o %t.large.obj
+# RUN: lld-link /dll /noentry /nodefaultlib /include:leader \
+# RUN:   %t.small.obj %t.large.obj /out:%t.dll
+# RUN: llvm-objdump -s %t.dll | FileCheck %s --check-prefix=LARGE \
+# RUN:   --implicit-check-not=11111111 --implicit-check-not=aaaaaaaa
+
+# LARGE: Contents of section .text:
+# LARGE: 44444444
+# LARGE: Contents of section .rdata:
+# LARGE: 55555555 bbbbbbbb
+
+#--- small.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .long 0x11111111
+        .section .rdata$assoc, "dr", associative, leader
+        .long 0xaaaaaaaa
+
+#--- large.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .long 0x44444444
+        .space 28, 0x44
+        .section .rdata$assoc, "dr", associative, leader
+        .long 0x55555555
+        .long 0xbbbbbbbb

--- a/lld/test/COFF/comdat-selection-largest-arm64.s
+++ b/lld/test/COFF/comdat-selection-largest-arm64.s
@@ -1,0 +1,96 @@
+# REQUIRES: aarch64
+
+# RUN: split-file %s %t.dir
+# RUN: llvm-mc -triple aarch64-pc-windows-msvc -filetype=obj \
+# RUN:   %t.dir/small.s -o %t.arm64-small.obj
+# RUN: llvm-mc -triple aarch64-pc-windows-msvc -filetype=obj \
+# RUN:   %t.dir/large.s -o %t.arm64-large.obj
+# RUN: lld-link /dll /noentry /nodefaultlib /include:leader \
+# RUN:   %t.arm64-small.obj %t.arm64-large.obj /out:%t.arm64.dll
+# RUN: llvm-objdump -s %t.arm64.dll | FileCheck %s --check-prefix=LARGE \
+# RUN:   --implicit-check-not=11111111 --implicit-check-not=aaaaaaaa
+# RUN: llvm-mc -triple arm64ec-pc-windows-msvc -filetype=obj \
+# RUN:   %t.dir/small.s -o %t.ec-small.obj
+# RUN: llvm-mc -triple arm64ec-pc-windows-msvc -filetype=obj \
+# RUN:   %t.dir/large.s -o %t.ec-large.obj
+# RUN: lld-link /dll /noentry /nodefaultlib /machine:arm64ec /include:leader \
+# RUN:   %t.ec-small.obj %t.ec-large.obj /out:%t.ec.dll
+# RUN: llvm-objdump -s %t.ec.dll | FileCheck %s --check-prefix=LARGE \
+# RUN:   --implicit-check-not=11111111 --implicit-check-not=aaaaaaaa
+# RUN: llvm-mc -triple arm64ec-pc-windows-msvc -filetype=obj \
+# RUN:   %t.dir/small-alias.s -o %t.ec-small-alias.obj
+# RUN: llvm-mc -triple arm64ec-pc-windows-msvc -filetype=obj \
+# RUN:   %t.dir/alias-ref.s -o %t.ec-alias-ref.obj
+# RUN: llvm-mc -triple arm64ec-pc-windows-msvc -filetype=obj \
+# RUN:   %t.dir/alias-provider.s -o %t.ec-alias-provider.obj
+# RUN: llvm-mc -triple x86_64-pc-windows-msvc -filetype=obj \
+# RUN:   %t.dir/x64-ref.s -o %t.x64-ref.obj
+# RUN: llvm-lib -machine:arm64ec -out:%t.ec-alias-provider.lib \
+# RUN:   %t.ec-alias-provider.obj
+# RUN: lld-link /dll /noentry /nodefaultlib /machine:arm64ec /include:func \
+# RUN:   %t.ec-small-alias.obj %t.ec-alias-ref.obj %t.ec-alias-provider.obj \
+# RUN:   %t.ec-large.obj /out:%t.ec-alias.dll
+# RUN: llvm-objdump -s %t.ec-alias.dll | FileCheck %s --check-prefix=ALIAS \
+# RUN:   --implicit-check-not=22222222
+# RUN: lld-link /dll /noentry /nodefaultlib /machine:arm64x /include:func \
+# RUN:   %t.ec-small-alias.obj %t.ec-alias-ref.obj %t.ec-alias-provider.obj \
+# RUN:   %t.ec-large.obj /out:%t.arm64x-alias.dll
+# RUN: llvm-objdump -s %t.arm64x-alias.dll | \
+# RUN:   FileCheck %s --check-prefix=ALIAS --implicit-check-not=22222222
+# RUN: lld-link /dll /noentry /nodefaultlib /machine:arm64ec /include:func \
+# RUN:   %t.ec-small-alias.obj %t.x64-ref.obj %t.ec-alias-provider.lib \
+# RUN:   %t.ec-large.obj /out:%t.ec-x64-alias.dll
+# RUN: llvm-objdump -s %t.ec-x64-alias.dll | FileCheck %s \
+# RUN:   --check-prefix=ALIAS --implicit-check-not=22222222
+# RUN: lld-link /dll /noentry /nodefaultlib /machine:arm64x /include:leader \
+# RUN:   %t.arm64-small.obj %t.arm64-large.obj %t.ec-small.obj %t.ec-large.obj \
+# RUN:   /out:%t.arm64x.dll
+# RUN: llvm-objdump -s %t.arm64x.dll | FileCheck %s --check-prefix=LARGE \
+# RUN:   --implicit-check-not=11111111 --implicit-check-not=aaaaaaaa
+
+# LARGE: Contents of section .text:
+# LARGE: 44444444
+# LARGE: Contents of section .rdata:
+# LARGE: 55555555 bbbbbbbb
+# ALIAS: 77777777
+
+#--- small.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .long 0x11111111
+        .section .rdata$assoc, "dr", associative, leader
+        .long 0xaaaaaaaa
+
+#--- large.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .long 0x44444444
+        .space 28, 0x44
+        .section .rdata$assoc, "dr", associative, leader
+        .long 0x55555555
+        .long 0xbbbbbbbb
+
+#--- small-alias.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .long 0x11111111
+        .globl func
+func:
+        .long 0x22222222
+
+#--- alias-ref.s
+        .weak_anti_dep func
+        .set func, "#func"
+
+#--- alias-provider.s
+        .text
+        .globl "#func"
+"#func":
+        .long 0x77777777
+
+#--- x64-ref.s
+        .data
+        .rva func

--- a/lld/test/COFF/comdat-selection-largest-associative-chain.s
+++ b/lld/test/COFF/comdat-selection-largest-associative-chain.s
@@ -1,0 +1,91 @@
+# REQUIRES: x86
+
+# Test a chain of associative COMDAT sections attached to competing
+# IMAGE_COMDAT_SELECT_LARGEST groups.
+#
+# level1 is associated with leader, while level2 is associated with level1.
+# Symbols defined in both associative levels must follow the prevailing leader.
+# Superseding the smaller group must discard the full association chain.
+
+# RUN: split-file %s %t.dir
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/small.s -o %t.small.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/large.s -o %t.large.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/root.s -o %t.root.obj
+
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.large.obj %t.root.obj \
+# RUN:   /map:%t.ref.small-large.map /out:%t.ref.small-large.exe
+# RUN: llvm-objdump -s %t.ref.small-large.exe | FileCheck --check-prefix=IMAGE \
+# RUN:   --implicit-check-not=11111111 --implicit-check-not=22222222 \
+# RUN:   --implicit-check-not=33333333 %s
+# RUN: FileCheck --check-prefix=MAP %s < %t.ref.small-large.map
+
+# RUN: lld-link /opt:noref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.large.obj %t.root.obj \
+# RUN:   /map:%t.noref.small-large.map /out:%t.noref.small-large.exe
+# RUN: llvm-objdump -s %t.noref.small-large.exe | \
+# RUN:   FileCheck --check-prefix=IMAGE --implicit-check-not=11111111 \
+# RUN:     --implicit-check-not=22222222 --implicit-check-not=33333333 %s
+# RUN: FileCheck --check-prefix=MAP %s < %t.noref.small-large.map
+
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.large.obj %t.small.obj %t.root.obj \
+# RUN:   /map:%t.ref.large-small.map /out:%t.ref.large-small.exe
+# RUN: llvm-objdump -s %t.ref.large-small.exe | FileCheck --check-prefix=IMAGE \
+# RUN:   --implicit-check-not=11111111 --implicit-check-not=22222222 \
+# RUN:   --implicit-check-not=33333333 %s
+# RUN: FileCheck --check-prefix=MAP %s < %t.ref.large-small.map
+
+# IMAGE-DAG: 44444444
+# IMAGE-DAG: 55555555
+# IMAGE-DAG: 66666666
+
+# MAP-DAG: leader{{.*}}large.obj
+# MAP-DAG: assoc_level1{{.*}}large.obj
+# MAP-DAG: nested_public{{.*}}large.obj
+
+#--- small.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .long 0x11111111
+
+        .section .rdata$level1, "dr", associative, leader
+        .globl assoc_level1
+assoc_level1:
+        .long 0x22222222
+
+        .section .rdata$level2, "dr", associative, assoc_level1
+        .globl nested_public
+nested_public:
+        .long 0x33333333
+
+#--- large.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .long 0x44444444
+        .long 0x45454545
+        .long 0x46464646
+
+        .section .rdata$level1, "dr", associative, leader
+        .globl assoc_level1
+assoc_level1:
+        .long 0x55555555
+
+        .section .rdata$level2, "dr", associative, assoc_level1
+        .globl nested_public
+nested_public:
+        .long 0x66666666
+
+#--- root.s
+        .section .text$root, "xr"
+        .globl entry
+entry:
+        leaq leader(%rip), %rax
+        leaq assoc_level1(%rip), %rcx
+        leaq nested_public(%rip), %rdx
+        retq

--- a/lld/test/COFF/comdat-selection-largest-associative-symbols.s
+++ b/lld/test/COFF/comdat-selection-largest-associative-symbols.s
@@ -1,0 +1,106 @@
+# REQUIRES: x86
+
+# Verify that external symbols defined directly in associative sections follow
+# the prevailing IMAGE_COMDAT_SELECT_LARGEST leader.
+#
+# The smaller and larger candidates both define assoc_public in an associative
+# section. When the larger leader supersedes the smaller one, the old
+# assoc_public definition must disappear with its section and the reference
+# from root.obj must resolve to the larger candidate.
+#
+# Cover the important symbol-table states:
+#
+#   small, large, root: replacement happens before the reference;
+#   small, root, large: the old definition is referenced before replacement;
+#   root, small, large: an undefined reference exists before either definition;
+#   large, small, root: the smaller candidate loses without becoming prevailing.
+
+# RUN: split-file %s %t.dir
+
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/small.s -o %t.small.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/large.s -o %t.large.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/root.s -o %t.root.obj
+
+# RUN: lld-link /entry:entry /subsystem:console /nodefaultlib /opt:ref \
+# RUN:   %t.small.obj %t.large.obj %t.root.obj \
+# RUN:   /out:%t.small-large-root-ref.exe
+# RUN: llvm-objdump -s %t.small-large-root-ref.exe | \
+# RUN:   FileCheck %s --check-prefix=LARGE \
+# RUN:   --implicit-check-not=11111111 --implicit-check-not=aaaaaaaa
+
+# RUN: lld-link /entry:entry /subsystem:console /nodefaultlib /opt:noref \
+# RUN:   %t.small.obj %t.large.obj %t.root.obj \
+# RUN:   /out:%t.small-large-root-noref.exe
+# RUN: llvm-objdump -s %t.small-large-root-noref.exe | \
+# RUN:   FileCheck %s --check-prefix=LARGE \
+# RUN:   --implicit-check-not=11111111 --implicit-check-not=aaaaaaaa
+
+# RUN: lld-link /entry:entry /subsystem:console /nodefaultlib /opt:ref \
+# RUN:   %t.large.obj %t.small.obj %t.root.obj \
+# RUN:   /out:%t.large-small-root-ref.exe
+# RUN: llvm-objdump -s %t.large-small-root-ref.exe | \
+# RUN:   FileCheck %s --check-prefix=LARGE \
+# RUN:   --implicit-check-not=11111111 --implicit-check-not=aaaaaaaa
+
+# RUN: lld-link /entry:entry /subsystem:console /nodefaultlib /opt:noref \
+# RUN:   %t.large.obj %t.small.obj %t.root.obj \
+# RUN:   /out:%t.large-small-root-noref.exe
+# RUN: llvm-objdump -s %t.large-small-root-noref.exe | \
+# RUN:   FileCheck %s --check-prefix=LARGE \
+# RUN:   --implicit-check-not=11111111 --implicit-check-not=aaaaaaaa
+
+# RUN: lld-link /entry:entry /subsystem:console /nodefaultlib /opt:ref \
+# RUN:   %t.small.obj %t.root.obj %t.large.obj \
+# RUN:   /out:%t.small-root-large.exe
+# RUN: llvm-objdump -s %t.small-root-large.exe | \
+# RUN:   FileCheck %s --check-prefix=LARGE \
+# RUN:   --implicit-check-not=11111111 --implicit-check-not=aaaaaaaa
+
+# RUN: lld-link /entry:entry /subsystem:console /nodefaultlib /opt:ref \
+# RUN:   %t.root.obj %t.small.obj %t.large.obj \
+# RUN:   /out:%t.root-small-large.exe
+# RUN: llvm-objdump -s %t.root-small-large.exe | \
+# RUN:   FileCheck %s --check-prefix=LARGE \
+# RUN:   --implicit-check-not=11111111 --implicit-check-not=aaaaaaaa
+
+# LARGE: Contents of section .rdata:
+# LARGE-NEXT: {{[0-9a-f]+}} 55555555 bbbbbbbb
+
+#--- small.s
+        .section .text$largest, "xr", largest, leader
+
+        .globl leader
+leader:
+        .byte 0x11
+
+        .section .rdata$assoc, "dr", associative, leader
+
+        .globl assoc_public
+assoc_public:
+        .long 0x11111111
+        .long 0xaaaaaaaa
+
+#--- large.s
+        .section .text$largest, "xr", largest, leader
+
+        .globl leader
+leader:
+        .space 32, 0x44
+
+        .section .rdata$assoc, "dr", associative, leader
+
+        .globl assoc_public
+assoc_public:
+        .long 0x55555555
+        .long 0xbbbbbbbb
+
+#--- root.s
+        .section .text$root, "xr"
+
+        .globl entry
+entry:
+        movl assoc_public(%rip), %eax
+        retq

--- a/lld/test/COFF/comdat-selection-largest-autoexport.s
+++ b/lld/test/COFF/comdat-selection-largest-autoexport.s
@@ -1,0 +1,45 @@
+# REQUIRES: x86
+
+# A public symbol defined only in a superseded IMAGE_COMDAT_SELECT_LARGEST
+# group must not be considered by MinGW automatic export. In particular, it
+# must not be emitted with an RVA relative to a section absent from the image.
+
+# RUN: split-file %s %t.dir
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/small.s -o %t.small.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/large.s -o %t.large.obj
+
+# Check both input orders. The small-first order exercises removal of an
+# already prevailing definition; the large-first order exercises a candidate
+# which never prevails.
+# RUN: lld-link /lldmingw /dll /noentry /nodefaultlib /noimplib \
+# RUN:   %t.small.obj %t.large.obj /out:%t.small-large.dll
+# RUN: llvm-readobj --coff-exports %t.small-large.dll | \
+# RUN:   FileCheck --implicit-check-not=only_small %s
+# RUN: lld-link /lldmingw /dll /noentry /nodefaultlib /noimplib \
+# RUN:   %t.large.obj %t.small.obj /out:%t.large-small.dll
+# RUN: llvm-readobj --coff-exports %t.large-small.dll | \
+# RUN:   FileCheck --implicit-check-not=only_small %s
+
+# CHECK: Export {
+# CHECK: Name: leader
+# CHECK: RVA: 0x1000
+# CHECK: }
+# CHECK-NOT: Export {
+
+#--- small.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .byte 0x11
+
+        .globl only_small
+only_small:
+        .byte 0x22
+
+#--- large.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .long 0x44444444

--- a/lld/test/COFF/comdat-selection-largest-autoimport.s
+++ b/lld/test/COFF/comdat-selection-largest-autoimport.s
@@ -1,0 +1,85 @@
+# REQUIRES: x86
+
+# RUN: split-file %s %t.dir
+# RUN: llvm-mc -triple=x86_64-windows-gnu -filetype=obj \
+# RUN:   %t.dir/provider.s -o %t.provider.obj
+# RUN: llvm-mc -triple=x86_64-windows-gnu -filetype=obj \
+# RUN:   %t.dir/root.s -o %t.root.obj
+# RUN: llvm-mc -triple=x86_64-windows-gnu -filetype=obj \
+# RUN:   %t.dir/small.s -o %t.small.obj
+# RUN: llvm-mc -triple=x86_64-windows-gnu -filetype=obj \
+# RUN:   %t.dir/large.s -o %t.large.obj
+# RUN: llvm-mc -triple=x86_64-windows-gnu -filetype=obj \
+# RUN:   %t.dir/winning-reference.s -o %t.winning-reference.obj
+# RUN: llvm-mc -triple=x86_64-windows-gnu -filetype=obj \
+# RUN:   %t.dir/losing-reference.s -o %t.losing-reference.obj
+# RUN: lld-link /dll /nodefaultlib /entry:DllMainCRTStartup \
+# RUN:   /export:variable,data /out:%t.provider.dll /implib:%t.provider.lib \
+# RUN:   %t.provider.obj
+
+# References from the prevailing LARGEST group must be visible to MinGW's
+# automatic-import discovery.
+# RUN: lld-link /lldmingw /nodefaultlib /entry:entry /subsystem:console \
+# RUN:   /opt:noref /out:%t.winning.exe %t.small.obj \
+# RUN:   %t.winning-reference.obj %t.root.obj %t.provider.lib
+# RUN: llvm-readobj --coff-imports %t.winning.exe | \
+# RUN:   FileCheck %s --check-prefix=IMPORT
+
+# Conversely, a reference originating only in the losing group must not load
+# an otherwise-unused import, including when section GC is disabled.
+# RUN: lld-link /lldmingw /nodefaultlib /entry:entry /subsystem:console \
+# RUN:   /opt:noref /out:%t.losing.exe %t.losing-reference.obj %t.large.obj \
+# RUN:   %t.root.obj %t.provider.lib
+# RUN: llvm-readobj --coff-imports %t.losing.exe | \
+# RUN:   FileCheck %s --check-prefix=NO-IMPORT
+
+# IMPORT: Import {
+# IMPORT: Symbol: variable (0)
+# NO-IMPORT-NOT: Import {
+
+#--- provider.s
+        .globl variable
+        .globl DllMainCRTStartup
+        .text
+DllMainCRTStartup:
+        retq
+        .data
+variable:
+        .long 42
+
+#--- root.s
+        .text
+        .globl entry
+entry:
+        leaq leader(%rip), %rax
+        retq
+        .globl _pei386_runtime_relocator
+_pei386_runtime_relocator:
+        retq
+
+#--- small.s
+        .section .text$leader, "xr", largest, leader
+        .globl leader
+leader:
+        retq
+
+#--- large.s
+        .section .text$leader, "xr", largest, leader
+        .globl leader
+leader:
+        .space 32, 0x44
+
+#--- winning-reference.s
+        .section .text$leader, "xr", largest, leader
+        .globl leader
+leader:
+        movl variable(%rip), %eax
+        retq
+        .space 32, 0x55
+
+#--- losing-reference.s
+        .section .text$leader, "xr", largest, leader
+        .globl leader
+leader:
+        movl variable(%rip), %eax
+        retq

--- a/lld/test/COFF/comdat-selection-largest-bigobj.s
+++ b/lld/test/COFF/comdat-selection-largest-bigobj.s
@@ -1,0 +1,210 @@
+# REQUIRES: x86
+#
+# Exercise the 32-bit COFF bigobj symbol layout through LARGEST replacement,
+# associative-section parent decoding, and secondary-definition tracking.
+#
+# llvm-mc has no bigobj output switch, so construct one minimal valid bigobj
+# directly. Keeping the object small avoids a fixture with > 65279 sections.
+#
+# RUN: split-file %s %t.dir
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/small.s -o %t.small.obj
+# RUN: %python %t.dir/gen-bigobj.py %t.large.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/root.s -o %t.root.obj
+#
+# RUN: llvm-objdump -t %t.large.obj | FileCheck %s --check-prefix=BIGOBJ
+# RUN: lld-link /entry:entry /subsystem:console /nodefaultlib /opt:noref \
+# RUN:   %t.small.obj %t.large.obj %t.root.obj /out:%t.exe
+# RUN: llvm-objdump -s %t.exe | FileCheck %s --check-prefix=IMAGE
+#
+# BIGOBJ: SYMBOL TABLE:
+# BIGOBJ: leader
+# BIGOBJ: assoc
+# BIGOBJ: nested
+#
+# IMAGE: 44444444
+# IMAGE: 55555555
+# IMAGE: 66666666
+# IMAGE-NOT: 11111111
+# IMAGE-NOT: 22222222
+# IMAGE-NOT: 33333333
+#
+#--- small.s
+        .section .text$l, "xr", largest, leader
+        .globl leader
+leader:
+        .long 0x11111111
+
+        .section .rdata$a, "dr", associative, leader
+        .globl assoc
+assoc:
+        .long 0x22222222
+
+        .section .rdat$b, "dr", associative, assoc
+        .globl nested
+nested:
+        .long 0x33333333
+#
+#--- root.s
+        .text
+        .globl entry
+entry:
+        leaq leader(%rip), %rax
+        movl assoc(%rip), %ecx
+        movl nested(%rip), %edx
+        retq
+#
+#--- gen-bigobj.py
+import struct
+import sys
+
+BIGOBJ_MAGIC = bytes.fromhex("c7a1bad1eebaa94baf20faf66aa4dcb8")
+MACHINE_AMD64 = 0x8664
+
+SCN_CODE = 0x00000020
+SCN_INIT_DATA = 0x00000040
+SCN_LNK_COMDAT = 0x00001000
+SCN_ALIGN_1 = 0x00100000
+SCN_EXEC = 0x20000000
+SCN_READ = 0x40000000
+
+STATIC = 3
+EXTERNAL = 2
+ASSOCIATIVE = 5
+LARGEST = 6
+
+
+def name8(name):
+    data = name.encode("ascii")
+    assert len(data) <= 8
+    return data.ljust(8, b"\0")
+
+
+def section(name, data, characteristics, raw_ptr):
+    return struct.pack(
+        "<8sIIIIIIHHI",
+        name8(name),
+        0,
+        0,
+        len(data),
+        raw_ptr,
+        0,
+        0,
+        0,
+        0,
+        characteristics,
+    )
+
+
+def symbol(name, value, section_number, storage_class, aux_count=0):
+    return struct.pack(
+        "<8sIiHBB",
+        name8(name),
+        value,
+        section_number,
+        0,
+        storage_class,
+        aux_count,
+    )
+
+
+def section_aux(length, number, selection):
+    # The standard section-definition auxiliary record is 18 bytes. BigObj
+    # symbol records are 20 bytes, so append the two bytes of record padding.
+    return (
+        struct.pack(
+            "<IHHIHBBH",
+            length,
+            0,
+            0,
+            0,
+            number & 0xFFFF,
+            selection,
+            0,
+            number >> 16,
+        )
+        + b"\0\0"
+    )
+
+
+text = bytes([0x44]) * 36
+assoc = bytes.fromhex("55555555")
+nested = bytes.fromhex("66666666")
+section_data = [text, assoc, nested]
+
+header_size = 56
+section_table_size = 3 * 40
+first_raw = header_size + section_table_size
+raw_ptrs = [
+    first_raw,
+    first_raw + len(text),
+    first_raw + len(text) + len(assoc),
+]
+symbol_table = first_raw + sum(map(len, section_data))
+number_of_symbols = 9
+
+header = struct.pack(
+    "<HHHHI16sIIIIIII",
+    0,
+    0xFFFF,
+    2,
+    MACHINE_AMD64,
+    0,
+    BIGOBJ_MAGIC,
+    0,
+    0,
+    0,
+    0,
+    3,
+    symbol_table,
+    number_of_symbols,
+)
+
+sections = b"".join(
+    [
+        section(
+            ".text$l",
+            text,
+            SCN_CODE | SCN_LNK_COMDAT | SCN_ALIGN_1 | SCN_EXEC | SCN_READ,
+            raw_ptrs[0],
+        ),
+        section(
+            ".rdata$a",
+            assoc,
+            SCN_INIT_DATA | SCN_LNK_COMDAT | SCN_ALIGN_1 | SCN_READ,
+            raw_ptrs[1],
+        ),
+        section(
+            ".rdat$b",
+            nested,
+            SCN_INIT_DATA | SCN_LNK_COMDAT | SCN_ALIGN_1 | SCN_READ,
+            raw_ptrs[2],
+        ),
+    ]
+)
+
+symbols = b"".join(
+    [
+        symbol(".text$l", 0, 1, STATIC, 1),
+        section_aux(len(text), 1, LARGEST),
+        symbol("leader", 0, 1, EXTERNAL),
+        symbol(".rdata$a", 0, 2, STATIC, 1),
+        section_aux(len(assoc), 1, ASSOCIATIVE),
+        symbol("assoc", 0, 2, EXTERNAL),
+        symbol(".rdat$b", 0, 3, STATIC, 1),
+        section_aux(len(nested), 2, ASSOCIATIVE),
+        symbol("nested", 0, 3, EXTERNAL),
+    ]
+)
+
+assert len(header) == header_size
+assert len(sections) == section_table_size
+assert len(symbols) == number_of_symbols * 20
+
+with open(sys.argv[1], "wb") as out:
+    out.write(header)
+    out.write(sections)
+    out.write(b"".join(section_data))
+    out.write(symbols)
+    out.write(struct.pack("<I", 4))

--- a/lld/test/COFF/comdat-selection-largest-cross-arch.s
+++ b/lld/test/COFF/comdat-selection-largest-cross-arch.s
@@ -1,0 +1,50 @@
+# Verify whole-group LARGEST replacement on i386, including SafeSEH metadata.
+# ARM, ARM64, ARM64EC, and ARM64X have target-specific companion tests.
+
+# RUN: split-file %s %t.dir
+
+# RUN: llvm-mc -triple i686-windows-msvc -filetype=obj \
+# RUN:   %t.dir/small.s -o %t.i386-small.obj
+# RUN: llvm-mc -triple i686-windows-msvc -filetype=obj \
+# RUN:   %t.dir/large.s -o %t.i386-large.obj
+# RUN: lld-link /dll /noentry /nodefaultlib /safeseh /include:leader \
+# RUN:   %t.i386-small.obj %t.i386-large.obj /out:%t.i386.dll
+# RUN: llvm-objdump -s %t.i386.dll | FileCheck %s --check-prefix=LARGE \
+# RUN:   --implicit-check-not=11111111 --implicit-check-not=aaaaaaaa
+
+# LARGE: Contents of section .text:
+# LARGE: 44444444
+# LARGE: Contents of section .rdata:
+# LARGE: 55555555 bbbbbbbb
+
+#--- small.s
+        .def @feat.00;
+        .scl 3;
+        .type 0;
+        .endef
+        .globl @feat.00
+@feat.00 = 1
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .long 0x11111111
+        .section .rdata$assoc, "dr", associative, leader
+        .long 0xaaaaaaaa
+        .safeseh leader
+
+#--- large.s
+        .def @feat.00;
+        .scl 3;
+        .type 0;
+        .endef
+        .globl @feat.00
+@feat.00 = 1
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .long 0x44444444
+        .space 28, 0x44
+        .section .rdata$assoc, "dr", associative, leader
+        .long 0x55555555
+        .long 0xbbbbbbbb
+        .safeseh leader

--- a/lld/test/COFF/comdat-selection-largest-debug.s
+++ b/lld/test/COFF/comdat-selection-largest-debug.s
@@ -1,0 +1,121 @@
+# REQUIRES: x86
+
+# Test IMAGE_COMDAT_SELECT_LARGEST with /debug. The image and the PDB must
+# contain public symbols only from the final largest COMDAT group.
+#
+# /debug disables section GC by default. The /opt:ref variant verifies the
+# same behavior when section GC is explicitly enabled.
+
+# RUN: split-file %s %t.dir
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/small.s -o %t.small.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/large.s -o %t.large.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/root.s -o %t.root.obj
+
+# RUN: lld-link /debug /opt:ref /pdb:%t.ref.pdb /entry:entry \
+# RUN:   /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.large.obj %t.root.obj /out:%t.ref.exe
+# RUN: llvm-pdbutil dump -publics %t.ref.pdb | \
+# RUN:   FileCheck --check-prefix=PDB \
+# RUN:     --implicit-check-not=small_public %s
+# RUN: llvm-pdbutil dump -l %t.ref.pdb | \
+# RUN:   FileCheck --check-prefix=LINES --implicit-check-not=small.cpp %s
+# RUN: llvm-objdump -s %t.ref.exe | \
+# RUN:   FileCheck --check-prefix=IMAGE \
+# RUN:     --implicit-check-not=11111111 \
+# RUN:     --implicit-check-not=22222222 %s
+
+# RUN: lld-link /debug /pdb:%t.noref.pdb /entry:entry /subsystem:console \
+# RUN:   /nodefaultlib %t.small.obj %t.large.obj %t.root.obj \
+# RUN:   /out:%t.noref.exe
+# RUN: llvm-pdbutil dump -publics %t.noref.pdb | \
+# RUN:   FileCheck --check-prefix=PDB \
+# RUN:     --implicit-check-not=small_public %s
+# RUN: llvm-pdbutil dump -l %t.noref.pdb | \
+# RUN:   FileCheck --check-prefix=LINES --implicit-check-not=small.cpp %s
+# RUN: llvm-objdump -s %t.noref.exe | \
+# RUN:   FileCheck --check-prefix=IMAGE \
+# RUN:     --implicit-check-not=11111111 \
+# RUN:     --implicit-check-not=22222222 %s
+
+# The 12-byte candidate must prevail. The small candidate's 0x11111111 and
+# 0x22222222 markers must not occur anywhere in the output image.
+
+# IMAGE: Contents of section .text:
+# IMAGE-NEXT:  140001000 44444444 55555555 66666666
+
+# The public stream must contain symbols backed by the prevailing chunk.
+# small_public belongs exclusively to the discarded candidate and is excluded
+# through --implicit-check-not above.
+
+# PDB: Public Symbols
+# PDB-DAG: S_PUB32 {{.*}} `leader`
+# PDB-DAG: S_PUB32 {{.*}} `large_public`
+# PDB-DAG: S_PUB32 {{.*}} `entry`
+
+# The line table comes from a real associative .debug$S chunk. The discarded
+# candidate's file is excluded through --implicit-check-not above.
+
+# LINES: large.cpp
+
+#--- small.s
+        .cv_file 1 "small.cpp" "11111111111111111111111111111111" 1
+
+        .section .text$largest, "xr", largest, leader
+
+        .globl leader
+leader:
+        .cv_func_id 0
+        .cv_loc 0 1 1 0 is_stmt 0
+        .long 0x11111111
+
+        .globl small_public
+small_public:
+        .long 0x22222222
+.Lsmall_end:
+
+        .section .debug$S, "dr", associative, leader
+        .long 4
+        .cv_linetable 0, leader, .Lsmall_end
+
+        .section .debug$S, "dr"
+        .long 4
+        .cv_filechecksums
+        .cv_stringtable
+
+#--- large.s
+        .cv_file 1 "large.cpp" "44444444444444444444444444444444" 1
+
+        .section .text$largest, "xr", largest, leader
+
+        .globl leader
+leader:
+        .cv_func_id 0
+        .cv_loc 0 1 1 0 is_stmt 0
+        .long 0x44444444
+
+        .globl large_public
+large_public:
+        .long 0x55555555
+
+        .long 0x66666666
+.Llarge_end:
+
+        .section .debug$S, "dr", associative, leader
+        .long 4
+        .cv_linetable 0, leader, .Llarge_end
+
+        .section .debug$S, "dr"
+        .long 4
+        .cv_filechecksums
+        .cv_stringtable
+
+#--- root.s
+        .section .text$root, "xr"
+
+        .globl entry
+entry:
+        leaq leader(%rip), %rax
+        retq

--- a/lld/test/COFF/comdat-selection-largest-deferred-epochs.ll
+++ b/lld/test/COFF/comdat-selection-largest-deferred-epochs.ll
@@ -1,0 +1,68 @@
+; REQUIRES: x86
+;
+; Exercise deferred COMDAT state in two driver epochs. Native inputs first
+; create and drain deferred providers. LTO then emits another native object
+; containing a replaceable COMDAT, which must be processed with freshly valid
+; provider IDs and empty per-epoch work queues.
+;
+; RUN: split-file %s %t.dir
+; RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+; RUN:   %t.dir/pre-small.s -o %t.pre-small.obj
+; RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+; RUN:   %t.dir/pre-large.s -o %t.pre-large.obj
+; RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+; RUN:   %t.dir/pre-provider.s -o %t.pre-provider.obj
+; RUN: llvm-lib -machine:amd64 -out:%t.pre-provider.lib %t.pre-provider.obj
+; RUN: llvm-as %t.dir/epoch-large.ll -o %t.epoch-large.obj
+; RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+; RUN:   %t.dir/root.s -o %t.root.obj
+;
+; RUN: lld-link /entry:entry /subsystem:console /nodefaultlib /opt:noref \
+; RUN:   %t.pre-small.obj %t.pre-provider.lib %t.pre-large.obj \
+; RUN:   %t.epoch-large.obj %t.root.obj \
+; RUN:   /out:%t.exe /map:%t.map
+; RUN: FileCheck %s --check-prefix=MAP < %t.map
+; RUN: llvm-objdump -s %t.exe | FileCheck %s --check-prefix=IMAGE
+;
+; MAP: pre_only{{.*}}pre-provider.obj
+; IMAGE: 88776655
+; IMAGE-NOT: 11111111
+;
+;--- pre-small.s
+        .section .text$pre, "xr", largest, pre_leader
+        .globl pre_leader
+pre_leader:
+        .byte 0x11
+        .globl pre_only
+pre_only:
+        .long 0x11111111
+;
+;--- pre-large.s
+        .section .text$pre, "xr", largest, pre_leader
+        .globl pre_leader
+pre_leader:
+        .space 32, 0x44
+;
+;--- pre-provider.s
+        .section .rdata$provider, "dr"
+        .globl pre_only
+pre_only:
+        .long 0x22222222
+;
+;--- epoch-large.ll
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-windows-msvc"
+
+$epoch_leader = comdat largest
+
+@epoch_leader = global [64 x i8] zeroinitializer, comdat
+@epoch_child = global i32 1432778632, comdat($epoch_leader)
+;
+;--- root.s
+        .text
+        .globl entry
+entry:
+        movl pre_only(%rip), %eax
+        leaq epoch_leader(%rip), %rcx
+        movl epoch_child(%rip), %edx
+        retq

--- a/lld/test/COFF/comdat-selection-largest-deferred-resolution.s
+++ b/lld/test/COFF/comdat-selection-largest-deferred-resolution.s
@@ -1,0 +1,532 @@
+# REQUIRES: x86
+
+# Exercise providers and references that are temporarily hidden by a secondary
+# definition in an IMAGE_COMDAT_SELECT_LARGEST group. All orderings here must
+# resolve as if the losing group had never published its symbols.
+
+# RUN: split-file %s %t.dir
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/small.s -o %t.small.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/large.s -o %t.large.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/medium.s -o %t.medium.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/large-with-foo.s -o %t.large-with-foo.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/assoc-small.s -o %t.assoc-small.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/small-import.s -o %t.small-import.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/provider.s -o %t.provider.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/provider-a.s -o %t.provider-a.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/provider-b.s -o %t.provider-b.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/provider-comdat.s -o %t.provider-comdat.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/provider-comdat-small.s -o %t.provider-comdat-small.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/provider-comdat-large.s -o %t.provider-comdat-large.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/common.s -o %t.common.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/common-large.s -o %t.common-large.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/absolute-a.s -o %t.absolute-a.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/absolute-b.s -o %t.absolute-b.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/root.s -o %t.root.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/root-call.s -o %t.root-call.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/root-import.s -o %t.root-import.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/same-object.s -o %t.same-object.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/same-object-assoc.s -o %t.same-object-assoc.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/same-object-comdat.s -o %t.same-object-comdat.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/local-reference.s -o %t.local-reference.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/assoc-local-reference.s -o %t.assoc-local-reference.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/only-small-provider.s -o %t.only-small-provider.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/discarded-reference.s -o %t.discarded-reference.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/root-leader.s -o %t.root-leader.obj
+# RUN: llvm-lib -machine:amd64 -out:%t.provider.lib %t.provider.obj
+# RUN: llvm-lib -machine:amd64 -out:%t.provider-a.lib %t.provider-a.obj
+# RUN: llvm-lib -machine:amd64 -out:%t.provider-b.lib %t.provider-b.obj
+# RUN: llvm-lib -machine:amd64 -out:%t.only-small.lib \
+# RUN:   %t.only-small-provider.obj
+# RUN: llvm-dlltool -m i386:x86-64 -d %t.dir/provider.def \
+# RUN:   -l %t.provider-import.lib
+
+# A lazy provider registered before the provisional definition must survive.
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.provider.lib %t.small.obj %t.large.obj %t.root.obj \
+# RUN:   /map:%t.provider-before.map /out:%t.provider-before.exe
+# RUN: FileCheck %s --check-prefix=PROVIDER < %t.provider-before.map
+
+# A provider remains deferred across multiple successive provisional winners.
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.provider.lib %t.medium.obj %t.large.obj %t.root.obj \
+# RUN:   /map:%t.three-candidates.map /out:%t.three-candidates.exe
+# RUN: FileCheck %s --check-prefix=PROVIDER < %t.three-candidates.map
+
+# Explicit roots established through /include and /export are real references
+# and must extract the recovered provider.
+# RUN: lld-link /dll /noentry /nodefaultlib /include:foo %t.small.obj \
+# RUN:   %t.provider.lib %t.large.obj /map:%t.include.map /out:%t.include.dll
+# RUN: FileCheck %s --check-prefix=PROVIDER < %t.include.map
+# RUN: lld-link /dll /noentry /nodefaultlib /export:foo %t.small.obj \
+# RUN:   %t.provider.lib %t.large.obj /map:%t.export.map /out:%t.export.dll
+# RUN: FileCheck %s --check-prefix=PROVIDER < %t.export.map
+# RUN: llvm-readobj --coff-exports %t.export.dll | \
+# RUN:   FileCheck %s --check-prefix=EXPORT
+
+# The first archive retains normal precedence when several providers are
+# suppressed between candidates.
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.provider-a.lib %t.provider-b.lib %t.large.obj \
+# RUN:   %t.root.obj /map:%t.lazy-order.map /out:%t.lazy-order.exe
+# RUN: FileCheck %s --check-prefix=FIRST-LAZY < %t.lazy-order.map
+
+# An associative child inherits the provisional state of its leader.
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.assoc-small.obj %t.provider.lib %t.large.obj %t.root.obj \
+# RUN:   /map:%t.assoc.map /out:%t.assoc.exe
+# RUN: FileCheck %s --check-prefix=PROVIDER < %t.assoc.map
+
+# /force:multiple must not warn about a provider whose apparent duplicate is
+# removed by the later LARGEST selection.
+# RUN: lld-link /force:multiple /opt:ref /entry:entry /subsystem:console \
+# RUN:   /nodefaultlib %t.small.obj %t.provider.obj %t.large.obj %t.root.obj \
+# RUN:   /out:%t.force-multiple.exe 2>&1 | \
+# RUN:   FileCheck %s --allow-empty --check-prefix=NO-SPURIOUS-WARN
+
+# If the provisional group remains selected, replay restores the duplicate
+# diagnostic that normal symbol resolution would have produced.
+# RUN: not lld-link /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.provider.obj %t.root.obj \
+# RUN:   /out:%t.surviving-duplicate.exe 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=SURVIVING-DUPLICATE
+# RUN: not lld-link /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.provider.obj %t.small.obj %t.root.obj \
+# RUN:   /out:%t.preceding-duplicate.exe 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=SURVIVING-DUPLICATE
+
+# A COMDAT provider is retained even though its section must be read before the
+# current LARGEST group is superseded. Cover both sides of the provisional
+# definition.
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.provider-comdat.obj %t.large.obj %t.root.obj \
+# RUN:   /map:%t.comdat-between.map /out:%t.comdat-between.exe
+# RUN: FileCheck %s --check-prefix=COMDAT < %t.comdat-between.map
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.provider-comdat.obj %t.small.obj %t.large.obj %t.root.obj \
+# RUN:   /map:%t.comdat-before.map /out:%t.comdat-before.exe
+# RUN: FileCheck %s --check-prefix=COMDAT < %t.comdat-before.map
+
+# A deferred COMDAT that is rejected after the provisional winner survives is
+# still discarded under /force:multiple.
+# RUN: lld-link /force:multiple /opt:noref /entry:entry /subsystem:console \
+# RUN:   /nodefaultlib %t.small.obj %t.provider-comdat.obj %t.root.obj \
+# RUN:   /out:%t.comdat-not-selected.exe 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=COMDAT-DUPLICATE
+# RUN: llvm-objdump -s %t.comdat-not-selected.exe | \
+# RUN:   FileCheck %s --check-prefix=COMDAT-REJECT \
+# RUN:   --implicit-check-not=cccccccc
+
+# Multiple deferred COMDAT providers must go through normal selection rather
+# than retaining the first provider unconditionally.
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   /include:provider_child \
+# RUN:   %t.small.obj %t.provider-comdat-small.obj \
+# RUN:   %t.provider-comdat-large.obj %t.large.obj %t.root.obj \
+# RUN:   /out:%t.comdat-largest.exe
+# RUN: llvm-objdump -s %t.comdat-largest.exe | \
+# RUN:   FileCheck %s --check-prefix=COMDAT-LARGEST
+
+# Eager imports loaded with /wholearchive work before and between candidates.
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj /wholearchive:%t.provider-import.lib %t.large.obj \
+# RUN:   %t.root-call.obj /out:%t.import-between.exe
+# RUN: llvm-readobj --coff-imports %t.import-between.exe | \
+# RUN:   FileCheck %s --check-prefix=IMPORT
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   /wholearchive:%t.provider-import.lib %t.small.obj %t.large.obj \
+# RUN:   %t.root-call.obj /out:%t.import-before.exe
+# RUN: llvm-readobj --coff-imports %t.import-before.exe | \
+# RUN:   FileCheck %s --check-prefix=IMPORT
+
+# Exercise both symbols produced by a function import: the callable thunk and
+# its __imp_ data entry.
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small-import.obj /wholearchive:%t.provider-import.lib \
+# RUN:   %t.large.obj %t.root-import.obj /out:%t.import-pair.exe
+# RUN: llvm-readobj --coff-imports %t.import-pair.exe | \
+# RUN:   FileCheck %s --check-prefix=IMPORT
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   /wholearchive:%t.provider-import.lib %t.small-import.obj \
+# RUN:   %t.large.obj %t.root-import.obj /out:%t.import-pair-before.exe
+# RUN: llvm-readobj --coff-imports %t.import-pair-before.exe | \
+# RUN:   FileCheck %s --check-prefix=IMPORT
+
+# If the provisional definitions survive under /force:multiple, the eager
+# import is a rejected duplicate and must not leak into the import table or
+# leave replaced ImportFile symbol pointers behind.
+# RUN: lld-link /force:multiple /opt:ref /entry:entry /subsystem:console \
+# RUN:   /nodefaultlib %t.small-import.obj \
+# RUN:   /wholearchive:%t.provider-import.lib %t.root-import.obj \
+# RUN:   /out:%t.import-not-selected.exe 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=IMPORT-DUPLICATE
+# RUN: llvm-readobj --coff-imports %t.import-not-selected.exe | \
+# RUN:   FileCheck %s --allow-empty --check-prefix=NO-IMPORT
+
+# If only the thunk name is shadowed, the IAT provider remains valid and the
+# rejected thunk must not leave a replaced pointer in ImportFile.
+# RUN: lld-link /force:multiple /opt:ref /entry:entry /subsystem:console \
+# RUN:   /nodefaultlib /wholearchive:%t.provider-import.lib %t.small.obj \
+# RUN:   %t.root-import.obj /out:%t.import-data-only.exe 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=IMPORT-THUNK-DUPLICATE
+# RUN: llvm-readobj --coff-imports %t.import-data-only.exe | \
+# RUN:   FileCheck %s --check-prefix=IMPORT
+
+# A deferred common that is not selected must not leave an allocation behind.
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.common.obj %t.large-with-foo.obj %t.root.obj \
+# RUN:   /out:%t.common-not-selected.exe
+# RUN: llvm-readobj --sections %t.common-not-selected.exe | \
+# RUN:   FileCheck %s --check-prefix=NO-COMMON
+
+# Multiple deferred commons retain normal size precedence without keeping the
+# allocations belonging to providers that were replayed but not selected.
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.common.obj %t.common-large.obj %t.large.obj \
+# RUN:   %t.root.obj /out:%t.multiple-common.exe
+# RUN: llvm-readobj --sections %t.multiple-common.exe | \
+# RUN:   FileCheck %s --check-prefix=MULTIPLE-COMMON
+
+# Common and absolute providers seen before the provisional group remain
+# available if it loses.
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.common.obj %t.small.obj %t.large.obj %t.root.obj \
+# RUN:   /map:%t.common-before.map /out:%t.common-before.exe
+# RUN: FileCheck %s --check-prefix=COMMON < %t.common-before.map
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.absolute-a.obj %t.small.obj %t.large.obj %t.root.obj \
+# RUN:   /map:%t.absolute-before.map /out:%t.absolute-before.exe
+# RUN: FileCheck %s --check-prefix=ABSOLUTE < %t.absolute-before.map
+
+# Replaying multiple absolute providers preserves the normal duplicate
+# diagnostic instead of silently collapsing the list.
+# RUN: not lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.absolute-a.obj %t.absolute-b.obj %t.large.obj \
+# RUN:   %t.root.obj /out:%t.absolute-conflict.exe 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=ABSOLUTE-CONFLICT
+
+# A relocation from a normal section in the same object is a real reference
+# and therefore extracts a deferred provider after the group is discarded.
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.same-object.obj %t.only-small.lib %t.large.obj \
+# RUN:   /map:%t.same-object.map /out:%t.same-object.exe
+# RUN: FileCheck %s --check-prefix=SAME-OBJECT < %t.same-object.map
+
+# The same provenance rule applies when the removed definition is in an
+# associative child, and when the live reference originates in another COMDAT
+# in the same object.
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.same-object-assoc.obj %t.only-small.lib %t.large.obj \
+# RUN:   /map:%t.same-object-assoc.map /out:%t.same-object-assoc.exe
+# RUN: FileCheck %s --check-prefix=ASSOC-SAME-OBJECT \
+# RUN:   < %t.same-object-assoc.map
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.same-object-comdat.obj %t.only-small.lib %t.large.obj \
+# RUN:   /map:%t.same-object-comdat.map /out:%t.same-object-comdat.exe
+# RUN: FileCheck %s --check-prefix=SAME-OBJECT \
+# RUN:   < %t.same-object-comdat.map
+
+# Local symbols cannot be satisfied by another file. Diagnose live relocations
+# to a discarded leader or associative child instead of emitting an invalid
+# RVA.
+# RUN: not lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.local-reference.obj %t.large.obj /out:%t.local-reference.exe \
+# RUN:   2>&1 | FileCheck %s --check-prefix=LOCAL
+# RUN: not lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.assoc-local-reference.obj %t.large.obj \
+# RUN:   /out:%t.assoc-local-reference.exe 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=ASSOC-LOCAL
+
+# Conversely, an undefined reference originating only in the losing group is
+# removed with that group.
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.discarded-reference.obj %t.large.obj %t.root-leader.obj \
+# RUN:   /out:%t.discarded-reference.exe
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.large.obj %t.discarded-reference.obj %t.root-leader.obj \
+# RUN:   /out:%t.discarded-reference-reversed.exe
+
+# PROVIDER: foo{{.*}}provider.obj
+# FIRST-LAZY: foo{{.*}}provider-a.obj
+# FIRST-LAZY-NOT: provider-b.obj
+# COMDAT: foo{{.*}}provider-comdat.obj
+# COMDAT-DUPLICATE: duplicate symbol: foo
+# COMDAT-REJECT: 11111111
+# COMDAT-LARGEST: Contents of section .rdata:
+# COMDAT-LARGEST: 22222222 22222222 22222222 22222222
+# COMDAT-LARGEST-NEXT: 44444444
+# IMPORT: Symbol: foo
+# IMPORT-DUPLICATE: duplicate symbol: __declspec(dllimport) foo
+# IMPORT-THUNK-DUPLICATE: duplicate symbol: foo
+# NO-IMPORT-NOT: Symbol: foo
+# EXPORT: Name: foo
+# NO-COMMON-NOT: Name: .data
+# NO-COMMON-NOT: Name: .bss
+# MULTIPLE-COMMON: Name: .data
+# MULTIPLE-COMMON-NEXT: VirtualSize: 0x10
+# COMMON: foo{{.*}}<common>
+# ABSOLUTE: foo{{.*}}<absolute>
+# ABSOLUTE-CONFLICT: duplicate symbol: foo
+# SURVIVING-DUPLICATE: duplicate symbol: foo
+# SAME-OBJECT: only_small{{.*}}only-small-provider.obj
+# ASSOC-SAME-OBJECT: assoc_only{{.*}}only-small-provider.obj
+# NO-SPURIOUS-WARN-NOT: duplicate symbol
+# LOCAL: relocation against symbol in discarded section: local_only
+# ASSOC-LOCAL: relocation against symbol in discarded section: assoc_local
+
+#--- small.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .byte 0x11
+        .globl foo
+foo:
+        .long 0x11111111
+        .globl provider_child
+provider_child:
+        .long 0x33333333
+
+#--- assoc-small.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .byte 0x11
+        .section .rdata$assoc, "dr", associative, leader
+        .globl foo
+foo:
+        .long 0x11111111
+
+#--- large.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .space 32, 0x44
+
+#--- medium.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .space 16, 0x33
+        .globl foo
+foo:
+        .long 0x33333333
+
+#--- small-import.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .byte 0x11
+        .globl foo
+foo:
+        .byte 0x22
+        .globl __imp_foo
+__imp_foo:
+        .quad 0
+
+#--- large-with-foo.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .space 32, 0x44
+        .globl foo
+foo:
+        .long 0x66666666
+
+#--- provider.s
+        .section .rdata$provider, "dr"
+        .globl foo
+foo:
+        .long 0x55555555
+
+#--- provider-a.s
+        .section .rdata$a, "dr"
+        .globl foo
+foo:
+        .long 0xaaaaaaaa
+
+#--- provider-b.s
+        .section .rdata$b, "dr"
+        .globl foo
+foo:
+        .long 0xbbbbbbbb
+
+#--- provider-comdat.s
+        .section .rdata$provider, "dr", discard, foo
+        .globl foo
+foo:
+        .long 0xcccccccc
+
+#--- provider-comdat-small.s
+        .section .rdata$foo, "dr", largest, foo
+        .globl foo
+foo:
+        .long 0x11111111
+
+#--- provider-comdat-large.s
+        .section .rdata$foo, "dr", largest, foo
+        .globl foo
+foo:
+        .space 16, 0x22
+        .globl provider_child
+provider_child:
+        .long 0x44444444
+
+#--- common.s
+        .comm foo, 8, 3
+
+#--- common-large.s
+        .comm foo, 16, 4
+
+#--- absolute-a.s
+        .globl foo
+        .set foo, 0x1111
+
+#--- absolute-b.s
+        .globl foo
+        .set foo, 0x2222
+
+#--- root.s
+        .text
+        .globl entry
+entry:
+        movabsq $foo, %rax
+        retq
+
+#--- root-call.s
+        .text
+        .globl entry
+entry:
+        callq foo
+        retq
+
+#--- root-import.s
+        .text
+        .globl entry
+entry:
+        callq foo
+        movq __imp_foo(%rip), %rax
+        retq
+
+#--- same-object.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .byte 0x11
+        .globl only_small
+only_small:
+        retq
+        .text
+        .globl entry
+entry:
+        callq only_small
+        retq
+
+#--- same-object-assoc.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .byte 0x11
+        .section .text$assoc, "xr", associative, leader
+        .globl assoc_only
+assoc_only:
+        retq
+        .text
+        .globl entry
+entry:
+        callq assoc_only
+        retq
+
+#--- same-object-comdat.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .byte 0x11
+        .globl only_small
+only_small:
+        retq
+        .section .text$entry, "xr", discard, entry
+        .globl entry
+entry:
+        callq only_small
+        retq
+
+#--- only-small-provider.s
+        .text
+        .globl only_small
+only_small:
+        retq
+        .globl assoc_only
+assoc_only:
+        retq
+
+#--- local-reference.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .byte 0x11
+local_only:
+        retq
+        .text
+        .globl entry
+entry:
+        callq local_only
+        retq
+
+#--- assoc-local-reference.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .byte 0x11
+        .section .text$assoc, "xr", associative, leader
+assoc_local:
+        retq
+        .text
+        .globl entry
+entry:
+        callq assoc_local
+        retq
+
+#--- discarded-reference.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        callq missing
+        retq
+
+#--- root-leader.s
+        .text
+        .globl entry
+entry:
+        leaq leader(%rip), %rax
+        retq
+
+#--- provider.def
+LIBRARY provider.dll
+EXPORTS
+        foo

--- a/lld/test/COFF/comdat-selection-largest-equal-size-secondary.s
+++ b/lld/test/COFF/comdat-selection-largest-equal-size-secondary.s
@@ -1,0 +1,84 @@
+# REQUIRES: x86
+#
+# Equal-sized LARGEST candidates keep the first selected leader. Secondary
+# definitions from the losing equal-sized group must disappear, and providers
+# hidden by those definitions must be recoverable independently of input order.
+#
+# RUN: split-file %s %t.dir
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/a.s -o %t.a.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/b.s -o %t.b.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/provider-a.s -o %t.provider-a.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/provider-b.s -o %t.provider-b.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/root.s -o %t.root.obj
+# RUN: llvm-lib -machine:amd64 -out:%t.providers.lib \
+# RUN:   %t.provider-a.obj %t.provider-b.obj
+#
+# A wins the tie; only_b must come from its fallback provider.
+# RUN: lld-link /entry:entry /subsystem:console /nodefaultlib /opt:noref \
+# RUN:   %t.a.obj %t.providers.lib %t.b.obj %t.root.obj \
+# RUN:   /map:%t.ab.map /out:%t.ab.exe
+# RUN: FileCheck %s --check-prefix=AB < %t.ab.map
+# RUN: llvm-objdump -s %t.ab.exe | FileCheck %s --check-prefix=A-IMAGE \
+# RUN:   --implicit-check-not=bbbbbbbb
+#
+# B wins the tie; only_a must come from its fallback provider.
+# RUN: lld-link /entry:entry /subsystem:console /nodefaultlib /opt:noref \
+# RUN:   %t.b.obj %t.providers.lib %t.a.obj %t.root.obj \
+# RUN:   /map:%t.ba.map /out:%t.ba.exe
+# RUN: FileCheck %s --check-prefix=BA < %t.ba.map
+# RUN: llvm-objdump -s %t.ba.exe | FileCheck %s --check-prefix=B-IMAGE \
+# RUN:   --implicit-check-not=aaaaaaaa
+#
+# AB-DAG: only_a{{.*}}a.obj
+# AB-DAG: only_b{{.*}}provider-b.obj
+# BA-DAG: only_a{{.*}}provider-a.obj
+# BA-DAG: only_b{{.*}}b.obj
+#
+# A-IMAGE-DAG: aaaaaaaa
+# A-IMAGE-DAG: 22222222
+# B-IMAGE-DAG: bbbbbbbb
+# B-IMAGE-DAG: 11111111
+#
+#--- a.s
+        .section .data$largest, "dw", largest, leader
+        .globl leader
+leader:
+        .space 16, 0xaa
+        .globl only_a
+only_a:
+        .long 0xaaaaaaaa
+#
+#--- b.s
+        .section .data$largest, "dw", largest, leader
+        .globl leader
+leader:
+        .space 16, 0xbb
+        .globl only_b
+only_b:
+        .long 0xbbbbbbbb
+#
+#--- provider-a.s
+        .section .rdata$provider_a, "dr"
+        .globl only_a
+only_a:
+        .long 0x11111111
+#
+#--- provider-b.s
+        .section .rdata$provider_b, "dr"
+        .globl only_b
+only_b:
+        .long 0x22222222
+#
+#--- root.s
+        .text
+        .globl entry
+entry:
+        leaq leader(%rip), %rax
+        movl only_a(%rip), %ecx
+        movl only_b(%rip), %edx
+        retq

--- a/lld/test/COFF/comdat-selection-largest-equal-size.s
+++ b/lld/test/COFF/comdat-selection-largest-equal-size.s
@@ -1,0 +1,48 @@
+# REQUIRES: x86
+
+# Equal-sized IMAGE_COMDAT_SELECT_LARGEST candidates may be selected
+# arbitrarily, but the leader and its associative section must always come from
+# the same candidate. The output must never contain a mixed group.
+
+# RUN: split-file %s %t.dir
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj %t.dir/a.s -o %t.a.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj %t.dir/b.s -o %t.b.obj
+
+# RUN: lld-link /opt:ref /include:leader /dll /noentry /nodefaultlib \
+# RUN:   %t.a.obj %t.b.obj /out:%t.ref.ab.exe
+# RUN: llvm-objdump -s %t.ref.ab.exe | FileCheck %s
+
+# RUN: lld-link /opt:noref /include:leader /dll /noentry /nodefaultlib \
+# RUN:   %t.a.obj %t.b.obj /out:%t.noref.ab.exe
+# RUN: llvm-objdump -s %t.noref.ab.exe | FileCheck %s
+
+# RUN: lld-link /opt:ref /include:leader /dll /noentry /nodefaultlib \
+# RUN:   %t.b.obj %t.a.obj /out:%t.ref.ba.exe
+# RUN: llvm-objdump -s %t.ref.ba.exe | FileCheck %s
+
+# RUN: lld-link /opt:noref /include:leader /dll /noentry /nodefaultlib \
+# RUN:   %t.b.obj %t.a.obj /out:%t.noref.ba.exe
+# RUN: llvm-objdump -s %t.noref.ba.exe | FileCheck %s
+
+# CHECK: Contents of section .text:
+# CHECK-NEXT: {{[0-9a-f]+}} {{(aaaaaaaa 11111111|bbbbbbbb 22222222)}}
+# CHECK-NOT: aaaaaaaa 22222222
+# CHECK-NOT: bbbbbbbb 11111111
+
+#--- a.s
+        .section .text$assoc, "xr", associative, leader
+        .long 0xaaaaaaaa
+
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .long 0x11111111
+
+#--- b.s
+        .section .text$assoc, "xr", associative, leader
+        .long 0xbbbbbbbb
+
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .long 0x22222222

--- a/lld/test/COFF/comdat-selection-largest-gc.s
+++ b/lld/test/COFF/comdat-selection-largest-gc.s
@@ -1,0 +1,61 @@
+# REQUIRES: x86
+
+# A reference to the COMDAT leader must resolve to the final largest candidate.
+# A superseded group must not be resurrected by section GC or interact
+# incorrectly with ICF.
+
+# RUN: split-file %s %t.dir
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/small.s -o %t.small.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/large.s -o %t.large.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/root.s -o %t.root.obj
+
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.large.obj %t.root.obj /out:%t.ref.exe
+# RUN: llvm-objdump -s %t.ref.exe | FileCheck %s
+
+# RUN: lld-link /opt:noref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.large.obj %t.root.obj /out:%t.noref.exe
+# RUN: llvm-objdump -s %t.noref.exe | FileCheck %s
+
+# RUN: lld-link /opt:ref /opt:icf /entry:entry /subsystem:console \
+# RUN:   /nodefaultlib %t.small.obj %t.large.obj %t.root.obj \
+# RUN:   /out:%t.ref-icf.exe
+# RUN: llvm-objdump -s %t.ref-icf.exe | FileCheck %s
+
+# RUN: lld-link /opt:noref /opt:icf /entry:entry /subsystem:console \
+# RUN:   /nodefaultlib %t.small.obj %t.large.obj %t.root.obj \
+# RUN:   /out:%t.noref-icf.exe
+# RUN: llvm-objdump -s %t.noref-icf.exe | FileCheck %s
+
+# CHECK: Contents of section .text:
+# CHECK-NEXT:  140001000 bbbbbbbb 44444444
+# CHECK-NOT: aaaaaaaa
+# CHECK-NOT: 11111111
+
+#--- small.s
+        .section .text$assoc, "xr", associative, leader
+        .long 0xaaaaaaaa
+
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .byte 0x11
+
+#--- large.s
+        .section .text$assoc, "xr", associative, leader
+        .long 0xbbbbbbbb
+
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .long 0x44444444
+
+#--- root.s
+        .section .text$root, "xr"
+        .globl entry
+entry:
+        leaq leader(%rip), %rax
+        retq

--- a/lld/test/COFF/comdat-selection-largest-hybmp.s
+++ b/lld/test/COFF/comdat-selection-largest-hybmp.s
@@ -1,0 +1,75 @@
+# REQUIRES: aarch64
+
+# Hybrid-map entries are symbol-table side effects. A map in a losing LARGEST
+# group must never install an entry thunk. Winner+loser in either order is
+# therefore byte-identical to winner alone.
+
+# RUN: split-file %s %t.dir
+# RUN: llvm-mc -triple arm64ec-pc-windows-msvc -filetype=obj \
+# RUN:   %S/Inputs/loadconfig-arm64ec.s -o %t.loadcfg.obj
+# RUN: llvm-mc -triple arm64ec-pc-windows-msvc -filetype=obj \
+# RUN:   %t.dir/func.s -o %t.func.obj
+# RUN: llvm-mc -triple arm64ec-pc-windows-msvc -filetype=obj \
+# RUN:   %t.dir/small.s -o %t.small.obj
+# RUN: llvm-mc -triple arm64ec-pc-windows-msvc -filetype=obj \
+# RUN:   %t.dir/large.s -o %t.large.obj
+
+# RUN: lld-link /machine:arm64ec /dll /noentry /nodefaultlib /opt:ref \
+# RUN:   /timestamp:0 \
+# RUN:   /include:func %t.loadcfg.obj %t.func.obj %t.large.obj \
+# RUN:   /out:%t.winner.dll
+# RUN: lld-link /machine:arm64ec /dll /noentry /nodefaultlib /opt:ref \
+# RUN:   /timestamp:0 \
+# RUN:   /include:func %t.loadcfg.obj %t.func.obj %t.small.obj %t.large.obj \
+# RUN:   /out:%t.small-first.dll
+# RUN: lld-link /machine:arm64ec /dll /noentry /nodefaultlib /opt:ref \
+# RUN:   /timestamp:0 \
+# RUN:   /include:func %t.loadcfg.obj %t.func.obj %t.large.obj %t.small.obj \
+# RUN:   /out:%t.large-first.dll
+# RUN: cmp %t.winner.dll %t.small-first.dll
+# RUN: cmp %t.winner.dll %t.large-first.dll
+# RUN: llvm-objdump -d %t.winner.dll | FileCheck %s
+
+# CHECK: mov w0, #0x2
+# CHECK-NOT: mov w0, #0x1
+
+#--- func.s
+        .section .text$func,"xr",discard,func
+        .globl func
+        .p2align 2
+func:
+        mov w0, #0
+        ret
+
+#--- small.s
+        .section .wowthk$small,"xr",discard,bad_thunk
+        .globl bad_thunk
+        .p2align 2
+bad_thunk:
+        mov w0, #1
+        ret
+
+        .section .hybmp$x,"yi",largest,hybmp_group
+        .globl hybmp_group
+hybmp_group:
+        .symidx func
+        .symidx bad_thunk
+        .word 1
+
+#--- large.s
+        .section .wowthk$large,"xr",discard,good_thunk
+        .globl good_thunk
+        .p2align 2
+good_thunk:
+        mov w0, #2
+        ret
+
+        .section .hybmp$x,"yi",largest,hybmp_group
+        .globl hybmp_group
+hybmp_group:
+        .symidx func
+        .symidx good_thunk
+        .word 1
+        .symidx func
+        .symidx func
+        .word 0

--- a/lld/test/COFF/comdat-selection-largest-late-mingw.s
+++ b/lld/test/COFF/comdat-selection-largest-late-mingw.s
@@ -1,0 +1,243 @@
+# REQUIRES: x86
+
+# A stdcall fixup can extract an archive member after the first deferred-COMDAT
+# fixed point. Providers hidden by the provisional winner must remain available
+# when that late member replaces the winner.
+
+# RUN: split-file %s %t.dir
+# RUN: llvm-mc -triple i386-windows-gnu -filetype=obj %t.dir/weak.s \
+# RUN:   -o %t.weak.obj
+# RUN: llvm-mc -triple i386-windows-gnu -filetype=obj %t.dir/small.s \
+# RUN:   -o %t.small.obj
+# RUN: llvm-mc -triple i386-windows-gnu -filetype=obj %t.dir/small-ref.s \
+# RUN:   -o %t.small-ref.obj
+# RUN: llvm-mc -triple i386-windows-gnu -filetype=obj %t.dir/late.s \
+# RUN:   -o %t.late.obj
+# RUN: llvm-mc -triple i386-windows-gnu -filetype=obj %t.dir/foo.s \
+# RUN:   -o %t.foo.obj
+# RUN: llvm-mc -triple i386-windows-gnu -filetype=obj %t.dir/root-auto.s \
+# RUN:   -o %t.root-auto.obj
+# RUN: llvm-mc -triple i386-windows-gnu -filetype=obj %t.dir/small-auto.s \
+# RUN:   -o %t.small-auto.obj
+# RUN: llvm-mc -triple i386-windows-gnu -filetype=obj %t.dir/permanent.s \
+# RUN:   -o %t.permanent.obj
+# RUN: llvm-mc -triple i386-windows-gnu -filetype=obj %t.dir/small-dup.s \
+# RUN:   -o %t.small-dup.obj
+# RUN: llvm-mc -triple i386-windows-gnu -filetype=obj %t.dir/stdcall-loser.s \
+# RUN:   -o %t.stdcall-loser.obj
+# RUN: llvm-mc -triple i386-windows-gnu -filetype=obj %t.dir/stdcall-winner.s \
+# RUN:   -o %t.stdcall-winner.obj
+# RUN: llvm-mc -triple i386-windows-gnu -filetype=obj %t.dir/stdcall-foo.s \
+# RUN:   -o %t.stdcall-foo.obj
+# RUN: llvm-mc -triple i386-windows-gnu -filetype=obj %t.dir/leak-small.s \
+# RUN:   -o %t.leak-small.obj
+# RUN: llvm-mc -triple i386-windows-gnu -filetype=obj %t.dir/leak-late.s \
+# RUN:   -o %t.leak-late.obj
+# RUN: llvm-mc -triple i386-windows-gnu -filetype=obj \
+# RUN:   %t.dir/auto-leak-small.s -o %t.auto-leak-small.obj
+# RUN: llvm-mc -triple i386-windows-gnu -filetype=obj \
+# RUN:   %t.dir/auto-leak-late.s -o %t.auto-leak-late.obj
+# RUN: llvm-lib -machine:x86 -out:%t.late.lib %t.late.obj
+# RUN: llvm-lib -machine:x86 -out:%t.foo.lib %t.foo.obj
+# RUN: llvm-lib -machine:x86 -out:%t.stdcall-foo.lib %t.stdcall-foo.obj
+# RUN: llvm-lib -machine:x86 -out:%t.leak-late.lib %t.leak-late.obj
+# RUN: llvm-lib -machine:x86 -out:%t.auto-leak-late.lib \
+# RUN:   %t.auto-leak-late.obj
+# RUN: llvm-dlltool -m i386 -d %t.dir/provider.def -l %t.provider.lib
+# RUN: lld-link /lldmingw /stdcall-fixup /safeseh:no /nodefaultlib /opt:noref \
+# RUN:   /entry:entry %t.weak.obj %t.small.obj %t.late.lib /out:%t.exe
+# RUN: llvm-objdump -s %t.exe | FileCheck %s
+# RUN: lld-link /lldmingw /stdcall-fixup /safeseh:no /nodefaultlib /opt:noref \
+# RUN:   /entry:entry %t.weak.obj %t.small-ref.obj %t.foo.lib %t.late.lib \
+# RUN:   /out:%t.no-extract.exe
+# RUN: llvm-objdump -s %t.no-extract.exe | \
+# RUN:   FileCheck %s --check-prefix=NOT-EXTRACTED
+# RUN: lld-link /lldmingw /stdcall-fixup /safeseh:no /nodefaultlib /opt:noref \
+# RUN:   /entry:entry %t.root-auto.obj %t.small-auto.obj %t.late.lib \
+# RUN:   %t.provider.lib /out:%t.no-autoimport.exe
+# RUN: llvm-readobj --coff-imports %t.no-autoimport.exe | \
+# RUN:   FileCheck %s --check-prefix=NO-AUTOIMPORT
+# RUN: llvm-readobj --coff-exports %t.no-autoimport.exe | \
+# RUN:   FileCheck %s --check-prefix=NO-AUTOEXPORT
+# RUN: lld-link /lldmingw /stdcall-fixup /safeseh:no /nodefaultlib /opt:noref \
+# RUN:   /entry:entry %t.root-auto.obj %t.permanent.obj %t.small-dup.obj \
+# RUN:   %t.late.lib /out:%t.no-duplicate.exe 2>&1 | \
+# RUN:   FileCheck %s --allow-empty --check-prefix=NO-DUPLICATE
+# RUN: lld-link /lldmingw /stdcall-fixup /safeseh:no /nodefaultlib /opt:noref \
+# RUN:   /entry:entry %t.root-auto.obj %t.stdcall-loser.obj \
+# RUN:   %t.stdcall-winner.obj %t.stdcall-foo.lib \
+# RUN:   /out:%t.no-loser-stdcall.exe
+# RUN: llvm-objdump -s %t.no-loser-stdcall.exe | \
+# RUN:   FileCheck %s --check-prefix=NO-LOSER-STDCALL
+# RUN: lld-link /lldmingw /stdcall-fixup /safeseh:no /nodefaultlib /opt:noref \
+# RUN:   /entry:entry %t.root-auto.obj %t.leak-small.obj %t.leak-late.lib \
+# RUN:   /out:%t.no-provisional-reference.exe
+# RUN: lld-link /lldmingw /auto-import /safeseh:no /nodefaultlib /opt:noref \
+# RUN:   /entry:entry %t.root-auto.obj %t.auto-leak-small.obj \
+# RUN:   %t.auto-leak-late.lib /out:%t.no-provisional-autoimport.exe
+
+# CHECK: Contents of section .text:
+# CHECK: 77777777
+# CHECK: 44444444
+# CHECK-NOT: 11111111
+# NOT-EXTRACTED-NOT: aaaaaaaa
+# NO-AUTOIMPORT-NOT: Import {
+# NO-AUTOEXPORT-NOT: Name: only_auto_small
+# NO-DUPLICATE-NOT: duplicate symbol: duplicate
+# NO-LOSER-STDCALL-NOT: abababab
+
+#--- weak.s
+        .text
+        .globl fallback
+fallback:
+        .long 0x77777777
+
+        .weak victim
+        victim = fallback
+
+        .globl _entry
+_entry:
+        movl victim, %eax
+        movl leader, %eax
+        calll "_trigger@0"
+        retl
+
+#--- small.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .space 8, 0x11
+        .globl victim
+victim:
+        .long 0x11111111
+
+#--- late.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .space 32, 0x44
+
+        .text
+        .globl _trigger
+_trigger:
+        retl
+
+# Automatic import must likewise be able to load a larger candidate without
+# publishing unrelated references from the provisional group.
+#--- auto-leak-small.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .long _missing_auto
+        .long _variable_auto
+
+#--- auto-leak-late.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .space 32, 0x77
+
+        .data
+        .globl __imp__variable_auto
+__imp__variable_auto:
+        .long 0
+
+#--- small-ref.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .long foo
+        .long 0x11111111
+        .globl victim
+victim:
+        .long 0x11111111
+
+#--- foo.s
+        .text
+        .globl foo
+foo:
+        .long 0xaaaaaaaa
+
+#--- root-auto.s
+        .text
+        .globl _entry
+_entry:
+        movl leader, %eax
+        retl
+
+#--- small-auto.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        movl _variable, %eax
+        calll "_trigger@0"
+        retl
+        .globl only_auto_small
+only_auto_small:
+        retl
+
+#--- permanent.s
+        .data
+        .globl duplicate
+duplicate:
+        .long 0x22222222
+
+#--- small-dup.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        calll "_trigger@0"
+        retl
+        .globl duplicate
+duplicate:
+        .long 0x11111111
+
+#--- provider.def
+LIBRARY provider.dll
+EXPORTS
+variable DATA
+
+#--- stdcall-loser.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        calll "_foo@0"
+        retl
+
+#--- stdcall-winner.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .space 32, 0x55
+
+#--- stdcall-foo.s
+        .text
+        .globl _foo
+_foo:
+        .long 0xabababab
+        retl
+
+# A stdcall fixup for _trigger@0 loads leak-late.obj and supersedes this
+# group. The other fixup must not make _missing@0 a permanent reference; its
+# undecorated secondary definition disappears with this provisional winner.
+#--- leak-small.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        calll "_missing@0"
+        calll "_trigger@0"
+        retl
+        .globl _missing
+_missing:
+        retl
+
+#--- leak-late.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .space 32, 0x66
+
+        .text
+        .globl _trigger
+_trigger:
+        retl

--- a/lld/test/COFF/comdat-selection-largest-lazy-provider.s
+++ b/lld/test/COFF/comdat-selection-largest-lazy-provider.s
@@ -1,0 +1,210 @@
+# REQUIRES: x86
+
+# Test that a regular definition from a lazily scanned archive can replace a
+# non-leader symbol from a superseded IMAGE_COMDAT_SELECT_LARGEST group.
+#
+# The primary regression case scans provider.lib after the smaller group has
+# been discarded but before a real undefined reference to foo_lazy appears.
+# The discarded definition must not prevent registration and later extraction
+# of the lazy archive member.
+
+# RUN: split-file %s %t.dir
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/small.s -o %t.small.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/large.s -o %t.large.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/large-with-symbol.s -o %t.large-with-symbol.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/provider.s -o %t.provider.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/root.s -o %t.root.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/entry-only.s -o %t.entry-only.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/provider-dll.s -o %t.provider-dll.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/root-dll.s -o %t.root-dll.obj
+# RUN: llvm-lib -machine:amd64 -out:%t.provider.lib %t.provider.obj
+# RUN: lld-link /dll /noentry /nodefaultlib /export:foo_lazy \
+# RUN:   %t.provider-dll.obj /out:%t.provider-dll.dll
+
+# Archive scanned before the undefined reference: regression case.
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.large.obj %t.provider.lib %t.root.obj \
+# RUN:   /map:%t.archive-first.map /out:%t.archive-first.exe
+# RUN: llvm-objdump -s %t.archive-first.exe | FileCheck --check-prefix=IMAGE %s
+# RUN: FileCheck --check-prefix=MAP %s < %t.archive-first.map
+
+# Preserve an archive provider seen while the smaller group still prevails.
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.provider.lib %t.large.obj %t.root.obj \
+# RUN:   /map:%t.archive-between.map /out:%t.archive-between.exe
+# RUN: llvm-objdump -s %t.archive-between.exe | \
+# RUN:   FileCheck --check-prefix=IMAGE %s
+# RUN: FileCheck --check-prefix=MAP %s < %t.archive-between.map
+
+# Merely deferring a provider between candidates must not extract it without a
+# real reference.
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.provider.lib %t.large.obj %t.entry-only.obj \
+# RUN:   /out:%t.unreferenced-between.exe
+# RUN: llvm-objdump -s %t.unreferenced-between.exe | \
+# RUN:   FileCheck --check-prefix=UNREFERENCED %s
+
+# Do not extract the deferred provider if the replacing group defines the
+# symbol itself.
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.provider.lib %t.large-with-symbol.obj %t.root.obj \
+# RUN:   /out:%t.redefined-by-larger.exe
+# RUN: llvm-objdump -s %t.redefined-by-larger.exe | \
+# RUN:   FileCheck --check-prefix=REDEFINED %s
+
+# Without a real reference, scanning the archive must register the lazy
+# provider without extracting its member.
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.large.obj %t.provider.lib %t.entry-only.obj \
+# RUN:   /out:%t.unreferenced.exe
+# RUN: llvm-objdump -s %t.unreferenced.exe | \
+# RUN:   FileCheck --check-prefix=UNREFERENCED %s
+
+# Undefined reference seen before the archive: control case.
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.large.obj %t.root.obj %t.provider.lib \
+# RUN:   /map:%t.reference-first.map /out:%t.reference-first.exe
+# RUN: llvm-objdump -s %t.reference-first.exe | \
+# RUN:   FileCheck --check-prefix=IMAGE %s
+# RUN: FileCheck --check-prefix=MAP %s < %t.reference-first.map
+
+# A /start-lib object follows the LazyObject path rather than LazyArchive.
+
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj /start-lib %t.provider.obj /end-lib %t.large.obj \
+# RUN:   %t.root.obj /map:%t.start-lib-between.map \
+# RUN:   /out:%t.start-lib-between.exe
+# RUN: llvm-objdump -s %t.start-lib-between.exe | \
+# RUN:   FileCheck --check-prefix=IMAGE %s
+# RUN: FileCheck --check-prefix=MAP %s < %t.start-lib-between.map
+
+# A /start-lib provider registered before the provisional group must also be
+# restored after replacement.
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   /start-lib %t.provider.obj /end-lib %t.small.obj %t.large.obj \
+# RUN:   %t.root.obj /map:%t.start-lib-before.map \
+# RUN:   /out:%t.start-lib-before.exe
+# RUN: FileCheck --check-prefix=MAP %s < %t.start-lib-before.map
+
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.large.obj \
+# RUN:   /start-lib %t.provider.obj /end-lib %t.root.obj \
+# RUN:   /map:%t.start-lib-first.map /out:%t.start-lib-first.exe
+# RUN: llvm-objdump -s %t.start-lib-first.exe | \
+# RUN:   FileCheck --check-prefix=IMAGE %s
+# RUN: FileCheck --check-prefix=MAP %s < %t.start-lib-first.map
+
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.large.obj %t.root.obj \
+# RUN:   /start-lib %t.provider.obj /end-lib \
+# RUN:   /map:%t.start-lib-reference-first.map \
+# RUN:   /out:%t.start-lib-reference-first.exe
+# RUN: llvm-objdump -s %t.start-lib-reference-first.exe | \
+# RUN:   FileCheck --check-prefix=IMAGE %s
+# RUN: FileCheck --check-prefix=MAP %s < %t.start-lib-reference-first.map
+
+# A directly loaded DLL follows the MinGW-only LazyDLLSymbol path.
+
+# RUN: lld-link /lldmingw /auto-import:no /opt:ref /entry:entry \
+# RUN:   /subsystem:console /nodefaultlib %t.small.obj %t.provider-dll.dll \
+# RUN:   %t.large.obj %t.root-dll.obj /out:%t.lazy-dll-between.exe
+# RUN: llvm-readobj --coff-imports %t.lazy-dll-between.exe | \
+# RUN:   FileCheck --check-prefix=DLL %s
+
+# Preserve a LazyDLLSymbol registered before the provisional definition.
+# RUN: lld-link /lldmingw /auto-import:no /opt:ref /entry:entry \
+# RUN:   /subsystem:console /nodefaultlib %t.provider-dll.dll %t.small.obj \
+# RUN:   %t.large.obj %t.root-dll.obj /out:%t.lazy-dll-before.exe
+# RUN: llvm-readobj --coff-imports %t.lazy-dll-before.exe | \
+# RUN:   FileCheck --check-prefix=DLL %s
+
+# RUN: lld-link /lldmingw /auto-import:no /opt:ref /entry:entry \
+# RUN:   /subsystem:console /nodefaultlib %t.small.obj %t.large.obj \
+# RUN:   %t.provider-dll.dll %t.root-dll.obj /out:%t.lazy-dll.exe
+# RUN: llvm-readobj --coff-imports %t.lazy-dll.exe | \
+# RUN:   FileCheck --check-prefix=DLL %s
+
+# Eager extraction proves the provider itself is valid.
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.large.obj /wholearchive:%t.provider.lib %t.root.obj \
+# RUN:   /map:%t.wholearchive.map /out:%t.wholearchive.exe
+# RUN: llvm-objdump -s %t.wholearchive.exe | FileCheck --check-prefix=IMAGE %s
+# RUN: FileCheck --check-prefix=MAP %s < %t.wholearchive.map
+
+# IMAGE: Contents of section .rdata:
+# IMAGE: 55555555
+
+# MAP: foo_lazy{{.*}}provider.obj
+
+# DLL: Symbol: foo_lazy
+
+# UNREFERENCED-NOT: 55555555
+
+# REDEFINED: 66666666
+# REDEFINED-NOT: 55555555
+
+#--- small.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .byte 0x11
+
+        .globl foo_lazy
+foo_lazy:
+        .byte 0x22
+
+#--- large.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .space 32, 0x44
+
+#--- large-with-symbol.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .space 32, 0x44
+
+        .globl foo_lazy
+foo_lazy:
+        .long 0x66666666
+
+#--- provider.s
+        .section .rdata$provider, "dr"
+        .globl foo_lazy
+foo_lazy:
+        .long 0x55555555
+
+#--- root.s
+        .section .text$root, "xr"
+        .globl entry
+entry:
+        movl foo_lazy(%rip), %eax
+        retq
+
+#--- entry-only.s
+        .text
+        .globl entry
+entry:
+        retq
+
+#--- provider-dll.s
+        .text
+        .globl foo_lazy
+foo_lazy:
+        retq
+
+#--- root-dll.s
+        .text
+        .globl entry
+entry:
+        callq foo_lazy
+        retq

--- a/lld/test/COFF/comdat-selection-largest-lto.ll
+++ b/lld/test/COFF/comdat-selection-largest-lto.ll
@@ -1,0 +1,243 @@
+; REQUIRES: x86
+
+; Verify that definitions which disappear with a non-prevailing COMDAT are
+; not mistaken for undefined references by the pre-LTO unresolved-symbol pass.
+
+; RUN: split-file %s %t.dir
+; RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+; RUN:   %t.dir/small.s -o %t.small.obj
+; RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+; RUN:   %t.dir/large.s -o %t.large.obj
+; RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+; RUN:   %t.dir/root.s -o %t.root.obj
+; RUN: llvm-as %t.dir/dummy.ll -o %t.dummy.obj
+; RUN: llvm-as %t.dir/losing-comdat.ll -o %t.losing-comdat.obj
+; RUN: llvm-as %t.dir/undefined.ll -o %t.undefined.obj
+; RUN: llvm-as %t.dir/weak-provider.ll -o %t.weak-provider.obj
+; RUN: llvm-as %t.dir/strong-provider.ll -o %t.strong-provider.obj
+; RUN: llvm-as %t.dir/common-provider.ll -o %t.common-provider.obj
+; RUN: llvm-as %t.dir/deferred-comdat-provider.ll \
+; RUN:   -o %t.deferred-comdat-provider.obj
+; RUN: llvm-as %t.dir/mixed-leader.ll -o %t.mixed-leader.obj
+; RUN: llvm-as %t.dir/mixed-child.ll -o %t.mixed-child.obj
+; RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+; RUN:   %t.dir/mixed-native.s -o %t.mixed-native.obj
+; RUN: opt -module-summary %t.dir/weak-provider.ll -o %t.weak-provider-thin.obj
+
+; A native candidate which loses before it is read leaves a non-reference
+; Undefined placeholder for its secondary symbols. The presence of unrelated
+; bitcode must not turn that placeholder into a pre-LTO error.
+; RUN: lld-link /dll /noentry /nodefaultlib /include:leader %t.large.obj \
+; RUN:   %t.small.obj %t.dummy.obj /out:%t.native-loser.dll
+; RUN: llvm-objdump -s %t.native-loser.dll | \
+; RUN:   FileCheck --check-prefix=IMAGE --implicit-check-not=11111111 %s
+
+; Replacing an already prevailing native candidate creates the same kind of
+; non-reference placeholder for symbols unique to the old group.
+; RUN: lld-link /dll /noentry /nodefaultlib /include:leader %t.small.obj \
+; RUN:   %t.large.obj %t.dummy.obj /out:%t.native-replaced.dll
+; RUN: llvm-objdump -s %t.native-replaced.dll | \
+; RUN:   FileCheck --check-prefix=IMAGE --implicit-check-not=11111111 %s
+
+; A weak bitcode definition suppressed by the smaller native group remains a
+; valid provider if that group is later superseded.
+; RUN: lld-link /dll /noentry /nodefaultlib /include:only_small \
+; RUN:   %t.small.obj %t.weak-provider.obj %t.large.obj \
+; RUN:   /out:%t.weak-provider.dll
+
+; Bitcode providers registered before the provisional native definition are
+; retained as well, for both weak and strong definitions.
+; RUN: lld-link /dll /noentry /nodefaultlib /include:only_small \
+; RUN:   %t.weak-provider.obj %t.small.obj %t.large.obj \
+; RUN:   /out:%t.weak-provider-before.dll
+; RUN: lld-link /dll /noentry /nodefaultlib /include:only_small \
+; RUN:   %t.strong-provider.obj %t.small.obj %t.large.obj \
+; RUN:   /out:%t.strong-provider-before.dll
+; RUN: llvm-objdump --no-print-imm-hex -d %t.strong-provider-before.dll | \
+; RUN:   FileCheck --check-prefix=STRONG %s
+
+; A normal relocation from a regular object must retain and select a weak
+; ThinLTO provider; /include is not required to make the reference visible.
+; RUN: lld-link /entry:entry /subsystem:console /nodefaultlib \
+; RUN:   %t.small.obj %t.weak-provider-thin.obj %t.large.obj %t.root.obj \
+; RUN:   /out:%t.weak-provider-thin.exe
+
+; Replaying providers uses normal weak/strong precedence rather than keeping
+; the first DefinedRegular unconditionally.
+; RUN: lld-link /dll /noentry /nodefaultlib /include:only_small \
+; RUN:   %t.small.obj %t.weak-provider.obj %t.strong-provider.obj \
+; RUN:   %t.large.obj /out:%t.strong-provider.dll
+; RUN: llvm-objdump --no-print-imm-hex -d %t.strong-provider.dll | \
+; RUN:   FileCheck --check-prefix=STRONG %s
+
+; Replaying a common provider from bitcode must not try to read a COFF symbol
+; record from the BitcodeFile.
+; RUN: lld-link /dll /noentry /nodefaultlib /include:only_small \
+; RUN:   %t.small.obj %t.common-provider.obj %t.large.obj \
+; RUN:   /out:%t.common-provider.dll
+; RUN: llvm-readobj --sections %t.common-provider.dll | \
+; RUN:   FileCheck --check-prefix=COMMON %s
+
+; Secondary definitions in a deferred bitcode COMDAT follow the eventual
+; selection of their leader. They must neither leak from a rejected group nor
+; disappear from a group selected after the native definition is replaced.
+; RUN: not lld-link /force:multiple /dll /noentry /nodefaultlib \
+; RUN:   /include:bitcode_child %t.small.obj %t.deferred-comdat-provider.obj \
+; RUN:   /out:%t.rejected-bitcode-comdat.dll 2>&1 | \
+; RUN:   FileCheck --check-prefix=BITCODE-REJECTED %s
+; RUN: lld-link /dll /noentry /nodefaultlib /include:only_small \
+; RUN:   /include:bitcode_child \
+; RUN:   %t.small.obj %t.deferred-comdat-provider.obj %t.large.obj \
+; RUN:   /out:%t.selected-bitcode-comdat.dll
+; RUN: llvm-objdump -s %t.selected-bitcode-comdat.dll | \
+; RUN:   FileCheck --check-prefix=BITCODE-SELECTED %s
+
+; A symbol-table slot may contain both a deferred COMDAT leader and a child of
+; another deferred COMDAT. Replay must revisit the slot after the child's
+; parent has been selected, regardless of bitcode input order.
+; RUN: lld-link /force:multiple /dll /noentry /nodefaultlib \
+; RUN:   %t.mixed-native.obj %t.mixed-leader.obj %t.mixed-child.obj \
+; RUN:   /out:%t.mixed-leader-first.dll 2>&1 | FileCheck --check-prefix=MIXED %s
+; RUN: lld-link /force:multiple /dll /noentry /nodefaultlib \
+; RUN:   %t.mixed-native.obj %t.mixed-child.obj %t.mixed-leader.obj \
+; RUN:   /out:%t.mixed-child-first.dll 2>&1 | FileCheck --check-prefix=MIXED %s
+
+; The same rule applies to secondary definitions in a losing bitcode COMDAT.
+; RUN: lld-link /dll /noentry /nodefaultlib /include:leader %t.large.obj \
+; RUN:   %t.losing-comdat.obj /out:%t.bitcode-loser.dll
+; RUN: llvm-objdump -s %t.bitcode-loser.dll | \
+; RUN:   FileCheck --check-prefix=IMAGE %s
+
+; A genuine bitcode undefined reference must still be diagnosed before LTO.
+; RUN: not lld-link /dll /noentry /nodefaultlib %t.large.obj \
+; RUN:   %t.undefined.obj /out:%t.undefined.dll 2>&1 | \
+; RUN:   FileCheck --check-prefix=UNDEFINED %s
+
+; IMAGE: Contents of section .text:
+; IMAGE: 44444444
+
+; UNDEFINED: error: undefined symbol: genuinely_missing
+; STRONG: movl $5678, %eax
+; COMMON: Name: .data
+; COMMON: VirtualSize: 0x4
+; BITCODE-REJECTED: undefined symbol: bitcode_child
+; BITCODE-SELECTED: 78563412
+; MIXED-DAG: warning: duplicate symbol: mixed_parent
+; MIXED-DAG: warning: duplicate symbol: mixed_role
+
+;--- small.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .byte 0x11
+
+        .globl only_small
+only_small:
+        .byte 0x11
+
+;--- large.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .long 0x44444444
+
+;--- dummy.ll
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-windows-msvc"
+
+define void @dummy() {
+  ret void
+}
+
+;--- root.s
+        .text
+        .globl entry
+entry:
+        callq only_small
+        retq
+
+;--- losing-comdat.ll
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-windows-msvc"
+
+$leader = comdat any
+
+define linkonce_odr void @leader() comdat {
+  ret void
+}
+
+define linkonce_odr void @only_bitcode() comdat($leader) {
+  ret void
+}
+
+;--- undefined.ll
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-windows-msvc"
+
+define void @references_missing() {
+  call void @genuinely_missing()
+  ret void
+}
+
+declare void @genuinely_missing()
+
+;--- weak-provider.ll
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-windows-msvc"
+
+define weak i32 @only_small() {
+  ret i32 1234
+}
+
+;--- strong-provider.ll
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-windows-msvc"
+
+define i32 @only_small() {
+  ret i32 5678
+}
+
+;--- common-provider.ll
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-windows-msvc"
+
+@only_small = common global i32 0, align 4
+
+;--- deferred-comdat-provider.ll
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-windows-msvc"
+
+$only_small = comdat largest
+; Keep the child before the leader: IR symbol order is independent of COMDAT
+; membership, so deferred-group tracking must not rely on seeing the leader.
+@bitcode_child = global i32 305419896, comdat($only_small)
+@only_small = global [8 x i8] zeroinitializer, comdat($only_small)
+
+;--- mixed-native.s
+        .section .data$largest, "dw", largest, native_leader
+        .globl native_leader
+native_leader:
+        .byte 0
+
+        .globl mixed_role
+mixed_role:
+        .byte 0
+
+        .globl mixed_parent
+mixed_parent:
+        .byte 0
+
+;--- mixed-leader.ll
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-windows-msvc"
+
+$mixed_role = comdat largest
+@mixed_role = global [8 x i8] zeroinitializer, comdat
+
+;--- mixed-child.ll
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-windows-msvc"
+
+$mixed_parent = comdat largest
+@mixed_role = global i32 42, comdat($mixed_parent)
+@mixed_parent = global [8 x i8] zeroinitializer, comdat

--- a/lld/test/COFF/comdat-selection-largest-malformed-indices.test
+++ b/lld/test/COFF/comdat-selection-largest-malformed-indices.test
@@ -1,0 +1,174 @@
+# REQUIRES: aarch64, x86
+#
+# Malformed indices that participate in COMDAT/weak-external bookkeeping must
+# be diagnosed before vector indexing or use of an auxiliary record as Symbol.
+#
+# RUN: split-file %s %t.dir
+# RUN: yaml2obj %t.dir/assoc-oob.yaml -o %t.assoc-oob.obj
+# RUN: yaml2obj %t.dir/weak-oob.yaml -o %t.weak-oob.obj
+# RUN: yaml2obj %t.dir/weak-aux.yaml -o %t.weak-aux.obj
+# RUN: yaml2obj %t.dir/weak-antidep-aux.yaml -o %t.weak-antidep-aux.obj
+#
+# RUN: not lld-link /dll /noentry /nodefaultlib %t.assoc-oob.obj \
+# RUN:   /out:%t.assoc-oob.dll 2>&1 | FileCheck %s --check-prefix=ASSOC
+# RUN: not lld-link /dll /noentry /nodefaultlib /include:bad_weak \
+# RUN:   %t.weak-oob.obj /out:%t.weak-oob.dll 2> %t.weak-oob.err
+# RUN: FileCheck %s --check-prefix=WEAK-OOB < %t.weak-oob.err
+# RUN: not lld-link /dll /noentry /nodefaultlib %t.weak-aux.obj \
+# RUN:   /out:%t.weak-aux.dll 2>&1 | FileCheck %s --check-prefix=WEAK-AUX
+# RUN: not lld-link /dll /noentry /nodefaultlib %t.weak-antidep-aux.obj \
+# RUN:   /out:%t.weak-antidep-aux.dll 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=WEAK-ANTIDEP-AUX
+#
+# ASSOC: error: {{.*}}: associative comdat .text$assoc (sec 1)
+# ASSOC-SAME: has invalid reference to section index 99
+# ASSOC-NOT: PLEASE submit a bug report
+# WEAK-OOB: error: {{.*}}: weak external has invalid target symbol index 65535
+# WEAK-OOB-NOT: PLEASE submit a bug report
+# WEAK-AUX: error: {{.*}}: weak external has invalid target symbol index 1
+# WEAK-AUX-NOT: PLEASE submit a bug report
+# WEAK-ANTIDEP-AUX: error: {{.*}}: weak external has invalid target symbol
+# WEAK-ANTIDEP-AUX-SAME: index 1
+# WEAK-ANTIDEP-AUX-NOT: PLEASE submit a bug report
+#
+#--- assoc-oob.yaml
+--- !COFF
+header:
+  Machine: IMAGE_FILE_MACHINE_AMD64
+  Characteristics: [ ]
+sections:
+  - Name: '.text$assoc'
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_LNK_COMDAT,
+                       IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_READ ]
+    Alignment: 1
+    SectionData: 'C3'
+symbols:
+  - Name: '.text$assoc'
+    Value: 0
+    SectionNumber: 1
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length: 1
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum: 0
+      Number: 99
+      Selection: IMAGE_COMDAT_SELECT_ASSOCIATIVE
+...
+#
+#--- weak-oob.yaml
+--- !COFF
+header:
+  Machine: IMAGE_FILE_MACHINE_AMD64
+  Characteristics: [ ]
+sections:
+  - Name: .text
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE,
+                       IMAGE_SCN_MEM_READ ]
+    Alignment: 1
+    SectionData: '00000000'
+    Relocations:
+      - VirtualAddress: 0
+        SymbolName: bad_weak
+        Type: IMAGE_REL_AMD64_ADDR32
+symbols:
+  # Keep a normal definition before the malformed weak external, matching the
+  # layout produced for real COFF weak aliases. This also makes the object
+  # independently useful even before bad_weak is resolved.
+  - Name: fallback
+    Value: 0
+    SectionNumber: 1
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_FUNCTION
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+  - Name: bad_weak
+    Value: 0
+    SectionNumber: 0
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_FUNCTION
+    StorageClass: IMAGE_SYM_CLASS_WEAK_EXTERNAL
+    WeakExternal:
+      TagIndex: 65535
+      Characteristics: IMAGE_WEAK_EXTERN_SEARCH_NOLIBRARY
+...
+#
+#--- weak-aux.yaml
+--- !COFF
+header:
+  Machine: IMAGE_FILE_MACHINE_AMD64
+  Characteristics: [ ]
+sections:
+  - Name: '.text$largest'
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_LNK_COMDAT,
+                       IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_READ ]
+    Alignment: 1
+    SectionData: 'C3'
+symbols:
+  # raw 0; its section-definition auxiliary record is raw 1
+  - Name: '.text$largest'
+    Value: 0
+    SectionNumber: 1
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length: 1
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum: 0
+      Number: 1
+      Selection: IMAGE_COMDAT_SELECT_LARGEST
+  - Name: leader
+    Value: 0
+    SectionNumber: 1
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+  - Name: bad_weak
+    Value: 0
+    SectionNumber: 0
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_WEAK_EXTERNAL
+    WeakExternal:
+      TagIndex: 1
+      Characteristics: IMAGE_WEAK_EXTERN_SEARCH_ALIAS
+...
+#
+#--- weak-antidep-aux.yaml
+--- !COFF
+header:
+  Machine: IMAGE_FILE_MACHINE_ARM64EC
+  Characteristics: [ ]
+sections:
+  - Name: .text
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE,
+                       IMAGE_SCN_MEM_READ ]
+    Alignment: 4
+    SectionData: 'C0035FD6'
+symbols:
+  # raw 0; its section-definition auxiliary record is raw 1
+  - Name: .text
+    Value: 0
+    SectionNumber: 1
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length: 4
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum: 0
+      Number: 0
+  - Name: bad_weak
+    Value: 0
+    SectionNumber: 0
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_FUNCTION
+    StorageClass: IMAGE_SYM_CLASS_WEAK_EXTERNAL
+    WeakExternal:
+      TagIndex: 1
+      Characteristics: IMAGE_WEAK_EXTERN_ANTI_DEPENDENCY
+...

--- a/lld/test/COFF/comdat-selection-largest-malformed-no-leader.test
+++ b/lld/test/COFF/comdat-selection-largest-malformed-no-leader.test
@@ -1,0 +1,68 @@
+# REQUIRES: x86
+#
+# A malformed replaceable COMDAT with a section-definition record but no leader
+# must not leak references from that invalid section. In particular, its
+# relocation must count as a relocation for provenance bookkeeping so the
+# undefined symbol is not misclassified as an "unrelocated" object-level
+# reference and used to extract an archive member.
+#
+# RUN: split-file %s %t.dir
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/provider.s -o %t.provider.obj
+# RUN: llvm-lib -machine:amd64 -out:%t.provider.lib %t.provider.obj
+# RUN: yaml2obj %t.dir/bad.yaml -o %t.bad.obj
+#
+# RUN: lld-link /dll /noentry /nodefaultlib /opt:noref \
+# RUN:   %t.provider.lib %t.bad.obj /out:%t.dll
+# RUN: llvm-objdump -s %t.dll | FileCheck %s
+#
+# CHECK-NOT: bebafeca
+#
+#--- provider.s
+        .section .rdata$provider, "dr"
+        .globl missing_from_bad_comdat
+missing_from_bad_comdat:
+        .long 0x01020304
+        .globl archive_marker
+archive_marker:
+        .long 0xcafebabe
+#
+#--- bad.yaml
+--- !COFF
+header:
+  Machine: IMAGE_FILE_MACHINE_AMD64
+  Characteristics: [ ]
+sections:
+  - Name: '.text$bad'
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_LNK_COMDAT,
+                       IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_READ ]
+    Alignment: 1
+    SectionData: '00000000'
+    Relocations:
+      - VirtualAddress: 0
+        SymbolTableIndex: 2
+        Type: IMAGE_REL_AMD64_ADDR32
+symbols:
+  - Name: '.text$bad'
+    Value: 0
+    SectionNumber: 1
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length: 4
+      NumberOfRelocations: 1
+      NumberOfLinenumbers: 0
+      CheckSum: 0
+      Number: 1
+      Selection: IMAGE_COMDAT_SELECT_LARGEST
+  # There is deliberately no leader symbol for section 1. Raw symbol table
+  # index 1 is the section-definition auxiliary record, so the undefined below
+  # is raw index 2 and is the relocation target.
+  - Name: missing_from_bad_comdat
+    Value: 0
+    SectionNumber: 0
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+...

--- a/lld/test/COFF/comdat-selection-largest-malformed-reloc-index.test
+++ b/lld/test/COFF/comdat-selection-largest-malformed-reloc-index.test
@@ -1,0 +1,106 @@
+# REQUIRES: x86
+#
+# Relocations in an object using replaceable-COMDAT provenance tracking must
+# not index outside the symbol table or target an auxiliary-symbol slot. Both
+# forms are malformed input and must be diagnosed without dereferencing a null
+# Symbol pointer.
+#
+# RUN: split-file %s %t.dir
+# RUN: yaml2obj %t.dir/aux.yaml -o %t.aux.obj
+# RUN: yaml2obj %t.dir/oob.yaml -o %t.oob.obj
+#
+# RUN: not lld-link /dll /noentry /nodefaultlib /opt:noref \
+# RUN:   %t.aux.obj /out:%t.aux.dll 2>&1 | FileCheck %s --check-prefix=AUX
+# RUN: not lld-link /dll /noentry /nodefaultlib /opt:noref \
+# RUN:   %t.oob.obj /out:%t.oob.dll 2>&1 | FileCheck %s --check-prefix=OOB
+#
+# AUX: error: {{.*}}: relocation refers to invalid symbol index 1
+# AUX-NOT: PLEASE submit a bug report
+# OOB: error: {{.*}}: relocation refers to invalid symbol index 65535
+# OOB-NOT: PLEASE submit a bug report
+#
+#--- aux.yaml
+--- !COFF
+header:
+  Machine: IMAGE_FILE_MACHINE_AMD64
+  Characteristics: [ ]
+sections:
+  - Name: .text
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE,
+                       IMAGE_SCN_MEM_READ ]
+    Alignment: 1
+    SectionData: '00000000'
+    Relocations:
+      - VirtualAddress: 0
+        SymbolTableIndex: 1
+        Type: IMAGE_REL_AMD64_ADDR32
+  - Name: '.rdata$largest'
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_LNK_COMDAT,
+                       IMAGE_SCN_MEM_READ ]
+    Alignment: 1
+    SectionData: '01020304'
+symbols:
+  # Raw index 0 is this section symbol, and raw index 1 is its auxiliary
+  # section-definition record. The relocation above deliberately targets 1.
+  - Name: '.rdata$largest'
+    Value: 0
+    SectionNumber: 2
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length: 4
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum: 0
+      Number: 2
+      Selection: IMAGE_COMDAT_SELECT_LARGEST
+  - Name: leader
+    Value: 0
+    SectionNumber: 2
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+...
+#
+#--- oob.yaml
+--- !COFF
+header:
+  Machine: IMAGE_FILE_MACHINE_AMD64
+  Characteristics: [ ]
+sections:
+  - Name: .text
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE,
+                       IMAGE_SCN_MEM_READ ]
+    Alignment: 1
+    SectionData: '00000000'
+    Relocations:
+      - VirtualAddress: 0
+        SymbolTableIndex: 65535
+        Type: IMAGE_REL_AMD64_ADDR32
+  - Name: '.rdata$largest'
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_LNK_COMDAT,
+                       IMAGE_SCN_MEM_READ ]
+    Alignment: 1
+    SectionData: '01020304'
+symbols:
+  - Name: '.rdata$largest'
+    Value: 0
+    SectionNumber: 2
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length: 4
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum: 0
+      Number: 2
+      Selection: IMAGE_COMDAT_SELECT_LARGEST
+  - Name: leader
+    Value: 0
+    SectionNumber: 2
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+...

--- a/lld/test/COFF/comdat-selection-largest-metadata.s
+++ b/lld/test/COFF/comdat-selection-largest-metadata.s
@@ -1,0 +1,147 @@
+# REQUIRES: x86
+
+# Verify that metadata/resource children and string-tail-merge candidates obey
+# late LARGEST replacement just like ordinary code and data sections.
+
+# RUN: split-file %s %t.dir
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/meta-small.s -o %t.meta-small.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/meta-large.s -o %t.meta-large.obj
+# RUN: lld-link /dll /noentry /nodefaultlib /include:leader /guard:cf \
+# RUN:   /guard:ehcont %t.meta-small.obj %t.meta-large.obj /out:%t.meta.dll \
+# RUN:   2>&1 | FileCheck %s --allow-empty --check-prefix=NO-ERROR
+# RUN: llvm-objdump -s %t.meta.dll | FileCheck %s --check-prefix=META \
+# RUN:   --implicit-check-not=11111111 --implicit-check-not=aaaaaaaa \
+# RUN:   --implicit-check-not=534d414c
+
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/string-small.s -o %t.string-small.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/string-large.s -o %t.string-large.obj
+# RUN: lld-link /dll /noentry /nodefaultlib '/include:??_C@largest' \
+# RUN:   %t.string-small.obj %t.string-large.obj /out:%t.string.dll
+# RUN: llvm-objdump -s %t.string.dll | FileCheck %s --check-prefix=STRING \
+# RUN:   --implicit-check-not=534d414c
+
+# MinGW implicitly associates .pdata$*, .xdata$* and .eh_frame$* COMDATs with
+# the matching function section. Those children must follow a late LARGEST
+# replacement as well.
+# RUN: llvm-mc -triple x86_64-windows-gnu -filetype=obj \
+# RUN:   %t.dir/mingw-small.s -o %t.mingw-small.obj
+# RUN: llvm-mc -triple x86_64-windows-gnu -filetype=obj \
+# RUN:   %t.dir/mingw-large.s -o %t.mingw-large.obj
+# RUN: lld-link /lldmingw /dll /noentry /nodefaultlib /include:leader \
+# RUN:   %t.mingw-small.obj %t.mingw-large.obj /out:%t.mingw.dll
+# RUN: llvm-objdump -s %t.mingw.dll | FileCheck %s --check-prefix=MINGW \
+# RUN:   --implicit-check-not=11111111 --implicit-check-not=aaaaaaaa \
+# RUN:   --implicit-check-not=534d414c
+
+# NO-ERROR-NOT: error:
+# META: Contents of section .text:
+# META: 44444444
+# META: Contents of section .rdata:
+# META: 55555555
+# META-NOT: Contents of section .rsrc:
+# STRING: Contents of section .rdata:
+# STRING: 4c415247 45522d53 5452494e 4700
+# MINGW: 44444444
+# MINGW: 4752414c
+
+#--- meta-small.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .long 0x11111111
+small_end:
+
+        .section .gfids$y, "dr", associative, leader
+        .symidx leader
+        .section .giats$y, "dr", associative, leader
+        .symidx leader
+        .section .gljmp$y, "dr", associative, leader
+        .symidx leader
+        .section .gehcont$y, "dr", associative, leader
+        .symidx leader
+
+        .section .xdata, "r", associative, leader
+small_unwind:
+        .long 0xaaaaaaaa
+        .section .pdata, "r", associative, leader
+        .rva leader, small_end, small_unwind
+        .section .eh_frame, "r", associative, leader
+        .long 0x534d414c
+        .section .rsrc$01, "dr", associative, leader
+        .long 0x534d414c
+
+#--- meta-large.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .long 0x44444444
+        .space 28, 0x44
+large_end:
+
+        .section .gfids$y, "dr", associative, leader
+        .symidx leader
+        .section .giats$y, "dr", associative, leader
+        .symidx leader
+        .section .gljmp$y, "dr", associative, leader
+        .symidx leader
+        .section .gehcont$y, "dr", associative, leader
+        .symidx leader
+
+        .section .xdata, "r", associative, leader
+large_unwind:
+        .long 0x55555555
+        .section .pdata, "r", associative, leader
+        .rva leader, large_end, large_unwind
+        .section .eh_frame, "r", associative, leader
+        .long 0x4c415247
+
+#--- string-small.s
+        .section .rdata, "dr", largest, "??_C@largest"
+        .globl "??_C@largest"
+"??_C@largest":
+        .asciz "SMALL"
+
+#--- string-large.s
+        .section .rdata, "dr", largest, "??_C@largest"
+        .globl "??_C@largest"
+"??_C@largest":
+        .asciz "LARGER-STRING"
+
+#--- mingw-small.s
+        .section .xdata$leader, "dr"
+        .linkonce discard
+        .long 0xaaaaaaaa
+        .section .pdata$leader, "dr"
+        .linkonce discard
+        .long 0x534d414c
+        .long 0x534d414c
+        .long 0x534d414c
+        .section .eh_frame$leader, "dr"
+        .linkonce discard
+        .long 0x534d414c
+        .section .text$leader, "xr", largest, leader
+        .globl leader
+leader:
+        .long 0x11111111
+
+#--- mingw-large.s
+        .section .xdata$leader, "dr"
+        .linkonce discard
+        .long 0x55555555
+        .section .pdata$leader, "dr"
+        .linkonce discard
+        .long 0x4c415247
+        .long 0x4c415247
+        .long 0x4c415247
+        .section .eh_frame$leader, "dr"
+        .linkonce discard
+        .long 0x4c415247
+        .section .text$leader, "xr", largest, leader
+        .globl leader
+leader:
+        .long 0x44444444
+        .space 28, 0x44

--- a/lld/test/COFF/comdat-selection-largest-provider-kinds.s
+++ b/lld/test/COFF/comdat-selection-largest-provider-kinds.s
@@ -1,0 +1,222 @@
+# REQUIRES: x86
+
+# Test that a non-leader symbol from a superseded
+# IMAGE_COMDAT_SELECT_LARGEST group can be replaced by providers of other
+# symbol kinds.
+#
+# The smaller candidate defines all provider symbols as regular external
+# symbols. The larger candidate supersedes that group without defining them.
+# A subsequent provider must then become the prevailing definition.
+
+# RUN: split-file %s %t.dir
+
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/small.s -o %t.small.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/large.s -o %t.large.obj
+
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/provider-regular.s -o %t.provider-regular.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/provider-comdat.s -o %t.provider-comdat.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/provider-common.s -o %t.provider-common.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/provider-absolute.s -o %t.provider-absolute.obj
+
+# RUN: sed 's/SYMBOL/foo_regular/g' %t.dir/root.s | \
+# RUN:   llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:     -o %t.root-regular.obj
+# RUN: sed 's/SYMBOL/foo_comdat/g' %t.dir/root.s | \
+# RUN:   llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:     -o %t.root-comdat.obj
+# RUN: sed 's/SYMBOL/foo_common/g' %t.dir/root.s | \
+# RUN:   llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:     -o %t.root-common.obj
+# RUN: sed 's/SYMBOL/foo_absolute/g' %t.dir/root.s | \
+# RUN:   llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:     -o %t.root-absolute.obj
+
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/root-synthetic.s -o %t.root-synthetic.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/root-import.s -o %t.root-import.obj
+
+# RUN: llvm-dlltool -m i386:x86-64 -d %t.dir/provider.def \
+# RUN:   -l %t.provider-import.lib
+
+# DefinedRegular control case.
+
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.large.obj %t.provider-regular.obj \
+# RUN:   %t.root-regular.obj /map:%t.regular.map \
+# RUN:   /out:%t.regular.exe
+# RUN: FileCheck --check-prefix=REGULAR %s < %t.regular.map
+
+# Under /force:multiple, retain a regular provider that was ignored while the
+# smaller group prevailed.
+# RUN: lld-link /force:multiple /opt:ref /entry:entry /subsystem:console \
+# RUN:   /nodefaultlib %t.small.obj %t.provider-regular.obj %t.large.obj \
+# RUN:   %t.root-regular.obj /map:%t.regular-between.map \
+# RUN:   /out:%t.regular-between.exe
+# RUN: FileCheck --check-prefix=REGULAR %s < %t.regular-between.map
+
+# A later COMDAT leader must replace the discarded regular provider.
+
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.large.obj %t.provider-comdat.obj \
+# RUN:   %t.root-comdat.obj /map:%t.comdat.map \
+# RUN:   /out:%t.comdat.exe
+# RUN: FileCheck --check-prefix=COMDAT %s < %t.comdat.map
+
+# A common symbol must replace the discarded regular provider.
+
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.large.obj %t.provider-common.obj \
+# RUN:   %t.root-common.obj /map:%t.common.map \
+# RUN:   /out:%t.common.exe
+# RUN: FileCheck --check-prefix=COMMON %s < %t.common.map
+
+# A common provider seen before the larger candidate must remain available if
+# the regular definition that suppressed it is superseded.
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.provider-common.obj %t.large.obj \
+# RUN:   %t.root-common.obj /map:%t.common-between.map \
+# RUN:   /out:%t.common-between.exe
+# RUN: FileCheck --check-prefix=COMMON %s < %t.common-between.map
+
+# An absolute symbol must replace the discarded regular provider.
+
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.large.obj %t.provider-absolute.obj \
+# RUN:   %t.root-absolute.obj /map:%t.absolute.map \
+# RUN:   /out:%t.absolute.exe
+# RUN: FileCheck --check-prefix=ABSOLUTE %s < %t.absolute.map
+
+# The same ordering rule applies to absolute providers.
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.provider-absolute.obj %t.large.obj \
+# RUN:   %t.root-absolute.obj /map:%t.absolute-between.map \
+# RUN:   /out:%t.absolute-between.exe
+# RUN: FileCheck --check-prefix=ABSOLUTE %s < %t.absolute-between.map
+
+# Linker-generated synthetic and absolute symbols must replace discarded
+# regular definitions with the same names. __guard_flags exercises the
+# addAbsolute(StringRef, uint64_t) overload.
+
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.large.obj %t.root-synthetic.obj \
+# RUN:   /map:%t.synthetic.map /out:%t.synthetic.exe
+# RUN: FileCheck --check-prefix=SYNTHETIC %s < %t.synthetic.map
+
+# Force the import-library members to be loaded so that both the import thunk
+# and the __imp_ data symbol encounter the discarded regular providers.
+
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.large.obj \
+# RUN:   /wholearchive:%t.provider-import.lib %t.root-import.obj \
+# RUN:   /map:%t.import.map /out:%t.import.exe
+# RUN: FileCheck --check-prefix=IMPORT %s < %t.import.map
+
+# The map must associate each symbol with the replacement provider.
+
+# REGULAR: foo_regular{{.*}}provider-regular.obj
+# COMDAT: foo_comdat{{.*}}provider-comdat.obj
+# COMMON: foo_common{{.*}}<common>
+# ABSOLUTE: foo_absolute{{.*}}<absolute>
+# SYNTHETIC-DAG: __ImageBase{{.*}}<linker-defined>
+# SYNTHETIC-DAG: __guard_flags{{.*}}<absolute>
+
+# The function import provides both a thunk and an import-address-table symbol.
+
+# IMPORT-DAG: {{[[:space:]]foo_import[[:space:]]}}{{.*}}provider.dll
+# IMPORT-DAG: {{[[:space:]]__imp_foo_import[[:space:]]}}{{.*}}provider.dll
+
+#--- small.s
+        .section .text$largest, "xr", largest, largest_leader
+        .globl largest_leader
+largest_leader:
+        .byte 0x11
+
+        .globl foo_regular
+foo_regular:
+        .byte 0x12
+
+        .globl foo_comdat
+foo_comdat:
+        .byte 0x13
+
+        .globl foo_common
+foo_common:
+        .byte 0x14
+
+        .globl foo_absolute
+foo_absolute:
+        .byte 0x15
+
+        .globl foo_import
+foo_import:
+        .byte 0x16
+
+        .globl __imp_foo_import
+__imp_foo_import:
+        .byte 0x17
+
+        .globl __ImageBase
+__ImageBase:
+        .byte 0x18
+
+        .globl __guard_flags
+__guard_flags:
+        .byte 0x19
+
+#--- large.s
+        .section .text$largest, "xr", largest, largest_leader
+        .globl largest_leader
+largest_leader:
+        .space 32, 0x44
+
+#--- provider-regular.s
+        .section .text$provider, "xr"
+        .globl foo_regular
+foo_regular:
+        .long 0x55555555
+
+#--- provider-comdat.s
+        .section .text$provider, "xr", discard, foo_comdat
+        .globl foo_comdat
+foo_comdat:
+        .long 0x66666666
+
+#--- provider-common.s
+        .comm foo_common, 8, 3
+
+#--- provider-absolute.s
+        .globl foo_absolute
+        .set foo_absolute, 0x1234
+
+#--- root.s
+        .text
+        .globl entry
+entry:
+        movabsq $SYMBOL, %rax
+        retq
+
+#--- root-synthetic.s
+        .text
+        .globl entry
+entry:
+        retq
+
+#--- root-import.s
+        .text
+        .globl entry
+entry:
+        callq foo_import
+        movq __imp_foo_import(%rip), %rax
+        retq
+
+#--- provider.def
+LIBRARY provider.dll
+EXPORTS
+        foo_import

--- a/lld/test/COFF/comdat-selection-largest-replacement-chain.s
+++ b/lld/test/COFF/comdat-selection-largest-replacement-chain.s
@@ -1,0 +1,107 @@
+# REQUIRES: x86
+
+# Test successive IMAGE_COMDAT_SELECT_LARGEST replacements. In the primary
+# order, the small group is replaced by the medium group, which is then
+# replaced by the large group. Secondary symbols and symbols in associative
+# sections must follow the final prevailing candidate.
+
+# RUN: split-file %s %t.dir
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/small.s -o %t.small.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/medium.s -o %t.medium.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/large.s -o %t.large.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/root.s -o %t.root.obj
+
+# Two successive replacements.
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.medium.obj %t.large.obj %t.root.obj \
+# RUN:   /map:%t.ref.sml.map /out:%t.ref.sml.exe
+# RUN: llvm-objdump -s %t.ref.sml.exe | FileCheck --check-prefix=IMAGE \
+# RUN:   --implicit-check-not=11111111 --implicit-check-not=12121212 \
+# RUN:   --implicit-check-not=aaaaaaaa --implicit-check-not=22222222 \
+# RUN:   --implicit-check-not=23232323 --implicit-check-not=bbbbbbbb %s
+# RUN: FileCheck --check-prefix=MAP %s < %t.ref.sml.map
+
+# RUN: lld-link /opt:noref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.medium.obj %t.large.obj %t.root.obj \
+# RUN:   /map:%t.noref.sml.map /out:%t.noref.sml.exe
+# RUN: llvm-objdump -s %t.noref.sml.exe | FileCheck --check-prefix=IMAGE \
+# RUN:   --implicit-check-not=11111111 --implicit-check-not=12121212 \
+# RUN:   --implicit-check-not=aaaaaaaa --implicit-check-not=22222222 \
+# RUN:   --implicit-check-not=23232323 --implicit-check-not=bbbbbbbb %s
+# RUN: FileCheck --check-prefix=MAP %s < %t.noref.sml.map
+
+# Largest candidate first: no later candidate may replace it.
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.large.obj %t.medium.obj %t.small.obj %t.root.obj \
+# RUN:   /map:%t.ref.lms.map /out:%t.ref.lms.exe
+# RUN: llvm-objdump -s %t.ref.lms.exe | FileCheck --check-prefix=IMAGE \
+# RUN:   --implicit-check-not=11111111 --implicit-check-not=12121212 \
+# RUN:   --implicit-check-not=aaaaaaaa --implicit-check-not=22222222 \
+# RUN:   --implicit-check-not=23232323 --implicit-check-not=bbbbbbbb %s
+# RUN: FileCheck --check-prefix=MAP %s < %t.ref.lms.map
+
+# IMAGE-DAG: 44444444
+# IMAGE-DAG: 55555555
+# IMAGE-DAG: cccccccc
+
+# MAP-DAG: leader{{.*}}large.obj
+# MAP-DAG: secondary{{.*}}large.obj
+# MAP-DAG: assoc_public{{.*}}large.obj
+
+#--- small.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .long 0x11111111
+        .globl secondary
+secondary:
+        .long 0x12121212
+
+        .section .rdata$assoc, "dr", associative, leader
+        .globl assoc_public
+assoc_public:
+        .long 0xaaaaaaaa
+
+#--- medium.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .long 0x22222222
+        .long 0x22222223
+        .globl secondary
+secondary:
+        .long 0x23232323
+
+        .section .rdata$assoc, "dr", associative, leader
+        .globl assoc_public
+assoc_public:
+        .long 0xbbbbbbbb
+
+#--- large.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .long 0x44444444
+        .long 0x45454545
+        .long 0x46464646
+        .globl secondary
+secondary:
+        .long 0x55555555
+
+        .section .rdata$assoc, "dr", associative, leader
+        .globl assoc_public
+assoc_public:
+        .long 0xcccccccc
+
+#--- root.s
+        .section .text$root, "xr"
+        .globl entry
+entry:
+        leaq leader(%rip), %rax
+        leaq secondary(%rip), %rcx
+        leaq assoc_public(%rip), %rdx
+        retq

--- a/lld/test/COFF/comdat-selection-largest-replay-cycle.s
+++ b/lld/test/COFF/comdat-selection-largest-replay-cycle.s
@@ -1,0 +1,86 @@
+# REQUIRES: x86
+#
+# Build a ring in which each deferred COMDAT leader name is also published as
+# a secondary definition by another replaceable group. This stresses the
+# cycle/input-order fallback in deferred leader replay. The linker must
+# terminate, drain all deferred providers, and keep each selected group
+# internally consistent in either input order.
+#
+# RUN: split-file %s %t.dir
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/root-small.s -o %t.root-small.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/a.s -o %t.a.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/b.s -o %t.b.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/c.s -o %t.c.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/root-large.s -o %t.root-large.obj
+#
+# RUN: lld-link /force:multiple /dll /noentry /nodefaultlib /opt:noref \
+# RUN:   /include:a /include:b /include:c %t.root-small.obj %t.a.obj \
+# RUN:   %t.b.obj %t.c.obj %t.root-large.obj /out:%t.abc.dll
+# RUN: llvm-objdump -s %t.abc.dll | FileCheck %s
+#
+# RUN: lld-link /force:multiple /dll /noentry /nodefaultlib /opt:noref \
+# RUN:   /include:a /include:b /include:c %t.root-small.obj %t.c.obj \
+# RUN:   %t.b.obj %t.a.obj %t.root-large.obj /out:%t.cba.dll
+# RUN: llvm-objdump -s %t.cba.dll | FileCheck %s
+#
+# CHECK: Contents of section .data:
+# CHECK-DAG: aaaaaaaa
+# CHECK-DAG: bbbbbbbb
+# CHECK-DAG: cccccccc
+# CHECK-NOT: 11111111
+# CHECK-NOT: 22222222
+# CHECK-NOT: 33333333
+#
+#--- root-small.s
+        .section .data$root, "dw", largest, root
+        .globl root
+root:
+        .byte 0
+
+        .globl a
+a:
+        .long 0x11111111
+        .globl b
+b:
+        .long 0x22222222
+        .globl c
+c:
+        .long 0x33333333
+#
+#--- a.s
+        .section .data$a, "dw", largest, a
+        .globl a
+a:
+        .space 16, 0xaa
+        .globl b
+b:
+        .long 0xaaaaaaaa
+#
+#--- b.s
+        .section .data$b, "dw", largest, b
+        .globl b
+b:
+        .space 16, 0xbb
+        .globl c
+c:
+        .long 0xbbbbbbbb
+#
+#--- c.s
+        .section .data$c, "dw", largest, c
+        .globl c
+c:
+        .space 16, 0xcc
+        .globl a
+a:
+        .long 0xcccccccc
+#
+#--- root-large.s
+        .section .data$root, "dw", largest, root
+        .globl root
+root:
+        .space 64, 0x44

--- a/lld/test/COFF/comdat-selection-largest-replay-order.s
+++ b/lld/test/COFF/comdat-selection-largest-replay-order.s
@@ -1,0 +1,72 @@
+# REQUIRES: x86
+
+# A deferred symbol slot can contain both a child of one COMDAT and the leader
+# of another. Leaders must be selected before any child is published, even when
+# the child was encountered first.
+
+# RUN: split-file %s %t.dir
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/root-small.s -o %t.root-small.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/group-b.s -o %t.group-b.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/group-a.s -o %t.group-a.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/root-large.s -o %t.root-large.obj
+
+# group-b registers its secondary definition of a before group-a registers a
+# as a leader. Publishing that child first would incorrectly reject group-a.
+# RUN: lld-link /force:multiple /dll /noentry /nodefaultlib /include:a \
+# RUN:   %t.root-small.obj %t.group-b.obj %t.group-a.obj %t.root-large.obj \
+# RUN:   /out:%t.child-first.dll
+# RUN: llvm-objdump -s %t.child-first.dll | FileCheck %s
+
+# The result must not depend on the order in which the leader and child
+# providers entered the slot.
+# RUN: lld-link /force:multiple /dll /noentry /nodefaultlib /include:a \
+# RUN:   %t.root-small.obj %t.group-a.obj %t.group-b.obj %t.root-large.obj \
+# RUN:   /out:%t.leader-first.dll
+# RUN: llvm-objdump -s %t.leader-first.dll | FileCheck %s
+
+# CHECK: Contents of section .data:
+# CHECK: aaaaaaaa
+# CHECK-NOT: bbbbbbbb
+# CHECK-NOT: 11111111
+
+#--- root-small.s
+        .section .data$root, "dw", largest, root_leader
+        .globl root_leader
+root_leader:
+        .byte 0
+
+        # Keep a before b in the symbol table. Discarding this group therefore
+        # schedules a before b for deferred replay.
+        .globl a
+a:
+        .long 0x11111111
+
+        .globl b
+b:
+        .byte 0
+
+#--- group-b.s
+        .section .data$b, "dw", largest, b
+        .globl b
+b:
+        .space 8
+
+        .globl a
+a:
+        .long 0xbbbbbbbb
+
+#--- group-a.s
+        .section .data$a, "dw", largest, a
+        .globl a
+a:
+        .long 0xaaaaaaaa
+
+#--- root-large.s
+        .section .data$root, "dw", largest, root_leader
+        .globl root_leader
+root_leader:
+        .space 32

--- a/lld/test/COFF/comdat-selection-largest-resources.s
+++ b/lld/test/COFF/comdat-selection-largest-resources.s
@@ -1,0 +1,39 @@
+# REQUIRES: x86
+
+# A resource chunk in a losing LARGEST group must be removed before resource
+# object classification and inclusion. Linking winner+loser in either order is
+# observably equivalent to linking the winner alone.
+
+# RUN: split-file %s %t.dir
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/small.s -o %t.small.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/large.s -o %t.large.obj
+# RUN: lld-link /dll /noentry /nodefaultlib /timestamp:0 \
+# RUN:   /include:resource_group \
+# RUN:   %t.large.obj /out:%t.winner.dll
+# RUN: lld-link /dll /noentry /nodefaultlib /timestamp:0 \
+# RUN:   /include:resource_group \
+# RUN:   %t.small.obj %t.large.obj /out:%t.small-first.dll
+# RUN: lld-link /dll /noentry /nodefaultlib /timestamp:0 \
+# RUN:   /include:resource_group \
+# RUN:   %t.large.obj %t.small.obj /out:%t.large-first.dll
+# RUN: cmp %t.winner.dll %t.small-first.dll
+# RUN: cmp %t.winner.dll %t.large-first.dll
+# RUN: llvm-objdump -s %t.winner.dll | FileCheck %s
+
+# CHECK: Contents of section .rsrc:
+# CHECK: 4c415247 452d5245 534f5552 434500
+# CHECK-NOT: 534d414c
+
+#--- small.s
+        .section .rsrc$01,"dr",largest,resource_group
+        .globl resource_group
+resource_group:
+        .ascii "SMALL"
+
+#--- large.s
+        .section .rsrc$01,"dr",largest,resource_group
+        .globl resource_group
+resource_group:
+        .asciz "LARGE-RESOURCE"

--- a/lld/test/COFF/comdat-selection-largest-same-object.test
+++ b/lld/test/COFF/comdat-selection-largest-same-object.test
@@ -1,0 +1,135 @@
+# REQUIRES: x86
+
+# Two LARGEST candidates can occur in one symbol table. The replacement is
+# processed before late secondary symbols and before pending associative
+# definitions. Neither may publish a definition from the losing group.
+
+# RUN: split-file %s %t.dir
+# RUN: yaml2obj %t.dir/candidates.yaml -o %t.candidates.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/provider.s -o %t.provider.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/root.s -o %t.root.obj
+# RUN: llvm-lib -machine:amd64 -out:%t.provider.lib %t.provider.obj
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.candidates.obj %t.provider.lib %t.root.obj \
+# RUN:   /map:%t.map /out:%t.exe
+# RUN: FileCheck %s --check-prefix=MAP < %t.map
+# RUN: llvm-objdump -s %t.exe | FileCheck %s --check-prefix=IMAGE \
+# RUN:   --implicit-check-not=11111111 --implicit-check-not=22
+
+# MAP-DAG: late_small{{.*}}provider.obj
+# MAP-DAG: assoc_small{{.*}}provider.obj
+# IMAGE: Contents of section .text:
+# IMAGE: 44444444
+# IMAGE: Contents of section .rdata:
+# IMAGE: 77777777
+# IMAGE: 88888888
+
+#--- candidates.yaml
+--- !COFF
+header:
+  Machine: IMAGE_FILE_MACHINE_AMD64
+  Characteristics: []
+sections:
+  - Name: '.text$one'
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_LNK_COMDAT,
+                       IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_READ ]
+    Alignment: 1
+    SectionData: '1122'
+    SizeOfRawData: 2
+  - Name: '.text$two'
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_LNK_COMDAT,
+                       IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_READ ]
+    Alignment: 1
+    SectionData: '4444444444444444444444444444444444444444444444444444444444444444'
+    SizeOfRawData: 32
+  - Name: '.rdata$assoc'
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_LNK_COMDAT,
+                       IMAGE_SCN_MEM_READ ]
+    Alignment: 1
+    SectionData: '11111111'
+    SizeOfRawData: 4
+symbols:
+  - Name: '.text$one'
+    Value: 0
+    SectionNumber: 1
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length: 2
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum: 0
+      Number: 1
+      Selection: IMAGE_COMDAT_SELECT_LARGEST
+  - Name: leader
+    Value: 0
+    SectionNumber: 1
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+  - Name: '.rdata$assoc'
+    Value: 0
+    SectionNumber: 3
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length: 4
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum: 0
+      Number: 1
+      Selection: IMAGE_COMDAT_SELECT_ASSOCIATIVE
+  - Name: '.text$two'
+    Value: 0
+    SectionNumber: 2
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length: 32
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum: 0
+      Number: 2
+      Selection: IMAGE_COMDAT_SELECT_LARGEST
+  - Name: leader
+    Value: 0
+    SectionNumber: 2
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+  - Name: late_small
+    Value: 1
+    SectionNumber: 1
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+  - Name: assoc_small
+    Value: 0
+    SectionNumber: 3
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+...
+
+#--- provider.s
+        .section .rdata$provider, "dr"
+        .globl late_small
+late_small:
+        .long 0x77777777
+        .globl assoc_small
+assoc_small:
+        .long 0x88888888
+
+#--- root.s
+        .text
+        .globl entry
+entry:
+        leaq leader(%rip), %rax
+        movl late_small(%rip), %ecx
+        movl assoc_small(%rip), %edx
+        retq

--- a/lld/test/COFF/comdat-selection-largest-special-metadata.s
+++ b/lld/test/COFF/comdat-selection-largest-special-metadata.s
@@ -1,0 +1,107 @@
+# REQUIRES: x86
+
+# .drectve can be emitted as an ANY COMDAT by Clang's ASan instrumentation.
+# NODUPLICATES cannot lose silently. For ANY, only the prevailing directives
+# are exposed and candidates must be identical, making input order irrelevant.
+# The LLVM addrsig and call-graph formats are object-level metadata and cannot
+# carry COMDAT provenance, so explicitly reject COMDAT combinations.
+
+# RUN: split-file %s %t.dir
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/directive-a.s -o %t.directive-a.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/directive-b.s -o %t.directive-b.raw.obj
+# RUN: llvm-objcopy --remove-section=.text --remove-section=.data \
+# RUN:   --remove-section=.bss %t.directive-b.raw.obj %t.directive-b.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/directive-conflict.s -o %t.directive-conflict.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/directive-largest.s -o %t.directive-largest.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/addrsig.s -o %t.addrsig.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/cgprofile.s -o %t.cgprofile.obj
+
+# RUN: lld-link /dll /noentry /nodefaultlib /timestamp:0 %t.directive-a.obj \
+# RUN:   /out:%t.same-name.dll
+# RUN: cp %t.same-name.dll %t.winner.dll
+# RUN: lld-link /verbose /dll /noentry /nodefaultlib /timestamp:0 \
+# RUN:   %t.directive-a.obj \
+# RUN:   %t.directive-b.obj /out:%t.same-name.dll 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=DIRECTIVE-ONCE
+# RUN: cmp %t.winner.dll %t.same-name.dll
+# RUN: lld-link /verbose /dll /noentry /nodefaultlib /timestamp:0 \
+# RUN:   %t.directive-b.obj \
+# RUN:   %t.directive-a.obj /out:%t.same-name.dll 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=DIRECTIVE-ONCE
+# RUN: cmp %t.winner.dll %t.same-name.dll
+# RUN: llvm-readobj --coff-exports %t.winner.dll | \
+# RUN:   FileCheck %s --check-prefix=EXPORT
+# RUN: not lld-link /dll /noentry /nodefaultlib %t.directive-a.obj \
+# RUN:   %t.directive-conflict.obj /out:%t.conflict.dll 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=DIRECTIVE-CONFLICT
+# RUN: not lld-link /dll /noentry /nodefaultlib %t.directive-largest.obj \
+# RUN:   /out:%t.largest.dll 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=DIRECTIVE-LARGEST
+# RUN: not lld-link /dll /noentry /nodefaultlib %t.addrsig.obj \
+# RUN:   /out:%t.addrsig.dll 2>&1 | FileCheck %s --check-prefix=ADDRSIG
+# RUN: not lld-link /dll /noentry /nodefaultlib \
+# RUN:   /discard-section:.llvm_addrsig %t.addrsig.obj \
+# RUN:   /out:%t.addrsig-discard.dll 2>&1 | FileCheck %s --check-prefix=ADDRSIG
+# RUN: not lld-link /dll /noentry /nodefaultlib %t.cgprofile.obj \
+# RUN:   /out:%t.cgprofile.dll 2>&1 | FileCheck %s --check-prefix=CGPROFILE
+# RUN: not lld-link /dll /noentry /nodefaultlib \
+# RUN:   /discard-section:.llvm.call-graph-profile %t.cgprofile.obj \
+# RUN:   /out:%t.cgprofile-discard.dll 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=CGPROFILE
+
+# EXPORT: Name: exported
+# DIRECTIVE-ONCE-COUNT-1: Directives:
+# DIRECTIVE-CONFLICT: error: {{.*}}directive-conflict.obj: COMDAT .drectve
+# DIRECTIVE-CONFLICT-SAME: candidates must use selection type ANY and have
+# DIRECTIVE-CONFLICT-SAME: identical contents
+# DIRECTIVE-LARGEST: error: {{.*}}directive-largest.obj: COMDAT .drectve must
+# DIRECTIVE-LARGEST-SAME: use selection type ANY or NODUPLICATES
+# ADDRSIG: error: {{.*}}addrsig.obj: .llvm_addrsig cannot be a COMDAT section
+# CGPROFILE: error: {{.*}}cgprofile.obj: .llvm.call-graph-profile cannot be a
+# CGPROFILE-SAME: COMDAT section
+
+#--- directive-a.s
+        .text
+        .globl exported
+exported:
+        retq
+        .section .drectve,"dr",discard,directive_group
+        .globl directive_group
+directive_group:
+        .ascii " /export:exported"
+
+#--- directive-b.s
+        .section .drectve,"dr",discard,directive_group
+        .globl directive_group
+directive_group:
+        .ascii " /export:exported"
+
+#--- directive-conflict.s
+        .section .drectve,"dr",discard,directive_group
+        .globl directive_group
+directive_group:
+        .ascii " /export:different"
+
+#--- directive-largest.s
+        .section .drectve,"dr",largest,directive_group
+        .globl directive_group
+directive_group:
+        .ascii " /export:exported"
+
+#--- addrsig.s
+        .section .llvm_addrsig,"dr",one_only,addrsig_group
+        .globl addrsig_group
+addrsig_group:
+        .byte 0
+
+#--- cgprofile.s
+        .section ".llvm.call-graph-profile","dr",one_only,cgprofile_group
+        .globl cgprofile_group
+cgprofile_group:
+        .quad 0

--- a/lld/test/COFF/comdat-selection-largest-symbol-order.test
+++ b/lld/test/COFF/comdat-selection-largest-symbol-order.test
@@ -1,0 +1,160 @@
+# REQUIRES: x86
+#
+# Freeze symbol-table ordering semantics around reference attribution. The
+# normal path eagerly references an undefined symbol as it is read. Objects
+# containing ANY/LARGEST defer reference attribution until section provenance
+# is known, so a later definition in the same object can satisfy that entry
+# without extracting an otherwise-unused archive member.
+#
+# RUN: split-file %s %t.dir
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/provider.s -o %t.provider.obj
+# RUN: llvm-lib -machine:amd64 -out:%t.provider.lib %t.provider.obj
+# RUN: yaml2obj %t.dir/undefined-defined.yaml -o %t.ud.obj
+# RUN: yaml2obj %t.dir/defined-undefined.yaml -o %t.du.obj
+# RUN: sed 's/COMDAT_SELECTION/IMAGE_COMDAT_SELECT_SAME_SIZE/' \
+# RUN:   %t.dir/comdat-undefined-defined.yaml | yaml2obj -o %t.same-size.obj
+# RUN: sed 's/COMDAT_SELECTION/IMAGE_COMDAT_SELECT_LARGEST/' \
+# RUN:   %t.dir/comdat-undefined-defined.yaml | yaml2obj -o %t.largest.obj
+#
+# Undefined-before-defined on the normal path schedules the lazy archive
+# extraction immediately. Archive extraction is monotonic, so the marker from
+# that member remains visible even though foo is defined later in the object.
+# RUN: lld-link /dll /noentry /nodefaultlib /force:multiple /opt:noref \
+# RUN:   %t.provider.lib %t.ud.obj /out:%t.ud.dll
+# RUN: llvm-objdump -s %t.ud.dll | FileCheck %s --check-prefix=EXTRACTED
+#
+# Definition-before-undefined does not request the archive member.
+# RUN: lld-link /dll /noentry /nodefaultlib /force:multiple /opt:noref \
+# RUN:   %t.provider.lib %t.du.obj /out:%t.du.dll
+# RUN: llvm-objdump -s %t.du.dll | FileCheck %s --check-prefix=NOT-EXTRACTED
+#
+# SAME_SIZE is not a replaceable group for reference-provenance tracking, so
+# it retains the normal eager path.
+# RUN: lld-link /dll /noentry /nodefaultlib /force:multiple /opt:noref \
+# RUN:   %t.provider.lib %t.same-size.obj /out:%t.same-size.dll
+# RUN: llvm-objdump -s %t.same-size.dll | FileCheck %s --check-prefix=EXTRACTED
+#
+# An unrelated LARGEST group activates section-provenance tracking. The later
+# same-object definition satisfies foo before deferred reference attribution is
+# published; the archive member must therefore remain unextracted.
+# RUN: lld-link /dll /noentry /nodefaultlib /force:multiple /opt:noref \
+# RUN:   %t.provider.lib %t.largest.obj /out:%t.largest.dll
+# RUN: llvm-objdump -s %t.largest.dll | \
+# RUN:   FileCheck %s --check-prefix=NOT-EXTRACTED
+#
+# EXTRACTED: Contents of section .rdata:
+# EXTRACTED: ddccbbaa
+# NOT-EXTRACTED-NOT: ddccbbaa
+#
+#--- provider.s
+        .section .rdata$provider, "dr"
+        .globl foo
+foo:
+        .long 0x13572468
+
+        .globl archive_marker
+archive_marker:
+        .long 0xaabbccdd
+#
+#--- undefined-defined.yaml
+--- !COFF
+header:
+  Machine: IMAGE_FILE_MACHINE_AMD64
+  Characteristics: [ ]
+sections:
+  - Name: .text
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE,
+                       IMAGE_SCN_MEM_READ ]
+    Alignment: 1
+    SectionData: 'C3'
+symbols:
+  - Name: foo
+    Value: 0
+    SectionNumber: 0
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+  - Name: foo
+    Value: 0
+    SectionNumber: 1
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+...
+#
+#--- defined-undefined.yaml
+--- !COFF
+header:
+  Machine: IMAGE_FILE_MACHINE_AMD64
+  Characteristics: [ ]
+sections:
+  - Name: .text
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE,
+                       IMAGE_SCN_MEM_READ ]
+    Alignment: 1
+    SectionData: 'C3'
+symbols:
+  - Name: foo
+    Value: 0
+    SectionNumber: 1
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+  - Name: foo
+    Value: 0
+    SectionNumber: 0
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+...
+#
+#--- comdat-undefined-defined.yaml
+--- !COFF
+header:
+  Machine: IMAGE_FILE_MACHINE_AMD64
+  Characteristics: [ ]
+sections:
+  - Name: .text
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE,
+                       IMAGE_SCN_MEM_READ ]
+    Alignment: 1
+    SectionData: 'C3'
+  - Name: '.rdata$unrelated'
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_LNK_COMDAT,
+                       IMAGE_SCN_MEM_READ ]
+    Alignment: 1
+    SectionData: '01020304'
+symbols:
+  - Name: foo
+    Value: 0
+    SectionNumber: 0
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+  - Name: '.rdata$unrelated'
+    Value: 0
+    SectionNumber: 2
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length: 4
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum: 0
+      Number: 2
+      Selection: COMDAT_SELECTION
+  - Name: unrelated_leader
+    Value: 0
+    SectionNumber: 2
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+  - Name: foo
+    Value: 0
+    SectionNumber: 1
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+...

--- a/lld/test/COFF/comdat-selection-largest-symbols.s
+++ b/lld/test/COFF/comdat-selection-largest-symbols.s
@@ -1,0 +1,182 @@
+# REQUIRES: x86
+
+# Test symbols other than the COMDAT leader when a larger definition replaces
+# an earlier prevailing IMAGE_COMDAT_SELECT_LARGEST group.
+#
+# The positive cases define the same secondary external symbol in both
+# candidates. The prevailing secondary symbol, local symbol, and associative
+# relocations must all refer to the final largest group.
+#
+# The negative cases define only_small exclusively in the smaller candidate.
+# Once that candidate is superseded, only_small must no longer provide a
+# definition, independently of input order.
+
+# RUN: split-file %s %t.dir
+
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/small.s -o %t.small.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/large.s -o %t.large.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/root.s -o %t.root.obj
+
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/only-small.s -o %t.only-small.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/only-large.s -o %t.only-large.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/only-root.s -o %t.only-root.obj
+
+# Check replacement when the smaller candidate is seen first.
+
+# RUN: lld-link /opt:noref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.large.obj %t.root.obj \
+# RUN:   /out:%t.noref.small-large.exe
+# RUN: llvm-objdump -s %t.noref.small-large.exe | FileCheck %s
+
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.large.obj %t.root.obj \
+# RUN:   /out:%t.ref.small-large.exe
+# RUN: llvm-objdump -s %t.ref.small-large.exe | FileCheck %s
+
+# Check that a smaller candidate seen later does not replace the prevailing
+# larger candidate.
+
+# RUN: lld-link /opt:noref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.large.obj %t.small.obj %t.root.obj \
+# RUN:   /out:%t.noref.large-small.exe
+# RUN: llvm-objdump -s %t.noref.large-small.exe | FileCheck %s
+
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.large.obj %t.small.obj %t.root.obj \
+# RUN:   /out:%t.ref.large-small.exe
+# RUN: llvm-objdump -s %t.ref.large-small.exe | FileCheck %s
+
+# A symbol defined only by the superseded smaller group must no longer
+# provide a definition after the larger group prevails.
+#
+# Cover all six permutations of the smaller candidate, larger candidate,
+# and the object containing the undefined reference.
+
+# Smaller candidate, larger candidate, reference.
+
+# RUN: not lld-link /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.only-small.obj %t.only-large.obj %t.only-root.obj \
+# RUN:   /out:%t.only-small-large-root.exe 2>&1 | \
+# RUN:   FileCheck --check-prefix=ONLY-SMALL %s
+
+# Smaller candidate, reference, larger candidate.
+
+# RUN: not lld-link /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.only-small.obj %t.only-root.obj %t.only-large.obj \
+# RUN:   /out:%t.only-small-root-large.exe 2>&1 | \
+# RUN:   FileCheck --check-prefix=ONLY-SMALL %s
+
+# Larger candidate, smaller candidate, reference.
+
+# RUN: not lld-link /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.only-large.obj %t.only-small.obj %t.only-root.obj \
+# RUN:   /out:%t.only-large-small-root.exe 2>&1 | \
+# RUN:   FileCheck --check-prefix=ONLY-SMALL %s
+
+# Larger candidate, reference, smaller candidate.
+
+# RUN: not lld-link /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.only-large.obj %t.only-root.obj %t.only-small.obj \
+# RUN:   /out:%t.only-large-root-small.exe 2>&1 | \
+# RUN:   FileCheck --check-prefix=ONLY-SMALL %s
+
+# Reference, smaller candidate, larger candidate.
+
+# RUN: not lld-link /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.only-root.obj %t.only-small.obj %t.only-large.obj \
+# RUN:   /out:%t.only-root-small-large.exe 2>&1 | \
+# RUN:   FileCheck --check-prefix=ONLY-SMALL %s
+
+# Reference, larger candidate, smaller candidate.
+
+# RUN: not lld-link /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.only-root.obj %t.only-large.obj %t.only-small.obj \
+# RUN:   /out:%t.only-root-large-small.exe 2>&1 | \
+# RUN:   FileCheck --check-prefix=ONLY-SMALL %s
+
+# CHECK: Contents of section .text:
+# CHECK-NEXT:  140001000 44444444 55555555 66666666 c3
+# CHECK: Contents of section .rdata:
+# The first three RVAs come from the associative section. The final two come
+# from the root section. They must all point into the prevailing large chunk:
+# leader = 0x1000, secondary = 0x1004, local = 0x1008.
+# CHECK-NEXT:  140002000 00100000 04100000 08100000 00100000
+# CHECK-NEXT:  140002010 04100000
+
+# ONLY-SMALL: error: undefined symbol: only_small
+# ONLY-SMALL-NOT: duplicate symbol: only_small
+
+#--- small.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .byte 0x11
+
+        .globl secondary
+secondary:
+        .byte 0x22
+
+local:
+        .byte 0x33
+
+        .section .rdata$assoc, "dr", associative, leader
+        .rva leader
+        .rva secondary
+        .rva local
+
+#--- large.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .long 0x44444444
+
+        .globl secondary
+secondary:
+        .long 0x55555555
+
+local:
+        .long 0x66666666
+
+        .section .rdata$assoc, "dr", associative, leader
+        .rva leader
+        .rva secondary
+        .rva local
+
+#--- root.s
+        .section .text$root, "xr"
+        .globl entry
+entry:
+        retq
+
+        .section .rdata$refs, "dr"
+        .rva leader
+        .rva secondary
+
+#--- only-small.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .byte 0x11
+
+        .globl only_small
+only_small:
+        .byte 0x22
+
+#--- only-large.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .long 0x44444444
+
+#--- only-root.s
+        .section .text$root, "xr"
+        .globl entry
+entry:
+        leaq only_small(%rip), %rax
+        retq

--- a/lld/test/COFF/comdat-selection-largest-transactional-replacement.test
+++ b/lld/test/COFF/comdat-selection-largest-transactional-replacement.test
@@ -1,0 +1,99 @@
+# REQUIRES: x86
+#
+# A larger LARGEST candidate is only committed after readSection() succeeds.
+# If the candidate is filtered (here via IMAGE_SCN_LNK_REMOVE), the previously
+# selected group must remain intact. This protects the replacement as a
+# transaction: selection can be proposed before section ingestion, but the old
+# group is not discarded until the replacement chunk actually exists.
+#
+# RUN: split-file %s %t.dir
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/small.s -o %t.small.obj
+# RUN: yaml2obj %t.dir/removed-large.yaml -o %t.removed-large.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/root.s -o %t.root.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/any-small.s -o %t.any-small.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/any-large.s -o %t.any-large.obj
+#
+# RUN: lld-link /dll /noentry /nodefaultlib /opt:noref /include:leader \
+# RUN:   %t.small.obj %t.removed-large.obj %t.root.obj /out:%t.dll
+# RUN: llvm-objdump -s %t.dll | FileCheck %s
+#
+# CHECK: Contents of section .text:
+# CHECK: 11111111
+# CHECK-NOT: 44444444
+#
+# A filtered candidate must not commit an ANY/LARGEST compatibility promotion
+# either. The third ANY candidate therefore follows the first-ANY-wins rule.
+# RUN: lld-link /dll /noentry /nodefaultlib /opt:noref /include:leader \
+# RUN:   %t.any-small.obj %t.removed-large.obj %t.any-large.obj \
+# RUN:   /out:%t.promotion.dll
+# RUN: llvm-objdump -s %t.promotion.dll | FileCheck %s --check-prefix=PROMOTION
+# RUN: lld-link /dll /noentry /nodefaultlib /opt:noref /include:leader \
+# RUN:   %t.removed-large.obj %t.any-small.obj /out:%t.filtered-first.dll
+# RUN: llvm-objdump -s %t.filtered-first.dll | \
+# RUN:   FileCheck %s --check-prefix=PROMOTION
+#
+# PROMOTION: 11111111
+# PROMOTION-NOT: 33333333
+#
+#--- small.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .long 0x11111111
+#
+#--- root.s
+        .text
+        .globl root
+root:
+        leaq leader(%rip), %rax
+        retq
+#
+#--- any-small.s
+        .section .text$largest, "xr", discard, leader
+        .globl leader
+leader:
+        .long 0x11111111
+#
+#--- any-large.s
+        .section .text$largest, "xr", discard, leader
+        .globl leader
+leader:
+        .space 32, 0x33
+#
+#--- removed-large.yaml
+--- !COFF
+header:
+  Machine: IMAGE_FILE_MACHINE_AMD64
+  Characteristics: [ ]
+sections:
+  - Name: '.text$largest'
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_LNK_COMDAT,
+                       IMAGE_SCN_LNK_REMOVE, IMAGE_SCN_MEM_EXECUTE,
+                       IMAGE_SCN_MEM_READ ]
+    Alignment: 1
+    SectionData: '44444444444444444444444444444444'
+symbols:
+  - Name: '.text$largest'
+    Value: 0
+    SectionNumber: 1
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length: 16
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum: 0
+      Number: 1
+      Selection: IMAGE_COMDAT_SELECT_LARGEST
+  - Name: leader
+    Value: 0
+    SectionNumber: 1
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+...

--- a/lld/test/COFF/comdat-selection-largest-unrelocated-undefined.test
+++ b/lld/test/COFF/comdat-selection-largest-unrelocated-undefined.test
@@ -1,0 +1,63 @@
+# REQUIRES: x86
+#
+# An undefined COFF symbol-table entry is an object-level reference even when
+# no relocation names it. Objects containing ANY/LARGEST defer reference
+# attribution, so this case protects the explicit undefinedIndexes path.
+#
+# RUN: split-file %s %t.dir
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/provider.s -o %t.provider.obj
+# RUN: llvm-lib -machine:amd64 -out:%t.provider.lib %t.provider.obj
+# RUN: yaml2obj %t.dir/input.yaml -o %t.input.obj
+#
+# RUN: lld-link /dll /noentry /nodefaultlib /opt:noref \
+# RUN:   %t.provider.lib %t.input.obj /out:%t.dll
+# RUN: llvm-objdump -s %t.dll | FileCheck %s
+#
+# CHECK: Contents of section .rdata:
+# CHECK: 78563412
+#
+#--- provider.s
+        .section .rdata$provider, "dr"
+        .globl no_reloc_reference
+no_reloc_reference:
+        .long 0x12345678
+#
+#--- input.yaml
+--- !COFF
+header:
+  Machine: IMAGE_FILE_MACHINE_AMD64
+  Characteristics: [ ]
+sections:
+  - Name: '.text$largest'
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_LNK_COMDAT,
+                       IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_READ ]
+    Alignment: 1
+    SectionData: 'C3'
+symbols:
+  - Name: '.text$largest'
+    Value: 0
+    SectionNumber: 1
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length: 1
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum: 0
+      Number: 1
+      Selection: IMAGE_COMDAT_SELECT_LARGEST
+  - Name: unrelated_leader
+    Value: 0
+    SectionNumber: 1
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+  - Name: no_reloc_reference
+    Value: 0
+    SectionNumber: 0
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+...

--- a/lld/test/COFF/comdat-selection-largest-weak-alias-cycle.test
+++ b/lld/test/COFF/comdat-selection-largest-weak-alias-cycle.test
@@ -1,0 +1,77 @@
+# REQUIRES: x86
+#
+# Weak aliases may form malformed cycles. Replacing and later discarding a
+# provisional secondary definition must restore the weak-alias state without
+# turning such input into use-after-replacement, recursion through stale
+# SymbolUnion storage, or a crash.
+#
+# RUN: split-file %s %t.dir
+# RUN: yaml2obj %t.dir/weak-cycle.yaml -o %t.weak-cycle.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/small.s -o %t.small.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/large.s -o %t.large.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/root.s -o %t.root.obj
+#
+# /force:unresolved makes the result of the malformed alias cycle non-fatal;
+# the regression property is that deferred restoration terminates safely.
+# RUN: lld-link /force:unresolved /force:multiple /entry:entry \
+# RUN:   /subsystem:console /nodefaultlib /opt:noref %t.weak-cycle.obj \
+# RUN:   %t.small.obj %t.large.obj %t.root.obj /out:%t.exe 2>&1 | \
+# RUN:   FileCheck %s --allow-empty
+#
+# CHECK-NOT: PLEASE submit a bug report
+# CHECK-NOT: Assertion failed
+#
+#--- weak-cycle.yaml
+--- !COFF
+header:
+  Machine: IMAGE_FILE_MACHINE_AMD64
+  Characteristics: [ ]
+sections: []
+symbols:
+  # raw 0, auxiliary record raw 1, targets weak_b at raw 2
+  - Name: weak_a
+    Value: 0
+    SectionNumber: 0
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_WEAK_EXTERNAL
+    WeakExternal:
+      TagIndex: 2
+      Characteristics: IMAGE_WEAK_EXTERN_SEARCH_ALIAS
+  # raw 2, auxiliary record raw 3, targets weak_a at raw 0
+  - Name: weak_b
+    Value: 0
+    SectionNumber: 0
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_WEAK_EXTERNAL
+    WeakExternal:
+      TagIndex: 0
+      Characteristics: IMAGE_WEAK_EXTERN_SEARCH_ALIAS
+...
+#
+#--- small.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .byte 0x11
+
+        .globl weak_a
+weak_a:
+        retq
+#
+#--- large.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .space 32, 0x44
+#
+#--- root.s
+        .text
+        .globl entry
+entry:
+        callq weak_a
+        retq

--- a/lld/test/COFF/comdat-selection-largest-weak-external.s
+++ b/lld/test/COFF/comdat-selection-largest-weak-external.s
@@ -1,0 +1,126 @@
+# REQUIRES: x86
+
+# Test that a weak external keeps its fallback when its initially prevailing
+# definition belongs to an IMAGE_COMDAT_SELECT_LARGEST group that is later
+# superseded.
+
+# RUN: split-file %s %t.dir
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/small.s -o %t.small.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/large.s -o %t.large.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/medium.s -o %t.medium.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/weak-reference.s -o %t.weak-reference.obj
+# RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj \
+# RUN:   %t.dir/weak-reference-2.s -o %t.weak-reference-2.obj
+
+# Weak aliases encountered while a regular definition prevails used to be
+# ignored. Deferring an alias in case that definition is later superseded must
+# not make a second weak alias diagnose the prevailing definition as a
+# duplicate.
+# RUN: lld-link /dll /noentry /nodefaultlib %t.small.obj \
+# RUN:   %t.weak-reference.obj %t.weak-reference-2.obj \
+# RUN:   /out:%t.multiple-weak-while-defined.dll
+
+# If the provisional definition is later discarded, replay all suppressed
+# aliases and preserve the normal conflicting-alias diagnostic.
+# RUN: not lld-link /dll /noentry /nodefaultlib %t.small.obj \
+# RUN:   %t.weak-reference.obj %t.weak-reference-2.obj %t.large.obj \
+# RUN:   /out:%t.multiple-weak-after-replacement.dll 2>&1 | \
+# RUN:   FileCheck --check-prefix=WEAK-CONFLICT %s
+# WEAK-CONFLICT: duplicate symbol: foo_lazy
+
+# The weak external is first observed while foo_lazy is defined. Its fallback
+# must be deferred until the smaller group is superseded.
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.weak-reference.obj %t.large.obj \
+# RUN:   /out:%t.definition-first.exe
+# RUN: llvm-objdump -s %t.definition-first.exe | \
+# RUN:   FileCheck --check-prefix=IMAGE --implicit-check-not=11111111 %s
+
+# Preserve the fallback as the symbol changes from undefined to defined and
+# back to undefined.
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.weak-reference.obj %t.small.obj %t.large.obj \
+# RUN:   /out:%t.weak-first.exe
+# RUN: llvm-objdump -s %t.weak-first.exe | \
+# RUN:   FileCheck --check-prefix=IMAGE --implicit-check-not=11111111 %s
+
+# Keep the fallback across more than one temporary definition.
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.weak-reference.obj %t.small.obj %t.medium.obj %t.large.obj \
+# RUN:   /out:%t.replacement-chain.exe
+# RUN: llvm-objdump -s %t.replacement-chain.exe | \
+# RUN:   FileCheck --check-prefix=IMAGE --implicit-check-not=11111111 \
+# RUN:     --implicit-check-not=22222222 %s
+
+# Control cases in which the final largest group is already known before the
+# weak external is read.
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.small.obj %t.large.obj %t.weak-reference.obj \
+# RUN:   /out:%t.largest-before-weak.exe
+# RUN: llvm-objdump -s %t.largest-before-weak.exe | \
+# RUN:   FileCheck --check-prefix=IMAGE --implicit-check-not=11111111 %s
+
+# RUN: lld-link /opt:ref /entry:entry /subsystem:console /nodefaultlib \
+# RUN:   %t.large.obj %t.small.obj %t.weak-reference.obj \
+# RUN:   /out:%t.largest-first.exe
+# RUN: llvm-objdump -s %t.largest-first.exe | \
+# RUN:   FileCheck --check-prefix=IMAGE --implicit-check-not=11111111 %s
+
+# IMAGE: Contents of section .text:
+# IMAGE-DAG: 77777777
+# IMAGE-DAG: 44444444
+
+#--- small.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .space 8, 0x11
+
+        .globl foo_lazy
+foo_lazy:
+        .space 8, 0x11
+
+#--- large.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .space 32, 0x44
+
+#--- medium.s
+        .section .text$largest, "xr", largest, leader
+        .globl leader
+leader:
+        .space 12, 0x22
+
+        .globl foo_lazy
+foo_lazy:
+        .space 12, 0x22
+
+#--- weak-reference.s
+        .section .text$fallback, "xr"
+        .globl fallback
+fallback:
+        .space 8, 0x77
+
+        .weak foo_lazy
+        foo_lazy = fallback
+
+        .section .text$entry, "xr"
+        .globl entry
+entry:
+        leaq foo_lazy(%rip), %rax
+        leaq leader(%rip), %rcx
+        retq
+
+#--- weak-reference-2.s
+        .section .text$fallback2, "xr"
+        .globl fallback2
+fallback2:
+        .space 8, 0x88
+
+        .weak foo_lazy
+        foo_lazy = fallback2

--- a/lld/test/COFF/lto-late-personality.ll
+++ b/lld/test/COFF/lto-late-personality.ll
@@ -14,6 +14,14 @@
 
 ; RUN: env LLD_IN_TEST=1 not lld-link /entry:entry %t.main.obj %t.other.obj %t.personality.lib /out:%t.exe /subsystem:console /opt:lldlto=0 /debug:symtab 2>&1 | FileCheck %s
 
+;; Do not preserve late references from arbitrary unassociated COMDATs in LTO
+;; output. The section is discarded, so its archive provider must not be loaded
+;; after LTO.
+; RUN: llvm-as %t.dir/nonunwind.ll -o %t.nonunwind.obj
+; RUN: llvm-as %t.dir/late.ll -o %t.late.obj
+; RUN: llvm-ar rcs %t.late.lib %t.late.obj
+; RUN: lld-link /entry:entry %t.nonunwind.obj %t.late.lib /out:%t.nonunwind.exe /subsystem:console /opt:lldlto=0 /debug:symtab
+
 ; CHECK: error: LTO object file lto-late-personality.ll.tmp.personality.lib(lto-late-personality.ll.tmp.personality.obj) linked in after doing LTO compilation.
 
 ;--- main.ll
@@ -46,3 +54,19 @@ define void @__C_specific_handler() {
 entry:
   ret void
 }
+
+;--- nonunwind.ll
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
+
+define i32 @entry() {
+entry:
+  tail call void asm sideeffect ".section .rdata$$late, \22dr\22\0A.linkonce discard\0A.long late_provider\0A.text\0A", "~{dirflag},~{fpsr},~{flags}"()
+  ret i32 0
+}
+
+;--- late.ll
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
+
+@late_provider = global i32 42


### PR DESCRIPTION
IMAGE_COMDAT_SELECT_LARGEST replaces the prevailing COMDAT when LLD finds a larger candidate. LLD currently replaces the leader while state owned by the losing group can remain visible, including associative sections, secondary definitions, references, providers, directives, and section-derived metadata.

D57324 ([48dc110](https://github.com/llvm/llvm-project/commit/48dc110eea1f44319f6df632a3a8fde903864f7e), r352590) added the first LARGEST implementation in 2019 and marked this behavior as incomplete. Its FIXME notes that replaced sections can still reach the output with /opt:noref. The associative LARGEST test left those cases disabled. [#39441](https://github.com/llvm/llvm-project/issues/39441) later tracked the remaining group-lifetime problem.

Treat replaceable ANY and LARGEST COMDATs as groups. LLD now keeps group-owned references and providers provisional until selection determines the survivor. When a candidate loses, LLD discards its leader, associative children, and secondary definitions. Children discovered after the loss inherit that state.

Archive extraction and native LTO output can introduce more COMDAT candidates, so LLD repeats deferred resolution while publication adds inputs. MinGW stdcall fixups and automatic imports can inspect provisional references before final publication. This patch leaves the existing one-pass behavior for chained stdcall fixups unchanged.

The same ownership rule covers .drectve and section-derived state. Losing groups cannot contribute CodeView/PDB data, resources, SafeSEH, GuardCF, or ARM64EC hybrid-map entries. LLD also validates affected COFF indices before it stores provisional state or replaces the selected group.

The patch adds 43 COFF tests and extends 2 existing tests. Coverage includes associative and secondary definitions, archives, provider precedence, weak externals, MinGW, GC, ARM/ARM64, ARM64EC, BigObj, LTO, directives, metadata, and malformed inputs. The associative LARGEST test now covers the /opt:noref cases left by the original FIXME.

Focused validation passes 21/21 lit tests. Audits classify all 37 affected Undefined consumers and 13 readSection() side-effect paths with no open correctness issue in the audited scope. A native Windows cross-check passes 34/34 cases with this patch versus 26/34 with LLVM-MinGW LLD 22.1.8; the remaining 26 cases produce byte-identical PE/COFF files.

Across nine base-to-patch workloads, median wall-time changes range from -3.70% to +4.32%, with every paired-median 95% bootstrap interval including zero. Peak RSS changes range from -3.63% to +2.02%. Cachegrind measures 8.4% to 11.8% more instructions on the instrumented COMDAT-heavy workloads from provenance tracking and deferred replay.

The amount of machinery comes from the point at which LLD discovers the winning COMDAT. By then, the linker may already have published references, selected symbol providers, extracted archive members, recorded directives, or copied section-derived metadata from a group that later loses ANY or LARGEST selection. Replacing the leader symbol cannot undo those effects. The implementation therefore keeps state owned by replaceable groups provisional until selection finishes, then publishes only the surviving group's state and repeats the process when archive extraction or LTO adds new candidates.

Follow-up to [#39441](https://github.com/llvm/llvm-project/issues/39441).

[#113974](https://github.com/llvm/llvm-project/issues/113974) remains open because this patch does not implement LLVM IR COMDAT selection kinds.