### PR TITLE
[HLSL][longvec][Tablegen] Use templates to define Vector api's larger than 4

### DIFF
--- a/clang/include/clang/Basic/HLSLIntrinsics.td
+++ b/clang/include/clang/Basic/HLSLIntrinsics.td
@@ -221,6 +221,10 @@ class HLSLBuiltin<string name, string builtin = ""> {
   // Vector sizes to generate for Varying typed arguments (e.g., [2,3,4]).
   list<int> VaryingVecSizes = [];
 
+  // Whether to generate a dependent-size vector template overload for N > 4.
+  // Sizes 1 through 4 use scalar and concrete vector overloads.
+  bit VaryingLongVector = 0;
+
   // Matrix dimensions to generate for Varying typed arguments.
   list<MatDim> VaryingMatDims = [];
 
@@ -321,6 +325,7 @@ def hlsl_abs : HLSLOneArgBuiltin<"abs", "__builtin_elementwise_abs"> {
 \param Val The input value.
 }];
   let VaryingTypes = SignedTypes;
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 

--- a/clang/test/CodeGenHLSL/builtins/abs.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/abs.hlsl
@@ -83,6 +83,9 @@ int3 test_abs_int3(int3 p0) { return abs(p0); }
 // CHECK-LABEL: define hidden noundef <4 x i32> @_Z13test_abs_int4
 // CHECK: call <4 x i32> @llvm.abs.v4i32(
 int4 test_abs_int4(int4 p0) { return abs(p0); }
+// CHECK-LABEL: define hidden noundef <5 x i32> @_Z13test_abs_int5
+// CHECK: call <5 x i32> @llvm.abs.v5i32(
+vector<int, 5> test_abs_int5(vector<int, 5> p0) { return abs(p0); }
 
 // CHECK-LABEL: define hidden noundef nofpclass(nan inf) float @_Z14test_abs_float
 // CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.fabs.f32(

--- a/clang/test/TableGen/hlsl-intrinsics.td
+++ b/clang/test/TableGen/hlsl-intrinsics.td
@@ -442,6 +442,31 @@ def test_17_shape_arg : HLSLBuiltin<"shapearg", "__builtin_shapearg"> {
 // ALIAS-NOT: shapearg
 
 //===----------------------------------------------------------------------===//
+// Dependent-size vector template overload.
+// Exercises: VaryingLongVector emission after concrete vector overloads.
+//===----------------------------------------------------------------------===//
+
+def test_18_long_vector : HLSLBuiltin<"longvec", "__builtin_longvec"> {
+  let Args = [Varying];
+  let ReturnType = Varying;
+  let VaryingVecSizes = [4];
+  let VaryingLongVector = 1;
+  let VaryingTypes = [IntTy];
+  let Availability = SM6_0;
+}
+
+// ALIAS-LABEL: // longvec overloads
+// ALIAS-NEXT: _HLSL_AVAILABILITY(shadermodel, 6.0)
+// ALIAS-NEXT: _HLSL_BUILTIN_ALIAS(__builtin_longvec)
+// ALIAS-NEXT: int4 longvec(int4);
+// ALIAS-NEXT: template <int N>
+// ALIAS-NEXT: _HLSL_AVAILABILITY(shadermodel, 6.0)
+// ALIAS-NEXT: _HLSL_BUILTIN_ALIAS(__builtin_longvec)
+// ALIAS-NEXT: vector<__detail::enable_if_t<(N > 4), int>, N> longvec(vector<__detail::enable_if_t<(N > 4), int>, N>);
+//
+// ALIAS-NOT: longvec
+
+//===----------------------------------------------------------------------===//
 // Verify no alias intrinsics are generated in the inline header.
 //===----------------------------------------------------------------------===//
 
@@ -461,6 +486,7 @@ def test_17_shape_arg : HLSLBuiltin<"shapearg", "__builtin_shapearg"> {
 // INLINE-NOT: shapesorted
 // INLINE-NOT: elemarg
 // INLINE-NOT: shapearg
+// INLINE-NOT: longvec
 
 //===----------------------------------------------------------------------===//
 // Verify no inline intrinsics are generated in the alias header.

--- a/clang/utils/TableGen/HLSLEmitter.cpp
+++ b/clang/utils/TableGen/HLSLEmitter.cpp
@@ -329,6 +329,14 @@ static void emitVectorOverload(const OverloadContext &Ctx, StringRef ElemType,
   });
 }
 
+/// Emit a dependent-size vector template overload for the given element type.
+static void emitLongVectorOverload(const OverloadContext &Ctx,
+                                   StringRef ElemType) {
+  emitOverload(Ctx, ElemType, [](StringRef ET) {
+    return ("vector<__detail::enable_if_t<(N > 4), " + ET + ">, N>").str();
+  });
+}
+
 /// Emit a matrix overload for the given element type and matrix dimensions.
 static void emitMatrixOverload(const OverloadContext &Ctx, StringRef ElemType,
                                unsigned Rows, unsigned Cols) {
@@ -459,6 +467,7 @@ static void emitWorklistOverloads(raw_ostream &OS, const OverloadContext &Ctx,
                                   ArrayRef<TypeWorkItem> Worklist,
                                   bool EmitScalarOverload,
                                   ArrayRef<int64_t> VectorSizes,
+                                  bool EmitLongVectorOverload,
                                   ArrayRef<const Record *> MatrixDimensions) {
   bool InIfdef = false;
   for (size_t I = 0, E = Worklist.size(); I != E; ++I) {
@@ -480,6 +489,11 @@ static void emitWorklistOverloads(raw_ostream &OS, const OverloadContext &Ctx,
     for (int64_t N : VectorSizes) {
       EmitAvail();
       emitVectorOverload(Ctx, Item.ElemType, N);
+    }
+    if (EmitLongVectorOverload) {
+      OS << "template <int N>\n";
+      EmitAvail();
+      emitLongVectorOverload(Ctx, Item.ElemType);
     }
     for (const Record *MD : MatrixDimensions) {
       EmitAvail();
@@ -517,6 +531,7 @@ static void emitBuiltinOverloads(raw_ostream &OS, const Record *R) {
                             R->getValueAsListOfDefs("VaryingTypes").empty();
 
   std::vector<int64_t> VectorSizes = R->getValueAsListOfInts("VaryingVecSizes");
+  bool EmitLongVectorOverload = R->getValueAsBit("VaryingLongVector");
   std::vector<const Record *> MatrixDimensions =
       R->getValueAsListOfDefs("VaryingMatDims");
 
@@ -530,7 +545,7 @@ static void emitBuiltinOverloads(raw_ostream &OS, const Record *R) {
   });
 
   emitWorklistOverloads(OS, Ctx, Worklist, EmitScalarOverload, VectorSizes,
-                        MatrixDimensions);
+                        EmitLongVectorOverload, MatrixDimensions);
 }
 
 /// Emit alias overloads for a single HLSLBuiltin record.


### PR DESCRIPTION
resolves #216139
resolves #216140

This change adds a templatized vector emitter to TableGen's HLSLEmitter.
 We add tests for the tablegen and confirm we did it right by implementing the abs api.

Assisted by GPT-5.6 sol via co-pilot