### PR TITLE
[libc++][NFC] Add clarifying comment on dangling macro defininition

### DIFF
--- a/libcxx/src/support/new.ipp
+++ b/libcxx/src/support/new.ipp
@@ -20,7 +20,7 @@ void __throw_bad_alloc_shim();
 
 #ifndef _LIBCPP_ASSERT_SHIM
 #  error _LIBCPP_ASSERT_SHIM should be defined
-#  define _LIBCPP_ASSERT_SHIM // make the header parseable
+#  define _LIBCPP_ASSERT_SHIM // make the file parseable
 #endif
 
 static void* operator_new_impl(std::size_t size) {

--- a/libcxx/src/support/new.ipp
+++ b/libcxx/src/support/new.ipp
@@ -20,7 +20,6 @@ void __throw_bad_alloc_shim();
 
 #ifndef _LIBCPP_ASSERT_SHIM
 #  error _LIBCPP_ASSERT_SHIM should be defined
-#  define _LIBCPP_ASSERT_SHIM
 #endif
 
 static void* operator_new_impl(std::size_t size) {

--- a/libcxx/src/support/new.ipp
+++ b/libcxx/src/support/new.ipp
@@ -20,6 +20,7 @@ void __throw_bad_alloc_shim();
 
 #ifndef _LIBCPP_ASSERT_SHIM
 #  error _LIBCPP_ASSERT_SHIM should be defined
+#  define _LIBCPP_ASSERT_SHIM // make the header parseable
 #endif
 
 static void* operator_new_impl(std::size_t size) {


### PR DESCRIPTION
Since we #error immediately before, a comment is needed to explain the purpose of the define.