### PR TITLE
[ADT] Add const and reverse iterators to SortedVectorMap

### DIFF
--- a/llvm/include/llvm/ADT/SortedVectorMap.h
+++ b/llvm/include/llvm/ADT/SortedVectorMap.h
@@ -54,6 +54,8 @@ public:
 
   using iterator = typename VectorType::iterator;
   using const_iterator = typename VectorType::const_iterator;
+  using reverse_iterator = typename VectorType::reverse_iterator;
+  using const_reverse_iterator = typename VectorType::const_reverse_iterator;
 
 private:
   VectorType Vector;
@@ -106,6 +108,15 @@ public:
   iterator end() { return Vector.end(); }
   const_iterator begin() const { return Vector.begin(); }
   const_iterator end() const { return Vector.end(); }
+  const_iterator cbegin() const { return Vector.begin(); }
+  const_iterator cend() const { return Vector.end(); }
+
+  reverse_iterator rbegin() { return Vector.rbegin(); }
+  reverse_iterator rend() { return Vector.rend(); }
+  const_reverse_iterator rbegin() const { return Vector.rbegin(); }
+  const_reverse_iterator rend() const { return Vector.rend(); }
+  const_reverse_iterator crbegin() const { return Vector.rbegin(); }
+  const_reverse_iterator crend() const { return Vector.rend(); }
 
   // Capacity
   [[nodiscard]] bool empty() const { return Vector.empty(); }

--- a/llvm/unittests/ADT/SortedVectorMapTest.cpp
+++ b/llvm/unittests/ADT/SortedVectorMapTest.cpp
@@ -119,4 +119,22 @@ TEST(SortedVectorMapTest, ReserveAndCapacity) {
   EXPECT_EQ(Map.size(), 1u);
   EXPECT_GE(Map.capacity(), 50u);
 }
+
+TEST(SortedVectorMapTest, Iterators) {
+  SortedVectorMap<int, int> Map;
+  Map[3] = 30;
+  Map[1] = 10;
+  Map[2] = 20;
+
+  const auto &ConstMap = Map;
+  ASSERT_EQ(std::distance(ConstMap.cbegin(), ConstMap.cend()), 3);
+  EXPECT_EQ(ConstMap.cbegin()->first, 1);
+  EXPECT_EQ(std::prev(ConstMap.cend())->first, 3);
+
+  ASSERT_EQ(std::distance(ConstMap.crbegin(), ConstMap.crend()), 3);
+  EXPECT_EQ(Map.rbegin()->first, 3);
+  EXPECT_EQ(std::prev(Map.rend())->first, 1);
+  EXPECT_EQ(ConstMap.crbegin()->first, 3);
+  EXPECT_EQ(std::prev(ConstMap.crend())->first, 1);
+}
 } // namespace


### PR DESCRIPTION
This patch adds cbegin, cend, rbegin, rend, crbegin, and crend to
SortedVectorMap along with reverse_iterator and const_reverse_iterator
type aliases.

The motivation here is to support const and reverse iteration in
SortedVectorMap, which is needed by tools like llvm-profdata for the
ongoing sample profile migration to SortedVectorMap.

Assisted-by: Antigravity
