### PR TITLE
[lldb] Make SBFile::operator bool explicit

### DIFF
--- a/lldb/include/lldb/API/SBFile.h
+++ b/lldb/include/lldb/API/SBFile.h
@@ -43,7 +43,7 @@ public:
   bool IsValid() const;
   SBError Close();
 
-  operator bool() const;
+  explicit operator bool() const;
 #ifndef SWIG
   bool operator!() const;
 #endif


### PR DESCRIPTION
Every other SB class in the API declares `explicit operator bool()`. SBFile was the only one with an implicit conversion, which in general is not something we want.