### PR TITLE
[clangd] Enable query-based custom checks

### DIFF
--- a/clang-tools-extra/clangd/Config.h
+++ b/clang-tools-extra/clangd/Config.h
@@ -111,6 +111,7 @@ struct Config {
       std::string Checks;
       llvm::StringMap<std::string> CheckOptions;
       FastCheckPolicy FastCheckFilter = FastCheckPolicy::Strict;
+      bool ExperimentalCustomChecks = false;
     } ClangTidy;
 
     IncludesPolicy UnusedIncludes = IncludesPolicy::Strict;

--- a/clang-tools-extra/clangd/ConfigCompile.cpp
+++ b/clang-tools-extra/clangd/ConfigCompile.cpp
@@ -624,6 +624,11 @@ struct FragmentCompiler {
         Out.Apply.push_back([Val](const Params &, Config &C) {
           C.Diagnostics.ClangTidy.FastCheckFilter = *Val;
         });
+    if (F.ExperimentalCustomChecks)
+      Out.Apply.push_back(
+          [Enabled = **F.ExperimentalCustomChecks](const Params &, Config &C) {
+            C.Diagnostics.ClangTidy.ExperimentalCustomChecks = Enabled;
+          });
   }
 
   void compile(Fragment::DiagnosticsBlock::IncludesBlock &&F) {

--- a/clang-tools-extra/clangd/ConfigFragment.h
+++ b/clang-tools-extra/clangd/ConfigFragment.h
@@ -297,6 +297,10 @@ struct Fragment {
       ///   Loose: Run checks unless they are known to be slow.
       ///   None: Run checks regardless of their speed.
       std::optional<Located<std::string>> FastCheckFilter;
+
+      /// Whether to enable experimental query-based custom checks configured
+      /// in .clang-tidy files.
+      std::optional<Located<bool>> ExperimentalCustomChecks;
     };
     ClangTidyBlock ClangTidy;
   };

--- a/clang-tools-extra/clangd/ConfigYAML.cpp
+++ b/clang-tools-extra/clangd/ConfigYAML.cpp
@@ -174,6 +174,10 @@ private:
       if (auto FastCheckFilter = scalarValue(N, "FastCheckFilter"))
         F.FastCheckFilter = *FastCheckFilter;
     });
+    Dict.handle("ExperimentalCustomChecks", [&](Node &N) {
+      if (auto Value = boolValue(N, "ExperimentalCustomChecks"))
+        F.ExperimentalCustomChecks = *Value;
+    });
     Dict.parse(N);
   }
 

--- a/clang-tools-extra/clangd/ParsedAST.cpp
+++ b/clang-tools-extra/clangd/ParsedAST.cpp
@@ -82,6 +82,11 @@
 #include "../clang-tidy/ClangTidyForceLinker.h"
 #endif
 
