### PR TITLE
[mlir] Fix RemoveDeadRegionBranchOpSuccessorInputs producing invalid scf.for (LoopLikeOpInterface tie)

### DIFF
--- a/mlir/include/mlir/Interfaces/ControlFlowInterfaces.h
+++ b/mlir/include/mlir/Interfaces/ControlFlowInterfaces.h
@@ -17,6 +17,7 @@
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/PatternMatch.h"
+#include "llvm/ADT/EquivalenceClasses.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/raw_ostream.h"
@@ -330,11 +331,25 @@ Region *getEnclosingRepetitiveRegion(Operation *op);
 /// exists.
 Region *getEnclosingRepetitiveRegion(Value value);
 
+/// Callback that reports successor-input values (e.g. a region iter_arg and its
+/// corresponding op result) that are structurally coupled and must be added or
+/// removed together, by unioning them in `tiedInputs`. This is needed when
+/// `getSuccessorRegions` refines the control-flow graph and drops an edge that
+/// would otherwise tie them (e.g. a statically-single-trip `scf.for` drops its
+/// region->region back edge, so its iter_args and results are no longer tied
+/// through the yield operand). Any number of values may be tied together. Loop-
+/// like ops can implement this by unioning each iter_arg with its result
+/// (`getRegionIterArgs()` / `getLoopResults()`).
+using RegionBranchStructuralTieFn =
+    std::function<void(Operation *, llvm::EquivalenceClasses<Value> &)>;
+
 /// Populate canonicalization patterns that simplify successor operands/inputs
 /// of region branch operations. Only operations with the given name are
-/// matched.
+/// matched. `structuralTieFn` is optional; see `RegionBranchStructuralTieFn`.
 void populateRegionBranchOpInterfaceCanonicalizationPatterns(
-    RewritePatternSet &patterns, StringRef opName, PatternBenefit benefit = 1);
+    RewritePatternSet &patterns, StringRef opName,
+    RegionBranchStructuralTieFn structuralTieFn = nullptr,
+    PatternBenefit benefit = 1);
 
 /// Helper function for the region branch op inlining pattern that builds
 /// replacement values for non-successor-input values.

--- a/mlir/lib/Dialect/SCF/IR/SCF.cpp
+++ b/mlir/lib/Dialect/SCF/IR/SCF.cpp
@@ -1004,11 +1004,33 @@ struct ForOpTensorCastFolder : public OpRewritePattern<ForOp> {
 };
 } // namespace
 
