### PR TITLE
[clang-tidy] Fix a -Wrange-loop-construct warning

### DIFF
--- a/clang-tools-extra/clang-tidy/ClangTidy.cpp
+++ b/clang-tools-extra/clang-tidy/ClangTidy.cpp
@@ -188,7 +188,7 @@ public:
       }
       reportFix(Diag, Error.Message.Fix);
     }
-    for (const auto Fix : FixLocations) {
+    for (const auto &Fix : FixLocations) {
       Diags.Report(Fix.first, Fix.second ? diag::note_fixit_applied
                                          : diag::note_fixit_failed);
     }


### PR DESCRIPTION
As a follow up to commit d4c991d34c8c8568c
([clang-tidy][NFC] Apply const-correctness for auto 1/N (#213839)) we make sure to use a const reference when iterating of FixLocations.

As indicated by -Wrange-loop-construct this prevents a copy from type 'std::pair<clang::SourceLocation, bool> const'.