### PR TITLE
[lldb] Indent Watchpoint's new value correctly.

### DIFF
--- a/lldb/source/Breakpoint/Watchpoint.cpp
+++ b/lldb/source/Breakpoint/Watchpoint.cpp
@@ -309,8 +309,10 @@ bool Watchpoint::DumpSnapshots(Stream *s, const char *prefix) const {
   }
 
   if (m_new_value_sp) {
-    if (values_ss.GetSize())
-      values_ss.PutCString("\n");
+    if (values_ss.GetSize()) {
+      values_ss.PutChar('\n');
+      values_ss.Indent(prefix);
+    }
 
     if (auto *new_value_cstr = m_new_value_sp->GetValueAsCString())
       values_ss.Printf("new value: %s", new_value_cstr);


### PR DESCRIPTION
Previously
```
Watchpoint 1 hit:
    old value: 2
new value: 4
```
Now
```
Watchpoint 1 hit:
    old value: 2
    new value: 4
```