### PR TITLE
[RISCV] Add mvendorid/marchid/mimpid values for SiFive P870-D.

### DIFF
--- a/clang/test/CodeGen/RISCV/builtin-cpu-is.c
+++ b/clang/test/CodeGen/RISCV/builtin-cpu-is.c
@@ -55,3 +55,21 @@ int test_cpu_is_spacemit_x60() {
 int test_cpu_is_sifive_p550() {
   return __builtin_cpu_is("sifive-p550");
 }
+
+// CHECK-RV64-LABEL: define dso_local signext i32 @test_cpu_is_sifive_p870_d(
+// CHECK-RV64-SAME: ) #[[ATTR0]] {
+// CHECK-RV64-NEXT:  [[ENTRY:.*:]]
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = load i32, ptr @__riscv_cpu_model, align 4
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i32 [[TMP0]], 1161
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = load i64, ptr getelementptr inbounds nuw (i8, ptr @__riscv_cpu_model, i64 8), align 8
+// CHECK-RV64-NEXT:    [[TMP3:%.*]] = icmp eq i64 [[TMP2]], -9223372036854775543
+// CHECK-RV64-NEXT:    [[TMP4:%.*]] = and i1 [[TMP1]], [[TMP3]]
+// CHECK-RV64-NEXT:    [[TMP5:%.*]] = load i64, ptr getelementptr inbounds nuw (i8, ptr @__riscv_cpu_model, i64 16), align 8
+// CHECK-RV64-NEXT:    [[TMP6:%.*]] = icmp eq i64 [[TMP5]], 337970694
+// CHECK-RV64-NEXT:    [[TMP7:%.*]] = and i1 [[TMP4]], [[TMP6]]
+// CHECK-RV64-NEXT:    [[CONV:%.*]] = zext i1 [[TMP7]] to i32
+// CHECK-RV64-NEXT:    ret i32 [[CONV]]
+//
+int test_cpu_is_sifive_p870_d() {
+  return __builtin_cpu_is("sifive-p870-d");
+}

--- a/llvm/lib/Target/RISCV/RISCVProcessors.td
+++ b/llvm/lib/Target/RISCV/RISCVProcessors.td
@@ -615,7 +615,11 @@ def SIFIVE_P870_D : RISCVProcessorModel<"sifive-p870-d", SiFiveP800Model,
                                         TuneAUIPCADDIFusion,
                                         TuneNoSinkSplatOperands,
                                         TuneVXRMPipelineFlush,
-                                        TunePostRAScheduler]>;
+                                        TunePostRAScheduler]> {
+  let MVendorID = 0x489;
+  let MArchID = 0x8000000000000109;
+  let MImpID = 0x14250606;
+}
 
 def SYNTACORE_SCR1_BASE : RISCVProcessorModel<"syntacore-scr1-base",
                                               SyntacoreSCR1Model,


### PR DESCRIPTION
You can double check the numbers against values published here https://camel-cdr.github.io/rvv-bench-results/sifive_p870/data/cpuinfo.txt

I don't have an official doc link for this from SiFive. These are not the only possible values for P870-D. We may need to support multiple values for a CPU in the future.