### PR TITLE
[Flang][OpenMP] Fix nested OpenMP mapper composition

### DIFF
--- a/flang/lib/Lower/OpenMP/Utils.cpp
+++ b/flang/lib/Lower/OpenMP/Utils.cpp
@@ -1089,9 +1089,9 @@ static std::string
 getDefaultMapperID(Fortran::lower::AbstractConverter &converter,
                    fir::FirOpBuilder &firOpBuilder,
                    const semantics::DerivedTypeSpec *typeSpec) {
-  if (mlir::isa<mlir::omp::DeclareMapperOp>(
-          firOpBuilder.getRegion().getParentOp()) ||
-      !typeSpec)
+  // Nested derived-type components inside a declare mapper may use their own
+  // default mapper. Only suppress the mapper currently being built.
+  if (!typeSpec)
     return {};
 
   std::string mapperIdName =

--- a/flang/lib/Optimizer/OpenMP/MapInfoFinalization.cpp
+++ b/flang/lib/Optimizer/OpenMP/MapInfoFinalization.cpp
@@ -138,6 +138,75 @@ class MapInfoFinalizationPass
     return findMemberByIndexPath(op, indexPath) != nullptr;
   }
 
+  static bool mapperCoversIndexPath(
+      mlir::Operation *symbolTableAnchor, mlir::FlatSymbolRefAttr mapperId,
+      llvm::ArrayRef<int64_t> indexPath,
+      llvm::SmallPtrSetImpl<mlir::Operation *> &visitedMappers) {
+    mlir::omp::DeclareMapperOp symbol =
+        mlir::SymbolTable::lookupNearestSymbolFrom<mlir::omp::DeclareMapperOp>(
+            symbolTableAnchor, mapperId);
+    if (!symbol || !visitedMappers.insert(symbol.getOperation()).second)
+      return false;
+
+    mlir::omp::DeclareMapperInfoOp mapperInfo = symbol.getDeclareMapperInfo();
+    if (!mapperInfo)
+      return false;
+
+    return llvm::any_of(mapperInfo.getMapVars(), [&](mlir::Value v) {
+      mlir::omp::MapInfoOp map =
+          mlir::dyn_cast_if_present<mlir::omp::MapInfoOp>(v.getDefiningOp());
+      return map && !map.getMembers().empty() &&
+             map.getMembersIndexAttr() &&
+             mapInfoCoversIndexPath(map, indexPath, visitedMappers);
+    });
+  }
+
+  static bool mapInfoCoversIndexPath(
+      mlir::omp::MapInfoOp map, llvm::ArrayRef<int64_t> indexPath,
+      llvm::SmallPtrSetImpl<mlir::Operation *> &visitedMappers) {
+    if (mappedIndexPathExists(map, indexPath))
+      return true;
+
+    mlir::ArrayAttr memberIndices = map.getMembersIndexAttr();
+    if (!memberIndices)
+      return false;
+
+    for (auto [memberIdx, memberIndexAttr] : llvm::enumerate(memberIndices)) {
+      auto memberIndexPath = mlir::cast<mlir::ArrayAttr>(memberIndexAttr);
+      if (memberIndexPath.size() >= indexPath.size())
+        continue;
+
+      bool isPrefix = true;
+      for (auto [idx, attr] : llvm::enumerate(memberIndexPath)) {
+        if (mlir::cast<mlir::IntegerAttr>(attr).getInt() != indexPath[idx]) {
+          isPrefix = false;
+          break;
+        }
+      }
+      if (!isPrefix)
+        continue;
+
+      mlir::omp::MapInfoOp memberMap =
+          mlir::dyn_cast_if_present<mlir::omp::MapInfoOp>(
+              map.getMembers()[memberIdx].getDefiningOp());
+      if (!memberMap)
+        continue;
+
+      llvm::ArrayRef<int64_t> nestedIndexPath =
+          indexPath.drop_front(memberIndexPath.size());
+      if (!memberMap.getMembers().empty() &&
+          mapInfoCoversIndexPath(memberMap, nestedIndexPath, visitedMappers))
+        return true;
+
+      if (memberMap.getMapperIdAttr() &&
+          mapperCoversIndexPath(memberMap, memberMap.getMapperIdAttr(),
+                                nestedIndexPath, visitedMappers))
+        return true;
+    }
+
+    return false;
+  }
+
   /// Get the map type of the nearest explicitly mapped parent for a member.
   /// "Explicitly mapped" means the map type does NOT have the implicit flag.
   ///
