### PR TITLE
[orc-rt] Update orc_rt::sps_ci::addAll to include new SPS CI.

### DIFF
--- a/orc-rt/lib/executor/sps-ci/AllSPSCI.cpp
+++ b/orc-rt/lib/executor/sps-ci/AllSPSCI.cpp
@@ -11,13 +11,23 @@
 //===----------------------------------------------------------------------===//
 
 #include "orc-rt/sps-ci/AllSPSCI.h"
+#include "orc-rt/sps-ci/CallSPSCI.h"
+#include "orc-rt/sps-ci/GDBJITRegistrarSPSCI.h"
+#include "orc-rt/sps-ci/MemoryAccessSPSCI.h"
+#include "orc-rt/sps-ci/NativeDylibManagerSPSCI.h"
 #include "orc-rt/sps-ci/SimpleNativeMemoryMapSPSCI.h"
+#include "orc-rt/sps-ci/StandaloneMachOUnwindInfoRegistrarSPSCI.h"
 
 namespace orc_rt::sps_ci {
 
 Error addAll(SimpleSymbolTable &ST) {
   using AdderFn = Error (*)(SimpleSymbolTable &);
-  AdderFn Adders[] = {addSimpleNativeMemoryMap};
+  AdderFn Adders[] = {addCall,
+                      addGDBJITRegistrar,
+                      addMemoryAccess,
+                      addNativeDylibManager,
+                      addSimpleNativeMemoryMap,
+                      addStandaloneMachOUnwindInfoRegistrar};
 
   for (auto *Adder : Adders)
     if (auto Err = Adder(ST))


### PR DESCRIPTION
sps_ci::addAll should add all SPS CI (Controller Interface) symbols to the given map.

Update it to include recently added SPS CI (Calls, GDBJITRegistrar, MemoryAccess, NativeDylibManager, and
StandaloneMachOUnwindInfoRegistrar)