### PR TITLE
[TableGen] Don't crash on !cond with mixed bits and int

### DIFF
--- a/llvm/lib/TableGen/Record.cpp
+++ b/llvm/lib/TableGen/Record.cpp
@@ -2762,8 +2762,14 @@ const Init *CondOpInit::Fold(const Record *CurRec) const {
   for (auto [Cond, Val] : getCondAndVals()) {
     if (const auto *CondI = dyn_cast_or_null<IntInit>(
             Cond->convertInitializerTo(IntRecTy::get(RK)))) {
-      if (CondI->getValue())
-        return Val->convertInitializerTo(getValType());
+      if (CondI->getValue()) {
+        // Mixed bits/int arms unify to int. A bits value with unresolved
+        // references cannot convert to int yet; returning null crashed later
+        // in BitsInit::resolveReferences. Leave the value for a later cast.
+        if (const Init *Converted = Val->convertInitializerTo(getValType()))
+          return Converted;
+        return Val;
+      }
     } else {
       return this;
     }

--- a/llvm/test/TableGen/cond-incomplete-bits.td
+++ b/llvm/test/TableGen/cond-incomplete-bits.td
@@ -1,0 +1,45 @@
+// Mixed bits (with a field reference) and integer arms in !cond.
+// Selecting the bits arm used to crash when converting to the unified int type.
+// RUN: llvm-tblgen %s | FileCheck %s
+
+class Profile<bit x> {
+  bit xx = x;
+}
+
+def P1 : Profile<1>;
+def P0 : Profile<0>;
+
+class TT<Profile p> {
+  bits<4> reg = {0, 1, 0, 1};
+  bits<2> fmt;
+  let fmt = !cond(!eq(p.xx, 1) : {0, reg{0}},
+                  true : 3);
+}
+
+// Unset register bits, matching the original crash report.
+class UU<Profile p> {
+  bits<10> reg;
+  bits<2> fmt = !cond(!eq(p.xx, 1) : {0, reg{0}},
+                      true : 3);
+}
+
+def TakenBits : TT<P1>;
+def TakenInt : TT<P0>;
+def UnsetBits : UU<P1>;
+def UnsetInt : UU<P0>;
+
+// CHECK: def TakenBits
+// CHECK-NEXT: bits<4> reg = { 0, 1, 0, 1 };
+// CHECK-NEXT: bits<2> fmt = { 0, 1 };
+
+// CHECK: def TakenInt
+// CHECK-NEXT: bits<4> reg = { 0, 1, 0, 1 };
+// CHECK-NEXT: bits<2> fmt = { 1, 1 };
+
+// CHECK: def UnsetBits
+// CHECK-NEXT: bits<10> reg = { ?, ?, ?, ?, ?, ?, ?, ?, ?, ? };
+// CHECK-NEXT: bits<2> fmt = { 0, reg{0} };
+
+// CHECK: def UnsetInt
+// CHECK-NEXT: bits<10> reg = { ?, ?, ?, ?, ?, ?, ?, ?, ?, ? };
+// CHECK-NEXT: bits<2> fmt = { 1, 1 };


### PR DESCRIPTION
`!cond` unifies mixed `bits<N>` and `int` arms to `int`. When the selected arm is a bit list that still contains unresolved field references, converting that value to `int` returns null and TableGen crashes in `BitsInit::resolveReferences`.

The original report is:

```
let fmt = !cond(!eq(p.xx, 1) : {0, reg{0}},
                true : 3);
```

`!if` already returns the selected value as-is. Do the same in `CondOpInit::Fold` when the conversion cannot be done yet, so the existing outer cast to the field type can finish.

Fixes #53450

AI disclosure: an AI coding assistant was used to help inspect the TableGen !cond fold path.