### PR TITLE
[OMP] Add omp.h in test

### DIFF
--- a/offload/test/offloading/ompx_bare_multi_dim.cpp
+++ b/offload/test/offloading/ompx_bare_multi_dim.cpp
@@ -4,6 +4,7 @@
 // REQUIRES: gpu
 // clang-format on
 
+#include <omp.h>
 #include <ompx.h>
 
 #include <cassert>


### PR DESCRIPTION
`omp_get_ancestor_thread_num` and `omp_get_team_size` are only declared in `omp.h`.

Fix build breakage in https://github.com/llvm/llvm-project/pull/215841#issuecomment-5271979382