### PR TITLE
clang: Add -fno-diagnostics-show-note-snippets flag

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -210,6 +210,11 @@ features cannot lower the translation-unit ABI level;
 
 ### Improvements to Clang's diagnostics
 
+- Added `-fno-diagnostics-show-note-snippets` (and corresponding
+  `-fdiagnostics-show-note-snippets`, the default) to suppress snippets on
+  notes. Errors and warnings keep printing snippets.  This makes output much
+  shorter for diagnostics with many notes, such as overload resolution failures.
+
 - More consistent rendering of Unicode characters in diagnostic messages.
 
 - Fixed bug in `-Wdocumentation` so that it correctly handles explicit

--- a/clang/docs/UsersManual.md
+++ b/clang/docs/UsersManual.md
@@ -268,6 +268,17 @@ test.c:28:8: warning: extra tokens at end of #endif directive [-Wextra-tokens]
 ```
 :::
 
+:::{option} -f[no-]diagnostics-show-note-snippets
+
+Print source line and caret snippets for note diagnostics.
+This option, which defaults to on, controls whether or not Clang
+prints the source line, source ranges, and caret for notes. When
+disabled, errors and warnings still show their snippets, but notes
+only show their message line. This makes output much shorter for
+diagnostics with many notes, such as overload resolution failures
+or template instantiation backtraces.
+:::
+
 :::{option} -f[no-]color-diagnostics
 
 This option, which defaults to on when a color-capable terminal is

--- a/clang/include/clang/Basic/DiagnosticOptions.def
+++ b/clang/include/clang/Basic/DiagnosticOptions.def
@@ -53,6 +53,7 @@ DIAGOPT(ShowLocation, 1, 1)     /// Show source location information.
 DIAGOPT(ShowLevel, 1, 1)        /// Show diagnostic level.
 DIAGOPT(AbsolutePath, 1, 0)     /// Use absolute paths.
 DIAGOPT(ShowCarets, 1, 1)       /// Show carets in diagnostics.
+DIAGOPT(ShowNoteSnippets, 1, 1) /// Show source snippets for notes.
 DIAGOPT(ShowFixits, 1, 1)       /// Show fixit information.
 DIAGOPT(ShowSourceRanges, 1, 0) /// Show source ranges in numeric form.
 DIAGOPT(ShowParseableFixits, 1, 0) /// Show machine parseable fix-its.

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -2326,6 +2326,12 @@ def fdiagnostics_misexpect_tolerance_EQ : Joined<["-"], "fdiagnostics-misexpect-
     Group<f_Group>, Visibility<[ClangOption, CC1Option]>,
     MetaVarName<"<value>">,
     HelpText<"Prevent misexpect diagnostics from being output if the profile counts are within N% of the expected. ">;
+defm diagnostics_show_note_snippets : BoolFOption<"diagnostics-show-note-snippets",
+    DiagnosticOpts<"ShowNoteSnippets">, DefaultTrue,
+    NegFlag<SetFalse, [], [ClangOption, CC1Option],
+            "Do not show source line and caret snippets for notes">,
+    PosFlag<SetTrue, [], [ClangOption],
+            "Show source line and caret snippets for notes (default)">>;
 defm diagnostics_show_option : BoolFOption<"diagnostics-show-option",
     DiagnosticOpts<"ShowOptionNames">, DefaultTrue,
     NegFlag<SetFalse, [], [ClangOption, CC1Option]>,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4538,6 +4538,8 @@ static void RenderDiagnosticsOptions(const Driver &D, const ArgList &Args,
                     options::OPT_fno_caret_diagnostics, CaretDefault))
     CmdArgs.push_back("-fno-caret-diagnostics");
 
+  Args.addOptOutFlag(CmdArgs, options::OPT_fdiagnostics_show_note_snippets,
+                     options::OPT_fno_diagnostics_show_note_snippets);
   Args.addOptOutFlag(CmdArgs, options::OPT_fdiagnostics_fixit_info,
                      options::OPT_fno_diagnostics_fixit_info);
   Args.addOptOutFlag(CmdArgs, options::OPT_fdiagnostics_show_option,

--- a/clang/lib/Frontend/TextDiagnostic.cpp
+++ b/clang/lib/Frontend/TextDiagnostic.cpp
@@ -1368,6 +1368,10 @@ void TextDiagnostic::emitSnippetAndCaret(
   // multiple times if one loc has multiple diagnostics.
   if (!DiagOpts.ShowCarets)
     return;
+  if (Level == DiagnosticsEngine::Note && !DiagOpts.ShowNoteSnippets) {
+    emitParseableFixits(Hints, Loc.getManager());
+    return;
+  }
   if (Loc == LastLoc && Ranges.empty() && Hints.empty() &&
       (LastLevel != DiagnosticsEngine::Note || Level == LastLevel))
     return;

--- a/clang/test/Driver/fdiagnostics-show-note-snippets.c
+++ b/clang/test/Driver/fdiagnostics-show-note-snippets.c
@@ -1,0 +1,11 @@
+// Default: nothing is passed to cc1.
+// RUN: %clang -### -fsyntax-only %s 2>&1 | FileCheck %s --check-prefix=DEFAULT
+// DEFAULT-NOT: "-fno-diagnostics-show-note-snippets"
+// DEFAULT-NOT: "-fdiagnostics-show-note-snippets"
+
+// RUN: %clang -### -fsyntax-only -fno-diagnostics-show-note-snippets %s 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=DISABLED
+// DISABLED: "-fno-diagnostics-show-note-snippets"
+
+// RUN: %clang -### -fsyntax-only -fno-diagnostics-show-note-snippets \
+// RUN:   -fdiagnostics-show-note-snippets %s 2>&1 | FileCheck %s --check-prefix=DEFAULT

--- a/clang/test/Misc/diag-note-snippets.cpp
+++ b/clang/test/Misc/diag-note-snippets.cpp
@@ -1,0 +1,41 @@
+// By default, both the error and the note show a snippet.
+// RUN: not %clang_cc1 -fsyntax-only %s 2>&1 | FileCheck %s --check-prefix=SNIPPET
+// SNIPPET: error: redefinition of 'x'
+// SNIPPET-NEXT: {{[0-9]+}} | float x;
+// SNIPPET-NEXT: | {{.*}}^
+// SNIPPET-NEXT: note: previous definition is here
+// SNIPPET-NEXT: {{[0-9]+}} | int x;
+// SNIPPET-NEXT: | {{.*}}^
+
+// With -fno-diagnostics-show-note-snippets, the error keeps its snippet but the
+// note only shows its message line.
+// RUN: not %clang_cc1 -fsyntax-only -fno-diagnostics-show-note-snippets %s 2>&1 | FileCheck %s --check-prefix=NOSNIPPET
+// NOSNIPPET: error: redefinition of 'x'
+// NOSNIPPET-NEXT: {{[0-9]+}} | float x;
+// NOSNIPPET-NEXT: | {{.*}}^
+// NOSNIPPET-NEXT: note: previous definition is here
+// NOSNIPPET-NOT: int x;
+// NOSNIPPET: error: no matching function for call to 'f'
+// NOSNIPPET-NEXT: {{[0-9]+}} | f();
+// NOSNIPPET-NEXT: | ^
+// NOSNIPPET-NEXT: note: candidate function not viable
+// NOSNIPPET-NOT: void f(int);
+
+
+// With -fno-diagnostics-show-note-snippets, parseable fixits on notes are still
+// emitted.
+// RUN: not %clang_cc1 -fsyntax-only -fno-diagnostics-show-note-snippets -fdiagnostics-parseable-fixits %s 2>&1 | FileCheck %s --check-prefix=FIXIT
+// FIXIT: warning: using the result of an assignment
+// FIXIT: note: place parentheses around the assignment
+// FIXIT-NEXT: fix-it:{{.*}}diag-note-snippets.cpp
+
+int x;
+float x;
+
+void f(int);
+
+void g(int a) {
+  f();
+  if (a = 5) {
+  }
+}


### PR DESCRIPTION
It disables showing snippets on notes (but not on warnings and errors).