### PR TITLE
[NFC][DirectX] Rename ResourceInfo::RecordID to BindingID

### DIFF
--- a/llvm/include/llvm/Analysis/DXILResource.h
+++ b/llvm/include/llvm/Analysis/DXILResource.h
@@ -371,7 +371,7 @@ enum class ResourceCounterDirection {
 class ResourceInfo {
 public:
   struct ResourceBinding {
-    uint32_t BindingID;
+    uint32_t BindingID = 0;
     uint32_t Space;
     uint32_t LowerBound;
     uint32_t Size;
@@ -415,7 +415,7 @@ public:
   ResourceInfo(uint32_t Space, uint32_t LowerBound, uint32_t Size,
                TargetExtType *HandleTy, StringRef Name = "",
                GlobalVariable *Symbol = nullptr)
-      : Binding{ResourceBinding{0, Space, LowerBound, Size}},
+      : Binding{0, Space, LowerBound, Size},
         HandleTy(HandleTy), Name(Name), Symbol(Symbol) {}
 
   void setBindingID(unsigned ID) { Binding.BindingID = ID; }

--- a/llvm/include/llvm/Analysis/DXILResource.h
+++ b/llvm/include/llvm/Analysis/DXILResource.h
@@ -371,14 +371,14 @@ enum class ResourceCounterDirection {
 class ResourceInfo {
 public:
   struct ResourceBinding {
-    uint32_t RecordID;
+    uint32_t BindingID;
     uint32_t Space;
     uint32_t LowerBound;
     uint32_t Size;
 
     bool operator==(const ResourceBinding &RHS) const {
-      return std::tie(RecordID, Space, LowerBound, Size) ==
-             std::tie(RHS.RecordID, RHS.Space, RHS.LowerBound, RHS.Size);
+      return std::tie(BindingID, Space, LowerBound, Size) ==
+             std::tie(RHS.BindingID, RHS.Space, RHS.LowerBound, RHS.Size);
     }
     bool operator!=(const ResourceBinding &RHS) const {
       return !(*this == RHS);
@@ -388,8 +388,8 @@ public:
       // guarantees a well ordered results.
       const bool LHSIsUnbounded = Size == 0;
       const bool RHSIsUnbounded = RHS.Size == 0;
-      return std::tie(RecordID, Space, LowerBound, LHSIsUnbounded, Size) <
-             std::tie(RHS.RecordID, RHS.Space, RHS.LowerBound, RHSIsUnbounded,
+      return std::tie(BindingID, Space, LowerBound, LHSIsUnbounded, Size) <
+             std::tie(RHS.BindingID, RHS.Space, RHS.LowerBound, RHSIsUnbounded,
                       RHS.Size);
     }
     bool overlapsWith(const ResourceBinding &RHS) const {
@@ -412,13 +412,13 @@ public:
   ResourceCounterDirection CounterDirection = ResourceCounterDirection::Unknown;
   bool HasAtomic64Use = false;
 
-  ResourceInfo(uint32_t RecordID, uint32_t Space, uint32_t LowerBound,
-               uint32_t Size, TargetExtType *HandleTy, StringRef Name = "",
+  ResourceInfo(uint32_t Space, uint32_t LowerBound, uint32_t Size,
+               TargetExtType *HandleTy, StringRef Name = "",
                GlobalVariable *Symbol = nullptr)
-      : Binding{RecordID, Space, LowerBound, Size}, HandleTy(HandleTy),
-        Name(Name), Symbol(Symbol) {}
+      : Binding{ResourceBinding{0, Space, LowerBound, Size}},
+        HandleTy(HandleTy), Name(Name), Symbol(Symbol) {}
 
-  void setBindingID(unsigned ID) { Binding.RecordID = ID; }
+  void setBindingID(unsigned ID) { Binding.BindingID = ID; }
 
   bool hasCounter() const {
     return CounterDirection != ResourceCounterDirection::Unknown;

--- a/llvm/include/llvm/Analysis/DXILResource.h
+++ b/llvm/include/llvm/Analysis/DXILResource.h
@@ -415,8 +415,8 @@ public:
   ResourceInfo(uint32_t Space, uint32_t LowerBound, uint32_t Size,
                TargetExtType *HandleTy, StringRef Name = "",
                GlobalVariable *Symbol = nullptr)
-      : Binding{0, Space, LowerBound, Size},
-        HandleTy(HandleTy), Name(Name), Symbol(Symbol) {}
+      : Binding{0, Space, LowerBound, Size}, HandleTy(HandleTy), Name(Name),
+        Symbol(Symbol) {}
 
   void setBindingID(unsigned ID) { Binding.BindingID = ID; }
 

--- a/llvm/lib/Analysis/DXILResource.cpp
+++ b/llvm/lib/Analysis/DXILResource.cpp
@@ -800,7 +800,7 @@ void ResourceInfo::print(raw_ostream &OS, dxil::ResourceTypeInfo &RTI,
   }
 
   OS << "  Binding:\n"
-     << "    Record ID: " << Binding.BindingID << "\n"
+     << "    Binding ID: " << Binding.BindingID << "\n"
      << "    Space: " << Binding.Space << "\n"
      << "    Lower Bound: " << Binding.LowerBound << "\n"
      << "    Size: " << Binding.Size << "\n";

--- a/llvm/lib/Analysis/DXILResource.cpp
+++ b/llvm/lib/Analysis/DXILResource.cpp
@@ -688,7 +688,7 @@ MDTuple *ResourceInfo::getAsMetadata(Module &M,
         Constant::getIntegerValue(I1Ty, APInt(1, V)));
   };
 
-  MDVals.push_back(getIntMD(Binding.RecordID));
+  MDVals.push_back(getIntMD(Binding.BindingID));
   assert(Symbol && "Cannot yet create useful resource metadata without symbol");
   MDVals.push_back(ValueAsMetadata::get(Symbol));
   MDVals.push_back(MDString::get(Ctx, Name));
@@ -800,7 +800,7 @@ void ResourceInfo::print(raw_ostream &OS, dxil::ResourceTypeInfo &RTI,
   }
 
   OS << "  Binding:\n"
-     << "    Record ID: " << Binding.RecordID << "\n"
+     << "    Record ID: " << Binding.BindingID << "\n"
      << "    Space: " << Binding.Space << "\n"
      << "    Lower Bound: " << Binding.LowerBound << "\n"
      << "    Size: " << Binding.Size << "\n";
@@ -889,8 +889,7 @@ void DXILResourceMap::populateResourceInfos(Module &M,
           StringRef Name = getResourceNameFromBindingCall(CI);
 
           ResourceInfo RI =
-              ResourceInfo{/*RecordID=*/0, Space,    LowerBound,
-                           Size,           HandleTy, Name};
+              ResourceInfo{Space, LowerBound, Size, HandleTy, Name};
 
           CIToInfos.emplace_back(CI, RI, RTI);
         }
@@ -917,7 +916,7 @@ void DXILResourceMap::populateResourceInfos(Module &M,
   }
 
   unsigned Size = Infos.size();
-  // In DXC, Record ID is unique per resource type. Match that.
+  // In DXC, Binding ID is unique per resource type. Match that.
   FirstUAV = FirstCBuffer = FirstSampler = Size;
   uint32_t NextID = 0;
   for (unsigned I = 0, E = Size; I != E; ++I) {

--- a/llvm/lib/Target/DirectX/DXILOpLowering.cpp
+++ b/llvm/lib/Target/DirectX/DXILOpLowering.cpp
@@ -357,7 +357,7 @@ public:
           (Binding.Size == 1) ? false : hasNonUniformIndex(IndexOp);
       std::array<Value *, 4> Args{
           ConstantInt::get(Int8Ty, llvm::to_underlying(RC)),
-          ConstantInt::get(Int32Ty, Binding.RecordID), IndexOp,
+          ConstantInt::get(Int32Ty, Binding.BindingID), IndexOp,
           ConstantInt::get(Int1Ty, HasNonUniformIndex)};
       Expected<CallInst *> OpCall =
           OpBuilder.tryCreateOp(OpCode::CreateHandle, Args, CI->getName());

--- a/llvm/lib/Target/DirectX/DXILPrettyPrinter.cpp
+++ b/llvm/lib/Target/DirectX/DXILPrettyPrinter.cpp
@@ -194,7 +194,7 @@ struct FormatBindingID
         RC(RTI.getResourceClass()) {}
 
   void format(llvm::raw_ostream &OS, StringRef Style) {
-    OS << getRCPrefix(RC).upper() << Item.getBinding().RecordID;
+    OS << getRCPrefix(RC).upper() << Item.getBinding().BindingID;
   }
 };
 

--- a/llvm/test/Analysis/DXILResource/buffer-frombinding-unbounded.ll
+++ b/llvm/test/Analysis/DXILResource/buffer-frombinding-unbounded.ll
@@ -10,7 +10,7 @@ define void @test_typedbuffer() {
   ; CHECK: Resource [[#SRV:]]:
   ; CHECK:   Name: One
   ; CHECK:   Binding:
-  ; CHECK:     Record ID: 0
+  ; CHECK:     Binding ID: 0
   ; CHECK:     Space: 0
   ; CHECK:     Lower Bound: 0
   ; CHECK:     Size: 4294967295
@@ -27,7 +27,7 @@ define void @test_typedbuffer() {
   ; CHECK: Resource [[#UAV:]]:
   ; CHECK:   Name: Two
   ; CHECK:   Binding:
-  ; CHECK:     Record ID: 0
+  ; CHECK:     Binding ID: 0
   ; CHECK:     Space: 0
   ; CHECK:     Lower Bound: 0
   ; CHECK:     Size: 4294967262

--- a/llvm/test/Analysis/DXILResource/buffer-frombinding.ll
+++ b/llvm/test/Analysis/DXILResource/buffer-frombinding.ll
@@ -20,7 +20,7 @@ define void @test_typedbuffer() {
   ; CHECK: Resource [[SRV0:[0-9]+]]:
   ; CHECK:   Name: Zero
   ; CHECK:   Binding:
-  ; CHECK:     Record ID: 0
+  ; CHECK:     Binding ID: 0
   ; CHECK:     Space: 1
   ; CHECK:     Lower Bound: 8
   ; CHECK:     Size: 1
@@ -34,7 +34,7 @@ define void @test_typedbuffer() {
   ; CHECK: Resource [[SRV1:[0-9]+]]:
   ; CHECK:   Name: One
   ; CHECK:   Binding:
-  ; CHECK:     Record ID: 1
+  ; CHECK:     Binding ID: 1
   ; CHECK:     Space: 4
   ; CHECK:     Lower Bound: 2
   ; CHECK:     Size: 1
@@ -49,7 +49,7 @@ define void @test_typedbuffer() {
   ; CHECK: Resource [[SRV2:[0-9]+]]:
   ; CHECK:   Name: Two
   ; CHECK:   Binding:
-  ; CHECK:     Record ID: 2
+  ; CHECK:     Binding ID: 2
   ; CHECK:     Space: 5
   ; CHECK:     Lower Bound: 3
   ; CHECK:     Size: 24
@@ -64,7 +64,7 @@ define void @test_typedbuffer() {
   ; CHECK: Resource [[UAV0:[0-9]+]]:
   ; CHECK:   Name: Three
   ; CHECK:   Binding:
-  ; CHECK:     Record ID: 0
+  ; CHECK:     Binding ID: 0
   ; CHECK:     Space: 2
   ; CHECK:     Lower Bound: 7
   ; CHECK:     Size: 1
@@ -83,7 +83,7 @@ define void @test_typedbuffer() {
   ; CHECK: Resource [[UAV1:[0-9]+]]:
   ; CHECK:   Name: Four
   ; CHECK:   Binding:
-  ; CHECK:     Record ID: 1
+  ; CHECK:     Binding ID: 1
   ; CHECK:     Space: 3
   ; CHECK:     Lower Bound: 5
   ; CHECK:     Size: 1
@@ -106,7 +106,7 @@ define void @test_typedbuffer() {
   ; CHECK: Resource [[UAV2:[0-9]+]]:
   ; CHECK:   Name: Array
   ; CHECK:   Binding:
-  ; CHECK:     Record ID: 2
+  ; CHECK:     Binding ID: 2
   ; CHECK:     Space: 4
   ; CHECK:     Lower Bound: 0
   ; CHECK:     Size: 10
@@ -126,7 +126,7 @@ define void @test_typedbuffer() {
   ; CHECK: Resource [[UAV3:[0-9]+]]:
   ; CHECK:   Name: Five
   ; CHECK:   Binding:
-  ; CHECK:     Record ID: 3
+  ; CHECK:     Binding ID: 3
   ; CHECK:     Space: 5
   ; CHECK:     Lower Bound: 0
   ; CHECK:     Size: 1
@@ -143,7 +143,7 @@ define void @test_typedbuffer() {
   ; CHECK: Resource [[UAV4:[0-9]+]]:
   ; CHECK:   Name: Six
   ; CHECK:   Binding:
-  ; CHECK:     Record ID: 4
+  ; CHECK:     Binding ID: 4
   ; CHECK:     Space: 5
   ; CHECK:     Lower Bound: 0
   ; CHECK:     Size: 1
@@ -160,7 +160,7 @@ define void @test_typedbuffer() {
   ; CHECK: Resource [[CB0:[0-9]+]]:
   ; CHECK:   Name: CB
   ; CHECK:   Binding:
-  ; CHECK:     Record ID: 0
+  ; CHECK:     Binding ID: 0
   ; CHECK:     Space: 1
   ; CHECK:     Lower Bound: 0
   ; CHECK:     Size: 1
@@ -173,7 +173,7 @@ define void @test_typedbuffer() {
   ; CHECK: Resource [[CB1:[0-9]+]]:
   ; CHECK:   Name: Constants
   ; CHECK:   Binding:
-  ; CHECK:     Record ID: 1
+  ; CHECK:     Binding ID: 1
   ; CHECK:     Space: 1
   ; CHECK:     Lower Bound: 8
   ; CHECK:     Size: 1

--- a/llvm/test/Analysis/DXILResource/has-atomic64-use.ll
+++ b/llvm/test/Analysis/DXILResource/has-atomic64-use.ll
@@ -15,7 +15,7 @@ define void @main() {
       @llvm.dx.resource.handlefrombinding.tdx.RawBuffer_i8_1_0t(
           i32 0, i32 0, i32 1, i32 0, ptr null)
   ; CHECK:      Binding:
-  ; CHECK:        Record ID: 0
+  ; CHECK:        Binding ID: 0
   ; CHECK:        Space: 0
   ; CHECK:        Lower Bound: 0
   ; CHECK:        Size: 1
@@ -29,7 +29,7 @@ define void @main() {
       @llvm.dx.resource.handlefrombinding.tdx.RawBuffer_i8_1_0t(
           i32 0, i32 1, i32 1, i32 0, ptr null)
   ; CHECK:      Binding:
-  ; CHECK:        Record ID: 1
+  ; CHECK:        Binding ID: 1
   ; CHECK:        Space: 0
   ; CHECK:        Lower Bound: 1
   ; CHECK:        Size: 1
@@ -43,7 +43,7 @@ define void @main() {
       @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_i32_1_0_1t(
           i32 0, i32 2, i32 1, i32 0, ptr null)
   ; CHECK:      Binding:
-  ; CHECK:        Record ID: 2
+  ; CHECK:        Binding ID: 2
   ; CHECK:        Space: 0
   ; CHECK:        Lower Bound: 2
   ; CHECK:        Size: 1

--- a/llvm/unittests/Analysis/DXILResourceTest.cpp
+++ b/llvm/unittests/Analysis/DXILResourceTest.cpp
@@ -99,9 +99,8 @@ TEST(DXILResource, AnnotationsAndMetadata) {
     EXPECT_EQ(RTI.getResourceClass(), ResourceClass::SRV);
     EXPECT_EQ(RTI.getResourceKind(), ResourceKind::RawBuffer);
 
-    ResourceInfo RI(
-        /*RecordID=*/0, /*Space=*/0, /*LowerBound=*/0, /*Size=*/1,
-        RTI.getHandleTy(), "Buffer");
+    ResourceInfo RI(/*Space=*/0, /*LowerBound=*/0, /*Size=*/1,
+                    RTI.getHandleTy(), "Buffer");
     GlobalVariable *GV = RI.createSymbol(M, RTI.createElementStruct());
     EXPECT_PROPS_EQ(RI.getAnnotateProps(M, RTI), 0x0000000bU, 0U);
     EXPECT_MDEQ(RI.getAsMetadata(M, RTI),
@@ -116,9 +115,9 @@ TEST(DXILResource, AnnotationsAndMetadata) {
     EXPECT_EQ(RTI.getUAV().IsROV, false);
     EXPECT_EQ(RTI.getResourceKind(), ResourceKind::RawBuffer);
 
-    ResourceInfo RI(
-        /*RecordID=*/1, /*Space=*/2, /*LowerBound=*/3, /*Size=*/1,
-        RTI.getHandleTy(), "BufferOut");
+    ResourceInfo RI(/*Space=*/2, /*LowerBound=*/3, /*Size=*/1,
+                    RTI.getHandleTy(), "BufferOut");
+    RI.setBindingID(1);
     GlobalVariable *GV = RI.createSymbol(M, RTI.createElementStruct());
     EXPECT_PROPS_EQ(RI.getAnnotateProps(M, RTI), 0x0000100bU, 0U);
     EXPECT_MDEQ(RI.getAsMetadata(M, RTI),
@@ -142,9 +141,8 @@ TEST(DXILResource, AnnotationsAndMetadata) {
     EXPECT_EQ(RTI.getStruct(DL).AlignLog2, Log2(Align(8)));
     EXPECT_EQ(RTI.getResourceKind(), ResourceKind::StructuredBuffer);
 
-    ResourceInfo RI(
-        /*RecordID=*/0, /*Space=*/0, /*LowerBound=*/0, /*Size=*/1,
-        RTI.getHandleTy(), "Buffer0");
+    ResourceInfo RI(/*Space=*/0, /*LowerBound=*/0, /*Size=*/1,
+                    RTI.getHandleTy(), "Buffer0");
     GlobalVariable *GV = RI.createSymbol(M, RTI.createElementStruct());
     EXPECT_PROPS_EQ(RI.getAnnotateProps(M, RTI), 0x0000030cU, 0x00000010U);
     EXPECT_MDEQ(RI.getAsMetadata(M, RTI), TestMD.get(0, GV, "Buffer0", 0, 0, 1,
@@ -161,9 +159,9 @@ TEST(DXILResource, AnnotationsAndMetadata) {
     EXPECT_EQ(RTI.getStruct(DL).AlignLog2, 0u);
     EXPECT_EQ(RTI.getResourceKind(), ResourceKind::StructuredBuffer);
 
-    ResourceInfo RI(
-        /*RecordID=*/1, /*Space=*/0, /*LowerBound=*/1, /*Size=*/1,
-        RTI.getHandleTy(), "Buffer1");
+    ResourceInfo RI(/*Space=*/0, /*LowerBound=*/1, /*Size=*/1,
+                    RTI.getHandleTy(), "Buffer1");
+    RI.setBindingID(1);
     GlobalVariable *GV = RI.createSymbol(M, RTI.createElementStruct());
     EXPECT_PROPS_EQ(RI.getAnnotateProps(M, RTI), 0x0000000cU, 0x0000000cU);
     EXPECT_MDEQ(RI.getAsMetadata(M, RTI), TestMD.get(1, GV, "Buffer1", 0, 1, 1,
@@ -183,8 +181,9 @@ TEST(DXILResource, AnnotationsAndMetadata) {
     EXPECT_EQ(RTI.getResourceKind(), ResourceKind::Texture2D);
 
     ResourceInfo RI(
-        /*RecordID=*/2, /*Space=*/0, /*LowerBound=*/2, /*Size=*/1,
-        RTI.getHandleTy(), "ColorMapTexture");
+        /*Space=*/0, /*LowerBound=*/2, /*Size=*/1, RTI.getHandleTy(),
+        "ColorMapTexture");
+    RI.setBindingID(2);
     GlobalVariable *GV = RI.createSymbol(M, RTI.createElementStruct());
     EXPECT_PROPS_EQ(RI.getAnnotateProps(M, RTI), 0x00000002U, 0x00000409U);
     EXPECT_MDEQ(
@@ -207,8 +206,8 @@ TEST(DXILResource, AnnotationsAndMetadata) {
     EXPECT_EQ(RTI.getResourceKind(), ResourceKind::Texture2DMS);
 
     ResourceInfo RI(
-        /*RecordID=*/0, /*Space=*/0, /*LowerBound=*/0, /*Size=*/1,
-        RTI.getHandleTy(), "DepthBuffer");
+        /*Space=*/0, /*LowerBound=*/0, /*Size=*/1, RTI.getHandleTy(),
+        "DepthBuffer");
     GlobalVariable *GV = RI.createSymbol(M, RTI.createElementStruct());
     EXPECT_PROPS_EQ(RI.getAnnotateProps(M, RTI), 0x00000003U, 0x00080109U);
     EXPECT_MDEQ(
@@ -228,8 +227,8 @@ TEST(DXILResource, AnnotationsAndMetadata) {
     EXPECT_EQ(RTI.getResourceKind(), ResourceKind::FeedbackTexture2D);
 
     ResourceInfo RI(
-        /*RecordID=*/0, /*Space=*/0, /*LowerBound=*/0, /*Size=*/1,
-        RTI.getHandleTy(), "feedbackMinMip");
+        /*Space=*/0, /*LowerBound=*/0, /*Size=*/1, RTI.getHandleTy(),
+        "feedbackMinMip");
     GlobalVariable *GV = RI.createSymbol(M, RTI.createElementStruct());
     EXPECT_PROPS_EQ(RI.getAnnotateProps(M, RTI), 0x00001011U, 0U);
     EXPECT_MDEQ(RI.getAsMetadata(M, RTI),
@@ -249,8 +248,8 @@ TEST(DXILResource, AnnotationsAndMetadata) {
     EXPECT_EQ(RTI.getResourceKind(), ResourceKind::FeedbackTexture2DArray);
 
     ResourceInfo RI(
-        /*RecordID=*/0, /*Space=*/0, /*LowerBound=*/0, /*Size=*/1,
-        RTI.getHandleTy(), "feedbackMipRegion");
+        /*Space=*/0, /*LowerBound=*/0, /*Size=*/1, RTI.getHandleTy(),
+        "feedbackMipRegion");
     GlobalVariable *GV = RI.createSymbol(M, RTI.createElementStruct());
     EXPECT_PROPS_EQ(RI.getAnnotateProps(M, RTI), 0x00001012U, 0x00000001U);
     EXPECT_MDEQ(RI.getAsMetadata(M, RTI),
@@ -271,8 +270,8 @@ TEST(DXILResource, AnnotationsAndMetadata) {
     EXPECT_EQ(RTI.getResourceKind(), ResourceKind::Texture2D);
 
     ResourceInfo RI(
-        /*RecordID=*/0, /*Space=*/2, /*LowerBound=*/0, /*Size=*/1,
-        RTI.getHandleTy(), "OutputTexture");
+        /*Space=*/2, /*LowerBound=*/0, /*Size=*/1, RTI.getHandleTy(),
+        "OutputTexture");
     RI.GloballyCoherent = true;
     GlobalVariable *GV = RI.createSymbol(M, RTI.createElementStruct());
     EXPECT_PROPS_EQ(RI.getAnnotateProps(M, RTI), 0x00005002U, 0x00000204U);
@@ -298,8 +297,7 @@ TEST(DXILResource, AnnotationsAndMetadata) {
     EXPECT_EQ(RTI.getResourceKind(), ResourceKind::TypedBuffer);
 
     ResourceInfo RI(
-        /*RecordID=*/0, /*Space=*/0, /*LowerBound=*/0, /*Size=*/1,
-        RTI.getHandleTy(), "ROB");
+        /*Space=*/0, /*LowerBound=*/0, /*Size=*/1, RTI.getHandleTy(), "ROB");
     GlobalVariable *GV = RI.createSymbol(M, RTI.createElementStruct());
     EXPECT_PROPS_EQ(RI.getAnnotateProps(M, RTI), 0x0000300aU, 0x00000409U);
     EXPECT_MDEQ(RI.getAsMetadata(M, RTI),
@@ -324,8 +322,8 @@ TEST(DXILResource, AnnotationsAndMetadata) {
     EXPECT_EQ(RTI.getResourceKind(), ResourceKind::StructuredBuffer);
 
     ResourceInfo RI(
-        /*RecordID=*/0, /*Space=*/0, /*LowerBound=*/2, /*Size=*/1,
-        RTI.getHandleTy(), "g_OutputBuffer");
+        /*Space=*/0, /*LowerBound=*/2, /*Size=*/1, RTI.getHandleTy(),
+        "g_OutputBuffer");
     RI.CounterDirection = ResourceCounterDirection::Increment;
     GlobalVariable *GV = RI.createSymbol(M, RTI.createElementStruct());
     EXPECT_PROPS_EQ(RI.getAnnotateProps(M, RTI), 0x0000920cU, 0x00000014U);
@@ -353,8 +351,9 @@ TEST(DXILResource, AnnotationsAndMetadata) {
     EXPECT_EQ(RTI.getResourceKind(), ResourceKind::Texture2DMSArray);
 
     ResourceInfo RI(
-        /*RecordID=*/0, /*Space=*/0, /*LowerBound=*/0, /*Size=*/1,
-        RTI.getHandleTy(), "g_rw_t2dmsa");
+        /*Space=*/0, /*LowerBound=*/0, /*Size=*/1, RTI.getHandleTy(),
+        "g_rw_t2dmsa");
+
     GlobalVariable *GV = RI.createSymbol(M, RTI.createElementStruct());
     EXPECT_PROPS_EQ(RI.getAnnotateProps(M, RTI), 0x00001008U, 0x00080105U);
     EXPECT_MDEQ(RI.getAsMetadata(M, RTI),
@@ -376,8 +375,7 @@ TEST(DXILResource, AnnotationsAndMetadata) {
     EXPECT_EQ(RTI.getResourceKind(), ResourceKind::CBuffer);
 
     ResourceInfo RI(
-        /*RecordID=*/0, /*Space=*/0, /*LowerBound=*/0, /*Size=*/1,
-        RTI.getHandleTy(), "");
+        /*Space=*/0, /*LowerBound=*/0, /*Size=*/1, RTI.getHandleTy(), "");
     GlobalVariable *GV = RI.createSymbol(M, RTI.createElementStruct());
     EXPECT_PROPS_EQ(RI.getAnnotateProps(M, RTI), 0x0000000dU, 0x00000020U);
     EXPECT_MDEQ(RI.getAsMetadata(M, RTI),
@@ -394,8 +392,8 @@ TEST(DXILResource, AnnotationsAndMetadata) {
     EXPECT_EQ(RTI.getResourceKind(), ResourceKind::Sampler);
 
     ResourceInfo RI(
-        /*RecordID=*/0, /*Space=*/0, /*LowerBound=*/0, /*Size=*/1,
-        RTI.getHandleTy(), "ColorMapSampler");
+        /*Space=*/0, /*LowerBound=*/0, /*Size=*/1, RTI.getHandleTy(),
+        "ColorMapSampler");
     GlobalVariable *GV = RI.createSymbol(M, RTI.createElementStruct());
     EXPECT_PROPS_EQ(RI.getAnnotateProps(M, RTI), 0x0000000eU, 0U);
     EXPECT_MDEQ(RI.getAsMetadata(M, RTI),
@@ -411,8 +409,8 @@ TEST(DXILResource, AnnotationsAndMetadata) {
     EXPECT_EQ(RTI.getResourceKind(), ResourceKind::Sampler);
 
     ResourceInfo RI(
-        /*RecordID=*/0, /*Space=*/0, /*LowerBound=*/0, /*Size=*/1,
-        RTI.getHandleTy(), "CmpSampler");
+        /*Space=*/0, /*LowerBound=*/0, /*Size=*/1, RTI.getHandleTy(),
+        "CmpSampler");
     GlobalVariable *GV = RI.createSymbol(M, RTI.createElementStruct());
     EXPECT_PROPS_EQ(RI.getAnnotateProps(M, RTI), 0x0000800eU, 0U);
     EXPECT_MDEQ(RI.getAsMetadata(M, RTI),


### PR DESCRIPTION
Rename `ResourceInfo::RecordID` to `BindingID` to better reflect its purpose. This field is set only for resources with an associated binding. This also clarifies the distinction from the upcoming `HeapResourceID` member, which will identify resources originating from a heap. The existing `RecordID` name could be ambiguous once both identifiers are present.

The change also removes the `RecordID` argument from the `ResourceIfo` constructor because it has always been called with `0` value. The `BindingID` is set later via `setBindingID` after all resource instances are collected.