### PR TITLE
[mlir] [linalg] Fuse the producer of an output operand for generic

### DIFF
--- a/mlir/lib/Dialect/Linalg/Transforms/ElementwiseOpFusion.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/ElementwiseOpFusion.cpp
@@ -160,9 +160,14 @@ bool mlir::linalg::areElementwiseOpsFusable(OpOperand *fusedOperand) {
   if (producer.getNumParallelLoops() != producer.getNumLoops())
     return false;
 
-  // Only allow fusing the producer of an input operand for now.
-  // TODO: allow fusing the producer of an output operand.
-  if (!consumer.isDpsInput(fusedOperand))
+  bool isInputFusion = consumer.isDpsInput(fusedOperand);
+  bool isOutputFusion = consumer.isDpsInit(fusedOperand);
+  if (!isInputFusion && !isOutputFusion)
+    return false;
+
+  // Only allow fusing the producer of an output operand with all dimension
+  // in consumer is parallel.
+  if (isOutputFusion && consumer.getNumReductionLoops() != 0)
     return false;
 
   // Get the consumer index map. The number of results of the consumer index
@@ -248,12 +253,16 @@ static void generateFusedElementwiseOpRegion(
       mapper.map(indexOp.getResult(), newIndex);
     }
   }
-  // TODO: allow fusing the producer of an output operand.
-  assert(consumer.isDpsInput(fusedOperand) &&
-         "expected producer of input operand");
+  bool isInputFusion = consumer.isDpsInput(fusedOperand);
+  bool isOutputFusion = consumer.isDpsInit(fusedOperand);
+  assert((isInputFusion || isOutputFusion) &&
+         "expected producer of input or output operand");
   // 3. Consumer input operands up to consumerIdx (exclusive).
-  for (BlockArgument bbArg : consumerBlock.getArguments().take_front(
-           fusedOperand->getOperandNumber())) // input assumption.
+  unsigned numConsumerInputsBeforeProducer =
+      isInputFusion ? fusedOperand->getOperandNumber()
+                    : consumer.getNumDpsInputs();
+  for (BlockArgument bbArg :
+       consumerBlock.getArguments().take_front(numConsumerInputsBeforeProducer))
     mapper.map(bbArg, fusedBlock->addArgument(bbArg.getType(), bbArg.getLoc()));
 
   // Replacing consumerIdx requires getting the cloned, yielded, value from
