### PR TITLE
[bazel] Fix bazelisk failures after ORC RTBridge removal and libc float128

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -2728,6 +2728,23 @@ libc_support_library(
 )
 
 libc_support_library(
+    name = "__support_fputil_float128",
+    hdrs = ["src/__support/FPUtil/float128.h"],
+    deps = [
+        ":__support_cpp_limits",
+        ":__support_cpp_type_traits",
+        ":__support_fputil_basic_operations",
+        ":__support_fputil_cast",
+        ":__support_fputil_comparison_operations",
+        ":__support_fputil_dyadic_float",
+        ":__support_macros_attributes",
+        ":__support_macros_config",
+        ":__support_uint128",
+        ":hdr_stdint_proxy",
+    ],
+)
+
+libc_support_library(
     name = "__support_osutil_syscall",
     hdrs = ["src/__support/OSUtil/syscall.h"],
     textual_hdrs = select({
@@ -3728,6 +3745,7 @@ cc_library(
         ":__support_fputil_dyadic_float",
         ":__support_fputil_except_value_utils",
         ":__support_fputil_fenv_impl",
+        ":__support_fputil_float128",
         ":__support_fputil_fma",
         ":__support_fputil_fp_bits",
         ":__support_fputil_generic_fmod",
@@ -5274,6 +5292,7 @@ libc_support_library(
     name = "__support_math_ceilf128",
     hdrs = ["src/__support/math/ceilf128.h"],
     deps = [
+        ":__support_fputil_float128",
         ":__support_fputil_nearest_integer_operations",
         ":__support_macros_config",
         ":llvm_libc_types_float128",

--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -4410,7 +4410,6 @@ cc_library(
     ]),
     hdrs = glob([
         "include/llvm/ExecutionEngine/Orc/*.h",
-        "include/llvm/ExecutionEngine/Orc/RTBridge/SPS/**/*.h",
     ]) + [
         "include/llvm-c/LLJIT.h",
         "include/llvm-c/Orc.h",
@@ -4456,10 +4455,9 @@ cc_library(
     ]),
     hdrs = glob([
         "include/llvm/ExecutionEngine/Orc/Shared/*.h",
-        "include/llvm/ExecutionEngine/Orc/RTBridge/*.h",
-    ] + [
+    ]) + [
         "include/llvm/ExecutionEngine/Orc/SymbolStringPool.h",
-    ]),
+    ],
     copts = llvm_copts,
     deps = [
         ":BinaryFormat",


### PR DESCRIPTION
…at128

Commit f406aaec5f6dcb8dbe5d7267afdfdf80cea29d32 removed the ORC/RTBridge directory and relocated its headers directly under include/llvm/ExecutionEngine/Orc/. This updates OrcJIT and OrcShared in llvm/BUILD.bazel to remove the obsolete RTBridge header glob patterns.

Additionally, this adds the missing :__support_fputil_float128 target in libc/BUILD.bazel and includes it in the dependencies of :__support_math_ceilf128 and :shared_math_headers_for_apfloat.

TAG=agy
CONV=cdc6d2a4-4a43-464a-ae1b-a56f935ee140