### PR TITLE
[PowerPC] Make IsPPC6xx an assembler predicate

### DIFF
--- a/llvm/lib/Target/PowerPC/PPC.td
+++ b/llvm/lib/Target/PowerPC/PPC.td
@@ -387,7 +387,8 @@ def IsNotBookE  : Predicate<"!Subtarget->isBookE()">;
 def HasOnlyMSYNC : Predicate<"Subtarget->hasOnlyMSYNC()">;
 def HasSYNC   : Predicate<"!Subtarget->hasOnlyMSYNC()">;
 def IsPPC4xx  : Predicate<"Subtarget->isPPC4xx()">;
-def IsPPC6xx  : Predicate<"Subtarget->isPPC6xx()">;
+def IsPPC6xx  : Predicate<"Subtarget->isPPC6xx()">,
+                AssemblerPredicate<(all_of FeaturePPC6xx)>;
 def IsE500  : Predicate<"Subtarget->isE500()">;
 def HasSPE  : Predicate<"Subtarget->hasSPE()">;
 def HasICBT : Predicate<"Subtarget->hasICBT()">;
@@ -676,45 +677,46 @@ def : ProcessorModel<"450", PPC440Model, [Directive440, FeatureISEL,
                                           FeatureFRES, FeatureFRSQRTE,
                                           FeatureICBT, FeatureBookE,
                                           FeatureMSYNC, FeatureMFTB]>;
