### PR TITLE
[lldb-dap] Only mark disconnecting when we are actually disconnecting

### DIFF
--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -943,11 +943,6 @@ void DAP::Received(const protocol::Event &event) {
 }
 
 void DAP::Received(const protocol::Request &request) {
-  if (request.command == "disconnect") {
-    std::lock_guard<std::mutex> guard(m_queue_mutex);
-    m_disconnecting = true;
-  }
-
   const std::optional<CancelArguments> cancel_args =
       getArgumentsIfRequest<CancelArguments>(request, "cancel");
   if (cancel_args) {
@@ -1065,8 +1060,13 @@ llvm::Error DAP::Loop() {
   // Don't wait to join the mainloop thread if our callback wasn't added
   // successfully, or we'll wait forever.
   if (m_loop.AddPendingCallback(
-          [](MainLoopBase &loop) { loop.RequestTermination(); }))
+          [](MainLoopBase &loop) { loop.RequestTermination(); })) {
     thread.join();
+  } else {
+    DAP_LOG(log, "failed to terminate stop the main loop. Detaching the "
+                 "Transport Handler thread.");
+    thread.detach();
+  }
 
   if (m_error_occurred)
     return llvm::createStringError(llvm::inconvertibleErrorCode(),

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -1063,8 +1063,10 @@ llvm::Error DAP::Loop() {
           [](MainLoopBase &loop) { loop.RequestTermination(); })) {
     thread.join();
   } else {
-    DAP_LOG(log, "failed to terminate stop the main loop. Detaching the "
-                 "Transport Handler thread.");
+    DAP_LOG(log,
+            "failed to terminate stop the main loop in {}. Detaching the "
+            "Transport Handler thread.",
+            GetClientName());
     thread.detach();
   }
 


### PR DESCRIPTION
Threads
 ```
 TransportHandler      |  Request Handler     | State
 =====================================================
 new request           | free                 | disconnecting = false |
                       |                      | queue = 1             |
 disconnect request    | handled new request  | disconnecting = true  |
                       |                      | queue = 0
```
In the transport handler we have set m_disconnecting to true. In the window before we push the disconnect request into the queue, the request handler thread finished handling the previous request and is in the while loop. It waits on the m_queue_cv and sees. m_disconnecting = true and queue is empty.

DAP shuts down because it assumes there is nothing else to do. The client then times out waiting for the disconnect response.

Detach the thread if we cannot join it and let the OS deal with the thread cleanup.