+#if CLANG_TIDY_ENABLE_QUERY_BASED_CUSTOM_CHECKS
+#include "../clang-tidy/ClangTidy.h"
+#include <mutex>
+#endif
+
 namespace clang {
 namespace clangd {
 namespace {
@@ -574,15 +579,30 @@ ParsedAST::build(llvm::StringRef Filename, const ParseInputs &Inputs,
         E.instantiate()->addCheckFactories(*CTFactories);
       return CTFactories;
     }();
-    tidy::ClangTidyCheckFactories FastFactories = filterFastTidyChecks(
-        *AllCTFactories, Cfg.Diagnostics.ClangTidy.FastCheckFilter);
     CTContext.emplace(std::make_unique<tidy::DefaultOptionsProvider>(
-        tidy::ClangTidyGlobalOptions(), ClangTidyOpts));
+                          tidy::ClangTidyGlobalOptions(), ClangTidyOpts),
+                      /*AllowEnablingAnalyzerAlphaCheckers=*/false,
+                      /*EnableModuleHeadersParsing=*/false,
+                      Cfg.Diagnostics.ClangTidy.ExperimentalCustomChecks);
     // The lifetime of DiagnosticOptions is managed by \c Clang.
     CTContext->setDiagnosticsEngine(nullptr, &Clang->getDiagnostics());
     CTContext->setASTContext(&Clang->getASTContext());
     CTContext->setCurrentFile(Filename);
     CTContext->setSelfContainedDiags(true);
+    tidy::ClangTidyCheckFactories CTCheckFactories = *AllCTFactories;
+#if CLANG_TIDY_ENABLE_QUERY_BASED_CUSTOM_CHECKS
+    if (CTContext->canExperimentalCustomChecks() &&
+        tidy::custom::RegisterCustomChecks) {
+      // RegisterCustomChecks tracks names in process-wide mutable state.
+      // Serializing its use keeps concurrent AST builds independent.
+      static std::mutex CustomChecksMu;
+      std::lock_guard<std::mutex> Lock(CustomChecksMu);
+      tidy::custom::RegisterCustomChecks(CTContext->getOptions(),
+                                         CTCheckFactories);
+    }
+#endif
+    tidy::ClangTidyCheckFactories FastFactories = filterFastTidyChecks(
+        CTCheckFactories, Cfg.Diagnostics.ClangTidy.FastCheckFilter);
     CTChecks = FastFactories.createChecksForLanguage(&*CTContext);
     Preprocessor *PP = &Clang->getPreprocessor();
     for (const auto &Check : CTChecks) {

--- a/clang-tools-extra/clangd/unittests/ConfigCompileTests.cpp
+++ b/clang-tools-extra/clangd/unittests/ConfigCompileTests.cpp
@@ -333,6 +333,20 @@ TEST_F(ConfigCompileTests, Tidy) {
 #endif
 }
 
+TEST_F(ConfigCompileTests, TidyExperimentalCustomChecks) {
+  EXPECT_FALSE(Conf.Diagnostics.ClangTidy.ExperimentalCustomChecks);
+
+  Frag.Diagnostics.ClangTidy.ExperimentalCustomChecks = true;
+  EXPECT_TRUE(compileAndApply());
+  EXPECT_TRUE(Conf.Diagnostics.ClangTidy.ExperimentalCustomChecks);
+
+  Fragment Override;
+  Override.Diagnostics.ClangTidy.ExperimentalCustomChecks = false;
+  auto Compiled = std::move(Override).compile(Diags.callback());
+  EXPECT_TRUE(Compiled(Parm, Conf));
+  EXPECT_FALSE(Conf.Diagnostics.ClangTidy.ExperimentalCustomChecks);
+}
+
 TEST_F(ConfigCompileTests, TidyBadChecks) {
   auto &Tidy = Frag.Diagnostics.ClangTidy;
   Tidy.Add.emplace_back("unknown-check");

--- a/clang-tools-extra/clangd/unittests/ConfigYAMLTests.cpp
+++ b/clang-tools-extra/clangd/unittests/ConfigYAMLTests.cpp
@@ -320,6 +320,21 @@ Diagnostics:
               llvm::ValueIs(val(true)));
 }
 
+TEST(ParseYAML, ClangTidyExperimentalCustomChecks) {
+  CapturedDiags Diags;
+  Annotations YAML(R"yaml(
+Diagnostics:
+  ClangTidy:
+    ExperimentalCustomChecks: true
+  )yaml");
+  auto Results =
+      Fragment::parseYAML(YAML.code(), "config.yaml", Diags.callback());
+  ASSERT_THAT(Diags.Diagnostics, IsEmpty());
+  ASSERT_EQ(Results.size(), 1u);
+  EXPECT_THAT(Results[0].Diagnostics.ClangTidy.ExperimentalCustomChecks,
+              llvm::ValueIs(val(true)));
+}
+
 TEST(ParseYAML, Style) {
   CapturedDiags Diags;
   Annotations YAML(R"yaml(

--- a/clang-tools-extra/clangd/unittests/DiagnosticsTests.cpp
+++ b/clang-tools-extra/clangd/unittests/DiagnosticsTests.cpp
@@ -18,6 +18,7 @@
 #include "TestIndex.h"
 #include "TestTU.h"
 #include "TidyProvider.h"
+#include "clang-tidy-config.h"
 #include "index/MemIndex.h"
 #include "index/Ref.h"
 #include "index/Relation.h"
@@ -358,6 +359,48 @@ TEST(DiagnosticsTest, ClangTidy) {
           Diag(Test.range("bar"),
                "function 'bar' is within a recursive call chain"))));
 }
