### PR TITLE
[NFC][lldb] Make skipIfTargetDoesNotSupportThreads a require decorator

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -1247,15 +1247,14 @@ def requireDarwinHost(func):
     return requireHostPlatform(lldbplatform.translate(lldbplatform.darwin_all))(func)
 
 
-def skipIfTargetDoesNotSupportThreads():
+def requireThreadSupport(func):
     """Skip tests that require thread support (e.g. pthreads)."""
     platform = lldbplatformutil.getPlatform()
-    # WASI targets ending in "-threads" (e.g. wasip1-threads) support threads;
-    # other WASI targets (e.g. wasip1, wasip2) do not.
-    no_threads = platform.startswith("wasi") and not platform.endswith("threads")
     return unittest.skipIf(
-        no_threads,
-        "threads are not supported on %s" % platform,
+        # WASI targets ending in "-threads" (e.g. wasip1-threads) support threads;
+        # other WASI targets (e.g. wasip1, wasip2) do not.
+        platform.startswith("wasi") and not platform.endswith("threads"),
+        UnsupportedReason(f"threads are not supported on {platform}"),
     )
 
 

--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -1248,14 +1248,14 @@ def requireDarwinHost(func):
 
 
 def requireThreadSupport(func):
-    """Skip tests that require thread support (e.g. pthreads)."""
+    """Mark the item as requiring thread support (e.g. pthreads) on the target."""
     platform = lldbplatformutil.getPlatform()
     return unittest.skipIf(
         # WASI targets ending in "-threads" (e.g. wasip1-threads) support threads;
         # other WASI targets (e.g. wasip1, wasip2) do not.
         platform.startswith("wasi") and not platform.endswith("threads"),
         UnsupportedReason(f"threads are not supported on {platform}"),
-    )
+    )(func)
 
 
 def skipIfTargetDoesNotSupportSharedLibraries():

--- a/lldb/test/API/api/multiple-debuggers/TestMultipleDebuggers.py
+++ b/lldb/test/API/api/multiple-debuggers/TestMultipleDebuggers.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class TestMultipleSimultaneousDebuggers(TestBase):
     SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True

--- a/lldb/test/API/api/multiple-debuggers/TestMultipleDebuggers.py
+++ b/lldb/test/API/api/multiple-debuggers/TestMultipleDebuggers.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class TestMultipleSimultaneousDebuggers(TestBase):
     SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True

--- a/lldb/test/API/api/multiple-targets/TestMultipleTargets.py
+++ b/lldb/test/API/api/multiple-targets/TestMultipleTargets.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class TestMultipleTargets(TestBase):
     SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True

--- a/lldb/test/API/api/multiple-targets/TestMultipleTargets.py
+++ b/lldb/test/API/api/multiple-targets/TestMultipleTargets.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class TestMultipleTargets(TestBase):
     SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True

--- a/lldb/test/API/api/multithreaded/TestMultithreaded.py
+++ b/lldb/test/API/api/multithreaded/TestMultithreaded.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfNoSBHeaders
 class SBBreakpointCallbackCase(TestBase):
     SHARED_BUILD_TESTCASE = False

--- a/lldb/test/API/api/multithreaded/TestMultithreaded.py
+++ b/lldb/test/API/api/multithreaded/TestMultithreaded.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfNoSBHeaders
 class SBBreakpointCallbackCase(TestBase):
     SHARED_BUILD_TESTCASE = False

--- a/lldb/test/API/commands/expression/no-deadlock/TestExprDoesntBlock.py
+++ b/lldb/test/API/commands/expression/no-deadlock/TestExprDoesntBlock.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class ExprDoesntDeadlockTestCase(TestBase):
     @add_test_categories(["basic_process"])
     def test_with_run_command(self):

--- a/lldb/test/API/commands/expression/no-deadlock/TestExprDoesntBlock.py
+++ b/lldb/test/API/commands/expression/no-deadlock/TestExprDoesntBlock.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class ExprDoesntDeadlockTestCase(TestBase):
     @add_test_categories(["basic_process"])
     def test_with_run_command(self):

--- a/lldb/test/API/commands/gui/expand-threads-tree/TestGuiExpandThreadsTree.py
+++ b/lldb/test/API/commands/gui/expand-threads-tree/TestGuiExpandThreadsTree.py
@@ -10,7 +10,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.lldbpexpect import PExpectTest
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class TestGuiExpandThreadsTree(PExpectTest):
     # PExpect uses many timeouts internally and doesn't play well
     # under ASAN on a loaded machine..

--- a/lldb/test/API/commands/gui/expand-threads-tree/TestGuiExpandThreadsTree.py
+++ b/lldb/test/API/commands/gui/expand-threads-tree/TestGuiExpandThreadsTree.py
@@ -10,7 +10,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.lldbpexpect import PExpectTest
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class TestGuiExpandThreadsTree(PExpectTest):
     # PExpect uses many timeouts internally and doesn't play well
     # under ASAN on a loaded machine..

--- a/lldb/test/API/commands/gui/spawn-threads/TestGuiSpawnThreads.py
+++ b/lldb/test/API/commands/gui/spawn-threads/TestGuiSpawnThreads.py
@@ -11,7 +11,7 @@ from lldbsuite.test.lldbpexpect import PExpectTest
 import sys
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class TestGuiSpawnThreadsTest(PExpectTest):
     # This tests spawns threads, so low resources on the host may
     # lead to the test program being stalled for a long time.

--- a/lldb/test/API/commands/gui/spawn-threads/TestGuiSpawnThreads.py
+++ b/lldb/test/API/commands/gui/spawn-threads/TestGuiSpawnThreads.py
@@ -11,7 +11,7 @@ from lldbsuite.test.lldbpexpect import PExpectTest
 import sys
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class TestGuiSpawnThreadsTest(PExpectTest):
     # This tests spawns threads, so low resources on the host may
     # lead to the test program being stalled for a long time.

