### PR TITLE
[mlir][acc] Add active parallel dimensions attribute

### DIFF
--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCCGAttributes.td
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCCGAttributes.td
@@ -7,7 +7,8 @@
 //===----------------------------------------------------------------------===//
 //
 // Defines OpenACC codegen attributes (GPU parallel dimensions used for
-// privatization, barrier management, and loop work-sharing).
+// privatization, barrier management, and loop work-sharing, plus active
+// parallel dimensions for predication analysis).
 //
 //===----------------------------------------------------------------------===//
 
@@ -100,6 +101,21 @@ def OpenACC_GPUBlockRedundantAttr
     parallelism may be assigned, and during GPU code generation its enclosing
     block dimensions are treated as active (not predicated away).
   }];
+}
+
+def OpenACC_ActiveParDimsAttr
+    : OpenACC_Attr<"ActiveParDims", "active_par_dims"> {
+  let summary = "Active GPU parallel dimensions for an OpenACC operation.";
+  let description = [{
+    Ordered list of GPU parallel dimensions that are active (not predicated
+    away) for an operation. Distinct from ownership `par_dims`: ownership
+    records which dimensions a privatization or reduction is associated with,
+    while active dimensions record which launch dimensions execute the op
+    without predication. Used by privatization / private_local analysis ahead
+    of GPU code generation.
+  }];
+  let parameters = (ins ArrayRefParameter<"::mlir::acc::GPUParallelDimAttr">:$array);
+  let hasCustomAssemblyFormat = 1;
 }
 
 #endif // OPENACCCG_ATTRIBUTES

--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCUtilsCG.h
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCUtilsCG.h
@@ -95,6 +95,18 @@ void updateParDimsAttr(Operation *op, GPUParallelDimsAttr attr);
 /// Copy parallel dimensions from \p from to \p to.
 void copyParDimsAttr(Operation *from, Operation *to);
 
+/// Obtain the active parallel dimensions carried by \p op, if any.
+ActiveParDimsAttr getActiveParDimsAttr(Operation *op);
+
+/// Return whether \p op carries active parallel dimensions.
+bool hasActiveParDimsAttr(Operation *op);
+
+/// Set active parallel dimensions on \p op.
+void setActiveParDimsAttr(Operation *op, ActiveParDimsAttr attr);
+
+/// Set active parallel dimensions on \p op from a dimension list.
+void setActiveParDimsAttr(Operation *op, ArrayRef<GPUParallelDimAttr> dims);
+
 /// Return whether \p op is marked with the `acc.gpu_block_redundant` attribute,
 /// i.e. it executes redundantly across all thread blocks. Such an op must not
 /// be assigned block/grid-level work-sharing; only thread-level parallelism may

