### PR TITLE
[ProfileData] Remove toCompress and setToCompress from ProfileSymbolList (NFC)

### DIFF
--- a/llvm/include/llvm/ProfileData/SampleProf.h
+++ b/llvm/include/llvm/ProfileData/SampleProf.h
@@ -1704,9 +1704,6 @@ public:
   unsigned size() const { return IsMD5 ? ColdGUIDTable.size() : Syms.size(); }
   void reserve(size_t Size) { Syms.reserve(Size); }
 
-  void setToCompress(bool TC) { ToCompress = TC; }
-  bool toCompress() { return ToCompress; }
-
   std::vector<uint64_t> collectGUIDs() const {
     assert(!IsMD5 &&
            "Collecting GUIDs from existing MD5 table not yet implemented");
@@ -1736,10 +1733,6 @@ public:
 
 private:
   bool IsMD5 = false;
-  // Determine whether or not to compress the symbol list when
-  // writing it into profile. The variable is unused when the symbol
-  // list is read from an existing profile.
-  bool ToCompress = false;
   DenseSet<StringRef> Syms;
   EytzingerTableSpan<support::ulittle64_t> ColdGUIDTable;
   BumpPtrAllocator Allocator;

--- a/llvm/lib/ProfileData/SampleProfWriter.cpp
+++ b/llvm/lib/ProfileData/SampleProfWriter.cpp
@@ -646,8 +646,6 @@ std::error_code SampleProfileWriterExtBinaryBase::writeOneSection(
   SecHdrTableEntry &Entry = SectionHdrLayout[LayoutIdx];
 
   // The setting of SecFlagCompress should happen before markSectionStart.
-  if (Type == SecProfileSymbolList && ProfSymList && ProfSymList->toCompress())
-    setToCompressSection(SecProfileSymbolList);
   if (Type == SecFuncMetadata && FunctionSamples::ProfileIsProbeBased)
     addSectionFlag(SecFuncMetadata, SecFuncMetadataFlags::SecFlagIsProbeBased);
   if (Type == SecFuncMetadata &&


### PR DESCRIPTION
This patch removes toCompress, setToCompress, and ToCompress in
ProfileSymbolList.  Nobody calls setToCompress, so ToCompress is
always false.
