### PR TITLE
[clang-format] Preserve compact TableGen bit ranges

### DIFF
--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -5208,6 +5208,12 @@ bool TokenAnnotator::spaceRequiredBefore(const AnnotatedLine &Line,
   const bool IsVerilog = Style.isVerilog();
   assert(!IsVerilog || !IsCpp);
 
+  // Keep TableGen bit ranges such as {24-20} compact.
+  if (Style.isTableGen() && Left.is(tok::numeric_constant) &&
+      Right.is(tok::numeric_constant) && Right.TokenText.starts_with("-")) {
+    return false;
+  }
+
   // Never ever merge two words.
   if (Keywords.isWordLike(Right, IsVerilog) &&
       Keywords.isWordLike(Left, IsVerilog)) {

--- a/clang/unittests/Format/FormatTestTableGen.cpp
+++ b/clang/unittests/Format/FormatTestTableGen.cpp
@@ -216,6 +216,13 @@ TEST_F(FormatTestTableGen, ValueSuffix) {
                "}");
 }
 
+TEST_F(FormatTestTableGen, BitRanges) {
+  verifyFormat("def Ranges {\n"
+               "  let Inst{24-20} = rs2;\n"
+               "  let Inst{19-15, 11-7} = rs1;\n"
+               "}");
+}
+
 TEST_F(FormatTestTableGen, PasteOperator) {
   verifyFormat("def Paste#\"Operator\" { string Paste = \"Paste\"#operator; }");
 


### PR DESCRIPTION
Clang-format currently changes compact TableGen bit ranges such as
`Inst{24-20}` to `Inst{24 -20}`, which produces an odd-looking range.

Keep hyphenated bit ranges compact in TableGen. Add coverage for both a single
range and a comma-separated range list.

Tests:

- `build-pr/tools/clang/unittests/Format/FormatTests` (1278 passed)
- `ninja -C build-pr check-clang-format` (33 passed)
- `python3 clang/tools/clang-format/git-clang-format --binary build-pr/bin/clang-format --diff origin/main`
- `git diff --check origin/main...HEAD`

Fixes #177051

Assisted-by: OpenAI Codex
