### PR TITLE
[dyndbg][Clang] Avoid memcpy on nullptr from #216307

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -1527,7 +1527,9 @@ static void createAndEmbedModuleForDynamicDebugging(
     // the same source file compiled twice won't generate unique hashes.
     Hash.update(CGOpts.CmdArgs);
     for (auto *CU : M->debug_compile_units()) {
-      Hash.update(CU->getDirectory());
+      if (CU->getDirectory().size() > 0)
+        Hash.update(CU->getDirectory());
+
       Hash.update(CU->getFilename());
     }
 


### PR DESCRIPTION
As reported in https://github.com/llvm/llvm-project/pull/216307#issuecomment-5311023374, the new tests fail on UBSan buildbots (e.g., https://lab.llvm.org/buildbot/#/builders/25/builds/19323) because the directory may be empty (only the file is initialized [*]). The StringRef from getDirectory() would be default-initialized, and hashing it results in memcpy'ing from a null pointer.

This patch attempts to fix-forward by not hashing the output of getDirectory() if it is empty.

[*] e.g., `!3 = !DIFile(filename: "/usr/local/google/home/thurston/llvm-projectA/clang/test/DebugInfo/DynamicDebugging/<stdin>", directory: "")`