### PR TITLE
[libc++] Update the CMake version we use in the CI

### DIFF
--- a/libcxx/utils/ci/docker/linux-builder-base.dockerfile
+++ b/libcxx/utils/ci/docker/linux-builder-base.dockerfile
@@ -137,7 +137,7 @@ EOF
 RUN <<EOF
     # Install a recent CMake
     set -e
-    wget https://github.com/Kitware/CMake/releases/download/v3.24.4/cmake-3.24.4-linux-x86_64.sh -O /tmp/install-cmake.sh
+    wget https://github.com/Kitware/CMake/releases/download/v3.31.0/cmake-3.31.0-linux-x86_64.sh -O /tmp/install-cmake.sh
     sudo bash /tmp/install-cmake.sh --prefix=/usr --exclude-subdir --skip-license
     rm /tmp/install-cmake.sh
 EOF


### PR DESCRIPTION
LLVM is raising the minimum CMake version to 3.31.0. We're currently using an older version, so we need to upgrade. To make sure things work with all supported versions this updates to the now oldest supported version instead of something more recent (which we've done previously).

RFC for updating CMake: https://discourse.llvm.org/t/rfc-raising-minimum-required-cmake-version-to-3-31