### PR TITLE
[CIR] Allow only CIR types in function signatures

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRTypesDetails.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypesDetails.h
@@ -13,6 +13,7 @@
 #ifndef CIR_DIALECT_IR_CIRTYPESDETAILS_H
 #define CIR_DIALECT_IR_CIRTYPESDETAILS_H
 
+#include "mlir/IR/AttrTypeSubElements.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/Support/LogicalResult.h"
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
@@ -211,5 +212,55 @@ struct UnionTypeStorage : public mlir::TypeStorage {
 
 } // namespace detail
 } // namespace cir
+
+namespace mlir {
+
+/// Allow walking and replacing the subelements of a StructTypeStorage key.
+template <>
+struct AttrTypeSubElementHandler<cir::detail::StructTypeStorage::KeyTy> {
+  static void walk(const cir::detail::StructTypeStorage::KeyTy &param,
+                   AttrTypeImmediateSubElementWalker &walker) {
+    walker.walkRange(param.members);
+  }
+  static FailureOr<cir::detail::StructTypeStorage::KeyTy>
+  replace(const cir::detail::StructTypeStorage::KeyTy &param,
+          AttrSubElementReplacements &attrRepls,
+          TypeSubElementReplacements &typeRepls) {
+    // TODO: It's not clear how we support replacing sub-elements of mutable
+    // types.
+    if (param.name)
+      return failure();
+
+    return cir::detail::StructTypeStorage::KeyTy(
+        typeRepls.take_front(param.members.size()), param.name,
+        param.incomplete, param.packed, param.padded, param.is_class);
+  }
+};
+
+/// Allow walking and replacing the subelements of a UnionTypeStorage key.
+template <>
+struct AttrTypeSubElementHandler<cir::detail::UnionTypeStorage::KeyTy> {
+  static void walk(const cir::detail::UnionTypeStorage::KeyTy &param,
+                   AttrTypeImmediateSubElementWalker &walker) {
+    walker.walkRange(param.members);
+    walker.walk(param.padding);
+  }
+  static FailureOr<cir::detail::UnionTypeStorage::KeyTy>
+  replace(const cir::detail::UnionTypeStorage::KeyTy &param,
+          AttrSubElementReplacements &attrRepls,
+          TypeSubElementReplacements &typeRepls) {
+    // TODO: It's not clear how we support replacing sub-elements of mutable
+    // types.
+    if (param.name)
+      return failure();
+
+    llvm::ArrayRef<Type> members = typeRepls.take_front(param.members.size());
+    Type padding = param.padding ? typeRepls.take_front(1)[0] : Type();
+    return cir::detail::UnionTypeStorage::KeyTy(
+        members, param.name, param.incomplete, param.packed, padding);
+  }
+};
+
+} // namespace mlir
 
 #endif // CIR_DIALECT_IR_CIRTYPESDETAILS_H

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypesDetails.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypesDetails.h
@@ -233,7 +233,7 @@ struct AttrTypeSubElementHandler<cir::detail::StructTypeStorage::KeyTy> {
 
     return cir::detail::StructTypeStorage::KeyTy(
         typeRepls.take_front(param.members.size()), param.name,
-        param.incomplete, param.packed, param.padded, param.is_class);
+        param.incomplete, param.packed, param.member_kinds, param.is_class);
   }
 };
 
@@ -256,8 +256,9 @@ struct AttrTypeSubElementHandler<cir::detail::UnionTypeStorage::KeyTy> {
 
     llvm::ArrayRef<Type> members = typeRepls.take_front(param.members.size());
     Type padding = param.padding ? typeRepls.take_front(1)[0] : Type();
-    return cir::detail::UnionTypeStorage::KeyTy(
-        members, param.name, param.incomplete, param.packed, padding);
+    return cir::detail::UnionTypeStorage::KeyTy(members, param.name,
+                                                param.incomplete, param.packed,
+                                                padding, param.member_kinds);
   }
 };
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -2533,7 +2533,9 @@ ParseResult cir::FuncOp::parse(OpAsmParser &parser, OperationState &state) {
       (resultTypes.empty() ? cir::VoidType::get(builder.getContext())
                            : resultTypes.front());
 
-  cir::FuncType fnType = cir::FuncType::get(argTypes, returnType, isVariadic);
+  cir::FuncType fnType =
+      cir::FuncType::getChecked([&]() { return parser.emitError(loc); },
+                                argTypes, returnType, isVariadic);
   if (!fnType)
     return failure();
 

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -61,6 +61,18 @@ cir::FPTypeInterface cir::getFloatingPointType(const llvm::fltSemantics &sem,
   }
 }
 
