### PR TITLE
lit/reports.py: Make Py3.8-compatible (for #211066)

### DIFF
--- a/llvm/utils/lit/lit/reports.py
+++ b/llvm/utils/lit/lit/reports.py
@@ -6,6 +6,7 @@ import json
 import os
 import tempfile
 
+from typing import Tuple
 from xml.sax.saxutils import quoteattr as quo
 
 import lit.Test
@@ -338,7 +339,7 @@ class WttReport(Report):
             base_dt.microsecond // 1000
         )
 
-        def times(test) -> tuple[int, int]:
+        def times(test) -> Tuple[int, int]:
             elapsed_time = test.result.elapsed or 0.0
             start_time = test.result.start - base if test.result.start else 0.0
             return int(start_time), int(start_time + elapsed_time)


### PR DESCRIPTION
I know py3.8 is slightly old. That said;

- llvm/CMakeLists.txt restricts the bottom version as 3.8
- This is not a functionally-critical change

I won't object further discussions if version upgrade would be required.