### PR TITLE
[Profcheck] Enable MergeFunc tests

### DIFF
--- a/llvm/test/lit.cfg.py
+++ b/llvm/test/lit.cfg.py
@@ -79,7 +79,7 @@ if config.enable_profcheck:
     )
     # Not aimed at being used for peak-optimized binaries. These will be
     # addressed later. PhaseOrdering has a couple of merge function tests.
-    config.excludes.extend(["GCOVProfiling", "MergeFunc", "PhaseOrdering"])
+    config.excludes.extend(["GCOVProfiling", "PhaseOrdering"])
 
 # test_source_root: The root path where tests are located.
 config.test_source_root = os.path.dirname(__file__)


### PR DESCRIPTION
Remove MergeFunc from the profcheck exclusion list.

All MergeFunc tests pass with LLVM_ENABLE_PROFCHECK enabled, so no expected-failure entries are needed.