### PR TITLE
[ORC] Give the SPS controller interface a home in OrcShared

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/SPS/CallProxySpecs.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/SPS/CallProxySpecs.h
@@ -6,8 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// SPS ProxySpecs (signatures, controller-interface names, and dispatch) for the
-// CallProxies.
+// SPS ProxySpecs for the CallProxies: each binds a Proxy to its
+// controller-interface descriptor in Shared/SPSCI/CallSPSCI.h, which supplies
+// the wrapper name and wire signature.
 //
 //===----------------------------------------------------------------------===//
 
@@ -16,42 +17,30 @@
 
 #include "llvm/ExecutionEngine/Orc/RTBridge/CallProxies.h"
 #include "llvm/ExecutionEngine/Orc/RTBridge/SPS/ProxySpec.h"
-
-#include <cstdint>
+#include "llvm/ExecutionEngine/Orc/Shared/SPSCI/CallSPSCI.h"
 
 namespace llvm::orc::rt::sps {
 
-using CallMainSPSSig = int64_t(shared::SPSExecutorAddr,
-                               shared::SPSSequence<shared::SPSString>);
-inline constexpr char CallMainCIName[] = "orc_rt_ci_sps_call_main";
 /// SPS proxy for rt::CallMainProxy: runs a main-like function
 /// (int(int argc, char *argv[])) in the executor.
-using CallMainProxySpec =
-    ProxySpec<rt::CallMainProxy, CallMainSPSSig, CallMainCIName>;
+using CallMainProxySpec = ProxySpec<rt::CallMainProxy, sps_ci::CallMain>;
 
-using CallVoidVoidSPSSig = void(shared::SPSExecutorAddr);
-inline constexpr char CallVoidVoidCIName[] = "orc_rt_ci_sps_call_void_void";
 /// SPS proxy for rt::CallVoidVoidProxy: runs a void() function in the executor.
 /// WARNING: This Proxy is experimental and may be removed.
 using CallVoidVoidProxySpec =
-    ProxySpec<rt::CallVoidVoidProxy, CallVoidVoidSPSSig, CallVoidVoidCIName>;
+    ProxySpec<rt::CallVoidVoidProxy, sps_ci::CallVoidVoid>;
 
-using CallInt32VoidSPSSig = int32_t(shared::SPSExecutorAddr);
-inline constexpr char CallInt32VoidCIName[] = "orc_rt_ci_sps_call_int32_void";
 /// SPS proxy for rt::CallInt32VoidProxy: runs an int32_t() function in the
 /// executor.
 /// WARNING: This Proxy is experimental and may be removed.
 using CallInt32VoidProxySpec =
-    ProxySpec<rt::CallInt32VoidProxy, CallInt32VoidSPSSig, CallInt32VoidCIName>;
+    ProxySpec<rt::CallInt32VoidProxy, sps_ci::CallInt32Void>;
 
-using CallInt32Int32SPSSig = int32_t(shared::SPSExecutorAddr, int32_t);
-inline constexpr char CallInt32Int32CIName[] = "orc_rt_ci_sps_call_int32_int32";
 /// SPS proxy for rt::CallInt32Int32Proxy: runs an int32_t(int32_t) function in
 /// the executor.
 /// WARNING: This Proxy is experimental and may be removed.
 using CallInt32Int32ProxySpec =
-    ProxySpec<rt::CallInt32Int32Proxy, CallInt32Int32SPSSig,
-              CallInt32Int32CIName>;
+    ProxySpec<rt::CallInt32Int32Proxy, sps_ci::CallInt32Int32>;
 
 } // namespace llvm::orc::rt::sps
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/SPS/GenericMemoryManagerProxySpecs.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/SPS/GenericMemoryManagerProxySpecs.h
@@ -6,14 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// SPS ProxySpecs (signatures, controller-interface names, and dispatch) for the
-// GenericMemoryManagerProxies. The controller-interface names here are the
-// runtime's SimpleNativeMemoryMap defaults (the Create methods look symbols up
-// under caller-supplied names).
-//
-// The signatures below duplicate the SPSSimpleExecutorMemoryManager* signatures
-// in OrcRTBridge.h; the intent is to retire those and have callers depend on
-// this header instead.
+// SPS ProxySpecs for the GenericMemoryManagerProxies: each binds a Proxy to
+// its controller-interface descriptor in
+// Shared/SPSCI/SimpleNativeMemoryMapSPSCI.h, which supplies the wrapper name
+// and wire signature. The names are the runtime's SimpleNativeMemoryMap
+// defaults (the Create methods look symbols up under caller-supplied names).
 //
 //===----------------------------------------------------------------------===//
 
@@ -22,46 +19,18 @@
 
 #include "llvm/ExecutionEngine/Orc/RTBridge/GenericMemoryManagerProxies.h"
 #include "llvm/ExecutionEngine/Orc/RTBridge/SPS/ProxySpec.h"
-
-#include <cstdint>
+#include "llvm/ExecutionEngine/Orc/Shared/SPSCI/SimpleNativeMemoryMapSPSCI.h"
 
 namespace llvm::orc::rt::sps {
 
-// Controller-interface name of the SimpleNativeMemoryMap instance: a data
-// symbol (the allocator object) passed as the first argument to each call, not
-// a wrapper to proxy.
-inline constexpr char MemMgrInstanceCIName[] =
-    "orc_rt_ci_SimpleNativeMemoryMap_Instance";
-
-using MemMgrReserveSPSSig = shared::SPSExpected<shared::SPSExecutorAddr>(
-    shared::SPSExecutorAddr, uint64_t);
-inline constexpr char MemMgrReserveCIName[] =
-    "orc_rt_ci_sps_SimpleNativeMemoryMap_reserve";
 using MemMgrReserveProxySpec =
-    ProxySpec<rt::MemMgrReserveProxy, MemMgrReserveSPSSig, MemMgrReserveCIName>;
-
-using MemMgrInitializeSPSSig = shared::SPSExpected<shared::SPSExecutorAddr>(
-    shared::SPSExecutorAddr, shared::SPSFinalizeRequest);
-inline constexpr char MemMgrInitializeCIName[] =
-    "orc_rt_ci_sps_SimpleNativeMemoryMap_initialize";
+    ProxySpec<rt::MemMgrReserveProxy, sps_ci::MemMgrReserve>;
 using MemMgrInitializeProxySpec =
-    ProxySpec<rt::MemMgrInitializeProxy, MemMgrInitializeSPSSig,
-              MemMgrInitializeCIName>;
-
-using MemMgrDeinitializeSPSSig = shared::SPSError(
-    shared::SPSExecutorAddr, shared::SPSSequence<shared::SPSExecutorAddr>);
-inline constexpr char MemMgrDeinitializeCIName[] =
-    "orc_rt_ci_sps_SimpleNativeMemoryMap_deinitializeMultiple";
+    ProxySpec<rt::MemMgrInitializeProxy, sps_ci::MemMgrInitialize>;
 using MemMgrDeinitializeProxySpec =
-    ProxySpec<rt::MemMgrDeinitializeProxy, MemMgrDeinitializeSPSSig,
-              MemMgrDeinitializeCIName>;
-
-using MemMgrReleaseSPSSig = shared::SPSError(
-    shared::SPSExecutorAddr, shared::SPSSequence<shared::SPSExecutorAddr>);
-inline constexpr char MemMgrReleaseCIName[] =
-    "orc_rt_ci_sps_SimpleNativeMemoryMap_releaseMultiple";
+    ProxySpec<rt::MemMgrDeinitializeProxy, sps_ci::MemMgrDeinitialize>;
 using MemMgrReleaseProxySpec =
-    ProxySpec<rt::MemMgrReleaseProxy, MemMgrReleaseSPSSig, MemMgrReleaseCIName>;
+    ProxySpec<rt::MemMgrReleaseProxy, sps_ci::MemMgrRelease>;
 
 } // namespace llvm::orc::rt::sps
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/SPS/MemoryAccessProxySpecs.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/SPS/MemoryAccessProxySpecs.h
@@ -6,8 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// SPS ProxySpecs (signatures, controller-interface names, and dispatch) for the
-// MemoryAccessProxies.
+// SPS ProxySpecs for the MemoryAccessProxies: each binds a Proxy to its
+// controller-interface descriptor in Shared/SPSCI/MemoryAccessSPSCI.h, which
+// supplies the wrapper name and wire signature.
 //
 //===----------------------------------------------------------------------===//
 
@@ -16,107 +17,36 @@
 
 #include "llvm/ExecutionEngine/Orc/RTBridge/MemoryAccessProxies.h"
 #include "llvm/ExecutionEngine/Orc/RTBridge/SPS/ProxySpec.h"
