### PR TITLE
fix pp-trace crashes with no options

### DIFF
--- a/clang-tools-extra/pp-trace/PPTrace.cpp
+++ b/clang-tools-extra/pp-trace/PPTrace.cpp
@@ -129,7 +129,7 @@ int main(int argc, const char **argv) {
   using namespace clang::pp_trace;
   InitLLVM X(argc, argv);
   auto OptionsParser = clang::tooling::CommonOptionsParser::create(
-      argc, argv, Cat, llvm::cl::ZeroOrMore);
+      argc, argv, Cat, llvm::cl::OneOrMore);
   if (!OptionsParser)
     error(toString(OptionsParser.takeError()));
   // Parse the IgnoreCallbacks list into strings.


### PR DESCRIPTION
Currently, executing pp-trace without parameters causes a crash. Now:
```
# pp-trace
error: pp-trace: Not enough positional command line arguments specified!
Must specify at least 1 positional argument: See: pp-trace --help
```