### PR TITLE
AArch64: Use MIPatternMatch in PostLegalizerCombiner ext checks

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/MIPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/MIPatternMatch.h
@@ -765,6 +765,27 @@ m_GFPTrunc(const SrcTy &Src) {
   return UnaryOp_match<SrcTy, TargetOpcode::G_FPTRUNC>(Src);
 }
 
+/// Matches a G_SEXT_INREG, binding its source operand. G_SEXT_INREG has an
+/// extra immediate operand, so it does not fit the plain UnaryOp_match shape.
+template <typename SrcTy> struct SExtInRegMatch {
+  SrcTy L;
+
+  SExtInRegMatch(const SrcTy &LHS) : L(LHS) {}
+  template <typename OpTy>
+  bool match(const MachineRegisterInfo &MRI, OpTy &&Op) {
+    MachineInstr *TmpMI;
+    if (mi_match(Op, MRI, m_MInstr(TmpMI)) &&
+        TmpMI->getOpcode() == TargetOpcode::G_SEXT_INREG)
+      return L.match(MRI, TmpMI->getOperand(1).getReg());
+    return false;
+  }
+};
+
+template <typename SrcTy>
+inline SExtInRegMatch<SrcTy> m_GSExtInReg(const SrcTy &Src) {
+  return SExtInRegMatch<SrcTy>(Src);
+}
+
 template <typename SrcTy>
 inline UnaryOp_match<SrcTy, TargetOpcode::G_FABS> m_GFabs(const SrcTy &Src) {
   return UnaryOp_match<SrcTy, TargetOpcode::G_FABS>(Src);

--- a/llvm/lib/Target/AArch64/GISel/AArch64PostLegalizerCombiner.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64PostLegalizerCombiner.cpp
@@ -126,13 +126,13 @@ void applyExtractVecEltPairwiseAdd(
 
 bool isSignExtended(Register R, MachineRegisterInfo &MRI) {
   // TODO: check if extended build vector as well.
-  unsigned Opc = MRI.getVRegDef(R)->getOpcode();
-  return Opc == TargetOpcode::G_SEXT || Opc == TargetOpcode::G_SEXT_INREG;
+  return mi_match(R, MRI, m_GSExt(m_Reg())) ||
+         mi_match(R, MRI, m_GSExtInReg(m_Reg()));
 }
 
 bool isZeroExtended(Register R, MachineRegisterInfo &MRI) {
   // TODO: check if extended build vector as well.
-  return MRI.getVRegDef(R)->getOpcode() == TargetOpcode::G_ZEXT;
+  return mi_match(R, MRI, m_GZExt(m_Reg()));
 }
 
 bool matchAArch64MulConstCombine(


### PR DESCRIPTION
Replace the getVRegDef + opcode-check idiom with mi_match. Add an
m_GSExtInReg matcher for G_SEXT_INREG, which has an extra immediate
operand and so does not fit the plain unary-op matcher shape.

Co-authored-by: Claude (Opus 4.8) <noreply@anthropic.com>