### PR TITLE
[SSAF][UnsafeBufferAnalysis] Do not create entries for empty contributors (follow-up change on #209354)

### DIFF
--- a/clang/lib/ScalableStaticAnalysis/Analyses/UnsafeBufferUsage/UnsafeBufferUsageAnalysis.cpp
+++ b/clang/lib/ScalableStaticAnalysis/Analyses/UnsafeBufferUsage/UnsafeBufferUsageAnalysis.cpp
@@ -272,8 +272,9 @@ public:
     for (auto &[Contributor, EPLs] : UnsafePtrs) {
       auto FilteredRange = llvm::make_filter_range(EPLs, HasNoTypeConstraint);
 
-      getResult().Reachables[Contributor].insert(FilteredRange.begin(),
-                                                 FilteredRange.end());
+      if (!FilteredRange.empty())
+        getResult().Reachables[Contributor].insert(FilteredRange.begin(),
+                                                   FilteredRange.end());
     }
     return llvm::Error::success();
   }

--- a/clang/test/Analysis/Scalable/TypeConstrainedPointers/unsafe-buffer-reachable-excludes-type-constrained-main.cpp
+++ b/clang/test/Analysis/Scalable/TypeConstrainedPointers/unsafe-buffer-reachable-excludes-type-constrained-main.cpp
@@ -20,8 +20,7 @@
 // RUN: sed -e 's|$NS|{{([^]]\|[[:space:]])+\\],}}|g' \
 // RUN:     -e 's|$WS|{{[[:space:]]+}}|g' \
 // RUN:     -e 's|$PTR_L1|{{[[:space:]]+\\},[[:space:]]+1[[:space:]]+\\]}}|g' \
-// RUN:     %s > %t/checks.txt
-// RUN: FileCheck %t/checks.txt --input-file=%t/wpa.json
+// RUN:     %s | FileCheck - --input-file=%t/wpa.json
 
 
 int main(int argc, char **argv) {
@@ -37,9 +36,9 @@ void foo(int *q) {
 // CHECK-DAG: "id": [[Q_ID:[0-9]+]],$NS$WS"suffix": "1",$WS"usr": "c:@F@foo#*I#"
 // CHECK-DAG: "id": [[ARGV_ID:[0-9]+]],$NS$WS"suffix": "2",$WS"usr": "c:@F@main{{.*}}"
 
-// Contributor function ids:
+// Contributor function id (main contributes nothing in the end thus absent):
 // CHECK-DAG: "id": [[CONTRIBUTOR_FOO:[0-9]+]],$NS$WS"suffix": "",$WS"usr": "c:@F@foo#*I#"
-// CHECK-DAG: "id": [[CONTRIBUTOR_MAIN:[0-9]+]],$NS$WS"suffix": "",$WS"usr": "c:@F@main{{.*}}"
+// CHECK-NOT: "id": [[CONTRIBUTOR_MAIN:[0-9]+]],$NS$WS"suffix": "",$WS"usr": "c:@F@main{{.*}}"
 
 // 'argv' is reported as type-constrained.
 // CHECK: "analysis_name": "TypeConstrainedPointersAnalysisResult"
@@ -52,9 +51,5 @@ void foo(int *q) {
 // CHECK: "@": [[CONTRIBUTOR_FOO]]$WS},$WS[
 // CHECK: "@": [[Q_ID]]$PTR_L1
 // CHECK-NOT: "@":
-
-// 'main' contributes nothing: 'argv' is type-constrained and excluded.
-// CHECK: "@": [[CONTRIBUTOR_MAIN]]$WS},$WS[
-// CHECK-NOT: "@": [[ARGV_ID]]
 
 // CHECK: "analysis_name"

--- a/clang/test/Analysis/Scalable/TypeConstrainedPointers/unsafe-buffer-reachable-excludes-type-constrained-new-delete.cpp
+++ b/clang/test/Analysis/Scalable/TypeConstrainedPointers/unsafe-buffer-reachable-excludes-type-constrained-new-delete.cpp
@@ -22,8 +22,7 @@
 // RUN: sed -e 's|$NS|{{([^]]\|[[:space:]])+\\],}}|g' \
 // RUN:     -e 's|$WS|{{[[:space:]]+}}|g' \
 // RUN:     -e 's|$PTR_L1|{{[[:space:]]+\\},[[:space:]]+1[[:space:]]+\\]}}|g' \
-// RUN:     %s > %t/checks.txt
-// RUN: FileCheck %t/checks.txt --input-file=%t/wpa.json
+// RUN:     %s | FileCheck - --input-file=%t/wpa.json
 
 typedef __SIZE_TYPE__ size_t;
 


### PR DESCRIPTION
Address follow up questions after the approval.

- The analysis should not create entries for empty contributors, which otherwise is non-empty in the serialized format.
- use std IO instead of a tmp file for regex-ing FileCheck queries.