### PR TITLE
GlobalISel: Introduce m_GPtrAdd flags matcher in CombinerHelper

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/MIPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/MIPatternMatch.h
@@ -430,6 +430,15 @@ inline bind_ty<CmpInst::Predicate> m_Pred(CmpInst::Predicate &P) { return P; }
 inline operand_type_match m_Pred() { return operand_type_match(); }
 inline bind_ty<FPClassTest> m_FPClassTest(FPClassTest &T) { return T; }
 
+/// Wraps a MIFlags output for use as an optional trailing operand of an
+/// instruction matcher (e.g. m_GPtrAdd(L, R, m_MIFlags(Flags))). On a
+/// successful match the matched instruction's flags are written to \p Flags.
+struct MIFlagsRef {
+  uint32_t &Flags;
+};
+
+inline MIFlagsRef m_MIFlags(uint32_t &Flags) { return {Flags}; }
+
 template <typename BindTy> struct deferred_helper {
   static bool match(const MachineRegisterInfo &MRI, BindTy &VR, BindTy &V) {
     return VR == V;
@@ -504,8 +513,12 @@ template <typename LHS_P, typename RHS_P, unsigned Opcode,
 struct BinaryOp_match {
   LHS_P L;
   RHS_P R;
+  // Optional output: when set, receives the matched instruction's flags.
+  uint32_t *FlagsOut = nullptr;
 
   BinaryOp_match(const LHS_P &LHS, const RHS_P &RHS) : L(LHS), R(RHS) {}
+  BinaryOp_match(const LHS_P &LHS, const RHS_P &RHS, MIFlagsRef FlagsOut)
+      : L(LHS), R(RHS), FlagsOut(&FlagsOut.Flags) {}
   template <typename OpTy>
   bool match(const MachineRegisterInfo &MRI, OpTy &&Op) {
     const MachineInstr *TmpMI;
@@ -521,7 +534,11 @@ struct BinaryOp_match {
             (!Commutable || !L.match(MRI, TmpMI->getOperand(2).getReg()) ||
              !R.match(MRI, TmpMI->getOperand(1).getReg())))
           return false;
-        return (TmpMI->getFlags() & Flags) == Flags;
+        if ((TmpMI->getFlags() & Flags) != Flags)
+          return false;
+        if (FlagsOut)
+          *FlagsOut = TmpMI->getFlags();
+        return true;
       }
     }
     return false;
@@ -593,6 +610,12 @@ template <typename LHS, typename RHS>
 inline BinaryOp_match<LHS, RHS, TargetOpcode::G_PTR_ADD, false>
 m_GPtrAdd(const LHS &L, const RHS &R) {
   return BinaryOp_match<LHS, RHS, TargetOpcode::G_PTR_ADD, false>(L, R);
+}
+
+template <typename LHS, typename RHS>
+inline BinaryOp_match<LHS, RHS, TargetOpcode::G_PTR_ADD, false>
+m_GPtrAdd(const LHS &L, const RHS &R, MIFlagsRef Flags) {
+  return BinaryOp_match<LHS, RHS, TargetOpcode::G_PTR_ADD, false>(L, R, Flags);
 }
 
 template <typename LHS, typename RHS>

--- a/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
@@ -1848,12 +1848,12 @@ bool CombinerHelper::matchPtrAddImmedChain(MachineInstr &MI,
   if (!MaybeImmVal)
     return false;
 
-  MachineInstr *Add2Def = MRI.getVRegDef(Add2);
-  if (!Add2Def || Add2Def->getOpcode() != TargetOpcode::G_PTR_ADD)
+  Register Base, Imm2;
+  uint32_t LHSPtrAddFlags;
+  if (!mi_match(Add2, MRI,
+                m_GPtrAdd(m_Reg(Base), m_Reg(Imm2), m_MIFlags(LHSPtrAddFlags))))
     return false;
 
-  Register Base = Add2Def->getOperand(1).getReg();
-  Register Imm2 = Add2Def->getOperand(2).getReg();
   auto MaybeImm2Val = getIConstantVRegValWithLookThrough(Imm2, MRI);
   if (!MaybeImm2Val)
     return false;
@@ -1892,7 +1892,6 @@ bool CombinerHelper::matchPtrAddImmedChain(MachineInstr &MI,
   // largest signed integer that fits into the index type, which is the maximum
   // size of allocated objects according to the IR Language Reference.
   unsigned PtrAddFlags = MI.getFlags();
-  unsigned LHSPtrAddFlags = Add2Def->getFlags();
   bool IsNoUWrap = PtrAddFlags & LHSPtrAddFlags & MachineInstr::MIFlag::NoUWrap;
   bool IsInBounds =
       PtrAddFlags & LHSPtrAddFlags & MachineInstr::MIFlag::InBounds;


### PR DESCRIPTION
Add an optional MIFlags output operand to the binary-op matcher and a
m_GPtrAdd(L, R, m_MIFlags(F)) overload, and use it to replace getVRegDef +
opcode checks.

Co-authored-by: Claude (Opus 4.8) <noreply@anthropic.com>