### PR TITLE
[mlir][XeGPU] Distribute create_nd_tdesc/load/store with SliceAttr layout

### DIFF
--- a/mlir/lib/Dialect/XeGPU/Transforms/XeGPUWgToSgDistribute.cpp
+++ b/mlir/lib/Dialect/XeGPU/Transforms/XeGPUWgToSgDistribute.cpp
@@ -189,7 +189,7 @@ struct WgToSgCreateNdOp : public OpConversionPattern<xegpu::CreateNdDescOp> {
     Location loc = op.getLoc();
     MLIRContext *ctx = op.getContext();
     xegpu::TensorDescType tdescTy = op.getType();
-    auto layout = dyn_cast<xegpu::LayoutAttr>(tdescTy.getLayout());
+    auto layout = dyn_cast<xegpu::DistributeLayoutAttr>(tdescTy.getLayout());
     if (!layout || !layout.isForWorkgroup())
       return failure();
 
@@ -1599,8 +1599,8 @@ void XeGPUWgToSgDistributePass::runOnOperation() {
                                xegpu::StoreNdOp, xegpu::PrefetchNdOp>(
       [=](Operation *op) -> bool {
         auto tdescTy = getTensorDescType(op);
-        auto layout =
-            dyn_cast_if_present<xegpu::LayoutAttr>(tdescTy.getLayout());
+        auto layout = dyn_cast_if_present<xegpu::DistributeLayoutAttr>(
+            tdescTy.getLayout());
         return isLegal(layout);
       });
 

--- a/mlir/test/Dialect/XeGPU/xegpu-wg-to-sg.mlir
+++ b/mlir/test/Dialect/XeGPU/xegpu-wg-to-sg.mlir
@@ -1378,11 +1378,10 @@ gpu.module @test_slice_layout {
   // CHECK-LABEL: slice_layout
   gpu.func @slice_layout(%arg0: memref<1024x1536xf16>) {
     // CHECK: xegpu.create_nd_tdesc %{{.*}} : memref<1024x1536xf16> -> !xegpu.tensor_desc<8x16xf16>
-    %tdesc = xegpu.create_nd_tdesc %arg0 : memref<1024x1536xf16>
-        -> !xegpu.tensor_desc<32x64xf16, #xegpu.slice<#xegpu.layout<sg_layout = [1, 4, 4], sg_data = [1, 8, 16]>, dims = [0]>>
+    %tdesc = xegpu.create_nd_tdesc %arg0 : memref<1024x1536xf16> -> !xegpu.tensor_desc<32x64xf16>
     // CHECK: xegpu.load_nd %{{.*}} : !xegpu.tensor_desc<8x16xf16> -> vector<8x16xf16>
     %load = xegpu.load_nd %tdesc[0, 0] <{layout = #xegpu.slice<#xegpu.layout<sg_layout = [1, 4, 4], sg_data = [1, 8, 16]>, dims = [0]>}>
-        : !xegpu.tensor_desc<32x64xf16, #xegpu.slice<#xegpu.layout<sg_layout = [1, 4, 4], sg_data = [1, 8, 16]>, dims = [0]>> -> vector<32x64xf16>
+        : !xegpu.tensor_desc<32x64xf16> -> vector<32x64xf16>
     gpu.return
   }
 }

--- a/mlir/test/Dialect/XeGPU/xegpu-wg-to-sg.mlir
+++ b/mlir/test/Dialect/XeGPU/xegpu-wg-to-sg.mlir
@@ -1373,35 +1373,16 @@ func.func @no_crash_on_dynamic_tensor(%arg0: tensor<?xi32>, %arg1: index) -> ten
 
 // -----
 
-// Regression test: a tensor_desc whose layout is a SliceAttr (produced e.g.
-// by unit-dim-expanding a vector.shape_cast) was not recognized as a
-// workgroup-level layout by WgToSgCreateNdOp, since it only matched
-// LayoutAttr. This left the tensor_desc and its load_nd undistributed,
-// causing a shape mismatch on the consuming shape_cast.
+// Regression test: a tensor_desc with a SliceAttr layout was not distributed.
 gpu.module @test_slice_layout {
-  // CHECK-LABEL: slice_layout_feeding_shape_cast
-  gpu.func @slice_layout_feeding_shape_cast(%arg0: memref<1024x1536xf16>, %arg1: memref<1024x1536xf16>) {
-    %cst = arith.constant {layout_result_0 = #xegpu.layout<sg_layout = [1, 4, 4], sg_data = [1, 8, 16]>} dense<3.000000e+00> : vector<1x32x64xf16>
+  // CHECK-LABEL: slice_layout
+  gpu.func @slice_layout(%arg0: memref<1024x1536xf16>) {
     // CHECK: xegpu.create_nd_tdesc %{{.*}} : memref<1024x1536xf16> -> !xegpu.tensor_desc<8x16xf16>
-    %tdesc0 = xegpu.create_nd_tdesc %arg0 : memref<1024x1536xf16>
+    %tdesc = xegpu.create_nd_tdesc %arg0 : memref<1024x1536xf16>
         -> !xegpu.tensor_desc<32x64xf16, #xegpu.slice<#xegpu.layout<sg_layout = [1, 4, 4], sg_data = [1, 8, 16]>, dims = [0]>>
     // CHECK: xegpu.load_nd %{{.*}} : !xegpu.tensor_desc<8x16xf16> -> vector<8x16xf16>
-    %load = xegpu.load_nd %tdesc0[0, 0] <{layout = #xegpu.slice<#xegpu.layout<sg_layout = [1, 4, 4], sg_data = [1, 8, 16]>, dims = [0]>}>
+    %load = xegpu.load_nd %tdesc[0, 0] <{layout = #xegpu.slice<#xegpu.layout<sg_layout = [1, 4, 4], sg_data = [1, 8, 16]>, dims = [0]>}>
         : !xegpu.tensor_desc<32x64xf16, #xegpu.slice<#xegpu.layout<sg_layout = [1, 4, 4], sg_data = [1, 8, 16]>, dims = [0]>> -> vector<32x64xf16>
-    // CHECK: vector.shape_cast {{.*}} : vector<8x16xf16> to vector<1x8x16xf16>
-    %expand = vector.shape_cast %load {layout_result_0 = #xegpu.layout<sg_layout = [1, 4, 4], sg_data = [1, 8, 16]>}
-        : vector<32x64xf16> to vector<1x32x64xf16>
-    // CHECK: arith.addf {{.*}} : vector<1x8x16xf16>
-    %add = arith.addf %expand, %cst {layout_result_0 = #xegpu.layout<sg_layout = [1, 4, 4], sg_data = [1, 8, 16]>}
-        : vector<1x32x64xf16>
-    // CHECK: vector.shape_cast {{.*}} : vector<1x8x16xf16> to vector<8x16xf16>
-    %collapse = vector.shape_cast %add {layout_result_0 = #xegpu.layout<sg_layout = [4, 4], sg_data = [8, 16]>}
-        : vector<1x32x64xf16> to vector<32x64xf16>
-    // CHECK: xegpu.store_nd {{.*}} : vector<8x16xf16>, !xegpu.tensor_desc<8x16xf16>
-    %tdesc1 = xegpu.create_nd_tdesc %arg1 : memref<1024x1536xf16>
-        -> !xegpu.tensor_desc<32x64xf16, #xegpu.layout<sg_layout = [4, 4], sg_data = [8, 16]>>
-    xegpu.store_nd %collapse, %tdesc1[0, 0] <{layout = #xegpu.layout<sg_layout = [4, 4], sg_data = [8, 16]>}>
-        : vector<32x64xf16>, !xegpu.tensor_desc<32x64xf16, #xegpu.layout<sg_layout = [4, 4], sg_data = [8, 16]>>
     gpu.return
   }
 }

--- a/mlir/test/Dialect/XeGPU/xegpu-wg-to-sg.mlir
+++ b/mlir/test/Dialect/XeGPU/xegpu-wg-to-sg.mlir
@@ -1370,3 +1370,38 @@ func.func @no_crash_on_dynamic_tensor(%arg0: tensor<?xi32>, %arg1: index) -> ten
   }
   return %result : tensor<?xi32>
 }
+
+// -----
+
+// Regression test: a tensor_desc whose layout is a SliceAttr (produced e.g.
+// by unit-dim-expanding a vector.shape_cast) was not recognized as a
+// workgroup-level layout by WgToSgCreateNdOp, since it only matched
+// LayoutAttr. This left the tensor_desc and its load_nd undistributed,
+// causing a shape mismatch on the consuming shape_cast.
+gpu.module @test_slice_layout {
+  // CHECK-LABEL: slice_layout_feeding_shape_cast
+  gpu.func @slice_layout_feeding_shape_cast(%arg0: memref<1024x1536xf16>, %arg1: memref<1024x1536xf16>) {
+    %cst = arith.constant {layout_result_0 = #xegpu.layout<sg_layout = [1, 4, 4], sg_data = [1, 8, 16]>} dense<3.000000e+00> : vector<1x32x64xf16>
+    // CHECK: xegpu.create_nd_tdesc %{{.*}} : memref<1024x1536xf16> -> !xegpu.tensor_desc<8x16xf16>
+    %tdesc0 = xegpu.create_nd_tdesc %arg0 : memref<1024x1536xf16>
+        -> !xegpu.tensor_desc<32x64xf16, #xegpu.slice<#xegpu.layout<sg_layout = [1, 4, 4], sg_data = [1, 8, 16]>, dims = [0]>>
+    // CHECK: xegpu.load_nd %{{.*}} : !xegpu.tensor_desc<8x16xf16> -> vector<8x16xf16>
+    %load = xegpu.load_nd %tdesc0[0, 0] <{layout = #xegpu.slice<#xegpu.layout<sg_layout = [1, 4, 4], sg_data = [1, 8, 16]>, dims = [0]>}>
+        : !xegpu.tensor_desc<32x64xf16, #xegpu.slice<#xegpu.layout<sg_layout = [1, 4, 4], sg_data = [1, 8, 16]>, dims = [0]>> -> vector<32x64xf16>
+    // CHECK: vector.shape_cast {{.*}} : vector<8x16xf16> to vector<1x8x16xf16>
+    %expand = vector.shape_cast %load {layout_result_0 = #xegpu.layout<sg_layout = [1, 4, 4], sg_data = [1, 8, 16]>}
+        : vector<32x64xf16> to vector<1x32x64xf16>
+    // CHECK: arith.addf {{.*}} : vector<1x8x16xf16>
+    %add = arith.addf %expand, %cst {layout_result_0 = #xegpu.layout<sg_layout = [1, 4, 4], sg_data = [1, 8, 16]>}
+        : vector<1x32x64xf16>
+    // CHECK: vector.shape_cast {{.*}} : vector<1x8x16xf16> to vector<8x16xf16>
+    %collapse = vector.shape_cast %add {layout_result_0 = #xegpu.layout<sg_layout = [4, 4], sg_data = [8, 16]>}
+        : vector<1x32x64xf16> to vector<32x64xf16>
+    // CHECK: xegpu.store_nd {{.*}} : vector<8x16xf16>, !xegpu.tensor_desc<8x16xf16>
+    %tdesc1 = xegpu.create_nd_tdesc %arg1 : memref<1024x1536xf16>
+        -> !xegpu.tensor_desc<32x64xf16, #xegpu.layout<sg_layout = [4, 4], sg_data = [8, 16]>>
+    xegpu.store_nd %collapse, %tdesc1[0, 0] <{layout = #xegpu.layout<sg_layout = [4, 4], sg_data = [8, 16]>}>
+        : vector<32x64xf16>, !xegpu.tensor_desc<32x64xf16, #xegpu.layout<sg_layout = [4, 4], sg_data = [8, 16]>>
+    gpu.return
+  }
+}


### PR DESCRIPTION
## Summary
- `WgToSgCreateNdOp` and `XeGPUWgToSgDistributePass`'s dynamic legality check only matched `xegpu::LayoutAttr` on a tensor_desc's layout, not `xegpu::SliceAttr` (also a `DistributeLayoutAttr`).
- A tensor_desc feeding a unit-dim-expanding `vector.shape_cast` carries a `SliceAttr`, so such `create_nd_tdesc`/`load_nd` ops were left undistributed while their consumers were already converted to subgroup shape, causing a `vector.shape_cast` element-count mismatch.
- Match on `DistributeLayoutAttr` instead, consistent with the rest of the pass (`getSgShapeAndCount`, `genOffsetsList`, etc.).

## Test plan
- [x] Added a regression test to `xegpu-wg-to-sg.mlir`: `create_nd_tdesc`/`load_nd` with a `SliceAttr` layout feeding `shape_cast` (expand) → `arith.addf` → `shape_cast` (collapse) → `store_nd`.
- [x] Verified the new test fails on `main` with the reported error and passes with this fix.