### PR TITLE
[JITLink] Make JITLink default in LLJIT for SystemZ

### DIFF
--- a/llvm/lib/ExecutionEngine/Orc/LLJIT.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/LLJIT.cpp
@@ -821,6 +821,9 @@ Error LLJITBuilderState::prepareForConstruction() {
     case Triple::ppc64le:
       UseJITLink = TT.isOSBinFormatELF();
       break;
+    case Triple::systemz:
+      UseJITLink = TT.isOSBinFormatELF();
+      break;
     default:
       break;
     }


### PR DESCRIPTION
ClangReplInterpreterTests fails on SystemZ with:

    ExecutorNativePlatform requires ObjectLinkingLayer

JITLink seems to have become a superset of rtdyld on SystemZ. Make it default.