### PR TITLE
[Flang][OpenMP] Prevent allocate directive ICE on module variables

### DIFF
--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -5788,6 +5788,15 @@ static void genOMP(lower::AbstractConverter &converter, lower::SymMap &symTable,
                    semantics::SemanticsContext &semaCtx,
                    lower::pft::Evaluation &eval,
                    const parser::OmpAllocateDirective &allocate) {
+  // The allocate directive is lowered as a runtime allocation with a matching
+  // deallocation registered as a cleanup at the exit of the enclosing function
+  // scope. In the case of modules, there is no place in which to emit the
+  // deallocation cleanup when that stage is reached, crashing the compiler
+  // during teardown.
+  if (converter.getCurrentScope().kind() == semantics::Scope::Kind::Module)
+    TODO(converter.genLocation(allocate.source),
+         "OpenMP ALLOCATE directive in unsupported declaration scope");
+
   lower::StatementContext stmtCtx;
   ObjectList objects = makeObjects((allocate.BeginDir().Arguments()), semaCtx);
   const auto &clauseList = (allocate.BeginDir().Clauses());

--- a/flang/test/Lower/OpenMP/Todo/allocate-module.f90
+++ b/flang/test/Lower/OpenMP/Todo/allocate-module.f90
@@ -1,0 +1,9 @@
+! RUN: %not_todo_cmd bbc -emit-hlfir -fopenmp -o - %s 2>&1 | FileCheck %s
+! RUN: %not_todo_cmd %flang_fc1 -emit-hlfir -fopenmp -o - %s 2>&1 | FileCheck %s
+
+! CHECK: not yet implemented: OpenMP ALLOCATE directive in unsupported declaration scope
+module omp_allocate_module
+  implicit none
+  integer :: x
+  !$omp allocate(x)
+end module omp_allocate_module


### PR DESCRIPTION
The current lowering implementation for `allocate` directives assumes the MLIR function in which it is creating operations will still be there by finalization time, so that it can add a deallocation call.

When lowering Fortran modules, this is not the case (lowering happens in a temporary dummy function) and it results in a compiler crash while running cleanup callbacks. This patch adds a TODO for this case.