### PR TITLE
[include-cleaner][objc] Add tests for completeness for @catch, @synchronized, and @encode

### DIFF
--- a/clang-tools-extra/include-cleaner/unittests/WalkASTTest.cpp
+++ b/clang-tools-extra/include-cleaner/unittests/WalkASTTest.cpp
@@ -1388,5 +1388,45 @@ TEST(WalkAST, ObjcSelectorCustomGetterClashWithMethod) {
            {"-x", "objective-c"});
 }
 
+TEST(WalkAST, ObjCAtCatchStmt) {
+  testWalk(R"objc(
+    @interface $explicit^CustomException
+    @end
+  )objc",
+           R"objc(
+    void test() {
+      @try {}
+      @catch (^CustomException *e) {}
+    }
+  )objc",
+           {"-x", "objective-c", "-fobjc-exceptions"});
+}
+
+TEST(WalkAST, ObjCAtSynchronizedStmt) {
+  testWalk(R"objc(
+    @interface $explicit^LockObject
+    + (id)sharedLock;
+    @end
+  )objc",
+           R"objc(
+    void test() {
+      @synchronized([^LockObject sharedLock]) {}
+    }
+  )objc",
+           {"-x", "objective-c", "-fobjc-exceptions"});
+}
+
+TEST(WalkAST, ObjCEncodeExpr) {
+  testWalk(R"objc(
+    struct $explicit^MyStruct { int x; };
+  )objc",
+           R"objc(
+    void test() {
+      const char *enc = @encode(struct ^MyStruct);
+    }
+  )objc",
+           {"-x", "objective-c"});
+}
+
 } // namespace
 } // namespace clang::include_cleaner

--- a/clang-tools-extra/include-cleaner/unittests/WalkASTTest.cpp
+++ b/clang-tools-extra/include-cleaner/unittests/WalkASTTest.cpp
@@ -1413,7 +1413,7 @@ TEST(WalkAST, ObjCAtSynchronizedStmt) {
       @synchronized([^LockObject sharedLock]) {}
     }
   )objc",
-           {"-x", "objective-c", "-fobjc-exceptions"});
+           {"-x", "objective-c"});
 }
 
 TEST(WalkAST, ObjCEncodeExpr) {


### PR DESCRIPTION
This adds tests to verify that include cleaner covers `@catch`, `@synchronized` and `@encode` statements. The current code was complete, this just adds test verification.

Note that this depends on on #216125.