### PR TITLE
[AMDGPU] Prefer packed minimum/maximum ops for two-input ops

### DIFF
--- a/llvm/lib/Target/AMDGPU/VOP3PInstructions.td
+++ b/llvm/lib/Target/AMDGPU/VOP3PInstructions.td
@@ -444,6 +444,38 @@ class MinimumMaximumByMinimum3Maximum3VOP3P<SDPatternOperator node,
   (inst $src0_mods, $src0, $src1_mods, $src1, $src1_mods, $src1)
 >;
 
+class MinimumMaximumV2F16VOP3P<SDPatternOperator node, Instruction inst> : GCNPat<
+  (v2f16 (node (VOP3PMods v2f16:$src0, i32:$src0_mods), (VOP3PMods v2f16:$src1, i32:$src1_mods))),
+  (inst $src0_mods, $src0, $src1_mods, $src1)
+>;
+
+class MinimumMaximum3V2F16VOP3P<SDPatternOperator node, Instruction inst> : GCNPat<
+  (v2f16 (node (VOP3PMods v2f16:$src0, i32:$src0_mods),
+               (node (VOP3PMods v2f16:$src1, i32:$src1_mods),
+                     (VOP3PMods v2f16:$src2, i32:$src2_mods)))),
+  (inst $src0_mods, $src0, $src1_mods, $src1, $src2_mods, $src2)
+>;
+
+class MinimumMaximum3CommuteV2F16VOP3P<SDPatternOperator node,
+                                       Instruction inst> : GCNPat<
+  (v2f16 (node (node (VOP3PMods v2f16:$src0, i32:$src0_mods),
+                     (VOP3PMods v2f16:$src1, i32:$src1_mods)),
+               (VOP3PMods v2f16:$src2, i32:$src2_mods))),
+  (inst $src0_mods, $src0, $src1_mods, $src1, $src2_mods, $src2)
+>;
+
+let SubtargetPredicate = HasMinimum3Maximum3PKF16, AddedComplexity = 2 in {
+  def : MinimumMaximum3V2F16VOP3P<fminimum, V_PK_MINIMUM3_F16>;
+  def : MinimumMaximum3V2F16VOP3P<fmaximum, V_PK_MAXIMUM3_F16>;
+  def : MinimumMaximum3CommuteV2F16VOP3P<fminimum, V_PK_MINIMUM3_F16>;
+  def : MinimumMaximum3CommuteV2F16VOP3P<fmaximum, V_PK_MAXIMUM3_F16>;
+}
+
+let SubtargetPredicate = HasIEEEMinimumMaximumInsts, AddedComplexity = 1 in {
+  def : MinimumMaximumV2F16VOP3P<fminimum, V_PK_MINIMUM_F16>;
+  def : MinimumMaximumV2F16VOP3P<fmaximum, V_PK_MAXIMUM_F16>;
+}
+
 let SubtargetPredicate = HasMinimum3Maximum3PKF16 in {
 def : MinimumMaximumByMinimum3Maximum3VOP3P<fminimum, V_PK_MINIMUM3_F16>;
 def : MinimumMaximumByMinimum3Maximum3VOP3P<fmaximum, V_PK_MAXIMUM3_F16>;

--- a/llvm/test/CodeGen/AMDGPU/fmaximum3.ll
+++ b/llvm/test/CodeGen/AMDGPU/fmaximum3.ll
@@ -4641,11 +4641,10 @@ define <2 x half> @v_no_fmaximum3_f16__multi_use(half %a, half %b, half %c) {
 ; GFX950-LABEL: v_no_fmaximum3_f16__multi_use:
 ; GFX950:       ; %bb.0:
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX950-NEXT:    v_pk_maximum3_f16 v0, v0, v1, v1
+; GFX950-NEXT:    v_pk_maximum3_f16 v3, v0, v1, v1
+; GFX950-NEXT:    v_pk_maximum3_f16 v0, v0, v1, v2
 ; GFX950-NEXT:    s_nop 0
-; GFX950-NEXT:    v_pk_maximum3_f16 v1, v0, v2, v2
-; GFX950-NEXT:    s_nop 0
-; GFX950-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX950-NEXT:    v_pack_b32_f16 v0, v3, v0
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
   %max0 = call half @llvm.maximum.f16(half %a, half %b)
   %max1 = call half @llvm.maximum.f16(half %max0, half %c)
@@ -4709,9 +4708,10 @@ define amdgpu_ps <2 x i32> @s_no_fmaximum3_f16__multi_use(half inreg %a, half in
 ; GFX950-LABEL: s_no_fmaximum3_f16__multi_use:
 ; GFX950:       ; %bb.0:
 ; GFX950-NEXT:    v_mov_b32_e32 v0, s0
+; GFX950-NEXT:    v_mov_b32_e32 v1, s1
+; GFX950-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX950-NEXT:    v_pk_maximum3_f16 v0, v0, s1, s1
-; GFX950-NEXT:    s_nop 0
-; GFX950-NEXT:    v_pk_maximum3_f16 v1, v0, s2, s2
+; GFX950-NEXT:    v_pk_maximum3_f16 v1, s0, v1, v2
 ; GFX950-NEXT:    v_and_b32_e32 v0, 0xffff, v0
 ; GFX950-NEXT:    v_and_b32_e32 v1, 0xffff, v1
 ; GFX950-NEXT:    v_readfirstlane_b32 s0, v0
@@ -4777,9 +4777,9 @@ define <4 x half> @v_no_fmaximum3_v2f16__multi_use(<2 x half> %a, <2 x half> %b,
 ; GFX950-LABEL: v_no_fmaximum3_v2f16__multi_use:
 ; GFX950:       ; %bb.0:
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX950-NEXT:    v_pk_maximum3_f16 v0, v0, v1, v1
-; GFX950-NEXT:    s_nop 0
-; GFX950-NEXT:    v_pk_maximum3_f16 v1, v0, v2, v2
+; GFX950-NEXT:    v_pk_maximum3_f16 v3, v0, v1, v1
+; GFX950-NEXT:    v_pk_maximum3_f16 v1, v0, v1, v2
+; GFX950-NEXT:    v_mov_b32_e32 v0, v3
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
   %max0 = call <2 x half> @llvm.maximum.f16(<2 x half> %a, <2 x half> %b)
   %max1 = call <2 x half> @llvm.maximum.f16(<2 x half> %max0, <2 x half> %c)

--- a/llvm/test/CodeGen/AMDGPU/fmaximum3.v2f16.ll
+++ b/llvm/test/CodeGen/AMDGPU/fmaximum3.v2f16.ll
@@ -5,21 +5,12 @@
 ; RUN: llc -global-isel=1 -mtriple=amdgpu12.50 -mattr=+real-true16 < %s | FileCheck --check-prefixes=GFX1250,GFX1250-GISEL,GFX1250-GISEL-REAL16 %s
 
 define <2 x half> @fmaximum3_v2f16(<2 x half> %a, <2 x half> %b, <2 x half> %c) {
-; GFX1250-SDAG-LABEL: fmaximum3_v2f16:
-; GFX1250-SDAG:       ; %bb.0: ; %entry
-; GFX1250-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
-; GFX1250-SDAG-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-SDAG-NEXT:    v_pk_maximum3_f16 v0, v2, v0, v1
-; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
-;
-; GFX1250-GISEL-LABEL: fmaximum3_v2f16:
-; GFX1250-GISEL:       ; %bb.0: ; %entry
-; GFX1250-GISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
-; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-GISEL-NEXT:    v_pk_maximum3_f16 v0, v0, v1, v1
-; GFX1250-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1250-GISEL-NEXT:    v_pk_maximum3_f16 v0, v2, v0, v0
-; GFX1250-GISEL-NEXT:    s_set_pc_i64 s[30:31]
+; GFX1250-LABEL: fmaximum3_v2f16:
+; GFX1250:       ; %bb.0: ; %entry
+; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1250-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-NEXT:    v_pk_maximum3_f16 v0, v2, v0, v1
+; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
 entry:
   %min = call <2 x half> @llvm.maximum.v2f16(<2 x half> %a, <2 x half> %b)
   %res = call <2 x half> @llvm.maximum.v2f16(<2 x half> %c, <2 x half> %min)
@@ -27,21 +18,12 @@ entry:
 }
 
 define <2 x half> @fmaximum3_v2f16_vss(<2 x half> %a, <2 x half> inreg %b, <2 x half> inreg %c) {
-; GFX1250-SDAG-LABEL: fmaximum3_v2f16_vss:
-; GFX1250-SDAG:       ; %bb.0: ; %entry
-; GFX1250-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
-; GFX1250-SDAG-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-SDAG-NEXT:    v_pk_maximum3_f16 v0, s1, v0, s0
-; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
-;
-; GFX1250-GISEL-LABEL: fmaximum3_v2f16_vss:
-; GFX1250-GISEL:       ; %bb.0: ; %entry
-; GFX1250-GISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
-; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-GISEL-NEXT:    v_pk_maximum3_f16 v0, v0, s0, s0
-; GFX1250-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1250-GISEL-NEXT:    v_pk_maximum3_f16 v0, s1, v0, v0
-; GFX1250-GISEL-NEXT:    s_set_pc_i64 s[30:31]
+; GFX1250-LABEL: fmaximum3_v2f16_vss:
+; GFX1250:       ; %bb.0: ; %entry
+; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1250-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-NEXT:    v_pk_maximum3_f16 v0, s1, v0, s0
+; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
 entry:
   %min = call <2 x half> @llvm.maximum.v2f16(<2 x half> %a, <2 x half> %b)
   %res = call <2 x half> @llvm.maximum.v2f16(<2 x half> %c, <2 x half> %min)
@@ -62,11 +44,9 @@ define <3 x half> @fmaximum3_v3f16(<3 x half> %a, <3 x half> %b, <3 x half> %c) 
 ; GFX1250-GISEL-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-GISEL-FAKE16-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-GISEL-FAKE16-NEXT:    v_maximum3_f16 v1, v1, v3, v5
-; GFX1250-GISEL-FAKE16-NEXT:    v_pk_maximum3_f16 v0, v0, v2, v2
-; GFX1250-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1250-GISEL-FAKE16-NEXT:    v_pk_maximum3_f16 v0, v4, v0, v2
+; GFX1250-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1250-GISEL-FAKE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
-; GFX1250-GISEL-FAKE16-NEXT:    v_pk_maximum3_f16 v0, v4, v0, v0
-; GFX1250-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1250-GISEL-FAKE16-NEXT:    v_lshl_or_b32 v1, s0, 16, v1
 ; GFX1250-GISEL-FAKE16-NEXT:    s_set_pc_i64 s[30:31]
 ;
@@ -74,10 +54,8 @@ define <3 x half> @fmaximum3_v3f16(<3 x half> %a, <3 x half> %b, <3 x half> %c) 
 ; GFX1250-GISEL-REAL16:       ; %bb.0: ; %entry
 ; GFX1250-GISEL-REAL16-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-GISEL-REAL16-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-GISEL-REAL16-NEXT:    v_pk_maximum3_f16 v0, v0, v2, v2
+; GFX1250-GISEL-REAL16-NEXT:    v_pk_maximum3_f16 v0, v4, v0, v2
 ; GFX1250-GISEL-REAL16-NEXT:    v_maximum3_f16 v1.l, v1.l, v3.l, v5.l
-; GFX1250-GISEL-REAL16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX1250-GISEL-REAL16-NEXT:    v_pk_maximum3_f16 v0, v4, v0, v0
 ; GFX1250-GISEL-REAL16-NEXT:    s_set_pc_i64 s[30:31]
 entry:
   %min = call <3 x half> @llvm.maximum.v3f16(<3 x half> %a, <3 x half> %b)
@@ -86,30 +64,19 @@ entry:
 }
 
 define <4 x half> @fmaximum3_v4f16(<4 x half> %a, <4 x half> %b, <4 x half> %c) {
-; GFX1250-SDAG-LABEL: fmaximum3_v4f16:
-; GFX1250-SDAG:       ; %bb.0: ; %entry
-; GFX1250-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
-; GFX1250-SDAG-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-SDAG-NEXT:    v_pk_maximum3_f16 v0, v4, v0, v2
-; GFX1250-SDAG-NEXT:    v_pk_maximum3_f16 v1, v5, v1, v3
-; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
-;
-; GFX1250-GISEL-LABEL: fmaximum3_v4f16:
-; GFX1250-GISEL:       ; %bb.0: ; %entry
-; GFX1250-GISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
-; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-GISEL-NEXT:    v_pk_maximum3_f16 v0, v0, v2, v2
-; GFX1250-GISEL-NEXT:    v_pk_maximum3_f16 v1, v1, v3, v3
-; GFX1250-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX1250-GISEL-NEXT:    v_pk_maximum3_f16 v0, v4, v0, v0
-; GFX1250-GISEL-NEXT:    v_pk_maximum3_f16 v1, v5, v1, v1
-; GFX1250-GISEL-NEXT:    s_set_pc_i64 s[30:31]
+; GFX1250-LABEL: fmaximum3_v4f16:
+; GFX1250:       ; %bb.0: ; %entry
+; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1250-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-NEXT:    v_pk_maximum3_f16 v0, v4, v0, v2
+; GFX1250-NEXT:    v_pk_maximum3_f16 v1, v5, v1, v3
+; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
 entry:
   %min = call <4 x half> @llvm.maximum.v4f16(<4 x half> %a, <4 x half> %b)
   %res = call <4 x half> @llvm.maximum.v4f16(<4 x half> %c, <4 x half> %min)
   ret <4 x half> %res
 }
 ;; NOTE: These prefixes are unused and the list is autogenerated. Do not add tests below this line:
-; GFX1250: {{.*}}
+; GFX1250-GISEL: {{.*}}
 ; GFX1250-SDAG-FAKE16: {{.*}}
 ; GFX1250-SDAG-REAL16: {{.*}}

--- a/llvm/test/CodeGen/AMDGPU/fminimum3.ll
+++ b/llvm/test/CodeGen/AMDGPU/fminimum3.ll
@@ -4641,11 +4641,10 @@ define <2 x half> @v_no_fminimum3_f16__multi_use(half %a, half %b, half %c) {
 ; GFX950-LABEL: v_no_fminimum3_f16__multi_use:
 ; GFX950:       ; %bb.0:
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX950-NEXT:    v_pk_minimum3_f16 v0, v0, v1, v1
+; GFX950-NEXT:    v_pk_minimum3_f16 v3, v0, v1, v1
+; GFX950-NEXT:    v_pk_minimum3_f16 v0, v0, v1, v2
 ; GFX950-NEXT:    s_nop 0
-; GFX950-NEXT:    v_pk_minimum3_f16 v1, v0, v2, v2
-; GFX950-NEXT:    s_nop 0
-; GFX950-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX950-NEXT:    v_pack_b32_f16 v0, v3, v0
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
   %max0 = call half @llvm.minimum.f16(half %a, half %b)
   %max1 = call half @llvm.minimum.f16(half %max0, half %c)
@@ -4709,9 +4708,10 @@ define amdgpu_ps <2 x i32> @s_no_fminimum3_f16__multi_use(half inreg %a, half in
 ; GFX950-LABEL: s_no_fminimum3_f16__multi_use:
 ; GFX950:       ; %bb.0:
 ; GFX950-NEXT:    v_mov_b32_e32 v0, s0
+; GFX950-NEXT:    v_mov_b32_e32 v1, s1
+; GFX950-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX950-NEXT:    v_pk_minimum3_f16 v0, v0, s1, s1
-; GFX950-NEXT:    s_nop 0
-; GFX950-NEXT:    v_pk_minimum3_f16 v1, v0, s2, s2
+; GFX950-NEXT:    v_pk_minimum3_f16 v1, s0, v1, v2
 ; GFX950-NEXT:    v_and_b32_e32 v0, 0xffff, v0
 ; GFX950-NEXT:    v_and_b32_e32 v1, 0xffff, v1
 ; GFX950-NEXT:    v_readfirstlane_b32 s0, v0
@@ -4777,9 +4777,9 @@ define <4 x half> @v_no_fminimum3_v2f16__multi_use(<2 x half> %a, <2 x half> %b,
 ; GFX950-LABEL: v_no_fminimum3_v2f16__multi_use:
 ; GFX950:       ; %bb.0:
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX950-NEXT:    v_pk_minimum3_f16 v0, v0, v1, v1
-; GFX950-NEXT:    s_nop 0
-; GFX950-NEXT:    v_pk_minimum3_f16 v1, v0, v2, v2
+; GFX950-NEXT:    v_pk_minimum3_f16 v3, v0, v1, v1
+; GFX950-NEXT:    v_pk_minimum3_f16 v1, v0, v1, v2
+; GFX950-NEXT:    v_mov_b32_e32 v0, v3
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
   %max0 = call <2 x half> @llvm.minimum.f16(<2 x half> %a, <2 x half> %b)
   %max1 = call <2 x half> @llvm.minimum.f16(<2 x half> %max0, <2 x half> %c)

--- a/llvm/test/CodeGen/AMDGPU/fminimum3.v2f16.ll
+++ b/llvm/test/CodeGen/AMDGPU/fminimum3.v2f16.ll
@@ -5,21 +5,12 @@
 ; RUN: llc -global-isel=1 -mtriple=amdgpu12.50 -mattr=+real-true16 < %s | FileCheck --check-prefixes=GFX1250,GFX1250-GISEL,GFX1250-GISEL-REAL16 %s
 
 define <2 x half> @fminimum3_v2f16(<2 x half> %a, <2 x half> %b, <2 x half> %c) {
-; GFX1250-SDAG-LABEL: fminimum3_v2f16:
-; GFX1250-SDAG:       ; %bb.0: ; %entry
-; GFX1250-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
-; GFX1250-SDAG-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-SDAG-NEXT:    v_pk_minimum3_f16 v0, v2, v0, v1
-; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
-;
-; GFX1250-GISEL-LABEL: fminimum3_v2f16:
-; GFX1250-GISEL:       ; %bb.0: ; %entry
-; GFX1250-GISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
-; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-GISEL-NEXT:    v_pk_minimum3_f16 v0, v0, v1, v1
-; GFX1250-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1250-GISEL-NEXT:    v_pk_minimum3_f16 v0, v2, v0, v0
-; GFX1250-GISEL-NEXT:    s_set_pc_i64 s[30:31]
+; GFX1250-LABEL: fminimum3_v2f16:
+; GFX1250:       ; %bb.0: ; %entry
+; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1250-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-NEXT:    v_pk_minimum3_f16 v0, v2, v0, v1
+; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
 entry:
   %min = call <2 x half> @llvm.minimum.v2f16(<2 x half> %a, <2 x half> %b)
   %res = call <2 x half> @llvm.minimum.v2f16(<2 x half> %c, <2 x half> %min)
@@ -27,21 +18,12 @@ entry:
 }
 
 define <2 x half> @fminimum3_v2f16_vss(<2 x half> %a, <2 x half> inreg %b, <2 x half> inreg %c) {
-; GFX1250-SDAG-LABEL: fminimum3_v2f16_vss:
-; GFX1250-SDAG:       ; %bb.0: ; %entry
-; GFX1250-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
-; GFX1250-SDAG-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-SDAG-NEXT:    v_pk_minimum3_f16 v0, s1, v0, s0
-; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
-;
-; GFX1250-GISEL-LABEL: fminimum3_v2f16_vss:
-; GFX1250-GISEL:       ; %bb.0: ; %entry
-; GFX1250-GISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
-; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-GISEL-NEXT:    v_pk_minimum3_f16 v0, v0, s0, s0
-; GFX1250-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1250-GISEL-NEXT:    v_pk_minimum3_f16 v0, s1, v0, v0
-; GFX1250-GISEL-NEXT:    s_set_pc_i64 s[30:31]
+; GFX1250-LABEL: fminimum3_v2f16_vss:
+; GFX1250:       ; %bb.0: ; %entry
+; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1250-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-NEXT:    v_pk_minimum3_f16 v0, s1, v0, s0
+; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
 entry:
   %min = call <2 x half> @llvm.minimum.v2f16(<2 x half> %a, <2 x half> %b)
   %res = call <2 x half> @llvm.minimum.v2f16(<2 x half> %c, <2 x half> %min)
@@ -62,11 +44,9 @@ define <3 x half> @fminimum3_v3f16(<3 x half> %a, <3 x half> %b, <3 x half> %c) 
 ; GFX1250-GISEL-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-GISEL-FAKE16-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-GISEL-FAKE16-NEXT:    v_minimum3_f16 v1, v1, v3, v5
-; GFX1250-GISEL-FAKE16-NEXT:    v_pk_minimum3_f16 v0, v0, v2, v2
-; GFX1250-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1250-GISEL-FAKE16-NEXT:    v_pk_minimum3_f16 v0, v4, v0, v2
+; GFX1250-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1250-GISEL-FAKE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
-; GFX1250-GISEL-FAKE16-NEXT:    v_pk_minimum3_f16 v0, v4, v0, v0
-; GFX1250-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1250-GISEL-FAKE16-NEXT:    v_lshl_or_b32 v1, s0, 16, v1
 ; GFX1250-GISEL-FAKE16-NEXT:    s_set_pc_i64 s[30:31]
 ;
@@ -74,10 +54,8 @@ define <3 x half> @fminimum3_v3f16(<3 x half> %a, <3 x half> %b, <3 x half> %c) 
 ; GFX1250-GISEL-REAL16:       ; %bb.0: ; %entry
 ; GFX1250-GISEL-REAL16-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-GISEL-REAL16-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-GISEL-REAL16-NEXT:    v_pk_minimum3_f16 v0, v0, v2, v2
+; GFX1250-GISEL-REAL16-NEXT:    v_pk_minimum3_f16 v0, v4, v0, v2
 ; GFX1250-GISEL-REAL16-NEXT:    v_minimum3_f16 v1.l, v1.l, v3.l, v5.l
-; GFX1250-GISEL-REAL16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX1250-GISEL-REAL16-NEXT:    v_pk_minimum3_f16 v0, v4, v0, v0
 ; GFX1250-GISEL-REAL16-NEXT:    s_set_pc_i64 s[30:31]
 entry:
   %min = call <3 x half> @llvm.minimum.v3f16(<3 x half> %a, <3 x half> %b)
@@ -86,30 +64,19 @@ entry:
 }
 
 define <4 x half> @fminimum3_v4f16(<4 x half> %a, <4 x half> %b, <4 x half> %c) {
-; GFX1250-SDAG-LABEL: fminimum3_v4f16:
-; GFX1250-SDAG:       ; %bb.0: ; %entry
-; GFX1250-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
-; GFX1250-SDAG-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-SDAG-NEXT:    v_pk_minimum3_f16 v0, v4, v0, v2
-; GFX1250-SDAG-NEXT:    v_pk_minimum3_f16 v1, v5, v1, v3
-; GFX1250-SDAG-NEXT:    s_set_pc_i64 s[30:31]
-;
-; GFX1250-GISEL-LABEL: fminimum3_v4f16:
-; GFX1250-GISEL:       ; %bb.0: ; %entry
-; GFX1250-GISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
-; GFX1250-GISEL-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-GISEL-NEXT:    v_pk_minimum3_f16 v0, v0, v2, v2
-; GFX1250-GISEL-NEXT:    v_pk_minimum3_f16 v1, v1, v3, v3
-; GFX1250-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX1250-GISEL-NEXT:    v_pk_minimum3_f16 v0, v4, v0, v0
-; GFX1250-GISEL-NEXT:    v_pk_minimum3_f16 v1, v5, v1, v1
-; GFX1250-GISEL-NEXT:    s_set_pc_i64 s[30:31]
+; GFX1250-LABEL: fminimum3_v4f16:
+; GFX1250:       ; %bb.0: ; %entry
+; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX1250-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-NEXT:    v_pk_minimum3_f16 v0, v4, v0, v2
+; GFX1250-NEXT:    v_pk_minimum3_f16 v1, v5, v1, v3
+; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
 entry:
   %min = call <4 x half> @llvm.minimum.v4f16(<4 x half> %a, <4 x half> %b)
   %res = call <4 x half> @llvm.minimum.v4f16(<4 x half> %c, <4 x half> %min)
   ret <4 x half> %res
 }
 ;; NOTE: These prefixes are unused and the list is autogenerated. Do not add tests below this line:
-; GFX1250: {{.*}}
+; GFX1250-GISEL: {{.*}}
 ; GFX1250-SDAG-FAKE16: {{.*}}
 ; GFX1250-SDAG-REAL16: {{.*}}


### PR DESCRIPTION
A two-input f16 fminimum or fmaximum operation should translate to a
packed two-input minimum/maximum instruction when the target supports
one.

It currently can be selected through the minimum3/maximum3 fallback
pattern instead. That emits a three-input instruction with one input
operand duplicated.

Keep the fallback for nested min/max expressions that can use the real
three-input instruction. Add a higher-priority direct pattern for
non-nested two-input operations on targets with packed IEEE
minimum/maximum opcodes.

