### PR TITLE
[mlir][spirv] Deduce VCE requirements from BuiltIn decorations

### DIFF
--- a/mlir/lib/Dialect/SPIRV/Transforms/UpdateVCEPass.cpp
+++ b/mlir/lib/Dialect/SPIRV/Transforms/UpdateVCEPass.cpp
@@ -165,6 +165,35 @@ void UpdateVCEPass::runOnOperation() {
     valueTypes.append(op->operand_type_begin(), op->operand_type_end());
     valueTypes.append(op->result_type_begin(), op->result_type_end());
 
+    // BuiltIn decorations can carry version, extension, and capability
+    // requirements that are not represented by the global variable's type.
+    auto requireBuiltIn = [&](spirv::BuiltIn builtIn) -> LogicalResult {
+      if (std::optional<spirv::Version> minVersion =
+              spirv::getMinVersion(builtIn)) {
+        deducedVersion = std::max(deducedVersion, *minVersion);
+        if (deducedVersion > allowedVersion) {
+          return op->emitError("'")
+                 << op->getName() << "' requires min version "
+                 << spirv::stringifyVersion(deducedVersion)
+                 << " but target environment allows up to "
+                 << spirv::stringifyVersion(allowedVersion);
+        }
+      }
+      if (auto exts = spirv::getExtensions(builtIn)) {
+        SmallVector<ArrayRef<spirv::Extension>, 1> extCandidates = {*exts};
+        if (failed(checkAndUpdateExtensionRequirements(
+                op, targetEnv, extCandidates, deducedExtensions)))
+          return failure();
+      }
+      if (auto caps = spirv::getCapabilities(builtIn)) {
+        SmallVector<ArrayRef<spirv::Capability>, 1> capCandidates = {*caps};
+        if (failed(checkAndUpdateCapabilityRequirements(
+                op, targetEnv, capCandidates, deducedCapabilities)))
+          return failure();
+      }
+      return success();
+    };
+
     // Per the SPIR-V spec Decoration table, the `LinkageAttributes` decoration
     // requires the `Linkage` capability, and specific linkage types pull in
     // additional extensions (e.g., `LinkOnceODR` -> `SPV_KHR_linkonce_odr`).
@@ -188,6 +217,12 @@ void UpdateVCEPass::runOnOperation() {
     // conveyed by type attributes.
     if (auto globalVar = dyn_cast<spirv::GlobalVariableOp>(op)) {
       valueTypes.push_back(globalVar.getType());
+
+      if (std::optional<StringRef> builtInName = globalVar.getBuiltIn())
+        if (std::optional<spirv::BuiltIn> builtIn =
+                spirv::symbolizeBuiltIn(*builtInName))
+          if (failed(requireBuiltIn(*builtIn)))
+            return WalkResult::interrupt();
 
       // The `DescriptorSet` and `Binding` decorations (represented by the
       // `binding` and `descriptor_set` attributes) require the `Shader`

--- a/mlir/test/Dialect/SPIRV/Transforms/vce-deduction.mlir
+++ b/mlir/test/Dialect/SPIRV/Transforms/vce-deduction.mlir
@@ -65,6 +65,39 @@ spirv.module Logical GLSL450 attributes {
 // Capability
 //===----------------------------------------------------------------------===//
 
+// Test requirements carried by BuiltIn decorations.
+
+// SubgroupId requires GroupNonUniform or Kernel. Select the capability allowed
+// by the target environment.
+// CHECK: requires #spirv.vce<v1.3, [GroupNonUniform, Shader, Matrix], []>
+spirv.module Logical GLSL450 attributes {
+  spirv.target_env = #spirv.target_env<
+    #spirv.vce<v1.3, [Shader, GroupNonUniform], []>, #spirv.resource_limits<>>
+} {
+  spirv.GlobalVariable @subgroup_id built_in("SubgroupId") : !spirv.ptr<i32, Input>
+}
+
+// SubgroupEqMask requires SPIR-V 1.3 and GroupNonUniformBallot or
+// SubgroupBallotKHR.
+// CHECK: requires #spirv.vce<v1.3, [GroupNonUniformBallot, Shader, GroupNonUniform, Matrix], []>
+spirv.module Logical GLSL450 attributes {
+  spirv.target_env = #spirv.target_env<
+    #spirv.vce<v1.3, [Shader, GroupNonUniformBallot], []>, #spirv.resource_limits<>>
+} {
+  spirv.GlobalVariable @subgroup_eq_mask built_in("SubgroupEqMask") : !spirv.ptr<vector<4xi32>, Input>
+}
+
+// BaseVertex requires the DrawParameters capability and
+// SPV_KHR_shader_draw_parameters extension.
+// CHECK: requires #spirv.vce<v1.0, [DrawParameters, Shader, Matrix], [SPV_KHR_shader_draw_parameters]>
+spirv.module Logical GLSL450 attributes {
+  spirv.target_env = #spirv.target_env<
+    #spirv.vce<v1.0, [Shader, DrawParameters], [SPV_KHR_shader_draw_parameters]>,
+    #spirv.resource_limits<>>
+} {
+  spirv.GlobalVariable @base_vertex built_in("BaseVertex") : !spirv.ptr<i32, Input>
+}
+
 // Test minimal capabilities.
 
 // CHECK: requires #spirv.vce<v1.0, [Shader, Matrix], []>


### PR DESCRIPTION
## Summary

Teach `spirv-update-vce` to account for version, extension, and capability requirements carried by `BuiltIn` decorations on `spirv.GlobalVariable` operations.

## Motivation

The pass previously considered operation and type requirements, but not the availability requirements of a global variable's `built_in` attribute. As a result, it could remove `GroupNonUniform` from a module using `BuiltIn SubgroupId`, producing SPIR-V that fails validation.

Reuse the TableGen-generated availability queries for `spirv::BuiltIn` values and select requirements allowed by the target environment.

Fixes #213193.

## Testing

- `build/bin/llvm-lit -v mlir/test/Dialect/SPIRV/Transforms/vce-deduction.mlir`
- Reproduced the original issue and confirmed `GroupNonUniform` is retained.