-def : Processor<"601", G3Itineraries, [Directive601, FeatureFPU]>;
+def : Processor<"601", G3Itineraries, [Directive601, FeatureFPU,
+                                       FeaturePPC6xx]>;
 def : Processor<"602", G3Itineraries, [Directive602, FeatureFPU,
-                                       FeatureMFTB]>;
+                                       FeatureMFTB, FeaturePPC6xx]>;
 def : Processor<"603", G3Itineraries, [Directive603,
                                        FeatureFRES, FeatureFRSQRTE,
-                                       FeatureMFTB]>;
+                                       FeatureMFTB, FeaturePPC6xx]>;
 def : Processor<"603e", G3Itineraries, [Directive603,
                                         FeatureFRES, FeatureFRSQRTE,
-                                        FeatureMFTB]>;
+                                        FeatureMFTB, FeaturePPC6xx]>;
 def : Processor<"603ev", G3Itineraries, [Directive603,
                                          FeatureFRES, FeatureFRSQRTE,
-                                         FeatureMFTB]>;
+                                         FeatureMFTB, FeaturePPC6xx]>;
 def : Processor<"604", G3Itineraries, [Directive604,
                                        FeatureFRES, FeatureFRSQRTE,
-                                       FeatureMFTB]>;
+                                       FeatureMFTB, FeaturePPC6xx]>;
 def : Processor<"604e", G3Itineraries, [Directive604,
                                         FeatureFRES, FeatureFRSQRTE,
-                                        FeatureMFTB]>;
+                                        FeatureMFTB, FeaturePPC6xx]>;
 def : Processor<"620", G3Itineraries, [Directive620,
                                        FeatureFRES, FeatureFRSQRTE,
-                                       FeatureMFTB]>;
+                                       FeatureMFTB, FeaturePPC6xx]>;
 def : Processor<"750", G4Itineraries, [Directive750,
                                        FeatureFRES, FeatureFRSQRTE,
-                                       FeatureMFTB]>;
+                                       FeatureMFTB, FeaturePPC6xx]>;
 def : Processor<"g3", G3Itineraries, [Directive750,
                                       FeatureFRES, FeatureFRSQRTE,
-                                      FeatureMFTB]>;
+                                      FeatureMFTB, FeaturePPC6xx]>;
 def : Processor<"7400", G4Itineraries, [Directive7400, FeatureAltivec,
                                         FeatureFRES, FeatureFRSQRTE,
-                                        FeatureMFTB]>;
+                                        FeatureMFTB, FeaturePPC6xx]>;
 def : Processor<"g4", G4Itineraries, [Directive7400, FeatureAltivec,
                                       FeatureFRES, FeatureFRSQRTE,
-                                      FeatureMFTB]>;
+                                      FeatureMFTB, FeaturePPC6xx]>;
 def : Processor<"7450", G4PlusItineraries, [Directive7400, FeatureAltivec,
                                             FeatureFRES, FeatureFRSQRTE,
-                                            FeatureMFTB]>;
+                                            FeatureMFTB, FeaturePPC6xx]>;
 def : Processor<"g4+", G4PlusItineraries, [Directive7400, FeatureAltivec,
                                            FeatureFRES, FeatureFRSQRTE,
-                                           FeatureMFTB]>;
+                                           FeatureMFTB, FeaturePPC6xx]>;
 
 def : ProcessorModel<"970", G5Model,
                   [Directive970, FeatureAltivec,

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.td
@@ -4942,31 +4942,25 @@ def : InstAlias<"mfpvr $RT", (MFSPR gprc:$RT, 287)>;
 def : InstAlias<"mfspefscr $Rx", (MFSPR gprc:$Rx, 512)>;
 def : InstAlias<"mtspefscr $Rx", (MTSPR 512, gprc:$Rx)>;
 
+let Predicates = [ModernAs, IsPPC6xx] in {
 foreach BATR = 0-3 in {
     def : InstAlias<"mtdbatu "#BATR#", $Rx",
-                    (MTSPR !add(BATR, !add(BATR, 536)), gprc:$Rx)>,
-                    Requires<[IsPPC6xx]>;
+                    (MTSPR !add(BATR, !add(BATR, 536)), gprc:$Rx)>;
     def : InstAlias<"mfdbatu $Rx, "#BATR,
-                    (MFSPR gprc:$Rx, !add(BATR, !add(BATR, 536)))>,
-                    Requires<[IsPPC6xx]>;
+                    (MFSPR gprc:$Rx, !add(BATR, !add(BATR, 536)))>;
     def : InstAlias<"mtdbatl "#BATR#", $Rx",
-                    (MTSPR !add(BATR, !add(BATR, 537)), gprc:$Rx)>,
-                    Requires<[IsPPC6xx]>;
+                    (MTSPR !add(BATR, !add(BATR, 537)), gprc:$Rx)>;
     def : InstAlias<"mfdbatl $Rx, "#BATR,
-                    (MFSPR gprc:$Rx, !add(BATR, !add(BATR, 537)))>,
-                    Requires<[IsPPC6xx]>;
+                    (MFSPR gprc:$Rx, !add(BATR, !add(BATR, 537)))>;
     def : InstAlias<"mtibatu "#BATR#", $Rx",
-                    (MTSPR !add(BATR, !add(BATR, 528)), gprc:$Rx)>,
-                    Requires<[IsPPC6xx]>;
+                    (MTSPR !add(BATR, !add(BATR, 528)), gprc:$Rx)>;
     def : InstAlias<"mfibatu $Rx, "#BATR,
-                    (MFSPR gprc:$Rx, !add(BATR, !add(BATR, 528)))>,
-                    Requires<[IsPPC6xx]>;
+                    (MFSPR gprc:$Rx, !add(BATR, !add(BATR, 528)))>;
     def : InstAlias<"mtibatl "#BATR#", $Rx",
-                    (MTSPR !add(BATR, !add(BATR, 529)), gprc:$Rx)>,
-                    Requires<[IsPPC6xx]>;
+                    (MTSPR !add(BATR, !add(BATR, 529)), gprc:$Rx)>;
     def : InstAlias<"mfibatl $Rx, "#BATR,
-                    (MFSPR gprc:$Rx, !add(BATR, !add(BATR, 529)))>,
-                    Requires<[IsPPC6xx]>;
+                    (MFSPR gprc:$Rx, !add(BATR, !add(BATR, 529)))>;
+}
 }
 
 def : InstAlias<"mtppr $RT", (MTSPR 896, gprc:$RT)>;

--- a/llvm/test/MC/Disassembler/PowerPC/ppc64-encoding-6xx.txt
+++ b/llvm/test/MC/Disassembler/PowerPC/ppc64-encoding-6xx.txt
@@ -1,4 +1,4 @@
-# RUN: llvm-mc --disassemble %s -triple powerpc64-unknown-unknown -mcpu=pwr7 | FileCheck %s
+# RUN: llvm-mc --disassemble %s -triple powerpc64-unknown-unknown -mattr=+ppc6xx | FileCheck %s
 
 # CHECK: tlbld 4
 0x7c 0x00 0x27 0xa4

--- a/llvm/test/MC/PowerPC/ppc64-encoding-6xx.s
+++ b/llvm/test/MC/PowerPC/ppc64-encoding-6xx.s
@@ -1,5 +1,5 @@
-# RUN: llvm-mc -triple powerpc64-unknown-unknown --show-encoding %s | FileCheck -check-prefix=CHECK-BE %s
-# RUN: llvm-mc -triple powerpc64le-unknown-unknown --show-encoding %s | FileCheck -check-prefix=CHECK-LE %s
+# RUN: llvm-mc -triple powerpc64-unknown-unknown -mattr=+ppc6xx --show-encoding %s | FileCheck -check-prefix=CHECK-BE %s
+# RUN: llvm-mc -triple powerpc64le-unknown-unknown -mattr=+ppc6xx --show-encoding %s | FileCheck -check-prefix=CHECK-LE %s
 
 # Instructions specific to the PowerPC 6xx family:
 


### PR DESCRIPTION
Enable FeaturePPC6xx on 6xx/7xx CPUs and gate IBAT aliases on it.