### PR TITLE
[lldb][test] Don't let the Darwin builder clobber ARCH_CFLAGS

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/builders/darwin.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/darwin.py
@@ -60,18 +60,7 @@ class BuilderDarwin(Builder):
         return ["{}={}".format(key, value) for key, value in args.items()]
 
     def getArchCFlags(self):
-        triple = self.getTriple()
-        if not triple:
-            return []
-
-        _, _, os, version, _ = split_triple(triple)
-
-        if os == "darwin" or not version:
-            return []
-
-        target_os = "-mtargetos={}{}".format(os, version)
-
-        return ["ARCH_CFLAGS={}".format(target_os)]
+        return []
 
     def _getDebugInfoArgs(self, debug_info):
         if debug_info == "dsym":


### PR DESCRIPTION
f5e2b8b1df07 ("[lldb] Rally around triple rather than arch in the API tests") moved the construction of ARCH_CFLAGS into Makefile.rules but left the builder returning a value. Configurations whose triple names a bare darwin OS take an early return and are unaffected, which is why a default macOS build does not notice.

Assisted-by: claude