### PR TITLE
[flang] Improve error for misplaced statement after CONTAINS in derived type

### DIFF
--- a/flang/lib/Parser/Fortran-parsers.cpp
+++ b/flang/lib/Parser/Fortran-parsers.cpp
@@ -567,12 +567,15 @@ TYPE_CONTEXT_PARSER("type bound procedure part"_en_US,
 //        final-procedure-stmt
 TYPE_CONTEXT_PARSER("type bound procedure binding"_en_US,
     recovery(
-        first(construct<TypeBoundProcBinding>(Parser<TypeBoundProcedureStmt>{}),
-            construct<TypeBoundProcBinding>(Parser<TypeBoundGenericStmt>{}),
-            construct<TypeBoundProcBinding>(Parser<FinalProcedureStmt>{}),
-            Parser<DataComponentDefStmt>{} >>
-                fail<TypeBoundProcBinding>(
-                    "component definition must precede CONTAINS in a derived type"_err_en_US)),
+        withMessage(
+            "expected a type-bound procedure binding (PROCEDURE, GENERIC, or FINAL) after CONTAINS"_err_en_US,
+            first(construct<TypeBoundProcBinding>(
+                      Parser<TypeBoundProcedureStmt>{}),
+                construct<TypeBoundProcBinding>(Parser<TypeBoundGenericStmt>{}),
+                construct<TypeBoundProcBinding>(Parser<FinalProcedureStmt>{}),
+                Parser<DataComponentDefStmt>{} >>
+                    fail<TypeBoundProcBinding>(
+                        "component definition must precede CONTAINS in a derived type"_err_en_US))),
         construct<TypeBoundProcBinding>(
             !"END"_tok >> SkipTo<'\n'>{} >> construct<ErrorRecovery>())))
 

--- a/flang/lib/Parser/basic-parsers.h
+++ b/flang/lib/Parser/basic-parsers.h
@@ -214,10 +214,12 @@ public:
       return result;
     }
     Messages messages{std::move(state.messages())};
+    const char *start{state.GetLocation()};
     bool hadAnyTokenMatched{state.anyTokenMatched()};
     state.set_anyTokenMatched(false);
     std::optional<resultType> result{parser_.Parse(state)};
     bool emitMessage{false};
+    bool emitAtStart{false};
     if (result) {
       messages.Annex(std::move(state.messages()));
       if (hadAnyTokenMatched) {
@@ -228,13 +230,18 @@ public:
       messages.Annex(std::move(state.messages()));
     } else {
       emitMessage = true;
+      emitAtStart = true;
       if (hadAnyTokenMatched) {
         state.set_anyTokenMatched();
       }
     }
     state.messages() = std::move(messages);
     if (emitMessage) {
-      state.Say(text_);
+      if (emitAtStart) {
+        state.Say(start, text_);
+      } else {
+        state.Say(text_);
+      }
     }
     return result;
   }

--- a/flang/test/Parser/recovery09.f90
+++ b/flang/test/Parser/recovery09.f90
@@ -1,12 +1,14 @@
 ! RUN: not %flang_fc1 -fsyntax-only %s 2>&1 | FileCheck %s
 
-! Verify that a data component definition appearing after CONTAINS in a
-! derived type gives a clear error instead of misleading
-! "expected 'FINAL'/'GENERIC'/'PROCEDURE'" messages.
+! Verify that a statement appearing after CONTAINS in a derived type that is not
+! a type-bound procedure binding gives a clear error instead of misleading
+! "expected 'FINAL'/'GENERIC'/'PROCEDURE'" or intrinsic-type-spec keyword
+! messages.
 
 module m
   implicit none
 
+  ! A data component definition after CONTAINS names the specific problem.
   type, public :: t1
      real :: x
    contains
@@ -17,10 +19,35 @@ module m
 ! CHECK: error: component definition must precede CONTAINS in a derived type
 ! CHECK-NEXT: {{.*}}real, pointer, dimension(:,:,:), public :: gpoint => null()
      real, pointer, dimension(:,:,:), public :: gpoint => null()
+  end type t1
+
+  ! A second CONTAINS is not a component definition.
+  type :: t2
+   contains
+   contains
+! CHECK: error: expected a type-bound procedure binding (PROCEDURE, GENERIC, or FINAL) after CONTAINS
+  end type t2
+
+  ! An IMPORT after CONTAINS is likewise not a binding.
+  type :: t3
+   contains
+     import
+! CHECK: error: expected a type-bound procedure binding (PROCEDURE, GENERIC, or FINAL) after CONTAINS
+  end type t3
+
+  ! A misplaced subprogram after CONTAINS.
+  type :: t4
+   contains
+     subroutine s
+     end subroutine
+! CHECK: error: expected a type-bound procedure binding (PROCEDURE, GENERIC, or FINAL) after CONTAINS
+  end type t4
+
 ! CHECK-NOT: expected 'FINAL'
 ! CHECK-NOT: expected 'GENERIC'
 ! CHECK-NOT: expected 'PROCEDURE'
