### PR TITLE
[CodeGen] Overload `adjustLaneLiveness` to cleanly split use cases (NFC)

### DIFF
--- a/llvm/include/llvm/CodeGen/RegisterPressure.h
+++ b/llvm/include/llvm/CodeGen/RegisterPressure.h
@@ -187,13 +187,27 @@ public:
                                const LiveIntervals &LIS);
 
   /// Use liveness information to find out which uses/defs are partially
-  /// undefined/dead and adjust the VRegMaskOrUnits accordingly.
-  /// If \p AddFlagsMI is given then missing read-undef and dead flags will be
-  /// added to the instruction.
+  /// undefined/dead at \p Pos and adjust the VRegMaskOrUnits accordingly.
   LLVM_ABI void adjustLaneLiveness(const LiveIntervals &LIS,
                                    const MachineRegisterInfo &MRI,
-                                   SlotIndex Pos,
-                                   MachineInstr *AddFlagsMI = nullptr);
+                                   SlotIndex Pos);
+
+  /// Use liveness information to find out which uses/defs are partially
+  /// undefined/dead at the \p MI's position and adjust the VRegMaskOrUnits
+  /// accordingly. Missing read-undef and dead flags are added to \p MI.
+  LLVM_ABI void adjustLaneLiveness(const LiveIntervals &LIS,
+                                   const MachineRegisterInfo &MRI,
+                                   MachineInstr &MI);
+
+private:
+  /// Adjusts the \p Def based on \p LiveAfterDef. The \p Def is removed from
+  /// the Defs vector when no defined lane remains live after the def. Returns a
+  /// pointer to the next definition to process in order in the Defs vector.
+  VRegMaskOrUnit *adjustDef(VRegMaskOrUnit &Def, LaneBitmask LiveAfterDef);
+
+  /// Use liveness information at \p Pos to adjust the lanemask of all uses.
+  void adjustUses(const LiveIntervals &LIS, const MachineRegisterInfo &MRI,
+                  SlotIndex Pos);
 };
 
 /// Array of PressureDiffs.

