### PR TITLE
[libc++] Stabilize the LNT machines we are going to generate data for

### DIFF
--- a/libcxx/utils/ci/lnt/machines.json
+++ b/libcxx/utils/ci/lnt/machines.json
@@ -1,11 +1,11 @@
 [
   {
-    "lnt-machine": "macos-26.5-arm64-20260811",
+    "lnt-machine": "macos-26.5-arm64-20260812",
     "runner": ["self-hosted", "macOS", "apple-runners"],
     "cxx": "clang++",
     "running-on": "macos",
     "xcode-version": "26.5",
-    "benchmark-suite-version": "TODO",
+    "benchmark-suite-version": "8bb5e216937e6b541f351aa1637c67e85a43ada0",
     "coverage": {
       "since": "2023-01-01",
       "every": "week",
@@ -15,11 +15,11 @@
     }
   },
   {
-    "lnt-machine": "linux-x86_64-20260811",
+    "lnt-machine": "linux-x86_64-20260812",
     "runner": "llvm-premerge-libcxx-runners",
     "cxx": "clang++-22",
     "running-on": "linux",
-    "benchmark-suite-version": "TODO",
+    "benchmark-suite-version": "8bb5e216937e6b541f351aa1637c67e85a43ada0",
     "coverage": {
       "since": "2023-01-01",
       "every": "week",

--- a/libcxx/utils/ci/lnt/machines.json
+++ b/libcxx/utils/ci/lnt/machines.json
@@ -1,13 +1,13 @@
 [
   {
-    "lnt-machine": "macos-26.5-arm64",
-    "runner": ["self-hosted", "macOS", "ARM64", "26", "26.5"],
+    "lnt-machine": "macos-26.5-arm64-20260811",
+    "runner": ["self-hosted", "macOS", "apple-runners"],
     "cxx": "clang++",
     "running-on": "macos",
     "xcode-version": "26.5",
-    "benchmark-suite-version": "810062e9771d8b47c25a89311139c621c13bbf9f",
+    "benchmark-suite-version": "TODO",
     "coverage": {
-      "since": "2025-01-01",
+      "since": "2024-01-01",
       "every": "week",
       "samples": 3,
       "max-in-flight": 4,
@@ -15,13 +15,13 @@
     }
   },
   {
-    "lnt-machine": "linux-x86_64",
+    "lnt-machine": "linux-x86_64-20260811",
     "runner": "llvm-premerge-libcxx-runners",
     "cxx": "clang++-22",
     "running-on": "linux",
-    "benchmark-suite-version": "810062e9771d8b47c25a89311139c621c13bbf9f",
+    "benchmark-suite-version": "TODO",
     "coverage": {
-      "since": "2025-01-01",
+      "since": "2024-01-01",
       "every": "week",
       "samples": 3,
       "max-in-flight": 8,

--- a/libcxx/utils/ci/lnt/machines.json
+++ b/libcxx/utils/ci/lnt/machines.json
@@ -7,7 +7,7 @@
     "xcode-version": "26.5",
     "benchmark-suite-version": "TODO",
     "coverage": {
-      "since": "2024-01-01",
+      "since": "2023-01-01",
       "every": "week",
       "samples": 3,
       "max-in-flight": 4,
@@ -21,7 +21,7 @@
     "running-on": "linux",
     "benchmark-suite-version": "TODO",
     "coverage": {
-      "since": "2024-01-01",
+      "since": "2023-01-01",
       "every": "week",
       "samples": 3,
       "max-in-flight": 8,


### PR DESCRIPTION
Now that the test suite has the necessary fixes to go back in time reasonably far, update it and update the names of the machines to version them.

As a drive-by, make the expression we use to target macOS runners consistent with what we use in the pre-commit CI jobs.