### PR TITLE
[lldb][test] Remove references to dotest's removed -A option

### DIFF
--- a/lldb/docs/resources/test.md
+++ b/lldb/docs/resources/test.md
@@ -540,16 +540,15 @@ You can also add to the test runner options by setting the
 items which must be separate parts of the runner's command line.
 
 It is possible to customize the architecture of the test binaries and compiler
-used by appending `-A` and `-C` options respectively. For example, to test
+used by appending `--triple` and `-C` options respectively. For example, to test
 LLDB against 32-bit binaries built with a custom version of clang, do:
 
 ```
-$ cmake -DLLDB_TEST_USER_ARGS="-A;i386;-C;/path/to/custom/clang" -G Ninja
+$ cmake -DLLDB_TEST_USER_ARGS="--triple;i386-unknown-linux-gnu;-C;/path/to/custom/clang" -G Ninja
 $ ninja check-lldb
 ```
 
-Note that multiple `-A` and `-C` flags can be specified to
-`LLDB_TEST_USER_ARGS`.
+Note that multiple `-C` flags can be specified to `LLDB_TEST_USER_ARGS`.
 
 If you want to change the LLDB settings that tests run with then you can set
 the `--setting` option of the test runner via this same variable. For example

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -8,14 +8,14 @@ common behavior for unitest.TestCase.setUp/tearDown implemented in this file.
 entire of part of the test suite .  Example:
 
 # Exercises the test suite in the types directory....
-/Volumes/data/lldb/svn/ToT/test $ ./dotest.py -A x86_64 types
+/Volumes/data/lldb/svn/ToT/test $ ./dotest.py types
 ...
 
 Session logs for test failures/errors/unexpected successes will go into directory '2012-05-16-13_35_42'
-Command invoked: python ./dotest.py -A x86_64 types
+Command invoked: python ./dotest.py types
 compilers=['clang']
 
-Configuration: arch=x86_64 compiler=clang
+Configuration: compiler=clang
 ----------------------------------------------------------------------
 Collected 72 tests
 
@@ -1586,18 +1586,6 @@ class Base(unittest.TestCase):
                 return True
 
         return False
-
-    def getRunOptions(self):
-        """Command line option for -A and -C to run this test again, called from
-        self.dumpSessionInfo()."""
-        arch = self.getArchitecture()
-        comp = self.getCompiler()
-        option_str = ""
-        if arch:
-            option_str = "-A " + arch
-        if comp:
-            option_str += " -C " + comp
-        return option_str
 
     def getVariant(self, variant_name):
         method = getattr(self, self.testMethodName)

--- a/lldb/test/API/CMakeLists.txt
+++ b/lldb/test/API/CMakeLists.txt
@@ -35,7 +35,7 @@ set(LLDB_TEST_TRIPLE
 set(LLDB_TEST_USER_ARGS
   ""
   CACHE STRING "Specify additional arguments to pass to test runner. Separate \
-items with \";\". For example: '-C;gcc;-C;clang;-A;i386;-A;x86_64'")
+items with \";\". For example: '-C;gcc;-C;clang'")
 
 set(LLDB_TEST_COMMON_ARGS_VAR
   -u CXXFLAGS


### PR DESCRIPTION
-A was for setting the architecture. 6175a4d455e170fa947859e2a5952c89585150aa removed it in favour of a triple option.

This change removes some remaining references to -A.

f8a92af893eee7ac7ffda93c24b9e69df506148f removed the only use of getRunOptions some time ago.

A few references remain to -A, but comments and old example files only. Nothing that developers are going to see without digging for it. Plus I don't know what some of them refer to, so it's safer just to leave it in.