### PR TITLE
[compiler-rt] Add libbacktrace support on Windows

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_libbacktrace.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_libbacktrace.cpp
@@ -19,15 +19,16 @@
 
 #if SANITIZER_LIBBACKTRACE
 # include "backtrace-supported.h"
-# if SANITIZER_POSIX && BACKTRACE_SUPPORTED && !BACKTRACE_USES_MALLOC
-#  include "backtrace.h"
-#  if SANITIZER_CP_DEMANGLE
-#   undef ARRAY_SIZE
-#   include "demangle.h"
+#  if (SANITIZER_POSIX || SANITIZER_WINDOWS) && BACKTRACE_SUPPORTED && \
+      !BACKTRACE_USES_MALLOC
+#    include "backtrace.h"
+#    if SANITIZER_CP_DEMANGLE
+#      undef ARRAY_SIZE
+#      include "demangle.h"
+#    endif
+#  else
+#    define SANITIZER_LIBBACKTRACE 0
 #  endif
-# else
-#  define SANITIZER_LIBBACKTRACE 0
-# endif
 #endif
 
 namespace __sanitizer {

--- a/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_win.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_win.cpp
@@ -16,6 +16,7 @@
 
 #  include "sanitizer_dbghelp.h"
 #  include "sanitizer_symbolizer_internal.h"
+#  include "sanitizer_symbolizer_libbacktrace.h"
 
 namespace __sanitizer {
 
@@ -279,6 +280,12 @@ static void ChooseSymbolizerTools(IntrusiveList<SymbolizerTool> *list,
     return;
   }
 
+#  if defined(__GNUC__) && !defined(__clang__)
+  if (SymbolizerTool* tool = LibbacktraceSymbolizer::get(allocator)) {
+    VReport(2, "Using libbacktrace symbolizer.\n");
+    list->push_back(tool);
+  }
+#  else
   // Add llvm-symbolizer.
   const char *user_path = common_flags()->external_symbolizer_path;
 
@@ -301,6 +308,7 @@ static void ChooseSymbolizerTools(IntrusiveList<SymbolizerTool> *list,
   } else {
     VReport(2, "External symbolizer is not present.\n");
   }
+#  endif
 
   // Add the dbghelp based symbolizer.
   list->push_back(new(*allocator) WinSymbolizerTool());


### PR DESCRIPTION
Allow the libbacktrace symbolizer on non-POSIX targets when libbacktrace is supported and does not use malloc.

For Windows runtimes built with GCC, register libbacktrace before the DbgHelp symbolizer instead of searching for llvm-symbolizer. Keep the existing symbolizer selection for Clang builds.

This change was split out of https://github.com/llvm/llvm-project/pull/209902, which adds GCC support to the sanitizer runtimes on Windows.