### PR TITLE
[BOLT][RISCV] Fix atomic-add operand order

### DIFF
--- a/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
+++ b/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
@@ -555,10 +555,11 @@ public:
 
   void atomicAdd(MCInst &Inst, MCPhysReg RegAtomic, MCPhysReg RegTo,
                  MCPhysReg RegCnt) const {
+    // AMO operands are ordered as rd, rs2 (value), rs1 (address).
     Inst = MCInstBuilder(atomicAddOpc())
                .addReg(RegAtomic)
-               .addReg(RegTo)
-               .addReg(RegCnt);
+               .addReg(RegCnt)
+               .addReg(RegTo);
   }
 
   InstructionListType createRegCmpJE(MCPhysReg RegNo, const MCSymbol *Target,

--- a/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
+++ b/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
@@ -555,7 +555,6 @@ public:
 
   void atomicAdd(MCInst &Inst, MCPhysReg RegAtomic, MCPhysReg RegTo,
                  MCPhysReg RegCnt) const {
-    // AMO operands are ordered as rd, rs2 (value), rs1 (address).
     Inst = MCInstBuilder(atomicAddOpc())
                .addReg(RegAtomic)
                .addReg(RegCnt)

--- a/bolt/test/runtime/RISCV/basic-instrumentation.s
+++ b/bolt/test/runtime/RISCV/basic-instrumentation.s
@@ -2,6 +2,9 @@
 
 # RUN: %clang %cflags -Wl,-q -o %t.exe %s
 # RUN: llvm-bolt --instrument --instrumentation-file=%t.fdata -o %t.instr %t.exe
+# RUN: llvm-objdump -d --no-show-raw-insn --disassemble-symbols=main %t.instr \
+# RUN:   | FileCheck %s --check-prefix=INSTR
+# INSTR: amoadd.d zero, a1, (a0)
 
 ## Run the profiled binary and check that the profile reports at least that `f`
 ## has been called.


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/162411 had changed AMO operand order to rd, rs2 (value), rs1 (address).

same as https://github.com/llvm/llvm-project/pull/171580, the test are different.