### PR TITLE
[GlobalISel] Use setInstrAndDebugLoc in artifact combines (NFCI)

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/LegalizationArtifactCombiner.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/LegalizationArtifactCombiner.h
@@ -398,7 +398,7 @@ public:
 
     if (MachineInstr *DefMI = getOpcodeDef(TargetOpcode::G_IMPLICIT_DEF,
                                            MI.getOperand(1).getReg(), MRI)) {
-      Builder.setInstr(MI);
+      Builder.setInstrAndDebugLoc(MI);
       Register DstReg = MI.getOperand(0).getReg();
       LLT DstTy = MRI.getType(DstReg);
 
@@ -474,7 +474,7 @@ public:
                     .Action == LegalizeActions::MoreElements)
           return false;
 
-        Builder.setInstr(MI);
+        Builder.setInstrAndDebugLoc(MI);
         auto NewUnmerge = Builder.buildUnmerge(UnmergeTy, CastSrcReg);
 
         for (unsigned I = 0; I != NumDefs; ++I) {
@@ -515,7 +515,7 @@ public:
         }
 
         // Build new unmerge
-        Builder.setInstr(MI);
+        Builder.setInstrAndDebugLoc(MI);
         Builder.buildUnmerge(DstRegs, CastSrcReg);
         UpdatedDefs.append(DstRegs.begin(), DstRegs.begin() + NewNumDefs);
         markInstAndDefDead(MI, CastMI, DeadInsts);
@@ -1184,7 +1184,7 @@ public:
       if (NumDefs % NumMergeRegs != 0)
         return false;
 
-      Builder.setInstr(MI);
+      Builder.setInstrAndDebugLoc(MI);
       // Transform to UNMERGEs, for example
       //   %1 = G_MERGE_VALUES %4, %5
       //   %9, %10, %11, %12 = G_UNMERGE_VALUES %1
@@ -1234,7 +1234,7 @@ public:
       if (ConvertOp != 0 || NumMergeRegs % NumDefs != 0)
         return false;
 
-      Builder.setInstr(MI);
+      Builder.setInstrAndDebugLoc(MI);
       // Transform to MERGEs
       //   %6 = G_MERGE_VALUES %17, %18, %19, %20
       //   %7, %8 = G_UNMERGE_VALUES %6
@@ -1267,7 +1267,7 @@ public:
       }
 
       if (ConvertOp) {
-        Builder.setInstr(MI);
+        Builder.setInstrAndDebugLoc(MI);
 
         for (unsigned Idx = 0; Idx < NumDefs; ++Idx) {
           Register DefReg = MI.getOperand(Idx).getReg();
@@ -1287,7 +1287,7 @@ public:
              "Bitcast and the other kinds of conversions should "
              "have happened earlier");
 
-      Builder.setInstr(MI);
+      Builder.setInstrAndDebugLoc(MI);
       for (unsigned Idx = 0; Idx < NumDefs; ++Idx) {
         Register DstReg = MI.getOperand(Idx).getReg();
         Register SrcReg = MergeI->getOperand(Idx + 1).getReg();
@@ -1348,7 +1348,7 @@ public:
       return false;
 
     // TODO: We could modify MI in place in most cases.
-    Builder.setInstr(MI);
+    Builder.setInstrAndDebugLoc(MI);
     Builder.buildExtract(DstReg, MergeI->getOperand(MergeSrcIdx + 1).getReg(),
                          Offset - MergeSrcIdx * MergeSrcSize);
     UpdatedDefs.push_back(DstReg);


### PR DESCRIPTION
This is an opportunistic follow-up to https://github.com/llvm/llvm-project/pull/216411 none of the existing tests are currently affected by this.

The remaining setInstr() call sites in LegalizationArtifactCombiner only move the insert point, leaving whatever DebugLoc the previous combine left in the shared builder. Each replaces MI in place, so MI's location is the one to build with.

Assisted-by: claude