### PR TITLE
[GlobalISel] Remove dead declarations

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/CombinerHelper.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/CombinerHelper.h
@@ -309,11 +309,6 @@ public:
   applyCombineBuildVectorOfBitcast(MachineInstr &MI,
                                    SmallVector<Register> &Ops) const;
 
-  /// Try to combine G_SHUFFLE_VECTOR into G_CONCAT_VECTORS.
-  /// Returns true if MI changed.
-  ///
-  /// \pre MI.getOpcode() == G_SHUFFLE_VECTOR.
-  LLVM_ABI bool tryCombineShuffleVector(MachineInstr &MI) const;
   /// Check if the G_SHUFFLE_VECTOR \p MI can be replaced by a
   /// concat_vectors.
   /// \p Ops will contain the operands needed to produce the flattened

--- a/llvm/include/llvm/CodeGen/GlobalISel/IRTranslator.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/IRTranslator.h
@@ -317,8 +317,6 @@ private:
   bool translateInvoke(const User &U, MachineIRBuilder &MIRBuilder);
 
   bool translateCallBr(const User &U, MachineIRBuilder &MIRBuilder);
-  bool translateCallBrIntrinsic(const CallBrInst &I,
-                                MachineIRBuilder &MIRBuilder);
 
   bool translateLandingPad(const User &U, MachineIRBuilder &MIRBuilder);
 

--- a/llvm/include/llvm/CodeGen/GlobalISel/MachineIRBuilder.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/MachineIRBuilder.h
@@ -1795,41 +1795,6 @@ public:
                                              const SrcOp &Val,
                                              MachineMemOperand &MMO);
 
-  /// Build and insert `OldValRes<def> = G_ATOMICRMW_USUB_COND Addr, Val, MMO`.
-  ///
-  /// Atomically replace the value at \p Addr with the original value minus \p
-  /// Val if the original value is greater than or equal to \p Val, or leaves it
-  /// unchanged otherwise. Puts the original value from \p Addr in \p OldValRes.
-  ///
-  /// \pre setBasicBlock or setMI must have been called.
-  /// \pre \p OldValRes must be a generic virtual register.
-  /// \pre \p Addr must be a generic virtual register with pointer type.
-  /// \pre \p OldValRes, and \p Val must be generic virtual registers of the
-  ///      same type.
-  ///
-  /// \return a MachineInstrBuilder for the newly created instruction.
-  MachineInstrBuilder buildAtomicRMWUSubCond(const DstOp &OldValRes,
-                                             const SrcOp &Addr,
-                                             const SrcOp &Val,
-                                             MachineMemOperand &MMO);
-
-  /// Build and insert `OldValRes<def> = G_ATOMICRMW_USUB_SAT Addr, Val, MMO`.
-  ///
-  /// Atomically replace the value at \p Addr with the original value minus \p
-  /// Val, with clamping to zero if the unsigned subtraction would overflow.
-  /// Puts the original value from \p Addr in \p OldValRes.
-  ///
-  /// \pre setBasicBlock or setMI must have been called.
-  /// \pre \p OldValRes must be a generic virtual register.
-  /// \pre \p Addr must be a generic virtual register with pointer type.
-  /// \pre \p OldValRes, and \p Val must be generic virtual registers of the
-  ///      same type.
-  ///
-  /// \return a MachineInstrBuilder for the newly created instruction.
-  MachineInstrBuilder buildAtomicRMWUSubSat(const DstOp &OldValRes,
-                                            const SrcOp &Addr, const SrcOp &Val,
-                                            MachineMemOperand &MMO);
-
   /// Build and insert `G_FENCE Ordering, Scope`.
   MachineInstrBuilder buildFence(unsigned Ordering, unsigned Scope);
 


### PR DESCRIPTION
tryCombineShuffleVector: The corresponding function definition was
removed on May 20, 2026 in commit
376870209db2e3ad33b082f839a7899c2972cc93.

translateCallBrIntrinsic: Added on December 4, 2025 in commit
e84fdbe1ef09c7c1ed2fab688607cf4b406fb395 without a corresponding
function definition.

buildAtomicRMWUSubCond and buildAtomicRMWUSubSat: Added on September 6,
2024 in commit 4af249fe6e81abd137c95bc25f5060ae305134ca without
corresponding function definitions.
