### PR TITLE
[lldb] Support Persistent Variables as DIL Identifiers

### DIFF
--- a/lldb/include/lldb/ValueObject/DILEval.h
+++ b/lldb/include/lldb/ValueObject/DILEval.h
@@ -18,6 +18,13 @@
 
 namespace lldb_private::dil {
 
+/// Given the name of a persistent identifier (i.e., one that starts with a $),
+/// find the ValueObject for that name (if it exists).
+lldb::ValueObjectSP LookupPersistentIdentifier(llvm::StringRef name_ref,
+                                               StackFrame &stack_frame,
+                                               lldb::TargetSP target_sp,
+                                               lldb::LanguageType language);
+
 /// Given the name of an identifier (variable name, member name, type name,
 /// etc.), find the ValueObject for that name (if it exists), excluding global
 /// variables, and create and return an IdentifierInfo object containing all

--- a/lldb/source/ValueObject/DILEval.cpp
+++ b/lldb/source/ValueObject/DILEval.cpp
@@ -8,10 +8,12 @@
 
 #include "lldb/ValueObject/DILEval.h"
 #include "lldb/Core/Module.h"
+#include "lldb/Expression/ExpressionVariable.h"
 #include "lldb/Symbol/CompileUnit.h"
 #include "lldb/Symbol/TypeSystem.h"
 #include "lldb/Symbol/VariableList.h"
 #include "lldb/Target/RegisterContext.h"
+#include "lldb/Target/Target.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/ValueObject/DILAST.h"
 #include "lldb/ValueObject/DILParser.h"
@@ -42,6 +44,17 @@ static lldb::ValueObjectSP ArrayToPointerConversion(ValueObject &valobj,
       name, addr, exe_ctx,
       valobj.GetCompilerType().GetArrayElementType(&ctx).GetPointerType(),
       /* do_deref */ false);
+}
+
+static llvm::Expected<lldb::LanguageType>
+GetSourceLanguageFromCU(StackFrame &ctx) {
+  SymbolContext symbol_context =
+      ctx.GetSymbolContext(lldb::eSymbolContextCompUnit);
+  if (!symbol_context.comp_unit)
+    return llvm::createStringErrorV("no compile unit for frame: {}",
+                                    ctx.GetFunctionName());
+
+  return symbol_context.comp_unit->GetLanguage();
 }
 
 static llvm::Expected<lldb::TypeSystemSP> GetTypeSystemFromCU(StackFrame &ctx) {
@@ -338,6 +351,20 @@ lldb::ValueObjectSP LookupGlobalIdentifier(llvm::StringRef name_ref,
   return nullptr;
 }
 
+lldb::ValueObjectSP LookupPersistentIdentifier(llvm::StringRef name_ref,
+                                               StackFrame &stack_frame,
+                                               lldb::TargetSP target_sp,
+                                               lldb::LanguageType language) {
+  if (name_ref.starts_with("$")) {
+    if (auto *state =
+            target_sp->GetPersistentExpressionStateForLanguage(language))
+      if (auto var_sp = state->GetVariable(name_ref))
+        if (auto valobj_sp = var_sp->GetValueObject())
+          return valobj_sp;
+  }
+  return nullptr;
+}
+
 lldb::ValueObjectSP LookupIdentifier(llvm::StringRef name_ref,
                                      StackFrame &stack_frame,
                                      lldb::DynamicValueType use_dynamic) {
@@ -473,6 +500,14 @@ Interpreter::Visit(const IdentifierNode &node) {
 
   if (!identifier)
     identifier = LookupEnumValue(node.GetName(), m_stack_frame);
+
+  if (!identifier && node.GetName()[0] == '$') {
+    auto language = GetSourceLanguageFromCU(m_stack_frame);
+    if (!language)
+      return language.takeError();
+    identifier = LookupPersistentIdentifier(node.GetName(), m_stack_frame,
+                                            m_target, language.get());
+  }
 
   if (!identifier && node.GetName() == "nullptr") {
     // If we got a "nullptr" identifier, and there is no defined variable with

--- a/lldb/test/API/commands/frame/var-dil/basics/PersistentResultVariableLookup/Makefile
+++ b/lldb/test/API/commands/frame/var-dil/basics/PersistentResultVariableLookup/Makefile
@@ -1,0 +1,3 @@
+CXX_SOURCES := main.cpp
+
+include Makefile.rules

--- a/lldb/test/API/commands/frame/var-dil/basics/PersistentResultVariableLookup/TestFrameVarDILPersistentResultVariableLookup.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/PersistentResultVariableLookup/TestFrameVarDILPersistentResultVariableLookup.py
@@ -1,0 +1,127 @@
+"""
+Make sure accessing persistent/result variables works using DIL parser/evaluator.
+"""
+
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+from lldbsuite.test import lldbutil
+
+
+class TestFrameVarDILPersistentResultVariableLookup(TestBase):
+    # If your test case doesn't stress debug info, then
+    # set this to true.  That way it won't be run once for
+    # each debug info format.
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def test_frame_var(self):
+        self.build()
+        _, process, _, _ = lldbutil.run_to_source_breakpoint(
+            self, "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
+        )
+
+        self.runCmd("settings set target.experimental.use-DIL true")
+
+        # Establish persistent variables.
+
+        # Establish a persistent variable with integer type.
+        self.expect(
+            "dwim-print --persistent-result true -- foo + 5", startstr="(int) $0 = "
+        )
+        # Establish a persistent variable using dwim-print with derived type (using C specification terminology).
+        self.expect(
+            "dwim-print --persistent-result true -- hsmt",
+            startstr="(HasMembersT) $1 = ",
+        )
+        # Establish a persistent variable (using dwim-print) as pointer to variable
+        # with derived type (using C specification terminology).
+        self.expect(
+            "dwim-print --persistent-result true -- &hsmt",
+            startstr="(HasMembersT *) $2 = ",
+        )
+        # Establish result variable using expression.
+        self.expect(
+            "expression foo",
+            startstr="(int) $3 = 1",
+        )
+        # Establish result variables with user-defined names.
+        self.runCmd(
+            "expression int *$foop = &foo",
+        )
+        self.runCmd(
+            "expression HasMembersT *$hsmtp = &hsmt",
+        )
+
+        # Test that accessing those persistent/result variables yields the proper values.
+
+        # Check to make sure that `dwim-print`'s note indicates the proper path through the code was taken.
+        self.runCmd("settings set dwim-print-verbosity full")
+        # Check that `dwim-print` uses DIL.
+        self.expect("dwim-print $0", startstr="note: ran `frame variable $0`")
+        self.expect(
+            "dwim-print $1.doublem", startstr="note: ran `frame variable $1.doublem`"
+        )
+
+        # Check that `dwim-print` looks up the name directly.
+        # (requires temporarily disabling DIL)
+        self.runCmd("settings set target.experimental.use-DIL false")
+        self.expect("dwim-print $3", startstr="(int) 1")
+        self.runCmd("settings set target.experimental.use-DIL true")
+
+        # Check that `dwim-print` uses `expression` command.
+        self.expect(
+            "dwim-print $2->doublem", startstr="note: ran `expression $2->doublem`"
+        )
+
+        self.runCmd("settings set dwim-print-verbosity none")
+
+        # Check simple persistent variable accesses.
+        self.expect_var_path("$0", type="int", value="6")
+        self.expect_var_path(
+            "$1",
+            type="HasMembersT",
+            children=[
+                ValueCheck(name="intm", value="1", type="int"),
+                ValueCheck(name="doublem", value="2", type="double"),
+                ValueCheck(
+                    name="nestedm",
+                    type="NestedT",
+                    children=[ValueCheck(name="charm", type="char", value="'c'")],
+                ),
+            ],
+        )
+        self.expect_var_path(
+            "$2",
+            type="HasMembersT *",
+            children=[
+                ValueCheck(name="intm", value="1", type="int"),
+                ValueCheck(name="doublem", value="2", type="double"),
+                ValueCheck(
+                    name="nestedm",
+                    type="NestedT",
+                    children=[ValueCheck(name="charm", type="char", value="'c'")],
+                ),
+            ],
+        )
+        self.expect_var_path("$3", type="int", value="1")
+
+        # Check that accessing fields of persistent variables works.
+        self.expect_var_path("$1.intm", type="int", value="1")
+        self.expect_var_path("$1.nestedm.charm", type="char", value="'c'")
+        self.expect_var_path("$1.intm + $0", type="int", value="7")
+
+        # Check that types work correctly when adding an int and a double.
+        self.expect_var_path("$1.intm + $1.doublem", type="double", value="3")
+
+        self.expect_var_path("*$foop", type="int", value="1")
+        self.expect_var_path("(*$hsmtp).doublem", type="double", value="2")
+
+        # Step past statements that update variable values to which persistent
+        # variables refer.
+        lldbutil.continue_to_source_breakpoint(
+            self, process, "Set a second breakpoint here", lldb.SBFileSpec("main.cpp")
+        )
+
+        # Make sure that the value accessed through the pointer in persistent variables are updated.
+        self.expect_var_path("*$foop", type="int", value="2")
+        self.expect_var_path("(*$hsmtp).doublem", type="double", value="3")

--- a/lldb/test/API/commands/frame/var-dil/basics/PersistentResultVariableLookup/main.cpp
+++ b/lldb/test/API/commands/frame/var-dil/basics/PersistentResultVariableLookup/main.cpp
@@ -1,0 +1,23 @@
+typedef struct {
+  char charm;
+} NestedT;
+
+typedef struct {
+  int intm;
+  double doublem;
+  NestedT nestedm;
+
+} HasMembersT;
+
+int main(int argc, char **argv) {
+  HasMembersT hsmt;
+
+  hsmt.nestedm.charm = 'c';
+  hsmt.intm = 1;
+  hsmt.doublem = 2.0;
+
+  int foo = 1;
+  foo = 2; // Set a breakpoint here
+  hsmt.doublem = 3.0;
+  return 0; // Set a second breakpoint here
+}


### PR DESCRIPTION
When a persistent variable is used in a DIL expression, look it up as if it were any other identifier.