### PR TITLE
[InstCombine] Avoid rewriting multi-use post-inc latch icmps

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -5385,9 +5385,12 @@ Instruction *InstCombinerImpl::foldICmpBinOp(ICmpInst &I,
     // icmp sgt (A + 1), Op1 -> icmp sge A, Op1
     // icmp ule (A + 1), Op0 -> icmp ult A, Op1
     // icmp ugt (A + 1), Op0 -> icmp uge A, Op1
+    // Do not strictness-fold icmp (add X, C), Y to icmp on X when the add has
+    // other users (e.g. a phi backedge on the latch increment).
     if (A && NoOp0WrapProblem &&
         ShareCommonDivisor(A, Op1, B,
-                           ICmpInst::isLT(Pred) || ICmpInst::isGE(Pred)))
+                           ICmpInst::isLT(Pred) || ICmpInst::isGE(Pred)) &&
+        (!BO0 || BO0->hasOneUse()))
       return new ICmpInst(ICmpInst::getFlippedStrictnessPredicate(Pred), A,
                           Op1);
 
@@ -5399,7 +5402,8 @@ Instruction *InstCombinerImpl::foldICmpBinOp(ICmpInst &I,
     // icmp ult Op0, (C + 1) -> icmp ule Op0, C
     if (C && NoOp1WrapProblem &&
         ShareCommonDivisor(Op0, C, D,
-                           ICmpInst::isGT(Pred) || ICmpInst::isLE(Pred)))
+                           ICmpInst::isGT(Pred) || ICmpInst::isLE(Pred)) &&
+        (!BO1 || BO1->hasOneUse()))
       return new ICmpInst(ICmpInst::getFlippedStrictnessPredicate(Pred), Op0,
                           C);
   }

