### PR TITLE
[Analysis] Remove dead declarations

### DIFF
--- a/llvm/include/llvm/Analysis/DependenceAnalysis.h
+++ b/llvm/include/llvm/Analysis/DependenceAnalysis.h
@@ -149,10 +149,6 @@ public:
   /// the source and destination of the dependence.
   virtual unsigned getSameSDLevels() const { return 0; }
 
-  /// getDVEntry - Returns the DV entry associated with a regular or a
-  /// SameSD level
-  DVEntry getDVEntry(unsigned Level, bool IsSameSD) const;
-
   /// getDirection - Returns the direction associated with a particular
   /// common or SameSD level.
   virtual unsigned getDirection(unsigned Level, bool SameSD = false) const {

--- a/llvm/include/llvm/Analysis/MemoryDependenceAnalysis.h
+++ b/llvm/include/llvm/Analysis/MemoryDependenceAnalysis.h
@@ -496,9 +496,6 @@ public:
   LLVM_ABI MemDepResult getInvariantGroupPointerDependency(LoadInst *LI,
                                                            BasicBlock *BB);
 
-  /// Release memory in caches.
-  LLVM_ABI void releaseMemory();
-
   /// Return the clobber offset to dependent instruction.
   std::optional<int32_t> getClobberOffset(LoadInst *DepInst) const {
     const auto Off = ClobberOffsets.find(DepInst);

--- a/llvm/include/llvm/Analysis/ValueTracking.h
+++ b/llvm/include/llvm/Analysis/ValueTracking.h
@@ -254,10 +254,6 @@ LLVM_ABI Intrinsic::ID getIntrinsicForCallSite(const CallBase &CB,
 LLVM_ABI bool isSignBitCheck(ICmpInst::Predicate Pred, const APInt &RHS,
                              bool &TrueIfSigned);
 
-LLVM_ABI KnownFPClass analyzeKnownFPClassFromSelect(
-    const Instruction *I, const KnownFPClass &KnownLHS,
-    const KnownFPClass &KnownRHS, const SimplifyQuery &SQ, unsigned Depth = 0);
-
 /// Determine which floating-point classes are valid for \p V, and return them
 /// in KnownFPClass bit sets.
 ///


### PR DESCRIPTION
getDVEntry: Added on October 10, 2025 in commit
1e84cb512748742e244d1062ef64f76764127423 without a corresponding
function definition.

releaseMemory: Added on March 10, 2016 in commit
61440d225b0869aa1c82a0d76e6311eccf7307bc without a corresponding
function definition.

analyzeKnownFPClassFromSelect: Added on January 8, 2026 in commit
80296b618e648ef56ea5e5bbf1b34be6b1b72dcf without a corresponding
function definition.
