### PR TITLE
[libcxx] Fix ODR violation in wchar.h

### DIFF
--- a/libcxx/include/__mbstate_t.h
+++ b/libcxx/include/__mbstate_t.h
@@ -49,10 +49,10 @@
 #  include <bits/mbstate_t.h> // works for Android
 #elif __has_include_next(<wchar.h>)
 // When this header is built as its own Clang module, the #include_next below can resolve back to
-// // libc++'s own <wchar.h> instead of the C library's one, since the lookup starts over from the
-// // beginning of the search path. libc++'s <wchar.h> forwards to the C library's one, but it would
-// // also emit its inline wcschr() & friends overloads into this module, in addition to the module
-// // owning <cwchar>. Tell it to provide only the C library declarations.
+// libc++'s own <wchar.h> instead of the C library's one, since the lookup starts over from the
+// beginning of the search path. libc++'s <wchar.h> forwards to the C library's one, but it would
+// also emit its inline wcschr() & friends overloads into this module, in addition to the module
+// owning <cwchar>. Tell it to provide only the C library declarations.
 #  define _LIBCPP_WCHAR_H_SYSTEM_HEADER_ONLY
 #  include_next <wchar.h> // use the C standard provider of mbstate_t if present
 #  undef _LIBCPP_WCHAR_H_SYSTEM_HEADER_ONLY

--- a/libcxx/include/__mbstate_t.h
+++ b/libcxx/include/__mbstate_t.h
@@ -48,7 +48,14 @@
 #elif __has_include(<bits/mbstate_t.h>)
 #  include <bits/mbstate_t.h> // works for Android
 #elif __has_include_next(<wchar.h>)
+// When this header is built as its own Clang module, the #include_next below can resolve back to
+// // libc++'s own <wchar.h> instead of the C library's one, since the lookup starts over from the
+// // beginning of the search path. libc++'s <wchar.h> forwards to the C library's one, but it would
+// // also emit its inline wcschr() & friends overloads into this module, in addition to the module
+// // owning <cwchar>. Tell it to provide only the C library declarations.
+#  define _LIBCPP_WCHAR_H_SYSTEM_HEADER_ONLY
 #  include_next <wchar.h> // use the C standard provider of mbstate_t if present
+#  undef _LIBCPP_WCHAR_H_SYSTEM_HEADER_ONLY
 #elif __has_include_next(<uchar.h>)
 #  include_next <uchar.h> // Try <uchar.h> in absence of <wchar.h> for mbstate_t
 #else

--- a/libcxx/include/wchar.h
+++ b/libcxx/include/wchar.h
@@ -116,7 +116,10 @@ size_t wcsrtombs(char* restrict dst, const wchar_t** restrict src, size_t len,
 #    include_next <wchar.h>
 #  endif
 
-#  ifndef _LIBCPP_WCHAR_H
+// <__mbstate_t.h> can reach us through its #include_next of <wchar.h>. It only needs the C library
+// // declarations pulled in above, and including <__mbstate_t.h> from here would be cyclic, so stop
+// // before libc++'s own additions in that case.
+#  if !defined(_LIBCPP_WCHAR_H) && !defined(_LIBCPP_WCHAR_H_SYSTEM_HEADER_ONLY)
 #    define _LIBCPP_WCHAR_H
 
 #    include <__mbstate_t.h> // provide mbstate_t

--- a/libcxx/include/wchar.h
+++ b/libcxx/include/wchar.h
@@ -117,8 +117,8 @@ size_t wcsrtombs(char* restrict dst, const wchar_t** restrict src, size_t len,
 #  endif
 
 // <__mbstate_t.h> can reach us through its #include_next of <wchar.h>. It only needs the C library
-// // declarations pulled in above, and including <__mbstate_t.h> from here would be cyclic, so stop
-// // before libc++'s own additions in that case.
+// declarations pulled in above, and including <__mbstate_t.h> from here would be cyclic, so stop
+// before libc++'s own additions in that case.
 #  if !defined(_LIBCPP_WCHAR_H) && !defined(_LIBCPP_WCHAR_H_SYSTEM_HEADER_ONLY)
 #    define _LIBCPP_WCHAR_H
 

--- a/libcxx/test/extensions/clang/clang_modules_include.gen.py
+++ b/libcxx/test/extensions/clang/clang_modules_include.gen.py
@@ -24,9 +24,6 @@
 # The Android headers don't appear to be compatible with modules yet
 # UNSUPPORTED: LIBCXX-ANDROID-FIXME
 
-# TODO: Investigate this failure
-# UNSUPPORTED: LIBCXX-FREEBSD-FIXME
-
 # TODO: Investigate why this doesn't work on Picolibc once the locale base API is refactored
 # UNSUPPORTED: LIBCXX-PICOLIBC-FIXME
 


### PR DESCRIPTION
When building the stdcxx Clang module, it includes `<cwchar>`, which triggers the inclusion of libc++'s `<wchar.h>` and instantiates the inline `__libcpp_wcschr` overloads. However, `<wchar.h>` includes `<__mbstate_t.h>`, which includes `<wchar.h>` again. This causes `__libcpp_wcschr` to be exposed to the std_private_mbstate_t module and results in an ODR violation.

This doesn't happen on other platforms because _LIBCPP_WCHAR_H_HAS_CONST_OVERLOADS is defined, so we don't instantiate __libcpp_wcschr.

To fix this, we introduce the _LIBCPP_WCHAR_H_SYSTEM_HEADER_ONLY stub macro to prevent <wchar.h> from instantiating its libc++ additions when building the std_private_mbstate_t module.