### PR TITLE
[NewPM] Register AsmPrinter passes like normal

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUPassRegistry.def
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPassRegistry.def
@@ -17,6 +17,8 @@
 #define MODULE_PASS(NAME, CREATE_PASS)
 #endif
 MODULE_PASS("amdgpu-always-inline", AMDGPUAlwaysInlinePass())
+MODULE_PASS("amdgpu-asm-printer-begin", AMDGPUAsmPrinterBeginPass())
+MODULE_PASS("amdgpu-asm-printer-end", AMDGPUAsmPrinterEndPass())
 MODULE_PASS("amdgpu-export-kernel-runtime-handles", AMDGPUExportKernelRuntimeHandlesPass())
 MODULE_PASS("amdgpu-lower-buffer-fat-pointers",
             AMDGPULowerBufferFatPointersPass(*this))
@@ -113,6 +115,7 @@ MACHINE_FUNCTION_ANALYSIS("amdgpu-next-use-analysis", AMDGPUNextUseAnalysisPass(
 #ifndef MACHINE_FUNCTION_PASS
 #define MACHINE_FUNCTION_PASS(NAME, CREATE_PASS)
 #endif
+MACHINE_FUNCTION_PASS("amdgpu-asm-printer", AMDGPUAsmPrinterPass())
 MACHINE_FUNCTION_PASS("amdgpu-insert-delay-alu", AMDGPUInsertDelayAluPass())
 MACHINE_FUNCTION_PASS("amdgpu-isel", AMDGPUISelDAGToDAGPass(*this))
 MACHINE_FUNCTION_PASS("amdgpu-lower-vgpr-encoding", AMDGPULowerVGPREncodingPass())

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -998,16 +998,6 @@ void AMDGPUTargetMachine::registerPassBuilderCallbacks(PassBuilder &PB) {
 #define GET_PASS_REGISTRY "AMDGPUPassRegistry.def"
 #include "llvm/Passes/TargetPassRegistry.inc"
 
-  // TODO: Move this into the base CodeGenPassBuilder once all
-  // targets that currently implement it have a ported asm-printer pass.
-  if (PIC) {
-    PIC->addClassToPassName(AMDGPUAsmPrinterBeginPass::name(),
-                            "amdgpu-asm-printer-begin");
-    PIC->addClassToPassName(AMDGPUAsmPrinterPass::name(), "amdgpu-asm-printer");
-    PIC->addClassToPassName(AMDGPUAsmPrinterEndPass::name(),
-                            "amdgpu-asm-printer-end");
-  }
-
   PB.registerPipelineParsingCallback(
       [this](StringRef Name, CGSCCPassManager &PM,
              ArrayRef<PassBuilder::PipelineElement> Pipeline) {

--- a/llvm/lib/Target/BPF/BPFCodeGenPassBuilder.cpp
+++ b/llvm/lib/Target/BPF/BPFCodeGenPassBuilder.cpp
@@ -101,15 +101,6 @@ static Expected<bool> parseBPFPreserveStaticOffsetOptions(StringRef Params) {
 void BPFTargetMachine::registerPassBuilderCallbacks(PassBuilder &PB) {
 #define GET_PASS_REGISTRY "BPFPassRegistry.def"
 #include "llvm/Passes/TargetPassRegistry.inc"
-  // TODO(boomanaiden154): Move this into the base CodeGenPassBuilder once all
-  // targets that currently implement it have a ported asm-printer pass.
-  if (PIC) {
-    PIC->addClassToPassName(BPFAsmPrinterBeginPass::name(),
-                            "bpf-asm-printer-begin");
-    PIC->addClassToPassName(BPFAsmPrinterPass::name(), "bpf-asmprinter");
-    PIC->addClassToPassName(BPFAsmPrinterEndPass::name(),
-                            "bpf-asm-printer-end");
-  }
 
   PB.registerPipelineStartEPCallback(
       [=](ModulePassManager &MPM, OptimizationLevel) {

--- a/llvm/lib/Target/BPF/BPFPassRegistry.def
+++ b/llvm/lib/Target/BPF/BPFPassRegistry.def
@@ -16,6 +16,8 @@
 #ifndef MODULE_PASS
 #define MODULE_PASS(NAME, CREATE_PASS)
 #endif
+MODULE_PASS("bpf-asm-printer-begin", BPFAsmPrinterBeginPass())
+MODULE_PASS("bpf-asm-printer-end", BPFAsmPrinterEndPass())
 MODULE_PASS("bpf-check-and-opt-ir", BPFCheckAndAdjustIRPass())
 #undef MODULE_PASS
 
@@ -40,6 +42,7 @@ FUNCTION_PASS_WITH_PARAMS(
 #ifndef MACHINE_FUNCTION_PASS
 #define MACHINE_FUNCTION_PASS(NAME, CREATE_PASS)
 #endif
+MACHINE_FUNCTION_PASS("bpf-asm-printer", BPFAsmPrinterPass())
 MACHINE_FUNCTION_PASS("bpf-mi-expand-stack-arg-pseudos", BPFMIExpandStackArgPseudosPass())
 MACHINE_FUNCTION_PASS("bpf-isel", BPFISelDAGToDAGPass(*this))
 MACHINE_FUNCTION_PASS("bpf-mi-checking", BPFMIPreEmitCheckingPass())

--- a/llvm/lib/Target/Lanai/LanaiCodeGenPassBuilder.cpp
+++ b/llvm/lib/Target/Lanai/LanaiCodeGenPassBuilder.cpp
@@ -73,18 +73,9 @@ void LanaiCodeGenPassBuilder::addAsmPrinterEnd(PassManagerWrapper &PMW) const {
 
 } // namespace
 
-void LanaiTargetMachine::registerPassBuilderCallbacks(PassBuilder &PB) {
+void LanaiTargetMachine::registerPassBuilderCallbacks(PassBuilder &PB){
 #define GET_PASS_REGISTRY "LanaiPassRegistry.def"
 #include "llvm/Passes/TargetPassRegistry.inc"
-  // TODO(boomanaiden154): Move this into the base CodeGenPassBuilder once all
-  // targets that currently implement it have a ported asm-printer pass.
-  if (PIC) {
-    PIC->addClassToPassName(LanaiAsmPrinterBeginPass::name(),
-                            "lanai-asm-printer-begin");
-    PIC->addClassToPassName(LanaiAsmPrinterPass::name(), "lanai-asmprinter");
-    PIC->addClassToPassName(LanaiAsmPrinterEndPass::name(),
-                            "lanai-asm-printer-end");
-  }
 }
 
 Error LanaiTargetMachine::buildCodeGenPipeline(

--- a/llvm/lib/Target/Lanai/LanaiPassRegistry.def
+++ b/llvm/lib/Target/Lanai/LanaiPassRegistry.def
@@ -13,9 +13,17 @@
 
 // NOTE: NO INCLUDE GUARD DESIRED!
 
+#ifndef MODULE_PASS
+#define MODULE_PASS(NAME, CREATE_PASS)
+#endif
+MODULE_PASS("lanai-asm-printer-begin", LanaiAsmPrinterBeginPass())
+MODULE_PASS("lanai-asm-printer-end", LanaiAsmPrinterEndPass())
+#undef MODULE_PASS
+
 #ifndef MACHINE_FUNCTION_PASS
 #define MACHINE_FUNCTION_PASS(NAME, CREATE_PASS)
 #endif
+MACHINE_FUNCTION_PASS("lanai-asm-printer", LanaiAsmPrinterPass())
 MACHINE_FUNCTION_PASS("lanai-delay-slot-fillter", LanaiDelaySlotFillerPass())
 MACHINE_FUNCTION_PASS("lanai-isel", LanaiISelDAGToDAGPass(*this))
 MACHINE_FUNCTION_PASS("lanai-mem-alu-combiner", LanaiMemAluCombinerPass())

--- a/llvm/lib/Target/MSP430/MSP430CodeGenPassBuilder.cpp
+++ b/llvm/lib/Target/MSP430/MSP430CodeGenPassBuilder.cpp
@@ -70,18 +70,9 @@ void MSP430CodeGenPassBuilder::addAsmPrinterEnd(PassManagerWrapper &PMW) const {
 
 } // namespace
 
-void MSP430TargetMachine::registerPassBuilderCallbacks(PassBuilder &PB) {
+void MSP430TargetMachine::registerPassBuilderCallbacks(PassBuilder &PB){
 #define GET_PASS_REGISTRY "MSP430PassRegistry.def"
 #include "llvm/Passes/TargetPassRegistry.inc"
-  // TODO(boomanaiden154): Move this into the base CodeGenPassBuilder once all
-  // targets that currently implement it have a ported asm-printer pass.
-  if (PIC) {
-    PIC->addClassToPassName(MSP430AsmPrinterBeginPass::name(),
-                            "msp430-asm-printer-begin");
-    PIC->addClassToPassName(MSP430AsmPrinterPass::name(), "msp430-asm-printer");
-    PIC->addClassToPassName(MSP430AsmPrinterEndPass::name(),
-                            "msp430-asm-printer-end");
-  }
 }
 
 Error MSP430TargetMachine::buildCodeGenPipeline(

--- a/llvm/lib/Target/MSP430/MSP430PassRegistry.def
+++ b/llvm/lib/Target/MSP430/MSP430PassRegistry.def
@@ -13,9 +13,17 @@
 
 // NOTE: NO INCLUDE GUARD DESIRED!
 
+#ifndef MODULE_PASS
+#define MODULE_PASS(NAME, CREATE_PASS)
+#endif
+MODULE_PASS("msp430-asm-printer-begin", MSP430AsmPrinterBeginPass())
+MODULE_PASS("msp430-asm-printer-end", MSP430AsmPrinterEndPass())
+#undef MODULE_PASS
+
 #ifndef MACHINE_FUNCTION_PASS
 #define MACHINE_FUNCTION_PASS(NAME, CREATE_PASS)
 #endif
+MACHINE_FUNCTION_PASS("msp430-asm-printer", MSP430AsmPrinterPass())
 MACHINE_FUNCTION_PASS("msp430-isel", MSP430ISelDAGToDAGPass(*this, getOptLevel()))
 MACHINE_FUNCTION_PASS("msp430-branch-select", MSP430BranchSelectPass())
 #undef MACHINE_FUNCTION_PASS

--- a/llvm/lib/Target/NVPTX/NVPTXPassRegistry.def
+++ b/llvm/lib/Target/NVPTX/NVPTXPassRegistry.def
@@ -17,6 +17,8 @@
 #define MODULE_PASS(NAME, CREATE_PASS)
 #endif
 MODULE_PASS("generic-to-nvvm", GenericToNVVMPass())
+MODULE_PASS("nvptx-asm-printer-begin", NVPTXAsmPrinterBeginPass())
+MODULE_PASS("nvptx-asm-printer-end", NVPTXAsmPrinterEndPass())
 MODULE_PASS("nvptx-lower-args", NVPTXLowerArgsPass(*this))
 MODULE_PASS("nvptx-lower-ctor-dtor", NVPTXCtorDtorLoweringPass())
 MODULE_PASS("nvptx-promote-param-align", NVPTXPromoteParamAlignPass())
@@ -57,6 +59,7 @@ FUNCTION_PASS("nvptx-lower-alloca", NVPTXLowerAllocaPass())
 #ifndef MACHINE_FUNCTION_PASS
 #define MACHINE_FUNCTION_PASS(NAME, CREATE_PASS)
 #endif
+MACHINE_FUNCTION_PASS("nvptx-asm-printer", NVPTXAsmPrinterPass())
 MACHINE_FUNCTION_PASS("nvptx-replace-image-handles",
                       NVPTXReplaceImageHandlesPass())
 MACHINE_FUNCTION_PASS("nvptx-isel", NVPTXISelDAGToDAGPass(*this, getOptLevel()))

--- a/llvm/lib/Target/NVPTX/NVPTXTargetMachine.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXTargetMachine.cpp
@@ -203,16 +203,6 @@ void NVPTXTargetMachine::registerPassBuilderCallbacks(PassBuilder &PB) {
 #define GET_PASS_REGISTRY "NVPTXPassRegistry.def"
 #include "llvm/Passes/TargetPassRegistry.inc"
 
-  // TODO: Move this into the base CodeGenPassBuilder once all targets that
-  // currently implement it have a ported asm-printer pass.
-  if (PIC) {
-    PIC->addClassToPassName(NVPTXAsmPrinterBeginPass::name(),
-                            "nvptx-asm-printer-begin");
-    PIC->addClassToPassName(NVPTXAsmPrinterPass::name(), "nvptx-asm-printer");
-    PIC->addClassToPassName(NVPTXAsmPrinterEndPass::name(),
-                            "nvptx-asm-printer-end");
-  }
-
   PB.registerPipelineStartEPCallback(
       [this](ModulePassManager &PM, OptimizationLevel Level) {
         // We do not want to fold out calls to nvvm.reflect early if the user

--- a/llvm/lib/Target/RISCV/RISCVCodeGenPassBuilder.cpp
+++ b/llvm/lib/Target/RISCV/RISCVCodeGenPassBuilder.cpp
@@ -218,16 +218,6 @@ void RISCVTargetMachine::registerPassBuilderCallbacks(PassBuilder &PB) {
     if (Level != OptimizationLevel::O0)
       LPM.addPass(LoopIdiomVectorizePass(LoopIdiomVectorizeStyle::Predicated));
   });
-
-  // TODO: Move this into the base CodeGenPassBuilder once all targets that
-  // currently implement it have a ported asm-printer pass.
-  if (PIC) {
-    PIC->addClassToPassName(RISCVAsmPrinterBeginPass::name(),
-                            "riscv-asm-printer-begin");
-    PIC->addClassToPassName(RISCVAsmPrinterPass::name(), "riscv-asm-printer");
-    PIC->addClassToPassName(RISCVAsmPrinterEndPass::name(),
-                            "riscv-asm-printer-end");
-  }
 }
 
 Error RISCVTargetMachine::buildCodeGenPipeline(

--- a/llvm/lib/Target/RISCV/RISCVPassRegistry.def
+++ b/llvm/lib/Target/RISCV/RISCVPassRegistry.def
@@ -13,6 +13,13 @@
 
 // NOTE: NO INCLUDE GUARD DESIRED!
 
+#ifndef MODULE_PASS
+#define MODULE_PASS(NAME, CREATE_PASS)
+#endif
+MODULE_PASS("riscv-asm-printer-begin", RISCVAsmPrinterBeginPass())
+MODULE_PASS("riscv-asm-printer-end", RISCVAsmPrinterEndPass())
+#undef MODULE_PASS
+
 #ifndef FUNCTION_PASS
 #define FUNCTION_PASS(NAME, CREATE_PASS)
 #endif
@@ -25,5 +32,6 @@ FUNCTION_PASS("riscv-zacas-abi-fix", RISCVZacasABIFixPass(this))
 #ifndef MACHINE_FUNCTION_PASS
 #define MACHINE_FUNCTION_PASS(NAME, CREATE_PASS)
 #endif
+MACHINE_FUNCTION_PASS("riscv-asm-printer", RISCVAsmPrinterPass())
 MACHINE_FUNCTION_PASS("riscv-isel", RISCVISelDAGToDAGPass(*this, getOptLevel()))
 #undef MACHINE_FUNCTION_PASS

--- a/llvm/lib/Target/WebAssembly/WebAssemblyCodeGenPassBuilder.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyCodeGenPassBuilder.cpp
@@ -279,19 +279,9 @@ void WebAssemblyCodeGenPassBuilder::addAsmPrinterEnd(
 
 } // namespace
 
-void WebAssemblyTargetMachine::registerPassBuilderCallbacks(PassBuilder &PB) {
+void WebAssemblyTargetMachine::registerPassBuilderCallbacks(PassBuilder &PB){
 #define GET_PASS_REGISTRY "WebAssemblyPassRegistry.def"
 #include "llvm/Passes/TargetPassRegistry.inc"
-  // TODO(boomanaiden154): Move this into the base CodeGenPassBuilder once all
-  // targets that currently implement it have a ported asm-printer pass.
-  if (PIC) {
-    PIC->addClassToPassName(WebAssemblyAsmPrinterBeginPass::name(),
-                            "wasm-asm-printer-begin");
-    PIC->addClassToPassName(WebAssemblyAsmPrinterPass::name(),
-                            "wasm-asm-printer");
-    PIC->addClassToPassName(WebAssemblyAsmPrinterEndPass::name(),
-                            "wasm-asm-printer-end");
-  }
 }
 
 Error WebAssemblyTargetMachine::buildCodeGenPipeline(

--- a/llvm/lib/Target/WebAssembly/WebAssemblyPassRegistry.def
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyPassRegistry.def
@@ -21,6 +21,8 @@ MACHINE_MODULE_PASS("wasm-mclower-prepass", WebAssemblyMCLowerPrePass())
 #define MODULE_PASS(NAME, CREATE_PASS)
 #endif
 MODULE_PASS("wasm-add-missing-prototypes", WebAssemblyAddMissingPrototypesPass())
+MODULE_PASS("wasm-asm-printer-begin", WebAssemblyAsmPrinterBeginPass())
+MODULE_PASS("wasm-asm-printer-end", WebAssemblyAsmPrinterEndPass())
 MODULE_PASS("wasm-coalesce-features-and-strip-atomics",
             WebAssemblyCoalesceFeaturesAndStripAtomicsPass(*this))
 MODULE_PASS("wasm-fix-function-bitcasts", WebAssemblyFixFunctionBitcastsPass())
@@ -45,6 +47,7 @@ MACHINE_FUNCTION_ANALYSIS("wasm-exception-info", WebAssemblyExceptionAnalysis())
 #define MACHINE_FUNCTION_PASS(NAME, CREATE_PASS)
 #endif
 MACHINE_FUNCTION_PASS("wasm-argument-move", WebAssemblyArgumentMovePass())
+MACHINE_FUNCTION_PASS("wasm-asm-printer", WebAssemblyAsmPrinterPass())
 MACHINE_FUNCTION_PASS("wasm-cfg-sort", WebAssemblyCFGSortPass())
 MACHINE_FUNCTION_PASS("wasm-cfg-stackify", WebAssemblyCFGStackifyPass())
 MACHINE_FUNCTION_PASS("wasm-clean-code-after-trap",

--- a/llvm/lib/Target/X86/X86CodeGenPassBuilder.cpp
+++ b/llvm/lib/Target/X86/X86CodeGenPassBuilder.cpp
@@ -275,18 +275,9 @@ void X86CodeGenPassBuilder::addAsmPrinterEnd(PassManagerWrapper &PMW) const {
 
 } // namespace
 
-void X86TargetMachine::registerPassBuilderCallbacks(PassBuilder &PB) {
+void X86TargetMachine::registerPassBuilderCallbacks(PassBuilder &PB){
 #define GET_PASS_REGISTRY "X86PassRegistry.def"
 #include "llvm/Passes/TargetPassRegistry.inc"
-  // TODO(boomanaiden154): Move this into the base CodeGenPassBuilder once all
-  // targets that currently implement it have a ported asm-printer pass.
-  if (PIC) {
-    PIC->addClassToPassName(X86AsmPrinterBeginPass::name(),
-                            "x86-asm-printer-begin");
-    PIC->addClassToPassName(X86AsmPrinterPass::name(), "x86-asm-printer");
-    PIC->addClassToPassName(X86AsmPrinterEndPass::name(),
-                            "x86-asm-printer-end");
-  }
 }
 
 Error X86TargetMachine::buildCodeGenPipeline(

--- a/llvm/lib/Target/X86/X86PassRegistry.def
+++ b/llvm/lib/Target/X86/X86PassRegistry.def
@@ -15,6 +15,8 @@
 #ifndef MODULE_PASS
 #define MODULE_PASS(NAME, CREATE_PASS)
 #endif
+MODULE_PASS("x86-asm-printer-begin", X86AsmPrinterBeginPass())
+MODULE_PASS("x86-asm-printer-end", X86AsmPrinterEndPass())
 MODULE_PASS("x86-winehstate", X86WinEHStatePass())
 #undef MODULE_PASS
 
@@ -30,6 +32,7 @@ FUNCTION_PASS("x86-partial-reduction", X86PartialReductionPass(this))
 #define MACHINE_FUNCTION_PASS(NAME, CREATE_PASS)
 #endif
 MACHINE_FUNCTION_PASS("x86-argument-stack-slot", X86ArgumentStackSlotPass())
+MACHINE_FUNCTION_PASS("x86-asm-printer", X86AsmPrinterPass())
 MACHINE_FUNCTION_PASS("x86-avoid-sfb", X86AvoidStoreForwardingBlocksPass())
 MACHINE_FUNCTION_PASS("x86-avoid-trailing-call", X86AvoidTrailingCallPass())
 MACHINE_FUNCTION_PASS("x86-cf-opt", X86CallFrameOptimizationPass())

--- a/llvm/test/CodeGen/Lanai/llc-pipeline-npm.ll
+++ b/llvm/test/CodeGen/Lanai/llc-pipeline-npm.ll
@@ -87,6 +87,6 @@
 ; CHECK:     machine-sanmd
 ; CHECK:     stack-frame-layout
 ; CHECK:     verify
-; CHECK:     lanai-asmprinter
+; CHECK:     lanai-asm-printer
 ; CHECK:   free-machine-function
 ; CHECK: lanai-asm-printer-end


### PR DESCRIPTION
This avoids needing to do anything custom in
registerPassBuilderCallbacks. Also does some cleanup around inconsistent naming.

I'm not really sure why I didn't do this before. Eventually I think we want to delete AsmPrinterBegin and AsmPrinterEnd, but that requires a lot of work that we probably can't do until we delete the LegacyPM version of AsmPrinter.