### PR TITLE
[libc++][NFC] Update implementation strategy of the `operator()(I&& first, S last)` for `std::ranges::distance`

### DIFF
--- a/libcxx/include/__iterator/distance.h
+++ b/libcxx/include/__iterator/distance.h
@@ -22,7 +22,8 @@
 #include <__ranges/size.h>
 #include <__type_traits/decay.h>
 #include <__type_traits/enable_if.h>
-#include <__type_traits/remove_cvref.h>
+#include <__type_traits/is_array.h>
+#include <__type_traits/remove_reference.h>
 #include <__utility/move.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
@@ -87,10 +88,10 @@ struct __distance {
 
   template <class _Ip, sized_sentinel_for<decay_t<_Ip>> _Sp>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr iter_difference_t<_Ip> operator()(_Ip&& __first, _Sp __last) const {
-    if constexpr (sized_sentinel_for<_Sp, __remove_cvref_t<_Ip>>) {
+    if constexpr (!is_array_v<remove_reference_t<_Ip>>) {
       return __last - __first;
     } else {
-      return __last - decay_t<_Ip>(__first);
+      return __last - static_cast<decay_t<_Ip>>(__first);
     }
   }
 

--- a/libcxx/include/__iterator/distance.h
+++ b/libcxx/include/__iterator/distance.h
@@ -87,7 +87,8 @@ struct __distance {
   }
 
   template <class _Ip, sized_sentinel_for<decay_t<_Ip>> _Sp>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr iter_difference_t<_Ip> operator()(_Ip&& __first, _Sp __last) const {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr iter_difference_t<decay_t<_Ip>>
+  operator()(_Ip&& __first, _Sp __last) const {
     if constexpr (!is_array_v<remove_reference_t<_Ip>>) {
       return __last - __first;
     } else {


### PR DESCRIPTION
This patch updates the implementation strategy for `ranges::distance(I&& first, S last)` to match the exact wording from the Standard.

This implementation is NFC because the return type and the branching condition will be the same after the change, and the tests present in `libcxx/test/std/iterators/iterator.primitives/range.iter.ops/range.iter.ops.distance/iterator_sentinel.pass.cpp`  are already covering the scenarios for such change.

References:
- https://cplusplus.github.io/LWG/issue3664
- https://cplusplus.github.io/LWG/issue4242
- https://wg21.link/range.iter.op.distance

Follows up: https://github.com/llvm/llvm-project/pull/211568