### PR TITLE
[compiler-rt] Adjust ASan Windows tests for mingw-w64

### DIFF
--- a/compiler-rt/test/asan/TestCases/Windows/fuse-lld.cpp
+++ b/compiler-rt/test/asan/TestCases/Windows/fuse-lld.cpp
@@ -2,8 +2,8 @@
 //
 // REQUIRES: lld-available
 //
-// RUN: %clangxx_asan -O2 %s -o %t.exe -g -gcodeview -fuse-ld=lld -Wl,-debug
-// RUN: not %run %t.exe 2>&1 | FileCheck %s
+// RUN: %clangxx_asan %if target={{.*-windows-gnu}} %{ -gcodeview -gcolumn-info -Wl,--pdb= %} %else %{ -g -gcodeview -Wl,-debug %} -O2 %s -o %t.exe -fuse-ld=lld
+// RUN: not %run %t.exe 2>&1 | FileCheck %s --check-prefixes=CHECK,%if target={{.*-windows-msvc.*}} %{MSVC%} %else %{MINGW%}
 
 #include <stdlib.h>
 
@@ -13,7 +13,9 @@ int main() {
   return x[5];
   // CHECK: heap-use-after-free
   // CHECK: free
-  // CHECK: main{{.*}}fuse-lld.cpp:[[@LINE-4]]:3
+  // MSVC: main{{.*}}fuse-lld.cpp:[[@LINE-4]]:3
+  // MINGW: {{.*fuse-lld.cpp.tmp.exe\+0x14000[0-9a-f]+}}
   // CHECK: malloc
-  // CHECK: main{{.*}}fuse-lld.cpp:[[@LINE-7]]:20
+  // MSVC: main{{.*}}fuse-lld.cpp:[[@LINE-8]]:20
+  // MINGW: {{.*fuse-lld.cpp.tmp.exe\+0x14000[0-9a-f]+}}
 }

--- a/compiler-rt/test/asan/TestCases/Windows/fuse-lld.cpp
+++ b/compiler-rt/test/asan/TestCases/Windows/fuse-lld.cpp
@@ -2,8 +2,8 @@
 //
 // REQUIRES: lld-available
 //
-// RUN: %clangxx_asan %if target={{.*-windows-gnu}} %{ -gcodeview -gcolumn-info -Wl,--pdb= %} %else %{ -g -gcodeview -Wl,-debug %} -O2 %s -o %t.exe -fuse-ld=lld
-// RUN: not %run %t.exe 2>&1 | FileCheck %s --check-prefixes=CHECK,%if target={{.*-windows-msvc.*}} %{MSVC%} %else %{MINGW%}
+// RUN: %clangxx_asan %if target={{.*-windows-gnu}} %{ -gcodeview -gcolumn-info -Wl,--pdb= -Wl,-S %} %else %{ -g -gcodeview -Wl,-debug %} -O2 %s -o %t.exe -fuse-ld=lld
+// RUN: not %run %t.exe 2>&1 | FileCheck %s
 
 #include <stdlib.h>
 
@@ -13,9 +13,7 @@ int main() {
   return x[5];
   // CHECK: heap-use-after-free
   // CHECK: free
-  // MSVC: main{{.*}}fuse-lld.cpp:[[@LINE-4]]:3
-  // MINGW: {{.*fuse-lld.cpp.tmp.exe\+0x14000[0-9a-f]+}}
+  // CHECK: main{{.*}}fuse-lld.cpp:[[@LINE-4]]:3
   // CHECK: malloc
-  // MSVC: main{{.*}}fuse-lld.cpp:[[@LINE-8]]:20
-  // MINGW: {{.*fuse-lld.cpp.tmp.exe\+0x14000[0-9a-f]+}}
+  // CHECK: main{{.*}}fuse-lld.cpp:[[@LINE-7]]:20
 }

--- a/compiler-rt/test/asan/TestCases/Windows/unsymbolized.cpp
+++ b/compiler-rt/test/asan/TestCases/Windows/unsymbolized.cpp
@@ -3,9 +3,13 @@
 // which is the default image base of an executable.
 
 // RUN: rm -f %t.pdb
-// RUN: %clangxx_asan -c -O2 %s -o %t.obj
-// RUN: lld-link /nologo /OUT:%t.exe %t.obj -defaultlib:libcmt -nodefaultlib:msvcrt -defaultlib:oldnames %asan_static_runtime_thunk %asan_lib
-// RUN: not %run %t.exe 2>&1 | FileCheck %s
+// RUN: %if target={{.*-windows-gnu}} %{ \
+// RUN:   %clangxx_asan -O2 %s -o %t.exe -gcodeview -gcolumn-info -fuse-ld=lld \
+// RUN: %} %else %{ \
+// RUN:   %clangxx_asan -c -O2 %s -o %t.obj && \
+// RUN:   lld-link /nologo /OUT:%t.exe %t.obj -defaultlib:libcmt -nodefaultlib:msvcrt -defaultlib:oldnames %asan_static_runtime_thunk %asan_lib \
+// RUN: %}
+// RUN: not %run %t.exe 2>&1 | FileCheck %s --check-prefixes=CHECK,%if target={{.*-windows-msvc.*}} %{MSVC%} %else %{MINGW%}
 // REQUIRES: lld-available
 
 #include "../defines.h"
