### PR TITLE
[DirectX] Set AdvancedTextureOps flag for basic sample ops with non-constant offset

### DIFF
--- a/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
+++ b/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
@@ -123,6 +123,41 @@ static bool checkDoubleExtensionOps(Intrinsic::ID IID) {
   }
 }
 
+/// Texture load and sample operations accept "programmable offsets", i.e.
+/// offsets that are not compile-time constants. Such offsets require the
+/// AdvancedTextureOps shader feature flag. Returns true if \p II is one of
+/// those operations and its offsets operand is not a constant.
+static bool checkAdvancedTextureOps(const IntrinsicInst &II) {
+  // TODO: (#116137) Several other DXIL ops also require this feature flag, but
+  // none of them can be generated yet:
+  //  - SampleCmp, SampleCmpBias, SampleCmpGrad and SampleCmpLevelZero set the
+  //    flag for non-constant offsets, exactly like the ops handled below.
+  //  - SampleCmpLevel, TextureGatherRaw and TextureStoreSample set the flag
+  //    unconditionally, and have no intrinsics yet.
+
+  // The offsets operand index differs between the intrinsics.
+  unsigned OffsetsIdx;
+  switch (II.getIntrinsicID()) {
+  default:
+    return false;
+  case Intrinsic::dx_resource_load_level:
+  case Intrinsic::dx_resource_sample:
+  case Intrinsic::dx_resource_sample_clamp:
+    OffsetsIdx = 3;
+    break;
+  case Intrinsic::dx_resource_samplebias:
+  case Intrinsic::dx_resource_samplebias_clamp:
+  case Intrinsic::dx_resource_samplelevel:
+    OffsetsIdx = 4;
+    break;
+  case Intrinsic::dx_resource_samplegrad:
+  case Intrinsic::dx_resource_samplegrad_clamp:
+    OffsetsIdx = 5;
+    break;
+  }
+  return !isa<Constant>(II.getArgOperand(OffsetsIdx));
+}
+
 static bool isOptimizationDisabled(const Module &M) {
   const StringRef Key = "dx.disable_optimizations";
   if (auto *Flag = mdconst::extract_or_null<ConstantInt>(M.getModuleFlag(Key)))
@@ -215,6 +250,8 @@ void ModuleShaderFlags::updateFunctionFlags(ComputedShaderFlags &CSF,
   }
 
   if (const auto *II = dyn_cast<IntrinsicInst>(&I)) {
+    CSF.AdvancedTextureOps |= checkAdvancedTextureOps(*II);
+
     switch (II->getIntrinsicID()) {
     default:
       break;

--- a/llvm/test/CodeGen/DirectX/ShaderFlags/advanced-texture-ops.ll
+++ b/llvm/test/CodeGen/DirectX/ShaderFlags/advanced-texture-ops.ll
@@ -1,0 +1,185 @@
+; RUN: opt -S --passes="print-dx-shader-flags" 2>&1 %s | FileCheck %s
+; RUN: llc %s --filetype=obj -o - | obj2yaml | FileCheck %s --check-prefix=CHECK-OBJ
+
+target triple = "dxil-pc-shadermodel6.7-library"
+
+; Texture load and sample operations with non-constant (programmable) offsets
+; require the AdvancedTextureOps shader feature flag.
+
+; CHECK-OBJ: - Name: SFI0
+; CHECK-OBJ:   Flags:
+; CHECK-OBJ:     AdvancedTextureOps: true
+
+; CHECK:      Combined Shader Flags for Module
+; CHECK-NEXT: Shader Flags Value: 0x400000000
+
+; CHECK: Note: shader requires additional functionality:
+; CHECK:       Advanced Texture Ops
+
+; CHECK: Function textureload_dynamic_offset : 0x400000000
+define void @textureload_dynamic_offset(<2 x i32> %coords, <2 x i32> %offsets) #0 {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding(i32 0, i32 0, i32 1, i32 0, ptr null)
+  %data = call <4 x float> @llvm.dx.resource.load.level(
+      target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture,
+      <2 x i32> %coords, i32 0, <2 x i32> %offsets)
+  ret void
+}
+
+; CHECK: Function textureload_const_offset : 0x00000000
+define void @textureload_const_offset(<2 x i32> %coords) #0 {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding(i32 0, i32 0, i32 1, i32 0, ptr null)
+  %data = call <4 x float> @llvm.dx.resource.load.level(
+      target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture,
+      <2 x i32> %coords, i32 0, <2 x i32> <i32 1, i32 -1>)
+  ret void
+}
+
+; CHECK: Function sample_dynamic_offset : 0x400000000
+define void @sample_dynamic_offset(<2 x float> %coords, <2 x i32> %offsets) #0 {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding(i32 0, i32 0, i32 1, i32 0, ptr null)
+  %sampler = call target("dx.Sampler", 0)
+      @llvm.dx.resource.handlefrombinding(i32 1, i32 0, i32 1, i32 0, ptr null)
+  %data = call <4 x float> @llvm.dx.resource.sample(
+      target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture,
+      target("dx.Sampler", 0) %sampler,
+      <2 x float> %coords, <2 x i32> %offsets)
+  ret void
+}
+
+; CHECK: Function sample_clamp_dynamic_offset : 0x400000000
+define void @sample_clamp_dynamic_offset(<2 x float> %coords, <2 x i32> %offsets,
+                                         float %clamp) #0 {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding(i32 0, i32 0, i32 1, i32 0, ptr null)
+  %sampler = call target("dx.Sampler", 0)
+      @llvm.dx.resource.handlefrombinding(i32 1, i32 0, i32 1, i32 0, ptr null)
+  %data = call <4 x float> @llvm.dx.resource.sample.clamp(
+      target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture,
+      target("dx.Sampler", 0) %sampler,
+      <2 x float> %coords, <2 x i32> %offsets, float %clamp)
+  ret void
+}
+
+; CHECK: Function sample_const_offset : 0x00000000
+define void @sample_const_offset(<2 x float> %coords) #0 {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding(i32 0, i32 0, i32 1, i32 0, ptr null)
+  %sampler = call target("dx.Sampler", 0)
+      @llvm.dx.resource.handlefrombinding(i32 1, i32 0, i32 1, i32 0, ptr null)
+  %data = call <4 x float> @llvm.dx.resource.sample(
+      target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture,
+      target("dx.Sampler", 0) %sampler,
+      <2 x float> %coords, <2 x i32> zeroinitializer)
+  ret void
+}
+
+; CHECK: Function samplebias_dynamic_offset : 0x400000000
+define void @samplebias_dynamic_offset(<2 x float> %coords, float %bias,
+                                       <2 x i32> %offsets) #0 {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding(i32 0, i32 0, i32 1, i32 0, ptr null)
+  %sampler = call target("dx.Sampler", 0)
+      @llvm.dx.resource.handlefrombinding(i32 1, i32 0, i32 1, i32 0, ptr null)
+  %data = call <4 x float> @llvm.dx.resource.samplebias(
+      target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture,
+      target("dx.Sampler", 0) %sampler,
+      <2 x float> %coords, float %bias, <2 x i32> %offsets)
+  ret void
+}
+
+; CHECK: Function samplebias_const_offset : 0x00000000
+define void @samplebias_const_offset(<2 x float> %coords, float %bias) #0 {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding(i32 0, i32 0, i32 1, i32 0, ptr null)
+  %sampler = call target("dx.Sampler", 0)
+      @llvm.dx.resource.handlefrombinding(i32 1, i32 0, i32 1, i32 0, ptr null)
+  %data = call <4 x float> @llvm.dx.resource.samplebias(
+      target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture,
+      target("dx.Sampler", 0) %sampler,
+      <2 x float> %coords, float %bias, <2 x i32> <i32 2, i32 3>)
+  ret void
+}
+
+; CHECK: Function samplelevel_dynamic_offset : 0x400000000
+define void @samplelevel_dynamic_offset(<2 x float> %coords, float %lod,
+                                        <2 x i32> %offsets) #0 {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding(i32 0, i32 0, i32 1, i32 0, ptr null)
+  %sampler = call target("dx.Sampler", 0)
+      @llvm.dx.resource.handlefrombinding(i32 1, i32 0, i32 1, i32 0, ptr null)
+  %data = call <4 x float> @llvm.dx.resource.samplelevel(
+      target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture,
+      target("dx.Sampler", 0) %sampler,
+      <2 x float> %coords, float %lod, <2 x i32> %offsets)
+  ret void
+}
+
+; CHECK: Function samplelevel_const_offset : 0x00000000
+define void @samplelevel_const_offset(<2 x float> %coords, float %lod) #0 {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding(i32 0, i32 0, i32 1, i32 0, ptr null)
+  %sampler = call target("dx.Sampler", 0)
+      @llvm.dx.resource.handlefrombinding(i32 1, i32 0, i32 1, i32 0, ptr null)
+  %data = call <4 x float> @llvm.dx.resource.samplelevel(
+      target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture,
+      target("dx.Sampler", 0) %sampler,
+      <2 x float> %coords, float %lod, <2 x i32> zeroinitializer)
+  ret void
+}
+
+; CHECK: Function samplegrad_dynamic_offset : 0x400000000
+define void @samplegrad_dynamic_offset(<2 x float> %coords, <2 x float> %ddx,
+                                       <2 x float> %ddy, <2 x i32> %offsets) #0 {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding(i32 0, i32 0, i32 1, i32 0, ptr null)
+  %sampler = call target("dx.Sampler", 0)
+      @llvm.dx.resource.handlefrombinding(i32 1, i32 0, i32 1, i32 0, ptr null)
+  %data = call <4 x float> @llvm.dx.resource.samplegrad(
+      target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture,
+      target("dx.Sampler", 0) %sampler,
+      <2 x float> %coords, <2 x float> %ddx, <2 x float> %ddy,
+      <2 x i32> %offsets)
+  ret void
+}
+
+; CHECK: Function samplegrad_clamp_dynamic_offset : 0x400000000
+define void @samplegrad_clamp_dynamic_offset(<2 x float> %coords,
+                                             <2 x float> %ddx, <2 x float> %ddy,
+                                             <2 x i32> %offsets,
+                                             float %clamp) #0 {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding(i32 0, i32 0, i32 1, i32 0, ptr null)
+  %sampler = call target("dx.Sampler", 0)
+      @llvm.dx.resource.handlefrombinding(i32 1, i32 0, i32 1, i32 0, ptr null)
+  %data = call <4 x float> @llvm.dx.resource.samplegrad.clamp(
+      target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture,
+      target("dx.Sampler", 0) %sampler,
+      <2 x float> %coords, <2 x float> %ddx, <2 x float> %ddy,
+      <2 x i32> %offsets, float %clamp)
+  ret void
+}
+
+; CHECK: Function samplegrad_const_offset : 0x00000000
+define void @samplegrad_const_offset(<2 x float> %coords, <2 x float> %ddx,
+                                     <2 x float> %ddy) #0 {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding(i32 0, i32 0, i32 1, i32 0, ptr null)
+  %sampler = call target("dx.Sampler", 0)
+      @llvm.dx.resource.handlefrombinding(i32 1, i32 0, i32 1, i32 0, ptr null)
+  %data = call <4 x float> @llvm.dx.resource.samplegrad(
+      target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture,
+      target("dx.Sampler", 0) %sampler,
+      <2 x float> %coords, <2 x float> %ddx, <2 x float> %ddy,
+      <2 x i32> <i32 -1, i32 1>)
+  ret void
+}
+
+!llvm.module.flags = !{!0}
+!dx.valver = !{!1}
+!0 = !{i32 1, !"dx.resmayalias", i32 1}
+!1 = !{i32 1, i32 8}
+
+attributes #0 = { convergent norecurse nounwind "hlsl.export"}


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/210462

This PR modifies `DXILShaderFlags.cpp` to set the `AdvancedTextureOps` shader flag true whenever any of

- `Intrinsic::dx_resource_load_level`
- `Intrinsic::dx_resource_sample`
- `Intrinsic::dx_resource_sample_clamp`
- `Intrinsic::dx_resource_samplebias`
- `Intrinsic::dx_resource_samplebias_clamp`
- `Intrinsic::dx_resource_samplelevel`
- `Intrinsic::dx_resource_samplegrad`
- `Intrinsic::dx_resource_samplegrad_clamp`
  
are used with a non-constant offset.

Assisted by: Claude Opus 5