### PR TITLE
[llvm][DebugInfo][NFC] Add equality operators to DISourceLanguageName

### DIFF
--- a/llvm/include/llvm/IR/DebugInfoMetadata.h
+++ b/llvm/include/llvm/IR/DebugInfoMetadata.h
@@ -121,6 +121,21 @@ public:
 
   uint16_t getDialect() const { return Dialect; }
 
+  /// Returns \c true if \p LHS and \p RHS hold the same language name,
+  /// version and dialect. Note that this is a structural comparison; a
+  /// versioned name never compares equal to an unversioned one, even if
+  /// both denote the same source language.
+  friend bool operator==(const DISourceLanguageName &LHS,
+                         const DISourceLanguageName &RHS) {
+    return LHS.Name == RHS.Name && LHS.HasVersion == RHS.HasVersion &&
+           LHS.Version == RHS.Version && LHS.Dialect == RHS.Dialect;
+  }
+
+  friend bool operator!=(const DISourceLanguageName &LHS,
+                         const DISourceLanguageName &RHS) {
+    return !(LHS == RHS);
+  }
+
   DISourceLanguageName(uint16_t Lang, uint32_t Version, uint16_t Dialect = 0)
       : Version(Version), Name(Lang), HasVersion(true), Dialect(Dialect) {}
   DISourceLanguageName(uint16_t Lang, uint16_t Dialect = 0)

--- a/llvm/unittests/IR/MetadataTest.cpp
+++ b/llvm/unittests/IR/MetadataTest.cpp
@@ -2877,6 +2877,25 @@ TEST_F(DIFileTest, ScopeGetFile) {
   EXPECT_EQ(N, N->getFile());
 }
 
+TEST(DISourceLanguageNameTest, Comparison) {
+  DISourceLanguageName CppUnversioned(dwarf::DW_LNAME_C_plus_plus);
+  DISourceLanguageName CppUnversionedAgain(dwarf::DW_LNAME_C_plus_plus);
+  DISourceLanguageName CUnversioned(dwarf::DW_LNAME_C);
+  DISourceLanguageName Cpp17(dwarf::DW_LNAME_C_plus_plus, uint32_t(201703));
+  DISourceLanguageName Cpp17Again(dwarf::DW_LNAME_C_plus_plus,
+                                  uint32_t(201703));
+  DISourceLanguageName Cpp20(dwarf::DW_LNAME_C_plus_plus, uint32_t(202002));
+  DISourceLanguageName CppWithDialect(dwarf::DW_LNAME_C_plus_plus, uint16_t(1));
+
+  EXPECT_EQ(CppUnversioned, CppUnversionedAgain);
+  EXPECT_EQ(Cpp17, Cpp17Again);
+
+  EXPECT_NE(CppUnversioned, CUnversioned);   // Different name.
+  EXPECT_NE(Cpp17, Cpp20);                   // Different version.
+  EXPECT_NE(CppUnversioned, CppWithDialect); // Different dialect.
+  EXPECT_NE(CppUnversioned, Cpp17);          // Versioned vs. unversioned.
+}
+
 typedef MetadataTest DICompileUnitTest;
 
 TEST_F(DICompileUnitTest, get) {


### PR DESCRIPTION
`DISourceLanguageName` is a value type, yet it currently lacks an equality operator (`operator==`). To check if two compile units share the same source language, callers currently have to manually compare fields using `hasVersionedName()`, `getName()`, `getVersion()`, and `getDialect()`. In particular, calling `getVersion()` when no version is set triggers an assertion, making a correct manual comparison easy to get wrong.

In addition, the type has already evolved once since its introduction (adding `Dialect` in #194898) and its layout may change further in the future (#162255). Client-side comparison logic can fail to account for such changes, leading to unexpected behavior.

This patch adds `operator==` (and `operator!=`) to `DISourceLanguageName`. It checks for structural equality—returning true only when the name, whether the name is versioned, version, and dialect all match.

Semantic equality is intentionally out of scope. Whether two language tags are semantically equivalent depends on the client's context; if needed, callers can already normalize names using `llvm::dwarf::toDW_LNAME()` prior to comparison.

AI usage:
- Discussed the design and drafted unit tests with Claude. Manually reviewed.