### PR TITLE
[clang-tidy] Add [[clang::annotate("clang-tidy", "bugprone-use-after-move", "specified_after_move")]] to inform bugprone-use-aft…

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/UseAfterMoveCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/UseAfterMoveCheck.cpp
@@ -30,6 +30,14 @@ namespace clang::tidy::bugprone {
 
 using matchers::hasUnevaluatedContext;
 
+static std::optional<StringRef> getStringLiteral(const Expr *E) {
+  assert(E);
+  if (const auto *SL = dyn_cast<StringLiteral>(E->IgnoreParenImpCasts()))
+    return SL->getString();
+  return std::nullopt;
+}
+
+
 namespace {
 AST_MATCHER_P(Expr, hasParentIgnoringParenImpCasts,
               ast_matchers::internal::Matcher<Expr>, InnerMatcher) {
@@ -45,6 +53,28 @@ AST_MATCHER_P(Expr, hasParentIgnoringParenImpCasts,
 
   return InnerMatcher.matches(*E, Finder, Builder);
 }
+
+// Methods can be decorated with [[clang::annotate]] to specify it has
+// a user-defined behavior when called on a moved-from.
+AST_MATCHER(CXXMethodDecl, hasSpecifiedAfterMoveAnnotation) {
+  for(const AnnotateAttr *Attr : Node.specific_attrs<AnnotateAttr>()) {
+    if (Attr->getAnnotation() != "clang-tidy")
+      continue;
+
+    if (Attr->args_size() != 2)
+      continue;
+
+    std::optional<StringRef> Plugin = getStringLiteral(Attr->args_begin()[0]);
+    std::optional<StringRef> Annotation =
+        getStringLiteral(Attr->args_begin()[1]);
+
+    if (Plugin && Annotation && *Plugin == "bugprone-use-after-move" &&
+        *Annotation == "specified_after_move")
+      return true;
+         }
+         return false;
+              }
+
 
 /// Contains information about a use-after-move.
 struct UseAfterMove {
@@ -351,13 +381,6 @@ void UseAfterMoveFinder::getUsesAndReinits(
   });
 }
 
-static std::optional<StringRef> getStringLiteral(const Expr *E) {
-  assert(E);
-  if (const auto *SL = dyn_cast<StringLiteral>(E->IgnoreParenImpCasts()))
-    return SL->getString();
-  return std::nullopt;
-}
-
 // User defined types can use [[clang::annotate]] to mark smart-pointer-like
 // types with a specified move from state that matches the standard smart
 // pointer's moved-from state (nullptr).
@@ -434,12 +457,13 @@ void UseAfterMoveFinder::getDeclRefs(
     };
 
     const auto DeclRefMatcher =
-        declRefExpr(hasDeclaration(equalsNode(MovedVariable)),
-                    unless(inDecltypeOrTemplateArg()),
-                    unless(hasParentIgnoringParenImpCasts(
-                        memberExpr(hasDeclaration(cxxDestructorDecl())))),
-                    optionally(hasParentIgnoringParenImpCasts(
-                        memberExpr().bind("member-expr"))))
+        declRefExpr(
+            hasDeclaration(equalsNode(MovedVariable)),
+            unless(inDecltypeOrTemplateArg()),
+            unless(hasParentIgnoringParenImpCasts(memberExpr(hasDeclaration(
+                anyOf(cxxDestructorDecl(), cxxMethodDecl(hasSpecifiedAfterMoveAnnotation())))))),
+            optionally(hasParentIgnoringParenImpCasts(
+                memberExpr().bind("member-expr"))))
             .bind("declref");
 
     AddDeclRefs(match(traverse(TK_AsIs, findAll(DeclRefMatcher)), *S->getStmt(),

--- a/clang-tools-extra/docs/ReleaseNotes.md
+++ b/clang-tools-extra/docs/ReleaseNotes.md
@@ -118,6 +118,10 @@ infrastructure are described first, followed by tool-specific sections.
   <clang-tidy/checks/bugprone/std-namespace-modification>` when checking
   lambda closure types used as template arguments.
 
+- Improved {doc}`bugprone-use-after-move
+  <clang-tidy/checks/bugprone/use-after-move>` check to honor new
+  `[[clang::annotate("clang-tidy", "bugprone-use-after-move", "specified_after_move")]]` attribute.
+
 - Improved {doc}`cppcoreguidelines-pro-type-member-init
   <clang-tidy/checks/cppcoreguidelines/pro-type-member-init>` check by treating
   `std::array` the same as built-in arrays when `IgnoreArrays` option is enabled.

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/use-after-move.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/use-after-move.cpp
@@ -68,6 +68,9 @@ public:
 
   void foo() const;
   [[clang::reinitializes]] void clear();
+  [[clang::annotate("clang-tidy",
+                        "bugprone-use-after-move",
+                        "specified_after_move")]] bool empty() const;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1004,6 +1007,15 @@ void reinitAnnotation() {
     obj1.foo();
     // CHECK-NOTES: [[@LINE-1]]:5: warning: 'obj1' used after it was
     // CHECK-NOTES: [[@LINE-4]]:5: note: move occurred here
+  }
+}
+
+void usableOnMovedAnnotation() {
+  {
+    AnnotatedContainer<int> obj;
+    std::move(obj);
+    obj.empty();
+    // No warning expected, empty is flagged as usable_on_moved
   }
 }
 


### PR DESCRIPTION
…er-move that a call usage is safe after a move

À la std::unique_ptr where it's ok to test for nullability a moved-from instance, several user-class may allow some method call on a moved-from object, typically checking if a moved-from container is empty, etc.