### PR TITLE
[mlir][ArmNeon] Enable native I8MM integration testing on Darwin

### DIFF
--- a/mlir/cmake/modules/MLIRCheckHardwareFeatures.cmake
+++ b/mlir/cmake/modules/MLIRCheckHardwareFeatures.cmake
@@ -121,8 +121,8 @@ endfunction(check_hwcap)
 #   emulator_exec
 # )
 #
-# mlir_e2e_tests  - MLIR CMake variables corresponding to the group of e2e tests
-#                   to check
+# mlir_e2e_tests  - Name of the MLIR CMake variable to gate on; also used to
+#                   name the flag in the error message below.
 # hwcap_spec      - HWCAP value to check. This should correspond to the hardware
 #                   capabilities required by the tests to be checked. Possible
 #                   values are defined in hwcap.h in the Linux kernel.

--- a/mlir/cmake/modules/MLIRCheckHardwareFeatures.cmake
+++ b/mlir/cmake/modules/MLIRCheckHardwareFeatures.cmake
@@ -26,6 +26,31 @@ function(check_sme_support_on_darwin output)
     set(${output} ${local_result} PARENT_SCOPE)
 endfunction(check_sme_support_on_darwin)
 
+# Checks whether I8MM is supported by the host Darwin (macOS) system. This is
+# implemented via `sysctl`, since Darwin has no equivalent of Linux's
+# auxiliary vector feature bits (hwcap).
+#
+# check_i8mm_support_on_darwin(
+#   output_var
+# )
+function(check_i8mm_support_on_darwin output)
+    execute_process(
+        COMMAND sysctl -n hw.optional.arm.FEAT_I8MM
+        OUTPUT_VARIABLE sysctl_output
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+        RESULT_VARIABLE sysctl_result
+    )
+
+    if(sysctl_result EQUAL 0 AND sysctl_output STREQUAL "1")
+      set(local_result TRUE)
+    else()
+      set(local_result FALSE)
+    endif()
+    message(STATUS "Checking whether I8MM is supported by the host system (via sysctl hw.optional.arm.FEAT_I8MM): ${local_result}")
+    set(${output} ${local_result} PARENT_SCOPE)
+endfunction(check_i8mm_support_on_darwin)
+
 # Checks whether the specified hardware capability is supported by the host
 # Linux system. This is implemented by checking auxiliary vector feature
 # provided by the Linux kernel.
@@ -115,9 +140,11 @@ function(check_emulator mlir_e2e_tests hwcap_spec emulator_exec)
 
   if(APPLE AND hwcap_spec STREQUAL "HWCAP2_SME")
     check_sme_support_on_darwin(emulator_not_required)
+  elseif(APPLE AND hwcap_spec STREQUAL "HWCAP2_I8MM")
+    check_i8mm_support_on_darwin(emulator_not_required)
   elseif(APPLE)
-    # No Darwin mapping for anything other than SME (yet); conservatively
-    # assume an emulator is required.
+    # No Darwin mapping for anything else (yet); conservatively assume an
+    # emulator is required.
     set(emulator_not_required FALSE)
   else()
     check_hwcap(${hwcap_spec} emulator_not_required)

--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -40,13 +40,13 @@ if (MLIR_INCLUDE_INTEGRATION_TESTS)
   option(MLIR_RUN_CUDA_SM90_TESTS "Run CUDA H100 tests.")
   option(MLIR_RUN_ARM_SVE_TESTS "Run Arm SVE tests.")
   option(MLIR_RUN_ARM_SME_TESTS "Run Arm SME tests.")
-  option(MLIR_RUN_ARM_I8MM_TESTS "Run Arm I8MM tests.")
+  option(MLIR_RUN_ARM_NEON_TESTS "Run Arm Neon tests.")
 
   # Check whether an emulator is required - if yes then make sure that it's
   # been set.
   check_emulator(MLIR_RUN_ARM_SVE_TESTS "HWCAP_SVE" ARM_EMULATOR_EXECUTABLE)
   check_emulator(MLIR_RUN_ARM_SME_TESTS "HWCAP2_SME" ARM_EMULATOR_EXECUTABLE)
-  check_emulator(MLIR_RUN_ARM_I8MM_TESTS "HWCAP2_I8MM" ARM_EMULATOR_EXECUTABLE)
+  check_emulator(MLIR_RUN_ARM_NEON_TESTS "HWCAP2_I8MM" ARM_EMULATOR_EXECUTABLE)
 
   # The native target may not be enabled when cross compiling, raise an error.
   if(NOT MLIR_ENABLE_EXECUTION_ENGINE)
