### PR TITLE
[lldb][test][lldb-dap] Use program path in TestDAP_runInTerminal.py

### DIFF
--- a/lldb/test/API/tools/lldb-dap/runInTerminal/TestDAP_runInTerminal.py
+++ b/lldb/test/API/tools/lldb-dap/runInTerminal/TestDAP_runInTerminal.py
@@ -187,20 +187,24 @@ class TestDAP_runInTerminal(lldbdap_testcase.DAPTestCaseBase):
     def test_runInTerminalInvalidTarget(self):
         self.build_and_create_debug_adapter()
         response = self.launch_and_configurationDone(
-            "INVALIDPROGRAM",
+            self.getBuildArtifact("INVALIDPROGRAM"),
             console="integratedTerminal",
             args=["foobar"],
             env=["FOO=bar"],
         )
         self.assertFalse(response["success"])
         self.assertIn(
-            "'INVALIDPROGRAM' does not exist",
+            f"'{self.getBuildArtifact('INVALIDPROGRAM')}' does not exist",
             response["body"]["error"]["format"],
         )
 
     def test_missingArgInRunInTerminalLauncher(self):
         proc = subprocess.run(
-            [self.lldbDAPExec, "--launch-target", "INVALIDPROGRAM"],
+            [
+                self.lldbDAPExec,
+                "--launch-target",
+                self.getBuildArtifact("INVALIDPROGRAM"),
+            ],
             capture_output=True,
             universal_newlines=True,
         )
@@ -217,7 +221,7 @@ class TestDAP_runInTerminal(lldbdap_testcase.DAPTestCaseBase):
                     "--comm-file",
                     comm_file,
                     "--launch-target",
-                    "INVALIDPROGRAM",
+                    self.getBuildArtifact("INVALIDPROGRAM"),
                 ],
                 universal_newlines=True,
                 stderr=subprocess.PIPE,


### PR DESCRIPTION
On Linux if you run `INVALIDPROGRAM` it will look in PATH for it. lldb-dap runs the program using execvp which has special behaviour for the case where an entry in path cannot be accessed.

https://linux.die.net/man/3/execvp

> If permission is denied for a file (the attempted execve(2)
> failed with the error EACCES), these functions will continue
> searching the rest of the search path. If no other file is
> found, however, they will return with errno set to EACCES.

We have a downstream bot where the PATH was:
PATH=/root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

The buildbot user is not root, so /root/.cargo/bin was not readable, and so one test failed on this machine:
```
FAIL: test_FakeAttachedRunInTerminalLauncherWithInvalidProgram (TestDAP_runInTerminal.TestDAP_runInTerminal)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/davspi01/llvm-project/lldb/test/API/tools/lldb-dap/runInTerminal/TestDAP_runInTerminal.py", line 231, in test_FakeAttachedRunInTerminalLauncherWithInvalidProgram
    self.assertIn(
AssertionError: 'No such file or directory' not found in '{"kind":"error","value":"Permission denied"}\n'
```
It's saying permission denied for the PATH entry, rather than could not find the program file.

You can reproduce this locally with:
$ mkdir /tmp/lldb-no-search
$ chmod 000 /tmp/lldb-no-search
$ env PATH="/tmp/lldb-no-search:$PATH" ./bin/lldb-dotest -p TestDAP_runInTerminal.py

To fix this, I've changed the test case to use the full path to the (non-existent) program file. As this test should not be depending on PATH anyway.