### PR TITLE
[libc++] Fix append_range and prepend_range benchmarks

### DIFF
--- a/libcxx/test/benchmarks/containers/sequence/sequence_container_benchmarks.h
+++ b/libcxx/test/benchmarks/containers/sequence/sequence_container_benchmarks.h
@@ -413,7 +413,7 @@ void sequence_container_benchmarks(std::string container) {
           DoNotOptimizeData(c);
 
           state.PauseTiming();
-          c.clear();
+          c = Container();
           state.ResumeTiming();
         }
       });
@@ -440,7 +440,7 @@ void sequence_container_benchmarks(std::string container) {
           DoNotOptimizeData(c);
 
           state.PauseTiming();
-          c.clear();
+          c = Container();
           state.ResumeTiming();
         }
       });


### PR DESCRIPTION
They were using clear(), which keeps the storage around, instead of starting over from an empty container.

Fixes #209499