### PR TITLE
[libc] Add `NEED_MPFR_F128` argument to add_fp_unittest.

### DIFF
--- a/libc/test/src/CMakeLists.txt
+++ b/libc/test/src/CMakeLists.txt
@@ -18,7 +18,7 @@ function(add_fp_unittest name)
 
   # TODO: To be removed when we find a workaround to run MPFR tests for
   # emulated type where compiler doesn't support the native float128
-  if(MATH_UNITTEST_NEED_MPFR128)
+  if(MATH_UNITTEST_NEED_MPFR_F128)
     set(MATH_UNITTEST_NEED_MPFR TRUE)
     if(NOT LIBC_TYPES_HAS_NATIVE_FLOAT128)
       message(VERBOSE "Math test ${name} will be skipped as native float128 support in MPFR is not available.")

--- a/libc/test/src/CMakeLists.txt
+++ b/libc/test/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 function(add_fp_unittest name)
   cmake_parse_arguments(
     "MATH_UNITTEST"
-    "NEED_MPFR;NEED_MPC;FULL_BUILD_ONLY;OVERLAY_BUILD_ONLY" # Optional arguments
+    "NEED_MPFR;NEED_MPFR128;NEED_MPC;FULL_BUILD_ONLY;OVERLAY_BUILD_ONLY" # Optional arguments
     "" # Single value arguments
     "LINK_LIBRARIES;DEPENDS" # Multi-value arguments
     ${ARGN}
@@ -14,6 +14,16 @@ function(add_fp_unittest name)
       return()
     endif()
     list(APPEND MATH_UNITTEST_LINK_LIBRARIES libcMPCWrapper)
+  endif()
+
+  # TODO: To be removed when we find a workaround to run MPFR tests for
+  # emulated type where compiler doesn't support the native float128
+  if(MATH_UNITTEST_NEED_MPFR128)
+    set(MATH_UNITTEST_NEED_MPFR TRUE)
+    if(NOT LIBC_TYPES_HAS_NATIVE_FLOAT128)
+      message(VERBOSE "Math test ${name} will be skipped as native float128 type is not available.")
+      return()
+    endif()
   endif()
 
   if(MATH_UNITTEST_NEED_MPFR)

--- a/libc/test/src/CMakeLists.txt
+++ b/libc/test/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 function(add_fp_unittest name)
   cmake_parse_arguments(
     "MATH_UNITTEST"
-    "NEED_MPFR;NEED_MPFR128;NEED_MPC;FULL_BUILD_ONLY;OVERLAY_BUILD_ONLY" # Optional arguments
+    "NEED_MPFR;NEED_MPFR_F128;NEED_MPC;FULL_BUILD_ONLY;OVERLAY_BUILD_ONLY" # Optional arguments
     "" # Single value arguments
     "LINK_LIBRARIES;DEPENDS" # Multi-value arguments
     ${ARGN}
@@ -21,7 +21,7 @@ function(add_fp_unittest name)
   if(MATH_UNITTEST_NEED_MPFR128)
     set(MATH_UNITTEST_NEED_MPFR TRUE)
     if(NOT LIBC_TYPES_HAS_NATIVE_FLOAT128)
-      message(VERBOSE "Math test ${name} will be skipped as native float128 type is not available.")
+      message(VERBOSE "Math test ${name} will be skipped as native float128 support in MPFR is not available.")
       return()
     endif()
   endif()

--- a/libc/test/src/CMakeLists.txt
+++ b/libc/test/src/CMakeLists.txt
@@ -18,6 +18,7 @@ function(add_fp_unittest name)
 
   # TODO: To be removed when we find a workaround to run MPFR tests for
   # emulated type where compiler doesn't support the native float128
+  # TODO: Check mpfr_buildopt_float128_p() returns non-zero.
   if(MATH_UNITTEST_NEED_MPFR_F128)
     set(MATH_UNITTEST_NEED_MPFR TRUE)
     if(NOT LIBC_TYPES_HAS_NATIVE_FLOAT128)

--- a/libc/test/src/math/CMakeLists.txt
+++ b/libc/test/src/math/CMakeLists.txt
@@ -424,7 +424,7 @@ add_fp_unittest(
 
 add_fp_unittest(
   ceilf128_test
-  NEED_MPFR
+  NEED_MPFR_F128
   SUITE
     libc-math-unittests
   SRCS
@@ -1781,7 +1781,7 @@ add_fp_unittest(
 
 add_fp_unittest(
   sqrtf128_test
-  NEED_MPFR
+  NEED_MPFR_F128
   SUITE
     libc-math-unittests
   SRCS
@@ -2756,7 +2756,7 @@ add_fp_unittest(
 
 add_fp_unittest(
   scalbnf128_test
-  NEED_MPFR
+  NEED_MPFR_F128
   SUITE
     libc-math-unittests
   SRCS
@@ -2866,7 +2866,7 @@ add_fp_unittest(
 
 add_fp_unittest(
   atan2f128_test
-  NEED_MPFR
+  NEED_MPFR_F128
   SUITE
     libc-math-unittests
   SRCS
@@ -3421,7 +3421,7 @@ add_fp_unittest(
 
 add_fp_unittest(
   bf16addf128_test
-  NEED_MPFR
+  NEED_MPFR_F128
   SUITE
     libc-math-unittests
   SRCS
@@ -3477,7 +3477,7 @@ add_fp_unittest(
 
 add_fp_unittest(
   bf16divf128_test
-  NEED_MPFR
+  NEED_MPFR_F128
   SUITE
     libc-math-unittests
   SRCS
@@ -3539,7 +3539,7 @@ add_fp_unittest(
 
 add_fp_unittest(
   bf16fmaf128_test
-  NEED_MPFR
+  NEED_MPFR_F128
   SUITE
     libc-math-unittests
   SRCS
@@ -3603,7 +3603,7 @@ add_fp_unittest(
 
 add_fp_unittest(
   bf16mulf128_test
-  NEED_MPFR
+  NEED_MPFR_F128
   SUITE
     libc-math-unittests
   SRCS
@@ -3661,7 +3661,7 @@ add_fp_unittest(
 
 add_fp_unittest(
   bf16subf128_test
-  NEED_MPFR
+  NEED_MPFR_F128
   SUITE
     libc-math-unittests
   SRCS

--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -4914,7 +4914,6 @@ add_fp_unittest(
 
 add_fp_unittest(
   acosbf16_test
-  NEED_MPFR
   SUITE
     libc-math-smoke-tests
   SRCS

--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -290,7 +290,6 @@ add_fp_unittest(
 
 add_fp_unittest(
   faddf128_test
-  NEED_MPFR
   SUITE
     libc-math-unittests
   SRCS

--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -274,7 +274,6 @@ add_fp_unittest(
 
 add_fp_unittest(
   faddl_test
-  NEED_MPFR
   SUITE
     libc-math-unittests
   SRCS
@@ -4774,7 +4773,6 @@ add_fp_unittest(
 
 add_fp_unittest(
   atanpif16_test
-  NEED_MPFR
   SUITE
     libc-math-unittests
   SRCS
@@ -4832,7 +4830,6 @@ add_fp_unittest(
 
 add_fp_unittest(
   asinpif16_test
-  NEED_MPFR
   SUITE
     libc-math-unittests
   SRCS

--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -5006,7 +5006,6 @@ add_fp_unittest(
 
 add_fp_unittest(
   atanbf16_test
-  NEED_MPFR
   SUITE
     libc-math-smoke-tests
   SRCS

--- a/libc/test/src/math/smoke/acosbf16_test.cpp
+++ b/libc/test/src/math/smoke/acosbf16_test.cpp
@@ -6,14 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/errno_macros.h"
 #include "src/__support/FPUtil/bfloat16.h"
 #include "src/math/acosbf16.h"
 #include "test/UnitTest/FEnvSafeTest.h"
 #include "test/UnitTest/FPMatcher.h"
 #include "test/UnitTest/Test.h"
-#include "utils/MPFRWrapper/MPFRUtils.h"
-
-namespace mpfr = LIBC_NAMESPACE::testing::mpfr;
 
 class LlvmLibcAcosBf16Test : public LIBC_NAMESPACE::testing::FEnvSafeTest {
   DECLARE_SPECIAL_CONSTANTS(bfloat16)
@@ -26,6 +24,14 @@ public:
         aNaN, LIBC_NAMESPACE::acosbf16(sNaN), FE_INVALID);
     EXPECT_MATH_ERRNO(0);
 
+    EXPECT_FP_EQ_WITH_EXCEPTION_ALL_ROUNDING(
+        aNaN, LIBC_NAMESPACE::acosbf16(inf), FE_INVALID);
+    EXPECT_MATH_ERRNO(EDOM);
+
+    EXPECT_FP_EQ_WITH_EXCEPTION_ALL_ROUNDING(
+        aNaN, LIBC_NAMESPACE::acosbf16(neg_inf), FE_INVALID);
+    EXPECT_MATH_ERRNO(EDOM);
+
     EXPECT_FP_EQ_ALL_ROUNDING(bfloat16(0x1.921fb6p0f),
                               LIBC_NAMESPACE::acosbf16(zero));
     EXPECT_MATH_ERRNO(0);
@@ -34,13 +40,12 @@ public:
                               LIBC_NAMESPACE::acosbf16(neg_zero));
     EXPECT_MATH_ERRNO(0);
 
-    bfloat16 VALUES[] = {inf, neg_inf, bfloat16(1.0f), bfloat16(-1.0)};
-    for (size_t i = 0; i < 4; ++i) {
-      bfloat16 x = VALUES[i];
+    EXPECT_FP_EQ_ALL_ROUNDING(zero, LIBC_NAMESPACE::acosbf16(1.0));
+    EXPECT_MATH_ERRNO(0);
 
-      EXPECT_MPFR_MATCH_ALL_ROUNDING(mpfr::Operation::Acos, x,
-                                     LIBC_NAMESPACE::acosbf16(x), 0.5);
-    }
+    EXPECT_FP_EQ_ALL_ROUNDING(bfloat16(0x1.921fb6p1f),
+                              LIBC_NAMESPACE::acosbf16(-1.0));
+    EXPECT_MATH_ERRNO(0);
   }
 };
 TEST_F(LlvmLibcAcosBf16Test, SpecialNumbers) { test_special_numbers(); }

--- a/libc/test/src/math/smoke/acosbf16_test.cpp
+++ b/libc/test/src/math/smoke/acosbf16_test.cpp
@@ -40,11 +40,11 @@ public:
                               LIBC_NAMESPACE::acosbf16(neg_zero));
     EXPECT_MATH_ERRNO(0);
 
-    EXPECT_FP_EQ_ALL_ROUNDING(zero, LIBC_NAMESPACE::acosbf16(1.0));
+    EXPECT_FP_EQ_ALL_ROUNDING(zero, LIBC_NAMESPACE::acosbf16(bfloat16(1.0)));
     EXPECT_MATH_ERRNO(0);
 
     EXPECT_FP_EQ_ALL_ROUNDING(bfloat16(0x1.921fb6p1f),
-                              LIBC_NAMESPACE::acosbf16(-1.0));
+                              LIBC_NAMESPACE::acosbf16(bfloat16(-1.0)));
     EXPECT_MATH_ERRNO(0);
   }
 };

--- a/libc/test/src/math/smoke/atanbf16_test.cpp
+++ b/libc/test/src/math/smoke/atanbf16_test.cpp
@@ -11,9 +11,6 @@
 #include "test/UnitTest/FEnvSafeTest.h"
 #include "test/UnitTest/FPMatcher.h"
 #include "test/UnitTest/Test.h"
-#include "utils/MPFRWrapper/MPFRUtils.h"
-
-namespace mpfr = LIBC_NAMESPACE::testing::mpfr;
 
 class LlvmLibcAtanBf16Test : public LIBC_NAMESPACE::testing::FEnvSafeTest {
   DECLARE_SPECIAL_CONSTANTS(bfloat16)
@@ -32,13 +29,21 @@ public:
     EXPECT_FP_EQ_ALL_ROUNDING(neg_zero, LIBC_NAMESPACE::atanbf16(neg_zero));
     EXPECT_MATH_ERRNO(0);
 
-    bfloat16 VALUES[] = {inf, neg_inf, bfloat16(1.0f), bfloat16(-1.0)};
-    for (size_t i = 0; i < 4; ++i) {
-      bfloat16 x = VALUES[i];
+    EXPECT_FP_EQ_ALL_ROUNDING(bfloat16(0x1.921fb6p0f),
+                              LIBC_NAMESPACE::atanbf16(inf));
+    EXPECT_MATH_ERRNO(0);
 
-      EXPECT_MPFR_MATCH_ALL_ROUNDING(mpfr::Operation::Atan, x,
-                                     LIBC_NAMESPACE::atanbf16(x), 0.5);
-    }
+    EXPECT_FP_EQ_ALL_ROUNDING(bfloat16(-0x1.921fb6p0f),
+                              LIBC_NAMESPACE::atanbf16(neg_inf));
+    EXPECT_MATH_ERRNO(0);
+
+    EXPECT_FP_EQ_ALL_ROUNDING(bfloat16(0x1.921fb6p-1f),
+                              LIBC_NAMESPACE::atanbf16(bfloat16(1.0)));
+    EXPECT_MATH_ERRNO(0);
+
+    EXPECT_FP_EQ_ALL_ROUNDING(bfloat16(-0x1.921fb6p-1f),
+                              LIBC_NAMESPACE::atanbf16(bfloat16(-1.0)));
+    EXPECT_MATH_ERRNO(0);
   }
 };
 TEST_F(LlvmLibcAtanBf16Test, SpecialNumbers) { test_special_numbers(); }


### PR DESCRIPTION
Currently, the MPFR would link unconditionally when we remove the function from the guards to make it available everywhere. This introduces another problem with the function's test, in which MPFR is used, which would also get tested unconditionally now .

The MPFR would use native float128 types internally when built on a compiler with float128 support. But where it doesn't have native support, it would fail .
Thus, to prevent this failure, we only run the MPFR tests for targets with native float128 by adding `NEED_MPFR128`