### PR TITLE
[bazel][libc] Temporarily disable full_build include tests

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/test/libc_test_rules.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/test/libc_test_rules.bzl
@@ -63,6 +63,7 @@ def libc_test(
 
     if full_build:
         copts = copts + _FULL_BUILD_COPTS
+
         # Temporarily disable full_build tests (currently broken) to unblock CI.
         tags = tags + ["manual", "notap"]
     cc_test(

--- a/utils/bazel/llvm-project-overlay/libc/test/libc_test_rules.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/test/libc_test_rules.bzl
@@ -63,6 +63,8 @@ def libc_test(
 
     if full_build:
         copts = copts + _FULL_BUILD_COPTS
+        # Temporarily disable full_build tests (currently broken) to unblock CI.
+        tags = tags + ["manual", "notap"]
     cc_test(
         name = name,
         local_defines = local_defines + _TEST_DEFINES + LIBC_CONFIGURE_OPTIONS,


### PR DESCRIPTION
They are currently broken due to
https://github.com/llvm/llvm-project/commit/1f4574c6033cae84c88ca69bb2b73c9b029925e3. We need a few hours to resolve it, and we're using this to unblock our CI.