### PR TITLE
[Offload][Test] Fix tests by adding omp.h

### DIFF
--- a/offload/test/offloading/ompx_bare_ballot_sync.c
+++ b/offload/test/offloading/ompx_bare_ballot_sync.c
@@ -4,6 +4,7 @@
 // XFAIL: intelgpu
 
 #include <assert.h>
+#include <omp.h>
 #include <ompx.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/offload/test/offloading/ompx_bare_shfl_down_sync.cpp
+++ b/offload/test/offloading/ompx_bare_shfl_down_sync.cpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <limits>
+#include <omp.h>
 #include <ompx.h>
 #include <type_traits>
 


### PR DESCRIPTION
Fixed the offload tests after PR: https://github.com/llvm/llvm-project/pull/215841. 

```
Failed Tests (2):
  libomptarget :: amdgpu-amd-amdhsa :: offloading/ompx_bare_ballot_sync.c
  libomptarget :: amdgpu-amd-amdhsa :: offloading/ompx_bare_shfl_down_sync.cpp
```

https://lab.llvm.org/buildbot/#/builders/234/builds/2092