### PR TITLE
[OpenMP][OMPT] Make omp_control_tool enums available in omp-tools.h

### DIFF
--- a/openmp/runtime/src/include/omp-tools.h.var
+++ b/openmp/runtime/src/include/omp-tools.h.var
@@ -302,6 +302,24 @@ typedef uint64_t ompt_device_time_t;
 
 typedef uint64_t ompt_buffer_cursor_t;
 
+    /* OpenMP 6.1: Define in omp.h and omp-tools.h */
+#ifndef OMPCONTROLENUM
+#define OMPCONTROLENUM
+typedef enum omp_control_tool_result_t {
+  omp_control_tool_notool             = -2,
+  omp_control_tool_nocallback         = -1,
+  omp_control_tool_success            = 0,
+  omp_control_tool_ignored            = 1
+} omp_control_tool_result_t;
+
+typedef enum omp_control_tool_t {
+  omp_control_tool_start              = 1,
+  omp_control_tool_pause              = 2,
+  omp_control_tool_flush              = 3,
+  omp_control_tool_end                = 4
+} omp_control_tool_t;
+#endif OMPCONTROLENUM
+
 typedef enum ompt_thread_t {
   ompt_thread_initial                 = 1,
   ompt_thread_worker                  = 2,

--- a/openmp/runtime/src/include/omp.h.var
+++ b/openmp/runtime/src/include/omp.h.var
@@ -312,6 +312,9 @@
     extern void   __KAI_KMPC_CONVENTION  kmp_set_warnings_off(void);
 
     /* OpenMP 5.0 Tool Control */
+    /* OpenMP 6.1: Define in omp.h and omp-tools.h */
+#ifndef OMPCONTROLENUM
+#define OMPCONTROLENUM
     typedef enum omp_control_tool_result_t {
         omp_control_tool_notool = -2,
         omp_control_tool_nocallback = -1,
@@ -325,6 +328,7 @@
         omp_control_tool_flush = 3,
         omp_control_tool_end = 4
     } omp_control_tool_t;
+#endif OMPCONTROLENUM
 
     extern int __KAI_KMPC_CONVENTION omp_control_tool(int, int, void*);
 


### PR DESCRIPTION
OpenMP 6.1 will introduce this change: the enums must be available by including either header file, but including both must also be valid.