### PR TITLE
[NFC][DebugInfo] Fix a parameter name in calculateFragmentIntersect's docs

### DIFF
--- a/llvm/include/llvm/IR/DebugInfoMetadata.h
+++ b/llvm/include/llvm/IR/DebugInfoMetadata.h
@@ -4019,7 +4019,7 @@ public:
   ///
   /// Results and return value:
   /// - Return false if the result can't be calculated for any reason.
-  /// - \p Result is set to nullopt if the intersect equals \p VarFarg.
+  /// - \p Result is set to nullopt if the intersect equals \p VarFrag.
   /// - \p Result contains a zero-sized fragment if there's no intersect.
   /// - \p OffsetFromLocationInBits is set to the difference between the first
   ///   bit of the variable location and the first bit of the slice. The


### PR DESCRIPTION
The docs spell it VarFarg, and the parameter is VarFrag, so the \p reference resolves to nothing. That line is the one saying when Result comes back empty, which is the behavior callers most need to look up.