### PR TITLE
[mlir] Compute ceildivs consistently for INT_MIN operands

### DIFF
--- a/mlir/lib/Conversion/IndexToLLVM/IndexToLLVM.cpp
+++ b/mlir/lib/Conversion/IndexToLLVM/IndexToLLVM.cpp
@@ -25,8 +25,8 @@ namespace {
 // ConvertIndexCeilDivS
 //===----------------------------------------------------------------------===//
 
-/// Convert `ceildivs(n, m)` into `x = m > 0 ? -1 : 1` and then
-/// `n*m > 0 ? (n+x)/m + 1 : -(-n/m)`.
+/// Convert `ceildivs(n, m)` into `z = n / m` and then
+/// `z*m != n && (n < 0) == (m < 0) ? z + 1 : z`.
 struct ConvertIndexCeilDivS : mlir::ConvertOpToLLVMPattern<CeilDivSOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
@@ -38,33 +38,27 @@ struct ConvertIndexCeilDivS : mlir::ConvertOpToLLVMPattern<CeilDivSOp> {
     Value m = adaptor.getRhs();
     Value zero = LLVM::ConstantOp::create(rewriter, loc, n.getType(), 0);
     Value posOne = LLVM::ConstantOp::create(rewriter, loc, n.getType(), 1);
-    Value negOne = LLVM::ConstantOp::create(rewriter, loc, n.getType(), -1);
 
-    // Compute `x`.
-    Value mPos =
-        LLVM::ICmpOp::create(rewriter, loc, LLVM::ICmpPredicate::sgt, m, zero);
-    Value x = LLVM::SelectOp::create(rewriter, loc, mPos, negOne, posOne);
+    // Compute the truncated quotient. sdiv rounds towards zero, so it already
+    // rounds up whenever the exact quotient is negative.
+    Value quotient = LLVM::SDivOp::create(rewriter, loc, n, m);
+    Value quotientPlusOne =
+        LLVM::AddOp::create(rewriter, loc, quotient, posOne);
 
-    // Compute the positive result.
-    Value nPlusX = LLVM::AddOp::create(rewriter, loc, n, x);
-    Value nPlusXDivM = LLVM::SDivOp::create(rewriter, loc, nPlusX, m);
-    Value posRes = LLVM::AddOp::create(rewriter, loc, nPlusXDivM, posOne);
-
-    // Compute the negative result.
-    Value negN = LLVM::SubOp::create(rewriter, loc, zero, n);
-    Value negNDivM = LLVM::SDivOp::create(rewriter, loc, negN, m);
-    Value negRes = LLVM::SubOp::create(rewriter, loc, zero, negNDivM);
-
-    // Pick the positive result if `n` and `m` have the same sign and `n` is
-    // non-zero, i.e. `(n > 0) == (m > 0) && n != 0`.
-    Value nPos =
-        LLVM::ICmpOp::create(rewriter, loc, LLVM::ICmpPredicate::sgt, n, zero);
+    // Correct the quotient by one if the division is inexact and the exact
+    // quotient is positive, i.e. if `n` and `m` have the same sign.
+    Value product = LLVM::MulOp::create(rewriter, loc, quotient, m);
+    Value inexact = LLVM::ICmpOp::create(rewriter, loc, LLVM::ICmpPredicate::ne,
+                                         n, product);
+    Value nNeg =
+        LLVM::ICmpOp::create(rewriter, loc, LLVM::ICmpPredicate::slt, n, zero);
+    Value mNeg =
+        LLVM::ICmpOp::create(rewriter, loc, LLVM::ICmpPredicate::slt, m, zero);
     Value sameSign = LLVM::ICmpOp::create(rewriter, loc,
-                                          LLVM::ICmpPredicate::eq, nPos, mPos);
-    Value nNonZero =
-        LLVM::ICmpOp::create(rewriter, loc, LLVM::ICmpPredicate::ne, n, zero);
-    Value cmp = LLVM::AndOp::create(rewriter, loc, sameSign, nNonZero);
-    rewriter.replaceOpWithNewOp<LLVM::SelectOp>(op, cmp, posRes, negRes);
+                                          LLVM::ICmpPredicate::eq, nNeg, mNeg);
+    Value cmp = LLVM::AndOp::create(rewriter, loc, inexact, sameSign);
+    rewriter.replaceOpWithNewOp<LLVM::SelectOp>(op, cmp, quotientPlusOne,
+                                                quotient);
     return success();
   }
 };

