### PR TITLE
[Clang] Use llvm::dyn_cast instead of dyn_cast on PointerUnion

### DIFF
--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/Loans.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/Loans.h
@@ -82,11 +82,11 @@ public:
   PlaceholderBase(const CXXMethodDecl *MD) : ParamOrMethod(MD) {}
 
   const ParmVarDecl *getParmVarDecl() const {
-    return ParamOrMethod.dyn_cast<const ParmVarDecl *>();
+    return dyn_cast<const ParmVarDecl *>(ParamOrMethod);
   }
 
   const CXXMethodDecl *getImplicitThisParent() const {
-    return ParamOrMethod.dyn_cast<const CXXMethodDecl *>();
+    return dyn_cast<const CXXMethodDecl *>(ParamOrMethod);
   }
 
   void Profile(llvm::FoldingSetNodeID &ID) const {
@@ -134,19 +134,19 @@ public:
   }
 
   const clang::ValueDecl *getAsValueDecl() const {
-    return Base.dyn_cast<const clang::ValueDecl *>();
+    return dyn_cast<const clang::ValueDecl *>(Base);
   }
 
   const clang::MaterializeTemporaryExpr *getAsMaterializeTemporaryExpr() const {
-    return Base.dyn_cast<const clang::MaterializeTemporaryExpr *>();
+    return dyn_cast<const clang::MaterializeTemporaryExpr *>(Base);
   }
 
   const PlaceholderBase *getAsPlaceholderBase() const {
-    return Base.dyn_cast<const PlaceholderBase *>();
+    return dyn_cast<const PlaceholderBase *>(Base);
   }
 
   const clang::CXXNewExpr *getAsNewAllocation() const {
-    return Base.dyn_cast<const clang::CXXNewExpr *>();
+    return dyn_cast<const clang::CXXNewExpr *>(Base);
   }
 
   bool operator==(const AccessPath &RHS) const {

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/Origins.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/Origins.h
@@ -59,10 +59,10 @@ struct Origin {
       : ID(ID), Ptr(E), Ty(QT) {}
 
   const clang::ValueDecl *getDecl() const {
-    return Ptr.dyn_cast<const clang::ValueDecl *>();
+    return dyn_cast<const clang::ValueDecl *>(Ptr);
   }
   const clang::Expr *getExpr() const {
-    return Ptr.dyn_cast<const clang::Expr *>();
+    return dyn_cast<const clang::Expr *>(Ptr);
   }
 };
 

--- a/clang/include/clang/Basic/FileEntry.h
+++ b/clang/include/clang/Basic/FileEntry.h
@@ -169,7 +169,7 @@ public:
   /// Retrieve the base MapEntry after redirects.
   const MapEntry &getBaseMapEntry() const {
     const MapEntry *Base = ME;
-    while (const auto *Next = Base->second->V.dyn_cast<const MapEntry *>())
+    while (const auto *Next = dyn_cast<const MapEntry *>(Base->second->V))
       Base = Next;
     return *Base;
   }

--- a/clang/include/clang/Lex/PreprocessingRecord.h
+++ b/clang/include/clang/Lex/PreprocessingRecord.h
@@ -192,7 +192,7 @@ class Token;
     /// The definition of the macro being expanded. May return null if
     /// this is a builtin macro.
     MacroDefinitionRecord *getDefinition() const {
-      return NameOrDef.dyn_cast<MacroDefinitionRecord *>();
+      return dyn_cast<MacroDefinitionRecord *>(NameOrDef);
     }
 
     // Implement isa/cast/dyncast/etc.

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h
@@ -230,9 +230,7 @@ public:
 
   /// Returns the declaration of the function or method that will be
   /// called. May be null.
-  virtual const Decl *getDecl() const {
-    return Origin.dyn_cast<const Decl *>();
-  }
+  virtual const Decl *getDecl() const { return dyn_cast<const Decl *>(Origin); }
 
   bool isForeign() const {
     assert(Foreign && "Foreign must be set before querying");
@@ -260,7 +258,7 @@ public:
   /// Returns the expression whose value will be the result of this call.
   /// Null if and only if 'this' is a CXXDestructorCall.
   virtual const Expr *getOriginExpr() const {
-    return Origin.dyn_cast<const Expr *>();
+    return dyn_cast<const Expr *>(Origin);
   }
 
   /// Returns the number of arguments (explicit and implicit).

--- a/clang/lib/APINotes/APINotesManager.cpp
+++ b/clang/lib/APINotes/APINotesManager.cpp
@@ -429,7 +429,7 @@ APINotesManager::findAPINotes(SourceLocation Loc) {
         }
 
         // Grab the result.
-        if (auto Reader = Readers[*Dir].dyn_cast<APINotesReader *>())
+        if (auto Reader = dyn_cast<APINotesReader *>(Readers[*Dir]))
           Results.push_back(Reader);
         break;
       }
@@ -444,7 +444,7 @@ APINotesManager::findAPINotes(SourceLocation Loc) {
       if (auto APINotesFile = FileMgr.getOptionalFileRef(APINotesPath)) {
         if (!loadAPINotes(*Dir, *APINotesFile)) {
           ++NumHeaderAPINotes;
-          if (auto Reader = Readers[*Dir].dyn_cast<APINotesReader *>())
+          if (auto Reader = dyn_cast<APINotesReader *>(Readers[*Dir]))
             Results.push_back(Reader);
           break;
         }

--- a/clang/lib/Analysis/LifetimeSafety/Checker.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Checker.cpp
@@ -73,9 +73,9 @@ private:
 
   static SourceLocation
   GetFactLoc(llvm::PointerUnion<const UseFact *, const OriginEscapesFact *> F) {
-    if (const auto *UF = F.dyn_cast<const UseFact *>())
+    if (const auto *UF = dyn_cast<const UseFact *>(F))
       return UF->getUseExpr()->getExprLoc();
-    if (const auto *OEF = F.dyn_cast<const OriginEscapesFact *>()) {
+    if (const auto *OEF = dyn_cast<const OriginEscapesFact *>(F)) {
       if (auto *ReturnEsc = dyn_cast<ReturnEscapeFact>(OEF))
         return ReturnEsc->getReturnExpr()->getExprLoc();
       if (auto *FieldEsc = dyn_cast<FieldEscapeFact>(OEF))
@@ -268,7 +268,7 @@ public:
       const Expr *MovedExpr = Warning.MovedExpr;
       SourceLocation ExpiryLoc = Warning.ExpiryLoc;
 
-      if (const auto *UF = CausingFact.dyn_cast<const UseFact *>()) {
+      if (const auto *UF = dyn_cast<const UseFact *>(CausingFact)) {
         llvm::SmallVector<const Expr *> ExprChain =
             getExprChain(LoanPropagation.buildOriginFlowChain(UF, LID, Cfg));
         if (Warning.InvalidatedByExpr) {
@@ -289,7 +289,7 @@ public:
                                           MovedExpr, ExpiryLoc, ExprChain);
 
       } else if (const auto *OEF =
-                     CausingFact.dyn_cast<const OriginEscapesFact *>()) {
+                     dyn_cast<const OriginEscapesFact *>(CausingFact)) {
         if (Warning.InvalidatedByExpr) {
           if (const auto *FieldEscape = dyn_cast<FieldEscapeFact>(OEF)) {
             // Invalidated object escapes to a field.
@@ -421,10 +421,10 @@ public:
       return;
     llvm::TimeTraceScope TimeTrace("SuggestAnnotations");
     for (auto [Target, EscapeTarget] : AnnotationWarningsMap) {
-      if (const auto *PVD = Target.dyn_cast<const ParmVarDecl *>())
+      if (const auto *PVD = dyn_cast<const ParmVarDecl *>(Target))
         suggestWithScopeForParmVar(PVD, EscapeTarget);
-      else if (const auto *MD = Target.dyn_cast<const CXXMethodDecl *>()) {
-        if (const auto *EscapeExpr = EscapeTarget.dyn_cast<const Expr *>())
+      else if (const auto *MD = dyn_cast<const CXXMethodDecl *>(Target)) {
+        if (const auto *EscapeExpr = dyn_cast<const Expr *>(EscapeTarget))
           suggestWithScopeForImplicitThis(MD, EscapeExpr);
         else
           llvm_unreachable("Implicit this can only escape via Expr (return)");
@@ -434,11 +434,11 @@ public:
 
   void reportNoescapeViolations() {
     for (auto [PVD, EscapeTarget] : NoescapeWarningsMap) {
-      if (const auto *E = EscapeTarget.dyn_cast<const Expr *>())
+      if (const auto *E = dyn_cast<const Expr *>(EscapeTarget))
         SemaHelper->reportNoescapeViolation(PVD, E);
-      else if (const auto *FD = EscapeTarget.dyn_cast<const FieldDecl *>())
+      else if (const auto *FD = dyn_cast<const FieldDecl *>(EscapeTarget))
         SemaHelper->reportNoescapeViolation(PVD, FD);
-      else if (const auto *G = EscapeTarget.dyn_cast<const VarDecl *>())
+      else if (const auto *G = dyn_cast<const VarDecl *>(EscapeTarget))
         SemaHelper->reportNoescapeViolation(PVD, G);
       else
         llvm_unreachable("Unhandled EscapingTarget type");
@@ -517,10 +517,10 @@ public:
 
   void inferAnnotations() {
     for (auto [Target, EscapeTarget] : AnnotationWarningsMap) {
-      if (const auto *MD = Target.dyn_cast<const CXXMethodDecl *>()) {
+      if (const auto *MD = dyn_cast<const CXXMethodDecl *>(Target)) {
         if (!implicitObjectParamIsLifetimeBound(MD))
           SemaHelper->addLifetimeBoundToImplicitThis(cast<CXXMethodDecl>(MD));
-      } else if (const auto *PVD = Target.dyn_cast<const ParmVarDecl *>()) {
+      } else if (const auto *PVD = dyn_cast<const ParmVarDecl *>(Target)) {
         const auto *FD = dyn_cast<FunctionDecl>(PVD->getDeclContext());
         if (!FD)
           continue;

--- a/clang/lib/Analysis/LifetimeSafety/LiveOrigins.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LiveOrigins.cpp
@@ -60,9 +60,9 @@ struct Lattice {
 };
 
 static SourceLocation GetFactLoc(CausingFactType F) {
-  if (const auto *UF = F.dyn_cast<const UseFact *>())
+  if (const auto *UF = dyn_cast<const UseFact *>(F))
     return UF->getUseExpr()->getExprLoc();
-  if (const auto *OEF = F.dyn_cast<const OriginEscapesFact *>()) {
+  if (const auto *OEF = dyn_cast<const OriginEscapesFact *>(F)) {
     if (auto *ReturnEsc = dyn_cast<ReturnEscapeFact>(OEF))
       return ReturnEsc->getReturnExpr()->getExprLoc();
     if (auto *FieldEsc = dyn_cast<FieldEscapeFact>(OEF))

--- a/clang/lib/CodeGen/CGBlocks.cpp
+++ b/clang/lib/CodeGen/CGBlocks.cpp
@@ -1094,7 +1094,7 @@ llvm::Value *CodeGenFunction::EmitBlockLiteral(const CGBlockInfo &blockInfo) {
       auto *EWC = llvm::dyn_cast_or_null<ExprWithCleanups>(RetExpr);
       if (EWC)
         for (auto &C : EWC->getObjects())
-          if (auto *BD = C.dyn_cast<BlockDecl *>())
+          if (auto *BD = dyn_cast<BlockDecl *>(C))
             if (BD == blockDecl)
               return true;
       return false;

--- a/clang/lib/Frontend/SARIFDiagnostic.cpp
+++ b/clang/lib/Frontend/SARIFDiagnostic.cpp
@@ -41,7 +41,7 @@ void SARIFDiagnostic::emitDiagnosticMessage(
     StringRef Message, ArrayRef<clang::CharSourceRange> Ranges,
     DiagOrStoredDiag D) {
 
-  const auto *Diag = D.dyn_cast<const Diagnostic *>();
+  const auto *Diag = dyn_cast<const Diagnostic *>(D);
 
   if (!Diag)
     return;

--- a/clang/lib/Index/FileIndexRecord.cpp
+++ b/clang/lib/Index/FileIndexRecord.cpp
@@ -44,7 +44,7 @@ void FileIndexRecord::addMacroOccurence(SymbolRoleSet Roles, unsigned Offset,
 
 void FileIndexRecord::removeHeaderGuardMacros() {
   llvm::erase_if(Decls, [](const DeclOccurrence &D) {
-    if (const auto *MI = D.DeclOrMacro.dyn_cast<const MacroInfo *>())
+    if (const auto *MI = dyn_cast<const MacroInfo *>(D.DeclOrMacro))
       return MI->isUsedForHeaderGuard();
     return false;
   });

--- a/clang/lib/Index/IndexDecl.cpp
+++ b/clang/lib/Index/IndexDecl.cpp
@@ -213,7 +213,7 @@ public:
     llvm::PointerUnion<ClassTemplateDecl *,
                        ClassTemplatePartialSpecializationDecl *>
         Template = CTSD->getSpecializedTemplateOrPartial();
-    if (const auto *CTD = Template.dyn_cast<ClassTemplateDecl *>()) {
+    if (const auto *CTD = dyn_cast<ClassTemplateDecl *>(Template)) {
       const CXXRecordDecl *Pattern = CTD->getTemplatedDecl();
       bool TypeOverride = isa<TypeDecl>(D);
       for (const NamedDecl *ND : Pattern->lookup(D->getDeclName())) {

--- a/clang/lib/Serialization/ASTReaderStmt.cpp
+++ b/clang/lib/Serialization/ASTReaderStmt.cpp
@@ -939,7 +939,7 @@ void ASTStmtReader::VisitRequiresExpr(RequiresExpr *E) {
               break;
           }
         }
-        if (Expr *Ex = E.dyn_cast<Expr *>())
+        if (Expr *Ex = dyn_cast<Expr *>(E))
           R = new (Record.getContext()) concepts::ExprRequirement(
                   Ex, RK == concepts::Requirement::RK_Simple, NoexceptLoc,
                   std::move(*Req), Status, SubstitutedConstraintExpr);

--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -6650,7 +6650,7 @@ void ASTWriter::WriteDeclUpdatesBlocks(ASTContext &Context,
           // specialization. If so, record which one.
           auto From = Spec->getInstantiatedFrom();
           if (auto PartialSpec =
-                From.dyn_cast<ClassTemplatePartialSpecializationDecl*>()) {
+                  dyn_cast<ClassTemplatePartialSpecializationDecl *>(From)) {
             Record.push_back(true);
             Record.AddDeclRef(PartialSpec);
             Record.AddTemplateArgumentList(

--- a/clang/lib/Serialization/ASTWriterDecl.cpp
+++ b/clang/lib/Serialization/ASTWriterDecl.cpp
@@ -1933,7 +1933,7 @@ void ASTDeclWriter::VisitClassTemplateSpecializationDecl(
   llvm::PointerUnion<ClassTemplateDecl *,
                      ClassTemplatePartialSpecializationDecl *> InstFrom
     = D->getSpecializedTemplateOrPartial();
-  if (Decl *InstFromD = InstFrom.dyn_cast<ClassTemplateDecl *>()) {
+  if (Decl *InstFromD = dyn_cast<ClassTemplateDecl *>(InstFrom)) {
     Record.AddDeclRef(InstFromD);
   } else {
     Record.AddDeclRef(cast<ClassTemplatePartialSpecializationDecl *>(InstFrom));
@@ -2016,7 +2016,7 @@ void ASTDeclWriter::VisitVarTemplateSpecializationDecl(
 
   llvm::PointerUnion<VarTemplateDecl *, VarTemplatePartialSpecializationDecl *>
   InstFrom = D->getSpecializedTemplateOrPartial();
-  if (Decl *InstFromD = InstFrom.dyn_cast<VarTemplateDecl *>()) {
+  if (Decl *InstFromD = dyn_cast<VarTemplateDecl *>(InstFrom)) {
     Record.AddDeclRef(InstFromD);
   } else {
     Record.AddDeclRef(cast<VarTemplatePartialSpecializationDecl *>(InstFrom));

--- a/clang/lib/Serialization/ASTWriterStmt.cpp
+++ b/clang/lib/Serialization/ASTWriterStmt.cpp
@@ -2096,10 +2096,10 @@ void ASTStmtWriter::VisitExprWithCleanups(ExprWithCleanups *E) {
   VisitExpr(E);
   Record.push_back(E->getNumObjects());
   for (auto &Obj : E->getObjects()) {
-    if (auto *BD = Obj.dyn_cast<BlockDecl *>()) {
+    if (auto *BD = dyn_cast<BlockDecl *>(Obj)) {
       Record.push_back(serialization::COK_Block);
       Record.AddDeclRef(BD);
-    } else if (auto *CLE = Obj.dyn_cast<CompoundLiteralExpr *>()) {
+    } else if (auto *CLE = dyn_cast<CompoundLiteralExpr *>(Obj)) {
       Record.push_back(serialization::COK_CompoundLiteral);
       Record.AddStmt(CLE);
     }

--- a/clang/lib/Serialization/MultiOnDiskHashTable.h
+++ b/clang/lib/Serialization/MultiOnDiskHashTable.h
@@ -110,8 +110,9 @@ private:
 
   MergedTable *getMergedTable() const {
     // If we already have a merged table, it's the first one.
-    return Tables.empty() ? nullptr : Table::getFromOpaqueValue(*Tables.begin())
-                                          .template dyn_cast<MergedTable*>();
+    return Tables.empty() ? nullptr
+                          : llvm::dyn_cast<MergedTable *>(
+                                Table::getFromOpaqueValue(*Tables.begin()));
   }
 
   /// Delete all our current on-disk tables.

--- a/clang/lib/StaticAnalyzer/Core/BugSuppression.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BugSuppression.cpp
@@ -257,7 +257,7 @@ preferTemplateDefinitionForTemplateSpecializations(const Decl *D) {
   if (!InstantiatedFrom)
     return D;
 
-  if (const auto *Tmpl = InstantiatedFrom.dyn_cast<ClassTemplateDecl *>()) {
+  if (const auto *Tmpl = dyn_cast<ClassTemplateDecl *>(InstantiatedFrom)) {
     // Interestingly, the source template might be a forward declaration, so we
     // need to find the definition redeclaration.
     return chooseDefinitionRedecl(walkInstantiatedFromChain(Tmpl));

--- a/clang/unittests/CodeGen/IRMatchers.h
+++ b/clang/unittests/CodeGen/IRMatchers.h
@@ -68,7 +68,7 @@ public:
 
     template<typename T>
     const T *get() const {
-      return Entity.dyn_cast<const T *>();
+      return dyn_cast<const T *>(Entity);
     }
 
     unsigned getOperandNo() const { return OperandNo; }


### PR DESCRIPTION
This is part of the migration from `PointerUnion<PTs>::dyn_cast<T>()` to `llvm::dyn_cast<T>(PointerUnion)`.
The dyn_cast method on PointerUnion is simply a wrapper around `llvm::dyn_cast_if_present`, which means that it can be replaced with `llvm::dyn_cast` for all non-optional types.