### PR TITLE
[ABI][CIR][NFC] Mark the last X86AVXABILevel in the enum

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/CallConvLoweringPass.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CallConvLoweringPass.cpp
@@ -705,7 +705,7 @@ void CallConvLoweringPass::runOnOperation() {
   // A per-function target attribute can raise the AVX level, so one classifier
   // per module would misclassify a wide vector in such a function.
   static constexpr unsigned numAvxLevels =
-      static_cast<unsigned>(llvm::abi::X86AVXABILevel::NumberOfEnumEntries);
+      static_cast<unsigned>(llvm::abi::X86AVXABILevel::Last) + 1;
   bool isX86 = target == cir::CallConvTarget::X86_64;
   std::optional<mlir::abi::ABITypeMapper> x86TypeMapper;
   std::array<std::unique_ptr<llvm::abi::TargetInfo>, numAvxLevels> x86Targets;
@@ -713,6 +713,8 @@ void CallConvLoweringPass::runOnOperation() {
     x86TypeMapper.emplace(dl);
   auto x86TargetFor =
       [&](llvm::abi::X86AVXABILevel level) -> const llvm::abi::TargetInfo & {
+    assert(static_cast<unsigned>(level) < numAvxLevels &&
+           "a new X86AVXABILevel must move X86AVXABILevel::Last");
     std::unique_ptr<llvm::abi::TargetInfo> &slot =
         x86Targets[static_cast<unsigned>(level)];
     if (!slot)

--- a/clang/lib/CIR/Dialect/Transforms/CallConvLoweringPass.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CallConvLoweringPass.cpp
@@ -705,7 +705,7 @@ void CallConvLoweringPass::runOnOperation() {
   // A per-function target attribute can raise the AVX level, so one classifier
   // per module would misclassify a wide vector in such a function.
   static constexpr unsigned numAvxLevels =
-      static_cast<unsigned>(llvm::abi::X86AVXABILevel::AVX512) + 1;
+      static_cast<unsigned>(llvm::abi::X86AVXABILevel::NumberOfEnumEntries);
   bool isX86 = target == cir::CallConvTarget::X86_64;
   std::optional<mlir::abi::ABITypeMapper> x86TypeMapper;
   std::array<std::unique_ptr<llvm::abi::TargetInfo>, numAvxLevels> x86Targets;
@@ -713,8 +713,6 @@ void CallConvLoweringPass::runOnOperation() {
     x86TypeMapper.emplace(dl);
   auto x86TargetFor =
       [&](llvm::abi::X86AVXABILevel level) -> const llvm::abi::TargetInfo & {
-    assert(static_cast<unsigned>(level) < numAvxLevels &&
-           "a new X86AVXABILevel needs a slot in x86Targets");
     std::unique_ptr<llvm::abi::TargetInfo> &slot =
         x86Targets[static_cast<unsigned>(level)];
     if (!slot)

--- a/llvm/include/llvm/ABI/TargetInfo.h
+++ b/llvm/include/llvm/ABI/TargetInfo.h
@@ -91,7 +91,7 @@ enum class X86AVXABILevel {
   None,
   AVX,
   AVX512,
-  NumberOfEnumEntries // must be last
+  Last = AVX512 // must be last
 };
 
 LLVM_ABI std::unique_ptr<TargetInfo>

--- a/llvm/include/llvm/ABI/TargetInfo.h
+++ b/llvm/include/llvm/ABI/TargetInfo.h
@@ -91,6 +91,7 @@ enum class X86AVXABILevel {
   None,
   AVX,
   AVX512,
+  NumberOfEnumEntries // must be last
 };
 
 LLVM_ABI std::unique_ptr<TargetInfo>

--- a/llvm/lib/ABI/Targets/X86.cpp
+++ b/llvm/lib/ABI/Targets/X86.cpp
@@ -29,8 +29,6 @@ static unsigned getNativeVectorSizeForAVXABI(X86AVXABILevel AVXLevel) {
     return 256;
   case X86AVXABILevel::None:
     return 128;
-  case X86AVXABILevel::NumberOfEnumEntries:
-    break;
   }
   llvm_unreachable("Unknown AVXLevel");
 }

--- a/llvm/lib/ABI/Targets/X86.cpp
+++ b/llvm/lib/ABI/Targets/X86.cpp
@@ -29,6 +29,8 @@ static unsigned getNativeVectorSizeForAVXABI(X86AVXABILevel AVXLevel) {
     return 256;
   case X86AVXABILevel::None:
     return 128;
+  case X86AVXABILevel::NumberOfEnumEntries:
+    break;
   }
   llvm_unreachable("Unknown AVXLevel");
 }


### PR DESCRIPTION
CIR CallConvLowering keeps one classifier per AVX level, so it sizes an array by the number of levels.  It got that number as the current end of the list plus one, which stops being the count the moment a level is added after the current end.  A runtime assert was necessary to guard the index.

The enum now names its own last enumerator and CallConvLowering derives the count from it.

Follow-up to review feedback deferred on #215118.

Assisted-by: Cursor / claude-opus-5
