### PR TITLE
[BOLT] Use MCRegister instead of MCPhysReg or unsigned. NFC

### DIFF
--- a/bolt/include/bolt/Core/BinaryFunction.h
+++ b/bolt/include/bolt/Core/BinaryFunction.h
@@ -1872,7 +1872,7 @@ public:
     FrameInstructions[Offset] = std::move(CFIInst);
   }
 
-  void mutateCFIRegisterFor(const MCInst &Instr, MCPhysReg NewReg);
+  void mutateCFIRegisterFor(const MCInst &Instr, unsigned NewReg);
 
   const MCCFIInstruction *mutateCFIOffsetFor(const MCInst &Instr,
                                              int64_t NewOffset);

--- a/bolt/include/bolt/Core/MCInstUtils.h
+++ b/bolt/include/bolt/Core/MCInstUtils.h
@@ -275,7 +275,7 @@ public:
   }
 };
 
-class Reg : public OpMatcher<MCPhysReg> {
+class Reg : public OpMatcher<MCRegister> {
   bool matches(const MCOperand &Op) const {
     if (!Op.isReg())
       return false;
@@ -288,7 +288,7 @@ class Reg : public OpMatcher<MCPhysReg> {
 
 public:
   Reg(std::optional<MCPhysReg> RegToMatch = std::nullopt)
-      : OpMatcher<MCPhysReg>(RegToMatch) {}
+      : OpMatcher<MCRegister>(RegToMatch) {}
 };
 
 class Imm : public OpMatcher<int64_t> {

--- a/bolt/include/bolt/Core/MCPlusBuilder.h
+++ b/bolt/include/bolt/Core/MCPlusBuilder.h
@@ -2015,9 +2015,8 @@ public:
 
   /// Create a store instruction using \p StackReg as the base register
   /// and \p Offset as the displacement.
-  virtual void createSaveToStack(MCInst &Inst, MCRegister StackReg,
-                                 int Offset, MCRegister SrcReg,
-                                 int Size) const {
+  virtual void createSaveToStack(MCInst &Inst, MCRegister StackReg, int Offset,
+                                 MCRegister SrcReg, int Size) const {
     llvm_unreachable("not implemented");
   }
 

--- a/bolt/include/bolt/Core/MCPlusBuilder.h
+++ b/bolt/include/bolt/Core/MCPlusBuilder.h
@@ -521,12 +521,12 @@ public:
     llvm_unreachable("not implemented");
   }
 
-  virtual void createPushRegister(MCInst &Inst, MCPhysReg Reg,
+  virtual void createPushRegister(MCInst &Inst, MCRegister Reg,
                                   unsigned Size) const {
     llvm_unreachable("not implemented");
   }
 
-  virtual void createPopRegister(MCInst &Inst, MCPhysReg Reg,
+  virtual void createPopRegister(MCInst &Inst, MCRegister Reg,
                                  unsigned Size) const {
     llvm_unreachable("not implemented");
   }
@@ -549,7 +549,7 @@ public:
     llvm_unreachable("not implemented");
   }
 
-  virtual MCPhysReg getX86R11() const { llvm_unreachable("not implemented"); }
+  virtual MCRegister getX86R11() const { llvm_unreachable("not implemented"); }
 
   virtual unsigned getShortBranchOpcode(unsigned Opcode) const {
     llvm_unreachable("not implemented");
@@ -571,14 +571,14 @@ public:
 
   /// Return a register number that is guaranteed to not match with
   /// any real register on the underlying architecture.
-  MCPhysReg getNoRegister() const { return MCRegister::NoRegister; }
+  MCRegister getNoRegister() const { return MCRegister(); }
 
   /// Return a register corresponding to a function integer argument \p ArgNo
   /// if the argument is passed in a register. Or return the result of
   /// getNoRegister() otherwise. The enumeration starts at 0.
   ///
   /// Note: this should depend on a used calling convention.
-  virtual MCPhysReg getIntArgRegister(unsigned ArgNo) const {
+  virtual MCRegister getIntArgRegister(unsigned ArgNo) const {
     llvm_unreachable("not implemented");
   }
 
@@ -600,7 +600,7 @@ public:
   /// Each register should be treated as if a successfully authenticated
   /// pointer was written to it before entering the function (i.e. the
   /// pointer is safe to jump to as well as to be signed).
-  virtual SmallVector<MCPhysReg> getTrustedLiveInRegs() const {
+  virtual SmallVector<MCRegister> getTrustedLiveInRegs() const {
     llvm_unreachable("not implemented");
     return {};
   }
@@ -612,7 +612,7 @@ public:
   /// i.e. it either writes a successfully authenticated pointer or terminates
   /// the program abnormally (such as "ldra x0, [x1]!" on AArch64, which crashes
   /// on authentication failure even if FEAT_FPAC is not implemented).
-  virtual std::optional<MCPhysReg>
+  virtual std::optional<MCRegister>
   getWrittenAuthenticatedReg(const MCInst &Inst, bool &IsChecked) const {
     llvm_unreachable("not implemented");
     return std::nullopt;
@@ -623,7 +623,7 @@ public:
   ///
   /// The returned register is assumed to be both input and output operand,
   /// as it is done on AArch64.
-  virtual std::optional<MCPhysReg> getSignedReg(const MCInst &Inst) const {
+  virtual std::optional<MCRegister> getSignedReg(const MCInst &Inst) const {
     llvm_unreachable("not implemented");
     return std::nullopt;
   }
@@ -657,7 +657,7 @@ public:
   /// pointer as its operand and authenticates it internally.
   ///
   /// Should only be called when isReturn(Inst) is true.
-  virtual std::optional<MCPhysReg>
+  virtual std::optional<MCRegister>
   getRegUsedAsRetDest(const MCInst &Inst,
                       bool &IsAuthenticatedInternally) const {
     llvm_unreachable("not implemented");
@@ -670,7 +670,7 @@ public:
   ///
   /// Should only be called if isIndirectCall(Inst) or isIndirectBranch(Inst)
   /// returns true.
-  virtual MCPhysReg
+  virtual MCRegister
   getRegUsedAsIndirectBranchDest(const MCInst &Inst,
                                  bool &IsAuthenticatedInternally) const {
     llvm_unreachable("not implemented");
@@ -691,7 +691,7 @@ public:
   ///
   /// The Pointer Authentication threat model assumes an attacker is able to
   /// modify any writable memory, but not executable code (due to W^X).
-  virtual std::optional<MCPhysReg>
+  virtual std::optional<MCRegister>
   getMaterializedAddressRegForPtrAuth(const MCInst &Inst) const {
     llvm_unreachable("not implemented");
     return std::nullopt;
@@ -710,7 +710,7 @@ public:
   ///
   /// The instruction should not write any values derived from InReg anywhere,
   /// except for OutReg.
-  virtual std::optional<std::pair<MCPhysReg, MCPhysReg>>
+  virtual std::optional<std::pair<MCRegister, MCRegister>>
   analyzeAddressArithmeticsForPtrAuth(const MCInst &Inst) const {
     llvm_unreachable("not implemented");
     return std::nullopt;
@@ -741,7 +741,7 @@ public:
   ///
   /// Note that this function is not expected to repeat the results returned
   /// by getAuthCheckedReg(Inst, MayOverwrite) function below.
-  virtual std::optional<std::pair<MCPhysReg, MCInst *>>
+  virtual std::optional<std::pair<MCRegister, MCInst *>>
   getAuthCheckedReg(BinaryBasicBlock &BB) const {
     llvm_unreachable("not implemented");
     return std::nullopt;
@@ -758,8 +758,8 @@ public:
   ///
   /// Use this function for simple, single-instruction patterns instead of
   /// its getAuthCheckedReg(BB) counterpart.
-  virtual std::optional<MCPhysReg> getAuthCheckedReg(const MCInst &Inst,
-                                                     bool MayOverwrite) const {
+  virtual std::optional<MCRegister> getAuthCheckedReg(const MCInst &Inst,
+                                                      bool MayOverwrite) const {
     llvm_unreachable("not implemented");
     return std::nullopt;
   }
@@ -977,7 +977,7 @@ public:
       if (!Op.isReg())
         return true;
 
-      MCPhysReg Reg = Op.getReg();
+      MCRegister Reg = Op.getReg();
       while (next()) {
         const MCInstrDesc &InstrDesc = MIA.Info->get(CurInst->getOpcode());
         if (InstrDesc.hasDefOfPhysReg(*CurInst, Reg, MRI)) {
@@ -1062,8 +1062,8 @@ public:
 
   /// Matches operands that are registers
   struct RegMatcher : MCInstMatcher {
-    MCPhysReg &Reg;
-    RegMatcher(MCPhysReg &Reg) : Reg(Reg) {}
+    MCRegister &Reg;
+    RegMatcher(MCRegister &Reg) : Reg(Reg) {}
 
     bool match(const MCRegisterInfo &MRI, MCPlusBuilder &MIA,
                MutableArrayRef<MCInst> InInstrWindow, int OpNum) override {
@@ -1091,12 +1091,12 @@ public:
     return std::unique_ptr<MCInstMatcher>(new AnyOperandMatcher(Unused));
   }
 
-  std::unique_ptr<MCInstMatcher> matchReg(MCPhysReg &Reg) const {
+  std::unique_ptr<MCInstMatcher> matchReg(MCRegister &Reg) const {
     return std::unique_ptr<MCInstMatcher>(new RegMatcher(Reg));
   }
 
   std::unique_ptr<MCInstMatcher> matchReg() const {
-    static MCPhysReg Unused;
+    static MCRegister Unused;
     return std::unique_ptr<MCInstMatcher>(new RegMatcher(Unused));
   }
 
@@ -1181,11 +1181,11 @@ public:
   virtual bool hasEVEXEncoding(const MCInst &Inst) const { return false; }
 
   struct X86MemOperand {
-    unsigned BaseRegNum;
+    MCRegister BaseReg;
     int64_t ScaleImm;
-    unsigned IndexRegNum;
+    MCRegister IndexReg;
     int64_t DispImm;
-    unsigned SegRegNum;
+    MCRegister SegReg;
     const MCExpr *DispExpr = nullptr;
   };
 
@@ -1234,8 +1234,8 @@ public:
   /// companion functions "replaceMemOperandWithImm" or
   /// "replaceMemOperandWithReg".
   virtual bool isStackAccess(const MCInst &Inst, bool &IsLoad, bool &IsStore,
-                             bool &IsStoreFromReg, MCPhysReg &Reg,
-                             int32_t &SrcImm, uint16_t &StackPtrReg,
+                             bool &IsStoreFromReg, MCRegister &Reg,
+                             int32_t &SrcImm, MCRegister &StackPtrReg,
                              int64_t &StackOffset, uint8_t &Size,
                              bool &IsSimple, bool &IsIndexed) const {
     llvm_unreachable("not implemented");
@@ -1270,29 +1270,29 @@ public:
   /// offset) OP constant is not the same as x + (offset OP constant).
   virtual bool
   evaluateStackOffsetExpr(const MCInst &Inst, int64_t &Output,
-                          std::pair<MCPhysReg, int64_t> Input1,
-                          std::pair<MCPhysReg, int64_t> Input2) const {
+                          std::pair<MCRegister, int64_t> Input1,
+                          std::pair<MCRegister, int64_t> Input2) const {
     llvm_unreachable("not implemented");
     return false;
   }
 
-  virtual bool isRegToRegMove(const MCInst &Inst, MCPhysReg &From,
-                              MCPhysReg &To) const {
+  virtual bool isRegToRegMove(const MCInst &Inst, MCRegister &From,
+                              MCRegister &To) const {
     llvm_unreachable("not implemented");
     return false;
   }
 
-  virtual MCPhysReg getStackPointer() const {
+  virtual MCRegister getStackPointer() const {
     llvm_unreachable("not implemented");
     return 0;
   }
 
-  virtual MCPhysReg getFramePointer() const {
+  virtual MCRegister getFramePointer() const {
     llvm_unreachable("not implemented");
     return 0;
   }
 
-  virtual MCPhysReg getFlagsReg() const {
+  virtual MCRegister getFlagsReg() const {
     llvm_unreachable("not implemented");
     return 0;
   }
@@ -1323,15 +1323,15 @@ public:
   }
 
   // Replace Register in Inst with Imm. Returns true if successful
-  virtual bool replaceRegWithImm(MCInst &Inst, unsigned Register,
+  virtual bool replaceRegWithImm(MCInst &Inst, MCRegister Register,
                                  int64_t Imm) const {
     llvm_unreachable("not implemented");
     return false;
   }
 
   // Replace ToReplace in Inst with ReplaceWith. Returns true if successful
-  virtual bool replaceRegWithReg(MCInst &Inst, unsigned ToReplace,
-                                 unsigned ReplaceWith) const {
+  virtual bool replaceRegWithReg(MCInst &Inst, MCRegister ToReplace,
+                                 MCRegister ReplaceWith) const {
     llvm_unreachable("not implemented");
     return false;
   }
@@ -1356,7 +1356,7 @@ public:
   }
 
   /// Same as replaceMemOperandWithImm, but for registers.
-  virtual bool replaceMemOperandWithReg(MCInst &Inst, MCPhysReg RegNum) const {
+  virtual bool replaceMemOperandWithReg(MCInst &Inst, MCRegister Reg) const {
     llvm_unreachable("not implemented");
     return false;
   }
@@ -1430,10 +1430,10 @@ public:
   uint64_t getJumpTable(const MCInst &Inst) const;
 
   /// Return index register for instruction that uses a jump table.
-  uint16_t getJumpTableIndexReg(const MCInst &Inst) const;
+  MCRegister getJumpTableIndexReg(const MCInst &Inst) const;
 
   /// Set jump table addressed by this instruction.
-  bool setJumpTable(MCInst &Inst, uint64_t Value, uint16_t IndexReg,
+  bool setJumpTable(MCInst &Inst, uint64_t Value, MCRegister IndexReg,
                     AllocatorIdTy AllocId = 0);
 
   /// Disassociate instruction with a jump table.
@@ -1561,7 +1561,7 @@ public:
 
   /// Return a BitVector marking all sub or super registers of \p Reg, including
   /// itself.
-  virtual const BitVector &getAliases(MCPhysReg Reg,
+  virtual const BitVector &getAliases(MCRegister Reg,
                                       bool OnlySmaller = false) const;
 
   /// Initialize aliases tables.
@@ -1616,18 +1616,18 @@ public:
   }
 
   /// Return the register width in bytes (1, 2, 4 or 8)
-  uint8_t getRegSize(MCPhysReg Reg) const { return SizeMap[Reg]; }
+  uint8_t getRegSize(MCRegister Reg) const { return SizeMap[Reg.id()]; }
 
   /// For aliased registers, return an alias of \p Reg that has the width of
   /// \p Size bytes
-  virtual MCPhysReg getAliasSized(MCPhysReg Reg, uint8_t Size) const {
+  virtual MCRegister getAliasSized(MCRegister Reg, uint8_t Size) const {
     llvm_unreachable("not implemented");
-    return 0;
+    return MCRegister();
   }
 
   /// For X86, return whether this register is an upper 8-bit register, such as
   /// AH, BH, etc.
-  virtual bool isUpper8BitReg(MCPhysReg Reg) const {
+  virtual bool isUpper8BitReg(MCRegister Reg) const {
     llvm_unreachable("not implemented");
     return false;
   }
@@ -1664,11 +1664,11 @@ public:
 
   /// Return true if this instruction defines the specified physical
   /// register either explicitly or implicitly.
-  virtual bool hasDefOfPhysReg(const MCInst &MI, unsigned Reg) const;
+  virtual bool hasDefOfPhysReg(const MCInst &MI, MCRegister Reg) const;
 
   /// Return true if this instruction uses the specified physical
   /// register either explicitly or implicitly.
-  virtual bool hasUseOfPhysReg(const MCInst &MI, unsigned Reg) const;
+  virtual bool hasUseOfPhysReg(const MCInst &MI, MCRegister Reg) const;
 
   /// Replace displacement in compound memory operand with given \p Label.
   bool replaceMemOperandDisp(MCInst &Inst, const MCSymbol *Label,
@@ -1723,7 +1723,7 @@ public:
   }
 
   /// Morph an indirect call into a load where \p Reg holds the call target.
-  virtual void convertIndirectCallToLoad(MCInst &Inst, MCPhysReg Reg) {
+  virtual void convertIndirectCallToLoad(MCInst &Inst, MCRegister Reg) {
     llvm_unreachable("not implemented");
   }
 
@@ -1776,8 +1776,8 @@ public:
   /// or may not be same as \p Instruction.
   virtual IndirectBranchType analyzeIndirectBranch(
       MCInst &Instruction, InstructionIterator Begin, InstructionIterator End,
-      const unsigned PtrSize, MCInst *&MemLocInstr, unsigned &BaseRegNum,
-      unsigned &IndexRegNum, int64_t &DispValue, const MCExpr *&DispExpr,
+      const unsigned PtrSize, MCInst *&MemLocInstr, MCRegister &BaseReg,
+      MCRegister &IndexReg, int64_t &DispValue, const MCExpr *&DispExpr,
       MCInst *&PCRelBaseOut, MCInst *&FixedEntryLoadInst) const {
     llvm_unreachable("not implemented");
     return IndirectBranchType::UNKNOWN;
@@ -1820,8 +1820,8 @@ public:
   virtual bool analyzeVirtualMethodCall(InstructionIterator Begin,
                                         InstructionIterator End,
                                         std::vector<MCInst *> &MethodFetchInsns,
-                                        unsigned &VtableRegNum,
-                                        unsigned &BaseRegNum,
+                                        MCRegister &VtableReg,
+                                        MCRegister &BaseReg,
                                         uint64_t &MethodOffset) const {
     llvm_unreachable("not implemented");
     return false;
@@ -1952,7 +1952,7 @@ public:
   /// Store \p Target absolute address to \p RegName
   virtual InstructionListType materializeAddress(const MCSymbol *Target,
                                                  MCContext *Ctx,
-                                                 MCPhysReg RegName,
+                                                 MCRegister RegName,
                                                  int64_t Addend = 0) const {
     llvm_unreachable("not implemented");
     return {};
@@ -2015,21 +2015,20 @@ public:
 
   /// Create a store instruction using \p StackReg as the base register
   /// and \p Offset as the displacement.
-  virtual void createSaveToStack(MCInst &Inst, const MCPhysReg &StackReg,
-                                 int Offset, const MCPhysReg &SrcReg,
+  virtual void createSaveToStack(MCInst &Inst, MCRegister StackReg,
+                                 int Offset, MCRegister SrcReg,
                                  int Size) const {
     llvm_unreachable("not implemented");
   }
 
-  virtual void createLoad(MCInst &Inst, const MCPhysReg &BaseReg, int64_t Scale,
-                          const MCPhysReg &IndexReg, int64_t Offset,
-                          const MCExpr *OffsetExpr,
-                          const MCPhysReg &AddrSegmentReg,
-                          const MCPhysReg &DstReg, int Size) const {
+  virtual void createLoad(MCInst &Inst, MCRegister BaseReg, int64_t Scale,
+                          MCRegister IndexReg, int64_t Offset,
+                          const MCExpr *OffsetExpr, MCRegister AddrSegmentReg,
+                          MCRegister DstReg, int Size) const {
     llvm_unreachable("not implemented");
   }
 
-  virtual InstructionListType createLoadImmediate(const MCPhysReg Dest,
+  virtual InstructionListType createLoadImmediate(const MCRegister Dest,
                                                   uint64_t Imm) const {
     llvm_unreachable("not implemented");
   }
@@ -2045,8 +2044,8 @@ public:
 
   /// Create a load instruction using \p StackReg as the base register
   /// and \p Offset as the displacement.
-  virtual void createRestoreFromStack(MCInst &Inst, const MCPhysReg &StackReg,
-                                      int Offset, const MCPhysReg &DstReg,
+  virtual void createRestoreFromStack(MCInst &Inst, MCRegister StackReg,
+                                      int Offset, MCRegister DstReg,
                                       int Size) const {
     llvm_unreachable("not implemented");
   }
@@ -2067,7 +2066,7 @@ public:
 
   /// Create a sequence of instructions to compare contents of a register
   /// \p RegNo to immediate \Imm and jump to \p Target if they are equal.
-  virtual InstructionListType createCmpJE(MCPhysReg RegNo, int64_t Imm,
+  virtual InstructionListType createCmpJE(MCRegister RegNo, int64_t Imm,
                                           const MCSymbol *Target,
                                           MCContext *Ctx) const {
     llvm_unreachable("not implemented");
@@ -2076,7 +2075,7 @@ public:
 
   /// Create a sequence of instructions to compare contents of a register
   /// \p RegNo to immediate \Imm and jump to \p Target if they are different.
-  virtual InstructionListType createCmpJNE(MCPhysReg RegNo, int64_t Imm,
+  virtual InstructionListType createCmpJNE(MCRegister RegNo, int64_t Imm,
                                            const MCSymbol *Target,
                                            MCContext *Ctx) const {
     llvm_unreachable("not implemented");
@@ -2085,8 +2084,8 @@ public:
 
   /// Create a sequence of instructions to compare contents of a register
   /// \p Reg1 to a register \p Reg2 and jump to \p Target if they are different.
-  virtual InstructionListType createCmpJNEWithReg(MCPhysReg Reg1,
-                                                  MCPhysReg Reg2,
+  virtual InstructionListType createCmpJNEWithReg(MCRegister Reg1,
+                                                  MCRegister Reg2,
                                                   const MCSymbol *Target,
                                                   MCContext *Ctx) const {
     llvm_unreachable("not implemented");
@@ -2121,7 +2120,7 @@ public:
   /// register. Returns the immediate value if the instruction is a
   /// move-immediate to TargetReg.
   virtual std::optional<uint64_t>
-  extractMoveImmediate(const MCInst &Inst, MCPhysReg TargetReg) const {
+  extractMoveImmediate(const MCInst &Inst, MCRegister TargetReg) const {
     return std::nullopt;
   }
 
@@ -2521,7 +2520,7 @@ public:
   };
 
   virtual BlocksVectorTy indirectCallPromotion(
-      const MCInst &CallInst, MCPhysReg Reg,
+      const MCInst &CallInst, MCRegister Reg,
       const std::vector<std::pair<MCSymbol *, uint64_t>> &Targets,
       const std::vector<std::pair<MCSymbol *, uint64_t>> &VtableSyms,
       const std::vector<MCInst *> &MethodFetchInsns,

--- a/bolt/include/bolt/Passes/FrameAnalysis.h
+++ b/bolt/include/bolt/Passes/FrameAnalysis.h
@@ -42,7 +42,7 @@ struct FrameIndexEntry {
   /// understand but we know it may write to a frame position.
   bool IsSimple;
 
-  uint16_t StackPtrReg;
+  MCRegister StackPtrReg;
 };
 
 /// Record an access to an argument in stack. This should be attached to

--- a/bolt/include/bolt/Passes/LivenessAnalysis.h
+++ b/bolt/include/bolt/Passes/LivenessAnalysis.h
@@ -46,7 +46,7 @@ public:
     return *this->getStateBefore(Inst);
   }
 
-  bool isAlive(ProgramPoint PP, MCPhysReg Reg) const {
+  bool isAlive(ProgramPoint PP, MCRegister Reg) const {
     const BitVector &BV = *this->getStateAt(PP);
     const BitVector &RegAliases = BC.MIB->getAliases(Reg);
     return BV.anyCommon(RegAliases);
@@ -56,14 +56,14 @@ public:
 
   // Return a usable general-purpose reg after point P. Return 0 if no reg is
   // available.
-  MCPhysReg scavengeRegAfter(ProgramPoint P) const {
+  MCRegister scavengeRegAfter(ProgramPoint P) const {
     BitVector BV = *this->getStateAt(P);
     return scavengeRegFromState(BV);
   }
 
   // Return a usable general-purpose reg given a liveness state. Return 0 if
   // no reg is available.
-  MCPhysReg scavengeRegFromState(BitVector &LiveRegs) const {
+  MCRegister scavengeRegFromState(BitVector &LiveRegs) const {
     BitVector GPRegs(NumRegs, false);
     this->BC.MIB->getGPRegs(GPRegs, /*IncludeAlias=*/false);
     LiveRegs.flip();
@@ -92,7 +92,7 @@ protected:
         BC.MIB->getCalleeSavedRegs(State);
       } else {
         State.set();
-        State.reset(BC.MIB->getFlagsReg());
+        State.reset(BC.MIB->getFlagsReg().id());
       }
       return State;
     }
@@ -158,7 +158,7 @@ protected:
           (!BC.MIB->isTailCall(Point) || !BC.MIB->isConditionalBranch(Point))) {
         // Never gen FLAGS from a non-conditional call... this is overly
         // conservative
-        Used.reset(BC.MIB->getFlagsReg());
+        Used.reset(BC.MIB->getFlagsReg().id());
       }
       Next |= Used;
     }

--- a/bolt/include/bolt/Passes/PAuthGadgetScanner.h
+++ b/bolt/include/bolt/Passes/PAuthGadgetScanner.h
@@ -36,8 +36,8 @@ namespace PAuthGadgetScanner {
 //   re-run to collect extra information to provide to the user. Which extra
 //   information can be requested depends on the particular analysis (for
 //   example, SrcSafetyAnalysis is able to compute the set of instructions
-//   clobbering the particular register, thus ReqT is MCPhysReg). At this stage,
-//   `FinalReport`s are created.
+//   clobbering the particular register, thus ReqT is MCRegister). At this
+//   stage, `FinalReport`s are created.
 //
 // Here, the subclasses of Diagnostic store the pieces of information which
 // are kept unchanged since they are collected on the first run of the analysis.
@@ -165,15 +165,15 @@ class FunctionAnalysisContext {
   /// Bitmask of detectors to run (only GS_PTRAUTH_* are allowed).
   opts::GadgetKindBitmask EnabledDetectors;
 
-  void findUnsafeUses(SmallVector<PartialReport<MCPhysReg>> &Reports);
-  void augmentUnsafeUseReports(ArrayRef<PartialReport<MCPhysReg>> Reports);
+  void findUnsafeUses(SmallVector<PartialReport<MCRegister>> &Reports);
+  void augmentUnsafeUseReports(ArrayRef<PartialReport<MCRegister>> Reports);
 
-  void findUnsafeDefs(SmallVector<PartialReport<MCPhysReg>> &Reports);
-  void augmentUnsafeDefReports(ArrayRef<PartialReport<MCPhysReg>> Reports);
+  void findUnsafeDefs(SmallVector<PartialReport<MCRegister>> &Reports);
+  void augmentUnsafeDefReports(ArrayRef<PartialReport<MCRegister>> Reports);
 
   /// Process the reports which do not have to be augmented, and remove them
   /// from Reports.
-  void handleSimpleReports(SmallVector<PartialReport<MCPhysReg>> &Reports);
+  void handleSimpleReports(SmallVector<PartialReport<MCRegister>> &Reports);
 
 public:
   FunctionAnalysisContext(BinaryFunction &BF,

--- a/bolt/include/bolt/Passes/ReachingDefOrUse.h
+++ b/bolt/include/bolt/Passes/ReachingDefOrUse.h
@@ -32,20 +32,20 @@ class ReachingDefOrUse
 
 public:
   ReachingDefOrUse(const RegAnalysis &RA, BinaryFunction &BF,
-                   std::optional<MCPhysReg> TrackingReg = std::nullopt,
+                   std::optional<MCRegister> TrackingReg = std::nullopt,
                    MCPlusBuilder::AllocatorIdTy AllocId = 0)
       : InstrsDataflowAnalysis<ReachingDefOrUse<Def>, !Def>(BF, AllocId),
         RA(RA), TrackingReg(TrackingReg) {}
   virtual ~ReachingDefOrUse() {}
 
-  bool isReachedBy(MCPhysReg Reg, ExprIterator Candidates) {
+  bool isReachedBy(MCRegister Reg, ExprIterator Candidates) {
     for (auto I = Candidates; I != this->expr_end(); ++I) {
       BitVector BV = BitVector(this->BC.MRI->getNumRegs(), false);
       if (Def)
         RA.getInstClobberList(**I, BV);
       else
         this->BC.MIB->getTouchedRegs(**I, BV);
-      if (BV[Reg])
+      if (BV[Reg.id()])
         return true;
     }
     return false;
@@ -63,7 +63,7 @@ protected:
 
   /// If set, limit the dataflow to only track instructions affecting this
   /// register. Otherwise the analysis can be too permissive.
-  std::optional<MCPhysReg> TrackingReg;
+  std::optional<MCRegister> TrackingReg;
 
   void preflight() {
     // Populate our universe of tracked expressions with all instructions

--- a/bolt/include/bolt/Passes/RegReAssign.h
+++ b/bolt/include/bolt/Passes/RegReAssign.h
@@ -34,7 +34,7 @@ class RegReAssign : public BinaryFunctionPass {
   int64_t StaticBytesSaved{0};
   int64_t DynBytesSaved{0};
 
-  void swap(BinaryFunction &Function, MCPhysReg A, MCPhysReg B);
+  void swap(BinaryFunction &Function, MCRegister A, MCRegister B);
   void rankRegisters(BinaryFunction &Function);
   void aggressivePassOverFunction(BinaryFunction &Function);
   bool conservativePassOverFunction(BinaryFunction &Function);

--- a/bolt/include/bolt/Passes/RetpolineInsertion.h
+++ b/bolt/include/bolt/Passes/RetpolineInsertion.h
@@ -34,7 +34,7 @@ public:
 
   union {
     // Register branch information
-    MCPhysReg BranchReg;
+    MCRegister BranchReg;
 
     // Memory branch information
     MemOpInfo Memory;

--- a/bolt/include/bolt/Passes/StackPointerTracking.h
+++ b/bolt/include/bolt/Passes/StackPointerTracking.h
@@ -91,7 +91,7 @@ protected:
       return SPVal + Sz;
     }
 
-    MCPhysReg From, To;
+    MCRegister From, To;
     if (MIB->isRegToRegMove(Point, From, To) && To == MIB->getStackPointer() &&
         From == MIB->getFramePointer()) {
       if (FPVal == EMPTY || FPVal == SUPERPOSITION)
@@ -104,16 +104,16 @@ protected:
 
     if (this->BC.MII->get(Point.getOpcode())
             .hasDefOfPhysReg(Point, MIB->getStackPointer(), *this->BC.MRI)) {
-      std::pair<MCPhysReg, int64_t> SP;
+      std::pair<MCRegister, int64_t> SP;
       if (SPVal != EMPTY && SPVal != SUPERPOSITION)
         SP = std::make_pair(MIB->getStackPointer(), SPVal);
       else
-        SP = std::make_pair(0, 0);
-      std::pair<MCPhysReg, int64_t> FP;
+        SP = std::make_pair(MCRegister(), 0);
+      std::pair<MCRegister, int64_t> FP;
       if (FPVal != EMPTY && FPVal != SUPERPOSITION)
         FP = std::make_pair(MIB->getFramePointer(), FPVal);
       else
-        FP = std::make_pair(0, 0);
+        FP = std::make_pair(MCRegister(), 0);
       int64_t Output;
       if (!MIB->evaluateStackOffsetExpr(Point, Output, SP, FP)) {
         if (SPVal == EMPTY && FPVal == EMPTY)
@@ -130,7 +130,7 @@ protected:
   int computeNextFP(const MCInst &Point, int SPVal, int FPVal) {
     const auto &MIB = this->BC.MIB;
 
-    MCPhysReg From, To;
+    MCRegister From, To;
     if (MIB->isRegToRegMove(Point, From, To) && To == MIB->getFramePointer() &&
         From == MIB->getStackPointer()) {
       HasFramePointer = true;
@@ -139,16 +139,16 @@ protected:
 
     if (this->BC.MII->get(Point.getOpcode())
             .hasDefOfPhysReg(Point, MIB->getFramePointer(), *this->BC.MRI)) {
-      std::pair<MCPhysReg, int64_t> FP;
+      std::pair<MCRegister, int64_t> FP;
       if (FPVal != EMPTY && FPVal != SUPERPOSITION)
         FP = std::make_pair(MIB->getFramePointer(), FPVal);
       else
-        FP = std::make_pair(0, 0);
-      std::pair<MCPhysReg, int64_t> SP;
+        FP = std::make_pair(MCRegister(), 0);
+      std::pair<MCRegister, int64_t> SP;
       if (SPVal != EMPTY && SPVal != SUPERPOSITION)
         SP = std::make_pair(MIB->getStackPointer(), SPVal);
       else
-        SP = std::make_pair(0, 0);
+        SP = std::make_pair(MCRegister(), 0);
       int64_t Output;
       if (!MIB->evaluateStackOffsetExpr(Point, Output, SP, FP)) {
         if (SPVal == EMPTY && FPVal == EMPTY)

--- a/bolt/include/bolt/Passes/TailDuplication.h
+++ b/bolt/include/bolt/Passes/TailDuplication.h
@@ -71,18 +71,18 @@ class TailDuplication : public BinaryFunctionPass {
                           BinaryContext &BC) const;
 
   /// Returns true if Reg is possibly overwritten by Inst
-  bool regIsPossiblyOverwritten(const MCInst &Inst, unsigned Reg,
+  bool regIsPossiblyOverwritten(const MCInst &Inst, MCRegister Reg,
                                 BinaryContext &BC) const;
 
   /// Returns true if Reg is definitely overwritten by Inst
-  bool regIsDefinitelyOverwritten(const MCInst &Inst, unsigned Reg,
+  bool regIsDefinitelyOverwritten(const MCInst &Inst, MCRegister Reg,
                                   BinaryContext &BC) const;
 
   /// Returns true if Reg is used by Inst
-  bool regIsUsed(const MCInst &Inst, unsigned Reg, BinaryContext &BC) const;
+  bool regIsUsed(const MCInst &Inst, MCRegister Reg, BinaryContext &BC) const;
 
   /// Returns true if Reg is overwritten before its used by StartBB's successors
-  bool isOverwrittenBeforeUsed(BinaryBasicBlock &StartBB, unsigned Reg) const;
+  bool isOverwrittenBeforeUsed(BinaryBasicBlock &StartBB, MCRegister Reg) const;
 
   /// Constant and Copy Propagate for the block formed by OriginalBB and
   /// BlocksToPropagate

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -713,7 +713,7 @@ void BinaryFunction::printRelocations(raw_ostream &OS, uint64_t Offset,
 }
 
 static std::string mutateDWARFExpressionTargetReg(const MCCFIInstruction &Instr,
-                                                  MCPhysReg NewReg) {
+                                                  unsigned NewReg) {
   StringRef ExprBytes = Instr.getValues();
   assert(ExprBytes.size() > 1 && "DWARF expression CFI is too short");
   uint8_t Opcode = ExprBytes[0];
@@ -738,7 +738,7 @@ static std::string mutateDWARFExpressionTargetReg(const MCCFIInstruction &Instr,
 }
 
 void BinaryFunction::mutateCFIRegisterFor(const MCInst &Instr,
-                                          MCPhysReg NewReg) {
+                                          unsigned NewReg) {
   const MCCFIInstruction *OldCFI = getCFIFor(Instr);
   assert(OldCFI && "invalid CFI instr");
   switch (OldCFI->getOperation()) {
@@ -821,7 +821,7 @@ BinaryFunction::processIndirectBranch(MCInst &Instruction, unsigned Size,
   // array of function pointers, or a jump table.
   uint64_t ArrayStart = 0;
 
-  unsigned BaseRegNum, IndexRegNum;
+  MCRegister BaseReg, IndexReg;
   int64_t DispValue;
   const MCExpr *DispExpr;
 
@@ -846,14 +846,14 @@ BinaryFunction::processIndirectBranch(MCInst &Instruction, unsigned Size,
   }
 
   IndirectBranchType BranchType = BC.MIB->analyzeIndirectBranch(
-      Instruction, Begin, Instructions.end(), PtrSize, MemLocInstr, BaseRegNum,
-      IndexRegNum, DispValue, DispExpr, PCRelBaseInstr, FixedEntryLoadInstr);
+      Instruction, Begin, Instructions.end(), PtrSize, MemLocInstr, BaseReg,
+      IndexReg, DispValue, DispExpr, PCRelBaseInstr, FixedEntryLoadInstr);
 
   if (BranchType == IndirectBranchType::UNKNOWN && !MemLocInstr)
     return BranchType;
 
   if (MemLocInstr != &Instruction)
-    IndexRegNum = BC.MIB->getNoRegister();
+    IndexReg = BC.MIB->getNoRegister();
 
   if (BC.isAArch64()) {
     const MCSymbol *Sym = BC.MIB->getTargetSymbol(*PCRelBaseInstr, 1);
@@ -901,7 +901,7 @@ BinaryFunction::processIndirectBranch(MCInst &Instruction, unsigned Size,
   // in processed instructions (but not in jump).
   if (DispExpr) {
     ArrayStart = getExprValue(DispExpr);
-    BaseRegNum = BC.MIB->getNoRegister();
+    BaseReg = BC.MIB->getNoRegister();
     if (BC.isAArch64()) {
       ArrayStart &= ~0xFFFULL;
       ArrayStart += DispValue & 0xFFFULL;
@@ -910,7 +910,7 @@ BinaryFunction::processIndirectBranch(MCInst &Instruction, unsigned Size,
     ArrayStart = static_cast<uint64_t>(DispValue);
   }
 
-  if (BaseRegNum == BC.MRI->getProgramCounter())
+  if (BaseReg == BC.MRI->getProgramCounter())
     ArrayStart += getAddress() + Offset + Size;
 
   if (FixedEntryLoadInstr) {
@@ -1023,7 +1023,7 @@ BinaryFunction::processIndirectBranch(MCInst &Instruction, unsigned Size,
   // Convert the instruction into jump table branch.
   const MCSymbol *JTLabel = BC.getOrCreateJumpTable(*this, ArrayStart, JTType);
   BC.MIB->replaceMemOperandDisp(*MemLocInstr, JTLabel, BC.Ctx.get());
-  BC.MIB->setJumpTable(Instruction, ArrayStart, IndexRegNum);
+  BC.MIB->setJumpTable(Instruction, ArrayStart, IndexReg);
 
   JTSites.emplace_back(Offset, ArrayStart);
 
@@ -2169,7 +2169,7 @@ bool BinaryFunction::postProcessIndirectBranches(
   MCInst *LastIndirectJump = nullptr;
   BinaryBasicBlock *LastIndirectJumpBB = nullptr;
   uint64_t LastJT = 0;
-  uint16_t LastJTIndexReg = BC.MIB->getNoRegister();
+  MCRegister LastJTIndexReg = BC.MIB->getNoRegister();
   for (BinaryBasicBlock &BB : blocks()) {
     for (BinaryBasicBlock::iterator II = BB.begin(); II != BB.end(); ++II) {
       MCInst &Instr = *II;
@@ -2195,14 +2195,14 @@ bool BinaryFunction::postProcessIndirectBranches(
       if (BC.MIB->isTailCall(Instr) || BC.MIB->getJumpTable(Instr)) {
         const unsigned PtrSize = BC.AsmInfo->getCodePointerSize();
         MCInst *MemLocInstr;
-        unsigned BaseRegNum, IndexRegNum;
+        MCRegister BaseReg, IndexReg;
         int64_t DispValue;
         const MCExpr *DispExpr;
         MCInst *PCRelBaseInstr;
         MCInst *FixedEntryLoadInstr;
         IndirectBranchType Type = BC.MIB->analyzeIndirectBranch(
-            Instr, BB.begin(), II, PtrSize, MemLocInstr, BaseRegNum,
-            IndexRegNum, DispValue, DispExpr, PCRelBaseInstr,
+            Instr, BB.begin(), II, PtrSize, MemLocInstr, BaseReg,
+            IndexReg, DispValue, DispExpr, PCRelBaseInstr,
             FixedEntryLoadInstr);
         if (Type != IndirectBranchType::UNKNOWN || MemLocInstr != nullptr)
           continue;
@@ -4221,7 +4221,7 @@ void BinaryFunction::disambiguateJumpTables(
       // This instruction is an indirect jump using a jump table, but it is
       // using the same jump table of another jump. Try all our tricks to
       // extract the jump table symbol and make it point to a new, duplicated JT
-      MCPhysReg BaseReg1;
+      MCRegister BaseReg1;
       uint64_t Scale;
       const MCSymbol *Target;
       // In case we match if our first matcher, first instruction is the one to
@@ -4236,7 +4236,7 @@ void BinaryFunction::disambiguateJumpTables(
               *BC.MRI, *BC.MIB,
               MutableArrayRef<MCInst>(&*BB->begin(), &Inst + 1), -1) ||
           BaseReg1 != BC.MIB->getNoRegister() || Scale != 8) {
-        MCPhysReg BaseReg2;
+        MCRegister BaseReg2;
         uint64_t Offset;
         // Standard JT matching failed. Trying now:
         //     movq  "jt.2397/1"(,%rax,8), %rax

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -2201,9 +2201,8 @@ bool BinaryFunction::postProcessIndirectBranches(
         MCInst *PCRelBaseInstr;
         MCInst *FixedEntryLoadInstr;
         IndirectBranchType Type = BC.MIB->analyzeIndirectBranch(
-            Instr, BB.begin(), II, PtrSize, MemLocInstr, BaseReg,
-            IndexReg, DispValue, DispExpr, PCRelBaseInstr,
-            FixedEntryLoadInstr);
+            Instr, BB.begin(), II, PtrSize, MemLocInstr, BaseReg, IndexReg,
+            DispValue, DispExpr, PCRelBaseInstr, FixedEntryLoadInstr);
         if (Type != IndirectBranchType::UNKNOWN || MemLocInstr != nullptr)
           continue;
 

--- a/bolt/lib/Core/HashUtilities.cpp
+++ b/bolt/lib/Core/HashUtilities.cpp
@@ -83,7 +83,7 @@ std::string hashInstOperand(BinaryContext &BC, const MCOperand &Operand) {
   if (Operand.isImm())
     return hashInteger(Operand.getImm());
   if (Operand.isReg())
-    return hashInteger(Operand.getReg());
+    return hashInteger(Operand.getReg().id());
   if (Operand.isExpr())
     return hashExpr(BC, *Operand.getExpr());
 

--- a/bolt/lib/Core/MCPlusBuilder.cpp
+++ b/bolt/lib/Core/MCPlusBuilder.cpp
@@ -264,16 +264,16 @@ uint64_t MCPlusBuilder::getJumpTable(const MCInst &Inst) const {
   return *Value;
 }
 
-uint16_t MCPlusBuilder::getJumpTableIndexReg(const MCInst &Inst) const {
-  return getAnnotationAs<uint16_t>(Inst, "JTIndexReg");
+MCRegister MCPlusBuilder::getJumpTableIndexReg(const MCInst &Inst) const {
+  return getAnnotationAs<MCRegister>(Inst, "JTIndexReg");
 }
 
 bool MCPlusBuilder::setJumpTable(MCInst &Inst, uint64_t Value,
-                                 uint16_t IndexReg, AllocatorIdTy AllocId) {
+                                 MCRegister IndexReg, AllocatorIdTy AllocId) {
   if (!isIndirectBranch(Inst))
     return false;
   setAnnotationOpValue(Inst, MCAnnotation::kJumpTable, Value);
-  getOrCreateAnnotationAs<uint16_t>(Inst, "JTIndexReg", AllocId) = IndexReg;
+  getOrCreateAnnotationAs<MCRegister>(Inst, "JTIndexReg", AllocId) = IndexReg;
   return true;
 }
 
@@ -539,12 +539,12 @@ void MCPlusBuilder::getSrcRegs(const MCInst &Inst, BitVector &Regs) const {
       Regs |= getAliases(Operand.getReg(), /*OnlySmaller=*/true);
 }
 
-bool MCPlusBuilder::hasDefOfPhysReg(const MCInst &MI, unsigned Reg) const {
+bool MCPlusBuilder::hasDefOfPhysReg(const MCInst &MI, MCRegister Reg) const {
   const MCInstrDesc &InstInfo = Info->get(MI.getOpcode());
   return InstInfo.hasDefOfPhysReg(MI, Reg, *RegInfo);
 }
 
-bool MCPlusBuilder::hasUseOfPhysReg(const MCInst &MI, unsigned Reg) const {
+bool MCPlusBuilder::hasUseOfPhysReg(const MCInst &MI, MCRegister Reg) const {
   const MCInstrDesc &InstInfo = Info->get(MI.getOpcode());
   for (int I = InstInfo.NumDefs; I < InstInfo.NumOperands; ++I)
     if (MI.getOperand(I).isReg() && MI.getOperand(I).getReg() &&
@@ -557,11 +557,11 @@ bool MCPlusBuilder::hasUseOfPhysReg(const MCInst &MI, unsigned Reg) const {
   return false;
 }
 
-const BitVector &MCPlusBuilder::getAliases(MCPhysReg Reg,
+const BitVector &MCPlusBuilder::getAliases(MCRegister Reg,
                                            bool OnlySmaller) const {
   if (OnlySmaller)
-    return SmallerAliasMap[Reg];
-  return AliasMap[Reg];
+    return SmallerAliasMap[Reg.id()];
+  return AliasMap[Reg.id()];
 }
 
 void MCPlusBuilder::initAliases() {
@@ -577,7 +577,7 @@ void MCPlusBuilder::initAliases() {
   // Cache all aliases for each register
   for (MCPhysReg I = 1, E = RegInfo->getNumRegs(); I != E; ++I) {
     for (MCRegAliasIterator AI(I, RegInfo, true); AI.isValid(); ++AI)
-      AliasMap[I].set(*AI);
+      AliasMap[I].set((*AI).id());
   }
 
   // Propagate smaller alias info upwards. Skip reg 0 (mapped to NoRegister)

--- a/bolt/lib/Passes/BranchLivenessUtils.cpp
+++ b/bolt/lib/Passes/BranchLivenessUtils.cpp
@@ -48,9 +48,9 @@ BranchLivenessInfo computeBranchLiveness(BinaryFunction &BF, RegAnalysis &RA) {
 
   DataflowInfoManager DIM(BF, &RA, nullptr);
   LivenessAnalysis &LA = DIM.getLivenessAnalysis();
-  const MCPhysReg FlagsReg = BC.MIB->getFlagsReg();
+  const MCRegister FlagsReg = BC.MIB->getFlagsReg();
   for (MCInst *Inst : Insts)
-    if (!LA.getLiveIn(*Inst).test(FlagsReg))
+    if (!LA.getLiveIn(*Inst).test(FlagsReg.id()))
       BLI.setFlagsDead(*Inst);
   return BLI;
 }

--- a/bolt/lib/Passes/FrameAnalysis.cpp
+++ b/bolt/lib/Passes/FrameAnalysis.cpp
@@ -112,7 +112,7 @@ class FrameAccessAnalysis {
 
   bool decodeFrameAccess(const MCInst &Inst) {
     int32_t SrcImm = 0;
-    MCPhysReg Reg = 0;
+    MCRegister Reg;
     int64_t StackOffset = 0;
     bool IsIndexed = false;
     if (!BC.MIB->isStackAccess(
@@ -133,7 +133,7 @@ class FrameAccessAnalysis {
 
     FIE.RegOrImm = SrcImm;
     if (FIE.IsLoad || FIE.IsStoreFromReg)
-      FIE.RegOrImm = Reg;
+      FIE.RegOrImm = Reg.id();
 
     if (FIE.StackPtrReg == BC.MIB->getStackPointer() && SPOffset != SPT.EMPTY &&
         SPOffset != SPT.SUPERPOSITION) {

--- a/bolt/lib/Passes/IndirectCallPromotion.cpp
+++ b/bolt/lib/Passes/IndirectCallPromotion.cpp
@@ -384,7 +384,7 @@ IndirectCallPromotion::maybeGetHotJumpTableTargets(BinaryBasicBlock &BB,
   MCInst *MemLocInstr;
   MCInst *PCRelBaseOut;
   MCInst *FixedEntryLoadInstr;
-  unsigned BaseReg, IndexReg;
+  MCRegister BaseReg, IndexReg;
   int64_t DispValue;
   const MCExpr *DispExpr;
   MutableArrayRef<MCInst> Insts(&BB.front(), &CallInst);
@@ -514,7 +514,7 @@ IndirectCallPromotion::maybeGetHotJumpTableTargets(BinaryBasicBlock &BB,
              << "Count = " << Target.first << "\n";
   });
 
-  BC.MIB->getOrCreateAnnotationAs<uint16_t>(CallInst, "JTIndexReg") = IndexReg;
+  BC.MIB->getOrCreateAnnotationAs<MCRegister>(CallInst, "JTIndexReg") = IndexReg;
 
   TargetFetchInst = MemLocInstr;
 
@@ -640,7 +640,7 @@ IndirectCallPromotion::MethodInfoType IndirectCallPromotion::maybeGetVtableSyms(
   BinaryContext &BC = Function.getBinaryContext();
   std::vector<std::pair<MCSymbol *, uint64_t>> VtableSyms;
   std::vector<MCInst *> MethodFetchInsns;
-  unsigned VtableReg, MethodReg;
+  MCRegister VtableReg, MethodReg;
   uint64_t MethodOffset;
 
   assert(!Function.getJumpTable(Inst) &&
@@ -1312,7 +1312,7 @@ Error IndirectCallPromotion::runOnFunctions(BinaryContext &BC) {
         if (IsJumpTable) {
           ErrorOr<const BitVector &> State =
               Info.getLivenessAnalysis().getStateBefore(Inst);
-          if (!State || (State && (*State)[BC.MIB->getFlagsReg()])) {
+          if (!State || (State && (*State)[BC.MIB->getFlagsReg().id()])) {
             if (opts::Verbosity >= 1)
               BC.outs() << "BOLT-INFO: ICP failed in " << Function << " @ "
                         << InstIdx << " in " << BB->getName()
@@ -1376,7 +1376,7 @@ Error IndirectCallPromotion::runOnFunctions(BinaryContext &BC) {
           MethodInfo.second.push_back(TargetFetchInst);
         }
 
-        MCPhysReg Reg = 0;
+        MCRegister Reg;
         if (BC.isAArch64()) {
           Reg = Info.getLivenessAnalysis().scavengeRegAfter(&Inst);
           LLVM_DEBUG({

--- a/bolt/lib/Passes/IndirectCallPromotion.cpp
+++ b/bolt/lib/Passes/IndirectCallPromotion.cpp
@@ -514,7 +514,8 @@ IndirectCallPromotion::maybeGetHotJumpTableTargets(BinaryBasicBlock &BB,
              << "Count = " << Target.first << "\n";
   });
 
-  BC.MIB->getOrCreateAnnotationAs<MCRegister>(CallInst, "JTIndexReg") = IndexReg;
+  BC.MIB->getOrCreateAnnotationAs<MCRegister>(CallInst, "JTIndexReg") =
+      IndexReg;
 
   TargetFetchInst = MemLocInstr;
 

--- a/bolt/lib/Passes/Inliner.cpp
+++ b/bolt/lib/Passes/Inliner.cpp
@@ -175,7 +175,7 @@ InliningInfo getInliningInfo(const BinaryFunction &BF) {
     if (BF.hasJumpTables())
       return INL_NONE;
 
-    const MCPhysReg SPReg = BC.MIB->getStackPointer();
+    const MCRegister SPReg = BC.MIB->getStackPointer();
     for (const BinaryBasicBlock &BB : BF) {
       for (const MCInst &Inst : BB) {
         // Tail calls are marked as implicitly using the stack pointer and they

--- a/bolt/lib/Passes/JTFootprintReduction.cpp
+++ b/bolt/lib/Passes/JTFootprintReduction.cpp
@@ -84,8 +84,8 @@ void JTFootprintReduction::checkOpportunities(BinaryFunction &Function,
       //    movslq  (%r11,%rdx,4), %rcx
       //    addq    %r11, %rcx
       //    jmpq    *%rcx # JUMPTABLE @0x402450
-      MCPhysReg BaseReg1;
-      MCPhysReg BaseReg2;
+      MCRegister BaseReg1;
+      MCRegister BaseReg2;
       uint64_t Offset;
       std::unique_ptr<MCPlusBuilder::MCInstMatcher> PICIndJmpMatcher =
           BC.MIB->matchIndJmp(BC.MIB->matchAdd(
@@ -135,7 +135,7 @@ bool JTFootprintReduction::tryOptimizeNonPIC(
 
   MCOperand Base;
   uint64_t Scale;
-  MCPhysReg Index;
+  MCRegister Index;
   MCOperand Offset;
   std::unique_ptr<MCPlusBuilder::MCInstMatcher> IndJmpMatcher =
       BC.MIB->matchIndJmp(BC.MIB->matchAnyOperand(Base),
@@ -152,8 +152,8 @@ bool JTFootprintReduction::tryOptimizeNonPIC(
   IndJmpMatcher->annotate(*BC.MIB, "DeleteMe");
 
   LivenessAnalysis &LA = Info.getLivenessAnalysis();
-  MCPhysReg Reg = LA.scavengeRegAfter(&*Inst);
-  assert(Reg != 0 && "Register scavenger failed!");
+  MCRegister Reg = LA.scavengeRegAfter(&*Inst);
+  assert(Reg && "Register scavenger failed!");
   MCOperand RegOp = MCOperand::createReg(Reg);
   SmallVector<MCInst, 4> NewFrag;
 
@@ -172,9 +172,9 @@ bool JTFootprintReduction::tryOptimizePIC(BinaryContext &BC,
                                           BinaryBasicBlock::iterator Inst,
                                           uint64_t JTAddr, JumpTable *JumpTable,
                                           DataflowInfoManager &Info) {
-  MCPhysReg BaseReg;
+  MCRegister BaseReg;
   uint64_t Scale;
-  MCPhysReg Index;
+  MCRegister Index;
   MCOperand Offset;
   MCOperand JumpTableRef;
   std::unique_ptr<MCPlusBuilder::MCInstMatcher> PICIndJmpMatcher =

--- a/bolt/lib/Passes/PAuthGadgetScanner.cpp
+++ b/bolt/lib/Passes/PAuthGadgetScanner.cpp
@@ -107,7 +107,7 @@ static cl::opt<bool> AuthTrapsOnFailure(
 }
 
 [[maybe_unused]] static void traceReg(const BinaryContext &BC, StringRef Label,
-                                      MCPhysReg Reg) {
+                                      MCRegister Reg) {
   dbgs() << "    " << Label << ": ";
   if (Reg == BC.MIB->getNoRegister())
     dbgs() << "(none)";
@@ -143,39 +143,39 @@ template <typename T> static void iterateOverInstrs(BinaryFunction &BF, T Fn) {
 // consecutive array indexes.
 class TrackedRegisters {
   static constexpr uint16_t NoIndex = -1;
-  const std::vector<MCPhysReg> Registers;
+  const std::vector<MCRegister> Registers;
   std::vector<uint16_t> RegToIndexMapping;
 
-  static size_t getMappingSize(ArrayRef<MCPhysReg> RegsToTrack) {
+  static size_t getMappingSize(ArrayRef<MCRegister> RegsToTrack) {
     if (RegsToTrack.empty())
       return 0;
-    return 1 + *llvm::max_element(RegsToTrack);
+    return 1 + llvm::max_element(RegsToTrack)->id();
   }
 
 public:
-  TrackedRegisters(ArrayRef<MCPhysReg> RegsToTrack)
+  TrackedRegisters(ArrayRef<MCRegister> RegsToTrack)
       : Registers(RegsToTrack),
         RegToIndexMapping(getMappingSize(RegsToTrack), NoIndex) {
     for (auto [MappedIndex, Reg] : llvm::enumerate(RegsToTrack))
-      RegToIndexMapping[Reg] = MappedIndex;
+      RegToIndexMapping[Reg.id()] = MappedIndex;
   }
 
-  ArrayRef<MCPhysReg> getRegisters() const { return Registers; }
+  ArrayRef<MCRegister> getRegisters() const { return Registers; }
 
   size_t getNumRegisters() const { return Registers.size(); }
 
   bool empty() const { return Registers.empty(); }
 
-  bool isTracked(MCPhysReg Reg) const {
-    bool IsTracked = (unsigned)Reg < RegToIndexMapping.size() &&
-                     RegToIndexMapping[Reg] != NoIndex;
+  bool isTracked(MCRegister Reg) const {
+    bool IsTracked = Reg.id() < RegToIndexMapping.size() &&
+                     RegToIndexMapping[Reg.id()] != NoIndex;
     assert(IsTracked == llvm::is_contained(Registers, Reg));
     return IsTracked;
   }
 
-  unsigned getIndex(MCPhysReg Reg) const {
+  unsigned getIndex(MCRegister Reg) const {
     assert(isTracked(Reg) && "Register is not tracked");
-    return RegToIndexMapping[Reg];
+    return RegToIndexMapping[Reg.id()];
   }
 };
 
@@ -233,7 +233,7 @@ struct SrcState {
   /// authentications. This is intended to provide best-effort clues on which
   /// instruction caused the particular register not to be safe-to-dereference.
   ///
-  /// Please note that the mapping from MCPhysReg values to indexes in this
+  /// Please note that the mapping from MCRegister values to indexes in this
   /// vector is provided by RegsToTrack field of SrcSafetyAnalysis.
   std::vector<SetOfRelatedInsts> LastInstWritingReg;
 
@@ -332,7 +332,7 @@ void SrcStatePrinter::print(raw_ostream &OS, const SrcState &S) const {
 /// version for functions without reconstructed CFG.
 class SrcSafetyAnalysis {
 public:
-  SrcSafetyAnalysis(BinaryFunction &BF, ArrayRef<MCPhysReg> RegsToTrack)
+  SrcSafetyAnalysis(BinaryFunction &BF, ArrayRef<MCRegister> RegsToTrack)
       : BC(BF.getBinaryContext()), NumRegs(BC.MRI->getNumRegs()),
         RegsToTrack(RegsToTrack) {}
 
@@ -340,7 +340,7 @@ public:
 
   static std::shared_ptr<SrcSafetyAnalysis>
   create(BinaryFunction &BF, MCPlusBuilder::AllocatorIdTy AllocId,
-         ArrayRef<MCPhysReg> RegsToTrack);
+         ArrayRef<MCRegister> RegsToTrack);
 
   virtual void run() = 0;
   virtual const SrcState &getStateBefore(const MCInst &Inst) const = 0;
@@ -362,15 +362,15 @@ protected:
   /// As the detection of such sequences requires iterating over the adjacent
   /// instructions, it should be done before calling computeNext(), which
   /// operates on separate instructions.
-  DenseMap<const MCInst *, std::pair<MCPhysReg, const MCInst *>>
+  DenseMap<const MCInst *, std::pair<MCRegister, const MCInst *>>
       CheckerSequenceInfo;
 
-  SetOfRelatedInsts &lastWritingInsts(SrcState &S, MCPhysReg Reg) const {
+  SetOfRelatedInsts &lastWritingInsts(SrcState &S, MCRegister Reg) const {
     unsigned Index = RegsToTrack.getIndex(Reg);
     return S.LastInstWritingReg[Index];
   }
   const SetOfRelatedInsts &lastWritingInsts(const SrcState &S,
-                                            MCPhysReg Reg) const {
+                                            MCRegister Reg) const {
     unsigned Index = RegsToTrack.getIndex(Reg);
     return S.LastInstWritingReg[Index];
   }
@@ -378,7 +378,7 @@ protected:
   /// Computes SrcState observed on function entry.
   SrcState createEntryState() {
     SrcState S(NumRegs, RegsToTrack.getNumRegisters());
-    for (MCPhysReg Reg : BC.MIB->getTrustedLiveInRegs())
+    for (MCRegister Reg : BC.MIB->getTrustedLiveInRegs())
       S.TrustedRegs |= BC.MIB->getAliases(Reg, /*OnlySmaller=*/true);
     S.SafeToDerefRegs = S.TrustedRegs;
     return S;
@@ -421,20 +421,20 @@ protected:
     return Clobbered;
   }
 
-  std::optional<MCPhysReg> getRegMadeTrustedByChecking(const MCInst &Inst,
-                                                       SrcState Cur) const {
+  std::optional<MCRegister> getRegMadeTrustedByChecking(const MCInst &Inst,
+                                                        SrcState Cur) const {
     // This function cannot return multiple registers. This is never the case
     // on AArch64.
-    std::optional<MCPhysReg> RegCheckedByInst =
+    std::optional<MCRegister> RegCheckedByInst =
         BC.MIB->getAuthCheckedReg(Inst, /*MayOverwrite=*/false);
-    if (RegCheckedByInst && Cur.SafeToDerefRegs[*RegCheckedByInst])
+    if (RegCheckedByInst && Cur.SafeToDerefRegs[RegCheckedByInst->id()])
       return *RegCheckedByInst;
 
     auto It = CheckerSequenceInfo.find(&Inst);
     if (It == CheckerSequenceInfo.end())
       return std::nullopt;
 
-    MCPhysReg RegCheckedBySequence = It->second.first;
+    MCRegister RegCheckedBySequence = It->second.first;
     const MCInst *FirstCheckerInst = It->second.second;
 
     // FirstCheckerInst should belong to the same basic block (see the
@@ -443,7 +443,7 @@ protected:
     const SrcState &StateBeforeChecker = getStateBefore(*FirstCheckerInst);
 
     // The sequence checks the register, but it should be authenticated before.
-    if (!StateBeforeChecker.SafeToDerefRegs[RegCheckedBySequence])
+    if (!StateBeforeChecker.SafeToDerefRegs[RegCheckedBySequence.id()])
       return std::nullopt;
 
     return RegCheckedBySequence;
@@ -451,9 +451,9 @@ protected:
 
   // Returns all registers that can be treated as if they are written by an
   // authentication instruction.
-  SmallVector<MCPhysReg> getRegsMadeSafeToDeref(const MCInst &Point,
-                                                const SrcState &Cur) const {
-    SmallVector<MCPhysReg> Regs;
+  SmallVector<MCRegister> getRegsMadeSafeToDeref(const MCInst &Point,
+                                                 const SrcState &Cur) const {
+    SmallVector<MCRegister> Regs;
 
     // A signed pointer can be authenticated, ...
     bool Dummy = false;
@@ -468,7 +468,7 @@ protected:
     // which is as trusted as the input address.
     if (auto DstAndSrc = BC.MIB->analyzeAddressArithmeticsForPtrAuth(Point)) {
       auto [DstReg, SrcReg] = *DstAndSrc;
-      if (Cur.SafeToDerefRegs[SrcReg])
+      if (Cur.SafeToDerefRegs[SrcReg.id()])
         Regs.push_back(DstReg);
     }
 
@@ -497,10 +497,10 @@ protected:
   }
 
   // Returns all registers made trusted by this instruction.
-  SmallVector<MCPhysReg> getRegsMadeTrusted(const MCInst &Point,
-                                            const SrcState &Cur) const {
+  SmallVector<MCRegister> getRegsMadeTrusted(const MCInst &Point,
+                                             const SrcState &Cur) const {
     assert(!AuthTrapsOnFailure && "Use getRegsMadeSafeToDeref instead");
-    SmallVector<MCPhysReg> Regs;
+    SmallVector<MCRegister> Regs;
 
     // An authenticated pointer can be checked, ...
     if (auto CheckedReg = getRegMadeTrustedByChecking(Point, Cur))
@@ -509,7 +509,7 @@ protected:
     // ... or a pointer can be authenticated by an instruction that always
     // checks the pointer, ...
     bool IsChecked = false;
-    std::optional<MCPhysReg> AutReg =
+    std::optional<MCRegister> AutReg =
         BC.MIB->getWrittenAuthenticatedReg(Point, IsChecked);
     if (AutReg && IsChecked)
       Regs.push_back(*AutReg);
@@ -522,7 +522,7 @@ protected:
     // which is as trusted as the input address.
     if (auto DstAndSrc = BC.MIB->analyzeAddressArithmeticsForPtrAuth(Point)) {
       auto [DstReg, SrcReg] = *DstAndSrc;
-      if (Cur.TrustedRegs[SrcReg])
+      if (Cur.TrustedRegs[SrcReg.id()])
         Regs.push_back(DstReg);
     }
 
@@ -557,11 +557,11 @@ protected:
     // before its execution into account, if necessary.
 
     BitVector Clobbered = getClobberedRegs(Point);
-    SmallVector<MCPhysReg> NewSafeToDerefRegs =
+    SmallVector<MCRegister> NewSafeToDerefRegs =
         getRegsMadeSafeToDeref(Point, Cur);
     // If authentication instructions trap on failure, safe-to-dereference
     // registers are always trusted.
-    SmallVector<MCPhysReg> NewTrustedRegs =
+    SmallVector<MCRegister> NewTrustedRegs =
         AuthTrapsOnFailure ? NewSafeToDerefRegs
                            : getRegsMadeTrusted(Point, Cur);
 
@@ -572,8 +572,8 @@ protected:
     Next.TrustedRegs.reset(Clobbered);
     // Keep track of this instruction if it writes to any of the registers we
     // need to track that for:
-    for (MCPhysReg Reg : RegsToTrack.getRegisters())
-      if (Clobbered[Reg])
+    for (MCRegister Reg : RegsToTrack.getRegisters())
+      if (Clobbered[Reg.id()])
         lastWritingInsts(Next, Reg) = {&Point};
 
     // After accounting for clobbered registers in general, override the state
@@ -582,7 +582,7 @@ protected:
     // The sub-registers are also safe-to-dereference now, but not their
     // super-registers (as they retain untrusted register units).
     BitVector NewSafeSubregs(NumRegs);
-    for (MCPhysReg SafeReg : NewSafeToDerefRegs)
+    for (MCRegister SafeReg : NewSafeToDerefRegs)
       NewSafeSubregs |= BC.MIB->getAliases(SafeReg, /*OnlySmaller=*/true);
     for (MCPhysReg Reg : NewSafeSubregs.set_bits()) {
       Next.SafeToDerefRegs.set(Reg);
@@ -591,7 +591,7 @@ protected:
     }
 
     // Process new trusted registers.
-    for (MCPhysReg TrustedReg : NewTrustedRegs)
+    for (MCRegister TrustedReg : NewTrustedRegs)
       Next.TrustedRegs |= BC.MIB->getAliases(TrustedReg, /*OnlySmaller=*/true);
 
     LLVM_DEBUG({
@@ -611,7 +611,7 @@ protected:
 public:
   std::vector<MCInstReference>
   getLastClobberingInsts(const MCInst &Inst, BinaryFunction &BF,
-                         MCPhysReg ClobberedReg) const {
+                         MCRegister ClobberedReg) const {
     const SrcState &S = getStateBefore(Inst);
 
     std::vector<MCInstReference> Result;
@@ -639,7 +639,7 @@ class DataflowSrcSafetyAnalysis
 public:
   DataflowSrcSafetyAnalysis(BinaryFunction &BF,
                             MCPlusBuilder::AllocatorIdTy AllocId,
-                            ArrayRef<MCPhysReg> RegsToTrack)
+                            ArrayRef<MCRegister> RegsToTrack)
       : SrcSafetyAnalysis(BF, RegsToTrack), DFParent(BF, AllocId) {}
 
   const SrcState &getStateBefore(const MCInst &Inst) const override {
@@ -649,7 +649,7 @@ public:
   void run() override {
     for (BinaryBasicBlock &BB : Func) {
       if (auto CheckerInfo = BC.MIB->getAuthCheckedReg(BB)) {
-        MCPhysReg CheckedReg = CheckerInfo->first;
+        MCRegister CheckedReg = CheckerInfo->first;
         MCInst &FirstInst = *CheckerInfo->second;
         MCInst &LastInst = *BB.getLastNonPseudoInstr();
         LLVM_DEBUG({
@@ -796,7 +796,7 @@ class CFGUnawareSrcSafetyAnalysis : public SrcSafetyAnalysis,
 public:
   CFGUnawareSrcSafetyAnalysis(BinaryFunction &BF,
                               MCPlusBuilder::AllocatorIdTy AllocId,
-                              ArrayRef<MCPhysReg> RegsToTrack)
+                              ArrayRef<MCRegister> RegsToTrack)
       : SrcSafetyAnalysis(BF, RegsToTrack),
         CFGUnawareAnalysis(BF, AllocId, "CFGUnawareSrcSafetyAnalysis"), BF(BF) {
   }
@@ -836,7 +836,7 @@ public:
 std::shared_ptr<SrcSafetyAnalysis>
 SrcSafetyAnalysis::create(BinaryFunction &BF,
                           MCPlusBuilder::AllocatorIdTy AllocId,
-                          ArrayRef<MCPhysReg> RegsToTrack) {
+                          ArrayRef<MCRegister> RegsToTrack) {
   if (BF.hasCFG())
     return std::make_shared<DataflowSrcSafetyAnalysis>(BF, AllocId,
                                                        RegsToTrack);
@@ -903,7 +903,7 @@ struct DstState {
   /// the authenticated pointer before it was checked. This is intended to
   /// provide clues on which instruction made the particular register unsafe.
   ///
-  /// Please note that the mapping from MCPhysReg values to indexes in this
+  /// Please note that the mapping from MCRegister values to indexes in this
   /// vector is provided by RegsToTrack field of DstSafetyAnalysis.
   std::vector<SetOfRelatedInsts> FirstInstLeakingReg;
 
@@ -984,7 +984,7 @@ void DstStatePrinter::print(raw_ostream &OS, const DstState &S) const {
 /// version for functions without reconstructed CFG.
 class DstSafetyAnalysis {
 public:
-  DstSafetyAnalysis(BinaryFunction &BF, ArrayRef<MCPhysReg> RegsToTrack)
+  DstSafetyAnalysis(BinaryFunction &BF, ArrayRef<MCRegister> RegsToTrack)
       : BC(BF.getBinaryContext()), NumRegs(BC.MRI->getNumRegs()),
         RegsToTrack(RegsToTrack) {}
 
@@ -992,7 +992,7 @@ public:
 
   static std::shared_ptr<DstSafetyAnalysis>
   create(BinaryFunction &BF, MCPlusBuilder::AllocatorIdTy AllocId,
-         ArrayRef<MCPhysReg> RegsToTrack);
+         ArrayRef<MCRegister> RegsToTrack);
 
   virtual void run() = 0;
   virtual const DstState &getStateAfter(const MCInst &Inst) const = 0;
@@ -1013,14 +1013,14 @@ protected:
   /// As the detection of such sequences requires iterating over the adjacent
   /// instructions, it should be done before calling computeNext(), which
   /// operates on separate instructions.
-  DenseMap<const MCInst *, MCPhysReg> RegCheckedAt;
+  DenseMap<const MCInst *, MCRegister> RegCheckedAt;
 
-  SetOfRelatedInsts &firstLeakingInsts(DstState &S, MCPhysReg Reg) const {
+  SetOfRelatedInsts &firstLeakingInsts(DstState &S, MCRegister Reg) const {
     unsigned Index = RegsToTrack.getIndex(Reg);
     return S.FirstInstLeakingReg[Index];
   }
   const SetOfRelatedInsts &firstLeakingInsts(const DstState &S,
-                                             MCPhysReg Reg) const {
+                                             MCRegister Reg) const {
     unsigned Index = RegsToTrack.getIndex(Reg);
     return S.FirstInstLeakingReg[Index];
   }
@@ -1060,10 +1060,10 @@ protected:
     return Leaked;
   }
 
-  SmallVector<MCPhysReg> getRegsMadeProtected(const MCInst &Inst,
-                                              const BitVector &LeakedRegs,
-                                              const DstState &Cur) const {
-    SmallVector<MCPhysReg> Regs;
+  SmallVector<MCRegister> getRegsMadeProtected(const MCInst &Inst,
+                                               const BitVector &LeakedRegs,
+                                               const DstState &Cur) const {
+    SmallVector<MCRegister> Regs;
 
     // A pointer can be checked, ...
     if (auto CheckedReg =
@@ -1075,7 +1075,7 @@ protected:
     // ... or it can be used as a branch target, ...
     if (BC.MIB->isIndirectBranch(Inst) || BC.MIB->isIndirectCall(Inst)) {
       bool IsAuthenticated;
-      MCPhysReg BranchDestReg =
+      MCRegister BranchDestReg =
           BC.MIB->getRegUsedAsIndirectBranchDest(Inst, IsAuthenticated);
       assert(BranchDestReg != BC.MIB->getNoRegister());
       if (!IsAuthenticated)
@@ -1085,7 +1085,7 @@ protected:
     // ... or it can be used as a return target, ...
     if (BC.MIB->isReturn(Inst)) {
       bool IsAuthenticated = false;
-      std::optional<MCPhysReg> RetReg =
+      std::optional<MCRegister> RetReg =
           BC.MIB->getRegUsedAsRetDest(Inst, IsAuthenticated);
       if (RetReg && !IsAuthenticated)
         Regs.push_back(*RetReg);
@@ -1096,8 +1096,8 @@ protected:
       auto [DstReg, SrcReg] = *DstAndSrc;
       // Note that *all* registers containing the derived values must be safe,
       // both source and destination ones. No temporaries are supported at now.
-      if (Cur.CannotEscapeUnchecked[SrcReg] &&
-          Cur.CannotEscapeUnchecked[DstReg])
+      if (Cur.CannotEscapeUnchecked[SrcReg.id()] &&
+          Cur.CannotEscapeUnchecked[DstReg.id()])
         Regs.push_back(SrcReg);
     }
 
@@ -1151,24 +1151,24 @@ protected:
     // after its execution into account, if necessary.
 
     BitVector LeakedRegs = getLeakedRegs(Point);
-    SmallVector<MCPhysReg> NewProtectedRegs =
+    SmallVector<MCRegister> NewProtectedRegs =
         getRegsMadeProtected(Point, LeakedRegs, Cur);
 
     // Then, compute the state before this instruction is executed.
     DstState Next = Cur;
 
     Next.CannotEscapeUnchecked.reset(LeakedRegs);
-    for (MCPhysReg Reg : RegsToTrack.getRegisters()) {
-      if (LeakedRegs[Reg])
+    for (MCRegister Reg : RegsToTrack.getRegisters()) {
+      if (LeakedRegs[Reg.id()])
         firstLeakingInsts(Next, Reg) = {&Point};
     }
 
     BitVector NewProtectedSubregs(NumRegs);
-    for (MCPhysReg Reg : NewProtectedRegs)
+    for (MCRegister Reg : NewProtectedRegs)
       NewProtectedSubregs |= BC.MIB->getAliases(Reg, /*OnlySmaller=*/true);
     Next.CannotEscapeUnchecked |= NewProtectedSubregs;
-    for (MCPhysReg Reg : RegsToTrack.getRegisters()) {
-      if (NewProtectedSubregs[Reg])
+    for (MCRegister Reg : RegsToTrack.getRegisters()) {
+      if (NewProtectedSubregs[Reg.id()])
         firstLeakingInsts(Next, Reg).clear();
     }
 
@@ -1184,7 +1184,7 @@ protected:
 public:
   std::vector<MCInstReference> getLeakingInsts(const MCInst &Inst,
                                                BinaryFunction &BF,
-                                               MCPhysReg LeakedReg) const {
+                                               MCRegister LeakedReg) const {
     const DstState &S = getStateAfter(Inst);
 
     std::vector<MCInstReference> Result;
@@ -1208,7 +1208,7 @@ class DataflowDstSafetyAnalysis
 public:
   DataflowDstSafetyAnalysis(BinaryFunction &BF,
                             MCPlusBuilder::AllocatorIdTy AllocId,
-                            ArrayRef<MCPhysReg> RegsToTrack)
+                            ArrayRef<MCRegister> RegsToTrack)
       : DstSafetyAnalysis(BF, RegsToTrack), DFParent(BF, AllocId) {}
 
   const DstState &getStateAfter(const MCInst &Inst) const override {
@@ -1290,7 +1290,7 @@ class CFGUnawareDstSafetyAnalysis : public DstSafetyAnalysis,
 public:
   CFGUnawareDstSafetyAnalysis(BinaryFunction &BF,
                               MCPlusBuilder::AllocatorIdTy AllocId,
-                              ArrayRef<MCPhysReg> RegsToTrack)
+                              ArrayRef<MCRegister> RegsToTrack)
       : DstSafetyAnalysis(BF, RegsToTrack),
         CFGUnawareAnalysis(BF, AllocId, "CFGUnawareDstSafetyAnalysis"), BF(BF) {
   }
@@ -1328,7 +1328,7 @@ public:
 std::shared_ptr<DstSafetyAnalysis>
 DstSafetyAnalysis::create(BinaryFunction &BF,
                           MCPlusBuilder::AllocatorIdTy AllocId,
-                          ArrayRef<MCPhysReg> RegsToTrack) {
+                          ArrayRef<MCRegister> RegsToTrack) {
   if (BF.hasCFG())
     return std::make_shared<DataflowDstSafetyAnalysis>(BF, AllocId,
                                                        RegsToTrack);
@@ -1337,11 +1337,11 @@ DstSafetyAnalysis::create(BinaryFunction &BF,
 }
 
 // This function could return PartialReport<T>, but currently T is always
-// MCPhysReg, even though it is an implementation detail.
-static PartialReport<MCPhysReg> make_generic_report(MCInstReference Location,
-                                                    StringRef Text) {
+// MCRegister, even though it is an implementation detail.
+static PartialReport<MCRegister> make_generic_report(MCInstReference Location,
+                                                     StringRef Text) {
   auto Report = std::make_shared<GenericDiagnostic>(Location, Text);
-  return PartialReport<MCPhysReg>(Report, std::nullopt);
+  return PartialReport<MCRegister>(Report, std::nullopt);
 }
 
 template <typename T>
@@ -1352,7 +1352,7 @@ static PartialReport<T> make_gadget_report(const GadgetKind &Kind,
   return PartialReport<T>(Report, RequestedDetails);
 }
 
-static std::optional<PartialReport<MCPhysReg>>
+static std::optional<PartialReport<MCRegister>>
 shouldReportReturnGadget(const BinaryContext &BC, const MCInstReference &Inst,
                          const SrcState &S) {
   static const GadgetKind RetKind("non-protected ret found");
@@ -1360,7 +1360,7 @@ shouldReportReturnGadget(const BinaryContext &BC, const MCInstReference &Inst,
     return std::nullopt;
 
   bool IsAuthenticated = false;
-  std::optional<MCPhysReg> RetReg =
+  std::optional<MCRegister> RetReg =
       BC.MIB->getRegUsedAsRetDest(Inst, IsAuthenticated);
   if (!RetReg) {
     return make_generic_report(
@@ -1376,7 +1376,7 @@ shouldReportReturnGadget(const BinaryContext &BC, const MCInstReference &Inst,
     traceRegMask(BC, "SafeToDerefRegs", S.SafeToDerefRegs);
   });
 
-  if (S.SafeToDerefRegs[*RetReg])
+  if (S.SafeToDerefRegs[RetReg->id()])
     return std::nullopt;
 
   return make_gadget_report(RetKind, Inst, *RetReg);
@@ -1419,7 +1419,7 @@ static bool shouldAnalyzeTailCallInst(const BinaryContext &BC,
   return false;
 }
 
-static std::optional<PartialReport<MCPhysReg>>
+static std::optional<PartialReport<MCRegister>>
 shouldReportUnsafeTailCall(const BinaryContext &BC, const BinaryFunction &BF,
                            const MCInstReference &Inst, const SrcState &S) {
   static const GadgetKind UntrustedLRKind(
@@ -1435,7 +1435,7 @@ shouldReportUnsafeTailCall(const BinaryContext &BC, const BinaryFunction &BF,
   // Thus, this function basically checks that the precondition expected to be
   // imposed by a function call instruction (which is hardcoded into the target-
   // specific getTrustedLiveInRegs() function) is also respected on tail calls.
-  SmallVector<MCPhysReg> RegsToCheck = BC.MIB->getTrustedLiveInRegs();
+  SmallVector<MCRegister> RegsToCheck = BC.MIB->getTrustedLiveInRegs();
   LLVM_DEBUG({
     traceInst(BC, "Found tail call inst", Inst);
     traceRegMask(BC, "Trusted regs", S.TrustedRegs);
@@ -1459,13 +1459,13 @@ shouldReportUnsafeTailCall(const BinaryContext &BC, const BinaryFunction &BF,
 
   // Returns at most one report per instruction - this is probably OK...
   for (auto Reg : RegsToCheck)
-    if (!S.TrustedRegs[Reg])
+    if (!S.TrustedRegs[Reg.id()])
       return make_gadget_report(UntrustedLRKind, Inst, Reg);
 
   return std::nullopt;
 }
 
-static std::optional<PartialReport<MCPhysReg>>
+static std::optional<PartialReport<MCRegister>>
 shouldReportCallGadget(const BinaryContext &BC, const MCInstReference &Inst,
                        const SrcState &S) {
   static const GadgetKind CallKind("non-protected call found");
@@ -1473,7 +1473,7 @@ shouldReportCallGadget(const BinaryContext &BC, const MCInstReference &Inst,
     return std::nullopt;
 
   bool IsAuthenticated = false;
-  MCPhysReg DestReg =
+  MCRegister DestReg =
       BC.MIB->getRegUsedAsIndirectBranchDest(Inst, IsAuthenticated);
   if (IsAuthenticated)
     return std::nullopt;
@@ -1484,18 +1484,18 @@ shouldReportCallGadget(const BinaryContext &BC, const MCInstReference &Inst,
     traceReg(BC, "Call destination reg", DestReg);
     traceRegMask(BC, "SafeToDerefRegs", S.SafeToDerefRegs);
   });
-  if (S.SafeToDerefRegs[DestReg])
+  if (S.SafeToDerefRegs[DestReg.id()])
     return std::nullopt;
 
   return make_gadget_report(CallKind, Inst, DestReg);
 }
 
-static std::optional<PartialReport<MCPhysReg>>
+static std::optional<PartialReport<MCRegister>>
 shouldReportSigningOracle(const BinaryContext &BC, const MCInstReference &Inst,
                           const SrcState &S) {
   static const GadgetKind SigningOracleKind("signing oracle found");
 
-  std::optional<MCPhysReg> SignedReg = BC.MIB->getSignedReg(Inst);
+  std::optional<MCRegister> SignedReg = BC.MIB->getSignedReg(Inst);
   if (!SignedReg)
     return std::nullopt;
 
@@ -1504,19 +1504,19 @@ shouldReportSigningOracle(const BinaryContext &BC, const MCInstReference &Inst,
     traceReg(BC, "Signed reg", *SignedReg);
     traceRegMask(BC, "TrustedRegs", S.TrustedRegs);
   });
-  if (S.TrustedRegs[*SignedReg])
+  if (S.TrustedRegs[SignedReg->id()])
     return std::nullopt;
 
   return make_gadget_report(SigningOracleKind, Inst, *SignedReg);
 }
 
-static std::optional<PartialReport<MCPhysReg>>
+static std::optional<PartialReport<MCRegister>>
 shouldReportAuthOracle(const BinaryContext &BC, const MCInstReference &Inst,
                        const DstState &S) {
   static const GadgetKind AuthOracleKind("authentication oracle found");
 
   bool IsChecked = false;
-  std::optional<MCPhysReg> AuthReg =
+  std::optional<MCRegister> AuthReg =
       BC.MIB->getWrittenAuthenticatedReg(Inst, IsChecked);
   if (!AuthReg || IsChecked)
     return std::nullopt;
@@ -1535,24 +1535,24 @@ shouldReportAuthOracle(const BinaryContext &BC, const MCInstReference &Inst,
 
   LLVM_DEBUG(
       { traceRegMask(BC, "safe output registers", S.CannotEscapeUnchecked); });
-  if (S.CannotEscapeUnchecked[*AuthReg])
+  if (S.CannotEscapeUnchecked[AuthReg->id()])
     return std::nullopt;
 
   return make_gadget_report(AuthOracleKind, Inst, *AuthReg);
 }
 
-static SmallVector<MCPhysReg>
-collectRegsToTrack(ArrayRef<PartialReport<MCPhysReg>> Reports) {
-  SmallSet<MCPhysReg, 4> RegsToTrack;
+static SmallVector<MCRegister>
+collectRegsToTrack(ArrayRef<PartialReport<MCRegister>> Reports) {
+  SmallSet<MCRegister, 4> RegsToTrack;
   for (auto Report : Reports)
     if (Report.RequestedDetails)
       RegsToTrack.insert(*Report.RequestedDetails);
 
-  return SmallVector<MCPhysReg>(RegsToTrack.begin(), RegsToTrack.end());
+  return SmallVector<MCRegister>(RegsToTrack.begin(), RegsToTrack.end());
 }
 
 void FunctionAnalysisContext::findUnsafeUses(
-    SmallVector<PartialReport<MCPhysReg>> &Reports) {
+    SmallVector<PartialReport<MCRegister>> &Reports) {
   const auto HandledDetectors =
       opts::GS_PTRAUTH_ALL_MASK & ~opts::GS_PTRAUTH_AUTH_ORACLES;
   if (!(EnabledDetectors & HandledDetectors))
@@ -1642,8 +1642,8 @@ void FunctionAnalysisContext::findUnsafeUses(
 }
 
 void FunctionAnalysisContext::augmentUnsafeUseReports(
-    ArrayRef<PartialReport<MCPhysReg>> Reports) {
-  SmallVector<MCPhysReg> RegsToTrack = collectRegsToTrack(Reports);
+    ArrayRef<PartialReport<MCRegister>> Reports) {
+  SmallVector<MCRegister> RegsToTrack = collectRegsToTrack(Reports);
   // Re-compute the analysis with register tracking.
   auto Analysis = SrcSafetyAnalysis::create(BF, AllocatorId, RegsToTrack);
   LLVM_DEBUG(dbgs() << "\nRunning detailed src register safety analysis...\n");
@@ -1667,7 +1667,7 @@ void FunctionAnalysisContext::augmentUnsafeUseReports(
 }
 
 void FunctionAnalysisContext::findUnsafeDefs(
-    SmallVector<PartialReport<MCPhysReg>> &Reports) {
+    SmallVector<PartialReport<MCRegister>> &Reports) {
   const auto HandledDetectors = opts::GS_PTRAUTH_AUTH_ORACLES;
   if (!(EnabledDetectors & HandledDetectors))
     return;
@@ -1695,8 +1695,8 @@ void FunctionAnalysisContext::findUnsafeDefs(
 }
 
 void FunctionAnalysisContext::augmentUnsafeDefReports(
-    ArrayRef<PartialReport<MCPhysReg>> Reports) {
-  SmallVector<MCPhysReg> RegsToTrack = collectRegsToTrack(Reports);
+    ArrayRef<PartialReport<MCRegister>> Reports) {
+  SmallVector<MCRegister> RegsToTrack = collectRegsToTrack(Reports);
   // Re-compute the analysis with register tracking.
   auto Analysis = DstSafetyAnalysis::create(BF, AllocatorId, RegsToTrack);
   LLVM_DEBUG(dbgs() << "\nRunning detailed dst register safety analysis...\n");
@@ -1719,7 +1719,7 @@ void FunctionAnalysisContext::augmentUnsafeDefReports(
 }
 
 void FunctionAnalysisContext::handleSimpleReports(
-    SmallVector<PartialReport<MCPhysReg>> &Reports) {
+    SmallVector<PartialReport<MCRegister>> &Reports) {
   // Before re-running the detailed analysis, process the reports which do not
   // need any additional details to be attached.
   for (auto &Report : Reports) {
@@ -1745,13 +1745,13 @@ void FunctionAnalysisContext::run() {
     BF.dump();
   });
 
-  SmallVector<PartialReport<MCPhysReg>> UnsafeUses;
+  SmallVector<PartialReport<MCRegister>> UnsafeUses;
   findUnsafeUses(UnsafeUses);
   handleSimpleReports(UnsafeUses);
   if (!UnsafeUses.empty())
     augmentUnsafeUseReports(UnsafeUses);
 
-  SmallVector<PartialReport<MCPhysReg>> UnsafeDefs;
+  SmallVector<PartialReport<MCRegister>> UnsafeDefs;
   findUnsafeDefs(UnsafeDefs);
   handleSimpleReports(UnsafeDefs);
   if (!UnsafeDefs.empty())

--- a/bolt/lib/Passes/RegReAssign.cpp
+++ b/bolt/lib/Passes/RegReAssign.cpp
@@ -36,7 +36,7 @@ static cl::opt<bool> AggressiveReAssign(
 namespace llvm {
 namespace bolt {
 
-void RegReAssign::swap(BinaryFunction &Function, MCPhysReg A, MCPhysReg B) {
+void RegReAssign::swap(BinaryFunction &Function, MCRegister A, MCRegister B) {
   BinaryContext &BC = Function.getBinaryContext();
   const BitVector &AliasA = BC.MIB->getAliases(A, false);
   const BitVector &AliasB = BC.MIB->getAliases(B, false);
@@ -48,14 +48,14 @@ void RegReAssign::swap(BinaryFunction &Function, MCPhysReg A, MCPhysReg B) {
         if (!Operand.isReg())
           continue;
 
-        unsigned Reg = Operand.getReg();
-        if (AliasA.test(Reg)) {
+        MCRegister Reg = Operand.getReg();
+        if (AliasA.test(Reg.id())) {
           Operand.setReg(BC.MIB->getAliasSized(B, BC.MIB->getRegSize(Reg)));
           --StaticBytesSaved;
           DynBytesSaved -= BB.getKnownExecutionCount();
           continue;
         }
-        if (!AliasB.test(Reg))
+        if (!AliasB.test(Reg.id()))
           continue;
         Operand.setReg(BC.MIB->getAliasSized(A, BC.MIB->getRegSize(Reg)));
         ++StaticBytesSaved;
@@ -78,15 +78,15 @@ void RegReAssign::swap(BinaryFunction &Function, MCPhysReg A, MCPhysReg B) {
       switch (CFI->getOperation()) {
       case MCCFIInstruction::OpRegister: {
         const unsigned CFIReg2 = CFI->getRegister2();
-        const MCPhysReg Reg2 = *BC.MRI->getLLVMRegNum(CFIReg2, /*isEH=*/false);
-        if (AliasA.test(Reg2)) {
+        const MCRegister Reg2 = *BC.MRI->getLLVMRegNum(CFIReg2, /*isEH=*/false);
+        if (AliasA.test(Reg2.id())) {
           Function.setCFIFor(
               Inst, MCCFIInstruction::createRegister(
                         nullptr, CFI->getRegister(),
                         BC.MRI->getDwarfRegNum(
                             BC.MIB->getAliasSized(B, BC.MIB->getRegSize(Reg2)),
                             false)));
-        } else if (AliasB.test(Reg2)) {
+        } else if (AliasB.test(Reg2.id())) {
           Function.setCFIFor(
               Inst, MCCFIInstruction::createRegister(
                         nullptr, CFI->getRegister(),
@@ -115,13 +115,13 @@ void RegReAssign::swap(BinaryFunction &Function, MCPhysReg A, MCPhysReg B) {
             break;
           CFIReg = *Reg;
         }
-        const MCPhysReg Reg = *BC.MRI->getLLVMRegNum(CFIReg, /*isEH=*/false);
-        if (AliasA.test(Reg))
+        const MCRegister Reg = *BC.MRI->getLLVMRegNum(CFIReg, /*isEH=*/false);
+        if (AliasA.test(Reg.id()))
           Function.mutateCFIRegisterFor(
               Inst,
               BC.MRI->getDwarfRegNum(
                   BC.MIB->getAliasSized(B, BC.MIB->getRegSize(Reg)), false));
-        else if (AliasB.test(Reg))
+        else if (AliasB.test(Reg.id()))
           Function.mutateCFIRegisterFor(
               Inst,
               BC.MRI->getDwarfRegNum(
@@ -169,7 +169,7 @@ void RegReAssign::rankRegisters(BinaryFunction &Function) {
         if (Desc.getOperandConstraint(I, MCOI::TIED_TO) != -1)
           continue;
 
-        unsigned Reg = Operand.getReg();
+        MCRegister Reg = Operand.getReg();
         size_t RegEC = BC.MIB->getAliases(Reg, false).find_first();
         if (RegEC == 0)
           continue;
@@ -193,15 +193,15 @@ void RegReAssign::rankRegisters(BinaryFunction &Function) {
         if (CannotUseREX) {
           RegScore[RegEC] =
               std::numeric_limits<decltype(RegScore)::value_type>::min();
-          RegScore[BC.MIB->getAliasSized(Reg, 1)] = RegScore[RegEC];
+          RegScore[BC.MIB->getAliasSized(Reg, 1).id()] = RegScore[RegEC];
           continue;
         }
 
         // Unsupported substitution, cannot swap BH with R* regs, bail
-        if (BC.MIB->isUpper8BitReg(Reg) && ClassicCSR.test(Reg)) {
+        if (BC.MIB->isUpper8BitReg(Reg) && ClassicCSR.test(Reg.id())) {
           RegScore[RegEC] =
               std::numeric_limits<decltype(RegScore)::value_type>::min();
-          RegScore[BC.MIB->getAliasSized(Reg, 1)] = RegScore[RegEC];
+          RegScore[BC.MIB->getAliasSized(Reg, 1).id()] = RegScore[RegEC];
           continue;
         }
 
@@ -360,23 +360,23 @@ bool RegReAssign::conservativePassOverFunction(BinaryFunction &Function) {
 
   // Try swapping R12, R13, R14 or R15 with RBX (we work with all callee-saved
   // regs except RBP)
-  MCPhysReg Candidate = 0;
+  MCRegister Candidate;
   for (int J : ExtendedCSR.set_bits())
-    if (RegScore[J] > RegScore[Candidate])
+    if (RegScore[J] > RegScore[Candidate.id()])
       Candidate = J;
 
-  if (!Candidate || RegScore[Candidate] < 0)
+  if (!Candidate || RegScore[Candidate.id()] < 0)
     return false;
 
   // Check if our classic callee-saved reg (RBX is the only one) has lower
   // score / utilization rate
-  MCPhysReg RBX = 0;
+  MCRegister RBX;
   for (int I : ClassicCSR.set_bits()) {
     int64_t ScoreRBX = RegScore[I];
     if (ScoreRBX <= 0)
       continue;
 
-    if (RegScore[Candidate] > (ScoreRBX + 10))
+    if (RegScore[Candidate.id()] > (ScoreRBX + 10))
       RBX = I;
   }
 
@@ -388,7 +388,7 @@ bool RegReAssign::conservativePassOverFunction(BinaryFunction &Function) {
   // low 8 bits of the register instead.
   if (BC.MIB->isUpper8BitReg(RBX)) {
     RBX = BC.MIB->getAliasSized(RBX, 1);
-    if (RegScore[RBX] < 0 || RegScore[RBX] > RegScore[Candidate])
+    if (RegScore[RBX.id()] < 0 || RegScore[RBX.id()] > RegScore[Candidate.id()])
       return false;
   }
 

--- a/bolt/lib/Passes/RetpolineInsertion.cpp
+++ b/bolt/lib/Passes/RetpolineInsertion.cpp
@@ -134,9 +134,9 @@ BinaryFunction *createNewRetpoline(BinaryContext &BC,
 
       MCInst LoadCalleeAddrs;
       const IndirectBranchInfo::MemOpInfo &MemRef = BrInfo.Memory;
-      MIB.createLoad(LoadCalleeAddrs, MemRef.BaseRegNum, MemRef.ScaleImm,
-                     MemRef.IndexRegNum, MemRef.DispImm, MemRef.DispExpr,
-                     MemRef.SegRegNum, MIB.getX86R11(), 8);
+      MIB.createLoad(LoadCalleeAddrs, MemRef.BaseReg, MemRef.ScaleImm,
+                     MemRef.IndexReg, MemRef.DispImm, MemRef.DispExpr,
+                     MemRef.SegReg, MIB.getX86R11(), 8);
 
       BB2.addInstruction(LoadCalleeAddrs);
 
@@ -191,8 +191,8 @@ std::string createRetpolineFunctionTag(BinaryContext &BC,
 
   TagOS << "mem_";
 
-  if (MemRef.BaseRegNum != BC.MIB->getNoRegister())
-    BC.InstPrinter->printRegName(TagOS, MemRef.BaseRegNum);
+  if (MemRef.BaseReg != BC.MIB->getNoRegister())
+    BC.InstPrinter->printRegName(TagOS, MemRef.BaseReg);
 
   TagOS << "+";
   if (MemRef.DispExpr)
@@ -200,14 +200,14 @@ std::string createRetpolineFunctionTag(BinaryContext &BC,
   else
     TagOS << MemRef.DispImm;
 
-  if (MemRef.IndexRegNum != BC.MIB->getNoRegister()) {
+  if (MemRef.IndexReg != BC.MIB->getNoRegister()) {
     TagOS << "+" << MemRef.ScaleImm << "*";
-    BC.InstPrinter->printRegName(TagOS, MemRef.IndexRegNum);
+    BC.InstPrinter->printRegName(TagOS, MemRef.IndexReg);
   }
 
-  if (MemRef.SegRegNum != BC.MIB->getNoRegister()) {
+  if (MemRef.SegReg != BC.MIB->getNoRegister()) {
     TagOS << "_seg_";
-    BC.InstPrinter->printRegName(TagOS, MemRef.SegRegNum);
+    BC.InstPrinter->printRegName(TagOS, MemRef.SegReg);
   }
 
   return Tag;
@@ -235,9 +235,9 @@ void createBranchReplacement(BinaryContext &BC,
   if (BrInfo.isMem() && R11Available) {
     const IndirectBranchInfo::MemOpInfo &MemRef = BrInfo.Memory;
     MCInst LoadCalleeAddrs;
-    MIB.createLoad(LoadCalleeAddrs, MemRef.BaseRegNum, MemRef.ScaleImm,
-                   MemRef.IndexRegNum, MemRef.DispImm, MemRef.DispExpr,
-                   MemRef.SegRegNum, MIB.getX86R11(), 8);
+    MIB.createLoad(LoadCalleeAddrs, MemRef.BaseReg, MemRef.ScaleImm,
+                   MemRef.IndexReg, MemRef.DispImm, MemRef.DispExpr,
+                   MemRef.SegReg, MIB.getX86R11(), 8);
     Replacement.push_back(LoadCalleeAddrs);
   }
 
@@ -310,9 +310,9 @@ Error RetpolineInsertion::runOnFunctions(BinaryContext &BC) {
         if (BrInfo.isMem() && !R11Available) {
           IndirectBranchInfo::MemOpInfo &MemRef = BrInfo.Memory;
           int Addend = (BrInfo.isJump() || BrInfo.isTailCall()) ? 8 : 16;
-          if (MemRef.BaseRegNum == MIB.getStackPointer())
+          if (MemRef.BaseReg == MIB.getStackPointer())
             MemRef.DispImm += Addend;
-          if (MemRef.IndexRegNum == MIB.getStackPointer())
+          if (MemRef.IndexReg == MIB.getStackPointer())
             MemRef.DispImm += Addend * MemRef.ScaleImm;
         }
 

--- a/bolt/lib/Passes/ShrinkWrapping.cpp
+++ b/bolt/lib/Passes/ShrinkWrapping.cpp
@@ -233,18 +233,18 @@ void StackLayoutModifier::checkFramePointerInitialization(MCInst &Point) {
 
   int SPVal, FPVal;
   std::tie(SPVal, FPVal) = *SPT.getStateBefore(Point);
-  std::pair<MCPhysReg, int64_t> FP;
+  std::pair<MCRegister, int64_t> FP;
 
   if (FPVal != SPT.EMPTY && FPVal != SPT.SUPERPOSITION)
     FP = std::make_pair(BC.MIB->getFramePointer(), FPVal);
   else
-    FP = std::make_pair(0, 0);
-  std::pair<MCPhysReg, int64_t> SP;
+    FP = std::make_pair(MCRegister(), 0);
+  std::pair<MCRegister, int64_t> SP;
 
   if (SPVal != SPT.EMPTY && SPVal != SPT.SUPERPOSITION)
     SP = std::make_pair(BC.MIB->getStackPointer(), SPVal);
   else
-    SP = std::make_pair(0, 0);
+    SP = std::make_pair(MCRegister(), 0);
 
   int64_t Output;
   if (!BC.MIB->evaluateStackOffsetExpr(Point, Output, SP, FP))
@@ -271,18 +271,18 @@ void StackLayoutModifier::checkStackPointerRestore(MCInst &Point) {
   // Setting up evaluation
   int SPVal, FPVal;
   std::tie(SPVal, FPVal) = *SPT.getStateBefore(Point);
-  std::pair<MCPhysReg, int64_t> FP;
+  std::pair<MCRegister, int64_t> FP;
 
   if (FPVal != SPT.EMPTY && FPVal != SPT.SUPERPOSITION)
     FP = std::make_pair(BC.MIB->getFramePointer(), FPVal);
   else
-    FP = std::make_pair(0, 0);
-  std::pair<MCPhysReg, int64_t> SP;
+    FP = std::make_pair(MCRegister(), 0);
+  std::pair<MCRegister, int64_t> SP;
 
   if (SPVal != SPT.EMPTY && SPVal != SPT.SUPERPOSITION)
     SP = std::make_pair(BC.MIB->getStackPointer(), SPVal);
   else
-    SP = std::make_pair(0, 0);
+    SP = std::make_pair(MCRegister(), 0);
 
   int64_t Output;
   if (!BC.MIB->evaluateStackOffsetExpr(Point, Output, SP, FP))
@@ -357,7 +357,7 @@ void StackLayoutModifier::classifyCFIs() {
   uint16_t CfaReg = 7;
 
   auto recordAccess = [&](MCInst *Inst, int64_t Offset) {
-    const uint16_t Reg = *BC.MRI->getLLVMRegNum(CfaReg, /*isEH=*/false);
+    const MCRegister Reg = *BC.MRI->getLLVMRegNum(CfaReg, /*isEH=*/false);
     if (Reg == BC.MIB->getStackPointer() || Reg == BC.MIB->getFramePointer()) {
       BC.MIB->addAnnotation(*Inst, getSlotTag(), Offset, AllocatorId);
       LLVM_DEBUG(dbgs() << "Recording CFI " << Offset << "\n");
@@ -656,8 +656,8 @@ void StackLayoutModifier::performChanges() {
         continue;
       }
       int32_t SrcImm = 0;
-      MCPhysReg Reg = 0;
-      MCPhysReg StackPtrReg = 0;
+      MCRegister Reg;
+      MCRegister StackPtrReg;
       int64_t StackOffset = 0;
       bool IsIndexed = false;
       bool IsLoad = false;
@@ -1524,8 +1524,8 @@ void ShrinkWrapping::insertUpdatedCFI(unsigned CSR, int SPValPush,
   for (BinaryBasicBlock &BB : BF) {
     for (MCInst &Inst : llvm::reverse(BB)) {
       int32_t SrcImm = 0;
-      MCPhysReg Reg = 0;
-      MCPhysReg StackPtrReg = 0;
+      MCRegister Reg;
+      MCRegister StackPtrReg;
       int64_t StackOffset = 0;
       bool IsIndexed = false;
       bool IsLoad = false;

--- a/bolt/lib/Passes/StackAllocationAnalysis.cpp
+++ b/bolt/lib/Passes/StackAllocationAnalysis.cpp
@@ -25,7 +25,7 @@ void StackAllocationAnalysis::preflight() {
 
   for (BinaryBasicBlock &BB : this->Func) {
     for (MCInst &Inst : BB) {
-      MCPhysReg From, To;
+      MCRegister From, To;
       if (!BC.MIB->isPush(Inst) &&
           (!BC.MIB->isRegToRegMove(Inst, From, To) ||
            To != BC.MIB->getStackPointer() ||
@@ -105,7 +105,7 @@ BitVector StackAllocationAnalysis::computeNext(const MCInst &Point,
     return Next;
   }
 
-  MCPhysReg From, To;
+  MCRegister From, To;
   int64_t SPOffset, FPOffset;
   std::tie(SPOffset, FPOffset) = *SPT.getStateBefore(Point);
   if (MIB->isRegToRegMove(Point, From, To) && To == MIB->getStackPointer() &&
@@ -123,16 +123,16 @@ BitVector StackAllocationAnalysis::computeNext(const MCInst &Point,
   }
   if (BC.MII->get(Point.getOpcode())
           .hasDefOfPhysReg(Point, MIB->getStackPointer(), *BC.MRI)) {
-    std::pair<MCPhysReg, int64_t> SP;
+    std::pair<MCRegister, int64_t> SP;
     if (SPOffset != SPT.EMPTY && SPOffset != SPT.SUPERPOSITION)
       SP = std::make_pair(MIB->getStackPointer(), SPOffset);
     else
-      SP = std::make_pair(0, 0);
-    std::pair<MCPhysReg, int64_t> FP;
+      SP = std::make_pair(MCRegister(), 0);
+    std::pair<MCRegister, int64_t> FP;
     if (FPOffset != SPT.EMPTY && FPOffset != SPT.SUPERPOSITION)
       FP = std::make_pair(MIB->getFramePointer(), FPOffset);
     else
-      FP = std::make_pair(0, 0);
+      FP = std::make_pair(MCRegister(), 0);
     int64_t Output;
     if (!MIB->evaluateStackOffsetExpr(Point, Output, SP, FP))
       return Next;

--- a/bolt/lib/Passes/TailDuplication.cpp
+++ b/bolt/lib/Passes/TailDuplication.cpp
@@ -90,7 +90,8 @@ void TailDuplication::getCallerSavedRegs(const MCInst &Inst, BitVector &Regs,
   Regs |= CallRegs;
 }
 
-bool TailDuplication::regIsPossiblyOverwritten(const MCInst &Inst, MCRegister Reg,
+bool TailDuplication::regIsPossiblyOverwritten(const MCInst &Inst,
+                                               MCRegister Reg,
                                                BinaryContext &BC) const {
   BitVector WrittenRegs = BitVector(BC.MRI->getNumRegs(), false);
   BC.MIB->getWrittenRegs(Inst, WrittenRegs);

--- a/bolt/lib/Passes/TailDuplication.cpp
+++ b/bolt/lib/Passes/TailDuplication.cpp
@@ -90,7 +90,7 @@ void TailDuplication::getCallerSavedRegs(const MCInst &Inst, BitVector &Regs,
   Regs |= CallRegs;
 }
 
-bool TailDuplication::regIsPossiblyOverwritten(const MCInst &Inst, unsigned Reg,
+bool TailDuplication::regIsPossiblyOverwritten(const MCInst &Inst, MCRegister Reg,
                                                BinaryContext &BC) const {
   BitVector WrittenRegs = BitVector(BC.MRI->getNumRegs(), false);
   BC.MIB->getWrittenRegs(Inst, WrittenRegs);
@@ -102,18 +102,18 @@ bool TailDuplication::regIsPossiblyOverwritten(const MCInst &Inst, unsigned Reg,
 }
 
 bool TailDuplication::regIsDefinitelyOverwritten(const MCInst &Inst,
-                                                 unsigned Reg,
+                                                 MCRegister Reg,
                                                  BinaryContext &BC) const {
   BitVector WrittenRegs = BitVector(BC.MRI->getNumRegs(), false);
   BC.MIB->getWrittenRegs(Inst, WrittenRegs);
   getCallerSavedRegs(Inst, WrittenRegs, BC);
   if (BC.MIB->isRep(Inst))
     BC.MIB->getRepRegs(WrittenRegs);
-  return (!regIsUsed(Inst, Reg, BC) && WrittenRegs.test(Reg) &&
+  return (!regIsUsed(Inst, Reg, BC) && WrittenRegs.test(Reg.id()) &&
           !BC.MIB->isConditionalMove(Inst));
 }
 
-bool TailDuplication::regIsUsed(const MCInst &Inst, unsigned Reg,
+bool TailDuplication::regIsUsed(const MCInst &Inst, MCRegister Reg,
                                 BinaryContext &BC) const {
   BitVector SrcRegs = BitVector(BC.MRI->getNumRegs(), false);
   BC.MIB->getSrcRegs(Inst, SrcRegs);
@@ -122,7 +122,7 @@ bool TailDuplication::regIsUsed(const MCInst &Inst, unsigned Reg,
 }
 
 bool TailDuplication::isOverwrittenBeforeUsed(BinaryBasicBlock &StartBB,
-                                              unsigned Reg) const {
+                                              MCRegister Reg) const {
   BinaryFunction *BF = StartBB.getFunction();
   BinaryContext &BC = BF->getBinaryContext();
   std::queue<BinaryBasicBlock *> Q;
@@ -187,7 +187,7 @@ void TailDuplication::constantAndCopyPropagate(
     // True if this is constant propagation and not copy propagation
     bool ConstantProp = BC.MII->get(OriginalInst.getOpcode()).isMoveImmediate();
     // The Register to replaced
-    unsigned Reg = OriginalInst.getOperand(0).getReg();
+    MCRegister Reg = OriginalInst.getOperand(0).getReg();
     // True if the register to replace was replaced everywhere it was used
     bool ReplacedEverywhere = true;
     // True if the register was definitely overwritten

--- a/bolt/lib/Passes/ValidateInternalCalls.cpp
+++ b/bolt/lib/Passes/ValidateInternalCalls.cpp
@@ -228,7 +228,7 @@ bool ValidateInternalCalls::analyzeFunction(BinaryFunction &Function) const {
 
       FrameIndexEntry FIE;
       int32_t SrcImm = 0;
-      MCPhysReg Reg = 0;
+      MCRegister Reg;
       int64_t StackOffset = 0;
       bool IsIndexed = false;
       MCInst *TargetInst = ProgramPoint::getFirstPointAt(*Target).getInst();
@@ -265,12 +265,12 @@ bool ValidateInternalCalls::analyzeFunction(BinaryFunction &Function) const {
         MCInst &Use = **I;
         BitVector UsedRegs = BitVector(BC.MRI->getNumRegs(), false);
         BC.MIB->getTouchedRegs(Use, UsedRegs);
-        if (!UsedRegs[Reg])
+        if (!UsedRegs[Reg.id()])
           continue;
         UseDetected = true;
         int64_t Output;
-        std::pair<MCPhysReg, int64_t> Input1 = std::make_pair(Reg, 0);
-        std::pair<MCPhysReg, int64_t> Input2 = std::make_pair(0, 0);
+        std::pair<MCRegister, int64_t> Input1 = std::make_pair(Reg, 0);
+        std::pair<MCRegister, int64_t> Input2 = std::make_pair(MCRegister(), 0);
         if (!BC.MIB->evaluateStackOffsetExpr(Use, Output, Input1, Input2)) {
           LLVM_DEBUG(dbgs() << "Evaluate stack offset expr failed.\n");
           return false;

--- a/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
+++ b/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
@@ -50,21 +50,22 @@ static cl::opt<bool> NoLSEAtomics(
 
 namespace {
 
-[[maybe_unused]] static void getSystemFlag(MCInst &Inst, MCPhysReg RegName) {
+[[maybe_unused]] static void getSystemFlag(MCInst &Inst, MCRegister RegName) {
   Inst.setOpcode(AArch64::MRS);
   Inst.clear();
   Inst.addOperand(MCOperand::createReg(RegName));
   Inst.addOperand(MCOperand::createImm(AArch64SysReg::NZCV));
 }
 
-[[maybe_unused]] static void setSystemFlag(MCInst &Inst, MCPhysReg RegName) {
+[[maybe_unused]] static void setSystemFlag(MCInst &Inst, MCRegister RegName) {
   Inst.setOpcode(AArch64::MSR);
   Inst.clear();
   Inst.addOperand(MCOperand::createImm(AArch64SysReg::NZCV));
   Inst.addOperand(MCOperand::createReg(RegName));
 }
 
-static void createPushRegisters(MCInst &Inst, MCPhysReg Reg1, MCPhysReg Reg2) {
+static void createPushRegisters(MCInst &Inst, MCRegister Reg1,
+                                MCRegister Reg2) {
   Inst.clear();
   unsigned NewOpcode = AArch64::STPXpre;
   Inst.setOpcode(NewOpcode);
@@ -75,7 +76,7 @@ static void createPushRegisters(MCInst &Inst, MCPhysReg Reg1, MCPhysReg Reg2) {
   Inst.addOperand(MCOperand::createImm(-2));
 }
 
-static void createPopRegisters(MCInst &Inst, MCPhysReg Reg1, MCPhysReg Reg2) {
+static void createPopRegisters(MCInst &Inst, MCRegister Reg1, MCRegister Reg2) {
   Inst.clear();
   unsigned NewOpcode = AArch64::LDPXpost;
   Inst.setOpcode(NewOpcode);
@@ -86,7 +87,7 @@ static void createPopRegisters(MCInst &Inst, MCPhysReg Reg1, MCPhysReg Reg2) {
   Inst.addOperand(MCOperand::createImm(2));
 }
 
-static void loadReg(MCInst &Inst, MCPhysReg To, MCPhysReg From) {
+static void loadReg(MCInst &Inst, MCRegister To, MCRegister From) {
   Inst.setOpcode(AArch64::LDRXui);
   Inst.clear();
   if (From == AArch64::SP) {
@@ -102,7 +103,7 @@ static void loadReg(MCInst &Inst, MCPhysReg To, MCPhysReg From) {
   }
 }
 
-static void storeReg(MCInst &Inst, MCPhysReg From, MCPhysReg To) {
+static void storeReg(MCInst &Inst, MCRegister From, MCRegister To) {
   Inst.setOpcode(AArch64::STRXui);
   Inst.clear();
   if (To == AArch64::SP) {
@@ -118,7 +119,7 @@ static void storeReg(MCInst &Inst, MCPhysReg From, MCPhysReg To) {
   }
 }
 
-static void atomicAdd(MCInst &Inst, MCPhysReg RegTo, MCPhysReg RegCnt) {
+static void atomicAdd(MCInst &Inst, MCRegister RegTo, MCRegister RegCnt) {
   assert(!opts::NoLSEAtomics && "Supports only ARM with LSE extension");
   Inst.setOpcode(AArch64::LDADDX);
   Inst.clear();
@@ -127,7 +128,7 @@ static void atomicAdd(MCInst &Inst, MCPhysReg RegTo, MCPhysReg RegCnt) {
   Inst.addOperand(MCOperand::createReg(RegTo));
 }
 
-static void createMovz(MCInst &Inst, MCPhysReg Reg, uint64_t Imm) {
+static void createMovz(MCInst &Inst, MCRegister Reg, uint64_t Imm) {
   assert(Imm <= UINT16_MAX && "Invalid Imm size");
   Inst.clear();
   Inst.setOpcode(AArch64::MOVZXi);
@@ -136,7 +137,8 @@ static void createMovz(MCInst &Inst, MCPhysReg Reg, uint64_t Imm) {
   Inst.addOperand(MCOperand::createImm(0));
 }
 
-static InstructionListType createIncMemory(MCPhysReg RegTo, MCPhysReg RegTmp) {
+static InstructionListType createIncMemory(MCRegister RegTo,
+                                           MCRegister RegTmp) {
   InstructionListType Insts;
   Insts.emplace_back();
   createMovz(Insts.back(), RegTmp, 1);
@@ -145,7 +147,7 @@ static InstructionListType createIncMemory(MCPhysReg RegTo, MCPhysReg RegTmp) {
   return Insts;
 }
 
-static InstructionListType createMOVImm(MCPhysReg DstReg, unsigned BitSize,
+static InstructionListType createMOVImm(MCRegister DstReg, unsigned BitSize,
                                         uint64_t Imm) {
   SmallVector<AArch64_IMM::ImmInsnModel> Insn;
   AArch64_IMM::expandMOVImm(Imm, BitSize, Insn);
@@ -214,9 +216,9 @@ public:
     return std::make_unique<AArch64MCSymbolizer>(Function, CreateNewSymbols);
   }
 
-  MCPhysReg getStackPointer() const override { return AArch64::SP; }
-  MCPhysReg getFramePointer() const override { return AArch64::FP; }
-  MCPhysReg getFlagsReg() const override { return AArch64::NZCV; }
+  MCRegister getStackPointer() const override { return AArch64::SP; }
+  MCRegister getFramePointer() const override { return AArch64::FP; }
+  MCRegister getFlagsReg() const override { return AArch64::NZCV; }
 
   bool isBreakpoint(const MCInst &Inst) const override {
     return Inst.getOpcode() == AArch64::BRK;
@@ -310,11 +312,11 @@ public:
     return false;
   }
 
-  SmallVector<MCPhysReg> getTrustedLiveInRegs() const override {
+  SmallVector<MCRegister> getTrustedLiveInRegs() const override {
     return {AArch64::LR};
   }
 
-  std::optional<MCPhysReg>
+  std::optional<MCRegister>
   getWrittenAuthenticatedReg(const MCInst &Inst,
                              bool &IsChecked) const override {
     IsChecked = false;
@@ -354,14 +356,14 @@ public:
   }
 
   bool isPSignOnLR(const MCInst &Inst) const override {
-    std::optional<MCPhysReg> SignReg = getSignedReg(Inst);
+    std::optional<MCRegister> SignReg = getSignedReg(Inst);
     return SignReg && *SignReg == AArch64::LR;
   }
 
   bool isPAuthOnLR(const MCInst &Inst) const override {
     // LDR(A|B) should not be covered.
     bool IsChecked;
-    std::optional<MCPhysReg> AuthReg =
+    std::optional<MCRegister> AuthReg =
         getWrittenAuthenticatedReg(Inst, IsChecked);
     return !IsChecked && AuthReg && *AuthReg == AArch64::LR;
   }
@@ -402,7 +404,7 @@ public:
     }
   }
 
-  std::optional<MCPhysReg> getSignedReg(const MCInst &Inst) const override {
+  std::optional<MCRegister> getSignedReg(const MCInst &Inst) const override {
     switch (Inst.getOpcode()) {
     case AArch64::PACIA:
     case AArch64::PACIB:
@@ -432,7 +434,7 @@ public:
     }
   }
 
-  std::optional<MCPhysReg>
+  std::optional<MCRegister>
   getRegUsedAsRetDest(const MCInst &Inst,
                       bool &IsAuthenticatedInternally) const override {
     assert(isReturn(Inst));
@@ -456,14 +458,15 @@ public:
       // ELR_EL3, depending on the current Exception Level at run-time.
       //
       // Furthermore, these registers are not modelled by LLVM as a regular
-      // MCPhysReg, so there is no way to indicate that through the current API.
+      // MCRegister, so there is no way to indicate that through the current
+      // API.
       return std::nullopt;
     default:
       llvm_unreachable("Unhandled return instruction");
     }
   }
 
-  MCPhysReg getRegUsedAsIndirectBranchDest(
+  MCRegister getRegUsedAsIndirectBranchDest(
       const MCInst &Inst, bool &IsAuthenticatedInternally) const override {
     assert(isIndirectCall(Inst) || isIndirectBranch(Inst));
 
@@ -487,7 +490,7 @@ public:
     }
   }
 
-  std::optional<MCPhysReg>
+  std::optional<MCRegister>
   getMaterializedAddressRegForPtrAuth(const MCInst &Inst) const override {
     switch (Inst.getOpcode()) {
     case AArch64::ADR:
@@ -502,7 +505,7 @@ public:
     }
   }
 
-  std::optional<std::pair<MCPhysReg, MCPhysReg>>
+  std::optional<std::pair<MCRegister, MCRegister>>
   analyzeAddressArithmeticsForPtrAuth(const MCInst &Inst) const override {
     switch (Inst.getOpcode()) {
     default:
@@ -524,7 +527,7 @@ public:
     }
   }
 
-  std::optional<std::pair<MCPhysReg, MCInst *>>
+  std::optional<std::pair<MCRegister, MCInst *>>
   getAuthCheckedReg(BinaryBasicBlock &BB) const override {
     // Match several possible hard-coded sequences of instructions which can be
     // emitted by LLVM backend to check that the authenticated pointer is
@@ -615,8 +618,8 @@ public:
     return std::nullopt;
   }
 
-  std::optional<MCPhysReg> getAuthCheckedReg(const MCInst &Inst,
-                                             bool MayOverwrite) const override {
+  std::optional<MCRegister>
+  getAuthCheckedReg(const MCInst &Inst, bool MayOverwrite) const override {
     // Cannot trivially reuse AArch64InstrInfo::getMemOperandWithOffsetWidth()
     // method as it accepts an instance of MachineInstr, not MCInst.
     const MCInstrDesc &Desc = Info->get(Inst.getOpcode());
@@ -650,7 +653,7 @@ public:
     auto ClobbersBaseRegExceptWriteback = [&](unsigned BaseRegUseIndex) {
       // FIXME: Compute the indices of address operands (base reg and written-
       //        back result) in AArch64InstrInfo instead of this ad-hoc code.
-      MCPhysReg BaseReg = Inst.getOperand(BaseRegUseIndex).getReg();
+      MCRegister BaseReg = Inst.getOperand(BaseRegUseIndex).getReg();
       unsigned WrittenBackDefIndex = Desc.getOperandConstraint(
           BaseRegUseIndex, MCOI::OperandConstraint::TIED_TO);
 
@@ -721,7 +724,7 @@ public:
            OpCode == AArch64::LDRSWl;
   }
 
-  MCPhysReg getADRReg(const MCInst &Inst) const {
+  MCRegister getADRReg(const MCInst &Inst) const {
     assert((isADR(Inst) || isADRP(Inst)) && "Not an ADR instruction");
     assert(MCPlus::getNumPrimeOperands(Inst) != 0 &&
            "No operands for ADR instruction");
@@ -734,7 +737,7 @@ public:
                                             MCContext *Ctx) const override {
     assert(isADR(ADRInst) && "ADR instruction expected");
 
-    const MCPhysReg Reg = getADRReg(ADRInst);
+    const MCRegister Reg = getADRReg(ADRInst);
     const MCSymbol *Target = getTargetSymbol(ADRInst);
     const uint64_t Addend = getTargetAddend(ADRInst);
     return materializeAddress(Target, Ctx, Reg, Addend);
@@ -746,13 +749,13 @@ public:
            "LDR (literal) or LDRSW (literal) expected");
     assert(LDRInst.getOperand(0).isReg() &&
            "unexpected operand in LDR instruction");
-    const MCPhysReg DataReg = LDRInst.getOperand(0).getReg();
-    MCPhysReg AddrReg;
+    const MCRegister DataReg = LDRInst.getOperand(0).getReg();
+    MCRegister AddrReg;
     unsigned OpCode;
     uint32_t RelType;
     switch (LDRInst.getOpcode()) {
     case AArch64::LDRWl:
-      AddrReg = (MCPhysReg)RegInfo->getMatchingSuperReg(
+      AddrReg = RegInfo->getMatchingSuperReg(
           DataReg, AArch64::sub_32,
           &RegInfo->getRegClass(AArch64::GPR64RegClassID));
       OpCode = AArch64::LDRWui;
@@ -1143,15 +1146,15 @@ public:
     for (const MCOperand &Operand : useOperands(Inst)) {
       if (!Operand.isReg())
         continue;
-      unsigned Reg = Operand.getReg();
+      MCRegister Reg = Operand.getReg();
       if (Reg == AArch64::SP || Reg == AArch64::WSP)
         return true;
     }
     return false;
   }
 
-  bool isRegToRegMove(const MCInst &Inst, MCPhysReg &From,
-                      MCPhysReg &To) const override {
+  bool isRegToRegMove(const MCInst &Inst, MCRegister &From,
+                      MCRegister &To) const override {
     if (Inst.getOpcode() == AArch64::FMOVDXr) {
       From = Inst.getOperand(1).getReg();
       To = Inst.getOperand(0).getReg();
@@ -1173,7 +1176,7 @@ public:
     return isIndirectCallOpcode(Inst.getOpcode());
   }
 
-  MCPhysReg getSpRegister(int Size) const {
+  MCRegister getSpRegister(int Size) const {
     switch (Size) {
     case 4:
       return AArch64::WSP;
@@ -1184,7 +1187,7 @@ public:
     }
   }
 
-  MCPhysReg getIntArgRegister(unsigned ArgNo) const override {
+  MCRegister getIntArgRegister(unsigned ArgNo) const override {
     switch (ArgNo) {
     case 0:
       return AArch64::X0;
@@ -1681,7 +1684,7 @@ public:
     // Match ADD that calculates the JumpTable Base Address (not the offset)
     SmallVector<MCInst *, 4> &UsesLoad = UDChain[DefLoad];
     const MCInst *DefJTBaseAdd = UsesLoad[1];
-    MCPhysReg From, To;
+    MCRegister From, To;
     if (DefJTBaseAdd == nullptr || isLoadFromStack(*DefJTBaseAdd) ||
         isRegToRegMove(*DefJTBaseAdd, From, To)) {
       // Sometimes base address may have been defined in another basic block
@@ -1726,7 +1729,7 @@ public:
   DenseMap<const MCInst *, SmallVector<MCInst *, 4>>
   computeLocalUDChain(const MCInst *CurInstr, InstructionIterator Begin,
                       InstructionIterator End) const {
-    DenseMap<int, MCInst *> RegAliasTable;
+    DenseMap<MCRegister, MCInst *> RegAliasTable;
     DenseMap<const MCInst *, SmallVector<MCInst *, 4>> Uses;
 
     auto addInstrOperands = [&](const MCInst &Instr) {
@@ -1734,7 +1737,7 @@ public:
       for (const MCOperand &Operand : MCPlus::primeOperands(Instr)) {
         if (!Operand.isReg())
           continue;
-        unsigned Reg = Operand.getReg();
+        MCRegister Reg = Operand.getReg();
         MCInst *AliasInst = RegAliasTable[Reg];
         Uses[&Instr].push_back(AliasInst);
         LLVM_DEBUG({
@@ -1787,13 +1790,13 @@ public:
   IndirectBranchType
   analyzeIndirectBranch(MCInst &Instruction, InstructionIterator Begin,
                         InstructionIterator End, const unsigned PtrSize,
-                        MCInst *&MemLocInstrOut, unsigned &BaseRegNumOut,
-                        unsigned &IndexRegNumOut, int64_t &DispValueOut,
+                        MCInst *&MemLocInstrOut, MCRegister &BaseRegOut,
+                        MCRegister &IndexRegOut, int64_t &DispValueOut,
                         const MCExpr *&DispExprOut, MCInst *&PCRelBaseOut,
                         MCInst *&FixedEntryLoadInstr) const override {
     MemLocInstrOut = nullptr;
-    BaseRegNumOut = AArch64::NoRegister;
-    IndexRegNumOut = AArch64::NoRegister;
+    BaseRegOut = MCRegister();
+    IndexRegOut = MCRegister();
     DispValueOut = 0;
     DispExprOut = nullptr;
     FixedEntryLoadInstr = nullptr;
@@ -2303,13 +2306,13 @@ public:
   // where cmp is an alias for subs, which results in the code below:
   // subs xzr, RegNo, #Imm
   // b.eq Target.
-  InstructionListType createCmpJE(MCPhysReg RegNo, int64_t Imm,
+  InstructionListType createCmpJE(MCRegister Reg, int64_t Imm,
                                   const MCSymbol *Target,
                                   MCContext *Ctx) const override {
     InstructionListType Code;
     Code.emplace_back(MCInstBuilder(AArch64::SUBSXri)
                           .addReg(AArch64::XZR)
-                          .addReg(RegNo)
+                          .addReg(Reg)
                           .addImm(Imm)
                           .addImm(0));
     Code.emplace_back(MCInstBuilder(AArch64::Bcc)
@@ -2325,13 +2328,13 @@ public:
   // where cmp is an alias for subs, which results in the code below:
   // subs xzr, RegNo, #Imm
   // b.ne Target.
-  InstructionListType createCmpJNE(MCPhysReg RegNo, int64_t Imm,
+  InstructionListType createCmpJNE(MCRegister Reg, int64_t Imm,
                                    const MCSymbol *Target,
                                    MCContext *Ctx) const override {
     InstructionListType Code;
     Code.emplace_back(MCInstBuilder(AArch64::SUBSXri)
                           .addReg(AArch64::XZR)
-                          .addReg(RegNo)
+                          .addReg(Reg)
                           .addImm(Imm)
                           .addImm(0));
     Code.emplace_back(MCInstBuilder(AArch64::Bcc)
@@ -2342,7 +2345,7 @@ public:
 
   // This helper function creates the snippet of code that compares a register
   // Reg1 with a register Reg2, and jumps to Target if they are not equal.
-  InstructionListType createCmpJNEWithReg(MCPhysReg Reg1, MCPhysReg Reg2,
+  InstructionListType createCmpJNEWithReg(MCRegister Reg1, MCRegister Reg2,
                                           const MCSymbol *Target,
                                           MCContext *Ctx) const override {
     InstructionListType Code;
@@ -2689,7 +2692,7 @@ public:
       if (!Operand.isReg())
         continue;
 
-      unsigned Reg = Operand.getReg();
+      MCRegister Reg = Operand.getReg();
       if (Reg == AArch64::SP || Reg == AArch64::WSP)
         return true;
     }
@@ -2831,7 +2834,7 @@ public:
     //  adrp ip0, imm
     //  add ip0, ip0, imm
     //  br ip0
-    MCPhysReg Reg = AArch64::X16;
+    MCRegister Reg = AArch64::X16;
     InstructionListType Insts = materializeAddress(Target, Ctx, Reg);
     Insts.emplace_back();
     MCInst &Inst = Insts.back();
@@ -2972,10 +2975,10 @@ public:
 
     assert(Adrp.getOperand(0).isReg() &&
            "Unexpected operand in ADRP instruction");
-    MCPhysReg AdrpReg = Adrp.getOperand(0).getReg();
+    MCRegister AdrpReg = Adrp.getOperand(0).getReg();
     assert(Add.getOperand(1).isReg() &&
            "Unexpected operand in ADDXri instruction");
-    MCPhysReg AddReg = Add.getOperand(1).getReg();
+    MCRegister AddReg = Add.getOperand(1).getReg();
     return AdrpReg == AddReg;
   }
 
@@ -3090,7 +3093,7 @@ public:
     Inst.addOperand(MCOperand::createImm(0));
   }
 
-  void createIndirectBranch(MCInst &Inst, MCPhysReg MemBaseReg,
+  void createIndirectBranch(MCInst &Inst, MCRegister MemBaseReg,
                             int64_t Disp) const {
     Inst.setOpcode(AArch64::BR);
     Inst.clear();
@@ -3142,7 +3145,7 @@ public:
     return createGetter(Ctx, "__bolt_instr_num_funcs");
   }
 
-  void convertIndirectCallToLoad(MCInst &Inst, MCPhysReg Reg) override {
+  void convertIndirectCallToLoad(MCInst &Inst, MCRegister Reg) override {
     bool IsTailCall = isTailCall(Inst);
     if (IsTailCall)
       removeAnnotation(Inst, MCPlus::MCAnnotation::kTailCall);
@@ -3156,7 +3159,7 @@ public:
     llvm_unreachable("not implemented");
   }
 
-  InstructionListType createLoadImmediate(const MCPhysReg Dest,
+  InstructionListType createLoadImmediate(const MCRegister Dest,
                                           uint64_t Imm) const override {
     if (RegInfo->getRegClass(AArch64::GPR64RegClassID).contains(Dest))
       return createMOVImm(Dest, 64, Imm);
@@ -3166,7 +3169,7 @@ public:
   }
 
   void createIndirectCallInst(MCInst &Inst, bool IsTailCall,
-                              MCPhysReg Reg) const {
+                              MCRegister Reg) const {
     Inst.clear();
     Inst.setOpcode(IsTailCall ? AArch64::BR : AArch64::BLR);
     Inst.addOperand(MCOperand::createReg(Reg));
@@ -3408,7 +3411,7 @@ public:
   }
 
   BlocksVectorTy indirectCallPromotion(
-      const MCInst &CallInst, MCPhysReg Reg,
+      const MCInst &CallInst, MCRegister Reg,
       const std::vector<std::pair<MCSymbol *, uint64_t>> &Targets,
       const std::vector<std::pair<MCSymbol *, uint64_t>> &VtableSyms,
       const std::vector<MCInst *> &MethodFetchInsns,
@@ -3428,7 +3431,7 @@ public:
     // MergeBlock remains null if CallInst is a tail call.
     MCSymbol *MergeBlock = nullptr;
 
-    MCPhysReg FuncAddrReg = Reg;
+    MCRegister FuncAddrReg = Reg;
 
     const bool LoadElim = !VtableSyms.empty();
     assert((!LoadElim || VtableSyms.size() == Targets.size()) &&
@@ -3443,7 +3446,7 @@ public:
 
     assert(CallInst.getOperand(0).isReg() &&
            "No register was found for indirect call.");
-    const MCPhysReg TargetReg = CallInst.getOperand(0).getReg();
+    const MCRegister TargetReg = CallInst.getOperand(0).getReg();
 
     const auto jumpToMergeBlock = [&](InstructionListType &NewCall) {
       assert(MergeBlock);
@@ -3585,7 +3588,7 @@ public:
              "Indirect branch needs to have 1 operand.");
       assert(Call.getOperand(0).isReg() &&
              "Indirect branch does not have a register operand.");
-      MCPhysReg Reg = Call.getOperand(0).getReg();
+      MCRegister Reg = Call.getOperand(0).getReg();
       if (Reg == AArch64::X16 || Reg == AArch64::X17)
         return isBTILandingPad(Pad, BTIKind::C) ||
                isBTILandingPad(Pad, BTIKind::J) ||
@@ -3623,7 +3626,7 @@ public:
              "Indirect branch needs to have 1 operand.");
       assert(Call.getOperand(0).isReg() &&
              "Indirect branch does not have a register operand.");
-      MCPhysReg Reg = Call.getOperand(0).getReg();
+      MCRegister Reg = Call.getOperand(0).getReg();
       if (Reg == AArch64::X16 || Reg == AArch64::X17) {
         // Add a new BTI c
         MCInst BTIInst;
@@ -3644,7 +3647,7 @@ public:
   }
 
   InstructionListType materializeAddress(const MCSymbol *Target, MCContext *Ctx,
-                                         MCPhysReg RegName,
+                                         MCRegister RegName,
                                          int64_t Addend = 0) const override {
     // Get page-aligned address and add page offset
     InstructionListType Insts(2);
@@ -3722,12 +3725,13 @@ public:
   }
 
   std::optional<uint64_t>
-  extractMoveImmediate(const MCInst &Inst, MCPhysReg TargetReg) const override {
+  extractMoveImmediate(const MCInst &Inst,
+                       MCRegister TargetReg) const override {
     // Match MOVZ instructions (both X and W register variants) with no shift.
     if ((Inst.getOpcode() == AArch64::MOVZXi ||
          Inst.getOpcode() == AArch64::MOVZWi) &&
         Inst.getOperand(2).getImm() == 0 &&
-        getAliases(TargetReg)[Inst.getOperand(0).getReg()])
+        getAliases(TargetReg)[Inst.getOperand(0).getReg().id()])
       return Inst.getOperand(1).getImm();
     return std::nullopt;
   }
@@ -3735,7 +3739,7 @@ public:
   std::optional<uint64_t>
   findMemcpySizeInBytes(const BinaryBasicBlock &BB,
                         InstructionListType::iterator CallInst) const override {
-    MCPhysReg SizeReg = getIntArgRegister(2);
+    MCRegister SizeReg = getIntArgRegister(2);
     if (SizeReg == getNoRegister())
       return std::nullopt;
 

--- a/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
+++ b/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
@@ -187,12 +187,12 @@ public:
 
   IndirectBranchType analyzeIndirectBranch(
       MCInst &Instruction, InstructionIterator Begin, InstructionIterator End,
-      const unsigned PtrSize, MCInst *&MemLocInstr, unsigned &BaseRegNum,
-      unsigned &IndexRegNum, int64_t &DispValue, const MCExpr *&DispExpr,
+      const unsigned PtrSize, MCInst *&MemLocInstr, MCRegister &BaseReg,
+      MCRegister &IndexReg, int64_t &DispValue, const MCExpr *&DispExpr,
       MCInst *&PCRelBaseOut, MCInst *&FixedEntryLoadInst) const override {
     MemLocInstr = nullptr;
-    BaseRegNum = 0;
-    IndexRegNum = 0;
+    BaseReg = MCRegister();
+    IndexReg = MCRegister();
     DispValue = 0;
     DispExpr = nullptr;
     PCRelBaseOut = nullptr;
@@ -529,12 +529,12 @@ public:
                .addImm(imm);
   }
 
-  void loadReg(MCInst &Inst, MCPhysReg To, MCPhysReg From,
+  void loadReg(MCInst &Inst, MCRegister To, MCRegister From,
                int64_t offset) const {
     Inst = MCInstBuilder(loadOpc()).addReg(To).addReg(From).addImm(offset);
   }
 
-  void storeReg(MCInst &Inst, MCPhysReg From, MCPhysReg To,
+  void storeReg(MCInst &Inst, MCRegister From, MCRegister To,
                 int64_t offset) const {
     Inst = MCInstBuilder(storeOpc()).addReg(From).addReg(To).addImm(offset);
   }
@@ -565,19 +565,19 @@ public:
     createStackPointerDecrement(Insts.back(), Regs.size() * regSize());
   }
 
-  void atomicAdd(MCInst &Inst, MCPhysReg RegAtomic, MCPhysReg RegTo,
-                 MCPhysReg RegCnt) const {
+  void atomicAdd(MCInst &Inst, MCRegister RegAtomic, MCRegister RegTo,
+                 MCRegister RegCnt) const {
     Inst = MCInstBuilder(atomicAddOpc())
                .addReg(RegAtomic)
                .addReg(RegCnt)
                .addReg(RegTo);
   }
 
-  InstructionListType createRegCmpJE(MCPhysReg RegNo, const MCSymbol *Target,
+  InstructionListType createRegCmpJE(MCRegister Reg, const MCSymbol *Target,
                                      MCContext *Ctx) const {
     InstructionListType Insts;
     Insts.emplace_back(MCInstBuilder(RISCV::BEQ)
-                           .addReg(RegNo)
+                           .addReg(Reg)
                            .addReg(RISCV::X0)
                            .addExpr(MCSymbolRefExpr::create(Target, *Ctx)));
     return Insts;
@@ -602,7 +602,7 @@ public:
     //  auipc   a5, hi20(Target)
     //  addi    a5, a5, low12(Target)
     //  jr x5 => jalr x0, x5, 0
-    MCPhysReg Reg = RISCV::X5;
+    MCRegister Reg = RISCV::X5;
     InstructionListType Insts = materializeAddress(Target, Ctx, Reg);
     Insts.emplace_back();
     MCInst &Inst = Insts.back();
@@ -623,8 +623,8 @@ public:
     return Insts;
   }
 
-  InstructionListType createIncMemory(MCPhysReg RegTo, MCPhysReg RegCnt,
-                                      MCPhysReg RegAtomic) const {
+  InstructionListType createIncMemory(MCRegister RegTo, MCRegister RegCnt,
+                                      MCRegister RegAtomic) const {
     InstructionListType Insts;
     Insts.emplace_back();
     Insts.back() =
@@ -635,7 +635,7 @@ public:
   }
 
   InstructionListType materializeAddress(const MCSymbol *Target, MCContext *Ctx,
-                                         MCPhysReg RegName,
+                                         MCRegister RegName,
                                          int64_t Addend = 0) const override {
     // Get the symbol address by auipc + addi
     InstructionListType Insts(2);
@@ -695,7 +695,7 @@ public:
     }
   }
 
-  void createIndirectCallInst(MCInst &Inst, bool IsTailCall, MCPhysReg Reg,
+  void createIndirectCallInst(MCInst &Inst, bool IsTailCall, MCRegister Reg,
                               int64_t Disp) const {
     Inst.clear();
     Inst.setOpcode(RISCV::JALR);
@@ -797,7 +797,7 @@ public:
     return createGetter(Ctx, "__bolt_instr_num_funcs");
   }
 
-  void convertIndirectCallToLoad(MCInst &Inst, MCPhysReg Reg) override {
+  void convertIndirectCallToLoad(MCInst &Inst, MCRegister Reg) override {
     bool IsTailCall = isTailCall(Inst);
     if (IsTailCall)
       removeAnnotation(Inst, MCPlus::MCAnnotation::kTailCall);
@@ -806,7 +806,7 @@ public:
     Inst.insert(Inst.begin() + 1, MCOperand::createReg(RISCV::X0));
   }
 
-  InstructionListType createLoadImmediate(const MCPhysReg Dest,
+  InstructionListType createLoadImmediate(const MCRegister Dest,
                                           uint64_t Imm) const override {
     InstructionListType Insts;
     // get IMM higher 32bit

--- a/bolt/lib/Target/X86/X86MCPlusBuilder.cpp
+++ b/bolt/lib/Target/X86/X86MCPlusBuilder.cpp
@@ -1482,8 +1482,7 @@ public:
   /// TODO: this implementation currently works for the most common opcodes that
   /// load from memory. It can be extended to work with memory store opcodes as
   /// well as more memory load opcodes.
-  bool replaceMemOperandWithReg(MCInst &Inst,
-                                MCRegister Reg) const override {
+  bool replaceMemOperandWithReg(MCInst &Inst, MCRegister Reg) const override {
     unsigned NewOpcode;
 
     switch (Inst.getOpcode()) {
@@ -2290,9 +2289,8 @@ public:
     Inst.addOperand(MCOperand::createReg(SrcReg));
   }
 
-  void createRestoreFromStack(MCInst &Inst, MCRegister StackReg,
-                              int Offset, MCRegister DstReg,
-                              int Size) const override {
+  void createRestoreFromStack(MCInst &Inst, MCRegister StackReg, int Offset,
+                              MCRegister DstReg, int Size) const override {
     return createLoad(Inst, StackReg, /*Scale=*/1, /*IndexReg=*/MCRegister(),
                       Offset, nullptr, /*AddrSegmentReg=*/MCRegister(), DstReg,
                       Size);

--- a/bolt/lib/Target/X86/X86MCPlusBuilder.cpp
+++ b/bolt/lib/Target/X86/X86MCPlusBuilder.cpp
@@ -67,15 +67,14 @@ static InstructionListType createIncMemory(const MCSymbol *Target,
   Insts.emplace_back();
   Insts.back().setOpcode(X86::LOCK_INC64m);
   Insts.back().clear();
-  Insts.back().addOperand(MCOperand::createReg(X86::RIP));        // BaseReg
-  Insts.back().addOperand(MCOperand::createImm(1));               // ScaleAmt
-  Insts.back().addOperand(MCOperand::createReg(X86::NoRegister)); // IndexReg
+  Insts.back().addOperand(MCOperand::createReg(X86::RIP));     // BaseReg
+  Insts.back().addOperand(MCOperand::createImm(1));            // ScaleAmt
+  Insts.back().addOperand(MCOperand::createReg(MCRegister())); // IndexReg
 
   Insts.back().addOperand(
       MCOperand::createExpr(MCSymbolRefExpr::create(Target,
                                                     *Ctx))); // Displacement
-  Insts.back().addOperand(
-      MCOperand::createReg(X86::NoRegister)); // AddrSegmentReg
+  Insts.back().addOperand(MCOperand::createReg(MCRegister())); // AddrSegmentReg
   return Insts;
 }
 
@@ -628,10 +627,8 @@ public:
         return false;
 
       if (CurInst->getOperand(1 + X86::AddrScaleAmt).getImm() != 1 ||
-          CurInst->getOperand(1 + X86::AddrIndexReg).getReg() !=
-              X86::NoRegister ||
-          (CurInst->getOperand(1 + X86::AddrBaseReg).getReg() !=
-               X86::NoRegister &&
+          CurInst->getOperand(1 + X86::AddrIndexReg).getReg() ||
+          (CurInst->getOperand(1 + X86::AddrBaseReg).getReg() &&
            CurInst->getOperand(1 + X86::AddrBaseReg).getReg() != X86::RIP))
         return false;
 
@@ -693,12 +690,12 @@ public:
       return std::nullopt;
 
     X86MemOperand MO;
-    MO.BaseRegNum = Base.getReg();
+    MO.BaseReg = Base.getReg();
     MO.ScaleImm = Scale.getImm();
-    MO.IndexRegNum = Index.getReg();
+    MO.IndexReg = Index.getReg();
     MO.DispImm = Disp.isImm() ? Disp.getImm() : 0;
     MO.DispExpr = Disp.isExpr() ? Disp.getExpr() : nullptr;
-    MO.SegRegNum = Segment.getReg();
+    MO.SegReg = Segment.getReg();
     return MO;
   }
 
@@ -710,13 +707,12 @@ public:
       return false;
 
     // Make sure it's a well-formed addressing we can statically evaluate.
-    if ((MO->BaseRegNum != X86::RIP && MO->BaseRegNum != X86::NoRegister) ||
-        MO->IndexRegNum != X86::NoRegister ||
-        MO->SegRegNum != X86::NoRegister || MO->DispExpr)
+    if ((MO->BaseReg != X86::RIP && MO->BaseReg) || MO->IndexReg ||
+        MO->SegReg || MO->DispExpr)
       return false;
 
     Target = MO->DispImm;
-    if (MO->BaseRegNum == X86::RIP) {
+    if (MO->BaseReg == X86::RIP) {
       assert(Size != 0 && "instruction size required in order to statically "
                           "evaluate RIP-relative address");
       Target += Address + Size;
@@ -847,14 +843,14 @@ public:
     Regs |= getAliases(X86::RCX);
   }
 
-  MCPhysReg getAliasSized(MCPhysReg Reg, uint8_t Size) const override {
+  MCRegister getAliasSized(MCRegister Reg, uint8_t Size) const override {
     Reg = getX86SubSuperRegister(Reg, Size * 8);
-    assert((Reg != X86::NoRegister) && "Invalid register");
+    assert(Reg && "Invalid register");
     return Reg;
   }
 
-  bool isUpper8BitReg(MCPhysReg Reg) const override {
-    switch (Reg) {
+  bool isUpper8BitReg(MCRegister Reg) const override {
+    switch (Reg.id()) {
     case X86::AH:
     case X86::BH:
     case X86::CH:
@@ -920,9 +916,10 @@ public:
   /// disable not only shrink wrapping but all frame analysis, it will fail it
   /// as "we don't understand this function and we give up on it".
   bool isStackAccess(const MCInst &Inst, bool &IsLoad, bool &IsStore,
-                     bool &IsStoreFromReg, MCPhysReg &Reg, int32_t &SrcImm,
-                     uint16_t &StackPtrReg, int64_t &StackOffset, uint8_t &Size,
-                     bool &IsSimple, bool &IsIndexed) const override {
+                     bool &IsStoreFromReg, MCRegister &Reg, int32_t &SrcImm,
+                     MCRegister &StackPtrReg, int64_t &StackOffset,
+                     uint8_t &Size, bool &IsSimple,
+                     bool &IsIndexed) const override {
     // Detect simple push/pop cases first
     if (int Sz = getPushSize(Inst)) {
       IsLoad = false;
@@ -1007,7 +1004,7 @@ public:
     }
 
     // Make sure it's a stack access
-    if (MO->BaseRegNum != X86::RBP && MO->BaseRegNum != X86::RSP)
+    if (MO->BaseReg != X86::RBP && MO->BaseReg != X86::RSP)
       return false;
 
     IsLoad = I.IsLoad;
@@ -1015,10 +1012,9 @@ public:
     IsStoreFromReg = I.StoreFromReg;
     Size = I.DataSize;
     IsSimple = I.Simple;
-    StackPtrReg = MO->BaseRegNum;
+    StackPtrReg = MO->BaseReg;
     StackOffset = MO->DispImm;
-    IsIndexed =
-        MO->IndexRegNum != X86::NoRegister || MO->SegRegNum != X86::NoRegister;
+    IsIndexed = MO->IndexReg || MO->SegReg;
 
     if (!I.Simple)
       return true;
@@ -1076,7 +1072,7 @@ public:
       return;
     }
     // Make sure it's a stack access
-    if (MO->BaseRegNum != X86::RBP && MO->BaseRegNum != X86::RSP) {
+    if (MO->BaseReg != X86::RBP && MO->BaseReg != X86::RSP) {
       llvm_unreachable("Not a stack access");
       return;
     }
@@ -1091,10 +1087,10 @@ public:
       default:
         llvm_unreachable("Unexpected size");
       }
-      unsigned RegOpndNum = Inst.getOperand(0).getReg();
+      MCRegister RegOpnd = Inst.getOperand(0).getReg();
       Inst.clear();
       Inst.setOpcode(NewOpcode);
-      Inst.addOperand(MCOperand::createReg(RegOpndNum));
+      Inst.addOperand(MCOperand::createReg(RegOpnd));
     } else {
       MCOperand SrcOpnd =
           Inst.getOperand(MemOpOffset + X86::AddrSegmentReg + 1);
@@ -1107,10 +1103,10 @@ public:
           llvm_unreachable("Unexpected size");
         }
         assert(SrcOpnd.isReg() && "Unexpected source operand");
-        unsigned RegOpndNum = SrcOpnd.getReg();
+        MCRegister RegOpnd = SrcOpnd.getReg();
         Inst.clear();
         Inst.setOpcode(NewOpcode);
-        Inst.addOperand(MCOperand::createReg(RegOpndNum));
+        Inst.addOperand(MCOperand::createReg(RegOpnd));
       } else {
         switch (I.DataSize) {
         case 2: NewOpcode = X86::PUSH16i8; break;
@@ -1145,12 +1141,12 @@ public:
     });
   }
 
-  bool
-  evaluateStackOffsetExpr(const MCInst &Inst, int64_t &Output,
-                          std::pair<MCPhysReg, int64_t> Input1,
-                          std::pair<MCPhysReg, int64_t> Input2) const override {
+  bool evaluateStackOffsetExpr(
+      const MCInst &Inst, int64_t &Output,
+      std::pair<MCRegister, int64_t> Input1,
+      std::pair<MCRegister, int64_t> Input2) const override {
 
-    auto getOperandVal = [&](MCPhysReg Reg) -> ErrorOr<int64_t> {
+    auto getOperandVal = [&](MCRegister Reg) -> ErrorOr<int64_t> {
       if (Reg == Input1.first)
         return Input1.second;
       if (Reg == Input2.first)
@@ -1196,12 +1192,10 @@ public:
       if (!MO)
         return false;
 
-      if (MO->BaseRegNum == X86::NoRegister ||
-          MO->IndexRegNum != X86::NoRegister ||
-          MO->SegRegNum != X86::NoRegister || MO->DispExpr)
+      if (!MO->BaseReg || MO->IndexReg || MO->SegReg || MO->DispExpr)
         return false;
 
-      if (ErrorOr<int64_t> InputVal = getOperandVal(MO->BaseRegNum))
+      if (ErrorOr<int64_t> InputVal = getOperandVal(MO->BaseReg))
         Output = *InputVal + MO->DispImm;
       else
         return false;
@@ -1212,8 +1206,8 @@ public:
     return true;
   }
 
-  bool isRegToRegMove(const MCInst &Inst, MCPhysReg &From,
-                      MCPhysReg &To) const override {
+  bool isRegToRegMove(const MCInst &Inst, MCRegister &From,
+                      MCRegister &To) const override {
     switch (Inst.getOpcode()) {
     default:
       return false;
@@ -1229,9 +1223,9 @@ public:
     }
   }
 
-  MCPhysReg getStackPointer() const override { return X86::RSP; }
-  MCPhysReg getFramePointer() const override { return X86::RBP; }
-  MCPhysReg getFlagsReg() const override { return X86::EFLAGS; }
+  MCRegister getStackPointer() const override { return X86::RSP; }
+  MCRegister getFramePointer() const override { return X86::RBP; }
+  MCRegister getFlagsReg() const override { return X86::EFLAGS; }
 
   bool escapesVariable(const MCInst &Inst,
                        bool HasFramePointer) const override {
@@ -1263,11 +1257,13 @@ public:
         continue;
 
       const MCOperand &Operand = Inst.getOperand(I);
-      if (HasFramePointer && Operand.isReg() && SPBPAliases[Operand.getReg()]) {
+      if (HasFramePointer && Operand.isReg() &&
+          SPBPAliases[Operand.getReg().id()]) {
         DoesLeak = true;
         break;
       }
-      if (!HasFramePointer && Operand.isReg() && SPAliases[Operand.getReg()]) {
+      if (!HasFramePointer && Operand.isReg() &&
+          SPAliases[Operand.getReg().id()]) {
         DoesLeak = true;
         break;
       }
@@ -1277,8 +1273,8 @@ public:
     if (DoesLeak) {
       DoesLeak = !any_of(defOperands(Inst), [&](const MCOperand &Operand) {
         assert(Operand.isReg());
-        MCPhysReg Reg = Operand.getReg();
-        return HasFramePointer ? SPBPAliases[Reg] : SPAliases[Reg];
+        MCRegister Reg = Operand.getReg();
+        return HasFramePointer ? SPBPAliases[Reg.id()] : SPAliases[Reg.id()];
       });
     }
     return DoesLeak;
@@ -1486,7 +1482,8 @@ public:
   /// TODO: this implementation currently works for the most common opcodes that
   /// load from memory. It can be extended to work with memory store opcodes as
   /// well as more memory load opcodes.
-  bool replaceMemOperandWithReg(MCInst &Inst, MCPhysReg RegNum) const override {
+  bool replaceMemOperandWithReg(MCInst &Inst,
+                                MCRegister Reg) const override {
     unsigned NewOpcode;
 
     switch (Inst.getOpcode()) {
@@ -1508,7 +1505,7 @@ public:
     }
 
     // Modify the instruction.
-    MCOperand RegOp = MCOperand::createReg(RegNum);
+    MCOperand RegOp = MCOperand::createReg(Reg);
     MCOperand TargetOp = Inst.getOperand(0);
     Inst.clear();
     Inst.setOpcode(NewOpcode);
@@ -1638,12 +1635,12 @@ public:
     // the instruction.
     Inst.erase(Inst.begin());
     Inst.insert(Inst.begin(),
-                MCOperand::createReg(X86::NoRegister)); // AddrSegmentReg
+                MCOperand::createReg(MCRegister())); // AddrSegmentReg
     Inst.insert(Inst.begin(),
                 MCOperand::createExpr( // Displacement
                     MCSymbolRefExpr::create(TargetLocation, *Ctx)));
     Inst.insert(Inst.begin(),
-                MCOperand::createReg(X86::NoRegister)); // IndexReg
+                MCOperand::createReg(MCRegister())); // IndexReg
     Inst.insert(Inst.begin(),
                 MCOperand::createImm(1));               // ScaleAmt
     Inst.insert(Inst.begin(),
@@ -1653,7 +1650,7 @@ public:
     return Code;
   }
 
-  void convertIndirectCallToLoad(MCInst &Inst, MCPhysReg Reg) override {
+  void convertIndirectCallToLoad(MCInst &Inst, MCRegister Reg) override {
     bool IsTailCall = isTailCall(Inst);
     if (IsTailCall)
       removeAnnotation(Inst, MCPlus::MCAnnotation::kTailCall);
@@ -1692,12 +1689,12 @@ public:
 
     // Check and remove EIZ/RIZ. These cases represent ambiguous cases where
     // SIB byte is present, but no index is used and modrm alone should have
-    // been enough. Converting to NoRegister effectively removes the SIB byte.
+    // been enough. Converting to MCRegister() effectively removes the SIB byte.
     if (MemOpNo >= 0) {
       MCOperand &IndexOp =
           Inst.getOperand(static_cast<unsigned>(MemOpNo) + X86::AddrIndexReg);
       if (IndexOp.getReg() == X86::EIZ || IndexOp.getReg() == X86::RIZ)
-        IndexOp = MCOperand::createReg(X86::NoRegister);
+        IndexOp = MCOperand::createReg(MCRegister());
     }
 
     if (isBranch(Inst)) {
@@ -1743,9 +1740,9 @@ public:
 
       // If stack memory operands are allowed, check if it's a load from stack
       bool IsLoad, IsStore, IsStoreFromReg, IsSimple, IsIndexed;
-      MCPhysReg Reg;
+      MCRegister Reg;
       int32_t SrcImm;
-      uint16_t StackPtrReg;
+      MCRegister StackPtrReg;
       int64_t StackOffset;
       uint8_t Size;
       bool IsStackAccess =
@@ -1875,7 +1872,7 @@ public:
   /// (POSSIBLE_PIC_FIXED_BRANCH case).
   template <typename Itr>
   std::tuple<IndirectBranchType, MCInst *, MCInst *>
-  analyzePICJumpTable(Itr II, Itr IE, MCPhysReg R1, MCPhysReg R2) const {
+  analyzePICJumpTable(Itr II, Itr IE, MCRegister R1, MCRegister R2) const {
     // Analyze PIC-style jump table code template:
     //
     //    lea PIC_JUMP_TABLE(%rip), {%r1|%r2}     <- MemLocInstr
@@ -1919,15 +1916,13 @@ public:
     auto isRIPRel = [&](X86MemOperand &MO) {
       // NB: DispExpr should be set
       return MO.DispExpr != nullptr &&
-             MO.BaseRegNum == RegInfo->getProgramCounter() &&
-             MO.IndexRegNum == X86::NoRegister &&
-             MO.SegRegNum == X86::NoRegister;
+             MO.BaseReg == RegInfo->getProgramCounter() && !MO.IndexReg &&
+             !MO.SegReg;
     };
-    auto isIndexed = [](X86MemOperand &MO, MCPhysReg R) {
-      // NB: IndexRegNum should be set.
-      return MO.IndexRegNum != X86::NoRegister && MO.BaseRegNum == R &&
-             MO.ScaleImm == 4 && MO.DispImm == 0 &&
-             MO.SegRegNum == X86::NoRegister;
+    auto isIndexed = [](X86MemOperand &MO, MCRegister R) {
+      // NB: IndexReg should be set.
+      return MO.IndexReg && MO.BaseReg == R && MO.ScaleImm == 4 &&
+             MO.DispImm == 0 && !MO.SegReg;
     };
     LLVM_DEBUG(dbgs() << "Checking for PIC jump table\n");
     MCInst *FirstInstr = nullptr;
@@ -1958,8 +1953,8 @@ public:
         // Check if the first instruction is setting %r1 or %r2. In canonical
         // form lea sets %r1 and mov sets %r2. If it's the opposite - rename so
         // we have to only check a single form.
-        unsigned DestReg = Instr.getOperand(0).getReg();
-        MCPhysReg &ExpectReg = MatchingState == MATCH_JUMP_TABLE ? R2 : R1;
+        MCRegister DestReg = Instr.getOperand(0).getReg();
+        MCRegister &ExpectReg = MatchingState == MATCH_JUMP_TABLE ? R2 : R1;
         if (DestReg != ExpectReg)
           std::swap(R1, R2);
         if (DestReg != ExpectReg)
@@ -1975,7 +1970,7 @@ public:
         else
           break;
       } else {
-        unsigned ExpectReg = MatchingState == MATCH_JUMP_TABLE ? R1 : R2;
+        MCRegister ExpectReg = MatchingState == MATCH_JUMP_TABLE ? R1 : R2;
         if (!InstrDesc.hasDefOfPhysReg(Instr, ExpectReg, *RegInfo))
           continue;
         if ((MatchingState == MATCH_JUMP_TABLE && !IsLEAInstr) ||
@@ -2011,8 +2006,8 @@ public:
   IndirectBranchType
   analyzeIndirectBranch(MCInst &Instruction, InstructionIterator Begin,
                         InstructionIterator End, const unsigned PtrSize,
-                        MCInst *&MemLocInstrOut, unsigned &BaseRegNumOut,
-                        unsigned &IndexRegNumOut, int64_t &DispValueOut,
+                        MCInst *&MemLocInstrOut, MCRegister &BaseRegOut,
+                        MCRegister &IndexRegOut, int64_t &DispValueOut,
                         const MCExpr *&DispExprOut, MCInst *&PCRelBaseOut,
                         MCInst *&FixedEntryLoadInst) const override {
     // Try to find a (base) memory location from where the address for
@@ -2037,8 +2032,8 @@ public:
     // We handle PIC-style jump tables separately.
     //
     MemLocInstrOut = nullptr;
-    BaseRegNumOut = X86::NoRegister;
-    IndexRegNumOut = X86::NoRegister;
+    BaseRegOut = MCRegister();
+    IndexRegOut = MCRegister();
     DispValueOut = 0;
     DispExprOut = nullptr;
     FixedEntryLoadInst = nullptr;
@@ -2057,7 +2052,7 @@ public:
       // If the indirect jump is on register - try to detect if the
       // register value is loaded from a memory location.
       assert(Instruction.getOperand(0).isReg() && "register operand expected");
-      const unsigned R1 = Instruction.getOperand(0).getReg();
+      const MCRegister R1 = Instruction.getOperand(0).getReg();
       // Check if one of the previous instructions defines the jump-on register.
       for (auto PrevII = II; PrevII != IE; ++PrevII) {
         MCInst &PrevInstr = *PrevII;
@@ -2071,7 +2066,7 @@ public:
           break;
         }
         if (isADD64rr(PrevInstr)) {
-          unsigned R2 = PrevInstr.getOperand(2).getReg();
+          MCRegister R2 = PrevInstr.getOperand(2).getReg();
           if (R1 == R2)
             return IndirectBranchType::UNKNOWN;
           std::tie(Type, MemLocInstr, FixedEntryLoadInst) =
@@ -2099,24 +2094,22 @@ public:
     if (!MO)
       return IndirectBranchType::UNKNOWN;
 
-    BaseRegNumOut = MO->BaseRegNum;
-    IndexRegNumOut = MO->IndexRegNum;
+    BaseRegOut = MO->BaseReg;
+    IndexRegOut = MO->IndexReg;
     DispValueOut = MO->DispImm;
     DispExprOut = MO->DispExpr;
 
-    if ((MO->BaseRegNum != X86::NoRegister && MO->BaseRegNum != RIPRegister) ||
-        MO->SegRegNum != X86::NoRegister)
+    if ((MO->BaseReg && MO->BaseReg != RIPRegister) || MO->SegReg)
       return IndirectBranchType::UNKNOWN;
 
-    if (MemLocInstr == &Instruction &&
-        (!MO->ScaleImm || MO->IndexRegNum == X86::NoRegister)) {
+    if (MemLocInstr == &Instruction && (!MO->ScaleImm || !MO->IndexReg)) {
       MemLocInstrOut = MemLocInstr;
       return IndirectBranchType::POSSIBLE_FIXED_BRANCH;
     }
 
     switch (Type) {
     case IndirectBranchType::POSSIBLE_PIC_JUMP_TABLE:
-      if (MO->ScaleImm != 1 || MO->BaseRegNum != RIPRegister)
+      if (MO->ScaleImm != 1 || MO->BaseReg != RIPRegister)
         return IndirectBranchType::UNKNOWN;
       break;
     case IndirectBranchType::POSSIBLE_PIC_FIXED_BRANCH:
@@ -2155,10 +2148,10 @@ public:
   bool analyzeVirtualMethodCall(InstructionIterator ForwardBegin,
                                 InstructionIterator ForwardEnd,
                                 std::vector<MCInst *> &MethodFetchInsns,
-                                unsigned &VtableRegNum, unsigned &MethodRegNum,
+                                MCRegister &VtableReg, MCRegister &MethodReg,
                                 uint64_t &MethodOffset) const override {
-    VtableRegNum = X86::NoRegister;
-    MethodRegNum = X86::NoRegister;
+    VtableReg = MCRegister();
+    MethodReg = MCRegister();
     MethodOffset = 0;
 
     std::reverse_iterator<InstructionIterator> Itr(ForwardEnd);
@@ -2169,12 +2162,11 @@ public:
 
     // The call can just be jmp offset(reg)
     if (std::optional<X86MemOperand> MO = evaluateX86MemoryOperand(CallInst)) {
-      if (!MO->DispExpr && MO->BaseRegNum != X86::RIP &&
-          MO->BaseRegNum != X86::RBP && MO->BaseRegNum != X86::NoRegister) {
-        MethodRegNum = MO->BaseRegNum;
-        if (MO->ScaleImm == 1 && MO->IndexRegNum == X86::NoRegister &&
-            MO->SegRegNum == X86::NoRegister) {
-          VtableRegNum = MethodRegNum;
+      if (!MO->DispExpr && MO->BaseReg != X86::RIP && MO->BaseReg != X86::RBP &&
+          MO->BaseReg) {
+        MethodReg = MO->BaseReg;
+        if (MO->ScaleImm == 1 && !MO->IndexReg && !MO->SegReg) {
+          VtableReg = MethodReg;
           MethodOffset = MO->DispImm;
           MethodFetchInsns.push_back(&CallInst);
           return true;
@@ -2183,13 +2175,13 @@ public:
       return false;
     }
     if (CallInst.getOperand(0).isReg())
-      MethodRegNum = CallInst.getOperand(0).getReg();
+      MethodReg = CallInst.getOperand(0).getReg();
     else
       return false;
 
-    if (MethodRegNum == X86::RIP || MethodRegNum == X86::RBP) {
-      VtableRegNum = X86::NoRegister;
-      MethodRegNum = X86::NoRegister;
+    if (MethodReg == X86::RIP || MethodReg == X86::RBP) {
+      VtableReg = MCRegister();
+      MethodReg = MCRegister();
       return false;
     }
 
@@ -2197,17 +2189,15 @@ public:
     while (Itr != End) {
       MCInst &CurInst = *Itr++;
       const MCInstrDesc &Desc = Info->get(CurInst.getOpcode());
-      if (Desc.hasDefOfPhysReg(CurInst, MethodRegNum, *RegInfo)) {
+      if (Desc.hasDefOfPhysReg(CurInst, MethodReg, *RegInfo)) {
         if (!mayLoad(CurInst))
           return false;
         if (std::optional<X86MemOperand> MO =
                 evaluateX86MemoryOperand(CurInst)) {
-          if (!MO->DispExpr && MO->ScaleImm == 1 &&
-              MO->BaseRegNum != X86::RIP && MO->BaseRegNum != X86::RBP &&
-              MO->BaseRegNum != X86::NoRegister &&
-              MO->IndexRegNum == X86::NoRegister &&
-              MO->SegRegNum == X86::NoRegister) {
-            VtableRegNum = MO->BaseRegNum;
+          if (!MO->DispExpr && MO->ScaleImm == 1 && MO->BaseReg != X86::RIP &&
+              MO->BaseReg != X86::RBP && MO->BaseReg && !MO->IndexReg &&
+              !MO->SegReg) {
+            VtableReg = MO->BaseReg;
             MethodOffset = MO->DispImm;
             MethodFetchInsns.push_back(&CurInst);
             if (MethodOffset != 0)
@@ -2219,14 +2209,14 @@ public:
       }
     }
 
-    if (!VtableRegNum)
+    if (!VtableReg)
       return false;
 
     // look for any adds affecting the method register.
     while (Itr != End) {
       MCInst &CurInst = *Itr++;
       const MCInstrDesc &Desc = Info->get(CurInst.getOpcode());
-      if (Desc.hasDefOfPhysReg(CurInst, VtableRegNum, *RegInfo)) {
+      if (Desc.hasDefOfPhysReg(CurInst, VtableReg, *RegInfo)) {
         if (isADDri(CurInst)) {
           assert(!MethodOffset);
           MethodOffset = CurInst.getOperand(2).getImm();
@@ -2245,11 +2235,11 @@ public:
       Inst.setOpcode(X86::LEA64r);
       Inst.clear();
       Inst.addOperand(MCOperand::createReg(X86::RSP));
-      Inst.addOperand(MCOperand::createReg(X86::RSP));        // BaseReg
-      Inst.addOperand(MCOperand::createImm(1));               // ScaleAmt
-      Inst.addOperand(MCOperand::createReg(X86::NoRegister)); // IndexReg
-      Inst.addOperand(MCOperand::createImm(-Size));           // Displacement
-      Inst.addOperand(MCOperand::createReg(X86::NoRegister)); // AddrSegmentReg
+      Inst.addOperand(MCOperand::createReg(X86::RSP));     // BaseReg
+      Inst.addOperand(MCOperand::createImm(1));            // ScaleAmt
+      Inst.addOperand(MCOperand::createReg(MCRegister())); // IndexReg
+      Inst.addOperand(MCOperand::createImm(-Size));        // Displacement
+      Inst.addOperand(MCOperand::createReg(MCRegister())); // AddrSegmentReg
       return;
     }
     Inst.setOpcode(X86::SUB64ri8);
@@ -2265,11 +2255,11 @@ public:
       Inst.setOpcode(X86::LEA64r);
       Inst.clear();
       Inst.addOperand(MCOperand::createReg(X86::RSP));
-      Inst.addOperand(MCOperand::createReg(X86::RSP));        // BaseReg
-      Inst.addOperand(MCOperand::createImm(1));               // ScaleAmt
-      Inst.addOperand(MCOperand::createReg(X86::NoRegister)); // IndexReg
-      Inst.addOperand(MCOperand::createImm(Size));            // Displacement
-      Inst.addOperand(MCOperand::createReg(X86::NoRegister)); // AddrSegmentReg
+      Inst.addOperand(MCOperand::createReg(X86::RSP));     // BaseReg
+      Inst.addOperand(MCOperand::createImm(1));            // ScaleAmt
+      Inst.addOperand(MCOperand::createReg(MCRegister())); // IndexReg
+      Inst.addOperand(MCOperand::createImm(Size));         // Displacement
+      Inst.addOperand(MCOperand::createReg(MCRegister())); // AddrSegmentReg
       return;
     }
     Inst.setOpcode(X86::ADD64ri8);
@@ -2279,8 +2269,8 @@ public:
     Inst.addOperand(MCOperand::createImm(Size));
   }
 
-  void createSaveToStack(MCInst &Inst, const MCPhysReg &StackReg, int Offset,
-                         const MCPhysReg &SrcReg, int Size) const override {
+  void createSaveToStack(MCInst &Inst, MCRegister StackReg, int Offset,
+                         MCRegister SrcReg, int Size) const override {
     unsigned NewOpcode;
     switch (Size) {
     default:
@@ -2292,26 +2282,26 @@ public:
     }
     Inst.setOpcode(NewOpcode);
     Inst.clear();
-    Inst.addOperand(MCOperand::createReg(StackReg));        // BaseReg
-    Inst.addOperand(MCOperand::createImm(1));               // ScaleAmt
-    Inst.addOperand(MCOperand::createReg(X86::NoRegister)); // IndexReg
-    Inst.addOperand(MCOperand::createImm(Offset));          // Displacement
-    Inst.addOperand(MCOperand::createReg(X86::NoRegister)); // AddrSegmentReg
+    Inst.addOperand(MCOperand::createReg(StackReg));     // BaseReg
+    Inst.addOperand(MCOperand::createImm(1));            // ScaleAmt
+    Inst.addOperand(MCOperand::createReg(MCRegister())); // IndexReg
+    Inst.addOperand(MCOperand::createImm(Offset));       // Displacement
+    Inst.addOperand(MCOperand::createReg(MCRegister())); // AddrSegmentReg
     Inst.addOperand(MCOperand::createReg(SrcReg));
   }
 
-  void createRestoreFromStack(MCInst &Inst, const MCPhysReg &StackReg,
-                              int Offset, const MCPhysReg &DstReg,
+  void createRestoreFromStack(MCInst &Inst, MCRegister StackReg,
+                              int Offset, MCRegister DstReg,
                               int Size) const override {
-    return createLoad(Inst, StackReg, /*Scale=*/1, /*IndexReg=*/X86::NoRegister,
-                      Offset, nullptr, /*AddrSegmentReg=*/X86::NoRegister,
-                      DstReg, Size);
+    return createLoad(Inst, StackReg, /*Scale=*/1, /*IndexReg=*/MCRegister(),
+                      Offset, nullptr, /*AddrSegmentReg=*/MCRegister(), DstReg,
+                      Size);
   }
 
-  void createLoad(MCInst &Inst, const MCPhysReg &BaseReg, int64_t Scale,
-                  const MCPhysReg &IndexReg, int64_t Offset,
-                  const MCExpr *OffsetExpr, const MCPhysReg &AddrSegmentReg,
-                  const MCPhysReg &DstReg, int Size) const override {
+  void createLoad(MCInst &Inst, MCRegister BaseReg, int64_t Scale,
+                  MCRegister IndexReg, int64_t Offset, const MCExpr *OffsetExpr,
+                  MCRegister AddrSegmentReg, MCRegister DstReg,
+                  int Size) const override {
     unsigned NewOpcode;
     switch (Size) {
     default:
@@ -2334,7 +2324,7 @@ public:
     Inst.addOperand(MCOperand::createReg(AddrSegmentReg)); // AddrSegmentReg
   }
 
-  InstructionListType createLoadImmediate(const MCPhysReg Dest,
+  InstructionListType createLoadImmediate(const MCRegister Dest,
                                           uint64_t Imm) const override {
     InstructionListType Insts;
     Insts.emplace_back();
@@ -2365,7 +2355,7 @@ public:
     Load.addOperand(Scale);
     Load.addOperand(IndexReg);
     Load.addOperand(Offset);
-    Load.addOperand(MCOperand::createReg(X86::NoRegister));
+    Load.addOperand(MCOperand::createReg(MCRegister()));
 
     Insts.push_back(Load);
     Insts.push_back(IJmp);
@@ -2390,7 +2380,7 @@ public:
                             .addImm(1)
                             .addReg(X86::RDX)
                             .addImm(0)
-                            .addReg(X86::NoRegister));
+                            .addReg(MCRegister()));
     else
       Code.emplace_back(MCInstBuilder(X86::MOV64rr)
                             .addReg(X86::RAX)
@@ -2410,15 +2400,15 @@ public:
                           .addReg(X86::CL)
                           .addReg(X86::RSI)
                           .addImm(0)
-                          .addReg(X86::NoRegister)
+                          .addReg(MCRegister())
                           .addImm(0)
-                          .addReg(X86::NoRegister));
+                          .addReg(MCRegister()));
     Code.emplace_back(MCInstBuilder(X86::MOV8mr)
                           .addReg(X86::RDI)
                           .addImm(0)
-                          .addReg(X86::NoRegister)
+                          .addReg(MCRegister())
                           .addImm(0)
-                          .addReg(X86::NoRegister)
+                          .addReg(MCRegister())
                           .addReg(X86::CL));
     Code.emplace_back(MCInstBuilder(X86::MOV64rr)
                           .addReg(X86::RAX)
@@ -2426,7 +2416,7 @@ public:
     return Code;
   }
 
-  InstructionListType createCmpJE(MCPhysReg RegNo, int64_t Imm,
+  InstructionListType createCmpJE(MCRegister RegNo, int64_t Imm,
                                   const MCSymbol *Target,
                                   MCContext *Ctx) const override {
     InstructionListType Code;
@@ -2439,7 +2429,7 @@ public:
     return Code;
   }
 
-  InstructionListType createCmpJNE(MCPhysReg RegNo, int64_t Imm,
+  InstructionListType createCmpJNE(MCRegister RegNo, int64_t Imm,
                                    const MCSymbol *Target,
                                    MCContext *Ctx) const override {
     InstructionListType Code;
@@ -2515,7 +2505,7 @@ public:
     return true;
   }
 
-  bool replaceRegWithImm(MCInst &Inst, unsigned Register,
+  bool replaceRegWithImm(MCInst &Inst, MCRegister Register,
                          int64_t Imm) const override {
 
     enum CheckSignExt : uint8_t {
@@ -2680,8 +2670,8 @@ public:
     return true;
   }
 
-  bool replaceRegWithReg(MCInst &Inst, unsigned ToReplace,
-                         unsigned ReplaceWith) const override {
+  bool replaceRegWithReg(MCInst &Inst, MCRegister ToReplace,
+                         MCRegister ReplaceWith) const override {
 
     // Get the HasLHS value so that iteration can be done
     bool HasLHS;
@@ -2733,10 +2723,10 @@ public:
          Index != E; ++Index) {
       BitVector RegAliases = getAliases(ToReplace, true);
       if (!Inst.getOperand(Index).isReg() ||
-          !RegAliases.test(Inst.getOperand(Index).getReg()))
+          !RegAliases.test(Inst.getOperand(Index).getReg().id()))
         continue;
       // Resize register if needed
-      unsigned SizedReplaceWith = getAliasSized(
+      MCRegister SizedReplaceWith = getAliasSized(
           ReplaceWith, getRegSize(Inst.getOperand(Index).getReg()));
       MCOperand NewOperand = MCOperand::createReg(SizedReplaceWith);
       Inst.getOperand(Index) = NewOperand;
@@ -2870,7 +2860,7 @@ public:
         MCOperand::createExpr(MCSymbolRefExpr::create(TBB, *Ctx));
   }
 
-  MCPhysReg getX86R11() const override { return X86::R11; }
+  MCRegister getX86R11() const override { return X86::R11; }
 
   unsigned getShortBranchOpcode(unsigned Opcode) const override {
     switch (Opcode) {
@@ -2887,7 +2877,7 @@ public:
     }
   }
 
-  MCPhysReg getIntArgRegister(unsigned ArgNo) const override {
+  MCRegister getIntArgRegister(unsigned ArgNo) const override {
     // FIXME: this should depend on the calling convention.
     switch (ArgNo) {
     case 0:   return X86::RDI;
@@ -2956,7 +2946,7 @@ public:
     return false;
   }
 
-  void createPushRegister(MCInst &Inst, MCPhysReg Reg,
+  void createPushRegister(MCInst &Inst, MCRegister Reg,
                           unsigned Size) const override {
     Inst.clear();
     unsigned NewOpcode = 0;
@@ -2982,7 +2972,7 @@ public:
     Inst.addOperand(MCOperand::createReg(Reg));
   }
 
-  void createPopRegister(MCInst &Inst, MCPhysReg Reg,
+  void createPopRegister(MCInst &Inst, MCRegister Reg,
                          unsigned Size) const override {
     Inst.clear();
     unsigned NewOpcode = 0;
@@ -3016,7 +3006,7 @@ public:
     return createPopRegister(Inst, X86::EFLAGS, Size);
   }
 
-  void createAddRegImm(MCInst &Inst, MCPhysReg Reg, int64_t Value,
+  void createAddRegImm(MCInst &Inst, MCRegister Reg, int64_t Value,
                        unsigned Size) const {
     unsigned int Opcode;
     switch (Size) {
@@ -3033,7 +3023,7 @@ public:
     Inst.addOperand(MCOperand::createImm(Value));
   }
 
-  void createClearRegWithNoEFlagsUpdate(MCInst &Inst, MCPhysReg Reg,
+  void createClearRegWithNoEFlagsUpdate(MCInst &Inst, MCRegister Reg,
                                         unsigned Size) const {
     unsigned int Opcode;
     switch (Size) {
@@ -3055,7 +3045,7 @@ public:
     Inst.addOperand(MCOperand::createImm(0));
   }
 
-  void createX86SaveOVFlagToRegister(MCInst &Inst, MCPhysReg Reg) const {
+  void createX86SaveOVFlagToRegister(MCInst &Inst, MCRegister Reg) const {
     Inst.setOpcode(X86::SETCCr);
     Inst.clear();
     Inst.addOperand(MCOperand::createReg(Reg));
@@ -3110,28 +3100,28 @@ public:
     return Instrs;
   }
 
-  void createSwap(MCInst &Inst, MCPhysReg Source, MCPhysReg MemBaseReg,
+  void createSwap(MCInst &Inst, MCRegister Source, MCRegister MemBaseReg,
                   int64_t Disp) const {
     Inst.setOpcode(X86::XCHG64rm);
     Inst.clear();
     Inst.addOperand(MCOperand::createReg(Source));
     Inst.addOperand(MCOperand::createReg(Source));
-    Inst.addOperand(MCOperand::createReg(MemBaseReg));      // BaseReg
-    Inst.addOperand(MCOperand::createImm(1));               // ScaleAmt
-    Inst.addOperand(MCOperand::createReg(X86::NoRegister)); // IndexReg
-    Inst.addOperand(MCOperand::createImm(Disp));            // Displacement
-    Inst.addOperand(MCOperand::createReg(X86::NoRegister)); // AddrSegmentReg
+    Inst.addOperand(MCOperand::createReg(MemBaseReg));   // BaseReg
+    Inst.addOperand(MCOperand::createImm(1));            // ScaleAmt
+    Inst.addOperand(MCOperand::createReg(MCRegister())); // IndexReg
+    Inst.addOperand(MCOperand::createImm(Disp));         // Displacement
+    Inst.addOperand(MCOperand::createReg(MCRegister())); // AddrSegmentReg
   }
 
-  void createIndirectBranch(MCInst &Inst, MCPhysReg MemBaseReg,
+  void createIndirectBranch(MCInst &Inst, MCRegister MemBaseReg,
                             int64_t Disp) const {
     Inst.setOpcode(X86::JMP64m);
     Inst.clear();
-    Inst.addOperand(MCOperand::createReg(MemBaseReg));      // BaseReg
-    Inst.addOperand(MCOperand::createImm(1));               // ScaleAmt
-    Inst.addOperand(MCOperand::createReg(X86::NoRegister)); // IndexReg
-    Inst.addOperand(MCOperand::createImm(Disp));            // Displacement
-    Inst.addOperand(MCOperand::createReg(X86::NoRegister)); // AddrSegmentReg
+    Inst.addOperand(MCOperand::createReg(MemBaseReg));   // BaseReg
+    Inst.addOperand(MCOperand::createImm(1));            // ScaleAmt
+    Inst.addOperand(MCOperand::createReg(MCRegister())); // IndexReg
+    Inst.addOperand(MCOperand::createImm(Disp));         // Displacement
+    Inst.addOperand(MCOperand::createReg(MCRegister())); // AddrSegmentReg
   }
 
   InstructionListType createInstrumentedIndirectCall(MCInst &&CallInst,
@@ -3142,11 +3132,11 @@ public:
     // uses the stack pointer, which we are going to clobber.
     static BitVector SPAliases(getAliases(X86::RSP));
     bool UsesSP = any_of(useOperands(CallInst), [&](const MCOperand &Op) {
-      return Op.isReg() && SPAliases[Op.getReg()];
+      return Op.isReg() && SPAliases[Op.getReg().id()];
     });
 
     InstructionListType Insts;
-    MCPhysReg TempReg = getIntArgRegister(0);
+    MCRegister TempReg = getIntArgRegister(0);
     // Code sequence used to enter indirect call instrumentation helper:
     //   push %rdi
     //   add $8, %rsp       ;; $rsp may be used in target, so fix it to prev val
@@ -3189,7 +3179,7 @@ public:
   }
 
   InstructionListType createInstrumentedIndCallHandlerExitBB() const override {
-    const MCPhysReg TempReg = getIntArgRegister(0);
+    const MCRegister TempReg = getIntArgRegister(0);
     // We just need to undo the sequence created for every ind call in
     // instrumentIndirectTarget(), which can be accomplished minimally with:
     //   popfq
@@ -3208,7 +3198,7 @@ public:
 
   InstructionListType
   createInstrumentedIndTailCallHandlerExitBB() const override {
-    const MCPhysReg TempReg = getIntArgRegister(0);
+    const MCRegister TempReg = getIntArgRegister(0);
     // Same thing as above, but for tail calls
     //   popfq
     //   add $16, %rsp
@@ -3226,7 +3216,7 @@ public:
   createInstrumentedIndCallHandlerEntryBB(const MCSymbol *InstrTrampoline,
                                           const MCSymbol *IndCallHandler,
                                           MCContext *Ctx) override {
-    const MCPhysReg TempReg = getIntArgRegister(0);
+    const MCRegister TempReg = getIntArgRegister(0);
     // Code sequence used to check whether InstrTampoline was initialized
     // and call it if so, returns via IndCallHandler.
     //   pushfq
@@ -3291,7 +3281,7 @@ public:
   }
 
   BlocksVectorTy indirectCallPromotion(
-      const MCInst &CallInst, MCPhysReg Reg,
+      const MCInst &CallInst, MCRegister Reg,
       const std::vector<std::pair<MCSymbol *, uint64_t>> &Targets,
       const std::vector<std::pair<MCSymbol *, uint64_t>> &VtableSyms,
       const std::vector<MCInst *> &MethodFetchInsns,
@@ -3315,7 +3305,7 @@ public:
            "in the targets vector.");
 
     if (MinimizeCodeSize && !LoadElim) {
-      std::set<unsigned> UsedRegs;
+      std::set<MCRegister> UsedRegs;
 
       for (unsigned int I = 0; I < MCPlus::getNumPrimeOperands(CallInst); ++I) {
         const MCOperand &Op = CallInst.getOperand(I);
@@ -3583,32 +3573,32 @@ public:
   }
 
 private:
-  void createMove(MCInst &Inst, const MCSymbol *Src, unsigned Reg,
+  void createMove(MCInst &Inst, const MCSymbol *Src, MCRegister Reg,
                   MCContext *Ctx) const {
     Inst.setOpcode(X86::MOV64rm);
     Inst.clear();
     Inst.addOperand(MCOperand::createReg(Reg));
-    Inst.addOperand(MCOperand::createReg(X86::RIP));        // BaseReg
-    Inst.addOperand(MCOperand::createImm(1));               // ScaleAmt
-    Inst.addOperand(MCOperand::createReg(X86::NoRegister)); // IndexReg
+    Inst.addOperand(MCOperand::createReg(X86::RIP));     // BaseReg
+    Inst.addOperand(MCOperand::createImm(1));            // ScaleAmt
+    Inst.addOperand(MCOperand::createReg(MCRegister())); // IndexReg
     Inst.addOperand(
         MCOperand::createExpr(MCSymbolRefExpr::create(Src,
                                                       *Ctx))); // Displacement
-    Inst.addOperand(MCOperand::createReg(X86::NoRegister)); // AddrSegmentReg
+    Inst.addOperand(MCOperand::createReg(MCRegister()));       // AddrSegmentReg
   }
 
-  void createLea(MCInst &Inst, const MCSymbol *Src, unsigned Reg,
+  void createLea(MCInst &Inst, const MCSymbol *Src, MCRegister Reg,
                  MCContext *Ctx) const {
     Inst.setOpcode(X86::LEA64r);
     Inst.clear();
     Inst.addOperand(MCOperand::createReg(Reg));
-    Inst.addOperand(MCOperand::createReg(X86::RIP));        // BaseReg
-    Inst.addOperand(MCOperand::createImm(1));               // ScaleAmt
-    Inst.addOperand(MCOperand::createReg(X86::NoRegister)); // IndexReg
+    Inst.addOperand(MCOperand::createReg(X86::RIP));     // BaseReg
+    Inst.addOperand(MCOperand::createImm(1));            // ScaleAmt
+    Inst.addOperand(MCOperand::createReg(MCRegister())); // IndexReg
     Inst.addOperand(
         MCOperand::createExpr(MCSymbolRefExpr::create(Src,
                                                       *Ctx))); // Displacement
-    Inst.addOperand(MCOperand::createReg(X86::NoRegister)); // AddrSegmentReg
+    Inst.addOperand(MCOperand::createReg(MCRegister()));       // AddrSegmentReg
   }
 };
 


### PR DESCRIPTION
MCPhysReg is a typedef for uint16_t and primarily exists to reduce the size of static tables.

The MCOperand getReg() and createReg interfaces use MCRegister which is a class around an unsigned. This class is currently implicitly convertible to unsigned but we want to remove that eventually.

This patch removes most of these implicit conversions and replaces the ones that are required with an explicit MCRegister::id().

This may increase memory usage where vectors of MCPhysReg were previously used. I'm not sure if this will be significant or not.

I also tried to replace NoRegister with MCRegister() or converting MCRegister to bool. We intend to have an operator bool() on MCRegister when the implicit conversion is removed.