### PR TITLE
[lldb] fix arm64e tests not compiling with an arm64e target

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbarm64e.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbarm64e.py
@@ -6,6 +6,5 @@ from lldbsuite.test import configuration
 @skipUnlessArm64eSupported
 class Arm64eTestBase(TestBase):
     def build(self):
-        super().build(
-            dictionary={"TRIPLE": configuration.triple.replace("arm64-", "arm64e-")}
-        )
+        triple = configuration.triple.replace("arm64-", "arm64e-")
+        super().build(dictionary={"TRIPLE": triple, "ARCH_CFLAGS": "-target " + triple})


### PR DESCRIPTION
Arm64eTestBase.build() only overrode TRIPLE, but ARCH_CFLAGS is a Make command-line variable set separately by the test harness to a non-arm64e flag. A plain in-Makefile assignment can't override a command-line variable, so the compiler silently fell back to the host's default (non-arm64e) triple and __ptrauth attributes failed to compile. Now overrides ARCH_CFLAGS too.