### PR TITLE
[NVPTX] Cleanup Subtarget predicates (NFC)

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
@@ -560,8 +560,7 @@ NVPTXTargetLowering::NVPTXTargetLowering(const NVPTXTargetMachine &TM,
     case ISD::FMINIMUM:
     case ISD::FMAXIMUMNUM:
     case ISD::FMINIMUMNUM:
-      IsOpSupported &=
-          STI.hasFeature(NVPTX::SM80) && STI.hasFeature(NVPTX::PTX70);
+      IsOpSupported &= STI.hasFeature(NVPTX::SM80);
       break;
     case ISD::FEXP2:
     case ISD::FTANH:
@@ -985,7 +984,7 @@ NVPTXTargetLowering::NVPTXTargetLowering(const NVPTXTargetMachine &TM,
   if (!STI.hasFeature(NVPTX::SM80) || !STI.hasFeature(NVPTX::PTX71)) {
     setOperationAction(ISD::BF16_TO_FP, MVT::f32, Expand);
   }
-  if (!STI.hasFeature(NVPTX::SM90) || !STI.hasFeature(NVPTX::PTX78)) {
+  if (!STI.hasFeature(NVPTX::SM90)) {
     for (MVT VT : {MVT::bf16, MVT::f32, MVT::f64}) {
       setOperationAction(ISD::FP_EXTEND, VT, Custom);
       setOperationAction(ISD::FP_ROUND, VT, Custom);
@@ -999,7 +998,7 @@ NVPTXTargetLowering::NVPTXTargetLowering(const NVPTXTargetMachine &TM,
 
   // sm_80 only has conversions between f32 and bf16. Custom lower all other
   // bf16 conversions.
-  if (!STI.hasFeature(NVPTX::SM90) || !STI.hasFeature(NVPTX::PTX78)) {
+  if (!STI.hasFeature(NVPTX::SM90)) {
     for (MVT VT : {MVT::i1, MVT::i16, MVT::i32, MVT::i64}) {
       setOperationAction(
           {ISD::SINT_TO_FP, ISD::UINT_TO_FP, ISD::FP_TO_SINT, ISD::FP_TO_UINT},
@@ -1091,8 +1090,7 @@ NVPTXTargetLowering::NVPTXTargetLowering(const NVPTXTargetMachine &TM,
       AddPromotedToType(Op, MVT::bf16, MVT::f32);
     setOperationAction(Op, MVT::v2f32, Expand);
   }
-  bool SupportsF32MinMaxNaN =
-      STI.hasFeature(NVPTX::SM80) && STI.hasFeature(NVPTX::PTX70);
+  bool SupportsF32MinMaxNaN = STI.hasFeature(NVPTX::SM80);
   for (const auto &Op : {ISD::FMINIMUM, ISD::FMAXIMUM}) {
     setOperationAction(Op, MVT::f32, SupportsF32MinMaxNaN ? Legal : Expand);
     setFP16OperationAction(Op, MVT::f16, Legal, Expand);
@@ -2361,7 +2359,7 @@ SDValue NVPTXTargetLowering::PromoteBinOpIfF32FTZ(SDValue Op,
 
 SDValue NVPTXTargetLowering::LowerINT_TO_FP(SDValue Op,
                                             SelectionDAG &DAG) const {
-  assert(!STI.hasFeature(NVPTX::SM90) || !STI.hasFeature(NVPTX::PTX78));
+  assert(!STI.hasFeature(NVPTX::SM90));
 
   if (Op.getValueType() == MVT::bf16) {
     SDLoc Loc(Op);
@@ -2377,7 +2375,7 @@ SDValue NVPTXTargetLowering::LowerINT_TO_FP(SDValue Op,
 
 SDValue NVPTXTargetLowering::LowerFP_TO_INT(SDValue Op,
                                             SelectionDAG &DAG) const {
-  assert(!STI.hasFeature(NVPTX::SM90) || !STI.hasFeature(NVPTX::PTX78));
+  assert(!STI.hasFeature(NVPTX::SM90));
 
   if (Op.getOperand(0).getValueType() == MVT::bf16) {
     SDLoc Loc(Op);
@@ -2397,24 +2395,22 @@ SDValue NVPTXTargetLowering::LowerFP_ROUND(SDValue Op,
   EVT WideVT = Wide.getValueType();
   if (NarrowVT.getScalarType() == MVT::bf16) {
     const TargetLowering *TLI = STI.getTargetLowering();
-    if (!STI.hasFeature(NVPTX::SM80) || !STI.hasFeature(NVPTX::PTX70)) {
+    if (!STI.hasFeature(NVPTX::SM80)) {
       return TLI->expandFP_ROUND(Op.getNode(), DAG);
     }
-    if (!STI.hasFeature(NVPTX::SM90) || !STI.hasFeature(NVPTX::PTX78)) {
-      // This combination was the first to support f32 -> bf16.
-      if (STI.hasFeature(NVPTX::SM80) && STI.hasFeature(NVPTX::PTX70)) {
-        if (WideVT.getScalarType() == MVT::f32) {
-          return Op;
-        }
-        if (WideVT.getScalarType() == MVT::f64) {
-          SDLoc Loc(Op);
-          // Round-inexact-to-odd f64 to f32, then do the final rounding using
-          // the hardware f32 -> bf16 instruction.
-          SDValue rod = TLI->expandRoundInexactToOdd(
-              WideVT.changeElementType(*DAG.getContext(), MVT::f32), Wide, Loc,
-              DAG);
-          return DAG.getFPExtendOrRound(rod, Loc, NarrowVT);
-        }
+    if (!STI.hasFeature(NVPTX::SM90)) {
+      // sm_80 was the first architecture to support f32 -> bf16.
+      if (WideVT.getScalarType() == MVT::f32) {
+        return Op;
+      }
+      if (WideVT.getScalarType() == MVT::f64) {
+        SDLoc Loc(Op);
+        // Round-inexact-to-odd f64 to f32, then do the final rounding using
+        // the hardware f32 -> bf16 instruction.
+        SDValue rod = TLI->expandRoundInexactToOdd(
+            WideVT.changeElementType(*DAG.getContext(), MVT::f32), Wide, Loc,
+            DAG);
+        return DAG.getFPExtendOrRound(rod, Loc, NarrowVT);
       }
       return TLI->expandFP_ROUND(Op.getNode(), DAG);
     }
@@ -2435,8 +2431,7 @@ SDValue NVPTXTargetLowering::LowerFP_EXTEND(SDValue Op,
       SDLoc Loc(Op);
       return DAG.getNode(ISD::BF16_TO_FP, Loc, WideVT, Narrow);
     }
-    if (WideVT.getScalarType() == MVT::f64 &&
-        (!STI.hasFeature(NVPTX::SM90) || !STI.hasFeature(NVPTX::PTX78))) {
+    if (WideVT.getScalarType() == MVT::f64 && !STI.hasFeature(NVPTX::SM90)) {
       EVT F32 = NarrowVT.changeElementType(*DAG.getContext(), MVT::f32);
       SDLoc Loc(Op);
       if (STI.hasFeature(NVPTX::SM80) && STI.hasFeature(NVPTX::PTX71)) {
@@ -7511,8 +7506,7 @@ NVPTXTargetLowering::shouldExpandAtomicRMWInIR(const AtomicRMWInst *AI) const {
         STI.hasFeature(NVPTX::SM70) && STI.hasFeature(NVPTX::PTX63))
       return AtomicExpansionKind::None;
 
-    if (Ty->isBFloatTy() && STI.hasFeature(NVPTX::SM90) &&
-        STI.hasFeature(NVPTX::PTX78))
+    if (Ty->isBFloatTy() && STI.hasFeature(NVPTX::SM90))
       return AtomicExpansionKind::None;
 
     if (Ty->isDoubleTy() && STI.hasAtomAddF64())

--- a/llvm/lib/Target/NVPTX/NVPTXInstrInfo.td
+++ b/llvm/lib/Target/NVPTX/NVPTXInstrInfo.td
@@ -125,35 +125,118 @@ def AddrSpaceSharedCluster : NVPTXAddressSpace<"ADDRESS_SPACE_SHARED_CLUSTER",
 // NVPTX Instruction Predicate Definitions
 //===----------------------------------------------------------------------===//
 
-// Helper predicate to call a subtarget method.
-class callSubtarget<string SubtargetMethod> : Predicate<"Subtarget->" # SubtargetMethod # "()">;
+class PredAnd<list<Predicate> ps>
+  : Predicate<"(" # !interleave(!foreach(p, ps, "(" # p.CondString # ")"),
+                                " && ") # ")">;
+class PredOr<list<Predicate> ps>
+  : Predicate<"(" # !interleave(!foreach(p, ps, "(" # p.CondString # ")"),
+                                " || ") # ")">;
+class PredNot<Predicate p> : Predicate<"!(" # p.CondString # ")">;
 
-def hasAtomAddF64 : Predicate<"Subtarget->hasAtomAddF64()">;
-def hasAtomScope : Predicate<"Subtarget->hasAtomScope()">;
-def hasAtomBitwise64 : Predicate<"Subtarget->hasAtomBitwise64()">;
-def hasAtomMinMax64 : Predicate<"Subtarget->hasAtomMinMax64()">;
-def hasAtomSwap128 : Predicate<"Subtarget->hasAtomSwap128()">;
-def hasClusters : Predicate<"Subtarget->hasClusters()">;
-def hasPTXASUnreachableBug : Predicate<"Subtarget->hasPTXASUnreachableBug()">;
-def noPTXASUnreachableBug : Predicate<"!Subtarget->hasPTXASUnreachableBug()">;
+class SubtargetPredicate : Predicate<"Subtarget->" # NAME # "()">;
+
+def hasAtomAddF64 : SubtargetPredicate;
+def hasAtomScope : SubtargetPredicate;
+def hasAtomBitwise64 : SubtargetPredicate;
+def hasAtomMinMax64 : SubtargetPredicate;
+def hasAtomSwap128 : SubtargetPredicate;
+def hasClusters : SubtargetPredicate;
+def hasPTXASUnreachableBug : SubtargetPredicate;
+def noPTXASUnreachableBug : PredNot<hasPTXASUnreachableBug>;
 def hasOptEnabled : Predicate<"TM.getOptLevel() != CodeGenOptLevel::None">;
 
 def doF32FTZ : Predicate<"useF32FTZ()">;
-def doNoF32FTZ : Predicate<"!useF32FTZ()">;
+def doNoF32FTZ : PredNot<doF32FTZ>;
 def doRsqrtOpt : Predicate<"doRsqrtOpt()">;
 def doMADWideOpt : Predicate<"doMADWideOpt()">;
 
-def hasHWROT32 : Predicate<"Subtarget->hasHWROT32()">;
-def noHWROT32 : Predicate<"!Subtarget->hasHWROT32()">;
-def hasDotInstructions : Predicate<"Subtarget->hasDotInstructions()">;
-def hasF32x2Instructions : Predicate<"Subtarget->hasF32x2Instructions()">;
+def hasHWROT32 : SubtargetPredicate;
+def noHWROT32 : PredNot<hasHWROT32>;
+def hasDotInstructions : SubtargetPredicate;
+def hasF32x2Instructions : SubtargetPredicate;
 
 // non-sync shfl instructions are not available on sm_70+ in PTX6.4+
-def hasSHFL : Predicate<"!(Subtarget->hasFeature(NVPTX::SM70)"
-                          "&& Subtarget->hasFeature(NVPTX::PTX64))">;
+def hasSHFL : PredNot<PredAnd<[SM70, PTX64]>>;
 
-def useFP16Math: Predicate<"Subtarget->allowFP16Math()">;
-def hasBF16Math: Predicate<"Subtarget->hasBF16Math()">;
+def allowFP16Math : SubtargetPredicate;
+def hasBF16Math : SubtargetPredicate;
+
+def hasTcgen05InstSupport : SubtargetPredicate;
+def hasTensormapReplaceSupport : SubtargetPredicate;
+
+// Checks Rubin family extensions support.
+//  - TMA S2G im2col_w mode support
+//  - tcgen05.commit shared mem A variants.
+def hasRubinFamilySupport : PredOr<[SM107f]>;
+
+// Checks tcgen05.shift instruction support.
+def hasTcgen05ShiftSupport : PredOr<[SM100a, SM103a, SM110a]>;
+
+def hasTcgen05MMAScaleInputDImm : PredOr<[SM100f]>;
+def hasTcgen05MMAI8Kind : PredOr<[SM100a, SM110a]>;
+def hasTcgen05MMASparseMxf4 : PredOr<[SM100a, SM103a, SM110a]>;
+def hasTcgen05MMASparseMxf4nvf4
+  : PredAnd<[PTX87, PredOr<[SM100a, SM103a, SM110a]>]>;
+def hasTcgen05LdRedSupport : PredAnd<[PTX88, PredOr<[SM103f, SM110f]>]>;
+
+def hasReduxSyncF32 : PredOr<[SM100f]>;
+
+def hasMMABlockScale : PredOr<[SM120f]>;
+def hasMMASparseBlockScaleF4 : PredOr<[SM120a, SM121a]>;
+def hasMMAWithMXF4NVF4Scale4xE8M0 : PredAnd<[PTX91, PredOr<[SM120f]>]>;
+def hasMMASparseWithMXF4NVF4Scale4xE8M0
+  : PredAnd<[PTX91, PredOr<[SM120a, SM121a]>]>;
+
+// Checks support for following in TMA:
+//  - cta_group::1/2 support
+//  - im2col_w/w_128 mode support
+//  - tile_gather4 mode support
+//  - tile_scatter4 mode support
+def hasTMABlackwellSupport : PredOr<[SM100f, SM110f]>;
+
+// Checks support for conversions involving e4m3x2 and e5m2x2. These arrived
+// with sm_90 in PTX 7.8, which SM90 already implies, and were extended to
+// sm_89 in PTX 8.1.
+def hasFP8ConversionSupport : PredOr<[SM90, PredAnd<[SM89, PTX81]>]>;
+
+// Checks support for conversions involving the following types:
+// - e2m3x2/e3m2x2
+// - e2m1x2
+// - ue8m0x2
+def hasNarrowFPConversionSupport : PredOr<[SM100f, SM110f, SM120f]>;
+
+// Checks support for conversions involving the following types:
+// - bf16x2 -> f8x2
+// - f16x2 -> f6x2
+// - bf16x2 -> f6x2
+// - f16x2 -> f4x2
+// - bf16x2 -> f4x2
+def hasFP16X2ToNarrowFPConversionSupport
+  : PredAnd<[PTX91, PredOr<[SM100f, SM110f, SM120f]>]>;
+
+def hasS2F6X2ConversionSupport
+  : PredAnd<[PTX91, PredOr<[SM100a, SM103a, SM110a, SM120a, SM121a]>]>;
+
+// Checks support for conversions from narrow FP types to bf16x2.
+def hasNarrowFPToBF16x2ConversionSupport
+  : PredAnd<[PTX92, PredOr<[SM100f, SM110f, SM120f]>]>;
+
+// Checks support for conversions involving ue5m3x2.
+def hasUE5M3TypeSupport : PredAnd<[PTX94, PredOr<[SM107f]>]>;
+
+def hasTensormapReplaceSwizzleAtomicitySupport
+  : PredOr<[PredAnd<[PTX88, PredOr<[SM100f, SM110f, SM120f]>]>,
+            PredAnd<[PTX87, PredOr<[SM100a, SM110a, SM120a]>]>]>;
+
+def hasClusterLaunchControlTryCancelMulticastSupport
+  : PredOr<[SM100f, SM110f, SM120f]>;
+
+def hasSetMaxNRegSupport : PredOr<[SM90a, SM100f, SM110f, SM120f]>;
+
+def hasLdStmatrixBlackwellSupport : PredOr<[SM100f, SM110f, SM120f]>;
+
+def hasConvertWithStochasticRounding
+  : PredAnd<[PTX87, PredOr<[SM100a, SM103a]>]>;
 
 
 //===----------------------------------------------------------------------===//
@@ -345,7 +428,7 @@ multiclass FMINIMUMMAXIMUM<string OpcStr, bit NaN, SDPatternOperator OpNode> {
                (ins FTZFlag:$ftz),
                OpcStr # "$ftz" # nan_str # ".f16",
                [(set f16:$dst, (OpNode f16:$a, f16:$b))]>,
-               Requires<[useFP16Math]>;
+               Requires<[allowFP16Math]>;
 
    def _f16x2_rr :
      BasicFlagsNVPTXInst<(outs B32:$dst),
@@ -353,19 +436,19 @@ multiclass FMINIMUMMAXIMUM<string OpcStr, bit NaN, SDPatternOperator OpNode> {
                (ins FTZFlag:$ftz),
                OpcStr # "$ftz" # nan_str # ".f16x2",
                [(set v2f16:$dst, (OpNode v2f16:$a, v2f16:$b))]>,
-               Requires<[useFP16Math, SM80, PTX70]>;
+               Requires<[allowFP16Math, SM80]>;
    def _bf16_rr :
      BasicNVPTXInst<(outs B16:$dst),
                (ins B16:$a, B16:$b),
                OpcStr # nan_str # ".bf16",
                [(set bf16:$dst, (OpNode bf16:$a, bf16:$b))]>,
-               Requires<[hasBF16Math, SM80, PTX70]>;
+               Requires<[hasBF16Math, SM80]>;
    def _bf16x2_rr :
      BasicNVPTXInst<(outs B32:$dst),
                (ins B32:$a, B32:$b),
                OpcStr # nan_str # ".bf16x2",
                [(set v2bf16:$dst, (OpNode v2bf16:$a, v2bf16:$b))]>,
-               Requires<[hasBF16Math, SM80, PTX70]>;
+               Requires<[hasBF16Math, SM80]>;
 }
 
 // Template for 3-input minimum/maximum instructions
@@ -437,7 +520,7 @@ multiclass F3<string op_str, SDPatternOperator op_pat> {
               (ins FTZFlag:$ftz),
               op_str # "$ftz.f16",
               [(set f16:$dst, (op_pat f16:$a, f16:$b))]>,
-              Requires<[useFP16Math]>;
+              Requires<[allowFP16Math]>;
   def f32x2rr :
     BasicFlagsNVPTXInst<(outs B64:$dst),
               (ins B64:$a, B64:$b),
@@ -451,7 +534,7 @@ multiclass F3<string op_str, SDPatternOperator op_pat> {
               (ins FTZFlag:$ftz),
               op_str # "$ftz.f16x2",
               [(set v2f16:$dst, (op_pat v2f16:$a, v2f16:$b))]>,
-              Requires<[useFP16Math]>;
+              Requires<[allowFP16Math]>;
   def bf16rr :
     BasicNVPTXInst<(outs B16:$dst),
               (ins B16:$a, B16:$b),
@@ -495,11 +578,11 @@ multiclass F2_Support_Half<string OpcStr, SDNode OpNode> {
    def bf16 :      BasicNVPTXInst<(outs B16:$dst), (ins B16:$a),
                            OpcStr # ".bf16",
                            [(set bf16:$dst, (OpNode bf16:$a))]>,
-                           Requires<[SM80, PTX70]>;
+                           Requires<[SM80]>;
    def bf16x2 :    BasicNVPTXInst<(outs B32:$dst), (ins B32:$a),
                            OpcStr # ".bf16x2",
                            [(set v2bf16:$dst, (OpNode v2bf16:$a))]>,
-                           Requires<[SM80, PTX70]>;
+                           Requires<[SM80]>;
    def f16 :       BasicFlagsNVPTXInst<(outs B16:$dst), (ins B16:$a),
                            (ins FTZFlag:$ftz),
                            OpcStr # "$ftz.f16",
@@ -560,15 +643,15 @@ let hasSideEffects = false in {
       Requires<!if(!eq(ToType, "f32"),
                    // bf16->f32 was introduced early.
                    [PTX71, SM80],
-                   // bf16->everything else needs sm90/ptx78
-                   [PTX78, SM90])>;
+                   // bf16->everything else needs sm_90.
+                   [SM90])>;
     def _f32 :
       BasicFlagsNVPTXInst<(outs RC:$dst),
                 (ins B32:$src), (ins CvtMode:$mode),
                 "cvt${mode:base}${mode:ftz}${mode:relu}${mode:sat}." # ToType # ".f32">,
       Requires<!if(!eq(ToType, "bf16"),
                    // f32->bf16 was introduced early.
-                   [PTX70, SM80],
+                   [SM80],
                    Preds)>;
     def _f64 :
       BasicFlagsNVPTXInst<(outs RC:$dst),
@@ -585,7 +668,7 @@ let hasSideEffects = false in {
     defm CVT_ # sign # "64" : CVT_FROM_ALL<sign # "64", B64>;
   }
   defm CVT_f16 : CVT_FROM_ALL<"f16", B16>;
-  defm CVT_bf16 : CVT_FROM_ALL<"bf16", B16, [PTX78, SM90]>;
+  defm CVT_bf16 : CVT_FROM_ALL<"bf16", B16, [SM90]>;
   defm CVT_f32 : CVT_FROM_ALL<"f32", B32>;
   defm CVT_f64 : CVT_FROM_ALL<"f64", B64>;
   
@@ -612,7 +695,7 @@ let hasSideEffects = false in {
       BasicFlagsNVPTXInst<(outs RC:$dst),
                 (ins B32:$src1, B32:$src2), (ins CvtMode:$mode),
                 "cvt${mode:base}${mode:relu}." # FromName # ".f32">,
-    Requires<[PTX70, SM80]>;
+    Requires<[SM80]>;
     
     def _f32_sf :
       BasicFlagsNVPTXInst<(outs RC:$dst),
@@ -655,7 +738,7 @@ let hasSideEffects = false in {
     def _bf16x2 :
       BasicFlagsNVPTXInst<(outs B16:$dst), (ins B32:$src), (ins CvtMode:$mode),
                 "cvt${mode:base}.satfinite${mode:relu}." # F8Name # "x2.bf16x2">,
-      Requires<[callSubtarget<"hasFP16X2ToNarrowFPConversionSupport">]>;
+      Requires<[hasFP16X2ToNarrowFPConversionSupport]>;
   }
 
   defm CVT_e4m3x2 : CVT_TO_F8X2<"e4m3">;
@@ -671,7 +754,7 @@ let hasSideEffects = false in {
       BasicFlagsNVPTXInst<(outs B32:$dst),
                 (ins B16:$src, B16:$src2), (ins CvtMode:$mode),
                 "cvt${mode:base}${mode:relu}${mode:satfinite}.scaled::n2::ue8m0.bf16x2." # F8Name # "x2">,
-      Requires<[callSubtarget<"hasNarrowFPToBF16x2ConversionSupport">]>;
+      Requires<[hasNarrowFPToBF16x2ConversionSupport]>;
   }
 
   defm CVT_ : CVT_F8x2_TO_FP16x2<"e4m3">;
@@ -687,7 +770,7 @@ let hasSideEffects = false in {
   def CVT_e5m2x4_f32x4_rs_sf : CVT_TO_FP8X4<"e5m2">;
 
   // Float to TF32 conversions
-  multiclass CVT_TO_TF32<string Modifier, list<Predicate> Preds = [PTX78, SM90]> {
+  multiclass CVT_TO_TF32<string Modifier, list<Predicate> Preds = [SM90]> {
     defvar Intr = !cast<Intrinsic>("int_nvvm_f2tf32_" # !subst(".", "_", Modifier));
 
     def NAME : BasicNVPTXInst<(outs B32:$dst), (ins B32:$src),
@@ -700,15 +783,15 @@ let hasSideEffects = false in {
   defm CVT_to_tf32_rz : CVT_TO_TF32<"rz">;
   defm CVT_to_tf32_rn_relu  : CVT_TO_TF32<"rn.relu">;
   defm CVT_to_tf32_rz_relu  : CVT_TO_TF32<"rz.relu">;
-  defm CVT_to_tf32_rna      : CVT_TO_TF32<"rna", [PTX70, SM80]>;
+  defm CVT_to_tf32_rna      : CVT_TO_TF32<"rna", [SM80]>;
   defm CVT_to_tf32_rna_satf : CVT_TO_TF32<"rna.satfinite", [PTX81, SM80]>;
 
-  defm CVT_to_tf32_rn_satf : CVT_TO_TF32<"rn.satfinite", [PTX86, SM100]>;
-  defm CVT_to_tf32_rz_satf : CVT_TO_TF32<"rz.satfinite", [PTX86, SM100]>;
-  defm CVT_to_tf32_rn_relu_satf  : CVT_TO_TF32<"rn.relu.satfinite", [PTX86, SM100]>;
-  defm CVT_to_tf32_rz_relu_satf  : CVT_TO_TF32<"rz.relu.satfinite", [PTX86, SM100]>;
+  defm CVT_to_tf32_rn_satf : CVT_TO_TF32<"rn.satfinite", [SM100]>;
+  defm CVT_to_tf32_rz_satf : CVT_TO_TF32<"rz.satfinite", [SM100]>;
+  defm CVT_to_tf32_rn_relu_satf  : CVT_TO_TF32<"rn.relu.satfinite", [SM100]>;
+  defm CVT_to_tf32_rz_relu_satf  : CVT_TO_TF32<"rz.relu.satfinite", [SM100]>;
   
-let Predicates = [callSubtarget<"hasS2F6X2ConversionSupport">] in {
+let Predicates = [hasS2F6X2ConversionSupport] in {
   def CVT_s2f6x2_f32_sf_scale : BasicFlagsNVPTXInst<(outs B16:$dst),
       (ins B32:$src1, B32:$src2, B16:$scale), (ins CvtMode:$mode),
       "cvt${mode:base}.satfinite${mode:relu}.scaled::n2::ue8m0.s2f6x2.f32">;
@@ -729,12 +812,12 @@ let Predicates = [callSubtarget<"hasS2F6X2ConversionSupport">] in {
       BasicFlagsNVPTXInst<(outs B32:$dst),
                 (ins B16:$src), (ins CvtMode:$mode),
                 "cvt${mode:base}${mode:relu}.f16x2." # F6Name # "x2">,
-      Requires<[callSubtarget<"hasNarrowFPConversionSupport">]>;
+      Requires<[hasNarrowFPConversionSupport]>;
     def bf16x2_ # F6Name # x2_scale :
       BasicFlagsNVPTXInst<(outs B32:$dst),
                 (ins B16:$src, B16:$src2), (ins CvtMode:$mode),
                 "cvt${mode:base}${mode:relu}${mode:satfinite}.scaled::n2::ue8m0.bf16x2." # F6Name # "x2">,
-      Requires<[callSubtarget<"hasNarrowFPToBF16x2ConversionSupport">]>;
+      Requires<[hasNarrowFPToBF16x2ConversionSupport]>;
   }
 
   defm CVT_ : CVT_F6x2_TO_FP16x2<"e2m3">;
@@ -757,11 +840,11 @@ let Predicates = [callSubtarget<"hasS2F6X2ConversionSupport">] in {
     def _f16x2_sf : 
       BasicFlagsNVPTXInst<(outs B16:$dst), (ins B32:$src), (ins CvtMode:$mode),
               "cvt${mode:base}.satfinite${mode:relu}." # FP6Name # "x2.f16x2">,
-      Requires<[callSubtarget<"hasFP16X2ToNarrowFPConversionSupport">]>;
+      Requires<[hasFP16X2ToNarrowFPConversionSupport]>;
     def _bf16x2_sf : 
       BasicFlagsNVPTXInst<(outs B16:$dst), (ins B32:$src), (ins CvtMode:$mode),
               "cvt${mode:base}.satfinite${mode:relu}." # FP6Name # "x2.bf16x2">,
-      Requires<[callSubtarget<"hasFP16X2ToNarrowFPConversionSupport">]>;
+      Requires<[hasFP16X2ToNarrowFPConversionSupport]>;
   }
 
   defm CVT_e2m3x2 : CVT_TO_FP6X2<"e2m3">;
@@ -792,7 +875,7 @@ let Predicates = [callSubtarget<"hasS2F6X2ConversionSupport">] in {
               "cvt.u8.u16 \t%e2m1x2_in, $src1; \n\t" #
               "cvt${mode:base}${mode:relu}${mode:satfinite}.scaled::n2::ue8m0.bf16x2.e2m1x2 \t$dst, %e2m1x2_in, $src2; \n\t" #
               "}}", []>,
-    Requires<[callSubtarget<"hasNarrowFPToBF16x2ConversionSupport">]>;
+    Requires<[hasNarrowFPToBF16x2ConversionSupport]>;
                  
   def CVT_e2m1x4_f32x4_rs_sf :
     NVPTXInst<(outs B16:$dst),
@@ -807,7 +890,7 @@ let Predicates = [callSubtarget<"hasS2F6X2ConversionSupport">] in {
       "cvt${mode:base}.satfinite${mode:relu}.e2m1x2.f16x2 \t%e2m1x2_out, $src; \n\t" #
       "cvt.u16.u8 \t$dst, %e2m1x2_out; \n\t" #
       "}}", []>,
-      Requires<[callSubtarget<"hasFP16X2ToNarrowFPConversionSupport">]>;
+      Requires<[hasFP16X2ToNarrowFPConversionSupport]>;
 
   def CVT_e2m1x2_bf16x2_sf : NVPTXInst<(outs B16:$dst), 
       (ins B32:$src, CvtMode:$mode),
@@ -816,7 +899,7 @@ let Predicates = [callSubtarget<"hasS2F6X2ConversionSupport">] in {
       "cvt${mode:base}.satfinite${mode:relu}.e2m1x2.bf16x2 \t%e2m1x2_out, $src; \n\t" #
       "cvt.u16.u8 \t$dst, %e2m1x2_out; \n\t" #
       "}}", []>,
-      Requires<[callSubtarget<"hasFP16X2ToNarrowFPConversionSupport">]>;
+      Requires<[hasFP16X2ToNarrowFPConversionSupport]>;
 
   // UE8M0x2 conversions.
   class CVT_f32_to_ue8m0x2<string sat = ""> :
@@ -843,15 +926,15 @@ let Predicates = [callSubtarget<"hasS2F6X2ConversionSupport">] in {
   def CVT_f16x2_ue5m3x2 : BasicFlagsNVPTXInst<(outs B32:$dst),
             (ins B16:$src), (ins CvtMode:$mode),
             "cvt${mode:base}.f16x2.ue5m3x2">,
-    Requires<[callSubtarget<"hasUE5M3TypeSupport">]>;
+    Requires<[hasUE5M3TypeSupport]>;
   def CVT_bf16x2_ue5m3x2 : BasicFlagsNVPTXInst<(outs B32:$dst),
             (ins B16:$src), (ins CvtMode:$mode),
             "cvt${mode:base}${mode:satfinite}.bf16x2.ue5m3x2">,
-    Requires<[callSubtarget<"hasUE5M3TypeSupport">]>;
+    Requires<[hasUE5M3TypeSupport]>;
   def CVT_bf16x2_ue5m3x2_scale_n2 : BasicFlagsNVPTXInst<(outs B32:$dst),
             (ins B16:$src, B16:$src2), (ins CvtMode:$mode),
             "cvt${mode:base}${mode:satfinite}.scaled::n2::ue8m0.bf16x2.ue5m3x2">,
-    Requires<[callSubtarget<"hasUE5M3TypeSupport">]>;
+    Requires<[hasUE5M3TypeSupport]>;
 
 }
 
@@ -859,12 +942,12 @@ def fpround_oneuse : OneUse1<fpround>;
 def : Pat<(v2bf16 (build_vector (bf16 (fpround_oneuse f32:$lo)),
                                 (bf16 (fpround_oneuse f32:$hi)))),
           (CVT_bf16x2_f32 $hi, $lo, CvtRN)>,
-      Requires<[PTX70, SM80, hasBF16Math]>;
+      Requires<[SM80, hasBF16Math]>;
 
 def : Pat<(v2f16 (build_vector (f16 (fpround_oneuse f32:$lo)),
                                (f16 (fpround_oneuse f32:$hi)))),
           (CVT_f16x2_f32 $hi, $lo, CvtRN)>,
-      Requires<[PTX70, SM80, useFP16Math]>;
+      Requires<[SM80, allowFP16Math]>;
 
 //-----------------------------------
 // Selection instructions (selp)
@@ -1129,7 +1212,7 @@ class FNEG16<RegTyInfo t> :
                 "neg$ftz." # t.PtxType,
                 [(set t.Ty:$dst, (fneg t.Ty:$src))]>;
 
-let Predicates = [useFP16Math, PTX60, SM53] in {
+let Predicates = [allowFP16Math, PTX60, SM53] in {
   def NEG_F16    : FNEG16<F16RT>;
   def NEG_F16x2  : FNEG16<F16X2RT>;
 }
@@ -1145,11 +1228,11 @@ class FEXP2Inst<RegTyInfo t, dag flags, string flag_str> :
 
 def EX2_APPROX_f32 : FEXP2Inst<F32RT, (ins FTZFlag:$ftz), "$ftz">;
 
-let Predicates = [useFP16Math, PTX70, SM75] in {
+let Predicates = [allowFP16Math, PTX70, SM75] in {
   def EX2_APPROX_f16 : FEXP2Inst<F16RT, (ins), "">;
   def EX2_APPROX_f16x2 : FEXP2Inst<F16X2RT, (ins), "">;
 }
-let Predicates = [PTX78, SM90] in {
+let Predicates = [SM90] in {
   def EX2_APPROX_bf16 : FEXP2Inst<BF16RT, (ins), ".ftz">;
   def EX2_APPROX_bf16x2 : FEXP2Inst<BF16X2RT, (ins), ".ftz">;
 }
@@ -1301,8 +1384,8 @@ multiclass FMA<RegTyInfo t, bit allow_ftz = true, list<Predicate> preds = []> {
   }
 }
 
-defm FMA_F16    : FMA<F16RT,    allow_ftz = true, preds = [useFP16Math]>;
-defm FMA_F16x2  : FMA<F16X2RT,  allow_ftz = true, preds = [useFP16Math]>;
+defm FMA_F16    : FMA<F16RT,    allow_ftz = true, preds = [allowFP16Math]>;
+defm FMA_F16x2  : FMA<F16X2RT,  allow_ftz = true, preds = [allowFP16Math]>;
 defm FMA_BF16   : FMA<BF16RT,   allow_ftz = false, preds = [hasBF16Math]>;
 defm FMA_BF16x2 : FMA<BF16X2RT, allow_ftz = false, preds = [hasBF16Math]>;
 defm FMA_F32    : FMA<F32RT,    allow_ftz = true>;
@@ -1333,11 +1416,11 @@ class FTANHInst<RegTyInfo t> :
 def TANH_APPROX_f32 : FTANHInst<F32RT>,
                       Requires<[PTX70, SM75]>;
 
-let Predicates = [useFP16Math, PTX70, SM75] in {
+let Predicates = [allowFP16Math, PTX70, SM75] in {
   def TANH_APPROX_f16   : FTANHInst<F16RT>;
   def TANH_APPROX_f16x2 : FTANHInst<F16X2RT>;
 }
-let Predicates = [PTX78, SM90] in {
+let Predicates = [SM90] in {
   def TANH_APPROX_bf16   : FTANHInst<BF16RT>;
   def TANH_APPROX_bf16x2 : FTANHInst<BF16X2RT>;
 }
@@ -1666,22 +1749,22 @@ defm SETP_i64 : ISETP<I64RT>;
 
 defm SETP_f32 : FSETP<F32RT>;
 defm SETP_f64 : FSETP<F64RT, allow_ftz = false>;
-let Predicates = [useFP16Math] in
+let Predicates = [allowFP16Math] in
   defm SETP_f16 : FSETP<F16RT>;
-let Predicates = [hasBF16Math, PTX78, SM90] in
+let Predicates = [hasBF16Math, SM90] in
   defm SETP_bf16 : FSETP<BF16RT, allow_ftz = false>;
 
 def SETP_f16x2rr :
       BasicFlagsNVPTXInst<(outs B1:$p, B1:$q),
                 (ins B32:$a, B32:$b), (ins CmpMode:$cmp, FTZFlag:$ftz),
                 "setp.${cmp:FCmp}$ftz.f16x2">,
-                Requires<[useFP16Math]>;
+                Requires<[allowFP16Math]>;
 
 def SETP_bf16x2rr :
       BasicFlagsNVPTXInst<(outs B1:$p, B1:$q),
                 (ins B32:$a, B32:$b), (ins CmpMode:$cmp),
                 "setp.${cmp:FCmp}.bf16x2">,
-                Requires<[hasBF16Math, PTX78, SM90]>;
+                Requires<[hasBF16Math, SM90]>;
 
 //-----------------------------------
 // Data Movement (Load / Store, Move)
@@ -2102,7 +2185,7 @@ def : Pat<(f16 (uint_to_fp i32:$a)), (CVT_f16_u32 $a, CvtRN)>;
 def : Pat<(f16 (uint_to_fp i64:$a)), (CVT_f16_u64 $a, CvtRN)>;
 
 // sint -> bf16
-let Predicates = [PTX78, SM90] in {
+let Predicates = [SM90] in {
   def : Pat<(bf16 (sint_to_fp i1:$a)), (CVT_bf16_s32 (SELP_b32ii -1, 0, $a), CvtRN)>;
   def : Pat<(bf16 (sint_to_fp i16:$a)), (CVT_bf16_s16 $a, CvtRN)>;
   def : Pat<(bf16 (sint_to_fp i32:$a)), (CVT_bf16_s32 $a, CvtRN)>;
@@ -2110,7 +2193,7 @@ let Predicates = [PTX78, SM90] in {
 }
 
 // uint -> bf16
-let Predicates = [PTX78, SM90] in {
+let Predicates = [SM90] in {
   def : Pat<(bf16 (uint_to_fp i1:$a)), (CVT_bf16_u32 (SELP_b32ii 1, 0, $a), CvtRN)>;
   def : Pat<(bf16 (uint_to_fp i16:$a)), (CVT_bf16_u16 $a, CvtRN)>;
   def : Pat<(bf16 (uint_to_fp i32:$a)), (CVT_bf16_u32 $a, CvtRN)>;
@@ -2426,14 +2509,14 @@ def : Pat<(f16 (fpround f32:$a)), (CVT_f16_f32 $a, CvtRN)>;
 
 // fpround f32 -> bf16
 def : Pat<(bf16 (fpround f32:$a)), (CVT_bf16_f32 $a, CvtRN)>, 
-      Requires<[PTX70, SM80]>;
+      Requires<[SM80]>;
 
 // fpround f64 -> f16
 def : Pat<(f16 (fpround f64:$a)), (CVT_f16_f64 $a, CvtRN)>;
 
 // fpround f64 -> bf16
 def : Pat<(bf16 (fpround f64:$a)), (CVT_bf16_f64 $a, CvtRN)>, 
-      Requires<[PTX78, SM90]>;
+      Requires<[SM90]>;
 
 // fpround f64 -> f32
 def : Pat<(f32 (fpround f64:$a)), (CVT_f32_f64 $a, CvtRN_FTZ)>, Requires<[doF32FTZ]>;
@@ -2443,14 +2526,14 @@ def : Pat<(f32 (fpround f64:$a)), (CVT_f32_f64 $a, CvtRN)>;
 def : Pat<(f32 (fpextend f16:$a)), (CVT_f32_f16 $a, CvtNONE_FTZ)>, Requires<[doF32FTZ]>;
 def : Pat<(f32 (fpextend f16:$a)), (CVT_f32_f16 $a, CvtNONE)>;
 // fpextend bf16 -> f32
-def : Pat<(f32 (fpextend bf16:$a)), (CVT_f32_bf16 $a, CvtNONE_FTZ)>, Requires<[doF32FTZ, PTX78, SM90]>;
+def : Pat<(f32 (fpextend bf16:$a)), (CVT_f32_bf16 $a, CvtNONE_FTZ)>, Requires<[doF32FTZ, SM90]>;
 def : Pat<(f32 (fpextend bf16:$a)), (CVT_f32_bf16 $a, CvtNONE)>, Requires<[PTX71, SM80]>;
 
 // fpextend f16 -> f64
 def : Pat<(f64 (fpextend f16:$a)), (CVT_f64_f16 $a, CvtNONE)>;
 
 // fpextend bf16 -> f64
-def : Pat<(f64 (fpextend bf16:$a)), (CVT_f64_bf16 $a, CvtNONE)>, Requires<[PTX78, SM90]>;
+def : Pat<(f64 (fpextend bf16:$a)), (CVT_f64_bf16 $a, CvtNONE)>, Requires<[SM90]>;
 
 // fpextend f32 -> f64
 def : Pat<(f64 (fpextend f32:$a)), (CVT_f64_f32 $a, CvtNONE_FTZ)>, Requires<[doF32FTZ]>;
@@ -2602,15 +2685,15 @@ include "NVPTXIntrinsics.td"
 // PTX Fence instructions
 ////////////////////////////////////////////////////////////////////////////////
 
-class NVPTXFenceInst<string scope, string sem, Predicate ptx>:
+class NVPTXFenceInst<string scope, string sem, list<Predicate> preds = []>:
     BasicNVPTXInst<(outs), (ins), "fence."#sem#"."#scope>,
-    Requires<[ptx, SM70]>;
+    Requires<!listconcat([SM70], preds)>;
 
 foreach scope = ["sys", "gpu", "cluster", "cta"] in {
-  def atomic_thread_fence_seq_cst_#scope: NVPTXFenceInst<scope, "sc", PTX60>;
-  def atomic_thread_fence_acq_rel_#scope: NVPTXFenceInst<scope, "acq_rel", PTX60>;
-  def atomic_thread_fence_acquire_#scope: NVPTXFenceInst<scope, "acquire", PTX87>;
-  def atomic_thread_fence_release_#scope: NVPTXFenceInst<scope, "release", PTX87>;
+  def atomic_thread_fence_seq_cst_#scope: NVPTXFenceInst<scope, "sc">;
+  def atomic_thread_fence_acq_rel_#scope: NVPTXFenceInst<scope, "acq_rel">;
+  def atomic_thread_fence_acquire_#scope: NVPTXFenceInst<scope, "acquire", [PTX87]>;
+  def atomic_thread_fence_release_#scope: NVPTXFenceInst<scope, "release", [PTX87]>;
 }
 
 // Perform substitution if fma only has one use, and also if instruction has
@@ -2632,12 +2715,12 @@ class FMARELUInst<RegTyInfo t, bit allow_ftz, PatFrag zero_pat>
                    "fma.rn" # !if(allow_ftz, "$ftz", "") # ".relu." # t.PtxType,
                    [(set t.Ty:$dst, (NVPTX_fmaxnum_or_fmaximumnum_nsz (NVPTX_fma_oneuse_and_nnan t.Ty:$a, t.Ty:$b, t.Ty:$c), zero_pat))]>;
 
-let Predicates = [useFP16Math, PTX70, SM80] in {
+let Predicates = [allowFP16Math, SM80] in {
   def FMARELU_F16 : FMARELUInst<F16RT, true, fpimm_0>;
   def FMARELU_F16X2 : FMARELUInst<F16X2RT, true, zeroinitializer<v2f16>>;
 }
 
-let Predicates = [hasBF16Math, PTX70, SM80] in {
+let Predicates = [hasBF16Math, SM80] in {
   def FMARELU_BF16 : FMARELUInst<BF16RT, false, fpimm_0>;
   def FMARELU_BF16X2 : FMARELUInst<BF16X2RT, false, zeroinitializer<v2bf16>>;
 }

--- a/llvm/lib/Target/NVPTX/NVPTXIntrinsics.td
+++ b/llvm/lib/Target/NVPTX/NVPTXIntrinsics.td
@@ -166,7 +166,7 @@ defm BARRIER_CTA_RED_AND_COUNT : BARRIER_RED_COUNT<"barrier.red.and.pred", int_n
 defm BARRIER_CTA_RED_OR_COUNT : BARRIER_RED_COUNT<"barrier.red.or.pred", int_nvvm_barrier_cta_red_or_count, I1RT, [PTX60]>;
 
 class INT_BARRIER_CLUSTER<string variant, Intrinsic Intr,
-                          list<Predicate> Preds = [PTX78, SM90]>:
+                          list<Predicate> Preds = [SM90]>:
         BasicNVPTXInst<(outs), (ins), "barrier.cluster."# variant, [(Intr)]>,
         Requires<Preds>;
 
@@ -270,7 +270,7 @@ def INT_ELECT_SYNC_R : BasicNVPTXInst<(outs B32:$dest, B1:$pred), (ins B32:$mask
             [(set i32:$dest, i1:$pred, (int_nvvm_elect_sync i32:$mask))]>;
 }
 
-let Predicates = [PTX60, SM70] in {
+let Predicates = [SM70] in {
   multiclass MATCH_ANY_SYNC<Intrinsic op, RegTyInfo t> {
     def ii : BasicNVPTXInst<(outs B32:$dest), (ins t.Imm:$value, i32imm:$mask),
                 "match.any.sync." # t.PtxType,
@@ -321,7 +321,7 @@ multiclass REDUX_SYNC<string BinOp, string PTXType, Intrinsic Intrin> {
   def : BasicNVPTXInst<(outs B32:$dst), (ins B32:$src, B32:$mask),
           "redux.sync." # BinOp # "." # PTXType,
           [(set i32:$dst, (Intrin i32:$src, B32:$mask))]>,
-        Requires<[PTX70, SM80]>;
+        Requires<[SM80]>;
 }
 
 defm REDUX_SYNC_UMIN : REDUX_SYNC<"min", "u32", int_nvvm_redux_sync_umin>;
@@ -340,7 +340,7 @@ multiclass REDUX_SYNC_F<string BinOp, string abs, string NaN> {
                   (ins B32:$src, B32:$mask),
                   "redux.sync." # BinOp # abs # NaN # ".f32",
                   [(set f32:$dst, (!cast<Intrinsic>(intr_name) f32:$src, B32:$mask))]>,
-                  Requires<[callSubtarget<"hasReduxSyncF32">]>;
+                  Requires<[hasReduxSyncF32]>;
 }
 
 defm REDUX_SYNC_FMIN : REDUX_SYNC_F<"min", "", "">;
@@ -366,7 +366,7 @@ def INT_MEMBAR_SYS : NullaryInst<"membar.sys", int_nvvm_membar_sys>;
 
 def INT_FENCE_SC_CLUSTER:
        NullaryInst<"fence.sc.cluster", int_nvvm_fence_sc_cluster>,
-       Requires<[PTX78, SM90]>;
+       Requires<[SM90]>;
 
 def INT_FENCE_MBARRIER_INIT_RELEASE_CLUSTER:
        NullaryInst<"fence.mbarrier_init.release.cluster",
@@ -450,7 +450,7 @@ multiclass CP_ASYNC_MBARRIER_ARRIVE<string NoInc, string AddrSpace, Intrinsic In
   def "" : BasicNVPTXInst<(outs), (ins ADDR:$addr),
             "cp.async.mbarrier.arrive" # NoInc # AddrSpace # ".b64",
             [(Intrin addr:$addr)]>,
-    Requires<[PTX70, SM80]>;
+    Requires<[SM80]>;
 }
 
 defm CP_ASYNC_MBARRIER_ARRIVE :
@@ -466,17 +466,17 @@ multiclass CP_ASYNC_SHARED_GLOBAL_I<string cc, string cpsize, Intrinsic Intrin, 
   def "" : NVPTXInst<(outs), (ins ADDR:$dst, ADDR:$src),
             "cp.async." # cc # ".shared.global" # " [$dst], [$src], " # cpsize # ";",
             [(Intrin addr:$dst, addr:$src)]>,
-    Requires<[PTX70, SM80]>;
+    Requires<[SM80]>;
 
   // Variant with src_size parameter
   def _s : NVPTXInst<(outs), (ins ADDR:$dst, ADDR:$src, B32:$src_size),
              "cp.async." # cc # ".shared.global" # " [$dst], [$src], " # cpsize # ", $src_size;",
              [(IntrinS addr:$dst, addr:$src, i32:$src_size)]>,
-    Requires<[PTX70, SM80]>;
+    Requires<[SM80]>;
   def _si: NVPTXInst<(outs), (ins ADDR:$dst, ADDR:$src, i32imm:$src_size),
              "cp.async." # cc # ".shared.global" # " [$dst], [$src], " # cpsize # ", $src_size;",
              [(IntrinS addr:$dst, addr:$src, imm:$src_size)]>,
-    Requires<[PTX70, SM80]>;
+    Requires<[SM80]>;
 }
 
 defm CP_ASYNC_CA_SHARED_GLOBAL_4 :
@@ -495,7 +495,7 @@ defm CP_ASYNC_CG_SHARED_GLOBAL_16 :
   CP_ASYNC_SHARED_GLOBAL_I<"cg", "16", int_nvvm_cp_async_cg_shared_global_16,
                                        int_nvvm_cp_async_cg_shared_global_16_s>;
 
-let Predicates = [PTX70, SM80] in {
+let Predicates = [SM80] in {
   def CP_ASYNC_COMMIT_GROUP :
     NullaryInst<"cp.async.commit_group", int_nvvm_cp_async_commit_group>;
 
@@ -557,7 +557,7 @@ multiclass CP_ASYNC_BULK_S2G_INTR<bit has_ch> {
           CpAsyncBulkStr<0, 1, 1>.S2G # " [$dst], [$src], $size, $ch, $mask;",
           CpAsyncBulkStr<0, 0, 1>.S2G # " [$dst], [$src], $size, $mask;"),
       [(int_nvvm_cp_async_bulk_shared_cta_to_global_bytemask addr:$dst, addr:$src, i32:$size, i64:$ch, !if(has_ch, -1, 0), i16:$mask)]>,
-      Requires<[PTX86, SM100]>;
+      Requires<[SM100]>;
 }
 defm CP_ASYNC_BULK_S2G    : CP_ASYNC_BULK_S2G_INTR<has_ch = 0>;
 defm CP_ASYNC_BULK_S2G_CH : CP_ASYNC_BULK_S2G_INTR<has_ch = 1>;
@@ -724,7 +724,7 @@ foreach dim = 1...5 in {
                             tma_cta_group_imm0>;
   defm TMA_G2S_TILE_ # dim # "D"
       : TMA_TENSOR_G2S_INTR<dim, "tile",
-                            [callSubtarget<"hasTMABlackwellSupport">]>;
+                            [hasTMABlackwellSupport]>;
 }
 foreach dim = 3...5 in {
   defm TMA_G2S_IM2COL_CG0_ # dim # "D"
@@ -732,15 +732,15 @@ foreach dim = 3...5 in {
                             tma_cta_group_imm0>;
   defm TMA_G2S_IM2COL_ # dim # "D"
       : TMA_TENSOR_G2S_INTR<dim, "im2col",
-                            [callSubtarget<"hasTMABlackwellSupport">]>;
+                            [hasTMABlackwellSupport]>;
   foreach mode = ["im2col_w", "im2col_w_128"] in {
     defm TMA_G2S_ # !toupper(mode) # "_" # dim # "D"
         : TMA_TENSOR_G2S_INTR<dim, mode,
-                              [callSubtarget<"hasTMABlackwellSupport">]>;
+                              [hasTMABlackwellSupport]>;
   }
 }
 defm TMA_G2S_TILE_GATHER4_2D : TMA_TENSOR_G2S_INTR<5, "tile_gather4",
-                               [callSubtarget<"hasTMABlackwellSupport">]>;
+                               [hasTMABlackwellSupport]>;
 
 multiclass TMA_TENSOR_G2S_CTA_INTR<int dim, string mode, list<Predicate> pred = []> {
   defvar dims_dag = TMA_DIMS_UTIL<dim>.ins_dag;
@@ -795,14 +795,14 @@ foreach dim = 3...5 in {
     : TMA_TENSOR_G2S_CTA_INTR<dim, "im2col", [PTX86, SM90]>;
 
   defm TMA_G2S_CTA_IM2COL_W_ # dim # "D"
-    : TMA_TENSOR_G2S_CTA_INTR<dim, "im2col_w", [PTX86, SM100]>;
+    : TMA_TENSOR_G2S_CTA_INTR<dim, "im2col_w", [SM100]>;
 
   defm TMA_G2S_CTA_IM2COL_W_128_ # dim # "D"
     : TMA_TENSOR_G2S_CTA_INTR<dim, "im2col_w_128",
-                              [callSubtarget<"hasTMABlackwellSupport">]>;
+                              [hasTMABlackwellSupport]>;
 }
 defm TMA_G2S_CTA_TILE_GATHER4_2D : TMA_TENSOR_G2S_CTA_INTR<5, "tile_gather4",
-                                   [PTX86, SM100]>;
+                                   [SM100]>;
 
 multiclass TMA_TENSOR_S2G_INTR<int dim, string mode,
                                list<Predicate> pred = [PTX80, SM90]> {
@@ -853,10 +853,10 @@ foreach dim = 1...5 in {
 foreach dim = 3...5 in {
   defm TMA_TENSOR_S2G_IM2COL_W_ # dim # D
     : TMA_TENSOR_S2G_INTR<dim, "im2col_w",
-                          [callSubtarget<"hasRubinFamilySupport">]>;
+                          [hasRubinFamilySupport]>;
 }
 defm TMA_S2G_TILE_SCATTER4_2D : TMA_TENSOR_S2G_INTR<5, "tile_scatter4",
-                                [callSubtarget<"hasTMABlackwellSupport">]>;
+                                [hasTMABlackwellSupport]>;
 
 def TMAReductionFlags : Operand<i32> {
   let PrintMethod = "printTmaReductionMode";
@@ -922,7 +922,7 @@ foreach dim = 1...5 in {
 foreach dim = 3...5 in {
   defm CP_ASYNC_BULK_TENSOR_RED_ # dim # D_IM2COL_W
     : CP_ASYNC_BULK_TENSOR_REDUCE_INTR<dim, "im2col_w",
-                          [callSubtarget<"hasRubinFamilySupport">]>;
+                          [hasRubinFamilySupport]>;
 }
 
 // TMA Prefetch from Global memory to L2 cache
@@ -979,11 +979,11 @@ foreach dim = 3...5 in {
   foreach mode = ["im2col_w", "im2col_w_128"] in {
     defvar suffix = !toupper(mode) # "_" # dim # "D";
     defm TMA_TENSOR_PF_ # suffix : TMA_TENSOR_PREFETCH_INTR<dim, mode,
-                                   [callSubtarget<"hasTMABlackwellSupport">]>;
+                                   [hasTMABlackwellSupport]>;
   }
 }
 defm TMA_TENSOR_PF_TILE_GATHER4_2D : TMA_TENSOR_PREFETCH_INTR<5, "tile_gather4",
-                                     [callSubtarget<"hasTMABlackwellSupport">]>;
+                                     [hasTMABlackwellSupport]>;
 
 //Prefetchu and Prefetch
 
@@ -1055,7 +1055,7 @@ def DISCARD_GLOBAL_L2 : DISCARD_L2_INTRS<"global">;
 // MBarrier Functions
 //-----------------------------------
 
-let Predicates = [PTX70, SM80] in {
+let Predicates = [SM80] in {
   class MBARRIER_INIT<string AddrSpace, Intrinsic Intrin> :
             BasicNVPTXInst<(outs), (ins ADDR:$addr, B32:$count),
             "mbarrier.init" # AddrSpace # ".b64",
@@ -1385,7 +1385,7 @@ def INT_PM_EVENT_MASK : BasicNVPTXInst<(outs),
 def : Pat<(int_nvvm_fmin_f f32:$a, f32:$b), (MIN_f32_rr $a, $b, NoFTZ)>;
 def : Pat<(int_nvvm_fmin_ftz_f f32:$a, f32:$b), (MIN_f32_rr $a, $b, FTZ)>;
 
-let Predicates = [PTX70, SM80] in {
+let Predicates = [SM80] in {
   def : Pat<(int_nvvm_fmin_nan_f f32:$a, f32:$b), (MIN_NAN_f32_rr $a, $b, NoFTZ)>;
   def : Pat<(int_nvvm_fmin_ftz_nan_f f32:$a, f32:$b), (MIN_NAN_f32_rr $a, $b, FTZ)>;
 }
@@ -1407,7 +1407,7 @@ def INT_NVVM_FMIN_FTZ_NAN_XORSIGN_ABS_F :
 def : Pat<(int_nvvm_fmax_f f32:$a, f32:$b), (MAX_f32_rr $a, $b, NoFTZ)>;
 def : Pat<(int_nvvm_fmax_ftz_f f32:$a, f32:$b), (MAX_f32_rr $a, $b, FTZ)>;
 
-let Predicates = [PTX70, SM80] in {
+let Predicates = [SM80] in {
   def : Pat<(int_nvvm_fmax_nan_f f32:$a, f32:$b), (MAX_NAN_f32_rr $a, $b, NoFTZ)>;
   def : Pat<(int_nvvm_fmax_ftz_nan_f f32:$a, f32:$b), (MAX_NAN_f32_rr $a, $b, FTZ)>;
 }
@@ -1433,7 +1433,7 @@ def : Pat<(int_nvvm_fmax_d f64:$a, f64:$b), (MAX_f64_rr $a, $b)>;
 //
 
 class MIN_MAX_TUPLE<string V, Intrinsic I, NVPTXRegClass RC,
-                    list<Predicate> Preds = [PTX70, SM80]> {
+                    list<Predicate> Preds = [SM80]> {
   string Variant = V;
   Intrinsic Intr = I;
   NVPTXRegClass RegClass = RC;
@@ -1608,8 +1608,8 @@ multiclass F_ABS<string suffix, RegTyInfo RT, bit support_ftz, list<Predicate> p
 defm ABS_F16 : F_ABS<"f16", F16RT, support_ftz = true, preds = [PTX65, SM53]>;
 defm ABS_F16X2 : F_ABS<"f16x2", F16X2RT, support_ftz = true, preds = [PTX65, SM53]>;
 
-defm ABS_BF16 : F_ABS<"bf16", BF16RT, support_ftz = false, preds = [PTX70, SM80]>;
-defm ABS_BF16X2 : F_ABS<"bf16x2", BF16X2RT, support_ftz = false, preds = [PTX70, SM80]>;
+defm ABS_BF16 : F_ABS<"bf16", BF16RT, support_ftz = false, preds = [SM80]>;
+defm ABS_BF16X2 : F_ABS<"bf16x2", BF16X2RT, support_ftz = false, preds = [SM80]>;
 
 defm ABS_F32 : F_ABS<"f32", F32RT, support_ftz = true>;
 defm ABS_F64 : F_ABS<"f64", F64RT, support_ftz = false>;
@@ -1631,9 +1631,9 @@ foreach t = [F32RT, F64RT] in
 //
 
 def INT_NVVM_NEG_BF16 : F_MATH_1<"neg.bf16", BF16RT,
-  BF16RT, int_nvvm_neg_bf16, [PTX70, SM80]>;
+  BF16RT, int_nvvm_neg_bf16, [SM80]>;
 def INT_NVVM_NEG_BF16X2 : F_MATH_1<"neg.bf16x2", BF16X2RT,
-  BF16X2RT, int_nvvm_neg_bf16x2, [PTX70, SM80]>;
+  BF16X2RT, int_nvvm_neg_bf16x2, [SM80]>;
 
 //
 // Round
@@ -1671,7 +1671,7 @@ let Predicates = [PTX70, SM75] in {
   def : Pat<(v2f16 (int_nvvm_ex2_approx v2f16:$a)), (EX2_APPROX_f16x2 $a)>;
 }
 
-let Predicates = [PTX78, SM90] in {
+let Predicates = [SM90] in {
   def : Pat<(bf16 (int_nvvm_ex2_approx_ftz bf16:$a)), (EX2_APPROX_bf16 $a)>;
   def : Pat<(v2bf16 (int_nvvm_ex2_approx_ftz v2bf16:$a)), (EX2_APPROX_bf16x2 $a)>;
 }
@@ -1735,39 +1735,39 @@ multiclass FMA_INST {
     FMA_TUPLE<"_rp_ftz_f32", int_nvvm_fma_rp_ftz_f, B32>,
     FMA_TUPLE<"_rp_ftz_sat_f32", int_nvvm_fma_rp_ftz_sat_f, B32>,
 
-    FMA_TUPLE<"_rn_f16", int_nvvm_fma_rn_f16, B16, [PTX42, SM53]>,
+    FMA_TUPLE<"_rn_f16", int_nvvm_fma_rn_f16, B16, [SM53]>,
     FMA_TUPLE<"_rn_ftz_f16", int_nvvm_fma_rn_ftz_f16, B16,
-      [PTX42, SM53]>,
+      [SM53]>,
     FMA_TUPLE<"_rn_sat_f16", int_nvvm_fma_rn_sat_f16, B16,
-      [PTX42, SM53]>,
+      [SM53]>,
     FMA_TUPLE<"_rn_ftz_sat_f16", int_nvvm_fma_rn_ftz_sat_f16, B16,
-      [PTX42, SM53]>,
+      [SM53]>,
     FMA_TUPLE<"_rn_relu_f16", int_nvvm_fma_rn_relu_f16, B16,
-      [PTX70, SM80]>,
+      [SM80]>,
     FMA_TUPLE<"_rn_ftz_relu_f16", int_nvvm_fma_rn_ftz_relu_f16, B16,
-      [PTX70, SM80]>,
+      [SM80]>,
 
-    FMA_TUPLE<"_rn_bf16", int_nvvm_fma_rn_bf16, B16, [PTX70, SM80]>,
+    FMA_TUPLE<"_rn_bf16", int_nvvm_fma_rn_bf16, B16, [SM80]>,
     FMA_TUPLE<"_rn_relu_bf16", int_nvvm_fma_rn_relu_bf16, B16,
-      [PTX70, SM80]>,
+      [SM80]>,
 
     FMA_TUPLE<"_rn_f16x2", int_nvvm_fma_rn_f16x2, B32,
-      [PTX42, SM53]>,
+      [SM53]>,
     FMA_TUPLE<"_rn_ftz_f16x2", int_nvvm_fma_rn_ftz_f16x2, B32,
-      [PTX42, SM53]>,
+      [SM53]>,
     FMA_TUPLE<"_rn_sat_f16x2", int_nvvm_fma_rn_sat_f16x2, B32,
-      [PTX42, SM53]>,
+      [SM53]>,
     FMA_TUPLE<"_rn_ftz_sat_f16x2", int_nvvm_fma_rn_ftz_sat_f16x2,
-      B32, [PTX42, SM53]>,
+      B32, [SM53]>,
     FMA_TUPLE<"_rn_relu_f16x2", int_nvvm_fma_rn_relu_f16x2, B32,
-      [PTX70, SM80]>,
+      [SM80]>,
     FMA_TUPLE<"_rn_ftz_relu_f16x2", int_nvvm_fma_rn_ftz_relu_f16x2,
-      B32, [PTX70, SM80]>,
+      B32, [SM80]>,
 
     FMA_TUPLE<"_rn_bf16x2", int_nvvm_fma_rn_bf16x2, B32,
-      [PTX70, SM80]>,
+      [SM80]>,
     FMA_TUPLE<"_rn_relu_bf16x2", int_nvvm_fma_rn_relu_bf16x2, B32,
-      [PTX70, SM80]>,
+      [SM80]>,
   ] in {
     def P.Variant :
       F_MATH_3<!strconcat("fma", !subst("_", ".", P.Variant)),
@@ -1788,13 +1788,13 @@ foreach rnd = ["_rn", "_rz", "_rm", "_rp"] in {
              (f32 (fpextend type:$a)),
              (f32 (fpextend type:$b)),
              f32:$c))]>,
-        Requires<[SM100, PTX86]>;
+        Requires<[SM100]>;
     }
   }
 }
 
 // Pattern for llvm.fma.f32 intrinsic when there is no FTZ flag
-let Predicates = [SM100, PTX86, doNoF32FTZ] in {
+let Predicates = [SM100, doNoF32FTZ] in {
   def : Pat<(f32 (fma (f32 (fpextend f16:$a)),
                       (f32 (fpextend f16:$b)), f32:$c)),
             (INT_NVVM_MIXED_FMA_rn_f32_f16 B16:$a, B16:$b, B32:$c)>;
@@ -1950,13 +1950,13 @@ foreach rnd = ["_rn", "_rz", "_rm", "_rp"] in {
            (!cast<Intrinsic>("int_nvvm_add" # rnd # sat # "_f") 
              (f32 (fpextend type:$a)),
              f32:$b))]>,
-        Requires<[SM100, PTX86]>;
+        Requires<[SM100]>;
     }
   }
 }
 
 // Pattern for fadd when there is no FTZ flag
-let Predicates = [SM100, PTX86, doNoF32FTZ] in {
+let Predicates = [SM100, doNoF32FTZ] in {
   def : Pat<(f32 (fadd (f32 (fpextend f16:$a)), f32:$b)),
             (INT_NVVM_MIXED_ADD_rn_f32_f16 B16:$a, B32:$b)>;
   def : Pat<(f32 (fadd (f32 (fpextend bf16:$a)), f32:$b)),
@@ -2010,13 +2010,13 @@ foreach rnd = ["_rn", "_rz", "_rm", "_rp"] in {
            (!cast<Intrinsic>("int_nvvm_add" # rnd # sat # "_f") 
              (f32 (fpextend type:$a)),
              (f32 (fneg f32:$b))))]>,
-        Requires<[SM100, PTX86]>;
+        Requires<[SM100]>;
     }
   }
 }
 
 // Pattern for fsub when there is no FTZ flag
-let Predicates = [SM100, PTX86, doNoF32FTZ] in {
+let Predicates = [SM100, doNoF32FTZ] in {
   def : Pat<(f32 (fsub (f32 (fpextend f16:$a)), f32:$b)),
             (INT_NVVM_MIXED_SUB_rn_f32_f16 B16:$a, B32:$b)>;
   def : Pat<(f32 (fsub (f32 (fpextend bf16:$a)), f32:$b)),
@@ -2140,7 +2140,7 @@ let Predicates = [PTX81, SM80] in {
   def : Pat<(int_nvvm_ff2bf16x2_rz_satfinite f32:$a, f32:$b), (CVT_bf16x2_f32_sf $a, $b, CvtRZ)>;
   def : Pat<(int_nvvm_ff2bf16x2_rz_relu_satfinite f32:$a, f32:$b), (CVT_bf16x2_f32_sf $a, $b, CvtRZ_RELU)>;
 }
-let Predicates = [callSubtarget<"hasConvertWithStochasticRounding">] in {
+let Predicates = [hasConvertWithStochasticRounding] in {
 def : Pat<(int_nvvm_ff2bf16x2_rs f32:$a, f32:$b, i32:$c),
           (CVT_bf16x2_f32_rs $a, $b, $c, CvtRS)>;
 def : Pat<(int_nvvm_ff2bf16x2_rs_relu f32:$a, f32:$b, i32:$c),
@@ -2162,7 +2162,7 @@ let Predicates = [PTX81, SM80] in {
   def : Pat<(int_nvvm_ff2f16x2_rz_relu_satfinite f32:$a, f32:$b), (CVT_f16x2_f32_sf $a, $b, CvtRZ_RELU)>;
 }
 
-let Predicates = [callSubtarget<"hasConvertWithStochasticRounding">] in {
+let Predicates = [hasConvertWithStochasticRounding] in {
 def : Pat<(int_nvvm_ff2f16x2_rs f32:$a, f32:$b, i32:$c),
           (CVT_f16x2_f32_rs $a, $b, $c, CvtRS)>;
 def : Pat<(int_nvvm_ff2f16x2_rs_relu f32:$a, f32:$b, i32:$c),
@@ -2253,7 +2253,7 @@ def : Pat<(int_nvvm_ull2d_rp i64:$a), (CVT_f64_u64 $a, CvtRP)>;
 def : Pat<(int_nvvm_f2h_rn_ftz f32:$a), (CVT_f16_f32 $a, CvtRN_FTZ)>;
 def : Pat<(int_nvvm_f2h_rn f32:$a), (CVT_f16_f32 $a, CvtRN)>;
 
-let Predicates = [callSubtarget<"hasFP8ConversionSupport">] in {
+let Predicates = [hasFP8ConversionSupport] in {
   def : Pat<(int_nvvm_ff_to_e4m3x2_rn f32:$a, f32:$b),
             (CVT_e4m3x2_f32 $a, $b, CvtRN)>;
   def : Pat<(int_nvvm_ff_to_e4m3x2_rn_relu f32:$a, f32:$b),
@@ -2264,7 +2264,7 @@ let Predicates = [callSubtarget<"hasFP8ConversionSupport">] in {
             (CVT_e5m2x2_f32 $a, $b, CvtRN_RELU)>;
 }
 
-let Predicates = [callSubtarget<"hasFP16X2ToNarrowFPConversionSupport">] in {
+let Predicates = [hasFP16X2ToNarrowFPConversionSupport] in {
   foreach dst_type = ["e4m3x2", "e5m2x2"] in {
     foreach relu = ["", "_relu"] in {
       defvar intrin = !cast<Intrinsic>("int_nvvm_bf16x2_to_" # dst_type # "_rn" # relu # "_satfinite");
@@ -2276,7 +2276,7 @@ let Predicates = [callSubtarget<"hasFP16X2ToNarrowFPConversionSupport">] in {
   }
 }
 
-let Predicates = [callSubtarget<"hasFP8ConversionSupport">] in {
+let Predicates = [hasFP8ConversionSupport] in {
   def : Pat<(int_nvvm_f16x2_to_e4m3x2_rn v2f16:$a),
             (CVT_e4m3x2_f16x2 $a, CvtRN)>;
   def : Pat<(int_nvvm_f16x2_to_e4m3x2_rn_relu v2f16:$a),
@@ -2296,7 +2296,7 @@ let Predicates = [callSubtarget<"hasFP8ConversionSupport">] in {
             (CVT_f16x2_e5m2x2 $a, CvtRN_RELU)>;
 }
 
-let Predicates = [callSubtarget<"hasNarrowFPToBF16x2ConversionSupport">] in {
+let Predicates = [hasNarrowFPToBF16x2ConversionSupport] in {
   foreach src_type = ["e4m3x2", "e5m2x2"] in {
     foreach relu = ["", "_relu"] in {
       foreach satfinite = ["", "_satfinite"] in {
@@ -2309,9 +2309,9 @@ let Predicates = [callSubtarget<"hasNarrowFPToBF16x2ConversionSupport">] in {
       }
     }
   }
-} // let Predicates = [callSubtarget<"hasNarrowFPToBF16x2ConversionSupport">]
+} // let Predicates = [hasNarrowFPToBF16x2ConversionSupport]
 
-let Predicates = [callSubtarget<"hasS2F6X2ConversionSupport">] in {
+let Predicates = [hasS2F6X2ConversionSupport] in {
   def : Pat<(int_nvvm_ff_to_s2f6x2_rn_satfinite_scale_n2_ue8m0 f32:$a, f32:$b, i16:$scale),
             (CVT_s2f6x2_f32_sf_scale $a, $b, $scale, CvtRN)>;
   def : Pat<(int_nvvm_ff_to_s2f6x2_rn_relu_satfinite_scale_n2_ue8m0 f32:$a, f32:$b, i16:$scale),
@@ -2333,7 +2333,7 @@ let Predicates = [callSubtarget<"hasS2F6X2ConversionSupport">] in {
             (CVT_bf16x2_s2f6x2_sf_scale $a, $scale, CvtRN_RELU)>;
 }
 
-let Predicates = [callSubtarget<"hasNarrowFPConversionSupport">] in {
+let Predicates = [hasNarrowFPConversionSupport] in {
   def : Pat<(int_nvvm_ff_to_e2m3x2_rn_satfinite f32:$a, f32:$b),
             (CVT_e2m3x2_f32_sf $a, $b, CvtRN)>;
   def : Pat<(int_nvvm_ff_to_e2m3x2_rn_relu_satfinite f32:$a, f32:$b),
@@ -2353,7 +2353,7 @@ let Predicates = [callSubtarget<"hasNarrowFPConversionSupport">] in {
             (CVT_f16x2_e3m2x2 $a, CvtRN_RELU)>;
 }
 
-let Predicates = [callSubtarget<"hasFP16X2ToNarrowFPConversionSupport">] in {
+let Predicates = [hasFP16X2ToNarrowFPConversionSupport] in {
   foreach src_type = ["f16x2", "bf16x2"] in {
     foreach dst_type = ["e2m3x2", "e3m2x2"] in {
       foreach relu = ["", "_relu"] in {
@@ -2366,7 +2366,7 @@ let Predicates = [callSubtarget<"hasFP16X2ToNarrowFPConversionSupport">] in {
   }
 }
 
-let Predicates = [callSubtarget<"hasNarrowFPToBF16x2ConversionSupport">] in {
+let Predicates = [hasNarrowFPToBF16x2ConversionSupport] in {
   foreach src_type = ["e2m3x2", "e3m2x2"] in {
     foreach relu = ["", "_relu"] in {
       foreach satfinite = ["", "_satfinite"] in {
@@ -2378,9 +2378,9 @@ let Predicates = [callSubtarget<"hasNarrowFPToBF16x2ConversionSupport">] in {
       }
     }
   }
-} // let Predicates = [callSubtarget<"hasNarrowFPToBF16x2ConversionSupport">]
+} // let Predicates = [hasNarrowFPToBF16x2ConversionSupport]
 
-let Predicates = [callSubtarget<"hasNarrowFPConversionSupport">] in {
+let Predicates = [hasNarrowFPConversionSupport] in {
   def : Pat<(int_nvvm_ff_to_e2m1x2_rn_satfinite f32:$a, f32:$b),
             (CVT_e2m1x2_f32_sf $a, $b, CvtRN)>;
   def : Pat<(int_nvvm_ff_to_e2m1x2_rn_relu_satfinite f32:$a, f32:$b),
@@ -2392,7 +2392,7 @@ let Predicates = [callSubtarget<"hasNarrowFPConversionSupport">] in {
             (CVT_f16x2_e2m1x2 $a, CvtRN_RELU)>;
 }
 
-let Predicates = [callSubtarget<"hasFP16X2ToNarrowFPConversionSupport">] in {
+let Predicates = [hasFP16X2ToNarrowFPConversionSupport] in {
   foreach src_type = ["f16x2", "bf16x2"] in {
     foreach relu = ["", "_relu"] in {
       defvar intrin = !cast<Intrinsic>("int_nvvm_" # src_type # "_to_e2m1x2_rn" # relu # "_satfinite");
@@ -2403,7 +2403,7 @@ let Predicates = [callSubtarget<"hasFP16X2ToNarrowFPConversionSupport">] in {
   }
 }
 
-let Predicates = [callSubtarget<"hasNarrowFPToBF16x2ConversionSupport">] in {
+let Predicates = [hasNarrowFPToBF16x2ConversionSupport] in {
   foreach relu = ["", "_relu"] in {
     foreach satfinite = ["", "_satfinite"] in {
       defvar intrin = !cast<Intrinsic>("int_nvvm_e2m1x2_to_bf16x2_rn" # relu # satfinite # "_scale_n2_ue8m0");
@@ -2413,9 +2413,9 @@ let Predicates = [callSubtarget<"hasNarrowFPToBF16x2ConversionSupport">] in {
                 (inst $a, $b, mode)>;
     }
   }
-} // let Predicates = [callSubtarget<"hasNarrowFPToBF16x2ConversionSupport">]
+} // let Predicates = [hasNarrowFPToBF16x2ConversionSupport]
 
-let Predicates = [callSubtarget<"hasNarrowFPConversionSupport">] in {
+let Predicates = [hasNarrowFPConversionSupport] in {
   def : Pat<(int_nvvm_ff_to_ue8m0x2_rz f32:$a, f32:$b),
             (CVT_ue8m0x2_f32 $a, $b, CvtRZ)>;
   def : Pat<(int_nvvm_ff_to_ue8m0x2_rz_satfinite f32:$a, f32:$b),
@@ -2439,7 +2439,7 @@ let Predicates = [callSubtarget<"hasNarrowFPConversionSupport">] in {
 }
 
 // ue5m3x2 to f16x2 / bf16x2 conversions.
-let Predicates = [callSubtarget<"hasUE5M3TypeSupport">] in {
+let Predicates = [hasUE5M3TypeSupport] in {
   def : Pat<(int_nvvm_ue5m3x2_to_f16x2_rn i16:$a),
             (CVT_f16x2_ue5m3x2 $a, CvtRN)>;
   
@@ -2452,7 +2452,7 @@ let Predicates = [callSubtarget<"hasUE5M3TypeSupport">] in {
             (CVT_bf16x2_ue5m3x2_scale_n2 $a, $b, CvtRN)>;
   def : Pat<(int_nvvm_ue5m3x2_to_bf16x2_rn_satfinite_scale_n2_ue8m0 i16:$a, i16:$b),
             (CVT_bf16x2_ue5m3x2_scale_n2 $a, $b, CvtRN_SATFINITE)>;
-} // let Predicates = [callSubtarget<"hasUE5M3TypeSupport">]
+} // let Predicates = [hasUE5M3TypeSupport]
 
 def SDT_CVT_F32X4_TO_FPX4_RS_VEC :
   SDTypeProfile<1, 6, [SDTCisVec<0>, SDTCisFP<1>, SDTCisFP<2>, SDTCisFP<3>, 
@@ -2480,7 +2480,7 @@ multiclass CVT_F32X4_TO_FPX4_RS_SF_VEC<string FPName, VTVec RetTy> {
 }
 
 // RS rounding mode conversions
-let Predicates = [callSubtarget<"hasConvertWithStochasticRounding">] in {
+let Predicates = [hasConvertWithStochasticRounding] in {
 // FP8x4 conversions
 defm : CVT_F32X4_TO_FPX4_RS_SF_VEC<"e4m3", v4i8>;
 defm : CVT_F32X4_TO_FPX4_RS_SF_VEC<"e5m2", v4i8>;
@@ -2618,7 +2618,7 @@ defm INT_PTX_ATOM_ADD_32 : F_ATOMIC_2<I32RT, atomic_load_add_i32, "add.u32", ato
 defm INT_PTX_ATOM_ADD_64 : F_ATOMIC_2<I64RT, atomic_load_add_i64, "add.u64", atomic_load_add>;
 
 defm INT_PTX_ATOM_ADD_F16  : F_ATOMIC_2<F16RT, atomic_load_fadd, "add.noftz.f16", atomic_load_fadd, [SM70, PTX63]>;
-defm INT_PTX_ATOM_ADD_BF16 : F_ATOMIC_2<BF16RT, atomic_load_fadd, "add.noftz.bf16", atomic_load_fadd, [SM90, PTX78]>;
+defm INT_PTX_ATOM_ADD_BF16 : F_ATOMIC_2<BF16RT, atomic_load_fadd, "add.noftz.bf16", atomic_load_fadd, [SM90]>;
 defm INT_PTX_ATOM_ADD_F32  : F_ATOMIC_2<F32RT, atomic_load_fadd, "add.f32", atomic_load_fadd>;
 defm INT_PTX_ATOM_ADD_F64  : F_ATOMIC_2<F64RT, atomic_load_fadd, "add.f64", atomic_load_fadd, [hasAtomAddF64]>;
 
@@ -2948,7 +2948,7 @@ defm isspace_local  : ISSPACEP<"local", int_nvvm_isspacep_local>;
 defm isspace_shared : ISSPACEP<"shared", int_nvvm_isspacep_shared>;
 defm isspace_shared_cluster : ISSPACEP<"shared::cluster",
                                        int_nvvm_isspacep_shared_cluster,
-                                       [PTX78, SM90]>;
+                                       [SM90]>;
 
 // Special register reads
 def MOV_SPECIAL : BasicNVPTXInst<(outs B32:$d),
@@ -4868,22 +4868,22 @@ defm INT_PTX_SREG_CTAID : PTX_READ_SREG_R32V4<"ctaid">;
 defm INT_PTX_SREG_NCTAID: PTX_READ_SREG_R32V4<"nctaid">;
 
 defm INT_PTX_SREG_CLUSTERID :
-       PTX_READ_SREG_R32V4<"clusterid", [SM90, PTX78]>;
+       PTX_READ_SREG_R32V4<"clusterid", [SM90]>;
 defm INT_PTX_SREG_NCLUSTERID :
-       PTX_READ_SREG_R32V4<"nclusterid", [SM90, PTX78]>;
+       PTX_READ_SREG_R32V4<"nclusterid", [SM90]>;
 defm INT_PTX_SREG_CLUSTER_CTAID :
-       PTX_READ_SREG_R32V4<"cluster_ctaid", [SM90, PTX78]>;
+       PTX_READ_SREG_R32V4<"cluster_ctaid", [SM90]>;
 defm INT_PTX_SREG_CLUSTER_NCTAID:
-       PTX_READ_SREG_R32V4<"cluster_nctaid", [SM90, PTX78]>;
+       PTX_READ_SREG_R32V4<"cluster_nctaid", [SM90]>;
 
 def  INT_PTX_SREG_CLUSTER_CTARANK :
        PTX_READ_SREG_R32<"cluster_ctarank",
                          int_nvvm_read_ptx_sreg_cluster_ctarank,
-                         [SM90, PTX78]>;
+                         [SM90]>;
 def  INT_PTX_SREG_CLUSTER_NCTARANK:
        PTX_READ_SREG_R32<"cluster_nctarank",
                          int_nvvm_read_ptx_sreg_cluster_nctarank,
-                         [SM90, PTX78]>;
+                         [SM90]>;
 
 def INT_PTX_SREG_TOTAL_SMEM_SIZE :
     PTX_READ_SREG_R32<"total_smem_size", int_nvvm_read_ptx_sreg_total_smem_size>;
@@ -4993,25 +4993,25 @@ class WMMA_REGINFO<WMMA_REGS r, string op, string metadata = "",
          !eq(kind, "mxf4nvf4"),
          !eq(stype, "ue8m0"),
          !eq(scale, ".scale_4x"))
-      : [callSubtarget<"hasMMAWithMXF4NVF4Scale4xE8M0">],
+      : [hasMMAWithMXF4NVF4Scale4xE8M0],
 
     !and(!eq(op, "mma.sp.block_scale"),
          !eq(kind, "mxf4nvf4"),
          !eq(stype, "ue8m0"),
          !eq(scale, ".scale_4x"))
-      : [callSubtarget<"hasMMASparseWithMXF4NVF4Scale4xE8M0">],
+      : [hasMMASparseWithMXF4NVF4Scale4xE8M0],
 
     !and(!eq(op, "mma.sp.block_scale"),
         !eq(kind, "mxf4nvf4"),
-        !eq(kind, "mxf4")) : [callSubtarget<"hasMMASparseBlockScaleF4">],
+        !eq(kind, "mxf4")) : [hasMMASparseBlockScaleF4],
 
     !or(!eq(op, "mma.block_scale"),
-        !eq(op, "mma.sp.block_scale")) : [callSubtarget<"hasMMABlockScale">],
+        !eq(op, "mma.sp.block_scale")) : [hasMMABlockScale],
 
     !or(!eq(ptx_elt_type, "e3m2"),
         !eq(ptx_elt_type, "e2m3"),
         !eq(ptx_elt_type, "e2m1"),
-        !ne(kind, "")) : [callSubtarget<"hasMMABlockScale">],
+        !ne(kind, "")) : [hasMMABlockScale],
 
     !and(!or(!eq(ptx_elt_type,"e4m3"),
              !eq(ptx_elt_type,"e5m2")),
@@ -5027,15 +5027,15 @@ class WMMA_REGINFO<WMMA_REGS r, string op, string metadata = "",
     // fp16 -> fp16/fp32 @ m16n16k16
     !and(!eq(geom, "m16n16k16"),
          !or(!eq(ptx_elt_type, "f16"),
-             !eq(ptx_elt_type, "f32"))) : [SM70, PTX60],
+             !eq(ptx_elt_type, "f32"))) : [SM70],
 
     !and(!eq(geom, "m8n8k4"),
-         !eq(ptx_elt_type, "f64")) : [SM80, PTX70],
+         !eq(ptx_elt_type, "f64")) : [SM80],
 
     !and(!or(!eq(geom, "m16n8k4"),
              !eq(geom, "m16n8k8"),
              !eq(geom, "m16n8k16")),
-         !eq(ptx_elt_type, "f64")) : [SM90, PTX78],
+         !eq(ptx_elt_type, "f64")) : [SM90],
 
     // fp16 -> fp16/fp32 @ m8n32k16/m32n8k16
     !and(!or(!eq(geom, "m8n32k16"),
@@ -5054,21 +5054,21 @@ class WMMA_REGINFO<WMMA_REGS r, string op, string metadata = "",
     !and(!or(!eq(geom, "m16n16k16"),
              !eq(geom, "m8n32k16"),
              !eq(geom, "m32n8k16")),
-         !eq(ptx_elt_type, "bf16")) : [SM80, PTX70],
+         !eq(ptx_elt_type, "bf16")) : [SM80],
 
     !and(!eq(geom, "m16n16k8"),
-         !eq(ptx_elt_type, "tf32")) : [SM80, PTX70],
+         !eq(ptx_elt_type, "tf32")) : [SM80],
 
     !and(!eq(geom, "m16n16k8"),
-         !eq(ptx_elt_type, "f32")) : [SM80, PTX70],
+         !eq(ptx_elt_type, "f32")) : [SM80],
 
     // b1 -> s32 @ m8n8k128(b1)
     !and(!ne(op, "mma"),
-         !eq(geom, "m8n8k128")) : [SM75, PTX63],
+         !eq(geom, "m8n8k128")) : [SM75],
 
     // u4/s4 -> s32 @ m8n8k32 (u4/s4)
     !and(!ne(op, "mma"),
-         !eq(geom, "m8n8k32")) : [SM75, PTX63],
+         !eq(geom, "m8n8k32")) : [SM75],
 
     !or(!eq(geom, "m16n8k8"),
         !eq(geom, "m8n8k16")) : [SM75, PTX65],
@@ -5081,7 +5081,7 @@ class WMMA_REGINFO<WMMA_REGS r, string op, string metadata = "",
          !eq(geom, "m8n8k32")) : [SM75, PTX65],
 
     !and(!eq(ptx_elt_type, "f64"),
-         !eq(geom, "m8n8k4")) : [SM80, PTX70],
+         !eq(geom, "m8n8k4")) : [SM80],
 
     !and(!eq(op, "mma"),
          !or(!eq(geom, "m16n8k16"),
@@ -5090,7 +5090,7 @@ class WMMA_REGINFO<WMMA_REGS r, string op, string metadata = "",
              !eq(geom, "m16n8k64"),
              !eq(geom, "m8n8k128"),
              !eq(geom, "m16n8k128"),
-             !eq(geom, "m16n8k256"))) : [SM80, PTX70],
+             !eq(geom, "m16n8k256"))) : [SM80],
 
     !and(!eq(op, "ldmatrix"),
          !eq(ptx_elt_type, "b16"),
@@ -5098,30 +5098,30 @@ class WMMA_REGINFO<WMMA_REGS r, string op, string metadata = "",
 
     !and(!eq(op, "ldmatrix"),
          !eq(ptx_elt_type, "b8"),
-         !eq(geom, "m16n16")) : [callSubtarget<"hasLdStmatrixBlackwellSupport">],
+         !eq(geom, "m16n16")) : [hasLdStmatrixBlackwellSupport],
 
     !and(!eq(op, "ldmatrix"),
          !eq(ptx_elt_type, "b8x16.b6x16_p32"),
-         !eq(geom, "m16n16")) : [callSubtarget<"hasLdStmatrixBlackwellSupport">],
+         !eq(geom, "m16n16")) : [hasLdStmatrixBlackwellSupport],
 
     !and(!eq(op, "ldmatrix"),
          !eq(ptx_elt_type, "b8x16.b4x16_p64"),
-         !eq(geom, "m16n16")) : [callSubtarget<"hasLdStmatrixBlackwellSupport">],
+         !eq(geom, "m16n16")) : [hasLdStmatrixBlackwellSupport],
 
     !and(!eq(op, "ldmatrix"),
          !eq(ptx_elt_type, "b8x16.b6x16_p32"),
-         !eq(geom, "m8n16")) : [callSubtarget<"hasLdStmatrixBlackwellSupport">],
+         !eq(geom, "m8n16")) : [hasLdStmatrixBlackwellSupport],
 
     !and(!eq(op, "ldmatrix"),
          !eq(ptx_elt_type, "b8x16.b4x16_p64"),
-         !eq(geom, "m8n16")) : [callSubtarget<"hasLdStmatrixBlackwellSupport">],
+         !eq(geom, "m8n16")) : [hasLdStmatrixBlackwellSupport],
 
     !and(!eq(op, "stmatrix"),!eq(ptx_elt_type, "b16"),
-         !eq(geom, "m8n8")) : [SM90, PTX78],
+         !eq(geom, "m8n8")) : [SM90],
 
     !and(!eq(op, "stmatrix"),
          !eq(ptx_elt_type, "b8"),
-         !eq(geom, "m16n8")) : [callSubtarget<"hasLdStmatrixBlackwellSupport">]);
+         !eq(geom, "m16n8")) : [hasLdStmatrixBlackwellSupport]);
 
   // template DAGs for instruction inputs/output.
   dag Outs = !dag(outs, ptx_regs, reg_names);
@@ -5659,7 +5659,7 @@ foreach mma = !listconcat(MMAs, MMA_BLOCK_SCALEs, WMMAs, MMA_LDSTs, LDMATRIXs,
   def : MMA_PAT<mma>;
 
 multiclass MAPA<string suffix, Intrinsic Intr> {
-  let Predicates = [SM90, PTX78] in {
+  let Predicates = [SM90] in {
     def _32: BasicNVPTXInst<(outs B32:$d), (ins B32:$a, B32:$b),
                 "mapa" # suffix # ".u32",
                 [(set i32:$d, (Intr i32:$a, i32:$b))]>;
@@ -5681,7 +5681,7 @@ defm mapa_shared_cluster  : MAPA<".shared::cluster", int_nvvm_mapa_shared_cluste
 
 
 multiclass GETCTARANK<string suffix, Intrinsic Intr> {
-  let Predicates = [SM90, PTX78] in {
+  let Predicates = [SM90] in {
     def _32: BasicNVPTXInst<(outs B32:$d), (ins B32:$a),
                 "getctarank" # suffix # ".u32",
                 [(set i32:$d, (Intr i32:$a))]>;
@@ -5697,7 +5697,7 @@ defm getctarank_shared_cluster  : GETCTARANK<".shared::cluster", int_nvvm_getcta
 def is_explicit_cluster: NVPTXInst<(outs B1:$d), (ins),
               "mov.pred\t$d, %is_explicit_cluster;",
               [(set i1:$d, (int_nvvm_is_explicit_cluster))]>,
-    Requires<[SM90, PTX78]>;
+    Requires<[SM90]>;
 
 // setmaxnreg inc/dec intrinsics
 let isConvergent = true in {
@@ -5705,7 +5705,7 @@ multiclass SET_MAXNREG<string Action, Intrinsic Intr> {
   def : BasicNVPTXInst<(outs), (ins i32imm:$reg_count),
           "setmaxnreg." # Action # ".sync.aligned.u32",
           [(Intr timm:$reg_count)]>,
-    Requires<[callSubtarget<"hasSetMaxNRegSupport">]>;
+    Requires<[hasSetMaxNRegSupport]>;
 }
 
 defm INT_SET_MAXNREG_INC : SET_MAXNREG<"inc", int_nvvm_setmaxnreg_inc_sync_aligned_u32>;
@@ -5716,7 +5716,7 @@ defm INT_SET_MAXNREG_DEC : SET_MAXNREG<"dec", int_nvvm_setmaxnreg_dec_sync_align
 //
 // WGMMA fence instructions
 //
-let isConvergent = true, Predicates = [SM90a, PTX80] in {
+let isConvergent = true, Predicates = [SM90a] in {
   def WGMMA_FENCE_SYNC_ALIGNED : NullaryInst<"wgmma.fence.sync.aligned", int_nvvm_wgmma_fence_sync_aligned>;
 
   def WGMMA_COMMIT_GROUP_SYNC_ALIGNED : NullaryInst<"wgmma.commit_group.sync.aligned", int_nvvm_wgmma_commit_group_sync_aligned>;
@@ -5725,7 +5725,7 @@ let isConvergent = true, Predicates = [SM90a, PTX80] in {
                               [(int_nvvm_wgmma_wait_group_sync_aligned timm:$n)]>;
 }
 
-let Predicates = [SM90, PTX78] in {
+let Predicates = [SM90] in {
   def GRIDDEPCONTROL_LAUNCH_DEPENDENTS :
         NullaryInst<"griddepcontrol.launch_dependents", int_nvvm_griddepcontrol_launch_dependents>;
   def GRIDDEPCONTROL_WAIT :
@@ -5736,7 +5736,7 @@ def EXIT : NullaryInst<"exit", int_nvvm_exit>;
 
 // Tcgen05 intrinsics
 let isConvergent = true in {
-let Predicates = [callSubtarget<"hasTcgen05InstSupport">] in {
+let Predicates = [hasTcgen05InstSupport] in {
 multiclass TCGEN05_ALLOC_INTR<string AS, string num, Intrinsic Intr> {
   def "" : BasicNVPTXInst<(outs),
              (ins ADDR:$dst, B32:$ncols),
@@ -5788,7 +5788,7 @@ multiclass TCGEN05_COMMIT_INTR<string num> {
   def _MC : BasicNVPTXInst<(outs), (ins ADDR:$mbar, B16:$mc),
               prefix # ".multicast::cluster.b64",
               [(IntrMC addr:$mbar, i16:$mc)]>;
-  let Predicates = [callSubtarget<"hasRubinFamilySupport">] in {
+  let Predicates = [hasRubinFamilySupport] in {
     def _MC_32B : BasicNVPTXInst<(outs), (ins ADDR:$mbar, B32:$mc),
                     prefix # ".multicast::cluster::32b.b64",
                     [(IntrMC addr:$mbar, i32:$mc)]>;
@@ -5839,7 +5839,7 @@ foreach src_fmt = ["", "b6x16_p32", "b4x16_p64"] in {
 defm TCGEN05_COMMIT_CG1 : TCGEN05_COMMIT_INTR<"1">;
 defm TCGEN05_COMMIT_CG2 : TCGEN05_COMMIT_INTR<"2">;
 
-let Predicates = [callSubtarget<"hasTcgen05ShiftSupport">] in {
+let Predicates = [hasTcgen05ShiftSupport] in {
 multiclass TCGEN05_SHIFT_INTR<string num, Intrinsic Intr> {
   def "" : BasicNVPTXInst<(outs),
              (ins ADDR:$tmem_addr),
@@ -5852,7 +5852,7 @@ defm TCGEN05_SHIFT_CG2: TCGEN05_SHIFT_INTR<"2", int_nvvm_tcgen05_shift_down_cg2>
 
 } // isConvergent
 
-let hasSideEffects = 1, Predicates = [callSubtarget<"hasTcgen05InstSupport">] in {
+let hasSideEffects = 1, Predicates = [hasTcgen05InstSupport] in {
 
   def tcgen05_fence_before_thread_sync: NullaryInst<
     "tcgen05.fence::before_thread_sync", int_nvvm_tcgen05_fence_before_thread_sync>;
@@ -5934,7 +5934,7 @@ class TCGEN05_ST_INST<string Shape, int Num, bit Unpack> :
                   # ";";
 }
 
-let isConvergent = true, Predicates = [callSubtarget<"hasTcgen05InstSupport">] in {
+let isConvergent = true, Predicates = [hasTcgen05InstSupport] in {
 
 foreach shape = ["16x64b", "16x128b", "16x256b", "32x32b", "16x32bx2"] in {
   foreach num = !range(0, 8) in {
@@ -5979,7 +5979,7 @@ class Tcgen05LdRedSDNode<string Shape, int Num, string Type>:
 class Tcgen05LdRedInst<string Shape, int Num, string RedOp, string Type,
                        bit Abs = 0, bit Nan = 0>:
          NVPTXInst<(outs), (ins), "?", []>,
-         Requires<[callSubtarget<"hasTcgen05LdRedSupport">]> {
+         Requires<[hasTcgen05LdRedSupport]> {
 
   bit IsFloat = !eq(Type, "f32");
   string TypeStr = !if(IsFloat, "f32", "u32");
@@ -6056,7 +6056,7 @@ let isConvergent = true in {
 // Bulk store instructions
 def st_bulk_imm : TImmLeaf<i64, [{ return Imm == 0; }]>;
 
-let Predicates = [SM100, PTX86] in {
+let Predicates = [SM100] in {
   def INT_NVVM_ST_BULK_GENERIC :
     BasicNVPTXInst<(outs), (ins ADDR:$dest_addr, B64:$size, i64imm:$value),
               "st.bulk",
@@ -6196,14 +6196,14 @@ def CLUSTERLAUNCHCONTRL_TRY_CANCEL:
       BasicNVPTXInst<(outs), (ins ADDR:$addr, ADDR:$mbar),
                 "clusterlaunchcontrol.try_cancel.async.shared::cta.mbarrier::complete_tx::bytes.b128",
                 [(int_nvvm_clusterlaunchcontrol_try_cancel_async_shared addr:$addr, addr:$mbar)]>,
-      Requires<[SM100, PTX86]>;
+      Requires<[SM100]>;
 
 def CLUSTERLAUNCHCONTRL_TRY_CANCEL_MULTICAST:
       BasicNVPTXInst<(outs), (ins ADDR:$addr, ADDR:$mbar),
                 "clusterlaunchcontrol.try_cancel.async.shared::cta.mbarrier::complete_tx::bytes" #
                 ".multicast::cluster::all.b128",
                 [(int_nvvm_clusterlaunchcontrol_try_cancel_async_multicast_shared addr:$addr, addr:$mbar)]>,
-      Requires<[callSubtarget<"hasClusterLaunchControlTryCancelMulticastSupport">]>;
+      Requires<[hasClusterLaunchControlTryCancelMulticastSupport]>;
 
 def SDTClusterLaunchControlQueryCancelIsCanceled: SDTypeProfile<1, 2, []>;
 def clusterlaunchcontrol_query_cancel_is_canceled:
@@ -6218,7 +6218,7 @@ def CLUSTERLAUNCHCONTROL_QUERY_CANCEL_IS_CANCELED:
                "clusterlaunchcontrol.query_cancel.is_canceled.pred.b128 $pred, %clc_handle;\n\t" #
             "}}", [(set i1:$pred,
                         (clusterlaunchcontrol_query_cancel_is_canceled i64:$try_cancel_response0, i64:$try_cancel_response1))]>,
-            Requires<[SM100, PTX86]>;
+            Requires<[SM100]>;
 
 class CLUSTERLAUNCHCONTROL_QUERY_CANCEL_GET_FIRST_CTAID<string Dim>:
   NVPTXInst<(outs B32:$reg), (ins B64:$try_cancel_response0, B64:$try_cancel_response1),
@@ -6229,7 +6229,7 @@ class CLUSTERLAUNCHCONTROL_QUERY_CANCEL_GET_FIRST_CTAID<string Dim>:
             "}}", [(set i32:$reg,
                         (!cast<SDNode>("clusterlaunchcontrol_query_cancel_first_cta_id_" # Dim)
                           i64:$try_cancel_response0, i64:$try_cancel_response1))]>,
-            Requires<[SM100, PTX86]>;
+            Requires<[SM100]>;
 
 foreach dim = ["x", "y", "z"] in {
   def SDTClusterLaunchControlQueryCancelGetFirstCtaId # dim: SDTypeProfile<1, 2, []>;
@@ -6314,11 +6314,11 @@ class Tcgen05MMAInst<bit IsSparse, string ASpace, string Kind, int CtaGroup,
         Tcgen05MMABase<IsSparse, ASpace, Kind, CtaGroup, CollectorUsageA,
                        CollectorUsageB> {
   let Predicates = !listconcat(
-    !if(HasCollectorBQualifier, [callSubtarget<"hasRubinFamilySupport">], []),
+    !if(HasCollectorBQualifier, [hasRubinFamilySupport], []),
     !cond(
-      IsScaleInputD : [callSubtarget<"hasTcgen05MMAScaleInputDImm">],
-      !eq(Kind, "i8") : [callSubtarget<"hasTcgen05MMAI8Kind">],
-      true : [callSubtarget<"hasTcgen05InstSupport">]
+      IsScaleInputD : [hasTcgen05MMAScaleInputDImm],
+      !eq(Kind, "i8") : [hasTcgen05MMAI8Kind],
+      true : [hasTcgen05InstSupport]
     )
   );
 
@@ -6420,11 +6420,11 @@ class Tcgen05MMADisableOutputLaneInst<bit IsSparse, string ASpace, string Kind,
         Tcgen05MMABase<IsSparse, ASpace, Kind, CtaGroup, CollectorUsageA,
                        CollectorUsageB> {
   let Predicates = !listconcat(
-    !if(HasCollectorBQualifier, [callSubtarget<"hasRubinFamilySupport">], []),
+    !if(HasCollectorBQualifier, [hasRubinFamilySupport], []),
     !cond(
-      IsScaleInputD : [callSubtarget<"hasTcgen05MMAScaleInputDImm">],
-      !eq(Kind, "i8") : [callSubtarget<"hasTcgen05MMAI8Kind">],
-      true : [callSubtarget<"hasTcgen05InstSupport">]
+      IsScaleInputD : [hasTcgen05MMAScaleInputDImm],
+      !eq(Kind, "i8") : [hasTcgen05MMAI8Kind],
+      true : [hasTcgen05InstSupport]
     )
   );
 
@@ -6516,14 +6516,14 @@ class Tcgen05MMABlockScaleInst<bit IsSparse, string ASpace, string Kind,
         Tcgen05MMABase<IsSparse, ASpace, Kind, CtaGroup, CollectorUsageA,
                        CollectorUsageB> {
   let Predicates = !listconcat(
-    !if(HasCollectorBQualifier, [callSubtarget<"hasRubinFamilySupport">], []),
+    !if(HasCollectorBQualifier, [hasRubinFamilySupport], []),
     !cond(
       !and(IsSparse,
-           !eq(Kind, "mxf4")) : [callSubtarget<"hasTcgen05MMASparseMxf4">],
+           !eq(Kind, "mxf4")) : [hasTcgen05MMASparseMxf4],
       !and(IsSparse,
-           !eq(Kind, "mxf4nvf4")) : [callSubtarget<"hasTcgen05MMASparseMxf4nvf4">],
-      !ne(ScaleVecSize, "") : [callSubtarget<"hasTcgen05InstSupport">, PTX88],
-      true : [callSubtarget<"hasTcgen05InstSupport">]
+           !eq(Kind, "mxf4nvf4")) : [hasTcgen05MMASparseMxf4nvf4],
+      !ne(ScaleVecSize, "") : [hasTcgen05InstSupport, PTX88],
+      true : [hasTcgen05InstSupport]
     )
   );
 
@@ -6590,8 +6590,8 @@ class Tcgen05MMAWSInst<bit IsSparse, string ASpace, string Kind,
         Tcgen05MMABase<IsSparse, ASpace, Kind, /*CtaGroup=*/ 1, CollectorUsage> {
 
   let Predicates = !cond(
-    !eq(Kind, "i8") : [callSubtarget<"hasTcgen05MMAI8Kind">],
-    true : [callSubtarget<"hasTcgen05InstSupport">]
+    !eq(Kind, "i8") : [hasTcgen05MMAI8Kind],
+    true : [hasTcgen05InstSupport]
   );
 
   Intrinsic Intrin = !cast<Intrinsic>(
@@ -6667,7 +6667,7 @@ class TensormapReplaceInst_3<string state_space, string field_name,
 foreach ss = ["GLOBAL", "SHARED_CTA"] in {
   defvar pred = !if(!eq(ss, "GLOBAL"), AS_match.global, AS_match.shared);
   defvar ss_ptx = !tolower(!subst("_", "::", ss));
-  let Predicates = [callSubtarget<"hasTensormapReplaceSupport">] in {
+  let Predicates = [hasTensormapReplaceSupport] in {
     def TENSORMAP_REPLACE_TILE_GLOBAL_ADDRESS_ # ss : 
       TensormapReplaceInst_2<ss_ptx, "global_address", "b64", B64, i64,
         int_nvvm_tensormap_replace_global_address, pred>;
@@ -6698,7 +6698,7 @@ foreach ss = ["GLOBAL", "SHARED_CTA"] in {
   def TENSORMAP_REPLACE_SWIZZLE_ATOMICITY_ # ss : 
     TensormapReplaceInst_2<ss_ptx, "swizzle_atomicity", "b32", B32, i32, 
       int_nvvm_tensormap_replace_swizzle_atomicity, pred>,
-    Requires<[callSubtarget<"hasTensormapReplaceSwizzleAtomicitySupport">]>;
+    Requires<[hasTensormapReplaceSwizzleAtomicitySupport]>;
 
   def TENSORMAP_REPLACE_SWIZZLE_MODE_ # ss : 
     TensormapReplaceInst_2<ss_ptx, "swizzle_mode", "b32", B32, i32, 

--- a/llvm/lib/Target/NVPTX/NVPTXSubtarget.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXSubtarget.cpp
@@ -160,7 +160,7 @@ bool NVPTXSubtarget::allowFP16Math() const {
 }
 
 bool NVPTXSubtarget::hasF32x2Instructions() const {
-  return hasFeature(NVPTX::SM100) && hasFeature(NVPTX::PTX86) && !NoF32x2;
+  return hasFeature(NVPTX::SM100) && !NoF32x2;
 }
 
 bool NVPTXSubtarget::hasNativeBF16Support(unsigned Opcode) const {
@@ -183,7 +183,7 @@ bool NVPTXSubtarget::hasNativeBF16Support(unsigned Opcode) const {
   case ISD::FRINT:
   case ISD::FROUNDEVEN:
   case ISD::FTRUNC:
-    return hasFeature(NVPTX::SM90) && hasFeature(NVPTX::PTX78);
+    return hasFeature(NVPTX::SM90);
   // Several BF16 instructions are available on sm_80 only.
   case ISD::FMINNUM:
   case ISD::FMAXNUM:
@@ -191,7 +191,7 @@ bool NVPTXSubtarget::hasNativeBF16Support(unsigned Opcode) const {
   case ISD::FMINNUM_IEEE:
   case ISD::FMAXIMUM:
   case ISD::FMINIMUM:
-    return hasFeature(NVPTX::SM80) && hasFeature(NVPTX::PTX70);
+    return hasFeature(NVPTX::SM80);
   }
   return true;
 }

--- a/llvm/lib/Target/NVPTX/NVPTXSubtarget.h
+++ b/llvm/lib/Target/NVPTX/NVPTXSubtarget.h
@@ -95,9 +95,7 @@ public:
   bool hasAtomSwap128() const {
     return hasFeature(NVPTX::SM90) && hasFeature(NVPTX::PTX83);
   }
-  bool hasClusters() const {
-    return hasFeature(NVPTX::SM90) && hasFeature(NVPTX::PTX78);
-  }
+  bool hasClusters() const { return hasFeature(NVPTX::SM90); }
   bool hasLDG() const { return hasFeature(NVPTX::SM32); }
   bool hasHWROT32() const { return hasFeature(NVPTX::SM32); }
   bool hasBrx() const {
@@ -112,9 +110,7 @@ public:
   }
   // Does SM & PTX support memory orderings (weak and atomic: relaxed, acquire,
   // release, acq_rel, sc) ?
-  bool hasMemoryOrdering() const {
-    return hasFeature(NVPTX::SM70) && hasFeature(NVPTX::PTX60);
-  }
+  bool hasMemoryOrdering() const { return hasFeature(NVPTX::SM70); }
   // Does SM & PTX support .acquire and .release qualifiers for fence?
   bool hasSplitAcquireAndReleaseFences() const {
     return hasFeature(NVPTX::SM90) && hasFeature(NVPTX::PTX86);
@@ -123,9 +119,7 @@ public:
   bool hasRelaxedMMIO() const {
     return hasFeature(NVPTX::SM70) && hasFeature(NVPTX::PTX82);
   }
-  bool hasDotInstructions() const {
-    return hasFeature(NVPTX::SM61) && hasFeature(NVPTX::PTX50);
-  }
+  bool hasDotInstructions() const { return hasFeature(NVPTX::SM61); }
   // Cache hint SM/PTX version requirements
   bool hasL1EvictionHint() const {
     return hasFeature(NVPTX::SM70) && hasFeature(NVPTX::PTX74);
@@ -157,113 +151,8 @@ public:
     return hasAnyFeature({NVPTX::SM100f, NVPTX::SM110f});
   }
 
-  // Checks Rubin family extensions support.
-  //  - TMA S2G im2col_w mode support
-  //  - tcgen05.commit shared mem A variants.
-  bool hasRubinFamilySupport() const { return hasAnyFeature({NVPTX::SM107f}); }
-
-  // Checks tcgen05.shift instruction support.
-  bool hasTcgen05ShiftSupport() const {
-    return hasAnyFeature({NVPTX::SM100a, NVPTX::SM103a, NVPTX::SM110a});
-  }
-
-  bool hasTcgen05MMAScaleInputDImm() const {
-    return hasAnyFeature({NVPTX::SM100f});
-  }
-
-  bool hasTcgen05MMAI8Kind() const {
-    return hasAnyFeature({NVPTX::SM100a, NVPTX::SM110a});
-  }
-
-  bool hasTcgen05MMASparseMxf4nvf4() const {
-    return hasFeature(NVPTX::PTX87) &&
-           hasAnyFeature({NVPTX::SM100a, NVPTX::SM103a, NVPTX::SM110a});
-  }
-
-  bool hasTcgen05MMASparseMxf4() const {
-    return hasAnyFeature({NVPTX::SM100a, NVPTX::SM103a, NVPTX::SM110a});
-  }
-
-  bool hasTcgen05LdRedSupport() const {
-    return hasFeature(NVPTX::PTX88) &&
-           hasAnyFeature({NVPTX::SM103f, NVPTX::SM110f});
-  }
-
-  bool hasReduxSyncF32() const { return hasAnyFeature({NVPTX::SM100f}); }
-
-  bool hasMMABlockScale() const { return hasAnyFeature({NVPTX::SM120f}); }
-
-  bool hasMMASparseBlockScaleF4() const {
-    return hasAnyFeature({NVPTX::SM120a, NVPTX::SM121a});
-  }
-
-  bool hasMMAWithMXF4NVF4Scale4xE8M0() const {
-    return hasFeature(NVPTX::PTX91) && hasAnyFeature({NVPTX::SM120f});
-  }
-
-  bool hasMMASparseWithMXF4NVF4Scale4xE8M0() const {
-    return hasFeature(NVPTX::PTX91) &&
-           hasAnyFeature({NVPTX::SM120a, NVPTX::SM121a});
-  }
-
   // f32x2 instructions in Blackwell family
   bool hasF32x2Instructions() const;
-
-  // Checks support for following in TMA:
-  //  - cta_group::1/2 support
-  //  - im2col_w/w_128 mode support
-  //  - tile_gather4 mode support
-  //  - tile_scatter4 mode support
-  bool hasTMABlackwellSupport() const {
-    return hasAnyFeature({NVPTX::SM100f, NVPTX::SM110f});
-  }
-
-  // Checks support for conversions involving e4m3x2 and e5m2x2.
-  bool hasFP8ConversionSupport() const {
-    if (hasFeature(NVPTX::PTX81))
-      return hasFeature(NVPTX::SM89);
-
-    if (hasFeature(NVPTX::PTX78))
-      return hasFeature(NVPTX::SM90);
-
-    return false;
-  }
-
-  // Checks support for conversions involving the following types:
-  // - e2m3x2/e3m2x2
-  // - e2m1x2
-  // - ue8m0x2
-  bool hasNarrowFPConversionSupport() const {
-    return hasAnyFeature({NVPTX::SM100f, NVPTX::SM110f, NVPTX::SM120f});
-  }
-
-  // Checks support for conversions involving the following types:
-  // - bf16x2 -> f8x2
-  // - f16x2 -> f6x2
-  // - bf16x2 -> f6x2
-  // - f16x2 -> f4x2
-  // - bf16x2 -> f4x2
-  bool hasFP16X2ToNarrowFPConversionSupport() const {
-    return hasFeature(NVPTX::PTX91) &&
-           hasAnyFeature({NVPTX::SM100f, NVPTX::SM110f, NVPTX::SM120f});
-  }
-
-  bool hasS2F6X2ConversionSupport() const {
-    return hasFeature(NVPTX::PTX91) &&
-           hasAnyFeature({NVPTX::SM100a, NVPTX::SM103a, NVPTX::SM110a,
-                          NVPTX::SM120a, NVPTX::SM121a});
-  }
-
-  // Checks support for conversions from narrow FP types to bf16x2.
-  bool hasNarrowFPToBF16x2ConversionSupport() const {
-    return hasFeature(NVPTX::PTX92) &&
-           hasAnyFeature({NVPTX::SM100f, NVPTX::SM110f, NVPTX::SM120f});
-  }
-
-  // Checks support for conversions involving ue5m3x2.
-  bool hasUE5M3TypeSupport() const {
-    return hasFeature(NVPTX::PTX94) && hasAnyFeature({NVPTX::SM107f});
-  }
 
   bool hasTensormapReplaceSupport() const {
     return hasAnyFeature({NVPTX::SM100f, NVPTX::SM110f, NVPTX::SM120f}) ||
@@ -280,32 +169,12 @@ public:
     return hasTensormapReplaceSupport();
   }
 
-  bool hasTensormapReplaceSwizzleAtomicitySupport() const {
-    return (hasFeature(NVPTX::PTX88) &&
-            hasAnyFeature({NVPTX::SM100f, NVPTX::SM110f, NVPTX::SM120f})) ||
-           (hasFeature(NVPTX::PTX87) &&
-            hasAnyFeature({NVPTX::SM100a, NVPTX::SM110a, NVPTX::SM120a}));
-  }
-
   bool hasTensormapReplaceSwizzleModeSupport(unsigned SwizzleMode) const {
     if (SwizzleMode ==
         static_cast<unsigned>(nvvm::TensormapSwizzleMode::SWIZZLE_96B))
       return hasAnyFeature({NVPTX::SM103a});
 
     return hasTensormapReplaceSupport();
-  }
-
-  bool hasClusterLaunchControlTryCancelMulticastSupport() const {
-    return hasAnyFeature({NVPTX::SM100f, NVPTX::SM110f, NVPTX::SM120f});
-  }
-
-  bool hasSetMaxNRegSupport() const {
-    return hasAnyFeature(
-        {NVPTX::SM90a, NVPTX::SM100f, NVPTX::SM110f, NVPTX::SM120f});
-  }
-
-  bool hasLdStmatrixBlackwellSupport() const {
-    return hasAnyFeature({NVPTX::SM100f, NVPTX::SM110f, NVPTX::SM120f});
   }
 
   // Prior to CUDA 12.3 ptxas did not recognize that the trap instruction
@@ -318,10 +187,6 @@ public:
   bool hasPTXASUnreachableBug() const { return !hasFeature(NVPTX::PTX83); }
   bool hasCvtaParam() const {
     return hasFeature(NVPTX::SM70) && hasFeature(NVPTX::PTX77);
-  }
-  bool hasConvertWithStochasticRounding() const {
-    return hasFeature(NVPTX::PTX87) &&
-           hasAnyFeature({NVPTX::SM100a, NVPTX::SM103a});
   }
   // The compute capability as a number, for __CUDA_ARCH__. This is the one
   // place an architecture needs to be a number, and it is not an identity:


### PR DESCRIPTION
Remove redundant PTX checks when that version of PTX is already required by the architecture. 

Introduces some new helper classes in TableGen and move predicates out of C++ where possible.