### PR TITLE
[libc++] Fix "leak" of PMR resource in benchmark

### DIFF
--- a/libcxx/test/benchmarks/containers/associative/associative_container_benchmarks.h
+++ b/libcxx/test/benchmarks/containers/associative/associative_container_benchmarks.h
@@ -147,18 +147,21 @@ void associative_container_benchmarks(std::string container) {
     std::pmr::monotonic_buffer_resource rs2(size * 64 * BatchSize); // 64 bytes should be enough per node
     while (st.KeepRunningBatch(BatchSize)) {
       for (std::size_t i = 0; i != BatchSize; ++i) {
-        new (c + i * sizeof(PMRContainer)) PMRContainer(std::move(srcs[i]), &rs2);
-        benchmark::DoNotOptimize(c + i);
+        PMRContainer* p = reinterpret_cast<PMRContainer*>(c) + i;
+        new (p) PMRContainer(std::move(srcs[i]), &rs2);
+        benchmark::DoNotOptimize(p);
         benchmark::ClobberMemory();
       }
 
       st.PauseTiming();
       for (std::size_t i = 0; i != BatchSize; ++i) {
-        reinterpret_cast<PMRContainer*>(c + i * sizeof(PMRContainer))->~PMRContainer();
+        PMRContainer* p = reinterpret_cast<PMRContainer*>(c) + i;
+        p->~PMRContainer();
       }
       rs2.release();
       srcs.clear();
-      for (size_t i = 0; i != BatchSize; ++i)
+      rs.release();
+      for (std::size_t i = 0; i != BatchSize; ++i)
         srcs.emplace_back(&rs).insert(in.begin(), in.end());
 
       st.ResumeTiming();

--- a/libcxx/test/benchmarks/containers/associative/associative_container_benchmarks.h
+++ b/libcxx/test/benchmarks/containers/associative/associative_container_benchmarks.h
@@ -135,28 +135,30 @@ void associative_container_benchmarks(std::string container) {
     using PMRContainer = adapt_operations<Container>::template rebind_alloc<
         std::pmr::polymorphic_allocator<typename Container::value_type>>;
 
+    struct alignas(PMRContainer) PMRScratchSpace {
+      char storage[sizeof(PMRContainer)];
+    };
+
     const std::size_t size = st.range(0);
     std::vector<Value> in  = make_value_types(generate_unique_keys(size));
     std::pmr::monotonic_buffer_resource rs(size * 64 * BatchSize); // 64 bytes should be enough per node
     std::vector<PMRContainer> srcs;
     srcs.reserve(BatchSize);
-    for (size_t i = 0; i != BatchSize; ++i)
+    for (std::size_t i = 0; i != BatchSize; ++i)
       srcs.emplace_back(&rs).insert(in.begin(), in.end());
-    alignas(PMRContainer) char c[BatchSize * sizeof(PMRContainer)];
+    PMRScratchSpace c[BatchSize];
 
     std::pmr::monotonic_buffer_resource rs2(size * 64 * BatchSize); // 64 bytes should be enough per node
     while (st.KeepRunningBatch(BatchSize)) {
       for (std::size_t i = 0; i != BatchSize; ++i) {
-        PMRContainer* p = reinterpret_cast<PMRContainer*>(c) + i;
-        new (p) PMRContainer(std::move(srcs[i]), &rs2);
-        benchmark::DoNotOptimize(p);
+        new (c + i) PMRContainer(std::move(srcs[i]), &rs2);
+        benchmark::DoNotOptimize(c + i);
         benchmark::ClobberMemory();
       }
 
       st.PauseTiming();
       for (std::size_t i = 0; i != BatchSize; ++i) {
-        PMRContainer* p = reinterpret_cast<PMRContainer*>(c) + i;
-        p->~PMRContainer();
+        reinterpret_cast<PMRContainer*>(c + i)->~PMRContainer();
       }
       rs2.release();
       srcs.clear();


### PR DESCRIPTION
The benchmark was not releasing the monotonic buffer resource, which means we'd grow a larger and larger pool as Google Benchmark would go through more and more iterations of the benchmark.

As a drive-by, it also fixes an incorrect `DoNotOptimize(c + i)` that was called on the wrong pointer (c is a pointer to bytes).