### PR TITLE
[Darwin][TSan] Use deadlock detector aware calls for Darwin-specific lock interceptors

### DIFF
--- a/compiler-rt/lib/tsan/rtl/tsan_interceptors_mac.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_interceptors_mac.cpp
@@ -213,8 +213,9 @@ TSAN_INTERCEPTOR(void, OSSpinLockLock, volatile OSSpinLock *lock) {
     return REAL(OSSpinLockLock)(lock);
   }
   SCOPED_TSAN_INTERCEPTOR(OSSpinLockLock, lock);
+  MutexPreLock(thr, pc, (uptr)lock);
   REAL(OSSpinLockLock)(lock);
-  Acquire(thr, pc, (uptr)lock);
+  MutexPostLock(thr, pc, (uptr)lock);
 }
 
 TSAN_INTERCEPTOR(bool, OSSpinLockTry, volatile OSSpinLock *lock) {
@@ -225,7 +226,7 @@ TSAN_INTERCEPTOR(bool, OSSpinLockTry, volatile OSSpinLock *lock) {
   SCOPED_TSAN_INTERCEPTOR(OSSpinLockTry, lock);
   bool result = REAL(OSSpinLockTry)(lock);
   if (result)
-    Acquire(thr, pc, (uptr)lock);
+    MutexPostLock(thr, pc, (uptr)lock, MutexFlagTryLock);
   return result;
 }
 
@@ -235,7 +236,7 @@ TSAN_INTERCEPTOR(void, OSSpinLockUnlock, volatile OSSpinLock *lock) {
     return REAL(OSSpinLockUnlock)(lock);
   }
   SCOPED_TSAN_INTERCEPTOR(OSSpinLockUnlock, lock);
-  Release(thr, pc, (uptr)lock);
+  MutexUnlock(thr, pc, (uptr)lock);
   REAL(OSSpinLockUnlock)(lock);
 }
 #  pragma clang diagnostic pop  // OSSpinLock* deprecation
@@ -246,8 +247,9 @@ TSAN_INTERCEPTOR(void, os_lock_lock, void *lock) {
     return REAL(os_lock_lock)(lock);
   }
   SCOPED_TSAN_INTERCEPTOR(os_lock_lock, lock);
+  MutexPreLock(thr, pc, (uptr)lock);
   REAL(os_lock_lock)(lock);
-  Acquire(thr, pc, (uptr)lock);
+  MutexPostLock(thr, pc, (uptr)lock);
 }
 
 TSAN_INTERCEPTOR(bool, os_lock_trylock, void *lock) {
@@ -258,7 +260,7 @@ TSAN_INTERCEPTOR(bool, os_lock_trylock, void *lock) {
   SCOPED_TSAN_INTERCEPTOR(os_lock_trylock, lock);
   bool result = REAL(os_lock_trylock)(lock);
   if (result)
-    Acquire(thr, pc, (uptr)lock);
+    MutexPostLock(thr, pc, (uptr)lock, MutexFlagTryLock);
   return result;
 }
 
@@ -268,7 +270,7 @@ TSAN_INTERCEPTOR(void, os_lock_unlock, void *lock) {
     return REAL(os_lock_unlock)(lock);
   }
   SCOPED_TSAN_INTERCEPTOR(os_lock_unlock, lock);
-  Release(thr, pc, (uptr)lock);
+  MutexUnlock(thr, pc, (uptr)lock);
   REAL(os_lock_unlock)(lock);
 }
 
@@ -277,8 +279,9 @@ TSAN_INTERCEPTOR(void, os_unfair_lock_lock, os_unfair_lock_t lock) {
     return REAL(os_unfair_lock_lock)(lock);
   }
   SCOPED_TSAN_INTERCEPTOR(os_unfair_lock_lock, lock);
+  MutexPreLock(thr, pc, (uptr)lock);
   REAL(os_unfair_lock_lock)(lock);
-  Acquire(thr, pc, (uptr)lock);
+  MutexPostLock(thr, pc, (uptr)lock);
 }
 
 // os_unfair_lock_lock_with_flags was introduced in macOS 15
