### PR TITLE
[AArch64][GlobalISel] Do not create atomic truncstore

### DIFF
--- a/llvm/lib/Target/AArch64/GISel/AArch64PostLegalizerLowering.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64PostLegalizerLowering.cpp
@@ -1168,6 +1168,8 @@ bool matchFormTruncstore(MachineInstr &MI, MachineRegisterInfo &MRI,
                          Register &SrcReg) {
   assert(MI.getOpcode() == TargetOpcode::G_STORE);
   Register DstReg = MI.getOperand(0).getReg();
+  if (cast<GLoadStore>(MI).isAtomic())
+    return false;
   if (MRI.getType(DstReg).isVector())
     return false;
   // Match a store of a truncate.

--- a/llvm/test/CodeGen/AArch64/GlobalISel/arm64-atomic.ll
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/arm64-atomic.ll
@@ -1655,6 +1655,239 @@ define void @atomic_store_relaxed_64(ptr %p, i32 %off32, i64 %val) #0 {
   ret void
 }
 
+
+define void @atomic_truncstore_relaxed_8(ptr %p, i32 %off32, i32 %inp1, i32 %inp2, i32 %inp3, i32 %inp4) #0 {
+; CHECK-NOLSE-O1-LABEL: atomic_truncstore_relaxed_8:
+; CHECK-NOLSE-O1:       ; %bb.0:
+; CHECK-NOLSE-O1-NEXT:    add x8, x0, #291, lsl #12 ; =1191936
+; CHECK-NOLSE-O1-NEXT:    strb w2, [x0, #4095]
+; CHECK-NOLSE-O1-NEXT:    strb w3, [x0, w1, sxtw]
+; CHECK-NOLSE-O1-NEXT:    sturb w4, [x0, #-256]
+; CHECK-NOLSE-O1-NEXT:    strb w5, [x8]
+; CHECK-NOLSE-O1-NEXT:    ret
+;
+; CHECK-OUTLINE-O1-LABEL: atomic_truncstore_relaxed_8:
+; CHECK-OUTLINE-O1:       ; %bb.0:
+; CHECK-OUTLINE-O1-NEXT:    add x8, x0, #291, lsl #12 ; =1191936
+; CHECK-OUTLINE-O1-NEXT:    strb w2, [x0, #4095]
+; CHECK-OUTLINE-O1-NEXT:    strb w3, [x0, w1, sxtw]
+; CHECK-OUTLINE-O1-NEXT:    sturb w4, [x0, #-256]
+; CHECK-OUTLINE-O1-NEXT:    strb w5, [x8]
+; CHECK-OUTLINE-O1-NEXT:    ret
+;
+; CHECK-NOLSE-O0-LABEL: atomic_truncstore_relaxed_8:
+; CHECK-NOLSE-O0:       ; %bb.0:
+; CHECK-NOLSE-O0-NEXT:    strb w2, [x0, #4095]
+; CHECK-NOLSE-O0-NEXT:    strb w3, [x0, w1, sxtw]
+; CHECK-NOLSE-O0-NEXT:    sturb w4, [x0, #-256]
+; CHECK-NOLSE-O0-NEXT:    add x8, x0, #291, lsl #12 ; =1191936
+; CHECK-NOLSE-O0-NEXT:    strb w5, [x8]
+; CHECK-NOLSE-O0-NEXT:    ret
+;
+; CHECK-OUTLINE-O0-LABEL: atomic_truncstore_relaxed_8:
+; CHECK-OUTLINE-O0:       ; %bb.0:
+; CHECK-OUTLINE-O0-NEXT:    strb w2, [x0, #4095]
+; CHECK-OUTLINE-O0-NEXT:    strb w3, [x0, w1, sxtw]
+; CHECK-OUTLINE-O0-NEXT:    sturb w4, [x0, #-256]
+; CHECK-OUTLINE-O0-NEXT:    add x8, x0, #291, lsl #12 ; =1191936
+; CHECK-OUTLINE-O0-NEXT:    strb w5, [x8]
+; CHECK-OUTLINE-O0-NEXT:    ret
+;
+; CHECK-LSE-O1-LABEL: atomic_truncstore_relaxed_8:
+; CHECK-LSE-O1:       ; %bb.0:
+; CHECK-LSE-O1-NEXT:    strb w2, [x0, #4095]
+; CHECK-LSE-O1-NEXT:    strb w3, [x0, w1, sxtw]
+; CHECK-LSE-O1-NEXT:    sturb w4, [x0, #-256]
+; CHECK-LSE-O1-NEXT:    add x8, x0, #291, lsl #12 ; =1191936
+; CHECK-LSE-O1-NEXT:    strb w5, [x8]
+; CHECK-LSE-O1-NEXT:    ret
+;
+; CHECK-LSE-O0-LABEL: atomic_truncstore_relaxed_8:
+; CHECK-LSE-O0:       ; %bb.0:
+; CHECK-LSE-O0-NEXT:    strb w2, [x0, #4095]
+; CHECK-LSE-O0-NEXT:    strb w3, [x0, w1, sxtw]
+; CHECK-LSE-O0-NEXT:    sturb w4, [x0, #-256]
+; CHECK-LSE-O0-NEXT:    add x8, x0, #291, lsl #12 ; =1191936
+; CHECK-LSE-O0-NEXT:    strb w5, [x8]
+; CHECK-LSE-O0-NEXT:    ret
+  %ptr_unsigned = getelementptr i8, ptr %p, i32 4095
+  %val1 = trunc i32 %inp1 to i8
+  store atomic i8 %val1, ptr %ptr_unsigned monotonic, align 1
+
+  %ptr_regoff = getelementptr i8, ptr %p, i32 %off32
+  %val2 = trunc i32 %inp2 to i8
+  store atomic i8 %val2, ptr %ptr_regoff unordered, align 1
+
+  %ptr_unscaled = getelementptr i8, ptr %p, i32 -256
+  %val3 = trunc i32 %inp3 to i8
+  store atomic i8 %val3, ptr %ptr_unscaled monotonic, align 1
+
+  %ptr_random = getelementptr i8, ptr %p, i32 1191936 ; 0x123000 (i.e. ADD imm)
+  %val4 = trunc i32 %inp4 to i8
+  store atomic i8 %val4, ptr %ptr_random unordered, align 1
+
+  ret void
+}
+
+define void @atomic_truncstore_relaxed_16(ptr %p, i32 %off32, i32 %inp1, i32 %inp2, i32 %inp3, i32 %inp4) #0 {
+; CHECK-NOLSE-O1-LABEL: atomic_truncstore_relaxed_16:
+; CHECK-NOLSE-O1:       ; %bb.0:
+; CHECK-NOLSE-O1-NEXT:    add x8, x0, #291, lsl #12 ; =1191936
+; CHECK-NOLSE-O1-NEXT:    strh w2, [x0, #8190]
+; CHECK-NOLSE-O1-NEXT:    strh w3, [x0, w1, sxtw #1]
+; CHECK-NOLSE-O1-NEXT:    sturh w4, [x0, #-256]
+; CHECK-NOLSE-O1-NEXT:    strh w5, [x8]
+; CHECK-NOLSE-O1-NEXT:    ret
+;
+; CHECK-OUTLINE-O1-LABEL: atomic_truncstore_relaxed_16:
+; CHECK-OUTLINE-O1:       ; %bb.0:
+; CHECK-OUTLINE-O1-NEXT:    add x8, x0, #291, lsl #12 ; =1191936
+; CHECK-OUTLINE-O1-NEXT:    strh w2, [x0, #8190]
+; CHECK-OUTLINE-O1-NEXT:    strh w3, [x0, w1, sxtw #1]
+; CHECK-OUTLINE-O1-NEXT:    sturh w4, [x0, #-256]
+; CHECK-OUTLINE-O1-NEXT:    strh w5, [x8]
+; CHECK-OUTLINE-O1-NEXT:    ret
+;
+; CHECK-NOLSE-O0-LABEL: atomic_truncstore_relaxed_16:
+; CHECK-NOLSE-O0:       ; %bb.0:
+; CHECK-NOLSE-O0-NEXT:    strh w2, [x0, #8190]
+; CHECK-NOLSE-O0-NEXT:    strh w3, [x0, w1, sxtw #1]
+; CHECK-NOLSE-O0-NEXT:    sturh w4, [x0, #-256]
+; CHECK-NOLSE-O0-NEXT:    add x8, x0, #291, lsl #12 ; =1191936
+; CHECK-NOLSE-O0-NEXT:    strh w5, [x8]
+; CHECK-NOLSE-O0-NEXT:    ret
+;
+; CHECK-OUTLINE-O0-LABEL: atomic_truncstore_relaxed_16:
+; CHECK-OUTLINE-O0:       ; %bb.0:
+; CHECK-OUTLINE-O0-NEXT:    strh w2, [x0, #8190]
+; CHECK-OUTLINE-O0-NEXT:    strh w3, [x0, w1, sxtw #1]
+; CHECK-OUTLINE-O0-NEXT:    sturh w4, [x0, #-256]
+; CHECK-OUTLINE-O0-NEXT:    add x8, x0, #291, lsl #12 ; =1191936
+; CHECK-OUTLINE-O0-NEXT:    strh w5, [x8]
+; CHECK-OUTLINE-O0-NEXT:    ret
+;
+; CHECK-LSE-O1-LABEL: atomic_truncstore_relaxed_16:
+; CHECK-LSE-O1:       ; %bb.0:
+; CHECK-LSE-O1-NEXT:    strh w2, [x0, #8190]
+; CHECK-LSE-O1-NEXT:    strh w3, [x0, w1, sxtw #1]
+; CHECK-LSE-O1-NEXT:    sturh w4, [x0, #-256]
+; CHECK-LSE-O1-NEXT:    add x8, x0, #291, lsl #12 ; =1191936
+; CHECK-LSE-O1-NEXT:    strh w5, [x8]
+; CHECK-LSE-O1-NEXT:    ret
+;
+; CHECK-LSE-O0-LABEL: atomic_truncstore_relaxed_16:
+; CHECK-LSE-O0:       ; %bb.0:
+; CHECK-LSE-O0-NEXT:    strh w2, [x0, #8190]
+; CHECK-LSE-O0-NEXT:    strh w3, [x0, w1, sxtw #1]
+; CHECK-LSE-O0-NEXT:    sturh w4, [x0, #-256]
+; CHECK-LSE-O0-NEXT:    add x8, x0, #291, lsl #12 ; =1191936
+; CHECK-LSE-O0-NEXT:    strh w5, [x8]
+; CHECK-LSE-O0-NEXT:    ret
+  %ptr_unsigned = getelementptr i16, ptr %p, i32 4095
+  %val1 = trunc i32 %inp1 to i16
+  store atomic i16 %val1, ptr %ptr_unsigned monotonic, align 2
+
+  %ptr_regoff = getelementptr i16, ptr %p, i32 %off32
+  %val2 = trunc i32 %inp2 to i16
+  store atomic i16 %val2, ptr %ptr_regoff unordered, align 2
+
+  %ptr_unscaled = getelementptr i16, ptr %p, i32 -128
+  %val3 = trunc i32 %inp3 to i16
+  store atomic i16 %val3, ptr %ptr_unscaled monotonic, align 2
+
+  %ptr_random = getelementptr i16, ptr %p, i32 595968 ; 0x123000/2 (i.e. ADD imm)
+  %val4 = trunc i32 %inp4 to i16
+  store atomic i16 %val4, ptr %ptr_random unordered, align 2
+
+  ret void
+}
+
+define void @atomic_truncstore_relaxed_32(ptr %p, i32 %off32, i64 %inp1, i64 %inp2, i64 %inp3, i64 %inp4) #0 {
+; CHECK-NOLSE-O1-LABEL: atomic_truncstore_relaxed_32:
+; CHECK-NOLSE-O1:       ; %bb.0:
+; CHECK-NOLSE-O1-NEXT:    add x8, x0, #291, lsl #12 ; =1191936
+; CHECK-NOLSE-O1-NEXT:    str w2, [x0, #16380]
+; CHECK-NOLSE-O1-NEXT:    str w3, [x0, w1, sxtw #2]
+; CHECK-NOLSE-O1-NEXT:    stur w4, [x0, #-256]
+; CHECK-NOLSE-O1-NEXT:    str w5, [x8]
+; CHECK-NOLSE-O1-NEXT:    ret
+;
+; CHECK-OUTLINE-O1-LABEL: atomic_truncstore_relaxed_32:
+; CHECK-OUTLINE-O1:       ; %bb.0:
+; CHECK-OUTLINE-O1-NEXT:    add x8, x0, #291, lsl #12 ; =1191936
+; CHECK-OUTLINE-O1-NEXT:    str w2, [x0, #16380]
+; CHECK-OUTLINE-O1-NEXT:    str w3, [x0, w1, sxtw #2]
+; CHECK-OUTLINE-O1-NEXT:    stur w4, [x0, #-256]
+; CHECK-OUTLINE-O1-NEXT:    str w5, [x8]
+; CHECK-OUTLINE-O1-NEXT:    ret
+;
+; CHECK-NOLSE-O0-LABEL: atomic_truncstore_relaxed_32:
+; CHECK-NOLSE-O0:       ; %bb.0:
+; CHECK-NOLSE-O0-NEXT:    mov w8, w2
+; CHECK-NOLSE-O0-NEXT:    str w8, [x0, #16380]
+; CHECK-NOLSE-O0-NEXT:    mov w8, w3
+; CHECK-NOLSE-O0-NEXT:    str w8, [x0, w1, sxtw #2]
+; CHECK-NOLSE-O0-NEXT:    mov w8, w4
+; CHECK-NOLSE-O0-NEXT:    stur w8, [x0, #-256]
+; CHECK-NOLSE-O0-NEXT:    mov w8, w5
+; CHECK-NOLSE-O0-NEXT:    add x9, x0, #291, lsl #12 ; =1191936
+; CHECK-NOLSE-O0-NEXT:    str w8, [x9]
+; CHECK-NOLSE-O0-NEXT:    ret
+;
+; CHECK-OUTLINE-O0-LABEL: atomic_truncstore_relaxed_32:
+; CHECK-OUTLINE-O0:       ; %bb.0:
+; CHECK-OUTLINE-O0-NEXT:    mov w8, w2
+; CHECK-OUTLINE-O0-NEXT:    str w8, [x0, #16380]
+; CHECK-OUTLINE-O0-NEXT:    mov w8, w3
+; CHECK-OUTLINE-O0-NEXT:    str w8, [x0, w1, sxtw #2]
+; CHECK-OUTLINE-O0-NEXT:    mov w8, w4
+; CHECK-OUTLINE-O0-NEXT:    stur w8, [x0, #-256]
+; CHECK-OUTLINE-O0-NEXT:    mov w8, w5
+; CHECK-OUTLINE-O0-NEXT:    add x9, x0, #291, lsl #12 ; =1191936
+; CHECK-OUTLINE-O0-NEXT:    str w8, [x9]
+; CHECK-OUTLINE-O0-NEXT:    ret
+;
+; CHECK-LSE-O1-LABEL: atomic_truncstore_relaxed_32:
+; CHECK-LSE-O1:       ; %bb.0:
+; CHECK-LSE-O1-NEXT:    str w2, [x0, #16380]
+; CHECK-LSE-O1-NEXT:    str w3, [x0, w1, sxtw #2]
+; CHECK-LSE-O1-NEXT:    stur w4, [x0, #-256]
+; CHECK-LSE-O1-NEXT:    add x8, x0, #291, lsl #12 ; =1191936
+; CHECK-LSE-O1-NEXT:    str w5, [x8]
+; CHECK-LSE-O1-NEXT:    ret
+;
+; CHECK-LSE-O0-LABEL: atomic_truncstore_relaxed_32:
+; CHECK-LSE-O0:       ; %bb.0:
+; CHECK-LSE-O0-NEXT:    mov x8, x2
+; CHECK-LSE-O0-NEXT:    str w8, [x0, #16380]
+; CHECK-LSE-O0-NEXT:    mov x8, x3
+; CHECK-LSE-O0-NEXT:    str w8, [x0, w1, sxtw #2]
+; CHECK-LSE-O0-NEXT:    mov x8, x4
+; CHECK-LSE-O0-NEXT:    stur w8, [x0, #-256]
+; CHECK-LSE-O0-NEXT:    mov x8, x5
+; CHECK-LSE-O0-NEXT:    add x9, x0, #291, lsl #12 ; =1191936
+; CHECK-LSE-O0-NEXT:    str w8, [x9]
+; CHECK-LSE-O0-NEXT:    ret
+  %ptr_unsigned = getelementptr i32, ptr %p, i32 4095
+  %val1 = trunc i64 %inp1 to i32
+  store atomic i32 %val1, ptr %ptr_unsigned monotonic, align 4
+
+  %ptr_regoff = getelementptr i32, ptr %p, i32 %off32
+  %val2 = trunc i64 %inp2 to i32
+  store atomic i32 %val2, ptr %ptr_regoff unordered, align 4
+
+  %ptr_unscaled = getelementptr i32, ptr %p, i32 -64
+  %val3 = trunc i64 %inp3 to i32
+  store atomic i32 %val3, ptr %ptr_unscaled monotonic, align 4
+
+  %ptr_random = getelementptr i32, ptr %p, i32 297984 ; 0x123000/4 (i.e. ADD imm)
+  %val4 = trunc i64 %inp4 to i32
+  store atomic i32 %val4, ptr %ptr_random unordered, align 4
+
+  ret void
+}
+
+
 define i32 @load_zext(ptr %p8, ptr %p16) {
 ; CHECK-NOLSE-O1-LABEL: load_zext:
 ; CHECK-NOLSE-O1:       ; %bb.0:
@@ -1804,29 +2037,119 @@ define i32 @load_sext(ptr %p8, ptr %p16) {
   ret i32 %res
 }
 
-define void @store_trunc(i32 %val, ptr %p8, ptr %p16) {
-; CHECK-NOLSE-LABEL: store_trunc:
-; CHECK-NOLSE:       ; %bb.0:
-; CHECK-NOLSE-NEXT:    stlrb w0, [x1]
-; CHECK-NOLSE-NEXT:    strh w0, [x2]
-; CHECK-NOLSE-NEXT:    ret
+define void @store_trunc(i32 %val, ptr %p8, ptr %p16, i64 %inp64) {
+; CHECK-NOLSE-O1-LABEL: store_trunc:
+; CHECK-NOLSE-O1:       ; %bb.0:
+; CHECK-NOLSE-O1-NEXT:    sub sp, sp, #32
+; CHECK-NOLSE-O1-NEXT:    stp x29, x30, [sp, #16] ; 16-byte Folded Spill
+; CHECK-NOLSE-O1-NEXT:    .cfi_def_cfa_offset 32
+; CHECK-NOLSE-O1-NEXT:    .cfi_offset w30, -8
+; CHECK-NOLSE-O1-NEXT:    .cfi_offset w29, -16
+; CHECK-NOLSE-O1-NEXT:    stlrb w0, [x1]
+; CHECK-NOLSE-O1-NEXT:    strh w0, [x2]
+; CHECK-NOLSE-O1-NEXT:    add x2, sp, #12
+; CHECK-NOLSE-O1-NEXT:    mov w0, #4 ; =0x4
+; CHECK-NOLSE-O1-NEXT:    str w3, [sp, #12]
+; CHECK-NOLSE-O1-NEXT:    mov w3, #5 ; =0x5
+; CHECK-NOLSE-O1-NEXT:    bl ___atomic_store
+; CHECK-NOLSE-O1-NEXT:    ldp x29, x30, [sp, #16] ; 16-byte Folded Reload
+; CHECK-NOLSE-O1-NEXT:    add sp, sp, #32
+; CHECK-NOLSE-O1-NEXT:    ret
 ;
-; CHECK-OUTLINE-LABEL: store_trunc:
-; CHECK-OUTLINE:       ; %bb.0:
-; CHECK-OUTLINE-NEXT:    stlrb w0, [x1]
-; CHECK-OUTLINE-NEXT:    strh w0, [x2]
-; CHECK-OUTLINE-NEXT:    ret
+; CHECK-OUTLINE-O1-LABEL: store_trunc:
+; CHECK-OUTLINE-O1:       ; %bb.0:
+; CHECK-OUTLINE-O1-NEXT:    sub sp, sp, #32
+; CHECK-OUTLINE-O1-NEXT:    stp x29, x30, [sp, #16] ; 16-byte Folded Spill
+; CHECK-OUTLINE-O1-NEXT:    .cfi_def_cfa_offset 32
+; CHECK-OUTLINE-O1-NEXT:    .cfi_offset w30, -8
+; CHECK-OUTLINE-O1-NEXT:    .cfi_offset w29, -16
+; CHECK-OUTLINE-O1-NEXT:    stlrb w0, [x1]
+; CHECK-OUTLINE-O1-NEXT:    strh w0, [x2]
+; CHECK-OUTLINE-O1-NEXT:    add x2, sp, #12
+; CHECK-OUTLINE-O1-NEXT:    mov w0, #4 ; =0x4
+; CHECK-OUTLINE-O1-NEXT:    str w3, [sp, #12]
+; CHECK-OUTLINE-O1-NEXT:    mov w3, #5 ; =0x5
+; CHECK-OUTLINE-O1-NEXT:    bl ___atomic_store
+; CHECK-OUTLINE-O1-NEXT:    ldp x29, x30, [sp, #16] ; 16-byte Folded Reload
+; CHECK-OUTLINE-O1-NEXT:    add sp, sp, #32
+; CHECK-OUTLINE-O1-NEXT:    ret
+;
+; CHECK-NOLSE-O0-LABEL: store_trunc:
+; CHECK-NOLSE-O0:       ; %bb.0:
+; CHECK-NOLSE-O0-NEXT:    sub sp, sp, #32
+; CHECK-NOLSE-O0-NEXT:    stp x29, x30, [sp, #16] ; 16-byte Folded Spill
+; CHECK-NOLSE-O0-NEXT:    .cfi_def_cfa_offset 32
+; CHECK-NOLSE-O0-NEXT:    .cfi_offset w30, -8
+; CHECK-NOLSE-O0-NEXT:    .cfi_offset w29, -16
+; CHECK-NOLSE-O0-NEXT:    stlrb w0, [x1]
+; CHECK-NOLSE-O0-NEXT:    strh w0, [x2]
+; CHECK-NOLSE-O0-NEXT:    add x2, sp, #12
+; CHECK-NOLSE-O0-NEXT:    mov w8, w3
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12]
+; CHECK-NOLSE-O0-NEXT:    mov w8, #4 ; =0x4
+; CHECK-NOLSE-O0-NEXT:    mov w0, w8
+; CHECK-NOLSE-O0-NEXT:    mov w3, #5 ; =0x5
+; CHECK-NOLSE-O0-NEXT:    bl ___atomic_store
+; CHECK-NOLSE-O0-NEXT:    ldp x29, x30, [sp, #16] ; 16-byte Folded Reload
+; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
+; CHECK-NOLSE-O0-NEXT:    ret
+;
+; CHECK-OUTLINE-O0-LABEL: store_trunc:
+; CHECK-OUTLINE-O0:       ; %bb.0:
+; CHECK-OUTLINE-O0-NEXT:    sub sp, sp, #32
+; CHECK-OUTLINE-O0-NEXT:    stp x29, x30, [sp, #16] ; 16-byte Folded Spill
+; CHECK-OUTLINE-O0-NEXT:    .cfi_def_cfa_offset 32
+; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w30, -8
+; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w29, -16
+; CHECK-OUTLINE-O0-NEXT:    stlrb w0, [x1]
+; CHECK-OUTLINE-O0-NEXT:    strh w0, [x2]
+; CHECK-OUTLINE-O0-NEXT:    add x2, sp, #12
+; CHECK-OUTLINE-O0-NEXT:    mov w8, w3
+; CHECK-OUTLINE-O0-NEXT:    str w8, [sp, #12]
+; CHECK-OUTLINE-O0-NEXT:    mov w8, #4 ; =0x4
+; CHECK-OUTLINE-O0-NEXT:    mov w0, w8
+; CHECK-OUTLINE-O0-NEXT:    mov w3, #5 ; =0x5
+; CHECK-OUTLINE-O0-NEXT:    bl ___atomic_store
+; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #16] ; 16-byte Folded Reload
+; CHECK-OUTLINE-O0-NEXT:    add sp, sp, #32
+; CHECK-OUTLINE-O0-NEXT:    ret
 ;
 ; CHECK-LSE-O1-LABEL: store_trunc:
 ; CHECK-LSE-O1:       ; %bb.0:
+; CHECK-LSE-O1-NEXT:    sub sp, sp, #32
+; CHECK-LSE-O1-NEXT:    stp x29, x30, [sp, #16] ; 16-byte Folded Spill
+; CHECK-LSE-O1-NEXT:    .cfi_def_cfa_offset 32
+; CHECK-LSE-O1-NEXT:    .cfi_offset w30, -8
+; CHECK-LSE-O1-NEXT:    .cfi_offset w29, -16
 ; CHECK-LSE-O1-NEXT:    stlrb w0, [x1]
 ; CHECK-LSE-O1-NEXT:    strh w0, [x2]
+; CHECK-LSE-O1-NEXT:    str w3, [sp, #12]
+; CHECK-LSE-O1-NEXT:    add x2, sp, #12
+; CHECK-LSE-O1-NEXT:    mov w0, #4 ; =0x4
+; CHECK-LSE-O1-NEXT:    mov w3, #5 ; =0x5
+; CHECK-LSE-O1-NEXT:    bl ___atomic_store
+; CHECK-LSE-O1-NEXT:    ldp x29, x30, [sp, #16] ; 16-byte Folded Reload
+; CHECK-LSE-O1-NEXT:    add sp, sp, #32
 ; CHECK-LSE-O1-NEXT:    ret
 ;
 ; CHECK-LSE-O0-LABEL: store_trunc:
 ; CHECK-LSE-O0:       ; %bb.0:
+; CHECK-LSE-O0-NEXT:    sub sp, sp, #32
+; CHECK-LSE-O0-NEXT:    stp x29, x30, [sp, #16] ; 16-byte Folded Spill
+; CHECK-LSE-O0-NEXT:    .cfi_def_cfa_offset 32
+; CHECK-LSE-O0-NEXT:    .cfi_offset w30, -8
+; CHECK-LSE-O0-NEXT:    .cfi_offset w29, -16
 ; CHECK-LSE-O0-NEXT:    stlrb w0, [x1]
 ; CHECK-LSE-O0-NEXT:    strh w0, [x2]
+; CHECK-LSE-O0-NEXT:    add x2, sp, #12
+; CHECK-LSE-O0-NEXT:    mov x8, x3
+; CHECK-LSE-O0-NEXT:    str w8, [sp, #12]
+; CHECK-LSE-O0-NEXT:    mov w8, #4 ; =0x4
+; CHECK-LSE-O0-NEXT:    mov x0, x8
+; CHECK-LSE-O0-NEXT:    mov w3, #5 ; =0x5
+; CHECK-LSE-O0-NEXT:    bl ___atomic_store
+; CHECK-LSE-O0-NEXT:    ldp x29, x30, [sp, #16] ; 16-byte Folded Reload
+; CHECK-LSE-O0-NEXT:    add sp, sp, #32
 ; CHECK-LSE-O0-NEXT:    ret
   %val8 = trunc i32 %val to i8
   store atomic i8 %val8, ptr %p8 seq_cst, align 1
@@ -1834,18 +2157,21 @@ define void @store_trunc(i32 %val, ptr %p8, ptr %p16) {
   %val16 = trunc i32 %val to i16
   store atomic i16 %val16, ptr %p16 monotonic, align 2
 
+  %val32 = trunc i64 %inp64 to i32
+  store atomic i32 %val32, ptr %p8 seq_cst, align 1
+
   ret void
 }
 
 define i8 @atomicrmw_add_i8(ptr %ptr, i8 %rhs) {
 ; CHECK-NOLSE-O1-LABEL: atomicrmw_add_i8:
 ; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB27_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:  LBB30_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O1-NEXT:    ldaxrb w8, [x0]
 ; CHECK-NOLSE-O1-NEXT:    add w9, w8, w1
 ; CHECK-NOLSE-O1-NEXT:    stlxrb w10, w9, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB27_1
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB30_1
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; CHECK-NOLSE-O1-NEXT:    mov w0, w8
 ; CHECK-NOLSE-O1-NEXT:    ret
@@ -1871,33 +2197,33 @@ define i8 @atomicrmw_add_i8(ptr %ptr, i8 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    ldrb w8, [x0]
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB27_1
-; CHECK-NOLSE-O0-NEXT:  LBB27_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    b LBB30_1
+; CHECK-NOLSE-O0-NEXT:  LBB30_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB27_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB30_2 Depth 2
 ; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add w12, w8, w10, uxth
-; CHECK-NOLSE-O0-NEXT:  LBB27_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB27_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:  LBB30_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB30_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxrb w8, [x11]
 ; CHECK-NOLSE-O0-NEXT:    cmp w8, w10, uxtb
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB27_4
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB30_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB27_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB30_2 Depth=2
 ; CHECK-NOLSE-O0-NEXT:    stlxrb w9, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB27_2
-; CHECK-NOLSE-O0-NEXT:  LBB27_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB27_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB30_2
+; CHECK-NOLSE-O0-NEXT:  LBB30_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB30_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    and w9, w8, #0xff
 ; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxtb
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB27_5
-; CHECK-NOLSE-O0-NEXT:    b LBB27_1
-; CHECK-NOLSE-O0-NEXT:  LBB27_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB30_5
+; CHECK-NOLSE-O0-NEXT:    b LBB30_1
+; CHECK-NOLSE-O0-NEXT:  LBB30_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
 ; CHECK-NOLSE-O0-NEXT:    ret
@@ -1933,11 +2259,11 @@ define i8 @atomicrmw_add_i8(ptr %ptr, i8 %rhs) {
 define i8 @atomicrmw_xchg_i8(ptr %ptr, i8 %rhs) {
 ; CHECK-NOLSE-O1-LABEL: atomicrmw_xchg_i8:
 ; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB28_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:  LBB31_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O1-NEXT:    ldxrb w8, [x0]
 ; CHECK-NOLSE-O1-NEXT:    stxrb w9, w1, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w9, LBB28_1
+; CHECK-NOLSE-O1-NEXT:    cbnz w9, LBB31_1
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; CHECK-NOLSE-O1-NEXT:    mov w0, w8
 ; CHECK-NOLSE-O1-NEXT:    ret
@@ -1963,32 +2289,32 @@ define i8 @atomicrmw_xchg_i8(ptr %ptr, i8 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    ldrb w8, [x0]
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB28_1
-; CHECK-NOLSE-O0-NEXT:  LBB28_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    b LBB31_1
+; CHECK-NOLSE-O0-NEXT:  LBB31_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB28_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB31_2 Depth 2
 ; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr w12, [sp, #24] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:  LBB28_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB28_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:  LBB31_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB31_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxrb w8, [x11]
 ; CHECK-NOLSE-O0-NEXT:    cmp w8, w10, uxtb
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB28_4
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB31_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB28_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB31_2 Depth=2
 ; CHECK-NOLSE-O0-NEXT:    stlxrb w9, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB28_2
-; CHECK-NOLSE-O0-NEXT:  LBB28_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB28_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB31_2
+; CHECK-NOLSE-O0-NEXT:  LBB31_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB31_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    and w9, w8, #0xff
 ; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxtb
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB28_5
-; CHECK-NOLSE-O0-NEXT:    b LBB28_1
-; CHECK-NOLSE-O0-NEXT:  LBB28_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB31_5
+; CHECK-NOLSE-O0-NEXT:    b LBB31_1
+; CHECK-NOLSE-O0-NEXT:  LBB31_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
 ; CHECK-NOLSE-O0-NEXT:    ret
@@ -2024,12 +2350,12 @@ define i8 @atomicrmw_xchg_i8(ptr %ptr, i8 %rhs) {
 define i8 @atomicrmw_sub_i8(ptr %ptr, i8 %rhs) {
 ; CHECK-NOLSE-O1-LABEL: atomicrmw_sub_i8:
 ; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB29_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:  LBB32_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O1-NEXT:    ldaxrb w8, [x0]
 ; CHECK-NOLSE-O1-NEXT:    sub w9, w8, w1
 ; CHECK-NOLSE-O1-NEXT:    stxrb w10, w9, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB29_1
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB32_1
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; CHECK-NOLSE-O1-NEXT:    mov w0, w8
 ; CHECK-NOLSE-O1-NEXT:    ret
@@ -2055,33 +2381,33 @@ define i8 @atomicrmw_sub_i8(ptr %ptr, i8 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    ldrb w8, [x0]
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB29_1
-; CHECK-NOLSE-O0-NEXT:  LBB29_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    b LBB32_1
+; CHECK-NOLSE-O0-NEXT:  LBB32_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB29_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB32_2 Depth 2
 ; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    subs w12, w10, w8
-; CHECK-NOLSE-O0-NEXT:  LBB29_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB29_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:  LBB32_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB32_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxrb w8, [x11]
 ; CHECK-NOLSE-O0-NEXT:    cmp w8, w10, uxtb
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB29_4
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB32_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB29_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB32_2 Depth=2
 ; CHECK-NOLSE-O0-NEXT:    stlxrb w9, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB29_2
-; CHECK-NOLSE-O0-NEXT:  LBB29_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB29_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB32_2
+; CHECK-NOLSE-O0-NEXT:  LBB32_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB32_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    and w9, w8, #0xff
 ; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxtb
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB29_5
-; CHECK-NOLSE-O0-NEXT:    b LBB29_1
-; CHECK-NOLSE-O0-NEXT:  LBB29_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB32_5
+; CHECK-NOLSE-O0-NEXT:    b LBB32_1
+; CHECK-NOLSE-O0-NEXT:  LBB32_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
 ; CHECK-NOLSE-O0-NEXT:    ret
@@ -2121,12 +2447,12 @@ define i8 @atomicrmw_sub_i8(ptr %ptr, i8 %rhs) {
 define i8 @atomicrmw_and_i8(ptr %ptr, i8 %rhs) {
 ; CHECK-NOLSE-O1-LABEL: atomicrmw_and_i8:
 ; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB30_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:  LBB33_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O1-NEXT:    ldxrb w8, [x0]
 ; CHECK-NOLSE-O1-NEXT:    and w9, w8, w1
 ; CHECK-NOLSE-O1-NEXT:    stlxrb w10, w9, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB30_1
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB33_1
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; CHECK-NOLSE-O1-NEXT:    mov w0, w8
 ; CHECK-NOLSE-O1-NEXT:    ret
@@ -2152,33 +2478,33 @@ define i8 @atomicrmw_and_i8(ptr %ptr, i8 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    ldrb w8, [x0]
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB30_1
-; CHECK-NOLSE-O0-NEXT:  LBB30_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    b LBB33_1
+; CHECK-NOLSE-O0-NEXT:  LBB33_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB30_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB33_2 Depth 2
 ; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    and w12, w10, w8
-; CHECK-NOLSE-O0-NEXT:  LBB30_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB30_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:  LBB33_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB33_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxrb w8, [x11]
 ; CHECK-NOLSE-O0-NEXT:    cmp w8, w10, uxtb
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB30_4
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB33_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB30_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB33_2 Depth=2
 ; CHECK-NOLSE-O0-NEXT:    stlxrb w9, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB30_2
-; CHECK-NOLSE-O0-NEXT:  LBB30_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB30_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB33_2
+; CHECK-NOLSE-O0-NEXT:  LBB33_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB33_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    and w9, w8, #0xff
 ; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxtb
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB30_5
-; CHECK-NOLSE-O0-NEXT:    b LBB30_1
-; CHECK-NOLSE-O0-NEXT:  LBB30_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB33_5
+; CHECK-NOLSE-O0-NEXT:    b LBB33_1
+; CHECK-NOLSE-O0-NEXT:  LBB33_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
 ; CHECK-NOLSE-O0-NEXT:    ret
@@ -2218,12 +2544,12 @@ define i8 @atomicrmw_and_i8(ptr %ptr, i8 %rhs) {
 define i8 @atomicrmw_or_i8(ptr %ptr, i8 %rhs) {
 ; CHECK-NOLSE-O1-LABEL: atomicrmw_or_i8:
 ; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB31_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:  LBB34_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O1-NEXT:    ldaxrb w8, [x0]
 ; CHECK-NOLSE-O1-NEXT:    orr w9, w8, w1
 ; CHECK-NOLSE-O1-NEXT:    stlxrb w10, w9, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB31_1
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB34_1
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; CHECK-NOLSE-O1-NEXT:    mov w0, w8
 ; CHECK-NOLSE-O1-NEXT:    ret
@@ -2249,33 +2575,33 @@ define i8 @atomicrmw_or_i8(ptr %ptr, i8 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    ldrb w8, [x0]
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB31_1
-; CHECK-NOLSE-O0-NEXT:  LBB31_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    b LBB34_1
+; CHECK-NOLSE-O0-NEXT:  LBB34_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB31_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB34_2 Depth 2
 ; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    orr w12, w10, w8
-; CHECK-NOLSE-O0-NEXT:  LBB31_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB31_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:  LBB34_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB34_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxrb w8, [x11]
 ; CHECK-NOLSE-O0-NEXT:    cmp w8, w10, uxtb
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB31_4
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB34_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB31_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB34_2 Depth=2
 ; CHECK-NOLSE-O0-NEXT:    stlxrb w9, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB31_2
-; CHECK-NOLSE-O0-NEXT:  LBB31_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB31_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB34_2
+; CHECK-NOLSE-O0-NEXT:  LBB34_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB34_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    and w9, w8, #0xff
 ; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxtb
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB31_5
-; CHECK-NOLSE-O0-NEXT:    b LBB31_1
-; CHECK-NOLSE-O0-NEXT:  LBB31_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB34_5
+; CHECK-NOLSE-O0-NEXT:    b LBB34_1
+; CHECK-NOLSE-O0-NEXT:  LBB34_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
 ; CHECK-NOLSE-O0-NEXT:    ret
@@ -2311,12 +2637,12 @@ define i8 @atomicrmw_or_i8(ptr %ptr, i8 %rhs) {
 define i8 @atomicrmw_xor_i8(ptr %ptr, i8 %rhs) {
 ; CHECK-NOLSE-O1-LABEL: atomicrmw_xor_i8:
 ; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB32_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:  LBB35_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O1-NEXT:    ldxrb w8, [x0]
 ; CHECK-NOLSE-O1-NEXT:    eor w9, w8, w1
 ; CHECK-NOLSE-O1-NEXT:    stxrb w10, w9, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB32_1
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB35_1
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; CHECK-NOLSE-O1-NEXT:    mov w0, w8
 ; CHECK-NOLSE-O1-NEXT:    ret
@@ -2342,33 +2668,33 @@ define i8 @atomicrmw_xor_i8(ptr %ptr, i8 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    ldrb w8, [x0]
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB32_1
-; CHECK-NOLSE-O0-NEXT:  LBB32_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    b LBB35_1
+; CHECK-NOLSE-O0-NEXT:  LBB35_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB32_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB35_2 Depth 2
 ; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    eor w12, w10, w8
-; CHECK-NOLSE-O0-NEXT:  LBB32_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB32_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:  LBB35_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB35_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxrb w8, [x11]
 ; CHECK-NOLSE-O0-NEXT:    cmp w8, w10, uxtb
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB32_4
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB35_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB32_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB35_2 Depth=2
 ; CHECK-NOLSE-O0-NEXT:    stlxrb w9, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB32_2
-; CHECK-NOLSE-O0-NEXT:  LBB32_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB32_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB35_2
+; CHECK-NOLSE-O0-NEXT:  LBB35_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB35_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    and w9, w8, #0xff
 ; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxtb
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB32_5
-; CHECK-NOLSE-O0-NEXT:    b LBB32_1
-; CHECK-NOLSE-O0-NEXT:  LBB32_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB35_5
+; CHECK-NOLSE-O0-NEXT:    b LBB35_1
+; CHECK-NOLSE-O0-NEXT:  LBB35_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
 ; CHECK-NOLSE-O0-NEXT:    ret
@@ -2404,391 +2730,33 @@ define i8 @atomicrmw_xor_i8(ptr %ptr, i8 %rhs) {
 define i8 @atomicrmw_min_i8(ptr %ptr, i8 %rhs) {
 ; CHECK-NOLSE-O1-LABEL: atomicrmw_min_i8:
 ; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB33_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:  LBB36_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O1-NEXT:    ldaxrb w8, [x0]
 ; CHECK-NOLSE-O1-NEXT:    sxtb w9, w8
 ; CHECK-NOLSE-O1-NEXT:    cmp w9, w1, sxtb
 ; CHECK-NOLSE-O1-NEXT:    csel w9, w8, w1, lt
 ; CHECK-NOLSE-O1-NEXT:    stxrb w10, w9, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB33_1
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB36_1
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; CHECK-NOLSE-O1-NEXT:    mov w0, w8
 ; CHECK-NOLSE-O1-NEXT:    ret
 ;
 ; CHECK-OUTLINE-O1-LABEL: atomicrmw_min_i8:
 ; CHECK-OUTLINE-O1:       ; %bb.0:
-; CHECK-OUTLINE-O1-NEXT:  LBB33_1: ; %atomicrmw.start
+; CHECK-OUTLINE-O1-NEXT:  LBB36_1: ; %atomicrmw.start
 ; CHECK-OUTLINE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-OUTLINE-O1-NEXT:    ldaxrb w8, [x0]
 ; CHECK-OUTLINE-O1-NEXT:    sxtb w9, w8
 ; CHECK-OUTLINE-O1-NEXT:    cmp w9, w1, sxtb
 ; CHECK-OUTLINE-O1-NEXT:    csel w9, w8, w1, lt
 ; CHECK-OUTLINE-O1-NEXT:    stxrb w10, w9, [x0]
-; CHECK-OUTLINE-O1-NEXT:    cbnz w10, LBB33_1
+; CHECK-OUTLINE-O1-NEXT:    cbnz w10, LBB36_1
 ; CHECK-OUTLINE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; CHECK-OUTLINE-O1-NEXT:    mov w0, w8
 ; CHECK-OUTLINE-O1-NEXT:    ret
 ;
 ; CHECK-NOLSE-O0-LABEL: atomicrmw_min_i8:
-; CHECK-NOLSE-O0:       ; %bb.0:
-; CHECK-NOLSE-O0-NEXT:    sub sp, sp, #32
-; CHECK-NOLSE-O0-NEXT:    .cfi_def_cfa_offset 32
-; CHECK-NOLSE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    ldrb w8, [x0]
-; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB33_1
-; CHECK-NOLSE-O0-NEXT:  LBB33_1: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB33_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    sxtb w9, w10
-; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w8, sxtb
-; CHECK-NOLSE-O0-NEXT:    csel w12, w10, w8, le
-; CHECK-NOLSE-O0-NEXT:  LBB33_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB33_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
-; CHECK-NOLSE-O0-NEXT:    ldaxrb w8, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w8, w10, uxtb
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB33_4
-; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB33_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxrb w9, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB33_2
-; CHECK-NOLSE-O0-NEXT:  LBB33_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB33_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    and w9, w8, #0xff
-; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxtb
-; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB33_5
-; CHECK-NOLSE-O0-NEXT:    b LBB33_1
-; CHECK-NOLSE-O0-NEXT:  LBB33_5: ; %atomicrmw.end
-; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
-; CHECK-NOLSE-O0-NEXT:    ret
-;
-; CHECK-OUTLINE-O0-LABEL: atomicrmw_min_i8:
-; CHECK-OUTLINE-O0:       ; %bb.0:
-; CHECK-OUTLINE-O0-NEXT:    sub sp, sp, #48
-; CHECK-OUTLINE-O0-NEXT:    stp x29, x30, [sp, #32] ; 16-byte Folded Spill
-; CHECK-OUTLINE-O0-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w30, -8
-; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w29, -16
-; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    ldrb w0, [x0]
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    b LBB33_1
-; CHECK-OUTLINE-O0-NEXT:  LBB33_1: ; %atomicrmw.start
-; CHECK-OUTLINE-O0-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #28] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldr x2, [sp, #16] ; 8-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #8] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    sxtb w9, w0
-; CHECK-OUTLINE-O0-NEXT:    subs w9, w9, w8, sxtb
-; CHECK-OUTLINE-O0-NEXT:    csel w1, w0, w8, le
-; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas1_acq
-; CHECK-OUTLINE-O0-NEXT:    ldr w9, [sp, #8] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #12] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    and w8, w0, #0xff
-; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w9, uxtb
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    b.eq LBB33_2
-; CHECK-OUTLINE-O0-NEXT:    b LBB33_1
-; CHECK-OUTLINE-O0-NEXT:  LBB33_2: ; %atomicrmw.end
-; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
-; CHECK-OUTLINE-O0-NEXT:    add sp, sp, #48
-; CHECK-OUTLINE-O0-NEXT:    ret
-;
-; CHECK-LSE-O1-LABEL: atomicrmw_min_i8:
-; CHECK-LSE-O1:       ; %bb.0:
-; CHECK-LSE-O1-NEXT:    ldsminab w1, w0, [x0]
-; CHECK-LSE-O1-NEXT:    ret
-;
-; CHECK-LSE-O0-LABEL: atomicrmw_min_i8:
-; CHECK-LSE-O0:       ; %bb.0:
-; CHECK-LSE-O0-NEXT:    ldsminab w1, w0, [x0]
-; CHECK-LSE-O0-NEXT:    ret
-  %res = atomicrmw min ptr %ptr, i8 %rhs acquire
-  ret i8 %res
-}
-
-define i8 @atomicrmw_max_i8(ptr %ptr, i8 %rhs) {
-; CHECK-NOLSE-O1-LABEL: atomicrmw_max_i8:
-; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB34_1: ; %atomicrmw.start
-; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-NOLSE-O1-NEXT:    ldxrb w8, [x0]
-; CHECK-NOLSE-O1-NEXT:    sxtb w9, w8
-; CHECK-NOLSE-O1-NEXT:    cmp w9, w1, sxtb
-; CHECK-NOLSE-O1-NEXT:    csel w9, w8, w1, gt
-; CHECK-NOLSE-O1-NEXT:    stlxrb w10, w9, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB34_1
-; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
-; CHECK-NOLSE-O1-NEXT:    mov w0, w8
-; CHECK-NOLSE-O1-NEXT:    ret
-;
-; CHECK-OUTLINE-O1-LABEL: atomicrmw_max_i8:
-; CHECK-OUTLINE-O1:       ; %bb.0:
-; CHECK-OUTLINE-O1-NEXT:  LBB34_1: ; %atomicrmw.start
-; CHECK-OUTLINE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-OUTLINE-O1-NEXT:    ldxrb w8, [x0]
-; CHECK-OUTLINE-O1-NEXT:    sxtb w9, w8
-; CHECK-OUTLINE-O1-NEXT:    cmp w9, w1, sxtb
-; CHECK-OUTLINE-O1-NEXT:    csel w9, w8, w1, gt
-; CHECK-OUTLINE-O1-NEXT:    stlxrb w10, w9, [x0]
-; CHECK-OUTLINE-O1-NEXT:    cbnz w10, LBB34_1
-; CHECK-OUTLINE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
-; CHECK-OUTLINE-O1-NEXT:    mov w0, w8
-; CHECK-OUTLINE-O1-NEXT:    ret
-;
-; CHECK-NOLSE-O0-LABEL: atomicrmw_max_i8:
-; CHECK-NOLSE-O0:       ; %bb.0:
-; CHECK-NOLSE-O0-NEXT:    sub sp, sp, #32
-; CHECK-NOLSE-O0-NEXT:    .cfi_def_cfa_offset 32
-; CHECK-NOLSE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    ldrb w8, [x0]
-; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB34_1
-; CHECK-NOLSE-O0-NEXT:  LBB34_1: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB34_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    sxtb w9, w10
-; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w8, sxtb
-; CHECK-NOLSE-O0-NEXT:    csel w12, w10, w8, gt
-; CHECK-NOLSE-O0-NEXT:  LBB34_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB34_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
-; CHECK-NOLSE-O0-NEXT:    ldaxrb w8, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w8, w10, uxtb
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB34_4
-; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB34_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxrb w9, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB34_2
-; CHECK-NOLSE-O0-NEXT:  LBB34_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB34_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    and w9, w8, #0xff
-; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxtb
-; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB34_5
-; CHECK-NOLSE-O0-NEXT:    b LBB34_1
-; CHECK-NOLSE-O0-NEXT:  LBB34_5: ; %atomicrmw.end
-; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
-; CHECK-NOLSE-O0-NEXT:    ret
-;
-; CHECK-OUTLINE-O0-LABEL: atomicrmw_max_i8:
-; CHECK-OUTLINE-O0:       ; %bb.0:
-; CHECK-OUTLINE-O0-NEXT:    sub sp, sp, #48
-; CHECK-OUTLINE-O0-NEXT:    stp x29, x30, [sp, #32] ; 16-byte Folded Spill
-; CHECK-OUTLINE-O0-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w30, -8
-; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w29, -16
-; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    ldrb w0, [x0]
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    b LBB34_1
-; CHECK-OUTLINE-O0-NEXT:  LBB34_1: ; %atomicrmw.start
-; CHECK-OUTLINE-O0-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #28] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldr x2, [sp, #16] ; 8-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #8] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    sxtb w9, w0
-; CHECK-OUTLINE-O0-NEXT:    subs w9, w9, w8, sxtb
-; CHECK-OUTLINE-O0-NEXT:    csel w1, w0, w8, gt
-; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas1_rel
-; CHECK-OUTLINE-O0-NEXT:    ldr w9, [sp, #8] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #12] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    and w8, w0, #0xff
-; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w9, uxtb
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    b.eq LBB34_2
-; CHECK-OUTLINE-O0-NEXT:    b LBB34_1
-; CHECK-OUTLINE-O0-NEXT:  LBB34_2: ; %atomicrmw.end
-; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
-; CHECK-OUTLINE-O0-NEXT:    add sp, sp, #48
-; CHECK-OUTLINE-O0-NEXT:    ret
-;
-; CHECK-LSE-O1-LABEL: atomicrmw_max_i8:
-; CHECK-LSE-O1:       ; %bb.0:
-; CHECK-LSE-O1-NEXT:    ldsmaxlb w1, w0, [x0]
-; CHECK-LSE-O1-NEXT:    ret
-;
-; CHECK-LSE-O0-LABEL: atomicrmw_max_i8:
-; CHECK-LSE-O0:       ; %bb.0:
-; CHECK-LSE-O0-NEXT:    ldsmaxlb w1, w0, [x0]
-; CHECK-LSE-O0-NEXT:    ret
-  %res = atomicrmw max ptr %ptr, i8 %rhs release
-  ret i8 %res
-}
-
-define i8 @atomicrmw_umin_i8(ptr %ptr, i8 %rhs) {
-; CHECK-NOLSE-O1-LABEL: atomicrmw_umin_i8:
-; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:    and w9, w1, #0xff
-; CHECK-NOLSE-O1-NEXT:  LBB35_1: ; %atomicrmw.start
-; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-NOLSE-O1-NEXT:    ldaxrb w8, [x0]
-; CHECK-NOLSE-O1-NEXT:    and w8, w8, #0xff
-; CHECK-NOLSE-O1-NEXT:    cmp w8, w9
-; CHECK-NOLSE-O1-NEXT:    csel w10, w8, w9, lo
-; CHECK-NOLSE-O1-NEXT:    stlxrb w11, w10, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w11, LBB35_1
-; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
-; CHECK-NOLSE-O1-NEXT:    mov w0, w8
-; CHECK-NOLSE-O1-NEXT:    ret
-;
-; CHECK-OUTLINE-O1-LABEL: atomicrmw_umin_i8:
-; CHECK-OUTLINE-O1:       ; %bb.0:
-; CHECK-OUTLINE-O1-NEXT:    and w9, w1, #0xff
-; CHECK-OUTLINE-O1-NEXT:  LBB35_1: ; %atomicrmw.start
-; CHECK-OUTLINE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-OUTLINE-O1-NEXT:    ldaxrb w8, [x0]
-; CHECK-OUTLINE-O1-NEXT:    and w8, w8, #0xff
-; CHECK-OUTLINE-O1-NEXT:    cmp w8, w9
-; CHECK-OUTLINE-O1-NEXT:    csel w10, w8, w9, lo
-; CHECK-OUTLINE-O1-NEXT:    stlxrb w11, w10, [x0]
-; CHECK-OUTLINE-O1-NEXT:    cbnz w11, LBB35_1
-; CHECK-OUTLINE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
-; CHECK-OUTLINE-O1-NEXT:    mov w0, w8
-; CHECK-OUTLINE-O1-NEXT:    ret
-;
-; CHECK-NOLSE-O0-LABEL: atomicrmw_umin_i8:
-; CHECK-NOLSE-O0:       ; %bb.0:
-; CHECK-NOLSE-O0-NEXT:    sub sp, sp, #32
-; CHECK-NOLSE-O0-NEXT:    .cfi_def_cfa_offset 32
-; CHECK-NOLSE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    ldrb w8, [x0]
-; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB35_1
-; CHECK-NOLSE-O0-NEXT:  LBB35_1: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB35_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    and w9, w10, #0xff
-; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w8, uxtb
-; CHECK-NOLSE-O0-NEXT:    csel w12, w10, w8, ls
-; CHECK-NOLSE-O0-NEXT:  LBB35_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB35_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
-; CHECK-NOLSE-O0-NEXT:    ldaxrb w8, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w8, w10, uxtb
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB35_4
-; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB35_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxrb w9, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB35_2
-; CHECK-NOLSE-O0-NEXT:  LBB35_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB35_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    and w9, w8, #0xff
-; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxtb
-; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB35_5
-; CHECK-NOLSE-O0-NEXT:    b LBB35_1
-; CHECK-NOLSE-O0-NEXT:  LBB35_5: ; %atomicrmw.end
-; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
-; CHECK-NOLSE-O0-NEXT:    ret
-;
-; CHECK-OUTLINE-O0-LABEL: atomicrmw_umin_i8:
-; CHECK-OUTLINE-O0:       ; %bb.0:
-; CHECK-OUTLINE-O0-NEXT:    sub sp, sp, #48
-; CHECK-OUTLINE-O0-NEXT:    stp x29, x30, [sp, #32] ; 16-byte Folded Spill
-; CHECK-OUTLINE-O0-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w30, -8
-; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w29, -16
-; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    ldrb w0, [x0]
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    b LBB35_1
-; CHECK-OUTLINE-O0-NEXT:  LBB35_1: ; %atomicrmw.start
-; CHECK-OUTLINE-O0-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #28] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldr x2, [sp, #16] ; 8-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #8] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    and w9, w0, #0xff
-; CHECK-OUTLINE-O0-NEXT:    subs w9, w9, w8, uxtb
-; CHECK-OUTLINE-O0-NEXT:    csel w1, w0, w8, ls
-; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas1_acq_rel
-; CHECK-OUTLINE-O0-NEXT:    ldr w9, [sp, #8] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #12] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    and w8, w0, #0xff
-; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w9, uxtb
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    b.eq LBB35_2
-; CHECK-OUTLINE-O0-NEXT:    b LBB35_1
-; CHECK-OUTLINE-O0-NEXT:  LBB35_2: ; %atomicrmw.end
-; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
-; CHECK-OUTLINE-O0-NEXT:    add sp, sp, #48
-; CHECK-OUTLINE-O0-NEXT:    ret
-;
-; CHECK-LSE-O1-LABEL: atomicrmw_umin_i8:
-; CHECK-LSE-O1:       ; %bb.0:
-; CHECK-LSE-O1-NEXT:    lduminalb w1, w0, [x0]
-; CHECK-LSE-O1-NEXT:    ret
-;
-; CHECK-LSE-O0-LABEL: atomicrmw_umin_i8:
-; CHECK-LSE-O0:       ; %bb.0:
-; CHECK-LSE-O0-NEXT:    lduminalb w1, w0, [x0]
-; CHECK-LSE-O0-NEXT:    ret
-  %res = atomicrmw umin ptr %ptr, i8 %rhs seq_cst
-  ret i8 %res
-}
-
-define i8 @atomicrmw_umax_i8(ptr %ptr, i8 %rhs) {
-; CHECK-NOLSE-O1-LABEL: atomicrmw_umax_i8:
-; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:    and w9, w1, #0xff
-; CHECK-NOLSE-O1-NEXT:  LBB36_1: ; %atomicrmw.start
-; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-NOLSE-O1-NEXT:    ldxrb w8, [x0]
-; CHECK-NOLSE-O1-NEXT:    and w8, w8, #0xff
-; CHECK-NOLSE-O1-NEXT:    cmp w8, w9
-; CHECK-NOLSE-O1-NEXT:    csel w10, w8, w9, hi
-; CHECK-NOLSE-O1-NEXT:    stxrb w11, w10, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w11, LBB36_1
-; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
-; CHECK-NOLSE-O1-NEXT:    mov w0, w8
-; CHECK-NOLSE-O1-NEXT:    ret
-;
-; CHECK-OUTLINE-O1-LABEL: atomicrmw_umax_i8:
-; CHECK-OUTLINE-O1:       ; %bb.0:
-; CHECK-OUTLINE-O1-NEXT:    and w9, w1, #0xff
-; CHECK-OUTLINE-O1-NEXT:  LBB36_1: ; %atomicrmw.start
-; CHECK-OUTLINE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-OUTLINE-O1-NEXT:    ldxrb w8, [x0]
-; CHECK-OUTLINE-O1-NEXT:    and w8, w8, #0xff
-; CHECK-OUTLINE-O1-NEXT:    cmp w8, w9
-; CHECK-OUTLINE-O1-NEXT:    csel w10, w8, w9, hi
-; CHECK-OUTLINE-O1-NEXT:    stxrb w11, w10, [x0]
-; CHECK-OUTLINE-O1-NEXT:    cbnz w11, LBB36_1
-; CHECK-OUTLINE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
-; CHECK-OUTLINE-O1-NEXT:    mov w0, w8
-; CHECK-OUTLINE-O1-NEXT:    ret
-;
-; CHECK-NOLSE-O0-LABEL: atomicrmw_umax_i8:
 ; CHECK-NOLSE-O0:       ; %bb.0:
 ; CHECK-NOLSE-O0-NEXT:    sub sp, sp, #32
 ; CHECK-NOLSE-O0-NEXT:    .cfi_def_cfa_offset 32
@@ -2803,9 +2771,9 @@ define i8 @atomicrmw_umax_i8(ptr %ptr, i8 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    and w9, w10, #0xff
-; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w8, uxtb
-; CHECK-NOLSE-O0-NEXT:    csel w12, w10, w8, hi
+; CHECK-NOLSE-O0-NEXT:    sxtb w9, w10
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w8, sxtb
+; CHECK-NOLSE-O0-NEXT:    csel w12, w10, w8, le
 ; CHECK-NOLSE-O0-NEXT:  LBB36_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB36_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
@@ -2829,7 +2797,7 @@ define i8 @atomicrmw_umax_i8(ptr %ptr, i8 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
 ; CHECK-NOLSE-O0-NEXT:    ret
 ;
-; CHECK-OUTLINE-O0-LABEL: atomicrmw_umax_i8:
+; CHECK-OUTLINE-O0-LABEL: atomicrmw_min_i8:
 ; CHECK-OUTLINE-O0:       ; %bb.0:
 ; CHECK-OUTLINE-O0-NEXT:    sub sp, sp, #48
 ; CHECK-OUTLINE-O0-NEXT:    stp x29, x30, [sp, #32] ; 16-byte Folded Spill
@@ -2847,6 +2815,364 @@ define i8 @atomicrmw_umax_i8(ptr %ptr, i8 %rhs) {
 ; CHECK-OUTLINE-O0-NEXT:    ldr x2, [sp, #16] ; 8-byte Reload
 ; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
 ; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #8] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    sxtb w9, w0
+; CHECK-OUTLINE-O0-NEXT:    subs w9, w9, w8, sxtb
+; CHECK-OUTLINE-O0-NEXT:    csel w1, w0, w8, le
+; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas1_acq
+; CHECK-OUTLINE-O0-NEXT:    ldr w9, [sp, #8] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #12] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    and w8, w0, #0xff
+; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w9, uxtb
+; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    b.eq LBB36_2
+; CHECK-OUTLINE-O0-NEXT:    b LBB36_1
+; CHECK-OUTLINE-O0-NEXT:  LBB36_2: ; %atomicrmw.end
+; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
+; CHECK-OUTLINE-O0-NEXT:    add sp, sp, #48
+; CHECK-OUTLINE-O0-NEXT:    ret
+;
+; CHECK-LSE-O1-LABEL: atomicrmw_min_i8:
+; CHECK-LSE-O1:       ; %bb.0:
+; CHECK-LSE-O1-NEXT:    ldsminab w1, w0, [x0]
+; CHECK-LSE-O1-NEXT:    ret
+;
+; CHECK-LSE-O0-LABEL: atomicrmw_min_i8:
+; CHECK-LSE-O0:       ; %bb.0:
+; CHECK-LSE-O0-NEXT:    ldsminab w1, w0, [x0]
+; CHECK-LSE-O0-NEXT:    ret
+  %res = atomicrmw min ptr %ptr, i8 %rhs acquire
+  ret i8 %res
+}
+
+define i8 @atomicrmw_max_i8(ptr %ptr, i8 %rhs) {
+; CHECK-NOLSE-O1-LABEL: atomicrmw_max_i8:
+; CHECK-NOLSE-O1:       ; %bb.0:
+; CHECK-NOLSE-O1-NEXT:  LBB37_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-NOLSE-O1-NEXT:    ldxrb w8, [x0]
+; CHECK-NOLSE-O1-NEXT:    sxtb w9, w8
+; CHECK-NOLSE-O1-NEXT:    cmp w9, w1, sxtb
+; CHECK-NOLSE-O1-NEXT:    csel w9, w8, w1, gt
+; CHECK-NOLSE-O1-NEXT:    stlxrb w10, w9, [x0]
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB37_1
+; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
+; CHECK-NOLSE-O1-NEXT:    mov w0, w8
+; CHECK-NOLSE-O1-NEXT:    ret
+;
+; CHECK-OUTLINE-O1-LABEL: atomicrmw_max_i8:
+; CHECK-OUTLINE-O1:       ; %bb.0:
+; CHECK-OUTLINE-O1-NEXT:  LBB37_1: ; %atomicrmw.start
+; CHECK-OUTLINE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-OUTLINE-O1-NEXT:    ldxrb w8, [x0]
+; CHECK-OUTLINE-O1-NEXT:    sxtb w9, w8
+; CHECK-OUTLINE-O1-NEXT:    cmp w9, w1, sxtb
+; CHECK-OUTLINE-O1-NEXT:    csel w9, w8, w1, gt
+; CHECK-OUTLINE-O1-NEXT:    stlxrb w10, w9, [x0]
+; CHECK-OUTLINE-O1-NEXT:    cbnz w10, LBB37_1
+; CHECK-OUTLINE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
+; CHECK-OUTLINE-O1-NEXT:    mov w0, w8
+; CHECK-OUTLINE-O1-NEXT:    ret
+;
+; CHECK-NOLSE-O0-LABEL: atomicrmw_max_i8:
+; CHECK-NOLSE-O0:       ; %bb.0:
+; CHECK-NOLSE-O0-NEXT:    sub sp, sp, #32
+; CHECK-NOLSE-O0-NEXT:    .cfi_def_cfa_offset 32
+; CHECK-NOLSE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    ldrb w8, [x0]
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b LBB37_1
+; CHECK-NOLSE-O0-NEXT:  LBB37_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB37_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    sxtb w9, w10
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w8, sxtb
+; CHECK-NOLSE-O0-NEXT:    csel w12, w10, w8, gt
+; CHECK-NOLSE-O0-NEXT:  LBB37_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB37_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
+; CHECK-NOLSE-O0-NEXT:    ldaxrb w8, [x11]
+; CHECK-NOLSE-O0-NEXT:    cmp w8, w10, uxtb
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB37_4
+; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB37_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    stlxrb w9, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB37_2
+; CHECK-NOLSE-O0-NEXT:  LBB37_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB37_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    and w9, w8, #0xff
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxtb
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB37_5
+; CHECK-NOLSE-O0-NEXT:    b LBB37_1
+; CHECK-NOLSE-O0-NEXT:  LBB37_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
+; CHECK-NOLSE-O0-NEXT:    ret
+;
+; CHECK-OUTLINE-O0-LABEL: atomicrmw_max_i8:
+; CHECK-OUTLINE-O0:       ; %bb.0:
+; CHECK-OUTLINE-O0-NEXT:    sub sp, sp, #48
+; CHECK-OUTLINE-O0-NEXT:    stp x29, x30, [sp, #32] ; 16-byte Folded Spill
+; CHECK-OUTLINE-O0-NEXT:    .cfi_def_cfa_offset 48
+; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w30, -8
+; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w29, -16
+; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    ldrb w0, [x0]
+; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    b LBB37_1
+; CHECK-OUTLINE-O0-NEXT:  LBB37_1: ; %atomicrmw.start
+; CHECK-OUTLINE-O0-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #28] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldr x2, [sp, #16] ; 8-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #8] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    sxtb w9, w0
+; CHECK-OUTLINE-O0-NEXT:    subs w9, w9, w8, sxtb
+; CHECK-OUTLINE-O0-NEXT:    csel w1, w0, w8, gt
+; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas1_rel
+; CHECK-OUTLINE-O0-NEXT:    ldr w9, [sp, #8] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #12] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    and w8, w0, #0xff
+; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w9, uxtb
+; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    b.eq LBB37_2
+; CHECK-OUTLINE-O0-NEXT:    b LBB37_1
+; CHECK-OUTLINE-O0-NEXT:  LBB37_2: ; %atomicrmw.end
+; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
+; CHECK-OUTLINE-O0-NEXT:    add sp, sp, #48
+; CHECK-OUTLINE-O0-NEXT:    ret
+;
+; CHECK-LSE-O1-LABEL: atomicrmw_max_i8:
+; CHECK-LSE-O1:       ; %bb.0:
+; CHECK-LSE-O1-NEXT:    ldsmaxlb w1, w0, [x0]
+; CHECK-LSE-O1-NEXT:    ret
+;
+; CHECK-LSE-O0-LABEL: atomicrmw_max_i8:
+; CHECK-LSE-O0:       ; %bb.0:
+; CHECK-LSE-O0-NEXT:    ldsmaxlb w1, w0, [x0]
+; CHECK-LSE-O0-NEXT:    ret
+  %res = atomicrmw max ptr %ptr, i8 %rhs release
+  ret i8 %res
+}
+
+define i8 @atomicrmw_umin_i8(ptr %ptr, i8 %rhs) {
+; CHECK-NOLSE-O1-LABEL: atomicrmw_umin_i8:
+; CHECK-NOLSE-O1:       ; %bb.0:
+; CHECK-NOLSE-O1-NEXT:    and w9, w1, #0xff
+; CHECK-NOLSE-O1-NEXT:  LBB38_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-NOLSE-O1-NEXT:    ldaxrb w8, [x0]
+; CHECK-NOLSE-O1-NEXT:    and w8, w8, #0xff
+; CHECK-NOLSE-O1-NEXT:    cmp w8, w9
+; CHECK-NOLSE-O1-NEXT:    csel w10, w8, w9, lo
+; CHECK-NOLSE-O1-NEXT:    stlxrb w11, w10, [x0]
+; CHECK-NOLSE-O1-NEXT:    cbnz w11, LBB38_1
+; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
+; CHECK-NOLSE-O1-NEXT:    mov w0, w8
+; CHECK-NOLSE-O1-NEXT:    ret
+;
+; CHECK-OUTLINE-O1-LABEL: atomicrmw_umin_i8:
+; CHECK-OUTLINE-O1:       ; %bb.0:
+; CHECK-OUTLINE-O1-NEXT:    and w9, w1, #0xff
+; CHECK-OUTLINE-O1-NEXT:  LBB38_1: ; %atomicrmw.start
+; CHECK-OUTLINE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-OUTLINE-O1-NEXT:    ldaxrb w8, [x0]
+; CHECK-OUTLINE-O1-NEXT:    and w8, w8, #0xff
+; CHECK-OUTLINE-O1-NEXT:    cmp w8, w9
+; CHECK-OUTLINE-O1-NEXT:    csel w10, w8, w9, lo
+; CHECK-OUTLINE-O1-NEXT:    stlxrb w11, w10, [x0]
+; CHECK-OUTLINE-O1-NEXT:    cbnz w11, LBB38_1
+; CHECK-OUTLINE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
+; CHECK-OUTLINE-O1-NEXT:    mov w0, w8
+; CHECK-OUTLINE-O1-NEXT:    ret
+;
+; CHECK-NOLSE-O0-LABEL: atomicrmw_umin_i8:
+; CHECK-NOLSE-O0:       ; %bb.0:
+; CHECK-NOLSE-O0-NEXT:    sub sp, sp, #32
+; CHECK-NOLSE-O0-NEXT:    .cfi_def_cfa_offset 32
+; CHECK-NOLSE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    ldrb w8, [x0]
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b LBB38_1
+; CHECK-NOLSE-O0-NEXT:  LBB38_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB38_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    and w9, w10, #0xff
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w8, uxtb
+; CHECK-NOLSE-O0-NEXT:    csel w12, w10, w8, ls
+; CHECK-NOLSE-O0-NEXT:  LBB38_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB38_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
+; CHECK-NOLSE-O0-NEXT:    ldaxrb w8, [x11]
+; CHECK-NOLSE-O0-NEXT:    cmp w8, w10, uxtb
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB38_4
+; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB38_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    stlxrb w9, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB38_2
+; CHECK-NOLSE-O0-NEXT:  LBB38_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB38_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    and w9, w8, #0xff
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxtb
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB38_5
+; CHECK-NOLSE-O0-NEXT:    b LBB38_1
+; CHECK-NOLSE-O0-NEXT:  LBB38_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
+; CHECK-NOLSE-O0-NEXT:    ret
+;
+; CHECK-OUTLINE-O0-LABEL: atomicrmw_umin_i8:
+; CHECK-OUTLINE-O0:       ; %bb.0:
+; CHECK-OUTLINE-O0-NEXT:    sub sp, sp, #48
+; CHECK-OUTLINE-O0-NEXT:    stp x29, x30, [sp, #32] ; 16-byte Folded Spill
+; CHECK-OUTLINE-O0-NEXT:    .cfi_def_cfa_offset 48
+; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w30, -8
+; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w29, -16
+; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    ldrb w0, [x0]
+; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    b LBB38_1
+; CHECK-OUTLINE-O0-NEXT:  LBB38_1: ; %atomicrmw.start
+; CHECK-OUTLINE-O0-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #28] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldr x2, [sp, #16] ; 8-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #8] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    and w9, w0, #0xff
+; CHECK-OUTLINE-O0-NEXT:    subs w9, w9, w8, uxtb
+; CHECK-OUTLINE-O0-NEXT:    csel w1, w0, w8, ls
+; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas1_acq_rel
+; CHECK-OUTLINE-O0-NEXT:    ldr w9, [sp, #8] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #12] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    and w8, w0, #0xff
+; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w9, uxtb
+; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    b.eq LBB38_2
+; CHECK-OUTLINE-O0-NEXT:    b LBB38_1
+; CHECK-OUTLINE-O0-NEXT:  LBB38_2: ; %atomicrmw.end
+; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
+; CHECK-OUTLINE-O0-NEXT:    add sp, sp, #48
+; CHECK-OUTLINE-O0-NEXT:    ret
+;
+; CHECK-LSE-O1-LABEL: atomicrmw_umin_i8:
+; CHECK-LSE-O1:       ; %bb.0:
+; CHECK-LSE-O1-NEXT:    lduminalb w1, w0, [x0]
+; CHECK-LSE-O1-NEXT:    ret
+;
+; CHECK-LSE-O0-LABEL: atomicrmw_umin_i8:
+; CHECK-LSE-O0:       ; %bb.0:
+; CHECK-LSE-O0-NEXT:    lduminalb w1, w0, [x0]
+; CHECK-LSE-O0-NEXT:    ret
+  %res = atomicrmw umin ptr %ptr, i8 %rhs seq_cst
+  ret i8 %res
+}
+
+define i8 @atomicrmw_umax_i8(ptr %ptr, i8 %rhs) {
+; CHECK-NOLSE-O1-LABEL: atomicrmw_umax_i8:
+; CHECK-NOLSE-O1:       ; %bb.0:
+; CHECK-NOLSE-O1-NEXT:    and w9, w1, #0xff
+; CHECK-NOLSE-O1-NEXT:  LBB39_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-NOLSE-O1-NEXT:    ldxrb w8, [x0]
+; CHECK-NOLSE-O1-NEXT:    and w8, w8, #0xff
+; CHECK-NOLSE-O1-NEXT:    cmp w8, w9
+; CHECK-NOLSE-O1-NEXT:    csel w10, w8, w9, hi
+; CHECK-NOLSE-O1-NEXT:    stxrb w11, w10, [x0]
+; CHECK-NOLSE-O1-NEXT:    cbnz w11, LBB39_1
+; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
+; CHECK-NOLSE-O1-NEXT:    mov w0, w8
+; CHECK-NOLSE-O1-NEXT:    ret
+;
+; CHECK-OUTLINE-O1-LABEL: atomicrmw_umax_i8:
+; CHECK-OUTLINE-O1:       ; %bb.0:
+; CHECK-OUTLINE-O1-NEXT:    and w9, w1, #0xff
+; CHECK-OUTLINE-O1-NEXT:  LBB39_1: ; %atomicrmw.start
+; CHECK-OUTLINE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-OUTLINE-O1-NEXT:    ldxrb w8, [x0]
+; CHECK-OUTLINE-O1-NEXT:    and w8, w8, #0xff
+; CHECK-OUTLINE-O1-NEXT:    cmp w8, w9
+; CHECK-OUTLINE-O1-NEXT:    csel w10, w8, w9, hi
+; CHECK-OUTLINE-O1-NEXT:    stxrb w11, w10, [x0]
+; CHECK-OUTLINE-O1-NEXT:    cbnz w11, LBB39_1
+; CHECK-OUTLINE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
+; CHECK-OUTLINE-O1-NEXT:    mov w0, w8
+; CHECK-OUTLINE-O1-NEXT:    ret
+;
+; CHECK-NOLSE-O0-LABEL: atomicrmw_umax_i8:
+; CHECK-NOLSE-O0:       ; %bb.0:
+; CHECK-NOLSE-O0-NEXT:    sub sp, sp, #32
+; CHECK-NOLSE-O0-NEXT:    .cfi_def_cfa_offset 32
+; CHECK-NOLSE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    ldrb w8, [x0]
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b LBB39_1
+; CHECK-NOLSE-O0-NEXT:  LBB39_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB39_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    and w9, w10, #0xff
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w8, uxtb
+; CHECK-NOLSE-O0-NEXT:    csel w12, w10, w8, hi
+; CHECK-NOLSE-O0-NEXT:  LBB39_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB39_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
+; CHECK-NOLSE-O0-NEXT:    ldaxrb w8, [x11]
+; CHECK-NOLSE-O0-NEXT:    cmp w8, w10, uxtb
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB39_4
+; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB39_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    stlxrb w9, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB39_2
+; CHECK-NOLSE-O0-NEXT:  LBB39_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB39_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    and w9, w8, #0xff
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxtb
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB39_5
+; CHECK-NOLSE-O0-NEXT:    b LBB39_1
+; CHECK-NOLSE-O0-NEXT:  LBB39_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
+; CHECK-NOLSE-O0-NEXT:    ret
+;
+; CHECK-OUTLINE-O0-LABEL: atomicrmw_umax_i8:
+; CHECK-OUTLINE-O0:       ; %bb.0:
+; CHECK-OUTLINE-O0-NEXT:    sub sp, sp, #48
+; CHECK-OUTLINE-O0-NEXT:    stp x29, x30, [sp, #32] ; 16-byte Folded Spill
+; CHECK-OUTLINE-O0-NEXT:    .cfi_def_cfa_offset 48
+; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w30, -8
+; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w29, -16
+; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    ldrb w0, [x0]
+; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    b LBB39_1
+; CHECK-OUTLINE-O0-NEXT:  LBB39_1: ; %atomicrmw.start
+; CHECK-OUTLINE-O0-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #28] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldr x2, [sp, #16] ; 8-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #8] ; 4-byte Spill
 ; CHECK-OUTLINE-O0-NEXT:    and w9, w0, #0xff
 ; CHECK-OUTLINE-O0-NEXT:    subs w9, w9, w8, uxtb
 ; CHECK-OUTLINE-O0-NEXT:    csel w1, w0, w8, hi
@@ -2856,9 +3182,9 @@ define i8 @atomicrmw_umax_i8(ptr %ptr, i8 %rhs) {
 ; CHECK-OUTLINE-O0-NEXT:    and w8, w0, #0xff
 ; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w9, uxtb
 ; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    b.eq LBB36_2
-; CHECK-OUTLINE-O0-NEXT:    b LBB36_1
-; CHECK-OUTLINE-O0-NEXT:  LBB36_2: ; %atomicrmw.end
+; CHECK-OUTLINE-O0-NEXT:    b.eq LBB39_2
+; CHECK-OUTLINE-O0-NEXT:    b LBB39_1
+; CHECK-OUTLINE-O0-NEXT:  LBB39_2: ; %atomicrmw.end
 ; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
 ; CHECK-OUTLINE-O0-NEXT:    add sp, sp, #48
@@ -2880,12 +3206,12 @@ define i8 @atomicrmw_umax_i8(ptr %ptr, i8 %rhs) {
 define i16 @atomicrmw_add_i16(ptr %ptr, i16 %rhs) {
 ; CHECK-NOLSE-O1-LABEL: atomicrmw_add_i16:
 ; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB37_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:  LBB40_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O1-NEXT:    ldaxrh w8, [x0]
 ; CHECK-NOLSE-O1-NEXT:    add w9, w8, w1
 ; CHECK-NOLSE-O1-NEXT:    stlxrh w10, w9, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB37_1
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB40_1
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; CHECK-NOLSE-O1-NEXT:    mov w0, w8
 ; CHECK-NOLSE-O1-NEXT:    ret
@@ -2911,34 +3237,34 @@ define i16 @atomicrmw_add_i16(ptr %ptr, i16 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    ldrh w8, [x0]
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB37_1
-; CHECK-NOLSE-O0-NEXT:  LBB37_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    b LBB40_1
+; CHECK-NOLSE-O0-NEXT:  LBB40_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB37_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB40_2 Depth 2
 ; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #28] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr w9, [sp, #24] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add w12, w9, w8, uxth
-; CHECK-NOLSE-O0-NEXT:  LBB37_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB37_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:  LBB40_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB40_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxrh w10, [x11]
 ; CHECK-NOLSE-O0-NEXT:    cmp w10, w8, uxth
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB37_4
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB40_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB37_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB40_2 Depth=2
 ; CHECK-NOLSE-O0-NEXT:    stlxrh w9, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB37_2
-; CHECK-NOLSE-O0-NEXT:  LBB37_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB37_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB40_2
+; CHECK-NOLSE-O0-NEXT:  LBB40_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB40_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    str w10, [sp, #12] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    uxth w9, w8
 ; CHECK-NOLSE-O0-NEXT:    mov w8, w10
 ; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxth
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB37_5
-; CHECK-NOLSE-O0-NEXT:    b LBB37_1
-; CHECK-NOLSE-O0-NEXT:  LBB37_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB40_5
+; CHECK-NOLSE-O0-NEXT:    b LBB40_1
+; CHECK-NOLSE-O0-NEXT:  LBB40_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
 ; CHECK-NOLSE-O0-NEXT:    ret
@@ -2974,11 +3300,11 @@ define i16 @atomicrmw_add_i16(ptr %ptr, i16 %rhs) {
 define i16 @atomicrmw_xchg_i16(ptr %ptr, i16 %rhs) {
 ; CHECK-NOLSE-O1-LABEL: atomicrmw_xchg_i16:
 ; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB38_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:  LBB41_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O1-NEXT:    ldxrh w8, [x0]
 ; CHECK-NOLSE-O1-NEXT:    stxrh w9, w1, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w9, LBB38_1
+; CHECK-NOLSE-O1-NEXT:    cbnz w9, LBB41_1
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; CHECK-NOLSE-O1-NEXT:    mov w0, w8
 ; CHECK-NOLSE-O1-NEXT:    ret
@@ -3004,33 +3330,33 @@ define i16 @atomicrmw_xchg_i16(ptr %ptr, i16 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    ldrh w8, [x0]
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB38_1
-; CHECK-NOLSE-O0-NEXT:  LBB38_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    b LBB41_1
+; CHECK-NOLSE-O0-NEXT:  LBB41_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB38_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB41_2 Depth 2
 ; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #28] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr w12, [sp, #24] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:  LBB38_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB38_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:  LBB41_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB41_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxrh w10, [x11]
 ; CHECK-NOLSE-O0-NEXT:    cmp w10, w8, uxth
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB38_4
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB41_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB38_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB41_2 Depth=2
 ; CHECK-NOLSE-O0-NEXT:    stlxrh w9, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB38_2
-; CHECK-NOLSE-O0-NEXT:  LBB38_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB38_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB41_2
+; CHECK-NOLSE-O0-NEXT:  LBB41_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB41_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    str w10, [sp, #12] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    uxth w9, w8
 ; CHECK-NOLSE-O0-NEXT:    mov w8, w10
 ; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxth
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB38_5
-; CHECK-NOLSE-O0-NEXT:    b LBB38_1
-; CHECK-NOLSE-O0-NEXT:  LBB38_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB41_5
+; CHECK-NOLSE-O0-NEXT:    b LBB41_1
+; CHECK-NOLSE-O0-NEXT:  LBB41_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
 ; CHECK-NOLSE-O0-NEXT:    ret
@@ -3066,12 +3392,12 @@ define i16 @atomicrmw_xchg_i16(ptr %ptr, i16 %rhs) {
 define i16 @atomicrmw_sub_i16(ptr %ptr, i16 %rhs) {
 ; CHECK-NOLSE-O1-LABEL: atomicrmw_sub_i16:
 ; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB39_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:  LBB42_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O1-NEXT:    ldaxrh w8, [x0]
 ; CHECK-NOLSE-O1-NEXT:    sub w9, w8, w1
 ; CHECK-NOLSE-O1-NEXT:    stxrh w10, w9, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB39_1
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB42_1
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; CHECK-NOLSE-O1-NEXT:    mov w0, w8
 ; CHECK-NOLSE-O1-NEXT:    ret
@@ -3097,34 +3423,34 @@ define i16 @atomicrmw_sub_i16(ptr %ptr, i16 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    ldrh w8, [x0]
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB39_1
-; CHECK-NOLSE-O0-NEXT:  LBB39_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    b LBB42_1
+; CHECK-NOLSE-O0-NEXT:  LBB42_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB39_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB42_2 Depth 2
 ; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #28] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr w9, [sp, #24] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    subs w12, w8, w9
-; CHECK-NOLSE-O0-NEXT:  LBB39_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB39_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:  LBB42_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB42_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxrh w10, [x11]
 ; CHECK-NOLSE-O0-NEXT:    cmp w10, w8, uxth
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB39_4
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB42_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB39_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB42_2 Depth=2
 ; CHECK-NOLSE-O0-NEXT:    stlxrh w9, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB39_2
-; CHECK-NOLSE-O0-NEXT:  LBB39_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB39_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB42_2
+; CHECK-NOLSE-O0-NEXT:  LBB42_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB42_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    str w10, [sp, #12] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    uxth w9, w8
 ; CHECK-NOLSE-O0-NEXT:    mov w8, w10
 ; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxth
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB39_5
-; CHECK-NOLSE-O0-NEXT:    b LBB39_1
-; CHECK-NOLSE-O0-NEXT:  LBB39_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB42_5
+; CHECK-NOLSE-O0-NEXT:    b LBB42_1
+; CHECK-NOLSE-O0-NEXT:  LBB42_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
 ; CHECK-NOLSE-O0-NEXT:    ret
@@ -3164,12 +3490,12 @@ define i16 @atomicrmw_sub_i16(ptr %ptr, i16 %rhs) {
 define i16 @atomicrmw_and_i16(ptr %ptr, i16 %rhs) {
 ; CHECK-NOLSE-O1-LABEL: atomicrmw_and_i16:
 ; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB40_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:  LBB43_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O1-NEXT:    ldxrh w8, [x0]
 ; CHECK-NOLSE-O1-NEXT:    and w9, w8, w1
 ; CHECK-NOLSE-O1-NEXT:    stlxrh w10, w9, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB40_1
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB43_1
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; CHECK-NOLSE-O1-NEXT:    mov w0, w8
 ; CHECK-NOLSE-O1-NEXT:    ret
@@ -3195,34 +3521,34 @@ define i16 @atomicrmw_and_i16(ptr %ptr, i16 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    ldrh w8, [x0]
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB40_1
-; CHECK-NOLSE-O0-NEXT:  LBB40_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    b LBB43_1
+; CHECK-NOLSE-O0-NEXT:  LBB43_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB40_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB43_2 Depth 2
 ; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #28] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr w9, [sp, #24] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    and w12, w8, w9
-; CHECK-NOLSE-O0-NEXT:  LBB40_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB40_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:  LBB43_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB43_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxrh w10, [x11]
 ; CHECK-NOLSE-O0-NEXT:    cmp w10, w8, uxth
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB40_4
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB43_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB40_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB43_2 Depth=2
 ; CHECK-NOLSE-O0-NEXT:    stlxrh w9, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB40_2
-; CHECK-NOLSE-O0-NEXT:  LBB40_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB40_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB43_2
+; CHECK-NOLSE-O0-NEXT:  LBB43_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB43_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    str w10, [sp, #12] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    uxth w9, w8
 ; CHECK-NOLSE-O0-NEXT:    mov w8, w10
 ; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxth
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB40_5
-; CHECK-NOLSE-O0-NEXT:    b LBB40_1
-; CHECK-NOLSE-O0-NEXT:  LBB40_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB43_5
+; CHECK-NOLSE-O0-NEXT:    b LBB43_1
+; CHECK-NOLSE-O0-NEXT:  LBB43_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
 ; CHECK-NOLSE-O0-NEXT:    ret
@@ -3262,12 +3588,12 @@ define i16 @atomicrmw_and_i16(ptr %ptr, i16 %rhs) {
 define i16 @atomicrmw_or_i16(ptr %ptr, i16 %rhs) {
 ; CHECK-NOLSE-O1-LABEL: atomicrmw_or_i16:
 ; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB41_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:  LBB44_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O1-NEXT:    ldaxrh w8, [x0]
 ; CHECK-NOLSE-O1-NEXT:    orr w9, w8, w1
 ; CHECK-NOLSE-O1-NEXT:    stlxrh w10, w9, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB41_1
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB44_1
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; CHECK-NOLSE-O1-NEXT:    mov w0, w8
 ; CHECK-NOLSE-O1-NEXT:    ret
@@ -3293,34 +3619,34 @@ define i16 @atomicrmw_or_i16(ptr %ptr, i16 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    ldrh w8, [x0]
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB41_1
-; CHECK-NOLSE-O0-NEXT:  LBB41_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    b LBB44_1
+; CHECK-NOLSE-O0-NEXT:  LBB44_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB41_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB44_2 Depth 2
 ; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #28] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr w9, [sp, #24] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    orr w12, w8, w9
-; CHECK-NOLSE-O0-NEXT:  LBB41_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB41_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:  LBB44_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB44_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxrh w10, [x11]
 ; CHECK-NOLSE-O0-NEXT:    cmp w10, w8, uxth
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB41_4
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB44_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB41_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB44_2 Depth=2
 ; CHECK-NOLSE-O0-NEXT:    stlxrh w9, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB41_2
-; CHECK-NOLSE-O0-NEXT:  LBB41_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB41_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB44_2
+; CHECK-NOLSE-O0-NEXT:  LBB44_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB44_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    str w10, [sp, #12] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    uxth w9, w8
 ; CHECK-NOLSE-O0-NEXT:    mov w8, w10
 ; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxth
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB41_5
-; CHECK-NOLSE-O0-NEXT:    b LBB41_1
-; CHECK-NOLSE-O0-NEXT:  LBB41_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB44_5
+; CHECK-NOLSE-O0-NEXT:    b LBB44_1
+; CHECK-NOLSE-O0-NEXT:  LBB44_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
 ; CHECK-NOLSE-O0-NEXT:    ret
@@ -3356,12 +3682,12 @@ define i16 @atomicrmw_or_i16(ptr %ptr, i16 %rhs) {
 define i16 @atomicrmw_xor_i16(ptr %ptr, i16 %rhs) {
 ; CHECK-NOLSE-O1-LABEL: atomicrmw_xor_i16:
 ; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB42_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:  LBB45_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O1-NEXT:    ldxrh w8, [x0]
 ; CHECK-NOLSE-O1-NEXT:    eor w9, w8, w1
 ; CHECK-NOLSE-O1-NEXT:    stxrh w10, w9, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB42_1
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB45_1
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; CHECK-NOLSE-O1-NEXT:    mov w0, w8
 ; CHECK-NOLSE-O1-NEXT:    ret
@@ -3387,34 +3713,34 @@ define i16 @atomicrmw_xor_i16(ptr %ptr, i16 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    ldrh w8, [x0]
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB42_1
-; CHECK-NOLSE-O0-NEXT:  LBB42_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    b LBB45_1
+; CHECK-NOLSE-O0-NEXT:  LBB45_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB42_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB45_2 Depth 2
 ; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #28] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr w9, [sp, #24] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    eor w12, w8, w9
-; CHECK-NOLSE-O0-NEXT:  LBB42_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB42_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:  LBB45_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB45_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxrh w10, [x11]
 ; CHECK-NOLSE-O0-NEXT:    cmp w10, w8, uxth
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB42_4
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB45_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB42_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB45_2 Depth=2
 ; CHECK-NOLSE-O0-NEXT:    stlxrh w9, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB42_2
-; CHECK-NOLSE-O0-NEXT:  LBB42_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB42_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB45_2
+; CHECK-NOLSE-O0-NEXT:  LBB45_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB45_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    str w10, [sp, #12] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    uxth w9, w8
 ; CHECK-NOLSE-O0-NEXT:    mov w8, w10
 ; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxth
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB42_5
-; CHECK-NOLSE-O0-NEXT:    b LBB42_1
-; CHECK-NOLSE-O0-NEXT:  LBB42_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB45_5
+; CHECK-NOLSE-O0-NEXT:    b LBB45_1
+; CHECK-NOLSE-O0-NEXT:  LBB45_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
 ; CHECK-NOLSE-O0-NEXT:    ret
@@ -3450,400 +3776,33 @@ define i16 @atomicrmw_xor_i16(ptr %ptr, i16 %rhs) {
 define i16 @atomicrmw_min_i16(ptr %ptr, i16 %rhs) {
 ; CHECK-NOLSE-O1-LABEL: atomicrmw_min_i16:
 ; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB43_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:  LBB46_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O1-NEXT:    ldaxrh w8, [x0]
 ; CHECK-NOLSE-O1-NEXT:    sxth w9, w8
 ; CHECK-NOLSE-O1-NEXT:    cmp w9, w1, sxth
 ; CHECK-NOLSE-O1-NEXT:    csel w9, w8, w1, lt
 ; CHECK-NOLSE-O1-NEXT:    stxrh w10, w9, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB43_1
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB46_1
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; CHECK-NOLSE-O1-NEXT:    mov w0, w8
 ; CHECK-NOLSE-O1-NEXT:    ret
 ;
 ; CHECK-OUTLINE-O1-LABEL: atomicrmw_min_i16:
 ; CHECK-OUTLINE-O1:       ; %bb.0:
-; CHECK-OUTLINE-O1-NEXT:  LBB43_1: ; %atomicrmw.start
+; CHECK-OUTLINE-O1-NEXT:  LBB46_1: ; %atomicrmw.start
 ; CHECK-OUTLINE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-OUTLINE-O1-NEXT:    ldaxrh w8, [x0]
 ; CHECK-OUTLINE-O1-NEXT:    sxth w9, w8
 ; CHECK-OUTLINE-O1-NEXT:    cmp w9, w1, sxth
 ; CHECK-OUTLINE-O1-NEXT:    csel w9, w8, w1, lt
 ; CHECK-OUTLINE-O1-NEXT:    stxrh w10, w9, [x0]
-; CHECK-OUTLINE-O1-NEXT:    cbnz w10, LBB43_1
+; CHECK-OUTLINE-O1-NEXT:    cbnz w10, LBB46_1
 ; CHECK-OUTLINE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; CHECK-OUTLINE-O1-NEXT:    mov w0, w8
 ; CHECK-OUTLINE-O1-NEXT:    ret
 ;
 ; CHECK-NOLSE-O0-LABEL: atomicrmw_min_i16:
-; CHECK-NOLSE-O0:       ; %bb.0:
-; CHECK-NOLSE-O0-NEXT:    sub sp, sp, #32
-; CHECK-NOLSE-O0-NEXT:    .cfi_def_cfa_offset 32
-; CHECK-NOLSE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    ldrh w8, [x0]
-; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB43_1
-; CHECK-NOLSE-O0-NEXT:  LBB43_1: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB43_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #28] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr w9, [sp, #24] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    sxth w10, w8
-; CHECK-NOLSE-O0-NEXT:    subs w10, w10, w9, sxth
-; CHECK-NOLSE-O0-NEXT:    csel w12, w8, w9, le
-; CHECK-NOLSE-O0-NEXT:  LBB43_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB43_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
-; CHECK-NOLSE-O0-NEXT:    ldaxrh w10, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w10, w8, uxth
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB43_4
-; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB43_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxrh w9, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB43_2
-; CHECK-NOLSE-O0-NEXT:  LBB43_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB43_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    str w10, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    uxth w9, w8
-; CHECK-NOLSE-O0-NEXT:    mov w8, w10
-; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxth
-; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB43_5
-; CHECK-NOLSE-O0-NEXT:    b LBB43_1
-; CHECK-NOLSE-O0-NEXT:  LBB43_5: ; %atomicrmw.end
-; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
-; CHECK-NOLSE-O0-NEXT:    ret
-;
-; CHECK-OUTLINE-O0-LABEL: atomicrmw_min_i16:
-; CHECK-OUTLINE-O0:       ; %bb.0:
-; CHECK-OUTLINE-O0-NEXT:    sub sp, sp, #48
-; CHECK-OUTLINE-O0-NEXT:    stp x29, x30, [sp, #32] ; 16-byte Folded Spill
-; CHECK-OUTLINE-O0-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w30, -8
-; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w29, -16
-; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    ldrh w0, [x0]
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    b LBB43_1
-; CHECK-OUTLINE-O0-NEXT:  LBB43_1: ; %atomicrmw.start
-; CHECK-OUTLINE-O0-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #28] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldr x2, [sp, #16] ; 8-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #8] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    sxth w9, w0
-; CHECK-OUTLINE-O0-NEXT:    subs w9, w9, w8, sxth
-; CHECK-OUTLINE-O0-NEXT:    csel w1, w0, w8, le
-; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas2_acq
-; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #8] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    mov w9, w0
-; CHECK-OUTLINE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    uxth w8, w8
-; CHECK-OUTLINE-O0-NEXT:    mov w0, w9
-; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w9, uxth
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    b.eq LBB43_2
-; CHECK-OUTLINE-O0-NEXT:    b LBB43_1
-; CHECK-OUTLINE-O0-NEXT:  LBB43_2: ; %atomicrmw.end
-; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
-; CHECK-OUTLINE-O0-NEXT:    add sp, sp, #48
-; CHECK-OUTLINE-O0-NEXT:    ret
-;
-; CHECK-LSE-O1-LABEL: atomicrmw_min_i16:
-; CHECK-LSE-O1:       ; %bb.0:
-; CHECK-LSE-O1-NEXT:    ldsminah w1, w0, [x0]
-; CHECK-LSE-O1-NEXT:    ret
-;
-; CHECK-LSE-O0-LABEL: atomicrmw_min_i16:
-; CHECK-LSE-O0:       ; %bb.0:
-; CHECK-LSE-O0-NEXT:    ldsminah w1, w0, [x0]
-; CHECK-LSE-O0-NEXT:    ret
-  %res = atomicrmw min ptr %ptr, i16 %rhs acquire
-  ret i16 %res
-}
-
-define i16 @atomicrmw_max_i16(ptr %ptr, i16 %rhs) {
-; CHECK-NOLSE-O1-LABEL: atomicrmw_max_i16:
-; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB44_1: ; %atomicrmw.start
-; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-NOLSE-O1-NEXT:    ldxrh w8, [x0]
-; CHECK-NOLSE-O1-NEXT:    sxth w9, w8
-; CHECK-NOLSE-O1-NEXT:    cmp w9, w1, sxth
-; CHECK-NOLSE-O1-NEXT:    csel w9, w8, w1, gt
-; CHECK-NOLSE-O1-NEXT:    stlxrh w10, w9, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB44_1
-; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
-; CHECK-NOLSE-O1-NEXT:    mov w0, w8
-; CHECK-NOLSE-O1-NEXT:    ret
-;
-; CHECK-OUTLINE-O1-LABEL: atomicrmw_max_i16:
-; CHECK-OUTLINE-O1:       ; %bb.0:
-; CHECK-OUTLINE-O1-NEXT:  LBB44_1: ; %atomicrmw.start
-; CHECK-OUTLINE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-OUTLINE-O1-NEXT:    ldxrh w8, [x0]
-; CHECK-OUTLINE-O1-NEXT:    sxth w9, w8
-; CHECK-OUTLINE-O1-NEXT:    cmp w9, w1, sxth
-; CHECK-OUTLINE-O1-NEXT:    csel w9, w8, w1, gt
-; CHECK-OUTLINE-O1-NEXT:    stlxrh w10, w9, [x0]
-; CHECK-OUTLINE-O1-NEXT:    cbnz w10, LBB44_1
-; CHECK-OUTLINE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
-; CHECK-OUTLINE-O1-NEXT:    mov w0, w8
-; CHECK-OUTLINE-O1-NEXT:    ret
-;
-; CHECK-NOLSE-O0-LABEL: atomicrmw_max_i16:
-; CHECK-NOLSE-O0:       ; %bb.0:
-; CHECK-NOLSE-O0-NEXT:    sub sp, sp, #32
-; CHECK-NOLSE-O0-NEXT:    .cfi_def_cfa_offset 32
-; CHECK-NOLSE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    ldrh w8, [x0]
-; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB44_1
-; CHECK-NOLSE-O0-NEXT:  LBB44_1: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB44_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #28] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr w9, [sp, #24] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    sxth w10, w8
-; CHECK-NOLSE-O0-NEXT:    subs w10, w10, w9, sxth
-; CHECK-NOLSE-O0-NEXT:    csel w12, w8, w9, gt
-; CHECK-NOLSE-O0-NEXT:  LBB44_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB44_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
-; CHECK-NOLSE-O0-NEXT:    ldaxrh w10, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w10, w8, uxth
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB44_4
-; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB44_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxrh w9, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB44_2
-; CHECK-NOLSE-O0-NEXT:  LBB44_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB44_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    str w10, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    uxth w9, w8
-; CHECK-NOLSE-O0-NEXT:    mov w8, w10
-; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxth
-; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB44_5
-; CHECK-NOLSE-O0-NEXT:    b LBB44_1
-; CHECK-NOLSE-O0-NEXT:  LBB44_5: ; %atomicrmw.end
-; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
-; CHECK-NOLSE-O0-NEXT:    ret
-;
-; CHECK-OUTLINE-O0-LABEL: atomicrmw_max_i16:
-; CHECK-OUTLINE-O0:       ; %bb.0:
-; CHECK-OUTLINE-O0-NEXT:    sub sp, sp, #48
-; CHECK-OUTLINE-O0-NEXT:    stp x29, x30, [sp, #32] ; 16-byte Folded Spill
-; CHECK-OUTLINE-O0-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w30, -8
-; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w29, -16
-; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    ldrh w0, [x0]
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    b LBB44_1
-; CHECK-OUTLINE-O0-NEXT:  LBB44_1: ; %atomicrmw.start
-; CHECK-OUTLINE-O0-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #28] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldr x2, [sp, #16] ; 8-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #8] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    sxth w9, w0
-; CHECK-OUTLINE-O0-NEXT:    subs w9, w9, w8, sxth
-; CHECK-OUTLINE-O0-NEXT:    csel w1, w0, w8, gt
-; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas2_rel
-; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #8] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    mov w9, w0
-; CHECK-OUTLINE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    uxth w8, w8
-; CHECK-OUTLINE-O0-NEXT:    mov w0, w9
-; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w9, uxth
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    b.eq LBB44_2
-; CHECK-OUTLINE-O0-NEXT:    b LBB44_1
-; CHECK-OUTLINE-O0-NEXT:  LBB44_2: ; %atomicrmw.end
-; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
-; CHECK-OUTLINE-O0-NEXT:    add sp, sp, #48
-; CHECK-OUTLINE-O0-NEXT:    ret
-;
-; CHECK-LSE-O1-LABEL: atomicrmw_max_i16:
-; CHECK-LSE-O1:       ; %bb.0:
-; CHECK-LSE-O1-NEXT:    ldsmaxlh w1, w0, [x0]
-; CHECK-LSE-O1-NEXT:    ret
-;
-; CHECK-LSE-O0-LABEL: atomicrmw_max_i16:
-; CHECK-LSE-O0:       ; %bb.0:
-; CHECK-LSE-O0-NEXT:    ldsmaxlh w1, w0, [x0]
-; CHECK-LSE-O0-NEXT:    ret
-  %res = atomicrmw max ptr %ptr, i16 %rhs release
-  ret i16 %res
-}
-
-define i16 @atomicrmw_umin_i16(ptr %ptr, i16 %rhs) {
-; CHECK-NOLSE-O1-LABEL: atomicrmw_umin_i16:
-; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:    and w9, w1, #0xffff
-; CHECK-NOLSE-O1-NEXT:  LBB45_1: ; %atomicrmw.start
-; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-NOLSE-O1-NEXT:    ldaxrh w8, [x0]
-; CHECK-NOLSE-O1-NEXT:    and w8, w8, #0xffff
-; CHECK-NOLSE-O1-NEXT:    cmp w8, w9
-; CHECK-NOLSE-O1-NEXT:    csel w10, w8, w9, lo
-; CHECK-NOLSE-O1-NEXT:    stlxrh w11, w10, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w11, LBB45_1
-; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
-; CHECK-NOLSE-O1-NEXT:    mov w0, w8
-; CHECK-NOLSE-O1-NEXT:    ret
-;
-; CHECK-OUTLINE-O1-LABEL: atomicrmw_umin_i16:
-; CHECK-OUTLINE-O1:       ; %bb.0:
-; CHECK-OUTLINE-O1-NEXT:    and w9, w1, #0xffff
-; CHECK-OUTLINE-O1-NEXT:  LBB45_1: ; %atomicrmw.start
-; CHECK-OUTLINE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-OUTLINE-O1-NEXT:    ldaxrh w8, [x0]
-; CHECK-OUTLINE-O1-NEXT:    and w8, w8, #0xffff
-; CHECK-OUTLINE-O1-NEXT:    cmp w8, w9
-; CHECK-OUTLINE-O1-NEXT:    csel w10, w8, w9, lo
-; CHECK-OUTLINE-O1-NEXT:    stlxrh w11, w10, [x0]
-; CHECK-OUTLINE-O1-NEXT:    cbnz w11, LBB45_1
-; CHECK-OUTLINE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
-; CHECK-OUTLINE-O1-NEXT:    mov w0, w8
-; CHECK-OUTLINE-O1-NEXT:    ret
-;
-; CHECK-NOLSE-O0-LABEL: atomicrmw_umin_i16:
-; CHECK-NOLSE-O0:       ; %bb.0:
-; CHECK-NOLSE-O0-NEXT:    sub sp, sp, #32
-; CHECK-NOLSE-O0-NEXT:    .cfi_def_cfa_offset 32
-; CHECK-NOLSE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    ldrh w8, [x0]
-; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB45_1
-; CHECK-NOLSE-O0-NEXT:  LBB45_1: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB45_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #28] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr w9, [sp, #24] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    uxth w10, w8
-; CHECK-NOLSE-O0-NEXT:    subs w10, w10, w9, uxth
-; CHECK-NOLSE-O0-NEXT:    csel w12, w8, w9, ls
-; CHECK-NOLSE-O0-NEXT:  LBB45_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB45_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
-; CHECK-NOLSE-O0-NEXT:    ldaxrh w10, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w10, w8, uxth
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB45_4
-; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB45_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxrh w9, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB45_2
-; CHECK-NOLSE-O0-NEXT:  LBB45_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB45_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    str w10, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    uxth w9, w8
-; CHECK-NOLSE-O0-NEXT:    mov w8, w10
-; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxth
-; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB45_5
-; CHECK-NOLSE-O0-NEXT:    b LBB45_1
-; CHECK-NOLSE-O0-NEXT:  LBB45_5: ; %atomicrmw.end
-; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
-; CHECK-NOLSE-O0-NEXT:    ret
-;
-; CHECK-OUTLINE-O0-LABEL: atomicrmw_umin_i16:
-; CHECK-OUTLINE-O0:       ; %bb.0:
-; CHECK-OUTLINE-O0-NEXT:    sub sp, sp, #48
-; CHECK-OUTLINE-O0-NEXT:    stp x29, x30, [sp, #32] ; 16-byte Folded Spill
-; CHECK-OUTLINE-O0-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w30, -8
-; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w29, -16
-; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    ldrh w0, [x0]
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    b LBB45_1
-; CHECK-OUTLINE-O0-NEXT:  LBB45_1: ; %atomicrmw.start
-; CHECK-OUTLINE-O0-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #28] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldr x2, [sp, #16] ; 8-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #8] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    uxth w9, w0
-; CHECK-OUTLINE-O0-NEXT:    subs w9, w9, w8, uxth
-; CHECK-OUTLINE-O0-NEXT:    csel w1, w0, w8, ls
-; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas2_acq_rel
-; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #8] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    mov w9, w0
-; CHECK-OUTLINE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    uxth w8, w8
-; CHECK-OUTLINE-O0-NEXT:    mov w0, w9
-; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w9, uxth
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    b.eq LBB45_2
-; CHECK-OUTLINE-O0-NEXT:    b LBB45_1
-; CHECK-OUTLINE-O0-NEXT:  LBB45_2: ; %atomicrmw.end
-; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
-; CHECK-OUTLINE-O0-NEXT:    add sp, sp, #48
-; CHECK-OUTLINE-O0-NEXT:    ret
-;
-; CHECK-LSE-O1-LABEL: atomicrmw_umin_i16:
-; CHECK-LSE-O1:       ; %bb.0:
-; CHECK-LSE-O1-NEXT:    lduminalh w1, w0, [x0]
-; CHECK-LSE-O1-NEXT:    ret
-;
-; CHECK-LSE-O0-LABEL: atomicrmw_umin_i16:
-; CHECK-LSE-O0:       ; %bb.0:
-; CHECK-LSE-O0-NEXT:    lduminalh w1, w0, [x0]
-; CHECK-LSE-O0-NEXT:    ret
-  %res = atomicrmw umin ptr %ptr, i16 %rhs seq_cst
-  ret i16 %res
-}
-
-define i16 @atomicrmw_umax_i16(ptr %ptr, i16 %rhs) {
-; CHECK-NOLSE-O1-LABEL: atomicrmw_umax_i16:
-; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:    and w9, w1, #0xffff
-; CHECK-NOLSE-O1-NEXT:  LBB46_1: ; %atomicrmw.start
-; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-NOLSE-O1-NEXT:    ldxrh w8, [x0]
-; CHECK-NOLSE-O1-NEXT:    and w8, w8, #0xffff
-; CHECK-NOLSE-O1-NEXT:    cmp w8, w9
-; CHECK-NOLSE-O1-NEXT:    csel w10, w8, w9, hi
-; CHECK-NOLSE-O1-NEXT:    stxrh w11, w10, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w11, LBB46_1
-; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
-; CHECK-NOLSE-O1-NEXT:    mov w0, w8
-; CHECK-NOLSE-O1-NEXT:    ret
-;
-; CHECK-OUTLINE-O1-LABEL: atomicrmw_umax_i16:
-; CHECK-OUTLINE-O1:       ; %bb.0:
-; CHECK-OUTLINE-O1-NEXT:    and w9, w1, #0xffff
-; CHECK-OUTLINE-O1-NEXT:  LBB46_1: ; %atomicrmw.start
-; CHECK-OUTLINE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-OUTLINE-O1-NEXT:    ldxrh w8, [x0]
-; CHECK-OUTLINE-O1-NEXT:    and w8, w8, #0xffff
-; CHECK-OUTLINE-O1-NEXT:    cmp w8, w9
-; CHECK-OUTLINE-O1-NEXT:    csel w10, w8, w9, hi
-; CHECK-OUTLINE-O1-NEXT:    stxrh w11, w10, [x0]
-; CHECK-OUTLINE-O1-NEXT:    cbnz w11, LBB46_1
-; CHECK-OUTLINE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
-; CHECK-OUTLINE-O1-NEXT:    mov w0, w8
-; CHECK-OUTLINE-O1-NEXT:    ret
-;
-; CHECK-NOLSE-O0-LABEL: atomicrmw_umax_i16:
 ; CHECK-NOLSE-O0:       ; %bb.0:
 ; CHECK-NOLSE-O0-NEXT:    sub sp, sp, #32
 ; CHECK-NOLSE-O0-NEXT:    .cfi_def_cfa_offset 32
@@ -3858,9 +3817,9 @@ define i16 @atomicrmw_umax_i16(ptr %ptr, i16 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #28] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr w9, [sp, #24] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    uxth w10, w8
-; CHECK-NOLSE-O0-NEXT:    subs w10, w10, w9, uxth
-; CHECK-NOLSE-O0-NEXT:    csel w12, w8, w9, hi
+; CHECK-NOLSE-O0-NEXT:    sxth w10, w8
+; CHECK-NOLSE-O0-NEXT:    subs w10, w10, w9, sxth
+; CHECK-NOLSE-O0-NEXT:    csel w12, w8, w9, le
 ; CHECK-NOLSE-O0-NEXT:  LBB46_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB46_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
@@ -3885,7 +3844,7 @@ define i16 @atomicrmw_umax_i16(ptr %ptr, i16 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
 ; CHECK-NOLSE-O0-NEXT:    ret
 ;
-; CHECK-OUTLINE-O0-LABEL: atomicrmw_umax_i16:
+; CHECK-OUTLINE-O0-LABEL: atomicrmw_min_i16:
 ; CHECK-OUTLINE-O0:       ; %bb.0:
 ; CHECK-OUTLINE-O0-NEXT:    sub sp, sp, #48
 ; CHECK-OUTLINE-O0-NEXT:    stp x29, x30, [sp, #32] ; 16-byte Folded Spill
@@ -3903,6 +3862,373 @@ define i16 @atomicrmw_umax_i16(ptr %ptr, i16 %rhs) {
 ; CHECK-OUTLINE-O0-NEXT:    ldr x2, [sp, #16] ; 8-byte Reload
 ; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
 ; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #8] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    sxth w9, w0
+; CHECK-OUTLINE-O0-NEXT:    subs w9, w9, w8, sxth
+; CHECK-OUTLINE-O0-NEXT:    csel w1, w0, w8, le
+; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas2_acq
+; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #8] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    mov w9, w0
+; CHECK-OUTLINE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    uxth w8, w8
+; CHECK-OUTLINE-O0-NEXT:    mov w0, w9
+; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w9, uxth
+; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    b.eq LBB46_2
+; CHECK-OUTLINE-O0-NEXT:    b LBB46_1
+; CHECK-OUTLINE-O0-NEXT:  LBB46_2: ; %atomicrmw.end
+; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
+; CHECK-OUTLINE-O0-NEXT:    add sp, sp, #48
+; CHECK-OUTLINE-O0-NEXT:    ret
+;
+; CHECK-LSE-O1-LABEL: atomicrmw_min_i16:
+; CHECK-LSE-O1:       ; %bb.0:
+; CHECK-LSE-O1-NEXT:    ldsminah w1, w0, [x0]
+; CHECK-LSE-O1-NEXT:    ret
+;
+; CHECK-LSE-O0-LABEL: atomicrmw_min_i16:
+; CHECK-LSE-O0:       ; %bb.0:
+; CHECK-LSE-O0-NEXT:    ldsminah w1, w0, [x0]
+; CHECK-LSE-O0-NEXT:    ret
+  %res = atomicrmw min ptr %ptr, i16 %rhs acquire
+  ret i16 %res
+}
+
+define i16 @atomicrmw_max_i16(ptr %ptr, i16 %rhs) {
+; CHECK-NOLSE-O1-LABEL: atomicrmw_max_i16:
+; CHECK-NOLSE-O1:       ; %bb.0:
+; CHECK-NOLSE-O1-NEXT:  LBB47_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-NOLSE-O1-NEXT:    ldxrh w8, [x0]
+; CHECK-NOLSE-O1-NEXT:    sxth w9, w8
+; CHECK-NOLSE-O1-NEXT:    cmp w9, w1, sxth
+; CHECK-NOLSE-O1-NEXT:    csel w9, w8, w1, gt
+; CHECK-NOLSE-O1-NEXT:    stlxrh w10, w9, [x0]
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB47_1
+; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
+; CHECK-NOLSE-O1-NEXT:    mov w0, w8
+; CHECK-NOLSE-O1-NEXT:    ret
+;
+; CHECK-OUTLINE-O1-LABEL: atomicrmw_max_i16:
+; CHECK-OUTLINE-O1:       ; %bb.0:
+; CHECK-OUTLINE-O1-NEXT:  LBB47_1: ; %atomicrmw.start
+; CHECK-OUTLINE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-OUTLINE-O1-NEXT:    ldxrh w8, [x0]
+; CHECK-OUTLINE-O1-NEXT:    sxth w9, w8
+; CHECK-OUTLINE-O1-NEXT:    cmp w9, w1, sxth
+; CHECK-OUTLINE-O1-NEXT:    csel w9, w8, w1, gt
+; CHECK-OUTLINE-O1-NEXT:    stlxrh w10, w9, [x0]
+; CHECK-OUTLINE-O1-NEXT:    cbnz w10, LBB47_1
+; CHECK-OUTLINE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
+; CHECK-OUTLINE-O1-NEXT:    mov w0, w8
+; CHECK-OUTLINE-O1-NEXT:    ret
+;
+; CHECK-NOLSE-O0-LABEL: atomicrmw_max_i16:
+; CHECK-NOLSE-O0:       ; %bb.0:
+; CHECK-NOLSE-O0-NEXT:    sub sp, sp, #32
+; CHECK-NOLSE-O0-NEXT:    .cfi_def_cfa_offset 32
+; CHECK-NOLSE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    ldrh w8, [x0]
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b LBB47_1
+; CHECK-NOLSE-O0-NEXT:  LBB47_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB47_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #28] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr w9, [sp, #24] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    sxth w10, w8
+; CHECK-NOLSE-O0-NEXT:    subs w10, w10, w9, sxth
+; CHECK-NOLSE-O0-NEXT:    csel w12, w8, w9, gt
+; CHECK-NOLSE-O0-NEXT:  LBB47_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB47_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
+; CHECK-NOLSE-O0-NEXT:    ldaxrh w10, [x11]
+; CHECK-NOLSE-O0-NEXT:    cmp w10, w8, uxth
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB47_4
+; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB47_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    stlxrh w9, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB47_2
+; CHECK-NOLSE-O0-NEXT:  LBB47_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB47_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    str w10, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    uxth w9, w8
+; CHECK-NOLSE-O0-NEXT:    mov w8, w10
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxth
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB47_5
+; CHECK-NOLSE-O0-NEXT:    b LBB47_1
+; CHECK-NOLSE-O0-NEXT:  LBB47_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
+; CHECK-NOLSE-O0-NEXT:    ret
+;
+; CHECK-OUTLINE-O0-LABEL: atomicrmw_max_i16:
+; CHECK-OUTLINE-O0:       ; %bb.0:
+; CHECK-OUTLINE-O0-NEXT:    sub sp, sp, #48
+; CHECK-OUTLINE-O0-NEXT:    stp x29, x30, [sp, #32] ; 16-byte Folded Spill
+; CHECK-OUTLINE-O0-NEXT:    .cfi_def_cfa_offset 48
+; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w30, -8
+; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w29, -16
+; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    ldrh w0, [x0]
+; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    b LBB47_1
+; CHECK-OUTLINE-O0-NEXT:  LBB47_1: ; %atomicrmw.start
+; CHECK-OUTLINE-O0-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #28] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldr x2, [sp, #16] ; 8-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #8] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    sxth w9, w0
+; CHECK-OUTLINE-O0-NEXT:    subs w9, w9, w8, sxth
+; CHECK-OUTLINE-O0-NEXT:    csel w1, w0, w8, gt
+; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas2_rel
+; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #8] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    mov w9, w0
+; CHECK-OUTLINE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    uxth w8, w8
+; CHECK-OUTLINE-O0-NEXT:    mov w0, w9
+; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w9, uxth
+; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    b.eq LBB47_2
+; CHECK-OUTLINE-O0-NEXT:    b LBB47_1
+; CHECK-OUTLINE-O0-NEXT:  LBB47_2: ; %atomicrmw.end
+; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
+; CHECK-OUTLINE-O0-NEXT:    add sp, sp, #48
+; CHECK-OUTLINE-O0-NEXT:    ret
+;
+; CHECK-LSE-O1-LABEL: atomicrmw_max_i16:
+; CHECK-LSE-O1:       ; %bb.0:
+; CHECK-LSE-O1-NEXT:    ldsmaxlh w1, w0, [x0]
+; CHECK-LSE-O1-NEXT:    ret
+;
+; CHECK-LSE-O0-LABEL: atomicrmw_max_i16:
+; CHECK-LSE-O0:       ; %bb.0:
+; CHECK-LSE-O0-NEXT:    ldsmaxlh w1, w0, [x0]
+; CHECK-LSE-O0-NEXT:    ret
+  %res = atomicrmw max ptr %ptr, i16 %rhs release
+  ret i16 %res
+}
+
+define i16 @atomicrmw_umin_i16(ptr %ptr, i16 %rhs) {
+; CHECK-NOLSE-O1-LABEL: atomicrmw_umin_i16:
+; CHECK-NOLSE-O1:       ; %bb.0:
+; CHECK-NOLSE-O1-NEXT:    and w9, w1, #0xffff
+; CHECK-NOLSE-O1-NEXT:  LBB48_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-NOLSE-O1-NEXT:    ldaxrh w8, [x0]
+; CHECK-NOLSE-O1-NEXT:    and w8, w8, #0xffff
+; CHECK-NOLSE-O1-NEXT:    cmp w8, w9
+; CHECK-NOLSE-O1-NEXT:    csel w10, w8, w9, lo
+; CHECK-NOLSE-O1-NEXT:    stlxrh w11, w10, [x0]
+; CHECK-NOLSE-O1-NEXT:    cbnz w11, LBB48_1
+; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
+; CHECK-NOLSE-O1-NEXT:    mov w0, w8
+; CHECK-NOLSE-O1-NEXT:    ret
+;
+; CHECK-OUTLINE-O1-LABEL: atomicrmw_umin_i16:
+; CHECK-OUTLINE-O1:       ; %bb.0:
+; CHECK-OUTLINE-O1-NEXT:    and w9, w1, #0xffff
+; CHECK-OUTLINE-O1-NEXT:  LBB48_1: ; %atomicrmw.start
+; CHECK-OUTLINE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-OUTLINE-O1-NEXT:    ldaxrh w8, [x0]
+; CHECK-OUTLINE-O1-NEXT:    and w8, w8, #0xffff
+; CHECK-OUTLINE-O1-NEXT:    cmp w8, w9
+; CHECK-OUTLINE-O1-NEXT:    csel w10, w8, w9, lo
+; CHECK-OUTLINE-O1-NEXT:    stlxrh w11, w10, [x0]
+; CHECK-OUTLINE-O1-NEXT:    cbnz w11, LBB48_1
+; CHECK-OUTLINE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
+; CHECK-OUTLINE-O1-NEXT:    mov w0, w8
+; CHECK-OUTLINE-O1-NEXT:    ret
+;
+; CHECK-NOLSE-O0-LABEL: atomicrmw_umin_i16:
+; CHECK-NOLSE-O0:       ; %bb.0:
+; CHECK-NOLSE-O0-NEXT:    sub sp, sp, #32
+; CHECK-NOLSE-O0-NEXT:    .cfi_def_cfa_offset 32
+; CHECK-NOLSE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    ldrh w8, [x0]
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b LBB48_1
+; CHECK-NOLSE-O0-NEXT:  LBB48_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB48_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #28] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr w9, [sp, #24] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    uxth w10, w8
+; CHECK-NOLSE-O0-NEXT:    subs w10, w10, w9, uxth
+; CHECK-NOLSE-O0-NEXT:    csel w12, w8, w9, ls
+; CHECK-NOLSE-O0-NEXT:  LBB48_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB48_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
+; CHECK-NOLSE-O0-NEXT:    ldaxrh w10, [x11]
+; CHECK-NOLSE-O0-NEXT:    cmp w10, w8, uxth
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB48_4
+; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB48_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    stlxrh w9, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB48_2
+; CHECK-NOLSE-O0-NEXT:  LBB48_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB48_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    str w10, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    uxth w9, w8
+; CHECK-NOLSE-O0-NEXT:    mov w8, w10
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxth
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB48_5
+; CHECK-NOLSE-O0-NEXT:    b LBB48_1
+; CHECK-NOLSE-O0-NEXT:  LBB48_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
+; CHECK-NOLSE-O0-NEXT:    ret
+;
+; CHECK-OUTLINE-O0-LABEL: atomicrmw_umin_i16:
+; CHECK-OUTLINE-O0:       ; %bb.0:
+; CHECK-OUTLINE-O0-NEXT:    sub sp, sp, #48
+; CHECK-OUTLINE-O0-NEXT:    stp x29, x30, [sp, #32] ; 16-byte Folded Spill
+; CHECK-OUTLINE-O0-NEXT:    .cfi_def_cfa_offset 48
+; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w30, -8
+; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w29, -16
+; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    ldrh w0, [x0]
+; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    b LBB48_1
+; CHECK-OUTLINE-O0-NEXT:  LBB48_1: ; %atomicrmw.start
+; CHECK-OUTLINE-O0-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #28] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldr x2, [sp, #16] ; 8-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #8] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    uxth w9, w0
+; CHECK-OUTLINE-O0-NEXT:    subs w9, w9, w8, uxth
+; CHECK-OUTLINE-O0-NEXT:    csel w1, w0, w8, ls
+; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas2_acq_rel
+; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #8] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    mov w9, w0
+; CHECK-OUTLINE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    uxth w8, w8
+; CHECK-OUTLINE-O0-NEXT:    mov w0, w9
+; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w9, uxth
+; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    b.eq LBB48_2
+; CHECK-OUTLINE-O0-NEXT:    b LBB48_1
+; CHECK-OUTLINE-O0-NEXT:  LBB48_2: ; %atomicrmw.end
+; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
+; CHECK-OUTLINE-O0-NEXT:    add sp, sp, #48
+; CHECK-OUTLINE-O0-NEXT:    ret
+;
+; CHECK-LSE-O1-LABEL: atomicrmw_umin_i16:
+; CHECK-LSE-O1:       ; %bb.0:
+; CHECK-LSE-O1-NEXT:    lduminalh w1, w0, [x0]
+; CHECK-LSE-O1-NEXT:    ret
+;
+; CHECK-LSE-O0-LABEL: atomicrmw_umin_i16:
+; CHECK-LSE-O0:       ; %bb.0:
+; CHECK-LSE-O0-NEXT:    lduminalh w1, w0, [x0]
+; CHECK-LSE-O0-NEXT:    ret
+  %res = atomicrmw umin ptr %ptr, i16 %rhs seq_cst
+  ret i16 %res
+}
+
+define i16 @atomicrmw_umax_i16(ptr %ptr, i16 %rhs) {
+; CHECK-NOLSE-O1-LABEL: atomicrmw_umax_i16:
+; CHECK-NOLSE-O1:       ; %bb.0:
+; CHECK-NOLSE-O1-NEXT:    and w9, w1, #0xffff
+; CHECK-NOLSE-O1-NEXT:  LBB49_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-NOLSE-O1-NEXT:    ldxrh w8, [x0]
+; CHECK-NOLSE-O1-NEXT:    and w8, w8, #0xffff
+; CHECK-NOLSE-O1-NEXT:    cmp w8, w9
+; CHECK-NOLSE-O1-NEXT:    csel w10, w8, w9, hi
+; CHECK-NOLSE-O1-NEXT:    stxrh w11, w10, [x0]
+; CHECK-NOLSE-O1-NEXT:    cbnz w11, LBB49_1
+; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
+; CHECK-NOLSE-O1-NEXT:    mov w0, w8
+; CHECK-NOLSE-O1-NEXT:    ret
+;
+; CHECK-OUTLINE-O1-LABEL: atomicrmw_umax_i16:
+; CHECK-OUTLINE-O1:       ; %bb.0:
+; CHECK-OUTLINE-O1-NEXT:    and w9, w1, #0xffff
+; CHECK-OUTLINE-O1-NEXT:  LBB49_1: ; %atomicrmw.start
+; CHECK-OUTLINE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-OUTLINE-O1-NEXT:    ldxrh w8, [x0]
+; CHECK-OUTLINE-O1-NEXT:    and w8, w8, #0xffff
+; CHECK-OUTLINE-O1-NEXT:    cmp w8, w9
+; CHECK-OUTLINE-O1-NEXT:    csel w10, w8, w9, hi
+; CHECK-OUTLINE-O1-NEXT:    stxrh w11, w10, [x0]
+; CHECK-OUTLINE-O1-NEXT:    cbnz w11, LBB49_1
+; CHECK-OUTLINE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
+; CHECK-OUTLINE-O1-NEXT:    mov w0, w8
+; CHECK-OUTLINE-O1-NEXT:    ret
+;
+; CHECK-NOLSE-O0-LABEL: atomicrmw_umax_i16:
+; CHECK-NOLSE-O0:       ; %bb.0:
+; CHECK-NOLSE-O0-NEXT:    sub sp, sp, #32
+; CHECK-NOLSE-O0-NEXT:    .cfi_def_cfa_offset 32
+; CHECK-NOLSE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    ldrh w8, [x0]
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b LBB49_1
+; CHECK-NOLSE-O0-NEXT:  LBB49_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB49_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #28] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr w9, [sp, #24] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    uxth w10, w8
+; CHECK-NOLSE-O0-NEXT:    subs w10, w10, w9, uxth
+; CHECK-NOLSE-O0-NEXT:    csel w12, w8, w9, hi
+; CHECK-NOLSE-O0-NEXT:  LBB49_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB49_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
+; CHECK-NOLSE-O0-NEXT:    ldaxrh w10, [x11]
+; CHECK-NOLSE-O0-NEXT:    cmp w10, w8, uxth
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB49_4
+; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB49_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    stlxrh w9, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB49_2
+; CHECK-NOLSE-O0-NEXT:  LBB49_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB49_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    str w10, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    uxth w9, w8
+; CHECK-NOLSE-O0-NEXT:    mov w8, w10
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxth
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB49_5
+; CHECK-NOLSE-O0-NEXT:    b LBB49_1
+; CHECK-NOLSE-O0-NEXT:  LBB49_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
+; CHECK-NOLSE-O0-NEXT:    ret
+;
+; CHECK-OUTLINE-O0-LABEL: atomicrmw_umax_i16:
+; CHECK-OUTLINE-O0:       ; %bb.0:
+; CHECK-OUTLINE-O0-NEXT:    sub sp, sp, #48
+; CHECK-OUTLINE-O0-NEXT:    stp x29, x30, [sp, #32] ; 16-byte Folded Spill
+; CHECK-OUTLINE-O0-NEXT:    .cfi_def_cfa_offset 48
+; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w30, -8
+; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w29, -16
+; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    ldrh w0, [x0]
+; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    b LBB49_1
+; CHECK-OUTLINE-O0-NEXT:  LBB49_1: ; %atomicrmw.start
+; CHECK-OUTLINE-O0-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #28] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldr x2, [sp, #16] ; 8-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #8] ; 4-byte Spill
 ; CHECK-OUTLINE-O0-NEXT:    uxth w9, w0
 ; CHECK-OUTLINE-O0-NEXT:    subs w9, w9, w8, uxth
 ; CHECK-OUTLINE-O0-NEXT:    csel w1, w0, w8, hi
@@ -3914,9 +4240,9 @@ define i16 @atomicrmw_umax_i16(ptr %ptr, i16 %rhs) {
 ; CHECK-OUTLINE-O0-NEXT:    mov w0, w9
 ; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w9, uxth
 ; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    b.eq LBB46_2
-; CHECK-OUTLINE-O0-NEXT:    b LBB46_1
-; CHECK-OUTLINE-O0-NEXT:  LBB46_2: ; %atomicrmw.end
+; CHECK-OUTLINE-O0-NEXT:    b.eq LBB49_2
+; CHECK-OUTLINE-O0-NEXT:    b LBB49_1
+; CHECK-OUTLINE-O0-NEXT:  LBB49_2: ; %atomicrmw.end
 ; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
 ; CHECK-OUTLINE-O0-NEXT:    add sp, sp, #48
@@ -3938,12 +4264,12 @@ define i16 @atomicrmw_umax_i16(ptr %ptr, i16 %rhs) {
 define i32 @atomicrmw_add_i32(ptr %ptr, i32 %rhs) {
 ; CHECK-NOLSE-O1-LABEL: atomicrmw_add_i32:
 ; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB47_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:  LBB50_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O1-NEXT:    ldaxr w8, [x0]
 ; CHECK-NOLSE-O1-NEXT:    add w9, w8, w1
 ; CHECK-NOLSE-O1-NEXT:    stlxr w10, w9, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB47_1
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB50_1
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; CHECK-NOLSE-O1-NEXT:    mov w0, w8
 ; CHECK-NOLSE-O1-NEXT:    ret
@@ -3969,33 +4295,33 @@ define i32 @atomicrmw_add_i32(ptr %ptr, i32 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    ldr w8, [x0]
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB47_1
-; CHECK-NOLSE-O0-NEXT:  LBB47_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    b LBB50_1
+; CHECK-NOLSE-O0-NEXT:  LBB50_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB47_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB50_2 Depth 2
 ; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add w12, w10, w8
-; CHECK-NOLSE-O0-NEXT:  LBB47_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB47_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:  LBB50_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB50_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr w9, [x11]
 ; CHECK-NOLSE-O0-NEXT:    cmp w9, w10
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB47_4
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB50_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB47_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB50_2 Depth=2
 ; CHECK-NOLSE-O0-NEXT:    stlxr w8, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB47_2
-; CHECK-NOLSE-O0-NEXT:  LBB47_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB47_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB50_2
+; CHECK-NOLSE-O0-NEXT:  LBB50_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB50_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    mov w8, w9
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB47_5
-; CHECK-NOLSE-O0-NEXT:    b LBB47_1
-; CHECK-NOLSE-O0-NEXT:  LBB47_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB50_5
+; CHECK-NOLSE-O0-NEXT:    b LBB50_1
+; CHECK-NOLSE-O0-NEXT:  LBB50_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
 ; CHECK-NOLSE-O0-NEXT:    ret
@@ -4032,11 +4358,11 @@ define i32 @atomicrmw_xchg_i32(ptr %ptr, i32 %rhs) {
 ; CHECK-NOLSE-O1-LABEL: atomicrmw_xchg_i32:
 ; CHECK-NOLSE-O1:       ; %bb.0:
 ; CHECK-NOLSE-O1-NEXT:    mov x8, x0
-; CHECK-NOLSE-O1-NEXT:  LBB48_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:  LBB51_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O1-NEXT:    ldxr w0, [x8]
 ; CHECK-NOLSE-O1-NEXT:    stxr w9, w1, [x8]
-; CHECK-NOLSE-O1-NEXT:    cbnz w9, LBB48_1
+; CHECK-NOLSE-O1-NEXT:    cbnz w9, LBB51_1
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; CHECK-NOLSE-O1-NEXT:    ; kill: def $w0 killed $w0 killed $x0
 ; CHECK-NOLSE-O1-NEXT:    ret
@@ -4062,32 +4388,32 @@ define i32 @atomicrmw_xchg_i32(ptr %ptr, i32 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    ldr w8, [x0]
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB48_1
-; CHECK-NOLSE-O0-NEXT:  LBB48_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    b LBB51_1
+; CHECK-NOLSE-O0-NEXT:  LBB51_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB48_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB51_2 Depth 2
 ; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr w12, [sp, #24] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:  LBB48_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB48_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:  LBB51_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB51_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr w9, [x11]
 ; CHECK-NOLSE-O0-NEXT:    cmp w9, w10
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB48_4
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB51_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB48_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB51_2 Depth=2
 ; CHECK-NOLSE-O0-NEXT:    stlxr w8, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB48_2
-; CHECK-NOLSE-O0-NEXT:  LBB48_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB48_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB51_2
+; CHECK-NOLSE-O0-NEXT:  LBB51_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB51_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    mov w8, w9
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB48_5
-; CHECK-NOLSE-O0-NEXT:    b LBB48_1
-; CHECK-NOLSE-O0-NEXT:  LBB48_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB51_5
+; CHECK-NOLSE-O0-NEXT:    b LBB51_1
+; CHECK-NOLSE-O0-NEXT:  LBB51_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
 ; CHECK-NOLSE-O0-NEXT:    ret
@@ -4123,12 +4449,12 @@ define i32 @atomicrmw_xchg_i32(ptr %ptr, i32 %rhs) {
 define i32 @atomicrmw_sub_i32(ptr %ptr, i32 %rhs) {
 ; CHECK-NOLSE-O1-LABEL: atomicrmw_sub_i32:
 ; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB49_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:  LBB52_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O1-NEXT:    ldaxr w8, [x0]
 ; CHECK-NOLSE-O1-NEXT:    sub w9, w8, w1
 ; CHECK-NOLSE-O1-NEXT:    stxr w10, w9, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB49_1
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB52_1
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; CHECK-NOLSE-O1-NEXT:    mov w0, w8
 ; CHECK-NOLSE-O1-NEXT:    ret
@@ -4154,33 +4480,33 @@ define i32 @atomicrmw_sub_i32(ptr %ptr, i32 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    ldr w8, [x0]
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB49_1
-; CHECK-NOLSE-O0-NEXT:  LBB49_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    b LBB52_1
+; CHECK-NOLSE-O0-NEXT:  LBB52_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB49_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB52_2 Depth 2
 ; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    subs w12, w10, w8
-; CHECK-NOLSE-O0-NEXT:  LBB49_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB49_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:  LBB52_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB52_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr w9, [x11]
 ; CHECK-NOLSE-O0-NEXT:    cmp w9, w10
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB49_4
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB52_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB49_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB52_2 Depth=2
 ; CHECK-NOLSE-O0-NEXT:    stlxr w8, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB49_2
-; CHECK-NOLSE-O0-NEXT:  LBB49_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB49_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB52_2
+; CHECK-NOLSE-O0-NEXT:  LBB52_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB52_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    mov w8, w9
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB49_5
-; CHECK-NOLSE-O0-NEXT:    b LBB49_1
-; CHECK-NOLSE-O0-NEXT:  LBB49_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB52_5
+; CHECK-NOLSE-O0-NEXT:    b LBB52_1
+; CHECK-NOLSE-O0-NEXT:  LBB52_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
 ; CHECK-NOLSE-O0-NEXT:    ret
@@ -4220,12 +4546,12 @@ define i32 @atomicrmw_sub_i32(ptr %ptr, i32 %rhs) {
 define i32 @atomicrmw_and_i32(ptr %ptr, i32 %rhs) {
 ; CHECK-NOLSE-O1-LABEL: atomicrmw_and_i32:
 ; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB50_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:  LBB53_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O1-NEXT:    ldxr w8, [x0]
 ; CHECK-NOLSE-O1-NEXT:    and w9, w8, w1
 ; CHECK-NOLSE-O1-NEXT:    stlxr w10, w9, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB50_1
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB53_1
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; CHECK-NOLSE-O1-NEXT:    mov w0, w8
 ; CHECK-NOLSE-O1-NEXT:    ret
@@ -4251,33 +4577,33 @@ define i32 @atomicrmw_and_i32(ptr %ptr, i32 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    ldr w8, [x0]
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB50_1
-; CHECK-NOLSE-O0-NEXT:  LBB50_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    b LBB53_1
+; CHECK-NOLSE-O0-NEXT:  LBB53_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB50_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB53_2 Depth 2
 ; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    and w12, w10, w8
-; CHECK-NOLSE-O0-NEXT:  LBB50_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB50_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:  LBB53_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB53_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr w9, [x11]
 ; CHECK-NOLSE-O0-NEXT:    cmp w9, w10
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB50_4
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB53_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB50_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB53_2 Depth=2
 ; CHECK-NOLSE-O0-NEXT:    stlxr w8, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB50_2
-; CHECK-NOLSE-O0-NEXT:  LBB50_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB50_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB53_2
+; CHECK-NOLSE-O0-NEXT:  LBB53_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB53_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    mov w8, w9
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB50_5
-; CHECK-NOLSE-O0-NEXT:    b LBB50_1
-; CHECK-NOLSE-O0-NEXT:  LBB50_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB53_5
+; CHECK-NOLSE-O0-NEXT:    b LBB53_1
+; CHECK-NOLSE-O0-NEXT:  LBB53_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
 ; CHECK-NOLSE-O0-NEXT:    ret
@@ -4317,12 +4643,12 @@ define i32 @atomicrmw_and_i32(ptr %ptr, i32 %rhs) {
 define i32 @atomicrmw_or_i32(ptr %ptr, i32 %rhs) {
 ; CHECK-NOLSE-O1-LABEL: atomicrmw_or_i32:
 ; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB51_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:  LBB54_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O1-NEXT:    ldaxr w8, [x0]
 ; CHECK-NOLSE-O1-NEXT:    orr w9, w8, w1
 ; CHECK-NOLSE-O1-NEXT:    stlxr w10, w9, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB51_1
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB54_1
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; CHECK-NOLSE-O1-NEXT:    mov w0, w8
 ; CHECK-NOLSE-O1-NEXT:    ret
@@ -4348,33 +4674,33 @@ define i32 @atomicrmw_or_i32(ptr %ptr, i32 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    ldr w8, [x0]
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB51_1
-; CHECK-NOLSE-O0-NEXT:  LBB51_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    b LBB54_1
+; CHECK-NOLSE-O0-NEXT:  LBB54_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB51_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB54_2 Depth 2
 ; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    orr w12, w10, w8
-; CHECK-NOLSE-O0-NEXT:  LBB51_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB51_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:  LBB54_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB54_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr w9, [x11]
 ; CHECK-NOLSE-O0-NEXT:    cmp w9, w10
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB51_4
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB54_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB51_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB54_2 Depth=2
 ; CHECK-NOLSE-O0-NEXT:    stlxr w8, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB51_2
-; CHECK-NOLSE-O0-NEXT:  LBB51_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB51_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB54_2
+; CHECK-NOLSE-O0-NEXT:  LBB54_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB54_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    mov w8, w9
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB51_5
-; CHECK-NOLSE-O0-NEXT:    b LBB51_1
-; CHECK-NOLSE-O0-NEXT:  LBB51_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB54_5
+; CHECK-NOLSE-O0-NEXT:    b LBB54_1
+; CHECK-NOLSE-O0-NEXT:  LBB54_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
 ; CHECK-NOLSE-O0-NEXT:    ret
@@ -4410,12 +4736,12 @@ define i32 @atomicrmw_or_i32(ptr %ptr, i32 %rhs) {
 define i32 @atomicrmw_xor_i32(ptr %ptr, i32 %rhs) {
 ; CHECK-NOLSE-O1-LABEL: atomicrmw_xor_i32:
 ; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB52_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:  LBB55_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O1-NEXT:    ldxr w8, [x0]
 ; CHECK-NOLSE-O1-NEXT:    eor w9, w8, w1
 ; CHECK-NOLSE-O1-NEXT:    stxr w10, w9, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB52_1
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB55_1
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; CHECK-NOLSE-O1-NEXT:    mov w0, w8
 ; CHECK-NOLSE-O1-NEXT:    ret
@@ -4441,33 +4767,33 @@ define i32 @atomicrmw_xor_i32(ptr %ptr, i32 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    ldr w8, [x0]
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB52_1
-; CHECK-NOLSE-O0-NEXT:  LBB52_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    b LBB55_1
+; CHECK-NOLSE-O0-NEXT:  LBB55_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB52_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB55_2 Depth 2
 ; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    eor w12, w10, w8
-; CHECK-NOLSE-O0-NEXT:  LBB52_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB52_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:  LBB55_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB55_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr w9, [x11]
 ; CHECK-NOLSE-O0-NEXT:    cmp w9, w10
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB52_4
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB55_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB52_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB55_2 Depth=2
 ; CHECK-NOLSE-O0-NEXT:    stlxr w8, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB52_2
-; CHECK-NOLSE-O0-NEXT:  LBB52_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB52_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB55_2
+; CHECK-NOLSE-O0-NEXT:  LBB55_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB55_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    mov w8, w9
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10
 ; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB52_5
-; CHECK-NOLSE-O0-NEXT:    b LBB52_1
-; CHECK-NOLSE-O0-NEXT:  LBB52_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB55_5
+; CHECK-NOLSE-O0-NEXT:    b LBB55_1
+; CHECK-NOLSE-O0-NEXT:  LBB55_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
 ; CHECK-NOLSE-O0-NEXT:    ret
@@ -4503,376 +4829,31 @@ define i32 @atomicrmw_xor_i32(ptr %ptr, i32 %rhs) {
 define i32 @atomicrmw_min_i32(ptr %ptr, i32 %rhs) {
 ; CHECK-NOLSE-O1-LABEL: atomicrmw_min_i32:
 ; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB53_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:  LBB56_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O1-NEXT:    ldaxr w8, [x0]
 ; CHECK-NOLSE-O1-NEXT:    cmp w8, w1
 ; CHECK-NOLSE-O1-NEXT:    csel w9, w8, w1, lt
-; CHECK-NOLSE-O1-NEXT:    stxr w10, w9, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB53_1
-; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
-; CHECK-NOLSE-O1-NEXT:    mov w0, w8
-; CHECK-NOLSE-O1-NEXT:    ret
-;
-; CHECK-OUTLINE-O1-LABEL: atomicrmw_min_i32:
-; CHECK-OUTLINE-O1:       ; %bb.0:
-; CHECK-OUTLINE-O1-NEXT:  LBB53_1: ; %atomicrmw.start
-; CHECK-OUTLINE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-OUTLINE-O1-NEXT:    ldaxr w8, [x0]
-; CHECK-OUTLINE-O1-NEXT:    cmp w8, w1
-; CHECK-OUTLINE-O1-NEXT:    csel w9, w8, w1, lt
-; CHECK-OUTLINE-O1-NEXT:    stxr w10, w9, [x0]
-; CHECK-OUTLINE-O1-NEXT:    cbnz w10, LBB53_1
-; CHECK-OUTLINE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
-; CHECK-OUTLINE-O1-NEXT:    mov w0, w8
-; CHECK-OUTLINE-O1-NEXT:    ret
-;
-; CHECK-NOLSE-O0-LABEL: atomicrmw_min_i32:
-; CHECK-NOLSE-O0:       ; %bb.0:
-; CHECK-NOLSE-O0-NEXT:    sub sp, sp, #32
-; CHECK-NOLSE-O0-NEXT:    .cfi_def_cfa_offset 32
-; CHECK-NOLSE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    ldr w8, [x0]
-; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB53_1
-; CHECK-NOLSE-O0-NEXT:  LBB53_1: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB53_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    subs w9, w10, w8
-; CHECK-NOLSE-O0-NEXT:    csel w12, w10, w8, le
-; CHECK-NOLSE-O0-NEXT:  LBB53_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB53_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
-; CHECK-NOLSE-O0-NEXT:    ldaxr w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w10
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB53_4
-; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB53_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxr w8, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB53_2
-; CHECK-NOLSE-O0-NEXT:  LBB53_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB53_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    mov w8, w9
-; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10
-; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB53_5
-; CHECK-NOLSE-O0-NEXT:    b LBB53_1
-; CHECK-NOLSE-O0-NEXT:  LBB53_5: ; %atomicrmw.end
-; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
-; CHECK-NOLSE-O0-NEXT:    ret
-;
-; CHECK-OUTLINE-O0-LABEL: atomicrmw_min_i32:
-; CHECK-OUTLINE-O0:       ; %bb.0:
-; CHECK-OUTLINE-O0-NEXT:    sub sp, sp, #48
-; CHECK-OUTLINE-O0-NEXT:    stp x29, x30, [sp, #32] ; 16-byte Folded Spill
-; CHECK-OUTLINE-O0-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w30, -8
-; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w29, -16
-; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    ldr w0, [x0]
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    b LBB53_1
-; CHECK-OUTLINE-O0-NEXT:  LBB53_1: ; %atomicrmw.start
-; CHECK-OUTLINE-O0-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #28] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldr x2, [sp, #16] ; 8-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #8] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    subs w9, w0, w8
-; CHECK-OUTLINE-O0-NEXT:    csel w1, w0, w8, le
-; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas4_acq
-; CHECK-OUTLINE-O0-NEXT:    ldr w9, [sp, #8] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    mov w8, w0
-; CHECK-OUTLINE-O0-NEXT:    mov w0, w8
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #12] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w9
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    b.eq LBB53_2
-; CHECK-OUTLINE-O0-NEXT:    b LBB53_1
-; CHECK-OUTLINE-O0-NEXT:  LBB53_2: ; %atomicrmw.end
-; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
-; CHECK-OUTLINE-O0-NEXT:    add sp, sp, #48
-; CHECK-OUTLINE-O0-NEXT:    ret
-;
-; CHECK-LSE-O1-LABEL: atomicrmw_min_i32:
-; CHECK-LSE-O1:       ; %bb.0:
-; CHECK-LSE-O1-NEXT:    ldsmina w1, w0, [x0]
-; CHECK-LSE-O1-NEXT:    ret
-;
-; CHECK-LSE-O0-LABEL: atomicrmw_min_i32:
-; CHECK-LSE-O0:       ; %bb.0:
-; CHECK-LSE-O0-NEXT:    ldsmina w1, w0, [x0]
-; CHECK-LSE-O0-NEXT:    ret
-  %res = atomicrmw min ptr %ptr, i32 %rhs acquire
-  ret i32 %res
-}
-
-define i32 @atomicrmw_max_i32(ptr %ptr, i32 %rhs) {
-; CHECK-NOLSE-O1-LABEL: atomicrmw_max_i32:
-; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB54_1: ; %atomicrmw.start
-; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-NOLSE-O1-NEXT:    ldxr w8, [x0]
-; CHECK-NOLSE-O1-NEXT:    cmp w8, w1
-; CHECK-NOLSE-O1-NEXT:    csel w9, w8, w1, gt
-; CHECK-NOLSE-O1-NEXT:    stlxr w10, w9, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB54_1
-; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
-; CHECK-NOLSE-O1-NEXT:    mov w0, w8
-; CHECK-NOLSE-O1-NEXT:    ret
-;
-; CHECK-OUTLINE-O1-LABEL: atomicrmw_max_i32:
-; CHECK-OUTLINE-O1:       ; %bb.0:
-; CHECK-OUTLINE-O1-NEXT:  LBB54_1: ; %atomicrmw.start
-; CHECK-OUTLINE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-OUTLINE-O1-NEXT:    ldxr w8, [x0]
-; CHECK-OUTLINE-O1-NEXT:    cmp w8, w1
-; CHECK-OUTLINE-O1-NEXT:    csel w9, w8, w1, gt
-; CHECK-OUTLINE-O1-NEXT:    stlxr w10, w9, [x0]
-; CHECK-OUTLINE-O1-NEXT:    cbnz w10, LBB54_1
-; CHECK-OUTLINE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
-; CHECK-OUTLINE-O1-NEXT:    mov w0, w8
-; CHECK-OUTLINE-O1-NEXT:    ret
-;
-; CHECK-NOLSE-O0-LABEL: atomicrmw_max_i32:
-; CHECK-NOLSE-O0:       ; %bb.0:
-; CHECK-NOLSE-O0-NEXT:    sub sp, sp, #32
-; CHECK-NOLSE-O0-NEXT:    .cfi_def_cfa_offset 32
-; CHECK-NOLSE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    ldr w8, [x0]
-; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB54_1
-; CHECK-NOLSE-O0-NEXT:  LBB54_1: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB54_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    subs w9, w10, w8
-; CHECK-NOLSE-O0-NEXT:    csel w12, w10, w8, gt
-; CHECK-NOLSE-O0-NEXT:  LBB54_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB54_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
-; CHECK-NOLSE-O0-NEXT:    ldaxr w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w10
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB54_4
-; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB54_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxr w8, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB54_2
-; CHECK-NOLSE-O0-NEXT:  LBB54_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB54_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    mov w8, w9
-; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10
-; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB54_5
-; CHECK-NOLSE-O0-NEXT:    b LBB54_1
-; CHECK-NOLSE-O0-NEXT:  LBB54_5: ; %atomicrmw.end
-; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
-; CHECK-NOLSE-O0-NEXT:    ret
-;
-; CHECK-OUTLINE-O0-LABEL: atomicrmw_max_i32:
-; CHECK-OUTLINE-O0:       ; %bb.0:
-; CHECK-OUTLINE-O0-NEXT:    sub sp, sp, #48
-; CHECK-OUTLINE-O0-NEXT:    stp x29, x30, [sp, #32] ; 16-byte Folded Spill
-; CHECK-OUTLINE-O0-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w30, -8
-; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w29, -16
-; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    ldr w0, [x0]
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    b LBB54_1
-; CHECK-OUTLINE-O0-NEXT:  LBB54_1: ; %atomicrmw.start
-; CHECK-OUTLINE-O0-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #28] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldr x2, [sp, #16] ; 8-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #8] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    subs w9, w0, w8
-; CHECK-OUTLINE-O0-NEXT:    csel w1, w0, w8, gt
-; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas4_rel
-; CHECK-OUTLINE-O0-NEXT:    ldr w9, [sp, #8] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    mov w8, w0
-; CHECK-OUTLINE-O0-NEXT:    mov w0, w8
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #12] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w9
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    b.eq LBB54_2
-; CHECK-OUTLINE-O0-NEXT:    b LBB54_1
-; CHECK-OUTLINE-O0-NEXT:  LBB54_2: ; %atomicrmw.end
-; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
-; CHECK-OUTLINE-O0-NEXT:    add sp, sp, #48
-; CHECK-OUTLINE-O0-NEXT:    ret
-;
-; CHECK-LSE-O1-LABEL: atomicrmw_max_i32:
-; CHECK-LSE-O1:       ; %bb.0:
-; CHECK-LSE-O1-NEXT:    ldsmaxl w1, w0, [x0]
-; CHECK-LSE-O1-NEXT:    ret
-;
-; CHECK-LSE-O0-LABEL: atomicrmw_max_i32:
-; CHECK-LSE-O0:       ; %bb.0:
-; CHECK-LSE-O0-NEXT:    ldsmaxl w1, w0, [x0]
-; CHECK-LSE-O0-NEXT:    ret
-  %res = atomicrmw max ptr %ptr, i32 %rhs release
-  ret i32 %res
-}
-
-define i32 @atomicrmw_umin_i32(ptr %ptr, i32 %rhs) {
-; CHECK-NOLSE-O1-LABEL: atomicrmw_umin_i32:
-; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB55_1: ; %atomicrmw.start
-; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-NOLSE-O1-NEXT:    ldaxr w8, [x0]
-; CHECK-NOLSE-O1-NEXT:    cmp w8, w1
-; CHECK-NOLSE-O1-NEXT:    csel w9, w8, w1, lo
-; CHECK-NOLSE-O1-NEXT:    stlxr w10, w9, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB55_1
-; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
-; CHECK-NOLSE-O1-NEXT:    mov w0, w8
-; CHECK-NOLSE-O1-NEXT:    ret
-;
-; CHECK-OUTLINE-O1-LABEL: atomicrmw_umin_i32:
-; CHECK-OUTLINE-O1:       ; %bb.0:
-; CHECK-OUTLINE-O1-NEXT:  LBB55_1: ; %atomicrmw.start
-; CHECK-OUTLINE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-OUTLINE-O1-NEXT:    ldaxr w8, [x0]
-; CHECK-OUTLINE-O1-NEXT:    cmp w8, w1
-; CHECK-OUTLINE-O1-NEXT:    csel w9, w8, w1, lo
-; CHECK-OUTLINE-O1-NEXT:    stlxr w10, w9, [x0]
-; CHECK-OUTLINE-O1-NEXT:    cbnz w10, LBB55_1
-; CHECK-OUTLINE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
-; CHECK-OUTLINE-O1-NEXT:    mov w0, w8
-; CHECK-OUTLINE-O1-NEXT:    ret
-;
-; CHECK-NOLSE-O0-LABEL: atomicrmw_umin_i32:
-; CHECK-NOLSE-O0:       ; %bb.0:
-; CHECK-NOLSE-O0-NEXT:    sub sp, sp, #32
-; CHECK-NOLSE-O0-NEXT:    .cfi_def_cfa_offset 32
-; CHECK-NOLSE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    ldr w8, [x0]
-; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB55_1
-; CHECK-NOLSE-O0-NEXT:  LBB55_1: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB55_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    subs w9, w10, w8
-; CHECK-NOLSE-O0-NEXT:    csel w12, w10, w8, ls
-; CHECK-NOLSE-O0-NEXT:  LBB55_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB55_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
-; CHECK-NOLSE-O0-NEXT:    ldaxr w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w10
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB55_4
-; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB55_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxr w8, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB55_2
-; CHECK-NOLSE-O0-NEXT:  LBB55_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB55_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    mov w8, w9
-; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10
-; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB55_5
-; CHECK-NOLSE-O0-NEXT:    b LBB55_1
-; CHECK-NOLSE-O0-NEXT:  LBB55_5: ; %atomicrmw.end
-; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
-; CHECK-NOLSE-O0-NEXT:    ret
-;
-; CHECK-OUTLINE-O0-LABEL: atomicrmw_umin_i32:
-; CHECK-OUTLINE-O0:       ; %bb.0:
-; CHECK-OUTLINE-O0-NEXT:    sub sp, sp, #48
-; CHECK-OUTLINE-O0-NEXT:    stp x29, x30, [sp, #32] ; 16-byte Folded Spill
-; CHECK-OUTLINE-O0-NEXT:    .cfi_def_cfa_offset 48
-; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w30, -8
-; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w29, -16
-; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    ldr w0, [x0]
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    b LBB55_1
-; CHECK-OUTLINE-O0-NEXT:  LBB55_1: ; %atomicrmw.start
-; CHECK-OUTLINE-O0-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #28] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldr x2, [sp, #16] ; 8-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #8] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    subs w9, w0, w8
-; CHECK-OUTLINE-O0-NEXT:    csel w1, w0, w8, ls
-; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas4_acq_rel
-; CHECK-OUTLINE-O0-NEXT:    ldr w9, [sp, #8] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    mov w8, w0
-; CHECK-OUTLINE-O0-NEXT:    mov w0, w8
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #12] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w9
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    b.eq LBB55_2
-; CHECK-OUTLINE-O0-NEXT:    b LBB55_1
-; CHECK-OUTLINE-O0-NEXT:  LBB55_2: ; %atomicrmw.end
-; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
-; CHECK-OUTLINE-O0-NEXT:    add sp, sp, #48
-; CHECK-OUTLINE-O0-NEXT:    ret
-;
-; CHECK-LSE-O1-LABEL: atomicrmw_umin_i32:
-; CHECK-LSE-O1:       ; %bb.0:
-; CHECK-LSE-O1-NEXT:    lduminal w1, w0, [x0]
-; CHECK-LSE-O1-NEXT:    ret
-;
-; CHECK-LSE-O0-LABEL: atomicrmw_umin_i32:
-; CHECK-LSE-O0:       ; %bb.0:
-; CHECK-LSE-O0-NEXT:    lduminal w1, w0, [x0]
-; CHECK-LSE-O0-NEXT:    ret
-  %res = atomicrmw umin ptr %ptr, i32 %rhs seq_cst
-  ret i32 %res
-}
-
-define i32 @atomicrmw_umax_i32(ptr %ptr, i32 %rhs) {
-; CHECK-NOLSE-O1-LABEL: atomicrmw_umax_i32:
-; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB56_1: ; %atomicrmw.start
-; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-NOLSE-O1-NEXT:    ldxr w8, [x0]
-; CHECK-NOLSE-O1-NEXT:    cmp w8, w1
-; CHECK-NOLSE-O1-NEXT:    csel w9, w8, w1, hi
 ; CHECK-NOLSE-O1-NEXT:    stxr w10, w9, [x0]
 ; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB56_1
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; CHECK-NOLSE-O1-NEXT:    mov w0, w8
 ; CHECK-NOLSE-O1-NEXT:    ret
 ;
-; CHECK-OUTLINE-O1-LABEL: atomicrmw_umax_i32:
+; CHECK-OUTLINE-O1-LABEL: atomicrmw_min_i32:
 ; CHECK-OUTLINE-O1:       ; %bb.0:
 ; CHECK-OUTLINE-O1-NEXT:  LBB56_1: ; %atomicrmw.start
 ; CHECK-OUTLINE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-OUTLINE-O1-NEXT:    ldxr w8, [x0]
+; CHECK-OUTLINE-O1-NEXT:    ldaxr w8, [x0]
 ; CHECK-OUTLINE-O1-NEXT:    cmp w8, w1
-; CHECK-OUTLINE-O1-NEXT:    csel w9, w8, w1, hi
+; CHECK-OUTLINE-O1-NEXT:    csel w9, w8, w1, lt
 ; CHECK-OUTLINE-O1-NEXT:    stxr w10, w9, [x0]
 ; CHECK-OUTLINE-O1-NEXT:    cbnz w10, LBB56_1
 ; CHECK-OUTLINE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; CHECK-OUTLINE-O1-NEXT:    mov w0, w8
 ; CHECK-OUTLINE-O1-NEXT:    ret
 ;
-; CHECK-NOLSE-O0-LABEL: atomicrmw_umax_i32:
+; CHECK-NOLSE-O0-LABEL: atomicrmw_min_i32:
 ; CHECK-NOLSE-O0:       ; %bb.0:
 ; CHECK-NOLSE-O0-NEXT:    sub sp, sp, #32
 ; CHECK-NOLSE-O0-NEXT:    .cfi_def_cfa_offset 32
@@ -4888,7 +4869,7 @@ define i32 @atomicrmw_umax_i32(ptr %ptr, i32 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    subs w9, w10, w8
-; CHECK-NOLSE-O0-NEXT:    csel w12, w10, w8, hi
+; CHECK-NOLSE-O0-NEXT:    csel w12, w10, w8, le
 ; CHECK-NOLSE-O0-NEXT:  LBB56_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB56_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
@@ -4912,7 +4893,7 @@ define i32 @atomicrmw_umax_i32(ptr %ptr, i32 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
 ; CHECK-NOLSE-O0-NEXT:    ret
 ;
-; CHECK-OUTLINE-O0-LABEL: atomicrmw_umax_i32:
+; CHECK-OUTLINE-O0-LABEL: atomicrmw_min_i32:
 ; CHECK-OUTLINE-O0:       ; %bb.0:
 ; CHECK-OUTLINE-O0-NEXT:    sub sp, sp, #48
 ; CHECK-OUTLINE-O0-NEXT:    stp x29, x30, [sp, #32] ; 16-byte Folded Spill
@@ -4931,8 +4912,8 @@ define i32 @atomicrmw_umax_i32(ptr %ptr, i32 %rhs) {
 ; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
 ; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #8] ; 4-byte Spill
 ; CHECK-OUTLINE-O0-NEXT:    subs w9, w0, w8
-; CHECK-OUTLINE-O0-NEXT:    csel w1, w0, w8, hi
-; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas4_relax
+; CHECK-OUTLINE-O0-NEXT:    csel w1, w0, w8, le
+; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas4_acq
 ; CHECK-OUTLINE-O0-NEXT:    ldr w9, [sp, #8] ; 4-byte Reload
 ; CHECK-OUTLINE-O0-NEXT:    mov w8, w0
 ; CHECK-OUTLINE-O0-NEXT:    mov w0, w8
@@ -4942,6 +4923,351 @@ define i32 @atomicrmw_umax_i32(ptr %ptr, i32 %rhs) {
 ; CHECK-OUTLINE-O0-NEXT:    b.eq LBB56_2
 ; CHECK-OUTLINE-O0-NEXT:    b LBB56_1
 ; CHECK-OUTLINE-O0-NEXT:  LBB56_2: ; %atomicrmw.end
+; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
+; CHECK-OUTLINE-O0-NEXT:    add sp, sp, #48
+; CHECK-OUTLINE-O0-NEXT:    ret
+;
+; CHECK-LSE-O1-LABEL: atomicrmw_min_i32:
+; CHECK-LSE-O1:       ; %bb.0:
+; CHECK-LSE-O1-NEXT:    ldsmina w1, w0, [x0]
+; CHECK-LSE-O1-NEXT:    ret
+;
+; CHECK-LSE-O0-LABEL: atomicrmw_min_i32:
+; CHECK-LSE-O0:       ; %bb.0:
+; CHECK-LSE-O0-NEXT:    ldsmina w1, w0, [x0]
+; CHECK-LSE-O0-NEXT:    ret
+  %res = atomicrmw min ptr %ptr, i32 %rhs acquire
+  ret i32 %res
+}
+
+define i32 @atomicrmw_max_i32(ptr %ptr, i32 %rhs) {
+; CHECK-NOLSE-O1-LABEL: atomicrmw_max_i32:
+; CHECK-NOLSE-O1:       ; %bb.0:
+; CHECK-NOLSE-O1-NEXT:  LBB57_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-NOLSE-O1-NEXT:    ldxr w8, [x0]
+; CHECK-NOLSE-O1-NEXT:    cmp w8, w1
+; CHECK-NOLSE-O1-NEXT:    csel w9, w8, w1, gt
+; CHECK-NOLSE-O1-NEXT:    stlxr w10, w9, [x0]
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB57_1
+; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
+; CHECK-NOLSE-O1-NEXT:    mov w0, w8
+; CHECK-NOLSE-O1-NEXT:    ret
+;
+; CHECK-OUTLINE-O1-LABEL: atomicrmw_max_i32:
+; CHECK-OUTLINE-O1:       ; %bb.0:
+; CHECK-OUTLINE-O1-NEXT:  LBB57_1: ; %atomicrmw.start
+; CHECK-OUTLINE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-OUTLINE-O1-NEXT:    ldxr w8, [x0]
+; CHECK-OUTLINE-O1-NEXT:    cmp w8, w1
+; CHECK-OUTLINE-O1-NEXT:    csel w9, w8, w1, gt
+; CHECK-OUTLINE-O1-NEXT:    stlxr w10, w9, [x0]
+; CHECK-OUTLINE-O1-NEXT:    cbnz w10, LBB57_1
+; CHECK-OUTLINE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
+; CHECK-OUTLINE-O1-NEXT:    mov w0, w8
+; CHECK-OUTLINE-O1-NEXT:    ret
+;
+; CHECK-NOLSE-O0-LABEL: atomicrmw_max_i32:
+; CHECK-NOLSE-O0:       ; %bb.0:
+; CHECK-NOLSE-O0-NEXT:    sub sp, sp, #32
+; CHECK-NOLSE-O0-NEXT:    .cfi_def_cfa_offset 32
+; CHECK-NOLSE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    ldr w8, [x0]
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b LBB57_1
+; CHECK-NOLSE-O0-NEXT:  LBB57_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB57_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    subs w9, w10, w8
+; CHECK-NOLSE-O0-NEXT:    csel w12, w10, w8, gt
+; CHECK-NOLSE-O0-NEXT:  LBB57_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB57_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
+; CHECK-NOLSE-O0-NEXT:    ldaxr w9, [x11]
+; CHECK-NOLSE-O0-NEXT:    cmp w9, w10
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB57_4
+; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB57_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    stlxr w8, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB57_2
+; CHECK-NOLSE-O0-NEXT:  LBB57_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB57_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    mov w8, w9
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB57_5
+; CHECK-NOLSE-O0-NEXT:    b LBB57_1
+; CHECK-NOLSE-O0-NEXT:  LBB57_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
+; CHECK-NOLSE-O0-NEXT:    ret
+;
+; CHECK-OUTLINE-O0-LABEL: atomicrmw_max_i32:
+; CHECK-OUTLINE-O0:       ; %bb.0:
+; CHECK-OUTLINE-O0-NEXT:    sub sp, sp, #48
+; CHECK-OUTLINE-O0-NEXT:    stp x29, x30, [sp, #32] ; 16-byte Folded Spill
+; CHECK-OUTLINE-O0-NEXT:    .cfi_def_cfa_offset 48
+; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w30, -8
+; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w29, -16
+; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    ldr w0, [x0]
+; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    b LBB57_1
+; CHECK-OUTLINE-O0-NEXT:  LBB57_1: ; %atomicrmw.start
+; CHECK-OUTLINE-O0-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #28] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldr x2, [sp, #16] ; 8-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #8] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    subs w9, w0, w8
+; CHECK-OUTLINE-O0-NEXT:    csel w1, w0, w8, gt
+; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas4_rel
+; CHECK-OUTLINE-O0-NEXT:    ldr w9, [sp, #8] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    mov w8, w0
+; CHECK-OUTLINE-O0-NEXT:    mov w0, w8
+; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #12] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w9
+; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    b.eq LBB57_2
+; CHECK-OUTLINE-O0-NEXT:    b LBB57_1
+; CHECK-OUTLINE-O0-NEXT:  LBB57_2: ; %atomicrmw.end
+; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
+; CHECK-OUTLINE-O0-NEXT:    add sp, sp, #48
+; CHECK-OUTLINE-O0-NEXT:    ret
+;
+; CHECK-LSE-O1-LABEL: atomicrmw_max_i32:
+; CHECK-LSE-O1:       ; %bb.0:
+; CHECK-LSE-O1-NEXT:    ldsmaxl w1, w0, [x0]
+; CHECK-LSE-O1-NEXT:    ret
+;
+; CHECK-LSE-O0-LABEL: atomicrmw_max_i32:
+; CHECK-LSE-O0:       ; %bb.0:
+; CHECK-LSE-O0-NEXT:    ldsmaxl w1, w0, [x0]
+; CHECK-LSE-O0-NEXT:    ret
+  %res = atomicrmw max ptr %ptr, i32 %rhs release
+  ret i32 %res
+}
+
+define i32 @atomicrmw_umin_i32(ptr %ptr, i32 %rhs) {
+; CHECK-NOLSE-O1-LABEL: atomicrmw_umin_i32:
+; CHECK-NOLSE-O1:       ; %bb.0:
+; CHECK-NOLSE-O1-NEXT:  LBB58_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-NOLSE-O1-NEXT:    ldaxr w8, [x0]
+; CHECK-NOLSE-O1-NEXT:    cmp w8, w1
+; CHECK-NOLSE-O1-NEXT:    csel w9, w8, w1, lo
+; CHECK-NOLSE-O1-NEXT:    stlxr w10, w9, [x0]
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB58_1
+; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
+; CHECK-NOLSE-O1-NEXT:    mov w0, w8
+; CHECK-NOLSE-O1-NEXT:    ret
+;
+; CHECK-OUTLINE-O1-LABEL: atomicrmw_umin_i32:
+; CHECK-OUTLINE-O1:       ; %bb.0:
+; CHECK-OUTLINE-O1-NEXT:  LBB58_1: ; %atomicrmw.start
+; CHECK-OUTLINE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-OUTLINE-O1-NEXT:    ldaxr w8, [x0]
+; CHECK-OUTLINE-O1-NEXT:    cmp w8, w1
+; CHECK-OUTLINE-O1-NEXT:    csel w9, w8, w1, lo
+; CHECK-OUTLINE-O1-NEXT:    stlxr w10, w9, [x0]
+; CHECK-OUTLINE-O1-NEXT:    cbnz w10, LBB58_1
+; CHECK-OUTLINE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
+; CHECK-OUTLINE-O1-NEXT:    mov w0, w8
+; CHECK-OUTLINE-O1-NEXT:    ret
+;
+; CHECK-NOLSE-O0-LABEL: atomicrmw_umin_i32:
+; CHECK-NOLSE-O0:       ; %bb.0:
+; CHECK-NOLSE-O0-NEXT:    sub sp, sp, #32
+; CHECK-NOLSE-O0-NEXT:    .cfi_def_cfa_offset 32
+; CHECK-NOLSE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    ldr w8, [x0]
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b LBB58_1
+; CHECK-NOLSE-O0-NEXT:  LBB58_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB58_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    subs w9, w10, w8
+; CHECK-NOLSE-O0-NEXT:    csel w12, w10, w8, ls
+; CHECK-NOLSE-O0-NEXT:  LBB58_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB58_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
+; CHECK-NOLSE-O0-NEXT:    ldaxr w9, [x11]
+; CHECK-NOLSE-O0-NEXT:    cmp w9, w10
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB58_4
+; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB58_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    stlxr w8, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB58_2
+; CHECK-NOLSE-O0-NEXT:  LBB58_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB58_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    mov w8, w9
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB58_5
+; CHECK-NOLSE-O0-NEXT:    b LBB58_1
+; CHECK-NOLSE-O0-NEXT:  LBB58_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
+; CHECK-NOLSE-O0-NEXT:    ret
+;
+; CHECK-OUTLINE-O0-LABEL: atomicrmw_umin_i32:
+; CHECK-OUTLINE-O0:       ; %bb.0:
+; CHECK-OUTLINE-O0-NEXT:    sub sp, sp, #48
+; CHECK-OUTLINE-O0-NEXT:    stp x29, x30, [sp, #32] ; 16-byte Folded Spill
+; CHECK-OUTLINE-O0-NEXT:    .cfi_def_cfa_offset 48
+; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w30, -8
+; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w29, -16
+; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    ldr w0, [x0]
+; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    b LBB58_1
+; CHECK-OUTLINE-O0-NEXT:  LBB58_1: ; %atomicrmw.start
+; CHECK-OUTLINE-O0-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #28] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldr x2, [sp, #16] ; 8-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #8] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    subs w9, w0, w8
+; CHECK-OUTLINE-O0-NEXT:    csel w1, w0, w8, ls
+; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas4_acq_rel
+; CHECK-OUTLINE-O0-NEXT:    ldr w9, [sp, #8] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    mov w8, w0
+; CHECK-OUTLINE-O0-NEXT:    mov w0, w8
+; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #12] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w9
+; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    b.eq LBB58_2
+; CHECK-OUTLINE-O0-NEXT:    b LBB58_1
+; CHECK-OUTLINE-O0-NEXT:  LBB58_2: ; %atomicrmw.end
+; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
+; CHECK-OUTLINE-O0-NEXT:    add sp, sp, #48
+; CHECK-OUTLINE-O0-NEXT:    ret
+;
+; CHECK-LSE-O1-LABEL: atomicrmw_umin_i32:
+; CHECK-LSE-O1:       ; %bb.0:
+; CHECK-LSE-O1-NEXT:    lduminal w1, w0, [x0]
+; CHECK-LSE-O1-NEXT:    ret
+;
+; CHECK-LSE-O0-LABEL: atomicrmw_umin_i32:
+; CHECK-LSE-O0:       ; %bb.0:
+; CHECK-LSE-O0-NEXT:    lduminal w1, w0, [x0]
+; CHECK-LSE-O0-NEXT:    ret
+  %res = atomicrmw umin ptr %ptr, i32 %rhs seq_cst
+  ret i32 %res
+}
+
+define i32 @atomicrmw_umax_i32(ptr %ptr, i32 %rhs) {
+; CHECK-NOLSE-O1-LABEL: atomicrmw_umax_i32:
+; CHECK-NOLSE-O1:       ; %bb.0:
+; CHECK-NOLSE-O1-NEXT:  LBB59_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-NOLSE-O1-NEXT:    ldxr w8, [x0]
+; CHECK-NOLSE-O1-NEXT:    cmp w8, w1
+; CHECK-NOLSE-O1-NEXT:    csel w9, w8, w1, hi
+; CHECK-NOLSE-O1-NEXT:    stxr w10, w9, [x0]
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB59_1
+; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
+; CHECK-NOLSE-O1-NEXT:    mov w0, w8
+; CHECK-NOLSE-O1-NEXT:    ret
+;
+; CHECK-OUTLINE-O1-LABEL: atomicrmw_umax_i32:
+; CHECK-OUTLINE-O1:       ; %bb.0:
+; CHECK-OUTLINE-O1-NEXT:  LBB59_1: ; %atomicrmw.start
+; CHECK-OUTLINE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-OUTLINE-O1-NEXT:    ldxr w8, [x0]
+; CHECK-OUTLINE-O1-NEXT:    cmp w8, w1
+; CHECK-OUTLINE-O1-NEXT:    csel w9, w8, w1, hi
+; CHECK-OUTLINE-O1-NEXT:    stxr w10, w9, [x0]
+; CHECK-OUTLINE-O1-NEXT:    cbnz w10, LBB59_1
+; CHECK-OUTLINE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
+; CHECK-OUTLINE-O1-NEXT:    mov w0, w8
+; CHECK-OUTLINE-O1-NEXT:    ret
+;
+; CHECK-NOLSE-O0-LABEL: atomicrmw_umax_i32:
+; CHECK-NOLSE-O0:       ; %bb.0:
+; CHECK-NOLSE-O0-NEXT:    sub sp, sp, #32
+; CHECK-NOLSE-O0-NEXT:    .cfi_def_cfa_offset 32
+; CHECK-NOLSE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    ldr w8, [x0]
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b LBB59_1
+; CHECK-NOLSE-O0-NEXT:  LBB59_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB59_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    subs w9, w10, w8
+; CHECK-NOLSE-O0-NEXT:    csel w12, w10, w8, hi
+; CHECK-NOLSE-O0-NEXT:  LBB59_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB59_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
+; CHECK-NOLSE-O0-NEXT:    ldaxr w9, [x11]
+; CHECK-NOLSE-O0-NEXT:    cmp w9, w10
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB59_4
+; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB59_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    stlxr w8, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB59_2
+; CHECK-NOLSE-O0-NEXT:  LBB59_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB59_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    mov w8, w9
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB59_5
+; CHECK-NOLSE-O0-NEXT:    b LBB59_1
+; CHECK-NOLSE-O0-NEXT:  LBB59_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
+; CHECK-NOLSE-O0-NEXT:    ret
+;
+; CHECK-OUTLINE-O0-LABEL: atomicrmw_umax_i32:
+; CHECK-OUTLINE-O0:       ; %bb.0:
+; CHECK-OUTLINE-O0-NEXT:    sub sp, sp, #48
+; CHECK-OUTLINE-O0-NEXT:    stp x29, x30, [sp, #32] ; 16-byte Folded Spill
+; CHECK-OUTLINE-O0-NEXT:    .cfi_def_cfa_offset 48
+; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w30, -8
+; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w29, -16
+; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    str w1, [sp, #24] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    ldr w0, [x0]
+; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    b LBB59_1
+; CHECK-OUTLINE-O0-NEXT:  LBB59_1: ; %atomicrmw.start
+; CHECK-OUTLINE-O0-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #28] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldr x2, [sp, #16] ; 8-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #8] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    subs w9, w0, w8
+; CHECK-OUTLINE-O0-NEXT:    csel w1, w0, w8, hi
+; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas4_relax
+; CHECK-OUTLINE-O0-NEXT:    ldr w9, [sp, #8] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    mov w8, w0
+; CHECK-OUTLINE-O0-NEXT:    mov w0, w8
+; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #12] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w9
+; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    b.eq LBB59_2
+; CHECK-OUTLINE-O0-NEXT:    b LBB59_1
+; CHECK-OUTLINE-O0-NEXT:  LBB59_2: ; %atomicrmw.end
 ; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
 ; CHECK-OUTLINE-O0-NEXT:    add sp, sp, #48
@@ -4963,12 +5289,12 @@ define i32 @atomicrmw_umax_i32(ptr %ptr, i32 %rhs) {
 define i64 @atomicrmw_add_i64(ptr %ptr, i64 %rhs) {
 ; CHECK-NOLSE-O1-LABEL: atomicrmw_add_i64:
 ; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB57_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:  LBB60_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O1-NEXT:    ldaxr x8, [x0]
 ; CHECK-NOLSE-O1-NEXT:    add x9, x8, x1
 ; CHECK-NOLSE-O1-NEXT:    stlxr w10, x9, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB57_1
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB60_1
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; CHECK-NOLSE-O1-NEXT:    mov x0, x8
 ; CHECK-NOLSE-O1-NEXT:    ret
@@ -4994,33 +5320,33 @@ define i64 @atomicrmw_add_i64(ptr %ptr, i64 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:    str x1, [sp, #16] ; 8-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    ldr x8, [x0]
 ; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB57_1
-; CHECK-NOLSE-O0-NEXT:  LBB57_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    b LBB60_1
+; CHECK-NOLSE-O0-NEXT:  LBB60_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB57_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB60_2 Depth 2
 ; CHECK-NOLSE-O0-NEXT:    ldr x10, [sp, #24] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #8] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x8, [sp, #16] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add x12, x10, x8
-; CHECK-NOLSE-O0-NEXT:  LBB57_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB57_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:  LBB60_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB60_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr x9, [x11]
 ; CHECK-NOLSE-O0-NEXT:    cmp x9, x10
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB57_4
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB60_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB57_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB60_2 Depth=2
 ; CHECK-NOLSE-O0-NEXT:    stlxr w8, x12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB57_2
-; CHECK-NOLSE-O0-NEXT:  LBB57_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB57_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB60_2
+; CHECK-NOLSE-O0-NEXT:  LBB60_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB60_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    mov x8, x9
 ; CHECK-NOLSE-O0-NEXT:    str x8, [sp] ; 8-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    subs x9, x9, x10
 ; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB57_5
-; CHECK-NOLSE-O0-NEXT:    b LBB57_1
-; CHECK-NOLSE-O0-NEXT:  LBB57_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB60_5
+; CHECK-NOLSE-O0-NEXT:    b LBB60_1
+; CHECK-NOLSE-O0-NEXT:  LBB60_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr x0, [sp] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
 ; CHECK-NOLSE-O0-NEXT:    ret
@@ -5056,11 +5382,11 @@ define i64 @atomicrmw_add_i64(ptr %ptr, i64 %rhs) {
 define i64 @atomicrmw_xchg_i64(ptr %ptr, i64 %rhs) {
 ; CHECK-NOLSE-O1-LABEL: atomicrmw_xchg_i64:
 ; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB58_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:  LBB61_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O1-NEXT:    ldxr x8, [x0]
 ; CHECK-NOLSE-O1-NEXT:    stxr w9, x1, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w9, LBB58_1
+; CHECK-NOLSE-O1-NEXT:    cbnz w9, LBB61_1
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; CHECK-NOLSE-O1-NEXT:    mov x0, x8
 ; CHECK-NOLSE-O1-NEXT:    ret
@@ -5086,32 +5412,32 @@ define i64 @atomicrmw_xchg_i64(ptr %ptr, i64 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:    str x1, [sp, #16] ; 8-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    ldr x8, [x0]
 ; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB58_1
-; CHECK-NOLSE-O0-NEXT:  LBB58_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    b LBB61_1
+; CHECK-NOLSE-O0-NEXT:  LBB61_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB58_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB61_2 Depth 2
 ; CHECK-NOLSE-O0-NEXT:    ldr x10, [sp, #24] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #8] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x12, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:  LBB58_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB58_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:  LBB61_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB61_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr x9, [x11]
 ; CHECK-NOLSE-O0-NEXT:    cmp x9, x10
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB58_4
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB61_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB58_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB61_2 Depth=2
 ; CHECK-NOLSE-O0-NEXT:    stlxr w8, x12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB58_2
-; CHECK-NOLSE-O0-NEXT:  LBB58_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB58_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB61_2
+; CHECK-NOLSE-O0-NEXT:  LBB61_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB61_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    mov x8, x9
 ; CHECK-NOLSE-O0-NEXT:    str x8, [sp] ; 8-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    subs x9, x9, x10
 ; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB58_5
-; CHECK-NOLSE-O0-NEXT:    b LBB58_1
-; CHECK-NOLSE-O0-NEXT:  LBB58_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB61_5
+; CHECK-NOLSE-O0-NEXT:    b LBB61_1
+; CHECK-NOLSE-O0-NEXT:  LBB61_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr x0, [sp] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
 ; CHECK-NOLSE-O0-NEXT:    ret
@@ -5147,12 +5473,12 @@ define i64 @atomicrmw_xchg_i64(ptr %ptr, i64 %rhs) {
 define i64 @atomicrmw_sub_i64(ptr %ptr, i64 %rhs) {
 ; CHECK-NOLSE-O1-LABEL: atomicrmw_sub_i64:
 ; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB59_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:  LBB62_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O1-NEXT:    ldaxr x8, [x0]
 ; CHECK-NOLSE-O1-NEXT:    sub x9, x8, x1
 ; CHECK-NOLSE-O1-NEXT:    stxr w10, x9, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB59_1
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB62_1
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; CHECK-NOLSE-O1-NEXT:    mov x0, x8
 ; CHECK-NOLSE-O1-NEXT:    ret
@@ -5178,33 +5504,33 @@ define i64 @atomicrmw_sub_i64(ptr %ptr, i64 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:    str x1, [sp, #16] ; 8-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    ldr x8, [x0]
 ; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB59_1
-; CHECK-NOLSE-O0-NEXT:  LBB59_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    b LBB62_1
+; CHECK-NOLSE-O0-NEXT:  LBB62_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB59_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB62_2 Depth 2
 ; CHECK-NOLSE-O0-NEXT:    ldr x10, [sp, #24] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #8] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x8, [sp, #16] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    subs x12, x10, x8
-; CHECK-NOLSE-O0-NEXT:  LBB59_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB59_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:  LBB62_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB62_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr x9, [x11]
 ; CHECK-NOLSE-O0-NEXT:    cmp x9, x10
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB59_4
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB62_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB59_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB62_2 Depth=2
 ; CHECK-NOLSE-O0-NEXT:    stlxr w8, x12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB59_2
-; CHECK-NOLSE-O0-NEXT:  LBB59_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB59_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB62_2
+; CHECK-NOLSE-O0-NEXT:  LBB62_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB62_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    mov x8, x9
 ; CHECK-NOLSE-O0-NEXT:    str x8, [sp] ; 8-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    subs x9, x9, x10
 ; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB59_5
-; CHECK-NOLSE-O0-NEXT:    b LBB59_1
-; CHECK-NOLSE-O0-NEXT:  LBB59_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB62_5
+; CHECK-NOLSE-O0-NEXT:    b LBB62_1
+; CHECK-NOLSE-O0-NEXT:  LBB62_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr x0, [sp] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
 ; CHECK-NOLSE-O0-NEXT:    ret
@@ -5244,12 +5570,12 @@ define i64 @atomicrmw_sub_i64(ptr %ptr, i64 %rhs) {
 define i64 @atomicrmw_and_i64(ptr %ptr, i64 %rhs) {
 ; CHECK-NOLSE-O1-LABEL: atomicrmw_and_i64:
 ; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB60_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:  LBB63_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O1-NEXT:    ldxr x8, [x0]
 ; CHECK-NOLSE-O1-NEXT:    and x9, x8, x1
 ; CHECK-NOLSE-O1-NEXT:    stlxr w10, x9, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB60_1
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB63_1
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; CHECK-NOLSE-O1-NEXT:    mov x0, x8
 ; CHECK-NOLSE-O1-NEXT:    ret
@@ -5275,33 +5601,33 @@ define i64 @atomicrmw_and_i64(ptr %ptr, i64 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:    str x1, [sp, #16] ; 8-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    ldr x8, [x0]
 ; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB60_1
-; CHECK-NOLSE-O0-NEXT:  LBB60_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    b LBB63_1
+; CHECK-NOLSE-O0-NEXT:  LBB63_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB60_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB63_2 Depth 2
 ; CHECK-NOLSE-O0-NEXT:    ldr x10, [sp, #24] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #8] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x8, [sp, #16] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    and x12, x10, x8
-; CHECK-NOLSE-O0-NEXT:  LBB60_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB60_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:  LBB63_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB63_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr x9, [x11]
 ; CHECK-NOLSE-O0-NEXT:    cmp x9, x10
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB60_4
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB63_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB60_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB63_2 Depth=2
 ; CHECK-NOLSE-O0-NEXT:    stlxr w8, x12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB60_2
-; CHECK-NOLSE-O0-NEXT:  LBB60_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB60_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB63_2
+; CHECK-NOLSE-O0-NEXT:  LBB63_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB63_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    mov x8, x9
 ; CHECK-NOLSE-O0-NEXT:    str x8, [sp] ; 8-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    subs x9, x9, x10
 ; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB60_5
-; CHECK-NOLSE-O0-NEXT:    b LBB60_1
-; CHECK-NOLSE-O0-NEXT:  LBB60_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB63_5
+; CHECK-NOLSE-O0-NEXT:    b LBB63_1
+; CHECK-NOLSE-O0-NEXT:  LBB63_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr x0, [sp] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
 ; CHECK-NOLSE-O0-NEXT:    ret
@@ -5341,12 +5667,12 @@ define i64 @atomicrmw_and_i64(ptr %ptr, i64 %rhs) {
 define i64 @atomicrmw_or_i64(ptr %ptr, i64 %rhs) {
 ; CHECK-NOLSE-O1-LABEL: atomicrmw_or_i64:
 ; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB61_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:  LBB64_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O1-NEXT:    ldaxr x8, [x0]
 ; CHECK-NOLSE-O1-NEXT:    orr x9, x8, x1
 ; CHECK-NOLSE-O1-NEXT:    stlxr w10, x9, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB61_1
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB64_1
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; CHECK-NOLSE-O1-NEXT:    mov x0, x8
 ; CHECK-NOLSE-O1-NEXT:    ret
@@ -5372,33 +5698,33 @@ define i64 @atomicrmw_or_i64(ptr %ptr, i64 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:    str x1, [sp, #16] ; 8-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    ldr x8, [x0]
 ; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB61_1
-; CHECK-NOLSE-O0-NEXT:  LBB61_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    b LBB64_1
+; CHECK-NOLSE-O0-NEXT:  LBB64_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB61_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB64_2 Depth 2
 ; CHECK-NOLSE-O0-NEXT:    ldr x10, [sp, #24] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #8] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x8, [sp, #16] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    orr x12, x10, x8
-; CHECK-NOLSE-O0-NEXT:  LBB61_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB61_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:  LBB64_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB64_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr x9, [x11]
 ; CHECK-NOLSE-O0-NEXT:    cmp x9, x10
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB61_4
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB64_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB61_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB64_2 Depth=2
 ; CHECK-NOLSE-O0-NEXT:    stlxr w8, x12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB61_2
-; CHECK-NOLSE-O0-NEXT:  LBB61_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB61_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB64_2
+; CHECK-NOLSE-O0-NEXT:  LBB64_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB64_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    mov x8, x9
 ; CHECK-NOLSE-O0-NEXT:    str x8, [sp] ; 8-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    subs x9, x9, x10
 ; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB61_5
-; CHECK-NOLSE-O0-NEXT:    b LBB61_1
-; CHECK-NOLSE-O0-NEXT:  LBB61_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB64_5
+; CHECK-NOLSE-O0-NEXT:    b LBB64_1
+; CHECK-NOLSE-O0-NEXT:  LBB64_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr x0, [sp] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
 ; CHECK-NOLSE-O0-NEXT:    ret
@@ -5434,12 +5760,12 @@ define i64 @atomicrmw_or_i64(ptr %ptr, i64 %rhs) {
 define i64 @atomicrmw_xor_i64(ptr %ptr, i64 %rhs) {
 ; CHECK-NOLSE-O1-LABEL: atomicrmw_xor_i64:
 ; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB62_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:  LBB65_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O1-NEXT:    ldxr x8, [x0]
 ; CHECK-NOLSE-O1-NEXT:    eor x9, x8, x1
 ; CHECK-NOLSE-O1-NEXT:    stxr w10, x9, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB62_1
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB65_1
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; CHECK-NOLSE-O1-NEXT:    mov x0, x8
 ; CHECK-NOLSE-O1-NEXT:    ret
@@ -5465,33 +5791,33 @@ define i64 @atomicrmw_xor_i64(ptr %ptr, i64 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:    str x1, [sp, #16] ; 8-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    ldr x8, [x0]
 ; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB62_1
-; CHECK-NOLSE-O0-NEXT:  LBB62_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    b LBB65_1
+; CHECK-NOLSE-O0-NEXT:  LBB65_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB62_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB65_2 Depth 2
 ; CHECK-NOLSE-O0-NEXT:    ldr x10, [sp, #24] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #8] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x8, [sp, #16] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    eor x12, x10, x8
-; CHECK-NOLSE-O0-NEXT:  LBB62_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB62_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:  LBB65_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB65_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr x9, [x11]
 ; CHECK-NOLSE-O0-NEXT:    cmp x9, x10
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB62_4
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB65_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB62_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB65_2 Depth=2
 ; CHECK-NOLSE-O0-NEXT:    stlxr w8, x12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB62_2
-; CHECK-NOLSE-O0-NEXT:  LBB62_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB62_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB65_2
+; CHECK-NOLSE-O0-NEXT:  LBB65_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB65_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    mov x8, x9
 ; CHECK-NOLSE-O0-NEXT:    str x8, [sp] ; 8-byte Spill
 ; CHECK-NOLSE-O0-NEXT:    subs x9, x9, x10
 ; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB62_5
-; CHECK-NOLSE-O0-NEXT:    b LBB62_1
-; CHECK-NOLSE-O0-NEXT:  LBB62_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB65_5
+; CHECK-NOLSE-O0-NEXT:    b LBB65_1
+; CHECK-NOLSE-O0-NEXT:  LBB65_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr x0, [sp] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
 ; CHECK-NOLSE-O0-NEXT:    ret
@@ -5527,376 +5853,31 @@ define i64 @atomicrmw_xor_i64(ptr %ptr, i64 %rhs) {
 define i64 @atomicrmw_min_i64(ptr %ptr, i64 %rhs) {
 ; CHECK-NOLSE-O1-LABEL: atomicrmw_min_i64:
 ; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB63_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:  LBB66_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O1-NEXT:    ldaxr x8, [x0]
 ; CHECK-NOLSE-O1-NEXT:    cmp x8, x1
 ; CHECK-NOLSE-O1-NEXT:    csel x9, x8, x1, lt
-; CHECK-NOLSE-O1-NEXT:    stxr w10, x9, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB63_1
-; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
-; CHECK-NOLSE-O1-NEXT:    mov x0, x8
-; CHECK-NOLSE-O1-NEXT:    ret
-;
-; CHECK-OUTLINE-O1-LABEL: atomicrmw_min_i64:
-; CHECK-OUTLINE-O1:       ; %bb.0:
-; CHECK-OUTLINE-O1-NEXT:  LBB63_1: ; %atomicrmw.start
-; CHECK-OUTLINE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-OUTLINE-O1-NEXT:    ldaxr x8, [x0]
-; CHECK-OUTLINE-O1-NEXT:    cmp x8, x1
-; CHECK-OUTLINE-O1-NEXT:    csel x9, x8, x1, lt
-; CHECK-OUTLINE-O1-NEXT:    stxr w10, x9, [x0]
-; CHECK-OUTLINE-O1-NEXT:    cbnz w10, LBB63_1
-; CHECK-OUTLINE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
-; CHECK-OUTLINE-O1-NEXT:    mov x0, x8
-; CHECK-OUTLINE-O1-NEXT:    ret
-;
-; CHECK-NOLSE-O0-LABEL: atomicrmw_min_i64:
-; CHECK-NOLSE-O0:       ; %bb.0:
-; CHECK-NOLSE-O0-NEXT:    sub sp, sp, #32
-; CHECK-NOLSE-O0-NEXT:    .cfi_def_cfa_offset 32
-; CHECK-NOLSE-O0-NEXT:    str x0, [sp, #8] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str x1, [sp, #16] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    ldr x8, [x0]
-; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB63_1
-; CHECK-NOLSE-O0-NEXT:  LBB63_1: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB63_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr x10, [sp, #24] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #8] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr x8, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    subs x9, x10, x8
-; CHECK-NOLSE-O0-NEXT:    csel x12, x10, x8, le
-; CHECK-NOLSE-O0-NEXT:  LBB63_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB63_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
-; CHECK-NOLSE-O0-NEXT:    ldaxr x9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp x9, x10
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB63_4
-; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB63_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxr w8, x12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB63_2
-; CHECK-NOLSE-O0-NEXT:  LBB63_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB63_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    mov x8, x9
-; CHECK-NOLSE-O0-NEXT:    str x8, [sp] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    subs x9, x9, x10
-; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB63_5
-; CHECK-NOLSE-O0-NEXT:    b LBB63_1
-; CHECK-NOLSE-O0-NEXT:  LBB63_5: ; %atomicrmw.end
-; CHECK-NOLSE-O0-NEXT:    ldr x0, [sp] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
-; CHECK-NOLSE-O0-NEXT:    ret
-;
-; CHECK-OUTLINE-O0-LABEL: atomicrmw_min_i64:
-; CHECK-OUTLINE-O0:       ; %bb.0:
-; CHECK-OUTLINE-O0-NEXT:    sub sp, sp, #64
-; CHECK-OUTLINE-O0-NEXT:    stp x29, x30, [sp, #48] ; 16-byte Folded Spill
-; CHECK-OUTLINE-O0-NEXT:    .cfi_def_cfa_offset 64
-; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w30, -8
-; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w29, -16
-; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #24] ; 8-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    str x1, [sp, #32] ; 8-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    ldr x0, [x0]
-; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #40] ; 8-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    b LBB63_1
-; CHECK-OUTLINE-O0-NEXT:  LBB63_1: ; %atomicrmw.start
-; CHECK-OUTLINE-O0-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-OUTLINE-O0-NEXT:    ldr x0, [sp, #40] ; 8-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldr x2, [sp, #24] ; 8-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldr x8, [sp, #32] ; 8-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #8] ; 8-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    subs x9, x0, x8
-; CHECK-OUTLINE-O0-NEXT:    csel x1, x0, x8, le
-; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas8_acq
-; CHECK-OUTLINE-O0-NEXT:    ldr x9, [sp, #8] ; 8-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    mov x8, x0
-; CHECK-OUTLINE-O0-NEXT:    mov x0, x8
-; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    subs x8, x8, x9
-; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #40] ; 8-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    b.eq LBB63_2
-; CHECK-OUTLINE-O0-NEXT:    b LBB63_1
-; CHECK-OUTLINE-O0-NEXT:  LBB63_2: ; %atomicrmw.end
-; CHECK-OUTLINE-O0-NEXT:    ldr x0, [sp, #16] ; 8-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #48] ; 16-byte Folded Reload
-; CHECK-OUTLINE-O0-NEXT:    add sp, sp, #64
-; CHECK-OUTLINE-O0-NEXT:    ret
-;
-; CHECK-LSE-O1-LABEL: atomicrmw_min_i64:
-; CHECK-LSE-O1:       ; %bb.0:
-; CHECK-LSE-O1-NEXT:    ldsmina x1, x0, [x0]
-; CHECK-LSE-O1-NEXT:    ret
-;
-; CHECK-LSE-O0-LABEL: atomicrmw_min_i64:
-; CHECK-LSE-O0:       ; %bb.0:
-; CHECK-LSE-O0-NEXT:    ldsmina x1, x0, [x0]
-; CHECK-LSE-O0-NEXT:    ret
-  %res = atomicrmw min ptr %ptr, i64 %rhs acquire
-  ret i64 %res
-}
-
-define i64 @atomicrmw_max_i64(ptr %ptr, i64 %rhs) {
-; CHECK-NOLSE-O1-LABEL: atomicrmw_max_i64:
-; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB64_1: ; %atomicrmw.start
-; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-NOLSE-O1-NEXT:    ldxr x8, [x0]
-; CHECK-NOLSE-O1-NEXT:    cmp x8, x1
-; CHECK-NOLSE-O1-NEXT:    csel x9, x8, x1, gt
-; CHECK-NOLSE-O1-NEXT:    stlxr w10, x9, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB64_1
-; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
-; CHECK-NOLSE-O1-NEXT:    mov x0, x8
-; CHECK-NOLSE-O1-NEXT:    ret
-;
-; CHECK-OUTLINE-O1-LABEL: atomicrmw_max_i64:
-; CHECK-OUTLINE-O1:       ; %bb.0:
-; CHECK-OUTLINE-O1-NEXT:  LBB64_1: ; %atomicrmw.start
-; CHECK-OUTLINE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-OUTLINE-O1-NEXT:    ldxr x8, [x0]
-; CHECK-OUTLINE-O1-NEXT:    cmp x8, x1
-; CHECK-OUTLINE-O1-NEXT:    csel x9, x8, x1, gt
-; CHECK-OUTLINE-O1-NEXT:    stlxr w10, x9, [x0]
-; CHECK-OUTLINE-O1-NEXT:    cbnz w10, LBB64_1
-; CHECK-OUTLINE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
-; CHECK-OUTLINE-O1-NEXT:    mov x0, x8
-; CHECK-OUTLINE-O1-NEXT:    ret
-;
-; CHECK-NOLSE-O0-LABEL: atomicrmw_max_i64:
-; CHECK-NOLSE-O0:       ; %bb.0:
-; CHECK-NOLSE-O0-NEXT:    sub sp, sp, #32
-; CHECK-NOLSE-O0-NEXT:    .cfi_def_cfa_offset 32
-; CHECK-NOLSE-O0-NEXT:    str x0, [sp, #8] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str x1, [sp, #16] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    ldr x8, [x0]
-; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB64_1
-; CHECK-NOLSE-O0-NEXT:  LBB64_1: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB64_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr x10, [sp, #24] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #8] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr x8, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    subs x9, x10, x8
-; CHECK-NOLSE-O0-NEXT:    csel x12, x10, x8, gt
-; CHECK-NOLSE-O0-NEXT:  LBB64_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB64_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
-; CHECK-NOLSE-O0-NEXT:    ldaxr x9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp x9, x10
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB64_4
-; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB64_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxr w8, x12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB64_2
-; CHECK-NOLSE-O0-NEXT:  LBB64_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB64_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    mov x8, x9
-; CHECK-NOLSE-O0-NEXT:    str x8, [sp] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    subs x9, x9, x10
-; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB64_5
-; CHECK-NOLSE-O0-NEXT:    b LBB64_1
-; CHECK-NOLSE-O0-NEXT:  LBB64_5: ; %atomicrmw.end
-; CHECK-NOLSE-O0-NEXT:    ldr x0, [sp] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
-; CHECK-NOLSE-O0-NEXT:    ret
-;
-; CHECK-OUTLINE-O0-LABEL: atomicrmw_max_i64:
-; CHECK-OUTLINE-O0:       ; %bb.0:
-; CHECK-OUTLINE-O0-NEXT:    sub sp, sp, #64
-; CHECK-OUTLINE-O0-NEXT:    stp x29, x30, [sp, #48] ; 16-byte Folded Spill
-; CHECK-OUTLINE-O0-NEXT:    .cfi_def_cfa_offset 64
-; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w30, -8
-; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w29, -16
-; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #24] ; 8-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    str x1, [sp, #32] ; 8-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    ldr x0, [x0]
-; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #40] ; 8-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    b LBB64_1
-; CHECK-OUTLINE-O0-NEXT:  LBB64_1: ; %atomicrmw.start
-; CHECK-OUTLINE-O0-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-OUTLINE-O0-NEXT:    ldr x0, [sp, #40] ; 8-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldr x2, [sp, #24] ; 8-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldr x8, [sp, #32] ; 8-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #8] ; 8-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    subs x9, x0, x8
-; CHECK-OUTLINE-O0-NEXT:    csel x1, x0, x8, gt
-; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas8_rel
-; CHECK-OUTLINE-O0-NEXT:    ldr x9, [sp, #8] ; 8-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    mov x8, x0
-; CHECK-OUTLINE-O0-NEXT:    mov x0, x8
-; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    subs x8, x8, x9
-; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #40] ; 8-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    b.eq LBB64_2
-; CHECK-OUTLINE-O0-NEXT:    b LBB64_1
-; CHECK-OUTLINE-O0-NEXT:  LBB64_2: ; %atomicrmw.end
-; CHECK-OUTLINE-O0-NEXT:    ldr x0, [sp, #16] ; 8-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #48] ; 16-byte Folded Reload
-; CHECK-OUTLINE-O0-NEXT:    add sp, sp, #64
-; CHECK-OUTLINE-O0-NEXT:    ret
-;
-; CHECK-LSE-O1-LABEL: atomicrmw_max_i64:
-; CHECK-LSE-O1:       ; %bb.0:
-; CHECK-LSE-O1-NEXT:    ldsmaxl x1, x0, [x0]
-; CHECK-LSE-O1-NEXT:    ret
-;
-; CHECK-LSE-O0-LABEL: atomicrmw_max_i64:
-; CHECK-LSE-O0:       ; %bb.0:
-; CHECK-LSE-O0-NEXT:    ldsmaxl x1, x0, [x0]
-; CHECK-LSE-O0-NEXT:    ret
-  %res = atomicrmw max ptr %ptr, i64 %rhs release
-  ret i64 %res
-}
-
-define i64 @atomicrmw_umin_i64(ptr %ptr, i64 %rhs) {
-; CHECK-NOLSE-O1-LABEL: atomicrmw_umin_i64:
-; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB65_1: ; %atomicrmw.start
-; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-NOLSE-O1-NEXT:    ldaxr x8, [x0]
-; CHECK-NOLSE-O1-NEXT:    cmp x8, x1
-; CHECK-NOLSE-O1-NEXT:    csel x9, x8, x1, lo
-; CHECK-NOLSE-O1-NEXT:    stlxr w10, x9, [x0]
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB65_1
-; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
-; CHECK-NOLSE-O1-NEXT:    mov x0, x8
-; CHECK-NOLSE-O1-NEXT:    ret
-;
-; CHECK-OUTLINE-O1-LABEL: atomicrmw_umin_i64:
-; CHECK-OUTLINE-O1:       ; %bb.0:
-; CHECK-OUTLINE-O1-NEXT:  LBB65_1: ; %atomicrmw.start
-; CHECK-OUTLINE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-OUTLINE-O1-NEXT:    ldaxr x8, [x0]
-; CHECK-OUTLINE-O1-NEXT:    cmp x8, x1
-; CHECK-OUTLINE-O1-NEXT:    csel x9, x8, x1, lo
-; CHECK-OUTLINE-O1-NEXT:    stlxr w10, x9, [x0]
-; CHECK-OUTLINE-O1-NEXT:    cbnz w10, LBB65_1
-; CHECK-OUTLINE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
-; CHECK-OUTLINE-O1-NEXT:    mov x0, x8
-; CHECK-OUTLINE-O1-NEXT:    ret
-;
-; CHECK-NOLSE-O0-LABEL: atomicrmw_umin_i64:
-; CHECK-NOLSE-O0:       ; %bb.0:
-; CHECK-NOLSE-O0-NEXT:    sub sp, sp, #32
-; CHECK-NOLSE-O0-NEXT:    .cfi_def_cfa_offset 32
-; CHECK-NOLSE-O0-NEXT:    str x0, [sp, #8] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str x1, [sp, #16] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    ldr x8, [x0]
-; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b LBB65_1
-; CHECK-NOLSE-O0-NEXT:  LBB65_1: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB65_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr x10, [sp, #24] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #8] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr x8, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    subs x9, x10, x8
-; CHECK-NOLSE-O0-NEXT:    csel x12, x10, x8, ls
-; CHECK-NOLSE-O0-NEXT:  LBB65_2: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB65_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
-; CHECK-NOLSE-O0-NEXT:    ldaxr x9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp x9, x10
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB65_4
-; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB65_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxr w8, x12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB65_2
-; CHECK-NOLSE-O0-NEXT:  LBB65_4: ; %atomicrmw.start
-; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB65_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    mov x8, x9
-; CHECK-NOLSE-O0-NEXT:    str x8, [sp] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    subs x9, x9, x10
-; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    b.eq LBB65_5
-; CHECK-NOLSE-O0-NEXT:    b LBB65_1
-; CHECK-NOLSE-O0-NEXT:  LBB65_5: ; %atomicrmw.end
-; CHECK-NOLSE-O0-NEXT:    ldr x0, [sp] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
-; CHECK-NOLSE-O0-NEXT:    ret
-;
-; CHECK-OUTLINE-O0-LABEL: atomicrmw_umin_i64:
-; CHECK-OUTLINE-O0:       ; %bb.0:
-; CHECK-OUTLINE-O0-NEXT:    sub sp, sp, #64
-; CHECK-OUTLINE-O0-NEXT:    stp x29, x30, [sp, #48] ; 16-byte Folded Spill
-; CHECK-OUTLINE-O0-NEXT:    .cfi_def_cfa_offset 64
-; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w30, -8
-; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w29, -16
-; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #24] ; 8-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    str x1, [sp, #32] ; 8-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    ldr x0, [x0]
-; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #40] ; 8-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    b LBB65_1
-; CHECK-OUTLINE-O0-NEXT:  LBB65_1: ; %atomicrmw.start
-; CHECK-OUTLINE-O0-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-OUTLINE-O0-NEXT:    ldr x0, [sp, #40] ; 8-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldr x2, [sp, #24] ; 8-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldr x8, [sp, #32] ; 8-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #8] ; 8-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    subs x9, x0, x8
-; CHECK-OUTLINE-O0-NEXT:    csel x1, x0, x8, ls
-; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas8_acq_rel
-; CHECK-OUTLINE-O0-NEXT:    ldr x9, [sp, #8] ; 8-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    mov x8, x0
-; CHECK-OUTLINE-O0-NEXT:    mov x0, x8
-; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    subs x8, x8, x9
-; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #40] ; 8-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    b.eq LBB65_2
-; CHECK-OUTLINE-O0-NEXT:    b LBB65_1
-; CHECK-OUTLINE-O0-NEXT:  LBB65_2: ; %atomicrmw.end
-; CHECK-OUTLINE-O0-NEXT:    ldr x0, [sp, #16] ; 8-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #48] ; 16-byte Folded Reload
-; CHECK-OUTLINE-O0-NEXT:    add sp, sp, #64
-; CHECK-OUTLINE-O0-NEXT:    ret
-;
-; CHECK-LSE-O1-LABEL: atomicrmw_umin_i64:
-; CHECK-LSE-O1:       ; %bb.0:
-; CHECK-LSE-O1-NEXT:    lduminal x1, x0, [x0]
-; CHECK-LSE-O1-NEXT:    ret
-;
-; CHECK-LSE-O0-LABEL: atomicrmw_umin_i64:
-; CHECK-LSE-O0:       ; %bb.0:
-; CHECK-LSE-O0-NEXT:    lduminal x1, x0, [x0]
-; CHECK-LSE-O0-NEXT:    ret
-  %res = atomicrmw umin ptr %ptr, i64 %rhs seq_cst
-  ret i64 %res
-}
-
-define i64 @atomicrmw_umax_i64(ptr %ptr, i64 %rhs) {
-; CHECK-NOLSE-O1-LABEL: atomicrmw_umax_i64:
-; CHECK-NOLSE-O1:       ; %bb.0:
-; CHECK-NOLSE-O1-NEXT:  LBB66_1: ; %atomicrmw.start
-; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-NOLSE-O1-NEXT:    ldxr x8, [x0]
-; CHECK-NOLSE-O1-NEXT:    cmp x8, x1
-; CHECK-NOLSE-O1-NEXT:    csel x9, x8, x1, hi
 ; CHECK-NOLSE-O1-NEXT:    stxr w10, x9, [x0]
 ; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB66_1
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; CHECK-NOLSE-O1-NEXT:    mov x0, x8
 ; CHECK-NOLSE-O1-NEXT:    ret
 ;
-; CHECK-OUTLINE-O1-LABEL: atomicrmw_umax_i64:
+; CHECK-OUTLINE-O1-LABEL: atomicrmw_min_i64:
 ; CHECK-OUTLINE-O1:       ; %bb.0:
 ; CHECK-OUTLINE-O1-NEXT:  LBB66_1: ; %atomicrmw.start
 ; CHECK-OUTLINE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-OUTLINE-O1-NEXT:    ldxr x8, [x0]
+; CHECK-OUTLINE-O1-NEXT:    ldaxr x8, [x0]
 ; CHECK-OUTLINE-O1-NEXT:    cmp x8, x1
-; CHECK-OUTLINE-O1-NEXT:    csel x9, x8, x1, hi
+; CHECK-OUTLINE-O1-NEXT:    csel x9, x8, x1, lt
 ; CHECK-OUTLINE-O1-NEXT:    stxr w10, x9, [x0]
 ; CHECK-OUTLINE-O1-NEXT:    cbnz w10, LBB66_1
 ; CHECK-OUTLINE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; CHECK-OUTLINE-O1-NEXT:    mov x0, x8
 ; CHECK-OUTLINE-O1-NEXT:    ret
 ;
-; CHECK-NOLSE-O0-LABEL: atomicrmw_umax_i64:
+; CHECK-NOLSE-O0-LABEL: atomicrmw_min_i64:
 ; CHECK-NOLSE-O0:       ; %bb.0:
 ; CHECK-NOLSE-O0-NEXT:    sub sp, sp, #32
 ; CHECK-NOLSE-O0-NEXT:    .cfi_def_cfa_offset 32
@@ -5912,7 +5893,7 @@ define i64 @atomicrmw_umax_i64(ptr %ptr, i64 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #8] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x8, [sp, #16] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    subs x9, x10, x8
-; CHECK-NOLSE-O0-NEXT:    csel x12, x10, x8, hi
+; CHECK-NOLSE-O0-NEXT:    csel x12, x10, x8, le
 ; CHECK-NOLSE-O0-NEXT:  LBB66_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB66_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
@@ -5936,7 +5917,7 @@ define i64 @atomicrmw_umax_i64(ptr %ptr, i64 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
 ; CHECK-NOLSE-O0-NEXT:    ret
 ;
-; CHECK-OUTLINE-O0-LABEL: atomicrmw_umax_i64:
+; CHECK-OUTLINE-O0-LABEL: atomicrmw_min_i64:
 ; CHECK-OUTLINE-O0:       ; %bb.0:
 ; CHECK-OUTLINE-O0-NEXT:    sub sp, sp, #64
 ; CHECK-OUTLINE-O0-NEXT:    stp x29, x30, [sp, #48] ; 16-byte Folded Spill
@@ -5955,8 +5936,8 @@ define i64 @atomicrmw_umax_i64(ptr %ptr, i64 %rhs) {
 ; CHECK-OUTLINE-O0-NEXT:    ldr x8, [sp, #32] ; 8-byte Reload
 ; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #8] ; 8-byte Spill
 ; CHECK-OUTLINE-O0-NEXT:    subs x9, x0, x8
-; CHECK-OUTLINE-O0-NEXT:    csel x1, x0, x8, hi
-; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas8_relax
+; CHECK-OUTLINE-O0-NEXT:    csel x1, x0, x8, le
+; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas8_acq
 ; CHECK-OUTLINE-O0-NEXT:    ldr x9, [sp, #8] ; 8-byte Reload
 ; CHECK-OUTLINE-O0-NEXT:    mov x8, x0
 ; CHECK-OUTLINE-O0-NEXT:    mov x0, x8
@@ -5966,6 +5947,351 @@ define i64 @atomicrmw_umax_i64(ptr %ptr, i64 %rhs) {
 ; CHECK-OUTLINE-O0-NEXT:    b.eq LBB66_2
 ; CHECK-OUTLINE-O0-NEXT:    b LBB66_1
 ; CHECK-OUTLINE-O0-NEXT:  LBB66_2: ; %atomicrmw.end
+; CHECK-OUTLINE-O0-NEXT:    ldr x0, [sp, #16] ; 8-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #48] ; 16-byte Folded Reload
+; CHECK-OUTLINE-O0-NEXT:    add sp, sp, #64
+; CHECK-OUTLINE-O0-NEXT:    ret
+;
+; CHECK-LSE-O1-LABEL: atomicrmw_min_i64:
+; CHECK-LSE-O1:       ; %bb.0:
+; CHECK-LSE-O1-NEXT:    ldsmina x1, x0, [x0]
+; CHECK-LSE-O1-NEXT:    ret
+;
+; CHECK-LSE-O0-LABEL: atomicrmw_min_i64:
+; CHECK-LSE-O0:       ; %bb.0:
+; CHECK-LSE-O0-NEXT:    ldsmina x1, x0, [x0]
+; CHECK-LSE-O0-NEXT:    ret
+  %res = atomicrmw min ptr %ptr, i64 %rhs acquire
+  ret i64 %res
+}
+
+define i64 @atomicrmw_max_i64(ptr %ptr, i64 %rhs) {
+; CHECK-NOLSE-O1-LABEL: atomicrmw_max_i64:
+; CHECK-NOLSE-O1:       ; %bb.0:
+; CHECK-NOLSE-O1-NEXT:  LBB67_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-NOLSE-O1-NEXT:    ldxr x8, [x0]
+; CHECK-NOLSE-O1-NEXT:    cmp x8, x1
+; CHECK-NOLSE-O1-NEXT:    csel x9, x8, x1, gt
+; CHECK-NOLSE-O1-NEXT:    stlxr w10, x9, [x0]
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB67_1
+; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
+; CHECK-NOLSE-O1-NEXT:    mov x0, x8
+; CHECK-NOLSE-O1-NEXT:    ret
+;
+; CHECK-OUTLINE-O1-LABEL: atomicrmw_max_i64:
+; CHECK-OUTLINE-O1:       ; %bb.0:
+; CHECK-OUTLINE-O1-NEXT:  LBB67_1: ; %atomicrmw.start
+; CHECK-OUTLINE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-OUTLINE-O1-NEXT:    ldxr x8, [x0]
+; CHECK-OUTLINE-O1-NEXT:    cmp x8, x1
+; CHECK-OUTLINE-O1-NEXT:    csel x9, x8, x1, gt
+; CHECK-OUTLINE-O1-NEXT:    stlxr w10, x9, [x0]
+; CHECK-OUTLINE-O1-NEXT:    cbnz w10, LBB67_1
+; CHECK-OUTLINE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
+; CHECK-OUTLINE-O1-NEXT:    mov x0, x8
+; CHECK-OUTLINE-O1-NEXT:    ret
+;
+; CHECK-NOLSE-O0-LABEL: atomicrmw_max_i64:
+; CHECK-NOLSE-O0:       ; %bb.0:
+; CHECK-NOLSE-O0-NEXT:    sub sp, sp, #32
+; CHECK-NOLSE-O0-NEXT:    .cfi_def_cfa_offset 32
+; CHECK-NOLSE-O0-NEXT:    str x0, [sp, #8] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    str x1, [sp, #16] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    ldr x8, [x0]
+; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b LBB67_1
+; CHECK-NOLSE-O0-NEXT:  LBB67_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB67_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ldr x10, [sp, #24] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #8] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr x8, [sp, #16] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    subs x9, x10, x8
+; CHECK-NOLSE-O0-NEXT:    csel x12, x10, x8, gt
+; CHECK-NOLSE-O0-NEXT:  LBB67_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB67_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
+; CHECK-NOLSE-O0-NEXT:    ldaxr x9, [x11]
+; CHECK-NOLSE-O0-NEXT:    cmp x9, x10
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB67_4
+; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB67_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    stlxr w8, x12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB67_2
+; CHECK-NOLSE-O0-NEXT:  LBB67_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB67_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    mov x8, x9
+; CHECK-NOLSE-O0-NEXT:    str x8, [sp] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    subs x9, x9, x10
+; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB67_5
+; CHECK-NOLSE-O0-NEXT:    b LBB67_1
+; CHECK-NOLSE-O0-NEXT:  LBB67_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    ldr x0, [sp] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
+; CHECK-NOLSE-O0-NEXT:    ret
+;
+; CHECK-OUTLINE-O0-LABEL: atomicrmw_max_i64:
+; CHECK-OUTLINE-O0:       ; %bb.0:
+; CHECK-OUTLINE-O0-NEXT:    sub sp, sp, #64
+; CHECK-OUTLINE-O0-NEXT:    stp x29, x30, [sp, #48] ; 16-byte Folded Spill
+; CHECK-OUTLINE-O0-NEXT:    .cfi_def_cfa_offset 64
+; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w30, -8
+; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w29, -16
+; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #24] ; 8-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    str x1, [sp, #32] ; 8-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    ldr x0, [x0]
+; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #40] ; 8-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    b LBB67_1
+; CHECK-OUTLINE-O0-NEXT:  LBB67_1: ; %atomicrmw.start
+; CHECK-OUTLINE-O0-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-OUTLINE-O0-NEXT:    ldr x0, [sp, #40] ; 8-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldr x2, [sp, #24] ; 8-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldr x8, [sp, #32] ; 8-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #8] ; 8-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    subs x9, x0, x8
+; CHECK-OUTLINE-O0-NEXT:    csel x1, x0, x8, gt
+; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas8_rel
+; CHECK-OUTLINE-O0-NEXT:    ldr x9, [sp, #8] ; 8-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    mov x8, x0
+; CHECK-OUTLINE-O0-NEXT:    mov x0, x8
+; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    subs x8, x8, x9
+; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #40] ; 8-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    b.eq LBB67_2
+; CHECK-OUTLINE-O0-NEXT:    b LBB67_1
+; CHECK-OUTLINE-O0-NEXT:  LBB67_2: ; %atomicrmw.end
+; CHECK-OUTLINE-O0-NEXT:    ldr x0, [sp, #16] ; 8-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #48] ; 16-byte Folded Reload
+; CHECK-OUTLINE-O0-NEXT:    add sp, sp, #64
+; CHECK-OUTLINE-O0-NEXT:    ret
+;
+; CHECK-LSE-O1-LABEL: atomicrmw_max_i64:
+; CHECK-LSE-O1:       ; %bb.0:
+; CHECK-LSE-O1-NEXT:    ldsmaxl x1, x0, [x0]
+; CHECK-LSE-O1-NEXT:    ret
+;
+; CHECK-LSE-O0-LABEL: atomicrmw_max_i64:
+; CHECK-LSE-O0:       ; %bb.0:
+; CHECK-LSE-O0-NEXT:    ldsmaxl x1, x0, [x0]
+; CHECK-LSE-O0-NEXT:    ret
+  %res = atomicrmw max ptr %ptr, i64 %rhs release
+  ret i64 %res
+}
+
+define i64 @atomicrmw_umin_i64(ptr %ptr, i64 %rhs) {
+; CHECK-NOLSE-O1-LABEL: atomicrmw_umin_i64:
+; CHECK-NOLSE-O1:       ; %bb.0:
+; CHECK-NOLSE-O1-NEXT:  LBB68_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-NOLSE-O1-NEXT:    ldaxr x8, [x0]
+; CHECK-NOLSE-O1-NEXT:    cmp x8, x1
+; CHECK-NOLSE-O1-NEXT:    csel x9, x8, x1, lo
+; CHECK-NOLSE-O1-NEXT:    stlxr w10, x9, [x0]
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB68_1
+; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
+; CHECK-NOLSE-O1-NEXT:    mov x0, x8
+; CHECK-NOLSE-O1-NEXT:    ret
+;
+; CHECK-OUTLINE-O1-LABEL: atomicrmw_umin_i64:
+; CHECK-OUTLINE-O1:       ; %bb.0:
+; CHECK-OUTLINE-O1-NEXT:  LBB68_1: ; %atomicrmw.start
+; CHECK-OUTLINE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-OUTLINE-O1-NEXT:    ldaxr x8, [x0]
+; CHECK-OUTLINE-O1-NEXT:    cmp x8, x1
+; CHECK-OUTLINE-O1-NEXT:    csel x9, x8, x1, lo
+; CHECK-OUTLINE-O1-NEXT:    stlxr w10, x9, [x0]
+; CHECK-OUTLINE-O1-NEXT:    cbnz w10, LBB68_1
+; CHECK-OUTLINE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
+; CHECK-OUTLINE-O1-NEXT:    mov x0, x8
+; CHECK-OUTLINE-O1-NEXT:    ret
+;
+; CHECK-NOLSE-O0-LABEL: atomicrmw_umin_i64:
+; CHECK-NOLSE-O0:       ; %bb.0:
+; CHECK-NOLSE-O0-NEXT:    sub sp, sp, #32
+; CHECK-NOLSE-O0-NEXT:    .cfi_def_cfa_offset 32
+; CHECK-NOLSE-O0-NEXT:    str x0, [sp, #8] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    str x1, [sp, #16] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    ldr x8, [x0]
+; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b LBB68_1
+; CHECK-NOLSE-O0-NEXT:  LBB68_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB68_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ldr x10, [sp, #24] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #8] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr x8, [sp, #16] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    subs x9, x10, x8
+; CHECK-NOLSE-O0-NEXT:    csel x12, x10, x8, ls
+; CHECK-NOLSE-O0-NEXT:  LBB68_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB68_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
+; CHECK-NOLSE-O0-NEXT:    ldaxr x9, [x11]
+; CHECK-NOLSE-O0-NEXT:    cmp x9, x10
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB68_4
+; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB68_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    stlxr w8, x12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB68_2
+; CHECK-NOLSE-O0-NEXT:  LBB68_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB68_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    mov x8, x9
+; CHECK-NOLSE-O0-NEXT:    str x8, [sp] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    subs x9, x9, x10
+; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB68_5
+; CHECK-NOLSE-O0-NEXT:    b LBB68_1
+; CHECK-NOLSE-O0-NEXT:  LBB68_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    ldr x0, [sp] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
+; CHECK-NOLSE-O0-NEXT:    ret
+;
+; CHECK-OUTLINE-O0-LABEL: atomicrmw_umin_i64:
+; CHECK-OUTLINE-O0:       ; %bb.0:
+; CHECK-OUTLINE-O0-NEXT:    sub sp, sp, #64
+; CHECK-OUTLINE-O0-NEXT:    stp x29, x30, [sp, #48] ; 16-byte Folded Spill
+; CHECK-OUTLINE-O0-NEXT:    .cfi_def_cfa_offset 64
+; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w30, -8
+; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w29, -16
+; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #24] ; 8-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    str x1, [sp, #32] ; 8-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    ldr x0, [x0]
+; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #40] ; 8-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    b LBB68_1
+; CHECK-OUTLINE-O0-NEXT:  LBB68_1: ; %atomicrmw.start
+; CHECK-OUTLINE-O0-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-OUTLINE-O0-NEXT:    ldr x0, [sp, #40] ; 8-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldr x2, [sp, #24] ; 8-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldr x8, [sp, #32] ; 8-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #8] ; 8-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    subs x9, x0, x8
+; CHECK-OUTLINE-O0-NEXT:    csel x1, x0, x8, ls
+; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas8_acq_rel
+; CHECK-OUTLINE-O0-NEXT:    ldr x9, [sp, #8] ; 8-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    mov x8, x0
+; CHECK-OUTLINE-O0-NEXT:    mov x0, x8
+; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    subs x8, x8, x9
+; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #40] ; 8-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    b.eq LBB68_2
+; CHECK-OUTLINE-O0-NEXT:    b LBB68_1
+; CHECK-OUTLINE-O0-NEXT:  LBB68_2: ; %atomicrmw.end
+; CHECK-OUTLINE-O0-NEXT:    ldr x0, [sp, #16] ; 8-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #48] ; 16-byte Folded Reload
+; CHECK-OUTLINE-O0-NEXT:    add sp, sp, #64
+; CHECK-OUTLINE-O0-NEXT:    ret
+;
+; CHECK-LSE-O1-LABEL: atomicrmw_umin_i64:
+; CHECK-LSE-O1:       ; %bb.0:
+; CHECK-LSE-O1-NEXT:    lduminal x1, x0, [x0]
+; CHECK-LSE-O1-NEXT:    ret
+;
+; CHECK-LSE-O0-LABEL: atomicrmw_umin_i64:
+; CHECK-LSE-O0:       ; %bb.0:
+; CHECK-LSE-O0-NEXT:    lduminal x1, x0, [x0]
+; CHECK-LSE-O0-NEXT:    ret
+  %res = atomicrmw umin ptr %ptr, i64 %rhs seq_cst
+  ret i64 %res
+}
+
+define i64 @atomicrmw_umax_i64(ptr %ptr, i64 %rhs) {
+; CHECK-NOLSE-O1-LABEL: atomicrmw_umax_i64:
+; CHECK-NOLSE-O1:       ; %bb.0:
+; CHECK-NOLSE-O1-NEXT:  LBB69_1: ; %atomicrmw.start
+; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-NOLSE-O1-NEXT:    ldxr x8, [x0]
+; CHECK-NOLSE-O1-NEXT:    cmp x8, x1
+; CHECK-NOLSE-O1-NEXT:    csel x9, x8, x1, hi
+; CHECK-NOLSE-O1-NEXT:    stxr w10, x9, [x0]
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB69_1
+; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
+; CHECK-NOLSE-O1-NEXT:    mov x0, x8
+; CHECK-NOLSE-O1-NEXT:    ret
+;
+; CHECK-OUTLINE-O1-LABEL: atomicrmw_umax_i64:
+; CHECK-OUTLINE-O1:       ; %bb.0:
+; CHECK-OUTLINE-O1-NEXT:  LBB69_1: ; %atomicrmw.start
+; CHECK-OUTLINE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-OUTLINE-O1-NEXT:    ldxr x8, [x0]
+; CHECK-OUTLINE-O1-NEXT:    cmp x8, x1
+; CHECK-OUTLINE-O1-NEXT:    csel x9, x8, x1, hi
+; CHECK-OUTLINE-O1-NEXT:    stxr w10, x9, [x0]
+; CHECK-OUTLINE-O1-NEXT:    cbnz w10, LBB69_1
+; CHECK-OUTLINE-O1-NEXT:  ; %bb.2: ; %atomicrmw.end
+; CHECK-OUTLINE-O1-NEXT:    mov x0, x8
+; CHECK-OUTLINE-O1-NEXT:    ret
+;
+; CHECK-NOLSE-O0-LABEL: atomicrmw_umax_i64:
+; CHECK-NOLSE-O0:       ; %bb.0:
+; CHECK-NOLSE-O0-NEXT:    sub sp, sp, #32
+; CHECK-NOLSE-O0-NEXT:    .cfi_def_cfa_offset 32
+; CHECK-NOLSE-O0-NEXT:    str x0, [sp, #8] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    str x1, [sp, #16] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    ldr x8, [x0]
+; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b LBB69_1
+; CHECK-NOLSE-O0-NEXT:  LBB69_1: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
+; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB69_2 Depth 2
+; CHECK-NOLSE-O0-NEXT:    ldr x10, [sp, #24] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #8] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr x8, [sp, #16] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    subs x9, x10, x8
+; CHECK-NOLSE-O0-NEXT:    csel x12, x10, x8, hi
+; CHECK-NOLSE-O0-NEXT:  LBB69_2: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB69_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
+; CHECK-NOLSE-O0-NEXT:    ldaxr x9, [x11]
+; CHECK-NOLSE-O0-NEXT:    cmp x9, x10
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB69_4
+; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB69_2 Depth=2
+; CHECK-NOLSE-O0-NEXT:    stlxr w8, x12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB69_2
+; CHECK-NOLSE-O0-NEXT:  LBB69_4: ; %atomicrmw.start
+; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB69_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    mov x8, x9
+; CHECK-NOLSE-O0-NEXT:    str x8, [sp] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    subs x9, x9, x10
+; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB69_5
+; CHECK-NOLSE-O0-NEXT:    b LBB69_1
+; CHECK-NOLSE-O0-NEXT:  LBB69_5: ; %atomicrmw.end
+; CHECK-NOLSE-O0-NEXT:    ldr x0, [sp] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
+; CHECK-NOLSE-O0-NEXT:    ret
+;
+; CHECK-OUTLINE-O0-LABEL: atomicrmw_umax_i64:
+; CHECK-OUTLINE-O0:       ; %bb.0:
+; CHECK-OUTLINE-O0-NEXT:    sub sp, sp, #64
+; CHECK-OUTLINE-O0-NEXT:    stp x29, x30, [sp, #48] ; 16-byte Folded Spill
+; CHECK-OUTLINE-O0-NEXT:    .cfi_def_cfa_offset 64
+; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w30, -8
+; CHECK-OUTLINE-O0-NEXT:    .cfi_offset w29, -16
+; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #24] ; 8-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    str x1, [sp, #32] ; 8-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    ldr x0, [x0]
+; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #40] ; 8-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    b LBB69_1
+; CHECK-OUTLINE-O0-NEXT:  LBB69_1: ; %atomicrmw.start
+; CHECK-OUTLINE-O0-NEXT:    ; =>This Inner Loop Header: Depth=1
+; CHECK-OUTLINE-O0-NEXT:    ldr x0, [sp, #40] ; 8-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldr x2, [sp, #24] ; 8-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    ldr x8, [sp, #32] ; 8-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #8] ; 8-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    subs x9, x0, x8
+; CHECK-OUTLINE-O0-NEXT:    csel x1, x0, x8, hi
+; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas8_relax
+; CHECK-OUTLINE-O0-NEXT:    ldr x9, [sp, #8] ; 8-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    mov x8, x0
+; CHECK-OUTLINE-O0-NEXT:    mov x0, x8
+; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    subs x8, x8, x9
+; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #40] ; 8-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    b.eq LBB69_2
+; CHECK-OUTLINE-O0-NEXT:    b LBB69_1
+; CHECK-OUTLINE-O0-NEXT:  LBB69_2: ; %atomicrmw.end
 ; CHECK-OUTLINE-O0-NEXT:    ldr x0, [sp, #16] ; 8-byte Reload
 ; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #48] ; 16-byte Folded Reload
 ; CHECK-OUTLINE-O0-NEXT:    add sp, sp, #64
@@ -5988,22 +6314,22 @@ define { i8, i1 } @cmpxchg_i8(ptr %ptr, i8 %desired, i8 %new) {
 ; CHECK-NOLSE-O1-LABEL: cmpxchg_i8:
 ; CHECK-NOLSE-O1:       ; %bb.0:
 ; CHECK-NOLSE-O1-NEXT:    mov x8, x0
-; CHECK-NOLSE-O1-NEXT:  LBB67_1: ; %cmpxchg.start
+; CHECK-NOLSE-O1-NEXT:  LBB70_1: ; %cmpxchg.start
 ; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O1-NEXT:    ldxrb w0, [x8]
 ; CHECK-NOLSE-O1-NEXT:    and w9, w0, #0xff
 ; CHECK-NOLSE-O1-NEXT:    cmp w9, w1, uxtb
-; CHECK-NOLSE-O1-NEXT:    b.ne LBB67_4
+; CHECK-NOLSE-O1-NEXT:    b.ne LBB70_4
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %cmpxchg.trystore
-; CHECK-NOLSE-O1-NEXT:    ; in Loop: Header=BB67_1 Depth=1
+; CHECK-NOLSE-O1-NEXT:    ; in Loop: Header=BB70_1 Depth=1
 ; CHECK-NOLSE-O1-NEXT:    stxrb w10, w2, [x8]
 ; CHECK-NOLSE-O1-NEXT:    mov w9, #1 ; =0x1
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB67_1
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB70_1
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.3: ; %cmpxchg.end
 ; CHECK-NOLSE-O1-NEXT:    mov w1, w9
 ; CHECK-NOLSE-O1-NEXT:    ; kill: def $w0 killed $w0 killed $x0
 ; CHECK-NOLSE-O1-NEXT:    ret
-; CHECK-NOLSE-O1-NEXT:  LBB67_4: ; %cmpxchg.nostore
+; CHECK-NOLSE-O1-NEXT:  LBB70_4: ; %cmpxchg.nostore
 ; CHECK-NOLSE-O1-NEXT:    mov w9, wzr
 ; CHECK-NOLSE-O1-NEXT:    clrex
 ; CHECK-NOLSE-O1-NEXT:    mov w1, w9
@@ -6035,14 +6361,14 @@ define { i8, i1 } @cmpxchg_i8(ptr %ptr, i8 %desired, i8 %new) {
 ; CHECK-NOLSE-O0-LABEL: cmpxchg_i8:
 ; CHECK-NOLSE-O0:       ; %bb.0:
 ; CHECK-NOLSE-O0-NEXT:    mov x9, x0
-; CHECK-NOLSE-O0-NEXT:  LBB67_1: ; =>This Inner Loop Header: Depth=1
+; CHECK-NOLSE-O0-NEXT:  LBB70_1: ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ldaxrb w0, [x9]
 ; CHECK-NOLSE-O0-NEXT:    cmp w0, w1, uxtb
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB67_3
-; CHECK-NOLSE-O0-NEXT:  ; %bb.2: ; in Loop: Header=BB67_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB70_3
+; CHECK-NOLSE-O0-NEXT:  ; %bb.2: ; in Loop: Header=BB70_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    stlxrb w8, w2, [x9]
-; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB67_1
-; CHECK-NOLSE-O0-NEXT:  LBB67_3:
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB70_1
+; CHECK-NOLSE-O0-NEXT:  LBB70_3:
 ; CHECK-NOLSE-O0-NEXT:    and w8, w0, #0xff
 ; CHECK-NOLSE-O0-NEXT:    subs w8, w8, w1, uxtb
 ; CHECK-NOLSE-O0-NEXT:    cset w1, eq
@@ -6096,22 +6422,22 @@ define { i16, i1 } @cmpxchg_i16(ptr %ptr, i16 %desired, i16 %new) {
 ; CHECK-NOLSE-O1-LABEL: cmpxchg_i16:
 ; CHECK-NOLSE-O1:       ; %bb.0:
 ; CHECK-NOLSE-O1-NEXT:    mov x8, x0
-; CHECK-NOLSE-O1-NEXT:  LBB68_1: ; %cmpxchg.start
+; CHECK-NOLSE-O1-NEXT:  LBB71_1: ; %cmpxchg.start
 ; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O1-NEXT:    ldxrh w0, [x8]
 ; CHECK-NOLSE-O1-NEXT:    and w9, w0, #0xffff
 ; CHECK-NOLSE-O1-NEXT:    cmp w9, w1, uxth
-; CHECK-NOLSE-O1-NEXT:    b.ne LBB68_4
+; CHECK-NOLSE-O1-NEXT:    b.ne LBB71_4
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %cmpxchg.trystore
-; CHECK-NOLSE-O1-NEXT:    ; in Loop: Header=BB68_1 Depth=1
+; CHECK-NOLSE-O1-NEXT:    ; in Loop: Header=BB71_1 Depth=1
 ; CHECK-NOLSE-O1-NEXT:    stxrh w10, w2, [x8]
 ; CHECK-NOLSE-O1-NEXT:    mov w9, #1 ; =0x1
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB68_1
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB71_1
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.3: ; %cmpxchg.end
 ; CHECK-NOLSE-O1-NEXT:    mov w1, w9
 ; CHECK-NOLSE-O1-NEXT:    ; kill: def $w0 killed $w0 killed $x0
 ; CHECK-NOLSE-O1-NEXT:    ret
-; CHECK-NOLSE-O1-NEXT:  LBB68_4: ; %cmpxchg.nostore
+; CHECK-NOLSE-O1-NEXT:  LBB71_4: ; %cmpxchg.nostore
 ; CHECK-NOLSE-O1-NEXT:    mov w9, wzr
 ; CHECK-NOLSE-O1-NEXT:    clrex
 ; CHECK-NOLSE-O1-NEXT:    mov w1, w9
@@ -6143,14 +6469,14 @@ define { i16, i1 } @cmpxchg_i16(ptr %ptr, i16 %desired, i16 %new) {
 ; CHECK-NOLSE-O0-LABEL: cmpxchg_i16:
 ; CHECK-NOLSE-O0:       ; %bb.0:
 ; CHECK-NOLSE-O0-NEXT:    mov x9, x0
-; CHECK-NOLSE-O0-NEXT:  LBB68_1: ; =>This Inner Loop Header: Depth=1
+; CHECK-NOLSE-O0-NEXT:  LBB71_1: ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ldaxrh w0, [x9]
 ; CHECK-NOLSE-O0-NEXT:    cmp w0, w1, uxth
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB68_3
-; CHECK-NOLSE-O0-NEXT:  ; %bb.2: ; in Loop: Header=BB68_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB71_3
+; CHECK-NOLSE-O0-NEXT:  ; %bb.2: ; in Loop: Header=BB71_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    stlxrh w8, w2, [x9]
-; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB68_1
-; CHECK-NOLSE-O0-NEXT:  LBB68_3:
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB71_1
+; CHECK-NOLSE-O0-NEXT:  LBB71_3:
 ; CHECK-NOLSE-O0-NEXT:    and w8, w0, #0xffff
 ; CHECK-NOLSE-O0-NEXT:    subs w8, w8, w1, uxth
 ; CHECK-NOLSE-O0-NEXT:    cset w1, eq
@@ -6205,20 +6531,20 @@ define { i32, i1 } @cmpxchg_i32(ptr %ptr, i32 %desired, i32 %new) {
 ; CHECK-NOLSE-O1:       ; %bb.0:
 ; CHECK-NOLSE-O1-NEXT:    mov x8, x0
 ; CHECK-NOLSE-O1-NEXT:    mov w9, #1 ; =0x1
-; CHECK-NOLSE-O1-NEXT:  LBB69_1: ; %cmpxchg.start
+; CHECK-NOLSE-O1-NEXT:  LBB72_1: ; %cmpxchg.start
 ; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O1-NEXT:    ldxr w0, [x8]
 ; CHECK-NOLSE-O1-NEXT:    cmp w0, w1
-; CHECK-NOLSE-O1-NEXT:    b.ne LBB69_4
+; CHECK-NOLSE-O1-NEXT:    b.ne LBB72_4
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %cmpxchg.trystore
-; CHECK-NOLSE-O1-NEXT:    ; in Loop: Header=BB69_1 Depth=1
+; CHECK-NOLSE-O1-NEXT:    ; in Loop: Header=BB72_1 Depth=1
 ; CHECK-NOLSE-O1-NEXT:    stxr w10, w2, [x8]
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB69_1
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB72_1
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.3: ; %cmpxchg.end
 ; CHECK-NOLSE-O1-NEXT:    mov w1, w9
 ; CHECK-NOLSE-O1-NEXT:    ; kill: def $w0 killed $w0 killed $x0
 ; CHECK-NOLSE-O1-NEXT:    ret
-; CHECK-NOLSE-O1-NEXT:  LBB69_4: ; %cmpxchg.nostore
+; CHECK-NOLSE-O1-NEXT:  LBB72_4: ; %cmpxchg.nostore
 ; CHECK-NOLSE-O1-NEXT:    mov w9, wzr
 ; CHECK-NOLSE-O1-NEXT:    clrex
 ; CHECK-NOLSE-O1-NEXT:    mov w1, w9
@@ -6249,14 +6575,14 @@ define { i32, i1 } @cmpxchg_i32(ptr %ptr, i32 %desired, i32 %new) {
 ; CHECK-NOLSE-O0-LABEL: cmpxchg_i32:
 ; CHECK-NOLSE-O0:       ; %bb.0:
 ; CHECK-NOLSE-O0-NEXT:    mov x9, x0
-; CHECK-NOLSE-O0-NEXT:  LBB69_1: ; =>This Inner Loop Header: Depth=1
+; CHECK-NOLSE-O0-NEXT:  LBB72_1: ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ldaxr w0, [x9]
 ; CHECK-NOLSE-O0-NEXT:    cmp w0, w1
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB69_3
-; CHECK-NOLSE-O0-NEXT:  ; %bb.2: ; in Loop: Header=BB69_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB72_3
+; CHECK-NOLSE-O0-NEXT:  ; %bb.2: ; in Loop: Header=BB72_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    stlxr w8, w2, [x9]
-; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB69_1
-; CHECK-NOLSE-O0-NEXT:  LBB69_3:
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB72_1
+; CHECK-NOLSE-O0-NEXT:  LBB72_3:
 ; CHECK-NOLSE-O0-NEXT:    subs w8, w0, w1
 ; CHECK-NOLSE-O0-NEXT:    cset w1, eq
 ; CHECK-NOLSE-O0-NEXT:    ret
@@ -6307,19 +6633,19 @@ define { i64, i1 } @cmpxchg_i64(ptr %ptr, i64 %desired, i64 %new) {
 ; CHECK-NOLSE-O1:       ; %bb.0:
 ; CHECK-NOLSE-O1-NEXT:    mov x8, x0
 ; CHECK-NOLSE-O1-NEXT:    mov w9, #1 ; =0x1
-; CHECK-NOLSE-O1-NEXT:  LBB70_1: ; %cmpxchg.start
+; CHECK-NOLSE-O1-NEXT:  LBB73_1: ; %cmpxchg.start
 ; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O1-NEXT:    ldxr x0, [x8]
 ; CHECK-NOLSE-O1-NEXT:    cmp x0, x1
-; CHECK-NOLSE-O1-NEXT:    b.ne LBB70_4
+; CHECK-NOLSE-O1-NEXT:    b.ne LBB73_4
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %cmpxchg.trystore
-; CHECK-NOLSE-O1-NEXT:    ; in Loop: Header=BB70_1 Depth=1
+; CHECK-NOLSE-O1-NEXT:    ; in Loop: Header=BB73_1 Depth=1
 ; CHECK-NOLSE-O1-NEXT:    stxr w10, x2, [x8]
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB70_1
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB73_1
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.3: ; %cmpxchg.end
 ; CHECK-NOLSE-O1-NEXT:    mov w1, w9
 ; CHECK-NOLSE-O1-NEXT:    ret
-; CHECK-NOLSE-O1-NEXT:  LBB70_4: ; %cmpxchg.nostore
+; CHECK-NOLSE-O1-NEXT:  LBB73_4: ; %cmpxchg.nostore
 ; CHECK-NOLSE-O1-NEXT:    mov w9, wzr
 ; CHECK-NOLSE-O1-NEXT:    clrex
 ; CHECK-NOLSE-O1-NEXT:    mov w1, w9
@@ -6349,14 +6675,14 @@ define { i64, i1 } @cmpxchg_i64(ptr %ptr, i64 %desired, i64 %new) {
 ; CHECK-NOLSE-O0-LABEL: cmpxchg_i64:
 ; CHECK-NOLSE-O0:       ; %bb.0:
 ; CHECK-NOLSE-O0-NEXT:    mov x9, x0
-; CHECK-NOLSE-O0-NEXT:  LBB70_1: ; =>This Inner Loop Header: Depth=1
+; CHECK-NOLSE-O0-NEXT:  LBB73_1: ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ldaxr x0, [x9]
 ; CHECK-NOLSE-O0-NEXT:    cmp x0, x1
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB70_3
-; CHECK-NOLSE-O0-NEXT:  ; %bb.2: ; in Loop: Header=BB70_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB73_3
+; CHECK-NOLSE-O0-NEXT:  ; %bb.2: ; in Loop: Header=BB73_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    stlxr w8, x2, [x9]
-; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB70_1
-; CHECK-NOLSE-O0-NEXT:  LBB70_3:
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB73_1
+; CHECK-NOLSE-O0-NEXT:  LBB73_3:
 ; CHECK-NOLSE-O0-NEXT:    subs x8, x0, x1
 ; CHECK-NOLSE-O0-NEXT:    cset w1, eq
 ; CHECK-NOLSE-O0-NEXT:    ret
@@ -6407,19 +6733,19 @@ define { ptr, i1 } @cmpxchg_ptr(ptr %ptr, ptr %desired, ptr %new) {
 ; CHECK-NOLSE-O1:       ; %bb.0:
 ; CHECK-NOLSE-O1-NEXT:    mov x8, x0
 ; CHECK-NOLSE-O1-NEXT:    mov w9, #1 ; =0x1
-; CHECK-NOLSE-O1-NEXT:  LBB71_1: ; %cmpxchg.start
+; CHECK-NOLSE-O1-NEXT:  LBB74_1: ; %cmpxchg.start
 ; CHECK-NOLSE-O1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O1-NEXT:    ldxr x0, [x8]
 ; CHECK-NOLSE-O1-NEXT:    cmp x0, x1
-; CHECK-NOLSE-O1-NEXT:    b.ne LBB71_4
+; CHECK-NOLSE-O1-NEXT:    b.ne LBB74_4
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.2: ; %cmpxchg.trystore
-; CHECK-NOLSE-O1-NEXT:    ; in Loop: Header=BB71_1 Depth=1
+; CHECK-NOLSE-O1-NEXT:    ; in Loop: Header=BB74_1 Depth=1
 ; CHECK-NOLSE-O1-NEXT:    stxr w10, x2, [x8]
-; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB71_1
+; CHECK-NOLSE-O1-NEXT:    cbnz w10, LBB74_1
 ; CHECK-NOLSE-O1-NEXT:  ; %bb.3: ; %cmpxchg.end
 ; CHECK-NOLSE-O1-NEXT:    mov w1, w9
 ; CHECK-NOLSE-O1-NEXT:    ret
-; CHECK-NOLSE-O1-NEXT:  LBB71_4: ; %cmpxchg.nostore
+; CHECK-NOLSE-O1-NEXT:  LBB74_4: ; %cmpxchg.nostore
 ; CHECK-NOLSE-O1-NEXT:    mov w9, wzr
 ; CHECK-NOLSE-O1-NEXT:    clrex
 ; CHECK-NOLSE-O1-NEXT:    mov w1, w9
@@ -6449,14 +6775,14 @@ define { ptr, i1 } @cmpxchg_ptr(ptr %ptr, ptr %desired, ptr %new) {
 ; CHECK-NOLSE-O0-LABEL: cmpxchg_ptr:
 ; CHECK-NOLSE-O0:       ; %bb.0:
 ; CHECK-NOLSE-O0-NEXT:    mov x9, x0
-; CHECK-NOLSE-O0-NEXT:  LBB71_1: ; =>This Inner Loop Header: Depth=1
+; CHECK-NOLSE-O0-NEXT:  LBB74_1: ; =>This Inner Loop Header: Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ldaxr x0, [x9]
 ; CHECK-NOLSE-O0-NEXT:    cmp x0, x1
-; CHECK-NOLSE-O0-NEXT:    b.ne LBB71_3
-; CHECK-NOLSE-O0-NEXT:  ; %bb.2: ; in Loop: Header=BB71_1 Depth=1
+; CHECK-NOLSE-O0-NEXT:    b.ne LBB74_3
+; CHECK-NOLSE-O0-NEXT:  ; %bb.2: ; in Loop: Header=BB74_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    stlxr w8, x2, [x9]
-; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB71_1
-; CHECK-NOLSE-O0-NEXT:  LBB71_3:
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB74_1
+; CHECK-NOLSE-O0-NEXT:  LBB74_3:
 ; CHECK-NOLSE-O0-NEXT:    subs x8, x0, x1
 ; CHECK-NOLSE-O0-NEXT:    cset w1, eq
 ; CHECK-NOLSE-O0-NEXT:    ret


### PR DESCRIPTION
After #213935 the i64->i32 truncstore was failing to create a COPY correctly.
We do not have tablegen patterns, so mirror what SDAG does and do not create
atomic truncstore.