+
+#if CLANGD_TIDY_CHECKS && CLANG_TIDY_ENABLE_QUERY_BASED_CUSTOM_CHECKS
+TEST(DiagnosticsTest, ClangTidyExperimentalCustomChecks) {
+  Annotations Test(R"cpp(
+    int x = $literal[[0]];
+  )cpp");
+  auto TU = TestTU::withCode(Test.code());
+  TU.ClangTidyProvider = [](tidy::ClangTidyOptions &Opts, llvm::StringRef) {
+    Opts.Checks = "-*,custom-integer-literal";
+    tidy::ClangTidyOptions::CustomCheckValue Check;
+    Check.Name = "integer-literal";
+    Check.Query = R"(match integerLiteral().bind("literal"))";
+    tidy::ClangTidyOptions::CustomCheckDiag Diagnostic;
+    Diagnostic.BindName = "literal";
+    Diagnostic.Message = "integer literal found";
+    Diagnostic.Level = DiagnosticIDs::Warning;
+    Check.Diags.push_back(std::move(Diagnostic));
+    Opts.CustomChecks.emplace();
+    Opts.CustomChecks->push_back(std::move(Check));
+  };
+
+  auto DiagnosticsFor = [&](bool Enabled, Config::FastCheckPolicy Policy) {
+    Config Cfg;
+    Cfg.Diagnostics.ClangTidy.ExperimentalCustomChecks = Enabled;
+    Cfg.Diagnostics.ClangTidy.FastCheckFilter = Policy;
+    WithContextValue WithCfg(Config::Key, std::move(Cfg));
+    auto AST = TU.build();
+    return std::vector<clangd::Diag>(AST.getDiagnostics());
+  };
+  auto CustomDiagnostic =
+      AllOf(Diag(Test.range("literal"), "integer literal found"),
+            diagSource(Diag::ClangTidy), diagName("custom-integer-literal"),
+            diagSeverity(DiagnosticsEngine::Warning));
+
+  EXPECT_THAT(DiagnosticsFor(false, Config::FastCheckPolicy::Loose), IsEmpty());
+  EXPECT_THAT(DiagnosticsFor(true, Config::FastCheckPolicy::Strict), IsEmpty());
+  EXPECT_THAT(DiagnosticsFor(true, Config::FastCheckPolicy::Loose),
+              ElementsAre(CustomDiagnostic));
+  EXPECT_THAT(DiagnosticsFor(true, Config::FastCheckPolicy::None),
+              ElementsAre(CustomDiagnostic));
+}
+#endif
 
 TEST(DiagnosticsTest, ClangTidyRedundantParenthesesFix) {
   Annotations Test(R"cpp(

--- a/clang-tools-extra/docs/ReleaseNotes.md
+++ b/clang-tools-extra/docs/ReleaseNotes.md
@@ -70,6 +70,11 @@ infrastructure are described first, followed by tool-specific sections.
 
 #### Diagnostics
 
+- Query-based custom clang-tidy checks can now be enabled with the
+  `Diagnostics.ClangTidy.ExperimentalCustomChecks` clangd configuration option.
+  Custom checks are subject to `FastCheckFilter`, and therefore require
+  `FastCheckFilter: Loose` or `None` to run.
+
 #### Semantic Highlighting
 
 #### Compile flags

--- a/clang-tools-extra/docs/clang-tidy/QueryBasedCustomChecks.rst
+++ b/clang-tools-extra/docs/clang-tidy/QueryBasedCustomChecks.rst
@@ -63,6 +63,25 @@ Example
     main(); // warning: call to main function. [custom-call-main-function]
   }
 
+Using with clangd
+=================
+
+To enable query-based custom checks in clangd, add the following to the clangd
+configuration:
+
+.. code-block:: yaml
+
+  Diagnostics:
+    ClangTidy:
+      ExperimentalCustomChecks: true
+      FastCheckFilter: Loose
+
+The custom-check definitions and check selection remain part of the clang-tidy
+configuration. `ExperimentalCustomChecks` does not override clangd's
+`FastCheckFilter`. Because custom checks are not present in clangd's
+fast-check database, `Strict` excludes them, while `Loose` and `None`
+allow them.
+
 Matters Need Attention
 ======================
 


### PR DESCRIPTION
Enable query-based custom checks in clangd behind a new `Diagnostics.ClangTidy.ExperimentalCustomChecks` configuration option.

Custom checks are registered from the per-file clang-tidy options and remain subject to clangd's `FastCheckFilter` policy.

Fixes #206696

Assisted by GPT-5.6