### PR TITLE
[lldb] Remove ConstString from ThreadPlanStepInRange

### DIFF
--- a/lldb/include/lldb/Target/Thread.h
+++ b/lldb/include/lldb/Target/Thread.h
@@ -829,7 +829,7 @@ public:
   ///     plan could not be queued.
   virtual lldb::ThreadPlanSP QueueThreadPlanForStepInRange(
       bool abort_other_plans, const AddressRange &range,
-      const SymbolContext &addr_context, const char *step_in_target,
+      const SymbolContext &addr_context, llvm::StringRef step_in_target,
       lldb::RunMode stop_other_threads, Status &status,
       LazyBool step_in_avoids_code_without_debug_info = eLazyBoolCalculate,
       LazyBool step_out_avoids_code_without_debug_info = eLazyBoolCalculate);
@@ -839,7 +839,7 @@ public:
   // step over a longer address range in a single operation.
   virtual lldb::ThreadPlanSP QueueThreadPlanForStepInRange(
       bool abort_other_plans, const LineEntry &line_entry,
-      const SymbolContext &addr_context, const char *step_in_target,
+      const SymbolContext &addr_context, llvm::StringRef step_in_target,
       lldb::RunMode stop_other_threads, Status &status,
       LazyBool step_in_avoids_code_without_debug_info = eLazyBoolCalculate,
       LazyBool step_out_avoids_code_without_debug_info = eLazyBoolCalculate);

--- a/lldb/include/lldb/Target/ThreadPlanStepInRange.h
+++ b/lldb/include/lldb/Target/ThreadPlanStepInRange.h
@@ -22,7 +22,7 @@ class ThreadPlanStepInRange : public ThreadPlanStepRange,
 public:
   ThreadPlanStepInRange(Thread &thread, const AddressRange &range,
                         const SymbolContext &addr_context,
-                        const char *step_into_target, lldb::RunMode stop_others,
+                        std::string step_into_target, lldb::RunMode stop_others,
                         LazyBool step_in_avoids_code_without_debug_info,
                         LazyBool step_out_avoids_code_without_debug_info);
 
@@ -82,7 +82,7 @@ private:
                              // demand for that.
   LazyBool m_virtual_step;   // true if we've just done a "virtual step", i.e.
                              // just moved the inline stack depth.
-  ConstString m_step_into_target;
+  std::string m_step_into_target;
   ThreadPlanStepInRange(const ThreadPlanStepInRange &) = delete;
   const ThreadPlanStepInRange &
   operator=(const ThreadPlanStepInRange &) = delete;

--- a/lldb/source/API/SBThreadPlan.cpp
+++ b/lldb/source/API/SBThreadPlan.cpp
@@ -286,7 +286,7 @@ SBThreadPlan::QueueThreadPlanForStepInRange(SBAddress &sb_start_address,
     Status plan_status;
     SBThreadPlan plan =
         SBThreadPlan(thread_plan_sp->GetThread().QueueThreadPlanForStepInRange(
-            false, range, sc, nullptr, eAllThreads, plan_status));
+            false, range, sc, llvm::StringRef(), eAllThreads, plan_status));
 
     if (plan_status.Fail())
       error.SetErrorString(plan_status.AsCString());