--- a/mlir/lib/Dialect/OpenACC/IR/OpenACCCG.cpp
+++ b/mlir/lib/Dialect/OpenACC/IR/OpenACCCG.cpp
@@ -271,9 +271,9 @@ parseGPUParallelDimList(AsmParser &parser) {
 static void printGPUParallelDimList(AsmPrinter &printer,
                                     ArrayRef<GPUParallelDimAttr> dims) {
   printer << "[";
-  llvm::interleaveComma(
-      dims, printer,
-      [&printer](const GPUParallelDimAttr &p) { printProcessorValue(printer, p); });
+  llvm::interleaveComma(dims, printer, [&printer](const GPUParallelDimAttr &p) {
+    printProcessorValue(printer, p);
+  });
   printer << "]";
 }
 

--- a/mlir/lib/Dialect/OpenACC/IR/OpenACCCG.cpp
+++ b/mlir/lib/Dialect/OpenACC/IR/OpenACCCG.cpp
@@ -252,6 +252,31 @@ static void printProcessorValue(AsmPrinter &printer,
   printer << gpu::stringifyProcessor(processor);
 }
 
+static FailureOr<SmallVector<GPUParallelDimAttr>>
+parseGPUParallelDimList(AsmParser &parser) {
+  SmallVector<GPUParallelDimAttr> parDims;
+  auto parseParDim = [&]() -> ParseResult {
+    GPUParallelDimAttr dim;
+    if (parseProcessorValue(parser, dim))
+      return failure();
+    parDims.push_back(dim);
+    return success();
+  };
+  if (parser.parseCommaSeparatedList(AsmParser::Delimiter::Square, parseParDim,
+                                     "list of OpenACC GPU parallel dimensions"))
+    return failure();
+  return parDims;
+}
+
+static void printGPUParallelDimList(AsmPrinter &printer,
+                                    ArrayRef<GPUParallelDimAttr> dims) {
+  printer << "[";
+  llvm::interleaveComma(
+      dims, printer,
+      [&printer](const GPUParallelDimAttr &p) { printProcessorValue(printer, p); });
+  printer << "]";
+}
+
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -1024,28 +1049,15 @@ bool GPUParallelDimsAttr::hasOnlyThreadXLevel() const {
 }
 
 Attribute GPUParallelDimsAttr::parse(AsmParser &parser, Type type) {
-  auto delimiter = AsmParser::Delimiter::Square;
-  SmallVector<GPUParallelDimAttr> parDims;
-  auto parseParDim = [&]() -> ParseResult {
-    GPUParallelDimAttr dim;
-    if (parseProcessorValue(parser, dim))
-      return failure();
-    parDims.push_back(dim);
-    return success();
-  };
-  if (parser.parseCommaSeparatedList(delimiter, parseParDim,
-                                     "list of OpenACC GPU parallel dimensions"))
+  FailureOr<SmallVector<GPUParallelDimAttr>> parDims =
+      parseGPUParallelDimList(parser);
+  if (failed(parDims))
     return {};
-  return GPUParallelDimsAttr::get(parser.getContext(), parDims);
+  return GPUParallelDimsAttr::get(parser.getContext(), *parDims);
 }
 
 void GPUParallelDimsAttr::print(AsmPrinter &printer) const {
-  printer << "[";
-  llvm::interleaveComma(getArray(), printer,
-                        [&printer](const GPUParallelDimAttr &p) {
-                          printProcessorValue(printer, p);
-                        });
-  printer << "]";
+  printGPUParallelDimList(printer, getArray());
 }
 
 //===----------------------------------------------------------------------===//
@@ -1053,26 +1065,13 @@ void GPUParallelDimsAttr::print(AsmPrinter &printer) const {
 //===----------------------------------------------------------------------===//
 
 Attribute ActiveParDimsAttr::parse(AsmParser &parser, Type type) {
-  auto delimiter = AsmParser::Delimiter::Square;
-  SmallVector<GPUParallelDimAttr> parDims;
-  auto parseParDim = [&]() -> ParseResult {
-    GPUParallelDimAttr dim;
-    if (parseProcessorValue(parser, dim))
-      return failure();
-    parDims.push_back(dim);
-    return success();
-  };
-  if (parser.parseCommaSeparatedList(delimiter, parseParDim,
-                                     "list of OpenACC GPU parallel dimensions"))
+  FailureOr<SmallVector<GPUParallelDimAttr>> parDims =
+      parseGPUParallelDimList(parser);
+  if (failed(parDims))
     return {};
-  return ActiveParDimsAttr::get(parser.getContext(), parDims);
+  return ActiveParDimsAttr::get(parser.getContext(), *parDims);
 }
 
 void ActiveParDimsAttr::print(AsmPrinter &printer) const {
-  printer << "[";
-  llvm::interleaveComma(getArray(), printer,
-                        [&printer](const GPUParallelDimAttr &p) {
-                          printProcessorValue(printer, p);
-                        });
-  printer << "]";
+  printGPUParallelDimList(printer, getArray());
 }

--- a/mlir/lib/Dialect/OpenACC/IR/OpenACCCG.cpp
+++ b/mlir/lib/Dialect/OpenACC/IR/OpenACCCG.cpp
@@ -1047,3 +1047,32 @@ void GPUParallelDimsAttr::print(AsmPrinter &printer) const {
                         });
   printer << "]";
 }
+
+//===----------------------------------------------------------------------===//
+// ActiveParDimsAttr
+//===----------------------------------------------------------------------===//
+
+Attribute ActiveParDimsAttr::parse(AsmParser &parser, Type type) {
+  auto delimiter = AsmParser::Delimiter::Square;
+  SmallVector<GPUParallelDimAttr> parDims;
+  auto parseParDim = [&]() -> ParseResult {
+    GPUParallelDimAttr dim;
+    if (parseProcessorValue(parser, dim))
+      return failure();
+    parDims.push_back(dim);
+    return success();
+  };
+  if (parser.parseCommaSeparatedList(delimiter, parseParDim,
+                                     "list of OpenACC GPU parallel dimensions"))
+    return {};
+  return ActiveParDimsAttr::get(parser.getContext(), parDims);
+}
+
+void ActiveParDimsAttr::print(AsmPrinter &printer) const {
+  printer << "[";
+  llvm::interleaveComma(getArray(), printer,
+                        [&printer](const GPUParallelDimAttr &p) {
+                          printProcessorValue(printer, p);
+                        });
+  printer << "]";
+}

