### PR TITLE
[libc] Avoid add_with_carry name shadowing issue

### DIFF
--- a/libc/src/__support/big_int.h
+++ b/libc/src/__support/big_int.h
@@ -124,10 +124,14 @@ LIBC_INLINE constexpr DoubleWide<word> mul2(word a, word b) {
     word no_carry = 0;
     word carry = 0;
     [[maybe_unused]] word _ = 0; // unused carry variable.
-    lo_digit = add_with_carry<word>(lo_digit, shiftl(step2), no_carry, carry);
-    hi_digit = add_with_carry<word>(hi_digit, shiftr(step2), carry, _);
-    lo_digit = add_with_carry<word>(lo_digit, shiftl(step3), no_carry, carry);
-    hi_digit = add_with_carry<word>(hi_digit, shiftr(step3), carry, _);
+    lo_digit = LIBC_NAMESPACE::add_with_carry<word>(lo_digit, shiftl(step2),
+                                                    no_carry, carry);
+    hi_digit =
+        LIBC_NAMESPACE::add_with_carry<word>(hi_digit, shiftr(step2), carry, _);
+    lo_digit = LIBC_NAMESPACE::add_with_carry<word>(lo_digit, shiftl(step3),
+                                                    no_carry, carry);
+    hi_digit =
+        LIBC_NAMESPACE::add_with_carry<word>(hi_digit, shiftr(step3), carry, _);
     return DoubleWide<word>(lo_digit, hi_digit);
   }
 }


### PR DESCRIPTION
Use fully namespace-qualified calls to the scalar versions of `add_with_carry` in `big_int.h` to avoid build errors due to function-name shadowing issues on MSVC when it is configured without using 2-phase lookup for templates.

This disambiguates the 2 templated functions:
  - `add_with_carry(dst, rhs)` in the `multiword` namespace
  - `add_with_carry(a, b, carry_in, carry_out)` in the outer libc namespace