### PR TITLE
[ProfileData] Reject incompatible ExtBinary section flags

### DIFF
--- a/llvm/include/llvm/ProfileData/SampleProf.h
+++ b/llvm/include/llvm/ProfileData/SampleProf.h
@@ -278,9 +278,10 @@ static inline void verifySecFlag(SecType Type, SecFlagType Flag) {
   case SecFuncMetadata:
     IsFlagLegal = std::is_same<SecFuncMetadataFlags, SecFlagType>();
     break;
-  default:
   case SecFuncOffsetTable:
     IsFlagLegal = std::is_same<SecFuncOffsetFlags, SecFlagType>();
+    break;
+  default:
     break;
   }
   if (!IsFlagLegal)

--- a/llvm/unittests/ProfileData/SampleProfTest.cpp
+++ b/llvm/unittests/ProfileData/SampleProfTest.cpp
@@ -603,6 +603,16 @@ TEST_F(SampleProfTest, SampleProfileFuncOffsetTableInMemory) {
   EXPECT_EQ(Table.lookup(0x55556666ULL), std::nullopt);
 }
 
+#if defined(GTEST_HAS_DEATH_TEST) && !defined(NDEBUG)
+// Verify that function-offset flags are rejected for unrelated section types.
+TEST(SampleProfSectionFlagTest, RejectsMismatchedSectionSpecificFlag) {
+  SecHdrTableEntry Entry{SecLBRProfile, 0, 0, 0, 0};
+  EXPECT_DEATH(
+      static_cast<void>(hasSecFlag(Entry, SecFuncOffsetFlags::SecFlagOrdered)),
+      "Misuse of a flag in an incompatible section");
+}
+#endif
+
 // Verify that requesting format version 103 results in a version 103 profile.
 TEST_F(SampleProfTest, SampleProfileFormatVersion103) {
   auto BufferOrErr = writeProfileToBuffer(103);


### PR DESCRIPTION
Reject section-specific ExtBinary flags that do not belong to the given section type, instead of silently accepting the mismatch. A death unit test covers applying SecFlagOrdered to SecLBRProfile.