### PR TITLE
[RISCV] Fix -Wunused-variable in #214866

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVZacasABIFix.cpp
+++ b/llvm/lib/Target/RISCV/RISCVZacasABIFix.cpp
@@ -72,6 +72,9 @@ bool RISCVZacasABIFixImpl::visitAtomicCmpXchgInst(AtomicCmpXchgInst &I) {
 }
 
 bool RISCVZacasABIFixImpl::run(Function &F) {
+  if (!ST->hasStdExtZacas())
+    return false;
+
   bool MadeChange = false;
   for (auto &BB : F)
     for (Instruction &I : llvm::make_early_inc_range(BB))
@@ -85,7 +88,7 @@ bool RISCVZacasABIFixLegacy::runOnFunction(Function &F) {
   auto &TM = TPC.getTM<RISCVTargetMachine>();
   auto *ST = &TM.getSubtarget<RISCVSubtarget>(F);
 
-  if (skipFunction(F) || !ST->hasStdExtZacas())
+  if (skipFunction(F))
     return false;
 
   return RISCVZacasABIFixImpl(ST).run(F);
@@ -105,8 +108,6 @@ FunctionPass *llvm::createRISCVZacasABIFixPass() {
 PreservedAnalyses RISCVZacasABIFixPass::run(Function &F,
                                             FunctionAnalysisManager &FAM) {
   auto *ST = &TM->getSubtarget<RISCVSubtarget>(F);
-  if (!ST->hasStdExtZacas())
-    return PreservedAnalyses::all();
 
   bool Changed = RISCVZacasABIFixImpl(ST).run(F);
   if (!Changed)


### PR DESCRIPTION
ST was unused (outside of assertions) as a class member, and it turns out we can just make the implementation common for what the ST is actually used for.