### PR TITLE
[RISCV][NFC] Move ZacasABIFix Pass Declaration

### DIFF
--- a/llvm/lib/Target/RISCV/RISCV.h
+++ b/llvm/lib/Target/RISCV/RISCV.h
@@ -88,18 +88,6 @@ void initializeRISCVLoadStoreOptPass(PassRegistry &);
 FunctionPass *createRISCVPreAllocZilsdOptPass();
 void initializeRISCVPreAllocZilsdOptPass(PassRegistry &);
 
-class RISCVZacasABIFixPass
-    : public RequiredPassInfoMixin<RISCVZacasABIFixPass> {
-private:
-  const RISCVTargetMachine *TM;
-
-public:
-  RISCVZacasABIFixPass(const RISCVTargetMachine *TM) : TM(TM) {}
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
-};
-FunctionPass *createRISCVZacasABIFixPass();
-void initializeRISCVZacasABIFixLegacyPass(PassRegistry &);
-
 InstructionSelector *
 createRISCVInstructionSelector(const RISCVTargetMachine &,
                                const RISCVSubtarget &,

--- a/llvm/lib/Target/RISCV/RISCVCodeGenPassBuilder.cpp
+++ b/llvm/lib/Target/RISCV/RISCVCodeGenPassBuilder.cpp
@@ -18,6 +18,7 @@
 #include "RISCVTargetMachine.h"
 #include "RISCVVLOptimizer.h"
 #include "RISCVVectorPeephole.h"
+#include "RISCVZacasABIFix.h"
 #include "llvm/CodeGen/AtomicExpand.h"
 #include "llvm/CodeGen/BranchRelaxation.h"
 #include "llvm/CodeGen/InterleavedAccess.h"

--- a/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
@@ -23,6 +23,7 @@
 #include "RISCVTargetTransformInfo.h"
 #include "RISCVVLOptimizer.h"
 #include "RISCVVectorPeephole.h"
+#include "RISCVZacasABIFix.h"
 #include "TargetInfo/RISCVTargetInfo.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/CodeGen/GlobalISel/CSEInfo.h"

--- a/llvm/lib/Target/RISCV/RISCVZacasABIFix.cpp
+++ b/llvm/lib/Target/RISCV/RISCVZacasABIFix.cpp
@@ -11,7 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "RISCV.h"
+#include "RISCVZacasABIFix.h"
 #include "RISCVTargetMachine.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Analysis/ValueTracking.h"

--- a/llvm/lib/Target/RISCV/RISCVZacasABIFix.h
+++ b/llvm/lib/Target/RISCV/RISCVZacasABIFix.h
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file declares the RISC-V Zacas ABI fix passes.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIB_TARGET_RISCV_RISCVZACASABIFIX_H
+#define LLVM_LIB_TARGET_RISCV_RISCVZACASABIFIX_H
+
+#include "llvm/IR/PassManager.h"
+
+namespace llvm {
+
+class FunctionPass;
+class PassRegistry;
+class RISCVTargetMachine;
+
+class RISCVZacasABIFixPass
+    : public RequiredPassInfoMixin<RISCVZacasABIFixPass> {
+private:
+  const RISCVTargetMachine *TM;
+
+public:
+  RISCVZacasABIFixPass(const RISCVTargetMachine *TM) : TM(TM) {}
+  PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
+};
+
+FunctionPass *createRISCVZacasABIFixPass();
+void initializeRISCVZacasABIFixLegacyPass(PassRegistry &);
+
+} // namespace llvm
+
+#endif // LLVM_LIB_TARGET_RISCV_RISCVZACASABIFIX_H


### PR DESCRIPTION
This change moves them into their own header, as has been done for the
other NewPM passes.

Assisted-by: AI

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>