### PR TITLE
[lldb][test] Do not check order of elements in SharedCluster test

### DIFF
--- a/lldb/unittests/Utility/SharedClusterTest.cpp
+++ b/lldb/unittests/Utility/SharedClusterTest.cpp
@@ -54,5 +54,5 @@ TEST(SharedCluster, ClusterManager) {
     }
     ASSERT_THAT(Queue, testing::IsEmpty());
   }
-  ASSERT_THAT(Queue, testing::ElementsAre(1, 2));
+  ASSERT_THAT(Queue, testing::UnorderedElementsAre(1, 2));
 }


### PR DESCRIPTION
Fixes #215310

ClusterManager uses a SmallPtrSet to track elements. SmallPtrSet is not intentionally ordered, but its "small" representation is when only using it in the ways that SmallPtrSet does.

When LLVM_REVERSE_ITERATION is ON, the order is reversed which causes this unit test to fail.

From what I understand, the order is not important. So I've changed the test to ignore the element order.

I think the large representation of SmallPtrSet is more likely to be unordered. So the fact that we've been using it in the field since 2022 (33722848fcb5b569ab3a388cae15f31acf9a9c5e) also backs up order not being important.