### PR TITLE
workflows/release-binaries: Disable LTO and PGO for PR testing on Windows ARM

### DIFF
--- a/.github/workflows/release-binaries-all.yml
+++ b/.github/workflows/release-binaries-all.yml
@@ -108,10 +108,6 @@ jobs:
         # We use ubuntu-22.04 rather than the latest version to make the built
         # binaries more portable (eg functional aginast older glibc).
         runs-on:
-          - ubuntu-22.04
-          - ubuntu-22.04-arm
-          - macos-14
-          - windows-2022
           - windows-11-arm
 
     uses: ./.github/workflows/release-binaries.yml

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -293,7 +293,7 @@ jobs:
       run: |
         subst S: ${{ github.workspace }}
         cd S:\llvm\utils\release\
-      .\build_llvm_release.bat "--$($env:RUNNER_ARCH.ToLower())" --version $env:LLVM_VERSION --local-python --skip-checkout $env:EXTRA_ARGS
+        .\build_llvm_release.bat "--$($env:RUNNER_ARCH.ToLower())" --version $env:LLVM_VERSION --local-python --skip-checkout $env:EXTRA_ARGS
         if ($env:INPUTS_RUNS_ON -eq "windows-11-arm") {
           $zstd = (Get-ChildItem -Recurse -Filter "zstd.exe" | Select-Object -First 1).fullName
           mv $zstd $env:GITHUB_WORKSPACE

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -289,10 +289,11 @@ jobs:
       env:
         INPUTS_RUNS_ON: ${{ inputs.runs-on }}
         LLVM_VERSION: ${{ needs.prepare.outputs.release-version }}
+        EXTRA_ARGS: ${{ case(needs.prepare.outputs.build-runs-on == 'windows-11-arm', '--disable-pgo', '') }}
       run: |
         subst S: ${{ github.workspace }}
         cd S:\llvm\utils\release\
-        .\build_llvm_release.bat "--$($env:RUNNER_ARCH.ToLower())" --version $env:LLVM_VERSION --local-python --skip-checkout
+      .\build_llvm_release.bat "--$($env:RUNNER_ARCH.ToLower())" --version $env:LLVM_VERSION --local-python --skip-checkout $env:EXTRA_ARGS
         if ($env:INPUTS_RUNS_ON -eq "windows-11-arm") {
           $zstd = (Get-ChildItem -Recurse -Filter "zstd.exe" | Select-Object -First 1).fullName
           mv $zstd $env:GITHUB_WORKSPACE

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -197,7 +197,7 @@ jobs:
           # These runners cannot build the full release package faster than
           # the 6 hours timeout limit, so we need to use a configuration
           # that builds more quickly.
-          macos-14)
+          macos-14 | windows-11-arm)
             bootstrap_prefix="BOOTSTRAP"
             target_cmake_flags="$target_cmake_flags -DLLVM_RELEASE_ENABLE_LTO=OFF -DLLVM_RELEASE_ENABLE_PGO=OFF"
             ;;

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -197,7 +197,7 @@ jobs:
           # These runners cannot build the full release package faster than
           # the 6 hours timeout limit, so we need to use a configuration
           # that builds more quickly.
-          macos-14 | windows-11-arm)
+          macos-14)
             bootstrap_prefix="BOOTSTRAP"
             target_cmake_flags="$target_cmake_flags -DLLVM_RELEASE_ENABLE_LTO=OFF -DLLVM_RELEASE_ENABLE_PGO=OFF"
             ;;

--- a/llvm/utils/release/build_llvm_release.bat
+++ b/llvm/utils/release/build_llvm_release.bat
@@ -354,7 +354,7 @@ set cmake_flags=%all_cmake_flags:\=/%
 
 mkdir build_%arch%
 cd build_%arch%
-if "%disable-pgo%" == "true" (
+if "%disable-pgo%" != "true" (
   call :do_generate_profile || exit /b 1
 )
 cmake -GNinja %cmake_flags% ^

--- a/llvm/utils/release/build_llvm_release.bat
+++ b/llvm/utils/release/build_llvm_release.bat
@@ -10,7 +10,7 @@ goto begin
 echo Script for building the LLVM installer on Windows,
 echo used for the releases at https://github.com/llvm/llvm-project/releases
 echo.
-echo Usage: build_llvm_release.bat --version ^<version^> [--x86,--x64, --arm64] [--skip-checkout] [--local-python] [--force-msvc]
+echo Usage: build_llvm_release.bat --version ^<version^> [--x86,--x64, --arm64] [--skip-checkout] [--local-python] [--force-msvc] [--disable-pgo]
 echo.
 echo Options:
 echo --version: [required] version to build
@@ -40,6 +40,7 @@ set arm64=
 set skip-checkout=
 set local-python=
 set force-msvc=
+set disable-pgo=
 call :parse_args %*
 
 if "%help%" NEQ "" goto usage
@@ -353,7 +354,9 @@ set cmake_flags=%all_cmake_flags:\=/%
 
 mkdir build_%arch%
 cd build_%arch%
-call :do_generate_profile || exit /b 1
+if "%disable-pgo%" == "true" (
+  call :do_generate_profile || exit /b 1
+)
 cmake -GNinja %cmake_flags% ^
   -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lld;lldb;flang;mlir" ^
   %common_lldb_flags% ^


### PR DESCRIPTION
Otherwise they will run into the 6 hour timeout and fail every time.