### PR TITLE
[NVPTX] Extend SETP commuting to support SELP users

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXInstrInfo.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXInstrInfo.cpp
@@ -16,6 +16,7 @@
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineInstrBuilder.h"
 #include "llvm/CodeGen/MachineRegisterInfo.h"
+#include "llvm/Support/ErrorHandling.h"
 
 using namespace llvm;
 
@@ -327,6 +328,131 @@ static void invertScalarCompareInstr(MachineInstr &MI) {
     llvm_unreachable("Invalid SETP instruction");
 }
 
+static void swapSelpOperands(MachineOperand &Src0, MachineOperand &Src1) {
+  if (Src0.isReg() && Src1.isReg()) {
+    Register Reg0 = Src0.getReg();
+    Register Reg1 = Src1.getReg();
+    bool IsKill0 = Src0.isKill();
+    bool IsKill1 = Src1.isKill();
+    bool IsUndef0 = Src0.isUndef();
+    bool IsUndef1 = Src1.isUndef();
+
+    Src0.setReg(Reg1);
+    Src1.setReg(Reg0);
+    Src0.setIsKill(IsKill1);
+    Src1.setIsKill(IsKill0);
+    Src0.setIsUndef(IsUndef1);
+    Src1.setIsUndef(IsUndef0);
+    return;
+  }
+
+  auto SwapRegAndNonReg = [](MachineOperand &RegOp, MachineOperand &NonRegOp) {
+    Register Reg = RegOp.getReg();
+    bool IsKill = RegOp.isKill();
+    bool IsUndef = RegOp.isUndef();
+
+    if (NonRegOp.isImm())
+      RegOp.ChangeToImmediate(NonRegOp.getImm());
+    else if (NonRegOp.isFPImm())
+      RegOp.ChangeToFPImmediate(NonRegOp.getFPImm());
+    else
+      llvm_unreachable("Unexpected SELP operand");
+
+    NonRegOp.ChangeToRegister(Reg, /*isDef=*/false, /*isImp=*/false, IsKill,
+                              /*isDead=*/false, IsUndef, /*isDebug=*/false);
+  };
+
+  if (Src0.isReg()) {
+    SwapRegAndNonReg(Src0, Src1);
+    return;
+  }
+
+  if (Src1.isReg()) {
+    SwapRegAndNonReg(Src1, Src0);
+    return;
+  }
+
+  if (Src0.isImm() && Src1.isImm()) {
+    int64_t Imm0 = Src0.getImm();
+    Src0.setImm(Src1.getImm());
+    Src1.setImm(Imm0);
+  } else if (Src0.isFPImm() && Src1.isFPImm()) {
+    const ConstantFP *FPImm0 = Src0.getFPImm();
+    Src0.setFPImm(Src1.getFPImm());
+    Src1.setFPImm(FPImm0);
+  } else {
+    llvm_unreachable("Unexpected SELP operand pair");
+  }
+}
+
+static void invertSelpInstr(MachineInstr &MI, const NVPTXInstrInfo &TII) {
+  unsigned NewOpcode = MI.getOpcode();
+
+  switch (NewOpcode) {
+  case NVPTX::SELP_b16ri:
+    NewOpcode = NVPTX::SELP_b16ir;
+    break;
+  case NVPTX::SELP_b16ir:
+    NewOpcode = NVPTX::SELP_b16ri;
+    break;
+  case NVPTX::SELP_b32ri:
+    NewOpcode = NVPTX::SELP_b32ir;
+    break;
+  case NVPTX::SELP_b32ir:
+    NewOpcode = NVPTX::SELP_b32ri;
+    break;
+  case NVPTX::SELP_b64ri:
+    NewOpcode = NVPTX::SELP_b64ir;
+    break;
+  case NVPTX::SELP_b64ir:
+    NewOpcode = NVPTX::SELP_b64ri;
+    break;
+  case NVPTX::SELP_f16ri:
+    NewOpcode = NVPTX::SELP_f16ir;
+    break;
+  case NVPTX::SELP_f16ir:
+    NewOpcode = NVPTX::SELP_f16ri;
+    break;
+  case NVPTX::SELP_f32ri:
+    NewOpcode = NVPTX::SELP_f32ir;
+    break;
+  case NVPTX::SELP_f32ir:
+    NewOpcode = NVPTX::SELP_f32ri;
+    break;
+  case NVPTX::SELP_f64ri:
+    NewOpcode = NVPTX::SELP_f64ir;
+    break;
+  case NVPTX::SELP_f64ir:
+    NewOpcode = NVPTX::SELP_f64ri;
+    break;
+  case NVPTX::SELP_bf16ri:
+    NewOpcode = NVPTX::SELP_bf16ir;
+    break;
+  case NVPTX::SELP_bf16ir:
+    NewOpcode = NVPTX::SELP_bf16ri;
+    break;
+  case NVPTX::SELP_b16rr:
+  case NVPTX::SELP_b16ii:
+  case NVPTX::SELP_b32rr:
+  case NVPTX::SELP_b32ii:
+  case NVPTX::SELP_b64rr:
+  case NVPTX::SELP_b64ii:
+  case NVPTX::SELP_f16rr:
+  case NVPTX::SELP_f16ii:
+  case NVPTX::SELP_f32rr:
+  case NVPTX::SELP_f32ii:
+  case NVPTX::SELP_f64rr:
+  case NVPTX::SELP_f64ii:
+  case NVPTX::SELP_bf16rr:
+  case NVPTX::SELP_bf16ii:
+    break;
+  default:
+    llvm_unreachable("Unexpected select instruction");
+  }
+  MI.setDesc(TII.get(NewOpcode));
+  swapSelpOperands(MI.getOperand(1), MI.getOperand(2));
+}
+
 bool NVPTXInstrInfo::findCommutedOpIndices(const MachineInstr &MI,
                                            unsigned &SrcOpIdx1,
                                            unsigned &SrcOpIdx2) const {
@@ -344,28 +470,40 @@ MachineInstr *NVPTXInstrInfo::commuteInstructionImpl(MachineInstr &MI,
   if (!isIntegerSetp(MI) && !isScalarFloatSetp(MI))
     return TargetInstrInfo::commuteInstructionImpl(MI, NewMI, OpIdx1, OpIdx2);
 
-  // For now all users must be invertible conditional branches.
-  // TODO: Support other users such as selects.
+  // For now all users must be invertible conditional branches or selects.
+  // TODO: Support other invertible predicate users.
   MachineRegisterInfo &MRI = MI.getParent()->getParent()->getRegInfo();
   SmallVector<MachineBasicBlock *, 4> BranchMBBs;
+  SmallVector<MachineInstr *, 4> SelectInstrs;
   for (MachineInstr &UseMI :
        MRI.use_nodbg_instructions(MI.getOperand(0).getReg())) {
-    if (!UseMI.isConditionalBranch())
+    if (UseMI.isConditionalBranch())
+      BranchMBBs.push_back(UseMI.getParent());
+    else if (UseMI.isSelect())
+      SelectInstrs.push_back(&UseMI);
+    else
       return nullptr;
-    BranchMBBs.push_back(UseMI.getParent());
   }
 
   invertScalarCompareInstr(MI);
-  auto *Failed = llvm::find_if(BranchMBBs, [this](MachineBasicBlock *MBB) {
-    return !invertPredicateBranchInstr(*MBB);
-  });
-  if (Failed == BranchMBBs.end())
-    return &MI;
 
-  // Couldn't invert one of the branches. Roll back the prefix we
-  // already inverted and the compare-mode flip.
-  for (MachineBasicBlock *MBB : make_range(BranchMBBs.begin(), Failed))
-    invertPredicateBranchInstr(*MBB);
-  invertScalarCompareInstr(MI);
-  return nullptr;
+  auto Failed = llvm::find_if(
+      BranchMBBs,
+      [this](MachineBasicBlock *MBB) { // NOLINT(llvm-qualified-auto)
+        return !invertPredicateBranchInstr(*MBB);
+      });
+
+  if (Failed != BranchMBBs.end()) {
+    // Couldn't invert one of the branches. Roll back the prefix we
+    // already inverted and the compare-mode flip.
+    for (MachineBasicBlock *MBB : llvm::make_range(BranchMBBs.begin(), Failed))
+      invertPredicateBranchInstr(*MBB);
+    invertScalarCompareInstr(MI);
+    return nullptr;
+  }
+
+  for (MachineInstr *SelectMI : SelectInstrs)
+    invertSelpInstr(*SelectMI, *this);
+
+  return &MI;
 }

--- a/llvm/lib/Target/NVPTX/NVPTXInstrInfo.td
+++ b/llvm/lib/Target/NVPTX/NVPTXInstrInfo.td
@@ -874,7 +874,7 @@ def : Pat<(v2f16 (build_vector (f16 (fpround_oneuse f32:$lo)),
 
 // selp instructions that don't have any pattern matches; we explicitly use
 // them within this file.
-let hasSideEffects = false in {
+let hasSideEffects = false, isSelect = 1 in {
   multiclass SELP_PATTERN<string TypeStr, RegTyInfo t> {
     defvar asm_str = "selp." # TypeStr;
     def rr :

--- a/llvm/test/CodeGen/NVPTX/arbitrary-fp-to-float.ll
+++ b/llvm/test/CodeGen/NVPTX/arbitrary-fp-to-float.ll
@@ -121,7 +121,7 @@ define float @from_f8e5m2_neg() {
 define float @from_f8e5m2_dynamic(i8 %x) {
 ; CHECK-LABEL: from_f8e5m2_dynamic(
 ; CHECK:       {
-; CHECK-NEXT:    .reg .pred %p<6>;
+; CHECK-NEXT:    .reg .pred %p<5>;
 ; CHECK-NEXT:    .reg .b32 %r<31>;
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
@@ -153,13 +153,12 @@ define float @from_f8e5m2_dynamic(i8 %x) {
 ; CHECK-NEXT:    or.b32 %r24, %r16, %r4;
 ; CHECK-NEXT:    setp.eq.b32 %p3, %r24, 0;
 ; CHECK-NEXT:    selp.b32 %r25, %r3, %r23, %p3;
-; CHECK-NEXT:    setp.eq.b32 %p4, %r4, 0;
 ; CHECK-NEXT:    or.b32 %r26, %r3, 2139095040;
-; CHECK-NEXT:    selp.b32 %r27, %r26, %r25, %p4;
-; CHECK-NEXT:    setp.eq.b32 %p5, %r16, 31;
-; CHECK-NEXT:    selp.b32 %r28, %r27, %r25, %p5;
+; CHECK-NEXT:    selp.b32 %r27, %r25, %r26, %p1;
+; CHECK-NEXT:    setp.eq.b32 %p4, %r16, 31;
+; CHECK-NEXT:    selp.b32 %r28, %r27, %r25, %p4;
 ; CHECK-NEXT:    selp.b32 %r29, 2143289344, %r28, %p1;
-; CHECK-NEXT:    selp.b32 %r30, %r29, %r28, %p5;
+; CHECK-NEXT:    selp.b32 %r30, %r29, %r28, %p4;
 ; CHECK-NEXT:    st.param.b32 [func_retval0], %r30;
 ; CHECK-NEXT:    ret;
   %r = call float @llvm.convert.from.arbitrary.fp.f32.i8(i8 %x, metadata !"Float8E5M2")
@@ -821,7 +820,7 @@ define <2 x float> @from_f8e4m3fn_v2f32(<2 x i8> %x) {
 define <2 x float> @from_f8e5m2_v2f32(<2 x i8> %x) {
 ; CHECK-LABEL: from_f8e5m2_v2f32(
 ; CHECK:       {
-; CHECK-NEXT:    .reg .pred %p<11>;
+; CHECK-NEXT:    .reg .pred %p<9>;
 ; CHECK-NEXT:    .reg .b16 %rs<3>;
 ; CHECK-NEXT:    .reg .b32 %r<60>;
 ; CHECK-EMPTY:
@@ -855,13 +854,12 @@ define <2 x float> @from_f8e5m2_v2f32(<2 x i8> %x) {
 ; CHECK-NEXT:    or.b32 %r24, %r16, %r4;
 ; CHECK-NEXT:    setp.eq.b32 %p3, %r24, 0;
 ; CHECK-NEXT:    selp.b32 %r25, %r3, %r23, %p3;
-; CHECK-NEXT:    setp.eq.b32 %p4, %r4, 0;
 ; CHECK-NEXT:    or.b32 %r26, %r3, 2139095040;
-; CHECK-NEXT:    selp.b32 %r27, %r26, %r25, %p4;
-; CHECK-NEXT:    setp.eq.b32 %p5, %r16, 31;
-; CHECK-NEXT:    selp.b32 %r28, %r27, %r25, %p5;
+; CHECK-NEXT:    selp.b32 %r27, %r25, %r26, %p1;
+; CHECK-NEXT:    setp.eq.b32 %p4, %r16, 31;
+; CHECK-NEXT:    selp.b32 %r28, %r27, %r25, %p4;
 ; CHECK-NEXT:    selp.b32 %r29, 2143289344, %r28, %p1;
-; CHECK-NEXT:    selp.b32 %r30, %r29, %r28, %p5;
+; CHECK-NEXT:    selp.b32 %r30, %r29, %r28, %p4;
 ; CHECK-NEXT:    cvt.u32.u16 %r31, %rs1;
 ; CHECK-NEXT:    shl.b32 %r32, %r31, 24;
 ; CHECK-NEXT:    and.b32 %r33, %r32, -2147483648;
@@ -882,20 +880,19 @@ define <2 x float> @from_f8e5m2_v2f32(<2 x i8> %x) {
 ; CHECK-NEXT:    shl.b32 %r48, %r34, 21;
 ; CHECK-NEXT:    or.b32 %r49, %r47, %r48;
 ; CHECK-NEXT:    add.s32 %r50, %r49, 939524096;
-; CHECK-NEXT:    setp.ne.b32 %p6, %r34, 0;
-; CHECK-NEXT:    selp.b32 %r51, %r44, %r50, %p6;
-; CHECK-NEXT:    setp.eq.b32 %p7, %r45, 0;
-; CHECK-NEXT:    selp.b32 %r52, %r51, %r50, %p7;
+; CHECK-NEXT:    setp.ne.b32 %p5, %r34, 0;
+; CHECK-NEXT:    selp.b32 %r51, %r44, %r50, %p5;
+; CHECK-NEXT:    setp.eq.b32 %p6, %r45, 0;
+; CHECK-NEXT:    selp.b32 %r52, %r51, %r50, %p6;
 ; CHECK-NEXT:    or.b32 %r53, %r45, %r34;
-; CHECK-NEXT:    setp.eq.b32 %p8, %r53, 0;
-; CHECK-NEXT:    selp.b32 %r54, %r33, %r52, %p8;
-; CHECK-NEXT:    setp.eq.b32 %p9, %r34, 0;
+; CHECK-NEXT:    setp.eq.b32 %p7, %r53, 0;
+; CHECK-NEXT:    selp.b32 %r54, %r33, %r52, %p7;
 ; CHECK-NEXT:    or.b32 %r55, %r33, 2139095040;
-; CHECK-NEXT:    selp.b32 %r56, %r55, %r54, %p9;
-; CHECK-NEXT:    setp.eq.b32 %p10, %r45, 31;
-; CHECK-NEXT:    selp.b32 %r57, %r56, %r54, %p10;
-; CHECK-NEXT:    selp.b32 %r58, 2143289344, %r57, %p6;
-; CHECK-NEXT:    selp.b32 %r59, %r58, %r57, %p10;
+; CHECK-NEXT:    selp.b32 %r56, %r54, %r55, %p5;
+; CHECK-NEXT:    setp.eq.b32 %p8, %r45, 31;
+; CHECK-NEXT:    selp.b32 %r57, %r56, %r54, %p8;
+; CHECK-NEXT:    selp.b32 %r58, 2143289344, %r57, %p5;
+; CHECK-NEXT:    selp.b32 %r59, %r58, %r57, %p8;
 ; CHECK-NEXT:    st.param.v2.b32 [func_retval0], {%r59, %r30};
 ; CHECK-NEXT:    ret;
   %r = call <2 x float> @llvm.convert.from.arbitrary.fp.v2f32.v2i8(<2 x i8> %x, metadata !"Float8E5M2")
@@ -1156,7 +1153,7 @@ define <4 x float> @from_f8e4m3fn_v4f32(<4 x i8> %x) {
 define <4 x float> @from_f8e5m2_v4f32(<4 x i8> %x) {
 ; CHECK-LABEL: from_f8e5m2_v4f32(
 ; CHECK:       {
-; CHECK-NEXT:    .reg .pred %p<21>;
+; CHECK-NEXT:    .reg .pred %p<17>;
 ; CHECK-NEXT:    .reg .b32 %r<119>;
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
@@ -1189,13 +1186,12 @@ define <4 x float> @from_f8e5m2_v4f32(<4 x i8> %x) {
 ; CHECK-NEXT:    or.b32 %r25, %r17, %r5;
 ; CHECK-NEXT:    setp.eq.b32 %p3, %r25, 0;
 ; CHECK-NEXT:    selp.b32 %r26, %r4, %r24, %p3;
-; CHECK-NEXT:    setp.eq.b32 %p4, %r5, 0;
 ; CHECK-NEXT:    or.b32 %r27, %r4, 2139095040;
-; CHECK-NEXT:    selp.b32 %r28, %r27, %r26, %p4;
-; CHECK-NEXT:    setp.eq.b32 %p5, %r17, 31;
-; CHECK-NEXT:    selp.b32 %r29, %r28, %r26, %p5;
+; CHECK-NEXT:    selp.b32 %r28, %r26, %r27, %p1;
+; CHECK-NEXT:    setp.eq.b32 %p4, %r17, 31;
+; CHECK-NEXT:    selp.b32 %r29, %r28, %r26, %p4;
 ; CHECK-NEXT:    selp.b32 %r30, 2143289344, %r29, %p1;
-; CHECK-NEXT:    selp.b32 %r31, %r30, %r29, %p5;
+; CHECK-NEXT:    selp.b32 %r31, %r30, %r29, %p4;
 ; CHECK-NEXT:    prmt.b32 %r32, %r1, 0, 0x7772U;
 ; CHECK-NEXT:    shl.b32 %r33, %r32, 24;
 ; CHECK-NEXT:    and.b32 %r34, %r33, -2147483648;
@@ -1216,20 +1212,19 @@ define <4 x float> @from_f8e5m2_v4f32(<4 x i8> %x) {
 ; CHECK-NEXT:    shl.b32 %r49, %r35, 21;
 ; CHECK-NEXT:    or.b32 %r50, %r48, %r49;
 ; CHECK-NEXT:    add.s32 %r51, %r50, 939524096;
-; CHECK-NEXT:    setp.ne.b32 %p6, %r35, 0;
-; CHECK-NEXT:    selp.b32 %r52, %r45, %r51, %p6;
-; CHECK-NEXT:    setp.eq.b32 %p7, %r46, 0;
-; CHECK-NEXT:    selp.b32 %r53, %r52, %r51, %p7;
+; CHECK-NEXT:    setp.ne.b32 %p5, %r35, 0;
+; CHECK-NEXT:    selp.b32 %r52, %r45, %r51, %p5;
+; CHECK-NEXT:    setp.eq.b32 %p6, %r46, 0;
+; CHECK-NEXT:    selp.b32 %r53, %r52, %r51, %p6;
 ; CHECK-NEXT:    or.b32 %r54, %r46, %r35;
-; CHECK-NEXT:    setp.eq.b32 %p8, %r54, 0;
-; CHECK-NEXT:    selp.b32 %r55, %r34, %r53, %p8;
-; CHECK-NEXT:    setp.eq.b32 %p9, %r35, 0;
+; CHECK-NEXT:    setp.eq.b32 %p7, %r54, 0;
+; CHECK-NEXT:    selp.b32 %r55, %r34, %r53, %p7;
 ; CHECK-NEXT:    or.b32 %r56, %r34, 2139095040;
-; CHECK-NEXT:    selp.b32 %r57, %r56, %r55, %p9;
-; CHECK-NEXT:    setp.eq.b32 %p10, %r46, 31;
-; CHECK-NEXT:    selp.b32 %r58, %r57, %r55, %p10;
-; CHECK-NEXT:    selp.b32 %r59, 2143289344, %r58, %p6;
-; CHECK-NEXT:    selp.b32 %r60, %r59, %r58, %p10;
+; CHECK-NEXT:    selp.b32 %r57, %r55, %r56, %p5;
+; CHECK-NEXT:    setp.eq.b32 %p8, %r46, 31;
+; CHECK-NEXT:    selp.b32 %r58, %r57, %r55, %p8;
+; CHECK-NEXT:    selp.b32 %r59, 2143289344, %r58, %p5;
+; CHECK-NEXT:    selp.b32 %r60, %r59, %r58, %p8;
 ; CHECK-NEXT:    prmt.b32 %r61, %r1, 0, 0x7771U;
 ; CHECK-NEXT:    shl.b32 %r62, %r61, 24;
 ; CHECK-NEXT:    and.b32 %r63, %r62, -2147483648;
@@ -1250,20 +1245,19 @@ define <4 x float> @from_f8e5m2_v4f32(<4 x i8> %x) {
 ; CHECK-NEXT:    shl.b32 %r78, %r64, 21;
 ; CHECK-NEXT:    or.b32 %r79, %r77, %r78;
 ; CHECK-NEXT:    add.s32 %r80, %r79, 939524096;
-; CHECK-NEXT:    setp.ne.b32 %p11, %r64, 0;
-; CHECK-NEXT:    selp.b32 %r81, %r74, %r80, %p11;
-; CHECK-NEXT:    setp.eq.b32 %p12, %r75, 0;
-; CHECK-NEXT:    selp.b32 %r82, %r81, %r80, %p12;
+; CHECK-NEXT:    setp.ne.b32 %p9, %r64, 0;
+; CHECK-NEXT:    selp.b32 %r81, %r74, %r80, %p9;
+; CHECK-NEXT:    setp.eq.b32 %p10, %r75, 0;
+; CHECK-NEXT:    selp.b32 %r82, %r81, %r80, %p10;
 ; CHECK-NEXT:    or.b32 %r83, %r75, %r64;
-; CHECK-NEXT:    setp.eq.b32 %p13, %r83, 0;
-; CHECK-NEXT:    selp.b32 %r84, %r63, %r82, %p13;
-; CHECK-NEXT:    setp.eq.b32 %p14, %r64, 0;
+; CHECK-NEXT:    setp.eq.b32 %p11, %r83, 0;
+; CHECK-NEXT:    selp.b32 %r84, %r63, %r82, %p11;
 ; CHECK-NEXT:    or.b32 %r85, %r63, 2139095040;
-; CHECK-NEXT:    selp.b32 %r86, %r85, %r84, %p14;
-; CHECK-NEXT:    setp.eq.b32 %p15, %r75, 31;
-; CHECK-NEXT:    selp.b32 %r87, %r86, %r84, %p15;
-; CHECK-NEXT:    selp.b32 %r88, 2143289344, %r87, %p11;
-; CHECK-NEXT:    selp.b32 %r89, %r88, %r87, %p15;
+; CHECK-NEXT:    selp.b32 %r86, %r84, %r85, %p9;
+; CHECK-NEXT:    setp.eq.b32 %p12, %r75, 31;
+; CHECK-NEXT:    selp.b32 %r87, %r86, %r84, %p12;
+; CHECK-NEXT:    selp.b32 %r88, 2143289344, %r87, %p9;
+; CHECK-NEXT:    selp.b32 %r89, %r88, %r87, %p12;
 ; CHECK-NEXT:    prmt.b32 %r90, %r1, 0, 0x7770U;
 ; CHECK-NEXT:    shl.b32 %r91, %r90, 24;
 ; CHECK-NEXT:    and.b32 %r92, %r91, -2147483648;
@@ -1284,20 +1278,19 @@ define <4 x float> @from_f8e5m2_v4f32(<4 x i8> %x) {
 ; CHECK-NEXT:    shl.b32 %r107, %r93, 21;
 ; CHECK-NEXT:    or.b32 %r108, %r106, %r107;
 ; CHECK-NEXT:    add.s32 %r109, %r108, 939524096;
-; CHECK-NEXT:    setp.ne.b32 %p16, %r93, 0;
-; CHECK-NEXT:    selp.b32 %r110, %r103, %r109, %p16;
-; CHECK-NEXT:    setp.eq.b32 %p17, %r104, 0;
-; CHECK-NEXT:    selp.b32 %r111, %r110, %r109, %p17;
+; CHECK-NEXT:    setp.ne.b32 %p13, %r93, 0;
+; CHECK-NEXT:    selp.b32 %r110, %r103, %r109, %p13;
+; CHECK-NEXT:    setp.eq.b32 %p14, %r104, 0;
+; CHECK-NEXT:    selp.b32 %r111, %r110, %r109, %p14;
 ; CHECK-NEXT:    or.b32 %r112, %r104, %r93;
-; CHECK-NEXT:    setp.eq.b32 %p18, %r112, 0;
-; CHECK-NEXT:    selp.b32 %r113, %r92, %r111, %p18;
-; CHECK-NEXT:    setp.eq.b32 %p19, %r93, 0;
+; CHECK-NEXT:    setp.eq.b32 %p15, %r112, 0;
+; CHECK-NEXT:    selp.b32 %r113, %r92, %r111, %p15;
 ; CHECK-NEXT:    or.b32 %r114, %r92, 2139095040;
-; CHECK-NEXT:    selp.b32 %r115, %r114, %r113, %p19;
-; CHECK-NEXT:    setp.eq.b32 %p20, %r104, 31;
-; CHECK-NEXT:    selp.b32 %r116, %r115, %r113, %p20;
-; CHECK-NEXT:    selp.b32 %r117, 2143289344, %r116, %p16;
-; CHECK-NEXT:    selp.b32 %r118, %r117, %r116, %p20;
+; CHECK-NEXT:    selp.b32 %r115, %r113, %r114, %p13;
+; CHECK-NEXT:    setp.eq.b32 %p16, %r104, 31;
+; CHECK-NEXT:    selp.b32 %r116, %r115, %r113, %p16;
+; CHECK-NEXT:    selp.b32 %r117, 2143289344, %r116, %p13;
+; CHECK-NEXT:    selp.b32 %r118, %r117, %r116, %p16;
 ; CHECK-NEXT:    st.param.v4.b32 [func_retval0], {%r118, %r89, %r60, %r31};
 ; CHECK-NEXT:    ret;
   %r = call <4 x float> @llvm.convert.from.arbitrary.fp.v4f32.v4i8(<4 x i8> %x, metadata !"Float8E5M2")
@@ -1402,7 +1395,7 @@ define <2 x half> @from_f8e4m3fn_v2f16(<2 x i8> %x) {
 define bfloat @from_f8e5m2_bf16(i8 %x) {
 ; CHECK-LABEL: from_f8e5m2_bf16(
 ; CHECK:       {
-; CHECK-NEXT:    .reg .pred %p<6>;
+; CHECK-NEXT:    .reg .pred %p<5>;
 ; CHECK-NEXT:    .reg .b16 %rs<32>;
 ; CHECK-NEXT:    .reg .b32 %r<6>;
 ; CHECK-EMPTY:
@@ -1441,13 +1434,12 @@ define bfloat @from_f8e5m2_bf16(i8 %x) {
 ; CHECK-NEXT:    or.b16 %rs25, %rs17, %rs4;
 ; CHECK-NEXT:    setp.eq.b16 %p3, %rs25, 0;
 ; CHECK-NEXT:    selp.b16 %rs26, %rs3, %rs24, %p3;
-; CHECK-NEXT:    setp.eq.b16 %p4, %rs4, 0;
 ; CHECK-NEXT:    or.b16 %rs27, %rs3, 32640;
-; CHECK-NEXT:    selp.b16 %rs28, %rs27, %rs26, %p4;
-; CHECK-NEXT:    setp.eq.b16 %p5, %rs17, 31;
-; CHECK-NEXT:    selp.b16 %rs29, %rs28, %rs26, %p5;
+; CHECK-NEXT:    selp.b16 %rs28, %rs26, %rs27, %p1;
+; CHECK-NEXT:    setp.eq.b16 %p4, %rs17, 31;
+; CHECK-NEXT:    selp.b16 %rs29, %rs28, %rs26, %p4;
 ; CHECK-NEXT:    selp.b16 %rs30, 32704, %rs29, %p1;
-; CHECK-NEXT:    selp.b16 %rs31, %rs30, %rs29, %p5;
+; CHECK-NEXT:    selp.b16 %rs31, %rs30, %rs29, %p4;
 ; CHECK-NEXT:    st.param.b16 [func_retval0], %rs31;
 ; CHECK-NEXT:    ret;
   %r = call bfloat @llvm.convert.from.arbitrary.fp.bf16.i8(i8 %x, metadata !"Float8E5M2")
@@ -1509,7 +1501,7 @@ define bfloat @from_f8e4m3fn_bf16(i8 %x) {
 define <2 x bfloat> @from_f8e5m2_v2bf16(<2 x i8> %x) {
 ; CHECK-LABEL: from_f8e5m2_v2bf16(
 ; CHECK:       {
-; CHECK-NEXT:    .reg .pred %p<11>;
+; CHECK-NEXT:    .reg .pred %p<9>;
 ; CHECK-NEXT:    .reg .b16 %rs<58>;
 ; CHECK-NEXT:    .reg .b32 %r<27>;
 ; CHECK-EMPTY:
@@ -1581,25 +1573,23 @@ define <2 x bfloat> @from_f8e5m2_v2bf16(<2 x i8> %x) {
 ; CHECK-NEXT:    selp.b16 %rs43, %rs19, %rs41, %p3;
 ; CHECK-NEXT:    or.b32 %r26, %r16, 2139127680;
 ; CHECK-NEXT:    mov.b32 {%rs44, %rs45}, %r26;
-; CHECK-NEXT:    setp.eq.b16 %p4, %rs4, 0;
-; CHECK-NEXT:    selp.b16 %rs46, %rs45, %rs43, %p4;
-; CHECK-NEXT:    setp.eq.b16 %p5, %rs31, 31;
-; CHECK-NEXT:    selp.b16 %rs47, %rs46, %rs43, %p5;
+; CHECK-NEXT:    selp.b16 %rs46, %rs43, %rs45, %p1;
+; CHECK-NEXT:    setp.eq.b16 %p4, %rs31, 31;
+; CHECK-NEXT:    selp.b16 %rs47, %rs46, %rs43, %p4;
 ; CHECK-NEXT:    selp.b16 %rs48, 32704, %rs47, %p1;
-; CHECK-NEXT:    selp.b16 %rs49, %rs48, %rs47, %p5;
-; CHECK-NEXT:    setp.ne.b16 %p6, %rs3, 0;
-; CHECK-NEXT:    selp.b16 %rs50, %rs26, %rs38, %p6;
-; CHECK-NEXT:    setp.eq.b16 %p7, %rs30, 0;
-; CHECK-NEXT:    selp.b16 %rs51, %rs50, %rs38, %p7;
+; CHECK-NEXT:    selp.b16 %rs49, %rs48, %rs47, %p4;
+; CHECK-NEXT:    setp.ne.b16 %p5, %rs3, 0;
+; CHECK-NEXT:    selp.b16 %rs50, %rs26, %rs38, %p5;
+; CHECK-NEXT:    setp.eq.b16 %p6, %rs30, 0;
+; CHECK-NEXT:    selp.b16 %rs51, %rs50, %rs38, %p6;
 ; CHECK-NEXT:    or.b16 %rs52, %rs30, %rs3;
-; CHECK-NEXT:    setp.eq.b16 %p8, %rs52, 0;
-; CHECK-NEXT:    selp.b16 %rs53, %rs21, %rs51, %p8;
-; CHECK-NEXT:    setp.eq.b16 %p9, %rs3, 0;
-; CHECK-NEXT:    selp.b16 %rs54, %rs44, %rs53, %p9;
-; CHECK-NEXT:    setp.eq.b16 %p10, %rs30, 31;
-; CHECK-NEXT:    selp.b16 %rs55, %rs54, %rs53, %p10;
-; CHECK-NEXT:    selp.b16 %rs56, 32704, %rs55, %p6;
-; CHECK-NEXT:    selp.b16 %rs57, %rs56, %rs55, %p10;
+; CHECK-NEXT:    setp.eq.b16 %p7, %rs52, 0;
+; CHECK-NEXT:    selp.b16 %rs53, %rs21, %rs51, %p7;
+; CHECK-NEXT:    selp.b16 %rs54, %rs53, %rs44, %p5;
+; CHECK-NEXT:    setp.eq.b16 %p8, %rs30, 31;
+; CHECK-NEXT:    selp.b16 %rs55, %rs54, %rs53, %p8;
+; CHECK-NEXT:    selp.b16 %rs56, 32704, %rs55, %p5;
+; CHECK-NEXT:    selp.b16 %rs57, %rs56, %rs55, %p8;
 ; CHECK-NEXT:    st.param.v2.b16 [func_retval0], {%rs57, %rs49};
 ; CHECK-NEXT:    ret;
   %r = call <2 x bfloat> @llvm.convert.from.arbitrary.fp.v2bf16.v2i8(<2 x i8> %x, metadata !"Float8E5M2")

--- a/llvm/test/CodeGen/NVPTX/machine-cse-predicate-inversion-multiple-users.ll
+++ b/llvm/test/CodeGen/NVPTX/machine-cse-predicate-inversion-multiple-users.ll
@@ -6,29 +6,37 @@
 ;       can also be processed.
 target triple = "nvptx64-nvidia-cuda"
 
-define i32 @test_multiple_users(i32 %a, i32 %b) {
+define i32 @test_multiple_users(i32 %a, i32 %b, i32 %x, i32 %y) {
 ; CHECK-LABEL: test_multiple_users(
 ; CHECK:       {
 ; CHECK-NEXT:    .reg .pred %p<3>;
-; CHECK-NEXT:    .reg .b32 %r<6>;
+; CHECK-NEXT:    .reg .b32 %r<14>;
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0: // %entry
-; CHECK-NEXT:    ld.param::func.b32 %r3, [test_multiple_users_param_1];
-; CHECK-NEXT:    ld.param::func.b32 %r2, [test_multiple_users_param_0];
-; CHECK-NEXT:    setp.eq.b32 %p1, %r2, %r3;
-; CHECK-NEXT:    mov.b32 %r5, 0;
+; CHECK-NEXT:    ld.param::func.b32 %r8, [test_multiple_users_param_3];
+; CHECK-NEXT:    ld.param::func.b32 %r7, [test_multiple_users_param_2];
+; CHECK-NEXT:    ld.param::func.b32 %r6, [test_multiple_users_param_1];
+; CHECK-NEXT:    ld.param::func.b32 %r5, [test_multiple_users_param_0];
+; CHECK-NEXT:    setp.eq.b32 %p1, %r5, %r6;
+; CHECK-NEXT:    mov.b32 %r13, 0;
 ; CHECK-NEXT:    @%p1 bra $L__BB0_2;
 ; CHECK-NEXT:  // %bb.1: // %then
-; CHECK-NEXT:    mov.b32 %r5, 1;
+; CHECK-NEXT:    mov.b32 %r13, 1;
 ; CHECK-NEXT:  $L__BB0_2: // %merge1
-; CHECK-NEXT:    setp.ne.b32 %p2, %r2, %r3;
+; CHECK-NEXT:    setp.ne.b32 %p2, %r5, %r6;
 ; CHECK-NEXT:    selp.b32 %r1, 1, 0, %p2;
+; CHECK-NEXT:    selp.b32 %r2, %r7, %r8, %p2;
+; CHECK-NEXT:    selp.b32 %r3, %r7, 7, %p2;
+; CHECK-NEXT:    selp.b32 %r4, 9, %r8, %p2;
 ; CHECK-NEXT:    @%p2 bra $L__BB0_4;
 ; CHECK-NEXT:  // %bb.3: // %else
-; CHECK-NEXT:    mov.b32 %r5, 0;
+; CHECK-NEXT:    mov.b32 %r13, 0;
 ; CHECK-NEXT:  $L__BB0_4: // %merge2
-; CHECK-NEXT:    add.s32 %r4, %r5, %r1;
-; CHECK-NEXT:    st.param::func.b32 [func_retval0], %r4;
+; CHECK-NEXT:    add.s32 %r9, %r13, %r1;
+; CHECK-NEXT:    add.s32 %r10, %r9, %r2;
+; CHECK-NEXT:    add.s32 %r11, %r10, %r3;
+; CHECK-NEXT:    add.s32 %r12, %r11, %r4;
+; CHECK-NEXT:    st.param::func.b32 [func_retval0], %r12;
 ; CHECK-NEXT:    ret;
 entry:
   %cmp1 = icmp eq i32 %a, %b
@@ -41,6 +49,9 @@ merge1:
   %phi1 = phi i32 [ 1, %then ], [ 0, %entry ]
   %cmp2 = icmp ne i32 %a, %b
   %val = select i1 %cmp2, i32 1, i32 0
+  %rr = select i1 %cmp2, i32 %x, i32 %y
+  %ri = select i1 %cmp2, i32 %x, i32 7
+  %ir = select i1 %cmp2, i32 9, i32 %y
   br i1 %cmp2, label %merge2, label %else
 
 else:
@@ -48,6 +59,9 @@ else:
 
 merge2:
   %phi2 = phi i32 [ %phi1, %merge1 ], [ 0, %else ]
-  %ret = add i32 %phi2, %val
+  %sum0 = add i32 %phi2, %val
+  %sum1 = add i32 %sum0, %rr
+  %sum2 = add i32 %sum1, %ri
+  %ret = add i32 %sum2, %ir
   ret i32 %ret
 }

--- a/llvm/test/CodeGen/NVPTX/machine-cse-predicate-inversion-multiple-users.ll
+++ b/llvm/test/CodeGen/NVPTX/machine-cse-predicate-inversion-multiple-users.ll
@@ -2,14 +2,12 @@
 ; RUN: llc -mcpu=sm_100 < %s | FileCheck %s
 ; RUN: %if ptxas-sm_100 %{ llc < %s -mcpu=sm_100 | %ptxas-verify -arch=sm_100 %}
 
-; NOTE: Currently SETP inversions require all users to be CBranch. However other users like selects
-;       can also be processed.
 target triple = "nvptx64-nvidia-cuda"
 
 define i32 @test_multiple_users(i32 %a, i32 %b, i32 %x, i32 %y) {
 ; CHECK-LABEL: test_multiple_users(
 ; CHECK:       {
-; CHECK-NEXT:    .reg .pred %p<3>;
+; CHECK-NEXT:    .reg .pred %p<2>;
 ; CHECK-NEXT:    .reg .b32 %r<14>;
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0: // %entry
@@ -23,12 +21,11 @@ define i32 @test_multiple_users(i32 %a, i32 %b, i32 %x, i32 %y) {
 ; CHECK-NEXT:  // %bb.1: // %then
 ; CHECK-NEXT:    mov.b32 %r13, 1;
 ; CHECK-NEXT:  $L__BB0_2: // %merge1
-; CHECK-NEXT:    setp.ne.b32 %p2, %r5, %r6;
-; CHECK-NEXT:    selp.b32 %r1, 1, 0, %p2;
-; CHECK-NEXT:    selp.b32 %r2, %r7, %r8, %p2;
-; CHECK-NEXT:    selp.b32 %r3, %r7, 7, %p2;
-; CHECK-NEXT:    selp.b32 %r4, 9, %r8, %p2;
-; CHECK-NEXT:    @%p2 bra $L__BB0_4;
+; CHECK-NEXT:    selp.b32 %r1, 0, 1, %p1;
+; CHECK-NEXT:    selp.b32 %r2, %r8, %r7, %p1;
+; CHECK-NEXT:    selp.b32 %r3, 7, %r7, %p1;
+; CHECK-NEXT:    selp.b32 %r4, %r8, 9, %p1;
+; CHECK-NEXT:    @!%p1 bra $L__BB0_4;
 ; CHECK-NEXT:  // %bb.3: // %else
 ; CHECK-NEXT:    mov.b32 %r13, 0;
 ; CHECK-NEXT:  $L__BB0_4: // %merge2


### PR DESCRIPTION
Extend NVPTX SETP commuting to support predicates used by SELP instructions.

When commuting a SETP reverses its predicate, update each SELP user by swapping its true and false operands. This allows MachineCSE to elimiate redundant inverse comparisons whose predicates are used by both branches and selects.

Add regression coverage for register and immediate SELP operands. This also removes redundant predicates from the arbitrary floating-point conversion tests.
