### PR TITLE
[compiler-rt] Add version info to Windows runtime DLLs

### DIFF
--- a/compiler-rt/cmake/Modules/AddCompilerRT.cmake
+++ b/compiler-rt/cmake/Modules/AddCompilerRT.cmake
@@ -1,7 +1,8 @@
 include(ExternalProject)
+include(AddLLVM)
 include(CompilerRTUtils)
 include(HandleCompilerRT)
-include(LLVMVersion OPTIONAL)
+include(LLVMVersion)
 
 function(set_target_output_directories target output_dir)
   # For RUNTIME_OUTPUT_DIRECTORY variable, Multi-configuration generators
@@ -28,61 +29,33 @@ endfunction()
 function(add_compiler_rt_windows_version_resource_file OUT_VAR RESOURCE_VAR name)
   set(sources ${ARGN})
   if(MSVC AND CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
-    set(resource_file)
-    foreach(candidate_resource_file IN ITEMS
-        "${LLVM_SOURCE_DIR}/resources/windows_version_resource.rc"
-        "${LLVM_MAIN_SRC_DIR}/resources/windows_version_resource.rc"
-        "${LLVM_MAIN_SRC_DIR}/llvm/resources/windows_version_resource.rc")
-      if(EXISTS "${candidate_resource_file}")
-        set(resource_file "${candidate_resource_file}")
-        break()
-      endif()
-    endforeach()
-
-    if(resource_file)
-      set(target_resource_file
-        "${CMAKE_CURRENT_BINARY_DIR}/${name}_windows_version_resource.rc")
-      configure_file("${resource_file}" "${target_resource_file}" COPYONLY)
-      list(APPEND sources "${target_resource_file}")
-      source_group("Resource Files" "${target_resource_file}")
-      set(${RESOURCE_VAR} "${target_resource_file}" PARENT_SCOPE)
-    endif()
+    set(resource_file
+      "${COMPILER_RT_SOURCE_DIR}/resources/windows_version_resource.rc")
+    set(target_resource_file
+      "${CMAKE_CURRENT_BINARY_DIR}/${name}_windows_version_resource.rc")
+    configure_file("${resource_file}" "${target_resource_file}" COPYONLY)
+    list(APPEND sources "${target_resource_file}")
+    source_group("Resource Files" "${target_resource_file}")
+    set(${RESOURCE_VAR} "${target_resource_file}" PARENT_SCOPE)
   endif()
   set(${OUT_VAR} ${sources} PARENT_SCOPE)
 endfunction()
 
 function(set_compiler_rt_windows_version_resource_properties name resource_file)
-  if(DEFINED LLVM_VERSION_MAJOR)
-    set(version_major ${LLVM_VERSION_MAJOR})
-  else()
-    set(version_major 0)
-  endif()
-  if(DEFINED LLVM_VERSION_MINOR)
-    set(version_minor ${LLVM_VERSION_MINOR})
-  else()
-    set(version_minor 0)
-  endif()
-  if(DEFINED LLVM_VERSION_PATCH)
-    set(version_patchlevel ${LLVM_VERSION_PATCH})
-  else()
-    set(version_patchlevel 0)
-  endif()
-
   if(DEFINED PACKAGE_VERSION AND NOT "${PACKAGE_VERSION}" STREQUAL "")
     set(version_string "${PACKAGE_VERSION}")
   else()
     set(version_string
-      "${version_major}.${version_minor}.${version_patchlevel}${LLVM_VERSION_SUFFIX}")
+      "${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH}${LLVM_VERSION_SUFFIX}")
   endif()
 
   set_windows_version_resource_properties(${name} ${resource_file}
-    VERSION_MAJOR ${version_major}
-    VERSION_MINOR ${version_minor}
-    VERSION_PATCHLEVEL ${version_patchlevel}
+    VERSION_MAJOR ${LLVM_VERSION_MAJOR}
+    VERSION_MINOR ${LLVM_VERSION_MINOR}
+    VERSION_PATCHLEVEL ${LLVM_VERSION_PATCH}
     VERSION_STRING "${version_string}"
     PRODUCT_NAME "compiler-rt")
 endfunction()
-
 
 # Tries to add an "object library" target for a given list of OSs and/or
 # architectures with name "<name>.<arch>" for non-Darwin platforms if

--- a/compiler-rt/cmake/Modules/AddCompilerRT.cmake
+++ b/compiler-rt/cmake/Modules/AddCompilerRT.cmake
@@ -1,5 +1,4 @@
 include(ExternalProject)
-include(AddLLVM)
 include(CompilerRTUtils)
 include(HandleCompilerRT)
 include(LLVMVersion)
@@ -49,12 +48,18 @@ function(set_compiler_rt_windows_version_resource_properties name resource_file)
       "${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH}${LLVM_VERSION_SUFFIX}")
   endif()
 
