### PR TITLE
GlobalISel: Use MIPatternMatch to look up defs in the artifact combiner

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/GenericMachineInstrs.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/GenericMachineInstrs.h
@@ -978,6 +978,17 @@ public:
   };
 };
 
+/// Represents a G_CONSTANT.
+class GConstant : public GenericMachineInstr {
+public:
+  const ConstantInt *getConstantInt() const { return getOperand(1).getCImm(); }
+  const APInt &getValue() const { return getConstantInt()->getValue(); }
+
+  static bool classof(const MachineInstr *MI) {
+    return MI->getOpcode() == TargetOpcode::G_CONSTANT;
+  };
+};
+
 /// Represents an integer subtraction.
 class GSub : public GIntBinOp {
 public:

--- a/llvm/include/llvm/CodeGen/GlobalISel/LegalizationArtifactCombiner.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/LegalizationArtifactCombiner.h
@@ -95,20 +95,19 @@ public:
     }
 
     // Try to fold aext(g_constant) when the larger constant type is legal.
-    auto *SrcMI = MRI.getVRegDef(SrcReg);
-    if (SrcMI->getOpcode() == TargetOpcode::G_CONSTANT) {
+    GConstant *SrcCst;
+    if (mi_match(SrcReg, MRI, m_GConstant(SrcCst))) {
       const LLT DstTy = MRI.getType(DstReg);
       if (isInstLegal({TargetOpcode::G_CONSTANT, {DstTy}})) {
-        auto &CstVal = SrcMI->getOperand(1);
-        auto MergedLocation =
-            DebugLoc::getMergedLocation(MI.getDebugLoc(), SrcMI->getDebugLoc());
-        // Set the debug location to the merged location of the SrcMI and the MI
-        // if the aext fold is successful.
+        auto MergedLocation = DebugLoc::getMergedLocation(
+            MI.getDebugLoc(), SrcCst->getDebugLoc());
+        // Set the debug location to the merged location of the SrcCst and the
+        // MI if the aext fold is successful.
         Builder.setDebugLoc(MergedLocation);
-        Builder.buildConstant(
-            DstReg, CstVal.getCImm()->getValue().sext(DstTy.getSizeInBits()));
+        Builder.buildConstant(DstReg,
+                              SrcCst->getValue().sext(DstTy.getSizeInBits()));
         UpdatedDefs.push_back(DstReg);
-        markInstAndDefDead(MI, *SrcMI, DeadInsts);
+        markInstAndDefDead(MI, *SrcCst, DeadInsts);
         return true;
       }
     }
@@ -175,15 +174,14 @@ public:
     }
 
     // Try to fold zext(g_constant) when the larger constant type is legal.
-    auto *SrcMI = MRI.getVRegDef(SrcReg);
-    if (SrcMI->getOpcode() == TargetOpcode::G_CONSTANT) {
+    GConstant *SrcCst;
+    if (mi_match(SrcReg, MRI, m_GConstant(SrcCst))) {
       const LLT DstTy = MRI.getType(DstReg);
       if (isInstLegal({TargetOpcode::G_CONSTANT, {DstTy}})) {
-        auto &CstVal = SrcMI->getOperand(1);
-        Builder.buildConstant(
-            DstReg, CstVal.getCImm()->getValue().zext(DstTy.getSizeInBits()));
+        Builder.buildConstant(DstReg,
+                              SrcCst->getValue().zext(DstTy.getSizeInBits()));
         UpdatedDefs.push_back(DstReg);
-        markInstAndDefDead(MI, *SrcMI, DeadInsts);
+        markInstAndDefDead(MI, *SrcCst, DeadInsts);
         return true;
       }
     }
@@ -242,15 +240,14 @@ public:
     }
 
     // Try to fold sext(g_constant) when the larger constant type is legal.
