### PR TITLE
[llvm-readobj] Improve unsupported option messages

### DIFF
--- a/llvm/test/tools/llvm-readobj/ELF/bb-addr-map-pgo-analysis-map.test
+++ b/llvm/test/tools/llvm-readobj/ELF/bb-addr-map-pgo-analysis-map.test
@@ -111,7 +111,7 @@
 # CHECK-NEXT:   }
 # CHECK-NEXT: ]
 
-# GNU: GNUStyle::printBBAddrMaps not implemented
+# GNU: GNU output style is not supported for --bb-addr-map
 
 # PRETTY-NO-BAM: warning: --bb-addr-map must be enabled for --pretty-pgo-analysis-map to have an effect
 

--- a/llvm/test/tools/llvm-readobj/ELF/bb-addr-map.test
+++ b/llvm/test/tools/llvm-readobj/ELF/bb-addr-map.test
@@ -86,7 +86,7 @@
 # CHECK-NEXT:   }
 # CHECK-NEXT: ]
 
-# GNU: GNUStyle::printBBAddrMaps not implemented
+# GNU: GNU output style is not supported for --bb-addr-map
 
 # TRUNCATED:      BBAddrMap [
 # TRUNCATED-NEXT:   warning: '[[FILE]]': unable to dump BB addr map section: unable to decode LEB128 at offset [[OFFSET]]: malformed uleb128, extends past end in SHT_LLVM_BB_ADDR_MAP section with index 3

--- a/llvm/test/tools/llvm-readobj/ELF/call-graph-profile.test
+++ b/llvm/test/tools/llvm-readobj/ELF/call-graph-profile.test
@@ -19,7 +19,7 @@
 # LLVM-NEXT:  }
 # LLVM-NEXT: ]
 
-# GNU: GNUStyle::printCGProfile not implemented
+# GNU: GNU output style is not supported for --cg-profile
 
 --- !ELF
 FileHeader:
@@ -271,7 +271,7 @@ Symbols:
 # LLVM-RELA-NEXT:  }
 # LLVM-RELA-NEXT: ]
 
-# GNU-RELA: GNUStyle::printCGProfile not implemented
+# GNU-RELA: GNU output style is not supported for --cg-profile
 
 --- !ELF
 FileHeader:

--- a/llvm/test/tools/llvm-readobj/ELF/linker-options.test
+++ b/llvm/test/tools/llvm-readobj/ELF/linker-options.test
@@ -62,4 +62,4 @@ Sections:
 ## llvm-readelf doesn't support --elf-linker-options yet.
 # RUN: llvm-readelf --elf-linker-options %t1 2>&1 | FileCheck %s --check-prefix=READELF
 
-# READELF: printELFLinkerOptions not implemented!
+# READELF: GNU output style is not supported for --elf-linker-options

--- a/llvm/tools/llvm-readobj/ELFDumper.cpp
+++ b/llvm/tools/llvm-readobj/ELFDumper.cpp
@@ -5332,7 +5332,7 @@ void GNUELFDumper<ELFT>::printHashHistogramStats(size_t NBucket,
 }
 
 template <class ELFT> void GNUELFDumper<ELFT>::printCGProfile() {
-  OS << "GNUStyle::printCGProfile not implemented\n";
+  OS << "GNU output style is not supported for --cg-profile\n";
 }
 
 template <class ELFT>
@@ -5466,7 +5466,7 @@ ELFDumper<ELFT>::processCallGraphSection(const Elf_Shdr *CGSection) {
 
 template <class ELFT>
 void GNUELFDumper<ELFT>::printBBAddrMaps(bool /*PrettyPGOAnalysis*/) {
-  OS << "GNUStyle::printBBAddrMaps not implemented\n";
+  OS << "GNU output style is not supported for --bb-addr-map\n";
 }
 
 static Expected<std::vector<uint64_t>> toULEB128Array(ArrayRef<uint8_t> Data) {
@@ -6910,7 +6910,7 @@ void ELFDumper<ELFT>::printSectionsAsSFrame(ArrayRef<std::string> Sections) {
 }
 
 template <class ELFT> void GNUELFDumper<ELFT>::printELFLinkerOptions() {
-  OS << "printELFLinkerOptions not implemented!\n";
+  OS << "GNU output style is not supported for --elf-linker-options\n";
 }
 
 template <class ELFT>


### PR DESCRIPTION
Improve the messages for unsupported options when using GNU output style.
Fixes #51294.
