### PR TITLE
[analyzer] Only underline the exact parameter that is bound to the return value in UseAfterLifetimeEnd

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/UseAfterLifetimeEnd.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/UseAfterLifetimeEnd.cpp
@@ -43,20 +43,30 @@ public:
 
 } // namespace
 
-static const Expr *getLifetimeBoundArg(const Expr *RetExpr) {
+static const Expr *getLifetimeBoundArg(const Expr *RetExpr,
+                                       const MemRegion *Region,
+                                       const ExplodedNode *N) {
   const CallExpr *Expr = dyn_cast_or_null<CallExpr>(RetExpr);
   if (!Expr)
     return nullptr;
+
   const FunctionDecl *FD = Expr->getDirectCallee();
   if (!FD)
     return nullptr;
 
+  const MemRegion *BaseReg = Region->getBaseRegion();
+
   for (const ParmVarDecl *PVD : FD->parameters()) {
-    if (PVD->hasAttr<LifetimeBoundAttr>()) {
-      unsigned Idx = PVD->getFunctionScopeIndex();
-      if (Idx < Expr->getNumArgs())
-        return Expr->getArg(Idx);
-    }
+    if (!PVD->hasAttr<LifetimeBoundAttr>())
+      continue;
+    unsigned Idx = PVD->getFunctionScopeIndex();
+
+    if (Idx >= Expr->getNumArgs())
+      continue;
+
+    const MemRegion *R = N->getSVal(Expr->getArg(Idx)).getAsRegion();
+    if (R && R->getBaseRegion() == BaseReg)
+      return Expr->getArg(Idx);
   }
   return nullptr;
 }
@@ -117,7 +127,7 @@ PathDiagnosticPieceRef UseAfterLifetimeEndBRVisitor::createSourcePiece(
     return nullptr;
 
   const Expr *RetExpr = dyn_cast_or_null<Expr>(S);
-  const Expr *Arg = getLifetimeBoundArg(RetExpr);
+  const Expr *Arg = getLifetimeBoundArg(RetExpr, SourceRegion, N);
 
   PathDiagnosticLocation Pos;
 

--- a/clang/test/Analysis/lifetime-bound.cpp
+++ b/clang/test/Analysis/lifetime-bound.cpp
@@ -428,18 +428,10 @@ int test_multi_param_highlight() {
   // expected-note@-7    {{Value's lifetime bound to the lifetime of 'local_two' here}}
   // expected-note@-8    {{Lifetime of 'local_two' ended here}}
 
-  // CHECK: :[[@LINE-10]]:33: note: Value's lifetime bound to the lifetime of 'local_one' here
-  // CHECK-NEXT: [[@LINE-14]] | int local_one = 1, local_two = 2;
-  // CHECK-NEXT:                ~~~~~~~~~~~~~~~~~
-  // CHECK-NEXT: [[@LINE-15]] | // expected{{-}}note@-1 {{.*}}
-  // CHECK-NEXT: [[@LINE-15]] | // expected{{-}}note@-2 {{.*}}
-  // CHECK-NEXT: [[@LINE-15]] | return multi_params_annotated(&local_one, &local_two);
-  // CHECK-NEXT:                                              ^~~~~~~~~~
-  // CHECK: :[[@LINE-17]]:45: note: Value's lifetime bound to the lifetime of 'local_two' here
-  // CHECK-NEXT: [[@LINE-21]] | int local_one = 1, local_two = 2;
-  // CHECK-NEXT:                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  // CHECK-NEXT: [[@LINE-22]] | // expected{{-}}note@-1 {{.*}}
-  // CHECK-NEXT: [[@LINE-22]] | // expected{{-}}note@-2 {{.*}}
-  // CHECK-NEXT: [[@LINE-22]] | return multi_params_annotated(&local_one, &local_two);
-  // CHECK-NEXT:                                                          ^~~~~~~~~~
+  // CHECK: note: Value's lifetime bound to the lifetime of 'local_one' here
+  // CHECK: return multi_params_annotated(&local_one, &local_two);
+  // CHECK-NEXT:                          ^~~~~~~~~~
+  // CHECK: note: Value's lifetime bound to the lifetime of 'local_two' here
+  // CHECK: return multi_params_annotated(&local_one, &local_two);
+  // CHECK-NEXT:                                      ^~~~~~~~~~
 }

--- a/clang/test/Analysis/lifetime-bound.cpp
+++ b/clang/test/Analysis/lifetime-bound.cpp
@@ -430,8 +430,23 @@ int test_multi_param_highlight() {
 
   // CHECK: note: Value's lifetime bound to the lifetime of 'local_one' here
   // CHECK: return multi_params_annotated(&local_one, &local_two);
-  // CHECK-NEXT:                          ^~~~~~~~~~
+  // CHECK-NEXT:{{\|                                 \^~~~~~~~~~$}}
   // CHECK: note: Value's lifetime bound to the lifetime of 'local_two' here
   // CHECK: return multi_params_annotated(&local_one, &local_two);
-  // CHECK-NEXT:                                      ^~~~~~~~~~
+  // CHECK-NEXT:{{\|                                             \^~~~~~~~~~$}}
+}
+
+int global_var;
+int test_correct_param_highlight() {
+  int local_n = 5;
+  // expected-note@-1 {{'local_n' initialized here}}
+  return multi_params_annotated(&global_var, &local_n);
+  // expected-warning@-1 {{address of stack memory associated with local variable 'local_n' returned}}
+  // expected-warning@-2 {{Returning value bound to 'local_n' that will go out of scope}}
+  // expected-note@-3    {{Value's lifetime bound to the lifetime of 'local_n' here}}
+  // expected-note@-4    {{Lifetime of 'local_n' ended here}}
+
+  // CHECK: note: Value's lifetime bound to the lifetime of 'local_n' here
+  // CHECK: return multi_params_annotated(&global_var, &local_n);
+  // CHECK-NEXT:{{\|                                              \^~~~~~~~$}}
 }

--- a/clang/test/Analysis/lifetime-bound.cpp
+++ b/clang/test/Analysis/lifetime-bound.cpp
@@ -1,6 +1,7 @@
 // RUN: %clang_analyze_cc1 -analyzer-checker=core,alpha.cplusplus.UseAfterLifetimeEnd,debug.DebugLifetimeModeling \
 // RUN:   -analyzer-config cfg-lifetime=true -analyzer-output=text -verify %s
-
+// RUN: %clang_analyze_cc1 -analyzer-checker=core,alpha.cplusplus.UseAfterLifetimeEnd,debug.DebugLifetimeModeling \
+// RUN:   -analyzer-output=text %s 2>&1 | FileCheck %s
 struct A {};
 
 struct Pair {
@@ -409,4 +410,36 @@ void no_dangling_by_value_argument() {
   // The BoundToSelf temporary's frame is not live on the stack when `self()` returns.
   // The returned reference does not dangle.
   takes_by_value(BoundToSelf());
+}
+
+int multi_params_annotated(int *p_one [[clang::lifetimebound]], int *p_two [[clang::lifetimebound]]);
+
+int test_multi_param_highlight() {
+  int local_one = 1, local_two = 2;
+  // expected-note@-1 {{'local_one' initialized here}}
+  // expected-note@-2 {{'local_two' initialized here}}
+  return multi_params_annotated(&local_one, &local_two);
+  // expected-warning@-1 {{address of stack memory associated with local variable 'local_one' returned}}
+  // expected-warning@-2 {{address of stack memory associated with local variable 'local_two' returned}}
+  // expected-warning@-3 {{Returning value bound to 'local_one' that will go out of scope}}
+  // expected-note@-4    {{Value's lifetime bound to the lifetime of 'local_one' here}}
+  // expected-note@-5    {{Lifetime of 'local_one' ended here}}
+  // expected-warning@-6 {{Returning value bound to 'local_two' that will go out of scope}}
+  // expected-note@-7    {{Value's lifetime bound to the lifetime of 'local_two' here}}
+  // expected-note@-8    {{Lifetime of 'local_two' ended here}}
+
+  // CHECK: :[[@LINE-10]]:33: note: Value's lifetime bound to the lifetime of 'local_one' here
+  // CHECK-NEXT: [[@LINE-14]] | int local_one = 1, local_two = 2;
+  // CHECK-NEXT:                ~~~~~~~~~~~~~~~~~
+  // CHECK-NEXT: [[@LINE-15]] | // expected{{-}}note@-1 {{.*}}
+  // CHECK-NEXT: [[@LINE-15]] | // expected{{-}}note@-2 {{.*}}
+  // CHECK-NEXT: [[@LINE-15]] | return multi_params_annotated(&local_one, &local_two);
+  // CHECK-NEXT:                                              ^~~~~~~~~~
+  // CHECK: :[[@LINE-17]]:45: note: Value's lifetime bound to the lifetime of 'local_two' here
+  // CHECK-NEXT: [[@LINE-21]] | int local_one = 1, local_two = 2;
+  // CHECK-NEXT:                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // CHECK-NEXT: [[@LINE-22]] | // expected{{-}}note@-1 {{.*}}
+  // CHECK-NEXT: [[@LINE-22]] | // expected{{-}}note@-2 {{.*}}
+  // CHECK-NEXT: [[@LINE-22]] | return multi_params_annotated(&local_one, &local_two);
+  // CHECK-NEXT:                                                          ^~~~~~~~~~
 }


### PR DESCRIPTION
Currently the `UseAfterLifetimeEnd` checker highlights always the first argument that is annotated with the `[[clang::lifetimebound]]` annotation. Like:
```text
temp.cpp:5:31: note: Value's lifetime bound to the lifetime of 'y' here
    4 |   int x = 1, y = 2;
      |   ~~~~~~~~~~~~~~~~
    5 |   return multi_param_test_ref(x, y);
      |                               ^
```

As seen even when checker correctly notes that the value's lifetime is bound to the lifetime of the `y` parameter, it incorrectly highlights x since that is the first annotated parameter. In order to fix this I have added a logic which checks which annotated parameter's region is bound to the return's region and do the highlight based on that.

This PR is part of stacked PRs that are improving the quality of the emitted report of the `UseAfterLifetimeEnd` checker. The initial PR is #215409

In a follow up PR I will fix the highlighting range of the variables, from:

```text
    4 |   int x = 1, y = 2;
      |   ~~~~~~~~~~~~~~~~
```

to:
```text
    4 |   int x = 1, y = 2;
      |             ~~~~~~~
```