### PR TITLE
[RISCV][NFC] add `_Complex {integer}` ABI tests

### DIFF
--- a/clang/test/CodeGen/RISCV/riscv32-abi.c
+++ b/clang/test/CodeGen/RISCV/riscv32-abi.c
@@ -1888,6 +1888,52 @@ struct float16complex_s f_ret_float16complex_s(void) {
   return (struct float16complex_s){1.0};
 }
 
+// CHECK-LABEL: define{{.*}} i64 @f_ucharcomplex(i64 %x.coerce)
+// ILP32-ILP32F-ILP32D-LABEL: define dso_local i16 @f_ucharcomplex
+// ILP32-ILP32F-ILP32D-SAME: (i16 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// ILP32-ILP32F-ILP32D:  entry:
+//
+unsigned char __complex__ f_ucharcomplex(unsigned char __complex__ x) { return x; }
+
+// CHECK-LABEL: define{{.*}} i64 @f_ushortcomplex(i64 %x.coerce)
+// ILP32-ILP32F-ILP32D-LABEL: define dso_local i32 @f_ushortcomplex
+// ILP32-ILP32F-ILP32D-SAME: (i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// ILP32-ILP32F-ILP32D:  entry:
+//
+unsigned short __complex__ f_ushortcomplex(unsigned short __complex__ x) { return x; }
+
+struct ucharcomplex_s {
+  unsigned char __complex__ c;
+};
+// CHECK-LABEL: define{{.*}} i64 @f_ucharcomplex_s(i64 %x.coerce)
+// ILP32-LABEL: define dso_local i16 @f_ucharcomplex_s
+// ILP32-SAME: (i16 [[X_COERCE:%.*]]) #[[ATTR0]] {
+// ILP32:  entry:
+//
+// ILP32F-ILP32D-LABEL: define dso_local { i8, i8 } @f_ucharcomplex_s
+// ILP32F-ILP32D-SAME: (i8 [[TMP0:%.*]], i8 [[TMP1:%.*]]) #[[ATTR0]] {
+// ILP32F-ILP32D:  entry:
+//
+struct ucharcomplex_s f_ucharcomplex_s(struct ucharcomplex_s x) {
+  return x;
+}
+
+struct ushortcomplex_s {
+  unsigned short __complex__ c;
+};
+// CHECK-LABEL: define{{.*}} i64 @f_ushortcomplex_s(i64 %x.coerce)
+// ILP32-LABEL: define dso_local i32 @f_ushortcomplex_s
+// ILP32-SAME: (i32 [[X_COERCE:%.*]]) #[[ATTR0]] {
+// ILP32:  entry:
+//
+// ILP32F-ILP32D-LABEL: define dso_local { i16, i16 } @f_ushortcomplex_s
+// ILP32F-ILP32D-SAME: (i16 [[TMP0:%.*]], i16 [[TMP1:%.*]]) #[[ATTR0]] {
+// ILP32F-ILP32D:  entry:
+//
+struct ushortcomplex_s f_ushortcomplex_s(struct ushortcomplex_s x) {
+  return x;
+}
+
 // Test single or two-element structs that need flattening. e.g. those
 // containing nested structs, _Float16 in small arrays, zero-length structs etc.
 

--- a/clang/test/CodeGen/RISCV/riscv64-abi.c
+++ b/clang/test/CodeGen/RISCV/riscv64-abi.c
@@ -709,6 +709,52 @@ struct floatcomplex_s f_ret_floatcomplex_s(void) {
   return (struct floatcomplex_s){1.0};
 }
 
+// CHECK-LABEL: define{{.*}} i64 @f_ucharcomplex(i64 %x.coerce)
+// LP64-LP64F-LP64D-LABEL: define dso_local i16 @f_ucharcomplex
+// LP64-LP64F-LP64D-SAME: (i16 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// LP64-LP64F-LP64D:  entry:
+//
+unsigned char __complex__ f_ucharcomplex(unsigned char __complex__ x) { return x; }
+
+// CHECK-LABEL: define{{.*}} i64 @f_ushortcomplex(i64 %x.coerce)
+// LP64-LP64F-LP64D-LABEL: define dso_local i32 @f_ushortcomplex
+// LP64-LP64F-LP64D-SAME: (i32 noundef [[X_COERCE:%.*]]) #[[ATTR0]] {
+// LP64-LP64F-LP64D:  entry:
+//
+unsigned short __complex__ f_ushortcomplex(unsigned short __complex__ x) { return x; }
+
+struct ucharcomplex_s {
+  unsigned char __complex__ c;
+};
+// CHECK-LABEL: define{{.*}} i64 @f_ucharcomplex_s(i64 %x.coerce)
+// LP64-LABEL: define dso_local i16 @f_ucharcomplex_s
+// LP64-SAME: (i16 [[X_COERCE:%.*]]) #[[ATTR0]] {
+// LP64:  entry:
+//
+// LP64F-LP64D-LABEL: define dso_local { i8, i8 } @f_ucharcomplex_s
+// LP64F-LP64D-SAME: (i8 [[TMP0:%.*]], i8 [[TMP1:%.*]]) #[[ATTR0]] {
+// LP64F-LP64D:  entry:
+//
+struct ucharcomplex_s f_ucharcomplex_s(struct ucharcomplex_s x) {
+  return x;
+}
+
+struct ushortcomplex_s {
+  unsigned short __complex__ c;
+};
+// CHECK-LABEL: define{{.*}} i64 @f_ushortcomplex_s(i64 %x.coerce)
+// LP64-LABEL: define dso_local i32 @f_ushortcomplex_s
+// LP64-SAME: (i32 [[X_COERCE:%.*]]) #[[ATTR0]] {
+// LP64:  entry:
+//
+// LP64F-LP64D-LABEL: define dso_local { i16, i16 } @f_ushortcomplex_s
+// LP64F-LP64D-SAME: (i16 [[TMP0:%.*]], i16 [[TMP1:%.*]]) #[[ATTR0]] {
+// LP64F-LP64D:  entry:
+//
+struct ushortcomplex_s f_ushortcomplex_s(struct ushortcomplex_s x) {
+  return x;
+}
+
 // Complex floating-point values or structs containing a single complex
 // floating-point value should be passed in GPRs if no two FPRs is available.
 


### PR DESCRIPTION
based on https://github.com/llvm/llvm-project/pull/215222, RISCV has the same bug.

The fix is basically identical, I'll put up a PR once this merges.