### PR TITLE
[clang][bytecode] Make `SourceMap` a proper class

### DIFF
--- a/clang/lib/AST/ByteCode/ByteCodeEmitter.cpp
+++ b/clang/lib/AST/ByteCode/ByteCodeEmitter.cpp
@@ -213,9 +213,9 @@ bool ByteCodeEmitter::emitOp(Opcode Op, const Tys &...Args, SourceInfo SI) {
   // attached to the address after the opcode.
   emit(P, Code, Op, Success);
   if (LocOverride)
-    SrcMap.emplace_back(Code.size(), *LocOverride);
+    SrcMap.push(Code.size(), *LocOverride);
   else if (SI)
-    SrcMap.emplace_back(Code.size(), SI);
+    SrcMap.push(Code.size(), SI);
 
   (..., emit(P, Code, Args, Success));
   return Success;

--- a/clang/lib/AST/ByteCode/Function.cpp
+++ b/clang/lib/AST/ByteCode/Function.cpp
@@ -64,9 +64,5 @@ SourceInfo Function::getSource(CodePtr PC) const {
   assert(PC <= getCodeEnd() && "PC Does not belong to this function");
   assert(hasBody() && "Function has no body");
   unsigned Offset = PC - getCodeBegin();
-  using Elem = std::pair<unsigned, SourceInfo>;
-  auto It = llvm::lower_bound(SrcMap, Elem{Offset, {}}, llvm::less_first());
-  if (It == SrcMap.end())
-    return SrcMap.back().second;
-  return It->second;
+  return SrcMap.findSourceForOffset(Offset);
 }

--- a/clang/lib/AST/ByteCode/Source.h
+++ b/clang/lib/AST/ByteCode/Source.h
@@ -17,6 +17,7 @@
 #include "clang/AST/DeclBase.h"
 #include "clang/AST/Stmt.h"
 #include "llvm/ADT/PointerUnion.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Endian.h"
 
 namespace clang {
@@ -97,7 +98,30 @@ private:
 };
 static_assert(sizeof(SourceInfo) == sizeof(void *));
 
-using SourceMap = std::vector<std::pair<unsigned, SourceInfo>>;
+// A map from byte code offset to source information.
+// This is used to get the location in the input source file for diagnostics.
+class SourceMap final {
+private:
+  llvm::SmallVector<uint32_t> Offsets;
+  llvm::SmallVector<SourceInfo> Infos;
+
+public:
+  SourceMap() = default;
+  void push(uint32_t Offset, SourceInfo Info) {
+    Offsets.push_back(Offset);
+    Infos.push_back(Info);
+  }
+
+  SourceInfo findSourceForOffset(uint32_t Offset) const {
+    assert(!Offsets.empty());
+    assert(Offsets.size() == Infos.size());
+#ifndef NDEBUG
+    assert(llvm::is_sorted(Offsets));
+#endif
+    const auto *It = llvm::lower_bound(Offsets, Offset);
+    return Infos[It - Offsets.begin()];
+  }
+};
 
 /// Interface for classes which map locations to sources.
 class SourceMapper {


### PR DESCRIPTION
Instead of a typedef. Save offsets and infos separately to speed up the binary search a bit.