### PR TITLE
[lldb-dap] Spawn debug sever in the build directory.

### DIFF
--- a/lldb/test/API/tools/lldb-dap/attach/TestDAP_attachByPortNum.py
+++ b/lldb/test/API/tools/lldb-dap/attach/TestDAP_attachByPortNum.py
@@ -51,6 +51,7 @@ class TestDAP_attachByPortNum(DAPTestCaseBase):
             str(self.get_debug_server_path()),
             debug_server_args,
             install_remote=False,
+            cwd=self.getBuildDir(),
         )
 
         # Read the port number from the debug server pipe.
@@ -108,7 +109,9 @@ class TestDAP_attachByPortNum(DAPTestCaseBase):
         if debug_server.stem == "lldb-server":
             server_args = ["gdbserver", *server_args]
 
-        self.spawnSubprocess(str(debug_server), server_args, install_remote=False)
+        self.spawnSubprocess(
+            str(debug_server), server_args, install_remote=False, cwd=self.getBuildDir()
+        )
 
         pending = session.initialize_and_launch(
             AttachArgs(


### PR DESCRIPTION
The debugserver may create files such as the socket in the working directory.