### PR TITLE
[lldb][NativePDB] Migrate away from `lldbassert`

### DIFF
--- a/lldb/source/Plugins/SymbolFile/NativePDB/CompileUnitIndex.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/CompileUnitIndex.cpp
@@ -23,7 +23,6 @@
 #include "llvm/DebugInfo/PDB/Native/TpiStream.h"
 #include "llvm/Support/Path.h"
 
-#include "lldb/Utility/LLDBAssert.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
 
@@ -94,9 +93,9 @@ static void ParseExtendedInfo(PdbIndex &index, CompilandIndexItem &item) {
 
   // This is a private function, it shouldn't be called if the information
   // has already been parsed.
-  lldbassert(!item.m_obj_name);
-  lldbassert(!item.m_compile_opts);
-  lldbassert(item.m_build_info.empty());
+  assert(!item.m_obj_name);
+  assert(!item.m_compile_opts);
+  assert(item.m_build_info.empty());
 
   Log *log = GetLog(LLDBLog::Symbols);
   // We're looking for 3 things.  S_COMPILE3, S_OBJNAME, and S_BUILDINFO.

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderClang.cpp
@@ -24,7 +24,6 @@
 #include "UdtRecordCompleter.h"
 #include "lldb/Core/Module.h"
 #include "lldb/Symbol/ObjectFile.h"
-#include "lldb/Utility/LLDBAssert.h"
 #include "lldb/Utility/LLDBLog.h"
 #include <optional>
 #include <string_view>
@@ -116,7 +115,7 @@ static clang::TagTypeKind TranslateUdtKind(const TagRecord &cr) {
   case TypeRecordKind::Enum:
     return clang::TagTypeKind::Enum;
   default:
-    lldbassert(false && "Invalid tag record kind!");
+    assert(false && "Invalid tag record kind!");
     return clang::TagTypeKind::Struct;
   }
 }
