### PR TITLE
[clang] Fix RecursiveASTVisitor to traverse the exception parameter in ObjCAtCatchStmt.

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -54,6 +54,13 @@ in a future version of Clang.
 
 ### C++ Specific Potentially Breaking Changes
 
+### Objective-C Specific Potentially Breaking Changes
+
+- Fixed an issue where AST consumers based on `RecursiveASTVisitor` would bypass
+  the exception parameter declaration inside Objective-C `@catch` blocks. This
+  could cause tooling that previously ignored the parameter declaration to now
+  find valid issues. (#GH212564)
+
 ### ABI Changes in This Version
 
 - Except on PlayStation, Clang now derives the x86-64 System V AVX ABI level
@@ -176,11 +183,6 @@ features cannot lower the translation-unit ABI level;
 #### C23 Feature Support
 
 ### Objective-C Language Changes
-
-- Fixed an issue where AST consumers based on `RecursiveASTVisitor`
-  (such as `clangd`, `include-cleaner`, and static analyzers) would bypass the
-  exception parameter declaration (and its type) inside Objective-C `@catch`
-  blocks.
 
 ### Non-comprehensive list of changes in this release
 

--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -177,6 +177,11 @@ features cannot lower the translation-unit ABI level;
 
 ### Objective-C Language Changes
 
+- Fixed an issue where AST consumers based on `RecursiveASTVisitor`
+  (such as `clangd`, `include-cleaner`, and static analyzers) would bypass the
+  exception parameter declaration (and its type) inside Objective-C `@catch`
+  blocks.
+
 ### Non-comprehensive list of changes in this release
 
 - Clang now allows GNU computed `goto` extension in `constexpr` functions, matching the relaxed

--- a/clang/include/clang/AST/RecursiveASTVisitor.h
+++ b/clang/include/clang/AST/RecursiveASTVisitor.h
@@ -2575,6 +2575,11 @@ DEF_TRAVERSE_STMT(CXXCatchStmt, {
   // children() iterates over the handler block.
 })
 
+DEF_TRAVERSE_STMT(ObjCAtCatchStmt, {
+  TRY_TO(TraverseDecl(S->getCatchParamDecl()));
+  // children() iterates over the handler block.
+})
+
 DEF_TRAVERSE_STMT(DeclStmt, {
   for (auto *I : S->decls()) {
     TRY_TO(TraverseDecl(I));
@@ -2604,7 +2609,6 @@ DEF_TRAVERSE_STMT(IndirectGotoStmt, {})
 DEF_TRAVERSE_STMT(LabelStmt, {})
 DEF_TRAVERSE_STMT(AttributedStmt, {})
 DEF_TRAVERSE_STMT(NullStmt, {})
-DEF_TRAVERSE_STMT(ObjCAtCatchStmt, {})
 DEF_TRAVERSE_STMT(ObjCAtFinallyStmt, {})
 DEF_TRAVERSE_STMT(ObjCAtSynchronizedStmt, {})
 DEF_TRAVERSE_STMT(ObjCAtThrowStmt, {})

--- a/clang/test/SemaObjC/unguarded-availability.m
+++ b/clang/test/SemaObjC/unguarded-availability.m
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -triple x86_64-apple-macosx10.9 -Wunguarded-availability -fblocks -fsyntax-only -verify %s
-// RUN: %clang_cc1 -xobjective-c++ -std=c++11 -DOBJCPP -triple x86_64-apple-macosx10.9 -Wunguarded-availability -fblocks -fsyntax-only -verify %s
+// RUN: %clang_cc1 -triple x86_64-apple-macosx10.9 -Wunguarded-availability -fblocks -fobjc-exceptions -fsyntax-only -verify %s
+// RUN: %clang_cc1 -xobjective-c++ -std=c++11 -DOBJCPP -triple x86_64-apple-macosx10.9 -Wunguarded-availability -fblocks -fobjc-exceptions -fsyntax-only -verify %s
 
 #define AVAILABLE_10_0  __attribute__((availability(macos, introduced = 10.0)))
 #define AVAILABLE_10_11 __attribute__((availability(macos, introduced = 10.11)))
@@ -72,7 +72,8 @@ void use_typedef(void) {
 }
 
 __attribute__((objc_root_class))
-AVAILABLE_10_11 @interface Class_10_11 { // expected-note{{annotate 'Class_10_11' with an availability attribute to silence}}
+AVAILABLE_10_11 @interface Class_10_11 { // expected-note{{annotate 'Class_10_11' with an availability attribute to silence}} \
+                                           // expected-note {{'Class_10_11' has been marked as being introduced in macOS 10.11 here, but the deployment target is macOS 10.9}}
   int_10_11 foo;
   int_10_12 bar; // expected-warning {{'int_10_12' is only available on macOS 10.12 or newer}}
 }
@@ -406,4 +407,10 @@ AVAILABLE_10_11 // expected-warning{{ignoring availability attribute with destru
 __attribute__((destructor))
 void is_destructor(void) {
   func_10_11(); // expected-warning{{'func_10_11' is only available on macOS 10.11 or newer}} expected-note{{enclose 'func_10_11' in an @available check to silence this warning}}
+}
+
+void test_catch(void) {
+  @try {
+  } @catch (Class_10_11 *e) { // expected-warning {{'Class_10_11' is only available on macOS 10.11 or newer}} expected-note {{enclose 'Class_10_11' in an @available check to silence this warning}}
+  }
 }

--- a/clang/unittests/Tooling/RecursiveASTVisitorTestDeclVisitor.cpp
+++ b/clang/unittests/Tooling/RecursiveASTVisitorTestDeclVisitor.cpp
@@ -134,4 +134,13 @@ TEST(RecursiveASTVisitor, NoRecursionInSelfFriend) {
     "vector_iterator<int> it_int;\n"));
 }
 
+TEST(RecursiveASTVisitor, VisitsObjCAtCatchStmtExceptionVariable) {
+  VarDeclVisitor Visitor;
+  Visitor.ExpectMatch("e", 2, 28);
+  EXPECT_TRUE(Visitor.runOver(
+    "@interface NSException; @end\n"
+    "void f() { @try {} @catch (NSException *e) {} }",
+    VarDeclVisitor::Lang_OBJC));
+}
+
 } // end anonymous namespace

--- a/clang/unittests/Tooling/RecursiveASTVisitorTestDeclVisitor.cpp
+++ b/clang/unittests/Tooling/RecursiveASTVisitorTestDeclVisitor.cpp
@@ -137,10 +137,9 @@ TEST(RecursiveASTVisitor, NoRecursionInSelfFriend) {
 TEST(RecursiveASTVisitor, VisitsObjCAtCatchStmtExceptionVariable) {
   VarDeclVisitor Visitor;
   Visitor.ExpectMatch("e", 2, 28);
-  EXPECT_TRUE(Visitor.runOver(
-    "@interface NSException; @end\n"
-    "void f() { @try {} @catch (NSException *e) {} }",
-    VarDeclVisitor::Lang_OBJC));
+  EXPECT_TRUE(Visitor.runOver("@interface NSException; @end\n"
+                              "void f() { @try {} @catch (NSException *e) {} }",
+                              VarDeclVisitor::Lang_OBJC));
 }
 
 } // end anonymous namespace


### PR DESCRIPTION
Ensures that the catch parameter declaration (the exception variable) in an Objective-C @catch block is visited during AST traversal. Previously, this declaration was skipped. A unit test has been added to verify the fix.

Note that this makes it match [ASTNodeTraverser](https://github.com/llvm/llvm-project/blob/dbac58277733fb87f5df02acf688b92b4b378cf3/clang/include/clang/AST/ASTNodeTraverser.h#L972)