### PR TITLE
[llvm][release] Update package versions in the Windows release script

### DIFF
--- a/llvm/utils/release/build_llvm_release.bat
+++ b/llvm/utils/release/build_llvm_release.bat
@@ -145,9 +145,9 @@ if "%skip-checkout%" == "true" (
   set llvm_src=%build_dir%\llvm-project
 )
 
-set libxml_version=2.9.12
+set libxml_version=2.15.3
 curl -O https://gitlab.gnome.org/GNOME/libxml2/-/archive/v%libxml_version%/libxml2-v%libxml_version%.tar.gz || exit /b 1
-call :verify_checksum libxml2-v%libxml_version%.tar.gz sha256 98bfa7a9a5e2a75638422050740448ee9f02bf4dc2075c9822d7747d5ff9e617 || exit /b 1
+call :verify_checksum libxml2-v%libxml_version%.tar.gz sha256 0da50c1415f4ec0364569d2119b1436ba837b31df44af28569d234272c23cf1f || exit /b 1
 REM 'test' directory excluded because of symlinks.
 tar zxf libxml2-v%libxml_version%.tar.gz --exclude "test/*" || exit /b 1
 
@@ -167,6 +167,7 @@ REM 'tests' directory excluded because of symlinks.
 tar zxf zstd-%zstd_version%.tar.gz --exclude "tests/*" || exit /b 1
 
 REM Setting CMAKE_CL_SHOWINCLUDES_PREFIX to work around PR27226.
+REM Have to add bcrypt.lib to the linker flags because of libxml2.
 REM Common flags for all builds.
 set common_compiler_flags=-DLIBXML_STATIC
 set common_cmake_flags=^
@@ -184,6 +185,8 @@ set common_cmake_flags=^
   -DLLVM_ENABLE_ZSTD=FORCE_ON ^
   -DCMAKE_C_FLAGS="%common_compiler_flags%" ^
   -DCMAKE_CXX_FLAGS="%common_compiler_flags%" ^
+  -DCMAKE_EXE_LINKER_FLAGS=bcrypt.lib ^
+  -DCMAKE_SHARED_LINKER_FLAGS=bcrypt.lib ^
   -DLLVM_ENABLE_RPMALLOC=ON ^
   -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lld" ^
   -DLLVM_ENABLE_RUNTIMES="compiler-rt;openmp" ^
@@ -191,12 +194,11 @@ set common_cmake_flags=^
   -DCOMPILER_RT_BUILD_ORC=OFF
 
 if "%force-msvc%" == "" (
-  where /q clang-cl
-  if %errorlevel% EQU 0 (
-    where /q lld-link
-    if %errorlevel% EQU 0 (
+  clang-cl --version
+  if !errorlevel! EQU 0 (
+    lld-link --version
+    if !errorlevel! EQU 0 (
       set common_compiler_flags=%common_compiler_flags% -fuse-ld=lld
-      
       set common_cmake_flags=%common_cmake_flags%^
         -DCMAKE_C_COMPILER=clang-cl.exe ^
         -DCMAKE_CXX_COMPILER=clang-cl.exe ^
@@ -394,19 +396,30 @@ exit /b 0
 ::==============================================================================
 :set_environment
 REM Restore original path
-set PATH=%OLDPATH%
+set "PATH=%OLDPATH%"
 
-set python_dir=%1
+set "python_dir=%1"
 
 REM Set Python environment
 if "%local-python%" == "true" (
-  FOR /F "delims=" %%i IN ('where python.exe ^| head -1') DO set python_exe=%%i
-  set PYTHONHOME=!python_exe:~0,-11!
-) else (
-  %python_dir%/python.exe --version || exit /b 1
-  set PYTHONHOME=%python_dir%
+  set "python_dir="
+  set "python_exe="
+  FOR /F "delims=" %%i IN ('where python.exe') DO (
+    if not defined python_exe (
+      set "python_exe=%%i"
+      rem Python Manager puts only the executable and a __target__ file into its bin directory.
+      rem winget installs a reparse point into WindowsApps.
+      rem But: CMake needs a full Python installation directory or find_package() will fail.
+      FOR /F "delims=" %%h IN ('!python_exe! -c "import sys; print(sys.exec_prefix)"') DO (
+        set "python_dir=%%h"
+      )
+    )
+  )
 )
-set PATH=%PYTHONHOME%;%PATH%
+if not defined python_dir exit /b 1
+"%python_dir%\python.exe" --version || exit /b 1
+set "PYTHONHOME=%python_dir%"
+set "PATH=%PYTHONHOME%;%PATH%"
 
 set "VSCMD_START_DIR=%build_dir%"
 


### PR DESCRIPTION
- Upgrade LibXML2 to version 2.15.3
- Fix clang-cl/lld-link check never failing
- Fix PYTHONHOME detection failing if no `head` utility is installed
- Fix PYTHONHOME detection failing for Python Manager-installed Python

Fixes #207197.
Fixes #215138.