### PR TITLE
[LLVMOffload] Fix LLVMOffload tests from running on Intel in #212373

### DIFF
--- a/offload/test/offloading/CUDA/thread_and_block_id.cu
+++ b/offload/test/offloading/CUDA/thread_and_block_id.cu
@@ -12,6 +12,7 @@
 // UNSUPPORTED: nvptx64-nvidia-cuda-LTO
 // UNSUPPORTED: amdgcn-amd-amdhsa-LTO
 // UNSUPPORTED: amdgpu-amd-amdhsa-LTO
+// UNSUPPORTED: intelgpu
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/offload/test/offloading/HIP/thread_and_block_id.hip
+++ b/offload/test/offloading/HIP/thread_and_block_id.hip
@@ -12,6 +12,7 @@
 // UNSUPPORTED: nvptx64-nvidia-cuda-LTO
 // UNSUPPORTED: amdgcn-amd-amdhsa-LTO
 // UNSUPPORTED: amdgpu-amd-amdhsa-LTO
+// UNSUPPORTED: intelgpu
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Offloading via LLVM currently does not support Intel GPUs, this disables running the tests for them. 

Fixes the buildbot error from #212373 