### PR TITLE
[NFC][SPIR-V] Fuse redundant full-traversal loops in SPIRVStructurizer

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVStructurizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVStructurizer.cpp
@@ -124,33 +124,6 @@ static bool isMergeInstruction(Instruction *I) {
   return getDesignatedMergeBlock(I) != nullptr;
 }
 
-// Returns all blocks in F having at least one OpLoopMerge or OpSelectionMerge
-// instruction.
-static SmallPtrSet<BasicBlock *, 2> getHeaderBlocks(Function &F) {
-  SmallPtrSet<BasicBlock *, 2> Output;
-  for (BasicBlock &BB : F) {
-    for (Instruction &I : BB) {
-      if (getDesignatedMergeBlock(&I) != nullptr)
-        Output.insert(&BB);
-    }
-  }
-  return Output;
-}
-
-// Returns all basic blocks in |F| referenced by at least 1
-// OpSelectionMerge/OpLoopMerge instruction.
-static SmallPtrSet<BasicBlock *, 2> getMergeBlocks(Function &F) {
-  SmallPtrSet<BasicBlock *, 2> Output;
-  for (BasicBlock &BB : F) {
-    for (Instruction &I : BB) {
-      BasicBlock *MB = getDesignatedMergeBlock(&I);
-      if (MB != nullptr)
-        Output.insert(MB);
-    }
-  }
-  return Output;
-}
-
 // Return all the merge instructions contained in BB.
 // Note: the SPIR-V spec doesn't allow a single BB to contain more than 1 merge
 // instruction, but this can happen while we structurize the CFG.
@@ -162,15 +135,33 @@ static std::vector<Instruction *> getMergeInstructions(BasicBlock &BB) {
   return Output;
 }
 
