### PR TITLE
[bazel] Include Orc/Shared/SPSCI headers in OrcShared target

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -11066,6 +11066,7 @@ libc_math_function(
     additional_deps = [
         ":__support_cpp_bit",
         ":__support_math_ceilf128",
+        ":__support_fputil_float128",
     ],
 )
 

--- a/utils/bazel/llvm-project-overlay/libc/test/src/math/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/math/BUILD.bazel
@@ -57,6 +57,9 @@ math_mpfr_test(
 math_mpfr_test(
     name = "ceilf128",
     hdrs = ["CeilTest.h"],
+    deps = [
+        "//libc:__support_fputil_float128",
+    ],
 )
 
 math_mpfr_test(name = "cos")

--- a/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
@@ -98,11 +98,17 @@ math_test(
 math_test(
     name = "ceill",
     hdrs = ["CeilTest.h"],
+    deps = [
+        "//libc:__support_fputil_float128",
+    ]
 )
 
 math_test(
     name = "ceilf128",
     hdrs = ["CeilTest.h"],
+    deps = [
+        "//libc:__support_fputil_float128",
+    ],
 )
 
 math_test(

--- a/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
@@ -100,7 +100,7 @@ math_test(
     hdrs = ["CeilTest.h"],
     deps = [
         "//libc:__support_fputil_float128",
-    ]
+    ],
 )
 
 math_test(

--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -4454,7 +4454,7 @@ cc_library(
         "lib/ExecutionEngine/Orc/Shared/*.cpp",
     ]),
     hdrs = glob([
-        "include/llvm/ExecutionEngine/Orc/Shared/*.h",
+        "include/llvm/ExecutionEngine/Orc/Shared/**/*.h",
     ]) + [
         "include/llvm/ExecutionEngine/Orc/SymbolStringPool.h",
     ],

--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -597,6 +597,7 @@ mlir_c_api_cc_library(
     deps = [
         ":IR",
         ":InferTypeOpInterface",
+        ":SideEffectInterfaces",
         "//llvm:Support",
     ],
 )


### PR DESCRIPTION
This fixes two active bazel failures:
1. Update `OrcShared` in `llvm/BUILD.bazel` to recursively glob headers under
`include/llvm/ExecutionEngine/Orc/Shared/**/*.h`.
2. libc float128 failures


Gemini assisted 