### PR TITLE
[Offload] Add rpath to LLVM libs if dynamically linked

### DIFF
--- a/offload/CMakeLists.txt
+++ b/offload/CMakeLists.txt
@@ -328,6 +328,16 @@ set(LIBOMPTARGET_LLVM_LIBRARY_DIR "${LLVM_LIBRARY_DIR}" CACHE STRING
 set(LIBOMPTARGET_LLVM_LIBRARY_INTDIR "${LIBOMPTARGET_LIBRARY_DIR}" CACHE STRING
   "Path to folder where intermediate libraries will be output")
 
+# If LLVM is dynamically linked we need to add its libraries.
+set(OFFLOAD_INSTALL_RPATH "$ORIGIN")
+if(LLVM_LINK_LLVM_DYLIB)
+  file(RELATIVE_PATH llvm_libdir_relpath
+       "${CMAKE_INSTALL_PREFIX}/${OFFLOAD_INSTALL_LIBDIR}"
+       "${CMAKE_INSTALL_PREFIX}/lib${LLVM_LIBDIR_SUFFIX}")
+  string(REGEX REPLACE "/$" "" llvm_libdir_relpath "${llvm_libdir_relpath}")
+  list(APPEND OFFLOAD_INSTALL_RPATH "$ORIGIN/${llvm_libdir_relpath}")
+endif()
+
 add_subdirectory(tools/offload-tblgen)
 
 # Build offloading plugins and device RTLs if they are available.

--- a/offload/liboffload/CMakeLists.txt
+++ b/offload/liboffload/CMakeLists.txt
@@ -43,7 +43,7 @@ target_compile_definitions(LLVMOffload PRIVATE
 
 set_target_properties(LLVMOffload PROPERTIES
                       POSITION_INDEPENDENT_CODE ON
-                      INSTALL_RPATH "$ORIGIN"
+                      INSTALL_RPATH "${OFFLOAD_INSTALL_RPATH}"
                       BUILD_RPATH "$ORIGIN:${CMAKE_CURRENT_BINARY_DIR}/..")
 if(UNIX AND NOT APPLE)
   set_target_properties(LLVMOffload PROPERTIES

--- a/offload/libomptarget/CMakeLists.txt
+++ b/offload/libomptarget/CMakeLists.txt
@@ -52,7 +52,7 @@ target_link_options(omptarget PRIVATE ${offload_link_flags})
 # are now separated in the build directory.
 set_target_properties(omptarget PROPERTIES
                       POSITION_INDEPENDENT_CODE ON
-                      INSTALL_RPATH "$ORIGIN"
+                      INSTALL_RPATH "${OFFLOAD_INSTALL_RPATH}"
                       BUILD_RPATH "$ORIGIN:${CMAKE_CURRENT_BINARY_DIR}/..")
 if(UNIX AND NOT APPLE)
   set_target_properties(omptarget PROPERTIES


### PR DESCRIPTION
Summary:
The offload/ library is different from every other LLVM runtime in that
it links the LLVM libraries themselves. The issue here is that in the
normal configuration, `libomptarget.so` goes in `lib/<triple>` while the
LLVM libs it depends on goes in `lib/`. If the LLVM libraries are
statically linked, there is no problem. However, we need to make sure
these point to the right place transitively when built in a shared
configuration. This solves the edge from `libomptarget -> LLVM`. The
edge from `user app -> libomptarget` should be solved by
`-frtlib-add-rpath`.

Should ideally fix the LLVM half of https://github.com/llvm/llvm-project/pull/215532
