### PR TITLE
[llvm-gsymutil] Suppress all error and warning messages when `--quiet`

### DIFF
--- a/llvm/include/llvm/DebugInfo/GSYM/GsymCreator.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/GsymCreator.h
@@ -20,6 +20,7 @@
 #include "llvm/ADT/StringSet.h"
 #include "llvm/DebugInfo/GSYM/FileEntry.h"
 #include "llvm/DebugInfo/GSYM/FunctionInfo.h"
+#include "llvm/DebugInfo/GSYM/OutputAggregator.h"
 #include "llvm/MC/StringTableBuilder.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/Error.h"
@@ -148,7 +149,7 @@ protected:
   std::optional<uint64_t> BaseAddress;
   bool IsSegment = false;
   bool Finalized = false;
-  bool Quiet;
+  QuietLevel Quiet;
 
 
   /// Get the first function start address.
@@ -314,10 +315,10 @@ protected:
   ///
   /// Used by createSegment() to create segment creators of the correct
   /// version type.
-  virtual std::unique_ptr<GsymCreator> createNew(bool Quiet) const = 0;
+  virtual std::unique_ptr<GsymCreator> createNew(QuietLevel Quiet) const = 0;
 
 public:
-  LLVM_ABI GsymCreator(bool Quiet = false);
+  LLVM_ABI GsymCreator(QuietLevel Quiet = QuietLevel::None);
   virtual ~GsymCreator() = default;
 
   /// Get the size in bytes needed for encoding string offsets.
@@ -493,8 +494,10 @@ public:
   }
 
   /// Whether the transformation should be quiet, i.e. not output warnings.
-  bool isQuiet() const { return Quiet; }
+  bool isQuiet() const { return Quiet >= QuietLevel::Quiet; }
 
+  /// How much of the diagnostic output the transformation should suppress.
+  QuietLevel getQuietLevel() const { return Quiet; }
 
   /// Create a segmented GSYM creator starting with function info index
   /// \a FuncIdx.

--- a/llvm/include/llvm/DebugInfo/GSYM/GsymCreator.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/GsymCreator.h
@@ -20,7 +20,6 @@
 #include "llvm/ADT/StringSet.h"
 #include "llvm/DebugInfo/GSYM/FileEntry.h"
 #include "llvm/DebugInfo/GSYM/FunctionInfo.h"
-#include "llvm/DebugInfo/GSYM/OutputAggregator.h"
 #include "llvm/MC/StringTableBuilder.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/Error.h"
@@ -149,8 +148,6 @@ protected:
   std::optional<uint64_t> BaseAddress;
   bool IsSegment = false;
   bool Finalized = false;
-  QuietLevel Quiet;
-
 
   /// Get the first function start address.
   ///
@@ -315,10 +312,10 @@ protected:
   ///
   /// Used by createSegment() to create segment creators of the correct
   /// version type.
-  virtual std::unique_ptr<GsymCreator> createNew(QuietLevel Quiet) const = 0;
+  virtual std::unique_ptr<GsymCreator> createNew() const = 0;
 
 public:
-  LLVM_ABI GsymCreator(QuietLevel Quiet = QuietLevel::None);
+  LLVM_ABI GsymCreator();
   virtual ~GsymCreator() = default;
 
   /// Get the size in bytes needed for encoding string offsets.
@@ -492,12 +489,6 @@ public:
   void setBaseAddress(uint64_t Addr) {
     BaseAddress = Addr;
   }
-
-  /// Whether the transformation should be quiet, i.e. not output warnings.
-  bool isQuiet() const { return Quiet >= QuietLevel::Quiet; }
-
-  /// How much of the diagnostic output the transformation should suppress.
-  QuietLevel getQuietLevel() const { return Quiet; }
 
   /// Create a segmented GSYM creator starting with function info index
   /// \a FuncIdx.

