### PR TITLE
[GlobalISel] Port computeNumSignBits for G_SAVGFLOOR/G_SAVGCEIL

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/GISelValueTracking.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/GISelValueTracking.cpp
@@ -2423,6 +2423,13 @@ unsigned GISelValueTracking::computeNumSignBits(Register R,
         SignBitsOps::rot(Tmp, TyBits, MaybeAmt, Opcode == TargetOpcode::G_ROTR);
     break;
   }
+  case TargetOpcode::G_SAVGFLOOR:
+  case TargetOpcode::G_SAVGCEIL: {
+    Register Src1 = MI.getOperand(1).getReg();
+    Register Src2 = MI.getOperand(2).getReg();
+    FirstAnswer = computeNumSignBitsMin(Src1, Src2, DemandedElts, Depth + 1);
+    break;
+  }
   case TargetOpcode::G_SREM: {
     // The sign bit is the LHS's sign bit, except when the result of the
     // remainder is zero. The magnitude of the result should be less than or

--- a/llvm/test/CodeGen/AArch64/GlobalISel/knownbits-avg.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/knownbits-avg.mir
@@ -6,9 +6,9 @@ name: Cst_UAvgFloor
 body: |
   bb.0:
   ; CHECK-LABEL: name: @Cst_UAvgFloor
-  ; CHECK-NEXT: %0:_ KnownBits:00001011 SignBits:4
-  ; CHECK-NEXT: %1:_ KnownBits:00000100 SignBits:5
-  ; CHECK-NEXT: %2:_ KnownBits:00000111 SignBits:5
+  ; CHECK-NEXT: %0:_ KnownBits:00001011 SignBits:4 IsKnownNeverZero:1
+  ; CHECK-NEXT: %1:_ KnownBits:00000100 SignBits:5 IsKnownNeverZero:1
+  ; CHECK-NEXT: %2:_ KnownBits:00000111 SignBits:5 IsKnownNeverZero:1
     %0:_(i8) = G_CONSTANT i8 11
     %1:_(i8) = G_CONSTANT i8 4
     %2:_(i8) = G_UAVGFLOOR %0, %1
@@ -18,9 +18,9 @@ name: Cst_UAvgCeil
 body: |
   bb.0:
   ; CHECK-LABEL: name: @Cst_UAvgCeil
-  ; CHECK-NEXT: %0:_ KnownBits:00001011 SignBits:4
-  ; CHECK-NEXT: %1:_ KnownBits:00000100 SignBits:5
-  ; CHECK-NEXT: %2:_ KnownBits:00001000 SignBits:4
+  ; CHECK-NEXT: %0:_ KnownBits:00001011 SignBits:4 IsKnownNeverZero:1
+  ; CHECK-NEXT: %1:_ KnownBits:00000100 SignBits:5 IsKnownNeverZero:1
+  ; CHECK-NEXT: %2:_ KnownBits:00001000 SignBits:4 IsKnownNeverZero:1
     %0:_(i8) = G_CONSTANT i8 11
     %1:_(i8) = G_CONSTANT i8 4
     %2:_(i8) = G_UAVGCEIL %0, %1
@@ -30,9 +30,9 @@ name: CstNoOverflow_UAvgFloor
 body: |
   bb.0:
   ; CHECK-LABEL: name: @CstNoOverflow_UAvgFloor
-  ; CHECK-NEXT: %0:_ KnownBits:11001000 SignBits:2
-  ; CHECK-NEXT: %1:_ KnownBits:01100100 SignBits:1
-  ; CHECK-NEXT: %2:_ KnownBits:10010110 SignBits:1
+  ; CHECK-NEXT: %0:_ KnownBits:11001000 SignBits:2 IsKnownNeverZero:1
+  ; CHECK-NEXT: %1:_ KnownBits:01100100 SignBits:1 IsKnownNeverZero:1
+  ; CHECK-NEXT: %2:_ KnownBits:10010110 SignBits:1 IsKnownNeverZero:1
     %0:_(i8) = G_CONSTANT i8 200
     %1:_(i8) = G_CONSTANT i8 100
     %2:_(i8) = G_UAVGFLOOR %0, %1
@@ -42,9 +42,9 @@ name: CstNoOverflow_UAvgCeil
 body: |
   bb.0:
   ; CHECK-LABEL: name: @CstNoOverflow_UAvgCeil
-  ; CHECK-NEXT: %0:_ KnownBits:11111111 SignBits:8
-  ; CHECK-NEXT: %1:_ KnownBits:11111111 SignBits:8
-  ; CHECK-NEXT: %2:_ KnownBits:11111111 SignBits:8
+  ; CHECK-NEXT: %0:_ KnownBits:11111111 SignBits:8 IsKnownNeverZero:1
+  ; CHECK-NEXT: %1:_ KnownBits:11111111 SignBits:8 IsKnownNeverZero:1
+  ; CHECK-NEXT: %2:_ KnownBits:11111111 SignBits:8 IsKnownNeverZero:1
     %0:_(i8) = G_CONSTANT i8 255
     %1:_(i8) = G_CONSTANT i8 255
     %2:_(i8) = G_UAVGCEIL %0, %1
@@ -54,9 +54,9 @@ name: Cst_SAvgFloor
 body: |
   bb.0:
   ; CHECK-LABEL: name: @Cst_SAvgFloor
-  ; CHECK-NEXT: %0:_ KnownBits:11110110 SignBits:4
-  ; CHECK-NEXT: %1:_ KnownBits:00000100 SignBits:5
-  ; CHECK-NEXT: %2:_ KnownBits:11111101 SignBits:6
+  ; CHECK-NEXT: %0:_ KnownBits:11110110 SignBits:4 IsKnownNeverZero:1
+  ; CHECK-NEXT: %1:_ KnownBits:00000100 SignBits:5 IsKnownNeverZero:1
+  ; CHECK-NEXT: %2:_ KnownBits:11111101 SignBits:6 IsKnownNeverZero:1
     %0:_(i8) = G_CONSTANT i8 -10
     %1:_(i8) = G_CONSTANT i8 4
     %2:_(i8) = G_SAVGFLOOR %0, %1
@@ -66,9 +66,9 @@ name: CstNoOverflow_SAvgFloor
 body: |
   bb.0:
   ; CHECK-LABEL: name: @CstNoOverflow_SAvgFloor
-  ; CHECK-NEXT: %0:_ KnownBits:10011100 SignBits:1
-  ; CHECK-NEXT: %1:_ KnownBits:10011100 SignBits:1
-  ; CHECK-NEXT: %2:_ KnownBits:10011100 SignBits:1
+  ; CHECK-NEXT: %0:_ KnownBits:10011100 SignBits:1 IsKnownNeverZero:1
+  ; CHECK-NEXT: %1:_ KnownBits:10011100 SignBits:1 IsKnownNeverZero:1
+  ; CHECK-NEXT: %2:_ KnownBits:10011100 SignBits:1 IsKnownNeverZero:1
     %0:_(i8) = G_CONSTANT i8 -100
     %1:_(i8) = G_CONSTANT i8 -100
     %2:_(i8) = G_SAVGFLOOR %0, %1
@@ -78,9 +78,9 @@ name: CstNoOverflow_SAvgCeil
 body: |
   bb.0:
   ; CHECK-LABEL: name: @CstNoOverflow_SAvgCeil
-  ; CHECK-NEXT: %0:_ KnownBits:01111111 SignBits:1
-  ; CHECK-NEXT: %1:_ KnownBits:01111111 SignBits:1
-  ; CHECK-NEXT: %2:_ KnownBits:01111111 SignBits:1
+  ; CHECK-NEXT: %0:_ KnownBits:01111111 SignBits:1 IsKnownNeverZero:1
+  ; CHECK-NEXT: %1:_ KnownBits:01111111 SignBits:1 IsKnownNeverZero:1
+  ; CHECK-NEXT: %2:_ KnownBits:01111111 SignBits:1 IsKnownNeverZero:1
     %0:_(i8) = G_CONSTANT i8 127
     %1:_(i8) = G_CONSTANT i8 127
     %2:_(i8) = G_SAVGCEIL %0, %1
@@ -90,11 +90,11 @@ name: PartialKnown_UAvgFloor
 body: |
   bb.0:
   ; CHECK-LABEL: name: @PartialKnown_UAvgFloor
-  ; CHECK-NEXT: %0:_ KnownBits:???????? SignBits:1
-  ; CHECK-NEXT: %1:_ KnownBits:00001111 SignBits:4
-  ; CHECK-NEXT: %2:_ KnownBits:0000???? SignBits:4
-  ; CHECK-NEXT: %3:_ KnownBits:00000100 SignBits:5
-  ; CHECK-NEXT: %4:_ KnownBits:0000???? SignBits:4
+  ; CHECK-NEXT: %0:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+  ; CHECK-NEXT: %1:_ KnownBits:00001111 SignBits:4 IsKnownNeverZero:1
+  ; CHECK-NEXT: %2:_ KnownBits:0000???? SignBits:4 IsKnownNeverZero:0
+  ; CHECK-NEXT: %3:_ KnownBits:00000100 SignBits:5 IsKnownNeverZero:1
+  ; CHECK-NEXT: %4:_ KnownBits:0000???? SignBits:4 IsKnownNeverZero:0
     %0:_(i8) = G_IMPLICIT_DEF
     %1:_(i8) = G_CONSTANT i8 15
     %2:_(i8) = G_AND %0, %1
@@ -106,11 +106,11 @@ name: Vector_UAvgFloor
 body: |
   bb.0:
   ; CHECK-LABEL: name: @Vector_UAvgFloor
-  ; CHECK-NEXT: %0:_ KnownBits:11001000 SignBits:2
-  ; CHECK-NEXT: %1:_ KnownBits:01100100 SignBits:1
-  ; CHECK-NEXT: %2:_ KnownBits:11001000 SignBits:2
-  ; CHECK-NEXT: %3:_ KnownBits:01100100 SignBits:1
-  ; CHECK-NEXT: %4:_ KnownBits:10010110 SignBits:1
+  ; CHECK-NEXT: %0:_ KnownBits:11001000 SignBits:2 IsKnownNeverZero:1
+  ; CHECK-NEXT: %1:_ KnownBits:01100100 SignBits:1 IsKnownNeverZero:1
+  ; CHECK-NEXT: %2:_ KnownBits:11001000 SignBits:2 IsKnownNeverZero:1
+  ; CHECK-NEXT: %3:_ KnownBits:01100100 SignBits:1 IsKnownNeverZero:1
+  ; CHECK-NEXT: %4:_ KnownBits:10010110 SignBits:1 IsKnownNeverZero:1
     %0:_(i8) = G_CONSTANT i8 200
     %1:_(i8) = G_CONSTANT i8 100
     %2:_(<2 x i8>) = G_BUILD_VECTOR %0, %0
@@ -122,10 +122,134 @@ name: Unknown_SAvgCeil
 body: |
   bb.0:
   ; CHECK-LABEL: name: @Unknown_SAvgCeil
-  ; CHECK-NEXT: %0:_ KnownBits:???????? SignBits:1
-  ; CHECK-NEXT: %1:_ KnownBits:???????? SignBits:1
-  ; CHECK-NEXT: %2:_ KnownBits:???????? SignBits:1
+  ; CHECK-NEXT: %0:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+  ; CHECK-NEXT: %1:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+  ; CHECK-NEXT: %2:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
     %0:_(i8) = COPY $b0
     %1:_(i8) = COPY $b1
     %2:_(i8) = G_SAVGCEIL %0, %1
+...
+---
+name: SExtInReg_SAvgFloor
+body: |
+  bb.0:
+  ; CHECK-LABEL: name: @SExtInReg_SAvgFloor
+  ; CHECK-NEXT: %0:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+  ; CHECK-NEXT: %1:_ KnownBits:???????? SignBits:5 IsKnownNeverZero:0
+  ; CHECK-NEXT: %2:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+  ; CHECK-NEXT: %3:_ KnownBits:???????? SignBits:5 IsKnownNeverZero:0
+  ; CHECK-NEXT: %4:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+    %0:_(i8) = COPY $b0
+    %1:_(i8) = G_SEXT_INREG %0, 4
+    %2:_(i8) = COPY $b1
+    %3:_(i8) = G_SEXT_INREG %2, 4
+    %4:_(i8) = G_SAVGFLOOR %1, %3
+...
+---
+name: SExtInReg_SAvgCeil
+body: |
+  bb.0:
+  ; CHECK-LABEL: name: @SExtInReg_SAvgCeil
+  ; CHECK-NEXT: %0:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+  ; CHECK-NEXT: %1:_ KnownBits:???????? SignBits:5 IsKnownNeverZero:0
+  ; CHECK-NEXT: %2:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+  ; CHECK-NEXT: %3:_ KnownBits:???????? SignBits:5 IsKnownNeverZero:0
+  ; CHECK-NEXT: %4:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+    %0:_(i8) = COPY $b0
+    %1:_(i8) = G_SEXT_INREG %0, 4
+    %2:_(i8) = COPY $b1
+    %3:_(i8) = G_SEXT_INREG %2, 4
+    %4:_(i8) = G_SAVGCEIL %1, %3
+...
+---
+name: SExtInRegMixed_SAvgFloor
+body: |
+  bb.0:
+  ; CHECK-LABEL: name: @SExtInRegMixed_SAvgFloor
+  ; CHECK-NEXT: %0:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+  ; CHECK-NEXT: %1:_ KnownBits:???????? SignBits:5 IsKnownNeverZero:0
+  ; CHECK-NEXT: %2:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+  ; CHECK-NEXT: %3:_ KnownBits:???????? SignBits:3 IsKnownNeverZero:0
+  ; CHECK-NEXT: %4:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+    %0:_(i8) = COPY $b0
+    %1:_(i8) = G_SEXT_INREG %0, 4
+    %2:_(i8) = COPY $b1
+    %3:_(i8) = G_SEXT_INREG %2, 6
+    %4:_(i8) = G_SAVGFLOOR %1, %3
+...
+---
+name: SExtInRegMixed_SAvgCeil
+body: |
+  bb.0:
+  ; CHECK-LABEL: name: @SExtInRegMixed_SAvgCeil
+  ; CHECK-NEXT: %0:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+  ; CHECK-NEXT: %1:_ KnownBits:???????? SignBits:5 IsKnownNeverZero:0
+  ; CHECK-NEXT: %2:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+  ; CHECK-NEXT: %3:_ KnownBits:???????? SignBits:3 IsKnownNeverZero:0
+  ; CHECK-NEXT: %4:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+    %0:_(i8) = COPY $b0
+    %1:_(i8) = G_SEXT_INREG %0, 4
+    %2:_(i8) = COPY $b1
+    %3:_(i8) = G_SEXT_INREG %2, 6
+    %4:_(i8) = G_SAVGCEIL %1, %3
+...
+---
+name: UnknownOperand_SAvgFloor
+body: |
+  bb.0:
+  ; CHECK-LABEL: name: @UnknownOperand_SAvgFloor
+  ; CHECK-NEXT: %0:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+  ; CHECK-NEXT: %1:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+  ; CHECK-NEXT: %2:_ KnownBits:???????? SignBits:5 IsKnownNeverZero:0
+  ; CHECK-NEXT: %3:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+    %0:_(i8) = COPY $b0
+    %1:_(i8) = COPY $b1
+    %2:_(i8) = G_SEXT_INREG %1, 4
+    %3:_(i8) = G_SAVGFLOOR %0, %2
+...
+---
+name: UnknownOperand_SAvgCeil
+body: |
+  bb.0:
+  ; CHECK-LABEL: name: @UnknownOperand_SAvgCeil
+  ; CHECK-NEXT: %0:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+  ; CHECK-NEXT: %1:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+  ; CHECK-NEXT: %2:_ KnownBits:???????? SignBits:5 IsKnownNeverZero:0
+  ; CHECK-NEXT: %3:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+    %0:_(i8) = COPY $b0
+    %1:_(i8) = COPY $b1
+    %2:_(i8) = G_SEXT_INREG %1, 4
+    %3:_(i8) = G_SAVGCEIL %0, %2
+...
+---
+name: UnknownOperand_SAvgFloor_Mirror
+body: |
+  bb.0:
+  ; CHECK-LABEL: name: @UnknownOperand_SAvgFloor_Mirror
+  ; CHECK-NEXT: %0:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+  ; CHECK-NEXT: %1:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+  ; CHECK-NEXT: %2:_ KnownBits:???????? SignBits:5 IsKnownNeverZero:0
+  ; CHECK-NEXT: %3:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+    %0:_(i8) = COPY $b0
+    %1:_(i8) = COPY $b1
+    %2:_(i8) = G_SEXT_INREG %1, 4
+    %3:_(i8) = G_SAVGFLOOR %2, %0
+...
+---
+name: AShr_SAvgFloor
+body: |
+  bb.0:
+  ; CHECK-LABEL: name: @AShr_SAvgFloor
+  ; CHECK-NEXT: %0:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+  ; CHECK-NEXT: %1:_ KnownBits:00000011 SignBits:6 IsKnownNeverZero:1
+  ; CHECK-NEXT: %2:_ KnownBits:???????? SignBits:4 IsKnownNeverZero:0
+  ; CHECK-NEXT: %3:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+  ; CHECK-NEXT: %4:_ KnownBits:???????? SignBits:4 IsKnownNeverZero:0
+  ; CHECK-NEXT: %5:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+    %0:_(i8) = COPY $b0
+    %1:_(i8) = G_CONSTANT i8 3
+    %2:_(i8) = G_ASHR %0, %1
+    %3:_(i8) = COPY $b1
+    %4:_(i8) = G_ASHR %3, %1
+    %5:_(i8) = G_SAVGFLOOR %2, %4
 ...

--- a/llvm/test/CodeGen/AArch64/GlobalISel/knownbits-avg.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/knownbits-avg.mir
@@ -138,7 +138,7 @@ body: |
   ; CHECK-NEXT: %1:_ KnownBits:???????? SignBits:5 IsKnownNeverZero:0
   ; CHECK-NEXT: %2:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
   ; CHECK-NEXT: %3:_ KnownBits:???????? SignBits:5 IsKnownNeverZero:0
-  ; CHECK-NEXT: %4:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+  ; CHECK-NEXT: %4:_ KnownBits:???????? SignBits:5 IsKnownNeverZero:0
     %0:_(i8) = COPY $b0
     %1:_(i8) = G_SEXT_INREG %0, 4
     %2:_(i8) = COPY $b1
@@ -154,7 +154,7 @@ body: |
   ; CHECK-NEXT: %1:_ KnownBits:???????? SignBits:5 IsKnownNeverZero:0
   ; CHECK-NEXT: %2:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
   ; CHECK-NEXT: %3:_ KnownBits:???????? SignBits:5 IsKnownNeverZero:0
-  ; CHECK-NEXT: %4:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+  ; CHECK-NEXT: %4:_ KnownBits:???????? SignBits:5 IsKnownNeverZero:0
     %0:_(i8) = COPY $b0
     %1:_(i8) = G_SEXT_INREG %0, 4
     %2:_(i8) = COPY $b1
@@ -170,7 +170,7 @@ body: |
   ; CHECK-NEXT: %1:_ KnownBits:???????? SignBits:5 IsKnownNeverZero:0
   ; CHECK-NEXT: %2:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
   ; CHECK-NEXT: %3:_ KnownBits:???????? SignBits:3 IsKnownNeverZero:0
-  ; CHECK-NEXT: %4:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+  ; CHECK-NEXT: %4:_ KnownBits:???????? SignBits:3 IsKnownNeverZero:0
     %0:_(i8) = COPY $b0
     %1:_(i8) = G_SEXT_INREG %0, 4
     %2:_(i8) = COPY $b1
@@ -186,7 +186,7 @@ body: |
   ; CHECK-NEXT: %1:_ KnownBits:???????? SignBits:5 IsKnownNeverZero:0
   ; CHECK-NEXT: %2:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
   ; CHECK-NEXT: %3:_ KnownBits:???????? SignBits:3 IsKnownNeverZero:0
-  ; CHECK-NEXT: %4:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+  ; CHECK-NEXT: %4:_ KnownBits:???????? SignBits:3 IsKnownNeverZero:0
     %0:_(i8) = COPY $b0
     %1:_(i8) = G_SEXT_INREG %0, 4
     %2:_(i8) = COPY $b1
@@ -245,7 +245,7 @@ body: |
   ; CHECK-NEXT: %2:_ KnownBits:???????? SignBits:4 IsKnownNeverZero:0
   ; CHECK-NEXT: %3:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
   ; CHECK-NEXT: %4:_ KnownBits:???????? SignBits:4 IsKnownNeverZero:0
-  ; CHECK-NEXT: %5:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+  ; CHECK-NEXT: %5:_ KnownBits:???????? SignBits:4 IsKnownNeverZero:0
     %0:_(i8) = COPY $b0
     %1:_(i8) = G_CONSTANT i8 3
     %2:_(i8) = G_ASHR %0, %1


### PR DESCRIPTION
Ports the ISD::AVGCEILS / ISD::AVGFLOORS case from SelectionDAG::ComputeNumSignBits over to GISelValueTracking::computeNumSignBits.
Part of #150515.

Unlike the SelectionDAG version, this sets FirstAnswer and breaks rather than returning directly, so the known-bits fallback at the end of computeNumSignBits still applies. That matters for the pre-existing constant-operand tests, where the known bits are fully determined and yield more sign bits than min() of the operands does; returning early would regress them.

Claude Code helped me navigate the codebase and write the PR description.