### PR TITLE
[SampleProfile] Move a couple of options to llvm-profdata

### DIFF
--- a/llvm/include/llvm/ProfileData/SampleProfWriter.h
+++ b/llvm/include/llvm/ProfileData/SampleProfWriter.h
@@ -131,7 +131,7 @@ public:
   virtual void setPartialProfile() {}
   virtual void setUseCtxSplitLayout() {}
   virtual void setUseMD5ProfileSymbolList() {}
-  virtual void setWriteEytzingerTables() {}
+  virtual void setUseMD5IndexedTables() {}
 
   void setFormatVersion(uint64_t V) {
     assert(sampleprof::formatVersionIsSupported(V) &&
@@ -317,7 +317,7 @@ public:
 
   void setUseMD5ProfileSymbolList() override { UseMD5ProfSymList = true; }
 
-  void setWriteEytzingerTables() override { UseEytzingerTables = true; }
+  void setUseMD5IndexedTables() override { UseMD5IndexedTables = true; }
 
   void resetSecLayout(SectionLayout SL) {
     verifySecLayout(SL);
@@ -430,9 +430,9 @@ private:
   // Whether to write the profile symbol list as 64-bit MD5 hashes in Eytzinger
   // layout.
   bool UseMD5ProfSymList = false;
-  // Whether to write Eytzinger 3-span layout for NameTable and parallel
-  // FuncOffsetTable.
-  bool UseEytzingerTables = false;
+  // Whether to write MD5-based indexed NameTable and parallel FuncOffsetTable
+  // in Eytzinger layout.
+  bool UseMD5IndexedTables = false;
   size_t NumNested = 0;
   size_t NumFlat = 0;
 

--- a/llvm/include/llvm/ProfileData/SampleProfWriter.h
+++ b/llvm/include/llvm/ProfileData/SampleProfWriter.h
@@ -130,6 +130,8 @@ public:
   virtual void setUseMD5() {}
   virtual void setPartialProfile() {}
   virtual void setUseCtxSplitLayout() {}
+  virtual void setUseMD5ProfileSymbolList() {}
+  virtual void setWriteEytzingerTables() {}
 
   void setFormatVersion(uint64_t V) {
     assert(sampleprof::formatVersionIsSupported(V) &&
@@ -313,6 +315,10 @@ public:
     resetSecLayout(SectionLayout::CtxSplitLayout);
   }
 
+  void setUseMD5ProfileSymbolList() override { UseMD5ProfSymList = true; }
+
+  void setWriteEytzingerTables() override { UseEytzingerTables = true; }
+
   void resetSecLayout(SectionLayout SL) {
     verifySecLayout(SL);
 #ifndef NDEBUG
@@ -421,6 +427,12 @@ private:
   MapVector<SampleContext, uint64_t> FuncOffsetTable;
   // Whether to use MD5 to represent string.
   bool UseMD5 = false;
+  // Whether to write the profile symbol list as 64-bit MD5 hashes in Eytzinger
+  // layout.
+  bool UseMD5ProfSymList = false;
+  // Whether to write Eytzinger 3-span layout for NameTable and parallel
+  // FuncOffsetTable.
+  bool UseEytzingerTables = false;
   size_t NumNested = 0;
   size_t NumFlat = 0;
 

--- a/llvm/lib/ProfileData/SampleProfWriter.cpp
+++ b/llvm/lib/ProfileData/SampleProfWriter.cpp
@@ -270,7 +270,7 @@ SampleProfileWriterExtBinaryBase::writeSample(const FunctionSamples &S) {
 
 std::error_code
 SampleProfileWriterExtBinaryBase::writeFuncOffsetTable(bool IsNested) {
-  if (UseEytzingerTables) {
+  if (UseMD5IndexedTables) {
     // Eytzinger layout requires MD5 representation and does not support
     // multi-context Context-Sensitive profiles.
     if (!UseMD5 || FunctionSamples::ProfileIsCS)
@@ -454,7 +454,7 @@ std::error_code SampleProfileWriterExtBinaryBase::writeNameTableSection(
     }
   }
 
-  if (UseMD5 && UseEytzingerTables) {
+  if (UseMD5 && UseMD5IndexedTables) {
     // Eytzinger name tables do not support CSSPGO profiles
     // (FunctionSamples::ProfileIsCS).
     if (FunctionSamples::ProfileIsCS)
@@ -642,7 +642,7 @@ std::error_code SampleProfileWriterExtBinaryBase::writeOneSection(
                    SecProfSummaryFlags::SecFlagHasVTableTypeProf);
   if (Type == SecProfileSymbolList && UseMD5ProfSymList)
     addSectionFlag(SecProfileSymbolList, SecProfileSymbolListFlags::SecFlagMD5);
-  if (Type == SecNameTable && UseEytzingerTables && UseMD5)
+  if (Type == SecNameTable && UseMD5IndexedTables && UseMD5)
     addSectionFlag(SecNameTable, SecNameTableFlags::SecFlagEytzinger);
 
   uint64_t SectionStart = markSectionStart(Type, LayoutIdx);

--- a/llvm/lib/ProfileData/SampleProfWriter.cpp
+++ b/llvm/lib/ProfileData/SampleProfWriter.cpp
@@ -51,16 +51,6 @@ static cl::opt<uint64_t> RequestedVersion(
     "sample-profile-format-version", cl::init(DefaultVersion), cl::Hidden,
     cl::desc("Format version to write for extensible binary profiles"));
 
-static cl::opt<bool>
-    WriteMD5ProfSymList("md5-prof-sym-list", cl::init(false), cl::Hidden,
-                        cl::desc("Write ProfileSymbolList (Cold Symbols) as "
-                                 "64-bit MD5 hashes in Eytzinger layout"));
-
-static cl::opt<bool> WriteEytzingerNameTables(
-    "sample-profile-write-eytzinger-name-tables", cl::init(false), cl::Hidden,
-    cl::desc("Write Eytzinger 3-span layout for NameTable and parallel "
-             "FuncOffsetTable"));
-
 namespace llvm {
 namespace support {
 namespace endian {
@@ -280,7 +270,7 @@ SampleProfileWriterExtBinaryBase::writeSample(const FunctionSamples &S) {
 
 std::error_code
 SampleProfileWriterExtBinaryBase::writeFuncOffsetTable(bool IsNested) {
-  if (WriteEytzingerNameTables) {
+  if (UseEytzingerTables) {
     // Eytzinger layout requires MD5 representation and does not support
     // multi-context Context-Sensitive profiles.
     if (!UseMD5 || FunctionSamples::ProfileIsCS)
@@ -464,7 +454,7 @@ std::error_code SampleProfileWriterExtBinaryBase::writeNameTableSection(
     }
   }
 
-  if (UseMD5 && WriteEytzingerNameTables) {
+  if (UseMD5 && UseEytzingerTables) {
     // Eytzinger name tables do not support CSSPGO profiles
     // (FunctionSamples::ProfileIsCS).
     if (FunctionSamples::ProfileIsCS)
@@ -595,7 +585,7 @@ std::error_code SampleProfileWriterExtBinaryBase::writeCSNameTableSection() {
 
 std::error_code
 SampleProfileWriterExtBinaryBase::writeProfileSymbolListSection() {
-  if (WriteMD5ProfSymList)
+  if (UseMD5ProfSymList)
     return writeMD5ProfileSymbolListSection();
   return writeStringBasedProfileSymbolListSection();
 }
@@ -650,9 +640,9 @@ std::error_code SampleProfileWriterExtBinaryBase::writeOneSection(
   if (Type == SecProfSummary && ExtBinaryWriteVTableTypeProf)
     addSectionFlag(SecProfSummary,
                    SecProfSummaryFlags::SecFlagHasVTableTypeProf);
-  if (Type == SecProfileSymbolList && WriteMD5ProfSymList)
+  if (Type == SecProfileSymbolList && UseMD5ProfSymList)
     addSectionFlag(SecProfileSymbolList, SecProfileSymbolListFlags::SecFlagMD5);
-  if (Type == SecNameTable && WriteEytzingerNameTables && UseMD5)
+  if (Type == SecNameTable && UseEytzingerTables && UseMD5)
     addSectionFlag(SecNameTable, SecNameTableFlags::SecFlagEytzinger);
 
   uint64_t SectionStart = markSectionStart(Type, LayoutIdx);

--- a/llvm/test/tools/llvm-profdata/cs-sample-profile.test
+++ b/llvm/test/tools/llvm-profdata/cs-sample-profile.test
@@ -5,5 +5,5 @@ RUN: diff -b %t1.proftext %S/Inputs/cs-sample.proftext
 RUN: llvm-profdata show --sample -show-sec-info-only %t.prof | FileCheck %s
 CHECK: FunctionMetadata {{.*}} Flags: {attr}
 
-RUN: not llvm-profdata merge --sample --extbinary --use-md5 --sample-profile-write-eytzinger-name-tables %p/Inputs/cs-sample.proftext -o /dev/null 2>&1 | FileCheck %s --check-prefix=ERR-CS-EYTZ
+RUN: not llvm-profdata merge --sample --extbinary --use-md5 --eytzinger-tables %p/Inputs/cs-sample.proftext -o /dev/null 2>&1 | FileCheck %s --check-prefix=ERR-CS-EYTZ
 ERR-CS-EYTZ: error: {{.*}}Profile encoding format unsupported for writing operations

--- a/llvm/test/tools/llvm-profdata/cs-sample-profile.test
+++ b/llvm/test/tools/llvm-profdata/cs-sample-profile.test
@@ -5,5 +5,5 @@ RUN: diff -b %t1.proftext %S/Inputs/cs-sample.proftext
 RUN: llvm-profdata show --sample -show-sec-info-only %t.prof | FileCheck %s
 CHECK: FunctionMetadata {{.*}} Flags: {attr}
 
-RUN: not llvm-profdata merge --sample --extbinary --use-md5 --eytzinger-tables %p/Inputs/cs-sample.proftext -o /dev/null 2>&1 | FileCheck %s --check-prefix=ERR-CS-EYTZ
+RUN: not llvm-profdata merge --sample --extbinary --use-md5 --md5-indexed-tables %p/Inputs/cs-sample.proftext -o /dev/null 2>&1 | FileCheck %s --check-prefix=ERR-CS-EYTZ
 ERR-CS-EYTZ: error: {{.*}}Profile encoding format unsupported for writing operations

--- a/llvm/test/tools/llvm-profdata/eytzinger-split-nametable-partition.test
+++ b/llvm/test/tools/llvm-profdata/eytzinger-split-nametable-partition.test
@@ -1,5 +1,5 @@
 # RUN: llvm-profdata merge --sample --extbinary --use-md5 --split-layout \
-# RUN:   --sample-profile-write-eytzinger-name-tables %s -o %t.xfdo
+# RUN:   --eytzinger-tables %s -o %t.xfdo
 # RUN: llvm-profdata show --sample --show-sec-info-only %t.xfdo > %t.secinfo
 # RUN: FileCheck %s -input-file %t.secinfo
 # RUN: llvm-profdata merge --sample --text %t.xfdo -o %t.text

--- a/llvm/test/tools/llvm-profdata/eytzinger-split-nametable-partition.test
+++ b/llvm/test/tools/llvm-profdata/eytzinger-split-nametable-partition.test
@@ -1,5 +1,5 @@
 # RUN: llvm-profdata merge --sample --extbinary --use-md5 --split-layout \
-# RUN:   --eytzinger-tables %s -o %t.xfdo
+# RUN:   --md5-indexed-tables %s -o %t.xfdo
 # RUN: llvm-profdata show --sample --show-sec-info-only %t.xfdo > %t.secinfo
 # RUN: FileCheck %s -input-file %t.secinfo
 # RUN: llvm-profdata merge --sample --text %t.xfdo -o %t.text

--- a/llvm/tools/llvm-profdata/llvm-profdata.cpp
+++ b/llvm/tools/llvm-profdata/llvm-profdata.cpp
@@ -237,6 +237,15 @@ static cl::opt<bool> SplitLayout(
     cl::desc("Split the profile to two sections with one containing sample "
              "profiles with inlined functions and the other without (only "
              "meaningful for -extbinary)"));
+static cl::opt<bool>
+    WriteMD5ProfSymList("md5-prof-sym-list", cl::init(false), cl::Hidden,
+                        cl::sub(MergeSubcommand),
+                        cl::desc("Write ProfileSymbolList (Cold Symbols) as "
+                                 "64-bit MD5 hashes in Eytzinger layout"));
+static cl::opt<bool> WriteEytzingerTables(
+    "eytzinger-tables", cl::init(false), cl::Hidden, cl::sub(MergeSubcommand),
+    cl::desc("Write Eytzinger 3-span layout for NameTable and parallel "
+             "FuncOffsetTable"));
 static cl::opt<std::string> SupplInstrWithSample(
     "supplement-instr-with-sample", cl::init(""), cl::Hidden,
     cl::sub(MergeSubcommand),
@@ -1586,6 +1595,18 @@ static void handleExtBinaryWriter(sampleprof::SampleProfileWriter &Writer,
       warn("-gen-partial-profile is ignored. Specify -extbinary to enable it");
     else
       Writer.setPartialProfile();
+  }
+  if (WriteMD5ProfSymList) {
+    if (OutputFormat != PF_Ext_Binary)
+      warn("-md5-prof-sym-list is ignored. Specify -extbinary to enable it");
+    else
+      Writer.setUseMD5ProfileSymbolList();
+  }
+  if (WriteEytzingerTables) {
+    if (OutputFormat != PF_Ext_Binary)
+      warn("-eytzinger-tables is ignored. Specify -extbinary to enable it");
+    else
+      Writer.setWriteEytzingerTables();
   }
 }
 

--- a/llvm/tools/llvm-profdata/llvm-profdata.cpp
+++ b/llvm/tools/llvm-profdata/llvm-profdata.cpp
@@ -242,10 +242,11 @@ static cl::opt<bool>
                         cl::sub(MergeSubcommand),
                         cl::desc("Write ProfileSymbolList (Cold Symbols) as "
                                  "64-bit MD5 hashes in Eytzinger layout"));
-static cl::opt<bool> WriteEytzingerTables(
-    "eytzinger-tables", cl::init(false), cl::Hidden, cl::sub(MergeSubcommand),
-    cl::desc("Write Eytzinger 3-span layout for NameTable and parallel "
-             "FuncOffsetTable"));
+static cl::opt<bool> WriteMD5IndexedTables(
+    "md5-indexed-tables", cl::init(false), cl::Hidden, cl::sub(MergeSubcommand),
+    cl::desc("Write MD5-based indexed NameTable and parallel "
+             "FuncOffsetTable in Eytzinger layout (only meaningful for "
+             "-extbinary)"));
 static cl::opt<std::string> SupplInstrWithSample(
     "supplement-instr-with-sample", cl::init(""), cl::Hidden,
     cl::sub(MergeSubcommand),
@@ -1602,11 +1603,11 @@ static void handleExtBinaryWriter(sampleprof::SampleProfileWriter &Writer,
     else
       Writer.setUseMD5ProfileSymbolList();
   }
-  if (WriteEytzingerTables) {
+  if (WriteMD5IndexedTables) {
     if (OutputFormat != PF_Ext_Binary)
-      warn("-eytzinger-tables is ignored. Specify -extbinary to enable it");
+      warn("-md5-indexed-tables is ignored. Specify -extbinary to enable it");
     else
-      Writer.setWriteEytzingerTables();
+      Writer.setUseMD5IndexedTables();
   }
 }
 

--- a/llvm/unittests/ProfileData/SampleProfTest.cpp
+++ b/llvm/unittests/ProfileData/SampleProfTest.cpp
@@ -198,11 +198,19 @@ struct SampleProfTest : ::testing::Test {
     return Reader->getFormatVersion();
   }
 
-  void testRoundTrip(SampleProfileFormat Format, bool Remap, bool UseMD5) {
+  void testRoundTrip(SampleProfileFormat Format, bool Remap, bool UseMD5,
+                     bool UseMD5ProfSymList = false,
+                     bool UseEytzingerTables = false) {
     TempFile ProfileFile("profile", "", "", /*Unique*/ true);
     createWriter(Format, ProfileFile.path());
-    if (Format == SampleProfileFormat::SPF_Ext_Binary && UseMD5)
-      static_cast<SampleProfileWriterExtBinary *>(Writer.get())->setUseMD5();
+    if (Format == SampleProfileFormat::SPF_Ext_Binary) {
+      if (UseMD5)
+        Writer->setUseMD5();
+      if (UseMD5ProfSymList)
+        Writer->setUseMD5ProfileSymbolList();
+      if (UseEytzingerTables)
+        Writer->setWriteEytzingerTables();
+    }
 
     StringRef FooName("_Z3fooi");
     FunctionSamples FooSamples;
@@ -487,29 +495,13 @@ TEST_F(SampleProfTest, roundtrip_md5_ext_binary_profile) {
 }
 
 TEST_F(SampleProfTest, roundtrip_eytzinger_ext_binary_profile) {
-  const char *Args[] = {"SampleProfTest", "--md5-prof-sym-list=true"};
-  cl::ResetAllOptionOccurrences();
-  cl::ParseCommandLineOptions(2, Args, StringRef(), &llvm::nulls());
-
-  testRoundTrip(SampleProfileFormat::SPF_Ext_Binary, false, false);
-
-  const char *ArgsFalse[] = {"SampleProfTest", "--md5-prof-sym-list=false"};
-  cl::ResetAllOptionOccurrences();
-  cl::ParseCommandLineOptions(2, ArgsFalse, StringRef(), &llvm::nulls());
+  testRoundTrip(SampleProfileFormat::SPF_Ext_Binary, false, false,
+                /*UseMD5ProfSymList=*/true);
 }
 
 TEST_F(SampleProfTest, roundtrip_eytzinger_name_table_ext_binary_profile) {
-  const char *Args[] = {"SampleProfTest",
-                        "--sample-profile-write-eytzinger-name-tables=true"};
-  cl::ResetAllOptionOccurrences();
-  cl::ParseCommandLineOptions(2, Args, StringRef(), &llvm::nulls());
-
-  testRoundTrip(SampleProfileFormat::SPF_Ext_Binary, false, true);
-
-  const char *ArgsFalse[] = {
-      "SampleProfTest", "--sample-profile-write-eytzinger-name-tables=false"};
-  cl::ResetAllOptionOccurrences();
-  cl::ParseCommandLineOptions(2, ArgsFalse, StringRef(), &llvm::nulls());
+  testRoundTrip(SampleProfileFormat::SPF_Ext_Binary, false, true,
+                /*UseMD5ProfSymList=*/false, /*UseEytzingerTables=*/true);
 }
 
 TEST_F(SampleProfTest, remap_text_profile) {

--- a/llvm/unittests/ProfileData/SampleProfTest.cpp
+++ b/llvm/unittests/ProfileData/SampleProfTest.cpp
@@ -200,7 +200,7 @@ struct SampleProfTest : ::testing::Test {
 
   void testRoundTrip(SampleProfileFormat Format, bool Remap, bool UseMD5,
                      bool UseMD5ProfSymList = false,
-                     bool UseEytzingerTables = false) {
+                     bool UseMD5IndexedTables = false) {
     TempFile ProfileFile("profile", "", "", /*Unique*/ true);
     createWriter(Format, ProfileFile.path());
     if (Format == SampleProfileFormat::SPF_Ext_Binary) {
@@ -208,8 +208,8 @@ struct SampleProfTest : ::testing::Test {
         Writer->setUseMD5();
       if (UseMD5ProfSymList)
         Writer->setUseMD5ProfileSymbolList();
-      if (UseEytzingerTables)
-        Writer->setWriteEytzingerTables();
+      if (UseMD5IndexedTables)
+        Writer->setUseMD5IndexedTables();
     }
 
     StringRef FooName("_Z3fooi");
@@ -501,7 +501,7 @@ TEST_F(SampleProfTest, roundtrip_eytzinger_ext_binary_profile) {
 
 TEST_F(SampleProfTest, roundtrip_eytzinger_name_table_ext_binary_profile) {
   testRoundTrip(SampleProfileFormat::SPF_Ext_Binary, false, true,
-                /*UseMD5ProfSymList=*/false, /*UseEytzingerTables=*/true);
+                /*UseMD5ProfSymList=*/false, /*UseMD5IndexedTables=*/true);
 }
 
 TEST_F(SampleProfTest, remap_text_profile) {


### PR DESCRIPTION
This patch moves -md5-prof-sym-list and
-sample-profile-write-eytzinger-name-tables to llvm-profdata.cpp while
renaming the latter to -md5-indexed-tables.

These command line options invoke programmatic setters like
setUseMD5ProfileSymbolList and setUseMD5IndexedTables on the sample
profile writer, much like -use-md5 invokes setUseMD5.  These setters
in turn allow external tools to configure the writer programmatically.
