### PR TITLE
[Modules] Exclude InstrumentorRuntimeHelper.h from LLVM_Transforms

### DIFF
--- a/llvm/include/module.modulemap
+++ b/llvm/include/module.modulemap
@@ -357,6 +357,10 @@ module LLVM_Transforms {
   // Requires DEBUG_TYPE to be defined by including file.
   exclude header "llvm/Transforms/Utils/InstructionWorklist.h"
 
+  // Not a normal header: it is read as a string at build time and embedded
+  // into the instrumentor runtime.
+  exclude header "llvm/Transforms/IPO/InstrumentorRuntimeHelper.h"
+
   textual header "llvm/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizerIRValues.def"
 }
 


### PR DESCRIPTION
7964b66bf55d53f7a528a8153c005bee0614a3d7
(https://github.com/llvm/llvm-project/pull/199329) added `llvm/Transforms/IPO/InstrumentorRuntimeHelper.h` under the umbrella directory of the `LLVM_Transforms` clang module. That header is not a normal C++ API header: it is read as a string at build time (via `file(READ)` in CMake) and embedded into the instrumentor runtime, and it includes the C standard headers
`<stdint.h>`/`<string.h>` inside an `extern "C"` block. In Swift's C++ interoperability mode, the includes resolve to the C++ `std_stdint_h`/`std_string_h` modules, which cannot be imported within an `extern "C"` linkage specification.

```
InstrumentorRuntimeHelper.h:21:1: error: import of C++ module 'std_stdint_h' appears within extern "C" language linkage specification
 17 | #ifdef __cplusplus
 18 | extern "C" {
    | `- note: extern "C" language linkage specification begins here
 19 | #endif
 20 |
 21 | #include <stdint.h>
    | `- error: import of C++ module 'std_stdint_h' appears within extern "C" language linkage specification
```

Exclude the header from `LLVM_Transforms`, mirroring the existing exclusion of `InstructionWorklist.h`. Since the header is only consumed as an embedded string and is not included by any other LLVM header, it never needs to be part of the module's API surface.