### PR TITLE
[Flang][OpenMP] Add declare simd to all subprogram entries

### DIFF
--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -4134,6 +4134,26 @@ private:
     Fortran::lower::gatherOpenMPDeferredDeclareTargets(
         *this, bridge.getSemanticsContext(), getEval(), ompDecl,
         ompDeferredDeclareTarget);
+
+    // A declarative directive describes a property of that procedure or its
+    // symbols; it is not an executable statement. Any operation it creates must
+    // therefore be reachable from every ENTRY. However, emitting at the running
+    // insertion point would drop the op into the shared specification-part
+    // block, which an alternate ENTRY skips over. Use the end of the entry
+    // block in that case instead.
+    //
+    // If this is reached through the specification part of an executable BLOCK
+    // construct (activeConstructStack is non-empty) or if this is a
+    // MODULE-scope declarative (currentFunctionUnit == nullptr), then we don't
+    // have to handle the multiple ENTRY case.
+    if (currentFunctionUnit && activeConstructStack.empty()) {
+      mlir::Block *entryBlock = builder->getEntryBlock();
+      if (entryBlock->mightHaveTerminator())
+        builder->setInsertionPoint(entryBlock->getTerminator());
+      else
+        builder->setInsertionPointToEnd(entryBlock);
+    }
+
     genOpenMPDeclarativeConstruct(
         *this, localSymbols, bridge.getSemanticsContext(), getEval(), ompDecl);
     builder->restoreInsertionPoint(insertPt);

