### PR TITLE
[libc] Fix link errors in some hermetic tests

### DIFF
--- a/libc/cmake/modules/LLVMLibCTestRules.cmake
+++ b/libc/cmake/modules/LLVMLibCTestRules.cmake
@@ -931,7 +931,13 @@ function(add_libc_hermetic test_name)
     PRIVATE
       libc.startup.${LIBC_TARGET_OS}.crt1
       ${link_libraries}
+      ${fq_target_name}.__libc__
       LibcHermeticTestSupport.hermetic
+      # Working around dependency issues caused by compiler introduced libcalls.
+      # We need to repeat the libc target so that we can resolve libcalls which
+      # pull in functions from LibcHermeticTestSupport (which then foward to
+      # internal implementations).
+      # TODO: clean this up
       ${fq_target_name}.__libc__
       ${compiler_runtime}
   )


### PR DESCRIPTION
There is a dependency loop between the __libc__ and the LibcHermeticTestSupport targets. If a compiler introduces a call to `extern "C" memcpy` to some __libc__ function, then we need to link LibcHermeticTestSupport to satisfy that. But the hermetic implementation simply forwards to LIBC_NAMESPACE::memcpy, which is in the __libc__ target.

Linking the libc library twice is a simple though unsatisfying solution to this problem. I'm working on a more principled fix, but that is going to take a while longer, so I'm adding this in the mean time.