### PR TITLE
[Coverage][MC/DC] Emit MC/DC instrumentation for block bodies

### DIFF
--- a/clang/lib/CodeGen/CGBlocks.cpp
+++ b/clang/lib/CodeGen/CGBlocks.cpp
@@ -1576,6 +1576,7 @@ llvm::Function *CodeGenFunction::GenerateBlockFunction(
   else {
     PGO->assignRegionCounters(GlobalDecl(blockDecl), fn);
     incrementProfileCounter(blockDecl->getBody());
+    maybeCreateMCDCCondBitmap();
     EmitStmt(blockDecl->getBody());
   }
 

--- a/clang/test/Profile/c-mcdc-block.c
+++ b/clang/test/Profile/c-mcdc-block.c
@@ -1,0 +1,18 @@
+// RUN: %clang_cc1 -triple %itanium_abi_triple -fblocks %s -o - -emit-llvm -fprofile-instrument=clang -fcoverage-mapping -fcoverage-mcdc -disable-llvm-passes | FileCheck %s -check-prefix=MCDC
+// RUN: %clang_cc1 -triple %itanium_abi_triple -fblocks %s -o - -emit-llvm -fprofile-instrument=clang -fcoverage-mapping | FileCheck %s -check-prefix=NOMCDC
+
+// Verify MC/DC coverage for block functions.
+
+typedef int (^blk)(int, int);
+
+blk make(void) {
+  return ^(int a, int b) {
+    return (a && b);
+  };
+}
+
+// MCDC-LABEL: @__make_block_invoke(
+// MCDC: call void @llvm.instrprof.mcdc.parameters(
+// MCDC: call void @llvm.instrprof.mcdc.tvbitmap.update(
+
+// NOMCDC-NOT: instrprof.mcdc


### PR DESCRIPTION
GenerateBlockFunction() emits the block body without going through EmitFunctionBody(), so call maybeCreateMCDCCondBitmap() to allocate a condition bitmap.