### PR TITLE
Fix `fp128` reaching `llvm_unreachable` on 32-bit PowerPC

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -4281,13 +4281,10 @@ SDValue PPCTargetLowering::LowerFormalArguments_32SVR4(
         case MVT::v16i8:
         case MVT::v8i16:
         case MVT::v4i32:
-          RC = &PPC::VRRCRegClass;
-          break;
         case MVT::v4f32:
-          RC = &PPC::VRRCRegClass;
-          break;
         case MVT::v2f64:
         case MVT::v2i64:
+        case MVT::f128:
           RC = &PPC::VRRCRegClass;
           break;
       }

--- a/llvm/test/CodeGen/PowerPC/ppc32-f128-abi.ll
+++ b/llvm/test/CodeGen/PowerPC/ppc32-f128-abi.ll
@@ -1,0 +1,9 @@
+; RUN: llc -verify-machineinstrs -mattr=+vsx < %s | FileCheck %s
+target triple = "powerpc-unknown-linux-gnu"
+
+; CHECK-LABEL: return_second:
+; CHECK: vmr 2, 3
+; CHECK-NEXT: blr
+define fp128 @return_second(fp128, fp128) {
+    ret fp128 %1
+}


### PR DESCRIPTION
`fp128` is a legal type that is passed in vector registers when `vsx` is enabled on 32-bit PowerPC: the switch statement didn't account for that, causing an LLVM assertion.

Fixes #213355

cc @folkertdev