### PR TITLE
[lldb] Fix _cplusplus typo that disabled all SB API deprecation warnings

### DIFF
--- a/lldb/include/lldb/API/SBDefines.h
+++ b/lldb/include/lldb/API/SBDefines.h
@@ -32,7 +32,7 @@
 // Don't add the deprecated attribute when generating the bindings or when
 // building for anything older than C++14 which is the first version that
 // supports the attribute.
-#if defined(SWIG) || _cplusplus < 201402L
+#if defined(SWIG) || __cplusplus < 201402L
 #undef LLDB_DEPRECATED
 #undef LLDB_DEPRECATED_FIXME
 #define LLDB_DEPRECATED(MSG)


### PR DESCRIPTION
The guard used `_cplusplus` instead of `__cplusplus`. Since `_cplusplus` is never defined it expanded to 0, so `0 < 201402L` was always true and the header unconditionally redefined LLDB_DEPRECATED and LLDB_DEPRECATED_FIXME to nothing.

The result was that every deprecation marker in the SB API was always empty. This bug existed since the introduction of the LLDB_DEPRECATED macro in 2279f77d2855d9caa0ece466462d34bcfdf4fb3d .