### PR TITLE
[libc++] Fix `expected::error_or(...) &&` test

### DIFF
--- a/libcxx/test/std/utilities/expected/expected.expected/observers/error_or.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/observers/error_or.pass.cpp
@@ -39,14 +39,14 @@ constexpr bool test_default_template_arg() {
 
   // &&, has_value()
   {
-    const std::expected<int, ConstructFromInt> e(5);
+    std::expected<int, ConstructFromInt> e(5);
     std::same_as<ConstructFromInt> decltype(auto) x = std::move(e).error_or(10);
     assert(x.value == 10);
   }
 
   // &&, !has_value()
   {
-    const std::expected<int, ConstructFromInt> e(std::unexpect, 5);
+    std::expected<int, ConstructFromInt> e(std::unexpect, 5);
     std::same_as<ConstructFromInt> decltype(auto) x = std::move(e).error_or(10);
     assert(x.value == 5);
   }

--- a/libcxx/test/std/utilities/expected/expected.void/observers/error_or.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/observers/error_or.pass.cpp
@@ -39,14 +39,14 @@ constexpr bool test_default_template_arg() {
 
   // &&, has_value()
   {
-    const std::expected<void, ConstructFromInt> e;
+    std::expected<void, ConstructFromInt> e;
     std::same_as<ConstructFromInt> decltype(auto) x = std::move(e).error_or(10);
     assert(x.value == 10);
   }
 
   // &&, !has_value()
   {
-    const std::expected<void, ConstructFromInt> e(std::unexpect, 5);
+    std::expected<void, ConstructFromInt> e(std::unexpect, 5);
     std::same_as<ConstructFromInt> decltype(auto) x = std::move(e).error_or(10);
     assert(x.value == 5);
   }


### PR DESCRIPTION
In tests that should test the `expected::error_or(...) &&` member function the `e` member is declared as `const`, thus the `const &` version is used and the `&&` overload stays untested. This PR removes the `const` specifier from the variable.