### PR TITLE
[include-cleaner] Support Objective-C literals and boxed expressions in WalkAST

### DIFF
--- a/clang-tools-extra/include-cleaner/lib/WalkAST.cpp
+++ b/clang-tools-extra/include-cleaner/lib/WalkAST.cpp
@@ -623,31 +623,31 @@ public:
     return true;
   }
 
-  void ReportObjCMethodDecl(SourceLocation Loc, ObjCMethodDecl *Method) {
+  void reportObjCLiteralMethod(SourceLocation Loc, ObjCMethodDecl *Method) {
     if (!Method)
       return;
-    report(Loc, Method->getClassInterface(), RefType::Implicit);
-    report(Loc, dyn_cast<ObjCCategoryDecl>(Method->getDeclContext()));
+    report(Loc, Method->getClassInterface());
   }
 
   bool VisitObjCBoxedExpr(ObjCBoxedExpr *E) {
-    ReportObjCMethodDecl(E->getBeginLoc(), E->getBoxingMethod());
+    // Handles NSNumber literals and NSValue literals.
+    reportObjCLiteralMethod(E->getBeginLoc(), E->getBoxingMethod());
     return true;
   }
 
   bool VisitObjCArrayLiteral(ObjCArrayLiteral *E) {
-    ReportObjCMethodDecl(E->getBeginLoc(), E->getArrayWithObjectsMethod());
+    reportObjCLiteralMethod(E->getBeginLoc(), E->getArrayWithObjectsMethod());
     return true;
   }
 
   bool VisitObjCDictionaryLiteral(ObjCDictionaryLiteral *E) {
-    ReportObjCMethodDecl(E->getBeginLoc(), E->getDictWithObjectsMethod());
+    reportObjCLiteralMethod(E->getBeginLoc(), E->getDictWithObjectsMethod());
     return true;
   }
 
   bool VisitObjCStringLiteral(ObjCStringLiteral *E) {
-    if (const auto *ObjCPtr = E->getType()->getAs<ObjCObjectPointerType>())
-      report(E->getBeginLoc(), ObjCPtr->getInterfaceDecl(), RefType::Implicit);
+    report(E->getBeginLoc(),
+           E->getType()->getAs<ObjCObjectPointerType>()->getInterfaceDecl());
     return true;
   }
 };

--- a/clang-tools-extra/include-cleaner/lib/WalkAST.cpp
+++ b/clang-tools-extra/include-cleaner/lib/WalkAST.cpp
@@ -622,6 +622,34 @@ public:
     }
     return true;
   }
+
+  void ReportObjCMethodDecl(SourceLocation Loc, ObjCMethodDecl *Method) {
+    if (!Method)
+      return;
+    report(Loc, Method->getClassInterface(), RefType::Implicit);
+    report(Loc, dyn_cast<ObjCCategoryDecl>(Method->getDeclContext()));
+  }
+
+  bool VisitObjCBoxedExpr(ObjCBoxedExpr *E) {
+    ReportObjCMethodDecl(E->getBeginLoc(), E->getBoxingMethod());
+    return true;
+  }
+
+  bool VisitObjCArrayLiteral(ObjCArrayLiteral *E) {
+    ReportObjCMethodDecl(E->getBeginLoc(), E->getArrayWithObjectsMethod());
+    return true;
+  }
+
+  bool VisitObjCDictionaryLiteral(ObjCDictionaryLiteral *E) {
+    ReportObjCMethodDecl(E->getBeginLoc(), E->getDictWithObjectsMethod());
+    return true;
+  }
+
+  bool VisitObjCStringLiteral(ObjCStringLiteral *E) {
+    if (const auto *ObjCPtr = E->getType()->getAs<ObjCObjectPointerType>())
+      report(E->getBeginLoc(), ObjCPtr->getInterfaceDecl(), RefType::Implicit);
+    return true;
+  }
 };
 
 } // namespace

--- a/clang-tools-extra/include-cleaner/unittests/WalkASTTest.cpp
+++ b/clang-tools-extra/include-cleaner/unittests/WalkASTTest.cpp
@@ -1250,6 +1250,7 @@ TEST(WalkAST, ObjCTollFreeBridgeCStyleCast) {
            {"-x", "objective-c"});
 }
 
