### PR TITLE
[mlir] Remove dead declaration verifyIndexingMapOpInterface

### DIFF
--- a/mlir/include/mlir/Interfaces/IndexingMapOpInterface.h
+++ b/mlir/include/mlir/Interfaces/IndexingMapOpInterface.h
@@ -14,13 +14,6 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OpDefinition.h"
 
-namespace mlir {
-namespace detail {
-/// Verify that `op` conforms to the invariants of StructuredOpInterface
-LogicalResult verifyIndexingMapOpInterface(Operation *op);
-} // namespace detail
-} // namespace mlir
-
 /// Include the generated interface declarations.
 #include "mlir/Interfaces/IndexingMapOpInterface.h.inc"
 


### PR DESCRIPTION
The declaration was added on June 23, 2025 in commit
d31ba5256327d30f264c2f671bf197877b242cde without a corresponding
function definition.
