### PR TITLE
[clang-tidy] Fix `DefaultHungarianPrefix` for incomplete classes in `readability-identifier-naming`

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.cpp
@@ -416,6 +416,9 @@ IdentifierNamingCheck::~IdentifierNamingCheck() = default;
 
 bool IdentifierNamingCheck::HungarianNotation::checkOptionValid(
     int StyleKindIndex) const {
+  if (StyleKindIndex == SK_Default)
+    return true;
+
   if ((StyleKindIndex >= SK_EnumConstant) &&
       (StyleKindIndex <= SK_ConstantParameter))
     return true;
@@ -643,7 +646,7 @@ StringRef IdentifierNamingCheck::HungarianNotation::getClassPrefix(
       !isOptionEnabled("TreatStructAsClass", HNOption.General))
     return {};
 
-  return CRD->isAbstract() ? "I" : "C";
+  return CRD->hasDefinition() && CRD->isAbstract() ? "I" : "C";
 }
 
 std::string IdentifierNamingCheck::HungarianNotation::getEnumPrefix(

--- a/clang-tools-extra/docs/ReleaseNotes.md
+++ b/clang-tools-extra/docs/ReleaseNotes.md
@@ -121,6 +121,15 @@ infrastructure are described first, followed by tool-specific sections.
   `std::initializer_list` constructor, as the braced form could select a
   different constructor.
 
+- Improved {doc}`readability-identifier-naming
+  <clang-tidy/checks/readability/identifier-naming>` check:
+
+  - Fixed a crash when checking forward-declared classes with
+    {option}`DefaultHungarianPrefix` enabled.
+
+  - Fixed {option}`DefaultHungarianPrefix` being incorrectly diagnosed as an
+    invalid option.
+
 - Improved {doc}`readability-named-parameter
   <clang-tidy/checks/readability/named-parameter>` check by ignoring
   standard tag types (e.g. `std::in_place_t`, `std::allocator_arg_t`,

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/Inputs/identifier-naming/hungarian-notation1/.clang-tidy
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/Inputs/identifier-naming/hungarian-notation1/.clang-tidy
@@ -30,6 +30,7 @@ CheckOptions:
   readability-identifier-naming.StaticConstantCase: CamelCase
   readability-identifier-naming.StaticVariableCase: CamelCase
   readability-identifier-naming.VariableCase: CamelCase
+  readability-identifier-naming.DefaultHungarianPrefix: On
   readability-identifier-naming.AbstractClassHungarianPrefix: On
   readability-identifier-naming.ClassHungarianPrefix: On
   readability-identifier-naming.ClassConstantHungarianPrefix: On

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming-hungarian-notation.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming-hungarian-notation.cpp
@@ -581,6 +581,10 @@ INDEX iIndex = 0;
 //===----------------------------------------------------------------------===//
 // Class
 //===----------------------------------------------------------------------===//
+class Incomplete;
+// CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for identifier 'Incomplete'
+// CHECK-FIXES: class CIncomplete;
+
 class ClassCase { int Func(); };
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for class 'ClassCase' [readability-identifier-naming]
 // CHECK-FIXES: class CClassCase { int Func(); };


### PR DESCRIPTION
Treat `DefaultHungarianPrefix` as a valid `readability-identifier-naming` option and check that a class has a definition before calling `isAbstract()` to compute its Hungarian prefix.

Closes #215732