### PR TITLE
[mlir] Remove dead declaration computeSum

### DIFF
--- a/mlir/include/mlir/Dialect/Utils/IndexingUtils.h
+++ b/mlir/include/mlir/Dialect/Utils/IndexingUtils.h
@@ -55,9 +55,6 @@ SmallVector<int64_t> computeElementwiseMul(ArrayRef<int64_t> v1,
                                            ArrayRef<int64_t> v2);
 
 /// Self-explicit.
-int64_t computeSum(ArrayRef<int64_t> basis);
-
-/// Self-explicit.
 int64_t computeProduct(ArrayRef<int64_t> basis);
 
 /// Return the number of elements of basis (i.e. the max linear index).


### PR DESCRIPTION
The corresponding function definition was removed on October 11, 2025
in commit 0820266651649c0eb6c384df91da4c6f662e5136.
