### PR TITLE
[TailCallElim] Only suppress tail call elim for cold calls in cold funcs

### DIFF
--- a/llvm/lib/Transforms/Scalar/TailRecursionElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/TailRecursionElimination.cpp
@@ -114,10 +114,6 @@ static bool shouldDisableTailCallsForCold(const CallBase *CB,
   if (CB && CB->isMustTailCall())
     return false;
 
-  if (CB && (CB->hasFnAttr(Attribute::Cold) ||
-             CB->getCallingConv() == CallingConv::Cold))
-    return true;
-
   if (Caller && (Caller->hasFnAttribute(Attribute::Cold) ||
                  Caller->getCallingConv() == CallingConv::Cold))
     return true;
@@ -125,9 +121,22 @@ static bool shouldDisableTailCallsForCold(const CallBase *CB,
   if (!PSI || !PSI->hasProfileSummary())
     return false;
 
-  if (CB && BFI &&
-      (PSI->isColdCallSite(*CB, BFI) || PSI->isColdBlock(CB->getParent(), BFI)))
-    return true;
+  // We require both the function entry and the call site/block/callee to be
+  // cold.
+  // 1. Checking that the function entry is cold ensures we don't disable tail
+  //    call elimination in hot functions (with calls on cold conditional
+  //    paths), which would force stack frame setup and teardown on hot paths.
+  // 2. Checking that the call site/block/callee is also cold ensures that if a
+  //    function has a cold entry count but contains a hot loop, we don't
+  //    disable tail call elimination for calls within that hot loop.
+  if (Caller && PSI->isFunctionEntryCold(Caller) && CB) {
+    if (CB->hasFnAttr(Attribute::Cold) ||
+        CB->getCallingConv() == CallingConv::Cold)
+      return true;
+    if (BFI && (PSI->isColdCallSite(*CB, BFI) ||
+                PSI->isColdBlock(CB->getParent(), BFI)))
+      return true;
+  }
 
   return false;
 }

--- a/llvm/test/Transforms/TailCallElim/disable-tail-call-elim-for-cold-calls.ll
+++ b/llvm/test/Transforms/TailCallElim/disable-tail-call-elim-for-cold-calls.ll
@@ -5,20 +5,18 @@ declare void @cold_callee() cold
 declare void @normal_callee()
 declare coldcc void @coldcc_callee()
 
-; Check that a call to a cold callee is not marked as tail when the flag is enabled.
+; Check that a call to a cold callee inside a non-cold caller IS marked as tail.
 define void @test_cold_callee() {
 ; CHECK-LABEL: @test_cold_callee(
-; DISABLED: call void @cold_callee()
-; ENABLED: tail call void @cold_callee()
+; CHECK: tail call void @cold_callee()
   call void @cold_callee()
   ret void
 }
 
-; Check that a call to a callee with coldcc is not marked as tail when the flag is enabled.
+; Check that a call to a callee with coldcc inside a non-cold caller IS marked as tail.
 define void @test_coldcc_callee() {
 ; CHECK-LABEL: @test_coldcc_callee(
-; DISABLED: call coldcc void @coldcc_callee()
-; ENABLED: tail call coldcc void @coldcc_callee()
+; CHECK: tail call coldcc void @coldcc_callee()
   call coldcc void @coldcc_callee()
   ret void
 }
@@ -41,11 +39,10 @@ define coldcc void @test_coldcc_caller() {
   ret void
 }
 
-; Check that a callsite with coldcc is not marked as tail when the flag is enabled.
+; Check that a callsite with coldcc inside a non-cold caller IS marked as tail.
 define void @test_coldcc_callsite() {
 ; CHECK-LABEL: @test_coldcc_callsite(
-; DISABLED: call coldcc void @normal_callee()
-; ENABLED: tail call coldcc void @normal_callee()
+; CHECK: tail call coldcc void @normal_callee()
   call coldcc void @normal_callee()
   ret void
 }
@@ -78,12 +75,65 @@ if.else:
   ret i32 %call
 }
 
-; Check that a call inside a basic block verified cold via ProfileSummary and BFI (function_entry_count = 0) is not marked as tail when the flag is enabled.
+; Check that a call inside a basic block verified cold via ProfileSummary and BFI in a function with cold entry count (function_entry_count = 0) is not marked as tail when the flag is enabled.
 define void @test_profile_cold_block() !prof !14 {
 ; CHECK-LABEL: @test_profile_cold_block(
 ; DISABLED: call void @normal_callee()
 ; ENABLED: tail call void @normal_callee()
   call void @normal_callee()
+  ret void
+}
+
+; Check that calling a cold callee inside a function with cold entry count is not marked as tail when the flag is enabled.
+define void @test_profile_cold_caller_cold_callee() !prof !14 {
+; CHECK-LABEL: @test_profile_cold_caller_cold_callee(
+; DISABLED: call void @cold_callee()
+; ENABLED: tail call void @cold_callee()
+  call void @cold_callee()
+  ret void
+}
+
+; Check that a call inside a cold block within a hot caller (function_entry_count = 1000) IS marked as tail.
+define void @test_hot_caller_cold_block(i1 %cond) !prof !15 {
+; CHECK-LABEL: @test_hot_caller_cold_block(
+; CHECK: tail call void @normal_callee()
+entry:
+  br i1 %cond, label %if.then, label %if.else, !prof !16
+
+if.then:
+  ret void
+
+if.else:
+  call void @normal_callee()
+  ret void
+}
+
+; Check that calling a cold callee within a hot caller (function_entry_count = 1000) IS marked as tail.
+define void @test_hot_caller_cold_callee() !prof !15 {
+; CHECK-LABEL: @test_hot_caller_cold_callee(
+; CHECK: tail call void @cold_callee()
+  call void @cold_callee()
+  ret void
+}
+
+; Check that a call inside a hot loop within a function with a cold entry count (function_entry_count = 1) IS marked as tail.
+define void @test_cold_caller_hot_loop(i32 %n) !prof !17 {
+; CHECK-LABEL: @test_cold_caller_hot_loop(
+; CHECK: tail call void @normal_callee()
+entry:
+  br label %loop
+
+loop:
+  %i = phi i32 [ 0, %entry ], [ %inc, %loop.body ]
+  %inc = add i32 %i, 1
+  %cmp = icmp slt i32 %inc, %n
+  br i1 %cmp, label %loop.body, label %exit, !prof !18
+
+loop.body:
+  call void @normal_callee()
+  br label %loop
+
+exit:
   ret void
 }
 
@@ -103,3 +153,7 @@ define void @test_profile_cold_block() !prof !14 {
 !12 = !{i32 999000, i64 100, i32 1}
 !13 = !{i32 999999, i64 1, i32 2}
 !14 = !{!"function_entry_count", i64 0}
+!15 = !{!"function_entry_count", i64 1000}
+!16 = !{!"branch_weights", i32 1000, i32 0}
+!17 = !{!"function_entry_count", i64 1}
+!18 = !{!"branch_weights", i32 1000, i32 1}


### PR DESCRIPTION
Modifies the optional suppression of tail call elimination added in
PR209642 to only apply when the function entry is also cold. Otherwise
the tail call elimination on a cold path within a hot function may force
unnecessary stack frame setup and teardown for the calling convention
into the hot entry block.
