### PR TITLE
[Verifier] Strip incorrect strictfp FIXME, test (NFC)

### DIFF
--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -3922,9 +3922,6 @@ void Verifier::visitCallBase(CallBase &Call) {
   Check(!Attrs.hasFnAttr(Attribute::DenormalFPEnv),
         "denormal_fpenv attribute may not apply to call sites", Call);
 
-  // FIXME: Missing verifier check to forbid a call site marked strictfp without
-  // caller function marked strictfp.
-
   // Verify call attributes.
   verifyFunctionAttrs(FTy, Attrs, &Call, IsIntrinsic, Call.isInlineAsm());
 

--- a/llvm/unittests/IR/VerifierTest.cpp
+++ b/llvm/unittests/IR/VerifierTest.cpp
@@ -797,27 +797,4 @@ TEST(VerifierTest, IntrinsicRetInvalidStruct) {
         << Error;
   }
 }
-
-TEST(VerifierTest, InvalidStrictFPAttribute) {
-  LLVMContext Ctx;
-  Module M("M", Ctx);
-  FunctionType *FuncTy =
-      FunctionType::get(Type::getVoidTy(Ctx), /*isVarArg=*/false);
-  Function *F =
-      Function::Create(FuncTy, Function::ExternalLinkage, "strictfp_test", M);
-  BasicBlock *Entry = BasicBlock::Create(Ctx, "entry", F);
-  Type *FloatTy = Type::getFloatTy(Ctx);
-
-  Function *CosF =
-      Intrinsic::getOrInsertDeclaration(&M, Intrinsic::cos, FloatTy);
-  CallInst *CI = CallInst::Create(CosF, ConstantFP::getNullValue(FloatTy),
-                                  "strictfp_call", Entry);
-  CI->addFnAttr(Attribute::StrictFP);
-  ReturnInst::Create(Ctx, Entry);
-
-  std::string Error;
-  raw_string_ostream ErrorOS(Error);
-  // FIXME: Missing verifier check for strictfp.
-  EXPECT_FALSE(verifyModule(M, &ErrorOS));
-}
 } // end anonymous namespace


### PR DESCRIPTION
Follow up on 0193519 (Partial-revert "[IR] Make semantics of strictfp consistent v2", #213723) to clean up the incorrect FIXME and test it left behind. There are still open questions around the semantics of strictfp, but it is clear that the semantics proposed by the original patch is incorrect.