--- a/llvm/test/Transforms/InstCombine/icmp-add.ll
+++ b/llvm/test/Transforms/InstCombine/icmp-add.ll
@@ -1982,7 +1982,7 @@ define <2 x i1> @slt_zero_add_nsw_splat_vec(<2 x i8> %a) {
 define void @latch_inc_phi_user(i32 %sub) {
 ; CHECK-LABEL: @latch_inc_phi_user(
 ; CHECK: [[INC:%.*]] = add nuw nsw i32 [[J:%.*]], 1
-; CHECK: icmp slt i32 [[J]], [[SUB:%.*]]
+; CHECK: icmp sgt i32 [[INC]], [[SUB:%.*]]
   entry:
   br label %loop
 
@@ -1998,8 +1998,7 @@ exit:
 
 define void @latch_inc_phi_user_sle(i32 %sub) {
 ; CHECK-LABEL: @latch_inc_phi_user_sle(
-; CHECK: [[INC:%.*]] = add nuw nsw i32 [[J:%.*]], 1
-; CHECK: icmp slt i32 [[J]], [[SUB:%.*]]
+; CHECK: icmp sgt i32 [[INC:%.*]], [[SUB:%.*]]
   entry:
   br label %loop
 loop:
@@ -2013,7 +2012,7 @@ exit:
 
 define void @latch_inc_phi_user_ugt(i32 %sub) {
 ; CHECK-LABEL: @latch_inc_phi_user_ugt(
-; CHECK: icmp ult i32 [[J:%.*]], [[SUB:%.*]]
+; CHECK: icmp ugt i32 [[INC:%.*]], [[SUB:%.*]]
   entry:
   br label %loop
 loop:

--- a/llvm/test/Transforms/InstCombine/icmp-add.ll
+++ b/llvm/test/Transforms/InstCombine/icmp-add.ll
@@ -1979,6 +1979,52 @@ define <2 x i1> @slt_zero_add_nsw_splat_vec(<2 x i8> %a) {
   ret <2 x i1> %cmp
 }
 
+define void @latch_inc_phi_user(i32 %sub) {
+; CHECK-LABEL: @latch_inc_phi_user(
+; CHECK: [[INC:%.*]] = add nuw nsw i32 [[J:%.*]], 1
+; CHECK: icmp slt i32 [[J]], [[SUB:%.*]]
+  entry:
+  br label %loop
+
+loop:
+  %j = phi i32 [ 0, %entry ], [ %inc, %loop ]
+  %inc = add nuw nsw i32 %j, 1
+  %cmp = icmp sgt i32 %inc, %sub
+  br i1 %cmp, label %exit, label %loop
+
+exit:
+  ret void
+}
+
+define void @latch_inc_phi_user_sle(i32 %sub) {
+; CHECK-LABEL: @latch_inc_phi_user_sle(
+; CHECK: [[INC:%.*]] = add nuw nsw i32 [[J:%.*]], 1
+; CHECK: icmp slt i32 [[J]], [[SUB:%.*]]
+  entry:
+  br label %loop
+loop:
+  %j = phi i32 [ 0, %entry ], [ %inc, %loop ]
+  %inc = add nsw i32 %j, 1
+  %cmp = icmp sle i32 %inc, %sub
+  br i1 %cmp, label %exit, label %loop
+exit:
+  ret void
+}
+
+define void @latch_inc_phi_user_ugt(i32 %sub) {
+; CHECK-LABEL: @latch_inc_phi_user_ugt(
+; CHECK: icmp ult i32 [[J:%.*]], [[SUB:%.*]]
+  entry:
+  br label %loop
+loop:
+  %j = phi i32 [ 0, %entry ], [ %inc, %loop ]
+  %inc = add nuw i32 %j, 1
+  %cmp = icmp ugt i32 %inc, %sub
+  br i1 %cmp, label %exit, label %loop
+exit:
+  ret void
+}
+
 ; Test the edges - instcombine should not interfere with simplification to constants.
 ; Constant subtraction does not overflow, but this is false.
 

--- a/llvm/test/Transforms/LoopStrengthReduce/latch-inc-lsr.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/latch-inc-lsr.ll
@@ -1,0 +1,118 @@
+; RUN: opt < %s -passes='instcombine,indvars' -indvars-widen-indvars=false -S \
+; RUN:   | opt -passes=loop-reduce -S | FileCheck %s
+
+target datalayout = "e-m:w-p:64:64-i32:32-i64:64-i128:128-n32:64-S128"
+
+declare void @usef(float)
+
+define void @gpu_addr_hoist(i32 %tmp20, i64 %sub47, i64 %stride, i32 %sub, ptr %tau1) {
+; CHECK-LABEL: @gpu_addr_hoist(
+; CHECK: call i32 @llvm.smax.i32(i32 [[SUB:%.*]], i32 0)
+; CHECK: body:
+; CHECK: sext i32 {{%.*}} to i64
+; CHECK: mul nsw i64 [[STRIDE:%.*]], {{%.*}}
+; CHECK: add nsw i64 [[SUB47:%.*]], {{%.*}}
+; CHECK: shl nsw i64 {{%.*}}, 2
+; CHECK: getelementptr inbounds i8, ptr [[TAU1:%.*]], i64 {{%.*}}
+; CHECK: load float, ptr {{%.*}}
+; CHECK: icmp ne i32 {{%.*}}, 0
+entry:
+  br label %pre
+pre:
+  br label %body
+body:
+  %j = phi i32 [ 0, %pre ], [ %inc, %cond ]
+  %add43 = add nsw i32 %j, %tmp20
+  %conv50 = sext i32 %add43 to i64
+  %mul51 = mul nsw i64 %stride, %conv50
+  %add52 = add nsw i64 %sub47, %mul51
+  %idx = shl nsw i64 %add52, 2
+  %gep = getelementptr inbounds i8, ptr %tau1, i64 %idx
+  %val = load float, ptr %gep, align 4
+  call void @usef(float %val)
+  br label %cond
+cond:
+  %inc = add nuw nsw i32 %j, 1
+  %cmp = icmp sgt i32 %inc, %sub
+  br i1 %cmp, label %exit, label %body
+exit:
+  ret void
+}
+
+define void @gpu_twostream_hoist(i32 %tmp20, i64 %sub47, i64 %stride, i32 %sub, ptr %tau1, ptr %tau2) {
+; CHECK-LABEL: @gpu_twostream_hoist(
+; CHECK: body:
+; CHECK: sext i32 {{%.*}} to i64
+; CHECK: mul nsw i64 [[STRIDE:%.*]], {{%.*}}
+; CHECK: getelementptr inbounds i8, ptr [[TAU1:%.*]], i64 {{%.*}}
+; CHECK: getelementptr inbounds i8, ptr [[TAU2:%.*]], i64 {{%.*}}
+; CHECK: load float, ptr {{%.*}}
+; CHECK: load float, ptr {{%.*}}
+; CHECK: icmp ne i32 {{%.*}}, 0
+entry:
+  br label %pre
+pre:
+  br label %body
+body:
+  %j = phi i32 [ 0, %pre ], [ %inc, %cond ]
+  %add43 = add nsw i32 %j, %tmp20
+  %conv50 = sext i32 %add43 to i64
+  %mul51 = mul nsw i64 %stride, %conv50
+  %add52 = add nsw i64 %sub47, %mul51
+  %idx = shl nsw i64 %add52, 2
+  %gep1 = getelementptr inbounds i8, ptr %tau1, i64 %idx
+  %gep2 = getelementptr inbounds i8, ptr %tau2, i64 %idx
+  %val1 = load float, ptr %gep1, align 4
+  %val2 = load float, ptr %gep2, align 4
+  call void @usef(float %val1)
+  call void @usef(float %val2)
+  br label %cond
+cond:
+  %inc = add nuw nsw i32 %j, 1
+  %cmp = icmp sgt i32 %inc, %sub
+  br i1 %cmp, label %exit, label %body
+exit:
+  ret void
+}
+
+define void @gpu_four_load(i32 %tmp20, i64 %sub47, i64 %stride, i32 %sub, ptr %tau1) {
+; CHECK-LABEL: @gpu_four_load(
+; CHECK: body:
+; CHECK: sext i32 {{%.*}} to i64
+; CHECK: mul nsw i64 [[STRIDE:%.*]], {{%.*}}
+; CHECK: load float, ptr {{%.*}}
+; CHECK: load float, ptr {{%.*}}
+; CHECK: load float, ptr {{%.*}}
+; CHECK: load float, ptr {{%.*}}
+; CHECK: icmp ne i32 {{%.*}}, 0
+entry:
+  br label %pre
+pre:
+  br label %body
+body:
+  %j = phi i32 [ 0, %pre ], [ %inc, %cond ]
+  %add43 = add nsw i32 %j, %tmp20
+  %conv50 = sext i32 %add43 to i64
+  %mul51 = mul nsw i64 %stride, %conv50
+  %add52 = add nsw i64 %sub47, %mul51
+  %idx = shl nsw i64 %add52, 2
+  %gep = getelementptr inbounds i8, ptr %tau1, i64 %idx
+  %gep1 = getelementptr inbounds i8, ptr %gep, i64 4
+  %gep2 = getelementptr inbounds i8, ptr %gep, i64 8
+  %gep3 = getelementptr inbounds i8, ptr %gep, i64 12
+  %v0 = load float, ptr %gep, align 4
+  %v1 = load float, ptr %gep1, align 4
+  %v2 = load float, ptr %gep2, align 4
+  %v3 = load float, ptr %gep3, align 4
+  call void @usef(float %v0)
+  call void @usef(float %v1)
+  call void @usef(float %v2)
+  call void @usef(float %v3)
+  br label %cond
+cond:
+  %inc = add nuw nsw i32 %j, 1
+  %cmp = icmp sgt i32 %inc, %sub
+  br i1 %cmp, label %exit, label %body
+exit:
+  ret void
+}

--- a/llvm/test/Transforms/LoopStrengthReduce/latch-inc-lsr.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/latch-inc-lsr.ll
@@ -7,15 +7,14 @@ declare void @usef(float)
 
 define void @gpu_addr_hoist(i32 %tmp20, i64 %sub47, i64 %stride, i32 %sub, ptr %tau1) {
 ; CHECK-LABEL: @gpu_addr_hoist(
-; CHECK: call i32 @llvm.smax.i32(i32 [[SUB:%.*]], i32 0)
+; CHECK: mul i64 [[STRIDE:%.*]], {{%.*}}
+; CHECK: shl i64 {{%.*}}, 2
 ; CHECK: body:
-; CHECK: sext i32 {{%.*}} to i64
-; CHECK: mul nsw i64 [[STRIDE:%.*]], {{%.*}}
-; CHECK: add nsw i64 [[SUB47:%.*]], {{%.*}}
-; CHECK: shl nsw i64 {{%.*}}, 2
-; CHECK: getelementptr inbounds i8, ptr [[TAU1:%.*]], i64 {{%.*}}
-; CHECK: load float, ptr {{%.*}}
-; CHECK: icmp ne i32 {{%.*}}, 0
+; CHECK: [[LSR_IV:%.*]] = phi ptr [ {{%.*}} ], [ {{%.*}} ]
+; CHECK-NEXT: [[J:%.*]] = phi i32 [ 0, {{%.*}} ], [ [[INC:%.*]], {{.*}} ]
+; CHECK-NEXT: load float, ptr [[LSR_IV]]
+; CHECK: [[INC]] = add nuw i32 [[J]], 1
+; CHECK: icmp sgt i32 [[INC]], [[SUB:%.*]]
 entry:
   br label %pre
 pre:
@@ -41,14 +40,15 @@ exit:
 
 define void @gpu_twostream_hoist(i32 %tmp20, i64 %sub47, i64 %stride, i32 %sub, ptr %tau1, ptr %tau2) {
 ; CHECK-LABEL: @gpu_twostream_hoist(
+; CHECK: mul i64 [[STRIDE:%.*]], {{%.*}}
 ; CHECK: body:
-; CHECK: sext i32 {{%.*}} to i64
-; CHECK: mul nsw i64 [[STRIDE:%.*]], {{%.*}}
-; CHECK: getelementptr inbounds i8, ptr [[TAU1:%.*]], i64 {{%.*}}
-; CHECK: getelementptr inbounds i8, ptr [[TAU2:%.*]], i64 {{%.*}}
-; CHECK: load float, ptr {{%.*}}
-; CHECK: load float, ptr {{%.*}}
-; CHECK: icmp ne i32 {{%.*}}, 0
+; CHECK: [[LSR_IV:%.*]] = phi i64 [ {{%.*}} ], [ {{%.*}} ]
+; CHECK-NEXT: [[J:%.*]] = phi i32 [ 0, {{%.*}} ], [ [[INC:%.*]], {{.*}} ]
+; CHECK-NEXT: getelementptr i8, ptr [[TAU1:%.*]], i64 [[LSR_IV]]
+; CHECK-NEXT: getelementptr i8, ptr [[TAU2:%.*]], i64 [[LSR_IV]]
+; CHECK-NEXT: load float, ptr {{%.*}}
+; CHECK-NEXT: load float, ptr {{%.*}}
+; CHECK: icmp sgt i32 [[INC:%.*]], [[SUB:%.*]]
 entry:
   br label %pre
 pre:
@@ -77,14 +77,18 @@ exit:
 
 define void @gpu_four_load(i32 %tmp20, i64 %sub47, i64 %stride, i32 %sub, ptr %tau1) {
 ; CHECK-LABEL: @gpu_four_load(
+; CHECK: mul i64 [[STRIDE:%.*]], {{%.*}}
 ; CHECK: body:
-; CHECK: sext i32 {{%.*}} to i64
-; CHECK: mul nsw i64 [[STRIDE:%.*]], {{%.*}}
-; CHECK: load float, ptr {{%.*}}
-; CHECK: load float, ptr {{%.*}}
-; CHECK: load float, ptr {{%.*}}
-; CHECK: load float, ptr {{%.*}}
-; CHECK: icmp ne i32 {{%.*}}, 0
+; CHECK: [[LSR_IV:%.*]] = phi ptr [ {{%.*}} ], [ {{%.*}} ]
+; CHECK-NEXT: [[J:%.*]] = phi i32 [ 0, {{%.*}} ], [ [[INC:%.*]], {{.*}} ]
+; CHECK-NEXT: getelementptr i8, ptr [[LSR_IV]], i64 4
+; CHECK-NEXT: getelementptr i8, ptr [[LSR_IV]], i64 8
+; CHECK-NEXT: getelementptr i8, ptr [[LSR_IV]], i64 12
+; CHECK-NEXT: load float, ptr [[LSR_IV]]
+; CHECK-NEXT: load float, ptr {{%.*}}
+; CHECK-NEXT: load float, ptr {{%.*}}
+; CHECK-NEXT: load float, ptr {{%.*}}
+; CHECK: icmp sgt i32 [[INC:%.*]], [[SUB:%.*]]
 entry:
   br label %pre
 pre:

--- a/llvm/test/Transforms/PhaseOrdering/instcombine-latch-inc-benefits.ll
+++ b/llvm/test/Transforms/PhaseOrdering/instcombine-latch-inc-benefits.ll
@@ -15,7 +15,7 @@ declare void @usef(float)
 define void @scev_postinc_nsw(i32 %sub) {
 ; CHECK-LABEL: 'scev_postinc_nsw'
 ; CHECK: %inc = add nuw nsw i32 %j, 1
-; CHECK-NEXT: --> {1,+,1}<nuw><%loop>
+; CHECK-NEXT: --> {1,+,1}<nuw><nsw>
 entry:
   br label %loop
 loop:
@@ -30,7 +30,7 @@ exit:
 define void @scev_gep_nsw(i32 %sub) {
 ; CHECK-LABEL: 'scev_gep_nsw'
 ; CHECK: %inc = add nuw nsw i32 %j, 1
-; CHECK-NEXT: --> {1,+,1}<nuw><%loop>
+; CHECK-NEXT: --> {1,+,1}<nuw><nsw>
 entry:
   br label %loop
 loop:
@@ -50,7 +50,7 @@ define void @scev_gpu_nssw(i32 %tmp20, i64 %sub47, i64 %stride, i32 %sub, ptr %t
 ; CHECK-LABEL: 'scev_gpu_nssw'
 ; CHECK: %conv50 = sext i32 %add43 to i64
 ; CHECK-NEXT: --> {(sext i32 %tmp20 to i64),+,1}<nsw>
-; CHECK: {1,+,1}<nuw><%body>
+; CHECK: {1,+,1}<nuw><{{.*}}> Added Flags: <nssw>
 entry:
   br label %pre
 pre:
@@ -76,7 +76,7 @@ exit:
 
 define void @scev_nssw_indvars(i32 %sub) {
 ; INDVARS-LABEL: 'scev_nssw_indvars'
-; INDVARS: {1,+,1}<nuw><%loop>
+; INDVARS: {1,+,1}<nuw><{{.*}}> Added Flags: <nssw>
 entry:
   br label %loop
 loop:

--- a/llvm/test/Transforms/PhaseOrdering/instcombine-latch-inc-benefits.ll
+++ b/llvm/test/Transforms/PhaseOrdering/instcombine-latch-inc-benefits.ll
@@ -1,0 +1,90 @@
+; SCEV gains from preserving post-inc latch exit compares
+
+; RUN: opt < %s -passes='instcombine,print<scalar-evolution>' -disable-output 2>&1 \
+; RUN:   | FileCheck %s
+; RUN: opt < %s -passes='instcombine,indvars,print<scalar-evolution>' \
+; RUN:   -indvars-widen-indvars=false -disable-output 2>&1 \
+; RUN:   | FileCheck %s --check-prefix=INDVARS
+
+target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64"
+
+@a = external global [1024 x i32]
+declare void @use(i32)
+declare void @usef(float)
+
+define void @scev_postinc_nsw(i32 %sub) {
+; CHECK-LABEL: 'scev_postinc_nsw'
+; CHECK: %inc = add nuw nsw i32 %j, 1
+; CHECK-NEXT: --> {1,+,1}<nuw><%loop>
+entry:
+  br label %loop
+loop:
+  %j = phi i32 [ 0, %entry ], [ %inc, %loop ]
+  %inc = add nuw nsw i32 %j, 1
+  %cmp = icmp sgt i32 %inc, %sub
+  br i1 %cmp, label %exit, label %loop
+exit:
+  ret void
+}
+
+define void @scev_gep_nsw(i32 %sub) {
+; CHECK-LABEL: 'scev_gep_nsw'
+; CHECK: %inc = add nuw nsw i32 %j, 1
+; CHECK-NEXT: --> {1,+,1}<nuw><%loop>
+entry:
+  br label %loop
+loop:
+  %j = phi i32 [ 0, %entry ], [ %inc, %loop ]
+  %idx = zext i32 %j to i64
+  %off = mul nuw nsw i64 %idx, 4
+  %p = getelementptr i8, ptr @a, i64 %off
+  %v = load i32, ptr %p
+  %inc = add nuw nsw i32 %j, 1
+  %cmp = icmp sgt i32 %inc, %sub
+  br i1 %cmp, label %exit, label %loop
+exit:
+  ret void
+}
+
+define void @scev_gpu_nssw(i32 %tmp20, i64 %sub47, i64 %stride, i32 %sub, ptr %tau1) {
+; CHECK-LABEL: 'scev_gpu_nssw'
+; CHECK: %conv50 = sext i32 %add43 to i64
+; CHECK-NEXT: --> {(sext i32 %tmp20 to i64),+,1}<nsw>
+; CHECK: {1,+,1}<nuw><%body>
+entry:
+  br label %pre
+pre:
+  br label %body
+body:
+  %j = phi i32 [ 0, %pre ], [ %inc, %cond ]
+  %add43 = add nsw i32 %j, %tmp20
+  %conv50 = sext i32 %add43 to i64
+  %mul51 = mul nsw i64 %stride, %conv50
+  %add52 = add nsw i64 %sub47, %mul51
+  %gep.idx = shl nsw i64 %add52, 2
+  %gep = getelementptr inbounds i8, ptr %tau1, i64 %gep.idx
+  %val = load float, ptr %gep, align 4
+  call void @usef(float %val)
+  br label %cond
+cond:
+  %inc = add nuw nsw i32 %j, 1
+  %cmp = icmp sgt i32 %inc, %sub
+  br i1 %cmp, label %exit, label %body
+exit:
+  ret void
+}
+
+define void @scev_nssw_indvars(i32 %sub) {
+; INDVARS-LABEL: 'scev_nssw_indvars'
+; INDVARS: {1,+,1}<nuw><%loop>
+entry:
+  br label %loop
+loop:
+  %j = phi i32 [ 0, %entry ], [ %inc, %loop ]
+  call void @use(i32 %j)
+  %inc = add nuw nsw i32 %j, 1
+  %cmp = icmp sgt i32 %inc, %sub
+  br i1 %cmp, label %exit, label %loop
+exit:
+  ret void
+}


### PR DESCRIPTION
Some loops arrive at InstCombine in post-increment form with nsw/nuw on the latch increment, e.g.:
```
%inc = add nuw nsw i32 %j, 1
%cmp = icmp sgt i32 %inc, %n
br i1 %cmp, label %exit, label %loop
```
InstCombine’s ShareCommonDivisor / strictness fold can rewrite this to a pre-increment compare on %j even when %inc has other users like the PHI backedge:
```
%inc = add nuw nsw i32 %j, 1
%cmp = icmp slt i32 %j, %n
```
The IR nsw on %inc is still present, but its meaning for the last iteration is effectively lost for SCEV: poison is only UB when used. After the fold, %inc is dead on the latch-exit path, so SCEV often cannot prove nowrap on the post-inc AddRec.

Later, linearFunctionTestReplace in IndVarSimplify prefers post-inc exit tests. When it rewrites back to a compare of %inc, it drops nowrap flags that SCEV did not prove on the post-inc AddRec. Net effect:

InstCombine: post-inc → pre-inc (incidental)
SCEV: cannot (re)prove post-inc <nsw>
LFTR: pre-inc → post-inc, strip nsw/nuw
Downstream (e.g. LSR): weaker formulas / missed computation hoist

This patch adds a hasOneUse guard on the strictness fold that rewrites icmp (add X, C), Y into a compare of X. When the add has only one use (the icmp), this eliminates an add-with-constant. When the add has other users (for example a PHI backedge), the addition must be performed anyway, and rewriting the icmp onto X may move the compare off the nsw/nuw value. This drops the exit-path use SCEV needs to prove that there is no wrap on the last iteration, which later hurts IndVarSimplify's ability to keep wrap flags when it switches back to post-inc, and can block other passes such as LSR. With the guard, we still allow the fold in the one-use case (where it deletes the add), and we skip it when the add is multi-use, so the exit icmp keeps using the nsw/nuw add and that fact stays available to SCEV and later passes.

On llvm-opt-benchmark, keeping post-inc form through this InstCombine change exposed a second issue: for some aligned, non-unit-stride, early-exit loops, SCEV could compute an exact latch exit count in the pre-inc shape but not in the equivalent post-inc shape, which encoded the same information. The SCEV changes in #215990 restore the same counting reasoning on the post-inc form when the addrec has the appropriate nowrap flags and both sides are aligned to the step. So #215990 would need to be merged before this one to avoid regressions on llvm-opt-benchmark.

Another option is that IndVarSimplify could refuse to switch to post-inc when that would entail dropping wrap flags. That may be worth considering, but post-inc exit tests are intentionally IndVarSimplify policy and may have other benefits we do not want to give up globally. The information loss starts earlier: after InstCombine, SCEV has already lost a use that justified post-inc nowrap. Preserving that use is a direct way to keep the information for later passes.
I am not sure of a better InstCombine-local way to encode “the increment does not wrap on the exiting iteration” once the icmp no longer uses the add. Or, if there is a cleaner, more canonical way to ensure that future passes, like LSR, have access to the wrap information after the loop is transformed back to a post-inc form, I'd welcome suggestions to accomplish this.
