### PR TITLE
[IndVarSimplify] Eliminate pointer IVs congruent up to a constant offset

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/ScalarEvolutionExpander.h
+++ b/llvm/include/llvm/Transforms/Utils/ScalarEvolutionExpander.h
@@ -307,6 +307,13 @@ public:
                       SmallVectorImpl<WeakTrackingVH> &DeadInsts,
                       const TargetTransformInfo *TTI = nullptr);
 
+  /// Replace pointer phis that are provably a constant byte offset apart from
+  /// another pointer phi in the same header with a GEP off that phi, so both
+  /// share a getPointerBase(). Return the number of phis eliminated.
+  LLVM_ABI unsigned
+  replaceOffsetCongruentIVs(Loop *L,
+                            SmallVectorImpl<WeakTrackingVH> &DeadInsts);
+
   /// Return true if the given expression is safe to expand in the sense that
   /// all materialized values are safe to speculate anywhere their operands are
   /// defined, and the expander is capable of expanding the expression.

--- a/llvm/lib/Transforms/Scalar/IndVarSimplify.cpp
+++ b/llvm/lib/Transforms/Scalar/IndVarSimplify.cpp
@@ -88,6 +88,7 @@ STATISTIC(NumReplaced    , "Number of exit values replaced");
 STATISTIC(NumLFTR        , "Number of loop exit tests replaced");
 STATISTIC(NumElimExt     , "Number of IV sign/zero extends eliminated");
 STATISTIC(NumElimIV      , "Number of congruent IVs eliminated");
