### PR TITLE
[libsycl][unit][CMake] Fix unittests gtest CMake target

### DIFF
--- a/libsycl/unittests/CMakeLists.txt
+++ b/libsycl/unittests/CMakeLists.txt
@@ -1,5 +1,8 @@
 include(AddUnitTest)
 
+# Make the targets default_gtest and default_gtest_main available.
+build_gtest()
+
 add_custom_target(LibsyclUnitTests)
 
 set_target_properties(LibsyclUnitTests PROPERTIES FOLDER "libsycl/Tests/Unit")

--- a/libsycl/unittests/mock/CMakeLists.txt
+++ b/libsycl/unittests/mock/CMakeLists.txt
@@ -5,16 +5,16 @@ add_library(ol_mock STATIC
 # LLVMOffload provides generated Offload API headers used by the mock.
 add_dependencies(ol_mock
   LLVMOffload
-  llvm_gtest
+  default_gtest
 )
 target_include_directories(ol_mock
   PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}"
     $<TARGET_PROPERTY:LLVMOffload,INTERFACE_INCLUDE_DIRECTORIES>
-    $<TARGET_PROPERTY:llvm_gtest,INTERFACE_INCLUDE_DIRECTORIES>
+    $<TARGET_PROPERTY:default_gtest,INTERFACE_INCLUDE_DIRECTORIES>
 )
 
 target_link_libraries(ol_mock
   PRIVATE
-  llvm_gtest
+  default_gtest
 )


### PR DESCRIPTION
This was exposed by my recent change moving the `gtest` unit tests to be called by `lit` (but still using `gtest`) but it seems the problem was technically there before.

We need to use a special gtest target for the runtime build. Luckily LLVM infra provides a cmake target we can depend on that will just make it work. More info [here](https://github.com/llvm/llvm-project/blob/ec26997e2e4606d97918a4a082c4f93ca38a6f46/third-party/unittest/CMakeLists.txt#L25) if interested.

Other runtimes do the same thing, see [here](https://github.com/llvm/llvm-project/blob/828d2d7fb65a9cd5946b347ad5173e3bdb21387d/openmp/tools/omptest/CMakeLists.txt#L88) for example.