### PR TITLE
[BOLT][RISCV][NFC] Add a test for GOT references with a non-adjacent load

### DIFF
--- a/bolt/test/RISCV/reloc-got.s
+++ b/bolt/test/RISCV/reloc-got.s
@@ -13,11 +13,42 @@ d:
   .p2align 1
 // CHECK: Binary Function "_start" after building cfg {
 _start:
-  nop // Here to not make the _start and .Ltmp0 symbols coincide
-// CHECK: auipc t0, %pcrel_hi(__BOLT_got_zero+{{[0-9]+}}) # Label: .Ltmp0
-// CHECK-NEXT: ld t0, %pcrel_lo(.Ltmp0)(t0)
+  nop // Here to not make the _start and the %pcrel_lo label coincide
+
+/// The load follows the AUIPC, so BOLT resolves the right GOT entry.
+// CHECK:      auipc t0, %pcrel_hi(__BOLT_got_zero+[[GOT:[0-9]+]]) # Label: [[HI:\.Ltmp[0-9]+]]
+// CHECK-NEXT: ld t0, %pcrel_lo([[HI]])(t0)
 1:
   auipc t0, %got_pcrel_hi(d)
   ld t0, %pcrel_lo(1b)(t0)
+
+/// An unrelated instruction sits between the AUIPC and its load.
+// FIXME: The AUIPC below should also use __BOLT_got_zero+[[GOT]], but BOLT
+// takes the low part from the ADDI instead of from the load that names the
+// AUIPC's label.
+// CHECK-NOT:  __BOLT_got_zero+[[GOT]])
+// CHECK:      addi t2, t2, 0x7ff
+// CHECK-NEXT: ld t1, %pcrel_lo({{\.Ltmp[0-9]+}})(t1)
+2:
+  auipc t1, %got_pcrel_hi(d)
+  addi t2, t2, 2047
+  ld t1, %pcrel_lo(2b)(t1)
+  j .L1
+.L2:
+  ld t1, %pcrel_lo(3f)(t1)
+  j .Lexit
+.L1:
+  nop
+/// The load lives in another basic block, so nothing follows the AUIPC but
+/// the terminator.
+// FIXME: The AUIPC below should also use __BOLT_got_zero+[[GOT]], but BOLT
+// takes the low part from the jump.
+// CHECK:      nop
+// CHECK-NOT:  __BOLT_got_zero+[[GOT]])
+// CHECK:      j
+3:
+  auipc t1, %got_pcrel_hi(d)
+  j .L2
+.Lexit:
   ret
   .size _start, .-_start


### PR DESCRIPTION
The RISC-V psABI pairs the two halves of a PC-relative address through the label that the %pcrel_lo relocation refers to, so the load holding the low part does not have to follow the AUIPC directly.

Pin down the current behavior in that case. All three references name the same symbol and should therefore resolve to the same GOT entry, but only the first one does, because BOLT takes the low part from whatever instruction follows the AUIPC: an unrelated ADDI in the second case, and the terminator of the basic block in the third. The next commit fixes this and updates the checks.