--- a/lldb/source/Commands/CommandObjectThread.cpp
+++ b/lldb/source/Commands/CommandObjectThread.cpp
@@ -707,8 +707,8 @@ protected:
         new_plan_sp = thread->QueueThreadPlanForStepInRange(
             abort_other_plans, range,
             frame->GetSymbolContext(eSymbolContextEverything),
-            m_options.m_step_in_target.c_str(), stop_other_threads,
-            new_plan_status, m_options.m_step_in_avoid_no_debug,
+            m_options.m_step_in_target, stop_other_threads, new_plan_status,
+            m_options.m_step_in_avoid_no_debug,
             m_options.m_step_out_avoid_no_debug);
 
         if (new_plan_sp && !m_options.m_avoid_regexp.empty()) {

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.cpp
@@ -508,7 +508,7 @@ CPPLanguageRuntime::GetStepThroughTrampolinePlan(Thread &thread,
       // We create a ThreadPlan to keep stepping through using the address range
       // of the current function.
       ret_plan_sp = std::make_shared<ThreadPlanStepInRange>(
-          thread, range_of_curr_func, sc, nullptr, eOnlyThisThread,
+          thread, range_of_curr_func, sc, std::string(), eOnlyThisThread,
           eLazyBoolYes, eLazyBoolYes);
       return ret_plan_sp;
     }

--- a/lldb/source/Target/Thread.cpp
+++ b/lldb/source/Target/Thread.cpp
@@ -1341,12 +1341,12 @@ ThreadPlanSP Thread::QueueThreadPlanForStepOverRange(
 
 ThreadPlanSP Thread::QueueThreadPlanForStepInRange(
     bool abort_other_plans, const AddressRange &range,
-    const SymbolContext &addr_context, const char *step_in_target,
+    const SymbolContext &addr_context, llvm::StringRef step_in_target,
     lldb::RunMode stop_other_threads, Status &status,
     LazyBool step_in_avoids_code_without_debug_info,
     LazyBool step_out_avoids_code_without_debug_info) {
   ThreadPlanSP thread_plan_sp(new ThreadPlanStepInRange(
-      *this, range, addr_context, step_in_target, stop_other_threads,
+      *this, range, addr_context, step_in_target.str(), stop_other_threads,
       step_in_avoids_code_without_debug_info,
       step_out_avoids_code_without_debug_info));
   status = QueueThreadPlan(thread_plan_sp, abort_other_plans);
@@ -1356,7 +1356,7 @@ ThreadPlanSP Thread::QueueThreadPlanForStepInRange(
 // Call the QueueThreadPlanForStepInRange method which takes an address range.
 ThreadPlanSP Thread::QueueThreadPlanForStepInRange(
     bool abort_other_plans, const LineEntry &line_entry,
-    const SymbolContext &addr_context, const char *step_in_target,
+    const SymbolContext &addr_context, llvm::StringRef step_in_target,
     lldb::RunMode stop_other_threads, Status &status,
     LazyBool step_in_avoids_code_without_debug_info,
     LazyBool step_out_avoids_code_without_debug_info) {
@@ -2302,8 +2302,8 @@ Status Thread::StepIn(bool source_step,
     if (source_step && frame_sp && frame_sp->HasDebugInformation()) {
       SymbolContext sc(frame_sp->GetSymbolContext(eSymbolContextEverything));
       new_plan_sp = QueueThreadPlanForStepInRange(
-          abort_other_plans, sc.line_entry, sc, nullptr, run_mode, error,
-          step_in_avoids_code_without_debug_info,
+          abort_other_plans, sc.line_entry, sc, llvm::StringRef(), run_mode,
+          error, step_in_avoids_code_without_debug_info,
           step_out_avoids_code_without_debug_info);
     } else {
       new_plan_sp = QueueThreadPlanForStepSingleInstruction(

--- a/lldb/source/Target/ThreadPlanShouldStopHere.cpp
+++ b/lldb/source/Target/ThreadPlanShouldStopHere.cpp
@@ -169,7 +169,7 @@ ThreadPlanSP ThreadPlanShouldStopHere::DefaultStepFromHereCallback(
                      "Queueing StepInRange plan to step through line 0 code.");
 
       return_plan_sp = current_plan->GetThread().QueueThreadPlanForStepInRange(
-          false, range, sc, nullptr, eOnlyDuringStepping, status,
+          false, range, sc, llvm::StringRef(), eOnlyDuringStepping, status,
           eLazyBoolCalculate, eLazyBoolNo);
     }
   }

--- a/lldb/source/Target/ThreadPlanStepInRange.cpp
+++ b/lldb/source/Target/ThreadPlanStepInRange.cpp
@@ -35,14 +35,15 @@ uint32_t ThreadPlanStepInRange::s_default_flag_values =
 
 ThreadPlanStepInRange::ThreadPlanStepInRange(
     Thread &thread, const AddressRange &range,
-    const SymbolContext &addr_context, const char *step_into_target,
+    const SymbolContext &addr_context, std::string step_into_target,
     lldb::RunMode stop_others, LazyBool step_in_avoids_code_without_debug_info,
     LazyBool step_out_avoids_code_without_debug_info)
     : ThreadPlanStepRange(ThreadPlan::eKindStepInRange,
                           "Step Range stepping in", thread, range, addr_context,
                           stop_others),
       ThreadPlanShouldStopHere(this), m_step_past_prologue(true),
-      m_virtual_step(eLazyBoolCalculate), m_step_into_target(step_into_target) {
+      m_virtual_step(eLazyBoolCalculate),
+      m_step_into_target(std::move(step_into_target)) {
   SetCallbacks();
   SetFlagsToDefault();
   SetupAvoidNoDebug(step_in_avoids_code_without_debug_info,
@@ -112,7 +113,7 @@ void ThreadPlanStepInRange::GetDescription(Stream *s,
     printed_line_info = true;
   }
 
-  if (m_step_into_target)
+  if (!m_step_into_target.empty())
     s->Format(" targeting {0}", m_step_into_target);
 
   if (!printed_line_info || level == eDescriptionLevelVerbose) {
@@ -376,30 +377,23 @@ bool ThreadPlanStepInRange::DefaultShouldStopHereCallback(
       operation == eFrameCompareYounger) {
     ThreadPlanStepInRange *step_in_range_plan =
         static_cast<ThreadPlanStepInRange *>(current_plan);
-    if (step_in_range_plan->m_step_into_target) {
+    if (!step_in_range_plan->m_step_into_target.empty()) {
+      llvm::StringRef target_name = step_in_range_plan->m_step_into_target;
       SymbolContext sc = frame->GetSymbolContext(
           eSymbolContextFunction | eSymbolContextBlock | eSymbolContextSymbol);
       if (sc.symbol != nullptr) {
-        // First try an exact match, since that's cheap with ConstStrings.
-        // Then do a strstr compare.
-        if (step_in_range_plan->m_step_into_target == sc.GetFunctionName()) {
+        if (target_name == sc.GetFunctionName()) {
           should_stop_here = true;
         } else {
-          const char *target_name =
-              step_in_range_plan->m_step_into_target.AsCString(nullptr);
-          const char *function_name = sc.GetFunctionName().AsCString(nullptr);
-
-          if (function_name == nullptr)
-            should_stop_here = false;
-          else if (strstr(function_name, target_name) == nullptr)
+          llvm::StringRef function_name = sc.GetFunctionName().GetStringRef();
+          if (function_name.empty() || !function_name.contains(target_name))
             should_stop_here = false;
         }
         if (log && !should_stop_here)
           LLDB_LOG(log,
                    "Stepping out of frame {0} which did not match step into "
                    "target {1}.",
-                   sc.GetFunctionName(),
-                   step_in_range_plan->m_step_into_target);
+                   sc.GetFunctionName(), target_name);
       }
     }
 


### PR DESCRIPTION
ThreadPlanStepInRange optionally took a "target function name" to determine if the thread plan could explain a given stop. The name was being stored into a ConstString which does not need to happen because (a) the function is sometimes user-supplied, meaning it may or may not exist, and (b) it may be a substring of a given function name (i.e. not otherwise in the string pool already).