### PR TITLE
[lldb] Fix crash when adding a python ParsedCommand

### DIFF
--- a/lldb/source/Commands/CommandObjectCommands.cpp
+++ b/lldb/source/Commands/CommandObjectCommands.cpp
@@ -1949,6 +1949,7 @@ public:
               Status::FromErrorStringWithFormatv("Argument definition element "
                                                  "{0} is not an array",
                                                  counter);
+          return false;
         }
         
         args_array->ForEach(args_adder);

--- a/lldb/test/API/commands/command/script/add/TestAddParsedCommand.py
+++ b/lldb/test/API/commands/command/script/add/TestAddParsedCommand.py
@@ -331,3 +331,8 @@ class ParsedCommandTestCase(TestBase):
             results.count("SECOND_ARG"), 2, "Passed second arg to both commands"
         )
         self.assertEqual(results.count("THIRD_ARG"), 1, "Passed third arg in repeat")
+
+        # Verify lldb did not register the 'fail_cmd'.
+        self.expect(
+            "fail_cmd", substrs=["'fail_cmd' is not a valid command"], error=True
+        )

--- a/lldb/test/API/commands/command/script/add/test_commands.py
+++ b/lldb/test/API/commands/command/script/add/test_commands.py
@@ -254,6 +254,19 @@ class TwoArgGroupsCommand(ReportingCmd):
         return self.help_string
 
 
+class FailCommand(ParsedCommand):
+    program: str = "fail_cmd"
+
+    def __call__(self, debugger, args_list, exe_ctx, result):
+        result.AppendMessage("hello world")
+
+    def setup_command_definition(self):
+        parser = self.get_parser()
+        # add_argument_set is expecting a list not dict.
+        parser.add_argument_set(
+            parser.make_argument_element(lldb.eArgTypeSymbol, "plain")
+        )
+
 def __lldb_init_module(debugger, dict):
     # Register all classes that have a register_lldb_command method
     for _name, cls in inspect.getmembers(sys.modules[__name__]):


### PR DESCRIPTION
The expected result of `ParsedCommand.get_args_definition` is a List of Lists and should not crash when it is not the case.