### PR TITLE
[SandboxVec][LoadStoreVec][NFC] Extract vectorizeStores from runOnRegion

### DIFF
--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/LoadStoreVec.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/LoadStoreVec.h
@@ -16,6 +16,7 @@
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/SandboxIR/Pass.h"
+#include "llvm/Support/InstructionCost.h"
 
 namespace llvm {
 
@@ -30,6 +31,19 @@ class Type;
 
 class LLVM_ABI LoadStoreVec final : public RegionPass {
   const DataLayout *DL = nullptr;
+  /// The region saved by saveIR(), used by acceptOrRevert().
+  Region *SavedRgn = nullptr;
+  /// The region's cost at the time of saveIR().
+  InstructionCost CostBefore = 0;
+
+  /// Saves the IR along with the current cost of \p Rgn, so that
+  /// acceptOrRevert() can tell whether vectorizing was profitable.
+  void saveIR(Region &Rgn);
+
+  /// Accepts the transaction saved by saveIR() if vectorizing was profitable,
+  /// reverts it otherwise. \Returns true if the transaction was accepted.
+  bool acceptOrRevert();
+
   /// Checks legality of vectorization and \returns the vector type on success,
   /// nullopt otherwise.
   std::optional<Type *> canVectorize(ArrayRef<Instruction *> Bndl,
@@ -37,6 +51,11 @@ class LLVM_ABI LoadStoreVec final : public RegionPass {
 
   void tryEraseDeadInstrs(ArrayRef<Instruction *> Stores,
                           ArrayRef<Value *> Operands);
+
+  /// Tries to vectorize the load/store/constant ops chain \p Bndl
+  /// into a single vector store. \Returns whether it succeeded.
+  bool vectorizeStores(ArrayRef<Instruction *> Bndl, Region &Rgn,
+                       Scheduler &Sched, const Analyses &A);
 
 public:
   LoadStoreVec(StringRef AuxArg) : RegionPass("load-store-vec") {

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/LoadStoreVec.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/LoadStoreVec.h
@@ -38,6 +38,11 @@ class LLVM_ABI LoadStoreVec final : public RegionPass {
   void tryEraseDeadInstrs(ArrayRef<Instruction *> Stores,
                           ArrayRef<Value *> Operands);
 
+  /// Tries to vectorize the store chain \p Bndl into a single vector store.
+  /// \Returns whether it succeeded.
+  bool vectorizeStores(ArrayRef<Instruction *> Bndl, Region &Rgn,
+                       Scheduler &Sched, const Analyses &A);
+
 public:
   LoadStoreVec(StringRef AuxArg) : RegionPass("load-store-vec") {
     assert(AuxArg.empty() && "This pass ignores aux arg!");

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/LoadStoreVec.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/LoadStoreVec.cpp
@@ -64,22 +64,40 @@ void LoadStoreVec::tryEraseDeadInstrs(ArrayRef<Instruction *> Stores,
       PtrI->eraseFromParent();
 }
 
-bool LoadStoreVec::runOnRegion(Region &Rgn, const Analyses &A) {
-  SmallVector<Instruction *, 8> Bndl(Rgn.getAux().begin(), Rgn.getAux().end());
-  if (Bndl.size() < 2)
+void LoadStoreVec::saveIR(Region &Rgn) {
+  SavedRgn = &Rgn;
+  const auto &SB = cast<RegionWithScore>(Rgn).getScoreboard();
+  CostBefore = SB.getAfterCost() - SB.getBeforeCost();
+  Rgn.getContext().save();
+}
+
+bool LoadStoreVec::acceptOrRevert() {
+  auto &Ctx = SavedRgn->getContext();
+  const auto &SB = cast<RegionWithScore>(*SavedRgn).getScoreboard();
+  InstructionCost CostAfter = SB.getAfterCost() - SB.getBeforeCost();
+  InstructionCost CostGain = CostAfter - CostBefore;
+  LLVM_DEBUG(dbgs() << DEBUG_PREFIX_LOCAL << "CostGain=" << CostGain
+                    << " (After=" << CostAfter << " Before=" << CostBefore
+                    << ")\n");
+  if (CostGain > CostThreshold) {
+    LLVM_DEBUG(dbgs() << DEBUG_PREFIX_LOCAL << "Not profitable, reverting.\n");
+    Ctx.revert();
     return false;
+  }
+  LLVM_DEBUG(dbgs() << DEBUG_PREFIX_LOCAL << "Profitable accepting.\n");
+  Ctx.accept();
+  return true;
+}
+
+bool LoadStoreVec::vectorizeStores(ArrayRef<Instruction *> Bndl, Region &Rgn,
+                                   Scheduler &Sched, const Analyses &A) {
   Function &F = *Bndl[0]->getParent()->getParent();
-  DL = &F.getParent()->getDataLayout();
   auto &Ctx = F.getContext();
-  Scheduler Sched(A.getAA(), Ctx, SchedDirection::BottomUp);
   if (!VecUtils::areConsecutive<StoreInst, Instruction>(
           Bndl, A.getScalarEvolution(), *DL))
     return false;
   if (!canVectorize(Bndl, Sched))
     return false;
-
-  const auto &SB = cast<RegionWithScore>(Rgn).getScoreboard();
-  InstructionCost CostBefore = SB.getAfterCost() - SB.getBeforeCost();
 
   SmallVector<Value *, 4> Operands;
   Operands.reserve(Bndl.size());
@@ -109,7 +127,7 @@ bool LoadStoreVec::runOnRegion(Region &Rgn, const Analyses &A) {
 
   // Vectorizing mixed floats and integers with external uses may not be
   // profitable on some targets, so save state here.
-  Ctx.save();
+  saveIR(Rgn);
 
   Value *VecOp = nullptr;
   if (AllLoads) {
@@ -184,20 +202,17 @@ bool LoadStoreVec::runOnRegion(Region &Rgn, const Analyses &A) {
 
   tryEraseDeadInstrs(Bndl, Operands);
 
-  // Check the cost.
-  InstructionCost CostAfter = SB.getAfterCost() - SB.getBeforeCost();
-  InstructionCost CostGain = CostAfter - CostBefore;
-  LLVM_DEBUG(dbgs() << DEBUG_PREFIX_LOCAL << "CostGain=" << CostGain
-                    << " (After=" << CostAfter << " Before=" << CostBefore
-                    << ")\n");
-  if (CostGain > CostThreshold) {
-    LLVM_DEBUG(dbgs() << DEBUG_PREFIX_LOCAL << "Not profitable, reverting.\n");
-    Ctx.revert();
+  return acceptOrRevert();
+}
+
+bool LoadStoreVec::runOnRegion(Region &Rgn, const Analyses &A) {
+  SmallVector<Instruction *, 8> Bndl(Rgn.getAux().begin(), Rgn.getAux().end());
+  if (Bndl.size() < 2)
     return false;
-  }
-  LLVM_DEBUG(dbgs() << DEBUG_PREFIX_LOCAL << "Profitable accepting.\n");
-  Ctx.accept();
-  return true;
+  Function &F = *Bndl[0]->getParent()->getParent();
+  DL = &F.getParent()->getDataLayout();
+  Scheduler Sched(A.getAA(), F.getContext(), SchedDirection::BottomUp);
+  return vectorizeStores(Bndl, Rgn, Sched, A);
 }
 
 } // namespace sandboxir

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/LoadStoreVec.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/LoadStoreVec.cpp
@@ -64,14 +64,29 @@ void LoadStoreVec::tryEraseDeadInstrs(ArrayRef<Instruction *> Stores,
       PtrI->eraseFromParent();
 }
 
-bool LoadStoreVec::runOnRegion(Region &Rgn, const Analyses &A) {
-  SmallVector<Instruction *, 8> Bndl(Rgn.getAux().begin(), Rgn.getAux().end());
-  if (Bndl.size() < 2)
+/// Accepts the transaction if vectorizing was profitable, reverts it otherwise.
+/// \Returns true if the transaction was accepted.
+static bool acceptIfProfitable(Context &Ctx, const ScoreBoard &SB,
+                               InstructionCost CostBefore) {
+  InstructionCost CostAfter = SB.getAfterCost() - SB.getBeforeCost();
+  InstructionCost CostGain = CostAfter - CostBefore;
+  LLVM_DEBUG(dbgs() << DEBUG_PREFIX_LOCAL << "CostGain=" << CostGain
+                    << " (After=" << CostAfter << " Before=" << CostBefore
+                    << ")\n");
+  if (CostGain > CostThreshold) {
+    LLVM_DEBUG(dbgs() << DEBUG_PREFIX_LOCAL << "Not profitable, reverting.\n");
+    Ctx.revert();
     return false;
+  }
+  LLVM_DEBUG(dbgs() << DEBUG_PREFIX_LOCAL << "Profitable accepting.\n");
+  Ctx.accept();
+  return true;
+}
+
+bool LoadStoreVec::vectorizeStores(ArrayRef<Instruction *> Bndl, Region &Rgn,
+                                   Scheduler &Sched, const Analyses &A) {
   Function &F = *Bndl[0]->getParent()->getParent();
-  DL = &F.getParent()->getDataLayout();
   auto &Ctx = F.getContext();
-  Scheduler Sched(A.getAA(), Ctx, SchedDirection::BottomUp);
   if (!VecUtils::areConsecutive<StoreInst, Instruction>(
           Bndl, A.getScalarEvolution(), *DL))
     return false;
@@ -184,20 +199,17 @@ bool LoadStoreVec::runOnRegion(Region &Rgn, const Analyses &A) {
 
   tryEraseDeadInstrs(Bndl, Operands);
 
-  // Check the cost.
-  InstructionCost CostAfter = SB.getAfterCost() - SB.getBeforeCost();
-  InstructionCost CostGain = CostAfter - CostBefore;
-  LLVM_DEBUG(dbgs() << DEBUG_PREFIX_LOCAL << "CostGain=" << CostGain
-                    << " (After=" << CostAfter << " Before=" << CostBefore
-                    << ")\n");
-  if (CostGain > CostThreshold) {
-    LLVM_DEBUG(dbgs() << DEBUG_PREFIX_LOCAL << "Not profitable, reverting.\n");
-    Ctx.revert();
+  return acceptIfProfitable(Ctx, SB, CostBefore);
+}
+
+bool LoadStoreVec::runOnRegion(Region &Rgn, const Analyses &A) {
+  SmallVector<Instruction *, 8> Bndl(Rgn.getAux().begin(), Rgn.getAux().end());
+  if (Bndl.size() < 2)
     return false;
-  }
-  LLVM_DEBUG(dbgs() << DEBUG_PREFIX_LOCAL << "Profitable accepting.\n");
-  Ctx.accept();
-  return true;
+  Function &F = *Bndl[0]->getParent()->getParent();
+  DL = &F.getParent()->getDataLayout();
+  Scheduler Sched(A.getAA(), F.getContext(), SchedDirection::BottomUp);
+  return vectorizeStores(Bndl, Rgn, Sched, A);
 }
 
 } // namespace sandboxir


### PR DESCRIPTION
Move runOnRegion()'s body -- the store-chain legality checks, operand classification, vector value construction, and profitability decision -- into a new vectorizeStores(Bndl, Rgn, Sched, A) method. runOnRegion() now only builds the initial bundle from the region's Aux and calls vectorizeStores() once. Also extract the cost-check tail into acceptIfProfitable(), a small helper worth having on its own. NFC.