### PR TITLE
[IR] Fix llvm.powi intrinsic decl

### DIFF
--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -1217,7 +1217,8 @@ let IntrProperties = [IntrNoMem, IntrSpeculatable, IntrNoCreateUndefOrPoison]
   // environment so they can be treated as readnone.
   def int_sqrt : DefaultAttrsIntrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
   def int_powi : DefaultAttrsIntrinsic<
-                   [llvm_anyfloat_ty], [LLVMMatchType<0>, llvm_anyint_ty]>;
+                   [llvm_anyfloat_ty],
+                   [LLVMMatchType<0>, llvm_any_scalar_int_ty]>;
   def int_sin  : DefaultAttrsIntrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
   def int_cos  : DefaultAttrsIntrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
   def int_pow  : DefaultAttrsIntrinsic<[llvm_anyfloat_ty],

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -5566,12 +5566,11 @@ void computeKnownFPClass(const Value *V, const APInt &DemandedElts,
       if ((InterestedClasses & (fcNan | fcInf | fcNegative)) == fcNone)
         break;
 
+      // The exponent is always a scalar, even when raising a vector to a power.
       const Value *Exp = II->getArgOperand(1);
-      Type *ExpTy = Exp->getType();
-      unsigned BitWidth = ExpTy->getScalarType()->getIntegerBitWidth();
+      unsigned BitWidth = Exp->getType()->getIntegerBitWidth();
       KnownBits ExponentKnownBits(BitWidth);
-      computeKnownBits(Exp, isa<VectorType>(ExpTy) ? DemandedElts : APInt(1, 1),
-                       ExponentKnownBits, Q, Depth + 1);
+      computeKnownBits(Exp, APInt(1, 1), ExponentKnownBits, Q, Depth + 1);
 
       FPClassTest InterestedSrcs = fcNone;
       if (InterestedClasses & fcNan)

--- a/llvm/lib/Transforms/Utils/SimplifyLibCalls.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyLibCalls.cpp
@@ -2511,7 +2511,9 @@ Value *LibCallSimplifier::optimizePow(CallInst *Pow, IRBuilderBase &B) {
   }
 
   // powf(x, itofp(y)) -> powi(x, y)
-  if (AllowApprox && (isa<SIToFPInst>(Expo) || isa<UIToFPInst>(Expo))) {
+  // The powi exponent must be a scalar integer, so a vector y is not usable.
+  if (AllowApprox && !Expo->getType()->isVectorTy() &&
+      (isa<SIToFPInst>(Expo) || isa<UIToFPInst>(Expo))) {
     if (Value *ExpoI = getIntToFPVal(Expo, B, TLI->getIntSize()))
       return copyFlags(*Pow, createPowWithIntegerExponent(Base, ExpoI, M, B));
   }

--- a/llvm/test/CodeGen/AArch64/bf16-v4-instructions.ll
+++ b/llvm/test/CodeGen/AArch64/bf16-v4-instructions.ll
@@ -2398,7 +2398,7 @@ define <4 x bfloat> @test_powi(<4 x bfloat> %a, i32 %b) #0 {
 ; CHECK-BF16-GI-NEXT:    // kill: def $d0 killed $d0 killed $q0
 ; CHECK-BF16-GI-NEXT:    add sp, sp, #96
 ; CHECK-BF16-GI-NEXT:    ret
-  %r = call <4 x bfloat> @llvm.powi.v4bf16.v4i32(<4 x bfloat> %a, i32 %b)
+  %r = call <4 x bfloat> @llvm.powi.v4bf16.i32(<4 x bfloat> %a, i32 %b)
   ret <4 x bfloat> %r
 }
 

--- a/llvm/test/CodeGen/AArch64/bf16-v8-instructions.ll
+++ b/llvm/test/CodeGen/AArch64/bf16-v8-instructions.ll
@@ -5264,7 +5264,7 @@ define <8 x bfloat> @test_powi(<8 x bfloat> %a, i32 %b) #0 {
 ; CHECK-BF16-GI-NEXT:    mov v0.16b, v1.16b
 ; CHECK-BF16-GI-NEXT:    add sp, sp, #192
 ; CHECK-BF16-GI-NEXT:    ret
-  %r = call <8 x bfloat> @llvm.powi.v8bf16.v8i32(<8 x bfloat> %a, i32 %b)
+  %r = call <8 x bfloat> @llvm.powi.v8bf16.i32(<8 x bfloat> %a, i32 %b)
   ret <8 x bfloat> %r
 }
 

