### PR TITLE
[libc++] Trigger the benchmark-request job more often

### DIFF
--- a/.github/workflows/libcxx-benchmark-cron.yml
+++ b/.github/workflows/libcxx-benchmark-cron.yml
@@ -16,8 +16,8 @@ permissions:
 
 on:
   schedule:
-    # Trigger every hour, off the hour boundary to avoid popular times.
-    - cron: '37 * * * *'
+    # Trigger every 30 minutes, off the hour boundary to avoid popular times.
+    - cron: '7,37 * * * *'
   workflow_dispatch:
     inputs:
       dry-run:

--- a/libcxx/utils/ci/lnt/README.md
+++ b/libcxx/utils/ci/lnt/README.md
@@ -5,9 +5,9 @@ This directory contains utilities for continuous benchmarking of libc++ with LNT
 ## Gathering historical performance data
 
 When generating historical performance data, benchmarking every commit of libc++
-is prohibitively expensive since a single run of the benchmark suite takes a few
-hours. Furthermore, generating this data from scratch is expected to be common,
-since it must happen whenever a fixed parameter like the compiler or the OS changes.
+is prohibitively expensive. Furthermore, generating this data from scratch is
+expected  to be common, since it must happen whenever a fixed parameter like the
+compiler or the OS changes.
 
 Instead, the tools in this directory aim to make it possible to generate historical
 performance data quickly with coarse granularity, with the goal of then generating


### PR DESCRIPTION
With the test suite taking under 1h to complete, it makes sense to trigger at least every 30 minutes so we don't leave available capacity unused.