### PR TITLE
[GlobPattern] add AsLiteral to help lld determine if a symbol is literal

### DIFF
--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -1361,7 +1361,11 @@ void SymbolPatterns::clear() {
 
 void SymbolPatterns::insert(StringRef symbolName) {
   Expected<GlobPattern> pattern = GlobPattern::create(symbolName);
-  checkError(pattern.takeError());
+  if (!pattern) {
+    error("invalid symbol-name pattern: " + symbolName + ": " +
+          toString(pattern.takeError()));
+    return;
+  }
   // A pattern that denotes a single string is kept as a literal: literals are
   // matched by hash lookup, and only literals seed the force-load of lazy
   // archive members below.

--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -1361,11 +1361,7 @@ void SymbolPatterns::clear() {
 
 void SymbolPatterns::insert(StringRef symbolName) {
   Expected<GlobPattern> pattern = GlobPattern::create(symbolName);
-  if (!pattern) {
-    llvm::consumeError(pattern.takeError());
-    error("invalid symbol-name pattern: " + symbolName);
-    return;
-  }
+  checkError(pattern.takeError());
   // A pattern that denotes a single string is kept as a literal: literals are
   // matched by hash lookup, and only literals seed the force-load of lazy
   // archive members below.

--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -1369,8 +1369,7 @@ void SymbolPatterns::insert(StringRef symbolName) {
   // A pattern that denotes a single string is kept as a literal: literals are
   // matched by hash lookup, and only literals seed the force-load of lazy
   // archive members below.
-  SmallString<32> storage;
-  if (std::optional<StringRef> literal = pattern->asLiteral(storage)) {
+  if (std::optional<std::string> literal = pattern->asLiteral()) {
     literals.insert(CachedHashStringRef(saver().save(*literal)));
     return;
   }

--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -1369,7 +1369,7 @@ void SymbolPatterns::insert(StringRef symbolName) {
   // A pattern that denotes a single string is kept as a literal: literals are
   // matched by hash lookup, and only literals seed the force-load of lazy
   // archive members below.
-  SmallVector<char, 128> storage;
+  SmallString<32> storage;
   if (std::optional<StringRef> literal = pattern->asLiteral(storage)) {
     literals.insert(CachedHashStringRef(saver().save(*literal)));
     return;

--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -1360,12 +1360,21 @@ void SymbolPatterns::clear() {
 }
 
 void SymbolPatterns::insert(StringRef symbolName) {
-  if (symbolName.find_first_of("*?[]") == StringRef::npos)
-    literals.insert(CachedHashStringRef(symbolName));
-  else if (Expected<GlobPattern> pattern = GlobPattern::create(symbolName))
-    globs.emplace_back(*pattern);
-  else
+  Expected<GlobPattern> pattern = GlobPattern::create(symbolName);
+  if (!pattern) {
+    llvm::consumeError(pattern.takeError());
     error("invalid symbol-name pattern: " + symbolName);
+    return;
+  }
+  // A pattern that denotes a single string is kept as a literal: literals are
+  // matched by hash lookup, and only literals seed the force-load of lazy
+  // archive members below.
+  SmallVector<char, 128> storage;
+  if (std::optional<StringRef> literal = pattern->asLiteral(storage)) {
+    literals.insert(CachedHashStringRef(saver().save(*literal)));
+    return;
+  }
+  globs.emplace_back(std::move(*pattern));
 }
 
 bool SymbolPatterns::matchLiteral(StringRef symbolName) const {

--- a/lld/test/MachO/exported-symbols-list-escapes.s
+++ b/lld/test/MachO/exported-symbols-list-escapes.s
@@ -1,25 +1,23 @@
 # REQUIRES: x86
 
-## An -exported_symbols_list entry may escape glob metacharacters with a
-## backslash to name a symbol literally. This matters for Objective-C direct
-## methods, whose names contain square brackets that would otherwise be parsed
-## as a character class and match nothing.
-
 # RUN: rm -rf %t; split-file %s %t
 # RUN: llvm-mc -filetype=obj -triple=x86_64-apple-macos %t/bracket.s -o %t/bracket.o
 # RUN: llvm-mc -filetype=obj -triple=x86_64-apple-macos %t/anchor.s -o %t/anchor.o
 # RUN: llvm-ar --format=darwin rcs %t/bracket.a %t/bracket.o
 
-## An escaped entry is a literal: it exact-matches, and because literals seed
-## addUndefined it also force-loads the archive member that defines it.
 # RUN: %lld -dylib -exported_symbols_list %t/escaped.txt \
 # RUN:     %t/anchor.o %t/bracket.a -o %t/escaped.dylib
 # RUN: llvm-nm --extern-only %t/escaped.dylib | FileCheck --check-prefix=ESCAPED %s
 
 # ESCAPED: -[C m]D
 
-## An unescaped entry keeps its glob meaning: "[C m]" is a character class, so
-## it does not match the real symbol and nothing is force-loaded.
+# RUN: %lld -dylib -exported_symbols_list %t/opener-only.txt \
+# RUN:     %t/anchor.o %t/bracket.a -o %t/opener-only.dylib
+# RUN: llvm-nm --extern-only %t/opener-only.dylib | \
+# RUN:     FileCheck --check-prefix=OPENER-ONLY %s
+
+# OPENER-ONLY: -[C m]D
+
 # RUN: %lld -dylib -exported_symbols_list %t/unescaped.txt \
 # RUN:     %t/anchor.o %t/bracket.a -o %t/unescaped.dylib
 # RUN: llvm-nm --extern-only %t/unescaped.dylib | \
@@ -27,8 +25,6 @@
 
 # UNESCAPED-NOT: -[C m]D
 
-## Escaping a star names a symbol that literally contains one, rather than
-## matching any symbol by prefix.
 # RUN: llvm-mc -filetype=obj -triple=x86_64-apple-macos %t/star.s -o %t/star.o
 # RUN: %lld -dylib -exported_symbols_list %t/escaped-star.txt \
 # RUN:     %t/star.o -o %t/star.dylib
@@ -57,6 +53,9 @@ _litoteral:
 
 #--- escaped.txt
 _-\[C m\]D
+
+#--- opener-only.txt
+_-\[C m]D
 
 #--- unescaped.txt
 _-[C m]D

--- a/lld/test/MachO/exported-symbols-list-escapes.s
+++ b/lld/test/MachO/exported-symbols-list-escapes.s
@@ -9,12 +9,18 @@
 # RUN:     %t/anchor.o %t/bracket.a -o %t/escaped.dylib
 # RUN: llvm-nm --extern-only %t/escaped.dylib | FileCheck --check-prefix=ESCAPED %s
 
+#--- escaped.txt
+_-\[C m\]D
+
 # ESCAPED: -[C m]D
 
 # RUN: %lld -dylib -exported_symbols_list %t/opener-only.txt \
 # RUN:     %t/anchor.o %t/bracket.a -o %t/opener-only.dylib
 # RUN: llvm-nm --extern-only %t/opener-only.dylib | \
 # RUN:     FileCheck --check-prefix=OPENER-ONLY %s
+
+#--- opener-only.txt
+_-\[C m]D
 
 # OPENER-ONLY: -[C m]D
 
@@ -23,6 +29,9 @@
 # RUN: llvm-nm --extern-only %t/unescaped.dylib | \
 # RUN:     FileCheck --check-prefix=UNESCAPED --allow-empty %s
 
+#--- unescaped.txt
+_-[C m]D
+
 # UNESCAPED-NOT: -[C m]D
 
 # RUN: llvm-mc -filetype=obj -triple=x86_64-apple-macos %t/star.s -o %t/star.o
@@ -30,8 +39,20 @@
 # RUN:     %t/star.o -o %t/star.dylib
 # RUN: llvm-nm --extern-only %t/star.dylib | FileCheck --check-prefix=STAR %s
 
+#--- escaped-star.txt
+_lit\*eral
+
 # STAR-DAG: _lit*eral
 # STAR-NOT: _litoteral
+
+# RUN: not %lld -dylib -exported_symbols_list %t/stray-backslash.txt \
+# RUN:     %t/anchor.o %t/bracket.a -o %t/stray.dylib 2>&1 | \
+# RUN:     FileCheck --check-prefix=STRAY %s
+
+#--- stray-backslash.txt
+_foo\
+
+# STRAY: error: invalid symbol-name pattern: _foo\: invalid glob pattern, stray '\'
 
 #--- bracket.s
 .globl "_-[C m]D"
@@ -50,15 +71,3 @@ _anchor:
 .globl _litoteral
 _litoteral:
   retq
-
-#--- escaped.txt
-_-\[C m\]D
-
-#--- opener-only.txt
-_-\[C m]D
-
-#--- unescaped.txt
-_-[C m]D
-
-#--- escaped-star.txt
-_lit\*eral

--- a/lld/test/MachO/exported-symbols-list-escapes.s
+++ b/lld/test/MachO/exported-symbols-list-escapes.s
@@ -1,0 +1,65 @@
+# REQUIRES: x86
+
+## An -exported_symbols_list entry may escape glob metacharacters with a
+## backslash to name a symbol literally. This matters for Objective-C direct
+## methods, whose names contain square brackets that would otherwise be parsed
+## as a character class and match nothing.
+
+# RUN: rm -rf %t; split-file %s %t
+# RUN: llvm-mc -filetype=obj -triple=x86_64-apple-macos %t/bracket.s -o %t/bracket.o
+# RUN: llvm-mc -filetype=obj -triple=x86_64-apple-macos %t/anchor.s -o %t/anchor.o
+# RUN: llvm-ar --format=darwin rcs %t/bracket.a %t/bracket.o
+
+## An escaped entry is a literal: it exact-matches, and because literals seed
+## addUndefined it also force-loads the archive member that defines it.
+# RUN: %lld -dylib -exported_symbols_list %t/escaped.txt \
+# RUN:     %t/anchor.o %t/bracket.a -o %t/escaped.dylib
+# RUN: llvm-nm --extern-only %t/escaped.dylib | FileCheck --check-prefix=ESCAPED %s
+
+# ESCAPED: -[C m]D
+
+## An unescaped entry keeps its glob meaning: "[C m]" is a character class, so
+## it does not match the real symbol and nothing is force-loaded.
+# RUN: %lld -dylib -exported_symbols_list %t/unescaped.txt \
+# RUN:     %t/anchor.o %t/bracket.a -o %t/unescaped.dylib
+# RUN: llvm-nm --extern-only %t/unescaped.dylib | \
+# RUN:     FileCheck --check-prefix=UNESCAPED --allow-empty %s
+
+# UNESCAPED-NOT: -[C m]D
+
+## Escaping a star names a symbol that literally contains one, rather than
+## matching any symbol by prefix.
+# RUN: llvm-mc -filetype=obj -triple=x86_64-apple-macos %t/star.s -o %t/star.o
+# RUN: %lld -dylib -exported_symbols_list %t/escaped-star.txt \
+# RUN:     %t/star.o -o %t/star.dylib
+# RUN: llvm-nm --extern-only %t/star.dylib | FileCheck --check-prefix=STAR %s
+
+# STAR-DAG: _lit*eral
+# STAR-NOT: _litoteral
+
+#--- bracket.s
+.globl "_-[C m]D"
+"_-[C m]D":
+  retq
+
+#--- anchor.s
+.globl _anchor
+_anchor:
+  retq
+
+#--- star.s
+.globl "_lit*eral"
+"_lit*eral":
+  retq
+.globl _litoteral
+_litoteral:
+  retq
+
+#--- escaped.txt
+_-\[C m\]D
+
+#--- unescaped.txt
+_-[C m]D
+
+#--- escaped-star.txt
+_lit\*eral

--- a/llvm/include/llvm/Support/GlobPattern.h
+++ b/llvm/include/llvm/Support/GlobPattern.h
@@ -19,6 +19,7 @@
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <optional>
+#include <string>
 
 namespace llvm {
 
@@ -65,12 +66,7 @@ public:
   /// no unescaped metacharacters; otherwise std::nullopt. Escapes are resolved,
   /// so `a\*b` yields `a*b`. Characters that are only special in context (`]`,
   /// `}`, `,`) do not make a pattern non-literal.
-  ///
-  /// \p Storage is used only when escapes have to be resolved; otherwise the
-  /// result aliases the text passed to create(). The result is valid for as
-  /// long as both remain alive.
-  LLVM_ABI std::optional<StringRef>
-  asLiteral(SmallVectorImpl<char> &Storage) const;
+  LLVM_ABI std::optional<std::string> asLiteral() const;
 
   // Returns true for glob pattern "*". Can be used to avoid expensive
   // preparation/acquisition of the input for match().

--- a/llvm/include/llvm/Support/GlobPattern.h
+++ b/llvm/include/llvm/Support/GlobPattern.h
@@ -61,6 +61,17 @@ public:
   /// \returns \p true if \p S matches this glob pattern
   LLVM_ABI bool match(StringRef S) const;
 
+  /// \returns the single string this pattern matches, if the pattern contains
+  /// no unescaped metacharacters; otherwise std::nullopt. Escapes are resolved,
+  /// so `a\*b` yields `a*b`. Characters that are only special in context (`]`,
+  /// `}`, `,`) do not make a pattern non-literal.
+  ///
+  /// \p Storage is used only when escapes have to be resolved; otherwise the
+  /// result aliases the text passed to create(). The result is valid for as
+  /// long as both remain alive.
+  LLVM_ABI std::optional<StringRef>
+  asLiteral(SmallVectorImpl<char> &Storage) const;
+
   // Returns true for glob pattern "*". Can be used to avoid expensive
   // preparation/acquisition of the input for match().
   bool isTrivialMatchAll() const {
@@ -97,6 +108,8 @@ private:
     /// \returns \p true if \p S matches this glob pattern
     LLVM_ABI bool match(StringRef S, bool SlashAgnostic) const;
     StringRef getPat() const { return StringRef(Pat.data(), Pat.size()); }
+    /// \returns \p true if this sub-pattern matches exactly one string.
+    bool isLiteral() const { return Brackets.empty() && !HasWildcard; }
 
     // Brackets with their end position and matched bytes.
     struct Bracket {
@@ -104,6 +117,8 @@ private:
       BitVector Bytes;
     };
     SmallVector<Bracket, 0> Brackets;
+    // Set while parsing if an unescaped '*' or '?' is present.
+    bool HasWildcard = false;
     SmallVector<char, 0> Pat;
   };
   SmallVector<SubGlobPattern, 1> SubGlobs;

--- a/llvm/lib/Support/GlobPattern.cpp
+++ b/llvm/lib/Support/GlobPattern.cpp
@@ -231,7 +231,7 @@ GlobPattern::asLiteral(SmallVectorImpl<char> &Storage) const {
   // this pattern denotes a single string is decided by the sub-patterns, which
   // recorded it while parsing. No sub-pattern at all means there was no
   // metacharacter; more than one means brace expansion produced a choice.
-  if (!SubGlobs.empty() && !(SubGlobs.size() == 1 && SubGlobs[0].isLiteral()))
+  if (SubGlobs.size() > 1 || (SubGlobs.size() == 1 && !SubGlobs[0].isLiteral()))
     return std::nullopt;
 
   StringRef Literal = Pattern;

--- a/llvm/lib/Support/GlobPattern.cpp
+++ b/llvm/lib/Support/GlobPattern.cpp
@@ -225,8 +225,7 @@ Expected<GlobPattern> GlobPattern::create(StringRef S,
   return Pat;
 }
 
-std::optional<StringRef>
-GlobPattern::asLiteral(SmallVectorImpl<char> &Storage) const {
+std::optional<std::string> GlobPattern::asLiteral() const {
   // The prefix and suffix are metacharacter-free by construction, so whether
   // this pattern denotes a single string is decided by the sub-patterns, which
   // recorded it while parsing. No sub-pattern at all means there was no
@@ -234,22 +233,19 @@ GlobPattern::asLiteral(SmallVectorImpl<char> &Storage) const {
   if (SubGlobs.size() > 1 || (SubGlobs.size() == 1 && !SubGlobs[0].isLiteral()))
     return std::nullopt;
 
-  StringRef Literal = Pattern;
-  if (Pattern.contains('\\')) {
-    Storage.clear();
-    Storage.reserve(Pattern.size());
-    for (size_t I = 0, E = Pattern.size(); I != E; ++I) {
-      if (Pattern[I] == '\\' && I + 1 != E)
-        ++I;
-      Storage.push_back(Pattern[I]);
-    }
-    Literal = StringRef(Storage.data(), Storage.size());
+  std::string Literal;
+  Literal.reserve(Pattern.size());
+  for (size_t I = 0, E = Pattern.size(); I != E; ++I) {
+    if (Pattern[I] == '\\' && I + 1 != E)
+      ++I;
+    Literal.push_back(Pattern[I]);
   }
 
   // In slash-agnostic mode '/' and '\\' match each other, so a pattern holding
   // either matches more than one string. A pattern with no sub-pattern cannot
   // reach here holding one, as both are prefix metacharacters in that mode.
-  if (SlashAgnostic && Literal.find_first_of("/\\") != StringRef::npos)
+  if (SlashAgnostic &&
+      StringRef(Literal).find_first_of("/\\") != StringRef::npos)
     return std::nullopt;
 
   return Literal;

--- a/llvm/lib/Support/GlobPattern.cpp
+++ b/llvm/lib/Support/GlobPattern.cpp
@@ -242,8 +242,7 @@ GlobPattern::asLiteral(SmallVectorImpl<char> &Storage) const {
   // this pattern denotes a single string is decided by the sub-patterns, which
   // recorded it while parsing. No sub-pattern at all means there was no
   // metacharacter; more than one means brace expansion produced a choice.
-  if (!SubGlobs.empty() &&
-      !(SubGlobs.size() == 1 && SubGlobs[0].isLiteral()))
+  if (!SubGlobs.empty() && !(SubGlobs.size() == 1 && SubGlobs[0].isLiteral()))
     return std::nullopt;
 
   if (!Pattern.contains('\\'))

--- a/llvm/lib/Support/GlobPattern.cpp
+++ b/llvm/lib/Support/GlobPattern.cpp
@@ -182,6 +182,17 @@ static StringRef maxPlainSubstring(StringRef S, bool SlashAgnostic) {
   return Best;
 }
 
+// Writes S into Storage with its escaping backslashes removed.
+static void unescapePattern(StringRef S, SmallVectorImpl<char> &Storage) {
+  Storage.clear();
+  Storage.reserve(S.size());
+  for (size_t I = 0, E = S.size(); I != E; ++I) {
+    if (S[I] == '\\' && I + 1 != E)
+      ++I;
+    Storage.push_back(S[I]);
+  }
+}
+
 Expected<GlobPattern> GlobPattern::create(StringRef S,
                                           std::optional<size_t> MaxSubPatterns,
                                           bool SlashAgnostic) {
@@ -225,6 +236,23 @@ Expected<GlobPattern> GlobPattern::create(StringRef S,
   return Pat;
 }
 
+std::optional<StringRef>
+GlobPattern::asLiteral(SmallVectorImpl<char> &Storage) const {
+  // The prefix and suffix are metacharacter-free by construction, so whether
+  // this pattern denotes a single string is decided by the sub-patterns, which
+  // recorded it while parsing. No sub-pattern at all means there was no
+  // metacharacter; more than one means brace expansion produced a choice.
+  if (!SubGlobs.empty() &&
+      !(SubGlobs.size() == 1 && SubGlobs[0].isLiteral()))
+    return std::nullopt;
+
+  if (!Pattern.contains('\\'))
+    return Pattern;
+
+  unescapePattern(Pattern, Storage);
+  return StringRef(Storage.data(), Storage.size());
+}
+
 Expected<GlobPattern::SubGlobPattern>
 GlobPattern::SubGlobPattern::create(StringRef S, bool SlashAgnostic) {
   SubGlobPattern Pat;
@@ -260,6 +288,8 @@ GlobPattern::SubGlobPattern::create(StringRef S, bool SlashAgnostic) {
       if (++I == E)
         return make_error<StringError>("invalid glob pattern, stray '\\'",
                                        errc::invalid_argument);
+    } else if (S[I] == '*' || S[I] == '?') {
+      Pat.HasWildcard = true;
     }
   }
   return Pat;

--- a/llvm/lib/Support/GlobPattern.cpp
+++ b/llvm/lib/Support/GlobPattern.cpp
@@ -182,17 +182,6 @@ static StringRef maxPlainSubstring(StringRef S, bool SlashAgnostic) {
   return Best;
 }
 
-// Writes S into Storage with its escaping backslashes removed.
-static void unescapePattern(StringRef S, SmallVectorImpl<char> &Storage) {
-  Storage.clear();
-  Storage.reserve(S.size());
-  for (size_t I = 0, E = S.size(); I != E; ++I) {
-    if (S[I] == '\\' && I + 1 != E)
-      ++I;
-    Storage.push_back(S[I]);
-  }
-}
-
 Expected<GlobPattern> GlobPattern::create(StringRef S,
                                           std::optional<size_t> MaxSubPatterns,
                                           bool SlashAgnostic) {
@@ -245,11 +234,25 @@ GlobPattern::asLiteral(SmallVectorImpl<char> &Storage) const {
   if (!SubGlobs.empty() && !(SubGlobs.size() == 1 && SubGlobs[0].isLiteral()))
     return std::nullopt;
 
-  if (!Pattern.contains('\\'))
-    return Pattern;
+  StringRef Literal = Pattern;
+  if (Pattern.contains('\\')) {
+    Storage.clear();
+    Storage.reserve(Pattern.size());
+    for (size_t I = 0, E = Pattern.size(); I != E; ++I) {
+      if (Pattern[I] == '\\' && I + 1 != E)
+        ++I;
+      Storage.push_back(Pattern[I]);
+    }
+    Literal = StringRef(Storage.data(), Storage.size());
+  }
 
-  unescapePattern(Pattern, Storage);
-  return StringRef(Storage.data(), Storage.size());
+  // In slash-agnostic mode '/' and '\\' match each other, so a pattern holding
+  // either matches more than one string. A pattern with no sub-pattern cannot
+  // reach here holding one, as both are prefix metacharacters in that mode.
+  if (SlashAgnostic && Literal.find_first_of("/\\") != StringRef::npos)
+    return std::nullopt;
+
+  return Literal;
 }
 
 Expected<GlobPattern::SubGlobPattern>

--- a/llvm/unittests/Support/GlobPatternTest.cpp
+++ b/llvm/unittests/Support/GlobPatternTest.cpp
@@ -40,14 +40,11 @@ TEST_F(GlobPatternTest, Wildcard) {
 }
 
 TEST_F(GlobPatternTest, AsLiteral) {
-  SmallVector<char, 64> Storage;
-
   // Plain literals, including characters that are only special in context.
-  // These need no unescaping, so the result aliases the pattern.
   for (StringRef P : {"abc", "", "a]c", "a}c", "a,c"}) {
     Expected<GlobPattern> Pat = GlobPattern::create(P);
     ASSERT_TRUE((bool)Pat) << P;
-    std::optional<StringRef> Lit = Pat->asLiteral(Storage);
+    std::optional<std::string> Lit = Pat->asLiteral();
     ASSERT_TRUE(Lit.has_value()) << P;
     EXPECT_EQ(*Lit, P);
   }
@@ -56,13 +53,13 @@ TEST_F(GlobPatternTest, AsLiteral) {
   for (StringRef P : {"a*c", "a?c", "a[bc]d"}) {
     Expected<GlobPattern> Pat = GlobPattern::create(P);
     ASSERT_TRUE((bool)Pat) << P;
-    EXPECT_FALSE(Pat->asLiteral(Storage).has_value()) << P;
+    EXPECT_FALSE(Pat->asLiteral().has_value()) << P;
   }
 
   // Escaped metacharacters denote a single string, with escapes resolved.
   Expected<GlobPattern> Star = GlobPattern::create("a\\*c");
   ASSERT_TRUE((bool)Star);
-  auto StarLit = Star->asLiteral(Storage);
+  auto StarLit = Star->asLiteral();
   ASSERT_TRUE(StarLit.has_value());
   EXPECT_EQ(*StarLit, "a*c");
   EXPECT_TRUE(Star->match("a*c"));
@@ -71,7 +68,7 @@ TEST_F(GlobPatternTest, AsLiteral) {
   // The motivating case: an Objective-C direct method symbol.
   Expected<GlobPattern> Method = GlobPattern::create("-\\[C m\\]D");
   ASSERT_TRUE((bool)Method);
-  auto MethodLit = Method->asLiteral(Storage);
+  auto MethodLit = Method->asLiteral();
   ASSERT_TRUE(MethodLit.has_value());
   EXPECT_EQ(*MethodLit, "-[C m]D");
   EXPECT_TRUE(Method->match("-[C m]D"));
@@ -79,32 +76,30 @@ TEST_F(GlobPatternTest, AsLiteral) {
   // An unescaped bracket expression is a character class, not this symbol.
   Expected<GlobPattern> Class = GlobPattern::create("-[C m]D");
   ASSERT_TRUE((bool)Class);
-  EXPECT_FALSE(Class->asLiteral(Storage).has_value());
+  EXPECT_FALSE(Class->asLiteral().has_value());
   EXPECT_FALSE(Class->match("-[C m]D"));
 
   // '{' is a metacharacter only when brace expansion is enabled.
   Expected<GlobPattern> NoBraces = GlobPattern::create("a{b,c}d");
   ASSERT_TRUE((bool)NoBraces);
-  EXPECT_TRUE(NoBraces->asLiteral(Storage).has_value());
+  EXPECT_TRUE(NoBraces->asLiteral().has_value());
   Expected<GlobPattern> Braces = GlobPattern::create("a{b,c}d", /*Max=*/1024);
   ASSERT_TRUE((bool)Braces);
-  EXPECT_FALSE(Braces->asLiteral(Storage).has_value());
+  EXPECT_FALSE(Braces->asLiteral().has_value());
 
   // An escaped backslash is a literal backslash.
   Expected<GlobPattern> Backslash = GlobPattern::create("a\\\\c");
   ASSERT_TRUE((bool)Backslash);
-  auto BackslashLit = Backslash->asLiteral(Storage);
+  auto BackslashLit = Backslash->asLiteral();
   ASSERT_TRUE(BackslashLit.has_value());
   EXPECT_EQ(*BackslashLit, "a\\c");
 }
 
 TEST_F(GlobPatternTest, AsLiteralSlashAgnostic) {
-  SmallString<64> Storage;
-
   // Without slash-agnostic matching a separator is an ordinary character.
   Expected<GlobPattern> Plain = GlobPattern::create("a/b");
   ASSERT_TRUE((bool)Plain);
-  auto PlainLit = Plain->asLiteral(Storage);
+  auto PlainLit = Plain->asLiteral();
   ASSERT_TRUE(PlainLit.has_value());
   EXPECT_EQ(*PlainLit, "a/b");
 
@@ -114,7 +109,7 @@ TEST_F(GlobPatternTest, AsLiteralSlashAgnostic) {
   ASSERT_TRUE((bool)Slash);
   EXPECT_TRUE(Slash->match("a/b"));
   EXPECT_TRUE(Slash->match("a\\b"));
-  EXPECT_FALSE(Slash->asLiteral(Storage).has_value());
+  EXPECT_FALSE(Slash->asLiteral().has_value());
 
   // An escaped backslash resolves to a separator, so likewise.
   Expected<GlobPattern> Backslash =
@@ -122,13 +117,13 @@ TEST_F(GlobPatternTest, AsLiteralSlashAgnostic) {
   ASSERT_TRUE((bool)Backslash);
   EXPECT_TRUE(Backslash->match("a\\b"));
   EXPECT_TRUE(Backslash->match("a/b"));
-  EXPECT_FALSE(Backslash->asLiteral(Storage).has_value());
+  EXPECT_FALSE(Backslash->asLiteral().has_value());
 
   // Escaping a non-separator is still a literal in slash-agnostic mode.
   Expected<GlobPattern> Star =
       GlobPattern::create("a\\*b", std::nullopt, /*SlashAgnostic=*/true);
   ASSERT_TRUE((bool)Star);
-  auto StarLit = Star->asLiteral(Storage);
+  auto StarLit = Star->asLiteral();
   ASSERT_TRUE(StarLit.has_value());
   EXPECT_EQ(*StarLit, "a*b");
 }

--- a/llvm/unittests/Support/GlobPatternTest.cpp
+++ b/llvm/unittests/Support/GlobPatternTest.cpp
@@ -50,7 +50,6 @@ TEST_F(GlobPatternTest, AsLiteral) {
     std::optional<StringRef> Lit = Pat->asLiteral(Storage);
     ASSERT_TRUE(Lit.has_value()) << P;
     EXPECT_EQ(*Lit, P);
-    EXPECT_EQ(Lit->data(), P.data()) << P;
   }
 
   // Real metacharacters are not literals.
@@ -63,16 +62,18 @@ TEST_F(GlobPatternTest, AsLiteral) {
   // Escaped metacharacters denote a single string, with escapes resolved.
   Expected<GlobPattern> Star = GlobPattern::create("a\\*c");
   ASSERT_TRUE((bool)Star);
-  ASSERT_TRUE(Star->asLiteral(Storage).has_value());
-  EXPECT_EQ(*Star->asLiteral(Storage), "a*c");
+  auto StarLit = Star->asLiteral(Storage);
+  ASSERT_TRUE(StarLit.has_value());
+  EXPECT_EQ(*StarLit, "a*c");
   EXPECT_TRUE(Star->match("a*c"));
   EXPECT_FALSE(Star->match("abc"));
 
   // The motivating case: an Objective-C direct method symbol.
   Expected<GlobPattern> Method = GlobPattern::create("-\\[C m\\]D");
   ASSERT_TRUE((bool)Method);
-  ASSERT_TRUE(Method->asLiteral(Storage).has_value());
-  EXPECT_EQ(*Method->asLiteral(Storage), "-[C m]D");
+  auto MethodLit = Method->asLiteral(Storage);
+  ASSERT_TRUE(MethodLit.has_value());
+  EXPECT_EQ(*MethodLit, "-[C m]D");
   EXPECT_TRUE(Method->match("-[C m]D"));
 
   // An unescaped bracket expression is a character class, not this symbol.
@@ -92,8 +93,44 @@ TEST_F(GlobPatternTest, AsLiteral) {
   // An escaped backslash is a literal backslash.
   Expected<GlobPattern> Backslash = GlobPattern::create("a\\\\c");
   ASSERT_TRUE((bool)Backslash);
-  ASSERT_TRUE(Backslash->asLiteral(Storage).has_value());
-  EXPECT_EQ(*Backslash->asLiteral(Storage), "a\\c");
+  auto BackslashLit = Backslash->asLiteral(Storage);
+  ASSERT_TRUE(BackslashLit.has_value());
+  EXPECT_EQ(*BackslashLit, "a\\c");
+}
+
+TEST_F(GlobPatternTest, AsLiteralSlashAgnostic) {
+  SmallString<64> Storage;
+
+  // Without slash-agnostic matching a separator is an ordinary character.
+  Expected<GlobPattern> Plain = GlobPattern::create("a/b");
+  ASSERT_TRUE((bool)Plain);
+  auto PlainLit = Plain->asLiteral(Storage);
+  ASSERT_TRUE(PlainLit.has_value());
+  EXPECT_EQ(*PlainLit, "a/b");
+
+  // With it, '/' also matches '\\', so this denotes two strings, not one.
+  Expected<GlobPattern> Slash =
+      GlobPattern::create("a/b", std::nullopt, /*SlashAgnostic=*/true);
+  ASSERT_TRUE((bool)Slash);
+  EXPECT_TRUE(Slash->match("a/b"));
+  EXPECT_TRUE(Slash->match("a\\b"));
+  EXPECT_FALSE(Slash->asLiteral(Storage).has_value());
+
+  // An escaped backslash resolves to a separator, so likewise.
+  Expected<GlobPattern> Backslash =
+      GlobPattern::create("a\\\\b", std::nullopt, /*SlashAgnostic=*/true);
+  ASSERT_TRUE((bool)Backslash);
+  EXPECT_TRUE(Backslash->match("a\\b"));
+  EXPECT_TRUE(Backslash->match("a/b"));
+  EXPECT_FALSE(Backslash->asLiteral(Storage).has_value());
+
+  // Escaping a non-separator is still a literal in slash-agnostic mode.
+  Expected<GlobPattern> Star =
+      GlobPattern::create("a\\*b", std::nullopt, /*SlashAgnostic=*/true);
+  ASSERT_TRUE((bool)Star);
+  auto StarLit = Star->asLiteral(Storage);
+  ASSERT_TRUE(StarLit.has_value());
+  EXPECT_EQ(*StarLit, "a*b");
 }
 
 TEST_F(GlobPatternTest, Escape) {

--- a/llvm/unittests/Support/GlobPatternTest.cpp
+++ b/llvm/unittests/Support/GlobPatternTest.cpp
@@ -39,6 +39,63 @@ TEST_F(GlobPatternTest, Wildcard) {
   EXPECT_FALSE(Pat1->match(""));
 }
 
+TEST_F(GlobPatternTest, AsLiteral) {
+  SmallVector<char, 64> Storage;
+
+  // Plain literals, including characters that are only special in context.
+  // These need no unescaping, so the result aliases the pattern.
+  for (StringRef P : {"abc", "", "a]c", "a}c", "a,c"}) {
+    Expected<GlobPattern> Pat = GlobPattern::create(P);
+    ASSERT_TRUE((bool)Pat) << P;
+    std::optional<StringRef> Lit = Pat->asLiteral(Storage);
+    ASSERT_TRUE(Lit.has_value()) << P;
+    EXPECT_EQ(*Lit, P);
+    EXPECT_EQ(Lit->data(), P.data()) << P;
+  }
+
+  // Real metacharacters are not literals.
+  for (StringRef P : {"a*c", "a?c", "a[bc]d"}) {
+    Expected<GlobPattern> Pat = GlobPattern::create(P);
+    ASSERT_TRUE((bool)Pat) << P;
+    EXPECT_FALSE(Pat->asLiteral(Storage).has_value()) << P;
+  }
+
+  // Escaped metacharacters denote a single string, with escapes resolved.
+  Expected<GlobPattern> Star = GlobPattern::create("a\\*c");
+  ASSERT_TRUE((bool)Star);
+  ASSERT_TRUE(Star->asLiteral(Storage).has_value());
+  EXPECT_EQ(*Star->asLiteral(Storage), "a*c");
+  EXPECT_TRUE(Star->match("a*c"));
+  EXPECT_FALSE(Star->match("abc"));
+
+  // The motivating case: an Objective-C direct method symbol.
+  Expected<GlobPattern> Method = GlobPattern::create("-\\[C m\\]D");
+  ASSERT_TRUE((bool)Method);
+  ASSERT_TRUE(Method->asLiteral(Storage).has_value());
+  EXPECT_EQ(*Method->asLiteral(Storage), "-[C m]D");
+  EXPECT_TRUE(Method->match("-[C m]D"));
+
+  // An unescaped bracket expression is a character class, not this symbol.
+  Expected<GlobPattern> Class = GlobPattern::create("-[C m]D");
+  ASSERT_TRUE((bool)Class);
+  EXPECT_FALSE(Class->asLiteral(Storage).has_value());
+  EXPECT_FALSE(Class->match("-[C m]D"));
+
+  // '{' is a metacharacter only when brace expansion is enabled.
+  Expected<GlobPattern> NoBraces = GlobPattern::create("a{b,c}d");
+  ASSERT_TRUE((bool)NoBraces);
+  EXPECT_TRUE(NoBraces->asLiteral(Storage).has_value());
+  Expected<GlobPattern> Braces = GlobPattern::create("a{b,c}d", /*Max=*/1024);
+  ASSERT_TRUE((bool)Braces);
+  EXPECT_FALSE(Braces->asLiteral(Storage).has_value());
+
+  // An escaped backslash is a literal backslash.
+  Expected<GlobPattern> Backslash = GlobPattern::create("a\\\\c");
+  ASSERT_TRUE((bool)Backslash);
+  ASSERT_TRUE(Backslash->asLiteral(Storage).has_value());
+  EXPECT_EQ(*Backslash->asLiteral(Storage), "a\\c");
+}
+
 TEST_F(GlobPatternTest, Escape) {
   Expected<GlobPattern> Pat1 = GlobPattern::create("\\*");
   EXPECT_TRUE((bool)Pat1);


### PR DESCRIPTION
lld determines if a `symbolName` is literal by `find_first_of("*?[]")`, which is not accurate and ignored escape characters, we do the following:

1. Add a new  API `std::optional<StringRef> asLiteral(...)` that dumps the pattern as a literal string if it is one.
2. All `symbolNames` are considered as `GlobPattern` first to leverage `asLeteral` to help us determine if a string is a literal. The quick path in during `GlobPattern` construction is `if (!S.find_first_of(PrefixMetas)) return Pat;`, so for strings without `*?[]` (most of the `symbolName`s), the performance should be about the same. 
3. `symbolName`s that are literal go back to hashing like lld did before

Added tests in lld and unit test for GlobPattern