### PR TITLE
[InstCombine] Fold [su]cmp of no-wrap ops with a common operand

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -1982,6 +1982,119 @@ static Value *foldSinAndCosToSinCos(IntrinsicInst *II, IRBuilderBase &B,
   return IsSin ? Sin : Cos;
 }
 
+/// [su]cmp only depends on the relative order of its operands, so applying the
+/// same order-preserving operation to both of them is a no-op. If both operands
+/// are computed by the same non-wrapping (and therefore monotonic) operation
+/// with a common operand, the comparison can be done on the original values:
+///   ucmp(add nuw X, Z, add nuw Y, Z) --> ucmp(X, Y)
+///   scmp(sub nsw Z, X, sub nsw Z, Y) --> scmp(Y, X)
+/// On a successful match \p X and \p Y are set to the new comparison operands,
+/// already swapped if the operation reverses the order.
+static bool matchOrderPreservingCmpOperands(Value *Op0, Value *Op1,
+                                            bool IsSigned, Value *&X, Value *&Y,
+                                            const SimplifyQuery &SQ,
+                                            const Instruction *CxtI) {
+  auto *BO0 = dyn_cast<BinaryOperator>(Op0);
+  auto *BO1 = dyn_cast<BinaryOperator>(Op1);
+  if (!BO0 || !BO1 || BO0->getOpcode() != BO1->getOpcode())
+    return false;
+
+  // Only an operation that cannot wrap in the compared domain is guaranteed to
+  // preserve the order of its operands.
+  auto HasNoWrap = [IsSigned](const BinaryOperator *BO) {
+    return IsSigned ? BO->hasNoSignedWrap() : BO->hasNoUnsignedWrap();
+  };
+  if (!HasNoWrap(BO0) || !HasNoWrap(BO1))
+    return false;
+
+  Value *A = BO0->getOperand(0), *B = BO0->getOperand(1);
+  Value *C = BO1->getOperand(0), *D = BO1->getOperand(1);
+
+  switch (BO0->getOpcode()) {
+  case Instruction::Add:
+    // (X + Z) cmp (Y + Z) --> X cmp Y (add is commutative)
+    if (B == D) {
+      X = A;
+      Y = C;
+      return true;
+    }
+    if (B == C) {
+      X = A;
+      Y = D;
+      return true;
+    }
+    if (A == D) {
+      X = B;
+      Y = C;
+      return true;
+    }
+    if (A == C) {
+      X = B;
+      Y = D;
+      return true;
+    }
+    return false;
+
+  case Instruction::Sub:
+    // (X - Z) cmp (Y - Z) --> X cmp Y
+    if (B == D) {
+      X = A;
+      Y = C;
+      return true;
+    }
+    // (Z - X) cmp (Z - Y) --> Y cmp X
+    if (A == C) {
+      X = D;
+      Y = B;
+      return true;
+    }
+    return false;
+
+  case Instruction::Mul: {
+    // Determine the common factor Z in (X * Z) cmp (Y * Z).
+    Value *Z;
+    if (B == D) {
+      Z = B;
+      X = A;
+      Y = C;
+    } else if (B == C) {
+      Z = B;
+      X = A;
+      Y = D;
+    } else if (A == D) {
+      Z = A;
+      X = B;
+      Y = C;
+    } else if (A == C) {
+      Z = A;
+      X = B;
+      Y = D;
+    } else {
+      return false;
+    }
+
+    SimplifyQuery Q = SQ.getWithInstruction(CxtI);
+    // Scaling by a non-zero factor preserves the unsigned order. A zero factor
+    // would map every value onto zero.
+    if (!IsSigned)
+      return isKnownNonZero(Z, Q);
+    // Scaling by a positive factor preserves the signed order, while a negative
+    // factor reverses it. The sign of the factor has to be known, because
+    // 'mul nsw' by an unknown value is not monotonic in either direction.
+    if (isKnownPositive(Z, Q))
+      return true;
+    if (isKnownNegative(Z, Q)) {
+      std::swap(X, Y);
+      return true;
+    }
+    return false;
+  }
+
+  default:
+    return false;
+  }
+}
+
 /// CallInst simplification. This mostly only handles folding of intrinsic
 /// instructions. For normal calls, it allows visitCallBase to do the heavy
 /// lifting.
