### PR TITLE
[Driver] Treat -O4 as -O3 in clang::getOptimizationLevel, which is called when building LTO link command

### DIFF
--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2726,7 +2726,8 @@ unsigned clang::getOptimizationLevel(const ArgList &Args, InputKind IK,
     if (A->getOption().matches(options::OPT_O0))
       return 0;
 
-    if (A->getOption().matches(options::OPT_Ofast) || A->getOption().matches(options::OPT_O4))
+    if (A->getOption().matches(options::OPT_Ofast) ||
+        A->getOption().matches(options::OPT_O4))
       return 3;
 
     assert(A->getOption().matches(options::OPT_O));

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2726,7 +2726,7 @@ unsigned clang::getOptimizationLevel(const ArgList &Args, InputKind IK,
     if (A->getOption().matches(options::OPT_O0))
       return 0;
 
-    if (A->getOption().matches(options::OPT_Ofast))
+    if (A->getOption().matches(options::OPT_Ofast) || A->getOption().matches(options::OPT_O4))
       return 3;
 
     assert(A->getOption().matches(options::OPT_O));

--- a/clang/test/Driver/lto.c
+++ b/clang/test/Driver/lto.c
@@ -66,6 +66,8 @@
 // RUN:   -fuse-ld=lld -flto -O3 -### 2>&1 | FileCheck --check-prefix=O3 %s
 // RUN: %clang --target=x86_64-unknown-linux-gnu --sysroot=%S/Inputs/basic_cross_linux_tree %s \
 // RUN:   -fuse-ld=lld -flto -Ofast -### 2>&1 | FileCheck --check-prefix=O3 %s
+// RUN: %clang --target=x86_64-unknown-linux-gnu --sysroot=%S/Inputs/basic_cross_linux_tree %s \
+// RUN:   -fuse-ld=lld -flto -O4 -### 2>&1 | FileCheck --check-prefix=O3 %s
 
 // O1: -plugin-opt=O1
 // O2: -plugin-opt=O2


### PR DESCRIPTION
#169762 (commit e60a69ab8a9e7) replaced the -O option handling in `tools::addLTOOptions` with `getOptimizationLevel()`, but `getOptimizationLevel` doesn't expect -O4, while `addLTOOptions` used to accept and without diagnostics. Teach `getOptimizationLevel` about -O4 and don't diagnose to revert to the old behavior.