### PR TITLE
Add a ValueCheck construction method that takes an SBValue

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -302,12 +302,12 @@ def dump_value_obj(val: lldb.SBValue, max_children: int = 10000) -> str:
 class ValueCheck:
     def __init__(
         self,
-        name: string = None,
-        value: string = None,
-        type: string = None,
-        summary: string = None,
+        name: str = None,
+        value: str = None,
+        type: str = None,
+        summary: str = None,
         children: [ValueCheck] = None,
-        dereference: boolean = None,
+        dereference: bool = None,
         valobj: lldb.SBValue = None,
     ):
         """

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -302,12 +302,13 @@ def dump_value_obj(val: lldb.SBValue, max_children: int = 10000) -> str:
 class ValueCheck:
     def __init__(
         self,
-        name=None,
-        value=None,
-        type=None,
-        summary=None,
-        children=None,
-        dereference=None,
+        name : string = None,
+        value : string = None,
+        type : string = None,
+        summary : string = None,
+        children : [ValueCheck] = None,
+        dereference : boolean = None,
+        valobj : lldb.SBValue = None,
     ):
         """
         :param name: The name that the SBValue should have. None if the summary
@@ -325,13 +326,33 @@ class ValueCheck:
                          children.
         :param dereference: A ValueCheck for the SBValue returned by the
                             `Dereference` function.
+        :param valobj: If supplied, ignore the other arguments and build a 
+                       ValueCheck that matches valobj except for the name
+                       of the toplevel valobj.
         """
-        self.expect_name = name
-        self.expect_value = value
-        self.expect_type = type
-        self.expect_summary = summary
-        self.children = children
-        self.dereference = dereference
+        if valobj:
+            # SBValues so we don't need to dereference
+            self.dereference = None
+            # We don't want to compare the top-level VO
+            # name as the reference object may come from
+            # a different source.  So we pass that in in
+            # the recursive part by hand below.
+            
+            self.expect_name = name
+            # Copy everything else from the incoming valobj:
+            self.expect_summary = valobj.GetSummary()
+            self.expect_type = valobj.GetDisplayTypeName()
+            self.expect_value = valobj.GetValue()
+            self.children : [ValueCheck] = []
+            for child in valobj.children:
+                self.children.append(ValueCheck(valobj=child, name = child.name))
+        else:
+            self.expect_name = name
+            self.expect_value = value
+            self.expect_type = type
+            self.expect_summary = summary
+            self.children = children
+            self.dereference = dereference
 
     def check_value(self, test_base, val, error_msg=""):
         """

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -302,13 +302,13 @@ def dump_value_obj(val: lldb.SBValue, max_children: int = 10000) -> str:
 class ValueCheck:
     def __init__(
         self,
-        name : string = None,
-        value : string = None,
-        type : string = None,
-        summary : string = None,
-        children : [ValueCheck] = None,
-        dereference : boolean = None,
-        valobj : lldb.SBValue = None,
+        name: string = None,
+        value: string = None,
+        type: string = None,
+        summary: string = None,
+        children: [ValueCheck] = None,
+        dereference: boolean = None,
+        valobj: lldb.SBValue = None,
     ):
         """
         :param name: The name that the SBValue should have. None if the summary
@@ -326,7 +326,7 @@ class ValueCheck:
                          children.
         :param dereference: A ValueCheck for the SBValue returned by the
                             `Dereference` function.
-        :param valobj: If supplied, ignore the other arguments and build a 
+        :param valobj: If supplied, ignore the other arguments and build a
                        ValueCheck that matches valobj except for the name
                        of the toplevel valobj.
         """
@@ -337,15 +337,15 @@ class ValueCheck:
             # name as the reference object may come from
             # a different source.  So we pass that in in
             # the recursive part by hand below.
-            
+
             self.expect_name = name
             # Copy everything else from the incoming valobj:
             self.expect_summary = valobj.GetSummary()
             self.expect_type = valobj.GetDisplayTypeName()
             self.expect_value = valobj.GetValue()
-            self.children : [ValueCheck] = []
+            self.children: [ValueCheck] = []
             for child in valobj.children:
-                self.children.append(ValueCheck(valobj=child, name = child.name))
+                self.children.append(ValueCheck(valobj=child, name=child.name))
         else:
             self.expect_name = name
             self.expect_value = value

--- a/lldb/test/API/functionalities/expr-result-var/TestCPPExprResult.py
+++ b/lldb/test/API/functionalities/expr-result-var/TestCPPExprResult.py
@@ -25,14 +25,16 @@ class TestCPPResultVariables(TestBase):
         my_derived = frame.FindVariable("my_derived")
         self.assertSuccess(my_derived.error, "Got my_derived")
         my_value_check = ValueCheck(valobj=my_derived)
-        
+
         direct_access_expr = "{0}->derived_int".format(result_varname)
         self.expect_expr(direct_access_expr, result_type="int", result_value="1000")
 
         # Also check this by directly accessing the result variable:
         result_value = frame.FindValue(result_varname, lldb.eValueTypeConstResult, True)
         self.assertTrue(result_value.error.success, "Found my result variable")
