### PR TITLE
[MLIR][DebugInfo] Add ArtificialLoc: a built-in location for compiler-generated instructions

### DIFF
--- a/mlir/include/mlir/IR/BuiltinLocationAttributes.td
+++ b/mlir/include/mlir/IR/BuiltinLocationAttributes.td
@@ -309,6 +309,42 @@ def OpaqueLoc : Builtin_LocationAttr<"OpaqueLoc"> {
 }
 
 //===----------------------------------------------------------------------===//
+// ArtificialLoc
+//===----------------------------------------------------------------------===//
+
+def ArtificialLoc : Builtin_LocationAttr<"ArtificialLoc"> {
+  let summary = "A location for compiler-generated instructions with no source correspondence";
+  let description = [{
+    Syntax:
+
+    ```
+    artificial-location ::= `artificial`
+    ```
+
+    Represents an instruction that is compiler-generated and cannot be
+    attributed to any position in the original source code.  The DWARF
+    specification allows the compiler to use the special line number 0 to
+    indicate code that cannot be attributed to any source location.  When
+    translated to LLVM IR this produces a `DILocation` with `line=0, column=0`
+    and the enclosing scope.  If no scope is available the instruction carries
+    no debug location.
+
+    `ArtificialLoc` expresses intentional absence of source attribution, in
+    contrast to `UnknownLoc` which expresses that the source location is
+    ambiguous or has not yet been determined.
+
+    Example:
+    ```mlir
+    loc(artificial)
+    ```
+  }];
+  let extraClassDeclaration = [{
+    static ArtificialLoc get(MLIRContext *context);
+  }];
+  let attrName = "builtin.artificial_loc";
+}
+
+//===----------------------------------------------------------------------===//
 // UnknownLoc
 //===----------------------------------------------------------------------===//
 