@@ -527,9 +526,12 @@ bool PdbAstBuilderClang::CompleteType(CompilerType ct) {
 }
 
 bool PdbAstBuilderClang::CompleteTagDecl(clang::TagDecl &tag) {
-  // If this is not in our map, it's an error.
   auto status_iter = m_decl_to_status.find(&tag);
-  lldbassert(status_iter != m_decl_to_status.end());
+  if (status_iter == m_decl_to_status.end()) {
+    // If this is not in our map, it's an error.
+    assert(false && "completing unknown tag decl");
+    return false;
+  }
 
   // If it's already complete, just return.
   DeclStatus &status = status_iter->second;
@@ -540,7 +542,6 @@ bool PdbAstBuilderClang::CompleteTagDecl(clang::TagDecl &tag) {
   PdbIndex &index = static_cast<SymbolFileNativePDB *>(
                         m_clang.GetSymbolFile()->GetBackingSymbolFile())
                         ->GetIndex();
-  lldbassert(IsTagRecord(type_id, index.tpi()));
 
   clang::QualType tag_qt = m_clang.getASTContext().getCanonicalTagType(&tag);
   TypeSystemClang::SetHasExternalStorage(tag_qt.getAsOpaquePtr(), false);
@@ -552,7 +553,10 @@ bool PdbAstBuilderClang::CompleteTagDecl(clang::TagDecl &tag) {
 
   PdbTypeSymId best_ti = GetBestPossibleDecl(tag_ti, index.tpi());
   cvt = index.tpi().getType(best_ti.index);
-  lldbassert(IsTagRecord(cvt));
+  if (!IsTagRecord(cvt)) {
+    assert(false && "completing tag record that's not a tag record");
+    return false;
+  }
 
   if (IsForwardRefUdt(cvt)) {
     // If we can't find a full decl for this forward ref anywhere in the debug
@@ -710,8 +714,11 @@ clang::QualType PdbAstBuilderClang::CreateRecordType(PdbTypeSymId id,
   CompilerType ct = m_clang.CreateRecordType(
       context, OptionalClangModuleID(), uname, llvm::to_underlying(ttk),
       lldb::eLanguageTypeC_plus_plus, metadata);
-
-  lldbassert(ct.IsValid());
+  if (!ct.IsValid()) {
+    LLDB_LOG(GetLog(LLDBLog::Symbols), "failed to create record type for {0}",
+             id);
+    return {};
+  }
 
   TypeSystemClang::StartTagDeclarationDefinition(ct);
 
@@ -822,7 +829,10 @@ CompilerType PdbAstBuilderClang::GetOrCreateTypedefType(PdbGlobalSymId id) {
       m_clang.GetSymbolFile()->GetBackingSymbolFile());
   PdbIndex &index = pdb->GetIndex();
   CVSymbol sym = index.ReadSymbolRecord(id);
-  lldbassert(sym.kind() == S_UDT);
+  if (sym.kind() != S_UDT) {
+    assert(false && "called on a non-udt type");
+    return {};
+  }
   llvm::Expected<UDTSym> udt = SymbolDeserializer::deserializeAs<UDTSym>(sym);
   if (!udt) {
     LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), udt.takeError(),
@@ -975,7 +985,7 @@ clang::QualType PdbAstBuilderClang::GetOrCreateClangType(PdbTypeSymId type) {
   m_uid_to_type[toOpaqueUid(type)] = qt;
   if (IsTagRecord(type, index.tpi())) {
     clang::TagDecl *tag = qt->getAsTagDecl();
-    lldbassert(m_decl_to_status.count(tag) == 0);
+    assert(m_decl_to_status.count(tag) == 0 && "type already created");
 
     DeclStatus &status = m_decl_to_status[tag];
     status.uid = uid;
@@ -1118,7 +1128,7 @@ clang::FunctionDecl *PdbAstBuilderClang::GetOrCreateInlinedFunctionDecl(
   // referring the same inline function. This avoid creating multiple same
   // inline function delcs.
   uint64_t func_uid = toOpaqueUid(func_id);
-  lldbassert(m_uid_to_decl.count(func_uid) == 0);
+  assert(m_uid_to_decl.count(func_uid) == 0 && "already created");
   m_uid_to_decl[func_uid] = function_decl;
   return function_decl;
 }
@@ -1126,7 +1136,11 @@ clang::FunctionDecl *PdbAstBuilderClang::GetOrCreateInlinedFunctionDecl(
 clang::FunctionDecl *
 PdbAstBuilderClang::CreateFunctionDeclFromId(PdbTypeSymId func_tid,
                                              PdbCompilandSymId func_sid) {
-  lldbassert(func_tid.is_ipi);
+  if (!func_tid.is_ipi) {
+    assert(false && "called with non-ipi index");
+    return nullptr;
+  }
+
   SymbolFileNativePDB *pdb = static_cast<SymbolFileNativePDB *>(
       m_clang.GetSymbolFile()->GetBackingSymbolFile());
   PdbIndex &index = pdb->GetIndex();
@@ -1184,7 +1198,8 @@ PdbAstBuilderClang::CreateFunctionDeclFromId(PdbTypeSymId func_tid,
     break;
   }
   default:
-    lldbassert(false && "Invalid function id type!");
+    LLDB_LOG(GetLog(LLDBLog::Symbols), "{0} is not a function type", func_tid);
+    return nullptr;
   }
   clang::QualType func_qt = GetOrCreateClangType(func_ti);
   if (func_qt.isNull() || !parent)
@@ -1255,7 +1270,7 @@ PdbAstBuilderClang::GetOrCreateFunctionDecl(PdbCompilandSymId func_id) {
   if (function_decl == nullptr)
     return nullptr;
 
-  lldbassert(m_uid_to_decl.count(toOpaqueUid(func_id)) == 0);
+  assert(m_uid_to_decl.count(toOpaqueUid(func_id)) == 0 && "already created");
   m_uid_to_decl[toOpaqueUid(func_id)] = function_decl;
   DeclStatus status;
   status.resolved = true;
@@ -1383,8 +1398,9 @@ void PdbAstBuilderClang::CreateFunctionParameters(
     clang::ParmVarDecl *param = m_clang.CreateParameterDeclaration(
         &function_decl, OptionalClangModuleID(), param_name.str().c_str(),
         param_type_ct, clang::SC_None, true);
-    lldbassert(m_uid_to_decl.count(toOpaqueUid(param_uid)) == 0);
 
+    assert(m_uid_to_decl.count(toOpaqueUid(param_uid)) == 0 &&
+           "already created");
     m_uid_to_decl[toOpaqueUid(param_uid)] = param;
     params.push_back(param);
     ++i;
@@ -1619,8 +1635,11 @@ void PdbAstBuilderClang::ParseBlockChildren(PdbCompilandSymId block_id) {
       m_clang.GetSymbolFile()->GetBackingSymbolFile());
   PdbIndex &index = pdb->GetIndex();
   CVSymbol sym = index.ReadSymbolRecord(block_id);
-  lldbassert(sym.kind() == S_GPROC32 || sym.kind() == S_LPROC32 ||
-             sym.kind() == S_BLOCK32 || sym.kind() == S_INLINESITE);
+  if (sym.kind() != S_GPROC32 && sym.kind() != S_LPROC32 &&
+      sym.kind() != S_BLOCK32 && sym.kind() != S_INLINESITE) {
+    assert(false && "called on non-block");
+    return;
+  }
   CompilandIndexItem &cii =
       index.compilands().GetOrCreateCompiland(block_id.modi);
   CVSymbolArray symbols =
@@ -1649,10 +1668,16 @@ void PdbAstBuilderClang::ParseDeclsForSimpleContext(
     clang::DeclContext &context) {
 
   clang::Decl *decl = clang::Decl::castFromDeclContext(&context);
-  lldbassert(decl);
+  if (!decl) {
+    assert(false);
+    return;
+  }
 
   auto iter = m_decl_to_status.find(decl);
-  lldbassert(iter != m_decl_to_status.end());
+  if (iter == m_decl_to_status.end()) {
+    assert(false && "cannot parse unknown decl");
+    return;
+  }
 
   if (auto *tag = llvm::dyn_cast<clang::TagDecl>(&context)) {
     CompleteTagDecl(*tag);

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbFPOProgramToDWARFExpression.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbFPOProgramToDWARFExpression.cpp
@@ -10,7 +10,6 @@
 #include "CodeViewRegisterMapping.h"
 
 #include "lldb/Symbol/PostfixExpression.h"
-#include "lldb/Utility/LLDBAssert.h"
 #include "lldb/Utility/Stream.h"
 #include "llvm/ADT/DenseMap.h"
 

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbIndex.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbIndex.cpp
@@ -20,7 +20,6 @@
 #include "llvm/Object/COFF.h"
 #include "llvm/Support/Error.h"
 
-#include "lldb/Utility/LLDBAssert.h"
 #include "lldb/lldb-defines.h"
 #include <optional>
 
@@ -41,7 +40,7 @@ PdbIndex::PdbIndex() : m_cus(*this), m_va_to_modi(m_allocator) {}
 
 llvm::Expected<std::unique_ptr<PdbIndex>>
 PdbIndex::create(llvm::pdb::PDBFile *file) {
-  lldbassert(file);
+  assert(file);
 
   std::unique_ptr<PdbIndex> result(new PdbIndex());
   ASSIGN_PTR_OR_RETURN(result->m_dbi, file->getPDBDbiStream());
@@ -114,8 +113,7 @@ void PdbIndex::ParseSectionContribs() {
 }
 
 void PdbIndex::BuildAddrToSymbolMap(CompilandIndexItem &cci) {
-  lldbassert(cci.m_symbols_by_va.empty() &&
-             "Addr to symbol map is already built!");
+  assert(cci.m_symbols_by_va.empty() && "Addr to symbol map is already built!");
   uint16_t modi = cci.m_id.modi;
   const CVSymbolArray &syms = cci.m_debug_stream.getSymbolArray();
   for (auto iter = syms.begin(); iter != syms.end(); ++iter) {
@@ -187,7 +185,10 @@ std::vector<SymbolAndUid> PdbIndex::FindSymbolsByVa(lldb::addr_t va) {
 CVSymbol PdbIndex::ReadSymbolRecord(PdbCompilandSymId cu_sym) const {
   const CompilandIndexItem *cci = compilands().GetCompiland(cu_sym.modi);
   auto iter = cci->m_debug_stream.getSymbolArray().at(cu_sym.offset);
-  lldbassert(iter != cci->m_debug_stream.getSymbolArray().end());
+  if (iter == cci->m_debug_stream.getSymbolArray().end()) {
+    assert(false && "missing symbol");
+    return {};
+  }
   return *iter;
 }
 

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbSymUid.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbSymUid.cpp
@@ -173,3 +173,16 @@ void llvm::format_provider<lldb_private::npdb::PdbGlobalSymId>::format(
     Stream << "public, ";
   Stream << V.offset << ')';
 }
+
+void llvm::format_provider<lldb_private::npdb::PdbTypeSymId>::format(
+    const lldb_private::npdb::PdbTypeSymId &V, raw_ostream &Stream,
+    StringRef Style) {
+  Stream << "TypeSym(";
+  if (V.is_ipi)
+    Stream << "IPI, ";
+  else
+    Stream << "TPI, ";
+
+  write_hex(Stream, V.index.getIndex(), HexPrintStyle::PrefixLower);
+  Stream << ')';
+}

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbSymUid.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbSymUid.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "PdbSymUid.h"
+#include "llvm/Support/NativeFormatting.h"
 
 using namespace lldb_private;
 using namespace lldb_private::npdb;

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbSymUid.h
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbSymUid.h
@@ -131,6 +131,11 @@ template <> struct format_provider<lldb_private::npdb::PdbGlobalSymId> {
                      raw_ostream &Stream, StringRef Style);
 };
 
+template <> struct format_provider<lldb_private::npdb::PdbTypeSymId> {
+  static void format(const lldb_private::npdb::PdbTypeSymId &V,
+                     raw_ostream &Stream, StringRef Style);
+};
+
 } // namespace llvm
 
 #endif

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbUtil.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbUtil.cpp
@@ -21,7 +21,6 @@
 #include "Plugins/Language/CPlusPlus/MSVCUndecoratedNameParser.h"
 #include "Plugins/SymbolFile/NativePDB/CodeViewRegisterMapping.h"
 #include "lldb/Symbol/Block.h"
-#include "lldb/Utility/LLDBAssert.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/lldb-enumerations.h"
 
@@ -275,7 +274,7 @@ PDB_SymType lldb_private::npdb::CVSymToPDBSym(SymbolKind kind) {
   case S_CALLERS:
     return PDB_SymType::Caller;
   default:
-    lldbassert(false && "Invalid symbol record kind!");
+    assert(false && "Invalid symbol record kind!");
   }
   return PDB_SymType::None;
 }
@@ -304,7 +303,7 @@ PDB_SymType lldb_private::npdb::CVTypeToPDBType(TypeLeafKind kind) {
   case LF_BITFIELD:
     return PDB_SymType::BuiltinType;
   default:
-    lldbassert(false && "Invalid type record kind!");
+    assert(false && "Invalid type record kind!");
   }
   return PDB_SymType::None;
 }
@@ -435,7 +434,7 @@ SegmentOffset lldb_private::npdb::GetSegmentAndOffset(const CVSymbol &sym) {
     return ::GetSegmentAndOffset<ThreadLocalDataSym>(sym);
     break;
   default:
-    lldbassert(false && "Record does not have a segment/offset!");
+    assert(false && "Record does not have a segment/offset!");
   }
   return {0, 0};
 }
@@ -489,7 +488,7 @@ lldb_private::npdb::GetSegmentOffsetAndLength(const CVSymbol &sym) {
     return ::GetSegmentOffsetAndLength<BlockSym>(sym);
     break;
   default:
-    lldbassert(false && "Record does not have a segment/offset/length triple!");
+    assert(false && "Record does not have a segment/offset/length triple!");
   }
   return {0, 0, 0};
 }
@@ -591,7 +590,10 @@ TypeIndex lldb_private::npdb::GetFieldListIndex(CVType cvt) {
 }
 
 TypeIndex lldb_private::npdb::LookThroughModifierRecord(CVType modifier) {
-  lldbassert(modifier.kind() == LF_MODIFIER);
+  if (modifier.kind() != LF_MODIFIER) {
+    assert(false && "must be called on an LF_MODIFIER");
+    return {};
+  }
   ModifierRecord mr;
   llvm::cantFail(TypeDeserializer::deserializeAs<ModifierRecord>(modifier, mr));
   return mr.ModifiedType;
@@ -662,7 +664,7 @@ VariableInfo lldb_private::npdb::GetVariableNameInfo(CVSymbol sym) {
     return result;
   }
 
-  lldbassert(false && "Invalid variable record kind!");
+  assert(false && "Invalid variable record kind!");
   return {};
 }
 
@@ -670,7 +672,8 @@ static llvm::FixedStreamArray<FrameData>::Iterator
 GetCorrespondingFrameData(lldb::addr_t load_addr,
                           const DebugFrameDataSubsectionRef &fpo_data,
                           const Variable::RangeList &ranges) {
-  lldbassert(!ranges.IsEmpty());
+  if (ranges.IsEmpty())
+    return fpo_data.end();
 
   // assume that all variable ranges correspond to one frame data
   using RangeListEntry = Variable::RangeList::Entry;
@@ -819,8 +822,10 @@ VariableInfo lldb_private::npdb::GetVariableLocationInfo(
           PdbCompilandSymId func_scope_id =
               PdbSymUid(func_block.GetID()).asCompilandSym();
           CVSymbol func_block_cvs = index.ReadSymbolRecord(func_scope_id);
-          lldbassert(func_block_cvs.kind() == S_GPROC32 ||
-                     func_block_cvs.kind() == S_LPROC32);
+          if (func_block_cvs.kind() != S_GPROC32 &&
+              func_block_cvs.kind() != S_LPROC32)
+            return result; // Invalid variable.
+
           PdbCompilandSymId frame_proc_id(func_scope_id.modi,
                                           func_scope_id.offset +
                                               func_block_cvs.length());

--- a/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
@@ -488,13 +488,21 @@ Block *SymbolFileNativePDB::CreateBlock(PdbCompilandSymId block_id) {
                      "Failed to deserialize BlockSym record: {0}");
       return nullptr;
     }
-    lldbassert(block.Parent != 0);
+    if (block.Parent == 0) {
+      LLDB_LOG(GetLog(LLDBLog::Symbols), "BlockSym record ({0}) with parent=0",
+               block_id);
+      return nullptr;
+    }
     PdbCompilandSymId parent_id(block_id.modi, block.Parent);
     Block *parent_block = GetOrCreateBlock(parent_id);
     if (!parent_block)
       return nullptr;
     Function *func = parent_block->CalculateSymbolContextFunction();
-    lldbassert(func);
+    if (!func) {
+      LLDB_LOG(GetLog(LLDBLog::Symbols), "parent of {0} is not a function",
+               parent_id);
+      return nullptr;
+    }
     lldb::addr_t block_base =
         m_index->MakeVirtualAddress(block.Segment, block.CodeOffset);
     lldb::addr_t func_base = func->GetAddress().GetFileAddress();
@@ -545,7 +553,8 @@ Block *SymbolFileNativePDB::CreateBlock(PdbCompilandSymId block_id) {
     break;
   }
   default:
-    lldbassert(false && "Symbol is not a block!");
+    LLDB_LOG(GetLog(LLDBLog::Symbols), "{0} is not a block", block_id);
+    return nullptr;
   }
 
   return nullptr;
@@ -555,10 +564,17 @@ lldb::FunctionSP SymbolFileNativePDB::CreateFunction(PdbCompilandSymId func_id,
                                                      CompileUnit &comp_unit) {
   const CompilandIndexItem *cci =
       m_index->compilands().GetCompiland(func_id.modi);
-  lldbassert(cci);
-  CVSymbol sym_record = cci->m_debug_stream.readSymbolAtOffset(func_id.offset);
+  if (!cci) {
+    LLDB_LOG(GetLog(LLDBLog::Symbols), "missing compiland {0}", func_id.modi);
+    return nullptr;
+  }
 
-  lldbassert(sym_record.kind() == S_LPROC32 || sym_record.kind() == S_GPROC32);
+  CVSymbol sym_record = cci->m_debug_stream.readSymbolAtOffset(func_id.offset);
+  if (sym_record.kind() != S_LPROC32 && sym_record.kind() != S_GPROC32) {
+    LLDB_LOG(GetLog(LLDBLog::Symbols), "{0} is not a function", func_id);
+    return nullptr;
+  }
+
   SegmentOffsetLength sol = GetSegmentOffsetAndLength(sym_record);
 
   auto file_vm_addr =
@@ -1195,10 +1211,12 @@ SymbolFileNativePDB::GetOrCreateCompileUnit(const CompilandIndexItem &cci) {
 
   auto emplace_result =
       m_compilands.try_emplace(toOpaqueUid(cci.m_id), nullptr);
-  if (emplace_result.second)
+  if (emplace_result.second) {
     emplace_result.first->second = CreateCompileUnit(cci);
+    LLDB_LOG(GetLog(LLDBLog::Symbols), "failed to create compile unit for {0}",
+             cci.m_id.modi);
+  }
 
-  lldbassert(emplace_result.first->second);
   return emplace_result.first->second;
 }
 
@@ -1224,7 +1242,7 @@ void SymbolFileNativePDB::ParseDeclsForContext(
 lldb::CompUnitSP SymbolFileNativePDB::ParseCompileUnitAtIndex(uint32_t index) {
   if (index >= GetNumCompileUnits())
     return CompUnitSP();
-  lldbassert(index < UINT16_MAX);
+  assert(index < UINT16_MAX && "Invalid compile unit index");
   if (index >= UINT16_MAX)
     return nullptr;
 
@@ -1236,12 +1254,15 @@ lldb::CompUnitSP SymbolFileNativePDB::ParseCompileUnitAtIndex(uint32_t index) {
 lldb::LanguageType SymbolFileNativePDB::ParseLanguage(CompileUnit &comp_unit) {
   std::lock_guard<std::recursive_mutex> guard(GetModuleMutex());
   PdbSymUid uid(comp_unit.GetID());
-  lldbassert(uid.kind() == PdbSymUidKind::Compiland);
+  if (uid.kind() != PdbSymUidKind::Compiland) {
+    assert(false && "uid of compile unit not a compiland");
+    return lldb::eLanguageTypeUnknown;
+  }
 
   CompilandIndexItem *item =
       m_index->compilands().GetCompiland(uid.asCompiland().modi);
-  lldbassert(item);
-  if (!item->m_compile_opts)
+  assert(item);
+  if (!item || !item->m_compile_opts)
     return lldb::eLanguageTypeUnknown;
 
   return TranslateLanguage(item->m_compile_opts->getLanguage());
@@ -1330,7 +1351,10 @@ void SymbolFileNativePDB::AddSymbols(Symtab &symtab) {
 size_t SymbolFileNativePDB::ParseFunctions(CompileUnit &comp_unit) {
   std::lock_guard<std::recursive_mutex> guard(GetModuleMutex());
   PdbSymUid uid{comp_unit.GetID()};
-  lldbassert(uid.kind() == PdbSymUidKind::Compiland);
+  if (uid.kind() != PdbSymUidKind::Compiland) {
+    assert(false && "uid of compile unit not a compiland");
+    return 0;
+  }
   uint16_t modi = uid.asCompiland().modi;
   CompilandIndexItem &cii = m_index->compilands().GetOrCreateCompiland(modi);
 
@@ -1346,7 +1370,10 @@ size_t SymbolFileNativePDB::ParseFunctions(CompileUnit &comp_unit) {
   }
 
   size_t new_count = comp_unit.GetNumFunctions();
-  lldbassert(new_count >= count);
+  if (new_count < count) {
+    assert(false && "less functions after parsing than before");
+    return 0;
+  }
   return new_count - count;
 }
 
@@ -1380,7 +1407,11 @@ uint32_t SymbolFileNativePDB::ResolveSymbolContext(
 
   if (resolve_scope & eSymbolContextFunction ||
       resolve_scope & eSymbolContextBlock) {
-    lldbassert(sc.comp_unit);
+    if (!sc.comp_unit) {
+      LLDB_LOG(GetLog(LLDBLog::Symbols),
+               "missing compile unit for symbol at address {0:x}", file_addr);
+      return 0;
+    }
     std::vector<SymbolAndUid> matches = m_index->FindSymbolsByVa(file_addr);
     // Search the matches in reverse.  This way if there are multiple matches
     // (for example we are 3 levels deep in a nested scope) it will find the
@@ -1425,7 +1456,11 @@ uint32_t SymbolFileNativePDB::ResolveSymbolContext(
   }
 
   if (resolve_scope & eSymbolContextLineEntry) {
-    lldbassert(sc.comp_unit);
+    if (!sc.comp_unit) {
+      LLDB_LOG(GetLog(LLDBLog::Symbols),
+               "missing compile unit for symbol at address {0:x}", file_addr);
+      return 0;
+    }
     if (auto *line_table = sc.comp_unit->GetLineTable()) {
       if (line_table->FindLineEntryByAddress(addr, sc.line_entry))
         resolved_flags |= eSymbolContextLineEntry;
@@ -1465,10 +1500,16 @@ bool SymbolFileNativePDB::ParseLineTable(CompileUnit &comp_unit) {
   // member, and we could only get the line info for the function in question.
   std::lock_guard<std::recursive_mutex> guard(GetModuleMutex());
   PdbSymUid cu_id(comp_unit.GetID());
-  lldbassert(cu_id.kind() == PdbSymUidKind::Compiland);
+  if (cu_id.kind() != PdbSymUidKind::Compiland) {
+    assert(false && "uid of compile unit not a compiland");
+    return false;
+  }
   uint16_t modi = cu_id.asCompiland().modi;
   CompilandIndexItem *cii = m_index->compilands().GetCompiland(modi);
-  lldbassert(cii);
+  if (!cii) {
+    LLDB_LOG(GetLog(LLDBLog::Symbols), "missing compiland for modi={0}", modi);
+    return false;
+  }
 
   // Parse DEBUG_S_LINES subsections first, then parse all S_INLINESITE records
   // in this CU. Add line entries into the set first so that if there are line
@@ -1506,7 +1547,11 @@ bool SymbolFileNativePDB::ParseLineTable(CompileUnit &comp_unit) {
         continue;
       }
       uint32_t file_index = file_index_or_err.get();
-      lldbassert(!group.LineNumbers.empty());
+      if (group.LineNumbers.empty()) {
+        LLDB_LOG(GetLog(LLDBLog::Symbols),
+                 "no line numbers for {0} in modi={1}", group.NameIndex, modi);
+        continue;
+      }
       CompilandIndexItem::GlobalLineTable::Entry line_entry(
           LLDB_INVALID_ADDRESS, 0);
       for (const LineNumberEntry &entry : group.LineNumbers) {
@@ -1654,10 +1699,17 @@ bool SymbolFileNativePDB::ParseSupportFiles(CompileUnit &comp_unit,
                                             SupportFileList &support_files) {
   std::lock_guard<std::recursive_mutex> guard(GetModuleMutex());
   PdbSymUid cu_id(comp_unit.GetID());
-  lldbassert(cu_id.kind() == PdbSymUidKind::Compiland);
+  if (cu_id.kind() != PdbSymUidKind::Compiland) {
+    assert(false && "uid of compile unit not a compiland");
+    return false;
+  }
   CompilandIndexItem *cci =
       m_index->compilands().GetCompiland(cu_id.asCompiland().modi);
-  lldbassert(cci);
+  if (!cci) {
+    LLDB_LOG(GetLog(LLDBLog::Symbols), "missing compiland for modi={0}",
+             cu_id.asCompiland().modi);
+    return false;
+  }
 
   for (llvm::StringRef f : cci->m_file_list) {
     FileSpec::Style style =
@@ -2186,7 +2238,11 @@ void SymbolFileNativePDB::FindFunctions(
 
       CVSymbol sym = m_index->ReadSymbolRecord(global);
       auto kind = sym.kind();
-      lldbassert(kind == S_PROCREF || kind == S_LPROCREF);
+      if (kind != S_PROCREF && kind != S_LPROCREF) {
+        LLDB_LOG(GetLog(LLDBLog::Symbols), "{0} is not a proc reference",
+                 global);
+        continue;
+      }
 
       auto proc_or_err = SymbolDeserializer::deserializeAs<ProcRefSym>(sym);
       if (!proc_or_err) {
@@ -2329,8 +2385,6 @@ size_t SymbolFileNativePDB::ParseTypes(CompileUnit &comp_unit) {
 size_t
 SymbolFileNativePDB::ParseVariablesForCompileUnit(CompileUnit &comp_unit,
                                                   VariableList &variables) {
-  PdbSymUid sym_uid(comp_unit.GetID());
-  lldbassert(sym_uid.kind() == PdbSymUidKind::Compiland);
   for (const uint32_t gid : m_index->globals().getGlobalsTable()) {
     PdbGlobalSymId global{gid, false};
     CVSymbol sym = m_index->ReadSymbolRecord(global);
@@ -2461,7 +2515,10 @@ SymbolFileNativePDB::GetOrCreateLocalVariable(PdbCompilandSymId scope_id,
 
 TypeSP SymbolFileNativePDB::CreateTypedef(PdbGlobalSymId id) {
   CVSymbol sym = m_index->ReadSymbolRecord(id);
-  lldbassert(sym.kind() == SymbolKind::S_UDT);
+  if (sym.kind() != S_UDT) {
+    LLDB_LOG(GetLog(LLDBLog::Symbols), "{0} is not an S_UDT", id);
+    return nullptr;
+  }
 
   auto udt_or_err = SymbolDeserializer::deserializeAs<UDTSym>(sym);
   if (!udt_or_err) {
@@ -2547,7 +2604,7 @@ size_t SymbolFileNativePDB::ParseVariablesForBlock(PdbCompilandSymId block_id) {
   case S_INLINESITE:
     break;
   default:
-    lldbassert(false && "Symbol is not a block!");
+    LLDB_LOG(GetLog(LLDBLog::Symbols), "{0} is not a block", block_id);
     return 0;
   }
 
@@ -2616,9 +2673,7 @@ size_t SymbolFileNativePDB::ParseVariablesForBlock(PdbCompilandSymId block_id) {
 
 size_t SymbolFileNativePDB::ParseVariablesForContext(const SymbolContext &sc) {
   std::lock_guard<std::recursive_mutex> guard(GetModuleMutex());
-  lldbassert(sc.function || sc.comp_unit);
 
-  VariableListSP variables;
   if (sc.block) {
     PdbSymUid block_id(sc.block->GetID());
 
@@ -2634,7 +2689,7 @@ size_t SymbolFileNativePDB::ParseVariablesForContext(const SymbolContext &sc) {
   }
 
   if (sc.comp_unit) {
-    variables = sc.comp_unit->GetVariableList(false);
+    VariableListSP variables = sc.comp_unit->GetVariableList(false);
     if (!variables) {
       variables = std::make_shared<VariableList>();
       sc.comp_unit->SetVariableList(variables);
@@ -2642,7 +2697,9 @@ size_t SymbolFileNativePDB::ParseVariablesForContext(const SymbolContext &sc) {
     return ParseVariablesForCompileUnit(*sc.comp_unit, *variables);
   }
 
-  llvm_unreachable("Unreachable!");
+  LLDB_LOG(GetLog(LLDBLog::Symbols),
+           "missing missing block, function, or module for symbol context");
+  return 0;
 }
 
 CompilerDecl SymbolFileNativePDB::GetDeclForUID(lldb::user_id_t uid) {
@@ -2698,7 +2755,10 @@ Type *SymbolFileNativePDB::ResolveTypeUID(lldb::user_id_t type_uid) {
     return &*iter->second;
 
   PdbSymUid uid(type_uid);
-  lldbassert(uid.kind() == PdbSymUidKind::Type);
+  if (uid.kind() != PdbSymUidKind::Type) {
+    assert(false && "uid is not a type index");
+    return nullptr;
+  }
   PdbTypeSymId type_id = uid.asTypeSym();
   if (type_id.index.isNoneType())
     return nullptr;
@@ -2918,7 +2978,8 @@ SymbolFileNativePDB::FindSymbolScope(PdbCompilandSymId id) {
   while (begin != end) {
     if (begin.offset() > id.offset) {
       // We passed it.  We couldn't even find this symbol record.
-      lldbassert(false && "Invalid compiland symbol id!");
+      LLDB_LOG(GetLog(LLDBLog::Symbols), "invalid compiland symbol id: {0}",
+               id);
       return std::nullopt;
     }
 

--- a/lldb/source/Plugins/SymbolFile/NativePDB/UdtRecordCompleter.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/UdtRecordCompleter.cpp
@@ -12,12 +12,12 @@
 #include "SymbolFileNativePDB.h"
 #include "lldb/Core/Address.h"
 #include "lldb/Symbol/Type.h"
-#include "lldb/Utility/LLDBAssert.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/lldb-enumerations.h"
 #include "lldb/lldb-forward.h"
 
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/DebugInfo/CodeView/Formatters.h"
 #include "llvm/DebugInfo/CodeView/SymbolDeserializer.h"
 #include "llvm/DebugInfo/CodeView/TypeDeserializer.h"
 #include "llvm/DebugInfo/CodeView/TypeIndex.h"
@@ -115,9 +115,13 @@ Error UdtRecordCompleter::visitKnownMember(CVMemberRecord &cvr,
 
   if (base_qt.isNull())
     return llvm::Error::success();
-  auto decl =
+  auto *decl =
       m_ast_builder.clang().GetAsCXXRecordDecl(base_qt.getAsOpaquePtr());
-  lldbassert(decl);
+  if (!decl) {
+    LLDB_LOG(GetLog(LLDBLog::Symbols), "base ({0}) of {1} is not a record",
+             base.Type, m_id.index);
+    return Error::success();
+  }
 
   auto offset = clang::CharUnits::fromQuantity(base.getBaseOffset());
   m_layout.base_offsets.insert(std::make_pair(decl, offset));
@@ -497,13 +501,13 @@ void UdtRecordCompleter::Record::ConstructRecord() {
   for (auto &pair : fields_map) {
     uint64_t offset = pair.first;
     auto &fields = pair.second;
-    lldbassert(offset >= start_offset);
+    assert(offset >= start_offset);
     Member *parent = &record;
     if (offset > start_offset) {
       // Find the field with largest end offset that is <= offset. If it's less
       // than offset, it indicates there are padding bytes between end offset
       // and offset.
-      lldbassert(!end_offset_map.empty());
+      assert(!end_offset_map.empty());
       auto iter = end_offset_map.lower_bound(offset);
       if (iter == end_offset_map.end())
         --iter;
@@ -543,8 +547,8 @@ void UdtRecordCompleter::Record::ConstructRecord() {
       if (parent->kind == Member::Struct) {
         end_offset_map[end_offset].push_back(parent);
       } else {
-        lldbassert(parent == &record &&
-                   "If parent is union, it must be the top level record.");
+        assert(parent == &record &&
+               "If parent is union, it must be the top level record.");
         end_offset_map[end_offset].push_back(parent->fields.back().get());
       }
     } else {
@@ -553,8 +557,8 @@ void UdtRecordCompleter::Record::ConstructRecord() {
         parent = parent->fields.back().get();
         parent->bit_offset = offset;
       } else {
-        lldbassert(parent == &record &&
-                   "If parent is union, it must be the top level record.");
+        assert(parent == &record &&
+               "If parent is union, it must be the top level record.");
       }
       for (auto &field : fields) {
         int64_t bit_size = field->bit_size;


### PR DESCRIPTION
`lldbassert` has a note on the lldb docs that reads:
> New code should not be using `lldbassert()` and existing uses should be replaced by other means of error handling.

(Native)PDB is the largest user of `lldbassert`. This migrates NativePDB away. I kept the DIA PDB asserts, because we want to remove it regardless.

There are two main reasons `lldbassert` is used:
1. Checking internal invariants. For example checking that we haven't already created a type when saving it to a map. I replaced this with `assert`.
2. Checking for invalid debug info. For example checking that the base class of a record is another record. I replaced this with a log and early out. We shouldn't even `assert` here.