### PR TITLE
[AMDGPU][GlobalISel] Reject guaranteed tail calls in call lowering

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUCallLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCallLowering.cpp
@@ -1614,8 +1614,14 @@ bool AMDGPUCallLowering::lowerCall(MachineIRBuilder &MIRBuilder,
     splitToValueTypes(Info.OrigRet, InArgs, DL, Info.CallConv);
 
   if (Info.IsTailCall && MF.getTarget().Options.GuaranteedTailCallOpt) {
-    LLVM_DEBUG(dbgs() << "Required tail calls not implemented\n");
-    return false;
+    StringRef CalleeName = Info.Callee.isGlobal()
+                               ? Info.Callee.getGlobal()->getName()
+                               : "<unknown>";
+    F.getContext().diagnose(DiagnosticInfoUnsupported(
+        F, "unsupported required tail call to function " + CalleeName));
+    for (Register ResReg : Info.OrigRet.Regs)
+      MIRBuilder.buildUndef(ResReg);
+    return true;
   }
 
   // If we can lower as a tail call, do that instead.

--- a/llvm/lib/Target/AMDGPU/AMDGPUCallLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCallLowering.cpp
@@ -1484,7 +1484,7 @@ bool AMDGPUCallLowering::lowerTailCall(
   // If we have -tailcallopt, we need to adjust the stack. We'll do the call
   // sequence start and end here.
   if (!IsSibCall) {
-    MIB->getOperand(CalleeIdx + 1).setImm(FPDiff);
+    MIB->getOperand(CalleeIdx + 2).setImm(FPDiff);
     CallSeqStart.addImm(NumBytes).addImm(0);
     // End the call sequence *before* emitting the call. Normally, we would
     // tidy the frame up after the call. However, here, we've laid out the
@@ -1612,6 +1612,11 @@ bool AMDGPUCallLowering::lowerCall(MachineIRBuilder &MIRBuilder,
   SmallVector<ArgInfo, 8> InArgs;
   if (Info.CanLowerReturn && !Info.OrigRet.Ty->isVoidTy())
     splitToValueTypes(Info.OrigRet, InArgs, DL, Info.CallConv);
+
+  if (Info.IsTailCall && MF.getTarget().Options.GuaranteedTailCallOpt) {
+    LLVM_DEBUG(dbgs() << "Required tail calls not implemented\n");
+    return false;
+  }
 
   // If we can lower as a tail call, do that instead.
   bool CanTailCallOpt =

--- a/llvm/test/CodeGen/AMDGPU/unsupported-calls.ll
+++ b/llvm/test/CodeGen/AMDGPU/unsupported-calls.ll
@@ -1,4 +1,5 @@
 ; RUN: not llc -mtriple=amdgpu6.00-mesa-mesa3d -tailcallopt < %s 2>&1 | FileCheck --check-prefix=GCN %s
+; RUN: not llc -global-isel -global-isel-abort=0 -mtriple=amdgpu6.00-mesa-mesa3d -tailcallopt < %s 2>&1 | FileCheck --check-prefix=GCN %s
 ; RUN: not llc -mtriple=amdgpu6.00--amdpal -tailcallopt < %s 2>&1 | FileCheck --check-prefix=GCN %s
 ; RUN: not llc -mtriple=r600-- -mcpu=cypress -tailcallopt < %s 2>&1 | FileCheck -check-prefix=R600 %s
 
@@ -40,6 +41,21 @@ define i32 @test_tail_call(ptr addrspace(1) %out, ptr addrspace(1) %in) {
   %a = load i32, ptr addrspace(1) %in
   %b = load i32, ptr addrspace(1) %b_ptr
   %c = tail call i32 @defined_function(i32 %b)
+  ret i32 %c
+}
+
+define fastcc i32 @defined_fastcc_function(i32 %x) nounwind noinline {
+  %y = add i32 %x, 8
+  ret i32 %y
+}
+
+; GCN: error: <unknown>:0:0: in function test_tail_call_fastcc i32 (ptr addrspace(1), ptr addrspace(1)): unsupported required tail call to function defined_fastcc_function
+; R600: in function test_tail_call_fastcc{{.*}}: unsupported call to function defined_fastcc_function
+define fastcc i32 @test_tail_call_fastcc(ptr addrspace(1) %out, ptr addrspace(1) %in) {
+  %b_ptr = getelementptr i32, ptr addrspace(1) %in, i32 1
+  %a = load i32, ptr addrspace(1) %in
+  %b = load i32, ptr addrspace(1) %b_ptr
+  %c = tail call fastcc i32 @defined_fastcc_function(i32 %b)
   ret i32 %c
 }
 

--- a/llvm/test/CodeGen/AMDGPU/unsupported-calls.ll
+++ b/llvm/test/CodeGen/AMDGPU/unsupported-calls.ll
@@ -1,5 +1,5 @@
 ; RUN: not llc -mtriple=amdgpu6.00-mesa-mesa3d -tailcallopt < %s 2>&1 | FileCheck --check-prefix=GCN %s
-; RUN: not llc -global-isel -global-isel-abort=0 -mtriple=amdgpu6.00-mesa-mesa3d -tailcallopt < %s 2>&1 | FileCheck --check-prefix=GCN %s
+; RUN: not llc -global-isel -mtriple=amdgpu6.00-mesa-mesa3d -tailcallopt < %s 2>&1 | FileCheck --check-prefix=GCN %s
 ; RUN: not llc -mtriple=amdgpu6.00--amdpal -tailcallopt < %s 2>&1 | FileCheck --check-prefix=GCN %s
 ; RUN: not llc -mtriple=r600-- -mcpu=cypress -tailcallopt < %s 2>&1 | FileCheck -check-prefix=R600 %s
 


### PR DESCRIPTION
The FPDiff immediate was being written to the wrong operand, corrupting the callee GlobalAddress

Reject required tail calls like SelectionDAG does, and fix the stale index for the one path that still needs it (cs.chain lowering)