### PR TITLE
[ORC] Align GDB-JIT alloc-action names with the ORC runtime

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/Debugging/DebuggerSupportPlugin.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Debugging/DebuggerSupportPlugin.h
@@ -36,7 +36,7 @@ public:
   };
 
   static Expected<std::unique_ptr<GDBJITDebugInfoRegistrationPlugin>>
-  Create(ExecutionSession &ES, JITDylib &ProcessJD, const Triple &TT);
+  Create(ExecutionSession &ES, JITDylib &BootstrapJD);
 
   GDBJITDebugInfoRegistrationPlugin(ExecutorAddr RegisterActionAddr)
       : RegisterActionAddr(RegisterActionAddr) {}

--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h
@@ -41,6 +41,7 @@ LLVM_ABI extern const char *RegisterEHFrameSectionAllocActionName;
 LLVM_ABI extern const char *DeregisterEHFrameSectionAllocActionName;
 
 LLVM_ABI extern const char *RegisterJITLoaderGDBAllocActionName;
+LLVM_ABI extern const char *DeregisterJITLoaderGDBAllocActionName;
 
 LLVM_ABI extern const char *const DispatchName;
 LLVM_ABI extern const char *const DispatchCtxName;

--- a/llvm/lib/ExecutionEngine/Orc/Debugging/DebuggerSupport.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Debugging/DebuggerSupport.cpp
@@ -24,12 +24,6 @@ Error enableDebuggerSupport(LLJIT &J) {
     return make_error<StringError>("Cannot enable LLJIT debugger support: "
                                    "Debugger support requires JITLink",
                                    inconvertibleErrorCode());
-  auto ProcessSymsJD = J.getProcessSymbolsJITDylib();
-  if (!ProcessSymsJD)
-    return make_error<StringError>("Cannot enable LLJIT debugger support: "
-                                   "Process symbols are not available",
-                                   inconvertibleErrorCode());
-
   auto &ES = J.getExecutionSession();
   const auto &TT = J.getTargetTriple();
 
@@ -41,7 +35,8 @@ Error enableDebuggerSupport(LLJIT &J) {
     return TargetSymErr;
   }
   case Triple::MachO: {
-    auto DS = GDBJITDebugInfoRegistrationPlugin::Create(ES, *ProcessSymsJD, TT);
+    auto DS = GDBJITDebugInfoRegistrationPlugin::Create(
+        ES, ES.getBootstrapJITDylib());
     if (!DS)
       return DS.takeError();
     ObjLinkingLayer->addPlugin(std::move(*DS));

--- a/llvm/lib/ExecutionEngine/Orc/Debugging/DebuggerSupportPlugin.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Debugging/DebuggerSupportPlugin.cpp
@@ -11,6 +11,7 @@
 
 #include "llvm/ExecutionEngine/Orc/Debugging/DebuggerSupportPlugin.h"
 #include "llvm/ExecutionEngine/Orc/MachOBuilder.h"
+#include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
 
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/BinaryFormat/MachO.h"
@@ -326,14 +327,10 @@ namespace orc {
 
 Expected<std::unique_ptr<GDBJITDebugInfoRegistrationPlugin>>
 GDBJITDebugInfoRegistrationPlugin::Create(ExecutionSession &ES,
-                                          JITDylib &ProcessJD,
-                                          const Triple &TT) {
-  auto RegisterActionAddr =
-      TT.isOSBinFormatMachO()
-          ? ES.intern("_llvm_orc_registerJITLoaderGDBAllocAction")
-          : ES.intern("llvm_orc_registerJITLoaderGDBAllocAction");
+                                          JITDylib &BootstrapJD) {
+  auto RegisterActionName = ES.intern(rt::RegisterJITLoaderGDBAllocActionName);
 
-  if (auto RegisterSym = ES.lookup({&ProcessJD}, RegisterActionAddr))
+  if (auto RegisterSym = ES.lookup({&BootstrapJD}, RegisterActionName))
     return std::make_unique<GDBJITDebugInfoRegistrationPlugin>(
         RegisterSym->getAddress());
   else

--- a/llvm/lib/ExecutionEngine/Orc/Shared/OrcRTBridge.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Shared/OrcRTBridge.cpp
@@ -40,7 +40,9 @@ const char *DeregisterEHFrameSectionAllocActionName =
     "llvm_orc_deregisterEHFrameAllocAction";
 
 const char *RegisterJITLoaderGDBAllocActionName =
-    "llvm_orc_registerJITLoaderGDBAllocAction";
+    "orc_rt_ci_aa_sps_GDBJITRegistrar_register";
+const char *DeregisterJITLoaderGDBAllocActionName =
+    "orc_rt_ci_aa_sps_GDBJITRegistrar_deregister";
 
 const char *const DispatchName = "__orc_rt_jit_dispatch";
 const char *const DispatchCtxName = "__orc_rt_jit_dispatch_ctx";

--- a/llvm/tools/llvm-jitlink/llvm-jitlink.cpp
+++ b/llvm/tools/llvm-jitlink/llvm-jitlink.cpp
@@ -1277,13 +1277,8 @@ Session::Session(std::unique_ptr<ExecutorProcessControl> EPC, Error &Err)
   }
 
   if (DebuggerSupport && TT.isOSBinFormatMachO()) {
-    if (!ProcessSymsJD) {
-      Err = make_error<StringError>("MachO debugging requires process symbols",
-                                    inconvertibleErrorCode());
-      return;
-    }
     ObjLayer->addPlugin(ExitOnErr(GDBJITDebugInfoRegistrationPlugin::Create(
-        this->ES, *ProcessSymsJD, TT)));
+        this->ES, this->ES.getBootstrapJITDylib())));
   }
 
   if (PerfSupport && TT.isOSBinFormatELF()) {


### PR DESCRIPTION
Align LLVM's GDB-JIT registration alloc-action names with the names added to the ORC runtime in 4a0fdbc25bb, and add a name for the deregistration action.

Look these names up in the Bootstrap JITDylib rather than the Process JITDylib. Since the lookup no longer depends on process symbols, drop the "requires process symbols" preconditions guarding MachO debugger support in llvm-jitlink and enableDebuggerSupport. GDBJITDebugInfoRegistrationPlugin::Create also loses its Triple parameter, which is now unused.

Together this lets GDBJITDebugInfoRegistrationPlugin work against either the LLVM OrcTargetProcess or ORC runtime implementation of these actions.