### PR TITLE
Revert "[offload] Fix compatibility for level_zero 25.22.33944- #2142…

### DIFF
--- a/offload/plugins-nextgen/common/include/APIHelpers.h
+++ b/offload/plugins-nextgen/common/include/APIHelpers.h
@@ -16,8 +16,6 @@
 
 #include "DLWrap.h"
 
-#include <tuple>
-
 #define API_HELPER_STRINGIFY_INNER(x) #x
 #define API_HELPER_STRINGIFY(x) API_HELPER_STRINGIFY_INNER(x)
 
@@ -53,29 +51,6 @@ template <auto Fn> bool canCall() {
   static_assert(sizeof(decltype(Fn) *) == 0,
                 "api_helper::canCall() should only be called on symbols "
                 "decorated with API_HELPER_OPTIONAL!");
-}
-
-// Currently APIHelpers.h supports only interatctions with lvalue references
-template <typename Fn> struct FunctionArgs {
-  static_assert(sizeof(Fn) == 0,
-                "FunctionArgs: Fn should be an lvalue reference to a function! "
-                "Supported form: R(A...).");
-};
-// Arguments to a function are just a tuple with all the types inside
-template <typename ReturnType, typename... ArgsTypes>
-struct FunctionArgs<ReturnType(ArgsTypes...)> {
-  using type = std::tuple<ArgsTypes...>;
-};
-
-// Template to call function with all arguments initialized
-// with default values, so we can check if APIs are not returning
-// any kind of NOT_SUPPORTED errors
-template <typename Fn> auto callWithDefaultArgs(Fn &FunctionByLValue) {
-  // Get arguments tuple type corresponding to the function
-  using FunctionArgsType = typename FunctionArgs<Fn>::type;
-
-  // Call the function
-  return std::apply(FunctionByLValue, FunctionArgsType{});
 }
 
 } // namespace api_helper

--- a/offload/plugins-nextgen/level_zero/dynamic_l0/L0DynWrapper.cpp
+++ b/offload/plugins-nextgen/level_zero/dynamic_l0/L0DynWrapper.cpp
@@ -9,7 +9,6 @@
 #include <memory>
 #include <mutex>
 
-#include "APIHelpers.h"
 #include "DLWrap.h"
 #include "Shared/Debug.h"
 #include "llvm/Support/DynamicLibrary.h"
@@ -95,8 +94,6 @@ DLWRAP(zeCommandListHostSynchronize, 2)
 DLWRAP(zeCommandListAppendSignalEvent, 2)
 DLWRAP(zeCommandListAppendWaitOnEvents, 3)
 DLWRAP(zeEventQueryStatus, 1)
-DLWRAP(zeDriverGetDefaultContext, 1)
-DLWRAP(zeCommandListAppendHostFunction, 7)
 
 DLWRAP_FINALIZE()
 
@@ -112,23 +109,6 @@ DLWRAP_FINALIZE()
 #ifndef DEBUG_PREFIX
 #define DEBUG_PREFIX "TARGET " GETNAME(TARGET_NAME) " RTL"
 #endif