+static bool isPureCIRType(mlir::Type ty) {
+  if (!ty)
+    return true;
+  return !ty.walk([](mlir::Type t) {
+              if (!t)
+                return mlir::WalkResult::advance();
+              return mlir::isa<cir::CIRDialect>(t.getDialect())
+                         ? mlir::WalkResult::advance()
+                         : mlir::WalkResult::interrupt();
+            }).wasInterrupted();
+}
+
 //===----------------------------------------------------------------------===//
 // CIR Custom Parser/Printer Signatures
 //===----------------------------------------------------------------------===//
@@ -1242,6 +1254,18 @@ FuncType::verify(llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
   if (mlir::isa_and_nonnull<cir::VoidType>(returnType))
     return emitError()
            << "!cir.func cannot have an explicit 'void' return type";
+
+  // The calling convention lowering pass expects all types in a function
+  // signature to be CIR types.
+  for (mlir::Type type : argTypes) {
+    if (!isPureCIRType(type))
+      return emitError()
+             << "expected all types in the function signature to be CIR types";
+  }
+  if (!isPureCIRType(returnType))
+    return emitError()
+           << "expected all types in the function signature to be CIR types";
+
   return mlir::success();
 }
 

--- a/clang/test/CIR/IR/builtin-int-cast.cir
+++ b/clang/test/CIR/IR/builtin-int-cast.cir
@@ -17,8 +17,9 @@ module {
   }
 
   // Builtin integer -> CIR integer.
