### PR TITLE
[lld][WebAssembly] Update incorrect assertion in global relocation code

### DIFF
--- a/lld/test/wasm/tls-init-symbols.s
+++ b/lld/test/wasm/tls-init-symbols.s
@@ -9,6 +9,7 @@
 
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t.o %s
 # RUN: wasm-ld -no-gc-sections --shared-memory -o %t.wasm %t.o
+# RUN: wasm-ld -no-gc-sections --shared-memory --extra-features=extended-const -o %t.extended.wasm %t.o
 # RUN: obj2yaml %t.wasm | FileCheck %s
 # RUN: llvm-objdump -d --no-show-raw-insn --no-leading-addr %t.wasm | FileCheck %s --check-prefixes DIS
 

--- a/lld/wasm/SyntheticSections.cpp
+++ b/lld/wasm/SyntheticSections.cpp
@@ -474,7 +474,7 @@ void GlobalSection::addInternalGOTEntry(Symbol *sym) {
 }
 
 void GlobalSection::generateRelocationCode(raw_ostream &os, bool TLS) const {
-  assert(!ctx.arg.extendedConst);
+  assert(!ctx.arg.extendedConst || TLS);
   bool is64 = ctx.arg.is64.value_or(false);
   unsigned opcode_ptr_add = is64 ? WASM_OPCODE_I64_ADD : WASM_OPCODE_I32_ADD;
 


### PR DESCRIPTION
When extended-const is enabled, non-TLS global relocations are handled via extended constant expressions. However, TLS GOT entries still require runtime relocation code in `__wasm_apply_global_tls_relocs` because TLS global addresses depend on `__tls_base`.

Allow `GlobalSection::generateRelocationCode` to be called when `TLS` is true even if `ctx.arg.extendedConst` is set.