### PR TITLE
[VPlan][NFC] Decide consecutive mem-op predication from VPlan masks.

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -5456,7 +5456,8 @@ void VPlanTransforms::makeMemOpWideningDecisions(VPlan &Plan, VFRange &Range,
         "makeVPlanMemOpDecision", ProcessSubset, Plan, [&](VPInstruction *VPI) {
           Instruction *I = VPI->getUnderlyingInstr();
           bool IsLoad = VPI->getOpcode() == Instruction::Load;
-          if (RecipeBuilder.isPredicatedInst(I) || !IsLoad ||
+          // Skip accesses that already carry a mask from VPlanPredicator.
+          if (VPI->isMasked() || !IsLoad ||
               !vputils::isUsedByLoadStoreAddress(VPI))
             return false;
 
@@ -5495,9 +5496,9 @@ void VPlanTransforms::makeMemOpWideningDecisions(VPlan &Plan, VFRange &Range,
         bool Reverse = Stride == -1;
 
         // A predicated access can only be widened (rather than scalarized) if
-        // the target supports a masked load/store for it.
-        // TODO: Determine if a load/store needs predication directly in VPlan.
-        bool IsPredicated = RecipeBuilder.isPredicatedInst(I);
+        // the target supports a masked load/store for it. Use the mask
+        // attached by VPlanPredicator instead of the legacy CM query.
+        bool IsPredicated = VPI->isMasked();
         if (IsPredicated && !CostCtx.Config.isLegalMaskedLoadOrStore(
                                 IsLoad, ScalarTy, getLoadStoreAlignment(I),
                                 getLoadStoreAddressSpace(I)))


### PR DESCRIPTION
Use the mask attached by VPlanPredicator instead of the legacy isPredicatedInst cost-model query when widening consecutive loads and stores.