--- a/llvm/lib/CodeGen/MachineScheduler.cpp
+++ b/llvm/lib/CodeGen/MachineScheduler.cpp
@@ -1892,8 +1892,7 @@ void ScheduleDAGMILive::scheduleMI(SUnit *SU, bool IsTopNode) {
                        /*IgnoreDead=*/false);
       if (ShouldTrackLaneMasks) {
         // Adjust liveness and add missing dead+read-undef flags.
-        SlotIndex SlotIdx = LIS->getInstructionIndex(*MI).getRegSlot();
-        RegOpers.adjustLaneLiveness(*LIS, MRI, SlotIdx, MI);
+        RegOpers.adjustLaneLiveness(*LIS, MRI, *MI);
       } else {
         // Adjust for missing dead-def flags.
         RegOpers.detectDeadDefs(*MI, *LIS);
@@ -1927,8 +1926,7 @@ void ScheduleDAGMILive::scheduleMI(SUnit *SU, bool IsTopNode) {
                        /*IgnoreDead=*/false);
       if (ShouldTrackLaneMasks) {
         // Adjust liveness and add missing dead+read-undef flags.
-        SlotIndex SlotIdx = LIS->getInstructionIndex(*MI).getRegSlot();
-        RegOpers.adjustLaneLiveness(*LIS, MRI, SlotIdx, MI);
+        RegOpers.adjustLaneLiveness(*LIS, MRI, *MI);
       } else {
         // Adjust for missing dead-def flags.
         RegOpers.detectDeadDefs(*MI, *LIS);

--- a/llvm/lib/CodeGen/RegisterPressure.cpp
+++ b/llvm/lib/CodeGen/RegisterPressure.cpp
@@ -597,41 +597,59 @@ void RegisterOperands::detectDeadDefs(const MachineInstr &MI,
 
 void RegisterOperands::adjustLaneLiveness(const LiveIntervals &LIS,
                                           const MachineRegisterInfo &MRI,
-                                          SlotIndex Pos,
-                                          MachineInstr *AddFlagsMI) {
-  for (auto *I = Defs.begin(); I != Defs.end();) {
-    LaneBitmask LiveAfter =
-        getLiveLanesAt(LIS, MRI, true, I->VRegOrUnit, Pos.getDeadSlot());
+                                          SlotIndex Pos) {
+  for (auto *I = Defs.begin(); I != Defs.end(); /*empty*/) {
+    LaneBitmask LiveAfter = getLiveLanesAt(LIS, MRI, /*TrackLaneMasks=*/true,
+                                           I->VRegOrUnit, Pos.getDeadSlot());
+    I = adjustDef(*I, LiveAfter);
+  }
+  adjustUses(LIS, MRI, Pos.getBaseIndex());
+}
+
+void RegisterOperands::adjustLaneLiveness(const LiveIntervals &LIS,
+                                          const MachineRegisterInfo &MRI,
+                                          MachineInstr &MI) {
+  SlotIndex Pos = LIS.getInstructionIndex(MI);
+  for (auto *I = Defs.begin(); I != Defs.end(); /*empty*/) {
+    LaneBitmask LiveAfter = getLiveLanesAt(LIS, MRI, /*TrackLaneMasks=*/true,
+                                           I->VRegOrUnit, Pos.getDeadSlot());
     // If the def is all that is live after the instruction, then in case
     // of a subregister def we need a read-undef flag.
     VirtRegOrUnit VRegOrUnit = I->VRegOrUnit;
-    if (VRegOrUnit.isVirtualReg() && AddFlagsMI != nullptr &&
-        (LiveAfter & ~I->LaneMask).none())
-      AddFlagsMI->setRegisterDefReadUndef(VRegOrUnit.asVirtualReg());
-
-    LaneBitmask ActualDef = I->LaneMask & LiveAfter;
-    if (ActualDef.none()) {
-      I = Defs.erase(I);
-    } else {
-      I->LaneMask = ActualDef;
-      ++I;
-    }
+    if (VRegOrUnit.isVirtualReg() && (LiveAfter & ~I->LaneMask).none())
+      MI.setRegisterDefReadUndef(VRegOrUnit.asVirtualReg());
+    I = adjustDef(*I, LiveAfter);
   }
 
-  // For uses just copy the information from LIS.
-  for (auto &[VRegOrUnit, LaneMask] : Uses)
-    LaneMask = getLiveLanesAt(LIS, MRI, true, VRegOrUnit, Pos.getBaseIndex());
+  adjustUses(LIS, MRI, Pos);
 
-  if (AddFlagsMI != nullptr) {
-    for (const VRegMaskOrUnit &P : DeadDefs) {
-      VirtRegOrUnit VRegOrUnit = P.VRegOrUnit;
-      if (!VRegOrUnit.isVirtualReg())
-        continue;
-      LaneBitmask LiveAfter =
-          getLiveLanesAt(LIS, MRI, true, VRegOrUnit, Pos.getDeadSlot());
-      if (LiveAfter.none())
-        AddFlagsMI->setRegisterDefReadUndef(VRegOrUnit.asVirtualReg());
-    }
+  for (const VRegMaskOrUnit &P : DeadDefs) {
+    VirtRegOrUnit VRegOrUnit = P.VRegOrUnit;
+    if (!VRegOrUnit.isVirtualReg())
+      continue;
+    LaneBitmask LiveAfter = getLiveLanesAt(LIS, MRI, /*TrackLaneMasks=*/true,
+                                           VRegOrUnit, Pos.getDeadSlot());
+    if (LiveAfter.none())
+      MI.setRegisterDefReadUndef(VRegOrUnit.asVirtualReg());
+  }
+}
+
+VRegMaskOrUnit *RegisterOperands::adjustDef(VRegMaskOrUnit &Def,
+                                            LaneBitmask LiveAfterDef) {
+  LaneBitmask ActualDef = Def.LaneMask & LiveAfterDef;
+  if (ActualDef.none())
+    return Defs.erase(&Def);
+
+  Def.LaneMask = ActualDef;
+  return &Def + 1;
+}
+
+void RegisterOperands::adjustUses(const LiveIntervals &LIS,
+                                  const MachineRegisterInfo &MRI,
+                                  SlotIndex Pos) {
+  for (auto &[VRegOrUnit, LaneMask] : Uses) {
+    LaneMask =
+        getLiveLanesAt(LIS, MRI, /*TrackLaneMasks=*/true, VRegOrUnit, Pos);
   }
 }
 

--- a/llvm/lib/Target/AMDGPU/GCNIterativeScheduler.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNIterativeScheduler.cpp
@@ -376,8 +376,7 @@ void GCNIterativeScheduler::restoreLivenessFlags(MachineInstr &MI) {
   RegisterOperands RegOpers;
   RegOpers.collect(MI, *TRI, MRI, /*ShouldTrackLaneMasks=*/true,
                    /*IgnoreDead=*/false);
-  SlotIndex SlotIdx = LIS->getInstructionIndex(MI).getRegSlot();
-  RegOpers.adjustLaneLiveness(*LIS, MRI, SlotIdx, &MI);
+  RegOpers.adjustLaneLiveness(*LIS, MRI, MI);
 }
 
 void GCNIterativeScheduler::restoreRegionLivenessFlags(const Region &R) {

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -2301,8 +2301,7 @@ void GCNSchedStage::modifyRegionSchedule(unsigned RegionIdx,
     RegOpers.collect(*MI, *DAG.TRI, DAG.MRI, DAG.ShouldTrackLaneMasks, false);
     if (DAG.ShouldTrackLaneMasks) {
       // Adjust liveness and add missing dead+read-undef flags.
-      SlotIndex SlotIdx = DAG.LIS->getInstructionIndex(*MI).getRegSlot();
-      RegOpers.adjustLaneLiveness(*DAG.LIS, DAG.MRI, SlotIdx, MI);
+      RegOpers.adjustLaneLiveness(*DAG.LIS, DAG.MRI, *MI);
     } else {
       // Adjust for missing dead-def flags.
       RegOpers.detectDeadDefs(*MI, *DAG.LIS);

--- a/llvm/unittests/CodeGen/RematerializerTest.cpp
+++ b/llvm/unittests/CodeGen/RematerializerTest.cpp
@@ -167,8 +167,7 @@ body:             |
 
     RegisterOperands RegOpers;
     RegOpers.collect(MI, TRI, MRI, true, /*IgnoreDead=*/false);
-    SlotIndex Slot = LIS.getInstructionIndex(MI).getRegSlot();
-    RegOpers.adjustLaneLiveness(LIS, MRI, Slot, &MI);
+    RegOpers.adjustLaneLiveness(LIS, MRI, MI);
   };
 };
 } // namespace


### PR DESCRIPTION
When providing a non-null `AddFlagsMI` it makes no sense to pass a `Pos` that is not `AddFlagsMI`'s own position. In such cases the position can be queried from the MI directly, avoiding possible inconsistencies.

This splits `RegisterOperands::adjustLaneLiveness` into two overloads whose behavior only differ in whether an MI's operand flags are updated in the process.