+
 TEST(WalkAST, ObjCBridgedCastExprToProtocol) {
   // Note this test case is handled by TraverseObjCProtocolLoc instead of
   // VisitCastExpr.
@@ -1540,6 +1541,78 @@ TEST(WalkAST, ObjCEncodeExpr) {
            R"objc(
     void test() {
       const char *enc = @encode(struct ^MyStruct);
+    }
+  )objc",
+           {"-x", "objective-c"});
+}
+
+TEST(WalkAST, ObjCBoxedExprInt) {
+  testWalk(R"objc(
+    @interface $implicit^NSNumber
+    + (id)numberWithInt:(int)val;
+    @end
+  )objc",
+           R"objc(
+    void test() {
+      id x = ^@42;
+    }
+  )objc",
+           {"-x", "objective-c"});
+}
+
+
+TEST(WalkAST, ObjCBoxedExprCategory) {
+  testWalk(R"objc(
+    @interface $implicit^NSNumber
+    @end
+    @interface $explicit^NSNumber (CustomCategory)
+    + (id)numberWithInt:(int)val;
+    @end
+  )objc",
+           R"objc(
+    void test() {
+      id x = ^@42;
+    }
+  )objc",
+           {"-x", "objective-c"});
+}
+
+TEST(WalkAST, ObjCArrayLiteral) {
+  testWalk(R"objc(
+    @interface $implicit^NSArray
+    + (id)arrayWithObjects:(const id *)objects count:(unsigned long)cnt;
+    @end
+  )objc",
+           R"objc(
+    void test(id a, id b) {
+      id arr = ^@[a, b];
+    }
+  )objc",
+           {"-x", "objective-c"});
+}
+
+TEST(WalkAST, ObjCDictionaryLiteral) {
+  testWalk(R"objc(
+    @interface $implicit^NSDictionary
+    + (id)dictionaryWithObjects:(const id *)objects forKeys:(const id *)keys count:(unsigned long)cnt;
+    @end
+  )objc",
+           R"objc(
+    void test(id k, id v) {
+      id dict = ^@{k: v};
+    }
+  )objc",
+           {"-x", "objective-c"});
+}
+
+TEST(WalkAST, ObjCStringLiteral) {
+  testWalk(R"objc(
+    @interface $implicit^NSString
+    @end
+  )objc",
+           R"objc(
+    void test() {
+      id s = ^@"hello";
     }
   )objc",
            {"-x", "objective-c"});

--- a/clang-tools-extra/include-cleaner/unittests/WalkASTTest.cpp
+++ b/clang-tools-extra/include-cleaner/unittests/WalkASTTest.cpp
@@ -1250,7 +1250,6 @@ TEST(WalkAST, ObjCTollFreeBridgeCStyleCast) {
            {"-x", "objective-c"});
 }
 
-
 TEST(WalkAST, ObjCBridgedCastExprToProtocol) {
   // Note this test case is handled by TraverseObjCProtocolLoc instead of
   // VisitCastExpr.
@@ -1548,7 +1547,7 @@ TEST(WalkAST, ObjCEncodeExpr) {
 
 TEST(WalkAST, ObjCBoxedExprInt) {
   testWalk(R"objc(
-    @interface $implicit^NSNumber
+    @interface $explicit^NSNumber
     + (id)numberWithInt:(int)val;
     @end
   )objc",
@@ -1560,18 +1559,19 @@ TEST(WalkAST, ObjCBoxedExprInt) {
            {"-x", "objective-c"});
 }
 
-
-TEST(WalkAST, ObjCBoxedExprCategory) {
+TEST(WalkAST, ObjCBoxedExprStruct) {
   testWalk(R"objc(
-    @interface $implicit^NSNumber
-    @end
-    @interface $explicit^NSNumber (CustomCategory)
-    + (id)numberWithInt:(int)val;
+    struct __attribute__((objc_boxable)) Point {
+      int x, y;
+    };
+    @interface $explicit^NSValue
+    + (id)valueWithBytes:(const void *)bytes objCType:(const char *)type;
     @end
   )objc",
            R"objc(
     void test() {
-      id x = ^@42;
+    struct Point p = {1, 2};
+      id x = ^@(p);
     }
   )objc",
            {"-x", "objective-c"});
@@ -1579,7 +1579,7 @@ TEST(WalkAST, ObjCBoxedExprCategory) {
 
 TEST(WalkAST, ObjCArrayLiteral) {
   testWalk(R"objc(
-    @interface $implicit^NSArray
+    @interface $explicit^NSArray
     + (id)arrayWithObjects:(const id *)objects count:(unsigned long)cnt;
     @end
   )objc",
@@ -1593,8 +1593,10 @@ TEST(WalkAST, ObjCArrayLiteral) {
 
 TEST(WalkAST, ObjCDictionaryLiteral) {
   testWalk(R"objc(
-    @interface $implicit^NSDictionary
-    + (id)dictionaryWithObjects:(const id *)objects forKeys:(const id *)keys count:(unsigned long)cnt;
+    @interface $explicit^NSDictionary
+    + (id)dictionaryWithObjects:(const id *)objects
+                        forKeys:(const id *)keys
+                          count:(unsigned long)cnt;
     @end
   )objc",
            R"objc(
@@ -1607,7 +1609,7 @@ TEST(WalkAST, ObjCDictionaryLiteral) {
 
 TEST(WalkAST, ObjCStringLiteral) {
   testWalk(R"objc(
-    @interface $implicit^NSString
+    @interface $explicit^NSString
     @end
   )objc",
            R"objc(


### PR DESCRIPTION
This change adds AST visitors for ObjCBoxedExpr, ObjCArrayLiteral, ObjCDictionaryLiteral, and ObjCStringLiteral. This ensures that the underlying class interfaces (such as NSNumber, NSArray, NSDictionary, and NSString) and any associated categories used for these literals are correctly reported as referenced. Unit tests are included to verify the new behavior.