### PR TITLE
[mlir][gpu][NFC] Remove unused patterns in GpuModuleToBinaryPass

### DIFF
--- a/mlir/lib/Dialect/GPU/Transforms/ModuleToBinary.cpp
+++ b/mlir/lib/Dialect/GPU/Transforms/ModuleToBinary.cpp
@@ -36,7 +36,6 @@ public:
 } // namespace
 
 void GpuModuleToBinaryPass::runOnOperation() {
-  RewritePatternSet patterns(&getContext());
   auto targetFormat =
       llvm::StringSwitch<std::optional<CompilationTarget>>(compilationTarget)
           .Cases({"offloading", "llvm"}, CompilationTarget::Offload)


### PR DESCRIPTION
The initial implementation of this pass used patterns but during PR review was removed, but the pattern set was accidently left in during diff 3->4; see https://reviews.llvm.org/D154149?id=547745