### PR TITLE
[LLVMOffload] Fix LLVMOffloadKernel dylib dependency

### DIFF
--- a/offload/languages/kernel/CMakeLists.txt
+++ b/offload/languages/kernel/CMakeLists.txt
@@ -39,11 +39,14 @@ add_llvm_library(
   src/LanguageLaunch.cpp
   src/LanguageRegistration.cpp
   src/State.cpp
-
-  LINK_COMPONENTS
-  Support
-  Offload
   )
+
+if(LLVM_LINK_LLVM_DYLIB)
+  set(llvm_libs LLVM)
+else()
+  llvm_map_components_to_libnames(llvm_libs Support)
+endif()
+target_link_libraries(LLVMOffloadKernel PRIVATE ${llvm_libs} LLVMOffload)
 
 if(LLVM_HAVE_LINK_VERSION_SCRIPT)
   target_link_libraries(LLVMOffloadKernel PRIVATE "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/exports")


### PR DESCRIPTION
LLVMOffloadKernel was linking Offload through LINK_COMPONENTS, which does not preserve the required LLVMOffload target dependency in dylib builds. Match the other `offload/` libraries by selecting LLVM deps via `LLVM_LINK_LLVM_DYLIB`, then link LLVMOffload explicitly.
