### PR TITLE
[CIR] Support packed boolean vectors (ext_vector_type of bool)

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -395,10 +395,22 @@ void CIRGenFunction::emitStoreThroughLValue(RValue src, LValue dst,
     if (dst.isVectorElt()) {
       // Read/modify/write the vector, inserting the new element
       const mlir::Location loc = dst.getVectorPointer().getLoc();
-      const mlir::Value vector =
-          builder.createLoad(loc, dst.getVectorAddress());
-      const mlir::Value newVector = cir::VecInsertOp::create(
+      mlir::Value vector = builder.createLoad(loc, dst.getVectorAddress());
+
+      // A packed boolean vector is stored as an integer with one bit per lane,
+      // so unpack it before inserting and pack it again afterwards.
+      auto storeTy = mlir::dyn_cast<cir::IntType>(vector.getType());
+      if (storeTy)
+        vector = builder.createBitcast(
+            vector,
+            cir::VectorType::get(builder.getBoolTy(), storeTy.getWidth()));
+
+      mlir::Value newVector = cir::VecInsertOp::create(
           builder, loc, vector, src.getValue(), dst.getVectorIdx());
+
+      if (storeTy)
+        newVector = builder.createBitcast(newVector, storeTy);
+
       builder.createStore(loc, newVector, dst.getVectorAddress());
       return;
     }
@@ -469,20 +481,24 @@ void CIRGenFunction::emitStoreOfScalar(mlir::Value value, Address addr,
                                        bool isNontemporal) {
 
   if (const auto *clangVecTy = ty->getAs<clang::VectorType>()) {
-    // Boolean vectors use `iN` as storage type.
-    if (clangVecTy->isExtVectorBoolType())
+    if (clangVecTy->isExtVectorBoolType() &&
+        !clangVecTy->isPackedVectorBoolType(getContext())) {
       cgm.errorNYI(addr.getPointer().getLoc(),
-                   "emitStoreOfScalar ExtVectorBoolType");
+                   "emitStoreOfScalar: HLSL bool vector");
+      return;
+    }
 
-    // Handle vectors of size 3 like size 4 for better performance.
-    const mlir::Type elementType = addr.getElementType();
-    const auto vecTy = cast<cir::VectorType>(elementType);
-
-    // TODO(CIR): Use `ABIInfo::getOptimalVectorMemoryType` once it upstreamed
-    assert(!cir::MissingFeatures::cirgenABIInfo());
-    if (vecTy.getSize() == 3 && !getLangOpts().PreserveVec3Type)
-      cgm.errorNYI(addr.getPointer().getLoc(),
-                   "emitStoreOfScalar Vec3 & PreserveVec3Type disabled");
+    // A packed boolean vector is stored as an integer, so the element type is
+    // not a vector and the fixup below does not apply to it. emitToMemory does
+    // the bit-packing instead.
+    if (auto vecTy = mlir::dyn_cast<cir::VectorType>(addr.getElementType())) {
+      // Handle vectors of size 3 like size 4 for better performance.
+      // TODO(CIR): Use `ABIInfo::getOptimalVectorMemoryType` once it upstreamed
+      assert(!cir::MissingFeatures::cirgenABIInfo());
+      if (vecTy.getSize() == 3 && !getLangOpts().PreserveVec3Type)
+        cgm.errorNYI(addr.getPointer().getLoc(),
+                     "emitStoreOfScalar Vec3 & PreserveVec3Type disabled");
+    }
   }
 
   value = emitToMemory(value, ty);
@@ -702,6 +718,21 @@ LValue CIRGenFunction::emitLValueForFieldInitialization(
   return makeAddrLValue(v, fieldType, fieldBaseInfo);
 }
 
+mlir::Value CIRGenFunction::emitBoolVecConversion(mlir::Value srcVec,
+                                                  unsigned numElementsDst) {
+  auto srcTy = mlir::cast<cir::VectorType>(srcVec.getType());
+  unsigned numElementsSrc = srcTy.getSize();
+  if (numElementsSrc == numElementsDst)
+    return srcVec;
+
+  // -1 selects poison, which is what the padding lanes get when widening.
+  SmallVector<int64_t, 16> mask(numElementsDst, -1);
+  for (unsigned i : llvm::seq(std::min(numElementsDst, numElementsSrc)))
+    mask[i] = i;
+
+  return builder.createVecShuffle(srcVec.getLoc(), srcVec, mask);
+}
+
 /// Converts a scalar value from its primary IR type (as returned
 /// by ConvertType) to its load/store type.
 mlir::Value CIRGenFunction::emitToMemory(mlir::Value value, QualType ty) {
@@ -709,7 +740,18 @@ mlir::Value CIRGenFunction::emitToMemory(mlir::Value value, QualType ty) {
     ty = atomicTy->getValueType();
 
   if (ty->isExtVectorBoolType()) {
-    cgm.errorNYI("emitToMemory: extVectorBoolType");
+    if (!ty->isPackedVectorBoolType(getContext())) {
+      // HLSL stores a bool vector as a vector of i32 rather than bit-packing
+      // it, so it needs a zero-extend here instead of the code below.
+      cgm.errorNYI("emitToMemory: HLSL bool vector");
+      return value;
+    }
+
+    // Widen <N x !cir.bool> to the padded lane count, then bitcast the whole
+    // vector to the iP it is stored as.
+    auto storeTy = mlir::cast<cir::IntType>(convertTypeForMem(ty));
+    value = emitBoolVecConversion(value, storeTy.getWidth());
+    return builder.createBitcast(value, storeTy);
   }
 
   // Unlike in classic codegen CIR, bools are kept as `cir.bool` and BitInts are
@@ -723,7 +765,13 @@ mlir::Value CIRGenFunction::emitFromMemory(mlir::Value value, QualType ty) {
     ty = atomicTy->getValueType();
 
   if (ty->isPackedVectorBoolType(getContext())) {
-    cgm.errorNYI("emitFromMemory: PackedVectorBoolType");
+    // Undo emitToMemory: bitcast the iP back to a vector of that many bool
+    // lanes, then narrow it to the type's actual lane count.
+    auto storeTy = mlir::cast<cir::IntType>(value.getType());
+    auto valueTy = mlir::cast<cir::VectorType>(convertType(ty));
+    mlir::Value paddedVec = builder.createBitcast(
+        value, cir::VectorType::get(builder.getBoolTy(), storeTy.getWidth()));
+    return emitBoolVecConversion(paddedVec, valueTy.getSize());
   }
 
   return value;
@@ -750,18 +798,22 @@ mlir::Value CIRGenFunction::emitLoadOfScalar(Address addr, bool isVolatile,
   mlir::Type eltTy = addr.getElementType();
 
   if (const auto *clangVecTy = ty->getAs<clang::VectorType>()) {
-    if (clangVecTy->isExtVectorBoolType()) {
-      cgm.errorNYI(loc, "emitLoadOfScalar: ExtVectorBoolType");
+    if (clangVecTy->isExtVectorBoolType() &&
+        !clangVecTy->isPackedVectorBoolType(getContext())) {
+      cgm.errorNYI(loc, "emitLoadOfScalar: HLSL bool vector");
       return nullptr;
     }
 
-    const auto vecTy = cast<cir::VectorType>(eltTy);
-
-    // Handle vectors of size 3 like size 4 for better performance.
-    assert(!cir::MissingFeatures::cirgenABIInfo());
-    if (vecTy.getSize() == 3 && !getLangOpts().PreserveVec3Type)
-      cgm.errorNYI(addr.getPointer().getLoc(),
-                   "emitLoadOfScalar Vec3 & PreserveVec3Type disabled");
+    // A packed boolean vector is stored as an integer, so the element type is
+    // not a vector and the fixup below does not apply to it. emitFromMemory
+    // unpacks the loaded integer back into lanes.
+    if (auto vecTy = mlir::dyn_cast<cir::VectorType>(eltTy)) {
+      // Handle vectors of size 3 like size 4 for better performance.
+      assert(!cir::MissingFeatures::cirgenABIInfo());
+      if (vecTy.getSize() == 3 && !getLangOpts().PreserveVec3Type)
+        cgm.errorNYI(addr.getPointer().getLoc(),
+                     "emitLoadOfScalar Vec3 & PreserveVec3Type disabled");
+    }
   }
 
   assert(!cir::MissingFeatures::opLoadStoreTbaa());
@@ -782,7 +834,7 @@ mlir::Value CIRGenFunction::emitLoadOfScalar(Address addr, bool isVolatile,
   // conversion here: like bool and _BitInt(N), CIR keeps them in their literal
   // type until LowerToLLVM widens them to the in-memory integer type (see
   // emitToMemory).
-  return loadOp;
+  return emitFromMemory(loadOp, ty);
 }
 
 mlir::Value CIRGenFunction::emitLoadOfScalar(LValue lvalue,

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -221,7 +221,12 @@ void CIRGenFunction::emitAndUpdateRetAlloca(QualType type, mlir::Location loc,
                                             CharUnits alignment) {
   if (!type->isVoidType()) {
     Address allocaAddr = Address::invalid();
-    returnValue = createMemTemp(type, alignment, loc, "__retval", &allocaAddr);
+    // As in classic codegen's CreateIRTemp, the return slot is typed with the
+    // value representation of the type rather than the in-memory one. The two
+    // only differ for packed boolean vectors.
+    returnValue = createTempAlloca(convertType(type), /*destAddrSpace=*/{},
+                                   alignment, loc, "__retval",
+                                   /*arraySize=*/nullptr, &allocaAddr);
     fnRetAlloca = allocaAddr.getPointer();
   }
 }
@@ -447,7 +452,7 @@ void CIRGenFunction::emitFunctionProlog(const FunctionArgList &args,
 
     mlir::Value addrVal =
         emitAlloca(cast<NamedDecl>(paramVar)->getName(),
-                   convertType(paramVar->getType()), paramLoc, alignment,
+                   convertTypeForMem(paramVar->getType()), paramLoc, alignment,
                    /*insertIntoFnEntryBlock=*/true);
 
     declare(addrVal, paramVar, paramVar->getType(), paramLoc, alignment,
@@ -464,6 +469,11 @@ void CIRGenFunction::emitFunctionProlog(const FunctionArgList &args,
     // Location of the store to the param storage tracked as beginning of
     // the function body.
     mlir::Location fnBodyBegin = getLoc(bodyBeginLoc);
+    // The argument arrives in its register form; convert it to the in-memory
+    // form the alloca was typed for. This is a no-op except for packed boolean
+    // vectors, which are held as <N x !cir.bool> but stored bit-packed in an
+    // integer.
+    paramVal = emitToMemory(paramVal, paramVar->getType());
     builder.CIRBaseBuilderTy::createStore(fnBodyBegin, paramVal, addrVal);
   }
   assert(builder.getInsertionBlock() && "Should be valid");

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -2321,6 +2321,12 @@ public:
   /// representation to its value representation.
   mlir::Value emitFromMemory(mlir::Value value, clang::QualType ty);
 
+  /// Reshape a vector of `!cir.bool` to \p numElementsDst lanes, padding with
+  /// poison when widening and dropping the tail when narrowing. Used to move
+  /// packed boolean vectors between their value and memory lane counts.
+  mlir::Value emitBoolVecConversion(mlir::Value srcVec,
+                                    unsigned numElementsDst);
+
   /// Emit a trap instruction, which is used to abort the program in an abnormal
   /// way, usually for debugging purposes.
   /// \p createNewBlock indicates whether to create a new block for the IR

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -1455,6 +1455,16 @@ void CIRGenModule::emitGlobalVarDefinition(const clang::VarDecl *vd,
   const VarDecl *initDecl;
   const Expr *initExpr = vd->getAnyInitializer(initDecl);
 
+  // A packed boolean vector is stored as an integer with one bit per lane, so
+  // its initializer has to be folded down to that integer. Classic codegen
+  // sidesteps this by giving the global the vector type, which typed CIR
+  // pointers do not allow.
+  if (initExpr && vd->getType()->isPackedVectorBoolType(astContext)) {
+    errorNYI(vd->getSourceRange(),
+             "emitGlobalVarDefinition: packed boolean vector initializer");
+    return;
+  }
+
   std::optional<ConstantEmitter> emitter;
 
   // CUDA E.2.4.1 "__shared__ variables cannot have an initialization
@@ -1491,7 +1501,7 @@ void CIRGenModule::emitGlobalVarDefinition(const clang::VarDecl *vd,
     // exists. A use may still exists, however, so we still may need
     // to do a RAUW.
     assert(!vd->getType()->isIncompleteType() && "Unexpected incomplete type");
-    init = builder.getZeroInitAttr(convertType(vd->getType()));
+    init = builder.getZeroInitAttr(getTypes().convertTypeForMem(vd->getType()));
   } else {
     emitter.emplace(*this);
     mlir::Attribute initializer = emitter->tryEmitForInitializer(*initDecl);

--- a/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
@@ -549,7 +549,9 @@ mlir::Type CIRGenTypes::convertType(QualType type) {
     QualType elemTy = ptrTy->getPointeeType();
     assert(!elemTy->isConstantMatrixType() && "not implemented");
 
-    mlir::Type pointeeType = convertType(elemTy);
+    // The pointee is spelled with its in-memory type, matching references
+    // above. This only differs from convertType for packed boolean vectors.
+    mlir::Type pointeeType = convertTypeForMem(elemTy);
 
     resultType = builder.getPointerTo(pointeeType, elemTy.getAddressSpace());
     break;
@@ -688,6 +690,15 @@ mlir::Type CIRGenTypes::convertTypeForMem(clang::QualType qualType,
   }
 
   mlir::Type convertedType = convertType(qualType);
+
+  // A packed boolean vector (an ext_vector_type of bool outside of HLSL) is a
+  // vector of bits: it is held in registers as <N x !cir.bool> but stored as a
+  // single integer with one bit per lane, padded up to at least a byte.
+  if (qualType->isPackedVectorBoolType(astContext)) {
+    uint64_t numElems = mlir::cast<cir::VectorType>(convertedType).getSize();
+    return cir::IntType::get(&getMLIRContext(), std::max<uint64_t>(numElems, 8),
+                             /*isSigned=*/false);
+  }
 
   assert(!forBitField && "Bit fields NYI");
 

--- a/clang/test/CIR/CodeGen/vector-bool.c
+++ b/clang/test/CIR/CodeGen/vector-bool.c
@@ -1,0 +1,154 @@
+// TODO(cir): drop -fno-clangir-call-conv-lowering once CallConvLowering
+// supports vector types.
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-call-conv-lowering -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-call-conv-lowering -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll %s -check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=OGCG
+
+// A packed boolean vector is held in registers as one lane per element, but
+// stored as an integer with one bit per lane, padded up to at least a byte.
+
+typedef _Bool vb4 __attribute__((ext_vector_type(4)));
+typedef _Bool vb8 __attribute__((ext_vector_type(8)));
+typedef _Bool vb16 __attribute__((ext_vector_type(16)));
+
+vb4 g4;
+vb8 g8;
+vb16 g16;
+
+// CIR: cir.global external @g4 = #cir.int<0> : !u8i {alignment = 1 : i64}
+// CIR: cir.global external @g8 = #cir.int<0> : !u8i {alignment = 1 : i64}
+// CIR: cir.global external @g16 = #cir.int<0> : !u16i {alignment = 2 : i64}
+
+// LLVM: @g4 = global i8 0, align 1
+// LLVM: @g8 = global i8 0, align 1
+// LLVM: @g16 = global i16 0, align 2
+
+// OGCG: @g4 = global i8 0, align 1
+// OGCG: @g8 = global i8 0, align 1
+// OGCG: @g16 = global i16 0, align 2
+
+void store(vb8 *p, vb8 v) { *p = v; }
+
+// CIR-LABEL: cir.func {{.*}}@store
+// CIR:         %[[SLOT:.*]] = cir.alloca "v" align(1) init : !cir.ptr<!u8i>
+// CIR:         %[[PACKED:.*]] = cir.cast bitcast %{{.*}} : !cir.vector<8 x !cir.bool> -> !u8i
+// CIR:         cir.store %[[PACKED]], %[[SLOT]] : !u8i, !cir.ptr<!u8i>
+// CIR:         %[[BITS:.*]] = cir.load align(1) %[[SLOT]] : !cir.ptr<!u8i>, !u8i
+// CIR:         %[[VEC:.*]] = cir.cast bitcast %[[BITS]] : !u8i -> !cir.vector<8 x !cir.bool>
+// CIR:         %[[OUT:.*]] = cir.cast bitcast %[[VEC]] : !cir.vector<8 x !cir.bool> -> !u8i
+// CIR:         cir.store align(1) %[[OUT]], %{{.*}} : !u8i, !cir.ptr<!u8i>
+
+// LLVM-LABEL: define {{.*}}void @store
+// LLVM:         %[[SLOT:.*]] = alloca i8, i64 1, align 1
+// LLVM:         %[[PACKED:.*]] = bitcast <8 x i1> %{{.*}} to i8
+// LLVM:         store i8 %[[PACKED]], ptr %[[SLOT]], align 1
+// LLVM:         %[[BITS:.*]] = load i8, ptr %[[SLOT]], align 1
+// LLVM:         %[[VEC:.*]] = bitcast i8 %[[BITS]] to <8 x i1>
+// LLVM:         %[[OUT:.*]] = bitcast <8 x i1> %[[VEC]] to i8
+// LLVM:         store i8 %[[OUT]], ptr %{{.*}}, align 1
+
+// OGCG-LABEL: define {{.*}}void @store
+// OGCG:         %[[PACKED:.*]] = bitcast <8 x i1> %{{.*}} to i8
+// OGCG:         store i8 %[[PACKED]], ptr %[[SLOT:.*]], align 1
+// OGCG:         %[[BITS:.*]] = load i8, ptr %[[SLOT]], align 1
+// OGCG:         %[[VEC:.*]] = bitcast i8 %[[BITS]] to <8 x i1>
+// OGCG:         %[[OUT:.*]] = bitcast <8 x i1> %[[VEC]] to i8
+// OGCG:         store i8 %[[OUT]], ptr %{{.*}}, align 1
+
+vb8 load(vb8 *p) { return *p; }
+
+// The return slot holds the value representation, so it is a vector of lanes.
+
+// CIR-LABEL: cir.func {{.*}}@load
+// CIR:         %[[RET:.*]] = cir.alloca "__retval" align(1) : !cir.ptr<!cir.vector<8 x !cir.bool>>
+// CIR:         %[[BITS:.*]] = cir.load align(1) %{{.*}} : !cir.ptr<!u8i>, !u8i
+// CIR:         %[[VEC:.*]] = cir.cast bitcast %[[BITS]] : !u8i -> !cir.vector<8 x !cir.bool>
+// CIR:         cir.store %[[VEC]], %[[RET]] : !cir.vector<8 x !cir.bool>, !cir.ptr<!cir.vector<8 x !cir.bool>>
+
+// LLVM-LABEL: define {{.*}}<8 x i1> @load
+// LLVM:         %[[RET:.*]] = alloca <8 x i1>, i64 1, align 1
+// LLVM:         %[[BITS:.*]] = load i8, ptr %{{.*}}, align 1
+// LLVM:         %[[VEC:.*]] = bitcast i8 %[[BITS]] to <8 x i1>
+// LLVM:         store <8 x i1> %[[VEC]], ptr %[[RET]], align 1
+
+// OGCG-LABEL: define {{.*}}i8 @load
+// OGCG:         %[[RET:.*]] = alloca <8 x i1>, align 1
+// OGCG:         %[[BITS:.*]] = load i8, ptr %{{.*}}, align 1
+// OGCG:         %[[VEC:.*]] = bitcast i8 %[[BITS]] to <8 x i1>
+// OGCG:         store <8 x i1> %[[VEC]], ptr %[[RET]], align 1
+
+// A vector with fewer than 8 lanes is padded out to a byte, so moving it in and
+// out of memory reshapes it with a shuffle.
+
+void store4(vb4 *p, vb4 v) { *p = v; }
+
+// CIR-LABEL: cir.func {{.*}}@store4
+// CIR:         %[[WIDE:.*]] = cir.vec.shuffle(%{{.*}}, %{{.*}} : !cir.vector<4 x !cir.bool>) [#cir.int<0> : !s32i, #cir.int<1> : !s32i, #cir.int<2> : !s32i, #cir.int<3> : !s32i, #cir.int<-1> : !s32i, #cir.int<-1> : !s32i, #cir.int<-1> : !s32i, #cir.int<-1> : !s32i] : !cir.vector<8 x !cir.bool>
+// CIR:         %[[PACKED:.*]] = cir.cast bitcast %[[WIDE]] : !cir.vector<8 x !cir.bool> -> !u8i
+// CIR:         cir.store %[[PACKED]], %{{.*}} : !u8i, !cir.ptr<!u8i>
+// CIR:         %[[BITS:.*]] = cir.load align(1) %{{.*}} : !cir.ptr<!u8i>, !u8i
+// CIR:         %[[PADDED:.*]] = cir.cast bitcast %[[BITS]] : !u8i -> !cir.vector<8 x !cir.bool>
+// CIR:         %[[NARROW:.*]] = cir.vec.shuffle(%[[PADDED]], %{{.*}} : !cir.vector<8 x !cir.bool>) [#cir.int<0> : !s32i, #cir.int<1> : !s32i, #cir.int<2> : !s32i, #cir.int<3> : !s32i] : !cir.vector<4 x !cir.bool>
+
+// LLVM-LABEL: define {{.*}}void @store4
+// LLVM:         %[[WIDE:.*]] = shufflevector <4 x i1> %{{.*}}, <4 x i1> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 poison, i32 poison, i32 poison, i32 poison>
+// LLVM:         %[[PACKED:.*]] = bitcast <8 x i1> %[[WIDE]] to i8
+// LLVM:         store i8 %[[PACKED]], ptr %{{.*}}, align 1
+// LLVM:         %[[BITS:.*]] = load i8, ptr %{{.*}}, align 1
+// LLVM:         %[[PADDED:.*]] = bitcast i8 %[[BITS]] to <8 x i1>
+// LLVM:         %[[NARROW:.*]] = shufflevector <8 x i1> %[[PADDED]], <8 x i1> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+
+// OGCG-LABEL: define {{.*}}void @store4
+// OGCG:         %[[WIDE:.*]] = shufflevector <4 x i1> %{{.*}}, <4 x i1> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 poison, i32 poison, i32 poison, i32 poison>
+// OGCG:         %[[PACKED:.*]] = bitcast <8 x i1> %[[WIDE]] to i8
+// OGCG:         store i8 %[[PACKED]], ptr %{{.*}}, align 1
+// OGCG:         %[[BITS:.*]] = load i8, ptr %{{.*}}, align 1
+// OGCG:         %[[PADDED:.*]] = bitcast i8 %[[BITS]] to <8 x i1>
+// OGCG:         %[[NARROW:.*]] = shufflevector <8 x i1> %[[PADDED]], <8 x i1> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+
+_Bool extract(vb8 *p) { return (*p)[3]; }
+
+// CIR-LABEL: cir.func {{.*}}@extract
+// CIR:         %[[BITS:.*]] = cir.load align(1) %{{.*}} : !cir.ptr<!u8i>, !u8i
+// CIR:         %[[VEC:.*]] = cir.cast bitcast %[[BITS]] : !u8i -> !cir.vector<8 x !cir.bool>
+// CIR:         %{{.*}} = cir.vec.extract %[[VEC]][%{{.*}} : !s32i] : !cir.vector<8 x !cir.bool>
+
+// LLVM-LABEL: define {{.*}}i1 @extract
+// LLVM:         %[[BITS:.*]] = load i8, ptr %{{.*}}, align 1
+// LLVM:         %[[VEC:.*]] = bitcast i8 %[[BITS]] to <8 x i1>
+// LLVM:         %{{.*}} = extractelement <8 x i1> %[[VEC]], i32 3
+
+// OGCG-LABEL: define {{.*}}i1 @extract
+// OGCG:         %[[BITS:.*]] = load i8, ptr %{{.*}}, align 1
+// OGCG:         %[[VEC:.*]] = bitcast i8 %[[BITS]] to <8 x i1>
+// OGCG:         %{{.*}} = extractelement <8 x i1> %[[VEC]], i32 3
+
+// Writing one lane is a read/modify/write of the whole packed integer.
+
+void insert(vb8 *p, _Bool b) { (*p)[2] = b; }
+
+// CIR-LABEL: cir.func {{.*}}@insert
+// CIR:         %[[BITS:.*]] = cir.load align(1) %{{.*}} : !cir.ptr<!u8i>, !u8i
+// CIR:         %[[VEC:.*]] = cir.cast bitcast %[[BITS]] : !u8i -> !cir.vector<8 x !cir.bool>
+// CIR:         %[[NEW:.*]] = cir.vec.insert %{{.*}}, %[[VEC]][%{{.*}} : !s32i] : !cir.vector<8 x !cir.bool>
+// CIR:         %[[OUT:.*]] = cir.cast bitcast %[[NEW]] : !cir.vector<8 x !cir.bool> -> !u8i
+// CIR:         cir.store align(1) %[[OUT]], %{{.*}} : !u8i, !cir.ptr<!u8i>
+
+// LLVM-LABEL: define {{.*}}void @insert
+// LLVM:         %[[PTR:.*]] = load ptr, ptr %{{.*}}, align 8
+// LLVM:         %[[BITS:.*]] = load i8, ptr %[[PTR]], align 1
+// LLVM:         %[[VEC:.*]] = bitcast i8 %[[BITS]] to <8 x i1>
+// LLVM:         %[[NEW:.*]] = insertelement <8 x i1> %[[VEC]], i1 %{{.*}}, i32 2
+// LLVM:         %[[OUT:.*]] = bitcast <8 x i1> %[[NEW]] to i8
+// LLVM:         store i8 %[[OUT]], ptr %{{.*}}, align 1
+
+// OGCG-LABEL: define {{.*}}void @insert
+// OGCG:         %[[PTR:.*]] = load ptr, ptr %{{.*}}, align 8
+// OGCG:         %[[BITS:.*]] = load i8, ptr %[[PTR]], align 1
+// OGCG:         %[[VEC:.*]] = bitcast i8 %[[BITS]] to <8 x i1>
+// OGCG:         %[[NEW:.*]] = insertelement <8 x i1> %[[VEC]], i1 %{{.*}}, i32 2
+// OGCG:         %[[OUT:.*]] = bitcast <8 x i1> %[[NEW]] to i8
+// OGCG:         store i8 %[[OUT]], ptr %{{.*}}, align 1

--- a/clang/test/CIR/CodeGenHLSL/matrix-element-expr-load.hlsl
+++ b/clang/test/CIR/CodeGenHLSL/matrix-element-expr-load.hlsl
@@ -2,7 +2,7 @@
 // RUN:   -fclangir -emit-cir -disable-llvm-passes -verify
 
 // expected-error@*:* {{ClangIR code gen Not Yet Implemented: processing of type: ConstantMatrix}}
-// expected-error@*:* {{ClangIR code gen Not Yet Implemented: Matrix type conversion}}
+// expected-error@*:* 2 {{ClangIR code gen Not Yet Implemented: Matrix type conversion}}
 float test_zero_indexed(float2x2 M) {
   // expected-error@+1 {{ClangIR code gen Not Yet Implemented: ScalarExprEmitter: matrix element}}
   return M._m00;


### PR DESCRIPTION
Held as <N x !cir.bool>, stored bit-packed in an iP, P = max(N, 8), as in classic CodeGen. HLSL bool vectors and packed global initializers stay NYI. Unblocks ~35 libc++ std/ tests. The test pins -fno-clangir-call-conv-lowering since CallConvLowering does not handle vector types yet.