### PR TITLE
[clang][modules] Cache failures for explicit modules

### DIFF
--- a/clang/lib/Serialization/ModuleManager.cpp
+++ b/clang/lib/Serialization/ModuleManager.cpp
@@ -56,7 +56,7 @@ ModuleManager::makeKey(const ModuleFileName &Name) const {
       return ModuleFileKey(Buf);
   } else {
     if (auto ModuleFile = FileMgr.getOptionalFileRef(Name, /*OpenFile=*/true,
-                                                     /*CacheFailure=*/false,
+                                                     /*CacheFailure=*/true,
                                                      /*IsText=*/false))
       return ModuleFileKey(*ModuleFile);
   }
@@ -206,7 +206,7 @@ AddModuleResult ModuleManager::addModule(
           FileName == StringRef("-")
               ? FileMgr.getSTDIN()
               : FileMgr.getFileRef(FileName, /*OpenFile=*/true,
-                                   /*CacheFailure=*/false,
+                                   /*CacheFailure=*/true,
                                    /*IsText=*/false);
       if (!Entry)
         return Entry.takeError();


### PR DESCRIPTION
Explicit module files are a (binary) input to the compilation. Just like any other input file they are expected to not change during compilation. There's no reason to disable failure caching in the `FileManager` for them.