### PR TITLE
[LLDB] Track tool dependencies in Makefile.rules

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -168,6 +168,14 @@ ifeq "$(HOST_OS)" "Windows_NT"
        override CXX := $(QUOTE)$(CXX)$(QUOTE)
 endif
 
+# Dependency tracking for build tools. For example, if a build rule
+# use uses $(CC) to compile a source file, add
+#
+#    $(call tool_prereq $(CC))
+#
+# as a dependency to the rule.
+tool_prereq = $(wildcard $(firstword $(1)))
+
 #----------------------------------------------------------------------
 # Handle SDKROOT for the cross platform builds.
 #----------------------------------------------------------------------
@@ -580,7 +588,10 @@ endif
 #----------------------------------------------------------------------
 # Make the dSYM file from the executable if $(MAKE_DSYM) != "NO"
 #----------------------------------------------------------------------
-$(DSYM) : $(EXE)
+$(DSYM) : $(EXE) \
+          $(call tool_prereq,$(DS)) \
+          $(call tool_prereq,$(OBJCOPY)) \
+          $(call tool_prereq,$(DWP))
 ifeq "$(OS)" "Darwin"
 ifneq "$(MAKE_DSYM)" "NO"
 	"$(DS)" $(DSFLAGS) -o "$(DSYM)" "$(EXE)"
@@ -656,20 +667,20 @@ endif
 #----------------------------------------------------------------------
 
 ifneq "$(PCH_OUTPUT)" ""
-$(PCH_OUTPUT) : $(PCH_CXX_SOURCE)
+$(PCH_OUTPUT) : $(PCH_CXX_SOURCE) $(call tool_prereq,$(CXX))
 	$(CXX) $(CXXFLAGS) -x c++-header -o $@ $<
 endif
 
-%.o: %.c %.d
+%.o: %.c %.d $(call tool_prereq,$(CC))
 	$(CC) $(CFLAGS) -MT $@ -MD -MP -MF $*.d -c -o $@ $<
 
-%.o: %.cpp %.d $(PCH_OUTPUT)
+%.o: %.cpp %.d $(PCH_OUTPUT) $(call tool_prereq,$(CXX))
 	$(CXX) $(PCHFLAGS) $(CXXFLAGS) -MT $@ -MD -MP -MF $*.d -c -o $@ $<
 
-%.o: %.m %.d
+%.o: %.m %.d $(call tool_prereq,$(CC))
 	$(CC) $(CFLAGS) -MT $@ -MD -MP -MF $*.d -c -o $@ $<
 
-%.o: %.mm %.d
+%.o: %.mm %.d $(call tool_prereq,$(CXX))
 	$(CXX) $(CXXFLAGS) -MT $@ -MD -MP -MF $*.d -c -o $@ $<
 
 #----------------------------------------------------------------------


### PR DESCRIPTION
Before b9225e860769 (Allow tests to share a single build) lldbtest.makeBuildDir() would delete the build dir before building a test, but the shared test builds no longer have that behavior. Neither does the check-lldb target delete the entire test build dir before running, so tests don't get rebuilt when one of the tools (for example, clang) change.

This patch is one way to solve this, by adding all tools as explicit dependencies to each rule in the shared Makefile.rules.

Assisted-by: claude