+/// Structural-tie callback for `RegionBranchOpInterface` canonicalization: a
+/// loop-like op's region iter_args and their corresponding op results are
+/// structurally coupled (same loop-carried slot, enforced by the op verifier)
+/// and must be added/removed together. The successor-operand/input mapping may
+/// not link them when `getSuccessorRegions` drops an edge for control-flow
+/// precision (e.g. a statically-single-trip `scf.for` drops its back edge), so
+/// union the coupling explicitly via `LoopLikeOpInterface`.
+static void addLoopLikeStructuralTies(Operation *op,
+                                      llvm::EquivalenceClasses<Value> &tied) {
+  auto loopOp = dyn_cast<LoopLikeOpInterface>(op);
+  if (!loopOp)
+    return;
+  std::optional<ResultRange> results = loopOp.getLoopResults();
+  if (!results)
+    return;
+  Block::BlockArgListType iterArgs = loopOp.getRegionIterArgs();
+  if (iterArgs.size() != results->size())
+    return;
+  for (auto [iterArg, result] : llvm::zip_equal(iterArgs, *results))
+    tied.unionSets(iterArg, result);
+}
+
 void ForOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                         MLIRContext *context) {
   results.add<ForOpTensorCastFolder>(context);
   populateRegionBranchOpInterfaceCanonicalizationPatterns(
-      results, ForOp::getOperationName());
+      results, ForOp::getOperationName(), addLoopLikeStructuralTies);
   populateRegionBranchOpInterfaceInliningPattern(
       results, ForOp::getOperationName(),
       /*replBuilderFn=*/[](OpBuilder &builder, Location loc, Value value) {

--- a/mlir/lib/Interfaces/ControlFlowInterfaces.cpp
+++ b/mlir/lib/Interfaces/ControlFlowInterfaces.cpp
@@ -839,9 +839,12 @@ static llvm::EquivalenceClasses<Value> computeTiedSuccessorInputs(
 /// There are two sets: {{%r1}, {%r2}}. Each set has one value, so there each
 /// value can be removed independently of the other values.
 struct RemoveDeadRegionBranchOpSuccessorInputs : public RewritePattern {
-  RemoveDeadRegionBranchOpSuccessorInputs(MLIRContext *context, StringRef name,
-                                          PatternBenefit benefit = 1)
-      : RewritePattern(name, benefit, context) {}
+  RemoveDeadRegionBranchOpSuccessorInputs(
+      MLIRContext *context, StringRef name,
+      RegionBranchStructuralTieFn structuralTieFn = nullptr,
+      PatternBenefit benefit = 1)
+      : RewritePattern(name, benefit, context),
+        structuralTieFn(std::move(structuralTieFn)) {}
 
   LogicalResult matchAndRewrite(Operation *op,
                                 PatternRewriter &rewriter) const override {
@@ -856,6 +859,14 @@ struct RemoveDeadRegionBranchOpSuccessorInputs : public RewritePattern {
     regionBranchOp.getSuccessorOperandInputMapping(operandToInputs);
     llvm::EquivalenceClasses<Value> tiedSuccessorInputs =
         computeTiedSuccessorInputs(operandToInputs);
+
+    // The mapping above is derived from `getSuccessorRegions`, which may refine
+    // the control-flow graph and drop structurally-required edges (e.g. the
+    // region->region back edge of a statically-single-trip loop). Let the
+    // caller union any structural ties the mapping missed, so that, e.g., a
+    // loop iter_arg is never removed without its corresponding op result.
+    if (structuralTieFn)
+      structuralTieFn(op, tiedSuccessorInputs);
 
     // Determine which values to remove and group them by block and operation.
     SmallVector<Value> valuesToRemove;
@@ -940,6 +951,8 @@ struct RemoveDeadRegionBranchOpSuccessorInputs : public RewritePattern {
 
     return success();
   }
+
+  RegionBranchStructuralTieFn structuralTieFn;
 };
 
 /// Return the "owner" of a value: the parent block for block arguments, the
@@ -1300,11 +1313,13 @@ struct InlineRegionBranchOp : public RewritePattern {
 } // namespace
 
 void mlir::populateRegionBranchOpInterfaceCanonicalizationPatterns(
-    RewritePatternSet &patterns, StringRef opName, PatternBenefit benefit) {
+    RewritePatternSet &patterns, StringRef opName,
+    RegionBranchStructuralTieFn structuralTieFn, PatternBenefit benefit) {
   patterns.add<MakeRegionBranchOpSuccessorInputsDead,
-               RemoveDuplicateSuccessorInputUses,
-               RemoveDeadRegionBranchOpSuccessorInputs>(patterns.getContext(),
-                                                        opName, benefit);
+               RemoveDuplicateSuccessorInputUses>(patterns.getContext(), opName,
+                                                  benefit);
+  patterns.add<RemoveDeadRegionBranchOpSuccessorInputs>(
+      patterns.getContext(), opName, std::move(structuralTieFn), benefit);
 }
 
 void mlir::populateRegionBranchOpInterfaceInliningPattern(


### PR DESCRIPTION
`RemoveDeadRegionBranchOpSuccessorInputs` (a `RegionBranchOpInterface` canonicalization) can leave an `scf.for` structurally invalid, aborting under `MLIR_ENABLE_EXPENSIVE_PATTERN_API_CHECKS`:

```
'scf.for' op mismatch in number of loop-carried values and defined values
LLVM ERROR: IR failed to verify after pattern application
```

### Root cause

The pattern builds its tied-value sets from `getSuccessorOperandInputMapping`, derived from `getSuccessorRegions`. For an `scf.for` with a **statically-known trip count of 1**, `getSuccessorRegions` drops the `region -> region` back edge (the loop provably never iterates back). That back edge is what forwards a `scf.yield` operand to the region `iter_args`, so without it the `iter_arg` and its op result are no longer tied through a shared operand. The pattern removes a dead `iter_arg` (and its init/yield operands) **without** the structurally-required result, yielding a loop with `0` iter_args but `1` result/yield.

The greedy driver repairs this on a later iteration (`InlineRegionBranchOp` folds the single-trip loop), so it is only observed with expensive pattern-API checks, which verify after **every** pattern application. This is the dominant cause of the Linalg tiling / pack-unpack / convolution and `scf` loop-canonicalization failures reported in #163599.

### Fix

Add an optional `RegionBranchStructuralTieFn` callback to `populateRegionBranchOpInterfaceCanonicalizationPatterns` (mirroring the existing `replBuilderFn` hook on the inlining pattern). It lets a dialect report pairs of successor inputs that are structurally coupled and must be added/removed together. `RemoveDeadRegionBranchOpSuccessorInputs` unions those pairs into its tied-value sets.

SCF supplies a callback (`addLoopLikeStructuralTies`) derived from `LoopLikeOpInterface` (`getRegionIterArgs()` / `getLoopResults()`), tying each loop `iter_arg` to its result, and wires it into **`scf.for`**'s canonicalizer. With the tie restored, a live result blocks removal of its dead `iter_arg`, so the pattern no longer produces an invalid intermediate. `getSuccessorRegions`' trip-count precision is untouched, so `InlineRegionBranchOp` still folds single-trip loops (optimization preserved).

The callback lives in the loop dialect rather than the interface library because `MLIRLoopLikeInterface` depends on `MLIRControlFlowInterfaces`; deriving the tie in SCF avoids that layering cycle.

Assisted by: Claude