### PR TITLE
[TLI][NFC] Mark TargetLibraryInfo::getLibFunc as [[nodiscard]]

### DIFF
--- a/llvm/include/llvm/Analysis/TargetLibraryInfo.h
+++ b/llvm/include/llvm/Analysis/TargetLibraryInfo.h
@@ -129,7 +129,7 @@ public:
   ///
   /// If it is one of the known library functions, return true and set F to the
   /// corresponding value.
-  LLVM_ABI bool getLibFunc(StringRef funcName, LibFunc &F) const;
+  [[nodiscard]] LLVM_ABI bool getLibFunc(StringRef funcName, LibFunc &F) const;
 
   /// Searches for a particular function name, also checking that its type is
   /// valid for the library function matching that name.
@@ -138,11 +138,13 @@ public:
   /// corresponding value.
   ///
   /// FDecl is assumed to have a parent Module when using this function.
-  LLVM_ABI bool getLibFunc(const Function &FDecl, LibFunc &F) const;
+  [[nodiscard]] LLVM_ABI bool getLibFunc(const Function &FDecl,
+                                         LibFunc &F) const;
 
   /// Searches for a function name using an Instruction \p Opcode.
   /// Currently, only the frem instruction is supported.
-  LLVM_ABI bool getLibFunc(unsigned int Opcode, Type *Ty, LibFunc &F) const;
+  [[nodiscard]] LLVM_ABI bool getLibFunc(unsigned int Opcode, Type *Ty,
+                                         LibFunc &F) const;
 
   /// Forces a function to be marked as unavailable.
   void setUnavailable(LibFunc F) {
@@ -330,24 +332,25 @@ public:
   ///
   /// If it is one of the known library functions, return true and set F to the
   /// corresponding value.
-  bool getLibFunc(StringRef funcName, LibFunc &F) const {
+  [[nodiscard]] bool getLibFunc(StringRef funcName, LibFunc &F) const {
     return Impl->getLibFunc(funcName, F);
   }
 
-  bool getLibFunc(const Function &FDecl, LibFunc &F) const {
+  [[nodiscard]] bool getLibFunc(const Function &FDecl, LibFunc &F) const {
     return Impl->getLibFunc(FDecl, F);
   }
 
   /// If a callbase does not have the 'nobuiltin' attribute, return if the
   /// called function is a known library function and set F to that function.
-  bool getLibFunc(const CallBase &CB, LibFunc &F) const {
+  [[nodiscard]] bool getLibFunc(const CallBase &CB, LibFunc &F) const {
     return !CB.isNoBuiltin() && CB.getCalledFunction() &&
            getLibFunc(*(CB.getCalledFunction()), F);
   }
 
   /// Searches for a function name using an Instruction \p Opcode.
   /// Currently, only the frem instruction is supported.
-  bool getLibFunc(unsigned int Opcode, Type *Ty, LibFunc &F) const {
+  [[nodiscard]] bool getLibFunc(unsigned int Opcode, Type *Ty,
+                                LibFunc &F) const {
     return Impl->getLibFunc(Opcode, Ty, F);
   }
 

--- a/llvm/lib/Analysis/BranchProbabilityInfo.cpp
+++ b/llvm/lib/Analysis/BranchProbabilityInfo.cpp
@@ -892,7 +892,8 @@ bool BPIConstruction::calcZeroHeuristics(const BasicBlock *BB,
   if (TLI)
     if (CallInst *Call = dyn_cast<CallInst>(CI->getOperand(0)))
       if (Function *CalledFn = Call->getCalledFunction())
-        TLI->getLibFunc(*CalledFn, Func);
+        if (!TLI->getLibFunc(*CalledFn, Func))
+          Func = LibFunc::NotLibFunc;
 
   bool Likely;
   if (Func == LibFunc_strcasecmp ||

--- a/llvm/lib/Transforms/Utils/BuildLibCalls.cpp
+++ b/llvm/lib/Transforms/Utils/BuildLibCalls.cpp
@@ -1948,7 +1948,8 @@ Value *llvm::emitUnaryFloatFnCall(Value *Op, const TargetLibraryInfo *TLI,
   appendTypeSuffix(Op, Name, NameBuffer);
 
   LibFunc TheLibFunc;
-  TLI->getLibFunc(Name, TheLibFunc);
+  if (!TLI->getLibFunc(Name, TheLibFunc))
+    TheLibFunc = NotLibFunc;
 
   return emitUnaryFloatFnCallHelper(Op, TheLibFunc, Name, B, Attrs, TLI);
 }
@@ -2001,7 +2002,8 @@ Value *llvm::emitBinaryFloatFnCall(Value *Op1, Value *Op2,
   appendTypeSuffix(Op1, Name, NameBuffer);
 
   LibFunc TheLibFunc;
-  TLI->getLibFunc(Name, TheLibFunc);
+  if (!TLI->getLibFunc(Name, TheLibFunc))
+    TheLibFunc = NotLibFunc;
 
   return emitBinaryFloatFnCallHelper(Op1, Op2, TheLibFunc, Name, B, Attrs, TLI);
 }

--- a/llvm/lib/Transforms/Utils/LibCallsShrinkWrap.cpp
+++ b/llvm/lib/Transforms/Utils/LibCallsShrinkWrap.cpp
@@ -488,8 +488,8 @@ bool LibCallsShrinkWrap::perform(CallInst *CI) {
   LibFunc Func;
   Function *Callee = CI->getCalledFunction();
   assert(Callee && "perform() should apply to a non-empty callee");
-  TLI.getLibFunc(*Callee, Func);
-  assert(Func && "perform() is not expecting an empty function");
+  [[maybe_unused]] bool FoundLibFunc = TLI.getLibFunc(*Callee, Func);
+  assert(FoundLibFunc && "perform() is not expecting an empty function");
 
   if (performCallDomainErrorOnly(CI, Func) || performCallRangeErrorOnly(CI, Func))
     return true;

--- a/llvm/lib/Transforms/Utils/SimplifyLibCalls.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyLibCalls.cpp
@@ -2719,8 +2719,9 @@ Value *LibCallSimplifier::optimizeLog(CallInst *Log, IRBuilderBase &B) {
   B.setFastMathFlags(FastMathFlags::getFast());
 
   Intrinsic::ID ArgID = Arg->getIntrinsicID();
-  LibFunc ArgLb = NotLibFunc;
-  TLI->getLibFunc(*Arg, ArgLb);
+  LibFunc ArgLb;
+  if (!TLI->getLibFunc(*Arg, ArgLb))
+    ArgLb = NotLibFunc;
 
   // log(pow(x,y)) -> y*log(x)
   AttributeList NoAttrs;
@@ -2775,8 +2776,9 @@ Value *LibCallSimplifier::mergeSqrtToExp(CallInst *CI, IRBuilderBase &B) {
   if (!Arg || !Arg->hasAllowReassoc() || !Arg->hasOneUse())
     return nullptr;
   Intrinsic::ID ArgID = Arg->getIntrinsicID();
-  LibFunc ArgLb = NotLibFunc;
-  TLI->getLibFunc(*Arg, ArgLb);
+  LibFunc ArgLb;
+  if (!TLI->getLibFunc(*Arg, ArgLb))
+    ArgLb = NotLibFunc;
 
   LibFunc SqrtLb, ExpLb, Exp2Lb, Exp10Lb;
 
@@ -3009,7 +3011,8 @@ static bool insertSinCosCall(IRBuilderBase &B, Function *OrigCallee, Value *Arg,
   if (!isLibFuncEmittable(M, TLI, Name))
     return false;
   LibFunc TheLibFunc;
-  TLI->getLibFunc(Name, TheLibFunc);
+  [[maybe_unused]] bool FoundLibFunc = TLI->getLibFunc(Name, TheLibFunc);
+  assert(FoundLibFunc && "isLibFuncEmittable should have rejected this name");
   FunctionCallee Callee = getOrInsertLibFunc(
       M, *TLI, TheLibFunc, OrigCallee->getAttributes(), ResTy, ArgTy);
 


### PR DESCRIPTION
getLibFunc only writes to its LibFunc output argument when it returns
true, so a caller that ignores the result can end up reading an
uninitialized LibFunc. That is easy to miss, and yes, we hit that issue
on our downstream code.
    
Mark every getLibFunc overload [[nodiscard]] so the compiler catches
this.
    
Assisted-by: Opus