### PR TITLE
[lldb] Improve diagnostic when a variable being assigned isn't an lvalue

### DIFF
--- a/lldb/source/Expression/Materializer.cpp
+++ b/lldb/source/Expression/Materializer.cpp
@@ -648,6 +648,14 @@ public:
       Status set_error;
 
       if (actually_write) {
+        if (!valobj_sp->CanSetValue()) {
+          err = Status::FromErrorStringWithFormatv(
+              "couldn't write the new contents of {0} back into the "
+              "variable\nnote: Left operand of assignment is not an lvalue",
+              GetName());
+          return;
+        }
+
         valobj_sp->SetData(data, set_error);
 
         if (!set_error.Success()) {


### PR DESCRIPTION
In some cases, when a binary is compiled with certain optimization flags, a variable may not have a memory location.

For example, a local variable may have its location represented in a register due to an optimization performed during compilation.

Since the current message is generic:

**"error: Couldn't apply expression side effects : couldn't write the new contents of var back into the variable"**

it could not make a clear why the write operation was not done, so this patch add a note for cases where the lvalue does not have a memory location.

Bug link: https://github.com/llvm/llvm-project/issues/130701