### PR TITLE
[libc++] Remove unnecessary container constructions in setup code

### DIFF
--- a/libcxx/test/benchmarks/containers/associative/associative_container_benchmarks.h
+++ b/libcxx/test/benchmarks/containers/associative/associative_container_benchmarks.h
@@ -477,31 +477,32 @@ void associative_container_benchmarks(std::string container) {
   }
 
   auto insert_iter_iter_bench = [=](bool bench_end_iter, auto& st) {
-    const std::size_t size = st.range(0);
-    std::vector<Value> in  = make_value_types(generate_unique_keys(size + (size / 10)));
-    auto skip_start        = bench_end_iter ? size : size / 2;
+    const std::size_t size   = st.range(0);
+    std::vector<Value> large = make_value_types(generate_unique_keys(size + (size / 10)));
+    auto skip_start          = bench_end_iter ? size : size / 2;
 
     std::vector<Value> small;
     small.reserve(size / 10);
     { // Split the range
       std::vector<Value> tmp;
       tmp.reserve(size);
-      std::copy_n(in.begin(), skip_start, std::back_inserter(tmp));
-      std::copy_n(in.begin() + skip_start, size / 10, std::back_inserter(small));
-      std::copy(in.begin() + skip_start + size / 10, in.end(), std::back_inserter(tmp));
+      std::copy_n(large.begin(), skip_start, std::back_inserter(tmp));
+      std::copy_n(large.begin() + skip_start, size / 10, std::back_inserter(small));
+      std::copy(large.begin() + skip_start + size / 10, large.end(), std::back_inserter(tmp));
 
-      in = std::move(tmp);
+      large = std::move(tmp);
     }
 
     Container c(small.begin(), small.end());
+    Container const copy = c;
 
     for ([[maybe_unused]] auto _ : st) {
-      c.insert(in.begin(), in.end());
+      c.insert(large.begin(), large.end());
       benchmark::DoNotOptimize(c);
       benchmark::ClobberMemory();
 
       st.PauseTiming();
-      c = Container(small.begin(), small.end());
+      c = copy;
       st.ResumeTiming();
     }
   };
@@ -513,24 +514,25 @@ void associative_container_benchmarks(std::string container) {
   });
 
   bench_non_empty("insert(iterator, iterator) (half new keys)", [=](auto& st) TEST_ALIGN_BENCHMARK {
-    const std::size_t size = st.range(0);
-    std::vector<Value> in  = make_value_types(generate_unique_keys(size));
+    const std::size_t size   = st.range(0);
+    std::vector<Value> large = make_value_types(generate_unique_keys(size));
 
     // Populate a container that already contains half the elements we'll try inserting,
     // that's what our container will start with.
     std::vector<Value> small;
     for (std::size_t i = 0; i != size / 2; ++i) {
-      small.push_back(in.at(i * 2));
+      small.push_back(large.at(i * 2));
     }
     Container c(small.begin(), small.end());
+    Container const copy = c;
 
     for ([[maybe_unused]] auto _ : st) {
-      c.insert(in.begin(), in.end());
+      c.insert(large.begin(), large.end());
       benchmark::DoNotOptimize(c);
       benchmark::ClobberMemory();
 
       st.PauseTiming();
-      c = Container(small.begin(), small.end());
+      c = copy;
       st.ResumeTiming();
     }
   });
@@ -667,10 +669,11 @@ void associative_container_benchmarks(std::string container) {
   bench_non_empty("erase(iterator, iterator) (erase half the container)", [=](auto& st) TEST_ALIGN_BENCHMARK {
     const std::size_t size = st.range(0);
     std::vector<Value> in  = make_value_types(generate_unique_keys(size));
-    Container c(in.begin(), in.end());
 
-    auto first = std::next(c.begin(), c.size() / 4);
-    auto last  = std::next(c.begin(), 3 * (c.size() / 4));
+    Container c(in.begin(), in.end());
+    Container const copy = c;
+    auto first           = std::next(c.begin(), c.size() / 4);
+    auto last            = std::next(first, c.size() / 2);
     for ([[maybe_unused]] auto _ : st) {
       auto result = c.erase(first, last);
       benchmark::DoNotOptimize(result);
@@ -678,9 +681,9 @@ void associative_container_benchmarks(std::string container) {
       benchmark::ClobberMemory();
 
       st.PauseTiming();
-      c     = Container(in.begin(), in.end());
+      c     = copy;
       first = std::next(c.begin(), c.size() / 4);
-      last  = std::next(c.begin(), 3 * (c.size() / 4));
+      last  = std::next(first, c.size() / 2);
       st.ResumeTiming();
     }
   });
@@ -688,7 +691,9 @@ void associative_container_benchmarks(std::string container) {
   bench("clear()", [=](auto& st) TEST_ALIGN_BENCHMARK {
     const std::size_t size = st.range(0);
     std::vector<Value> in  = make_value_types(generate_unique_keys(size));
+
     Container c(in.begin(), in.end());
+    Container const copy = c;
 
     for ([[maybe_unused]] auto _ : st) {
       c.clear();
@@ -696,7 +701,7 @@ void associative_container_benchmarks(std::string container) {
       benchmark::ClobberMemory();
 
       st.PauseTiming();
-      c = Container(in.begin(), in.end());
+      c = copy;
       st.ResumeTiming();
     }
   });


### PR DESCRIPTION
It turns out that a fair amount of the benchmark suite is spent in unmeasured code. Amongst other things, we were constructing temporary containers from scratch instead of assigning from an already built-up copy, which is a lot faster.

This patch speeds up the wall time for running flat_map benchmarks by approximately 30s (from 98s to 66s) on my machine.