--- a/mlir/lib/Conversion/IndexToSPIRV/IndexToSPIRV.cpp
+++ b/mlir/lib/Conversion/IndexToSPIRV/IndexToSPIRV.cpp
@@ -100,9 +100,9 @@ struct ConvertIndexConstantOpPattern final : OpConversionPattern<ConstantOp> {
 // ConvertIndexCeilDivS
 //===----------------------------------------------------------------------===//
 
-/// Convert `ceildivs(n, m)` into `x = m > 0 ? -1 : 1` and then
-/// `n*m > 0 ? (n+x)/m + 1 : -(-n/m)`. Formula taken from the equivalent
-/// conversion in IndexToLLVM.
+/// Convert `ceildivs(n, m)` into `z = n / m` and then
+/// `z*m != n && (n < 0) == (m < 0) ? z + 1 : z`. Formula taken from the
+/// equivalent conversion in IndexToLLVM.
 struct ConvertIndexCeilDivSPattern final : OpConversionPattern<CeilDivSOp> {
   using Base::Base;
 
@@ -119,30 +119,23 @@ struct ConvertIndexCeilDivSPattern final : OpConversionPattern<CeilDivSOp> {
                                            IntegerAttr::get(nType, 0));
     Value posOne = spirv::ConstantOp::create(rewriter, loc, nType,
                                              IntegerAttr::get(nType, 1));
-    Value negOne = spirv::ConstantOp::create(rewriter, loc, nType,
-                                             IntegerAttr::get(nType, -1));
 
-    // Compute `x`.
-    Value mPos = spirv::SGreaterThanOp::create(rewriter, loc, m, zero);
-    Value x = spirv::SelectOp::create(rewriter, loc, mPos, negOne, posOne);
+    // Compute the truncated quotient. Signed division rounds towards zero, so
+    // it already rounds up whenever the exact quotient is negative.
+    Value quotient = spirv::SDivOp::create(rewriter, loc, n, m);
+    Value quotientPlusOne =
+        spirv::IAddOp::create(rewriter, loc, quotient, posOne);
 
-    // Compute the positive result.
-    Value nPlusX = spirv::IAddOp::create(rewriter, loc, n, x);
-    Value nPlusXDivM = spirv::SDivOp::create(rewriter, loc, nPlusX, m);
-    Value posRes = spirv::IAddOp::create(rewriter, loc, nPlusXDivM, posOne);
-
-    // Compute the negative result.
-    Value negN = spirv::ISubOp::create(rewriter, loc, zero, n);
-    Value negNDivM = spirv::SDivOp::create(rewriter, loc, negN, m);
-    Value negRes = spirv::ISubOp::create(rewriter, loc, zero, negNDivM);
-
-    // Pick the positive result if `n` and `m` have the same sign and `n` is
-    // non-zero, i.e. `(n > 0) == (m > 0) && n != 0`.
-    Value nPos = spirv::SGreaterThanOp::create(rewriter, loc, n, zero);
-    Value sameSign = spirv::LogicalEqualOp::create(rewriter, loc, nPos, mPos);
-    Value nNonZero = spirv::INotEqualOp::create(rewriter, loc, n, zero);
-    Value cmp = spirv::LogicalAndOp::create(rewriter, loc, sameSign, nNonZero);
-    rewriter.replaceOpWithNewOp<spirv::SelectOp>(op, cmp, posRes, negRes);
+    // Correct the quotient by one if the division is inexact and the exact
+    // quotient is positive, i.e. if `n` and `m` have the same sign.
+    Value product = spirv::IMulOp::create(rewriter, loc, quotient, m);
+    Value inexact = spirv::INotEqualOp::create(rewriter, loc, n, product);
+    Value nNeg = spirv::SLessThanOp::create(rewriter, loc, n, zero);
+    Value mNeg = spirv::SLessThanOp::create(rewriter, loc, m, zero);
+    Value sameSign = spirv::LogicalEqualOp::create(rewriter, loc, nNeg, mNeg);
+    Value cmp = spirv::LogicalAndOp::create(rewriter, loc, inexact, sameSign);
+    rewriter.replaceOpWithNewOp<spirv::SelectOp>(op, cmp, quotientPlusOne,
+                                                 quotient);
     return success();
   }
 };

--- a/mlir/lib/Dialect/Affine/Utils/Utils.cpp
+++ b/mlir/lib/Dialect/Affine/Utils/Utils.cpp
@@ -152,10 +152,15 @@ public:
   /// single division operation as
   ///
   ///     a ceildiv b =
-  ///         let negative = a <= 0 in
-  ///         let absolute = negative ? -a : a - 1 in
-  ///         let quotient = absolute / b in
-  ///             negative ? -quotient : quotient + 1
+  ///         let quotient = a / b in
+  ///             a > quotient * b ? quotient + 1 : quotient
+  ///
+  /// Signed division rounds towards zero, so it already rounds up whenever the
+  /// exact quotient is negative. `quotient * b` is `a` minus the remainder, so
+  /// a positive divisor, which affine ceildiv requires, makes the comparison
+  /// hold exactly when the division is inexact and the exact quotient is
+  /// positive. Unlike the arith.ceildivsi expansion, no sign comparison is
+  /// needed.
   ///
   /// Note: not using arith.ceildivsi for the same reason as explained in the
   /// visitFloorDivExpr comment.
@@ -170,21 +175,15 @@ public:
     auto rhs = visit(expr.getRHS());
     assert(lhs && rhs && "unexpected affine expr lowering failure");
 
-    Value zeroCst = arith::ConstantIndexOp::create(builder, loc, 0);
     Value oneCst = arith::ConstantIndexOp::create(builder, loc, 1);
-    Value nonPositive = arith::CmpIOp::create(
-        builder, loc, arith::CmpIPredicate::sle, lhs, zeroCst);
-    Value negated = arith::SubIOp::create(builder, loc, zeroCst, lhs);
-    Value decremented = arith::SubIOp::create(builder, loc, lhs, oneCst);
-    Value dividend = arith::SelectOp::create(builder, loc, nonPositive, negated,
-                                             decremented);
-    Value quotient = arith::DivSIOp::create(builder, loc, dividend, rhs);
-    Value negatedQuotient =
-        arith::SubIOp::create(builder, loc, zeroCst, quotient);
+    Value quotient = arith::DivSIOp::create(builder, loc, lhs, rhs);
+    Value product = arith::MulIOp::create(builder, loc, quotient, rhs);
+    Value roundUp = arith::CmpIOp::create(
+        builder, loc, arith::CmpIPredicate::sgt, lhs, product);
     Value incrementedQuotient =
         arith::AddIOp::create(builder, loc, quotient, oneCst);
