### PR TITLE
Revert "[libc][bazel] Remove full-build dependency from __support_libc_assert"

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -1467,12 +1467,15 @@ libc_support_library(
     name = "__support_libc_assert",
     hdrs = ["src/__support/libc_assert.h"],
     deps = [
+        ":__support_integer_to_string",
         ":__support_macros_attributes",
         ":__support_macros_config",
         ":__support_macros_hardening",
         ":__support_macros_macro_utils",
         ":__support_macros_optimization",
         ":__support_macros_properties_os",
+        ":__support_osutil_exit_hdrs",
+        ":__support_osutil_io",
     ],
 )
 


### PR DESCRIPTION
Reverts llvm/llvm-project#215588

it is breaking other libc tests