--- a/lldb/test/API/commands/process/attach-resume/TestAttachResume.py
+++ b/lldb/test/API/commands/process/attach-resume/TestAttachResume.py
@@ -11,7 +11,7 @@ from lldbsuite.test import lldbutil
 exe_name = "AttachResume"  # Must match Makefile
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class AttachResumeTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/commands/process/attach-resume/TestAttachResume.py
+++ b/lldb/test/API/commands/process/attach-resume/TestAttachResume.py
@@ -11,7 +11,7 @@ from lldbsuite.test import lldbutil
 exe_name = "AttachResume"  # Must match Makefile
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class AttachResumeTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/commands/process/detach-resumes/TestDetachResumes.py
+++ b/lldb/test/API/commands/process/detach-resumes/TestDetachResumes.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class DetachResumesTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/commands/process/detach-resumes/TestDetachResumes.py
+++ b/lldb/test/API/commands/process/detach-resumes/TestDetachResumes.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class DetachResumesTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/commands/register/aarch64_sme_z_registers/za_dynamic_resize/TestZAThreadedDynamic.py
+++ b/lldb/test/API/commands/register/aarch64_sme_z_registers/za_dynamic_resize/TestZAThreadedDynamic.py
@@ -10,7 +10,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class AArch64ZAThreadedTestCase(TestBase):
     def get_supported_vg(self):
         exe = self.getBuildArtifact("a.out")

--- a/lldb/test/API/commands/register/aarch64_sme_z_registers/za_dynamic_resize/TestZAThreadedDynamic.py
+++ b/lldb/test/API/commands/register/aarch64_sme_z_registers/za_dynamic_resize/TestZAThreadedDynamic.py
@@ -10,7 +10,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class AArch64ZAThreadedTestCase(TestBase):
     def get_supported_vg(self):
         exe = self.getBuildArtifact("a.out")

--- a/lldb/test/API/commands/register/aarch64_sve_registers/rw_access_dynamic_resize/TestSVEThreadedDynamic.py
+++ b/lldb/test/API/commands/register/aarch64_sve_registers/rw_access_dynamic_resize/TestSVEThreadedDynamic.py
@@ -15,7 +15,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class Mode(Enum):
     SVE = 0
     SSVE = 1

--- a/lldb/test/API/commands/register/aarch64_sve_registers/rw_access_dynamic_resize/TestSVEThreadedDynamic.py
+++ b/lldb/test/API/commands/register/aarch64_sve_registers/rw_access_dynamic_resize/TestSVEThreadedDynamic.py
@@ -15,7 +15,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class Mode(Enum):
     SVE = 0
     SSVE = 1

