### PR TITLE
[libc][CI] Remove Windows 2022 from libc overlay tests

### DIFF
--- a/.github/workflows/libc-overlay-tests.yml
+++ b/.github/workflows/libc-overlay-tests.yml
@@ -33,10 +33,6 @@ jobs:
               c_compiler: clang-23
               cpp_compiler: clang++-23
             linker: lld-23
-          - os: windows-2022
-            compiler:
-              c_compiler: clang-cl
-              cpp_compiler: clang-cl
           - os: windows-2025
             compiler:
               c_compiler: clang-cl


### PR DESCRIPTION
Removed Windows 2022 configuration from CI workflow. Mainstream support is up to Oct. 13,  2026.