### PR TITLE
[lldb][Windows] Derive the loader one-thread timeout from settings

### DIFF
--- a/lldb/source/Plugins/Platform/Windows/PlatformWindows.cpp
+++ b/lldb/source/Plugins/Platform/Windows/PlatformWindows.cpp
@@ -50,7 +50,9 @@ static uint32_t g_initialize_count = 0;
 
 // Upper bound on the timeout used when running a utility expression with
 // only one thread allowed to run.
-static constexpr std::chrono::seconds g_max_one_thread_timeout(5);
+static std::chrono::microseconds GetLoaderOneThreadTimeout(Process *process) {
+  return std::chrono::microseconds(process->GetUtilityExpressionTimeout()) / 2;
+}
 
 namespace {
 
@@ -429,8 +431,7 @@ uint32_t PlatformWindows::DoLoadImage(Process *process,
   // handle currently.
   options.SetTrapExceptions(false);
   options.SetTimeout(process->GetUtilityExpressionTimeout());
-  options.SetOneThreadTimeout(std::min<std::chrono::microseconds>(
-      g_max_one_thread_timeout, process->GetUtilityExpressionTimeout() / 2));
+  options.SetOneThreadTimeout(GetLoaderOneThreadTimeout(process));
   options.SetIsForUtilityExpr(true);
 
   ExpressionResults result =
@@ -942,8 +943,7 @@ extern "C" {
   // handle currently.
   options.SetTrapExceptions(false);
   options.SetTimeout(process->GetUtilityExpressionTimeout());
-  options.SetOneThreadTimeout(std::min<std::chrono::microseconds>(
-      g_max_one_thread_timeout, process->GetUtilityExpressionTimeout() / 2));
+  options.SetOneThreadTimeout(GetLoaderOneThreadTimeout(process));
 
   ExpressionResults result = UserExpression::Evaluate(
       context, options, expression, kLoaderDecls, value);


### PR DESCRIPTION
Timeouts always lead to hard to debug behavior on slow bots. Instead of hard coding the value, use half of `target.process.utility-expression-timeout` instead, which is the same split `RunThreadPlan` applies when no one-thread timeout is set.
That setting is already the one used for LLDB internal utility expressions: it can be set by the user and its default is raised from 15s to 60s in sanitized builds.