### PR TITLE
[libc] Remove APPEND_LIBC_TEST

### DIFF
--- a/libc/cmake/modules/LLVMLibCTestRules.cmake
+++ b/libc/cmake/modules/LLVMLibCTestRules.cmake
@@ -107,7 +107,6 @@ endfunction()
 
 function(_get_hermetic_test_compile_options output_var c_test flags)
   _get_common_test_compile_options(compile_options "${c_test}" "${flags}")
-  libc_add_definition(compile_options "LIBC_TEST=HERMETIC")
 
   # null check tests are death tests, remove from hermetic tests for now.
   if(LIBC_ADD_NULL_CHECKS)
@@ -282,7 +281,6 @@ function(create_libc_unittest fq_target_name)
 
   _get_common_test_compile_options(compile_options "${LIBC_UNITTEST_C_TEST}"
     "${LIBC_UNITTEST_FLAGS}")
-  libc_add_definition(compile_options "LIBC_TEST=UNIT")
 
   get_link_options(link_options
     ${compile_options}

--- a/libc/test/UnitTest/Test.h
+++ b/libc/test/UnitTest/Test.h
@@ -37,13 +37,4 @@
 #include "LibcTest.h"
 #endif
 
-// Some macro utility to append file names with LIBC_TEST macro's value to be
-// used in stdio tests.
-#undef STR
-#undef EVAL_THEN_STR
-#define STR(X) #X
-#define EVAL_THEN_STR(X) STR(X)
-
-#define APPEND_LIBC_TEST(X) X "." EVAL_THEN_STR(LIBC_TEST)
-
 #endif // LLVM_LIBC_TEST_UNITTEST_TEST_H

--- a/libc/test/src/__support/File/platform_file_test.cpp
+++ b/libc/test/src/__support/File/platform_file_test.cpp
@@ -21,8 +21,7 @@ LIBC_INLINE File *openfile(const char *file_name, const char *mode) {
 }
 
 TEST(LlvmLibcPlatformFileTest, CreateWriteCloseAndReadBack) {
-  constexpr char FILENAME[] =
-      APPEND_LIBC_TEST("testdata/create_write_close_and_readback.test");
+  constexpr char FILENAME[] = "testdata/create_write_close_and_readback.test";
   File *file = openfile(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
   ASSERT_EQ(file->write(TEXT, TEXT_SIZE).value, TEXT_SIZE);
@@ -43,8 +42,7 @@ TEST(LlvmLibcPlatformFileTest, CreateWriteCloseAndReadBack) {
 }
 
 TEST(LlvmLibcPlatformFileTest, CreateWriteSeekAndReadBack) {
-  constexpr char FILENAME[] =
-      APPEND_LIBC_TEST("testdata/create_write_seek_and_readback.test");
+  constexpr char FILENAME[] = "testdata/create_write_seek_and_readback.test";
   File *file = openfile(FILENAME, "w+");
   ASSERT_FALSE(file == nullptr);
   ASSERT_EQ(file->write(TEXT, TEXT_SIZE).value, TEXT_SIZE);
@@ -64,8 +62,7 @@ TEST(LlvmLibcPlatformFileTest, CreateWriteSeekAndReadBack) {
 }
 
 TEST(LlvmLibcPlatformFileTest, CreateAppendCloseAndReadBack) {
-  constexpr char FILENAME[] =
-      APPEND_LIBC_TEST("testdata/create_append_close_and_readback.test");
+  constexpr char FILENAME[] = "testdata/create_append_close_and_readback.test";
   File *file = openfile(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
   ASSERT_EQ(file->write(TEXT, TEXT_SIZE).value, TEXT_SIZE);
@@ -94,8 +91,7 @@ TEST(LlvmLibcPlatformFileTest, CreateAppendCloseAndReadBack) {
 }
 
 TEST(LlvmLibcPlatformFileTest, CreateAppendSeekAndReadBack) {
-  constexpr char FILENAME[] =
-      APPEND_LIBC_TEST("testdata/create_append_seek_and_readback.test");
+  constexpr char FILENAME[] = "testdata/create_append_seek_and_readback.test";
   File *file = openfile(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
   ASSERT_EQ(file->write(TEXT, TEXT_SIZE).value, TEXT_SIZE);
@@ -128,7 +124,7 @@ TEST(LlvmLibcPlatformFileTest, LargeFile) {
   for (size_t i = 0; i < DATA_SIZE; ++i)
     write_data[i] = BYTE;
 
-  constexpr char FILENAME[] = APPEND_LIBC_TEST("testdata/large_file.test");
+  constexpr char FILENAME[] = "testdata/large_file.test";
   File *file = openfile(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
 
@@ -155,8 +151,7 @@ TEST(LlvmLibcPlatformFileTest, LargeFile) {
 }
 
 TEST(LlvmLibcPlatformFileTest, ReadSeekCurAndRead) {
-  constexpr char FILENAME[] =
-      APPEND_LIBC_TEST("testdata/read_seek_cur_and_read.test");
+  constexpr char FILENAME[] = "testdata/read_seek_cur_and_read.test";
   File *file = openfile(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
   constexpr char CONTENT[] = "1234567890987654321";
@@ -183,8 +178,7 @@ TEST(LlvmLibcPlatformFileTest, ReadSeekCurAndRead) {
 }
 
 TEST(LlvmLibcPlatformFileTest, IncorrectOperation) {
-  constexpr char FILENAME[] =
-      APPEND_LIBC_TEST("testdata/incorrect_operation.test");
+  constexpr char FILENAME[] = "testdata/incorrect_operation.test";
   char data[1] = {123};
 
   File *file = openfile(FILENAME, "w");

--- a/libc/test/src/__support/OSUtil/linux/sysinfo_test.cpp
+++ b/libc/test/src/__support/OSUtil/linux/sysinfo_test.cpp
@@ -50,8 +50,7 @@ TEST(LlvmLibcOSUtilSysinfoTest, OnlineCpuCountSmokeTest) {
 }
 
 TEST(LlvmLibcOSUtilSysinfoTest, SyntheticCpuLists) {
-  constexpr char FILENAME[] =
-      APPEND_LIBC_TEST("sysinfo.synthetic_cpu_list.test");
+  constexpr char FILENAME[] = "sysinfo.synthetic_cpu_list.test";
   CString test_file = libc_make_test_file_path(FILENAME);
 
   struct TestCase {

--- a/libc/test/src/semaphore/linux/semaphore_test.cpp
+++ b/libc/test/src/semaphore/linux/semaphore_test.cpp
@@ -153,7 +153,7 @@ TEST(LlvmLibcSemaphoreTest, ClockWaitUnsupportedClock) {
 // Named semaphore tests.
 
 TEST(LlvmLibcSemaphoreTest, NamedOpenCloseUnlink) {
-  const char *name = APPEND_LIBC_TEST("/llvmlibc_test_sem");
+  const char *name = "/llvmlibc_test_sem";
 
   // clean up any leftover from previous test runs.
   Semaphore::unlink(name);
@@ -172,7 +172,7 @@ TEST(LlvmLibcSemaphoreTest, NamedOpenCloseUnlink) {
 }
 
 TEST(LlvmLibcSemaphoreTest, NamedOpenExisting) {
-  const char *name = APPEND_LIBC_TEST("/llvmlibc_test_sem_exist");
+  const char *name = "/llvmlibc_test_sem_exist";
 
   Semaphore::unlink(name);
 
@@ -196,7 +196,7 @@ TEST(LlvmLibcSemaphoreTest, NamedOpenExisting) {
 }
 
 TEST(LlvmLibcSemaphoreTest, NamedOpenExclFails) {
-  const char *name = APPEND_LIBC_TEST("/llvmlibc_test_sem_excl");
+  const char *name = "/llvmlibc_test_sem_excl";
 
   Semaphore::unlink(name);
 

--- a/libc/test/src/stdio/fdopen_test.cpp
+++ b/libc/test/src/stdio/fdopen_test.cpp
@@ -23,8 +23,7 @@ using LlvmLibcStdioFdopenTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
 TEST_F(LlvmLibcStdioFdopenTest, WriteAppendRead) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-  constexpr const char *TEST_FILE_NAME =
-      APPEND_LIBC_TEST("testdata/write_read_append.test");
+  constexpr const char *TEST_FILE_NAME = "testdata/write_read_append.test";
   auto TEST_FILE = libc_make_test_file_path(TEST_FILE_NAME);
   int fd = LIBC_NAMESPACE::open(TEST_FILE, O_CREAT | O_TRUNC | O_RDWR, S_IRWXU);
   auto *fp = LIBC_NAMESPACE::fdopen(fd, "w");
@@ -54,8 +53,7 @@ TEST_F(LlvmLibcStdioFdopenTest, WriteAppendRead) {
 }
 
 TEST_F(LlvmLibcStdioFdopenTest, InvalidFd) {
-  constexpr const char *TEST_FILE_NAME =
-      APPEND_LIBC_TEST("testdata/invalid_fd.test");
+  constexpr const char *TEST_FILE_NAME = "testdata/invalid_fd.test";
   auto TEST_FILE = libc_make_test_file_path(TEST_FILE_NAME);
   int fd = LIBC_NAMESPACE::open(TEST_FILE, O_CREAT | O_TRUNC);
   LIBC_NAMESPACE::close(fd);
@@ -66,8 +64,7 @@ TEST_F(LlvmLibcStdioFdopenTest, InvalidFd) {
 }
 
 TEST_F(LlvmLibcStdioFdopenTest, InvalidMode) {
-  constexpr const char *TEST_FILE_NAME =
-      APPEND_LIBC_TEST("testdata/invalid_mode.test");
+  constexpr const char *TEST_FILE_NAME = "testdata/invalid_mode.test";
   auto TEST_FILE = libc_make_test_file_path(TEST_FILE_NAME);
   int fd = LIBC_NAMESPACE::open(TEST_FILE, O_CREAT | O_RDONLY, S_IRWXU);
   ASSERT_ERRNO_SUCCESS();

--- a/libc/test/src/stdio/fgetc_test.cpp
+++ b/libc/test/src/stdio/fgetc_test.cpp
@@ -64,10 +64,9 @@ public:
 };
 
 TEST_F(LlvmLibcGetcTest, WriteAndReadCharactersWithFgetc) {
-  test_with_func(&LIBC_NAMESPACE::fgetc,
-                 APPEND_LIBC_TEST("testdata/fgetc.test"));
+  test_with_func(&LIBC_NAMESPACE::fgetc, "testdata/fgetc.test");
 }
 
 TEST_F(LlvmLibcGetcTest, WriteAndReadCharactersWithGetc) {
-  test_with_func(&LIBC_NAMESPACE::getc, APPEND_LIBC_TEST("testdata/getc.test"));
+  test_with_func(&LIBC_NAMESPACE::getc, "testdata/getc.test");
 }

--- a/libc/test/src/stdio/fgetc_unlocked_test.cpp
+++ b/libc/test/src/stdio/fgetc_unlocked_test.cpp
@@ -71,10 +71,9 @@ public:
 
 TEST_F(LlvmLibcGetcTest, WriteAndReadCharactersWithFgetcUnlocked) {
   test_with_func(&LIBC_NAMESPACE::fgetc_unlocked,
-                 APPEND_LIBC_TEST("testdata/fgetc_unlocked.test"));
+                 "testdata/fgetc_unlocked.test");
 }
 
 TEST_F(LlvmLibcGetcTest, WriteAndReadCharactersWithGetcUnlocked) {
-  test_with_func(&LIBC_NAMESPACE::getc_unlocked,
-                 APPEND_LIBC_TEST("testdata/getc_unlocked.test"));
+  test_with_func(&LIBC_NAMESPACE::getc_unlocked, "testdata/getc_unlocked.test");
 }

--- a/libc/test/src/stdio/fgets_test.cpp
+++ b/libc/test/src/stdio/fgets_test.cpp
@@ -22,7 +22,7 @@ using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
 using LIBC_NAMESPACE::cpp::scope_exit;
 
 TEST_F(LlvmLibcFgetsTest, WriteAndReadCharacters) {
-  constexpr char FILENAME[] = APPEND_LIBC_TEST("testdata/fgets.test");
+  constexpr char FILENAME[] = "testdata/fgets.test";
   char buff[8];
   char *output;
 

--- a/libc/test/src/stdio/fileop_test.cpp
+++ b/libc/test/src/stdio/fileop_test.cpp
@@ -30,8 +30,7 @@ using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::returns;
 
 TEST_F(LlvmLibcFILETest, SimpleFileOperations) {
   // TODO: Use libc_make_test_file_path macro for file paths.
-  constexpr char FILENAME[] =
-      APPEND_LIBC_TEST("testdata/simple_operations.test");
+  constexpr char FILENAME[] = "testdata/simple_operations.test";
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
   ASSERT_GE(LIBC_NAMESPACE::fileno(file), 0);
@@ -129,7 +128,7 @@ TEST_F(LlvmLibcFILETest, SimpleFileOperations) {
 }
 
 TEST_F(LlvmLibcFILETest, FFlush) {
-  constexpr char FILENAME[] = APPEND_LIBC_TEST("testdata/fflush.test");
+  constexpr char FILENAME[] = "testdata/fflush.test";
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w+");
   ASSERT_FALSE(file == nullptr);
   constexpr char CONTENT[] = "1234567890987654321";
@@ -150,7 +149,7 @@ TEST_F(LlvmLibcFILETest, FFlush) {
 }
 
 TEST_F(LlvmLibcFILETest, FFlushNull) {
-  constexpr char FILENAME[] = APPEND_LIBC_TEST("testdata/fflush_null.test");
+  constexpr char FILENAME[] = "testdata/fflush_null.test";
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w+");
   ASSERT_FALSE(file == nullptr);
   constexpr char CONTENT[] = "1234567890987654321";
@@ -176,7 +175,7 @@ TEST_F(LlvmLibcFILETest, FOpenFWriteSizeGreaterThanOne) {
   };
   constexpr MyStruct WRITE_DATA[] = {{'a', 1}, {'b', 2}, {'c', 3}};
   constexpr size_t WRITE_NMEMB = sizeof(WRITE_DATA) / sizeof(MyStruct);
-  constexpr char FILENAME[] = APPEND_LIBC_TEST("testdata/fread_fwrite.test");
+  constexpr char FILENAME[] = "testdata/fread_fwrite.test";
 
   FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);

--- a/libc/test/src/stdio/fopen_test.cpp
+++ b/libc/test/src/stdio/fopen_test.cpp
@@ -22,8 +22,7 @@ TEST(LlvmLibcFOpenTest, PrintToFile) {
 
   static constexpr char STRING[] = "A simple string written to a file\n";
   {
-    FILE *file =
-        LIBC_NAMESPACE::fopen(APPEND_LIBC_TEST("testdata/test.txt"), "w");
+    FILE *file = LIBC_NAMESPACE::fopen("testdata/test.txt", "w");
     ASSERT_FALSE(file == nullptr);
     scope_exit close_file([&] { ASSERT_EQ(0, LIBC_NAMESPACE::fclose(file)); });
 
@@ -32,8 +31,7 @@ TEST(LlvmLibcFOpenTest, PrintToFile) {
   }
 
   {
-    FILE *file =
-        LIBC_NAMESPACE::fopen(APPEND_LIBC_TEST("testdata/test.txt"), "r");
+    FILE *file = LIBC_NAMESPACE::fopen("testdata/test.txt", "r");
     ASSERT_FALSE(file == nullptr);
     scope_exit close_file([&] { ASSERT_EQ(0, LIBC_NAMESPACE::fclose(file)); });
 

--- a/libc/test/src/stdio/fprintf_test.cpp
+++ b/libc/test/src/stdio/fprintf_test.cpp
@@ -38,7 +38,7 @@ using ::fread;
 using LlvmLibcFPrintfTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
 TEST(LlvmLibcFPrintfTest, WriteToFile) {
-  const char *FILENAME = APPEND_LIBC_TEST("fprintf_output.test");
+  const char *FILENAME = "fprintf_output.test";
   auto FILE_PATH = libc_make_test_file_path(FILENAME);
 
   ::FILE *file = printf_test::fopen(FILE_PATH, "w");
@@ -93,7 +93,7 @@ TEST(LlvmLibcFPrintfTest, WriteToFile) {
     !defined(LIBC_COPT_PRINTF_DISABLE_WRITE_INT) &&                            \
     !defined(LIBC_TARGET_ARCH_IS_GPU)
 TEST(LlvmLibcFPrintfTest, NullPtrCheck) {
-  const char *FILENAME = APPEND_LIBC_TEST("fprintf_nullptr.test");
+  const char *FILENAME = "fprintf_nullptr.test";
   auto FILE_PATH = libc_make_test_file_path(FILENAME);
 
   ::FILE *file = printf_test::fopen(FILE_PATH, "w");

--- a/libc/test/src/stdio/fscanf_test.cpp
+++ b/libc/test/src/stdio/fscanf_test.cpp
@@ -36,7 +36,7 @@ using ::fwrite;
 } // namespace scanf_test
 
 TEST(LlvmLibcFScanfTest, WriteToFile) {
-  const char *FILENAME = APPEND_LIBC_TEST("fscanf_output.test");
+  const char *FILENAME = "fscanf_output.test";
   auto FILE_PATH = libc_make_test_file_path(FILENAME);
   ::FILE *file = scanf_test::fopen(FILE_PATH, "w");
   ASSERT_FALSE(file == nullptr);
@@ -92,7 +92,7 @@ TEST(LlvmLibcFScanfTest, WriteToFile) {
 }
 
 TEST(LlvmLibcFScanfTest, ProcNetIfInet6Sample) {
-  const char *FILENAME = APPEND_LIBC_TEST("proc_net_if_inet6.txt");
+  const char *FILENAME = "proc_net_if_inet6.txt";
   auto FILE_PATH = libc_make_test_file_path(FILENAME);
   ::FILE *file = scanf_test::fopen(FILE_PATH, "w");
   ASSERT_FALSE(file == nullptr);
@@ -164,7 +164,7 @@ TEST(LlvmLibcFScanfTest, ProcNetIfInet6Sample) {
 }
 
 TEST(LlvmLibcFScanfTest, EofPartialMatch) {
-  const char *FILENAME = APPEND_LIBC_TEST("eof_partial_match.txt");
+  const char *FILENAME = "eof_partial_match.txt";
   auto FILE_PATH = libc_make_test_file_path(FILENAME);
   ::FILE *file = scanf_test::fopen(FILE_PATH, "w");
   ASSERT_FALSE(file == nullptr);
@@ -193,7 +193,7 @@ TEST(LlvmLibcFScanfTest, EofPartialMatch) {
 }
 
 TEST(LlvmLibcFScanfTest, MatchingErrors) {
-  const char *FILENAME = APPEND_LIBC_TEST("matching_error_partial_match.txt");
+  const char *FILENAME = "matching_error_partial_match.txt";
   auto FILE_PATH = libc_make_test_file_path(FILENAME);
   ::FILE *file = scanf_test::fopen(FILE_PATH, "w");
   ASSERT_FALSE(file == nullptr);

--- a/libc/test/src/stdio/ftell_test.cpp
+++ b/libc/test/src/stdio/ftell_test.cpp
@@ -21,7 +21,7 @@
 class LlvmLibcFTellTest : public LIBC_NAMESPACE::testing::Test {
 protected:
   void test_with_bufmode(int bufmode) {
-    constexpr char FILENAME[] = APPEND_LIBC_TEST("testdata/ftell.test");
+    constexpr char FILENAME[] = "testdata/ftell.test";
     // We will set a special buffer to the file so that we guarantee buffering.
     constexpr size_t BUFFER_SIZE = 1024;
     char buffer[BUFFER_SIZE];

--- a/libc/test/src/stdio/putc_test.cpp
+++ b/libc/test/src/stdio/putc_test.cpp
@@ -16,7 +16,7 @@
 #include "test/UnitTest/Test.h"
 
 TEST(LlvmLibcPutcTest, WriteToFile) {
-  constexpr char FILENAME[] = APPEND_LIBC_TEST("testdata/putc_output.test");
+  constexpr char FILENAME[] = "testdata/putc_output.test";
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
 

--- a/libc/test/src/stdio/remove_test.cpp
+++ b/libc/test/src/stdio/remove_test.cpp
@@ -26,7 +26,7 @@ TEST_F(LlvmLibcRemoveTest, CreateAndRemoveFile) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
 
-  constexpr const char *FILENAME = APPEND_LIBC_TEST("remove.test.file");
+  constexpr const char *FILENAME = "remove.test.file";
   auto TEST_FILE = libc_make_test_file_path(FILENAME);
   int fd = LIBC_NAMESPACE::open(TEST_FILE, O_WRONLY | O_CREAT, S_IRWXU);
   ASSERT_ERRNO_SUCCESS();
@@ -43,7 +43,7 @@ TEST_F(LlvmLibcRemoveTest, CreateAndRemoveDir) {
   // it was removed.
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-  constexpr const char *FILENAME = APPEND_LIBC_TEST("remove.test.dir");
+  constexpr const char *FILENAME = "remove.test.dir";
   auto TEST_DIR = libc_make_test_file_path(FILENAME);
   ASSERT_THAT(LIBC_NAMESPACE::mkdirat(AT_FDCWD, TEST_DIR, S_IRWXU),
               Succeeds(0));

--- a/libc/test/src/stdio/rename_test.cpp
+++ b/libc/test/src/stdio/rename_test.cpp
@@ -24,7 +24,7 @@ TEST_F(LlvmLibcRenameTest, CreateAndRenameFile) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
 
-  constexpr const char *FILENAME0 = APPEND_LIBC_TEST("rename.test.file0");
+  constexpr const char *FILENAME0 = "rename.test.file0";
   auto TEST_FILEPATH0 = libc_make_test_file_path(FILENAME0);
 
   int fd = LIBC_NAMESPACE::open(TEST_FILEPATH0, O_WRONLY | O_CREAT, S_IRWXU);
@@ -33,7 +33,7 @@ TEST_F(LlvmLibcRenameTest, CreateAndRenameFile) {
   ASSERT_THAT(LIBC_NAMESPACE::close(fd), Succeeds(0));
   ASSERT_THAT(LIBC_NAMESPACE::access(TEST_FILEPATH0, F_OK), Succeeds(0));
 
-  constexpr const char *FILENAME1 = APPEND_LIBC_TEST("rename.test.file1");
+  constexpr const char *FILENAME1 = "rename.test.file1";
   auto TEST_FILEPATH1 = libc_make_test_file_path(FILENAME1);
   ASSERT_THAT(LIBC_NAMESPACE::rename(TEST_FILEPATH0, TEST_FILEPATH1),
               Succeeds(0));
@@ -44,7 +44,7 @@ TEST_F(LlvmLibcRenameTest, CreateAndRenameFile) {
 TEST_F(LlvmLibcRenameTest, RenameNonExistent) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
 
-  constexpr const char *FILENAME1 = APPEND_LIBC_TEST("rename.test.file1");
+  constexpr const char *FILENAME1 = "rename.test.file1";
   auto TEST_FILEPATH1 = libc_make_test_file_path(FILENAME1);
 
   ASSERT_THAT(LIBC_NAMESPACE::rename("non-existent", TEST_FILEPATH1),

--- a/libc/test/src/stdio/rewind_test.cpp
+++ b/libc/test/src/stdio/rewind_test.cpp
@@ -22,7 +22,7 @@ using LIBC_NAMESPACE::cpp::scope_exit;
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
 
 TEST_F(LlvmLibcRewindTest, WriteRewindRead) {
-  constexpr char FILENAME[] = APPEND_LIBC_TEST("testdata/rewind.test");
+  constexpr char FILENAME[] = "testdata/rewind.test";
   auto FILEPATH = libc_make_test_file_path(FILENAME);
   constexpr char FIRST_DATA[] = "123456789";
 

--- a/libc/test/src/stdio/setbuf_test.cpp
+++ b/libc/test/src/stdio/setbuf_test.cpp
@@ -18,8 +18,7 @@
 TEST(LlvmLibcSetbufTest, DefaultBufsize) {
   // The idea in this test is to change the buffer after opening a file and
   // ensure that read and write work as expected.
-  constexpr char FILENAME[] =
-      APPEND_LIBC_TEST("testdata/setbuf_test_default_bufsize.test");
+  constexpr char FILENAME[] = "testdata/setbuf_test_default_bufsize.test";
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
   char buffer[BUFSIZ];
@@ -42,8 +41,7 @@ TEST(LlvmLibcSetbufTest, DefaultBufsize) {
 TEST(LlvmLibcSetbufTest, NullBuffer) {
   // The idea in this test is that we set a null buffer and ensure that
   // everything works correctly.
-  constexpr char FILENAME[] =
-      APPEND_LIBC_TEST("testdata/setbuf_test_null_buffer.test");
+  constexpr char FILENAME[] = "testdata/setbuf_test_null_buffer.test";
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
   LIBC_NAMESPACE::setbuf(file, nullptr);

--- a/libc/test/src/stdio/setvbuf_test.cpp
+++ b/libc/test/src/stdio/setvbuf_test.cpp
@@ -23,7 +23,7 @@ TEST_F(LlvmLibcSetvbufTest, SetNBFBuffer) {
   // then set a NBF buffer to the write handle. Since it is NBF, the data
   // written using the write handle should be immediately readable by the read
   // handle.
-  constexpr char FILENAME[] = APPEND_LIBC_TEST("testdata/setvbuf_nbf.test");
+  constexpr char FILENAME[] = "testdata/setvbuf_nbf.test";
 
   ::FILE *fw = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(fw == nullptr);
@@ -59,7 +59,7 @@ TEST_F(LlvmLibcSetvbufTest, SetLBFBuffer) {
   // then set a LBF buffer to the write handle. Since it is LBF, the data
   // written using the write handle should be available right after a '\n' is
   // written.
-  constexpr char FILENAME[] = APPEND_LIBC_TEST("testdata/setvbuf_lbf.test");
+  constexpr char FILENAME[] = "testdata/setvbuf_lbf.test";
 
   ::FILE *fw = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(fw == nullptr);
@@ -96,8 +96,7 @@ TEST_F(LlvmLibcSetvbufTest, SetLBFBuffer) {
 }
 
 TEST(LlvmLibcSetbufTest, InvalidBufferMode) {
-  constexpr char FILENAME[] =
-      APPEND_LIBC_TEST("testdata/setvbuf_invalid_bufmode.test");
+  constexpr char FILENAME[] = "testdata/setvbuf_invalid_bufmode.test";
   ::FILE *f = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(f == nullptr);
   char buf[BUFSIZ];

--- a/libc/test/src/stdio/ungetc_test.cpp
+++ b/libc/test/src/stdio/ungetc_test.cpp
@@ -17,7 +17,7 @@
 #include "test/UnitTest/Test.h"
 
 TEST(LlvmLibcUngetcTest, UngetAndReadBack) {
-  constexpr char FILENAME[] = APPEND_LIBC_TEST("testdata/ungetc_test.test");
+  constexpr char FILENAME[] = "testdata/ungetc_test.test";
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
   constexpr char CONTENT[] = "abcdef";

--- a/libc/test/src/stdio/unlocked_fileop_test.cpp
+++ b/libc/test/src/stdio/unlocked_fileop_test.cpp
@@ -21,8 +21,7 @@
 using LlvmLibcFILETest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
 TEST_F(LlvmLibcFILETest, UnlockedReadAndWrite) {
-  constexpr char fNAME[] =
-      APPEND_LIBC_TEST("testdata/unlocked_read_and_write.test");
+  constexpr char fNAME[] = "testdata/unlocked_read_and_write.test";
   ::FILE *f = LIBC_NAMESPACE::fopen(fNAME, "w");
   ASSERT_FALSE(f == nullptr);
   constexpr char CONTENT[] = "1234567890987654321";

--- a/libc/test/src/stdio/vfprintf_test.cpp
+++ b/libc/test/src/stdio/vfprintf_test.cpp
@@ -49,7 +49,7 @@ int call_vfprintf(::FILE *__restrict stream, const char *__restrict format,
 using LlvmLibcVFPrintfTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
 TEST(LlvmLibcVFPrintfTest, WriteToFile) {
-  const char *FILENAME = APPEND_LIBC_TEST("vfprintf_output.test");
+  const char *FILENAME = "vfprintf_output.test";
   auto FILE_PATH = libc_make_test_file_path(FILENAME);
 
   ::FILE *file = printf_test::fopen(FILE_PATH, "w");

--- a/libc/test/src/stdio/vfscanf_test.cpp
+++ b/libc/test/src/stdio/vfscanf_test.cpp
@@ -42,7 +42,7 @@ static int call_vfscanf(::FILE *stream, const char *__restrict format, ...) {
 }
 
 TEST(LlvmLibcVFScanfTest, WriteToFile) {
-  const char *FILENAME = APPEND_LIBC_TEST("vfscanf_output.test");
+  const char *FILENAME = "vfscanf_output.test";
   auto FILE_PATH = libc_make_test_file_path(FILENAME);
   ::FILE *file = scanf_test::fopen(FILE_PATH, "w");
   ASSERT_FALSE(file == nullptr);

--- a/libc/test/src/sys/sendfile/sendfile_test.cpp
+++ b/libc/test/src/sys/sendfile/sendfile_test.cpp
@@ -29,9 +29,8 @@ TEST_F(LlvmLibcSendfileTest, CreateAndTransfer) {
   //   2. Use sendfile to copy it to another file.
   //   3. Make sure that the data was actually copied.
   //   4. Clean up the temporary files.
-  constexpr const char *IN_FILE = APPEND_LIBC_TEST("testdata/sendfile_in.test");
-  constexpr const char *OUT_FILE =
-      APPEND_LIBC_TEST("testdata/sendfile_out.test");
+  constexpr const char *IN_FILE = "testdata/sendfile_in.test";
+  constexpr const char *OUT_FILE = "testdata/sendfile_out.test";
   const char IN_DATA[] = "sendfile test";
   constexpr ssize_t IN_SIZE = ssize_t(sizeof(IN_DATA));
 

--- a/libc/test/src/sys/time/utimes_test.cpp
+++ b/libc/test/src/sys/time/utimes_test.cpp
@@ -26,7 +26,7 @@ using LlvmLibcUtimesTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 TEST_F(LlvmLibcUtimesTest, ChangeTimesSpecific) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
 
-  constexpr const char *FILE_PATH = APPEND_LIBC_TEST("utimes_pass.test");
+  constexpr const char *FILE_PATH = "utimes_pass.test";
   auto TEST_FILE = libc_make_test_file_path(FILE_PATH);
   int fd = LIBC_NAMESPACE::open(TEST_FILE, O_WRONLY | O_CREAT, S_IRWXU);
   ASSERT_ERRNO_SUCCESS();

--- a/libc/test/src/unistd/access_test.cpp
+++ b/libc/test/src/unistd/access_test.cpp
@@ -24,7 +24,7 @@ TEST_F(LlvmLibcAccessTest, CreateAndTest) {
   // test that it is accessable in those modes but not in others.
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-  constexpr const char *FILENAME = APPEND_LIBC_TEST("access.test");
+  constexpr const char *FILENAME = "access.test";
   auto TEST_FILE = libc_make_test_file_path(FILENAME);
   int fd = LIBC_NAMESPACE::open(TEST_FILE, O_WRONLY | O_CREAT, S_IRWXU);
   ASSERT_ERRNO_SUCCESS();

--- a/libc/test/src/unistd/chown_test.cpp
+++ b/libc/test/src/unistd/chown_test.cpp
@@ -25,7 +25,7 @@ TEST_F(LlvmLibcChownTest, ChownSuccess) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
   uid_t my_uid = LIBC_NAMESPACE::getuid();
   gid_t my_gid = LIBC_NAMESPACE::getgid();
-  constexpr const char *FILENAME = APPEND_LIBC_TEST("chown.test");
+  constexpr const char *FILENAME = "chown.test";
   auto TEST_FILE = libc_make_test_file_path(FILENAME);
 
   // Create a test file.

--- a/libc/test/src/unistd/dup2_test.cpp
+++ b/libc/test/src/unistd/dup2_test.cpp
@@ -22,7 +22,7 @@ using LlvmLibcdupTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 TEST_F(LlvmLibcdupTest, ReadAndWriteViaDup) {
   constexpr int DUPFD = 0xD0;
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-  constexpr const char *FILENAME = APPEND_LIBC_TEST("dup2.test");
+  constexpr const char *FILENAME = "dup2.test";
   auto TEST_FILE = libc_make_test_file_path(FILENAME);
   int fd = LIBC_NAMESPACE::open(TEST_FILE, O_WRONLY | O_CREAT, S_IRWXU);
   ASSERT_ERRNO_SUCCESS();

--- a/libc/test/src/unistd/faccessat_test.cpp
+++ b/libc/test/src/unistd/faccessat_test.cpp
@@ -28,7 +28,7 @@ using LlvmLibcFaccessatTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 TEST_F(LlvmLibcFaccessatTest, WithAtFdcwd) {
   // Test access checks on a file with AT_FDCWD and no flags, equivalent to
   // access().
-  constexpr const char *FILENAME = APPEND_LIBC_TEST("faccessat_basic.test");
+  constexpr const char *FILENAME = "faccessat_basic.test";
   auto TEST_FILE = libc_make_test_file_path(FILENAME);
 
   // Check permissions on a file with full permissions
@@ -71,7 +71,7 @@ TEST_F(LlvmLibcFaccessatTest, AtEaccess) {
   // With AT_EACCESS, faccessat checks permissions using the effective user ID,
   // but the effective and real user ID will be the same here and changing that
   // is not feasible in a test, so this is just a basic sanity check.
-  constexpr const char *FILENAME = APPEND_LIBC_TEST("faccessat_eaccess.test");
+  constexpr const char *FILENAME = "faccessat_eaccess.test";
   auto TEST_FILE = libc_make_test_file_path(FILENAME);
 
   int fd = LIBC_NAMESPACE::open(TEST_FILE, O_WRONLY | O_CREAT, S_IRWXU);
@@ -87,8 +87,7 @@ TEST_F(LlvmLibcFaccessatTest, AtEaccess) {
 }
 
 TEST_F(LlvmLibcFaccessatTest, AtEmptyPath) {
-  constexpr const char *FILENAME =
-      APPEND_LIBC_TEST("faccessat_atemptypath.test");
+  constexpr const char *FILENAME = "faccessat_atemptypath.test";
   auto TEST_FILE = libc_make_test_file_path(FILENAME);
 
   int fd = LIBC_NAMESPACE::open(TEST_FILE, O_WRONLY | O_CREAT, S_IRWXU);

--- a/libc/test/src/unistd/pread_pwrite_test.cpp
+++ b/libc/test/src/unistd/pread_pwrite_test.cpp
@@ -33,7 +33,7 @@ TEST_F(LlvmLibcUniStd, PWriteAndPReadBackTest) {
 
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
 
-  constexpr const char *FILENAME = APPEND_LIBC_TEST("pread_pwrite.test");
+  constexpr const char *FILENAME = "pread_pwrite.test";
   auto TEST_FILE = libc_make_test_file_path(FILENAME);
   int fd = LIBC_NAMESPACE::open(TEST_FILE, O_WRONLY | O_CREAT, S_IRWXU);
   ASSERT_ERRNO_SUCCESS();

--- a/libc/test/src/unistd/syscall_test.cpp
+++ b/libc/test/src/unistd/syscall_test.cpp
@@ -34,8 +34,7 @@ TEST_F(LlvmLibcSyscallTest, TrivialCall) {
 
 TEST_F(LlvmLibcSyscallTest, SymlinkCreateDestroy) {
   constexpr const char LINK_VAL[] = "syscall_readlink_test_value";
-  constexpr const char LINK[] =
-      APPEND_LIBC_TEST("testdata/syscall_readlink.test.link");
+  constexpr const char LINK[] = "testdata/syscall_readlink.test.link";
 
 #ifdef SYS_symlink
   ASSERT_GE(LIBC_NAMESPACE::syscall(SYS_symlink, LINK_VAL, LINK), 0l);
@@ -72,8 +71,7 @@ TEST_F(LlvmLibcSyscallTest, FileReadWrite) {
   constexpr const char HELLO[] = "hello";
   constexpr int HELLO_SIZE = sizeof(HELLO);
 
-  constexpr const char *TEST_FILE =
-      APPEND_LIBC_TEST("testdata/syscall_pread_pwrite.test");
+  constexpr const char *TEST_FILE = "testdata/syscall_pread_pwrite.test";
 
 #ifdef SYS_open
   long fd =
@@ -100,13 +98,11 @@ TEST_F(LlvmLibcSyscallTest, FileReadWrite) {
 
 TEST_F(LlvmLibcSyscallTest, FileLinkCreateDestroy) {
   constexpr const char *TEST_DIR = "testdata";
-  constexpr const char *TEST_FILE = APPEND_LIBC_TEST("syscall_linkat.test");
-  constexpr const char *TEST_FILE_PATH =
-      APPEND_LIBC_TEST("testdata/syscall_linkat.test");
-  constexpr const char *TEST_FILE_LINK =
-      APPEND_LIBC_TEST("syscall_linkat.test.link");
+  constexpr const char *TEST_FILE = "syscall_linkat.test";
+  constexpr const char *TEST_FILE_PATH = "testdata/syscall_linkat.test";
+  constexpr const char *TEST_FILE_LINK = "syscall_linkat.test.link";
   constexpr const char *TEST_FILE_LINK_PATH =
-      APPEND_LIBC_TEST("testdata/syscall_linkat.test.link");
+      "testdata/syscall_linkat.test.link";
 
   // The test strategy is as follows:
   //   1. Create a normal file

--- a/libc/test/src/unistd/truncate_test.cpp
+++ b/libc/test/src/unistd/truncate_test.cpp
@@ -24,7 +24,7 @@ using LlvmLibcTruncateTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
 TEST_F(LlvmLibcTruncateTest, CreateAndTruncate) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-  constexpr const char *FILENAME = APPEND_LIBC_TEST("truncate.test");
+  constexpr const char *FILENAME = "truncate.test";
   auto TEST_FILE = libc_make_test_file_path(FILENAME);
   constexpr const char WRITE_DATA[] = "hello, truncate";
   constexpr size_t WRITE_SIZE = sizeof(WRITE_DATA);

--- a/libc/test/src/wchar/fgetwc_test.cpp
+++ b/libc/test/src/wchar/fgetwc_test.cpp
@@ -22,8 +22,7 @@
 using LlvmLibcFgetwcTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
 TEST_F(LlvmLibcFgetwcTest, ReadASCII) {
-  auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("fgetwc_ascii.test"));
+  auto FILENAME = libc_make_test_file_path("fgetwc_ascii.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
 
@@ -45,8 +44,7 @@ TEST_F(LlvmLibcFgetwcTest, ReadASCII) {
 }
 
 TEST_F(LlvmLibcFgetwcTest, ReadUtf8) {
-  auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("fgetwc_utf8.test"));
+  auto FILENAME = libc_make_test_file_path("fgetwc_utf8.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
 
@@ -77,7 +75,7 @@ TEST_F(LlvmLibcFgetwcTest, ReadUtf8) {
 }
 
 TEST_F(LlvmLibcFgetwcTest, EOFAndInvalidStream) {
-  auto FILENAME = libc_make_test_file_path(APPEND_LIBC_TEST("fgetwc_eof.test"));
+  auto FILENAME = libc_make_test_file_path("fgetwc_eof.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
 
@@ -107,8 +105,7 @@ TEST_F(LlvmLibcFgetwcTest, EOFAndInvalidStream) {
 }
 
 TEST_F(LlvmLibcFgetwcTest, EncodingErrorEILSEQ) {
-  auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("fgetwc_eilseq.test"));
+  auto FILENAME = libc_make_test_file_path("fgetwc_eilseq.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
 
@@ -132,8 +129,7 @@ TEST_F(LlvmLibcFgetwcTest, EncodingErrorEILSEQ) {
 }
 
 TEST_F(LlvmLibcFgetwcTest, ByteModeFailure) {
-  auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("fgetwc_bytemode.test"));
+  auto FILENAME = libc_make_test_file_path("fgetwc_bytemode.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w+");
   ASSERT_FALSE(file == nullptr);
 

--- a/libc/test/src/wchar/fgetws_test.cpp
+++ b/libc/test/src/wchar/fgetws_test.cpp
@@ -30,8 +30,7 @@ using LlvmLibcFgetwsTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 // assert macros (e.g., EXPECT_STREQ for wchar_t) once they are supported
 // natively by the LLVM-libc test framework, instead of calling wcscmp.
 TEST_F(LlvmLibcFgetwsTest, ReadWideString) {
-  const auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("fgetws_string.test"));
+  const auto FILENAME = libc_make_test_file_path("fgetws_string.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
 
@@ -66,8 +65,7 @@ TEST_F(LlvmLibcFgetwsTest, ReadWideString) {
 }
 
 TEST_F(LlvmLibcFgetwsTest, ReadBounded) {
-  const auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("fgetws_bounded.test"));
+  const auto FILENAME = libc_make_test_file_path("fgetws_bounded.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
 
@@ -101,8 +99,7 @@ TEST_F(LlvmLibcFgetwsTest, ReadBounded) {
 }
 
 TEST_F(LlvmLibcFgetwsTest, NewlineStops) {
-  const auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("fgetws_newline.test"));
+  const auto FILENAME = libc_make_test_file_path("fgetws_newline.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
 
@@ -126,8 +123,7 @@ TEST_F(LlvmLibcFgetwsTest, NewlineStops) {
 }
 
 TEST_F(LlvmLibcFgetwsTest, InvalidStream) {
-  const auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("fgetws_invalid.test"));
+  const auto FILENAME = libc_make_test_file_path("fgetws_invalid.test");
 
   // Create the file first
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
@@ -150,8 +146,7 @@ TEST_F(LlvmLibcFgetwsTest, InvalidStream) {
 }
 
 TEST_F(LlvmLibcFgetwsTest, EncodingErrorEILSEQ) {
-  const auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("fgetws_eilseq.test"));
+  const auto FILENAME = libc_make_test_file_path("fgetws_eilseq.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
 
@@ -177,8 +172,7 @@ TEST_F(LlvmLibcFgetwsTest, EncodingErrorEILSEQ) {
 }
 
 TEST_F(LlvmLibcFgetwsTest, ByteModeFailure) {
-  const auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("fgetws_bytemode.test"));
+  const auto FILENAME = libc_make_test_file_path("fgetws_bytemode.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w+");
   ASSERT_FALSE(file == nullptr);
 

--- a/libc/test/src/wchar/fputwc_test.cpp
+++ b/libc/test/src/wchar/fputwc_test.cpp
@@ -27,8 +27,7 @@
 using LlvmLibcFputwcTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
 TEST_F(LlvmLibcFputwcTest, WriteASCII) {
-  const auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("fputwc_ascii.test"));
+  const auto FILENAME = libc_make_test_file_path("fputwc_ascii.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
 
@@ -51,8 +50,7 @@ TEST_F(LlvmLibcFputwcTest, WriteASCII) {
 }
 
 TEST_F(LlvmLibcFputwcTest, WriteUtf8) {
-  const auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("fputwc_utf8.test"));
+  const auto FILENAME = libc_make_test_file_path("fputwc_utf8.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
 
@@ -104,8 +102,7 @@ TEST_F(LlvmLibcFputwcTest, WriteUtf8) {
 // the UTF-16 range.
 #if WCHAR_MAX > 0xFFFF
 TEST_F(LlvmLibcFputwcTest, EncodingErrorEILSEQ) {
-  const auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("fputwc_eilseq.test"));
+  const auto FILENAME = libc_make_test_file_path("fputwc_eilseq.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
 
@@ -121,8 +118,7 @@ TEST_F(LlvmLibcFputwcTest, EncodingErrorEILSEQ) {
 #endif
 
 TEST_F(LlvmLibcFputwcTest, InvalidStream) {
-  const auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("fputwc_invalid.test"));
+  const auto FILENAME = libc_make_test_file_path("fputwc_invalid.test");
 
   // Create the file first
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
@@ -142,8 +138,7 @@ TEST_F(LlvmLibcFputwcTest, InvalidStream) {
 }
 
 TEST_F(LlvmLibcFputwcTest, ByteModeFailure) {
-  const auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("fputwc_bytemode.test"));
+  const auto FILENAME = libc_make_test_file_path("fputwc_bytemode.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
 

--- a/libc/test/src/wchar/fputws_test.cpp
+++ b/libc/test/src/wchar/fputws_test.cpp
@@ -25,8 +25,7 @@
 using LlvmLibcFputwsTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
 TEST_F(LlvmLibcFputwsTest, WriteWideString) {
-  const auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("fputws_string.test"));
+  const auto FILENAME = libc_make_test_file_path("fputws_string.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
 
@@ -92,8 +91,7 @@ TEST_F(LlvmLibcFputwsTest, WriteWideString) {
 }
 
 TEST_F(LlvmLibcFputwsTest, EmptyString) {
-  const auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("fputws_empty.test"));
+  const auto FILENAME = libc_make_test_file_path("fputws_empty.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
 
@@ -112,8 +110,7 @@ TEST_F(LlvmLibcFputwsTest, EmptyString) {
 }
 
 TEST_F(LlvmLibcFputwsTest, InvalidStream) {
-  const auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("fputws_invalid.test"));
+  const auto FILENAME = libc_make_test_file_path("fputws_invalid.test");
 
   // Create the file first
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
@@ -134,8 +131,7 @@ TEST_F(LlvmLibcFputwsTest, InvalidStream) {
 
 #if WCHAR_MAX > 0xFFFF
 TEST_F(LlvmLibcFputwsTest, EncodingErrorEILSEQ) {
-  const auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("fputws_eilseq.test"));
+  const auto FILENAME = libc_make_test_file_path("fputws_eilseq.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
 
@@ -152,8 +148,7 @@ TEST_F(LlvmLibcFputwsTest, EncodingErrorEILSEQ) {
 #endif
 
 TEST_F(LlvmLibcFputwsTest, ByteModeFailure) {
-  const auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("fputws_bytemode.test"));
+  const auto FILENAME = libc_make_test_file_path("fputws_bytemode.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w+");
   ASSERT_FALSE(file == nullptr);
 

--- a/libc/test/src/wchar/fwide_test.cpp
+++ b/libc/test/src/wchar/fwide_test.cpp
@@ -12,8 +12,7 @@
 #include "test/UnitTest/Test.h"
 
 TEST(LlvmLibcFwideTest, QueryInitial) {
-  auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("fwide_query.test"));
+  auto FILENAME = libc_make_test_file_path("fwide_query.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
 
@@ -24,7 +23,7 @@ TEST(LlvmLibcFwideTest, QueryInitial) {
 }
 
 TEST(LlvmLibcFwideTest, OrientWide) {
-  auto FILENAME = libc_make_test_file_path(APPEND_LIBC_TEST("fwide_wide.test"));
+  auto FILENAME = libc_make_test_file_path("fwide_wide.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
 
@@ -39,7 +38,7 @@ TEST(LlvmLibcFwideTest, OrientWide) {
 }
 
 TEST(LlvmLibcFwideTest, OrientByte) {
-  auto FILENAME = libc_make_test_file_path(APPEND_LIBC_TEST("fwide_byte.test"));
+  auto FILENAME = libc_make_test_file_path("fwide_byte.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
 

--- a/libc/test/src/wchar/getwc_test.cpp
+++ b/libc/test/src/wchar/getwc_test.cpp
@@ -22,8 +22,7 @@
 using LlvmLibcGetwcTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
 TEST_F(LlvmLibcGetwcTest, ReadValidCharacters) {
-  auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("getwc_valid.test"));
+  auto FILENAME = libc_make_test_file_path("getwc_valid.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
 
@@ -50,7 +49,7 @@ TEST_F(LlvmLibcGetwcTest, ReadValidCharacters) {
 }
 
 TEST_F(LlvmLibcGetwcTest, ReadUtf8) {
-  auto FILENAME = libc_make_test_file_path(APPEND_LIBC_TEST("getwc_utf8.test"));
+  auto FILENAME = libc_make_test_file_path("getwc_utf8.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
 
@@ -76,7 +75,7 @@ TEST_F(LlvmLibcGetwcTest, ReadUtf8) {
 }
 
 TEST_F(LlvmLibcGetwcTest, EndOfFile) {
-  auto FILENAME = libc_make_test_file_path(APPEND_LIBC_TEST("getwc_eof.test"));
+  auto FILENAME = libc_make_test_file_path("getwc_eof.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
   ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
@@ -93,8 +92,7 @@ TEST_F(LlvmLibcGetwcTest, EndOfFile) {
 }
 
 TEST_F(LlvmLibcGetwcTest, ReadError) {
-  auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("getwc_readerr.test"));
+  auto FILENAME = libc_make_test_file_path("getwc_readerr.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
 
@@ -108,8 +106,7 @@ TEST_F(LlvmLibcGetwcTest, ReadError) {
 }
 
 TEST_F(LlvmLibcGetwcTest, ByteOrientedStreamFail) {
-  auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("getwc_bytemode.test"));
+  auto FILENAME = libc_make_test_file_path("getwc_bytemode.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w+");
   ASSERT_FALSE(file == nullptr);
 

--- a/libc/test/src/wchar/getwchar_test.cpp
+++ b/libc/test/src/wchar/getwchar_test.cpp
@@ -29,8 +29,7 @@
 using LlvmLibcGetwcharTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
 TEST_F(LlvmLibcGetwcharTest, ReadValidWideCharacters) {
-  const auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("getwchar_valid.test"));
+  const auto FILENAME = libc_make_test_file_path("getwchar_valid.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
 
@@ -61,8 +60,7 @@ TEST_F(LlvmLibcGetwcharTest, ReadValidWideCharacters) {
 }
 
 TEST_F(LlvmLibcGetwcharTest, ReadUtf8) {
-  const auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("getwchar_utf8.test"));
+  const auto FILENAME = libc_make_test_file_path("getwchar_utf8.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
 
@@ -91,8 +89,7 @@ TEST_F(LlvmLibcGetwcharTest, ReadUtf8) {
 }
 
 TEST_F(LlvmLibcGetwcharTest, EndOfFileBehavior) {
-  const auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("getwchar_eof.test"));
+  const auto FILENAME = libc_make_test_file_path("getwchar_eof.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
   ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
@@ -113,8 +110,7 @@ TEST_F(LlvmLibcGetwcharTest, EndOfFileBehavior) {
 }
 
 TEST_F(LlvmLibcGetwcharTest, ReadError) {
-  const auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("getwchar_readerr.test"));
+  const auto FILENAME = libc_make_test_file_path("getwchar_readerr.test");
 
   // Redirect stdin using a write-only stream
   ::FILE *original_stdin = LIBC_NAMESPACE::stdin;
@@ -133,8 +129,7 @@ TEST_F(LlvmLibcGetwcharTest, ReadError) {
 }
 
 TEST_F(LlvmLibcGetwcharTest, ByteOrientedMisuse) {
-  const auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("getwchar_bytemode.test"));
+  const auto FILENAME = libc_make_test_file_path("getwchar_bytemode.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w+");
   ASSERT_FALSE(file == nullptr);
 
@@ -156,8 +151,7 @@ TEST_F(LlvmLibcGetwcharTest, ByteOrientedMisuse) {
 }
 
 TEST_F(LlvmLibcGetwcharTest, InteractionWithUngetwc) {
-  const auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("getwchar_unget.test"));
+  const auto FILENAME = libc_make_test_file_path("getwchar_unget.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
 

--- a/libc/test/src/wchar/putwc_test.cpp
+++ b/libc/test/src/wchar/putwc_test.cpp
@@ -26,8 +26,7 @@
 using LlvmLibcPutwcTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
 TEST_F(LlvmLibcPutwcTest, WriteASCII) {
-  const auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("putwc_ascii.test"));
+  const auto FILENAME = libc_make_test_file_path("putwc_ascii.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
 
@@ -57,8 +56,7 @@ TEST_F(LlvmLibcPutwcTest, WriteASCII) {
 }
 
 TEST_F(LlvmLibcPutwcTest, WriteUtf8) {
-  const auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("putwc_utf8.test"));
+  const auto FILENAME = libc_make_test_file_path("putwc_utf8.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
 
@@ -110,8 +108,7 @@ TEST_F(LlvmLibcPutwcTest, WriteUtf8) {
 }
 
 TEST_F(LlvmLibcPutwcTest, InvalidStream) {
-  const auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("putwc_invalid.test"));
+  const auto FILENAME = libc_make_test_file_path("putwc_invalid.test");
 
   // Create file
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
@@ -131,8 +128,7 @@ TEST_F(LlvmLibcPutwcTest, InvalidStream) {
 }
 
 TEST_F(LlvmLibcPutwcTest, ByteModeFailure) {
-  const auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("putwc_bytemode.test"));
+  const auto FILENAME = libc_make_test_file_path("putwc_bytemode.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w+");
   ASSERT_FALSE(file == nullptr);
 

--- a/libc/test/src/wchar/putwchar_test.cpp
+++ b/libc/test/src/wchar/putwchar_test.cpp
@@ -22,8 +22,7 @@
 using LlvmLibcPutwcharTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
 TEST_F(LlvmLibcPutwcharTest, WriteASCII) {
-  auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("putwchar_ascii.test"));
+  auto FILENAME = libc_make_test_file_path("putwchar_ascii.test");
 
   // Redirect stdout
   ::FILE *original_stdout = LIBC_NAMESPACE::stdout;
@@ -58,8 +57,7 @@ TEST_F(LlvmLibcPutwcharTest, WriteASCII) {
 }
 
 TEST_F(LlvmLibcPutwcharTest, WriteUtf8) {
-  auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("putwchar_utf8.test"));
+  auto FILENAME = libc_make_test_file_path("putwchar_utf8.test");
 
   // Redirect stdout
   ::FILE *original_stdout = LIBC_NAMESPACE::stdout;
@@ -116,8 +114,7 @@ TEST_F(LlvmLibcPutwcharTest, WriteUtf8) {
 }
 
 TEST_F(LlvmLibcPutwcharTest, InvalidStream) {
-  auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("putwchar_invalid.test"));
+  auto FILENAME = libc_make_test_file_path("putwchar_invalid.test");
 
   // Create the file first
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
@@ -141,8 +138,7 @@ TEST_F(LlvmLibcPutwcharTest, InvalidStream) {
 }
 
 TEST_F(LlvmLibcPutwcharTest, ByteModeFailure) {
-  auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("putwchar_bytemode.test"));
+  auto FILENAME = libc_make_test_file_path("putwchar_bytemode.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w+");
   ASSERT_FALSE(file == nullptr);
 

--- a/libc/test/src/wchar/ungetwc_test.cpp
+++ b/libc/test/src/wchar/ungetwc_test.cpp
@@ -28,8 +28,7 @@
 using LlvmLibcUngetwcTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
 TEST_F(LlvmLibcUngetwcTest, PushBackAndRead) {
-  auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("ungetwc_push.test"));
+  auto FILENAME = libc_make_test_file_path("ungetwc_push.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
 
@@ -60,8 +59,7 @@ TEST_F(LlvmLibcUngetwcTest, PushBackAndRead) {
 }
 
 TEST_F(LlvmLibcUngetwcTest, PushBackWEOF) {
-  auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("ungetwc_weof.test"));
+  auto FILENAME = libc_make_test_file_path("ungetwc_weof.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
   ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
@@ -77,8 +75,7 @@ TEST_F(LlvmLibcUngetwcTest, PushBackWEOF) {
 }
 
 TEST_F(LlvmLibcUngetwcTest, ByteModeFailure) {
-  auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("ungetwc_bytemode.test"));
+  auto FILENAME = libc_make_test_file_path("ungetwc_bytemode.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w+");
   ASSERT_FALSE(file == nullptr);
 
@@ -93,8 +90,7 @@ TEST_F(LlvmLibcUngetwcTest, ByteModeFailure) {
 }
 
 TEST_F(LlvmLibcUngetwcTest, OrientUnorientedStream) {
-  auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("ungetwc_orient.test"));
+  auto FILENAME = libc_make_test_file_path("ungetwc_orient.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w+");
   ASSERT_FALSE(file == nullptr);
 
@@ -112,8 +108,7 @@ TEST_F(LlvmLibcUngetwcTest, OrientUnorientedStream) {
 }
 
 TEST_F(LlvmLibcUngetwcTest, ClearEofIndicator) {
-  auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("ungetwc_cleareof.test"));
+  auto FILENAME = libc_make_test_file_path("ungetwc_cleareof.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
 
@@ -143,8 +138,7 @@ TEST_F(LlvmLibcUngetwcTest, ClearEofIndicator) {
 }
 
 TEST_F(LlvmLibcUngetwcTest, DiscardOnFilePositioning) {
-  auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("ungetwc_discard.test"));
+  auto FILENAME = libc_make_test_file_path("ungetwc_discard.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
 
@@ -174,8 +168,7 @@ TEST_F(LlvmLibcUngetwcTest, DiscardOnFilePositioning) {
 }
 
 TEST_F(LlvmLibcUngetwcTest, LifoMultiplePushbacks) {
-  auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("ungetwc_lifo.test"));
+  auto FILENAME = libc_make_test_file_path("ungetwc_lifo.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w+");
   ASSERT_FALSE(file == nullptr);
 
@@ -197,8 +190,7 @@ TEST_F(LlvmLibcUngetwcTest, LifoMultiplePushbacks) {
 }
 
 TEST_F(LlvmLibcUngetwcTest, PushbackAtStartOfFile) {
-  auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("ungetwc_start.test"));
+  auto FILENAME = libc_make_test_file_path("ungetwc_start.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
 
@@ -225,8 +217,7 @@ TEST_F(LlvmLibcUngetwcTest, PushbackAtStartOfFile) {
 }
 
 TEST_F(LlvmLibcUngetwcTest, PushbackMultibyteChars) {
-  auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("ungetwc_multibyte.test"));
+  auto FILENAME = libc_make_test_file_path("ungetwc_multibyte.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
   ASSERT_FALSE(file == nullptr);
   ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
@@ -260,8 +251,7 @@ TEST_F(LlvmLibcUngetwcTest, PushbackMultibyteChars) {
 
 #if WCHAR_MAX > 0xFFFF
 TEST_F(LlvmLibcUngetwcTest, PushbackInvalidWchar) {
-  auto FILENAME =
-      libc_make_test_file_path(APPEND_LIBC_TEST("ungetwc_invalid.test"));
+  auto FILENAME = libc_make_test_file_path("ungetwc_invalid.test");
   ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w+");
   ASSERT_FALSE(file == nullptr);
 


### PR DESCRIPTION
It is not needed now that we're never running hermetic and unit tests in the same build, and it also avoids races with leftover unit test binaries in the build folder.