### PR TITLE
[llvm-dwarfdump] Added --output-style option for controlling output format

### DIFF
--- a/llvm/docs/CommandGuide/llvm-dwarfdump.rst
+++ b/llvm/docs/CommandGuide/llvm-dwarfdump.rst
@@ -95,6 +95,13 @@ OPTIONS
             Redirect output to a file specified by <path>, where `-` is the
             standard output stream.
 
+.. option:: --output-style=<value>
+
+            Specify the format of the output. The supported values are:
+
+            `LLVM` - Output in the format used by llvm-dwarfdump. [default]
+            `JSON` - Output in JSON format.
+
 .. option:: -p, --show-parents
 
             Show a debug info entry's parents when selectively printing with

--- a/llvm/test/tools/llvm-dwarfdump/output-style.test
+++ b/llvm/test/tools/llvm-dwarfdump/output-style.test
@@ -4,6 +4,11 @@
 
 # LLVM: file format elf64-x86-64
 
+## Show that omitting --output-style is equivalent to passing --output-style=LLVM explicitly.
+# RUN: llvm-dwarfdump %t.o > %t.default.txt
+# RUN: llvm-dwarfdump --output-style=LLVM %t.o > %t.llvm.txt
+# RUN: cmp %t.default.txt %t.llvm.txt
+
 ## Show that --output-style=JSON emits a warning, since JSON output is not yet implemented.
 # RUN: llvm-dwarfdump --output-style=JSON %t.o 2>&1 | FileCheck %s --check-prefix=JSON
 

--- a/llvm/test/tools/llvm-dwarfdump/output-style.test
+++ b/llvm/test/tools/llvm-dwarfdump/output-style.test
@@ -4,11 +4,6 @@
 
 # LLVM: file format elf64-x86-64
 
-## Show that omitting --output-style is equivalent to passing --output-style=LLVM explicitly.
-# RUN: llvm-dwarfdump %t.o > %t.default.txt
-# RUN: llvm-dwarfdump --output-style=LLVM %t.o > %t.llvm.txt
-# RUN: cmp %t.default.txt %t.llvm.txt
-
 ## Show that --output-style=JSON emits a warning, since JSON output is not yet implemented.
 # RUN: llvm-dwarfdump --output-style=JSON %t.o 2>&1 | FileCheck %s --check-prefix=JSON
 

--- a/llvm/test/tools/llvm-dwarfdump/output-style.test
+++ b/llvm/test/tools/llvm-dwarfdump/output-style.test
@@ -1,0 +1,23 @@
+## Show that --output-style=LLVM (the default) dumps normally.
+# RUN: yaml2obj %s -o %t.o
+# RUN: llvm-dwarfdump --output-style=LLVM %t.o | FileCheck %s --check-prefix=LLVM
+
+# LLVM: file format elf64-x86-64
+
+## Show that --output-style=JSON emits a warning, since JSON output is not yet implemented.
+# RUN: llvm-dwarfdump --output-style=JSON %t.o 2>&1 | FileCheck %s --check-prefix=JSON
+
+#      JSON: file format elf64-x86-64
+# JSON-NEXT: warning: JSON output style is not yet implemented
+
+## Show that an unrecognized --output-style value is rejected.
+# RUN: not llvm-dwarfdump --output-style=YAML 2>&1 | FileCheck %s --check-prefix=INVALID
+
+# INVALID: error: --output-style value should be either 'LLVM' or 'JSON', but was 'YAML'
+
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64

--- a/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
+++ b/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
@@ -136,7 +136,7 @@ enum ErrorDetailLevel {
   Unspecified
 };
 
-enum class OutputStyleKind { LLVM, JSON, Unknown };
+enum OutputStyleTy { LLVM, JSON, UNKNOWN };
 
 OptionCategory DwarfDumpCategory("Specific Options");
 static list<std::string>
@@ -341,7 +341,7 @@ static opt<std::string>
     OutputStyleOpt("output-style", init("LLVM"),
                    desc("Specify the format of the output (LLVM or JSON)"),
                    cat(DwarfDumpCategory));
