### PR TITLE
[libc++] Fix duplicate names in benchmarks

### DIFF
--- a/libcxx/test/benchmarks/containers/associative/map.bench.cpp
+++ b/libcxx/test/benchmarks/containers/associative/map.bench.cpp
@@ -27,7 +27,7 @@ static void BM_map_find_string_literal(benchmark::State& state) {
   }
 }
 
-BENCHMARK(BM_map_find_string_literal);
+BENCHMARK(BM_map_find_string_literal)->Name("std::map<std::string, int>::find(const char*)");
 
 template <class K, class V>
 struct support::adapt_operations<std::map<K, V>> {

--- a/libcxx/test/benchmarks/containers/associative/unordered_map.bench.cpp
+++ b/libcxx/test/benchmarks/containers/associative/unordered_map.bench.cpp
@@ -8,6 +8,7 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
+#include <string>
 #include <unordered_map>
 #include <utility>
 
@@ -26,7 +27,7 @@ static void BM_map_find_string_literal(benchmark::State& state) {
   }
 }
 
-BENCHMARK(BM_map_find_string_literal);
+BENCHMARK(BM_map_find_string_literal)->Name("std::unordered_map<std::string, int>::find(const char*)");
 
 template <class K, class V>
 struct support::adapt_operations<std::unordered_map<K, V>> {

--- a/libcxx/test/benchmarks/format/formatter_float.bench.cpp
+++ b/libcxx/test/benchmarks/format/formatter_float.bench.cpp
@@ -30,10 +30,13 @@ inline constexpr std::string to_string<double> = "double";
 
 enum class ValueE { Inf, Random };
 
+std::string value_name(ValueE value) { return value == ValueE::Inf ? "-inf" : "random"; }
+
 int main(int argc, char** argv) {
   auto bm = []<class FloatingPoint>(std::type_identity<FloatingPoint>, ValueE v, std::string fmt) {
     benchmark::RegisterBenchmark(
-        "std::format(" + to_string<FloatingPoint> + ") (fmt: " + fmt + ")", [fmt, v](benchmark::State& state) {
+        "std::format(" + to_string<FloatingPoint> + ") (value: " + value_name(v) + ", fmt: " + fmt + ")",
+        [fmt, v](benchmark::State& state) {
           std::array<FloatingPoint, 1000> data = [&] {
             std::array<FloatingPoint, 1000> result;
             if (v == ValueE::Inf) {

--- a/libcxx/test/benchmarks/format/write_double_comparison.bench.cpp
+++ b/libcxx/test/benchmarks/format/write_double_comparison.bench.cpp
@@ -96,27 +96,33 @@ static void BM_format_to_iterator(benchmark::State& state, F&& f) {
     }
 }
 
-BENCHMARK(BM_sprintf);
-BENCHMARK(BM_to_string);
-BENCHMARK(BM_to_chars);
-BENCHMARK(BM_to_chars_as_string);
-BENCHMARK(BM_format);
-BENCHMARK_TEMPLATE(BM_format_to_back_inserter, std::string);
-BENCHMARK_TEMPLATE(BM_format_to_back_inserter, std::vector<char>);
-BENCHMARK_TEMPLATE(BM_format_to_back_inserter, std::list<char>);
+BENCHMARK(BM_sprintf)->Name("std::sprintf(double)");
+BENCHMARK(BM_to_string)->Name("std::to_string(double)");
+BENCHMARK(BM_to_chars)->Name("std::to_chars(double)");
+BENCHMARK(BM_to_chars_as_string)->Name("std::to_chars(double) (as std::string)");
+BENCHMARK(BM_format)->Name("std::format(double)");
+BENCHMARK_TEMPLATE(BM_format_to_back_inserter, std::string)
+    ->Name("std::format_to(double) (std::back_insert_iterator<std::string>)");
+BENCHMARK_TEMPLATE(BM_format_to_back_inserter, std::vector<char>)
+    ->Name("std::format_to(double) (std::back_insert_iterator<std::vector<char>>)");
+BENCHMARK_TEMPLATE(BM_format_to_back_inserter, std::list<char>)
+    ->Name("std::format_to(double) (std::back_insert_iterator<std::list<char>>)");
 BENCHMARK_CAPTURE(BM_format_to_iterator, <std::array>, ([] {
                     std::array<char, 100> a;
                     return a;
-                  }));
+                  }))
+    ->Name("std::format_to(double) (std::array<char, 100>::iterator)");
 BENCHMARK_CAPTURE(BM_format_to_iterator, <std::string>, ([] {
                     std::string s;
                     s.resize(100);
                     return s;
-                  }));
+                  }))
+    ->Name("std::format_to(double) (std::string::iterator)");
 BENCHMARK_CAPTURE(BM_format_to_iterator, <std::vector>, ([] {
                     std::vector<char> v;
                     v.resize(100);
                     return v;
-                  }));
+                  }))
+    ->Name("std::format_to(double) (std::vector<char>::iterator)");
 
 BENCHMARK_MAIN();