-  end type t1
+! CHECK-NOT: expected 'COMPLEX'
+! CHECK-NOT: expected 'INTEGER'
 
 contains
   subroutine init(this)

--- a/flang/test/Parser/recovery09.f90
+++ b/flang/test/Parser/recovery09.f90
@@ -1,9 +1,15 @@
-! RUN: not %flang_fc1 -fsyntax-only %s 2>&1 | FileCheck %s
+! RUN: not %flang_fc1 -fsyntax-only %s 2>&1 | FileCheck %s \
+! RUN:   --implicit-check-not="expected 'FINAL'" \
+! RUN:   --implicit-check-not="expected 'GENERIC'" \
+! RUN:   --implicit-check-not="expected 'PROCEDURE'" \
+! RUN:   --implicit-check-not="expected 'COMPLEX'" \
+! RUN:   --implicit-check-not="expected 'INTEGER'"
 
 ! Verify that a statement appearing after CONTAINS in a derived type that is not
 ! a type-bound procedure binding gives a clear error instead of misleading
 ! "expected 'FINAL'/'GENERIC'/'PROCEDURE'" or intrinsic-type-spec keyword
-! messages.
+! messages.  The --implicit-check-not options above assert, across the whole
+! output, that none of those spurious messages reappear.
 
 module m
   implicit none
@@ -26,6 +32,7 @@ module m
    contains
    contains
 ! CHECK: error: expected a type-bound procedure binding (PROCEDURE, GENERIC, or FINAL) after CONTAINS
+! CHECK-NEXT: {{.*}}contains
   end type t2
 
   ! An IMPORT after CONTAINS is likewise not a binding.
@@ -33,21 +40,16 @@ module m
    contains
      import
 ! CHECK: error: expected a type-bound procedure binding (PROCEDURE, GENERIC, or FINAL) after CONTAINS
+! CHECK-NEXT: {{.*}}import
   end type t3
 
   ! A misplaced subprogram after CONTAINS.
   type :: t4
    contains
      subroutine s
-     end subroutine
 ! CHECK: error: expected a type-bound procedure binding (PROCEDURE, GENERIC, or FINAL) after CONTAINS
+! CHECK-NEXT: {{.*}}subroutine s
   end type t4
-
-! CHECK-NOT: expected 'FINAL'
-! CHECK-NOT: expected 'GENERIC'
-! CHECK-NOT: expected 'PROCEDURE'
-! CHECK-NOT: expected 'COMPLEX'
-! CHECK-NOT: expected 'INTEGER'
 
 contains
   subroutine init(this)


### PR DESCRIPTION
A statement after `CONTAINS` in a derived type that is not a type-bound procedure binding (e.g. a second `CONTAINS`, an `IMPORT`, or a misplaced subprogram) leaked the intrinsic type-spec parse failures (`expected 'COMPLEX'`, `expected 'INTEGER'`, ...) instead of reporting that a type-bound procedure binding was expected. In the misplaced-subprogram case flang emitted an avalanche of unrelated `expected '<type-keyword>'` errors.

This is a diagnostic regression from #203379, which added `DataComponentDefStmt` as a trailing alternative in the type-bound-proc-binding parser. Its intended `fail<>()` message only fires when `DataComponentDefStmt` fully matches; for other invalid statement the partial parse into `declarationTypeSpec` displaced the recovery message in `CombineFailedParses`.

This patch wraps the binding alternatives in `withMessage()` so that when none of them match a token a single clear message is emitted:

```
error: expected a type-bound procedure binding (PROCEDURE, GENERIC, or FINAL) after CONTAINS
```

The specific `component definition must precede CONTAINS in a derived type` message is still produced for a genuine misplaced component definition (`withMessage` only overrides when no tokens were matched), and malformed `PROCEDURE`/`GENERIC`/`FINAL`/component statements keep their own specific diagnostics.

`flang/test/Parser/recovery09.f90` is extended to cover the double-`CONTAINS`, `IMPORT`, and misplaced-subprogram cases.

This implements the fix for https://github.com/llvm/llvm-project/issues/215849

Assisted-by: AI