-  set_windows_version_resource_properties(${name} ${resource_file}
-    VERSION_MAJOR ${LLVM_VERSION_MAJOR}
-    VERSION_MINOR ${LLVM_VERSION_MINOR}
-    VERSION_PATCHLEVEL ${LLVM_VERSION_PATCH}
-    VERSION_STRING "${version_string}"
-    PRODUCT_NAME "compiler-rt")
+  set_property(SOURCE ${resource_file}
+               PROPERTY COMPILE_FLAGS /nologo)
+  set_property(SOURCE ${resource_file}
+               PROPERTY COMPILE_DEFINITIONS
+               "RC_VERSION_FIELD_1=${LLVM_VERSION_MAJOR}"
+               "RC_VERSION_FIELD_2=${LLVM_VERSION_MINOR}"
+               "RC_VERSION_FIELD_3=${LLVM_VERSION_PATCH}"
+               "RC_VERSION_FIELD_4=0"
+               "RC_FILE_VERSION=\"${version_string}\""
+               "RC_INTERNAL_NAME=\"${name}\""
+               "RC_PRODUCT_NAME=\"compiler-rt\""
+               "RC_PRODUCT_VERSION=\"${version_string}\"")
 endfunction()
 
 # Tries to add an "object library" target for a given list of OSs and/or

--- a/compiler-rt/cmake/Modules/AddCompilerRT.cmake
+++ b/compiler-rt/cmake/Modules/AddCompilerRT.cmake
@@ -1,6 +1,7 @@
 include(ExternalProject)
 include(CompilerRTUtils)
 include(HandleCompilerRT)
+include(LLVMVersion OPTIONAL)
 
 function(set_target_output_directories target output_dir)
   # For RUNTIME_OUTPUT_DIRECTORY variable, Multi-configuration generators
@@ -23,6 +24,65 @@ function(set_target_output_directories target output_dir)
         RUNTIME_OUTPUT_DIRECTORY ${output_dir})
   endif()
 endfunction()
+
+function(add_compiler_rt_windows_version_resource_file OUT_VAR RESOURCE_VAR name)
+  set(sources ${ARGN})
+  if(MSVC AND CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
+    set(resource_file)
+    foreach(candidate_resource_file IN ITEMS
+        "${LLVM_SOURCE_DIR}/resources/windows_version_resource.rc"
+        "${LLVM_MAIN_SRC_DIR}/resources/windows_version_resource.rc"
+        "${LLVM_MAIN_SRC_DIR}/llvm/resources/windows_version_resource.rc")
+      if(EXISTS "${candidate_resource_file}")
+        set(resource_file "${candidate_resource_file}")
+        break()
+      endif()
+    endforeach()
+
+    if(resource_file)
+      set(target_resource_file
+        "${CMAKE_CURRENT_BINARY_DIR}/${name}_windows_version_resource.rc")
+      configure_file("${resource_file}" "${target_resource_file}" COPYONLY)
+      list(APPEND sources "${target_resource_file}")
+      source_group("Resource Files" "${target_resource_file}")
+      set(${RESOURCE_VAR} "${target_resource_file}" PARENT_SCOPE)
+    endif()
+  endif()
+  set(${OUT_VAR} ${sources} PARENT_SCOPE)
+endfunction()
+
+function(set_compiler_rt_windows_version_resource_properties name resource_file)
+  if(DEFINED LLVM_VERSION_MAJOR)
+    set(version_major ${LLVM_VERSION_MAJOR})
+  else()
+    set(version_major 0)
+  endif()
+  if(DEFINED LLVM_VERSION_MINOR)
+    set(version_minor ${LLVM_VERSION_MINOR})
+  else()
+    set(version_minor 0)
+  endif()
+  if(DEFINED LLVM_VERSION_PATCH)
+    set(version_patchlevel ${LLVM_VERSION_PATCH})
+  else()
+    set(version_patchlevel 0)
+  endif()
+
+  if(DEFINED PACKAGE_VERSION AND NOT "${PACKAGE_VERSION}" STREQUAL "")
+    set(version_string "${PACKAGE_VERSION}")
+  else()
+    set(version_string
+      "${version_major}.${version_minor}.${version_patchlevel}${LLVM_VERSION_SUFFIX}")
+  endif()
+
+  set_windows_version_resource_properties(${name} ${resource_file}
+    VERSION_MAJOR ${version_major}
+    VERSION_MINOR ${version_minor}
+    VERSION_PATCHLEVEL ${version_patchlevel}
+    VERSION_STRING "${version_string}"
+    PRODUCT_NAME "compiler-rt")
+endfunction()
+
 
 # Tries to add an "object library" target for a given list of OSs and/or
 # architectures with name "<name>.<arch>" for non-Darwin platforms if
@@ -362,7 +422,17 @@ function(add_compiler_rt_runtime name type)
         DESTINATION ${install_dir_${libname}}
         ${COMPONENT_OPTION})
     else()
