### PR TITLE
X86: Fix optimizeCompareInstr crash on a compare from an undef register

### DIFF
--- a/llvm/lib/CodeGen/PeepholeOptimizer.cpp
+++ b/llvm/lib/CodeGen/PeepholeOptimizer.cpp
@@ -745,8 +745,11 @@ public:
                const TargetInstrInfo *TII = nullptr)
       : DefSubReg(DefSubReg), Reg(Reg), MRI(MRI), TII(TII) {
     if (!Reg.isPhysical()) {
-      Def = MRI.getVRegDef(Reg);
-      DefIdx = MRI.def_begin(Reg).getOperandNo();
+      MachineRegisterInfo::def_iterator DI = MRI.def_begin(Reg);
+      if (DI != MRI.def_end()) {
+        Def = DI->getParent();
+        DefIdx = DI.getOperandNo();
+      }
     }
   }
 

--- a/llvm/lib/Target/X86/X86InstrInfo.cpp
+++ b/llvm/lib/Target/X86/X86InstrInfo.cpp
@@ -5476,7 +5476,8 @@ bool X86InstrInfo::optimizeCompareInstr(MachineInstr &CmpInstr, Register SrcReg,
   if (SrcReg2.isPhysical())
     return false;
   MachineInstr *SrcRegDef = MRI->getVRegDef(SrcReg);
-  assert(SrcRegDef && "Must have a definition (SSA)");
+  if (!SrcRegDef)
+    return false;
 
   MachineInstr *MI = nullptr;
   MachineInstr *Sub = nullptr;

--- a/llvm/test/CodeGen/X86/optimize-compare-undef.mir
+++ b/llvm/test/CodeGen/X86/optimize-compare-undef.mir
@@ -1,0 +1,23 @@
+# RUN: llc -mtriple=x86_64-- -run-pass=peephole-opt -o - %s | FileCheck %s
+# A compare whose source is an undef register with no def must not crash the
+# compare-optimization while it looks for an earlier flags-defining instruction
+# to reuse.
+
+---
+name: undef_cmp
+tracksRegLiveness: true
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: undef_cmp
+    ; CHECK: TEST32rr undef %{{[0-9]+}}:gr32, undef %{{[0-9]+}}:gr32, implicit-def $eflags
+    successors: %bb.1, %bb.2
+    TEST32rr undef %0:gr32, undef %0:gr32, implicit-def $eflags
+    JCC_1 %bb.1, 4, implicit $eflags
+    JMP_1 %bb.2
+
+  bb.1:
+    RET64
+
+  bb.2:
+    RET64
+...

--- a/llvm/test/CodeGen/X86/peephole-valuetracker-undef.mir
+++ b/llvm/test/CodeGen/X86/peephole-valuetracker-undef.mir
@@ -1,0 +1,17 @@
+# RUN: llc -mtriple=x86_64-- -run-pass=peephole-opt -o - %s | FileCheck %s
+# A copy whose source is an undef register with no def must not crash the
+# peephole optimizer while it looks through the copy for a replacement source.
+
+---
+name: undef_subreg_copy
+tracksRegLiveness: true
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: undef_subreg_copy
+    ; CHECK: [[COPY:%[0-9]+]]:gr32 = COPY undef %{{[0-9]+}}.sub_32bit:gr64
+    ; CHECK-NEXT: $eax = COPY [[COPY]]
+    ; CHECK-NEXT: RET64 implicit $eax
+    %1:gr32 = COPY undef %0.sub_32bit:gr64
+    $eax = COPY %1
+    RET64 implicit $eax
+...


### PR DESCRIPTION
getVRegDef returns null for undef sources, so the assert would fire.
Found by AI while working on other stuff.

Co-authored-by: Claude (Opus 4.8) <noreply@anthropic.com>