### PR TITLE
[lldb][Windows] Mark unwind plan as valid at all instructions

### DIFF
--- a/lldb/source/Plugins/ABI/X86/ABIWindows_x86_64.cpp
+++ b/lldb/source/Plugins/ABI/X86/ABIWindows_x86_64.cpp
@@ -772,7 +772,7 @@ UnwindPlanSP ABIWindows_x86_64::CreateDefaultUnwindPlan() {
   plan_sp->AppendRow(std::move(row));
   plan_sp->SetSourceName("x86_64 default unwind plan");
   plan_sp->SetSourcedFromCompiler(eLazyBoolNo);
-  plan_sp->SetUnwindPlanValidAtAllInstructions(eLazyBoolNo);
+  plan_sp->SetUnwindPlanValidAtAllInstructions(eLazyBoolYes);
   return plan_sp;
 }
 


### PR DESCRIPTION
This is a follow up to https://github.com/llvm/llvm-project/pull/210076.

The unwind plan is now valid at every location.