### PR TITLE
[libcxx][FreeBSD] Add comments for unsupported xopen_source.gen.py test

### DIFF
--- a/libcxx/test/extensions/posix/xopen_source.gen.py
+++ b/libcxx/test/extensions/posix/xopen_source.gen.py
@@ -16,8 +16,10 @@
 # recent value of _XOPEN_SOURCE.
 # UNSUPPORTED: LIBCXX-AIX-FIXME
 
-# This test fails on FreeBSD for an unknown reason.
-# UNSUPPORTED: LIBCXX-FREEBSD-FIXME
+# FreeBSD maps _XOPEN_SOURCE=500 to __ISO_C_VISIBLE=1990 (see <sys/_visible.h>), which hides
+# everything C99 added to the C library, even in C++ mode. libc++ needs some of those
+# additions to provide a conforming library at all.
+# UNSUPPORTED: freebsd
 
 # RUN: %{python} %s %{libcxx-dir}/utils
 # END.


### PR DESCRIPTION
FreeBSD _XOPEN_SOURCE == 500 does not satisfy some requirements in libcxx. As a result, tests fail when trying to find the declarations of these functions.