### PR TITLE
[libc++] Support file offsets larger than 2GB in basic_filebuf on 32-bit AIX and 32-bit glibc Linux

### DIFF
--- a/libcxx/docs/ReleaseNotes/24.rst
+++ b/libcxx/docs/ReleaseNotes/24.rst
@@ -51,7 +51,7 @@ Implemented Papers
 Improvements and New Features
 -----------------------------
 
-- ``basic_filebuf`` now supports files larger than 2GB on 32-bit AIX and 32-bit glibc Linux targets.
+- ``basic_filebuf`` now supports files larger than 2GB on 32-bit AIX and 32-bit glibc targets.
 
 Deprecations and Removals
 -------------------------

--- a/libcxx/docs/ReleaseNotes/24.rst
+++ b/libcxx/docs/ReleaseNotes/24.rst
@@ -51,6 +51,8 @@ Implemented Papers
 Improvements and New Features
 -----------------------------
 
+- ``basic_filebuf`` now supports files larger than 2GB on 32-bit AIX and 32-bit glib Linux targets.
+
 Deprecations and Removals
 -------------------------
 

--- a/libcxx/docs/ReleaseNotes/24.rst
+++ b/libcxx/docs/ReleaseNotes/24.rst
@@ -51,7 +51,7 @@ Implemented Papers
 Improvements and New Features
 -----------------------------
 
-- ``basic_filebuf`` now supports files larger than 2GB on 32-bit AIX and 32-bit glib Linux targets.
+- ``basic_filebuf`` now supports files larger than 2GB on 32-bit AIX and 32-bit glibc Linux targets.
 
 Deprecations and Removals
 -------------------------

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -217,7 +217,7 @@ typedef basic_fstream<wchar_t> wfstream;
 #      pragma GCC system_header
 #    endif
 
-#    if _AIX
+#    if defined(_AIX)
 // On AIX, fopen64/fseeko64/ftello64 are not guaranteed to always be declared, so we declare them
 // here. They are not POSIX-reserved names, so we use __asm__ to guard them against a user #define.
 extern "C" FILE* __libcpp_fopen64(const char*, const char*) __asm__("fopen64");

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -1104,7 +1104,7 @@ typename basic_filebuf<_CharT, _Traits>::pos_type basic_filebuf<_CharT, _Traits>
   return ftell(__file);
 #    elif defined(_AIX)
   return ::__libcpp_ftello64(__file);
-#   elif defined(__GLIBC__)
+#    elif defined(__GLIBC__)
   return ::ftello64(__file);
 #    else
   return ftello(__file);

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -217,14 +217,8 @@ typedef basic_fstream<wchar_t> wfstream;
 #      pragma GCC system_header
 #    endif
 
-#    if defined(_AIX) || (defined(__linux__) && defined(__GLIBC__))
-#      define _LIBCPP_HAS_LARGEFILE_API 1
-#    else
-#      define _LIBCPP_HAS_LARGEFILE_API 0
-#    endif
-
-#    if _LIBCPP_HAS_LARGEFILE_API
-// On AIX and glibc on Linux, fopen64/fseeko64/ftello64 are not guaranteed to always be declared, so we declare them
+#    if _AIX
+// On AIX, fopen64/fseeko64/ftello64 are not guaranteed to always be declared, so we declare them
 // here. They are not POSIX-reserved names, so we use __asm__ to guard them against a user #define.
 extern "C" FILE* __libcpp_fopen64(const char*, const char*) __asm__("fopen64");
 extern "C" long long __libcpp_ftello64(FILE*) __asm__("ftello64");
@@ -240,14 +234,6 @@ _LIBCPP_BEGIN_EXPLICIT_ABI_ANNOTATIONS
 #    if _LIBCPP_STD_VER >= 23 && defined(_WIN32)
 _LIBCPP_EXPORTED_FROM_ABI void* __filebuf_windows_native_handle(FILE* __file) noexcept;
 #    endif
