### PR TITLE
[LLVMABI][AARCH64] Add support for simple direct return case

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -352,6 +352,9 @@ bool CodeGenModule::shouldUseLLVMABILowering(unsigned CallingConv) const {
   if (T.isBPF())
     return true;
 
+  if (T.getArch() == llvm::Triple::aarch64 && !T.isOSWindows())
+    return true;
+
   if (T.getArch() == llvm::Triple::x86_64 && !T.isOSWindows() && !T.isUEFI() &&
       !T.isOSDarwin() && !T.isOSCygMing()) {
     switch (CallingConv) {
@@ -382,12 +385,30 @@ CodeGenModule::getLLVMABITargetInfo(llvm::abi::TypeBuilder &TB) {
     return *TheLLVMABITargetInfo;
 
   const llvm::Triple &T = getTriple();
-  if (T.isBPF()) {
-    TheLLVMABITargetInfo = llvm::abi::createBPFTargetInfo(TB);
+
+  switch (T.getArch()) {
+  default:
+    llvm_unreachable("LLVMABI lowering requested for an unsupported target");
+
+  case llvm::Triple::aarch64: {
+    StringRef ABI = getTarget().getABI();
+    llvm::abi::AArch64ABIKind Kind = llvm::abi::AArch64ABIKind::AAPCS;
+    if (ABI == "darwinpcs")
+      Kind = llvm::abi::AArch64ABIKind::DarwinPCS;
+    else if (T.isOSWindows())
+      Kind = llvm::abi::AArch64ABIKind::Win64;
+    else if (ABI == "aapcs-soft")
+      Kind = llvm::abi::AArch64ABIKind::AAPCSSoft;
+    TheLLVMABITargetInfo = llvm::abi::createAArch64TargetInfo(TB, Kind);
     return *TheLLVMABITargetInfo;
   }
 
-  if (T.getArch() == llvm::Triple::x86_64) {
+  case llvm::Triple::bpfeb:
+  case llvm::Triple::bpfel:
+    TheLLVMABITargetInfo = llvm::abi::createBPFTargetInfo(TB);
+    return *TheLLVMABITargetInfo;
+
+  case llvm::Triple::x86_64: {
     StringRef ABI = getTarget().getABI();
     llvm::abi::X86AVXABILevel AVXLevel =
         ABI == "avx512" ? llvm::abi::X86AVXABILevel::AVX512
@@ -414,8 +435,7 @@ CodeGenModule::getLLVMABITargetInfo(llvm::abi::TypeBuilder &TB) {
         TB, AVXLevel, Has64BitPointers, CompatInfo);
     return *TheLLVMABITargetInfo;
   }
-
-  llvm_unreachable("LLVMABI lowering requested for an unsupported target");
+  }
 }
 
 static void checkDataLayoutConsistency(const TargetInfo &Target,

--- a/clang/test/CodeGen/AArch64/abi-classify-return-types.c
+++ b/clang/test/CodeGen/AArch64/abi-classify-return-types.c
@@ -1,0 +1,62 @@
+// RUN: %clang_cc1 -triple arm64-apple-ios7.0 -target-abi darwinpcs -fenable-matrix -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,DARWIN
+// RUN: %clang_cc1 -triple arm64-apple-ios7.0 -target-abi darwinpcs -fenable-matrix -fexperimental-abi-lowering -emit-llvm -o - %s 2>&1 | FileCheck %s --check-prefixes=CHECK,DARWIN --implicit-check-not="not yet implemented"
+// RUN: %clang_cc1 -triple aarch64-linux-gnu -fenable-matrix -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,AAPCS
+// RUN: %clang_cc1 -triple aarch64-linux-gnu -fenable-matrix -fexperimental-abi-lowering -emit-llvm -o - %s 2>&1 | FileCheck %s --check-prefixes=CHECK,AAPCS --implicit-check-not="not yet implemented"
+
+// This test is verifying that the LLVM ABI library classifies return types in
+// the same way that Clang does without the library.
+
+// The AArch64 support in the ABI library is a work in progress. New test cases
+// will be added here as the types are implemented. Unimplemented cases will
+// report a warning if the ABI library is used.
+
+void ret_void() {}
+// CHECK: define{{.*}} void @ret_void
+
+_Bool ret_bool() { return 1; }
+// AAPCS: define{{.*}} i1 @ret_bool
+// DARWIN: define{{.*}} zeroext i1 @ret_bool
+
+char ret_char() { return 'a'; }
+// AAPCS: define{{.*}} i8 @ret_char
+// DARWIN: define{{.*}} signext i8 @ret_char
+
+short ret_short() { return 1; }
+// AAPCS: define{{.*}} i16 @ret_short
+// DARWIN: define{{.*}} signext i16 @ret_short
+
+unsigned short ret_ushort() { return 1; }
+// AAPCS: define{{.*}} i16 @ret_ushort
+// DARWIN: define{{.*}} zeroext i16 @ret_ushort
+
+int ret_int() { return 1; }
+// CHECK: define{{.*}} i32 @ret_int
+
+unsigned int ret_uint() { return 1; }
+// CHECK: define{{.*}} i32 @ret_uint
+
+long int ret_long() { return 1; }
+// CHECK: define{{.*}} i64 @ret_long
+
+_Float16 ret_float16() { return (_Float16)1.0f; }
+// CHECK: define{{.*}} half @ret_float16
+
+__fp16 ret_fp16() { return (__fp16)1.0f; }
+// CHECK: define{{.*}} half @ret_fp16
+
+float ret_float() { return 1.0f; }
+// CHECK: define{{.*}} float @ret_float
+
+double ret_double() { return 1.0; }
+// CHECK: define{{.*}} double @ret_double
+
+int gi;
+int* ret_int_ptr() { return &gi; }
+// CHECK: define{{.*}} ptr @ret_int_ptr
+
+void* ret_void_ptr() { return &gi; }
+// CHECK: define{{.*}} ptr @ret_void_ptr
+
+typedef float fx2x2_t __attribute__((matrix_type(2, 2)));
+fx2x2_t ret_matrix() { return (fx2x2_t){1.0f, 2.0f, 3.0f, 4.0f}; }
+// CHECK: define{{.*}} <4 x float> @ret_matrix

--- a/llvm/include/llvm/ABI/TargetInfo.h
+++ b/llvm/include/llvm/ABI/TargetInfo.h
@@ -82,6 +82,9 @@ protected:
   LLVM_ABI ArgInfo getNaturalAlignIndirect(const Type *Ty,
                                            bool ByVal = true) const;
   LLVM_ABI bool isAggregateTypeForABI(const Type *Ty) const;
+
+  /// Apply rules for classifying return types that are common to all targets.
+  LLVM_ABI bool maybeCommonClassifyReturnType(FunctionInfo &FI) const;
 };
 
 LLVM_ABI std::unique_ptr<TargetInfo> createBPFTargetInfo(TypeBuilder &TB);

--- a/llvm/lib/ABI/TargetInfo.cpp
+++ b/llvm/lib/ABI/TargetInfo.cpp
@@ -51,3 +51,23 @@ RecordArgABI TargetInfo::getRecordArgABI(const Type *Ty) const {
     return RAA_Default;
   return getRecordArgABI(RT);
 }
+
+bool TargetInfo::maybeCommonClassifyReturnType(FunctionInfo &FI) const {
+  const abi::Type *Ty = FI.getReturnType();
+
+  // TODO: When Microsoft ABI is supported, CXX records may need different
+  // handling here (see MicrosoftCXXABI::classifyReturnType in Clang).
+  if (const auto *RT = llvm::dyn_cast<abi::RecordType>(Ty)) {
+    if (!RT->canPassInRegisters()) {
+      // A record that cannot pass in registers (e.g. a non-trivial copy/dtor)
+      // is returned indirectly with ByVal=false. This is the RAA path and is
+      // distinct from getIndirectReturnResult (plain aggregates), which uses
+      // ByVal=true.
+      FI.getReturnInfo() =
+          ArgInfo::getIndirect(RT->getAlignment(), /*ByVal=*/false);
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/llvm/lib/ABI/Targets/AArch64.cpp
+++ b/llvm/lib/ABI/Targets/AArch64.cpp
@@ -10,6 +10,7 @@
 #include "llvm/ABI/TargetInfo.h"
 #include "llvm/ABI/Types.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/WithColor.h"
 
 namespace llvm {
 namespace abi {
@@ -20,21 +21,84 @@ public:
       : TB(TB), Kind(Kind) {}
 
   void computeInfo(FunctionInfo &FI) const override {
-    FI.getReturnInfo() = ArgInfo::getDirect();
-    for (auto &I : FI.arguments())
-      I.Info = ArgInfo::getDirect();
+    if (!maybeCommonClassifyReturnType(FI))
+      FI.getReturnInfo() =
+          classifyReturnType(FI.getReturnType(), FI.isVariadic());
+
+    unsigned ArgNo = 0;
+    unsigned NSRN = 0, NPRN = 0;
+    for (auto &I : FI.arguments()) {
+      const bool IsNamedArg =
+          !FI.isVariadic() || ArgNo < FI.getNumRequiredArgs();
+      ++ArgNo;
+      I.Info = classifyArgumentType(I.ABIType, FI.isVariadic(), IsNamedArg,
+                                    FI.getCallingConvention(), NSRN, NPRN);
+    }
   }
 
 private:
   [[maybe_unused]] TypeBuilder &TB;
-  [[maybe_unused]] AArch64ABIKind Kind;
+  AArch64ABIKind Kind;
+
+  ArgInfo classifyReturnType(const Type *RetTy, bool IsVariadicFn) const;
+  ArgInfo classifyArgumentType(const Type *Ty, bool IsVariadicFn,
+                               bool IsNamedArg, unsigned CallingConvention,
+                               unsigned &NSRN, unsigned &NPRN) const;
+
+  bool isDarwinPCS() const { return Kind == AArch64ABIKind::DarwinPCS; }
+  bool passAsAggregateType(const Type *Ty) const;
 };
 
 std::unique_ptr<TargetInfo> createAArch64TargetInfo(TypeBuilder &TB,
                                                     AArch64ABIKind Kind) {
   if (Kind == AArch64ABIKind::Win64)
-    llvm_unreachable("Win64 ABI not supported yet");
+    reportFatalUsageError("Win64 ABI is not supported yet for AArch64");
   return std::make_unique<AArch64TargetInfo>(TB, Kind);
+}
+
+static void reportNYI(StringRef Feature) {
+  WithColor::warning() << Feature << " is not yet implemented for AArch64\n";
+}
+
+ArgInfo AArch64TargetInfo::classifyReturnType(const Type *RetTy,
+                                              bool IsVariadicFn) const {
+  if (RetTy->isVoid())
+    return ArgInfo::getIgnore();
+
+  if (RetTy->isVector()) {
+    reportNYI("Vector return type");
+    return ArgInfo::getDirect();
+  }
+
+  if (!passAsAggregateType(RetTy)) {
+    if (const auto *IntTy = dyn_cast<IntegerType>(RetTy)) {
+      if (IntTy->isBitInt()) {
+        reportNYI("BitInt return type");
+        return ArgInfo::getDirect();
+      }
+      if (isPromotableInteger(IntTy) && isDarwinPCS()) {
+        return ArgInfo::getExtend(IntTy);
+      }
+    }
+
+    // Everything not handled above is returned directly.
+    return ArgInfo::getDirect();
+  }
+
+  reportNYI("Aggregate return type");
+  return ArgInfo::getDirect();
+}
+
+ArgInfo AArch64TargetInfo::classifyArgumentType(
+    const Type *Ty, bool IsVariadicFn, bool IsNamedArg,
+    unsigned CallingConvention, unsigned &NSRN, unsigned &NPRN) const {
+  reportNYI("Classify argument type");
+  return ArgInfo::getDirect();
+}
+
+bool AArch64TargetInfo::passAsAggregateType(const Type *Ty) const {
+  // TODO: Handle SVE types. For now, they don't get through the type mapper.
+  return isAggregateTypeForABI(Ty);
 }
 
 } // namespace abi

--- a/llvm/lib/ABI/Targets/X86.cpp
+++ b/llvm/lib/ABI/Targets/X86.cpp
@@ -1392,24 +1392,6 @@ ArgInfo X86_64TargetInfo::getIndirectReturnResult(const Type *Ty) const {
   return getNaturalAlignIndirect(Ty, /*ByVal=*/true);
 }
 
-static bool classifyCXXReturnType(FunctionInfo &FI) {
-  const abi::Type *Ty = FI.getReturnType();
-
-  if (const auto *RT = llvm::dyn_cast<abi::RecordType>(Ty)) {
-    if (!RT->canPassInRegisters()) {
-      // A C++ record that cannot pass in registers (non-trivial copy/dtor)
-      // is returned indirectly with ByVal=false, matching
-      // ItaniumCXXABI::classifyReturnType. This is the RAA path and is distinct
-      // from getIndirectReturnResult (plain aggregates), which uses ByVal=true.
-      FI.getReturnInfo() =
-          ArgInfo::getIndirect(RT->getAlignment(), /*ByVal=*/false);
-      return true;
-    }
-  }
-
-  return false;
-}
-
 void X86_64TargetInfo::computeInfo(FunctionInfo &FI) const {
   CallingConv::ID CallingConv = FI.getCallingConvention();
 
@@ -1428,7 +1410,7 @@ void X86_64TargetInfo::computeInfo(FunctionInfo &FI) const {
   unsigned FreeSSERegs = 8;
   unsigned NeededInt = 0, NeededSSE = 0;
 
-  if (!classifyCXXReturnType(FI)) {
+  if (!maybeCommonClassifyReturnType(FI)) {
     const Type *RetTy = FI.getReturnType();
     FI.getReturnInfo() = classifyReturnType(RetTy);
   }

--- a/llvm/unittests/ABI/AArch64TargetInfoTest.cpp
+++ b/llvm/unittests/ABI/AArch64TargetInfoTest.cpp
@@ -19,7 +19,6 @@ namespace {
 
 using ABIType = llvm::abi::Type;
 using llvm::abi::AArch64ABIKind;
-using llvm::abi::ArgEntry;
 using llvm::abi::ArgInfo;
 using llvm::abi::createAArch64TargetInfo;
 using llvm::abi::FunctionInfo;
@@ -30,65 +29,118 @@ class AArch64TargetInfoTest : public ::testing::Test {
 protected:
   llvm::BumpPtrAllocator Alloc;
   TypeBuilder TB;
+  const ABIType *Bool;
+  const ABIType *I8;
+  const ABIType *U8;
+  const ABIType *I16;
+  const ABIType *U16;
   const ABIType *I32;
+  const ABIType *U32;
+  const ABIType *I64;
+  const ABIType *U64;
+  const ABIType *F32;
   const ABIType *F64;
   const ABIType *Ptr;
   const ABIType *Void;
+  const ABIType *Matrix;
 
   AArch64TargetInfoTest()
-      : TB(Alloc), I32(TB.getIntegerType(32, llvm::Align(4), /*Signed=*/true)),
+      : TB(Alloc), Bool(TB.getIntegerType(1, llvm::Align(1), /*Signed=*/true)),
+        I8(TB.getIntegerType(8, llvm::Align(1), /*Signed=*/true)),
+        U8(TB.getIntegerType(8, llvm::Align(1), /*Signed=*/false)),
+        I16(TB.getIntegerType(16, llvm::Align(2), /*Signed=*/true)),
+        U16(TB.getIntegerType(16, llvm::Align(2), /*Signed=*/false)),
+        I32(TB.getIntegerType(32, llvm::Align(4), /*Signed=*/true)),
+        U32(TB.getIntegerType(32, llvm::Align(4), /*Signed=*/false)),
+        I64(TB.getIntegerType(64, llvm::Align(8), /*Signed=*/true)),
+        U64(TB.getIntegerType(64, llvm::Align(8), /*Signed=*/false)),
+        F32(TB.getFloatType(llvm::APFloat::IEEEsingle(), llvm::Align(4))),
         F64(TB.getFloatType(llvm::APFloat::IEEEdouble(), llvm::Align(8))),
-        Ptr(TB.getPointerType(64, llvm::Align(8))), Void(TB.getVoidType()) {}
+        Ptr(TB.getPointerType(64, llvm::Align(8))), Void(TB.getVoidType()),
+        Matrix(TB.getArrayType(F32, /*NumElements=*/4, /*SizeInBits=*/128,
+                               /*IsMatrixType=*/true)) {}
 };
 
-static void expectAllDirect(const FunctionInfo &FI) {
-  EXPECT_TRUE(FI.getReturnInfo().isDirect());
-  EXPECT_EQ(FI.getReturnInfo().getCoerceToType(), nullptr);
-  for (const ArgEntry &Arg : FI.arguments()) {
-    EXPECT_TRUE(Arg.Info.isDirect());
-    EXPECT_EQ(Arg.Info.getCoerceToType(), nullptr);
-  }
+static void expectUncoercedDirect(const ArgInfo &Info) {
+  EXPECT_TRUE(Info.isDirect());
+  EXPECT_EQ(Info.getCoerceToType(), nullptr);
 }
 
-TEST_F(AArch64TargetInfoTest, ComputeInfoMarksReturnAndArgsDirect) {
-  std::unique_ptr<TargetInfo> TI =
-      createAArch64TargetInfo(TB, AArch64ABIKind::AAPCS);
-  std::unique_ptr<FunctionInfo> FI =
-      FunctionInfo::create(llvm::CallingConv::C, I32, {I32, F64, Ptr});
-
-  // Poison the defaults so a no-op would fail the assertions below.
-  FI->getReturnInfo() = ArgInfo::getIgnore();
-  for (ArgEntry &Arg : FI->arguments())
-    Arg.Info = ArgInfo::getIgnore();
-
-  TI->computeInfo(*FI);
-  expectAllDirect(*FI);
+static void expectExtendInteger(const ArgInfo &Info, const ABIType *Ty,
+                                bool IsSigned) {
+  EXPECT_TRUE(Info.isExtend());
+  EXPECT_EQ(Info.isSignExt(), IsSigned);
+  EXPECT_EQ(Info.getCoerceToType(), Ty);
 }
 
-TEST_F(AArch64TargetInfoTest, ComputeInfoVoidReturnNoArgs) {
+TEST_F(AArch64TargetInfoTest, ClassifyReturnVoidIsIgnore) {
   std::unique_ptr<TargetInfo> TI =
       createAArch64TargetInfo(TB, AArch64ABIKind::DarwinPCS);
   std::unique_ptr<FunctionInfo> FI =
       FunctionInfo::create(llvm::CallingConv::C, Void, {});
 
-  FI->getReturnInfo() = ArgInfo::getIgnore();
+  FI->getReturnInfo() = ArgInfo::getDirect();
   TI->computeInfo(*FI);
 
-  EXPECT_TRUE(FI->getReturnInfo().isDirect());
+  EXPECT_TRUE(FI->getReturnInfo().isIgnore());
   EXPECT_TRUE(FI->arguments().empty());
 }
 
-TEST_F(AArch64TargetInfoTest, ComputeInfoAAPCSSoftSameAsStub) {
+// Non-aggregate scalars, matrix types, and promotable integers take the Direct
+// return path under AAPCS.
+TEST_F(AArch64TargetInfoTest, ClassifyReturnScalarsDirectAAPCS) {
+  std::unique_ptr<TargetInfo> TI =
+      createAArch64TargetInfo(TB, AArch64ABIKind::AAPCS);
+
+  for (const ABIType *RetTy :
+       {Bool, I8, U8, I16, U16, I32, U32, I64, U64, F32, F64, Ptr, Matrix}) {
+    std::unique_ptr<FunctionInfo> FI =
+        FunctionInfo::create(llvm::CallingConv::C, RetTy, {});
+    FI->getReturnInfo() = ArgInfo::getIgnore();
+    TI->computeInfo(*FI);
+    expectUncoercedDirect(FI->getReturnInfo());
+  }
+}
+
+// DarwinPCS returns non-promotable scalars directly. Promotable integer
+// returns are extended.
+TEST_F(AArch64TargetInfoTest, ClassifyReturnNonPromotableScalarsDirectDarwin) {
+  std::unique_ptr<TargetInfo> TI =
+      createAArch64TargetInfo(TB, AArch64ABIKind::DarwinPCS);
+
+  for (const ABIType *RetTy : {I32, U32, I64, U64, F32, F64, Ptr, Matrix}) {
+    std::unique_ptr<FunctionInfo> FI =
+        FunctionInfo::create(llvm::CallingConv::C, RetTy, {});
+    FI->getReturnInfo() = ArgInfo::getIgnore();
+    TI->computeInfo(*FI);
+    expectUncoercedDirect(FI->getReturnInfo());
+  }
+
+  for (const ABIType *RetTy : {Bool, I8, U8, I16, U16}) {
+    std::unique_ptr<FunctionInfo> FI =
+        FunctionInfo::create(llvm::CallingConv::C, RetTy, {});
+    FI->getReturnInfo() = ArgInfo::getIgnore();
+    TI->computeInfo(*FI);
+
+    bool IsSigned = llvm::cast<llvm::abi::IntegerType>(RetTy)->isSigned();
+    expectExtendInteger(FI->getReturnInfo(), RetTy, IsSigned);
+  }
+}
+
+// Non-aggregate scalars, matrix types, and promotable integers take the Direct
+// return path under AAPCSSoft.
+TEST_F(AArch64TargetInfoTest, ClassifyReturnScalarsDirectAAPCSSoft) {
   std::unique_ptr<TargetInfo> TI =
       createAArch64TargetInfo(TB, AArch64ABIKind::AAPCSSoft);
-  std::unique_ptr<FunctionInfo> FI =
-      FunctionInfo::create(llvm::CallingConv::C, F64, {I32});
 
-  FI->getReturnInfo() = ArgInfo::getIgnore();
-  FI->getArgInfo(0).Info = ArgInfo::getIgnore();
-
-  TI->computeInfo(*FI);
-  expectAllDirect(*FI);
+  for (const ABIType *RetTy :
+       {Bool, I8, U8, I16, U16, I32, U32, I64, U64, F32, F64, Ptr, Matrix}) {
+    std::unique_ptr<FunctionInfo> FI =
+        FunctionInfo::create(llvm::CallingConv::C, RetTy, {});
+    FI->getReturnInfo() = ArgInfo::getIgnore();
+    TI->computeInfo(*FI);
+    expectUncoercedDirect(FI->getReturnInfo());
+  }
 }
 
 } // namespace


### PR DESCRIPTION
This adds LLVM ABI library support for AArch64 return type classification for scalar and matrix types that are classified as Direct. Other types and all arguments are now reported as not yet implemented.

This also introduces the hook in Clang to use the ABI library for non-Windows AArch64 targets when `-fexperimental-abi-lowering` is passed and adds a test for the ABI handling of types which are handled by the library.

Assisted-by: Cursor / various models