--- a/llvm/test/CodeGen/NVPTX/bf16x2-instructions.ll
+++ b/llvm/test/CodeGen/NVPTX/bf16x2-instructions.ll
@@ -414,7 +414,7 @@ define <2 x bfloat> @test_bitcast_2xi16_to_2xbf16(<2 x i16> %a) #0 {
 }
 
 declare <2 x bfloat> @llvm.sqrt.f16(<2 x bfloat> %a) #0
-declare <2 x bfloat> @llvm.powi.f16(<2 x bfloat> %a, <2 x i32> %b) #0
+declare <2 x bfloat> @llvm.powi.f16(<2 x bfloat> %a, i32 %b) #0
 declare <2 x bfloat> @llvm.sin.f16(<2 x bfloat> %a) #0
 declare <2 x bfloat> @llvm.cos.f16(<2 x bfloat> %a) #0
 declare <2 x bfloat> @llvm.pow.f16(<2 x bfloat> %a, <2 x bfloat> %b) #0

--- a/llvm/test/CodeGen/NVPTX/f16x2-instructions.ll
+++ b/llvm/test/CodeGen/NVPTX/f16x2-instructions.ll
@@ -1610,7 +1610,7 @@ define float @test_bitcast_2xhalf_to_float(<2 x half> %a) #0 {
 }
 
 declare <2 x half> @llvm.sqrt.f16(<2 x half> %a) #0
-declare <2 x half> @llvm.powi.f16.i32(<2 x half> %a, <2 x i32> %b) #0
+declare <2 x half> @llvm.powi.f16.i32(<2 x half> %a, i32 %b) #0
 declare <2 x half> @llvm.sin.f16(<2 x half> %a) #0
 declare <2 x half> @llvm.cos.f16(<2 x half> %a) #0
 declare <2 x half> @llvm.pow.f16(<2 x half> %a, <2 x half> %b) #0
@@ -1657,8 +1657,8 @@ define <2 x half> @test_sqrt(<2 x half> %a) #0 {
 
 ;;; Can't do this yet: requires libcall.
 ; XCHECK-LABEL: test_powi(
-;define <2 x half> @test_powi(<2 x half> %a, <2 x i32> %b) #0 {
-;  %r = call <2 x half> @llvm.powi.f16.i32(<2 x half> %a, <2 x i32> %b)
+;define <2 x half> @test_powi(<2 x half> %a, i32 %b) #0 {
+;  %r = call <2 x half> @llvm.powi.f16.i32(<2 x half> %a, i32 %b)
 ;  ret <2 x half> %r
 ;}
 

--- a/llvm/test/Transforms/Attributor/nofpclass-powi.ll
+++ b/llvm/test/Transforms/Attributor/nofpclass-powi.ll
@@ -4,7 +4,7 @@
 declare float @llvm.powi.f32.i32(float, i32)
 declare float @llvm.powi.f32.i64(float, i64)
 
-declare <2 x float> @llvm.powi.v2f32.v2i32(<2 x float>, <2 x i32>)
+declare <2 x float> @llvm.powi.v2f32.i32(<2 x float>, i32)
 declare <4 x float> @llvm.powi.v4f32.i32(<4 x float>, i32)
 
 define float @ret_powi_f32(float %arg0, i32 %arg1) #0 {
