### PR TITLE
PeepholeOpt: Fix crash on copy from an undef register

### DIFF
--- a/llvm/lib/CodeGen/PeepholeOptimizer.cpp
+++ b/llvm/lib/CodeGen/PeepholeOptimizer.cpp
@@ -745,8 +745,11 @@ public:
                const TargetInstrInfo *TII = nullptr)
       : DefSubReg(DefSubReg), Reg(Reg), MRI(MRI), TII(TII) {
     if (!Reg.isPhysical()) {
-      Def = MRI.getVRegDef(Reg);
-      DefIdx = MRI.def_begin(Reg).getOperandNo();
+      MachineRegisterInfo::def_iterator DI = MRI.def_begin(Reg);
+      if (DI != MRI.def_end()) {
+        Def = DI->getParent();
+        DefIdx = DI.getOperandNo();
+      }
     }
   }
 

--- a/llvm/test/CodeGen/X86/peephole-valuetracker-undef.mir
+++ b/llvm/test/CodeGen/X86/peephole-valuetracker-undef.mir
@@ -1,0 +1,17 @@
+# RUN: llc -mtriple=x86_64-- -run-pass=peephole-opt -o - %s | FileCheck %s
+# A copy whose source is an undef register with no def must not crash the
+# peephole optimizer while it looks through the copy for a replacement source.
+
+---
+name: undef_subreg_copy
+tracksRegLiveness: true
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: undef_subreg_copy
+    ; CHECK: [[COPY:%[0-9]+]]:gr32 = COPY undef %{{[0-9]+}}.sub_32bit:gr64
+    ; CHECK-NEXT: $eax = COPY [[COPY]]
+    ; CHECK-NEXT: RET64 implicit $eax
+    %1:gr32 = COPY undef %0.sub_32bit:gr64
+    $eax = COPY %1
+    RET64 implicit $eax
+...


### PR DESCRIPTION
Fix ValueTracker looking at the def chain of an undef subregister.
Found by AI while working on something else.

Co-authored-by: Claude (Opus 4.8) <noreply@anthropic.com>