### PR TITLE
[flang] Improve the error message for the option "-fconvert" with allowed values

### DIFF
--- a/clang/include/clang/Options/FlangOptions.td
+++ b/clang/include/clang/Options/FlangOptions.td
@@ -148,6 +148,7 @@ def ffixed_line_length_EQ : Joined<["-"], "ffixed-line-length=">, Group<f_Group>
 file}]>;
 def ffixed_line_length_VALUE : Joined<["-"], "ffixed-line-length-">, Group<f_Group>, Alias<ffixed_line_length_EQ>;
 def fconvert_EQ : Joined<["-"], "fconvert=">, Group<f_Group>,
+  Values<"unknown,native,little-endian,big-endian,swap">,
   HelpText<"Set endian conversion of data for unformatted files">;
 def fdefault_double_8 : Flag<["-"],"fdefault-double-8">, Group<f_Group>,
   HelpText<"Set the default double precision kind to an 8 byte wide type">;

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -887,8 +887,10 @@ static bool parseFrontendArgs(FrontendOptions &opts, llvm::opt::ArgList &args,
     if (auto convert = parseConvertArg(argValue))
       opts.envDefaults.push_back({"FORT_CONVERT", *convert});
     else
-      diags.Report(clang::diag::err_drv_invalid_value)
-          << arg->getAsString(args) << argValue;
+      diags.Report(clang::diag::err_drv_invalid_value_with_suggestion)
+          << arg->getAsString(args) << argValue
+          << clang::getDriverOptTable().getOptionValues(
+                 clang::options::OPT_fconvert_EQ);
   }
 
   // -f{no-}implicit-none

--- a/flang/test/Driver/convert.f90
+++ b/flang/test/Driver/convert.f90
@@ -10,7 +10,6 @@
 ! RUN: %flang -### -fconvert=big-endian %s  2>&1 | FileCheck %s --check-prefix=VALID
 ! RUN: %flang -### -fconvert=swap %s  2>&1 | FileCheck %s --check-prefix=VALID
 ! RUN: not %flang -fconvert=foobar %s  2>&1 | FileCheck %s --check-prefix=INVALID
-! RUN: not %flang -fconvert=big_endian %s  2>&1 | FileCheck %s --check-prefix=INVALID-BIG-ENDIAN
 
 !-----------------------------------------
 ! FRONTEND FLANG DRIVER (flang -fc1)
@@ -21,7 +20,6 @@
 ! RUN: %flang_fc1 -emit-mlir -fconvert=big-endian %s -o - | FileCheck %s --check-prefix=VALID_FC1
 ! RUN: %flang_fc1 -emit-mlir -fconvert=swap %s -o - | FileCheck %s --check-prefix=VALID_FC1
 ! RUN: not %flang_fc1 -fconvert=foobar %s  2>&1 | FileCheck %s --check-prefix=INVALID
-! RUN: not %flang_fc1 -fconvert=big_endian %s  2>&1 | FileCheck %s --check-prefix=INVALID-BIG-ENDIAN
 
 ! Only test that the command executes without error. Correct handling of each
 ! option is handled in Lowering tests.
@@ -29,4 +27,3 @@
 ! VALID_FC1: module
 
 ! INVALID: error: invalid value 'foobar' in '-fconvert=foobar', expected one of: unknown,native,little-endian,big-endian,swap
-! INVALID-BIG-ENDIAN: error: invalid value 'big_endian' in '-fconvert=big_endian', expected one of: unknown,native,little-endian,big-endian,swap

--- a/flang/test/Driver/convert.f90
+++ b/flang/test/Driver/convert.f90
@@ -10,6 +10,7 @@
 ! RUN: %flang -### -fconvert=big-endian %s  2>&1 | FileCheck %s --check-prefix=VALID
 ! RUN: %flang -### -fconvert=swap %s  2>&1 | FileCheck %s --check-prefix=VALID
 ! RUN: not %flang -fconvert=foobar %s  2>&1 | FileCheck %s --check-prefix=INVALID
+! RUN: not %flang -fconvert=big_endian %s  2>&1 | FileCheck %s --check-prefix=INVALID-BIG-ENDIAN
 
 !-----------------------------------------
 ! FRONTEND FLANG DRIVER (flang -fc1)
@@ -20,10 +21,12 @@
 ! RUN: %flang_fc1 -emit-mlir -fconvert=big-endian %s -o - | FileCheck %s --check-prefix=VALID_FC1
 ! RUN: %flang_fc1 -emit-mlir -fconvert=swap %s -o - | FileCheck %s --check-prefix=VALID_FC1
 ! RUN: not %flang_fc1 -fconvert=foobar %s  2>&1 | FileCheck %s --check-prefix=INVALID
+! RUN: not %flang_fc1 -fconvert=big_endian %s  2>&1 | FileCheck %s --check-prefix=INVALID-BIG-ENDIAN
 
 ! Only test that the command executes without error. Correct handling of each
 ! option is handled in Lowering tests.
 ! VALID: -fconvert
 ! VALID_FC1: module
 
-! INVALID: error: invalid value 'foobar' in '-fconvert=foobar'
+! INVALID: error: invalid value 'foobar' in '-fconvert=foobar', expected one of: unknown,native,little-endian,big-endian,swap
+! INVALID-BIG-ENDIAN: error: invalid value 'big_endian' in '-fconvert=big_endian', expected one of: unknown,native,little-endian,big-endian,swap

--- a/llvm/include/llvm/Option/OptTable.h
+++ b/llvm/include/llvm/Option/OptTable.h
@@ -326,6 +326,13 @@ public:
     return (*StrTable)[getInfo(id).MetaVarOffset];
   }
 
+  /// Get the comma-separated list of values accepted by this option, as
+  /// declared by `Values` in its TableGen definition. Returns an empty string
+  /// for options that do not declare any.
+  StringRef getOptionValues(OptSpecifier id) const {
+    return StringRef(getInfo(id).Values);
+  }
+
   /// Specify the environment variable where initial options should be read.
   void setInitialOptionsFromEnvironment(const char *E) { EnvVar = E; }
 


### PR DESCRIPTION
	For the option "-fconvert=foobar"

	Earlier error message:
	error: invalid value 'foobar' in '-fconvert=foobar'

	Updated Error message:
	error: invalid value 'foobar' in '-fconvert=foobar', expected one of: unknown,native,little-endian,big-endian,swap