--- a/lldb/test/API/commands/thread/backtrace/TestThreadBacktraceRepeat.py
+++ b/lldb/test/API/commands/thread/backtrace/TestThreadBacktraceRepeat.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class TestThreadBacktracePage(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/commands/thread/backtrace/TestThreadBacktraceRepeat.py
+++ b/lldb/test/API/commands/thread/backtrace/TestThreadBacktraceRepeat.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class TestThreadBacktracePage(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/commands/trace/multiple-threads/TestTraceStartStopMultipleThreads.py
+++ b/lldb/test/API/commands/trace/multiple-threads/TestTraceStartStopMultipleThreads.py
@@ -6,7 +6,7 @@ from lldbsuite.test import lldbutil
 from lldbsuite.test.decorators import *
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfNoIntelPT
 class TestTraceStartStopMultipleThreads(TraceIntelPTTestCaseBase):
     @skipIf(oslist=no_match(["linux"]), archs=no_match(["i386", "x86_64"]))

--- a/lldb/test/API/commands/trace/multiple-threads/TestTraceStartStopMultipleThreads.py
+++ b/lldb/test/API/commands/trace/multiple-threads/TestTraceStartStopMultipleThreads.py
@@ -6,7 +6,7 @@ from lldbsuite.test import lldbutil
 from lldbsuite.test.decorators import *
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfNoIntelPT
 class TestTraceStartStopMultipleThreads(TraceIntelPTTestCaseBase):
     @skipIf(oslist=no_match(["linux"]), archs=no_match(["i386", "x86_64"]))

--- a/lldb/test/API/commands/watchpoints/hello_watchlocation/TestWatchLocation.py
+++ b/lldb/test/API/commands/watchpoints/hello_watchlocation/TestWatchLocation.py
@@ -10,7 +10,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class HelloWatchLocationTestCase(TestBase):
     SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True

--- a/lldb/test/API/commands/watchpoints/hello_watchlocation/TestWatchLocation.py
+++ b/lldb/test/API/commands/watchpoints/hello_watchlocation/TestWatchLocation.py
@@ -10,7 +10,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class HelloWatchLocationTestCase(TestBase):
     SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True

--- a/lldb/test/API/commands/watchpoints/multiple_threads/TestWatchpointMultipleThreads.py
+++ b/lldb/test/API/commands/watchpoints/multiple_threads/TestWatchpointMultipleThreads.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class WatchpointForMultipleThreadsTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     main_spec = lldb.SBFileSpec("main.cpp", False)

--- a/lldb/test/API/commands/watchpoints/multiple_threads/TestWatchpointMultipleThreads.py
+++ b/lldb/test/API/commands/watchpoints/multiple_threads/TestWatchpointMultipleThreads.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class WatchpointForMultipleThreadsTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     main_spec = lldb.SBFileSpec("main.cpp", False)

--- a/lldb/test/API/commands/watchpoints/watchpoint_set_command/TestWatchLocationWithWatchSet.py
+++ b/lldb/test/API/commands/watchpoints/watchpoint_set_command/TestWatchLocationWithWatchSet.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class WatchLocationUsingWatchpointSetTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/commands/watchpoints/watchpoint_set_command/TestWatchLocationWithWatchSet.py
+++ b/lldb/test/API/commands/watchpoints/watchpoint_set_command/TestWatchLocationWithWatchSet.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class WatchLocationUsingWatchpointSetTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/functionalities/always-run-threads/TestAlwaysRunThreadNames.py
+++ b/lldb/test/API/functionalities/always-run-threads/TestAlwaysRunThreadNames.py
@@ -4,7 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class AlwaysRunThreadNamesTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/functionalities/always-run-threads/TestAlwaysRunThreadNames.py
+++ b/lldb/test/API/functionalities/always-run-threads/TestAlwaysRunThreadNames.py
@@ -4,7 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class AlwaysRunThreadNamesTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_command_auto_continue/TestBreakpointCommandAutoContinue.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_command_auto_continue/TestBreakpointCommandAutoContinue.py
@@ -11,7 +11,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.lldbpexpect import PExpectTest
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfAsan
 @skipIfEditlineSupportMissing
 class BreakpointCommandAutoContinueTestCase(PExpectTest):

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_command_auto_continue/TestBreakpointCommandAutoContinue.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_command_auto_continue/TestBreakpointCommandAutoContinue.py
@@ -11,7 +11,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.lldbpexpect import PExpectTest
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfAsan
 @skipIfEditlineSupportMissing
 class BreakpointCommandAutoContinueTestCase(PExpectTest):

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_on_lambda_capture/TestBreakOnLambdaCapture.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_on_lambda_capture/TestBreakOnLambdaCapture.py
@@ -10,7 +10,7 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class TestBreakOnLambdaCapture(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_on_lambda_capture/TestBreakOnLambdaCapture.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_on_lambda_capture/TestBreakOnLambdaCapture.py
@@ -10,7 +10,7 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class TestBreakOnLambdaCapture(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/functionalities/breakpoint/hardware_breakpoints/hardware_breakpoint_on_multiple_threads/TestHWBreakMultiThread.py
+++ b/lldb/test/API/functionalities/breakpoint/hardware_breakpoints/hardware_breakpoint_on_multiple_threads/TestHWBreakMultiThread.py
@@ -11,7 +11,7 @@ from lldbsuite.test import lldbutil
 from functionalities.breakpoint.hardware_breakpoints.base import *
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class HardwareBreakpointMultiThreadTestCase(HardwareBreakpointTestBase):
     @skipTestIfFn(HardwareBreakpointTestBase.hw_breakpoints_unsupported)
     def test_hw_break_set_delete_multi_thread_macos(self):

--- a/lldb/test/API/functionalities/breakpoint/hardware_breakpoints/hardware_breakpoint_on_multiple_threads/TestHWBreakMultiThread.py
+++ b/lldb/test/API/functionalities/breakpoint/hardware_breakpoints/hardware_breakpoint_on_multiple_threads/TestHWBreakMultiThread.py
@@ -11,7 +11,7 @@ from lldbsuite.test import lldbutil
 from functionalities.breakpoint.hardware_breakpoints.base import *
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class HardwareBreakpointMultiThreadTestCase(HardwareBreakpointTestBase):
     @skipTestIfFn(HardwareBreakpointTestBase.hw_breakpoints_unsupported)
     def test_hw_break_set_delete_multi_thread_macos(self):

--- a/lldb/test/API/functionalities/breakpoint/two_hits_one_actual/TestTwoHitsOneActual.py
+++ b/lldb/test/API/functionalities/breakpoint/two_hits_one_actual/TestTwoHitsOneActual.py
@@ -11,7 +11,7 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class TestTwoHitsOneActual(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/functionalities/breakpoint/two_hits_one_actual/TestTwoHitsOneActual.py
+++ b/lldb/test/API/functionalities/breakpoint/two_hits_one_actual/TestTwoHitsOneActual.py
@@ -11,7 +11,7 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class TestTwoHitsOneActual(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/functionalities/fork/concurrent_vfork/TestConcurrentVFork.py
+++ b/lldb/test/API/functionalities/fork/concurrent_vfork/TestConcurrentVFork.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class TestConcurrentVFork(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/functionalities/fork/concurrent_vfork/TestConcurrentVFork.py
+++ b/lldb/test/API/functionalities/fork/concurrent_vfork/TestConcurrentVFork.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class TestConcurrentVFork(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/functionalities/plugins/python_os_plugin/stepping_plugin_threads/TestOSPluginStepping.py
+++ b/lldb/test/API/functionalities/plugins/python_os_plugin/stepping_plugin_threads/TestOSPluginStepping.py
@@ -10,7 +10,7 @@ from lldbsuite.test.lldbtest import *
 import lldbsuite.test.lldbutil as lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class TestOSPluginStepping(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/functionalities/plugins/python_os_plugin/stepping_plugin_threads/TestOSPluginStepping.py
+++ b/lldb/test/API/functionalities/plugins/python_os_plugin/stepping_plugin_threads/TestOSPluginStepping.py
@@ -10,7 +10,7 @@ from lldbsuite.test.lldbtest import *
 import lldbsuite.test.lldbutil as lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class TestOSPluginStepping(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump.py
+++ b/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class ProcessSaveCoreMinidumpTestCase(TestBase):
     def verify_core_file(
         self,

--- a/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump.py
+++ b/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class ProcessSaveCoreMinidumpTestCase(TestBase):
     def verify_core_file(
         self,

--- a/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump64b.py
+++ b/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump64b.py
@@ -10,7 +10,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class ProcessSaveCoreMinidump64bTestCase(TestBase):
     def verify_minidump(
         self,

--- a/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump64b.py
+++ b/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump64b.py
@@ -10,7 +10,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class ProcessSaveCoreMinidump64bTestCase(TestBase):
     def verify_minidump(
         self,

--- a/lldb/test/API/functionalities/scripted_process/TestScriptedProcess.py
+++ b/lldb/test/API/functionalities/scripted_process/TestScriptedProcess.py
@@ -13,7 +13,7 @@ from lldbsuite.test import lldbtest
 import dummy_scripted_process
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class ScriptedProcesTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/functionalities/scripted_process/TestScriptedProcess.py
+++ b/lldb/test/API/functionalities/scripted_process/TestScriptedProcess.py
@@ -13,7 +13,7 @@ from lldbsuite.test import lldbtest
 import dummy_scripted_process
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class ScriptedProcesTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/functionalities/single-thread-step/TestSingleThreadStepTimeout.py
+++ b/lldb/test/API/functionalities/single-thread-step/TestSingleThreadStepTimeout.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class SingleThreadStepTimeoutTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/functionalities/single-thread-step/TestSingleThreadStepTimeout.py
+++ b/lldb/test/API/functionalities/single-thread-step/TestSingleThreadStepTimeout.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class SingleThreadStepTimeoutTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/functionalities/thread/break_after_join/TestBreakAfterJoin.py
+++ b/lldb/test/API/functionalities/thread/break_after_join/TestBreakAfterJoin.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class BreakpointAfterJoinTestCase(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/functionalities/thread/break_after_join/TestBreakAfterJoin.py
+++ b/lldb/test/API/functionalities/thread/break_after_join/TestBreakAfterJoin.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class BreakpointAfterJoinTestCase(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentBatchedBreakpointStepOver.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentBatchedBreakpointStepOver.py
@@ -12,7 +12,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentBatchedBreakpointStepOver(ConcurrentEventsBase):
     @skipIf(triple="^mips")

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentBatchedBreakpointStepOver.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentBatchedBreakpointStepOver.py
@@ -12,7 +12,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentBatchedBreakpointStepOver(ConcurrentEventsBase):
     @skipIf(triple="^mips")

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentBreakpointDelayBreakpointOneSignal.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentBreakpointDelayBreakpointOneSignal.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentBreakpointDelayBreakpointOneSignal(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentBreakpointDelayBreakpointOneSignal.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentBreakpointDelayBreakpointOneSignal.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentBreakpointDelayBreakpointOneSignal(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentBreakpointOneDelayBreakpointThreads.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentBreakpointOneDelayBreakpointThreads.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentBreakpointOneDelayBreakpointThreads(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentBreakpointOneDelayBreakpointThreads.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentBreakpointOneDelayBreakpointThreads.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentBreakpointOneDelayBreakpointThreads(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentBreakpointsDelayedBreakpointOneWatchpoint.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentBreakpointsDelayedBreakpointOneWatchpoint.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentBreakpointsDelayedBreakpointOneWatchpoint(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentBreakpointsDelayedBreakpointOneWatchpoint.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentBreakpointsDelayedBreakpointOneWatchpoint.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentBreakpointsDelayedBreakpointOneWatchpoint(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentCrashWithBreak.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentCrashWithBreak.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentCrashWithBreak(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentCrashWithBreak.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentCrashWithBreak.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentCrashWithBreak(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentCrashWithSignal.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentCrashWithSignal.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentCrashWithSignal(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentCrashWithSignal.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentCrashWithSignal.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentCrashWithSignal(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentCrashWithWatchpoint.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentCrashWithWatchpoint.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentCrashWithWatchpoint(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentCrashWithWatchpoint.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentCrashWithWatchpoint.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentCrashWithWatchpoint(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentCrashWithWatchpointBreakpointSignal.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentCrashWithWatchpointBreakpointSignal.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentCrashWithWatchpointBreakpointSignal(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentCrashWithWatchpointBreakpointSignal.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentCrashWithWatchpointBreakpointSignal.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentCrashWithWatchpointBreakpointSignal(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentDelaySignalBreak.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentDelaySignalBreak.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentDelaySignalBreak(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentDelaySignalBreak.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentDelaySignalBreak.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentDelaySignalBreak(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentDelaySignalWatch.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentDelaySignalWatch.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentDelaySignalWatch(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentDelaySignalWatch.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentDelaySignalWatch.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentDelaySignalWatch(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentDelayWatchBreak.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentDelayWatchBreak.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentDelayWatchBreak(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentDelayWatchBreak.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentDelayWatchBreak.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentDelayWatchBreak(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentDelayedCrashWithBreakpointSignal.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentDelayedCrashWithBreakpointSignal.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentDelayedCrashWithBreakpointSignal(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentDelayedCrashWithBreakpointSignal.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentDelayedCrashWithBreakpointSignal.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentDelayedCrashWithBreakpointSignal(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentDelayedCrashWithBreakpointWatchpoint.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentDelayedCrashWithBreakpointWatchpoint.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentDelayedCrashWithBreakpointWatchpoint(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentDelayedCrashWithBreakpointWatchpoint.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentDelayedCrashWithBreakpointWatchpoint.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentDelayedCrashWithBreakpointWatchpoint(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentManyBreakpoints.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentManyBreakpoints.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 @skipIf  # See llvm/llvm-project/#205297
 class ConcurrentManyBreakpoints(ConcurrentEventsBase):

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentManyBreakpoints.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentManyBreakpoints.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 @skipIf  # See llvm/llvm-project/#205297
 class ConcurrentManyBreakpoints(ConcurrentEventsBase):

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentManyCrash.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentManyCrash.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentManyCrash(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentManyCrash.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentManyCrash.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentManyCrash(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentManySignals.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentManySignals.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentManySignals(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentManySignals.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentManySignals.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentManySignals(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentManyWatchpoints.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentManyWatchpoints.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentManyWatchpoints(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentManyWatchpoints.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentManyWatchpoints.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentManyWatchpoints(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentNWatchNBreak.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentNWatchNBreak.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentNWatchNBreak(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentNWatchNBreak.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentNWatchNBreak.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentNWatchNBreak(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentSignalBreak.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentSignalBreak.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentSignalBreak(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentSignalBreak.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentSignalBreak.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentSignalBreak(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentSignalDelayBreak.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentSignalDelayBreak.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentSignalDelayBreak(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentSignalDelayBreak.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentSignalDelayBreak.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentSignalDelayBreak(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentSignalDelayWatch.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentSignalDelayWatch.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentSignalDelayWatch(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentSignalDelayWatch.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentSignalDelayWatch.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentSignalDelayWatch(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentSignalNWatchNBreak.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentSignalNWatchNBreak.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentSignalNWatchNBreak(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentSignalNWatchNBreak.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentSignalNWatchNBreak.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentSignalNWatchNBreak(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentSignalWatch.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentSignalWatch.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentSignalWatch(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentSignalWatch.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentSignalWatch.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentSignalWatch(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentSignalWatchBreak.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentSignalWatchBreak.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentSignalWatchBreak(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentSignalWatchBreak.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentSignalWatchBreak.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentSignalWatchBreak(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoBreakpointThreads.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoBreakpointThreads.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentTwoBreakpointThreads(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoBreakpointThreads.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoBreakpointThreads.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentTwoBreakpointThreads(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoBreakpointsOneDelaySignal.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoBreakpointsOneDelaySignal.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentTwoBreakpointsOneDelaySignal(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoBreakpointsOneDelaySignal.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoBreakpointsOneDelaySignal.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentTwoBreakpointsOneDelaySignal(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoBreakpointsOneSignal.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoBreakpointsOneSignal.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentTwoBreakpointsOneSignal(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoBreakpointsOneSignal.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoBreakpointsOneSignal.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentTwoBreakpointsOneSignal(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoBreakpointsOneWatchpoint.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoBreakpointsOneWatchpoint.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentTwoBreakpointsOneWatchpoint(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoBreakpointsOneWatchpoint.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoBreakpointsOneWatchpoint.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentTwoBreakpointsOneWatchpoint(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoWatchpointThreads.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoWatchpointThreads.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentTwoWatchpointThreads(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoWatchpointThreads.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoWatchpointThreads.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentTwoWatchpointThreads(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoWatchpointsOneBreakpoint.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoWatchpointsOneBreakpoint.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentTwoWatchpointsOneBreakpoint(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoWatchpointsOneBreakpoint.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoWatchpointsOneBreakpoint.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentTwoWatchpointsOneBreakpoint(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoWatchpointsOneDelayBreakpoint.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoWatchpointsOneDelayBreakpoint.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentTwoWatchpointsOneDelayBreakpoint(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoWatchpointsOneDelayBreakpoint.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoWatchpointsOneDelayBreakpoint.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentTwoWatchpointsOneDelayBreakpoint(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoWatchpointsOneSignal.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoWatchpointsOneSignal.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentTwoWatchpointsOneSignal(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoWatchpointsOneSignal.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoWatchpointsOneSignal.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentTwoWatchpointsOneSignal(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentWatchBreak.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentWatchBreak.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentWatchBreak(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentWatchBreak.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentWatchBreak.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentWatchBreak(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentWatchBreakDelay.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentWatchBreakDelay.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentWatchBreakDelay(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentWatchBreakDelay.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentWatchBreakDelay.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentWatchBreakDelay(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentWatchpointDelayWatchpointOneBreakpoint.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentWatchpointDelayWatchpointOneBreakpoint.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentWatchpointDelayWatchpointOneBreakpoint(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentWatchpointDelayWatchpointOneBreakpoint.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentWatchpointDelayWatchpointOneBreakpoint.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentWatchpointDelayWatchpointOneBreakpoint(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentWatchpointWithDelayWatchpointThreads.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentWatchpointWithDelayWatchpointThreads.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfWindows
 class ConcurrentWatchpointWithDelayWatchpointThreads(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentWatchpointWithDelayWatchpointThreads.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentWatchpointWithDelayWatchpointThreads.py
@@ -3,7 +3,7 @@ from lldbsuite.test.concurrent_base import ConcurrentEventsBase
 from lldbsuite.test.lldbtest import TestBase
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfWindows
 class ConcurrentWatchpointWithDelayWatchpointThreads(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.

--- a/lldb/test/API/functionalities/thread/concurrent_events/exit/TestConcurrentThreadExit.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/exit/TestConcurrentThreadExit.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 import lldbsuite.test.lldbutil as lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class ConcurrentThreadExitTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/functionalities/thread/concurrent_events/exit/TestConcurrentThreadExit.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/exit/TestConcurrentThreadExit.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 import lldbsuite.test.lldbutil as lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class ConcurrentThreadExitTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/functionalities/thread/create_after_attach/TestCreateAfterAttach.py
+++ b/lldb/test/API/functionalities/thread/create_after_attach/TestCreateAfterAttach.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class CreateAfterAttachTestCase(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/functionalities/thread/create_after_attach/TestCreateAfterAttach.py
+++ b/lldb/test/API/functionalities/thread/create_after_attach/TestCreateAfterAttach.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class CreateAfterAttachTestCase(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/functionalities/thread/create_during_step/TestCreateDuringStep.py
+++ b/lldb/test/API/functionalities/thread/create_during_step/TestCreateDuringStep.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class CreateDuringStepTestCase(TestBase):
     @expectedFailureAll(
         oslist=["linux"],

--- a/lldb/test/API/functionalities/thread/create_during_step/TestCreateDuringStep.py
+++ b/lldb/test/API/functionalities/thread/create_during_step/TestCreateDuringStep.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class CreateDuringStepTestCase(TestBase):
     @expectedFailureAll(
         oslist=["linux"],

--- a/lldb/test/API/functionalities/thread/exit_during_break/TestExitDuringBreak.py
+++ b/lldb/test/API/functionalities/thread/exit_during_break/TestExitDuringBreak.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class ExitDuringBreakpointTestCase(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/functionalities/thread/exit_during_break/TestExitDuringBreak.py
+++ b/lldb/test/API/functionalities/thread/exit_during_break/TestExitDuringBreak.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class ExitDuringBreakpointTestCase(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/functionalities/thread/exit_during_expression/TestExitDuringExpression.py
+++ b/lldb/test/API/functionalities/thread/exit_during_expression/TestExitDuringExpression.py
@@ -9,7 +9,7 @@ import lldbsuite.test.lldbutil as lldbutil
 from lldbsuite.test.lldbtest import *
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfAsan
 class TestExitDuringExpression(TestBase):
     NO_DEBUG_INFO_TESTCASE = True

--- a/lldb/test/API/functionalities/thread/exit_during_expression/TestExitDuringExpression.py
+++ b/lldb/test/API/functionalities/thread/exit_during_expression/TestExitDuringExpression.py
@@ -9,7 +9,7 @@ import lldbsuite.test.lldbutil as lldbutil
 from lldbsuite.test.lldbtest import *
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfAsan
 class TestExitDuringExpression(TestBase):
     NO_DEBUG_INFO_TESTCASE = True

--- a/lldb/test/API/functionalities/thread/exit_during_step/TestExitDuringStep.py
+++ b/lldb/test/API/functionalities/thread/exit_during_step/TestExitDuringStep.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class ExitDuringStepTestCase(TestBase):
     @skipIfWindows  # This is flakey on Windows: llvm.org/pr38373
     def test(self):

--- a/lldb/test/API/functionalities/thread/exit_during_step/TestExitDuringStep.py
+++ b/lldb/test/API/functionalities/thread/exit_during_step/TestExitDuringStep.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class ExitDuringStepTestCase(TestBase):
     @skipIfWindows  # This is flakey on Windows: llvm.org/pr38373
     def test(self):

--- a/lldb/test/API/functionalities/thread/ignore_suspended/TestIgnoreSuspendedThread.py
+++ b/lldb/test/API/functionalities/thread/ignore_suspended/TestIgnoreSuspendedThread.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 import lldbsuite.test.lldbutil as lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class IgnoreSuspendedThreadTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/functionalities/thread/ignore_suspended/TestIgnoreSuspendedThread.py
+++ b/lldb/test/API/functionalities/thread/ignore_suspended/TestIgnoreSuspendedThread.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 import lldbsuite.test.lldbutil as lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class IgnoreSuspendedThreadTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/functionalities/thread/main_thread_exit/TestMainThreadExit.py
+++ b/lldb/test/API/functionalities/thread/main_thread_exit/TestMainThreadExit.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 import lldbsuite.test.lldbutil as lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class ThreadExitTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/functionalities/thread/main_thread_exit/TestMainThreadExit.py
+++ b/lldb/test/API/functionalities/thread/main_thread_exit/TestMainThreadExit.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 import lldbsuite.test.lldbutil as lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class ThreadExitTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/functionalities/thread/multi_break/TestMultipleBreakpoints.py
+++ b/lldb/test/API/functionalities/thread/multi_break/TestMultipleBreakpoints.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class MultipleBreakpointTestCase(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/functionalities/thread/multi_break/TestMultipleBreakpoints.py
+++ b/lldb/test/API/functionalities/thread/multi_break/TestMultipleBreakpoints.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class MultipleBreakpointTestCase(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/functionalities/thread/num_threads/TestNumThreads.py
+++ b/lldb/test/API/functionalities/thread/num_threads/TestNumThreads.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 import lldbsuite.test.lldbutil as lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class NumberOfThreadsTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/functionalities/thread/num_threads/TestNumThreads.py
+++ b/lldb/test/API/functionalities/thread/num_threads/TestNumThreads.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 import lldbsuite.test.lldbutil as lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class NumberOfThreadsTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/functionalities/thread/state_after_expression/TestStateAfterExpression.py
+++ b/lldb/test/API/functionalities/thread/state_after_expression/TestStateAfterExpression.py
@@ -10,7 +10,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class TestStopReasonAfterExpression(TestBase):
     @skipIfWindows
     @expectedFailureAll(oslist=["freebsd"], bugnumber="llvm.org/pr48415")

--- a/lldb/test/API/functionalities/thread/state_after_expression/TestStateAfterExpression.py
+++ b/lldb/test/API/functionalities/thread/state_after_expression/TestStateAfterExpression.py
@@ -10,7 +10,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class TestStopReasonAfterExpression(TestBase):
     @skipIfWindows
     @expectedFailureAll(oslist=["freebsd"], bugnumber="llvm.org/pr48415")

--- a/lldb/test/API/functionalities/thread/step_out/TestThreadStepOut.py
+++ b/lldb/test/API/functionalities/thread/step_out/TestThreadStepOut.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class ThreadStepOutTestCase(TestBase):
     @skipIfWindows  # This test will hang on windows llvm.org/pr21753
     @expectedFailureAll(oslist=["windows"])

--- a/lldb/test/API/functionalities/thread/step_out/TestThreadStepOut.py
+++ b/lldb/test/API/functionalities/thread/step_out/TestThreadStepOut.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class ThreadStepOutTestCase(TestBase):
     @skipIfWindows  # This test will hang on windows llvm.org/pr21753
     @expectedFailureAll(oslist=["windows"])

--- a/lldb/test/API/functionalities/thread/thread_exit/TestThreadExit.py
+++ b/lldb/test/API/functionalities/thread/thread_exit/TestThreadExit.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 import lldbsuite.test.lldbutil as lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class ThreadExitTestCase(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/functionalities/thread/thread_exit/TestThreadExit.py
+++ b/lldb/test/API/functionalities/thread/thread_exit/TestThreadExit.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 import lldbsuite.test.lldbutil as lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class ThreadExitTestCase(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/functionalities/thread/thread_specific_break/TestThreadSpecificBreakpoint.py
+++ b/lldb/test/API/functionalities/thread/thread_specific_break/TestThreadSpecificBreakpoint.py
@@ -23,7 +23,7 @@ def set_thread_name(test, thread, breakpoint):
     breakpoint.SetThreadName("main-thread")
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class ThreadSpecificBreakTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/functionalities/thread/thread_specific_break/TestThreadSpecificBreakpoint.py
+++ b/lldb/test/API/functionalities/thread/thread_specific_break/TestThreadSpecificBreakpoint.py
@@ -23,7 +23,7 @@ def set_thread_name(test, thread, breakpoint):
     breakpoint.SetThreadName("main-thread")
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class ThreadSpecificBreakTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/functionalities/thread/thread_specific_break_plus_condition/TestThreadSpecificBpPlusCondition.py
+++ b/lldb/test/API/functionalities/thread/thread_specific_break_plus_condition/TestThreadSpecificBpPlusCondition.py
@@ -10,7 +10,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class ThreadSpecificBreakPlusConditionTestCase(TestBase):
     # test frequently times out or hangs
     @skipIfDarwin

--- a/lldb/test/API/functionalities/thread/thread_specific_break_plus_condition/TestThreadSpecificBpPlusCondition.py
+++ b/lldb/test/API/functionalities/thread/thread_specific_break_plus_condition/TestThreadSpecificBpPlusCondition.py
@@ -10,7 +10,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class ThreadSpecificBreakPlusConditionTestCase(TestBase):
     # test frequently times out or hangs
     @skipIfDarwin

--- a/lldb/test/API/lang/c/step_over_no_deadlock/TestStepOverDoesntBlock.py
+++ b/lldb/test/API/lang/c/step_over_no_deadlock/TestStepOverDoesntBlock.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class StepOverDoesntDeadlockTestCase(TestBase):
     def test_step_over(self):
         """Test that when step over steps over a function it lets other threads run."""

--- a/lldb/test/API/lang/c/step_over_no_deadlock/TestStepOverDoesntBlock.py
+++ b/lldb/test/API/lang/c/step_over_no_deadlock/TestStepOverDoesntBlock.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class StepOverDoesntDeadlockTestCase(TestBase):
     def test_step_over(self):
         """Test that when step over steps over a function it lets other threads run."""

--- a/lldb/test/API/lang/c/tls_globals/TestTlsGlobals.py
+++ b/lldb/test/API/lang/c/tls_globals/TestTlsGlobals.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfTargetDoesNotSupportSharedLibraries()
 class TlsGlobalTestCase(TestBase):
     def setUp(self):

--- a/lldb/test/API/lang/c/tls_globals/TestTlsGlobals.py
+++ b/lldb/test/API/lang/c/tls_globals/TestTlsGlobals.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfTargetDoesNotSupportSharedLibraries()
 class TlsGlobalTestCase(TestBase):
     def setUp(self):

--- a/lldb/test/API/linux/thread/create_during_instruction_step/TestCreateDuringInstructionStep.py
+++ b/lldb/test/API/linux/thread/create_during_instruction_step/TestCreateDuringInstructionStep.py
@@ -10,7 +10,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class CreateDuringInstructionStepTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/linux/thread/create_during_instruction_step/TestCreateDuringInstructionStep.py
+++ b/lldb/test/API/linux/thread/create_during_instruction_step/TestCreateDuringInstructionStep.py
@@ -10,7 +10,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class CreateDuringInstructionStepTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/python_api/lldbutil/iter/TestLLDBIterator.py
+++ b/lldb/test/API/python_api/lldbutil/iter/TestLLDBIterator.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class LLDBIteratorTestCase(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/python_api/lldbutil/iter/TestLLDBIterator.py
+++ b/lldb/test/API/python_api/lldbutil/iter/TestLLDBIterator.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class LLDBIteratorTestCase(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/python_api/lldbutil/iter/TestRegistersIterator.py
+++ b/lldb/test/API/python_api/lldbutil/iter/TestRegistersIterator.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class RegistersIteratorTestCase(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/python_api/lldbutil/iter/TestRegistersIterator.py
+++ b/lldb/test/API/python_api/lldbutil/iter/TestRegistersIterator.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class RegistersIteratorTestCase(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/python_api/watchpoint/watchlocation/TestSetWatchlocation.py
+++ b/lldb/test/API/python_api/watchpoint/watchlocation/TestSetWatchlocation.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class SetWatchlocationAPITestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/python_api/watchpoint/watchlocation/TestSetWatchlocation.py
+++ b/lldb/test/API/python_api/watchpoint/watchlocation/TestSetWatchlocation.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class SetWatchlocationAPITestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/python_api/watchpoint/watchlocation/TestTargetWatchAddress.py
+++ b/lldb/test/API/python_api/watchpoint/watchlocation/TestTargetWatchAddress.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class TargetWatchpointCreateByAddressPITestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/python_api/watchpoint/watchlocation/TestTargetWatchAddress.py
+++ b/lldb/test/API/python_api/watchpoint/watchlocation/TestTargetWatchAddress.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class TargetWatchpointCreateByAddressPITestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/tools/lldb-dap/stopped-events/TestDAP_stopped_events.py
+++ b/lldb/test/API/tools/lldb-dap/stopped-events/TestDAP_stopped_events.py
@@ -8,7 +8,7 @@ from lldbsuite.test.decorators import (
     expectedFailureAll,
     expectedFailureNetBSD,
     skipIfLinux,
-    skipIfTargetDoesNotSupportThreads,
+    requireThreadSupport,
     skipIfWindows,
 )
 from lldbsuite.test.lldbtest import line_number
@@ -18,7 +18,7 @@ from lldbsuite.test.tools.lldb_dap.types import LaunchArgs, StoppedEvent, Thread
 
 @skipIfWindows  # This is flakey on Windows: llvm.org/pr24668, llvm.org/pr38373
 @skipIfLinux
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class TestDAP_stopped_events(DAPTestCaseBase):
     """
     Test validates different operations that produce 'stopped' events.

--- a/lldb/test/API/tools/lldb-dap/stopped-events/TestDAP_stopped_events.py
+++ b/lldb/test/API/tools/lldb-dap/stopped-events/TestDAP_stopped_events.py
@@ -7,8 +7,8 @@ from typing import Sequence
 from lldbsuite.test.decorators import (
     expectedFailureAll,
     expectedFailureNetBSD,
-    skipIfLinux,
     requireThreadSupport,
+    skipIfLinux,
     skipIfWindows,
 )
 from lldbsuite.test.lldbtest import line_number

--- a/lldb/test/API/tools/lldb-dap/stopped-events/TestDAP_stopped_events.py
+++ b/lldb/test/API/tools/lldb-dap/stopped-events/TestDAP_stopped_events.py
@@ -18,7 +18,7 @@ from lldbsuite.test.tools.lldb_dap.types import LaunchArgs, StoppedEvent, Thread
 
 @skipIfWindows  # This is flakey on Windows: llvm.org/pr24668, llvm.org/pr38373
 @skipIfLinux
-@requireThreadSupport()
+@requireThreadSupport
 class TestDAP_stopped_events(DAPTestCaseBase):
     """
     Test validates different operations that produce 'stopped' events.

--- a/lldb/test/API/tools/lldb-dap/threads/TestDAP_threads.py
+++ b/lldb/test/API/tools/lldb-dap/threads/TestDAP_threads.py
@@ -2,13 +2,13 @@
 Test lldb-dap threads request
 """
 
-from lldbsuite.test.decorators import skipIfTargetDoesNotSupportThreads
+from lldbsuite.test.decorators import requireThreadSupport
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs, StoppedReason, ThreadsArgs
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class TestDAP_threads(DAPTestCaseBase):
     def test_correct_thread(self):
         """

--- a/lldb/test/API/tools/lldb-dap/threads/TestDAP_threads.py
+++ b/lldb/test/API/tools/lldb-dap/threads/TestDAP_threads.py
@@ -8,7 +8,7 @@ from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs, StoppedReason, ThreadsArgs
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class TestDAP_threads(DAPTestCaseBase):
     def test_correct_thread(self):
         """

--- a/lldb/test/API/tools/lldb-server/TestGdbRemoteThreadsInStopReply.py
+++ b/lldb/test/API/tools/lldb-server/TestGdbRemoteThreadsInStopReply.py
@@ -7,7 +7,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 @skipIfMTE  # MTE security transition shims restrict socket operations.
 class TestGdbRemoteThreadsInStopReply(gdbremote_testcase.GdbRemoteTestCaseBase):
     ENABLE_THREADS_IN_STOP_REPLY_ENTRIES = [

--- a/lldb/test/API/tools/lldb-server/TestGdbRemoteThreadsInStopReply.py
+++ b/lldb/test/API/tools/lldb-server/TestGdbRemoteThreadsInStopReply.py
@@ -7,7 +7,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 @skipIfMTE  # MTE security transition shims restrict socket operations.
 class TestGdbRemoteThreadsInStopReply(gdbremote_testcase.GdbRemoteTestCaseBase):
     ENABLE_THREADS_IN_STOP_REPLY_ENTRIES = [

--- a/lldb/test/API/tools/lldb-server/cached-memory-region-info/TestCachedMemoryRegionInfo.py
+++ b/lldb/test/API/tools/lldb-server/cached-memory-region-info/TestCachedMemoryRegionInfo.py
@@ -9,7 +9,7 @@ from lldbsuite.test import lldbutil
 
 
 @skipIfWindowsAndNoLLDBServer
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class MemoryRegionInfoPacketsCached(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/tools/lldb-server/cached-memory-region-info/TestCachedMemoryRegionInfo.py
+++ b/lldb/test/API/tools/lldb-server/cached-memory-region-info/TestCachedMemoryRegionInfo.py
@@ -9,7 +9,7 @@ from lldbsuite.test import lldbutil
 
 
 @skipIfWindowsAndNoLLDBServer
-@requireThreadSupport()
+@requireThreadSupport
 class MemoryRegionInfoPacketsCached(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/tools/lldb-server/vCont-threads/TestPartialResume.py
+++ b/lldb/test/API/tools/lldb-server/vCont-threads/TestPartialResume.py
@@ -5,7 +5,7 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class TestPartialResume(gdbremote_testcase.GdbRemoteTestCaseBase):
     THREAD_MATCH_RE = re.compile(r"thread ([0-9a-f]+) running")
 

--- a/lldb/test/API/tools/lldb-server/vCont-threads/TestPartialResume.py
+++ b/lldb/test/API/tools/lldb-server/vCont-threads/TestPartialResume.py
@@ -5,7 +5,7 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class TestPartialResume(gdbremote_testcase.GdbRemoteTestCaseBase):
     THREAD_MATCH_RE = re.compile(r"thread ([0-9a-f]+) running")
 

--- a/lldb/test/API/tools/lldb-server/vCont-threads/TestSignal.py
+++ b/lldb/test/API/tools/lldb-server/vCont-threads/TestSignal.py
@@ -6,7 +6,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@requireThreadSupport()
+@requireThreadSupport
 class TestSignal(gdbremote_testcase.GdbRemoteTestCaseBase):
     def start_threads(self, num):
         procs = self.prep_debug_monitor_and_inferior(inferior_args=[str(num)])

--- a/lldb/test/API/tools/lldb-server/vCont-threads/TestSignal.py
+++ b/lldb/test/API/tools/lldb-server/vCont-threads/TestSignal.py
@@ -6,7 +6,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfTargetDoesNotSupportThreads()
+@requireThreadSupport()
 class TestSignal(gdbremote_testcase.GdbRemoteTestCaseBase):
     def start_threads(self, num):
         procs = self.prep_debug_monitor_and_inferior(inferior_args=[str(num)])


### PR DESCRIPTION
Convert `skipIfTargetDoesNotSupportThreads` to `requireThreadSupport` to clearly mark wasi targets as unsupported for tests which use threads.