### PR TITLE
[include-cleaner] Support Objective-C toll-free bridged casts

### DIFF
--- a/clang-tools-extra/include-cleaner/lib/WalkAST.cpp
+++ b/clang-tools-extra/include-cleaner/lib/WalkAST.cpp
@@ -17,6 +17,7 @@
 #include "clang/AST/Expr.h"
 #include "clang/AST/ExprCXX.h"
 #include "clang/AST/ExprObjC.h"
+#include "clang/AST/OperationKinds.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/TemplateBase.h"
 #include "clang/AST/TemplateName.h"
@@ -531,12 +532,17 @@ public:
   bool VisitCastExpr(CastExpr *E) {
     // Handle implicit or explicit casts between Objective-C object pointers
     // aimed towards protocol-qualification (e.g., `ClassName *` to
-    // `id<Proto>`).
+    // `id<Proto>`), as well as toll-free bridged C-pointer-to-ObjC casts.
     QualType SourceType = E->getSubExpr()->getType();
     QualType DestType = E->getType();
 
     const auto *SrcPtr = SourceType->getAs<ObjCObjectPointerType>();
     const auto *DestPtr = DestType->getAs<ObjCObjectPointerType>();
+
+    if (E->getCastKind() == CK_CPointerToObjCPointerCast) {
+      if (DestPtr && DestPtr->getInterfaceDecl())
+        report(E->getExprLoc(), DestPtr->getInterfaceDecl(), RefType::Implicit);
+    }
 
     // If we're casting from a known class pointer to protocol conformance.
     if (SrcPtr && DestPtr && SrcPtr->getInterfaceDecl()) {

--- a/clang-tools-extra/include-cleaner/lib/WalkAST.cpp
+++ b/clang-tools-extra/include-cleaner/lib/WalkAST.cpp
@@ -539,6 +539,7 @@ public:
     const auto *SrcPtr = SourceType->getAs<ObjCObjectPointerType>();
     const auto *DestPtr = DestType->getAs<ObjCObjectPointerType>();
 
+    // Handles non-arc CPointer to ObjCPointer casts.
     if (E->getCastKind() == CK_CPointerToObjCPointerCast) {
       if (DestPtr && DestPtr->getInterfaceDecl())
         report(E->getExprLoc(), DestPtr->getInterfaceDecl(), RefType::Implicit);

--- a/clang-tools-extra/include-cleaner/lib/WalkAST.cpp
+++ b/clang-tools-extra/include-cleaner/lib/WalkAST.cpp
@@ -532,59 +532,57 @@ public:
   bool VisitCastExpr(CastExpr *E) {
     // Handle implicit or explicit casts between Objective-C object pointers
     // aimed towards protocol-qualification (e.g., `ClassName *` to
-    // `id<Proto>`), as well as toll-free bridged C-pointer-to-ObjC casts.
-    QualType SourceType = E->getSubExpr()->getType();
-    QualType DestType = E->getType();
+    // `id<Proto>`), as well as C-pointer-to-ObjC and id-to-ObjC pointer casts.
+    const auto *DestPtr = E->getType()->getAs<ObjCObjectPointerType>();
 
-    const auto *SrcPtr = SourceType->getAs<ObjCObjectPointerType>();
-    const auto *DestPtr = DestType->getAs<ObjCObjectPointerType>();
+    if (!DestPtr)
+      return true;
 
-    // Handles non-arc CPointer to ObjCPointer casts.
-    if (E->getCastKind() == CK_CPointerToObjCPointerCast) {
-      if (DestPtr && DestPtr->getInterfaceDecl())
-        report(E->getExprLoc(), DestPtr->getInterfaceDecl(), RefType::Implicit);
-    }
+    const auto *SrcPtr =
+        E->getSubExpr()->getType()->getAs<ObjCObjectPointerType>();
+
+    // Handles non-arc CPointer to ObjCPointer and id to ObjCPointer casts.
+    if (isa<ImplicitCastExpr>(E) &&
+        (E->getCastKind() == CK_CPointerToObjCPointerCast ||
+         (SrcPtr && SrcPtr->isObjCIdType())))
+      report(E->getExprLoc(), DestPtr->getInterfaceDecl(), RefType::Implicit);
+
+    if (!SrcPtr)
+      return true;
 
     // If we're casting from a known class pointer to protocol conformance.
-    if (SrcPtr && DestPtr && SrcPtr->getInterfaceDecl()) {
-      const ObjCInterfaceDecl *Class = SrcPtr->getInterfaceDecl();
-      ASTContext &Ctx = Class->getASTContext();
+    const ObjCInterfaceDecl *Class = SrcPtr->getInterfaceDecl();
+    if (!Class)
+      return true;
 
-      // For every protocol required by the destination type.
-      for (const ObjCProtocolDecl *Proto : DestPtr->quals()) {
-        const ObjCInterfaceDecl *Current = Class;
-        // Search the inheritance hierarchy for the provider of conformance.
-        while (Current) {
-          bool ConformsDirectly = false;
-          for (const auto *PI : Current->protocols()) {
-            if (Ctx.ProtocolCompatibleWithProtocol(
-                    const_cast<ObjCProtocolDecl *>(Proto),
-                    const_cast<ObjCProtocolDecl *>(PI))) {
-              ConformsDirectly = true;
-              break;
-            }
-          }
-          // If the class itself provides the conformance directly, we don't
-          // need to keep searching Categories.
-          if (ConformsDirectly)
+    ASTContext &Ctx = Class->getASTContext();
+
+    // For every protocol required by the destination type.
+    for (ObjCProtocolDecl *Proto : DestPtr->quals()) {
+      const ObjCInterfaceDecl *Current = Class;
+      // Search the inheritance hierarchy for the provider of conformance.
+      while (Current) {
+        bool ConformsDirectly = false;
+        for (auto *PI : Current->protocols()) {
+          if (Ctx.ProtocolCompatibleWithProtocol(Proto, PI)) {
+            ConformsDirectly = true;
             break;
-
-          // If the class doesn't declare direct conformance but conformance is
-          // injected via a visible Category attached to this class, note that
-          // the category header is required by recording an Implicit reference
-          // to it.
-          for (const auto *Cat : Current->visible_categories()) {
-            for (auto *PI : Cat->protocols()) {
-              if (Ctx.ProtocolCompatibleWithProtocol(
-                      const_cast<ObjCProtocolDecl *>(Proto),
-                      const_cast<ObjCProtocolDecl *>(PI))) {
-                report(E->getExprLoc(), const_cast<ObjCCategoryDecl *>(Cat),
-                       RefType::Implicit);
-              }
-            }
           }
-          Current = Current->getSuperClass();
         }
+        // If the class itself provides the conformance directly, we don't
+        // need to keep searching Categories.
+        if (ConformsDirectly)
+          break;
+
+        // If the class doesn't declare direct conformance but conformance is
+        // injected via a visible Category attached to this class, note that
+        // the category header is required by recording an Implicit reference
+        // to it.
+        for (auto *Cat : Current->visible_categories())
+          for (auto *PI : Cat->protocols())
+            if (Ctx.ProtocolCompatibleWithProtocol(Proto, PI))
+              report(E->getExprLoc(), Cat, RefType::Implicit);
+        Current = Current->getSuperClass();
       }
     }
     return true;

--- a/clang-tools-extra/include-cleaner/unittests/WalkASTTest.cpp
+++ b/clang-tools-extra/include-cleaner/unittests/WalkASTTest.cpp
@@ -1179,6 +1179,94 @@ TEST(WalkAST, ObjCSelectorExpr) {
            {"-x", "objective-c"});
 }
 
+TEST(WalkAST, ObjCBridgedCastExprToObjC) {
+  testWalk(R"objc(
+    typedef const struct __CFString *CFStringRef;
+    @interface $explicit^NSString
+    @end
+  )objc",
+           R"objc(
+    void test(CFStringRef cf) {
+      NSString *s = (__bridge ^NSString *)cf;
+    }
+  )objc",
+           {"-x", "objective-c", "-fobjc-arc"});
+}
+
+TEST(WalkAST, ObjCBridgedCastExprToCF) {
+  testWalk(R"objc(
+    typedef const struct __CFString * $explicit^CFStringRef;
+    @interface NSString
+    @end
+  )objc",
+           R"objc(
+    void test(NSString *s) {
+      CFStringRef cf = (__bridge ^CFStringRef)s;
+    }
+  )objc",
+           {"-x", "objective-c", "-fobjc-arc"});
+}
+
+TEST(WalkAST, ObjCBridgedCastExprBridgeTransfer) {
+  testWalk(R"objc(
+    typedef const struct __CFString *CFStringRef;
+    @interface $explicit^NSString
+    @end
+  )objc",
+           R"objc(
+    void test(CFStringRef cf) {
+      NSString *s = (__bridge_transfer ^NSString *)cf;
+    }
+  )objc",
+           {"-x", "objective-c", "-fobjc-arc"});
+}
+
+TEST(WalkAST, ObjCBridgedCastExprBridgeRetained) {
+  testWalk(R"objc(
+    typedef const struct __CFString * $explicit^CFStringRef;
+    @interface NSString
+    @end
+  )objc",
+           R"objc(
+    void test(NSString *s) {
+      CFStringRef cf = (__bridge_retained ^CFStringRef)s;
+    }
+  )objc",
+           {"-x", "objective-c", "-fobjc-arc"});
+}
+
+TEST(WalkAST, ObjCTollFreeBridgeCStyleCast) {
+  testWalk(R"objc(
+    typedef const struct __attribute__((objc_bridge(NSString))) __CFString * CFStringRef;
+    @interface $explicit^NSString
+    @end
+  )objc",
+           R"objc(
+    void test(CFStringRef cf) {
+      NSString *s = (^NSString *)cf;
+    }
+  )objc",
+           {"-x", "objective-c"});
+}
+
+TEST(WalkAST, ObjCBridgedCastExprToProtocol) {
+  // Note this test case is handled by TraverseObjCProtocolLoc instead of
+  // VisitCastExpr.
+  // It is here for completeness.
+  testWalk(R"objc(
+    typedef const struct __CFString *CFStringRef;
+    @protocol $explicit^MyProtocol
+    - (void)doSomething;
+    @end
+  )objc",
+           R"objc(
+    void test(CFStringRef cf) {
+      id<MyProtocol> p = (__bridge id<^MyProtocol>)cf;
+    }
+  )objc",
+           {"-x", "objective-c", "-fobjc-arc"});
+}
+
 TEST(WalkAST, ObjCSelectorExprPropertyGetter) {
   auto Decls = testWalk(R"objc(
     @interface MyClass

--- a/clang-tools-extra/include-cleaner/unittests/WalkASTTest.cpp
+++ b/clang-tools-extra/include-cleaner/unittests/WalkASTTest.cpp
@@ -1237,7 +1237,8 @@ TEST(WalkAST, ObjCBridgedCastExprBridgeRetained) {
 
 TEST(WalkAST, ObjCTollFreeBridgeCStyleCast) {
   testWalk(R"objc(
-    typedef const struct __attribute__((objc_bridge(NSString))) __CFString * CFStringRef;
+    typedef const struct __attribute__((objc_bridge(NSString)))
+      __CFString * CFStringRef;
     @interface $explicit^NSString
     @end
   )objc",
@@ -1265,6 +1266,19 @@ TEST(WalkAST, ObjCBridgedCastExprToProtocol) {
     }
   )objc",
            {"-x", "objective-c", "-fobjc-arc"});
+}
+
+TEST(WalkAST, ObjCImplicitPointerCast) {
+  testWalk(R"objc(
+    @interface $implicit^NSString
+    @end
+  )objc",
+           R"objc(
+    NSString *foo(void *p) {
+      return ^p;
+    }
+  )objc",
+           {"-x", "objective-c"});
 }
 
 TEST(WalkAST, ObjCSelectorExprPropertyGetter) {
@@ -1511,10 +1525,10 @@ TEST(WalkAST, ObjCEncodeExpr) {
            R"objc(
     void test() {
       const char *enc = @encode(struct ^MyStruct);
-    }
+     }
   )objc",
            {"-x", "objective-c"});