+STATISTIC(NumElimOffsetIV, "Number of offset-congruent pointer IVs eliminated");
 
 static cl::opt<ReplaceExitVal> ReplaceExitValue(
     "replexitval", cl::Hidden, cl::init(OnlyCheapRepl),
@@ -2101,6 +2102,7 @@ bool IndVarSimplify::run(Loop *L) {
 
   // Eliminate redundant IV cycles.
   NumElimIV += Rewriter.replaceCongruentIVs(L, DT, DeadInsts, TTI);
+  NumElimOffsetIV += Rewriter.replaceOffsetCongruentIVs(L, DeadInsts);
 
   // Try to convert exit conditions to unsigned and rotate computation
   // out of the loop.  Note: Handles invalidation internally if needed.

--- a/llvm/lib/Transforms/Utils/ScalarEvolutionExpander.cpp
+++ b/llvm/lib/Transforms/Utils/ScalarEvolutionExpander.cpp
@@ -1971,6 +1971,134 @@ SCEVExpander::replaceCongruentIVs(Loop *L, const DominatorTree *DT,
   return NumElim;
 }
 
+/// Constant byte delta (Q - P), or nullopt if no constant one is provable.
+static std::optional<APInt> getConstantPtrDelta(ScalarEvolution &SE,
+                                                const SCEV *P, const SCEV *Q,
+                                                ValueToSCEVMapTy &Hyp) {
+  if (!Hyp.empty()) {
+    P = SCEVParameterRewriter::rewrite(P, SE, Hyp);
+    Q = SCEVParameterRewriter::rewrite(Q, SE, Hyp);
+  }
+  if (const auto *C = dyn_cast<SCEVConstant>(SE.getMinusSCEV(Q, P)))
+    return C->getAPInt();
+  return std::nullopt;
+}
+
+static std::optional<APInt> proveConstPtrOffset(ScalarEvolution &SE, Loop *L,
+                                                PHINode *P, PHINode *Q,
+                                                ValueToSCEVMapTy &Hyp) {
+  BasicBlock *Preheader = L->getLoopPreheader();
+  BasicBlock *Latch = L->getLoopLatch();
+  if (!Preheader || !Latch || P->getType() != Q->getType())
+    return std::nullopt;
+
+  Value *PPre = P->getIncomingValueForBlock(Preheader);
+  Value *QPre = Q->getIncomingValueForBlock(Preheader);
+
+  if (!getConstantPtrDelta(SE, SE.getSCEV(PPre), SE.getSCEV(QPre), Hyp)) {
+    Loop *Parent = L->getParentLoop();
+    auto *PPhi = dyn_cast<PHINode>(PPre);
+    auto *QPhi = dyn_cast<PHINode>(QPre);
+    if (!Parent || !PPhi || !QPhi || PPhi->getParent() != Parent->getHeader() ||
+        QPhi->getParent() != Parent->getHeader() ||
+        !proveConstPtrOffset(SE, Parent, PPhi, QPhi, Hyp))
+      return std::nullopt;
+  }
+
+  if (auto Delta = getConstantPtrDelta(SE, SE.getSCEV(P), SE.getSCEV(Q), Hyp))
+    return Delta;
+
+  // SCEV gave up on these phis, so induct by hand: assume Q == P + C and check
+  // that the backedge values still differ by C.
+  auto C = getConstantPtrDelta(SE, SE.getSCEV(PPre), SE.getSCEV(QPre), Hyp);
+  if (!C)
+    return std::nullopt;
+
+  ValueToSCEVMapTy Trial = Hyp;
+  Trial[Q] =
+      SE.getAddExpr(SCEVParameterRewriter::rewrite(SE.getSCEV(P), SE, Trial),
+                    SE.getConstant(*C));
+  auto Step = getConstantPtrDelta(
+      SE, SE.getSCEV(P->getIncomingValueForBlock(Latch)),
+      SE.getSCEV(Q->getIncomingValueForBlock(Latch)), Trial);
+  if (!Step || *Step != *C)
+    return std::nullopt;
+
+  Hyp[Q] = Trial[Q];
+  return C;
+}
+
+unsigned SCEVExpander::replaceOffsetCongruentIVs(
+    Loop *L, SmallVectorImpl<WeakTrackingVH> &DeadInsts) {
+  BasicBlock *Header = L->getHeader();
+  if (!L->getLoopPreheader() || !L->getLoopLatch())
+    return 0;
+
+  SmallVector<PHINode *, 4> PtrIVs;
+  for (PHINode &Phi : Header->phis())
+    if (Phi.getType()->isPointerTy() && !Phi.use_empty())
+      PtrIVs.push_back(&Phi);
+
+  if (PtrIVs.size() < 2)
+    return 0;
+
+  ValueToSCEVMapTy Hyp;
+  SmallPtrSet<PHINode *, 4> Handled;
+  unsigned NumElim = 0;
+
+  for (PHINode *B : PtrIVs) {
+    if (!Handled.insert(B).second)
+      continue;
+
+    SmallVector<std::pair<PHINode *, APInt>, 2> Group;
+    Group.emplace_back(B, APInt(DL.getIndexTypeSizeInBits(B->getType()), 0));
+    for (PHINode *A : PtrIVs) {
+      if (Handled.count(A) || A->getType() != B->getType())
+        continue;
+      if (auto Delta = proveConstPtrOffset(SE, L, B, A, Hyp)) {
+        Group.emplace_back(A, *Delta);
+        Handled.insert(A);
+      }
+    }
+
+    if (Group.size() < 2)
+      continue;
+
+    auto *Keep = llvm::min_element(Group, [](const auto &A, const auto &B) {
+      return A.second.slt(B.second);
+    });
+    PHINode *Keeper = Keep->first;
+    APInt KeeperOff = Keep->second;
+
+    IRBuilder<> Builder(Header, Header->getFirstInsertionPt());
+    for (auto &Entry : Group) {
+      PHINode *Phi = Entry.first;
+      if (Phi == Keeper)
+        continue;
+
+      Builder.SetCurrentDebugLocation(Phi->getDebugLoc());
+      APInt Off = Entry.second - KeeperOff;
+      Value *NewPtr = Keeper;
+      if (!Off.isZero())
+        NewPtr = Builder.CreatePtrAdd(Keeper,
+                                      ConstantInt::get(Phi->getContext(), Off),
+                                      Phi->getName() + ".off");
+
+      SCEV_DEBUG_WITH_TYPE(DebugType,
+                           dbgs() << "INDVARS: Eliminated offset congruent iv: "
+                                  << *Phi << '\n');
+      SCEV_DEBUG_WITH_TYPE(
+          DebugType, dbgs() << "INDVARS: Original iv: " << *Keeper << '\n');
+
+      SE.forgetValue(Phi);
+      Phi->replaceAllUsesWith(NewPtr);
+      DeadInsts.emplace_back(Phi);
+      ++NumElim;
+    }
+  }
+  return NumElim;
+}
+
 bool SCEVExpander::hasRelatedExistingExpansion(const SCEV *S,
                                                const Instruction *At,
                                                Loop *L) {

--- a/llvm/test/Transforms/IndVarSimplify/offset-congruent-ptr-ivs.ll
+++ b/llvm/test/Transforms/IndVarSimplify/offset-congruent-ptr-ivs.ll
@@ -1,0 +1,277 @@
+; RUN: opt -passes='loop-mssa(indvars)' -verify-scev -S %s | FileCheck %s
+
+; Two pointer IVs in a single loop, 4 bytes apart.
+define void @single_loop(ptr noalias %dst, i32 %n) {
+; CHECK-LABEL: define void @single_loop(
+; CHECK-SAME: ptr noalias [[DST:%.*]], i32 [[N:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*]]:
+; CHECK-NEXT:    br label %[[LOOP:.*]]
+; CHECK:       [[LOOP]]:
+; CHECK-NEXT:    [[PA:%.*]] = phi ptr [ [[DST]], %[[ENTRY]] ], [ [[PA_NEXT:%.*]], %[[LOOP]] ]
+; CHECK-NEXT:    [[I:%.*]] = phi i32 [ 0, %[[ENTRY]] ], [ [[I_NEXT:%.*]], %[[LOOP]] ]
+; CHECK-NEXT:    [[PB_OFF:%.*]] = getelementptr i8, ptr [[PA]], i64 4
+; CHECK-NEXT:    store float 2.000000e+00, ptr [[PA]], align 4
+; CHECK-NEXT:    store float 3.000000e+00, ptr [[PB_OFF]], align 4
+; CHECK-NEXT:    [[PA_NEXT]] = getelementptr inbounds float, ptr [[PA]], i64 2
+; CHECK-NEXT:    [[I_NEXT]] = add nuw i32 [[I]], 1
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[I_NEXT]], [[N]]
+; CHECK-NEXT:    br i1 [[CMP]], label %[[LOOP]], label %[[EXIT:.*]]
+; CHECK:       [[EXIT]]:
+; CHECK-NEXT:    ret void
+;
+entry:
+  %pB.start = getelementptr inbounds float, ptr %dst, i64 1
+  br label %loop
+
+loop:
+  %pA = phi ptr [ %dst, %entry ], [ %pA.next, %loop ]
+  %pB = phi ptr [ %pB.start, %entry ], [ %pB.next, %loop ]
+  %i = phi i32 [ 0, %entry ], [ %i.next, %loop ]
+  store float 2.000000e+00, ptr %pA, align 4
+  store float 3.000000e+00, ptr %pB, align 4
+  %pA.next = getelementptr inbounds float, ptr %pA, i64 2
+  %pB.next = getelementptr inbounds float, ptr %pB, i64 2
+  %i.next = add nuw i32 %i, 1
+  %cmp = icmp ult i32 %i.next, %n
+  br i1 %cmp, label %loop, label %exit
+
+exit:
+  ret void
+}
+
+define void @nested_loop(ptr noalias %dst, i32 %width, i32 %height) {
+; CHECK-LABEL: define void @nested_loop(
+; CHECK-SAME: ptr noalias [[DST:%.*]], i32 [[WIDTH:%.*]], i32 [[HEIGHT:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*]]:
+; CHECK-NEXT:    br label %[[OUTER_HEADER:.*]]
+; CHECK:       [[OUTER_HEADER]]:
+; CHECK-NEXT:    [[PA_OUTER:%.*]] = phi ptr [ [[DST]], %[[ENTRY]] ], [ [[PA_LCSSA:%.*]], %[[OUTER_LATCH:.*]] ]
+; CHECK-NEXT:    [[Y:%.*]] = phi i32 [ 0, %[[ENTRY]] ], [ [[Y_NEXT:%.*]], %[[OUTER_LATCH]] ]
+; CHECK-NEXT:    [[OUTER_CMP:%.*]] = icmp ult i32 [[Y]], [[HEIGHT]]
+; CHECK-NEXT:    br i1 [[OUTER_CMP]], label %[[INNER_PREHEADER:.*]], label %[[EXIT:.*]]
+; CHECK:       [[INNER_PREHEADER]]:
+; CHECK-NEXT:    br label %[[INNER_HEADER:.*]]
+; CHECK:       [[INNER_HEADER]]:
+; CHECK-NEXT:    [[PA_INNER:%.*]] = phi ptr [ [[PA_OUTER]], %[[INNER_PREHEADER]] ], [ [[PA_NEXT:%.*]], %[[INNER_HEADER]] ]
+; CHECK-NEXT:    [[X:%.*]] = phi i32 [ 0, %[[INNER_PREHEADER]] ], [ [[X_NEXT:%.*]], %[[INNER_HEADER]] ]
+; CHECK-NEXT:    [[PB_INNER_OFF:%.*]] = getelementptr i8, ptr [[PA_INNER]], i64 4
+; CHECK-NEXT:    store float 2.000000e+00, ptr [[PA_INNER]], align 4
+; CHECK-NEXT:    store float 3.000000e+00, ptr [[PB_INNER_OFF]], align 4
+; CHECK-NEXT:    [[PA_NEXT]] = getelementptr inbounds float, ptr [[PA_INNER]], i64 2
+; CHECK-NEXT:    [[X_NEXT]] = add nuw i32 [[X]], 1
+; CHECK-NEXT:    [[INNER_CMP:%.*]] = icmp ult i32 [[X_NEXT]], [[WIDTH]]
+; CHECK-NEXT:    br i1 [[INNER_CMP]], label %[[INNER_HEADER]], label %[[INNER_EXIT:.*]]
+; CHECK:       [[INNER_EXIT]]:
+; CHECK-NEXT:    [[PA_LCSSA]] = phi ptr [ [[PA_NEXT]], %[[INNER_HEADER]] ]
+; CHECK-NEXT:    br label %[[OUTER_LATCH]]
+; CHECK:       [[OUTER_LATCH]]:
+; CHECK-NEXT:    [[Y_NEXT]] = add nuw i32 [[Y]], 1
+; CHECK-NEXT:    br label %[[OUTER_HEADER]]
+; CHECK:       [[EXIT]]:
+; CHECK-NEXT:    ret void
+;
+entry:
+  %pB.start = getelementptr inbounds float, ptr %dst, i64 1
+  br label %outer.header
+
+outer.header:
+  %pA.outer = phi ptr [ %dst, %entry ], [ %pA.lcssa, %outer.latch ]
+  %pB.outer = phi ptr [ %pB.start, %entry ], [ %pB.lcssa, %outer.latch ]
+  %y = phi i32 [ 0, %entry ], [ %y.next, %outer.latch ]
+  %outer.cmp = icmp ult i32 %y, %height
+  br i1 %outer.cmp, label %inner.preheader, label %exit
+
+inner.preheader:
+  br label %inner.header
+
+inner.header:
+  %pA.inner = phi ptr [ %pA.outer, %inner.preheader ], [ %pA.next, %inner.header ]
+  %pB.inner = phi ptr [ %pB.outer, %inner.preheader ], [ %pB.next, %inner.header ]
+  %x = phi i32 [ 0, %inner.preheader ], [ %x.next, %inner.header ]
+  store float 2.000000e+00, ptr %pA.inner, align 4
+  store float 3.000000e+00, ptr %pB.inner, align 4
+  %pA.next = getelementptr inbounds float, ptr %pA.inner, i64 2
+  %pB.next = getelementptr inbounds float, ptr %pB.inner, i64 2
+  %x.next = add nuw i32 %x, 1
+  %inner.cmp = icmp ult i32 %x.next, %width
+  br i1 %inner.cmp, label %inner.header, label %inner.exit
+
+inner.exit:
+  %pA.lcssa = phi ptr [ %pA.next, %inner.header ]
+  %pB.lcssa = phi ptr [ %pB.next, %inner.header ]
+  br label %outer.latch
+
+outer.latch:
+  %y.next = add nuw i32 %y, 1
+  br label %outer.header
+
+exit:
+  ret void
+}
+
+; Interleave factor 3: all three collapse onto the lowest-addressed IV.
+define void @three_ptr_ivs(ptr noalias %dst, i32 %n) {
+; CHECK-LABEL: define void @three_ptr_ivs(
+; CHECK-SAME: ptr noalias [[DST:%.*]], i32 [[N:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*]]:
+; CHECK-NEXT:    br label %[[LOOP:.*]]
+; CHECK:       [[LOOP]]:
+; CHECK-NEXT:    [[PA:%.*]] = phi ptr [ [[DST]], %[[ENTRY]] ], [ [[PA_NEXT:%.*]], %[[LOOP]] ]
+; CHECK-NEXT:    [[I:%.*]] = phi i32 [ 0, %[[ENTRY]] ], [ [[I_NEXT:%.*]], %[[LOOP]] ]
+; CHECK-NEXT:    [[PB_OFF:%.*]] = getelementptr i8, ptr [[PA]], i64 4
+; CHECK-NEXT:    [[PC_OFF:%.*]] = getelementptr i8, ptr [[PA]], i64 8
+; CHECK-NEXT:    store float 2.000000e+00, ptr [[PA]], align 4
+; CHECK-NEXT:    store float 3.000000e+00, ptr [[PB_OFF]], align 4
+; CHECK-NEXT:    store float 4.000000e+00, ptr [[PC_OFF]], align 4
+; CHECK-NEXT:    [[PA_NEXT]] = getelementptr inbounds float, ptr [[PA]], i64 3
+; CHECK-NEXT:    [[I_NEXT]] = add nuw i32 [[I]], 1
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[I_NEXT]], [[N]]
+; CHECK-NEXT:    br i1 [[CMP]], label %[[LOOP]], label %[[EXIT:.*]]
+; CHECK:       [[EXIT]]:
+; CHECK-NEXT:    ret void
+;
+entry:
+  %pB.start = getelementptr inbounds float, ptr %dst, i64 1
+  %pC.start = getelementptr inbounds float, ptr %dst, i64 2
+  br label %loop
+
+loop:
+  %pA = phi ptr [ %dst, %entry ], [ %pA.next, %loop ]
+  %pB = phi ptr [ %pB.start, %entry ], [ %pB.next, %loop ]
+  %pC = phi ptr [ %pC.start, %entry ], [ %pC.next, %loop ]
+  %i = phi i32 [ 0, %entry ], [ %i.next, %loop ]
+  store float 2.000000e+00, ptr %pA, align 4
+  store float 3.000000e+00, ptr %pB, align 4
+  store float 4.000000e+00, ptr %pC, align 4
+  %pA.next = getelementptr inbounds float, ptr %pA, i64 3
+  %pB.next = getelementptr inbounds float, ptr %pB, i64 3
+  %pC.next = getelementptr inbounds float, ptr %pC, i64 3
+  %i.next = add nuw i32 %i, 1
+  %cmp = icmp ult i32 %i.next, %n
+  br i1 %cmp, label %loop, label %exit
+
+exit:
+  ret void
+}
+
+; The lowest-addressed IV wins even when it is not the first phi in the header,
+; so every emitted GEP has a non-negative offset.
+define void @keeper_is_not_first_phi(ptr noalias %dst, i32 %n) {
+; CHECK-LABEL: define void @keeper_is_not_first_phi(
+; CHECK-SAME: ptr noalias [[DST:%.*]], i32 [[N:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*]]:
+; CHECK-NEXT:    br label %[[LOOP:.*]]
+; CHECK:       [[LOOP]]:
+; CHECK-NEXT:    [[PLO:%.*]] = phi ptr [ [[DST]], %[[ENTRY]] ], [ [[PLO_NEXT:%.*]], %[[LOOP]] ]
+; CHECK-NEXT:    [[I:%.*]] = phi i32 [ 0, %[[ENTRY]] ], [ [[I_NEXT:%.*]], %[[LOOP]] ]
+; CHECK-NEXT:    [[PHI_OFF:%.*]] = getelementptr i8, ptr [[PLO]], i64 4
+; CHECK-NEXT:    store float 2.000000e+00, ptr [[PHI_OFF]], align 4
+; CHECK-NEXT:    store float 3.000000e+00, ptr [[PLO]], align 4
+; CHECK-NEXT:    [[PLO_NEXT]] = getelementptr inbounds float, ptr [[PLO]], i64 2
+; CHECK-NEXT:    [[I_NEXT]] = add nuw i32 [[I]], 1
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[I_NEXT]], [[N]]
+; CHECK-NEXT:    br i1 [[CMP]], label %[[LOOP]], label %[[EXIT:.*]]
+; CHECK:       [[EXIT]]:
+; CHECK-NEXT:    ret void
+;
+entry:
+  %pHi.start = getelementptr inbounds float, ptr %dst, i64 1
+  br label %loop
+
+loop:
+  %pHi = phi ptr [ %pHi.start, %entry ], [ %pHi.next, %loop ]
+  %pLo = phi ptr [ %dst, %entry ], [ %pLo.next, %loop ]
+  %i = phi i32 [ 0, %entry ], [ %i.next, %loop ]
+  store float 2.000000e+00, ptr %pHi, align 4
+  store float 3.000000e+00, ptr %pLo, align 4
+  %pHi.next = getelementptr inbounds float, ptr %pHi, i64 2
+  %pLo.next = getelementptr inbounds float, ptr %pLo, i64 2
+  %i.next = add nuw i32 %i, 1
+  %cmp = icmp ult i32 %i.next, %n
+  br i1 %cmp, label %loop, label %exit
+
+exit:
+  ret void
+}
+
+; Same nest, but not rotated: the inner loop has a separate latch and the LCSSA
+; phis forward the inner header phis rather than the increments.
+define void @nested_loop_unrotated(ptr noalias %dst, i32 %width, i32 %height) {
+; CHECK-LABEL: define void @nested_loop_unrotated(
+; CHECK-SAME: ptr noalias [[DST:%.*]], i32 [[WIDTH:%.*]], i32 [[HEIGHT:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*]]:
+; CHECK-NEXT:    br label %[[OUTER_HEADER:.*]]
+; CHECK:       [[OUTER_HEADER]]:
+; CHECK-NEXT:    [[PA_OUTER:%.*]] = phi ptr [ [[DST]], %[[ENTRY]] ], [ [[PA_LCSSA:%.*]], %[[OUTER_LATCH:.*]] ]
+; CHECK-NEXT:    [[Y:%.*]] = phi i32 [ 0, %[[ENTRY]] ], [ [[Y_NEXT:%.*]], %[[OUTER_LATCH]] ]
+; CHECK-NEXT:    [[OUTER_CMP:%.*]] = icmp ult i32 [[Y]], [[HEIGHT]]
+; CHECK-NEXT:    br i1 [[OUTER_CMP]], label %[[INNER_PREHEADER:.*]], label %[[EXIT:.*]]
+; CHECK:       [[INNER_PREHEADER]]:
+; CHECK-NEXT:    br label %[[INNER_HEADER:.*]]
+; CHECK:       [[INNER_HEADER]]:
+; CHECK-NEXT:    [[PA_INNER:%.*]] = phi ptr [ [[PA_OUTER]], %[[INNER_PREHEADER]] ], [ [[PA_NEXT:%.*]], %[[INNER_LATCH:.*]] ]
+; CHECK-NEXT:    [[X:%.*]] = phi i32 [ 0, %[[INNER_PREHEADER]] ], [ [[X_NEXT:%.*]], %[[INNER_LATCH]] ]
+; CHECK-NEXT:    [[PB_INNER_OFF:%.*]] = getelementptr i8, ptr [[PA_INNER]], i64 4
+; CHECK-NEXT:    [[INNER_CMP:%.*]] = icmp ult i32 [[X]], [[WIDTH]]
+; CHECK-NEXT:    br i1 [[INNER_CMP]], label %[[INNER_BODY:.*]], label %[[INNER_EXIT:.*]]
+; CHECK:       [[INNER_BODY]]:
+; CHECK-NEXT:    store float 2.000000e+00, ptr [[PA_INNER]], align 4
+; CHECK-NEXT:    store float 3.000000e+00, ptr [[PB_INNER_OFF]], align 4
+; CHECK-NEXT:    [[PA_NEXT]] = getelementptr inbounds float, ptr [[PA_INNER]], i64 2
+; CHECK-NEXT:    br label %[[INNER_LATCH]]
+; CHECK:       [[INNER_LATCH]]:
+; CHECK-NEXT:    [[X_NEXT]] = add nuw i32 [[X]], 1
+; CHECK-NEXT:    br label %[[INNER_HEADER]]
+; CHECK:       [[INNER_EXIT]]:
+; CHECK-NEXT:    [[PA_LCSSA]] = phi ptr [ [[PA_INNER]], %[[INNER_HEADER]] ]
+; CHECK-NEXT:    br label %[[OUTER_LATCH]]
+; CHECK:       [[OUTER_LATCH]]:
+; CHECK-NEXT:    [[Y_NEXT]] = add nuw i32 [[Y]], 1
+; CHECK-NEXT:    br label %[[OUTER_HEADER]]
+; CHECK:       [[EXIT]]:
+; CHECK-NEXT:    ret void
+;
+entry:
+  %pB.start = getelementptr inbounds float, ptr %dst, i64 1
+  br label %outer.header
+
+outer.header:
+  %pA.outer = phi ptr [ %dst, %entry ], [ %pA.lcssa, %outer.latch ]
+  %pB.outer = phi ptr [ %pB.start, %entry ], [ %pB.lcssa, %outer.latch ]
+  %y = phi i32 [ 0, %entry ], [ %y.next, %outer.latch ]
+  %outer.cmp = icmp ult i32 %y, %height
+  br i1 %outer.cmp, label %inner.preheader, label %exit
+
+inner.preheader:
+  br label %inner.header
+
+inner.header:
+  %pA.inner = phi ptr [ %pA.outer, %inner.preheader ], [ %pA.next, %inner.latch ]
+  %pB.inner = phi ptr [ %pB.outer, %inner.preheader ], [ %pB.next, %inner.latch ]
+  %x = phi i32 [ 0, %inner.preheader ], [ %x.next, %inner.latch ]
+  %inner.cmp = icmp ult i32 %x, %width
+  br i1 %inner.cmp, label %inner.body, label %inner.exit
+
+inner.body:
+  store float 2.000000e+00, ptr %pA.inner, align 4
+  store float 3.000000e+00, ptr %pB.inner, align 4
+  %pA.next = getelementptr inbounds float, ptr %pA.inner, i64 2
+  %pB.next = getelementptr inbounds float, ptr %pB.inner, i64 2
+  br label %inner.latch
+
+inner.latch:
+  %x.next = add nuw i32 %x, 1
+  br label %inner.header
+
+inner.exit:
+  %pA.lcssa = phi ptr [ %pA.inner, %inner.header ]
+  %pB.lcssa = phi ptr [ %pB.inner, %inner.header ]
+  br label %outer.latch
+
+outer.latch:
+  %y.next = add nuw i32 %y, 1
+  br label %outer.header
+
+exit:
+  ret void
+}

--- a/llvm/test/Transforms/LoopVectorize/AArch64/interleave-offset-congruent-ptr-ivs.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/interleave-offset-congruent-ptr-ivs.ll
@@ -1,0 +1,152 @@
+; RUN: opt -passes='loop-mssa(indvars),loop-vectorize' -force-vector-interleave=1 -S %s | FileCheck %s
+
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
+target triple = "aarch64-unknown-linux-gnu"
+
+define void @nested_interleaved_store(ptr noalias %src, ptr noalias %dst, i32 %width, i32 %height, i32 %srcStride) {
+; CHECK-LABEL: define void @nested_interleaved_store(
+; CHECK-SAME: ptr noalias [[SRC:%.*]], ptr noalias [[DST:%.*]], i32 [[WIDTH:%.*]], i32 [[HEIGHT:%.*]], i32 [[SRCSTRIDE:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*]]:
+; CHECK-NEXT:    [[UMAX:%.*]] = call i32 @llvm.umax.i32(i32 [[WIDTH]], i32 1)
+; CHECK-NEXT:    [[WIDE_TRIP_COUNT5:%.*]] = zext i32 [[HEIGHT]] to i64
+; CHECK-NEXT:    [[TMP0:%.*]] = add i32 [[UMAX]], -1
+; CHECK-NEXT:    [[TMP1:%.*]] = zext i32 [[TMP0]] to i64
+; CHECK-NEXT:    [[TMP2:%.*]] = shl nuw nsw i64 [[TMP1]], 3
+; CHECK-NEXT:    [[TMP3:%.*]] = add nuw nsw i64 [[TMP2]], 8
+; CHECK-NEXT:    [[TMP4:%.*]] = zext i32 [[SRCSTRIDE]] to i64
+; CHECK-NEXT:    [[TMP5:%.*]] = shl nuw nsw i64 [[TMP1]], 2
+; CHECK-NEXT:    [[TMP6:%.*]] = add nuw nsw i64 [[TMP5]], 4
+; CHECK-NEXT:    [[SCEVGEP8:%.*]] = getelementptr i8, ptr [[SRC]], i64 [[TMP6]]
+; CHECK-NEXT:    br label %[[OUTER_HEADER:.*]]
+; CHECK:       [[OUTER_HEADER]]:
+; CHECK-NEXT:    [[INDVARS_IV2:%.*]] = phi i64 [ [[INDVARS_IV_NEXT3:%.*]], %[[OUTER_LATCH:.*]] ], [ 0, %[[ENTRY]] ]
+; CHECK-NEXT:    [[PA_OUTER:%.*]] = phi ptr [ [[DST]], %[[ENTRY]] ], [ [[PA_LCSSA:%.*]], %[[OUTER_LATCH]] ]
+; CHECK-NEXT:    [[TMP7:%.*]] = mul i64 [[TMP4]], [[INDVARS_IV2]]
+; CHECK-NEXT:    [[TMP8:%.*]] = trunc i64 [[TMP7]] to i32
+; CHECK-NEXT:    [[TMP9:%.*]] = zext i32 [[TMP8]] to i64
+; CHECK-NEXT:    [[TMP10:%.*]] = shl nuw nsw i64 [[TMP9]], 2
+; CHECK-NEXT:    [[SCEVGEP7:%.*]] = getelementptr i8, ptr [[SRC]], i64 [[TMP10]]
+; CHECK-NEXT:    [[SCEVGEP9:%.*]] = getelementptr i8, ptr [[SCEVGEP8]], i64 [[TMP10]]
+; CHECK-NEXT:    [[EXITCOND6:%.*]] = icmp ne i64 [[INDVARS_IV2]], [[WIDE_TRIP_COUNT5]]
+; CHECK-NEXT:    br i1 [[EXITCOND6]], label %[[INNER_PREHEADER:.*]], label %[[EXIT:.*]]
+; CHECK:       [[INNER_PREHEADER]]:
+; CHECK-NEXT:    [[TMP11:%.*]] = trunc nuw i64 [[INDVARS_IV2]] to i32
+; CHECK-NEXT:    [[ROWOFF:%.*]] = mul i32 [[TMP11]], [[SRCSTRIDE]]
+; CHECK-NEXT:    [[ROWOFF_EXT:%.*]] = zext i32 [[ROWOFF]] to i64
+; CHECK-NEXT:    [[ROW:%.*]] = getelementptr inbounds nuw float, ptr [[SRC]], i64 [[ROWOFF_EXT]]
+; CHECK-NEXT:    [[WIDE_TRIP_COUNT:%.*]] = zext i32 [[UMAX]] to i64
+; CHECK-NEXT:    [[MIN_ITERS_CHECK:%.*]] = icmp ult i64 [[WIDE_TRIP_COUNT]], 4
+; CHECK-NEXT:    br i1 [[MIN_ITERS_CHECK]], label %[[SCALAR_PH:.*]], label %[[VECTOR_MEMCHECK:.*]]
+; CHECK:       [[VECTOR_MEMCHECK]]:
+; CHECK-NEXT:    [[SCEVGEP:%.*]] = getelementptr i8, ptr [[PA_OUTER]], i64 [[TMP3]]
+; CHECK-NEXT:    [[BOUND0:%.*]] = icmp ult ptr [[PA_OUTER]], [[SCEVGEP9]]
+; CHECK-NEXT:    [[BOUND1:%.*]] = icmp ult ptr [[SCEVGEP7]], [[SCEVGEP]]
+; CHECK-NEXT:    [[FOUND_CONFLICT:%.*]] = and i1 [[BOUND0]], [[BOUND1]]
+; CHECK-NEXT:    br i1 [[FOUND_CONFLICT]], label %[[SCALAR_PH]], label %[[VECTOR_PH:.*]]
+; CHECK:       [[VECTOR_PH]]:
+; CHECK-NEXT:    [[N_MOD_VF:%.*]] = urem i64 [[WIDE_TRIP_COUNT]], 4
+; CHECK-NEXT:    [[N_VEC:%.*]] = sub i64 [[WIDE_TRIP_COUNT]], [[N_MOD_VF]]
+; CHECK-NEXT:    [[TMP12:%.*]] = shl i64 [[N_VEC]], 3
+; CHECK-NEXT:    [[TMP13:%.*]] = getelementptr i8, ptr [[PA_OUTER]], i64 [[TMP12]]
+; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
+; CHECK:       [[VECTOR_BODY]]:
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[TMP14:%.*]] = shl i64 [[INDEX]], 3
+; CHECK-NEXT:    [[NEXT_GEP:%.*]] = getelementptr i8, ptr [[PA_OUTER]], i64 [[TMP14]]
+; CHECK-NEXT:    [[TMP15:%.*]] = getelementptr inbounds nuw float, ptr [[ROW]], i64 [[INDEX]]
+; CHECK-NEXT:    [[WIDE_LOAD:%.*]] = load <4 x float>, ptr [[TMP15]], align 4, !alias.scope [[META0:![0-9]+]]
+; CHECK-NEXT:    [[TMP16:%.*]] = fmul <4 x float> [[WIDE_LOAD]], splat (float 2.000000e+00)
+; CHECK-NEXT:    [[TMP17:%.*]] = fmul <4 x float> [[WIDE_LOAD]], splat (float 3.000000e+00)
+; CHECK-NEXT:    [[TMP18:%.*]] = shufflevector <4 x float> [[TMP16]], <4 x float> [[TMP17]], <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+; CHECK-NEXT:    [[INTERLEAVED_VEC:%.*]] = shufflevector <8 x float> [[TMP18]], <8 x float> poison, <8 x i32> <i32 0, i32 4, i32 1, i32 5, i32 2, i32 6, i32 3, i32 7>
+; CHECK-NEXT:    store <8 x float> [[INTERLEAVED_VEC]], ptr [[NEXT_GEP]], align 4, !alias.scope [[META3:![0-9]+]], !noalias [[META0]]
+; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
+; CHECK-NEXT:    [[TMP19:%.*]] = icmp eq i64 [[INDEX_NEXT]], [[N_VEC]]
+; CHECK-NEXT:    br i1 [[TMP19]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP5:![0-9]+]]
+; CHECK:       [[MIDDLE_BLOCK]]:
+; CHECK-NEXT:    [[CMP_N:%.*]] = icmp eq i64 [[WIDE_TRIP_COUNT]], [[N_VEC]]
+; CHECK-NEXT:    br i1 [[CMP_N]], label %[[INNER_EXIT:.*]], label %[[SCALAR_PH]]
+; CHECK:       [[SCALAR_PH]]:
+; CHECK-NEXT:    [[BC_RESUME_VAL:%.*]] = phi i64 [ [[N_VEC]], %[[MIDDLE_BLOCK]] ], [ 0, %[[INNER_PREHEADER]] ], [ 0, %[[VECTOR_MEMCHECK]] ]
+; CHECK-NEXT:    [[BC_RESUME_VAL10:%.*]] = phi ptr [ [[TMP13]], %[[MIDDLE_BLOCK]] ], [ [[PA_OUTER]], %[[INNER_PREHEADER]] ], [ [[PA_OUTER]], %[[VECTOR_MEMCHECK]] ]
+; CHECK-NEXT:    br label %[[INNER_HEADER:.*]]
+; CHECK:       [[INNER_HEADER]]:
+; CHECK-NEXT:    [[INDVARS_IV:%.*]] = phi i64 [ [[INDVARS_IV_NEXT:%.*]], %[[INNER_HEADER]] ], [ [[BC_RESUME_VAL]], %[[SCALAR_PH]] ]
+; CHECK-NEXT:    [[PA_INNER:%.*]] = phi ptr [ [[BC_RESUME_VAL10]], %[[SCALAR_PH]] ], [ [[PA_NEXT:%.*]], %[[INNER_HEADER]] ]
+; CHECK-NEXT:    [[PB_INNER_OFF:%.*]] = getelementptr i8, ptr [[PA_INNER]], i64 4
+; CHECK-NEXT:    [[ELT_ADDR:%.*]] = getelementptr inbounds nuw float, ptr [[ROW]], i64 [[INDVARS_IV]]
+; CHECK-NEXT:    [[ELT:%.*]] = load float, ptr [[ELT_ADDR]], align 4
+; CHECK-NEXT:    [[MUL2:%.*]] = fmul float [[ELT]], 2.000000e+00
+; CHECK-NEXT:    store float [[MUL2]], ptr [[PA_INNER]], align 4
+; CHECK-NEXT:    [[MUL3:%.*]] = fmul float [[ELT]], 3.000000e+00
+; CHECK-NEXT:    store float [[MUL3]], ptr [[PB_INNER_OFF]], align 4
+; CHECK-NEXT:    [[PA_NEXT]] = getelementptr inbounds float, ptr [[PA_INNER]], i64 2
+; CHECK-NEXT:    [[INDVARS_IV_NEXT]] = add nuw nsw i64 [[INDVARS_IV]], 1
+; CHECK-NEXT:    [[EXITCOND:%.*]] = icmp ne i64 [[INDVARS_IV_NEXT]], [[WIDE_TRIP_COUNT]]
+; CHECK-NEXT:    br i1 [[EXITCOND]], label %[[INNER_HEADER]], label %[[INNER_EXIT]], !llvm.loop [[LOOP8:![0-9]+]]
+; CHECK:       [[INNER_EXIT]]:
+; CHECK-NEXT:    [[PA_LCSSA]] = phi ptr [ [[PA_NEXT]], %[[INNER_HEADER]] ], [ [[TMP13]], %[[MIDDLE_BLOCK]] ]
+; CHECK-NEXT:    br label %[[OUTER_LATCH]]
+; CHECK:       [[OUTER_LATCH]]:
+; CHECK-NEXT:    [[INDVARS_IV_NEXT3]] = add nuw nsw i64 [[INDVARS_IV2]], 1
+; CHECK-NEXT:    br label %[[OUTER_HEADER]]
+; CHECK:       [[EXIT]]:
+; CHECK-NEXT:    ret void
+;
+entry:
+  %pB.start = getelementptr inbounds float, ptr %dst, i64 1
+  br label %outer.header
+
+outer.header:
+  %pA.outer = phi ptr [ %dst, %entry ], [ %pA.lcssa, %outer.latch ]
+  %pB.outer = phi ptr [ %pB.start, %entry ], [ %pB.lcssa, %outer.latch ]
+  %y = phi i32 [ 0, %entry ], [ %y.next, %outer.latch ]
+  %outer.cmp = icmp ult i32 %y, %height
+  br i1 %outer.cmp, label %inner.preheader, label %exit
+
+inner.preheader:
+  %rowoff = mul i32 %y, %srcStride
+  %rowoff.ext = zext i32 %rowoff to i64
+  %row = getelementptr inbounds nuw float, ptr %src, i64 %rowoff.ext
+  br label %inner.header
+
+inner.header:
+  %pA.inner = phi ptr [ %pA.outer, %inner.preheader ], [ %pA.next, %inner.header ]
+  %pB.inner = phi ptr [ %pB.outer, %inner.preheader ], [ %pB.next, %inner.header ]
+  %x = phi i32 [ 0, %inner.preheader ], [ %x.next, %inner.header ]
+  %x.ext = zext i32 %x to i64
+  %elt.addr = getelementptr inbounds nuw float, ptr %row, i64 %x.ext
+  %elt = load float, ptr %elt.addr, align 4
+  %mul2 = fmul float %elt, 2.000000e+00
+  store float %mul2, ptr %pA.inner, align 4
+  %mul3 = fmul float %elt, 3.000000e+00
+  store float %mul3, ptr %pB.inner, align 4
+  %pA.next = getelementptr inbounds float, ptr %pA.inner, i64 2
+  %pB.next = getelementptr inbounds float, ptr %pB.inner, i64 2
+  %x.next = add nuw i32 %x, 1
+  %inner.cmp = icmp ult i32 %x.next, %width
+  br i1 %inner.cmp, label %inner.header, label %inner.exit
+
+inner.exit:
+  %pA.lcssa = phi ptr [ %pA.next, %inner.header ]
+  %pB.lcssa = phi ptr [ %pB.next, %inner.header ]
+  br label %outer.latch
+
+outer.latch:
+  %y.next = add nuw i32 %y, 1
+  br label %outer.header
+
+exit:
+  ret void
+}
+;.
+; CHECK: [[META0]] = !{[[META1:![0-9]+]]}
+; CHECK: [[META1]] = distinct !{[[META1]], [[META2:![0-9]+]]}
+; CHECK: [[META2]] = distinct !{[[META2]], !"LVerDomain"}
+; CHECK: [[META3]] = !{[[META4:![0-9]+]]}
+; CHECK: [[META4]] = distinct !{[[META4]], [[META2]]}
+; CHECK: [[LOOP5]] = distinct !{[[LOOP5]], [[META6:![0-9]+]], [[META7:![0-9]+]]}
+; CHECK: [[META6]] = !{!"llvm.loop.isvectorized", i32 1}
+; CHECK: [[META7]] = !{!"llvm.loop.unroll.runtime.disable"}
+; CHECK: [[LOOP8]] = distinct !{[[LOOP8]], [[META6]]}
+;.


### PR DESCRIPTION
Adds `SCEVExpander::replaceOffsetCongruentIVs`, which proves Q == P + C by induction over the loop, base case from the pre-header values. Proven IVs are rewritten as a non-inbounds byte GEP off the lowest-offset survivor, and the dead phi chain unravels via the existing RecursivelyDeleteDeadPHINode cleanup in IndVarSimplify.

Fixes #211229