### PR TITLE
[mlir] Remove dead declaration promoteSingleIterationLoops

### DIFF
--- a/mlir/include/mlir/Dialect/Affine/LoopUtils.h
+++ b/mlir/include/mlir/Dialect/Affine/LoopUtils.h
@@ -86,10 +86,6 @@ LogicalResult loopUnrollJamUpToFactor(AffineForOp forOp,
 /// was known to have a single iteration.
 LogicalResult promoteIfSingleIteration(AffineForOp forOp);
 
-/// Promotes all single iteration AffineForOp's in the Function, i.e., moves
-/// their body into the containing Block.
-void promoteSingleIterationLoops(func::FuncOp f);
-
 /// Skew the operations in an affine.for's body with the specified
 /// operation-wise shifts. The shifts are with respect to the original execution
 /// order, and are multiplied by the loop 'step' before being applied. If


### PR DESCRIPTION
The corresponding function definition was removed on January 24, 2022
in a70aa7bb0d9a6066831b339e0a09a2c1bc74fe2b.
