### PR TITLE
[lldb][NFC] Fix unused variables in RegisterContextPOSIXCore_riscv32

### DIFF
--- a/lldb/source/Plugins/Process/elf-core/RegisterContextPOSIXCore_riscv32.cpp
+++ b/lldb/source/Plugins/Process/elf-core/RegisterContextPOSIXCore_riscv32.cpp
@@ -49,8 +49,10 @@ RegisterContextCorePOSIX_riscv32::RegisterContextCorePOSIX_riscv32(
   // Compute the maximum register counts for GPR, FPR, and CSR.
   constexpr uint32_t k_num_gpr_registers =
       std::size(g_register_infos_riscv32_gpr);
+  UNUSED_IF_ASSERT_DISABLED(k_num_gpr_registers);
   constexpr uint32_t k_num_fpr_registers =
       std::size(g_register_infos_riscv32_fpr);
+  UNUSED_IF_ASSERT_DISABLED(k_num_fpr_registers);
   constexpr uint32_t k_num_csr_registers =
       std::size(g_register_infos_riscv32_csr);
   const ArchSpec &target_arch = m_reg_infos_up->GetTargetArchitecture();


### PR DESCRIPTION
These are only used in asserts.