### PR TITLE
[VectorCombine] Recognise partially commuted operands in foldShuffleToIdentity

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
+++ b/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
@@ -3536,6 +3536,75 @@ generateInstLaneVectorFromOperand(ArrayRef<InstLane> Item, int Op) {
   return NItem;
 }
 
+// Handle cases where some profitable patterns can be recovered by swapping
+// some lanes on operands of commutative binops. Does not try to see through
+// shuffles.
+static std::optional<std::pair<SmallVector<InstLane>, SmallVector<InstLane>>>
+generateInstLaneVectorsFromCommutativeOperands(ArrayRef<InstLane> Item) {
+  auto *BO = dyn_cast<BinaryOperator>(Item.front().first);
+  if (!BO || !BO->isCommutative())
+    return std::nullopt;
+
+  SmallVector<InstLane> Op0 = generateInstLaneVectorFromOperand(Item, 0);
+  SmallVector<InstLane> Op1 = generateInstLaneVectorFromOperand(Item, 1);
+
+  // Tries to make all lanes on operand <ToSide> satisfy <Pred> by swapping some
+  // lanes. Poison fits anywhere. Decline when the predicate is satisfied
+  // without swapping, or already satisfied on the other side (prevent
+  // unnecessarily swapping whole operands)
+  auto TrySplit = [&](function_ref<bool(InstLane)> Pred, unsigned ToSide)
+      -> std::optional<
+          std::pair<SmallVector<InstLane>, SmallVector<InstLane>>> {
+    SmallVector<InstLane> NewOp0 = Op0, NewOp1 = Op1;
+    if (ToSide == 1)
+      std::swap(NewOp0, NewOp1);
+    bool Swapped = false, AlreadyOnOtherSide = true;
+    for (auto [L0, L1] : zip(NewOp0, NewOp1)) {
+      AlreadyOnOtherSide &= !L1.first || Pred(L1);
+      if (!L0.first || Pred(L0))
+        continue;
+      if (L1.first && !Pred(L1))
+        return std::nullopt;
+      std::swap(L0, L1);
+      Swapped = true;
+    }
+    if (!Swapped || AlreadyOnOtherSide)
+      return std::nullopt;
+    return std::make_pair(std::move(NewOp0), std::move(NewOp1));
+  };
+
+  // Use the first lanes of each operand as anchors to check against
+  SmallVector<InstLane> Anchors = {Op0.front(), Op1.front()};
+  SmallVector<Value *> Src = {Anchors[0].first, Anchors[1].first};
+
+  if (Src[0] && Src[0] == Src[1]) {
+    // Same source value: try to recover a splat. The only profitable pattern to
+    // recover here is binop(splat, identity), e.g.
+    //   <a[0]+a[0], a[1]+a[0], a[0]+a[2], a[0]+a[3]>
+    //   -> <a[0], a[1], a[2], a[3]> + <a[0], a[0], a[0], a[0]>
+    for (auto [ToSide, A] : enumerate(Anchors)) {
+      InstLane Anchor = A; // C++17 lambdas cannot capture a binding directly.
+      if (auto Split =
+              TrySplit([&](InstLane X) { return X == Anchor; }, ToSide))
+        return Split;
+    }
+  } else {
+    // Distinct source values: try to swap the same source value to one side.
+    // Any binop(identity/splat/constant, identity/splat/constant) on distinct
+    // sources falls on this path.
+    for (auto [ToSide, A] : enumerate(Anchors)) {
+      InstLane Anchor = A;
+      if (!Anchor.first)
+        continue;
+      if (auto Split = TrySplit(
+              [&](InstLane X) { return X.first == Anchor.first; }, ToSide))
+        return Split;
+    }
+  }
+
+  return std::nullopt;
+}
+
 /// Detect concat of multiple values into a vector
 static bool isFreeConcat(ArrayRef<InstLane> Item, TTI::TargetCostKind CostKind,
                          const TargetTransformInfo &TTI) {
@@ -3658,15 +3727,20 @@ generateNewInstTree(ArrayRef<InstLane> Item, Use *From,
   auto *II = dyn_cast<IntrinsicInst>(I);
   unsigned NumOps = I->getNumOperands() - (II ? 1 : 0);
   SmallVector<Value *> Ops(NumOps);
+  std::optional<std::pair<SmallVector<InstLane>, SmallVector<InstLane>>> Split =
+      generateInstLaneVectorsFromCommutativeOperands(Item);
   for (unsigned Idx = 0; Idx < NumOps; Idx++) {
     if (II &&
         isVectorIntrinsicWithScalarOpAtArg(II->getIntrinsicID(), Idx, TTI)) {
       Ops[Idx] = II->getOperand(Idx);
       continue;
     }
-    Ops[Idx] = generateNewInstTree(
-        generateInstLaneVectorFromOperand(Item, Idx), &I->getOperandUse(Idx),
-        IdentityLeafs, SplatLeafs, ConcatLeafs, Builder, WorkList, TTI);
+    SmallVector<InstLane> OpItem =
+        Split ? (Idx == 0 ? Split->first : Split->second)
+              : generateInstLaneVectorFromOperand(Item, Idx);
+    Ops[Idx] =
+        generateNewInstTree(OpItem, &I->getOperandUse(Idx), IdentityLeafs,
+                            SplatLeafs, ConcatLeafs, Builder, WorkList, TTI);
     // Don't re-queue the operand of a bitcast we just regenerated. Doing so
     // lets foldBitcastShuffle sink the bitcast back into a shuffle(bitcast),
     // which foldShuffleToIdentity then re-matches as the same superfluous
@@ -3819,6 +3893,13 @@ bool VectorCombine::foldShuffleToIdentity(Instruction &I) {
         if (auto *BO = dyn_cast<BinaryOperator>(FrontV);
             BO && BO->isIntDivRem())
           return false;
+        if (auto Split = generateInstLaneVectorsFromCommutativeOperands(Item)) {
+          Candidates.emplace_back(Split->first,
+                                  &cast<Instruction>(FrontV)->getOperandUse(0));
+          Candidates.emplace_back(Split->second,
+                                  &cast<Instruction>(FrontV)->getOperandUse(1));
+          continue;
+        }
         Candidates.emplace_back(generateInstLaneVectorFromOperand(Item, 0),
                                 &cast<Instruction>(FrontV)->getOperandUse(0));
         Candidates.emplace_back(generateInstLaneVectorFromOperand(Item, 1),

--- a/llvm/test/Transforms/VectorCombine/AArch64/shuffletoidentity.ll
+++ b/llvm/test/Transforms/VectorCombine/AArch64/shuffletoidentity.ll
@@ -1421,3 +1421,102 @@ define <16 x i8> @bitcast_narrow4_widen4_add(<16 x i8> %a, <16 x i8> %b) {
   %result = shufflevector <8 x i8> %bc_lo, <8 x i8> %bc_hi, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   ret <16 x i8> %result
 }
+
+define <8 x half> @splat_and_identity_commuted(<8 x half> %a) {
+; CHECK-LABEL: @splat_and_identity_commuted(
+; CHECK-NEXT:    [[AB:%.*]] = shufflevector <8 x half> [[A:%.*]], <8 x half> poison, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
+; CHECK-NEXT:    [[AT:%.*]] = shufflevector <8 x half> [[A]], <8 x half> poison, <4 x i32> <i32 7, i32 6, i32 5, i32 4>
+; CHECK-NEXT:    [[BS:%.*]] = shufflevector <8 x half> [[A]], <8 x half> poison, <4 x i32> zeroinitializer
+; CHECK-NEXT:    [[ABT:%.*]] = fadd <4 x half> [[AT]], [[BS]]
+; CHECK-NEXT:    [[ABB:%.*]] = fadd <4 x half> [[BS]], [[AB]]
+; CHECK-NEXT:    [[R:%.*]] = shufflevector <4 x half> [[ABT]], <4 x half> [[ABB]], <8 x i32> <i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
+; CHECK-NEXT:    ret <8 x half> [[R]]
+;
+  %ab = shufflevector <8 x half> %a, <8 x half> poison, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
+  %at = shufflevector <8 x half> %a, <8 x half> poison, <4 x i32> <i32 7, i32 6, i32 5, i32 4>
+  %bs = shufflevector <8 x half> %a, <8 x half> poison, <4 x i32> zeroinitializer
+  %abt = fadd <4 x half> %at, %bs
+  %abb = fadd <4 x half> %bs, %ab
+  %r = shufflevector <4 x half> %abt, <4 x half> %abb, <8 x i32> <i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
+  ret <8 x half> %r
+}
+
+define <8 x half> @fadd_commuted(<8 x half> %a, <8 x half> %b) {
+; CHECK-LABEL: @fadd_commuted(
+; CHECK-NEXT:    [[AB:%.*]] = shufflevector <8 x half> [[A:%.*]], <8 x half> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+; CHECK-NEXT:    [[AT:%.*]] = shufflevector <8 x half> [[A]], <8 x half> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+; CHECK-NEXT:    [[BB:%.*]] = shufflevector <8 x half> [[B:%.*]], <8 x half> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+; CHECK-NEXT:    [[BT:%.*]] = shufflevector <8 x half> [[B]], <8 x half> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+; CHECK-NEXT:    [[XB:%.*]] = fadd <4 x half> [[AB]], [[BB]]
+; CHECK-NEXT:    [[XT:%.*]] = fadd <4 x half> [[BT]], [[AT]]
+; CHECK-NEXT:    [[R:%.*]] = shufflevector <4 x half> [[XB]], <4 x half> [[XT]], <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+; CHECK-NEXT:    ret <8 x half> [[R]]
+;
+  %ab = shufflevector <8 x half> %a, <8 x half> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %at = shufflevector <8 x half> %a, <8 x half> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %bb = shufflevector <8 x half> %b, <8 x half> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %bt = shufflevector <8 x half> %b, <8 x half> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %xb = fadd <4 x half> %ab, %bb
+  %xt = fadd <4 x half> %bt, %at
+  %r = shufflevector <4 x half> %xb, <4 x half> %xt, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  ret <8 x half> %r
+}
+
+define <8 x i8> @constantsplat_commuted(<8 x i8> %a) {
+; CHECK-LABEL: @constantsplat_commuted(
+; CHECK-NEXT:    [[AB:%.*]] = shufflevector <8 x i8> [[A:%.*]], <8 x i8> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+; CHECK-NEXT:    [[AT:%.*]] = shufflevector <8 x i8> [[A]], <8 x i8> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+; CHECK-NEXT:    [[XB:%.*]] = add <4 x i8> [[AB]], splat (i8 10)
+; CHECK-NEXT:    [[XT:%.*]] = add <4 x i8> splat (i8 10), [[AT]]
+; CHECK-NEXT:    [[R:%.*]] = shufflevector <4 x i8> [[XB]], <4 x i8> [[XT]], <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+; CHECK-NEXT:    ret <8 x i8> [[R]]
+;
+  %ab = shufflevector <8 x i8> %a, <8 x i8> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %at = shufflevector <8 x i8> %a, <8 x i8> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %xb = add <4 x i8> %ab, <i8 10, i8 10, i8 10, i8 10>
+  %xt = add <4 x i8> <i8 10, i8 10, i8 10, i8 10>, %at
+  %r = shufflevector <4 x i8> %xb, <4 x i8> %xt, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  ret <8 x i8> %r
+}
+
+define <8 x i8> @undeflane_commuted(<8 x i8> %a, <8 x i8> %b) {
+; CHECK-LABEL: @undeflane_commuted(
+; CHECK-NEXT:    [[AB:%.*]] = shufflevector <8 x i8> [[A:%.*]], <8 x i8> poison, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
+; CHECK-NEXT:    [[AT:%.*]] = shufflevector <8 x i8> [[A]], <8 x i8> poison, <4 x i32> <i32 7, i32 6, i32 5, i32 4>
+; CHECK-NEXT:    [[BB:%.*]] = shufflevector <8 x i8> [[B:%.*]], <8 x i8> poison, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
+; CHECK-NEXT:    [[BT:%.*]] = shufflevector <8 x i8> [[B]], <8 x i8> poison, <4 x i32> <i32 7, i32 6, i32 5, i32 4>
+; CHECK-NEXT:    [[ABT:%.*]] = add <4 x i8> [[AT]], [[BT]]
+; CHECK-NEXT:    [[ABB:%.*]] = add <4 x i8> [[BB]], [[AB]]
+; CHECK-NEXT:    [[R:%.*]] = shufflevector <4 x i8> [[ABT]], <4 x i8> [[ABB]], <8 x i32> <i32 7, i32 6, i32 5, i32 4, i32 3, i32 poison, i32 1, i32 0>
+; CHECK-NEXT:    ret <8 x i8> [[R]]
+;
+  %ab = shufflevector <8 x i8> %a, <8 x i8> poison, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
+  %at = shufflevector <8 x i8> %a, <8 x i8> poison, <4 x i32> <i32 7, i32 6, i32 5, i32 4>
+  %bb = shufflevector <8 x i8> %b, <8 x i8> poison, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
+  %bt = shufflevector <8 x i8> %b, <8 x i8> poison, <4 x i32> <i32 7, i32 6, i32 5, i32 4>
+  %abt = add <4 x i8> %at, %bt
+  %abb = add <4 x i8> %bb, %ab
+  %r = shufflevector <4 x i8> %abt, <4 x i8> %abb, <8 x i32> <i32 7, i32 6, i32 5, i32 4, i32 3, i32 poison, i32 1, i32 0>
+  ret <8 x i8> %r
+}
+
+define <8 x half> @commuted_poison_operand(<8 x half> %a, <8 x half> %b) {
+; CHECK-LABEL: @commuted_poison_operand(
+; CHECK-NEXT:    [[AB:%.*]] = shufflevector <8 x half> [[A:%.*]], <8 x half> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+; CHECK-NEXT:    [[AT:%.*]] = shufflevector <8 x half> [[A]], <8 x half> poison, <4 x i32> <i32 4, i32 poison, i32 6, i32 7>
+; CHECK-NEXT:    [[BB:%.*]] = shufflevector <8 x half> [[B:%.*]], <8 x half> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+; CHECK-NEXT:    [[BT:%.*]] = shufflevector <8 x half> [[B]], <8 x half> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+; CHECK-NEXT:    [[XB:%.*]] = fadd <4 x half> [[AB]], [[BB]]
+; CHECK-NEXT:    [[XT:%.*]] = fadd <4 x half> [[BT]], [[AT]]
+; CHECK-NEXT:    [[R:%.*]] = shufflevector <4 x half> [[XB]], <4 x half> [[XT]], <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+; CHECK-NEXT:    ret <8 x half> [[R]]
+;
+  %ab = shufflevector <8 x half> %a, <8 x half> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %at = shufflevector <8 x half> %a, <8 x half> poison, <4 x i32> <i32 4, i32 poison, i32 6, i32 7>
+  %bb = shufflevector <8 x half> %b, <8 x half> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %bt = shufflevector <8 x half> %b, <8 x half> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %xb = fadd <4 x half> %ab, %bb
+  %xt = fadd <4 x half> %bt, %at
+  %r = shufflevector <4 x half> %xb, <4 x half> %xt, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  ret <8 x half> %r
+}

--- a/llvm/test/Transforms/VectorCombine/AArch64/shuffletoidentity.ll
+++ b/llvm/test/Transforms/VectorCombine/AArch64/shuffletoidentity.ll
@@ -1424,12 +1424,8 @@ define <16 x i8> @bitcast_narrow4_widen4_add(<16 x i8> %a, <16 x i8> %b) {
 
 define <8 x half> @splat_and_identity_commuted(<8 x half> %a) {
 ; CHECK-LABEL: @splat_and_identity_commuted(
-; CHECK-NEXT:    [[AB:%.*]] = shufflevector <8 x half> [[A:%.*]], <8 x half> poison, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
-; CHECK-NEXT:    [[AT:%.*]] = shufflevector <8 x half> [[A]], <8 x half> poison, <4 x i32> <i32 7, i32 6, i32 5, i32 4>
-; CHECK-NEXT:    [[BS:%.*]] = shufflevector <8 x half> [[A]], <8 x half> poison, <4 x i32> zeroinitializer
-; CHECK-NEXT:    [[ABT:%.*]] = fadd <4 x half> [[AT]], [[BS]]
-; CHECK-NEXT:    [[ABB:%.*]] = fadd <4 x half> [[BS]], [[AB]]
-; CHECK-NEXT:    [[R:%.*]] = shufflevector <4 x half> [[ABT]], <4 x half> [[ABB]], <8 x i32> <i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
+; CHECK-NEXT:    [[TMP1:%.*]] = shufflevector <8 x half> [[A:%.*]], <8 x half> poison, <8 x i32> zeroinitializer
+; CHECK-NEXT:    [[R:%.*]] = fadd <8 x half> [[TMP1]], [[A]]
 ; CHECK-NEXT:    ret <8 x half> [[R]]
 ;
   %ab = shufflevector <8 x half> %a, <8 x half> poison, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
@@ -1443,13 +1439,7 @@ define <8 x half> @splat_and_identity_commuted(<8 x half> %a) {
 
 define <8 x half> @fadd_commuted(<8 x half> %a, <8 x half> %b) {
 ; CHECK-LABEL: @fadd_commuted(
-; CHECK-NEXT:    [[AB:%.*]] = shufflevector <8 x half> [[A:%.*]], <8 x half> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-; CHECK-NEXT:    [[AT:%.*]] = shufflevector <8 x half> [[A]], <8 x half> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-; CHECK-NEXT:    [[BB:%.*]] = shufflevector <8 x half> [[B:%.*]], <8 x half> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-; CHECK-NEXT:    [[BT:%.*]] = shufflevector <8 x half> [[B]], <8 x half> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-; CHECK-NEXT:    [[XB:%.*]] = fadd <4 x half> [[AB]], [[BB]]
-; CHECK-NEXT:    [[XT:%.*]] = fadd <4 x half> [[BT]], [[AT]]
-; CHECK-NEXT:    [[R:%.*]] = shufflevector <4 x half> [[XB]], <4 x half> [[XT]], <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+; CHECK-NEXT:    [[R:%.*]] = fadd <8 x half> [[A:%.*]], [[B:%.*]]
 ; CHECK-NEXT:    ret <8 x half> [[R]]
 ;
   %ab = shufflevector <8 x half> %a, <8 x half> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
@@ -1464,11 +1454,7 @@ define <8 x half> @fadd_commuted(<8 x half> %a, <8 x half> %b) {
 
 define <8 x i8> @constantsplat_commuted(<8 x i8> %a) {
 ; CHECK-LABEL: @constantsplat_commuted(
-; CHECK-NEXT:    [[AB:%.*]] = shufflevector <8 x i8> [[A:%.*]], <8 x i8> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-; CHECK-NEXT:    [[AT:%.*]] = shufflevector <8 x i8> [[A]], <8 x i8> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-; CHECK-NEXT:    [[XB:%.*]] = add <4 x i8> [[AB]], splat (i8 10)
-; CHECK-NEXT:    [[XT:%.*]] = add <4 x i8> splat (i8 10), [[AT]]
-; CHECK-NEXT:    [[R:%.*]] = shufflevector <4 x i8> [[XB]], <4 x i8> [[XT]], <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+; CHECK-NEXT:    [[R:%.*]] = add <8 x i8> [[A:%.*]], splat (i8 10)
 ; CHECK-NEXT:    ret <8 x i8> [[R]]
 ;
   %ab = shufflevector <8 x i8> %a, <8 x i8> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
@@ -1481,13 +1467,7 @@ define <8 x i8> @constantsplat_commuted(<8 x i8> %a) {
 
 define <8 x i8> @undeflane_commuted(<8 x i8> %a, <8 x i8> %b) {
 ; CHECK-LABEL: @undeflane_commuted(
-; CHECK-NEXT:    [[AB:%.*]] = shufflevector <8 x i8> [[A:%.*]], <8 x i8> poison, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
-; CHECK-NEXT:    [[AT:%.*]] = shufflevector <8 x i8> [[A]], <8 x i8> poison, <4 x i32> <i32 7, i32 6, i32 5, i32 4>
-; CHECK-NEXT:    [[BB:%.*]] = shufflevector <8 x i8> [[B:%.*]], <8 x i8> poison, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
-; CHECK-NEXT:    [[BT:%.*]] = shufflevector <8 x i8> [[B]], <8 x i8> poison, <4 x i32> <i32 7, i32 6, i32 5, i32 4>
-; CHECK-NEXT:    [[ABT:%.*]] = add <4 x i8> [[AT]], [[BT]]
-; CHECK-NEXT:    [[ABB:%.*]] = add <4 x i8> [[BB]], [[AB]]
-; CHECK-NEXT:    [[R:%.*]] = shufflevector <4 x i8> [[ABT]], <4 x i8> [[ABB]], <8 x i32> <i32 7, i32 6, i32 5, i32 4, i32 3, i32 poison, i32 1, i32 0>
+; CHECK-NEXT:    [[R:%.*]] = add <8 x i8> [[B:%.*]], [[A:%.*]]
 ; CHECK-NEXT:    ret <8 x i8> [[R]]
 ;
   %ab = shufflevector <8 x i8> %a, <8 x i8> poison, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
@@ -1502,13 +1482,7 @@ define <8 x i8> @undeflane_commuted(<8 x i8> %a, <8 x i8> %b) {
 
 define <8 x half> @commuted_poison_operand(<8 x half> %a, <8 x half> %b) {
 ; CHECK-LABEL: @commuted_poison_operand(
-; CHECK-NEXT:    [[AB:%.*]] = shufflevector <8 x half> [[A:%.*]], <8 x half> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-; CHECK-NEXT:    [[AT:%.*]] = shufflevector <8 x half> [[A]], <8 x half> poison, <4 x i32> <i32 4, i32 poison, i32 6, i32 7>
-; CHECK-NEXT:    [[BB:%.*]] = shufflevector <8 x half> [[B:%.*]], <8 x half> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-; CHECK-NEXT:    [[BT:%.*]] = shufflevector <8 x half> [[B]], <8 x half> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-; CHECK-NEXT:    [[XB:%.*]] = fadd <4 x half> [[AB]], [[BB]]
-; CHECK-NEXT:    [[XT:%.*]] = fadd <4 x half> [[BT]], [[AT]]
-; CHECK-NEXT:    [[R:%.*]] = shufflevector <4 x half> [[XB]], <4 x half> [[XT]], <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+; CHECK-NEXT:    [[R:%.*]] = fadd <8 x half> [[A:%.*]], [[B:%.*]]
 ; CHECK-NEXT:    ret <8 x half> [[R]]
 ;
   %ab = shufflevector <8 x half> %a, <8 x half> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>


### PR DESCRIPTION
(Almost given up on this one as the fix is more complex than I expected and the motivating issue looks somewhat synthetic, but this class of problems does seem reachable from the front end via intrinsics and cannot be caught by `foldShuffleOfBinops`)

Currently `foldShuffleToIdentity` consider each operand vector of a binop contiguously. This patch tries to recover some profitable patterns by swapping some lanes in the operands of commutative binops.

More precisely, we use the front lane of the operands as anchors. When the two anchors have different source values, we try to swap lanes so that all lanes on at least one side would have the same source values as either anchor. 

e.g.

```
 <a[0] + b[0], b[0] + a[1]> -> <a[0], a[1]> + <b[0], b[0]>
```

When source values are the same, we try to swap so that either side is identical to its anchor (i.e. recover a splat), which is enough to handle the splat + identity on same src value case for the motivating issue. Note splat + identity is the only profitable case as Identity + Identity or splat + splat are degenerate when src value are the same.
e.g.

```
 <a[0] + a[0], a[1] + a[0], a[2] + a[0], a[0] + a[a3]>
 ->  <a[0], a[0], a[0], a[0]> + <a[0], a[1], a[2], a[3]>
```

Note this patch does not try to see through the identities of the source values - I think more cases can be covered if we try to establish the true identity of the lanes by looking through shuffles but i’m not sure it’s worth it.

Fixes #206147