### PR TITLE
[DAGCombiner] Remove unnecessary N0->hasOneUse() check from foldSelectOfBinops. NFC

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -31068,9 +31068,7 @@ SDValue DAGCombiner::foldSelectOfBinops(SDNode *N) {
 
   // The use checks are intentionally on SDNode because we may be dealing
   // with opcodes that produce more than one SDValue.
-  // TODO: Do we really need to check N0 (the condition operand of the select)?
-  //       But removing that clause could cause an infinite loop...
-  if (!N0->hasOneUse() || !N1->hasOneUse() || !N2->hasOneUse())
+  if (!N1->hasOneUse() || !N2->hasOneUse())
     return SDValue();
 
   // Binops may include opcodes that return multiple values, so all values

--- a/llvm/test/CodeGen/AMDGPU/bf16.ll
+++ b/llvm/test/CodeGen/AMDGPU/bf16.ll
@@ -40628,28 +40628,16 @@ define <2 x bfloat> @v_select_v2bf16(i1 %cond, <2 x bfloat> %a, <2 x bfloat> %b)
 ; GCN:       ; %bb.0:
 ; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GCN-NEXT:    v_and_b32_e32 v0, 1, v0
-; GCN-NEXT:    v_lshrrev_b32_e32 v3, 16, v1
-; GCN-NEXT:    v_lshrrev_b32_e32 v4, 16, v2
 ; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 1, v0
-; GCN-NEXT:    v_cndmask_b32_e32 v0, v4, v3, vcc
-; GCN-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GCN-NEXT:    v_lshlrev_b32_e32 v0, 16, v0
-; GCN-NEXT:    v_and_b32_e32 v1, 0xffff, v1
-; GCN-NEXT:    v_or_b32_e32 v0, v1, v0
+; GCN-NEXT:    v_cndmask_b32_e32 v0, v2, v1, vcc
 ; GCN-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX7-LABEL: v_select_v2bf16:
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_and_b32_e32 v0, 1, v0
-; GFX7-NEXT:    v_lshrrev_b32_e32 v3, 16, v1
-; GFX7-NEXT:    v_lshrrev_b32_e32 v4, 16, v2
 ; GFX7-NEXT:    v_cmp_eq_u32_e32 vcc, 1, v0
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v4, v3, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GFX7-NEXT:    v_lshlrev_b32_e32 v0, 16, v0
-; GFX7-NEXT:    v_and_b32_e32 v1, 0xffff, v1
-; GFX7-NEXT:    v_or_b32_e32 v0, v1, v0
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v1, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_select_v2bf16:
@@ -40972,35 +40960,19 @@ define amdgpu_ps i32 @s_select_bf16(bfloat inreg %a, bfloat inreg %b, i32 %c) #0
 define amdgpu_ps i32 @s_select_v2bf16(<2 x bfloat> inreg %a, <2 x bfloat> inreg %b, i32 %c) #0 {
 ; GCN-LABEL: s_select_v2bf16:
 ; GCN:       ; %bb.0:
-; GCN-NEXT:    s_lshr_b32 s2, s0, 16
-; GCN-NEXT:    s_lshr_b32 s3, s1, 16
-; GCN-NEXT:    v_mov_b32_e32 v1, s3
-; GCN-NEXT:    v_mov_b32_e32 v2, s2
-; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
-; GCN-NEXT:    v_cndmask_b32_e32 v0, v1, v2, vcc
 ; GCN-NEXT:    v_mov_b32_e32 v1, s1
 ; GCN-NEXT:    v_mov_b32_e32 v2, s0
-; GCN-NEXT:    v_cndmask_b32_e32 v1, v1, v2, vcc
-; GCN-NEXT:    v_lshlrev_b32_e32 v0, 16, v0
-; GCN-NEXT:    v_and_b32_e32 v1, 0xffff, v1
-; GCN-NEXT:    v_or_b32_e32 v0, v1, v0
+; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
+; GCN-NEXT:    v_cndmask_b32_e32 v0, v1, v2, vcc
 ; GCN-NEXT:    v_readfirstlane_b32 s0, v0
 ; GCN-NEXT:    ; return to shader part epilog
 ;
 ; GFX7-LABEL: s_select_v2bf16:
 ; GFX7:       ; %bb.0:
-; GFX7-NEXT:    s_lshr_b32 s2, s0, 16
-; GFX7-NEXT:    s_lshr_b32 s3, s1, 16
-; GFX7-NEXT:    v_mov_b32_e32 v1, s3
-; GFX7-NEXT:    v_mov_b32_e32 v2, s2
-; GFX7-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v1, v2, vcc
 ; GFX7-NEXT:    v_mov_b32_e32 v1, s1
 ; GFX7-NEXT:    v_mov_b32_e32 v2, s0
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v1, v2, vcc
-; GFX7-NEXT:    v_lshlrev_b32_e32 v0, 16, v0
-; GFX7-NEXT:    v_and_b32_e32 v1, 0xffff, v1
-; GFX7-NEXT:    v_or_b32_e32 v0, v1, v0
+; GFX7-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v1, v2, vcc
 ; GFX7-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX7-NEXT:    ; return to shader part epilog
 ;

--- a/llvm/test/CodeGen/AMDGPU/freeze-other-uses-issue-198094.ll
+++ b/llvm/test/CodeGen/AMDGPU/freeze-other-uses-issue-198094.ll
@@ -15,9 +15,8 @@ define void @repro(<6 x i32> %a, i32 %i) {
 ; CHECK-NEXT:    v_cndmask_b32_e32 v2, v2, v4, vcc
 ; CHECK-NEXT:    v_cmp_eq_u32_e32 vcc, 5, v6
 ; CHECK-NEXT:    v_cndmask_b32_e32 v2, v2, v5, vcc
-; CHECK-NEXT:    v_xor_b32_e32 v1, v2, v1
-; CHECK-NEXT:    v_xor_b32_e32 v0, v2, v0
 ; CHECK-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
+; CHECK-NEXT:    v_xor_b32_e32 v0, v2, v0
 ; CHECK-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
 ; CHECK-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; CHECK-NEXT:    s_or_b64 exec, exec, s[4:5]

--- a/llvm/test/CodeGen/AMDGPU/shift-i128.ll
+++ b/llvm/test/CodeGen/AMDGPU/shift-i128.ll
@@ -66,13 +66,11 @@ define i128 @v_ashr_i128_vv(i128 %lhs, i128 %rhs) {
 ; GCN-NEXT:    v_ashr_i64 v[5:6], v[2:3], v5
 ; GCN-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v4
 ; GCN-NEXT:    v_cndmask_b32_e32 v5, v5, v7, vcc
+; GCN-NEXT:    v_cndmask_b32_e32 v4, 63, v4, vcc
 ; GCN-NEXT:    v_cndmask_b32_e64 v0, v5, v0, s[4:5]
 ; GCN-NEXT:    v_cndmask_b32_e32 v5, v6, v8, vcc
+; GCN-NEXT:    v_ashr_i64 v[2:3], v[2:3], v4
 ; GCN-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s[4:5]
-; GCN-NEXT:    v_ashr_i64 v[4:5], v[2:3], v4
-; GCN-NEXT:    v_ashrrev_i32_e32 v3, 31, v3
-; GCN-NEXT:    v_cndmask_b32_e32 v2, v3, v4, vcc
-; GCN-NEXT:    v_cndmask_b32_e32 v3, v3, v5, vcc
 ; GCN-NEXT:    s_setpc_b64 s[30:31]
   %shl = ashr i128 %lhs, %rhs
   ret i128 %shl
@@ -260,27 +258,25 @@ define amdgpu_kernel void @s_ashr_i128_ss(i128 %lhs, i128 %rhs) {
 ; GCN-NEXT:    s_mov_b32 flat_scratch_lo, s13
 ; GCN-NEXT:    v_mov_b32_e32 v4, 0
 ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
-; GCN-NEXT:    s_sub_i32 s5, 64, s4
+; GCN-NEXT:    s_sub_i32 s10, 64, s4
+; GCN-NEXT:    s_sub_i32 s5, s4, 64
 ; GCN-NEXT:    s_lshr_b64 s[6:7], s[0:1], s4
-; GCN-NEXT:    s_sub_i32 s10, s4, 64
-; GCN-NEXT:    s_lshl_b64 s[8:9], s[2:3], s5
-; GCN-NEXT:    s_ashr_i32 s12, s3, 31
-; GCN-NEXT:    s_ashr_i64 s[10:11], s[2:3], s10
-; GCN-NEXT:    s_or_b64 s[6:7], s[6:7], s[8:9]
-; GCN-NEXT:    s_ashr_i64 s[2:3], s[2:3], s4
+; GCN-NEXT:    s_lshl_b64 s[10:11], s[2:3], s10
+; GCN-NEXT:    s_ashr_i64 s[8:9], s[2:3], s5
+; GCN-NEXT:    s_or_b64 s[6:7], s[6:7], s[10:11]
 ; GCN-NEXT:    s_cmp_lt_u32 s4, 64
-; GCN-NEXT:    s_cselect_b32 s3, s3, s12
-; GCN-NEXT:    s_cselect_b32 s2, s2, s12
-; GCN-NEXT:    s_cselect_b32 s5, s6, s10
-; GCN-NEXT:    s_cselect_b32 s6, s7, s11
+; GCN-NEXT:    s_cselect_b32 s5, s6, s8
+; GCN-NEXT:    s_cselect_b32 s6, s7, s9
+; GCN-NEXT:    s_cselect_b32 s7, s4, 63
 ; GCN-NEXT:    s_cmp_eq_u32 s4, 0
-; GCN-NEXT:    s_cselect_b32 s1, s1, s6
-; GCN-NEXT:    s_cselect_b32 s0, s0, s5
-; GCN-NEXT:    v_mov_b32_e32 v0, s0
-; GCN-NEXT:    v_mov_b32_e32 v1, s1
-; GCN-NEXT:    v_mov_b32_e32 v2, s2
+; GCN-NEXT:    s_cselect_b32 s4, s1, s6
+; GCN-NEXT:    s_cselect_b32 s5, s0, s5
+; GCN-NEXT:    s_ashr_i64 s[0:1], s[2:3], s7
+; GCN-NEXT:    v_mov_b32_e32 v0, s5
+; GCN-NEXT:    v_mov_b32_e32 v1, s4
+; GCN-NEXT:    v_mov_b32_e32 v2, s0
 ; GCN-NEXT:    v_mov_b32_e32 v5, 0
-; GCN-NEXT:    v_mov_b32_e32 v3, s3
+; GCN-NEXT:    v_mov_b32_e32 v3, s1
 ; GCN-NEXT:    flat_store_dwordx4 v[4:5], v[0:3]
 ; GCN-NEXT:    s_endpgm
   %shift = ashr i128 %lhs, %rhs
@@ -420,18 +416,14 @@ define <2 x i128> @v_ashr_v2i128_vv(<2 x i128> %lhs, <2 x i128> %rhs) {
 ; GCN-NEXT:    v_or_b32_e32 v14, v12, v14
 ; GCN-NEXT:    s_and_b64 s[4:5], s[6:7], s[4:5]
 ; GCN-NEXT:    v_cmp_eq_u64_e64 s[6:7], 0, v[14:15]
+; GCN-NEXT:    v_cndmask_b32_e32 v8, 63, v8, vcc
 ; GCN-NEXT:    v_cndmask_b32_e64 v9, v9, v16, s[4:5]
+; GCN-NEXT:    v_ashr_i64 v[2:3], v[2:3], v8
+; GCN-NEXT:    v_cndmask_b32_e64 v8, 63, v12, s[4:5]
 ; GCN-NEXT:    v_cndmask_b32_e64 v4, v9, v4, s[6:7]
 ; GCN-NEXT:    v_cndmask_b32_e64 v9, v10, v11, s[4:5]
+; GCN-NEXT:    v_ashr_i64 v[6:7], v[6:7], v8
 ; GCN-NEXT:    v_cndmask_b32_e64 v5, v9, v5, s[6:7]
-; GCN-NEXT:    v_ashr_i64 v[8:9], v[2:3], v8
-; GCN-NEXT:    v_ashrrev_i32_e32 v3, 31, v3
-; GCN-NEXT:    v_cndmask_b32_e32 v2, v3, v8, vcc
-; GCN-NEXT:    v_cndmask_b32_e32 v3, v3, v9, vcc
-; GCN-NEXT:    v_ashr_i64 v[8:9], v[6:7], v12
-; GCN-NEXT:    v_ashrrev_i32_e32 v7, 31, v7
-; GCN-NEXT:    v_cndmask_b32_e64 v6, v7, v8, s[4:5]
-; GCN-NEXT:    v_cndmask_b32_e64 v7, v7, v9, s[4:5]
 ; GCN-NEXT:    s_setpc_b64 s[30:31]
   %shl = ashr <2 x i128> %lhs, %rhs
   ret <2 x i128> %shl
@@ -637,26 +629,22 @@ define amdgpu_kernel void @s_ashr_v2i128_ss(<2 x i128> %lhs, <2 x i128> %rhs) {
 ; GCN-NEXT:    s_cselect_b32 s5, s18, s10
 ; GCN-NEXT:    s_and_b64 s[10:11], s[14:15], exec
 ; GCN-NEXT:    s_cselect_b32 s10, s4, s5
-; GCN-NEXT:    s_ashr_i32 s11, s3, 31
-; GCN-NEXT:    s_ashr_i64 s[2:3], s[2:3], s8
 ; GCN-NEXT:    s_and_b64 s[4:5], s[16:17], exec
-; GCN-NEXT:    s_cselect_b32 s4, s3, s11
-; GCN-NEXT:    s_cselect_b32 s5, s2, s11
-; GCN-NEXT:    s_ashr_i32 s8, s7, 31
-; GCN-NEXT:    s_ashr_i64 s[2:3], s[6:7], s12
+; GCN-NEXT:    s_cselect_b32 s4, s8, 63
+; GCN-NEXT:    s_ashr_i64 s[2:3], s[2:3], s4
 ; GCN-NEXT:    s_and_b64 s[0:1], s[0:1], exec
-; GCN-NEXT:    s_cselect_b32 s0, s3, s8
-; GCN-NEXT:    s_cselect_b32 s1, s2, s8
+; GCN-NEXT:    s_cselect_b32 s0, s12, 63
+; GCN-NEXT:    s_ashr_i64 s[0:1], s[6:7], s0
 ; GCN-NEXT:    v_mov_b32_e32 v0, s10
 ; GCN-NEXT:    v_mov_b32_e32 v1, s13
-; GCN-NEXT:    v_mov_b32_e32 v2, s1
-; GCN-NEXT:    v_mov_b32_e32 v3, s0
+; GCN-NEXT:    v_mov_b32_e32 v2, s0
+; GCN-NEXT:    v_mov_b32_e32 v3, s1
 ; GCN-NEXT:    flat_store_dwordx4 v[6:7], v[0:3]
 ; GCN-NEXT:    s_nop 0
 ; GCN-NEXT:    v_mov_b32_e32 v0, s22
 ; GCN-NEXT:    v_mov_b32_e32 v1, s9
-; GCN-NEXT:    v_mov_b32_e32 v2, s5
-; GCN-NEXT:    v_mov_b32_e32 v3, s4
+; GCN-NEXT:    v_mov_b32_e32 v2, s2
+; GCN-NEXT:    v_mov_b32_e32 v3, s3
 ; GCN-NEXT:    flat_store_dwordx4 v[4:5], v[0:3]
 ; GCN-NEXT:    s_endpgm
   %shift = ashr <2 x i128> %lhs, %rhs

--- a/llvm/test/CodeGen/RISCV/select-optimize-multiple.ll
+++ b/llvm/test/CodeGen/RISCV/select-optimize-multiple.ll
@@ -43,39 +43,18 @@ define i128 @cmovcc128(i64 signext %a, i128 %b, i128 %c) nounwind {
 ; RV32I:       # %bb.0: # %entry
 ; RV32I-NEXT:    xori a1, a1, 123
 ; RV32I-NEXT:    or a1, a1, a2
-; RV32I-NEXT:    mv a2, a3
 ; RV32I-NEXT:    beqz a1, .LBB1_2
 ; RV32I-NEXT:  # %bb.1: # %entry
-; RV32I-NEXT:    mv a2, a4
+; RV32I-NEXT:    mv a3, a4
 ; RV32I-NEXT:  .LBB1_2: # %entry
-; RV32I-NEXT:    beqz a1, .LBB1_5
-; RV32I-NEXT:  # %bb.3: # %entry
-; RV32I-NEXT:    addi a5, a4, 4
-; RV32I-NEXT:    bnez a1, .LBB1_6
-; RV32I-NEXT:  .LBB1_4:
-; RV32I-NEXT:    addi a6, a3, 8
-; RV32I-NEXT:    j .LBB1_7
-; RV32I-NEXT:  .LBB1_5:
-; RV32I-NEXT:    addi a5, a3, 4
-; RV32I-NEXT:    beqz a1, .LBB1_4
-; RV32I-NEXT:  .LBB1_6: # %entry
-; RV32I-NEXT:    addi a6, a4, 8
-; RV32I-NEXT:  .LBB1_7: # %entry
-; RV32I-NEXT:    lw a2, 0(a2)
-; RV32I-NEXT:    lw a5, 0(a5)
-; RV32I-NEXT:    lw a6, 0(a6)
-; RV32I-NEXT:    beqz a1, .LBB1_9
-; RV32I-NEXT:  # %bb.8: # %entry
-; RV32I-NEXT:    addi a3, a4, 12
-; RV32I-NEXT:    j .LBB1_10
-; RV32I-NEXT:  .LBB1_9:
-; RV32I-NEXT:    addi a3, a3, 12
-; RV32I-NEXT:  .LBB1_10: # %entry
 ; RV32I-NEXT:    lw a1, 0(a3)
-; RV32I-NEXT:    sw a2, 0(a0)
-; RV32I-NEXT:    sw a5, 4(a0)
-; RV32I-NEXT:    sw a6, 8(a0)
-; RV32I-NEXT:    sw a1, 12(a0)
+; RV32I-NEXT:    lw a2, 4(a3)
+; RV32I-NEXT:    lw a4, 8(a3)
+; RV32I-NEXT:    lw a3, 12(a3)
+; RV32I-NEXT:    sw a1, 0(a0)
+; RV32I-NEXT:    sw a2, 4(a0)
+; RV32I-NEXT:    sw a4, 8(a0)
+; RV32I-NEXT:    sw a3, 12(a0)
 ; RV32I-NEXT:    ret
 ;
 ; RV64I-LABEL: cmovcc128:
@@ -127,39 +106,18 @@ define i128 @cmov128(i1 %a, i128 %b, i128 %c) nounwind {
 ; RV32I-LABEL: cmov128:
 ; RV32I:       # %bb.0: # %entry
 ; RV32I-NEXT:    andi a1, a1, 1
-; RV32I-NEXT:    mv a4, a2
 ; RV32I-NEXT:    bnez a1, .LBB3_2
 ; RV32I-NEXT:  # %bb.1: # %entry
-; RV32I-NEXT:    mv a4, a3
+; RV32I-NEXT:    mv a2, a3
 ; RV32I-NEXT:  .LBB3_2: # %entry
-; RV32I-NEXT:    bnez a1, .LBB3_5
-; RV32I-NEXT:  # %bb.3: # %entry
-; RV32I-NEXT:    addi a5, a3, 4
-; RV32I-NEXT:    beqz a1, .LBB3_6
-; RV32I-NEXT:  .LBB3_4:
-; RV32I-NEXT:    addi a6, a2, 8
-; RV32I-NEXT:    j .LBB3_7
-; RV32I-NEXT:  .LBB3_5:
-; RV32I-NEXT:    addi a5, a2, 4
-; RV32I-NEXT:    bnez a1, .LBB3_4
-; RV32I-NEXT:  .LBB3_6: # %entry
-; RV32I-NEXT:    addi a6, a3, 8
-; RV32I-NEXT:  .LBB3_7: # %entry
-; RV32I-NEXT:    lw a4, 0(a4)
-; RV32I-NEXT:    lw a5, 0(a5)
-; RV32I-NEXT:    lw a6, 0(a6)
-; RV32I-NEXT:    bnez a1, .LBB3_9
-; RV32I-NEXT:  # %bb.8: # %entry
-; RV32I-NEXT:    addi a2, a3, 12
-; RV32I-NEXT:    j .LBB3_10
-; RV32I-NEXT:  .LBB3_9:
-; RV32I-NEXT:    addi a2, a2, 12
-; RV32I-NEXT:  .LBB3_10: # %entry
 ; RV32I-NEXT:    lw a1, 0(a2)
-; RV32I-NEXT:    sw a4, 0(a0)
-; RV32I-NEXT:    sw a5, 4(a0)
-; RV32I-NEXT:    sw a6, 8(a0)
-; RV32I-NEXT:    sw a1, 12(a0)
+; RV32I-NEXT:    lw a3, 4(a2)
+; RV32I-NEXT:    lw a4, 8(a2)
+; RV32I-NEXT:    lw a2, 12(a2)
+; RV32I-NEXT:    sw a1, 0(a0)
+; RV32I-NEXT:    sw a3, 4(a0)
+; RV32I-NEXT:    sw a4, 8(a0)
+; RV32I-NEXT:    sw a2, 12(a0)
 ; RV32I-NEXT:    ret
 ;
 ; RV64I-LABEL: cmov128:

--- a/llvm/test/CodeGen/X86/pseudo_cmov_lower2.ll
+++ b/llvm/test/CodeGen/X86/pseudo_cmov_lower2.ll
@@ -29,16 +29,17 @@ define double @foo2(float %p1, double %p2, double %p3) nounwind {
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    xorps %xmm3, %xmm3
 ; CHECK-NEXT:    ucomiss %xmm3, %xmm0
-; CHECK-NEXT:    movsd {{.*#+}} xmm0 = [1.25E+0,0.0E+0]
-; CHECK-NEXT:    jae .LBB1_1
-; CHECK-NEXT:  # %bb.2: # %entry
-; CHECK-NEXT:    addsd %xmm0, %xmm2
+; CHECK-NEXT:    movapd %xmm1, %xmm0
+; CHECK-NEXT:    jae .LBB1_2
+; CHECK-NEXT:  # %bb.1: # %entry
 ; CHECK-NEXT:    movapd %xmm2, %xmm0
-; CHECK-NEXT:    movapd %xmm2, %xmm1
-; CHECK-NEXT:    jmp .LBB1_3
-; CHECK-NEXT:  .LBB1_1:
-; CHECK-NEXT:    addsd %xmm1, %xmm0
-; CHECK-NEXT:  .LBB1_3: # %entry
+; CHECK-NEXT:  .LBB1_2: # %entry
+; CHECK-NEXT:    addsd {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0
+; CHECK-NEXT:    jae .LBB1_4
+; CHECK-NEXT:  # %bb.3: # %entry
+; CHECK-NEXT:    movapd %xmm0, %xmm1
+; CHECK-NEXT:    movapd %xmm0, %xmm2
+; CHECK-NEXT:  .LBB1_4: # %entry
 ; CHECK-NEXT:    subsd %xmm1, %xmm0
 ; CHECK-NEXT:    addsd %xmm2, %xmm0
 ; CHECK-NEXT:    retq
@@ -201,23 +202,26 @@ declare void @llvm.dbg.value(metadata, metadata, metadata)
 define double @foo1_g(float %p1, double %p2, double %p3) nounwind !dbg !4 {
 ; CHECK-LABEL: foo1_g:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    .file   1 "." "test.c"
-; CHECK-NEXT:    .loc 1 3 0 prologue_end
+; CHECK-NEXT:    .file 1 "." "test.c"
+; CHECK-NEXT:    .loc 1 3 0 prologue_end # test.c:3:0
 ; CHECK-NEXT:    xorps %xmm3, %xmm3
 ; CHECK-NEXT:    ucomiss %xmm3, %xmm0
-; CHECK-NEXT:    movsd {{.*#+}} xmm0 = [1.25E+0,0.0E+0]
-; CHECK-NEXT:    jae .LBB6_1
-; CHECK-NEXT:  # %bb.2: # %entry
-; CHECK-NEXT:    addsd %xmm2, %xmm0
-; CHECK-NEXT:    jmp .LBB6_3
-; CHECK-NEXT:  .LBB6_1:
-; CHECK-NEXT:    addsd %xmm0, %xmm1
 ; CHECK-NEXT:    movapd %xmm1, %xmm0
-; CHECK-NEXT:    movapd %xmm1, %xmm2
-; CHECK-NEXT:  .LBB6_3: # %entry
+; CHECK-NEXT:    jae .LBB6_2
+; CHECK-NEXT:  # %bb.1: # %entry
+; CHECK-NEXT:    movapd %xmm2, %xmm0
+; CHECK-NEXT:  .LBB6_2: # %entry
+; CHECK-NEXT:    addsd {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0
 ; CHECK-NEXT:    #DEBUG_VALUE: foobar:xyzzy <- undef
-; CHECK-NEXT:    subsd %xmm1, %xmm0
-; CHECK-NEXT:    addsd %xmm2, %xmm0
+; CHECK-NEXT:    movapd %xmm0, %xmm3
+; CHECK-NEXT:    movapd %xmm0, %xmm4
+; CHECK-NEXT:    jae .LBB6_4
+; CHECK-NEXT:  # %bb.3: # %entry
+; CHECK-NEXT:    movapd %xmm1, %xmm3
+; CHECK-NEXT:    movapd %xmm2, %xmm4
+; CHECK-NEXT:  .LBB6_4: # %entry
+; CHECK-NEXT:    subsd %xmm3, %xmm0
+; CHECK-NEXT:    addsd %xmm4, %xmm0
 ; CHECK-NEXT:    retq
 entry:
   %c1 = fcmp oge float %p1, 0.000000e+00


### PR DESCRIPTION
The TODO suggests this might cause an infinite loop, but it does not show up in any lit tests.

The TODO was added by Sanjay Patel in 2021 in 985b48f183410