### PR TITLE
[LegalizeTypes] Allow v1i128 as a valid SETCC result type during vector operand scalarization

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorTypes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorTypes.cpp
@@ -1114,13 +1114,16 @@ SDValue DAGTypeLegalizer::ScalarizeVecOp_VSELECT(SDNode *N) {
 }
 
 /// If the operand is a vector that needs to be scalarized then the
-/// result must be v1i1, so just convert to a scalar SETCC and wrap
-/// with a scalar_to_vector since the res type is legal if we got here
+/// result must be v1i1 or v1i128, so just convert to a scalar SETCC
+/// and wrap with a scalar_to_vector since the res type is legal if we
+/// got here
 SDValue DAGTypeLegalizer::ScalarizeVecOp_VSETCC(SDNode *N) {
   assert(N->getValueType(0).isVector() &&
          N->getOperand(0).getValueType().isVector() &&
          "Operand types must be vectors");
-  assert(N->getValueType(0) == MVT::v1i1 && "Expected v1i1 type");
+  assert(
+      (N->getValueType(0) == MVT::v1i1 || N->getValueType(0) == MVT::v1i128) &&
+      "Expected v1i1 or v1i128 type");
 
   EVT VT = N->getValueType(0);
   SDValue LHS = GetScalarizedVector(N->getOperand(0));
@@ -1150,7 +1153,9 @@ SDValue DAGTypeLegalizer::ScalarizeVecOp_VSTRICT_FSETCC(SDNode *N,
   assert(N->getValueType(0).isVector() &&
          N->getOperand(1).getValueType().isVector() &&
          "Operand types must be vectors");
-  assert(N->getValueType(0) == MVT::v1i1 && "Expected v1i1 type");
+  assert(
+      (N->getValueType(0) == MVT::v1i1 || N->getValueType(0) == MVT::v1i128) &&
+      "Expected v1i1 or v1i128 type");
 
   EVT VT = N->getValueType(0);
   SDValue Ch = N->getOperand(0);

--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorTypes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorTypes.cpp
@@ -1114,16 +1114,15 @@ SDValue DAGTypeLegalizer::ScalarizeVecOp_VSELECT(SDNode *N) {
 }
 
 /// If the operand is a vector that needs to be scalarized then the
-/// result must be v1i1 or v1i128, so just convert to a scalar SETCC
-/// and wrap with a scalar_to_vector since the res type is legal if we
-/// got here
+/// result must be a single-element vector, so just convert to a scalar
+/// SETCC and wrap with a scalar_to_vector since the res type is legal
+/// if we got here
 SDValue DAGTypeLegalizer::ScalarizeVecOp_VSETCC(SDNode *N) {
   assert(N->getValueType(0).isVector() &&
          N->getOperand(0).getValueType().isVector() &&
          "Operand types must be vectors");
-  assert(
-      (N->getValueType(0) == MVT::v1i1 || N->getValueType(0) == MVT::v1i128) &&
-      "Expected v1i1 or v1i128 type");
+  assert(N->getValueType(0).getVectorNumElements() == 1 &&
+         "Expected single-element vector type");
 
   EVT VT = N->getValueType(0);
   SDValue LHS = GetScalarizedVector(N->getOperand(0));
@@ -1153,9 +1152,8 @@ SDValue DAGTypeLegalizer::ScalarizeVecOp_VSTRICT_FSETCC(SDNode *N,
   assert(N->getValueType(0).isVector() &&
          N->getOperand(1).getValueType().isVector() &&
          "Operand types must be vectors");
-  assert(
-      (N->getValueType(0) == MVT::v1i1 || N->getValueType(0) == MVT::v1i128) &&
-      "Expected v1i1 or v1i128 type");
+  assert(N->getValueType(0).getVectorNumElements() == 1 &&
+         "Expected single-element vector type");
 
   EVT VT = N->getValueType(0);
   SDValue Ch = N->getOperand(0);

--- a/llvm/test/CodeGen/PowerPC/fp128-vector-setcc.ll
+++ b/llvm/test/CodeGen/PowerPC/fp128-vector-setcc.ll
@@ -1,0 +1,22 @@
+; RUN: llc -mtriple=powerpc64le-unknown-linux-gnu -mcpu=pwr8 %s -o - | FileCheck %s
+
+define <4 x i1> @fp(<4 x fp128> %0)  {
+; CHECK-LABEL: fp:
+; CHECK-COUNT-4: bl __eqkf2
+; CHECK: blr
+Entry:
+  %1 = fcmp oeq <4 x fp128> %0, zeroinitializer
+  ret <4 x i1> %1
+}
+
+define <4 x i1> @foo(<4 x fp128> %0) strictfp {
+; CHECK-LABEL: foo:
+; CHECK-COUNT-4: bl __eqkf2
+; CHECK: blr
+Entry:
+  %1 = call <4 x i1> @llvm.experimental.constrained.fcmp.v4fp128(<4 x fp128> %0, <4 x fp128> zeroinitializer, metadata !"oeq", metadata !"fpexcept.strict")
+  ret <4 x i1> %1
+}
+
+declare <4 x i1> @llvm.experimental.constrained.fcmp.v4fp128(<4 x fp128>, <4 x fp128>, metadata, metadata)
+


### PR DESCRIPTION
PowerPC registers v1i128 as a legal type when P8Altivec is available. When lowering <4 x fp128> comparisons, the type legalizer hits a v1i1 only assert. Generalize the assert to accept any single-element vector result type.