### PR TITLE
CodeGen: Add getDefBlock helper

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineRegisterInfo.h
+++ b/llvm/include/llvm/CodeGen/MachineRegisterInfo.h
@@ -643,6 +643,13 @@ public:
   /// multiple definitions or no definition, return null.
   LLVM_ABI MachineInstr *getUniqueVRegDef(Register Reg) const;
 
+  /// Return the machine basic block in which the specified virtual register is
+  /// defined, or null if it has no definition. This assumes SSA form.
+  MachineBasicBlock *getDefBlock(Register Reg) const {
+    MachineInstr *DefMI = getVRegDef(Reg);
+    return DefMI ? DefMI->getParent() : nullptr;
+  }
+
   /// clearKillFlags - Iterate over all the uses of the given register and
   /// clear the kill flag from the MachineOperand. This function is used by
   /// optimization passes which extend register lifetimes and need only

--- a/llvm/lib/CodeGen/LiveVariables.cpp
+++ b/llvm/lib/CodeGen/LiveVariables.cpp
@@ -191,7 +191,7 @@ void LiveVariables::HandleVirtRegUse(Register Reg, MachineBasicBlock *MBB,
   // where there is a use in a PHI node that's a predecessor to the defining
   // block. We don't want to mark all predecessors as having the value "alive"
   // in this case.
-  if (MBB == MRI->getVRegDef(Reg)->getParent())
+  if (MBB == MRI->getDefBlock(Reg))
     return;
 
   // Add a new kill entry for this basic block. If this virtual register is
@@ -202,7 +202,7 @@ void LiveVariables::HandleVirtRegUse(Register Reg, MachineBasicBlock *MBB,
 
   // Update all dominating blocks to mark them as "known live".
   for (MachineBasicBlock *Pred : MBB->predecessors())
-    MarkVirtRegAliveInBlock(VRInfo, MRI->getVRegDef(Reg)->getParent(), Pred);
+    MarkVirtRegAliveInBlock(VRInfo, MRI->getDefBlock(Reg), Pred);
 }
 
 void LiveVariables::HandleVirtRegDef(Register Reg, MachineInstr &MI) {
@@ -566,8 +566,7 @@ void LiveVariables::runOnBlock(MachineBasicBlock *MBB, unsigned NumRegs) {
 
     for (Register I : VarInfoVec)
       // Mark it alive only in the block we are representing.
-      MarkVirtRegAliveInBlock(getVarInfo(I), MRI->getVRegDef(I)->getParent(),
-                              MBB);
+      MarkVirtRegAliveInBlock(getVarInfo(I), MRI->getDefBlock(I), MBB);
   }
 
   // MachineCSE may CSE instructions which write to non-allocatable physical

--- a/llvm/lib/CodeGen/MachineCycleAnalysis.cpp
+++ b/llvm/lib/CodeGen/MachineCycleAnalysis.cpp
@@ -167,7 +167,7 @@ bool llvm::isCycleInvariant(const MachineCycleInfo &CI, CycleRef Cycle,
 
     // If the cycle contains the definition of an operand, then the instruction
     // isn't cycle invariant.
-    if (CI.contains(Cycle, MRI->getVRegDef(Reg)->getParent()))
+    if (CI.contains(Cycle, MRI->getDefBlock(Reg)))
       return false;
   }
 

--- a/llvm/lib/CodeGen/MachinePipeliner.cpp
+++ b/llvm/lib/CodeGen/MachinePipeliner.cpp
@@ -1652,7 +1652,7 @@ private:
   }
 
   bool isDefinedInThisLoop(Register Reg) const {
-    return Reg.isVirtual() && MRI.getVRegDef(Reg)->getParent() == OrigMBB;
+    return Reg.isVirtual() && MRI.getDefBlock(Reg) == OrigMBB;
   }
 
   // Search for live-in variables. They are factored into the register pressure
@@ -2912,7 +2912,7 @@ static Register findUniqueOperandDefinedInLoop(const MachineInstr &MI) {
     Register Reg = Use.getReg();
     if (!Reg.isVirtual())
       return Register();
-    if (MRI.getVRegDef(Reg)->getParent() != MI.getParent())
+    if (MRI.getDefBlock(Reg) != MI.getParent())
       continue;
     if (Result)
       return Register();

--- a/llvm/lib/CodeGen/MachineSSAContext.cpp
+++ b/llvm/lib/CodeGen/MachineSSAContext.cpp
@@ -51,7 +51,7 @@ template <>
 const MachineBasicBlock *MachineSSAContext::getDefBlock(Register value) const {
   if (!value)
     return nullptr;
-  return F->getRegInfo().getVRegDef(value)->getParent();
+  return F->getRegInfo().getDefBlock(value);
 }
 
 static bool isUndef(const MachineInstr &MI) {

--- a/llvm/lib/CodeGen/ModuloSchedule.cpp
+++ b/llvm/lib/CodeGen/ModuloSchedule.cpp
@@ -2747,8 +2747,7 @@ bool ModuloScheduleExpanderMVE::canApply(MachineLoop &L) {
     // most.
     Register InitVal, LoopVal;
     getPhiRegs(MI, MI.getParent(), InitVal, LoopVal);
-    if (!Register(LoopVal).isVirtual() ||
-        MRI.getVRegDef(LoopVal)->getParent() != BB) {
+    if (!Register(LoopVal).isVirtual() || MRI.getDefBlock(LoopVal) != BB) {
       LLVM_DEBUG(
           dbgs() << "Can not apply MVE expander: A phi source value coming "
                     "from the loop is not defined in the loop.\n");

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -12075,7 +12075,7 @@ static bool isDefinedOutside(Register Reg, const MachineBasicBlock *BB) {
   if (!Reg.isVirtual())
     return false;
   const MachineRegisterInfo &MRI = BB->getParent()->getRegInfo();
-  return MRI.getVRegDef(Reg)->getParent() != BB;
+  return MRI.getDefBlock(Reg) != BB;
 }
 
 /// If Reg is an induction variable, return true and set some parameters

--- a/llvm/lib/Target/AMDGPU/AMDGPUGlobalISelDivergenceLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUGlobalISelDivergenceLowering.cpp
@@ -261,7 +261,7 @@ bool DivergenceLoweringHelper::lowerTemporalDivergenceI1() {
     Register MergedMask = MRI->createVirtualRegister(BoolS1);
     SSAUpdater.Initialize(MergedMask);
 
-    MachineBasicBlock *MBB = MRI->getVRegDef(Reg)->getParent();
+    MachineBasicBlock *MBB = MRI->getDefBlock(Reg);
     SSAUpdater.AddAvailableValue(MBB, MergedMask);
 
     for (auto Entry : CInfo.getEntries(Cycle)) {

--- a/llvm/lib/Target/AMDGPU/SIOptimizeVGPRLiveRange.cpp
+++ b/llvm/lib/Target/AMDGPU/SIOptimizeVGPRLiveRange.cpp
@@ -250,7 +250,7 @@ void SIOptimizeVGPRLiveRange::collectCandidateRegisters(
 
         if (MO.readsReg()) {
           LiveVariables::VarInfo &VI = LV->getVarInfo(MOReg);
-          const MachineBasicBlock *DefMBB = MRI->getVRegDef(MOReg)->getParent();
+          const MachineBasicBlock *DefMBB = MRI->getDefBlock(MOReg);
           // Make sure two conditions are met:
           // a.) the value is defined before/in the IF block
           // b.) should be defined in the same loop-level.
@@ -298,7 +298,7 @@ void SIOptimizeVGPRLiveRange::collectCandidateRegisters(
       // Make sure two conditions are met:
       // a.) the value is defined before/in the IF block
       // b.) should be defined in the same loop-level.
-      const MachineBasicBlock *DefMBB = MRI->getVRegDef(Reg)->getParent();
+      const MachineBasicBlock *DefMBB = MRI->getDefBlock(Reg);
       if ((VI.AliveBlocks.test(If->getNumber()) || DefMBB == If) &&
           Loops->getLoopFor(DefMBB) == Loops->getLoopFor(If))
         KillsInElse.insert(Reg);
@@ -375,7 +375,7 @@ void SIOptimizeVGPRLiveRange::collectWaterfallCandidateRegisters(
         continue;
 
       if (MO.readsReg()) {
-        MachineBasicBlock *DefMBB = MRI->getVRegDef(MOReg)->getParent();
+        MachineBasicBlock *DefMBB = MRI->getDefBlock(MOReg);
         // Make sure the value is defined before the LOOP block
         if (!Blocks.contains(DefMBB) && !CandidateRegs.contains(MOReg)) {
           // If the variable is used after the loop, the register coalescer will
@@ -461,8 +461,7 @@ void SIOptimizeVGPRLiveRange::updateLiveRangeInThenRegion(
 
     // Mark Reg alive through the block if this is a PHI incoming block
     if (PHIIncoming.contains(MBB))
-      LV->MarkVirtRegAliveInBlock(OldVarInfo, MRI->getVRegDef(Reg)->getParent(),
-                                  MBB);
+      LV->MarkVirtRegAliveInBlock(OldVarInfo, MRI->getDefBlock(Reg), MBB);
   }
 
   // Set the isKilled flag if we get new Kills in the THEN region.

--- a/llvm/lib/Target/Hexagon/HexagonHardwareLoops.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonHardwareLoops.cpp
@@ -700,7 +700,7 @@ CountValue *HexagonHardwareLoops::getLoopTripCount(MachineLoop *L,
 
   if (InitialValue->isReg()) {
     Register R = InitialValue->getReg();
-    MachineBasicBlock *DefBB = MRI->getVRegDef(R)->getParent();
+    MachineBasicBlock *DefBB = MRI->getDefBlock(R);
     if (!MDT->properlyDominates(DefBB, Header)) {
       int64_t V;
       if (!checkForImmediate(*InitialValue, V))
@@ -710,7 +710,7 @@ CountValue *HexagonHardwareLoops::getLoopTripCount(MachineLoop *L,
   }
   if (EndValue->isReg()) {
     Register R = EndValue->getReg();
-    MachineBasicBlock *DefBB = MRI->getVRegDef(R)->getParent();
+    MachineBasicBlock *DefBB = MRI->getDefBlock(R);
     if (!MDT->properlyDominates(DefBB, Header)) {
       int64_t V;
       if (!checkForImmediate(*EndValue, V))


### PR DESCRIPTION
A reasonable number of places check getVRegDef just to
return the parent block, so introduce a helper for it.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>