### PR TITLE
[asan][test] Exclude invalid-pointer-pairs-vector-extract.cpp from Solaris

### DIFF
--- a/compiler-rt/test/asan/TestCases/invalid-pointer-pairs-vector-extract.cpp
+++ b/compiler-rt/test/asan/TestCases/invalid-pointer-pairs-vector-extract.cpp
@@ -4,6 +4,8 @@
 // RUN: %env_asan_opts=detect_invalid_pointer_pairs=2:halt_on_error=0 %run %t 2>&1 | FileCheck %s
 
 // UNSUPPORTED: windows
+// UNSUPPORTED: target={{.*solaris.*}}
+
 // XFAIL: *
 
 #include <cstdint>


### PR DESCRIPTION
Intended to fix buildbot breakage on Solaris (XPASS), as reported in https://github.com/llvm/llvm-project/pull/216532#issuecomment-5309297518

This change is only a transient step for the test, since the upcoming https://github.com/llvm/llvm-project/pull/213546 is expected to make the test pass on all platforms.