@@ -27,13 +27,13 @@ define float @ret_powi_f32_i64(float %arg0, i64 %arg1) #0 {
   ret float %call
 }
 
-define <2 x float> @ret_powi_v2f32(<2 x float> %arg0, <2 x i32> %arg1) #0 {
+define <2 x float> @ret_powi_v2f32(<2 x float> %arg0, i32 %arg1) #0 {
 ; CHECK-LABEL: define <2 x float> @ret_powi_v2f32
-; CHECK-SAME: (<2 x float> [[ARG0:%.*]], <2 x i32> [[ARG1:%.*]]) #[[ATTR1]] {
-; CHECK-NEXT:    [[CALL:%.*]] = call <2 x float> @llvm.powi.v2f32.v2i32(<2 x float> [[ARG0]], <2 x i32> [[ARG1]]) #[[ATTR6]]
+; CHECK-SAME: (<2 x float> [[ARG0:%.*]], i32 [[ARG1:%.*]]) #[[ATTR1]] {
+; CHECK-NEXT:    [[CALL:%.*]] = call <2 x float> @llvm.powi.v2f32.i32(<2 x float> [[ARG0]], i32 [[ARG1]]) #[[ATTR6]]
 ; CHECK-NEXT:    ret <2 x float> [[CALL]]
 ;
-  %call = call <2 x float> @llvm.powi.v2f32.v2i32(<2 x float> %arg0, <2 x i32> %arg1)
+  %call = call <2 x float> @llvm.powi.v2f32.i32(<2 x float> %arg0, i32 %arg1)
   ret <2 x float> %call
 }
 
@@ -269,23 +269,23 @@ define float @ret_powi_f32_no_nan_no_zero_nosub__arg1__daz(float nofpclass(nan z
   ret float %call
 }
 
-define <2 x float> @ret_powi_v2f32_even_nonsplat(<2 x float> %arg0) #0 {
-; CHECK-LABEL: define nofpclass(ninf nzero nsub nnorm) <2 x float> @ret_powi_v2f32_even_nonsplat
+define <2 x float> @ret_powi_v2f32_even_constant(<2 x float> %arg0) #0 {
+; CHECK-LABEL: define nofpclass(ninf nzero nsub nnorm) <2 x float> @ret_powi_v2f32_even_constant
 ; CHECK-SAME: (<2 x float> [[ARG0:%.*]]) #[[ATTR1]] {
-; CHECK-NEXT:    [[CALL:%.*]] = call nofpclass(ninf nzero nsub nnorm) <2 x float> @llvm.powi.v2f32.v2i32(<2 x float> [[ARG0]], <2 x i32> noundef <i32 2, i32 4>) #[[ATTR6]]
+; CHECK-NEXT:    [[CALL:%.*]] = call nofpclass(ninf nzero nsub nnorm) <2 x float> @llvm.powi.v2f32.i32(<2 x float> [[ARG0]], i32 noundef 4) #[[ATTR6]]
 ; CHECK-NEXT:    ret <2 x float> [[CALL]]
 ;
-  %call = call <2 x float> @llvm.powi.v2f32.v2i32(<2 x float> %arg0, <2 x i32> <i32 2, i32 4>)
+  %call = call <2 x float> @llvm.powi.v2f32.i32(<2 x float> %arg0, i32 4)
   ret <2 x float> %call
 }
 
-define <2 x float> @ret_powi_v2f32_odd_nonsplat(<2 x float> %arg0) #0 {
-; CHECK-LABEL: define <2 x float> @ret_powi_v2f32_odd_nonsplat
+define <2 x float> @ret_powi_v2f32_odd_constant(<2 x float> %arg0) #0 {
+; CHECK-LABEL: define <2 x float> @ret_powi_v2f32_odd_constant
 ; CHECK-SAME: (<2 x float> [[ARG0:%.*]]) #[[ATTR1]] {