@@ -265,11 +274,14 @@ static void generateFusedElementwiseOpRegion(
     mapper.map(bbArg, fusedBlock->addArgument(bbArg.getType(), bbArg.getLoc()));
 
   // 5. Remaining consumer's input operands (drop past index `consumerIdx`).
-  for (BlockArgument bbArg :
-       consumerBlock.getArguments()
-           .take_front(consumer.getNumDpsInputs())
-           .drop_front(fusedOperand->getOperandNumber() + 1))
-    mapper.map(bbArg, fusedBlock->addArgument(bbArg.getType(), bbArg.getLoc()));
+  if (isInputFusion) {
+    for (BlockArgument bbArg :
+         consumerBlock.getArguments()
+             .take_front(consumer.getNumDpsInputs())
+             .drop_front(fusedOperand->getOperandNumber() + 1))
+      mapper.map(bbArg,
+                 fusedBlock->addArgument(bbArg.getType(), bbArg.getLoc()));
+  }
 
   // 6. All of the producer's output operands
   for (const auto &bbArg : llvm::enumerate(
@@ -281,9 +293,15 @@ static void generateFusedElementwiseOpRegion(
   }
 
   // 7. All of consumer's output operands.
-  for (BlockArgument bbArg :
-       consumerBlock.getArguments().take_back(consumer.getNumDpsInits()))
-    mapper.map(bbArg, fusedBlock->addArgument(bbArg.getType(), bbArg.getLoc()));
+  for (auto [initIndex, consumerOutputArg] : llvm::enumerate(
+           consumerBlock.getArguments().take_back(consumer.getNumDpsInits()))) {
+    BlockArgument fusedOutputArg = fusedBlock->addArgument(
+        consumerOutputArg.getType(), consumerOutputArg.getLoc());
+    bool replaceWithProducerYield =
+        isOutputFusion && consumer.getDpsInitOperand(initIndex) == fusedOperand;
+    if (!replaceWithProducerYield)
+      mapper.map(consumerOutputArg, fusedOutputArg);
+  }
 
   // 8. Clone all producer operations except for the yield and index operations
   // to the fused operation.
@@ -344,9 +362,10 @@ mlir::linalg::fuseElementwiseOps(RewriterBase &rewriter,
   auto producerResult = cast<OpResult>(fusedOperand->get());
   auto producer = cast<GenericOp>(producerResult.getOwner());
   auto consumer = cast<GenericOp>(fusedOperand->getOwner());
-  // TODO: allow fusing the producer of an output operand.
-  assert(consumer.isDpsInput(fusedOperand) &&
-         "expected producer of input operand");
+  bool isInputFusion = consumer.isDpsInput(fusedOperand);
+  bool isOutputFusion = consumer.isDpsInit(fusedOperand);
+  assert((isInputFusion || isOutputFusion) &&
+         "expected producer of input or output operand");
   /// Find the results of the producer that have uses outside of the consumer,
   /// after the fusion.
   llvm::SmallDenseSet<int> preservedProducerResults =
@@ -368,10 +387,10 @@ mlir::linalg::fuseElementwiseOps(RewriterBase &rewriter,
   // In the following, numbering matches that of `generateFusedTensorOpRegion`.
   // 3. Consumer input operands/maps up to consumerIdx (exclusive).
   auto consumerInputs = consumer.getDpsInputOperands();
-  auto *it = llvm::find_if(consumerInputs, [&](OpOperand *operand) {
-    return operand == fusedOperand;
-  });
-  assert(it != consumerInputs.end() && "expected to find the consumer operand");
+  auto it = isInputFusion ? llvm::find(consumerInputs, fusedOperand)
+                          : consumerInputs.end();
+  assert((!isInputFusion || it != consumerInputs.end()) &&
+         "expected to find the consumer input operand");
   for (OpOperand *opOperand : llvm::make_range(consumerInputs.begin(), it)) {
     fusedInputOperands.push_back(opOperand->get());
     fusedIndexMaps.push_back(consumer.getMatchingIndexingMap(opOperand));
@@ -389,10 +408,12 @@ mlir::linalg::fuseElementwiseOps(RewriterBase &rewriter,
   }
   // 5. Remaining consumer's input operands/maps (drop past index
   // `consumerIdx`).
-  for (OpOperand *opOperand :
-       llvm::make_range(std::next(it), consumerInputs.end())) {
-    fusedInputOperands.push_back(opOperand->get());
-    fusedIndexMaps.push_back(consumer.getMatchingIndexingMap(opOperand));
+  if (isInputFusion) {
+    for (OpOperand *opOperand :
+         llvm::make_range(std::next(it), consumerInputs.end())) {
+      fusedInputOperands.push_back(opOperand->get());
+      fusedIndexMaps.push_back(consumer.getMatchingIndexingMap(opOperand));
+    }
   }
 
   // 6. Collect all of the producer outputs.
@@ -410,7 +431,11 @@ mlir::linalg::fuseElementwiseOps(RewriterBase &rewriter,
 
   // 7. All of consumer's output operands (skip operands: added by the builder).
   for (OpOperand &opOperand : consumer.getDpsInitsMutable()) {
-    fusedOutputOperands.push_back(opOperand.get());
+    Value output = opOperand.get();
+    if (&opOperand == fusedOperand)
+      output =
+          producer.getDpsInitOperand(producerResult.getResultNumber())->get();
+    fusedOutputOperands.push_back(output);
     fusedIndexMaps.push_back(consumer.getMatchingIndexingMap(&opOperand));
     Type resultType = opOperand.get().getType();
     if (!isa<MemRefType>(resultType))

--- a/mlir/test/Dialect/Linalg/fusion-elementwise-ops.mlir
+++ b/mlir/test/Dialect/Linalg/fusion-elementwise-ops.mlir
@@ -1,5 +1,72 @@
 // RUN: mlir-opt %s -linalg-fuse-elementwise-ops -split-input-file | FileCheck %s
 
+// CHECK-LABEL: @output_operand_producer_fusion
+//       CHECK:   %[[FUSED:.+]] = linalg.generic
+//  CHECK-SAME:       ins(%{{.+}}, %{{.+}} : tensor<8xf32>, tensor<8xf32>)
+//       CHECK:     %[[PRODUCED:.+]] = arith.mulf
+//       CHECK:     %[[CONSUMED:.+]] = arith.addf %{{.+}}, %[[PRODUCED]]
+//       CHECK:     linalg.yield %[[CONSUMED]]
+//   CHECK-NOT:   linalg.generic
+//       CHECK:   return %[[FUSED]]
+func.func @output_operand_producer_fusion(
+    %arg0: tensor<8xf32>, %arg1: tensor<8xf32>,
+    %init: tensor<8xf32>) -> tensor<8xf32> {
+  %producer = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>,
+                       affine_map<(d0) -> (d0)>],
+      iterator_types = ["parallel"]}
+      ins(%arg0 : tensor<8xf32>) outs(%init : tensor<8xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %product = arith.mulf %in, %in : f32
+      linalg.yield %product : f32
+  } -> tensor<8xf32>
+  %consumer = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>,
+                       affine_map<(d0) -> (d0)>],
+      iterator_types = ["parallel"]}
+      ins(%arg1 : tensor<8xf32>) outs(%producer : tensor<8xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %sum = arith.addf %in, %out : f32
+      linalg.yield %sum : f32
+  } -> tensor<8xf32>
+  return %consumer : tensor<8xf32>
+}
+
+// -----
+
+// A producer cannot be fused into a reduction init because it would change
+// which value initializes the reduction.
+// CHECK-LABEL: @do_not_fuse_reduction_output_operand
+//       CHECK:   %[[PRODUCER:.+]] = linalg.generic
+//       CHECK:   %[[CONSUMER:.+]] = linalg.generic
+//  CHECK-SAME:       outs(%[[PRODUCER]] : tensor<4xf32>)
+//       CHECK:   return %[[CONSUMER]]
+func.func @do_not_fuse_reduction_output_operand(
+    %arg0: tensor<4xf32>, %arg1: tensor<4x8xf32>,
+    %init: tensor<4xf32>) -> tensor<4xf32> {
+  %producer = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>,
+                       affine_map<(d0) -> (d0)>],
+      iterator_types = ["parallel"]}
+      ins(%arg0 : tensor<4xf32>) outs(%init : tensor<4xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %product = arith.mulf %in, %in : f32
+      linalg.yield %product : f32
+  } -> tensor<4xf32>
+  %consumer = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                       affine_map<(d0, d1) -> (d0)>],
+      iterator_types = ["parallel", "reduction"]}
+      ins(%arg1 : tensor<4x8xf32>) outs(%producer : tensor<4xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %sum = arith.addf %in, %out : f32
+      linalg.yield %sum : f32
+  } -> tensor<4xf32>
+  return %consumer : tensor<4xf32>
+}
+
+// -----
+
 // CHECK-DAG: [[$MAP0:#[a-zA-Z0-9_]*]] = affine_map<(d0, d1) -> (d0, d1)>
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 


### PR DESCRIPTION
This patch fixes a TODO in the source code.

e.g.,

```
  %producer = linalg.generic {
      indexing_maps = [affine_map<(d0) -> (d0)>,
                       affine_map<(d0) -> (d0)>],
      iterator_types = ["parallel"]}
      ins(%arg0 : tensor<8xf32>) outs(%init : tensor<8xf32>) {
    ^bb0(%in: f32, %out: f32):
      %product = arith.mulf %in, %in : f32
      linalg.yield %product : f32
  } -> tensor<8xf32>
  %consumer = linalg.generic {
      indexing_maps = [affine_map<(d0) -> (d0)>,
                       affine_map<(d0) -> (d0)>],
      iterator_types = ["parallel"]}
      ins(%arg1 : tensor<8xf32>) outs(%producer : tensor<8xf32>) {
    ^bb0(%in: f32, %out: f32):
      %sum = arith.addf %in, %out : f32
      linalg.yield %sum : f32
  } -> tensor<8xf32>
```

we can fold them into

```
%fused = linalg.generic {
      indexing_maps = ...,
      iterator_types = ["parallel"]}
      ins(%arg1, %arg0: tensor<8xf32>, tensor<8xf32>)
      outs(%init: tensor<8xf32>) {
    ^bb0(%consumer_in: f32, %producer_in: f32, %fused_out: f32):
      %produced = arith.mulf %producer_in, %producer_in: f32
      %sum = arith.addf %consumer_in, %produced: f32
      linalg.yield %sum: f32
} -> tensor<8xf32>
```

AI assisted.