### PR TITLE
[CodeGen] Fix compiler warning about copy in Rematerializer

### DIFF
--- a/llvm/lib/CodeGen/Rematerializer.cpp
+++ b/llvm/lib/CodeGen/Rematerializer.cpp
@@ -326,7 +326,7 @@ void Rematerializer::deleteReg(RegisterIdx RootIdx) {
         shrinkToUses(DepRegIdx);
       }
     }
-    for (const auto [Reg, Mask] : getUnrematableDeps(DeletedRegIdx)) {
+    for (const auto &[Reg, Mask] : getUnrematableDeps(DeletedRegIdx)) {
       if (ShrinkUnrematRegs.insert(Reg).second)
         shrinkToUsesUnremat(Reg);
     }


### PR DESCRIPTION
Fixes the following warning with the recommended suggestion:

```
llvm/lib/CodeGen/Rematerializer.cpp:329:21: warning: loop variable
'[Reg, Mask]' creates a copy from type 'const value_type' (aka 'const
std::pair<llvm::Register, llvm::LaneBitmask>') [-Wrange-loop-construct]
  329 |     for (const auto [Reg, Mask] :
getUnrematableDeps(DeletedRegIdx)) {
      |                     ^
llvm/lib/CodeGen/Rematerializer.cpp:329:10: note: use reference type
'const value_type &' (aka 'const std::pair<llvm::Register,
llvm::LaneBitmask> &') to prevent copying
  329 |     for (const auto [Reg, Mask] :
getUnrematableDeps(DeletedRegIdx)) {
      |          ^~~~~~~~~~~~~~~~~~~~~~~~
      |                     &
```