### PR TITLE
[InstCombine] Correct handling of `fabs` with `nsz` attribute

### DIFF
--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -6541,7 +6541,7 @@ Value *llvm::simplifyUnaryIntrinsic(Intrinsic::ID IID, Value *Op0,
       return Op0;
 
     if (KnownClass.cannotBeOrderedLessThanZero() &&
-        KnownClass.isKnownNeverNaN() && FMF.noSignedZeros() && 
+        KnownClass.isKnownNeverNaN() && FMF.noSignedZeros() &&
         KnownClass.isKnownNeverNegZero())
       return Op0;
 

--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -6541,7 +6541,8 @@ Value *llvm::simplifyUnaryIntrinsic(Intrinsic::ID IID, Value *Op0,
       return Op0;
 
     if (KnownClass.cannotBeOrderedLessThanZero() &&
-        KnownClass.isKnownNeverNaN() && FMF.noSignedZeros())
+        KnownClass.isKnownNeverNaN() && FMF.noSignedZeros() && 
+        KnownClass.isKnownNeverNegZero())
       return Op0;
 
     break;

--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -3230,6 +3230,10 @@ Instruction *InstCombinerImpl::visitFNeg(UnaryOperator &I) {
     return replaceInstUsesWith(I, Reverse);
   }
 
+  // fneg (abs x) --> fneg (x) if we can prove that x is positive or -0.0 if nsz is set.
+  if (match(OneUse, m_FAbs(m_Value(X))) && SimplifyDemandedInstructionFPClass(I))
+    return &I;
+
   return nullptr;
 }
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -3230,8 +3230,10 @@ Instruction *InstCombinerImpl::visitFNeg(UnaryOperator &I) {
     return replaceInstUsesWith(I, Reverse);
   }
 
-  // fneg (abs x) --> fneg (x) if we can prove that x is positive or -0.0 if nsz is set.
-  if (match(OneUse, m_FAbs(m_Value(X))) && SimplifyDemandedInstructionFPClass(I))
+  // fneg (abs x) --> fneg (x) if we can prove that x is positive or -0.0 if nsz
+  // is set.
+  if (match(OneUse, m_FAbs(m_Value(X))) &&
+      SimplifyDemandedInstructionFPClass(I))
     return &I;
 
   return nullptr;

--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -3230,8 +3230,7 @@ Instruction *InstCombinerImpl::visitFNeg(UnaryOperator &I) {
     return replaceInstUsesWith(I, Reverse);
   }
 
-  // fneg (abs x) --> fneg (x) if we can prove that x is positive or -0.0 if nsz
-  // is set.
+  // fneg (fabs x) --> fneg (x) if we can prove that x is nonnegative (or that x is -0.0 when nsz is set)
   if (match(OneUse, m_FAbs(m_Value(X))) &&
       SimplifyDemandedInstructionFPClass(I))
     return &I;

--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -3230,7 +3230,8 @@ Instruction *InstCombinerImpl::visitFNeg(UnaryOperator &I) {
     return replaceInstUsesWith(I, Reverse);
   }
 
-  // fneg (fabs x) --> fneg (x) if we can prove that x is nonnegative (or that x is -0.0 when nsz is set)
+  // fneg (fabs x) --> fneg (x) if we can prove that x is nonnegative (or that x
+  // is -0.0 when nsz is set)
   if (match(OneUse, m_FAbs(m_Value(X))) &&
       SimplifyDemandedInstructionFPClass(I))
     return &I;

--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -2064,7 +2064,7 @@ static Constant *getFPClassConstant(Type *Ty, FPClassTest Mask,
 /// with the known fpclass if not simplified.
 static Value *simplifyDemandedFPClassFabs(KnownFPClass &Known, Value *Src,
                                           FPClassTest DemandedMask,
-                                          KnownFPClass KnownSrc, bool NSZ) {
+                                          KnownFPClass KnownSrc) {
   if ((DemandedMask & fcNan) == fcNone)
     KnownSrc.knownNot(fcNan);
   if ((DemandedMask & fcInf) == fcNone)
@@ -2072,12 +2072,6 @@ static Value *simplifyDemandedFPClassFabs(KnownFPClass &Known, Value *Src,
 
   if (KnownSrc.SignBit == false ||
       ((DemandedMask & fcNan) == fcNone && KnownSrc.isKnownNever(fcNegative)))
-    return Src;
-
-  // If the only sign bit difference is due to -0, ignore it with nsz
-  // TODO: need to think about this more
-  if (NSZ &&
-      KnownSrc.isKnownNever(KnownFPClass::OrderedLessThanZeroMask | fcNan))
     return Src;
 
   Known = KnownFPClass::fabs(KnownSrc);
@@ -2831,8 +2825,7 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
         return I;
 
       if (Value *Simplified = simplifyDemandedFPClassFabs(
-              Known, CI->getArgOperand(0), DemandedMask, KnownSrc,
-              FMF.noSignedZeros()))
+              Known, CI->getArgOperand(0), DemandedMask, KnownSrc))
         return Simplified;
       break;
     }