-
-// Macro used to make APIs that are returning
-// ZE_RESULT_ERROR_UNSUPPORTED_FEATURE nullptr in dlwrap.
-#define INVALIDATE_LEVEL_ZERO_API(function)                                    \
-  if (dlwrap::function##_loaded() &&                                           \
-      api_helper::callWithDefaultArgs(function) ==                             \
-          ZE_RESULT_ERROR_UNSUPPORTED_FEATURE) {                               \
-    for (size_t I = 0; I < dlwrap::size(); I++) {                              \
-      const char *Sym = dlwrap::symbol(I);                                     \
-      if (std::strcmp(Sym, #function) != 0)                                    \
-        continue;                                                              \
-      ODBG(OLDT_Init) << #function                                             \
-                      << " returns ZE_RESULT_ERROR_UNSUPPORTED_FEATURE, "      \
-                         "fallback might be available";                        \
-      *dlwrap::pointer(I) = nullptr;                                           \
-    }                                                                          \
-  }
 
 // Extension function pointer for getting argument sizes.
 static ze_result_t (*zexKernelGetArgumentSize_ptr)(ze_kernel_handle_t, uint32_t,
@@ -296,15 +276,6 @@ static bool loadLevelZero() {
   return true;
 }
 
-// Some APIs might be invalid in some Level Zero and
-// compute runtime environments. They will return
-// `ZE_RESULT_ERROR_UNSUPPORTED_FEATURE`. This
-// function sets their dlwrap pointers to null
-// in this situation.
-static void invalidateLevelZeroSymbols() {
-  INVALIDATE_LEVEL_ZERO_API(zeCommandListAppendLaunchKernelWithArguments);
-}
-
 static void addLevelZeroFallbacks() {
   std::string L0Library{LEVEL_ZERO_LIBRARY};
 
@@ -334,13 +305,6 @@ ze_result_t ZE_APICALL zeInit(ze_init_flags_t flags) {
     return ZE_RESULT_ERROR_UNKNOWN;
 
   auto InitResult = dlwrap_zeInit(flags);
-
-  if (InitResult != ZE_RESULT_SUCCESS)
-    return InitResult;
-
-  // Some functions might be present in loader but return
-  // ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
-  invalidateLevelZeroSymbols();
 
   // Add fallbacks after calling zeInit, so we can
   // use level_zero APIs to check if they work

--- a/offload/plugins-nextgen/level_zero/dynamic_l0/level_zero/ze_api.h
+++ b/offload/plugins-nextgen/level_zero/dynamic_l0/level_zero/ze_api.h
@@ -654,17 +654,6 @@ typedef struct _ze_copy_region_t {
   uint32_t depth;
 } ze_copy_region_t;
 
-/* Callbacks for host functions */
-#ifndef ZE_CALLBACK_CONV
-#if defined(_WIN32)
-/// @brief Callback function calling convention
-#define ZE_CALLBACK_CONV __stdcall
-#else
-#define ZE_CALLBACK_CONV
-#endif // defined(_WIN32)
-#endif // ZE_CALLBACK_CONV
-typedef void(ZE_CALLBACK_CONV *ze_host_function_callback_t)(void *pUserData);
-
 /*
  * ============================================================================
  * Level Zero API Functions
@@ -681,8 +670,6 @@ ZE_APIEXPORT ze_result_t ZE_APICALL zeDriverGetExtensionFunctionAddress(
     ze_driver_handle_t hDriver, const char *name, void **ppFunctionAddress);
 ZE_APIEXPORT ze_result_t ZE_APICALL zeDriverGetExtensionProperties(
     ze_driver_handle_t hDriver, uint32_t *pCount, void *pExtensionProperties);
-ZE_APIEXPORT ze_context_handle_t ZE_APICALL
-zeDriverGetDefaultContext(ze_driver_handle_t hDriver);
 
 /* Device functions */
 ZE_APIEXPORT ze_result_t ZE_APICALL zeDeviceGet(ze_driver_handle_t hDriver,
@@ -800,11 +787,6 @@ ZE_APIEXPORT ze_result_t ZE_APICALL zeCommandListAppendMemoryPrefetch(
 ZE_APIEXPORT ze_result_t ZE_APICALL zeCommandListAppendMemAdvise(
     ze_command_list_handle_t hCommandList, ze_device_handle_t hDevice,
     const void *ptr, size_t size, uint32_t advice);
-ZE_APIEXPORT ze_result_t ZE_APICALL zeCommandListAppendHostFunction(
-    ze_command_list_handle_t hCommandList,
-    ze_host_function_callback_t pfnHostFunction, void *pUserData,
-    const void *pNext, ze_event_handle_t hSignalEvent, uint32_t numWaitEvents,
-    ze_event_handle_t *phWaitEvents);
 
 /* Memory functions */
 ZE_APIEXPORT ze_result_t ZE_APICALL zeMemAllocDevice(

--- a/offload/plugins-nextgen/level_zero/include/L0CmdListManager.h
+++ b/offload/plugins-nextgen/level_zero/include/L0CmdListManager.h
@@ -13,7 +13,6 @@
 #ifndef OPENMP_LIBOMPTARGET_PLUGINS_NEXTGEN_LEVEL_ZERO_L0CMDLISTMANAGER_H
 #define OPENMP_LIBOMPTARGET_PLUGINS_NEXTGEN_LEVEL_ZERO_L0CMDLISTMANAGER_H
 
-#include "APIHelpers.h"
 #include "L0Compat.h"
 #include "L0Context.h"
 #include "L0Defs.h"
@@ -28,11 +27,14 @@ namespace llvm::omp::target::plugin {
 class L0CmdListManagerTy {
   /// Underlying immediate command list.
   ze_command_list_handle_t CmdList;
+  /// Owning context (provides driver-loaded extension function pointers).
+  L0ContextTy &Context;
   /// Mutex to protect L0 operations that are not thread safe.
   std::mutex Mtx;
 
 public:
-  L0CmdListManagerTy(ze_command_list_handle_t CmdList) : CmdList(CmdList) {}
+  L0CmdListManagerTy(ze_command_list_handle_t CmdList, L0ContextTy &Context)
+      : CmdList(CmdList), Context(Context) {}
 
   ze_command_list_handle_t getCmdList() const { return CmdList; }
 
@@ -175,15 +177,16 @@ public:
                            ze_event_handle_t SignalEvent = nullptr,
                            uint32_t NumWaitEvents = 0,
                            ze_event_handle_t *WaitEvents = nullptr) {
-    if (!api_helper::canCall<zeCommandListAppendHostFunction>())
+    auto zeCommandListAppendHost = Context.zeCommandListAppendHostFunction;
+    if (!zeCommandListAppendHost)
       return Plugin::error(ErrorCode::UNSUPPORTED,
                            "zeCommandListAppendHostFunction extension is not "
                            "available on this driver");
     std::lock_guard<std::mutex> Lock(Mtx);
-    CALL_ZE_RET_ERROR(
-        zeCommandListAppendHostFunction, CmdList,
-        reinterpret_cast<ze_host_function_callback_t>(Callback), UserData,
-        /*pNext*/ nullptr, SignalEvent, NumWaitEvents, WaitEvents);
+    CALL_ZE_RET_ERROR(zeCommandListAppendHost, CmdList,
+                      reinterpret_cast<void *>(Callback), UserData,
+                      /*pReserved*/ nullptr, SignalEvent, NumWaitEvents,
+                      WaitEvents);
     return Plugin::success();
   }
 };

--- a/offload/plugins-nextgen/level_zero/include/L0Compat.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Compat.h
@@ -25,14 +25,4 @@ API_HELPER_OPTIONAL(ze_result_t, zeCommandListAppendLaunchKernelWithArguments,
                     const void *pNext, ze_event_handle_t hSignalEvent,
                     uint32_t numWaitEvents, ze_event_handle_t *phWaitEvents)
 
-API_HELPER_OPTIONAL(ze_context_handle_t, zeDriverGetDefaultContext,
-                    ze_driver_handle_t hDriver);
-
-API_HELPER_OPTIONAL(ze_result_t, zeCommandListAppendHostFunction,
-                    ze_command_list_handle_t hCommandList,
-                    ze_host_function_callback_t pfnHostFunction,
-                    void *pUserData, const void *pNext,
-                    ze_event_handle_t hSignalEvent, uint32_t numWaitEvents,
-                    ze_event_handle_t *phWaitEvents);
-
 #endif // OPENMP_LIBOMPTARGET_PLUGINS_NEXTGEN_LEVEL_ZERO_L0COMPAT_H

--- a/offload/plugins-nextgen/level_zero/include/L0Context.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Context.h
@@ -141,7 +141,21 @@ public:
   ze_result_t(ZE_APICALL *zexKernelGetArgumentSize)(
       ze_kernel_handle_t hKernel, uint32_t argIndex,
       uint32_t *pArgSize) = nullptr;
+
+  /// Level Zero extension function pointer for host function callbacks.
+  ze_result_t(ZE_APICALL *zeCommandListAppendHostFunction)(
+      ze_command_list_handle_t hCommandList, void *pfnHostFunction,
+      void *pUserData, void *pReserved, ze_event_handle_t hSignalEvent,
+      uint32_t numWaitEvents, ze_event_handle_t *phWaitEvents) = nullptr;
+
+  /// Level Zero extension function pointer for querying the driver's default
+  /// ze_context, when the extension is supported. Used by
+  /// LevelZeroPluginTy::createPluginContext to reuse the driver default
+  /// context when the user asks for every device on the driver.
+  ze_context_handle_t(ZE_APICALL *zeDriverGetDefaultContext)(
+      ze_driver_handle_t hDriver) = nullptr;
 };
+
 } // namespace llvm::omp::target::plugin
 
 #endif // OPENMP_LIBOMPTARGET_PLUGINS_NEXTGEN_LEVEL_ZERO_L0CONTEXT_H

--- a/offload/plugins-nextgen/level_zero/include/L0Device.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Device.h
@@ -386,7 +386,7 @@ public:
     auto CmdListOrErr = createImmCmdList(InOrder);
     if (!CmdListOrErr)
       return CmdListOrErr.takeError();
-    return new L0CmdListManagerTy(*CmdListOrErr);
+    return new L0CmdListManagerTy(*CmdListOrErr, L0Context);
   }
 
   Error releaseCmdListManager(L0CmdListManagerTy *CmndListMngr) {

--- a/offload/plugins-nextgen/level_zero/src/L0Context.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Context.cpp
@@ -57,6 +57,17 @@ Error L0ContextTy::init() {
   if (RC != ZE_RESULT_SUCCESS)
     zexKernelGetArgumentSize = nullptr;
 
+  CALL_ZE(RC, zeDriverGetExtensionFunctionAddress, zeDriver,
+          "zeCommandListAppendHostFunction",
+          (void **)&zeCommandListAppendHostFunction);
+  if (RC != ZE_RESULT_SUCCESS)
+    zeCommandListAppendHostFunction = nullptr;
+
+  CALL_ZE(RC, zeDriverGetExtensionFunctionAddress, zeDriver,
+          "zeDriverGetDefaultContext", (void **)&zeDriverGetDefaultContext);
+  if (RC != ZE_RESULT_SUCCESS)
+    zeDriverGetDefaultContext = nullptr;
+
   return Plugin::success();
 }
 

--- a/offload/plugins-nextgen/level_zero/src/L0Plugin.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Plugin.cpp
@@ -12,8 +12,6 @@
 
 #include <level_zero/zes_api.h>
 
-#include "APIHelpers.h"
-#include "L0Compat.h"
 #include "L0Device.h"
 #include "L0Interop.h"
 #include "L0Kernel.h"
@@ -294,8 +292,8 @@ LevelZeroPluginTy::createPluginContext(
 
   ze_context_handle_t ZeContext = nullptr;
   bool OwnsZeContext = false;
-  if (IsFullDriver && api_helper::canCall<zeDriverGetDefaultContext>())
-    ZeContext = zeDriverGetDefaultContext(Driver);
+  if (IsFullDriver && DriverCtx.zeDriverGetDefaultContext)
+    ZeContext = DriverCtx.zeDriverGetDefaultContext(Driver);
   if (!ZeContext) {
     ze_context_desc_t Desc{ZE_STRUCTURE_TYPE_CONTEXT_DESC, nullptr, 0};
     CALL_ZE_RET_ERROR(zeContextCreate, Driver, &Desc, &ZeContext);

--- a/offload/unittests/OffloadAPI/queue/olLaunchHostFunction.cpp
+++ b/offload/unittests/OffloadAPI/queue/olLaunchHostFunction.cpp
@@ -12,22 +12,7 @@
 #include <thread>
 
 struct olLaunchHostFunctionTest : OffloadQueueTest {
-  void SetUp() override {
-    RETURN_ON_FATAL_FAILURE(OffloadQueueTest::SetUp());
-
-    // Test if olLaunchHostFunction is supported
-    auto *Result = olLaunchHostFunction(
-        Queue,
-        [](void *) {
-          printf(""); // Making sure the function has side effect
-        },
-        nullptr);
-
-    if (Result != nullptr && Result->Code == OL_ERRC_UNSUPPORTED)
-      GTEST_SKIP() << "olLaunchHostFunction is not supported on this platform. "
-                      "Either the device does not support the feature or "
-                      "you need to update its drivers";
-  }
+  void SetUp() override { RETURN_ON_FATAL_FAILURE(OffloadQueueTest::SetUp()); }
 };
 OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olLaunchHostFunctionTest);
 


### PR DESCRIPTION
…15 (#215977)"

This reverts commit 77c8ecd7a6b912b6c61665f623f864c4cba52a00.

Level zero approach to zex pointers is a little inconsistent and I need to rework the PR. Some APIs such as `zeCommandListAppendLaunchKernelWithArguments` would return `SUCCESS` on older versions and provide a valid pointer to implemntation, but in more recent versions of level zero you would get `ERR_INVALID_ARGUMENT`.