### PR TITLE
[APInt][NFC] Use qp >= b in KnuthDiv step D3 trial-quotient test

### DIFF
--- a/llvm/lib/Support/APInt.cpp
+++ b/llvm/lib/Support/APInt.cpp
@@ -1385,10 +1385,10 @@ static void KnuthDiv(uint32_t *u, uint32_t *v, uint32_t *q, uint32_t* r,
     DEBUG_KNUTH(dbgs() << "KnuthDiv: dividend == " << dividend << '\n');
     uint64_t qp = dividend / v[n-1];
     uint64_t rp = dividend % v[n-1];
-    if (qp >= b || qp*v[n-2] > b*rp + u[j+n-2]) {
+    if (qp >= b || qp * v[n - 2] > b * rp + u[j + n - 2]) {
       qp--;
       rp += v[n-1];
-      if (rp < b && (qp >= b || qp*v[n-2] > b*rp + u[j+n-2]))
+      if (rp < b && (qp >= b || qp * v[n - 2] > b * rp + u[j + n - 2]))
         qp--;
     }
     DEBUG_KNUTH(dbgs() << "KnuthDiv: qp == " << qp << ", rp == " << rp << '\n');

--- a/llvm/lib/Support/APInt.cpp
+++ b/llvm/lib/Support/APInt.cpp
@@ -1376,7 +1376,7 @@ static void KnuthDiv(uint32_t *u, uint32_t *v, uint32_t *q, uint32_t* r,
     // D3. [Calculate q'.].
     //     Set qp = (u[j+n]*b + u[j+n-1]) / v[n-1]. (qp=qprime=q')
     //     Set rp = (u[j+n]*b + u[j+n-1]) % v[n-1]. (rp=rprime=r')
-    // Now test if qp == b or qp*v[n-2] > b*rp + u[j+n-2]; if so, decrease
+    // Now test if qp >= b or qp*v[n-2] > b*rp + u[j+n-2]; if so, decrease
     // qp by 1, increase rp by v[n-1], and repeat this test if rp < b. The test
     // on v[n-2] determines at high speed most of the cases in which the trial
     // value qp is one too large, and it eliminates all cases where qp is two
@@ -1385,10 +1385,10 @@ static void KnuthDiv(uint32_t *u, uint32_t *v, uint32_t *q, uint32_t* r,
     DEBUG_KNUTH(dbgs() << "KnuthDiv: dividend == " << dividend << '\n');
     uint64_t qp = dividend / v[n-1];
     uint64_t rp = dividend % v[n-1];
-    if (qp == b || qp*v[n-2] > b*rp + u[j+n-2]) {
+    if (qp >= b || qp*v[n-2] > b*rp + u[j+n-2]) {
       qp--;
       rp += v[n-1];
-      if (rp < b && (qp == b || qp*v[n-2] > b*rp + u[j+n-2]))
+      if (rp < b && (qp >= b || qp*v[n-2] > b*rp + u[j+n-2]))
         qp--;
     }
     DEBUG_KNUTH(dbgs() << "KnuthDiv: qp == " << qp << ", rp == " << rp << '\n');

--- a/llvm/unittests/ADT/APIntTest.cpp
+++ b/llvm/unittests/ADT/APIntTest.cpp
@@ -1097,6 +1097,13 @@ TEST(APIntTest, divrem_big7) {
           {224, "80000000800000010000000f", 16});
 }
 
+TEST(APIntTest, divrem_big8) {
+  // A test for KnuthDiv step D3 when qp = b + 1.
+  testDiv({128, "8000000080000001", 16},
+          {128, "ffffffff", 16},
+          {128, "7fffffff80000001", 16});
+}
+
 void testDiv(APInt a, uint64_t b, APInt c) {
   auto p = a * b + c;
 

--- a/llvm/unittests/ADT/APIntTest.cpp
+++ b/llvm/unittests/ADT/APIntTest.cpp
@@ -1099,8 +1099,7 @@ TEST(APIntTest, divrem_big7) {
 
 TEST(APIntTest, divrem_big8) {
   // A test for KnuthDiv step D3 when qp = b + 1.
-  testDiv({128, "8000000080000001", 16},
-          {128, "ffffffff", 16},
+  testDiv({128, "8000000080000001", 16}, {128, "ffffffff", 16},
           {128, "7fffffff80000001", 16});
 }
 


### PR DESCRIPTION
No functional change. For `b = 2^32` the old and new code compute identical quotients and remainders for all inputs.
This PR aligns the code with the corrected text of TAOCP and stops it from relying on a property that is true but not proven.

# The issue

`KnuthDiv` in `llvm/lib/Support/APInt.cpp` implements Algorithm D from TAOCP Vol. 2, §4.3.1. 
Step D3 computes the trial quotient `qp = (u[j+n]*b + u[j+n-1]) / v[n-1]` and then corrects it, testing `qp == b || qp*v[n-2] > b*rp + u[j+n-2]`.

The `qp == b` clause is a typo in the third edition of the book, which printed "`test if q̂ = b`". Knuth's errata (see [TAOCP errata](https://www-cs-faculty.stanford.edu/~knuth/taocp.html), Errata et Addenda for Volume 2, [Earliest errata for Volume 2 (3rd ed.)](https://www-cs-faculty.stanford.edu/~knuth/all2-prepre.ps.gz)) corrected this to "`test if q̂ ≥ b`" in 2005.

Errata entry:
<img width="649" height="65" alt="b_errata_fix" src="https://github.com/user-attachments/assets/31234c49-6642-473c-97c2-05186f406f4f" />

Current text of Step D3:
<img width="949" height="204" alt="step_d3_new" src="https://github.com/user-attachments/assets/9d1aa232-3536-4d6a-bf56-1c485a68b824" />

This distinction matters because `qp` can exceed `b`. Since the loop invariant gives `u[j+n] <= v[n-1]`, and normalization gives `v[n-1] >= b/2`, we have 
`qp <= (v[n-1]*b + (b-1)) / v[n-1] = b + (b-1)/v[n-1] < b + 2`
so `qp <= b + 1`, and the only case `qp == b` misses is `qp == b + 1`.

# Why NFC
When `qp == b + 1`, the second clause `qp*v[n-2] > b*rp + u[j+n-2]` happens to fire, so the correction is applied anyway and the final result is correct. However this property is not established by Theorems A/B or exercises 19-20-21, which govern the correctness of step D3. In particular exercise 20 which governs this particular property explicitly constrains `q̂ < b`. The book's intent is that `qp >= b` be handled by the first clause. The code was relying on an unproven (though true, for `b = 2^32`) coincidence. The proof can be found in [the llvm chapter](https://kolja.rs/algorithm-d/#the-llvm-bug) of my blog, along with a discussion of a bug in Algorithm D in the case when `b` is odd. There is an additional change in Step D3 due to this bug that can be found in Knuth's latest [errata](https://bear-images.sfo2.cdn.digitaloceanspaces.com/kolja/full_errata.webp), but it would amount to adding a clause (`if b is odd`) that is always false since `b` is hard coded at `2^32`, so I opted not to introduce it.

Two of the existing tests already reach `qp == b + 1` incidentally: `divrem_big2` and `divrem_big3`. However a new explicit test was added for completeness and to put more emphasis on the way correctness is deduced for this algorithm.

# Changes
1. Step D3: `qp == b` -> `qp >= b` (both tests), and the comment above it, which quoted the pre-errata book text.
2. New test `divrem_big8`: the minimal normalised input that reaches `qp == b + 1` deliberately. Its value is in pinning the case down explicitly and documenting it. All tests pass both before and after the changes.

Second commit is clang-format-only on the touched lines. However this was kept separate because the surrounding file predates the current style, and formatting the newly introduced lines would make them stick our from the rest of the file. From my perspective this commit should be dropped but I kept it to align with the guidelines.


Assisted-by: Claude Code for checking whether original tests reach the `qp == b + 1` case