@@ -3613,8 +3606,7 @@ Value *InstCombinerImpl::SimplifyMultipleUseDemandedFPClass(
       // NSZ cannot be applied in multiple use case (maybe it could if all uses
       // were known nsz)
       if (Value *Simplified = simplifyDemandedFPClassFabs(
-              Known, CI->getArgOperand(0), DemandedMask, KnownSrc,
-              /*NSZ=*/false))
+              Known, CI->getArgOperand(0), DemandedMask, KnownSrc))
         return Simplified;
       break;
     }

--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -3603,8 +3603,6 @@ Value *InstCombinerImpl::SimplifyMultipleUseDemandedFPClass(
       KnownFPClass KnownSrc =
           computeKnownFPClass(Src, fcAllFlags, SQ, Depth + 1);
 
-      // NSZ cannot be applied in multiple use case (maybe it could if all uses
-      // were known nsz)
       if (Value *Simplified = simplifyDemandedFPClassFabs(
               Known, CI->getArgOperand(0), DemandedMask, KnownSrc))
         return Simplified;

--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -2349,7 +2349,7 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
       FPClassTest ThisDemandedMask =
           adjustDemandedMaskFromFlags(DemandedMask, FabsFMF);
 
-      bool IsNSZ = FMF.noSignedZeros() || FabsFMF.noSignedZeros();
+      bool IsNSZ = FMF.noSignedZeros();
       if (Value *Simplified = simplifyDemandedFPClassFnegFabs(
               Known, FNegFAbsSrc, ThisDemandedMask, KnownSrc, IsNSZ))
         return Simplified;

--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -2075,6 +2075,7 @@ static Value *simplifyDemandedFPClassFabs(KnownFPClass &Known, Value *Src,
     return Src;
 
   // If the only sign bit difference is due to -0, ignore it with nsz
+  // TODO: need to think about this more
   if (NSZ &&
       KnownSrc.isKnownNever(KnownFPClass::OrderedLessThanZeroMask | fcNan))
     return Src;

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass.ll
@@ -592,7 +592,8 @@ define nofpclass(snan) float @fabs_src_known_positive_except_negzero_multiple_us
 define nofpclass(snan) float @fabs_nsz_src_known_positive_except_negzero(float nofpclass(nan ninf nnorm nsub) %always.positive.or.nzero) {
 ; CHECK-LABEL: define nofpclass(snan) float @fabs_nsz_src_known_positive_except_negzero
 ; CHECK-SAME: (float nofpclass(nan ninf nsub nnorm) [[ALWAYS_POSITIVE_OR_NZERO:%.*]]) {
-; CHECK-NEXT:    ret float [[ALWAYS_POSITIVE_OR_NZERO]]
+; CHECK-NEXT:    [[FABS:%.*]] = call nsz float @llvm.fabs.f32(float [[ALWAYS_POSITIVE_OR_NZERO]])
+; CHECK-NEXT:    ret float [[FABS]]
 ;
   %fabs = call nsz float @llvm.fabs.f32(float %always.positive.or.nzero)
   ret float %fabs
@@ -601,8 +602,9 @@ define nofpclass(snan) float @fabs_nsz_src_known_positive_except_negzero(float n
 define nofpclass(snan) float @fabs_nsz_src_known_positive_except_negzero_multiple_uses(float nofpclass(nan ninf nnorm nsub) %always.positive.or.nzero, ptr %ptr) {
 ; CHECK-LABEL: define nofpclass(snan) float @fabs_nsz_src_known_positive_except_negzero_multiple_uses
 ; CHECK-SAME: (float nofpclass(nan ninf nsub nnorm) [[ALWAYS_POSITIVE_OR_NZERO:%.*]], ptr [[PTR:%.*]]) {
-; CHECK-NEXT:    store float [[ALWAYS_POSITIVE_OR_NZERO]], ptr [[PTR]], align 4
-; CHECK-NEXT:    ret float [[ALWAYS_POSITIVE_OR_NZERO]]
+; CHECK-NEXT:    [[FABS:%.*]] = call nsz float @llvm.fabs.f32(float [[ALWAYS_POSITIVE_OR_NZERO]])
+; CHECK-NEXT:    store float [[FABS]], ptr [[PTR]], align 4
+; CHECK-NEXT:    ret float [[FABS]]
 ;
   %fabs = call nsz float @llvm.fabs.f32(float %always.positive.or.nzero)
   store float %fabs, ptr %ptr
@@ -672,9 +674,7 @@ define nofpclass(snan) float @fabs_src_known_negative(float nofpclass(nan pinf p
 define nofpclass(snan) float @fneg_fabs_src_known_negative_multiple_uses(float nofpclass(nan pinf pnorm psub pzero) %always.negative, ptr %ptr) {
 ; CHECK-LABEL: define nofpclass(snan) float @fneg_fabs_src_known_negative_multiple_uses
 ; CHECK-SAME: (float nofpclass(nan pinf pzero psub pnorm) [[ALWAYS_NEGATIVE:%.*]], ptr [[PTR:%.*]]) {
-; CHECK-NEXT:    [[FABS:%.*]] = call float @llvm.fabs.f32(float [[ALWAYS_NEGATIVE]])
-; CHECK-NEXT:    [[FNEG_FABS:%.*]] = fneg float [[FABS]]
-; CHECK-NEXT:    store float [[FNEG_FABS]], ptr [[PTR]], align 4
+; CHECK-NEXT:    store float [[ALWAYS_NEGATIVE]], ptr [[PTR]], align 4
 ; CHECK-NEXT:    ret float [[ALWAYS_NEGATIVE]]
 ;
   %fabs = call float @llvm.fabs.f32(float %always.negative)
@@ -727,9 +727,7 @@ define nofpclass(nan) float @ret_nonan_fneg_fabs_src_known_positive_or_nan_multi
 define nofpclass(snan) float @fneg_nnan_fabs_src_known_negative_or_nan_multiple_uses(float nofpclass(pinf pnorm psub pzero) %always.negative.or.nan, ptr %ptr) {
 ; CHECK-LABEL: define nofpclass(snan) float @fneg_nnan_fabs_src_known_negative_or_nan_multiple_uses
 ; CHECK-SAME: (float nofpclass(pinf pzero psub pnorm) [[ALWAYS_NEGATIVE_OR_NAN:%.*]], ptr [[PTR:%.*]]) {
-; CHECK-NEXT:    [[FABS:%.*]] = call float @llvm.fabs.f32(float [[ALWAYS_NEGATIVE_OR_NAN]])
-; CHECK-NEXT:    [[FNEG_FABS:%.*]] = fneg nnan float [[FABS]]
-; CHECK-NEXT:    store float [[FNEG_FABS]], ptr [[PTR]], align 4
+; CHECK-NEXT:    store float [[ALWAYS_NEGATIVE_OR_NAN]], ptr [[PTR]], align 4
 ; CHECK-NEXT:    ret float [[ALWAYS_NEGATIVE_OR_NAN]]
 ;
   %fabs = call float @llvm.fabs.f32(float %always.negative.or.nan)
@@ -741,9 +739,7 @@ define nofpclass(snan) float @fneg_nnan_fabs_src_known_negative_or_nan_multiple_
 define nofpclass(snan) float @fneg_fabs_nnan_src_known_negative_or_nan_multiple_uses(float nofpclass(pinf pnorm psub pzero) %always.negative.or.nan, ptr %ptr) {
 ; CHECK-LABEL: define nofpclass(snan) float @fneg_fabs_nnan_src_known_negative_or_nan_multiple_uses
 ; CHECK-SAME: (float nofpclass(pinf pzero psub pnorm) [[ALWAYS_NEGATIVE_OR_NAN:%.*]], ptr [[PTR:%.*]]) {
-; CHECK-NEXT:    [[FABS:%.*]] = call nnan float @llvm.fabs.f32(float [[ALWAYS_NEGATIVE_OR_NAN]])
-; CHECK-NEXT:    [[FNEG_FABS:%.*]] = fneg float [[FABS]]
-; CHECK-NEXT:    store float [[FNEG_FABS]], ptr [[PTR]], align 4
+; CHECK-NEXT:    store float [[ALWAYS_NEGATIVE_OR_NAN]], ptr [[PTR]], align 4
 ; CHECK-NEXT:    ret float [[ALWAYS_NEGATIVE_OR_NAN]]
 ;
   %fabs = call nnan float @llvm.fabs.f32(float %always.negative.or.nan)
@@ -770,9 +766,7 @@ define nofpclass(snan) float @fneg_fabs_nofpclass_nan_src__known_negative_or_nan
 define nofpclass(snan) float @ret_fneg_ninf_fabs_src_known_negative_or_posinf_multiple_uses(float nofpclass(nan pnorm psub pzero) %negative.or.neginf, ptr %ptr) {
 ; CHECK-LABEL: define nofpclass(snan) float @ret_fneg_ninf_fabs_src_known_negative_or_posinf_multiple_uses
 ; CHECK-SAME: (float nofpclass(nan pzero psub pnorm) [[NEGATIVE_OR_NEGINF:%.*]], ptr [[PTR:%.*]]) {
-; CHECK-NEXT:    [[FABS:%.*]] = call float @llvm.fabs.f32(float [[NEGATIVE_OR_NEGINF]])
-; CHECK-NEXT:    [[FNEG_FABS:%.*]] = fneg ninf float [[FABS]]
-; CHECK-NEXT:    store float [[FNEG_FABS]], ptr [[PTR]], align 4
+; CHECK-NEXT:    store float [[NEGATIVE_OR_NEGINF]], ptr [[PTR]], align 4
 ; CHECK-NEXT:    ret float [[NEGATIVE_OR_NEGINF]]
 ;
   %fabs = call float @llvm.fabs.f32(float %negative.or.neginf)
@@ -785,9 +779,7 @@ define nofpclass(snan) float @ret_fneg_ninf_fabs_src_known_negative_or_posinf_mu
 define nofpclass(snan) float @ret_fneg_fabs_ninf_src_known_negative_or_posinf_multiple_uses(float nofpclass(nan pnorm psub pzero) %negative.or.neginf, ptr %ptr) {
 ; CHECK-LABEL: define nofpclass(snan) float @ret_fneg_fabs_ninf_src_known_negative_or_posinf_multiple_uses
 ; CHECK-SAME: (float nofpclass(nan pzero psub pnorm) [[NEGATIVE_OR_NEGINF:%.*]], ptr [[PTR:%.*]]) {
-; CHECK-NEXT:    [[FABS:%.*]] = call ninf float @llvm.fabs.f32(float [[NEGATIVE_OR_NEGINF]])
-; CHECK-NEXT:    [[FNEG_FABS:%.*]] = fneg float [[FABS]]
-; CHECK-NEXT:    store float [[FNEG_FABS]], ptr [[PTR]], align 4
+; CHECK-NEXT:    store float [[NEGATIVE_OR_NEGINF]], ptr [[PTR]], align 4
 ; CHECK-NEXT:    ret float [[NEGATIVE_OR_NEGINF]]
 ;
   %fabs = call ninf float @llvm.fabs.f32(float %negative.or.neginf)
@@ -813,7 +805,9 @@ define nofpclass(snan) float @fneg_fabs_src_known_negative_or_poszero_multiple_u
 define nofpclass(snan) float @fneg_fabs_nsz_src_known_negative_or_poszero(float nofpclass(nan pinf pnorm psub) %always.negative.or.pzero) {
 ; CHECK-LABEL: define nofpclass(snan) float @fneg_fabs_nsz_src_known_negative_or_poszero
 ; CHECK-SAME: (float nofpclass(nan pinf psub pnorm) [[ALWAYS_NEGATIVE_OR_PZERO:%.*]]) {
-; CHECK-NEXT:    ret float [[ALWAYS_NEGATIVE_OR_PZERO]]
+; CHECK-NEXT:    [[FABS:%.*]] = call nsz float @llvm.fabs.f32(float [[ALWAYS_NEGATIVE_OR_PZERO]])
+; CHECK-NEXT:    [[FNEG_FABS:%.*]] = fneg float [[FABS]]
+; CHECK-NEXT:    ret float [[FNEG_FABS]]
 ;
   %fabs = call nsz float @llvm.fabs.f32(float %always.negative.or.pzero)
   %fneg.fabs = fneg float %fabs
@@ -875,10 +869,8 @@ define nofpclass(snan) float @fneg_nsz_fabs_src_known_negative_or_poszero(float 
 define nofpclass(snan) float @fneg_nsz_fabs_src_known_negative_or_poszero_multiple_uses(float nofpclass(nan pinf pnorm psub) %always.negative.or.pzero, ptr %ptr) {
 ; CHECK-LABEL: define nofpclass(snan) float @fneg_nsz_fabs_src_known_negative_or_poszero_multiple_uses
 ; CHECK-SAME: (float nofpclass(nan pinf psub pnorm) [[ALWAYS_NEGATIVE_OR_PZERO:%.*]], ptr [[PTR:%.*]]) {
-; CHECK-NEXT:    [[FABS:%.*]] = call float @llvm.fabs.f32(float [[ALWAYS_NEGATIVE_OR_PZERO]])
-; CHECK-NEXT:    [[FNEG_FABS:%.*]] = fneg nsz float [[FABS]]
-; CHECK-NEXT:    store float [[FNEG_FABS]], ptr [[PTR]], align 4
-; CHECK-NEXT:    ret float [[FNEG_FABS]]
+; CHECK-NEXT:    store float [[ALWAYS_NEGATIVE_OR_PZERO]], ptr [[PTR]], align 4
+; CHECK-NEXT:    ret float [[ALWAYS_NEGATIVE_OR_PZERO]]
 ;
   %fabs = call float @llvm.fabs.f32(float %always.negative.or.pzero)
   %fneg.fabs = fneg nsz float %fabs
@@ -976,8 +968,9 @@ define nofpclass(snan) float @fneg_nsz_fabs__known_positive__sign_known_positive
 define nofpclass(snan) float @fneg_nsz_fabs_nsz__known_positive__sign_known_positive_or_negzero_or_nan_multiple_use_fabs(float nofpclass(nan ninf nsub nnorm) %known.positive.or.neg.zero, ptr %ptr) {
 ; CHECK-LABEL: define nofpclass(snan) float @fneg_nsz_fabs_nsz__known_positive__sign_known_positive_or_negzero_or_nan_multiple_use_fabs
 ; CHECK-SAME: (float nofpclass(nan ninf nsub nnorm) [[KNOWN_POSITIVE_OR_NEG_ZERO:%.*]], ptr [[PTR:%.*]]) {
-; CHECK-NEXT:    store float [[KNOWN_POSITIVE_OR_NEG_ZERO]], ptr [[PTR]], align 4
-; CHECK-NEXT:    [[FNEG_FABS:%.*]] = fneg nsz float [[KNOWN_POSITIVE_OR_NEG_ZERO]]
+; CHECK-NEXT:    [[FABS:%.*]] = call nsz float @llvm.fabs.f32(float [[KNOWN_POSITIVE_OR_NEG_ZERO]])
+; CHECK-NEXT:    store float [[FABS]], ptr [[PTR]], align 4
+; CHECK-NEXT:    [[FNEG_FABS:%.*]] = fneg nsz float [[FABS]]
 ; CHECK-NEXT:    ret float [[FNEG_FABS]]
 ;
   %fabs = call nsz float @llvm.fabs.f32(float %known.positive.or.neg.zero)
@@ -1002,7 +995,8 @@ define nofpclass(snan) float @fneg_nsz_fabs_nsz__known_positive__sign_known_posi
 define nofpclass(snan) float @fneg_fabs_nsz__known_positive__sign_known_positive_or_negzero_or_nan(float nofpclass(nan ninf nsub nnorm) %known.positive.or.neg.zero) {
 ; CHECK-LABEL: define nofpclass(snan) float @fneg_fabs_nsz__known_positive__sign_known_positive_or_negzero_or_nan
 ; CHECK-SAME: (float nofpclass(nan ninf nsub nnorm) [[KNOWN_POSITIVE_OR_NEG_ZERO:%.*]]) {
-; CHECK-NEXT:    [[COPYSIGN:%.*]] = fneg float [[KNOWN_POSITIVE_OR_NEG_ZERO]]
+; CHECK-NEXT:    [[FABS:%.*]] = call nsz float @llvm.fabs.f32(float [[KNOWN_POSITIVE_OR_NEG_ZERO]])
+; CHECK-NEXT:    [[COPYSIGN:%.*]] = fneg float [[FABS]]
 ; CHECK-NEXT:    ret float [[COPYSIGN]]
 ;
   %fabs = call nsz float @llvm.fabs.f32(float %known.positive.or.neg.zero)
@@ -1013,8 +1007,9 @@ define nofpclass(snan) float @fneg_fabs_nsz__known_positive__sign_known_positive
 define nofpclass(snan) float @fneg_fabs_nsz__known_positive__sign_known_positive_or_negzero_or_nan__multi_use_fabs(float nofpclass(nan ninf nsub nnorm) %known.positive.or.neg.zero, ptr %ptr) {
 ; CHECK-LABEL: define nofpclass(snan) float @fneg_fabs_nsz__known_positive__sign_known_positive_or_negzero_or_nan__multi_use_fabs
 ; CHECK-SAME: (float nofpclass(nan ninf nsub nnorm) [[KNOWN_POSITIVE_OR_NEG_ZERO:%.*]], ptr [[PTR:%.*]]) {
-; CHECK-NEXT:    store float [[KNOWN_POSITIVE_OR_NEG_ZERO]], ptr [[PTR]], align 4
-; CHECK-NEXT:    [[COPYSIGN:%.*]] = fneg float [[KNOWN_POSITIVE_OR_NEG_ZERO]]
+; CHECK-NEXT:    [[FABS:%.*]] = call nsz float @llvm.fabs.f32(float [[KNOWN_POSITIVE_OR_NEG_ZERO]])
+; CHECK-NEXT:    store float [[FABS]], ptr [[PTR]], align 4
+; CHECK-NEXT:    [[COPYSIGN:%.*]] = fneg float [[FABS]]
 ; CHECK-NEXT:    ret float [[COPYSIGN]]
 ;
   %fabs = call nsz float @llvm.fabs.f32(float %known.positive.or.neg.zero)
@@ -2054,9 +2049,7 @@ define nofpclass(snan) float @copysign_src_known_positive__sign_known_negative_m
 define nofpclass(snan) float @copysign_src_known_negative__sign_known_negative_multiple_use(float nofpclass(nan pinf pnorm psub pzero) %always.negative0, float nofpclass(nan pinf pnorm psub pzero) %always.negative1, ptr %ptr) {
 ; CHECK-LABEL: define nofpclass(snan) float @copysign_src_known_negative__sign_known_negative_multiple_use
 ; CHECK-SAME: (float nofpclass(nan pinf pzero psub pnorm) [[ALWAYS_NEGATIVE0:%.*]], float nofpclass(nan pinf pzero psub pnorm) [[ALWAYS_NEGATIVE1:%.*]], ptr [[PTR:%.*]]) {
-; CHECK-NEXT:    [[TMP1:%.*]] = call float @llvm.fabs.f32(float [[ALWAYS_NEGATIVE0]])
-; CHECK-NEXT:    [[COPYSIGN:%.*]] = fneg float [[TMP1]]
-; CHECK-NEXT:    store float [[COPYSIGN]], ptr [[PTR]], align 4
+; CHECK-NEXT:    store float [[ALWAYS_NEGATIVE0]], ptr [[PTR]], align 4
 ; CHECK-NEXT:    ret float [[ALWAYS_NEGATIVE0]]
 ;
   %copysign = call float @llvm.copysign.f32(float %always.negative0, float %always.negative1)


### PR DESCRIPTION
# Background

PR #180906 clarified the `nsz` semantics to only apply to the input of an instruction. A result of this is that `fabs` instructions must always clear the sign bit of its input, even if the `nsz` flag is present and the input is `-0.0`. 

# Description

- Updated the InstCombine pass to correctly fold `fabs` instructions with `nsz` attribute. Specifically, in the case of `fabs nsz -0.0`, we cannot erase this instruction and replace its uses with `-0.0`, because now its result is `+0.0` under the new `nsz` semantics. 
- Added a special folding for `fnegs(fabs(x))`. This was previously done incorrectly in `InstCombineSimplifyDemanded.cpp`, which leads to missed optimization opportunities and sometimes incorrect optimization.

# Test

Updated checks in `simplify-demanded-fpclass.ll`, which were previously incorrect under the new `nsz` semantics. I didn't add any new lit tests, because I think the existing tests in `simplify-demanded-fpclass.ll` sufficiently cover the cases involving `fabs nsz`. 

Fixes #217505
Assisted-by: Codex