-    Value result = arith::SelectOp::create(
-        builder, loc, nonPositive, negatedQuotient, incrementedQuotient);
+    Value result = arith::SelectOp::create(builder, loc, roundUp,
+                                           incrementedQuotient, quotient);
     return result;
   }
 

--- a/mlir/lib/Dialect/Index/IR/IndexOps.cpp
+++ b/mlir/lib/Dialect/Index/IR/IndexOps.cpp
@@ -245,27 +245,18 @@ OpFoldResult DivUOp::fold(FoldAdaptor adaptor) {
 // CeilDivSOp
 //===----------------------------------------------------------------------===//
 
-/// Compute `ceildivs(n, m)` as `x = m > 0 ? -1 : 1` and then
-/// `n*m > 0 ? (n+x)/m + 1 : -(-n/m)`.
+/// Compute `ceildivs(n, m)` by rounding the quotient of `n / m` towards
+/// positive infinity.
 static std::optional<APInt> calculateCeilDivS(const APInt &n, const APInt &m) {
   // Don't fold division by zero.
   if (m.isZero())
     return std::nullopt;
-  // Short-circuit the zero case.
-  if (n.isZero())
-    return n;
+  // Don't fold `INT_MIN / -1`, the one quotient that is not representable.
+  // Neither operand is negated, so every other `INT_MIN` dividend is fine.
+  if (n.isMinSignedValue() && m.isAllOnes())
+    return std::nullopt;
 
-  bool mGtZ = m.sgt(0);
-  if (n.sgt(0) != mGtZ) {
-    // If the operands have different signs, compute the negative result. Signed
-    // division overflow is not possible, since if `m == -1`, `n` can be at most
-    // `INT_MAX`, and `-INT_MAX != INT_MIN` in two's complement.
-    return -(-n).sdiv(m);
-  }
-  // Otherwise, compute the positive result. Signed division overflow is not
-  // possible since if `m == -1`, `x` will be `1`.
-  int64_t x = mGtZ ? -1 : 1;
-  return (n + x).sdiv(m) + 1;
+  return llvm::APIntOps::RoundingSDiv(n, m, APInt::Rounding::UP);
 }
 
 OpFoldResult CeilDivSOp::fold(FoldAdaptor adaptor) {

--- a/mlir/lib/Interfaces/Utils/InferIntRangeCommon.cpp
+++ b/mlir/lib/Interfaces/Utils/InferIntRangeCommon.cpp
@@ -378,26 +378,9 @@ mlir::intrange::inferCeilDivS(ArrayRef<ConstantIntRanges> argRanges) {
           result.sadd_ov(APInt(result.getBitWidth(), 1), overflowed);
       return overflowed ? std::optional<APInt>() : corrected;
     }
-    // Special case where the usual implementation of ceilDiv causes
-    // INT_MIN / [positive number] to be positive. This doesn't match the
-    // definition of signed ceiling division mathematically, but it prevents
-    // inconsistent constant-folding results. This arises because (-int_min) is
-    // still negative, so -(-int_min / b) is -(int_min / b), which is
-    // positive See #115293.
-    if (lhs.isMinSignedValue() && rhs.sgt(1)) {
-      return -result;
-    }
     return result;
   };
-  ConstantIntRanges result = inferDivSRange(lhs, rhs, ceilDivSIFix);
-  if (lhs.smin().isMinSignedValue() && lhs.smax().sgt(lhs.smin())) {
-    // If lhs range includes INT_MIN and lhs is not a single value, we can
-    // suddenly wrap to positive val, skipping entire negative range, add
-    // [INT_MIN + 1, smax()] range to the result to handle this.
-    auto newLhs = ConstantIntRanges::fromSigned(lhs.smin() + 1, lhs.smax());
-    result = result.rangeUnion(inferDivSRange(newLhs, rhs, ceilDivSIFix));
-  }
-  return result;
+  return inferDivSRange(lhs, rhs, ceilDivSIFix);
 }
 
 ConstantIntRanges

--- a/mlir/test/Conversion/AffineToStandard/lower-affine.mlir
+++ b/mlir/test/Conversion/AffineToStandard/lower-affine.mlir
@@ -1,4 +1,5 @@
 // RUN: mlir-opt -lower-affine %s | FileCheck %s
