### PR TITLE
[RISCV] Rename Legacy Pass Creation Functions

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVFoldMemOffset.cpp
+++ b/llvm/lib/Target/RISCV/RISCVFoldMemOffset.cpp
@@ -84,7 +84,7 @@ char RISCVFoldMemOffsetLegacy::ID = 0;
 INITIALIZE_PASS(RISCVFoldMemOffsetLegacy, DEBUG_TYPE,
                 RISCV_FOLD_MEM_OFFSET_NAME, false, false)
 
-FunctionPass *llvm::createRISCVFoldMemOffsetPass() {
+FunctionPass *llvm::createRISCVFoldMemOffsetLegacyPass() {
   return new RISCVFoldMemOffsetLegacy();
 }
 

--- a/llvm/lib/Target/RISCV/RISCVFoldMemOffset.h
+++ b/llvm/lib/Target/RISCV/RISCVFoldMemOffset.h
@@ -28,7 +28,7 @@ public:
                         MachineFunctionAnalysisManager &MFAM);
 };
 
-FunctionPass *createRISCVFoldMemOffsetPass();
+FunctionPass *createRISCVFoldMemOffsetLegacyPass();
 void initializeRISCVFoldMemOffsetLegacyPass(PassRegistry &);
 
 } // namespace llvm

--- a/llvm/lib/Target/RISCV/RISCVGatherScatterLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVGatherScatterLowering.cpp
@@ -97,7 +97,7 @@ INITIALIZE_PASS_DEPENDENCY(TargetPassConfig)
 INITIALIZE_PASS_END(RISCVGatherScatterLoweringLegacy, DEBUG_TYPE,
                     "RISC-V gather/scatter lowering pass", false, false)
 
-FunctionPass *llvm::createRISCVGatherScatterLoweringPass() {
+FunctionPass *llvm::createRISCVGatherScatterLoweringLegacyPass() {
   return new RISCVGatherScatterLoweringLegacy();
 }
 

--- a/llvm/lib/Target/RISCV/RISCVGatherScatterLowering.h
+++ b/llvm/lib/Target/RISCV/RISCVGatherScatterLowering.h
@@ -32,7 +32,7 @@ public:
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
 };
 
-FunctionPass *createRISCVGatherScatterLoweringPass();
+FunctionPass *createRISCVGatherScatterLoweringLegacyPass();
 void initializeRISCVGatherScatterLoweringLegacyPass(PassRegistry &);
 
 } // namespace llvm

--- a/llvm/lib/Target/RISCV/RISCVOptWInstrs.cpp
+++ b/llvm/lib/Target/RISCV/RISCVOptWInstrs.cpp
@@ -94,7 +94,7 @@ char RISCVOptWInstrsLegacy::ID = 0;
 INITIALIZE_PASS(RISCVOptWInstrsLegacy, DEBUG_TYPE, RISCV_OPT_W_INSTRS_NAME,
                 false, false)
 
-FunctionPass *llvm::createRISCVOptWInstrsPass() {
+FunctionPass *llvm::createRISCVOptWInstrsLegacyPass() {
   return new RISCVOptWInstrsLegacy();
 }
 

--- a/llvm/lib/Target/RISCV/RISCVOptWInstrs.h
+++ b/llvm/lib/Target/RISCV/RISCVOptWInstrs.h
@@ -27,7 +27,7 @@ public:
                         MachineFunctionAnalysisManager &MFAM);
 };
 
-FunctionPass *createRISCVOptWInstrsPass();
+FunctionPass *createRISCVOptWInstrsLegacyPass();
 void initializeRISCVOptWInstrsLegacyPass(PassRegistry &);
 
 } // namespace llvm

--- a/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
@@ -489,7 +489,7 @@ void RISCVPassConfig::addIRPasses() {
     if (EnableLoopDataPrefetch)
       addPass(createLoopDataPrefetchPass());
 
-    addPass(createRISCVGatherScatterLoweringPass());
+    addPass(createRISCVGatherScatterLoweringLegacyPass());
     addPass(createInterleavedAccessPass());
     addPass(createRISCVCodeGenPrepareLegacyPass());
   }
@@ -637,16 +637,16 @@ void RISCVPassConfig::addMachineSSAOptimization() {
     // vsetvli toggles, and still requires the MachineLoopInfo analysis to be
     // run.
     addPass(&EarlyMachineLICMID);
-    addPass(createRISCVVLOptimizerPass());
+    addPass(createRISCVVLOptimizerLegacyPass());
   }
 
-  addPass(createRISCVVectorPeepholePass());
-  addPass(createRISCVFoldMemOffsetPass());
+  addPass(createRISCVVectorPeepholeLegacyPass());
+  addPass(createRISCVFoldMemOffsetLegacyPass());
 
   TargetPassConfig::addMachineSSAOptimization();
 
   if (TM->getTargetTriple().isRISCV64()) {
-    addPass(createRISCVOptWInstrsPass());
+    addPass(createRISCVOptWInstrsLegacyPass());
   }
 }
 

--- a/llvm/lib/Target/RISCV/RISCVVLOptimizer.cpp
+++ b/llvm/lib/Target/RISCV/RISCVVLOptimizer.cpp
@@ -164,7 +164,7 @@ INITIALIZE_PASS_BEGIN(RISCVVLOptimizerLegacy, DEBUG_TYPE, PASS_NAME, false,
 INITIALIZE_PASS_DEPENDENCY(MachineDominatorTreeWrapperPass)
 INITIALIZE_PASS_END(RISCVVLOptimizerLegacy, DEBUG_TYPE, PASS_NAME, false, false)
 
-FunctionPass *llvm::createRISCVVLOptimizerPass() {
+FunctionPass *llvm::createRISCVVLOptimizerLegacyPass() {
   return new RISCVVLOptimizerLegacy();
 }
 

--- a/llvm/lib/Target/RISCV/RISCVVLOptimizer.h
+++ b/llvm/lib/Target/RISCV/RISCVVLOptimizer.h
@@ -28,7 +28,7 @@ public:
                         MachineFunctionAnalysisManager &MFAM);
 };
 
-FunctionPass *createRISCVVLOptimizerPass();
+FunctionPass *createRISCVVLOptimizerLegacyPass();
 void initializeRISCVVLOptimizerLegacyPass(PassRegistry &);
 
 } // namespace llvm

--- a/llvm/lib/Target/RISCV/RISCVVectorPeephole.cpp
+++ b/llvm/lib/Target/RISCV/RISCVVectorPeephole.cpp
@@ -846,6 +846,6 @@ RISCVVectorPeepholePass::run(MachineFunction &MF,
   return PA;
 }
 
-FunctionPass *llvm::createRISCVVectorPeepholePass() {
+FunctionPass *llvm::createRISCVVectorPeepholeLegacyPass() {
   return new RISCVVectorPeepholeLegacy();
 }

--- a/llvm/lib/Target/RISCV/RISCVVectorPeephole.h
+++ b/llvm/lib/Target/RISCV/RISCVVectorPeephole.h
@@ -31,7 +31,7 @@ public:
   }
 };
 
-FunctionPass *createRISCVVectorPeepholePass();
+FunctionPass *createRISCVVectorPeepholeLegacyPass();
 void initializeRISCVVectorPeepholeLegacyPass(PassRegistry &);
 
 } // namespace llvm


### PR DESCRIPTION
This renames the `create*Pass` functions for the passes ported to the new
pass manager so it's clearer that they relate to the legacy versions of
the passes.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>