### PR TITLE
[SPIR-V] Drop storage-class MemorySemantics bit for relaxed Vulkan atomics

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -2606,18 +2606,21 @@ SPIRVEmitIntrinsicsImpl::visitAtomicCmpXchgInst(AtomicCmpXchgInst &I) {
   IRBuilder<> B(I.getParent());
   B.SetInsertPoint(&I);
   SmallVector<Value *> Args(I.operands());
+  const Triple &TT = TM.getTargetTriple();
   Args.push_back(B.getInt32(static_cast<uint32_t>(
-      getMemScope(TM.getTargetTriple(), I.getContext(), I.getSyncScopeID()))));
+      getMemScope(TT, I.getContext(), I.getSyncScopeID()))));
   // Per SPIR-V spec atomic ops must combine the ordering bits with the
   // storage-class bit.
   const SPIRVSubtarget &ST = TM.getSubtarget<SPIRVSubtarget>(*I.getFunction());
   unsigned AS = I.getPointerOperand()->getType()->getPointerAddressSpace();
   uint32_t ScSem = static_cast<uint32_t>(
       getMemSemanticsForStorageClass(addressSpaceToStorageClass(AS, ST)));
-  Args.push_back(B.getInt32(
-      static_cast<uint32_t>(getMemSemantics(I.getSuccessOrdering())) | ScSem));
-  Args.push_back(B.getInt32(
-      static_cast<uint32_t>(getMemSemantics(I.getFailureOrdering())) | ScSem));
+  Args.push_back(B.getInt32(getMemSemanticsWithStorageClass(
+      TT, static_cast<uint32_t>(getMemSemantics(I.getSuccessOrdering())),
+      ScSem)));
+  Args.push_back(B.getInt32(getMemSemanticsWithStorageClass(
+      TT, static_cast<uint32_t>(getMemSemantics(I.getFailureOrdering())),
+      ScSem)));
   Instruction *NewI = B.CreateIntrinsicWithoutFolding(
       Intrinsic::spv_cmpxchg, {I.getPointerOperand()->getType()}, {Args});
   replaceMemInstrUses(&I, NewI, B);

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -2141,7 +2141,9 @@ bool SPIRVInstructionSelector::selectAtomicLoad(Register ResVReg,
   uint32_t MemSem = static_cast<uint32_t>(getMemSemantics(AO));
   if (MemOp.isVolatile() && STI.getTargetTriple().isVulkanOS())
     MemSem |= static_cast<uint32_t>(SPIRV::MemorySemantics::Volatile);
-  Register MemSemReg = buildI32Constant(MemSem | StorageClass, I);
+  uint32_t Sem = getMemSemanticsWithStorageClass(STI.getTargetTriple(), MemSem,
+                                                 StorageClass);
+  Register MemSemReg = buildI32Constant(Sem, I);
 
   MachineIRBuilder MIRBuilder(I);
 
@@ -2298,7 +2300,9 @@ bool SPIRVInstructionSelector::selectAtomicStore(MachineInstr &I) const {
   uint32_t MemSem = static_cast<uint32_t>(getMemSemantics(AO));
   if (MemOp.isVolatile() && STI.getTargetTriple().isVulkanOS())
     MemSem |= static_cast<uint32_t>(SPIRV::MemorySemantics::Volatile);
-  Register MemSemReg = buildI32Constant(MemSem | StorageClass, I);
+  uint32_t Sem = getMemSemanticsWithStorageClass(STI.getTargetTriple(), MemSem,
+                                                 StorageClass);
+  Register MemSemReg = buildI32Constant(Sem, I);
   MachineIRBuilder MIRBuilder(I);
 
   if (PointeeType.isTypePtr()) {
@@ -2581,8 +2585,10 @@ bool SPIRVInstructionSelector::selectAtomicRMW(Register ResVReg,
   uint32_t ScSem = static_cast<uint32_t>(
       getMemSemanticsForStorageClass(GR.getPointerStorageClass(Ptr)));
   AtomicOrdering AO = MemOp->getSuccessOrdering();
-  uint32_t MemSem = static_cast<uint32_t>(getMemSemantics(AO)) | ScSem;
-  Register MemSemReg = buildI32Constant(MemSem, I);
+  uint32_t OrderSem = static_cast<uint32_t>(getMemSemantics(AO));
+  Register MemSemReg = buildI32Constant(
+      getMemSemanticsWithStorageClass(STI.getTargetTriple(), OrderSem, ScSem),
+      I);
 
   Register ValueReg = I.getOperand(2).getReg();
   if (NegateOpcode != 0) {

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -449,6 +449,14 @@ SPIRV::MemorySemantics::MemorySemantics getMemSemantics(AtomicOrdering Ord) {
   llvm_unreachable(nullptr);
 }
 
+uint32_t getMemSemanticsWithStorageClass(const Triple &TT, uint32_t OrderSem,
+                                         uint32_t StorageClassSem) {
+  bool DropStorageClass =
+      TT.isVulkanOS() &&
+      OrderSem == static_cast<uint32_t>(SPIRV::MemorySemantics::None);
+  return OrderSem | (DropStorageClass ? 0 : StorageClassSem);
+}
+
 SPIRV::Scope::Scope getMemScope(const Triple &TT, LLVMContext &Ctx,
                                 SyncScope::ID Id) {
   // Named by

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.h
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.h
@@ -286,6 +286,9 @@ getMemSemanticsForStorageClass(SPIRV::StorageClass::StorageClass SC);
 
 SPIRV::MemorySemantics::MemorySemantics getMemSemantics(AtomicOrdering Ord);
 
+uint32_t getMemSemanticsWithStorageClass(const Triple &TT, uint32_t OrderSem,
+                                         uint32_t StorageClassSem);
+
 SPIRV::Scope::Scope getMemScope(const Triple &TT, LLVMContext &Ctx,
                                 SyncScope::ID Id);
 

--- a/llvm/test/CodeGen/SPIRV/atomiccmpxchg-storage-class-semantics-vulkan.ll
+++ b/llvm/test/CodeGen/SPIRV/atomiccmpxchg-storage-class-semantics-vulkan.ll
@@ -1,0 +1,20 @@
+; Vulkan cmpxchg counterpart of atomicrmw-storage-class-semantics-vulkan.ll;
+; see that file for the VUID this fixes.
+;
+; TODO: a Workgroup-storage-class cmpxchg crossing a function boundary (call
+; arg or OpEntryPoint param) hits an unrelated crash in
+; SPIRVLegalizePointerCast. Once fixed, add:
+; RUNx: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan1.3-compute %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
+
+; RUN: llc -O0 -mtriple=spirv-unknown-vulkan1.3-compute %s -o - | FileCheck %s
+
+; CHECK-DAG: %[[#Int:]] = OpTypeInt 32 0
+; CHECK-DAG: %[[#Workgroup:]] = OpConstant %[[#Int]] 2
+
+define spir_func void @cmpxchg(ptr addrspace(3) %p) {
+  ; WorkgroupMemory bit (256) must not appear on either semantics operand.
+  ; CHECK: OpAtomicCompareExchange %[[#Int]] %[[#]] %[[#Workgroup]] %[[#]] %[[#]] %[[#]] %[[#]]
+  ; CHECK-NOT: OpConstant %[[#Int]] 256
+  %pair = cmpxchg ptr addrspace(3) %p, i32 0, i32 1 syncscope("workgroup") monotonic monotonic
+  ret void
+}

--- a/llvm/test/CodeGen/SPIRV/atomicrmw-storage-class-semantics-vulkan.ll
+++ b/llvm/test/CodeGen/SPIRV/atomicrmw-storage-class-semantics-vulkan.ll
@@ -1,0 +1,39 @@
+; Vulkan counterpart of atomicrmw-storage-class-semantics.ll.
+;
+; Vulkan forbids a storage-class MemorySemantics bit combined with a relaxed
+; order (VUID-StandaloneSpirv-MemorySemantics-10871), so relaxed atomics must
+; drop the bit instead of OR'ing it in. See
+; atomiccmpxchg-storage-class-semantics-vulkan.ll for the cmpxchg case.
+
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-unknown-vulkan1.3-compute %s -o - | FileCheck %s --check-prefixes=CHECK,NO-SC-BIT
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan1.3-compute %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
+
+; CHECK-DAG: %[[#Int:]] = OpTypeInt 32 0
+; CHECK-DAG: %[[#Workgroup:]] = OpConstant %[[#Int]] 2
+; None (0) semantics is emitted as OpConstantNull.
+; CHECK-DAG: %[[#None:]] = OpConstantNull %[[#Int]]
+
+; NOT-only prefix scans the whole module, since the constant precedes the atomics in output.
+; NO-SC-BIT-NOT: OpConstant %[[#Int]] 256
+
+@gs = external hidden addrspace(3) global i32, align 4
+
+define void @rmw() #0 {
+  ; CHECK: OpAtomicOr %[[#Int]] %[[#]] %[[#Workgroup]] %[[#None]] %[[#]]
+  %r = atomicrmw or ptr addrspace(3) @gs, i32 1 syncscope("workgroup") monotonic, align 4
+  ret void
+}
+
+define void @ld() #0 {
+  ; CHECK: OpAtomicLoad %[[#Int]] %[[#]] %[[#Workgroup]] %[[#None]]
+  %v = load atomic i32, ptr addrspace(3) @gs syncscope("workgroup") monotonic, align 4
+  ret void
+}
+
+define void @st() #0 {
+  ; CHECK: OpAtomicStore %[[#]] %[[#Workgroup]] %[[#None]] %[[#]]
+  store atomic i32 1, ptr addrspace(3) @gs syncscope("workgroup") monotonic, align 4
+  ret void
+}
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }


### PR DESCRIPTION
VUID-StandaloneSpirv-MemorySemantics-10871 forbids combining a storage class semantics bit with a relaxed memory order

The backend unconditionally OR'd the two together, which was untested until #215634 moved this test under the SPIR-V backend where spirv-val actually runs

Unblocks the currently failing on main `llvm/test/CodeGen/SPIRV/hlsl-intrinsics/InterlockedOr-scope.ll` test