### PR TITLE
[clang] Preserve matching constraints for register variables

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -415,6 +415,7 @@ features cannot lower the translation-unit ABI level;
 - Fixed an ICE that occurred when a structured binding pack is expanded outside the lambda where it was declared. (#GH214160)
 - Fixed a bug where a stray closing curley brace in an OpenMP/OpenACC pragma could cause pragma parsing issues when inside of a member function. (#GH214195)
 - Fixed a bug where preprocessor directives following comments were not correctly recognized when using -C. (#GH48361)
+- Fixed a bug where inline assembly matching constraints were not preserved for register variables. (#GH44930)
 
 #### Bug Fixes to Compiler Builtins
 

--- a/clang/lib/AST/Stmt.cpp
+++ b/clang/lib/AST/Stmt.cpp
@@ -474,6 +474,10 @@ AsmStmt::addVariableConstraints(StringRef Constraint, const Expr &AsmExpr,
     return Constraint.str();
   StringRef Register = Attr->getLabel();
   assert(Target.isValidGCCRegisterName(Register));
+  // Preserve matching constraints instead of replacing them with the
+  // register variable's fixed register.
+  if (Constraint[0] == '%' || isdigit(Constraint[0]))
+    return Constraint.str();
   // We're using validateOutputConstraint here because we only care if
   // this is a register constraint.
   TargetInfo::ConstraintInfo Info(Constraint, "");

--- a/clang/test/CodeGen/PowerPC/inline-asm-matching-constraint.c
+++ b/clang/test/CodeGen/PowerPC/inline-asm-matching-constraint.c
@@ -8,4 +8,4 @@ void a(void) {
 
 // Check that we can generate code for this correctly. The matching input
 // constraint should not have an early clobber on it.
-// CHECK: call i64 asm sideeffect "mfcr $0", "=&{r0},{r0}"
+// CHECK: call i64 asm sideeffect "mfcr $0", "=&{r0},0"

--- a/clang/test/CodeGen/inline-asm-register-variable-matching.c
+++ b/clang/test/CodeGen/inline-asm-register-variable-matching.c
@@ -1,0 +1,19 @@
+// RUN: %clang_cc1 -triple s390x-unknown-linux-gnu -emit-llvm -o - %s | FileCheck %s
+
+void test() {
+  unsigned long sum_high = 1, sum_low = 2;
+  register unsigned long a_high asm("r8") = 3;
+  register unsigned long a_low asm("r9") = 4;
+  unsigned long b_high = 5, b_low = 6;
+
+  __asm__ (
+      "algr\t%1,%5\n\t"
+      "alcgr\t%0,%3"
+      : "=r"(sum_high), "=&r"(sum_low)
+      : "0"(a_high), "r"(b_high),
+        "%1"(a_low), "r"(b_low)
+      : "cc");
+}
+
+// CHECK-NOT: "=r,=&r,{r8},r,{r9},r,~{cc}"
+// CHECK: "=r,=&r,0,r,%1,r,~{cc}"


### PR DESCRIPTION
When a matching constraint is used with a register variable, preserve the matching constraint instead of replacing it with a fixed-register constraint.

For example, a constraint such as "0" must remain a matching constraint even when the corresponding register variable is assigned to a specific register. Replacing it with "{r8}" loses the relationship between the input and output operands.

This can result in invalid code when the matching constraint requires the input operand to use the same register as an output operand.

Fixes: #44930