### PR TITLE
[Mistakenly Marked Merged] Add blocking to LaunchKernel and Memcpy

### DIFF
--- a/clang/lib/CodeGen/CGCUDANV.cpp
+++ b/clang/lib/CodeGen/CGCUDANV.cpp
@@ -442,7 +442,9 @@ void CGNVCUDARuntime::emitDeviceStubBodyNew(CodeGenFunction &CGF,
   std::string KernelLaunchAPI = "LaunchKernel";
   if (CGF.getLangOpts().GPUDefaultStream ==
       LangOptions::GPUDefaultStreamKind::PerThread) {
-    if (CGF.getLangOpts().HIP)
+    if (CGF.getLangOpts().OffloadViaLLVM)
+      KernelLaunchAPI = KernelLaunchAPI + "";
+    else if (CGF.getLangOpts().HIP)
       KernelLaunchAPI = KernelLaunchAPI + "_spt";
     else if (CGF.getLangOpts().CUDA)
       KernelLaunchAPI = KernelLaunchAPI + "_ptsz";

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8396,6 +8396,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
 
   if (IsHIP) {
     CmdArgs.push_back("-fcuda-allow-variadic-functions");
+    /// TODO: Why is this not forwarded when IsCUDA?
     Args.AddLastArg(CmdArgs, options::OPT_fgpu_default_stream_EQ);
   }
 

--- a/offload/languages/kernel/CMakeLists.txt
+++ b/offload/languages/kernel/CMakeLists.txt
@@ -64,6 +64,7 @@ add_llvm_library(
   src/LanguageLaunch.cpp
   src/LanguageRegistration.cpp
   src/State.cpp
+  src/Stream.cpp
   )
 
 if(LLVM_LINK_LLVM_DYLIB)

--- a/offload/languages/kernel/include/LanguageUtils.h
+++ b/offload/languages/kernel/include/LanguageUtils.h
@@ -13,6 +13,7 @@
 #include "OffloadAPI.h"
 #include "State.h"
 #include "Stream.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 
 using RuntimeState = llvm::offload::StateTy;
@@ -63,24 +64,49 @@ static inline llvm::offload::StreamTy *getInternalStream(Stream_t Stream) {
   return reinterpret_cast<StreamTy *>(Stream);
 }
 
+static inline ol_result_t
+syncAndDestroyEvents(llvm::SmallVectorImpl<ol_event_handle_t> &Events) {
+  ol_result_t FirstError = OL_SUCCESS;
+  for (ol_event_handle_t Event : Events) {
+    if (!Event)
+      continue;
+
+    ol_result_t SyncResult = olSyncEvent(Event);
+    if (FirstError == OL_SUCCESS && SyncResult != OL_SUCCESS)
+      FirstError = SyncResult;
+
+    ol_result_t DestroyResult = olDestroyEvent(Event);
+    if (FirstError == OL_SUCCESS && DestroyResult != OL_SUCCESS)
+      FirstError = DestroyResult;
+  }
+  Events.clear();
+  return FirstError;
+}
+
 /// Wait for blocking streams before executing if we are legacy default stream.
 static inline ol_result_t waitOnBlockingStreams() {
   ol_device_handle_t Device = ThreadState::getDefaultDevice();
-  if (!RuntimeState::hasLegacyDefaultStream(Device) ||
-      RuntimeState::getBlockingStreams(Device).empty())
+  llvm::SmallPtrSet<StreamTy *, 8> BlockingStreams =
+      RuntimeState::getBlockingStreams(Device);
+  if (!RuntimeState::hasLegacyDefaultStream(Device) || BlockingStreams.empty())
     return OL_SUCCESS;
+
   StreamTy *DefaultStream = ThreadState::getDefaultStream();
   llvm::SmallVector<ol_event_handle_t, 8> Events;
-  for (StreamTy *BlockingStream : RuntimeState::getBlockingStreams(Device)) {
+  for (StreamTy *BlockingStream : BlockingStreams) {
     ol_event_handle_t Event = nullptr;
     ol_result_t Result =
         olCreateEvent(BlockingStream->Queue, OL_EVENT_FLAGS_NONE, &Event);
-    if (Result != OL_SUCCESS)
+    if (Result != OL_SUCCESS) {
+      if (Event)
+        Events.push_back(Event);
+      syncAndDestroyEvents(Events);
       return Result;
+    }
     Events.push_back(Event);
   }
 
-  return olWaitEvents(DefaultStream->Queue, Events.data(), Events.size());
+  return DefaultStream->waitOnAndTrackDependencyEvents(Events);
 }
 
 /// Wait for the legacy default stream to complete before launching a kernel on
@@ -97,23 +123,15 @@ static inline ol_result_t waitOnLegacyDefaultStream(StreamTy *SourceStream,
   ol_event_handle_t Event = nullptr;
   ol_result_t Result =
       olCreateEvent(DefaultStream->Queue, OL_EVENT_FLAGS_NONE, &Event);
-  if (Result != OL_SUCCESS)
+  if (Result != OL_SUCCESS) {
+    if (Event) {
+      llvm::SmallVector<ol_event_handle_t, 1> Events = {Event};
+      syncAndDestroyEvents(Events);
+    }
     return Result;
-  return olWaitEvents(SourceStream->Queue, &Event, 1);
-}
-
-/// Convert a Stream_t to an ol_queue_handle_t.
-static inline Error_t getQueueFromStream(Stream_t Stream,
-                                         ol_queue_handle_t *Queue) {
-  if (!Stream)
-    return ErrorInvalidValue;
-
-  llvm::offload::StreamTy *InternalStream = getInternalStream(Stream);
-  if (!llvm::offload::StateTy::isStreamRegistered(InternalStream))
-    return ErrorInvalidResourceHandle;
-
-  *Queue = InternalStream->Queue;
-  return Success;
+  }
+  return SourceStream->waitOnAndTrackDependencyEvents(
+      llvm::ArrayRef<ol_event_handle_t>(&Event, 1));
 }
 
 #endif // LLVM_OFFLOAD_LANGUAGES_KERNEL_INCLUDE_LANGUAGE_UTILS_H

--- a/offload/languages/kernel/include/LanguageUtils.h
+++ b/offload/languages/kernel/include/LanguageUtils.h
@@ -13,6 +13,11 @@
 #include "OffloadAPI.h"
 #include "State.h"
 #include "Stream.h"
+#include "llvm/ADT/SmallVector.h"
+
+using RuntimeState = llvm::offload::StateTy;
+using ThreadState = llvm::offload::ThreadStateTy;
+using StreamTy = llvm::offload::StreamTy;
 
 /// Convert an ol_result_t to the active language's Error_t.
 static inline Error_t convertResult(ol_result_t Result) {
@@ -40,8 +45,7 @@ static inline Error_t convertResult(ol_result_t Result) {
 /// Set the last error for the current thread and return it.
 static inline Error_t setLastError(Error_t Error) {
   // TODO: find a more efficient way to set last error
-  return static_cast<Error_t>(
-      llvm::offload::ThreadStateTy::setLastError(Error));
+  return static_cast<Error_t>(ThreadState::setLastError(Error));
 }
 
 /// Convert an ol_result_t to the active language's Error_t and set it as the
@@ -51,12 +55,51 @@ static inline Error_t convertAndSetLastError(ol_result_t Result) {
 }
 
 /// Convert between the language-facing opaque stream and the internal stream.
-static inline Stream_t makeLanguageStream(llvm::offload::StreamTy *Stream) {
+static inline Stream_t makeLanguageStream(StreamTy *Stream) {
   return reinterpret_cast<Stream_t>(Stream);
 }
 
 static inline llvm::offload::StreamTy *getInternalStream(Stream_t Stream) {
-  return reinterpret_cast<llvm::offload::StreamTy *>(Stream);
+  return reinterpret_cast<StreamTy *>(Stream);
+}
+
+/// Wait for blocking streams before executing if we are legacy default stream.
+static inline ol_result_t waitOnBlockingStreams() {
+  ol_device_handle_t Device = ThreadState::getDefaultDevice();
+  if (!RuntimeState::hasLegacyDefaultStream(Device) ||
+      RuntimeState::getBlockingStreams(Device).empty())
+    return OL_SUCCESS;
+  StreamTy *DefaultStream = ThreadState::getDefaultStream();
+  llvm::SmallVector<ol_event_handle_t, 8> Events;
+  for (StreamTy *BlockingStream : RuntimeState::getBlockingStreams(Device)) {
+    ol_event_handle_t Event = nullptr;
+    ol_result_t Result =
+        olCreateEvent(BlockingStream->Queue, OL_EVENT_FLAGS_NONE, &Event);
+    if (Result != OL_SUCCESS)
+      return Result;
+    Events.push_back(Event);
+  }
+
+  return olWaitEvents(DefaultStream->Queue, Events.data(), Events.size());
+}
+
+/// Wait for the legacy default stream to complete before launching a kernel on
+/// a blocking stream.
+static inline ol_result_t waitOnLegacyDefaultStream(StreamTy *SourceStream,
+                                                    ol_device_handle_t Device) {
+  if (!RuntimeState::hasLegacyDefaultStream(Device))
+    return OL_SUCCESS;
+
+  StreamTy *DefaultStream = ThreadState::getDefaultStream();
+  assert(DefaultStream->Kind == llvm::offload::QueueKind::LegacyDefault &&
+         "Default stream is not a legacy default stream");
+
+  ol_event_handle_t Event = nullptr;
+  ol_result_t Result =
+      olCreateEvent(DefaultStream->Queue, OL_EVENT_FLAGS_NONE, &Event);
+  if (Result != OL_SUCCESS)
+    return Result;
+  return olWaitEvents(SourceStream->Queue, &Event, 1);
 }
 
 /// Convert a Stream_t to an ol_queue_handle_t.

--- a/offload/languages/kernel/include/State.h
+++ b/offload/languages/kernel/include/State.h
@@ -148,7 +148,8 @@ struct StateTy {
   static llvm::SmallPtrSet<StreamTy *, 8>
   getBlockingStreams(ol_device_handle_t Device);
 
-  /// Return true if \p Device has an initialized (i.e. previously used) legacy default stream.
+  /// Return true if \p Device has an initialized (i.e. previously used) legacy
+  /// default stream.
   static bool hasLegacyDefaultStream(ol_device_handle_t Device);
 
   /// Create a stream for \p Device and register it with the process state.

--- a/offload/languages/kernel/include/State.h
+++ b/offload/languages/kernel/include/State.h
@@ -148,7 +148,7 @@ struct StateTy {
   static llvm::SmallPtrSet<StreamTy *, 8>
   getBlockingStreams(ol_device_handle_t Device);
 
-  /// Return true if \p Device has an existing legacy default stream.
+  /// Return true if \p Device has an initialized (i.e. previously used) legacy default stream.
   static bool hasLegacyDefaultStream(ol_device_handle_t Device);
 
   /// Create a stream for \p Device and register it with the process state.

--- a/offload/languages/kernel/include/Stream.h
+++ b/offload/languages/kernel/include/Stream.h
@@ -10,6 +10,10 @@
 #define LLVM_OFFLOAD_LANGUAGES_KERNEL_INCLUDE_STREAM_H
 
 #include "OffloadAPI.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
+#include <cstddef>
+#include <mutex>
 
 namespace llvm {
 namespace offload {
@@ -22,9 +26,24 @@ enum class QueueKind {
 };
 
 struct StreamTy {
+  StreamTy(ol_queue_handle_t Queue, ol_device_handle_t Device, QueueKind Kind)
+      : Queue(Queue), Device(Device), Kind(Kind) {}
+
+  ol_result_t
+  waitOnAndTrackDependencyEvents(llvm::ArrayRef<ol_event_handle_t> Events);
+  ol_result_t syncStream();
+
   ol_queue_handle_t Queue = nullptr;
   ol_device_handle_t Device = nullptr;
   QueueKind Kind = QueueKind::ExplicitBlocking;
+
+private:
+  ol_result_t reclaimDependencyEventsLocked();
+
+  static constexpr size_t MaxPendingDependencyEvents = 64;
+
+  std::mutex DependencyEventsLock;
+  llvm::SmallVector<ol_event_handle_t, 8> DependencyEvents;
 };
 
 } // namespace offload

--- a/offload/languages/kernel/src/LanguageLaunch.cpp
+++ b/offload/languages/kernel/src/LanguageLaunch.cpp
@@ -8,6 +8,7 @@
 
 #include "LanguageLaunch.h"
 #include "LanguageUtils.h"
+#include "OffloadAPI.h"
 #include "State.h"
 #include "Stream.h"
 #include <cstdio>
@@ -56,8 +57,21 @@ ol_result_t __llvmLaunchKernelImpl(const char *KernelID, dim3 GridDim,
   LaunchSizeArgs.GroupSize.z = BlockDim.z;
   LaunchSizeArgs.DynSharedMemory = DynamicSharedMem;
 
-  ol_queue_handle_t Queue = Stream ? reinterpret_cast<StreamTy *>(Stream)->Queue
-                                   : ThreadState::getDefaultQueue();
+  StreamTy *LaunchStream = Stream ? reinterpret_cast<StreamTy *>(Stream)
+                                  : ThreadState::getDefaultStream();
+  if (!LaunchStream || !RuntimeState::isStreamRegistered(LaunchStream) ||
+      LaunchStream->Device != Device)
+    return &InvalidConfigurationError;
+
+  if (LaunchStream->Kind == llvm::offload::QueueKind::LegacyDefault) {
+    ol_result_t Result = waitOnBlockingStreams();
+    if (Result != OL_SUCCESS)
+      return Result;
+  } else if (LaunchStream->Kind == llvm::offload::QueueKind::ExplicitBlocking) {
+    ol_result_t Result = waitOnLegacyDefaultStream(LaunchStream, Device);
+    if (Result != OL_SUCCESS)
+      return Result;
+  }
 
   struct OffloadKernelArgs {
     void **Args;
@@ -73,7 +87,7 @@ ol_result_t __llvmLaunchKernelImpl(const char *KernelID, dim3 GridDim,
     if (!OKA->Args[I] || OKA->ArgSizes[I] == 0)
       return &InvalidArgumentError;
 
-  return olLaunchKernel(Queue, Device, Kernel, &LaunchSizeArgs,
+  return olLaunchKernel(LaunchStream->Queue, Device, Kernel, &LaunchSizeArgs,
                         /*Properties=*/nullptr, OKA->NumArgs, OKA->Args,
                         OKA->ArgSizes);
 }

--- a/offload/languages/kernel/src/LanguageRuntime.cpp
+++ b/offload/languages/kernel/src/LanguageRuntime.cpp
@@ -23,6 +23,7 @@
 #include "Types.h"
 
 #include "OffloadAPI.h"
+#include "llvm/ADT/SmallVector.h"
 
 #include <cassert>
 #include <cstdio>
@@ -45,8 +46,13 @@ Error_t Free(void *DevPtr) {
 }
 
 Error_t Memcpy(void *Dst, const void *Src, size_t Size, MemcpyKind Kind) {
+  if (Kind != MemcpyHostToHost) {
+    ol_result_t Result = waitOnBlockingStreams();
+    if (Result != OL_SUCCESS)
+      return convertAndSetLastError(Result);
+  }
+  ol_device_handle_t Device = ThreadState::getDefaultDevice();
   ol_queue_handle_t Queue = ThreadState::getDefaultQueue();
-
   ol_result_t Result;
   switch (Kind) {
   case MemcpyHostToHost: {
@@ -55,21 +61,17 @@ Error_t Memcpy(void *Dst, const void *Src, size_t Size, MemcpyKind Kind) {
     break;
   }
   case MemcpyHostToDevice: {
-    ol_device_handle_t Device = ThreadState::getDefaultDevice();
     ol_device_handle_t Host = RuntimeState::getHostDevice();
     Result = olMemcpy(Queue, Dst, Device, const_cast<void *>(Src), Host, Size);
     break;
   }
   case MemcpyDeviceToHost: {
-    ol_device_handle_t Device = ThreadState::getDefaultDevice();
     ol_device_handle_t Host = RuntimeState::getHostDevice();
 
     Result = olMemcpy(Queue, Dst, Host, const_cast<void *>(Src), Device, Size);
     break;
   }
   case MemcpyDeviceToDevice: {
-    ol_device_handle_t Device = ThreadState::getDefaultDevice();
-
     Result =
         olMemcpy(Queue, Dst, Device, const_cast<void *>(Src), Device, Size);
     break;
@@ -79,6 +81,9 @@ Error_t Memcpy(void *Dst, const void *Src, size_t Size, MemcpyKind Kind) {
   };
 
   if (Result != OL_SUCCESS)
+    return convertAndSetLastError(Result);
+
+  if (!Queue)
     return convertAndSetLastError(Result);
 
   Result = olSyncQueue(Queue);

--- a/offload/languages/kernel/src/LanguageRuntime.cpp
+++ b/offload/languages/kernel/src/LanguageRuntime.cpp
@@ -52,7 +52,8 @@ Error_t Memcpy(void *Dst, const void *Src, size_t Size, MemcpyKind Kind) {
       return convertAndSetLastError(Result);
   }
   ol_device_handle_t Device = ThreadState::getDefaultDevice();
-  ol_queue_handle_t Queue = ThreadState::getDefaultQueue();
+  StreamTy *DefaultStream = ThreadState::getDefaultStream();
+  ol_queue_handle_t Queue = DefaultStream->Queue;
   ol_result_t Result;
   switch (Kind) {
   case MemcpyHostToHost: {
@@ -83,18 +84,16 @@ Error_t Memcpy(void *Dst, const void *Src, size_t Size, MemcpyKind Kind) {
   if (Result != OL_SUCCESS)
     return convertAndSetLastError(Result);
 
-  if (!Queue)
-    return convertAndSetLastError(Result);
-
-  Result = olSyncQueue(Queue);
+  Result = DefaultStream->syncStream();
   return convertAndSetLastError(Result);
 }
 
 Error_t DeviceSynchronize() {
   // TODO: This is not correct. We likely want to pipe this through to the
   // plugins.
-  ol_queue_handle_t Queue = ThreadState::getDefaultQueue();
-  ol_result_t Result = olSyncQueue(Queue);
+  StreamTy *DefaultStream = ThreadState::getDefaultStream();
+  ol_result_t Result =
+      DefaultStream ? DefaultStream->syncStream() : olSyncQueue(nullptr);
   return convertAndSetLastError(Result);
 }
 
@@ -189,11 +188,14 @@ Error_t StreamDestroy(Stream_t Stream) {
 }
 
 Error_t StreamSynchronize(Stream_t Stream) {
-  ol_queue_handle_t Queue;
-  Error_t Err = getQueueFromStream(Stream, &Queue);
-  if (Err != Success)
-    return setLastError(Err);
-  ol_result_t Result = olSyncQueue(Queue);
+  if (!Stream)
+    return setLastError(ErrorInvalidValue);
+
+  llvm::offload::StreamTy *InternalStream = getInternalStream(Stream);
+  if (!llvm::offload::StateTy::isStreamRegistered(InternalStream))
+    return setLastError(ErrorInvalidResourceHandle);
+
+  ol_result_t Result = InternalStream->syncStream();
   return convertAndSetLastError(Result);
 }
 

--- a/offload/languages/kernel/src/State.cpp
+++ b/offload/languages/kernel/src/State.cpp
@@ -99,7 +99,7 @@ static void destroyStreamHandle(StreamTy *&Stream) {
   if (!Stream)
     return;
 
-  olSyncQueue(Stream->Queue);
+  (void)Stream->syncStream();
   olDestroyQueue(Stream->Queue);
   delete Stream;
   Stream = nullptr;
@@ -344,8 +344,12 @@ ol_result_t StateTy::destroyStream(StreamTy *Stream) {
   if (!isStreamRegistered(Stream))
     return &InvalidStreamError;
 
+  ol_result_t Result = Stream->syncStream();
+  if (Result != OL_SUCCESS)
+    return Result;
+
   get().removeStream(Stream);
-  ol_result_t Result = olDestroyQueue(Stream->Queue);
+  Result = olDestroyQueue(Stream->Queue);
   delete Stream;
   return Result;
 }

--- a/offload/languages/kernel/src/Stream.cpp
+++ b/offload/languages/kernel/src/Stream.cpp
@@ -1,0 +1,85 @@
+//===-- Stream.cpp - Kernel language stream state -------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Stream.h"
+#include "OffloadAPI.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <mutex>
+#include <utility>
+
+using namespace llvm;
+using namespace offload;
+
+static ol_result_t syncAndDestroyEvents(ArrayRef<ol_event_handle_t> Events) {
+  ol_result_t FirstError = OL_SUCCESS;
+  for (ol_event_handle_t Event : Events) {
+    if (!Event)
+      continue;
+
+    ol_result_t SyncResult = olSyncEvent(Event);
+    if (FirstError == OL_SUCCESS && SyncResult != OL_SUCCESS)
+      FirstError = SyncResult;
+
+    ol_result_t DestroyResult = olDestroyEvent(Event);
+    if (FirstError == OL_SUCCESS && DestroyResult != OL_SUCCESS)
+      FirstError = DestroyResult;
+  }
+  return FirstError;
+}
+
+ol_result_t
+StreamTy::waitOnAndTrackDependencyEvents(ArrayRef<ol_event_handle_t> Events) {
+  if (Events.empty())
+    return OL_SUCCESS;
+
+  SmallVector<ol_event_handle_t, 8> MutableEvents(Events.begin(), Events.end());
+  std::lock_guard<std::mutex> LG(DependencyEventsLock);
+  ol_result_t WaitResult =
+      olWaitEvents(Queue, MutableEvents.data(), MutableEvents.size());
+  if (WaitResult != OL_SUCCESS) {
+    syncAndDestroyEvents(MutableEvents);
+    return WaitResult;
+  }
+
+  DependencyEvents.append(MutableEvents.begin(), MutableEvents.end());
+  ol_result_t ReclaimResult = OL_SUCCESS;
+  if (DependencyEvents.size() >= MaxPendingDependencyEvents) {
+    ReclaimResult = olSyncQueue(Queue);
+    if (ReclaimResult == OL_SUCCESS)
+      ReclaimResult = reclaimDependencyEventsLocked();
+  }
+  return ReclaimResult;
+}
+
+ol_result_t StreamTy::syncStream() {
+  std::lock_guard<std::mutex> LG(DependencyEventsLock);
+  ol_result_t Result = olSyncQueue(Queue);
+  if (Result != OL_SUCCESS)
+    return Result;
+  return reclaimDependencyEventsLocked();
+}
+
+ol_result_t StreamTy::reclaimDependencyEventsLocked() {
+  if (DependencyEvents.empty())
+    return OL_SUCCESS;
+
+  ol_result_t FirstError = OL_SUCCESS;
+  SmallVector<ol_event_handle_t, 8> RemainingEvents;
+  for (ol_event_handle_t Event : DependencyEvents) {
+    ol_result_t Result = olDestroyEvent(Event);
+    if (Result != OL_SUCCESS) {
+      if (FirstError == OL_SUCCESS)
+        FirstError = Result;
+      RemainingEvents.push_back(Event);
+    }
+  }
+  DependencyEvents = std::move(RemainingEvents);
+  return FirstError;
+}

--- a/offload/test/offloading/CUDA/blocking_stream_semantics.cu
+++ b/offload/test/offloading/CUDA/blocking_stream_semantics.cu
@@ -1,0 +1,131 @@
+// clang-format off
+// RUN: %clang++ %flags -foffload-via-llvm --offload-arch=native %s -o %t
+// RUN: %t | %fcheck-generic --check-prefix=LEGACY
+// RUN: %clang++ %flags -foffload-via-llvm --offload-arch=native %s -o %t -fopenmp
+// RUN: %t | %fcheck-generic --check-prefix=LEGACY
+// RUN: %clang++ %flags -foffload-via-llvm --offload-arch=native %s -o %t -fgpu-default-stream=per-thread
+// RUN: %t | %fcheck-generic --check-prefix=PERTHREAD
+// clang-format on
+
+// UNSUPPORTED: aarch64-unknown-linux-gnu
+// UNSUPPORTED: x86_64-unknown-linux-gnu
+// UNSUPPORTED: nvptx64-nvidia-cuda-LTO
+// UNSUPPORTED: amdgcn-amd-amdhsa-LTO
+// UNSUPPORTED: amdgpu-amd-amdhsa-LTO
+// UNSUPPORTED: intelgpu
+
+#include <stdio.h>
+
+__global__ void delayedSetValue(int *Out, int Value) {
+  volatile unsigned long long Delay = 0;
+  for (unsigned I = 0; I < 1000000; ++I)
+    Delay += I;
+  if (Delay)
+    *Out = Value;
+}
+
+__global__ void copyValue(int *In, int *Out) { *Out = *In; }
+
+__global__ void waitThenSetValue(int *Gate, int *Out, int Value) {
+  volatile int *VolatileGate = Gate;
+  for (unsigned I = 0; I < 100000000 && *VolatileGate == 0; ++I)
+    ;
+  *Out = Value;
+}
+
+__global__ void copyValueAndRelease(int *In, int *Out, int *Gate) {
+  *Out = *In;
+  volatile int *VolatileGate = Gate;
+  *VolatileGate = 1;
+}
+
+int main(int argc, char **argv) {
+  cudaStream_t BlockingStream = nullptr;
+  if (cudaStreamCreateWithFlags(&BlockingStream, cudaStreamDefault) !=
+      cudaSuccess)
+    return 1;
+  cudaStream_t NonBlockingStream = nullptr;
+  if (cudaStreamCreateWithFlags(&NonBlockingStream, cudaStreamNonBlocking) !=
+      cudaSuccess)
+    return 1;
+
+  int *In = nullptr;
+  int *Out = nullptr;
+  int *Gate = nullptr;
+  if (cudaMalloc(&In, sizeof(int)) != cudaSuccess)
+    return 1;
+  if (cudaMalloc(&Out, sizeof(int)) != cudaSuccess)
+    return 1;
+  if (cudaMalloc(&Gate, sizeof(int)) != cudaSuccess)
+    return 1;
+
+  int Initial = 0;
+  int Result = 0;
+  if (cudaMemcpy(In, &Initial, sizeof(int), cudaMemcpyHostToDevice) !=
+      cudaSuccess)
+    return 1;
+  if (cudaMemcpy(Out, &Initial, sizeof(int), cudaMemcpyHostToDevice) !=
+      cudaSuccess)
+    return 1;
+
+  delayedSetValue<<<1, 1, 0, BlockingStream>>>(In, 99);
+  copyValue<<<1, 1>>>(In, Out);
+  if (cudaMemcpy(&Result, Out, sizeof(int), cudaMemcpyDeviceToHost) !=
+      cudaSuccess)
+    return 1;
+
+  printf("legacy default waited on blocking stream: %d\n", Result);
+  // LEGACY: legacy default waited on blocking stream: 99
+  // PERTHREAD: legacy default waited on blocking stream: 0
+
+  Result = 0;
+  if (cudaMemcpy(Out, &Initial, sizeof(int), cudaMemcpyHostToDevice) !=
+      cudaSuccess)
+    return 1;
+
+  delayedSetValue<<<1, 1>>>(In, 123);
+  copyValue<<<1, 1, 0, BlockingStream>>>(In, Out);
+  if (cudaStreamSynchronize(BlockingStream) != cudaSuccess)
+    return 1;
+  if (cudaMemcpy(&Result, Out, sizeof(int), cudaMemcpyDeviceToHost) !=
+      cudaSuccess)
+    return 1;
+
+  printf("blocking stream waited on legacy default: %d\n", Result);
+  // LEGACY: blocking stream waited on legacy default: 123
+  // PERTHREAD: blocking stream waited on legacy default: 99
+
+  Result = 0;
+  if (cudaMemcpy(In, &Initial, sizeof(int), cudaMemcpyHostToDevice) !=
+      cudaSuccess)
+    return 1;
+  if (cudaMemcpy(Out, &Initial, sizeof(int), cudaMemcpyHostToDevice) !=
+      cudaSuccess)
+    return 1;
+  if (cudaMemcpy(Gate, &Initial, sizeof(int), cudaMemcpyHostToDevice) !=
+      cudaSuccess)
+    return 1;
+
+  waitThenSetValue<<<1, 1>>>(Gate, In, 321);
+  copyValueAndRelease<<<1, 1, 0, NonBlockingStream>>>(In, Out, Gate);
+  if (cudaStreamSynchronize(NonBlockingStream) != cudaSuccess)
+    return 1;
+  if (cudaMemcpy(&Result, Out, sizeof(int), cudaMemcpyDeviceToHost) !=
+      cudaSuccess)
+    return 1;
+
+  printf("nonblocking stream did not wait on legacy default: %d\n", Result);
+  // LEGACY: nonblocking stream did not wait on legacy default: 0
+  // PERTHREAD: nonblocking stream did not wait on legacy default: 0
+
+  if (cudaStreamDestroy(BlockingStream) != cudaSuccess)
+    return 1;
+  if (cudaStreamDestroy(NonBlockingStream) != cudaSuccess)
+    return 1;
+  if (cudaFree(In) != cudaSuccess)
+    return 1;
+  if (cudaFree(Out) != cudaSuccess)
+    return 1;
+  if (cudaFree(Gate) != cudaSuccess)
+    return 1;
+}

--- a/offload/test/offloading/CUDA/stream_api.cu
+++ b/offload/test/offloading/CUDA/stream_api.cu
@@ -70,8 +70,6 @@ int main(int argc, char **argv) {
 
   if (cudaStreamSynchronize(Stream) != cudaSuccess)
     return 1;
-  if (cudaDeviceSynchronize() != cudaSuccess)
-    return 1;
   if (cudaMemcpy(&StreamResult, StreamPtr, sizeof(int),
                  cudaMemcpyDeviceToHost) != cudaSuccess)
     return 1;
@@ -85,6 +83,10 @@ int main(int argc, char **argv) {
   // CHECK: default result: 17
 
   if (cudaStreamDestroy(Stream) != cudaSuccess)
+    return 1;
+  if (cudaStreamDestroy(BlockingStream) != cudaSuccess)
+    return 1;
+  if (cudaStreamDestroy(NonBlockingStream) != cudaSuccess)
     return 1;
   print_error("destroyed stream destroy", cudaStreamDestroy(Stream));
   // CHECK: destroyed stream destroy value: 4

--- a/offload/test/offloading/HIP/blocking_stream_semantics.hip
+++ b/offload/test/offloading/HIP/blocking_stream_semantics.hip
@@ -1,0 +1,125 @@
+// clang-format off
+// RUN: %clang++ %flags -foffload-via-llvm --offload-arch=native %s -o %t
+// RUN: %t | %fcheck-generic --check-prefix=LEGACY
+// RUN: %clang++ %flags -foffload-via-llvm --offload-arch=native %s -o %t -fopenmp
+// RUN: %t | %fcheck-generic --check-prefix=LEGACY
+// RUN: %clang++ %flags -foffload-via-llvm --offload-arch=native %s -o %t -fgpu-default-stream=per-thread
+// RUN: %t | %fcheck-generic --check-prefix=PERTHREAD
+// clang-format on
+
+// UNSUPPORTED: aarch64-unknown-linux-gnu
+// UNSUPPORTED: x86_64-unknown-linux-gnu
+// UNSUPPORTED: nvptx64-nvidia-cuda-LTO
+// UNSUPPORTED: amdgcn-amd-amdhsa-LTO
+// UNSUPPORTED: amdgpu-amd-amdhsa-LTO
+// UNSUPPORTED: intelgpu
+
+#include <stdio.h>
+
+__global__ void delayedSetValue(int *Out, int Value) {
+  volatile unsigned long long Delay = 0;
+  for (unsigned I = 0; I < 1000000; ++I)
+    Delay += I;
+  if (Delay)
+    *Out = Value;
+}
+
+__global__ void copyValue(int *In, int *Out) { *Out = *In; }
+
+__global__ void waitThenSetValue(int *Gate, int *Out, int Value) {
+  volatile int *VolatileGate = Gate;
+  for (unsigned I = 0; I < 100000000 && *VolatileGate == 0; ++I)
+    ;
+  *Out = Value;
+}
+
+__global__ void copyValueAndRelease(int *In, int *Out, int *Gate) {
+  *Out = *In;
+  volatile int *VolatileGate = Gate;
+  *VolatileGate = 1;
+}
+
+int main(int argc, char **argv) {
+  hipStream_t BlockingStream = nullptr;
+  if (hipStreamCreateWithFlags(&BlockingStream, hipStreamDefault) != hipSuccess)
+    return 1;
+  hipStream_t NonBlockingStream = nullptr;
+  if (hipStreamCreateWithFlags(&NonBlockingStream, hipStreamNonBlocking) !=
+      hipSuccess)
+    return 1;
+
+  int *In = nullptr;
+  int *Out = nullptr;
+  int *Gate = nullptr;
+  if (hipMalloc(&In, sizeof(int)) != hipSuccess)
+    return 1;
+  if (hipMalloc(&Out, sizeof(int)) != hipSuccess)
+    return 1;
+  if (hipMalloc(&Gate, sizeof(int)) != hipSuccess)
+    return 1;
+
+  int Initial = 0;
+  int Result = 0;
+  if (hipMemcpy(In, &Initial, sizeof(int), hipMemcpyHostToDevice) != hipSuccess)
+    return 1;
+  if (hipMemcpy(Out, &Initial, sizeof(int), hipMemcpyHostToDevice) !=
+      hipSuccess)
+    return 1;
+
+  delayedSetValue<<<1, 1, 0, BlockingStream>>>(In, 99);
+  copyValue<<<1, 1>>>(In, Out);
+  if (hipMemcpy(&Result, Out, sizeof(int), hipMemcpyDeviceToHost) != hipSuccess)
+    return 1;
+
+  printf("legacy default waited on blocking stream: %d\n", Result);
+  // LEGACY: legacy default waited on blocking stream: 99
+  // PERTHREAD: legacy default waited on blocking stream: 0
+
+  Result = 0;
+  if (hipMemcpy(Out, &Initial, sizeof(int), hipMemcpyHostToDevice) !=
+      hipSuccess)
+    return 1;
+
+  delayedSetValue<<<1, 1>>>(In, 123);
+  copyValue<<<1, 1, 0, BlockingStream>>>(In, Out);
+  if (hipStreamSynchronize(BlockingStream) != hipSuccess)
+    return 1;
+  if (hipMemcpy(&Result, Out, sizeof(int), hipMemcpyDeviceToHost) != hipSuccess)
+    return 1;
+
+  printf("blocking stream waited on legacy default: %d\n", Result);
+  // LEGACY: blocking stream waited on legacy default: 123
+  // PERTHREAD: blocking stream waited on legacy default: 99
+
+  Result = 0;
+  if (hipMemcpy(In, &Initial, sizeof(int), hipMemcpyHostToDevice) != hipSuccess)
+    return 1;
+  if (hipMemcpy(Out, &Initial, sizeof(int), hipMemcpyHostToDevice) !=
+      hipSuccess)
+    return 1;
+  if (hipMemcpy(Gate, &Initial, sizeof(int), hipMemcpyHostToDevice) !=
+      hipSuccess)
+    return 1;
+
+  waitThenSetValue<<<1, 1>>>(Gate, In, 321);
+  copyValueAndRelease<<<1, 1, 0, NonBlockingStream>>>(In, Out, Gate);
+  if (hipStreamSynchronize(NonBlockingStream) != hipSuccess)
+    return 1;
+  if (hipMemcpy(&Result, Out, sizeof(int), hipMemcpyDeviceToHost) != hipSuccess)
+    return 1;
+
+  printf("nonblocking stream did not wait on legacy default: %d\n", Result);
+  // LEGACY: nonblocking stream did not wait on legacy default: 0
+  // PERTHREAD: nonblocking stream did not wait on legacy default: 0
+
+  if (hipStreamDestroy(BlockingStream) != hipSuccess)
+    return 1;
+  if (hipStreamDestroy(NonBlockingStream) != hipSuccess)
+    return 1;
+  if (hipFree(In) != hipSuccess)
+    return 1;
+  if (hipFree(Out) != hipSuccess)
+    return 1;
+  if (hipFree(Gate) != hipSuccess)
+    return 1;
+}

--- a/offload/test/offloading/HIP/stream_api.hip
+++ b/offload/test/offloading/HIP/stream_api.hip
@@ -69,8 +69,6 @@ int main(int argc, char **argv) {
 
   if (hipStreamSynchronize(Stream) != hipSuccess)
     return 1;
-  if (hipDeviceSynchronize() != hipSuccess)
-    return 1;
   if (hipMemcpy(&StreamResult, StreamPtr, sizeof(int), hipMemcpyDeviceToHost) !=
       hipSuccess)
     return 1;
@@ -84,6 +82,10 @@ int main(int argc, char **argv) {
   // CHECK: default result: 17
 
   if (hipStreamDestroy(Stream) != hipSuccess)
+    return 1;
+  if (hipStreamDestroy(BlockingStream) != hipSuccess)
+    return 1;
+  if (hipStreamDestroy(NonBlockingStream) != hipSuccess)
     return 1;
   print_error("destroyed stream destroy", hipStreamDestroy(Stream));
   // CHECK: destroyed stream destroy value: 4


### PR DESCRIPTION
⚠️ This PR was mistakenly marked as merged ⚠️

This implements CUDA/HIP legacy default stream ordering in the LLVM offload language runtime. 

It now makes work submitted to the legacy default stream wait on explicitly-created blocking streams, and makes blocking stream kernel launches wait on prior legacy default stream work. Nonblocking streams remain independent, and per-thread default stream mode keeps the expected separate-stream behavior. We also extend the behavior to Memcpy.

Builds upon #216381 

Assisted by GPT-5.5, checked and reviewed manually