### PR TITLE
[sanitizer-common][rtsan] Fix log and stack printing for rtsan

### DIFF
--- a/compiler-rt/lib/rtsan/rtsan.cpp
+++ b/compiler-rt/lib/rtsan/rtsan.cpp
@@ -18,6 +18,7 @@
 
 #include "sanitizer_common/sanitizer_atomic.h"
 #include "sanitizer_common/sanitizer_common.h"
+#include "sanitizer_common/sanitizer_interface_internal.h"
 #include "sanitizer_common/sanitizer_mutex.h"
 #include "sanitizer_common/sanitizer_stackdepot.h"
 
@@ -82,7 +83,9 @@ SANITIZER_INTERFACE_ATTRIBUTE void __rtsan_init() {
   SetInitializationState(InitializationState::Initializing);
 
   SanitizerToolName = "RealtimeSanitizer";
+  CacheBinaryName();
   InitializeFlags();
+  __sanitizer_set_report_path(common_flags()->log_path);
 
   InitializePlatformEarly();
 
@@ -149,6 +152,14 @@ __rtsan_notify_blocking_call(const char *func_name) {
   ExpectNotRealtime(GetContextForThisThread(),
                     {DiagnosticsInfoType::BlockingCall, func_name, pc, bp},
                     OnViolation);
+}
+
+SANITIZER_INTERFACE_ATTRIBUTE
+void __sanitizer_print_stack_trace() {
+  GET_CURRENT_PC_BP;
+  UNINITIALIZED BufferedStackTrace stack;
+  stack.Unwind(pc, bp, nullptr, common_flags()->fast_unwind_on_fatal);
+  stack.Print();
 }
 
 } // extern "C"


### PR DESCRIPTION
Fixes:
* sanitizer_common/TestCases/suffix-log-path_test.c
* sanitizer_common/TestCases/print-stack-trace.cpp


These two tests have some overlap, which is why they are fixed in the same commit. Functionally, this means:
* RTSan now exports the common `__sanitizer_print_stack_trace` API, from what I understand from the comment on the master version of this, this is for debuggers to call
* RTSan can now report out to a log file using the common utilities