### PR TITLE
Improve diagnostic for malformed constant vectors

### DIFF
--- a/llvm/include/llvm/AsmParser/LLParser.h
+++ b/llvm/include/llvm/AsmParser/LLParser.h
@@ -196,6 +196,7 @@ namespace llvm {
 
     bool SeenNewDbgInfoFormat = false;
     bool SeenOldDbgInfoFormat = false;
+    bool InConstantVector = false;
 
     std::string SourceFileName;
 

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -3234,9 +3234,10 @@ bool LLParser::parseType(Type *&Result, const Twine &Msg, bool AllowVoid) {
     } else if (parseArrayVectorType(Result, true))
       return true;
     if (InConstantVector && Result && Result->isVectorTy())
-      return error(TypeLoc,
-                   "unexpected vector type; constant vector elements should not "
-                   "repeat the type");
+      return error(
+          TypeLoc,
+          "unexpected vector type; constant vector elements should not "
+          "repeat the type");
     break;
   case lltok::LocalVar: {
     // Type ::= %foo
@@ -4211,8 +4212,7 @@ bool LLParser::parseValID(ValID &ID, PerFunctionState *PFS, Type *ExpectedTy) {
     break;
   case lltok::APSInt:
     if (InConstantVector && !ExpectedTy)
-      return error(ID.Loc,
-                   "constant vector elements must begin with a type");
+      return error(ID.Loc, "constant vector elements must begin with a type");
     ID.APSIntVal = Lex.getAPSIntVal();
     ID.Kind = ValID::t_APSInt;
     break;

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -3178,6 +3178,9 @@ bool LLParser::parseType(Type *&Result, const Twine &Msg, bool AllowVoid) {
   SMLoc TypeLoc = Lex.getLoc();
   switch (Lex.getKind()) {
   default:
+    if (InConstantVector && Lex.getKind() == lltok::APSInt)
+      return error(Lex.getLoc(),
+                   "constant vector elements must begin with a type");
     return tokError(Msg);
   case lltok::Type:
     // Type ::= 'float' | 'void' (etc)
@@ -3230,6 +3233,10 @@ bool LLParser::parseType(Type *&Result, const Twine &Msg, bool AllowVoid) {
         return true;
     } else if (parseArrayVectorType(Result, true))
       return true;
+    if (InConstantVector && Result && Result->isVectorTy())
+      return error(TypeLoc,
+                   "unexpected vector type; constant vector elements should not "
+                   "repeat the type");
     break;
   case lltok::LocalVar: {
     // Type ::= %foo
@@ -4203,6 +4210,9 @@ bool LLParser::parseValID(ValID &ID, PerFunctionState *PFS, Type *ExpectedTy) {
     ID.Kind = ValID::t_LocalName;
     break;
   case lltok::APSInt:
+    if (InConstantVector && !ExpectedTy)
+      return error(ID.Loc,
+                   "constant vector elements must begin with a type");
     ID.APSIntVal = Lex.getAPSIntVal();
     ID.Kind = ValID::t_APSInt;
     break;
@@ -4276,16 +4286,15 @@ bool LLParser::parseValID(ValID &ID, PerFunctionState *PFS, Type *ExpectedTy) {
     // ValID ::= '<' '{' ConstVector '}' '>' --> Packed Struct.
     Lex.Lex();
 
-    // guard constant vector elements must begin with a type.
-    if (Lex.getKind() == lltok::APSInt || Lex.getKind() == lltok::Type)
-      return error(Lex.getLoc(),
-                   "constant vector elements must begin with a type");
-
     bool isPackedStruct = EatIfPresent(lltok::lbrace);
 
     SmallVector<Constant*, 16> Elts;
     LocTy FirstEltLoc = Lex.getLoc();
-    if (parseGlobalValueVector(Elts) ||
+    bool SavedInConstantVector = InConstantVector;
+    InConstantVector = true;
+    bool ParseRes = parseGlobalValueVector(Elts);
+    InConstantVector = SavedInConstantVector;
+    if (ParseRes ||
         (isPackedStruct &&
          parseToken(lltok::rbrace, "expected end of packed struct")) ||
         parseToken(lltok::greater, "expected end of constant"))

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -4277,8 +4277,7 @@ bool LLParser::parseValID(ValID &ID, PerFunctionState *PFS, Type *ExpectedTy) {
     Lex.Lex();
 
     // guard constant vector elements must begin with a type.
-    if (Lex.getKind() == lltok::APSInt ||
-        Lex.getKind() == lltok::Type)
+    if (Lex.getKind() == lltok::APSInt || Lex.getKind() == lltok::Type)
       return error(Lex.getLoc(),
                    "constant vector elements must begin with a type");
 

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -4945,13 +4945,24 @@ bool LLParser::parseGlobalValueVector(SmallVectorImpl<Constant *> &Elts) {
     return false;
 
   do {
-    // Let the caller deal with inrange.
     if (Lex.getKind() == lltok::kw_inrange)
       return false;
 
     Constant *C;
-    if (parseGlobalTypeAndValue(C))
-      return true;
+    if (InConstantVector) {
+      Type *Ty = nullptr;
+      bool Saved = InConstantVector;
+      if (parseType(Ty))
+        return true;
+      InConstantVector = false;
+      bool Res = parseGlobalValue(Ty, C);
+      InConstantVector = Saved;
+      if (Res)
+        return true;
+    } else {
+      if (parseGlobalTypeAndValue(C))
+        return true;
+    }
     Elts.push_back(C);
   } while (EatIfPresent(lltok::comma));
 

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -4277,7 +4277,8 @@ bool LLParser::parseValID(ValID &ID, PerFunctionState *PFS, Type *ExpectedTy) {
     Lex.Lex();
 
     // guard constant vector elements must begin with a type.
-    if (Lex.getKind() == lltok::APSInt)
+    if (Lex.getKind() == lltok::APSInt ||
+        Lex.getKind() == lltok::Type)
       return error(Lex.getLoc(),
                    "constant vector elements must begin with a type");
 

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -4278,8 +4278,7 @@ bool LLParser::parseValID(ValID &ID, PerFunctionState *PFS, Type *ExpectedTy) {
 
     // guard constant vector elements must begin with a type.
     if (Lex.getKind() == lltok::APSInt)
-      return error(Lex.getLoc(), "unexpected vector type; constant vector "
-                                 "elements should not repeat the type");
+      return error(Lex.getLoc(), "constant vector elements must begin with a type");
 
     bool isPackedStruct = EatIfPresent(lltok::lbrace);
 

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -4275,6 +4275,12 @@ bool LLParser::parseValID(ValID &ID, PerFunctionState *PFS, Type *ExpectedTy) {
     // ValID ::= '<' ConstVector '>'         --> Vector.
     // ValID ::= '<' '{' ConstVector '}' '>' --> Packed Struct.
     Lex.Lex();
+
+    // guard constant vector elements must begin with a type.
+    if (Lex.getKind() == lltok::APSInt)
+      return error(Lex.getLoc(), "unexpected vector type; constant vector "
+                                 "elements should not repeat the type");
+
     bool isPackedStruct = EatIfPresent(lltok::lbrace);
 
     SmallVector<Constant*, 16> Elts;

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -4278,7 +4278,8 @@ bool LLParser::parseValID(ValID &ID, PerFunctionState *PFS, Type *ExpectedTy) {
 
     // guard constant vector elements must begin with a type.
     if (Lex.getKind() == lltok::APSInt)
-      return error(Lex.getLoc(), "constant vector elements must begin with a type");
+      return error(Lex.getLoc(),
+                   "constant vector elements must begin with a type");
 
     bool isPackedStruct = EatIfPresent(lltok::lbrace);
 

--- a/llvm/test/Assembler/constant-vector-typed-elements.ll
+++ b/llvm/test/Assembler/constant-vector-typed-elements.ll
@@ -1,0 +1,28 @@
+; RUN: llvm-as < %s | llvm-dis | FileCheck %s
+; make sure typed constant vectors still parse fine after the apsint guard
+
+@my_global = external global i32
+
+; CHECK: @g1 = constant <2 x i16> <i16 123, i16 456>
+@g1 = constant <2 x i16> <i16 123, i16 456>
+
+; CHECK: @g2 = constant <2 x float> <float 1.000000e+00, float 2.000000e+00>
+@g2 = constant <2 x float> <float 1.0, float 2.0>
+
+; CHECK: @g3 = constant <{ i32, i32 }> <{ i32 1, i32 2 }>
+@g3 = constant <{ i32, i32 }> <{ i32 1, i32 2 }>
+
+; CHECK: @g4 = constant <2 x ptr> <ptr @my_global, ptr @my_global>
+@g4 = constant <2 x ptr> <ptr @my_global, ptr @my_global>
+
+; CHECK: @g5 = constant <vscale x 2 x i32> <i32 1, i32 2>
+@g5 = constant <vscale x 2 x i32> <i32 1, i32 2>
+
+; CHECK: @g6 = constant <{ i32, ptr, float }> <{ i32 1, ptr @my_global, float 2.000000e+00 }>
+@g6 = constant <{ i32, ptr, float }> <{ i32 1, ptr @my_global, float 2.0 }>
+
+; CHECK: @g7 = constant <4 x i32> splat (i32 7)
+@g7 = constant <4 x i32> splat (i32 7)
+
+; CHECK: @g8 = constant <0 x i32> zeroinitializer
+@g8 = constant <0 x i32> zeroinitializer

--- a/llvm/test/Assembler/constant-vector-typed-elements.ll
+++ b/llvm/test/Assembler/constant-vector-typed-elements.ll
@@ -1,4 +1,5 @@
 ; RUN: llvm-as < %s | llvm-dis | FileCheck %s
+
 ; make sure typed constant vectors still parse fine after the apsint guard
 
 @my_global = external global i32
@@ -15,14 +16,5 @@
 ; CHECK: @g4 = constant <2 x ptr> <ptr @my_global, ptr @my_global>
 @g4 = constant <2 x ptr> <ptr @my_global, ptr @my_global>
 
-; CHECK: @g5 = constant <vscale x 2 x i32> <i32 1, i32 2>
-@g5 = constant <vscale x 2 x i32> <i32 1, i32 2>
-
-; CHECK: @g6 = constant <{ i32, ptr, float }> <{ i32 1, ptr @my_global, float 2.000000e+00 }>
-@g6 = constant <{ i32, ptr, float }> <{ i32 1, ptr @my_global, float 2.0 }>
-
 ; CHECK: @g7 = constant <4 x i32> splat (i32 7)
 @g7 = constant <4 x i32> splat (i32 7)
-
-; CHECK: @g8 = constant <0 x i32> zeroinitializer
-@g8 = constant <0 x i32> zeroinitializer

--- a/llvm/test/Assembler/invalid-constant-vector-repeated-type.ll
+++ b/llvm/test/Assembler/invalid-constant-vector-repeated-type.ll
@@ -1,0 +1,9 @@
+; RUN: not llvm-as < %s 2>&1 | FileCheck %s
+; CHECK: error: unexpected vector type; constant vector elements should not repeat the type
+
+define <2 x i16> @test(<2 x i16> %in) {
+entry:
+  %arst = add <2 x i16> %in,
+      <2 x i16> <i16 123, i16 456>
+  ret <2 x i16> %arst
+}

--- a/llvm/test/Assembler/invalid-constant-vector-repeated-type.ll
+++ b/llvm/test/Assembler/invalid-constant-vector-repeated-type.ll
@@ -1,5 +1,5 @@
 ; RUN: not llvm-as < %s 2>&1 | FileCheck %s
-; CHECK: error: unexpected vector type; constant vector elements should not repeat the type
+; CHECK: error: constant vector elements must begin with a type
 
 define <2 x i16> @test(<2 x i16> %in) {
 entry:


### PR DESCRIPTION
fixes #29043.

improve the diagnostic emitted for malformed constant vectors that begin
with a bare integer literal and add regression tests

-> this is my first PR to this repo - please guide me if i did something wrong here