### PR TITLE
[LLDB] Add a GetTargetSP() accessor to ObjectFileJITDelegate. (NFC)

### DIFF
--- a/lldb/include/lldb/Expression/IRExecutionUnit.h
+++ b/lldb/include/lldb/Expression/IRExecutionUnit.h
@@ -100,6 +100,8 @@ public:
 
   ArchSpec GetArchitecture() override;
 
+  lldb::TargetSP GetTargetSP() override { return GetTarget(); }
+
   lldb::ModuleSP GetJITModule();
 
   lldb::addr_t FindSymbol(ConstString name, bool &missing_weak);

--- a/lldb/include/lldb/Expression/ObjectFileJIT.h
+++ b/lldb/include/lldb/Expression/ObjectFileJIT.h
@@ -28,6 +28,9 @@ public:
   virtual void PopulateSectionList(lldb_private::ObjectFile *obj_file,
                                    lldb_private::SectionList &section_list) = 0;
   virtual ArchSpec GetArchitecture() = 0;
+  /// Returns the Target this JIT-compiled code was produced for, or null
+  /// if the delegate that created this ObjectFile no longer exists.
+  virtual lldb::TargetSP GetTargetSP() = 0;
 };
 
 class ObjectFileJIT : public ObjectFile {
@@ -91,6 +94,10 @@ public:
   void Dump(lldb_private::Stream *s) override;
 
   lldb_private::ArchSpec GetArchitecture() override;
+
+  /// Returns the Target this JIT-compiled code was produced for, or null
+  /// if the delegate that created this ObjectFile no longer exists.
+  lldb::TargetSP GetTargetSP();
 
   lldb_private::UUID GetUUID() override;
 

--- a/lldb/source/Expression/ObjectFileJIT.cpp
+++ b/lldb/source/Expression/ObjectFileJIT.cpp
@@ -167,6 +167,12 @@ ArchSpec ObjectFileJIT::GetArchitecture() {
   return ArchSpec();
 }
 
+TargetSP ObjectFileJIT::GetTargetSP() {
+  if (ObjectFileJITDelegateSP delegate_sp = m_delegate_wp.lock())
+    return delegate_sp->GetTargetSP();
+  return nullptr;
+}
+
 bool ObjectFileJIT::SetLoadAddress(Target &target, lldb::addr_t value,
                                    bool value_is_offset) {
   size_t num_loaded_sections = 0;


### PR DESCRIPTION
This is needed to implement the Swift REPL and potentially generally useful to other expression evaluators.