@@ -205,20 +274,10 @@ class MapInfoFinalizationPass
       return;
 
     if (op.getMapperId()) {
-      mlir::omp::DeclareMapperOp symbol =
-          mlir::SymbolTable::lookupNearestSymbolFrom<
-              mlir::omp::DeclareMapperOp>(op, op.getMapperIdAttr());
-      assert(symbol && "missing symbol for declare mapper identifier");
-      mlir::omp::DeclareMapperInfoOp mapperInfo = symbol.getDeclareMapperInfo();
-      // TODO: Probably a way to cache these keys in someway so we don't
-      // constantly go through the process of rebuilding them on every check, to
-      // save some cycles, but it can wait for a subsequent patch.
-      for (auto v : mapperInfo.getMapVars()) {
-        mlir::omp::MapInfoOp map =
-            mlir::cast<mlir::omp::MapInfoOp>(v.getDefiningOp());
-        if (!map.getMembers().empty() && mappedIndexPathExists(map, indexPath))
-          return;
-      }
+      llvm::SmallPtrSet<mlir::Operation *, 4> visitedMappers;
+      if (mapperCoversIndexPath(op, op.getMapperIdAttr(), indexPath,
+                                visitedMappers))
+        return;
     }
 
     builder.setInsertionPoint(op);

--- a/flang/lib/Optimizer/OpenMP/MapInfoFinalization.cpp
+++ b/flang/lib/Optimizer/OpenMP/MapInfoFinalization.cpp
@@ -41,7 +41,6 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Support/LLVM.h"
 #include "llvm/ADT/BitmaskEnum.h"
-#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/raw_ostream.h"
 #include <algorithm>
@@ -66,6 +65,10 @@ class MapInfoFinalizationPass
     mlir::omp::MapInfoOp parent;
     size_t index;
   };
+
+  using MapperPath =
+      std::pair<mlir::Operation *, llvm::SmallVector<int64_t, 4>>;
+  using MapperPathStack = llvm::SmallVector<MapperPath, 8>;
 
   /// Tracks any intermediate function/subroutine local allocations we
   /// generate for the descriptors of box type dummy arguments, so that
@@ -138,32 +141,47 @@ class MapInfoFinalizationPass
     return findMemberByIndexPath(op, indexPath) != nullptr;
   }
 
-  static bool mapperCoversIndexPath(
-      mlir::Operation *symbolTableAnchor, mlir::FlatSymbolRefAttr mapperId,
-      llvm::ArrayRef<int64_t> indexPath,
-      llvm::SmallPtrSetImpl<mlir::Operation *> &visitedMappers) {
+  static bool mapperCoversIndexPath(mlir::Operation *symbolTableAnchor,
+                                    mlir::FlatSymbolRefAttr mapperId,
+                                    llvm::ArrayRef<int64_t> indexPath,
+                                    MapperPathStack &activeMapperPaths) {
     mlir::omp::DeclareMapperOp symbol =
         mlir::SymbolTable::lookupNearestSymbolFrom<mlir::omp::DeclareMapperOp>(
             symbolTableAnchor, mapperId);
-    if (!symbol || !visitedMappers.insert(symbol.getOperation()).second)
+    if (!symbol)
       return false;
+
+    mlir::Operation *symbolOp = symbol.getOperation();
+    if (llvm::any_of(activeMapperPaths, [&](const MapperPath &entry) {
+          return entry.first == symbolOp &&
+                 entry.second.size() == indexPath.size() &&
+                 std::equal(entry.second.begin(), entry.second.end(),
+                            indexPath.begin());
+        }))
+      return false;
+    activeMapperPaths.emplace_back(
+        symbolOp,
+        llvm::SmallVector<int64_t, 4>(indexPath.begin(), indexPath.end()));
 
     mlir::omp::DeclareMapperInfoOp mapperInfo = symbol.getDeclareMapperInfo();
-    if (!mapperInfo)
+    if (!mapperInfo) {
+      activeMapperPaths.pop_back();
       return false;
+    }
 
-    return llvm::any_of(mapperInfo.getMapVars(), [&](mlir::Value v) {
+    bool covers = llvm::any_of(mapperInfo.getMapVars(), [&](mlir::Value v) {
       mlir::omp::MapInfoOp map =
           mlir::dyn_cast_if_present<mlir::omp::MapInfoOp>(v.getDefiningOp());
-      return map && !map.getMembers().empty() &&
-             map.getMembersIndexAttr() &&
-             mapInfoCoversIndexPath(map, indexPath, visitedMappers);
+      return map && !map.getMembers().empty() && map.getMembersIndexAttr() &&
+             mapInfoCoversIndexPath(map, indexPath, activeMapperPaths);
     });
+    activeMapperPaths.pop_back();
+    return covers;
   }
 
-  static bool mapInfoCoversIndexPath(
-      mlir::omp::MapInfoOp map, llvm::ArrayRef<int64_t> indexPath,
-      llvm::SmallPtrSetImpl<mlir::Operation *> &visitedMappers) {
+  static bool mapInfoCoversIndexPath(mlir::omp::MapInfoOp map,
+                                     llvm::ArrayRef<int64_t> indexPath,
+                                     MapperPathStack &activeMapperPaths) {
     if (mappedIndexPathExists(map, indexPath))
       return true;
 
@@ -195,12 +213,12 @@ class MapInfoFinalizationPass
       llvm::ArrayRef<int64_t> nestedIndexPath =
           indexPath.drop_front(memberIndexPath.size());
       if (!memberMap.getMembers().empty() &&
-          mapInfoCoversIndexPath(memberMap, nestedIndexPath, visitedMappers))
+          mapInfoCoversIndexPath(memberMap, nestedIndexPath, activeMapperPaths))
         return true;
 
       if (memberMap.getMapperIdAttr() &&
           mapperCoversIndexPath(memberMap, memberMap.getMapperIdAttr(),
-                                nestedIndexPath, visitedMappers))
+                                nestedIndexPath, activeMapperPaths))
         return true;
     }
 
@@ -274,9 +292,9 @@ class MapInfoFinalizationPass
       return;
 
     if (op.getMapperId()) {
-      llvm::SmallPtrSet<mlir::Operation *, 4> visitedMappers;
+      MapperPathStack activeMapperPaths;
       if (mapperCoversIndexPath(op, op.getMapperIdAttr(), indexPath,
-                                visitedMappers))
+                                activeMapperPaths))
         return;
     }
 

