### PR TITLE
[Offload] Add logger in Plugin API functions for OpenMP

### DIFF
--- a/offload/include/Shared/APITrace.h
+++ b/offload/include/Shared/APITrace.h
@@ -1,0 +1,162 @@
+//===-- Shared/APITrace.h - Tracing of offload API calls --------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Prints one line per offload API call when the OMP_INFOTYPE_API_TRACE bit of
+// LIBOMPTARGET_INFO is set:
+//
+//   ---> init_device(.DeviceId = 0)-> OFFLOAD_SUCCESS (1053 us)
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef OMPTARGET_SHARED_API_TRACE_H
+#define OMPTARGET_SHARED_API_TRACE_H
+
+#include "APITypes.h"
+#include "Debug.h"
+#include "omptarget.h"
+
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <chrono>
+#include <type_traits>
+#include <utility>
+
+namespace llvm::offload::trace {
+
+/// The level is read on every call so that __tgt_set_info_flag can turn tracing
+/// on and off around a region of interest.
+inline bool isTraceEnabled() { return getInfoLevel() & OMP_INFOTYPE_API_TRACE; }
+
+inline raw_ostream &operator<<(raw_ostream &OS, __tgt_device_binary Binary) {
+  return OS << reinterpret_cast<void *>(Binary.handle);
+}
+
+inline raw_ostream &operator<<(raw_ostream &OS, OffloadStatusTy Status) {
+  switch (Status) {
+  case OFFLOAD_SUCCESS:
+    return OS << "OFFLOAD_SUCCESS";
+  case OFFLOAD_FAIL:
+    return OS << "OFFLOAD_FAIL";
+  }
+  return OS << static_cast<int32_t>(Status);
+}
+
+inline raw_ostream &operator<<(raw_ostream &OS, TargetAllocTy Kind) {
+  switch (Kind) {
+  case TARGET_ALLOC_DEVICE:
+    return OS << "TARGET_ALLOC_DEVICE";
+  case TARGET_ALLOC_HOST:
+    return OS << "TARGET_ALLOC_HOST";
+  case TARGET_ALLOC_SHARED:
+    return OS << "TARGET_ALLOC_SHARED";
+  case TARGET_ALLOC_DEFAULT:
+    return OS << "TARGET_ALLOC_DEFAULT";
+  }
+  return OS << static_cast<int32_t>(Kind);
+}
+
+template <typename Ty, typename = void> struct IsPrintable : std::false_type {};
+template <typename Ty>
+struct IsPrintable<Ty, std::void_t<decltype(std::declval<raw_ostream &>()
+                                            << std::declval<const Ty &>())>>
+    : std::true_type {};
+
+/// Types with no raw_ostream overload are shown as an address, so that adding a
+/// parameter to a traced entry point never breaks the build.
+template <typename Ty> void printArg(raw_ostream &OS, const Ty &Arg) {
+  using DecayedTy = std::decay_t<Ty>;
+  if constexpr (std::is_same_v<DecayedTy, char *> ||
+                std::is_same_v<DecayedTy, const char *>) {
+    if (Arg)
+      OS << '"' << Arg << '"';
+    else
+      OS << "(nullptr)";
+  } else if constexpr (IsPrintable<Ty>::value) {
+    OS << Arg;
+  } else {
+    OS << '&' << static_cast<const void *>(&Arg);
+  }
+}
+
+/// Arguments are formatted on entry so that output parameters show the values
+/// the caller passed in, and the line is buffered so that concurrent calls do
+/// not interleave.
+class CallTraceTy {
+  SmallString<128> Buffer;
+  raw_svector_ostream OS;
+  std::chrono::steady_clock::time_point Start;
+  bool Enabled;
+
+  /// Argument names arrive as one stringified list, consumed alongside the
+  /// values they belong to. Only the trailing identifier is kept so that a
+  /// conversion such as 'TargetAllocTy(Kind)' is still named 'Kind'.
+  static StringRef takeName(StringRef &Names) {
+    static constexpr StringLiteral IdentChars =
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_";
+
+    auto [Name, Rest] = Names.split(',');
+    Names = Rest;
+
+    size_t End = Name.find_last_of(IdentChars);
+    if (End == StringRef::npos)
+      return Name.trim();
+    return Name.slice(Name.find_last_not_of(IdentChars, End) + 1, End + 1);
+  }
+
+public:
+  template <typename... ArgsTy>
+  CallTraceTy(const char *Name, StringRef ArgNames, ArgsTy &&...Args)
+      : OS(Buffer), Enabled(isTraceEnabled()) {
+    if (!Enabled)
+      return;
+
+    OS << "---> " << Name << '(';
+    StringRef Separator = "";
+    ((OS << Separator << '.' << takeName(ArgNames) << " = ", printArg(OS, Args),
+      Separator = ", "),
+     ...);
+    OS << ')';
+
+    Start = std::chrono::steady_clock::now();
+  }
+
+  CallTraceTy(const CallTraceTy &) = delete;
+  CallTraceTy &operator=(const CallTraceTy &) = delete;
+
+  ~CallTraceTy() {
+    if (!Enabled)
+      return;
+
+    auto Elapsed = std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::steady_clock::now() - Start);
+    OS << " (" << Elapsed.count() << " us)\n";
+    errs() << OS.str();
+  }
+
+  template <typename Ty> Ty &&result(Ty &&Result) {
+    if (Enabled) {
+      OS << "-> ";
+      printArg(OS, Result);
+    }
+    return std::forward<Ty>(Result);
+  }
+};
+
+} // namespace llvm::offload::trace
+
+#define OFFLOAD_TRACE_CALL(...)                                                \
+  ::llvm::offload::trace::CallTraceTy OffloadCallTrace(                        \
+      __func__, #__VA_ARGS__ __VA_OPT__(, ) __VA_ARGS__)
+
+/// Only valid where OFFLOAD_TRACE_CALL opened a scope. Optional; entry points
+/// returning void just open the scope.
+#define OFFLOAD_TRACE_RESULT(Result) OffloadCallTrace.result(Result)
+
+#endif // OMPTARGET_SHARED_API_TRACE_H

--- a/offload/include/Shared/APITrace.h
+++ b/offload/include/Shared/APITrace.h
@@ -6,10 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Prints one line per offload API call when the OMP_INFOTYPE_API_TRACE bit of
-// LIBOMPTARGET_INFO is set:
+// Prints one line per offload API call while tracing is enabled:
 //
 //   ---> init_device(.DeviceId = 0)-> OFFLOAD_SUCCESS (1053 us)
+//
+// Tracing is off until the runtime above the plugins turns it on, see
+// GenericPluginTy::set_api_trace.
 //
 //===----------------------------------------------------------------------===//
 
@@ -17,22 +19,33 @@
 #define OMPTARGET_SHARED_API_TRACE_H
 
 #include "APITypes.h"
-#include "Debug.h"
 #include "omptarget.h"
 
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <atomic>
 #include <chrono>
 #include <type_traits>
 #include <utility>
 
 namespace llvm::offload::trace {
 
-/// The level is read on every call so that __tgt_set_info_flag can turn tracing
-/// on and off around a region of interest.
-inline bool isTraceEnabled() { return getInfoLevel() & OMP_INFOTYPE_API_TRACE; }
+inline std::atomic<bool> &getTraceEnabledFlag() {
+  static std::atomic<bool> Enabled = false;
+  return Enabled;
+}
+
+/// The flag is read on every call so that tracing can be toggled around a
+/// region of interest.
+inline bool isTraceEnabled() {
+  return getTraceEnabledFlag().load(std::memory_order_relaxed);
+}
+
+inline void setTraceEnabled(bool Enable) {
+  getTraceEnabledFlag().store(Enable, std::memory_order_relaxed);
+}
 
 inline raw_ostream &operator<<(raw_ostream &OS, __tgt_device_binary Binary) {
   return OS << reinterpret_cast<void *>(Binary.handle);
@@ -94,20 +107,12 @@ class CallTraceTy {
   std::chrono::steady_clock::time_point Start;
   bool Enabled;
 
-  /// Argument names arrive as one stringified list, consumed alongside the
-  /// values they belong to. Only the trailing identifier is kept so that a
-  /// conversion such as 'TargetAllocTy(Kind)' is still named 'Kind'.
+  /// The argument names arrive as a single stringified macro argument list,
+  /// e.g. "DeviceId, Size, HostPtr", which is consumed one name at a time.
   static StringRef takeName(StringRef &Names) {
-    static constexpr StringLiteral IdentChars =
-        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_";
-
     auto [Name, Rest] = Names.split(',');
     Names = Rest;
-
-    size_t End = Name.find_last_of(IdentChars);
-    if (End == StringRef::npos)
-      return Name.trim();
-    return Name.slice(Name.find_last_not_of(IdentChars, End) + 1, End + 1);
+    return Name.trim();
   }
 
 public:

--- a/offload/include/Shared/Debug.h
+++ b/offload/include/Shared/Debug.h
@@ -63,6 +63,8 @@ enum OpenMPInfoType : uint32_t {
   OMP_INFOTYPE_DATA_TRANSFER = 0x0020,
   // Print whenever data does not have a viable device counterpart.
   OMP_INFOTYPE_EMPTY_MAPPING = 0x0040,
+  // Print every plugin API call with its arguments, result and duration.
+  OMP_INFOTYPE_API_TRACE = 0x0080,
   // Enable every flag.
   OMP_INFOTYPE_ALL = 0xffffffff,
 };

--- a/offload/include/omptarget.h
+++ b/offload/include/omptarget.h
@@ -28,8 +28,11 @@
 
 #include "llvm/ADT/SmallVector.h"
 
-#define OFFLOAD_SUCCESS (0)
-#define OFFLOAD_FAIL (~0)
+/// Return status of the internal offload and plugin interfaces.
+enum OffloadStatusTy : int32_t {
+  OFFLOAD_SUCCESS = 0,
+  OFFLOAD_FAIL = ~0,
+};
 
 #define OFFLOAD_DEVICE_DEFAULT -1
 

--- a/offload/libomptarget/PluginManager.cpp
+++ b/offload/libomptarget/PluginManager.cpp
@@ -47,6 +47,9 @@ void PluginManager::init() {
   } while (false);
 #include "Shared/Targets.def"
 
+  for (auto &Plugin : Plugins)
+    Plugin->set_api_trace(getInfoLevel() & OMP_INFOTYPE_API_TRACE);
+
   ODBG(ODT_Init) << "RTLs loaded!";
 }
 

--- a/offload/libomptarget/interface.cpp
+++ b/offload/libomptarget/interface.cpp
@@ -589,6 +589,9 @@ EXTERN void __tgt_set_info_flag(uint32_t NewInfoLevel) {
   assert(PM && "Runtime not initialized");
   std::atomic<uint32_t> &InfoLevel = getInfoLevelInternal();
   InfoLevel.store(NewInfoLevel);
+
+  for (auto &Plugin : PM->plugins())
+    Plugin.set_api_trace(NewInfoLevel & OMP_INFOTYPE_API_TRACE);
 }
 
 EXTERN int __tgt_print_device_info(int64_t DeviceId) {

--- a/offload/plugins-nextgen/common/include/PluginInterface.h
+++ b/offload/plugins-nextgen/common/include/PluginInterface.h
@@ -1794,6 +1794,9 @@ public:
   /// Remove the event from the plugin.
   void set_info_flag(uint32_t NewInfoLevel);
 
+  /// Enable or disable tracing of every plugin API call.
+  void set_api_trace(bool Enable);
+
   /// Creates an asynchronous queue for the given plugin.
   int32_t init_async_info(int32_t DeviceId, __tgt_async_info **AsyncInfoPtr);
 

--- a/offload/plugins-nextgen/common/src/PluginInterface.cpp
+++ b/offload/plugins-nextgen/common/src/PluginInterface.cpp
@@ -10,6 +10,7 @@
 
 #include "PluginInterface.h"
 
+#include "Shared/APITrace.h"
 #include "Shared/APITypes.h"
 #include "Shared/Debug.h"
 #include "Shared/Environment.h"
@@ -1398,9 +1399,13 @@ Expected<bool> GenericPluginTy::checkBitcodeImage(StringRef Image) const {
   return M.getTargetTriple().getArch() == getTripleArch();
 }
 
-int32_t GenericPluginTy::is_initialized() const { return Initialized; }
+int32_t GenericPluginTy::is_initialized() const {
+  OFFLOAD_TRACE_CALL();
+  return OFFLOAD_TRACE_RESULT(Initialized);
+}
 
 int32_t GenericPluginTy::isPluginCompatible(StringRef Image) {
+  OFFLOAD_TRACE_CALL();
   auto HandleError = [&](Error Err) -> bool {
     std::string ErrStr = toString(std::move(Err));
     ODBG(OLDT_Init) << "Failure to check validity of image "
@@ -1416,24 +1421,25 @@ int32_t GenericPluginTy::isPluginCompatible(StringRef Image) {
   case file_magic::elf_core: {
     auto MatchOrErr = checkELFImage(Image);
     if (Error Err = MatchOrErr.takeError())
-      return HandleError(std::move(Err));
-    return *MatchOrErr;
+      return OFFLOAD_TRACE_RESULT(HandleError(std::move(Err)));
+    return OFFLOAD_TRACE_RESULT(*MatchOrErr);
   }
   case file_magic::bitcode: {
     auto MatchOrErr = checkBitcodeImage(Image);
     if (Error Err = MatchOrErr.takeError())
-      return HandleError(std::move(Err));
-    return *MatchOrErr;
+      return OFFLOAD_TRACE_RESULT(HandleError(std::move(Err)));
+    return OFFLOAD_TRACE_RESULT(*MatchOrErr);
   }
   default:
     auto MatchOrErr = isImageCompatible(Image);
     if (Error Err = MatchOrErr.takeError())
-      return HandleError(std::move(Err));
-    return *MatchOrErr;
+      return OFFLOAD_TRACE_RESULT(HandleError(std::move(Err)));
+    return OFFLOAD_TRACE_RESULT(*MatchOrErr);
   }
 }
 
 int32_t GenericPluginTy::isDeviceCompatible(int32_t DeviceId, StringRef Image) {
+  OFFLOAD_TRACE_CALL(DeviceId);
   auto HandleError = [&](Error Err) -> bool {
     std::string ErrStr = toString(std::move(Err));
     ODBG(OLDT_Init) << "Failure to check validity of image "
@@ -1449,56 +1455,65 @@ int32_t GenericPluginTy::isDeviceCompatible(int32_t DeviceId, StringRef Image) {
   case file_magic::elf_core: {
     auto MatchOrErr = checkELFImage(Image);
     if (Error Err = MatchOrErr.takeError())
-      return HandleError(std::move(Err));
+      return OFFLOAD_TRACE_RESULT(HandleError(std::move(Err)));
     if (!*MatchOrErr)
-      return false;
+      return OFFLOAD_TRACE_RESULT(false);
 
     // Perform plugin-dependent checks for the specific architecture if needed.
     auto CompatibleOrErr = isELFCompatible(DeviceId, Image);
     if (Error Err = CompatibleOrErr.takeError())
-      return HandleError(std::move(Err));
-    return *CompatibleOrErr;
+      return OFFLOAD_TRACE_RESULT(HandleError(std::move(Err)));
+    return OFFLOAD_TRACE_RESULT(*CompatibleOrErr);
   }
   case file_magic::bitcode: {
     auto MatchOrErr = checkBitcodeImage(Image);
     if (Error Err = MatchOrErr.takeError())
-      return HandleError(std::move(Err));
-    return *MatchOrErr;
+      return OFFLOAD_TRACE_RESULT(HandleError(std::move(Err)));
+    return OFFLOAD_TRACE_RESULT(*MatchOrErr);
   }
   default:
     auto MatchOrErr = isImageCompatible(DeviceId, Image);
     if (Error Err = MatchOrErr.takeError())
-      return HandleError(std::move(Err));
-    return *MatchOrErr;
+      return OFFLOAD_TRACE_RESULT(HandleError(std::move(Err)));
+    return OFFLOAD_TRACE_RESULT(*MatchOrErr);
   }
 }
 
 int32_t GenericPluginTy::is_device_initialized(int32_t DeviceId) const {
-  return isValidDeviceId(DeviceId) && Devices[DeviceId] != nullptr;
+  OFFLOAD_TRACE_CALL(DeviceId);
+  return OFFLOAD_TRACE_RESULT(isValidDeviceId(DeviceId) &&
+                              Devices[DeviceId] != nullptr);
 }
 
 int32_t GenericPluginTy::init_device(int32_t DeviceId) {
+  OFFLOAD_TRACE_CALL(DeviceId);
   auto Err = initDevice(DeviceId);
   if (Err) {
     REPORT() << "Failure to initialize device " << DeviceId << ": "
              << toString(std::move(Err));
-    return OFFLOAD_FAIL;
+    return OFFLOAD_TRACE_RESULT(OFFLOAD_FAIL);
   }
 
-  return OFFLOAD_SUCCESS;
+  return OFFLOAD_TRACE_RESULT(OFFLOAD_SUCCESS);
 }
 
-int32_t GenericPluginTy::number_of_devices() { return getNumDevices(); }
+int32_t GenericPluginTy::number_of_devices() {
+  OFFLOAD_TRACE_CALL();
+  return OFFLOAD_TRACE_RESULT(getNumDevices());
+}
 
 int32_t GenericPluginTy::is_data_exchangable(int32_t SrcDeviceId,
                                              int32_t DstDeviceId) {
-  return isDataExchangable(SrcDeviceId, DstDeviceId);
+  OFFLOAD_TRACE_CALL(SrcDeviceId, DstDeviceId);
+  return OFFLOAD_TRACE_RESULT(isDataExchangable(SrcDeviceId, DstDeviceId));
 }
 
 int32_t GenericPluginTy::initialize_record_replay(
     int32_t DeviceId, int64_t MemorySize, void *VAddr, bool IsRecord,
     bool IsNative, bool SaveOutput, bool EmitReport, const char *ReportFilename,
     const char *OutputDirPath) {
+  OFFLOAD_TRACE_CALL(DeviceId, MemorySize, VAddr, IsRecord, IsNative,
+                     SaveOutput, EmitReport, ReportFilename, OutputDirPath);
   GenericDeviceTy &Device = getDevice(DeviceId);
 
   if (auto Err = Device.initRecordReplay(MemorySize, VAddr, IsRecord, IsNative,
@@ -1507,14 +1522,15 @@ int32_t GenericPluginTy::initialize_record_replay(
     REPORT() << "Failure to initialize RR with " << MemorySize
              << " bytes on device " << DeviceId << ": "
              << toString(std::move(Err));
-    return OFFLOAD_FAIL;
+    return OFFLOAD_TRACE_RESULT(OFFLOAD_FAIL);
   }
-  return OFFLOAD_SUCCESS;
+  return OFFLOAD_TRACE_RESULT(OFFLOAD_SUCCESS);
 }
 
 int32_t GenericPluginTy::load_binary(int32_t DeviceId,
                                      __tgt_device_image *TgtImage,
                                      __tgt_device_binary *Binary) {
+  OFFLOAD_TRACE_CALL(DeviceId, TgtImage, Binary);
   GenericDeviceTy &Device = getDevice(DeviceId);
 
   StringRef Buffer(reinterpret_cast<const char *>(TgtImage->ImageStart),
@@ -1524,7 +1540,7 @@ int32_t GenericPluginTy::load_binary(int32_t DeviceId,
     auto Err = ImageOrErr.takeError();
     REPORT() << "Failure to load binary image " << TgtImage << " on device "
              << DeviceId << ": " << toString(std::move(Err));
-    return OFFLOAD_FAIL;
+    return OFFLOAD_TRACE_RESULT(OFFLOAD_FAIL);
   }
 
   DeviceImageTy *Image = *ImageOrErr;
@@ -1532,143 +1548,157 @@ int32_t GenericPluginTy::load_binary(int32_t DeviceId,
 
   *Binary = __tgt_device_binary{reinterpret_cast<uint64_t>(Image)};
 
-  return OFFLOAD_SUCCESS;
+  return OFFLOAD_TRACE_RESULT(OFFLOAD_SUCCESS);
 }
 
 void *GenericPluginTy::data_alloc(int32_t DeviceId, int64_t Size, void *HostPtr,
                                   int32_t Kind) {
+  OFFLOAD_TRACE_CALL(DeviceId, Size, HostPtr, TargetAllocTy(Kind));
   auto AllocOrErr = getDevice(DeviceId).dataAlloc(
       Size, HostPtr, (TargetAllocTy)Kind, /*Alignment=*/0);
   if (!AllocOrErr) {
     auto Err = AllocOrErr.takeError();
     REPORT() << "Failure to allocate device memory: "
              << toString(std::move(Err));
-    return nullptr;
+    return OFFLOAD_TRACE_RESULT(nullptr);
   }
   assert(*AllocOrErr && "Null pointer upon successful allocation");
 
-  return *AllocOrErr;
+  return OFFLOAD_TRACE_RESULT(*AllocOrErr);
 }
 
 int32_t GenericPluginTy::data_delete(int32_t DeviceId, void *TgtPtr,
                                      int32_t Kind) {
+  OFFLOAD_TRACE_CALL(DeviceId, TgtPtr, TargetAllocTy(Kind));
   auto Err =
       getDevice(DeviceId).dataDelete(TgtPtr, static_cast<TargetAllocTy>(Kind));
   if (Err) {
     REPORT() << "Failure to deallocate device pointer " << TgtPtr << ": "
              << toString(std::move(Err));
-    return OFFLOAD_FAIL;
+    return OFFLOAD_TRACE_RESULT(OFFLOAD_FAIL);
   }
 
-  return OFFLOAD_SUCCESS;
+  return OFFLOAD_TRACE_RESULT(OFFLOAD_SUCCESS);
 }
 
 int32_t GenericPluginTy::data_lock(int32_t DeviceId, void *Ptr, int64_t Size,
                                    void **LockedPtr) {
+  OFFLOAD_TRACE_CALL(DeviceId, Ptr, Size, LockedPtr);
   auto LockedPtrOrErr = getDevice(DeviceId).registerMemory(Ptr, Size);
   if (!LockedPtrOrErr) {
     auto Err = LockedPtrOrErr.takeError();
     REPORT() << "Failure to lock memory " << Ptr << ": "
              << toString(std::move(Err));
-    return OFFLOAD_FAIL;
+    return OFFLOAD_TRACE_RESULT(OFFLOAD_FAIL);
   }
 
   if (!(*LockedPtrOrErr)) {
     REPORT() << "Failure to lock memory " << Ptr
              << ": obtained a null locked pointer";
-    return OFFLOAD_FAIL;
+    return OFFLOAD_TRACE_RESULT(OFFLOAD_FAIL);
   }
   *LockedPtr = *LockedPtrOrErr;
 
-  return OFFLOAD_SUCCESS;
+  return OFFLOAD_TRACE_RESULT(OFFLOAD_SUCCESS);
 }
 
 int32_t GenericPluginTy::data_unlock(int32_t DeviceId, void *Ptr) {
+  OFFLOAD_TRACE_CALL(DeviceId, Ptr);
   auto Err = getDevice(DeviceId).unregisterMemory(Ptr);
   if (Err) {
     REPORT() << "Failure to unlock memory " << Ptr << ": "
              << toString(std::move(Err));
-    return OFFLOAD_FAIL;
+    return OFFLOAD_TRACE_RESULT(OFFLOAD_FAIL);
   }
 
-  return OFFLOAD_SUCCESS;
+  return OFFLOAD_TRACE_RESULT(OFFLOAD_SUCCESS);
 }
 
 int32_t GenericPluginTy::data_notify_mapped(int32_t DeviceId, void *HstPtr,
                                             int64_t Size) {
+  OFFLOAD_TRACE_CALL(DeviceId, HstPtr, Size);
   auto Err = getDevice(DeviceId).notifyDataMapped(HstPtr, Size);
   if (Err) {
     REPORT() << "Failure to notify data mapped " << HstPtr << ": "
              << toString(std::move(Err));
-    return OFFLOAD_FAIL;
+    return OFFLOAD_TRACE_RESULT(OFFLOAD_FAIL);
   }
 
-  return OFFLOAD_SUCCESS;
+  return OFFLOAD_TRACE_RESULT(OFFLOAD_SUCCESS);
 }
 
 int32_t GenericPluginTy::data_notify_unmapped(int32_t DeviceId, void *HstPtr) {
+  OFFLOAD_TRACE_CALL(DeviceId, HstPtr);
   auto Err = getDevice(DeviceId).notifyDataUnmapped(HstPtr);
   if (Err) {
     REPORT() << "Failure to notify data unmapped " << HstPtr << ": "
              << toString(std::move(Err));
-    return OFFLOAD_FAIL;
+    return OFFLOAD_TRACE_RESULT(OFFLOAD_FAIL);
   }
 
-  return OFFLOAD_SUCCESS;
+  return OFFLOAD_TRACE_RESULT(OFFLOAD_SUCCESS);
 }
 
 int32_t GenericPluginTy::data_submit(int32_t DeviceId, void *TgtPtr,
                                      void *HstPtr, int64_t Size) {
-  return data_submit_async(DeviceId, TgtPtr, HstPtr, Size,
-                           /*AsyncInfoPtr=*/nullptr);
+  OFFLOAD_TRACE_CALL(DeviceId, TgtPtr, HstPtr, Size);
+  return OFFLOAD_TRACE_RESULT(data_submit_async(DeviceId, TgtPtr, HstPtr, Size,
+                                                /*AsyncInfoPtr=*/nullptr));
 }
 
 int32_t GenericPluginTy::data_submit_async(int32_t DeviceId, void *TgtPtr,
                                            void *HstPtr, int64_t Size,
                                            __tgt_async_info *AsyncInfoPtr) {
+  OFFLOAD_TRACE_CALL(DeviceId, TgtPtr, HstPtr, Size, AsyncInfoPtr);
   auto Err = getDevice(DeviceId).dataSubmit(TgtPtr, HstPtr, Size, AsyncInfoPtr);
   if (Err) {
     REPORT() << "Failure to copy data from host to device. Pointers: host "
              << "= " << HstPtr << ", device = " << TgtPtr << ", size = " << Size
              << ": " << toString(std::move(Err));
-    return OFFLOAD_FAIL;
+    return OFFLOAD_TRACE_RESULT(OFFLOAD_FAIL);
   }
 
-  return OFFLOAD_SUCCESS;
+  return OFFLOAD_TRACE_RESULT(OFFLOAD_SUCCESS);
 }
 
 int32_t GenericPluginTy::data_retrieve(int32_t DeviceId, void *HstPtr,
                                        void *TgtPtr, int64_t Size) {
-  return data_retrieve_async(DeviceId, HstPtr, TgtPtr, Size,
-                             /*AsyncInfoPtr=*/nullptr);
+  OFFLOAD_TRACE_CALL(DeviceId, HstPtr, TgtPtr, Size);
+  return OFFLOAD_TRACE_RESULT(data_retrieve_async(DeviceId, HstPtr, TgtPtr,
+                                                  Size,
+                                                  /*AsyncInfoPtr=*/nullptr));
 }
 
 int32_t GenericPluginTy::data_retrieve_async(int32_t DeviceId, void *HstPtr,
                                              void *TgtPtr, int64_t Size,
                                              __tgt_async_info *AsyncInfoPtr) {
+  OFFLOAD_TRACE_CALL(DeviceId, HstPtr, TgtPtr, Size, AsyncInfoPtr);
   auto Err =
       getDevice(DeviceId).dataRetrieve(HstPtr, TgtPtr, Size, AsyncInfoPtr);
   if (Err) {
     REPORT() << "Failure to copy data from device to host. Pointers: host "
              << "= " << HstPtr << ", device = " << TgtPtr << ", size = " << Size
              << ": " << toString(std::move(Err));
-    return OFFLOAD_FAIL;
+    return OFFLOAD_TRACE_RESULT(OFFLOAD_FAIL);
   }
 
-  return OFFLOAD_SUCCESS;
+  return OFFLOAD_TRACE_RESULT(OFFLOAD_SUCCESS);
 }
 
 int32_t GenericPluginTy::data_exchange(int32_t SrcDeviceId, void *SrcPtr,
                                        int32_t DstDeviceId, void *DstPtr,
                                        int64_t Size) {
-  return data_exchange_async(SrcDeviceId, SrcPtr, DstDeviceId, DstPtr, Size,
-                             /*AsyncInfoPtr=*/nullptr);
+  OFFLOAD_TRACE_CALL(SrcDeviceId, SrcPtr, DstDeviceId, DstPtr, Size);
+  return OFFLOAD_TRACE_RESULT(data_exchange_async(SrcDeviceId, SrcPtr,
+                                                  DstDeviceId, DstPtr, Size,
+                                                  /*AsyncInfoPtr=*/nullptr));
 }
 
 int32_t GenericPluginTy::data_exchange_async(int32_t SrcDeviceId, void *SrcPtr,
                                              int DstDeviceId, void *DstPtr,
                                              int64_t Size,
                                              __tgt_async_info *AsyncInfo) {
+  OFFLOAD_TRACE_CALL(SrcDeviceId, SrcPtr, DstDeviceId, DstPtr, Size, AsyncInfo);
   GenericDeviceTy &SrcDevice = getDevice(SrcDeviceId);
   GenericDeviceTy &DstDevice = getDevice(DstDeviceId);
   auto Err = SrcDevice.dataExchange(SrcPtr, DstDevice, DstPtr, Size, AsyncInfo);
@@ -1677,51 +1707,55 @@ int32_t GenericPluginTy::data_exchange_async(int32_t SrcDeviceId, void *SrcPtr,
              << ") to device (" << DstDeviceId
              << "). Pointers: host = " << SrcPtr << ", device = " << DstPtr
              << ", size = " << Size << ": " << toString(std::move(Err));
-    return OFFLOAD_FAIL;
+    return OFFLOAD_TRACE_RESULT(OFFLOAD_FAIL);
   }
 
-  return OFFLOAD_SUCCESS;
+  return OFFLOAD_TRACE_RESULT(OFFLOAD_SUCCESS);
 }
 
 int32_t GenericPluginTy::launch_kernel(int32_t DeviceId, void *TgtEntryPtr,
                                        KernelLaunchArgsTy &LaunchArgs,
                                        __tgt_async_info *AsyncInfoPtr) {
+  OFFLOAD_TRACE_CALL(DeviceId, TgtEntryPtr, &LaunchArgs, AsyncInfoPtr);
   auto Err =
       getDevice(DeviceId).launchKernel(TgtEntryPtr, LaunchArgs, AsyncInfoPtr);
   if (Err) {
     REPORT() << "Failure to run target region " << TgtEntryPtr << " in device "
              << DeviceId << ": " << toString(std::move(Err));
-    return OFFLOAD_FAIL;
+    return OFFLOAD_TRACE_RESULT(OFFLOAD_FAIL);
   }
 
-  return OFFLOAD_SUCCESS;
+  return OFFLOAD_TRACE_RESULT(OFFLOAD_SUCCESS);
 }
 
 int32_t GenericPluginTy::synchronize(int32_t DeviceId,
                                      __tgt_async_info *AsyncInfoPtr) {
+  OFFLOAD_TRACE_CALL(DeviceId, AsyncInfoPtr);
   auto Err = getDevice(DeviceId).synchronize(AsyncInfoPtr);
   if (Err) {
     REPORT() << "Failure to synchronize stream " << AsyncInfoPtr->Queue << ": "
              << toString(std::move(Err));
-    return OFFLOAD_FAIL;
+    return OFFLOAD_TRACE_RESULT(OFFLOAD_FAIL);
   }
 
-  return OFFLOAD_SUCCESS;
+  return OFFLOAD_TRACE_RESULT(OFFLOAD_SUCCESS);
 }
 
 int32_t GenericPluginTy::query_async(int32_t DeviceId,
                                      __tgt_async_info *AsyncInfoPtr) {
+  OFFLOAD_TRACE_CALL(DeviceId, AsyncInfoPtr);
   auto Err = getDevice(DeviceId).queryAsync(AsyncInfoPtr);
   if (Err) {
     REPORT() << "Failure to query stream " << AsyncInfoPtr->Queue << ": "
              << toString(std::move(Err));
-    return OFFLOAD_FAIL;
+    return OFFLOAD_TRACE_RESULT(OFFLOAD_FAIL);
   }
 
-  return OFFLOAD_SUCCESS;
+  return OFFLOAD_TRACE_RESULT(OFFLOAD_SUCCESS);
 }
 
 InfoTreeNode GenericPluginTy::obtain_device_info(int32_t DeviceId) {
+  OFFLOAD_TRACE_CALL(DeviceId);
   auto InfoOrErr = getDevice(DeviceId).obtainInfo();
   if (auto Err = InfoOrErr.takeError()) {
     REPORT() << "Failure to obtain device " << DeviceId
@@ -1732,116 +1766,128 @@ InfoTreeNode GenericPluginTy::obtain_device_info(int32_t DeviceId) {
 }
 
 void GenericPluginTy::print_device_info(int32_t DeviceId) {
+  OFFLOAD_TRACE_CALL(DeviceId);
   if (auto Err = getDevice(DeviceId).printInfo())
     REPORT() << "Failure to print device " << DeviceId
              << " info: " << toString(std::move(Err));
 }
 
 int32_t GenericPluginTy::create_event(int32_t DeviceId, void **EventPtr) {
+  OFFLOAD_TRACE_CALL(DeviceId, EventPtr);
   auto Err = getDevice(DeviceId).createEvent(EventPtr);
   if (Err) {
     REPORT() << "Failure to create event: " << toString(std::move(Err));
-    return OFFLOAD_FAIL;
+    return OFFLOAD_TRACE_RESULT(OFFLOAD_FAIL);
   }
 
-  return OFFLOAD_SUCCESS;
+  return OFFLOAD_TRACE_RESULT(OFFLOAD_SUCCESS);
 }
 
 int32_t GenericPluginTy::record_event(int32_t DeviceId, void *EventPtr,
                                       __tgt_async_info *AsyncInfoPtr) {
+  OFFLOAD_TRACE_CALL(DeviceId, EventPtr, AsyncInfoPtr);
   auto Err = getDevice(DeviceId).recordEvent(EventPtr, AsyncInfoPtr);
   if (Err) {
     REPORT() << "Failure to record event " << EventPtr << ": "
              << toString(std::move(Err));
-    return OFFLOAD_FAIL;
+    return OFFLOAD_TRACE_RESULT(OFFLOAD_FAIL);
   }
 
-  return OFFLOAD_SUCCESS;
+  return OFFLOAD_TRACE_RESULT(OFFLOAD_SUCCESS);
 }
 
 int32_t GenericPluginTy::wait_event(int32_t DeviceId, void *EventPtr,
                                     __tgt_async_info *AsyncInfoPtr) {
+  OFFLOAD_TRACE_CALL(DeviceId, EventPtr, AsyncInfoPtr);
   auto Err = getDevice(DeviceId).waitEvent(EventPtr, AsyncInfoPtr);
   if (Err) {
     REPORT() << "Failure to wait event " << EventPtr << ": "
              << toString(std::move(Err));
-    return OFFLOAD_FAIL;
+    return OFFLOAD_TRACE_RESULT(OFFLOAD_FAIL);
   }
 
-  return OFFLOAD_SUCCESS;
+  return OFFLOAD_TRACE_RESULT(OFFLOAD_SUCCESS);
 }
 
 int32_t GenericPluginTy::sync_event(int32_t DeviceId, void *EventPtr) {
+  OFFLOAD_TRACE_CALL(DeviceId, EventPtr);
   auto Err = getDevice(DeviceId).syncEvent(EventPtr);
   if (Err) {
     REPORT() << "Failure to synchronize event " << EventPtr << ": "
              << toString(std::move(Err));
-    return OFFLOAD_FAIL;
+    return OFFLOAD_TRACE_RESULT(OFFLOAD_FAIL);
   }
 
-  return OFFLOAD_SUCCESS;
+  return OFFLOAD_TRACE_RESULT(OFFLOAD_SUCCESS);
 }
 
 int32_t GenericPluginTy::get_event_elapsed_time(int32_t DeviceId,
                                                 void *StartEventPtr,
                                                 void *EndEventPtr,
                                                 float *ElapsedTime) {
+  OFFLOAD_TRACE_CALL(DeviceId, StartEventPtr, EndEventPtr, ElapsedTime);
   auto ElapsedTimeOrErr =
       getDevice(DeviceId).getEventElapsedTime(StartEventPtr, EndEventPtr);
   if (!ElapsedTimeOrErr) {
     REPORT() << "Failure to get elapsed time between events " << StartEventPtr
              << " and " << EndEventPtr << ": "
              << toString(ElapsedTimeOrErr.takeError());
-    return OFFLOAD_FAIL;
+    return OFFLOAD_TRACE_RESULT(OFFLOAD_FAIL);
   }
 
   *ElapsedTime = *ElapsedTimeOrErr;
-  return OFFLOAD_SUCCESS;
+  return OFFLOAD_TRACE_RESULT(OFFLOAD_SUCCESS);
 }
 
 int32_t GenericPluginTy::destroy_event(int32_t DeviceId, void *EventPtr) {
+  OFFLOAD_TRACE_CALL(DeviceId, EventPtr);
   auto Err = getDevice(DeviceId).destroyEvent(EventPtr);
   if (Err) {
     REPORT() << "Failure to destroy event " << EventPtr << ": "
              << toString(std::move(Err));
-    return OFFLOAD_FAIL;
+    return OFFLOAD_TRACE_RESULT(OFFLOAD_FAIL);
   }
 
-  return OFFLOAD_SUCCESS;
+  return OFFLOAD_TRACE_RESULT(OFFLOAD_SUCCESS);
 }
 
 void GenericPluginTy::set_info_flag(uint32_t NewInfoLevel) {
+  OFFLOAD_TRACE_CALL(NewInfoLevel);
   std::atomic<uint32_t> &InfoLevel = getInfoLevelInternal();
   InfoLevel.store(NewInfoLevel);
 }
 
 int32_t GenericPluginTy::init_async_info(int32_t DeviceId,
                                          __tgt_async_info **AsyncInfoPtr) {
+  OFFLOAD_TRACE_CALL(DeviceId, AsyncInfoPtr);
   assert(AsyncInfoPtr && "Invalid async info");
 
   auto Err = getDevice(DeviceId).initAsyncInfo(AsyncInfoPtr);
   if (Err) {
     REPORT() << "Failure to initialize async info at " << *AsyncInfoPtr
              << " on device " << DeviceId << ": " << toString(std::move(Err));
-    return OFFLOAD_FAIL;
+    return OFFLOAD_TRACE_RESULT(OFFLOAD_FAIL);
   }
 
-  return OFFLOAD_SUCCESS;
+  return OFFLOAD_TRACE_RESULT(OFFLOAD_SUCCESS);
 }
 
 int32_t GenericPluginTy::set_device_identifier(int32_t UserId,
                                                int32_t DeviceId) {
+  OFFLOAD_TRACE_CALL(UserId, DeviceId);
   UserDeviceIds[DeviceId] = UserId;
 
-  return OFFLOAD_SUCCESS;
+  return OFFLOAD_TRACE_RESULT(OFFLOAD_SUCCESS);
 }
 
 int32_t GenericPluginTy::use_auto_zero_copy(int32_t DeviceId) {
-  return getDevice(DeviceId).useAutoZeroCopy();
+  OFFLOAD_TRACE_CALL(DeviceId);
+  return OFFLOAD_TRACE_RESULT(getDevice(DeviceId).useAutoZeroCopy());
 }
 
 int32_t GenericPluginTy::is_accessible_ptr(int32_t DeviceId, const void *Ptr,
                                            size_t Size) {
+  OFFLOAD_TRACE_CALL(DeviceId, Ptr, Size);
   auto HandleError = [&](Error Err) -> bool {
     std::string ErrStr = toString(std::move(Err));
     ODBG(OLDT_Device) << "Failure while checking accessibility of pointer "
@@ -1851,13 +1897,14 @@ int32_t GenericPluginTy::is_accessible_ptr(int32_t DeviceId, const void *Ptr,
 
   auto AccessibleOrErr = getDevice(DeviceId).isAccessiblePtr(Ptr, Size);
   if (Error Err = AccessibleOrErr.takeError())
-    return HandleError(std::move(Err));
+    return OFFLOAD_TRACE_RESULT(HandleError(std::move(Err)));
 
-  return *AccessibleOrErr;
+  return OFFLOAD_TRACE_RESULT(*AccessibleOrErr);
 }
 
 int32_t GenericPluginTy::get_global(__tgt_device_binary Binary, uint64_t Size,
                                     const char *Name, void **DevicePtr) {
+  OFFLOAD_TRACE_CALL(Binary, Size, Name, DevicePtr);
   assert(Binary.handle && "Invalid device binary handle");
   DeviceImageTy &Image = *reinterpret_cast<DeviceImageTy *>(Binary.handle);
 
@@ -1868,7 +1915,7 @@ int32_t GenericPluginTy::get_global(__tgt_device_binary Binary, uint64_t Size,
   if (auto Err =
           GHandler.getGlobalMetadataFromDevice(Device, Image, DeviceGlobal)) {
     consumeError(std::move(Err));
-    return OFFLOAD_FAIL;
+    return OFFLOAD_TRACE_RESULT(OFFLOAD_FAIL);
   }
 
   *DevicePtr = DeviceGlobal.getPtr();
@@ -1879,11 +1926,12 @@ int32_t GenericPluginTy::get_global(__tgt_device_binary Binary, uint64_t Size,
   if (RecordReplay && RecordReplay->isRecording())
     RecordReplay->addGlobal(Name, Size, *DevicePtr);
 
-  return OFFLOAD_SUCCESS;
+  return OFFLOAD_TRACE_RESULT(OFFLOAD_SUCCESS);
 }
 
 int32_t GenericPluginTy::get_function(__tgt_device_binary Binary,
                                       const char *Name, void **KernelPtr) {
+  OFFLOAD_TRACE_CALL(Binary, Name, KernelPtr);
   assert(Binary.handle && "Invalid device binary handle");
   DeviceImageTy &Image = *reinterpret_cast<DeviceImageTy *>(Binary.handle);
 
@@ -1892,38 +1940,40 @@ int32_t GenericPluginTy::get_function(__tgt_device_binary Binary,
   auto KernelOrErr = Device.constructKernel(Name);
   if (Error Err = KernelOrErr.takeError()) {
     REPORT() << "Failure to look up kernel: " << toString(std::move(Err));
-    return OFFLOAD_FAIL;
+    return OFFLOAD_TRACE_RESULT(OFFLOAD_FAIL);
   }
 
   GenericKernelTy &Kernel = *KernelOrErr;
   if (auto Err = Kernel.init(Device, Image)) {
     REPORT() << "Failure to init kernel: " << toString(std::move(Err));
-    return OFFLOAD_FAIL;
+    return OFFLOAD_TRACE_RESULT(OFFLOAD_FAIL);
   }
 
   // Note that this is not the kernel's device address.
   *KernelPtr = &Kernel;
-  return OFFLOAD_SUCCESS;
+  return OFFLOAD_TRACE_RESULT(OFFLOAD_SUCCESS);
 }
 
 /// Create OpenMP interop with the given interop context
 omp_interop_val_t *
 GenericPluginTy::create_interop(int32_t ID, int32_t InteropContext,
                                 interop_spec_t *InteropSpec) {
+  OFFLOAD_TRACE_CALL(ID, InteropContext, InteropSpec);
   assert(InteropSpec && "Interop spec is null");
   auto &Device = getDevice(ID);
   auto InteropOrErr = Device.createInterop(InteropContext, *InteropSpec);
   if (!InteropOrErr) {
     REPORT() << "Failure to create interop object for device " << InteropSpec
              << ": " << toString(InteropOrErr.takeError());
-    return nullptr;
+    return OFFLOAD_TRACE_RESULT(nullptr);
   }
-  return *InteropOrErr;
+  return OFFLOAD_TRACE_RESULT(*InteropOrErr);
 }
 
 /// Release OpenMP interop object
 int32_t GenericPluginTy::release_interop(int32_t ID,
                                          omp_interop_val_t *Interop) {
+  OFFLOAD_TRACE_CALL(ID, Interop);
   assert(Interop && "Interop is null");
   assert(Interop->device_id == ID && "Interop does not match device id");
   auto &Device = getDevice(ID);
@@ -1931,57 +1981,61 @@ int32_t GenericPluginTy::release_interop(int32_t ID,
   if (Err) {
     REPORT() << "Failure to release interop object " << Interop << ": "
              << toString(std::move(Err));
-    return OFFLOAD_FAIL;
+    return OFFLOAD_TRACE_RESULT(OFFLOAD_FAIL);
   }
-  return OFFLOAD_SUCCESS;
+  return OFFLOAD_TRACE_RESULT(OFFLOAD_SUCCESS);
 }
 
 /// Flush the queue associated with the interop object if necessary
 int32_t GenericPluginTy::flush_queue(omp_interop_val_t *Interop) {
+  OFFLOAD_TRACE_CALL(Interop);
   assert(Interop && "Interop is null");
   auto Err = flushQueueImpl(Interop);
   if (Err) {
     REPORT() << "Failure to flush interop object " << Interop
              << " queue: " << toString(std::move(Err));
-    return OFFLOAD_FAIL;
+    return OFFLOAD_TRACE_RESULT(OFFLOAD_FAIL);
   }
-  return OFFLOAD_SUCCESS;
+  return OFFLOAD_TRACE_RESULT(OFFLOAD_SUCCESS);
 }
 
 /// Perform a host synchronization with the queue associated with the interop
 /// object and wait for it to complete.
 int32_t GenericPluginTy::sync_barrier(omp_interop_val_t *Interop) {
+  OFFLOAD_TRACE_CALL(Interop);
   assert(Interop && "Interop is null");
   auto Err = syncBarrierImpl(Interop);
   if (Err) {
     REPORT() << "Failure to synchronize interop object " << Interop << ": "
              << toString(std::move(Err));
-    return OFFLOAD_FAIL;
+    return OFFLOAD_TRACE_RESULT(OFFLOAD_FAIL);
   }
-  return OFFLOAD_SUCCESS;
+  return OFFLOAD_TRACE_RESULT(OFFLOAD_SUCCESS);
 }
 
 /// Queue an asynchronous barrier in the queue associated with the interop
 /// object and return immediately.
 int32_t GenericPluginTy::async_barrier(omp_interop_val_t *Interop) {
+  OFFLOAD_TRACE_CALL(Interop);
   assert(Interop && "Interop is null");
   auto Err = asyncBarrierImpl(Interop);
   if (Err) {
     REPORT() << "Failure to queue barrier in interop object " << Interop << ": "
              << toString(std::move(Err));
-    return OFFLOAD_FAIL;
+    return OFFLOAD_TRACE_RESULT(OFFLOAD_FAIL);
   }
-  return OFFLOAD_SUCCESS;
+  return OFFLOAD_TRACE_RESULT(OFFLOAD_SUCCESS);
 }
 
 int32_t GenericPluginTy::data_fence(int32_t DeviceId,
                                     __tgt_async_info *AsyncInfo) {
+  OFFLOAD_TRACE_CALL(DeviceId, AsyncInfo);
   auto Err = getDevice(DeviceId).dataFence(AsyncInfo);
   if (Err) {
     REPORT() << "Failure to place data fence on device " << DeviceId << ": "
              << toString(std::move(Err));
-    return OFFLOAD_FAIL;
+    return OFFLOAD_TRACE_RESULT(OFFLOAD_FAIL);
   }
 
-  return OFFLOAD_SUCCESS;
+  return OFFLOAD_TRACE_RESULT(OFFLOAD_SUCCESS);
 }

--- a/offload/plugins-nextgen/common/src/PluginInterface.cpp
+++ b/offload/plugins-nextgen/common/src/PluginInterface.cpp
@@ -1553,9 +1553,10 @@ int32_t GenericPluginTy::load_binary(int32_t DeviceId,
 
 void *GenericPluginTy::data_alloc(int32_t DeviceId, int64_t Size, void *HostPtr,
                                   int32_t Kind) {
-  OFFLOAD_TRACE_CALL(DeviceId, Size, HostPtr, TargetAllocTy(Kind));
-  auto AllocOrErr = getDevice(DeviceId).dataAlloc(
-      Size, HostPtr, (TargetAllocTy)Kind, /*Alignment=*/0);
+  auto AllocKind = static_cast<TargetAllocTy>(Kind);
+  OFFLOAD_TRACE_CALL(DeviceId, Size, HostPtr, AllocKind);
+  auto AllocOrErr =
+      getDevice(DeviceId).dataAlloc(Size, HostPtr, AllocKind, /*Alignment=*/0);
   if (!AllocOrErr) {
     auto Err = AllocOrErr.takeError();
     REPORT() << "Failure to allocate device memory: "
@@ -1569,9 +1570,9 @@ void *GenericPluginTy::data_alloc(int32_t DeviceId, int64_t Size, void *HostPtr,
 
 int32_t GenericPluginTy::data_delete(int32_t DeviceId, void *TgtPtr,
                                      int32_t Kind) {
-  OFFLOAD_TRACE_CALL(DeviceId, TgtPtr, TargetAllocTy(Kind));
-  auto Err =
-      getDevice(DeviceId).dataDelete(TgtPtr, static_cast<TargetAllocTy>(Kind));
+  auto AllocKind = static_cast<TargetAllocTy>(Kind);
+  OFFLOAD_TRACE_CALL(DeviceId, TgtPtr, AllocKind);
+  auto Err = getDevice(DeviceId).dataDelete(TgtPtr, AllocKind);
   if (Err) {
     REPORT() << "Failure to deallocate device pointer " << TgtPtr << ": "
              << toString(std::move(Err));
@@ -1716,7 +1717,7 @@ int32_t GenericPluginTy::data_exchange_async(int32_t SrcDeviceId, void *SrcPtr,
 int32_t GenericPluginTy::launch_kernel(int32_t DeviceId, void *TgtEntryPtr,
                                        KernelLaunchArgsTy &LaunchArgs,
                                        __tgt_async_info *AsyncInfoPtr) {
-  OFFLOAD_TRACE_CALL(DeviceId, TgtEntryPtr, &LaunchArgs, AsyncInfoPtr);
+  OFFLOAD_TRACE_CALL(DeviceId, TgtEntryPtr, LaunchArgs, AsyncInfoPtr);
   auto Err =
       getDevice(DeviceId).launchKernel(TgtEntryPtr, LaunchArgs, AsyncInfoPtr);
   if (Err) {
@@ -1855,6 +1856,10 @@ void GenericPluginTy::set_info_flag(uint32_t NewInfoLevel) {
   OFFLOAD_TRACE_CALL(NewInfoLevel);
   std::atomic<uint32_t> &InfoLevel = getInfoLevelInternal();
   InfoLevel.store(NewInfoLevel);
+}
+
+void GenericPluginTy::set_api_trace(bool Enable) {
+  llvm::offload::trace::setTraceEnabled(Enable);
 }
 
 int32_t GenericPluginTy::init_async_info(int32_t DeviceId,

--- a/offload/test/offloading/api_trace.c
+++ b/offload/test/offloading/api_trace.c
@@ -6,23 +6,35 @@
 
 #include <stdio.h>
 
+extern void __tgt_set_info_flag(unsigned);
+
 int main() {
   int Data = 0;
 #pragma omp target map(tofrom : Data)
   Data = 1;
 
   printf("Data = %d\n", Data);
+  fflush(stdout);
+
+  // Tracing is disabled for everything that follows.
+  __tgt_set_info_flag(0x0);
+#pragma omp target
+  ;
+
   return Data != 1;
 }
 
-// Argument values other than the device number vary between runs.
+// Argument values other than the device number and the size vary between runs.
 // TRACE-DAG: ---> init_device(.DeviceId = 0)-> OFFLOAD_SUCCESS ({{[0-9]+}} us)
 // TRACE-DAG: ---> load_binary(.DeviceId = 0, {{.*}})-> OFFLOAD_SUCCESS ({{[0-9]+}} us)
-// TRACE-DAG: ---> data_alloc(.DeviceId = 0, {{.*}}, .Kind = TARGET_ALLOC_{{[A-Z]+}})-> 0x{{[0-9a-f]+}} ({{[0-9]+}} us)
-// TRACE-DAG: ---> data_submit_async(.DeviceId = 0, {{.*}})-> OFFLOAD_SUCCESS ({{[0-9]+}} us)
-// TRACE-DAG: ---> launch_kernel(.DeviceId = 0, {{.*}})-> OFFLOAD_SUCCESS ({{[0-9]+}} us)
-// TRACE-DAG: ---> data_retrieve_async(.DeviceId = 0, {{.*}})-> OFFLOAD_SUCCESS ({{[0-9]+}} us)
-// TRACE-DAG: ---> data_delete(.DeviceId = 0, {{.*}}, .Kind = TARGET_ALLOC_{{[A-Z]+}})-> OFFLOAD_SUCCESS ({{[0-9]+}} us)
+// TRACE-DAG: ---> data_alloc(.DeviceId = 0, .Size = 4, .HostPtr = 0x{{[0-9a-f]+}}, .AllocKind = TARGET_ALLOC_{{[A-Z]+}})-> 0x{{[0-9a-f]+}} ({{[0-9]+}} us)
+// TRACE-DAG: ---> data_submit_async(.DeviceId = 0, .TgtPtr = 0x{{[0-9a-f]+}}, .HstPtr = 0x{{[0-9a-f]+}}, .Size = 4, .AsyncInfoPtr = 0x{{[0-9a-f]+}})-> OFFLOAD_SUCCESS ({{[0-9]+}} us)
+// TRACE-DAG: ---> launch_kernel(.DeviceId = 0, .TgtEntryPtr = 0x{{[0-9a-f]+}}, .LaunchArgs = &0x{{[0-9a-f]+}}, .AsyncInfoPtr = 0x{{[0-9a-f]+}})-> OFFLOAD_SUCCESS ({{[0-9]+}} us)
+// TRACE-DAG: ---> data_retrieve_async(.DeviceId = 0, .HstPtr = 0x{{[0-9a-f]+}}, .TgtPtr = 0x{{[0-9a-f]+}}, .Size = 4, .AsyncInfoPtr = 0x{{[0-9a-f]+}})-> OFFLOAD_SUCCESS ({{[0-9]+}} us)
+// TRACE-DAG: ---> data_delete(.DeviceId = 0, .TgtPtr = 0x{{[0-9a-f]+}}, .AllocKind = TARGET_ALLOC_{{[A-Z]+}})-> OFFLOAD_SUCCESS ({{[0-9]+}} us)
 // TRACE-DAG: ---> number_of_devices()-> {{[0-9]+}} ({{[0-9]+}} us)
+
+// TRACE: Data = 1
+// TRACE-NOT: --->
 
 // NOTRACE-NOT: --->

--- a/offload/test/offloading/api_trace.c
+++ b/offload/test/offloading/api_trace.c
@@ -1,0 +1,28 @@
+// RUN: %libomptarget-compile-generic
+// RUN: env LIBOMPTARGET_INFO=128 %libomptarget-run-generic 2>&1 | \
+// RUN:   %fcheck-generic -check-prefix=TRACE
+// RUN: %libomptarget-run-generic 2>&1 | \
+// RUN:   %fcheck-generic -allow-empty -check-prefix=NOTRACE
+
+#include <stdio.h>
+
+int main() {
+  int Data = 0;
+#pragma omp target map(tofrom : Data)
+  Data = 1;
+
+  printf("Data = %d\n", Data);
+  return Data != 1;
+}
+
+// Argument values other than the device number vary between runs.
+// TRACE-DAG: ---> init_device(.DeviceId = 0)-> OFFLOAD_SUCCESS ({{[0-9]+}} us)
+// TRACE-DAG: ---> load_binary(.DeviceId = 0, {{.*}})-> OFFLOAD_SUCCESS ({{[0-9]+}} us)
+// TRACE-DAG: ---> data_alloc(.DeviceId = 0, {{.*}}, .Kind = TARGET_ALLOC_{{[A-Z]+}})-> 0x{{[0-9a-f]+}} ({{[0-9]+}} us)
+// TRACE-DAG: ---> data_submit_async(.DeviceId = 0, {{.*}})-> OFFLOAD_SUCCESS ({{[0-9]+}} us)
+// TRACE-DAG: ---> launch_kernel(.DeviceId = 0, {{.*}})-> OFFLOAD_SUCCESS ({{[0-9]+}} us)
+// TRACE-DAG: ---> data_retrieve_async(.DeviceId = 0, {{.*}})-> OFFLOAD_SUCCESS ({{[0-9]+}} us)
+// TRACE-DAG: ---> data_delete(.DeviceId = 0, {{.*}}, .Kind = TARGET_ALLOC_{{[A-Z]+}})-> OFFLOAD_SUCCESS ({{[0-9]+}} us)
+// TRACE-DAG: ---> number_of_devices()-> {{[0-9]+}} ({{[0-9]+}} us)
+
+// NOTRACE-NOT: --->

--- a/openmp/docs/design/Runtimes.rst
+++ b/openmp/docs/design/Runtimes.rst
@@ -813,6 +813,9 @@ with `-g` for full debug information. A full list of flags supported by
     * Indicate when an entry is changed in the device mapping table: ``0x08``
     * Print OpenMP kernel information from device plugins: ``0x10``
     * Indicate when data is copied to and from the device: ``0x20``
+    * Indicate when mapped data has no viable device counterpart: ``0x40``
+    * Trace every plugin API call with its arguments, result and duration:
+      ``0x80``
 
 Any combination of these flags can be used by setting the appropriate bits. For
 example, to enable printing all data active in an OpenMP target region along


### PR DESCRIPTION
Summary:
This is intended to provide logged output, intended to be an upstream
alternative to the AMD fork's tracing utility.

I am unsure how best to expose this, we already have the offload tracer
for the core library, and this would be confusing on top of that. I
restrict it to OpenMP, but that also puts OpenMP only details into the
core plugin interface. Let me know if you think we should expose this,
or the LIBOMPTARGET_INFO interface more generically, like the debug.
