### PR TITLE
[ADT] Remove bucket_begin, bucket_end, and FoldingSetBucketIterator (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/FoldingSet.h
+++ b/llvm/include/llvm/ADT/FoldingSet.h
@@ -402,8 +402,7 @@ protected:
 
 // Convenience type to hide the implementation of the folding set.
 using FoldingSetNode = FoldingSetBase::Node;
-template<class T> class FoldingSetIterator;
-template<class T> class FoldingSetBucketIterator;
+template <class T> class FoldingSetIterator;
 
 // Definitions of FoldingSetTrait and ContextualFoldingSetTrait functions, which
 // require the definition of FoldingSetNodeID.
@@ -462,16 +461,6 @@ public:
 
   const_iterator begin() const { return const_iterator(Buckets); }
   const_iterator end() const { return const_iterator(Buckets+NumBuckets); }
-
-  using bucket_iterator = FoldingSetBucketIterator<T>;
-
-  bucket_iterator bucket_begin(unsigned hash) {
-    return bucket_iterator(Buckets + (hash & (NumBuckets-1)));
-  }
-
-  bucket_iterator bucket_end(unsigned hash) {
-    return bucket_iterator(Buckets + (hash & (NumBuckets-1)), true);
-  }
 
   /// Increase the number of buckets such that adding the \p EltCount th node
   /// won't cause a rebucket operation. reserve is permitted to allocate more
@@ -730,53 +719,6 @@ public:
   }
   FoldingSetIterator operator++(int) {        // Postincrement
     FoldingSetIterator tmp = *this; ++*this; return tmp;
-  }
-};
-
-//===----------------------------------------------------------------------===//
-/// This is the common bucket iterator support shared by all folding sets, which
-/// knows how to walk a particular bucket of a folding set hash table.
-class FoldingSetBucketIteratorImpl {
-protected:
-  void *Ptr;
-
-  LLVM_ABI explicit FoldingSetBucketIteratorImpl(void **Bucket);
-
-  FoldingSetBucketIteratorImpl(void **Bucket, bool) : Ptr(Bucket) {}
-
-  void advance() {
-    void *Probe = static_cast<FoldingSetNode*>(Ptr)->getNextInBucket();
-    uintptr_t x = reinterpret_cast<uintptr_t>(Probe) & ~0x1;
-    Ptr = reinterpret_cast<void*>(x);
-  }
-
-public:
-  bool operator==(const FoldingSetBucketIteratorImpl &RHS) const {
-    return Ptr == RHS.Ptr;
-  }
-  bool operator!=(const FoldingSetBucketIteratorImpl &RHS) const {
-    return Ptr != RHS.Ptr;
-  }
-};
-
-template <class T>
-class FoldingSetBucketIterator : public FoldingSetBucketIteratorImpl {
-public:
-  explicit FoldingSetBucketIterator(void **Bucket) :
-    FoldingSetBucketIteratorImpl(Bucket) {}
-
-  FoldingSetBucketIterator(void **Bucket, bool) :
-    FoldingSetBucketIteratorImpl(Bucket, true) {}
-
-  T &operator*() const { return *static_cast<T*>(Ptr); }
-  T *operator->() const { return static_cast<T*>(Ptr); }
-
-  inline FoldingSetBucketIterator &operator++() { // Preincrement
-    advance();
-    return *this;
-  }
-  FoldingSetBucketIterator operator++(int) {      // Postincrement
-    FoldingSetBucketIterator tmp = *this; ++*this; return tmp;
   }
 };
 

--- a/llvm/lib/Support/FoldingSet.cpp
+++ b/llvm/lib/Support/FoldingSet.cpp
@@ -416,10 +416,3 @@ void FoldingSetIteratorImpl::advance() {
     NodePtr = static_cast<FoldingSetNode*>(*Bucket);
   }
 }
-
-//===----------------------------------------------------------------------===//
-// FoldingSetBucketIteratorImpl Implementation
-
-FoldingSetBucketIteratorImpl::FoldingSetBucketIteratorImpl(void **Bucket) {
-  Ptr = (!*Bucket || !GetNextPtr(*Bucket)) ? (void*) Bucket : *Bucket;
-}


### PR DESCRIPTION
This patch removes bucket_begin, bucket_end, and the underlying
FoldingSetBucketIterator and FoldingSetBucketIteratorImpl classes in
FoldingSet.

These were added on February 4, 2008 in commit
e2887863563fe5d2fdd8e1219b76fdc1ee9ec37d for ImutAVLTree in
ImmutableSet.h.  The last use was removed on November 30, 2010 in commit
dbd89971ffb3a222dc91513585e8d6b5bc7882db when ImmutableSet switched
from FoldingSet to DenseSet.

Assisted-by: Antigravity
