### PR TITLE
CodeGen: Synthesize "float-abi" module flag from -float-abi

### DIFF
--- a/llvm/lib/CodeGen/CommandFlags.cpp
+++ b/llvm/lib/CodeGen/CommandFlags.cpp
@@ -271,9 +271,7 @@ codegen::RegisterCodeGenFlags::RegisterCodeGenFlags() {
   CGBINDOPT(EnableHonorSignDependentRoundingFPMath);
 
   static cl::opt<FloatABI::ABIType> FloatABIForCalls(
-      "float-abi",
-      cl::desc(
-          "Choose float ABI type (writes the \"float-abi\" IR module flag)"),
+      "float-abi", cl::desc("Choose float ABI type"),
       cl::init(FloatABI::Default),
       cl::values(clEnumValN(FloatABI::Default, "default",
                             "Target default float ABI type"),

--- a/llvm/lib/CodeGen/CommandFlags.cpp
+++ b/llvm/lib/CodeGen/CommandFlags.cpp
@@ -270,7 +270,9 @@ codegen::RegisterCodeGenFlags::RegisterCodeGenFlags() {
   CGBINDOPT(EnableHonorSignDependentRoundingFPMath);
 
   static cl::opt<FloatABI::ABIType> FloatABIForCalls(
-      "float-abi", cl::desc("Choose float ABI type"),
+      "float-abi",
+      cl::desc(
+          "Choose float ABI type (writes the \"float-abi\" IR module flag)"),
       cl::init(FloatABI::Default),
       cl::values(clEnumValN(FloatABI::Default, "default",
                             "Target default float ABI type"),
@@ -774,6 +776,14 @@ void codegen::setFunctionAttributes(Function &F, StringRef CPU,
 
 void codegen::setFunctionAttributes(Module &M, StringRef CPU,
                                     StringRef Features, StringRef TuneCPU) {
+  // Synthesize the "float-abi" module flag from the -float-abi option,
+  FloatABI::ABIType ABI = getFloatABIForCalls();
+  if (ABI != FloatABI::Default && !M.getModuleFlag("float-abi")) {
+    M.addModuleFlag(
+        Module::Error, "float-abi",
+        MDString::get(M.getContext(), FloatABI::getABITypeName(ABI)));
+  }
+
   for (Function &F : M)
     setFunctionAttributes(F, CPU, Features, TuneCPU);
 }

--- a/llvm/lib/CodeGen/CommandFlags.cpp
+++ b/llvm/lib/CodeGen/CommandFlags.cpp
@@ -23,6 +23,7 @@
 #include "llvm/MC/MCTargetOptionsCommandFlags.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
@@ -776,12 +777,23 @@ void codegen::setFunctionAttributes(Function &F, StringRef CPU,
 
 void codegen::setFunctionAttributes(Module &M, StringRef CPU,
                                     StringRef Features, StringRef TuneCPU) {
-  // Synthesize the "float-abi" module flag from the -float-abi option,
+  // Synthesize the "float-abi" module flag from the -float-abi option.
   FloatABI::ABIType ABI = getFloatABIForCalls();
-  if (ABI != FloatABI::Default && !M.getModuleFlag("float-abi")) {
-    M.addModuleFlag(
-        Module::Error, "float-abi",
-        MDString::get(M.getContext(), FloatABI::getABITypeName(ABI)));
+  if (ABI != FloatABI::Default) {
+    if (auto *Existing =
+            dyn_cast_or_null<MDString>(M.getModuleFlag("float-abi"))) {
+      // The module already records a float ABI; -float-abi must not contradict
+      // it.
+      if (Existing->getString() != FloatABI::getABITypeName(ABI))
+        reportFatalUsageError(
+            "-float-abi=" + FloatABI::getABITypeName(ABI) +
+            " conflicts with the \"float-abi\" module flag \"" +
+            Existing->getString() + "\"");
+    } else {
+      M.addModuleFlag(
+          Module::Error, "float-abi",
+          MDString::get(M.getContext(), FloatABI::getABITypeName(ABI)));
+    }
   }
 
   for (Function &F : M)

--- a/llvm/test/CodeGen/ARM/float-abi-module-flag.ll
+++ b/llvm/test/CodeGen/ARM/float-abi-module-flag.ll
@@ -14,9 +14,9 @@
 ; The triple default applies with no module flag.
 ; RUN: llc -mtriple=armv7-none-eabi -mattr=+vfp3 < %t/none.ll | FileCheck %s --check-prefix=SOFT
 
-; An explicit module flag takes precedence over a conflicting -float-abi option.
-; RUN: llc -mtriple=armv7-none-eabi -mattr=+vfp3 -float-abi=soft < %t/hard.ll | FileCheck %s --check-prefix=HARD
-; RUN: llc -mtriple=armv7-none-eabi -mattr=+vfp3 -float-abi=hard < %t/soft.ll | FileCheck %s --check-prefix=SOFT
+; A -float-abi option conflicting with the module flag is an error.
+; RUN: not llc -mtriple=armv7-none-eabi -mattr=+vfp3 -float-abi=soft < %t/hard.ll -filetype=null 2>&1 | FileCheck %s --check-prefix=CONFLICT-SOFT
+; RUN: not llc -mtriple=armv7-none-eabi -mattr=+vfp3 -float-abi=hard < %t/soft.ll -filetype=null 2>&1 | FileCheck %s --check-prefix=CONFLICT-HARD
 
 ;--- hard.ll
 define float @f(float %x) {
@@ -26,6 +26,7 @@ define float @f(float %x) {
 !llvm.module.flags = !{!0}
 !0 = !{i32 1, !"float-abi", !"hard"}
 ; HARD: vadd.f32 s0,
+; CONFLICT-SOFT: -float-abi=soft conflicts with the "float-abi" module flag "hard"
 
 ;--- soft.ll
 define float @f(float %x) {
@@ -35,6 +36,7 @@ define float @f(float %x) {
 !llvm.module.flags = !{!0}
 !0 = !{i32 1, !"float-abi", !"soft"}
 ; SOFT: vmov {{s[0-9]+}}, r0
+; CONFLICT-HARD: -float-abi=hard conflicts with the "float-abi" module flag "soft"
 
 ;--- none.ll
 define float @f(float %x) {

--- a/llvm/test/CodeGen/ARM/float-abi-synthesize-flag.ll
+++ b/llvm/test/CodeGen/ARM/float-abi-synthesize-flag.ll
@@ -1,0 +1,32 @@
+; Check behavior of the -float-abi command-line option; it should
+; synthesize the "float-abi" module flag, unless one is already
+; present
+
+; RUN: split-file %s %t
+
+; -float-abi=hard writes the module flag.
+; RUN: llc -mtriple=armv7-none-eabi -float-abi=hard -stop-after=finalize-isel %t/none.ll -o - | FileCheck %s --check-prefix=HARD
+
+; -float-abi=soft writes the module flag.
+; RUN: llc -mtriple=armv7-none-eabi -float-abi=soft -stop-after=finalize-isel %t/none.ll -o - | FileCheck %s --check-prefix=SOFT
+
+; Without -float-abi, no flag is synthesized.
+; RUN: llc -mtriple=armv7-none-eabi -stop-after=finalize-isel %t/none.ll -o - | FileCheck %s --check-prefix=NONE
+
+; An explicit in-IR flag is not overridden by -float-abi.
+; RUN: llc -mtriple=armv7-none-eabi -float-abi=soft -stop-after=finalize-isel %t/hard.ll -o - | FileCheck %s --check-prefix=HARD
+
+;--- none.ll
+define void @f() {
+  ret void
+}
+; HARD: !{i32 1, !"float-abi", !"hard"}
+; SOFT: !{i32 1, !"float-abi", !"soft"}
+; NONE-NOT: !"float-abi"
+
+;--- hard.ll
+define void @f() {
+  ret void
+}
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"float-abi", !"hard"}

--- a/llvm/test/CodeGen/ARM/float-abi-synthesize-flag.ll
+++ b/llvm/test/CodeGen/ARM/float-abi-synthesize-flag.ll
@@ -13,8 +13,11 @@
 ; Without -float-abi, no flag is synthesized.
 ; RUN: llc -mtriple=armv7-none-eabi -stop-after=finalize-isel %t/none.ll -o - | FileCheck %s --check-prefix=NONE
 
-; An explicit in-IR flag is not overridden by -float-abi.
-; RUN: llc -mtriple=armv7-none-eabi -float-abi=soft -stop-after=finalize-isel %t/hard.ll -o - | FileCheck %s --check-prefix=HARD
+; -float-abi matching an existing in-IR flag is accepted.
+; RUN: llc -mtriple=armv7-none-eabi -float-abi=hard -stop-after=finalize-isel %t/hard.ll -o - | FileCheck %s --check-prefix=HARD
+
+; -float-abi conflicting with an existing in-IR flag is an error.
+; RUN: not llc -mtriple=armv7-none-eabi -float-abi=soft -stop-after=finalize-isel %t/hard.ll -filetype=null 2>&1 | FileCheck %s --check-prefix=CONFLICT
 
 ;--- none.ll
 define void @f() {
@@ -30,3 +33,4 @@ define void @f() {
 }
 !llvm.module.flags = !{!0}
 !0 = !{i32 1, !"float-abi", !"hard"}
+; CONFLICT: -float-abi=soft conflicts with the "float-abi" module flag "hard"

--- a/llvm/test/CodeGen/CSKY/float-abi-module-flag.ll
+++ b/llvm/test/CodeGen/CSKY/float-abi-module-flag.ll
@@ -16,8 +16,8 @@
 ; no "float-abi" flag.
 ; RUN: llc -csky-no-aliases -mtriple=csky -mattr=+2e3,+fpuv2_sf,+fpuv2_df,+hard-float -float-abi=hard < %t/none.ll | FileCheck %s --check-prefix=HARD
 
-; An explicit module flag takes precedence over the legacy -float-abi option.
-; RUN: llc -csky-no-aliases -mtriple=csky -mattr=+2e3,+fpuv2_sf,+fpuv2_df,+hard-float -float-abi=hard < %t/soft.ll | FileCheck %s --check-prefix=SOFT
+; A -float-abi option conflicting with the module flag is an error.
+; RUN: not llc -csky-no-aliases -mtriple=csky -mattr=+2e3,+fpuv2_sf,+fpuv2_df,+hard-float -float-abi=hard < %t/soft.ll -filetype=null 2>&1 | FileCheck %s --check-prefix=CONFLICT
 
 ;--- none.ll
 define float @f(float %x, float %y) {
@@ -43,3 +43,4 @@ define float @f(float %x, float %y) {
 
 ; SOFT: fmtvrl
 ; HARD-NOT: fmtvrl
+; CONFLICT: -float-abi=hard conflicts with the "float-abi" module flag "soft"


### PR DESCRIPTION
Avoid annoying test updates when the corresponding TargetOptions
field is removed. Make the -float-abi llc/opt option a lit test
convenience that records the floating-point ABI in the IR,
mirroring how -mcpu/-mattr are recorded as function attributes.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>