### PR TITLE
[Release] Pass -n to gzip so the release tarball is reproducible

### DIFF
--- a/llvm/utils/release/test-release.sh
+++ b/llvm/utils/release/test-release.sh
@@ -369,7 +369,7 @@ function build_with_cmake_cache() {
  pushd $BuildDir/Release
  mv $InstallDir/usr/local $Package
  if [ "$use_gzip" = "yes" ]; then
-    tar cf - $Package | gzip -9c > $BuildDir/$Package.tar.gz
+    tar cf - $Package | gzip -9c -n > $BuildDir/$Package.tar.gz
   else
     tar cf - $Package | xz -9ce -T $NumJobs > $BuildDir/$Package.tar.xz
   fi
@@ -613,7 +613,7 @@ function package_release() {
     cd $BuildDir/Phase3/Release
     mv llvmCore-$Release-$RC.install/usr/local $Package
     if [ "$use_gzip" = "yes" ]; then
-      tar cf - $Package | gzip -9c > $BuildDir/$Package.tar.gz
+      tar cf - $Package | gzip -9c -n > $BuildDir/$Package.tar.gz
     else
       tar cf - $Package | xz -9ce -T $NumJobs > $BuildDir/$Package.tar.xz
     fi


### PR DESCRIPTION
`test-release.sh -use-gzip` packages the release with

```sh
tar cf - $Package | gzip -9c > $BuildDir/$Package.tar.gz
```
Older versions of gzip, and the parallel pigz set the MTIME field in the gzip header to the current time, breaking reproducibility. Adding the -n option sets MTIME to 0.

AMD has carried this two-line change downstream since August 2025. The patch is Jonathan Luu's.

## Test plan

The two call sites are the only `.tar.gz` producers in the script (lines 372 and 616); the third `use_gzip` reference at line 769 is an `echo`.

- `bash -n llvm/utils/release/test-release.sh` parses.
- Measured on the pipeline the script uses (`tar cf - pkg | gzip -9c` versus `... | gzip -9c -n`, two runs two seconds apart), with the MTIME field read out of the header:
  - GNU gzip 1.10: MTIME already zero, output identical with and without `-n`.
  - pigz 2.6: without `-n` the runs differ (`2bf61f7c…` versus `c20e2b21…`) and MTIME holds the wall clock; with `-n` both runs are identical and byte-for-byte equal to GNU gzip's output.
  - busybox gzip 1.30.1: accepts `-n`, MTIME zero either way.