--- a/mlir/lib/Dialect/OpenACC/Utils/OpenACCUtilsCG.cpp
+++ b/mlir/lib/Dialect/OpenACC/Utils/OpenACCUtilsCG.cpp
@@ -224,6 +224,22 @@ void copyParDimsAttr(Operation *from, Operation *to) {
   setParDimsAttr(to, getParDimsAttr(from));
 }
 
+ActiveParDimsAttr getActiveParDimsAttr(Operation *op) {
+  return op->getAttrOfType<ActiveParDimsAttr>(ActiveParDimsAttr::name);
+}
+
+bool hasActiveParDimsAttr(Operation *op) {
+  return getActiveParDimsAttr(op) != nullptr;
+}
+
+void setActiveParDimsAttr(Operation *op, ActiveParDimsAttr attr) {
+  op->setAttr(ActiveParDimsAttr::name, attr);
+}
+
+void setActiveParDimsAttr(Operation *op, ArrayRef<GPUParallelDimAttr> dims) {
+  setActiveParDimsAttr(op, ActiveParDimsAttr::get(op->getContext(), dims));
+}
+
 int64_t SharedMemoryBudget::alignOffset(int64_t offset, int64_t alignment) {
   assert(alignment > 0 && llvm::isPowerOf2_64(alignment) &&
          "alignment must be a power of two");

--- a/mlir/test/Dialect/OpenACC/ops-cg.mlir
+++ b/mlir/test/Dialect/OpenACC/ops-cg.mlir
@@ -52,6 +52,19 @@ func.func @par_dims_block_thread() {
 
 // -----
 
+// CHECK-LABEL: func @active_par_dims_attr
+func.func @active_par_dims_attr() {
+  %private = acc.privatize {acc.active_par_dims = #acc<active_par_dims[block_x, thread_x]>}
+      : () -> !acc.private_type<memref<i32>>
+  %local = acc.private_local %private {acc.active_par_dims = #acc<active_par_dims[block_x, thread_x]>}
+      : (!acc.private_type<memref<i32>>) -> memref<i32>
+  return
+}
+// CHECK: acc.privatize {{.*}}{acc.active_par_dims = #acc<active_par_dims[block_x, thread_x]>}
+// CHECK: acc.private_local {{.*}}{acc.active_par_dims = #acc<active_par_dims[block_x, thread_x]>}
+
+// -----
+
 // All GPU parallel dimensions (par_dim values) in par_dims list
 func.func @par_dims_all_dims() {
   %c0 = arith.constant 0 : index

--- a/mlir/unittests/Dialect/OpenACC/OpenACCUtilsCGTest.cpp
+++ b/mlir/unittests/Dialect/OpenACC/OpenACCUtilsCGTest.cpp
@@ -260,6 +260,24 @@ TEST_F(OpenACCUtilsCGTest, setParDimsAttrSetsInherentAttribute) {
   EXPECT_EQ(privatize.getParDimsAttr(), blockAttr);
 }
 
+TEST_F(OpenACCUtilsCGTest, activeParDimsOperationAttributes) {
+  OwningOpRef<ModuleOp> module = ModuleOp::create(b, loc);
+  Operation *op = module->getOperation();
+  ActiveParDimsAttr activeAttr = ActiveParDimsAttr::get(
+      &context, {GPUParallelDimAttr::blockXDim(&context),
+                 GPUParallelDimAttr::threadXDim(&context)});
+
+  EXPECT_FALSE(hasActiveParDimsAttr(op));
+  setActiveParDimsAttr(op, activeAttr);
+  EXPECT_TRUE(hasActiveParDimsAttr(op));
+  EXPECT_EQ(getActiveParDimsAttr(op), activeAttr);
+
+  ActiveParDimsAttr threadAttr = ActiveParDimsAttr::get(
+      &context, {GPUParallelDimAttr::threadXDim(&context)});
+  setActiveParDimsAttr(op, threadAttr);
+  EXPECT_EQ(getActiveParDimsAttr(op), threadAttr);
+}
+
 //===----------------------------------------------------------------------===//
 // buildComputeRegion Tests
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This change adds `acc.active_par_dims` attribute to OpenACC dialect. This attribute will be used to record which launch dimensions execute an operation without predication.