-// Returns all basic blocks in |F| referenced as continue target by at least 1
-// OpLoopMerge instruction.
-static SmallPtrSet<BasicBlock *, 2> getContinueBlocks(Function &F) {
-  SmallPtrSet<BasicBlock *, 2> Output;
+// Bundles the header/merge/continue block sets computed by
+// getHeaderMergeContinueBlocks so callers only needing a subset of them can
+// still share the single underlying scan.
+struct HeaderMergeContinueBlocks {
+  // Blocks in F having at least one OpLoopMerge or OpSelectionMerge
+  // instruction.
+  SmallPtrSet<BasicBlock *, 2> Header;
+  // Blocks in F referenced by at least 1 OpSelectionMerge/OpLoopMerge
+  // instruction.
+  SmallPtrSet<BasicBlock *, 2> Merge;
+  // Blocks in F referenced as continue target by at least 1 OpLoopMerge
+  // instruction.
+  SmallPtrSet<BasicBlock *, 2> Continue;
+};
+
+// Computes Header, Merge and Continue block sets for |F| in a single scan,
+// since they all classify the same instructions.
+static HeaderMergeContinueBlocks getHeaderMergeContinueBlocks(Function &F) {
+  HeaderMergeContinueBlocks Output;
   for (BasicBlock &BB : F) {
     for (Instruction &I : BB) {
-      BasicBlock *MB = getDesignatedContinueBlock(&I);
-      if (MB != nullptr)
-        Output.insert(MB);
+      if (BasicBlock *MB = getDesignatedMergeBlock(&I)) {
+        Output.Header.insert(&BB);
+        Output.Merge.insert(MB);
+      }
+      if (BasicBlock *CB = getDesignatedContinueBlock(&I))
+        Output.Continue.insert(CB);
     }
   }
   return Output;
@@ -647,8 +638,9 @@ class SPIRVStructurizerImpl {
     PDT.recalculate(F);
     bool Modified = false;
 
-    auto MergeBlocks = getMergeBlocks(F);
-    auto ContinueBlocks = getContinueBlocks(F);
+    HeaderMergeContinueBlocks Blocks = getHeaderMergeContinueBlocks(F);
+    auto &MergeBlocks = Blocks.Merge;
+    auto &ContinueBlocks = Blocks.Continue;
 
     for (auto &BB : F) {
       if (getMergeInstructions(BB).size() != 0)
@@ -924,8 +916,9 @@ class SPIRVStructurizerImpl {
   bool removeUselessBlocks(Function &F) {
     std::vector<BasicBlock *> ToRemove;
 
-    auto MergeBlocks = getMergeBlocks(F);
-    auto ContinueBlocks = getContinueBlocks(F);
+    HeaderMergeContinueBlocks Blocks = getHeaderMergeContinueBlocks(F);
+    auto &MergeBlocks = Blocks.Merge;
+    auto &ContinueBlocks = Blocks.Continue;
 
     for (BasicBlock &BB : F) {
       if (BB.size() != 1)
@@ -957,9 +950,10 @@ class SPIRVStructurizerImpl {
   bool addHeaderToRemainingDivergentDAG(Function &F) {
     bool Modified = false;
 
-    auto MergeBlocks = getMergeBlocks(F);
-    auto ContinueBlocks = getContinueBlocks(F);
-    auto HeaderBlocks = getHeaderBlocks(F);
+    HeaderMergeContinueBlocks Blocks = getHeaderMergeContinueBlocks(F);
+    auto &MergeBlocks = Blocks.Merge;
+    auto &ContinueBlocks = Blocks.Continue;
+    auto &HeaderBlocks = Blocks.Header;
 
     DomTreeBuilder::BBDomTree DT;
     DomTreeBuilder::BBPostDomTree PDT;

--- a/llvm/lib/Target/SPIRV/SPIRVStructurizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVStructurizer.cpp
@@ -135,9 +135,9 @@ static std::vector<Instruction *> getMergeInstructions(BasicBlock &BB) {
   return Output;
 }
 
-// Bundles the header/merge/continue block sets computed by
-// getHeaderMergeContinueBlocks so callers only needing a subset of them can
-// still share the single underlying scan.
+// Bundles the header/merge/continue block sets for a function, computed in a
+// single scan since they all classify the same instructions. Callers only
+// needing a subset of them still share the single underlying scan.
 struct HeaderMergeContinueBlocks {
   // Blocks in F having at least one OpLoopMerge or OpSelectionMerge
   // instruction.
@@ -148,24 +148,20 @@ struct HeaderMergeContinueBlocks {
   // Blocks in F referenced as continue target by at least 1 OpLoopMerge
   // instruction.
   SmallPtrSet<BasicBlock *, 2> Continue;
-};
 
-// Computes Header, Merge and Continue block sets for |F| in a single scan,
-// since they all classify the same instructions.
-static HeaderMergeContinueBlocks getHeaderMergeContinueBlocks(Function &F) {
-  HeaderMergeContinueBlocks Output;
-  for (BasicBlock &BB : F) {
-    for (Instruction &I : BB) {
-      if (BasicBlock *MB = getDesignatedMergeBlock(&I)) {
-        Output.Header.insert(&BB);
-        Output.Merge.insert(MB);
+  HeaderMergeContinueBlocks(Function &F) {
+    for (BasicBlock &BB : F) {
+      for (Instruction &I : BB) {
+        if (BasicBlock *MB = getDesignatedMergeBlock(&I)) {
+          Header.insert(&BB);
+          Merge.insert(MB);
+        }
+        if (BasicBlock *CB = getDesignatedContinueBlock(&I))
+          Continue.insert(CB);
       }
-      if (BasicBlock *CB = getDesignatedContinueBlock(&I))
-        Output.Continue.insert(CB);
     }
   }
-  return Output;
-}
+};
 
 // Do a preorder traversal of the CFG starting from the BB |Start|.
 // point. Calls |op| on each basic block encountered during the traversal.
@@ -638,7 +634,7 @@ class SPIRVStructurizerImpl {
     PDT.recalculate(F);
     bool Modified = false;
 
-    HeaderMergeContinueBlocks Blocks = getHeaderMergeContinueBlocks(F);
+    HeaderMergeContinueBlocks Blocks(F);
     auto &MergeBlocks = Blocks.Merge;
     auto &ContinueBlocks = Blocks.Continue;
 
@@ -916,7 +912,7 @@ class SPIRVStructurizerImpl {
   bool removeUselessBlocks(Function &F) {
     std::vector<BasicBlock *> ToRemove;
 
-    HeaderMergeContinueBlocks Blocks = getHeaderMergeContinueBlocks(F);
+    HeaderMergeContinueBlocks Blocks(F);
     auto &MergeBlocks = Blocks.Merge;
     auto &ContinueBlocks = Blocks.Continue;
 
@@ -950,7 +946,7 @@ class SPIRVStructurizerImpl {
   bool addHeaderToRemainingDivergentDAG(Function &F) {
     bool Modified = false;
 
-    HeaderMergeContinueBlocks Blocks = getHeaderMergeContinueBlocks(F);
+    HeaderMergeContinueBlocks Blocks(F);
     auto &MergeBlocks = Blocks.Merge;
     auto &ContinueBlocks = Blocks.Continue;
     auto &HeaderBlocks = Blocks.Header;


### PR DESCRIPTION
Split out of #211299 per review. getHeaderBlocks, getMergeBlocks and getContinueBlocks each did their own full scan of F even though they classify the same instructions; merge them into a single getHeaderMergeContinueBlocks scan.