### PR TITLE
[NFC][SPIR-V] Enable spirv-val for SPV_AMD_weak_linkage test

### DIFF
--- a/llvm/test/CodeGen/SPIRV/linkage/weak-linkage.ll
+++ b/llvm/test/CodeGen/SPIRV/linkage/weak-linkage.ll
@@ -1,6 +1,5 @@
 ; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv32-unknown-unknown --spirv-ext=+SPV_AMD_weak_linkage %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV-EXT
-; TODO: enable validation when SPIR-V Headers patch is merged
-; RUNx: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown --spirv-ext=+SPV_AMD_weak_linkage %s -o - -filetype=obj | spirv-val %}
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown --spirv-ext=+SPV_AMD_weak_linkage %s -o - -filetype=obj | spirv-val %}
 
 ; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}


### PR DESCRIPTION
WeakLinkageAMD is now defined in SPIR-V Headers: https://github.com/KhronosGroup/SPIRV-Headers/pull/583