### PR TITLE
[JITLink] Allocate frames in SystemZ atexit tests

### DIFF
--- a/compiler-rt/test/orc/TestCases/Linux/systemz/trivial-atexit.S
+++ b/compiler-rt/test/orc/TestCases/Linux/systemz/trivial-atexit.S
@@ -25,13 +25,14 @@ _ZN6OnExitD2Ev:
 main:
         .cfi_startproc
 # %bb.0:
-        stmg    %r14, %r15, 48(%r15)
+        stmg    %r14, %r15, 112(%r15)
+        aghi    %r15, -160
         lgrl    %r2, _ZN6OnExitD2Ev@GOT
         brasl   %r14, atexit@PLT
         lghi    %r2, 1
         brasl   %r14, llvm_jitlink_setTestResultOverride@PLT
         lghi    %r2, 0
-        lmg     %r14, %r15, 48(%r15)
+        lmg     %r14, %r15, 272(%r15)
         br      %r14
 .Lfunc_end1:
         .size   main, .Lfunc_end1-main

--- a/compiler-rt/test/orc/TestCases/Linux/systemz/trivial-cxa-atexit.S
+++ b/compiler-rt/test/orc/TestCases/Linux/systemz/trivial-cxa-atexit.S
@@ -21,7 +21,8 @@ _ZN6OnExitD2Ev:
 main:
         .cfi_startproc
 # %bb.0:
-        stmg    %r14, %r15, 48(%r15)
+        stmg    %r14, %r15, 112(%r15)
+        aghi    %r15, -160
         lgrl    %r2, _ZN6OnExitD2Ev@GOT
         lgrl    %r4, __dso_handle@GOT
         larl    %r3, _ZL6onExit
@@ -29,7 +30,7 @@ main:
         lghi    %r2, 1
         brasl   %r14, llvm_jitlink_setTestResultOverride@PLT
         lghi    %r2, 0
-        lmg     %r14, %r15, 48(%r15)
+        lmg     %r14, %r15, 272(%r15)
         br      %r14
 .Lfunc_end1:
         .size   main, .Lfunc_end1-main


### PR DESCRIPTION
SystemZ JITLink atexit tests crash, because they call functions without first allocating a frame.

Fix by allocating one. While at it, switch to the more conventional slots for %r14 and %r15.