### PR TITLE
[compiler-rt] Clean up Windows includes in sanitizer runtimes

### DIFF
--- a/compiler-rt/lib/asan/asan_malloc_win.cpp
+++ b/compiler-rt/lib/asan/asan_malloc_win.cpp
@@ -14,12 +14,14 @@
 #include "sanitizer_common/sanitizer_allocator_interface.h"
 #include "sanitizer_common/sanitizer_platform.h"
 #if SANITIZER_WINDOWS
-#include "asan_allocator.h"
-#include "asan_interceptors.h"
-#include "asan_internal.h"
-#include "asan_stack.h"
-#include "interception/interception.h"
-#include <stddef.h>
+#  include <stddef.h>
+
+#  include "asan_allocator.h"
+#  include "asan_interceptors.h"
+#  include "asan_internal.h"
+#  include "asan_stack.h"
+#  include "interception/interception.h"
+#  include "sanitizer_common/sanitizer_win_defs.h"
 
 // Intentionally not including windows.h here, to avoid the risk of
 // pulling in conflicting declarations of these functions. (With mingw-w64,

--- a/compiler-rt/lib/builtins/emutls.c
+++ b/compiler-rt/lib/builtins/emutls.c
@@ -138,6 +138,7 @@ static __inline void emutls_unlock(void) { pthread_mutex_unlock(&emutls_mutex); 
 #include <assert.h>
 #include <malloc.h>
 #include <stdio.h>
+#define WIN32_LEAN_AND_MEAN 1
 #include <windows.h>
 
 static LPCRITICAL_SECTION emutls_mutex;

--- a/compiler-rt/lib/builtins/gcc_personality_v0.c
+++ b/compiler-rt/lib/builtins/gcc_personality_v0.c
@@ -22,8 +22,8 @@
 #endif
 
 #if defined(__SEH__) && !defined(__USING_SJLJ_EXCEPTIONS__)
+#define WIN32_LEAN_AND_MEAN 1
 #include <windows.h>
-#include <winnt.h>
 
 EXCEPTION_DISPOSITION _GCC_specific_handler(PEXCEPTION_RECORD, void *, PCONTEXT,
                                             PDISPATCHER_CONTEXT,


### PR DESCRIPTION
Extracted from https://github.com/llvm/llvm-project/pull/209902.
 It's one of the patches that enables ASan and UBSan in GCC for Windows.