### PR TITLE
[ASan] Register assert lit feature in `lit.cfg.py`

### DIFF
--- a/compiler-rt/test/asan/lit.cfg.py
+++ b/compiler-rt/test/asan/lit.cfg.py
@@ -6,6 +6,7 @@ import re
 import shlex
 
 import lit.formats
+from lit.llvm import llvm_config
 
 
 def get_required_attr(config, attr_name):
@@ -108,6 +109,7 @@ if platform.system() == "Windows":
         win_runtime_feature = "win32-static-asan"
     config.available_features.add(win_runtime_feature)
 
+llvm_config.feature_config([("--assertion-mode", {"ON": "asserts"})])
 
 def build_invocation(compile_flags, with_lto=False):
     lto_flags = []


### PR DESCRIPTION
Add this feature to test a functional change related to asserts, see https://github.com/llvm/llvm-project/pull/213546#discussion_r3790705838.

And this will allow other people to add `// REQUIRES: asserts` in testcases in the future too.

I follow the same pattern already used in `flang/test/lit.cfg.py` and other configs.