### PR TITLE
[VectorCombine] Handle frees and synchronization in single element stores

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
+++ b/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
@@ -1833,15 +1833,21 @@ bool VectorCombine::foldBinopOfReductions(Instruction &I) {
   return true;
 }
 
-// Check if memory loc modified between two instrs in the same BB
+// Check if memory is modified, freed, or synchronized between two instrs in
+// the same BB.
 static bool isMemModifiedBetween(BasicBlock::iterator Begin,
                                  BasicBlock::iterator End,
                                  const MemoryLocation &Loc, AAResults &AA) {
   unsigned NumScanned = 0;
-  return std::any_of(Begin, End, [&](const Instruction &Instr) {
-    return isModSet(AA.getModRefInfo(&Instr, Loc)) ||
-           ++NumScanned > MaxInstrsToScan;
-  });
+  if (std::any_of(Begin, End, [&](const Instruction &Instr) {
+        return isModSet(AA.getModRefInfo(&Instr, Loc)) ||
+               ++NumScanned > MaxInstrsToScan;
+      }))
+    return true;
+
+  // willNotFreeBetween expects instructions rather than iterators. An empty
+  // range cannot free or synchronize, so avoid dereferencing its end.
+  return Begin != End && !willNotFreeBetween(&*Begin, &*End);
 }
 
 namespace {

--- a/llvm/test/Transforms/VectorCombine/SPIRV/load-insert-store.ll
+++ b/llvm/test/Transforms/VectorCombine/SPIRV/load-insert-store.ll
@@ -800,7 +800,7 @@ entry:
 
 declare void @foo()
 declare void @maywrite(ptr)
-declare void @nowrite(ptr) readonly
+declare void @nowrite(ptr) readonly nofree
 
 ; To test if number of instructions in-between exceeds the limit (default 30),
 ; the combine will quit.

--- a/llvm/test/Transforms/VectorCombine/load-insert-store.ll
+++ b/llvm/test/Transforms/VectorCombine/load-insert-store.ll
@@ -16,6 +16,26 @@ entry:
   ret void
 }
 
+declare void @may_synchronize() memory(none)
+
+define void @insert_store_across_synchronization(ptr %q, i32 %s) {
+; CHECK-LABEL: @insert_store_across_synchronization(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[V:%.*]] = load <4 x i32>, ptr [[Q:%.*]], align 16
+; CHECK-NEXT:    call void @may_synchronize()
+; CHECK-NEXT:    [[VECINS:%.*]] = insertelement <4 x i32> [[V]], i32 [[S:%.*]],
+; CHECK-SAME:    i32 1
+; CHECK-NEXT:    store <4 x i32> [[VECINS]], ptr [[Q]], align 16
+; CHECK-NEXT:    ret void
+;
+entry:
+  %v = load <4 x i32>, ptr %q, align 16
+  call void @may_synchronize()
+  %vecins = insertelement <4 x i32> %v, i32 %s, i32 1
+  store <4 x i32> %vecins, ptr %q, align 16
+  ret void
+}
+
 define void @insert_store_i16_align1(ptr %q, i16 zeroext %s) {
 ; CHECK-LABEL: @insert_store_i16_align1(
 ; CHECK-NEXT:  entry:
@@ -762,7 +782,7 @@ entry:
 
 declare void @foo()
 declare void @maywrite(ptr)
-declare void @nowrite(ptr) readonly
+declare void @nowrite(ptr) readonly nofree
 
 ; To test if number of instructions in-between exceeds the limit (default 30),
 ; the combine will quit.


### PR DESCRIPTION
foldSingleElementStore only checked whether intervening instructions modified
the stored memory. Calls that may free or synchronize could therefore make
scalarization incorrect.

Fixes https://github.com/llvm/llvm-project/issues/216557
