### PR TITLE
[lldb-dap][NFC] Fix deprecated SB API usages

### DIFF
--- a/lldb/tools/lldb-dap/Breakpoint.cpp
+++ b/lldb/tools/lldb-dap/Breakpoint.cpp
@@ -128,7 +128,8 @@ void Breakpoint::SetBreakpoint() {
   lldb::SBMutex lock = m_dap.GetAPIMutex();
   std::lock_guard<lldb::SBMutex> guard(lock);
 
-  m_bp.AddName(kDAPBreakpointLabel);
+  lldb::SBError error = m_bp.AddNameWithErrorHandling(kDAPBreakpointLabel);
+  // TODO: Report this error to the user instead of silently dropping it.
   if (!m_condition.empty())
     SetCondition();
   if (!m_hit_condition.empty())

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -225,7 +225,8 @@ ExceptionBreakpoint *DAP::GetExceptionBreakpoint(const lldb::break_id_t bp_id) {
 }
 
 llvm::Error DAP::ConfigureIO(std::FILE *overrideOut, std::FILE *overrideErr) {
-  in = lldb::SBFile(std::fopen(DEV_NULL, "r"), /*transfer_ownership=*/true);
+  in =
+      lldb::SBFile(std::fopen(DEV_NULL, "r"), "r", /*transfer_ownership=*/true);
 
   if (auto error = out.RedirectTo(
           m_loop, overrideOut,

--- a/lldb/tools/lldb-dap/ExceptionBreakpoint.cpp
+++ b/lldb/tools/lldb-dap/ExceptionBreakpoint.cpp
@@ -27,7 +27,9 @@ protocol::Breakpoint ExceptionBreakpoint::SetBreakpoint(StringRef condition) {
     m_bp = m_dap.target.BreakpointCreateForException(
         m_language, m_kind == eExceptionKindCatch,
         m_kind == eExceptionKindThrow);
-    m_bp.AddName(BreakpointBase::kDAPBreakpointLabel);
+    lldb::SBError error =
+        m_bp.AddNameWithErrorHandling(BreakpointBase::kDAPBreakpointLabel);
+    // TODO: Report this error to the user instead of silently dropping it.
   }
 
   m_bp.SetCondition(condition.data());

--- a/lldb/tools/lldb-dap/JSONUtils.cpp
+++ b/lldb/tools/lldb-dap/JSONUtils.cpp
@@ -445,10 +445,10 @@ static void FilterAndGetValueForKey(const lldb::SBStructuredData data,
     out.try_emplace(key_utf8, value.GetFloatValue());
     break;
   case lldb::eStructuredDataTypeUnsignedInteger:
-    out.try_emplace(key_utf8, value.GetIntegerValue((uint64_t)0));
+    out.try_emplace(key_utf8, value.GetUnsignedIntegerValue());
     break;
   case lldb::eStructuredDataTypeSignedInteger:
-    out.try_emplace(key_utf8, value.GetIntegerValue((int64_t)0));
+    out.try_emplace(key_utf8, value.GetSignedIntegerValue());
     break;
   case lldb::eStructuredDataTypeArray: {
     lldb::SBStream contents;

--- a/lldb/tools/lldb-dap/ProtocolUtils.cpp
+++ b/lldb/tools/lldb-dap/ProtocolUtils.cpp
@@ -162,7 +162,7 @@ std::optional<protocol::Source> CreateSource(const lldb::SBFileSpec &file) {
   if (file.GetPath(path, sizeof(path)) &&
       lldb::SBFileSpec::ResolvePath(path, path, PATH_MAX)) {
     source.path = path;
-    if (!lldb::SBFileSpec(path).Exists())
+    if (!lldb::SBFileSpec(path, /*resolve=*/true).Exists())
       source.presentationHint = Source::eSourcePresentationHintDeemphasize;
   }
   return source;

--- a/lldb/tools/lldb-dap/SourceBreakpoint.cpp
+++ b/lldb/tools/lldb-dap/SourceBreakpoint.cpp
@@ -80,8 +80,9 @@ void SourceBreakpoint::UpdateBreakpoint(const SourceBreakpoint &request_bp) {
 void SourceBreakpoint::CreatePathBreakpoint(const protocol::Source &source) {
   const auto source_path = source.path.value_or("");
   lldb::SBFileSpecList module_list;
-  m_bp = m_dap.target.BreakpointCreateByLocation(source_path.c_str(), m_line,
-                                                 m_column, 0, module_list);
+  m_bp = m_dap.target.BreakpointCreateByLocation(
+      lldb::SBFileSpec(source_path.c_str(), /*resolve=*/true), m_line, m_column,
+      0, module_list);
 }
 
 llvm::Error SourceBreakpoint::CreateAssemblyBreakpointWithSourceReference(
@@ -120,7 +121,8 @@ llvm::Error SourceBreakpoint::CreateAssemblyBreakpointWithSourceReference(
 
 llvm::Error SourceBreakpoint::CreateAssemblyBreakpointWithPersistenceData(
     const protocol::PersistenceData &persistence_data) {
-  lldb::SBFileSpec file_spec(persistence_data.module_path.c_str());
+  lldb::SBFileSpec file_spec(persistence_data.module_path.c_str(),
+                             /*resolve=*/true);
   lldb::SBFileSpecList comp_unit_list;
   lldb::SBFileSpecList file_spec_list;
   file_spec_list.Append(file_spec);

--- a/lldb/unittests/DAP/TestBase.cpp
+++ b/lldb/unittests/DAP/TestBase.cpp
@@ -89,7 +89,7 @@ bool DAPTestBase::GetDebuggerSupportsTarget(StringRef platform) {
 }
 
 void DAPTestBase::CreateDebugger() {
-  dap->debugger = lldb::SBDebugger::Create();
+  dap->debugger = lldb::SBDebugger::Create(/*source_init_files=*/false);
   ASSERT_TRUE(dap->debugger);
   dap->target = dap->debugger.GetDummyTarget();
 

--- a/lldb/unittests/DAP/VariablesTest.cpp
+++ b/lldb/unittests/DAP/VariablesTest.cpp
@@ -60,7 +60,9 @@ protected:
   std::optional<llvm::sys::fs::TempFile> core;
   std::optional<llvm::sys::fs::TempFile> binary;
 
-  void CreateDebugger() { debugger = lldb::SBDebugger::Create(); }
+  void CreateDebugger() {
+    debugger = lldb::SBDebugger::Create(/*source_init_files=*/false);
+  }
 
   void LoadCore() {
     ASSERT_TRUE(debugger);


### PR DESCRIPTION
lldb-dap has accumulated over time several calls to deprecated SB API functions. Since #215818 we actually emit the missing deprecation warnings which breaks the lldb-dap build with -Werror. This patch replaces the deprecated functions with the equivalent non-deprecated version.

Note that this patch is intentionally NFC and I just added TODOs for the missing error handling.

assisted-by: claude