### PR TITLE
[SCEV] Avoid recursion in PHI handling in more cases.

### DIFF
--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -7853,9 +7853,10 @@ ScalarEvolution::getOperandsToCreate(Value *V, SmallVectorImpl<Value *> &Ops) {
           valuesForAddRecFromPHI(LI, cast<PHINode>(U));
       if (BEValueV && StartValueV) {
         Ops.push_back(StartValueV);
-        // FIXME: Find invariant values which feed into BEValueV. This search
-        // probably needs to be integrated into the top-level loop in
-        // createSCEVIter.
+        // FIXME: Handle values which feed into BEValueV. This probably needs
+        // to be integrated into the main loop of createSCEVIter. We could
+        // search for invariant values, or we could turn the whole
+        // createAddRecFromPHI algorithm into an iterative process.
       }
     }
     // In addition to getNodeForPHI, also construct nodes which might be needed

--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -5866,10 +5866,12 @@ const SCEV *ScalarEvolution::createSimpleAffineAddRec(PHINode *PN,
   return PHISCEV;
 }
 
-const SCEV *ScalarEvolution::createAddRecFromPHI(PHINode *PN) {
+// Compute the initial and backedge values for a PHI node in a loop header.
+static std::pair<Value *, Value *> valuesForAddRecFromPHI(LoopInfo &LI,
+                                                          PHINode *PN) {
   const Loop *L = LI.getLoopFor(PN->getParent());
   if (!L || L->getHeader() != PN->getParent())
-    return nullptr;
+    return {};
 
   // The loop may have multiple entrances or multiple exits; we can analyze
   // this phi as an addrec if it has a unique entry value and a unique
@@ -5891,11 +5893,16 @@ const SCEV *ScalarEvolution::createAddRecFromPHI(PHINode *PN) {
       break;
     }
   }
-  if (!BEValueV || !StartValueV)
-    return nullptr;
+  return {BEValueV, StartValueV};
+}
 
+const SCEV *ScalarEvolution::createAddRecFromPHI(PHINode *PN) {
   assert(ValueExprMap.find_as(PN) == ValueExprMap.end() &&
          "PHI node already processed?");
+
+  auto [BEValueV, StartValueV] = valuesForAddRecFromPHI(LI, PN);
+  if (!BEValueV || !StartValueV)
+    return nullptr;
 
   // First, try to find AddRec expression without creating a fictituos symbolic
   // value for PN.
@@ -5908,6 +5915,7 @@ const SCEV *ScalarEvolution::createAddRecFromPHI(PHINode *PN) {
 
   // Using this symbolic name for the PHI, analyze the value coming around
   // the back-edge.
+  const Loop *L = LI.getLoopFor(PN->getParent());
   const SCEV *BEValue = getSCEV(BEValueV);
 
   // NOTE: If BEValue is loop invariant, we know that the PHI node just
@@ -7814,7 +7822,6 @@ ScalarEvolution::getOperandsToCreate(Value *V, SmallVectorImpl<Value *> &Ops) {
              /*UseInstrInfo=*/true, /*CanUseUndef=*/false})) {
       assert(V);
       Ops.push_back(V);
-      return nullptr;
     }
     // The second is createNodeForPHIWithIdenticalOperands: this looks for
     // operands which all perform the same operation, but haven't been
@@ -7822,7 +7829,6 @@ ScalarEvolution::getOperandsToCreate(Value *V, SmallVectorImpl<Value *> &Ops) {
     if (BinaryOperator *BO = getCommonInstForPHI(cast<PHINode>(U))) {
       assert(BO);
       Ops.push_back(BO);
-      return nullptr;
     }
     // The third is createNodeFromSelectLikePHI; this takes a PHI which
     // is equivalent to a select, and analyzes it like a select.
@@ -7839,18 +7845,24 @@ ScalarEvolution::getOperandsToCreate(Value *V, SmallVectorImpl<Value *> &Ops) {
         Ops.push_back(Cond);
         Ops.push_back(LHS);
         Ops.push_back(RHS);
-        return nullptr;
       }
     }
-    // The fourth way is createAddRecFromPHI. It's complicated to handle here,
-    // so just construct it recursively.
-    //
+    // The fourth way is createAddRecFromPHI.
+    {
+      auto [BEValueV, StartValueV] =
+          valuesForAddRecFromPHI(LI, cast<PHINode>(U));
+      if (BEValueV && StartValueV) {
+        Ops.push_back(StartValueV);
+        // FIXME: Find invariant values which feed into BEValueV. This search
+        // probably needs to be integrated into the top-level loop in
+        // createSCEVIter.
+      }
+    }
     // In addition to getNodeForPHI, also construct nodes which might be needed
-    // by getRangeRef.
+    // by getRangeRef() on a SCEVUnknown for a PHI.
     if (RangeRefPHIAllowedOperands(DT, cast<PHINode>(U))) {
       for (Value *V : cast<PHINode>(U)->operands())
         Ops.push_back(V);
-      return nullptr;
     }
     return nullptr;
 


### PR DESCRIPTION
If a PHI is of the form that createAddRecFromPHI() accepts, make getOperandsToCreate() add the starting value to the worklist.

This isn't enough to make this fully non-recursive, but it helps a bit, and it makes the changes in
https://github.com/llvm/llvm-project/pull/215658 work in more cases.

While I'm here, also remove some early returns which didn't really make sense; there's some overlap between the different cases of PHIs, so make sure to add all operands which might be necessary.