-static OutputStyleKind Style = OutputStyleKind::LLVM;
+static OutputStyleTy OutputStyle = LLVM;
 static opt<bool>
     ShowVariableCoverage("show-variable-coverage",
                          desc("Show per-variable coverage metrics."),
@@ -783,14 +783,14 @@ static bool dumpObjectFile(ObjectFile &Obj, DWARFContext &DICtx,
   // Dump the complete DWARF structure.
   auto DumpOpts = getDumpOpts(DICtx);
   DumpOpts.GetNameForDWARFReg = GetRegName;
-  switch (Style) {
-  case OutputStyleKind::LLVM:
+  switch (OutputStyle) {
+  case LLVM:
     DICtx.dump(OS, DumpOpts, DumpOffsets);
     break;
-  case OutputStyleKind::JSON:
+  case JSON:
     WithColor::warning() << "JSON output style is not yet implemented\n";
     break;
-  case OutputStyleKind::Unknown:
+  case UNKNOWN:
     WithColor::error() << "--output-style value should be either 'LLVM' or "
                           "'JSON', but was '"
                        << OutputStyleOpt << "'\n";
@@ -909,11 +909,11 @@ int main(int argc, char **argv) {
       "pretty-print DWARF debug information in object files"
       " and debug info archives.\n");
 
-  Style = StringSwitch<OutputStyleKind>(OutputStyleOpt)
-              .Case("LLVM", OutputStyleKind::LLVM)
-              .Case("JSON", OutputStyleKind::JSON)
-              .Default(OutputStyleKind::Unknown);
-  if (Style == OutputStyleKind::Unknown) {
+  OutputStyle = StringSwitch<OutputStyleTy>(OutputStyleOpt)
+                    .Case("LLVM", LLVM)
+                    .Case("JSON", JSON)
+                    .Default(UNKNOWN);
+  if (OutputStyle == UNKNOWN) {
     WithColor::error(errs(), sys::path::filename(argv[0]))
         << "--output-style value should be either 'LLVM' or 'JSON', but was '"
         << OutputStyleOpt << "'\n";

--- a/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
+++ b/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
@@ -136,7 +136,7 @@ enum ErrorDetailLevel {
   Unspecified
 };
 
-enum OutputStyleTy { LLVM, JSON, UNKNOWN };
+enum class OutputStyleKind { LLVM, JSON, Unknown };
 
 OptionCategory DwarfDumpCategory("Specific Options");
 static list<std::string>
@@ -341,7 +341,7 @@ static opt<std::string>
     OutputStyleOpt("output-style", init("LLVM"),
                    desc("Specify the format of the output (LLVM or JSON)"),
                    cat(DwarfDumpCategory));
-static OutputStyleTy OutputStyle = LLVM;
+static OutputStyleKind Style = OutputStyleKind::LLVM;
 static opt<bool>
     ShowVariableCoverage("show-variable-coverage",
                          desc("Show per-variable coverage metrics."),
@@ -783,14 +783,14 @@ static bool dumpObjectFile(ObjectFile &Obj, DWARFContext &DICtx,
   // Dump the complete DWARF structure.
   auto DumpOpts = getDumpOpts(DICtx);
   DumpOpts.GetNameForDWARFReg = GetRegName;
-  switch (OutputStyle) {
-  case LLVM:
+  switch (Style) {
+  case OutputStyleKind::LLVM:
     DICtx.dump(OS, DumpOpts, DumpOffsets);
     break;
-  case JSON:
+  case OutputStyleKind::JSON:
     WithColor::warning() << "JSON output style is not yet implemented\n";
     break;
-  case UNKNOWN:
+  case OutputStyleKind::Unknown:
     WithColor::error() << "--output-style value should be either 'LLVM' or "
                           "'JSON', but was '"
                        << OutputStyleOpt << "'\n";
@@ -909,11 +909,11 @@ int main(int argc, char **argv) {
       "pretty-print DWARF debug information in object files"
       " and debug info archives.\n");
 
-  OutputStyle = StringSwitch<OutputStyleTy>(OutputStyleOpt)
-                    .Case("LLVM", LLVM)
-                    .Case("JSON", JSON)
-                    .Default(UNKNOWN);
-  if (OutputStyle == UNKNOWN) {
+  Style = StringSwitch<OutputStyleKind>(OutputStyleOpt)
+              .Case("LLVM", OutputStyleKind::LLVM)
+              .Case("JSON", OutputStyleKind::JSON)
+              .Default(OutputStyleKind::Unknown);
+  if (Style == OutputStyleKind::Unknown) {
     WithColor::error(errs(), sys::path::filename(argv[0]))
         << "--output-style value should be either 'LLVM' or 'JSON', but was '"
         << OutputStyleOpt << "'\n";

--- a/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
+++ b/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
@@ -16,6 +16,7 @@
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVectorExtras.h"
 #include "llvm/ADT/StringSet.h"
+#include "llvm/ADT/StringSwitch.h"
 #include "llvm/DebugInfo/DIContext.h"
 #include "llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h"
 #include "llvm/DebugInfo/DWARF/DWARFCompileUnit.h"
@@ -134,6 +135,8 @@ enum ErrorDetailLevel {
   BothDetailsAndSummary,
   Unspecified
 };
+
+enum OutputStyleTy { LLVM, JSON, UNKNOWN };
 
 OptionCategory DwarfDumpCategory("Specific Options");
 static list<std::string>
@@ -334,6 +337,11 @@ static opt<bool> Verbose("verbose",
                          cat(DwarfDumpCategory));
 static alias VerboseAlias("v", desc("Alias for --verbose."), aliasopt(Verbose),
                           cat(DwarfDumpCategory), cl::NotHidden);
+static opt<std::string>
+    OutputStyleOpt("output-style", init("LLVM"),
+                   desc("Specify the format of the output (LLVM or JSON)"),
+                   cat(DwarfDumpCategory));
+static OutputStyleTy OutputStyle = LLVM;
 static opt<bool>
     ShowVariableCoverage("show-variable-coverage",
                          desc("Show per-variable coverage metrics."),
@@ -775,7 +783,19 @@ static bool dumpObjectFile(ObjectFile &Obj, DWARFContext &DICtx,
   // Dump the complete DWARF structure.
   auto DumpOpts = getDumpOpts(DICtx);
   DumpOpts.GetNameForDWARFReg = GetRegName;
-  DICtx.dump(OS, DumpOpts, DumpOffsets);
+  switch (OutputStyle) {
+  case LLVM:
+    DICtx.dump(OS, DumpOpts, DumpOffsets);
+    break;
+  case JSON:
+    WithColor::warning() << "JSON output style is not yet implemented\n";
+    break;
+  case UNKNOWN:
+    WithColor::error() << "--output-style value should be either 'LLVM' or "
+                          "'JSON', but was '"
+                       << OutputStyleOpt << "'\n";
+    return false;
+  }
   return true;
 }
 
@@ -888,6 +908,17 @@ int main(int argc, char **argv) {
       argc, argv,
       "pretty-print DWARF debug information in object files"
       " and debug info archives.\n");
+
+  OutputStyle = StringSwitch<OutputStyleTy>(OutputStyleOpt)
+                    .Case("LLVM", LLVM)
+                    .Case("JSON", JSON)
+                    .Default(UNKNOWN);
+  if (OutputStyle == UNKNOWN) {
+    WithColor::error(errs(), sys::path::filename(argv[0]))
+        << "--output-style value should be either 'LLVM' or 'JSON', but was '"
+        << OutputStyleOpt << "'\n";
+    return 1;
+  }
 
   // FIXME: Audit interactions between these two options and make them
   //        compatible.


### PR DESCRIPTION
The `--output-style` flag gives the option to print in JSON format or LLVM format. This specific PR just adds the flag option to `llvm-dwarfdump` with TODO for the JSON format, which I will be implementing in the next PRs. I have not added any specific testcase for this. The option has also been updated in `llvm-dwardump --help` section for the same.

Partially fixes #147850 