### PR TITLE
[lldb][AArch64] Fix compilation error in RegisterTypeDetector

### DIFF
--- a/lldb/source/Plugins/Process/Utility/RegisterTypeDetector_arm64.h
+++ b/lldb/source/Plugins/Process/Utility/RegisterTypeDetector_arm64.h
@@ -101,12 +101,7 @@ private:
   bool m_has_detected = false;
 
   template <typename T, typename... Args> const T *MakeType(Args &&...args) {
-    static_assert(std::is_base_of_v<RegisterType, T>);
-
-    auto type = std::make_unique<T>(std::forward<Args>(args)...);
-    const T *type_ptr = type.get();
-    m_detected_types.detected_types.push_back(std::move(type));
-    return type_ptr;
+    return m_detected_types.MakeType<T>(std::forward<Args>(args)...);
   }
 
   // This stores all the types created. There may be > 1 type per register,
@@ -118,8 +113,15 @@ private:
   class DetectedTypesHolder {
     std::vector<std::unique_ptr<RegisterType>> detected_types;
 
-    template <typename T, typename... Args>
-    friend const T *Arm64RegisterTypeDetector::MakeType(Args &&...args);
+  public:
+    template <typename T, typename... Args> const T *MakeType(Args &&...args) {
+      static_assert(std::is_base_of_v<RegisterType, T>);
+
+      auto type = std::make_unique<T>(std::forward<Args>(args)...);
+      const T *type_ptr = type.get();
+      detected_types.push_back(std::move(type));
+      return type_ptr;
+    }
   } m_detected_types;
 };
 


### PR DESCRIPTION
#214515 introduced a compilation failure on Apple Clang 15:

```
FAILED: tools/lldb/source/Plugins/Process/elf-core/CMakeFiles/lldbPluginProcessElfCore.dir/ThreadElfCore.cpp.o
  In file included from …/src/lldb/source/Plugins/Process/elf-core/ThreadElfCore.cpp:35:
  In file included from …/src/lldb/source/Plugins/Process/elf-core/RegisterContextPOSIXCore_arm64.h:14:
  …/src/lldb/source/Plugins/Process/Utility/RegisterTypeDetector_arm64.h:122:64: error: type 'Args &&' of function parameter pack does not contain any unexpanded parameter packs
      friend const T *Arm64RegisterTypeDetector::MakeType(Args &&...args);
                                                          ~~~~~~~^~~~~~~
  …/src/lldb/source/Plugins/Process/Utility/RegisterTypeDetector_arm64.h:122:48: error: friend declaration of 'MakeType' does not match any declaration in 'lldb_private::Arm64RegisterTypeDetector'
      friend const T *Arm64RegisterTypeDetector::MakeType(Args &&...args);
                                                 ^~~~~~~~
  2 errors generated.
```

This PR moves the type creation into `DetectedTypesHolder` and has `MakeType` forward to it, so no `friend` declaration is needed.
