### PR TITLE
[CodeGen] Pass alignment and size to supportsUnalignedAtomics. NFC

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -2279,11 +2279,11 @@ public:
   /// require a more complex expansion.
   unsigned getMinCmpXchgSizeInBits() const { return MinCmpXchgSizeInBits; }
 
-  /// Return true if the target can lower the atomic instruction \p I when it
-  /// has the given \p Alignment, for an access of \p SizeInBytes bytes. The
-  /// default implementation only allows naturally aligned atomics, unless
-  /// setSupportsUnalignedAtomics(true) was called.
-  virtual bool supportsAtomicAlignment(const Instruction *I, Align Alignment,
+  /// Return true if the target supports an atomic access of \p SizeInBytes
+  /// bytes at the given \p Alignment. The default implementation only allows
+  /// naturally aligned atomics, unless setSupportsUnalignedAtomics(true) was
+  /// called.
+  virtual bool supportsAtomicAlignment(Align Alignment,
                                        uint64_t SizeInBytes) const {
     return SupportsUnalignedAtomics || Alignment.value() >= SizeInBytes;
   }

--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -2279,9 +2279,13 @@ public:
   /// require a more complex expansion.
   unsigned getMinCmpXchgSizeInBits() const { return MinCmpXchgSizeInBits; }
 
-  /// Whether the target supports unaligned atomic operations.
-  virtual bool supportsUnalignedAtomics(const Instruction *I) const {
-    return SupportsUnalignedAtomics;
+  /// Return true if the target can lower the atomic instruction \p I when it
+  /// has the given \p Alignment, for an access of \p SizeInBytes bytes. The
+  /// default implementation only allows naturally aligned atomics, unless
+  /// setSupportsUnalignedAtomics(true) was called.
+  virtual bool supportsAtomicAlignment(const Instruction *I, Align Alignment,
+                                       uint64_t SizeInBytes) const {
+    return SupportsUnalignedAtomics || Alignment.value() >= SizeInBytes;
   }
 
   /// Whether AtomicExpandPass should automatically insert fences and reduce

--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -2283,8 +2283,8 @@ public:
   /// bytes at the given \p Alignment. The default implementation only allows
   /// naturally aligned atomics, unless setSupportsUnalignedAtomics(true) was
   /// called.
-  virtual bool supportsAtomicAlignment(Align Alignment,
-                                       uint64_t SizeInBytes) const {
+  virtual bool isAtomicAlignmentSupported(Align Alignment,
+                                          uint64_t SizeInBytes) const {
     return SupportsUnalignedAtomics || Alignment.value() >= SizeInBytes;
   }
 

--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -2280,7 +2280,9 @@ public:
   unsigned getMinCmpXchgSizeInBits() const { return MinCmpXchgSizeInBits; }
 
   /// Whether the target supports unaligned atomic operations.
-  bool supportsUnalignedAtomics() const { return SupportsUnalignedAtomics; }
+  virtual bool supportsUnalignedAtomics(const Instruction *I) const {
+    return SupportsUnalignedAtomics;
+  }
 
   /// Whether AtomicExpandPass should automatically insert fences and reduce
   /// ordering for this atomic. This should be true for most architectures with

--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -2301,9 +2301,13 @@ public:
   /// require a more complex expansion.
   unsigned getMinCmpXchgSizeInBits() const { return MinCmpXchgSizeInBits; }
 
-  /// Whether the target supports unaligned atomic operations.
-  virtual bool supportsUnalignedAtomics(const Instruction *I) const {
-    return SupportsUnalignedAtomics;
+  /// Return true if the target can lower the atomic instruction \p I when it
+  /// has the given \p Alignment, for an access of \p SizeInBytes bytes. The
+  /// default implementation only allows naturally aligned atomics, unless
+  /// setSupportsUnalignedAtomics(true) was called.
+  virtual bool supportsAtomicAlignment(const Instruction *I, Align Alignment,
+                                       uint64_t SizeInBytes) const {
+    return SupportsUnalignedAtomics || Alignment.value() >= SizeInBytes;
   }
 
   /// Whether AtomicExpandPass should automatically insert fences and reduce

--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -2302,7 +2302,9 @@ public:
   unsigned getMinCmpXchgSizeInBits() const { return MinCmpXchgSizeInBits; }
 
   /// Whether the target supports unaligned atomic operations.
-  bool supportsUnalignedAtomics() const { return SupportsUnalignedAtomics; }
+  virtual bool supportsUnalignedAtomics(const Instruction *I) const {
+    return SupportsUnalignedAtomics;
+  }
 
   /// Whether AtomicExpandPass should automatically insert fences and reduce
   /// ordering for this atomic. This should be true for most architectures with

--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -2301,11 +2301,11 @@ public:
   /// require a more complex expansion.
   unsigned getMinCmpXchgSizeInBits() const { return MinCmpXchgSizeInBits; }
 
-  /// Return true if the target can lower the atomic instruction \p I when it
-  /// has the given \p Alignment, for an access of \p SizeInBytes bytes. The
-  /// default implementation only allows naturally aligned atomics, unless
-  /// setSupportsUnalignedAtomics(true) was called.
-  virtual bool supportsAtomicAlignment(const Instruction *I, Align Alignment,
+  /// Return true if the target supports an atomic access of \p SizeInBytes
+  /// bytes at the given \p Alignment. The default implementation only allows
+  /// naturally aligned atomics, unless setSupportsUnalignedAtomics(true) was
+  /// called.
+  virtual bool supportsAtomicAlignment(Align Alignment,
                                        uint64_t SizeInBytes) const {
     return SupportsUnalignedAtomics || Alignment.value() >= SizeInBytes;
   }

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -5368,7 +5368,7 @@ void SelectionDAGBuilder::visitAtomicLoad(const LoadInst &I) {
   EVT VT = TLI.getValueType(DAG.getDataLayout(), I.getType());
   EVT MemVT = TLI.getMemValueType(DAG.getDataLayout(), I.getType());
 
-  if (!TLI.supportsUnalignedAtomics() &&
+  if (!TLI.supportsUnalignedAtomics(&I) &&
       I.getAlign().value() < MemVT.getSizeInBits() / 8)
     report_fatal_error("Cannot generate unaligned atomic load");
 
@@ -5405,7 +5405,7 @@ void SelectionDAGBuilder::visitAtomicStore(const StoreInst &I) {
   EVT MemVT =
       TLI.getMemValueType(DAG.getDataLayout(), I.getValueOperand()->getType());
 
-  if (!TLI.supportsUnalignedAtomics() &&
+  if (!TLI.supportsUnalignedAtomics(&I) &&
       I.getAlign().value() < MemVT.getSizeInBits() / 8)
     report_fatal_error("Cannot generate unaligned atomic store");
 

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -5368,7 +5368,7 @@ void SelectionDAGBuilder::visitAtomicLoad(const LoadInst &I) {
   EVT VT = TLI.getValueType(DAG.getDataLayout(), I.getType());
   EVT MemVT = TLI.getMemValueType(DAG.getDataLayout(), I.getType());
 
-  if (!TLI.supportsAtomicAlignment(I.getAlign(), MemVT.getSizeInBits() / 8))
+  if (!TLI.isAtomicAlignmentSupported(I.getAlign(), MemVT.getSizeInBits() / 8))
     report_fatal_error("Cannot generate unaligned atomic load");
 
   auto Flags = TLI.getLoadMemOperandFlags(I, DAG.getDataLayout(), AC, LibInfo);
@@ -5404,7 +5404,7 @@ void SelectionDAGBuilder::visitAtomicStore(const StoreInst &I) {
   EVT MemVT =
       TLI.getMemValueType(DAG.getDataLayout(), I.getValueOperand()->getType());
 
-  if (!TLI.supportsAtomicAlignment(I.getAlign(), MemVT.getSizeInBits() / 8))
+  if (!TLI.isAtomicAlignmentSupported(I.getAlign(), MemVT.getSizeInBits() / 8))
     report_fatal_error("Cannot generate unaligned atomic store");
 
   auto Flags = TLI.getStoreMemOperandFlags(I, DAG.getDataLayout());

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -5368,8 +5368,7 @@ void SelectionDAGBuilder::visitAtomicLoad(const LoadInst &I) {
   EVT VT = TLI.getValueType(DAG.getDataLayout(), I.getType());
   EVT MemVT = TLI.getMemValueType(DAG.getDataLayout(), I.getType());
 
-  if (!TLI.supportsUnalignedAtomics(&I) &&
-      I.getAlign().value() < MemVT.getSizeInBits() / 8)
+  if (!TLI.supportsAtomicAlignment(&I, I.getAlign(), MemVT.getSizeInBits() / 8))
     report_fatal_error("Cannot generate unaligned atomic load");
 
   auto Flags = TLI.getLoadMemOperandFlags(I, DAG.getDataLayout(), AC, LibInfo);
@@ -5405,8 +5404,7 @@ void SelectionDAGBuilder::visitAtomicStore(const StoreInst &I) {
   EVT MemVT =
       TLI.getMemValueType(DAG.getDataLayout(), I.getValueOperand()->getType());
 
-  if (!TLI.supportsUnalignedAtomics(&I) &&
-      I.getAlign().value() < MemVT.getSizeInBits() / 8)
+  if (!TLI.supportsAtomicAlignment(&I, I.getAlign(), MemVT.getSizeInBits() / 8))
     report_fatal_error("Cannot generate unaligned atomic store");
 
   auto Flags = TLI.getStoreMemOperandFlags(I, DAG.getDataLayout());

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -5368,7 +5368,7 @@ void SelectionDAGBuilder::visitAtomicLoad(const LoadInst &I) {
   EVT VT = TLI.getValueType(DAG.getDataLayout(), I.getType());
   EVT MemVT = TLI.getMemValueType(DAG.getDataLayout(), I.getType());
 
-  if (!TLI.supportsAtomicAlignment(&I, I.getAlign(), MemVT.getSizeInBits() / 8))
+  if (!TLI.supportsAtomicAlignment(I.getAlign(), MemVT.getSizeInBits() / 8))
     report_fatal_error("Cannot generate unaligned atomic load");
 
   auto Flags = TLI.getLoadMemOperandFlags(I, DAG.getDataLayout(), AC, LibInfo);
@@ -5404,7 +5404,7 @@ void SelectionDAGBuilder::visitAtomicStore(const StoreInst &I) {
   EVT MemVT =
       TLI.getMemValueType(DAG.getDataLayout(), I.getValueOperand()->getType());
 
-  if (!TLI.supportsAtomicAlignment(&I, I.getAlign(), MemVT.getSizeInBits() / 8))
+  if (!TLI.supportsAtomicAlignment(I.getAlign(), MemVT.getSizeInBits() / 8))
     report_fatal_error("Cannot generate unaligned atomic store");
 
   auto Flags = TLI.getStoreMemOperandFlags(I, DAG.getDataLayout());

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -5369,8 +5369,7 @@ void SelectionDAGBuilder::visitAtomicLoad(const LoadInst &I) {
   EVT VT = TLI.getValueType(DAG.getDataLayout(), I.getType());
   EVT MemVT = TLI.getMemValueType(DAG.getDataLayout(), I.getType());
 
-  if (!TLI.supportsUnalignedAtomics(&I) &&
-      I.getAlign().value() < MemVT.getSizeInBits() / 8)
+  if (!TLI.supportsAtomicAlignment(&I, I.getAlign(), MemVT.getSizeInBits() / 8))
     report_fatal_error("Cannot generate unaligned atomic load");
 
   auto Flags = TLI.getLoadMemOperandFlags(I, DAG.getDataLayout(), AC, LibInfo);
@@ -5406,8 +5405,7 @@ void SelectionDAGBuilder::visitAtomicStore(const StoreInst &I) {
   EVT MemVT =
       TLI.getMemValueType(DAG.getDataLayout(), I.getValueOperand()->getType());
 
-  if (!TLI.supportsUnalignedAtomics(&I) &&
-      I.getAlign().value() < MemVT.getSizeInBits() / 8)
+  if (!TLI.supportsAtomicAlignment(&I, I.getAlign(), MemVT.getSizeInBits() / 8))
     report_fatal_error("Cannot generate unaligned atomic store");
 
   auto Flags = TLI.getStoreMemOperandFlags(I, DAG.getDataLayout());

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -5369,7 +5369,7 @@ void SelectionDAGBuilder::visitAtomicLoad(const LoadInst &I) {
   EVT VT = TLI.getValueType(DAG.getDataLayout(), I.getType());
   EVT MemVT = TLI.getMemValueType(DAG.getDataLayout(), I.getType());
 
-  if (!TLI.supportsUnalignedAtomics() &&
+  if (!TLI.supportsUnalignedAtomics(&I) &&
       I.getAlign().value() < MemVT.getSizeInBits() / 8)
     report_fatal_error("Cannot generate unaligned atomic load");
 
@@ -5406,7 +5406,7 @@ void SelectionDAGBuilder::visitAtomicStore(const StoreInst &I) {
   EVT MemVT =
       TLI.getMemValueType(DAG.getDataLayout(), I.getValueOperand()->getType());
 
-  if (!TLI.supportsUnalignedAtomics() &&
+  if (!TLI.supportsUnalignedAtomics(&I) &&
       I.getAlign().value() < MemVT.getSizeInBits() / 8)
     report_fatal_error("Cannot generate unaligned atomic store");
 

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -5369,7 +5369,7 @@ void SelectionDAGBuilder::visitAtomicLoad(const LoadInst &I) {
   EVT VT = TLI.getValueType(DAG.getDataLayout(), I.getType());
   EVT MemVT = TLI.getMemValueType(DAG.getDataLayout(), I.getType());
 
-  if (!TLI.supportsAtomicAlignment(&I, I.getAlign(), MemVT.getSizeInBits() / 8))
+  if (!TLI.supportsAtomicAlignment(I.getAlign(), MemVT.getSizeInBits() / 8))
     report_fatal_error("Cannot generate unaligned atomic load");
 
   auto Flags = TLI.getLoadMemOperandFlags(I, DAG.getDataLayout(), AC, LibInfo);
@@ -5405,7 +5405,7 @@ void SelectionDAGBuilder::visitAtomicStore(const StoreInst &I) {
   EVT MemVT =
       TLI.getMemValueType(DAG.getDataLayout(), I.getValueOperand()->getType());
 
-  if (!TLI.supportsAtomicAlignment(&I, I.getAlign(), MemVT.getSizeInBits() / 8))
+  if (!TLI.supportsAtomicAlignment(I.getAlign(), MemVT.getSizeInBits() / 8))
     report_fatal_error("Cannot generate unaligned atomic store");
 
   auto Flags = TLI.getStoreMemOperandFlags(I, DAG.getDataLayout());


### PR DESCRIPTION
Replace `supportsUnalignedAtomics()` with `isAtomicAlignmentSupported()`, passing the
access alignment and size as target independent properties.

Move the natural alignment check into the default implementation of the new
hook. The default behavior remains unchanged: targets that enable
SupportsUnalignedAtomics accept any alignment, while other targets require the
access to be naturally aligned.