### PR TITLE
[compiler-rt] Emit wrapper function for __eqsf2, __eqdf2 for SPIR-V

### DIFF
--- a/compiler-rt/lib/builtins/comparedf2.c
+++ b/compiler-rt/lib/builtins/comparedf2.c
@@ -67,9 +67,9 @@ COMPILER_RT_ALIAS(__unorddf2, __aeabi_dcmpun)
 #endif
 #endif
 
-#if defined(_WIN32) && !defined(__MINGW32__)
-// The alias mechanism doesn't work on Windows except for MinGW, so emit
-// wrapper functions.
+#if (defined(_WIN32) && !defined(__MINGW32__)) || defined(__SPIRV__)
+// The alias mechanism doesn't work on Windows (except for MinGW) or SPIR-V, so
+// emit wrapper functions.
 int __eqdf2(fp_t a, fp_t b) { return __ledf2(a, b); }
 int __ltdf2(fp_t a, fp_t b) { return __ledf2(a, b); }
 int __nedf2(fp_t a, fp_t b) { return __ledf2(a, b); }

--- a/compiler-rt/lib/builtins/comparesf2.c
+++ b/compiler-rt/lib/builtins/comparesf2.c
@@ -67,9 +67,9 @@ COMPILER_RT_ALIAS(__unordsf2, __aeabi_fcmpun)
 #endif
 #endif
 
-#if defined(_WIN32) && !defined(__MINGW32__)
-// The alias mechanism doesn't work on Windows except for MinGW, so emit
-// wrapper functions.
+#if (defined(_WIN32) && !defined(__MINGW32__)) || defined(__SPIRV__)
+// The alias mechanism doesn't work on Windows (except for MinGW) or SPIR-V, so
+// emit wrapper functions.
 int __eqsf2(fp_t a, fp_t b) { return __lesf2(a, b); }
 int __ltsf2(fp_t a, fp_t b) { return __lesf2(a, b); }
 int __nesf2(fp_t a, fp_t b) { return __lesf2(a, b); }


### PR DESCRIPTION
We disabled some compiler-rt builtins such as __eqsf2/__eqdf2 when building compiler-rt builtins for SPIR-V target since these functions depend on symbol alias which is not supported in core SPIR-V spec.
This PR follows Windows approach to support these builtins via emitting wrapper functions.