### PR TITLE
[flang][acc] Ensure location is set for acc routine bind target

### DIFF
--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -4791,8 +4791,11 @@ void Fortran::lower::materializeOpenACCRoutineBindTargets(
       if (mlir::func::FuncOp func =
               fir::FirOpBuilder::getNamedFunction(module, symbolTable, name))
         return func;
-      return fir::FirOpBuilder::createFunction(builder.getUnknownLoc(), module,
-                                               name, type, symbolTable);
+      // The bind target has no declaration of its own in the source: attribute
+      // it to the routine directive that named it so diagnostics can point at
+      // something meaningful.
+      return fir::FirOpBuilder::createFunction(routineOp.getLoc(), module, name,
+                                               type, symbolTable);
     };
 
     auto createRoutineForBindTarget =

--- a/flang/test/Lower/OpenACC/acc-routine-bind-string-undeclared.f90
+++ b/flang/test/Lower/OpenACC/acc-routine-bind-string-undeclared.f90
@@ -1,11 +1,13 @@
 ! A bind("name") target is its own external name, declared verbatim (not
 ! mangled), so later passes reference a live symbol.
 
-! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
+! RUN: bbc -fopenacc -emit-hlfir --mlir-print-debuginfo --mlir-print-local-scope %s -o - | FileCheck %s
 
 ! CHECK: acc.routine @[[ACLEAR_DEV_ROUTINE:.*]] func(@aclear_dev) seq
 ! CHECK: acc.routine @{{.*}} func(@_QPaclear) bind("aclear_dev") seq
 ! CHECK: func.func private @aclear_dev({{.*}}) attributes {acc.routine_info = #acc.routine_info<[@[[ACLEAR_DEV_ROUTINE]]]>}
+! CHECK-SAME: loc("{{.*}}acc-routine-bind-string-undeclared.f90":{{[0-9]+}}:{{[0-9]+}})
+! CHECK-NOT: func.func private @aclear_dev{{.*}}loc(unknown)
 
 subroutine s_bind_str_undeclared(n, x)
   integer :: n, i

--- a/flang/test/Lower/OpenACC/acc-routine-bind-undeclared.f90
+++ b/flang/test/Lower/OpenACC/acc-routine-bind-undeclared.f90
@@ -1,10 +1,12 @@
 ! An otherwise-undeclared acc routine bind(name) target still gets a func.func.
 
-! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
+! RUN: bbc -fopenacc -emit-hlfir --mlir-print-debuginfo --mlir-print-local-scope %s -o - | FileCheck %s
 
 ! CHECK: acc.routine @[[ACLEAR_SEQ_ROUTINE:.*]] func(@_QPaclear_seq) seq
 ! CHECK: acc.routine @{{.*}} func(@_QPaclear) bind(@_QPaclear_seq) seq
 ! CHECK: func.func private @_QPaclear_seq({{.*}}) attributes {acc.routine_info = #acc.routine_info<[@[[ACLEAR_SEQ_ROUTINE]]]>}
+! CHECK-SAME: loc("{{.*}}acc-routine-bind-undeclared.f90":{{[0-9]+}}:{{[0-9]+}})
+! CHECK-NOT: func.func private @_QPaclear_seq{{.*}}loc(unknown)
 
 subroutine s_bind_undeclared(n, x)
   integer :: n, i


### PR DESCRIPTION
Currently when prototype is created for an `acc routine bind` target, it receives unknown location. Update it so that it inherits the location from the `acc routine` directive that led to this creation in first place.