### PR TITLE
[clang][bytecode][NFC] Use hasBody() instead of getBody()

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -1122,8 +1122,8 @@ static bool diagnoseCallableDecl(InterpState &S, CodePtr OpPC,
         << DiagDecl->isConstexpr() << (bool)CD << DiagDecl;
 
     const FunctionDecl *Definition;
-    const Stmt *Body = DiagDecl->getBody(Definition);
-    if (Body && Definition)
+    bool HasBody = DiagDecl->hasBody(Definition);
+    if (HasBody && Definition)
       S.Note(Definition->getLocation(), diag::note_declared_at);
     else
       S.Note(DiagDecl->getLocation(), diag::note_declared_at);
@@ -1146,7 +1146,7 @@ static bool CheckCallable(InterpState &S, CodePtr OpPC, const Function *F) {
 
   const FunctionDecl *DiagDecl = F->getDecl();
   const FunctionDecl *Definition = nullptr;
-  DiagDecl->getBody(Definition);
+  DiagDecl->hasBody(Definition);
 
   if (!Definition && S.checkingPotentialConstantExpression() &&
       DiagDecl->isConstexpr()) {
@@ -1796,9 +1796,9 @@ bool CheckFunctionDecl(InterpState &S, CodePtr OpPC, const FunctionDecl *FD) {
     return false;
 
   const FunctionDecl *Definition = nullptr;
-  const Stmt *Body = FD->getBody(Definition);
+  bool HasBody = FD->hasBody(Definition);
 
-  if (Definition && Body &&
+  if (Definition && HasBody &&
       (Definition->isConstexpr() || (S.Current->MSVCConstexprAllowed &&
                                      Definition->hasAttr<MSConstexprAttr>())))
     return true;
@@ -1853,7 +1853,7 @@ bool CheckBitCast(InterpState &S, CodePtr OpPC, const Type *TargetType,
 
 static void compileFunction(InterpState &S, const Function *Func) {
   const FunctionDecl *Definition;
-  if (!Func->getDecl()->getBody(Definition))
+  if (!Func->getDecl()->hasBody(Definition))
     return;
   if (!Definition)
     return;


### PR DESCRIPTION
We either don't use the body at all, or only use it to convert it to an integer. Use `hasBody()` instead.