### PR TITLE
[JITLink] Stripe InProcessMemoryManager allocations by permission

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h
@@ -441,9 +441,6 @@ public:
 
   ~InProcessMemoryManager() override;
 
-  /// Returns the slab options that this memory manager was created with.
-  const SlabOptions &getSlabOptions() const { return SlabOpts; }
-
   void allocate(const JITLinkDylib *JD, LinkGraph &G,
                 OnAllocatedFunction OnAllocated) override;
 

--- a/llvm/include/llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_JITLINK_JITLINKMEMORYMANAGER_H
 #define LLVM_EXECUTIONENGINE_JITLINK_JITLINKMEMORYMANAGER_H
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/FunctionExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ExecutionEngine/JITLink/JITLinkDylib.h"
@@ -376,17 +377,72 @@ private:
 };
 
 /// A JITLinkMemoryManager that allocates in-process memory.
+///
+/// Memory is handed out from slabs: large reservations of address space that
+/// are striped between AllocGroups at chunk granularity. Each chunk of a slab
+/// is only ever used by a single AllocGroup, so that segments with matching
+/// memory protections end up next to one another rather than interleaved with
+/// segments carrying other protections. This keeps the number of distinct
+/// memory mappings -- and hence the size of the OS page tables -- low: without
+/// striping, linking many objects produces a layout like
+///
+///   |R--|R-X|RW-|R--|R-X|RW-|R--|R-X|RW-|...
+///
+/// where every segment needs its own mapping, whereas striping produces
+///
+///   |R-X|R-X|R-X|...|R--|RW-|R--|R--|RW-|...
+///
+/// where adjacent segments with matching protections can share one.
+/// Executable segments are allocated from the bottom of each slab and
+/// non-executable ones from the top, so that (in the common case where a
+/// slab's chunks aren't exhausted) all executable memory is contiguous.
+///
+/// All segments for any one LinkGraph are allocated from a single slab, so the
+/// slab size bounds the distance between any two blocks in a graph. It must
+/// therefore be kept small enough to satisfy the range requirements of the
+/// relocations that JITLink applies without indirection (e.g. 32-bit
+/// PC-relative references from code to read-only data).
 class LLVM_ABI InProcessMemoryManager : public JITLinkMemoryManager {
 public:
   class IPInFlightAlloc;
 
+  /// Slab allocation parameters.
+  struct SlabOptions {
+    /// The size of each address space reservation. Since all segments for a
+    /// single LinkGraph are allocated from one slab this also bounds the
+    /// distance between any two blocks in a graph.
+    ///
+    /// Slabs larger than this may still be created to hold graphs that don't
+    /// fit in a slab of this size.
+    uint64_t SlabSize = 0;
+
+    /// The granularity at which slabs are striped between AllocGroups. No
+    /// chunk is ever shared by two different AllocGroups.
+    uint64_t ChunkSize = 0;
+
+    /// Returns default slab options for the given page size.
+    static SlabOptions defaults(uint64_t PageSize);
+  };
+
   /// Attempts to auto-detect the host page size.
   static Expected<std::unique_ptr<InProcessMemoryManager>> Create();
 
-  /// Create an instance using the given page size.
-  InProcessMemoryManager(uint64_t PageSize) : PageSize(PageSize) {
-    assert(isPowerOf2_64(PageSize) && "PageSize must be a power of 2");
-  }
+  /// Attempts to auto-detect the host page size, and uses the given slab
+  /// options.
+  static Expected<std::unique_ptr<InProcessMemoryManager>>
+  Create(SlabOptions SO);
+
+  /// Create an instance using the given page size and default slab options.
+  InProcessMemoryManager(uint64_t PageSize)
+      : InProcessMemoryManager(PageSize, SlabOptions::defaults(PageSize)) {}
+
+  /// Create an instance using the given page size and slab options.
+  InProcessMemoryManager(uint64_t PageSize, SlabOptions SO);
+
+  ~InProcessMemoryManager() override;
+
+  /// Returns the slab options that this memory manager was created with.
+  const SlabOptions &getSlabOptions() const { return SlabOpts; }
 
   void allocate(const JITLinkDylib *JD, LinkGraph &G,
                 OnAllocatedFunction OnAllocated) override;
@@ -401,18 +457,47 @@ public:
   using JITLinkMemoryManager::deallocate;
 
 private:
+  struct Slab;
+
+  /// A range of memory allocated from a slab.
+  struct SlabRange {
+    Slab *S = nullptr;
+    uint64_t Offset = 0;
+    uint64_t Size = 0;
+    orc::AllocGroup AG;
+
+    char *base() const;
+  };
+
+  using SlabRangeList = SmallVector<SlabRange, 4>;
+
   // FIXME: Use an in-place array instead of a vector for DeallocActions.
   //        There shouldn't need to be a heap alloc for this.
   struct FinalizedAllocInfo {
-    sys::MemoryBlock StandardSegments;
+    SlabRangeList StandardSegments;
     std::vector<orc::shared::WrapperFunctionCall> DeallocActions;
   };
 
+  /// Reserve a new slab of at least MinSize bytes. Must be called with
+  /// SlabsMutex held.
+  Expected<Slab *> createSlab(uint64_t MinSize);
+
+  /// Allocate one range per segment in BL, all from the same slab.
+  Expected<SlabRangeList> allocateSegments(BasicLayout &BL);
+
+  /// Return the given ranges to their slabs. If ResetProtections is true then
+  /// read/write protections are restored before the memory is made available
+  /// for reuse; ranges whose protections can't be reset are left allocated.
+  Error freeSegments(MutableArrayRef<SlabRange> Ranges, bool ResetProtections);
+
   FinalizedAlloc createFinalizedAlloc(
-      sys::MemoryBlock StandardSegments,
+      SlabRangeList StandardSegments,
       std::vector<orc::shared::WrapperFunctionCall> DeallocActions);
 
   uint64_t PageSize;
+  SlabOptions SlabOpts;
+  std::mutex SlabsMutex;
+  std::vector<std::unique_ptr<Slab>> Slabs;
   std::mutex FinalizedAllocsMutex;
   RecyclingAllocator<BumpPtrAllocator, FinalizedAllocInfo> FinalizedAllocInfos;
 };

--- a/llvm/include/llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h
@@ -378,9 +378,26 @@ private:
 
 /// A JITLinkMemoryManager that allocates in-process memory.
 ///
-/// Memory is handed out from slabs: large reservations of address space that
-/// are striped between AllocGroups at chunk granularity. Each chunk of a slab
-/// is only ever used by a single AllocGroup, so that segments with matching
+/// All memory this manager ever hands out is carved from a single, fixed
+/// address-space reservation that it makes once, lazily, the first time it's
+/// needed. Slabs -- and the chunks and segments within them, see below -- are
+/// logical sub-ranges of that one reservation rather than separate OS
+/// mappings of their own. This matters beyond bookkeeping convenience: some
+/// platforms need every piece of code a process JITs, for the lifetime of the
+/// session, to stay within a fixed distance of a single early address (on
+/// Darwin, compact-unwind info can only encode addresses within 2^32 of a
+/// fixed base -- see CompactUnwindSupport.h and MachOPlatform's use of
+/// '__jitlink$libunwind_dso_base'). Carving everything out of one reservation
+/// guarantees that no matter how many slabs are created and released over a
+/// long-running session, nothing ever ends up further from the start of the
+/// reservation than the reservation is wide -- a guarantee that placement
+/// hints passed to individual OS mapping calls cannot provide, since such
+/// hints are advisory and may simply be ignored (as they typically are on
+/// Darwin for anonymous mappings).
+///
+/// Within the reservation, memory is handed out from slabs, which are in turn
+/// striped between AllocGroups at chunk granularity. Each chunk of a slab is
+/// only ever used by a single AllocGroup, so that segments with matching
 /// memory protections end up next to one another rather than interleaved with
 /// segments carrying other protections. This keeps the number of distinct
 /// memory mappings -- and hence the size of the OS page tables -- low: without
@@ -408,9 +425,9 @@ public:
 
   /// Slab allocation parameters.
   struct SlabOptions {
-    /// The size of each address space reservation. Since all segments for a
-    /// single LinkGraph are allocated from one slab this also bounds the
-    /// distance between any two blocks in a graph.
+    /// The size of each slab carved out of the reservation. Since all
+    /// segments for a single LinkGraph are allocated from one slab this also
+    /// bounds the distance between any two blocks in a graph.
     ///
     /// Slabs larger than this may still be created to hold graphs that don't
     /// fit in a slab of this size.
@@ -419,6 +436,14 @@ public:
     /// The granularity at which slabs are striped between AllocGroups. No
     /// chunk is ever shared by two different AllocGroups.
     uint64_t ChunkSize = 0;
+
+    /// The size of the single address-space reservation that all of this
+    /// manager's slabs are carved out of. This bounds the distance between
+    /// any two pieces of memory this manager ever hands out, for the whole
+    /// lifetime of the manager -- see the class comment for why that matters.
+    /// Allocations that would need more room than is left in the reservation
+    /// fail outright rather than falling back to a separate OS mapping.
+    uint64_t ReservationSize = 0;
 
     /// Returns default slab options for the given page size.
     static SlabOptions defaults(uint64_t PageSize);
@@ -454,6 +479,7 @@ public:
   using JITLinkMemoryManager::deallocate;
 
 private:
+  struct Reservation;
   struct Slab;
 
   /// A range of memory allocated from a slab.
@@ -475,8 +501,9 @@ private:
     std::vector<orc::shared::WrapperFunctionCall> DeallocActions;
   };
 
-  /// Reserve a new slab of at least MinSize bytes. Must be called with
-  /// SlabsMutex held.
+  /// Reserve a new slab of at least MinSize bytes from the reservation,
+  /// creating the reservation itself first if this is the first slab it's
+  /// ever been asked for. Must be called with SlabsMutex held.
   Expected<Slab *> createSlab(uint64_t MinSize);
 
   /// Allocate one range per segment in BL, all from the same slab.
