### PR TITLE
[ORC] Split RTBridge Proxy headers by operation family (NFC)

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/EPCGenericMemoryAccess.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/EPCGenericMemoryAccess.h
@@ -20,7 +20,9 @@
 
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/MemoryAccess.h"
-#include "llvm/ExecutionEngine/Orc/RTBridge/SPS/ProxySpecs.h"
+#include "llvm/ExecutionEngine/Orc/RTBridge/MemoryAccessProxies.h"
+#include "llvm/ExecutionEngine/Orc/RTBridge/Proxy.h"
+#include "llvm/ExecutionEngine/Orc/RTBridge/SPS/MemoryAccessProxySpecs.h"
 
 namespace llvm {
 namespace orc {

--- a/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/CallProxies.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/CallProxies.h
@@ -1,0 +1,57 @@
+//===------- CallProxies.h - Proxies for running functions ------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Named rt::Proxy types for running functions in the executor. Each takes the
+// target function's ExecutorAddr (plus any arguments) and runs it.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_EXECUTIONENGINE_ORC_RTBRIDGE_CALLPROXIES_H
+#define LLVM_EXECUTIONENGINE_ORC_RTBRIDGE_CALLPROXIES_H
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ExecutionEngine/Orc/RTBridge/Proxy.h"
+
+#include <cstdint>
+#include <string>
+
+namespace llvm::orc::rt {
+
+/// Runtime-agnostic interface for running a main-like function
+/// (int(int argc, char *argv[])) in the executor.
+///
+/// The function to run is given by its ExecutorAddr, its arguments as an
+/// argument vector, and its int64_t result is returned.
+using CallMainProxy = Proxy<int64_t(ExecutorAddr, ArrayRef<std::string>)>;
+
+/// Runtime-agnostic interface for running a void() function in the executor.
+///
+/// The function to run is given by its ExecutorAddr.
+///
+/// WARNING: This Proxy is experimental and may be removed.
+using CallVoidVoidProxy = Proxy<void(ExecutorAddr)>;
+
+/// Runtime-agnostic interface for running an int32_t() function in the
+/// executor.
+///
+/// The function to run is given by its ExecutorAddr.
+///
+/// WARNING: This Proxy is experimental and may be removed.
+using CallInt32VoidProxy = Proxy<int32_t(ExecutorAddr)>;
+
+/// Runtime-agnostic interface for running an int32_t(int32_t) function in the
+/// executor.
+///
+/// The function to run is given by its ExecutorAddr.
+///
+/// WARNING: This Proxy is experimental and may be removed.
+using CallInt32Int32Proxy = Proxy<int32_t(ExecutorAddr, int32_t)>;
+
+} // namespace llvm::orc::rt
+
+#endif // LLVM_EXECUTIONENGINE_ORC_RTBRIDGE_CALLPROXIES_H

--- a/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/MemoryAccessProxies.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/MemoryAccessProxies.h
@@ -1,0 +1,50 @@
+//===--- MemoryAccessProxies.h - Proxies for memory access ------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Named rt::Proxy types for the executor's memory-access operations. Unlike the
+// Call proxies, these target wrappers that perform the operation directly, so
+// they take the operation's data arguments rather than a callee address.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_EXECUTIONENGINE_ORC_RTBRIDGE_MEMORYACCESSPROXIES_H
+#define LLVM_EXECUTIONENGINE_ORC_RTBRIDGE_MEMORYACCESSPROXIES_H
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ExecutionEngine/Orc/RTBridge/Proxy.h"
+#include "llvm/ExecutionEngine/Orc/Shared/TargetProcessControlTypes.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace llvm::orc::rt {
+
+using MemWriteUInt8sProxy = Proxy<void(ArrayRef<tpctypes::UInt8Write>)>;
+using MemWriteUInt16sProxy = Proxy<void(ArrayRef<tpctypes::UInt16Write>)>;
+using MemWriteUInt32sProxy = Proxy<void(ArrayRef<tpctypes::UInt32Write>)>;
+using MemWriteUInt64sProxy = Proxy<void(ArrayRef<tpctypes::UInt64Write>)>;
+using MemWritePointersProxy = Proxy<void(ArrayRef<tpctypes::PointerWrite>)>;
+using MemWriteBuffersProxy = Proxy<void(ArrayRef<tpctypes::BufferWrite>)>;
+using MemReadUInt8sProxy = Proxy<std::vector<uint8_t>(ArrayRef<ExecutorAddr>)>;
+using MemReadUInt16sProxy =
+    Proxy<std::vector<uint16_t>(ArrayRef<ExecutorAddr>)>;
+using MemReadUInt32sProxy =
+    Proxy<std::vector<uint32_t>(ArrayRef<ExecutorAddr>)>;
+using MemReadUInt64sProxy =
+    Proxy<std::vector<uint64_t>(ArrayRef<ExecutorAddr>)>;
+using MemReadPointersProxy =
+    Proxy<std::vector<ExecutorAddr>(ArrayRef<ExecutorAddr>)>;
+using MemReadBuffersProxy =
+    Proxy<std::vector<std::vector<uint8_t>>(ArrayRef<ExecutorAddrRange>)>;
+using MemReadStringsProxy =
+    Proxy<std::vector<std::string>(ArrayRef<ExecutorAddr>)>;
+
+} // namespace llvm::orc::rt
+
+#endif // LLVM_EXECUTIONENGINE_ORC_RTBRIDGE_MEMORYACCESSPROXIES_H

--- a/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/Proxy.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/Proxy.h
@@ -12,24 +12,23 @@
 // LLVM's own ORC-runtime-lite. Concrete implementations live in subdirectories
 // (e.g. RTBridge/SPS).
 //
+// This header provides only the core Proxy machinery. Named proxies for
+// specific operation families live in sibling headers (e.g. CallProxies.h,
+// MemoryAccessProxies.h).
+//
 //===----------------------------------------------------------------------===//
 
 #ifndef LLVM_EXECUTIONENGINE_ORC_RTBRIDGE_PROXY_H
 #define LLVM_EXECUTIONENGINE_ORC_RTBRIDGE_PROXY_H
 
-#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/FunctionExtras.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
-#include "llvm/ExecutionEngine/Orc/Shared/TargetProcessControlTypes.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MSVCErrorWorkarounds.h"
 
-#include <cstdint>
 #include <future>
-#include <string>
 #include <type_traits>
-#include <vector>
 
 namespace llvm::orc::rt {
 
@@ -204,60 +203,6 @@ Error buildProxies(JITDylib &JD, ProxyInit<FnT> PI, ProxyInit<FnTs>... PIs) {
     return POrErr.takeError();
   return buildProxies(JD, PIs...);
 }
-
-/// Runtime-agnostic interface for running a main-like function
-/// (int(int argc, char *argv[])) in the executor.
-///
-/// The function to run is given by its ExecutorAddr, its arguments as an
-/// argument vector, and its int64_t result is returned.
-using CallMainProxy = Proxy<int64_t(ExecutorAddr, ArrayRef<std::string>)>;
-
-/// Runtime-agnostic interface for running a void() function in the executor.
-///
-/// The function to run is given by its ExecutorAddr.
-///
-/// WARNING: This Proxy is experimental and may be removed.
-using CallVoidVoidProxy = Proxy<void(ExecutorAddr)>;
-
-/// Runtime-agnostic interface for running an int32_t() function in the
-/// executor.
-///
-/// The function to run is given by its ExecutorAddr.
-///
-/// WARNING: This Proxy is experimental and may be removed.
-using CallInt32VoidProxy = Proxy<int32_t(ExecutorAddr)>;
-
-/// Runtime-agnostic interface for running an int32_t(int32_t) function in the
-/// executor.
-///
-/// The function to run is given by its ExecutorAddr.
-///
-/// WARNING: This Proxy is experimental and may be removed.
-using CallInt32Int32Proxy = Proxy<int32_t(ExecutorAddr, int32_t)>;
-
-/// Runtime-agnostic interfaces for the memory-access operations. Unlike the
-/// Call* proxies above, these target wrappers that perform the operation
-/// directly, so they take the operation's data arguments rather than a callee
-/// address.
-using MemWriteUInt8sProxy = Proxy<void(ArrayRef<tpctypes::UInt8Write>)>;
-using MemWriteUInt16sProxy = Proxy<void(ArrayRef<tpctypes::UInt16Write>)>;
-using MemWriteUInt32sProxy = Proxy<void(ArrayRef<tpctypes::UInt32Write>)>;
-using MemWriteUInt64sProxy = Proxy<void(ArrayRef<tpctypes::UInt64Write>)>;
-using MemWritePointersProxy = Proxy<void(ArrayRef<tpctypes::PointerWrite>)>;
-using MemWriteBuffersProxy = Proxy<void(ArrayRef<tpctypes::BufferWrite>)>;
-using MemReadUInt8sProxy = Proxy<std::vector<uint8_t>(ArrayRef<ExecutorAddr>)>;
-using MemReadUInt16sProxy =
-    Proxy<std::vector<uint16_t>(ArrayRef<ExecutorAddr>)>;
-using MemReadUInt32sProxy =
-    Proxy<std::vector<uint32_t>(ArrayRef<ExecutorAddr>)>;
-using MemReadUInt64sProxy =
-    Proxy<std::vector<uint64_t>(ArrayRef<ExecutorAddr>)>;
-using MemReadPointersProxy =
-    Proxy<std::vector<ExecutorAddr>(ArrayRef<ExecutorAddr>)>;
-using MemReadBuffersProxy =
-    Proxy<std::vector<std::vector<uint8_t>>(ArrayRef<ExecutorAddrRange>)>;
-using MemReadStringsProxy =
-    Proxy<std::vector<std::string>(ArrayRef<ExecutorAddr>)>;
 
 } // namespace llvm::orc::rt
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/SPS/CallProxySpecs.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/SPS/CallProxySpecs.h
@@ -1,0 +1,58 @@
+//===----- CallProxySpecs.h - SPS specs for CallProxies ---------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// SPS ProxySpecs (signatures, controller-interface names, and dispatch) for the
+// CallProxies.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_EXECUTIONENGINE_ORC_RTBRIDGE_SPS_CALLPROXYSPECS_H
+#define LLVM_EXECUTIONENGINE_ORC_RTBRIDGE_SPS_CALLPROXYSPECS_H
+
+#include "llvm/ExecutionEngine/Orc/RTBridge/CallProxies.h"
+#include "llvm/ExecutionEngine/Orc/RTBridge/SPS/ProxySpec.h"
+
+#include <cstdint>
+
+namespace llvm::orc::rt::sps {
+
+using CallMainSPSSig = int64_t(shared::SPSExecutorAddr,
+                               shared::SPSSequence<shared::SPSString>);
+inline constexpr char CallMainCIName[] = "orc_rt_ci_sps_call_main";
+/// SPS proxy for rt::CallMainProxy: runs a main-like function
+/// (int(int argc, char *argv[])) in the executor.
+using CallMainProxySpec =
+    ProxySpec<rt::CallMainProxy, CallMainSPSSig, CallMainCIName>;
+
+using CallVoidVoidSPSSig = void(shared::SPSExecutorAddr);
+inline constexpr char CallVoidVoidCIName[] = "orc_rt_ci_sps_call_void_void";
+/// SPS proxy for rt::CallVoidVoidProxy: runs a void() function in the executor.
+/// WARNING: This Proxy is experimental and may be removed.
+using CallVoidVoidProxySpec =
+    ProxySpec<rt::CallVoidVoidProxy, CallVoidVoidSPSSig, CallVoidVoidCIName>;
+
+using CallInt32VoidSPSSig = int32_t(shared::SPSExecutorAddr);
+inline constexpr char CallInt32VoidCIName[] = "orc_rt_ci_sps_call_int32_void";
+/// SPS proxy for rt::CallInt32VoidProxy: runs an int32_t() function in the
+/// executor.
+/// WARNING: This Proxy is experimental and may be removed.
+using CallInt32VoidProxySpec =
+    ProxySpec<rt::CallInt32VoidProxy, CallInt32VoidSPSSig, CallInt32VoidCIName>;
+
+using CallInt32Int32SPSSig = int32_t(shared::SPSExecutorAddr, int32_t);
+inline constexpr char CallInt32Int32CIName[] = "orc_rt_ci_sps_call_int32_int32";
+/// SPS proxy for rt::CallInt32Int32Proxy: runs an int32_t(int32_t) function in
+/// the executor.
+/// WARNING: This Proxy is experimental and may be removed.
+using CallInt32Int32ProxySpec =
+    ProxySpec<rt::CallInt32Int32Proxy, CallInt32Int32SPSSig,
+              CallInt32Int32CIName>;
+
+} // namespace llvm::orc::rt::sps
+
+#endif // LLVM_EXECUTIONENGINE_ORC_RTBRIDGE_SPS_CALLPROXYSPECS_H

--- a/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/SPS/MemoryAccessProxySpecs.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/SPS/MemoryAccessProxySpecs.h
@@ -1,4 +1,4 @@
-//===-------- ProxySpecs.h - SPS-based Call Wrappers ------------*- C++ -*-===//
+//===-- MemoryAccessProxySpecs.h - SPS specs for mem access -----*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,108 +6,21 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// SPS-based implementations of the RTBridge proxy interfaces.
-//
-// These implement the rt::Proxy interfaces by invoking executor-side wrapper
-// functions in the runtime's controller interface, using Simple Packed
-// Serialization to encode arguments and decode results.
+// SPS ProxySpecs (signatures, controller-interface names, and dispatch) for the
+// MemoryAccessProxies.
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_EXECUTIONENGINE_ORC_RTBRIDGE_SPS_PROXYSPECS_H
-#define LLVM_EXECUTIONENGINE_ORC_RTBRIDGE_SPS_PROXYSPECS_H
+#ifndef LLVM_EXECUTIONENGINE_ORC_RTBRIDGE_SPS_MEMORYACCESSPROXYSPECS_H
+#define LLVM_EXECUTIONENGINE_ORC_RTBRIDGE_SPS_MEMORYACCESSPROXYSPECS_H
 
-#include "llvm/ExecutionEngine/Orc/Core.h"
-#include "llvm/ExecutionEngine/Orc/RTBridge/Proxy.h"
+#include "llvm/ExecutionEngine/Orc/RTBridge/MemoryAccessProxies.h"
+#include "llvm/ExecutionEngine/Orc/RTBridge/SPS/ProxySpec.h"
 #include "llvm/ExecutionEngine/Orc/Shared/TargetProcessControlTypes.h"
 
 #include <cstdint>
 
 namespace llvm::orc::rt::sps {
-
-template <typename ProxyT, typename SPSSigT, const char *DefaultName,
-          typename FnType = typename ProxyT::FnType>
-class ProxySpec;
-
-template <typename ProxyT, typename SPSSigT, const char *DefaultName,
-          typename RetT, typename... ArgTs>
-class ProxySpec<ProxyT, SPSSigT, DefaultName, RetT(ArgTs...)> {
-
-  using CalleeRetT = typename ProxyT::CalleeRetT;
-  using ErrorRetT = typename ProxyT::ErrorRetT;
-
-  static void consumeResult(Error &Err) { consumeError(std::move(Err)); }
-
-  template <typename T> static void consumeResult(T &V) {}
-
-  template <typename T> static void consumeResult(Expected<T> &E) {
-    consumeError(E.takeError());
-  }
-
-public:
-  static constexpr const char *Name = DefaultName;
-
-  static void dispatch(unique_function<void(ErrorRetT)> OnComplete,
-                       ExecutionSession &ES, ExecutorAddr CalleeAddr,
-                       const ArgTs &...Args) {
-    if constexpr (std::is_void_v<CalleeRetT>) {
-      // Void result: the executor-side function produces no value, so the only
-      // thing to report is the dispatch error (success if the call ran).
-      ES.callSPSWrapperAsync<SPSSigT>(CalleeAddr, std::move(OnComplete),
-                                      Args...);
-    } else {
-      ES.callSPSWrapperAsync<SPSSigT>(
-          CalleeAddr,
-          [OnComplete = std::move(OnComplete)](Error SerErr,
-                                               CalleeRetT Result) mutable {
-            if (SerErr) {
-              consumeResult(Result);
-              return OnComplete(std::move(SerErr));
-            }
-            // For an Error/Expected callee this forwards the callee's own
-            // result; for a plain value it is wrapped into Expected.
-            return OnComplete(std::move(Result));
-          },
-          Args...);
-    }
-  }
-};
-
-using CallMainSPSSig = int64_t(shared::SPSExecutorAddr,
-                               shared::SPSSequence<shared::SPSString>);
-inline constexpr char CallMainCIName[] = "orc_rt_ci_sps_call_main";
-/// SPS proxy for rt::CallMainProxy: runs a main-like function
-/// (int(int argc, char *argv[])) in the executor.
-using CallMainProxySpec =
-    ProxySpec<rt::CallMainProxy, CallMainSPSSig, CallMainCIName>;
-
-using CallVoidVoidSPSSig = void(shared::SPSExecutorAddr);
-inline constexpr char CallVoidVoidCIName[] = "orc_rt_ci_sps_call_void_void";
-/// SPS proxy for rt::CallVoidVoidProxy: runs a void() function in the executor.
-/// WARNING: This Proxy is experimental and may be removed.
-using CallVoidVoidProxySpec =
-    ProxySpec<rt::CallVoidVoidProxy, CallVoidVoidSPSSig, CallVoidVoidCIName>;
-
-using CallInt32VoidSPSSig = int32_t(shared::SPSExecutorAddr);
-inline constexpr char CallInt32VoidCIName[] = "orc_rt_ci_sps_call_int32_void";
-/// SPS proxy for rt::CallInt32VoidProxy: runs an int32_t() function in the
-/// executor.
-/// WARNING: This Proxy is experimental and may be removed.
-using CallInt32VoidProxySpec =
-    ProxySpec<rt::CallInt32VoidProxy, CallInt32VoidSPSSig, CallInt32VoidCIName>;
-
-using CallInt32Int32SPSSig = int32_t(shared::SPSExecutorAddr, int32_t);
-inline constexpr char CallInt32Int32CIName[] = "orc_rt_ci_sps_call_int32_int32";
-/// SPS proxy for rt::CallInt32Int32Proxy: runs an int32_t(int32_t) function in
-/// the executor.
-/// WARNING: This Proxy is experimental and may be removed.
-using CallInt32Int32ProxySpec =
-    ProxySpec<rt::CallInt32Int32Proxy, CallInt32Int32SPSSig,
-              CallInt32Int32CIName>;
-
-// Memory-access proxies. Unlike the Call* proxies above, these target wrappers
-// that perform the operation directly, so they take the operation's data
-// arguments and no callee address.
 
 using MemWriteUInt8sSPSSig =
     void(shared::SPSSequence<shared::SPSMemoryAccessUInt8Write>);
@@ -207,4 +120,4 @@ using MemReadStringsProxySpec =
 
 } // namespace llvm::orc::rt::sps
 
-#endif // LLVM_EXECUTIONENGINE_ORC_RTBRIDGE_SPS_PROXYSPECS_H
+#endif // LLVM_EXECUTIONENGINE_ORC_RTBRIDGE_SPS_MEMORYACCESSPROXYSPECS_H

--- a/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/SPS/ProxySpec.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/SPS/ProxySpec.h
@@ -1,0 +1,77 @@
+//===------- ProxySpec.h - SPS dispatch for rt::Proxy -----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// ProxySpec implements an rt::Proxy's dispatch by invoking an executor-side
+// wrapper function in the runtime's controller interface, using Simple Packed
+// Serialization to encode arguments and decode results.
+//
+// Specs for specific operation families live in sibling headers whose specs
+// only need Shared/SPS vocabulary types (e.g. CallProxySpecs.h,
+// MemoryAccessProxySpecs.h).
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_EXECUTIONENGINE_ORC_RTBRIDGE_SPS_PROXYSPEC_H
+#define LLVM_EXECUTIONENGINE_ORC_RTBRIDGE_SPS_PROXYSPEC_H
+
+#include "llvm/ExecutionEngine/Orc/Core.h"
+#include "llvm/ExecutionEngine/Orc/RTBridge/Proxy.h"
+
+namespace llvm::orc::rt::sps {
+
+template <typename ProxyT, typename SPSSigT, const char *DefaultName,
+          typename FnType = typename ProxyT::FnType>
+class ProxySpec;
+
+template <typename ProxyT, typename SPSSigT, const char *DefaultName,
+          typename RetT, typename... ArgTs>
+class ProxySpec<ProxyT, SPSSigT, DefaultName, RetT(ArgTs...)> {
+
+  using CalleeRetT = typename ProxyT::CalleeRetT;
+  using ErrorRetT = typename ProxyT::ErrorRetT;
+
+  static void consumeResult(Error &Err) { consumeError(std::move(Err)); }
+
+  template <typename T> static void consumeResult(T &V) {}
+
+  template <typename T> static void consumeResult(Expected<T> &E) {
+    consumeError(E.takeError());
+  }
+
+public:
+  static constexpr const char *Name = DefaultName;
+
+  static void dispatch(unique_function<void(ErrorRetT)> OnComplete,
+                       ExecutionSession &ES, ExecutorAddr CalleeAddr,
+                       const ArgTs &...Args) {
+    if constexpr (std::is_void_v<CalleeRetT>) {
+      // Void result: the executor-side function produces no value, so the only
+      // thing to report is the dispatch error (success if the call ran).
+      ES.callSPSWrapperAsync<SPSSigT>(CalleeAddr, std::move(OnComplete),
+                                      Args...);
+    } else {
+      ES.callSPSWrapperAsync<SPSSigT>(
+          CalleeAddr,
+          [OnComplete = std::move(OnComplete)](Error SerErr,
+                                               CalleeRetT Result) mutable {
+            if (SerErr) {
+              consumeResult(Result);
+              return OnComplete(std::move(SerErr));
+            }
+            // For an Error/Expected callee this forwards the callee's own
+            // result; for a plain value it is wrapped into Expected.
+            return OnComplete(std::move(Result));
+          },
+          Args...);
+    }
+  }
+};
+
+} // namespace llvm::orc::rt::sps
+
+#endif // LLVM_EXECUTIONENGINE_ORC_RTBRIDGE_SPS_PROXYSPEC_H

--- a/llvm/lib/ExecutionEngine/Orc/COFFPlatform.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/COFFPlatform.cpp
@@ -13,7 +13,7 @@
 #include "llvm/ExecutionEngine/Orc/DebugUtils.h"
 #include "llvm/ExecutionEngine/Orc/LookupAndRecordAddrs.h"
 #include "llvm/ExecutionEngine/Orc/ObjectFileInterface.h"
-#include "llvm/ExecutionEngine/Orc/RTBridge/SPS/ProxySpecs.h"
+#include "llvm/ExecutionEngine/Orc/RTBridge/SPS/CallProxySpecs.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ObjectFormats.h"
 #include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
 #include "llvm/Object/COFF.h"

--- a/llvm/lib/ExecutionEngine/Orc/COFFVCRuntimeSupport.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/COFFVCRuntimeSupport.cpp
@@ -11,7 +11,7 @@
 #include "llvm/ExecutionEngine/Orc/COFF.h"
 #include "llvm/ExecutionEngine/Orc/ExecutionUtils.h"
 #include "llvm/ExecutionEngine/Orc/LookupAndRecordAddrs.h"
-#include "llvm/ExecutionEngine/Orc/RTBridge/SPS/ProxySpecs.h"
+#include "llvm/ExecutionEngine/Orc/RTBridge/SPS/CallProxySpecs.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/WindowsDriver/MSVCPaths.h"
 

--- a/llvm/lib/ExecutionEngine/Orc/EPCGenericDylibManager.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/EPCGenericDylibManager.cpp
@@ -10,7 +10,7 @@
 
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/LookupAndRecordAddrs.h"
-#include "llvm/ExecutionEngine/Orc/RTBridge/SPS/ProxySpecs.h"
+#include "llvm/ExecutionEngine/Orc/RTBridge/SPS/ProxySpec.h"
 #include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
 #include "llvm/ExecutionEngine/Orc/Shared/SimpleRemoteEPCUtils.h"
 

--- a/llvm/lib/ExecutionEngine/Orc/Shared/OrcRTBridge.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Shared/OrcRTBridge.cpp
@@ -8,8 +8,6 @@
 
 #include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
 
-#include "llvm/ExecutionEngine/Orc/RTBridge/Proxy.h"
-
 namespace llvm {
 namespace orc {
 namespace rt {

--- a/llvm/lib/ExecutionEngine/Orc/SimpleRemoteEPC.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/SimpleRemoteEPC.cpp
@@ -10,7 +10,7 @@
 #include "llvm/ExecutionEngine/Orc/EPCGenericDylibManager.h"
 #include "llvm/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManager.h"
 #include "llvm/ExecutionEngine/Orc/EPCGenericMemoryAccess.h"
-#include "llvm/ExecutionEngine/Orc/RTBridge/SPS/ProxySpecs.h"
+#include "llvm/ExecutionEngine/Orc/RTBridge/SPS/CallProxySpecs.h"
 #include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
 #include "llvm/Support/FormatVariadic.h"
 

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/OrcRTBootstrap.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/OrcRTBootstrap.cpp
@@ -8,7 +8,8 @@
 
 #include "OrcRTBootstrap.h"
 
-#include "llvm/ExecutionEngine/Orc/RTBridge/SPS/ProxySpecs.h"
+#include "llvm/ExecutionEngine/Orc/RTBridge/SPS/CallProxySpecs.h"
+#include "llvm/ExecutionEngine/Orc/RTBridge/SPS/MemoryAccessProxySpecs.h"
 #include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
 #include "llvm/ExecutionEngine/Orc/Shared/WrapperFunctionUtils.h"
 #include "llvm/ExecutionEngine/Orc/TargetProcess/RegisterEHFrames.h"

--- a/llvm/unittests/ExecutionEngine/Orc/EPCGenericMemoryAccessTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/EPCGenericMemoryAccessTest.cpp
@@ -10,7 +10,7 @@
 
 #include "llvm/ExecutionEngine/Orc/AbsoluteSymbols.h"
 #include "llvm/ExecutionEngine/Orc/EPCGenericMemoryAccess.h"
-#include "llvm/ExecutionEngine/Orc/RTBridge/SPS/ProxySpecs.h"
+#include "llvm/ExecutionEngine/Orc/RTBridge/SPS/MemoryAccessProxySpecs.h"
 #include "llvm/ExecutionEngine/Orc/SelfExecutorProcessControl.h"
 #include "llvm/Testing/Support/Error.h"
 

--- a/llvm/unittests/ExecutionEngine/Orc/SPSProxiesTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/SPSProxiesTest.cpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "llvm/ExecutionEngine/Orc/RTBridge/SPS/ProxySpecs.h"
+#include "llvm/ExecutionEngine/Orc/RTBridge/SPS/CallProxySpecs.h"
+#include "llvm/ExecutionEngine/Orc/RTBridge/SPS/ProxySpec.h"
 #include "llvm/ExecutionEngine/Orc/SelfExecutorProcessControl.h"
 #include "llvm/ExecutionEngine/Orc/Shared/WrapperFunctionUtils.h"
 #include "llvm/Support/MSVCErrorWorkarounds.h"


### PR DESCRIPTION
Break the monolithic RTBridge/Proxy.h and RTBridge/SPS/ProxySpecs.h into a core header plus per-family sibling headers, so a client pays only for the proxy families it uses. In particular Proxy.h no longer pulls in TargetProcessControlTypes.h -- that was needed only by the memory-access alias set -- so consumers of the core Proxy class (e.g. clients that define their own proxies) no longer depend on it transitively.

Layout:

* RTBridge/Proxy.h -- core only: ProxyBase, Proxy, proxyInit, buildProxies.
* RTBridge/CallProxies.h, RTBridge/MemoryAccessProxies.h -- the named proxy alias sets.
* RTBridge/SPS/ProxySpec.h -- the SPS ProxySpec template.
* RTBridge/SPS/CallProxySpecs.h, RTBridge/SPS/MemoryAccessProxySpecs.h -- the SPS signatures, controller-interface names, and specs.