### PR TITLE
[lldb] Fix dotest.py --help

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -316,7 +316,8 @@ def parseOptionsAndInitTestdirs():
         configuration.libcxx_include_target_dir = None
         configuration.libcxx_library_dir = None
 
-    configuration.cmake_build_type = args.cmake_build_type.lower()
+    if args.cmake_build_type:
+        configuration.cmake_build_type = args.cmake_build_type.lower()
 
     if args.channels:
         lldbtest_config.channels = args.channels


### PR DESCRIPTION
Fixes the following `--help` bug I ran into:

```
% python3 ./lldb/test/API/dotest.py --help
Traceback (most recent call last):
  File "path/to/llvm-project/lldb/test/API/dotest.py", line 8, in <module>
    lldbsuite.test.run_suite()
  File "path/to/llvm-project/lldb/packages/Python/lldbsuite/test/dotest.py", line 1099, in run_suite
    parseOptionsAndInitTestdirs()
  File "path/to/llvm-project/lldb/packages/Python/lldbsuite/test/dotest.py", line 318, in parseOptionsAndInitTestdirs
    configuration.cmake_build_type = args.cmake_build_type.lower()
AttributeError: 'NoneType' object has no attribute 'lower'
```