### PR TITLE
[OpenMP][OMPT] Fix warning : extra tokens at end of #endif directive

### DIFF
--- a/openmp/runtime/src/include/omp-tools.h.var
+++ b/openmp/runtime/src/include/omp-tools.h.var
@@ -318,7 +318,7 @@ typedef enum omp_control_tool_t {
   omp_control_tool_flush              = 3,
   omp_control_tool_end                = 4
 } omp_control_tool_t;
-#endif OMPCONTROLENUM
+#endif /* OMPCONTROLENUM */
 
 typedef enum ompt_thread_t {
   ompt_thread_initial                 = 1,

--- a/openmp/runtime/src/include/omp.h.var
+++ b/openmp/runtime/src/include/omp.h.var
@@ -328,7 +328,7 @@
         omp_control_tool_flush = 3,
         omp_control_tool_end = 4
     } omp_control_tool_t;
-#endif OMPCONTROLENUM
+#endif /* OMPCONTROLENUM */
 
     extern int __KAI_KMPC_CONVENTION omp_control_tool(int, int, void*);
 


### PR DESCRIPTION
Started appearing after #216076