### PR TITLE
[libsycl][unit] Use mock dummy handle functions for olMemAlloc functions

### DIFF
--- a/libsycl/unittests/mock/helpers.cpp
+++ b/libsycl/unittests/mock/helpers.cpp
@@ -335,7 +335,7 @@ void mock::MockLiboffload::initDefault() {
         EXPECT_NE(Type, OL_ALLOC_TYPE_HOST);
         EXPECT_GT(Size, 0);
         EXPECT_NE(AllocationOut, nullptr);
-        *AllocationOut = std::malloc(Size);
+        *AllocationOut = mock::createDummyHandle<void *>(Size);
         return OL_SUCCESS;
       });
 
@@ -345,13 +345,13 @@ void mock::MockLiboffload::initDefault() {
         EXPECT_NE(Device, nullptr);
         EXPECT_GT(Size, 0);
         EXPECT_NE(AllocationOut, nullptr);
-        *AllocationOut = std::malloc(Size);
+        *AllocationOut = mock::createDummyHandle<void *>(Size);
         return OL_SUCCESS;
       });
 
   ON_CALL(*this, olMemFree).WillByDefault([this](void *Address) -> ol_result_t {
     EXPECT_NE(Address, nullptr);
-    std::free(Address);
+    mock::releaseDummyHandle(Address);
     return OL_SUCCESS;
   });
 }

--- a/libsycl/unittests/mock/helpers.hpp
+++ b/libsycl/unittests/mock/helpers.hpp
@@ -22,7 +22,6 @@
 #include <atomic>
 #include <cassert>
 #include <cstddef>
-#include <cstdlib>
 #include <cstring>
 #include <unordered_map>
 #include <vector>


### PR DESCRIPTION
Review feedback from https://github.com/llvm/llvm-project/pull/216170.