### PR TITLE
[lld][MachO] Order objc stubs by caller priority

### DIFF
--- a/lld/MachO/SectionPriorities.h
+++ b/lld/MachO/SectionPriorities.h
@@ -12,10 +12,12 @@
 #include "InputSection.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/SetVector.h"
 
 namespace lld::macho {
 
 using SectionPair = std::pair<const InputSection *, const InputSection *>;
+class Symbol;
 
 class PriorityBuilder {
 public:
@@ -75,6 +77,11 @@ public:
   // Each section gets assigned the priority of the highest-priority symbol it
   // contains.
   llvm::DenseMap<const InputSection *, int> buildInputSectionPriorities();
+
+  /// Sections that branch to each objc stub. Objc stubs are synthetic and carry
+  /// no profile data, so they are ordered from the priority of their callers.
+  llvm::MapVector<const Symbol *, llvm::SetVector<const InputSection *>>
+      objcStubCallers;
 
 private:
   // The symbol with the smallest priority should be ordered first in the output

--- a/lld/MachO/SyntheticSections.cpp
+++ b/lld/MachO/SyntheticSections.cpp
@@ -944,6 +944,16 @@ uint64_t ObjCStubsSection::getSize() const {
   return stubSize * symbols.size();
 }
 
+void ObjCStubsSection::reorderSymbols(ArrayRef<Defined *> newOrder) {
+  assert(newOrder.size() == symbols.size() && "must be a permutation");
+  auto stubSize = config->objcStubsMode == ObjCStubsMode::fast
+                      ? target->objcStubsFastSize
+                      : target->objcStubsSmallSize;
+  symbols.assign(newOrder.begin(), newOrder.end());
+  for (auto [idx, sym] : llvm::enumerate(symbols))
+    sym->value = idx * stubSize;
+}
+
 void ObjCStubsSection::writeTo(uint8_t *buf) const {
   uint64_t stubOffset = 0;
   for (Defined *sym : symbols) {

--- a/lld/MachO/SyntheticSections.h
+++ b/lld/MachO/SyntheticSections.h
@@ -346,6 +346,9 @@ public:
   static bool isObjCStubSymbol(Symbol *sym);
   static StringRef getMethname(Symbol *sym);
 
+  ArrayRef<Defined *> getSymbols() const { return symbols; }
+  void reorderSymbols(ArrayRef<Defined *> newOrder);
+
 private:
   std::vector<Defined *> symbols;
   Symbol *objcMsgSend = nullptr;

--- a/lld/MachO/Writer.cpp
+++ b/lld/MachO/Writer.cpp
@@ -729,8 +729,12 @@ void Writer::scanRelocations() {
         if (auto *undefined = dyn_cast<Undefined>(sym))
           treatUndefinedSymbol(*undefined, isec, r.offset);
         // treatUndefinedSymbol() can replace sym with a DylibSymbol; re-check.
-        if (!isa<Undefined>(sym) && validateSymbolRelocation(sym, isec, r))
+        if (!isa<Undefined>(sym) && validateSymbolRelocation(sym, isec, r)) {
+          if (target->hasAttr(r.type, RelocAttrBits::BRANCH) &&
+              ObjCStubsSection::isObjCStubSymbol(sym))
+            priorityBuilder.objcStubCallers[sym].insert(isec);
           prepareSymbolRelocation(sym, isec, r);
+        }
       } else {
         if (!r.pcrel) {
           if (config->emitChainedFixups)
@@ -974,12 +978,51 @@ template <class LP> void Writer::createLoadCommands() {
 // Sorting only can happen once all outputs have been collected. Here we sort
 // segments, output sections within each segment, and input sections within each
 // output segment.
+static void orderObjCStubsByCallerPriority(
+    const DenseMap<const InputSection *, int> &prios) {
+  if (prios.empty() || !in.objcStubs->isNeeded())
+    return;
+
+  DenseMap<const Symbol *, int> stubPriority;
+  for (const auto &[stub, callers] : priorityBuilder.objcStubCallers) {
+    for (const InputSection *caller : callers) {
+      if (!caller->isLive(0))
+        continue;
+      auto prio = prios.find(caller);
+      if (prio == prios.end())
+        continue;
+      auto existing = stubPriority.find(stub);
+      if (existing == stubPriority.end() || prio->second < existing->second)
+        stubPriority[stub] = prio->second;
+    }
+  }
+  if (stubPriority.empty())
+    return;
+
+  ArrayRef<Defined *> symbols = in.objcStubs->getSymbols();
+  SmallVector<Defined *> order(symbols.begin(), symbols.end());
+  llvm::stable_sort(order, [&](const Defined *a, const Defined *b) {
+    auto ia = stubPriority.find(a);
+    auto ib = stubPriority.find(b);
+    bool hasA = ia != stubPriority.end();
+    bool hasB = ib != stubPriority.end();
+    if (hasA != hasB)
+      return hasA;
+    if (!hasA)
+      return false;
+    return ia->second < ib->second;
+  });
+  in.objcStubs->reorderSymbols(order);
+}
+
 static void sortSegmentsAndSections() {
   TimeTraceScope timeScope("Sort segments and sections");
   sortOutputSegments();
 
   DenseMap<const InputSection *, int> isecPriorities =
       priorityBuilder.buildInputSectionPriorities();
+
+  orderObjCStubsByCallerPriority(isecPriorities);
 
   uint32_t sectionIndex = 0;
   for (OutputSegment *seg : outputSegments) {

--- a/lld/test/MachO/objc-stubs-order-file.s
+++ b/lld/test/MachO/objc-stubs-order-file.s
@@ -1,0 +1,46 @@
+# REQUIRES: aarch64
+
+# RUN: rm -rf %t && split-file %s %t
+# RUN: llvm-mc -filetype=obj -triple=arm64-apple-darwin %t/a.s -o %t/a.o
+# RUN: echo _hot > %t/order
+
+# RUN: %lld -arch arm64 -e _main -U _objc_msgSend -o %t/base.out %t/a.o \
+# RUN:   -objc_stubs_small
+# RUN: llvm-objdump --no-show-raw-insn --section=__TEXT,__objc_stubs --macho \
+# RUN:   %t/base.out | FileCheck %s --check-prefix=BASE
+
+# RUN: %lld -arch arm64 -e _main -U _objc_msgSend -o %t/ordered.out %t/a.o \
+# RUN:   -objc_stubs_small -order_file %t/order
+# RUN: llvm-objdump --no-show-raw-insn --section=__TEXT,__objc_stubs --macho \
+# RUN:   %t/ordered.out | FileCheck %s --check-prefix=ORDERED
+
+# BASE:      Contents of (__TEXT,__objc_stubs) section
+# BASE-NEXT: _objc_msgSend$cold:
+# BASE:      _objc_msgSend$hot:
+
+# ORDERED:      Contents of (__TEXT,__objc_stubs) section
+# ORDERED-NEXT: _objc_msgSend$hot:
+# ORDERED:      _objc_msgSend$cold:
+
+#--- a.s
+.text
+.globl _cold
+.p2align 2
+_cold:
+  bl _objc_msgSend$cold
+  ret
+
+.globl _hot
+.p2align 2
+_hot:
+  bl _objc_msgSend$hot
+  ret
+
+.globl _main
+.p2align 2
+_main:
+  bl _cold
+  bl _hot
+  ret
+
+.subsections_via_symbols


### PR DESCRIPTION
__objc_stubs is synthetic, so normal input-section sorting does not affect its entries. Record branch-reloc callers, inherit the earliest live caller section priority, stable-sort objc stub symbols before address assignment, and update their symbol values.

This intentionally handles __objc_stubs only. General __stubs ordering is separate because stubsIndex also drives lazy pointers, indirect symbols, and bind/rebase offsets.