### PR TITLE
[CIR] Use 32-bit value of alloca number of elements

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1965,7 +1965,7 @@ mlir::LogicalResult CIRToLLVMAllocaOpLowering::matchAndRewrite(
           ? adaptor.getDynAllocSize()
           : mlir::LLVM::ConstantOp::create(
                 rewriter, op.getLoc(),
-                typeConverter->convertType(rewriter.getIndexType()), 1);
+                typeConverter->convertType(rewriter.getI32Type()), 1);
   mlir::Type elementTy =
       convertTypeForMemory(*getTypeConverter(), dataLayout, op.getAllocaType());
   if (!elementTy)

--- a/clang/test/CIR/CodeGen/agg-atomic-cast.c
+++ b/clang/test/CIR/CodeGen/agg-atomic-cast.c
@@ -18,8 +18,8 @@ void non_atomic_to_atomic_cast() {
 // CIR: %[[SA_ADDR:.*]] = cir.alloca "as" {{.*}} init : !cir.ptr<!rec_S>
 // CIR: cir.copy %[[S_ADDR]] align(4) to %[[SA_ADDR]] align(4) : !cir.ptr<!rec_S>
 
-// LLVM:  %[[S_ADDR:.*]] = alloca %struct.S, i64 1, align 4
-// LLVM: %[[SA_ADDR:.*]] = alloca %struct.S, i64 1, align 4
+// LLVM:  %[[S_ADDR:.*]] = alloca %struct.S, align 4
+// LLVM: %[[SA_ADDR:.*]] = alloca %struct.S, align 4
 // LLVM: call void @llvm.memcpy.p0.p0.i64(ptr align 4 %[[SA_ADDR]], ptr align 4 %[[S_ADDR]], i64 4, i1 false)
 
 // OGCG: %[[S_ADDR:.*]] = alloca %struct.S, align 4
@@ -39,8 +39,8 @@ void atomic_to_non_atomic_cast() {
 // CIR: %[[S_PTR:.*]] = cir.cast bitcast %[[S_ADDR]] : !cir.ptr<!rec_S> -> !cir.ptr<!u32i>
 // CIR: cir.store {{.*}} %[[ATOMIC_LOAD]], %[[S_PTR]] : !u32i, !cir.ptr<!u32i>
 
-// LLVM: %[[AS_ADDR:.*]] = alloca %struct.S, i64 1, align 4
-// LLVM: %[[S_ADDR:.*]] = alloca %struct.S, i64 1, align 4
+// LLVM: %[[AS_ADDR:.*]] = alloca %struct.S, align 4
+// LLVM: %[[S_ADDR:.*]] = alloca %struct.S, align 4
 // LLVM: %[[ATOMIC_LOAD:.*]] = load atomic i32, ptr %[[AS_ADDR]] seq_cst, align 4
 // LLVM: store i32 %[[ATOMIC_LOAD]], ptr %[[S_ADDR]], align 4
 

--- a/clang/test/CIR/CodeGen/amdgpu-call-addrspace-cast.cpp
+++ b/clang/test/CIR/CodeGen/amdgpu-call-addrspace-cast.cpp
@@ -33,7 +33,7 @@ void call_with_global_ptr() {
 // CIR:         cir.call @_Z9takes_ptrPi(%[[CAST]])
 
 // LLVM-LABEL: define{{.*}} void @_Z19call_with_local_ptrv()
-// LLVM:         %[[ALLOCA:.*]] = alloca i32, i64 1, align 4, addrspace(5)
+// LLVM:         %[[ALLOCA:.*]] = alloca i32, align 4, addrspace(5)
 // LLVM:         %[[CAST:.*]] = addrspacecast ptr addrspace(5) %[[ALLOCA]] to ptr
 // LLVM:         call void @_Z9takes_ptrPi(ptr noundef %[[CAST]])
 

--- a/clang/test/CIR/CodeGen/amdgpu-stack-alloca-array-decay.cpp
+++ b/clang/test/CIR/CodeGen/amdgpu-stack-alloca-array-decay.cpp
@@ -26,8 +26,8 @@ void foo() {
 // CIR:         cir.store{{.*}} %[[DECAY]], %[[TMP]] : !cir.ptr<!s8i>, !cir.ptr<!cir.ptr<!s8i>>
 
 // LLVM-LABEL: define{{.*}} void @_Z3foov()
-// LLVM:         %[[FMT:.*]] = alloca [6 x i8], i64 1, align 1, addrspace(5)
-// LLVM-NEXT:    %[[TMP:.*]] = alloca ptr, i64 1, align 8, addrspace(5)
+// LLVM:         %[[FMT:.*]] = alloca [6 x i8], align 1, addrspace(5)
+// LLVM-NEXT:    %[[TMP:.*]] = alloca ptr, align 8, addrspace(5)
 // LLVM-DAG:     %[[FMT_CAST:.*]] = addrspacecast ptr addrspace(5) %[[FMT]] to ptr
 // LLVM-DAG:     %[[TMP_CAST:.*]] = addrspacecast ptr addrspace(5) %[[TMP]] to ptr
 // LLVM:         %[[DECAY:.*]] = getelementptr {{.*}} ptr %[[FMT_CAST]],

--- a/clang/test/CIR/CodeGen/array.cpp
+++ b/clang/test/CIR/CodeGen/array.cpp
@@ -175,9 +175,9 @@ void func() {
 // CIR" cir.store %[[TMP]], %[[INIT_2]] : !s32i, !cir.ptr<!s32i>
 
 // LLVM: define{{.*}} void @_Z4funcv(){{.*}}
-// LLVM-NEXT: %[[ARR:.*]] = alloca [10 x i32], i64 1, align 16
-// LLVM-NEXT: %[[INIT:.*]] = alloca i32, i64 1, align 4
-// LLVM-NEXT: %[[INIT_2:.*]] = alloca i32, i64 1, align 4
+// LLVM-NEXT: %[[ARR:.*]] = alloca [10 x i32], align 16
+// LLVM-NEXT: %[[INIT:.*]] = alloca i32, align 4
+// LLVM-NEXT: %[[INIT_2:.*]] = alloca i32, align 4
 // LLVM-NEXT: %[[ELE_PTR:.*]] = getelementptr [10 x i32], ptr %[[ARR]], i32 0, i64 0
 // LLVM-NEXT: %[[TMP_1:.*]] = load i32, ptr %[[ELE_PTR]], align 16
 // LLVM-NEXT: store i32 %[[TMP_1]], ptr %[[INIT]], align 4
@@ -204,7 +204,7 @@ void func2() {
 // CIR: cir.copy %[[CONST]] to %[[ARR2]] : !cir.ptr<!cir.array<!s32i x 2>>
 
 // LLVM: define{{.*}} void @_Z5func2v(){{.*}}
-// LLVM:   %[[ARR:.*]] = alloca [2 x i32], i64 1, align 4
+// LLVM:   %[[ARR:.*]] = alloca [2 x i32], align 4
 // LLVM:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %[[ARR]], ptr align 4 @[[FUNC2_ARR:.*]], i64 8, i1 false)
 
 // OGCG: %[[ARR:.*]] = alloca [2 x i32], align 4
@@ -231,9 +231,9 @@ void func3() {
 // CIR: cir.store{{.*}} %[[ELE_TMP]], %[[INIT]] : !s32i, !cir.ptr<!s32i>
 
 // LLVM: define{{.*}} void @_Z5func3v(){{.*}}
-// LLVM:  %[[ARR:.*]] = alloca [2 x i32], i64 1, align 4
-// LLVM:  %[[IDX:.*]] = alloca i32, i64 1, align 4
-// LLVM:  %[[INIT:.*]] = alloca i32, i64 1, align 4
+// LLVM:  %[[ARR:.*]] = alloca [2 x i32], align 4
+// LLVM:  %[[IDX:.*]] = alloca i32, align 4
+// LLVM:  %[[INIT:.*]] = alloca i32, align 4
 // LLVM:  call void @llvm.memcpy.p0.p0.i64(ptr align 4 %[[ARR]], ptr align 4 @[[FUNC3_ARR:.*]], i64 8, i1 false)
 // LLVM:  store i32 1, ptr %[[IDX]], align 4
 // LLVM:  %[[TMP1:.*]] = load i32, ptr %[[IDX]], align 4
@@ -270,8 +270,8 @@ void func4() {
 // CIR: cir.store{{.*}} %[[TMP]], %[[INIT]] : !s32i, !cir.ptr<!s32i>
 
 // LLVM: define{{.*}} void @_Z5func4v(){{.*}}
-// LLVM:  %[[ARR:.*]] = alloca [2 x [1 x i32]], i64 1, align 4
-// LLVM:  %[[INIT:.*]] = alloca i32, i64 1, align 4
+// LLVM:  %[[ARR:.*]] = alloca [2 x [1 x i32]], align 4
+// LLVM:  %[[INIT:.*]] = alloca i32, align 4
 // LLVM:  call void @llvm.memcpy.p0.p0.i64(ptr align 4 %[[ARR]], ptr align 4 @[[FUNC4_ARR:.*]], i64 8, i1 false)
 // LLVM:  %[[ARR_1:.*]] = getelementptr [2 x [1 x i32]], ptr %[[ARR]], i32 0, i64 1
 // LLVM:  %[[ELE_PTR:.*]] = getelementptr [1 x i32], ptr %[[ARR_1]], i32 0, i64 0
@@ -295,7 +295,7 @@ void func5() {
 // CIR: cir.copy %[[CONST]] to %[[ARR]] : !cir.ptr<!cir.array<!cir.array<!s32i x 1> x 2>>
 
 // LLVM: define{{.*}} void @_Z5func5v(){{.*}}
-// LLVM:   %[[ARR:.*]] = alloca [2 x [1 x i32]], i64 1, align 4
+// LLVM:   %[[ARR:.*]] = alloca [2 x [1 x i32]], align 4
 // LLVM:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %[[ARR]], ptr align 4 @[[FUNC5_ARR:.*]], i64 8, i1 false)
 
 // OGCG: %[[ARR:.*]] = alloca [2 x [1 x i32]], align 4
@@ -319,8 +319,8 @@ void func6() {
 // CIR: cir.store{{.*}} %[[V1]], %[[ELE_PTR]] : !s32i, !cir.ptr<!s32i>
 
 // LLVM: define{{.*}} void @_Z5func6v(){{.*}}
-// LLVM:  %[[VAR:.*]] = alloca i32, i64 1, align 4
-// LLVM:  %[[ARR:.*]] = alloca [2 x i32], i64 1, align 4
+// LLVM:  %[[VAR:.*]] = alloca i32, align 4
+// LLVM:  %[[ARR:.*]] = alloca [2 x i32], align 4
 // LLVM:  store i32 4, ptr %[[VAR]], align 4
 // LLVM:  %[[ELE_0:.*]] = getelementptr i32, ptr %[[ARR]], i32 0
 // LLVM:  %[[TMP:.*]] = load i32, ptr %[[VAR]], align 4
@@ -345,7 +345,7 @@ void func7() {
 // CIR: cir.copy %[[CONST]] to %[[ARR]] : !cir.ptr<!cir.array<!cir.ptr<!s32i> x 1>>
 
 // LLVM: define{{.*}} void @_Z5func7v(){{.*}}
-// LLVM:   %[[ARR:.*]] = alloca [1 x ptr], i64 1, align 8
+// LLVM:   %[[ARR:.*]] = alloca [1 x ptr], align 8
 // LLVM:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %[[ARR]], ptr align 8 @[[FUNC7_ARR:.*]], i64 8, i1 false)
 
 // OGCG: %[[ARR:.*]] = alloca [1 x ptr], align 8
@@ -373,9 +373,9 @@ void func8(int arr[10]) {
 // CIR:  cir.store{{.*}} %[[TMP_4]], %[[INIT_2]] : !s32i, !cir.ptr<!s32i>
 
 // LLVM: define{{.*}} void @_Z5func8Pi(ptr {{.*}} %[[ARG:.*]]){{.*}}
-// LLVM:  %[[ARR:.*]] = alloca ptr, i64 1, align 8
-// LLVM:  %[[INIT:.*]] = alloca i32, i64 1, align 4
-// LLVM:  %[[INIT_2:.*]] = alloca i32, i64 1, align 4
+// LLVM:  %[[ARR:.*]] = alloca ptr, align 8
+// LLVM:  %[[INIT:.*]] = alloca i32, align 4
+// LLVM:  %[[INIT_2:.*]] = alloca i32, align 4
 // LLVM:  store ptr %[[ARG]], ptr %[[ARR]], align 8
 // LLVM:  %[[TMP_1:.*]] = load ptr, ptr %[[ARR]], align 8
 // LLVM:  %[[ELE_0:.*]] = getelementptr i32, ptr %[[TMP_1]], i64 0
@@ -416,8 +416,8 @@ void func9(int arr[10][5]) {
 // CIR:  cir.store{{.*}} %[[TMP_2]], %[[INIT]] : !s32i, !cir.ptr<!s32i>
 
 // LLVM: define{{.*}} void @_Z5func9PA5_i(ptr {{.*}} %[[ARG:.*]]){{.*}}
-// LLVM:  %[[ARR:.*]] = alloca ptr, i64 1, align 8
-// LLVM:  %[[INIT:.*]] = alloca i32, i64 1, align 4
+// LLVM:  %[[ARR:.*]] = alloca ptr, align 8
+// LLVM:  %[[INIT:.*]] = alloca i32, align 4
 // LLVM:  store ptr %[[ARG]], ptr %[[ARR]], align 8
 // LLVM:  %[[TMP_1:.*]] = load ptr, ptr %[[ARR]], align 8
 // LLVM:  %[[ARR_1:.*]] = getelementptr [5 x i32], ptr %[[TMP_1]], i64 1
@@ -449,8 +449,8 @@ void func10(int *a) {
 // CIR: cir.store{{.*}} %[[TMP_2]], %[[INIT]] : !s32i, !cir.ptr<!s32i>
 
 // LLVM: define{{.*}} void @_Z6func10Pi(ptr {{.*}} %[[ARG:.*]]){{.*}} {
-// LLVM:  %[[ARR:.*]] = alloca ptr, i64 1, align 8
-// LLVM:  %[[INIT:.*]] = alloca i32, i64 1, align 4
+// LLVM:  %[[ARR:.*]] = alloca ptr, align 8
+// LLVM:  %[[INIT:.*]] = alloca i32, align 4
 // LLVM:  store ptr %[[ARG]], ptr %[[ARR]], align 8
 // LLVM:  %[[TMP_1:.*]] = load ptr, ptr %[[ARR]], align 8
 // LLVM:  %[[ELE:.*]] = getelementptr i32, ptr %[[TMP_1]], i64 5
@@ -469,7 +469,7 @@ void func11() { int _Complex a[4]; }
 
 // CIR: %[[ARR:.*]] = cir.alloca "a" {{.*}} : !cir.ptr<!cir.array<!cir.complex<!s32i> x 4>>
 
-// LLVM: %[[ARR:.*]] = alloca [4 x { i32, i32 }], i64 1, align 16
+// LLVM: %[[ARR:.*]] = alloca [4 x { i32, i32 }], align 16
 
 // OGCG: %[[ARR:.*]] = alloca [4 x { i32, i32 }], align 16
 
@@ -484,7 +484,7 @@ void func12() {
 
 // CIR: %[[ARR:.*]] = cir.alloca "a" {{.*}} : !cir.ptr<!cir.array<!rec_Point x 4>>
 
-// LLVM: %[[ARR:.*]] = alloca [4 x %struct.Point], i64 1, align 16
+// LLVM: %[[ARR:.*]] = alloca [4 x %struct.Point], align 16
 
 // OGCG: %[[ARR:.*]] = alloca [4 x %struct.Point], align 16
 
@@ -496,7 +496,7 @@ void array_with_complex_elements() {
 // CIR: %[[CONST:.*]] = cir.get_global @[[COMPLEX_ARR]] : !cir.ptr<!cir.array<!cir.complex<!cir.float> x 2>>
 // CIR: cir.copy %[[CONST]] to %[[ARR_ADDR]] : !cir.ptr<!cir.array<!cir.complex<!cir.float> x 2>>
 
-// LLVM: %[[ARR_ADDR:.*]] = alloca [2 x { float, float }], i64 1, align 16
+// LLVM: %[[ARR_ADDR:.*]] = alloca [2 x { float, float }], align 16
 // LLVM: call void @llvm.memcpy.p0.p0.i64(ptr align 4 %[[ARR_ADDR]], ptr align 4 @[[COMPLEX_ARR:.*]], i64 16, i1 false)
 
 // OGCG: %[[ARR_ADDR:.*]] = alloca [2 x { float, float }], align 16

--- a/clang/test/CIR/CodeGen/atomic-thread-fence.c
+++ b/clang/test/CIR/CodeGen/atomic-thread-fence.c
@@ -55,7 +55,7 @@ void modifyWithThreadFence(DataPtr d) {
   // CIR:    cir.return
 
   // LLVM-LABEL: @modifyWithThreadFence
-  // LLVM:    %[[DATA:.*]] = alloca ptr, i64 1, align 8
+  // LLVM:    %[[DATA:.*]] = alloca ptr, align 8
   // LLVM:    fence seq_cst
   // LLVM:    %[[DATA_PTR:.*]] = load ptr, ptr %[[DATA]], align 8
   // LLVM:    %[[DATA_VALUE:.*]] = getelementptr inbounds nuw %struct.Data, ptr %[[DATA_PTR]], i32 0, i32 0
@@ -84,7 +84,7 @@ void modifyWithSignalFence(DataPtr d) {
   // CIR:    cir.return
 
   // LLVM-LABEL: @modifyWithSignalFence
-  // LLVM:    %[[DATA:.*]] = alloca ptr, i64 1, align 8
+  // LLVM:    %[[DATA:.*]] = alloca ptr, align 8
   // LLVM:    fence syncscope("singlethread") seq_cst
   // LLVM:    %[[DATA_PTR:.*]] = load ptr, ptr %[[DATA]], align 8
   // LLVM:    %[[DATA_VALUE:.*]] = getelementptr inbounds nuw %struct.Data, ptr %[[DATA_PTR]], i32 0, i32 0
@@ -115,8 +115,8 @@ void loadWithThreadFence(DataPtr d) {
   // CIR:    cir.return
 
   // LLVM-LABEL: @loadWithThreadFence
-  // LLVM:    %[[DATA:.*]] = alloca ptr, i64 1, align 8
-  // LLVM:    %[[DATA_TEMP:.*]] = alloca ptr, i64 1, align 8
+  // LLVM:    %[[DATA:.*]] = alloca ptr, align 8
+  // LLVM:    %[[DATA_TEMP:.*]] = alloca ptr, align 8
   // LLVM:    fence seq_cst
   // LLVM:    %[[DATA_PTR:.*]] = load ptr, ptr %[[DATA]], align 8
   // LLVM:    %[[DATA_VALUE:.*]] = getelementptr inbounds nuw %struct.Data, ptr %[[DATA_PTR]], i32 0, i32 1
@@ -152,8 +152,8 @@ void loadWithSignalFence(DataPtr d) {
   // CIR:    cir.return
 
   // LLVM-LABEL: @loadWithSignalFence
-  // LLVM:    %[[DATA:.*]] = alloca ptr, i64 1, align 8
-  // LLVM:    %[[DATA_TEMP:.*]] = alloca ptr, i64 1, align 8
+  // LLVM:    %[[DATA:.*]] = alloca ptr, align 8
+  // LLVM:    %[[DATA_TEMP:.*]] = alloca ptr, align 8
   // LLVM:    fence syncscope("singlethread") seq_cst
   // LLVM:    %[[DATA_PTR:.*]] = load ptr, ptr %[[DATA]], align 8
   // LLVM:    %[[DATA_VALUE:.*]] = getelementptr inbounds nuw %struct.Data, ptr %[[DATA_PTR]], i32 0, i32 1

--- a/clang/test/CIR/CodeGen/atomic.c
+++ b/clang/test/CIR/CodeGen/atomic.c
@@ -31,7 +31,7 @@ void f1(void) {
 // CIR:       }
 
 // LLVM-LABEL: @f1
-// LLVM:         %[[SLOT:.+]] = alloca i32, i64 1, align 4
+// LLVM:         %[[SLOT:.+]] = alloca i32, align 4
 // LLVM-NEXT:    store i32 42, ptr %[[SLOT]], align 4
 // LLVM:       }
 
@@ -52,7 +52,7 @@ void f2(void) {
 // CIR:       }
 
 // LLVM-LABEL: @f2
-// LLVM:         %[[SLOT:.+]] = alloca i32, i64 1, align 4
+// LLVM:         %[[SLOT:.+]] = alloca i32, align 4
 // LLVM-NEXT:    store i32 42, ptr %[[SLOT]], align 4
 // LLVM:       }
 
@@ -3768,13 +3768,13 @@ void store_atomic_different_size(S a) {
  // CIR: %[[DATA:.*]] = cir.load {{.*}} %[[ATOMIC_TMP_U32]] : !cir.ptr<!u32i>, !u32i
  // CIR: cir.store {{.*}} syncscope(system) atomic(seq_cst) %[[DATA]], %[[B_VOID_PTR]] : !u32i, !cir.ptr<!u32i>
 
- // LLVM: %[[COERCE:.*]] = alloca i24, i64 1, align 4
+ // LLVM: %[[COERCE:.*]] = alloca i24, align 4
  // LLVM: store i24 %{{.+}}, ptr %[[COERCE]], align 4
  // LLVM: %[[A:.*]] = load %struct.S, ptr %[[COERCE]], align 1
- // LLVM: %[[A_ADDR:.*]] = alloca %struct.S, i64 1, align 1
- // LLVM: %[[B_ADDR:.*]] = alloca { %struct.S, [1 x i8] }, i64 1, align 4
- // LLVM: %[[A_ATOMIC_TMP_ADDR:.*]] = alloca %struct.S, i64 1, align 1
- // LLVM: %[[ATOMIC_TMP_ADDR:.*]] = alloca { %struct.S, [1 x i8] }, i64 1, align 4
+ // LLVM: %[[A_ADDR:.*]] = alloca %struct.S, align 1
+ // LLVM: %[[B_ADDR:.*]] = alloca { %struct.S, [1 x i8] }, align 4
+ // LLVM: %[[A_ATOMIC_TMP_ADDR:.*]] = alloca %struct.S, align 1
+ // LLVM: %[[ATOMIC_TMP_ADDR:.*]] = alloca { %struct.S, [1 x i8] }, align 4
  // LLVM: store %struct.S %[[A]], ptr %[[A_ADDR]], align 1
  // LLVM: call void @llvm.memcpy.p0.p0.i64(ptr align 1 %[[A_ATOMIC_TMP_ADDR]], ptr align 1 %[[A_ADDR]], i64 3, i1 false)
  // LLVM: call void @llvm.memset.p0.i64(ptr align 1 %[[A_ATOMIC_TMP_ADDR]], i8 0, i64 4, i1 false)

--- a/clang/test/CIR/CodeGen/base-to-derived.cpp
+++ b/clang/test/CIR/CodeGen/base-to-derived.cpp
@@ -52,7 +52,7 @@ X *castBtoX(B *b) {
 // CIR:   %[[X:.*]] = cir.derived_class_addr %[[B]] : !cir.ptr<!rec_B> [4] -> !cir.ptr<!rec_X>
 
 // LLVM: define {{.*}} ptr @_Z8castBtoXP1B(ptr {{.*}} %[[ARG0:.*]])
-// LLVM:   %[[B_ADDR:.*]] = alloca ptr, i64 1, align 8
+// LLVM:   %[[B_ADDR:.*]] = alloca ptr, align 8
 // LLVM:   store ptr %[[ARG0]], ptr %[[B_ADDR]], align 8
 // LLVM:   %[[B:.*]] = load ptr, ptr %[[B_ADDR]], align 8
 // LLVM:   %[[IS_NULL:.*]] = icmp eq ptr %[[B]], null

--- a/clang/test/CIR/CodeGen/basic.c
+++ b/clang/test/CIR/CodeGen/basic.c
@@ -45,8 +45,8 @@ int f1(int i) {
 // CIR-NEXT:   cir.return %[[R]] : !s32i
 
 //      LLVM: define{{.*}} i32 @f1(i32 noundef %[[IP:.*]])
-// LLVM-NEXT:   %[[I_PTR:.*]] = alloca i32, i64 1, align 4
-// LLVM-NEXT:   %[[RV:.*]] = alloca i32, i64 1, align 4
+// LLVM-NEXT:   %[[I_PTR:.*]] = alloca i32, align 4
+// LLVM-NEXT:   %[[RV:.*]] = alloca i32, align 4
 // LLVM-NEXT:   store i32 %[[IP]], ptr %[[I_PTR]], align 4
 // LLVM-NEXT:   %[[I_IGNORED:.*]] = load i32, ptr %[[I_PTR]], align 4
 // LLVM-NEXT:   %[[I:.*]] = load i32, ptr %[[I_PTR]], align 4
@@ -72,7 +72,7 @@ int f2(void) { return 3; }
 // CIR-NEXT:   cir.return %[[R]] : !s32i
 
 //      LLVM: define{{.*}} i32 @f2()
-// LLVM-NEXT:   %[[RV:.*]] = alloca i32, i64 1, align 4
+// LLVM-NEXT:   %[[RV:.*]] = alloca i32, align 4
 // LLVM-NEXT:   store i32 3, ptr %[[RV]], align 4
 // LLVM-NEXT:   %[[R:.*]] = load i32, ptr %[[RV]], align 4
 // LLVM-NEXT:   ret i32 %[[R]]
@@ -97,8 +97,8 @@ int f3(void) {
 // CIR-NEXT:   cir.return %[[R]] : !s32i
 
 //      LLVM: define{{.*}} i32 @f3()
-// LLVM-NEXT:   %[[RV:.*]] = alloca i32, i64 1, align 4
-// LLVM-NEXT:   %[[I_PTR:.*]] = alloca i32, i64 1, align 4
+// LLVM-NEXT:   %[[RV:.*]] = alloca i32, align 4
+// LLVM-NEXT:   %[[I_PTR:.*]] = alloca i32, align 4
 // LLVM-NEXT:   store i32 3, ptr %[[I_PTR]], align 4
 // LLVM-NEXT:   %[[I:.*]] = load i32, ptr %[[I_PTR]], align 4
 // LLVM-NEXT:   store i32 %[[I]], ptr %[[RV]], align 4
@@ -180,7 +180,7 @@ int f6(void) {
 // CIR-NEXT:   cir.return %[[R]] : !s32i
 
 // LLVM:      define{{.*}} i32 @f6()
-// LLVM-NEXT:   %[[RV_PTR:.*]] = alloca i32, i64 1, align 4
+// LLVM-NEXT:   %[[RV_PTR:.*]] = alloca i32, align 4
 // LLVM-NEXT:   %[[GV:.*]] = load i32, ptr @gv, align 4
 // LLVM-NEXT:   store i32 %[[GV]], ptr %[[RV_PTR]], align 4
 // LLVM-NEXT:   %[[RV:.*]] = load i32, ptr %[[RV_PTR]], align 4
@@ -206,9 +206,9 @@ int f7(int a, int b, int c) {
 // CIR:  %[[RETVAL:.*]] = cir.add nsw %[[A]], %[[B_PLUS_C]] : !s32i
 
 // LLVM: define{{.*}} i32 @f7
-// LLVM:   %[[A_PTR:.*]] = alloca i32, i64 1, align 4
-// LLVM:   %[[B_PTR:.*]] = alloca i32, i64 1, align 4
-// LLVM:   %[[C_PTR:.*]] = alloca i32, i64 1, align 4
+// LLVM:   %[[A_PTR:.*]] = alloca i32, align 4
+// LLVM:   %[[B_PTR:.*]] = alloca i32, align 4
+// LLVM:   %[[C_PTR:.*]] = alloca i32, align 4
 // LLVM:   %[[A:.*]] = load i32, ptr %[[A_PTR]], align 4
 // LLVM:   %[[B:.*]] = load i32, ptr %[[B_PTR]], align 4
 // LLVM:   %[[C:.*]] = load i32, ptr %[[C_PTR]], align 4
@@ -240,7 +240,7 @@ int f8(int *p) {
 // CIR:    %[[STAR_P:.*]] = cir.load{{.*}} %[[P2]] : !cir.ptr<!s32i>, !s32i
 
 // LLVM: define{{.*}} i32 @f8
-// LLVM:   %[[P_PTR:.*]] = alloca ptr, i64 1, align 8
+// LLVM:   %[[P_PTR:.*]] = alloca ptr, align 8
 // LLVM:   %[[P:.*]] = load ptr, ptr %[[P_PTR]], align 8
 // LLVM:   store i32 2, ptr %[[P]], align 4
 // LLVM:   %[[P2:.*]] = load ptr, ptr %[[P_PTR]], align 8
@@ -275,7 +275,7 @@ void f10(int arg0, ...) {}
 // CIR-NEXT:   cir.return
 
 //      LLVM: define{{.*}} void @f10(i32 noundef %[[ARG0:.*]], ...)
-// LLVM-NEXT:   %[[ARG0_PTR:.*]] = alloca i32, i64 1, align 4
+// LLVM-NEXT:   %[[ARG0_PTR:.*]] = alloca i32, align 4
 // LLVM-NEXT:   store i32 %[[ARG0]], ptr %[[ARG0_PTR]], align 4
 // LLVM-NEXT:   ret void
 

--- a/clang/test/CIR/CodeGen/binop.cpp
+++ b/clang/test/CIR/CodeGen/binop.cpp
@@ -142,9 +142,9 @@ void testFloatingPointBinOps(float a, float b) {
 
 // LLVM-LABEL: define{{.*}} void @_Z23testFloatingPointBinOpsff(
 // LLVM-SAME: float {{.*}} %[[A:.*]], float {{.*}} %[[B:.*]])
-// LLVM:         %[[A_ADDR:.*]] = alloca float, i64 1
-// LLVM:         %[[B_ADDR:.*]] = alloca float, i64 1
-// LLVM:         %[[X_ADDR:.*]] = alloca float, i64 1
+// LLVM:         %[[A_ADDR:.*]] = alloca float, 
+// LLVM:         %[[B_ADDR:.*]] = alloca float, 
+// LLVM:         %[[X_ADDR:.*]] = alloca float, 
 // LLVM:         store float %[[A]], ptr %[[A_ADDR]]
 // LLVM:         store float %[[B]], ptr %[[B_ADDR]]
 
@@ -702,11 +702,11 @@ void b3(int a, int b, int c, int d) {
 
 // LLVM-LABEL: define{{.*}} void @_Z2b3iiii(
 // LLVM-SAME: i32 {{.*}} %[[ARG0:.+]], i32 {{.*}} %[[ARG1:.+]], i32 {{.*}} %[[ARG2:.+]], i32 {{.*}} %[[ARG3:.+]])
-// LLVM: %[[A_ADDR:.*]] = alloca i32, i64 1
-// LLVM: %[[B_ADDR:.*]] = alloca i32, i64 1
-// LLVM: %[[C_ADDR:.*]] = alloca i32, i64 1
-// LLVM: %[[D_ADDR:.*]] = alloca i32, i64 1
-// LLVM: %[[X:.*]] = alloca i8, i64 1
+// LLVM: %[[A_ADDR:.*]] = alloca i32, 
+// LLVM: %[[B_ADDR:.*]] = alloca i32, 
+// LLVM: %[[C_ADDR:.*]] = alloca i32, 
+// LLVM: %[[D_ADDR:.*]] = alloca i32, 
+// LLVM: %[[X:.*]] = alloca i8, 
 // LLVM: store i32 %[[ARG0]], ptr %[[A_ADDR]]
 // LLVM: store i32 %[[ARG1]], ptr %[[B_ADDR]]
 // LLVM: store i32 %[[ARG2]], ptr %[[C_ADDR]]

--- a/clang/test/CIR/CodeGen/bitfield-union.c
+++ b/clang/test/CIR/CodeGen/bitfield-union.c
@@ -53,7 +53,7 @@ void f() {
 // CIR:    cir.return
 
 // LLVM: define dso_local void @f
-// LLVM:   [[ALLOC:%.*]] = alloca %union.demo, i64 1, align 4
+// LLVM:   [[ALLOC:%.*]] = alloca %union.demo, align 4
 // LLVM:   store i32 1, ptr [[ALLOC]], align 4
 // LLVM:   [[BFLOAD:%.*]] = load i8, ptr [[ALLOC]], align 4
 // LLVM:   [[CLEAR:%.*]] = and i8 [[BFLOAD]], -16

--- a/clang/test/CIR/CodeGen/bitfields.c
+++ b/clang/test/CIR/CodeGen/bitfields.c
@@ -101,8 +101,8 @@ int load_field(S* s) {
 // CIR:   [[TMP3:%.*]] = cir.get_bitfield align(4) (#bfi_c, [[TMP2]] : !cir.ptr<!u64i>) -> !s32i
 
 // LLVM: define dso_local i32 @load_field
-// LLVM:   [[TMP0:%.*]] = alloca ptr, i64 1, align 8
-// LLVM:   [[TMP1:%.*]] = alloca i32, i64 1, align 4
+// LLVM:   [[TMP0:%.*]] = alloca ptr, align 8
+// LLVM:   [[TMP1:%.*]] = alloca i32, align 4
 // LLVM:   [[TMP2:%.*]] = load ptr, ptr [[TMP0]], align 8
 // LLVM:   [[TMP3:%.*]] = getelementptr inbounds nuw %struct.S, ptr [[TMP2]], i32 0, i32 0
 // LLVM:   [[TMP4:%.*]] = load i64, ptr [[TMP3]], align 4
@@ -129,7 +129,7 @@ unsigned int load_field_unsigned(A* s) {
 //CIR:   [[TMP3:%.*]] = cir.get_bitfield align(1) (#bfi_more_bits, [[TMP2]] : !cir.ptr<!u16i>) -> !u32i
 
 //LLVM: define dso_local i32 @load_field_unsigned
-//LLVM:   [[TMP0:%.*]] = alloca ptr, i64 1, align 8
+//LLVM:   [[TMP0:%.*]] = alloca ptr, align 8
 //LLVM:   [[TMP1:%.*]] = load ptr, ptr [[TMP0]], align 8
 //LLVM:   [[TMP2:%.*]] = getelementptr inbounds nuw %struct.A, ptr [[TMP1]], i32 0, i32 3
 //LLVM:   [[TMP3:%.*]] = load i16, ptr [[TMP2]], align 1
@@ -157,7 +157,7 @@ void store_field() {
 // CIR:   cir.set_bitfield align(4) (#bfi_e, [[TMP2]] : !cir.ptr<!u16i>, [[TMP1]] : !s32i)
 
 // LLVM: define dso_local void @store_field()
-// LLVM:   [[TMP0:%.*]] = alloca %struct.S, i64 1, align 4
+// LLVM:   [[TMP0:%.*]] = alloca %struct.S, align 4
 // LLVM:   [[TMP1:%.*]] = getelementptr inbounds nuw %struct.S, ptr [[TMP0]], i32 0, i32 1
 // LLVM:   [[TMP2:%.*]] = load i16, ptr [[TMP1]], align 4
 // LLVM:   [[TMP3:%.*]] = and i16 [[TMP2]], -32768
@@ -185,7 +185,7 @@ void store_bitfield_to_bitfield() {
 // CIR:   [[TMP4:%.*]] = cir.set_bitfield align(4) (#bfi_a, [[TMP3]] : !cir.ptr<!u64i>, [[TMP2]] : !s32i) -> !s32i
 
 // LLVM: define dso_local void @store_bitfield_to_bitfield()
-// LLVM:  [[TMP0:%.*]] = alloca %struct.S, i64 1, align 4
+// LLVM:  [[TMP0:%.*]] = alloca %struct.S, align 4
 // LLVM:  [[TMP1:%.*]] = getelementptr inbounds nuw %struct.S, ptr [[TMP0]], i32 0, i32 0
 // LLVM:  [[TMP2:%.*]] = load i64, ptr [[TMP1]], align 4
 // LLVM:  [[TMP3:%.*]] = shl i64 [[TMP2]], 15
@@ -236,7 +236,7 @@ void get_volatile(V* v) {
 // CIR:   [[TMP4:%.*]] = cir.set_bitfield align(4) (#bfi_b, [[TMP3]] : !cir.ptr<!u64i>, [[TMP1]] : !s32i) {is_volatile} -> !s32i
 
 // LLVM: define dso_local void @get_volatile
-// LLVM:   [[TMP0:%.*]] = alloca ptr, i64 1, align 8
+// LLVM:   [[TMP0:%.*]] = alloca ptr, align 8
 // LLVM:   [[TMP1:%.*]] = load ptr, ptr [[TMP0]], align 8
 // LLVM:   [[TMP2:%.*]] = getelementptr inbounds nuw %struct.V, ptr [[TMP1]], i32 0, i32 0
 // LLVM:   [[TMP3:%.*]] = load volatile i64, ptr [[TMP2]], align 4
@@ -263,7 +263,7 @@ void set_volatile(V* v) {
 //CIR:   [[TMP4:%.*]] = cir.set_bitfield align(4) (#bfi_b, [[TMP3]] : !cir.ptr<!u64i>, [[TMP1]] : !s32i) {is_volatile} -> !s32i
 
 // LLVM: define dso_local void @set_volatile
-// LLVM:   [[TMP0:%.*]] = alloca ptr, i64 1, align 8
+// LLVM:   [[TMP0:%.*]] = alloca ptr, align 8
 // LLVM:   [[TMP1:%.*]] = load ptr, ptr [[TMP0]], align 8
 // LLVM:   [[TMP2:%.*]] = getelementptr inbounds nuw %struct.V, ptr [[TMP1]], i32 0, i32 0
 // LLVM:   [[TMP3:%.*]] = load volatile i64, ptr [[TMP2]], align 4

--- a/clang/test/CIR/CodeGen/bitfields.cpp
+++ b/clang/test/CIR/CodeGen/bitfields.cpp
@@ -54,8 +54,8 @@ int load_field(S* s) {
 // CIR:   [[TMP3:%.*]] = cir.get_bitfield align(4) (#bfi_c, [[TMP2]] : !cir.ptr<!u64i>) -> !s32i
 
 // LLVM: define dso_local noundef i32 @_Z10load_fieldP1S
-// LLVM:   [[TMP0:%.*]] = alloca ptr, i64 1, align 8
-// LLVM:   [[TMP1:%.*]] = alloca i32, i64 1, align 4
+// LLVM:   [[TMP0:%.*]] = alloca ptr, align 8
+// LLVM:   [[TMP1:%.*]] = alloca i32, align 4
 // LLVM:   [[TMP2:%.*]] = load ptr, ptr [[TMP0]], align 8
 // LLVM:   [[TMP3:%.*]] = getelementptr inbounds nuw %struct.S, ptr [[TMP2]], i32 0, i32 0
 // LLVM:   [[TMP4:%.*]] = load i64, ptr [[TMP3]], align 4
@@ -82,7 +82,7 @@ void store_field() {
 // CIR:   cir.set_bitfield align(4) (#bfi_a, [[TMP2]] : !cir.ptr<!u64i>, [[TMP1]] : !s32i)
 
 // LLVM: define dso_local void @_Z11store_fieldv
-// LLVM:   [[TMP0:%.*]] = alloca %struct.S, i64 1, align 4
+// LLVM:   [[TMP0:%.*]] = alloca %struct.S, align 4
 // LLVM:   [[TMP1:%.*]] = getelementptr inbounds nuw %struct.S, ptr [[TMP0]], i32 0, i32 0
 // LLVM:   [[TMP2:%.*]] = load i64, ptr [[TMP1]], align 4
 // LLVM:   [[TMP3:%.*]] = and i64 [[TMP2]], -16
@@ -111,7 +111,7 @@ void store_bitfield_to_bitfield(S* s) {
 // CIR:   [[TMP7:%.*]] = cir.set_bitfield align(4) (#bfi_a, [[TMP6]] : !cir.ptr<!u64i>, [[TMP4]] : !s32i) -> !s32i
 
 // LLVM: define dso_local void @_Z26store_bitfield_to_bitfieldP1S
-// LLVM:   [[TMP0:%.*]] = alloca ptr, i64 1, align 8
+// LLVM:   [[TMP0:%.*]] = alloca ptr, align 8
 // LLVM:   [[TMP1:%.*]] = load ptr, ptr [[TMP0]], align 8
 // LLVM:   [[TMP2:%.*]] = getelementptr inbounds nuw %struct.S, ptr [[TMP1]], i32 0, i32 0
 // LLVM:   [[TMP3:%.*]] = load i64, ptr [[TMP2]], align 4

--- a/clang/test/CIR/CodeGen/bitfields_be.c
+++ b/clang/test/CIR/CodeGen/bitfields_be.c
@@ -28,8 +28,8 @@ int init(S* s) {
 //CIR:   [[TMP3:%.*]] = cir.get_bitfield align(4) (#bfi_c, [[TMP2]] : !cir.ptr<!u32i>) -> !s32i
 
 //LLVM: define dso_local i32 @init
-//LLVM:   [[TMP0:%.*]] = alloca ptr, i64 1, align 8
-//LLVM:   [[TMP1:%.*]] = alloca i32, i64 1, align 4
+//LLVM:   [[TMP0:%.*]] = alloca ptr, align 8
+//LLVM:   [[TMP1:%.*]] = alloca i32, align 4
 //LLVM:   [[TMP2:%.*]] = load ptr, ptr [[TMP0]], align 8
 //LLVM:   [[TMP3:%.*]] = getelementptr inbounds nuw %struct.S, ptr [[TMP2]], i32 0, i32 0
 //LLVM:   [[TMP4:%.*]] = load i32, ptr [[TMP3]], align 4

--- a/clang/test/CIR/CodeGen/call-conv-lowering-x86_64-variadic.c
+++ b/clang/test/CIR/CodeGen/call-conv-lowering-x86_64-variadic.c
@@ -78,7 +78,7 @@ int call_big(Pair2 p, Big b) { return vf(p, b); }
 // LLVM-CIR-SAME:    i64 %[[P:[0-9a-zA-Z._]+]], ptr noalias noundef byval(%struct.Big) align 8 %[[B:[0-9a-zA-Z._]+]])
 // LLVM-CIR:       %{{[0-9a-zA-Z._]+}} = load %struct.Big, ptr %[[B]], align 8
 // LLVM-CIR:       %[[PV:[0-9a-zA-Z._]+]] = load i64, ptr %{{[0-9a-zA-Z._]+}}, align 8
-// LLVM-CIR-NEXT:  %[[COPY:[0-9a-zA-Z._]+]] = alloca %struct.Big, i64 1, align 8
+// LLVM-CIR-NEXT:  %[[COPY:[0-9a-zA-Z._]+]] = alloca %struct.Big, align 8
 // LLVM-CIR-NEXT:  store %struct.Big %{{[0-9a-zA-Z._]+}}, ptr %[[COPY]], align 8
 // LLVM-CIR-NEXT:  %{{[0-9a-zA-Z._]+}} = call i32 (i64, ...) @vf(i64 %[[PV]], ptr noalias noundef byval(%struct.Big) align 8 %[[COPY]])
 
@@ -121,7 +121,7 @@ int call_exhausted(Pair2 p, long a, long b, long c, long d, Pair16 q) {
 // LLVM:         %[[CV:[0-9a-zA-Z._]+]] = load i64, ptr %[[CS]], align 8
 // LLVM:         %[[DV:[0-9a-zA-Z._]+]] = load i64, ptr %[[DS]], align 8
 // LLVM-CIR:       %[[PV:[0-9a-zA-Z._]+]] = load i64, ptr %{{[0-9a-zA-Z._]+}}, align 8
-// LLVM-CIR-NEXT:  %[[COPY:[0-9a-zA-Z._]+]] = alloca %struct.Pair16, i64 1, align 8
+// LLVM-CIR-NEXT:  %[[COPY:[0-9a-zA-Z._]+]] = alloca %struct.Pair16, align 8
 // LLVM-CIR-NEXT:  store %struct.Pair16 %{{[0-9a-zA-Z._]+}}, ptr %[[COPY]], align 8
 // LLVM-CIR-NEXT:  %{{[0-9a-zA-Z._]+}} = call i32 (i64, ...) @vf(i64 %[[PV]], i64 noundef %[[AV]], i64 noundef %[[BV]], i64 noundef %[[CV]], i64 noundef %[[DV]], ptr noalias noundef byval(%struct.Pair16) align 8 %[[COPY]])
 // LLVM-OGCG:      %[[PV:[0-9a-zA-Z._]+]] = load i64, ptr %{{[0-9a-zA-Z._]+}}, align 4
@@ -188,7 +188,7 @@ int call_wide_char(Pair2 p, WideChar w) { return vf(p, w); }
 // LLVM-CIR-SAME:    i64 %[[P:[0-9a-zA-Z._]+]], ptr noalias noundef byval(%struct.WideChar) align 16 %[[W:[0-9a-zA-Z._]+]])
 // LLVM-CIR:       %{{[0-9a-zA-Z._]+}} = load %struct.WideChar, ptr %[[W]], align 16
 // LLVM-CIR:       %[[PV:[0-9a-zA-Z._]+]] = load i64, ptr %{{[0-9a-zA-Z._]+}}, align 8
-// LLVM-CIR-NEXT:  %[[COPY:[0-9a-zA-Z._]+]] = alloca %struct.WideChar, i64 1, align 16
+// LLVM-CIR-NEXT:  %[[COPY:[0-9a-zA-Z._]+]] = alloca %struct.WideChar, align 16
 // LLVM-CIR-NEXT:  store %struct.WideChar %{{[0-9a-zA-Z._]+}}, ptr %[[COPY]], align 16
 // LLVM-CIR-NEXT:  %{{[0-9a-zA-Z._]+}} = call i32 (i64, ...) @vf(i64 %[[PV]], ptr noalias noundef byval(%struct.WideChar) align 16 %[[COPY]])
 

--- a/clang/test/CIR/CodeGen/call-conv-lowering-x86_64.c
+++ b/clang/test/CIR/CodeGen/call-conv-lowering-x86_64.c
@@ -148,7 +148,7 @@ void call_union_big_over_aligned(UBigOverAligned u) {
 // CIR: cir.func {{.*}}@call_union_big_over_aligned(%arg0: !cir.ptr<!rec_UBigOverAligned> {{.*}}llvm.align = 32 : i64{{.*}})
 // CIR:   cir.call @take_union_big_over_aligned(%{{.+}}) : (!cir.ptr<!rec_UBigOverAligned> {{.*}}llvm.align = 32 : i64{{.*}}) -> ()
 // LLVM-CIR: define dso_local void @call_union_big_over_aligned(ptr noalias noundef byval(%union.UBigOverAligned) align 32 %{{.+}})
-// LLVM-CIR:   alloca %union.UBigOverAligned, i64 1, align 32
+// LLVM-CIR:   alloca %union.UBigOverAligned, align 32
 // LLVM-CIR:   call void @take_union_big_over_aligned(ptr noalias noundef byval(%union.UBigOverAligned) align 32 %{{.+}})
 // LLVM-OGCG: define dso_local void @call_union_big_over_aligned(ptr noundef byval(%union.UBigOverAligned) align 32 %{{.+}})
 // LLVM-OGCG:   call void @take_union_big_over_aligned(ptr noundef byval(%union.UBigOverAligned) align 32 %{{.+}})

--- a/clang/test/CIR/CodeGen/call.c
+++ b/clang/test/CIR/CodeGen/call.c
@@ -25,7 +25,7 @@ void f2(void) {
 // CIR-NEXT:    cir.call @f1(%[[ARG]]) : (!u64i) -> ()
 
 // LLVM-LABEL: define{{.*}} void @f2(){{.*}}
-// LLVM:         %[[COERCE:.+]] = alloca %struct.S, i64 1, align 8
+// LLVM:         %[[COERCE:.+]] = alloca %struct.S, align 8
 // LLVM:         %[[S:.+]] = load %struct.S, ptr %{{.+}}, align 4
 // LLVM-NEXT:    store %struct.S %[[S]], ptr %[[COERCE]], align 4
 // LLVM-NEXT:    %[[ARG:.+]] = load i64, ptr %[[COERCE]], align 8
@@ -49,7 +49,7 @@ void f4(void) {
 // CIR-NEXT:    cir.store align(4) %[[S]], %{{.+}} : !rec_S, !cir.ptr<!rec_S>
 
 // LLVM-LABEL: define{{.*}} void @f4(){{.*}} {
-// LLVM:         %[[COERCE:.+]] = alloca i64, i64 1, align 8
+// LLVM:         %[[COERCE:.+]] = alloca i64, align 8
 // LLVM:         %[[RET:.+]] = call i64 @f3()
 // LLVM-NEXT:    store i64 %[[RET]], ptr %[[COERCE]], align 8
 // LLVM-NEXT:    %[[S:.+]] = load %struct.S, ptr %[[COERCE]], align 4
@@ -79,7 +79,7 @@ void f7(void) {
 
 // LLVM-LABEL: define{{.*}} void @f7(){{.*}} {
 // LLVM:         %[[B:.+]] = load %struct.Big, ptr %{{.+}}, align 4
-// LLVM-NEXT:    %[[SLOT:.+]] = alloca %struct.Big, i64 1, align 8
+// LLVM-NEXT:    %[[SLOT:.+]] = alloca %struct.Big, align 8
 // LLVM-NEXT:    store %struct.Big %[[B]], ptr %[[SLOT]], align 4
 // TODO(cir): CIR adds noalias to a byval argument where classic does not.
 // LLVM-NEXT:    call void @f5(ptr noalias noundef byval(%struct.Big) align 8 %[[SLOT]])
@@ -97,7 +97,7 @@ void f8(void) {
 // CIR-NEXT:    cir.call @f6(%[[B]]) : (!cir.ptr<!rec_Big> {llvm.align = 4 : i64, llvm.dead_on_unwind, llvm.sret = !rec_Big, llvm.writable}) -> ()
 
 // LLVM-LABEL: define{{.*}} void @f8(){{.*}} {
-// LLVM:        %[[B:.+]] = alloca %struct.Big, i64 1, align 4
+// LLVM:        %[[B:.+]] = alloca %struct.Big, align 4
 // LLVM-NEXT:   call void @f6(ptr dead_on_unwind writable sret(%struct.Big) align 4 %[[B]])
 
 // OGCG-LABEL: define{{.*}} void @f8() #0 {
@@ -124,9 +124,9 @@ void f9(void) {
 // CIR-NEXT:    cir.call @f1(%[[ARGVAL]]) : (!u64i) -> ()
 
 // LLVM-LABEL: define{{.*}} void @f9(){{.*}} {
-// LLVM:         %[[RETSLOT:.+]] = alloca i64, i64 1, align 8
-// LLVM-NEXT:    %[[ARGSLOT:.+]] = alloca %struct.S, i64 1, align 8
-// LLVM-NEXT:    %[[SLOT:.+]] = alloca %struct.S, i64 1, align 4
+// LLVM:         %[[RETSLOT:.+]] = alloca i64, align 8
+// LLVM-NEXT:    %[[ARGSLOT:.+]] = alloca %struct.S, align 8
+// LLVM-NEXT:    %[[SLOT:.+]] = alloca %struct.S, align 4
 // LLVM-NEXT:    %[[RET:.+]] = call i64 @f3()
 // LLVM-NEXT:    store i64 %[[RET]], ptr %[[RETSLOT]], align 8
 // LLVM-NEXT:    %[[RETVAL:.+]] = load %struct.S, ptr %[[RETSLOT]], align 4

--- a/clang/test/CIR/CodeGen/call.cpp
+++ b/clang/test/CIR/CodeGen/call.cpp
@@ -92,7 +92,7 @@ void f11() {
 // CIR-NEXT:    cir.store align(4) %[[#s]], %{{.+}} : !rec_S, !cir.ptr<!rec_S>
 
 // LLVM-LABEL: define{{.*}} void @_Z3f11v(){{.*}}
-// LLVM:         %[[#coerce:]] = alloca i64, i64 1, align 8
+// LLVM:         %[[#coerce:]] = alloca i64, align 8
 // LLVM:         %[[#ret:]] = call i64 @_Z3f10v()
 // LLVM-NEXT:    store i64 %[[#ret]], ptr %[[#coerce]], align 8
 // LLVM-NEXT:    %[[#s:]] = load %struct.S, ptr %[[#coerce]], align 4
@@ -117,8 +117,8 @@ void f12() {
 // CIR-NEXT:    cir.store align(4) %[[#val]], %[[#slot]] : !rec_S, !cir.ptr<!rec_S>
 
 // LLVM-LABEL: define{{.*}} void @_Z3f12v(){{.*}} {
-// LLVM:         %[[#coerce:]] = alloca i64, i64 1, align 8
-// LLVM-NEXT:    %[[#slot:]] = alloca %struct.S, i64 1, align 4
+// LLVM:         %[[#coerce:]] = alloca i64, align 8
+// LLVM-NEXT:    %[[#slot:]] = alloca %struct.S, align 4
 // LLVM-NEXT:    %[[#ret:]] = call i64 @_Z3f10v()
 // LLVM-NEXT:    store i64 %[[#ret]], ptr %[[#coerce]], align 8
 // LLVM-NEXT:    %[[#val:]] = load %struct.S, ptr %[[#coerce]], align 4

--- a/clang/test/CIR/CodeGen/cast.cpp
+++ b/clang/test/CIR/CodeGen/cast.cpp
@@ -96,9 +96,9 @@ bool cptr(void *d) {
 // CIR:   %{{[0-9]+}} = cir.cast ptr_to_bool %[[DVAL]] : !cir.ptr<!void> -> !cir.bool
 
 // LLVM-LABEL: define{{.*}} i1 @_Z4cptrPv(ptr {{.*}} %0)
-// LLVM:         %[[ARG_STORAGE:.*]] = alloca ptr, i64 1
-// LLVM:         %[[RETVAL:.*]] = alloca i8, i64 1
-// LLVM:         %[[X_STORAGE:.*]] = alloca i8, i64 1
+// LLVM:         %[[ARG_STORAGE:.*]] = alloca ptr, 
+// LLVM:         %[[RETVAL:.*]] = alloca i8, 
+// LLVM:         %[[X_STORAGE:.*]] = alloca i8, 
 // LLVM:         store ptr %0, ptr %[[ARG_STORAGE]]
 // LLVM:         %[[LOADED_PTR:.*]] = load ptr, ptr %[[ARG_STORAGE]]
 // LLVM:         %[[NULL_CHECK:.*]] = icmp ne ptr %[[LOADED_PTR]], null
@@ -140,8 +140,8 @@ void f(long int start) {
 // CIR:          cir.cast int_to_ptr %[[MID]] : !u64i -> !cir.ptr<!void>
 
 // LLVM-LABEL: define{{.*}} void @_Z1fl(i64 {{.*}} %0)
-// LLVM: %[[ADDR:.*]] = alloca i64, i64 1, align 8
-// LLVM: %[[PADDR:.*]] = alloca ptr, i64 1, align 8
+// LLVM: %[[ADDR:.*]] = alloca i64, align 8
+// LLVM: %[[PADDR:.*]] = alloca ptr, align 8
 // LLVM: store i64 %0, ptr %[[ADDR]], align 8
 // LLVM: %[[L:.*]] = load i64, ptr %[[ADDR]], align 8
 // LLVM: %[[PTR:.*]] = inttoptr i64 %[[L]] to ptr

--- a/clang/test/CIR/CodeGen/choose-expr.cpp
+++ b/clang/test/CIR/CodeGen/choose-expr.cpp
@@ -13,7 +13,7 @@ void choose_expr() {
 // CIR: %[[CONST_2:.*]] = cir.const #cir.int<2> : !s32i
 // CIR: cir.store {{.*}} %[[CONST_2]], %[[A_ADDR]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM: %[[A_ADDR:.*]] = alloca i32, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca i32, align 4
 // LLVM: store i32 2, ptr %[[A_ADDR]], align 4
 
 // OGCG: %[[A_ADDR:.*]] = alloca i32, align 4
@@ -31,9 +31,9 @@ void choose_expr_non_constant() {
 // CIR: %[[TMP_A:.*]] = cir.load {{.*}} %[[A_ADDR]] : !cir.ptr<!s32i>, !s32i
 // CIR: cir.store {{.*}} %[[TMP_A]], %[[C_ADDR]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM: %[[A_ADDR:.*]] = alloca i32, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca i32, i64 1, align 4
-// LLVM: %[[C_ADDR:.*]] = alloca i32, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca i32, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca i32, align 4
+// LLVM: %[[C_ADDR:.*]] = alloca i32, align 4
 // LLVM: %[[TMP_A:.*]] = load i32, ptr %[[A_ADDR]], align 4
 // LLVM: store i32 %[[TMP_A]], ptr %[[C_ADDR]], align 4
 

--- a/clang/test/CIR/CodeGen/cmp.cpp
+++ b/clang/test/CIR/CodeGen/cmp.cpp
@@ -46,9 +46,9 @@ void c0(int a, int b) {
 // CIR: %{{.*}} = cir.cmp eq %[[A6]], %[[B6]] : !s32i
 
 // LLVM-LABEL: define{{.*}} void @_Z2c0ii(i32 {{.*}} %0, i32 {{.*}} %1){{.*}} {
-// LLVM: %[[PTR1:.*]] = alloca i32, i64 1
-// LLVM: %[[PTR2:.*]] = alloca i32, i64 1
-// LLVM: %[[BOOL_PTR:.*]] = alloca i8, i64 1
+// LLVM: %[[PTR1:.*]] = alloca i32, 
+// LLVM: %[[PTR2:.*]] = alloca i32, 
+// LLVM: %[[BOOL_PTR:.*]] = alloca i8, 
 // LLVM: store i32 %0, ptr %[[PTR1]]
 // LLVM: store i32 %1, ptr %[[PTR2]]
 
@@ -171,9 +171,9 @@ void c0_unsigned(unsigned int a, unsigned int b) {
 // CIR: %{{.*}} = cir.cmp eq %[[UA6]], %[[UB6]] : !u32i
 
 // LLVM-LABEL: define{{.*}} void @_Z11c0_unsignedjj(i32 {{.*}} %0, i32 {{.*}} %1){{.*}} {
-// LLVM: %[[U_PTR1:.*]] = alloca i32, i64 1
-// LLVM: %[[U_PTR2:.*]] = alloca i32, i64 1
-// LLVM: %[[U_BOOL_PTR:.*]] = alloca i8, i64 1
+// LLVM: %[[U_PTR1:.*]] = alloca i32, 
+// LLVM: %[[U_PTR2:.*]] = alloca i32, 
+// LLVM: %[[U_BOOL_PTR:.*]] = alloca i8, 
 // LLVM: store i32 %0, ptr %[[U_PTR1]]
 // LLVM: store i32 %1, ptr %[[U_PTR2]]
 

--- a/clang/test/CIR/CodeGen/complex-atomic-cast.c
+++ b/clang/test/CIR/CodeGen/complex-atomic-cast.c
@@ -15,8 +15,8 @@ void complex_to_atomic_complex() {
 // CIR: %[[TMP_A:.*]] = cir.load {{.*}} %[[A_ADDR]] : !cir.ptr<!cir.complex<!s32i>>, !cir.complex<!s32i>
 // CIR: cir.store {{.*}} %[[TMP_A]], %[[B_ADDR]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 8
+// LLVM: %[[A_ADDR:.*]] = alloca { i32, i32 }, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca { i32, i32 }, align 8
 // LLVM: %[[TMP_A:.*]] = load { i32, i32 }, ptr %[[A_ADDR]], align 4
 // LLVM: store { i32, i32 } %[[TMP_A]], ptr %[[B_ADDR]], align 8
 
@@ -46,9 +46,9 @@ void atomic_complex_to_complex() {
 // CIR: %[[TMP_ATOMIC:.*]] = cir.load {{.*}} %[[ATOMIC_TMP_ADDR]] : !cir.ptr<!cir.complex<!s32i>>, !cir.complex<!s32i>
 // CIR: cir.store {{.*}} %[[TMP_ATOMIC]], %[[B_ADDR]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 8
-// LLVM: %[[B_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
-// LLVM: %[[ATOMIC_TMP_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 8
+// LLVM: %[[A_ADDR:.*]] = alloca { i32, i32 }, align 8
+// LLVM: %[[B_ADDR:.*]] = alloca { i32, i32 }, align 4
+// LLVM: %[[ATOMIC_TMP_ADDR:.*]] = alloca { i32, i32 }, align 8
 // LLVM: %[[TMP_A:.*]] = load atomic i64, ptr %[[A_ADDR]] seq_cst, align 8
 // LLVM: store i64 %[[TMP_A]], ptr %[[ATOMIC_TMP_ADDR]], align 8
 // LLVM: %[[TMP_ATOMIC:.*]] = load { i32, i32 }, ptr %[[ATOMIC_TMP_ADDR]], align 8
@@ -78,7 +78,7 @@ void explicit_cast_scalar_to_atomic_complex() {
 // CIR: %[[COMPLEX:.*]] = cir.complex.create %[[CONST_2F]], %[[CONST_0F]] : !cir.float -> !cir.complex<!cir.float>
 // CIR: cir.store {{.*}} %[[COMPLEX]], %[[A_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 8
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 8
 // LLVM: store { float, float } { float 2.000000e+00, float 0.000000e+00 }, ptr %[[A_ADDR]], align 8
 
 // OGCG: %[[A_ADDR:.*]] = alloca { float, float }, align 8
@@ -111,9 +111,9 @@ void explicit_cast_atomic_complex_to_complex() {
 // CIR: %[[RESULT:.*]] = cir.complex.create %[[ATOMIC_TMP_REAL_I32]], %[[ATOMIC_TMP_IMAG_I32]] : !s32i -> !cir.complex<!s32i>
 // CIR: cir.store {{.*}} %[[RESULT]], %[[B_ADDR]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 8
-// LLVM: %[[B_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
-// LLVM: %[[ATOMIC_TMP_ADDR:.*]] = alloca { float, float }, i64 1, align 8
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 8
+// LLVM: %[[B_ADDR:.*]] = alloca { i32, i32 }, align 4
+// LLVM: %[[ATOMIC_TMP_ADDR:.*]] = alloca { float, float }, align 8
 // LLVM: store { float, float } { float 2.000000e+00, float 0.000000e+00 }, ptr %[[A_ADDR]], align 8
 // LLVM: %[[TMP_A:.*]] = load atomic i64, ptr %[[A_ADDR]] seq_cst, align 8
 // LLVM: store i64 %[[TMP_A]], ptr %[[ATOMIC_TMP_ADDR]], align 8
@@ -170,9 +170,9 @@ void explicit_cast_atomic_complex_to_atomic_complex() {
 // CIR: %[[RESULT:.*]] = cir.complex.create %[[ATOMIC_TMP_REAL_I32]], %[[ATOMIC_TMP_IMAG_I32]] : !s32i -> !cir.complex<!s32i>
 // CIR: cir.store {{.*}} %[[RESULT]], %[[B_ADDR]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 8
-// LLVM: %[[B_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 8
-// LLVM: %[[ATOMIC_TMP_ADDR:.*]] = alloca { float, float }, i64 1, align 8
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 8
+// LLVM: %[[B_ADDR:.*]] = alloca { i32, i32 }, align 8
+// LLVM: %[[ATOMIC_TMP_ADDR:.*]] = alloca { float, float }, align 8
 // LLVM: store { float, float } { float 2.000000e+00, float 0.000000e+00 }, ptr %[[A_ADDR]], align 8
 // LLVM: %[[TMP_A:.*]] = load atomic i64, ptr %[[A_ADDR]] seq_cst, align 8
 // LLVM: store i64 %[[TMP_A]], ptr %[[ATOMIC_TMP_ADDR]], align 8

--- a/clang/test/CIR/CodeGen/complex-builtins.cpp
+++ b/clang/test/CIR/CodeGen/complex-builtins.cpp
@@ -16,9 +16,9 @@ void foo() {
 // CIR: %[[TMP_A:.*]] = cir.load{{.*}} %[[COMPLEX_A]] : !cir.ptr<!cir.complex<!s32i>>, !cir.complex<!s32i>
 // CIR: cir.store{{.*}} %[[TMP_A]], %[[COMPLEX_R]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
 
-// LLVM: %[[COMPLEX_A:.*]] = alloca { i32, i32 }, i64 1, align 4
-// LLVM: %[[COMPLEX_B:.*]] = alloca { i32, i32 }, i64 1, align 4
-// LLVM: %[[COMPLEX_R:.*]] = alloca { i32, i32 }, i64 1, align 4
+// LLVM: %[[COMPLEX_A:.*]] = alloca { i32, i32 }, align 4
+// LLVM: %[[COMPLEX_B:.*]] = alloca { i32, i32 }, align 4
+// LLVM: %[[COMPLEX_R:.*]] = alloca { i32, i32 }, align 4
 // LLVM: %[[TMP_A:.*]] = load { i32, i32 }, ptr %[[COMPLEX_A]], align 4
 // LLVM: store { i32, i32 } %[[TMP_A]], ptr %[[COMPLEX_R]], align 4
 
@@ -45,8 +45,8 @@ void foo2() {
 // CIR: %[[REAL:.*]] = cir.complex.real %[[TMP]] : !cir.complex<!cir.double> -> !cir.double
 // CIR: cir.store{{.*}} %[[REAL]], %[[INIT]] : !cir.double, !cir.ptr<!cir.double>
 
-// LLVM: %[[COMPLEX:.*]] = alloca { double, double }, i64 1, align 8
-// LLVM: %[[INIT:.*]] = alloca double, i64 1, align 8
+// LLVM: %[[COMPLEX:.*]] = alloca { double, double }, align 8
+// LLVM: %[[INIT:.*]] = alloca double, align 8
 // LLVM: %[[TMP:.*]] = load { double, double }, ptr %[[COMPLEX]], align 8
 // LLVM: %[[REAL:.*]] = extractvalue { double, double } %[[TMP]], 0
 // LLVM: store double %[[REAL]], ptr %[[INIT]], align 8
@@ -70,8 +70,8 @@ void foo3() {
 // CIR: %[[IMAG:.*]] = cir.complex.imag %[[TMP]] : !cir.complex<!cir.double> -> !cir.double
 // CIR: cir.store{{.*}} %[[IMAG]], %[[INIT]] : !cir.double, !cir.ptr<!cir.double>
 
-// LLVM: %[[COMPLEX:.*]] = alloca { double, double }, i64 1, align 8
-// LLVM: %[[INIT:.*]] = alloca double, i64 1, align 8
+// LLVM: %[[COMPLEX:.*]] = alloca { double, double }, align 8
+// LLVM: %[[INIT:.*]] = alloca double, align 8
 // LLVM: %[[TMP:.*]] = load { double, double }, ptr %[[COMPLEX]], align 8
 // LLVM: %[[IMAG:.*]] = extractvalue { double, double } %[[TMP]], 1
 // LLVM: store double %[[IMAG]], ptr %[[INIT]], align 8
@@ -98,8 +98,8 @@ void foo4() {
 // CIR: %[[RESULT_VAL:.*]] = cir.complex.create %[[REAL]], %[[IMAG_MINUS]] : !cir.float -> !cir.complex<!cir.float>
 // CIR: cir.store{{.*}} %[[RESULT_VAL]], %[[RESULT]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM: %[[COMPLEX:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM: %[[RESULT:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM: %[[COMPLEX:.*]] = alloca { float, float }, align 4
+// LLVM: %[[RESULT:.*]] = alloca { float, float }, align 4
 // LLVM: %[[TMP:.*]] = load { float, float }, ptr %[[COMPLEX]], align 4
 // LLVM: %[[REAL:.*]] = extractvalue { float, float } %[[TMP]], 0
 // LLVM: %[[IMAG:.*]] = extractvalue { float, float } %[[TMP]], 1

--- a/clang/test/CIR/CodeGen/complex-cast.cpp
+++ b/clang/test/CIR/CodeGen/complex-cast.cpp
@@ -342,8 +342,8 @@ void lvalue_to_rvalue_bitcast() {
 
 // CIR-AFTER: %{{.*}} = cir.cast bitcast %{{.*}} : !cir.ptr<!rec_CX> -> !cir.ptr<!cir.complex<!cir.double>>
 
-// LLVM: %[[PTR_ADDR:.*]] = alloca %struct.CX, i64 1, align 8
-// LLVM: %[[COMPLEX_ADDR:.*]] = alloca { double, double }, i64 1, align 8
+// LLVM: %[[PTR_ADDR:.*]] = alloca %struct.CX, align 8
+// LLVM: %[[COMPLEX_ADDR:.*]] = alloca { double, double }, align 8
 // LLVM: %[[PTR_TO_COMPLEX:.*]] = load { double, double }, ptr %[[PTR_ADDR]], align 8
 // LLVM: store { double, double } %[[PTR_TO_COMPLEX]], ptr %[[COMPLEX_ADDR]], align 8
 
@@ -367,7 +367,7 @@ void lvalue_bitcast() {
 
 // CIR-AFTER: %{{.*}} = cir.cast bitcast %{{.*}} : !cir.ptr<!rec_CX> -> !cir.ptr<!cir.complex<!cir.double>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca %struct.CX, i64 1, align 8
+// LLVM: %[[A_ADDR:.*]] = alloca %struct.CX, align 8
 // LLVM: store { double, double } zeroinitializer, ptr %[[A_ADDR]], align 8
 
 // OGCG: %[[A_ADDR]] = alloca %struct.CX, align 8

--- a/clang/test/CIR/CodeGen/complex-compound-assignment.cpp
+++ b/clang/test/CIR/CodeGen/complex-compound-assignment.cpp
@@ -24,8 +24,8 @@ void foo() {
 // CIR: %[[RESULT:.*]] = cir.complex.add %[[TMP_B]], %[[TMP_A]] : !cir.complex<!cir.float>
 // CIR: cir.store{{.*}} %[[RESULT]], %[[B_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM: %[[TMP_A:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM: %[[TMP_B:.*]] = load { float, float }, ptr %[[B_ADDR]], align 4
 // LLVM: %[[B_REAL:.*]] = extractvalue { float, float } %[[TMP_B]], 0
@@ -68,8 +68,8 @@ void foo1() {
 // CIR: %[[RESULT:.*]] = cir.complex.sub %[[TMP_B]], %[[TMP_A]] : !cir.complex<!cir.float>
 // CIR: cir.store{{.*}} %[[RESULT]], %[[B_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM: %[[TMP_A:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM: %[[TMP_B:.*]] = load { float, float }, ptr %[[B_ADDR]], align 4
 // LLVM: %[[B_REAL:.*]] = extractvalue { float, float } %[[TMP_B]], 0
@@ -112,8 +112,8 @@ void foo2() {
 // CIR: %[[RESULT:.*]] = cir.complex.add %[[TMP_B]], %[[TMP_A]] : !cir.complex<!s32i>
 // CIR: cir.store{{.*}} %[[RESULT]], %[[B_ADDR]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { i32, i32 }, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca { i32, i32 }, align 4
 // LLVM: %[[TMP_A:.*]] = load { i32, i32 }, ptr %[[A_ADDR]], align 4
 // LLVM: %[[TMP_B:.*]] = load { i32, i32 }, ptr %[[B_ADDR]], align 4
 // LLVM: %[[B_REAL:.*]] = extractvalue { i32, i32 } %[[TMP_B]], 0
@@ -171,8 +171,8 @@ void foo3() {
 // CIR: %[[RESULT:.*]] = cir.complex.create %[[ADD_REAL_F16]], %[[ADD_IMAG_F16]] : !cir.f16 -> !cir.complex<!cir.f16>
 // CIR: cir.store{{.*}} %[[RESULT]], %[[B_ADDR]] : !cir.complex<!cir.f16>, !cir.ptr<!cir.complex<!cir.f16>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { half, half }, i64 1, align 2
-// LLVM: %[[B_ADDR:.*]] = alloca { half, half }, i64 1, align 2
+// LLVM: %[[A_ADDR:.*]] = alloca { half, half }, align 2
+// LLVM: %[[B_ADDR:.*]] = alloca { half, half }, align 2
 // LLVM: %[[TMP_A:.*]] = load { half, half }, ptr %[[A_ADDR]], align 2
 // LLVM: %[[A_REAL:.*]] = extractvalue { half, half } %[[TMP_A]], 0
 // LLVM: %[[A_IMAG:.*]] = extractvalue { half, half } %[[TMP_A]], 1
@@ -244,9 +244,9 @@ void foo4() {
 // CXX_CIR: %[[TMP_B:.*]] = cir.load volatile {{.*}} %[[B_ADDR]] : !cir.ptr<!cir.complex<!s32i>>, !cir.complex<!s32i>
 // CXX_CIR: cir.store{{.*}} %[[TMP_B]], %[[C_ADDR]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>
 
-// CXX_LLVM: %[[A_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
-// CXX_LLVM: %[[B_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
-// CXX_LLVM: %[[C_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
+// CXX_LLVM: %[[A_ADDR:.*]] = alloca { i32, i32 }, align 4
+// CXX_LLVM: %[[B_ADDR:.*]] = alloca { i32, i32 }, align 4
+// CXX_LLVM: %[[C_ADDR:.*]] = alloca { i32, i32 }, align 4
 // CXX_LLVM: %[[TMP_A:.*]] = load volatile { i32, i32 }, ptr %[[A_ADDR]], align 4
 // CXX_LLVM: %[[TMP_B:.*]] = load volatile { i32, i32 }, ptr %[[B_ADDR]], align 4
 // CXX_LLVM: %[[B_REAL:.*]] = extractvalue { i32, i32 } %[[TMP_B]], 0
@@ -303,8 +303,8 @@ void foo5() {
 // CIR: %[[RESULT:.*]] = cir.complex.create %[[RESULT_REAL]], %[[A_IMAG]] : !cir.float -> !cir.complex<!cir.float>
 // CIR: cir.store{{.*}} %[[RESULT]], %[[A_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca float, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca float, align 4
 // LLVM: %[[TMP_B:.*]] = load float, ptr %[[B_ADDR]], align 4
 // LLVM: %[[TMP_A:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM: %[[A_REAL:.*]] = extractvalue { float, float } %[[TMP_A]], 0
@@ -350,8 +350,8 @@ void foo6() {
 // CIR: %[[RESULT:.*]] = cir.complex.create %[[RESULT_REAL]], %[[RESULT_IMAG]] : !s32i -> !cir.complex<!s32i>
 // CIR: cir.store{{.*}} %[[RESULT]], %[[B_ADDR]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { i32, i32 }, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca { i32, i32 }, align 4
 // LLVM: %[[TMP_A:.*]] = load { i32, i32 }, ptr %[[A_ADDR]], align 4
 // LLVM: %[[TMP_B:.*]] = load { i32, i32 }, ptr %[[B_ADDR]], align 4
 // LLVM: %[[B_REAL:.*]] = extractvalue { i32, i32 } %[[TMP_B]], 0
@@ -422,8 +422,8 @@ void foo7() {
 // CIR: }) : (!cir.bool) -> !cir.complex<!cir.float>
 // CIR: cir.store{{.*}} %[[RESULT]], %[[B_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM: %[[TMP_A:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM: %[[TMP_B:.*]] = load { float, float }, ptr %[[B_ADDR]], align 4
 // LLVM: %[[B_REAL:.*]] = extractvalue { float, float } %[[TMP_B]], 0
@@ -508,8 +508,8 @@ void foo8() {
 // CIR: %[[RESULT:.*]] = cir.complex.create %[[RESULT_REAL]], %[[RESULT_IMAG]] : !cir.float -> !cir.complex<!cir.float>
 // CIR: cir.store{{.*}} %[[RESULT]], %[[A_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca float, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca float, align 4
 // LLVM: %[[TMP_B:.*]] = load float, ptr %[[B_ADDR]], align 4
 // LLVM: %[[TMP_A:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM: %[[A_REAL:.*]] = extractvalue { float, float } %[[TMP_A]], 0
@@ -551,8 +551,8 @@ void foo10() {
 // CIR: %[[RESULT:.*]] = cir.call @__divsc3(%[[A_REAL]], %[[A_IMAG]], %[[B_REAL]], %[[B_IMAG]]) : (!cir.float, !cir.float, !cir.float, !cir.float) -> !cir.complex<!cir.float>
 // CIR: cir.store{{.*}} %[[RESULT]], %[[A_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM: %[[TMP_B:.*]] = load { float, float }, ptr %[[B_ADDR]], align 4
 // LLVM: %[[TMP_A:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM: %[[A_REAL:.*]] = extractvalue { float, float } %[[TMP_A]], 0
@@ -601,8 +601,8 @@ void foo11() {
 // CIR: %[[RESULT:.*]] = cir.complex.create %[[RESULT_REAL]], %[[RESULT_IMAG]] : !cir.float -> !cir.complex<!cir.float>
 // CIR: cir.store{{.*}} %[[RESULT]], %[[A_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca float, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca float, align 4
 // LLVM: %[[TMP_B:.*]] = load float, ptr %[[B_ADDR]], align 4
 // LLVM: %[[TMP_A:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM: %[[A_REAL:.*]] = extractvalue { float, float } %[[TMP_A]], 0
@@ -657,8 +657,8 @@ void foo12() {
 // CIR: %[[RESULT:.*]] = cir.complex.create %[[RESULT_REAL]], %[[RESULT_IMAG]] : !s32i -> !cir.complex<!s32i>
 // CIR: cir.store{{.*}} %[[RESULT]], %[[A_ADDR]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca i32, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { i32, i32 }, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca i32, align 4
 // LLVM: %[[TMP_B:.*]] = load i32, ptr %[[B_ADDR]], align 4
 // LLVM: %[[TMP_B_COMPLEX:.*]] = insertvalue { i32, i32 } {{.*}}, i32 %[[TMP_B]], 0
 // LLVM: %[[B_COMPLEX:.*]] = insertvalue { i32, i32 } %[[TMP_B_COMPLEX]], i32 0, 1
@@ -744,8 +744,8 @@ void foo13() {
 // CIR: %[[RESULT_COMPLEX_F16:.*]] = cir.complex.create %[[RESULT_REAL_F16]], %[[RESULT_IMAG_F16]] : !cir.f16 -> !cir.complex<!cir.f16>
 // CIR: cir.store{{.*}} %[[RESULT_COMPLEX_F16]], %[[B_ADDR]] : !cir.complex<!cir.f16>, !cir.ptr<!cir.complex<!cir.f16>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { half, half }, i64 1, align 2
-// LLVM: %[[B_ADDR:.*]] = alloca { half, half }, i64 1, align 2
+// LLVM: %[[A_ADDR:.*]] = alloca { half, half }, align 2
+// LLVM: %[[B_ADDR:.*]] = alloca { half, half }, align 2
 // LLVM: %[[TMP_A:.*]] = load { half, half }, ptr %[[A_ADDR]], align 2
 // LLVM: %[[A_REAL:.*]] = extractvalue { half, half } %[[TMP_A]], 0
 // LLVM: %[[A_IMAG:.*]] = extractvalue { half, half } %[[TMP_A]], 1
@@ -839,8 +839,8 @@ void foo9() {
 // C_CIR: %[[RESULT_REAL:.*]] = cir.complex.real %[[RESULT]] : !cir.complex<!cir.float> -> !cir.float
 // C_CIR: cir.store{{.*}} %[[RESULT_REAL]], %[[B_ADDR]] : !cir.float, !cir.ptr<!cir.float>
 
-// C_LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// C_LLVM: %[[B_ADDR:.*]] = alloca float, i64 1, align 4
+// C_LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// C_LLVM: %[[B_ADDR:.*]] = alloca float, align 4
 // C_LLVM: %[[TMP_A:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // C_LLVM: %[[TMP_B:.*]] = load float, ptr %[[B_ADDR]], align 4
 // C_LLVM: %[[A_REAL:.*]] = extractvalue { float, float } %[[TMP_A]], 0
@@ -887,9 +887,9 @@ void compound_assignment_atomic() {
 // CIR: %[[A_PTR:.*]] = cir.cast bitcast %[[A_ADDR]] : !cir.ptr<!cir.complex<!cir.float>> -> !cir.ptr<!u64i>
 // CIR: cir.store {{.*}} atomic(seq_cst) %[[RESULT]], %[[A_PTR]] : !u64i, !cir.ptr<!u64i>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 8
-// LLVM: %[[ATOMIC_TMP1_ADDR:.*]] = alloca { float, float }, i64 1, align 8
-// LLVM: %[[ATOMIC_TMP2_ADDR:.*]] = alloca { float, float }, i64 1, align 8
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 8
+// LLVM: %[[ATOMIC_TMP1_ADDR:.*]] = alloca { float, float }, align 8
+// LLVM: %[[ATOMIC_TMP2_ADDR:.*]] = alloca { float, float }, align 8
 // LLVM: store { float, float } { float 2.000000e+00, float 0.000000e+00 }, ptr %[[A_ADDR]], align 8
 // LLVM: %[[TMP_A:.*]] = load atomic i64, ptr %[[A_ADDR]] seq_cst, align 8
 // LLVM: store i64 %[[TMP_A]], ptr %[[ATOMIC_TMP1_ADDR]], align 8

--- a/clang/test/CIR/CodeGen/complex-mul-div.cpp
+++ b/clang/test/CIR/CodeGen/complex-mul-div.cpp
@@ -64,9 +64,9 @@ void foo() {
 // CIR-AFTER-MUL-COMBINED: %[[RESULT:.*]] = cir.complex.create %[[C_REAL]], %[[C_IMAG]] : !cir.float -> !cir.complex<!cir.float>
 // CIR-AFTER-MUL-COMBINED: cir.store{{.*}} %[[RESULT]], %[[C_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM-MUL-COMBINED: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM-MUL-COMBINED: %[[B_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM-MUL-COMBINED: %[[C_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM-MUL-COMBINED: %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM-MUL-COMBINED: %[[B_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM-MUL-COMBINED: %[[C_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM-MUL-COMBINED: %[[TMP_A:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM-MUL-COMBINED: %[[TMP_B:.*]] = load { float, float }, ptr %[[B_ADDR]], align 4
 // LLVM-MUL-COMBINED: %[[A_REAL:.*]] = extractvalue { float, float } %[[TMP_A]], 0
@@ -135,9 +135,9 @@ void foo() {
 // CIR-AFTER-FULL: }) : (!cir.bool) -> !cir.complex<!cir.float>
 // CIR-AFTER-FULL: cir.store{{.*}} %[[RESULT]], %[[C_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM-FULL: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM-FULL: %[[B_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM-FULL: %[[C_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM-FULL: %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM-FULL: %[[B_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM-FULL: %[[C_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM-FULL: %[[TMP_A:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM-FULL: %[[TMP_B:.*]] = load { float, float }, ptr %[[B_ADDR]], align 4
 // LLVM-FULL: %[[A_REAL:.*]] = extractvalue { float, float } %[[TMP_A]], 0
@@ -238,9 +238,9 @@ void foo1() {
 // CIR-AFTER-INT: %[[RESULT:.*]] = cir.complex.create %[[C_REAL]], %[[C_IMAG]] : !s32i -> !cir.complex<!s32i>
 // CIR-AFTER-INT: cir.store{{.*}} %[[RESULT]], %[[C_ADDR]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
 
-// LLVM-INT: %[[A_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
-// LLVM-INT: %[[B_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
-// LLVM-INT: %[[C_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
+// LLVM-INT: %[[A_ADDR:.*]] = alloca { i32, i32 }, align 4
+// LLVM-INT: %[[B_ADDR:.*]] = alloca { i32, i32 }, align 4
+// LLVM-INT: %[[C_ADDR:.*]] = alloca { i32, i32 }, align 4
 // LLVM-INT: %[[TMP_A:.*]] = load { i32, i32 }, ptr %[[A_ADDR]], align 4
 // LLVM-INT: %[[TMP_B:.*]] = load { i32, i32 }, ptr %[[B_ADDR]], align 4
 // LLVM-INT: %[[A_REAL:.*]] = extractvalue { i32, i32 } %[[TMP_A]], 0
@@ -297,9 +297,9 @@ void foo2() {
 // CIR-COMBINED: %[[RESULT:.*]] = cir.complex.create %[[RESULT_REAL]], %[[RESULT_IMAG]] : !cir.float -> !cir.complex<!cir.float>
 // CIR-COMBINED: cir.store{{.*}} %[[RESULT]], %[[C_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM-COMBINED: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM-COMBINED: %[[B_ADDR:.*]] = alloca float, i64 1, align 4
-// LLVM-COMBINED: %[[C_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM-COMBINED: %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM-COMBINED: %[[B_ADDR:.*]] = alloca float, align 4
+// LLVM-COMBINED: %[[C_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM-COMBINED: %[[TMP_A:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM-COMBINED: %[[TMP_B:.*]] = load float, ptr %[[B_ADDR]], align 4
 // LLVM-COMBINED: %[[A_REAL:.*]] = extractvalue { float, float } %[[TMP_A]], 0
@@ -356,9 +356,9 @@ void foo3() {
 // CIR-AFTER-BASIC: %[[RESULT:.*]] = cir.complex.create %[[RESULT_REAL]], %[[RESULT_IMAG]] : !cir.float -> !cir.complex<!cir.float>
 // CIR-AFTER-BASIC: cir.store{{.*}} %[[RESULT]], %[[C_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM-BASIC: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM-BASIC: %[[B_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM-BASIC: %[[C_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM-BASIC: %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM-BASIC: %[[B_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM-BASIC: %[[C_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM-BASIC: %[[TMP_A:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM-BASIC: %[[TMP_B:.*]] = load { float, float }, ptr %[[B_ADDR]], align 4
 // LLVM-BASIC: %[[A_REAL:.*]] = extractvalue { float, float } %[[TMP_A]], 0
@@ -448,9 +448,9 @@ void foo3() {
 // CIR-AFTER-IMPROVED: }) : (!cir.bool) -> !cir.complex<!cir.float>
 // CIR-AFTER-IMPROVED: cir.store{{.*}} %[[RESULT]], %[[C_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM-IMPROVED: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM-IMPROVED: %[[B_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM-IMPROVED: %[[C_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM-IMPROVED: %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM-IMPROVED: %[[B_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM-IMPROVED: %[[C_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM-IMPROVED: %[[TMP_A:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM-IMPROVED: %[[TMP_B:.*]] = load { float, float }, ptr %[[B_ADDR]], align 4
 // LLVM-IMPROVED: %[[A_REAL:.*]] = extractvalue { float, float } %[[TMP_A]], 0
@@ -572,9 +572,9 @@ void foo3() {
 // CIR-AFTER-PROMOTED: %[[RESULT_F32:.*]] = cir.complex.create %[[RESULT_REAL_F32]], %[[RESULT_IMAG_F32]] : !cir.float -> !cir.complex<!cir.float>
 // CIR-AFTER-PROMOTED: cir.store{{.*}} %[[RESULT_F32]], %[[C_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM-PROMOTED: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM-PROMOTED: %[[B_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM-PROMOTED: %[[C_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM-PROMOTED: %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM-PROMOTED: %[[B_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM-PROMOTED: %[[C_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM-PROMOTED: %[[TMP_A:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM-PROMOTED: %[[TMP_B:.*]] = load { float, float }, ptr %[[B_ADDR]], align 4
 // LLVM-PROMOTED: %[[A_REAL:.*]] = extractvalue { float, float } %[[TMP_A]], 0
@@ -651,9 +651,9 @@ void foo3() {
 // CIR-AFTER-FULL: %[[RESULT:.*]] = cir.call @__divsc3(%[[A_REAL]], %[[A_IMAG]], %[[B_REAL]], %[[B_IMAG]]) : (!cir.float, !cir.float, !cir.float, !cir.float) -> !cir.complex<!cir.float>
 // CIR-AFTER-FULL: cir.store{{.*}} %[[RESULT]], %[[C_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM-FULL: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM-FULL: %[[B_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM-FULL: %[[C_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM-FULL: %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM-FULL: %[[B_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM-FULL: %[[C_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM-FULL: %[[TMP_A:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM-FULL: %[[TMP_B:.*]] = load { float, float }, ptr %[[B_ADDR]], align 4
 // LLVM-FULL: %[[A_REAL:.*]] = extractvalue { float, float } %[[TMP_A]], 0
@@ -723,9 +723,9 @@ void foo4() {
 // CIR-COMBINED: %[[RESULT:.*]] = cir.complex.create %[[RESULT_REAL]], %[[RESULT_IMAG]] : !s32i -> !cir.complex<!s32i>
 // CIR-COMBINED: cir.store{{.*}} %[[RESULT]], %[[C_ADDR]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
 
-// LLVM-COMBINED: %[[A_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
-// LLVM-COMBINED: %[[B_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
-// LLVM-COMBINED: %[[C_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
+// LLVM-COMBINED: %[[A_ADDR:.*]] = alloca { i32, i32 }, align 4
+// LLVM-COMBINED: %[[B_ADDR:.*]] = alloca { i32, i32 }, align 4
+// LLVM-COMBINED: %[[C_ADDR:.*]] = alloca { i32, i32 }, align 4
 // LLVM-COMBINED: %[[TMP_A:.*]] = load { i32, i32 }, ptr %[[A_ADDR]], align 4
 // LLVM-COMBINED: %[[TMP_B:.*]] = load { i32, i32 }, ptr %[[B_ADDR]], align 4
 // LLVM-COMBINED: %[[A_REAL:.*]] = extractvalue { i32, i32 } %[[TMP_A]], 0
@@ -792,9 +792,9 @@ void foo5() {
 // CIR-COMBINED: %[[RESULT:.*]] = cir.complex.create %[[RESULT_REAL]], %[[RESULT_IMAG]] : !cir.float -> !cir.complex<!cir.float>
 // CIR-COMBINED: cir.store{{.*}} %[[RESULT]], %[[C_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM-COMBINED: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM-COMBINED: %[[B_ADDR:.*]] = alloca float, i64 1, align 4
-// LLVM-COMBINED: %[[C_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM-COMBINED: %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM-COMBINED: %[[B_ADDR:.*]] = alloca float, align 4
+// LLVM-COMBINED: %[[C_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM-COMBINED: %[[TMP_A:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM-COMBINED: %[[TMP_B:.*]] = load float, ptr %[[B_ADDR]], align 4
 // LLVM-COMBINED: %[[A_REAL:.*]] = extractvalue { float, float } %[[TMP_A]], 0
@@ -853,9 +853,9 @@ void foo6() {
 // CIR-AFTER-BASIC: %[[RESULT:.*]] = cir.complex.create %[[RESULT_REAL]], %[[RESULT_IMAG]] : !cir.float -> !cir.complex<!cir.float>
 // CIR-AFTER-BASIC: cir.store{{.*}} %[[RESULT]], %[[C_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM-BASIC: %[[A_ADDR:.*]] = alloca float, i64 1, align 4
-// LLVM-BASIC: %[[B_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM-BASIC: %[[C_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM-BASIC: %[[A_ADDR:.*]] = alloca float, align 4
+// LLVM-BASIC: %[[B_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM-BASIC: %[[C_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM-BASIC: %[[TMP_A:.*]] = load float, ptr %[[A_ADDR]], align 4
 // LLVM-BASIC: %[[TMP_B:.*]] = load { float, float }, ptr %[[B_ADDR]], align 4
 // LLVM-BASIC: %[[TMP_COMPELX_A:.*]] = insertvalue { float, float } undef, float %[[TMP_A]], 0
@@ -944,9 +944,9 @@ void foo6() {
 // CIR-AFTER-IMPROVED: }) : (!cir.bool) -> !cir.complex<!cir.float>
 // CIR-AFTER-IMPROVED: cir.store{{.*}} %[[RESULT]], %[[C_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM-IMPROVED: %[[A_ADDR:.*]] = alloca float, i64 1, align 4
-// LLVM-IMPROVED: %[[B_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM-IMPROVED: %[[C_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM-IMPROVED: %[[A_ADDR:.*]] = alloca float, align 4
+// LLVM-IMPROVED: %[[B_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM-IMPROVED: %[[C_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM-IMPROVED: %[[TMP_A:.*]] = load float, ptr %[[A_ADDR]], align 4
 // LLVM-IMPROVED: %[[TMP_B:.*]] = load { float, float }, ptr %[[B_ADDR]], align 4
 // LLVM-IMPROVED: %[[TMP_COMPLEX_A:.*]] = insertvalue { float, float } {{.*}}, float %[[TMP_A]], 0
@@ -1067,9 +1067,9 @@ void foo6() {
 // CIR-AFTER-PROMOTED: %[[RESULT_F32:.*]] = cir.complex.create %[[RESULT_REAL_F32]], %[[RESULT_IMAG_F32]] : !cir.float -> !cir.complex<!cir.float>
 // CIR-AFTER-PROMOTED: cir.store{{.*}} %[[RESULT_F32]], %[[C_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM-PROMOTED: %[[A_ADDR:.*]] = alloca float, i64 1, align 4
-// LLVM-PROMOTED: %[[B_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM-PROMOTED: %[[C_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM-PROMOTED: %[[A_ADDR:.*]] = alloca float, align 4
+// LLVM-PROMOTED: %[[B_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM-PROMOTED: %[[C_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM-PROMOTED: %[[TMP_A:.*]] = load float, ptr %[[A_ADDR]], align 4
 // LLVM-PROMOTED: %[[TMP_B:.*]] = load { float, float }, ptr %[[B_ADDR]], align 4
 // LLVM-PROMOTED: %[[TMP_COMPLEX_A:.*]] = insertvalue { float, float } {{.*}}, float %[[TMP_A]], 0
@@ -1143,9 +1143,9 @@ void foo6() {
 // CIR-AFTER-FULL: %[[RESULT:.*]] = cir.call @__divsc3(%[[A_REAL]], %[[A_IMAG]], %[[B_REAL]], %[[B_IMAG]]) : (!cir.float, !cir.float, !cir.float, !cir.float) -> !cir.complex<!cir.float>
 // CIR-AFTER-FULL: cir.store{{.*}} %[[RESULT]], %[[C_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM-FULL: %[[A_ADDR:.*]] = alloca float, i64 1, align 4
-// LLVM-FULL: %[[B_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM-FULL: %[[C_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM-FULL: %[[A_ADDR:.*]] = alloca float, align 4
+// LLVM-FULL: %[[B_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM-FULL: %[[C_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM-FULL: %[[TMP_A:.*]] = load float, ptr %[[A_ADDR]], align 4
 // LLVM-FULL: %[[TMP_B:.*]] = load { float, float }, ptr %[[B_ADDR]], align 4
 // LLVM-FULL: %[[TMP_COMPLEX_A:.*]] = insertvalue { float, float } {{.*}}, float %[[TMP_A]], 0
@@ -1214,9 +1214,9 @@ void foo7() {
 // CIR-COMBINED: %[[RESULT:.*]] = cir.complex.create %[[RESULT_REAL]], %[[RESULT_IMAG]] : !s32i -> !cir.complex<!s32i>
 // CIR-COMBINED: cir.store{{.*}} %[[RESULT]], %[[C_ADDR]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
 
-// LLVM-COMBINED: %[[A_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
-// LLVM-COMBINED: %[[B_ADDR:.*]] = alloca i32, i64 1, align 4
-// LLVM-COMBINED: %[[C_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
+// LLVM-COMBINED: %[[A_ADDR:.*]] = alloca { i32, i32 }, align 4
+// LLVM-COMBINED: %[[B_ADDR:.*]] = alloca i32, align 4
+// LLVM-COMBINED: %[[C_ADDR:.*]] = alloca { i32, i32 }, align 4
 // LLVM-COMBINED: %[[TMP_A:.*]] = load { i32, i32 }, ptr %[[A_ADDR]], align 4
 // LLVM-COMBINED: %[[TMP_B:.*]] = load i32, ptr %[[B_ADDR]], align 4
 // LLVM-COMBINED: %[[TMP_COMPLEX_B:.*]] = insertvalue { i32, i32 } {{.*}}, i32 %[[TMP_B]], 0

--- a/clang/test/CIR/CodeGen/complex-plus-minus.cpp
+++ b/clang/test/CIR/CodeGen/complex-plus-minus.cpp
@@ -17,8 +17,8 @@ void foo() {
 // CIR: %[[TMP_B:.*]] = cir.load{{.*}} %[[B_ADDR]] : !cir.ptr<!cir.complex<!s32i>>, !cir.complex<!s32i>
 // CIR: %[[ADD:.*]] = cir.complex.add %[[TMP_A]], %[[TMP_B]] : !cir.complex<!s32i>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { i32, i32 }, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca { i32, i32 }, align 4
 // LLVM: %[[TMP_A:.*]] = load { i32, i32 }, ptr %[[A_ADDR]], align 4
 // LLVM: %[[TMP_B:.*]] = load { i32, i32 }, ptr %[[B_ADDR]], align 4
 // LLVM: %[[A_REAL:.*]] = extractvalue { i32, i32 } %[[TMP_A]], 0
@@ -60,8 +60,8 @@ void foo2() {
 // CIR: %[[TMP_B:.*]] = cir.load{{.*}} %[[B_ADDR]] : !cir.ptr<!cir.complex<!cir.float>>, !cir.complex<!cir.float>
 // CIR: %[[ADD:.*]] = cir.complex.add %[[TMP_A]], %[[TMP_B]] : !cir.complex<!cir.float>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM: %[[TMP_A:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM: %[[TMP_B:.*]] = load { float, float }, ptr %[[B_ADDR]], align 4
 // LLVM: %[[A_REAL:.*]] = extractvalue { float, float } %[[TMP_A]], 0
@@ -109,10 +109,10 @@ void foo3() {
 // CIR: %[[ADD_A_B_C:.*]] = cir.complex.add %[[ADD_A_B]], %[[TMP_C]] : !cir.complex<!cir.float>
 // CIR: cir.store{{.*}} %[[ADD_A_B_C]], %[[RESULT]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM: %[[C_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM: %[[RESULT:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM: %[[C_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM: %[[RESULT:.*]] = alloca { float, float }, align 4
 // LLVM: %[[TMP_A:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM: %[[TMP_B:.*]] = load { float, float }, ptr %[[B_ADDR]], align 4
 // LLVM: %[[A_REAL:.*]] = extractvalue { float, float } %[[TMP_A]], 0
@@ -171,9 +171,9 @@ void foo4() {
 // CIR: %[[TMP_B:.*]] = cir.load{{.*}} %[[B_ADDR]] : !cir.ptr<!cir.complex<!s32i>>, !cir.complex<!s32i>
 // CIR: %[[SUB:.*]] = cir.complex.sub %[[TMP_A]], %[[TMP_B]] : !cir.complex<!s32i>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
-// LLVM: %[[C_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { i32, i32 }, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca { i32, i32 }, align 4
+// LLVM: %[[C_ADDR:.*]] = alloca { i32, i32 }, align 4
 // LLVM: %[[TMP_A:.*]] = load { i32, i32 }, ptr %[[A_ADDR]], align 4
 // LLVM: %[[TMP_B:.*]] = load { i32, i32 }, ptr %[[B_ADDR]], align 4
 // LLVM: %[[A_REAL:.*]] = extractvalue { i32, i32 } %[[TMP_A]], 0
@@ -216,8 +216,8 @@ void foo5() {
 // CIR: %[[TMP_B:.*]] = cir.load{{.*}} %[[B_ADDR]] : !cir.ptr<!cir.complex<!cir.float>>, !cir.complex<!cir.float>
 // CIR: %[[SUB:.*]] = cir.complex.sub %[[TMP_A]], %[[TMP_B]] : !cir.complex<!cir.float>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM: %[[TMP_A:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM: %[[TMP_B:.*]] = load { float, float }, ptr %[[B_ADDR]], align 4
 // LLVM: %[[A_REAL:.*]] = extractvalue { float, float } %[[TMP_A]], 0
@@ -265,10 +265,10 @@ void foo6() {
 // CIR: %[[SUB_A_B_C:.*]] = cir.complex.sub %[[SUB_A_B]], %[[TMP_C]] : !cir.complex<!cir.float>
 // CIR: cir.store{{.*}} %[[SUB_A_B_C]], %[[RESULT]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM: %[[C_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM: %[[RESULT:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM: %[[C_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM: %[[RESULT:.*]] = alloca { float, float }, align 4
 // LLVM: %[[TMP_A:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM: %[[TMP_B:.*]] = load { float, float }, ptr %[[B_ADDR]], align 4
 // LLVM: %[[A_REAL:.*]] = extractvalue { float, float } %[[TMP_A]], 0
@@ -343,10 +343,10 @@ void scalar_complex_minus() {
 // CIR: %[[RESULT:.*]] = cir.complex.create %[[RESULT_REAL]], %[[RESULT_IMAG]] : !cir.double -> !cir.complex<!cir.double>
 // CIR: cir.store {{.*}} %[[RESULT]], %[[B_ADDR]] : !cir.complex<!cir.double>, !cir.ptr<!cir.complex<!cir.double>>
 
-// LLVM: %[[REAL_ADDR:.*]] = alloca double, i64 1, align 8
-// LLVM: %[[IMAG_ADDR:.*]] = alloca double, i64 1, align 8
-// LLVM: %[[A_ADDR:.*]] = alloca { double, double }, i64 1, align 8
-// LLVM: %[[B_ADDR:.*]] = alloca { double, double }, i64 1, align 8
+// LLVM: %[[REAL_ADDR:.*]] = alloca double, align 8
+// LLVM: %[[IMAG_ADDR:.*]] = alloca double, align 8
+// LLVM: %[[A_ADDR:.*]] = alloca { double, double }, align 8
+// LLVM: %[[B_ADDR:.*]] = alloca { double, double }, align 8
 // LLVM: store double 5.000000e-01, ptr %[[REAL_ADDR]], align 8
 // LLVM: store double -2.500000e-01, ptr %[[IMAG_ADDR]], align 8
 // LLVM: %[[TMP_REAL:.*]] = load double, ptr %[[REAL_ADDR]], align 8

--- a/clang/test/CIR/CodeGen/complex-unary.cpp
+++ b/clang/test/CIR/CodeGen/complex-unary.cpp
@@ -25,8 +25,8 @@ void foo() {
 // CIR-AFTER: %[[RESULT_VAL:.*]] = cir.complex.create %[[REAL]], %[[IMAG_MINUS]] : !s32i -> !cir.complex<!s32i>
 // CIR-AFTER: cir.store{{.*}} %[[RESULT_VAL]], %[[B_ADDR]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { i32, i32 }, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca { i32, i32 }, align 4
 // LLVM: %[[TMP:.*]] = load { i32, i32 }, ptr %[[A_ADDR]], align 4
 // LLVM: %[[REAL:.*]] = extractvalue { i32, i32 } %[[TMP]], 0
 // LLVM: %[[IMAG:.*]] = extractvalue { i32, i32 } %[[TMP]], 1
@@ -67,8 +67,8 @@ void foo2() {
 // CIR-AFTER: %[[RESULT_VAL:.*]] = cir.complex.create %[[REAL]], %[[IMAG_MINUS]] : !cir.float -> !cir.complex<!cir.float>
 // CIR-AFTER: cir.store{{.*}} %[[RESULT_VAL]], %[[B_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM: %[[TMP:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM: %[[REAL:.*]] = extractvalue { float, float } %[[TMP]], 0
 // LLVM: %[[IMAG:.*]] = extractvalue { float, float } %[[TMP]], 1
@@ -116,8 +116,8 @@ void foo3() {
 // CIR-AFTER: cir.store{{.*}} %[[NEW_COMPLEX]], %[[A_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 // CIR-AFTER: cir.store{{.*}} %[[TMP]], %[[B_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM: %[[TMP:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM: %[[REAL:.*]] = extractvalue { float, float } %[[TMP]], 0
 // LLVM: %[[IMAG:.*]] = extractvalue { float, float } %[[TMP]], 1
@@ -170,8 +170,8 @@ void foo4() {
 // CIR-AFTER: cir.store{{.*}} %[[NEW_COMPLEX]], %[[A_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 // CIR-AFTER: cir.store{{.*}} %[[NEW_COMPLEX]], %[[B_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM: %[[TMP:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM: %[[REAL:.*]] = extractvalue { float, float } %[[TMP]], 0
 // LLVM: %[[IMAG:.*]] = extractvalue { float, float } %[[TMP]], 1
@@ -224,8 +224,8 @@ void foo5() {
 // CIR-AFTER: cir.store{{.*}} %[[NEW_COMPLEX]], %[[A_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 // CIR-AFTER: cir.store{{.*}} %[[TMP]], %[[B_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM: %[[TMP:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM: %[[REAL:.*]] = extractvalue { float, float } %[[TMP]], 0
 // LLVM: %[[IMAG:.*]] = extractvalue { float, float } %[[TMP]], 1
@@ -278,8 +278,8 @@ void foo6() {
 // CIR-AFTER: cir.store{{.*}} %[[NEW_COMPLEX]], %[[A_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 // CIR-AFTER: cir.store{{.*}} %[[NEW_COMPLEX]], %[[B_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM: %[[TMP:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM: %[[REAL:.*]] = extractvalue { float, float } %[[TMP]], 0
 // LLVM: %[[IMAG:.*]] = extractvalue { float, float } %[[TMP]], 1
@@ -320,8 +320,8 @@ void foo7() {
 // CIR-AFTER: %[[TMP:.*]] = cir.load{{.*}} %[[A_ADDR]] : !cir.ptr<!cir.complex<!cir.float>>, !cir.complex<!cir.float>
 // CIR-AFTER: cir.store{{.*}} %[[TMP]], %[[B_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM: %[[TMP:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM: store { float, float } %[[TMP]], ptr %[[B_ADDR]], align 4
 
@@ -361,8 +361,8 @@ void foo8() {
 // CIR-AFTER: %[[NEW_COMPLEX:.*]] = cir.complex.create %[[REAL_MINUS]], %[[IMAG_MINUS]] : !cir.float -> !cir.complex<!cir.float>
 // CIR-AFTER: cir.store{{.*}} %[[NEW_COMPLEX]], %[[B_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM: %[[TMP:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM: %[[REAL:.*]] = extractvalue { float, float } %[[TMP]], 0
 // LLVM: %[[IMAG:.*]] = extractvalue { float, float } %[[TMP]], 1
@@ -413,8 +413,8 @@ void foo9() {
 // CIR-AFTER: %[[RESULT_COMPLEX_F16:.*]] = cir.complex.create %[[RESULT_REAL_F16]], %[[RESULT_IMAG_F16]] : !cir.f16 -> !cir.complex<!cir.f16>
 // CIR-AFTER: cir.store{{.*}} %[[RESULT_COMPLEX_F16]], %[[B_ADDR]] : !cir.complex<!cir.f16>, !cir.ptr<!cir.complex<!cir.f16>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { half, half }, i64 1, align 2
-// LLVM: %[[B_ADDR:.*]] = alloca { half, half }, i64 1, align 2
+// LLVM: %[[A_ADDR:.*]] = alloca { half, half }, align 2
+// LLVM: %[[B_ADDR:.*]] = alloca { half, half }, align 2
 // LLVM: %[[TMP_A:.*]] = load { half, half }, ptr %[[A_ADDR]], align 2
 // LLVM: %[[A_REAL:.*]] = extractvalue { half, half } %[[TMP_A]], 0
 // LLVM: %[[A_IMAG:.*]] = extractvalue { half, half } %[[TMP_A]], 1
@@ -478,8 +478,8 @@ void foo10() {
 // CIR-AFTER: %[[RESULT_COMPLEX_F16:.*]] = cir.complex.create %[[RESULT_REAL_F16]], %[[RESULT_IMAG_F16]] : !cir.f16 -> !cir.complex<!cir.f16>
 // CIR-AFTER: cir.store{{.*}} %[[RESULT_COMPLEX_F16]], %[[B_ADDR]] : !cir.complex<!cir.f16>, !cir.ptr<!cir.complex<!cir.f16>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { half, half }, i64 1, align 2
-// LLVM: %[[B_ADDR:.*]] = alloca { half, half }, i64 1, align 2
+// LLVM: %[[A_ADDR:.*]] = alloca { half, half }, align 2
+// LLVM: %[[B_ADDR:.*]] = alloca { half, half }, align 2
 // LLVM: %[[TMP_A:.*]] = load { half, half }, ptr %[[A_ADDR]], align 2
 // LLVM: %[[A_REAL:.*]] = extractvalue { half, half } %[[TMP_A]], 0
 // LLVM: %[[A_IMAG:.*]] = extractvalue { half, half } %[[TMP_A]], 1
@@ -538,7 +538,7 @@ void complex_unary_inc_lvalue() {
 // CIR-AFTER: %[[RESULT:.*]] = cir.complex.create %[[RESULT_REAL]], %[[A_IMAG]] : !cir.float -> !cir.complex<!cir.float>
 // CIR-AFTER: cir.store{{.*}} %[[RESULT]], %[[A_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM: %[[TMP_A:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM: %[[A_REAL:.*]] = extractvalue { float, float } %[[TMP_A]], 0
 // LLVM: %[[A_IMAG:.*]] = extractvalue { float, float } %[[TMP_A]], 1
@@ -581,7 +581,7 @@ void complex_unary_dec_lvalue() {
 // CIR-AFTER: %[[RESULT:.*]] = cir.complex.create %[[RESULT_REAL]], %[[A_IMAG]] : !cir.float -> !cir.complex<!cir.float>
 // CIR-AFTER: cir.store{{.*}} %[[RESULT]], %[[A_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM: %[[TMP_A:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM: %[[A_REAL:.*]] = extractvalue { float, float } %[[TMP_A]], 0
 // LLVM: %[[A_IMAG:.*]] = extractvalue { float, float } %[[TMP_A]], 1

--- a/clang/test/CIR/CodeGen/complex.cpp
+++ b/clang/test/CIR/CodeGen/complex.cpp
@@ -36,7 +36,7 @@ void foo() { int _Complex c = {}; }
 // CIR: %[[COMPLEX:.*]] = cir.const #cir.zero : !cir.complex<!s32i>
 // CIR: cir.store{{.*}} %[[COMPLEX]], %[[INIT]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
 
-// LLVM: %[[INIT:.*]] = alloca { i32, i32 }, i64 1, align 4
+// LLVM: %[[INIT:.*]] = alloca { i32, i32 }, align 4
 // LLVM: store { i32, i32 } zeroinitializer, ptr %[[INIT]], align 4
 
 // OGCG: %[[COMPLEX:.*]] = alloca { i32, i32 }, align 4
@@ -51,7 +51,7 @@ void foo2() { int _Complex c = {1, 2}; }
 // CIR: %[[COMPLEX:.*]] = cir.const #cir.const_complex<#cir.int<1> : !s32i, #cir.int<2> : !s32i> : !cir.complex<!s32i>
 // CIR: cir.store{{.*}} %[[COMPLEX]], %[[INIT]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
 
-// LLVM: %[[INIT:.*]] = alloca { i32, i32 }, i64 1, align 4
+// LLVM: %[[INIT:.*]] = alloca { i32, i32 }, align 4
 // LLVM: store { i32, i32 } { i32 1, i32 2 }, ptr %[[INIT]], align 4
 
 // OGCG: %[[COMPLEX:.*]] = alloca { i32, i32 }, align 4
@@ -72,7 +72,7 @@ void foo3() {
 // CIR: %[[COMPLEX:.*]] = cir.complex.create %[[TMP_A]], %[[TMP_B]] : !s32i -> !cir.complex<!s32i>
 // CIR: cir.store{{.*}} %[[COMPLEX]], %[[INIT]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
 
-// LLVM: %[[INIT:.*]] = alloca { i32, i32 }, i64 1, align 4
+// LLVM: %[[INIT:.*]] = alloca { i32, i32 }, align 4
 // LLVM: %[[TMP_A:.*]] = load i32, ptr {{.*}}, align 4
 // LLVM: %[[TMP_B:.*]] = load i32, ptr {{.*}}, align 4
 // LLVM: %[[TMP:.*]] = insertvalue { i32, i32 } undef, i32 %[[TMP_A]], 0
@@ -98,7 +98,7 @@ void foo4() {
 // CIR: %[[COMPLEX:.*]] = cir.complex.create %[[CONST_1]], %[[TMP_A]] : !s32i -> !cir.complex<!s32i>
 // CIR: cir.store{{.*}} %[[COMPLEX]], %[[INIT]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
 
-// LLVM: %[[INIT:.*]] = alloca { i32, i32 }, i64 1, align 4
+// LLVM: %[[INIT:.*]] = alloca { i32, i32 }, align 4
 // LLVM: %[[TMP_A:.*]] = load i32, ptr {{.*}}, align 4
 // LLVM: %[[COMPLEX:.*]] = insertvalue { i32, i32 } { i32 1, i32 undef }, i32 %[[TMP_A]], 1
 // LLVM: store { i32, i32 } %[[COMPLEX]], ptr %[[INIT]], align 4
@@ -118,7 +118,7 @@ void foo5() {
 // CIR: %[[COMPLEX:.*]] = cir.const #cir.const_complex<#cir.fp<1.000000e+00> : !cir.float, #cir.fp<2.000000e+00> : !cir.float> : !cir.complex<!cir.float>
 // CIR: cir.store{{.*}} %[[COMPLEX]], %[[INIT]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM: %[[INIT:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM: %[[INIT:.*]] = alloca { float, float }, align 4
 // LLVM: store { float, float } { float 1.000000e+00, float 2.000000e+00 }, ptr %[[INIT]], align 4
 
 // OGCG: %[[COMPLEX]] = alloca { float, float }, align 4
@@ -139,7 +139,7 @@ void foo6() {
 // CIR: %[[COMPLEX:.*]] = cir.complex.create %[[TMP_A]], %[[TMP_B]] : !cir.float -> !cir.complex<!cir.float>
 // CIR: cir.store{{.*}} %[[COMPLEX]], %[[INIT]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM: %[[COMPLEX:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM: %[[COMPLEX:.*]] = alloca { float, float }, align 4
 // LLVM: %[[TMP_A:.*]] = load float, ptr {{.*}}, align 4
 // LLVM: %[[TMP_B:.*]] = load float, ptr {{.*}}, align 4
 // LLVM: %[[TMP:.*]] = insertvalue { float, float } undef, float %[[TMP_A]], 0
@@ -165,7 +165,7 @@ void foo7() {
 // CIR: %[[COMPLEX:.*]] = cir.complex.create %[[TMP_A]], %[[CONST_2F]] : !cir.float -> !cir.complex<!cir.float>
 // CIR: cir.store{{.*}} %[[COMPLEX]], %[[INIT]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM: %[[COMPLEX:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM: %[[COMPLEX:.*]] = alloca { float, float }, align 4
 // LLVM: %[[TMP_A:.*]] = load float, ptr {{.*}}, align 4
 // LLVM: %[[TMP:.*]] = insertvalue { float, float } undef, float %[[TMP_A]], 0
 // LLVM: %[[TMP_2:.*]] = insertvalue { float, float } %[[TMP]], float 2.000000e+00, 1
@@ -184,7 +184,7 @@ void foo8() {
 
 // CIR: %[[COMPLEX:.*]] = cir.const #cir.const_complex<#cir.fp<0.000000e+00> : !cir.double, #cir.fp<2.000000e+00> : !cir.double> : !cir.complex<!cir.double>
 
-// LLVM: %[[COMPLEX:.*]] = alloca { double, double }, i64 1, align 8
+// LLVM: %[[COMPLEX:.*]] = alloca { double, double }, align 8
 // LLVM: store { double, double } { double 0.000000e+00, double 2.000000e+00 }, ptr %[[COMPLEX]], align 8
 
 // OGCG: %[[COMPLEX:.*]] = alloca { double, double }, align 8
@@ -203,7 +203,7 @@ void foo9(double a, double b) {
 // CIR: %[[COMPLEX:.*]] = cir.complex.create %[[TMP_A]], %[[TMP_B]] : !cir.double -> !cir.complex<!cir.double>
 // CIR: cir.store{{.*}} %[[COMPLEX]], %[[INIT]] : !cir.complex<!cir.double>, !cir.ptr<!cir.complex<!cir.double>>
 
-// LLVM: %[[COMPLEX:.*]] = alloca { double, double }, i64 1, align 8
+// LLVM: %[[COMPLEX:.*]] = alloca { double, double }, align 8
 // LLVM: %[[TMP_A:.*]] = load double, ptr {{.*}}, align 8
 // LLVM: %[[TMP_B:.*]] = load double, ptr {{.*}}, align 8
 // LLVM: %[[TMP:.*]] = insertvalue { double, double } undef, double %[[TMP_A]], 0
@@ -226,7 +226,7 @@ void foo10() {
 // CIR: %[[COMPLEX:.*]] = cir.alloca "c" {{.*}} : !cir.ptr<!cir.complex<!cir.double>>
 // CIR: %[[REAL_PTR:.*]] = cir.complex.real_ptr %[[COMPLEX]] : !cir.ptr<!cir.complex<!cir.double>> -> !cir.ptr<!cir.double>
 
-// LLVM: %[[COMPLEX:.*]] = alloca { double, double }, i64 1, align 8
+// LLVM: %[[COMPLEX:.*]] = alloca { double, double }, align 8
 // LLVM: %[[REAL_PTR:.*]] = getelementptr inbounds nuw { double, double }, ptr %[[COMPLEX]], i32 0, i32 0
 
 // OGCG: %[[COMPLEX:.*]] = alloca { double, double }, align 8
@@ -240,7 +240,7 @@ void foo11() {
 // CIR: %[[COMPLEX:.*]] = cir.alloca "c" {{.*}} : !cir.ptr<!cir.complex<!cir.double>>
 // CIR: %[[IMAG_PTR:.*]] = cir.complex.imag_ptr %[[COMPLEX]] : !cir.ptr<!cir.complex<!cir.double>> -> !cir.ptr<!cir.double>
 
-// LLVM: %[[COMPLEX:.*]] = alloca { double, double }, i64 1, align 8
+// LLVM: %[[COMPLEX:.*]] = alloca { double, double }, align 8
 // LLVM: %[[IMAG_PTR:.*]] = getelementptr inbounds nuw { double, double }, ptr %[[COMPLEX]], i32 0, i32 1
 
 // OGCG: %[[COMPLEX:.*]] = alloca { double, double }, align 8
@@ -257,8 +257,8 @@ void foo12() {
 // CIR: %[[IMAG:.*]] = cir.complex.imag %[[TMP]] : !cir.complex<!cir.double> -> !cir.double
 // CIR: cir.store{{.*}} %[[IMAG]], %[[INIT]] : !cir.double, !cir.ptr<!cir.double>
 
-// LLVM: %[[COMPLEX:.*]] = alloca { double, double }, i64 1, align 8
-// LLVM: %[[INIT:.*]] = alloca double, i64 1, align 8
+// LLVM: %[[COMPLEX:.*]] = alloca { double, double }, align 8
+// LLVM: %[[INIT:.*]] = alloca double, align 8
 // LLVM: %[[TMP:.*]] = load { double, double }, ptr %[[COMPLEX]], align 8
 // LLVM: %[[IMAG:.*]] = extractvalue { double, double } %[[TMP]], 1
 // LLVM: store double %[[IMAG]], ptr %[[INIT]], align 8
@@ -280,8 +280,8 @@ void foo13() {
 // CIR: %[[REAL:.*]] = cir.complex.real %[[TMP]] : !cir.complex<!cir.double> -> !cir.double
 // CIR: cir.store{{.*}} %[[REAL]], %[[INIT]] : !cir.double, !cir.ptr<!cir.double>
 
-// LLVM: %[[COMPLEX:.*]] = alloca { double, double }, i64 1, align 8
-// LLVM: %[[INIT:.*]] = alloca double, i64 1, align 8
+// LLVM: %[[COMPLEX:.*]] = alloca { double, double }, align 8
+// LLVM: %[[INIT:.*]] = alloca double, align 8
 // LLVM: %[[TMP:.*]] = load { double, double }, ptr %[[COMPLEX]], align 8
 // LLVM: %[[REAL:.*]] = extractvalue { double, double } %[[TMP]], 0
 // LLVM: store double %[[REAL]], ptr %[[INIT]], align 8
@@ -299,7 +299,7 @@ void foo14() {
 
 // CIR: %[[COMPLEX:.*]] = cir.const #cir.const_complex<#cir.int<0> : !s32i, #cir.int<2> : !s32i> : !cir.complex<!s32i>
 
-// LLVM: %[[COMPLEX:.*]] = alloca { i32, i32 }, i64 1, align 4
+// LLVM: %[[COMPLEX:.*]] = alloca { i32, i32 }, align 4
 // LLVM: store { i32, i32 } { i32 0, i32 2 }, ptr %[[COMPLEX]], align 4
 
 // OGCG: %[[COMPLEX:.*]] = alloca { i32, i32 }, align 4
@@ -318,8 +318,8 @@ void foo15() {
 // CIR: %[[TMP_A:.*]] = cir.load{{.*}} %[[COMPLEX_A]] : !cir.ptr<!cir.complex<!s32i>>, !cir.complex<!s32i>
 // CIR: cir.store{{.*}} %[[TMP_A]], %[[COMPLEX_B]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
 
-// LLVM: %[[COMPLEX_A:.*]] = alloca { i32, i32 }, i64 1, align 4
-// LLVM: %[[COMPLEX_B:.*]] = alloca { i32, i32 }, i64 1, align 4
+// LLVM: %[[COMPLEX_A:.*]] = alloca { i32, i32 }, align 4
+// LLVM: %[[COMPLEX_B:.*]] = alloca { i32, i32 }, align 4
 // LLVM: %[[TMP_A:.*]] = load { i32, i32 }, ptr %[[COMPLEX_A]], align 4
 // LLVM: store { i32, i32 } %[[TMP_A]], ptr %[[COMPLEX_B]], align 4
 
@@ -348,7 +348,7 @@ int foo16(int _Complex a, int _Complex b) {
 // CIR: %[[TMP:.*]] = cir.load %[[RET]] : !cir.ptr<!s32i>, !s32i
 // CIR: cir.return %[[TMP]] : !s32i
 
-// LLVM: %[[RET:.*]] = alloca i32, i64 1, align 4
+// LLVM: %[[RET:.*]] = alloca i32, align 4
 // LLVM: %[[COMPLEX_A:.*]] = load { i32, i32 }, ptr {{.*}}, align 4
 // LLVM: %[[A_IMAG:.*]] = extractvalue { i32, i32 } %[[COMPLEX_A]], 1
 // LLVM: %[[COMPLEX_B:.*]] = load { i32, i32 }, ptr {{.*}}, align 4
@@ -381,7 +381,7 @@ int foo17(int _Complex a, int _Complex b) {
 // CIR: %[[TMP:.*]] = cir.load %[[RET]] : !cir.ptr<!s32i>, !s32i
 // CIR: cir.return %[[TMP]] : !s32i
 
-// LLVM: %[[RET:.*]] = alloca i32, i64 1, align 4
+// LLVM: %[[RET:.*]] = alloca i32, align 4
 // LLVM: %[[COMPLEX_A:.*]] = load { i32, i32 }, ptr {{.*}}, align 4
 // LLVM: %[[A_REAL:.*]] = extractvalue { i32, i32 } %[[COMPLEX_A]], 0
 // LLVM: %[[COMPLEX_B:.*]] = load { i32, i32 }, ptr {{.*}}, align 4
@@ -556,9 +556,9 @@ void foo22(int _Complex a, int _Complex b) {
 // CIR: %[[TMP_B:.*]] = cir.load{{.*}} %[[COMPLEX_B]] : !cir.ptr<!cir.complex<!s32i>>, !cir.complex<!s32i>
 // CIR: cir.store{{.*}} %[[TMP_B]], %[[RESULT]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
 
-// LLVM: %[[COMPLEX_A:.*]] = alloca { i32, i32 }, i64 1, align 4
-// LLVM: %[[COMPLEX_B:.*]] = alloca { i32, i32 }, i64 1, align 4
-// LLVM: %[[RESULT:.*]] = alloca { i32, i32 }, i64 1, align 4
+// LLVM: %[[COMPLEX_A:.*]] = alloca { i32, i32 }, align 4
+// LLVM: %[[COMPLEX_B:.*]] = alloca { i32, i32 }, align 4
+// LLVM: %[[RESULT:.*]] = alloca { i32, i32 }, align 4
 // LLVM: %[[TMP_B:.*]] = load { i32, i32 }, ptr %[[COMPLEX_B]], align 4
 // LLVM: store { i32, i32 } %[[TMP_B]], ptr %[[RESULT]], align 4
 
@@ -586,10 +586,10 @@ void foo23(int _Complex a, int _Complex b) {
 // CIR: %[[TMP:.*]] = cir.load{{.*}} %[[COMPLEX_B]] : !cir.ptr<!cir.complex<!s32i>>, !cir.complex<!s32i>
 // CIR: cir.store{{.*}} %[[TMP]], %[[RESULT]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
 
-// LLVM: %[[COMPLEX_A:.*]] = alloca { i32, i32 }, i64 1, align 4
-// LLVM: %[[COMPLEX_B:.*]] = alloca { i32, i32 }, i64 1, align 4
-// LLVM: %[[COMPLEX_F:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM: %[[RESULT:.*]] = alloca { i32, i32 }, i64 1, align 4
+// LLVM: %[[COMPLEX_A:.*]] = alloca { i32, i32 }, align 4
+// LLVM: %[[COMPLEX_B:.*]] = alloca { i32, i32 }, align 4
+// LLVM: %[[COMPLEX_F:.*]] = alloca { float, float }, align 4
+// LLVM: %[[RESULT:.*]] = alloca { i32, i32 }, align 4
 // LLVM: %[[TMP:.*]] = load { i32, i32 }, ptr %[[COMPLEX_B]], align 4
 // LLVM: store { i32, i32 } %[[TMP]], ptr %[[RESULT]], align 4
 
@@ -618,8 +618,8 @@ void foo24() {
 // CIR: %[[TMP:.*]] = cir.load{{.*}} %[[RESULT_VAL]] : !cir.ptr<!cir.complex<!s32i>>, !cir.complex<!s32i>
 // CIR: cir.store{{.*}} %[[TMP]], %[[RESULT]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
 
-// LLVM: %[[ARR:.*]] = alloca [2 x { i32, i32 }], i64 1, align 16
-// LLVM: %[[RESULT:.*]] = alloca { i32, i32 }, i64 1, align 4
+// LLVM: %[[ARR:.*]] = alloca [2 x { i32, i32 }], align 16
+// LLVM: %[[RESULT:.*]] = alloca { i32, i32 }, align 4
 // LLVM: %[[RESULT_VAL:.*]] = getelementptr [2 x { i32, i32 }], ptr %[[ARR]], i32 0, i64 1
 // LLVM: %[[TMP:.*]] = load { i32, i32 }, ptr %[[RESULT_VAL]], align 8
 // LLVM: store { i32, i32 } %[[TMP]], ptr %[[RESULT]], align 4
@@ -646,7 +646,7 @@ void foo25() {
 // CIR: %[[COMPLEX:.*]] = cir.const #cir.const_complex<#cir.fp<1.000000e+00> : !cir.double, #cir.fp<2.000000e+00> : !cir.double> : !cir.complex<!cir.double>
 // CIR: cir.store{{.*}} %[[COMPLEX]], %[[INIT]] : !cir.complex<!cir.double>, !cir.ptr<!cir.complex<!cir.double>>
 
-// LLVM: %[[INIT:.*]] = alloca { double, double }, i64 1, align 8
+// LLVM: %[[INIT:.*]] = alloca { double, double }, align 8
 // LLVM: store { double, double } { double 1.000000e+00, double 2.000000e+00 }, ptr %[[INIT]], align 8
 
 // OGCG: %[[INIT:.*]] = alloca { double, double }, align 8
@@ -665,8 +665,8 @@ void foo26(int _Complex* a) {
 // CIR: %[[TMP:.*]] = cir.load{{.*}} %[[COMPLEX_A]] : !cir.ptr<!cir.complex<!s32i>>, !cir.complex<!s32i>
 // CIR: cir.store{{.*}} %[[TMP]], %[[COMPLEX_B]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
 
-// LLVM: %[[COMPLEX_A_PTR:.*]] = alloca ptr, i64 1, align 8
-// LLVM: %[[COMPLEX_B:.*]] = alloca { i32, i32 }, i64 1, align 4
+// LLVM: %[[COMPLEX_A_PTR:.*]] = alloca ptr, align 8
+// LLVM: %[[COMPLEX_B:.*]] = alloca { i32, i32 }, align 4
 // LLVM: %[[COMPLEX_A:.*]] = load ptr, ptr %[[COMPLEX_A_PTR]], align 8
 // LLVM: %[[TMP:.*]] = load { i32, i32 }, ptr %[[COMPLEX_A]], align 4
 // LLVM: store { i32, i32 } %[[TMP]], ptr %[[COMPLEX_B]], align 4
@@ -701,10 +701,10 @@ void foo27(bool cond, int _Complex a, int _Complex b) {
 // CIR: }) : (!cir.bool) -> !cir.complex<!s32i>
 // CIR: cir.store{{.*}} %[[RESULT_VAL]], %[[RESULT]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
 
-// LLVM: %[[COND:.*]] = alloca i8, i64 1, align 1
-// LLVM: %[[COMPLEX_A:.*]] = alloca { i32, i32 }, i64 1, align 4
-// LLVM: %[[COMPLEX_B:.*]] = alloca { i32, i32 }, i64 1, align 4
-// LLVM: %[[RESULT:.*]] = alloca { i32, i32 }, i64 1, align 4
+// LLVM: %[[COND:.*]] = alloca i8, align 1
+// LLVM: %[[COMPLEX_A:.*]] = alloca { i32, i32 }, align 4
+// LLVM: %[[COMPLEX_B:.*]] = alloca { i32, i32 }, align 4
+// LLVM: %[[RESULT:.*]] = alloca { i32, i32 }, align 4
 // LLVM: %[[TMP_COND:.*]] = load i8, ptr %[[COND]], align 1
 // LLVM: %[[COND_VAL:.*]] = trunc i8 %[[TMP_COND]] to i1
 // LLVM: br i1 %[[COND_VAL]], label %[[TRUE_BB:.*]], label %[[FALSE_BB:.*]]
@@ -754,7 +754,7 @@ void foo28() {
 // CIR: %[[COMPLEX:.*]] = cir.const #cir.zero : !cir.complex<!s32i>
 // CIR: cir.store align(4) %[[COMPLEX]], %[[INIT]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
 
-// LLVM: %[[INIT:.*]] = alloca { i32, i32 }, i64 1, align 4
+// LLVM: %[[INIT:.*]] = alloca { i32, i32 }, align 4
 // LLVM: store { i32, i32 } zeroinitializer, ptr %[[INIT]], align 4
 
 // OGCG: %[[INIT:.*]] = alloca { i32, i32 }, align 4
@@ -772,7 +772,7 @@ void foo29() {
 // CIR: %[[COMPLEX:.*]] = cir.const #cir.zero : !cir.complex<!s32i>
 // CIR: cir.store{{.*}} %[[COMPLEX]], %[[INIT]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
 
-// LLVM: %[[INIT:.*]] = alloca { i32, i32 }, i64 1, align 4
+// LLVM: %[[INIT:.*]] = alloca { i32, i32 }, align 4
 // LLVM: store { i32, i32 } zeroinitializer, ptr %[[INIT]], align 4
 
 // OGCG: %[[INIT:.*]] = alloca { i32, i32 }, align 4
@@ -791,7 +791,7 @@ void foo30() {
 // CIR: %[[COMPLEX:.*]] = cir.complex.create %[[CONST_1F]], %[[CONST_0F]] : !cir.float -> !cir.complex<!cir.float>
 // CIR: cir.store{{.*}} %[[COMPLEX]], %[[A_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM: store { float, float } { float 1.000000e+00, float 0.000000e+00 }, ptr %[[A_ADDR]], align 4
 
 // OGCG:  %[[A_ADDR:.*]] = alloca { float, float }, align 4
@@ -816,8 +816,8 @@ void foo31() {
 // CIR: %[[REAL:.*]] = cir.complex.real %[[TMP_ELEM_PTR]] : !cir.complex<!s32i> -> !s32i
 // CIR: cir.store{{.*}} %[[REAL]], %[[REAL_ADDR]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM: %[[W_ADDR:.*]] = alloca %struct.Wrapper, i64 1, align 4
-// LLVM: %[[REAL_ADDR:.*]] = alloca i32, i64 1, align 4
+// LLVM: %[[W_ADDR:.*]] = alloca %struct.Wrapper, align 4
+// LLVM: %[[REAL_ADDR:.*]] = alloca i32, align 4
 // LLVM: %[[ELEM_PTR:.*]] = getelementptr inbounds nuw %struct.Wrapper, ptr %[[W_ADDR]], i32 0, i32 0
 // LLVM: %[[TMP_ELEM_PTR:.*]] = load { i32, i32 }, ptr %[[ELEM_PTR]], align 4
 // LLVM: %[[REAL:.*]] = extractvalue { i32, i32 } %[[TMP_ELEM_PTR]], 0
@@ -845,7 +845,7 @@ void foo32() {
 // CIR: %[[REAL:.*]] = cir.complex.real %[[ELEM]] : !cir.complex<!s32i> -> !s32i
 // CIR: cir.store{{.*}} %[[REAL]], %[[REAL_ADDR]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM: %[[REAL_ADDR:.*]] = alloca i32, i64 1, align 4
+// LLVM: %[[REAL_ADDR:.*]] = alloca i32, align 4
 // LLVM: %[[ELEM:.*]] = load { i32, i32 }, ptr @_ZN9Container1cE, align 4
 // LLVM: %[[REAL:.*]] = extractvalue { i32, i32 } %[[ELEM]], 0
 // LLVM: store i32 %[[REAL]], ptr %[[REAL_ADDR]], align 4
@@ -865,8 +865,8 @@ void foo33(__builtin_va_list a) {
 // CIR: %[[COMPLEX:.*]] = cir.va_arg %[[VA_TAG]] : (!cir.ptr<!rec___va_list_tag>) -> !cir.complex<!cir.float>
 // CIR: cir.store{{.*}} %[[COMPLEX]], %[[B_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca ptr, i64 1, align 8
-// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca ptr, align 8
+// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM: store ptr %[[ARG_0:.*]], ptr %[[A_ADDR]], align 8
 // LLVM: %[[TMP_A:.*]] = load ptr, ptr %[[A_ADDR]], align 8
 // LLVM: %[[COMPLEX:.*]] = va_arg ptr %[[TMP_A]], { float, float }
@@ -919,7 +919,7 @@ void foo34() {
 // CIR: %[[CONST_COMPLEX:.*]] = cir.const #cir.const_complex<#cir.fp<1.000000e+00> : !cir.float, #cir.fp<2.000000e+00> : !cir.float> : !cir.complex<!cir.float>
 // CIR: cir.store{{.*}} %[[CONST_COMPLEX]], %[[A_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 8
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 8
 // LLVM: store { float, float } { float 1.000000e+00, float 2.000000e+00 }, ptr %[[A_ADDR]], align 8
 
 // OGCG: %[[A_ADDR:.*]] = alloca { float, float }, align 8
@@ -945,8 +945,8 @@ void foo35() {
 // CIR: %[[A_REAL_F16:.*]] = cir.cast floating %[[A_REAL_F32]] : !cir.float -> !cir.f16
 // CIR: cir.store{{.*}} %[[A_REAL_F16]], %[[REAL_ADDR]] : !cir.f16, !cir.ptr<!cir.f16>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { half, half }, i64 1, align 2
-// LLVM: %[[REAL_ADDR:.*]] = alloca half, i64 1, align 2
+// LLVM: %[[A_ADDR:.*]] = alloca { half, half }, align 2
+// LLVM: %[[REAL_ADDR:.*]] = alloca half, align 2
 // LLVM: %[[TMP_A:.*]] = load { half, half }, ptr %[[A_ADDR]], align 2
 // LLVM: %[[A_REAL:.*]] = extractvalue { half, half } %[[TMP_A]], 0
 // LLVM: %[[A_IMAG:.*]] = extractvalue { half, half } %[[TMP_A]], 1
@@ -982,8 +982,8 @@ void foo36() {
 // CIR: %[[A_IMAG_F16:.*]] = cir.cast floating %[[A_IMAG_F32]] : !cir.float -> !cir.f16
 // CIR: cir.store{{.*}} %[[A_IMAG_F16]], %[[IMAG_ADDR]] : !cir.f16, !cir.ptr<!cir.f16>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { half, half }, i64 1, align 2
-// LLVM: %[[IMAG_ADDR:.*]] = alloca half, i64 1, align 2
+// LLVM: %[[A_ADDR:.*]] = alloca { half, half }, align 2
+// LLVM: %[[IMAG_ADDR:.*]] = alloca half, align 2
 // LLVM: %[[TMP_A:.*]] = load { half, half }, ptr %[[A_ADDR]], align 2
 // LLVM: %[[A_REAL:.*]] = extractvalue { half, half } %[[TMP_A]], 0
 // LLVM: %[[A_IMAG:.*]] = extractvalue { half, half } %[[TMP_A]], 1
@@ -1012,8 +1012,8 @@ void foo37() {
 // CIR: %[[TMP_A:.*]] = cir.load{{.*}} %[[A_ADDR]] : !cir.ptr<!cir.complex<!cir.float>>, !cir.complex<!cir.float>
 // CIR: cir.store{{.*}} %[[TMP_A]], %[[B_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM: %[[TMP_A:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM: store { float, float } %[[TMP_A]], ptr %[[B_ADDR]], align 4
 
@@ -1039,8 +1039,8 @@ void real_on_non_glvalue() {
 // CIR: %[[RESULT_REAL:.*]] = cir.complex.real %[[TMP_A]] : !cir.complex<!cir.float> -> !cir.float
 // CIR: cir.store{{.*}} %[[RESULT_REAL]], %[[B_ADDR]] : !cir.float, !cir.ptr<!cir.float>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca float, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca float, align 4
 // LLVM: %[[TMP_A:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM: %[[A_REAL:.*]] = extractvalue { float, float } %[[TMP_A]], 0
 // LLVM: store float %[[A_REAL]], ptr %[[B_ADDR]], align 4
@@ -1064,8 +1064,8 @@ void imag_on_non_glvalue() {
 // CIR: %[[RESULT_IMAG:.*]] = cir.complex.imag %[[TMP_A]] : !cir.complex<!cir.float> -> !cir.float
 // CIR: cir.store{{.*}} %[[RESULT_IMAG]], %[[B_ADDR]] : !cir.float, !cir.ptr<!cir.float>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca float, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca float, align 4
 // LLVM: %[[TMP_A:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM: %[[A_IMAG:.*]] = extractvalue { float, float } %[[TMP_A]], 1
 // LLVM: store float %[[A_IMAG]], ptr %[[B_ADDR]], align 4
@@ -1094,9 +1094,9 @@ void atomic_complex_type() {
 // CIR: %[[TMP_ATOMIC:.*]] = cir.load{{.*}} %[[TMP_ATOMIC_PTR]] : !cir.ptr<!cir.complex<!cir.float>>, !cir.complex<!cir.float>
 // CIR: cir.store{{.*}} %[[TMP_ATOMIC]], %[[B_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 8
-// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM: %[[ATOMIC_TMP_ADDR:.*]] = alloca { float, float }, i64 1, align 8
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 8
+// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM: %[[ATOMIC_TMP_ADDR:.*]] = alloca { float, float }, align 8
 // LLVM: %[[TMP_A_ATOMIC:.*]] = load atomic i64, ptr %[[A_ADDR]] monotonic, align 8
 // LLVM: store i64 %[[TMP_A_ATOMIC]], ptr %[[ATOMIC_TMP_ADDR]], align 8
 // LLVM: %[[TMP_ATOMIC:.*]] = load { float, float }, ptr %[[ATOMIC_TMP_ADDR]], align 8
@@ -1127,8 +1127,8 @@ void real_on_scalar_glvalue() {
 // CIR: %[[A_REAL:.*]] = cir.complex.real %[[TMP_A]] : !cir.float -> !cir.float
 // CIR: cir.store{{.*}} %[[A_REAL]], %[[B_ADDR]] : !cir.float, !cir.ptr<!cir.float>
 
-// LLVM: %[[A_ADDR:.*]] = alloca float, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca float, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca float, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca float, align 4
 // LLVM: %[[TMP_A:.*]] = load float, ptr %[[A_ADDR]], align 4
 // LLVM: store float %[[TMP_A]], ptr %[[B_ADDR]], align 4
 
@@ -1148,8 +1148,8 @@ void imag_on_scalar_glvalue() {
 // CIR: %[[A_IMAG:.*]] = cir.complex.imag %[[TMP_A]] : !cir.float -> !cir.float
 // CIR: cir.store{{.*}} %[[A_IMAG]], %[[B_ADDR]] : !cir.float, !cir.ptr<!cir.float>
 
-// LLVM: %[[A_ADDR:.*]] = alloca float, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca float, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca float, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca float, align 4
 // LLVM: store float 0.000000e+00, ptr %[[B_ADDR]], align 4
 
 // OGCG: %[[A_ADDR:.*]] = alloca float, align 4
@@ -1169,8 +1169,8 @@ void real_on_scalar_with_type_promotion() {
 // CIR: %[[TMP_A_F16:.*]] = cir.cast floating %[[A_REAL]] : !cir.float -> !cir.f16
 // CIR: cir.store{{.*}} %[[TMP_A_F16]], %[[B_ADDR]] : !cir.f16, !cir.ptr<!cir.f16>
 
-// LLVM: %[[A_ADDR:.*]] = alloca half, i64 1, align 2
-// LLVM: %[[B_ADDR:.*]] = alloca half, i64 1, align 2
+// LLVM: %[[A_ADDR:.*]] = alloca half, align 2
+// LLVM: %[[B_ADDR:.*]] = alloca half, align 2
 // LLVM: %[[TMP_A:.*]] = load half, ptr %[[A_ADDR]], align 2
 // LLVM: %[[TMP_A_F32:.*]] = fpext half %[[TMP_A]] to float
 // LLVM: %[[TMP_A_F16:.*]] = fptrunc float %[[TMP_A_F32]] to half
@@ -1195,8 +1195,8 @@ void imag_on_scalar_with_type_promotion() {
 // CIR: %[[A_IMAG_F16:.*]] = cir.cast floating %[[A_IMAG]] : !cir.f16 -> !cir.f16
 // CIR: cir.store{{.*}} %[[A_IMAG_F16]], %[[B_ADDR]] : !cir.f16, !cir.ptr<!cir.f16>
 
-// LLVM: %[[A_ADDR:.*]] = alloca half, i64 1, align 2
-// LLVM: %[[B_ADDR:.*]] = alloca half, i64 1, align 2
+// LLVM: %[[A_ADDR:.*]] = alloca half, align 2
+// LLVM: %[[B_ADDR:.*]] = alloca half, align 2
 // LLVM: store half 0.000000e+00, ptr %[[B_ADDR]], align 2
 
 // OGCG: %[[A_ADDR:.*]] = alloca half, align 2
@@ -1214,8 +1214,8 @@ void imag_on_const_scalar() {
 // CIR: %[[CONST_IMAG:.*]] = cir.complex.imag %[[CONST_ONE]] : !cir.float -> !cir.float
 // CIR: cir.store{{.*}} %[[CONST_IMAG]], %[[B_ADDR]] : !cir.float, !cir.ptr<!cir.float>
 
-// LLVM: %[[A_ADDR:.*]] = alloca float, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca float, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca float, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca float, align 4
 // LLVM: store float 0.000000e+00, ptr %[[B_ADDR]], align 4
 
 // OGCG: %[[A_ADDR:.*]] = alloca float, align 4
@@ -1240,8 +1240,8 @@ void real_on_scalar_from_real_with_type_promotion() {
 // CIR: %[[A_REAL_F16:.*]] = cir.cast floating %[[A_REAL]] : !cir.float -> !cir.f16
 // CIR: cir.store{{.*}} %[[A_REAL_F16]], %[[B_ADDR]] : !cir.f16, !cir.ptr<!cir.f16>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { half, half }, i64 1, align 2
-// LLVM: %[[B_ADDR]] = alloca half, i64 1, align 2
+// LLVM: %[[A_ADDR:.*]] = alloca { half, half }, align 2
+// LLVM: %[[B_ADDR]] = alloca half, align 2
 // LLVM: %[[TMP_A:.*]] = load { half, half }, ptr %[[A_ADDR]], align 2
 // LLVM: %[[A_REAL:.*]] = extractvalue { half, half } %[[TMP_A]], 0
 // LLVM: %[[A_IMAG:.*]] = extractvalue { half, half } %[[TMP_A]], 1
@@ -1278,8 +1278,8 @@ void real_on_scalar_from_imag_with_type_promotion() {
 // CIR: %[[A_REAL_F16:.*]] = cir.cast floating %[[A_REAL_F32]] : !cir.float -> !cir.f16
 // CIR: cir.store{{.*}} %[[A_REAL_F16]], %[[B_ADDR]] : !cir.f16, !cir.ptr<!cir.f16>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { half, half }, i64 1, align 2
-// LLVM: %[[B_ADDR]] = alloca half, i64 1, align 2
+// LLVM: %[[A_ADDR:.*]] = alloca { half, half }, align 2
+// LLVM: %[[B_ADDR]] = alloca half, align 2
 // LLVM: %[[TMP_A:.*]] = load { half, half }, ptr %[[A_ADDR]], align 2
 // LLVM: %[[A_REAL:.*]] = extractvalue { half, half } %[[TMP_A]], 0
 // LLVM: %[[A_IMAG:.*]] = extractvalue { half, half } %[[TMP_A]], 1
@@ -1306,7 +1306,7 @@ void complex_type_parameter(float _Complex a) {}
 // TODO(CIR): the difference between the CIR LLVM and OGCG is because the lack of calling convention lowering,
 // Test will be updated when that is implemented
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM: store { float, float } %{{.*}}, ptr %[[A_ADDR]], align 4
 
 // OGCG: %[[A_ADDR:.*]] = alloca { float, float }, align 4
@@ -1324,8 +1324,8 @@ void complex_type_argument() {
 // CIR: %[[TMP_ARG:.*]] = cir.load{{.*}} %[[ARG_ADDR]] : !cir.ptr<!cir.complex<!cir.float>>, !cir.complex<!cir.float>
 // CIR: cir.call @_Z22complex_type_parameterCf(%[[TMP_ARG]]) : (!cir.complex<!cir.float> {llvm.noundef}) -> ()
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM: %[[ARG_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM: %[[ARG_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM: %[[TMP_A:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM: store { float, float } %[[TMP_A]], ptr %[[ARG_ADDR]], align 4
 // LLVM: %[[TMP_ARG:.*]] = load { float, float }, ptr %[[ARG_ADDR]], align 4
@@ -1355,7 +1355,7 @@ float _Complex complex_type_return_type() {
 // CIR: cir.return %[[TMP_RET]] : !cir.complex<!cir.float>
 
 // TODO(CIR): the difference between the CIR LLVM and OGCG is because the lack of calling convention lowering,
-// LLVM: %[[RET_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM: %[[RET_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM: store { float, float } { float 1.000000e+00, float 2.000000e+00 }, ptr %[[RET_ADDR]], align 4
 // LLVM: %[[TMP_RET:.*]] = load { float, float }, ptr %[[RET_ADDR]], align 4
 // LLVM: ret { float, float } %[[TMP_RET]]
@@ -1379,8 +1379,8 @@ void real_on_scalar_bool() {
 // CIR: %[[A_REAL:.*]] = cir.complex.real %[[TMP_A]] : !cir.bool -> !cir.bool
 // CIR: cir.store{{.*}} %[[A_REAL]], %[[B_ADDR]] : !cir.bool, !cir.ptr<!cir.bool>
 
-// LLVM: %[[A_ADDR:.*]] = alloca i8, i64 1, align 1
-// LLVM: %[[B_ADDR:.*]] = alloca i8, i64 1, align 1
+// LLVM: %[[A_ADDR:.*]] = alloca i8, align 1
+// LLVM: %[[B_ADDR:.*]] = alloca i8, align 1
 // LLVM: %[[TMP_A:.*]] = load i8, ptr %[[A_ADDR]], align 1
 // LLVM: %[[TMP_A_I1:.*]] = trunc i8 %[[TMP_A]] to i1
 // LLVM: %[[TMP_A_I8:.*]] = zext i1 %[[TMP_A_I1]] to i8
@@ -1404,8 +1404,8 @@ void imag_on_scalar_bool() {
 // CIR: %[[A_IMAG:.*]] = cir.complex.imag %[[TMP_A]] : !cir.bool -> !cir.bool
 // CIR: cir.store{{.*}} %[[A_IMAG]], %[[B_ADDR]] : !cir.bool, !cir.ptr<!cir.bool>
 
-// LLVM: %[[A_ADDR:.*]] = alloca i8, i64 1, align 1
-// LLVM: %[[B_ADDR:.*]] = alloca i8, i64 1, align 1
+// LLVM: %[[A_ADDR:.*]] = alloca i8, align 1
+// LLVM: %[[B_ADDR:.*]] = alloca i8, align 1
 // LLVM: %[[TMP_A:.*]] = load i8, ptr %[[A_ADDR]], align 1
 // LLVM: %[[TMP_A_I1:.*]] = trunc i8 %[[TMP_A]] to i1
 // LLVM: store i8 0, ptr %[[B_ADDR]], align 1
@@ -1422,7 +1422,7 @@ void function_with_complex_default_arg(
 
 // TODO(CIR): the difference between the CIR LLVM and OGCG is because the lack of calling convention lowering,
 
-// LLVM: %[[ARG_0_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM: %[[ARG_0_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM: store { float, float } %{{.*}}, ptr %[[ARG_0_ADDR]], align 4
 
 // OGCG: %[[ARG_0_ADDR:.*]] = alloca { float, float }, align 4
@@ -1440,7 +1440,7 @@ void calling_function_with_default_arg() {
 
 // TODO(CIR): the difference between the CIR LLVM and OGCG is because the lack of calling convention lowering,
 
-// LLVM: %[[DEFAULT_ARG_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM: %[[DEFAULT_ARG_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM: store { float, float } { float 1.000000e+00, float 2.200000e+00 }, ptr %[[DEFAULT_ARG_ADDR]], align 4
 // LLVM: %[[TMP_DEFAULT_ARG:.*]] = load { float, float }, ptr %[[DEFAULT_ARG_ADDR]], align 4
 // LLVM: call void @_Z33function_with_complex_default_argCf({ float, float } {{.*}} %[[TMP_DEFAULT_ARG]])
@@ -1463,7 +1463,7 @@ void calling_function_that_return_complex() {
 
 // TODO(CIR): the difference between the CIR LLVM and OGCG is because the lack of calling convention lowering,
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM: %[[RESULT:.*]] = call noundef { float, float } @_Z24complex_type_return_typev()
 // LLVM: store { float, float } %[[RESULT]], ptr %[[A_ADDR]], align 4
 
@@ -1496,9 +1496,9 @@ void imag_literal_gnu_extension() {
 // CIR: %[[COMPLEX_C:.*]] = cir.const #cir.const_complex<#cir.int<0> : !s32i, #cir.int<3> : !s32i> : !cir.complex<!s32i>
 // CIR: cir.store{{.*}} %[[COMPLEX_C]], %[[C_ADDR]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca { double, double }, i64 1, align 8
-// LLVM: %[[C_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca { double, double }, align 8
+// LLVM: %[[C_ADDR:.*]] = alloca { i32, i32 }, align 4
 // LLVM: store { float, float } { float 0.000000e+00, float 3.000000e+00 }, ptr %[[A_ADDR]], align 4
 // LLVM: store { double, double } { double 0.000000e+00, double 3.000000e+00 }, ptr %[[B_ADDR]], align 8
 // LLVM: store { i32, i32 } { i32 0, i32 3 }, ptr %[[C_ADDR]], align 4
@@ -1538,10 +1538,10 @@ void load_store_volatile() {
 // CIR: %[[TMP_D:.*]] = cir.load volatile {{.*}} %[[D_ADDR]] : !cir.ptr<!cir.complex<!s32i>>, !cir.complex<!s32i>
 // CIR: cir.store volatile {{.*}} %[[TMP_D]], %[[C_ADDR]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { double, double }, i64 1, align 8
-// LLVM: %[[B_ADDR:.*]] = alloca { double, double }, i64 1, align 8
-// LLVM: %[[C_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
-// LLVM: %[[D_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { double, double }, align 8
+// LLVM: %[[B_ADDR:.*]] = alloca { double, double }, align 8
+// LLVM: %[[C_ADDR:.*]] = alloca { i32, i32 }, align 4
+// LLVM: %[[D_ADDR:.*]] = alloca { i32, i32 }, align 4
 // LLVM: %[[TMP_B:.*]] = load volatile { double, double }, ptr %[[B_ADDR]], align 8
 // LLVM: store volatile { double, double } %[[TMP_B]], ptr %[[A_ADDR]], align 8
 // LLVM: %[[TMP_D:.*]] = load volatile { i32, i32 }, ptr %[[D_ADDR]], align 4
@@ -1604,14 +1604,14 @@ void load_store_volatile_2() {
 // CIR: %[[TMP_D:.*]] = cir.load {{.*}} %[[D_ADDR]] : !cir.ptr<!cir.complex<!s32i>>, !cir.complex<!s32i>
 // CIR: cir.store volatile {{.*}} %[[TMP_D]], %[[DV_ADDR]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
 
-// LLVM: %[[AV_ADDR:.*]] = alloca { double, double }, i64 1, align 8
-// LLVM: %[[A_ADDR:.*]] = alloca { double, double }, i64 1, align 8
-// LLVM: %[[B_ADDR:.*]] = alloca { double, double }, i64 1, align 8
-// LLVM: %[[BV_ADDR:.*]] = alloca { double, double }, i64 1, align 8
-// LLVM: %[[C_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
-// LLVM: %[[CV_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
-// LLVM: %[[DV_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
-// LLVM: %[[D_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
+// LLVM: %[[AV_ADDR:.*]] = alloca { double, double }, align 8
+// LLVM: %[[A_ADDR:.*]] = alloca { double, double }, align 8
+// LLVM: %[[B_ADDR:.*]] = alloca { double, double }, align 8
+// LLVM: %[[BV_ADDR:.*]] = alloca { double, double }, align 8
+// LLVM: %[[C_ADDR:.*]] = alloca { i32, i32 }, align 4
+// LLVM: %[[CV_ADDR:.*]] = alloca { i32, i32 }, align 4
+// LLVM: %[[DV_ADDR:.*]] = alloca { i32, i32 }, align 4
+// LLVM: %[[D_ADDR:.*]] = alloca { i32, i32 }, align 4
 // LLVM: %[[TMP_A:.*]] = load { double, double }, ptr %[[A_ADDR]], align 8
 // LLVM: store volatile { double, double } %[[TMP_A]], ptr %[[AV_ADDR]], align 8
 // LLVM: %[[TMP_BV:.*]] = load volatile { double, double }, ptr %[[BV_ADDR]], align 8
@@ -1872,9 +1872,9 @@ void compare_two_complex_bin_ops() {
 // CIR: %[[RESULT:.*]] = cir.cmp ne %[[COMPLEX_AB]], %[[COMPLEX_BA]] : !cir.complex<!cir.double>
 // CIR: cir.store {{.*}} %[[RESULT]], %[[C_ADDR]] : !cir.bool, !cir.ptr<!cir.bool>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { double, double }, i64 1, align 8
-// LLVM: %[[B_ADDR:.*]] = alloca { double, double }, i64 1, align 8
-// LLVM: %[[C_ADDR:.*]] = alloca i8, i64 1, align 1
+// LLVM: %[[A_ADDR:.*]] = alloca { double, double }, align 8
+// LLVM: %[[B_ADDR:.*]] = alloca { double, double }, align 8
+// LLVM: %[[C_ADDR:.*]] = alloca i8, align 1
 // LLVM: %[[TMP_A:.*]] = load { double, double }, ptr %[[A_ADDR]], align 8
 // LLVM: %[[TMP_B:.*]] = load { double, double }, ptr %[[B_ADDR]], align 8
 // LLVM: %[[A_REAL:.*]] = extractvalue { double, double } %[[TMP_A]], 0

--- a/clang/test/CIR/CodeGen/compound_literal.cpp
+++ b/clang/test/CIR/CodeGen/compound_literal.cpp
@@ -25,9 +25,9 @@ int foo() {
 // CIR: %[[TMP_3:.*]] = cir.load %[[RET]] : !cir.ptr<!s32i>, !s32i
 // CIR: cir.return %[[TMP_3]] : !s32i
 
-// LLVM: %[[RET:.*]] = alloca i32, i64 1, align 4
-// LLVM: %[[INIT:.*]] = alloca i32, i64 1, align 4
-// LLVM: %[[COMPOUND:.*]] = alloca i32, i64 1, align 4
+// LLVM: %[[RET:.*]] = alloca i32, align 4
+// LLVM: %[[INIT:.*]] = alloca i32, align 4
+// LLVM: %[[COMPOUND:.*]] = alloca i32, align 4
 // LLVM: store i32 1, ptr %[[COMPOUND]], align 4
 // LLVM: %[[TMP:.*]] = load i32, ptr %[[COMPOUND]], align 4
 // LLVM: store i32 %[[TMP]], ptr %[[INIT]], align 4
@@ -55,8 +55,8 @@ void foo2() {
 // CIR: %[[TMP:.*]] = cir.load{{.*}} %[[CL_ADDR]] : !cir.ptr<!cir.complex<!s32i>>, !cir.complex<!s32i>
 // CIR: cir.store{{.*}} %[[TMP]], %[[A_ADDR]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
 
-// LLVM:  %[[A_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
-// LLVM: %[[CL_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
+// LLVM:  %[[A_ADDR:.*]] = alloca { i32, i32 }, align 4
+// LLVM: %[[CL_ADDR:.*]] = alloca { i32, i32 }, align 4
 // LLVM: store { i32, i32 } { i32 1, i32 2 }, ptr %[[CL_ADDR]], align 4
 // LLVM: %[[TMP:.*]] = load { i32, i32 }, ptr %[[CL_ADDR]], align 4
 // LLVM: store { i32, i32 } %[[TMP]], ptr %[[A_ADDR]], align 4
@@ -85,7 +85,7 @@ void foo3() {
 // CIR: %[[VEC:.*]] = cir.const #cir.const_vector<[#cir.int<10> : !s32i, #cir.int<20> : !s32i, #cir.int<30> : !s32i, #cir.int<40> : !s32i]> : !cir.vector<4 x !s32i>
 // CIR: cir.store{{.*}} %[[VEC]], %[[A_ADDR]] : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, align 16
 // LLVM: store <4 x i32> <i32 10, i32 20, i32 30, i32 40>, ptr %[[A_ADDR]], align 16
 
 // FIXME: OGCG emits a temporary compound literal in this case because it omits

--- a/clang/test/CIR/CodeGen/concept-specialization.cpp
+++ b/clang/test/CIR/CodeGen/concept-specialization.cpp
@@ -14,7 +14,7 @@ void concept_specialization() { bool a = C<int>; }
 // CIR: %[[CONST_TRUE:.*]] = cir.const #true
 // CIR: cir.store {{.*}} %[[CONST_TRUE]], %[[A_ADDR]] : !cir.bool, !cir.ptr<!cir.bool>
 
-// LLVM: %[[A_ADDR:.*]] = alloca i8, i64 1, align 1
+// LLVM: %[[A_ADDR:.*]] = alloca i8, align 1
 // LLVM: store i8 1, ptr %[[A_ADDR]], align 1
 
 // OGCG: %[[A_ADDR:.*]] = alloca i8, align 1

--- a/clang/test/CIR/CodeGen/constant-expr.cpp
+++ b/clang/test/CIR/CodeGen/constant-expr.cpp
@@ -26,9 +26,9 @@ void calling_consteval_methods() {
 // CIR: %[[CONST_COMPLEX:.*]] = cir.const #cir.const_complex<#cir.int<1> : !s32i, #cir.int<2> : !s32i> : !cir.complex<!s32i>
 // CIR: cir.store {{.*}} %[[CONST_COMPLEX]], %[[C_ADDR]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca %struct.StructWithConstEval, i64 1, align 1
-// LLVM: %[[B_ADDR:.*]] = alloca i32, i64 1, align 4
-// LLVM: %[[C_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca %struct.StructWithConstEval, align 1
+// LLVM: %[[B_ADDR:.*]] = alloca i32, align 4
+// LLVM: %[[C_ADDR:.*]] = alloca { i32, i32 }, align 4
 // LLVM: store i32 1, ptr %[[B_ADDR]], align 4
 // LLVM: store { i32, i32 } { i32 1, i32 2 }, ptr %[[C_ADDR]], align 4
 

--- a/clang/test/CIR/CodeGen/count-of.c
+++ b/clang/test/CIR/CodeGen/count-of.c
@@ -17,8 +17,8 @@ unsigned long vla_with_array_element_type_with_const_size() {
 // CIR: %[[RET_VAL:.*]] = cir.load %[[RET_ADDR]] : !cir.ptr<!u64i>, !u64i
 // CIR: cir.return %[[RET_VAL]] : !u64i
 
-// LLVM: %[[RET_ADDR:.*]] = alloca i64, i64 1, align 8
-// LLVM: %[[SIZE_ADDR:.*]] = alloca i64, i64 1, align 8
+// LLVM: %[[RET_ADDR:.*]] = alloca i64, align 8
+// LLVM: %[[SIZE_ADDR:.*]] = alloca i64, align 8
 // LLVM: store i64 5, ptr %[[RET_ADDR]], align 8
 // LLVM: %[[RET_VAL:.*]] = load i64, ptr %[[RET_ADDR]], align 8
 // LLVM: ret i64 %[[RET_VAL]]
@@ -39,8 +39,8 @@ unsigned long vla_with_array_element_type_non_const_size() {
 // CIR: %[[TMP_RET:.*]] = cir.load %[[RET_ADDR]] : !cir.ptr<!u64i>, !u64i
 // CIR: cir.return %[[TMP_RET]] : !u64i
 
-// LLVM: %[[RET_ADDR:.*]] = alloca i64, i64 1, align 8
-// LLVM: %[[SIZE_ADDR:.*]] = alloca i64, i64 1, align 8
+// LLVM: %[[RET_ADDR:.*]] = alloca i64, align 8
+// LLVM: %[[SIZE_ADDR:.*]] = alloca i64, align 8
 // LLVM: %[[TMP_SIZE:.*]] = load i64, ptr %[[SIZE_ADDR]], align 8
 // LLVM: store i64 %[[TMP_SIZE]], ptr %[[RET_ADDR]], align 8
 // LLVM: %[[TMP_RET:.*]] = load i64, ptr %[[RET_ADDR]], align 8

--- a/clang/test/CIR/CodeGen/ctor-alias.cpp
+++ b/clang/test/CIR/CodeGen/ctor-alias.cpp
@@ -42,7 +42,7 @@ void bar() {
 // CHECK:   cir.return
 
 // LLVM: define{{.*}} void @_Z3barv()
-// LLVM:   %[[B:.*]] = alloca %struct.B, i64 1, align 1
+// LLVM:   %[[B:.*]] = alloca %struct.B, align 1
 // LLVM:   call void @_ZN1BC1Ev(ptr{{.*}} %[[B]])
 // LLVM:   ret void
 

--- a/clang/test/CIR/CodeGen/cxx-conversion-operators.cpp
+++ b/clang/test/CIR/CodeGen/cxx-conversion-operators.cpp
@@ -63,8 +63,8 @@ void test() {
 // CIR: }
 
 // LLVM: define dso_local noundef i32 @_ZN20out_of_line_operatorcviEv(ptr {{.*}} %[[PARAM0:.+]])
-// LLVM:   %[[THIS_ALLOCA:.+]] = alloca ptr, i64 1
-// LLVM:   %[[RETVAL:.+]] = alloca i32, i64 1
+// LLVM:   %[[THIS_ALLOCA:.+]] = alloca ptr, 
+// LLVM:   %[[RETVAL:.+]] = alloca i32, 
 // LLVM:   store ptr %[[PARAM0]], ptr %[[THIS_ALLOCA]]
 // LLVM:   %[[THIS_LOAD:.+]] = load ptr, ptr %[[THIS_ALLOCA]]
 // LLVM:   store i32 123, ptr %[[RETVAL]]
@@ -73,8 +73,8 @@ void test() {
 // LLVM: }
 
 // LLVM: define linkonce_odr noundef i32 @_ZNK15inline_operatorcviEv(ptr {{.*}} %[[INLINE_PARAM0:.+]])
-// LLVM:   %[[INLINE_THIS_ALLOCA:.+]] = alloca ptr, i64 1
-// LLVM:   %[[INLINE_RETVAL:.+]] = alloca i32, i64 1
+// LLVM:   %[[INLINE_THIS_ALLOCA:.+]] = alloca ptr, 
+// LLVM:   %[[INLINE_RETVAL:.+]] = alloca i32, 
 // LLVM:   store ptr %[[INLINE_PARAM0]], ptr %[[INLINE_THIS_ALLOCA]]
 // LLVM:   %[[INLINE_THIS_LOAD:.+]] = load ptr, ptr %[[INLINE_THIS_ALLOCA]]
 // LLVM:   store i32 987, ptr %[[INLINE_RETVAL]]
@@ -83,9 +83,9 @@ void test() {
 // LLVM: }
 
 // LLVM: define {{.*}} void @_Z4testv()
-// LLVM:   %[[X_ALLOCA:.+]] = alloca i32, i64 1
-// LLVM:   %[[I_ALLOCA:.+]] = alloca {{.*}}, i64 1
-// LLVM:   %[[O_ALLOCA:.+]] = alloca {{.*}}, i64 1
+// LLVM:   %[[X_ALLOCA:.+]] = alloca i32, 
+// LLVM:   %[[I_ALLOCA:.+]] = alloca {{.*}}, 
+// LLVM:   %[[O_ALLOCA:.+]] = alloca {{.*}}, 
 // LLVM:   store i32 42, ptr %[[X_ALLOCA]]
 // LLVM:   %[[INLINE_CALL:.+]] = call noundef i32 @_ZNK15inline_operatorcviEv(ptr {{.*}} %[[I_ALLOCA]])
 // LLVM:   store i32 %[[INLINE_CALL]], ptr %[[X_ALLOCA]]

--- a/clang/test/CIR/CodeGen/cxx-rewritten-binary-operator.cpp
+++ b/clang/test/CIR/CodeGen/cxx-rewritten-binary-operator.cpp
@@ -24,9 +24,9 @@ void cxx_rewritten_binary_operator_scalar_expr() {
 // CIR: %[[NEQ:.*]] = cir.not %[[EQ]] : !cir.bool
 // CIR: cir.store{{.*}} %[[NEQ]], %[[NEQ_ADDR]] : !cir.bool, !cir.ptr<!cir.bool>
 
-// LLVM: %[[A_ADDR:.*]] = alloca %struct.HasOpEq, i64 1, align 1
-// LLVM: %[[B_ADDR:.*]] = alloca %struct.HasOpEq, i64 1, align 1
-// LLVM: %[[NEQ_ADDR:.*]] = alloca i8, i64 1, align 1
+// LLVM: %[[A_ADDR:.*]] = alloca %struct.HasOpEq, align 1
+// LLVM: %[[B_ADDR:.*]] = alloca %struct.HasOpEq, align 1
+// LLVM: %[[NEQ_ADDR:.*]] = alloca i8, align 1
 // LLVM: %[[EQ:.*]] = call {{.*}} i1 @_ZNK7HasOpEqeqERKS_(ptr {{.*}} %[[A_ADDR]], ptr {{.*}} %[[B_ADDR]])
 // LLVM: %[[NEQ_I1:.*]] = xor i1 %[[EQ]], true
 // LLVM: %[[NEQ:.*]] = zext i1 %[[NEQ_I1]] to i8
@@ -66,10 +66,10 @@ void cxx_rewritten_binary_operator_complex_expr() {
 
 // The difference between LLVM and OGCG is due to missing ABI lowering.
 
-// LLVM: %[[A_ADDR:.*]] = alloca %struct.ComplexItem, i64 1, align 1
-// LLVM: %[[B_ADDR:.*]] = alloca %struct.ComplexItem, i64 1, align 1
-// LLVM: %[[R_ADDR:.*]] = alloca { i32, i32 }, i64 1, align 4
-// LLVM: %[[TMP_ADDR:.*]] = alloca %struct.SpaceshipComplexResult, i64 1, align 1
+// LLVM: %[[A_ADDR:.*]] = alloca %struct.ComplexItem, align 1
+// LLVM: %[[B_ADDR:.*]] = alloca %struct.ComplexItem, align 1
+// LLVM: %[[R_ADDR:.*]] = alloca { i32, i32 }, align 4
+// LLVM: %[[TMP_ADDR:.*]] = alloca %struct.SpaceshipComplexResult, align 1
 // LLVM: %[[OP_RESULT:.*]] = call %struct.SpaceshipComplexResult @_ZNK11ComplexItemssERKS_(ptr noundef nonnull align 1 dereferenceable(1) %[[A_ADDR]], ptr noundef nonnull align 1 dereferenceable(1) %[[B_ADDR]])
 // LLVM: store %struct.SpaceshipComplexResult %[[OP_RESULT]], ptr %[[TMP_ADDR]], align 1
 // LLVM: %[[RESULT:.*]] = call noundef { i32, i32 } @_ZNK22SpaceshipComplexResultltEi(ptr noundef nonnull align 1 dereferenceable(1) %[[TMP_ADDR]], i32 noundef 0)
@@ -122,10 +122,10 @@ void cxx_rewritten_binary_operator_aggr_expr() {
 
 // The difference between LLVM and OGCG is due to missing ABI lowering.
 
-// LLVM: %[[A_ADDR:.*]] = alloca %struct.Item, i64 1, align 1
-// LLVM: %[[B_ADDR:.*]] = alloca %struct.Item, i64 1, align 1
-// LLVM: %[[R_ADDR:.*]] = alloca %struct.Result, i64 1, align 4
-// LLVM: %[[TMP_ADDR:.*]] = alloca %struct.SpaceshipResult, i64 1, align 1
+// LLVM: %[[A_ADDR:.*]] = alloca %struct.Item, align 1
+// LLVM: %[[B_ADDR:.*]] = alloca %struct.Item, align 1
+// LLVM: %[[R_ADDR:.*]] = alloca %struct.Result, align 4
+// LLVM: %[[TMP_ADDR:.*]] = alloca %struct.SpaceshipResult, align 1
 // LLVM: %[[OP_RESULT:.*]] = call %struct.SpaceshipResult @_ZNK4ItemssERKS_(ptr noundef nonnull align 1 dereferenceable(1) %[[A_ADDR]], ptr noundef nonnull align 1 dereferenceable(1) %[[B_ADDR]])
 // LLVM: store %struct.SpaceshipResult %[[OP_RESULT]], ptr %[[TMP_ADDR]], align 1
 // LLVM: %[[RESULT:.*]] = call %struct.Result @_ZNK15SpaceshipResultltEi(ptr noundef nonnull align 1 dereferenceable(1) %[[TMP_ADDR]], i32 noundef 0)

--- a/clang/test/CIR/CodeGen/cxx-traits.cpp
+++ b/clang/test/CIR/CodeGen/cxx-traits.cpp
@@ -13,7 +13,7 @@ void expression_trait_expr() {
 // CIR: %[[CONST_FALSE:.*]] = cir.const #false
 // CIR: cir.store {{.*}} %[[CONST_FALSE]], %[[A_ADDR]] : !cir.bool, !cir.ptr<!cir.bool>
 
-// LLVM: %[[A_ADDR:.*]] = alloca i8, i64 1, align 1
+// LLVM: %[[A_ADDR:.*]] = alloca i8, align 1
 // LLVM: store i8 0, ptr %[[A_ADDR]], align 1
 
 // OGCG: %[[A_ADDR:.*]] = alloca i8, align 1
@@ -40,10 +40,10 @@ void type_trait_expr() {
 // CIR: %[[CONST_FALSE:.*]] = cir.const #false
 // CIR: cir.store {{.*}} %[[CONST_FALSE]], %[[D_ADDR]] : !cir.bool, !cir.ptr<!cir.bool>
 
-// LLVM: %[[A_ADDR:.*]] = alloca i8, i64 1, align 1
-// LLVM: %[[B_ADDR:.*]] = alloca i8, i64 1, align 1
-// LLVM: %[[C_ADDR:.*]] = alloca i8, i64 1, align 1
-// LLVM: %[[D_ADDR:.*]] = alloca i8, i64 1, align 1
+// LLVM: %[[A_ADDR:.*]] = alloca i8, align 1
+// LLVM: %[[B_ADDR:.*]] = alloca i8, align 1
+// LLVM: %[[C_ADDR:.*]] = alloca i8, align 1
+// LLVM: %[[D_ADDR:.*]] = alloca i8, align 1
 // LLVM: store i8 1, ptr %[[A_ADDR]], align 1
 // LLVM: store i8 0, ptr %[[B_ADDR]], align 1
 // LLVM: store i8 0, ptr %[[C_ADDR]], align 1
@@ -70,8 +70,8 @@ void array_type_trait_expr() {
 // CIR: %[[CONST_20:.*]] = cir.const #cir.int<20> : !u64i
 // CIR: cir.store {{.*}} %[[CONST_20]], %[[B_ADDR]] : !u64i, !cir.ptr<!u64i>
 
-// LLVM: %[[A_ADDR:.*]] = alloca i64, i64 1, align 8
-// LLVM: %[[B_ADDR:.*]] = alloca i64, i64 1, align 8
+// LLVM: %[[A_ADDR:.*]] = alloca i64, align 8
+// LLVM: %[[B_ADDR:.*]] = alloca i64, align 8
 // LLVM: store i64 2, ptr %[[A_ADDR]], align 8
 // LLVM: store i64 20, ptr %[[B_ADDR]], align 8
 

--- a/clang/test/CIR/CodeGen/dtors.cpp
+++ b/clang/test/CIR/CodeGen/dtors.cpp
@@ -20,7 +20,7 @@ void test_temporary_dtor() {
 // CIR:   cir.call @_ZN1AD1Ev(%[[ALLOCA]]) nothrow : (!cir.ptr<!rec_A> {{.*}}) -> ()
 
 // LLVM: define dso_local void @_Z19test_temporary_dtorv(){{.*}}
-// LLVM:   %[[ALLOCA:.*]] = alloca %struct.A, i64 1, align 1
+// LLVM:   %[[ALLOCA:.*]] = alloca %struct.A, align 1
 // LLVM:   call void @_ZN1AD1Ev(ptr {{.*}} %[[ALLOCA]])
 
 // OGCG: define dso_local void @_Z19test_temporary_dtorv()

--- a/clang/test/CIR/CodeGen/embed-expr.c
+++ b/clang/test/CIR/CodeGen/embed-expr.c
@@ -19,7 +19,7 @@ void embed_expr_on_scalar_with_constants() {
 // CIR: %[[ARRAY:.*]] = cir.get_global @[[EMBED_A]] : !cir.ptr<!cir.array<!s32i x 3>>
 // CIR: cir.copy %[[ARRAY]] to %[[A_ADDR]] : !cir.ptr<!cir.array<!s32i x 3>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca [3 x i32], i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca [3 x i32], align 4
 // LLVM: call void @llvm.memcpy{{.*}}(ptr align 4 %[[A_ADDR]], ptr align 4 @[[EMBED_A:.*]], i64 12, i1 false)
 
 // OGCG: %[[A_ADDR:.*]] = alloca [3 x i32], align 4
@@ -48,8 +48,8 @@ void embed_expr_on_scalar_with_non_constants() {
 // CIR: %[[CONST_47:.*]] = cir.const #cir.int<47> : !s32i
 // CIR: cir.store {{.*}} %[[CONST_47]], %[[B_ELEM_2_PTR]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM: %[[A_ADDR:.*]] = alloca i32, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca [3 x i32], i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca i32, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca [3 x i32], align 4
 // LLVM: %[[B_ELEM_0_PTR:.*]] = getelementptr i32, ptr %[[B_ADDR]], i32 0
 // LLVM: %[[TMP_A:.*]] = load i32, ptr %[[A_ADDR]], align 4
 // LLVM: store i32 %[[TMP_A]], ptr %[[B_ELEM_0_PTR]], align 4

--- a/clang/test/CIR/CodeGen/empty-union.c
+++ b/clang/test/CIR/CodeGen/empty-union.c
@@ -20,7 +20,7 @@ void useEmpty() {
 // CIR: cir.func {{.*}}@useEmpty()
 // CIR:   cir.alloca "e" align(1) : !cir.ptr<!rec_Empty>
 // LLVM: define {{.*}} void @useEmpty()
-// LLVM:   alloca %union.Empty, i64 1, align 1
+// LLVM:   alloca %union.Empty, align 1
 // OGCG: define {{.*}} void @useEmpty()
 // OGCG:   alloca %union.Empty, align 1
 
@@ -30,6 +30,6 @@ void useEmptyAligned() {
 // CIR: cir.func {{.*}}@useEmptyAligned()
 // CIR:   cir.alloca "e" align(16) : !cir.ptr<!rec_EmptyAligned>
 // LLVM: define {{.*}} void @useEmptyAligned()
-// LLVM:   alloca %union.EmptyAligned, i64 1, align 16
+// LLVM:   alloca %union.EmptyAligned, align 16
 // OGCG: define {{.*}} void @useEmptyAligned()
 // OGCG:   alloca %union.EmptyAligned, align 16

--- a/clang/test/CIR/CodeGen/fixed-point-literal.c
+++ b/clang/test/CIR/CodeGen/fixed-point-literal.c
@@ -129,11 +129,11 @@ void test_sat_short_accum() {
   // OGCG: void @test_sat_short_accum
   _Sat short _Accum ssa;
   // CIR:  cir.alloca "ssa" {{.*}} : !cir.ptr<!s16i>
-  // LLVM: alloca i16, i64 1, align 2
+  // LLVM: alloca i16, align 2
   // OGCG: alloca i16, align 2
   _Sat unsigned short _Accum susa;
   // CIR:  cir.alloca "susa" {{.*}} : !cir.ptr<!u16i>
-  // LLVM: alloca i16, i64 1, align 2
+  // LLVM: alloca i16, align 2
   // OGCG: alloca i16, align 2
 }
 
@@ -143,11 +143,11 @@ void test_sat_accum() {
   // OGCG: void @test_sat_accum
   _Sat _Accum sa;
   // CIR:  cir.alloca "sa" {{.*}} : !cir.ptr<!s32i>
-  // LLVM: alloca i32, i64 1, align 4
+  // LLVM: alloca i32, align 4
   // OGCG: alloca i32, align 4
   _Sat unsigned _Accum sua;
   // CIR:  cir.alloca "sua" {{.*}} : !cir.ptr<!u32i>
-  // LLVM: alloca i32, i64 1, align 4
+  // LLVM: alloca i32, align 4
   // OGCG: alloca i32, align 4
 }
 
@@ -157,11 +157,11 @@ void test_sat_long_accum() {
   // OGCG: void @test_sat_long_accum
   _Sat long _Accum sla;
   // CIR:  cir.alloca "sla" {{.*}} : !cir.ptr<!s64i>
-  // LLVM: alloca i64, i64 1, align 8
+  // LLVM: alloca i64, align 8
   // OGCG: alloca i64, align 8
   _Sat unsigned long _Accum sula;
   // CIR:  cir.alloca "sula" {{.*}} : !cir.ptr<!u64i>
-  // LLVM: alloca i64, i64 1, align 8
+  // LLVM: alloca i64, align 8
   // OGCG: alloca i64, align 8
 }
 
@@ -171,11 +171,11 @@ void test_sat_short_fract() {
   // OGCG: void @test_sat_short_fract
   _Sat short _Fract ssf;
   // CIR:  cir.alloca "ssf" {{.*}} : !cir.ptr<!s8i>
-  // LLVM: alloca i8, i64 1, align 1
+  // LLVM: alloca i8, align 1
   // OGCG: alloca i8, align 1
   _Sat unsigned short _Fract susf;
   // CIR:  cir.alloca "susf" {{.*}} : !cir.ptr<!u8i>
-  // LLVM: alloca i8, i64 1, align 1
+  // LLVM: alloca i8, align 1
   // OGCG: alloca i8, align 1
 }
 
@@ -185,11 +185,11 @@ void test_sat_fract() {
   // OGCG: void @test_sat_fract
   _Sat _Fract sf;
   // CIR:  cir.alloca "sf" {{.*}} : !cir.ptr<!s16i>
-  // LLVM: alloca i16, i64 1, align 2
+  // LLVM: alloca i16, align 2
   // OGCG: alloca i16, align 2
   _Sat unsigned _Fract suf;
   // CIR:  cir.alloca "suf" {{.*}} : !cir.ptr<!u16i>
-  // LLVM: alloca i16, i64 1, align 2
+  // LLVM: alloca i16, align 2
   // OGCG: alloca i16, align 2
 }
 
@@ -199,10 +199,10 @@ void test_sat_long_fract() {
   // OGCG: void @test_sat_long_fract
   _Sat long _Fract slf;
   // CIR:  cir.alloca "slf" {{.*}} : !cir.ptr<!s32i>
-  // LLVM: alloca i32, i64 1, align 4
+  // LLVM: alloca i32, align 4
   // OGCG: alloca i32, align 4
   _Sat unsigned long _Fract sulf;
   // CIR:  cir.alloca "sulf" {{.*}} : !cir.ptr<!u32i>
-  // LLVM: alloca i32, i64 1, align 4
+  // LLVM: alloca i32, align 4
   // OGCG: alloca i32, align 4
 }

--- a/clang/test/CIR/CodeGen/generic-selection.c
+++ b/clang/test/CIR/CodeGen/generic-selection.c
@@ -15,8 +15,8 @@ void foo() {
 // CIR: %[[RES_VAL:.*]] = cir.const #cir.int<3> : !s32i
 // CIR: cir.store{{.*}} %[[RES_VAL]], %[[RES]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM: %[[A:.*]] = alloca i32, i64 1, align 4
-// LLVM: %[[RES:.*]] = alloca i32, i64 1, align 4
+// LLVM: %[[A:.*]] = alloca i32, align 4
+// LLVM: %[[RES:.*]] = alloca i32, align 4
 // LLVM: store i32 3, ptr %[[RES]], align 4
 
 // OGCG: %[[A:.*]] = alloca i32, align 4

--- a/clang/test/CIR/CodeGen/global-init-coerced-return.cpp
+++ b/clang/test/CIR/CodeGen/global-init-coerced-return.cpp
@@ -21,7 +21,7 @@ Pair g = makePair();
 // CIR-NEXT:    cir.store %[[RET]], %[[COERCE]] : !rec_anon_struct, !cir.ptr<!rec_anon_struct>
 
 // LLVM-LABEL: define internal void @__cxx_global_var_init()
-// LLVM-NEXT:    %[[COERCE:.+]] = alloca { i64, i64 }, i64 1, align 8
+// LLVM-NEXT:    %[[COERCE:.+]] = alloca { i64, i64 }, align 8
 // LLVM-NEXT:    %[[RET:.+]] = call { i64, i64 } @_Z8makePairv()
 // LLVM-NEXT:    store { i64, i64 } %[[RET]], ptr %[[COERCE]], align 8
 

--- a/clang/test/CIR/CodeGen/gnu-null.cpp
+++ b/clang/test/CIR/CodeGen/gnu-null.cpp
@@ -17,8 +17,8 @@ void gnu_null_expr() {
 // CIR: %[[CONST_NULL:.*]] = cir.const #cir.ptr<null> : !cir.ptr<!s32i>
 // CIR: cir.store {{.*}} %[[CONST_NULL]], %[[B_ADDR]] : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca i64, i64 1, align 8
-// LLVM: %[[B_ADDR:.*]] = alloca ptr, i64 1, align 8
+// LLVM: %[[A_ADDR:.*]] = alloca i64, align 8
+// LLVM: %[[B_ADDR:.*]] = alloca ptr, align 8
 // LLVM: store i64 0, ptr %[[A_ADDR]], align 8
 // LLVM: store ptr null, ptr %[[B_ADDR]], align 8
 

--- a/clang/test/CIR/CodeGen/if.cpp
+++ b/clang/test/CIR/CodeGen/if.cpp
@@ -85,8 +85,8 @@ void if1(int a) {
 // CIR: }
 
 // LLVM: define{{.*}} void @_Z3if1i(i32 noundef %0)
-// LLVM: %[[A:.*]] = alloca i32, i64 1, align 4
-// LLVM: %[[X:.*]] = alloca i32, i64 1, align 4
+// LLVM: %[[A:.*]] = alloca i32, align 4
+// LLVM: %[[X:.*]] = alloca i32, align 4
 // LLVM: store i32 %0, ptr %[[A]], align 4
 // LLVM: store i32 0, ptr %[[X]], align 4
 // LLVM: br label %[[ENTRY:.*]]
@@ -166,10 +166,10 @@ void if2(int a, bool b, bool c) {
 // CIR: }
 
 // LLVM: define{{.*}} void @_Z3if2ibb(i32 noundef %[[A:.*]], i1 noundef zeroext %[[B:.*]], i1 noundef zeroext %[[C:.*]])
-// LLVM:   %[[VARA:.*]] = alloca i32, i64 1, align 4
-// LLVM:   %[[VARB:.*]] = alloca i8, i64 1, align 1
-// LLVM:   %[[VARC:.*]] = alloca i8, i64 1, align 1
-// LLVM:   %[[VARX:.*]] = alloca i32, i64 1, align 4
+// LLVM:   %[[VARA:.*]] = alloca i32, align 4
+// LLVM:   %[[VARB:.*]] = alloca i8, align 1
+// LLVM:   %[[VARC:.*]] = alloca i8, align 1
+// LLVM:   %[[VARX:.*]] = alloca i32, align 4
 // LLVM:   store i32 %[[A]], ptr %[[VARA]], align 4
 // LLVM:   %[[B_EXT:.*]] = zext i1 %[[B]] to i8
 // LLVM:   store i8 %[[B_EXT]], ptr %[[VARB]], align 1
@@ -286,8 +286,8 @@ int if_init() {
 // CIR: }
 
 // LLVM: define{{.*}} i32 @_Z7if_initv()
-// LLVM: %[[X:.*]] = alloca i32, i64 1, align 4
-// LLVM: %[[RETVAL:.*]] = alloca i32, i64 1, align 4
+// LLVM: %[[X:.*]] = alloca i32, align 4
+// LLVM: %[[RETVAL:.*]] = alloca i32, align 4
 // LLVM: store i32 42, ptr %[[X]], align 4
 // LLVM: %[[X_VAL:.*]] = load i32, ptr %[[X]], align 4
 // LLVM: %[[COND:.*]] = icmp ne i32 %[[X_VAL]], 0

--- a/clang/test/CIR/CodeGen/implicit-value-init-expr.cpp
+++ b/clang/test/CIR/CodeGen/implicit-value-init-expr.cpp
@@ -20,7 +20,7 @@ void test(void *p) {
 // CIR-NEXT:    cir.store align(4) %[[P3]], %[[P2]] : !s32i, !cir.ptr<!s32i>
 
 // LLVM:    define{{.*}} void @_Z4testPv(ptr{{.*}} %[[ARG:.*]])
-// LLVM-NEXT:   %[[P:.*]] = alloca ptr, i64 1, align 8
+// LLVM-NEXT:   %[[P:.*]] = alloca ptr, align 8
 // LLVM-NEXT:   store ptr %[[ARG]], ptr %[[P]], align 8
 // LLVM-NEXT:   %[[P1:.*]] = load ptr, ptr %[[P]], align 8
 // LLVM-NEXT:   store i32 0, ptr %[[P1]], align 4

--- a/clang/test/CIR/CodeGen/initializer-list-two-pointers.cpp
+++ b/clang/test/CIR/CodeGen/initializer-list-two-pointers.cpp
@@ -38,8 +38,8 @@ void initalizer_list_with_two_pointers_layout() {
 // CIR: %[[ARR_END_PTR:.*]] = cir.cast bitcast %[[END_PTR]] : !cir.ptr<!cir.ptr<!s32i>> -> !cir.ptr<!cir.ptr<!cir.array<!s32i x 3>>>
 // CIR: cir.store {{.*}} %[[ARR_END]], %[[ARR_END_PTR]] : !cir.ptr<!cir.array<!s32i x 3>>, !cir.ptr<!cir.ptr<!cir.array<!s32i x 3>>>
 
-// LLVM: %[[ARR_ADDR:.*]] = alloca [3 x i32], i64 1, align 4
-// LLVM: %[[A_ADDR:.*]] = alloca %"class.std::initializer_list<int>", i64 1, align 8
+// LLVM: %[[ARR_ADDR:.*]] = alloca [3 x i32], align 4
+// LLVM: %[[A_ADDR:.*]] = alloca %"class.std::initializer_list<int>", align 8
 // LLVM: %[[ARR_ELEM_0_PTR:.*]] = getelementptr i32, ptr %[[ARR_ADDR]], i32 0
 // LLVM: store i32 10, ptr %[[ARR_ELEM_0_PTR]], align 4
 // LLVM: %[[ARR_ELEM_1_PTR:.*]] = getelementptr i32, ptr %[[ARR_ELEM_0_PTR]], i64 1

--- a/clang/test/CIR/CodeGen/inline-cxx-func.cpp
+++ b/clang/test/CIR/CodeGen/inline-cxx-func.cpp
@@ -29,8 +29,8 @@ struct S {
 // CIR:   cir.return %[[RET_VAL]] : !s32i
 
 // LLVM: define{{.*}} i32 @_ZN1S10InlineFuncEv(ptr{{.*}} %[[ARG0:.*]])
-// LLVM:   %[[THIS_ADDR:.*]] = alloca ptr, i64 1, align 8
-// LLVM:   %[[RET_ADDR:.*]] = alloca i32, i64 1, align 4
+// LLVM:   %[[THIS_ADDR:.*]] = alloca ptr, align 8
+// LLVM:   %[[RET_ADDR:.*]] = alloca i32, align 4
 // LLVM:   store ptr %[[ARG0]], ptr %[[THIS_ADDR]], align 8
 // LLVM:   %[[THIS:.*]] = load ptr, ptr %[[THIS_ADDR]], align 8
 // LLVM:   %[[MEMBER_ADDR:.*]] = getelementptr inbounds nuw %struct.S, ptr %[[THIS]], i32 0, i32 0

--- a/clang/test/CIR/CodeGen/instantiate-init.cpp
+++ b/clang/test/CIR/CodeGen/instantiate-init.cpp
@@ -60,10 +60,10 @@ void init_vec_using_initalizer_list() {
 // CIR:   cir.yield
 // CIR: }
 
-// LLVM:   %[[COERCE:.*]] = alloca %"class.std::initializer_list<int>", i64 1, align 8
-// LLVM:   %[[VEC_ADDR:.*]] = alloca %struct.Vector, i64 1, align 1
-// LLVM:   %[[AGG_ADDR:.*]] = alloca %"class.std::initializer_list<int>", i64 1, align 8
-// LLVM:   %[[INIT_LIST_ADDR:.*]] = alloca [3 x i32], i64 1, align 4
+// LLVM:   %[[COERCE:.*]] = alloca %"class.std::initializer_list<int>", align 8
+// LLVM:   %[[VEC_ADDR:.*]] = alloca %struct.Vector, align 1
+// LLVM:   %[[AGG_ADDR:.*]] = alloca %"class.std::initializer_list<int>", align 8
+// LLVM:   %[[INIT_LIST_ADDR:.*]] = alloca [3 x i32], align 4
 // LLVM:   %[[INIT_LIST_PTR:.*]] = getelementptr i32, ptr %[[INIT_LIST_ADDR]], i32 0
 // LLVM:   store i32 0, ptr %[[INIT_LIST_PTR]], align 4
 // LLVM:   %[[ELEM_1_PTR:.*]] = getelementptr i32, ptr %[[INIT_LIST_PTR]], i64 1

--- a/clang/test/CIR/CodeGen/kr-func-promote.c
+++ b/clang/test/CIR/CodeGen/kr-func-promote.c
@@ -13,7 +13,7 @@
 void foo(x) short x; {}
 
 // LLVM: define{{.*}} void @foo(i32 noundef %0)
-// LLVM:   %[[X_PTR:.*]] = alloca i16, i64 1, align 2
+// LLVM:   %[[X_PTR:.*]] = alloca i16, align 2
 // LLVM:   %[[X:.*]] = trunc i32 %0 to i16
 // LLVM:   store i16 %[[X]], ptr %[[X_PTR]], align 2
 
@@ -31,7 +31,7 @@ void foo(x) short x; {}
 void bar(f) float f; {}
 
 // LLVM: define{{.*}} void @bar(double noundef %0)
-// LLVM:   %[[F_PTR:.*]] = alloca float, i64 1, align 4
+// LLVM:   %[[F_PTR:.*]] = alloca float, align 4
 // LLVM:   %[[F:.*]] = fptrunc double %0 to float
 // LLVM:   store float %[[F]], ptr %[[F_PTR]], align 4
 

--- a/clang/test/CIR/CodeGen/label-values.c
+++ b/clang/test/CIR/CodeGen/label-values.c
@@ -21,7 +21,7 @@ LABEL_A:
 // CIR:    cir.return
 
 // LLVM: define dso_local void @A()
-// LLVM:   [[PTR:%.*]] = alloca ptr, i64 1, align 8
+// LLVM:   [[PTR:%.*]] = alloca ptr, align 8
 // LLVM:   store ptr blockaddress(@A, %[[LABEL_A:.*]]), ptr [[PTR]], align 8
 // LLVM:   [[BLOCKADD:%.*]] = load ptr, ptr [[PTR]], align 8
 // LLVM:   br label %[[indirectgoto:.*]]
@@ -59,7 +59,7 @@ LABEL_B:
 // CIR:    cir.indirect_goto [[BLOCKADD]] : !cir.ptr<!void>
 
 // LLVM: define dso_local void @B
-// LLVM:   %[[PTR:.*]] = alloca ptr, i64 1, align 8
+// LLVM:   %[[PTR:.*]] = alloca ptr, align 8
 // LLVM:   br label %[[LABEL_B:.*]]
 // LLVM: [[LABEL_B]]:
 // LLVM:   store ptr blockaddress(@B, %[[LABEL_B]]), ptr %[[PTR]], align 8
@@ -154,9 +154,9 @@ LABEL_A:
 // CIR:    cir.return
 
 // LLVM: define dso_local void @D
-// LLVM:   %[[PTR:.*]] = alloca ptr, i64 1, align 8
-// LLVM:   %[[PTR2:.*]] = alloca ptr, i64 1, align 8
-// LLVM:   %[[PTR3:.*]] = alloca ptr, i64 1, align 8
+// LLVM:   %[[PTR:.*]] = alloca ptr, align 8
+// LLVM:   %[[PTR2:.*]] = alloca ptr, align 8
+// LLVM:   %[[PTR3:.*]] = alloca ptr, align 8
 // LLVM:   store ptr blockaddress(@D, %[[LABEL_A:.*]]), ptr %[[PTR]], align 8
 // LLVM:   store ptr blockaddress(@D, %[[LABEL_A]]), ptr %[[PTR2]], align 8
 // LLVM:   %[[BLOCKADD:.*]] = load ptr, ptr %[[PTR2]], align 8

--- a/clang/test/CIR/CodeGen/label.c
+++ b/clang/test/CIR/CodeGen/label.c
@@ -185,7 +185,7 @@ void foo() {
 // CIR:     cir.label "label"
 
 // LLVM: define dso_local void @foo(){{.*}} {
-// LLVM:  %{{.*}} = alloca %struct.S, i64 1, align 1
+// LLVM:  %{{.*}} = alloca %struct.S, align 1
 // LLVM:  br label %2
 // LLVM:2:
 // LLVM:  br label %3

--- a/clang/test/CIR/CodeGen/lambda.cpp
+++ b/clang/test/CIR/CodeGen/lambda.cpp
@@ -64,7 +64,7 @@ void fn() {
 
 // FIXME: parameter attributes should be emitted
 // LLVM: define {{.*}} void @_Z2fnv()
-// LLVM:   [[A:%.*]] = alloca %[[REC_LAM_FN_A:.*]], i64 1, align 1
+// LLVM:   [[A:%.*]] = alloca %[[REC_LAM_FN_A:.*]], align 1
 // LLVM:   call void @"_ZZ2fnvENK3$_0clEv"(ptr {{.*}} [[A]])
 // LLVM:   ret void
 
@@ -172,7 +172,7 @@ auto g() {
 // CIR:   cir.return %[[RET]] : !cir.ptr<!void>
 
 // LLVM: define dso_local ptr @_Z1gv()
-// LLVM:   %[[COERCE:.*]] = alloca %[[REC_LAM_G:.*]], i64 1
+// LLVM:   %[[COERCE:.*]] = alloca %[[REC_LAM_G:.*]],
 // LLVM:   %[[RETVAL:.*]] = alloca %[[REC_LAM_G]]
 // LLVM:   %[[I:.*]] = alloca i32
 // LLVM:   store i32 12, ptr %[[I]]
@@ -218,7 +218,7 @@ auto g2() {
 // CIR:   cir.return %[[RET]] : !cir.ptr<!void>
 
 // LLVM: define dso_local ptr @_Z2g2v()
-// LLVM:   %[[COERCE:.*]] = alloca %[[REC_LAM_G:.*]], i64 1
+// LLVM:   %[[COERCE:.*]] = alloca %[[REC_LAM_G:.*]],
 // LLVM:   %[[RETVAL:.*]] = alloca %[[REC_LAM_G]]
 // LLVM:   %[[I:.*]] = alloca i32
 // LLVM:   store i32 12, ptr %[[I]]

--- a/clang/test/CIR/CodeGen/loop.cpp
+++ b/clang/test/CIR/CodeGen/loop.cpp
@@ -71,7 +71,7 @@ void l1() {
 // CIR-NEXT: }
 
 // LLVM: define{{.*}} void @_Z2l1v(){{.*}}
-// LLVM:   %[[I:.*]] = alloca i32, i64 1, align 4
+// LLVM:   %[[I:.*]] = alloca i32, align 4
 // LLVM:   br label %[[LABEL1:.*]]
 // LLVM: [[LABEL1]]:
 // LLVM:   store i32 0, ptr %[[I]], align 4
@@ -121,7 +121,7 @@ void l2() {
 // CIR-NEXT: }
 
 // LLVM: define{{.*}} void @_Z2l2v(){{.*}}
-// LLVM:   %[[I:.*]] = alloca i32, i64 1, align 4
+// LLVM:   %[[I:.*]] = alloca i32, align 4
 // LLVM:   br label %[[LABEL1:.*]]
 // LLVM: [[LABEL1]]:
 // LLVM:   br label %[[LABEL2:.*]]
@@ -169,7 +169,7 @@ void l3() {
 // CIR-NEXT: }
 
 // LLVM: define{{.*}} void @_Z2l3v(){{.*}}
-// LLVM:   %[[I:.*]] = alloca i32, i64 1, align 4
+// LLVM:   %[[I:.*]] = alloca i32, align 4
 // LLVM:   br label %[[LABEL1:.*]]
 // LLVM: [[LABEL1]]:
 // LLVM:   br label %[[LABEL2:.*]]
@@ -523,7 +523,7 @@ void unreachable_after_continue() {
 // CIR: }
 
 // LLVM: define{{.*}} void @_Z26unreachable_after_continuev(){{.*}}
-// LLVM:   %[[X:.*]] = alloca i32, i64 1, align 4
+// LLVM:   %[[X:.*]] = alloca i32, align 4
 // LLVM:   br label %[[LABEL1:.*]]
 // LLVM: [[LABEL1]]:
 // LLVM:   br label %[[LABEL2:.*]]
@@ -583,7 +583,7 @@ void unreachable_after_break() {
 // CIR: }
 
 // LLVM: define{{.*}} void @_Z23unreachable_after_breakv(){{.*}}
-// LLVM:   %[[X:.*]] = alloca i32, i64 1, align 4
+// LLVM:   %[[X:.*]] = alloca i32, align 4
 // LLVM:   br label %[[LABEL1:.*]]
 // LLVM: [[LABEL1]]:
 // LLVM:   br label %[[LABEL2:.*]]

--- a/clang/test/CIR/CodeGen/new.cpp
+++ b/clang/test/CIR/CodeGen/new.cpp
@@ -38,9 +38,9 @@ void test_basic_new() {
 // CHECK:   cir.return
 
 // LLVM: define{{.*}} void @_Z14test_basic_newv
-// LLVM:   %[[PS_ADDR:.*]] = alloca ptr, i64 1, align 8
-// LLVM:   %[[PN_ADDR:.*]] = alloca ptr, i64 1, align 8
-// LLVM:   %[[PD_ADDR:.*]] = alloca ptr, i64 1, align 8
+// LLVM:   %[[PS_ADDR:.*]] = alloca ptr, align 8
+// LLVM:   %[[PN_ADDR:.*]] = alloca ptr, align 8
+// LLVM:   %[[PD_ADDR:.*]] = alloca ptr, align 8
 // LLVM:   %[[NEW_S:.*]] = call{{.*}} ptr @_Znwm(i64 noundef 8)
 // LLVM:   store ptr %[[NEW_S]], ptr %[[PS_ADDR]], align 8
 // LLVM:   %[[NEW_INT:.*]] = call{{.*}} ptr @_Znwm(i64 noundef 4)
@@ -84,8 +84,8 @@ void test_new_with_init() {
 // CHECK:   cir.return
 
 // LLVM: define{{.*}} void @_Z18test_new_with_initv
-// LLVM:   %[[PN_ADDR:.*]] = alloca ptr, i64 1, align 8
-// LLVM:   %[[PD_ADDR:.*]] = alloca ptr, i64 1, align 8
+// LLVM:   %[[PN_ADDR:.*]] = alloca ptr, align 8
+// LLVM:   %[[PD_ADDR:.*]] = alloca ptr, align 8
 // LLVM:   %[[NEW_INT:.*]] = call{{.*}} ptr @_Znwm(i64 noundef 4)
 // LLVM:   store i32 2, ptr %[[NEW_INT]], align 4
 // LLVM:   store ptr %[[NEW_INT]], ptr %[[PN_ADDR]], align 8
@@ -135,8 +135,8 @@ void test_new_with_ctor() {
 // CHECK:   cir.return
 
 // LLVM: define{{.*}} void @_Z18test_new_with_ctorv
-// LLVM:   %[[PS2_ADDR:.*]] = alloca ptr, i64 1, align 8
-// LLVM:   %[[PS2_2_ADDR:.*]] = alloca ptr, i64 1, align 8
+// LLVM:   %[[PS2_ADDR:.*]] = alloca ptr, align 8
+// LLVM:   %[[PS2_2_ADDR:.*]] = alloca ptr, align 8
 // LLVM:   %[[NEW_S2:.*]] = call{{.*}} ptr @_Znwm(i64 noundef 8)
 // LLVM:   call{{.*}} void @_ZN2S2C1Ev(ptr {{.*}} %[[NEW_S2]])
 // LLVM:   store ptr %[[NEW_S2]], ptr %[[PS2_ADDR]], align 8
@@ -170,7 +170,7 @@ void test_new_with_complex_type() {
 // CHECK:   cir.store{{.*}} %[[COMPLEX_PTR]], %[[A_ADDR]] : !cir.ptr<!cir.complex<!cir.float>>, !cir.ptr<!cir.ptr<!cir.complex<!cir.float>>>
 
 // LLVM: define{{.*}} void @_Z26test_new_with_complex_typev
-// LLVM:   %[[A_ADDR:.*]] = alloca ptr, i64 1, align 8
+// LLVM:   %[[A_ADDR:.*]] = alloca ptr, align 8
 // LLVM:   %[[NEW_COMPLEX:.*]] = call noundef nonnull ptr @_Znwm(i64 noundef 8)
 // LLVM:   store { float, float } { float 1.000000e+00, float 2.000000e+00 }, ptr %[[NEW_COMPLEX]], align 8
 // LLVM:   store ptr %[[NEW_COMPLEX]], ptr %[[A_ADDR]], align 8
@@ -198,7 +198,7 @@ void t_new_constant_size() {
 // CHECK:  }
 
 // LLVM: define{{.*}} void @_Z19t_new_constant_sizev
-// LLVM:   %[[P_ADDR:.*]] = alloca ptr, i64 1, align 8
+// LLVM:   %[[P_ADDR:.*]] = alloca ptr, align 8
 // LLVM:   %[[CALL:.*]] = call noundef nonnull ptr @_Znam(i64 noundef 128)
 // LLVM:   store ptr %[[CALL]], ptr %[[P_ADDR]], align 8
 
@@ -233,7 +233,7 @@ void t_constant_size_nontrivial() {
 // CHECK:  }
 
 // LLVM: @_Z26t_constant_size_nontrivialv()
-// LLVM:   %[[ALLOCA:.*]] = alloca ptr, i64 1, align 8
+// LLVM:   %[[ALLOCA:.*]] = alloca ptr, align 8
 // LLVM:   %[[COOKIE_PTR:.*]] = call noundef nonnull ptr @_Znam(i64 noundef 11)
 // LLVM:   store i64 3, ptr %[[COOKIE_PTR]], align 8
 // LLVM:   %[[ALLOCATED_PTR:.*]] = getelementptr i8, ptr %[[COOKIE_PTR]], i64 8
@@ -273,7 +273,7 @@ void t_constant_size_nontrivial2() {
 // CHECK:  }
 
 // LLVM: @_Z27t_constant_size_nontrivial2v()
-// LLVM:   %[[ALLOCA:.*]] = alloca ptr, i64 1, align 8
+// LLVM:   %[[ALLOCA:.*]] = alloca ptr, align 8
 // LLVM:   %[[COOKIE_PTR:.*]] = call noundef nonnull ptr @_Znam(i64 noundef 20)
 // LLVM:   store i64 3, ptr %[[COOKIE_PTR]], align 8
 // LLVM:   %[[ALLOCATED_PTR:.*]] = getelementptr i8, ptr %[[COOKIE_PTR]], i64 8
@@ -307,7 +307,7 @@ void t_align16_nontrivial() {
 // CHECK:  }
 
 // LLVM: @_Z20t_align16_nontrivialv()
-// LLVM:   %[[ALLOCA:.*]] = alloca ptr, i64 1, align 8
+// LLVM:   %[[ALLOCA:.*]] = alloca ptr, align 8
 // LLVM:   %[[RAW_PTR:.*]] = call noundef nonnull ptr @_Znam(i64 noundef 48)
 // LLVM:   %[[COOKIE_PTR:.*]] = getelementptr i8, ptr %[[RAW_PTR]], i64 8
 // LLVM:   store i64 2, ptr %[[COOKIE_PTR]], align 8
@@ -336,7 +336,7 @@ void t_new_multidim_constant_size() {
 // CHECK:  }
 
 // LLVM: define{{.*}} void @_Z28t_new_multidim_constant_sizev
-// LLVM:   %[[P_ADDR:.*]] = alloca ptr, i64 1, align 8
+// LLVM:   %[[P_ADDR:.*]] = alloca ptr, align 8
 // LLVM:   %[[CALL:.*]] = call noundef nonnull ptr @_Znam(i64 noundef 192)
 // LLVM:   store ptr %[[CALL]], ptr %[[P_ADDR]], align 8
 
@@ -773,11 +773,11 @@ void test_array_new_with_ctor_init() {
 // CHECK:    cir.return
 
 // LLVM: define{{.*}} void @_Z29test_array_new_with_ctor_initv
-// LLVM:   %[[P_ADDR:.*]] = alloca ptr, i64 1, align 8
+// LLVM:   %[[P_ADDR:.*]] = alloca ptr, align 8
 // LLVM:   %[[RAW_PTR:.*]] = call noundef nonnull ptr @_Znam(i64 noundef 3)
 // LLVM:   %[[BEGIN:.*]] = getelementptr %class.F, ptr %[[RAW_PTR]], i32 0
 // LLVM:   %[[ARRAY_END:.*]] = getelementptr %class.F, ptr %[[BEGIN]], i64 3
-// LLVM:   %[[IDX_ADDR:.*]] = alloca ptr, i64 1, align 1
+// LLVM:   %[[IDX_ADDR:.*]] = alloca ptr, align 1
 // LLVM:   store ptr %[[BEGIN]], ptr %[[IDX_ADDR]], align 8
 // LLVM:   br label
 // LLVM:   %[[CUR2:.*]] = load ptr, ptr %[[IDX_ADDR]], align 8
@@ -1163,7 +1163,7 @@ void test_array_new_with_ctor_partial_init_list() {
 // CHECK:    cir.return
 
 // LLVM: define{{.*}} void @_Z42test_array_new_with_ctor_partial_init_listv
-// LLVM:   %[[P_ADDR:.*]] = alloca ptr, i64 1, align 8
+// LLVM:   %[[P_ADDR:.*]] = alloca ptr, align 8
 // LLVM:   %[[RAW_PTR:.*]] = call noundef nonnull ptr @_Znam(i64 noundef 8)
 // LLVM:   call void @_ZN1GC1Ei(ptr noundef nonnull align 1 dereferenceable(1) %[[RAW_PTR]], i32 noundef 1)
 // LLVM:   %[[SECOND:.*]] = getelementptr %class.G, ptr %[[RAW_PTR]], i64 1
@@ -1171,7 +1171,7 @@ void test_array_new_with_ctor_partial_init_list() {
 // LLVM:   %[[THIRD:.*]] = getelementptr %class.G, ptr %[[SECOND]], i64 1
 // LLVM:   %[[ARRAY_BEGIN:.*]] = getelementptr %class.G, ptr %[[THIRD]], i32 0
 // LLVM:   %[[ARRAY_END:.*]] = getelementptr %class.G, ptr %[[ARRAY_BEGIN]], i64 6
-// LLVM:   %[[IDX_ADDR:.*]] = alloca ptr, i64 1, align 1
+// LLVM:   %[[IDX_ADDR:.*]] = alloca ptr, align 1
 // LLVM:   store ptr %[[ARRAY_BEGIN]], ptr %[[IDX_ADDR]], align 8
 // LLVM:   br label
 // LLVM:   %[[CUR2:.*]] = load ptr, ptr %[[IDX_ADDR]], align 8

--- a/clang/test/CIR/CodeGen/noexcept.cpp
+++ b/clang/test/CIR/CodeGen/noexcept.cpp
@@ -25,9 +25,9 @@ void no_except() {
 // CIR: %[[CONST_TRUE:.*]] = cir.const #true
 // CIR: cir.store {{.*}} %[[CONST_TRUE]], %[[C_ADDR]] : !cir.bool, !cir.ptr<!cir.bool>
 
-// LLVM: %[[A_ADDR:.*]] = alloca i8, i64 1, align 1
-// LLVM: %[[B_ADDR:.*]] = alloca i8, i64 1, align 1
-// LLVM: %[[C_ADDR:.*]] = alloca i8, i64 1, align 1
+// LLVM: %[[A_ADDR:.*]] = alloca i8, align 1
+// LLVM: %[[B_ADDR:.*]] = alloca i8, align 1
+// LLVM: %[[C_ADDR:.*]] = alloca i8, align 1
 // LLVM: store i8 1, ptr %[[A_ADDR]], align 1
 // LLVM: store i8 0, ptr %[[B_ADDR]], align 1
 // LLVM: store i8 1, ptr %[[C_ADDR]], align 1

--- a/clang/test/CIR/CodeGen/non-type-template-param.cpp
+++ b/clang/test/CIR/CodeGen/non-type-template-param.cpp
@@ -16,7 +16,7 @@ void template_foo() {
 // CIR: %[[ADD:.*]] = cir.add nsw %[[CONST_1]], %[[CONST_2]] : !s32i
 // CIR: cir.store{{.*}} %[[ADD]], %[[INIT]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM: %[[INIT:.*]] = alloca i32, i64 1, align 4
+// LLVM: %[[INIT:.*]] = alloca i32, align 4
 // LLVM: store i32 6, ptr %[[INIT]], align 4
 
 // OGCG: %[[INIT:.*]] = alloca i32, align 4

--- a/clang/test/CIR/CodeGen/nullptr-init.cpp
+++ b/clang/test/CIR/CodeGen/nullptr-init.cpp
@@ -25,9 +25,9 @@ void t1() {
 // CIR-NEXT: }
 
 // LLVM:      define{{.*}} @_Z2t1v()
-// LLVM-NEXT:     %[[P1:.*]] = alloca ptr, i64 1, align 8
-// LLVM-NEXT:     %[[P2:.*]] = alloca ptr, i64 1, align 8
-// LLVM-NEXT:     %[[P3:.*]] = alloca ptr, i64 1, align 8
+// LLVM-NEXT:     %[[P1:.*]] = alloca ptr, align 8
+// LLVM-NEXT:     %[[P2:.*]] = alloca ptr, align 8
+// LLVM-NEXT:     %[[P3:.*]] = alloca ptr, align 8
 // LLVM-NEXT:     store ptr null, ptr %[[P1]], align 8
 // LLVM-NEXT:     store ptr null, ptr %[[P2]], align 8
 // LLVM-NEXT:     store ptr null, ptr %[[P3]], align 8

--- a/clang/test/CIR/CodeGen/opaque.c
+++ b/clang/test/CIR/CodeGen/opaque.c
@@ -29,9 +29,9 @@ void foo2() {
 // CIR: }) : (!cir.bool) -> !cir.complex<!cir.float>
 // CIR: cir.store{{.*}} %[[RESULT]], %[[C_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM: %[[C_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM: %[[C_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM: %[[TMP_A:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM: %[[A_REAL:.*]] = extractvalue { float, float } %[[TMP_A]], 0
 // LLVM: %[[A_IMAG:.*]] = extractvalue { float, float } %[[TMP_A]], 1

--- a/clang/test/CIR/CodeGen/opaque.cpp
+++ b/clang/test/CIR/CodeGen/opaque.cpp
@@ -15,8 +15,8 @@ void foo() {
 // CIR: %[[CONST_1:.*]] = cir.const #cir.int<1> : !s32i
 // CIR: cir.store{{.*}} %[[CONST_1]], %[[B_ADDR]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM: %[[A_ADDR:.*]] = alloca i32, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca i32, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca i32, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca i32, align 4
 // LLVM: store i32 1, ptr %[[B_ADDR]], align 4
 
 // OGCG: %[[A_ADDR:.*]] = alloca i32, align 4
@@ -48,9 +48,9 @@ void foo2() {
 // CIR: }) : (!cir.bool) -> !cir.complex<!cir.float>
 // CIR: cir.store{{.*}} %[[RESULT]], %[[C_ADDR]] : !cir.complex<!cir.float>, !cir.ptr<!cir.complex<!cir.float>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM: %[[C_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM: %[[C_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM: %[[TMP_A:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4
 // LLVM: %[[A_REAL:.*]] = extractvalue { float, float } %[[TMP_A]], 0
 // LLVM: %[[A_IMAG:.*]] = extractvalue { float, float } %[[TMP_A]], 1
@@ -121,9 +121,9 @@ void foo3() {
 // CIR: }) : (!cir.bool) -> !s32i
 // CIR: cir.store{{.*}} %[[RESULT]], %[[C_ADDR]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM: %[[A_ADDR:.*]] = alloca i32, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca i32, i64 1, align 4
-// LLVM: %[[C_ADDR:.*]] = alloca i32, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca i32, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca i32, align 4
+// LLVM: %[[C_ADDR:.*]] = alloca i32, align 4
 // LLVM: %[[TMP_A:.*]] = load i32, ptr %[[A_ADDR]], align 4
 // LLVM: %[[COND:.*]] = icmp ne i32 %[[TMP_A]], 0
 // LLVM: br i1 %[[COND]], label %[[COND_TRUE:.*]], label %[[COND_FALSE:.*]]

--- a/clang/test/CIR/CodeGen/pack-indexing.cpp
+++ b/clang/test/CIR/CodeGen/pack-indexing.cpp
@@ -18,10 +18,10 @@ auto pack_indexing(auto... p) { return p...[0]; }
 // CIR: %[[TMP:.*]] = cir.load %[[RET_VAL]] : !cir.ptr<!s32i>, !s32i
 // CIR: cir.return %[[TMP]] : !s32i
 
-// LLVM: %[[P_0:.*]] = alloca i32, i64 1, align 4
-// LLVM: %[[P_1:.*]] = alloca i32, i64 1, align 4
-// LLVM: %[[P_2:.*]] = alloca i32, i64 1, align 4
-// LLVM: %[[RET_VAL:.*]] = alloca i32, i64 1, align 4
+// LLVM: %[[P_0:.*]] = alloca i32, align 4
+// LLVM: %[[P_1:.*]] = alloca i32, align 4
+// LLVM: %[[P_2:.*]] = alloca i32, align 4
+// LLVM: %[[RET_VAL:.*]] = alloca i32, align 4
 // LLVM: %[[RESULT:.*]] = load i32, ptr %[[P_0]], align 4
 // LLVM: store i32 %[[RESULT]], ptr %[[RET_VAL]], align 4
 // LLVM: %[[TMP:.*]] = load i32, ptr %[[RET_VAL]], align 4
@@ -41,7 +41,7 @@ int pack_indexing_scalar() { return pack_indexing(1, 2, 3); }
 // CIR: %[[TMP:.*]] = cir.load %[[RET_VAL]] : !cir.ptr<!s32i>, !s32i
 // CIR: cir.return %[[TMP]] : !s32i
 
-// LLVM: %[[RET_VAL:.*]] = alloca i32, i64 1, align 4
+// LLVM: %[[RET_VAL:.*]] = alloca i32, align 4
 // LLVM: %[[RESULT:.*]] = call noundef i32 @_Z13pack_indexingIJiiiEEDaDpT_(i32 noundef 1, i32 noundef 2, i32 noundef 3)
 // LLVM: store i32 %[[RESULT]], ptr %[[RET_VAL]], align 4
 // LLVM: %[[TMP:.*]] = load i32, ptr %[[RET_VAL]], align 4
@@ -71,9 +71,9 @@ float _Complex pack_indexing_complex() {
 // CIR:   cir.return %[[TMP_RET]] : !cir.complex<!cir.float>
 
 // LLVM: define {{.*}} { float, float } @_Z21pack_indexing_complexv()
-// LLVM:   %[[RET_VAL:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM:   %[[COMPLEX_0:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM:   %[[COMPLEX_1:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM:   %[[RET_VAL:.*]] = alloca { float, float }, align 4
+// LLVM:   %[[COMPLEX_0:.*]] = alloca { float, float }, align 4
+// LLVM:   %[[COMPLEX_1:.*]] = alloca { float, float }, align 4
 // LLVM:   store { float, float } { float 1.000000e+00, float 2.000000e+00 }, ptr %[[COMPLEX_0]], align 4
 // LLVM:   %[[TMP_COMPLEX_0:.*]] = load { float, float }, ptr %[[COMPLEX_0]], align 4
 // LLVM:   store { float, float } { float 3.000000e+00, float 4.000000e+00 }, ptr %[[COMPLEX_1]], align 4

--- a/clang/test/CIR/CodeGen/paren-init-list.cpp
+++ b/clang/test/CIR/CodeGen/paren-init-list.cpp
@@ -19,7 +19,7 @@ void cxx_paren_list_init_expr() { CompleteS a(1, 'a'); }
 // CIR: %[[CONST:.*]] = cir.get_global @[[PAREN_A]] : !cir.ptr<!rec_CompleteS>
 // CIR: cir.copy %[[CONST]] to %[[A_ADDR]]
 
-// LLVM: %[[A_ADDR:.*]] = alloca %struct.CompleteS, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca %struct.CompleteS, align 4
 // LLVM: call void @llvm.memcpy{{.*}}(ptr align 4 %[[A_ADDR]], ptr align 4 @[[PAREN_A]]
 
 // OGCG: %[[A_ADDR:.*]] = alloca %struct.CompleteS, align 4

--- a/clang/test/CIR/CodeGen/requires-expr.cpp
+++ b/clang/test/CIR/CodeGen/requires-expr.cpp
@@ -24,8 +24,8 @@ template <typename T> void summable(T a) {
 // CIR:   }
 // CIR: }
 
-// LLVM:   %[[B_ADDR:.*]] = alloca i32, i64 1, align 4
-// LLVM:   %[[A_ADDR:.*]] = alloca i32, i64 1, align 4
+// LLVM:   %[[B_ADDR:.*]] = alloca i32, align 4
+// LLVM:   %[[A_ADDR:.*]] = alloca i32, align 4
 // LLVM:   store i32 %[[ARG_A:.*]], ptr %[[A_ADDR]], align 4
 // LLVM:   br label %[[IF_COND:.*]]
 // LLVM: [[IF_COND]]:

--- a/clang/test/CIR/CodeGen/size-of-vla.cpp
+++ b/clang/test/CIR/CodeGen/size-of-vla.cpp
@@ -17,8 +17,8 @@ void vla_type_with_element_type_of_size_1() {
 // CIR: %[[TMP_N:.*]] = cir.load {{.*}} %[[N_ADDR]] : !cir.ptr<!u64i>, !u64i
 // CIR: cir.store {{.*}} %[[TMP_N]], %[[SIZE_ADDR]] : !u64i, !cir.ptr<!u64i>
 
-// LLVM: %[[N_ADDR:.*]] = alloca i64, i64 1, align 8
-// LLVM: %[[SIZE_ADDR:.*]] = alloca i64, i64 1, align 8
+// LLVM: %[[N_ADDR:.*]] = alloca i64, align 8
+// LLVM: %[[SIZE_ADDR:.*]] = alloca i64, align 8
 // LLVM: store i64 10, ptr %[[N_ADDR]], align 8
 // LLVM: %[[TMP_N:.*]] = load i64, ptr %[[N_ADDR]], align 8
 // LLVM: store i64 %[[TMP_N]], ptr %[[SIZE_ADDR]], align 8
@@ -43,8 +43,8 @@ void vla_type_with_element_type_int() {
 // CIR: %[[SIZE:.*]] = cir.mul nuw %[[CONST_4]], %[[TMP_N]] : !u64i
 // CIR: cir.store {{.*}} %[[SIZE]], %[[SIZE_ADDR]] : !u64i, !cir.ptr<!u64i>
 
-// LLVM: %[[N_ADDR:.*]] = alloca i64, i64 1, align 8
-// LLVM: %[[SIZE_ADDR:.*]] = alloca i64, i64 1, align 8
+// LLVM: %[[N_ADDR:.*]] = alloca i64, align 8
+// LLVM: %[[SIZE_ADDR:.*]] = alloca i64, align 8
 // LLVM: store i64 10, ptr %[[N_ADDR]], align 8
 // LLVM: %[[TMP_N:.*]] = load i64, ptr %[[N_ADDR]], align 8
 // LLVM: %[[SIZE:.*]] = mul nuw i64 4, %[[TMP_N]]
@@ -81,9 +81,9 @@ void vla_expr_element_type_of_size_1() {
 // CIR:   cir.yield
 // CIR: }
 
-// LLVM: %[[N_ADDR:.*]] = alloca i64, i64 1, align 8
-// LLVM: %[[SAVED_STACK_ADDR:.*]] = alloca ptr, i64 1, align 8
-// LLVM: %[[SIZE_ADDR:.*]] = alloca i64, i64 1, align 8
+// LLVM: %[[N_ADDR:.*]] = alloca i64, align 8
+// LLVM: %[[SAVED_STACK_ADDR:.*]] = alloca ptr, align 8
+// LLVM: %[[SIZE_ADDR:.*]] = alloca i64, align 8
 // LLVM: store i64 10, ptr %[[N_ADDR]], align 8
 // LLVM: %[[TMP_N:.*]] = load i64, ptr %[[N_ADDR]], align 8
 // LLVM: %[[STACK_SAVE:.*]] = call ptr @llvm.stacksave.p0()
@@ -135,9 +135,9 @@ void vla_expr_element_type_int() {
 // CIR:   cir.yield
 // CIR: }
 
-// LLVM: %[[N_ADDR:.*]] = alloca i64, i64 1, align 8
-// LLVM: %[[SAVED_STACK_ADDR:.*]] = alloca ptr, i64 1, align 8
-// LLVM: %[[SIZE_ADDR:.*]] = alloca i64, i64 1, align 8
+// LLVM: %[[N_ADDR:.*]] = alloca i64, align 8
+// LLVM: %[[SAVED_STACK_ADDR:.*]] = alloca ptr, align 8
+// LLVM: %[[SIZE_ADDR:.*]] = alloca i64, align 8
 // LLVM: store i64 10, ptr %[[N_ADDR]], align 8
 // LLVM: %[[TMP_N:.*]] = load i64, ptr %[[N_ADDR]], align 8
 // LLVM: %[[STACK_SAVE:.*]] = call ptr @llvm.stacksave.p0()

--- a/clang/test/CIR/CodeGen/source-loc.cpp
+++ b/clang/test/CIR/CodeGen/source-loc.cpp
@@ -76,8 +76,8 @@ void line_column() {
 // CIR: %[[CONST_20:.*]] = cir.const #cir.int<20> : !u32i
 // CIR: cir.store {{.*}} %[[CONST_20]], %[[B_ADDR]] : !u32i, !cir.ptr<!u32i>
 
-// LLVM: %[[A_ADDR:.*]] = alloca i32, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca i32, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca i32, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca i32, align 4
 // LLVM: store i32 68, ptr %[[A_ADDR]], align 4
 // LLVM: store i32 20, ptr %[[B_ADDR]], align 4
 
@@ -102,9 +102,9 @@ void function_file() {
 // CIR: %[[FILE_GV:.*]] = cir.const #cir.global_view<@".str.4"> : !cir.ptr<!s8i>
 // CIR: cir.store {{.*}} %[[FILE_GV]], %[[C_ADDR]] : !cir.ptr<!s8i>, !cir.ptr<!cir.ptr<!s8i>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca ptr, i64 1, align 8
-// LLVM: %[[B_ADDR:.*]] = alloca ptr, i64 1, align 8
-// LLVM: %[[C_ADDR:.*]] = alloca ptr, i64 1, align 8
+// LLVM: %[[A_ADDR:.*]] = alloca ptr, align 8
+// LLVM: %[[B_ADDR:.*]] = alloca ptr, align 8
+// LLVM: %[[C_ADDR:.*]] = alloca ptr, align 8
 // LLVM: store ptr @.str.3, ptr %[[A_ADDR]], align 8
 // LLVM: store ptr @.str, ptr %[[B_ADDR]], align 8
 // LLVM: store ptr @.str.4, ptr %[[C_ADDR]], align 8

--- a/clang/test/CIR/CodeGen/statement-exprs.c
+++ b/clang/test/CIR/CodeGen/statement-exprs.c
@@ -25,8 +25,8 @@ int f19(void) {
 // CIR:   cir.return %[[RES]] : !s32i
 
 // LLVM: define dso_local i32 @f19()
-// LLVM:   %[[VAR1:.+]] = alloca i32, i64 1
-// LLVM:   %[[VAR2:.+]] = alloca i32, i64 1
+// LLVM:   %[[VAR1:.+]] = alloca i32, 
+// LLVM:   %[[VAR2:.+]] = alloca i32, 
 // LLVM:   br label %[[LBL3:.+]]
 // LLVM: [[LBL3]]:
 // LLVM:     store i32 4, ptr %[[VAR2]]
@@ -103,13 +103,13 @@ int nested(void) {
 // CIR:   cir.return %[[FINAL_RES]] : !s32i
 
 // LLVM: define dso_local i32 @nested()
-// LLVM:   %[[VAR1:.+]] = alloca i32, i64 1
-// LLVM:   %[[VAR2:.+]] = alloca i32, i64 1
-// LLVM:   %[[VAR3:.+]] = alloca i32, i64 1
-// LLVM:   %[[VAR4:.+]] = alloca i32, i64 1
-// LLVM:   %[[VAR5:.+]] = alloca i32, i64 1
-// LLVM:   %[[VAR6:.+]] = alloca i32, i64 1
-// LLVM:   %[[VAR7:.+]] = alloca i32, i64 1
+// LLVM:   %[[VAR1:.+]] = alloca i32, 
+// LLVM:   %[[VAR2:.+]] = alloca i32, 
+// LLVM:   %[[VAR3:.+]] = alloca i32, 
+// LLVM:   %[[VAR4:.+]] = alloca i32, 
+// LLVM:   %[[VAR5:.+]] = alloca i32, 
+// LLVM:   %[[VAR6:.+]] = alloca i32, 
+// LLVM:   %[[VAR7:.+]] = alloca i32, 
 // LLVM:   br label %[[LBL8:.+]]
 // LLVM: [[LBL8]]:
 // LLVM:     store i32 123, ptr %[[VAR7]]
@@ -204,8 +204,8 @@ void test2() { ({int x = 3; x; }); }
 // CIR: %{{.+}} = cir.load{{.*}} %[[RETVAL]] : !cir.ptr<!s32i>, !s32i
 
 // LLVM: define dso_local void @test2()
-// LLVM:   %[[X:.+]] = alloca i32, i64 1
-// LLVM:   %[[TMP:.+]] = alloca i32, i64 1
+// LLVM:   %[[X:.+]] = alloca i32, 
+// LLVM:   %[[TMP:.+]] = alloca i32, 
 // LLVM:   br label %[[LBL3:.+]]
 // LLVM: [[LBL3]]:
 // LLVM:     store i32 3, ptr %[[X]]
@@ -245,10 +245,10 @@ int test3() { return ({ struct S s = {1}; s; }).x; }
 // CIR:   cir.return %[[RES]] : !s32i
 
 // LLVM: define dso_local i32 @test3()
-// LLVM:   %[[VAR1:.+]] = alloca %struct.S, i64 1
-// LLVM:   %[[VAR2:.+]] = alloca i32, i64 1
-// LLVM:   %[[VAR3:.+]] = alloca %struct.S, i64 1
-// LLVM:   %[[VAR4:.+]] = alloca %struct.S, i64 1
+// LLVM:   %[[VAR1:.+]] = alloca %struct.S, 
+// LLVM:   %[[VAR2:.+]] = alloca i32, 
+// LLVM:   %[[VAR3:.+]] = alloca %struct.S, 
+// LLVM:   %[[VAR4:.+]] = alloca %struct.S, 
 // LLVM:   br label %[[LBL5:.+]]
 // LLVM: [[LBL5]]:
 // LLVM:     call void @llvm.memcpy{{.*}}(ptr align 4 %[[VAR1]], ptr align 4 @[[TEST3_S]], i64 4, i1 false)

--- a/clang/test/CIR/CodeGen/stmt-expr.cpp
+++ b/clang/test/CIR/CodeGen/stmt-expr.cpp
@@ -32,9 +32,9 @@ void test1() {
 // CIR:   cir.return
 
 // LLVM: define dso_local void @_Z5test1v()
-// LLVM:   %[[A:.+]] = alloca %class.A, i64 1
-// LLVM:   %[[REF_TMP:.+]] = alloca %class.A, i64 1
-// LLVM:   %[[TMP:.+]] = alloca %class.A, i64 1
+// LLVM:   %[[A:.+]] = alloca %class.A, 
+// LLVM:   %[[REF_TMP:.+]] = alloca %class.A, 
+// LLVM:   %[[TMP:.+]] = alloca %class.A, 
 // LLVM:   br label %[[LBL4:.+]]
 // LLVM: [[LBL4]]:
 // LLVM:     call void @_ZN1AC2Ev(ptr {{.*}} %[[A]])
@@ -74,7 +74,7 @@ void cleanup() {
 // CIR:   cir.return
 
 // LLVM: define dso_local void @_Z7cleanupv()
-// LLVM:   %[[WD:.+]] = alloca %struct.with_dtor, i64 1
+// LLVM:   %[[WD:.+]] = alloca %struct.with_dtor, 
 // LLVM:   br label %[[LBL2:.+]]
 // LLVM: [[LBL2]]:
 // LLVM:     call void @_ZN9with_dtorD1Ev(ptr {{.*}} %[[WD]])
@@ -103,9 +103,9 @@ void gnu_statement_extension() {
 // CIR: %[[REAL:.*]] = cir.complex.real %[[TMP]] : !cir.complex<!cir.float> -> !cir.float
 // CIR: cir.store {{.*}} %[[REAL]], %[[B_ADDR]] : !cir.float, !cir.ptr<!cir.float>
 
-// LLVM:   %[[A_ADDR:.*]] = alloca { float, float }, i64 1, align 4
-// LLVM:   %[[B_ADDR:.*]] = alloca float, i64 1, align 4
-// LLVM:   %[[TMP_ADDR:.*]] = alloca { float, float }, i64 1, align 4
+// LLVM:   %[[A_ADDR:.*]] = alloca { float, float }, align 4
+// LLVM:   %[[B_ADDR:.*]] = alloca float, align 4
+// LLVM:   %[[TMP_ADDR:.*]] = alloca { float, float }, align 4
 // LLVM:   br label %[[LABEL_1:.*]]
 // LLVM: [[LABEL_1]]:
 // LLVM:   %[[TMP_A:.*]] = load { float, float }, ptr %[[A_ADDR]], align 4

--- a/clang/test/CIR/CodeGen/struct-init.cpp
+++ b/clang/test/CIR/CodeGen/struct-init.cpp
@@ -235,7 +235,7 @@ void cxx_default_init_with_struct_field() {
 // CIR: %[[METHOD_CALL:.*]] = cir.call @_ZZ34cxx_default_init_with_struct_fieldvEN6Parent4getAEv(%[[P_ADDR]]) : (!cir.ptr<!rec_Parent>{{.*}}) -> (!s32i {llvm.noundef})
 // CIR: cir.store{{.*}} %[[METHOD_CALL]], %[[P_ELEM_0_PTR]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM: %[[P_ADDR:.*]] = alloca %struct.Parent, i64 1, align 4
+// LLVM: %[[P_ADDR:.*]] = alloca %struct.Parent, align 4
 // LLVM: %[[P_ELEM_0_PTR:.*]] = getelementptr inbounds nuw %struct.Parent, ptr %[[P_ADDR]], i32 0, i32 0
 // LLVM: %[[METHOD_CALL:.*]] = call noundef i32 @_ZZ34cxx_default_init_with_struct_fieldvEN6Parent4getAEv(ptr {{.*}} %[[P_ADDR]])
 // LLVM: store i32 %[[METHOD_CALL]], ptr %[[P_ELEM_0_PTR]], align 4

--- a/clang/test/CIR/CodeGen/struct.c
+++ b/clang/test/CIR/CodeGen/struct.c
@@ -171,7 +171,7 @@ void f(void) {
 // CIR-NEXT:   cir.return
 
 // LLVM:      define{{.*}} void @f()
-// LLVM-NEXT:   %[[P:.*]] = alloca ptr, i64 1, align 8
+// LLVM-NEXT:   %[[P:.*]] = alloca ptr, align 8
 // LLVM-NEXT:   ret void
 
 // OGCG:      define{{.*}} void @f()
@@ -188,7 +188,7 @@ void f2(void) {
 // CIR-NEXT:   cir.return
 
 // LLVM:      define{{.*}} void @f2()
-// LLVM-NEXT:   %[[S:.*]] = alloca %struct.CompleteS, i64 1, align 4
+// LLVM-NEXT:   %[[S:.*]] = alloca %struct.CompleteS, align 4
 // LLVM-NEXT:   ret void
 
 // OGCG:      define{{.*}} void @f2()
@@ -217,8 +217,8 @@ char f3(int a) {
 // CIR-NEXT:   cir.return %[[RETVAL]]
 
 // LLVM:      define{{.*}} i8 @f3(i32{{.*}} %[[ARG_A:.*]])
-// LLVM-NEXT:   %[[A_ADDR:.*]] = alloca i32, i64 1, align 4
-// LLVM-NEXT:   %[[RETVAL_ADDR:.*]] = alloca i8, i64 1, align 1
+// LLVM-NEXT:   %[[A_ADDR:.*]] = alloca i32, align 4
+// LLVM-NEXT:   %[[RETVAL_ADDR:.*]] = alloca i8, align 1
 // LLVM-NEXT:   store i32 %[[ARG_A]], ptr %[[A_ADDR]], align 4
 // LLVM-NEXT:   %[[A_VAL:.*]] = load i32, ptr %[[A_ADDR]], align 4
 // LLVM-NEXT:   store i32 %[[A_VAL]], ptr @cs, align 4
@@ -259,9 +259,9 @@ char f4(int a, struct CompleteS *p) {
 // CIR-NEXT:   cir.return %[[RETVAL]]
 
 // LLVM:      define{{.*}} i8 @f4(i32{{.*}} %[[ARG_A:.*]], ptr{{.*}} %[[ARG_P:.*]])
-// LLVM-NEXT:   %[[A_ADDR:.*]] = alloca i32, i64 1, align 4
-// LLVM-NEXT:   %[[P_ADDR:.*]] = alloca ptr, i64 1, align 8
-// LLVM-NEXT:   %[[RETVAL_ADDR:.*]] = alloca i8, i64 1, align 1
+// LLVM-NEXT:   %[[A_ADDR:.*]] = alloca i32, align 4
+// LLVM-NEXT:   %[[P_ADDR:.*]] = alloca ptr, align 8
+// LLVM-NEXT:   %[[RETVAL_ADDR:.*]] = alloca i8, align 1
 // LLVM-NEXT:   store i32 %[[ARG_A]], ptr %[[A_ADDR]], align 4
 // LLVM-NEXT:   store ptr %[[ARG_P]], ptr %[[P_ADDR]], align 8
 // LLVM-NEXT:   %[[A_VAL:.*]] = load i32, ptr %[[A_ADDR]], align 4

--- a/clang/test/CIR/CodeGen/struct.cpp
+++ b/clang/test/CIR/CodeGen/struct.cpp
@@ -41,7 +41,7 @@ void f(void) {
 // CIR-NEXT:   cir.return
 
 // LLVM:      define{{.*}} void @_Z1fv()
-// LLVM-NEXT:   %[[P:.*]] = alloca ptr, i64 1, align 8
+// LLVM-NEXT:   %[[P:.*]] = alloca ptr, align 8
 // LLVM-NEXT:   ret void
 
 // OGCG:      define{{.*}} void @_Z1fv()
@@ -94,7 +94,7 @@ void f3() {
 // CIR:   %[[O_I_N:.*]] = cir.get_member %[[O_I]][0] {name = "n"}
 
 // LLVM: define{{.*}} void @_Z2f3v()
-// LLVM:   %[[O:.*]] = alloca %struct.Outer, i64 1, align 4
+// LLVM:   %[[O:.*]] = alloca %struct.Outer, align 4
 // LLVM:   %[[O_I:.*]] = getelementptr inbounds nuw %struct.Outer, ptr %[[O]], i32 0, i32 0
 // LLVM:   %[[O_I_N:.*]] = getelementptr inbounds nuw %struct.Inner, ptr %[[O_I]], i32 0, i32 0
 
@@ -121,8 +121,8 @@ void paren_expr() {
 // CIR:   cir.copy %[[A_ADDR]] align(4) to %[[B_ADDR]] align(4) : !cir.ptr<!rec_Point>
 
 // LLVM: define{{.*}} void @_Z10paren_exprv()
-// LLVM:   %[[A_ADDR:.*]] = alloca %struct.Point, i64 1, align 4
-// LLVM:   %[[B_ADDR:.*]] = alloca %struct.Point, i64 1, align 4
+// LLVM:   %[[A_ADDR:.*]] = alloca %struct.Point, align 4
+// LLVM:   %[[B_ADDR:.*]] = alloca %struct.Point, align 4
 // LLVM:   call void @llvm.memcpy{{.*}}(ptr align 4 %[[A_ADDR]], ptr align 4 @[[PAREN_A]]
 // LLVM:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %[[B_ADDR]], ptr align 4 %[[A_ADDR]], i64 8, i1 false)
 
@@ -145,9 +145,9 @@ void choose_expr() {
 // CIR:   cir.copy %[[A_ADDR]] align(4) to %[[C_ADDR]] align(4) : !cir.ptr<!rec_CompleteS>
 
 // LLVM: define{{.*}} void @_Z11choose_exprv()
-// LLVM:   %[[A_ADDR:.*]] = alloca %struct.CompleteS, i64 1, align 4
-// LLVM:   %[[B_ADDR:.*]] = alloca %struct.CompleteS, i64 1, align 4
-// LLVM:   %[[C_ADDR:.*]] = alloca %struct.CompleteS, i64 1, align 4
+// LLVM:   %[[A_ADDR:.*]] = alloca %struct.CompleteS, align 4
+// LLVM:   %[[B_ADDR:.*]] = alloca %struct.CompleteS, align 4
+// LLVM:   %[[C_ADDR:.*]] = alloca %struct.CompleteS, align 4
 // LLVM:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %[[C_ADDR]], ptr align 4 %[[A_ADDR]], i64 8, i1 false)
 
 // OGCG: define{{.*}} void @_Z11choose_exprv()
@@ -171,10 +171,10 @@ void generic_selection() {
 // CIR:   cir.copy %[[A_ADDR]] align(4) to %[[D_ADDR]] align(4) : !cir.ptr<!rec_CompleteS>
 
 // LLVM: define{{.*}} void @_Z17generic_selectionv()
-// LLVM:   %1 = alloca %struct.CompleteS, i64 1, align 4
-// LLVM:   %2 = alloca %struct.CompleteS, i64 1, align 4
-// LLVM:   %3 = alloca i32, i64 1, align 4
-// LLVM:   %4 = alloca %struct.CompleteS, i64 1, align 4
+// LLVM:   %1 = alloca %struct.CompleteS, align 4
+// LLVM:   %2 = alloca %struct.CompleteS, align 4
+// LLVM:   %3 = alloca i32, align 4
+// LLVM:   %4 = alloca %struct.CompleteS, align 4
 // LLVM:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %4, ptr align 4 %1, i64 8, i1 false)
 
 // OGCG: define{{.*}} void @_Z17generic_selectionv()
@@ -201,8 +201,8 @@ void designated_init_update_expr() {
 // CIR: cir.store{{.*}} %[[CONST_1]], %[[ELEM_0_PTR]] : !s32i, !cir.ptr<!s32i>
 // CIR: %[[ELEM_1_PTR:.*]] = cir.get_member %[[C_ADDR]][1] {name = "b"} : !cir.ptr<!rec_CompleteS> -> !cir.ptr<!s8i>
 
-// LLVM: %[[A_ADDR:.*]] = alloca %struct.CompleteS, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca %struct.Container, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca %struct.CompleteS, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca %struct.Container, align 4
 // LLVM: %[[C_ADDR:.*]] = getelementptr inbounds nuw %struct.Container, ptr %[[B_ADDR]], i32 0, i32 0
 // LLVM: call void @llvm.memcpy.p0.p0.i64(ptr align 4 %[[C_ADDR]], ptr align 4 %[[A_ADDR]], i64 8, i1 false)
 // LLVM: %[[ELEM_0_PTR:.*]] = getelementptr inbounds nuw %struct.CompleteS, ptr %[[C_ADDR]], i32 0, i32 0
@@ -232,7 +232,7 @@ void atomic_init() {
 // CIR:   cir.store{{.*}} %[[CONST_0]], %[[ELEM_1_PTR]] : !s8i, !cir.ptr<!s8i>
 
 // LLVM: define{{.*}} void @_Z11atomic_initv()
-// LLVM:   %[[A_ADDR:.*]] = alloca %struct.CompleteS, i64 1, align 8
+// LLVM:   %[[A_ADDR:.*]] = alloca %struct.CompleteS, align 8
 // LLVM:   %[[ELEM_0_PTR:.*]] = getelementptr inbounds nuw %struct.CompleteS, ptr %[[A_ADDR]], i32 0, i32 0
 // LLVM:   store i32 0, ptr %[[ELEM_0_PTR]], align 8
 // LLVM:   %[[ELEM_1_PTR:.*]] = getelementptr inbounds nuw %struct.CompleteS, ptr %[[A_ADDR]], i32 0, i32 1
@@ -253,7 +253,7 @@ void unary_extension() {
 // CIR: %[[ZERO_INIT:.*]] = cir.get_global @[[UNARY_A:.*]] : !cir.ptr<!rec_CompleteS>
 // CIR: cir.copy %[[ZERO_INIT]] to %[[A_ADDR]] : !cir.ptr<!rec_CompleteS>
 
-// LLVM: %[[A_ADDR:.*]] = alloca %struct.CompleteS, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca %struct.CompleteS, align 4
 // LLVM: call void @llvm.memcpy{{.*}}(ptr align 4 %[[A_ADDR]], ptr align 4 @[[UNARY_A:.*]]
 
 // OGCG: %[[A_ADDR:.*]] = alloca %struct.CompleteS, align 4
@@ -269,7 +269,7 @@ void bin_comma() {
 // CIR:   cir.copy %[[CONST]] to %[[A_ADDR]] : !cir.ptr<!rec_CompleteS>
 
 // LLVM: define{{.*}} void @_Z9bin_commav()
-// LLVM:   %[[A_ADDR:.*]] = alloca %struct.CompleteS, i64 1, align 4
+// LLVM:   %[[A_ADDR:.*]] = alloca %struct.CompleteS, align 4
 // LLVM:   call void @llvm.memcpy{{.*}}(ptr align 4 %[[A_ADDR]], ptr align 4 @[[COMMA_A:.*]]
 
 // OGCG: define{{.*}} void @_Z9bin_commav()
@@ -284,7 +284,7 @@ void compound_literal_expr() { CompleteS a = (CompleteS){}; }
 
 // TODO(cir): zero-initialize the padding
 
-// LLVM: %[[A_ADDR:.*]] = alloca %struct.CompleteS, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca %struct.CompleteS, align 4
 // LLVM: call void @llvm.memcpy{{.*}}(ptr align 4 %[[A_ADDR]], ptr align 4 @[[COMPLIT_A:.*]]
 
 // OGCG: %[[A_ADDR:.*]] = alloca %struct.CompleteS, align 4
@@ -308,8 +308,8 @@ void struct_with_const_member_expr() {
 
 // TODO(cir): zero-initialize the padding
 
-// LLVM:  %[[A_ADDR:.*]] = alloca i32, i64 1, align 4
-// LLVM:  %[[REF_ADDR:.*]] = alloca %struct.StructWithConstMember, i64 1, align 4
+// LLVM:  %[[A_ADDR:.*]] = alloca i32, align 4
+// LLVM:  %[[REF_ADDR:.*]] = alloca %struct.StructWithConstMember, align 4
 // LLVM:  %[[ELEM_0_PTR:.*]] = getelementptr inbounds nuw %struct.StructWithConstMember, ptr %[[REF_ADDR]], i32 0, i32 0
 // LLVM:  %[[TMP_REF:.*]] = load i8, ptr %[[ELEM_0_PTR]], align 4
 // LLVM:  %[[BF_CLEAR:.*]] = and i8 %[[TMP_REF]], -2
@@ -330,7 +330,7 @@ void function_arg_with_default_value(CompleteS a = {1, 2}) {}
 // CIR: %[[ARG_ADDR:.*]] = cir.alloca "a" {{.*}} init : !cir.ptr<!rec_CompleteS>
 // CIR: cir.store %{{.*}}, %[[ARG_ADDR]] : !rec_CompleteS, !cir.ptr<!rec_CompleteS>
 
-// LLVM: %[[ARG_ADDR:.*]] = alloca %struct.CompleteS, i64 1, align 4
+// LLVM: %[[ARG_ADDR:.*]] = alloca %struct.CompleteS, align 4
 // LLVM: store %struct.CompleteS %{{.*}}, ptr %[[ARG_ADDR]], align 4
 
 // OGCG: %[[ARG_ADDR:.*]] = alloca %struct.CompleteS, align 4
@@ -354,8 +354,8 @@ void calling_function_with_default_values() {
 // CIR: %[[ARG:.*]] = cir.load %[[COERCE_PTR]] : !cir.ptr<!u64i>, !u64i
 // CIR: cir.call @_Z31function_arg_with_default_value9CompleteS(%[[ARG]]) : (!u64i) -> ()
 
-// LLVM: %[[COERCE:.*]] = alloca %struct.CompleteS, i64 1, align 8
-// LLVM: %[[AGG_ADDR:.*]] = alloca %struct.CompleteS, i64 1, align 4
+// LLVM: %[[COERCE:.*]] = alloca %struct.CompleteS, align 8
+// LLVM: %[[AGG_ADDR:.*]] = alloca %struct.CompleteS, align 4
 // LLVM: %[[ELEM_0_PTR:.*]] = getelementptr inbounds nuw %struct.CompleteS, ptr %[[AGG_ADDR]], i32 0, i32 0
 // LLVM: store i32 1, ptr %[[ELEM_0_PTR]], align 4
 // LLVM: %[[ELEM_1_PTR:.*]] = getelementptr inbounds nuw %struct.CompleteS, ptr %[[AGG_ADDR]], i32 0, i32 1

--- a/clang/test/CIR/CodeGen/switch.cpp
+++ b/clang/test/CIR/CodeGen/switch.cpp
@@ -216,8 +216,8 @@ int sw4(int a) {
 // CIR-NEXT:  }
 
 // LLVM: define{{.*}} i32 @_Z3sw4i
-// LLVM:   %[[A_ADDR:.*]] = alloca i32, i64 1, align 4
-// LLVM:   %[[RET_ADDR:.*]] = alloca i32, i64 1, align 4
+// LLVM:   %[[A_ADDR:.*]] = alloca i32, align 4
+// LLVM:   %[[RET_ADDR:.*]] = alloca i32, align 4
 // LLVM:   br label %[[ENTRY:.*]]
 // LLVM: [[ENTRY]]:
 // LLVM:   %[[A_VAL:.*]] = load i32, ptr %[[A_ADDR]], align 4
@@ -272,7 +272,7 @@ void sw5(int a) {
 // CIR-NEXT:   }
 
 // LLVM-LABEL: define{{.*}} void @_Z3sw5i
-// LLVM:   %[[A_ADDR:.*]] = alloca i32, i64 1, align 4
+// LLVM:   %[[A_ADDR:.*]] = alloca i32, align 4
 // LLVM:   br label %[[ENTRY:.*]]
 // LLVM: [[ENTRY]]:
 // LLVM:   %[[A_VAL:.*]] = load i32, ptr %[[A_ADDR]], align 4
@@ -1082,9 +1082,9 @@ int nested_switch(int a) {
 // CIR:           cir.return
 
 // LLVM: define{{.*}} i32 @_Z13nested_switchi
-// LLVM:   %[[B_ADDR:.*]] = alloca i32, i64 1, align 4
-// LLVM:   %[[A_ADDR:.*]] = alloca i32, i64 1, align 4
-// LLVM:   %[[RES_ADDR:.*]] = alloca i32, i64 1, align 4
+// LLVM:   %[[B_ADDR:.*]] = alloca i32, align 4
+// LLVM:   %[[A_ADDR:.*]] = alloca i32, align 4
+// LLVM:   %[[RES_ADDR:.*]] = alloca i32, align 4
 // LLVM:   store i32 %[[ARG:.*]], ptr %[[A_ADDR]], align 4
 // LLVM:   br label %[[ENTRY:.*]]
 // LLVM: [[ENTRY]]:

--- a/clang/test/CIR/CodeGen/ternary-throw.cpp
+++ b/clang/test/CIR/CodeGen/ternary-throw.cpp
@@ -217,8 +217,8 @@ const int &test_cond_const_true_throw_true() {
 // CIR:   cir.return %[[TMP_RET]] : !cir.ptr<!s32i>
 
 // LLVM-LABEL: define{{.*}} ptr @_Z31test_cond_const_true_throw_truev(
-// LLVM:  %[[RET_ADDR:.*]] = alloca ptr, i64 1, align 8
-// LLVM:  %[[A_ADDR:.*]] = alloca i32, i64 1, align 4
+// LLVM:  %[[RET_ADDR:.*]] = alloca ptr, align 8
+// LLVM:  %[[A_ADDR:.*]] = alloca i32, align 4
 // LLVM:  store i32 30, ptr %[[A_ADDR]], align 4
 // LLVM:  %[[EXCEPTION:.*]] = call ptr @__cxa_allocate_exception(i64 4)
 // LLVM:  store i32 0, ptr %[[EXCEPTION]], align 16

--- a/clang/test/CIR/CodeGen/throws.cpp
+++ b/clang/test/CIR/CodeGen/throws.cpp
@@ -45,9 +45,9 @@ int rethrow_from_block(int a, int b) {
 // CIR:  %[[RESULT:.*]] = cir.load %[[RES_ADDR]] : !cir.ptr<!s32i>, !s32i
 // CIR:  cir.return %[[RESULT]] : !s32i
 
-// LLVM: %[[A_ADDR:.*]] = alloca i32, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca i32, i64 1, align 4
-// LLVM: %[[RES_ADDR:.*]] = alloca i32, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca i32, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca i32, align 4
+// LLVM: %[[RES_ADDR:.*]] = alloca i32, align 4
 // LLVM: store i32 %{{.*}}, ptr %[[A_ADDR]], align 4
 // LLVM: store i32 %{{.*}}, ptr %[[B_ADDR]], align 4
 // LLVM: br label %[[CHECK_COND:.*]]
@@ -156,7 +156,7 @@ void throw_vector_type() {
 // CIR: cir.throw %[[EXCEPTION_ADDR]] : !cir.ptr<!cir.vector<4 x !s32i>>, @_ZTIDv4_i
 // CIR: cir.unreachable
 
-// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, align 16
 // LLVM: %[[EXCEPTION_ADDR:.*]] = call ptr @__cxa_allocate_exception(i64 16)
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[A_ADDR]], align 16
 // LLVM: store <4 x i32> %[[TMP_A]], ptr %[[EXCEPTION_ADDR]], align 16
@@ -182,7 +182,7 @@ void throw_ext_vector_type() {
 // CIR: cir.throw %[[EXCEPTION_ADDR]] : !cir.ptr<!cir.vector<4 x !s32i>>, @_ZTIDv4_i
 // CIR: cir.unreachable
 
-// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, align 16
 // LLVM: %[[EXCEPTION_ADDR:.*]] = call ptr @__cxa_allocate_exception(i64 16)
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[A_ADDR]], align 16
 // LLVM: store <4 x i32> %[[TMP_A]], ptr %[[EXCEPTION_ADDR]], align 16

--- a/clang/test/CIR/CodeGen/try-catch.cpp
+++ b/clang/test/CIR/CodeGen/try-catch.cpp
@@ -56,7 +56,7 @@ void try_catch_with_empty_catch_all() {
 // CIR:   }
 // CIR: }
 
-// LLVM:   %[[A_ADDR:.*]] = alloca i32, i64 1, align 4
+// LLVM:   %[[A_ADDR:.*]] = alloca i32, align 4
 // LLVM:   store i32 1, ptr %[[A_ADDR]], align 4
 // LLVM:   br label %[[BB_2:.*]]
 // LLVM: [[BB_2]]:
@@ -98,7 +98,7 @@ void try_catch_with_empty_catch_all_2() {
 // CIR:   }
 // CIR: }
 
-// LLVM:   %[[A_ADDR]] = alloca i32, i64 1, align 4
+// LLVM:   %[[A_ADDR]] = alloca i32, align 4
 // LLVM:   store i32 1, ptr %[[A_ADDR]], align 4
 // LLVM:   br label %[[BB_2:.*]]
 // LLVM: [[BB_2]]:
@@ -143,9 +143,9 @@ void try_catch_with_alloca() {
 // CIR:   }
 // CIR: }
 
-// LLVM:  %[[A_ADDR:.*]] = alloca i32, i64 1, align 4
-// LLVM:  %[[B_ADDR:.*]] = alloca i32, i64 1, align 4
-// LLVM:  %[[C_ADDR:.*]] = alloca i32, i64 1, align 4
+// LLVM:  %[[A_ADDR:.*]] = alloca i32, align 4
+// LLVM:  %[[B_ADDR:.*]] = alloca i32, align 4
+// LLVM:  %[[C_ADDR:.*]] = alloca i32, align 4
 // LLVM:  br label %[[LABEL_1:.*]]
 // LLVM: [[LABEL_1]]:
 // LLVM:  br label %[[LABEL_2:.*]]
@@ -1376,9 +1376,9 @@ int init_catch_param_with_type_int() {
 // CIR:   cir.return %[[TMP_RET]] : !s32i
 
 // LLVM: define {{.*}} i32 @_Z30init_catch_param_with_type_intv() {{.*}} personality ptr @__gxx_personality_v0
-// LLVM:   %[[X_ADDR:.*]] = alloca i32, i64 1, align 4
-// LLVM:   %[[RET_ADDR:.*]] = alloca i32, i64 1, align 4
-// LLVM:   %[[RV_ADDR:.*]] = alloca i32, i64 1, align 4
+// LLVM:   %[[X_ADDR:.*]] = alloca i32, align 4
+// LLVM:   %[[RET_ADDR:.*]] = alloca i32, align 4
+// LLVM:   %[[RV_ADDR:.*]] = alloca i32, align 4
 // LLVM:   br label %[[TRY_SCOPE:.*]]
 // LLVM: [[TRY_SCOPE]]:
 // LLVM:   br label %[[TRY_BEGIN:.*]]
@@ -1518,9 +1518,9 @@ int init_catch_param_with_type_int_ptr() {
 // CIR:   cir.return %[[TMP_RET]] : !s32i
 
 // LLVM: define {{.*}} i32 @_Z34init_catch_param_with_type_int_ptrv() {{.*}} personality ptr @__gxx_personality_v0
-// LLVM:   %[[X_ADDR:.*]] = alloca ptr, i64 1, align 8
-// LLVM:   %[[RET_ADDR:.*]] = alloca i32, i64 1, align 4
-// LLVM:   %[[RV_ADDR:.*]] = alloca i32, i64 1, align 4
+// LLVM:   %[[X_ADDR:.*]] = alloca ptr, align 8
+// LLVM:   %[[RET_ADDR:.*]] = alloca i32, align 4
+// LLVM:   %[[RV_ADDR:.*]] = alloca i32, align 4
 // LLVM:   br label %[[TRY_SCOPE:.*]]
 // LLVM: [[TRY_SCOPE]]:
 // LLVM:   br label %[[TRY_BEGIN:.*]]
@@ -1661,9 +1661,9 @@ int init_catch_param_with_ref_to_ptr_to_non_record() {
 // CIR:   cir.return %[[TMP_RET]] : !s32i
 
 // LLVM: define {{.*}} i32 @_Z46init_catch_param_with_ref_to_ptr_to_non_recordv() {{.*}} personality ptr @__gxx_personality_v0
-// LLVM:   %[[P_ADDR:.*]] = alloca ptr, i64 1, align 8
-// LLVM:   %[[RET_ADDR:.*]] = alloca i32, i64 1, align 4
-// LLVM:   %[[RV_ADDR:.*]] = alloca i32, i64 1, align 4
+// LLVM:   %[[P_ADDR:.*]] = alloca ptr, align 8
+// LLVM:   %[[RET_ADDR:.*]] = alloca i32, align 4
+// LLVM:   %[[RV_ADDR:.*]] = alloca i32, align 4
 // LLVM:   br label %[[TRY_SCOPE:.*]]
 // LLVM: [[TRY_SCOPE]]:
 // LLVM:   br label %[[TRY_BEGIN:.*]]

--- a/clang/test/CIR/CodeGen/typedef.c
+++ b/clang/test/CIR/CodeGen/typedef.c
@@ -16,7 +16,7 @@ void local_typedef(void) {
 
 // LLVM: %struct.Struct = type { i32 }
 // LLVM: define{{.*}} void @local_typedef()
-// LLVM:   alloca %struct.Struct, i64 1, align 4
+// LLVM:   alloca %struct.Struct, align 4
 // LLVM:   ret void
 
 // OGCG: %struct.Struct = type { i32 }

--- a/clang/test/CIR/CodeGen/unary.cpp
+++ b/clang/test/CIR/CodeGen/unary.cpp
@@ -17,8 +17,8 @@ unsigned up0() {
 // CHECK:   %[[INPUT:.*]] = cir.load{{.*}} %[[A]]
 
 // LLVM: define{{.*}} i32 @_Z3up0v()
-// LLVM:   %[[RV:.*]] = alloca i32, i64 1, align 4
-// LLVM:   %[[A:.*]] = alloca i32, i64 1, align 4
+// LLVM:   %[[RV:.*]] = alloca i32, align 4
+// LLVM:   %[[A:.*]] = alloca i32, align 4
 // LLVM:   store i32 1, ptr %[[A]], align 4
 // LLVM:   %[[A_LOAD:.*]] = load i32, ptr %[[A]], align 4
 
@@ -38,8 +38,8 @@ unsigned um0() {
 // CHECK:   %[[OUTPUT:.*]] = cir.minus %[[INPUT]]
 
 // LLVM: define{{.*}} i32 @_Z3um0v()
-// LLVM:   %[[RV:.*]] = alloca i32, i64 1, align 4
-// LLVM:   %[[A:.*]] = alloca i32, i64 1, align 4
+// LLVM:   %[[RV:.*]] = alloca i32, align 4
+// LLVM:   %[[A:.*]] = alloca i32, align 4
 // LLVM:   store i32 1, ptr %[[A]], align 4
 // LLVM:   %[[A_LOAD:.*]] = load i32, ptr %[[A]], align 4
 // LLVM:   %[[RESULT:.*]] = sub i32 0, %[[A_LOAD]]
@@ -61,8 +61,8 @@ unsigned un0() {
 // CHECK:   %[[OUTPUT:.*]] = cir.not %[[INPUT]]
 
 // LLVM: define{{.*}} i32 @_Z3un0v()
-// LLVM:   %[[RV:.*]] = alloca i32, i64 1, align 4
-// LLVM:   %[[A:.*]] = alloca i32, i64 1, align 4
+// LLVM:   %[[RV:.*]] = alloca i32, align 4
+// LLVM:   %[[A:.*]] = alloca i32, align 4
 // LLVM:   store i32 1, ptr %[[A]], align 4
 // LLVM:   %[[A_LOAD:.*]] = load i32, ptr %[[A]], align 4
 // LLVM:   %[[RESULT:.*]] = xor i32 %[[A_LOAD]], -1
@@ -89,8 +89,8 @@ int inc0() {
 // CHECK:   %[[A_TO_OUTPUT:.*]] = cir.load{{.*}} %[[A]]
 
 // LLVM: define{{.*}} i32 @_Z4inc0v()
-// LLVM:   %[[RV:.*]] = alloca i32, i64 1, align 4
-// LLVM:   %[[A:.*]] = alloca i32, i64 1, align 4
+// LLVM:   %[[RV:.*]] = alloca i32, align 4
+// LLVM:   %[[A:.*]] = alloca i32, align 4
 // LLVM:   store i32 1, ptr %[[A]], align 4
 // LLVM:   %[[A_LOAD:.*]] = load i32, ptr %[[A]], align 4
 // LLVM:   %[[RESULT:.*]] = add nsw i32 %[[A_LOAD]], 1
@@ -117,8 +117,8 @@ int dec0() {
 // CHECK:   %[[A_TO_OUTPUT:.*]] = cir.load{{.*}} %[[A]]
 
 // LLVM: define{{.*}} i32 @_Z4dec0v()
-// LLVM:   %[[RV:.*]] = alloca i32, i64 1, align 4
-// LLVM:   %[[A:.*]] = alloca i32, i64 1, align 4
+// LLVM:   %[[RV:.*]] = alloca i32, align 4
+// LLVM:   %[[A:.*]] = alloca i32, align 4
 // LLVM:   store i32 1, ptr %[[A]], align 4
 // LLVM:   %[[A_LOAD:.*]] = load i32, ptr %[[A]], align 4
 // LLVM:   %[[RESULT:.*]] = sub nsw i32 %[[A_LOAD]], 1
@@ -145,8 +145,8 @@ int inc1() {
 // CHECK:   %[[A_TO_OUTPUT:.*]] = cir.load{{.*}} %[[A]]
 
 // LLVM: define{{.*}} i32 @_Z4inc1v()
-// LLVM:   %[[RV:.*]] = alloca i32, i64 1, align 4
-// LLVM:   %[[A:.*]] = alloca i32, i64 1, align 4
+// LLVM:   %[[RV:.*]] = alloca i32, align 4
+// LLVM:   %[[A:.*]] = alloca i32, align 4
 // LLVM:   store i32 1, ptr %[[A]], align 4
 // LLVM:   %[[A_LOAD:.*]] = load i32, ptr %[[A]], align 4
 // LLVM:   %[[RESULT:.*]] = add nsw i32 %[[A_LOAD]], 1
@@ -173,8 +173,8 @@ int dec1() {
 // CHECK:   %[[A_TO_OUTPUT:.*]] = cir.load{{.*}} %[[A]]
 
 // LLVM: define{{.*}} i32 @_Z4dec1v()
-// LLVM:   %[[RV:.*]] = alloca i32, i64 1, align 4
-// LLVM:   %[[A:.*]] = alloca i32, i64 1, align 4
+// LLVM:   %[[RV:.*]] = alloca i32, align 4
+// LLVM:   %[[A:.*]] = alloca i32, align 4
 // LLVM:   store i32 1, ptr %[[A]], align 4
 // LLVM:   %[[A_LOAD:.*]] = load i32, ptr %[[A]], align 4
 // LLVM:   %[[RESULT:.*]] = sub nsw i32 %[[A_LOAD]], 1
@@ -204,9 +204,9 @@ int inc2() {
 // CHECK:   %[[B_TO_OUTPUT:.*]] = cir.load{{.*}} %[[B]]
 
 // LLVM: define{{.*}} i32 @_Z4inc2v()
-// LLVM:   %[[RV:.*]] = alloca i32, i64 1, align 4
-// LLVM:   %[[A:.*]] = alloca i32, i64 1, align 4
-// LLVM:   %[[B:.*]] = alloca i32, i64 1, align 4
+// LLVM:   %[[RV:.*]] = alloca i32, align 4
+// LLVM:   %[[A:.*]] = alloca i32, align 4
+// LLVM:   %[[B:.*]] = alloca i32, align 4
 // LLVM:   store i32 1, ptr %[[A]], align 4
 // LLVM:   %[[A_LOAD:.*]] = load i32, ptr %[[A]], align 4
 // LLVM:   %[[A_INC:.*]] = add nsw i32 %[[A_LOAD]], 1
@@ -234,8 +234,8 @@ float fpPlus() {
 // CHECK:   %[[INPUT:.*]] = cir.load{{.*}} %[[A]]
 
 // LLVM: define{{.*}} float @_Z6fpPlusv()
-// LLVM:   %[[RV:.*]] = alloca float, i64 1, align 4
-// LLVM:   %[[A:.*]] = alloca float, i64 1, align 4
+// LLVM:   %[[RV:.*]] = alloca float, align 4
+// LLVM:   %[[A:.*]] = alloca float, align 4
 // LLVM:   store float 1.000000e+00, ptr %[[A]], align 4
 // LLVM:   %[[A_LOAD:.*]] = load float, ptr %[[A]], align 4
 
@@ -255,8 +255,8 @@ float fpMinus() {
 // CHECK:   %[[OUTPUT:.*]] = cir.fneg %[[INPUT]]
 
 // LLVM: define{{.*}} float @_Z7fpMinusv()
-// LLVM:   %[[RV:.*]] = alloca float, i64 1, align 4
-// LLVM:   %[[A:.*]] = alloca float, i64 1, align 4
+// LLVM:   %[[RV:.*]] = alloca float, align 4
+// LLVM:   %[[A:.*]] = alloca float, align 4
 // LLVM:   store float 1.000000e+00, ptr %[[A]], align 4
 // LLVM:   %[[A_LOAD:.*]] = load float, ptr %[[A]], align 4
 // LLVM:   %[[RESULT:.*]] = fneg float %[[A_LOAD]]
@@ -281,8 +281,8 @@ float fpPreInc() {
 // CHECK:   %[[INCREMENTED:.*]] = cir.fadd %[[INPUT]], %[[ONE]]
 
 // LLVM: define{{.*}} float @_Z8fpPreIncv()
-// LLVM:   %[[RV:.*]] = alloca float, i64 1, align 4
-// LLVM:   %[[A:.*]] = alloca float, i64 1, align 4
+// LLVM:   %[[RV:.*]] = alloca float, align 4
+// LLVM:   %[[A:.*]] = alloca float, align 4
 // LLVM:   store float 1.000000e+00, ptr %[[A]], align 4
 // LLVM:   %[[A_LOAD:.*]] = load float, ptr %[[A]], align 4
 // LLVM:   %[[RESULT:.*]] = fadd float %[[A_LOAD]], 1.000000e+00
@@ -307,8 +307,8 @@ float fpPreDec() {
 // CHECK:   %[[DECREMENTED:.*]] = cir.fsub %[[INPUT]], %[[ONE]]
 
 // LLVM: define{{.*}} float @_Z8fpPreDecv()
-// LLVM:   %[[RV:.*]] = alloca float, i64 1, align 4
-// LLVM:   %[[A:.*]] = alloca float, i64 1, align 4
+// LLVM:   %[[RV:.*]] = alloca float, align 4
+// LLVM:   %[[A:.*]] = alloca float, align 4
 // LLVM:   store float 1.000000e+00, ptr %[[A]], align 4
 // LLVM:   %[[A_LOAD:.*]] = load float, ptr %[[A]], align 4
 // LLVM:   %[[RESULT:.*]] = fsub float %[[A_LOAD]], 1.000000e+00
@@ -333,8 +333,8 @@ float fpPostInc() {
 // CHECK:   %[[INCREMENTED:.*]] = cir.fadd %[[INPUT]], %[[ONE]]
 
 // LLVM: define{{.*}} float @_Z9fpPostIncv()
-// LLVM:   %[[RV:.*]] = alloca float, i64 1, align 4
-// LLVM:   %[[A:.*]] = alloca float, i64 1, align 4
+// LLVM:   %[[RV:.*]] = alloca float, align 4
+// LLVM:   %[[A:.*]] = alloca float, align 4
 // LLVM:   store float 1.000000e+00, ptr %[[A]], align 4
 // LLVM:   %[[A_LOAD:.*]] = load float, ptr %[[A]], align 4
 // LLVM:   %[[RESULT:.*]] = fadd float %[[A_LOAD]], 1.000000e+00
@@ -359,8 +359,8 @@ float fpPostDec() {
 // CHECK:   %[[DECREMENTED:.*]] = cir.fsub %[[INPUT]], %[[ONE]]
 
 // LLVM: define{{.*}} float @_Z9fpPostDecv()
-// LLVM:   %[[RV:.*]] = alloca float, i64 1, align 4
-// LLVM:   %[[A:.*]] = alloca float, i64 1, align 4
+// LLVM:   %[[RV:.*]] = alloca float, align 4
+// LLVM:   %[[A:.*]] = alloca float, align 4
 // LLVM:   store float 1.000000e+00, ptr %[[A]], align 4
 // LLVM:   %[[A_LOAD:.*]] = load float, ptr %[[A]], align 4
 // LLVM:   %[[RESULT:.*]] = fsub float %[[A_LOAD]], 1.000000e+00
@@ -391,9 +391,9 @@ float fpPostInc2() {
 // CHECK:   %[[B_TO_OUTPUT:.*]] = cir.load{{.*}} %[[B]]
 
 // LLVM: define{{.*}} float @_Z10fpPostInc2v()
-// LLVM:   %[[RV:.*]] = alloca float, i64 1, align 4
-// LLVM:   %[[A:.*]] = alloca float, i64 1, align 4
-// LLVM:   %[[B:.*]] = alloca float, i64 1, align 4
+// LLVM:   %[[RV:.*]] = alloca float, align 4
+// LLVM:   %[[A:.*]] = alloca float, align 4
+// LLVM:   %[[B:.*]] = alloca float, align 4
 // LLVM:   store float 1.000000e+00, ptr %[[A]], align 4
 // LLVM:   %[[A_LOAD:.*]] = load float, ptr %[[A]], align 4
 // LLVM:   %[[A_INC:.*]] = fadd float %[[A_LOAD]], 1.000000e+00
@@ -574,8 +574,8 @@ void f16NestedUPlus() {
 // CHECK:  cir.store{{.*}} %[[RESULT]], %[[B_ADDR]] : !cir.f16, !cir.ptr<!cir.f16>
 
 // LLVM: define{{.*}} void @_Z14f16NestedUPlusv()
-// LLVM:  %[[A_ADDR:.*]] = alloca half, i64 1, align 2
-// LLVM:  %[[B_ADDR:.*]] = alloca half, i64 1, align 2
+// LLVM:  %[[A_ADDR:.*]] = alloca half, align 2
+// LLVM:  %[[B_ADDR:.*]] = alloca half, align 2
 // LLVM:  %[[TMP_A:.*]] = load half, ptr %[[A_ADDR]], align 2
 // LLVM:  %[[RESULT_F32:.*]] = fpext half %[[TMP_A]] to float
 // LLVM:  %[[RESULT:.*]] = fptrunc float %[[RESULT_F32]] to half
@@ -605,8 +605,8 @@ void f16NestedUMinus() {
 // CHECK:  cir.store{{.*}} %[[RESULT]], %[[B_ADDR]] : !cir.f16, !cir.ptr<!cir.f16>
 
 // LLVM: define{{.*}} void @_Z15f16NestedUMinusv()
-// LLVM:  %[[A_ADDR:.*]] = alloca half, i64 1, align 2
-// LLVM:  %[[B_ADDR:.*]] = alloca half, i64 1, align 2
+// LLVM:  %[[A_ADDR:.*]] = alloca half, align 2
+// LLVM:  %[[B_ADDR:.*]] = alloca half, align 2
 // LLVM:  %[[TMP_A:.*]] = load half, ptr %[[A_ADDR]], align 2
 // LLVM:  %[[A_F32:.*]] = fpext half %[[TMP_A]] to float
 // LLVM:  %[[A_MINUS:.*]] = fneg float %[[A_F32]]

--- a/clang/test/CIR/CodeGen/union.c
+++ b/clang/test/CIR/CodeGen/union.c
@@ -61,7 +61,7 @@ void f1(void) {
 // CIR-NEXT:   cir.return
 
 // LLVM:      define{{.*}} void @f1()
-// LLVM-NEXT:   %[[P:.*]] = alloca ptr, i64 1, align 8
+// LLVM-NEXT:   %[[P:.*]] = alloca ptr, align 8
 // LLVM-NEXT:   ret void
 
 // OGCG:      define{{.*}} void @f1()
@@ -88,8 +88,8 @@ int f2(void) {
 // CIR-NEXT:   cir.return %[[RET]] : !s32i
 
 // LLVM:      define{{.*}} i32 @f2()
-// LLVM-NEXT:   %[[RETVAL:.*]] = alloca i32, i64 1, align 4
-// LLVM-NEXT:   %[[U:.*]] = alloca %union.U1, i64 1, align 4
+// LLVM-NEXT:   %[[RETVAL:.*]] = alloca i32, align 4
+// LLVM-NEXT:   %[[U:.*]] = alloca %union.U1, align 4
 // LLVM-NEXT:   store i32 42, ptr %[[U]], align 4
 // LLVM-NEXT:   %[[N_VAL:.*]] = load i32, ptr %[[U]], align 4
 // LLVM-NEXT:   store i32 %[[N_VAL]], ptr %[[RETVAL]], align 4
@@ -140,7 +140,7 @@ void shouldGenerateUnionAccess(union U2 u) {
 // CIR-NEXT:   cir.return
 
 // LLVM:      define{{.*}} void @shouldGenerateUnionAccess(%union.U2 %[[ARG:.*]])
-// LLVM-NEXT:   %[[U:.*]] = alloca %union.U2, i64 1, align 8
+// LLVM-NEXT:   %[[U:.*]] = alloca %union.U2, align 8
 // LLVM-NEXT:   store %union.U2 %[[ARG]], ptr %[[U]], align 8
 // LLVM-NEXT:   store i8 0, ptr %[[U]], align 8
 // LLVM-NEXT:   %[[B_VAL:.*]] = load i8, ptr %[[U]], align 8
@@ -182,7 +182,7 @@ void f3(union U3 u) {
 // CIR-NEXT:   cir.return
 
 // LLVM:      define{{.*}} void @f3(%union.U3 %[[ARG:.*]])
-// LLVM-NEXT:   %[[U:.*]] = alloca %union.U3, i64 1, align 1
+// LLVM-NEXT:   %[[U:.*]] = alloca %union.U3, align 1
 // LLVM-NEXT:   store %union.U3 %[[ARG]], ptr %[[U]], align 1
 // LLVM-NEXT:   %[[ELEM_PTR:.*]] = getelementptr [5 x i8], ptr %[[U]], i32 0, i64 2
 // LLVM-NEXT:   store i8 0, ptr %[[ELEM_PTR]], align 1
@@ -211,7 +211,7 @@ void f5(union U4 u) {
 // CIR-NEXT:   cir.return
 
 // LLVM:      define{{.*}} void @f5(%union.U4 %[[ARG:.*]])
-// LLVM-NEXT:   %[[U:.*]] = alloca %union.U4, i64 1, align 4
+// LLVM-NEXT:   %[[U:.*]] = alloca %union.U4, align 4
 // LLVM-NEXT:   store %union.U4 %[[ARG]], ptr %[[U]], align 4
 // LLVM-NEXT:   %[[ELEM_PTR:.*]] = getelementptr [5 x i8], ptr %[[U]], i32 0, i64 4
 // LLVM-NEXT:   store i8 65, ptr %[[ELEM_PTR]], align 4

--- a/clang/test/CIR/CodeGen/variable-decomposition.cpp
+++ b/clang/test/CIR/CodeGen/variable-decomposition.cpp
@@ -35,8 +35,8 @@ float function() {
 // CIR:  cir.return %[[RET]] : !cir.float
 
 // LLVM-LABEL: define dso_local noundef float @_Z8functionv()
-// LLVM:  %[[RETVAL:.+]] = alloca float, i64 1
-// LLVM:  %[[STRUCT:.+]] = alloca %struct.some_struct, i64 1
+// LLVM:  %[[RETVAL:.+]] = alloca float, 
+// LLVM:  %[[STRUCT:.+]] = alloca %struct.some_struct, 
 // LLVM:  call void @llvm.memcpy{{.*}}(ptr align 4 %[[STRUCT]], ptr align 4 @[[FUNC_CONST]], i64 8, i1 false)
 // LLVM:  %[[GEP_A:.+]] = getelementptr inbounds nuw %struct.some_struct, ptr %[[STRUCT]], i32 0, i32 0
 // LLVM:  %[[LOAD_A:.+]] = load i32, ptr %[[GEP_A]]

--- a/clang/test/CIR/CodeGen/vector-ext-element.cpp
+++ b/clang/test/CIR/CodeGen/vector-ext-element.cpp
@@ -26,9 +26,9 @@ void element_expr_from_gl() {
 // CIR: %[[ELEM_1:.*]] = cir.vec.extract %[[TMP_A]][%[[CONST_1]] : !s64i] : !cir.vector<4 x !s32i>
 // CIR: cir.store {{.*}} %[[ELEM_1]], %[[Y_ADDR]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[X_ADDR:.*]] = alloca i32, i64 1, align 4
-// LLVM: %[[Y_ADDR:.*]] = alloca i32, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[X_ADDR:.*]] = alloca i32, align 4
+// LLVM: %[[Y_ADDR:.*]] = alloca i32, align 4
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[A_ADDR]], align 16
 // LLVM: %[[ELEM_0:.*]] = extractelement <4 x i32> %4, i64 0
 // LLVM: store i32 %[[ELEM_0]], ptr %[[X_ADDR]], align 4
@@ -64,9 +64,9 @@ void element_expr_from_gl_with_vec_result() {
 // CIR: %[[C_VALUE:.*]] = cir.vec.shuffle(%[[TMP_A]], %[[POISON]] : !cir.vector<4 x !s32i>) [#cir.int<3> : !s32i, #cir.int<2> : !s32i, #cir.int<1> : !s32i, #cir.int<0> : !s32i] : !cir.vector<4 x !s32i>
 // CIR: cir.store {{.*}} %[[C_VALUE]], %[[C_ADDR]] : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[B_ADDR:.*]] = alloca <2 x i32>, i64 1, align 8
-// LLVM: %[[C_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[B_ADDR:.*]] = alloca <2 x i32>, align 8
+// LLVM: %[[C_ADDR:.*]] = alloca <4 x i32>, align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[A_ADDR]], align 16
 // LLVM: %[[B_VALUE:.*]] = shufflevector <4 x i32> %[[TMP_A]], <4 x i32> poison, <2 x i32> <i32 0, i32 1>
 // LLVM: store <2 x i32> %[[B_VALUE]], ptr %[[B_ADDR]], align 8
@@ -104,9 +104,9 @@ void element_expr_from_pointer() {
 // CIR: %[[ELEM_1:.*]] = cir.vec.extract %[[TMP_A]][%[[CONST_1]] : !s64i] : !cir.vector<4 x !s32i>
 // CIR: cir.store {{.*}} %[[ELEM_1]], %[[Y_ADDR]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM: %[[A_ADDR:.*]] = alloca ptr, i64 1, align 8
-// LLVM: %[[X_ADDR:.*]] = alloca i32, i64 1, align 4
-// LLVM: %[[Y_ADDR:.*]] = alloca i32, i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca ptr, align 8
+// LLVM: %[[X_ADDR:.*]] = alloca i32, align 4
+// LLVM: %[[Y_ADDR:.*]] = alloca i32, align 4
 // LLVM: %[[TMP_A_PTR:.*]] = load ptr, ptr %[[A_ADDR]], align 8
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[TMP_A_PTR]], align 16
 // LLVM: %[[ELEM_0:.*]] = extractelement <4 x i32> %[[TMP_A]], i64 0
@@ -148,9 +148,9 @@ void element_expr_from_pointer_with_vec_result() {
 // CIR: %[[C_VALUE:.*]] = cir.vec.shuffle(%[[TMP_A]], %[[POISON]] : !cir.vector<4 x !s32i>) [#cir.int<3> : !s32i, #cir.int<2> : !s32i, #cir.int<1> : !s32i, #cir.int<0> : !s32i] : !cir.vector<4 x !s32i>
 // CIR: cir.store {{.*}} %[[C_VALUE]], %[[C_ADDR]] : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca ptr, i64 1, align 8
-// LLVM: %[[B_ADDR:.*]] = alloca <2 x i32>, i64 1, align 8
-// LLVM: %[[C_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[A_ADDR:.*]] = alloca ptr, align 8
+// LLVM: %[[B_ADDR:.*]] = alloca <2 x i32>, align 8
+// LLVM: %[[C_ADDR:.*]] = alloca <4 x i32>, align 16
 // LLVM: %[[TMP_A_PTR:.*]] = load ptr, ptr %[[A_ADDR]], align 8
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[TMP_A_PTR]], align 16
 // LLVM: %[[B_VALUE:.*]] = shufflevector <4 x i32> %[[TMP_A]], <4 x i32> poison, <2 x i32> <i32 0, i32 1>
@@ -202,12 +202,12 @@ void element_expr_from_rvalue() {
 // CIR: %[[ELEM_1:.*]] = cir.vec.extract %[[TMP_2]][%[[CONST_1]] : !s64i] : !cir.vector<4 x !s32i>
 // CIR: cir.store {{.*}} %[[ELEM_1]], %[[Y_ADDR]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[B_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[X_ADDR:.*]] = alloca i32, i64 1, align 4
-// LLVM: %[[TMP_1_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[Y_ADDR:.*]] = alloca i32, i64 1, align 4
-// LLVM: %[[TMP_2_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[B_ADDR:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[X_ADDR:.*]] = alloca i32, align 4
+// LLVM: %[[TMP_1_ADDR:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[Y_ADDR:.*]] = alloca i32, align 4
+// LLVM: %[[TMP_2_ADDR:.*]] = alloca <4 x i32>, align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[A_ADDR]], align 16
 // LLVM: %[[TMP_B:.*]] = load <4 x i32>, ptr %[[B_ADDR]], align 16
 // LLVM: %[[ADD_A_B:.*]] = add <4 x i32> %[[TMP_A]], %[[TMP_B]]
@@ -274,12 +274,12 @@ void element_expr_from_rvalue_with_vec_result() {
 // CIR: %[[D_VALUE:.*]] = cir.vec.shuffle(%[[TMP_2]], %[[POISON]] : !cir.vector<4 x !s32i>) [#cir.int<3> : !s32i, #cir.int<2> : !s32i, #cir.int<1> : !s32i, #cir.int<0> : !s32i] : !cir.vector<4 x !s32i>
 // CIR: cir.store {{.*}} %[[D_VALUE]], %[[D_ADDR]] : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[B_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[C_ADDR:.*]] = alloca <2 x i32>, i64 1, align 8
-// LLVM: %[[TMP_1_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[D_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[TMP_2_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[B_ADDR:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[C_ADDR:.*]] = alloca <2 x i32>, align 8
+// LLVM: %[[TMP_1_ADDR:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[D_ADDR:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[TMP_2_ADDR:.*]] = alloca <4 x i32>, align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[A_ADDR]], align 16
 // LLVM: %[[TMP_B:.*]] = load <4 x i32>, ptr %[[B_ADDR]], align 16
 // LLVM: %[[ADD_A_B:.*]] = add <4 x i32> %[[TMP_A]], %[[TMP_B]]
@@ -330,7 +330,7 @@ void array_subscript_expr_with_element_expr_base() {
 // CIR: %[[VEC_ELEM_PTR:.*]] = cir.ptr_stride %[[VEC_MEMBER_EXPR]], %[[CONST_1]] : (!cir.ptr<!s32i>, !s64i) -> !cir.ptr<!s32i>
 // CIR: cir.store {{.*}} %[[CONST_2]], %[[VEC_ELEM_PTR]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, align 16
 // LLVM: %[[VEC_MEMBER_EXPR:.*]] = getelementptr i32, ptr %[[A_ADDR]], i64 0
 // LLVM: %[[VEC_ELEM_PTR:.*]] = getelementptr i32, ptr %[[VEC_MEMBER_EXPR]], i64 1
 // LLVM: store i32 2, ptr %[[VEC_ELEM_PTR]], align 4
@@ -356,8 +356,8 @@ void store_src_dest_same_size() {
 // CIR: %[[RESULT:.*]] = cir.vec.shuffle(%[[SHUFFLE_A]], %[[POISON]] : !cir.vector<2 x !s32i>) [#cir.int<0> : !s32i, #cir.int<1> : !s32i] : !cir.vector<2 x !s32i>
 // CIR: cir.store {{.*}} %[[RESULT]], %[[B_ADDR]] : !cir.vector<2 x !s32i>, !cir.ptr<!cir.vector<2 x !s32i>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[B_ADDR:.*]] = alloca <2 x i32>, i64 1, align 8
+// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[B_ADDR:.*]] = alloca <2 x i32>, align 8
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[A_ADDR]], align 16
 // LLVM: %[[SHUFFLE_A:.*]] = shufflevector <4 x i32> %[[TMP_A]], <4 x i32> poison, <2 x i32> <i32 0, i32 1>
 // LLVM: %[[TMP_B:.*]] = load <2 x i32>, ptr %[[B_ADDR]], align 8
@@ -387,8 +387,8 @@ void store_src_dest_not_same_size() {
 // CIR: %[[RESULT:.*]] = cir.vec.shuffle(%[[TMP_A]], %[[SHUFFLE_B]] : !cir.vector<4 x !s32i>) [#cir.int<4> : !s32i, #cir.int<5> : !s32i, #cir.int<2> : !s32i, #cir.int<3> : !s32i] : !cir.vector<4 x !s32i> 
 // CIR: cir.store {{.*}} %[[RESULT]], %[[A_ADDR]] : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[B_ADDR:.*]] = alloca <2 x i32>, i64 1, align 8
+// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[B_ADDR:.*]] = alloca <2 x i32>, align 8
 // LLVM: %[[TMP_B:.*]] = load <2 x i32>, ptr %[[B_ADDR]], align 8
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[A_ADDR]], align 16
 // LLVM: %[[SHUFFLE_A:.*]] = shufflevector <2 x i32> %[[TMP_B]], <2 x i32> poison, <4 x i32> <i32 0, i32 1, i32 poison, i32 poison>

--- a/clang/test/CIR/CodeGen/vector-ext.cpp
+++ b/clang/test/CIR/CodeGen/vector-ext.cpp
@@ -101,14 +101,14 @@ void foo() {
 // CIR-SAME; #cir.int<0> : !s32i, #cir.int<0> : !s32i]> : !cir.vector<4 x !s32i>
 // CIR: cir.store{{.*}} %[[VEC_H_VAL]], %[[VEC_H]] : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[VEC_B:.*]] = alloca <3 x i32>, i64 1, align 16
-// LLVM: %[[VEC_C:.*]] = alloca <2 x i32>, i64 1, align 8
-// LLVM: %[[VEC_D:.*]] = alloca <2 x double>, i64 1, align 16
-// LLVM: %[[VEC_E:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[VEC_F:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[VEC_G:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[VEC_H:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[VEC_B:.*]] = alloca <3 x i32>, align 16
+// LLVM: %[[VEC_C:.*]] = alloca <2 x i32>, align 8
+// LLVM: %[[VEC_D:.*]] = alloca <2 x double>, align 16
+// LLVM: %[[VEC_E:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[VEC_F:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[VEC_G:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[VEC_H:.*]] = alloca <4 x i32>, align 16
 // LLVM: store <4 x i32> <i32 1, i32 2, i32 3, i32 4>, ptr %[[VEC_E]], align 16
 // LLVM: store <4 x i32> {{.*}}, ptr %[[VEC_F]], align 16
 // LLVM: store <4 x i32> <i32 5, i32 0, i32 0, i32 0>, ptr %[[VEC_G]], align 16
@@ -132,7 +132,7 @@ void foo2(vi4 p) {}
 // CIR: %[[VEC_A:.*]] = cir.alloca "p" {{.*}} init : !cir.ptr<!cir.vector<4 x !s32i>>
 // CIR: cir.store{{.*}} %{{.*}}, %[[VEC_A]] : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, align 16
 // LLVM: store <4 x i32> %{{.*}}, ptr %[[VEC_A]], align 16
 
 // OGCG: %[[VEC_A:.*]] = alloca <4 x i32>, align 16
@@ -153,8 +153,8 @@ void foo3() {
 // CIR: %[[ELE:.*]] = cir.vec.extract %[[TMP]][%[[IDX]] : !s32i] : !cir.vector<4 x !s32i>
 // CIR: cir.store{{.*}} %[[ELE]], %[[INIT]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM: %[[VEC:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[INIT:.*]] = alloca i32, i64 1, align 4
+// LLVM: %[[VEC:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[INIT:.*]] = alloca i32, align 4
 // LLVM: store <4 x i32> <i32 1, i32 2, i32 3, i32 4>, ptr %[[VEC]], align 16
 // LLVM: %[[TMP:.*]] = load <4 x i32>, ptr %[[VEC]], align 16
 // LLVM: %[[ELE:.*]] = extractelement <4 x i32> %[[TMP]], i32 1
@@ -187,9 +187,9 @@ void foo4() {
 // CIR: %[[ELE:.*]] = cir.vec.extract %[[TMP1]][%[[TMP2]] : !s32i] : !cir.vector<4 x !s32i>
 // CIR: cir.store{{.*}} %[[ELE]], %[[INIT]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM: %[[VEC:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[IDX:.*]] = alloca i32, i64 1, align 4
-// LLVM: %[[INIT:.*]] = alloca i32, i64 1, align 4
+// LLVM: %[[VEC:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[IDX:.*]] = alloca i32, align 4
+// LLVM: %[[INIT:.*]] = alloca i32, align 4
 // LLVM: store <4 x i32> <i32 1, i32 2, i32 3, i32 4>, ptr %[[VEC]], align 16
 // LLVM: store i32 2, ptr %[[IDX]], align 4
 // LLVM: %[[TMP1:.*]] = load <4 x i32>, ptr %[[VEC]], align 16
@@ -223,7 +223,7 @@ void foo5() {
 // CIR: %[[NEW_VEC:.*]] = cir.vec.insert %[[CONST_VAL]], %[[TMP]][%[[CONST_IDX]] : !s32i] : !cir.vector<4 x !s32i>
 // CIR: cir.store{{.*}} %[[NEW_VEC]], %[[VEC]] : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[VEC:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[VEC:.*]] = alloca <4 x i32>, align 16
 // LLVM: store <4 x i32> <i32 1, i32 2, i32 3, i32 4>, ptr %[[VEC]], align 16
 // LLVM: %[[TMP:.*]] = load <4 x i32>, ptr %[[VEC]], align 16
 // LLVM: %[[NEW_VEC:.*]] = insertelement <4 x i32> %[[TMP]], i32 5, i32 2
@@ -258,9 +258,9 @@ void foo6() {
 // CIR: %[[NEW_VEC:.*]] = cir.vec.insert %[[TMP1]], %[[TMP3]][%[[TMP2]] : !s32i] : !cir.vector<4 x !s32i>
 // CIR: cir.store{{.*}} %[[NEW_VEC]], %[[VEC]] : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[VEC:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[IDX:.*]] = alloca i32, i64 1, align 4
-// LLVM: %[[VAL:.*]] = alloca i32, i64 1, align 4
+// LLVM: %[[VEC:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[IDX:.*]] = alloca i32, align 4
+// LLVM: %[[VAL:.*]] = alloca i32, align 4
 // LLVM: store <4 x i32> <i32 1, i32 2, i32 3, i32 4>, ptr %1, align 16
 // LLVM: store i32 2, ptr %[[IDX]], align 4
 // LLVM: store i32 5, ptr %[[VAL]], align 4
@@ -300,7 +300,7 @@ void foo7() {
 // CIR: %[[NEW_VEC:.*]] = cir.vec.insert %[[RES]], %[[TMP2]][%[[CONST_IDX]] : !s32i] : !cir.vector<4 x !s32i>
 // CIR: cir.store{{.*}} %[[NEW_VEC]], %[[VEC]] : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[VEC:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[VEC:.*]] = alloca <4 x i32>, align 16
 // LLVM: store <4 x i32> <i32 1, i32 2, i32 3, i32 4>, ptr %[[VEC]], align 16
 // LLVM: %[[TMP:.*]] = load <4 x i32>, ptr %[[VEC]], align 16
 // LLVM: %[[ELE:.*]] = extractelement <4 x i32> %[[TMP]], i32 2
@@ -342,10 +342,10 @@ void foo8() {
 // CIR: %[[NOT:.*]] = cir.not %[[TMP3]] : !cir.vector<4 x !s32i>
 // CIR: cir.store{{.*}} %[[NOT]], %[[NOT_RES]] : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[VEC:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[PLUS_RES:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[MINUS_RES:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[NOT_RES:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[VEC:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[PLUS_RES:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[MINUS_RES:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[NOT_RES:.*]] = alloca <4 x i32>, align 16
 // LLVM: store <4 x i32> <i32 1, i32 2, i32 3, i32 4>, ptr %[[VEC]], align 16
 // LLVM: %[[TMP1:.*]] = load <4 x i32>, ptr %[[VEC]], align 16
 // LLVM: store <4 x i32> %[[TMP1]], ptr %[[PLUS_RES]], align 16
@@ -397,10 +397,10 @@ void foo9() {
 // CIR: %[[SHR:.*]] = cir.shift(right, %[[TMP_A]] : !cir.vector<4 x !s32i>, %[[TMP_B]] : !cir.vector<4 x !s32i>) -> !cir.vector<4 x !s32i>
 // CIR: cir.store{{.*}} %[[SHR]], %[[SHR_RES]] : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[VEC_B:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[SHL_RES:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[SHR_RES:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[VEC_B:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[SHL_RES:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[SHR_RES:.*]] = alloca <4 x i32>, align 16
 // LLVM: store <4 x i32> <i32 1, i32 2, i32 3, i32 4>, ptr %[[VEC_A]], align 16
 // LLVM: store <4 x i32> <i32 5, i32 6, i32 7, i32 8>, ptr %[[VEC_B]], align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[VEC_A]], align 16
@@ -454,10 +454,10 @@ void foo10() {
 // CIR: %[[SHR:.*]] = cir.shift(right, %[[TMP_B]] : !cir.vector<4 x !u32i>, %[[TMP_A]] : !cir.vector<4 x !s32i>) -> !cir.vector<4 x !u32i>
 // CIR: cir.store{{.*}} %[[SHR]], %[[SHR_RES]] : !cir.vector<4 x !u32i>, !cir.ptr<!cir.vector<4 x !u32i>>
 
-// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[VEC_B:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[SHL_RES:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[SHR_RES:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[VEC_B:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[SHL_RES:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[SHR_RES:.*]] = alloca <4 x i32>, align 16
 // LLVM: store <4 x i32> <i32 1, i32 2, i32 3, i32 4>, ptr %[[VEC_A]], align 16
 // LLVM: store <4 x i32> <i32 5, i32 6, i32 7, i32 8>, ptr %[[VEC_B]], align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[VEC_A]], align 16
@@ -539,8 +539,8 @@ void foo11() {
 // CIR: %[[XOR:.*]] = cir.xor %[[TMP_A]], %[[TMP_B]] : !cir.vector<4 x !s32i>
 // CIR: cir.store{{.*}} %[[XOR]], {{.*}} : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[VEC_B:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[VEC_B:.*]] = alloca <4 x i32>, align 16
 // LLVM: store <4 x i32> <i32 1, i32 2, i32 3, i32 4>, ptr %[[VEC_A]], align 16
 // LLVM: store <4 x i32> <i32 5, i32 6, i32 7, i32 8>, ptr %[[VEC_B]], align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[VEC_A]], align 16
@@ -658,8 +658,8 @@ void foo12() {
 // CIR: %[[GE:.*]] = cir.vec.cmp(ge, %[[TMP_A]], %[[TMP_B]]) : !cir.vector<4 x !s32i>, !cir.vector<4 x !s32i>
 // CIR: cir.store{{.*}} %[[GE]], {{.*}} : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[VEC_B:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[VEC_B:.*]] = alloca <4 x i32>, align 16
 // LLVM: store <4 x i32> <i32 1, i32 2, i32 3, i32 4>, ptr %[[VEC_A]], align 16
 // LLVM: store <4 x i32> <i32 5, i32 6, i32 7, i32 8>, ptr %[[VEC_B]], align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[VEC_A]], align 16
@@ -773,8 +773,8 @@ void foo13() {
 // CIR: %[[GE:.*]] = cir.vec.cmp(ge, %[[TMP_A]], %[[TMP_B]]) : !cir.vector<4 x !u32i>, !cir.vector<4 x !s32i>
 // CIR: cir.store{{.*}} %[[GE]], {{.*}} : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[VEC_B:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[VEC_B:.*]] = alloca <4 x i32>, align 16
 // LLVM: store <4 x i32> <i32 1, i32 2, i32 3, i32 4>, ptr %[[VEC_A]], align 16
 // LLVM: store <4 x i32> <i32 5, i32 6, i32 7, i32 8>, ptr %[[VEC_B]], align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[VEC_A]], align 16
@@ -888,8 +888,8 @@ void foo14() {
 // CIR: %[[GE:.*]] = cir.vec.cmp(ge, %[[TMP_A]], %[[TMP_B]]) : !cir.vector<4 x !cir.float>, !cir.vector<4 x !s32i>
 // CIR: cir.store{{.*}} %[[GE]], {{.*}} : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[VEC_A:.*]] = alloca <4 x float>, i64 1, align 16
-// LLVM: %[[VEC_B:.*]] = alloca <4 x float>, i64 1, align 16
+// LLVM: %[[VEC_A:.*]] = alloca <4 x float>, align 16
+// LLVM: %[[VEC_B:.*]] = alloca <4 x float>, align 16
 // LLVM: store <4 x float> <float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}>, ptr %[[VEC_A]], align 16
 // LLVM: store <4 x float> <float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}>, ptr %[[VEC_B]], align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x float>, ptr %[[VEC_A]], align 16
@@ -1051,7 +1051,7 @@ void foo17() {
 // CIR: %[[TMP:.*]] = cir.load{{.*}} %[[VEC_A]] : !cir.ptr<!cir.vector<2 x !cir.double>>, !cir.vector<2 x !cir.double>
 // CIR: %[[RES:.*]] = cir.cast float_to_int %[[TMP]] : !cir.vector<2 x !cir.double> -> !cir.vector<2 x !u16i>
 
-// LLVM: %[[VEC_A:.*]] = alloca <2 x double>, i64 1, align 16
+// LLVM: %[[VEC_A:.*]] = alloca <2 x double>, align 16
 // LLVM: %[[TMP:.*]] = load <2 x double>, ptr %[[VEC_A]], align 16
 // LLVM: %[[RES:.*]]= fptoui <2 x double> %[[TMP]] to <2 x i16>
 
@@ -1088,10 +1088,10 @@ void foo18() {
 // CIR: %[[SHR:.*]] = cir.shift(right, %[[TMP_B]] : !cir.vector<4 x !u32i>, %[[SPLAT_VEC]] : !cir.vector<4 x !u32i>) -> !cir.vector<4 x !u32i>
 // CIR: cir.store{{.*}} %[[SHR]], %[[SHR_RES]] : !cir.vector<4 x !u32i>, !cir.ptr<!cir.vector<4 x !u32i>>
 
-// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[SHL_RES:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[VEC_B:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[SHR_RES:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[SHL_RES:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[VEC_B:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[SHR_RES:.*]] = alloca <4 x i32>, align 16
 // LLVM: store <4 x i32> <i32 1, i32 2, i32 3, i32 4>, ptr %[[VEC_A]], align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[VEC_A]], align 16
 // LLVM: %[[SHL:.*]] = shl <4 x i32> %[[TMP_A]], splat (i32 3)
@@ -1127,8 +1127,8 @@ void foo19() {
 // CIR: %[[SHUF:.*]] = cir.vec.shuffle(%[[TMP_A]], %[[TMP_B]] : !cir.vector<4 x !s32i>) [#cir.int<7> :
 // CIR-SAME: !s64i, #cir.int<5> : !s64i, #cir.int<3> : !s64i, #cir.int<1> : !s64i] : !cir.vector<4 x !s32i>
 
-// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[VEC_B:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[VEC_B:.*]] = alloca <4 x i32>, align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[VEC_A]], align 16
 // LLVM: %[[TMP_B:.*]] = load <4 x i32>, ptr %[[VEC_B]], align 16
 // LLVM: %[[SHUF:.*]] = shufflevector <4 x i32> %[[TMP_A]], <4 x i32> %[[TMP_B]], <4 x i32> <i32 7, i32 5, i32 3, i32 1>
@@ -1152,8 +1152,8 @@ void foo20() {
 // CIR: %[[SHUF:.*]] = cir.vec.shuffle(%[[TMP_A]], %[[TMP_B]] : !cir.vector<4 x !s32i>) [#cir.int<-1> :
 // CIR-SAME: !s64i, #cir.int<1> : !s64i, #cir.int<-1> : !s64i, #cir.int<1> : !s64i] : !cir.vector<4 x !s32i>
 
-// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[VEC_B:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[VEC_B:.*]] = alloca <4 x i32>, align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[VEC_A]], align 16
 // LLVM: %[[TMP_B:.*]] = load <4 x i32>, ptr %[[VEC_B]], align 16
 // LLVM: %[[SHUF:.*]] = shufflevector <4 x i32> %[[TMP_A]], <4 x i32> %[[TMP_B]], <4 x i32> <i32 poison, i32 1, i32 poison, i32 1>
@@ -1173,7 +1173,7 @@ void foo21() {
 // CIR: %[[SIZE:.*]] = cir.const #cir.int<4> : !u64i
 // CIR: cir.store align(8) %[[SIZE]], %[[INIT]] : !u64i, !cir.ptr<!u64i>
 
-// LLVM: %[[SIZE:.*]] = alloca i64, i64 1, align 8
+// LLVM: %[[SIZE:.*]] = alloca i64, align 8
 // LLVM: store i64 4, ptr %[[SIZE]], align 8
 
 // OGCG: %[[SIZE:.*]] = alloca i64, align 8
@@ -1196,9 +1196,9 @@ void logical_or_vi4() {
 // CIR: %[[RESULT:.*]] = cir.or %[[NE_A_ZERO]], %[[NE_B_ZERO]] : !cir.vector<4 x !s32i>
 // CIR: cir.store{{.*}} %[[RESULT]], %[[C_ADDR]] : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[B_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[C_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[B_ADDR:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[C_ADDR:.*]] = alloca <4 x i32>, align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[A_ADDR]], align 16
 // LLVM: %[[TMP_B:.*]] = load <4 x i32>, ptr %[[B_ADDR]], align 16
 // LLVM: %[[NE_A_ZERO:.*]] = icmp ne <4 x i32> %[[TMP_A]], zeroinitializer
@@ -1236,9 +1236,9 @@ void logical_or_vf4() {
 // CIR: %[[RESULT:.*]] = cir.or %[[NE_A_ZERO]], %[[NE_B_ZERO]] : !cir.vector<4 x !s32i>
 // CIR: cir.store {{.*}} %[[RESULT]], %[[C_ADDR]] : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca <4 x float>, i64 1, align 16
-// LLVM: %[[B_ADDR:.*]] = alloca <4 x float>, i64 1, align 16
-// LLVM: %[[C_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[A_ADDR:.*]] = alloca <4 x float>, align 16
+// LLVM: %[[B_ADDR:.*]] = alloca <4 x float>, align 16
+// LLVM: %[[C_ADDR:.*]] = alloca <4 x i32>, align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x float>, ptr %[[A_ADDR]], align 16
 // LLVM: %[[TMP_B:.*]] = load <4 x float>, ptr %[[B_ADDR]], align 16
 // LLVM: %[[NE_A_ZERO:.*]] = fcmp une <4 x float> %[[TMP_A]], zeroinitializer
@@ -1276,9 +1276,9 @@ void foo24() {
 // CIR: %[[RESULT_VF16:.*]] = cir.cast floating %[[RESULT]] : !cir.vector<4 x !cir.float> -> !cir.vector<4 x !cir.f16>
 // CIR: cir.store{{.*}} %[[RESULT_VF16]], %[[C_ADDR]] : !cir.vector<4 x !cir.f16>, !cir.ptr<!cir.vector<4 x !cir.f16>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca <4 x half>, i64 1, align 8
-// LLVM: %[[B_ADDR:.*]] = alloca <4 x half>, i64 1, align 8
-// LLVM: %[[C_ADDR:.*]] = alloca <4 x half>, i64 1, align 8
+// LLVM: %[[A_ADDR:.*]] = alloca <4 x half>, align 8
+// LLVM: %[[B_ADDR:.*]] = alloca <4 x half>, align 8
+// LLVM: %[[C_ADDR:.*]] = alloca <4 x half>, align 8
 // LLVM: %[[TMP_A:.*]] = load <4 x half>, ptr %[[A_ADDR]], align 8
 // LLVM: %[[TMP_A_F16:.*]] = fpext <4 x half> %[[TMP_A]] to <4 x float>
 // LLVM: %[[TMP_B:.*]] = load <4 x half>, ptr %[[B_ADDR]], align 8
@@ -1315,9 +1315,9 @@ void logical_and_vi4() {
 // CIR: %[[RESULT:.*]] = cir.and %[[NE_A_ZERO]], %[[NE_B_ZERO]] : !cir.vector<4 x !s32i>
 // CIR: cir.store{{.*}} %[[RESULT]], %[[C_ADDR]] : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[B_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[C_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[B_ADDR:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[C_ADDR:.*]] = alloca <4 x i32>, align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[A_ADDR]], align 16
 // LLVM: %[[TMP_B:.*]] = load <4 x i32>, ptr %[[B_ADDR]], align 16
 // LLVM: %[[NE_A_ZERO:.*]] = icmp ne <4 x i32> %[[TMP_A]], zeroinitializer
@@ -1355,9 +1355,9 @@ void logical_and_vf4() {
 // CIR: %[[RESULT:.*]] = cir.and %[[NE_A_ZERO]], %[[NE_B_ZERO]] : !cir.vector<4 x !s32i>
 // CIR: cir.store {{.*}} %[[RESULT]], %[[C_ADDR]] : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca <4 x float>, i64 1, align 16
-// LLVM: %[[B_ADDR:.*]] = alloca <4 x float>, i64 1, align 16
-// LLVM: %[[C_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[A_ADDR:.*]] = alloca <4 x float>, align 16
+// LLVM: %[[B_ADDR:.*]] = alloca <4 x float>, align 16
+// LLVM: %[[C_ADDR:.*]] = alloca <4 x i32>, align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x float>, ptr %[[A_ADDR]], align 16
 // LLVM: %[[TMP_B:.*]] = load <4 x float>, ptr %[[B_ADDR]], align 16
 // LLVM: %[[NE_A_ZERO:.*]] = fcmp une <4 x float> %[[TMP_A]], zeroinitializer
@@ -1390,8 +1390,8 @@ void logical_not() {
 // CIR: %[[RESULT:.*]] = cir.vec.cmp(eq, %[[TMP_A]], %[[CONST_V0]]) : !cir.vector<4 x !s32i>, !cir.vector<4 x !s32i>
 // CIR: cir.store{{.*}} %[[RESULT]], %[[B_ADDR]] : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[B_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[B_ADDR:.*]] = alloca <4 x i32>, align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[A_ADDR]], align 16
 // LLVM: %[[RESULT:.*]] = icmp eq <4 x i32> %[[TMP_A]], zeroinitializer
 // LLVM: %[[RESULT_VI4:.*]] = sext <4 x i1> %[[RESULT]] to <4 x i32>
@@ -1414,8 +1414,8 @@ void unary_extension() {
 // CIR: %[[TMP_A:.*]] = cir.load{{.*}} %[[A_ADDR]] : !cir.ptr<!cir.vector<4 x !s32i>>, !cir.vector<4 x !s32i>
 // CIR: cir.store{{.*}} %[[TMP_A]], %[[B_ADDR]] : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[B_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[B_ADDR:.*]] = alloca <4 x i32>, align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[A_ADDR]], align 16
 // LLVM: store <4 x i32> %[[TMP_A]], ptr %[[B_ADDR]], align 16
 
@@ -1443,10 +1443,10 @@ vi4 ternary_expression_with_vec_cond() {
 // CIR: %[[TMP_RET:.*]] = cir.load %[[RET_ADDR]] : !cir.ptr<!cir.vector<4 x !s32i>>, !cir.vector<4 x !s32i>
 // CIR: cir.return %[[TMP_RET]] : !cir.vector<4 x !s32i>
 
-// LLVM: %[[RET_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[B_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[C_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[RET_ADDR:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[B_ADDR:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[C_ADDR:.*]] = alloca <4 x i32>, align 16
 // LLVM: %[[TMP_C:.*]] = load <4 x i32>, ptr %[[C_ADDR]], align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[A_ADDR]], align 16
 // LLVM: %[[TMP_B:.*]] = load <4 x i32>, ptr %[[B_ADDR]], align 16

--- a/clang/test/CIR/CodeGen/vector.cpp
+++ b/clang/test/CIR/CodeGen/vector.cpp
@@ -90,13 +90,13 @@ void foo() {
 // CIR-SAME; #cir.int<0> : !s32i, #cir.int<0> : !s32i]> : !cir.vector<4 x !s32i>
 // CIR: cir.store{{.*}} %[[VEC_G_VAL]], %[[VEC_G]] : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[VEC_B:.*]] = alloca <2 x double>, i64 1, align 16
-// LLVM: %[[VEC_C:.*]] = alloca <2 x i64>, i64 1, align 16
-// LLVM: %[[VEC_D:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[VEC_E:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[VEC_F:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[VEC_G:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[VEC_B:.*]] = alloca <2 x double>, align 16
+// LLVM: %[[VEC_C:.*]] = alloca <2 x i64>, align 16
+// LLVM: %[[VEC_D:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[VEC_E:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[VEC_F:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[VEC_G:.*]] = alloca <4 x i32>, align 16
 // LLVM: store <4 x i32> <i32 1, i32 2, i32 3, i32 4>, ptr %[[VEC_D]], align 16
 // LLVM: store <4 x i32> {{.*}}, ptr %[[VEC_E]], align 16
 // LLVM: store <4 x i32> <i32 5, i32 0, i32 0, i32 0>, ptr %[[VEC_F]], align 16
@@ -119,7 +119,7 @@ void foo2(vi4 p) {}
 // CIR: %[[VEC_A:.*]] = cir.alloca "p" {{.*}} init : !cir.ptr<!cir.vector<4 x !s32i>>
 // CIR: cir.store{{.*}} %{{.*}}, %[[VEC_A]] : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, align 16
 // LLVM: store <4 x i32> %{{.*}}, ptr %[[VEC_A]], align 16
 
 // OGCG: %[[VEC_A:.*]] = alloca <4 x i32>, align 16
@@ -140,8 +140,8 @@ void foo3() {
 // CIR: %[[ELE:.*]] = cir.vec.extract %[[TMP]][%[[IDX]] : !s32i] : !cir.vector<4 x !s32i>
 // CIR: cir.store{{.*}} %[[ELE]], %[[INIT]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM: %[[VEC:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[INIT:.*]] = alloca i32, i64 1, align 4
+// LLVM: %[[VEC:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[INIT:.*]] = alloca i32, align 4
 // LLVM: store <4 x i32> <i32 1, i32 2, i32 3, i32 4>, ptr %[[VEC]], align 16
 // LLVM: %[[TMP:.*]] = load <4 x i32>, ptr %[[VEC]], align 16
 // LLVM: %[[ELE:.*]] = extractelement <4 x i32> %[[TMP]], i32 1
@@ -174,9 +174,9 @@ void foo4() {
 // CIR: %[[ELE:.*]] = cir.vec.extract %[[TMP1]][%[[TMP2]] : !s32i] : !cir.vector<4 x !s32i>
 // CIR: cir.store{{.*}} %[[ELE]], %[[INIT]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM: %[[VEC:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[IDX:.*]] = alloca i32, i64 1, align 4
-// LLVM: %[[INIT:.*]] = alloca i32, i64 1, align 4
+// LLVM: %[[VEC:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[IDX:.*]] = alloca i32, align 4
+// LLVM: %[[INIT:.*]] = alloca i32, align 4
 // LLVM: store <4 x i32> <i32 1, i32 2, i32 3, i32 4>, ptr %[[VEC]], align 16
 // LLVM: store i32 2, ptr %[[IDX]], align 4
 // LLVM: %[[TMP1:.*]] = load <4 x i32>, ptr %[[VEC]], align 16
@@ -210,7 +210,7 @@ void foo5() {
 // CIR: %[[NEW_VEC:.*]] = cir.vec.insert %[[CONST_VAL]], %[[TMP]][%[[CONST_IDX]] : !s32i] : !cir.vector<4 x !s32i>
 // CIR: cir.store{{.*}} %[[NEW_VEC]], %[[VEC]] : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[VEC:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[VEC:.*]] = alloca <4 x i32>, align 16
 // LLVM: store <4 x i32> <i32 1, i32 2, i32 3, i32 4>, ptr %[[VEC]], align 16
 // LLVM: %[[TMP:.*]] = load <4 x i32>, ptr %[[VEC]], align 16
 // LLVM: %[[NEW_VEC:.*]] = insertelement <4 x i32> %[[TMP]], i32 5, i32 2
@@ -245,9 +245,9 @@ void foo6() {
 // CIR: %[[NEW_VEC:.*]] = cir.vec.insert %[[TMP1]], %[[TMP3]][%[[TMP2]] : !s32i] : !cir.vector<4 x !s32i>
 // CIR: cir.store{{.*}} %[[NEW_VEC]], %[[VEC]] : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[VEC:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[IDX:.*]] = alloca i32, i64 1, align 4
-// LLVM: %[[VAL:.*]] = alloca i32, i64 1, align 4
+// LLVM: %[[VEC:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[IDX:.*]] = alloca i32, align 4
+// LLVM: %[[VAL:.*]] = alloca i32, align 4
 // LLVM: store <4 x i32> <i32 1, i32 2, i32 3, i32 4>, ptr %1, align 16
 // LLVM: store i32 2, ptr %[[IDX]], align 4
 // LLVM: store i32 5, ptr %[[VAL]], align 4
@@ -287,7 +287,7 @@ void foo7() {
 // CIR: %[[NEW_VEC:.*]] = cir.vec.insert %[[RES]], %[[TMP2]][%[[CONST_IDX]] : !s32i] : !cir.vector<4 x !s32i>
 // CIR: cir.store{{.*}} %[[NEW_VEC]], %[[VEC]] : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[VEC:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[VEC:.*]] = alloca <4 x i32>, align 16
 // LLVM: store <4 x i32> <i32 1, i32 2, i32 3, i32 4>, ptr %[[VEC]], align 16
 // LLVM: %[[TMP:.*]] = load <4 x i32>, ptr %[[VEC]], align 16
 // LLVM: %[[ELE:.*]] = extractelement <4 x i32> %[[TMP]], i32 2
@@ -329,10 +329,10 @@ void foo8() {
 // CIR: %[[NOT:.*]] = cir.not %[[TMP3]] : !cir.vector<4 x !s32i>
 // CIR: cir.store{{.*}} %[[NOT]], %[[NOT_RES]] : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[VEC:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[PLUS_RES:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[MINUS_RES:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[NOT_RES:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[VEC:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[PLUS_RES:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[MINUS_RES:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[NOT_RES:.*]] = alloca <4 x i32>, align 16
 // LLVM: store <4 x i32> <i32 1, i32 2, i32 3, i32 4>, ptr %[[VEC]], align 16
 // LLVM: %[[TMP1:.*]] = load <4 x i32>, ptr %[[VEC]], align 16
 // LLVM: store <4 x i32> %[[TMP1]], ptr %[[PLUS_RES]], align 16
@@ -384,10 +384,10 @@ void foo9() {
 // CIR: %[[SHR:.*]] = cir.shift(right, %[[TMP_A]] : !cir.vector<4 x !s32i>, %[[TMP_B]] : !cir.vector<4 x !s32i>) -> !cir.vector<4 x !s32i>
 // CIR: cir.store{{.*}} %[[SHR]], %[[SHR_RES]] : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[VEC_B:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[SHL_RES:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[SHR_RES:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[VEC_B:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[SHL_RES:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[SHR_RES:.*]] = alloca <4 x i32>, align 16
 // LLVM: store <4 x i32> <i32 1, i32 2, i32 3, i32 4>, ptr %[[VEC_A]], align 16
 // LLVM: store <4 x i32> <i32 5, i32 6, i32 7, i32 8>, ptr %[[VEC_B]], align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[VEC_A]], align 16
@@ -441,10 +441,10 @@ void foo10() {
 // CIR: %[[SHR:.*]] = cir.shift(right, %[[TMP_B]] : !cir.vector<4 x !u32i>, %[[TMP_A]] : !cir.vector<4 x !s32i>) -> !cir.vector<4 x !u32i>
 // CIR: cir.store{{.*}} %[[SHR]], %[[SHR_RES]] : !cir.vector<4 x !u32i>, !cir.ptr<!cir.vector<4 x !u32i>>
 
-// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[VEC_B:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[SHL_RES:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[SHR_RES:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[VEC_B:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[SHL_RES:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[SHR_RES:.*]] = alloca <4 x i32>, align 16
 // LLVM: store <4 x i32> <i32 1, i32 2, i32 3, i32 4>, ptr %[[VEC_A]], align 16
 // LLVM: store <4 x i32> <i32 5, i32 6, i32 7, i32 8>, ptr %[[VEC_B]], align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[VEC_A]], align 16
@@ -526,8 +526,8 @@ void foo11() {
 // CIR: %[[XOR:.*]] = cir.xor %[[TMP_A]], %[[TMP_B]] : !cir.vector<4 x !s32i>
 // CIR: cir.store{{.*}} %[[XOR]], {{.*}} : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[VEC_B:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[VEC_B:.*]] = alloca <4 x i32>, align 16
 // LLVM: store <4 x i32> <i32 1, i32 2, i32 3, i32 4>, ptr %[[VEC_A]], align 16
 // LLVM: store <4 x i32> <i32 5, i32 6, i32 7, i32 8>, ptr %[[VEC_B]], align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[VEC_A]], align 16
@@ -645,8 +645,8 @@ void foo12() {
 // CIR: %[[GE:.*]] = cir.vec.cmp(ge, %[[TMP_A]], %[[TMP_B]]) : !cir.vector<4 x !s32i>, !cir.vector<4 x !s32i>
 // CIR: cir.store{{.*}} %[[GE]], {{.*}} : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[VEC_B:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[VEC_B:.*]] = alloca <4 x i32>, align 16
 // LLVM: store <4 x i32> <i32 1, i32 2, i32 3, i32 4>, ptr %[[VEC_A]], align 16
 // LLVM: store <4 x i32> <i32 5, i32 6, i32 7, i32 8>, ptr %[[VEC_B]], align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[VEC_A]], align 16
@@ -760,8 +760,8 @@ void foo13() {
 // CIR: %[[GE:.*]] = cir.vec.cmp(ge, %[[TMP_A]], %[[TMP_B]]) : !cir.vector<4 x !u32i>, !cir.vector<4 x !s32i>
 // CIR: cir.store{{.*}} %[[GE]], {{.*}} : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[VEC_B:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[VEC_B:.*]] = alloca <4 x i32>, align 16
 // LLVM: store <4 x i32> <i32 1, i32 2, i32 3, i32 4>, ptr %[[VEC_A]], align 16
 // LLVM: store <4 x i32> <i32 5, i32 6, i32 7, i32 8>, ptr %[[VEC_B]], align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[VEC_A]], align 16
@@ -875,8 +875,8 @@ void foo14() {
 // CIR: %[[GE:.*]] = cir.vec.cmp(ge, %[[TMP_A]], %[[TMP_B]]) : !cir.vector<4 x !cir.float>, !cir.vector<4 x !s32i>
 // CIR: cir.store{{.*}} %[[GE]], {{.*}} : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[VEC_A:.*]] = alloca <4 x float>, i64 1, align 16
-// LLVM: %[[VEC_B:.*]] = alloca <4 x float>, i64 1, align 16
+// LLVM: %[[VEC_A:.*]] = alloca <4 x float>, align 16
+// LLVM: %[[VEC_B:.*]] = alloca <4 x float>, align 16
 // LLVM: store <4 x float> <float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}>, ptr %[[VEC_A]], align 16
 // LLVM: store <4 x float> <float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}>, ptr %[[VEC_B]], align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x float>, ptr %[[VEC_A]], align 16
@@ -1038,7 +1038,7 @@ void foo17() {
 // CIR: %[[TMP:.*]] = cir.load{{.*}} %[[VEC_A]] : !cir.ptr<!cir.vector<2 x !cir.double>>, !cir.vector<2 x !cir.double>
 // CIR: %[[RES:.*]] = cir.cast float_to_int %[[TMP]] : !cir.vector<2 x !cir.double> -> !cir.vector<2 x !u16i>
 
-// LLVM: %[[VEC_A:.*]] = alloca <2 x double>, i64 1, align 16
+// LLVM: %[[VEC_A:.*]] = alloca <2 x double>, align 16
 // LLVM: %[[TMP:.*]] = load <2 x double>, ptr %[[VEC_A]], align 16
 // LLVM: %[[RES:.*]]= fptoui <2 x double> %[[TMP]] to <2 x i16>
 
@@ -1075,10 +1075,10 @@ void foo18() {
 // CIR: %[[SHR:.*]] = cir.shift(right, %[[TMP_B]] : !cir.vector<4 x !u32i>, %[[SPLAT_VEC]] : !cir.vector<4 x !u32i>) -> !cir.vector<4 x !u32i>
 // CIR: cir.store{{.*}} %[[SHR]], %[[SHR_RES]] : !cir.vector<4 x !u32i>, !cir.ptr<!cir.vector<4 x !u32i>>
 
-// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[SHL_RES:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[VEC_B:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[SHR_RES:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[SHL_RES:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[VEC_B:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[SHR_RES:.*]] = alloca <4 x i32>, align 16
 // LLVM: store <4 x i32> <i32 1, i32 2, i32 3, i32 4>, ptr %[[VEC_A]], align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[VEC_A]], align 16
 // LLVM: %[[SHL:.*]] = shl <4 x i32> %[[TMP_A]], splat (i32 3)
@@ -1114,8 +1114,8 @@ void foo19() {
 // CIR: %[[SHUF:.*]] = cir.vec.shuffle(%[[TMP_A]], %[[TMP_B]] : !cir.vector<4 x !s32i>) [#cir.int<7> :
 // CIR-SAME: !s64i, #cir.int<5> : !s64i, #cir.int<3> : !s64i, #cir.int<1> : !s64i] : !cir.vector<4 x !s32i>
 
-// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[VEC_B:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[VEC_B:.*]] = alloca <4 x i32>, align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[VEC_A]], align 16
 // LLVM: %[[TMP_B:.*]] = load <4 x i32>, ptr %[[VEC_B]], align 16
 // LLVM: %[[SHUF:.*]] = shufflevector <4 x i32> %[[TMP_A]], <4 x i32> %[[TMP_B]], <4 x i32> <i32 7, i32 5, i32 3, i32 1>
@@ -1194,8 +1194,8 @@ void foo23() {
 // CIR: %[[SHUF:.*]] = cir.vec.shuffle(%[[TMP_A]], %[[TMP_B]] : !cir.vector<4 x !s32i>) [#cir.int<-1> :
 // CIR-SAME: !s64i, #cir.int<1> : !s64i, #cir.int<-1> : !s64i, #cir.int<1> : !s64i] : !cir.vector<4 x !s32i>
 
-// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[VEC_B:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[VEC_A:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[VEC_B:.*]] = alloca <4 x i32>, align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[VEC_A]], align 16
 // LLVM: %[[TMP_B:.*]] = load <4 x i32>, ptr %[[VEC_B]], align 16
 // LLVM: %[[SHUF:.*]] = shufflevector <4 x i32> %[[TMP_A]], <4 x i32> %[[TMP_B]], <4 x i32> <i32 poison, i32 1, i32 poison, i32 1>
@@ -1215,7 +1215,7 @@ void foo24() {
 // CIR: %[[SIZE:.*]] = cir.const #cir.int<4> : !u64i
 // CIR: cir.store align(8) %[[SIZE]], %[[INIT]] : !u64i, !cir.ptr<!u64i>
 
-// LLVM: %[[SIZE:.*]] = alloca i64, i64 1, align 8
+// LLVM: %[[SIZE:.*]] = alloca i64, align 8
 // LLVM: store i64 4, ptr %[[SIZE]], align 8
 
 // OGCG: %[[SIZE:.*]] = alloca i64, align 8
@@ -1238,9 +1238,9 @@ void logical_or_vi4() {
 // CIR: %[[RESULT:.*]] = cir.or %[[NE_A_ZERO]], %[[NE_B_ZERO]] : !cir.vector<4 x !s32i>
 // CIR: cir.store{{.*}} %[[RESULT]], %[[C_ADDR]] : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[B_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[C_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[B_ADDR:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[C_ADDR:.*]] = alloca <4 x i32>, align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[A_ADDR]], align 16
 // LLVM: %[[TMP_B:.*]] = load <4 x i32>, ptr %[[B_ADDR]], align 16
 // LLVM: %[[NE_A_ZERO:.*]] = icmp ne <4 x i32> %[[TMP_A]], zeroinitializer
@@ -1278,9 +1278,9 @@ void logical_or_vf4() {
 // CIR: %[[RESULT:.*]] = cir.or %[[NE_A_ZERO]], %[[NE_B_ZERO]] : !cir.vector<4 x !s32i>
 // CIR: cir.store {{.*}} %[[RESULT]], %[[C_ADDR]] : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca <4 x float>, i64 1, align 16
-// LLVM: %[[B_ADDR:.*]] = alloca <4 x float>, i64 1, align 16
-// LLVM: %[[C_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[A_ADDR:.*]] = alloca <4 x float>, align 16
+// LLVM: %[[B_ADDR:.*]] = alloca <4 x float>, align 16
+// LLVM: %[[C_ADDR:.*]] = alloca <4 x i32>, align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x float>, ptr %[[A_ADDR]], align 16
 // LLVM: %[[TMP_B:.*]] = load <4 x float>, ptr %[[B_ADDR]], align 16
 // LLVM: %[[NE_A_ZERO:.*]] = fcmp une <4 x float> %[[TMP_A]], zeroinitializer
@@ -1318,9 +1318,9 @@ void foo27() {
 // CIR: %[[RESULT_VF16:.*]] = cir.cast floating %[[RESULT]] : !cir.vector<4 x !cir.float> -> !cir.vector<4 x !cir.f16>
 // CIR: cir.store{{.*}} %[[RESULT_VF16]], %[[C_ADDR]] : !cir.vector<4 x !cir.f16>, !cir.ptr<!cir.vector<4 x !cir.f16>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca <4 x half>, i64 1, align 8
-// LLVM: %[[B_ADDR:.*]] = alloca <4 x half>, i64 1, align 8
-// LLVM: %[[C_ADDR:.*]] = alloca <4 x half>, i64 1, align 8
+// LLVM: %[[A_ADDR:.*]] = alloca <4 x half>, align 8
+// LLVM: %[[B_ADDR:.*]] = alloca <4 x half>, align 8
+// LLVM: %[[C_ADDR:.*]] = alloca <4 x half>, align 8
 // LLVM: %[[TMP_A:.*]] = load <4 x half>, ptr %[[A_ADDR]], align 8
 // LLVM: %[[TMP_A_F16:.*]] = fpext <4 x half> %[[TMP_A]] to <4 x float>
 // LLVM: %[[TMP_B:.*]] = load <4 x half>, ptr %[[B_ADDR]], align 8
@@ -1357,9 +1357,9 @@ void logical_and_vi4() {
 // CIR: %[[RESULT:.*]] = cir.and %[[NE_A_ZERO]], %[[NE_B_ZERO]] : !cir.vector<4 x !s32i>
 // CIR: cir.store{{.*}} %[[RESULT]], %[[C_ADDR]] : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[B_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[C_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[B_ADDR:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[C_ADDR:.*]] = alloca <4 x i32>, align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[A_ADDR]], align 16
 // LLVM: %[[TMP_B:.*]] = load <4 x i32>, ptr %[[B_ADDR]], align 16
 // LLVM: %[[NE_A_ZERO:.*]] = icmp ne <4 x i32> %[[TMP_A]], zeroinitializer
@@ -1397,9 +1397,9 @@ void logical_and_vf4() {
 // CIR: %[[RESULT:.*]] = cir.and %[[NE_A_ZERO]], %[[NE_B_ZERO]] : !cir.vector<4 x !s32i>
 // CIR: cir.store {{.*}} %[[RESULT]], %[[C_ADDR]] : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca <4 x float>, i64 1, align 16
-// LLVM: %[[B_ADDR:.*]] = alloca <4 x float>, i64 1, align 16
-// LLVM: %[[C_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[A_ADDR:.*]] = alloca <4 x float>, align 16
+// LLVM: %[[B_ADDR:.*]] = alloca <4 x float>, align 16
+// LLVM: %[[C_ADDR:.*]] = alloca <4 x i32>, align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x float>, ptr %[[A_ADDR]], align 16
 // LLVM: %[[TMP_B:.*]] = load <4 x float>, ptr %[[B_ADDR]], align 16
 // LLVM: %[[NE_A_ZERO:.*]] = fcmp une <4 x float> %[[TMP_A]], zeroinitializer
@@ -1432,8 +1432,8 @@ void logical_not() {
 // CIR: %[[RESULT:.*]] = cir.vec.cmp(eq, %[[TMP_A]], %[[CONST_V0]]) : !cir.vector<4 x !s32i>, !cir.vector<4 x !s32i>
 // CIR: cir.store{{.*}} %[[RESULT]], %[[B_ADDR]] : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[B_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[B_ADDR:.*]] = alloca <4 x i32>, align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[A_ADDR]], align 16
 // LLVM: %[[RESULT:.*]] = icmp eq <4 x i32> %[[TMP_A]], zeroinitializer
 // LLVM: %[[RESULT_VI4:.*]] = sext <4 x i1> %[[RESULT]] to <4 x i32>
@@ -1458,8 +1458,8 @@ void logical_not_float() {
 // CIR: %[[RESULT:.*]] = cir.vec.cmp(eq, %[[TMP_A]], %[[CONST_V0]]) : !cir.vector<4 x !cir.float>, !cir.vector<4 x !s32i>
 // CIR: cir.store{{.*}} %[[RESULT]], %[[B_ADDR]] : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca <4 x float>, i64 1, align 16
-// LLVM: %[[B_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[A_ADDR:.*]] = alloca <4 x float>, align 16
+// LLVM: %[[B_ADDR:.*]] = alloca <4 x i32>, align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x float>, ptr %[[A_ADDR]], align 16
 // LLVM: %[[RESULT:.*]] = fcmp oeq <4 x float> %[[TMP_A]], zeroinitializer
 // LLVM: %[[RESULT_VI4:.*]] = sext <4 x i1> %[[RESULT]] to <4 x i32>
@@ -1482,8 +1482,8 @@ void unary_extension() {
 // CIR: %[[TMP_A:.*]] = cir.load{{.*}} %[[A_ADDR]] : !cir.ptr<!cir.vector<4 x !s32i>>, !cir.vector<4 x !s32i>
 // CIR: cir.store{{.*}} %[[TMP_A]], %[[B_ADDR]] : !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[B_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[B_ADDR:.*]] = alloca <4 x i32>, align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[A_ADDR]], align 16
 // LLVM: store <4 x i32> %[[TMP_A]], ptr %[[B_ADDR]], align 16
 
@@ -1511,10 +1511,10 @@ vi4 ternary_expression_with_vec_cond() {
 // CIR: %[[TMP_RET:.*]] = cir.load %[[RET_ADDR]] : !cir.ptr<!cir.vector<4 x !s32i>>, !cir.vector<4 x !s32i>
 // CIR: cir.return %[[TMP_RET]] : !cir.vector<4 x !s32i>
 
-// LLVM: %[[RET_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[B_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
-// LLVM: %[[C_ADDR:.*]] = alloca <4 x i32>, i64 1, align 16
+// LLVM: %[[RET_ADDR:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[A_ADDR:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[B_ADDR:.*]] = alloca <4 x i32>, align 16
+// LLVM: %[[C_ADDR:.*]] = alloca <4 x i32>, align 16
 // LLVM: %[[TMP_C:.*]] = load <4 x i32>, ptr %[[C_ADDR]], align 16
 // LLVM: %[[TMP_A:.*]] = load <4 x i32>, ptr %[[A_ADDR]], align 16
 // LLVM: %[[TMP_B:.*]] = load <4 x i32>, ptr %[[B_ADDR]], align 16

--- a/clang/test/CIR/CodeGen/virtual-destructor-calls.cpp
+++ b/clang/test/CIR/CodeGen/virtual-destructor-calls.cpp
@@ -141,7 +141,7 @@ D::~D() = default;
 // CIR: cir.return
 
 // LLVM: define {{.*}} @_ZN1DD2Ev
-// LLVM: %[[THIS_ADDR:.*]] = alloca ptr, i64 1, align 8
+// LLVM: %[[THIS_ADDR:.*]] = alloca ptr, align 8
 // LLVM: store ptr %[[THIS:.*]], ptr %[[THIS_ADDR]], align 8
 // LLVM: %[[THIS1:.*]] = load ptr, ptr %[[THIS_ADDR]], align 8
 // LLVM: ret void
@@ -161,7 +161,7 @@ D::~D() = default;
 // CIR: cir.trap
 
 // LLVM: define {{.*}} @_ZN1DD0Ev
-// LLVM:  %[[THIS_ADDR:.*]] = alloca ptr, i64 1, align 8
+// LLVM:  %[[THIS_ADDR:.*]] = alloca ptr, align 8
 // LLVM:  store ptr %[[THIS:.*]], ptr %[[THIS_ADDR]], align 8
 // LLVM:  %[[THIS1:.*]] = load ptr, ptr %[[THIS_ADDR]], align 8
 // LLVM:  call void @llvm.trap()

--- a/clang/test/CIR/CodeGen/vla.c
+++ b/clang/test/CIR/CodeGen/vla.c
@@ -407,9 +407,9 @@ void vla_subscript_expr() {
 // CIR: %[[ELEM_5_PTR:.*]] = cir.ptr_stride %[[VLA_A_PTR]], %[[CONST_5]] : (!cir.ptr<!s32i>, !s64i) -> !cir.ptr<!s32i>
 // CIR: cir.store {{.*}} %[[CONST_0_VAL]], %[[ELEM_5_PTR]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM: %[[A_ADDR:.*]] = alloca ptr, i64 1, align 8
-// LLVM: %[[N_ADDR:.*]] = alloca i64, i64 1, align 8
-// LLVM: %[[COMPOUND_ADDR:.*]] = alloca ptr, i64 1, align 8
+// LLVM: %[[A_ADDR:.*]] = alloca ptr, align 8
+// LLVM: %[[N_ADDR:.*]] = alloca i64, align 8
+// LLVM: %[[COMPOUND_ADDR:.*]] = alloca ptr, align 8
 // LLVM: store i64 5, ptr %[[N_ADDR]], align 8
 // LLVM: %[[TMP_N:.*]] = load i64, ptr %[[N_ADDR]], align 8
 // LLVM: store ptr %[[A_ADDR]], ptr %[[COMPOUND_ADDR]], align 8
@@ -529,8 +529,8 @@ void complex_vla_cast(int n) {
 // CIR:   }
 
 // LLVM: define {{.*}} void @complex_vla_cast
-// LLVM:   %[[LEN_ADDR:.*]] = alloca i32, i64 1, align 4
-// LLVM:   %[[SAVED_STACK:.*]] = alloca ptr, i64 1, align 8
+// LLVM:   %[[LEN_ADDR:.*]] = alloca i32, align 4
+// LLVM:   %[[SAVED_STACK:.*]] = alloca ptr, align 8
 // LLVM:   store i32 %{{.*}}, ptr %[[LEN_ADDR]], align 4
 // LLVM:   %[[LEN:.*]] = load i32, ptr %[[LEN_ADDR]], align 4
 // LLVM:   %[[LEN_SIZE_T:.*]] = sext i32 %[[LEN]] to i64

--- a/clang/test/CIR/CodeGen/vtt.cpp
+++ b/clang/test/CIR/CodeGen/vtt.cpp
@@ -488,7 +488,7 @@ D::D() {}
 // CIR-COMMON:        cir.store{{.*}} %[[VPTR]], %[[VPTR_ADDR]] : !cir.vptr, !cir.ptr<!cir.vptr>
 
 // LLVM-COMMON: define {{.*}} void @_ZN1AC2Ev(ptr {{.*}} %[[THIS_ARG:.*]]){{.*}} {
-// LLVM-COMMON:   %[[THIS_ADDR:.*]] = alloca ptr, i64 1, align 8
+// LLVM-COMMON:   %[[THIS_ADDR:.*]] = alloca ptr, align 8
 // LLVM-COMMON:   store ptr %[[THIS_ARG]], ptr %[[THIS_ADDR]], align 8
 // LLVM-COMMON:   %[[THIS:.*]] = load ptr, ptr %[[THIS_ADDR]], align 8
 // LLVM-COMMON:   store ptr getelementptr inbounds nuw (i8, ptr @_ZTV1A, i64 16), ptr %[[THIS]]

--- a/clang/test/CIR/CodeGenBuiltins/builtin-address-of.cpp
+++ b/clang/test/CIR/CodeGenBuiltins/builtin-address-of.cpp
@@ -19,8 +19,8 @@ void builtin_address_of() {
 // CIR: %[[B_ADDR:.*]] = cir.alloca "b" {{.*}} init : !cir.ptr<!cir.ptr<!rec_Container>>
 // CIR: cir.store {{.*}} %[[A_ADDR]], %[[B_ADDR]] : !cir.ptr<!rec_Container>, !cir.ptr<!cir.ptr<!rec_Container>>
 
-// LLVM: %[[A_ADDR:.*]] = alloca %struct.Container, i64 1, align 4
-// LLVM: %[[B_ADDR:.*]] = alloca ptr, i64 1, align 8
+// LLVM: %[[A_ADDR:.*]] = alloca %struct.Container, align 4
+// LLVM: %[[B_ADDR:.*]] = alloca ptr, align 8
 // LLVM: store ptr %[[A_ADDR]], ptr %[[B_ADDR]], align 8
 
 // OGCG: %[[A_ADDR:.*]] = alloca %struct.Container, align 4

--- a/clang/test/CIR/CodeGenBuiltins/builtin-bcopy.cpp
+++ b/clang/test/CIR/CodeGenBuiltins/builtin-bcopy.cpp
@@ -20,8 +20,8 @@ void foo(void) {
   // CIR: cir.return
 
   // LLVM-LABEL: define dso_local void @_Z3foov()
-  // LLVM: %[[V1:.*]] = alloca [4 x float], i64 1, align 16
-  // LLVM: %[[V2:.*]] = alloca [8 x float], i64 1, align 16
+  // LLVM: %[[V1:.*]] = alloca [4 x float], align 16
+  // LLVM: %[[V2:.*]] = alloca [8 x float], align 16
   // LLVM: %[[V3:.*]] = getelementptr float, ptr %[[V1]], i32 0
   // LLVM: %[[V4:.*]] = getelementptr float, ptr %[[V2]], i32 0
   // LLVM: call void @llvm.memmove.p0.p0.i64(ptr %[[V4]], ptr %[[V3]], i64 16, i1 false)

--- a/clang/test/CIR/CodeGenBuiltins/builtin-fcmp-sse.c
+++ b/clang/test/CIR/CodeGenBuiltins/builtin-fcmp-sse.c
@@ -30,9 +30,9 @@ __m128 test_cmpnleps(__m128 A, __m128 B) {
 
   // LLVM-LABEL: define dso_local <4 x float> @test_cmpnleps(
   // LLVM-SAME: <4 x float> noundef [[TMP0:%.*]], <4 x float> noundef [[TMP1:%.*]]) #{{[0-9]+}} {
-  // LLVM-NEXT:    [[TMP3:%.*]] = alloca <4 x float>, i64 1, align 16
-  // LLVM-NEXT:    [[TMP4:%.*]] = alloca <4 x float>, i64 1, align 16
-  // LLVM-NEXT:    [[TMP5:%.*]] = alloca <4 x float>, i64 1, align 16
+  // LLVM-NEXT:    [[TMP3:%.*]] = alloca <4 x float>, align 16
+  // LLVM-NEXT:    [[TMP4:%.*]] = alloca <4 x float>, align 16
+  // LLVM-NEXT:    [[TMP5:%.*]] = alloca <4 x float>, align 16
   // LLVM-NEXT:    store <4 x float> [[TMP0]], ptr [[TMP3]], align 16
   // LLVM-NEXT:    store <4 x float> [[TMP1]], ptr [[TMP4]], align 16
   // LLVM-NEXT:    [[TMP6:%.*]] = load <4 x float>, ptr [[TMP3]], align 16
@@ -81,9 +81,9 @@ __m128d test_cmpnlepd(__m128d A, __m128d B) {
 
   // LLVM-LABEL: define dso_local <2 x double> @test_cmpnlepd(
   // LLVM-SAME: <2 x double> noundef [[TMP0:%.*]], <2 x double> noundef [[TMP1:%.*]]) #{{[0-9]+}} {
-  // LLVM-NEXT:    [[TMP3:%.*]] = alloca <2 x double>, i64 1, align 16
-  // LLVM-NEXT:    [[TMP4:%.*]] = alloca <2 x double>, i64 1, align 16
-  // LLVM-NEXT:    [[TMP5:%.*]] = alloca <2 x double>, i64 1, align 16
+  // LLVM-NEXT:    [[TMP3:%.*]] = alloca <2 x double>, align 16
+  // LLVM-NEXT:    [[TMP4:%.*]] = alloca <2 x double>, align 16
+  // LLVM-NEXT:    [[TMP5:%.*]] = alloca <2 x double>, align 16
   // LLVM-NEXT:    store <2 x double> [[TMP0]], ptr [[TMP3]], align 16
   // LLVM-NEXT:    store <2 x double> [[TMP1]], ptr [[TMP4]], align 16
   // LLVM-NEXT:    [[TMP6:%.*]] = load <2 x double>, ptr [[TMP3]], align 16
@@ -132,9 +132,9 @@ __m128 test_cmpnltps(__m128 A, __m128 B) {
 
   // LLVM-LABEL: define dso_local <4 x float> @test_cmpnltps(
   // LLVM-SAME: <4 x float> noundef [[TMP0:%.*]], <4 x float> noundef [[TMP1:%.*]]) #{{[0-9]+}} {
-  // LLVM-NEXT:    [[TMP3:%.*]] = alloca <4 x float>, i64 1, align 16
-  // LLVM-NEXT:    [[TMP4:%.*]] = alloca <4 x float>, i64 1, align 16
-  // LLVM-NEXT:    [[TMP5:%.*]] = alloca <4 x float>, i64 1, align 16
+  // LLVM-NEXT:    [[TMP3:%.*]] = alloca <4 x float>, align 16
+  // LLVM-NEXT:    [[TMP4:%.*]] = alloca <4 x float>, align 16
+  // LLVM-NEXT:    [[TMP5:%.*]] = alloca <4 x float>, align 16
   // LLVM-NEXT:    store <4 x float> [[TMP0]], ptr [[TMP3]], align 16
   // LLVM-NEXT:    store <4 x float> [[TMP1]], ptr [[TMP4]], align 16
   // LLVM-NEXT:    [[TMP6:%.*]] = load <4 x float>, ptr [[TMP3]], align 16
@@ -183,9 +183,9 @@ __m128d test_cmpnltpd(__m128d A, __m128d B) {
 
   // LLVM-LABEL: define dso_local <2 x double> @test_cmpnltpd(
   // LLVM-SAME: <2 x double> noundef [[TMP0:%.*]], <2 x double> noundef [[TMP1:%.*]]) #{{[0-9]+}} {
-  // LLVM-NEXT:    [[TMP3:%.*]] = alloca <2 x double>, i64 1, align 16
-  // LLVM-NEXT:    [[TMP4:%.*]] = alloca <2 x double>, i64 1, align 16
-  // LLVM-NEXT:    [[TMP5:%.*]] = alloca <2 x double>, i64 1, align 16
+  // LLVM-NEXT:    [[TMP3:%.*]] = alloca <2 x double>, align 16
+  // LLVM-NEXT:    [[TMP4:%.*]] = alloca <2 x double>, align 16
+  // LLVM-NEXT:    [[TMP5:%.*]] = alloca <2 x double>, align 16
   // LLVM-NEXT:    store <2 x double> [[TMP0]], ptr [[TMP3]], align 16
   // LLVM-NEXT:    store <2 x double> [[TMP1]], ptr [[TMP4]], align 16
   // LLVM-NEXT:    [[TMP6:%.*]] = load <2 x double>, ptr [[TMP3]], align 16

--- a/clang/test/CIR/CodeGenBuiltins/builtin-offset-of.cpp
+++ b/clang/test/CIR/CodeGenBuiltins/builtin-offset-of.cpp
@@ -32,10 +32,10 @@ void offset_of_builtin() {
 // CIR: %[[CONST_16:.*]] = cir.const #cir.int<16> : !u64i
 // CIR: cir.store {{.*}} %[[CONST_16]], %[[D_ADDR]] : !u64i, !cir.ptr<!u64i>
 
-// LLVM: %[[A_ADDR:.*]] = alloca i64, i64 1, align 8
-// LLVM: %[[B_ADDR:.*]] = alloca i64, i64 1, align 8
-// LLVM: %[[C_ADDR:.*]] = alloca i64, i64 1, align 8
-// LLVM: %[[D_ADDR:.*]] = alloca i64, i64 1, align 8
+// LLVM: %[[A_ADDR:.*]] = alloca i64, align 8
+// LLVM: %[[B_ADDR:.*]] = alloca i64, align 8
+// LLVM: %[[C_ADDR:.*]] = alloca i64, align 8
+// LLVM: %[[D_ADDR:.*]] = alloca i64, align 8
 // LLVM: store i64 0, ptr %[[A_ADDR]], align 8
 // LLVM: store i64 4, ptr %[[B_ADDR]], align 8
 // LLVM: store i64 8, ptr %[[C_ADDR]], align 8
@@ -74,10 +74,10 @@ void offset_of_builtin_from_array_element() {
 // CIR: %[[CONST_376:.*]] = cir.const #cir.int<376> : !u64i
 // CIR: cir.store {{.*}} %[[CONST_376]], %[[D_ADDR]] : !u64i, !cir.ptr<!u64i>
 
-// LLVM: %[[A_ADDR:.*]] = alloca i64, i64 1, align 8
-// LLVM: %[[B_ADDR:.*]] = alloca i64, i64 1, align 8
-// LLVM: %[[C_ADDR:.*]] = alloca i64, i64 1, align 8
-// LLVM: %[[D_ADDR:.*]] = alloca i64, i64 1, align 8
+// LLVM: %[[A_ADDR:.*]] = alloca i64, align 8
+// LLVM: %[[B_ADDR:.*]] = alloca i64, align 8
+// LLVM: %[[C_ADDR:.*]] = alloca i64, align 8
+// LLVM: %[[D_ADDR:.*]] = alloca i64, align 8
 // LLVM: store i64 0, ptr %[[A_ADDR]], align 8
 // LLVM: store i64 124, ptr %[[B_ADDR]], align 8
 // LLVM: store i64 248, ptr %[[C_ADDR]], align 8

--- a/clang/test/CIR/CodeGenBuiltins/builtin-prefetch.c
+++ b/clang/test/CIR/CodeGenBuiltins/builtin-prefetch.c
@@ -23,7 +23,7 @@ void foo(void *a) {
 // CIR: cir.return
 
 // LLVM-LABEL: define dso_local void @foo(
-// LLVM: [[ALLOCA:%.*]] = alloca ptr, i64 1
+// LLVM: [[ALLOCA:%.*]] = alloca ptr, 
 // LLVM: store ptr {{.*}}, ptr [[ALLOCA]]
 // LLVM: [[LP1:%.*]] = load ptr, ptr [[ALLOCA]]
 // LLVM: call void @llvm.prefetch.p0(ptr [[LP1]], i32 0, i32 3, i32 1)

--- a/clang/test/CIR/CodeGenCUDA/address-spaces.cu
+++ b/clang/test/CIR/CodeGenCUDA/address-spaces.cu
@@ -167,7 +167,7 @@ __global__ void fn() {
 // CIR-DEVICE:   cir.return
 
 // LLVM-DEVICE: define dso_local ptx_kernel void @_Z2fnv()
-// LLVM-DEVICE:   %[[ALLOCA:.*]] = alloca i32, i64 1, align 4
+// LLVM-DEVICE:   %[[ALLOCA:.*]] = alloca i32, align 4
 // LLVM-DEVICE:   store i32 0, ptr %[[ALLOCA]], align 4
 // LLVM-DEVICE:   %[[VAL:.*]] = load i32, ptr %[[ALLOCA]], align 4
 // LLVM-DEVICE:   store i32 %[[VAL]], ptr @_ZZ2fnvE1j, align 4

--- a/clang/test/CIR/CodeGenOpenMP/omp-llvmir.c
+++ b/clang/test/CIR/CodeGenOpenMP/omp-llvmir.c
@@ -40,8 +40,8 @@
 
 // LLVM-LABEL: define dso_local i32 @main()
 // LLVM: %[[STRUCTARG:.*]] = alloca { ptr }, align 8
-// LLVM: %[[RETVAL:.*]] = alloca i32, i64 1, align 4
-// LLVM: %[[J:.*]] = alloca i32, i64 1, align 4
+// LLVM: %[[RETVAL:.*]] = alloca i32, align 4
+// LLVM: %[[J:.*]] = alloca i32, align 4
 // LLVM: br label %[[ENTRY:.*]]
 
 // LLVM: [[ENTRY]]:
@@ -66,7 +66,7 @@
 // LLVM: %[[TID_VAL:.*]] = load i32, ptr %{{.*}}, align 4
 // LLVM: store i32 %[[TID_VAL]], ptr %[[TID_LOCAL]], align 4
 // LLVM: %{{.*}} = load i32, ptr %[[TID_LOCAL]], align 4
-// LLVM: %[[I:.*]] = alloca i32, i64 1, align 4
+// LLVM: %[[I:.*]] = alloca i32, align 4
 // LLVM: br label %[[AFTER_ALLOCA:.*]]
 
 // LLVM: [[AFTER_ALLOCA]]:

--- a/clang/test/CIR/CodeGenOpenMP/target-map-llvm-host.c
+++ b/clang/test/CIR/CodeGenOpenMP/target-map-llvm-host.c
@@ -39,7 +39,7 @@ void target_map_multiple(int a, int b) {
 //
 // LLVM-LABEL: define {{.*}} void @target_map_to(
 // LLVM-SAME:  i32 noundef %[[ARG:[^,)]+]]
-// LLVM:         %[[X_ADDR:.*]] = alloca i32, i64 1, align 4
+// LLVM:         %[[X_ADDR:.*]] = alloca i32, align 4
 // LLVM:         store i32 %[[ARG]], ptr %[[X_ADDR]], align 4
 // LLVM:         %[[BP:.*]] = getelementptr inbounds [2 x ptr], ptr %.offload_baseptrs, i32 0, i32 0
 // LLVM:         store ptr %[[X_ADDR]], ptr %[[BP]], align 8
@@ -51,7 +51,7 @@ void target_map_multiple(int a, int b) {
 
 // LLVM-LABEL: define {{.*}} void @target_map_from(
 // LLVM-SAME:  i32 noundef %[[ARG:[^,)]+]]
-// LLVM:         %[[X_ADDR:.*]] = alloca i32, i64 1, align 4
+// LLVM:         %[[X_ADDR:.*]] = alloca i32, align 4
 // LLVM:         store i32 %[[ARG]], ptr %[[X_ADDR]], align 4
 // LLVM:         %[[BP:.*]] = getelementptr inbounds [2 x ptr], ptr %.offload_baseptrs, i32 0, i32 0
 // LLVM:         store ptr %[[X_ADDR]], ptr %[[BP]], align 8
@@ -63,7 +63,7 @@ void target_map_multiple(int a, int b) {
 
 // LLVM-LABEL: define {{.*}} void @target_map_tofrom(
 // LLVM-SAME:  i32 noundef %[[ARG:[^,)]+]]
-// LLVM:         %[[X_ADDR:.*]] = alloca i32, i64 1, align 4
+// LLVM:         %[[X_ADDR:.*]] = alloca i32, align 4
 // LLVM:         store i32 %[[ARG]], ptr %[[X_ADDR]], align 4
 // LLVM:         %[[BP:.*]] = getelementptr inbounds [2 x ptr], ptr %.offload_baseptrs, i32 0, i32 0
 // LLVM:         store ptr %[[X_ADDR]], ptr %[[BP]], align 8
@@ -75,8 +75,8 @@ void target_map_multiple(int a, int b) {
 
 // LLVM-LABEL: define {{.*}} void @target_map_multiple(
 // LLVM-SAME:  i32 noundef %[[ARG_A:[^,)]+]], i32 noundef %[[ARG_B:[^,)]+]]
-// LLVM:         %[[A_ADDR:.*]] = alloca i32, i64 1, align 4
-// LLVM:         %[[B_ADDR:.*]] = alloca i32, i64 1, align 4
+// LLVM:         %[[A_ADDR:.*]] = alloca i32, align 4
+// LLVM:         %[[B_ADDR:.*]] = alloca i32, align 4
 // LLVM:         store i32 %[[ARG_A]], ptr %[[A_ADDR]], align 4
 // LLVM:         store i32 %[[ARG_B]], ptr %[[B_ADDR]], align 4
 // LLVM:         %[[BP_A:.*]] = getelementptr inbounds [3 x ptr], ptr %.offload_baseptrs, i32 0, i32 0

--- a/clang/test/CIR/Lowering/alloca.cir
+++ b/clang/test/CIR/Lowering/alloca.cir
@@ -4,8 +4,8 @@
 
 module {
   // CHECK-LABEL: llvm.func @alloca_i32
-  // CHECK:         %[[SIZE:.*]] = llvm.mlir.constant(1 : i64) : i64
-  // CHECK-NEXT:    %{{.*}} = llvm.alloca %[[SIZE]] x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr
+  // CHECK:         %[[SIZE:.*]] = llvm.mlir.constant(1 : i32) : i32
+  // CHECK-NEXT:    %{{.*}} = llvm.alloca %[[SIZE]] x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
   cir.func @alloca_i32() {
     %0 = cir.alloca "var_name" align(4) : !cir.ptr<!s32i>
     cir.return

--- a/clang/test/CIR/Lowering/array.cpp
+++ b/clang/test/CIR/Lowering/array.cpp
@@ -48,9 +48,9 @@ void func() {
   int e2 = arr[1];
 }
 // CHECK: define{{.*}} void @_Z4funcv()
-// CHECK-NEXT: %[[ARR_ALLOCA:.*]] = alloca [10 x i32], i64 1, align 16
-// CHECK-NEXT: %[[INIT:.*]] = alloca i32, i64 1, align 4
-// CHECK-NEXT: %[[INIT_2:.*]] = alloca i32, i64 1, align 4
+// CHECK-NEXT: %[[ARR_ALLOCA:.*]] = alloca [10 x i32], align 16
+// CHECK-NEXT: %[[INIT:.*]] = alloca i32, align 4
+// CHECK-NEXT: %[[INIT_2:.*]] = alloca i32, align 4
 // CHECK-NEXT: %[[ELE_PTR:.*]] = getelementptr [10 x i32], ptr %[[ARR_ALLOCA]], i32 0, i64 0
 // CHECK-NEXT: %[[TMP:.*]] = load i32, ptr %[[ELE_PTR]], align 16
 // CHECK-NEXT: store i32 %[[TMP]], ptr %[[INIT]], align 4
@@ -63,7 +63,7 @@ void func2() {
 }
 
 // CHECK: define{{.*}} void @_Z5func2v()
-// CHECK:   %[[ARR:.*]] = alloca [2 x i32], i64 1, align 4
+// CHECK:   %[[ARR:.*]] = alloca [2 x i32], align 4
 // CHECK:   call void @llvm.memcpy{{.*}}(ptr align 4 %[[ARR]], ptr align 4 @[[FUNC2_ARR]], i64 8, i1 false)
 // CHECK:   ret void
 
@@ -71,7 +71,7 @@ void func3() {
   int arr3[2] = {5, 6};
 }
 // CHECK: define{{.*}} void @_Z5func3v()
-// CHECK:  %[[ARR_ALLOCA:.*]] = alloca [2 x i32], i64 1, align 4
+// CHECK:  %[[ARR_ALLOCA:.*]] = alloca [2 x i32], align 4
 // CHECK:  call void @llvm.memcpy{{.*}}(ptr align 4 %[[ARR_ALLOCA]], ptr align 4 @[[FUNC3_ARR]], i64 8, i1 false)
 
 void func4() {
@@ -79,8 +79,8 @@ void func4() {
   int e = arr[1][0];
 }
 // CHECK: define{{.*}} void @_Z5func4v()
-// CHECK:  %[[ARR_ALLOCA:.*]] = alloca [2 x [1 x i32]], i64 1, align 4
-// CHECK:  %[[INIT:.*]] = alloca i32, i64 1, align 4
+// CHECK:  %[[ARR_ALLOCA:.*]] = alloca [2 x [1 x i32]], align 4
+// CHECK:  %[[INIT:.*]] = alloca i32, align 4
 // CHECK:  call void @llvm.memcpy{{.*}}(ptr align 4 %[[ARR_ALLOCA]], ptr align 4 @[[FUNC4_ARR]], i64 8, i1 false)
 // CHECK:  %[[ARR_1:.*]] = getelementptr [2 x [1 x i32]], ptr %[[ARR_ALLOCA]], i32 0, i64 1
 // CHECK:  %[[ELE_PTR:.*]] = getelementptr [1 x i32], ptr %[[ARR_1]], i32 0, i64 0
@@ -91,7 +91,7 @@ void func5() {
   int arr[2][1] = {{5}};
 }
 // CHECK: define{{.*}} void @_Z5func5v()
-// CHECK:   %[[ARR:.*]] = alloca [2 x [1 x i32]], i64 1, align 4
+// CHECK:   %[[ARR:.*]] = alloca [2 x [1 x i32]], align 4
 // CHECK:   call void @llvm.memcpy{{.*}}(ptr align 4 %[[ARR]], ptr align 4 @[[FUNC5_ARR]], i64 8, i1 false)
 // CHECK:   ret void
 
@@ -100,8 +100,8 @@ void func6() {
   int arr[2] = { x, 5 };
 }
 // CHECK: define{{.*}} void @_Z5func6v()
-// CHECK:  %[[VAR:.*]] = alloca i32, i64 1, align 4
-// CHECK:  %[[ARR:.*]] = alloca [2 x i32], i64 1, align 4
+// CHECK:  %[[VAR:.*]] = alloca i32, align 4
+// CHECK:  %[[ARR:.*]] = alloca [2 x i32], align 4
 // CHECK:  store i32 4, ptr %[[VAR]], align 4
 // CHECK:  %[[ELE_0:.*]] = getelementptr i32, ptr %[[ARR]], i32 0
 // CHECK:  %[[TMP:.*]] = load i32, ptr %[[VAR]], align 4
@@ -113,14 +113,14 @@ void func7() {
   int* arr[1] = {};
 }
 // CHECK: define{{.*}} void @_Z5func7v()
-// CHECK:   %[[ARR:.*]] = alloca [1 x ptr], i64 1, align 8
+// CHECK:   %[[ARR:.*]] = alloca [1 x ptr], align 8
 // CHECK:   call void @llvm.memcpy{{.*}}(ptr align 8 %[[ARR]], ptr align 8 @[[FUNC7_ARR]], i64 8, i1 false)
 // CHECK:   ret void
 
 void func8(int p[10]) {}
 // CHECK: define{{.*}} void @_Z5func8Pi(ptr noundef {{%.*}})
-// CHECK-NEXT: alloca ptr, i64 1, align 8
+// CHECK-NEXT: alloca ptr, align 8
 
 void func9(int pp[10][5]) {}
 // CHECK: define{{.*}} void @_Z5func9PA5_i(ptr noundef {{%.*}})
-// CHECK-NEXT: alloca ptr, i64 1, align 8
+// CHECK-NEXT: alloca ptr, align 8

--- a/clang/test/CIR/Lowering/basic.cpp
+++ b/clang/test/CIR/Lowering/basic.cpp
@@ -6,8 +6,8 @@ int f1() {
 }
 
 // CHECK: define{{.*}} i32 @_Z2f1v(){{.*}} {
-// CHECK:    %[[RV:.*]] = alloca i32, i64 1, align 4
-// CHECK:    %[[I_PTR:.*]] = alloca i32, i64 1, align 4
+// CHECK:    %[[RV:.*]] = alloca i32, align 4
+// CHECK:    %[[I_PTR:.*]] = alloca i32, align 4
 // CHECK:    %[[I:.*]] = load i32, ptr %[[I_PTR]], align 4
 // CHECK:    store i32 %[[I]], ptr %[[RV]], align 4
 // CHECK:    %[[R:.*]] = load i32, ptr %[[RV]], align 4
@@ -19,8 +19,8 @@ int f2() {
 }
 
 // CHECK: define{{.*}} i32 @_Z2f2v(){{.*}} {
-// CHECK:    %[[RV:.*]] = alloca i32, i64 1, align 4
-// CHECK:    %[[I_PTR:.*]] = alloca i32, i64 1, align 4
+// CHECK:    %[[RV:.*]] = alloca i32, align 4
+// CHECK:    %[[I_PTR:.*]] = alloca i32, align 4
 // CHECK:    store i32 2, ptr %[[I_PTR]], align 4
 // CHECK:    %[[I:.*]] = load i32, ptr %[[I_PTR]], align 4
 // CHECK:    store i32 %[[I]], ptr %[[RV]], align 4
@@ -32,8 +32,8 @@ int f3(int i) {
   }
 
 // CHECK: define{{.*}} i32 @_Z2f3i(i32 noundef %[[ARG:.*]])
-// CHECK:   %[[ARG_ALLOCA:.*]] = alloca i32, i64 1, align 4
-// CHECK:   %[[RV:.*]] = alloca i32, i64 1, align 4
+// CHECK:   %[[ARG_ALLOCA:.*]] = alloca i32, align 4
+// CHECK:   %[[RV:.*]] = alloca i32, align 4
 // CHECK:   store i32 %[[ARG]], ptr %[[ARG_ALLOCA]], align 4
 // CHECK:   %[[ARG_VAL:.*]] = load i32, ptr %[[ARG_ALLOCA]], align 4
 // CHECK:   store i32 %[[ARG_VAL]], ptr %[[RV]], align 4
@@ -45,8 +45,8 @@ int f4(const int i) {
 }
 
 // CHECK: define{{.*}} i32 @_Z2f4i(i32 noundef %[[ARG:.*]])
-// CHECK:   %[[ARG_ALLOCA:.*]] = alloca i32, i64 1, align 4
-// CHECK:   %[[RV:.*]] = alloca i32, i64 1, align 4
+// CHECK:   %[[ARG_ALLOCA:.*]] = alloca i32, align 4
+// CHECK:   %[[RV:.*]] = alloca i32, align 4
 // CHECK:   store i32 %[[ARG]], ptr %[[ARG_ALLOCA]], align 4
 // CHECK:   %[[ARG_VAL:.*]] = load i32, ptr %[[ARG_ALLOCA]], align 4
 // CHECK:   store i32 %[[ARG_VAL]], ptr %[[RV]], align 4

--- a/clang/test/CIR/Lowering/binop-fp.cir
+++ b/clang/test/CIR/Lowering/binop-fp.cir
@@ -45,8 +45,8 @@ module {
   }
 }
 
-// MLIR: = llvm.alloca {{.*}} f32 {alignment = 4 : i64} : (i64) -> !llvm.ptr
-// MLIR: = llvm.alloca {{.*}} f64 {alignment = 8 : i64} : (i64) -> !llvm.ptr
+// MLIR: = llvm.alloca {{.*}} f32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+// MLIR: = llvm.alloca {{.*}} f64 {alignment = 8 : i64} : (i32) -> !llvm.ptr
 // MLIR: = llvm.fmul {{.*}} : f32
 // MLIR: = llvm.fdiv
 // MLIR: = llvm.fadd
@@ -56,8 +56,8 @@ module {
 // MLIR: = llvm.fmul
 // MLIR: = llvm.fdiv
 
-// LLVM: = alloca float, i64
-// LLVM: = alloca double, i64
+// LLVM: = alloca float
+// LLVM: = alloca double
 // LLVM: = fmul float
 // LLVM: = fdiv float
 // LLVM: = fadd float

--- a/clang/test/CIR/Lowering/func-simple.cpp
+++ b/clang/test/CIR/Lowering/func-simple.cpp
@@ -11,7 +11,7 @@ void voidret() { return; }
 
 int intfunc() { return 42; }
 // CHECK: define{{.*}} i32 @_Z7intfuncv()
-// CHECK:   %[[RV:.*]] = alloca i32, i64 1, align 4
+// CHECK:   %[[RV:.*]] = alloca i32, align 4
 // CHECK:   store i32 42, ptr %[[RV]], align 4
 // CHECK:   %[[R:.*]] = load i32, ptr %[[RV]], align 4
 // CHECK:   ret i32 %[[R]]
@@ -24,7 +24,7 @@ int scopes() {
   }
 }
 // CHECK: define{{.*}} i32 @_Z6scopesv(){{.*}} {
-// CHECK:   %[[RV:.*]] = alloca i32, i64 1, align 4
+// CHECK:   %[[RV:.*]] = alloca i32, align 4
 // CHECK:   br label %[[LABEL1:.*]]
 // CHECK: [[LABEL1]]:
 // CHECK:   br label %[[LABEL2:.*]]
@@ -41,7 +41,7 @@ int scopes() {
 
 long longfunc() { return 42l; }
 // CHECK: define{{.*}} i64 @_Z8longfuncv(){{.*}} {
-// CHECK:   %[[RV:.*]] = alloca i64, i64 1, align 8
+// CHECK:   %[[RV:.*]] = alloca i64, align 8
 // CHECK:   store i64 42, ptr %[[RV]], align 8
 // CHECK:   %[[R:.*]] = load i64, ptr %[[RV]], align 8
 // CHECK:   ret i64 %[[R]]
@@ -49,7 +49,7 @@ long longfunc() { return 42l; }
 
 unsigned unsignedfunc() { return 42u; }
 // CHECK: define{{.*}} i32 @_Z12unsignedfuncv(){{.*}} {
-// CHECK:   %[[RV:.*]] = alloca i32, i64 1, align 4
+// CHECK:   %[[RV:.*]] = alloca i32, align 4
 // CHECK:   store i32 42, ptr %[[RV]], align 4
 // CHECK:   %[[R:.*]] = load i32, ptr %[[RV]], align 4
 // CHECK:   ret i32 %[[R]]
@@ -57,7 +57,7 @@ unsigned unsignedfunc() { return 42u; }
 
 unsigned long long ullfunc() { return 42ull; }
 // CHECK: define{{.*}} i64 @_Z7ullfuncv(){{.*}} {
-// CHECK:   %[[RV:.*]] = alloca i64, i64 1, align 8
+// CHECK:   %[[RV:.*]] = alloca i64, align 8
 // CHECK:   store i64 42, ptr %[[RV]], align 8
 // CHECK:   %[[R:.*]] = load i64, ptr %[[RV]], align 8
 // CHECK:   ret i64 %[[R]]
@@ -65,7 +65,7 @@ unsigned long long ullfunc() { return 42ull; }
 
 bool boolfunc() { return true; }
 // CHECK: define{{.*}} i1 @_Z8boolfuncv(){{.*}} {
-// CHECK:   %[[RV:.*]] = alloca i8, i64 1, align 1
+// CHECK:   %[[RV:.*]] = alloca i8, align 1
 // CHECK:   store i8 1, ptr %[[RV]], align 1
 // CHECK:   %[[R8:.*]] = load i8, ptr %[[RV]], align 1
 // CHECK:   %[[R:.*]] = trunc i8 %[[R8]] to i1

--- a/clang/test/CIR/Lowering/local-vars.cpp
+++ b/clang/test/CIR/Lowering/local-vars.cpp
@@ -25,23 +25,23 @@ void test() {
 //       when we add alignment attributes to the load/store ops.
 
 // CHECK: define{{.*}} void @_Z4testv()
-// CHECK:    %[[I_PTR:.*]] = alloca i32, i64 1, align 4
-// CHECK:    %[[L_PTR:.*]] = alloca i64, i64 1, align 8
-// CHECK:    %[[F_PTR:.*]] = alloca float, i64 1, align 4
-// CHECK:    %[[D_PTR:.*]] = alloca double, i64 1, align 8
-// CHECK:    %[[B1_PTR:.*]] = alloca i8, i64 1, align 1
-// CHECK:    %[[B2_PTR:.*]] = alloca i8, i64 1, align 1
-// CHECK:    %[[CI_PTR:.*]] = alloca i32, i64 1, align 4
-// CHECK:    %[[CL_PTR:.*]] = alloca i64, i64 1, align 8
-// CHECK:    %[[CF_PTR:.*]] = alloca float, i64 1, align 4
-// CHECK:    %[[CD_PTR:.*]] = alloca double, i64 1, align 8
-// CHECK:    %[[CB1_PTR:.*]] = alloca i8, i64 1, align 1
-// CHECK:    %[[CB2_PTR:.*]] = alloca i8, i64 1, align 1
-// CHECK:    %[[UII_PTR:.*]] = alloca i32, i64 1, align 4
-// CHECK:    %[[UIL_PTR:.*]] = alloca i64, i64 1, align 8
-// CHECK:    %[[UIF_PTR:.*]] = alloca float, i64 1, align 4
-// CHECK:    %[[UID_PTR:.*]] = alloca double, i64 1, align 8
-// CHECK:    %[[UIB_PTR:.*]] = alloca i8, i64 1, align 1
+// CHECK:    %[[I_PTR:.*]] = alloca i32, align 4
+// CHECK:    %[[L_PTR:.*]] = alloca i64, align 8
+// CHECK:    %[[F_PTR:.*]] = alloca float, align 4
+// CHECK:    %[[D_PTR:.*]] = alloca double, align 8
+// CHECK:    %[[B1_PTR:.*]] = alloca i8, align 1
+// CHECK:    %[[B2_PTR:.*]] = alloca i8, align 1
+// CHECK:    %[[CI_PTR:.*]] = alloca i32, align 4
+// CHECK:    %[[CL_PTR:.*]] = alloca i64, align 8
+// CHECK:    %[[CF_PTR:.*]] = alloca float, align 4
+// CHECK:    %[[CD_PTR:.*]] = alloca double, align 8
+// CHECK:    %[[CB1_PTR:.*]] = alloca i8, align 1
+// CHECK:    %[[CB2_PTR:.*]] = alloca i8, align 1
+// CHECK:    %[[UII_PTR:.*]] = alloca i32, align 4
+// CHECK:    %[[UIL_PTR:.*]] = alloca i64, align 8
+// CHECK:    %[[UIF_PTR:.*]] = alloca float, align 4
+// CHECK:    %[[UID_PTR:.*]] = alloca double, align 8
+// CHECK:    %[[UIB_PTR:.*]] = alloca i8, align 1
 // CHECK:    store i32 1, ptr %[[I_PTR]], align 4
 // CHECK:    store i64 2, ptr %[[L_PTR]], align 8
 // CHECK:    store float 3.000000e+00, ptr %[[F_PTR]], align 4

--- a/clang/test/CIR/Transforms/abi-lowering/x86_64-bitint.cir
+++ b/clang/test/CIR/Transforms/abi-lowering/x86_64-bitint.cir
@@ -529,13 +529,13 @@ module attributes {
   // LLVM-SAME:    i17 signext %{{[0-9]+}}, i64 %[[A1:[0-9]+]]
   // LLVM-SAME:    , i64 %[[A2:[0-9]+]], i64 %[[A3:[0-9]+]])
   // The fourth register holds the 33-bit value, materialized first.
-  // LLVM-NEXT:    %[[W33SLOT:[0-9]+]] = alloca i64, i64 1, align 8
+  // LLVM-NEXT:    %[[W33SLOT:[0-9]+]] = alloca i64, align 8
   // LLVM-NEXT:    store i64 %[[A3]], ptr %[[W33SLOT]], align 8
   // LLVM-NEXT:    %[[W33:[0-9]+]] = load i64, ptr %[[W33SLOT]], align 8
   // LLVM-NEXT:    %{{[0-9]+}} = trunc i64 %[[W33]] to i33
   // The second and third rebuild the 65-bit pair in order.
-  // LLVM-NEXT:    %[[P65SLOT:[0-9]+]] = alloca { i64, i64 }, i64 1, align 8
-  // LLVM-NEXT:    %[[FLAT:[0-9]+]] = alloca { i64, i64 }, i64 1, align 8
+  // LLVM-NEXT:    %[[P65SLOT:[0-9]+]] = alloca { i64, i64 }, align 8
+  // LLVM-NEXT:    %[[FLAT:[0-9]+]] = alloca { i64, i64 }, align 8
   // LLVM-NEXT:    %[[E0:[0-9]+]] = getelementptr inbounds nuw { i64, i64 }
   // LLVM-SAME:      , ptr %[[FLAT]], i32 0, i32 0
   // LLVM-NEXT:    store i64 %[[A1]], ptr %[[E0]], align 8
@@ -609,12 +609,12 @@ module attributes {
   // LLVM-LABEL: define void @call_widths(
   // LLVM-SAME:    i17 signext %[[A0:[0-9]+]], i64 %[[A1:[0-9]+]]
   // LLVM-SAME:    , i64 %[[A2:[0-9]+]], i64 %[[A3:[0-9]+]])
-  // LLVM-NEXT:    %[[V33SLOT:[0-9]+]] = alloca i64, i64 1, align 8
+  // LLVM-NEXT:    %[[V33SLOT:[0-9]+]] = alloca i64, align 8
   // LLVM-NEXT:    store i64 %[[A3]], ptr %[[V33SLOT]], align 8
   // LLVM-NEXT:    %[[W33:[0-9]+]] = load i64, ptr %[[V33SLOT]], align 8
   // LLVM-NEXT:    %[[V33:[0-9]+]] = trunc i64 %[[W33]] to i33
-  // LLVM-NEXT:    %[[V65SLOT:[0-9]+]] = alloca { i64, i64 }, i64 1, align 8
-  // LLVM-NEXT:    %[[FLAT:[0-9]+]] = alloca { i64, i64 }, i64 1, align 8
+  // LLVM-NEXT:    %[[V65SLOT:[0-9]+]] = alloca { i64, i64 }, align 8
+  // LLVM-NEXT:    %[[FLAT:[0-9]+]] = alloca { i64, i64 }, align 8
   // LLVM-NEXT:    %[[E0:[0-9]+]] = getelementptr inbounds nuw { i64, i64 }
   // LLVM-SAME:      , ptr %[[FLAT]], i32 0, i32 0
   // LLVM-NEXT:    store i64 %[[A1]], ptr %[[E0]], align 8
@@ -626,8 +626,8 @@ module attributes {
   // LLVM-NEXT:    %[[WIDE:[0-9]+]] = load i128, ptr %[[V65SLOT]], align 8
   // LLVM-NEXT:    %[[V65:[0-9]+]] = trunc i128 %[[WIDE]] to i65
   // Each callee register traces back to the value it carries.
-  // LLVM-NEXT:    %[[C3SLOT:[0-9]+]] = alloca i64, i64 1, align 8
-  // LLVM-NEXT:    %[[PAIRSLOT:[0-9]+]] = alloca { i64, i64 }, i64 1, align 8
+  // LLVM-NEXT:    %[[C3SLOT:[0-9]+]] = alloca i64, align 8
+  // LLVM-NEXT:    %[[PAIRSLOT:[0-9]+]] = alloca { i64, i64 }, align 8
   // LLVM-NEXT:    %[[EXT65:[0-9]+]] = sext i65 %[[V65]] to i128
   // LLVM-NEXT:    store i128 %[[EXT65]], ptr %[[PAIRSLOT]], align 8
   // LLVM-NEXT:    %[[P0:[0-9]+]] = getelementptr inbounds nuw { i64, i64 }
@@ -684,11 +684,11 @@ module attributes {
 
   // LLVM-LABEL: define i32 @coerce_s(
   // LLVM-SAME:    i32 %[[ARG:[0-9]+]])
-  // LLVM-NEXT:    %[[RETSLOT:[0-9]+]] = alloca %struct.S, i64 1, align 4
-  // LLVM-NEXT:    %[[ARGSLOT:[0-9]+]] = alloca i32, i64 1, align 4
+  // LLVM-NEXT:    %[[RETSLOT:[0-9]+]] = alloca %struct.S, align 4
+  // LLVM-NEXT:    %[[ARGSLOT:[0-9]+]] = alloca i32, align 4
   // LLVM-NEXT:    store i32 %[[ARG]], ptr %[[ARGSLOT]], align 4
   // LLVM-NEXT:    %[[REC:[0-9]+]] = load %struct.S, ptr %[[ARGSLOT]], align 4
-  // LLVM-NEXT:    %[[LOCAL:[0-9]+]] = alloca %struct.S, i64 1, align 4
+  // LLVM-NEXT:    %[[LOCAL:[0-9]+]] = alloca %struct.S, align 4
   // LLVM-NEXT:    store %struct.S %[[REC]], ptr %[[LOCAL]], align 4
   // LLVM-NEXT:    %[[VAL:[0-9]+]] = load %struct.S, ptr %[[LOCAL]], align 4
   // LLVM-NEXT:    store %struct.S %[[VAL]], ptr %[[RETSLOT]], align 4
@@ -722,8 +722,8 @@ module attributes {
 
   // LLVM-LABEL: define void @take_p(
   // LLVM-SAME:    i64 %[[A0:[0-9]+]], i64 %[[A1:[0-9]+]])
-  // LLVM-NEXT:    %[[VALSLOT:[0-9]+]] = alloca { i64, i64 }, i64 1, align 8
-  // LLVM-NEXT:    %[[FLAT:[0-9]+]] = alloca { i64, i64 }, i64 1, align 8
+  // LLVM-NEXT:    %[[VALSLOT:[0-9]+]] = alloca { i64, i64 }, align 8
+  // LLVM-NEXT:    %[[FLAT:[0-9]+]] = alloca { i64, i64 }, align 8
   // LLVM-NEXT:    %[[E0:[0-9]+]] = getelementptr inbounds nuw { i64, i64 }
   // LLVM-SAME:      , ptr %[[FLAT]], i32 0, i32 0
   // LLVM-NEXT:    store i64 %[[A0]], ptr %[[E0]], align 8
@@ -750,7 +750,7 @@ module attributes {
 
   // LLVM-LABEL: define void @take_w(
   // LLVM-SAME:    i128 %[[ARG:[0-9]+]])
-  // LLVM-NEXT:    %[[SLOT:[0-9]+]] = alloca i128, i64 1, align 8
+  // LLVM-NEXT:    %[[SLOT:[0-9]+]] = alloca i128, align 8
   // LLVM-NEXT:    store i128 %[[ARG]], ptr %[[SLOT]], align 8
   // LLVM-NEXT:    %{{[0-9]+}} = load %struct.W, ptr %[[SLOT]]
   // LLVM-NEXT:    ret void


### PR DESCRIPTION
When we lower cir.alloca instructions to LLVM IR, the LLVM IR alloca instruction was being printed with an explicit `i64 1` number of elements operand. This was happening because the LLVM IR printer only suppresses that operand if its type is `i32` and we were lowering it with index type. This change switches our alloca lowering to use `i32` for the type.