### PR TITLE
[APINotes] Show API notes warnings in system headers

### DIFF
--- a/clang/include/clang/Basic/DiagnosticCommonKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCommonKinds.td
@@ -425,7 +425,8 @@ def err_module_format_unhandled : Error<
 
 // API notes
 def err_apinotes_message : Error<"%0">;
-def warn_apinotes_message : Warning<"%0">, InGroup<DiagGroup<"apinotes">>;
+def warn_apinotes_message : Warning<"%0">,
+  InGroup<DiagGroup<"apinotes">>, ShowInSystemHeader;
 def note_apinotes_message : Note<"%0">;
 
 class NonportablePrivateAPINotesPath  : Warning<

--- a/clang/test/APINotes/apinotes-warnings-system-headers.cpp
+++ b/clang/test/APINotes/apinotes-warnings-system-headers.cpp
@@ -1,0 +1,28 @@
+// RUN: rm -rf %t && split-file %s %t
+// RUN: %clang_cc1 -fsyntax-only -fapinotes -Wapinotes -isystem %t/SystemHeaderAPINotes %t/test.cpp -x c++ 2>&1 | FileCheck %s
+
+// CHECK: warning: API notes entry for 'systemHeaderUnmatched' has unmatched Where.Parameters [double]
+
+//--- test.cpp
+#include "SystemHeaderAPINotes.h"
+
+//--- SystemHeaderAPINotes/SystemHeaderAPINotes.h
+#ifndef SYSTEM_HEADER_API_NOTES_H
+#define SYSTEM_HEADER_API_NOTES_H
+
+#pragma clang system_header
+
+void systemHeaderUnmatched(int);
+
+#endif // SYSTEM_HEADER_API_NOTES_H
+
+//--- SystemHeaderAPINotes/APINotes.apinotes
+---
+Name: SystemHeaderAPINotes
+Functions:
+- Name: systemHeaderUnmatched
+  Where:
+    Parameters:
+    - double
+  SwiftName: systemHeaderUnmatched(_:)
+...


### PR DESCRIPTION
APINotes are often used for system headers, so warnings emitted through the generic API-notes diagnostic should not be hidden solely because the referenced declaration is in a system header.

This PR sets `ShowInSystemHeader` on `warn_apinotes_message` and adds test coverage for an unmatched `Where.Parameters` warning emitted from a system-header declaration.

This follows up on feedback from https://github.com/llvm/llvm-project/pull/209408#pullrequestreview-4797088847

Reviewers: @Xazax-hun @j-hui @egorzhdan