### PR TITLE
[SPIRV] Emit OpenCL printf format operand as a pointer to i8

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
@@ -1267,6 +1267,30 @@ static bool generateExtInst(const SPIRV::IncomingCall *Call,
   SmallVector<Register> Arguments =
       getBuiltinCallArguments(Call, Number, MIRBuilder, GR);
 
+  // OpenCL printf's format operand must be a pointer to i8, but string
+  // literals are [N x i8] array globals and the deduced pointer-to-array
+  // type would flow into the ExtInst otherwise. Consumers that type the
+  // printf declaration from its first call site (e.g. Arm's SPIR-V
+  // importer) then reject modules whose format strings differ in length.
+  if (Number == SPIRV::OpenCLExtInst::printf && !Arguments.empty()) {
+    Register FmtReg = Arguments[0];
+    SPIRVTypeInst FmtTy = GR->getSPIRVTypeForVReg(FmtReg);
+    if (FmtTy && FmtTy->getOpcode() == SPIRV::OpTypePointer) {
+      const SPIRVTypeInst Int8Ty =
+          GR->getOrCreateSPIRVIntegerType(8, MIRBuilder);
+      if (GR->getPointeeType(FmtTy) != Int8Ty) {
+        const SPIRVTypeInst Int8Ptr = GR->getOrCreateSPIRVPointerType(
+            Int8Ty, MIRBuilder, GR->getPointerStorageClass(FmtReg));
+        Register Cast = createVirtualRegister(Int8Ptr, GR, MIRBuilder);
+        MIRBuilder.buildInstr(SPIRV::OpBitcast)
+            .addDef(Cast)
+            .addUse(GR->getSPIRVTypeID(Int8Ptr))
+            .addUse(FmtReg);
+        Arguments[0] = Cast;
+      }
+    }
+  }
+
   MachineInstrBuilder MIB;
   if (ST.canUseExtension(SPIRV::Extension::SPV_KHR_fma) &&
       Number == SPIRV::OpenCLExtInst::fma) {

--- a/llvm/test/CodeGen/SPIRV/printf-format-operand-i8ptr.ll
+++ b/llvm/test/CodeGen/SPIRV/printf-format-operand-i8ptr.ll
@@ -1,0 +1,33 @@
+; Verify that the OpenCL printf format operand is always a pointer to i8, even
+; when the format string is a global whose deduced pointee type is the array
+; type. Consumers that type the printf declaration from its first call site
+; reject a module whose format strings differ in length otherwise.
+
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; CHECK: %[[#ExtImport:]] = OpExtInstImport "OpenCL.std"
+; CHECK-DAG: %[[#Char:]] = OpTypeInt 8 0
+; CHECK-DAG: %[[#CharPtr:]] = OpTypePointer UniformConstant %[[#Char]]
+
+; Both format strings are cast to the same pointer-to-i8 type before the call,
+; so both printf calls agree on the type of their first operand.
+; CHECK: %[[#Cast1:]] = OpBitcast %[[#CharPtr]] %[[#]]
+; CHECK: OpExtInst %[[#]] %[[#ExtImport]] printf %[[#Cast1]]
+; CHECK: %[[#Cast2:]] = OpBitcast %[[#CharPtr]] %[[#]]
+; CHECK: OpExtInst %[[#]] %[[#ExtImport]] printf %[[#Cast2]]
+
+@.str = private unnamed_addr addrspace(2) constant [10 x i8] c"short %d\0A\00", align 1
+@.str.1 = private unnamed_addr addrspace(2) constant [37 x i8] c"a much longer format string here %d\0A\00", align 1
+
+declare spir_func i32 @printf(ptr addrspace(2), ...)
+
+define spir_kernel void @test_printf_format_operand(i32 %n) {
+entry:
+  %call = call spir_func i32 (ptr addrspace(2), ...) @printf(ptr addrspace(2) @.str, i32 %n)
+  %call1 = call spir_func i32 (ptr addrspace(2), ...) @printf(ptr addrspace(2) @.str.1, i32 %n)
+  ret void
+}


### PR DESCRIPTION
The OpenCL extended instruction set types printf's format operand as a pointer to i8, but string literals are `[N x i8]` array globals and the deduced pointer-to-array type was forwarded into the OpExtInst unchanged.

Two calls whose format strings differ in length therefore pass different pointer types to the same printf. A consumer that types the printf declaration from its first call site (Arm Mali's SPIR-V importer) rejects such a module with "Call parameter type does not match function signature".

On current main this reproduces with two format strings of different lengths: the operands are `OpTypePointer UniformConstant [10 x i8]` and `OpTypePointer UniformConstant [37 x i8]`, with no OpBitcast.

This bitcasts the operand to a pointer to i8 in the same storage class, matching what the llvm-spirv translator flow produced. The decay cannot be done in IR: with opaque pointers a zero-index GEP is a no-op that constant folds away before the backend runs.

The existing printf.ll covers inputs that reach the cast through another path, so the plain array-global case was untested. The new test uses two format strings of different lengths and checks both calls end up with the same pointer-to-i8 operand type.

Testing: new test and the existing printf.ll pass for spirv32 and spirv64, and both emit spirv-val clean modules. The full CodeGen/SPIRV suite shows 1177/1188 passing with the same 8 failures present on unpatched main.