@@ -2487,6 +2600,22 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
       return replaceInstUsesWith(
           CI,
           Builder.CreateIntrinsic(II->getType(), Intrinsic::scmp, {LHS, RHS}));
+
+    if (matchOrderPreservingCmpOperands(I0, I1, /*IsSigned=*/true, LHS, RHS, SQ,
+                                        II))
+      return replaceInstUsesWith(
+          CI,
+          Builder.CreateIntrinsic(II->getType(), Intrinsic::scmp, {LHS, RHS}));
+    break;
+  }
+  case Intrinsic::ucmp: {
+    Value *I0 = II->getArgOperand(0), *I1 = II->getArgOperand(1);
+    Value *LHS, *RHS;
+    if (matchOrderPreservingCmpOperands(I0, I1, /*IsSigned=*/false, LHS, RHS,
+                                        SQ, II))
+      return replaceInstUsesWith(
+          CI,
+          Builder.CreateIntrinsic(II->getType(), Intrinsic::ucmp, {LHS, RHS}));
     break;
   }
   case Intrinsic::bitreverse: {

--- a/llvm/test/Transforms/InstCombine/scmp.ll
+++ b/llvm/test/Transforms/InstCombine/scmp.ll
@@ -864,3 +864,99 @@ define i8 @trunc_scmp_multiuse(i32 %x, i32 %y) {
   %tr = trunc i32 %cmp to i8
   ret i8 %tr
 }
+
+; scmp(add nsw X, Z, add nsw Y, Z) --> scmp(X, Y)
+define i8 @scmp_add_nsw_common_op(i32 %x, i32 %y, i32 %z) {
+; CHECK-LABEL: define i8 @scmp_add_nsw_common_op(
+; CHECK-SAME: i32 [[X:%.*]], i32 [[Y:%.*]], i32 [[Z:%.*]]) {
+; CHECK-NEXT:    [[CMP:%.*]] = call i8 @llvm.scmp.i8.i32(i32 [[X]], i32 [[Y]])
+; CHECK-NEXT:    ret i8 [[CMP]]
+;
+  %xz = add nsw i32 %x, %z
+  %yz = add nsw i32 %y, %z
+  %cmp = call i8 @llvm.scmp(i32 %xz, i32 %yz)
+  ret i8 %cmp
+}
+
+; scmp(sub nsw X, Z, sub nsw Y, Z) --> scmp(X, Y)
+define i8 @scmp_sub_nsw_common_rhs(i32 %x, i32 %y, i32 %z) {
+; CHECK-LABEL: define i8 @scmp_sub_nsw_common_rhs(
+; CHECK-SAME: i32 [[X:%.*]], i32 [[Y:%.*]], i32 [[Z:%.*]]) {
+; CHECK-NEXT:    [[CMP:%.*]] = call i8 @llvm.scmp.i8.i32(i32 [[X]], i32 [[Y]])
+; CHECK-NEXT:    ret i8 [[CMP]]
+;
+  %xz = sub nsw i32 %x, %z
+  %yz = sub nsw i32 %y, %z
+  %cmp = call i8 @llvm.scmp(i32 %xz, i32 %yz)
+  ret i8 %cmp
+}
+
+; scmp(sub nsw Z, X, sub nsw Z, Y) --> scmp(Y, X)
+define i8 @scmp_sub_nsw_common_lhs(i32 %x, i32 %y, i32 %z) {
+; CHECK-LABEL: define i8 @scmp_sub_nsw_common_lhs(
+; CHECK-SAME: i32 [[X:%.*]], i32 [[Y:%.*]], i32 [[Z:%.*]]) {
+; CHECK-NEXT:    [[CMP:%.*]] = call i8 @llvm.scmp.i8.i32(i32 [[Y]], i32 [[X]])
+; CHECK-NEXT:    ret i8 [[CMP]]
+;
+  %zx = sub nsw i32 %z, %x
+  %zy = sub nsw i32 %z, %y
+  %cmp = call i8 @llvm.scmp(i32 %zx, i32 %zy)
+  ret i8 %cmp
+}
+
+; A positive factor preserves the signed order.
+define i8 @scmp_mul_nsw_positive(i32 %x, i32 %y) {
+; CHECK-LABEL: define i8 @scmp_mul_nsw_positive(
+; CHECK-SAME: i32 [[X:%.*]], i32 [[Y:%.*]]) {
+; CHECK-NEXT:    [[CMP:%.*]] = call i8 @llvm.scmp.i8.i32(i32 [[X]], i32 [[Y]])
+; CHECK-NEXT:    ret i8 [[CMP]]
+;
+  %xz = mul nsw i32 %x, 3
+  %yz = mul nsw i32 %y, 3
+  %cmp = call i8 @llvm.scmp(i32 %xz, i32 %yz)
+  ret i8 %cmp
+}
+
+; A negative factor reverses the signed order.
+define i8 @scmp_mul_nsw_negative(i32 %x, i32 %y) {
+; CHECK-LABEL: define i8 @scmp_mul_nsw_negative(
+; CHECK-SAME: i32 [[X:%.*]], i32 [[Y:%.*]]) {
+; CHECK-NEXT:    [[CMP:%.*]] = call i8 @llvm.scmp.i8.i32(i32 [[Y]], i32 [[X]])
+; CHECK-NEXT:    ret i8 [[CMP]]
+;
+  %xz = mul nsw i32 %x, -3
+  %yz = mul nsw i32 %y, -3
+  %cmp = call i8 @llvm.scmp(i32 %xz, i32 %yz)
+  ret i8 %cmp
+}
+
+; Negative test: 'mul nsw' by a value of unknown sign is not monotonic in
+; either direction.
+define i8 @scmp_mul_nsw_unknown_sign(i32 %x, i32 %y, i32 %z) {
+; CHECK-LABEL: define i8 @scmp_mul_nsw_unknown_sign(
+; CHECK-SAME: i32 [[X:%.*]], i32 [[Y:%.*]], i32 [[Z:%.*]]) {
+; CHECK-NEXT:    [[XZ:%.*]] = mul nsw i32 [[X]], [[Z]]
+; CHECK-NEXT:    [[YZ:%.*]] = mul nsw i32 [[Y]], [[Z]]
+; CHECK-NEXT:    [[CMP:%.*]] = call i8 @llvm.scmp.i8.i32(i32 [[XZ]], i32 [[YZ]])
+; CHECK-NEXT:    ret i8 [[CMP]]
+;
+  %xz = mul nsw i32 %x, %z
+  %yz = mul nsw i32 %y, %z
+  %cmp = call i8 @llvm.scmp(i32 %xz, i32 %yz)
+  ret i8 %cmp
+}
+
+; Negative test: nuw does not imply anything about the signed order.
+define i8 @scmp_add_only_nuw(i32 %x, i32 %y, i32 %z) {
+; CHECK-LABEL: define i8 @scmp_add_only_nuw(
+; CHECK-SAME: i32 [[X:%.*]], i32 [[Y:%.*]], i32 [[Z:%.*]]) {
+; CHECK-NEXT:    [[XZ:%.*]] = add nuw i32 [[X]], [[Z]]
+; CHECK-NEXT:    [[YZ:%.*]] = add nuw i32 [[Y]], [[Z]]
+; CHECK-NEXT:    [[CMP:%.*]] = call i8 @llvm.scmp.i8.i32(i32 [[XZ]], i32 [[YZ]])
+; CHECK-NEXT:    ret i8 [[CMP]]
+;
+  %xz = add nuw i32 %x, %z
+  %yz = add nuw i32 %y, %z
+  %cmp = call i8 @llvm.scmp(i32 %xz, i32 %yz)
+  ret i8 %cmp
+}

--- a/llvm/test/Transforms/InstCombine/ucmp.ll
+++ b/llvm/test/Transforms/InstCombine/ucmp.ll
@@ -622,3 +622,115 @@ define i8 @trunc_ucmp_multiuse(i32 %x, i32 %y) {
   %tr = trunc i32 %cmp to i8
   ret i8 %tr
 }
+
+; ucmp(add nuw X, Z, add nuw Y, Z) --> ucmp(X, Y)
+define i8 @ucmp_add_nuw_common_op(i32 %x, i32 %y, i32 %z) {
+; CHECK-LABEL: define i8 @ucmp_add_nuw_common_op(
+; CHECK-SAME: i32 [[X:%.*]], i32 [[Y:%.*]], i32 [[Z:%.*]]) {
+; CHECK-NEXT:    [[CMP:%.*]] = call i8 @llvm.ucmp.i8.i32(i32 [[X]], i32 [[Y]])
+; CHECK-NEXT:    ret i8 [[CMP]]
+;
+  %xz = add nuw i32 %x, %z
+  %yz = add nuw i32 %y, %z
+  %cmp = call i8 @llvm.ucmp(i32 %xz, i32 %yz)
+  ret i8 %cmp
+}
+
+; The common operand may appear on either side of the add.
+define i8 @ucmp_add_nuw_commuted(i32 %x, i32 %y, i32 %z) {
+; CHECK-LABEL: define i8 @ucmp_add_nuw_commuted(
+; CHECK-SAME: i32 [[X:%.*]], i32 [[Y:%.*]], i32 [[Z:%.*]]) {
+; CHECK-NEXT:    [[CMP:%.*]] = call i8 @llvm.ucmp.i8.i32(i32 [[X]], i32 [[Y]])
+; CHECK-NEXT:    ret i8 [[CMP]]
+;
+  %xz = add nuw i32 %z, %x
+  %yz = add nuw i32 %y, %z
+  %cmp = call i8 @llvm.ucmp(i32 %xz, i32 %yz)
+  ret i8 %cmp
+}
+
+; ucmp(sub nuw X, Z, sub nuw Y, Z) --> ucmp(X, Y)
+define i8 @ucmp_sub_nuw_common_rhs(i32 %x, i32 %y, i32 %z) {
+; CHECK-LABEL: define i8 @ucmp_sub_nuw_common_rhs(
+; CHECK-SAME: i32 [[X:%.*]], i32 [[Y:%.*]], i32 [[Z:%.*]]) {
+; CHECK-NEXT:    [[CMP:%.*]] = call i8 @llvm.ucmp.i8.i32(i32 [[X]], i32 [[Y]])
+; CHECK-NEXT:    ret i8 [[CMP]]
+;
+  %xz = sub nuw i32 %x, %z
+  %yz = sub nuw i32 %y, %z
+  %cmp = call i8 @llvm.ucmp(i32 %xz, i32 %yz)
+  ret i8 %cmp
+}
+
+; Subtracting from a common value reverses the order:
+; ucmp(sub nuw Z, X, sub nuw Z, Y) --> ucmp(Y, X)
+define i8 @ucmp_sub_nuw_common_lhs(i32 %x, i32 %y, i32 %z) {
+; CHECK-LABEL: define i8 @ucmp_sub_nuw_common_lhs(
+; CHECK-SAME: i32 [[X:%.*]], i32 [[Y:%.*]], i32 [[Z:%.*]]) {
+; CHECK-NEXT:    [[CMP:%.*]] = call i8 @llvm.ucmp.i8.i32(i32 [[Y]], i32 [[X]])
+; CHECK-NEXT:    ret i8 [[CMP]]
+;
+  %zx = sub nuw i32 %z, %x
+  %zy = sub nuw i32 %z, %y
+  %cmp = call i8 @llvm.ucmp(i32 %zx, i32 %zy)
+  ret i8 %cmp
+}
+
+; ucmp(mul nuw X, C, mul nuw Y, C) --> ucmp(X, Y) for a non-zero C
+define i8 @ucmp_mul_nuw_nonzero(i32 %x, i32 %y) {
+; CHECK-LABEL: define i8 @ucmp_mul_nuw_nonzero(
+; CHECK-SAME: i32 [[X:%.*]], i32 [[Y:%.*]]) {
+; CHECK-NEXT:    [[CMP:%.*]] = call i8 @llvm.ucmp.i8.i32(i32 [[X]], i32 [[Y]])
+; CHECK-NEXT:    ret i8 [[CMP]]
+;
+  %xz = mul nuw i32 %x, 3
+  %yz = mul nuw i32 %y, 3
+  %cmp = call i8 @llvm.ucmp(i32 %xz, i32 %yz)
+  ret i8 %cmp
+}
+
+; Negative test: a zero factor maps every value onto zero, so the order is not
+; preserved.
+define i8 @ucmp_mul_nuw_maybe_zero(i32 %x, i32 %y, i32 %z) {
+; CHECK-LABEL: define i8 @ucmp_mul_nuw_maybe_zero(
+; CHECK-SAME: i32 [[X:%.*]], i32 [[Y:%.*]], i32 [[Z:%.*]]) {
+; CHECK-NEXT:    [[XZ:%.*]] = mul nuw i32 [[X]], [[Z]]
+; CHECK-NEXT:    [[YZ:%.*]] = mul nuw i32 [[Y]], [[Z]]
+; CHECK-NEXT:    [[CMP:%.*]] = call i8 @llvm.ucmp.i8.i32(i32 [[XZ]], i32 [[YZ]])
+; CHECK-NEXT:    ret i8 [[CMP]]
+;
+  %xz = mul nuw i32 %x, %z
+  %yz = mul nuw i32 %y, %z
+  %cmp = call i8 @llvm.ucmp(i32 %xz, i32 %yz)
+  ret i8 %cmp
+}
+
+; Negative test: without nuw on both operands the add may wrap.
+define i8 @ucmp_add_missing_nuw(i32 %x, i32 %y, i32 %z) {
+; CHECK-LABEL: define i8 @ucmp_add_missing_nuw(
+; CHECK-SAME: i32 [[X:%.*]], i32 [[Y:%.*]], i32 [[Z:%.*]]) {
+; CHECK-NEXT:    [[XZ:%.*]] = add nuw i32 [[X]], [[Z]]
+; CHECK-NEXT:    [[YZ:%.*]] = add i32 [[Y]], [[Z]]
+; CHECK-NEXT:    [[CMP:%.*]] = call i8 @llvm.ucmp.i8.i32(i32 [[XZ]], i32 [[YZ]])
+; CHECK-NEXT:    ret i8 [[CMP]]
+;
+  %xz = add nuw i32 %x, %z
+  %yz = add i32 %y, %z
+  %cmp = call i8 @llvm.ucmp(i32 %xz, i32 %yz)
+  ret i8 %cmp
+}
+
+; Negative test: nsw does not imply anything about the unsigned order.
+define i8 @ucmp_add_only_nsw(i32 %x, i32 %y, i32 %z) {
+; CHECK-LABEL: define i8 @ucmp_add_only_nsw(
+; CHECK-SAME: i32 [[X:%.*]], i32 [[Y:%.*]], i32 [[Z:%.*]]) {
+; CHECK-NEXT:    [[XZ:%.*]] = add nsw i32 [[X]], [[Z]]
+; CHECK-NEXT:    [[YZ:%.*]] = add nsw i32 [[Y]], [[Z]]
+; CHECK-NEXT:    [[CMP:%.*]] = call i8 @llvm.ucmp.i8.i32(i32 [[XZ]], i32 [[YZ]])
+; CHECK-NEXT:    ret i8 [[CMP]]
+;
+  %xz = add nsw i32 %x, %z
+  %yz = add nsw i32 %y, %z
+  %cmp = call i8 @llvm.ucmp(i32 %xz, i32 %yz)
+  ret i8 %cmp
+}


### PR DESCRIPTION
`llvm.ucmp`/`llvm.scmp` only depend on the *relative order* of their operands, so applying the same order-preserving operation to both operands is a no-op. As noted in #216127, these folds exist for `icmp` (see `icmp (A+B), (A+D) -> icmp B, D` in `foldICmpBinOp`) but were missing for the three-way compares.

This adds a `matchOrderPreservingCmpOperands()` helper that recognises when both operands are computed by the same non-wrapping — and therefore monotonic — operation with a common operand, and rewrites the comparison in terms of the original values:

| Fold | Condition |
| --- | --- |
| `ucmp(add nuw X, Z, add nuw Y, Z)` → `ucmp(X, Y)` | |
| `ucmp(sub nuw X, Z, sub nuw Y, Z)` → `ucmp(X, Y)` | |
| `ucmp(sub nuw Z, X, sub nuw Z, Y)` → `ucmp(Y, X)` | order reversed |
| `ucmp(mul nuw X, Z, mul nuw Y, Z)` → `ucmp(X, Y)` | `Z != 0` |
| `scmp(add nsw X, Z, add nsw Y, Z)` → `scmp(X, Y)` | |
| `scmp(sub nsw X, Z, sub nsw Y, Z)` → `scmp(X, Y)` | |
| `scmp(sub nsw Z, X, sub nsw Z, Y)` → `scmp(Y, X)` | order reversed |
| `scmp(mul nsw X, Z, mul nsw Y, Z)` → `scmp(X, Y)` | `Z > 0` |
| `scmp(mul nsw X, Z, mul nsw Y, Z)` → `scmp(Y, X)` | `Z < 0` |

`add` and `mul` are commutative, so the common operand is matched in either position.

Two cases need care, both called out in the issue:

* **`mul` by zero** is not order preserving in the unsigned domain (it maps every value onto zero), so the common factor must be known non-zero.
* **`mul nsw` by a value of unknown sign** is not monotonic in either direction, so the fold requires the sign of the common factor to be known — positive keeps the order, negative reverses it.

Alive2 proofs for these are linked from the issue, e.g. `add nuw` <https://alive2.llvm.org/ce/z/wdGE-_>, `mul nuw` <https://alive2.llvm.org/ce/z/Ye5rXq>, `sub nuw` <https://alive2.llvm.org/ce/z/sxqeFt>, `add nsw` <https://alive2.llvm.org/ce/z/v3NT4u>, `sub nsw` <https://alive2.llvm.org/ce/z/4o8aZu>, `mul nsw` by a positive <https://alive2.llvm.org/ce/z/9Z5H6z> and by a negative <https://alive2.llvm.org/ce/z/ESq3VL> value.

The remaining operations listed in the issue (`shl nuw`, `udiv exact`, `lshr exact`) are order preserving under the same reasoning and fit the same helper; I left them out here to keep the first change reviewable and can add them in a follow-up if you'd prefer them in this PR.

Tests cover each fold plus negative tests for a missing no-wrap flag, the wrong no-wrap flag for the compared domain (`nsw` for `ucmp` and `nuw` for `scmp`), a possibly-zero unsigned factor, and an unknown-sign signed factor.

One note for reviewers: I was not able to build LLVM in this environment, so the `CHECK` lines in `ucmp.ll`/`scmp.ll` were written by hand rather than produced by `utils/update_test_checks.py`. They follow the existing conventions in those files, but please regenerate them if anything is off — and I would appreciate an extra look at the `mul` sign reasoning in particular.

Fixes #216127