### PR TITLE
[clang-tools-extra] Add separate CLANG_TOOLS_EXTRA_INCLUDE_TESTS option for tests

### DIFF
--- a/clang-tools-extra/CMakeLists.txt
+++ b/clang-tools-extra/CMakeLists.txt
@@ -7,8 +7,10 @@ option(CLANG_TIDY_ENABLE_STATIC_ANALYZER
   "Include static analyzer checks in clang-tidy" ON)
 option(CLANG_TIDY_ENABLE_QUERY_BASED_CUSTOM_CHECKS
   "Enable query-based custom checks in clang-tidy" ON)
+option(CLANG_TOOLS_EXTRA_INCLUDE_TESTS
+  "Generate build targets for Clang Extra Tools tests." ON)
 
-if(CLANG_INCLUDE_TESTS)
+if(CLANG_INCLUDE_TESTS AND CLANG_TOOLS_EXTRA_INCLUDE_TESTS)
   umbrella_lit_testsuite_begin(check-clang-tools)
 
   option(CLANG_TOOLS_TEST_USE_VG "Run Clang tools' tests under Valgrind" OFF)
@@ -45,7 +47,7 @@ if (CLANG_ENABLE_CLANGD)
 endif()
 
 # Add the common testsuite after all the tools.
-if(CLANG_INCLUDE_TESTS)
+if(CLANG_INCLUDE_TESTS AND CLANG_TOOLS_EXTRA_INCLUDE_TESTS)
   add_subdirectory(test)
   add_subdirectory(unittests)
   umbrella_lit_testsuite_end(check-clang-tools)

--- a/clang-tools-extra/clangd/CMakeLists.txt
+++ b/clang-tools-extra/clangd/CMakeLists.txt
@@ -218,7 +218,7 @@ endif()
 option(CLANGD_BUILD_DEXP "Build the dexp tool as part of Clangd" ON)
 llvm_canonicalize_cmake_booleans(CLANGD_BUILD_DEXP)
 
-if(CLANG_INCLUDE_TESTS)
+if(CLANG_INCLUDE_TESTS AND CLANG_TOOLS_EXTRA_INCLUDE_TESTS)
   add_subdirectory(test)
   add_subdirectory(unittests)
 endif()

--- a/clang-tools-extra/include-cleaner/CMakeLists.txt
+++ b/clang-tools-extra/include-cleaner/CMakeLists.txt
@@ -1,7 +1,7 @@
 include_directories(include)
 add_subdirectory(lib)
 add_subdirectory(tool)
-if(CLANG_INCLUDE_TESTS)
+if(CLANG_INCLUDE_TESTS AND CLANG_TOOLS_EXTRA_INCLUDE_TESTS)
   add_subdirectory(test)
   add_subdirectory(unittests)
 endif()


### PR DESCRIPTION
clang-tools-extra tests depend on the llvm-bcanalyzer CMake target, which exists in LLVM's CMake project but is not visible when Clang is built separately from LLVM. This causes CMake errors when CLANG_INCLUDE_TESTS is ON but the LLVM tools are not available.

This patch introduces CLANG_TOOLS_EXTRA_INCLUDE_TESTS as a separate CMake option to control clang-tools-extra tests independently, allowing users to build Clang with tests enabled (CLANG_INCLUDE_TESTS=ON) while disabling clang-tools-extra tests (CLANG_TOOLS_EXTRA_INCLUDE_TESTS=OFF) when building Clang separately from LLVM.

Without this patch, the following error occurs when CLANG_INCLUDE_TESTS is ON:

```
  CMake Error at AddLLVM.cmake:2113 (add_dependencies):
    The dependency target "llvm-bcanalyzer" of target
    "check-clang-extra-clang-tidy-infrastructure-..." does not exist.
```