### PR TITLE
[ORC] Realign EPCGenericJITLinkMemoryManager Create API

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManager.h
@@ -21,7 +21,6 @@
 #include "llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/RTBridge/GenericMemoryManagerProxies.h"
-#include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
 #include "llvm/Support/Compiler.h"
 
 namespace llvm {
@@ -52,18 +51,17 @@ public:
   EPCGenericJITLinkMemoryManager(ExecutionSession &ES, Bindings B)
       : ES(ES), B(std::move(B)) {}
 
-  /// Create an EPCGenericJITLinkMemoryManager using the given implementation
-  /// symbol names. These will be looked up in the given JITDylib.
+  /// Create an EPCGenericJITLinkMemoryManager for the ORC runtime's
+  /// SimpleNativeMemoryMap interface, resolving its symbols in the given
+  /// JITDylib.
   static Expected<std::unique_ptr<EPCGenericJITLinkMemoryManager>>
-  Create(JITDylib &JD, rt::SimpleExecutorMemoryManagerSymbolNames SNs =
-                           rt::orc_rt_SimpleNativeMemoryMapSPSSymbols);
+  Create(JITDylib &JD);
 
-  /// Create an EPCGenericJITLinkMemoryManager using the given implementation
-  /// symbol names. These will be looked up in the given ExecutionSession's
-  /// Bootstrap JITDylib.
+  /// Create an EPCGenericJITLinkMemoryManager for the ORC runtime's
+  /// SimpleNativeMemoryMap interface, resolving its symbols in the given
+  /// ExecutionSession's bootstrap JITDylib.
   static Expected<std::unique_ptr<EPCGenericJITLinkMemoryManager>>
-  Create(ExecutionSession &ES, rt::SimpleExecutorMemoryManagerSymbolNames SNs =
-                                   rt::orc_rt_SimpleNativeMemoryMapSPSSymbols);
+  Create(ExecutionSession &ES);
 
   void allocate(const jitlink::JITLinkDylib *JD, jitlink::LinkGraph &G,
                 OnAllocatedFunction OnAllocated) override;

--- a/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/SPS/GenericMemoryManagerProxySpecs.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/SPS/GenericMemoryManagerProxySpecs.h
@@ -27,6 +27,12 @@
 
 namespace llvm::orc::rt::sps {
 
+// Controller-interface name of the SimpleNativeMemoryMap instance: a data
+// symbol (the allocator object) passed as the first argument to each call, not
+// a wrapper to proxy.
+inline constexpr char MemMgrInstanceCIName[] =
+    "orc_rt_ci_SimpleNativeMemoryMap_Instance";
+
 using MemMgrReserveSPSSig = shared::SPSExpected<shared::SPSExecutorAddr>(
     shared::SPSExecutorAddr, uint64_t);
 inline constexpr char MemMgrReserveCIName[] =

--- a/llvm/lib/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManager.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManager.cpp
@@ -11,7 +11,6 @@
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/ExecutionEngine/Orc/LookupAndRecordAddrs.h"
 #include "llvm/ExecutionEngine/Orc/RTBridge/SPS/GenericMemoryManagerProxySpecs.h"
-#include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
 
 #include <limits>
 
@@ -83,35 +82,29 @@ private:
 };
 
 Expected<std::unique_ptr<EPCGenericJITLinkMemoryManager>>
-EPCGenericJITLinkMemoryManager::Create(
-    JITDylib &JD, rt::SimpleExecutorMemoryManagerSymbolNames SNs) {
+EPCGenericJITLinkMemoryManager::Create(JITDylib &JD) {
   namespace sps = rt::sps;
   auto &ES = JD.getExecutionSession();
   Bindings B;
-  // The allocator instance is a data symbol passed as the first argument to
-  // each call, not a wrapper to proxy.
+  // Instance is the executor-side allocator object -- a data symbol passed as
+  // the first argument to each call, not a wrapper to proxy.
   if (auto Err = lookupAndRecordAddrs(
           ES, LookupKind::Static, makeJITDylibSearchOrder({&JD}),
-          {{ES.intern(SNs.AllocatorName), &B.Instance}}))
-    return Err;
+          {{ES.intern(sps::MemMgrInstanceCIName), &B.Instance}}))
+    return std::move(Err);
+  // The proxies resolve to the specs' default (SimpleNativeMemoryMap) names.
   if (auto Err = rt::buildProxies(
-          JD,
-          rt::proxyInit<sps::MemMgrReserveProxySpec>(&B.Reserve,
-                                                     SNs.ReserveName),
-          rt::proxyInit<sps::MemMgrInitializeProxySpec>(&B.Initialize,
-                                                        SNs.InitializeName),
-          rt::proxyInit<sps::MemMgrDeinitializeProxySpec>(&B.Deinitialize,
-                                                          SNs.DeinitializeName),
-          rt::proxyInit<sps::MemMgrReleaseProxySpec>(&B.Release,
-                                                     SNs.ReleaseName)))
-    return Err;
+          JD, rt::proxyInit<sps::MemMgrReserveProxySpec>(&B.Reserve),
+          rt::proxyInit<sps::MemMgrInitializeProxySpec>(&B.Initialize),
+          rt::proxyInit<sps::MemMgrDeinitializeProxySpec>(&B.Deinitialize),
+          rt::proxyInit<sps::MemMgrReleaseProxySpec>(&B.Release)))
+    return std::move(Err);
   return std::make_unique<EPCGenericJITLinkMemoryManager>(ES, std::move(B));
 }
 
 Expected<std::unique_ptr<EPCGenericJITLinkMemoryManager>>
