### PR TITLE
[CIR] Add cir.cxx_module_init_fn_name and cir.static_local_info attributes

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -2012,6 +2012,52 @@ def CIR_ASTVarDeclAttr : CIR_AST<"VarDecl", "var.decl", [
 ]>;
 
 //===----------------------------------------------------------------------===//
+// StaticLocalInfoAttr
+//===----------------------------------------------------------------------===//
+
+def CIR_StaticLocalInfoAttr
+    : CIR_Attr<"StaticLocalInfo", "static_local_info",
+               [ASTVarDeclInterface]> {
+  let summary = "AST-free cache of static-local VarDecl facts.";
+  let description = [{
+    Materialized form of the facts `cir::ASTVarDeclInterface` exposes, so
+    that post-CIRGen passes (notably LoweringPrepare) can query them without
+    a live `clang::ASTContext`. Emitted by CIRGen for static-local guarded
+    globals in place of the AST-backed `ASTVarDeclAttr`.
+
+    The TLS and template-specialization kinds are encoded as plain integers
+    matching the underlying `clang::VarDecl::TLSKind` and
+    `clang::TemplateSpecializationKind` enumerators.
+  }];
+
+  let parameters = (ins
+    "bool":$is_local_var_decl,
+    "uint32_t":$tls,
+    "bool":$is_inline,
+    "uint32_t":$tsk
+  );
+
+  let assemblyFormat = [{
+    `<` struct($is_local_var_decl, $tls, $is_inline, $tsk) `>`
+  }];
+
+  let extraClassDeclaration = [{
+    // Satisfy ASTVarDeclInterface by reading cached fields instead of an
+    // AST-backed VarDecl pointer.
+    bool isLocalVarDecl() const { return getIsLocalVarDecl(); }
+    clang::VarDecl::TLSKind getTLSKind() const {
+      return static_cast<clang::VarDecl::TLSKind>(getTls());
+    }
+    bool isInline() const { return getIsInline(); }
+    clang::TemplateSpecializationKind getTemplateSpecializationKind() const {
+      return static_cast<clang::TemplateSpecializationKind>(getTsk());
+    }
+  }];
+
+  let canHaveIllegalCXXABIType = 0;
+}
+
+//===----------------------------------------------------------------------===//
 // AnnotationAttr
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -2016,18 +2016,29 @@ def CIR_ASTVarDeclAttr : CIR_AST<"VarDecl", "var.decl", [
 //===----------------------------------------------------------------------===//
 
 def CIR_StaticLocalInfoAttr
-    : CIR_Attr<"StaticLocalInfo", "static_local_info",
-               [ASTVarDeclInterface]> {
-  let summary = "AST-free cache of static-local VarDecl facts.";
+    : CIR_Attr<"StaticLocalInfo", "static_local_info"> {
+  let summary = "Static-local variable facts needed by later lowering";
   let description = [{
-    Materialized form of the facts `cir::ASTVarDeclInterface` exposes, so
-    that post-CIRGen passes (notably LoweringPrepare) can query them without
-    a live `clang::ASTContext`. Emitted by CIRGen for static-local guarded
-    globals in place of the AST-backed `ASTVarDeclAttr`.
+    Holds the subset of a static-local variable's declaration facts that
+    post-CIRGen lowering needs: whether it is a local variable declaration
+    (`is_local_var_decl`), its thread-local storage kind (`tls`), whether it
+    is inline (`is_inline`), and its template-specialization kind (`tsk`).
+    `tls` and `tsk` are stored as plain integers matching the
+    `clang::VarDecl::TLSKind` and `clang::TemplateSpecializationKind`
+    enumerators.
 
-    The TLS and template-specialization kinds are encoded as plain integers
-    matching the underlying `clang::VarDecl::TLSKind` and
-    `clang::TemplateSpecializationKind` enumerators.
+    Example:
+    ```
+    cir.global ... @x = ...
+      {static_local_info = #cir.static_local_info<
+         is_local_var_decl = true, tls = 0, is_inline = false, tsk = 0>}
+    ```
+
+    Because it stores plain data rather than a `clang::VarDecl` pointer, it
+    round-trips through textual CIR and stays valid once the AST is gone.
+    This is what lets LoweringPrepare consume these facts without a live
+    `clang::ASTContext`; the `$ast` `ASTVarDeclAttr` remains a separate,
+    live-AST handle for consumers that need arbitrary AST properties.
   }];
 
   let parameters = (ins
@@ -2042,13 +2053,10 @@ def CIR_StaticLocalInfoAttr
   }];
 
   let extraClassDeclaration = [{
-    // Satisfy ASTVarDeclInterface by reading cached fields instead of an
-    // AST-backed VarDecl pointer.
-    bool isLocalVarDecl() const { return getIsLocalVarDecl(); }
+    // Typed accessors over the stored integer fields.
     clang::VarDecl::TLSKind getTLSKind() const {
       return static_cast<clang::VarDecl::TLSKind>(getTls());
     }
-    bool isInline() const { return getIsInline(); }
     clang::TemplateSpecializationKind getTemplateSpecializationKind() const {
       return static_cast<clang::TemplateSpecializationKind>(getTsk());
     }

--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -2015,23 +2015,64 @@ def CIR_ASTVarDeclAttr : CIR_AST<"VarDecl", "var.decl", [
 // StaticLocalInfoAttr
 //===----------------------------------------------------------------------===//
 
+// CIR-native thread-local storage kind. Cases mirror clang::VarDecl::TLSKind
+// so CIRGen can map between them, but CIR does not depend on the underlying
+// clang enumerator values.
+def CIR_TLSKind : CIR_I32EnumAttr<"TLSKind", "thread-local storage kind", [
+  I32EnumAttrCase<"None", 0, "none">,          // clang::VarDecl::TLS_None
+  I32EnumAttrCase<"Static", 1, "static">,      // clang::VarDecl::TLS_Static
+  I32EnumAttrCase<"Dynamic", 2, "dynamic">     // clang::VarDecl::TLS_Dynamic
+]> {
+  let genSpecializedAttr = 0;
+}
+
+// CIR-native template-specialization kind. Cases mirror
+// clang::TemplateSpecializationKind.
+def CIR_TemplateSpecializationKind
+    : CIR_I32EnumAttr<"TemplateSpecializationKind",
+                      "template specialization kind", [
+  // clang::TSK_Undeclared
+  I32EnumAttrCase<"Undeclared", 0, "undeclared">,
+  // clang::TSK_ImplicitInstantiation
+  I32EnumAttrCase<"ImplicitInstantiation", 1, "implicit_instantiation">,
+  // clang::TSK_ExplicitSpecialization
+  I32EnumAttrCase<"ExplicitSpecialization", 2, "explicit_specialization">,
+  // clang::TSK_ExplicitInstantiationDeclaration
+  I32EnumAttrCase<"ExplicitInstantiationDeclaration", 3,
+                  "explicit_instantiation_declaration">,
+  // clang::TSK_ExplicitInstantiationDefinition
+  I32EnumAttrCase<"ExplicitInstantiationDefinition", 4,
+                  "explicit_instantiation_definition">
+]> {
+  let genSpecializedAttr = 0;
+}
+
 def CIR_StaticLocalInfoAttr
     : CIR_Attr<"StaticLocalInfo", "static_local_info"> {
   let summary = "Static-local variable facts needed by later lowering";
   let description = [{
     Holds the subset of a static-local variable's declaration facts that
-    post-CIRGen lowering needs: whether it is a local variable declaration
-    (`is_local_var_decl`), its thread-local storage kind (`tls`), whether it
-    is inline (`is_inline`), and its template-specialization kind (`tsk`).
-    `tls` and `tsk` are stored as plain integers matching the
-    `clang::VarDecl::TLSKind` and `clang::TemplateSpecializationKind`
-    enumerators.
+    post-CIRGen lowering needs, as plain data (no `clang::VarDecl` pointer).
+
+    - `local`: whether the variable is a block-scope (local) declaration.
+      Mirrors `clang::VarDecl::isLocalVarDecl()`. The namespace-scope inline
+      variables that also reach guarded initialization are not local.
+
+    - `tls`: the thread-local storage kind (`none`, `static`, or `dynamic`).
+
+    - `is_inline`: whether the variable is inline. Mirrors
+      `clang::VarDecl::isInline()`.
+
+    - `tsk`: the template-specialization kind (`undeclared`,
+      `implicit_instantiation`, `explicit_specialization`,
+      `explicit_instantiation_declaration`, or
+      `explicit_instantiation_definition`).
 
     Example:
     ```
     cir.global ... @x = ...
       {static_local_info = #cir.static_local_info<
-         is_local_var_decl = true, tls = 0, is_inline = false, tsk = 0>}
+         local = true, tls = none, is_inline = false, tsk = undeclared>}
     ```
 
     Because it stores plain data rather than a `clang::VarDecl` pointer, it
@@ -2042,24 +2083,14 @@ def CIR_StaticLocalInfoAttr
   }];
 
   let parameters = (ins
-    "bool":$is_local_var_decl,
-    "uint32_t":$tls,
+    "bool":$local,
+    EnumParameter<CIR_TLSKind>:$tls,
     "bool":$is_inline,
-    "uint32_t":$tsk
+    EnumParameter<CIR_TemplateSpecializationKind>:$tsk
   );
 
   let assemblyFormat = [{
-    `<` struct($is_local_var_decl, $tls, $is_inline, $tsk) `>`
-  }];
-
-  let extraClassDeclaration = [{
-    // Typed accessors over the stored integer fields.
-    clang::VarDecl::TLSKind getTLSKind() const {
-      return static_cast<clang::VarDecl::TLSKind>(getTls());
-    }
-    clang::TemplateSpecializationKind getTemplateSpecializationKind() const {
-      return static_cast<clang::TemplateSpecializationKind>(getTsk());
-    }
+    `<` struct($local, $tls, $is_inline, $tsk) `>`
   }];
 
   let canHaveIllegalCXXABIType = 0;

--- a/clang/include/clang/CIR/Dialect/IR/CIRDialect.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRDialect.td
@@ -81,6 +81,9 @@ def CIR_Dialect : Dialect {
     static llvm::StringRef getTuneCPUAttrName() { return "cir.tune-cpu"; }
     static llvm::StringRef getTargetFeaturesAttrName() { return "cir.target-features"; }
     static llvm::StringRef getCUDABinaryHandleAttrName() { return "cir.cu.binary_handle"; }
+    // Mangled symbol name of the C++20 named-module initializer function,
+    // precomputed by CIRGen so later passes don't need a live ASTContext.
+    static llvm::StringRef getCXXModuleInitFnNameAttrName() { return "cir.cxx_module_init_fn_name"; }
     static llvm::StringRef getMustTailAttrName() { return "musttail"; }
     static llvm::StringRef getCatchCopyThunkAttrName() { return "cir.eh.catch_copy_thunk"; }
 

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3388,6 +3388,7 @@ def CIR_GlobalOp : CIR_Op<"global", [
                        OptionalAttr<CIR_StaticLocalGuardAttr>:$static_local_guard,
                        OptionalAttr<I64Attr>:$alignment,
                        OptionalAttr<ASTVarDeclInterface>:$ast,
+                       OptionalAttr<CIR_StaticLocalInfoAttr>:$static_local_info,
                        OptionalAttr<StrAttr>:$section,
                        OptionalAttr<CIR_AnnotationArrayAttr>:$annotations,
                        OptionalAttr<FlatSymbolRefAttr>:$aliasee,

--- a/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
@@ -270,7 +270,18 @@ void CIRGenModule::emitCXXSpecialVarDeclInit(const VarDecl *varDecl,
   // expects "this" in the "generic" address space.
   assert(!cir::MissingFeatures::addressSpace());
 
-  addr.setAstAttr(cir::ASTVarDeclAttr::get(&getMLIRContext(), varDecl));
+  // LoweringPrepare reads VarDecl facts back through ASTVarDeclInterface, but
+  // only for static-local guarded globals. For those, emit the materialized
+  // StaticLocalInfoAttr so the facts survive without a live ASTContext (e.g.
+  // serialized CIR in split-compilation flows). Other globals keep the
+  // AST-backed attribute; their $ast is never queried after CIRGen.
+  if (addr.getStaticLocalGuard().has_value())
+    addr.setAstAttr(cir::StaticLocalInfoAttr::get(
+        &getMLIRContext(), varDecl->isLocalVarDecl(),
+        static_cast<uint32_t>(varDecl->getTLSKind()), varDecl->isInline(),
+        static_cast<uint32_t>(varDecl->getTemplateSpecializationKind())));
+  else
+    addr.setAstAttr(cir::ASTVarDeclAttr::get(&getMLIRContext(), varDecl));
 
   if (!ty->isReferenceType()) {
     assert(!cir::MissingFeatures::openMP());

--- a/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
@@ -237,6 +237,37 @@ cir::FuncOp CIRGenModule::codegenCXXStructor(GlobalDecl gd) {
 // initialization for each global there. In CIR, we attach a ctor
 // region to the global variable and insert the initialization code
 // into the ctor region. This will be moved into the
+// Map clang's VarDecl::TLSKind onto the CIR-native enum.
+static cir::TLSKind getCIRTLSKind(clang::VarDecl::TLSKind kind) {
+  switch (kind) {
+  case clang::VarDecl::TLS_None:
+    return cir::TLSKind::None;
+  case clang::VarDecl::TLS_Static:
+    return cir::TLSKind::Static;
+  case clang::VarDecl::TLS_Dynamic:
+    return cir::TLSKind::Dynamic;
+  }
+  llvm_unreachable("unknown TLSKind");
+}
+
+// Map clang's TemplateSpecializationKind onto the CIR-native enum.
+static cir::TemplateSpecializationKind
+getCIRTemplateSpecializationKind(clang::TemplateSpecializationKind kind) {
+  switch (kind) {
+  case clang::TSK_Undeclared:
+    return cir::TemplateSpecializationKind::Undeclared;
+  case clang::TSK_ImplicitInstantiation:
+    return cir::TemplateSpecializationKind::ImplicitInstantiation;
+  case clang::TSK_ExplicitSpecialization:
+    return cir::TemplateSpecializationKind::ExplicitSpecialization;
+  case clang::TSK_ExplicitInstantiationDeclaration:
+    return cir::TemplateSpecializationKind::ExplicitInstantiationDeclaration;
+  case clang::TSK_ExplicitInstantiationDefinition:
+    return cir::TemplateSpecializationKind::ExplicitInstantiationDefinition;
+  }
+  llvm_unreachable("unknown clang::TemplateSpecializationKind");
+}
+
 // __cxx_global_var_init function during the LoweringPrepare pass.
 void CIRGenModule::emitCXXSpecialVarDeclInit(const VarDecl *varDecl,
                                              cir::GlobalOp addr,
@@ -280,8 +311,9 @@ void CIRGenModule::emitCXXSpecialVarDeclInit(const VarDecl *varDecl,
   if (addr.getStaticLocalGuard().has_value())
     addr.setStaticLocalInfoAttr(cir::StaticLocalInfoAttr::get(
         &getMLIRContext(), varDecl->isLocalVarDecl(),
-        static_cast<uint32_t>(varDecl->getTLSKind()), varDecl->isInline(),
-        static_cast<uint32_t>(varDecl->getTemplateSpecializationKind())));
+        getCIRTLSKind(varDecl->getTLSKind()), varDecl->isInline(),
+        getCIRTemplateSpecializationKind(
+            varDecl->getTemplateSpecializationKind())));
 
   if (!ty->isReferenceType()) {
     assert(!cir::MissingFeatures::openMP());

--- a/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
@@ -270,18 +270,18 @@ void CIRGenModule::emitCXXSpecialVarDeclInit(const VarDecl *varDecl,
   // expects "this" in the "generic" address space.
   assert(!cir::MissingFeatures::addressSpace());
 
-  // LoweringPrepare reads VarDecl facts back through ASTVarDeclInterface, but
-  // only for static-local guarded globals. For those, emit the materialized
-  // StaticLocalInfoAttr so the facts survive without a live ASTContext (e.g.
-  // serialized CIR in split-compilation flows). Other globals keep the
-  // AST-backed attribute; their $ast is never queried after CIRGen.
+  // Attach the AST handle for consumers that need arbitrary AST properties.
+  addr.setAstAttr(cir::ASTVarDeclAttr::get(&getMLIRContext(), varDecl));
+
+  // For static-local guarded globals, also materialize the specific facts
+  // LoweringPrepare needs into a serializable attribute, so that lowering can
+  // run without a live ASTContext (e.g. on serialized CIR in split-compilation
+  // flows). This is orthogonal to the AST handle above.
   if (addr.getStaticLocalGuard().has_value())
-    addr.setAstAttr(cir::StaticLocalInfoAttr::get(
+    addr.setStaticLocalInfoAttr(cir::StaticLocalInfoAttr::get(
         &getMLIRContext(), varDecl->isLocalVarDecl(),
         static_cast<uint32_t>(varDecl->getTLSKind()), varDecl->isInline(),
         static_cast<uint32_t>(varDecl->getTemplateSpecializationKind())));
-  else
-    addr.setAstAttr(cir::ASTVarDeclAttr::get(&getMLIRContext(), varDecl));
 
   if (!ty->isReferenceType()) {
     assert(!cir::MissingFeatures::openMP());

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -24,9 +24,11 @@
 #include "clang/AST/DeclBase.h"
 #include "clang/AST/DeclOpenACC.h"
 #include "clang/AST/GlobalDecl.h"
+#include "clang/AST/Mangle.h"
 #include "clang/AST/RecordLayout.h"
 #include "clang/AST/StmtOpenMP.h"
 #include "clang/Basic/DiagnosticFrontend.h"
+#include "clang/Basic/Module.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/CIR/Dialect/IR/CIRAttrs.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
@@ -3888,6 +3890,24 @@ void CIRGenModule::release() {
     getCUDARuntime().finalizeModule();
 
   emitLLVMUsed();
+
+  // Precompute the mangled C++20 named-module initializer function name and
+  // stash it on the ModuleOp so LoweringPrepare (which may run without a live
+  // ASTContext in split-compilation flows) can read it back as an attribute.
+  if (langOpts.CPlusPlusModules &&
+      getCXXABI().getMangleContext().getKind() ==
+          clang::ItaniumMangleContext::MK_Itanium) {
+    if (clang::Module *primary = astContext.getCurrentNamedModule();
+        primary && !primary->isModuleImplementation()) {
+      llvm::SmallString<256> fnName;
+      llvm::raw_svector_ostream out(fnName);
+      cast<clang::ItaniumMangleContext>(getCXXABI().getMangleContext())
+          .mangleModuleInitializer(primary, out);
+      theModule->setAttr(
+          cir::CIRDialect::getCXXModuleInitFnNameAttrName(),
+          builder.getStringAttr(fnName));
+    }
+  }
 
   // Classic codegen calls `checkAliases` here to validate any alias
   // definitions emitted during codegen.

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -3903,9 +3903,8 @@ void CIRGenModule::release() {
       llvm::raw_svector_ostream out(fnName);
       cast<clang::ItaniumMangleContext>(getCXXABI().getMangleContext())
           .mangleModuleInitializer(primary, out);
-      theModule->setAttr(
-          cir::CIRDialect::getCXXModuleInitFnNameAttrName(),
-          builder.getStringAttr(fnName));
+      theModule->setAttr(cir::CIRDialect::getCXXModuleInitFnNameAttrName(),
+                         builder.getStringAttr(fnName));
     }
   }
 

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -1371,9 +1371,13 @@ void LoweringPreparePass::handleStaticLocal(cir::GlobalOp globalOp,
 
   // Inline variables that weren't instantiated from variable templates have
   // partially-ordered initialization within their translation unit.
-  bool nonTemplateInline =
-      info.getIsInline() &&
-      !clang::isTemplateInstantiation(info.getTemplateSpecializationKind());
+  cir::TemplateSpecializationKind tsk = info.getTsk();
+  bool isTemplateInstantiation =
+      tsk == cir::TemplateSpecializationKind::ImplicitInstantiation ||
+      tsk ==
+          cir::TemplateSpecializationKind::ExplicitInstantiationDeclaration ||
+      tsk == cir::TemplateSpecializationKind::ExplicitInstantiationDefinition;
+  bool nonTemplateInline = info.getIsInline() && !isTemplateInstantiation;
 
   // Inline namespace-scope variables require guarded initialization in a
   // __cxx_global_var_init function. This is not yet implemented.
@@ -1387,8 +1391,8 @@ void LoweringPreparePass::handleStaticLocal(cir::GlobalOp globalOp,
   // inline variables; other global initialization is always single-threaded
   // or (through lazy dynamic loading in multiple threads) unsequenced.
   bool threadsafe = astCtx->getLangOpts().ThreadsafeStatics &&
-                    (info.getIsLocalVarDecl() || nonTemplateInline) &&
-                    !info.getTLSKind();
+                    (info.getLocal() || nonTemplateInline) &&
+                    info.getTls() == cir::TLSKind::None;
 
   // If we have a global variable with internal linkage and thread-safe statics
   // are disabled, we can just let the guard variable be of type i8.
@@ -1397,7 +1401,7 @@ void LoweringPreparePass::handleStaticLocal(cir::GlobalOp globalOp,
   // Create the guard variable if we don't already have it.
   cir::GlobalOp guard = getOrCreateStaticLocalDeclGuardAddress(
       builder, globalOp, globalOp.getStaticLocalGuard()->getName().getValue(),
-      info.getIsLocalVarDecl(), useInt8GuardVariable);
+      info.getLocal(), useInt8GuardVariable);
   if (!guard) {
     // Error was already emitted, just restore the terminator and return.
     localInitBlock->push_back(ret);
@@ -1487,7 +1491,7 @@ void LoweringPreparePass::handleStaticLocal(cir::GlobalOp globalOp,
         /*withElseRegion=*/false, [&](mlir::OpBuilder &, mlir::Location) {
           emitCXXGuardedInitIf(
               builder, globalOp, localInitOp.getCtorRegion(),
-              localInitOp.getDtorRegion(), info.getIsLocalVarDecl(), guardPtr,
+              localInitOp.getDtorRegion(), info.getLocal(), guardPtr,
               builder.getPointerTo(guard.getSymType()), threadsafe);
         });
   } else {

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -1967,9 +1967,16 @@ void LoweringPreparePass::buildCXXGlobalInitFunc() {
   // and makes sure these symbols appear lexicographically behind the symbols
   // with priority (TBD).  Module implementation units behave the same
   // way as a non-modular TU with imports.
-  // TODO: check CXX20ModuleInits
-  if (astCtx->getCurrentNamedModule() &&
-      !astCtx->getCurrentNamedModule()->isModuleImplementation()) {
+  // The C++20 named-module init function name is precomputed by CIRGen and
+  // stored as a module-level attribute, so this pass does not need a live
+  // ASTContext in split-compilation flows. Fall back to the AST-based path
+  // only when the attribute is absent (e.g. tests that bypass CIRGen).
+  if (auto fnNameAttr = mlirModule->getAttrOfType<mlir::StringAttr>(
+          cir::CIRDialect::getCXXModuleInitFnNameAttrName())) {
+    fnName += fnNameAttr.getValue();
+    linkage = cir::GlobalLinkageKind::ExternalLinkage;
+  } else if (astCtx && astCtx->getCurrentNamedModule() &&
+             !astCtx->getCurrentNamedModule()->isModuleImplementation()) {
     llvm::raw_svector_ostream out(fnName);
     std::unique_ptr<clang::MangleContext> mangleCtx(
         astCtx->createMangleContext());

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -425,9 +425,8 @@ struct LoweringPreparePass
   /// following OG's ItaniumCXXABI::EmitGuardedInit skeleton.
   void emitCXXGuardedInitIf(CIRBaseBuilderTy &builder, cir::GlobalOp globalOp,
                             mlir::Region &ctorRegion, mlir::Region &dtorRegion,
-                            cir::ASTVarDeclInterface varDecl,
-                            mlir::Value guardPtr, cir::PointerType guardPtrTy,
-                            bool threadsafe) {
+                            bool isLocalVarDecl, mlir::Value guardPtr,
+                            cir::PointerType guardPtrTy, bool threadsafe) {
     auto loc = globalOp->getLoc();
 
     // The semantics of dynamic initialization of variables with static or
@@ -525,7 +524,7 @@ struct LoweringPreparePass
                            mlir::ValueRange{guardPtr});
 
       builder.createYield(loc);
-    } else if (!varDecl.isLocalVarDecl()) {
+    } else if (!isLocalVarDecl) {
       // For non-local variables, store 1 into the first byte of the guard
       // variable before the object initialization begins so that references
       // to the variable during initialization don't restart initialization.
@@ -1353,9 +1352,12 @@ void LoweringPreparePass::handleStaticLocal(cir::GlobalOp globalOp,
                                             cir::LocalInitOp localInitOp) {
   CIRBaseBuilderTy builder(getContext());
 
-  std::optional<cir::ASTVarDeclInterface> astOption = globalOp.getAst();
-  assert(astOption.has_value());
-  cir::ASTVarDeclInterface varDecl = astOption.value();
+  // Static-local facts are materialized into a serializable attribute by
+  // CIRGen, so this pass does not need a live ASTContext to read them.
+  std::optional<cir::StaticLocalInfoAttr> infoOption =
+      globalOp.getStaticLocalInfo();
+  assert(infoOption.has_value());
+  cir::StaticLocalInfoAttr info = infoOption.value();
 
   builder.setInsertionPointAfter(localInitOp);
   mlir::Block *localInitBlock = builder.getInsertionBlock();
@@ -1370,8 +1372,8 @@ void LoweringPreparePass::handleStaticLocal(cir::GlobalOp globalOp,
   // Inline variables that weren't instantiated from variable templates have
   // partially-ordered initialization within their translation unit.
   bool nonTemplateInline =
-      varDecl.isInline() &&
-      !clang::isTemplateInstantiation(varDecl.getTemplateSpecializationKind());
+      info.getIsInline() &&
+      !clang::isTemplateInstantiation(info.getTemplateSpecializationKind());
 
   // Inline namespace-scope variables require guarded initialization in a
   // __cxx_global_var_init function. This is not yet implemented.
@@ -1385,8 +1387,8 @@ void LoweringPreparePass::handleStaticLocal(cir::GlobalOp globalOp,
   // inline variables; other global initialization is always single-threaded
   // or (through lazy dynamic loading in multiple threads) unsequenced.
   bool threadsafe = astCtx->getLangOpts().ThreadsafeStatics &&
-                    (varDecl.isLocalVarDecl() || nonTemplateInline) &&
-                    !varDecl.getTLSKind();
+                    (info.getIsLocalVarDecl() || nonTemplateInline) &&
+                    !info.getTLSKind();
 
   // If we have a global variable with internal linkage and thread-safe statics
   // are disabled, we can just let the guard variable be of type i8.
@@ -1395,7 +1397,7 @@ void LoweringPreparePass::handleStaticLocal(cir::GlobalOp globalOp,
   // Create the guard variable if we don't already have it.
   cir::GlobalOp guard = getOrCreateStaticLocalDeclGuardAddress(
       builder, globalOp, globalOp.getStaticLocalGuard()->getName().getValue(),
-      varDecl.isLocalVarDecl(), useInt8GuardVariable);
+      info.getIsLocalVarDecl(), useInt8GuardVariable);
   if (!guard) {
     // Error was already emitted, just restore the terminator and return.
     localInitBlock->push_back(ret);
@@ -1483,10 +1485,10 @@ void LoweringPreparePass::handleStaticLocal(cir::GlobalOp globalOp,
     cir::IfOp::create(
         builder, globalOp.getLoc(), needsInit,
         /*withElseRegion=*/false, [&](mlir::OpBuilder &, mlir::Location) {
-          emitCXXGuardedInitIf(builder, globalOp, localInitOp.getCtorRegion(),
-                               localInitOp.getDtorRegion(), varDecl, guardPtr,
-                               builder.getPointerTo(guard.getSymType()),
-                               threadsafe);
+          emitCXXGuardedInitIf(
+              builder, globalOp, localInitOp.getCtorRegion(),
+              localInitOp.getDtorRegion(), info.getIsLocalVarDecl(), guardPtr,
+              builder.getPointerTo(guard.getSymType()), threadsafe);
         });
   } else {
     // Threadsafe statics without inline atomics - call __cxa_guard_acquire

--- a/clang/test/CIR/CodeGen/cxx20-module-initializer.cppm
+++ b/clang/test/CIR/CodeGen/cxx20-module-initializer.cppm
@@ -1,0 +1,22 @@
+// RUN: %clang_cc1 -std=c++20 -triple %itanium_abi_triple -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
+
+// CIRGen precomputes the mangled C++20 named-module initializer function
+// name and stores it as a module-level attribute so LoweringPrepare can
+// build the initializer without a live ASTContext after split-compilation.
+// The dynamic initializer below forces LoweringPrepare to actually emit that
+// initializer function, which must have external linkage for a named-module
+// interface unit.
+
+export module A;
+
+int foo();
+int x = foo();
+
+// CIR: module
+// CIR-SAME: cir.cxx_module_init_fn_name = "_ZGIW1A"
+
+// The initializer for a named-module interface unit has external linkage.
+// (Internal linkage would render as "cir.func internal private", so matching
+// "cir.func private" immediately after the name asserts external linkage.)
+// CIR: cir.func private @_ZGIW1A()

--- a/clang/test/CIR/CodeGen/static-local-info.cpp
+++ b/clang/test/CIR/CodeGen/static-local-info.cpp
@@ -3,10 +3,9 @@
 
 // CIRGen attaches the VarDecl facts LoweringPrepare needs (isLocalVarDecl,
 // TLSKind, isInline, TemplateSpecializationKind) to static-local guarded
-// globals as a materialized #cir.static_local_info attribute, so the facts
-// survive without a live ASTContext. The attribute is emitted directly at
-// CIRGen time; there is no separate materialization pass and no AST-backed
-// #cir.var.decl placeholder is left on these globals.
+// globals as a #cir.static_local_info attribute, so the facts survive without
+// a live ASTContext. This is orthogonal to the #cir.var.decl AST handle, which
+// is still attached for consumers that need arbitrary AST properties.
 
 struct HasCtor {
   HasCtor();
@@ -23,13 +22,12 @@ int tls() {
   return s.x;
 }
 
-// A static local is always a local var decl; the guarded global therefore
-// carries is_local_var_decl = true and never the AST-backed placeholder.
-// CHECK-NOT: #cir.var.decl
-
-// The thread_local static local materializes a non-default TLS kind.
+// The thread_local static local materializes a non-default TLS kind, alongside
+// the retained AST handle.
 // CHECK: @_ZZ3tlsvE1s
-// CHECK-SAME: ast = #cir.static_local_info<is_local_var_decl = true, tls = 2, is_inline = false, tsk = 0>
+// CHECK-SAME: ast = #cir.var.decl.ast
+// CHECK-SAME: static_local_info = #cir.static_local_info<is_local_var_decl = true, tls = 2, is_inline = false, tsk = 0>
 
 // CHECK: @_ZZ7regularvE1s
-// CHECK-SAME: ast = #cir.static_local_info<is_local_var_decl = true, tls = 0, is_inline = false, tsk = 0>
+// CHECK-SAME: ast = #cir.var.decl.ast
+// CHECK-SAME: static_local_info = #cir.static_local_info<is_local_var_decl = true, tls = 0, is_inline = false, tsk = 0>

--- a/clang/test/CIR/CodeGen/static-local-info.cpp
+++ b/clang/test/CIR/CodeGen/static-local-info.cpp
@@ -26,8 +26,8 @@ int tls() {
 // the retained AST handle.
 // CHECK: @_ZZ3tlsvE1s
 // CHECK-SAME: ast = #cir.var.decl.ast
-// CHECK-SAME: static_local_info = #cir.static_local_info<is_local_var_decl = true, tls = 2, is_inline = false, tsk = 0>
+// CHECK-SAME: static_local_info = #cir.static_local_info<local = true, tls = dynamic, is_inline = false, tsk = undeclared>
 
 // CHECK: @_ZZ7regularvE1s
 // CHECK-SAME: ast = #cir.var.decl.ast
-// CHECK-SAME: static_local_info = #cir.static_local_info<is_local_var_decl = true, tls = 0, is_inline = false, tsk = 0>
+// CHECK-SAME: static_local_info = #cir.static_local_info<local = true, tls = none, is_inline = false, tsk = undeclared>

--- a/clang/test/CIR/CodeGen/static-local-info.cpp
+++ b/clang/test/CIR/CodeGen/static-local-info.cpp
@@ -1,0 +1,35 @@
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -fclangir \
+// RUN:   -emit-cir %s -o - | FileCheck %s
+
+// CIRGen attaches the VarDecl facts LoweringPrepare needs (isLocalVarDecl,
+// TLSKind, isInline, TemplateSpecializationKind) to static-local guarded
+// globals as a materialized #cir.static_local_info attribute, so the facts
+// survive without a live ASTContext. The attribute is emitted directly at
+// CIRGen time; there is no separate materialization pass and no AST-backed
+// #cir.var.decl placeholder is left on these globals.
+
+struct HasCtor {
+  HasCtor();
+  int x;
+};
+
+int regular() {
+  static HasCtor s;
+  return s.x;
+}
+
+int tls() {
+  static thread_local HasCtor s;
+  return s.x;
+}
+
+// A static local is always a local var decl; the guarded global therefore
+// carries is_local_var_decl = true and never the AST-backed placeholder.
+// CHECK-NOT: #cir.var.decl
+
+// The thread_local static local materializes a non-default TLS kind.
+// CHECK: @_ZZ3tlsvE1s
+// CHECK-SAME: ast = #cir.static_local_info<is_local_var_decl = true, tls = 2, is_inline = false, tsk = 0>
+
+// CHECK: @_ZZ7regularvE1s
+// CHECK-SAME: ast = #cir.static_local_info<is_local_var_decl = true, tls = 0, is_inline = false, tsk = 0>

--- a/clang/test/CIR/IR/static-local-info.cir
+++ b/clang/test/CIR/IR/static-local-info.cir
@@ -1,20 +1,21 @@
 // RUN: cir-opt %s --verify-roundtrip | FileCheck %s
 
 // #cir.static_local_info holds plain data (no AST pointer), so it parses and
-// prints without a live ASTContext. Check that each field round-trips.
+// prints without a live ASTContext. Check that each field round-trips,
+// including the named tls / tsk enum keywords at non-default values.
 
 !s32i = !cir.int<s, 32>
 
 module {
   cir.global "private" internal @regular = #cir.int<0> : !s32i
     {static_local_info = #cir.static_local_info<
-       is_local_var_decl = true, tls = 0, is_inline = false, tsk = 0>}
+       local = true, tls = none, is_inline = false, tsk = undeclared>}
   // CHECK: @regular
-  // CHECK-SAME: static_local_info = #cir.static_local_info<is_local_var_decl = true, tls = 0, is_inline = false, tsk = 0>
+  // CHECK-SAME: static_local_info = #cir.static_local_info<local = true, tls = none, is_inline = false, tsk = undeclared>
 
   cir.global "private" internal @tls = #cir.int<0> : !s32i
     {static_local_info = #cir.static_local_info<
-       is_local_var_decl = true, tls = 2, is_inline = true, tsk = 1>}
+       local = true, tls = dynamic, is_inline = true, tsk = implicit_instantiation>}
   // CHECK: @tls
-  // CHECK-SAME: static_local_info = #cir.static_local_info<is_local_var_decl = true, tls = 2, is_inline = true, tsk = 1>
+  // CHECK-SAME: static_local_info = #cir.static_local_info<local = true, tls = dynamic, is_inline = true, tsk = implicit_instantiation>
 }

--- a/clang/test/CIR/IR/static-local-info.cir
+++ b/clang/test/CIR/IR/static-local-info.cir
@@ -1,0 +1,20 @@
+// RUN: cir-opt %s --verify-roundtrip | FileCheck %s
+
+// #cir.static_local_info holds plain data (no AST pointer), so it parses and
+// prints without a live ASTContext. Check that each field round-trips.
+
+!s32i = !cir.int<s, 32>
+
+module {
+  cir.global "private" internal @regular = #cir.int<0> : !s32i
+    {static_local_info = #cir.static_local_info<
+       is_local_var_decl = true, tls = 0, is_inline = false, tsk = 0>}
+  // CHECK: @regular
+  // CHECK-SAME: static_local_info = #cir.static_local_info<is_local_var_decl = true, tls = 0, is_inline = false, tsk = 0>
+
+  cir.global "private" internal @tls = #cir.int<0> : !s32i
+    {static_local_info = #cir.static_local_info<
+       is_local_var_decl = true, tls = 2, is_inline = true, tsk = 1>}
+  // CHECK: @tls
+  // CHECK-SAME: static_local_info = #cir.static_local_info<is_local_var_decl = true, tls = 2, is_inline = true, tsk = 1>
+}


### PR DESCRIPTION
Adds two CIR attributes that record specific declaration facts, so passes
that consume them don't have to query the AST for those particular facts:

- `cir.cxx_module_init_fn_name` (module attribute): the mangled C++20
  named-module initializer function name, precomputed in
  `CIRGenModule::release()`. LoweringPrepare reads it, falling back to the
  AST path when absent.

- `cir.static_local_info` (new `$static_local_info` field on `cir.global`):
  caches the static-local VarDecl facts LoweringPrepare needs
  (`is_local_var_decl`, `tls`, `is_inline`, `tsk`). Emitted by CIRGen for
  static-local guarded globals, alongside — not replacing — the existing
  `$ast` `ASTVarDeclAttr`. LoweringPrepare reads it directly.

Both are additive: the `$ast` AST handle is unchanged, `-emit-llvm` is
byte-identical, and the new attributes round-trip through textual CIR
(tests included).

Motivation: split-compilation flows reload/round-trip CIR after the AST is
gone; having these specific facts as plain data lets the corresponding
lowering run without a live ASTContext.