### PR TITLE
[ORC] Drop AutoRegisterCode option for JIT-debug registration

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/Debugging/ELFDebugObjectPlugin.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Debugging/ELFDebugObjectPlugin.h
@@ -45,14 +45,8 @@ public:
   ///   this off allows minimal debugging based on raw symbol names, but it
   ///   comes with significant overhead for release configurations.
   ///
-  /// AutoRegisterCode:
-  ///   Notify the debugger for each new debug object. This is a good default
-  ///   mode, but it may cause significant overhead when adding many modules in
-  ///   sequence. Otherwise the user must call __jit_debug_register_code() in
-  ///   the debug session manually.
-  ///
   ELFDebugObjectPlugin(ExecutionSession &ES, bool RequireDebugSections,
-                       bool AutoRegisterCode, Error &Err);
+                       Error &Err);
   ~ELFDebugObjectPlugin() override;
 
   void notifyMaterializing(MaterializationResponsibility &MR,
@@ -81,7 +75,6 @@ private:
 
   ExecutorAddr RegistrationAction;
   bool RequireDebugSections;
-  bool AutoRegisterCode;
 
   DebugObject *getPendingDebugObj(MaterializationResponsibility &MR);
 };

--- a/llvm/lib/ExecutionEngine/Orc/Debugging/DebuggerSupport.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Debugging/DebuggerSupport.cpp
@@ -37,7 +37,7 @@ Error enableDebuggerSupport(LLJIT &J) {
   case Triple::ELF: {
     Error TargetSymErr = Error::success();
     ObjLinkingLayer->addPlugin(
-        std::make_unique<ELFDebugObjectPlugin>(ES, false, true, TargetSymErr));
+        std::make_unique<ELFDebugObjectPlugin>(ES, false, TargetSymErr));
     return TargetSymErr;
   }
   case Triple::MachO: {

--- a/llvm/lib/ExecutionEngine/Orc/Debugging/DebuggerSupportPlugin.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Debugging/DebuggerSupportPlugin.cpp
@@ -283,12 +283,11 @@ public:
 
     Builder.write(MachOContainerBlock->getAlreadyMutableContent());
 
-    static constexpr bool AutoRegisterCode = true;
     SectionRange R(MachOContainerBlock->getSection());
     G.allocActions().push_back(
         {cantFail(shared::WrapperFunctionCall::Create<
-                  shared::SPSArgList<shared::SPSExecutorAddrRange, bool>>(
-             RegisterActionAddr, R.getRange(), AutoRegisterCode)),
+                  shared::SPSArgList<shared::SPSExecutorAddrRange>>(
+             RegisterActionAddr, R.getRange())),
          {}});
 
     return Error::success();

--- a/llvm/lib/ExecutionEngine/Orc/Debugging/ELFDebugObjectPlugin.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Debugging/ELFDebugObjectPlugin.cpp
@@ -193,9 +193,8 @@ Error DebugObject::visitSections(GetLoadAddressFn Callback) {
 
 ELFDebugObjectPlugin::ELFDebugObjectPlugin(ExecutionSession &ES,
                                            bool RequireDebugSections,
-                                           bool AutoRegisterCode, Error &Err)
-    : ES(ES), RequireDebugSections(RequireDebugSections),
-      AutoRegisterCode(AutoRegisterCode) {
+                                           Error &Err)
+    : ES(ES), RequireDebugSections(RequireDebugSections) {
   // Pass bootstrap symbol for registration function to enable debugging
   ErrorAsOutParameter _(&Err);
   Err = ES.getExecutorProcessControl().getBootstrapSymbols(
@@ -377,9 +376,8 @@ void ELFDebugObjectPlugin::modifyPassConfig(MaterializationResponsibility &MR,
 
     using namespace shared;
     G.allocActions().push_back(
-        {cantFail(WrapperFunctionCall::Create<
-                  SPSArgList<SPSExecutorAddrRange, bool>>(
-             RegistrationAction, *R, AutoRegisterCode)),
+        {cantFail(WrapperFunctionCall::Create<SPSArgList<SPSExecutorAddrRange>>(
+             RegistrationAction, *R)),
          {/* no deregistration */}});
     return Error::success();
   });

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/JITLoaderGDB.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/JITLoaderGDB.cpp
@@ -75,14 +75,13 @@ static void appendJITDebugDescriptor(const char *ObjAddr, size_t Size) {
 extern "C" orc::shared::CWrapperFunctionBuffer
 llvm_orc_registerJITLoaderGDBAllocAction(const char *ArgData, size_t ArgSize) {
   using namespace orc::shared;
-  return WrapperFunction<SPSError(SPSExecutorAddrRange, bool)>::handle(
+  return WrapperFunction<SPSError(SPSExecutorAddrRange)>::handle(
              ArgData, ArgSize,
-             [](ExecutorAddrRange R, bool AutoRegisterCode) {
+             [](ExecutorAddrRange R) {
                appendJITDebugDescriptor(R.Start.toPtr<const char *>(),
                                         R.size());
                // Run into the rendezvous breakpoint.
-               if (AutoRegisterCode)
-                 __jit_debug_register_code();
+               __jit_debug_register_code();
                return Error::success();
              })
       .release();

--- a/llvm/tools/llvm-jitlink/llvm-jitlink.cpp
+++ b/llvm/tools/llvm-jitlink/llvm-jitlink.cpp
@@ -1371,7 +1371,7 @@ Session::Session(std::unique_ptr<ExecutorProcessControl> EPC, Error &Err)
     if (DebuggerSupport) {
       Error TargetSymErr = Error::success();
       auto Plugin =
-          std::make_unique<ELFDebugObjectPlugin>(ES, true, true, TargetSymErr);
+          std::make_unique<ELFDebugObjectPlugin>(ES, true, TargetSymErr);
       if (!TargetSymErr)
         ObjLayer->addPlugin(std::move(Plugin));
       else


### PR DESCRIPTION
AutoRegisterCode was introduced in 4c7f53b99c0 to gate calls to the debugger rendezvous breakpoint `__jit_debug_register_code()`. The assumption was that this would facilitate batched registration of JIT'd debug info: clients could call `__jit_debug_register_code()` manually after multiple object files worth of debug info were accumulated. This assumption turns out not to be true: Debuggers only consume the most recently recorded object file when the rendezvous breakpoint is triggered, and all previously recorded, as-yet-unregistered, debug info is ignored.

Since calling the rendezvous function is essential for correctness when a debugger is attached, and essentially free when a debugger is not attached, we should just call it unconditionally.