### PR TITLE
[AMDGPU] Avoid dangling SSAUpdater reference in PromoteAlloca full-vector store

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/SSAUpdater.h
+++ b/llvm/include/llvm/Transforms/Utils/SSAUpdater.h
@@ -141,7 +141,7 @@ private:
 };
 
 /// Wrapper around SSAUpdater that uses TrackingVH to keep available values
-/// up-to-date when the original values are RAUW'd or deleted.  The plain
+/// up-to-date when the original values are RAUW'd or deleted. The plain
 /// SSAUpdater stores raw Value* pointers that become dangling when a value it
 /// holds is replaced and erased.
 class TrackingSSAUpdater {

--- a/llvm/include/llvm/Transforms/Utils/SSAUpdater.h
+++ b/llvm/include/llvm/Transforms/Utils/SSAUpdater.h
@@ -14,7 +14,9 @@
 #define LLVM_TRANSFORMS_UTILS_SSAUPDATER_H
 
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/IR/ValueHandle.h"
 #include <string>
 
 namespace llvm {
@@ -136,6 +138,59 @@ public:
 private:
   Value *GetValueAtEndOfBlockInternal(BasicBlock *BB);
   void UpdateDebugValue(Instruction *I, DbgVariableRecord *DbgValue);
+};
+
+/// Wrapper around SSAUpdater that uses TrackingVH to keep available values
+/// up-to-date when the original values are RAUW'd or deleted.  The plain
+/// SSAUpdater stores raw Value* pointers that become dangling when a value it
+/// holds is replaced and erased.
+class TrackingSSAUpdater {
+  SSAUpdater Updater;
+  DenseMap<BasicBlock *, TrackingVH<Value>> TrackedVals;
+
+public:
+  explicit TrackingSSAUpdater(
+      SmallVectorImpl<PHINode *> *InsertedPHIs = nullptr)
+      : Updater(InsertedPHIs) {}
+
+  void Initialize(Type *Ty, StringRef Name) {
+    Updater.Initialize(Ty, Name);
+    TrackedVals.clear();
+  }
+
+  void AddAvailableValue(BasicBlock *BB, Value *V) {
+    TrackedVals[BB] = TrackingVH<Value>(V);
+    Updater.AddAvailableValue(BB, V);
+  }
+
+  Value *FindValueForBlock(BasicBlock *BB) const {
+    auto It = TrackedVals.find(BB);
+    if (It == TrackedVals.end())
+      return nullptr;
+    Value *Tracked = It->second;
+    Value *Raw = Updater.FindValueForBlock(BB);
+    if (Raw && Raw != Tracked) {
+      const_cast<TrackingSSAUpdater *>(this)->Updater.AddAvailableValue(
+          BB, Tracked);
+    }
+    return Tracked;
+  }
+
+  Value *GetValueInMiddleOfBlock(BasicBlock *BB) {
+    syncAll();
+    return Updater.GetValueInMiddleOfBlock(BB);
+  }
+
+  Value *GetValueAtEndOfBlock(BasicBlock *BB) {
+    syncAll();
+    return Updater.GetValueAtEndOfBlock(BB);
+  }
+
+private:
+  void syncAll() {
+    for (auto &[BB, VH] : TrackedVals)
+      Updater.AddAvailableValue(BB, VH);
+  }
 };
 
 /// Helper class for promoting a collection of loads and stores into SSA

--- a/llvm/include/llvm/Transforms/Utils/SSAUpdater.h
+++ b/llvm/include/llvm/Transforms/Utils/SSAUpdater.h
@@ -14,9 +14,7 @@
 #define LLVM_TRANSFORMS_UTILS_SSAUPDATER_H
 
 #include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/IR/ValueHandle.h"
 #include <string>
 
 namespace llvm {
@@ -138,59 +136,6 @@ public:
 private:
   Value *GetValueAtEndOfBlockInternal(BasicBlock *BB);
   void UpdateDebugValue(Instruction *I, DbgVariableRecord *DbgValue);
-};
-
-/// Wrapper around SSAUpdater that uses TrackingVH to keep available values
-/// up-to-date when the original values are RAUW'd or deleted. The plain
-/// SSAUpdater stores raw Value* pointers that become dangling when a value it
-/// holds is replaced and erased.
-class TrackingSSAUpdater {
-  SSAUpdater Updater;
-  DenseMap<BasicBlock *, TrackingVH<Value>> TrackedVals;
-
-public:
-  explicit TrackingSSAUpdater(
-      SmallVectorImpl<PHINode *> *InsertedPHIs = nullptr)
-      : Updater(InsertedPHIs) {}
-
-  void Initialize(Type *Ty, StringRef Name) {
-    Updater.Initialize(Ty, Name);
-    TrackedVals.clear();
-  }
-
-  void AddAvailableValue(BasicBlock *BB, Value *V) {
-    TrackedVals[BB] = TrackingVH<Value>(V);
-    Updater.AddAvailableValue(BB, V);
-  }
-
-  Value *FindValueForBlock(BasicBlock *BB) const {
-    auto It = TrackedVals.find(BB);
-    if (It == TrackedVals.end())
-      return nullptr;
-    Value *Tracked = It->second;
-    Value *Raw = Updater.FindValueForBlock(BB);
-    if (Raw && Raw != Tracked) {
-      const_cast<TrackingSSAUpdater *>(this)->Updater.AddAvailableValue(
-          BB, Tracked);
-    }
-    return Tracked;
-  }
-
-  Value *GetValueInMiddleOfBlock(BasicBlock *BB) {
-    syncAll();
-    return Updater.GetValueInMiddleOfBlock(BB);
-  }
-
-  Value *GetValueAtEndOfBlock(BasicBlock *BB) {
-    syncAll();
-    return Updater.GetValueAtEndOfBlock(BB);
-  }
-
-private:
-  void syncAll() {
-    for (auto &[BB, VH] : TrackedVals)
-      Updater.AddAvailableValue(BB, VH);
-  }
 };
 
 /// Helper class for promoting a collection of loads and stores into SSA

--- a/llvm/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
@@ -40,7 +40,6 @@
 #include "llvm/IR/IntrinsicsAMDGPU.h"
 #include "llvm/IR/IntrinsicsR600.h"
 #include "llvm/IR/PatternMatch.h"
-#include "llvm/IR/ValueHandle.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/MathExtras.h"
@@ -52,60 +51,6 @@
 using namespace llvm;
 
 namespace {
-
-/// Wrapper around SSAUpdater that uses TrackingVH to keep available values
-/// up-to-date when the original values are RAUW'd or deleted.  The plain
-/// SSAUpdater stores raw Value* pointers that become dangling when a value it
-/// holds is replaced and erased.
-class TrackingSSAUpdater {
-  SSAUpdater Updater;
-  DenseMap<BasicBlock *, TrackingVH<Value>> TrackedVals;
-
-public:
-  explicit TrackingSSAUpdater(
-      SmallVectorImpl<PHINode *> *InsertedPHIs = nullptr)
-      : Updater(InsertedPHIs) {}
-
-  void Initialize(Type *Ty, StringRef Name) {
-    Updater.Initialize(Ty, Name);
-    TrackedVals.clear();
-  }
-
-  void AddAvailableValue(BasicBlock *BB, Value *V) {
-    TrackedVals[BB] = TrackingVH<Value>(V);
-    Updater.AddAvailableValue(BB, V);
-  }
-
-  Value *FindValueForBlock(BasicBlock *BB) const {
-    auto It = TrackedVals.find(BB);
-    if (It == TrackedVals.end())
-      return nullptr;
-    Value *Tracked = It->second;
-    Value *Raw = Updater.FindValueForBlock(BB);
-    if (Raw && Raw != Tracked) {
-      // The tracked value was RAUW'd; update the inner SSAUpdater.
-      const_cast<TrackingSSAUpdater *>(this)->Updater.AddAvailableValue(
-          BB, Tracked);
-    }
-    return Tracked;
-  }
-
-  Value *GetValueInMiddleOfBlock(BasicBlock *BB) {
-    syncAll();
-    return Updater.GetValueInMiddleOfBlock(BB);
-  }
-
-  Value *GetValueAtEndOfBlock(BasicBlock *BB) {
-    syncAll();
-    return Updater.GetValueAtEndOfBlock(BB);
-  }
-
-private:
-  void syncAll() {
-    for (auto &[BB, VH] : TrackedVals)
-      Updater.AddAvailableValue(BB, VH);
-  }
-};
 
 static cl::opt<bool>
     DisablePromoteAllocaToVector("disable-promote-alloca-to-vector",
@@ -1171,7 +1116,7 @@ void AMDGPUPromoteAllocaImpl::promoteAllocaToVector(AllocaAnalysis &AA) {
   const unsigned ElementSize = DL.getTypeSizeInBits(VecEltTy) / 8;
 
   // Alloca is uninitialized memory. Imitate that by making the first value
-  // undef.  Use TrackingSSAUpdater so that values RAUW'd after being
+  // undef. Use TrackingSSAUpdater so that values RAUW'd after being
   // registered (e.g. a forwarded load) are automatically kept up-to-date.
   TrackingSSAUpdater Updater;
   Updater.Initialize(AA.Vector.Ty, "promotealloca");

--- a/llvm/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
@@ -724,9 +724,20 @@ static Value *promoteAllocaUserToVector(Instruction *Inst, const DataLayout &DL,
     // We're storing the full vector, we can handle this without knowing CurVal.
     Type *AccessTy = Val->getType();
     TypeSize AccessSize = DL.getTypeStoreSize(AccessTy);
-    if (Constant *CI = dyn_cast<Constant>(Index))
-      if (CI->isNullValue() && AccessSize == VecStoreSize)
-        return Builder.CreateBitPreservingCastChain(DL, Val, AA.Vector.Ty);
+    if (Constant *CI = dyn_cast<Constant>(Index)) {
+      if (CI->isNullValue() && AccessSize == VecStoreSize) {
+        Value *Result =
+            Builder.CreateBitPreservingCastChain(DL, Val, AA.Vector.Ty);
+        // If Result is a load from this alloca, it will later be RAUW'd and
+        // deleted. The SSAUpdater holds a raw Value* that RAUW doesn't update,
+        // leaving a dangling pointer. Wrap in a freeze to create a fresh value
+        // the SSAUpdater can safely hold; the freeze's operand is a proper IR
+        // use that RAUW does update.
+        if (isa<LoadInst>(Result))
+          Result = Builder.CreateFreeze(Result);
+        return Result;
+      }
+    }
 
     // Storing a subvector.
     if (isa<FixedVectorType>(AccessTy)) {
@@ -1116,9 +1127,8 @@ void AMDGPUPromoteAllocaImpl::promoteAllocaToVector(AllocaAnalysis &AA) {
   const unsigned ElementSize = DL.getTypeSizeInBits(VecEltTy) / 8;
 
   // Alloca is uninitialized memory. Imitate that by making the first value
-  // undef. Use TrackingSSAUpdater so that values RAUW'd after being
-  // registered (e.g. a forwarded load) are automatically kept up-to-date.
-  TrackingSSAUpdater Updater;
+  // undef.
+  SSAUpdater Updater;
   Updater.Initialize(AA.Vector.Ty, "promotealloca");
 
   BasicBlock *EntryBB = AA.Alloca->getParent();

--- a/llvm/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
@@ -40,11 +40,11 @@
 #include "llvm/IR/IntrinsicsAMDGPU.h"
 #include "llvm/IR/IntrinsicsR600.h"
 #include "llvm/IR/PatternMatch.h"
+#include "llvm/IR/ValueHandle.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Target/TargetMachine.h"
-#include "llvm/IR/ValueHandle.h"
 #include "llvm/Transforms/Utils/SSAUpdater.h"
 
 #define DEBUG_TYPE "amdgpu-promote-alloca"

--- a/llvm/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
@@ -724,9 +724,21 @@ static Value *promoteAllocaUserToVector(Instruction *Inst, const DataLayout &DL,
     // We're storing the full vector, we can handle this without knowing CurVal.
     Type *AccessTy = Val->getType();
     TypeSize AccessSize = DL.getTypeStoreSize(AccessTy);
-    if (Constant *CI = dyn_cast<Constant>(Index))
-      if (CI->isNullValue() && AccessSize == VecStoreSize)
-        return Builder.CreateBitPreservingCastChain(DL, Val, AA.Vector.Ty);
+    if (Constant *CI = dyn_cast<Constant>(Index)) {
+      if (CI->isNullValue() && AccessSize == VecStoreSize) {
+        Value *Result =
+            Builder.CreateBitPreservingCastChain(DL, Val, AA.Vector.Ty);
+        // If Result is an instruction in the worklist (e.g. a load from this
+        // alloca), it will later be RAUW'd and deleted. The SSAUpdater holds
+        // a raw Value* that RAUW doesn't update, leaving a dangling pointer.
+        // Wrap in a freeze to create a fresh value the SSAUpdater can safely
+        // hold; the freeze's operand is a proper IR use that RAUW does update.
+        if (auto *RI = dyn_cast<Instruction>(Result))
+          if (llvm::is_contained(AA.Vector.Worklist, RI))
+            Result = Builder.CreateFreeze(Result);
+        return Result;
+      }
+    }
 
     // Storing a subvector.
     if (isa<FixedVectorType>(AccessTy)) {

--- a/llvm/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
@@ -44,6 +44,7 @@
 #include "llvm/Pass.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Target/TargetMachine.h"
+#include "llvm/IR/ValueHandle.h"
 #include "llvm/Transforms/Utils/SSAUpdater.h"
 
 #define DEBUG_TYPE "amdgpu-promote-alloca"
@@ -51,6 +52,60 @@
 using namespace llvm;
 
 namespace {
+
+/// Wrapper around SSAUpdater that uses TrackingVH to keep available values
+/// up-to-date when the original values are RAUW'd or deleted.  The plain
+/// SSAUpdater stores raw Value* pointers that become dangling when a value it
+/// holds is replaced and erased.
+class TrackingSSAUpdater {
+  SSAUpdater Updater;
+  DenseMap<BasicBlock *, TrackingVH<Value>> TrackedVals;
+
+public:
+  explicit TrackingSSAUpdater(
+      SmallVectorImpl<PHINode *> *InsertedPHIs = nullptr)
+      : Updater(InsertedPHIs) {}
+
+  void Initialize(Type *Ty, StringRef Name) {
+    Updater.Initialize(Ty, Name);
+    TrackedVals.clear();
+  }
+
+  void AddAvailableValue(BasicBlock *BB, Value *V) {
+    TrackedVals[BB] = TrackingVH<Value>(V);
+    Updater.AddAvailableValue(BB, V);
+  }
+
+  Value *FindValueForBlock(BasicBlock *BB) const {
+    auto It = TrackedVals.find(BB);
+    if (It == TrackedVals.end())
+      return nullptr;
+    Value *Tracked = It->second;
+    Value *Raw = Updater.FindValueForBlock(BB);
+    if (Raw && Raw != Tracked) {
+      // The tracked value was RAUW'd; update the inner SSAUpdater.
+      const_cast<TrackingSSAUpdater *>(this)->Updater.AddAvailableValue(
+          BB, Tracked);
+    }
+    return Tracked;
+  }
+
+  Value *GetValueInMiddleOfBlock(BasicBlock *BB) {
+    syncAll();
+    return Updater.GetValueInMiddleOfBlock(BB);
+  }
+
+  Value *GetValueAtEndOfBlock(BasicBlock *BB) {
+    syncAll();
+    return Updater.GetValueAtEndOfBlock(BB);
+  }
+
+private:
+  void syncAll() {
+    for (auto &[BB, VH] : TrackedVals)
+      Updater.AddAvailableValue(BB, VH);
+  }
+};
 
 static cl::opt<bool>
     DisablePromoteAllocaToVector("disable-promote-alloca-to-vector",
@@ -724,21 +779,9 @@ static Value *promoteAllocaUserToVector(Instruction *Inst, const DataLayout &DL,
     // We're storing the full vector, we can handle this without knowing CurVal.
     Type *AccessTy = Val->getType();
     TypeSize AccessSize = DL.getTypeStoreSize(AccessTy);
-    if (Constant *CI = dyn_cast<Constant>(Index)) {
-      if (CI->isNullValue() && AccessSize == VecStoreSize) {
-        Value *Result =
-            Builder.CreateBitPreservingCastChain(DL, Val, AA.Vector.Ty);
-        // If Result is an instruction in the worklist (e.g. a load from this
-        // alloca), it will later be RAUW'd and deleted. The SSAUpdater holds
-        // a raw Value* that RAUW doesn't update, leaving a dangling pointer.
-        // Wrap in a freeze to create a fresh value the SSAUpdater can safely
-        // hold; the freeze's operand is a proper IR use that RAUW does update.
-        if (auto *RI = dyn_cast<Instruction>(Result))
-          if (llvm::is_contained(AA.Vector.Worklist, RI))
-            Result = Builder.CreateFreeze(Result);
-        return Result;
-      }
-    }
+    if (Constant *CI = dyn_cast<Constant>(Index))
+      if (CI->isNullValue() && AccessSize == VecStoreSize)
+        return Builder.CreateBitPreservingCastChain(DL, Val, AA.Vector.Ty);
 
     // Storing a subvector.
     if (isa<FixedVectorType>(AccessTy)) {
@@ -1128,8 +1171,9 @@ void AMDGPUPromoteAllocaImpl::promoteAllocaToVector(AllocaAnalysis &AA) {
   const unsigned ElementSize = DL.getTypeSizeInBits(VecEltTy) / 8;
 
   // Alloca is uninitialized memory. Imitate that by making the first value
-  // undef.
-  SSAUpdater Updater;
+  // undef.  Use TrackingSSAUpdater so that values RAUW'd after being
+  // registered (e.g. a forwarded load) are automatically kept up-to-date.
+  TrackingSSAUpdater Updater;
   Updater.Initialize(AA.Vector.Ty, "promotealloca");
 
   BasicBlock *EntryBB = AA.Alloca->getParent();

--- a/llvm/test/CodeGen/AMDGPU/promote-alloca-proper-value-replacement.ll
+++ b/llvm/test/CodeGen/AMDGPU/promote-alloca-proper-value-replacement.ll
@@ -29,21 +29,23 @@ define void @alloca_value_cross_reference() {
 }
 
 ; The full-vector store in %bb2 forwards %v (a load from the same alloca in a
-; dominating block) as bb2's live-out value.  When the worklist visits the
+; dominating block) as bb2's live-out value. When the worklist visits the
 ; store before the load (they are in different blocks), that operand is the
 ; original load instruction, which is later replaced and deleted while the
-; SSAUpdater still references it.  TrackingSSAUpdater keeps the reference
-; up-to-date via TrackingVH so the replacement is seen automatically.
+; SSAUpdater still references it. The freeze in the full-vector store path
+; creates a fresh instruction the SSAUpdater can safely hold; the freeze's
+; operand is a proper IR use that RAUW does update.
 define half @forwarded_load_across_blocks() {
 ; CHECK-LABEL: define half @forwarded_load_across_blocks() {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    [[ARR:%.*]] = freeze <4 x half> poison
 ; CHECK-NEXT:    br label %[[BB2:.*]]
 ; CHECK:       [[BB2]]:
+; CHECK-NEXT:    [[TMP0:%.*]] = freeze <4 x half> <half 1.000000e+00, half 2.000000e+00, half 3.000000e+00, half 4.000000e+00>
 ; CHECK-NEXT:    br label %[[BB3:.*]]
 ; CHECK:       [[BB3]]:
-; CHECK-NEXT:    [[TMP0:%.*]] = extractelement <4 x half> <half 1.000000e+00, half 2.000000e+00, half 3.000000e+00, half 4.000000e+00>, i32 0
-; CHECK-NEXT:    ret half [[TMP0]]
+; CHECK-NEXT:    [[TMP1:%.*]] = extractelement <4 x half> [[TMP0]], i32 0
+; CHECK-NEXT:    ret half [[TMP1]]
 ;
 entry:
   %arr = alloca [4 x half], align 8, addrspace(5)

--- a/llvm/test/CodeGen/AMDGPU/promote-alloca-proper-value-replacement.ll
+++ b/llvm/test/CodeGen/AMDGPU/promote-alloca-proper-value-replacement.ll
@@ -27,3 +27,29 @@ define void @alloca_value_cross_reference() {
   store float 0.000000e+00, ptr addrspace(5) %p, align 4
   ret void
 }
+
+; The full-vector store in %bb2 forwards %v (a load from the same alloca in a
+; dominating block) as bb2's live-out value. If the pass visits bb2 before
+; entry, it hands the not-yet-replaced load to the SSAUpdater; the load is
+; later deleted while the SSAUpdater still references it, causing a crash.
+; The full-vector store now always creates a fresh value so the SSAUpdater
+; never holds a pointer to a worklist instruction.
+define half @forwarded_load_across_blocks() {
+; CHECK-LABEL: define half @forwarded_load_across_blocks()
+; CHECK-NOT: alloca
+; CHECK-NOT: addrspace(5)
+; CHECK: ret half
+entry:
+  %arr = alloca [4 x half], align 8, addrspace(5)
+  store <4 x half> <half 1.0, half 2.0, half 3.0, half 4.0>, ptr addrspace(5) %arr, align 8
+  %v = load <4 x half>, ptr addrspace(5) %arr, align 8
+  br label %bb2
+
+bb2:
+  store <4 x half> %v, ptr addrspace(5) %arr, align 8
+  br label %bb3
+
+bb3:
+  %e = load half, ptr addrspace(5) %arr, align 2
+  ret half %e
+}

--- a/llvm/test/CodeGen/AMDGPU/promote-alloca-proper-value-replacement.ll
+++ b/llvm/test/CodeGen/AMDGPU/promote-alloca-proper-value-replacement.ll
@@ -29,16 +29,22 @@ define void @alloca_value_cross_reference() {
 }
 
 ; The full-vector store in %bb2 forwards %v (a load from the same alloca in a
-; dominating block) as bb2's live-out value. If the pass visits bb2 before
-; entry, it hands the not-yet-replaced load to the SSAUpdater; the load is
-; later deleted while the SSAUpdater still references it, causing a crash.
-; The full-vector store now always creates a fresh value so the SSAUpdater
-; never holds a pointer to a worklist instruction.
+; dominating block) as bb2's live-out value.  When the worklist visits the
+; store before the load (they are in different blocks), that operand is the
+; original load instruction, which is later replaced and deleted while the
+; SSAUpdater still references it.  TrackingSSAUpdater keeps the reference
+; up-to-date via TrackingVH so the replacement is seen automatically.
 define half @forwarded_load_across_blocks() {
-; CHECK-LABEL: define half @forwarded_load_across_blocks()
-; CHECK-NOT: alloca
-; CHECK-NOT: addrspace(5)
-; CHECK: ret half
+; CHECK-LABEL: define half @forwarded_load_across_blocks() {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    [[ARR:%.*]] = freeze <4 x half> poison
+; CHECK-NEXT:    br label %[[BB2:.*]]
+; CHECK:       [[BB2]]:
+; CHECK-NEXT:    br label %[[BB3:.*]]
+; CHECK:       [[BB3]]:
+; CHECK-NEXT:    [[TMP0:%.*]] = extractelement <4 x half> <half 1.000000e+00, half 2.000000e+00, half 3.000000e+00, half 4.000000e+00>, i32 0
+; CHECK-NEXT:    ret half [[TMP0]]
+;
 entry:
   %arr = alloca [4 x half], align 8, addrspace(5)
   store <4 x half> <half 1.0, half 2.0, half 3.0, half 4.0>, ptr addrspace(5) %arr, align 8


### PR DESCRIPTION
promoteAllocaToVector walks alloca users in use-list order across blocks. A full-vector store forwards its value operand to the SSAUpdater, and that operand can be a load from the same alloca in a dominating block. If the store is visited first, the SSAUpdater holds a raw pointer to the load; the load is later RAUW'd and deleted, leaving a dangling reference that causes a crash.

Fix by sorting blocks in reverse post-order before visiting them, so a forwarded load is always replaced before any store hands it to the SSAUpdater.

Assisted-By: Cursor (Claude)