### PR TITLE
[lldb] Run TestDenyAttach only with locally built debug server

### DIFF
--- a/lldb/test/API/macosx/deny-attach/TestDenyAttach.py
+++ b/lldb/test/API/macosx/deny-attach/TestDenyAttach.py
@@ -11,6 +11,7 @@ class DenyAttachTestCase(TestBase):
     @requireDarwin
     @skipIfDarwinEmbedded  # PT_DENY_ATTACH attach behavior differs on ios/tvos/etc
     @skipIfAsan  # Attach tests time out inconsistently under asan.
+    @skipIfOutOfTreeDebugserver
     def test_attach_to_deny_attach_process(self):
         """Attaching to a PT_DENY_ATTACH process reports an error, not a crash."""
         self.build()


### PR DESCRIPTION
The PT_DENY_ATTACH handling is in debugserver, so a system debugserver still reports lost connection. Added @skipIfOutOfTreeDebugserver