### PR TITLE
[lldb][test] Skip the frame 0 stack expedite test with an out-of-tree debugserver

### DIFF
--- a/lldb/test/API/tools/lldb-server/TestGdbRemoteThreadsInStopReply.py
+++ b/lldb/test/API/tools/lldb-server/TestGdbRemoteThreadsInStopReply.py
@@ -209,6 +209,9 @@ class TestGdbRemoteThreadsInStopReply(gdbremote_testcase.GdbRemoteTestCaseBase):
         # walks depends on where the backchain terminates.
         self.assertLessEqual(len(entries), 2, "expected at most 2 backchain entries")
 
+    # Frame 0's stack memory is expedited only by a debugserver built from this
+    # tree; an older system debugserver sends the backchain alone.
+    @skipIfOutOfTreeDebugserver
     @add_test_categories(["debugserver"])
     def test_threads_info_expedites_stopped_frame_stack(self):
         """jThreadsInfo expedites every thread's frame pointer backchain, plus


### PR DESCRIPTION
test_threads_info_expedites_stopped_frame_stack asserts that jThreadsInfo
carries frame 0's stack memory for the stopped thread. debugserver only does
that since b631e0cbd1c9, so a system debugserver sends the backchain alone and
the test fails with "no frame 0 stack memory for stopped thread".
