### PR TITLE
[OpenACC][NFC] Make CHECK-NOT lines more specific

### DIFF
--- a/clang/test/CodeGen/openacc-invalid-stmt.cpp
+++ b/clang/test/CodeGen/openacc-invalid-stmt.cpp
@@ -1,24 +1,27 @@
 // RUN: %clang_cc1 %s -emit-llvm -o - | FileCheck %s
 // CHECK: target triple
+// Note: the original bug was just that the test asserted
+// because it attempted to emit an empty statement, so check-lines
+// are effectively irrelevant, but included for completeness.
 
 void foo() {
 #pragma acc parallel
   _Alignas(4);
-  // CHECK-NOT: parallel
+  // CHECK-NOT: acc parallel
 #pragma acc loop
   _Alignas(4);
-  // CHECK-NOT: loop
+  // CHECK-NOT: acc loop
 #pragma acc kernels loop
   _Alignas(4);
-  // CHECK-NOT: kernels
+  // CHECK-NOT: acc kernels
 #pragma acc data
   _Alignas(4);
-  // CHECK-NOT: data 
+  // CHECK-NOT: acc data
 #pragma acc host_data
   _Alignas(4);
-  // CHECK-NOT: host 
+  // CHECK-NOT: acc host
 #pragma acc atomic
   _Alignas(4);
-  // CHECK-NOT: atomic 
+  // CHECK-NOT: acc atomic
 }
 


### PR DESCRIPTION
These are effectively irrelevant, as the problem we are trying to check for is that the app doesn't crash. So make them a bit more specific (add 'acc ') since we don't know what any sort of IR for these would look like ANYWAY.  Hopefully the higher specificity makes these good enough for folks.