### PR TITLE
[MIR] Test the unterminated quoted block name error path

### DIFF
--- a/llvm/test/CodeGen/MIR/AMDGPU/bb-name-needs-quotes.ll
+++ b/llvm/test/CodeGen/MIR/AMDGPU/bb-name-needs-quotes.ll
@@ -1,12 +1,9 @@
-; Basic block names that are not plain identifiers must be quoted when printed,
-; otherwise the MIR that llc emits cannot be parsed back by llc. The names here
-; contain commas and spaces, which is the shape a Fortran front end emits.
-;
-; Check both that the name is quoted on the way out and that the result parses.
+; Block names that are not plain identifiers must be quoted, otherwise llc
+; cannot parse back the MIR it just wrote.
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a -stop-before=greedy -o %t.mir %s
 ; RUN: FileCheck %s < %t.mir
-; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a -x mir -start-before=greedy -o /dev/null %t.mir
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a -x mir -start-before=greedy -filetype=null %t.mir
 
 ; CHECK: bb.0.entry:
 ; CHECK: bb.1.", bb71":

--- a/llvm/test/CodeGen/MIR/Generic/unterminated-quoted-block-name.mir
+++ b/llvm/test/CodeGen/MIR/Generic/unterminated-quoted-block-name.mir
@@ -1,0 +1,18 @@
+# RUN: not llc -run-pass none -o /dev/null %s 2>&1 | FileCheck %s
+# A quoted block name that is never closed must be diagnosed, not lexed as an
+# identifier.
+
+--- |
+
+  define void @f() {
+  entry:
+    ret void
+  }
+
+...
+---
+name:            f
+body: |
+  ; CHECK: [[@LINE+1]]:{{[0-9]+}}: unable to parse quoted string from opening quote
+  bb.0."unterminated
+...


### PR DESCRIPTION
Follow-up to #214054, addressing @arsenm's post-merge review.

The quoted-name branch added to `maybeLexMachineBasicBlock` calls `ErrorCallback` when `lexStringConstant` fails, and nothing exercised that path. New test `llvm/test/CodeGen/MIR/Generic/unterminated-quoted-block-name.mir` feeds it `bb.0."unterminated`. It is in `Generic` with no triple, since the change is generic CodeGen.

Verified the test is load-bearing rather than passing for the wrong reason: the same diagnostic string exists at two sites in `MILexer.cpp`, so I disabled the new branch and rebuilt. With it, the error is `unable to parse quoted string from opening quote`; without it, `expected ':'` and FileCheck fails. So the test reaches the new path, not the pre-existing one.

Also switches the parse-back RUN in `bb-name-needs-quotes.ll` to `-filetype=null`, and trims the header comment.

The third comment, "use new triples", is still open; I asked on the original PR which form is meant. The test uses `-mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a`, which is what the rest of `llvm/test/CodeGen` uses, so I did not want to guess. Happy to fold that change in here once it is settled.

Test-only, no functional change. The reduced cases and this change were produced with Claude; I reviewed and verified them.
