### PR TITLE
[OMP] Remove omp_get_ancestor_thread_num and omp_get_team_size in ompx.h

### DIFF
--- a/openmp/runtime/src/include/ompx.h.var
+++ b/openmp/runtime/src/include/ompx.h.var
@@ -25,17 +25,6 @@ static inline uint32_t __warpSize(void) {
 #endif
 }
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-int omp_get_ancestor_thread_num(int);
-int omp_get_team_size(int);
-
-#ifdef __cplusplus
-}
-#endif
-
 /// Target kernel language extensions
 ///
 /// These extensions exist for the host to allow fallback implementations,


### PR DESCRIPTION
These two routines are standardized and already exist in omp.h.