### PR TITLE
[LLDB] Fix tool dependency tracking on windows

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -162,6 +162,9 @@ override LD := $(CC)
 # A kind of linker. It always gets retrieved from CC.
 override LDC := $(CC_TYPE)
 
+# The bare path to the C++ compiler before it is converted into a shell word on windows.
+CXX_PATH := $(CXX)
+
 ifeq "$(HOST_OS)" "Windows_NT"
        # This function enframes the full path with the platform specific quotes. This is necessary to run the c++ executable
        # properly under 'sh' on Windows host (prevent the path breakage because of Windows style path separators).
@@ -667,20 +670,20 @@ endif
 #----------------------------------------------------------------------
 
 ifneq "$(PCH_OUTPUT)" ""
-$(PCH_OUTPUT) : $(PCH_CXX_SOURCE) $(call tool_prereq,$(CXX))
+$(PCH_OUTPUT) : $(PCH_CXX_SOURCE) $(call tool_prereq,$(CXX_PATH))
 	$(CXX) $(CXXFLAGS) -x c++-header -o $@ $<
 endif
 
 %.o: %.c %.d $(call tool_prereq,$(CC))
 	$(CC) $(CFLAGS) -MT $@ -MD -MP -MF $*.d -c -o $@ $<
 
-%.o: %.cpp %.d $(PCH_OUTPUT) $(call tool_prereq,$(CXX))
+%.o: %.cpp %.d $(PCH_OUTPUT) $(call tool_prereq,$(CXX_PATH))
 	$(CXX) $(PCHFLAGS) $(CXXFLAGS) -MT $@ -MD -MP -MF $*.d -c -o $@ $<
 
 %.o: %.m %.d $(call tool_prereq,$(CC))
 	$(CC) $(CFLAGS) -MT $@ -MD -MP -MF $*.d -c -o $@ $<
 
-%.o: %.mm %.d $(call tool_prereq,$(CXX))
+%.o: %.mm %.d $(call tool_prereq,$(CXX_PATH))
 	$(CXX) $(CXXFLAGS) -MT $@ -MD -MP -MF $*.d -c -o $@ $<
 
 #----------------------------------------------------------------------


### PR DESCRIPTION
On Windows $(CXX) is converted into "$(CXX)" which doesn't work as a path as needed by dependency tracking. Separate the two uses.