### PR TITLE
[compiler-rt] Fix clang_rt.builtins spirv64 bitcode install component

### DIFF
--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -1216,7 +1216,7 @@ else ()
           get_compiler_rt_install_dir(${arch} BUILTIN_INSTALL_DIR)
           install(FILES "${SPIRV64_BC_OUTPUT}"
                   DESTINATION "${BUILTIN_INSTALL_DIR}"
-                  COMPONENT builtins)
+                  COMPONENT clang_rt.builtins-${arch})
         else()
           message(WARNING
             "llvm-link not found (LLVM_TOOLS_BINARY_DIR='${LLVM_TOOLS_BINARY_DIR}'); "


### PR DESCRIPTION
Install component for libclang_rt.builtins static archive library for spirv64 is clang_rt.builtins-spirv64, libclang_rt.builtins bitcode library install should use same component as static archive library.