--- a/flang/lib/Optimizer/OpenMP/MapInfoFinalization.cpp
+++ b/flang/lib/Optimizer/OpenMP/MapInfoFinalization.cpp
@@ -189,6 +189,8 @@ class MapInfoFinalizationPass
     if (!memberIndices)
       return false;
 
+    // Match a mapped member whose index path is a prefix of the requested
+    // path, then continue the lookup through that member with the suffix.
     for (auto [memberIdx, memberIndexAttr] : llvm::enumerate(memberIndices)) {
       auto memberIndexPath = mlir::cast<mlir::ArrayAttr>(memberIndexAttr);
       if (memberIndexPath.size() >= indexPath.size())

--- a/flang/test/Lower/OpenMP/nested-default-mapper.f90
+++ b/flang/test/Lower/OpenMP/nested-default-mapper.f90
@@ -27,6 +27,56 @@ program main
   !$omp end target
 end program main
 
+subroutine recursive_mapper
+  implicit none
+
+  type node_t
+    integer, allocatable :: payload(:)
+    type(node_t), allocatable :: next
+  end type node_t
+
+  type wrapper_t
+    type(node_t), allocatable :: head
+  end type wrapper_t
+
+  type(wrapper_t) :: w
+
+  !$omp target map(tofrom: w)
+    w%head%next%next%payload(1) = 7
+  !$omp end target
+end subroutine recursive_mapper
+
+subroutine mutual_mapper
+  implicit none
+
+  type a_t
+    type(b_t), allocatable :: b
+  end type a_t
+
+  type b_t
+    type(a_t), allocatable :: a
+    integer, allocatable :: payload(:)
+  end type b_t
+
+  type(a_t) :: a
+
+  !$omp target map(tofrom: a)
+    a%b%a%b%payload(1) = 11
+  !$omp end target
+end subroutine mutual_mapper
+
+! CHECK-LABEL: omp.declare_mapper @_QQFmutual_mapper_QFmutual_mapperTa_t_omp_default_mapper
+! CHECK: omp.map.info {{.*}} mapper(@_QFmutual_mapperTb_t_omp_default_mapper)
+! CHECK-LABEL: omp.declare_mapper @_QFmutual_mapperTb_t_omp_default_mapper
+! CHECK: omp.map.info {{.*}} mapper(@_QQFmutual_mapper_QFmutual_mapperTa_t_omp_default_mapper)
+! CHECK-LABEL: omp.declare_mapper @_QQFmutual_mappera_t_omp_default_mapper
+! CHECK: omp.map.info {{.*}} mapper(@_QFmutual_mapperTb_t_omp_default_mapper)
+
+! CHECK-LABEL: omp.declare_mapper @_QFrecursive_mapperTnode_t_omp_default_mapper
+! CHECK: omp.map.info {{.*}} mapper(@_QFrecursive_mapperTnode_t_omp_default_mapper)
+! CHECK-LABEL: omp.declare_mapper @_QQFrecursive_mapperwrapper_t_omp_default_mapper
+! CHECK: omp.map.info {{.*}} mapper(@_QFrecursive_mapperTnode_t_omp_default_mapper)
+
 ! CHECK-LABEL: omp.declare_mapper @_QQFtyp_t_omp_default_mapper
 ! CHECK: omp.map.info {{.*}} map_clauses(tofrom) capture(ByRef) mapper(@_QQFnested_t_omp_default_mapper) -> {{.*}} {name = "t%nested"}
 ! CHECK-LABEL: omp.declare_mapper @_QQFnested_t_omp_default_mapper
@@ -35,3 +85,13 @@ end program main
 ! CHECK-NOT: implicit_map
 ! CHECK: %[[TYP_MAP:.*]] = omp.map.info {{.*}} mapper(@_QQFtyp_t_omp_default_mapper){{.*}} {name = "typ"}
 ! CHECK-NEXT: omp.target kernel_type(generic) map_entries(%[[TYP_MAP]] -> %{{[^,]*}} : {{.*}}) {
+
+! CHECK-LABEL: func.func @_QPrecursive_mapper
+! CHECK-NOT: implicit_map
+! CHECK: %[[RECURSIVE_MAP:.*]] = omp.map.info {{.*}} mapper(@_QQFrecursive_mapperwrapper_t_omp_default_mapper){{.*}} {name = "w"}
+! CHECK-NEXT: omp.target kernel_type(generic) map_entries(%[[RECURSIVE_MAP]] -> %{{[^,]*}} : {{.*}}) {
+
+! CHECK-LABEL: func.func @_QPmutual_mapper
+! CHECK-NOT: implicit_map
+! CHECK: %[[MUTUAL_MAP:.*]] = omp.map.info {{.*}} mapper(@_QQFmutual_mappera_t_omp_default_mapper){{.*}} {name = "a"}
+! CHECK-NEXT: omp.target kernel_type(generic) map_entries(%[[MUTUAL_MAP]] -> %{{[^,]*}} : {{.*}}) {

--- a/flang/test/Lower/OpenMP/nested-default-mapper.f90
+++ b/flang/test/Lower/OpenMP/nested-default-mapper.f90
@@ -1,0 +1,37 @@
+! RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=50 %s -o - | FileCheck %s
+
+program main
+  implicit none
+
+  type nested_t
+    integer, allocatable :: y(:)
+  end type nested_t
+
+  !$omp declare mapper(nested_t :: n) map(n%y)
+
+  type typ_t
+    integer, allocatable :: x(:)
+    type(nested_t) :: nested
+  end type typ_t
+
+  !$omp declare mapper(typ_t :: t) map(t%x, t%nested)
+
+  type(typ_t) :: typ
+
+  allocate(typ%x(3), source=1)
+  allocate(typ%nested%y(3), source=42)
+
+  !$omp target map(tofrom: typ)
+    typ%x(1) = 999
+    typ%nested%y(1) = -555
+  !$omp end target
+end program main
+
+! CHECK-LABEL: omp.declare_mapper @_QQFtyp_t_omp_default_mapper
+! CHECK: omp.map.info {{.*}} map_clauses(tofrom) capture(ByRef) mapper(@_QQFnested_t_omp_default_mapper) -> {{.*}} {name = "t%nested"}
+! CHECK-LABEL: omp.declare_mapper @_QQFnested_t_omp_default_mapper
+
+! CHECK-LABEL: func.func @_QQmain
+! CHECK-NOT: implicit_map
+! CHECK: %[[TYP_MAP:.*]] = omp.map.info {{.*}} mapper(@_QQFtyp_t_omp_default_mapper){{.*}} {name = "typ"}
+! CHECK-NEXT: omp.target kernel_type(generic) map_entries(%[[TYP_MAP]] -> %{{[^,]*}} : {{.*}}) {


### PR DESCRIPTION
Fixes Flang lowering for nested OpenMP declare mappers by attaching the nested default mapper to mapped derived-type components and preventing redundant implicit member maps already covered by that mapper.