### PR TITLE
[Flang] Avoid crash on invalid EQUIVALENCE objects

### DIFF
--- a/flang/lib/Semantics/compute-offsets.cpp
+++ b/flang/lib/Semantics/compute-offsets.cpp
@@ -212,7 +212,9 @@ void ComputeOffsetsHelper::Compute(Scope &scope) {
   for (auto &[symbol, dep] : dependents_) {
     symbol->set_offset(dep.symbol->offset() + dep.offset);
     if (const auto *block{FindCommonBlockContaining(*dep.symbol)}) {
-      symbol->get<ObjectEntityDetails>().set_commonBlock(*block);
+      if (auto *object{symbol->detailsIf<ObjectEntityDetails>()}) {
+        object->set_commonBlock(*block);
+      }
     }
   }
 }

--- a/flang/test/Semantics/equivalence-non-data-object.f90
+++ b/flang/test/Semantics/equivalence-non-data-object.f90
@@ -1,0 +1,7 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1
+
+subroutine test3()
+  common /blk/ k1
+  ! ERROR: 'test3' in equivalence set is not a data object
+  equivalence(i1, TEST3, k1) 
+end subroutine test3


### PR DESCRIPTION
An invalid EQUIVALENCE statement may introduce a symbol that is not a data object into later offset computation. ComputeOffsetsHelper assumes such symbols have ObjectEntityDetails when assigning COMMON block information, which can cause a crash after a semantic error.

Check for ObjectEntityDetails before accessing object-specific information to keep error recovery paths safe.

Test coverage
- Add a regression test for using a subroutine name as an EQUIVALENCE object.

Tests:
- llvm-lit -v flang/test/Semantics/equivalence-non-data-object.f90


Fixes https://github.com/llvm/llvm-project/issues/210047