@@ -22,6 +26,8 @@ int do_uaf(void) {
   free(x);
   return x[5];
   // CHECK: AddressSanitizer: heap-use-after-free
-  // CHECK: #0 {{0x[a-f0-9]+ \(.*[\\/]unsymbolized.cpp.*.exe\+(0x40|0x14000)[a-f0-9]{4}\)}}
-  // CHECK: #1 {{0x[a-f0-9]+ \(.*[\\/]unsymbolized.cpp.*.exe\+(0x40|0x14000)[a-f0-9]{4}\)}}
+  // MSVC: #0 {{0x[a-f0-9]+ \(.*[\\/]unsymbolized.cpp.*.exe\+(0x40|0x14000)[a-f0-9]{4}\)}}
+  // MSVC: #1 {{0x[a-f0-9]+ \(.*[\\/]unsymbolized.cpp.*.exe\+(0x40|0x14000)[a-f0-9]{4}\)}}
+  // MINGW: #0 {{0x[a-f0-9]+ in do_uaf\(\) \(.*[\\/]unsymbolized.cpp.*.exe\+0x14000[a-f0-9]{4}\)}}
+  // MINGW: #1 {{0x[a-f0-9]+ in main \(.*[\\/]unsymbolized.cpp.*.exe\+0x14000[a-f0-9]{4}\)}}
 }

--- a/compiler-rt/test/asan/TestCases/Windows/unsymbolized.cpp
+++ b/compiler-rt/test/asan/TestCases/Windows/unsymbolized.cpp
@@ -4,12 +4,12 @@
 
 // RUN: rm -f %t.pdb
 // RUN: %if target={{.*-windows-gnu}} %{ \
-// RUN:   %clangxx_asan -O2 %s -o %t.exe -gcodeview -gcolumn-info -fuse-ld=lld \
+// RUN:   %clangxx_asan -O2 %s -o %t.exe -fuse-ld=lld -Wl,-s \
 // RUN: %} %else %{ \
 // RUN:   %clangxx_asan -c -O2 %s -o %t.obj && \
 // RUN:   lld-link /nologo /OUT:%t.exe %t.obj -defaultlib:libcmt -nodefaultlib:msvcrt -defaultlib:oldnames %asan_static_runtime_thunk %asan_lib \
 // RUN: %}
-// RUN: not %run %t.exe 2>&1 | FileCheck %s --check-prefixes=CHECK,%if target={{.*-windows-msvc.*}} %{MSVC%} %else %{MINGW%}
+// RUN: not %run %t.exe 2>&1 | FileCheck %s
 // REQUIRES: lld-available
 
 #include "../defines.h"
@@ -26,8 +26,6 @@ int do_uaf(void) {
   free(x);
   return x[5];
   // CHECK: AddressSanitizer: heap-use-after-free
-  // MSVC: #0 {{0x[a-f0-9]+ \(.*[\\/]unsymbolized.cpp.*.exe\+(0x40|0x14000)[a-f0-9]{4}\)}}
-  // MSVC: #1 {{0x[a-f0-9]+ \(.*[\\/]unsymbolized.cpp.*.exe\+(0x40|0x14000)[a-f0-9]{4}\)}}
-  // MINGW: #0 {{0x[a-f0-9]+ in do_uaf\(\) \(.*[\\/]unsymbolized.cpp.*.exe\+0x14000[a-f0-9]{4}\)}}
-  // MINGW: #1 {{0x[a-f0-9]+ in main \(.*[\\/]unsymbolized.cpp.*.exe\+0x14000[a-f0-9]{4}\)}}
+  // CHECK: #0 {{0x[a-f0-9]+ \(.*[\\/]unsymbolized.cpp.*.exe\+(0x40|0x14000)[a-f0-9]{4}\)}}
+  // CHECK: #1 {{0x[a-f0-9]+ \(.*[\\/]unsymbolized.cpp.*.exe\+(0x40|0x14000)[a-f0-9]{4}\)}}
 }


### PR DESCRIPTION
Add MinGW-specific configurations to the fuse-lld and unsymbolized tests. Use the Clang driver and GNU-compatible LLD options instead of the MSVC-oriented lld-link invocation, and account for differences in the resulting symbolization output.

This change was split out of https://github.com/llvm/llvm-project/pull/209902, which adds GCC support to the sanitizer runtimes on Windows.