### PR TITLE
[libc++] Return a const reference from get_key in benchmarks

### DIFF
--- a/libcxx/test/benchmarks/containers/associative/associative_container_benchmarks.h
+++ b/libcxx/test/benchmarks/containers/associative/associative_container_benchmarks.h
@@ -29,7 +29,7 @@ template <class Container>
 struct adapt_operations {
   // using ValueType = ...;
   // using KeyType   = ...;
-  // static ValueType create_value_from_key(KeyType const& k);
+  // static ValueType make_value_from_key(KeyType const& k);
   // static KeyType const& key_from_value(ValueType const& value);
 
   // using InsertionResult = ...;
@@ -56,7 +56,7 @@ void associative_container_benchmarks(std::string container) {
   auto make_value_types = [](std::vector<Key> const& keys) {
     std::vector<Value> kv;
     for (Key const& k : keys)
-      kv.push_back(adapt_operations<Container>::create_value_from_key(k));
+      kv.push_back(adapt_operations<Container>::make_value_from_key(k));
     return kv;
   };
 

--- a/libcxx/test/benchmarks/containers/associative/associative_container_benchmarks.h
+++ b/libcxx/test/benchmarks/containers/associative/associative_container_benchmarks.h
@@ -29,8 +29,8 @@ template <class Container>
 struct adapt_operations {
   // using ValueType = ...;
   // using KeyType   = ...;
-  // static ValueType value_from_key(KeyType const& k);
-  // static KeyType key_from_value(ValueType const& value);
+  // static ValueType create_value_from_key(KeyType const& k);
+  // static KeyType const& key_from_value(ValueType const& value);
 
   // using InsertionResult = ...;
   // static Container::iterator get_iterator(InsertionResult const&);
@@ -56,11 +56,11 @@ void associative_container_benchmarks(std::string container) {
   auto make_value_types = [](std::vector<Key> const& keys) {
     std::vector<Value> kv;
     for (Key const& k : keys)
-      kv.push_back(adapt_operations<Container>::value_from_key(k));
+      kv.push_back(adapt_operations<Container>::create_value_from_key(k));
     return kv;
   };
 
-  auto get_key = [](Value const& v) { return adapt_operations<Container>::key_from_value(v); };
+  auto get_key = [](Value const& v) -> Key const& { return adapt_operations<Container>::key_from_value(v); };
 
   auto bench = [&](std::string operation, auto f) {
     benchmark::RegisterBenchmark(container + "::" + operation, f)->Arg(0)->Arg(32)->Arg(8192);

--- a/libcxx/test/benchmarks/containers/associative/flat_map.bench.cpp
+++ b/libcxx/test/benchmarks/containers/associative/flat_map.bench.cpp
@@ -19,7 +19,7 @@ template <class K, class V>
 struct support::adapt_operations<std::flat_map<K, V>> {
   using ValueType = typename std::flat_map<K, V>::value_type;
   using KeyType   = typename std::flat_map<K, V>::key_type;
-  static ValueType create_value_from_key(KeyType const& k) { return {k, Generate<V>::arbitrary()}; }
+  static ValueType make_value_from_key(KeyType const& k) { return {k, Generate<V>::arbitrary()}; }
   static KeyType const& key_from_value(ValueType const& value) { return value.first; }
 
   using InsertionResult = std::pair<typename std::flat_map<K, V>::iterator, bool>;

--- a/libcxx/test/benchmarks/containers/associative/flat_map.bench.cpp
+++ b/libcxx/test/benchmarks/containers/associative/flat_map.bench.cpp
@@ -19,8 +19,8 @@ template <class K, class V>
 struct support::adapt_operations<std::flat_map<K, V>> {
   using ValueType = typename std::flat_map<K, V>::value_type;
   using KeyType   = typename std::flat_map<K, V>::key_type;
-  static ValueType value_from_key(KeyType const& k) { return {k, Generate<V>::arbitrary()}; }
-  static KeyType key_from_value(ValueType const& value) { return value.first; }
+  static ValueType create_value_from_key(KeyType const& k) { return {k, Generate<V>::arbitrary()}; }
+  static KeyType const& key_from_value(ValueType const& value) { return value.first; }
 
   using InsertionResult = std::pair<typename std::flat_map<K, V>::iterator, bool>;
   static auto get_iterator(InsertionResult const& result) { return result.first; }

--- a/libcxx/test/benchmarks/containers/associative/flat_multimap.bench.cpp
+++ b/libcxx/test/benchmarks/containers/associative/flat_multimap.bench.cpp
@@ -18,7 +18,7 @@ template <class K, class V>
 struct support::adapt_operations<std::flat_multimap<K, V>> {
   using ValueType = typename std::flat_multimap<K, V>::value_type;
   using KeyType   = typename std::flat_multimap<K, V>::key_type;
-  static ValueType create_value_from_key(KeyType const& k) { return {k, Generate<V>::arbitrary()}; }
+  static ValueType make_value_from_key(KeyType const& k) { return {k, Generate<V>::arbitrary()}; }
   static KeyType const& key_from_value(ValueType const& value) { return value.first; }
 
   using InsertionResult = typename std::flat_multimap<K, V>::iterator;

--- a/libcxx/test/benchmarks/containers/associative/flat_multimap.bench.cpp
+++ b/libcxx/test/benchmarks/containers/associative/flat_multimap.bench.cpp
@@ -18,8 +18,8 @@ template <class K, class V>
 struct support::adapt_operations<std::flat_multimap<K, V>> {
   using ValueType = typename std::flat_multimap<K, V>::value_type;
   using KeyType   = typename std::flat_multimap<K, V>::key_type;
-  static ValueType value_from_key(KeyType const& k) { return {k, Generate<V>::arbitrary()}; }
-  static KeyType key_from_value(ValueType const& value) { return value.first; }
+  static ValueType create_value_from_key(KeyType const& k) { return {k, Generate<V>::arbitrary()}; }
+  static KeyType const& key_from_value(ValueType const& value) { return value.first; }
 
   using InsertionResult = typename std::flat_multimap<K, V>::iterator;
   static auto get_iterator(InsertionResult const& result) { return result; }

--- a/libcxx/test/benchmarks/containers/associative/map.bench.cpp
+++ b/libcxx/test/benchmarks/containers/associative/map.bench.cpp
@@ -34,7 +34,7 @@ template <class K, class V>
 struct support::adapt_operations<std::map<K, V>> {
   using ValueType = typename std::map<K, V>::value_type;
   using KeyType   = typename std::map<K, V>::key_type;
-  static ValueType create_value_from_key(KeyType const& k) { return {k, Generate<V>::arbitrary()}; }
+  static ValueType make_value_from_key(KeyType const& k) { return {k, Generate<V>::arbitrary()}; }
   static KeyType const& key_from_value(ValueType const& value) { return value.first; }
 
   using InsertionResult = std::pair<typename std::map<K, V>::iterator, bool>;

--- a/libcxx/test/benchmarks/containers/associative/map.bench.cpp
+++ b/libcxx/test/benchmarks/containers/associative/map.bench.cpp
@@ -34,8 +34,8 @@ template <class K, class V>
 struct support::adapt_operations<std::map<K, V>> {
   using ValueType = typename std::map<K, V>::value_type;
   using KeyType   = typename std::map<K, V>::key_type;
-  static ValueType value_from_key(KeyType const& k) { return {k, Generate<V>::arbitrary()}; }
-  static KeyType key_from_value(ValueType const& value) { return value.first; }
+  static ValueType create_value_from_key(KeyType const& k) { return {k, Generate<V>::arbitrary()}; }
+  static KeyType const& key_from_value(ValueType const& value) { return value.first; }
 
   using InsertionResult = std::pair<typename std::map<K, V>::iterator, bool>;
   static auto get_iterator(InsertionResult const& result) { return result.first; }

--- a/libcxx/test/benchmarks/containers/associative/multimap.bench.cpp
+++ b/libcxx/test/benchmarks/containers/associative/multimap.bench.cpp
@@ -19,8 +19,8 @@ template <class K, class V>
 struct support::adapt_operations<std::multimap<K, V>> {
   using ValueType = typename std::multimap<K, V>::value_type;
   using KeyType   = typename std::multimap<K, V>::key_type;
-  static ValueType value_from_key(KeyType const& k) { return {k, Generate<V>::arbitrary()}; }
-  static KeyType key_from_value(ValueType const& value) { return value.first; }
+  static ValueType create_value_from_key(KeyType const& k) { return {k, Generate<V>::arbitrary()}; }
+  static KeyType const& key_from_value(ValueType const& value) { return value.first; }
 
   using InsertionResult = typename std::multimap<K, V>::iterator;
   static auto get_iterator(InsertionResult const& result) { return result; }

--- a/libcxx/test/benchmarks/containers/associative/multimap.bench.cpp
+++ b/libcxx/test/benchmarks/containers/associative/multimap.bench.cpp
@@ -19,7 +19,7 @@ template <class K, class V>
 struct support::adapt_operations<std::multimap<K, V>> {
   using ValueType = typename std::multimap<K, V>::value_type;
   using KeyType   = typename std::multimap<K, V>::key_type;
-  static ValueType create_value_from_key(KeyType const& k) { return {k, Generate<V>::arbitrary()}; }
+  static ValueType make_value_from_key(KeyType const& k) { return {k, Generate<V>::arbitrary()}; }
   static KeyType const& key_from_value(ValueType const& value) { return value.first; }
 
   using InsertionResult = typename std::multimap<K, V>::iterator;

--- a/libcxx/test/benchmarks/containers/associative/multiset.bench.cpp
+++ b/libcxx/test/benchmarks/containers/associative/multiset.bench.cpp
@@ -17,8 +17,8 @@ template <class K>
 struct support::adapt_operations<std::multiset<K>> {
   using ValueType = typename std::multiset<K>::value_type;
   using KeyType   = typename std::multiset<K>::key_type;
-  static ValueType value_from_key(KeyType const& k) { return k; }
-  static KeyType key_from_value(ValueType const& value) { return value; }
+  static ValueType create_value_from_key(KeyType const& k) { return k; }
+  static KeyType const& key_from_value(ValueType const& value) { return value; }
 
   using InsertionResult = typename std::multiset<K>::iterator;
   static auto get_iterator(InsertionResult const& result) { return result; }

--- a/libcxx/test/benchmarks/containers/associative/multiset.bench.cpp
+++ b/libcxx/test/benchmarks/containers/associative/multiset.bench.cpp
@@ -17,7 +17,7 @@ template <class K>
 struct support::adapt_operations<std::multiset<K>> {
   using ValueType = typename std::multiset<K>::value_type;
   using KeyType   = typename std::multiset<K>::key_type;
-  static ValueType create_value_from_key(KeyType const& k) { return k; }
+  static ValueType make_value_from_key(KeyType const& k) { return k; }
   static KeyType const& key_from_value(ValueType const& value) { return value; }
 
   using InsertionResult = typename std::multiset<K>::iterator;

--- a/libcxx/test/benchmarks/containers/associative/set.bench.cpp
+++ b/libcxx/test/benchmarks/containers/associative/set.bench.cpp
@@ -18,7 +18,7 @@ template <class K>
 struct support::adapt_operations<std::set<K>> {
   using ValueType = typename std::set<K>::value_type;
   using KeyType   = typename std::set<K>::key_type;
-  static ValueType create_value_from_key(KeyType const& k) { return k; }
+  static ValueType make_value_from_key(KeyType const& k) { return k; }
   static KeyType const& key_from_value(ValueType const& value) { return value; }
 
   using InsertionResult = std::pair<typename std::set<K>::iterator, bool>;

--- a/libcxx/test/benchmarks/containers/associative/set.bench.cpp
+++ b/libcxx/test/benchmarks/containers/associative/set.bench.cpp
@@ -18,8 +18,8 @@ template <class K>
 struct support::adapt_operations<std::set<K>> {
   using ValueType = typename std::set<K>::value_type;
   using KeyType   = typename std::set<K>::key_type;
-  static ValueType value_from_key(KeyType const& k) { return k; }
-  static KeyType key_from_value(ValueType const& value) { return value; }
+  static ValueType create_value_from_key(KeyType const& k) { return k; }
+  static KeyType const& key_from_value(ValueType const& value) { return value; }
 
   using InsertionResult = std::pair<typename std::set<K>::iterator, bool>;
   static auto get_iterator(InsertionResult const& result) { return result.first; }

--- a/libcxx/test/benchmarks/containers/associative/unordered_map.bench.cpp
+++ b/libcxx/test/benchmarks/containers/associative/unordered_map.bench.cpp
@@ -34,8 +34,8 @@ template <class K, class V>
 struct support::adapt_operations<std::unordered_map<K, V>> {
   using ValueType = typename std::unordered_map<K, V>::value_type;
   using KeyType   = typename std::unordered_map<K, V>::key_type;
-  static ValueType value_from_key(KeyType const& k) { return {k, Generate<V>::arbitrary()}; }
-  static KeyType key_from_value(ValueType const& value) { return value.first; }
+  static ValueType create_value_from_key(KeyType const& k) { return {k, Generate<V>::arbitrary()}; }
+  static KeyType const& key_from_value(ValueType const& value) { return value.first; }
 
   using InsertionResult = std::pair<typename std::unordered_map<K, V>::iterator, bool>;
   static auto get_iterator(InsertionResult const& result) { return result.first; }

--- a/libcxx/test/benchmarks/containers/associative/unordered_map.bench.cpp
+++ b/libcxx/test/benchmarks/containers/associative/unordered_map.bench.cpp
@@ -34,7 +34,7 @@ template <class K, class V>
 struct support::adapt_operations<std::unordered_map<K, V>> {
   using ValueType = typename std::unordered_map<K, V>::value_type;
   using KeyType   = typename std::unordered_map<K, V>::key_type;
-  static ValueType create_value_from_key(KeyType const& k) { return {k, Generate<V>::arbitrary()}; }
+  static ValueType make_value_from_key(KeyType const& k) { return {k, Generate<V>::arbitrary()}; }
   static KeyType const& key_from_value(ValueType const& value) { return value.first; }
 
   using InsertionResult = std::pair<typename std::unordered_map<K, V>::iterator, bool>;

--- a/libcxx/test/benchmarks/containers/associative/unordered_multimap.bench.cpp
+++ b/libcxx/test/benchmarks/containers/associative/unordered_multimap.bench.cpp
@@ -18,7 +18,7 @@ template <class K, class V>
 struct support::adapt_operations<std::unordered_multimap<K, V>> {
   using ValueType = typename std::unordered_multimap<K, V>::value_type;
   using KeyType   = typename std::unordered_multimap<K, V>::key_type;
-  static ValueType create_value_from_key(KeyType const& k) { return {k, Generate<V>::arbitrary()}; }
+  static ValueType make_value_from_key(KeyType const& k) { return {k, Generate<V>::arbitrary()}; }
   static KeyType const& key_from_value(ValueType const& value) { return value.first; }
 
   using InsertionResult = typename std::unordered_multimap<K, V>::iterator;

--- a/libcxx/test/benchmarks/containers/associative/unordered_multimap.bench.cpp
+++ b/libcxx/test/benchmarks/containers/associative/unordered_multimap.bench.cpp
@@ -18,8 +18,8 @@ template <class K, class V>
 struct support::adapt_operations<std::unordered_multimap<K, V>> {
   using ValueType = typename std::unordered_multimap<K, V>::value_type;
   using KeyType   = typename std::unordered_multimap<K, V>::key_type;
-  static ValueType value_from_key(KeyType const& k) { return {k, Generate<V>::arbitrary()}; }
-  static KeyType key_from_value(ValueType const& value) { return value.first; }
+  static ValueType create_value_from_key(KeyType const& k) { return {k, Generate<V>::arbitrary()}; }
+  static KeyType const& key_from_value(ValueType const& value) { return value.first; }
 
   using InsertionResult = typename std::unordered_multimap<K, V>::iterator;
   static auto get_iterator(InsertionResult const& result) { return result; }

--- a/libcxx/test/benchmarks/containers/associative/unordered_multiset.bench.cpp
+++ b/libcxx/test/benchmarks/containers/associative/unordered_multiset.bench.cpp
@@ -17,8 +17,8 @@ template <class K>
 struct support::adapt_operations<std::unordered_multiset<K>> {
   using ValueType = typename std::unordered_multiset<K>::value_type;
   using KeyType   = typename std::unordered_multiset<K>::key_type;
-  static ValueType value_from_key(KeyType const& k) { return k; }
-  static KeyType key_from_value(ValueType const& value) { return value; }
+  static ValueType create_value_from_key(KeyType const& k) { return k; }
+  static KeyType const& key_from_value(ValueType const& value) { return value; }
 
   using InsertionResult = typename std::unordered_multiset<K>::iterator;
   static auto get_iterator(InsertionResult const& result) { return result; }

--- a/libcxx/test/benchmarks/containers/associative/unordered_multiset.bench.cpp
+++ b/libcxx/test/benchmarks/containers/associative/unordered_multiset.bench.cpp
@@ -17,7 +17,7 @@ template <class K>
 struct support::adapt_operations<std::unordered_multiset<K>> {
   using ValueType = typename std::unordered_multiset<K>::value_type;
   using KeyType   = typename std::unordered_multiset<K>::key_type;
-  static ValueType create_value_from_key(KeyType const& k) { return k; }
+  static ValueType make_value_from_key(KeyType const& k) { return k; }
   static KeyType const& key_from_value(ValueType const& value) { return value; }
 
   using InsertionResult = typename std::unordered_multiset<K>::iterator;

--- a/libcxx/test/benchmarks/containers/associative/unordered_set.bench.cpp
+++ b/libcxx/test/benchmarks/containers/associative/unordered_set.bench.cpp
@@ -19,8 +19,8 @@ template <class K>
 struct support::adapt_operations<std::unordered_set<K>> {
   using ValueType = typename std::unordered_set<K>::value_type;
   using KeyType   = typename std::unordered_set<K>::key_type;
-  static ValueType value_from_key(KeyType const& k) { return k; }
-  static KeyType key_from_value(ValueType const& value) { return value; }
+  static ValueType create_value_from_key(KeyType const& k) { return k; }
+  static KeyType const& key_from_value(ValueType const& value) { return value; }
 
   using InsertionResult = std::pair<typename std::unordered_set<K>::iterator, bool>;
   static auto get_iterator(InsertionResult const& result) { return result.first; }

--- a/libcxx/test/benchmarks/containers/associative/unordered_set.bench.cpp
+++ b/libcxx/test/benchmarks/containers/associative/unordered_set.bench.cpp
@@ -19,7 +19,7 @@ template <class K>
 struct support::adapt_operations<std::unordered_set<K>> {
   using ValueType = typename std::unordered_set<K>::value_type;
   using KeyType   = typename std::unordered_set<K>::key_type;
-  static ValueType create_value_from_key(KeyType const& k) { return k; }
+  static ValueType make_value_from_key(KeyType const& k) { return k; }
   static KeyType const& key_from_value(ValueType const& value) { return value; }
 
   using InsertionResult = std::pair<typename std::unordered_set<K>::iterator, bool>;


### PR DESCRIPTION
It was unnecessary to create a temporary string, and in fact it would have a negative impact on some benchmarks like `erase(key) (existent)` which called get_key in the hot loop.