--- a/libcxx/test/benchmarks/format/write_int_comparison.bench.cpp
+++ b/libcxx/test/benchmarks/format/write_int_comparison.bench.cpp
@@ -96,27 +96,33 @@ static void BM_format_to_iterator(benchmark::State& state, F&& f) {
     }
 }
 
-BENCHMARK(BM_sprintf);
-BENCHMARK(BM_to_string);
-BENCHMARK(BM_to_chars);
-BENCHMARK(BM_to_chars_as_string);
-BENCHMARK(BM_format);
-BENCHMARK_TEMPLATE(BM_format_to_back_inserter, std::string);
-BENCHMARK_TEMPLATE(BM_format_to_back_inserter, std::vector<char>);
-BENCHMARK_TEMPLATE(BM_format_to_back_inserter, std::list<char>);
+BENCHMARK(BM_sprintf)->Name("std::sprintf(int)");
+BENCHMARK(BM_to_string)->Name("std::to_string(int)");
+BENCHMARK(BM_to_chars)->Name("std::to_chars(int)");
+BENCHMARK(BM_to_chars_as_string)->Name("std::to_chars(int) (as std::string)");
+BENCHMARK(BM_format)->Name("std::format(int)");
+BENCHMARK_TEMPLATE(BM_format_to_back_inserter, std::string)
+    ->Name("std::format_to(int) (std::back_insert_iterator<std::string>)");
+BENCHMARK_TEMPLATE(BM_format_to_back_inserter, std::vector<char>)
+    ->Name("std::format_to(int) (std::back_insert_iterator<std::vector<char>>)");
+BENCHMARK_TEMPLATE(BM_format_to_back_inserter, std::list<char>)
+    ->Name("std::format_to(int) (std::back_insert_iterator<std::list<char>>)");
 BENCHMARK_CAPTURE(BM_format_to_iterator, <std::array>, ([] {
                     std::array<char, 100> a;
                     return a;
-                  }));
+                  }))
+    ->Name("std::format_to(int) (std::array<char, 100>::iterator)");
 BENCHMARK_CAPTURE(BM_format_to_iterator, <std::string>, ([] {
                     std::string s;
                     s.resize(100);
                     return s;
-                  }));
+                  }))
+    ->Name("std::format_to(int) (std::string::iterator)");
 BENCHMARK_CAPTURE(BM_format_to_iterator, <std::vector>, ([] {
                     std::vector<char> v;
                     v.resize(100);
                     return v;
-                  }));
+                  }))
+    ->Name("std::format_to(int) (std::vector<char>::iterator)");
 
 BENCHMARK_MAIN();


### PR DESCRIPTION
A few benchmarks were using names that were reused elsewhere in the test suite. All benchmarks must have a unique name, otherwise we can't distinguish them in LNT.