### PR TITLE
[ORC] Drop SimpleExecutorMemoryManagerSymbolNames struct

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h
@@ -46,21 +46,6 @@ LLVM_ABI extern const char *DeregisterJITLoaderGDBAllocActionName;
 LLVM_ABI extern const char *const DispatchName;
 LLVM_ABI extern const char *const DispatchCtxName;
 
-/// Symbol names for memory management implementation.
-/// FIXME: We should find a better home for this struct.
-struct SimpleExecutorMemoryManagerSymbolNames {
-  StringRef AllocatorName;
-  StringRef ReserveName;
-  StringRef InitializeName;
-  StringRef DeinitializeName;
-  StringRef ReleaseName;
-};
-
-/// Default symbol names for the ORC runtime's SimpleNativeMemoryMap SPS
-/// interface.
-extern const LLVM_ABI SimpleExecutorMemoryManagerSymbolNames
-    orc_rt_SimpleNativeMemoryMapSPSSymbols;
-
 /// Symbol names for the ORC runtime's NativeDylibManager SPS interface.
 inline constexpr char NativeDylibManagerInstanceName[] =
     "orc_rt_ci_NativeDylibManager_Instance";

--- a/llvm/lib/ExecutionEngine/Orc/Shared/OrcRTBridge.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Shared/OrcRTBridge.cpp
@@ -47,15 +47,6 @@ const char *DeregisterJITLoaderGDBAllocActionName =
 const char *const DispatchName = "__orc_rt_jit_dispatch";
 const char *const DispatchCtxName = "__orc_rt_jit_dispatch_ctx";
 
-const SimpleExecutorMemoryManagerSymbolNames
-    orc_rt_SimpleNativeMemoryMapSPSSymbols = {
-        "orc_rt_ci_SimpleNativeMemoryMap_Instance",
-        "orc_rt_ci_sps_SimpleNativeMemoryMap_reserve",
-        "orc_rt_ci_sps_SimpleNativeMemoryMap_initialize",
-        "orc_rt_ci_sps_SimpleNativeMemoryMap_deinitializeMultiple",
-        "orc_rt_ci_sps_SimpleNativeMemoryMap_releaseMultiple",
-};
-
 const MachOUnwindInfoRegistrarSymbolNames
     orc_rt_MachOUnwindInfoRegistrarSPSSymbols = {
         "orc_rt_ci_aa_sps_MachOUnwindInfoRegistrar_registerSections",

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/SimpleExecutorMemoryManager.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/SimpleExecutorMemoryManager.cpp
@@ -9,6 +9,7 @@
 #include "llvm/ExecutionEngine/Orc/TargetProcess/SimpleExecutorMemoryManager.h"
 
 #include "llvm/ADT/ScopeExit.h"
+#include "llvm/ExecutionEngine/Orc/RTBridge/SPS/GenericMemoryManagerProxySpecs.h"
 #include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
 #include "llvm/Support/FormatVariadic.h"
 
@@ -213,12 +214,13 @@ void SimpleExecutorMemoryManager::addBootstrapSymbols(
     // FIXME: We should codify a "simple" memory manager interface and make
     // SimpleExecutorMemoryManager its LLVM-based implementation, and
     // SimpleNativeMemoryMap its ORC-runtime implementation.
-    const auto &SNs = rt::orc_rt_SimpleNativeMemoryMapSPSSymbols;
-    M[SNs.AllocatorName] = ExecutorAddr::fromPtr(this);
-    M[SNs.ReserveName] = ExecutorAddr::fromPtr(reserveWrapper);
-    M[SNs.InitializeName] = ExecutorAddr::fromPtr(initializeWrapper);
-    M[SNs.DeinitializeName] = ExecutorAddr::fromPtr(deinitializeWrapper);
-    M[SNs.ReleaseName] = ExecutorAddr::fromPtr(releaseWrapper);
+    namespace sps = rt::sps;
+    M[sps::MemMgrInstanceCIName] = ExecutorAddr::fromPtr(this);
+    M[sps::MemMgrReserveCIName] = ExecutorAddr::fromPtr(reserveWrapper);
+    M[sps::MemMgrInitializeCIName] = ExecutorAddr::fromPtr(initializeWrapper);
+    M[sps::MemMgrDeinitializeCIName] =
+        ExecutorAddr::fromPtr(deinitializeWrapper);
+    M[sps::MemMgrReleaseCIName] = ExecutorAddr::fromPtr(releaseWrapper);
   }
 }
 

--- a/llvm/unittests/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManagerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManagerTest.cpp
@@ -112,19 +112,20 @@ TEST(EPCGenericJITLinkMemoryManagerTest, AllocFinalizeFree) {
 
   // Register the test wrappers in the bootstrap JITDylib under the default
   // SimpleNativeMemoryMap names so that Create resolves its proxies to them.
-  auto &SNs = rt::orc_rt_SimpleNativeMemoryMapSPSSymbols;
+  namespace sps = rt::sps;
   auto Exported = JITSymbolFlags::Exported;
   cantFail(ES.getBootstrapJITDylib().define(absoluteSymbols({
-      {ES.intern(SNs.AllocatorName), {ExecutorAddr::fromPtr(&SA), Exported}},
-      {ES.intern(SNs.ReserveName),
+      {ES.intern(sps::MemMgrInstanceCIName),
+       {ExecutorAddr::fromPtr(&SA), Exported}},
+      {ES.intern(sps::MemMgrReserveCIName),
        {ExecutorAddr::fromPtr(&testReserve), Exported}},
-      {ES.intern(SNs.InitializeName),
+      {ES.intern(sps::MemMgrInitializeCIName),
        {ExecutorAddr::fromPtr(&testInitialize), Exported}},
       // Deinitialize is part of the interface but unused here; the release
       // wrapper (same signature) stands in so the proxy resolves.
-      {ES.intern(SNs.DeinitializeName),
+      {ES.intern(sps::MemMgrDeinitializeCIName),
        {ExecutorAddr::fromPtr(&testRelease), Exported}},
-      {ES.intern(SNs.ReleaseName),
+      {ES.intern(sps::MemMgrReleaseCIName),
        {ExecutorAddr::fromPtr(&testRelease), Exported}},
   })));
 


### PR DESCRIPTION
Remove the SimpleExecutorMemoryManagerSymbolNames struct and the orc_rt_SimpleNativeMemoryMapSPSSymbols global. The sps::MemMgr*CIName constants in GenericMemoryManagerProxySpecs.h are now the single source of truth for the SimpleNativeMemoryMap controller-interface names, used by both the controller-side proxies and the executor-side SimpleExecutorMemoryManager bootstrap registration (as OrcRTBootstrap.cpp already does for the memory-access wrappers).

No functional change: the name strings are identical to those previously held in orc_rt_SimpleNativeMemoryMapSPSSymbols.