-    auto *SrcMI = MRI.getVRegDef(SrcReg);
-    if (SrcMI->getOpcode() == TargetOpcode::G_CONSTANT) {
+    GConstant *SrcCst;
+    if (mi_match(SrcReg, MRI, m_GConstant(SrcCst))) {
       const LLT DstTy = MRI.getType(DstReg);
       if (isInstLegal({TargetOpcode::G_CONSTANT, {DstTy}})) {
-        auto &CstVal = SrcMI->getOperand(1);
-        Builder.buildConstant(
-            DstReg, CstVal.getCImm()->getValue().sext(DstTy.getSizeInBits()));
+        Builder.buildConstant(DstReg,
+                              SrcCst->getValue().sext(DstTy.getSizeInBits()));
         UpdatedDefs.push_back(DstReg);
-        markInstAndDefDead(MI, *SrcMI, DeadInsts);
+        markInstAndDefDead(MI, *SrcCst, DeadInsts);
         return true;
       }
     }
@@ -271,20 +268,20 @@ public:
     Register SrcReg = lookThroughCopyInstrs(MI.getOperand(1).getReg());
 
     // Try to fold trunc(g_constant) when the smaller constant type is legal.
-    auto *SrcMI = MRI.getVRegDef(SrcReg);
-    if (SrcMI->getOpcode() == TargetOpcode::G_CONSTANT) {
+    GConstant *SrcCst;
+    if (mi_match(SrcReg, MRI, m_GConstant(SrcCst))) {
       if (isInstLegal({TargetOpcode::G_CONSTANT, {DstTy}})) {
-        auto &CstVal = SrcMI->getOperand(1);
-        Builder.buildConstant(
-            DstReg, CstVal.getCImm()->getValue().trunc(DstTy.getSizeInBits()));
+        Builder.buildConstant(DstReg,
+                              SrcCst->getValue().trunc(DstTy.getSizeInBits()));
         UpdatedDefs.push_back(DstReg);
-        markInstAndDefDead(MI, *SrcMI, DeadInsts);
+        markInstAndDefDead(MI, *SrcCst, DeadInsts);
         return true;
       }
     }
 
     // Try to fold trunc(merge) to directly use the source of the merge.
     // This gets rid of large, difficult to legalize, merges
+    MachineInstr *SrcMI = MRI.getVRegDef(SrcReg);
     if (auto *SrcMerge = dyn_cast<GMerge>(SrcMI)) {
       const Register MergeSrcReg = SrcMerge->getSourceReg(0);
       const LLT MergeSrcTy = MRI.getType(MergeSrcReg);
@@ -964,6 +961,7 @@ public:
                                GUnmerge *Unmerge, unsigned UnmergeIdxStart,
                                unsigned NumElts, unsigned EltSize,
                                bool AllowUndef) {
+      using namespace llvm::MIPatternMatch;
       assert(MergeStartIdx + NumElts <= MI.getNumSources());
       for (unsigned i = MergeStartIdx; i < MergeStartIdx + NumElts; ++i) {
         unsigned EltUnmergeIdx;
@@ -975,8 +973,7 @@ public:
           if (i - MergeStartIdx != EltUnmergeIdx - UnmergeIdxStart)
             return false;
         } else if (!AllowUndef ||
-                   MRI.getVRegDef(MI.getSourceReg(i))->getOpcode() !=
-                       TargetOpcode::G_IMPLICIT_DEF)
+                   !mi_match(MI.getSourceReg(i), MRI, m_GImplicitDef()))
           return false;
       }
       return true;

--- a/llvm/include/llvm/CodeGen/GlobalISel/MIPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/MIPatternMatch.h
@@ -471,6 +471,30 @@ struct ImplicitDefMatch {
 
 inline ImplicitDefMatch m_GImplicitDef() { return ImplicitDefMatch(); }
 
+/// Matches a G_CONSTANT and binds the defining instruction. Unlike m_ICst, this
+/// returns the instruction (not the value) and does not look through vector
+/// splats.
+template <typename Class> struct GConstantMatch {
+  Class *&Inst;
+
+  GConstantMatch(Class *&Inst) : Inst(Inst) {}
+  bool match(const MachineRegisterInfo &MRI, Register Reg) {
+    MachineInstr *TmpMI;
+    if (mi_match(Reg, MRI, m_MInstr(TmpMI))) {
+      if (auto *Cst = dyn_cast<Class>(TmpMI)) {
+        Inst = Cst;
+        return true;
+      }
+    }
+    return false;
+  }
+};
+
+inline GConstantMatch<GConstant> m_GConstant(GConstant *&Inst) { return Inst; }
+inline GConstantMatch<const GConstant> m_GConstant(const GConstant *&Inst) {
+  return Inst;
+}
+
 // Helper for matching G_FCONSTANT
 inline bind_ty<const ConstantFP *> m_GFCst(const ConstantFP *&C) { return C; }
 


### PR DESCRIPTION
Replace direct getVRegDef uses in the legalization artifact combiner with
the mi_match/m_MInstr idiom. To avoid awkwardly split handling of G_IMPLICIT_DEF,
add a similar matcher for G_CONSTANT.

Co-authored-by: Claude (Opus 4.8) <noreply@anthropic.com>