### PR TITLE
[Support] Fix format_object streaming ambiguity in Objective-C++ mode

### DIFF
--- a/llvm/include/llvm/Support/Format.h
+++ b/llvm/include/llvm/Support/Format.h
@@ -76,8 +76,16 @@ public:
 
 template <typename... Ts>
 raw_ostream &operator<<(raw_ostream &OS, format_object<Ts...> Fmt) {
-  OS <<
-      [&Fmt](char *Buf, size_t Size) -> int { return Fmt.snprint(Buf, Size); };
+  // Stream through an explicitly-typed function_ref. Passing the lambda
+  // directly is ambiguous when block pointer conversions are enabled due to a
+  // competing raw_ostream::operator<<(const void *) candidate. This ambiguity
+  // affects the Swift compiler because it contains Swift code that
+  // interoperates with C++ code that instantiates this template, and Swift's
+  // C++ interoperability enables block pointer conversions.
+  auto Print = [&Fmt](char *Buf, size_t Size) -> int {
+    return Fmt.snprint(Buf, Size);
+  };
+  OS << function_ref<int(char *, size_t)>(Print);
   return OS;
 }
 


### PR DESCRIPTION
Upstreams https://github.com/swiftlang/llvm-project/pull/13625.

Streaming a format_object writes it through a temporary lambda. Swift's C++ interoperability enables block pointer conversions, which makes `raw_ostream::operator<<(const void *)` a viable candidate alongside `operator<<(function_ref<size_t(char *, size_t)>)`, so overload resolution is ambiguous. This breaks the Swift compiler because it contains Swift code that interoperates with C++ code that instantiates this template.

Bind the lambda to an explicit function_ref before streaming so the intended overload is selected unambiguously in every language mode.

Assisted-by: Claude Code