### PR TITLE
Add John McCall as Swift conformance maintainer

### DIFF
--- a/clang/Maintainers.md
+++ b/clang/Maintainers.md
@@ -303,6 +303,12 @@ serebrennikov.vladislav@gmail.com (email), [Endilll](https://github.com/Endilll)
 Akira Hatanaka \
 ahatanak@gmail.com, [ahatanak](https://github.com/ahatanak) (GitHub), ahatanak4220 (Discord), ahatanak (Discourse)
 
+### Swift conformance
+
+John McCall \
+rjmccall@apple.com (email), [rjmccall](https://github.com/rjmccall) (GitHub)
+
+
 ### OpenMP conformance
 
 Alexey Bataev \


### PR DESCRIPTION
We've had a small number of PRs and issues come up that touch on Swift, so this adds John as the point of contact for Swift related concerns as they come up in Clang.