### PR TITLE
[clang][Lex] Preserve physical line start after comments in -C mode

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -412,6 +412,7 @@ features cannot lower the translation-unit ABI level;
 - Clang now defines the GCC-compatible predefined macro `__SIG_ATOMIC_TYPE__`. (#GH213895)
 - Fixed an ICE that occurred when a structured binding pack is expanded outside the lambda where it was declared. (#GH214160)
 - Fixed a bug where a stray closing curley brace in an OpenMP/OpenACC pragma could cause pragma parsing issues when inside of a member function. (#GH214195)
+- Fixed a bug where preprocessor directives following comments were not correctly recognized when using -C. (#GH48361)
 
 #### Bug Fixes to Compiler Builtins
 

--- a/clang/lib/Lex/Lexer.cpp
+++ b/clang/lib/Lex/Lexer.cpp
@@ -3163,6 +3163,7 @@ bool Lexer::SkipBlockComment(Token &Result, const char *CurPtr) {
   // If we are returning comments as tokens, return this comment as a token.
   if (inKeepCommentMode()) {
     FormTokenWithChars(Result, CurPtr, tok::comment);
+    IsAtPhysicalStartOfLine = Result.isAtPhysicalStartOfLine();
     return true;
   }
 

--- a/clang/test/Preprocessor/comment_directive.c
+++ b/clang/test/Preprocessor/comment_directive.c
@@ -1,0 +1,33 @@
+// RUN: %clang_cc1 -E -C %s | FileCheck %s
+
+/* comment */ #define A 1
+int a = A;
+
+/*
+ * multiline comment
+ */ #define B 2
+int b = B;
+
+int c; /* comment */ #define C 3
+int d = C;
+
+int e; /*
+ * multiline comment
+ */ #define D 4
+int f = D;
+
+// CHECK: /* comment */
+// CHECK-NEXT: int a = 1;
+
+// CHECK: /*
+// CHECK-NEXT:  * multiline comment
+// CHECK-NEXT:  */
+// CHECK-NEXT: int b = 2;
+
+// CHECK: int c; /* comment */ #define C 3
+// CHECK-NEXT: int d = C;
+
+// CHECK: int e; /*
+// CHECK-NEXT:  * multiline comment
+// CHECK-NEXT:  */ #define D 4
+// CHECK-NEXT: int f = D;


### PR DESCRIPTION
When comments are preserved with -C, a comment at the start of a physical line consumes the PhysicalStartOfLine state. As a result, a preprocessor directive following the comment is not recognized.

Preserve the PhysicalStartOfLine state when returning a comment token so that directives following comments are still handled correctly.

Fixes: #48361