-}
+}     
 
 } // namespace
 } // namespace clang::include_cleaner

--- a/clang-tools-extra/include-cleaner/unittests/WalkASTTest.cpp
+++ b/clang-tools-extra/include-cleaner/unittests/WalkASTTest.cpp
@@ -1268,14 +1268,29 @@ TEST(WalkAST, ObjCBridgedCastExprToProtocol) {
            {"-x", "objective-c", "-fobjc-arc"});
 }
 
-TEST(WalkAST, ObjCImplicitPointerCast) {
+TEST(WalkAST, ObjCImplicitVoidPointerCast) {
   testWalk(R"objc(
     @interface $implicit^NSString
     @end
+    void cast(NSString *p);
   )objc",
            R"objc(
-    NSString *foo(void *p) {
-      return ^p;
+    void foo(void *p) {
+      cast(^p);
+    }
+  )objc",
+           {"-x", "objective-c"});
+}
+
+TEST(WalkAST, ObjCImplicitIdPointerCast) {
+  testWalk(R"objc(
+    @interface $implicit^NSString
+    @end
+    void cast(NSString *p);
+  )objc",
+           R"objc(
+   void foo(id p) {
+      cast(^p);
     }
   )objc",
            {"-x", "objective-c"});
@@ -1525,10 +1540,10 @@ TEST(WalkAST, ObjCEncodeExpr) {
            R"objc(
     void test() {
       const char *enc = @encode(struct ^MyStruct);
-     }
+    }
   )objc",
            {"-x", "objective-c"});
-}     
+}
 
 } // namespace
 } // namespace clang::include_cleaner


### PR DESCRIPTION
Handle `CK_CPointerToObjCPointerCast` in `WalkAST` to report implicit case when converting id/void to an Objective-C type (non-arc only). Also adds unit tests for various bridged cast types (these were already covered, but this verifies that they work).