-
-_LIBCPP_HIDE_FROM_ABI inline FILE* __fopen(const char* __name, const char* __mode) {
-#    if _LIBCPP_HAS_LARGEFILE_API
-  return ::__libcpp_fopen64(__name, __mode);
-#    else
-  return std::fopen(__name, __mode);
-#    endif
-}
 
 template <class _CharT, class _Traits>
 class basic_filebuf : public basic_streambuf<_CharT, _Traits> {
@@ -454,6 +440,7 @@ private:
 
   _LIBCPP_HIDE_FROM_ABI static int __fseek(FILE* __file, pos_type __offset, int __whence);
   _LIBCPP_HIDE_FROM_ABI static pos_type __ftell(FILE* __file);
+  _LIBCPP_HIDE_FROM_ABI static FILE* __fopen(const char* __name, const char* __mode);
 
   _LIBCPP_EXPORTED_FROM_ABI friend FILE* __get_ostream_file(ostream&);
 
@@ -802,6 +789,17 @@ const wchar_t* basic_filebuf<_CharT, _Traits>::__make_mdwstring(ios_base::openmo
 #    endif
 
 template <class _CharT, class _Traits>
+FILE* basic_filebuf<_CharT, _Traits>::__fopen(const char* __name, const char* __mode) {
+#    if defined(_AIX)
+  return ::__libcpp_fopen64(__name, __mode);
+#    elif defined(__GLIBC__)
+  return ::fopen64(__name, __mode);
+#    else
+  return std::fopen(__name, __mode);
+#    endif
+}
+
+template <class _CharT, class _Traits>
 basic_filebuf<_CharT, _Traits>* basic_filebuf<_CharT, _Traits>::open(const char* __s, ios_base::openmode __mode) {
   if (__file_)
     return nullptr;
@@ -1089,8 +1087,10 @@ int basic_filebuf<_CharT, _Traits>::__fseek(FILE* __file, pos_type __offset, int
   return _fseeki64(__file, __offset, __whence);
 #    elif _LIBCPP_LIBC_NEWLIB
   return fseek(__file, __offset, __whence);
-#    elif _LIBCPP_HAS_LARGEFILE_API
+#    elif defined(_AIX)
   return ::__libcpp_fseeko64(__file, __offset, __whence);
+#    elif defined(__GLIBC__)
+  return ::fseeko64(__file, __offset, __whence);
 #    else
   return ::fseeko(__file, __offset, __whence);
 #    endif
@@ -1102,8 +1102,10 @@ typename basic_filebuf<_CharT, _Traits>::pos_type basic_filebuf<_CharT, _Traits>
   return _ftelli64(__file);
 #    elif _LIBCPP_LIBC_NEWLIB
   return ftell(__file);
-#    elif _LIBCPP_HAS_LARGEFILE_API
+#    elif defined(_AIX)
   return ::__libcpp_ftello64(__file);
+#   elif defined(__GLIBC__)
+  return ::ftello64(__file);
 #    else
   return ftello(__file);
 #    endif

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -219,7 +219,7 @@ typedef basic_fstream<wchar_t> wfstream;
 
 #    if defined(_AIX)
 // On AIX, fopen64/fseeko64/ftello64 are not guaranteed to always be declared, so we declare them
-// here. They are not POSIX-reserved names, so we use __asm__ to guard them against a user #define.
+// here. We use `__asm__` to avoid colliding with the declaration in the header in any way.
 extern "C" FILE* __libcpp_fopen64(const char*, const char*) __asm__("fopen64");
 extern "C" long long __libcpp_ftello64(FILE*) __asm__("ftello64");
 extern "C" int __libcpp_fseeko64(FILE*, long long, int) __asm__("fseeko64");

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -807,7 +807,7 @@ basic_filebuf<_CharT, _Traits>* basic_filebuf<_CharT, _Traits>::open(const char*
   if (!__mdstr)
     return nullptr;
 
-  return __adopt_file(std::__fopen(__s, __mdstr), __mode);
+  return __adopt_file(__fopen(__s, __mdstr), __mode);
 }
 
 template <class _CharT, class _Traits>

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -217,13 +217,13 @@ typedef basic_fstream<wchar_t> wfstream;
 #      pragma GCC system_header
 #    endif
 
-#if defined(_AIX)
+#    if defined(_AIX)
 // On AIX, fopen64/fseeko64/ftello64 are not guaranteed to always be declared, so we declare them here.
 // They are not POSIX-reserved names, so we use __asm__ to guard them against a user #define.
 extern "C" FILE* __libcpp_aix_fopen64(const char*, const char*) __asm__("fopen64");
 extern "C" long long __libcpp_aix_ftello64(FILE*) __asm__("ftello64");
 extern "C" int __libcpp_aix_fseeko64(FILE*, long long, int) __asm__("fseeko64");
-#endif
+#    endif
 
 _LIBCPP_PUSH_MACROS
 #    include <__undef_macros>

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -241,6 +241,14 @@ _LIBCPP_BEGIN_EXPLICIT_ABI_ANNOTATIONS
 _LIBCPP_EXPORTED_FROM_ABI void* __filebuf_windows_native_handle(FILE* __file) noexcept;
 #    endif
 
+_LIBCPP_HIDE_FROM_ABI inline FILE* __fopen(const char* __name, const char* __mode) {
+#    if _LIBCPP_HAS_LARGEFILE_API
+  return ::__libcpp_fopen64(__name, __mode);
+#    else
+  return std::fopen(__name, __mode);
+#    endif
+}
+
 template <class _CharT, class _Traits>
 class basic_filebuf : public basic_streambuf<_CharT, _Traits> {
 public:
@@ -446,7 +454,6 @@ private:
 
   _LIBCPP_HIDE_FROM_ABI static int __fseek(FILE* __file, pos_type __offset, int __whence);
   _LIBCPP_HIDE_FROM_ABI static pos_type __ftell(FILE* __file);
-  _LIBCPP_HIDE_FROM_ABI static FILE* __fopen(const char* __name, const char* __mode);
 
   _LIBCPP_EXPORTED_FROM_ABI friend FILE* __get_ostream_file(ostream&);
 
@@ -795,15 +802,6 @@ const wchar_t* basic_filebuf<_CharT, _Traits>::__make_mdwstring(ios_base::openmo
 #    endif
 
 template <class _CharT, class _Traits>
-FILE* basic_filebuf<_CharT, _Traits>::__fopen(const char* __name, const char* __mode) {
-#    if _LIBCPP_HAS_LARGEFILE_API
-  return __libcpp_fopen64(__name, __mode);
-#    else
-  return std::fopen(__name, __mode);
-#    endif
-}
-
-template <class _CharT, class _Traits>
 basic_filebuf<_CharT, _Traits>* basic_filebuf<_CharT, _Traits>::open(const char* __s, ios_base::openmode __mode) {
   if (__file_)
     return nullptr;
@@ -1092,7 +1090,7 @@ int basic_filebuf<_CharT, _Traits>::__fseek(FILE* __file, pos_type __offset, int
 #    elif _LIBCPP_LIBC_NEWLIB
   return fseek(__file, __offset, __whence);
 #    elif _LIBCPP_HAS_LARGEFILE_API
-  return __libcpp_fseeko64(__file, __offset, __whence);
+  return ::__libcpp_fseeko64(__file, __offset, __whence);
 #    else
   return ::fseeko(__file, __offset, __whence);
 #    endif
@@ -1105,7 +1103,7 @@ typename basic_filebuf<_CharT, _Traits>::pos_type basic_filebuf<_CharT, _Traits>
 #    elif _LIBCPP_LIBC_NEWLIB
   return ftell(__file);
 #    elif _LIBCPP_HAS_LARGEFILE_API
-  return __libcpp_ftello64(__file);
+  return ::__libcpp_ftello64(__file);
 #    else
   return ftello(__file);
 #    endif

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -217,12 +217,18 @@ typedef basic_fstream<wchar_t> wfstream;
 #      pragma GCC system_header
 #    endif
 
-#    if defined(_AIX)
-// On AIX, fopen64/fseeko64/ftello64 are not guaranteed to always be declared, so we declare them here.
+#    if defined(_AIX) || ((defined(__linux__) && defined(__GLIBC__))
+#      define _LIBCPP_HAS_LARGEFILE_API 1
+#    else
+#      define _LIBCPP_HAS_LARGEFILE_API 0
+#    endif
+
+#    if _LIBCPP_HAS_LARGEFILE_API
+// On AIX and glibc on Linux, fopen64/fseeko64/ftello64 are not guaranteed to always be declared, so we declare them here.
 // They are not POSIX-reserved names, so we use __asm__ to guard them against a user #define.
-extern "C" FILE* __libcpp_aix_fopen64(const char*, const char*) __asm__("fopen64");
-extern "C" long long __libcpp_aix_ftello64(FILE*) __asm__("ftello64");
-extern "C" int __libcpp_aix_fseeko64(FILE*, long long, int) __asm__("fseeko64");
+extern "C" FILE* __libcpp_fopen64(const char*, const char*) __asm__("fopen64");
+extern "C" long long __libcpp_ftello64(FILE*) __asm__("ftello64");
+extern "C" int __libcpp_fseeko64(FILE*, long long, int) __asm__("fseeko64");
 #    endif
 
 _LIBCPP_PUSH_MACROS
@@ -790,8 +796,8 @@ const wchar_t* basic_filebuf<_CharT, _Traits>::__make_mdwstring(ios_base::openmo
 
 template <class _CharT, class _Traits>
 FILE* basic_filebuf<_CharT, _Traits>::__fopen(const char* __name, const char* __mode) {
-#    if defined(_AIX)
-  return __libcpp_aix_fopen64(__name, __mode);
+#    if _LIBCPP_HAS_LARGEFILE_API
+  return __libcpp_fopen64(__name, __mode);
 #    else
   return std::fopen(__name, __mode);
 #    endif
@@ -1085,8 +1091,8 @@ int basic_filebuf<_CharT, _Traits>::__fseek(FILE* __file, pos_type __offset, int
   return _fseeki64(__file, __offset, __whence);
 #    elif _LIBCPP_LIBC_NEWLIB
   return fseek(__file, __offset, __whence);
-#    elif defined(_AIX)
-  return __libcpp_aix_fseeko64(__file, __offset, __whence);
+#    elif _LIBCPP_HAS_LARGEFILE_API
+  return __libcpp_fseeko64(__file, __offset, __whence);
 #    else
   return ::fseeko(__file, __offset, __whence);
 #    endif
@@ -1098,8 +1104,8 @@ typename basic_filebuf<_CharT, _Traits>::pos_type basic_filebuf<_CharT, _Traits>
   return _ftelli64(__file);
 #    elif _LIBCPP_LIBC_NEWLIB
   return ftell(__file);
-#    elif defined(_AIX)
-  return __libcpp_aix_ftello64(__file);
+#    elif _LIBCPP_HAS_LARGEFILE_API
+  return __libcpp_ftello64(__file);
 #    else
   return ftello(__file);
 #    endif

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -217,7 +217,7 @@ typedef basic_fstream<wchar_t> wfstream;
 #      pragma GCC system_header
 #    endif
 
-#    if defined(_AIX) || ((defined(__linux__) && defined(__GLIBC__))
+#    if defined(_AIX) || (defined(__linux__) && defined(__GLIBC__))
 #      define _LIBCPP_HAS_LARGEFILE_API 1
 #    else
 #      define _LIBCPP_HAS_LARGEFILE_API 0

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -224,8 +224,8 @@ typedef basic_fstream<wchar_t> wfstream;
 #    endif
 
 #    if _LIBCPP_HAS_LARGEFILE_API
-// On AIX and glibc on Linux, fopen64/fseeko64/ftello64 are not guaranteed to always be declared, so we declare them here.
-// They are not POSIX-reserved names, so we use __asm__ to guard them against a user #define.
+// On AIX and glibc on Linux, fopen64/fseeko64/ftello64 are not guaranteed to always be declared, so we declare them
+// here. They are not POSIX-reserved names, so we use __asm__ to guard them against a user #define.
 extern "C" FILE* __libcpp_fopen64(const char*, const char*) __asm__("fopen64");
 extern "C" long long __libcpp_ftello64(FILE*) __asm__("ftello64");
 extern "C" int __libcpp_fseeko64(FILE*, long long, int) __asm__("fseeko64");

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -782,11 +782,11 @@ const wchar_t* basic_filebuf<_CharT, _Traits>::__make_mdwstring(ios_base::openmo
 
 template <class _CharT, class _Traits>
 FILE* basic_filebuf<_CharT, _Traits>::__fopen(const char* __name, const char* __mode) {
-#   if defined(_AIX) && !defined(__64BIT__)
+#    if defined(_AIX) && !defined(__64BIT__)
   return fopen64(__name, __mode);
-#   else
+#    else
   return std::fopen(__name, __mode);
-#   endif
+#    endif
 }
 
 template <class _CharT, class _Traits>

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -809,7 +809,7 @@ basic_filebuf<_CharT, _Traits>* basic_filebuf<_CharT, _Traits>::open(const char*
   if (!__mdstr)
     return nullptr;
 
-  return __adopt_file(__fopen(__s, __mdstr), __mode);
+  return __adopt_file(std::__fopen(__s, __mdstr), __mode);
 }
 
 template <class _CharT, class _Traits>

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -217,6 +217,14 @@ typedef basic_fstream<wchar_t> wfstream;
 #      pragma GCC system_header
 #    endif
 
+#if defined(_AIX)
+// On AIX, fopen64/fseeko64/ftello64 are not guaranteed to always be declared, so we declare them here.
+// They are not POSIX-reserved names, so we use __asm__ to guard them against a user #define.
+extern "C" FILE* __libcpp_aix_fopen64(const char*, const char*) __asm__("fopen64");
+extern "C" long long __libcpp_aix_ftello64(FILE*) __asm__("ftello64");
+extern "C" int __libcpp_aix_fseeko64(FILE*, long long, int) __asm__("fseeko64");
+#endif
+
 _LIBCPP_PUSH_MACROS
 #    include <__undef_macros>
 
@@ -782,8 +790,8 @@ const wchar_t* basic_filebuf<_CharT, _Traits>::__make_mdwstring(ios_base::openmo
 
 template <class _CharT, class _Traits>
 FILE* basic_filebuf<_CharT, _Traits>::__fopen(const char* __name, const char* __mode) {
-#    if defined(_AIX) && !defined(__64BIT__)
-  return fopen64(__name, __mode);
+#    if defined(_AIX)
+  return __libcpp_aix_fopen64(__name, __mode);
 #    else
   return std::fopen(__name, __mode);
 #    endif
@@ -1077,8 +1085,8 @@ int basic_filebuf<_CharT, _Traits>::__fseek(FILE* __file, pos_type __offset, int
   return _fseeki64(__file, __offset, __whence);
 #    elif _LIBCPP_LIBC_NEWLIB
   return fseek(__file, __offset, __whence);
-#    elif defined(_AIX) && !defined(__64BIT__)
-  return fseeko64(__file, __offset, __whence);
+#    elif defined(_AIX)
+  return __libcpp_aix_fseeko64(__file, __offset, __whence);
 #    else
   return ::fseeko(__file, __offset, __whence);
 #    endif
@@ -1090,8 +1098,8 @@ typename basic_filebuf<_CharT, _Traits>::pos_type basic_filebuf<_CharT, _Traits>
   return _ftelli64(__file);
 #    elif _LIBCPP_LIBC_NEWLIB
   return ftell(__file);
-#    elif defined(_AIX) && !defined(__64BIT__)
-  return ftello64(__file);
+#    elif defined(_AIX)
+  return __libcpp_aix_ftello64(__file);
 #    else
   return ftello(__file);
 #    endif

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -432,6 +432,7 @@ private:
 
   _LIBCPP_HIDE_FROM_ABI static int __fseek(FILE* __file, pos_type __offset, int __whence);
   _LIBCPP_HIDE_FROM_ABI static pos_type __ftell(FILE* __file);
+  _LIBCPP_HIDE_FROM_ABI static FILE* __fopen(const char* __name, const char* __mode);
 
   _LIBCPP_EXPORTED_FROM_ABI friend FILE* __get_ostream_file(ostream&);
 
@@ -780,6 +781,15 @@ const wchar_t* basic_filebuf<_CharT, _Traits>::__make_mdwstring(ios_base::openmo
 #    endif
 
 template <class _CharT, class _Traits>
+FILE* basic_filebuf<_CharT, _Traits>::__fopen(const char* __name, const char* __mode) {
+#   if defined(_AIX) && !defined(__64BIT__)
+  return fopen64(__name, __mode);
+#   else
+  return std::fopen(__name, __mode);
+#   endif
+}
+
+template <class _CharT, class _Traits>
 basic_filebuf<_CharT, _Traits>* basic_filebuf<_CharT, _Traits>::open(const char* __s, ios_base::openmode __mode) {
   if (__file_)
     return nullptr;
@@ -787,7 +797,7 @@ basic_filebuf<_CharT, _Traits>* basic_filebuf<_CharT, _Traits>::open(const char*
   if (!__mdstr)
     return nullptr;
 
-  return __adopt_file(std::fopen(__s, __mdstr), __mode);
+  return __adopt_file(__fopen(__s, __mdstr), __mode);
 }
 
 template <class _CharT, class _Traits>
@@ -1067,6 +1077,8 @@ int basic_filebuf<_CharT, _Traits>::__fseek(FILE* __file, pos_type __offset, int
   return _fseeki64(__file, __offset, __whence);
 #    elif _LIBCPP_LIBC_NEWLIB
   return fseek(__file, __offset, __whence);
+#    elif defined(_AIX) && !defined(__64BIT__)
+  return fseeko64(__file, __offset, __whence);
 #    else
   return ::fseeko(__file, __offset, __whence);
 #    endif
@@ -1078,6 +1090,8 @@ typename basic_filebuf<_CharT, _Traits>::pos_type basic_filebuf<_CharT, _Traits>
   return _ftelli64(__file);
 #    elif _LIBCPP_LIBC_NEWLIB
   return ftell(__file);
+#    elif defined(_AIX) && !defined(__64BIT__)
+  return ftello64(__file);
 #    else
   return ftello(__file);
 #    endif

--- a/libcxx/test/std/input.output/file.streams/fstreams/ifstream.members/offset_range.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/ifstream.members/offset_range.pass.cpp
@@ -18,10 +18,10 @@
 //
 // XFAIL: target={{i686|arm.*}}-{{.+}}-android{{.*}}
 
-// By default, off_t is typically a 32-bit integer on ARMv7 Linux systems and
-// 32-bit AIX, meaning it can represent file sizes up to 2GB (2^31 bytes) only.
+// By default, off_t is typically a 32-bit integer on ARMv7 Linux systems,
+// meaning it can represent file sizes up to 2GB (2^31 bytes) only.
 //
-// UNSUPPORTED: target=armv7-unknown-linux-gnueabihf, target=powerpc-{{.+}}-aix{{.*}}
+// UNSUPPORTED: target=armv7-unknown-linux-gnueabihf
 
 #include <fstream>
 #include <iostream>

--- a/libcxx/test/std/input.output/file.streams/fstreams/ifstream.members/offset_range.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/ifstream.members/offset_range.pass.cpp
@@ -18,11 +18,6 @@
 //
 // XFAIL: target={{i686|arm.*}}-{{.+}}-android{{.*}}
 
-// By default, off_t is typically a 32-bit integer on ARMv7 Linux systems,
-// meaning it can represent file sizes up to 2GB (2^31 bytes) only.
-//
-// UNSUPPORTED: target=armv7-unknown-linux-gnueabihf
-
 #include <fstream>
 #include <iostream>
 #include <cassert>


### PR DESCRIPTION
Currently, opening files greater than 2GB on 32-bit AIX doesn't work, even with `_LARGE_FILES` defined in the user program. A similar issue exists with 32-bit glibc.

On AIX, the `_LARGE_FILES` macro enables programs to handle large files (greater than 2GB). When `_LARGE_FILES` is defined, all data types, structures, and subroutine names are mapped to their 64-bit versions during preprocessing ([source](https://www.ibm.com/docs/en/aix/7.2.0?topic=volumes-writing-programs-that-access-large-files)). Since the shared library is pre-compiled, defining the macro in user programs doesn't affect fstream's open/seek/tell, causing failure with large files on 32-bit.

Instead of building libc++ with `_LARGE_FILES` defined, which could cause ODR violations, we can swap `fopen`/`fseeko`/`ftello` calls with their 64-bit counter-parts.