### PR TITLE
[AMDGPU] Skip pointer users with no uses when preloading kernel args

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUPreloadKernelArguments.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPreloadKernelArguments.cpp
@@ -203,7 +203,8 @@ public:
         int64_t Offset = 0;
         auto *Load = dyn_cast<LoadInst>(U); // Load from ImplicitArgPtr?
         if (!Load) {
-          if (GetPointerBaseWithConstantOffset(U, Offset, DL) != CI)
+          if (U->user_empty() ||
+              GetPointerBaseWithConstantOffset(U, Offset, DL) != CI)
             continue;
 
           Load = dyn_cast<LoadInst>(*U->user_begin()); // Load from GEP?

--- a/llvm/test/CodeGen/AMDGPU/preload-implicit-kernargs-IR-lowering.ll
+++ b/llvm/test/CodeGen/AMDGPU/preload-implicit-kernargs-IR-lowering.ll
@@ -217,6 +217,24 @@ define amdgpu_kernel void @incompatible_attribute_block_count_x(ptr addrspace(1)
   ret void
 }
 
+define amdgpu_kernel void @preload_hidden_arg_dead_gep() {
+; NO-PRELOAD-LABEL: define amdgpu_kernel void @preload_hidden_arg_dead_gep(
+; NO-PRELOAD-SAME: ) #[[ATTR0]] {
+; NO-PRELOAD-NEXT:    [[IMP_ARG_PTR:%.*]] = call ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
+; NO-PRELOAD-NEXT:    [[GEP:%.*]] = getelementptr i8, ptr addrspace(4) [[IMP_ARG_PTR]], i64 12
+; NO-PRELOAD-NEXT:    ret void
+;
+; PRELOAD-LABEL: define amdgpu_kernel void @preload_hidden_arg_dead_gep(
+; PRELOAD-SAME: ) #[[ATTR0]] {
+; PRELOAD-NEXT:    [[IMP_ARG_PTR:%.*]] = call ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
+; PRELOAD-NEXT:    [[GEP:%.*]] = getelementptr i8, ptr addrspace(4) [[IMP_ARG_PTR]], i64 12
+; PRELOAD-NEXT:    ret void
+;
+  %imp_arg_ptr = call ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
+  %gep = getelementptr i8, ptr addrspace(4) %imp_arg_ptr, i64 12
+  ret void
+}
+
 ;.
 ; NO-PRELOAD: [[META0]] = !{}
 ;.


### PR DESCRIPTION
A dead GEP has no users, so dereferencing user_begin() looking for a load hits the end iterator and asserts