### PR TITLE
[mlir] Highlight FileLineColRange diagnostics

### DIFF
--- a/mlir/include/mlir/IR/Diagnostics.h
+++ b/mlir/include/mlir/IR/Diagnostics.h
@@ -613,8 +613,8 @@ protected:
   ShouldShowLocFn shouldShowLocFn;
 
 private:
-  /// Convert a location into the given memory buffer into an SMLoc.
-  SMLoc convertLocToSMLoc(FileLineColLoc loc);
+  /// Convert the start of a location range into an SMLoc.
+  SMLoc convertLocToSMLoc(FileLineColRange loc);
 
   /// Given a location, returns the first nested location (including 'loc') that
   /// can be shown to the user.

--- a/mlir/lib/IR/Diagnostics.cpp
+++ b/mlir/lib/IR/Diagnostics.cpp
@@ -446,7 +446,7 @@ void SourceMgrDiagnosticHandler::emitDiagnostic(Location loc, Twine message,
                                                 DiagnosticSeverity kind,
                                                 bool displaySourceLine) {
   // Extract a file location from this loc.
-  auto fileLoc = loc->findInstanceOf<FileLineColLoc>();
+  auto fileLoc = loc->findInstanceOf<FileLineColRange>();
 
   // If one doesn't exist, then print the raw message without a source location.
   if (!fileLoc) {
@@ -462,8 +462,30 @@ void SourceMgrDiagnosticHandler::emitDiagnostic(Location loc, Twine message,
   // location to an SMLoc.
   if (displaySourceLine) {
     auto smloc = convertLocToSMLoc(fileLoc);
-    if (smloc.isValid())
+    if (smloc.isValid()) {
+      // Preserve the existing point diagnostic for FileLineColLoc. For a
+      // proper range, highlight it when both endpoints form a resolvable,
+      // non-empty, ordered range in the same source buffer. Otherwise, safely
+      // fall back to the start point.
+      auto start =
+          std::make_pair(fileLoc.getStartLine(), fileLoc.getStartColumn());
+      auto end = std::make_pair(fileLoc.getEndLine(), fileLoc.getEndColumn());
+      if (!isStrictFileLineColLoc(fileLoc) && start.first != 0 &&
+          start.second != 0 && end.first != 0 && end.second != 0 &&
+          start < end) {
+        unsigned bufferId =
+            impl->getSourceMgrBufferIDForFile(mgr, fileLoc.getFilename());
+        SMLoc endLoc = mgr.FindLocForLineAndColumn(
+            bufferId, fileLoc.getEndLine(), fileLoc.getEndColumn());
+        if (endLoc.isValid() &&
+            mgr.FindBufferContainingLoc(smloc) == bufferId &&
+            mgr.FindBufferContainingLoc(endLoc) == bufferId) {
+          SMRange range(smloc, endLoc);
+          return mgr.PrintMessage(os, smloc, getDiagKind(kind), message, range);
+        }
+      }
       return mgr.PrintMessage(os, smloc, getDiagKind(kind), message);
+    }
   }
 
   // If the conversion was unsuccessful, create a diagnostic with the file
@@ -471,8 +493,8 @@ void SourceMgrDiagnosticHandler::emitDiagnostic(Location loc, Twine message,
   // the constructor of SMDiagnostic that takes a location.
   std::string locStr;
   llvm::raw_string_ostream locOS(locStr);
-  locOS << fileLoc.getFilename().getValue() << ":" << fileLoc.getLine() << ":"
-        << fileLoc.getColumn();
+  locOS << fileLoc.getFilename().getValue() << ":" << fileLoc.getStartLine()
+        << ":" << fileLoc.getStartColumn();
   llvm::SMDiagnostic diag(locStr, getDiagKind(kind), message.str());
   diag.print(nullptr, os);
 }
@@ -549,7 +571,7 @@ SourceMgrDiagnosticHandler::findLocToShow(Location loc) {
         // emitted in a different note on the main diagnostic.
         return findLocToShow(callLoc.getCallee());
       })
-      .Case([&](FileLineColLoc) -> std::optional<Location> { return loc; })
+      .Case([&](FileLineColRange) -> std::optional<Location> { return loc; })
       .Case([&](FusedLoc fusedLoc) -> std::optional<Location> {
         // Fused location is unique in that we try to find a sub-location to
         // show, rather than the top-level location itself.
@@ -573,16 +595,17 @@ SourceMgrDiagnosticHandler::findLocToShow(Location loc) {
 
 /// Get a memory buffer for the given file, or the main file of the source
 /// manager if one doesn't exist. This always returns non-null.
-SMLoc SourceMgrDiagnosticHandler::convertLocToSMLoc(FileLineColLoc loc) {
+SMLoc SourceMgrDiagnosticHandler::convertLocToSMLoc(FileLineColRange loc) {
   // The column and line may be zero to represent unknown column and/or unknown
   /// line/column information.
-  if (loc.getLine() == 0 || loc.getColumn() == 0)
+  if (loc.getStartLine() == 0 || loc.getStartColumn() == 0)
     return SMLoc();
 
   unsigned bufferId = impl->getSourceMgrBufferIDForFile(mgr, loc.getFilename());
   if (!bufferId)
     return SMLoc();
-  return mgr.FindLocForLineAndColumn(bufferId, loc.getLine(), loc.getColumn());
+  return mgr.FindLocForLineAndColumn(bufferId, loc.getStartLine(),
+                                     loc.getStartColumn());
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/unittests/IR/Diagnostic.cpp
+++ b/mlir/unittests/IR/Diagnostic.cpp
@@ -6,14 +6,35 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/Support/TypeID.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/SourceMgr.h"
 #include "gtest/gtest.h"
 
 using namespace mlir;
 using namespace mlir::detail;
 
 namespace {
+
+static std::string emitSourceMgrDiagnostic(Location loc,
+                                           llvm::SourceMgr &sourceMgr) {
+  std::string output;
+  llvm::raw_string_ostream os(output);
+  SourceMgrDiagnosticHandler handler(sourceMgr, loc->getContext(), os,
+                                     [](Location) { return true; });
+  emitError(loc, "message");
+  return output;
+}
+
+static std::string emitSourceMgrDiagnostic(Location loc, StringRef source,
+                                           StringRef filename = "test.mlir") {
+  llvm::SourceMgr sourceMgr;
+  sourceMgr.AddNewSourceBuffer(
+      llvm::MemoryBuffer::getMemBuffer(source, filename), SMLoc());
+  return emitSourceMgrDiagnostic(loc, sourceMgr);
+}
 
 TEST(DiagnosticLifetime, TestCopiesConstCharStar) {
   const auto *expectedMessage = "Error 1, don't mutate this";
@@ -58,6 +79,121 @@ TEST(DiagnosticLifetime, TestLazyCopyStringLiteral) {
   llvm::raw_string_ostream stringStream(resultMessage);
   diagnostic.print(stringStream);
   ASSERT_STREQ("^rror 1, mutate this", resultMessage.c_str());
+}
+
+TEST(SourceMgrDiagnosticHandler, PreservesFileLineColLocDiagnostic) {
+  MLIRContext context;
+  Location loc = FileLineColLoc::get(&context, "test.mlir", 1, 3);
+
+  EXPECT_EQ(emitSourceMgrDiagnostic(loc, "abcdef\n"),
+            "test.mlir:1:3: error: message\n"
+            "abcdef\n"
+            "  ^\n");
+}
+
+TEST(SourceMgrDiagnosticHandler, HighlightsSameLineFileLineColRange) {
+  MLIRContext context;
+  auto filename = StringAttr::get(&context, "test.mlir");
+  Location loc = FileLineColRange::get(filename, 1, 2, 1, 5);
+
+  EXPECT_EQ(emitSourceMgrDiagnostic(loc, "abcdef\n"),
+            "test.mlir:1:2: error: message\n"
+            "abcdef\n"
+            " ^~~\n");
+}
+
+TEST(SourceMgrDiagnosticHandler, HighlightsFirstLineOfMultilineRange) {
+  MLIRContext context;
+  auto filename = StringAttr::get(&context, "test.mlir");
+  Location loc = FileLineColRange::get(filename, 1, 2, 2, 4);
+
+  EXPECT_EQ(emitSourceMgrDiagnostic(loc, "abcdef\nsecond\n"),
+            "test.mlir:1:2: error: message\n"
+            "abcdef\n"
+            " ^~~~~\n");
+}
+
+TEST(SourceMgrDiagnosticHandler, FindsNestedFileLineColRange) {
+  MLIRContext context;
+  auto filename = StringAttr::get(&context, "test.mlir");
+  Location range = FileLineColRange::get(filename, 1, 2, 1, 5);
+  Location loc = NameLoc::get(StringAttr::get(&context, "nested"), range);
+
+  EXPECT_EQ(emitSourceMgrDiagnostic(loc, "abcdef\n"),
+            "test.mlir:1:2: error: message\n"
+            "abcdef\n"
+            " ^~~\n");
+}
+
+TEST(SourceMgrDiagnosticHandler, CrossFileNestedLocationsRemainSeparate) {
+  MLIRContext context;
+  auto firstFilename = StringAttr::get(&context, "first.mlir");
+  auto secondFilename = StringAttr::get(&context, "second.mlir");
+  Location first = FileLineColRange::get(firstFilename, 1, 2, 1, 5);
+  Location second = FileLineColRange::get(secondFilename, 1, 3, 1, 6);
+  Location loc = FusedLoc::get(&context, {first, second});
+
+  llvm::SourceMgr sourceMgr;
+  sourceMgr.AddNewSourceBuffer(
+      llvm::MemoryBuffer::getMemBuffer("abcdef\n", "first.mlir"), SMLoc());
+  sourceMgr.AddNewSourceBuffer(
+      llvm::MemoryBuffer::getMemBuffer("ghijkl\n", "second.mlir"), SMLoc());
+
+  EXPECT_EQ(emitSourceMgrDiagnostic(loc, sourceMgr),
+            "first.mlir:1:2: error: message\n"
+            "abcdef\n"
+            " ^~~\n");
+}
+
+TEST(SourceMgrDiagnosticHandler, InvalidRangeFallsBackToStartPoint) {
+  MLIRContext context;
+  auto filename = StringAttr::get(&context, "test.mlir");
+  Location loc = FileLineColRange::get(filename, 1, 5, 1, 2);
+
+  EXPECT_EQ(emitSourceMgrDiagnostic(loc, "abcdef\n"),
+            "test.mlir:1:5: error: message\n"
+            "abcdef\n"
+            "    ^\n");
+}
+
+TEST(SourceMgrDiagnosticHandler, IncompleteRangeFallsBackToStartPoint) {
+  MLIRContext context;
+  auto filename = StringAttr::get(&context, "test.mlir");
+  Location loc = FileLineColRange::get(filename, 1, 3, 0, 0);
+
+  EXPECT_EQ(emitSourceMgrDiagnostic(loc, "abcdef\n"),
+            "test.mlir:1:3: error: message\n"
+            "abcdef\n"
+            "  ^\n");
+}
+
+TEST(SourceMgrDiagnosticHandler, ZeroStartFallsBackToLocation) {
+  MLIRContext context;
+  auto filename = StringAttr::get(&context, "test.mlir");
+  Location loc = FileLineColRange::get(filename, 0, 0, 1, 5);
+
+  EXPECT_EQ(emitSourceMgrDiagnostic(loc, "abcdef\n"),
+            "test.mlir:0:0: error: message\n");
+}
+
+TEST(SourceMgrDiagnosticHandler, UnresolvableEndFallsBackToStartPoint) {
+  MLIRContext context;
+  auto filename = StringAttr::get(&context, "test.mlir");
+  Location loc = FileLineColRange::get(filename, 1, 2, 1, 99);
+
+  EXPECT_EQ(emitSourceMgrDiagnostic(loc, "abcdef\n"),
+            "test.mlir:1:2: error: message\n"
+            "abcdef\n"
+            " ^\n");
+}
+
+TEST(SourceMgrDiagnosticHandler, UnresolvableRangeFallsBackToLocation) {
+  MLIRContext context;
+  auto filename = StringAttr::get(&context, "missing.mlir");
+  Location loc = FileLineColRange::get(filename, 1, 2, 1, 5);
+
+  EXPECT_EQ(emitSourceMgrDiagnostic(loc, "abcdef\n"),
+            "missing.mlir:1:2: error: message\n");
 }
 
 } // namespace


### PR DESCRIPTION
SourceMgrDiagnosticHandler currently recognizes only FileLineColLoc. As a result, a diagnostic carrying a FileLineColRange (added in [#80213](https://github.com/ancalled/neutrino-translator/issues/80213)) is reduced to its start point before reaching SourceMgr::PrintMessage, discarding the range information and preventing frontends from getting exact ranges in the underlined diagnostic output.
This patch maps a valid, ordered, same-buffer FileLineColRange to an SMRange and passes it to PrintMessage, so the exact source range is highlighted. Existing behavior is otherwise preserved: strict FileLineColLoc output remains byte-compatible, while zero, incomplete, reversed, cross-buffer, or unresolvable endpoints fall back to the existing start-point rendering.
Unit tests cover same-line and multiline ranges, nested locations, invalid and incomplete ranges, and the relevant fallback paths.
This is useful for frontends and downstream tooling that rely on precise source ranges, including source maps and language-intelligence features. For example, our MLIR-based compiler ([neutrino-language](https://github.com/neutrinopr/neutrino-language)) currently derives ranges separately in its view layer to compensate for point-only diagnostics. With this change, the standard handler can preserve and render range information already provided by frontends.