### PR TITLE
[clang][bytecode] Fix assertion failure in in valid continue stmt

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -7023,7 +7023,9 @@ bool Compiler<Emitter>::visitContinueStmt(const ContinueStmt *S) {
       }
     }
   }
-  assert(TargetLabel);
+
+  if (!TargetLabel)
+    return false;
 
   for (VariableScope<Emitter> *C = VarScope; C != ContinueScope;
        C = C->getParent()) {

--- a/clang/test/AST/ByteCode/cxx23.cpp
+++ b/clang/test/AST/ByteCode/cxx23.cpp
@@ -650,6 +650,19 @@ namespace DynamicCast {
 }
 
 #if __cplusplus >= 202302L
+namespace BrokenContinueLabel {
+  constexpr int test() {
+  bar: {} // all-note {{here}}
+  bar: // all-error {{redefinition of label 'bar'}}
+    for (;;) {
+      continue bar; // all-error {{only supported in C2y}}
+    }
+    return 0;
+  }
+
+  static_assert(test(), ""); // all-error {{not an integral constant expression}}
+}
+
 namespace BrokenShuffleVector {
   typedef float __m128 __attribute__((__vector_size__(16)));
 


### PR DESCRIPTION
We need to handle the missing TargetLabel here, similarly to what we do in break statements.