@@ -84,7 +84,7 @@ llvm_canonicalize_cmake_booleans(
   MLIR_RUN_X86_TESTS
   MLIR_RUN_ARM_SVE_TESTS
   MLIR_RUN_ARM_SME_TESTS
-  MLIR_RUN_ARM_I8MM_TESTS
+  MLIR_RUN_ARM_NEON_TESTS
   MLIR_RUN_CUDA_SM80_TESTS
   MLIR_RUN_CUDA_SM80_LT_TESTS
   MLIR_RUN_CUDA_SM90_TESTS

--- a/mlir/test/Integration/Dialect/Linalg/CPU/ArmNeon/lit.local.cfg
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/ArmNeon/lit.local.cfg
@@ -1,0 +1,9 @@
+import sys
+
+# ArmNeon tests must be enabled via build flag.
+if not config.mlir_run_arm_neon_tests:
+    config.unsupported = True
+
+# No JIT on win32.
+if sys.platform == "win32":
+    config.unsupported = True

--- a/mlir/test/Integration/Dialect/Linalg/CPU/ArmNeon/matmul-i8.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/ArmNeon/matmul-i8.mlir
@@ -1,5 +1,3 @@
-// REQUIRES: mlir_arm_i8mm_tests
-
 // DEFINE: %{compile} = mlir-opt %s \
 // DEFINE:   -transform-interpreter -test-transform-dialect-erase-schedule \
 // DEFINE:   -cse -canonicalize -convert-vector-to-scf \

--- a/mlir/test/Integration/Dialect/Vector/CPU/ArmNeon/vector-contract-i8mm.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/ArmNeon/vector-contract-i8mm.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: mlir_arm_i8mm_tests
+// REQUIRES: mlir_arm_neon_tests
 
 // DEFINE: %{compile} = mlir-opt %s \
 // DEFINE:   --convert-vector-to-scf --convert-scf-to-cf  --convert-vector-to-llvm='enable-arm-neon enable-arm-i8mm' \

--- a/mlir/test/Integration/Dialect/Vector/CPU/ArmNeon/vector-contract-i8mm.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/ArmNeon/vector-contract-i8mm.mlir
@@ -1,3 +1,5 @@
+// REQUIRES: mlir_arm_i8mm_tests
+
 // DEFINE: %{compile} = mlir-opt %s \
 // DEFINE:   --convert-vector-to-scf --convert-scf-to-cf  --convert-vector-to-llvm='enable-arm-neon enable-arm-i8mm' \
 // DEFINE:   --expand-strided-metadata --convert-to-llvm --finalize-memref-to-llvm  \

--- a/mlir/test/Integration/Dialect/Vector/CPU/ArmNeon/vector-contract-i8mm.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/ArmNeon/vector-contract-i8mm.mlir
@@ -1,5 +1,3 @@
-// REQUIRES: arm-emulator
-
 // DEFINE: %{compile} = mlir-opt %s \
 // DEFINE:   --convert-vector-to-scf --convert-scf-to-cf  --convert-vector-to-llvm='enable-arm-neon enable-arm-i8mm' \
 // DEFINE:   --expand-strided-metadata --convert-to-llvm --finalize-memref-to-llvm  \

--- a/mlir/test/Integration/lit.local.cfg
+++ b/mlir/test/Integration/lit.local.cfg
@@ -13,7 +13,7 @@ def configure_aarch64_mcr_cmd():
     if not (
         config.mlir_run_arm_sve_tests
         or config.mlir_run_arm_sme_tests
-        or config.mlir_run_arm_i8mm_tests
+        or config.mlir_run_arm_neon_tests
     ):
         config.substitutions.append(("%mcr_aarch64_cmd", mcr_cmd))
         return

--- a/mlir/test/lit.site.cfg.py.in
+++ b/mlir/test/lit.site.cfg.py.in
@@ -55,9 +55,9 @@ config.mlir_run_arm_sve_tests = @MLIR_RUN_ARM_SVE_TESTS@
 if config.mlir_run_arm_sve_tests:
     config.available_features.add("mlir_arm_sve_tests")
 config.mlir_run_arm_sme_tests = @MLIR_RUN_ARM_SME_TESTS@
-config.mlir_run_arm_i8mm_tests = @MLIR_RUN_ARM_I8MM_TESTS@
-if config.mlir_run_arm_i8mm_tests:
-    config.available_features.add("mlir_arm_i8mm_tests")
+config.mlir_run_arm_neon_tests = @MLIR_RUN_ARM_NEON_TESTS@
+if config.mlir_run_arm_neon_tests:
+    config.available_features.add("mlir_arm_neon_tests")
 config.mlir_run_x86_tests = @MLIR_RUN_X86_TESTS@
 config.mlir_run_riscv_vector_tests = "@MLIR_RUN_RISCV_VECTOR_TESTS@"
 config.mlir_run_cuda_tensor_core_tests = @MLIR_RUN_CUDA_TENSOR_CORE_TESTS@


### PR DESCRIPTION
This PR, which follows the #215296 fashion, _simply_ allows I8MM tests to be run natively on Darwin.

**Stacked on** #215296.

