### PR TITLE
[Support][test] Fix OpenDirectoryAsFileForRead test on AIX and z/OS

### DIFF
--- a/llvm/unittests/Support/Path.cpp
+++ b/llvm/unittests/Support/Path.cpp
@@ -2040,11 +2040,7 @@ TEST_F(FileSystemTest, SetLastAccessAndModificationTimeDirectory) {
 TEST_F(FileSystemTest, OpenDirectoryAsFileForRead) {
   std::string Buf(5, '?');
   Expected<fs::file_t> FD = fs::openNativeFileForRead(TestDirectory);
-#ifdef _WIN32
-  EXPECT_EQ(errorToErrorCode(FD.takeError()), errc::is_a_directory);
-#elif defined(_AIX) || defined(__MVS__)
-  // On AIX and z/OS, open() on a directory with O_RDONLY fails immediately
-  // with EISDIR, unlike Linux where open() succeeds and read() returns EISDIR.
+#if defined(_WIN32) || defined(_AIX) || defined(__MVS__)
   EXPECT_EQ(errorToErrorCode(FD.takeError()), errc::is_a_directory);
 #else
   ASSERT_THAT_EXPECTED(FD, Succeeded());

--- a/llvm/unittests/Support/Path.cpp
+++ b/llvm/unittests/Support/Path.cpp
@@ -2042,6 +2042,10 @@ TEST_F(FileSystemTest, OpenDirectoryAsFileForRead) {
   Expected<fs::file_t> FD = fs::openNativeFileForRead(TestDirectory);
 #ifdef _WIN32
   EXPECT_EQ(errorToErrorCode(FD.takeError()), errc::is_a_directory);
+#elif defined(_AIX) || defined(__MVS__)
+  // On AIX and z/OS, open() on a directory with O_RDONLY fails immediately
+  // with EISDIR, unlike Linux where open() succeeds and read() returns EISDIR.
+  EXPECT_EQ(errorToErrorCode(FD.takeError()), errc::is_a_directory);
 #else
   ASSERT_THAT_EXPECTED(FD, Succeeded());
   scope_exit Close([&] { fs::closeFile(*FD); });


### PR DESCRIPTION
Commit 9c7ba7b1d12e ("[AIX][SystemZ][Support] Check if file is dir on
open instead of read") moved the `fstat`/`EISDIR` check from
`readNativeFile()` to `openNativeFileForRead()` on AIX and z/OS. This
means `openNativeFileForRead()` now returns `EISDIR` immediately on those
platforms, but the test `FileSystemTest.OpenDirectoryAsFileForRead` was
not updated to match, causing it to fail at the
`ASSERT_THAT_EXPECTED(FD, Succeeded())` assertion.

Add a `#elif defined(_AIX) || defined(__MVS__)` branch to the test that
expects the error to be returned from `openNativeFileForRead()` rather
than from `readNativeFile()`, consistent with the behavior introduced by
that commit.