### PR TITLE
[clang] Fix crash on implicit conversion of a reference NTTP bound to a subobject

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -476,6 +476,10 @@ features cannot lower the translation-unit ABI level;
 - Fixed merging of lambdas across modules in the case where neither lambda is
   imported from an AST file. (#GH214560)
 
+- Fixed a crash when a non-type template parameter of reference type is bound
+  to a subobject and is used in a context that requires an implicit conversion.
+  (#GH215900)
+
 #### Bug Fixes to AST Handling
 
 - Fixed a non-deterministic ordering of unused local typedefs that made

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -12255,9 +12255,14 @@ static std::optional<IntRange> TryGetExprRange(ASTContext &C, const Expr *E,
     }
   }
 
-  if (const auto *OVE = dyn_cast<OpaqueValueExpr>(E))
-    return TryGetExprRange(C, OVE->getSourceExpr(), MaxWidth, InConstantContext,
-                           Approximate);
+  if (const auto *OVE = dyn_cast<OpaqueValueExpr>(E)) {
+    // The source expression is null for the OpaqueValueExpr that stands in for
+    // a non-type template argument of pointer or reference type; fall back to
+    // the range of the type in that case.
+    if (const Expr *SourceExpr = OVE->getSourceExpr())
+      return TryGetExprRange(C, SourceExpr, MaxWidth, InConstantContext,
+                             Approximate);
+  }
 
   if (const auto *BitField = E->getSourceBitField())
     return IntRange(BitField->getBitWidthValue(),

--- a/clang/test/SemaTemplate/temp_arg_nontype_cxx20.cpp
+++ b/clang/test/SemaTemplate/temp_arg_nontype_cxx20.cpp
@@ -386,3 +386,20 @@ void test() {
     g<X>();
 }
 }
+
+namespace GH215900 {
+// A non-type template parameter of reference type bound to a subobject is
+// represented as a ConstantExpr wrapping a source-less OpaqueValueExpr; the
+// implicit conversion checks used to crash when walking into it.
+struct S {
+  static bool arr[2];
+  bool b;
+};
+bool S::arr[2];
+S s;
+
+template <bool &Ref> int f() { return Ref; }
+template <bool &Ref> int g() { int n = 0; n += Ref; return n; }
+
+int test() { return f<S::arr[1]>() + g<S::arr[0]>() + f<s.b>(); }
+}


### PR DESCRIPTION
A non-type template parameter of pointer or reference type is substituted with
a `ConstantExpr` wrapping an `OpaqueValueExpr` that has no source expression,
see `BuildExpressionFromNonTypeTemplateArgumentValue()`.

When such a parameter appears where an implicit conversion happens,
`Sema::CheckImplicitConversion()` asks for the range of the expression, and
`TryGetExprRange()` recursed into `OpaqueValueExpr::getSourceExpr()` without
checking for null. The recursive call then dereferences null in
`Expr::IgnoreParens()`.

Reproducer (crashes with plain `-fsyntax-only`, no extra warning flags):

```c++
struct S { static bool arr[2]; };
bool S::arr[2];

template <bool &Ref> int f() { return Ref; }  // bool -> int conversion

int g() { return f<S::arr[1]>(); }
```

```
clang++: llvm/include/llvm/Support/Casting.h:656: decltype(auto) llvm::dyn_cast(From *)
  [To = clang::ParenExpr, From = clang::Expr]: Assertion `detail::isPresent(Val) &&
  "dyn_cast on a non-existent value"' failed.
...
2.      repro.cc:3:26: instantiating function definition 'f<arr[1]>'
...
11 clang++ clang::Expr::IgnoreParens() + 27
12 clang++
13 clang++
14 clang++ clang::Sema::CheckImplicitConversion(clang::Expr*, clang::QualType,
                                                clang::SourceLocation, bool*, bool) + 6782
...
```

Binding the parameter to the whole object (`f<some_bool>()`) is fine: the
argument is then a `TemplateArgument::Declaration` and gets a real
`DeclRefExpr`. Only the C++20 subobject form (array element or member) goes
through the source-less `OpaqueValueExpr`, and only conversions trigger it, so
`return Ref;` from a `bool` function or `if (Ref)` do not crash while
`return Ref;` from an `int` function or `n += Ref;` do.

The fix only recurses when there is a source expression -- the same null check
`CheckImplicitConversion()` already does for `OpaqueValueExpr` -- and otherwise
falls back to the range of the expression's type.

Found in Chromium: a scoped test helper is parameterized on a `bool&` bound to
an element of a static flag array, and instantiating its destructor crashed the
compiler on the try bots --
https://chromium-review.googlesource.com/c/chromium/src/+/8185556


The contents of this pull request were substantially written using pi (using gpt-sol and fable). I've reviewed to the best of my ability.
