### PR TITLE
[libsycl][unit] Mock 3 missing liboffload functions for unit tests

### DIFF
--- a/libsycl/unittests/mock/helpers.cpp
+++ b/libsycl/unittests/mock/helpers.cpp
@@ -327,4 +327,31 @@ void mock::MockLiboffload::initDefault() {
         mock::releaseDummyHandle(Event);
         return OL_SUCCESS;
       });
+
+  ON_CALL(*this, olMemAlloc)
+      .WillByDefault([this](ol_device_handle_t Device, ol_alloc_type_t Type,
+                            size_t Size, void **AllocationOut) -> ol_result_t {
+        EXPECT_NE(Device, nullptr);
+        EXPECT_NE(Type, OL_ALLOC_TYPE_HOST);
+        EXPECT_GT(Size, 0);
+        EXPECT_NE(AllocationOut, nullptr);
+        *AllocationOut = std::malloc(Size);
+        return OL_SUCCESS;
+      });
+
+  ON_CALL(*this, olMemAllocHost)
+      .WillByDefault([this](ol_device_handle_t Device, size_t Size,
+                            void **AllocationOut) -> ol_result_t {
+        EXPECT_NE(Device, nullptr);
+        EXPECT_GT(Size, 0);
+        EXPECT_NE(AllocationOut, nullptr);
+        *AllocationOut = std::malloc(Size);
+        return OL_SUCCESS;
+      });
+
+  ON_CALL(*this, olMemFree).WillByDefault([this](void *Address) -> ol_result_t {
+    EXPECT_NE(Address, nullptr);
+    std::free(Address);
+    return OL_SUCCESS;
+  });
 }

--- a/libsycl/unittests/mock/helpers.hpp
+++ b/libsycl/unittests/mock/helpers.hpp
@@ -22,6 +22,7 @@
 #include <atomic>
 #include <cassert>
 #include <cstddef>
+#include <cstdlib>
 #include <cstring>
 #include <unordered_map>
 #include <vector>
@@ -129,6 +130,12 @@ public:
   MOCK_METHOD(ol_result_t, olGetMemInfo,
               (const void *Ptr, ol_mem_info_t PropName, size_t PropSize,
                void *PropValue));
+  MOCK_METHOD(ol_result_t, olMemAlloc,
+              (ol_device_handle_t Device, ol_alloc_type_t Type, size_t Size,
+               void **AllocationOut));
+  MOCK_METHOD(ol_result_t, olMemAllocHost,
+              (ol_device_handle_t Device, size_t Size, void **AllocationOut));
+  MOCK_METHOD(ol_result_t, olMemFree, (void *Address));
 
   ol_result_t makeEmptyStrError(ol_errc_t Code) {
     auto [Iterator, Flag] =

--- a/libsycl/unittests/mock/mock.cpp
+++ b/libsycl/unittests/mock/mock.cpp
@@ -123,6 +123,21 @@ ol_result_t olGetMemInfo(const void *Ptr, ol_mem_info_t PropName,
                                                 PropValue);
 }
 
+ol_result_t olMemAlloc(ol_device_handle_t Device, ol_alloc_type_t Type,
+                       size_t Size, void **AllocationOut) {
+  return mock::getMockLiboffload().olMemAlloc(Device, Type, Size,
+                                              AllocationOut);
+}
+
+ol_result_t olMemAllocHost(ol_device_handle_t Device, size_t Size,
+                           void **AllocationOut) {
+  return mock::getMockLiboffload().olMemAllocHost(Device, Size, AllocationOut);
+}
+
+ol_result_t olMemFree(void *Address) {
+  return mock::getMockLiboffload().olMemFree(Address);
+}
+
 ol_result_t olCreateEvent(ol_queue_handle_t Queue, ol_event_flags_t Flags,
                           ol_event_handle_t *Event) {
   return mock::getMockLiboffload().olCreateEvent(Queue, Flags, Event);


### PR DESCRIPTION
We missed mocking these three functions that are never called in our current tests but are used in `libsycl`, it happens to not fail on Linux due to a linker optimization (`-ffunction-sections` and `--gc-sections`) that happens to kick in so we never actually try to resolve these symbols on Linux.

Windows does't have the same optimization (or at least, it's not enabled), so compiling the unit tests throws a linker error.

Mock the functions so we can compile/link `check-sycl` on Windows.

With this PR and my previous one moving the tests to `lit`, `check-sycl` passes on Windows!