### PR TITLE
[modulemap] Exclude the z/OS string.h wrapper from LLVM_Utils

### DIFF
--- a/llvm/include/module.modulemap
+++ b/llvm/include/module.modulemap
@@ -412,6 +412,9 @@ module LLVM_Utils {
     // Exclude this; it should only be used on Windows.
     exclude header "llvm/Support/Windows/WindowsSupport.h"
 
+    // Exclude this; it should only be used on z/OS.
+    exclude header "llvm/Support/SystemZ/zos_wrappers/string.h"
+
     // Exclude these; they are fundamentally non-modular.
     exclude header "llvm/Support/PluginLoader.h"
     exclude header "llvm/Support/Solaris/sys/regset.h"


### PR DESCRIPTION
8fce476c8122 (https://github.com/llvm/llvm-project/pull/167703) replaced `llvm/Support/SystemZ/zOSSupport.h` with
`llvm/Support/SystemZ/zos_wrappers/string.h`, a wrapper that pulls in the system header via `#include_next` and then redeclares `strsignal` and `strnlen` with `asm` labels. It is only meant to be reachable on z/OS, and `llvm/CMakeLists.txt` adds the directory to the include path solely when `CMAKE_SYSTEM_NAME` matches OS390.

The header was never excluded from the module map, though. `LLVM_Utils.Support` is an umbrella over `llvm/Support`, so building that module textually includes the wrapper on every host. This surfaced building the Swift compiler on Windows, where `<string.h>` resolves to the UCRT header that already declares `strnlen` as `_ACRTIMP`, i.e. `__declspec(dllimport)`:

```
error: cannot apply asm label to function after its first use
warning: 'strnlen' redeclared without 'dllimport' attribute:
           previous 'dllimport' ignored
```

Exclude it, as we already do for the platform-specific and non-modular headers listed alongside it, e.g.
`llvm/Support/Windows/WindowsSupport.h`. The Solaris entry is the closest precedent: `llvm/CMakeLists.txt` adds that directory to the include path under the same kind of platform check, right next to the z/OS one.

Assisted-by: Claude Code