--- a/mlir/lib/AsmParser/LocationParser.cpp
+++ b/mlir/lib/AsmParser/LocationParser.cpp
@@ -226,6 +226,13 @@ ParseResult Parser::parseLocationInstance(LocationAttr &loc) {
   if (getToken().getSpelling() == "fused")
     return parseFusedLocation(loc);
 
+  // Check for 'artificial' - compiler-generated, no source correspondence.
+  if (getToken().getSpelling() == "artificial") {
+    consumeToken(Token::bare_identifier);
+    loc = ArtificialLoc::get(getContext());
+    return success();
+  }
+
   // Check for a 'unknown' for an unknown location.
   if (getToken().getSpelling() == "unknown") {
     consumeToken(Token::bare_identifier);

--- a/mlir/lib/IR/AsmPrinter.cpp
+++ b/mlir/lib/IR/AsmPrinter.cpp
@@ -2174,6 +2174,12 @@ void AsmPrinter::Impl::printLocationInternal(LocationAttr loc, bool pretty,
       .Case([&](OpaqueLoc loc) {
         printLocationInternal(loc.getFallbackLocation(), pretty);
       })
+      .Case([&](ArtificialLoc loc) {
+        if (pretty)
+          os << "[artificial]";
+        else
+          os << "artificial";
+      })
       .Case([&](UnknownLoc loc) {
         if (pretty)
           os << "[unknown]";

--- a/mlir/lib/IR/MLIRContext.cpp
+++ b/mlir/lib/IR/MLIRContext.cpp
@@ -253,6 +253,7 @@ public:
   /// Cached Attribute Instances.
   BoolAttr falseAttr, trueAttr;
   UnitAttr unitAttr;
+  ArtificialLoc artificialLocAttr;
   UnknownLoc unknownLocAttr;
   DictionaryAttr emptyDictionaryAttr;
   StringAttr emptyStringAttr;
@@ -335,6 +336,8 @@ MLIRContext::MLIRContext(const DialectRegistry &registry, Threading setting)
   //// Attributes.
   //// Note: These must be registered after the types as they may generate one
   //// of the above types internally.
+  /// Artificial Location Attribute (compiler-generated, DWARF line=0).
+  impl->artificialLocAttr = AttributeUniquer::get<ArtificialLoc>(this);
   /// Unknown Location Attribute.
   impl->unknownLocAttr = AttributeUniquer::get<UnknownLoc>(this);
   /// Bool Attributes.
@@ -1150,6 +1153,10 @@ BoolAttr BoolAttr::get(MLIRContext *context, bool value) {
 
 UnitAttr UnitAttr::get(MLIRContext *context) {
   return context->getImpl().unitAttr;
+}
+
+ArtificialLoc ArtificialLoc::get(MLIRContext *context) {
+  return context->getImpl().artificialLocAttr;
 }
 
 UnknownLoc UnknownLoc::get(MLIRContext *context) {

--- a/mlir/lib/Target/LLVMIR/DebugTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/DebugTranslation.cpp
@@ -602,6 +602,15 @@ llvm::DILocation *DebugTranslation::translateLoc(Location loc,
   if (isa<UnknownLoc>(loc))
     return nullptr;
 
+  // Compiler-generated instructions with no source position carry line number
+  // 0.
+  if (isa<ArtificialLoc>(loc)) {
+    if (!scope)
+      return nullptr;
+    return llvm::DILocation::get(llvmCtx, /*Line=*/0, /*Col=*/0, scope,
+                                 const_cast<llvm::DILocation *>(inlinedAt));
+  }
+
   // Check for a cached instance.
   auto existingIt = locationToLoc.find(std::make_tuple(loc, scope, inlinedAt));
   if (existingIt != locationToLoc.end())

--- a/mlir/test/IR/artificial-loc.mlir
+++ b/mlir/test/IR/artificial-loc.mlir
@@ -1,0 +1,20 @@
+// RUN: mlir-opt -allow-unregistered-dialect %s -mlir-print-debuginfo | FileCheck %s
+// RUN: mlir-opt -allow-unregistered-dialect %s -mlir-print-debuginfo | mlir-opt -allow-unregistered-dialect -mlir-print-debuginfo | FileCheck %s
+// Tests that ArtificialLoc round-trips correctly through the MLIR parser/printer.
+// Locations shared across multiple ops are printed as aliases; verify the alias
+// definition contains the expected keyword.
+
+// CHECK-DAG: = loc(artificial)
+// CHECK-DAG: = loc(unknown)
+
+func.func @artificial_loc_on_ops() -> i32 {
+  %0 = "test.op"() : () -> i32 loc(artificial)
+  return %0 : i32 loc(artificial)
+} loc(artificial)
+
+func.func @mix_with_unknown() {
+  // ArtificialLoc and UnknownLoc are distinct types.
+  "test.op"() : () -> () loc(artificial)
+  "test.op"() : () -> () loc(unknown)
+  return
+}

--- a/mlir/test/Target/LLVMIR/artificial-loc.mlir
+++ b/mlir/test/Target/LLVMIR/artificial-loc.mlir
@@ -1,0 +1,44 @@
+// RUN: mlir-translate -mlir-to-llvmir --split-input-file %s | FileCheck %s
+
+// Verify that ArtificialLoc translates to DILocation(line: 0, column: 0).
+// The DWARF specification allows the compiler to use the special line number 0
+// to indicate code that cannot be attributed to any source location.
+
+// When a valid scope is available, ArtificialLoc produces a DILocation with
+// line=0 attached to the instruction, preserving the enclosing scope.
+//
+// CHECK-LABEL: define void @func_artificial_in_debug_scope
+// CHECK-SAME:  !dbg ![[SP:[0-9]+]]
+// CHECK:       call void @callee(), !dbg ![[ARTLOC:[0-9]+]]
+// CHECK-DAG:   ![[ARTLOC]] = !DILocation(line: 0, scope: ![[SP]])
+
+#file = #llvm.di_file<"test.mlir" in "/test/">
+#cu = #llvm.di_compile_unit<
+  id = distinct[0]<>, sourceLanguage = DW_LANG_C, file = #file,
+  producer = "MLIR", isOptimized = false, emissionKind = Full>
+#spTy = #llvm.di_subroutine_type<callingConvention = DW_CC_normal>
+#sp = #llvm.di_subprogram<
+  id = distinct[1]<>, compileUnit = #cu, scope = #file,
+  name = "func_artificial_in_debug_scope", file = #file,
+  subprogramFlags = "Definition", type = #spTy>
+
+llvm.func @callee() {
+  llvm.return
+}
+
+llvm.func @func_artificial_in_debug_scope() {
+  llvm.call @callee() : () -> () loc(artificial)
+  llvm.return
+} loc(fused<#sp>["test.mlir":1:1])
+
+// -----
+
+// When no enclosing scope exists, ArtificialLoc produces no !dbg metadata,
+// consistent with the behaviour of loc(unknown).
+//
+// CHECK-LABEL: define void @func_artificial_no_scope()
+// CHECK-NOT:   !dbg
+
+llvm.func @func_artificial_no_scope() {
+  llvm.return loc(artificial)
+} loc(artificial)


### PR DESCRIPTION
This change adds the `ArtificialLoc` built-in MLIR location attribute for compiler-generated instructions. 

When translated to LLVM IR, it produces a `DILocation(line: 0, scope: <enclosing>)`. 
If no enclosing scope is available,  the instruction carries no debug metadata, mirroring `UnknownLoc`. 

Implementation follows the `UnknownLoc` implementation pattern throughout.

Co-authored with Claude code.