-  cir.func @from_builtin(%arg0: i64) {
-    %0 = cir.builtin_int_cast %arg0 : i64 -> !u64i
+  cir.func @from_builtin() {
+    %0 = llvm.mlir.constant(42 : i64) : i64
+    %1 = cir.builtin_int_cast %0 : i64 -> !u64i
     cir.return
   }
 
@@ -28,8 +29,9 @@ module {
     cir.return
   }
 
-  cir.func @from_index(%arg0: index) {
-    %0 = cir.builtin_int_cast %arg0 : index -> !u64i
+  cir.func @from_index(%arg0: !u64i) {
+    %0 = cir.builtin_int_cast %arg0 : !u64i -> index
+    %1 = cir.builtin_int_cast %0 : index -> !u64i
     cir.return
   }
 }
@@ -40,11 +42,13 @@ module {
 // CHECK: cir.func{{.*}} @to_builtin_signed(%arg0: !s32i)
 // CHECK: %0 = cir.builtin_int_cast %arg0 : !s32i -> si32
 
-// CHECK: cir.func{{.*}} @from_builtin(%arg0: i64)
-// CHECK: %0 = cir.builtin_int_cast %arg0 : i64 -> !u64i
+// CHECK: cir.func{{.*}} @from_builtin()
+// CHECK: %0 = llvm.mlir.constant(42 : i64) : i64
+// CHECK: %1 = cir.builtin_int_cast %0 : i64 -> !u64i
 
 // CHECK: cir.func{{.*}} @to_index(%arg0: !u64i)
 // CHECK: %0 = cir.builtin_int_cast %arg0 : !u64i -> index
 
-// CHECK: cir.func{{.*}} @from_index(%arg0: index)
-// CHECK: %0 = cir.builtin_int_cast %arg0 : index -> !u64i
+// CHECK: cir.func{{.*}} @from_index(%arg0: !u64i)
+// CHECK: %0 = cir.builtin_int_cast %arg0 : !u64i -> index
+// CHECK: %1 = cir.builtin_int_cast %0 : index -> !u64i

--- a/clang/test/CIR/IR/invalid-func.cir
+++ b/clang/test/CIR/IR/invalid-func.cir
@@ -53,3 +53,12 @@ module {
 module {
   cir.func private @l0(!cir.ptr<!rec_S>) // expected-error {{expected all types in the function signature to be CIR types}}
 }
+
+// -----
+
+!s32i = !cir.int<s, 32>
+!rec_U = !cir.union<"U" {!s32i, i32}>
+
+module {
+  cir.func private @l0(!rec_U) // expected-error {{expected all types in the function signature to be CIR types}}
+}

--- a/clang/test/CIR/IR/invalid-func.cir
+++ b/clang/test/CIR/IR/invalid-func.cir
@@ -48,7 +48,7 @@ module {
 // -----
 
 !s32i = !cir.int<s, 32>
-!rec_S = !cir.struct<"S" {!s32i, i32}>
+!rec_S = !cir.struct<"S" {data !s32i, data i32}>
 
 module {
   cir.func private @l0(!cir.ptr<!rec_S>) // expected-error {{expected all types in the function signature to be CIR types}}
@@ -57,7 +57,7 @@ module {
 // -----
 
 !s32i = !cir.int<s, 32>
-!rec_U = !cir.union<"U" {!s32i, i32}>
+!rec_U = !cir.union<"U" {data !s32i, data i32}>
 
 module {
   cir.func private @l0(!rec_U) // expected-error {{expected all types in the function signature to be CIR types}}

--- a/clang/test/CIR/IR/invalid-func.cir
+++ b/clang/test/CIR/IR/invalid-func.cir
@@ -26,3 +26,30 @@ module {
     cir.return
   }
 }
+
+// -----
+
+module {
+  cir.func @l0() -> i32 // expected-error {{expected all types in the function signature to be CIR types}}
+}
+
+// -----
+
+module {
+  cir.func @l0(i32) // expected-error {{expected all types in the function signature to be CIR types}}
+}
+
+// -----
+
+module {
+  cir.func @l0(!cir.ptr<i32>) // expected-error {{expected all types in the function signature to be CIR types}}
+}
+
+// -----
+
+!s32i = !cir.int<s, 32>
+!rec_S = !cir.struct<"S" {!s32i, i32}>
+
+module {
+  cir.func private @l0(!cir.ptr<!rec_S>) // expected-error {{expected all types in the function signature to be CIR types}}
+}

--- a/clang/test/CIR/Lowering/builtin-int-cast.cir
+++ b/clang/test/CIR/Lowering/builtin-int-cast.cir
@@ -13,11 +13,12 @@ module {
   // Same width: the cast carries no resize and is dropped entirely, so the
   // argument flows straight to the return.
   // CHECK-LABEL: llvm.func @cast_noop
-  // CHECK-SAME: (%[[ARG:.*]]: i32)
-  // CHECK-NEXT: llvm.return %[[ARG]] : i32
-  cir.func @cast_noop(%arg0: i32) -> !s32i {
-    %0 = cir.builtin_int_cast %arg0 : i32 -> !s32i
-    cir.return %0 : !s32i
+  // CHECK-NEXT: %[[VAL:.*]] = llvm.mlir.constant(42 : i32) : i32
+  // CHECK-NEXT: llvm.return %[[VAL]] : i32
+  cir.func @cast_noop() -> !s32i {
+    %0 = llvm.mlir.constant(42 : i32) : i32
+    %1 = cir.builtin_int_cast %0 : i32 -> !s32i
+    cir.return %1 : !s32i
   }
 
   // index (i64) down to a narrower CIR integer: truncation.
@@ -25,9 +26,10 @@ module {
   // CHECK-SAME: (%[[ARG:.*]]: i64)
   // CHECK-NEXT: %[[T:.*]] = llvm.trunc %[[ARG]] : i64 to i16
   // CHECK-NEXT: llvm.return %[[T]] : i16
-  cir.func @cast_trunc(%arg0: index) -> !s16i {
-    %0 = cir.builtin_int_cast %arg0 : index -> !s16i
-    cir.return %0 : !s16i
+  cir.func @cast_trunc(%arg0: !u64i) -> !s16i {
+    %0 = cir.builtin_int_cast %arg0 : !u64i -> index
+    %1 = cir.builtin_int_cast %0 : index -> !s16i
+    cir.return %1 : !s16i
   }
 
   // Signed CIR integer widened through index: sign extension. The trailing

--- a/clang/test/CIR/Transforms/builtin-int-cast-fold.cir
+++ b/clang/test/CIR/Transforms/builtin-int-cast-fold.cir
@@ -17,13 +17,15 @@ module {
   // CHECK-NEXT: }
 
   // A round-trip that returns to a *different* CIR type must not fold.
-  cir.func @no_fold_diff_type(%arg0: i32) -> !s32i {
-    %0 = cir.builtin_int_cast %arg0 : i32 -> !s32i
-    cir.return %0 : !s32i
+  cir.func @no_fold_diff_type() -> !s32i {
+    %0 = llvm.mlir.constant(42 : i32) : i32
+    %1 = cir.builtin_int_cast %0 : i32 -> !s32i
+    cir.return %1 : !s32i
   }
 
-  // CHECK: cir.func{{.*}} @no_fold_diff_type(%[[ARG2:.+]]: i32) -> !s32i {
-  // CHECK-NEXT:   %[[CAST:.+]] = cir.builtin_int_cast %[[ARG2]] : i32 -> !s32i
+  // CHECK: cir.func{{.*}} @no_fold_diff_type() -> !s32i {
+  // CHECK-NEXT:   %[[VAL:.+]] = llvm.mlir.constant(42 : i32) : i32
+  // CHECK-NEXT:   %[[CAST:.+]] = cir.builtin_int_cast %[[VAL]] : i32 -> !s32i
   // CHECK-NEXT:   cir.return %[[CAST]] : !s32i
   // CHECK-NEXT: }
 }


### PR DESCRIPTION
The calling convention lowering pass expects cir.func operations to contain only CIR types in the signature. This change adds verifier support to enforce that.

In the process, I discovered that it wasn't possible to walk the subtypes of a CIR struct or union. The `AttrTypeSubElementHandler` implementation to handle that (including the TODO comment) is copied from the LLVM struct type handling.

Adding tests for this revealed a problem where if the `FuncType` verifier reports an error, the `FuncOp` parser asserted. This change fixes that by using `FuncType::getChecked()` to catch and report the error.