### PR TITLE
[ELF] Don't relax PLT32 for branches from small into large code on x86-64

### DIFF
--- a/lld/ELF/Arch/X86_64.cpp
+++ b/lld/ELF/Arch/X86_64.cpp
@@ -711,6 +711,17 @@ void X86_64::scanSectionImpl(InputSectionBase &sec, Relocs<RelTy> rels,
 
       // PLT-generating relocation:
     case R_X86_64_PLT32:
+      // Don't relax a branch from small code into large code: the callee may
+      // be more than 2GB away.
+      if (!sym.isPreemptible && !sym.isGnuIFunc() &&
+          !(sec.flags & SHF_X86_64_LARGE)) {
+        auto *d = dyn_cast<Defined>(&sym);
+        if (d && d->section && (d->section->flags & SHF_X86_64_LARGE)) {
+          sym.setFlags(NEEDS_PLT);
+          sec.addReloc({R_PLT_PC, type, offset, addend, &sym});
+          continue;
+        }
+      }
       rs.processR_PLT_PC(type, offset, addend, sym);
       continue;
 

--- a/lld/ELF/RelocScan.h
+++ b/lld/ELF/RelocScan.h
@@ -45,16 +45,6 @@ template <RelExpr... Exprs> bool oneof(RelExpr expr) {
   return (uint64_t(1) << expr) & buildMask(Exprs...);
 }
 
-// Don't relax a branch from small code into large code: the callee may be more
-// than 2GB away.
-inline bool keepPltForRange(Ctx &ctx, const InputSectionBase *sec,
-                            const Symbol &sym) {
-  if (ctx.arg.emachine != EM_X86_64 || sec->flags & SHF_X86_64_LARGE)
-    return false;
-  auto *d = dyn_cast<Defined>(&sym);
-  return d && d->section && (d->section->flags & SHF_X86_64_LARGE);
-}
-
 // This class encapsulates states needed to scan relocations for one
 // InputSectionBase.
 class RelocScan {
@@ -103,7 +93,7 @@ public:
       process(R_PLT_PC, type, offset, sym, addend);
       return;
     }
-    if (sym.isPreemptible || keepPltForRange(ctx, sec, sym)) {
+    if (sym.isPreemptible) {
       sym.setFlags(NEEDS_PLT);
       sec->addReloc({R_PLT_PC, type, offset, addend, &sym});
     } else if (!(isAbsolute(sym) && ctx.arg.isPic)) {

--- a/lld/ELF/RelocScan.h
+++ b/lld/ELF/RelocScan.h
@@ -45,6 +45,16 @@ template <RelExpr... Exprs> bool oneof(RelExpr expr) {
   return (uint64_t(1) << expr) & buildMask(Exprs...);
 }
 
+// Don't relax a branch from small code into large code: the callee may be more
+// than 2GB away.
+inline bool keepPltForRange(Ctx &ctx, const InputSectionBase *sec,
+                            const Symbol &sym) {
+  if (ctx.arg.emachine != EM_X86_64 || sec->flags & SHF_X86_64_LARGE)
+    return false;
+  auto *d = dyn_cast<Defined>(&sym);
+  return d && d->section && (d->section->flags & SHF_X86_64_LARGE);
+}
+
 // This class encapsulates states needed to scan relocations for one
 // InputSectionBase.
 class RelocScan {
@@ -93,7 +103,7 @@ public:
       process(R_PLT_PC, type, offset, sym, addend);
       return;
     }
-    if (sym.isPreemptible) {
+    if (sym.isPreemptible || keepPltForRange(ctx, sec, sym)) {
       sym.setFlags(NEEDS_PLT);
       sec->addReloc({R_PLT_PC, type, offset, addend, &sym});
     } else if (!(isAbsolute(sym) && ctx.arg.isPic)) {

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -758,11 +758,10 @@ static void addPltEntry(Ctx &ctx, PltSection &plt, GotPltSection &gotPlt,
   }
   gotPlt.addEntry(sym);
   uint64_t off = sym.getGotPltOffset(ctx);
-  // A non-preemptible symbol has no dynsym entry, so a symbol-indexed pltRel
-  // would name STN_UNDEF. Resolve the slot at link time instead.
-  if (!isPreemptible && type == ctx.target->pltRel) {
-    if (ctx.arg.isPic)
-      addRelativeReloc(ctx, gotPlt, off, sym, 0, expr, ctx.target->symbolicRel);
+  // Non-PIC needs no runtime fixup; the slot is a link-time constant.
+  if (!isPreemptible && type == ctx.target->relativeRel &&
+      (!ctx.arg.isPic || isAbsolute(sym))) {
+    gotPlt.addReloc({R_ABS, ctx.target->symbolicRel, off, 0, &sym});
     return;
   }
   rel.addReloc({type, &gotPlt, off, isPreemptible, sym, 0, expr});
@@ -1313,9 +1312,18 @@ void elf::postScanRelocations(Ctx &ctx) {
       else
         addGotEntry(ctx, sym);
     }
-    if (flags & NEEDS_PLT)
-      addPltEntry(ctx, *ctx.in.plt, *ctx.in.gotPlt, *ctx.in.relaPlt,
-                  ctx.target->pltRel, sym);
+    if (flags & NEEDS_PLT) {
+      if (sym.isPreemptible) {
+        addPltEntry(ctx, *ctx.in.plt, *ctx.in.gotPlt, *ctx.in.relaPlt,
+                    ctx.target->pltRel, sym);
+      } else {
+        assert(ctx.target->usesGotPlt &&
+               "IPLT route needs a GOT.PLT slot to resolve");
+        sym.isInIplt = true;
+        addPltEntry(ctx, *ctx.in.iplt, *ctx.in.igotPlt, *ctx.in.relaDyn,
+                    ctx.target->relativeRel, sym);
+      }
+    }
     if (flags & NEEDS_COPY) {
       if (sym.isObject()) {
         invokeELFT(addCopyRelSymbol, ctx, cast<SharedSymbol>(sym));

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -757,8 +757,15 @@ static void addPltEntry(Ctx &ctx, PltSection &plt, GotPltSection &gotPlt,
     return;
   }
   gotPlt.addEntry(sym);
-  rel.addReloc(
-      {type, &gotPlt, sym.getGotPltOffset(ctx), isPreemptible, sym, 0, expr});
+  uint64_t off = sym.getGotPltOffset(ctx);
+  // A non-preemptible symbol has no dynsym entry, so a symbol-indexed pltRel
+  // would name STN_UNDEF. Resolve the slot at link time instead.
+  if (!isPreemptible && type == ctx.target->pltRel) {
+    if (ctx.arg.isPic)
+      addRelativeReloc(ctx, gotPlt, off, sym, 0, expr, ctx.target->symbolicRel);
+    return;
+  }
+  rel.addReloc({type, &gotPlt, off, isPreemptible, sym, 0, expr});
 }
 
 void elf::addGotEntry(Ctx &ctx, Symbol &sym) {

--- a/lld/ELF/SyntheticSections.cpp
+++ b/lld/ELF/SyntheticSections.cpp
@@ -1045,12 +1045,7 @@ void GotPltSection::writeTo(uint8_t *buf) {
   ctx.target->writeGotPltHeader(buf);
   buf += ctx.target->gotPltHeaderEntriesNum * ctx.target->gotEntrySize;
   for (const Symbol *b : entries) {
-    // A non-preemptible symbol is never lazily bound, so the slot holds the
-    // target rather than the lazy stub.
-    if (b->isPreemptible)
-      ctx.target->writeGotPlt(buf, *b);
-    else
-      writeUint(ctx, buf, b->getVA(ctx));
+    ctx.target->writeGotPlt(buf, *b);
     buf += ctx.target->gotEntrySize;
   }
 }
@@ -1091,6 +1086,7 @@ size_t IgotPltSection::getSize() const {
 }
 
 void IgotPltSection::writeTo(uint8_t *buf) {
+  ctx.target->relocateAlloc(*this, buf);
   for (const Symbol *b : entries) {
     ctx.target->writeIgotPlt(buf, *b);
     buf += ctx.target->gotEntrySize;

--- a/lld/ELF/SyntheticSections.cpp
+++ b/lld/ELF/SyntheticSections.cpp
@@ -1045,7 +1045,12 @@ void GotPltSection::writeTo(uint8_t *buf) {
   ctx.target->writeGotPltHeader(buf);
   buf += ctx.target->gotPltHeaderEntriesNum * ctx.target->gotEntrySize;
   for (const Symbol *b : entries) {
-    ctx.target->writeGotPlt(buf, *b);
+    // A non-preemptible symbol is never lazily bound, so the slot holds the
+    // target rather than the lazy stub.
+    if (b->isPreemptible)
+      ctx.target->writeGotPlt(buf, *b);
+    else
+      writeUint(ctx, buf, b->getVA(ctx));
     buf += ctx.target->gotEntrySize;
   }
 }

--- a/lld/test/ELF/x86-64-plt-large.s
+++ b/lld/test/ELF/x86-64-plt-large.s
@@ -1,37 +1,33 @@
 # REQUIRES: x86
-## A branch from small code into a SHF_X86_64_LARGE section keeps its PLT entry,
+## A branch from small code into a SHF_X86_64_LARGE section keeps an indirection,
 ## because the callee may be more than 2GB away.
 
-# RUN: split-file %s %t
-# RUN: llvm-mc -filetype=obj -triple=x86_64 %t/a.s -o %t/a.o
+# RUN: split-file %s %t && cd %t
+# RUN: llvm-mc -filetype=obj -triple=x86_64 a.s -o a.o
 
-# RUN: ld.lld %t/a.o -T %t/lds -o %t/a
-# RUN: llvm-objdump -d --no-show-raw-insn %t/a | FileCheck %s --check-prefix=DISASM
-# RUN: llvm-readelf -x .got.plt %t/a | FileCheck %s --check-prefix=GOTPLT
-# RUN: llvm-readelf -r %t/a | FileCheck %s --check-prefix=NOREL
+# RUN: ld.lld a.o -T lds -o a
+# RUN: llvm-objdump -d --no-show-raw-insn a | FileCheck %s --check-prefix=DISASM
+# RUN: llvm-readelf -x .got.plt a | FileCheck %s --check-prefix=GOTPLT
+# RUN: llvm-readelf -r a | FileCheck %s --check-prefix=NOREL
 
-# RUN: ld.lld -pie %t/a.o -T %t/lds -o %t/a.pie
-# RUN: llvm-readelf -r %t/a.pie | FileCheck %s --check-prefix=PIE
+# RUN: ld.lld -pie a.o -T lds -o a.pie
+# RUN: llvm-readelf -rW a.pie | FileCheck %s --check-prefix=PIE
 
-## The call to large targets a PLT entry rather than large itself, while the
+## The call to large targets an IPLT entry rather than large itself, while the
 ## call to small is relaxed to a direct branch as usual.
 # DISASM:      <_start>:
-# DISASM-NEXT:   callq 0x210010{{$}}
+# DISASM-NEXT:   callq 0x210000{{$}}
 # DISASM-NEXT:   callq 0x200000 <small>
 
-## The slot holds large (0x300000) rather than a lazy binding stub.
+## The slot holds large's address (0x300000).
 # GOTPLT:      Hex dump of section '.got.plt':
-# GOTPLT-NEXT: 0x00220000 00000000 00000000 00000000 00000000
-# GOTPLT-NEXT: 0x00220010 00000000 00000000 00003000 00000000
+# GOTPLT-NEXT: 0x00220000 00003000 00000000
 
 ## Nothing is left for a dynamic linker to resolve.
 # NOREL: There are no relocations in this file.
 
-## Under PIC the slot only needs the load base added, so the same slot gets a
-## relative relocation whose addend is large, rather than a symbol lookup.
-# PIE-NOT: R_X86_64_JUMP_SLOT
-# PIE:     0000000000220018 0000000000000008 R_X86_64_RELATIVE 300000
-# PIE-NOT: R_X86_64_JUMP_SLOT
+## Under PIC the slot only needs the load base added.
+# PIE: 0000000000220000 0000000000000008 R_X86_64_RELATIVE 300000
 
 #--- a.s
 .section .ltext,"axl",@progbits
@@ -55,8 +51,8 @@ _start:
 
 #--- lds
 SECTIONS {
-  .text    0x200000 : { *(.text) }
-  .plt     0x210000 : { *(.plt) }
-  .got.plt 0x220000 : { *(.got.plt) }
-  .ltext   0x300000 : { *(.ltext) }
+  .text     0x200000 : { *(.text) }
+  .iplt     0x210000 : { *(.iplt) }
+  .got.plt  0x220000 : { *(.got.plt) }
+  .ltext    0x300000 : { *(.ltext) }
 }

--- a/lld/test/ELF/x86-64-plt-large.s
+++ b/lld/test/ELF/x86-64-plt-large.s
@@ -1,0 +1,62 @@
+# REQUIRES: x86
+## A branch from small code into a SHF_X86_64_LARGE section keeps its PLT entry,
+## because the callee may be more than 2GB away.
+
+# RUN: split-file %s %t
+# RUN: llvm-mc -filetype=obj -triple=x86_64 %t/a.s -o %t/a.o
+
+# RUN: ld.lld %t/a.o -T %t/lds -o %t/a
+# RUN: llvm-objdump -d --no-show-raw-insn %t/a | FileCheck %s --check-prefix=DISASM
+# RUN: llvm-readelf -x .got.plt %t/a | FileCheck %s --check-prefix=GOTPLT
+# RUN: llvm-readelf -r %t/a | FileCheck %s --check-prefix=NOREL
+
+# RUN: ld.lld -pie %t/a.o -T %t/lds -o %t/a.pie
+# RUN: llvm-readelf -r %t/a.pie | FileCheck %s --check-prefix=PIE
+
+## The call to large targets a PLT entry rather than large itself, while the
+## call to small is relaxed to a direct branch as usual.
+# DISASM:      <_start>:
+# DISASM-NEXT:   callq 0x210010{{$}}
+# DISASM-NEXT:   callq 0x200000 <small>
+
+## The slot holds large (0x300000) rather than a lazy binding stub.
+# GOTPLT:      Hex dump of section '.got.plt':
+# GOTPLT-NEXT: 0x00220000 00000000 00000000 00000000 00000000
+# GOTPLT-NEXT: 0x00220010 00000000 00000000 00003000 00000000
+
+## Nothing is left for a dynamic linker to resolve.
+# NOREL: There are no relocations in this file.
+
+## Under PIC the slot only needs the load base added, so the same slot gets a
+## relative relocation whose addend is large, rather than a symbol lookup.
+# PIE-NOT: R_X86_64_JUMP_SLOT
+# PIE:     0000000000220018 0000000000000008 R_X86_64_RELATIVE 300000
+# PIE-NOT: R_X86_64_JUMP_SLOT
+
+#--- a.s
+.section .ltext,"axl",@progbits
+.globl large
+.type large, @function
+large:
+  retq
+
+.text
+.globl small
+.type small, @function
+small:
+  retq
+
+.globl _start
+.type _start, @function
+_start:
+  call large
+  call small
+  retq
+
+#--- lds
+SECTIONS {
+  .text    0x200000 : { *(.text) }
+  .plt     0x210000 : { *(.plt) }
+  .got.plt 0x220000 : { *(.got.plt) }
+  .ltext   0x300000 : { *(.ltext) }
+}


### PR DESCRIPTION
With mixed code models, a call from small code into `.ltext` assembles to PLT32. lld relaxes PLT32 to PC32 for every non-preemptible symbol, turning it into a direct branch. Large sections are placed at the edges of the image, so the two can be more than 2GB apart and the branch overflows.

Don't relax PLT32 to PC32 when the callee is in a `SHF_X86_64_LARGE` section. Ifuncs are the precedent for routing a non-preemptible symbol through the PLT.