### PR TITLE
[ExpandVariadics] Move NewPM class to RequiredPassInfoMixin

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/ExpandVariadics.h
+++ b/llvm/include/llvm/Transforms/IPO/ExpandVariadics.h
@@ -22,7 +22,7 @@ enum class ExpandVariadicsMode {
   Lowering,    // Change variadic calling convention
 };
 
-class ExpandVariadicsPass : public OptionalPassInfoMixin<ExpandVariadicsPass> {
+class ExpandVariadicsPass : public RequiredPassInfoMixin<ExpandVariadicsPass> {
   const ExpandVariadicsMode Mode;
 
 public:


### PR DESCRIPTION
This pass is required lowering for most targets that use it during CodeGen.