### PR TITLE
[lldb] Note Command Used For DWIM Printing Of Persistent Variable

### DIFF
--- a/lldb/source/Commands/CommandObjectDWIMPrint.cpp
+++ b/lldb/source/Commands/CommandObjectDWIMPrint.cpp
@@ -197,6 +197,12 @@ void CommandObjectDWIMPrint::DoExecute(StringRef command,
             language.AsLanguageType()))
       if (auto var_sp = state->GetVariable(expr))
         if (auto valobj_sp = var_sp->GetValueObject()) {
+
+          if (verbosity == eDWIMPrintVerbosityFull) {
+            result.AppendNoteWithFormatv(
+                "looked up `{0}` in persistent variables", expr);
+          }
+
           dump_val_object(*valobj_sp);
           return;
         }

--- a/lldb/test/Shell/Commands/command-dwim-print.test
+++ b/lldb/test/Shell/Commands/command-dwim-print.test
@@ -14,3 +14,11 @@
 # RUN: echo quit | %lldb -o "settings set show-inline-diagnostics false" \
 # RUN:   -o "dwim-print a" 2>&1 | FileCheck %s --check-prefix=CHECK4
 # CHECK4: error: <user expression 0>:1:1: use of undeclared identifier
+
+# RUN: %clang_host -g %S/Inputs/main.c -o %t
+# RUN: echo quit | %lldb %t -o "b main" -o "r" -o \
+# RUN: "dwim-print --persistent-result true -- foo" -o \
+# RUN: "settings set dwim-print-verbosity full" -o \
+# RUN: "dwim-print -l C11 -- $0" | FileCheck %s --check-prefix=CHECK5
+#            (lldb) dwim-print -l C11 -- $0
+# CHECK5:note: looked up `$0` in persistent variables


### PR DESCRIPTION
When DWIM printing, lldb will usually output explanatory feedback about the actual command used to generate the printed output (when the user has set the DWIM print verbosity to `true`). However, when DWIM printing a persistent variable, that note was omitted. This patch adds the explanatory message in that case.