@@ -494,6 +521,7 @@ private:
   uint64_t PageSize;
   SlabOptions SlabOpts;
   std::mutex SlabsMutex;
+  std::unique_ptr<Reservation> TheReservation;
   std::vector<std::unique_ptr<Slab>> Slabs;
   std::mutex FinalizedAllocsMutex;
   RecyclingAllocator<BumpPtrAllocator, FinalizedAllocInfo> FinalizedAllocInfos;

--- a/llvm/lib/ExecutionEngine/JITLink/JITLinkMemoryManager.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/JITLinkMemoryManager.cpp
@@ -241,7 +241,74 @@ SimpleSegmentAlloc::SimpleSegmentAlloc(
     : G(std::move(G)), ContentBlocks(std::move(ContentBlocks)),
       Alloc(std::move(Alloc)) {}
 
-/// A reservation of address space that is striped between AllocGroups at
+/// A single, fixed reservation of address space that every slab a memory
+/// manager ever creates is carved out of -- see the class comment on
+/// InProcessMemoryManager for why that matters. Backed by one OS mapping,
+/// made lazily the first time a slab is needed.
+struct InProcessMemoryManager::Reservation {
+  explicit Reservation(const sys::MemoryBlock &Mem) : Mem(Mem) {
+    FreeRanges[0] = Mem.allocatedSize();
+  }
+
+  char *base() const { return static_cast<char *>(Mem.base()); }
+  uint64_t size() const { return Mem.allocatedSize(); }
+
+  /// Carve Size bytes out of the reservation, first-fit. Returns the offset
+  /// of the allocation within the reservation, or std::nullopt if there's no
+  /// room left.
+  std::optional<uint64_t> allocate(uint64_t Size);
+
+  /// Return a previously allocated range to the reservation.
+  void free(uint64_t Offset, uint64_t Size);
+
+  sys::MemoryBlock Mem;
+
+  /// Free ranges of the reservation, keyed by offset. Ranges are disjoint,
+  /// and never adjacent to one another (adjacent ranges are always
+  /// coalesced).
+  std::map<uint64_t, uint64_t> FreeRanges;
+};
+
+std::optional<uint64_t>
+InProcessMemoryManager::Reservation::allocate(uint64_t Size) {
+  assert(Size && "Cannot allocate zero bytes");
+
+  for (auto I = FreeRanges.begin(), E = FreeRanges.end(); I != E; ++I) {
+    if (I->second < Size)
+      continue;
+    const uint64_t Offset = I->first, RangeSize = I->second;
+    FreeRanges.erase(I);
+    if (RangeSize > Size)
+      FreeRanges[Offset + Size] = RangeSize - Size;
+    return Offset;
+  }
+  return std::nullopt;
+}
+
+void InProcessMemoryManager::Reservation::free(uint64_t Offset, uint64_t Size) {
+  assert(Size && "Cannot free zero bytes");
+  assert(Offset + Size <= size() && "Freed range out of reservation bounds");
+
+  // Add the range to the free list, coalescing with its neighbors.
+  uint64_t Start = Offset, End = Offset + Size;
+  const auto Next = FreeRanges.upper_bound(Offset);
+  if (Next != FreeRanges.begin()) {
+    const auto Prev = std::prev(Next);
+    assert(Prev->first + Prev->second <= Offset &&
+           "Freed range overlaps existing free range");
+    if (Prev->first + Prev->second == Offset) {
+      Start = Prev->first;
+      FreeRanges.erase(Prev);
+    }
+  }
+  if (Next != FreeRanges.end() && Next->first == End) {
+    End = Next->first + Next->second;
+    FreeRanges.erase(Next);
+  }
+  FreeRanges[Start] = End - Start;
+}
+
+/// A logical range of the reservation that is striped between AllocGroups at
 /// chunk granularity.
 ///
 /// Each chunk of the slab is owned by at most one AllocGroup at a time: a
@@ -253,14 +320,14 @@ struct InProcessMemoryManager::Slab {
   /// used for chunks that no group has claimed yet.
   static constexpr uint8_t NoOwner = ~static_cast<uint8_t>(0);
 
-  Slab(sys::MemoryBlock Mem, uint64_t ChunkSize)
-      : Mem(Mem), ChunkSize(ChunkSize),
-        ChunkOwners(divideCeil(Mem.allocatedSize(), ChunkSize), NoOwner) {
-    FreeRanges[0] = Mem.allocatedSize();
+  Slab(char *Base, uint64_t Size, uint64_t ChunkSize)
+      : Base(Base), Size(Size), ChunkSize(ChunkSize),
+        ChunkOwners(divideCeil(Size, ChunkSize), NoOwner) {
+    FreeRanges[0] = Size;
   }
 
-  char *base() const { return static_cast<char *>(Mem.base()); }
-  uint64_t size() const { return Mem.allocatedSize(); }
+  char *base() const { return Base; }
+  uint64_t size() const { return Size; }
 
   /// Allocate Size bytes for the group with index Owner.
   ///
@@ -273,7 +340,8 @@ struct InProcessMemoryManager::Slab {
   /// Return a previously allocated range to the slab.
   void free(uint64_t Offset, uint64_t Size);
 
-  sys::MemoryBlock Mem;
+  char *Base;
+  uint64_t Size;
   uint64_t ChunkSize;
   SmallVector<uint8_t, 64> ChunkOwners;
 
@@ -511,15 +579,22 @@ InProcessMemoryManager::SlabOptions::defaults(uint64_t PageSize) {
   if constexpr (sizeof(uintptr_t) >= 8) {
     SO.SlabSize = 16 * 1024 * 1024;
     SO.ChunkSize = 256 * 1024;
+    // Comfortably under the 2^32 budget that some platforms need every piece
+    // of code a session ever JITs to stay within, of a fixed base address
+    // (see the class comment).
+    SO.ReservationSize = 2ULL * 1024 * 1024 * 1024;
   } else {
     SO.SlabSize = 4 * 1024 * 1024;
     SO.ChunkSize = 64 * 1024;
+    SO.ReservationSize = 64 * 1024 * 1024;
   }
 
-  // Chunks must be a whole number of pages, and slabs a whole number of
-  // chunks.
+  // Chunks must be a whole number of pages, slabs a whole number of chunks,
+  // and the reservation a whole number of slabs.
   SO.ChunkSize = alignTo(std::max(SO.ChunkSize, PageSize), PageSize);
   SO.SlabSize = alignTo(std::max(SO.SlabSize, SO.ChunkSize), SO.ChunkSize);
+  SO.ReservationSize =
+      alignTo(std::max(SO.ReservationSize, SO.SlabSize), SO.SlabSize);
 
   return SO;
 }
@@ -532,11 +607,14 @@ InProcessMemoryManager::InProcessMemoryManager(uint64_t PageSize,
          "ChunkSize must be a non-zero multiple of PageSize");
   assert(SlabOpts.SlabSize && SlabOpts.SlabSize % SlabOpts.ChunkSize == 0 &&
          "SlabSize must be a non-zero multiple of ChunkSize");
+  assert(SlabOpts.ReservationSize &&
+         SlabOpts.ReservationSize % SlabOpts.SlabSize == 0 &&
+         "ReservationSize must be a non-zero multiple of SlabSize");
 }
 
 InProcessMemoryManager::~InProcessMemoryManager() {
-  for (const auto &S : Slabs)
-    (void)sys::Memory::releaseMappedMemory(S->Mem);
+  if (TheReservation)
+    (void)sys::Memory::releaseMappedMemory(TheReservation->Mem);
 }
 
 Expected<std::unique_ptr<InProcessMemoryManager>>
@@ -572,6 +650,13 @@ InProcessMemoryManager::Create(SlabOptions SO) {
               Twine(SO.ChunkSize),
           inconvertibleErrorCode());
 
+    if (!SO.ReservationSize || SO.ReservationSize % SO.SlabSize)
+      return make_error<StringError>(
+          "Could not create InProcessMemoryManager: Reservation size " +
+              Twine(SO.ReservationSize) +
+              " is not a non-zero multiple of slab size " + Twine(SO.SlabSize),
+          inconvertibleErrorCode());
+
     return std::make_unique<InProcessMemoryManager>(*PageSize, SO);
   } else
     return PageSize.takeError();
@@ -579,29 +664,51 @@ InProcessMemoryManager::Create(SlabOptions SO) {
 
 Expected<InProcessMemoryManager::Slab *>
 InProcessMemoryManager::createSlab(uint64_t MinSize) {
-  const uint64_t SlabSize =
+  if (!TheReservation) {
+    // Placement doesn't matter here -- unlike a hint passed to an individual
+    // mapping, the address the OS puts this reservation at doesn't affect
+    // whether later slabs stay within range of one another, since they're
+    // all carved out of this one mapping (see the class comment).
+    std::error_code EC;
+    auto MB = sys::Memory::allocateMappedMemory(SlabOpts.ReservationSize,
+                                                nullptr, ReadWrite, EC);
+    if (EC)
+      return errorCodeToError(EC);
+
+    LLVM_DEBUG({
+      dbgs() << "InProcessMemoryManager reserved "
+             << formatv("[ {0:x16} -- {1:x16} ]",
+                        orc::ExecutorAddr::fromPtr(MB.base()),
+                        orc::ExecutorAddr::fromPtr(MB.base()) +
+                            MB.allocatedSize())
+             << "\n";
+    });
+
+    TheReservation = std::make_unique<Reservation>(MB);
+  }
+
+  const uint64_t ThisSlabSize =
       alignTo(std::max(MinSize, SlabOpts.SlabSize), SlabOpts.ChunkSize);
 
-  // Hint that the new slab should be placed immediately after the previous
-  // one: keeping slabs close together improves locality, and gives the OS the
-  // chance to merge mappings with matching permissions across slab boundaries.
-  const sys::MemoryBlock *Near = Slabs.empty() ? nullptr : &Slabs.back()->Mem;
+  auto Offset = TheReservation->allocate(ThisSlabSize);
+  if (!Offset)
+    return make_error<StringError>(
+        "InProcessMemoryManager's " + Twine(SlabOpts.ReservationSize) +
+            "-byte address space reservation is exhausted; consider "
+            "increasing SlabOptions::ReservationSize",
+        inconvertibleErrorCode());
 
-  std::error_code EC;
-  auto MB = sys::Memory::allocateMappedMemory(SlabSize, Near, ReadWrite, EC);
-  if (EC)
-    return errorCodeToError(EC);
-
+  char *Base = TheReservation->base() + *Offset;
   LLVM_DEBUG({
-    dbgs() << "InProcessMemoryManager reserved slab "
+    dbgs() << "InProcessMemoryManager created slab "
            << formatv("[ {0:x16} -- {1:x16} ]",
-                      orc::ExecutorAddr::fromPtr(MB.base()),
-                      orc::ExecutorAddr::fromPtr(MB.base()) +
-                          MB.allocatedSize())
+                      orc::ExecutorAddr::fromPtr(Base),
+                      orc::ExecutorAddr::fromPtr(Base) + ThisSlabSize)
            << "\n";
   });
 
-  Slabs.push_back(std::make_unique<Slab>(MB, SlabOpts.ChunkSize));
+  Slabs.push_back(
+      std::make_unique<Slab>(Base, ThisSlabSize, SlabOpts.ChunkSize));
   return Slabs.back().get();
 }
 
@@ -710,12 +817,13 @@ Error InProcessMemoryManager::freeSegments(MutableArrayRef<SlabRange> Ranges,
   for (const auto *R : ToFree)
     R->S->free(R->Offset, R->Size);
 
-  // Return fully-freed slabs to the OS, keeping one around to absorb the
-  // common allocate / deallocate / allocate pattern without re-reserving.
-  for (auto I = Slabs.begin(); I != Slabs.end() && Slabs.size() > 1;) {
+  // Return fully-freed slabs to the reservation so their space can be reused
+  // by future slabs. This never touches the OS -- the reservation itself is
+  // held for the lifetime of this memory manager (see the class comment) --
+  // so unlike the old per-slab OS mappings this replaced, it can't fail.
+  for (auto I = Slabs.begin(); I != Slabs.end();) {
     if ((*I)->NumLiveRanges == 0) {
-      if (const auto EC = sys::Memory::releaseMappedMemory((*I)->Mem))
-        Err = joinErrors(std::move(Err), errorCodeToError(EC));
+      TheReservation->free((*I)->base() - TheReservation->base(), (*I)->size());
       I = Slabs.erase(I);
     } else {
       ++I;

--- a/llvm/lib/ExecutionEngine/JITLink/JITLinkMemoryManager.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/JITLinkMemoryManager.cpp
@@ -9,7 +9,11 @@
 #include "llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/Support/FormatVariadic.h"
+#include "llvm/Support/MathExtras.h"
 #include "llvm/Support/Process.h"
+
+#include <map>
+#include <optional>
 
 #define DEBUG_TYPE "jitlink"
 
@@ -237,15 +241,183 @@ SimpleSegmentAlloc::SimpleSegmentAlloc(
     : G(std::move(G)), ContentBlocks(std::move(ContentBlocks)),
       Alloc(std::move(Alloc)) {}
 
-class InProcessMemoryManager::IPInFlightAlloc
-    : public JITLinkMemoryManager::InFlightAlloc {
+/// A reservation of address space that is striped between AllocGroups at
+/// chunk granularity.
+///
+/// Each chunk of the slab is owned by at most one AllocGroup at a time: a
+/// range may only be allocated for a group if every chunk that it touches is
+/// either unowned, or already owned by that group. Chunks are returned to the
+/// unowned state once all memory within them has been freed.
+struct InProcessMemoryManager::Slab {
+  /// Chunk owners are AllocGroup indexes (see allocGroupIndex), with NoOwner
+  /// used for chunks that no group has claimed yet.
+  static constexpr uint8_t NoOwner = ~static_cast<uint8_t>(0);
+
+  Slab(sys::MemoryBlock Mem, uint64_t ChunkSize)
+      : Mem(Mem), ChunkSize(ChunkSize),
+        ChunkOwners(divideCeil(Mem.allocatedSize(), ChunkSize), NoOwner) {
+    FreeRanges[0] = Mem.allocatedSize();
+  }
+
+  char *base() const { return static_cast<char *>(Mem.base()); }
+  uint64_t size() const { return Mem.allocatedSize(); }
+
+  /// Allocate Size bytes for the group with index Owner.
+  ///
+  /// If FromTop is true then the allocation is taken from the highest suitable
+  /// address in the slab, otherwise from the lowest. Returns the offset of the
+  /// allocation within the slab, or std::nullopt if the request can't be
+  /// satisfied.
+  std::optional<uint64_t> allocate(uint64_t Size, uint8_t Owner, bool FromTop);
+
+  /// Return a previously allocated range to the slab.
+  void free(uint64_t Offset, uint64_t Size);
+
+  sys::MemoryBlock Mem;
+  uint64_t ChunkSize;
+  SmallVector<uint8_t, 64> ChunkOwners;
+
+  /// Free ranges of the slab, keyed by offset. Ranges are disjoint, and never
+  /// adjacent to one another (adjacent ranges are always coalesced).
+  ///
+  /// FIXME: Allocation is first-fit over this map, which is O(#free-ranges) in
+  /// the worst case. Revisit if this shows up in profiles.
+  std::map<uint64_t, uint64_t> FreeRanges;
+
+  uint64_t NumLiveRanges = 0;
+};
+
+std::optional<uint64_t> InProcessMemoryManager::Slab::allocate(uint64_t Size,
+                                                               uint8_t Owner,
+                                                               bool FromTop) {
+  assert(Size && "Cannot allocate zero bytes");
+
+  auto ChunkOf = [&](uint64_t Offset) { return Offset / ChunkSize; };
+  auto EndOfChunk = [&](uint64_t Offset) {
+    return (ChunkOf(Offset) + 1) * ChunkSize;
+  };
+  auto AvailableAt = [&](uint64_t Offset) {
+    const uint8_t O = ChunkOwners[ChunkOf(Offset)];
+    return O == NoOwner || O == Owner;
+  };
+
+  // Find a Size-byte position within the free range [Start, End) that only
+  // covers chunks available to Owner, preferring the highest such position if
+  // FromTop is set and the lowest otherwise.
+  auto FindInRange = [&](uint64_t Start,
+                         uint64_t End) -> std::optional<uint64_t> {
+    std::optional<uint64_t> Result;
+    uint64_t Cur = Start;
+    while (Cur < End) {
+      if (!AvailableAt(Cur)) {
+        Cur = EndOfChunk(Cur);
+        continue;
+      }
+      // Extend the run of available chunks as far as we can.
+      uint64_t RunStart = Cur;
+      while (Cur < End && AvailableAt(Cur))
+        Cur = std::min(EndOfChunk(Cur), End);
+      if (Cur - RunStart >= Size) {
+        Result = FromTop ? Cur - Size : RunStart;
+        if (!FromTop)
+          break;
+      }
+    }
+    return Result;
+  };
+
+  std::optional<uint64_t> Offset;
+  if (FromTop) {
+    for (auto I = FreeRanges.rbegin(), E = FreeRanges.rend(); I != E; ++I)
+      if ((Offset = FindInRange(I->first, I->first + I->second)))
+        break;
+  } else {
+    for (auto &KV : FreeRanges)
+      if ((Offset = FindInRange(KV.first, KV.first + KV.second)))
+        break;
+  }
+
+  if (!Offset)
+    return std::nullopt;
+
+  // Remove the allocated range from the free list, keeping any leading or
+  // trailing remainder.
+  const auto I = std::prev(FreeRanges.upper_bound(*Offset));
+  const uint64_t RangeStart = I->first, RangeEnd = I->first + I->second;
+  assert(RangeStart <= *Offset && *Offset + Size <= RangeEnd &&
+         "Allocation not contained in the free range it came from");
+  FreeRanges.erase(I);
+  if (RangeStart < *Offset)
+    FreeRanges[RangeStart] = *Offset - RangeStart;
+  if (*Offset + Size < RangeEnd)
+    FreeRanges[*Offset + Size] = RangeEnd - (*Offset + Size);
+
+  // Claim the chunks that the allocation touches for Owner.
+  for (uint64_t C = ChunkOf(*Offset), CE = ChunkOf(*Offset + Size - 1); C <= CE;
+       ++C)
+    ChunkOwners[C] = Owner;
+
+  ++NumLiveRanges;
+  return Offset;
+}
+
+void InProcessMemoryManager::Slab::free(uint64_t Offset, uint64_t Size) {
+  assert(Size && "Cannot free zero bytes");
+  assert(Offset + Size <= size() && "Freed range out of slab bounds");
+  assert(NumLiveRanges && "Freeing range from empty slab");
+
+  // Add the range to the free list, coalescing with its neighbors.
+  uint64_t Start = Offset, End = Offset + Size;
+  const auto Next = FreeRanges.upper_bound(Offset);
+  if (Next != FreeRanges.begin()) {
+    const auto Prev = std::prev(Next);
+    assert(Prev->first + Prev->second <= Offset &&
+           "Freed range overlaps existing free range");
+    if (Prev->first + Prev->second == Offset) {
+      Start = Prev->first;
+      FreeRanges.erase(Prev);
+    }
+  }
+  if (Next != FreeRanges.end() && Next->first == End) {
+    End = Next->first + Next->second;
+    FreeRanges.erase(Next);
+  }
+  FreeRanges[Start] = End - Start;
+
+  // Release any chunks that are now entirely free back to the slab so that
+  // they can be re-used by other AllocGroups.
+  for (uint64_t C = Offset / ChunkSize, CE = (Offset + Size - 1) / ChunkSize;
+       C <= CE; ++C) {
+    const uint64_t ChunkStart = C * ChunkSize;
+    const uint64_t ChunkEnd = std::min(ChunkStart + ChunkSize, size());
+    if (Start <= ChunkStart && ChunkEnd <= End)
+      ChunkOwners[C] = NoOwner;
+  }
+
+  --NumLiveRanges;
+}
+
+char *InProcessMemoryManager::SlabRange::base() const {
+  return S->base() + Offset;
+}
+
+/// Returns a unique index in the range [0, AllocGroup::NumGroups) for AG.
+static uint8_t allocGroupIndex(orc::AllocGroup AG) {
+  static_assert(orc::AllocGroup::NumGroups <=
+                    std::numeric_limits<uint8_t>::max(),
+                "AllocGroup indexes must fit in a uint8_t");
+  return static_cast<uint8_t>(static_cast<unsigned>(AG.getMemProt()) |
+                              static_cast<unsigned>(AG.getMemLifetime()) << 3);
+}
+
+static constexpr auto ReadWrite = static_cast<sys::Memory::ProtectionFlags>(
+    sys::Memory::MF_READ | sys::Memory::MF_WRITE);
+
+class InProcessMemoryManager::IPInFlightAlloc : public InFlightAlloc {
 public:
-  IPInFlightAlloc(InProcessMemoryManager &MemMgr, LinkGraph &G, BasicLayout BL,
-                  sys::MemoryBlock StandardSegments,
-                  sys::MemoryBlock FinalizationSegments)
-      : MemMgr(MemMgr), G(&G), BL(std::move(BL)),
-        StandardSegments(std::move(StandardSegments)),
-        FinalizationSegments(std::move(FinalizationSegments)) {}
+  IPInFlightAlloc(InProcessMemoryManager &MemMgr, LinkGraph &G,
+                  SlabRangeList Segments)
+      : MemMgr(MemMgr), G(&G), Segments(std::move(Segments)) {}
 
   ~IPInFlightAlloc() override {
     assert(!G && "InFlight alloc neither abandoned nor finalized");
@@ -266,9 +438,20 @@ public:
       return;
     }
 
-    // Release the finalize segments slab.
-    if (auto EC = sys::Memory::releaseMappedMemory(FinalizationSegments)) {
-      OnFinalized(errorCodeToError(EC));
+    // Split the segments by lifetime: the finalize-lifetime ones are done with
+    // now, the standard-lifetime ones live on in the finalized allocation.
+    SlabRangeList StandardSegs, FinalizeSegs;
+    for (auto &R : Segments) {
+      if (R.AG.getMemLifetime() == orc::MemLifetime::Standard)
+        StandardSegs.push_back(R);
+      else
+        FinalizeSegs.push_back(R);
+    }
+    Segments.clear();
+
+    if (auto Err = MemMgr.freeSegments(FinalizeSegs,
+                                       /*ResetProtections=*/true)) {
+      OnFinalized(std::move(Err));
       return;
     }
 
@@ -280,16 +463,15 @@ public:
 #endif
 
     // Continue with finalized allocation.
-    OnFinalized(MemMgr.createFinalizedAlloc(std::move(StandardSegments),
+    OnFinalized(MemMgr.createFinalizedAlloc(std::move(StandardSegs),
                                             std::move(*DeallocActions)));
   }
 
   void abandon(OnAbandonedFunction OnAbandoned) override {
-    Error Err = Error::success();
-    if (auto EC = sys::Memory::releaseMappedMemory(FinalizationSegments))
-      Err = joinErrors(std::move(Err), errorCodeToError(EC));
-    if (auto EC = sys::Memory::releaseMappedMemory(StandardSegments))
-      Err = joinErrors(std::move(Err), errorCodeToError(EC));
+    // Protections have not been applied yet, so the memory is still writable
+    // and can be returned to its slab as-is.
+    Error Err = MemMgr.freeSegments(Segments, /*ResetProtections=*/false);
+    Segments.clear();
 
 #ifndef NDEBUG
     // Set 'G' to null to flag that we've been successfully finalized.
@@ -303,15 +485,10 @@ public:
 
 private:
   Error applyProtections() {
-    for (auto &KV : BL.segments()) {
-      const auto &AG = KV.first;
-      auto &Seg = KV.second;
+    for (auto &R : Segments) {
+      auto Prot = toSysMemoryProtectionFlags(R.AG.getMemProt());
 
-      auto Prot = toSysMemoryProtectionFlags(AG.getMemProt());
-
-      uint64_t SegSize =
-          alignTo(Seg.ContentSize + Seg.ZeroFillSize, MemMgr.PageSize);
-      sys::MemoryBlock MB(Seg.WorkingMem, SegSize);
+      sys::MemoryBlock MB(R.base(), R.Size);
       if (auto EC = sys::Memory::protectMappedMemory(MB, Prot))
         return errorCodeToError(EC);
       if (Prot & sys::Memory::MF_EXEC)
@@ -322,16 +499,51 @@ private:
 
   InProcessMemoryManager &MemMgr;
   LinkGraph *G;
-  BasicLayout BL;
-  sys::MemoryBlock StandardSegments;
-  sys::MemoryBlock FinalizationSegments;
+  SlabRangeList Segments;
 };
+
+InProcessMemoryManager::SlabOptions
+InProcessMemoryManager::SlabOptions::defaults(uint64_t PageSize) {
+  SlabOptions SO;
+
+  // On 64-bit hosts we can afford to reserve address space generously. On
+  // 32-bit hosts we have to be much more frugal.
+  if constexpr (sizeof(uintptr_t) >= 8) {
+    SO.SlabSize = 16 * 1024 * 1024;
+    SO.ChunkSize = 256 * 1024;
+  } else {
+    SO.SlabSize = 4 * 1024 * 1024;
+    SO.ChunkSize = 64 * 1024;
+  }
+
+  // Chunks must be a whole number of pages, and slabs a whole number of
+  // chunks.
+  SO.ChunkSize = alignTo(std::max(SO.ChunkSize, PageSize), PageSize);
+  SO.SlabSize = alignTo(std::max(SO.SlabSize, SO.ChunkSize), SO.ChunkSize);
+
+  return SO;
+}
+
+InProcessMemoryManager::InProcessMemoryManager(uint64_t PageSize,
+                                               SlabOptions SO)
+    : PageSize(PageSize), SlabOpts(SO) {
+  assert(isPowerOf2_64(PageSize) && "PageSize must be a power of 2");
+  assert(SlabOpts.ChunkSize && SlabOpts.ChunkSize % PageSize == 0 &&
+         "ChunkSize must be a non-zero multiple of PageSize");
+  assert(SlabOpts.SlabSize && SlabOpts.SlabSize % SlabOpts.ChunkSize == 0 &&
+         "SlabSize must be a non-zero multiple of ChunkSize");
+}
+
+InProcessMemoryManager::~InProcessMemoryManager() {
+  for (const auto &S : Slabs)
+    (void)sys::Memory::releaseMappedMemory(S->Mem);
+}
 
 Expected<std::unique_ptr<InProcessMemoryManager>>
 InProcessMemoryManager::Create() {
   if (auto PageSize = sys::Process::getPageSize()) {
     // FIXME: Just check this once on startup.
-    if (!isPowerOf2_64((uint64_t)*PageSize))
+    if (!isPowerOf2_64(*PageSize))
       return make_error<StringError>(
           "Could not create InProcessMemoryManager: Page size " +
               Twine(*PageSize) + " is not a power of 2",
@@ -340,6 +552,184 @@ InProcessMemoryManager::Create() {
     return std::make_unique<InProcessMemoryManager>(*PageSize);
   } else
     return PageSize.takeError();
+}
+
+Expected<std::unique_ptr<InProcessMemoryManager>>
+InProcessMemoryManager::Create(SlabOptions SO) {
+  if (auto PageSize = sys::Process::getPageSize()) {
+    // FIXME: Just check this once on startup.
+    if (!isPowerOf2_64(*PageSize))
+      return make_error<StringError>(
+          "Could not create InProcessMemoryManager: Page size " +
+              Twine(*PageSize) + " is not a power of 2",
+          inconvertibleErrorCode());
+
+    if (!SO.ChunkSize || SO.ChunkSize % *PageSize)
+      return make_error<StringError>(
+          "Could not create InProcessMemoryManager: Chunk size " +
+              Twine(SO.ChunkSize) +
+              " is not a non-zero multiple of page size " + Twine(*PageSize),
+          inconvertibleErrorCode());
+
+    if (!SO.SlabSize || SO.SlabSize % SO.ChunkSize)
+      return make_error<StringError>(
+          "Could not create InProcessMemoryManager: Slab size " +
+              Twine(SO.SlabSize) +
+              " is not a non-zero multiple of chunk size " +
+              Twine(SO.ChunkSize),
+          inconvertibleErrorCode());
+
+    return std::make_unique<InProcessMemoryManager>(*PageSize, SO);
+  } else
+    return PageSize.takeError();
+}
+
+Expected<InProcessMemoryManager::Slab *>
+InProcessMemoryManager::createSlab(uint64_t MinSize) {
+  const uint64_t SlabSize =
+      alignTo(std::max(MinSize, SlabOpts.SlabSize), SlabOpts.ChunkSize);
+
+  // Hint that the new slab should be placed immediately after the previous
+  // one: keeping slabs close together improves locality, and gives the OS the
+  // chance to merge mappings with matching permissions across slab boundaries.
+  const sys::MemoryBlock *Near = Slabs.empty() ? nullptr : &Slabs.back()->Mem;
+
+  std::error_code EC;
+  auto MB = sys::Memory::allocateMappedMemory(SlabSize, Near, ReadWrite, EC);
+  if (EC)
+    return errorCodeToError(EC);
+
+  LLVM_DEBUG({
+    dbgs() << "InProcessMemoryManager reserved slab "
+           << formatv("[ {0:x16} -- {1:x16} ]",
+                      orc::ExecutorAddr::fromPtr(MB.base()),
+                      orc::ExecutorAddr::fromPtr(MB.base()) +
+                          MB.allocatedSize())
+           << "\n";
+  });
+
+  Slabs.push_back(std::make_unique<Slab>(MB, SlabOpts.ChunkSize));
+  return Slabs.back().get();
+}
+
+Expected<InProcessMemoryManager::SlabRangeList>
+InProcessMemoryManager::allocateSegments(BasicLayout &BL) {
+  // Work out the page-aligned size of each segment, along with the amount of
+  // slab space needed to hold all of them in the worst case, i.e. when no
+  // chunk can be shared with an existing allocation. BasicLayout guarantees at
+  // most one segment per AllocGroup, so this is just the sum of the segment
+  // sizes rounded up to chunk size.
+  SmallVector<std::pair<orc::AllocGroup, uint64_t>, 8> SegSizes;
+  uint64_t WorstCaseSize = 0;
+  for (auto &KV : BL.segments()) {
+    auto &Seg = KV.second;
+    // Zero-sized segments would still need somewhere to point, so round them
+    // up to a page like everything else.
+    uint64_t SegSize = std::max(
+        alignTo(Seg.ContentSize + Seg.ZeroFillSize, PageSize), PageSize);
+    SegSizes.push_back({KV.first, SegSize});
+    WorstCaseSize += alignTo(SegSize, SlabOpts.ChunkSize);
+  }
+
+  SlabRangeList Ranges;
+
+  {
+    std::lock_guard<std::mutex> Lock(SlabsMutex);
+
+    // Try to allocate every segment from S. All segments for a graph have to
+    // come from the same slab so that intra-graph references stay in range, so
+    // this either succeeds completely or leaves S untouched.
+    auto TryAllocFrom = [&](Slab &S) {
+      for (auto &[AG, SegSize] : SegSizes) {
+        // Grow executable memory up from the bottom of the slab and everything
+        // else down from the top, so that code stays contiguous.
+        bool FromTop =
+            (AG.getMemProt() & orc::MemProt::Exec) == orc::MemProt::None;
+        auto Offset = S.allocate(SegSize, allocGroupIndex(AG), FromTop);
+        if (!Offset) {
+          for (auto &R : Ranges)
+            S.free(R.Offset, R.Size);
+          Ranges.clear();
+          return false;
+        }
+        Ranges.push_back({&S, *Offset, SegSize, AG});
+      }
+      return true;
+    };
+
+    bool Allocated = false;
+    for (auto &S : Slabs)
+      if ((Allocated = TryAllocFrom(*S)))
+        break;
+
+    if (!Allocated) {
+      auto S = createSlab(WorstCaseSize);
+      if (!S)
+        return S.takeError();
+      // A fresh slab is at least WorstCaseSize bytes and has no chunks claimed
+      // yet, so this can't fail.
+      Allocated = TryAllocFrom(**S);
+      assert(Allocated && "Failed to allocate segments from fresh slab");
+      (void)Allocated;
+    }
+  }
+
+  // Zero the memory: slab memory may have been used by an earlier allocation,
+  // and both zero-fill blocks and inter-block padding are required to be zero.
+  for (auto &R : Ranges)
+    memset(R.base(), 0, R.Size);
+
+  LLVM_DEBUG({
+    dbgs() << "InProcessMemoryManager allocated:\n";
+    for (auto &R : Ranges)
+      dbgs() << formatv("  [ {0:x16} -- {1:x16} ]",
+                        orc::ExecutorAddr::fromPtr(R.base()),
+                        orc::ExecutorAddr::fromPtr(R.base()) + R.Size)
+             << " to " << R.AG << " segment\n";
+  });
+
+  return Ranges;
+}
+
+Error InProcessMemoryManager::freeSegments(MutableArrayRef<SlabRange> Ranges,
+                                           bool ResetProtections) {
+  Error Err = Error::success();
+
+  SmallVector<SlabRange *, 4> ToFree;
+  for (auto &R : Ranges) {
+    // Restore read/write permissions so that the memory can be written to by
+    // whichever allocation picks it up next. If that fails we can't safely
+    // hand this range out again, so leave it allocated (which also stops its
+    // slab from being released).
+    if (ResetProtections &&
+        R.AG.getMemProt() != (orc::MemProt::Read | orc::MemProt::Write)) {
+      sys::MemoryBlock MB(R.base(), R.Size);
+      if (const auto EC = sys::Memory::protectMappedMemory(MB, ReadWrite)) {
+        Err = joinErrors(std::move(Err), errorCodeToError(EC));
+        continue;
+      }
+    }
+    ToFree.push_back(&R);
+  }
+
+  std::lock_guard<std::mutex> Lock(SlabsMutex);
+
+  for (const auto *R : ToFree)
+    R->S->free(R->Offset, R->Size);
+
+  // Return fully-freed slabs to the OS, keeping one around to absorb the
+  // common allocate / deallocate / allocate pattern without re-reserving.
+  for (auto I = Slabs.begin(); I != Slabs.end() && Slabs.size() > 1;) {
+    if ((*I)->NumLiveRanges == 0) {
+      if (const auto EC = sys::Memory::releaseMappedMemory((*I)->Mem))
+        Err = joinErrors(std::move(Err), errorCodeToError(EC));
+      I = Slabs.erase(I);
+    } else {
+      ++I;
+    }
+  }
+
+  return Err;
 }
 
 void InProcessMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
@@ -363,87 +753,38 @@ void InProcessMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
     return;
   }
 
-  // Allocate one slab for the whole thing (to make sure everything is
-  // in-range), then partition into standard and finalization blocks.
-  //
-  // FIXME: Make two separate allocations in the future to reduce
-  // fragmentation: finalization segments will usually be a single page, and
-  // standard segments are likely to be more than one page. Where multiple
-  // allocations are in-flight at once (likely) the current approach will leave
-  // a lot of single-page holes.
-  sys::MemoryBlock Slab;
-  sys::MemoryBlock StandardSegsMem;
-  sys::MemoryBlock FinalizeSegsMem;
-  {
-    const sys::Memory::ProtectionFlags ReadWrite =
-        static_cast<sys::Memory::ProtectionFlags>(sys::Memory::MF_READ |
-                                                  sys::Memory::MF_WRITE);
-
-    std::error_code EC;
-    Slab = sys::Memory::allocateMappedMemory(SegsSizes->total(), nullptr,
-                                             ReadWrite, EC);
-
-    if (EC) {
-      OnAllocated(errorCodeToError(EC));
-      return;
-    }
-
-    // Zero-fill the whole slab up-front.
-    memset(Slab.base(), 0, Slab.allocatedSize());
-
-    StandardSegsMem = {Slab.base(),
-                       static_cast<size_t>(SegsSizes->StandardSegs)};
-    FinalizeSegsMem = {(void *)((char *)Slab.base() + SegsSizes->StandardSegs),
-                       static_cast<size_t>(SegsSizes->FinalizeSegs)};
+  auto Segments = allocateSegments(BL);
+  if (!Segments) {
+    OnAllocated(Segments.takeError());
+    return;
   }
 
-  auto NextStandardSegAddr = orc::ExecutorAddr::fromPtr(StandardSegsMem.base());
-  auto NextFinalizeSegAddr = orc::ExecutorAddr::fromPtr(FinalizeSegsMem.base());
-
-  LLVM_DEBUG({
-    dbgs() << "InProcessMemoryManager allocated:\n";
-    if (SegsSizes->StandardSegs)
-      dbgs() << formatv("  [ {0:x16} -- {1:x16} ]", NextStandardSegAddr,
-                        NextStandardSegAddr + StandardSegsMem.allocatedSize())
-             << " to stardard segs\n";
-    else
-      dbgs() << "  no standard segs\n";
-    if (SegsSizes->FinalizeSegs)
-      dbgs() << formatv("  [ {0:x16} -- {1:x16} ]", NextFinalizeSegAddr,
-                        NextFinalizeSegAddr + FinalizeSegsMem.allocatedSize())
-             << " to finalize segs\n";
-    else
-      dbgs() << "  no finalize segs\n";
-  });
-
-  // Build ProtMap, assign addresses.
+  // Assign addresses and working memory to the segments. allocateSegments
+  // produces one range per segment, in segment iteration order.
+  unsigned Idx = 0;
   for (auto &KV : BL.segments()) {
-    auto &AG = KV.first;
-    auto &Seg = KV.second;
-
-    auto &SegAddr = (AG.getMemLifetime() == orc::MemLifetime::Standard)
-                        ? NextStandardSegAddr
-                        : NextFinalizeSegAddr;
-
-    Seg.WorkingMem = SegAddr.toPtr<char *>();
-    Seg.Addr = SegAddr;
-
-    SegAddr += alignTo(Seg.ContentSize + Seg.ZeroFillSize, PageSize);
+    auto &R = (*Segments)[Idx++];
+    assert(KV.first == R.AG && "Segment / range mismatch");
+    KV.second.WorkingMem = R.base();
+    KV.second.Addr = orc::ExecutorAddr::fromPtr(R.base());
   }
 
   if (auto Err = BL.apply()) {
+    // Roll the allocation back: protections haven't been applied yet, so the
+    // segments can go straight back to their slab.
+    Err = joinErrors(std::move(Err),
+                     freeSegments(*Segments, /*ResetProtections=*/false));
     OnAllocated(std::move(Err));
     return;
   }
 
-  OnAllocated(std::make_unique<IPInFlightAlloc>(*this, G, std::move(BL),
-                                                std::move(StandardSegsMem),
-                                                std::move(FinalizeSegsMem)));
+  OnAllocated(
+      std::make_unique<IPInFlightAlloc>(*this, G, std::move(*Segments)));
 }
 
 void InProcessMemoryManager::deallocate(std::vector<FinalizedAlloc> Allocs,
                                         OnDeallocatedFunction OnDeallocated) {
-  std::vector<sys::MemoryBlock> StandardSegmentsList;
+  std::vector<SlabRangeList> StandardSegmentsList;
   std::vector<std::vector<orc::shared::WrapperFunctionCall>> DeallocActionsList;
 
   {
@@ -470,9 +811,9 @@ void InProcessMemoryManager::deallocate(std::vector<FinalizedAlloc> Allocs,
       DeallocActions.pop_back();
     }
 
-    /// Release the standard segments slab.
-    if (auto EC = sys::Memory::releaseMappedMemory(StandardSegments))
-      DeallocErr = joinErrors(std::move(DeallocErr), errorCodeToError(EC));
+    /// Return the standard segments to their slab.
+    if (auto Err = freeSegments(StandardSegments, /*ResetProtections=*/true))
+      DeallocErr = joinErrors(std::move(DeallocErr), std::move(Err));
 
     DeallocActionsList.pop_back();
     StandardSegmentsList.pop_back();
@@ -483,7 +824,7 @@ void InProcessMemoryManager::deallocate(std::vector<FinalizedAlloc> Allocs,
 
 JITLinkMemoryManager::FinalizedAlloc
 InProcessMemoryManager::createFinalizedAlloc(
-    sys::MemoryBlock StandardSegments,
+    SlabRangeList StandardSegments,
     std::vector<orc::shared::WrapperFunctionCall> DeallocActions) {
   std::lock_guard<std::mutex> Lock(FinalizedAllocsMutex);
   auto *FA = FinalizedAllocInfos.Allocate<FinalizedAllocInfo>();

--- a/llvm/lib/ExecutionEngine/JITLink/JITLinkMemoryManager.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/JITLinkMemoryManager.cpp
@@ -541,16 +541,9 @@ InProcessMemoryManager::~InProcessMemoryManager() {
 
 Expected<std::unique_ptr<InProcessMemoryManager>>
 InProcessMemoryManager::Create() {
-  if (auto PageSize = sys::Process::getPageSize()) {
-    // FIXME: Just check this once on startup.
-    if (!isPowerOf2_64(*PageSize))
-      return make_error<StringError>(
-          "Could not create InProcessMemoryManager: Page size " +
-              Twine(*PageSize) + " is not a power of 2",
-          inconvertibleErrorCode());
-
-    return std::make_unique<InProcessMemoryManager>(*PageSize);
-  } else
+  if (auto PageSize = sys::Process::getPageSize())
+    return Create(SlabOptions::defaults(*PageSize));
+  else
     return PageSize.takeError();
 }
 

--- a/llvm/unittests/ExecutionEngine/JITLink/CMakeLists.txt
+++ b/llvm/unittests/ExecutionEngine/JITLink/CMakeLists.txt
@@ -13,6 +13,7 @@ add_llvm_unittest(JITLinkTests
     AArch64Tests.cpp
     COFFLinkGraphTests.cpp
     EHFrameSupportTests.cpp
+    InProcessMemoryManagerTest.cpp
     JITLinkDylibTest.cpp
     JITLinkTestUtils.cpp
     LinkGraphTests.cpp

--- a/llvm/unittests/ExecutionEngine/JITLink/InProcessMemoryManagerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/JITLink/InProcessMemoryManagerTest.cpp
@@ -1,0 +1,437 @@
+//===------ InProcessMemoryManagerTest.cpp - Test the default mem mgr -----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ExecutionEngine/JITLink/JITLink.h"
+#include "llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/MathExtras.h"
+#include "llvm/Support/Process.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include "llvm/Testing/Support/Error.h"
+#include "gtest/gtest.h"
+
+#include <random>
+
+using namespace llvm;
+using namespace llvm::jitlink;
+
+namespace {
+
+struct SegSpec {
+  orc::MemProt Prot;
+  orc::MemLifetime Lifetime = orc::MemLifetime::Standard;
+  size_t ContentSize = 1;
+  size_t ZeroFillSize = 0;
+};
+
+/// Create a LinkGraph with one section (holding one block per non-zero size in
+/// the spec) per SegSpec.
+std::unique_ptr<LinkGraph> makeGraph(const Twine &Name,
+                                     ArrayRef<SegSpec> Specs) {
+  auto G = std::make_unique<LinkGraph>(
+      Name.str(), std::make_shared<orc::SymbolStringPool>(),
+      Triple("x86_64-unknown-linux-gnu"), SubtargetFeatures(),
+      getGenericEdgeKindName);
+
+  orc::ExecutorAddr NextAddr(0x1000);
+  unsigned SecIdx = 0;
+  for (auto &Spec : Specs) {
+    auto &Sec = G->createSection(("sec." + Twine(SecIdx++)).str(), Spec.Prot);
+    Sec.setMemLifetime(Spec.Lifetime);
+    if (Spec.ContentSize) {
+      G->createMutableContentBlock(Sec, Spec.ContentSize, NextAddr, 1, 0);
+      NextAddr += Spec.ContentSize;
+    }
+    if (Spec.ZeroFillSize) {
+      G->createZeroFillBlock(Sec, Spec.ZeroFillSize, NextAddr, 1, 0);
+      NextAddr += Spec.ZeroFillSize;
+    }
+  }
+
+  return G;
+}
+
+/// The address range that a section was assigned by the memory manager, and
+/// the AllocGroup that it belongs to.
+struct SegPlacement {
+  orc::AllocGroup AG;
+  orc::ExecutorAddr Addr;
+  uint64_t Size = 0;
+};
+
+std::vector<SegPlacement> getPlacements(LinkGraph &G) {
+  std::vector<SegPlacement> Placements;
+  for (auto &Sec : G.sections()) {
+    orc::ExecutorAddr Start(~static_cast<uint64_t>(0)), End(0);
+    for (const auto *B : Sec.blocks()) {
+      Start = std::min(Start, B->getAddress());
+      End = std::max(End, B->getRange().End);
+    }
+    Placements.push_back(
+        {{Sec.getMemProt(), Sec.getMemLifetime()}, Start, End - Start});
+  }
+  return Placements;
+}
+
+std::string toString(orc::AllocGroup AG) {
+  std::string S;
+  raw_string_ostream(S) << AG;
+  return S;
+}
+
+/// Returns the lowest address assigned to any of G's blocks. For graphs with a
+/// single segment this is the base of that segment.
+orc::ExecutorAddr getLowestBlockAddr(LinkGraph &G) {
+  orc::ExecutorAddr Lowest(~static_cast<uint64_t>(0));
+  for (const auto *B : G.blocks())
+    Lowest = std::min(Lowest, B->getAddress());
+  return Lowest;
+}
+
+/// Returns the address range spanned by all of G's segments.
+orc::ExecutorAddrRange getSpan(LinkGraph &G) {
+  orc::ExecutorAddr Lowest(~static_cast<uint64_t>(0)), Highest(0);
+  for (auto &P : getPlacements(G)) {
+    Lowest = std::min(Lowest, P.Addr);
+    Highest = std::max(Highest, P.Addr + P.Size);
+  }
+  return {Lowest, Highest};
+}
+
+class InProcessMemoryManagerTest : public testing::Test {
+protected:
+  void SetUp() override {
+    auto PS = sys::Process::getPageSize();
+    ASSERT_THAT_EXPECTED(PS, Succeeded());
+    PageSize = *PS;
+    ChunkSize = 4 * PageSize;
+    SlabSize = 64 * ChunkSize;
+
+    auto MM = InProcessMemoryManager::Create({SlabSize, ChunkSize});
+    ASSERT_THAT_EXPECTED(MM, Succeeded());
+    MemMgr = std::move(*MM);
+  }
+
+  void TearDown() override {
+    if (!FinalizedAllocs.empty())
+      EXPECT_THAT_ERROR(MemMgr->deallocate(std::move(FinalizedAllocs)),
+                        Succeeded());
+  }
+
+  /// Allocate and finalize G, keeping the resulting allocation alive until the
+  /// end of the test.
+  void allocateAndFinalize(LinkGraph &G) {
+    auto Alloc = MemMgr->allocate(nullptr, G);
+    ASSERT_THAT_EXPECTED(Alloc, Succeeded());
+    auto FA = (*Alloc)->finalize();
+    ASSERT_THAT_EXPECTED(FA, Succeeded());
+    FinalizedAllocs.push_back(std::move(*FA));
+  }
+
+  /// Link NumGraphs graphs, each with an R-X, an R-- and an RW- segment of one
+  /// page each, and return the placements of all their segments.
+  std::vector<SegPlacement> linkRXROAndRWGraphs(unsigned NumGraphs) {
+    std::vector<SegPlacement> Placements;
+    for (unsigned I = 0; I != NumGraphs; ++I) {
+      auto G = makeGraph("g" + Twine(I),
+                         {{orc::MemProt::Read | orc::MemProt::Exec},
+                          {orc::MemProt::Read},
+                          {orc::MemProt::Read | orc::MemProt::Write}});
+      allocateAndFinalize(*G);
+      append_range(Placements, getPlacements(*G));
+      Graphs.push_back(std::move(G));
+    }
+    return Placements;
+  }
+
+  uint64_t PageSize = 0;
+  uint64_t ChunkSize = 0;
+  uint64_t SlabSize = 0;
+  std::unique_ptr<InProcessMemoryManager> MemMgr;
+  std::vector<std::unique_ptr<LinkGraph>> Graphs;
+  std::vector<JITLinkMemoryManager::FinalizedAlloc> FinalizedAllocs;
+};
+
+TEST_F(InProcessMemoryManagerTest, ChunksAreNotSharedBetweenAllocGroups) {
+  // Link a batch of graphs whose segments would interleave permissions if they
+  // were laid out one graph at a time, then check that each chunk of the slab
+  // only ever holds segments from a single AllocGroup.
+  constexpr unsigned NumGraphs = 32;
+  auto Placements = linkRXROAndRWGraphs(NumGraphs);
+  ASSERT_EQ(Placements.size(), 3 * NumGraphs);
+
+  // Each graph asked for three single-page segments, so everything should have
+  // fit in one slab. Since executable memory is allocated from the bottom of
+  // the slab, the lowest address handed out is the slab's base.
+  orc::ExecutorAddr SlabBase(~static_cast<uint64_t>(0));
+  for (auto &P : Placements)
+    SlabBase = std::min(SlabBase, P.Addr);
+
+  DenseMap<uint64_t, orc::AllocGroup> ChunkGroups;
+  for (auto &P : Placements) {
+    ASSERT_GE(P.Addr, SlabBase);
+    ASSERT_LE(P.Addr + P.Size, SlabBase + SlabSize)
+        << "Segments spread over more than one slab";
+
+    const uint64_t FirstChunk = (P.Addr - SlabBase) / ChunkSize;
+    const uint64_t LastChunk = (P.Addr + P.Size - 1 - SlabBase) / ChunkSize;
+    for (uint64_t C = FirstChunk; C <= LastChunk; ++C) {
+      auto [I, Inserted] = ChunkGroups.try_emplace(C, P.AG);
+      EXPECT_TRUE(Inserted || I->second == P.AG)
+          << "Chunk " << C << " shared by " << toString(I->second) << " and "
+          << toString(P.AG);
+    }
+  }
+}
+
+TEST_F(InProcessMemoryManagerTest, ExecutableMemoryIsPackedAtTheBottom) {
+  // Executable segments are allocated from the bottom of the slab and
+  // everything else from the top, so no non-executable segment should ever end
+  // up below an executable one.
+  constexpr unsigned NumGraphs = 32;
+  const auto Placements = linkRXROAndRWGraphs(NumGraphs);
+
+  orc::ExecutorAddr LowestExec(~static_cast<uint64_t>(0)), HighestExec(0);
+  orc::ExecutorAddr LowestNonExec(~static_cast<uint64_t>(0));
+  for (auto &P : Placements) {
+    if ((P.AG.getMemProt() & orc::MemProt::Exec) != orc::MemProt::None) {
+      LowestExec = std::min(LowestExec, P.Addr);
+      HighestExec = std::max(HighestExec, P.Addr + P.Size);
+    } else
+      LowestNonExec = std::min(LowestNonExec, P.Addr);
+  }
+
+  EXPECT_LE(HighestExec, LowestNonExec)
+      << "Executable and non-executable memory are interleaved";
+
+  // The executable segments were one page each, so they should be packed into
+  // the smallest number of chunks that can hold them.
+  EXPECT_LE(HighestExec - LowestExec,
+            divideCeil(NumGraphs * PageSize, ChunkSize) * ChunkSize)
+      << "Executable memory is not densely packed";
+}
+
+TEST_F(InProcessMemoryManagerTest, SegmentsForOneGraphShareASlab) {
+  // Force many slabs to be created by linking graphs that are large relative
+  // to the slab size, and check that the segments of any one graph always stay
+  // within a slab's worth of address space of each other: intra-graph
+  // references have to stay in range of one another.
+  constexpr unsigned NumGraphs = 8;
+  const size_t SegSize = SlabSize / 8;
+
+  for (unsigned I = 0; I != NumGraphs; ++I) {
+    auto G =
+        makeGraph("g" + Twine(I),
+                  {{orc::MemProt::Read | orc::MemProt::Exec,
+                    orc::MemLifetime::Standard, SegSize},
+                   {orc::MemProt::Read, orc::MemLifetime::Standard, SegSize},
+                   {orc::MemProt::Read | orc::MemProt::Write,
+                    orc::MemLifetime::Standard, SegSize}});
+    allocateAndFinalize(*G);
+
+    auto Span = getSpan(*G);
+    EXPECT_LE(Span.size(), SlabSize)
+        << "Segments of graph " << I << " span more than one slab";
+
+    Graphs.push_back(std::move(G));
+  }
+}
+
+TEST_F(InProcessMemoryManagerTest, FreedMemoryIsReusedAndZeroed) {
+  // Check that memory returned by deallocate is handed out again, and that it
+  // is writable and zeroed when it is.
+  auto G1 = makeGraph("g1", {{orc::MemProt::Read | orc::MemProt::Exec,
+                              orc::MemLifetime::Standard, PageSize}});
+  auto Alloc1 = MemMgr->allocate(nullptr, *G1);
+  ASSERT_THAT_EXPECTED(Alloc1, Succeeded());
+
+  orc::ExecutorAddr Addr1 = getLowestBlockAddr(*G1);
+
+  // Dirty the whole page before finalizing (memory is still writable at this
+  // point) so that we can tell whether it is zeroed on re-use.
+  memset(Addr1.toPtr<char *>(), 0xAA, PageSize);
+
+  auto FA1 = (*Alloc1)->finalize();
+  ASSERT_THAT_EXPECTED(FA1, Succeeded());
+  EXPECT_THAT_ERROR(MemMgr->deallocate(std::move(*FA1)), Succeeded());
+
+  // The same AllocGroup should get the same memory back.
+  auto G2 = makeGraph("g2", {{orc::MemProt::Read | orc::MemProt::Exec,
+                              orc::MemLifetime::Standard, 1, PageSize - 1}});
+  auto Alloc2 = MemMgr->allocate(nullptr, *G2);
+  ASSERT_THAT_EXPECTED(Alloc2, Succeeded());
+
+  ASSERT_EQ(getLowestBlockAddr(*G2), Addr1) << "Freed memory was not reused";
+
+  // Re-used memory must be writable again (protections are reset on free) and
+  // zeroed, so that zero-fill blocks really do read as zero.
+  auto *Mem = Addr1.toPtr<char *>();
+  Mem[0] = 42;
+  for (uint64_t I = 1; I != PageSize; ++I)
+    ASSERT_EQ(Mem[I], 0) << "Re-used memory was not zeroed at offset " << I;
+
+  auto FA2 = (*Alloc2)->finalize();
+  ASSERT_THAT_EXPECTED(FA2, Succeeded());
+  EXPECT_THAT_ERROR(MemMgr->deallocate(std::move(*FA2)), Succeeded());
+}
+
+TEST_F(InProcessMemoryManagerTest, FinalizeLifetimeSegmentsAreFreedOnFinalize) {
+  // Finalize-lifetime segments should be returned to their slab as soon as the
+  // allocation is finalized, so that the memory can be handed straight back
+  // out to the next allocation.
+  auto G1 = makeGraph("g1", {{orc::MemProt::Read | orc::MemProt::Write,
+                              orc::MemLifetime::Finalize}});
+  auto Alloc1 = MemMgr->allocate(nullptr, *G1);
+  ASSERT_THAT_EXPECTED(Alloc1, Succeeded());
+  orc::ExecutorAddr FinalizeSegAddr = getLowestBlockAddr(*G1);
+  auto FA1 = (*Alloc1)->finalize();
+  ASSERT_THAT_EXPECTED(FA1, Succeeded());
+
+  auto G2 = makeGraph("g2", {{orc::MemProt::Read | orc::MemProt::Write,
+                              orc::MemLifetime::Finalize}});
+  auto Alloc2 = MemMgr->allocate(nullptr, *G2);
+  ASSERT_THAT_EXPECTED(Alloc2, Succeeded());
+  EXPECT_EQ(getLowestBlockAddr(*G2), FinalizeSegAddr)
+      << "Finalize-lifetime memory was not released on finalize";
+
+  auto FA2 = (*Alloc2)->finalize();
+  ASSERT_THAT_EXPECTED(FA2, Succeeded());
+
+  std::vector<JITLinkMemoryManager::FinalizedAlloc> Allocs;
+  Allocs.push_back(std::move(*FA1));
+  Allocs.push_back(std::move(*FA2));
+  EXPECT_THAT_ERROR(MemMgr->deallocate(std::move(Allocs)), Succeeded());
+}
+
+TEST_F(InProcessMemoryManagerTest, AbandonReturnsMemoryToSlab) {
+  const auto G1 = makeGraph("g1", {{orc::MemProt::Read | orc::MemProt::Write}});
+  auto Alloc1 = MemMgr->allocate(nullptr, *G1);
+  ASSERT_THAT_EXPECTED(Alloc1, Succeeded());
+  const orc::ExecutorAddr Addr1 = getLowestBlockAddr(*G1);
+
+  std::promise<MSVCPError> P;
+  auto F = P.get_future();
+  (*Alloc1)->abandon([&](Error Err) { P.set_value(std::move(Err)); });
+  EXPECT_THAT_ERROR(F.get(), Succeeded());
+
+  const auto G2 = makeGraph("g2", {{orc::MemProt::Read | orc::MemProt::Write}});
+  auto Alloc2 = MemMgr->allocate(nullptr, *G2);
+  ASSERT_THAT_EXPECTED(Alloc2, Succeeded());
+  EXPECT_EQ(getLowestBlockAddr(*G2), Addr1)
+      << "Abandoned memory was not returned to its slab";
+
+  auto FA2 = (*Alloc2)->finalize();
+  ASSERT_THAT_EXPECTED(FA2, Succeeded());
+  EXPECT_THAT_ERROR(MemMgr->deallocate(std::move(*FA2)), Succeeded());
+}
+
+TEST_F(InProcessMemoryManagerTest, OversizedGraphGetsItsOwnSlab) {
+  // Graphs that are too big for a default-sized slab should still be linkable.
+  const auto G = makeGraph("g", {{orc::MemProt::Read | orc::MemProt::Exec,
+                                  orc::MemLifetime::Standard, SlabSize},
+                                 {orc::MemProt::Read | orc::MemProt::Write,
+                                  orc::MemLifetime::Standard, SlabSize}});
+  allocateAndFinalize(*G);
+  EXPECT_GE(getSpan(*G).size(), 2 * SlabSize);
+}
+
+TEST_F(InProcessMemoryManagerTest, RandomAllocateAndDeallocate) {
+  // Exercise the slab free lists with a randomized allocate / deallocate
+  // workload, checking that live segments never overlap one another and that
+  // memory handed out is always writable and zeroed.
+  constexpr unsigned NumOps = 512;
+  std::minstd_rand Rng(42);
+
+  struct LiveAlloc {
+    JITLinkMemoryManager::FinalizedAlloc FA;
+    std::vector<SegPlacement> Segs;
+  };
+  std::vector<LiveAlloc> Live;
+
+  auto Overlaps = [](const SegPlacement &A, const SegPlacement &B) {
+    return A.Addr < B.Addr + B.Size && B.Addr < A.Addr + A.Size;
+  };
+
+  for (unsigned Op = 0; Op != NumOps; ++Op) {
+    // Deallocate roughly a third of the time, once there's something to free.
+    if (!Live.empty() && Rng() % 3 == 0) {
+      unsigned Idx = Rng() % Live.size();
+      std::swap(Live[Idx], Live.back());
+      ASSERT_THAT_ERROR(MemMgr->deallocate(std::move(Live.back().FA)),
+                        Succeeded());
+      Live.pop_back();
+      continue;
+    }
+
+    // Build a graph with a random subset of segments at random sizes.
+    SmallVector<SegSpec, 4> Specs;
+    for (auto Prot :
+         {orc::MemProt::Read | orc::MemProt::Exec, orc::MemProt::Read,
+          orc::MemProt::Read | orc::MemProt::Write})
+      if (Rng() % 2)
+        Specs.push_back(
+            {Prot, orc::MemLifetime::Standard, 1 + Rng() % (4 * PageSize)});
+    if (Specs.empty())
+      Specs.push_back({orc::MemProt::Read | orc::MemProt::Write});
+    if (Rng() % 4 == 0)
+      Specs.push_back({orc::MemProt::Read | orc::MemProt::Write,
+                       orc::MemLifetime::Finalize, 1 + Rng() % PageSize});
+
+    auto G = makeGraph("g" + Twine(Op), Specs);
+    auto Alloc = MemMgr->allocate(nullptr, *G);
+    ASSERT_THAT_EXPECTED(Alloc, Succeeded());
+
+    // Every byte handed out should be zero, and writable.
+    for (auto &P : getPlacements(*G)) {
+      auto *Mem = P.Addr.toPtr<char *>();
+      for (uint64_t I = 0; I != P.Size; ++I)
+        ASSERT_EQ(Mem[I], 0) << "Memory was not zeroed on allocation";
+      memset(Mem, 0xAA, P.Size);
+    }
+
+    auto FA = (*Alloc)->finalize();
+    ASSERT_THAT_EXPECTED(FA, Succeeded());
+
+    // Only standard-lifetime segments are still live after finalization.
+    std::vector<SegPlacement> Segs;
+    for (auto &P : getPlacements(*G))
+      if (P.AG.getMemLifetime() == orc::MemLifetime::Standard)
+        Segs.push_back(P);
+
+    for (auto &Other : Live)
+      for (auto &A : Other.Segs)
+        for (auto &B : Segs)
+          ASSERT_FALSE(Overlaps(A, B))
+              << "Live segments overlap at " << A.Addr.getValue() << " and "
+              << B.Addr.getValue();
+
+    Live.push_back({std::move(*FA), std::move(Segs)});
+    Graphs.push_back(std::move(G));
+  }
+
+  std::vector<JITLinkMemoryManager::FinalizedAlloc> Remaining;
+  for (auto &L : Live)
+    Remaining.push_back(std::move(L.FA));
+  EXPECT_THAT_ERROR(MemMgr->deallocate(std::move(Remaining)), Succeeded());
+}
+
+TEST_F(InProcessMemoryManagerTest, DefaultSlabOptionsAreConsistent) {
+  auto PS = sys::Process::getPageSize();
+  ASSERT_THAT_EXPECTED(PS, Succeeded());
+
+  auto SO = InProcessMemoryManager::SlabOptions::defaults(*PS);
+  EXPECT_GT(SO.ChunkSize, 0U);
+  EXPECT_EQ(SO.ChunkSize % *PS, 0U);
+  EXPECT_EQ(SO.SlabSize % SO.ChunkSize, 0U);
+  EXPECT_GE(SO.SlabSize, SO.ChunkSize);
+}
+
+} // namespace

--- a/llvm/unittests/ExecutionEngine/JITLink/InProcessMemoryManagerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/JITLink/InProcessMemoryManagerTest.cpp
@@ -114,8 +114,10 @@ protected:
     PageSize = *PS;
     ChunkSize = 4 * PageSize;
     SlabSize = 64 * ChunkSize;
+    ReservationSize = 128 * SlabSize;
 
-    auto MM = InProcessMemoryManager::Create({SlabSize, ChunkSize});
+    auto MM =
+        InProcessMemoryManager::Create({SlabSize, ChunkSize, ReservationSize});
     ASSERT_THAT_EXPECTED(MM, Succeeded());
     MemMgr = std::move(*MM);
   }
@@ -155,6 +157,7 @@ protected:
   uint64_t PageSize = 0;
   uint64_t ChunkSize = 0;
   uint64_t SlabSize = 0;
+  uint64_t ReservationSize = 0;
   std::unique_ptr<InProcessMemoryManager> MemMgr;
   std::vector<std::unique_ptr<LinkGraph>> Graphs;
   std::vector<JITLinkMemoryManager::FinalizedAlloc> FinalizedAllocs;
@@ -343,6 +346,49 @@ TEST_F(InProcessMemoryManagerTest, OversizedGraphGetsItsOwnSlab) {
   EXPECT_GE(getSpan(*G).size(), 2 * SlabSize);
 }
 
+TEST_F(InProcessMemoryManagerTest, AllAllocationsStayWithinTheReservation) {
+  // Force lots of slab churn -- allocate an oversized graph (so it needs a
+  // fresh slab of its own) and free it immediately, many times over -- and
+  // check that every address ever handed out stays within ReservationSize of
+  // the very first one. All slabs are carved out of one fixed reservation
+  // (see the class comment on InProcessMemoryManager), so this is a
+  // deterministic guarantee of the allocator itself: unlike relying on the OS
+  // to honor a placement hint for separate mappings, it can't drift.
+  auto G0 = makeGraph("g0", {{orc::MemProt::Read | orc::MemProt::Write}});
+  allocateAndFinalize(*G0);
+  const orc::ExecutorAddr FirstAddr = getLowestBlockAddr(*G0);
+
+  orc::ExecutorAddr Lowest = FirstAddr, Highest = FirstAddr;
+  constexpr unsigned NumCycles = 64;
+  for (unsigned I = 0; I != NumCycles; ++I) {
+    auto G = makeGraph("churn" + Twine(I),
+                       {{orc::MemProt::Read | orc::MemProt::Write,
+                         orc::MemLifetime::Standard, SlabSize}});
+    auto Alloc = MemMgr->allocate(nullptr, *G);
+    ASSERT_THAT_EXPECTED(Alloc, Succeeded());
+    auto Span = getSpan(*G);
+    Lowest = std::min(Lowest, Span.Start);
+    Highest = std::max(Highest, Span.End);
+    auto FA = (*Alloc)->finalize();
+    ASSERT_THAT_EXPECTED(FA, Succeeded());
+    EXPECT_THAT_ERROR(MemMgr->deallocate(std::move(*FA)), Succeeded());
+  }
+
+  EXPECT_LE((Highest - Lowest), ReservationSize)
+      << "Allocations spread further than the reservation is wide";
+}
+
+TEST_F(InProcessMemoryManagerTest, ReservationExhaustionFails) {
+  // A single graph that needs more room than the whole reservation should
+  // fail cleanly rather than falling back to a separate, unbounded mapping
+  // (which would defeat the point of the reservation).
+  auto G = makeGraph(
+      "g", {{orc::MemProt::Read | orc::MemProt::Write,
+             orc::MemLifetime::Standard, ReservationSize + SlabSize}});
+  auto Alloc = MemMgr->allocate(nullptr, *G);
+  ASSERT_THAT_EXPECTED(Alloc, Failed());
+}
+
 TEST_F(InProcessMemoryManagerTest, RandomAllocateAndDeallocate) {
   // Exercise the slab free lists with a randomized allocate / deallocate
   // workload, checking that live segments never overlap one another and that
@@ -432,6 +478,12 @@ TEST_F(InProcessMemoryManagerTest, DefaultSlabOptionsAreConsistent) {
   EXPECT_EQ(SO.ChunkSize % *PS, 0U);
   EXPECT_EQ(SO.SlabSize % SO.ChunkSize, 0U);
   EXPECT_GE(SO.SlabSize, SO.ChunkSize);
+  EXPECT_EQ(SO.ReservationSize % SO.SlabSize, 0U);
+  EXPECT_GE(SO.ReservationSize, SO.SlabSize);
+  // Comfortably under the 2^32 budget some platforms need every piece of
+  // code a session ever JITs to stay within (see the class comment on
+  // InProcessMemoryManager).
+  EXPECT_LT(SO.ReservationSize, 1ULL << 32);
 }
 
 } // namespace


### PR DESCRIPTION
InProcessMemoryManager allocated one slab per LinkGraph and laid the graph's segments out contiguously within it. Across a session with many objects that produces a layout where permissions interleave at segment granularity:

```
  |R--|R-X|RW-|R--|R-X|RW-|R--|R-X|RW-|...
   \_________/ \_________/ \_________/
     Object #1   Object #2   Object #3
```

Since each segment needs its own mapping, the number of mappings (and the size of the OS page tables backing them) grows linearly with the number of objects linked.

Allocate from slabs that are striped between AllocGroups at chunk granularity instead. Each chunk of a slab is only ever handed out to a single AllocGroup, so segments with matching permissions end up next to one another and the OS can coalesce their mappings:

```
  |R-X|R-X|R-X|...|R--|RW-|R--|R--|RW-|...
```

Executable segments are allocated from the bottom of each slab and everything else from the top, so executable memory stays contiguous while read-only and read-write data stripe among themselves in the upper part of the slab.

All segments for a single LinkGraph are still allocated from one slab, so the slab size continues to bound the distance between any two blocks in a graph -- intra-graph references that JITLink fixes up without indirection (e.g. 32-bit PC-relative references from code to read-only data) stay in range. Slab and chunk sizes are configurable via a new SlabOptions parameter; the defaults are 16MB slabs striped at 256KB on 64-bit hosts.

Freed segments are returned to their slab's free list (with read/write permissions restored so the memory can be re-used) rather than being unmapped one allocation at a time, and slabs are released once they are completely free.

Linking 500 synthetic three-segment objects in-process goes from 1500 extra mappings to 17; 2000 objects goes from 6000 to 66.

Resolves #191727