### PR TITLE
[CodeGen] Delete empty sub-ranges after refinement of rematerializations

### DIFF
--- a/llvm/lib/CodeGen/Rematerializer.cpp
+++ b/llvm/lib/CodeGen/Rematerializer.cpp
@@ -844,6 +844,8 @@ void Rematerializer::extendToNewUsers(RegisterIdx RegIdx,
       LI.refineSubRanges(
           LIS.getVNInfoAllocator(), RegMask, [](LiveInterval::SubRange &SR) {},
           *LIS.getSlotIndexes(), TRI);
+      // Refining may have introduced empty sub-ranges, which are illegal.
+      LI.removeEmptySubRanges();
     }
     extendInterval(LI, RegMask, UseIdx);
   }

--- a/llvm/unittests/CodeGen/RematerializerTest.cpp
+++ b/llvm/unittests/CodeGen/RematerializerTest.cpp
@@ -825,12 +825,10 @@ TEST_F(RematerializerTest, SplitSubRegDeadDef) {
       PreRemat);
 }
 
-/// The rematerializer had a bug where rematerializing a register which has uses
-/// of undefined lanes could create empty sub-ranges during live-interval
+/// Uses of undefined lanes may create empty sub-ranges during live-interval
 /// refinement. Empty sub-ranges are illegal and are only allowed to exist
-/// temporarily, so we would hit an assert when extending the live interval of
-/// the rematerialized register. The rematerializer now automatically deletes
-/// empty sub-ranges.
+/// temporarily. The rematerializer now automatically deletes these empty
+/// sub-ranges.
 TEST_F(RematerializerTest, RemoveEmptySubRanges) {
   StringRef MIRBody = R"MIR(
   bb.0:

--- a/llvm/unittests/CodeGen/RematerializerTest.cpp
+++ b/llvm/unittests/CodeGen/RematerializerTest.cpp
@@ -825,6 +825,38 @@ TEST_F(RematerializerTest, SplitSubRegDeadDef) {
       PreRemat);
 }
 
+/// The rematerializer had a bug where rematerializing a register which has uses
+/// of undefined lanes could create empty sub-ranges during live-interval
+/// refinement. Empty sub-ranges are illegal and are only allowed to exist
+/// temporarily, so we would hit an assert when extending the live interval of
+/// the rematerialized register. The rematerializer now automatically deletes
+/// empty sub-ranges.
+TEST_F(RematerializerTest, RemoveEmptySubRanges) {
+  StringRef MIRBody = R"MIR(
+  bb.0:
+    undef %fullUndefUse.sub0:vreg_64 = IMPLICIT_DEF
+    undef %partialUndefUse.sub0_sub1_sub2:vreg_128 = IMPLICIT_DEF
+    
+  bb.1:
+    S_NOP 0, implicit %fullUndefUse.sub1
+    S_NOP 0, implicit %partialUndefUse.sub2_sub3
+    S_ENDPGM 0
+)MIR";
+  rematerializerTest(MIRBody, [](RematerializerWrapper &RW) {
+    // Both registers in bb.0 should be rematerializable.
+    ASSERT_EQ(RW->getNumRegs(), 2U);
+
+    // Rematerialize both registers to bb.1. When the new registers intervals
+    // are created and extended to their users in bb.1, an empty sub-range will
+    // be temporarily created then removed immediately.
+    Rematerializer::DependencyReuseInfo DRI;
+    const unsigned MBB1 = 1;
+    const RegisterIdx FullUndefUse = 0, PartialUndefUse = 1;
+    RW->rematerializeToRegion(FullUndefUse, MBB1, DRI);
+    RW->rematerializeToRegion(PartialUndefUse, MBB1, DRI.clear());
+  });
+}
+
 /// Checks that dead-def elimination successfully deletes all unrematerializable
 /// MIs and rematerializable registers that become dead after shrinking the
 /// interval of an unrematerializable register reveals a dead definition.


### PR DESCRIPTION
Rematerializing registers which have uses of undefined lanes can yield empty sub-ranges during refinement of the rematerialized register's live interval. These are only allowed to temporarily exist and should be removed before extending the interval to new indices.