### PR TITLE
[lldb] Don't consult the plan stack for a stop an auto-continue will discard

### DIFF
--- a/lldb/include/lldb/Target/ThreadPlan.h
+++ b/lldb/include/lldb/Target/ThreadPlan.h
@@ -380,8 +380,8 @@ public:
   /// subsequently processed plans.
   ///
   /// When processing the thread plan stack, this function gives plans the
-  /// ability to continue - even when subsequent plans return true from
-  /// `ShouldStop`. \see Thread::ShouldStop
+  /// ability to continue. If it returns true, the `ShouldStop` of
+  /// subsequently processed plans is not consulted. \see Thread::ShouldStop
   virtual bool ShouldAutoContinue(Event *event_ptr) { return false; }
 
   // Whether a "stop class" event should be reported to the "outside world".

--- a/lldb/source/Target/Thread.cpp
+++ b/lldb/source/Target/Thread.cpp
@@ -940,10 +940,42 @@ bool Thread::ShouldStop(Event *event_ptr) {
           if (should_stop)
             current_plan->WillStop();
 
-          if (current_plan->ShouldAutoContinue(event_ptr)) {
+          const bool auto_continue =
+              current_plan->ShouldAutoContinue(event_ptr);
+          if (auto_continue) {
             override_stop = true;
             LLDB_LOGF(log, "Plan %s auto-continue: true.",
                       current_plan->GetName());
+          }
+
+          // A plan that auto-continues has already settled that this stop will
+          // not be reported: override_stop discards whatever the plans below
+          // answer.  Asking them anyway is not free, because the asking
+          // consumes them -- a plan that answers MischiefManaged() is popped
+          // here, and it tears its state down on the way out, the way
+          // ThreadPlanRunToAddress deletes the breakpoint it was running to.
+          // With its vote discarded and its breakpoint gone, nothing is left
+          // to stop the thread and the process runs away.
+          //
+          // The plan that does this is the one nothing on the stack owns:
+          // SetupToStepOverBreakpointIfNeeded() interposes a
+          // ThreadPlanStepOverBreakpoint just before the resume, and gives it
+          // auto-continue exactly when it was interposed for a plan that
+          // wanted to run rather than step.  This stop is the end of the one
+          // instruction it stepped on that plan's behalf, not an event any
+          // plan below asked to see.  So pop it and resume instead: the plans
+          // below keep their state, and a BreakpointSite the thread is sitting
+          // on but has not executed is still installed, so it is hit for real
+          // on that resume -- which is also what keeps a user breakpoint there
+          // reported as a hit.
+          if (auto_continue &&
+              current_plan->GetKind() == ThreadPlan::eKindStepOverBreakpoint) {
+            LLDB_LOGF(log,
+                      "Plan %s auto-continues; not asking the plans below it "
+                      "about a stop that will not be reported.",
+                      current_plan->GetName());
+            PopPlan();
+            break;
           }
 
           // If a Controlling Plan wants to stop, we let it. Otherwise, see if

--- a/lldb/source/Target/Thread.cpp
+++ b/lldb/source/Target/Thread.cpp
@@ -944,6 +944,9 @@ bool Thread::ShouldStop(Event *event_ptr) {
             override_stop = true;
             LLDB_LOGF(log, "Plan %s auto-continue: true.",
                       current_plan->GetName());
+            // The ShouldAutoContinue contract: subsequent plans are not asked.
+            PopPlan();
+            break;
           }
 
           // If a Controlling Plan wants to stop, we let it. Otherwise, see if

--- a/lldb/test/API/functionalities/thread_plan/step_over_breakpoint_site/Makefile
+++ b/lldb/test/API/functionalities/thread_plan/step_over_breakpoint_site/Makefile
@@ -1,0 +1,3 @@
+C_SOURCES := main.c
+
+include Makefile.rules

--- a/lldb/test/API/functionalities/thread_plan/step_over_breakpoint_site/TestStepOverBreakpointSite.py
+++ b/lldb/test/API/functionalities/thread_plan/step_over_breakpoint_site/TestStepOverBreakpointSite.py
@@ -1,0 +1,142 @@
+"""
+Test that a thread plan queued while the thread sits on a breakpoint site keeps
+control of the process.
+
+Resuming from a stop on an enabled breakpoint site makes lldb push a
+ThreadPlanStepOverBreakpoint to single-step off the site first.  That plan
+auto-continues, and the stop it produces must not consume the plans below it:
+they keep their state, and the site the single step lands on is hit for real on
+the resume.
+"""
+
+import lldb
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+
+
+class StepOverBreakpointSiteTestCase(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def test_run_to_address_from_a_breakpoint_site(self):
+        """The pc is on an enabled breakpoint site when the plan is queued."""
+        thread, target, process = self.setup_target()
+        self.expect_run_to_next_instruction(target, process, thread)
+
+    def test_run_to_address_off_a_breakpoint_site(self):
+        """The control: the same plan, with the pc one instruction past the
+        site, which needs no step-over plan at all."""
+        thread, target, process = self.setup_target()
+        thread.StepInstruction(False)
+        self.assertState(process.GetState(), lldb.eStateStopped)
+        self.expect_run_to_next_instruction(target, process, thread)
+
+    def test_user_breakpoint_at_the_target_is_still_reported(self):
+        """A user breakpoint at the address the plan runs to must still be
+        reported as a hit: the thread steps off the site it was stopped on and
+        the site it lands on is hit on the resume, not swallowed."""
+        thread, target, process = self.setup_target()
+        next_pc = self.next_pc(target, thread)
+        user_bp = target.BreakpointCreateByAddress(next_pc)
+        self.assertTrue(user_bp.GetNumLocations() > 0, VALID_BREAKPOINT)
+
+        thread.RunToAddress(next_pc)
+
+        self.assertState(process.GetState(), lldb.eStateStopped)
+        self.assertEqual(thread.GetFrameAtIndex(0).GetPC(), next_pc)
+        self.assertEqual(
+            user_bp.GetHitCount(),
+            1,
+            "the user breakpoint at the address run to was not reported as hit",
+        )
+        self.assertStopReason(thread.GetStopReason(), lldb.eStopReasonBreakpoint)
+
+    def test_run_to_address_two_instructions_from_a_breakpoint_site(self):
+        """A target further than one instruction away must be reached, not
+        merely stepped towards: the single step off the site lands short of it,
+        and the thread has to carry on to the address it was given."""
+        thread, target, process = self.setup_target()
+        pc = thread.GetFrameAtIndex(0).GetPCAddress()
+        instructions = target.ReadInstructions(pc, 3)
+        self.assertEqual(instructions.GetSize(), 3)
+        target_pc = (
+            instructions.GetInstructionAtIndex(2).GetAddress().GetLoadAddress(target)
+        )
+
+        thread.RunToAddress(target_pc)
+
+        self.assertState(process.GetState(), lldb.eStateStopped)
+        self.assertEqual(
+            thread.GetFrameAtIndex(0).GetPC(),
+            target_pc,
+            "the thread stopped short of the address the plan was given",
+        )
+
+    def test_the_stepped_over_breakpoint_is_hit_again(self):
+        """The site the thread was parked on must be re-enabled after the plan
+        that stepped off it is popped, so a later pass hits it again."""
+        thread, target, process = self.setup_target()
+        breakpoint = target.GetBreakpointAtIndex(0)
+        self.assertEqual(breakpoint.GetHitCount(), 1)
+
+        self.expect_run_to_next_instruction(target, process, thread)
+        process.Continue()
+
+        self.assertState(process.GetState(), lldb.eStateStopped)
+        self.assertEqual(
+            breakpoint.GetHitCount(),
+            2,
+            "the breakpoint that was stepped over was not hit on the next pass",
+        )
+
+    def test_scripted_plan_queueing_the_run_to_address(self):
+        """The shape the issue reports: the run-to-address plan is queued by a
+        scripted thread plan rather than by the API directly."""
+        thread, target, process = self.setup_target()
+        self.runCmd("command script import run_to_address_plan.py")
+        next_pc = self.next_pc(target, thread)
+
+        args = lldb.SBStructuredData()
+        args.SetFromJSON('{"addr":%d}' % next_pc)
+        err = thread.StepUsingScriptedThreadPlan(
+            "run_to_address_plan.RunToAddress", args, True
+        )
+        self.assertSuccess(err)
+
+        self.assertState(
+            process.GetState(),
+            lldb.eStateStopped,
+            "the process ran away instead of stopping at the queued address",
+        )
+        self.assertEqual(thread.GetFrameAtIndex(0).GetPC(), next_pc)
+
+    def next_pc(self, target, thread):
+        pc = thread.GetFrameAtIndex(0).GetPCAddress()
+        instructions = target.ReadInstructions(pc, 2)
+        self.assertEqual(
+            instructions.GetSize(), 2, "could not read two instructions at the pc"
+        )
+        return instructions.GetInstructionAtIndex(1).GetAddress().GetLoadAddress(target)
+
+    def expect_run_to_next_instruction(self, target, process, thread):
+        next_pc = self.next_pc(target, thread)
+
+        thread.RunToAddress(next_pc)
+
+        self.assertState(
+            process.GetState(),
+            lldb.eStateStopped,
+            "the process was not stopped at the address the plan was given",
+        )
+        self.assertEqual(
+            thread.GetFrameAtIndex(0).GetPC(),
+            next_pc,
+            "the thread did not stop at the address the plan was given",
+        )
+
+    def setup_target(self):
+        self.build()
+        (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(
+            self, "Set a breakpoint here", lldb.SBFileSpec("main.c")
+        )
+        return thread, target, process

--- a/lldb/test/API/functionalities/thread_plan/step_over_breakpoint_site/TestStepOverBreakpointSite.py
+++ b/lldb/test/API/functionalities/thread_plan/step_over_breakpoint_site/TestStepOverBreakpointSite.py
@@ -1,0 +1,96 @@
+"""
+Test thread plans queued while the thread sits on an enabled breakpoint site.
+lldb first steps off the site with a ThreadPlanStepOverBreakpoint; that plan
+auto-continues without consulting the plans already on the stack.
+"""
+
+import lldb
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+
+
+class StepOverBreakpointSiteTestCase(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def run_to_breakpoint(self):
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "Set a breakpoint here", lldb.SBFileSpec("main.c")
+        )
+        return target, process, thread
+
+    def pc_after(self, target, thread, count):
+        """Return the load address `count` instructions after the current one."""
+        pc = thread.GetFrameAtIndex(0).GetPCAddress()
+        instructions = target.ReadInstructions(pc, count + 1)
+        self.assertEqual(instructions.GetSize(), count + 1)
+        return (
+            instructions.GetInstructionAtIndex(count)
+            .GetAddress()
+            .GetLoadAddress(target)
+        )
+
+    def run_to_next_instruction(self, target, process, thread):
+        next_pc = self.pc_after(target, thread, 1)
+        thread.RunToAddress(next_pc)
+        self.assertState(process.GetState(), lldb.eStateStopped)
+        self.assertEqual(thread.GetFrameAtIndex(0).GetPC(), next_pc)
+
+    def test_run_to_address_from_a_breakpoint_site(self):
+        """RunToAddress with the PC on a breakpoint site stops at the target."""
+        target, process, thread = self.run_to_breakpoint()
+        self.run_to_next_instruction(target, process, thread)
+
+    def test_run_to_address_off_a_breakpoint_site(self):
+        """RunToAddress with the PC off the breakpoint site stops at the target."""
+        target, process, thread = self.run_to_breakpoint()
+        thread.StepInstruction(False)
+        self.assertState(process.GetState(), lldb.eStateStopped)
+        self.run_to_next_instruction(target, process, thread)
+
+    def test_run_to_address_two_instructions_from_a_breakpoint_site(self):
+        """RunToAddress reaches a target beyond the single step off the site."""
+        target, process, thread = self.run_to_breakpoint()
+        target_pc = self.pc_after(target, thread, 2)
+        thread.RunToAddress(target_pc)
+        self.assertState(process.GetState(), lldb.eStateStopped)
+        self.assertEqual(thread.GetFrameAtIndex(0).GetPC(), target_pc)
+
+    def test_user_breakpoint_at_the_target_is_still_reported(self):
+        """A user breakpoint at the RunToAddress target is reported as hit."""
+        target, process, thread = self.run_to_breakpoint()
+        next_pc = self.pc_after(target, thread, 1)
+        user_bp = target.BreakpointCreateByAddress(next_pc)
+        self.assertTrue(user_bp.GetNumLocations() > 0, VALID_BREAKPOINT)
+        thread.RunToAddress(next_pc)
+        self.assertState(process.GetState(), lldb.eStateStopped)
+        self.assertEqual(thread.GetFrameAtIndex(0).GetPC(), next_pc)
+        self.assertStopReason(thread.GetStopReason(), lldb.eStopReasonBreakpoint)
+        self.assertEqual(user_bp.GetHitCount(), 1)
+
+    def test_the_stepped_over_breakpoint_is_hit_again(self):
+        """The breakpoint stepped over before RunToAddress resumes is hit again."""
+        target, process, thread = self.run_to_breakpoint()
+        breakpoint = target.GetBreakpointAtIndex(0)
+        self.assertEqual(breakpoint.GetHitCount(), 1)
+        self.run_to_next_instruction(target, process, thread)
+        process.Continue()
+        self.assertState(process.GetState(), lldb.eStateStopped)
+        self.assertStopReason(thread.GetStopReason(), lldb.eStopReasonBreakpoint)
+        self.assertEqual(breakpoint.GetHitCount(), 2)
+
+    def test_scripted_plan_queueing_the_run_to_address(self):
+        """A scripted plan that queues RunToAddress from a breakpoint site stops
+        at the target."""
+        target, process, thread = self.run_to_breakpoint()
+        self.runCmd("command script import run_to_address_plan.py")
+        next_pc = self.pc_after(target, thread, 1)
+        args = lldb.SBStructuredData()
+        args.SetFromJSON('{"addr":%d}' % next_pc)
+        err = thread.StepUsingScriptedThreadPlan(
+            "run_to_address_plan.RunToAddress", args, True
+        )
+        self.assertSuccess(err)
+        self.assertState(process.GetState(), lldb.eStateStopped)
+        self.assertEqual(thread.GetFrameAtIndex(0).GetPC(), next_pc)

--- a/lldb/test/API/functionalities/thread_plan/step_over_breakpoint_site/main.c
+++ b/lldb/test/API/functionalities/thread_plan/step_over_breakpoint_site/main.c
@@ -1,0 +1,10 @@
+static int f(int x) {
+  int y = x + 1; // Set a breakpoint here.
+  return y;
+}
+
+int main() {
+  int a = f(1);
+  a += f(2);
+  return a;
+}

--- a/lldb/test/API/functionalities/thread_plan/step_over_breakpoint_site/run_to_address_plan.py
+++ b/lldb/test/API/functionalities/thread_plan/step_over_breakpoint_site/run_to_address_plan.py
@@ -1,0 +1,21 @@
+import lldb
+
+
+class RunToAddress:
+    """The shape the issue reports: a scripted plan whose only job is to queue a
+    run-to-address sub-plan for an address it is handed."""
+
+    def __init__(self, thread_plan, args_data):
+        self.thread_plan = thread_plan
+        target = thread_plan.GetThread().GetProcess().GetTarget()
+        addr = args_data.GetValueForKey("addr").GetUnsignedIntegerValue()
+        self.sub_plan = thread_plan.QueueThreadPlanForRunToAddress(
+            lldb.SBAddress(addr, target), lldb.SBError()
+        )
+
+    def explains_stop(self, event):
+        return False
+
+    def should_stop(self, event):
+        self.thread_plan.SetPlanComplete(True)
+        return True

--- a/lldb/test/API/functionalities/thread_plan/step_over_breakpoint_site/run_to_address_plan.py
+++ b/lldb/test/API/functionalities/thread_plan/step_over_breakpoint_site/run_to_address_plan.py
@@ -1,0 +1,20 @@
+import lldb
+
+
+class RunToAddress:
+    """Queues a run-to-address sub-plan for the address it is handed."""
+
+    def __init__(self, thread_plan, args_data):
+        self.thread_plan = thread_plan
+        target = thread_plan.GetThread().GetProcess().GetTarget()
+        addr = args_data.GetValueForKey("addr").GetUnsignedIntegerValue()
+        self.sub_plan = thread_plan.QueueThreadPlanForRunToAddress(
+            lldb.SBAddress(addr, target), lldb.SBError()
+        )
+
+    def explains_stop(self, event):
+        return False
+
+    def should_stop(self, event):
+        self.thread_plan.SetPlanComplete(True)
+        return True


### PR DESCRIPTION
Fixes part (2) of #215189. The sibling PR for part (1) is #215521. The two are
independent, but are best landed together.

When a completed thread plan auto-continues, `Thread::ShouldStop()` still
consults subsequent plans and then discards their stop decisions. Those calls
can change the state of the plans being consulted. In the failing case,
`ThreadPlanRunToAddress` loses the breakpoint it was running to, so the process
runs past the requested address.

This does not require a scripted plan:

```python
# thread stopped on an enabled breakpoint site
thread.RunToAddress(next_instruction_address)   # before: process runs away
```

`ThreadPlan.h` already says that an auto-continuing plan overrides the
`ShouldStop` of subsequently processed plans. Tighten that contract so their
`ShouldStop` is not consulted at all, and make `Thread::ShouldStop()` follow it
by ending the plan walk after popping the auto-continuing plan.

The subsequent plans therefore keep their state, and an unexecuted
`BreakpointSite` at the current PC is hit normally on the following resume.

### Testing

Adds
`lldb/test/API/functionalities/thread_plan/step_over_breakpoint_site/`
with coverage for:

* `RunToAddress` from an enabled breakpoint site;
* the same plan queued by a scripted thread plan;
* the stepped-over breakpoint being hit again on a later pass;
* `RunToAddress` with the PC already off the breakpoint site;
* a target two instructions away;
* a user breakpoint at the target address.

The first three fail before the change on both Linux and Windows. The remaining
three pass before and after the change and cover the surrounding behavior.

Whole `check-lldb` passes on both Linux x86_64 and Windows x86_64 with 0 failed
and 0 unresolved tests.

macOS is not covered because no host was available.

---

Tool-use disclosure, per the LLVM AI tool policy: this change was prepared with
the assistance of Claude Code (`Assisted-by:` trailer on the commit). Everything
was read and reviewed before posting.
