### PR TITLE
HashingTest.cpp: Prune `StructWithHashBuilderAndHashValueSupport::hash_value()` [-Wunused-template]

### DIFF
--- a/llvm/unittests/ADT/HashingTest.cpp
+++ b/llvm/unittests/ADT/HashingTest.cpp
@@ -390,9 +390,6 @@ TEST(HashingTest, HashWithHashBuilder) {
 struct StructWithHashBuilderAndHashValueSupport {
   char C;
   int I;
-  template <typename HasherT, llvm::endianness Endianness>
-  friend void addHash(llvm::HashBuilder<HasherT, Endianness> &HBuilder,
-                      const StructWithHashBuilderAndHashValueSupport &Value) {}
   friend hash_code
   hash_value(const StructWithHashBuilderAndHashValueSupport &Value) {
     return 0xbeef;


### PR DESCRIPTION
The customized version of `hash_value()` won't use it.