### PR TITLE
[DebugInfo] Print the record in the salvage debug line

### DIFF
--- a/llvm/lib/Transforms/Utils/Local.cpp
+++ b/llvm/lib/Transforms/Utils/Local.cpp
@@ -2143,7 +2143,7 @@ void llvm::salvageDebugInfoForDbgValues(Instruction &I,
       // unreasonably large number of values.
       DVR->setKillLocation();
     }
-    LLVM_DEBUG(dbgs() << "SALVAGE: " << DVR << '\n');
+    LLVM_DEBUG(dbgs() << "SALVAGE: " << *DVR << '\n');
     Salvaged = true;
   }
 


### PR DESCRIPTION
The line takes the record pointer, so -debug prints an address rather than the record.

Changes -debug output only.