### PR TITLE
[clang][WebAssembly] Remove `OPT_no_pthread` handling

### DIFF
--- a/clang/lib/Driver/ToolChains/WebAssembly.cpp
+++ b/clang/lib/Driver/ToolChains/WebAssembly.cpp
@@ -77,8 +77,7 @@ static bool TargetBuildsComponents(const llvm::Triple &TargetTriple) {
 }
 
 static bool WantsPthread(const llvm::Triple &Triple, const ArgList &Args) {
-  bool WantsPthread =
-      Args.hasFlag(options::OPT_pthread, options::OPT_no_pthread, false);
+  bool WantsPthread = Args.hasArg(options::OPT_pthread);
 
   // If the WASI environment is "threads" then enable pthreads support
   // without requiring -pthread, in order to prevent user error


### PR DESCRIPTION
`-no-pthread` was originally added to Clang in 425b1a5106def (D11087) simply to prevent "unknown argument" errors when building winpthreads in mingw-w64.

It was subsequently used in `WebAssembly.cpp` when thread options were made consistent in 9d5a089bf544e (D57874) via `Args.hasFlag`.

No other Clang toolchains handle `OPT_no_pthread` (they all use `Args.hasArg(options::OPT_pthread)`), and `-pthread` is not typically treated as a negatable boolean option in GCC/Clang drivers.

Align WebAssembly with all other Clang toolchains by removing the `OPT_no_pthread` check.