### PR TITLE
[lldb-dap][NFC] Use wildcard imports for test decorators

### DIFF
--- a/lldb/test/API/tools/lldb-dap/attach-commands/TestDAP_attachCommands.py
+++ b/lldb/test/API/tools/lldb-dap/attach-commands/TestDAP_attachCommands.py
@@ -2,7 +2,7 @@
 Test lldb-dap attach commands
 """
 
-from lldbsuite.test.decorators import skipIfNetBSD, skipIfWasm
+from lldbsuite.test.decorators import *
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.types import AttachArgs, PauseArgs
 

--- a/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
+++ b/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
@@ -7,13 +7,7 @@ import uuid
 from pathlib import Path
 
 from lldbsuite.test import lldbutil
-from lldbsuite.test.decorators import (
-    expectedFailureWindows,
-    expectedFailureWindowsAndNoLLDBServer,
-    requireNotWasm,
-    skipIf,
-    skipIfWindowsAndLLDBServer,
-)
+from lldbsuite.test.decorators import *
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.types import (
     AttachArgs,

--- a/lldb/test/API/tools/lldb-dap/attach/TestDAP_attachByPortNum.py
+++ b/lldb/test/API/tools/lldb-dap/attach/TestDAP_attachByPortNum.py
@@ -6,7 +6,7 @@ from typing import List
 
 from lldbgdbserverutils import Pipe
 from lldbsuite.test import lldbplatformutil
-from lldbsuite.test.decorators import skipIfNetBSD, skipIfWasm, skipIfWindows
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.types import AttachArgs

--- a/lldb/test/API/tools/lldb-dap/breakpoint-assembly/TestDAP_breakpointAssembly.py
+++ b/lldb/test/API/tools/lldb-dap/breakpoint-assembly/TestDAP_breakpointAssembly.py
@@ -2,7 +2,7 @@
 Test lldb-dap setBreakpoints request in assembly source references.
 """
 
-from lldbsuite.test.decorators import skipIfWindows
+from lldbsuite.test.decorators import *
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 

--- a/lldb/test/API/tools/lldb-dap/breakpoint-events/TestDAP_breakpointEvents.py
+++ b/lldb/test/API/tools/lldb-dap/breakpoint-events/TestDAP_breakpointEvents.py
@@ -5,10 +5,7 @@ Test lldb-dap setBreakpoints request
 import os
 from typing import List
 