-; CHECK-NEXT:    [[CALL:%.*]] = call <2 x float> @llvm.powi.v2f32.v2i32(<2 x float> [[ARG0]], <2 x i32> noundef <i32 3, i32 4>) #[[ATTR6]]
+; CHECK-NEXT:    [[CALL:%.*]] = call <2 x float> @llvm.powi.v2f32.i32(<2 x float> [[ARG0]], i32 noundef 3) #[[ATTR6]]
 ; CHECK-NEXT:    ret <2 x float> [[CALL]]
 ;
-  %call = call <2 x float> @llvm.powi.v2f32.v2i32(<2 x float> %arg0, <2 x i32> <i32 3, i32 4>)
+  %call = call <2 x float> @llvm.powi.v2f32.i32(<2 x float> %arg0, i32 3)
   ret <2 x float> %call
 }
 
@@ -313,15 +313,15 @@ define float @ret_powi_f32_masked_to_even_extrabits(float %arg0, i32 %arg1) #0 {
   ret float %call
 }
 
-define <2 x float> @ret_powi_v2f32_masked_to_even(<2 x float> %arg0, <2 x i32> %arg1) #0 {
+define <2 x float> @ret_powi_v2f32_masked_to_even(<2 x float> %arg0, i32 %arg1) #0 {
 ; CHECK-LABEL: define nofpclass(ninf nzero nsub nnorm) <2 x float> @ret_powi_v2f32_masked_to_even
-; CHECK-SAME: (<2 x float> [[ARG0:%.*]], <2 x i32> [[ARG1:%.*]]) #[[ATTR1]] {
-; CHECK-NEXT:    [[KNOWN_EVEN:%.*]] = and <2 x i32> [[ARG1]], splat (i32 -2)
-; CHECK-NEXT:    [[CALL:%.*]] = call nofpclass(ninf nzero nsub nnorm) <2 x float> @llvm.powi.v2f32.v2i32(<2 x float> [[ARG0]], <2 x i32> [[KNOWN_EVEN]]) #[[ATTR6]]
+; CHECK-SAME: (<2 x float> [[ARG0:%.*]], i32 [[ARG1:%.*]]) #[[ATTR1]] {
+; CHECK-NEXT:    [[KNOWN_EVEN:%.*]] = and i32 [[ARG1]], -2
+; CHECK-NEXT:    [[CALL:%.*]] = call nofpclass(ninf nzero nsub nnorm) <2 x float> @llvm.powi.v2f32.i32(<2 x float> [[ARG0]], i32 [[KNOWN_EVEN]]) #[[ATTR6]]
 ; CHECK-NEXT:    ret <2 x float> [[CALL]]
 ;
-  %known.even = and <2 x i32> %arg1, <i32 -2, i32 -2>
-  %call = call <2 x float> @llvm.powi.v2f32.v2i32(<2 x float> %arg0, <2 x i32> %known.even)
+  %known.even = and i32 %arg1, -2
+  %call = call <2 x float> @llvm.powi.v2f32.i32(<2 x float> %arg0, i32 %known.even)
   ret <2 x float> %call
 }
 

--- a/llvm/test/Transforms/InstCombine/pow_fp_int.ll
+++ b/llvm/test/Transforms/InstCombine/pow_fp_int.ll
@@ -539,6 +539,30 @@ define <2 x float> @pow_sitofp_const_base_2_no_fast_vector(<2 x i8> %x) {
   ret <2 x float> %r
 }
 
