### PR TITLE
[Darwin] Silence error if `ld-classic` not found

### DIFF
--- a/llvm/cmake/config-ix.cmake
+++ b/llvm/cmake/config-ix.cmake
@@ -682,6 +682,7 @@ if(CMAKE_HOST_APPLE AND APPLE)
     if(CMAKE_XCRUN)
       execute_process(COMMAND ${CMAKE_XCRUN} -find ld-classic
         OUTPUT_VARIABLE LD64_EXECUTABLE
+        ERROR_QUIET
         OUTPUT_STRIP_TRAILING_WHITESPACE)
     else()
       find_program(LD64_EXECUTABLE NAMES ld-classic DOC "The ld64 linker")


### PR DESCRIPTION
Silence the `unable to find utility` xcrun error if `ld-classic` not found.