### PR TITLE
[libc][bazel] Update bazel overlay for ceilf128 emulated float128 changes

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -5295,7 +5295,6 @@ libc_support_library(
         ":__support_fputil_float128",
         ":__support_fputil_nearest_integer_operations",
         ":__support_macros_config",
-        ":llvm_libc_types_float128",
     ],
 )
 
@@ -11062,6 +11061,7 @@ libc_math_function(
 libc_math_function(
     name = "ceilf128",
     additional_deps = [
+        ":__support_cpp_bit",
         ":__support_math_ceilf128",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/test/src/math/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/math/BUILD.bazel
@@ -54,6 +54,11 @@ math_mpfr_test(
     hdrs = ["CeilTest.h"],
 )
 
+math_mpfr_test(
+    name = "ceilf128",
+    hdrs = ["CeilTest.h"],
+)
+
 math_mpfr_test(name = "cos")
 
 math_mpfr_test(


### PR DESCRIPTION
This updates the Bazel overlay following commit e5174fe683e882f6bbd2ef023c9c9e293b273a98:

- Remove `:llvm_libc_types_float128` from `__support_math_ceilf128` deps as `include/llvm-libc-types/float128.h` is no longer included.
- Add `:__support_cpp_bit` to `ceilf128` additional_deps for `bit_cast`.
- Add `ceilf128` math MPFR test target in `libc/test/src/math/BUILD.bazel`.