### PR TITLE
[clang][HLSL] Complete the pattern an instantiation is built from, not the primary template

### DIFF
--- a/clang/lib/AST/DeclTemplate.cpp
+++ b/clang/lib/AST/DeclTemplate.cpp
@@ -991,14 +991,6 @@ ClassTemplateSpecializationDecl *ClassTemplateSpecializationDecl::Create(
       Context, ClassTemplateSpecialization, TK, DC, StartLoc, IdLoc,
       SpecializedTemplate, Args, StrictPackMatch, PrevDecl);
 
-  // If the template decl is incomplete, copy the external lexical storage from
-  // the base template. This allows instantiations of incomplete types to
-  // complete using the external AST if the template's declaration came from an
-  // external AST.
-  if (!SpecializedTemplate->getTemplatedDecl()->isCompleteDefinition())
-    Result->setHasExternalLexicalStorage(
-      SpecializedTemplate->getTemplatedDecl()->hasExternalLexicalStorage());
-
   return Result;
 }
 

--- a/clang/lib/Sema/HLSLExternalSemaSource.cpp
+++ b/clang/lib/Sema/HLSLExternalSemaSource.cpp
@@ -24,7 +24,6 @@
 #include "clang/Sema/Lookup.h"
 #include "clang/Sema/Sema.h"
 #include "clang/Sema/SemaHLSL.h"