--- a/llvm/include/llvm/DebugInfo/GSYM/GsymCreatorV1.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/GsymCreatorV1.h
@@ -17,12 +17,12 @@ namespace gsym {
 
 class LLVM_ABI GsymCreatorV1 : public GsymCreator {
   uint64_t calculateHeaderAndTableSize() const override;
-  std::unique_ptr<GsymCreator> createNew(bool Quiet) const override {
+  std::unique_ptr<GsymCreator> createNew(QuietLevel Quiet) const override {
     return std::make_unique<GsymCreatorV1>(Quiet);
   }
 
 public:
-  GsymCreatorV1(bool Quiet = false) : GsymCreator(Quiet) {}
+  GsymCreatorV1(QuietLevel Quiet = QuietLevel::None) : GsymCreator(Quiet) {}
 
   uint8_t getStringOffsetSize() const override {
     return Header::getStringOffsetSize();

--- a/llvm/include/llvm/DebugInfo/GSYM/GsymCreatorV1.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/GsymCreatorV1.h
@@ -17,13 +17,11 @@ namespace gsym {
 
 class LLVM_ABI GsymCreatorV1 : public GsymCreator {
   uint64_t calculateHeaderAndTableSize() const override;
-  std::unique_ptr<GsymCreator> createNew(QuietLevel Quiet) const override {
-    return std::make_unique<GsymCreatorV1>(Quiet);
+  std::unique_ptr<GsymCreator> createNew() const override {
+    return std::make_unique<GsymCreatorV1>();
   }
 
 public:
-  GsymCreatorV1(QuietLevel Quiet = QuietLevel::None) : GsymCreator(Quiet) {}
-
   uint8_t getStringOffsetSize() const override {
     return Header::getStringOffsetSize();
   }

--- a/llvm/include/llvm/DebugInfo/GSYM/GsymCreatorV2.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/GsymCreatorV2.h
@@ -18,12 +18,12 @@ namespace gsym {
 /// GsymCreatorV2 emits GSYM V2 data with a GlobalData-based section layout.
 class LLVM_ABI GsymCreatorV2 : public GsymCreator {
   uint64_t calculateHeaderAndTableSize() const override;
-  std::unique_ptr<GsymCreator> createNew(bool Quiet) const override {
+  std::unique_ptr<GsymCreator> createNew(QuietLevel Quiet) const override {
     return std::make_unique<GsymCreatorV2>(Quiet);
   }
 
 public:
-  GsymCreatorV2(bool Quiet = false) : GsymCreator(Quiet) {}
+  GsymCreatorV2(QuietLevel Quiet = QuietLevel::None) : GsymCreator(Quiet) {}
 
   uint8_t getStringOffsetSize() const override {
     return HeaderV2::getStringOffsetSize();

--- a/llvm/include/llvm/DebugInfo/GSYM/GsymCreatorV2.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/GsymCreatorV2.h
@@ -18,13 +18,11 @@ namespace gsym {
 /// GsymCreatorV2 emits GSYM V2 data with a GlobalData-based section layout.
 class LLVM_ABI GsymCreatorV2 : public GsymCreator {
   uint64_t calculateHeaderAndTableSize() const override;
-  std::unique_ptr<GsymCreator> createNew(QuietLevel Quiet) const override {
-    return std::make_unique<GsymCreatorV2>(Quiet);
+  std::unique_ptr<GsymCreator> createNew() const override {
+    return std::make_unique<GsymCreatorV2>();
   }
 
 public:
-  GsymCreatorV2(QuietLevel Quiet = QuietLevel::None) : GsymCreator(Quiet) {}
-
   uint8_t getStringOffsetSize() const override {
     return HeaderV2::getStringOffsetSize();
   }

--- a/llvm/include/llvm/DebugInfo/GSYM/OutputAggregator.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/OutputAggregator.h
@@ -21,48 +21,28 @@ class raw_ostream;
 
 namespace gsym {
 
-// How much of the debug information diagnostic output to suppress. Each level
-// suppresses everything the previous one does, so these are ordered and are
-// meant to be compared with >=.
-enum class QuietLevel : uint8_t {
-  None = 0, // Emit warnings and errors.
-  Quiet,    // Emit errors only.
-  Quieter,  // Emit neither warnings nor errors.
-};
-
-// The severity of a diagnostic handed to OutputAggregator::Report().
-enum class Severity : uint8_t { Warning, Error };
-
 class OutputAggregator {
 protected:
   // A std::map is preferable over an llvm::StringMap for presenting results
   // in a predictable order.
   std::map<std::string, unsigned> Aggregation;
   raw_ostream *Out;
-  // Diagnostics silenced by this level are still counted, so the aggregated
-  // totals are the same no matter how quiet we are; only the detail messages
-  // and anything written through operator<< are affected.
-  QuietLevel Quiet;
+  // Whether to suppress printing the detail messages passed to Report().
+  // Anything written through operator<< is unaffected, as is the aggregated
+  // summary.
+  bool Quiet;
 
 public:
-  OutputAggregator(raw_ostream *out, QuietLevel Quiet = QuietLevel::None)
+  OutputAggregator(raw_ostream *out, bool Quiet = false)
       : Out(out), Quiet(Quiet) {}
 
   size_t GetNumCategories() const { return Aggregation.size(); }
 
-  QuietLevel GetQuietLevel() const { return Quiet; }
+  bool IsQuiet() const { return Quiet; }
 
-  // Returns true if the detail message for a diagnostic of this severity
-  // should be silenced.
-  bool IsSuppressed(Severity Sev) const {
-    return Sev == Severity::Error ? Quiet >= QuietLevel::Quieter
-                                  : Quiet >= QuietLevel::Quiet;
-  }
-
-  void Report(StringRef s, Severity Sev,
-              std::function<void(raw_ostream &o)> detailCallback) {
+  void Report(StringRef s, std::function<void(raw_ostream &o)> detailCallback) {
     Aggregation[std::string(s)]++;
-    if (GetOS() && !IsSuppressed(Sev))
+    if (GetOS() && !Quiet)
       detailCallback(*Out);
   }
 

--- a/llvm/include/llvm/DebugInfo/GSYM/OutputAggregator.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/OutputAggregator.h
@@ -21,21 +21,48 @@ class raw_ostream;
 
 namespace gsym {
 
+// How much of the debug information diagnostic output to suppress. Each level
+// suppresses everything the previous one does, so these are ordered and are
+// meant to be compared with >=.
+enum class QuietLevel : uint8_t {
+  None = 0, // Emit warnings and errors.
+  Quiet,    // Emit errors only.
+  Quieter,  // Emit neither warnings nor errors.
+};
+
+// The severity of a diagnostic handed to OutputAggregator::Report().
+enum class Severity : uint8_t { Warning, Error };
+
 class OutputAggregator {
 protected:
   // A std::map is preferable over an llvm::StringMap for presenting results
   // in a predictable order.
   std::map<std::string, unsigned> Aggregation;
   raw_ostream *Out;
+  // Diagnostics silenced by this level are still counted, so the aggregated
+  // totals are the same no matter how quiet we are; only the detail messages
+  // and anything written through operator<< are affected.
+  QuietLevel Quiet;
 
 public:
-  OutputAggregator(raw_ostream *out) : Out(out) {}
+  OutputAggregator(raw_ostream *out, QuietLevel Quiet = QuietLevel::None)
+      : Out(out), Quiet(Quiet) {}
 
   size_t GetNumCategories() const { return Aggregation.size(); }
 
-  void Report(StringRef s, std::function<void(raw_ostream &o)> detailCallback) {
+  QuietLevel GetQuietLevel() const { return Quiet; }
+
+  // Returns true if the detail message for a diagnostic of this severity
+  // should be silenced.
+  bool IsSuppressed(Severity Sev) const {
+    return Sev == Severity::Error ? Quiet >= QuietLevel::Quieter
+                                  : Quiet >= QuietLevel::Quiet;
+  }
+
+  void Report(StringRef s, Severity Sev,
+              std::function<void(raw_ostream &o)> detailCallback) {
     Aggregation[std::string(s)]++;
-    if (GetOS())
+    if (GetOS() && !IsSuppressed(Sev))
       detailCallback(*Out);
   }
 

--- a/llvm/lib/DebugInfo/GSYM/DwarfTransformer.cpp
+++ b/llvm/lib/DebugInfo/GSYM/DwarfTransformer.cpp
@@ -251,7 +251,7 @@ static void parseInlineInfo(GsymCreator &Gsym, OutputAggregator &Out,
               WarnIfEmpty = false;
             } else
               Out.Report("Function DIE has uncontained address range",
-                         Severity::Error, [&](raw_ostream &OS) {
+                         [&](raw_ostream &OS) {
                            OS << "error: inlined function DIE at "
                               << HEX32(Die.getOffset()) << " has a range ["
                               << HEX64(InlineRange.start()) << " - "
@@ -290,7 +290,7 @@ static void parseInlineInfo(GsymCreator &Gsym, OutputAggregator &Out,
     } else
       Out.Report(
           "Inlined function die has invlaid file index in DW_AT_call_file",
-          Severity::Error, [&](raw_ostream &OS) {
+          [&](raw_ostream &OS) {
             OS << "error: inlined function DIE at " << HEX32(Die.getOffset())
                << " has an invalid file index " << DwarfFileIdx
                << " in its DW_AT_call_file attribute, this inline entry and "
@@ -340,7 +340,7 @@ static void convertFunctionLineTable(OutputAggregator &Out, CUInfo &CUI,
     // was invalid, but we still have valid line entries.
     if (StmtSeqOffset &&
         CUI.LineTable->lookupAddressRange(SecAddress, RangeSize, RowVector)) {
-      Out.Report("Invalid DW_AT_LLVM_stmt_sequence value", Severity::Error,
+      Out.Report("Invalid DW_AT_LLVM_stmt_sequence value",
                  [&](raw_ostream &OS) {
                    OS << "error: function DIE at " << HEX32(Die.getOffset())
                       << " has a DW_AT_LLVM_stmt_sequence value "
@@ -363,16 +363,14 @@ static void convertFunctionLineTable(OutputAggregator &Out, CUInfo &CUI,
         // error if it isn't there.
         if (DwarfFileIdx == UINT32_MAX)
           return;
-        Out.Report(
-            "Invalid file index in DW_AT_decl_file", Severity::Error,
-            [&](raw_ostream &OS) {
-              OS << "error: function DIE at " << HEX32(Die.getOffset())
-                 << " has an invalid file index " << DwarfFileIdx
-                 << " in its DW_AT_decl_file attribute, unable to create a "
-                    "single "
-                 << "line entry from the DW_AT_decl_file/DW_AT_decl_line "
-                 << "attributes.\n";
-            });
+        Out.Report("Invalid file index in DW_AT_decl_file", [&](raw_ostream
+                                                                    &OS) {
+          OS << "error: function DIE at " << HEX32(Die.getOffset())
+             << " has an invalid file index " << DwarfFileIdx
+             << " in its DW_AT_decl_file attribute, unable to create a single "
+             << "line entry from the DW_AT_decl_file/DW_AT_decl_line "
+             << "attributes.\n";
+        });
         return;
       }
       if (auto Line = dwarf::toUnsigned(
@@ -394,8 +392,7 @@ static void convertFunctionLineTable(OutputAggregator &Out, CUInfo &CUI,
         CUI.DWARFToGSYMFileIndex(Gsym, Row.File);
     if (!OptFileIdx) {
       Out.Report(
-          "Invalid file index in DWARF line table", Severity::Error,
-          [&](raw_ostream &OS) {
+          "Invalid file index in DWARF line table", [&](raw_ostream &OS) {
             OS << "error: function DIE at " << HEX32(Die.getOffset()) << " has "
                << "a line entry with invalid DWARF file index, this entry will "
                << "be removed:\n";
@@ -416,7 +413,7 @@ static void convertFunctionLineTable(OutputAggregator &Out, CUInfo &CUI,
     if (!FI.Range.contains(RowAddress)) {
       if (RowAddress < FI.Range.start()) {
         Out.Report("Start address lies between valid Row table entries",
-                   Severity::Error, [&](raw_ostream &OS) {
+                   [&](raw_ostream &OS) {
                      OS << "error: DIE has a start address whose LowPC is "
                            "between the "
                            "line table Row["
@@ -440,13 +437,12 @@ static void convertFunctionLineTable(OutputAggregator &Out, CUInfo &CUI,
       // so break out after printing a warning.
       auto FirstLE = FI.OptLineTable->first();
       if (FirstLE && *FirstLE == LE)
-        Out.Report("Duplicate line table detected", Severity::Warning,
-                   [&](raw_ostream &OS) {
-                     OS << "warning: duplicate line table detected for DIE:\n";
-                     Die.dump(OS, 0, DIDumpOptions::getForSingleDIE());
-                   });
+        Out.Report("Duplicate line table detected", [&](raw_ostream &OS) {
+          OS << "warning: duplicate line table detected for DIE:\n";
+          Die.dump(OS, 0, DIDumpOptions::getForSingleDIE());
+        });
       else
-        Out.Report("Non-monotonically increasing addresses", Severity::Error,
+        Out.Report("Non-monotonically increasing addresses",
                    [&](raw_ostream &OS) {
                      OS << "error: line table has addresses that do not "
                         << "monotonically increase:\n";
@@ -495,7 +491,7 @@ void DwarfTransformer::handleDie(OutputAggregator &Out, CUInfo &CUI,
       break;
     auto NameIndex = getQualifiedNameIndex(Die, CUI.Language, Gsym);
     if (!NameIndex) {
-      Out.Report("Function has no name", Severity::Error, [&](raw_ostream &OS) {
+      Out.Report("Function has no name", [&](raw_ostream &OS) {
         OS << "error: function at " << HEX64(Die.getOffset())
            << " has no name\n ";
         Die.dump(OS, 0, DIDumpOptions::getForSingleDIE());
@@ -535,7 +531,7 @@ void DwarfTransformer::handleDie(OutputAggregator &Out, CUInfo &CUI,
         if (Range.LowPC != 0) {
           // Unexpected invalid address, emit a warning
           Out.Report("Address range starts outside executable section",
-                     Severity::Warning, [&](raw_ostream &OS) {
+                     [&](raw_ostream &OS) {
                        OS << "warning: DIE has an address range whose "
                              "start address "
                              "is not in any executable sections ("
@@ -572,7 +568,7 @@ void DwarfTransformer::handleDie(OutputAggregator &Out, CUInfo &CUI,
         if (FI.Inline->Children.empty()) {
           if (WarnIfEmpty)
             Out.Report("DIE contains inline functions with no valid ranges",
-                       Severity::Warning, [&](raw_ostream &OS) {
+                       [&](raw_ostream &OS) {
                          OS << "warning: DIE contains inline function "
                                "information that has no valid ranges, removing "
                                "inline information:\n";
@@ -664,7 +660,7 @@ Error DwarfTransformer::convert(uint32_t NumThreads, OutputAggregator &Out) {
         Out.Report(
             "warning: Unable to retrieve DWO .debug_info section for some "
             "object files. (Remove the --quiet flag for full output)",
-            Severity::Warning, [&](raw_ostream &OS) {
+            [&](raw_ostream &OS) {
               std::string DWOName = dwarf::toString(
                   DwarfUnit.getUnitDIE().find(
                       {dwarf::DW_AT_dwo_name, dwarf::DW_AT_GNU_dwo_name}),
@@ -714,7 +710,7 @@ Error DwarfTransformer::convert(uint32_t NumThreads, OutputAggregator &Out) {
           std::string storage;
           raw_string_ostream StrStream(storage);
           OutputAggregator ThreadOut(Out.GetOS() ? &StrStream : nullptr,
-                                     Out.GetQuietLevel());
+                                     Out.IsQuiet());
           handleDie(ThreadOut, CUI, Die);
           // Print ThreadLogStorage lines into an actual stream under a lock
           std::lock_guard<std::mutex> guard(LogMutex);

--- a/llvm/lib/DebugInfo/GSYM/DwarfTransformer.cpp
+++ b/llvm/lib/DebugInfo/GSYM/DwarfTransformer.cpp
@@ -440,7 +440,6 @@ static void convertFunctionLineTable(OutputAggregator &Out, CUInfo &CUI,
       // so break out after printing a warning.
       auto FirstLE = FI.OptLineTable->first();
       if (FirstLE && *FirstLE == LE)
-        // if (Log && !Gsym.isQuiet()) { TODO <-- This looks weird
         Out.Report("Duplicate line table detected", Severity::Warning,
                    [&](raw_ostream &OS) {
                      OS << "warning: duplicate line table detected for DIE:\n";

--- a/llvm/lib/DebugInfo/GSYM/DwarfTransformer.cpp
+++ b/llvm/lib/DebugInfo/GSYM/DwarfTransformer.cpp
@@ -251,7 +251,7 @@ static void parseInlineInfo(GsymCreator &Gsym, OutputAggregator &Out,
               WarnIfEmpty = false;
             } else
               Out.Report("Function DIE has uncontained address range",
-                         [&](raw_ostream &OS) {
+                         Severity::Error, [&](raw_ostream &OS) {
                            OS << "error: inlined function DIE at "
                               << HEX32(Die.getOffset()) << " has a range ["
                               << HEX64(InlineRange.start()) << " - "
@@ -290,7 +290,7 @@ static void parseInlineInfo(GsymCreator &Gsym, OutputAggregator &Out,
     } else
       Out.Report(
           "Inlined function die has invlaid file index in DW_AT_call_file",
-          [&](raw_ostream &OS) {
+          Severity::Error, [&](raw_ostream &OS) {
             OS << "error: inlined function DIE at " << HEX32(Die.getOffset())
                << " has an invalid file index " << DwarfFileIdx
                << " in its DW_AT_call_file attribute, this inline entry and "
@@ -340,7 +340,7 @@ static void convertFunctionLineTable(OutputAggregator &Out, CUInfo &CUI,
     // was invalid, but we still have valid line entries.
     if (StmtSeqOffset &&
         CUI.LineTable->lookupAddressRange(SecAddress, RangeSize, RowVector)) {
-      Out.Report("Invalid DW_AT_LLVM_stmt_sequence value",
+      Out.Report("Invalid DW_AT_LLVM_stmt_sequence value", Severity::Error,
                  [&](raw_ostream &OS) {
                    OS << "error: function DIE at " << HEX32(Die.getOffset())
                       << " has a DW_AT_LLVM_stmt_sequence value "
@@ -363,14 +363,16 @@ static void convertFunctionLineTable(OutputAggregator &Out, CUInfo &CUI,
         // error if it isn't there.
         if (DwarfFileIdx == UINT32_MAX)
           return;
-        Out.Report("Invalid file index in DW_AT_decl_file", [&](raw_ostream
-                                                                    &OS) {
-          OS << "error: function DIE at " << HEX32(Die.getOffset())
-             << " has an invalid file index " << DwarfFileIdx
-             << " in its DW_AT_decl_file attribute, unable to create a single "
-             << "line entry from the DW_AT_decl_file/DW_AT_decl_line "
-             << "attributes.\n";
-        });
+        Out.Report(
+            "Invalid file index in DW_AT_decl_file", Severity::Error,
+            [&](raw_ostream &OS) {
+              OS << "error: function DIE at " << HEX32(Die.getOffset())
+                 << " has an invalid file index " << DwarfFileIdx
+                 << " in its DW_AT_decl_file attribute, unable to create a "
+                    "single "
+                 << "line entry from the DW_AT_decl_file/DW_AT_decl_line "
+                 << "attributes.\n";
+            });
         return;
       }
       if (auto Line = dwarf::toUnsigned(
@@ -392,7 +394,8 @@ static void convertFunctionLineTable(OutputAggregator &Out, CUInfo &CUI,
         CUI.DWARFToGSYMFileIndex(Gsym, Row.File);
     if (!OptFileIdx) {
       Out.Report(
-          "Invalid file index in DWARF line table", [&](raw_ostream &OS) {
+          "Invalid file index in DWARF line table", Severity::Error,
+          [&](raw_ostream &OS) {
             OS << "error: function DIE at " << HEX32(Die.getOffset()) << " has "
                << "a line entry with invalid DWARF file index, this entry will "
                << "be removed:\n";
@@ -413,7 +416,7 @@ static void convertFunctionLineTable(OutputAggregator &Out, CUInfo &CUI,
     if (!FI.Range.contains(RowAddress)) {
       if (RowAddress < FI.Range.start()) {
         Out.Report("Start address lies between valid Row table entries",
-                   [&](raw_ostream &OS) {
+                   Severity::Error, [&](raw_ostream &OS) {
                      OS << "error: DIE has a start address whose LowPC is "
                            "between the "
                            "line table Row["
@@ -438,12 +441,13 @@ static void convertFunctionLineTable(OutputAggregator &Out, CUInfo &CUI,
       auto FirstLE = FI.OptLineTable->first();
       if (FirstLE && *FirstLE == LE)
         // if (Log && !Gsym.isQuiet()) { TODO <-- This looks weird
-        Out.Report("Duplicate line table detected", [&](raw_ostream &OS) {
-          OS << "warning: duplicate line table detected for DIE:\n";
-          Die.dump(OS, 0, DIDumpOptions::getForSingleDIE());
-        });
+        Out.Report("Duplicate line table detected", Severity::Warning,
+                   [&](raw_ostream &OS) {
+                     OS << "warning: duplicate line table detected for DIE:\n";
+                     Die.dump(OS, 0, DIDumpOptions::getForSingleDIE());
+                   });
       else
-        Out.Report("Non-monotonically increasing addresses",
+        Out.Report("Non-monotonically increasing addresses", Severity::Error,
                    [&](raw_ostream &OS) {
                      OS << "error: line table has addresses that do not "
                         << "monotonically increase:\n";
@@ -492,7 +496,7 @@ void DwarfTransformer::handleDie(OutputAggregator &Out, CUInfo &CUI,
       break;
     auto NameIndex = getQualifiedNameIndex(Die, CUI.Language, Gsym);
     if (!NameIndex) {
-      Out.Report("Function has no name", [&](raw_ostream &OS) {
+      Out.Report("Function has no name", Severity::Error, [&](raw_ostream &OS) {
         OS << "error: function at " << HEX64(Die.getOffset())
            << " has no name\n ";
         Die.dump(OS, 0, DIDumpOptions::getForSingleDIE());
@@ -530,18 +534,16 @@ void DwarfTransformer::handleDie(OutputAggregator &Out, CUInfo &CUI,
         // and the debug info wasn't able to be stripped from the DWARF. If
         // the LowPC isn't zero or -1, then we should emit an error.
         if (Range.LowPC != 0) {
-          if (!Gsym.isQuiet()) {
-            // Unexpected invalid address, emit a warning
-            Out.Report("Address range starts outside executable section",
-                       [&](raw_ostream &OS) {
-                         OS << "warning: DIE has an address range whose "
-                               "start address "
-                               "is not in any executable sections ("
-                            << *Gsym.GetValidTextRanges()
-                            << ") and will not be processed:\n";
-                         Die.dump(OS, 0, DIDumpOptions::getForSingleDIE());
-                       });
-          }
+          // Unexpected invalid address, emit a warning
+          Out.Report("Address range starts outside executable section",
+                     Severity::Warning, [&](raw_ostream &OS) {
+                       OS << "warning: DIE has an address range whose "
+                             "start address "
+                             "is not in any executable sections ("
+                          << *Gsym.GetValidTextRanges()
+                          << ") and will not be processed:\n";
+                       Die.dump(OS, 0, DIDumpOptions::getForSingleDIE());
+                     });
         }
         break;
       }
@@ -569,9 +571,9 @@ void DwarfTransformer::handleDie(OutputAggregator &Out, CUInfo &CUI,
         // information object, we will know if we got anything valid from the
         // debug info.
         if (FI.Inline->Children.empty()) {
-          if (WarnIfEmpty && !Gsym.isQuiet())
+          if (WarnIfEmpty)
             Out.Report("DIE contains inline functions with no valid ranges",
-                       [&](raw_ostream &OS) {
+                       Severity::Warning, [&](raw_ostream &OS) {
                          OS << "warning: DIE contains inline function "
                                "information that has no valid ranges, removing "
                                "inline information:\n";
@@ -663,7 +665,7 @@ Error DwarfTransformer::convert(uint32_t NumThreads, OutputAggregator &Out) {
         Out.Report(
             "warning: Unable to retrieve DWO .debug_info section for some "
             "object files. (Remove the --quiet flag for full output)",
-            [&](raw_ostream &OS) {
+            Severity::Warning, [&](raw_ostream &OS) {
               std::string DWOName = dwarf::toString(
                   DwarfUnit.getUnitDIE().find(
                       {dwarf::DW_AT_dwo_name, dwarf::DW_AT_GNU_dwo_name}),
@@ -712,7 +714,8 @@ Error DwarfTransformer::convert(uint32_t NumThreads, OutputAggregator &Out) {
         pool.async([this, CUI, &LogMutex, &Out, Die]() mutable {
           std::string storage;
           raw_string_ostream StrStream(storage);
-          OutputAggregator ThreadOut(Out.GetOS() ? &StrStream : nullptr);
+          OutputAggregator ThreadOut(Out.GetOS() ? &StrStream : nullptr,
+                                     Out.GetQuietLevel());
           handleDie(ThreadOut, CUI, Die);
           // Print ThreadLogStorage lines into an actual stream under a lock
           std::lock_guard<std::mutex> guard(LogMutex);

--- a/llvm/lib/DebugInfo/GSYM/GsymCreator.cpp
+++ b/llvm/lib/DebugInfo/GSYM/GsymCreator.cpp
@@ -228,7 +228,7 @@ llvm::Error GsymCreator::finalize(OutputAggregator &Out) {
               if (PrevRich)
                 Out.Report(
                     "Duplicate address ranges with different debug info.",
-                    Severity::Warning, [&](raw_ostream &OS) {
+                    [&](raw_ostream &OS) {
                       OS << "warning: same address range contains "
                             "different debug "
                          << "info. Removing:\n"
@@ -238,13 +238,12 @@ llvm::Error GsymCreator::finalize(OutputAggregator &Out) {
               std::swap(Prev, Curr);
             }
           } else {
-            Out.Report("Overlapping function ranges", Severity::Warning,
-                       [&](raw_ostream &OS) {
-                         // print warnings about overlaps
-                         OS << "warning: function ranges overlap:\n"
-                            << Prev << "\n"
-                            << Curr << "\n";
-                       });
+            Out.Report("Overlapping function ranges", [&](raw_ostream &OS) {
+              // print warnings about overlaps
+              OS << "warning: function ranges overlap:\n"
+                << Prev << "\n"
+                << Curr << "\n";
+            });
             FinalizedFuncs.emplace_back(std::move(Curr));
           }
         } else {

--- a/llvm/lib/DebugInfo/GSYM/GsymCreator.cpp
+++ b/llvm/lib/DebugInfo/GSYM/GsymCreator.cpp
@@ -50,7 +50,7 @@ static bool shouldReplaceWithMangledName(StringRef AlternateName,
   return AlternateName.contains(StringRef(LengthAndName));
 }
 
-GsymCreator::GsymCreator(bool Quiet)
+GsymCreator::GsymCreator(QuietLevel Quiet)
     : StrTab(StringTableBuilder::ELF), Quiet(Quiet) {
   insertFile(StringRef());
 }
@@ -229,7 +229,7 @@ llvm::Error GsymCreator::finalize(OutputAggregator &Out) {
               if (PrevRich)
                 Out.Report(
                     "Duplicate address ranges with different debug info.",
-                    [&](raw_ostream &OS) {
+                    Severity::Warning, [&](raw_ostream &OS) {
                       OS << "warning: same address range contains "
                             "different debug "
                          << "info. Removing:\n"
@@ -239,12 +239,13 @@ llvm::Error GsymCreator::finalize(OutputAggregator &Out) {
               std::swap(Prev, Curr);
             }
           } else {
-            Out.Report("Overlapping function ranges", [&](raw_ostream &OS) {
-              // print warnings about overlaps
-              OS << "warning: function ranges overlap:\n"
-                << Prev << "\n"
-                << Curr << "\n";
-            });
+            Out.Report("Overlapping function ranges", Severity::Warning,
+                       [&](raw_ostream &OS) {
+                         // print warnings about overlaps
+                         OS << "warning: function ranges overlap:\n"
+                            << Prev << "\n"
+                            << Curr << "\n";
+                       });
             FinalizedFuncs.emplace_back(std::move(Curr));
           }
         } else {
@@ -554,7 +555,7 @@ GsymCreator::createSegment(uint64_t SegmentSize, size_t &FuncIdx) const {
   if (FuncIdx >= Funcs.size())
     return std::unique_ptr<GsymCreator>();
 
-  std::unique_ptr<GsymCreator> GC = createNew(/*Quiet=*/true);
+  std::unique_ptr<GsymCreator> GC = createNew(QuietLevel::Quiet);
 
   // Tell the creator that this is a segment.
   GC->setIsSegment();

--- a/llvm/lib/DebugInfo/GSYM/GsymCreator.cpp
+++ b/llvm/lib/DebugInfo/GSYM/GsymCreator.cpp
@@ -50,8 +50,7 @@ static bool shouldReplaceWithMangledName(StringRef AlternateName,
   return AlternateName.contains(StringRef(LengthAndName));
 }
 
-GsymCreator::GsymCreator(QuietLevel Quiet)
-    : StrTab(StringTableBuilder::ELF), Quiet(Quiet) {
+GsymCreator::GsymCreator() : StrTab(StringTableBuilder::ELF) {
   insertFile(StringRef());
 }
 
@@ -555,7 +554,7 @@ GsymCreator::createSegment(uint64_t SegmentSize, size_t &FuncIdx) const {
   if (FuncIdx >= Funcs.size())
     return std::unique_ptr<GsymCreator>();
 
-  std::unique_ptr<GsymCreator> GC = createNew(QuietLevel::Quiet);
+  std::unique_ptr<GsymCreator> GC = createNew();
 
   // Tell the creator that this is a segment.
   GC->setIsSegment();

--- a/llvm/test/tools/llvm-gsymutil/X86/elf-dwo.yaml
+++ b/llvm/test/tools/llvm-gsymutil/X86/elf-dwo.yaml
@@ -5,8 +5,6 @@
 ## RUN: yaml2obj %s -o %t
 ## RUN: llvm-gsymutil --convert=%t -o %t.gsym | FileCheck %s --check-prefix=WARNING
 ## RUN: llvm-gsymutil --convert=%t -o %t.gsym --quiet | FileCheck %s --check-prefix=WARNING-QUIET --implicit-check-not=main_split-main.dwo
-## --quieter suppresses at least as much as --quiet does.
-## RUN: llvm-gsymutil --convert=%t -o %t.gsym --quieter | FileCheck %s --check-prefix=WARNING-QUIET --implicit-check-not=main_split-main.dwo
 
 ## WARNING: Input file: {{.*\.yaml\.tmp}}
 ## WARNING: Output file (x86_64): {{.*\.yaml\.tmp\.gsym}}

--- a/llvm/test/tools/llvm-gsymutil/X86/elf-dwo.yaml
+++ b/llvm/test/tools/llvm-gsymutil/X86/elf-dwo.yaml
@@ -4,7 +4,9 @@
 
 ## RUN: yaml2obj %s -o %t
 ## RUN: llvm-gsymutil --convert=%t -o %t.gsym | FileCheck %s --check-prefix=WARNING
-## RUN: llvm-gsymutil --convert=%t -o %t.gsym --quiet | FileCheck %s --check-prefix=WARNING-QUIET
+## RUN: llvm-gsymutil --convert=%t -o %t.gsym --quiet | FileCheck %s --check-prefix=WARNING-QUIET --implicit-check-not=main_split-main.dwo
+## --quieter suppresses at least as much as --quiet does.
+## RUN: llvm-gsymutil --convert=%t -o %t.gsym --quieter | FileCheck %s --check-prefix=WARNING-QUIET --implicit-check-not=main_split-main.dwo
 
 ## WARNING: Input file: {{.*\.yaml\.tmp}}
 ## WARNING: Output file (x86_64): {{.*\.yaml\.tmp\.gsym}}

--- a/llvm/test/tools/llvm-gsymutil/X86/elf-invalid-llvm-stmt-sequence.yaml
+++ b/llvm/test/tools/llvm-gsymutil/X86/elf-invalid-llvm-stmt-sequence.yaml
@@ -7,12 +7,9 @@
 # RUN: llvm-gsymutil --convert %t -o %t.gsym  2>&1 | FileCheck %s --check-prefix=CONVERT
 # RUN: llvm-gsymutil %t.gsym 2>&1 | FileCheck %s --check-prefix=DUMP
 
-## --quiet only silences warnings, so the error is still reported.
-# RUN: llvm-gsymutil --convert %t -o %t.gsym --quiet 2>&1 | FileCheck %s --check-prefix=CONVERT
-
-## --quieter silences the error text but still counts it, and leaves other
-## output alone.
-# RUN: llvm-gsymutil --convert %t -o %t.gsym --quieter 2>&1 | FileCheck %s --check-prefix=QUIETER
+## --quiet silences the error text but still counts it, and leaves the rest of
+## the output alone.
+# RUN: llvm-gsymutil --convert %t -o %t.gsym --quiet 2>&1 | FileCheck %s --check-prefix=QUIET
 
 # Make sure we get an error when parsing due to an invalid
 # DW_AT_LLVM_stmt_sequence.
@@ -20,10 +17,10 @@
 # CONVERT: Loaded 1 functions from DWARF.
 # CONVERT: Invalid DW_AT_LLVM_stmt_sequence value occurred 1 time(s)
 
-# QUIETER-NOT: error:
-# QUIETER: Loaded 1 functions from DWARF.
-# QUIETER: Invalid DW_AT_LLVM_stmt_sequence value occurred 1 time(s)
-# QUIETER-NOT: error:
+# QUIET-NOT: error:
+# QUIET: Loaded 1 functions from DWARF.
+# QUIET: Invalid DW_AT_LLVM_stmt_sequence value occurred 1 time(s)
+# QUIET-NOT: error:
 
 # Check that the line table got converted correctly for the function with
 # a valid DW_AT_LLVM_stmt_sequence.

--- a/llvm/test/tools/llvm-gsymutil/X86/elf-invalid-llvm-stmt-sequence.yaml
+++ b/llvm/test/tools/llvm-gsymutil/X86/elf-invalid-llvm-stmt-sequence.yaml
@@ -7,10 +7,23 @@
 # RUN: llvm-gsymutil --convert %t -o %t.gsym  2>&1 | FileCheck %s --check-prefix=CONVERT
 # RUN: llvm-gsymutil %t.gsym 2>&1 | FileCheck %s --check-prefix=DUMP
 
+## --quiet only silences warnings, so the error is still reported.
+# RUN: llvm-gsymutil --convert %t -o %t.gsym --quiet 2>&1 | FileCheck %s --check-prefix=CONVERT
+
+## --quieter silences the error text but still counts it, and leaves other
+## output alone.
+# RUN: llvm-gsymutil --convert %t -o %t.gsym --quieter 2>&1 | FileCheck %s --check-prefix=QUIETER
+
 # Make sure we get an error when parsing due to an invalid
 # DW_AT_LLVM_stmt_sequence.
 # CONVERT: error: function DIE at 0x00000015 has a DW_AT_LLVM_stmt_sequence value 0x0000002a which doesn't match any line table sequence offset but there are 2 matching line entries in other sequences.
 # CONVERT: Loaded 1 functions from DWARF.
+# CONVERT: Invalid DW_AT_LLVM_stmt_sequence value occurred 1 time(s)
+
+# QUIETER-NOT: error:
+# QUIETER: Loaded 1 functions from DWARF.
+# QUIETER: Invalid DW_AT_LLVM_stmt_sequence value occurred 1 time(s)
+# QUIETER-NOT: error:
 
 # Check that the line table got converted correctly for the function with
 # a valid DW_AT_LLVM_stmt_sequence.

--- a/llvm/test/tools/llvm-gsymutil/cmdline.test
+++ b/llvm/test/tools/llvm-gsymutil/cmdline.test
@@ -10,7 +10,6 @@ HELP: --convert=<value>
 HELP: --help
 HELP: --num-threads=<value>
 HELP: --out-file=<value>
-HELP: --quieter
 HELP: --quiet
 HELP: --symtab-file=<value>
 HELP: --verbose

--- a/llvm/test/tools/llvm-gsymutil/cmdline.test
+++ b/llvm/test/tools/llvm-gsymutil/cmdline.test
@@ -10,6 +10,7 @@ HELP: --convert=<value>
 HELP: --help
 HELP: --num-threads=<value>
 HELP: --out-file=<value>
+HELP: --quieter
 HELP: --quiet
 HELP: --symtab-file=<value>
 HELP: --verbose

--- a/llvm/tools/llvm-gsymutil/Opts.td
+++ b/llvm/tools/llvm-gsymutil/Opts.td
@@ -43,8 +43,7 @@ defm num_threads :
 defm segment_size :
   Eq<"segment-size",
      "Specify the size in bytes of the size the final GSYM file should be segmented into. This allows GSYM files to be split across multiple files">;
-def quiet : FF<"quiet", "Do not output warnings about the debug information">;
-def quieter : FF<"quieter", "Do not output warnings or errors about the debug information, but still print the aggregated counts. Implies --quiet">;
+def quiet : FF<"quiet", "Do not output warnings or errors about the debug information. The aggregated counts are still printed">;
 defm address : Eq<"address", "Lookup an address in a GSYM file">;
 def addresses_from_stdin :
   FF<"addresses-from-stdin",

--- a/llvm/tools/llvm-gsymutil/Opts.td
+++ b/llvm/tools/llvm-gsymutil/Opts.td
@@ -44,6 +44,7 @@ defm segment_size :
   Eq<"segment-size",
      "Specify the size in bytes of the size the final GSYM file should be segmented into. This allows GSYM files to be split across multiple files">;
 def quiet : FF<"quiet", "Do not output warnings about the debug information">;
+def quieter : FF<"quieter", "Do not output warnings or errors about the debug information, but still print the aggregated counts. Implies --quiet">;
 defm address : Eq<"address", "Lookup an address in a GSYM file">;
 def addresses_from_stdin :
   FF<"addresses-from-stdin",

--- a/llvm/tools/llvm-gsymutil/llvm-gsymutil.cpp
+++ b/llvm/tools/llvm-gsymutil/llvm-gsymutil.cpp
@@ -104,7 +104,7 @@ static uint32_t BenchmarkStart;
 static uint32_t BenchmarkStride;
 static unsigned NumThreads;
 static uint64_t SegmentSize;
-static QuietLevel Quiet = QuietLevel::None;
+static bool Quiet;
 static std::vector<uint64_t> LookupAddresses;
 static bool LookupAddressesFromStdin;
 static bool UseMergedFunctions = false;
@@ -216,12 +216,7 @@ static void parseArgs(int argc, char **argv) {
     }
   }
 
-  // --quieter is the next level up from --quiet: it silences the warnings
-  // that --quiet does, and the errors on top of that.
-  if (Args.hasArg(OPT_quieter))
-    Quiet = QuietLevel::Quieter;
-  else if (Args.hasArg(OPT_quiet))
-    Quiet = QuietLevel::Quiet;
+  Quiet = Args.hasArg(OPT_quiet);
 
   for (const llvm::opt::Arg *A : Args.filtered(OPT_address_EQ)) {
     StringRef S{A->getValue()};

--- a/llvm/tools/llvm-gsymutil/llvm-gsymutil.cpp
+++ b/llvm/tools/llvm-gsymutil/llvm-gsymutil.cpp
@@ -481,10 +481,10 @@ static llvm::Error handleObjectFile(ObjectFile &Obj, ObjectFile *SymtabObj,
   std::unique_ptr<GsymCreator> GsymPtr;
   switch (OutputVersion) {
   case Header::getVersion():
-    GsymPtr = std::make_unique<GsymCreatorV1>(Quiet);
+    GsymPtr = std::make_unique<GsymCreatorV1>();
     break;
   case HeaderV2::getVersion():
-    GsymPtr = std::make_unique<GsymCreatorV2>(Quiet);
+    GsymPtr = std::make_unique<GsymCreatorV2>();
     break;
   default:
     return createStringError(std::errc::invalid_argument,

--- a/llvm/tools/llvm-gsymutil/llvm-gsymutil.cpp
+++ b/llvm/tools/llvm-gsymutil/llvm-gsymutil.cpp
@@ -104,7 +104,7 @@ static uint32_t BenchmarkStart;
 static uint32_t BenchmarkStride;
 static unsigned NumThreads;
 static uint64_t SegmentSize;
-static bool Quiet;
+static QuietLevel Quiet = QuietLevel::None;
 static std::vector<uint64_t> LookupAddresses;
 static bool LookupAddressesFromStdin;
 static bool UseMergedFunctions = false;
@@ -216,7 +216,12 @@ static void parseArgs(int argc, char **argv) {
     }
   }
 
-  Quiet = Args.hasArg(OPT_quiet);
+  // --quieter is the next level up from --quiet: it silences the warnings
+  // that --quiet does, and the errors on top of that.
+  if (Args.hasArg(OPT_quieter))
+    Quiet = QuietLevel::Quieter;
+  else if (Args.hasArg(OPT_quiet))
+    Quiet = QuietLevel::Quiet;
 
   for (const llvm::opt::Arg *A : Args.filtered(OPT_address_EQ)) {
     StringRef S{A->getValue()};
@@ -824,7 +829,7 @@ int llvm_gsymutil_main(int argc, char **argv, const llvm::ToolContext &) {
     return EXIT_SUCCESS;
   }
 
-  OutputAggregator Aggregation(&OS);
+  OutputAggregator Aggregation(&OS, Quiet);
   if (!ConvertFilename.empty()) {
     // Convert DWARF to GSYM
     if (!InputFilenames.empty()) {


### PR DESCRIPTION
# Motivation

When converting a large iOS dSYM, it can sometimes emit too many errors and warnings. For example, one large dSYM produced 437,389 "error:" and 24,224 "warning:" lines. When these logs are unwanted, they make the output unreadable and consumes unnecessary disk/network resources. The current `--quiet` option only silences _some (not all)_ warnings, and _none_ of the errors. The intention for this option was to silence all of them.

This patch fixes the above, so that the `--quiet` option silences all error and warning messages.

# Implementation

Moved the `bool Quiet = false` ctor parameter from `GsymCreator` to `OutputAggregator`, which is the single funnel every diagnostic already flows through, so that the callsites of `OutputAggregator::Report()` will all be covered without having to specify `Quiet`.

A few places in `GsymCreator` which were not guarded by `IsQuiet()` previously are fixed automatically by the above.