+      unset(windows_resource_file)
+      if(type STREQUAL "SHARED")
+        add_compiler_rt_windows_version_resource_file(
+          sources_${libname} windows_resource_file ${libname}
+          ${sources_${libname}})
+      endif()
       add_library(${libname} ${type} ${sources_${libname}})
+      if(windows_resource_file)
+        set_compiler_rt_windows_version_resource_properties(${libname}
+          ${windows_resource_file})
+      endif()
       set_target_compile_flags(${libname} ${extra_cflags_${libname}})
       set_target_link_flags(${libname} ${extra_link_flags_${libname}})
       set_property(TARGET ${libname} APPEND PROPERTY

--- a/compiler-rt/resources/windows_version_resource.rc
+++ b/compiler-rt/resources/windows_version_resource.rc
@@ -1,0 +1,89 @@
+// Microsoft Visual C++ resource script for embedding version information.
+// The format is described at:
+//   http://msdn.microsoft.com/en-gb/library/windows/desktop/aa380599(v=vs.85).aspx
+// The VERSIONINFO resource is described at:
+//   https://msdn.microsoft.com/en-gb/library/windows/desktop/aa381058(v=vs.85).aspx
+
+
+// Default values for required fields.
+
+#ifndef RC_VERSION_FIELD_1
+#define RC_VERSION_FIELD_1 0
+#endif
+
+#ifndef RC_VERSION_FIELD_2
+#define RC_VERSION_FIELD_2 0
+#endif
+
+#ifndef RC_VERSION_FIELD_3
+#define RC_VERSION_FIELD_3 0
+#endif
+
+#ifndef RC_VERSION_FIELD_4
+#define RC_VERSION_FIELD_4 0
+#endif
+
+#ifndef RC_COMPANY_NAME
+#define RC_COMPANY_NAME ""
+#endif
+
+#ifndef RC_FILE_DESCRIPTION
+#define RC_FILE_DESCRIPTION ""
+#endif
+
+#ifndef RC_FILE_VERSION
+#define RC_FILE_VERSION ""
+#endif
+
+#ifndef RC_INTERNAL_NAME
+#define RC_INTERNAL_NAME ""
+#endif
+
+#ifndef RC_ORIGINAL_FILENAME
+#define RC_ORIGINAL_FILENAME ""
+#endif
+
+#ifndef RC_PRODUCT_NAME
+#define RC_PRODUCT_NAME ""
+#endif
+
+#ifndef RC_PRODUCT_VERSION
+#define RC_PRODUCT_VERSION ""
+#endif
+
+
+1 VERSIONINFO
+FILEVERSION RC_VERSION_FIELD_1,RC_VERSION_FIELD_2,RC_VERSION_FIELD_3,RC_VERSION_FIELD_4
+BEGIN
+  BLOCK "StringFileInfo"
+  BEGIN
+    BLOCK "040904B0"
+    BEGIN
+      // Required strings
+      VALUE "CompanyName", RC_COMPANY_NAME
+      VALUE "FileDescription", RC_FILE_DESCRIPTION
+      VALUE "FileVersion", RC_FILE_VERSION
+      VALUE "InternalName", RC_INTERNAL_NAME
+      VALUE "OriginalFilename", RC_ORIGINAL_FILENAME
+      VALUE "ProductName", RC_PRODUCT_NAME
+      VALUE "ProductVersion", RC_PRODUCT_VERSION
+
+      // Optional strings
+#ifdef RC_COMMENTS
+        VALUE "Comments", RC_COMMENTS
+#endif
+
+#ifdef RC_COPYRIGHT
+        VALUE "LegalCopyright", RC_COPYRIGHT
+#endif
+    END
+  END
+
+  BLOCK "VarFileInfo"
+  BEGIN
+    // The translation must correspond to the above BLOCK inside StringFileInfo
+    // langID     0x0409  U.S. English
+    // charsetID  0x04B0  Unicode
+    VALUE "Translation", 0x0409, 0x04B0
+  END
+END


### PR DESCRIPTION
Windows runtime DLLs built by compiler-rt currently do not include
VERSIONINFO metadata. This leaves fields such as FileVersion,
ProductName, and ProductVersion empty in Windows file properties.

LLVM and Clang already use windows_version_resource.rc to add this
metadata to Windows executables and shared libraries. compiler-rt uses a
separate CMake helper for runtime libraries, so its DLLs do not inherit
that support.

Add compiler-rt support for attaching the shared LLVM Windows version
resource to MSVC shared runtime targets. The resource file is copied to
a target-specific file before being added as a source, so each DLL can
use its own source properties.

Use LLVMVersion.cmake to fill in the version fields. This gives runtime
DLLs such as clang_rt.asan_dynamic-x86_64.dll FileVersion and
ProductVersion values matching the LLVM version.

This only applies to shared runtime targets. Static and object runtime
libraries are unchanged.
