### PR TITLE
[Verifier] Prevent insertion/extraction of scalable vectors into/from fixed vectors

### DIFF
--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -6841,6 +6841,13 @@ void Verifier::visitIntrinsicCall(Intrinsic::ID ID, CallBase &Call) {
           "vector_insert index must be a constant multiple of "
           "the subvector's known minimum vector length.");
 
+    // The only allowed 'mixed' case is inserting a fixed vector into a
+    // scalable vector.
+    if (SubVecEC.isScalable()) {
+      Check(VecEC.isScalable(), "Scalable vectors can only be inserted into "
+                                "other scalable vectors.");
+    }
+
     // If this insertion is not the 'mixed' case where a fixed vector is
     // inserted into a scalable vector, ensure that the insertion of the
     // subvector does not overrun the parent vector.
@@ -6870,6 +6877,13 @@ void Verifier::visitIntrinsicCall(Intrinsic::ID ID, CallBase &Call) {
     Check(IdxN % ResultEC.getKnownMinValue() == 0,
           "vector_extract index must be a constant multiple of "
           "the result type's known minimum vector length.");
+
+    // The only allowed 'mixed' case is extracting a fixed vector from a
+    // scalable vector.
+    if (ResultEC.isScalable()) {
+      Check(VecEC.isScalable(), "Scalable vectors can only be extracted from "
+                                "other scalable vectors.");
+    }
 
     // If this extraction is not the 'mixed' case where a fixed vector is
     // extracted from a scalable vector, ensure that the extraction does not

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -6844,8 +6844,8 @@ void Verifier::visitIntrinsicCall(Intrinsic::ID ID, CallBase &Call) {
     // The only allowed 'mixed' case is inserting a fixed vector into a
     // scalable vector.
     if (SubVecEC.isScalable()) {
-      Check(VecEC.isScalable(), "Scalable vectors can only be inserted into "
-                                "other scalable vectors.");
+      Check(VecEC.isScalable(), "cannot vector_insert a scalable vector into "
+                                "a fixed vector.");
     }
 
     // If this insertion is not the 'mixed' case where a fixed vector is
@@ -6881,8 +6881,8 @@ void Verifier::visitIntrinsicCall(Intrinsic::ID ID, CallBase &Call) {
     // The only allowed 'mixed' case is extracting a fixed vector from a
     // scalable vector.
     if (ResultEC.isScalable()) {
-      Check(VecEC.isScalable(), "Scalable vectors can only be extracted from "
-                                "other scalable vectors.");
+      Check(VecEC.isScalable(), "cannot vector_extract a scalable vector from "
+                                "a fixed vector.");
     }
 
     // If this extraction is not the 'mixed' case where a fixed vector is

--- a/llvm/test/Verifier/insert-extract-intrinsics-invalid.ll
+++ b/llvm/test/Verifier/insert-extract-intrinsics-invalid.ll
@@ -83,13 +83,13 @@ define <vscale x 8 x i32> @insert_overrun_scalable_fixed(<vscale x 8 x i32> %vec
 ; are captured.
 ;
 
-; CHECK: Scalable vectors can only be extracted from other scalable vectors.
+; CHECK: cannot vector_extract a scalable vector from a fixed vector.
 define <vscale x 4 x i32> @extract_scalable_from_fixed(<8 x i32> %vec) {
   %1 = call <vscale x 4 x i32> @llvm.vector.extract.nxv4i32.v8i32(<8 x i32> %vec, i64 0)
   ret <vscale x 4 x i32> %1
 }
 
-; CHECK: Scalable vectors can only be inserted into other scalable vectors.
+; CHECK: cannot vector_insert a scalable vector into a fixed vector.
 define <8 x i32> @insert_scalable_into_fixed(<8 x i32> %vec, <vscale x 4 x i32> %subvec) {
   %1 = call <8 x i32> @llvm.vector.insert.v8i32.nxv4i32(<8 x i32> %vec, <vscale x 4 x i32> %subvec, i64 0)
   ret <8 x i32> %1

--- a/llvm/test/Verifier/insert-extract-intrinsics-invalid.ll
+++ b/llvm/test/Verifier/insert-extract-intrinsics-invalid.ll
@@ -89,22 +89,10 @@ define <vscale x 4 x i32> @extract_scalable_from_fixed(<8 x i32> %vec) {
   ret <vscale x 4 x i32> %1
 }
 
-; CHECK-NOT: Scalable vectors can only be extracted from other scalable vectors.
-define <4 x i32> @extract_fixed_from_scalable(<vscale x 8 x i32> %vec) {
-  %1 = call <4 x i32> @llvm.vector.extract.v4i32.nxv8i32(<vscale x 8 x i32> %vec, i64 0)
-  ret <4 x i32> %1
-}
-
 ; CHECK: Scalable vectors can only be inserted into other scalable vectors.
 define <8 x i32> @insert_scalable_into_fixed(<8 x i32> %vec, <vscale x 4 x i32> %subvec) {
   %1 = call <8 x i32> @llvm.vector.insert.v8i32.nxv4i32(<8 x i32> %vec, <vscale x 4 x i32> %subvec, i64 0)
   ret <8 x i32> %1
-}
-
-; CHECK-NOT: Scalable vectors can only be inserted into other scalable vectors.
-define <vscale x 8 x i32> @insert_fixed_into_scalable(<vscale x 8 x i32> %vec, <4 x i32> %subvec) {
-  %1 = call <vscale x 8 x i32> @llvm.vector.insert.nxv8i32.v4i32(<vscale x 8 x i32> %vec, <4 x i32> %subvec, i64 0)
-  ret <vscale x 8 x i32> %1
 }
 
 declare <vscale x 3 x i32> @llvm.vector.extract.nxv8i32.nxv3i32(<vscale x 8 x i32>, i64)

--- a/llvm/test/Verifier/insert-extract-intrinsics-invalid.ll
+++ b/llvm/test/Verifier/insert-extract-intrinsics-invalid.ll
@@ -78,6 +78,23 @@ define <vscale x 8 x i32> @insert_overrun_scalable_fixed(<vscale x 8 x i32> %vec
   ret <vscale x 8 x i32> %1
 }
 
+;
+; Test that extractions/insertions of a scalable vector from/into a fixed vector
+; are captured.
+;
+
+; CHECK: Scalable vectors can only be extracted from other scalable vectors.
+define <vscale x 4 x i32> @extract_scalable_from_fixed(<8 x i32> %vec) {
+  %1 = call <vscale x 4 x i32> @llvm.vector.extract.nxv4i32.v8i32(<8 x i32> %vec, i64 0)
+  ret <vscale x 4 x i32> %1
+}
+
+; CHECK: Scalable vectors can only be inserted into other scalable vectors.
+define <8 x i32> @insert_scalable_into_fixed(<8 x i32> %vec, <vscale x 4 x i32> %subvec) {
+  %1 = call <8 x i32> @llvm.vector.insert.v8i32.nxv4i32(<8 x i32> %vec, <vscale x 4 x i32> %subvec, i64 0)
+  ret <8 x i32> %1
+}
+
 declare <vscale x 3 x i32> @llvm.vector.extract.nxv8i32.nxv3i32(<vscale x 8 x i32>, i64)
 declare <vscale x 8 x i32> @llvm.vector.insert.nxv8i32.nxv3i32(<vscale x 8 x i32>, <vscale x 3 x i32>, i64)
 declare <vscale x 8 x i32> @llvm.vector.insert.nxv8i32.v3i32(<vscale x 8 x i32>, <3 x i32>, i64)

--- a/llvm/test/Verifier/insert-extract-intrinsics-invalid.ll
+++ b/llvm/test/Verifier/insert-extract-intrinsics-invalid.ll
@@ -89,10 +89,22 @@ define <vscale x 4 x i32> @extract_scalable_from_fixed(<8 x i32> %vec) {
   ret <vscale x 4 x i32> %1
 }
 
+; CHECK-NOT: Scalable vectors can only be extracted from other scalable vectors.
+define <4 x i32> @extract_fixed_from_scalable(<vscale x 8 x i32> %vec) {
+  %1 = call <4 x i32> @llvm.vector.extract.v4i32.nxv8i32(<vscale x 8 x i32> %vec, i64 0)
+  ret <4 x i32> %1
+}
+
 ; CHECK: Scalable vectors can only be inserted into other scalable vectors.
 define <8 x i32> @insert_scalable_into_fixed(<8 x i32> %vec, <vscale x 4 x i32> %subvec) {
   %1 = call <8 x i32> @llvm.vector.insert.v8i32.nxv4i32(<8 x i32> %vec, <vscale x 4 x i32> %subvec, i64 0)
   ret <8 x i32> %1
+}
+
+; CHECK-NOT: Scalable vectors can only be inserted into other scalable vectors.
+define <vscale x 8 x i32> @insert_fixed_into_scalable(<vscale x 8 x i32> %vec, <4 x i32> %subvec) {
+  %1 = call <vscale x 8 x i32> @llvm.vector.insert.nxv8i32.v4i32(<vscale x 8 x i32> %vec, <4 x i32> %subvec, i64 0)
+  ret <vscale x 8 x i32> %1
 }
 
 declare <vscale x 3 x i32> @llvm.vector.extract.nxv8i32.nxv3i32(<vscale x 8 x i32>, i64)


### PR DESCRIPTION
Per LangRef:
> Scalable vectors can only be inserted into other scalable vectors.
> (...)
> Scalable vectors can only be extracted from other scalable vectors.

Add checks to enforce these rules for `llvm.vector.insert` and `llvm.vector.extract` intrinsics.