--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -5788,27 +5788,22 @@ genOMP(lower::AbstractConverter &converter, lower::SymMap &symTable,
   const parser::OmpDirectiveSpecification &beginSpec = declareSimdConstruct.v;
 
   // A `declare simd` directive may appear in the specification part of an
-  // interface body. In that case the PFT records the directive as an
+  // interface body. In that case, the PFT records the directive as an
   // evaluation of the enclosing program unit rather than of the interface
-  // body's subprogram. Detect this by comparing the program unit lexically
-  // containing the directive with the procedure currently being lowered; if
-  // they differ, the two options are:
-  //   1. It represents the described INTERFACE case, and emitting an
-  // `omp.declare_simd` op would be incorrect. These are lowered as external
-  // function declarations.
-  //   2. It represents an alternative ENTRY point to a subprogram, in which
-  // case we do need to emit the proper `omp.declare_simd` op.
+  // body's subprogram. Consequently, to detect this case we need to check the
+  // program unit lexically containing the directive, rather than the current
+  // evaluation's owning procedure.
+  //
+  // Emitting an `omp.declare_simd` op in that case would be incorrect, as
+  // interface contents are lowered as external function declarations.
   const semantics::Scope &progUnitScope =
       semantics::GetProgramUnitContaining(semaCtx.FindScope(beginSpec.source));
-  lower::pft::FunctionLikeUnit *owningProc = eval.getOwningProcedure();
-  bool owningProcNotMainProgram = owningProc && !owningProc->isMainProgram();
-  const semantics::Symbol *owningSym =
-      owningProcNotMainProgram
-          ? &owningProc->getSubprogramSymbol()
-          : (owningProc ? owningProc->getMainProgramSymbol() : nullptr);
-
-  if (!owningProcNotMainProgram && progUnitScope.symbol() != owningSym)
-    return;
+  if (const semantics::Symbol *progUnitSym = progUnitScope.symbol()) {
+    if (const auto *subpDetails =
+            progUnitSym->detailsIf<semantics::SubprogramDetails>();
+        subpDetails && subpDetails->isInterface())
+      return;
+  }
 
   List<Clause> clauses = makeClauses(beginSpec.Clauses(), semaCtx);
 

--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -5790,23 +5790,24 @@ genOMP(lower::AbstractConverter &converter, lower::SymMap &symTable,
   // A `declare simd` directive may appear in the specification part of an
   // interface body. In that case the PFT records the directive as an
   // evaluation of the enclosing program unit rather than of the interface
-  // body's subprogram, and the clause operands (linear/aligned/uniform)
-  // reference dummy arguments that are local to the interface body and
-  // therefore have no address in the enclosing scope. Detect this by
-  // comparing the program unit lexically containing the directive with the
-  // procedure currently being lowered; if they differ, this evaluation is
-  // for a different procedure (the interface-body subprogram) and emitting
-  // an `omp.declare_simd` op here would create it with null operands. Skip
-  // emission: lowering for `declare simd` on an external procedure declared
-  // only via an interface body is not handled by this op-based form.
+  // body's subprogram. Detect this by comparing the program unit lexically
+  // containing the directive with the procedure currently being lowered; if
+  // they differ, the two options are:
+  //   1. It represents the described INTERFACE case, and emitting an
+  // `omp.declare_simd` op would be incorrect. These are lowered as external
+  // function declarations.
+  //   2. It represents an alternative ENTRY point to a subprogram, in which
+  // case we do need to emit the proper `omp.declare_simd` op.
   const semantics::Scope &progUnitScope =
       semantics::GetProgramUnitContaining(semaCtx.FindScope(beginSpec.source));
   lower::pft::FunctionLikeUnit *owningProc = eval.getOwningProcedure();
+  bool owningProcNotMainProgram = owningProc && !owningProc->isMainProgram();
   const semantics::Symbol *owningSym =
-      (owningProc && !owningProc->isMainProgram())
+      owningProcNotMainProgram
           ? &owningProc->getSubprogramSymbol()
           : (owningProc ? owningProc->getMainProgramSymbol() : nullptr);
-  if (progUnitScope.symbol() != owningSym)
+
+  if (!owningProcNotMainProgram && progUnitScope.symbol() != owningSym)
     return;
 
   List<Clause> clauses = makeClauses(beginSpec.Clauses(), semaCtx);

--- a/flang/test/Lower/OpenMP/declare-simd-interface-body.f90
+++ b/flang/test/Lower/OpenMP/declare-simd-interface-body.f90
@@ -1,10 +1,7 @@
 ! Regression test for #192581:
 ! DECLARE SIMD applies to the external procedure declared via the interface
-! body, not to the enclosing program unit.
-! Lowering must not emit an omp.declare_simd op in the enclosing
-! scope (the op-based form requires operands referring to the procedure's
-! dummy arguments, which are not in scope here, and creating it would yield
-! null operands).
+! body, not to the enclosing program unit or procedure. Lowering must not emit
+! an omp.declare_simd op in the enclosing scope.
 
 ! RUN: %flang_fc1 -emit-hlfir -fopenmp %s -o - | FileCheck %s
 
@@ -23,10 +20,27 @@ interface
   end subroutine
 end interface
 
-print *, 'pass'
 end
 
-! CHECK-LABEL: func.func @_QQmain()
-! CHECK-NOT:   omp.declare_simd
-! CHECK:       return
+! Interfaces in subroutine / function; multiple nesting levels.
+subroutine a(x)
+  implicit none
+  integer :: x
 
+  interface
+    subroutine b(y)
+      !$omp declare simd linear(y:1)
+      integer :: y
+      interface
+        function c(z)
+          !$omp declare simd linear(z:1)
+          integer :: z
+        end function
+      end interface
+    end subroutine
+  end interface
+
+  call b(x)
+end subroutine
+
+! CHECK-NOT:   omp.declare_simd

--- a/flang/test/Lower/OpenMP/declare-simd-multiple-entry.f90
+++ b/flang/test/Lower/OpenMP/declare-simd-multiple-entry.f90
@@ -1,0 +1,60 @@
+! DECLARE SIMD applies to all entries of a subprogram, not just to the main one.
+
+! RUN: %flang_fc1 -emit-hlfir -fopenmp %s -o - | FileCheck %s
+
+subroutine main_entry(x)
+  !$omp declare simd linear(x:1)
+  integer :: x, y
+  call foo()
+
+entry alt_entry_1(x, y)
+  call bar(x, y)
+  return
+
+entry alt_entry_2(x)
+  call baz(x)
+  return
+end subroutine
+
+! CHECK-LABEL: func.func @_QPmain_entry(
+! CHECK-SAME:  %[[X_ARG:.*]]: !fir.ref<i32>{{.*}})
+! CHECK:       %[[X:.*]]:2 = hlfir.declare %[[X_ARG]]
+! CHECK:       omp.declare_simd linear(%[[X]]
+! CHECK:       return
+
+! CHECK-LABEL: func.func @_QPalt_entry_1(
+! CHECK-SAME:  %[[X_ARG:.*]]: !fir.ref<i32>{{.*}},{{.*}})
+! CHECK:       %[[X:.*]]:2 = hlfir.declare %[[X_ARG]]
+! CHECK:       omp.declare_simd linear(%[[X]]
+! CHECK:       return
+
+! CHECK-LABEL: func.func @_QPalt_entry_2(
+! CHECK-SAME:  %[[X_ARG:.*]]: !fir.ref<i32>{{.*}})
+! CHECK:       %[[X:.*]]:2 = hlfir.declare %[[X_ARG]]
+! CHECK:       omp.declare_simd linear(%[[X]]
+! CHECK:       return
+
+module mymod
+  contains
+  subroutine f(x)
+    !$omp declare simd linear(x:1)
+    integer :: x, y
+    call foo()
+
+  entry g(x, y)
+    call bar(x, y)
+    return
+  end subroutine
+end module mymod
+
+! CHECK-LABEL: func.func @_QMmymodPf(
+! CHECK-SAME:  %[[X_ARG:.*]]: !fir.ref<i32>{{.*}})
+! CHECK:       %[[X:.*]]:2 = hlfir.declare %[[X_ARG]]
+! CHECK:       omp.declare_simd linear(%[[X]]
+! CHECK:       return
+
+! CHECK-LABEL: func.func @_QMmymodPg(
+! CHECK-SAME:  %[[X_ARG:.*]]: !fir.ref<i32>{{.*}},{{.*}})
+! CHECK:       %[[X:.*]]:2 = hlfir.declare %[[X_ARG]]
+! CHECK:       omp.declare_simd linear(%[[X]]
+! CHECK:       return


### PR DESCRIPTION
Currently, lowering of OpenMP `declare simd` directives handles alternative ENTRY points to a subroutine or function the same way as an INTERFACE inside of a main program unit. This means they don't get the `omp.declare_simd` operation added to the resulting function.

This patch changes the existing check to prevent both cases from being detected as the same situation, enabling `omp.declare_simd` to be created for alternative ENTRY points.

However, this change uncovered an existing bug related to where operations associated to OpenMP declarative constructs are added when lowering alternative ENTRY points. The issue being that they get grouped in the same basic block as initialization code for the specification part of the function, which is only intended to run for the default entry point, so they get skipped. Directives such as `allocate` and `declare simd` are impacted by this, since operations for them are created inline when lowered.

The insertion point in these cases is updated to point to the end of the entry block to avoid being skipped.

Assisted-by: Claude Opus 4.6.