### PR TITLE
[bazel][libc] Temporarily disable full_build include tests (cont.)

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/test/libc_test_rules.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/test/libc_test_rules.bzl
@@ -61,6 +61,7 @@ def libc_test(
     else:
         deps = deps + ["//libc/test/UnitTest:LibcUnitTest"]
 
+    tags = kwargs.pop("tags", [])
     if full_build:
         copts = copts + _FULL_BUILD_COPTS
 
@@ -72,6 +73,7 @@ def libc_test(
         deps = deps,
         copts = copts + libc_common_copts(),
         linkstatic = 1,
+        tags = tags,
         **kwargs
     )
 


### PR DESCRIPTION
Fix #216359.  Sorry about that.