### PR TITLE
[RISCV] Diagnose -mtune CPU with a : and no features as requiring -mexperimental-mtune-syntax.

### DIFF
--- a/clang/lib/Driver/ToolChains/Arch/RISCV.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/RISCV.cpp
@@ -404,22 +404,25 @@ riscv::getRISCVTuneCPU(const Driver &D, const llvm::opt::ArgList &Args,
   if (!MTuneArg)
     return "";
 
-  StringRef MTune = MTuneArg->getValue();
-  // Split the CPU name part from the tune features string.
-  auto [TuneCPU, TFString] = MTune.split(':');
-  if (!Args.hasFlag(options::OPT_mexperimental_mtune_syntax,
+  StringRef TuneCPU = MTuneArg->getValue();
+  StringRef TFString;
+
+  auto Idx = TuneCPU.find(':');
+  if (Idx != StringRef::npos) {
+    if (!Args.hasFlag(options::OPT_mexperimental_mtune_syntax,
                     options::OPT_mno_experimental_mtune_syntax, false)) {
-    if (!TFString.empty()) {
       // Only print this diagnostics if it's used for retrieving tune features
       // to avoid printing the same error message multiple times.
       if (TuneFeatures)
         D.Diag(diag::err_drv_invalid_riscv_mtune_string)
-            << 0 << MTune
+            << 0 << TuneCPU
             << "require '-mexperimental-mtune-syntax' to use with tune feature "
                "string";
       return std::nullopt;
     }
-    return MTune;
+
+    TFString = TuneCPU.substr(Idx + 1);
+    TuneCPU = TuneCPU.slice(0, Idx);
   }
 
   if (!TuneFeatures || TFString.empty())

--- a/clang/lib/Driver/ToolChains/Arch/RISCV.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/RISCV.cpp
@@ -410,7 +410,7 @@ riscv::getRISCVTuneCPU(const Driver &D, const llvm::opt::ArgList &Args,
   auto Idx = TuneCPU.find(':');
   if (Idx != StringRef::npos) {
     if (!Args.hasFlag(options::OPT_mexperimental_mtune_syntax,
-                    options::OPT_mno_experimental_mtune_syntax, false)) {
+                      options::OPT_mno_experimental_mtune_syntax, false)) {
       // Only print this diagnostics if it's used for retrieving tune features
       // to avoid printing the same error message multiple times.
       if (TuneFeatures)

--- a/clang/test/Driver/riscv-mtune-tune-features.c
+++ b/clang/test/Driver/riscv-mtune-tune-features.c
@@ -19,6 +19,11 @@
 // RUN:     FileCheck --check-prefix=NO-EXPERIMENTAL %s
 // NO-EXPERIMENTAL: invalid -mtune string 'sifive-x390:full-vec-fp64':
 // NO-EXPERIMENTAL-SAME: require '-mexperimental-mtune-syntax' to use with tune feature string
+//
+// RUN: not %clang --target=riscv64 -mtune=sifive-x390: -c %s 2>&1 | \
+// RUN:     FileCheck --check-prefix=NO-EXPERIMENTAL2 %s
+// NO-EXPERIMENTAL2: invalid -mtune string 'sifive-x390:':
+// NO-EXPERIMENTAL2-SAME: require '-mexperimental-mtune-syntax' to use with tune feature string
 
 // RUN: not %clang --target=riscv64 -mexperimental-mtune-syntax \
 // RUN:     -mtune=sifive-p470:full-vec-fp64 -c %s 2>&1 | \


### PR DESCRIPTION
Without -mexperimental-mtune-syntax -mtune=sifive-x280: was considering
sifive-x280: as the full CPU name and give an invalid CPU error. With this
patch we now diagnose any use of the : even if there's nothing after it.