### PR TITLE
[clang][test] Cache failed stats in a unit test

### DIFF
--- a/clang/unittests/Frontend/ASTUnitTest.cpp
+++ b/clang/unittests/Frontend/ASTUnitTest.cpp
@@ -193,7 +193,7 @@ TEST_F(ASTUnitTest, ModuleTextualHeader) {
       CInvok, PCHContainerOps, DiagOpts, Diags, FileMgr, false,
       CaptureDiagsKind::None, 1, TU_Complete, false, false, false);
   ASSERT_TRUE(AU);
-  auto File = AU->getFileManager().getFileRef("Textual.h", false, false);
+  auto File = AU->getFileManager().getFileRef("Textual.h");
   ASSERT_TRUE(bool(File));
   // Verify that we do not crash here.
   EXPECT_TRUE(


### PR DESCRIPTION
I'd like to remove the possibility of disabling caching of failures in `FileManager`, and this test is one of the few users of that feature. There's no reason to disable failure caching in the `FileManager` here.