### PR TITLE
[clang][Sema] Fixed a crash when an `address_space` attribute with a dependent argument was written after the declarator-id

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -441,6 +441,10 @@ features cannot lower the translation-unit ABI level;
   `sized_by_or_null` describe the size in bytes rather than a count of elements,
   they are now correctly accepted on such pointers.
 
+- Fixed a crash when an `address_space` attribute with a dependent argument was
+  written after the declarator-id, where it appertains to the declared entity
+  rather than to a declarator chunk. (#GH196982)
+
 #### Bug Fixes to C++ Support
 
 - Fixed an issue where `__typeof__` incorrectly rejected cv-qualified function types.

--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -443,7 +443,7 @@ features cannot lower the translation-unit ABI level;
 
 - Fixed a crash when an `address_space` attribute with a dependent argument was
   written after the declarator-id, where it appertains to the declared entity
-  rather than to a declarator chunk. (#GH196982)
+  rather than to a declarator chunk. (#GH196982, #GH111463)
 
 #### Bug Fixes to C++ Support
 

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -6350,8 +6350,7 @@ static void fillDependentAddressSpaceTypeLoc(
     for (const ParsedAttr &AL : *Attrs) {
       if (AL.getKind() != ParsedAttr::AT_AddressSpace)
         continue;
-      // Skip an attribute that did not produce a type: one diagnosed as
-      // invalid, or one whose argument is missing or is not an expression.
+      // Skip invalid or malformed attributes; they did not produce a type.
       if (AL.isInvalid() || AL.getNumArgs() != 1 || !AL.isArgExpr(0))
         continue;
       DASTL.setAttrNameLoc(AL.getLoc());
@@ -6429,9 +6428,8 @@ GetTypeSourceInfoForDeclarator(TypeProcessingState &State,
       case TypeLoc::DependentAddressSpace: {
         auto TL = CurrTL.castAs<DependentAddressSpaceTypeLoc>();
         // An attribute written after the declarator-id appertains to the
-        // declared entity and is applied to the outermost type rather than
-        // to a chunk, so every attribute list of the declarator has to be
-        // searched.
+        // declared entity, not to a chunk, so every attribute list of the
+        // declarator has to be searched.
         fillDependentAddressSpaceTypeLoc(TL, {&D.getTypeObject(i).getAttrs(),
                                               &D.getAttributes(),
                                               &D.getDeclSpec().getAttributes(),

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -6348,10 +6348,9 @@ static void fillDependentAddressSpaceTypeLoc(
     ArrayRef<const ParsedAttributesView *> AttrLists) {
   for (const ParsedAttributesView *Attrs : AttrLists) {
     for (const ParsedAttr &AL : *Attrs) {
-      if (AL.getKind() != ParsedAttr::AT_AddressSpace)
-        continue;
       // Skip invalid or malformed attributes; they did not produce a type.
-      if (AL.isInvalid() || AL.getNumArgs() != 1 || !AL.isArgExpr(0))
+      if (AL.getKind() != ParsedAttr::AT_AddressSpace || AL.isInvalid() ||
+          AL.getNumArgs() != 1 || !AL.isArgExpr(0))
         continue;
       DASTL.setAttrNameLoc(AL.getLoc());
       DASTL.setAttrExprOperand(AL.getArgAsExpr(0));

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -6343,19 +6343,21 @@ namespace {
   };
 } // end anonymous namespace
 
-static void fillDependentAddressSpaceTypeLoc(ASTContext &Context,
-                                             DependentAddressSpaceTypeLoc DASTL,
-                                             const Declarator &D,
-                                             const DeclaratorChunk &Chunk) {
+static void
+fillDependentAddressSpaceTypeLoc(DependentAddressSpaceTypeLoc DASTL,
+                                 const Declarator &D,
+                                 const DeclaratorChunk &Chunk) {
   // An attribute written after the declarator-id appertains to the declared
-  // entity, so it is applied to the outermost type instead of to the chunk
-  // that is being visited.
-  const ParsedAttributesView *AttrLists[] = {&Chunk.getAttrs(),
-                                             &D.getAttributes()};
+  // entity and is applied to the outermost type rather than to a chunk, so
+  // every attribute list of the declarator has to be searched.
+  const ParsedAttributesView *AttrLists[] = {
+      &Chunk.getAttrs(), &D.getAttributes(), &D.getDeclSpec().getAttributes(),
+      &D.getDeclarationAttributes()};
   for (const ParsedAttributesView *Attrs : AttrLists) {
     for (const ParsedAttr &AL : *Attrs) {
-      if (AL.getKind() != ParsedAttr::AT_AddressSpace || AL.getNumArgs() != 1 ||
-          !AL.isArgExpr(0))
+      // Invalid or malformed attributes never produce a type.
+      if (AL.getKind() != ParsedAttr::AT_AddressSpace || AL.isInvalid() ||
+          AL.getNumArgs() != 1 || !AL.isArgExpr(0))
         continue;
       DASTL.setAttrNameLoc(AL.getLoc());
       DASTL.setAttrExprOperand(AL.getArgAsExpr(0));
@@ -6364,7 +6366,8 @@ static void fillDependentAddressSpaceTypeLoc(ASTContext &Context,
     }
   }
 
-  DASTL.initializeLocal(Context, DASTL.getTypePtr()->getAttributeLoc());
+  llvm_unreachable(
+      "no address_space attribute found at the expected location!");
 }
 
 /// Create and instantiate a TypeSourceInfo with type source information.
@@ -6430,7 +6433,7 @@ GetTypeSourceInfoForDeclarator(TypeProcessingState &State,
 
       case TypeLoc::DependentAddressSpace: {
         auto TL = CurrTL.castAs<DependentAddressSpaceTypeLoc>();
-        fillDependentAddressSpaceTypeLoc(S.Context, TL, D, D.getTypeObject(i));
+        fillDependentAddressSpaceTypeLoc(TL, D, D.getTypeObject(i));
         CurrTL = TL.getPointeeTypeLoc().getUnqualifiedLoc();
         break;
       }

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -6343,11 +6343,20 @@ namespace {
   };
 } // end anonymous namespace
 
-static void
-fillDependentAddressSpaceTypeLoc(DependentAddressSpaceTypeLoc DASTL,
-                                 const ParsedAttributesView &Attrs) {
-  for (const ParsedAttr &AL : Attrs) {
-    if (AL.getKind() == ParsedAttr::AT_AddressSpace) {
+static void fillDependentAddressSpaceTypeLoc(ASTContext &Context,
+                                             DependentAddressSpaceTypeLoc DASTL,
+                                             const Declarator &D,
+                                             const DeclaratorChunk &Chunk) {
+  // An attribute written after the declarator-id appertains to the declared
+  // entity, so it is applied to the outermost type instead of to the chunk
+  // that is being visited.
+  const ParsedAttributesView *AttrLists[] = {&Chunk.getAttrs(),
+                                             &D.getAttributes()};
+  for (const ParsedAttributesView *Attrs : AttrLists) {
+    for (const ParsedAttr &AL : *Attrs) {
+      if (AL.getKind() != ParsedAttr::AT_AddressSpace || AL.getNumArgs() != 1 ||
+          !AL.isArgExpr(0))
+        continue;
       DASTL.setAttrNameLoc(AL.getLoc());
       DASTL.setAttrExprOperand(AL.getArgAsExpr(0));
       DASTL.setAttrOperandParensRange(SourceRange());
@@ -6355,8 +6364,7 @@ fillDependentAddressSpaceTypeLoc(DependentAddressSpaceTypeLoc DASTL,
     }
   }
 
-  llvm_unreachable(
-      "no address_space attribute found at the expected location!");
+  DASTL.initializeLocal(Context, DASTL.getTypePtr()->getAttributeLoc());
 }
 
 /// Create and instantiate a TypeSourceInfo with type source information.
@@ -6422,7 +6430,7 @@ GetTypeSourceInfoForDeclarator(TypeProcessingState &State,
 
       case TypeLoc::DependentAddressSpace: {
         auto TL = CurrTL.castAs<DependentAddressSpaceTypeLoc>();
-        fillDependentAddressSpaceTypeLoc(TL, D.getTypeObject(i).getAttrs());
+        fillDependentAddressSpaceTypeLoc(S.Context, TL, D, D.getTypeObject(i));
         CurrTL = TL.getPointeeTypeLoc().getUnqualifiedLoc();
         break;
       }

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -6343,21 +6343,16 @@ namespace {
   };
 } // end anonymous namespace
 
-static void
-fillDependentAddressSpaceTypeLoc(DependentAddressSpaceTypeLoc DASTL,
-                                 const Declarator &D,
-                                 const DeclaratorChunk &Chunk) {
-  // An attribute written after the declarator-id appertains to the declared
-  // entity and is applied to the outermost type rather than to a chunk, so
-  // every attribute list of the declarator has to be searched.
-  const ParsedAttributesView *AttrLists[] = {
-      &Chunk.getAttrs(), &D.getAttributes(), &D.getDeclSpec().getAttributes(),
-      &D.getDeclarationAttributes()};
+static void fillDependentAddressSpaceTypeLoc(
+    DependentAddressSpaceTypeLoc DASTL,
+    ArrayRef<const ParsedAttributesView *> AttrLists) {
   for (const ParsedAttributesView *Attrs : AttrLists) {
     for (const ParsedAttr &AL : *Attrs) {
-      // Invalid or malformed attributes never produce a type.
-      if (AL.getKind() != ParsedAttr::AT_AddressSpace || AL.isInvalid() ||
-          AL.getNumArgs() != 1 || !AL.isArgExpr(0))
+      if (AL.getKind() != ParsedAttr::AT_AddressSpace)
+        continue;
+      // Skip an attribute that did not produce a type: one diagnosed as
+      // invalid, or one whose argument is missing or is not an expression.
+      if (AL.isInvalid() || AL.getNumArgs() != 1 || !AL.isArgExpr(0))
         continue;
       DASTL.setAttrNameLoc(AL.getLoc());
       DASTL.setAttrExprOperand(AL.getArgAsExpr(0));
@@ -6433,7 +6428,14 @@ GetTypeSourceInfoForDeclarator(TypeProcessingState &State,
 
       case TypeLoc::DependentAddressSpace: {
         auto TL = CurrTL.castAs<DependentAddressSpaceTypeLoc>();
-        fillDependentAddressSpaceTypeLoc(TL, D, D.getTypeObject(i));
+        // An attribute written after the declarator-id appertains to the
+        // declared entity and is applied to the outermost type rather than
+        // to a chunk, so every attribute list of the declarator has to be
+        // searched.
+        fillDependentAddressSpaceTypeLoc(TL, {&D.getTypeObject(i).getAttrs(),
+                                              &D.getAttributes(),
+                                              &D.getDeclSpec().getAttributes(),
+                                              &D.getDeclarationAttributes()});
         CurrTL = TL.getPointeeTypeLoc().getUnqualifiedLoc();
         break;
       }

--- a/clang/test/SemaTemplate/address_space-dependent.cpp
+++ b/clang/test/SemaTemplate/address_space-dependent.cpp
@@ -130,3 +130,17 @@ struct EntryTy {
 ASPtrTy<1> x;
 EntryTy<2> y;
 }
+
+namespace gh196982 {
+template <int AS>
+void trailing() {
+  void *p [[clang::address_space(AS)]]; // expected-warning {{applying attribute 'clang::address_space' to a declaration is deprecated; apply it to the type instead}}
+  void *q __attribute__((address_space(AS)));
+  int r[2] __attribute__((address_space(AS)));
+}
+
+void invalidOperand() {
+  void *p [[clang::address_space(undeclared())]]; // expected-error {{use of undeclared identifier 'undeclared'}} \
+                                                 // expected-warning {{applying attribute 'clang::address_space' to a declaration is deprecated; apply it to the type instead}}
+}
+}

--- a/clang/test/SemaTemplate/address_space-dependent.cpp
+++ b/clang/test/SemaTemplate/address_space-dependent.cpp
@@ -151,3 +151,10 @@ void invalidFirst() {
   void *v __attribute__((address_space)) __attribute__((address_space(AS))); // expected-error {{'address_space' attribute takes one argument}}
 }
 }
+
+namespace gh111463 {
+template <int I>
+void func() {
+  int *y __attribute__((address_space(I)));
+}
+}

--- a/clang/test/SemaTemplate/address_space-dependent.cpp
+++ b/clang/test/SemaTemplate/address_space-dependent.cpp
@@ -143,4 +143,11 @@ void invalidOperand() {
   void *p [[clang::address_space(undeclared())]]; // expected-error {{use of undeclared identifier 'undeclared'}} \
                                                  // expected-warning {{applying attribute 'clang::address_space' to a declaration is deprecated; apply it to the type instead}}
 }
+
+template <int AS>
+void invalidFirst() {
+  // The type location is filled from the second attribute; the first one is
+  // malformed and produced no type.
+  void *v __attribute__((address_space)) __attribute__((address_space(AS))); // expected-error {{'address_space' attribute takes one argument}}
+}
 }


### PR DESCRIPTION
Fixes #196982
Fixes #111463 

When filling in source locations for a dependent `address_space` type, we only looked at the declarator chunk being visited. But an attribute written after the declarator-id appertains to the declared entity, so it never lands on a chunk — it gets applied to the outermost type instead. The search came up empty and we hit the `llvm_unreachable`. Nothing to do with the malformed code in the bug report, by the way: plain template `<int AS> void f() { void *p [[clang::address_space(AS)]]; }` crashes too.

The lookup now searches every attribute list of the declarator (chunk, declarator, decl-spec, declaration), passed as an `ArrayRef` by the caller, so the attribute is always findable and the original `llvm_unreachable` stays. Attributes that are invalid or malformed are skipped, since they never produced a type. This matters when a malformed attribute comes before the valid one in the same list, e.g. `void *v __attribute__((address_space)) __attribute__((address_space(AS)));` — the first attribute is diagnosed and produces nothing, and matching it would mean reading an argument it doesn't have.

LLM tools were used for this contribution. I've reviewed, built, and tested the change myself before pushing to GitHub.