### PR TITLE
[Objective-C][WebAssembly] Always emit nil-check for indirect calls

### DIFF
--- a/clang/lib/CodeGen/CGObjCGNU.cpp
+++ b/clang/lib/CodeGen/CGObjCGNU.cpp
@@ -2968,9 +2968,19 @@ CGObjCGNU::GenerateMessageSend(CodeGenFunction &CGF,
                                   Class, Receiver))
       return false;
 
+
     // If there's a consumed argument, we need a nil check.
     if (Method && Method->hasParamDestroyedInCallee()) {
       hasParamDestroyedInCallee = true;
+    }
+
+    // WebAssembly indirect calls require an exact function type match.
+    // Therfore, we cannot use libobjc2's nil-IMP stubs for WebAssembly
+    // and must always emit a null check and optionally zero the result.
+    if (CGM.getTriple().isWasm() && !isDirect) {
+      requiresExplicitZeroResult =
+          !Return.isUnused() && !ResultType->isVoidType();
+      return true;
     }
 
     // If the return value isn't flagged as unused, and the result

--- a/clang/lib/CodeGen/CGObjCGNU.cpp
+++ b/clang/lib/CodeGen/CGObjCGNU.cpp
@@ -2968,7 +2968,6 @@ CGObjCGNU::GenerateMessageSend(CodeGenFunction &CGF,
                                   Class, Receiver))
       return false;
 
-
     // If there's a consumed argument, we need a nil check.
     if (Method && Method->hasParamDestroyedInCallee()) {
       hasParamDestroyedInCallee = true;

--- a/clang/test/CodeGenObjC/gnustep2-wasm32-nil.m
+++ b/clang/test/CodeGenObjC/gnustep2-wasm32-nil.m
@@ -1,0 +1,44 @@
+// RUN: %clang_cc1 -triple wasm32-unknown-emscripten -emit-llvm -fobjc-runtime=gnustep-2.2 -o - %s | FileCheck %s
+
+
+typedef struct {
+  int x;
+  int y;
+  int z;
+} S;
+
+@interface Object
+- (int)value;
+- (S)s;
+@end
+
+// We expect generated nil-checks and zeroing of the result for WASM.
+
+int sendToPossiblyNil(Object *object) {
+  // CHECK-LABEL: define{{.*}} i32 @sendToPossiblyNil
+  // CHECK: icmp eq ptr %{{.*}}, null
+  // CHECK: br i1 %{{.*}}, label %[[CONTINUE:.*]], label %[[SEND:.*]]
+  // CHECK: [[SEND]]:
+  // CHECK: call ptr @objc_msg_lookup_sender
+  // CHECK: br label %[[CONTINUE]]
+  // CHECK: [[CONTINUE]]:
+  // CHECK: phi i32 [ %{{.*}}, %[[SEND]] ], [ 0, %{{.*}} ]
+  return [object value];
+}
+
+Triple sendStructToPossiblyNil(Object *object) {
+  // CHECK-LABEL: define{{.*}} void @sendStructToPossiblyNil
+  // CHECK: [[ISNIL:%.*]] = icmp eq ptr %{{.*}}, null
+  // CHECK: br i1 [[ISNIL]], label %[[NIL_CLEANUP:.*]], label %[[STRUCT_SEND:.*]]
+  // CHECK: [[STRUCT_SEND]]:
+  // CHECK: call ptr @objc_msg_lookup_sender
+  // CHECK: call void %{{.*}}(ptr{{.*}} sret(%struct.Triple){{.*}}
+  // CHECK: br label %[[STRUCT_CONTINUE:.*]]
+  // CHECK: [[NIL_CLEANUP]]:
+  // CHECK-NEXT: call void @llvm.memset.p0.i32(ptr align 4 %agg.result, i8 0, i32 12, i1 false)
+  // CHECK-NEXT: br label %[[STRUCT_CONTINUE]]
+  // CHECK: [[STRUCT_CONTINUE]]:
+  // CHECK: ret void
+  return [object s];
+}
+

--- a/clang/test/CodeGenObjC/gnustep2-wasm32-nil.m
+++ b/clang/test/CodeGenObjC/gnustep2-wasm32-nil.m
@@ -26,13 +26,13 @@ int sendToPossiblyNil(Object *object) {
   return [object value];
 }
 
-Triple sendStructToPossiblyNil(Object *object) {
+S sendStructToPossiblyNil(Object *object) {
   // CHECK-LABEL: define{{.*}} void @sendStructToPossiblyNil
   // CHECK: [[ISNIL:%.*]] = icmp eq ptr %{{.*}}, null
   // CHECK: br i1 [[ISNIL]], label %[[NIL_CLEANUP:.*]], label %[[STRUCT_SEND:.*]]
   // CHECK: [[STRUCT_SEND]]:
   // CHECK: call ptr @objc_msg_lookup_sender
-  // CHECK: call void %{{.*}}(ptr{{.*}} sret(%struct.Triple){{.*}}
+  // CHECK: call void %{{.*}}(ptr{{.*}} sret(%struct.S){{.*}}
   // CHECK: br label %[[STRUCT_CONTINUE:.*]]
   // CHECK: [[NIL_CLEANUP]]:
   // CHECK-NEXT: call void @llvm.memset.p0.i32(ptr align 4 %agg.result, i8 0, i32 12, i1 false)
@@ -41,4 +41,3 @@ Triple sendStructToPossiblyNil(Object *object) {
   // CHECK: ret void
   return [object s];
 }
-


### PR DESCRIPTION
We cannot use the nil-IMP stubs in libobjc2 because WebAssembly requires exact function signature matches for indirect calls. On native platforms such as x86 and arm this is fine, since the native calling conventions typically allow for additional arguments to be passed without issue. For WebAssembly, we may run into RuntimeErrors without this change.