+define <2 x float> @pow_sitofp_vector_exp(<2 x float> %base, <2 x i16> %x) {
+; CHECK-LABEL: define <2 x float> @pow_sitofp_vector_exp(
+; CHECK-SAME: <2 x float> [[BASE:%.*]], <2 x i16> [[X:%.*]]) {
+; CHECK-NEXT:    [[S:%.*]] = sitofp <2 x i16> [[X]] to <2 x float>
+; CHECK-NEXT:    [[R:%.*]] = tail call afn <2 x float> @llvm.pow.v2f32(<2 x float> [[BASE]], <2 x float> [[S]])
+; CHECK-NEXT:    ret <2 x float> [[R]]
+;
+  %s = sitofp <2 x i16> %x to <2 x float>
+  %r = tail call afn <2 x float> @llvm.pow.v2f32(<2 x float> %base, <2 x float> %s)
+  ret <2 x float> %r
+}
+
+define <2 x float> @pow_uitofp_vector_exp(<2 x float> %base, <2 x i16> %x) {
+; CHECK-LABEL: define <2 x float> @pow_uitofp_vector_exp(
+; CHECK-SAME: <2 x float> [[BASE:%.*]], <2 x i16> [[X:%.*]]) {
+; CHECK-NEXT:    [[S:%.*]] = uitofp <2 x i16> [[X]] to <2 x float>
+; CHECK-NEXT:    [[R:%.*]] = tail call afn <2 x float> @llvm.pow.v2f32(<2 x float> [[BASE]], <2 x float> [[S]])
+; CHECK-NEXT:    ret <2 x float> [[R]]
+;
+  %s = uitofp <2 x i16> %x to <2 x float>
+  %r = tail call afn <2 x float> @llvm.pow.v2f32(<2 x float> %base, <2 x float> %s)
+  ret <2 x float> %r
+}
+
 declare float @llvm.pow.f32(float, float)
 declare double @llvm.pow.f64(double, double)
 declare <2 x float> @llvm.pow.v2f32(<2 x float>, <2 x float>)

--- a/llvm/test/Transforms/VectorCombine/AArch64/shuffle-of-intrinsics.ll
+++ b/llvm/test/Transforms/VectorCombine/AArch64/shuffle-of-intrinsics.ll
@@ -73,17 +73,17 @@ entry:
   ret <2 x i1> %4
 }
 
-define <8 x float> @test5(<4 x float> %0, i32 %1, <4 x float> %2, <4 x i32> %3) {
+define <8 x float> @test5(<4 x float> %0, i32 %1, <4 x float> %2, i32 %3) {
 ; CHECK-LABEL: @test5(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[TMP4:%.*]] = call <4 x float> @llvm.powi.v4f32.i32(<4 x float> [[TMP0:%.*]], i32 [[TMP1:%.*]])
-; CHECK-NEXT:    [[TMP5:%.*]] = call <4 x float> @llvm.powi.v4f32.v4i32(<4 x float> [[TMP2:%.*]], <4 x i32> [[TMP3:%.*]])
+; CHECK-NEXT:    [[TMP5:%.*]] = call <4 x float> @llvm.powi.v4f32.i32(<4 x float> [[TMP2:%.*]], i32 [[TMP3:%.*]])
 ; CHECK-NEXT:    [[TMP6:%.*]] = shufflevector <4 x float> [[TMP4]], <4 x float> [[TMP5]], <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
 ; CHECK-NEXT:    ret <8 x float> [[TMP6]]
 ;
 entry:
   %4 = call <4 x float> @llvm.powi.v4f32.i32(<4 x float> %0, i32 %1)
-  %5 = call <4 x float> @llvm.powi.v4f32.v4i32(<4 x float> %2, <4 x i32> %3)
+  %5 = call <4 x float> @llvm.powi.v4f32.i32(<4 x float> %2, i32 %3)
   %6 = shufflevector <4 x float> %4, <4 x float> %5, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   ret <8 x float> %6
 }
@@ -106,4 +106,3 @@ declare <4 x i32> @llvm.abs.v4i32(<4 x i32>, i1)
 declare <4 x i32> @llvm.smax.v4i32(<4 x i32>, <4 x i32>)
 declare <4 x i1> @llvm.is.fpclass.v4f32(<4 x float>, i32)
 declare <4 x float> @llvm.powi.v4f32.i32(<4 x float>, i32)
-declare <4 x float> @llvm.powi.v4f32.v4i32(<4 x float>, <4 x i32>)

--- a/llvm/test/Transforms/VectorCombine/RISCV/shuffle-of-intrinsics.ll
+++ b/llvm/test/Transforms/VectorCombine/RISCV/shuffle-of-intrinsics.ll
@@ -59,17 +59,17 @@ entry:
   ret <8 x i1> %4
 }
 
-define <8 x float> @test5(<4 x float> %0, i32 %1, <4 x float> %2, <4 x i32> %3) {
+define <8 x float> @test5(<4 x float> %0, i32 %1, <4 x float> %2, i32 %3) {
 ; CHECK-LABEL: @test5(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[TMP4:%.*]] = call <4 x float> @llvm.powi.v4f32.i32(<4 x float> [[TMP0:%.*]], i32 [[TMP1:%.*]])
-; CHECK-NEXT:    [[TMP5:%.*]] = call <4 x float> @llvm.powi.v4f32.v4i32(<4 x float> [[TMP2:%.*]], <4 x i32> [[TMP3:%.*]])
+; CHECK-NEXT:    [[TMP5:%.*]] = call <4 x float> @llvm.powi.v4f32.i32(<4 x float> [[TMP2:%.*]], i32 [[TMP3:%.*]])
 ; CHECK-NEXT:    [[TMP6:%.*]] = shufflevector <4 x float> [[TMP4]], <4 x float> [[TMP5]], <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
 ; CHECK-NEXT:    ret <8 x float> [[TMP6]]
 ;
 entry:
   %4 = call <4 x float> @llvm.powi.v4f32.i32(<4 x float> %0, i32 %1)
-  %5 = call <4 x float> @llvm.powi.v4f32.v4i32(<4 x float> %2, <4 x i32> %3)
+  %5 = call <4 x float> @llvm.powi.v4f32.i32(<4 x float> %2, i32 %3)
   %6 = shufflevector <4 x float> %4, <4 x float> %5, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   ret <8 x float> %6
 }
@@ -78,4 +78,3 @@ declare <4 x i32> @llvm.abs.v4i32(<4 x i32>, i1)
 declare <4 x i32> @llvm.smax.v4i32(<4 x i32>, <4 x i32>)
 declare <4 x i1> @llvm.is.fpclass.v4f32(<4 x float>, i32)
 declare <4 x float> @llvm.powi.v4f32.i32(<4 x float>, i32)
-declare <4 x float> @llvm.powi.v4f32.v4i32(<4 x float>, <4 x i32>)

--- a/llvm/test/Transforms/VectorCombine/X86/shuffle-of-intrinsics.ll
+++ b/llvm/test/Transforms/VectorCombine/X86/shuffle-of-intrinsics.ll
@@ -83,17 +83,17 @@ entry:
   ret <2 x i1> %4
 }
 
-define <8 x float> @test5(<4 x float> %0, i32 %1, <4 x float> %2, <4 x i32> %3) {
+define <8 x float> @test5(<4 x float> %0, i32 %1, <4 x float> %2, i32 %3) {
 ; CHECK-LABEL: @test5(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[TMP4:%.*]] = call <4 x float> @llvm.powi.v4f32.i32(<4 x float> [[TMP0:%.*]], i32 [[TMP1:%.*]])
-; CHECK-NEXT:    [[TMP5:%.*]] = call <4 x float> @llvm.powi.v4f32.v4i32(<4 x float> [[TMP2:%.*]], <4 x i32> [[TMP3:%.*]])
+; CHECK-NEXT:    [[TMP5:%.*]] = call <4 x float> @llvm.powi.v4f32.i32(<4 x float> [[TMP2:%.*]], i32 [[TMP3:%.*]])
 ; CHECK-NEXT:    [[TMP6:%.*]] = shufflevector <4 x float> [[TMP4]], <4 x float> [[TMP5]], <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
 ; CHECK-NEXT:    ret <8 x float> [[TMP6]]
 ;
 entry:
   %4 = call <4 x float> @llvm.powi.v4f32.i32(<4 x float> %0, i32 %1)
-  %5 = call <4 x float> @llvm.powi.v4f32.v4i32(<4 x float> %2, <4 x i32> %3)
+  %5 = call <4 x float> @llvm.powi.v4f32.i32(<4 x float> %2, i32 %3)
   %6 = shufflevector <4 x float> %4, <4 x float> %5, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   ret <8 x float> %6
 }
@@ -148,7 +148,6 @@ declare <4 x i32> @llvm.abs.v4i32(<4 x i32>, i1)
 declare <4 x i32> @llvm.smax.v4i32(<4 x i32>, <4 x i32>)
 declare <4 x i1> @llvm.is.fpclass.v4f32(<4 x float>, i32)
 declare <4 x float> @llvm.powi.v4f32.i32(<4 x float>, i32)
-declare <4 x float> @llvm.powi.v4f32.v4i32(<4 x float>, <4 x i32>)
 declare <4 x float> @llvm.fma.v4f32(<4 x float>, <4 x float>, <4 x float>)
 declare <8 x float> @llvm.fma.v8f32(<8 x float>, <8 x float>, <8 x float>)
 

--- a/llvm/test/Verifier/powi.ll
+++ b/llvm/test/Verifier/powi.ll
@@ -1,0 +1,6 @@
+; RUN: not llvm-as -disable-output < %s 2>&1 | FileCheck %s
+
+; The exponent of llvm.powi is scalar even when the base is a vector.
+; CHECK: intrinsic argument 1 type (overload type 1) expected any integer type, but got <4 x i32>
+; CHECK-NEXT: declare <4 x float> @llvm.powi.v4f32.v4i32(<4 x float>, <4 x i32>)
+declare <4 x float> @llvm.powi.v4f32.v4i32(<4 x float>, <4 x i32>)

--- a/llvm/test/Verifier/powi.ll
+++ b/llvm/test/Verifier/powi.ll
@@ -1,6 +1,6 @@
 ; RUN: not llvm-as -disable-output < %s 2>&1 | FileCheck %s
 
 ; The exponent of llvm.powi is scalar even when the base is a vector.
-; CHECK: intrinsic argument 1 type (overload type 1) expected any integer type, but got <4 x i32>
+; CHECK: intrinsic argument 1 type (overload type 1) expected any scalar integer type, but got <4 x i32>
 ; CHECK-NEXT: declare <4 x float> @llvm.powi.v4f32.v4i32(<4 x float>, <4 x i32>)
 declare <4 x float> @llvm.powi.v4f32.v4i32(<4 x float>, <4 x i32>)

--- a/llvm/test/Verifier/powi.ll
+++ b/llvm/test/Verifier/powi.ll
@@ -1,6 +1,6 @@
 ; RUN: not llvm-as -disable-output < %s 2>&1 | FileCheck %s
 
 ; The exponent of llvm.powi is scalar even when the base is a vector.
-; CHECK: intrinsic argument 1 type (overload type 1) expected any scalar integer type, but got <4 x i32>
+; CHECK: intrinsic argument 1 type (overload type 1) expected any integer type, but got <4 x i32>
 ; CHECK-NEXT: declare <4 x float> @llvm.powi.v4f32.v4i32(<4 x float>, <4 x i32>)
 declare <4 x float> @llvm.powi.v4f32.v4i32(<4 x float>, <4 x i32>)


### PR DESCRIPTION
As per the https://llvm.org/docs/LangRef.html#llvm-powi-intrinsic , operand 1 always should be integer scalar.
but llvm.powi accepts vector for exponent(operand 1) this PR fixes it to follow the standard by correcting type for second operand in intrinsic declaration.