-#include "llvm/ExecutionEngine/Orc/Shared/TargetProcessControlTypes.h"
-
-#include <cstdint>
+#include "llvm/ExecutionEngine/Orc/Shared/SPSCI/MemoryAccessSPSCI.h"
 
 namespace llvm::orc::rt::sps {
 
-using MemWriteUInt8sSPSSig =
-    void(shared::SPSSequence<shared::SPSMemoryAccessUInt8Write>);
-inline constexpr char MemWriteUInt8sCIName[] = "orc_rt_ci_sps_mem_write_uint8s";
 using MemWriteUInt8sProxySpec =
-    ProxySpec<rt::MemWriteUInt8sProxy, MemWriteUInt8sSPSSig,
-              MemWriteUInt8sCIName>;
-
-using MemWriteUInt16sSPSSig =
-    void(shared::SPSSequence<shared::SPSMemoryAccessUInt16Write>);
-inline constexpr char MemWriteUInt16sCIName[] =
-    "orc_rt_ci_sps_mem_write_uint16s";
+    ProxySpec<rt::MemWriteUInt8sProxy, sps_ci::MemWriteUInt8s>;
 using MemWriteUInt16sProxySpec =
-    ProxySpec<rt::MemWriteUInt16sProxy, MemWriteUInt16sSPSSig,
-              MemWriteUInt16sCIName>;
-
-using MemWriteUInt32sSPSSig =
-    void(shared::SPSSequence<shared::SPSMemoryAccessUInt32Write>);
-inline constexpr char MemWriteUInt32sCIName[] =
-    "orc_rt_ci_sps_mem_write_uint32s";
+    ProxySpec<rt::MemWriteUInt16sProxy, sps_ci::MemWriteUInt16s>;
 using MemWriteUInt32sProxySpec =
-    ProxySpec<rt::MemWriteUInt32sProxy, MemWriteUInt32sSPSSig,
-              MemWriteUInt32sCIName>;
-
-using MemWriteUInt64sSPSSig =
-    void(shared::SPSSequence<shared::SPSMemoryAccessUInt64Write>);
-inline constexpr char MemWriteUInt64sCIName[] =
-    "orc_rt_ci_sps_mem_write_uint64s";
+    ProxySpec<rt::MemWriteUInt32sProxy, sps_ci::MemWriteUInt32s>;
 using MemWriteUInt64sProxySpec =
-    ProxySpec<rt::MemWriteUInt64sProxy, MemWriteUInt64sSPSSig,
-              MemWriteUInt64sCIName>;
-
-using MemWritePointersSPSSig =
-    void(shared::SPSSequence<shared::SPSMemoryAccessPointerWrite>);
-inline constexpr char MemWritePointersCIName[] =
-    "orc_rt_ci_sps_mem_write_pointers";
+    ProxySpec<rt::MemWriteUInt64sProxy, sps_ci::MemWriteUInt64s>;
 using MemWritePointersProxySpec =
-    ProxySpec<rt::MemWritePointersProxy, MemWritePointersSPSSig,
-              MemWritePointersCIName>;
-
-using MemWriteBuffersSPSSig =
-    void(shared::SPSSequence<shared::SPSMemoryAccessBufferWrite>);
-inline constexpr char MemWriteBuffersCIName[] =
-    "orc_rt_ci_sps_mem_write_buffers";
+    ProxySpec<rt::MemWritePointersProxy, sps_ci::MemWritePointers>;
 using MemWriteBuffersProxySpec =
-    ProxySpec<rt::MemWriteBuffersProxy, MemWriteBuffersSPSSig,
-              MemWriteBuffersCIName>;
-
-using MemReadUInt8sSPSSig =
-    shared::SPSSequence<uint8_t>(shared::SPSSequence<shared::SPSExecutorAddr>);
-inline constexpr char MemReadUInt8sCIName[] = "orc_rt_ci_sps_mem_read_uint8s";
+    ProxySpec<rt::MemWriteBuffersProxy, sps_ci::MemWriteBuffers>;
 using MemReadUInt8sProxySpec =
-    ProxySpec<rt::MemReadUInt8sProxy, MemReadUInt8sSPSSig, MemReadUInt8sCIName>;
-
-using MemReadUInt16sSPSSig =
-    shared::SPSSequence<uint16_t>(shared::SPSSequence<shared::SPSExecutorAddr>);
-inline constexpr char MemReadUInt16sCIName[] = "orc_rt_ci_sps_mem_read_uint16s";
+    ProxySpec<rt::MemReadUInt8sProxy, sps_ci::MemReadUInt8s>;
 using MemReadUInt16sProxySpec =
-    ProxySpec<rt::MemReadUInt16sProxy, MemReadUInt16sSPSSig,
-              MemReadUInt16sCIName>;
-
-using MemReadUInt32sSPSSig =
-    shared::SPSSequence<uint32_t>(shared::SPSSequence<shared::SPSExecutorAddr>);
-inline constexpr char MemReadUInt32sCIName[] = "orc_rt_ci_sps_mem_read_uint32s";
+    ProxySpec<rt::MemReadUInt16sProxy, sps_ci::MemReadUInt16s>;
 using MemReadUInt32sProxySpec =
-    ProxySpec<rt::MemReadUInt32sProxy, MemReadUInt32sSPSSig,
-              MemReadUInt32sCIName>;
-
-using MemReadUInt64sSPSSig =
-    shared::SPSSequence<uint64_t>(shared::SPSSequence<shared::SPSExecutorAddr>);
-inline constexpr char MemReadUInt64sCIName[] = "orc_rt_ci_sps_mem_read_uint64s";
+    ProxySpec<rt::MemReadUInt32sProxy, sps_ci::MemReadUInt32s>;
 using MemReadUInt64sProxySpec =
-    ProxySpec<rt::MemReadUInt64sProxy, MemReadUInt64sSPSSig,
-              MemReadUInt64sCIName>;
-
-using MemReadPointersSPSSig = shared::SPSSequence<shared::SPSExecutorAddr>(
-    shared::SPSSequence<shared::SPSExecutorAddr>);
-inline constexpr char MemReadPointersCIName[] =
-    "orc_rt_ci_sps_mem_read_pointers";
+    ProxySpec<rt::MemReadUInt64sProxy, sps_ci::MemReadUInt64s>;
 using MemReadPointersProxySpec =
-    ProxySpec<rt::MemReadPointersProxy, MemReadPointersSPSSig,
-              MemReadPointersCIName>;
-
-using MemReadBuffersSPSSig = shared::SPSSequence<shared::SPSSequence<uint8_t>>(
-    shared::SPSSequence<shared::SPSExecutorAddrRange>);
-inline constexpr char MemReadBuffersCIName[] = "orc_rt_ci_sps_mem_read_buffers";
+    ProxySpec<rt::MemReadPointersProxy, sps_ci::MemReadPointers>;
 using MemReadBuffersProxySpec =
-    ProxySpec<rt::MemReadBuffersProxy, MemReadBuffersSPSSig,
-              MemReadBuffersCIName>;
-
-using MemReadStringsSPSSig = shared::SPSSequence<shared::SPSString>(
-    shared::SPSSequence<shared::SPSExecutorAddr>);
-inline constexpr char MemReadStringsCIName[] = "orc_rt_ci_sps_mem_read_strings";
+    ProxySpec<rt::MemReadBuffersProxy, sps_ci::MemReadBuffers>;
 using MemReadStringsProxySpec =
-    ProxySpec<rt::MemReadStringsProxy, MemReadStringsSPSSig,
-              MemReadStringsCIName>;
+    ProxySpec<rt::MemReadStringsProxy, sps_ci::MemReadStrings>;
 
 } // namespace llvm::orc::rt::sps
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/SPS/ProxySpec.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/RTBridge/SPS/ProxySpec.h
@@ -24,14 +24,14 @@
 
 namespace llvm::orc::rt::sps {
 
-template <typename ProxyT, typename SPSSigT, const char *DefaultName,
+template <typename ProxyT, typename CI,
           typename FnType = typename ProxyT::FnType>
 class ProxySpec;
 
-template <typename ProxyT, typename SPSSigT, const char *DefaultName,
-          typename RetT, typename... ArgTs>
-class ProxySpec<ProxyT, SPSSigT, DefaultName, RetT(ArgTs...)> {
+template <typename ProxyT, typename CI, typename RetT, typename... ArgTs>
+class ProxySpec<ProxyT, CI, RetT(ArgTs...)> {
 
+  using SPSSigT = typename CI::SPSSig;
   using CalleeRetT = typename ProxyT::CalleeRetT;
   using ErrorRetT = typename ProxyT::ErrorRetT;
 
@@ -44,7 +44,7 @@ class ProxySpec<ProxyT, SPSSigT, DefaultName, RetT(ArgTs...)> {
   }
 
 public:
-  static constexpr const char *Name = DefaultName;
+  static constexpr const char *Name = CI::Name;
 
   static void dispatch(unique_function<void(ErrorRetT)> OnComplete,
                        ExecutionSession &ES, ExecutorAddr CalleeAddr,

--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h
@@ -15,7 +15,6 @@
 
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorSymbolDef.h"
-#include "llvm/ExecutionEngine/Orc/Shared/SimpleRemoteEPCUtils.h"
 #include "llvm/ExecutionEngine/Orc/Shared/TargetProcessControlTypes.h"
 #include "llvm/Support/Compiler.h"
 
@@ -46,14 +45,6 @@ LLVM_ABI extern const char *DeregisterJITLoaderGDBAllocActionName;
 LLVM_ABI extern const char *const DispatchName;
 LLVM_ABI extern const char *const DispatchCtxName;
 
-/// Symbol names for the ORC runtime's NativeDylibManager SPS interface.
-inline constexpr char NativeDylibManagerInstanceName[] =
-    "orc_rt_ci_NativeDylibManager_Instance";
-inline constexpr char NativeDylibManagerLoadWrapperName[] =
-    "orc_rt_ci_sps_NativeDylibManager_load";
-inline constexpr char NativeDylibManagerLookupWrapperName[] =
-    "orc_rt_ci_sps_NativeDylibManager_lookup";
-
 /// Symbol names for the ORC runtime's StandaloneMachOUnwindInfoRegistrar
 /// SPS interface.
 struct MachOUnwindInfoRegistrarSymbolNames {
@@ -65,15 +56,6 @@ struct MachOUnwindInfoRegistrarSymbolNames {
 /// StandaloneMachOUnwindInfoRegistrar SPS interface.
 extern const LLVM_ABI MachOUnwindInfoRegistrarSymbolNames
     orc_rt_MachOUnwindInfoRegistrarSPSSymbols;
-
-using SPSSimpleExecutorDylibManagerOpenSignature =
-    shared::SPSExpected<shared::SPSExecutorAddr>(shared::SPSExecutorAddr,
-                                                 shared::SPSString, uint64_t);
-
-using SPSSimpleExecutorDylibManagerResolveSignature = shared::SPSExpected<
-    shared::SPSSequence<shared::SPSOptional<shared::SPSExecutorAddr>>>(
-    shared::SPSExecutorAddr, shared::SPSExecutorAddr,
-    shared::SPSRemoteSymbolLookupSet);
 
 using SPSSimpleExecutorMemoryManagerReserveSignature =
     shared::SPSExpected<shared::SPSExecutorAddr>(shared::SPSExecutorAddr,
@@ -101,20 +83,6 @@ using SPSExecutorSharedMemoryMapperServiceDeinitializeSignature =
 using SPSExecutorSharedMemoryMapperServiceReleaseSignature = shared::SPSError(
     shared::SPSExecutorAddr, shared::SPSSequence<shared::SPSExecutorAddr>);
 
-// SimpleNativeMemoryMap APIs.
-using SPSSimpleRemoteMemoryMapReserveSignature =
-    shared::SPSExpected<shared::SPSExecutorAddr>(shared::SPSExecutorAddr,
-                                                 uint64_t);
-using SPSSimpleRemoteMemoryMapInitializeSignature =
-    shared::SPSExpected<shared::SPSExecutorAddr>(shared::SPSExecutorAddr,
-                                                 shared::SPSFinalizeRequest);
-using SPSSimpleRemoteMemoryMapDeinitializeSignature = shared::SPSError(
-    shared::SPSExecutorAddr, shared::SPSSequence<shared::SPSExecutorAddr>);
-using SPSSimpleRemoteMemoryMapReleaseSignature = shared::SPSError(
-    shared::SPSExecutorAddr, shared::SPSSequence<shared::SPSExecutorAddr>);
-
-using SPSRunAsMainSignature = int64_t(shared::SPSExecutorAddr,
-                                      shared::SPSSequence<shared::SPSString>);
 } // end namespace rt
 
 namespace rt_alt {

--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/SPSCI/CallSPSCI.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/SPSCI/CallSPSCI.h
@@ -1,0 +1,60 @@
+//===----- CallSPSCI.h - SPS CI for running functions -----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// SPS controller-interface descriptors for running functions in the executor.
+//
+// Each descriptor names one operation in the runtime's SPS controller
+// interface and gives its wire signature. This is the contract between the
+// party that implements the operation (the ORC runtime, or LLVM's
+// OrcTargetProcess) and the party that calls it (the ORC controller), so it
+// must not depend on either side's implementation.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_EXECUTIONENGINE_ORC_SHARED_SPSCI_CALLSPSCI_H
+#define LLVM_EXECUTIONENGINE_ORC_SHARED_SPSCI_CALLSPSCI_H
+
+#include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
+#include "llvm/ExecutionEngine/Orc/Shared/SimplePackedSerialization.h"
+
+#include <cstdint>
+
+namespace llvm::orc::rt::sps_ci {
+
+/// Runs a main-like function (int(int argc, char *argv[])) in the executor.
+/// Takes the function's address and an argument vector.
+struct CallMain {
+  static constexpr char Name[] = "orc_rt_ci_sps_call_main";
+  using SPSSig = int64_t(shared::SPSExecutorAddr,
+                         shared::SPSSequence<shared::SPSString>);
+};
+
+/// Runs a void() function in the executor, given its address.
+/// WARNING: This operation is experimental and may be removed.
+struct CallVoidVoid {
+  static constexpr char Name[] = "orc_rt_ci_sps_call_void_void";
+  using SPSSig = void(shared::SPSExecutorAddr);
+};
+
+/// Runs an int32_t() function in the executor, given its address.
+/// WARNING: This operation is experimental and may be removed.
+struct CallInt32Void {
+  static constexpr char Name[] = "orc_rt_ci_sps_call_int32_void";
+  using SPSSig = int32_t(shared::SPSExecutorAddr);
+};
+
+/// Runs an int32_t(int32_t) function in the executor, given its address.
+/// WARNING: This operation is experimental and may be removed.
+struct CallInt32Int32 {
+  static constexpr char Name[] = "orc_rt_ci_sps_call_int32_int32";
+  using SPSSig = int32_t(shared::SPSExecutorAddr, int32_t);
+};
+
+} // namespace llvm::orc::rt::sps_ci
+
+#endif // LLVM_EXECUTIONENGINE_ORC_SHARED_SPSCI_CALLSPSCI_H

--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/SPSCI/MemoryAccessSPSCI.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/SPSCI/MemoryAccessSPSCI.h
@@ -1,0 +1,102 @@
+//===--- MemoryAccessSPSCI.h - SPS CI for memory access ---------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// SPS controller-interface descriptors for the executor's memory-access
+// operations. These wrappers perform the operation directly, so they take the
+// operation's data arguments rather than a callee address.
+//
+// See CallSPSCI.h for a description of the descriptor scheme.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_EXECUTIONENGINE_ORC_SHARED_SPSCI_MEMORYACCESSSPSCI_H
+#define LLVM_EXECUTIONENGINE_ORC_SHARED_SPSCI_MEMORYACCESSSPSCI_H
+
+#include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
+#include "llvm/ExecutionEngine/Orc/Shared/SimplePackedSerialization.h"
+#include "llvm/ExecutionEngine/Orc/Shared/TargetProcessControlTypes.h"
+
+#include <cstdint>
+
+namespace llvm::orc::rt::sps_ci {
+
+struct MemWriteUInt8s {
+  static constexpr char Name[] = "orc_rt_ci_sps_mem_write_uint8s";
+  using SPSSig = void(shared::SPSSequence<shared::SPSMemoryAccessUInt8Write>);
+};
+
+struct MemWriteUInt16s {
+  static constexpr char Name[] = "orc_rt_ci_sps_mem_write_uint16s";
+  using SPSSig = void(shared::SPSSequence<shared::SPSMemoryAccessUInt16Write>);
+};
+
+struct MemWriteUInt32s {
+  static constexpr char Name[] = "orc_rt_ci_sps_mem_write_uint32s";
+  using SPSSig = void(shared::SPSSequence<shared::SPSMemoryAccessUInt32Write>);
+};
+
+struct MemWriteUInt64s {
+  static constexpr char Name[] = "orc_rt_ci_sps_mem_write_uint64s";
+  using SPSSig = void(shared::SPSSequence<shared::SPSMemoryAccessUInt64Write>);
+};
+
+struct MemWritePointers {
+  static constexpr char Name[] = "orc_rt_ci_sps_mem_write_pointers";
+  using SPSSig = void(shared::SPSSequence<shared::SPSMemoryAccessPointerWrite>);
+};
+
+struct MemWriteBuffers {
+  static constexpr char Name[] = "orc_rt_ci_sps_mem_write_buffers";
+  using SPSSig = void(shared::SPSSequence<shared::SPSMemoryAccessBufferWrite>);
+};
+
+struct MemReadUInt8s {
+  static constexpr char Name[] = "orc_rt_ci_sps_mem_read_uint8s";
+  using SPSSig = shared::SPSSequence<uint8_t>(
+      shared::SPSSequence<shared::SPSExecutorAddr>);
+};
+
+struct MemReadUInt16s {
+  static constexpr char Name[] = "orc_rt_ci_sps_mem_read_uint16s";
+  using SPSSig = shared::SPSSequence<uint16_t>(
+      shared::SPSSequence<shared::SPSExecutorAddr>);
+};
+
+struct MemReadUInt32s {
+  static constexpr char Name[] = "orc_rt_ci_sps_mem_read_uint32s";
+  using SPSSig = shared::SPSSequence<uint32_t>(
+      shared::SPSSequence<shared::SPSExecutorAddr>);
+};
+
+struct MemReadUInt64s {
+  static constexpr char Name[] = "orc_rt_ci_sps_mem_read_uint64s";
+  using SPSSig = shared::SPSSequence<uint64_t>(
+      shared::SPSSequence<shared::SPSExecutorAddr>);
+};
+
+struct MemReadPointers {
+  static constexpr char Name[] = "orc_rt_ci_sps_mem_read_pointers";
+  using SPSSig = shared::SPSSequence<shared::SPSExecutorAddr>(
+      shared::SPSSequence<shared::SPSExecutorAddr>);
+};
+
+struct MemReadBuffers {
+  static constexpr char Name[] = "orc_rt_ci_sps_mem_read_buffers";
+  using SPSSig = shared::SPSSequence<shared::SPSSequence<uint8_t>>(
+      shared::SPSSequence<shared::SPSExecutorAddrRange>);
+};
+
+struct MemReadStrings {
+  static constexpr char Name[] = "orc_rt_ci_sps_mem_read_strings";
+  using SPSSig = shared::SPSSequence<shared::SPSString>(
+      shared::SPSSequence<shared::SPSExecutorAddr>);
+};
+
+} // namespace llvm::orc::rt::sps_ci
+
+#endif // LLVM_EXECUTIONENGINE_ORC_SHARED_SPSCI_MEMORYACCESSSPSCI_H

--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/SPSCI/NativeDylibManagerSPSCI.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/SPSCI/NativeDylibManagerSPSCI.h
@@ -1,0 +1,52 @@
+//===--- NativeDylibManagerSPSCI.h - SPS CI for dylib mgmt ------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// SPS controller-interface descriptors for the runtime's NativeDylibManager
+// interface. The instance address of the executor-side manager is passed as
+// the first argument to each call.
+//
+// See CallSPSCI.h for a description of the descriptor scheme.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_EXECUTIONENGINE_ORC_SHARED_SPSCI_NATIVEDYLIBMANAGERSPSCI_H
+#define LLVM_EXECUTIONENGINE_ORC_SHARED_SPSCI_NATIVEDYLIBMANAGERSPSCI_H
+
+#include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
+#include "llvm/ExecutionEngine/Orc/Shared/SimplePackedSerialization.h"
+#include "llvm/ExecutionEngine/Orc/Shared/SimpleRemoteEPCUtils.h"
+
+#include <cstdint>
+
+namespace llvm::orc::rt::sps_ci {
+
+/// The executor-side dylib-manager instance. This is a data symbol -- passed
+/// as the first argument to each call below -- not a wrapper to call.
+inline constexpr char NativeDylibManagerInstanceName[] =
+    "orc_rt_ci_NativeDylibManager_Instance";
+
+/// Open the dylib at the given path with the given mode flags; returns a
+/// handle to it.
+struct DylibMgrOpen {
+  static constexpr char Name[] = "orc_rt_ci_sps_NativeDylibManager_load";
+  using SPSSig = shared::SPSExpected<shared::SPSExecutorAddr>(
+      shared::SPSExecutorAddr, shared::SPSString, uint64_t);
+};
+
+/// Resolve the given lookup set within the given dylib.
+struct DylibMgrResolve {
+  static constexpr char Name[] = "orc_rt_ci_sps_NativeDylibManager_lookup";
+  using SPSSig = shared::SPSExpected<
+      shared::SPSSequence<shared::SPSOptional<shared::SPSExecutorAddr>>>(
+      shared::SPSExecutorAddr, shared::SPSExecutorAddr,
+      shared::SPSRemoteSymbolLookupSet);
+};
+
+} // namespace llvm::orc::rt::sps_ci
+
+#endif // LLVM_EXECUTIONENGINE_ORC_SHARED_SPSCI_NATIVEDYLIBMANAGERSPSCI_H

--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/SPSCI/SimpleNativeMemoryMapSPSCI.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/SPSCI/SimpleNativeMemoryMapSPSCI.h
@@ -1,0 +1,72 @@
+//===-- SimpleNativeMemoryMapSPSCI.h - SPS CI for mem mgmt ------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// SPS controller-interface descriptors for the runtime's SimpleNativeMemoryMap
+// interface. The instance address of the executor-side manager is passed as
+// the first argument to each call.
+//
+// The names below are the SimpleNativeMemoryMap defaults. Callers may resolve
+// these operations under other names, so a descriptor's Name is a default
+// rather than a fixed part of the contract.
+//
+// See CallSPSCI.h for a description of the descriptor scheme.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_EXECUTIONENGINE_ORC_SHARED_SPSCI_SIMPLENATIVEMEMORYMAPSPSCI_H
+#define LLVM_EXECUTIONENGINE_ORC_SHARED_SPSCI_SIMPLENATIVEMEMORYMAPSPSCI_H
+
+#include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
+#include "llvm/ExecutionEngine/Orc/Shared/SimplePackedSerialization.h"
+#include "llvm/ExecutionEngine/Orc/Shared/TargetProcessControlTypes.h"
+
+#include <cstdint>
+
+namespace llvm::orc::rt::sps_ci {
+
+/// The executor-side memory-manager instance. This is a data symbol (the
+/// allocator object) -- passed as the first argument to each call below -- not
+/// a wrapper to call.
+inline constexpr char SimpleNativeMemoryMapInstanceName[] =
+    "orc_rt_ci_SimpleNativeMemoryMap_Instance";
+
+/// Reserve an address range of the given size; returns its base.
+struct MemMgrReserve {
+  static constexpr char Name[] = "orc_rt_ci_sps_SimpleNativeMemoryMap_reserve";
+  using SPSSig = shared::SPSExpected<shared::SPSExecutorAddr>(
+      shared::SPSExecutorAddr, uint64_t);
+};
+
+/// Apply a finalize request; returns a key for the initialized allocation.
+struct MemMgrInitialize {
+  static constexpr char Name[] =
+      "orc_rt_ci_sps_SimpleNativeMemoryMap_initialize";
+  using SPSSig = shared::SPSExpected<shared::SPSExecutorAddr>(
+      shared::SPSExecutorAddr, shared::SPSFinalizeRequest);
+};
+
+/// Deinitialize the allocations with the given base addresses (running their
+/// deallocation actions) without releasing their memory.
+struct MemMgrDeinitialize {
+  static constexpr char Name[] =
+      "orc_rt_ci_sps_SimpleNativeMemoryMap_deinitializeMultiple";
+  using SPSSig = shared::SPSError(shared::SPSExecutorAddr,
+                                  shared::SPSSequence<shared::SPSExecutorAddr>);
+};
+
+/// Release the allocations with the given base addresses.
+struct MemMgrRelease {
+  static constexpr char Name[] =
+      "orc_rt_ci_sps_SimpleNativeMemoryMap_releaseMultiple";
+  using SPSSig = shared::SPSError(shared::SPSExecutorAddr,
+                                  shared::SPSSequence<shared::SPSExecutorAddr>);
+};
+
+} // namespace llvm::orc::rt::sps_ci
+
+#endif // LLVM_EXECUTIONENGINE_ORC_SHARED_SPSCI_SIMPLENATIVEMEMORYMAPSPSCI_H

--- a/llvm/lib/ExecutionEngine/Orc/EPCGenericDylibManager.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/EPCGenericDylibManager.cpp
@@ -11,7 +11,7 @@
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/LookupAndRecordAddrs.h"
 #include "llvm/ExecutionEngine/Orc/RTBridge/SPS/ProxySpec.h"
-#include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
+#include "llvm/ExecutionEngine/Orc/Shared/SPSCI/NativeDylibManagerSPSCI.h"
 #include "llvm/ExecutionEngine/Orc/Shared/SimpleRemoteEPCUtils.h"
 
 namespace llvm {
@@ -47,14 +47,10 @@ public:
 
 namespace {
 
-using OpenSpec =
-    rt::sps::ProxySpec<EPCGenericDylibManager::OpenProxy,
-                       rt::SPSSimpleExecutorDylibManagerOpenSignature,
-                       rt::NativeDylibManagerLoadWrapperName>;
-using ResolveSpec =
-    rt::sps::ProxySpec<EPCGenericDylibManager::ResolveProxy,
-                       rt::SPSSimpleExecutorDylibManagerResolveSignature,
-                       rt::NativeDylibManagerLookupWrapperName>;
+using OpenSpec = rt::sps::ProxySpec<EPCGenericDylibManager::OpenProxy,
+                                    rt::sps_ci::DylibMgrOpen>;
+using ResolveSpec = rt::sps::ProxySpec<EPCGenericDylibManager::ResolveProxy,
+                                       rt::sps_ci::DylibMgrResolve>;
 
 } // namespace
 
@@ -65,7 +61,8 @@ Expected<EPCGenericDylibManager> EPCGenericDylibManager::Create(JITDylib &JD) {
   // first argument to each call, not a wrapper to proxy.
   if (auto Err = lookupAndRecordAddrs(
           ES, LookupKind::Static, makeJITDylibSearchOrder({&JD}),
-          {{ES.intern(rt::NativeDylibManagerInstanceName), &B.Instance}}))
+          {{ES.intern(rt::sps_ci::NativeDylibManagerInstanceName),
+            &B.Instance}}))
     return std::move(Err);
   // The proxies resolve to the specs' default (NativeDylibManager) names.
   if (auto Err = rt::buildProxies(JD, rt::proxyInit<OpenSpec>(&B.Open),

--- a/llvm/lib/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManager.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManager.cpp
@@ -11,6 +11,7 @@
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/ExecutionEngine/Orc/LookupAndRecordAddrs.h"
 #include "llvm/ExecutionEngine/Orc/RTBridge/SPS/GenericMemoryManagerProxySpecs.h"
+#include "llvm/ExecutionEngine/Orc/Shared/SPSCI/SimpleNativeMemoryMapSPSCI.h"
 
 #include <limits>
 
@@ -84,13 +85,15 @@ private:
 Expected<std::unique_ptr<EPCGenericJITLinkMemoryManager>>
 EPCGenericJITLinkMemoryManager::Create(JITDylib &JD) {
   namespace sps = rt::sps;
+  namespace sps_ci = rt::sps_ci;
   auto &ES = JD.getExecutionSession();
   Bindings B;
   // Instance is the executor-side allocator object -- a data symbol passed as
   // the first argument to each call, not a wrapper to proxy.
   if (auto Err = lookupAndRecordAddrs(
           ES, LookupKind::Static, makeJITDylibSearchOrder({&JD}),
-          {{ES.intern(sps::MemMgrInstanceCIName), &B.Instance}}))
+          {{ES.intern(sps_ci::SimpleNativeMemoryMapInstanceName),
+            &B.Instance}}))
     return std::move(Err);
   // The proxies resolve to the specs' default (SimpleNativeMemoryMap) names.
   if (auto Err = rt::buildProxies(

--- a/llvm/lib/ExecutionEngine/Orc/SimpleRemoteEPC.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/SimpleRemoteEPC.cpp
@@ -29,7 +29,7 @@ SimpleRemoteEPC::~SimpleRemoteEPC() {
 Expected<int32_t> SimpleRemoteEPC::runAsMain(ExecutorAddr MainFnAddr,
                                              ArrayRef<std::string> Args) {
   int64_t Result = 0;
-  if (auto Err = callSPSWrapper<rt::SPSRunAsMainSignature>(
+  if (auto Err = callSPSWrapper<rt::sps_ci::CallMain::SPSSig>(
           RunAsMainAddr, Result, MainFnAddr, Args))
     return std::move(Err);
   return Result;
@@ -298,7 +298,7 @@ Error SimpleRemoteEPC::setup() {
       BootstrapSymbols[ExecutorSessionObjectName];
 
   if (auto Err =
-          getBootstrapSymbols({{RunAsMainAddr, rt::sps::CallMainCIName}}))
+          getBootstrapSymbols({{RunAsMainAddr, rt::sps_ci::CallMain::Name}}))
     return Err;
 
   return Error::success();

--- a/llvm/lib/ExecutionEngine/Orc/SimpleRemoteMemoryMapper.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/SimpleRemoteMemoryMapper.cpp
@@ -9,7 +9,7 @@
 #include "llvm/ExecutionEngine/Orc/SimpleRemoteMemoryMapper.h"
 
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
-#include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
+#include "llvm/ExecutionEngine/Orc/Shared/SPSCI/SimpleNativeMemoryMapSPSCI.h"
 
 namespace llvm::orc {
 
@@ -19,7 +19,7 @@ SimpleRemoteMemoryMapper::SimpleRemoteMemoryMapper(ExecutorProcessControl &EPC,
 
 void SimpleRemoteMemoryMapper::reserve(size_t NumBytes,
                                        OnReservedFunction OnReserved) {
-  EPC.callSPSWrapperAsync<rt::SPSSimpleRemoteMemoryMapReserveSignature>(
+  EPC.callSPSWrapperAsync<rt::sps_ci::MemMgrReserve::SPSSig>(
       SAs.Reserve,
       [NumBytes, OnReserved = std::move(OnReserved)](
           Error SerializationErr, Expected<ExecutorAddr> Result) mutable {
@@ -54,7 +54,7 @@ void SimpleRemoteMemoryMapper::initialize(MemoryMapper::AllocInfo &AI,
                            Seg.ContentSize + Seg.ZeroFillSize,
                            ArrayRef<char>(Seg.WorkingMem, Seg.ContentSize)});
 
-  EPC.callSPSWrapperAsync<rt::SPSSimpleRemoteMemoryMapInitializeSignature>(
+  EPC.callSPSWrapperAsync<rt::sps_ci::MemMgrInitialize::SPSSig>(
       SAs.Initialize,
       [OnInitialized = std::move(OnInitialized)](
           Error SerializationErr, Expected<ExecutorAddr> Result) mutable {
@@ -71,7 +71,7 @@ void SimpleRemoteMemoryMapper::initialize(MemoryMapper::AllocInfo &AI,
 void SimpleRemoteMemoryMapper::deinitialize(
     ArrayRef<ExecutorAddr> Allocations,
     MemoryMapper::OnDeinitializedFunction OnDeinitialized) {
-  EPC.callSPSWrapperAsync<rt::SPSSimpleRemoteMemoryMapDeinitializeSignature>(
+  EPC.callSPSWrapperAsync<rt::sps_ci::MemMgrDeinitialize::SPSSig>(
       SAs.Deinitialize,
       [OnDeinitialized = std::move(OnDeinitialized)](Error SerializationErr,
                                                      Error Result) mutable {
@@ -87,7 +87,7 @@ void SimpleRemoteMemoryMapper::deinitialize(
 
 void SimpleRemoteMemoryMapper::release(ArrayRef<ExecutorAddr> Bases,
                                        OnReleasedFunction OnReleased) {
-  EPC.callSPSWrapperAsync<rt::SPSSimpleRemoteMemoryMapReleaseSignature>(
+  EPC.callSPSWrapperAsync<rt::sps_ci::MemMgrRelease::SPSSig>(
       SAs.Release,
       [OnReleased = std::move(OnReleased)](Error SerializationErr,
                                            Error Result) mutable {

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/OrcRTBootstrap.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/OrcRTBootstrap.cpp
@@ -8,9 +8,8 @@
 
 #include "OrcRTBootstrap.h"
 
-#include "llvm/ExecutionEngine/Orc/RTBridge/SPS/CallProxySpecs.h"
-#include "llvm/ExecutionEngine/Orc/RTBridge/SPS/MemoryAccessProxySpecs.h"
-#include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
+#include "llvm/ExecutionEngine/Orc/Shared/SPSCI/CallSPSCI.h"
+#include "llvm/ExecutionEngine/Orc/Shared/SPSCI/MemoryAccessSPSCI.h"
 #include "llvm/ExecutionEngine/Orc/Shared/WrapperFunctionUtils.h"
 #include "llvm/ExecutionEngine/Orc/TargetProcess/RegisterEHFrames.h"
 #include "llvm/ExecutionEngine/Orc/TargetProcess/TargetExecutionUtils.h"
@@ -127,7 +126,7 @@ readStringsWrapper(const char *ArgData, size_t ArgSize) {
 
 static llvm::orc::shared::CWrapperFunctionBuffer
 runAsMainWrapper(const char *ArgData, size_t ArgSize) {
-  return WrapperFunction<rt::SPSRunAsMainSignature>::handle(
+  return WrapperFunction<rt::sps_ci::CallMain::SPSSig>::handle(
              ArgData, ArgSize,
              [](ExecutorAddr MainAddr,
                 std::vector<std::string> Args) -> int64_t {
@@ -138,7 +137,7 @@ runAsMainWrapper(const char *ArgData, size_t ArgSize) {
 
 static llvm::orc::shared::CWrapperFunctionBuffer
 runAsInt32VoidFunctionWrapper(const char *ArgData, size_t ArgSize) {
-  return WrapperFunction<rt::sps::CallInt32VoidSPSSig>::handle(
+  return WrapperFunction<rt::sps_ci::CallInt32Void::SPSSig>::handle(
              ArgData, ArgSize,
              [](ExecutorAddr MainAddr) -> int32_t {
                return runAsVoidFunction(MainAddr.toPtr<int32_t (*)(void)>());
@@ -148,7 +147,7 @@ runAsInt32VoidFunctionWrapper(const char *ArgData, size_t ArgSize) {
 
 static llvm::orc::shared::CWrapperFunctionBuffer
 runAsInt32Int32FunctionWrapper(const char *ArgData, size_t ArgSize) {
-  return WrapperFunction<rt::sps::CallInt32Int32SPSSig>::handle(
+  return WrapperFunction<rt::sps_ci::CallInt32Int32::SPSSig>::handle(
              ArgData, ArgSize,
              [](ExecutorAddr MainAddr, int32_t Arg) -> int32_t {
                return runAsIntFunction(MainAddr.toPtr<int32_t (*)(int32_t)>(),
@@ -158,38 +157,40 @@ runAsInt32Int32FunctionWrapper(const char *ArgData, size_t ArgSize) {
 }
 
 void addTo(StringMap<ExecutorAddr> &M) {
-  M[rt::sps::MemWriteUInt8sCIName] = ExecutorAddr::fromPtr(
+  M[rt::sps_ci::MemWriteUInt8s::Name] = ExecutorAddr::fromPtr(
       &writeUIntsWrapper<tpctypes::UInt8Write,
                          shared::SPSMemoryAccessUInt8Write>);
-  M[rt::sps::MemWriteUInt16sCIName] = ExecutorAddr::fromPtr(
+  M[rt::sps_ci::MemWriteUInt16s::Name] = ExecutorAddr::fromPtr(
       &writeUIntsWrapper<tpctypes::UInt16Write,
                          shared::SPSMemoryAccessUInt16Write>);
-  M[rt::sps::MemWriteUInt32sCIName] = ExecutorAddr::fromPtr(
+  M[rt::sps_ci::MemWriteUInt32s::Name] = ExecutorAddr::fromPtr(
       &writeUIntsWrapper<tpctypes::UInt32Write,
                          shared::SPSMemoryAccessUInt32Write>);
-  M[rt::sps::MemWriteUInt64sCIName] = ExecutorAddr::fromPtr(
+  M[rt::sps_ci::MemWriteUInt64s::Name] = ExecutorAddr::fromPtr(
       &writeUIntsWrapper<tpctypes::UInt64Write,
                          shared::SPSMemoryAccessUInt64Write>);
-  M[rt::sps::MemWritePointersCIName] =
+  M[rt::sps_ci::MemWritePointers::Name] =
       ExecutorAddr::fromPtr(&writePointersWrapper);
-  M[rt::sps::MemWriteBuffersCIName] =
+  M[rt::sps_ci::MemWriteBuffers::Name] =
       ExecutorAddr::fromPtr(&writeBuffersWrapper);
-  M[rt::sps::MemReadUInt8sCIName] =
+  M[rt::sps_ci::MemReadUInt8s::Name] =
       ExecutorAddr::fromPtr(&readUIntsWrapper<uint8_t>);
-  M[rt::sps::MemReadUInt16sCIName] =
+  M[rt::sps_ci::MemReadUInt16s::Name] =
       ExecutorAddr::fromPtr(&readUIntsWrapper<uint16_t>);
-  M[rt::sps::MemReadUInt32sCIName] =
+  M[rt::sps_ci::MemReadUInt32s::Name] =
       ExecutorAddr::fromPtr(&readUIntsWrapper<uint32_t>);
-  M[rt::sps::MemReadUInt64sCIName] =
+  M[rt::sps_ci::MemReadUInt64s::Name] =
       ExecutorAddr::fromPtr(&readUIntsWrapper<uint64_t>);
-  M[rt::sps::MemReadPointersCIName] =
+  M[rt::sps_ci::MemReadPointers::Name] =
       ExecutorAddr::fromPtr(&readPointersWrapper);
-  M[rt::sps::MemReadBuffersCIName] = ExecutorAddr::fromPtr(&readBuffersWrapper);
-  M[rt::sps::MemReadStringsCIName] = ExecutorAddr::fromPtr(&readStringsWrapper);
-  M[rt::sps::CallMainCIName] = ExecutorAddr::fromPtr(&runAsMainWrapper);
-  M[rt::sps::CallInt32VoidCIName] =
+  M[rt::sps_ci::MemReadBuffers::Name] =
+      ExecutorAddr::fromPtr(&readBuffersWrapper);
+  M[rt::sps_ci::MemReadStrings::Name] =
+      ExecutorAddr::fromPtr(&readStringsWrapper);
+  M[rt::sps_ci::CallMain::Name] = ExecutorAddr::fromPtr(&runAsMainWrapper);
+  M[rt::sps_ci::CallInt32Void::Name] =
       ExecutorAddr::fromPtr(&runAsInt32VoidFunctionWrapper);
-  M[rt::sps::CallInt32Int32CIName] =
+  M[rt::sps_ci::CallInt32Int32::Name] =
       ExecutorAddr::fromPtr(&runAsInt32Int32FunctionWrapper);
 }
 

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/SimpleExecutorDylibManager.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/SimpleExecutorDylibManager.cpp
@@ -8,7 +8,7 @@
 
 #include "llvm/ExecutionEngine/Orc/TargetProcess/SimpleExecutorDylibManager.h"
 
-#include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
+#include "llvm/ExecutionEngine/Orc/Shared/SPSCI/NativeDylibManagerSPSCI.h"
 
 #include "llvm/Support/MSVCErrorWorkarounds.h"
 
@@ -73,32 +73,28 @@ void SimpleExecutorDylibManager::addBootstrapSymbols(
   // NativeDylibManager controller interface, so it publishes its bootstrap
   // symbols under the NativeDylibManager_* names. The class itself will be
   // renamed to NativeDylibManager to match in a future cleanup.
-  M[rt::NativeDylibManagerInstanceName] = ExecutorAddr::fromPtr(this);
-  M[rt::NativeDylibManagerLoadWrapperName] =
-      ExecutorAddr::fromPtr(&openWrapper);
-  M[rt::NativeDylibManagerLookupWrapperName] =
-      ExecutorAddr::fromPtr(&resolveWrapper);
+  M[rt::sps_ci::NativeDylibManagerInstanceName] = ExecutorAddr::fromPtr(this);
+  M[rt::sps_ci::DylibMgrOpen::Name] = ExecutorAddr::fromPtr(&openWrapper);
+  M[rt::sps_ci::DylibMgrResolve::Name] = ExecutorAddr::fromPtr(&resolveWrapper);
 }
 
 llvm::orc::shared::CWrapperFunctionBuffer
 SimpleExecutorDylibManager::openWrapper(const char *ArgData, size_t ArgSize) {
-  return shared::
-      WrapperFunction<rt::SPSSimpleExecutorDylibManagerOpenSignature>::handle(
+  return shared::WrapperFunction<rt::sps_ci::DylibMgrOpen::SPSSig>::handle(
              ArgData, ArgSize,
              shared::makeMethodWrapperHandler(
                  &SimpleExecutorDylibManager::open))
-          .release();
+      .release();
 }
 
 llvm::orc::shared::CWrapperFunctionBuffer
 SimpleExecutorDylibManager::resolveWrapper(const char *ArgData,
                                            size_t ArgSize) {
-  return shared::WrapperFunction<
-             rt::SPSSimpleExecutorDylibManagerResolveSignature>::
-      handle(ArgData, ArgSize,
+  return shared::WrapperFunction<rt::sps_ci::DylibMgrResolve::SPSSig>::handle(
+             ArgData, ArgSize,
              shared::makeMethodWrapperHandler(
                  &SimpleExecutorDylibManager::resolve))
-          .release();
+      .release();
 }
 
 } // namespace rt_bootstrap

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/SimpleExecutorMemoryManager.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/SimpleExecutorMemoryManager.cpp
@@ -9,8 +9,8 @@
 #include "llvm/ExecutionEngine/Orc/TargetProcess/SimpleExecutorMemoryManager.h"
 
 #include "llvm/ADT/ScopeExit.h"
-#include "llvm/ExecutionEngine/Orc/RTBridge/SPS/GenericMemoryManagerProxySpecs.h"
 #include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
+#include "llvm/ExecutionEngine/Orc/Shared/SPSCI/SimpleNativeMemoryMapSPSCI.h"
 #include "llvm/Support/FormatVariadic.h"
 
 #define DEBUG_TYPE "orc"
@@ -214,13 +214,14 @@ void SimpleExecutorMemoryManager::addBootstrapSymbols(
     // FIXME: We should codify a "simple" memory manager interface and make
     // SimpleExecutorMemoryManager its LLVM-based implementation, and
     // SimpleNativeMemoryMap its ORC-runtime implementation.
-    namespace sps = rt::sps;
-    M[sps::MemMgrInstanceCIName] = ExecutorAddr::fromPtr(this);
-    M[sps::MemMgrReserveCIName] = ExecutorAddr::fromPtr(reserveWrapper);
-    M[sps::MemMgrInitializeCIName] = ExecutorAddr::fromPtr(initializeWrapper);
-    M[sps::MemMgrDeinitializeCIName] =
+    namespace sps_ci = rt::sps_ci;
+    M[sps_ci::SimpleNativeMemoryMapInstanceName] = ExecutorAddr::fromPtr(this);
+    M[sps_ci::MemMgrReserve::Name] = ExecutorAddr::fromPtr(reserveWrapper);
+    M[sps_ci::MemMgrInitialize::Name] =
+        ExecutorAddr::fromPtr(initializeWrapper);
+    M[sps_ci::MemMgrDeinitialize::Name] =
         ExecutorAddr::fromPtr(deinitializeWrapper);
-    M[sps::MemMgrReleaseCIName] = ExecutorAddr::fromPtr(releaseWrapper);
+    M[sps_ci::MemMgrRelease::Name] = ExecutorAddr::fromPtr(releaseWrapper);
   }
 }
 
@@ -324,29 +325,27 @@ SimpleExecutorMemoryManager::getRegionInfo(ExecutorAddr A, StringRef Context) {
 llvm::orc::shared::CWrapperFunctionBuffer
 SimpleExecutorMemoryManager::reserveWrapper(const char *ArgData,
                                             size_t ArgSize) {
-  return shared::WrapperFunction<rt::SPSSimpleRemoteMemoryMapReserveSignature>::
-      handle(ArgData, ArgSize,
+  return shared::WrapperFunction<rt::sps_ci::MemMgrReserve::SPSSig>::handle(
+             ArgData, ArgSize,
              shared::makeMethodWrapperHandler(
                  &SimpleExecutorMemoryManager::reserve))
-          .release();
+      .release();
 }
 
 llvm::orc::shared::CWrapperFunctionBuffer
 SimpleExecutorMemoryManager::initializeWrapper(const char *ArgData,
                                                size_t ArgSize) {
-  return shared::
-      WrapperFunction<rt::SPSSimpleRemoteMemoryMapInitializeSignature>::handle(
+  return shared::WrapperFunction<rt::sps_ci::MemMgrInitialize::SPSSig>::handle(
              ArgData, ArgSize,
              shared::makeMethodWrapperHandler(
                  &SimpleExecutorMemoryManager::initialize))
-          .release();
+      .release();
 }
 
 llvm::orc::shared::CWrapperFunctionBuffer
 SimpleExecutorMemoryManager::deinitializeWrapper(const char *ArgData,
                                                  size_t ArgSize) {
-  return shared::WrapperFunction<
-             rt::SPSSimpleRemoteMemoryMapDeinitializeSignature>::
+  return shared::WrapperFunction<rt::sps_ci::MemMgrDeinitialize::SPSSig>::
       handle(ArgData, ArgSize,
              shared::makeMethodWrapperHandler(
                  &SimpleExecutorMemoryManager::deinitialize))
@@ -356,11 +355,11 @@ SimpleExecutorMemoryManager::deinitializeWrapper(const char *ArgData,
 llvm::orc::shared::CWrapperFunctionBuffer
 SimpleExecutorMemoryManager::releaseWrapper(const char *ArgData,
                                             size_t ArgSize) {
-  return shared::WrapperFunction<rt::SPSSimpleRemoteMemoryMapReleaseSignature>::
-      handle(ArgData, ArgSize,
+  return shared::WrapperFunction<rt::sps_ci::MemMgrRelease::SPSSig>::handle(
+             ArgData, ArgSize,
              shared::makeMethodWrapperHandler(
                  &SimpleExecutorMemoryManager::release))
-          .release();
+      .release();
 }
 
 } // namespace rt_bootstrap

--- a/llvm/unittests/ExecutionEngine/Orc/EPCGenericDylibManagerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/EPCGenericDylibManagerTest.cpp
@@ -12,7 +12,7 @@
 
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
-#include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
+#include "llvm/ExecutionEngine/Orc/Shared/SPSCI/NativeDylibManagerSPSCI.h"
 #include "llvm/Testing/Support/Error.h"
 
 using namespace llvm;
@@ -35,9 +35,9 @@ TEST(EPCGenericDylibManagerTest, CreateFromExecutionSession) {
   ExecutorAddr InstanceAddr(1), OpenAddr(2), ResolveAddr(3);
 
   StringMap<ExecutorAddr> BootstrapSyms;
-  BootstrapSyms[rt::NativeDylibManagerInstanceName] = InstanceAddr;
-  BootstrapSyms[rt::NativeDylibManagerLoadWrapperName] = OpenAddr;
-  BootstrapSyms[rt::NativeDylibManagerLookupWrapperName] = ResolveAddr;
+  BootstrapSyms[rt::sps_ci::NativeDylibManagerInstanceName] = InstanceAddr;
+  BootstrapSyms[rt::sps_ci::DylibMgrOpen::Name] = OpenAddr;
+  BootstrapSyms[rt::sps_ci::DylibMgrResolve::Name] = ResolveAddr;
 
   auto SSP = std::make_shared<SymbolStringPool>();
   auto EPC =

--- a/llvm/unittests/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManagerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManagerTest.cpp
@@ -12,9 +12,9 @@
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ExecutionEngine/Orc/AbsoluteSymbols.h"
-#include "llvm/ExecutionEngine/Orc/RTBridge/SPS/GenericMemoryManagerProxySpecs.h"
 #include "llvm/ExecutionEngine/Orc/SelfExecutorProcessControl.h"
 #include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
+#include "llvm/ExecutionEngine/Orc/Shared/SPSCI/SimpleNativeMemoryMapSPSCI.h"
 #include "llvm/ExecutionEngine/Orc/Shared/TargetProcessControlTypes.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/Memory.h"
@@ -112,20 +112,20 @@ TEST(EPCGenericJITLinkMemoryManagerTest, AllocFinalizeFree) {
 
   // Register the test wrappers in the bootstrap JITDylib under the default
   // SimpleNativeMemoryMap names so that Create resolves its proxies to them.
-  namespace sps = rt::sps;
+  namespace sps_ci = rt::sps_ci;
   auto Exported = JITSymbolFlags::Exported;
   cantFail(ES.getBootstrapJITDylib().define(absoluteSymbols({
-      {ES.intern(sps::MemMgrInstanceCIName),
+      {ES.intern(sps_ci::SimpleNativeMemoryMapInstanceName),
        {ExecutorAddr::fromPtr(&SA), Exported}},
-      {ES.intern(sps::MemMgrReserveCIName),
+      {ES.intern(sps_ci::MemMgrReserve::Name),
        {ExecutorAddr::fromPtr(&testReserve), Exported}},
-      {ES.intern(sps::MemMgrInitializeCIName),
+      {ES.intern(sps_ci::MemMgrInitialize::Name),
        {ExecutorAddr::fromPtr(&testInitialize), Exported}},
       // Deinitialize is part of the interface but unused here; the release
       // wrapper (same signature) stands in so the proxy resolves.
-      {ES.intern(sps::MemMgrDeinitializeCIName),
+      {ES.intern(sps_ci::MemMgrDeinitialize::Name),
        {ExecutorAddr::fromPtr(&testRelease), Exported}},
-      {ES.intern(sps::MemMgrReleaseCIName),
+      {ES.intern(sps_ci::MemMgrRelease::Name),
        {ExecutorAddr::fromPtr(&testRelease), Exported}},
   })));
 
@@ -158,7 +158,7 @@ TEST(EPCGenericJITLinkMemoryManagerTest, AllocFinalizeFree) {
 TEST(EPCGenericJITLinkMemoryManagerTest, CreateFromJITDylib) {
   // Verify that Create(JITDylib&) looks up the default SimpleNativeMemoryMap
   // symbols and constructs the memory manager.
-  namespace sps = rt::sps;
+  namespace sps_ci = rt::sps_ci;
   auto SSP = std::make_shared<SymbolStringPool>();
   auto EPC =
       std::make_unique<UnsupportedExecutorProcessControl>(std::move(SSP));
@@ -169,15 +169,15 @@ TEST(EPCGenericJITLinkMemoryManagerTest, CreateFromJITDylib) {
       ReleaseAddr(5);
 
   cantFail(JD.define(absoluteSymbols({
-      {ES.intern(sps::MemMgrInstanceCIName),
+      {ES.intern(sps_ci::SimpleNativeMemoryMapInstanceName),
        {AllocatorAddr, JITSymbolFlags::Exported}},
-      {ES.intern(sps::MemMgrReserveCIName),
+      {ES.intern(sps_ci::MemMgrReserve::Name),
        {ReserveAddr, JITSymbolFlags::Exported}},
-      {ES.intern(sps::MemMgrInitializeCIName),
+      {ES.intern(sps_ci::MemMgrInitialize::Name),
        {InitAddr, JITSymbolFlags::Exported}},
-      {ES.intern(sps::MemMgrDeinitializeCIName),
+      {ES.intern(sps_ci::MemMgrDeinitialize::Name),
        {DeinitAddr, JITSymbolFlags::Exported}},
-      {ES.intern(sps::MemMgrReleaseCIName),
+      {ES.intern(sps_ci::MemMgrRelease::Name),
        {ReleaseAddr, JITSymbolFlags::Exported}},
   })));
 
@@ -189,7 +189,7 @@ TEST(EPCGenericJITLinkMemoryManagerTest, CreateFromJITDylib) {
 
 TEST(EPCGenericJITLinkMemoryManagerTest, CreateFailsOnMissingSymbol) {
   // Verify that Create returns an error when a symbol is missing.
-  namespace sps = rt::sps;
+  namespace sps_ci = rt::sps_ci;
   auto SSP = std::make_shared<SymbolStringPool>();
   auto EPC =
       std::make_unique<UnsupportedExecutorProcessControl>(std::move(SSP));
@@ -198,7 +198,7 @@ TEST(EPCGenericJITLinkMemoryManagerTest, CreateFailsOnMissingSymbol) {
 
   // Only define the instance symbol; the wrapper symbols are missing.
   cantFail(JD.define(absoluteSymbols({
-      {ES.intern(sps::MemMgrInstanceCIName),
+      {ES.intern(sps_ci::SimpleNativeMemoryMapInstanceName),
        {ExecutorAddr(1), JITSymbolFlags::Exported}},
   })));
 
@@ -211,7 +211,7 @@ TEST(EPCGenericJITLinkMemoryManagerTest, CreateFailsOnMissingSymbol) {
 TEST(EPCGenericJITLinkMemoryManagerTest, CreateFromExecutionSession) {
   // Verify that Create(ExecutionSession&) looks up symbols in the bootstrap
   // JITDylib using the default SimpleNativeMemoryMap symbol names.
-  namespace sps = rt::sps;
+  namespace sps_ci = rt::sps_ci;
   class EPCWithBootstrapSymbols : public UnsupportedExecutorProcessControl {
   public:
     EPCWithBootstrapSymbols(std::shared_ptr<SymbolStringPool> SSP,
@@ -225,11 +225,11 @@ TEST(EPCGenericJITLinkMemoryManagerTest, CreateFromExecutionSession) {
       ReleaseAddr(5);
 
   StringMap<ExecutorAddr> BootstrapSyms;
-  BootstrapSyms[sps::MemMgrInstanceCIName] = AllocatorAddr;
-  BootstrapSyms[sps::MemMgrReserveCIName] = ReserveAddr;
-  BootstrapSyms[sps::MemMgrInitializeCIName] = InitAddr;
-  BootstrapSyms[sps::MemMgrDeinitializeCIName] = DeinitAddr;
-  BootstrapSyms[sps::MemMgrReleaseCIName] = ReleaseAddr;
+  BootstrapSyms[sps_ci::SimpleNativeMemoryMapInstanceName] = AllocatorAddr;
+  BootstrapSyms[sps_ci::MemMgrReserve::Name] = ReserveAddr;
+  BootstrapSyms[sps_ci::MemMgrInitialize::Name] = InitAddr;
+  BootstrapSyms[sps_ci::MemMgrDeinitialize::Name] = DeinitAddr;
+  BootstrapSyms[sps_ci::MemMgrRelease::Name] = ReleaseAddr;
 
   auto SSP = std::make_shared<SymbolStringPool>();
   auto EPC =

--- a/llvm/unittests/ExecutionEngine/Orc/EPCGenericMemoryAccessTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/EPCGenericMemoryAccessTest.cpp
@@ -10,8 +10,8 @@
 
 #include "llvm/ExecutionEngine/Orc/AbsoluteSymbols.h"
 #include "llvm/ExecutionEngine/Orc/EPCGenericMemoryAccess.h"
-#include "llvm/ExecutionEngine/Orc/RTBridge/SPS/MemoryAccessProxySpecs.h"
 #include "llvm/ExecutionEngine/Orc/SelfExecutorProcessControl.h"
+#include "llvm/ExecutionEngine/Orc/Shared/SPSCI/MemoryAccessSPSCI.h"
 #include "llvm/Testing/Support/Error.h"
 
 using namespace llvm;
@@ -124,42 +124,42 @@ public:
     // Register the test wrappers in the bootstrap JITDylib under the SPS
     // controller-interface names, so that EPCGenericMemoryAccess::Create
     // resolves its proxies to them.
-    namespace sps = rt::sps;
+    namespace sps_ci = rt::sps_ci;
     auto Exported = JITSymbolFlags::Exported;
     cantFail(ES->getBootstrapJITDylib().define(absoluteSymbols(
-        {{ES->intern(sps::MemWriteUInt8sCIName),
+        {{ES->intern(sps_ci::MemWriteUInt8s::Name),
           {ExecutorAddr::fromPtr(&testWriteUInts<tpctypes::UInt8Write,
                                                  SPSMemoryAccessUInt8Write>),
            Exported}},
-         {ES->intern(sps::MemWriteUInt16sCIName),
+         {ES->intern(sps_ci::MemWriteUInt16s::Name),
           {ExecutorAddr::fromPtr(&testWriteUInts<tpctypes::UInt16Write,
                                                  SPSMemoryAccessUInt16Write>),
            Exported}},
-         {ES->intern(sps::MemWriteUInt32sCIName),
+         {ES->intern(sps_ci::MemWriteUInt32s::Name),
           {ExecutorAddr::fromPtr(&testWriteUInts<tpctypes::UInt32Write,
                                                  SPSMemoryAccessUInt32Write>),
            Exported}},
-         {ES->intern(sps::MemWriteUInt64sCIName),
+         {ES->intern(sps_ci::MemWriteUInt64s::Name),
           {ExecutorAddr::fromPtr(&testWriteUInts<tpctypes::UInt64Write,
                                                  SPSMemoryAccessUInt64Write>),
            Exported}},
-         {ES->intern(sps::MemWritePointersCIName),
+         {ES->intern(sps_ci::MemWritePointers::Name),
           {ExecutorAddr::fromPtr(&testWritePointers), Exported}},
-         {ES->intern(sps::MemWriteBuffersCIName),
+         {ES->intern(sps_ci::MemWriteBuffers::Name),
           {ExecutorAddr::fromPtr(&testWriteBuffers), Exported}},
-         {ES->intern(sps::MemReadUInt8sCIName),
+         {ES->intern(sps_ci::MemReadUInt8s::Name),
           {ExecutorAddr::fromPtr(&testReadUInts<uint8_t>), Exported}},
-         {ES->intern(sps::MemReadUInt16sCIName),
+         {ES->intern(sps_ci::MemReadUInt16s::Name),
           {ExecutorAddr::fromPtr(&testReadUInts<uint16_t>), Exported}},
-         {ES->intern(sps::MemReadUInt32sCIName),
+         {ES->intern(sps_ci::MemReadUInt32s::Name),
           {ExecutorAddr::fromPtr(&testReadUInts<uint32_t>), Exported}},
-         {ES->intern(sps::MemReadUInt64sCIName),
+         {ES->intern(sps_ci::MemReadUInt64s::Name),
           {ExecutorAddr::fromPtr(&testReadUInts<uint64_t>), Exported}},
-         {ES->intern(sps::MemReadPointersCIName),
+         {ES->intern(sps_ci::MemReadPointers::Name),
           {ExecutorAddr::fromPtr(&testReadPointers), Exported}},
-         {ES->intern(sps::MemReadBuffersCIName),
+         {ES->intern(sps_ci::MemReadBuffers::Name),
           {ExecutorAddr::fromPtr(&testReadBuffers), Exported}},
-         {ES->intern(sps::MemReadStringsCIName),
+         {ES->intern(sps_ci::MemReadStrings::Name),
           {ExecutorAddr::fromPtr(&testReadStrings), Exported}}})));
 
     MemAccess = cantFail(EPCGenericMemoryAccess::Create(*ES));

--- a/llvm/unittests/ExecutionEngine/Orc/SPSProxiesTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/SPSProxiesTest.cpp
@@ -223,10 +223,12 @@ static CWrapperFunctionBuffer errorFnWrapper(const char *ArgData,
       .release();
 }
 
-inline constexpr char ErrorFnCIName[] = "test_sps_error_fn";
+struct ErrorFnCI {
+  static constexpr char Name[] = "test_sps_error_fn";
+  using SPSSig = SPSError(bool);
+};
 using ErrorFnProxy = rt::Proxy<Error(bool)>;
-using ErrorFnProxySpec =
-    sps::ProxySpec<ErrorFnProxy, SPSError(bool), ErrorFnCIName>;
+using ErrorFnProxySpec = sps::ProxySpec<ErrorFnProxy, ErrorFnCI>;
 
 // Exercises the Error -> Error mapping across the SPS boundary, including a
 // failure reported by the executor-side function itself.
@@ -257,11 +259,12 @@ static CWrapperFunctionBuffer expectedFnWrapper(const char *ArgData,
       .release();
 }
 
-inline constexpr char ExpectedFnCIName[] = "test_sps_expected_fn";
+struct ExpectedFnCI {
+  static constexpr char Name[] = "test_sps_expected_fn";
+  using SPSSig = SPSExpected<int32_t>(int32_t);
+};
 using ExpectedFnProxy = rt::Proxy<Expected<int32_t>(int32_t)>;
-using ExpectedFnProxySpec =
-    sps::ProxySpec<ExpectedFnProxy, SPSExpected<int32_t>(int32_t),
-                   ExpectedFnCIName>;
+using ExpectedFnProxySpec = sps::ProxySpec<ExpectedFnProxy, ExpectedFnCI>;
 
 // Exercises the Expected<T> -> Expected<T> (flattening) mapping across the SPS
 // boundary, for both the value and the executor-reported-error cases.


### PR DESCRIPTION
The proxy specs in Orc/RTBridge/SPS fused the wire contract (an operation's controller-interface symbol name and SPS signature) with the controller-side machinery that calls it. This was dragging Orc Core APIs (e.g. ExecutionSession) into the OrcTargetProcess library via OrcRTBootstrap.cpp.

Fix this by introducing Orc/Shared/SPSCI, holding one descriptor per operation:

  struct MemWriteUInt8s {
    static constexpr char Name[] = "orc_rt_ci_sps_mem_write_uint8s";
    using SPSSig = void(SPSSequence<SPSMemoryAccessUInt8Write>);
  };

The filenames mirror orc-rt/include/orc-rt/sps-ci/*SPSCI.h, so the two sides of each contract pair up by name. ProxySpec now takes a descriptor in place of a signature and a name pointer:

  using MemWriteUInt8sProxySpec =
      ProxySpec<rt::MemWriteUInt8sProxy, sps_ci::MemWriteUInt8s>;

OrcRTBootstrap.cpp includes the SPSCI headers directly and no longer reaches into OrcCore. Also carves the NativeDylibManager names and the dylib-manager, SimpleNativeMemoryMap and run-as-main signatures out of Shared/OrcRTBridge.h, which this scheme is intended to retire; the legacy SimpleExecutorMemoryManager and ExecutorSharedMemoryMapperService names stay there for now.

No functional change intended: the wire names and signatures are unchanged.