### PR TITLE
[NFC][AMDGPU] Avoid storing through a poison pointer in function-args.ll test

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/function-args.ll
+++ b/llvm/test/CodeGen/AMDGPU/function-args.ll
@@ -4431,14 +4431,20 @@ define void @void_func_v16bf16(<16 x bfloat> %arg0) #0 {
   ret void
 }
 
+@g = external addrspace(1) global i32
+
 ; A zero-sized argument produces no InputArg, so later args must still lower correctly.
 define void @void_func_empty_struct_i32({} %arg0, i32 %arg1) #0 {
 ; CIGFX89-LABEL: void_func_empty_struct_i32:
 ; CIGFX89:       ; %bb.0:
 ; CIGFX89-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; CIGFX89-NEXT:    s_mov_b64 s[4:5], 0
+; CIGFX89-NEXT:    s_getpc_b64 s[4:5]
+; CIGFX89-NEXT:    s_add_u32 s4, s4, g@gotpcrel32@lo+4
+; CIGFX89-NEXT:    s_addc_u32 s5, s5, g@gotpcrel32@hi+12
+; CIGFX89-NEXT:    s_load_dwordx2 s[4:5], s[4:5], 0x0
 ; CIGFX89-NEXT:    s_mov_b32 s7, 0xf000
 ; CIGFX89-NEXT:    s_mov_b32 s6, -1
+; CIGFX89-NEXT:    s_waitcnt lgkmcnt(0)
 ; CIGFX89-NEXT:    buffer_store_dword v0, off, s[4:7], 0
 ; CIGFX89-NEXT:    s_waitcnt vmcnt(0)
 ; CIGFX89-NEXT:    s_setpc_b64 s[30:31]
@@ -4446,12 +4452,16 @@ define void @void_func_empty_struct_i32({} %arg0, i32 %arg1) #0 {
 ; GFX11-LABEL: void_func_empty_struct_i32:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    s_mov_b64 s[0:1], 0
+; GFX11-NEXT:    s_getpc_b64 s[0:1]
+; GFX11-NEXT:    s_add_u32 s0, s0, g@gotpcrel32@lo+4
+; GFX11-NEXT:    s_addc_u32 s1, s1, g@gotpcrel32@hi+12
 ; GFX11-NEXT:    s_mov_b32 s3, 0x31016000
+; GFX11-NEXT:    s_load_b64 s[0:1], s[0:1], 0x0
 ; GFX11-NEXT:    s_mov_b32 s2, -1
+; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-NEXT:    buffer_store_b32 v0, off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store i32 %arg1, ptr addrspace(1) null
+  store i32 %arg1, ptr addrspace(1) @g
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/function-args.ll
+++ b/llvm/test/CodeGen/AMDGPU/function-args.ll
@@ -4436,6 +4436,7 @@ define void @void_func_empty_struct_i32({} %arg0, i32 %arg1) #0 {
 ; CIGFX89-LABEL: void_func_empty_struct_i32:
 ; CIGFX89:       ; %bb.0:
 ; CIGFX89-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; CIGFX89-NEXT:    s_mov_b64 s[4:5], 0
 ; CIGFX89-NEXT:    s_mov_b32 s7, 0xf000
 ; CIGFX89-NEXT:    s_mov_b32 s6, -1
 ; CIGFX89-NEXT:    buffer_store_dword v0, off, s[4:7], 0
@@ -4445,11 +4446,12 @@ define void @void_func_empty_struct_i32({} %arg0, i32 %arg1) #0 {
 ; GFX11-LABEL: void_func_empty_struct_i32:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    s_mov_b64 s[0:1], 0
 ; GFX11-NEXT:    s_mov_b32 s3, 0x31016000
 ; GFX11-NEXT:    s_mov_b32 s2, -1
 ; GFX11-NEXT:    buffer_store_b32 v0, off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store i32 %arg1, ptr addrspace(1) poison
+  store i32 %arg1, ptr addrspace(1) null
   ret void
 }
 


### PR DESCRIPTION
Address post-merge comment: https://github.com/llvm/llvm-project/pull/215970 