-from lldbsuite.test.decorators import (
-    skipIfTargetDoesNotSupportSharedLibraries,
-    skipIfWindows,
-)
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.types import (

--- a/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_breakpointLocations.py
+++ b/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_breakpointLocations.py
@@ -4,10 +4,7 @@ Test lldb-dap breakpointLocations request
 
 import os
 
-from lldbsuite.test.decorators import (
-    skipIfTargetDoesNotSupportSharedLibraries,
-    skipIfWindows,
-)
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.types import BreakpointLocation, LaunchArgs

--- a/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_logpoints.py
+++ b/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_logpoints.py
@@ -4,10 +4,7 @@ Test lldb-dap logpoints feature.
 
 import os
 
-from lldbsuite.test.decorators import (
-    skipIfTargetDoesNotSupportSharedLibraries,
-    skipIfWindows,
-)
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase, DAPTestSession
 from lldbsuite.test.tools.lldb_dap.types import (
@@ -15,7 +12,6 @@ from lldbsuite.test.tools.lldb_dap.types import (
     SourceBreakpoint,
     StoppedEvent,
 )
-
 
 @skipIfTargetDoesNotSupportSharedLibraries()
 class TestDAP_logpoints(DAPTestCaseBase):

--- a/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_setBreakpoints.py
+++ b/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_setBreakpoints.py
@@ -6,11 +6,7 @@ import os
 import shutil
 from typing import Dict
 
-from lldbsuite.test.decorators import (
-    skipIfTargetDoesNotSupportSharedLibraries,
-    skipIfWasm,
-    skipIfWindows,
-)
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.types import (

--- a/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_setExceptionBreakpoints.py
+++ b/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_setExceptionBreakpoints.py
@@ -2,10 +2,7 @@
 Test lldb-dap setExceptionBreakpoints request
 """
 
-from lldbsuite.test.decorators import (
-    skipIfTargetDoesNotSupportSharedLibraries,
-    skipIfWindows,
-)
+from lldbsuite.test.decorators import *
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 

--- a/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_setFunctionBreakpoints.py
+++ b/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_setFunctionBreakpoints.py
@@ -2,10 +2,7 @@
 Test lldb-dap setFunctionBreakpoints request
 """
 
-from lldbsuite.test.decorators import (
-    skipIfTargetDoesNotSupportSharedLibraries,
-    skipIfWindows,
-)
+from lldbsuite.test.decorators import *
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.types import (
     DAPTestGetTargetBreakpointsArgs,

--- a/lldb/test/API/tools/lldb-dap/completions/TestDAP_completions.py
+++ b/lldb/test/API/tools/lldb-dap/completions/TestDAP_completions.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from typing import Optional, Union
 
-from lldbsuite.test.decorators import skipIf
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase, DAPTestSession
 from lldbsuite.test.tools.lldb_dap.types import (
@@ -15,7 +15,6 @@ from lldbsuite.test.tools.lldb_dap.types import (
     LaunchArgs,
     StoppedReason,
 )
-
 
 session_completion = CompletionItem(
     label="session",

--- a/lldb/test/API/tools/lldb-dap/console/TestDAP_console.py
+++ b/lldb/test/API/tools/lldb-dap/console/TestDAP_console.py
@@ -6,7 +6,7 @@ import importlib.util
 import os
 import unittest
 
-from lldbsuite.test.decorators import requireNotWindows, requireNotWasm
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase, DAPTestSession

--- a/lldb/test/API/tools/lldb-dap/databreakpoint/TestDAP_setDataBreakpoints.py
+++ b/lldb/test/API/tools/lldb-dap/databreakpoint/TestDAP_setDataBreakpoints.py
@@ -2,7 +2,7 @@
 Test lldb-dap dataBreakpointInfo and setDataBreakpoints requests
 """
 
-from lldbsuite.test.decorators import requireNotWasm, skipIfWindows
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.types import DataBreakpoint, LaunchArgs

--- a/lldb/test/API/tools/lldb-dap/disassemble/TestDAP_disassemble.py
+++ b/lldb/test/API/tools/lldb-dap/disassemble/TestDAP_disassemble.py
@@ -2,7 +2,7 @@
 Test lldb-dap disassemble request
 """
 
-from lldbsuite.test.decorators import skipIfWindows
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase

--- a/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
+++ b/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
@@ -5,7 +5,7 @@ Test lldb-dap evaluate request
 import re
 from typing import Optional, Union
 
-from lldbsuite.test.decorators import skipIfWasm, skipIfWindows
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.session_helpers import ExpectEval, FrameContext

--- a/lldb/test/API/tools/lldb-dap/eventStatistic/TestDAP_eventStatistic.py
+++ b/lldb/test/API/tools/lldb-dap/eventStatistic/TestDAP_eventStatistic.py
@@ -4,11 +4,7 @@ Test lldb-dap terminated event
 
 import json
 
-from lldbsuite.test.decorators import (
-    skipIfRemote,
-    skipIfTargetDoesNotSupportSharedLibraries,
-    skipIfWindows,
-)
+from lldbsuite.test.decorators import *
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.types import InitializedEvent, LaunchArgs
 

--- a/lldb/test/API/tools/lldb-dap/exception/TestDAP_exception.py
+++ b/lldb/test/API/tools/lldb-dap/exception/TestDAP_exception.py
@@ -2,8 +2,8 @@
 Test exception behavior in DAP with signal.
 """
 
+from lldbsuite.test.decorators import *
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
-from lldbsuite.test.decorators import requireSignals
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 
 

--- a/lldb/test/API/tools/lldb-dap/exception/asan/TestDAP_asan.py
+++ b/lldb/test/API/tools/lldb-dap/exception/asan/TestDAP_asan.py
@@ -2,7 +2,7 @@
 Test that we stop at runtime instrumentation locations (asan).
 """
 
-from lldbsuite.test.decorators import skipUnlessAddressSanitizer
+from lldbsuite.test.decorators import *
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 

--- a/lldb/test/API/tools/lldb-dap/exception/cpp/TestDAP_exception_cpp.py
+++ b/lldb/test/API/tools/lldb-dap/exception/cpp/TestDAP_exception_cpp.py
@@ -2,7 +2,7 @@
 Test exception behavior in DAP with c++ throw.
 """
 
-from lldbsuite.test.decorators import skipIfWasm, skipIfWindows
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase

--- a/lldb/test/API/tools/lldb-dap/exception/objc/TestDAP_exception_objc.py
+++ b/lldb/test/API/tools/lldb-dap/exception/objc/TestDAP_exception_objc.py
@@ -2,9 +2,9 @@
 Test exception behavior in DAP with obj-c throw.
 """
 
-from lldbsuite.test.decorators import requireDarwin
-from lldbsuite.test.tools.lldb_dap.types import ExceptionFilterOptions, LaunchArgs
+from lldbsuite.test.decorators import *
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
+from lldbsuite.test.tools.lldb_dap.types import ExceptionFilterOptions, LaunchArgs
 
 
 class TestDAP_exception_objc(DAPTestCaseBase):

--- a/lldb/test/API/tools/lldb-dap/exception/ubsan/TestDAP_ubsan.py
+++ b/lldb/test/API/tools/lldb-dap/exception/ubsan/TestDAP_ubsan.py
@@ -2,7 +2,7 @@
 Test that we stop at runtime instrumentation locations (ubsan).
 """
 
-from lldbsuite.test.decorators import skipUnlessUndefinedBehaviorSanitizer
+from lldbsuite.test.decorators import *
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 

--- a/lldb/test/API/tools/lldb-dap/extendedStackTrace/TestDAP_extendedStackTrace.py
+++ b/lldb/test/API/tools/lldb-dap/extendedStackTrace/TestDAP_extendedStackTrace.py
@@ -4,7 +4,7 @@ Test lldb-dap stackTrace request with an extended backtrace thread.
 
 import os
 
-from lldbsuite.test.decorators import requireDarwin
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbplatformutil import findBacktraceRecordingDylib
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase

--- a/lldb/test/API/tools/lldb-dap/instruction-breakpoint/TestDAP_instruction_breakpoint.py
+++ b/lldb/test/API/tools/lldb-dap/instruction-breakpoint/TestDAP_instruction_breakpoint.py
@@ -4,7 +4,7 @@ Test lldb-dap instruction breakpoints.
 
 import os
 
-from lldbsuite.test.decorators import skipIfWindows
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs

--- a/lldb/test/API/tools/lldb-dap/invalidated-event/TestDAP_invalidatedEvent.py
+++ b/lldb/test/API/tools/lldb-dap/invalidated-event/TestDAP_invalidatedEvent.py
@@ -4,7 +4,7 @@ stack, variables, threads has changes but the client does not
 know about it.
 """
 
-from lldbsuite.test.decorators import skipIfWasm
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_commands.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_commands.py
@@ -2,7 +2,7 @@
 Test lldb-dap launch request.
 """
 
-from lldbsuite.test.decorators import skipIf
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_cwd.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_cwd.py
@@ -4,7 +4,7 @@ Test lldb-dap launch request.
 
 import os
 
-from lldbsuite.test.decorators import skipIfWasm
+from lldbsuite.test.decorators import *
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_disableSTDIO.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_disableSTDIO.py
@@ -2,7 +2,7 @@
 Test lldb-dap launch request.
 """
 
-from lldbsuite.test.decorators import skipIfWindows
+from lldbsuite.test.decorators import *
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_environment_with_array.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_environment_with_array.py
@@ -2,7 +2,7 @@
 Test lldb-dap launch request.
 """
 
-from lldbsuite.test.decorators import skipIfWindows
+from lldbsuite.test.decorators import *
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_environment_with_object.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_environment_with_object.py
@@ -2,7 +2,7 @@
 Test lldb-dap launch request.
 """
 
-from lldbsuite.test.decorators import skipIfWindows
+from lldbsuite.test.decorators import *
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_extra_launch_commands.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_extra_launch_commands.py
@@ -2,7 +2,7 @@
 Test lldb-dap launch request.
 """
 
-from lldbsuite.test.decorators import skipIf
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_shellExpandArguments_enabled.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_shellExpandArguments_enabled.py
@@ -4,7 +4,7 @@ Test lldb-dap launch request.
 
 import os
 
-from lldbsuite.test.decorators import expectedFailureAll, skipIfLinux, skipIfWasm
+from lldbsuite.test.decorators import *
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_stdio_redirection_and_console.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_stdio_redirection_and_console.py
@@ -4,14 +4,7 @@ Test lldb-dap launch request.
 
 import tempfile
 
-from lldbsuite.test.decorators import (
-    no_match,
-    skipIf,
-    skipIfAsan,
-    skipIfBuildType,
-    skipIfWasm,
-    skipIfWindows,
-)
+from lldbsuite.test.decorators import *
 from lldbsuite.test.tools.lldb_dap.types import Console, LaunchArgs
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_terminate_commands.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_terminate_commands.py
@@ -2,7 +2,7 @@
 Test lldb-dap launch request.
 """
 
-from lldbsuite.test.decorators import skipIf, skipIfNetBSD
+from lldbsuite.test.decorators import *
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_win_debug_heap.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_win_debug_heap.py
@@ -2,7 +2,7 @@
 Test lldb-dap launch request.
 """
 
-from lldbsuite.test.decorators import requireWindows, skipIfBuildType
+from lldbsuite.test.decorators import *
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs, Console
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from typing import List

--- a/lldb/test/API/tools/lldb-dap/launch/io/TestDAP_launch_io_integratedTerminal.py
+++ b/lldb/test/API/tools/lldb-dap/launch/io/TestDAP_launch_io_integratedTerminal.py
@@ -3,13 +3,7 @@ Test the redirection after launching in the integrated terminal.
 """
 
 from DAP_launch_io import DAP_launchIO
-from lldbsuite.test.decorators import (
-    skipIfAsan,
-    skipIfBuildType,
-    skipIfRemote,
-    skipIfWasm,
-    skipIfWindows,
-)
+from lldbsuite.test.decorators import *
 from lldbsuite.test.tools.lldb_dap import DAPTestSession
 from lldbsuite.test.tools.lldb_dap.types import Console, RunInTerminalRequest
 

--- a/lldb/test/API/tools/lldb-dap/launch/io/TestDAP_launch_io_internalConsole.py
+++ b/lldb/test/API/tools/lldb-dap/launch/io/TestDAP_launch_io_internalConsole.py
@@ -3,7 +3,7 @@ Test the redirection after launching in the internal console.
 """
 
 from DAP_launch_io import DAP_launchIO
-from lldbsuite.test.decorators import skipIfWindows
+from lldbsuite.test.decorators import *
 from lldbsuite.test.tools.lldb_dap import DAPTestSession
 from lldbsuite.test.tools.lldb_dap.types import Console
 

--- a/lldb/test/API/tools/lldb-dap/locations/TestDAP_locations.py
+++ b/lldb/test/API/tools/lldb-dap/locations/TestDAP_locations.py
@@ -2,7 +2,7 @@
 Test lldb-dap locations request
 """
 
-from lldbsuite.test.decorators import skipIf, skipIfWasm, skipIfWindows
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs

--- a/lldb/test/API/tools/lldb-dap/longpath/TestDAP_launch_longPath.py
+++ b/lldb/test/API/tools/lldb-dap/longpath/TestDAP_launch_longPath.py
@@ -7,7 +7,7 @@ import os
 import shutil
 
 from lldbsuite.test import lldbutil
-from lldbsuite.test.decorators import requireWindows
+from lldbsuite.test.decorators import *
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.types import ExitedEvent, LaunchArgs, TerminatedEvent
 

--- a/lldb/test/API/tools/lldb-dap/memory/TestDAP_memory.py
+++ b/lldb/test/API/tools/lldb-dap/memory/TestDAP_memory.py
@@ -5,9 +5,9 @@ Test lldb-dap memory support
 from base64 import b64decode
 
 from lldbsuite.test.decorators import *
-from lldbsuite.test.lldbtest import *
+from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase, DAPTestSession
-from lldbsuite.test.tools.lldb_dap.types import *
+from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 
 
 class TestDAP_memory(DAPTestCaseBase):

--- a/lldb/test/API/tools/lldb-dap/module-event/TestDAP_module_event.py
+++ b/lldb/test/API/tools/lldb-dap/module-event/TestDAP_module_event.py
@@ -1,10 +1,7 @@
-from lldbsuite.test.decorators import (
-    skipIfTargetDoesNotSupportSharedLibraries,
-    skipIfWindows,
-)
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
-from lldbsuite.test.tools.lldb_dap.types import LaunchArgs, StoppedReason
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
+from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 
 
 @skipIfTargetDoesNotSupportSharedLibraries()

--- a/lldb/test/API/tools/lldb-dap/module/TestDAP_module.py
+++ b/lldb/test/API/tools/lldb-dap/module/TestDAP_module.py
@@ -5,21 +5,15 @@ Test lldb-dap module request
 import platform
 import re
 
-from lldbsuite.test.decorators import (
-    requireDarwin,
-    skipIf,
-    skipIfWindows,
-    skipIfTargetDoesNotSupportSharedLibraries,
-)
-import lldbsuite.test.lldbplatformutil as lldbplatformutil
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
+from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.types import (
     CompileUnitsArgs,
     LaunchArgs,
     ModuleEvent,
     ModuleReason,
 )
-from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 
 
 @skipIfTargetDoesNotSupportSharedLibraries()

--- a/lldb/test/API/tools/lldb-dap/moduleSymbols/TestDAP_moduleSymbols.py
+++ b/lldb/test/API/tools/lldb-dap/moduleSymbols/TestDAP_moduleSymbols.py
@@ -2,7 +2,7 @@
 Test lldb-dap moduleSymbols request
 """
 
-from lldbsuite.test.decorators import skipIfWindows
+from lldbsuite.test.decorators import *
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs, ModuleSymbolsArgs
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 

--- a/lldb/test/API/tools/lldb-dap/optimized/TestDAP_optimized.py
+++ b/lldb/test/API/tools/lldb-dap/optimized/TestDAP_optimized.py
@@ -2,10 +2,10 @@
 Test lldb-dap variables/stackTrace request for optimized code
 """
 
-from lldbsuite.test.decorators import skipIfAsan, skipIfWasm, skipIfWindows
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
-from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
+from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 
 
 class TestDAP_optimized(DAPTestCaseBase):

--- a/lldb/test/API/tools/lldb-dap/output/TestDAP_output.py
+++ b/lldb/test/API/tools/lldb-dap/output/TestDAP_output.py
@@ -2,7 +2,7 @@
 Test lldb-dap output events
 """
 
-from lldbsuite.test.decorators import skipIfWasm, skipIfWindows
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase

--- a/lldb/test/API/tools/lldb-dap/repl-mode/TestDAP_repl_mode_detection.py
+++ b/lldb/test/API/tools/lldb-dap/repl-mode/TestDAP_repl_mode_detection.py
@@ -4,7 +4,7 @@ Test lldb-dap repl mode detection
 
 from typing import Optional
 
-from lldbsuite.test.lldbtest import line_number
+from lldbsuite.test.lldbtest import *
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 

--- a/lldb/test/API/tools/lldb-dap/restart/TestDAP_restart.py
+++ b/lldb/test/API/tools/lldb-dap/restart/TestDAP_restart.py
@@ -2,7 +2,7 @@
 Test lldb-dap RestartRequest.
 """
 
-from lldbsuite.test.decorators import skipIfWindows
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs

--- a/lldb/test/API/tools/lldb-dap/restart/TestDAP_restart_console.py
+++ b/lldb/test/API/tools/lldb-dap/restart/TestDAP_restart_console.py
@@ -2,13 +2,7 @@
 Test lldb-dap RestartRequest.
 """
 
-from lldbsuite.test.decorators import (
-    skipIf,
-    skipIfAsan,
-    skipIfBuildType,
-    skipIfWasm,
-    skipIfWindows,
-)
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.types import Console, LaunchArgs

--- a/lldb/test/API/tools/lldb-dap/send-event/TestDAP_sendEvent.py
+++ b/lldb/test/API/tools/lldb-dap/send-event/TestDAP_sendEvent.py
@@ -6,7 +6,7 @@ import json
 from dataclasses import dataclass
 from typing import List, Optional
 
-from lldbsuite.test.decorators import skipIfWindows
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.types import Event, LaunchArgs, message_to_dict

--- a/lldb/test/API/tools/lldb-dap/server/TestDAP_server.py
+++ b/lldb/test/API/tools/lldb-dap/server/TestDAP_server.py
@@ -33,7 +33,7 @@ class TestDAP_server(lldbdap_testcase.DAPTestCaseBase):
             try:
                 process.stdin.close()
                 process.wait(timeout=5)
-            except TimeoutExpired:
+            except subprocess.TimeoutExpired:
                 process.kill()
 
         self.addTearDownHook(cleanup)

--- a/lldb/test/API/tools/lldb-dap/source/TestDAP_source.py
+++ b/lldb/test/API/tools/lldb-dap/source/TestDAP_source.py
@@ -2,7 +2,7 @@
 Test lldb-dap source request
 """
 
-from lldbsuite.test.decorators import skipIfWindows
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs, Source, SourceArgs

--- a/lldb/test/API/tools/lldb-dap/stackTrace-x86/TestDAP_source_x86.py
+++ b/lldb/test/API/tools/lldb-dap/stackTrace-x86/TestDAP_source_x86.py
@@ -3,7 +3,7 @@ Test lldb-dap stack trace containing x86 assembly
 """
 
 from lldbsuite.test import lldbplatformutil
-from lldbsuite.test.decorators import skipUnlessArch, skipUnlessPlatform
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs

--- a/lldb/test/API/tools/lldb-dap/stackTrace/TestDAP_stackTrace.py
+++ b/lldb/test/API/tools/lldb-dap/stackTrace/TestDAP_stackTrace.py
@@ -5,14 +5,10 @@ Test lldb-dap stackTrace request
 import os
 from typing import List, NamedTuple
 
-from lldbsuite.test.decorators import skipIfWindows
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
-from lldbsuite.test.tools.lldb_dap.types import (
-    LaunchArgs,
-    StackFrame,
-    StackFrameFormat,
-)
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
+from lldbsuite.test.tools.lldb_dap.types import LaunchArgs, StackFrame, StackFrameFormat
 
 
 class _RecurseSource(NamedTuple):

--- a/lldb/test/API/tools/lldb-dap/stackTrace/subtleFrames/TestDAP_subtleFrames.py
+++ b/lldb/test/API/tools/lldb-dap/stackTrace/subtleFrames/TestDAP_subtleFrames.py
@@ -2,7 +2,7 @@
 Test lldb-dap stack trace response
 """
 
-from lldbsuite.test.decorators import add_test_categories
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs

--- a/lldb/test/API/tools/lldb-dap/stackTraceMissingFunctionName/TestDAP_stackTraceMissingFunctionName.py
+++ b/lldb/test/API/tools/lldb-dap/stackTraceMissingFunctionName/TestDAP_stackTraceMissingFunctionName.py
@@ -2,7 +2,7 @@
 Test lldb-dap stack trace response
 """
 
-from lldbsuite.test.decorators import skipIfWasm, skipIfWindows
+from lldbsuite.test.decorators import *
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 

--- a/lldb/test/API/tools/lldb-dap/stackTraceMissingModule/TestDAP_stackTraceMissingModule.py
+++ b/lldb/test/API/tools/lldb-dap/stackTraceMissingModule/TestDAP_stackTraceMissingModule.py
@@ -4,7 +4,7 @@ Test lldb-dap stack trace when module is missing
 
 import re
 
-from lldbsuite.test.decorators import skipUnlessPlatform
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs, StoppedReason
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase

--- a/lldb/test/API/tools/lldb-dap/step/TestDAP_step.py
+++ b/lldb/test/API/tools/lldb-dap/step/TestDAP_step.py
@@ -2,7 +2,7 @@
 Test lldb-dap setBreakpoints request
 """
 
-from lldbsuite.test.decorators import skipIfWindows
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase

--- a/lldb/test/API/tools/lldb-dap/stepInTargets/TestDAP_stepInTargets.py
+++ b/lldb/test/API/tools/lldb-dap/stepInTargets/TestDAP_stepInTargets.py
@@ -2,7 +2,7 @@
 Test lldb-dap stepInTargets request
 """
 
-from lldbsuite.test.decorators import expectedFailureAll, no_match, skipIf
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs, StepInTargetsArgs

--- a/lldb/test/API/tools/lldb-dap/stopped-events/TestDAP_stopped_events.py
+++ b/lldb/test/API/tools/lldb-dap/stopped-events/TestDAP_stopped_events.py
@@ -4,13 +4,7 @@ Test lldb-dap 'stopped' events.
 
 from typing import Sequence
 
-from lldbsuite.test.decorators import (
-    expectedFailureAll,
-    expectedFailureNetBSD,
-    requireThreadSupport,
-    skipIfLinux,
-    skipIfWindows,
-)
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase, DAPTestSession
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs, StoppedEvent, ThreadsArgs

--- a/lldb/test/API/tools/lldb-dap/terminated-event/TestDAP_terminatedEvent.py
+++ b/lldb/test/API/tools/lldb-dap/terminated-event/TestDAP_terminatedEvent.py
@@ -4,10 +4,7 @@ Test lldb-dap terminated event
 
 import json
 
-from lldbsuite.test.decorators import (
-    skipIfTargetDoesNotSupportSharedLibraries,
-    skipIfWindows,
-)
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs

--- a/lldb/test/API/tools/lldb-dap/threads/TestDAP_threads.py
+++ b/lldb/test/API/tools/lldb-dap/threads/TestDAP_threads.py
@@ -2,7 +2,7 @@
 Test lldb-dap threads request
 """
 
-from lldbsuite.test.decorators import requireThreadSupport
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs, StoppedReason, ThreadsArgs

--- a/lldb/test/API/tools/lldb-dap/utils/TestDAPUtils_EventHistory.py
+++ b/lldb/test/API/tools/lldb-dap/utils/TestDAPUtils_EventHistory.py
@@ -1,7 +1,8 @@
 import json
 import threading
-from typing import List, Union
+from typing import List
 
+from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.types import (
     CapabilitiesEvent,
     DAPError,
@@ -14,7 +15,6 @@ from lldbsuite.test.tools.lldb_dap.types import (
     ProgressEndEvent,
     TerminatedEvent,
 )
-from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase
 from lldbsuite.test.tools.lldb_dap.utils import EventHistory
 
 

--- a/lldb/test/API/tools/lldb-dap/variables/TestDAP_variables.py
+++ b/lldb/test/API/tools/lldb-dap/variables/TestDAP_variables.py
@@ -6,12 +6,7 @@ import os
 from typing import List, Optional
 
 from lldbsuite.test import lldbplatformutil
-from lldbsuite.test.decorators import (
-    no_debug_info_test,
-    requireDarwin,
-    skipIfAsan,
-    skipIfWindows,
-)
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap.types import (
     EvaluateContext,

--- a/lldb/test/API/tools/lldb-dap/variables/children/TestDAP_variables_children.py
+++ b/lldb/test/API/tools/lldb-dap/variables/children/TestDAP_variables_children.py
@@ -1,4 +1,4 @@
-from lldbsuite.test.decorators import expectedFailureAll, skipIfWasm
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import line_number
 from lldbsuite.test.tools.lldb_dap.types import LaunchArgs
 from lldbsuite.test.tools.lldb_dap import DAPTestCaseBase


### PR DESCRIPTION
Replace explicit imports `from ... import (a, b, c)` with wildcard imports `from ... import *` for `lldbsuite.test.decorators`,

This lets downstream forks introduce extra decorators (e.g. to skip tests on private configurations) without needing to patch each test's import list.

[Related discourse](https://discourse.llvm.org/t/do-we-want-to-tighten-up-imports-in-the-api-testcases/91557/3)