### PR TITLE
[clang][bytecode] check reduce_min element type

### DIFF
--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -1711,6 +1711,9 @@ static bool interp__builtin_vector_reduce(InterpState &S, CodePtr OpPC,
   PrimType ElemT = *S.getContext().classify(ElemType);
   unsigned NumElems = Arg.getNumElems();
 
+  if (!isIntegerType(ElemT))
+    return false;
+
   INT_TYPE_SWITCH_NO_BOOL(ElemT, {
     T Result = Arg.elem<T>(0);
     unsigned BitWidth = Result.bitWidth();

--- a/clang/test/AST/ByteCode/builtin-functions.cpp
+++ b/clang/test/AST/ByteCode/builtin-functions.cpp
@@ -2122,3 +2122,8 @@ namespace SubCb {
   }
   static_assert(subcb2() == 0);
 }
+
+namespace ReduceMin {
+  typedef float v4f __attribute__((__vector_size__(16)));
+  static_assert(__builtin_reduce_min((v4f){1.123, 2.123, 3.123, 4.123}) == 0); // both-error {{not an integral constant expression}}
+}


### PR DESCRIPTION
Only integer types are allowed.