+// RUN: mlir-opt -lower-affine -canonicalize %s | FileCheck %s --check-prefix=FOLDED
 
 // CHECK-LABEL: func @empty() {
 func.func @empty() {
@@ -559,33 +560,45 @@ func.func @affine_apply_floordiv_dynamic_divisor(%arg0 : index, %arg1 : index) -
 // CHECK-LABEL: func @affine_apply_ceildiv
 func.func @affine_apply_ceildiv(%arg0 : index) -> (index) {
 // CHECK-NEXT:  %[[c42:.*]] = arith.constant 42 : index
-// CHECK-NEXT:  %[[c0:.*]] = arith.constant 0 : index
 // CHECK-NEXT:  %[[c1:.*]] = arith.constant 1 : index
-// CHECK-NEXT:  %[[v0:.*]] = arith.cmpi sle, %{{.*}}, %[[c0]] : index
-// CHECK-NEXT:  %[[v1:.*]] = arith.subi %[[c0]], %{{.*}} : index
-// CHECK-NEXT:  %[[v2:.*]] = arith.subi %{{.*}}, %[[c1]] : index
-// CHECK-NEXT:  %[[v3:.*]] = arith.select %[[v0]], %[[v1]], %[[v2]] : index
-// CHECK-NEXT:  %[[v4:.*]] = arith.divsi %[[v3]], %[[c42]] : index
-// CHECK-NEXT:  %[[v5:.*]] = arith.subi %[[c0]], %[[v4]] : index
-// CHECK-NEXT:  %[[v6:.*]] = arith.addi %[[v4]], %[[c1]] : index
-// CHECK-NEXT:  %[[v7:.*]] = arith.select %[[v0]], %[[v5]], %[[v6]] : index
+// CHECK-NEXT:  %[[v0:.*]] = arith.divsi %{{.*}}, %[[c42]] : index
+// CHECK-NEXT:  %[[v1:.*]] = arith.muli %[[v0]], %[[c42]] : index
+// CHECK-NEXT:  %[[v2:.*]] = arith.cmpi sgt, %{{.*}}, %[[v1]] : index
+// CHECK-NEXT:  %[[v3:.*]] = arith.addi %[[v0]], %[[c1]] : index
+// CHECK-NEXT:  %[[v4:.*]] = arith.select %[[v2]], %[[v3]], %[[v0]] : index
   %0 = affine.apply #map_ceildiv (%arg0)
   return %0 : index
 }
 #map_ceildiv_dynamic_divisor = affine_map<(i)[s] -> (i ceildiv s)>
 // CHECK-LABEL: func @affine_apply_ceildiv_dynamic_divisor
 func.func @affine_apply_ceildiv_dynamic_divisor(%arg0 : index, %arg1 : index) -> (index) {
-// CHECK-NEXT:  %[[c0:.*]] = arith.constant 0 : index
 // CHECK-NEXT:  %[[c1:.*]] = arith.constant 1 : index
-// CHECK-NEXT:  %[[v0:.*]] = arith.cmpi sle, %{{.*}}, %[[c0]] : index
-// CHECK-NEXT:  %[[v1:.*]] = arith.subi %[[c0]], %{{.*}} : index
-// CHECK-NEXT:  %[[v2:.*]] = arith.subi %{{.*}}, %[[c1]] : index
-// CHECK-NEXT:  %[[v3:.*]] = arith.select %[[v0]], %[[v1]], %[[v2]] : index
-// CHECK-NEXT:  %[[v4:.*]] = arith.divsi %[[v3]], %arg1 : index
-// CHECK-NEXT:  %[[v5:.*]] = arith.subi %[[c0]], %[[v4]] : index
-// CHECK-NEXT:  %[[v6:.*]] = arith.addi %[[v4]], %[[c1]] : index
-// CHECK-NEXT:  %[[v7:.*]] = arith.select %[[v0]], %[[v5]], %[[v6]] : index
+// CHECK-NEXT:  %[[v0:.*]] = arith.divsi %{{.*}}, %arg1 : index
+// CHECK-NEXT:  %[[v1:.*]] = arith.muli %[[v0]], %arg1 : index
+// CHECK-NEXT:  %[[v2:.*]] = arith.cmpi sgt, %{{.*}}, %[[v1]] : index
+// CHECK-NEXT:  %[[v3:.*]] = arith.addi %[[v0]], %[[c1]] : index
+// CHECK-NEXT:  %[[v4:.*]] = arith.select %[[v2]], %[[v3]], %[[v0]] : index
   %0 = affine.apply #map_ceildiv_dynamic_divisor (%arg0)[%arg1]
+  return %0 : index
+}
+
+#map_ceildiv_seven = affine_map<(i) -> (i ceildiv 7)>
+// The lowered arithmetic has to agree with the constant folder
+// (`divideCeilSigned`) and with range inference (`intrange::inferCeilDivS`),
+// both of which give the exact, negative quotient for an INT_MIN dividend.
+// Negating the dividend, which the lowering used to do, made this positive
+// (`1317624576693539401`).
+//
+// The dividend is hidden behind an `arith.addi` so that the map is lowered
+// rather than folded; the affine folder never reaches the expansion.
+// FOLDED-LABEL: func @affine_apply_ceildiv_intmin_dividend
+func.func @affine_apply_ceildiv_intmin_dividend() -> (index) {
+  %c0 = arith.constant 0 : index
+  %cmin = arith.constant -9223372036854775808 : index
+  %dividend = arith.addi %cmin, %c0 : index
+// FOLDED:      %[[c:.*]] = arith.constant -1317624576693539401 : index
+// FOLDED-NEXT: return %[[c]]
+  %0 = affine.apply #map_ceildiv_seven (%dividend)
   return %0 : index
 }
 

--- a/mlir/test/Conversion/IndexToLLVM/index-to-llvm.mlir
+++ b/mlir/test/Conversion/IndexToLLVM/index-to-llvm.mlir
@@ -54,29 +54,39 @@ func.func @ceildivs(%n: index, %m: index) -> index {
   // CHECK-DAG: %[[N:.*]] = builtin.unrealized_conversion_cast %[[NI]]
   // CHECK-DAG: %[[M:.*]] = builtin.unrealized_conversion_cast %[[MI]]
   // CHECK: %[[ZERO:.*]] = llvm.mlir.constant(0 :
-  // CHECK: %[[POS_ONE:.*]] = llvm.mlir.constant(1 :
-  // CHECK: %[[NEG_ONE:.*]] = llvm.mlir.constant(-1 :
+  // CHECK: %[[ONE:.*]] = llvm.mlir.constant(1 :
 
-  // CHECK: %[[M_POS:.*]] = llvm.icmp "sgt" %[[M]], %[[ZERO]]
-  // CHECK: %[[X:.*]] = llvm.select %[[M_POS]], %[[NEG_ONE]], %[[POS_ONE]]
+  // CHECK: %[[QUOTIENT:.*]] = llvm.sdiv %[[N]], %[[M]]
+  // CHECK: %[[QUOTIENT_PLUS_ONE:.*]] = llvm.add %[[QUOTIENT]], %[[ONE]]
 
-  // CHECK: %[[N_PLUS_X:.*]] = llvm.add %[[N]], %[[X]]
-  // CHECK: %[[N_PLUS_X_DIV_M:.*]] = llvm.sdiv %[[N_PLUS_X]], %[[M]]
-  // CHECK: %[[POS_RES:.*]] = llvm.add %[[N_PLUS_X_DIV_M]], %[[POS_ONE]]
-
-  // CHECK: %[[NEG_N:.*]] = llvm.sub %[[ZERO]], %[[N]]
-  // CHECK: %[[NEG_N_DIV_M:.*]] = llvm.sdiv %[[NEG_N]], %[[M]]
-  // CHECK: %[[NEG_RES:.*]] = llvm.sub %[[ZERO]], %[[NEG_N_DIV_M]]
-
-  // CHECK: %[[N_POS:.*]] = llvm.icmp "sgt" %[[N]], %[[ZERO]]
-  // CHECK: %[[SAME_SIGN:.*]] = llvm.icmp "eq" %[[N_POS]], %[[M_POS]]
-  // CHECK: %[[N_NON_ZERO:.*]] = llvm.icmp "ne" %[[N]], %[[ZERO]]
-  // CHECK: %[[CMP:.*]] = llvm.and %[[SAME_SIGN]], %[[N_NON_ZERO]]
-  // CHECK: %[[RESULT:.*]] = llvm.select %[[CMP]], %[[POS_RES]], %[[NEG_RES]]
+  // CHECK: %[[PRODUCT:.*]] = llvm.mul %[[QUOTIENT]], %[[M]]
+  // CHECK: %[[INEXACT:.*]] = llvm.icmp "ne" %[[N]], %[[PRODUCT]]
+  // CHECK: %[[N_NEG:.*]] = llvm.icmp "slt" %[[N]], %[[ZERO]]
+  // CHECK: %[[M_NEG:.*]] = llvm.icmp "slt" %[[M]], %[[ZERO]]
+  // CHECK: %[[SAME_SIGN:.*]] = llvm.icmp "eq" %[[N_NEG]], %[[M_NEG]]
+  // CHECK: %[[CMP:.*]] = llvm.and %[[INEXACT]], %[[SAME_SIGN]]
+  // CHECK: %[[RESULT:.*]] = llvm.select %[[CMP]], %[[QUOTIENT_PLUS_ONE]], %[[QUOTIENT]]
   %result = index.ceildivs %n, %m
 
   // CHECK: %[[RESULTI:.*]] = builtin.unrealized_conversion_cast %[[RESULT]]
   // CHECK: return %[[RESULTI]]
+  return %result : index
+}
+
+// INDEX32-LABEL: @ceildivs_intmin_dividend
+// INDEX64-LABEL: @ceildivs_intmin_dividend
+func.func @ceildivs_intmin_dividend() -> index {
+  %n = index.constant -2147483648
+  %m = index.constant 7
+
+  // The conversion folds an op before it looks for a pattern, and the fold
+  // needs the 32-bit and the 64-bit result to agree, which they now do. They
+  // did not while the dividend was negated, so the sequence above ran instead
+  // and computed 306783378 on 32-bit.
+  // INDEX32: llvm.mlir.constant(-306783378 : i32) : i32
+  // INDEX64: llvm.mlir.constant(-306783378 : i64) : i64
+  %result = index.ceildivs %n, %m
+
   return %result : index
 }
 

--- a/mlir/test/Conversion/IndexToSPIRV/index-to-spirv.mlir
+++ b/mlir/test/Conversion/IndexToSPIRV/index-to-spirv.mlir
@@ -71,29 +71,39 @@ func.func @ceildivs(%n: index, %m: index) -> index {
   // CHECK-DAG: %[[N:.*]] = builtin.unrealized_conversion_cast %[[NI]]
   // CHECK-DAG: %[[M:.*]] = builtin.unrealized_conversion_cast %[[MI]]
   // CHECK: %[[ZERO:.*]] = spirv.Constant 0
-  // CHECK: %[[POS_ONE:.*]] = spirv.Constant 1
-  // CHECK: %[[NEG_ONE:.*]] = spirv.Constant -1
+  // CHECK: %[[ONE:.*]] = spirv.Constant 1
 
-  // CHECK: %[[M_POS:.*]] = spirv.SGreaterThan %[[M]], %[[ZERO]]
-  // CHECK: %[[X:.*]] = spirv.Select %[[M_POS]], %[[NEG_ONE]], %[[POS_ONE]]
+  // CHECK: %[[QUOTIENT:.*]] = spirv.SDiv %[[N]], %[[M]]
+  // CHECK: %[[QUOTIENT_PLUS_ONE:.*]] = spirv.IAdd %[[QUOTIENT]], %[[ONE]]
 
-  // CHECK: %[[N_PLUS_X:.*]] = spirv.IAdd %[[N]], %[[X]]
-  // CHECK: %[[N_PLUS_X_DIV_M:.*]] = spirv.SDiv %[[N_PLUS_X]], %[[M]]
-  // CHECK: %[[POS_RES:.*]] = spirv.IAdd %[[N_PLUS_X_DIV_M]], %[[POS_ONE]]
-
-  // CHECK: %[[NEG_N:.*]] = spirv.ISub %[[ZERO]], %[[N]]
-  // CHECK: %[[NEG_N_DIV_M:.*]] = spirv.SDiv %[[NEG_N]], %[[M]]
-  // CHECK: %[[NEG_RES:.*]] = spirv.ISub %[[ZERO]], %[[NEG_N_DIV_M]]
-
-  // CHECK: %[[N_POS:.*]] = spirv.SGreaterThan %[[N]], %[[ZERO]]
-  // CHECK: %[[SAME_SIGN:.*]] = spirv.LogicalEqual %[[N_POS]], %[[M_POS]]
-  // CHECK: %[[N_NON_ZERO:.*]] = spirv.INotEqual %[[N]], %[[ZERO]]
-  // CHECK: %[[CMP:.*]] = spirv.LogicalAnd %[[SAME_SIGN]], %[[N_NON_ZERO]]
-  // CHECK: %[[RESULT:.*]] = spirv.Select %[[CMP]], %[[POS_RES]], %[[NEG_RES]]
+  // CHECK: %[[PRODUCT:.*]] = spirv.IMul %[[QUOTIENT]], %[[M]]
+  // CHECK: %[[INEXACT:.*]] = spirv.INotEqual %[[N]], %[[PRODUCT]]
+  // CHECK: %[[N_NEG:.*]] = spirv.SLessThan %[[N]], %[[ZERO]]
+  // CHECK: %[[M_NEG:.*]] = spirv.SLessThan %[[M]], %[[ZERO]]
+  // CHECK: %[[SAME_SIGN:.*]] = spirv.LogicalEqual %[[N_NEG]], %[[M_NEG]]
+  // CHECK: %[[CMP:.*]] = spirv.LogicalAnd %[[INEXACT]], %[[SAME_SIGN]]
+  // CHECK: %[[RESULT:.*]] = spirv.Select %[[CMP]], %[[QUOTIENT_PLUS_ONE]], %[[QUOTIENT]]
   %result = index.ceildivs %n, %m
 
   // %[[RESULTI:.*] = builtin.unrealized_conversion_cast %[[RESULT]]
   // return %[[RESULTI]]
+  return %result : index
+}
+
+// INDEX32-LABEL: @ceildivs_intmin_dividend
+// INDEX64-LABEL: @ceildivs_intmin_dividend
+func.func @ceildivs_intmin_dividend() -> index {
+  %n = index.constant -2147483648
+  %m = index.constant 7
+
+  // The conversion folds an op before it looks for a pattern, and the fold
+  // needs the 32-bit and the 64-bit result to agree, which they now do. They
+  // did not while the dividend was negated, so the sequence above ran instead
+  // and computed 306783378 on 32-bit.
+  // INDEX32: spirv.Constant -306783378 : i32
+  // INDEX64: spirv.Constant -306783378 : i64
+  %result = index.ceildivs %n, %m
+
   return %result : index
 }
 

--- a/mlir/test/Dialect/Arith/int-range-interface.mlir
+++ b/mlir/test/Dialect/Arith/int-range-interface.mlir
@@ -272,16 +272,35 @@ func.func @ceil_divsi_full_range(%6: index) -> index {
   return %55 : index
 }
 
-// CHECK-LABEL: func @ceil_divsi_intmin_bug_115293
+// ceildivsi(INT_MIN, x > 1) is negative, as the mathematical definition of
+// signed ceiling division requires. See #115293, where it was inferred to be
+// positive to match a folder that gave up on INT_MIN operands.
+// CHECK-LABEL: func @ceil_divsi_intmin
 // CHECK: %[[ret:.*]] = arith.constant true
 // CHECK: return %[[ret]]
-func.func @ceil_divsi_intmin_bug_115293() -> i1 {
+func.func @ceil_divsi_intmin() -> i1 {
     %intMin_i64 = test.with_bounds { smin = -9223372036854775808 : si64, smax = -9223372036854775808 : si64, umin = 9223372036854775808 : ui64, umax = 9223372036854775808 : ui64 } : i64
     %denom_i64 = test.with_bounds { smin = 1189465982 : si64, smax = 1189465982 : si64, umin = 1189465982 : ui64, umax = 1189465982 : ui64 } : i64
-    %res_i64 = test.with_bounds { smin = 7754212542 : si64, smax = 7754212542 : si64, umin = 7754212542 : ui64, umax = 7754212542 : ui64 }  : i64
+    %res_i64 = test.with_bounds { smin = -7754212542 : si64, smax = -7754212542 : si64, umin = 18446744065955339074 : ui64, umax = 18446744065955339074 : ui64 }  : i64
 
     %0 = arith.ceildivsi %intMin_i64, %denom_i64 : i64
     %1 = arith.cmpi eq, %0, %res_i64 : i64
+    func.return %1 : i1
+}
+
+// A dividend range that starts at INT_MIN needs no special case either:
+// ceildivsi is monotonic in its dividend, so the endpoints bound it. Here every
+// quotient is negative, which #115293 could not conclude.
+// CHECK-LABEL: func @ceil_divsi_intmin_dividend_range
+// CHECK: %[[ret:.*]] = arith.constant true
+// CHECK: return %[[ret]]
+func.func @ceil_divsi_intmin_dividend_range() -> i1 {
+    %c0_i64 = arith.constant 0 : i64
+    %c64_i64 = arith.constant 64 : i64
+    %num_i64 = test.with_bounds { smin = -9223372036854775808 : si64, smax = -9223372036854775553 : si64, umin = 9223372036854775808 : ui64, umax = 9223372036854776063 : ui64 } : i64
+
+    %0 = arith.ceildivsi %num_i64, %c64_i64 : i64
+    %1 = arith.cmpi slt, %0, %c0_i64 : i64
     func.return %1 : i1
 }
 

--- a/mlir/test/Dialect/Index/index-canonicalize.mlir
+++ b/mlir/test/Dialect/Index/index-canonicalize.mlir
@@ -150,30 +150,55 @@ func.func @ceildivs() -> (index, index, index) {
 }
 
 // CHECK-LABEL: @ceildivs_neg
-func.func @ceildivs_neg() -> index {
+func.func @ceildivs_neg() -> (index, index) {
   %c5 = index.constant -5
   %c2 = index.constant 2
-  // CHECK: %[[A:.*]] = index.constant -2
+  %cn2 = index.constant -2
+
+  // CHECK-DAG: %[[A:.*]] = index.constant -2
   %0 = index.ceildivs %c5, %c2
-  // CHECK: return %[[A]]
-  return %0 : index
+
+  // Both operands are negative, so the exact quotient is positive and the
+  // truncated one has to be corrected.
+  // CHECK-DAG: %[[B:.*]] = index.constant 3
+  %1 = index.ceildivs %c5, %cn2
+
+  // CHECK: return %[[A]], %[[B]]
+  return %0, %1 : index, index
 }
 
 // CHECK-LABEL: @ceildivs_edge
 func.func @ceildivs_edge() -> (index, index) {
+  // CHECK-DAG: %[[B:.*]] = index.constant -2147483647
+  // CHECK-DAG: %[[NEG_ONE:.*]] = index.constant -1
+  // CHECK-DAG: %[[INT_MIN:.*]] = index.constant -2147483648
   %cn1 = index.constant -1
   %cIntMin = index.constant -2147483648
   %cIntMax = index.constant 2147483647
 
-  // The result is 0 on 32-bit.
-  // CHECK-DAG: %[[A:.*]] = index.constant 2147483648
+  // The result, 2147483648, is not representable on 32-bit, so this does not
+  // fold on either bitwidth.
+  // CHECK: %[[A:.*]] = index.ceildivs %[[INT_MIN]], %[[NEG_ONE]]
   %0 = index.ceildivs %cIntMin, %cn1
 
-  // CHECK-DAG: %[[B:.*]] = index.constant -2147483647
   %1 = index.ceildivs %cIntMax, %cn1
 
   // CHECK: return %[[A]], %[[B]]
   return %0, %1 : index, index
+}
+
+// CHECK-LABEL: @ceildivs_intmin_dividend
+func.func @ceildivs_intmin_dividend() -> index {
+  %c7 = index.constant 7
+  %cIntMin = index.constant -2147483648
+
+  // Negating the dividend wrapped on 32-bit and gave a positive result there,
+  // which disagreed with the 64-bit one, so this used not to fold at all.
+  // CHECK: %[[A:.*]] = index.constant -306783378
+  %0 = index.ceildivs %cIntMin, %c7
+
+  // CHECK: return %[[A]]
+  return %0 : index
 }
 
 // CHECK-LABEL: @ceildivu

--- a/mlir/test/Dialect/Index/int-range-inference.mlir
+++ b/mlir/test/Dialect/Index/int-range-inference.mlir
@@ -64,3 +64,21 @@ func.func @add_big(%arg0 : index) -> i1 {
   %3 = index.cmp uge(%1, %cmin)
   func.return %3 : i1
 }
+
+// The dividend range starts at INT_MIN once truncated to 32 bits. The 32-bit
+// inference used to negate the quotient there, which put a positive value in
+// the result range and left the comparison unresolved.
+// CHECK-LABEL: func @ceildivs_intmin_dividend
+// CHECK: %[[true:.*]] = index.bool.constant true
+// CHECK: return %[[true]]
+func.func @ceildivs_intmin_dividend(%arg0 : index) -> i1 {
+  %c0 = index.constant 0
+  %c7 = index.constant 7
+  %cmin = index.constant -2147483648
+  %cmax = index.constant -2147483393
+  %0 = index.maxs %arg0, %cmin
+  %1 = index.mins %0, %cmax
+  %2 = index.ceildivs %1, %c7
+  %3 = index.cmp slt(%2, %c0)
+  func.return %3 : i1
+}

--- a/mlir/test/Transforms/canonicalize.mlir
+++ b/mlir/test/Transforms/canonicalize.mlir
@@ -655,32 +655,24 @@ func.func @lowered_affine_ceildiv() -> (index, index) {
 // CHECK-DAG:  %c-1 = arith.constant -1 : index
   %c-43 = arith.constant -43 : index
   %c42 = arith.constant 42 : index
-  %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
-  %0 = arith.cmpi sle, %c-43, %c0 : index
-  %1 = arith.subi %c0, %c-43 : index
-  %2 = arith.subi %c-43, %c1 : index
-  %3 = arith.select %0, %1, %2 : index
-  %4 = arith.divsi %3, %c42 : index
-  %5 = arith.subi %c0, %4 : index
-  %6 = arith.addi %4, %c1 : index
-  %7 = arith.select %0, %5, %6 : index
+  %0 = arith.divsi %c-43, %c42 : index
+  %1 = arith.muli %0, %c42 : index
+  %2 = arith.cmpi sgt, %c-43, %1 : index
+  %3 = arith.addi %0, %c1 : index
+  %4 = arith.select %2, %3, %0 : index
 // CHECK-DAG:  %c2 = arith.constant 2 : index
   %c43 = arith.constant 43 : index
   %c42_0 = arith.constant 42 : index
-  %c0_1 = arith.constant 0 : index
-  %c1_2 = arith.constant 1 : index
-  %8 = arith.cmpi sle, %c43, %c0_1 : index
-  %9 = arith.subi %c0_1, %c43 : index
-  %10 = arith.subi %c43, %c1_2 : index
-  %11 = arith.select %8, %9, %10 : index
-  %12 = arith.divsi %11, %c42_0 : index
-  %13 = arith.subi %c0_1, %12 : index
-  %14 = arith.addi %12, %c1_2 : index
-  %15 = arith.select %8, %13, %14 : index
+  %c1_0 = arith.constant 1 : index
+  %5 = arith.divsi %c43, %c42_0 : index
+  %6 = arith.muli %5, %c42_0 : index
+  %7 = arith.cmpi sgt, %c43, %6 : index
+  %8 = arith.addi %5, %c1_0 : index
+  %9 = arith.select %7, %8, %5 : index
 
   // CHECK-NEXT: return %c-1, %c2
-  return %7, %15 : index, index
+  return %4, %9 : index, index
 }
 
 // Checks that NOP casts are removed.


### PR DESCRIPTION
Split out of #214637, where @kuhar pointed out that changing the shared
`intrange::inferCeilDivS` would put it at odds with `index::CeilDivSOp`, whose
folder and lowerings still negate an operand.

Negating `INT_MIN` wraps, so every implementation that computes the mixed-sign
case as `-(-n / m)` reports a positive value where the mathematical result is
negative. Along the arith / index / affine path, signed ceiling division is
computed here:

| where | before this PR |
|---|---|
| `arith::CeilDivSIOp::fold` | does not negate (#214637) |
| `CeilDivSIOpConverter` in `ExpandOps.cpp` | does not negate (#133774) |
| affine constant folding, `divideCeilSigned` | does not negate |
| `index::calculateCeilDivS` | `-(-n / m)` |
| `ConvertIndexCeilDivS`, IndexToLLVM | `-(-n / m)` |
| `ConvertIndexCeilDivSPattern`, IndexToSPIRV | `-(-n / m)` |
| `visitCeilDivExpr` in `expandAffineExpr` | `a <= 0 ? -(-a / b) : (a - 1) / b + 1` |
| `intrange::inferCeilDivS` | negates the quotient of `MININT / [positive number]`, with a second workaround unioning in `[MININT + 1, smax]` to cover the discontinuity that introduces |

This PR changes the last five. The workarounds in the inference were written for
the expansion that preceded #133774 (2025-04), which is the row above them.

The commits are ordered so that nothing in tree is inconsistent in between:

1. The `index` folder and both `index` lowerings compute the ceiling without
   negating an operand.
2. The affine `ceildiv` expansion does the same.
3. The `inferCeilDivS` workarounds are dropped.
4. A 32-bit regression for the inference, in `int-range-inference.mlir`.

### What changes for `index`

The folder never returned the wrong value, because `foldBinaryOpChecked`
requires the 32-bit and the 64-bit result to agree, and for
`index.ceildivs(-2147483648, 7)` they do not (`306783378` against
`-306783378`). It simply did not fold. It folds to `-306783378` now.

The lowerings have no such check.
`-convert-index-to-llvm=index-bitwidth=32` and
`-convert-index-to-spirv=use-64bit-index=false` emitted the wrapped
computation, so the same op evaluated to `306783378` at run time.

One fold is lost: `ceildivs(INT_MIN, -1)`. Its exact result, `2^31`, is not
representable on 32-bit; the old computation passed the consistency check there
only because the correction wrapped back to `INT_MIN`, and the lowering emits
`sdiv INT_MIN, -1`, which is poison. `arith.ceildivsi` does not fold this case
either.

### What changes for affine

Affine `ceildiv` requires a strictly positive divisor -- `visitCeilDivExpr`
rejects a non-positive constant one, and the old expansion relied on that too --
so the correction needs neither a negation nor a sign test:

    a ceildiv b = let q = a / b in a > q * b ? q + 1 : q

`q * b` is `a` minus the remainder, so with `b > 0` the comparison holds exactly
when the division is inexact and the exact quotient is positive. For
`INT64_MIN ceildiv 7` the lowered arithmetic went from `1317624576693539401` to
`-1317624576693539401`, which is what the affine constant folder already
returned.

`@lowered_affine_ceildiv` in `Transforms/canonicalize.mlir` is a hand-copy of
what this lowering emits, so it changes with it.

### Verification

`check-mlir`: 3858 passed, 0 failed (613 unsupported, 1 expectedly failed). `git clang-format` clean.

Measured before and after:

| | before | after |
|---|---|---|
| `-canonicalize` on `index.ceildivs(-2147483648, 7)` | does not fold | `-306783378` |
| `-canonicalize` on `index.ceildivs(-2147483648, -1)` | `2147483648` | does not fold |
| `-int-range-optimizations` on `index.cmp sle(index.ceildivs(-2147483648, 7), 0)` | unresolved | `true` |
| `-lower-affine -canonicalize` on `INT64_MIN ceildiv 7` | `1317624576693539401` | `-1317624576693539401` |
| the SPIR-V sequence evaluated at i32 for `(-2147483648, 7)` | `306783378` | `-306783378` |

Each new regression was checked against a build without the change it covers:
the `int-range-inference.mlir` one fails with only the first commit applied, so
it pins the inference rather than the folder, and the affine one fails with the
old expansion restored, printing the positive value.

The affine regression hides its dividend behind an `arith.addi` on purpose:
`affine.apply` folds before the conversion looks for a pattern, so a plain
constant operand never reaches the expansion under test.
