### PR TITLE
[Clang][AST] Use llvm::dyn_cast instead of dyn_cast on PointerUnion

### DIFF
--- a/clang/include/clang/AST/ASTConcept.h
+++ b/clang/include/clang/AST/ASTConcept.h
@@ -76,7 +76,7 @@ public:
 
   bool HasSubstitutionFailure() {
     for (const auto &Detail : Details)
-      if (Detail.dyn_cast<const ConstraintSubstitutionDiagnostic *>())
+      if (isa<const ConstraintSubstitutionDiagnostic *>(Detail))
         return true;
     return false;
   }

--- a/clang/include/clang/AST/DeclCXX.h
+++ b/clang/include/clang/AST/DeclCXX.h
@@ -2534,7 +2534,7 @@ public:
   /// Returns the declarator information for a base class or delegating
   /// initializer.
   TypeSourceInfo *getTypeSourceInfo() const {
-    return Initializee.dyn_cast<TypeSourceInfo *>();
+    return dyn_cast<TypeSourceInfo *>(Initializee);
   }
 
   /// If this is a member initializer, returns the declaration of the

--- a/clang/include/clang/AST/DeclContextInternals.h
+++ b/clang/include/clang/AST/DeclContextInternals.h
@@ -56,13 +56,13 @@ class StoredDeclsList {
       if (!ShouldErase(*DeclListNode::iterator(List))) {
         NewLast = NewTail;
         *NewTail = List;
-        if (auto *Node = List.dyn_cast<DeclListNode*>()) {
+        if (auto *Node = dyn_cast<DeclListNode *>(List)) {
           NewTail = &Node->Rest;
           List = Node->Rest;
         } else {
           break;
         }
-      } else if (DeclListNode *N = List.dyn_cast<DeclListNode*>()) {
+      } else if (DeclListNode *N = dyn_cast<DeclListNode *>(List)) {
         List = N->Rest;
         C.DeallocateDeclListNode(N);
       } else {
@@ -111,7 +111,7 @@ public:
     // If this is a list-form, free the list.
     ASTContext &C = getASTContext();
     Decls List = Data.getPointer();
-    while (DeclListNode *ToDealloc = List.dyn_cast<DeclListNode *>()) {
+    while (DeclListNode *ToDealloc = dyn_cast<DeclListNode *>(List)) {
       List = ToDealloc->Rest;
       C.DeallocateDeclListNode(ToDealloc);
     }
@@ -142,11 +142,11 @@ public:
   DeclsAndHasExternalTy getAsListAndHasExternal() const { return Data; }
 
   NamedDecl *getAsDecl() const {
-    return getAsListAndHasExternal().getPointer().dyn_cast<NamedDecl *>();
+    return dyn_cast<NamedDecl *>(getAsListAndHasExternal().getPointer());
   }
 
   DeclListNode *getAsList() const {
-    return getAsListAndHasExternal().getPointer().dyn_cast<DeclListNode*>();
+    return dyn_cast<DeclListNode *>(getAsListAndHasExternal().getPointer());
   }
 
   bool hasExternalDecls() const {
@@ -248,12 +248,12 @@ public:
     assert(!llvm::is_contained(getLookupResult(), D) && "Already exists!");
     // Determine if this declaration is actually a redeclaration.
     for (DeclListNode *N = getAsList(); /*return in loop*/;
-         N = N->Rest.dyn_cast<DeclListNode *>()) {
+         N = dyn_cast<DeclListNode *>(N->Rest)) {
       if (D->declarationReplaces(N->D, IsKnownNewer)) {
         N->D = D;
         return;
       }
-      if (auto *ND = N->Rest.dyn_cast<NamedDecl *>()) {
+      if (auto *ND = dyn_cast<NamedDecl *>(N->Rest)) {
         if (D->declarationReplaces(ND, IsKnownNewer)) {
           N->Rest = D;
           return;
@@ -290,7 +290,7 @@ public:
     }
 
     while (true) {
-      if (auto *Node = D.dyn_cast<DeclListNode*>()) {
+      if (auto *Node = dyn_cast<DeclListNode *>(D)) {
         llvm::errs() << '[' << Node->D << "] -> ";
         D = Node->Rest;
       } else {

--- a/clang/include/clang/AST/DeclFriend.h
+++ b/clang/include/clang/AST/DeclFriend.h
@@ -123,7 +123,7 @@ public:
   /// is used for elaborated-type-specifiers and, in C++0x, for
   /// arbitrary friend type declarations.
   TypeSourceInfo *getFriendType() const {
-    return Friend.dyn_cast<TypeSourceInfo*>();
+    return dyn_cast<TypeSourceInfo *>(Friend);
   }
 
   unsigned getFriendTypeNumTemplateParameterLists() const {
@@ -136,9 +136,7 @@ public:
 
   /// If this friend declaration doesn't name a type, return the inner
   /// declaration.
-  NamedDecl *getFriendDecl() const {
-    return Friend.dyn_cast<NamedDecl *>();
-  }
+  NamedDecl *getFriendDecl() const { return dyn_cast<NamedDecl *>(Friend); }
 
   /// Retrieves the location of the 'friend' keyword.
   SourceLocation getFriendLoc() const {

--- a/clang/include/clang/AST/DeclTemplate.h
+++ b/clang/include/clang/AST/DeclTemplate.h
@@ -315,7 +315,7 @@ class DefaultArgStorage {
 
   static ParmDecl *getParmOwningDefaultArg(ParmDecl *Parm) {
     const DefaultArgStorage &Storage = Parm->getDefaultArgStorage();
-    if (auto *Prev = Storage.ValueOrInherited.template dyn_cast<ParmDecl *>())
+    if (auto *Prev = dyn_cast<ParmDecl *>(Storage.ValueOrInherited))
       Parm = Prev;
     assert(!isa<ParmDecl *>(Parm->getDefaultArgStorage().ValueOrInherited) &&
            "should only be one level of indirection");
@@ -336,9 +336,9 @@ public:
   /// default argument is visible.
   ArgType get() const {
     const DefaultArgStorage *Storage = this;
-    if (const auto *Prev = ValueOrInherited.template dyn_cast<ParmDecl *>())
+    if (const auto *Prev = dyn_cast<ParmDecl *>(ValueOrInherited))
       Storage = &Prev->getDefaultArgStorage();
-    if (const auto *C = Storage->ValueOrInherited.template dyn_cast<Chain *>())
+    if (const auto *C = dyn_cast<Chain *>(Storage->ValueOrInherited))
       return C->Value;
     return cast<ArgType>(Storage->ValueOrInherited);
   }
@@ -346,9 +346,9 @@ public:
   /// Get the parameter from which we inherit the default argument, if any.
   /// This is the parameter on which the default argument was actually written.
   const ParmDecl *getInheritedFrom() const {
-    if (const auto *D = ValueOrInherited.template dyn_cast<ParmDecl *>())
+    if (const auto *D = dyn_cast<ParmDecl *>(ValueOrInherited))
       return D;
-    if (const auto *C = ValueOrInherited.template dyn_cast<Chain *>())
+    if (const auto *C = dyn_cast<Chain *>(ValueOrInherited))
       return C->PrevDeclWithDefaultArg;
     return nullptr;
   }
@@ -1989,7 +1989,7 @@ public:
                      ClassTemplatePartialSpecializationDecl *>
   getSpecializedTemplateOrPartial() const {
     if (const auto *PartialSpec =
-            SpecializedTemplate.dyn_cast<SpecializedPartialSpecialization *>())
+            dyn_cast<SpecializedPartialSpecialization *>(SpecializedTemplate))
       return PartialSpec->PartialSpecialization;
 
     return cast<ClassTemplateDecl *>(SpecializedTemplate);
@@ -2008,7 +2008,7 @@ public:
   /// itself.
   const TemplateArgumentList &getTemplateInstantiationArgs() const {
     if (const auto *PartialSpec =
-            SpecializedTemplate.dyn_cast<SpecializedPartialSpecialization *>())
+            dyn_cast<SpecializedPartialSpecialization *>(SpecializedTemplate))
       return *PartialSpec->TemplateArgs;
 
     return getTemplateArgs();
@@ -2505,15 +2505,13 @@ public:
   /// a dependent member type of a templated type), return that
   /// type;  otherwise return null.
   TypeSourceInfo *getFriendType() const {
-    return Friend.dyn_cast<TypeSourceInfo*>();
+    return dyn_cast<TypeSourceInfo *>(Friend);
   }
 
   /// If this friend declaration names a templated function (or
   /// a member function of a templated type), return that type;
   /// otherwise return null.
-  NamedDecl *getFriendDecl() const {
-    return Friend.dyn_cast<NamedDecl*>();
-  }
+  NamedDecl *getFriendDecl() const { return dyn_cast<NamedDecl *>(Friend); }
 
   /// Retrieves the location of the 'friend' keyword.
   SourceLocation getFriendLoc() const {
@@ -2757,7 +2755,7 @@ public:
   llvm::PointerUnion<VarTemplateDecl *, VarTemplatePartialSpecializationDecl *>
   getSpecializedTemplateOrPartial() const {
     if (const auto *PartialSpec =
-            SpecializedTemplate.dyn_cast<SpecializedPartialSpecialization *>())
+            dyn_cast<SpecializedPartialSpecialization *>(SpecializedTemplate))
       return PartialSpec->PartialSpecialization;
 
     return cast<VarTemplateDecl *>(SpecializedTemplate);
@@ -2776,7 +2774,7 @@ public:
   /// specialization itself.
   const TemplateArgumentList &getTemplateInstantiationArgs() const {
     if (const auto *PartialSpec =
-            SpecializedTemplate.dyn_cast<SpecializedPartialSpecialization *>())
+            dyn_cast<SpecializedPartialSpecialization *>(SpecializedTemplate))
       return *PartialSpec->TemplateArgs;
 
     return getTemplateArgs();
@@ -3458,9 +3456,9 @@ public:
 };
 
 inline NamedDecl *getAsNamedDecl(TemplateParameter P) {
-  if (auto *PD = P.dyn_cast<TemplateTypeParmDecl *>())
+  if (auto *PD = dyn_cast<TemplateTypeParmDecl *>(P))
     return PD;
-  if (auto *PD = P.dyn_cast<NonTypeTemplateParmDecl *>())
+  if (auto *PD = dyn_cast<NonTypeTemplateParmDecl *>(P))
     return PD;
   return cast<TemplateTemplateParmDecl *>(P);
 }

--- a/clang/include/clang/AST/ExprCXX.h
+++ b/clang/include/clang/AST/ExprCXX.h
@@ -2711,11 +2711,11 @@ public:
   PseudoDestructorTypeStorage(TypeSourceInfo *Info);
 
   TypeSourceInfo *getTypeSourceInfo() const {
-    return Type.dyn_cast<TypeSourceInfo *>();
+    return dyn_cast<TypeSourceInfo *>(Type);
   }
 
   const IdentifierInfo *getIdentifier() const {
-    return Type.dyn_cast<const IdentifierInfo *>();
+    return dyn_cast<const IdentifierInfo *>(Type);
   }
 
   SourceLocation getLocation() const { return Location; }
@@ -4957,11 +4957,11 @@ public:
   }
 
   LifetimeExtendedTemporaryDecl *getLifetimeExtendedTemporaryDecl() {
-    return State.dyn_cast<LifetimeExtendedTemporaryDecl *>();
+    return dyn_cast<LifetimeExtendedTemporaryDecl *>(State);
   }
   const LifetimeExtendedTemporaryDecl *
   getLifetimeExtendedTemporaryDecl() const {
-    return State.dyn_cast<LifetimeExtendedTemporaryDecl *>();
+    return dyn_cast<LifetimeExtendedTemporaryDecl *>(State);
   }
 
   /// Get the declaration which triggered the lifetime-extension of this

--- a/clang/include/clang/AST/ExternalASTSource.h
+++ b/clang/include/clang/AST/ExternalASTSource.h
@@ -479,7 +479,7 @@ public:
 
   /// Set the value of this pointer, in the current generation.
   void set(T NewValue) {
-    if (auto *LazyVal = Value.template dyn_cast<LazyData *>()) {
+    if (auto *LazyVal = dyn_cast<LazyData *>(Value)) {
       LazyVal->LastValue = NewValue;
       return;
     }
@@ -491,7 +491,7 @@ public:
 
   /// Get the value of this pointer, updating its owner if necessary.
   T get(Owner O) {
-    if (auto *LazyVal = Value.template dyn_cast<LazyData *>()) {
+    if (auto *LazyVal = dyn_cast<LazyData *>(Value)) {
       if (LazyVal->LastGeneration != LazyVal->ExternalSource->getGeneration()) {
         LazyVal->LastGeneration = LazyVal->ExternalSource->getGeneration();
         (LazyVal->ExternalSource->*Update)(O);
@@ -503,7 +503,7 @@ public:
 
   /// Get the most recently computed value of this pointer without updating it.
   T getNotUpdated() const {
-    if (auto *LazyVal = Value.template dyn_cast<LazyData *>())
+    if (auto *LazyVal = dyn_cast<LazyData *>(Value))
       return LazyVal->LastValue;
     return cast<T>(Value);
   }

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -1580,8 +1580,8 @@ void ASTContext::addExplicitInstantiationDecl(const NamedDecl *Spec,
 MemberSpecializationInfo *
 ASTContext::getInstantiatedFromStaticDataMember(const VarDecl *Var) {
   assert(Var->isStaticDataMember() && "Not a static data member");
-  return getTemplateOrSpecializationInfo(Var)
-      .dyn_cast<MemberSpecializationInfo *>();
+  return dyn_cast<MemberSpecializationInfo *>(
+      getTemplateOrSpecializationInfo(Var));
 }
 
 ASTContext::TemplateOrSpecializationInfo

--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -1075,19 +1075,18 @@ Error ASTNodeImporter::ImportConstraintSatisfaction(
   ToSat.ContainsErrors = FromSat.ContainsErrors;
   if (!ToSat.IsSatisfied) {
     for (auto Record = FromSat.begin(); Record != FromSat.end(); ++Record) {
-      if (const Expr *E = Record->dyn_cast<const Expr *>()) {
+      if (const Expr *E = dyn_cast<const Expr *>(*Record)) {
         ExpectedExpr ToSecondExpr = import(E);
         if (!ToSecondExpr)
           return ToSecondExpr.takeError();
         ToSat.Details.emplace_back(ToSecondExpr.get());
-      } else if (auto CR = Record->dyn_cast<const ConceptReference *>()) {
+      } else if (auto CR = dyn_cast<const ConceptReference *>(*Record)) {
         Expected<ConceptReference *> ToCROrErr = import(CR);
         if (!ToCROrErr)
           return ToCROrErr.takeError();
         ToSat.Details.emplace_back(ToCROrErr.get());
       } else {
-        auto Pair =
-            Record->dyn_cast<const ConstraintSubstitutionDiagnostic *>();
+        auto Pair = dyn_cast<const ConstraintSubstitutionDiagnostic *>(*Record);
 
         ExpectedSLoc ToPairFirst = import(Pair->first);
         if (!ToPairFirst)
@@ -9446,7 +9445,7 @@ void ASTImporter::RegisterImportedDecl(Decl *FromD, Decl *ToD) {
 
 llvm::Expected<ExprWithCleanups::CleanupObject>
 ASTImporter::Import(ExprWithCleanups::CleanupObject From) {
-  if (auto *CLE = From.dyn_cast<CompoundLiteralExpr *>()) {
+  if (auto *CLE = dyn_cast<CompoundLiteralExpr *>(From)) {
     if (Expected<Expr *> R = Import(CLE))
       return ExprWithCleanups::CleanupObject(cast<CompoundLiteralExpr>(*R));
   }

--- a/clang/lib/AST/ByteCode/DeclOrExpr.h
+++ b/clang/lib/AST/ByteCode/DeclOrExpr.h
@@ -29,8 +29,8 @@ struct DeclOrExpr {
   bool isDecl() const { return isa_and_nonnull<const Decl *>(V); }
   bool isValueDecl() const { return isa_and_nonnull<ValueDecl>(asDecl()); }
 
-  const Expr *asExpr() const { return V.dyn_cast<const Expr *>(); }
-  const Decl *asDecl() const { return V.dyn_cast<const Decl *>(); }
+  const Expr *asExpr() const { return dyn_cast<const Expr *>(V); }
+  const Decl *asDecl() const { return dyn_cast<const Decl *>(V); }
   const ValueDecl *asValueDecl() const {
     return dyn_cast_if_present<ValueDecl>(asDecl());
   }

--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -2401,7 +2401,7 @@ Expr *VarDecl::getInit() {
 }
 
 Stmt **VarDecl::getInitAddress() {
-  if (auto *ES = Init.dyn_cast<EvaluatedStmt *>())
+  if (auto *ES = dyn_cast<EvaluatedStmt *>(Init))
     return ES->Value.getAddressOfPointer(getASTContext().getExternalSource());
 
   return Init.getAddrOfPtr1();
@@ -2705,7 +2705,7 @@ VarDecl *VarDecl::getTemplateInstantiationPattern() const {
   if (auto *VDTemplSpec = dyn_cast<VarTemplateSpecializationDecl>(VD)) {
     if (isTemplateInstantiation(VDTemplSpec->getTemplateSpecializationKind())) {
       auto From = VDTemplSpec->getInstantiatedFrom();
-      if (auto *VTD = From.dyn_cast<VarTemplateDecl *>()) {
+      if (auto *VTD = dyn_cast<VarTemplateDecl *>(From)) {
         while (!VTD->isMemberSpecialization()) {
           auto *NewVTD = VTD->getInstantiatedFromMemberTemplate();
           if (!NewVTD)
@@ -2715,7 +2715,7 @@ VarDecl *VarDecl::getTemplateInstantiationPattern() const {
         return VTD->getTemplatedDecl();
       }
       if (auto *VTPSD =
-              From.dyn_cast<VarTemplatePartialSpecializationDecl *>()) {
+              dyn_cast<VarTemplatePartialSpecializationDecl *>(From)) {
         while (!VTPSD->isMemberSpecialization()) {
           auto *NewVTPSD = VTPSD->getInstantiatedFromMember();
           if (!NewVTPSD)
@@ -4251,7 +4251,7 @@ void FunctionDecl::setInstantiatedFromDecl(FunctionDecl *FD) {
 
 FunctionDecl *FunctionDecl::getInstantiatedFromDecl() const {
   return dyn_cast_if_present<FunctionDecl>(
-      TemplateOrSpecialization.dyn_cast<NamedDecl *>());
+      dyn_cast<NamedDecl *>(TemplateOrSpecialization));
 }
 
 bool FunctionDecl::isImplicitlyInstantiable() const {
@@ -4567,12 +4567,12 @@ bool FunctionDecl::isImplicitHDExplicitInstantiation() const {
 }
 
 SourceLocation FunctionDecl::getPointOfInstantiation() const {
-  if (FunctionTemplateSpecializationInfo *FTSInfo
-        = TemplateOrSpecialization.dyn_cast<
-                                        FunctionTemplateSpecializationInfo*>())
+  if (FunctionTemplateSpecializationInfo *FTSInfo =
+          dyn_cast<FunctionTemplateSpecializationInfo *>(
+              TemplateOrSpecialization))
     return FTSInfo->getPointOfInstantiation();
   if (MemberSpecializationInfo *MSInfo =
-          TemplateOrSpecialization.dyn_cast<MemberSpecializationInfo *>())
+          dyn_cast<MemberSpecializationInfo *>(TemplateOrSpecialization))
     return MSInfo->getPointOfInstantiation();
 
   return SourceLocation();

--- a/clang/lib/AST/DeclTemplate.cpp
+++ b/clang/lib/AST/DeclTemplate.cpp
@@ -1030,7 +1030,7 @@ void ClassTemplateSpecializationDecl::getNameForDiagnostic(
 ClassTemplateDecl *
 ClassTemplateSpecializationDecl::getSpecializedTemplate() const {
   if (const auto *PartialSpec =
-          SpecializedTemplate.dyn_cast<SpecializedPartialSpecialization*>())
+          dyn_cast<SpecializedPartialSpecialization *>(SpecializedTemplate))
     return PartialSpec->PartialSpecialization->getSpecializedTemplate();
   return cast<ClassTemplateDecl *>(SpecializedTemplate);
 }
@@ -1460,7 +1460,7 @@ void VarTemplateSpecializationDecl::getNameForDiagnostic(
 
 VarTemplateDecl *VarTemplateSpecializationDecl::getSpecializedTemplate() const {
   if (const auto *PartialSpec =
-          SpecializedTemplate.dyn_cast<SpecializedPartialSpecialization *>())
+          dyn_cast<SpecializedPartialSpecialization *>(SpecializedTemplate))
     return PartialSpec->PartialSpecialization->getSpecializedTemplate();
   return cast<VarTemplateDecl *>(SpecializedTemplate);
 }

--- a/clang/lib/AST/TemplateName.cpp
+++ b/clang/lib/AST/TemplateName.cpp
@@ -251,7 +251,7 @@ std::optional<TemplateName> TemplateName::desugar(bool IgnoreDeduced) const {
 
 OverloadedTemplateStorage *TemplateName::getAsOverloadedTemplate() const {
   if (UncommonTemplateNameStorage *Uncommon =
-          Storage.dyn_cast<UncommonTemplateNameStorage *>())
+          dyn_cast<UncommonTemplateNameStorage *>(Storage))
     return Uncommon->getAsOverloadedStorage();
 
   return nullptr;
@@ -259,7 +259,7 @@ OverloadedTemplateStorage *TemplateName::getAsOverloadedTemplate() const {
 
 AssumedTemplateStorage *TemplateName::getAsAssumedTemplateName() const {
   if (UncommonTemplateNameStorage *Uncommon =
-          Storage.dyn_cast<UncommonTemplateNameStorage *>())
+          dyn_cast<UncommonTemplateNameStorage *>(Storage))
     return Uncommon->getAsAssumedTemplateName();
 
   return nullptr;
@@ -277,7 +277,7 @@ TemplateName::getAsSubstTemplateTemplateParm() const {
 SubstTemplateTemplateParmPackStorage *
 TemplateName::getAsSubstTemplateTemplateParmPack() const {
   if (UncommonTemplateNameStorage *Uncommon =
-          Storage.dyn_cast<UncommonTemplateNameStorage *>())
+          dyn_cast<UncommonTemplateNameStorage *>(Storage))
     return Uncommon->getAsSubstTemplateTemplateParmPack();
 
   return nullptr;
@@ -288,7 +288,7 @@ QualifiedTemplateName *TemplateName::getAsQualifiedTemplateName() const {
 }
 
 DependentTemplateName *TemplateName::getAsDependentTemplateName() const {
-  return Storage.dyn_cast<DependentTemplateName *>();
+  return dyn_cast<DependentTemplateName *>(Storage);
 }
 
 std::tuple<NestedNameSpecifier, bool>
@@ -307,7 +307,7 @@ TemplateName::getQualifierAndTemplateKeyword() const {
 }
 
 UsingShadowDecl *TemplateName::getAsUsingShadowDecl() const {
-  if (Decl *D = Storage.dyn_cast<Decl *>())
+  if (Decl *D = dyn_cast<Decl *>(Storage))
     if (UsingShadowDecl *USD = dyn_cast<UsingShadowDecl>(D))
       return USD;
   if (QualifiedTemplateName *QTN = getAsQualifiedTemplateName())

--- a/clang/lib/ASTMatchers/ASTMatchFinder.cpp
+++ b/clang/lib/ASTMatchers/ASTMatchFinder.cpp
@@ -805,7 +805,7 @@ private:
                    const T *>                                                  \
   getNode() const {                                                            \
     assertHoldsState();                                                        \
-    return Callback.getInt() == (Index) ? Node##Index.dyn_cast<const T *>()    \
+    return Callback.getInt() == (Index) ? dyn_cast<const T *>(Node##Index)     \
                                         : nullptr;                             \
   }
 


### PR DESCRIPTION
This is part of the migration from `PointerUnion<PTs>::dyn_cast<T>()` to `llvm::dyn_cast<T>(PointerUnion)`.
The dyn_cast method on PointerUnion is simply a wrapper around `llvm::dyn_cast_if_present`, which means that it can be replaced with `llvm::dyn_cast` for all non-optional types.