-        my_value_check.check_value(self, result_value.Dereference(), "children are correct")
+        my_value_check.check_value(
+            self, result_value.Dereference(), "children are correct"
+        )
 
         # Make sure we can also call a function through the derived type:
         method_result = self.expect_expr(

--- a/lldb/test/API/functionalities/expr-result-var/TestCPPExprResult.py
+++ b/lldb/test/API/functionalities/expr-result-var/TestCPPExprResult.py
@@ -20,74 +20,19 @@ class TestCPPResultVariables(TestBase):
         self.main_source_file = lldb.SBFileSpec("two-bases.cpp")
 
     def check_dereference(self, result_varname, frame, expr_options):
-        deref_expr = "*{0}".format(result_varname)
-        base_children = ValueCheck(
-            name="Base", value="", children=[ValueCheck(name="base_int", value="100")]
-        )
-        base_1_arr_children = [
-            ValueCheck(name="[0]", value="100"),
-            ValueCheck(name="[1]", value="101"),
-            ValueCheck(name="[2]", value="102"),
-            ValueCheck(name="[3]", value="103"),
-            ValueCheck(name="[4]", value="104"),
-            ValueCheck(name="[5]", value="105"),
-            ValueCheck(name="[6]", value="106"),
-            ValueCheck(name="[7]", value="107"),
-            ValueCheck(name="[8]", value="108"),
-            ValueCheck(name="[9]", value="109"),
-        ]
-        base_2_arr_children = [
-            ValueCheck(name="[0]", value="200"),
-            ValueCheck(name="[1]", value="201"),
-            ValueCheck(name="[2]", value="202"),
-            ValueCheck(name="[3]", value="203"),
-            ValueCheck(name="[4]", value="204"),
-            ValueCheck(name="[5]", value="205"),
-            ValueCheck(name="[6]", value="206"),
-            ValueCheck(name="[7]", value="207"),
-            ValueCheck(name="[8]", value="208"),
-            ValueCheck(name="[9]", value="209"),
-        ]
-        deref_children = [
-            ValueCheck(
-                name="Base_1",
-                value="",
-                children=[
-                    base_children,
-                    ValueCheck(
-                        name="base_1_arr", value="", children=base_1_arr_children
-                    ),
-                ],
-            ),
-            ValueCheck(
-                name="Base_2",
-                value="",
-                children=[
-                    base_children,
-                    ValueCheck(
-                        name="base_2_arr", value="", children=base_2_arr_children
-                    ),
-                ],
-            ),
-            ValueCheck(name="derived_int", value="1000"),
-        ]
-        result_var_deref = self.expect_expr(
-            deref_expr,
-            result_type="Derived",
-            result_children=deref_children,
-            options=expr_options,
-        )
-
+        # All the variables we are comparing against are various ways to get
+        # pointers to my_derived.  So use that to make our CheckValue:
+        my_derived = frame.FindVariable("my_derived")
+        self.assertSuccess(my_derived.error, "Got my_derived")
+        my_value_check = ValueCheck(valobj=my_derived)
+        
         direct_access_expr = "{0}->derived_int".format(result_varname)
         self.expect_expr(direct_access_expr, result_type="int", result_value="1000")
 
         # Also check this by directly accessing the result variable:
         result_value = frame.FindValue(result_varname, lldb.eValueTypeConstResult, True)
         self.assertTrue(result_value.error.success, "Found my result variable")
-        value_check = ValueCheck(children=deref_children)
-        value_check.check_value(
-            self, result_value, f"{result_varname} children are correct"
-        )
+        my_value_check.check_value(self, result_value.Dereference(), "children are correct")
 
         # Make sure we can also call a function through the derived type:
         method_result = self.expect_expr(

--- a/lldb/test/API/functionalities/expr-result-var/two-bases.cpp
+++ b/lldb/test/API/functionalities/expr-result-var/two-bases.cpp
@@ -27,9 +27,7 @@ struct Derived : public Base_1, Base_2 {
 
 Base *MakeADerivedReportABase() { return (Base *)((Base_1 *)new Derived()); }
 
-Base *ReportABase(Base *input) {
-  return input;
-}
+Base *ReportABase(Base *input) { return input; }
 
 int main() {
   Derived my_derived;

--- a/lldb/test/API/functionalities/expr-result-var/two-bases.cpp
+++ b/lldb/test/API/functionalities/expr-result-var/two-bases.cpp
@@ -27,6 +27,10 @@ struct Derived : public Base_1, Base_2 {
 
 Base *MakeADerivedReportABase() { return (Base *)((Base_1 *)new Derived()); }
 
+Base *ReportABase(Base *input) {
+  return input;
+}
+
 int main() {
   Derived my_derived;
   int call_it = my_derived.method_of_derived();
@@ -40,6 +44,7 @@ int main() {
 
   // Call this to make sure the compiler makes it.
   Base *fake_base = MakeADerivedReportABase();
+  Base *reported_base = ReportABase(fake_base);
 
   uint64_t base_through_1_addr = (uint64_t)base_through_1;
   uint64_t base_through_2_addr = (uint64_t)base_through_2;


### PR DESCRIPTION
Making ValueCheck's can be pretty tedious.  But in cases where you are checking an SBValue that comes from some complex operation, e.g. an expression evaluation, you can arrange to have the result you expect as another value in your test program.  In that case, it would be much easier to make a SBValue from the reference object, and then compare the result against that reference ValueCheck.

This PR adds the valobj based ValueCheck and uses it to replace the hand-crafted one in TestCPPExprResult.py.