-EPCGenericJITLinkMemoryManager::Create(
-    ExecutionSession &ES, rt::SimpleExecutorMemoryManagerSymbolNames SNs) {
-  return Create(ES.getBootstrapJITDylib(), std::move(SNs));
+EPCGenericJITLinkMemoryManager::Create(ExecutionSession &ES) {
+  return Create(ES.getBootstrapJITDylib());
 }
 
 void EPCGenericJITLinkMemoryManager::allocate(const JITLinkDylib *JD,

--- a/llvm/unittests/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManagerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManagerTest.cpp
@@ -12,6 +12,7 @@
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ExecutionEngine/Orc/AbsoluteSymbols.h"
+#include "llvm/ExecutionEngine/Orc/RTBridge/SPS/GenericMemoryManagerProxySpecs.h"
 #include "llvm/ExecutionEngine/Orc/SelfExecutorProcessControl.h"
 #include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
 #include "llvm/ExecutionEngine/Orc/Shared/TargetProcessControlTypes.h"
@@ -153,9 +154,10 @@ TEST(EPCGenericJITLinkMemoryManagerTest, AllocFinalizeFree) {
   cantFail(ES.endSession());
 }
 
-TEST(EPCGenericJITLinkMemoryManagerTest, CreateFromSymbolNames) {
-  // Verify that Create successfully looks up symbols and constructs
-  // the memory manager.
+TEST(EPCGenericJITLinkMemoryManagerTest, CreateFromJITDylib) {
+  // Verify that Create(JITDylib&) looks up the default SimpleNativeMemoryMap
+  // symbols and constructs the memory manager.
+  namespace sps = rt::sps;
   auto SSP = std::make_shared<SymbolStringPool>();
   auto EPC =
       std::make_unique<UnsupportedExecutorProcessControl>(std::move(SSP));
@@ -166,22 +168,19 @@ TEST(EPCGenericJITLinkMemoryManagerTest, CreateFromSymbolNames) {
       ReleaseAddr(5);
 
   cantFail(JD.define(absoluteSymbols({
-      {ES.intern("allocator_instance"),
+      {ES.intern(sps::MemMgrInstanceCIName),
        {AllocatorAddr, JITSymbolFlags::Exported}},
-      {ES.intern("allocator_reserve"), {ReserveAddr, JITSymbolFlags::Exported}},
-      {ES.intern("allocator_init"), {InitAddr, JITSymbolFlags::Exported}},
-      {ES.intern("allocator_deinit"), {DeinitAddr, JITSymbolFlags::Exported}},
-      {ES.intern("allocator_release"), {ReleaseAddr, JITSymbolFlags::Exported}},
+      {ES.intern(sps::MemMgrReserveCIName),
+       {ReserveAddr, JITSymbolFlags::Exported}},
+      {ES.intern(sps::MemMgrInitializeCIName),
+       {InitAddr, JITSymbolFlags::Exported}},
+      {ES.intern(sps::MemMgrDeinitializeCIName),
+       {DeinitAddr, JITSymbolFlags::Exported}},
+      {ES.intern(sps::MemMgrReleaseCIName),
+       {ReleaseAddr, JITSymbolFlags::Exported}},
   })));
 
-  rt::SimpleExecutorMemoryManagerSymbolNames SNs;
-  SNs.AllocatorName = "allocator_instance";
-  SNs.ReserveName = "allocator_reserve";
-  SNs.InitializeName = "allocator_init";
-  SNs.DeinitializeName = "allocator_deinit";
-  SNs.ReleaseName = "allocator_release";
-
-  auto Result = EPCGenericJITLinkMemoryManager::Create(JD, SNs);
+  auto Result = EPCGenericJITLinkMemoryManager::Create(JD);
   EXPECT_THAT_EXPECTED(Result, Succeeded());
 
   cantFail(ES.endSession());
@@ -189,26 +188,20 @@ TEST(EPCGenericJITLinkMemoryManagerTest, CreateFromSymbolNames) {
 
 TEST(EPCGenericJITLinkMemoryManagerTest, CreateFailsOnMissingSymbol) {
   // Verify that Create returns an error when a symbol is missing.
+  namespace sps = rt::sps;
   auto SSP = std::make_shared<SymbolStringPool>();
   auto EPC =
       std::make_unique<UnsupportedExecutorProcessControl>(std::move(SSP));
   ExecutionSession ES(std::move(EPC));
   auto &JD = ES.createBareJITDylib("JD");
 
-  // Only define some of the required symbols.
+  // Only define the instance symbol; the wrapper symbols are missing.
   cantFail(JD.define(absoluteSymbols({
-      {ES.intern("allocator_instance"),
+      {ES.intern(sps::MemMgrInstanceCIName),
        {ExecutorAddr(1), JITSymbolFlags::Exported}},
   })));
 
-  rt::SimpleExecutorMemoryManagerSymbolNames SNs;
-  SNs.AllocatorName = "allocator_instance";
-  SNs.ReserveName = "allocator_reserve";     // missing
-  SNs.InitializeName = "allocator_init";     // missing
-  SNs.DeinitializeName = "allocator_deinit"; // missing
-  SNs.ReleaseName = "allocator_release";     // missing
-
-  auto Result = EPCGenericJITLinkMemoryManager::Create(JD, SNs);
+  auto Result = EPCGenericJITLinkMemoryManager::Create(JD);
   EXPECT_THAT_EXPECTED(Result, Failed());
 
   cantFail(ES.endSession());
@@ -217,6 +210,7 @@ TEST(EPCGenericJITLinkMemoryManagerTest, CreateFailsOnMissingSymbol) {
 TEST(EPCGenericJITLinkMemoryManagerTest, CreateFromExecutionSession) {
   // Verify that Create(ExecutionSession&) looks up symbols in the bootstrap
   // JITDylib using the default SimpleNativeMemoryMap symbol names.
+  namespace sps = rt::sps;
   class EPCWithBootstrapSymbols : public UnsupportedExecutorProcessControl {
   public:
     EPCWithBootstrapSymbols(std::shared_ptr<SymbolStringPool> SSP,
@@ -226,24 +220,22 @@ TEST(EPCGenericJITLinkMemoryManagerTest, CreateFromExecutionSession) {
     }
   };
 
-  auto &SNs = rt::orc_rt_SimpleNativeMemoryMapSPSSymbols;
-
   ExecutorAddr AllocatorAddr(1), ReserveAddr(2), InitAddr(3), DeinitAddr(4),
       ReleaseAddr(5);
 
   StringMap<ExecutorAddr> BootstrapSyms;
-  BootstrapSyms[SNs.AllocatorName] = AllocatorAddr;
-  BootstrapSyms[SNs.ReserveName] = ReserveAddr;
-  BootstrapSyms[SNs.InitializeName] = InitAddr;
-  BootstrapSyms[SNs.DeinitializeName] = DeinitAddr;
-  BootstrapSyms[SNs.ReleaseName] = ReleaseAddr;
+  BootstrapSyms[sps::MemMgrInstanceCIName] = AllocatorAddr;
+  BootstrapSyms[sps::MemMgrReserveCIName] = ReserveAddr;
+  BootstrapSyms[sps::MemMgrInitializeCIName] = InitAddr;
+  BootstrapSyms[sps::MemMgrDeinitializeCIName] = DeinitAddr;
+  BootstrapSyms[sps::MemMgrReleaseCIName] = ReleaseAddr;
 
   auto SSP = std::make_shared<SymbolStringPool>();
   auto EPC =
       std::make_unique<EPCWithBootstrapSymbols>(SSP, std::move(BootstrapSyms));
   ExecutionSession ES(std::move(EPC));
 
-  auto Result = EPCGenericJITLinkMemoryManager::Create(ES, SNs);
+  auto Result = EPCGenericJITLinkMemoryManager::Create(ES);
   EXPECT_THAT_EXPECTED(Result, Succeeded());
 
   cantFail(ES.endSession());


### PR DESCRIPTION
Bring EPCGenericJITLinkMemoryManager into alignment with EPCGenericMemoryAccess and EPCGenericDylibManager: a Bindings constructor plus static Create methods that build the bindings from the ProxySpecs using the default controller-interface names. Create(JITDylib&) resolves the SimpleNativeMemoryMap symbols in the given JITDylib; Create(ExecutionSession&) uses the bootstrap JITDylib. Clients targeting a different protocol can construct their own Bindings directly.

This replaces the previous scheme where Create took a SimpleExecutorMemoryManagerSymbolNames override.