@@ -294,8 +297,9 @@ TSAN_INTERCEPTOR(void, os_unfair_lock_lock_with_flags, os_unfair_lock_t lock,
     return REAL(os_unfair_lock_lock_with_flags)(lock, flags);
   }
   SCOPED_TSAN_INTERCEPTOR(os_unfair_lock_lock_with_flags, lock, flags);
+  MutexPreLock(thr, pc, (uptr)lock);
   REAL(os_unfair_lock_lock_with_flags)(lock, flags);
-  Acquire(thr, pc, (uptr)lock);
+  MutexPostLock(thr, pc, (uptr)lock);
 }
 #    pragma clang diagnostic pop
 #  endif
@@ -306,8 +310,9 @@ TSAN_INTERCEPTOR(void, os_unfair_lock_lock_with_options, os_unfair_lock_t lock,
     return REAL(os_unfair_lock_lock_with_options)(lock, options);
   }
   SCOPED_TSAN_INTERCEPTOR(os_unfair_lock_lock_with_options, lock, options);
+  MutexPreLock(thr, pc, (uptr)lock);
   REAL(os_unfair_lock_lock_with_options)(lock, options);
-  Acquire(thr, pc, (uptr)lock);
+  MutexPostLock(thr, pc, (uptr)lock);
 }
 
 TSAN_INTERCEPTOR(bool, os_unfair_lock_trylock, os_unfair_lock_t lock) {
@@ -317,7 +322,7 @@ TSAN_INTERCEPTOR(bool, os_unfair_lock_trylock, os_unfair_lock_t lock) {
   SCOPED_TSAN_INTERCEPTOR(os_unfair_lock_trylock, lock);
   bool result = REAL(os_unfair_lock_trylock)(lock);
   if (result)
-    Acquire(thr, pc, (uptr)lock);
+    MutexPostLock(thr, pc, (uptr)lock, MutexFlagTryLock);
   return result;
 }
 
@@ -326,7 +331,7 @@ TSAN_INTERCEPTOR(void, os_unfair_lock_unlock, os_unfair_lock_t lock) {
     return REAL(os_unfair_lock_unlock)(lock);
   }
   SCOPED_TSAN_INTERCEPTOR(os_unfair_lock_unlock, lock);
-  Release(thr, pc, (uptr)lock);
+  MutexUnlock(thr, pc, (uptr)lock);
   REAL(os_unfair_lock_unlock)(lock);
 }
 

--- a/compiler-rt/test/tsan/Darwin/os_unfair_lock_deadlock.c
+++ b/compiler-rt/test/tsan/Darwin/os_unfair_lock_deadlock.c
@@ -1,0 +1,39 @@
+// RUN: %clang_tsan %s -o %t
+// RUN: not %run %t 2>&1 | FileCheck %s
+
+#include <os/lock.h>
+#include <pthread.h>
+#include <stdio.h>
+
+long global_variable;
+os_unfair_lock lock1 = OS_UNFAIR_LOCK_INIT, lock2 = OS_UNFAIR_LOCK_INIT;
+
+void *LockInAscendingOrder(void *a) {
+  os_unfair_lock_lock(&lock1);
+  os_unfair_lock_lock(&lock2);
+  global_variable++;
+  os_unfair_lock_unlock(&lock2);
+  os_unfair_lock_unlock(&lock1);
+  return NULL;
+}
+
+void *LockInDescendingOrder(void *a) {
+  os_unfair_lock_lock(&lock2);
+  os_unfair_lock_lock(&lock1);
+  global_variable++;
+  os_unfair_lock_unlock(&lock1);
+  os_unfair_lock_unlock(&lock2);
+  return NULL;
+}
+
+int main() {
+  pthread_t t1, t2;
+  global_variable = 0;
+  pthread_create(&t1, NULL, LockInAscendingOrder, NULL);
+  pthread_join(t1, NULL);
+  pthread_create(&t2, NULL, LockInDescendingOrder, NULL);
+  pthread_join(t2, NULL);
+  // CHECK: WARNING: ThreadSanitizer: lock-order-inversion (potential deadlock)
+  fprintf(stderr, "global_variable = %ld\n", global_variable);
+  // CHECK: global_variable = 2
+}

