### PR TITLE
[BOLT] Link pthread in Profile and Target libs to fix undefined pthread_rwlock_* symbols

### DIFF
--- a/bolt/lib/Profile/CMakeLists.txt
+++ b/bolt/lib/Profile/CMakeLists.txt
@@ -10,6 +10,9 @@ add_llvm_library(LLVMBOLTProfile
   NO_EXPORT
   DISABLE_LLVM_LINK_LLVM_DYLIB
 
+  LINK_LIBS
+  ${LLVM_PTHREAD_LIB}
+
   LINK_COMPONENTS
   BinaryFormat
   Demangle

--- a/bolt/lib/Target/AArch64/CMakeLists.txt
+++ b/bolt/lib/Target/AArch64/CMakeLists.txt
@@ -25,6 +25,9 @@ add_llvm_library(LLVMBOLTTargetAArch64
   NO_EXPORT
   DISABLE_LLVM_LINK_LLVM_DYLIB
 
+  LINK_LIBS
+  ${LLVM_PTHREAD_LIB}
+
   DEPENDS
   AArch64CommonTableGen
   )

--- a/bolt/lib/Target/RISCV/CMakeLists.txt
+++ b/bolt/lib/Target/RISCV/CMakeLists.txt
@@ -23,6 +23,9 @@ add_llvm_library(LLVMBOLTTargetRISCV
   NO_EXPORT
   DISABLE_LLVM_LINK_LLVM_DYLIB
 
+  LINK_LIBS
+  ${LLVM_PTHREAD_LIB}
+
   DEPENDS
   RISCVCommonTableGen
   )

--- a/bolt/lib/Target/X86/CMakeLists.txt
+++ b/bolt/lib/Target/X86/CMakeLists.txt
@@ -24,6 +24,9 @@ add_llvm_library(LLVMBOLTTargetX86
   NO_EXPORT
   DISABLE_LLVM_LINK_LLVM_DYLIB
 
+  LINK_LIBS
+  ${LLVM_PTHREAD_LIB}
+
   DEPENDS
   X86CommonTableGen
   )


### PR DESCRIPTION
MCPlusBuilder.h uses llvm::sys::RWMutex, which aliases std::shared_mutex on non-Apple platforms. Its inline lock/unlock calls pthread_rwlock_* directly, so any shared library that instantiates these inline functions must link pthread explicitly under -Wl,-z,defs.

This only shows up when building with -DBUILD_SHARED_LIBS=ON. With static libs, the missing symbols get resolved elsewhere on the final link line, so the problem stays hidden.

LLVMBOLTCore, LLVMBOLTRewrite, LLVMBOLTPasses, and LLVMBOLTUtils already link ${LLVM_PTHREAD_LIB}; LLVMBOLTProfile and the LLVMBOLTTarget{X86, AArch64,RISCV} libs were missing it, causing link failures.