-#include "clang/Sema/TemplateDeduction.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 
@@ -856,31 +855,7 @@ void HLSLExternalSemaSource::onCompletion(CXXRecordDecl *Record,
 void HLSLExternalSemaSource::CompleteType(TagDecl *Tag) {
   if (!isa<CXXRecordDecl>(Tag))
     return;
-  auto Record = cast<CXXRecordDecl>(Tag);
-
-  // If this is a specialization, we need to get the underlying templated
-  // declaration and complete that.
-  if (auto TDecl = dyn_cast<ClassTemplateSpecializationDecl>(Record)) {
-    if (!isa<ClassTemplatePartialSpecializationDecl>(TDecl)) {
-      ClassTemplateDecl *Template = TDecl->getSpecializedTemplate();
-      llvm::SmallVector<ClassTemplatePartialSpecializationDecl *, 4> Partials;
-      Template->getPartialSpecializations(Partials);
-      ClassTemplatePartialSpecializationDecl *MatchedPartial = nullptr;
-      for (auto *Partial : Partials) {
-        sema::TemplateDeductionInfo Info(TDecl->getLocation());
-        if (SemaPtr->DeduceTemplateArguments(Partial, TDecl->getTemplateArgs(),
-                                             Info) ==
-            TemplateDeductionResult::Success) {
-          MatchedPartial = Partial;
-          break;
-        }
-      }
-      if (MatchedPartial)
-        Record = MatchedPartial;
-      else
-        Record = Template->getTemplatedDecl();
-    }
-  }
+  auto *Record = cast<CXXRecordDecl>(Tag);
   Record = Record->getCanonicalDecl();
   auto It = Completions.find(Record);
   if (It == Completions.end())

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -4184,6 +4184,13 @@ bool Sema::InstantiateClassTemplateSpecialization(
   if (!Pattern.isUsable())
     return Pattern.isInvalid();
 
+  // Deduction has picked the pattern this specialization will be instantiated
+  // from, which may be a declaration an external AST source has yet to define.
+  if (!Pattern.get()->isCompleteDefinition() &&
+      Pattern.get()->hasExternalLexicalStorage())
+    if (ExternalASTSource *Source = Context.getExternalSource())
+      Source->CompleteType(Pattern.get());
+
   bool Err = InstantiateClassImpl(
       PointOfInstantiation, ClassTemplateSpec, Pattern.get(),
       getTemplateInstantiationArgs(ClassTemplateSpec), TSK, Complain);

--- a/clang/test/SemaHLSL/Resources/Textures-declaration-order.hlsl
+++ b/clang/test/SemaHLSL/Resources/Textures-declaration-order.hlsl
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -fsyntax-only -finclude-default-header -verify -DSCALAR_FIRST %s
-// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -fsyntax-only -finclude-default-header -verify %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -fsyntax-only -finclude-default-header -verify -USCALAR_FIRST %s
 // RUN: %clang_cc1 -triple spirv-unknown-vulkan-library -x hlsl -fsyntax-only -finclude-default-header -verify -DSCALAR_FIRST %s
-// RUN: %clang_cc1 -triple spirv-unknown-vulkan-library -x hlsl -fsyntax-only -finclude-default-header -verify %s
+// RUN: %clang_cc1 -triple spirv-unknown-vulkan-library -x hlsl -fsyntax-only -finclude-default-header -verify -USCALAR_FIRST %s
 
 // Texture resource classes are declared as a primary class template, used for
 // scalar element types, plus a partial specialization used for vector element

--- a/clang/test/SemaHLSL/Resources/Textures-declaration-order.hlsl
+++ b/clang/test/SemaHLSL/Resources/Textures-declaration-order.hlsl
@@ -1,0 +1,48 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -fsyntax-only -finclude-default-header -verify -DSCALAR_FIRST %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -fsyntax-only -finclude-default-header -verify %s
+// RUN: %clang_cc1 -triple spirv-unknown-vulkan-library -x hlsl -fsyntax-only -finclude-default-header -verify -DSCALAR_FIRST %s
+// RUN: %clang_cc1 -triple spirv-unknown-vulkan-library -x hlsl -fsyntax-only -finclude-default-header -verify %s
+
+// Texture resource classes are declared as a primary class template, used for
+// scalar element types, plus a partial specialization used for vector element
+// types. Both patterns are only defined on demand by HLSLExternalSemaSource, so
+// completing one of them must not prevent the other one from being completed.
+// See https://github.com/llvm/llvm-project/issues/212575.
+
+// expected-no-diagnostics
+
+#ifdef SCALAR_FIRST
+Texture2D<float> Tex2D;
+Texture2D<float2> Tex2DVec;
+RWTexture2D<float> RWTex2D;
+RWTexture2D<float2> RWTex2DVec;
+Texture2DArray<float> Tex2DArray;
+Texture2DArray<float2> Tex2DArrayVec;
+RWTexture2DArray<float> RWTex2DArray;
+RWTexture2DArray<float2> RWTex2DArrayVec;
+#else
+Texture2D<float2> Tex2DVec;
+Texture2D<float> Tex2D;
+RWTexture2D<float2> RWTex2DVec;
+RWTexture2D<float> RWTex2D;
+Texture2DArray<float2> Tex2DArrayVec;
+Texture2DArray<float> Tex2DArray;
+RWTexture2DArray<float2> RWTex2DArrayVec;
+RWTexture2DArray<float> RWTex2DArray;
+#endif
+
+SamplerState Samp;
+
+// Use members of both the primary template and the partial specialization to
+// make sure both patterns really have been completed.
+export void useTextures(float2 UV, float3 UVW) {
+  float S = Tex2D.Sample(Samp, UV);
+  float2 V = Tex2DVec.Sample(Samp, UV);
+  RWTex2D[uint2(0, 0)] = S;
+  RWTex2DVec[uint2(0, 0)] = V;
+
+  float AS = Tex2DArray.Sample(Samp, UVW);
+  float2 AV = Tex2DArrayVec.Sample(Samp, UVW);
+  RWTex2DArray[uint3(0, 0, 0)] = AS;
+  RWTex2DArrayVec[uint3(0, 0, 0)] = AV;
+}

--- a/clang/unittests/AST/ExternalASTSourceTest.cpp
+++ b/clang/unittests/AST/ExternalASTSourceTest.cpp
@@ -13,6 +13,8 @@
 #include "clang/AST/ExternalASTSource.h"
 #include "clang/AST/ASTConsumer.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/DeclCXX.h"
+#include "clang/AST/DeclTemplate.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/CompilerInvocation.h"
 #include "clang/Frontend/FrontendActions.h"
@@ -26,14 +28,18 @@ using namespace llvm;
 
 class TestFrontendAction : public ASTFrontendAction {
 public:
-  TestFrontendAction(IntrusiveRefCntPtr<ExternalASTSource> Source)
-      : Source(std::move(Source)) {}
+  TestFrontendAction(IntrusiveRefCntPtr<ExternalASTSource> Source,
+                     std::function<void(ASTContext &)> Inject = nullptr)
+      : Source(std::move(Source)), Inject(std::move(Inject)) {}
 
 private:
   void ExecuteAction() override {
-    getCompilerInstance().getASTContext().setExternalSource(Source);
-    getCompilerInstance().getASTContext().getTranslationUnitDecl()
-        ->setHasExternalVisibleStorage();
+    ASTContext &Ctx = getCompilerInstance().getASTContext();
+    Ctx.setExternalSource(Source);
+    if (Inject)
+      Inject(Ctx);
+    else
+      Ctx.getTranslationUnitDecl()->setHasExternalVisibleStorage();
     return ASTFrontendAction::ExecuteAction();
   }
 
@@ -43,10 +49,12 @@ private:
   }
 
   IntrusiveRefCntPtr<ExternalASTSource> Source;
+  std::function<void(ASTContext &)> Inject;
 };
 
 bool testExternalASTSource(llvm::IntrusiveRefCntPtr<ExternalASTSource> Source,
-                           StringRef FileContents) {
+                           StringRef FileContents,
+                           std::function<void(ASTContext &)> Inject = nullptr) {
 
   auto Invocation = std::make_shared<CompilerInvocation>();
   Invocation->getPreprocessorOpts().addRemappedFile(
@@ -62,7 +70,7 @@ bool testExternalASTSource(llvm::IntrusiveRefCntPtr<ExternalASTSource> Source,
   Compiler.setVirtualFileSystem(llvm::vfs::getRealFileSystem());
   Compiler.createDiagnostics();
 
-  TestFrontendAction Action(Source);
+  TestFrontendAction Action(Source, std::move(Inject));
   return Compiler.ExecuteAction(Action);
 }
 
@@ -86,4 +94,93 @@ TEST(ExternalASTSourceTest, FailedLookupOccursOnce) {
   ASSERT_TRUE(testExternalASTSource(
       llvm::makeIntrusiveRefCnt<TestSource>(Calls), "int j, k = j;"));
   EXPECT_EQ(1u, Calls);
+}
+
+namespace {
+
+/// An external source which announces, without definitions,
+///
+///   template <typename T> struct A;      // primary pattern
+///   template <typename T> struct A<T *>; // partial specialization pattern
+///
+/// and supplies the definition of whichever pattern it is asked to complete.
+struct LazyTemplatePatterns : ExternalASTSource {
+  CXXRecordDecl *Primary = nullptr;
+  ClassTemplatePartialSpecializationDecl *Partial = nullptr;
+  unsigned PrimaryCompletions = 0;
+  unsigned PartialCompletions = 0;
+
+  void inject(ASTContext &Ctx) {
+    TranslationUnitDecl *TU = Ctx.getTranslationUnitDecl();
+    IdentifierInfo &AName = Ctx.Idents.get("A");
+
+    auto MakeParams = [&] {
+      auto *Param = TemplateTypeParmDecl::Create(
+          Ctx, TU, {}, {}, /*D=*/0, /*P=*/0, &Ctx.Idents.get("T"),
+          /*Typename=*/true, /*ParameterPack=*/false);
+      return TemplateParameterList::Create(Ctx, {}, {}, {Param}, {}, nullptr);
+    };
+
+    // template <typename T> struct A;
+    Primary = CXXRecordDecl::Create(Ctx, TagDecl::TagKind::Struct, TU, {}, {},
+                                    &AName);
+    auto *Template = ClassTemplateDecl::Create(
+        Ctx, TU, {}, DeclarationName(&AName), MakeParams(), Primary);
+    Primary->setDescribedClassTemplate(Template);
+    Primary->setHasExternalLexicalStorage();
+    TU->addDecl(Template);
+
+    // template <typename T> struct A<T *>;
+    TemplateParameterList *PartialParams = MakeParams();
+    TemplateArgument Arg(Ctx.getPointerType(Ctx.getTemplateTypeParmType(
+        /*Depth=*/0, /*Index=*/0, /*ParameterPack=*/false,
+        cast<TemplateTypeParmDecl>(PartialParams->getParam(0)))));
+    Partial = ClassTemplatePartialSpecializationDecl::Create(
+        Ctx, TagDecl::TagKind::Struct, TU, {}, {}, PartialParams, Template, Arg,
+        Ctx.getCanonicalType(Ctx.getTemplateSpecializationType(
+            ElaboratedTypeKeyword::Struct, TemplateName(Template), Arg, {})),
+        nullptr);
+    Partial->setHasExternalLexicalStorage();
+
+    // Deduction against a partial specialization reads its arguments as
+    // written, so they must be supplied even though nothing was written.
+    TemplateArgumentListInfo ArgsInfo;
+    ArgsInfo.addArgument(TemplateArgumentLoc(
+        Arg, Ctx.getTrivialTypeSourceInfo(Arg.getAsType())));
+    Partial->setTemplateArgsAsWritten(
+        ASTTemplateArgumentListInfo::Create(Ctx, ArgsInfo));
+
+    TU->addDecl(Partial);
+    Template->AddPartialSpecialization(Partial, nullptr);
+  }
+
+  void CompleteType(TagDecl *Tag) override {
+    auto *Record = dyn_cast<CXXRecordDecl>(Tag);
+    if (!Record || Record->isCompleteDefinition())
+      return;
+    if (Record == Primary)
+      ++PrimaryCompletions;
+    else if (Record == Partial)
+      ++PartialCompletions;
+    else
+      return;
+    Record->setHasExternalLexicalStorage(false);
+    Record->startDefinition();
+    Record->completeDefinition();
+  }
+};
+
+} // namespace
+
+// An instantiation must be able to complete the pattern it is actually built
+// from, whichever of the two that is, and in either order.
+TEST(ExternalASTSourceTest, CompletesPatternInEitherOrder) {
+  for (StringRef Code : {"A<int> a; A<int *> b;", "A<int *> b; A<int> a;"}) {
+    auto Source = llvm::makeIntrusiveRefCnt<LazyTemplatePatterns>();
+    ASSERT_TRUE(testExternalASTSource(Source, Code, [&](ASTContext &Ctx) {
+      Source->inject(Ctx);
+    })) << Code;
+    EXPECT_EQ(1u, Source->PrimaryCompletions) << Code;
+    EXPECT_EQ(1u, Source->PartialCompletions) << Code;
+  }
 }

--- a/clang/unittests/AST/ExternalASTSourceTest.cpp
+++ b/clang/unittests/AST/ExternalASTSourceTest.cpp
@@ -25,21 +25,22 @@
 using namespace clang;
 using namespace llvm;
 
+struct TestExternalASTSource : public ExternalASTSource {
+  virtual void setupTestAST(ASTContext &Ctx) {
+    Ctx.getTranslationUnitDecl()->setHasExternalVisibleStorage();
+  }
+};
 
 class TestFrontendAction : public ASTFrontendAction {
 public:
-  TestFrontendAction(IntrusiveRefCntPtr<ExternalASTSource> Source,
-                     std::function<void(ASTContext &)> Inject = nullptr)
-      : Source(std::move(Source)), Inject(std::move(Inject)) {}
+  TestFrontendAction(IntrusiveRefCntPtr<TestExternalASTSource> Source)
+      : Source(std::move(Source)) {}
 
 private:
   void ExecuteAction() override {
     ASTContext &Ctx = getCompilerInstance().getASTContext();
     Ctx.setExternalSource(Source);
-    if (Inject)
-      Inject(Ctx);
-    else
-      Ctx.getTranslationUnitDecl()->setHasExternalVisibleStorage();
+    Source->setupTestAST(Ctx);
     return ASTFrontendAction::ExecuteAction();
   }
 
@@ -48,13 +49,12 @@ private:
     return std::make_unique<ASTConsumer>();
   }
 
-  IntrusiveRefCntPtr<ExternalASTSource> Source;
-  std::function<void(ASTContext &)> Inject;
+  IntrusiveRefCntPtr<TestExternalASTSource> Source;
 };
 
-bool testExternalASTSource(llvm::IntrusiveRefCntPtr<ExternalASTSource> Source,
-                           StringRef FileContents,
-                           std::function<void(ASTContext &)> Inject = nullptr) {
+bool testExternalASTSource(
+    llvm::IntrusiveRefCntPtr<TestExternalASTSource> Source,
+    StringRef FileContents) {
 
   auto Invocation = std::make_shared<CompilerInvocation>();
   Invocation->getPreprocessorOpts().addRemappedFile(
@@ -70,13 +70,13 @@ bool testExternalASTSource(llvm::IntrusiveRefCntPtr<ExternalASTSource> Source,
   Compiler.setVirtualFileSystem(llvm::vfs::getRealFileSystem());
   Compiler.createDiagnostics();
 
-  TestFrontendAction Action(Source, std::move(Inject));
+  TestFrontendAction Action(Source);
   return Compiler.ExecuteAction(Action);
 }
 
 // Ensure that a failed name lookup into an external source only occurs once.
 TEST(ExternalASTSourceTest, FailedLookupOccursOnce) {
-  struct TestSource : ExternalASTSource {
+  struct TestSource : TestExternalASTSource {
     TestSource(unsigned &Calls) : Calls(Calls) {}
 
     bool
@@ -104,13 +104,13 @@ namespace {
 ///   template <typename T> struct A<T *>; // partial specialization pattern
 ///
 /// and supplies the definition of whichever pattern it is asked to complete.
-struct LazyTemplatePatterns : ExternalASTSource {
+struct LazyTemplatePatterns : TestExternalASTSource {
   CXXRecordDecl *Primary = nullptr;
   ClassTemplatePartialSpecializationDecl *Partial = nullptr;
   unsigned PrimaryCompletions = 0;
   unsigned PartialCompletions = 0;
 
-  void inject(ASTContext &Ctx) {
+  void setupTestAST(ASTContext &Ctx) override {
     TranslationUnitDecl *TU = Ctx.getTranslationUnitDecl();
     IdentifierInfo &AName = Ctx.Idents.get("A");
 
@@ -177,9 +177,7 @@ struct LazyTemplatePatterns : ExternalASTSource {
 TEST(ExternalASTSourceTest, CompletesPatternInEitherOrder) {
   for (StringRef Code : {"A<int> a; A<int *> b;", "A<int *> b; A<int> a;"}) {
     auto Source = llvm::makeIntrusiveRefCnt<LazyTemplatePatterns>();
-    ASSERT_TRUE(testExternalASTSource(Source, Code, [&](ASTContext &Ctx) {
-      Source->inject(Ctx);
-    })) << Code;
+    ASSERT_TRUE(testExternalASTSource(Source, Code)) << Code;
     EXPECT_EQ(1u, Source->PrimaryCompletions) << Code;
     EXPECT_EQ(1u, Source->PartialCompletions) << Code;
   }


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/212575

When an external AST source lazily supplies class template patterns, Clang stopped asking it for definitions once the primary pattern had been completed. A partial specialization declared after that point is then instantiated from a pattern that had never been defined, failing with `err_template_instantiate_undefined`.
So whether a declaration compiled depended on what had been declared before it (as seen in https://hlsl.godbolt.org/z/vW3xGY6sW).

The problem Is that `ClassTemplateSpecializationDecl::Create` copies the `hasExternalLexicalStorage()` flag only from the primary template, and only while the primary template was still incomplete. Partial specializations therefore failed when the primary template was completed, hence exhibiting the aforementioned `err_template_instantiate_undefined` error behavior when the primary template was completed.

To fix the issue, this PR replaces the logic in `ClassTemplateSpecializationDecl::Create` (introduced by https://github.com/llvm/llvm-project/commit/6e56d0dbe3c89d3cd5730a57b9049b74e0bf605f) with a request for completion at the point the pattern is actually known in `Sema::InstantiateClassTemplateSpecialization`. This PR also removes the compensating logic that it had forced on `HLSLExternalSemaSource::CompleteType`.

A unit test is added to `clang/unittests/AST/ExternalASTSourceTest.cpp` to exercise such lazy template patterns, and an HLSL sema test has been added to ensure that https://github.com/llvm/llvm-project/issues/212575 is properly fixed.

Assisted by: Claude Opus 5