### PR TITLE
[clang][bytecode][NFC] Remove redundant setSource() call

### DIFF
--- a/clang/lib/AST/ByteCode/EvalEmitter.cpp
+++ b/clang/lib/AST/ByteCode/EvalEmitter.cpp
@@ -63,7 +63,6 @@ EvaluationResult EvalEmitter::interpretDecl(const VarDecl *VD, const Expr *Init,
   QualType T = VD->getType();
   this->ConvertResultToRValue = !Init->isGLValue() && !T->isPointerType() &&
                                 !T->isObjCObjectPointerType();
-  EvalResult.setSource(VD);
 
   if (!this->visitDeclAndReturn(VD, Init, S.inConstantContext()))
     EvalResult.setInvalid();


### PR DESCRIPTION
We already do that a few lines up.