### PR TITLE
[lldb] Use `GetValueAsUnsigned` for pointers in an `lldb.value`

### DIFF
--- a/lldb/bindings/python/python-extensions.swig
+++ b/lldb/bindings/python/python-extensions.swig
@@ -540,7 +540,10 @@ class value(object):
         return complex (int(self))
 
     def __int__(self):
-        is_num,is_sign = is_numeric_type(self.sbvalue.GetType().GetCanonicalType().GetBasicType())
+        ty = self.sbvalue.GetType().GetCanonicalType()
+        if ty.IsPointerType():
+            return self.sbvalue.GetValueAsUnsigned()
+        is_num,is_sign = is_numeric_type(ty.GetBasicType())
         if is_num and not is_sign: return self.sbvalue.GetValueAsUnsigned()
         return self.sbvalue.GetValueAsSigned()
 


### PR DESCRIPTION
When we had a pointer in an `lldb.value`, we used to use `GetValueAsSigned`. If the sign bit is set, we'd get negative values like in the failed lldb-arm-ubuntu test (https://github.com/llvm/llvm-project/pull/214295#issuecomment-5254541467).

With this PR, we use `GetValueAsUnsigned` for pointers to get the unsigned value. I'm not sure if we should use `AsUnsigned` or `AsAddress` here. The difference is that `AsAddress` will clear the top bits. In the test, I'm using `assertEqual(arr_start + 2, arr[1].sbvalue.GetLoadAddress())`, but as far as I know, `GetLoadAddress` will not clear any bits(?)