--- a/compiler-rt/test/tsan/Darwin/trylock_no_deadlock.c
+++ b/compiler-rt/test/tsan/Darwin/trylock_no_deadlock.c
@@ -1,0 +1,93 @@
+// trylock should not count towards a lock cycle; this test checks that this
+// holds for Darwin-specific locks
+
+// RUN: %clang_tsan %s -o %t
+// RUN: %run %t 2>&1 | FileCheck %s --implicit-check-not='ThreadSanitizer'
+
+#include <libkern/OSAtomic.h>
+#include <libkern/OSSpinLockDeprecated.h>
+#include <os/lock.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+
+long global_variable;
+
+// --- os_unfair_lock ---------------------------------------------------------
+
+os_unfair_lock unfair1 = OS_UNFAIR_LOCK_INIT, unfair2 = OS_UNFAIR_LOCK_INIT;
+
+// Holds unfair1, then *tries* unfair2. Were an edge recorded for the
+// successful trylock, this would register unfair1 -> unfair2.
+void *UnfairTrylockSecond(void *a) {
+  os_unfair_lock_lock(&unfair1);
+  if (os_unfair_lock_trylock(&unfair2)) {
+    global_variable++;
+    os_unfair_lock_unlock(&unfair2);
+  }
+  os_unfair_lock_unlock(&unfair1);
+  return NULL;
+}
+
+// Blocking locks in the opposite order register unfair2 -> unfair1; combined
+// with a wrongly-recorded unfair1 -> unfair2 edge this would form a cycle.
+void *UnfairLockDescending(void *a) {
+  os_unfair_lock_lock(&unfair2);
+  os_unfair_lock_lock(&unfair1);
+  global_variable++;
+  os_unfair_lock_unlock(&unfair1);
+  os_unfair_lock_unlock(&unfair2);
+  return NULL;
+}
+
+// --- OSSpinLock -------------------------------------------------------------
+
+#pragma clang diagnostic push // OSSpinLock* deprecation
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
+OSSpinLock spin1 = OS_SPINLOCK_INIT, spin2 = OS_SPINLOCK_INIT;
+
+void *SpinTrylockSecond(void *a) {
+  OSSpinLockLock(&spin1);
+  if (OSSpinLockTry(&spin2)) {
+    global_variable++;
+    OSSpinLockUnlock(&spin2);
+  }
+  OSSpinLockUnlock(&spin1);
+  return NULL;
+}
+
+void *SpinLockDescending(void *a) {
+  OSSpinLockLock(&spin2);
+  OSSpinLockLock(&spin1);
+  global_variable++;
+  OSSpinLockUnlock(&spin1);
+  OSSpinLockUnlock(&spin2);
+  return NULL;
+}
+
+#pragma clang diagnostic pop // OSSpinLock* deprecation
+
+static void RunPair(void *(*first)(void *), void *(*second)(void *)) {
+  pthread_t t;
+  pthread_create(&t, NULL, first, NULL);
+  pthread_join(t, NULL);
+  pthread_create(&t, NULL, second, NULL);
+  pthread_join(t, NULL);
+}
+
+int main() {
+  global_variable = 0;
+
+  RunPair(UnfairTrylockSecond, UnfairLockDescending);
+  fprintf(stderr, "os_unfair_lock done\n");
+  // CHECK: os_unfair_lock done
+
+  RunPair(SpinTrylockSecond, SpinLockDescending);
+  fprintf(stderr, "OSSpinLock done\n");
+  // CHECK: OSSpinLock done
+
+  fprintf(stderr, "global_variable = %ld\n", global_variable);
+  // CHECK: global_variable = 4
+}


### PR DESCRIPTION
Currently the deadlock detector is unaware of these lock types because the interceptors use bare Acquire-Release calls. This patch switches them over to the Mutex(Pre|Post)Lock calls instead.

Assisted by: Claude

rdar://155410097