### PR TITLE
GlobalISel: Use m_GImplicitDef instead of getVRegDef opcode checks

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
@@ -9731,8 +9731,7 @@ LegalizerHelper::lowerVECTOR_COMPRESS(llvm::MachineInstr &MI) {
 
   auto OutPos = MIRBuilder.buildConstant(IdxTy, 0);
 
-  bool HasPassthru =
-      MRI.getVRegDef(Passthru)->getOpcode() != TargetOpcode::G_IMPLICIT_DEF;
+  bool HasPassthru = !mi_match(Passthru, MRI, m_GImplicitDef());
 
   if (HasPassthru)
     MIRBuilder.buildStore(Passthru, StackPtr, PtrInfo, VecAlign);

--- a/llvm/lib/CodeGen/GlobalISel/Utils.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/Utils.cpp
@@ -1331,7 +1331,7 @@ std::optional<ValueAndVReg> getAnyConstantSplat(Register VReg,
 
     // If AllowUndef, treat undef as value that will result in a constant splat.
     if (!ElementValAndReg) {
-      if (AllowUndef && isa<GImplicitDef>(MRI.getVRegDef(Element)))
+      if (AllowUndef && mi_match(Element, MRI, m_GImplicitDef()))
         continue;
       return std::nullopt;
     }


### PR DESCRIPTION
Co-authored-by: Claude (Opus 4.8) <noreply@anthropic.com>