### PR TITLE
[M68k] Implement `CLR` instruction encoding and logic

### DIFF
--- a/llvm/lib/Target/M68k/M68kExpandPseudo.cpp
+++ b/llvm/lib/Target/M68k/M68kExpandPseudo.cpp
@@ -81,7 +81,7 @@ bool M68kExpandPseudo::ExpandMI(MachineBasicBlock &MBB,
 
   case M68k::MOVI8di:
     return TII->ExpandMOVI(MIB, MVT::i8);
-  case M68k::MOVI16ri:
+  case M68k::MOVI16di:
     return TII->ExpandMOVI(MIB, MVT::i16);
   case M68k::MOVI32ri:
     return TII->ExpandMOVI(MIB, MVT::i32);

--- a/llvm/lib/Target/M68k/M68kInstrArithmetic.td
+++ b/llvm/lib/Target/M68k/M68kInstrArithmetic.td
@@ -13,7 +13,7 @@
 ///  Machine:
 ///
 ///    ADD       [~]   ADDA      [~]   ADDI        [~]   ADDQ [ ]   ADDX [~]
-///    CLR       [ ]   CMP       [~]   CMPA        [~]   CMPI [~]   CMPM [ ]
+///    CLR       [~]   CMP       [~]   CMPA        [~]   CMPI [~]   CMPM [ ]
 ///    CMP2      [ ]   DIVS/DIVU [~]   DIVSL/DIVUL [ ]   EXT  [~]   EXTB [ ]
 ///    MULS/MULU [~]   NEG       [~]   NEGX        [~]   NOT  [~]   SUB  [~]
 ///    SUBA      [~]   SUBI      [~]   SUBQ        [ ]   SUBX [~]
@@ -1109,3 +1109,100 @@ defm FADD : MxFBinaryOp<"add", 0b1100010, 0b1100110, 0b0100010>;
 defm FSUB : MxFBinaryOp<"sub", 0b1101000, 0b1101100, 0b0101000>;
 defm FMUL : MxFBinaryOp<"mul", 0b1100011, 0b1100111, 0b0100011>;
 defm FDIV : MxFBinaryOp<"div", 0b1100000, 0b1100100, 0b0100000>;
+
+
+//===----------------------------------------------------------------------===//
+// CLR
+//===----------------------------------------------------------------------===//
+
+/// ---------------------------------------------------
+///  F  E  D  C  B  A  9  8 | 7  6 | 5  4  3 | 2  1  0
+/// ---------------------------------------------------
+///                         |      | EFFECTIVE ADDRESS
+///  0  1  0  0  0  0  1  0 | SIZE |   MODE  |   REG
+/// ---------------------------------------------------
+
+let Defs = [CCR] in {
+
+// No pattern, this instead gets used when expanding the MOVI pseudo.
+class MxClr_D<MxType TYPE>
+    : MxInst<(outs TYPE.ROp:$dst), (ins),
+             "clr."#TYPE.Prefix#"\t$dst", []> {
+  let Inst = (descend 0b01000010,
+    /*SIZE*/!cast<MxEncSize>("MxEncSize"#TYPE.Size).Value,
+    //MODE without last bit
+    0b00,
+    //REGISTER prefixed by D/A bit
+    (operand "$dst", 4)
+  );
+}
+
+// Identical to the above, but takes a register input for use in DAG selection
+let isCodeGenOnly = 1, Constraints = "$src = $dst" in
+class MxClr_DD<MxType TYPE>
+    : MxInst<(outs TYPE.ROp:$dst), (ins TYPE.ROp:$src),
+             "clr."#TYPE.Prefix#"\t$dst", []> {
+  let Inst = (descend 0b01000010,
+    /*SIZE*/!cast<MxEncSize>("MxEncSize"#TYPE.Size).Value,
+    //MODE without last bit
+    0b00,
+    //REGISTER prefixed by D/A bit
+    (operand "$dst", 4)
+  );
+}
+
+// NOTE: On M68000 specifically, the memory is (pointlessly) read before
+// written. This isn't modeled via mayLoad, because the 'store' in the pattern
+// is enough to implicitly indicate side effects for all practical purposes.
+class MxClr_M<MxType TYPE, MxOpBundle DST, MxEncMemOp DST_ENC>
+    : MxInst<(outs), (ins DST.Op:$dst),
+             "clr."#TYPE.Prefix#"\t$dst",
+             [(store (TYPE.VT 0), DST.Pat:$dst)]> {
+  let Inst = (ascend
+    (descend 0b01000010,
+    /*SIZE*/!cast<MxEncSize>("MxEncSize"#TYPE.Size).Value,
+    DST_ENC.EA), DST_ENC.Supplement
+  );
+}
+
+// Mirrors MxCmp_BI for abs.L pattern matching
+class MxClr_B<MxType TYPE>
+    : MxInst<(outs), (ins MxAL32:$dst),
+             "clr."#TYPE.Prefix#"\t$dst",
+             [(store (TYPE.VT 0), (i32 (MxWrapper tglobaladdr:$dst)))]> {
+  defvar AbsEncoding = MxEncAddrMode_abs<"dst", true>;
+  let Inst = (ascend
+    (descend 0b01000010,
+    /*SIZE*/!cast<MxEncSize>("MxEncSize"#TYPE.Size).Value,
+    AbsEncoding.EA), AbsEncoding.Supplement
+  );
+}
+} // let Defs = [CCR]
+
+foreach S = [8, 16, 32] in {
+  defvar DTYPE = !cast<MxType>("MxType"#S#"d");
+  def CLR#S#d : MxClr_D<DTYPE>;
+  def CLR#S#dd : MxClr_DD<DTYPE>;
+  def CLR#S#b : MxClr_B<DTYPE>;
+
+  defvar MTYPE = !cast<MxType>("MxType"#S);
+  def CLR#S#j : MxClr_M<MTYPE, !cast<MxOpBundle>("MxOp"#S#"AddrMode_j"),
+                        MxEncAddrMode_j<"dst">>;
+  def CLR#S#o : MxClr_M<MTYPE, !cast<MxOpBundle>("MxOp"#S#"AddrMode_o"),
+                        MxEncAddrMode_o<"dst">>;
+  def CLR#S#e : MxClr_M<MTYPE, !cast<MxOpBundle>("MxOp"#S#"AddrMode_e"),
+                        MxEncAddrMode_e<"dst">>;
+  def CLR#S#p : MxClr_M<MTYPE, !cast<MxOpBundle>("MxOp"#S#"AddrMode_p"),
+                        MxEncAddrMode_p<"dst">>;
+  def CLR#S#f : MxClr_M<MTYPE, !cast<MxOpBundle>("MxOp"#S#"AddrMode_f"),
+                        MxEncAddrMode_f<"dst">>;
+  def CLR#S#q : MxClr_M<MTYPE, !cast<MxOpBundle>("MxOp"#S#"AddrMode_q"),
+                        MxEncAddrMode_q<"dst">>;
+  def CLR#S#k : MxClr_M<MTYPE, !cast<MxOpBundle>("MxOp"#S#"AddrMode_k"),
+                        MxEncAddrMode_k<"dst">>;
+}
+
+// Left shift 16 bits lowers to: swap dn -> clr.w dn
+def : Pat<(shl i32:$src, (i32 16)),
+  (SUBREG_TO_REG (CLR16dd (EXTRACT_SUBREG (SWAP MxDRD32:$src),
+  MxSubRegIndex16Lo)), MxSubRegIndex16Lo)>;

--- a/llvm/lib/Target/M68k/M68kInstrData.td
+++ b/llvm/lib/Target/M68k/M68kInstrData.td
@@ -597,6 +597,9 @@ class MxPseudoMove_RM<MxType DST, MxOperand SRCOpd, list<dag> PAT = []>
 // depending on size, destination register class, and immediate value.
 // This is done with pseudoinstructions in order to not constrain RA to
 // data registers if moveq matches.
+// TODO: We should be more deliberate about whether or not these instructions
+// are expected to preserve the upper bits of the register, because the free
+// sext of moveq and movea have different utility from non-ext move.[bw].
 class MxPseudoMove_DI<MxType TYPE>
     : MxPseudo<(outs TYPE.ROp:$dst), (ins TYPE.IOp:$src),
                [(set TYPE.ROp:$dst, imm:$src)]>;
@@ -604,7 +607,7 @@ class MxPseudoMove_DI<MxType TYPE>
 // i8 imm -> reg can always be converted to moveq,
 // but we still emit a pseudo for consistency.
 def MOVI8di  : MxPseudoMove_DI<MxType8d>;
-def MOVI16ri : MxPseudoMove_DI<MxType16r>;
+def MOVI16di : MxPseudoMove_DI<MxType16d>;
 def MOVI32ri : MxPseudoMove_DI<MxType32r>;
 } // let Defs = [CCR]
 

--- a/llvm/lib/Target/M68k/M68kInstrInfo.cpp
+++ b/llvm/lib/Target/M68k/M68kInstrInfo.cpp
@@ -335,7 +335,8 @@ void M68kInstrInfo::AddZExt(MachineBasicBlock &MBB,
                             MachineBasicBlock::iterator I, DebugLoc DL,
                             unsigned Reg, MVT From, MVT To) const {
 
-  // On 68000, SWAP -> CLR -> SWAP is faster than AND with mask.
+  // On pre-020 (16-bit bus) CPUs, SWAP -> CLR -> SWAP is faster than AND with
+  // mask.
   if (!Subtarget.atLeastM68020() && From == MVT::i16 && To == MVT::i32 &&
       M68k::DR32RegClass.contains(Reg)) {
     unsigned SubReg = RI.getSubReg(Reg, M68k::MxSubRegIndex16Lo);

--- a/llvm/lib/Target/M68k/M68kInstrInfo.cpp
+++ b/llvm/lib/Target/M68k/M68kInstrInfo.cpp
@@ -389,8 +389,9 @@ bool M68kInstrInfo::ExpandMOVI(MachineInstrBuilder &MIB, MVT MVTSize) const {
     LLVM_DEBUG(dbgs() << NewMI << "\n");
     MIB->removeFromParent();
 
-  // Sign extention doesn't matter if we only use the bottom 8 bits
-  } else if (MVTSize == MVT::i8 || (!IsAddressReg && Imm >= -128 && Imm <= 127)) {
+    // Sign extention doesn't matter if we only use the bottom 8 bits
+  } else if (MVTSize == MVT::i8 ||
+             (!IsAddressReg && Imm >= -128 && Imm <= 127)) {
     LLVM_DEBUG(dbgs() << "MOVEQ\n");
 
     MIB->setDesc(get(M68k::MOVQ));
@@ -504,13 +505,11 @@ bool M68kInstrInfo::ExpandMOVSZX_RR(MachineInstrBuilder &MIB, bool IsSigned,
     if (MVTSrc == MVT::i8) {
       unsigned SubDst = RI.getSubReg(Dst, M68k::MxSubRegIndex8Lo);
       BuildMI(MBB, MIB.getInstr(), DL, get(M68k::MOV8dd), SubDst).addReg(Src);
-    }
-    else { // i16
+    } else { // i16
       unsigned SubDst = RI.getSubReg(Dst, M68k::MxSubRegIndex16Lo);
       BuildMI(MBB, MIB.getInstr(), DL, get(M68k::MOV16dd), SubDst).addReg(Src);
     }
-  }
-  else {
+  } else {
 
     unsigned Move;
     if (MVTDst == MVT::i16)
@@ -568,7 +567,7 @@ bool M68kInstrInfo::ExpandMOVSZX_RM(MachineInstrBuilder &MIB, bool IsSigned,
     LLVM_DEBUG(dbgs() << "Clear and LOAD" << '\n');
     buildClearRegister(Dst, MBB, I, DL);
 
-  // Extend after load
+    // Extend after load
   } else {
     I++;
     if (IsSigned) {
@@ -639,13 +638,14 @@ bool M68kInstrInfo::ExpandMOVEM(MachineInstrBuilder &MIB,
 }
 
 void M68kInstrInfo::buildClearRegister(Register Reg, MachineBasicBlock &MBB,
-                        MachineBasicBlock::iterator Iter, DebugLoc &DL,
-                        bool AllowSideEffects) const {
+                                       MachineBasicBlock::iterator Iter,
+                                       DebugLoc &DL,
+                                       bool AllowSideEffects) const {
   // Clear an address register by subtracting it from itself.
   if (M68k::AR32RegClass.contains(Reg)) {
     BuildMI(MBB, Iter, DL, get(M68k::SUB32ar), Reg)
-      .addReg(Reg, RegState::Undef)
-      .addReg(Reg, RegState::Undef);
+        .addReg(Reg, RegState::Undef)
+        .addReg(Reg, RegState::Undef);
     return;
   }
 

--- a/llvm/lib/Target/M68k/M68kInstrInfo.cpp
+++ b/llvm/lib/Target/M68k/M68kInstrInfo.cpp
@@ -15,8 +15,10 @@
 
 #include "M68kInstrBuilder.h"
 #include "M68kMachineFunction.h"
+#include "M68kRegisterInfo.h"
 #include "M68kTargetMachine.h"
 #include "MCTargetDesc/M68kMCCodeEmitter.h"
+#include "MCTargetDesc/M68kMCTargetDesc.h"
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/ScopeExit.h"
@@ -333,6 +335,16 @@ void M68kInstrInfo::AddZExt(MachineBasicBlock &MBB,
                             MachineBasicBlock::iterator I, DebugLoc DL,
                             unsigned Reg, MVT From, MVT To) const {
 
+  // On 68000, SWAP -> CLR -> SWAP is faster than AND with mask.
+  if (!Subtarget.atLeastM68020() && From == MVT::i16 && To == MVT::i32 &&
+      M68k::DR32RegClass.contains(Reg)) {
+    unsigned SubReg = RI.getSubReg(Reg, M68k::MxSubRegIndex16Lo);
+    BuildMI(MBB, I, DL, get(M68k::SWAP), Reg).addReg(Reg);
+    BuildMI(MBB, I, DL, get(M68k::CLR16d), SubReg);
+    BuildMI(MBB, I, DL, get(M68k::SWAP), Reg).addReg(Reg);
+    return;
+  }
+
   unsigned Mask, And;
   if (From == MVT::i8)
     Mask = 0xFF;
@@ -353,14 +365,14 @@ void M68kInstrInfo::AddZExt(MachineBasicBlock &MBB,
 bool M68kInstrInfo::ExpandMOVI(MachineInstrBuilder &MIB, MVT MVTSize) const {
   Register Reg = MIB->getOperand(0).getReg();
   int64_t Imm = MIB->getOperand(1).getImm();
-  bool IsAddressReg = false;
 
   const auto *DR32 = RI.getRegClass(M68k::DR32RegClassID);
   const auto *AR32 = RI.getRegClass(M68k::AR32RegClassID);
   const auto *AR16 = RI.getRegClass(M68k::AR16RegClassID);
+  bool IsAddressReg = AR16->contains(Reg) || AR32->contains(Reg);
 
-  if (AR16->contains(Reg) || AR32->contains(Reg))
-    IsAddressReg = true;
+  MachineBasicBlock &MBB = *MIB->getParent();
+  DebugLoc DL = MIB->getDebugLoc();
 
   // We need to assign to the full register to make IV happy
   Register SReg =
@@ -371,8 +383,14 @@ bool M68kInstrInfo::ExpandMOVI(MachineInstrBuilder &MIB, MVT MVTSize) const {
 
   LLVM_DEBUG(dbgs() << "Expand " << *MIB.getInstr() << " to ");
 
+  if (Imm == 0) {
+    buildClearRegister(Reg, MBB, MIB, DL);
+    MachineInstr &NewMI = *std::prev((MachineBasicBlock::iterator)MIB);
+    LLVM_DEBUG(dbgs() << NewMI << "\n");
+    MIB->removeFromParent();
+
   // Sign extention doesn't matter if we only use the bottom 8 bits
-  if (MVTSize == MVT::i8 || (!IsAddressReg && Imm >= -128 && Imm <= 127)) {
+  } else if (MVTSize == MVT::i8 || (!IsAddressReg && Imm >= -128 && Imm <= 127)) {
     LLVM_DEBUG(dbgs() << "MOVEQ\n");
 
     MIB->setDesc(get(M68k::MOVQ));
@@ -383,27 +401,11 @@ bool M68kInstrInfo::ExpandMOVI(MachineInstrBuilder &MIB, MVT MVTSize) const {
   } else if (DR32->contains(Reg) && isUInt<8>(Imm)) {
     LLVM_DEBUG(dbgs() << "MOVEQ and NOT\n");
 
-    MachineBasicBlock &MBB = *MIB->getParent();
-    DebugLoc DL = MIB->getDebugLoc();
-
     unsigned SubReg = RI.getSubReg(Reg, M68k::MxSubRegIndex8Lo);
     assert(SubReg && "No viable SUB register available");
 
     BuildMI(MBB, MIB.getInstr(), DL, get(M68k::MOVQ), SReg).addImm(~Imm & 0xFF);
     BuildMI(MBB, MIB.getInstr(), DL, get(M68k::NOT8d), SubReg).addReg(SubReg);
-
-    MIB->removeFromParent();
-
-    // Special case for setting address register to NULL (0)
-  } else if (IsAddressReg && Imm == 0) {
-    LLVM_DEBUG(dbgs() << "SUBA\n");
-
-    MachineBasicBlock &MBB = *MIB->getParent();
-    DebugLoc DL = MIB->getDebugLoc();
-
-    BuildMI(MBB, MIB.getInstr(), DL, get(M68k::SUB32ar), SReg)
-        .addReg(SReg, RegState::Undef)
-        .addReg(SReg, RegState::Undef);
 
     MIB->removeFromParent();
 
@@ -471,13 +473,6 @@ bool M68kInstrInfo::ExpandMOVSZX_RR(MachineInstrBuilder &MIB, bool IsSigned,
                                     MVT MVTDst, MVT MVTSrc) const {
   LLVM_DEBUG(dbgs() << "Expand " << *MIB.getInstr() << " to ");
 
-  unsigned Move;
-
-  if (MVTDst == MVT::i16)
-    Move = M68k::MOV16rr;
-  else // i32
-    Move = M68k::MOV32rr;
-
   Register Dst = MIB->getOperand(0).getReg();
   Register Src = MIB->getOperand(1).getReg();
 
@@ -499,17 +494,42 @@ bool M68kInstrInfo::ExpandMOVSZX_RR(MachineInstrBuilder &MIB, bool IsSigned,
   MachineBasicBlock &MBB = *MIB->getParent();
   DebugLoc DL = MIB->getDebugLoc();
 
-  if (Dst != SSrc) {
-    LLVM_DEBUG(dbgs() << "Move and " << '\n');
-    BuildMI(MBB, MIB.getInstr(), DL, get(Move), Dst).addReg(SSrc);
-  }
+  // It's more efficient to clear the destination and *then* move, rather than
+  // move and zext.
+  if (Dst != SSrc && !IsSigned) {
+    LLVM_DEBUG(dbgs() << "Clear and Move" << '\n');
 
-  if (IsSigned) {
-    LLVM_DEBUG(dbgs() << "Sign Extend" << '\n');
-    AddSExt(MBB, MIB.getInstr(), DL, Dst, MVTSrc, MVTDst);
-  } else {
-    LLVM_DEBUG(dbgs() << "Zero Extend" << '\n');
-    AddZExt(MBB, MIB.getInstr(), DL, Dst, MVTSrc, MVTDst);
+    buildClearRegister(Dst, MBB, MIB.getInstr(), DL);
+
+    if (MVTSrc == MVT::i8) {
+      unsigned SubDst = RI.getSubReg(Dst, M68k::MxSubRegIndex8Lo);
+      BuildMI(MBB, MIB.getInstr(), DL, get(M68k::MOV8dd), SubDst).addReg(Src);
+    }
+    else { // i16
+      unsigned SubDst = RI.getSubReg(Dst, M68k::MxSubRegIndex16Lo);
+      BuildMI(MBB, MIB.getInstr(), DL, get(M68k::MOV16dd), SubDst).addReg(Src);
+    }
+  }
+  else {
+
+    unsigned Move;
+    if (MVTDst == MVT::i16)
+      Move = M68k::MOV16dd;
+    else // i32
+      Move = M68k::MOV32dd;
+
+    if (Dst != SSrc) {
+      LLVM_DEBUG(dbgs() << "Move and " << '\n');
+      BuildMI(MBB, MIB.getInstr(), DL, get(Move), Dst).addReg(SSrc);
+    }
+
+    if (IsSigned) {
+      LLVM_DEBUG(dbgs() << "Sign Extend" << '\n');
+      AddSExt(MBB, MIB.getInstr(), DL, Dst, MVTSrc, MVTDst);
+    } else {
+      LLVM_DEBUG(dbgs() << "Zero Extend" << '\n');
+      AddZExt(MBB, MIB.getInstr(), DL, Dst, MVTSrc, MVTDst);
+    }
   }
 
   MIB->eraseFromParent();
@@ -520,7 +540,7 @@ bool M68kInstrInfo::ExpandMOVSZX_RR(MachineInstrBuilder &MIB, bool IsSigned,
 bool M68kInstrInfo::ExpandMOVSZX_RM(MachineInstrBuilder &MIB, bool IsSigned,
                                     const MCInstrDesc &Desc, MVT MVTDst,
                                     MVT MVTSrc) const {
-  LLVM_DEBUG(dbgs() << "Expand " << *MIB.getInstr() << " to LOAD and ");
+  LLVM_DEBUG(dbgs() << "Expand " << *MIB.getInstr() << " to ");
 
   Register Dst = MIB->getOperand(0).getReg();
 
@@ -539,16 +559,25 @@ bool M68kInstrInfo::ExpandMOVSZX_RM(MachineInstrBuilder &MIB, bool IsSigned,
   MIB->getOperand(0).setReg(SubDst);
 
   MachineBasicBlock::iterator I = MIB.getInstr();
-  I++;
   MachineBasicBlock &MBB = *MIB->getParent();
   DebugLoc DL = MIB->getDebugLoc();
 
-  if (IsSigned) {
-    LLVM_DEBUG(dbgs() << "Sign Extend" << '\n');
-    AddSExt(MBB, I, DL, Dst, MVTSrc, MVTDst);
+  // We can only clear before loading if the destination register isn't being
+  // used as an index for the load.
+  if (!IsSigned && !MIB->readsRegister(Dst, &RI)) {
+    LLVM_DEBUG(dbgs() << "Clear and LOAD" << '\n');
+    buildClearRegister(Dst, MBB, I, DL);
+
+  // Extend after load
   } else {
-    LLVM_DEBUG(dbgs() << "Zero Extend" << '\n');
-    AddZExt(MBB, I, DL, Dst, MVTSrc, MVTDst);
+    I++;
+    if (IsSigned) {
+      LLVM_DEBUG(dbgs() << "LOAD and Sign Extend" << '\n');
+      AddSExt(MBB, I, DL, Dst, MVTSrc, MVTDst);
+    } else {
+      LLVM_DEBUG(dbgs() << "Zero Extend" << '\n');
+      AddZExt(MBB, I, DL, Dst, MVTSrc, MVTDst);
+    }
   }
 
   return true;
@@ -607,6 +636,28 @@ bool M68kInstrInfo::ExpandMOVEM(MachineInstrBuilder &MIB,
   MIB->eraseFromParent();
 
   return true;
+}
+
+void M68kInstrInfo::buildClearRegister(Register Reg, MachineBasicBlock &MBB,
+                        MachineBasicBlock::iterator Iter, DebugLoc &DL,
+                        bool AllowSideEffects) const {
+  // Clear an address register by subtracting it from itself.
+  if (M68k::AR32RegClass.contains(Reg)) {
+    BuildMI(MBB, Iter, DL, get(M68k::SUB32ar), Reg)
+      .addReg(Reg, RegState::Undef)
+      .addReg(Reg, RegState::Undef);
+    return;
+  }
+
+  if (M68k::DR8RegClass.contains(Reg))
+    BuildMI(MBB, Iter, DL, get(M68k::CLR8d), Reg);
+  else if (M68k::DR16RegClass.contains(Reg))
+    BuildMI(MBB, Iter, DL, get(M68k::CLR16d), Reg);
+  else if (M68k::DR32RegClass.contains(Reg))
+    BuildMI(MBB, Iter, DL, get(M68k::MOVQ), Reg).addImm(0);
+  else
+    llvm::reportFatalInternalError(
+        "buildClearRegister is not implemented for " + RI.getRegAsmName(Reg));
 }
 
 /// Expand a single-def pseudo instruction to a two-addr

--- a/llvm/lib/Target/M68k/M68kInstrInfo.h
+++ b/llvm/lib/Target/M68k/M68kInstrInfo.h
@@ -325,7 +325,7 @@ public:
 
   void buildClearRegister(Register Reg, MachineBasicBlock &MBB,
                           MachineBasicBlock::iterator Iter, DebugLoc &DL,
-                          bool AllowSideEffects=true) const override;
+                          bool AllowSideEffects = true) const override;
 
   /// Return a virtual register initialized with the global base register
   /// value. Output instructions required to initialize the register in the

--- a/llvm/lib/Target/M68k/M68kInstrInfo.h
+++ b/llvm/lib/Target/M68k/M68kInstrInfo.h
@@ -323,6 +323,10 @@ public:
   bool ExpandMOVEM(MachineInstrBuilder &MIB, const MCInstrDesc &Desc,
                    bool IsRM) const;
 
+  void buildClearRegister(Register Reg, MachineBasicBlock &MBB,
+                          MachineBasicBlock::iterator Iter, DebugLoc &DL,
+                          bool AllowSideEffects=true) const override;
+
   /// Return a virtual register initialized with the global base register
   /// value. Output instructions required to initialize the register in the
   /// function entry block, if necessary.

--- a/llvm/test/CodeGen/M68k/Arith/add-with-overflow.ll
+++ b/llvm/test/CodeGen/M68k/Arith/add-with-overflow.ll
@@ -10,7 +10,7 @@ define fastcc i32 @test5(i32 %v1, i32 %v2, ptr %X) nounwind {
 ; CHECK-NEXT:    add.l %d1, %d0
 ; CHECK-NEXT:    bvs .LBB0_2
 ; CHECK-NEXT:  ; %bb.1: ; %normal
-; CHECK-NEXT:    move.l #0, (%a0)
+; CHECK-NEXT:    clr.l (%a0)
 ; CHECK-NEXT:  .LBB0_2: ; %overflow
 ; CHECK-NEXT:    rts
 entry:
@@ -33,9 +33,9 @@ define fastcc i1 @test6(i32 %v1, i32 %v2, ptr %X) nounwind {
 ; CHECK-NEXT:    add.l %d1, %d0
 ; CHECK-NEXT:    bcs .LBB1_2
 ; CHECK-NEXT:  ; %bb.1: ; %normal
-; CHECK-NEXT:    move.l #0, (%a0)
+; CHECK-NEXT:    clr.l (%a0)
 ; CHECK-NEXT:  .LBB1_2: ; %carry
-; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    clr.b %d0
 ; CHECK-NEXT:    rts
 entry:
   %t = call {i32, i1} @llvm.uadd.with.overflow.i32(i32 %v1, i32 %v2)

--- a/llvm/test/CodeGen/M68k/Arith/bitwise.ll
+++ b/llvm/test/CodeGen/M68k/Arith/bitwise.ll
@@ -9,8 +9,8 @@ define zeroext i8 @andb(i8 zeroext %a, i8 zeroext %b) nounwind {
 ; CHECK-NEXT:    move.b (11,%sp), %d0
 ; CHECK-NEXT:    move.b (7,%sp), %d1
 ; CHECK-NEXT:    and.b %d0, %d1
-; CHECK-NEXT:    move.l %d1, %d0
-; CHECK-NEXT:    and.l #255, %d0
+; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    move.b %d1, %d0
 ; CHECK-NEXT:    rts
   %1 = and i8 %a, %b
   ret i8 %1
@@ -22,8 +22,8 @@ define zeroext i16 @andw(i16 zeroext %a, i16 zeroext %b) nounwind {
 ; CHECK-NEXT:    move.w (10,%sp), %d0
 ; CHECK-NEXT:    move.w (6,%sp), %d1
 ; CHECK-NEXT:    and.w %d0, %d1
-; CHECK-NEXT:    move.l %d1, %d0
-; CHECK-NEXT:    and.l #65535, %d0
+; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    move.w %d1, %d0
 ; CHECK-NEXT:    rts
   %1 = and i16 %a, %b
   ret i16 %1
@@ -46,8 +46,8 @@ define zeroext i8 @orb(i8 zeroext %a, i8 zeroext %b) nounwind {
 ; CHECK-NEXT:    move.b (11,%sp), %d0
 ; CHECK-NEXT:    move.b (7,%sp), %d1
 ; CHECK-NEXT:    or.b %d0, %d1
-; CHECK-NEXT:    move.l %d1, %d0
-; CHECK-NEXT:    and.l #255, %d0
+; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    move.b %d1, %d0
 ; CHECK-NEXT:    rts
   %1 = or i8 %a, %b
   ret i8 %1
@@ -59,8 +59,8 @@ define zeroext i16 @orw(i16 zeroext %a, i16 zeroext %b) nounwind {
 ; CHECK-NEXT:    move.w (10,%sp), %d0
 ; CHECK-NEXT:    move.w (6,%sp), %d1
 ; CHECK-NEXT:    or.w %d0, %d1
-; CHECK-NEXT:    move.l %d1, %d0
-; CHECK-NEXT:    and.l #65535, %d0
+; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    move.w %d1, %d0
 ; CHECK-NEXT:    rts
   %1 = or i16 %a, %b
   ret i16 %1
@@ -83,8 +83,8 @@ define zeroext i8 @eorb(i8 zeroext %a, i8 zeroext %b) nounwind {
 ; CHECK-NEXT:    move.b (11,%sp), %d0
 ; CHECK-NEXT:    move.b (7,%sp), %d1
 ; CHECK-NEXT:    eor.b %d0, %d1
-; CHECK-NEXT:    move.l %d1, %d0
-; CHECK-NEXT:    and.l #255, %d0
+; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    move.b %d1, %d0
 ; CHECK-NEXT:    rts
   %1 = xor i8 %a, %b
   ret i8 %1
@@ -96,8 +96,8 @@ define zeroext i16 @eorw(i16 zeroext %a, i16 zeroext %b) nounwind {
 ; CHECK-NEXT:    move.w (10,%sp), %d0
 ; CHECK-NEXT:    move.w (6,%sp), %d1
 ; CHECK-NEXT:    eor.w %d0, %d1
-; CHECK-NEXT:    move.l %d1, %d0
-; CHECK-NEXT:    and.l #65535, %d0
+; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    move.w %d1, %d0
 ; CHECK-NEXT:    rts
   %1 = xor i16 %a, %b
   ret i16 %1

--- a/llvm/test/CodeGen/M68k/Arith/divide-by-constant.ll
+++ b/llvm/test/CodeGen/M68k/Arith/divide-by-constant.ll
@@ -8,7 +8,9 @@ define zeroext i16 @test1(i16 zeroext %x) nounwind {
 ; CHECK-NEXT:    mulu #-1985, %d0
 ; CHECK-NEXT:    swap %d0
 ; CHECK-NEXT:    lsr.w #5, %d0
-; CHECK-NEXT:    and.l #65535, %d0
+; CHECK-NEXT:    swap %d0
+; CHECK-NEXT:    clr.w %d0
+; CHECK-NEXT:    swap %d0
 ; CHECK-NEXT:    rts
 entry:
 	%div = udiv i16 %x, 33
@@ -23,7 +25,9 @@ define zeroext i16 @test2(i8 signext %x, i16 zeroext %c) {
 ; CHECK-NEXT:    mulu #-21845, %d0
 ; CHECK-NEXT:    swap %d0
 ; CHECK-NEXT:    lsr.w #1, %d0
-; CHECK-NEXT:    and.l #65535, %d0
+; CHECK-NEXT:    swap %d0
+; CHECK-NEXT:    clr.w %d0
+; CHECK-NEXT:    swap %d0
 ; CHECK-NEXT:    rts
 entry:
   %div = udiv i16 %c, 3
@@ -34,12 +38,14 @@ define zeroext i8 @test3(i8 zeroext %x, i8 zeroext %c) {
 ; CHECK-LABEL: test3:
 ; CHECK:         .cfi_startproc
 ; CHECK-NEXT:  ; %bb.0: ; %entry
+; CHECK-NEXT:    moveq #0, %d0
 ; CHECK-NEXT:    move.b (11,%sp), %d0
-; CHECK-NEXT:    and.l #255, %d0
 ; CHECK-NEXT:    muls #171, %d0
 ; CHECK-NEXT:    moveq #9, %d1
 ; CHECK-NEXT:    lsr.w %d1, %d0
-; CHECK-NEXT:    and.l #65535, %d0
+; CHECK-NEXT:    swap %d0
+; CHECK-NEXT:    clr.w %d0
+; CHECK-NEXT:    swap %d0
 ; CHECK-NEXT:    rts
 entry:
   %div = udiv i8 %c, 3

--- a/llvm/test/CodeGen/M68k/Arith/imul.ll
+++ b/llvm/test/CodeGen/M68k/Arith/imul.ll
@@ -186,7 +186,7 @@ define i64 @mul3_64(i64 %A) {
 ; CHECK-NEXT:    move.l (24,%sp), %d0
 ; CHECK-NEXT:    move.l %d0, (%sp)
 ; CHECK-NEXT:    move.l #3, (12,%sp)
-; CHECK-NEXT:    move.l #0, (8,%sp)
+; CHECK-NEXT:    clr.l (8,%sp)
 ; CHECK-NEXT:    jsr __muldi3
 ; CHECK-NEXT:    adda.l #20, %sp
 ; CHECK-NEXT:    rts
@@ -205,7 +205,7 @@ define i64 @mul40_64(i64 %A) {
 ; CHECK-NEXT:    move.l (24,%sp), %d0
 ; CHECK-NEXT:    move.l %d0, (%sp)
 ; CHECK-NEXT:    move.l #40, (12,%sp)
-; CHECK-NEXT:    move.l #0, (8,%sp)
+; CHECK-NEXT:    clr.l (8,%sp)
 ; CHECK-NEXT:    jsr __muldi3
 ; CHECK-NEXT:    adda.l #20, %sp
 ; CHECK-NEXT:    rts

--- a/llvm/test/CodeGen/M68k/Arith/rem.ll
+++ b/llvm/test/CodeGen/M68k/Arith/rem.ll
@@ -7,11 +7,15 @@ define zeroext i16 @test1(i16 zeroext %a, i16 zeroext %b) nounwind {
 ; CHECK-LABEL: test1:
 ; CHECK:       ; %bb.0: ; %entry
 ; CHECK-NEXT:    move.w (6,%sp), %d0
-; CHECK-NEXT:    and.l #65535, %d0
+; CHECK-NEXT:    swap %d0
+; CHECK-NEXT:    clr.w %d0
+; CHECK-NEXT:    swap %d0
 ; CHECK-NEXT:    move.w (10,%sp), %d1
 ; CHECK-NEXT:    divu %d1, %d0
 ; CHECK-NEXT:    swap %d0
-; CHECK-NEXT:    and.l #65535, %d0
+; CHECK-NEXT:    swap %d0
+; CHECK-NEXT:    clr.w %d0
+; CHECK-NEXT:    swap %d0
 ; CHECK-NEXT:    rts
 entry:
 	%rem = urem i16 %a, %b
@@ -26,7 +30,9 @@ define zeroext i16 @test2(i16 zeroext %a, i16 zeroext %b) nounwind {
 ; CHECK-NEXT:    move.w (10,%sp), %d1
 ; CHECK-NEXT:    divs %d1, %d0
 ; CHECK-NEXT:    swap %d0
-; CHECK-NEXT:    and.l #65535, %d0
+; CHECK-NEXT:    swap %d0
+; CHECK-NEXT:    clr.w %d0
+; CHECK-NEXT:    swap %d0
 ; CHECK-NEXT:    rts
 entry:
 	%rem = srem i16 %a, %b
@@ -42,8 +48,8 @@ define zeroext i8 @test3(i8 zeroext %a, i8 zeroext %b) nounwind {
 ; CHECK-NEXT:    and.l #255, %d1
 ; CHECK-NEXT:    divu %d0, %d1
 ; CHECK-NEXT:    swap %d1
-; CHECK-NEXT:    move.l %d1, %d0
-; CHECK-NEXT:    and.l #255, %d0
+; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    move.b %d1, %d0
 ; CHECK-NEXT:    rts
 entry:
 	%rem = urem i8 %a, %b
@@ -60,8 +66,8 @@ define zeroext i8 @test4(i8 zeroext %a, i8 zeroext %b) nounwind {
 ; CHECK-NEXT:    ext.l %d1
 ; CHECK-NEXT:    divs %d0, %d1
 ; CHECK-NEXT:    swap %d1
-; CHECK-NEXT:    move.l %d1, %d0
-; CHECK-NEXT:    and.l #255, %d0
+; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    move.b %d1, %d0
 ; CHECK-NEXT:    rts
 entry:
 	%rem = srem i8 %a, %b

--- a/llvm/test/CodeGen/M68k/Arith/smul-with-overflow.ll
+++ b/llvm/test/CodeGen/M68k/Arith/smul-with-overflow.ll
@@ -4,13 +4,13 @@
 define zeroext i8 @smul_i8(i8 signext %a, i8 signext %b) nounwind ssp {
 ; CHECK-LABEL: smul_i8:
 ; CHECK:       ; %bb.0: ; %entry
+; CHECK-NEXT:    moveq #0, %d0
 ; CHECK-NEXT:    move.b (11,%sp), %d0
-; CHECK-NEXT:    and.l #255, %d0
+; CHECK-NEXT:    moveq #0, %d1
 ; CHECK-NEXT:    move.b (7,%sp), %d1
-; CHECK-NEXT:    and.l #255, %d1
 ; CHECK-NEXT:    muls %d0, %d1
-; CHECK-NEXT:    move.l %d1, %d0
-; CHECK-NEXT:    and.l #65535, %d0
+; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    move.w %d1, %d0
 ; CHECK-NEXT:    and.l #255, %d0
 ; CHECK-NEXT:    rts
 entry:
@@ -42,7 +42,9 @@ define zeroext i16 @smul_i16(i16 signext %a, i16 signext %b) nounwind ssp {
 ; CHECK-NEXT:    move.w (6,%sp), %d0
 ; CHECK-NEXT:    move.w (10,%sp), %d1
 ; CHECK-NEXT:    muls %d1, %d0
-; CHECK-NEXT:    and.l #65535, %d0
+; CHECK-NEXT:    swap %d0
+; CHECK-NEXT:    clr.w %d0
+; CHECK-NEXT:    swap %d0
 ; CHECK-NEXT:    rts
 entry:
   %smul = tail call { i16, i1 } @llvm.smul.with.overflow.i16(i16 %a, i16 %b)
@@ -70,7 +72,7 @@ define fastcc i1 @test1(i32 %v1, i32 %v2) nounwind {
 ; CHECK-NEXT:    lea (no,%pc), %a0
 ; CHECK-NEXT:    move.l %a0, (%sp)
 ; CHECK-NEXT:    jsr printf
-; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    clr.b %d0
 ; CHECK-NEXT:    adda.l #12, %sp
 ; CHECK-NEXT:    rts
 ; CHECK-NEXT:  .LBB3_1: ; %normal
@@ -109,7 +111,7 @@ define fastcc i1 @test2(i32 %v1, i32 %v2) nounwind {
 ; CHECK-NEXT:    lea (no,%pc), %a0
 ; CHECK-NEXT:    move.l %a0, (%sp)
 ; CHECK-NEXT:    jsr printf
-; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    clr.b %d0
 ; CHECK-NEXT:    adda.l #12, %sp
 ; CHECK-NEXT:    rts
 ; CHECK-NEXT:  .LBB4_2: ; %normal

--- a/llvm/test/CodeGen/M68k/Arith/sub-with-overflow.ll
+++ b/llvm/test/CodeGen/M68k/Arith/sub-with-overflow.ll
@@ -19,7 +19,7 @@ define i1 @func1(i32 %v1, i32 %v2) nounwind {
 ; CHECK-NEXT:    lea (no,%pc), %a0
 ; CHECK-NEXT:    move.l %a0, (%sp)
 ; CHECK-NEXT:    jsr printf
-; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    clr.b %d0
 ; CHECK-NEXT:    adda.l #12, %sp
 ; CHECK-NEXT:    rts
 ; CHECK-NEXT:  .LBB0_1: ; %normal
@@ -56,7 +56,7 @@ define i1 @func2(i32 %v1, i32 %v2) nounwind {
 ; CHECK-NEXT:    lea (no,%pc), %a0
 ; CHECK-NEXT:    move.l %a0, (%sp)
 ; CHECK-NEXT:    jsr printf
-; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    clr.b %d0
 ; CHECK-NEXT:    adda.l #12, %sp
 ; CHECK-NEXT:    rts
 ; CHECK-NEXT:  .LBB1_1: ; %normal

--- a/llvm/test/CodeGen/M68k/Arith/umul-with-overflow.ll
+++ b/llvm/test/CodeGen/M68k/Arith/umul-with-overflow.ll
@@ -4,13 +4,13 @@
 define zeroext i8 @umul_i8(i8 signext %a, i8 signext %b) nounwind ssp {
 ; CHECK-LABEL: umul_i8:
 ; CHECK:       ; %bb.0: ; %entry
+; CHECK-NEXT:    moveq #0, %d0
 ; CHECK-NEXT:    move.b (11,%sp), %d0
-; CHECK-NEXT:    and.l #255, %d0
+; CHECK-NEXT:    moveq #0, %d1
 ; CHECK-NEXT:    move.b (7,%sp), %d1
-; CHECK-NEXT:    and.l #255, %d1
 ; CHECK-NEXT:    muls %d0, %d1
-; CHECK-NEXT:    move.l %d1, %d0
-; CHECK-NEXT:    and.l #65535, %d0
+; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    move.w %d1, %d0
 ; CHECK-NEXT:    and.l #255, %d0
 ; CHECK-NEXT:    rts
 entry:
@@ -42,7 +42,9 @@ define zeroext i16 @umul_i16(i16 signext %a, i16 signext %b) nounwind ssp {
 ; CHECK-NEXT:    move.w (6,%sp), %d0
 ; CHECK-NEXT:    move.w (10,%sp), %d1
 ; CHECK-NEXT:    muls %d1, %d0
-; CHECK-NEXT:    and.l #65535, %d0
+; CHECK-NEXT:    swap %d0
+; CHECK-NEXT:    clr.w %d0
+; CHECK-NEXT:    swap %d0
 ; CHECK-NEXT:    rts
 entry:
   %umul = tail call { i16, i1 } @llvm.umul.with.overflow.i16(i16 %a, i16 %b)

--- a/llvm/test/CodeGen/M68k/Atomics/cmpxchg.ll
+++ b/llvm/test/CodeGen/M68k/Atomics/cmpxchg.ll
@@ -10,12 +10,12 @@ define i1 @cmpxchg_i8_monotonic_monotonic(i8 %cmp, i8 %new, ptr %mem) nounwind {
 ; NO-ATOMIC:       ; %bb.0:
 ; NO-ATOMIC-NEXT:    suba.l #20, %sp
 ; NO-ATOMIC-NEXT:    movem.l %d2, (16,%sp) ; 8-byte Folded Spill
+; NO-ATOMIC-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-NEXT:    move.b (31,%sp), %d0
-; NO-ATOMIC-NEXT:    and.l #255, %d0
 ; NO-ATOMIC-NEXT:    move.l %d0, (8,%sp)
 ; NO-ATOMIC-NEXT:    move.b (27,%sp), %d2
-; NO-ATOMIC-NEXT:    move.l %d2, %d0
-; NO-ATOMIC-NEXT:    and.l #255, %d0
+; NO-ATOMIC-NEXT:    moveq #0, %d0
+; NO-ATOMIC-NEXT:    move.b %d2, %d0
 ; NO-ATOMIC-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-NEXT:    move.l (32,%sp), %d0
 ; NO-ATOMIC-NEXT:    move.l %d0, (%sp)
@@ -49,11 +49,11 @@ define i16 @cmpxchg_i16_release_monotonic(i16 %cmp, i16 %new, ptr %mem) nounwind
 ; NO-ATOMIC-LABEL: cmpxchg_i16_release_monotonic:
 ; NO-ATOMIC:       ; %bb.0:
 ; NO-ATOMIC-NEXT:    suba.l #12, %sp
+; NO-ATOMIC-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-NEXT:    move.w (22,%sp), %d0
-; NO-ATOMIC-NEXT:    and.l #65535, %d0
 ; NO-ATOMIC-NEXT:    move.l %d0, (8,%sp)
+; NO-ATOMIC-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-NEXT:    move.w (18,%sp), %d0
-; NO-ATOMIC-NEXT:    and.l #65535, %d0
 ; NO-ATOMIC-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-NEXT:    move.l (24,%sp), %d0
 ; NO-ATOMIC-NEXT:    move.l %d0, (%sp)

--- a/llvm/test/CodeGen/M68k/Atomics/load-store.ll
+++ b/llvm/test/CodeGen/M68k/Atomics/load-store.ll
@@ -203,7 +203,7 @@ define i64 @atomic_load_i64_unordered(ptr %a) nounwind {
 ; NO-ATOMIC-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-NEXT:    move.l (16,%sp), %d0
 ; NO-ATOMIC-NEXT:    move.l %d0, (%sp)
-; NO-ATOMIC-NEXT:    move.l #0, (4,%sp)
+; NO-ATOMIC-NEXT:    clr.l (4,%sp)
 ; NO-ATOMIC-NEXT:    jsr __atomic_load_8
 ; NO-ATOMIC-NEXT:    adda.l #12, %sp
 ; NO-ATOMIC-NEXT:    rts
@@ -213,7 +213,7 @@ define i64 @atomic_load_i64_unordered(ptr %a) nounwind {
 ; ATOMIC-NEXT:    suba.l #12, %sp
 ; ATOMIC-NEXT:    move.l (16,%sp), %d0
 ; ATOMIC-NEXT:    move.l %d0, (%sp)
-; ATOMIC-NEXT:    move.l #0, (4,%sp)
+; ATOMIC-NEXT:    clr.l (4,%sp)
 ; ATOMIC-NEXT:    jsr __atomic_load_8
 ; ATOMIC-NEXT:    adda.l #12, %sp
 ; ATOMIC-NEXT:    rts
@@ -227,7 +227,7 @@ define i64 @atomic_load_i64_monotonic(ptr %a) nounwind {
 ; NO-ATOMIC-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-NEXT:    move.l (16,%sp), %d0
 ; NO-ATOMIC-NEXT:    move.l %d0, (%sp)
-; NO-ATOMIC-NEXT:    move.l #0, (4,%sp)
+; NO-ATOMIC-NEXT:    clr.l (4,%sp)
 ; NO-ATOMIC-NEXT:    jsr __atomic_load_8
 ; NO-ATOMIC-NEXT:    adda.l #12, %sp
 ; NO-ATOMIC-NEXT:    rts
@@ -237,7 +237,7 @@ define i64 @atomic_load_i64_monotonic(ptr %a) nounwind {
 ; ATOMIC-NEXT:    suba.l #12, %sp
 ; ATOMIC-NEXT:    move.l (16,%sp), %d0
 ; ATOMIC-NEXT:    move.l %d0, (%sp)
-; ATOMIC-NEXT:    move.l #0, (4,%sp)
+; ATOMIC-NEXT:    clr.l (4,%sp)
 ; ATOMIC-NEXT:    jsr __atomic_load_8
 ; ATOMIC-NEXT:    adda.l #12, %sp
 ; ATOMIC-NEXT:    rts
@@ -519,7 +519,7 @@ define void @atomic_store_i64_unordered(ptr %a, i64 %val) nounwind {
 ; NO-ATOMIC-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-NEXT:    move.l (24,%sp), %d0
 ; NO-ATOMIC-NEXT:    move.l %d0, (%sp)
-; NO-ATOMIC-NEXT:    move.l #0, (12,%sp)
+; NO-ATOMIC-NEXT:    clr.l (12,%sp)
 ; NO-ATOMIC-NEXT:    jsr __atomic_store_8
 ; NO-ATOMIC-NEXT:    adda.l #20, %sp
 ; NO-ATOMIC-NEXT:    rts
@@ -533,7 +533,7 @@ define void @atomic_store_i64_unordered(ptr %a, i64 %val) nounwind {
 ; ATOMIC-NEXT:    move.l %d0, (4,%sp)
 ; ATOMIC-NEXT:    move.l (24,%sp), %d0
 ; ATOMIC-NEXT:    move.l %d0, (%sp)
-; ATOMIC-NEXT:    move.l #0, (12,%sp)
+; ATOMIC-NEXT:    clr.l (12,%sp)
 ; ATOMIC-NEXT:    jsr __atomic_store_8
 ; ATOMIC-NEXT:    adda.l #20, %sp
 ; ATOMIC-NEXT:    rts
@@ -551,7 +551,7 @@ define void @atomic_store_i64_monotonic(ptr %a, i64 %val) nounwind {
 ; NO-ATOMIC-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-NEXT:    move.l (24,%sp), %d0
 ; NO-ATOMIC-NEXT:    move.l %d0, (%sp)
-; NO-ATOMIC-NEXT:    move.l #0, (12,%sp)
+; NO-ATOMIC-NEXT:    clr.l (12,%sp)
 ; NO-ATOMIC-NEXT:    jsr __atomic_store_8
 ; NO-ATOMIC-NEXT:    adda.l #20, %sp
 ; NO-ATOMIC-NEXT:    rts
@@ -565,7 +565,7 @@ define void @atomic_store_i64_monotonic(ptr %a, i64 %val) nounwind {
 ; ATOMIC-NEXT:    move.l %d0, (4,%sp)
 ; ATOMIC-NEXT:    move.l (24,%sp), %d0
 ; ATOMIC-NEXT:    move.l %d0, (%sp)
-; ATOMIC-NEXT:    move.l #0, (12,%sp)
+; ATOMIC-NEXT:    clr.l (12,%sp)
 ; ATOMIC-NEXT:    jsr __atomic_store_8
 ; ATOMIC-NEXT:    adda.l #20, %sp
 ; ATOMIC-NEXT:    rts

--- a/llvm/test/CodeGen/M68k/Atomics/rmw.ll
+++ b/llvm/test/CodeGen/M68k/Atomics/rmw.ll
@@ -11,8 +11,8 @@ define i8 @atomicrmw_add_i8(i8 %val, ptr %ptr) {
 ; NO-ATOMIC-000-NEXT:  ; %bb.0:
 ; NO-ATOMIC-000-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-000-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-000-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-000-NEXT:    move.b (19,%sp), %d0
-; NO-ATOMIC-000-NEXT:    and.l #255, %d0
 ; NO-ATOMIC-000-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-000-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-000-NEXT:    move.l %d0, (%sp)
@@ -25,8 +25,8 @@ define i8 @atomicrmw_add_i8(i8 %val, ptr %ptr) {
 ; NO-ATOMIC-010-NEXT:  ; %bb.0:
 ; NO-ATOMIC-010-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-010-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-010-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-010-NEXT:    move.b (19,%sp), %d0
-; NO-ATOMIC-010-NEXT:    and.l #255, %d0
 ; NO-ATOMIC-010-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-010-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-010-NEXT:    move.l %d0, (%sp)
@@ -72,8 +72,8 @@ define i16 @atomicrmw_sub_i16(i16 %val, ptr %ptr) {
 ; NO-ATOMIC-000-NEXT:  ; %bb.0:
 ; NO-ATOMIC-000-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-000-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-000-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-000-NEXT:    move.w (18,%sp), %d0
-; NO-ATOMIC-000-NEXT:    and.l #65535, %d0
 ; NO-ATOMIC-000-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-000-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-000-NEXT:    move.l %d0, (%sp)
@@ -86,8 +86,8 @@ define i16 @atomicrmw_sub_i16(i16 %val, ptr %ptr) {
 ; NO-ATOMIC-010-NEXT:  ; %bb.0:
 ; NO-ATOMIC-010-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-010-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-010-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-010-NEXT:    move.w (18,%sp), %d0
-; NO-ATOMIC-010-NEXT:    and.l #65535, %d0
 ; NO-ATOMIC-010-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-010-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-010-NEXT:    move.l %d0, (%sp)
@@ -244,8 +244,8 @@ define i8 @atomicrmw_or_i8(i8 %val, ptr %ptr) {
 ; NO-ATOMIC-000-NEXT:  ; %bb.0:
 ; NO-ATOMIC-000-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-000-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-000-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-000-NEXT:    move.b (19,%sp), %d0
-; NO-ATOMIC-000-NEXT:    and.l #255, %d0
 ; NO-ATOMIC-000-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-000-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-000-NEXT:    move.l %d0, (%sp)
@@ -258,8 +258,8 @@ define i8 @atomicrmw_or_i8(i8 %val, ptr %ptr) {
 ; NO-ATOMIC-010-NEXT:  ; %bb.0:
 ; NO-ATOMIC-010-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-010-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-010-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-010-NEXT:    move.b (19,%sp), %d0
-; NO-ATOMIC-010-NEXT:    and.l #255, %d0
 ; NO-ATOMIC-010-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-010-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-010-NEXT:    move.l %d0, (%sp)
@@ -307,8 +307,8 @@ define i16 @atmoicrmw_nand_i16(i16 %val, ptr %ptr) {
 ; NO-ATOMIC-000-NEXT:    .cfi_def_cfa_offset -16
 ; NO-ATOMIC-000-NEXT:    movem.l %d2, (8,%sp) ; 8-byte Folded Spill
 ; NO-ATOMIC-000-NEXT:    move.w (18,%sp), %d2
-; NO-ATOMIC-000-NEXT:    move.l %d2, %d0
-; NO-ATOMIC-000-NEXT:    and.l #65535, %d0
+; NO-ATOMIC-000-NEXT:    moveq #0, %d0
+; NO-ATOMIC-000-NEXT:    move.w %d2, %d0
 ; NO-ATOMIC-000-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-000-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-000-NEXT:    move.l %d0, (%sp)
@@ -325,8 +325,8 @@ define i16 @atmoicrmw_nand_i16(i16 %val, ptr %ptr) {
 ; NO-ATOMIC-010-NEXT:    .cfi_def_cfa_offset -16
 ; NO-ATOMIC-010-NEXT:    movem.l %d2, (8,%sp) ; 8-byte Folded Spill
 ; NO-ATOMIC-010-NEXT:    move.w (18,%sp), %d2
-; NO-ATOMIC-010-NEXT:    move.l %d2, %d0
-; NO-ATOMIC-010-NEXT:    and.l #65535, %d0
+; NO-ATOMIC-010-NEXT:    moveq #0, %d0
+; NO-ATOMIC-010-NEXT:    move.w %d2, %d0
 ; NO-ATOMIC-010-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-010-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-010-NEXT:    move.l %d0, (%sp)
@@ -448,7 +448,7 @@ define i64 @atomicrmw_max_i64(i64 %val, ptr %ptr) {
 ; NO-ATOMIC-000-NEXT:    movem.l %d2-%d5/%a2, (32,%sp) ; 24-byte Folded Spill
 ; NO-ATOMIC-000-NEXT:    move.l (64,%sp), %d3
 ; NO-ATOMIC-000-NEXT:    move.l %d3, (%sp)
-; NO-ATOMIC-000-NEXT:    move.l #0, (4,%sp)
+; NO-ATOMIC-000-NEXT:    clr.l (4,%sp)
 ; NO-ATOMIC-000-NEXT:    move.l (60,%sp), %d4
 ; NO-ATOMIC-000-NEXT:    move.l (56,%sp), %d5
 ; NO-ATOMIC-000-NEXT:    jsr __atomic_load_8
@@ -499,7 +499,7 @@ define i64 @atomicrmw_max_i64(i64 %val, ptr %ptr) {
 ; NO-ATOMIC-010-NEXT:    movem.l %d2-%d5/%a2, (32,%sp) ; 24-byte Folded Spill
 ; NO-ATOMIC-010-NEXT:    move.l (64,%sp), %d3
 ; NO-ATOMIC-010-NEXT:    move.l %d3, (%sp)
-; NO-ATOMIC-010-NEXT:    move.l #0, (4,%sp)
+; NO-ATOMIC-010-NEXT:    clr.l (4,%sp)
 ; NO-ATOMIC-010-NEXT:    move.l (60,%sp), %d4
 ; NO-ATOMIC-010-NEXT:    move.l (56,%sp), %d5
 ; NO-ATOMIC-010-NEXT:    jsr __atomic_load_8
@@ -550,7 +550,7 @@ define i64 @atomicrmw_max_i64(i64 %val, ptr %ptr) {
 ; ATOMIC-NEXT:    movem.l %d2-%d5/%a2, (32,%sp) ; 24-byte Folded Spill
 ; ATOMIC-NEXT:    move.l (64,%sp), %d3
 ; ATOMIC-NEXT:    move.l %d3, (%sp)
-; ATOMIC-NEXT:    move.l #0, (4,%sp)
+; ATOMIC-NEXT:    clr.l (4,%sp)
 ; ATOMIC-NEXT:    move.l (60,%sp), %d4
 ; ATOMIC-NEXT:    move.l (56,%sp), %d5
 ; ATOMIC-NEXT:    jsr __atomic_load_8
@@ -602,8 +602,8 @@ define i8 @atomicrmw_i8_umin(i8 %val, ptr %ptr) {
 ; NO-ATOMIC-000-NEXT:  ; %bb.0:
 ; NO-ATOMIC-000-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-000-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-000-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-000-NEXT:    move.b (19,%sp), %d0
-; NO-ATOMIC-000-NEXT:    and.l #255, %d0
 ; NO-ATOMIC-000-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-000-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-000-NEXT:    move.l %d0, (%sp)
@@ -616,8 +616,8 @@ define i8 @atomicrmw_i8_umin(i8 %val, ptr %ptr) {
 ; NO-ATOMIC-010-NEXT:  ; %bb.0:
 ; NO-ATOMIC-010-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-010-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-010-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-010-NEXT:    move.b (19,%sp), %d0
-; NO-ATOMIC-010-NEXT:    and.l #255, %d0
 ; NO-ATOMIC-010-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-010-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-010-NEXT:    move.l %d0, (%sp)
@@ -674,8 +674,8 @@ define i16 @atomicrmw_umax_i16(i16 %val, ptr %ptr) {
 ; NO-ATOMIC-000-NEXT:  ; %bb.0:
 ; NO-ATOMIC-000-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-000-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-000-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-000-NEXT:    move.w (18,%sp), %d0
-; NO-ATOMIC-000-NEXT:    and.l #65535, %d0
 ; NO-ATOMIC-000-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-000-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-000-NEXT:    move.l %d0, (%sp)
@@ -688,8 +688,8 @@ define i16 @atomicrmw_umax_i16(i16 %val, ptr %ptr) {
 ; NO-ATOMIC-010-NEXT:  ; %bb.0:
 ; NO-ATOMIC-010-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-010-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-010-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-010-NEXT:    move.w (18,%sp), %d0
-; NO-ATOMIC-010-NEXT:    and.l #65535, %d0
 ; NO-ATOMIC-010-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-010-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-010-NEXT:    move.l %d0, (%sp)
@@ -746,8 +746,8 @@ define i16 @atomicrmw_xchg_i16(i16 %val, ptr %ptr) {
 ; NO-ATOMIC-000-NEXT:  ; %bb.0: ; %entry
 ; NO-ATOMIC-000-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-000-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-000-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-000-NEXT:    move.w (18,%sp), %d0
-; NO-ATOMIC-000-NEXT:    and.l #65535, %d0
 ; NO-ATOMIC-000-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-000-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-000-NEXT:    move.l %d0, (%sp)
@@ -760,8 +760,8 @@ define i16 @atomicrmw_xchg_i16(i16 %val, ptr %ptr) {
 ; NO-ATOMIC-010-NEXT:  ; %bb.0: ; %entry
 ; NO-ATOMIC-010-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-010-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-010-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-010-NEXT:    move.w (18,%sp), %d0
-; NO-ATOMIC-010-NEXT:    and.l #65535, %d0
 ; NO-ATOMIC-010-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-010-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-010-NEXT:    move.l %d0, (%sp)

--- a/llvm/test/CodeGen/M68k/Bits/btst.ll
+++ b/llvm/test/CodeGen/M68k/Bits/btst.ll
@@ -9,7 +9,9 @@ define fastcc i16 @switch_to_btst(i16 %a) nounwind {
 ; CHECK-NEXT:    sub.l #11, %d1
 ; CHECK-NEXT:    bhi .LBB0_3
 ; CHECK-NEXT:  ; %bb.1: ; %entry
-; CHECK-NEXT:    and.l #65535, %d0
+; CHECK-NEXT:    swap %d0
+; CHECK-NEXT:    clr.w %d0
+; CHECK-NEXT:    swap %d0
 ; CHECK-NEXT:    move.l #3612, %d1
 ; CHECK-NEXT:    btst %d0, %d1
 ; CHECK-NEXT:    beq .LBB0_3
@@ -17,7 +19,7 @@ define fastcc i16 @switch_to_btst(i16 %a) nounwind {
 ; CHECK-NEXT:    moveq #1, %d0
 ; CHECK-NEXT:    rts
 ; CHECK-NEXT:  .LBB0_3: ; %no_match
-; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    clr.w %d0
 ; CHECK-NEXT:    rts
   entry:
     switch i16 %a, label %no_match [
@@ -43,7 +45,7 @@ define fastcc i16 @and_mask_to_btst(i8 %a, i8 %b) nounwind {
 ; CHECK-NEXT:    btst %d1, %d0
 ; CHECK-NEXT:    beq .LBB1_1
 ; CHECK-NEXT:  ; %bb.2: ; %cond_false
-; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    clr.w %d0
 ; CHECK-NEXT:    rts
 ; CHECK-NEXT:  .LBB1_1: ; %cond_true
 ; CHECK-NEXT:    moveq #1, %d0

--- a/llvm/test/CodeGen/M68k/CConv/c-call.ll
+++ b/llvm/test/CodeGen/M68k/CConv/c-call.ll
@@ -34,7 +34,7 @@ define i16 @test2() nounwind {
 ; CHECK-NEXT:    move.l #2, (4,%sp)
 ; CHECK-NEXT:    move.l #1, (%sp)
 ; CHECK-NEXT:    jsr (test2_callee@PLT,%pc)
-; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    clr.w %d0
 ; CHECK-NEXT:    adda.l #20, %sp
 ; CHECK-NEXT:    rts
 entry:
@@ -54,7 +54,7 @@ define i8 @test3() nounwind {
 ; CHECK-NEXT:    move.l #2, (4,%sp)
 ; CHECK-NEXT:    move.l #1, (%sp)
 ; CHECK-NEXT:    jsr (test3_callee@PLT,%pc)
-; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    clr.b %d0
 ; CHECK-NEXT:    adda.l #20, %sp
 ; CHECK-NEXT:    rts
 entry:

--- a/llvm/test/CodeGen/M68k/CodeModel/Large/Atomics/cmpxchg.ll
+++ b/llvm/test/CodeGen/M68k/CodeModel/Large/Atomics/cmpxchg.ll
@@ -19,7 +19,7 @@ define { i32, i1 } @std_thread_new() {
 ; NO-ATOMIC-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-NEXT:    .cfi_def_cfa_offset -16
 ; NO-ATOMIC-NEXT:    move.l #1, (8,%sp)
-; NO-ATOMIC-NEXT:    move.l #0, (4,%sp)
+; NO-ATOMIC-NEXT:    clr.l (4,%sp)
 ; NO-ATOMIC-NEXT:    move.l #thread_id, (%sp)
 ; NO-ATOMIC-NEXT:    jsr __sync_val_compare_and_swap_4
 ; NO-ATOMIC-NEXT:    cmpi.l #0, %d0
@@ -36,7 +36,7 @@ define { i32, i1 } @std_thread_new() {
 ; NO-ATOMIC-PIC-NEXT:    adda.l #thread_id@GOTOFF, %a0
 ; NO-ATOMIC-PIC-NEXT:    move.l %a0, (%sp)
 ; NO-ATOMIC-PIC-NEXT:    move.l #1, (8,%sp)
-; NO-ATOMIC-PIC-NEXT:    move.l #0, (4,%sp)
+; NO-ATOMIC-PIC-NEXT:    clr.l (4,%sp)
 ; NO-ATOMIC-PIC-NEXT:    jsr (__sync_val_compare_and_swap_4@PLT,%pc)
 ; NO-ATOMIC-PIC-NEXT:    cmpi.l #0, %d0
 ; NO-ATOMIC-PIC-NEXT:    seq %d1
@@ -80,12 +80,12 @@ define i1 @cmpxchg_i8_monotonic_monotonic(i8 %cmp, i8 %new, ptr %mem) nounwind {
 ; NO-ATOMIC:       ; %bb.0:
 ; NO-ATOMIC-NEXT:    suba.l #20, %sp
 ; NO-ATOMIC-NEXT:    movem.l %d2, (16,%sp) ; 8-byte Folded Spill
+; NO-ATOMIC-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-NEXT:    move.b (31,%sp), %d0
-; NO-ATOMIC-NEXT:    and.l #255, %d0
 ; NO-ATOMIC-NEXT:    move.l %d0, (8,%sp)
 ; NO-ATOMIC-NEXT:    move.b (27,%sp), %d2
-; NO-ATOMIC-NEXT:    move.l %d2, %d0
-; NO-ATOMIC-NEXT:    and.l #255, %d0
+; NO-ATOMIC-NEXT:    moveq #0, %d0
+; NO-ATOMIC-NEXT:    move.b %d2, %d0
 ; NO-ATOMIC-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-NEXT:    move.l (32,%sp), %d0
 ; NO-ATOMIC-NEXT:    move.l %d0, (%sp)
@@ -100,12 +100,12 @@ define i1 @cmpxchg_i8_monotonic_monotonic(i8 %cmp, i8 %new, ptr %mem) nounwind {
 ; NO-ATOMIC-PIC:       ; %bb.0:
 ; NO-ATOMIC-PIC-NEXT:    suba.l #20, %sp
 ; NO-ATOMIC-PIC-NEXT:    movem.l %d2, (16,%sp) ; 8-byte Folded Spill
+; NO-ATOMIC-PIC-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-PIC-NEXT:    move.b (31,%sp), %d0
-; NO-ATOMIC-PIC-NEXT:    and.l #255, %d0
 ; NO-ATOMIC-PIC-NEXT:    move.l %d0, (8,%sp)
 ; NO-ATOMIC-PIC-NEXT:    move.b (27,%sp), %d2
-; NO-ATOMIC-PIC-NEXT:    move.l %d2, %d0
-; NO-ATOMIC-PIC-NEXT:    and.l #255, %d0
+; NO-ATOMIC-PIC-NEXT:    moveq #0, %d0
+; NO-ATOMIC-PIC-NEXT:    move.b %d2, %d0
 ; NO-ATOMIC-PIC-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-PIC-NEXT:    move.l (32,%sp), %d0
 ; NO-ATOMIC-PIC-NEXT:    move.l %d0, (%sp)
@@ -154,11 +154,11 @@ define i16 @cmpxchg_i16_release_monotonic(i16 %cmp, i16 %new, ptr %mem) nounwind
 ; NO-ATOMIC-LABEL: cmpxchg_i16_release_monotonic:
 ; NO-ATOMIC:       ; %bb.0:
 ; NO-ATOMIC-NEXT:    suba.l #12, %sp
+; NO-ATOMIC-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-NEXT:    move.w (22,%sp), %d0
-; NO-ATOMIC-NEXT:    and.l #65535, %d0
 ; NO-ATOMIC-NEXT:    move.l %d0, (8,%sp)
+; NO-ATOMIC-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-NEXT:    move.w (18,%sp), %d0
-; NO-ATOMIC-NEXT:    and.l #65535, %d0
 ; NO-ATOMIC-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-NEXT:    move.l (24,%sp), %d0
 ; NO-ATOMIC-NEXT:    move.l %d0, (%sp)
@@ -169,11 +169,11 @@ define i16 @cmpxchg_i16_release_monotonic(i16 %cmp, i16 %new, ptr %mem) nounwind
 ; NO-ATOMIC-PIC-LABEL: cmpxchg_i16_release_monotonic:
 ; NO-ATOMIC-PIC:       ; %bb.0:
 ; NO-ATOMIC-PIC-NEXT:    suba.l #12, %sp
+; NO-ATOMIC-PIC-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-PIC-NEXT:    move.w (22,%sp), %d0
-; NO-ATOMIC-PIC-NEXT:    and.l #65535, %d0
 ; NO-ATOMIC-PIC-NEXT:    move.l %d0, (8,%sp)
+; NO-ATOMIC-PIC-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-PIC-NEXT:    move.w (18,%sp), %d0
-; NO-ATOMIC-PIC-NEXT:    and.l #65535, %d0
 ; NO-ATOMIC-PIC-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-PIC-NEXT:    move.l (24,%sp), %d0
 ; NO-ATOMIC-PIC-NEXT:    move.l %d0, (%sp)

--- a/llvm/test/CodeGen/M68k/CodeModel/Large/Atomics/load-store.ll
+++ b/llvm/test/CodeGen/M68k/CodeModel/Large/Atomics/load-store.ll
@@ -352,7 +352,7 @@ define i64 @atomic_load_i64_unordered(ptr %a) nounwind {
 ; NO-ATOMIC-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-NEXT:    move.l (16,%sp), %d0
 ; NO-ATOMIC-NEXT:    move.l %d0, (%sp)
-; NO-ATOMIC-NEXT:    move.l #0, (4,%sp)
+; NO-ATOMIC-NEXT:    clr.l (4,%sp)
 ; NO-ATOMIC-NEXT:    jsr __atomic_load_8
 ; NO-ATOMIC-NEXT:    adda.l #12, %sp
 ; NO-ATOMIC-NEXT:    rts
@@ -362,7 +362,7 @@ define i64 @atomic_load_i64_unordered(ptr %a) nounwind {
 ; NO-ATOMIC-PIC-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-PIC-NEXT:    move.l (16,%sp), %d0
 ; NO-ATOMIC-PIC-NEXT:    move.l %d0, (%sp)
-; NO-ATOMIC-PIC-NEXT:    move.l #0, (4,%sp)
+; NO-ATOMIC-PIC-NEXT:    clr.l (4,%sp)
 ; NO-ATOMIC-PIC-NEXT:    jsr (__atomic_load_8@PLT,%pc)
 ; NO-ATOMIC-PIC-NEXT:    adda.l #12, %sp
 ; NO-ATOMIC-PIC-NEXT:    rts
@@ -372,7 +372,7 @@ define i64 @atomic_load_i64_unordered(ptr %a) nounwind {
 ; ATOMIC-NEXT:    suba.l #12, %sp
 ; ATOMIC-NEXT:    move.l (16,%sp), %d0
 ; ATOMIC-NEXT:    move.l %d0, (%sp)
-; ATOMIC-NEXT:    move.l #0, (4,%sp)
+; ATOMIC-NEXT:    clr.l (4,%sp)
 ; ATOMIC-NEXT:    jsr __atomic_load_8
 ; ATOMIC-NEXT:    adda.l #12, %sp
 ; ATOMIC-NEXT:    rts
@@ -382,7 +382,7 @@ define i64 @atomic_load_i64_unordered(ptr %a) nounwind {
 ; ATOMIC-PIC-NEXT:    suba.l #12, %sp
 ; ATOMIC-PIC-NEXT:    move.l (16,%sp), %d0
 ; ATOMIC-PIC-NEXT:    move.l %d0, (%sp)
-; ATOMIC-PIC-NEXT:    move.l #0, (4,%sp)
+; ATOMIC-PIC-NEXT:    clr.l (4,%sp)
 ; ATOMIC-PIC-NEXT:    jsr (__atomic_load_8@PLT,%pc)
 ; ATOMIC-PIC-NEXT:    adda.l #12, %sp
 ; ATOMIC-PIC-NEXT:    rts
@@ -396,7 +396,7 @@ define i64 @atomic_load_i64_monotonic(ptr %a) nounwind {
 ; NO-ATOMIC-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-NEXT:    move.l (16,%sp), %d0
 ; NO-ATOMIC-NEXT:    move.l %d0, (%sp)
-; NO-ATOMIC-NEXT:    move.l #0, (4,%sp)
+; NO-ATOMIC-NEXT:    clr.l (4,%sp)
 ; NO-ATOMIC-NEXT:    jsr __atomic_load_8
 ; NO-ATOMIC-NEXT:    adda.l #12, %sp
 ; NO-ATOMIC-NEXT:    rts
@@ -406,7 +406,7 @@ define i64 @atomic_load_i64_monotonic(ptr %a) nounwind {
 ; NO-ATOMIC-PIC-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-PIC-NEXT:    move.l (16,%sp), %d0
 ; NO-ATOMIC-PIC-NEXT:    move.l %d0, (%sp)
-; NO-ATOMIC-PIC-NEXT:    move.l #0, (4,%sp)
+; NO-ATOMIC-PIC-NEXT:    clr.l (4,%sp)
 ; NO-ATOMIC-PIC-NEXT:    jsr (__atomic_load_8@PLT,%pc)
 ; NO-ATOMIC-PIC-NEXT:    adda.l #12, %sp
 ; NO-ATOMIC-PIC-NEXT:    rts
@@ -416,7 +416,7 @@ define i64 @atomic_load_i64_monotonic(ptr %a) nounwind {
 ; ATOMIC-NEXT:    suba.l #12, %sp
 ; ATOMIC-NEXT:    move.l (16,%sp), %d0
 ; ATOMIC-NEXT:    move.l %d0, (%sp)
-; ATOMIC-NEXT:    move.l #0, (4,%sp)
+; ATOMIC-NEXT:    clr.l (4,%sp)
 ; ATOMIC-NEXT:    jsr __atomic_load_8
 ; ATOMIC-NEXT:    adda.l #12, %sp
 ; ATOMIC-NEXT:    rts
@@ -426,7 +426,7 @@ define i64 @atomic_load_i64_monotonic(ptr %a) nounwind {
 ; ATOMIC-PIC-NEXT:    suba.l #12, %sp
 ; ATOMIC-PIC-NEXT:    move.l (16,%sp), %d0
 ; ATOMIC-PIC-NEXT:    move.l %d0, (%sp)
-; ATOMIC-PIC-NEXT:    move.l #0, (4,%sp)
+; ATOMIC-PIC-NEXT:    clr.l (4,%sp)
 ; ATOMIC-PIC-NEXT:    jsr (__atomic_load_8@PLT,%pc)
 ; ATOMIC-PIC-NEXT:    adda.l #12, %sp
 ; ATOMIC-PIC-NEXT:    rts
@@ -916,7 +916,7 @@ define void @atomic_store_i64_unordered(ptr %a, i64 %val) nounwind {
 ; NO-ATOMIC-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-NEXT:    move.l (24,%sp), %d0
 ; NO-ATOMIC-NEXT:    move.l %d0, (%sp)
-; NO-ATOMIC-NEXT:    move.l #0, (12,%sp)
+; NO-ATOMIC-NEXT:    clr.l (12,%sp)
 ; NO-ATOMIC-NEXT:    jsr __atomic_store_8
 ; NO-ATOMIC-NEXT:    adda.l #20, %sp
 ; NO-ATOMIC-NEXT:    rts
@@ -930,7 +930,7 @@ define void @atomic_store_i64_unordered(ptr %a, i64 %val) nounwind {
 ; NO-ATOMIC-PIC-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-PIC-NEXT:    move.l (24,%sp), %d0
 ; NO-ATOMIC-PIC-NEXT:    move.l %d0, (%sp)
-; NO-ATOMIC-PIC-NEXT:    move.l #0, (12,%sp)
+; NO-ATOMIC-PIC-NEXT:    clr.l (12,%sp)
 ; NO-ATOMIC-PIC-NEXT:    jsr (__atomic_store_8@PLT,%pc)
 ; NO-ATOMIC-PIC-NEXT:    adda.l #20, %sp
 ; NO-ATOMIC-PIC-NEXT:    rts
@@ -944,7 +944,7 @@ define void @atomic_store_i64_unordered(ptr %a, i64 %val) nounwind {
 ; ATOMIC-NEXT:    move.l %d0, (4,%sp)
 ; ATOMIC-NEXT:    move.l (24,%sp), %d0
 ; ATOMIC-NEXT:    move.l %d0, (%sp)
-; ATOMIC-NEXT:    move.l #0, (12,%sp)
+; ATOMIC-NEXT:    clr.l (12,%sp)
 ; ATOMIC-NEXT:    jsr __atomic_store_8
 ; ATOMIC-NEXT:    adda.l #20, %sp
 ; ATOMIC-NEXT:    rts
@@ -958,7 +958,7 @@ define void @atomic_store_i64_unordered(ptr %a, i64 %val) nounwind {
 ; ATOMIC-PIC-NEXT:    move.l %d0, (4,%sp)
 ; ATOMIC-PIC-NEXT:    move.l (24,%sp), %d0
 ; ATOMIC-PIC-NEXT:    move.l %d0, (%sp)
-; ATOMIC-PIC-NEXT:    move.l #0, (12,%sp)
+; ATOMIC-PIC-NEXT:    clr.l (12,%sp)
 ; ATOMIC-PIC-NEXT:    jsr (__atomic_store_8@PLT,%pc)
 ; ATOMIC-PIC-NEXT:    adda.l #20, %sp
 ; ATOMIC-PIC-NEXT:    rts
@@ -976,7 +976,7 @@ define void @atomic_store_i64_monotonic(ptr %a, i64 %val) nounwind {
 ; NO-ATOMIC-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-NEXT:    move.l (24,%sp), %d0
 ; NO-ATOMIC-NEXT:    move.l %d0, (%sp)
-; NO-ATOMIC-NEXT:    move.l #0, (12,%sp)
+; NO-ATOMIC-NEXT:    clr.l (12,%sp)
 ; NO-ATOMIC-NEXT:    jsr __atomic_store_8
 ; NO-ATOMIC-NEXT:    adda.l #20, %sp
 ; NO-ATOMIC-NEXT:    rts
@@ -990,7 +990,7 @@ define void @atomic_store_i64_monotonic(ptr %a, i64 %val) nounwind {
 ; NO-ATOMIC-PIC-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-PIC-NEXT:    move.l (24,%sp), %d0
 ; NO-ATOMIC-PIC-NEXT:    move.l %d0, (%sp)
-; NO-ATOMIC-PIC-NEXT:    move.l #0, (12,%sp)
+; NO-ATOMIC-PIC-NEXT:    clr.l (12,%sp)
 ; NO-ATOMIC-PIC-NEXT:    jsr (__atomic_store_8@PLT,%pc)
 ; NO-ATOMIC-PIC-NEXT:    adda.l #20, %sp
 ; NO-ATOMIC-PIC-NEXT:    rts
@@ -1004,7 +1004,7 @@ define void @atomic_store_i64_monotonic(ptr %a, i64 %val) nounwind {
 ; ATOMIC-NEXT:    move.l %d0, (4,%sp)
 ; ATOMIC-NEXT:    move.l (24,%sp), %d0
 ; ATOMIC-NEXT:    move.l %d0, (%sp)
-; ATOMIC-NEXT:    move.l #0, (12,%sp)
+; ATOMIC-NEXT:    clr.l (12,%sp)
 ; ATOMIC-NEXT:    jsr __atomic_store_8
 ; ATOMIC-NEXT:    adda.l #20, %sp
 ; ATOMIC-NEXT:    rts
@@ -1018,7 +1018,7 @@ define void @atomic_store_i64_monotonic(ptr %a, i64 %val) nounwind {
 ; ATOMIC-PIC-NEXT:    move.l %d0, (4,%sp)
 ; ATOMIC-PIC-NEXT:    move.l (24,%sp), %d0
 ; ATOMIC-PIC-NEXT:    move.l %d0, (%sp)
-; ATOMIC-PIC-NEXT:    move.l #0, (12,%sp)
+; ATOMIC-PIC-NEXT:    clr.l (12,%sp)
 ; ATOMIC-PIC-NEXT:    jsr (__atomic_store_8@PLT,%pc)
 ; ATOMIC-PIC-NEXT:    adda.l #20, %sp
 ; ATOMIC-PIC-NEXT:    rts

--- a/llvm/test/CodeGen/M68k/CodeModel/Large/Atomics/rmw.ll
+++ b/llvm/test/CodeGen/M68k/CodeModel/Large/Atomics/rmw.ll
@@ -16,8 +16,8 @@ define i8 @atomicrmw_add_i8(i8 %val, ptr %ptr) {
 ; NO-ATOMIC-000-NEXT:  ; %bb.0:
 ; NO-ATOMIC-000-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-000-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-000-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-000-NEXT:    move.b (19,%sp), %d0
-; NO-ATOMIC-000-NEXT:    and.l #255, %d0
 ; NO-ATOMIC-000-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-000-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-000-NEXT:    move.l %d0, (%sp)
@@ -30,8 +30,8 @@ define i8 @atomicrmw_add_i8(i8 %val, ptr %ptr) {
 ; NO-ATOMIC-010-NEXT:  ; %bb.0:
 ; NO-ATOMIC-010-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-010-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-010-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-010-NEXT:    move.b (19,%sp), %d0
-; NO-ATOMIC-010-NEXT:    and.l #255, %d0
 ; NO-ATOMIC-010-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-010-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-010-NEXT:    move.l %d0, (%sp)
@@ -44,8 +44,8 @@ define i8 @atomicrmw_add_i8(i8 %val, ptr %ptr) {
 ; NO-ATOMIC-PIC-000-NEXT:  ; %bb.0:
 ; NO-ATOMIC-PIC-000-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-PIC-000-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-PIC-000-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-PIC-000-NEXT:    move.b (19,%sp), %d0
-; NO-ATOMIC-PIC-000-NEXT:    and.l #255, %d0
 ; NO-ATOMIC-PIC-000-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-PIC-000-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-PIC-000-NEXT:    move.l %d0, (%sp)
@@ -58,8 +58,8 @@ define i8 @atomicrmw_add_i8(i8 %val, ptr %ptr) {
 ; NO-ATOMIC-PIC-010-NEXT:  ; %bb.0:
 ; NO-ATOMIC-PIC-010-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-PIC-010-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-PIC-010-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-PIC-010-NEXT:    move.b (19,%sp), %d0
-; NO-ATOMIC-PIC-010-NEXT:    and.l #255, %d0
 ; NO-ATOMIC-PIC-010-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-PIC-010-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-PIC-010-NEXT:    move.l %d0, (%sp)
@@ -134,8 +134,8 @@ define i16 @atomicrmw_sub_i16(i16 %val, ptr %ptr) {
 ; NO-ATOMIC-000-NEXT:  ; %bb.0:
 ; NO-ATOMIC-000-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-000-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-000-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-000-NEXT:    move.w (18,%sp), %d0
-; NO-ATOMIC-000-NEXT:    and.l #65535, %d0
 ; NO-ATOMIC-000-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-000-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-000-NEXT:    move.l %d0, (%sp)
@@ -148,8 +148,8 @@ define i16 @atomicrmw_sub_i16(i16 %val, ptr %ptr) {
 ; NO-ATOMIC-010-NEXT:  ; %bb.0:
 ; NO-ATOMIC-010-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-010-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-010-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-010-NEXT:    move.w (18,%sp), %d0
-; NO-ATOMIC-010-NEXT:    and.l #65535, %d0
 ; NO-ATOMIC-010-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-010-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-010-NEXT:    move.l %d0, (%sp)
@@ -162,8 +162,8 @@ define i16 @atomicrmw_sub_i16(i16 %val, ptr %ptr) {
 ; NO-ATOMIC-PIC-000-NEXT:  ; %bb.0:
 ; NO-ATOMIC-PIC-000-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-PIC-000-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-PIC-000-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-PIC-000-NEXT:    move.w (18,%sp), %d0
-; NO-ATOMIC-PIC-000-NEXT:    and.l #65535, %d0
 ; NO-ATOMIC-PIC-000-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-PIC-000-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-PIC-000-NEXT:    move.l %d0, (%sp)
@@ -176,8 +176,8 @@ define i16 @atomicrmw_sub_i16(i16 %val, ptr %ptr) {
 ; NO-ATOMIC-PIC-010-NEXT:  ; %bb.0:
 ; NO-ATOMIC-PIC-010-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-PIC-010-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-PIC-010-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-PIC-010-NEXT:    move.w (18,%sp), %d0
-; NO-ATOMIC-PIC-010-NEXT:    and.l #65535, %d0
 ; NO-ATOMIC-PIC-010-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-PIC-010-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-PIC-010-NEXT:    move.l %d0, (%sp)
@@ -466,8 +466,8 @@ define i8 @atomicrmw_or_i8(i8 %val, ptr %ptr) {
 ; NO-ATOMIC-000-NEXT:  ; %bb.0:
 ; NO-ATOMIC-000-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-000-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-000-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-000-NEXT:    move.b (19,%sp), %d0
-; NO-ATOMIC-000-NEXT:    and.l #255, %d0
 ; NO-ATOMIC-000-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-000-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-000-NEXT:    move.l %d0, (%sp)
@@ -480,8 +480,8 @@ define i8 @atomicrmw_or_i8(i8 %val, ptr %ptr) {
 ; NO-ATOMIC-010-NEXT:  ; %bb.0:
 ; NO-ATOMIC-010-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-010-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-010-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-010-NEXT:    move.b (19,%sp), %d0
-; NO-ATOMIC-010-NEXT:    and.l #255, %d0
 ; NO-ATOMIC-010-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-010-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-010-NEXT:    move.l %d0, (%sp)
@@ -494,8 +494,8 @@ define i8 @atomicrmw_or_i8(i8 %val, ptr %ptr) {
 ; NO-ATOMIC-PIC-000-NEXT:  ; %bb.0:
 ; NO-ATOMIC-PIC-000-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-PIC-000-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-PIC-000-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-PIC-000-NEXT:    move.b (19,%sp), %d0
-; NO-ATOMIC-PIC-000-NEXT:    and.l #255, %d0
 ; NO-ATOMIC-PIC-000-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-PIC-000-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-PIC-000-NEXT:    move.l %d0, (%sp)
@@ -508,8 +508,8 @@ define i8 @atomicrmw_or_i8(i8 %val, ptr %ptr) {
 ; NO-ATOMIC-PIC-010-NEXT:  ; %bb.0:
 ; NO-ATOMIC-PIC-010-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-PIC-010-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-PIC-010-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-PIC-010-NEXT:    move.b (19,%sp), %d0
-; NO-ATOMIC-PIC-010-NEXT:    and.l #255, %d0
 ; NO-ATOMIC-PIC-010-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-PIC-010-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-PIC-010-NEXT:    move.l %d0, (%sp)
@@ -586,8 +586,8 @@ define i16 @atmoicrmw_nand_i16(i16 %val, ptr %ptr) {
 ; NO-ATOMIC-000-NEXT:    .cfi_def_cfa_offset -16
 ; NO-ATOMIC-000-NEXT:    movem.l %d2, (8,%sp) ; 8-byte Folded Spill
 ; NO-ATOMIC-000-NEXT:    move.w (18,%sp), %d2
-; NO-ATOMIC-000-NEXT:    move.l %d2, %d0
-; NO-ATOMIC-000-NEXT:    and.l #65535, %d0
+; NO-ATOMIC-000-NEXT:    moveq #0, %d0
+; NO-ATOMIC-000-NEXT:    move.w %d2, %d0
 ; NO-ATOMIC-000-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-000-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-000-NEXT:    move.l %d0, (%sp)
@@ -604,8 +604,8 @@ define i16 @atmoicrmw_nand_i16(i16 %val, ptr %ptr) {
 ; NO-ATOMIC-010-NEXT:    .cfi_def_cfa_offset -16
 ; NO-ATOMIC-010-NEXT:    movem.l %d2, (8,%sp) ; 8-byte Folded Spill
 ; NO-ATOMIC-010-NEXT:    move.w (18,%sp), %d2
-; NO-ATOMIC-010-NEXT:    move.l %d2, %d0
-; NO-ATOMIC-010-NEXT:    and.l #65535, %d0
+; NO-ATOMIC-010-NEXT:    moveq #0, %d0
+; NO-ATOMIC-010-NEXT:    move.w %d2, %d0
 ; NO-ATOMIC-010-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-010-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-010-NEXT:    move.l %d0, (%sp)
@@ -622,8 +622,8 @@ define i16 @atmoicrmw_nand_i16(i16 %val, ptr %ptr) {
 ; NO-ATOMIC-PIC-000-NEXT:    .cfi_def_cfa_offset -16
 ; NO-ATOMIC-PIC-000-NEXT:    movem.l %d2, (8,%sp) ; 8-byte Folded Spill
 ; NO-ATOMIC-PIC-000-NEXT:    move.w (18,%sp), %d2
-; NO-ATOMIC-PIC-000-NEXT:    move.l %d2, %d0
-; NO-ATOMIC-PIC-000-NEXT:    and.l #65535, %d0
+; NO-ATOMIC-PIC-000-NEXT:    moveq #0, %d0
+; NO-ATOMIC-PIC-000-NEXT:    move.w %d2, %d0
 ; NO-ATOMIC-PIC-000-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-PIC-000-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-PIC-000-NEXT:    move.l %d0, (%sp)
@@ -640,8 +640,8 @@ define i16 @atmoicrmw_nand_i16(i16 %val, ptr %ptr) {
 ; NO-ATOMIC-PIC-010-NEXT:    .cfi_def_cfa_offset -16
 ; NO-ATOMIC-PIC-010-NEXT:    movem.l %d2, (8,%sp) ; 8-byte Folded Spill
 ; NO-ATOMIC-PIC-010-NEXT:    move.w (18,%sp), %d2
-; NO-ATOMIC-PIC-010-NEXT:    move.l %d2, %d0
-; NO-ATOMIC-PIC-010-NEXT:    and.l #65535, %d0
+; NO-ATOMIC-PIC-010-NEXT:    moveq #0, %d0
+; NO-ATOMIC-PIC-010-NEXT:    move.w %d2, %d0
 ; NO-ATOMIC-PIC-010-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-PIC-010-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-PIC-010-NEXT:    move.l %d0, (%sp)
@@ -859,7 +859,7 @@ define i64 @atomicrmw_max_i64(i64 %val, ptr %ptr) {
 ; NO-ATOMIC-000-NEXT:    movem.l %d2-%d5/%a2, (32,%sp) ; 24-byte Folded Spill
 ; NO-ATOMIC-000-NEXT:    move.l (64,%sp), %d3
 ; NO-ATOMIC-000-NEXT:    move.l %d3, (%sp)
-; NO-ATOMIC-000-NEXT:    move.l #0, (4,%sp)
+; NO-ATOMIC-000-NEXT:    clr.l (4,%sp)
 ; NO-ATOMIC-000-NEXT:    move.l (60,%sp), %d4
 ; NO-ATOMIC-000-NEXT:    move.l (56,%sp), %d5
 ; NO-ATOMIC-000-NEXT:    jsr __atomic_load_8
@@ -910,7 +910,7 @@ define i64 @atomicrmw_max_i64(i64 %val, ptr %ptr) {
 ; NO-ATOMIC-010-NEXT:    movem.l %d2-%d5/%a2, (32,%sp) ; 24-byte Folded Spill
 ; NO-ATOMIC-010-NEXT:    move.l (64,%sp), %d3
 ; NO-ATOMIC-010-NEXT:    move.l %d3, (%sp)
-; NO-ATOMIC-010-NEXT:    move.l #0, (4,%sp)
+; NO-ATOMIC-010-NEXT:    clr.l (4,%sp)
 ; NO-ATOMIC-010-NEXT:    move.l (60,%sp), %d4
 ; NO-ATOMIC-010-NEXT:    move.l (56,%sp), %d5
 ; NO-ATOMIC-010-NEXT:    jsr __atomic_load_8
@@ -961,7 +961,7 @@ define i64 @atomicrmw_max_i64(i64 %val, ptr %ptr) {
 ; NO-ATOMIC-PIC-000-NEXT:    movem.l %d2-%d5/%a2, (32,%sp) ; 24-byte Folded Spill
 ; NO-ATOMIC-PIC-000-NEXT:    move.l (64,%sp), %d3
 ; NO-ATOMIC-PIC-000-NEXT:    move.l %d3, (%sp)
-; NO-ATOMIC-PIC-000-NEXT:    move.l #0, (4,%sp)
+; NO-ATOMIC-PIC-000-NEXT:    clr.l (4,%sp)
 ; NO-ATOMIC-PIC-000-NEXT:    move.l (60,%sp), %d4
 ; NO-ATOMIC-PIC-000-NEXT:    move.l (56,%sp), %d5
 ; NO-ATOMIC-PIC-000-NEXT:    jsr (__atomic_load_8@PLT,%pc)
@@ -1012,7 +1012,7 @@ define i64 @atomicrmw_max_i64(i64 %val, ptr %ptr) {
 ; NO-ATOMIC-PIC-010-NEXT:    movem.l %d2-%d5/%a2, (32,%sp) ; 24-byte Folded Spill
 ; NO-ATOMIC-PIC-010-NEXT:    move.l (64,%sp), %d3
 ; NO-ATOMIC-PIC-010-NEXT:    move.l %d3, (%sp)
-; NO-ATOMIC-PIC-010-NEXT:    move.l #0, (4,%sp)
+; NO-ATOMIC-PIC-010-NEXT:    clr.l (4,%sp)
 ; NO-ATOMIC-PIC-010-NEXT:    move.l (60,%sp), %d4
 ; NO-ATOMIC-PIC-010-NEXT:    move.l (56,%sp), %d5
 ; NO-ATOMIC-PIC-010-NEXT:    jsr (__atomic_load_8@PLT,%pc)
@@ -1063,7 +1063,7 @@ define i64 @atomicrmw_max_i64(i64 %val, ptr %ptr) {
 ; ATOMIC-NEXT:    movem.l %d2-%d5/%a2, (32,%sp) ; 24-byte Folded Spill
 ; ATOMIC-NEXT:    move.l (64,%sp), %d3
 ; ATOMIC-NEXT:    move.l %d3, (%sp)
-; ATOMIC-NEXT:    move.l #0, (4,%sp)
+; ATOMIC-NEXT:    clr.l (4,%sp)
 ; ATOMIC-NEXT:    move.l (60,%sp), %d4
 ; ATOMIC-NEXT:    move.l (56,%sp), %d5
 ; ATOMIC-NEXT:    jsr __atomic_load_8
@@ -1114,7 +1114,7 @@ define i64 @atomicrmw_max_i64(i64 %val, ptr %ptr) {
 ; ATOMIC-PIC-NEXT:    movem.l %d2-%d5/%a2, (32,%sp) ; 24-byte Folded Spill
 ; ATOMIC-PIC-NEXT:    move.l (64,%sp), %d3
 ; ATOMIC-PIC-NEXT:    move.l %d3, (%sp)
-; ATOMIC-PIC-NEXT:    move.l #0, (4,%sp)
+; ATOMIC-PIC-NEXT:    clr.l (4,%sp)
 ; ATOMIC-PIC-NEXT:    move.l (60,%sp), %d4
 ; ATOMIC-PIC-NEXT:    move.l (56,%sp), %d5
 ; ATOMIC-PIC-NEXT:    jsr (__atomic_load_8@PLT,%pc)
@@ -1166,8 +1166,8 @@ define i8 @atomicrmw_i8_umin(i8 %val, ptr %ptr) {
 ; NO-ATOMIC-000-NEXT:  ; %bb.0:
 ; NO-ATOMIC-000-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-000-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-000-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-000-NEXT:    move.b (19,%sp), %d0
-; NO-ATOMIC-000-NEXT:    and.l #255, %d0
 ; NO-ATOMIC-000-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-000-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-000-NEXT:    move.l %d0, (%sp)
@@ -1180,8 +1180,8 @@ define i8 @atomicrmw_i8_umin(i8 %val, ptr %ptr) {
 ; NO-ATOMIC-010-NEXT:  ; %bb.0:
 ; NO-ATOMIC-010-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-010-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-010-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-010-NEXT:    move.b (19,%sp), %d0
-; NO-ATOMIC-010-NEXT:    and.l #255, %d0
 ; NO-ATOMIC-010-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-010-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-010-NEXT:    move.l %d0, (%sp)
@@ -1194,8 +1194,8 @@ define i8 @atomicrmw_i8_umin(i8 %val, ptr %ptr) {
 ; NO-ATOMIC-PIC-000-NEXT:  ; %bb.0:
 ; NO-ATOMIC-PIC-000-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-PIC-000-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-PIC-000-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-PIC-000-NEXT:    move.b (19,%sp), %d0
-; NO-ATOMIC-PIC-000-NEXT:    and.l #255, %d0
 ; NO-ATOMIC-PIC-000-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-PIC-000-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-PIC-000-NEXT:    move.l %d0, (%sp)
@@ -1208,8 +1208,8 @@ define i8 @atomicrmw_i8_umin(i8 %val, ptr %ptr) {
 ; NO-ATOMIC-PIC-010-NEXT:  ; %bb.0:
 ; NO-ATOMIC-PIC-010-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-PIC-010-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-PIC-010-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-PIC-010-NEXT:    move.b (19,%sp), %d0
-; NO-ATOMIC-PIC-010-NEXT:    and.l #255, %d0
 ; NO-ATOMIC-PIC-010-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-PIC-010-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-PIC-010-NEXT:    move.l %d0, (%sp)
@@ -1306,8 +1306,8 @@ define i16 @atomicrmw_umax_i16(i16 %val, ptr %ptr) {
 ; NO-ATOMIC-000-NEXT:  ; %bb.0:
 ; NO-ATOMIC-000-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-000-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-000-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-000-NEXT:    move.w (18,%sp), %d0
-; NO-ATOMIC-000-NEXT:    and.l #65535, %d0
 ; NO-ATOMIC-000-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-000-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-000-NEXT:    move.l %d0, (%sp)
@@ -1320,8 +1320,8 @@ define i16 @atomicrmw_umax_i16(i16 %val, ptr %ptr) {
 ; NO-ATOMIC-010-NEXT:  ; %bb.0:
 ; NO-ATOMIC-010-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-010-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-010-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-010-NEXT:    move.w (18,%sp), %d0
-; NO-ATOMIC-010-NEXT:    and.l #65535, %d0
 ; NO-ATOMIC-010-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-010-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-010-NEXT:    move.l %d0, (%sp)
@@ -1334,8 +1334,8 @@ define i16 @atomicrmw_umax_i16(i16 %val, ptr %ptr) {
 ; NO-ATOMIC-PIC-000-NEXT:  ; %bb.0:
 ; NO-ATOMIC-PIC-000-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-PIC-000-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-PIC-000-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-PIC-000-NEXT:    move.w (18,%sp), %d0
-; NO-ATOMIC-PIC-000-NEXT:    and.l #65535, %d0
 ; NO-ATOMIC-PIC-000-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-PIC-000-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-PIC-000-NEXT:    move.l %d0, (%sp)
@@ -1348,8 +1348,8 @@ define i16 @atomicrmw_umax_i16(i16 %val, ptr %ptr) {
 ; NO-ATOMIC-PIC-010-NEXT:  ; %bb.0:
 ; NO-ATOMIC-PIC-010-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-PIC-010-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-PIC-010-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-PIC-010-NEXT:    move.w (18,%sp), %d0
-; NO-ATOMIC-PIC-010-NEXT:    and.l #65535, %d0
 ; NO-ATOMIC-PIC-010-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-PIC-010-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-PIC-010-NEXT:    move.l %d0, (%sp)
@@ -1446,8 +1446,8 @@ define i16 @atomicrmw_xchg_i16(i16 %val, ptr %ptr) {
 ; NO-ATOMIC-000-NEXT:  ; %bb.0: ; %entry
 ; NO-ATOMIC-000-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-000-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-000-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-000-NEXT:    move.w (18,%sp), %d0
-; NO-ATOMIC-000-NEXT:    and.l #65535, %d0
 ; NO-ATOMIC-000-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-000-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-000-NEXT:    move.l %d0, (%sp)
@@ -1460,8 +1460,8 @@ define i16 @atomicrmw_xchg_i16(i16 %val, ptr %ptr) {
 ; NO-ATOMIC-010-NEXT:  ; %bb.0: ; %entry
 ; NO-ATOMIC-010-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-010-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-010-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-010-NEXT:    move.w (18,%sp), %d0
-; NO-ATOMIC-010-NEXT:    and.l #65535, %d0
 ; NO-ATOMIC-010-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-010-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-010-NEXT:    move.l %d0, (%sp)
@@ -1474,8 +1474,8 @@ define i16 @atomicrmw_xchg_i16(i16 %val, ptr %ptr) {
 ; NO-ATOMIC-PIC-000-NEXT:  ; %bb.0: ; %entry
 ; NO-ATOMIC-PIC-000-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-PIC-000-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-PIC-000-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-PIC-000-NEXT:    move.w (18,%sp), %d0
-; NO-ATOMIC-PIC-000-NEXT:    and.l #65535, %d0
 ; NO-ATOMIC-PIC-000-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-PIC-000-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-PIC-000-NEXT:    move.l %d0, (%sp)
@@ -1488,8 +1488,8 @@ define i16 @atomicrmw_xchg_i16(i16 %val, ptr %ptr) {
 ; NO-ATOMIC-PIC-010-NEXT:  ; %bb.0: ; %entry
 ; NO-ATOMIC-PIC-010-NEXT:    suba.l #12, %sp
 ; NO-ATOMIC-PIC-010-NEXT:    .cfi_def_cfa_offset -16
+; NO-ATOMIC-PIC-010-NEXT:    moveq #0, %d0
 ; NO-ATOMIC-PIC-010-NEXT:    move.w (18,%sp), %d0
-; NO-ATOMIC-PIC-010-NEXT:    and.l #65535, %d0
 ; NO-ATOMIC-PIC-010-NEXT:    move.l %d0, (4,%sp)
 ; NO-ATOMIC-PIC-010-NEXT:    move.l (20,%sp), %d0
 ; NO-ATOMIC-PIC-010-NEXT:    move.l %d0, (%sp)

--- a/llvm/test/CodeGen/M68k/Control/cmp.ll
+++ b/llvm/test/CodeGen/M68k/Control/cmp.ll
@@ -59,7 +59,7 @@ define i8 @test2b(ptr %y) nounwind {
 ; CHECK-NEXT:    cmpi.b #0, %d0
 ; CHECK-NEXT:    beq .LBB2_2
 ; CHECK-NEXT:  ; %bb.1: ; %cond_false
-; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    clr.b %d0
 ; CHECK-NEXT:    rts
 ; CHECK-NEXT:  .LBB2_2: ; %cond_true
 ; CHECK-NEXT:    moveq #1, %d0
@@ -82,8 +82,8 @@ define i64 @test3(i64 %x) nounwind {
 ; CHECK-NEXT:    move.l (8,%sp), %d0
 ; CHECK-NEXT:    or.l (4,%sp), %d0
 ; CHECK-NEXT:    seq %d0
-; CHECK-NEXT:    move.l %d0, %d1
-; CHECK-NEXT:    and.l #255, %d1
+; CHECK-NEXT:    moveq #0, %d1
+; CHECK-NEXT:    move.b %d0, %d1
 ; CHECK-NEXT:    and.l #1, %d1
 ; CHECK-NEXT:    moveq #0, %d0
 ; CHECK-NEXT:    rts
@@ -243,8 +243,8 @@ define zeroext i1 @test15(i32 %bf.load, i32 %n) {
 ; CHECK-NEXT:    cmpi.l #0, %d1
 ; CHECK-NEXT:    seq %d1
 ; CHECK-NEXT:    or.b %d0, %d1
-; CHECK-NEXT:    move.l %d1, %d0
-; CHECK-NEXT:    and.l #255, %d0
+; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    move.b %d1, %d0
 ; CHECK-NEXT:    and.l #1, %d0
 ; CHECK-NEXT:    rts
   %bf.lshr = lshr i32 %bf.load, 16
@@ -300,8 +300,8 @@ define void @test20(i32 %bf.load, i8 %x1, ptr %b_addr) {
 ; CHECK-NEXT:    sne %d1
 ; CHECK-NEXT:    and.l #255, %d1
 ; CHECK-NEXT:    and.l #1, %d1
+; CHECK-NEXT:    moveq #0, %d2
 ; CHECK-NEXT:    move.b (15,%sp), %d2
-; CHECK-NEXT:    and.l #255, %d2
 ; CHECK-NEXT:    add.l %d1, %d2
 ; CHECK-NEXT:    sne %d1
 ; CHECK-NEXT:    and.b #1, %d1

--- a/llvm/test/CodeGen/M68k/Control/long-setcc.ll
+++ b/llvm/test/CodeGen/M68k/Control/long-setcc.ll
@@ -26,7 +26,7 @@ define i1 @t2(i64 %x) nounwind {
 define i1 @t3(i32 %x) nounwind {
 ; CHECK-LABEL: t3:
 ; CHECK:       ; %bb.0:
-; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    clr.b %d0
 ; CHECK-NEXT:    rts
   %tmp = icmp ugt i32 %x, -1
   ret i1 %tmp

--- a/llvm/test/CodeGen/M68k/Control/setcc.ll
+++ b/llvm/test/CodeGen/M68k/Control/setcc.ll
@@ -6,8 +6,8 @@
 define zeroext i16 @t1(i16 zeroext %x) nounwind readnone ssp {
 ; CHECK-LABEL: t1:
 ; CHECK:       ; %bb.0: ; %entry
+; CHECK-NEXT:    moveq #0, %d0
 ; CHECK-NEXT:    move.w (6,%sp), %d0
-; CHECK-NEXT:    and.l #65535, %d0
 ; CHECK-NEXT:    sub.l #26, %d0
 ; CHECK-NEXT:    shi %d0
 ; CHECK-NEXT:    and.l #255, %d0
@@ -23,8 +23,8 @@ entry:
 define zeroext i16 @t2(i16 zeroext %x) nounwind readnone ssp {
 ; CHECK-LABEL: t2:
 ; CHECK:       ; %bb.0: ; %entry
+; CHECK-NEXT:    moveq #0, %d0
 ; CHECK-NEXT:    move.w (6,%sp), %d0
-; CHECK-NEXT:    and.l #65535, %d0
 ; CHECK-NEXT:    sub.l #26, %d0
 ; CHECK-NEXT:    scs %d0
 ; CHECK-NEXT:    and.l #255, %d0
@@ -41,17 +41,17 @@ define fastcc i64 @t3(i64 %x) nounwind readnone ssp {
 ; CHECK-LABEL: t3:
 ; CHECK:       ; %bb.0: ; %entry
 ; CHECK-NEXT:    suba.l #4, %sp
-; CHECK-NEXT:    movem.l %d2, (0,%sp)                    ; 8-byte Folded Spill
+; CHECK-NEXT:    movem.l %d2, (0,%sp) ; 8-byte Folded Spill
 ; CHECK-NEXT:    moveq #0, %d2
 ; CHECK-NEXT:    sub.l #18, %d1
 ; CHECK-NEXT:    subx.l %d2, %d0
 ; CHECK-NEXT:    scs %d0
-; CHECK-NEXT:    move.l %d0, %d1
-; CHECK-NEXT:    and.l #255, %d1
+; CHECK-NEXT:    moveq #0, %d1
+; CHECK-NEXT:    move.b %d0, %d1
 ; CHECK-NEXT:    and.l #1, %d1
 ; CHECK-NEXT:    lsl.l #6, %d1
 ; CHECK-NEXT:    move.l %d2, %d0
-; CHECK-NEXT:    movem.l (0,%sp), %d2                    ; 8-byte Folded Reload
+; CHECK-NEXT:    movem.l (0,%sp), %d2 ; 8-byte Folded Reload
 ; CHECK-NEXT:    adda.l #4, %sp
 ; CHECK-NEXT:    rts
 entry:
@@ -93,8 +93,8 @@ define zeroext i1 @t6(i32 %a) {
 ; CHECK-NEXT:    move.l (4,%sp), %d1
 ; CHECK-NEXT:    lsr.l %d0, %d1
 ; CHECK-NEXT:    eori.b #1, %d1
-; CHECK-NEXT:    move.l %d1, %d0
-; CHECK-NEXT:    and.l #255, %d0
+; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    move.b %d1, %d0
 ; CHECK-NEXT:    rts
 entry:
   %.lobit = lshr i32 %a, 31

--- a/llvm/test/CodeGen/M68k/Data/load-extend.ll
+++ b/llvm/test/CodeGen/M68k/Data/load-extend.ll
@@ -7,8 +7,8 @@ define i32 @"test_zext_pcd_i8_to_i32"() {
 ; CHECK-LABEL: test_zext_pcd_i8_to_i32:
 ; CHECK:         .cfi_startproc
 ; CHECK-NEXT:  ; %bb.0:
+; CHECK-NEXT:    moveq #0, %d0
 ; CHECK-NEXT:    move.b (__unnamed_1+16,%pc), %d0
-; CHECK-NEXT:    and.l #255, %d0
 ; CHECK-NEXT:    rts
   %p = getelementptr inbounds i8, ptr @0, i32 16
   %val = load i8, ptr %p
@@ -20,8 +20,8 @@ define i16 @"test_zext_pcd_i8_to_i16"() {
 ; CHECK-LABEL: test_zext_pcd_i8_to_i16:
 ; CHECK:         .cfi_startproc
 ; CHECK-NEXT:  ; %bb.0:
+; CHECK-NEXT:    clr.w %d0
 ; CHECK-NEXT:    move.b (__unnamed_1+16,%pc), %d0
-; CHECK-NEXT:    and.w #255, %d0
 ; CHECK-NEXT:    rts
   %p = getelementptr inbounds i8, ptr @0, i32 16
   %val = load i8, ptr %p
@@ -33,8 +33,8 @@ define i32 @"test_zext_pcd_i16_to_i32"() {
 ; CHECK-LABEL: test_zext_pcd_i16_to_i32:
 ; CHECK:         .cfi_startproc
 ; CHECK-NEXT:  ; %bb.0:
+; CHECK-NEXT:    moveq #0, %d0
 ; CHECK-NEXT:    move.w (__unnamed_1+16,%pc), %d0
-; CHECK-NEXT:    and.l #65535, %d0
 ; CHECK-NEXT:    rts
   %p = getelementptr inbounds i16, ptr @0, i32 8
   %val = load i16, ptr %p
@@ -45,8 +45,8 @@ define i32 @"test_zext_pcd_i16_to_i32"() {
 define i16 @test_anyext_pcd_i8_to_i16() nounwind {
 ; CHECK-LABEL: test_anyext_pcd_i8_to_i16:
 ; CHECK:       ; %bb.0:
+; CHECK-NEXT:    moveq #0, %d0
 ; CHECK-NEXT:    move.b (__unnamed_1+4,%pc), %d0
-; CHECK-NEXT:    and.l #255, %d0
 ; CHECK-NEXT:    lsl.w #8, %d0
 ; CHECK-NEXT:    ; kill: def $wd0 killed $wd0 killed $d0
 ; CHECK-NEXT:    rts
@@ -60,8 +60,8 @@ define i32 @test_anyext_pcd_i8_to_i32() nounwind {
 ; CHECK-LABEL: test_anyext_pcd_i8_to_i32:
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    moveq #24, %d1
+; CHECK-NEXT:    moveq #0, %d0
 ; CHECK-NEXT:    move.b (__unnamed_1+4,%pc), %d0
-; CHECK-NEXT:    and.l #255, %d0
 ; CHECK-NEXT:    lsl.l %d1, %d0
 ; CHECK-NEXT:    rts
   %copyload = load i8, ptr getelementptr inbounds nuw (i8, ptr @0, i32 4)
@@ -73,10 +73,10 @@ define i32 @test_anyext_pcd_i8_to_i32() nounwind {
 define i32 @test_anyext_pcd_i16_to_i32() nounwind {
 ; CHECK-LABEL: test_anyext_pcd_i16_to_i32:
 ; CHECK:       ; %bb.0:
-; CHECK-NEXT:    moveq #16, %d1
+; CHECK-NEXT:    moveq #0, %d0
 ; CHECK-NEXT:    move.w (__unnamed_1+4,%pc), %d0
-; CHECK-NEXT:    and.l #65535, %d0
-; CHECK-NEXT:    lsl.l %d1, %d0
+; CHECK-NEXT:    swap %d0
+; CHECK-NEXT:    clr.w %d0
 ; CHECK-NEXT:    rts
   %copyload = load i16, ptr getelementptr inbounds nuw (i8, ptr @0, i32 4)
   %insert_ext = zext i16 %copyload to i32

--- a/llvm/test/CodeGen/M68k/Data/load-imm.ll
+++ b/llvm/test/CodeGen/M68k/Data/load-imm.ll
@@ -14,7 +14,7 @@ define i8 @return_0_i8() {
 ; CHECK-LABEL: return_0_i8:
 ; CHECK:         .cfi_startproc
 ; CHECK-NEXT:  ; %bb.0:
-; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    clr.b %d0
 ; CHECK-NEXT:    rts
   ret i8 0
 }
@@ -23,7 +23,7 @@ define i16 @return_0_i16() {
 ; CHECK-LABEL: return_0_i16:
 ; CHECK:         .cfi_startproc
 ; CHECK-NEXT:  ; %bb.0:
-; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    clr.w %d0
 ; CHECK-NEXT:    rts
   ret i16 0
 }

--- a/llvm/test/CodeGen/M68k/Data/sext-i1.ll
+++ b/llvm/test/CodeGen/M68k/Data/sext-i1.ll
@@ -21,8 +21,8 @@ define void @sext_inreg_i1_to_i16(i1 %val, ptr %ptr) {
 ; CHECK-LABEL: sext_inreg_i1_to_i16:
 ; CHECK:         .cfi_startproc
 ; CHECK-NEXT:  ; %bb.0: ; %entry
+; CHECK-NEXT:    moveq #0, %d0
 ; CHECK-NEXT:    move.b (7,%sp), %d0
-; CHECK-NEXT:    and.l #255, %d0
 ; CHECK-NEXT:    and.w #1, %d0
 ; CHECK-NEXT:    neg.w %d0
 ; CHECK-NEXT:    move.l (8,%sp), %a0
@@ -38,8 +38,8 @@ define void @sext_inreg_i1_to_i32(i1 %val, ptr %ptr) {
 ; CHECK-LABEL: sext_inreg_i1_to_i32:
 ; CHECK:         .cfi_startproc
 ; CHECK-NEXT:  ; %bb.0: ; %entry
+; CHECK-NEXT:    moveq #0, %d0
 ; CHECK-NEXT:    move.b (7,%sp), %d0
-; CHECK-NEXT:    and.l #255, %d0
 ; CHECK-NEXT:    and.l #1, %d0
 ; CHECK-NEXT:    neg.l %d0
 ; CHECK-NEXT:    move.l (8,%sp), %a0

--- a/llvm/test/CodeGen/M68k/PR57660.ll
+++ b/llvm/test/CodeGen/M68k/PR57660.ll
@@ -7,7 +7,7 @@ define dso_local void @foo1() {
 ; CHECK-NEXT:  ; %bb.0: ; %entry
 ; CHECK-NEXT:    suba.l #2, %sp
 ; CHECK-NEXT:    .cfi_def_cfa_offset -6
-; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    clr.b %d0
 ; CHECK-NEXT:    movem.w %d0, (0,%sp)
 ; CHECK-NEXT:  .LBB0_1: ; %do.body
 ; CHECK-NEXT:    ; =>This Inner Loop Header: Depth=1

--- a/llvm/test/CodeGen/M68k/Regression/146213.ll
+++ b/llvm/test/CodeGen/M68k/Regression/146213.ll
@@ -18,12 +18,12 @@ define float @float_arg_test(ptr %inout) nounwind {
 ; CHECK:       ; %bb.0: ; %start
 ; CHECK-NEXT:    suba.l #12, %sp
 ; CHECK-NEXT:    movem.l %a2, (8,%sp) ; 8-byte Folded Spill
-; CHECK-NEXT:    move.l #0, (%sp)
+; CHECK-NEXT:    clr.l (%sp)
 ; CHECK-NEXT:    jsr float_arg
 ; CHECK-NEXT:    move.l (16,%sp), %a2
 ; CHECK-NEXT:    move.l (%a2), %d0
 ; CHECK-NEXT:    move.l %d0, (%sp)
-; CHECK-NEXT:    move.l #0, (4,%sp)
+; CHECK-NEXT:    clr.l (4,%sp)
 ; CHECK-NEXT:    jsr __mulsf3
 ; CHECK-NEXT:    move.l %d0, (%a2)
 ; CHECK-NEXT:    moveq #0, %d0
@@ -44,13 +44,13 @@ define float @double_arg_test(ptr %inout) nounwind {
 ; CHECK:       ; %bb.0: ; %start
 ; CHECK-NEXT:    suba.l #12, %sp
 ; CHECK-NEXT:    movem.l %a2, (8,%sp) ; 8-byte Folded Spill
-; CHECK-NEXT:    move.l #0, (4,%sp)
-; CHECK-NEXT:    move.l #0, (%sp)
+; CHECK-NEXT:    clr.l (4,%sp)
+; CHECK-NEXT:    clr.l (%sp)
 ; CHECK-NEXT:    jsr double_arg
 ; CHECK-NEXT:    move.l (16,%sp), %a2
 ; CHECK-NEXT:    move.l (%a2), %d0
 ; CHECK-NEXT:    move.l %d0, (%sp)
-; CHECK-NEXT:    move.l #0, (4,%sp)
+; CHECK-NEXT:    clr.l (4,%sp)
 ; CHECK-NEXT:    jsr __mulsf3
 ; CHECK-NEXT:    move.l %d0, (%a2)
 ; CHECK-NEXT:    moveq #0, %d0

--- a/llvm/test/CodeGen/M68k/ShiftRotate/asr.ll
+++ b/llvm/test/CodeGen/M68k/ShiftRotate/asr.ll
@@ -9,8 +9,8 @@ define zeroext i8 @asrb(i8 zeroext %a, i8 zeroext %b) nounwind {
 ; CHECK-NEXT:    move.b (11,%sp), %d0
 ; CHECK-NEXT:    move.b (7,%sp), %d1
 ; CHECK-NEXT:    asr.b %d0, %d1
-; CHECK-NEXT:    move.l %d1, %d0
-; CHECK-NEXT:    and.l #255, %d0
+; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    move.b %d1, %d0
 ; CHECK-NEXT:    rts
   %1 = ashr i8 %a, %b
   ret i8 %1
@@ -22,8 +22,8 @@ define zeroext i16 @asrw(i16 zeroext %a, i16 zeroext %b) nounwind {
 ; CHECK-NEXT:    move.w (10,%sp), %d0
 ; CHECK-NEXT:    move.w (6,%sp), %d1
 ; CHECK-NEXT:    asr.w %d0, %d1
-; CHECK-NEXT:    move.l %d1, %d0
-; CHECK-NEXT:    and.l #65535, %d0
+; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    move.w %d1, %d0
 ; CHECK-NEXT:    rts
   %1 = ashr i16 %a, %b
   ret i16 %1
@@ -58,7 +58,9 @@ define zeroext i16 @asriw(i16 zeroext %a) nounwind {
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    move.w (6,%sp), %d0
 ; CHECK-NEXT:    asr.w #5, %d0
-; CHECK-NEXT:    and.l #65535, %d0
+; CHECK-NEXT:    swap %d0
+; CHECK-NEXT:    clr.w %d0
+; CHECK-NEXT:    swap %d0
 ; CHECK-NEXT:    rts
   %1 = ashr i16 %a, 5
   ret i16 %1

--- a/llvm/test/CodeGen/M68k/ShiftRotate/bswap.ll
+++ b/llvm/test/CodeGen/M68k/ShiftRotate/bswap.ll
@@ -9,7 +9,9 @@ define zeroext i16 @bswap16(i16 zeroext %a) nounwind {
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    move.w (6,%sp), %d0
 ; CHECK-NEXT:    rol.w #8, %d0
-; CHECK-NEXT:    and.l #65535, %d0
+; CHECK-NEXT:    swap %d0
+; CHECK-NEXT:    clr.w %d0
+; CHECK-NEXT:    swap %d0
 ; CHECK-NEXT:    rts
   %1 = tail call i16 @llvm.bswap.i16(i16 %a)
   ret i16 %1

--- a/llvm/test/CodeGen/M68k/ShiftRotate/lsl.ll
+++ b/llvm/test/CodeGen/M68k/ShiftRotate/lsl.ll
@@ -9,8 +9,8 @@ define zeroext i8 @lslb(i8 zeroext %a, i8 zeroext %b) nounwind {
 ; CHECK-NEXT:    move.b (11,%sp), %d0
 ; CHECK-NEXT:    move.b (7,%sp), %d1
 ; CHECK-NEXT:    lsl.b %d0, %d1
-; CHECK-NEXT:    move.l %d1, %d0
-; CHECK-NEXT:    and.l #255, %d0
+; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    move.b %d1, %d0
 ; CHECK-NEXT:    rts
   %1 = shl i8 %a, %b
   ret i8 %1
@@ -22,8 +22,8 @@ define zeroext i16 @lslw(i16 zeroext %a, i16 zeroext %b) nounwind {
 ; CHECK-NEXT:    move.w (10,%sp), %d0
 ; CHECK-NEXT:    move.w (6,%sp), %d1
 ; CHECK-NEXT:    lsl.w %d0, %d1
-; CHECK-NEXT:    move.l %d1, %d0
-; CHECK-NEXT:    and.l #65535, %d0
+; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    move.w %d1, %d0
 ; CHECK-NEXT:    rts
   %1 = shl i16 %a, %b
   ret i16 %1
@@ -58,7 +58,9 @@ define zeroext i16 @lsliw(i16 zeroext %a) nounwind {
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    move.w (6,%sp), %d0
 ; CHECK-NEXT:    lsl.w #5, %d0
-; CHECK-NEXT:    and.l #65535, %d0
+; CHECK-NEXT:    swap %d0
+; CHECK-NEXT:    clr.w %d0
+; CHECK-NEXT:    swap %d0
 ; CHECK-NEXT:    rts
   %1 = shl i16 %a, 5
   ret i16 %1

--- a/llvm/test/CodeGen/M68k/ShiftRotate/lsr.ll
+++ b/llvm/test/CodeGen/M68k/ShiftRotate/lsr.ll
@@ -9,8 +9,8 @@ define zeroext i8 @lsrb(i8 zeroext %a, i8 zeroext %b) nounwind {
 ; CHECK-NEXT:    move.b (11,%sp), %d0
 ; CHECK-NEXT:    move.b (7,%sp), %d1
 ; CHECK-NEXT:    lsr.b %d0, %d1
-; CHECK-NEXT:    move.l %d1, %d0
-; CHECK-NEXT:    and.l #255, %d0
+; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    move.b %d1, %d0
 ; CHECK-NEXT:    rts
   %1 = lshr i8 %a, %b
   ret i8 %1
@@ -22,8 +22,8 @@ define zeroext i16 @lsrw(i16 zeroext %a, i16 zeroext %b) nounwind {
 ; CHECK-NEXT:    move.w (10,%sp), %d0
 ; CHECK-NEXT:    move.w (6,%sp), %d1
 ; CHECK-NEXT:    lsr.w %d0, %d1
-; CHECK-NEXT:    move.l %d1, %d0
-; CHECK-NEXT:    and.l #65535, %d0
+; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    move.w %d1, %d0
 ; CHECK-NEXT:    rts
   %1 = lshr i16 %a, %b
   ret i16 %1
@@ -58,7 +58,9 @@ define zeroext i16 @lsriw(i16 zeroext %a) nounwind {
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    move.w (6,%sp), %d0
 ; CHECK-NEXT:    lsr.w #5, %d0
-; CHECK-NEXT:    and.l #65535, %d0
+; CHECK-NEXT:    swap %d0
+; CHECK-NEXT:    clr.w %d0
+; CHECK-NEXT:    swap %d0
 ; CHECK-NEXT:    rts
   %1 = lshr i16 %a, 5
   ret i16 %1

--- a/llvm/test/CodeGen/M68k/ShiftRotate/rol.ll
+++ b/llvm/test/CodeGen/M68k/ShiftRotate/rol.ll
@@ -13,8 +13,8 @@ define zeroext i8 @rolb(i8 zeroext %a, i8 zeroext %b) nounwind {
 ; CHECK-NEXT:    move.b (11,%sp), %d0
 ; CHECK-NEXT:    move.b (7,%sp), %d1
 ; CHECK-NEXT:    rol.b %d0, %d1
-; CHECK-NEXT:    move.l %d1, %d0
-; CHECK-NEXT:    and.l #255, %d0
+; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    move.b %d1, %d0
 ; CHECK-NEXT:    rts
   %1 = tail call i8 @llvm.fshl.i8(i8 %a, i8 %a, i8 %b)
   ret i8 %1
@@ -26,8 +26,8 @@ define zeroext i16 @rolw(i16 zeroext %a, i16 zeroext %b) nounwind {
 ; CHECK-NEXT:    move.w (10,%sp), %d0
 ; CHECK-NEXT:    move.w (6,%sp), %d1
 ; CHECK-NEXT:    rol.w %d0, %d1
-; CHECK-NEXT:    move.l %d1, %d0
-; CHECK-NEXT:    and.l #65535, %d0
+; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    move.w %d1, %d0
 ; CHECK-NEXT:    rts
   %1 = tail call i16 @llvm.fshl.i16(i16 %a, i16 %a, i16 %b)
   ret i16 %1
@@ -62,7 +62,9 @@ define zeroext i16 @roliw(i16 zeroext %a) nounwind {
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    move.w (6,%sp), %d0
 ; CHECK-NEXT:    rol.w #5, %d0
-; CHECK-NEXT:    and.l #65535, %d0
+; CHECK-NEXT:    swap %d0
+; CHECK-NEXT:    clr.w %d0
+; CHECK-NEXT:    swap %d0
 ; CHECK-NEXT:    rts
   %1 = tail call i16 @llvm.fshl.i16(i16 %a, i16 %a, i16 5)
   ret i16 %1

--- a/llvm/test/CodeGen/M68k/ShiftRotate/ror.ll
+++ b/llvm/test/CodeGen/M68k/ShiftRotate/ror.ll
@@ -13,8 +13,8 @@ define zeroext i8 @rorb(i8 zeroext %a, i8 zeroext %b) nounwind {
 ; CHECK-NEXT:    move.b (11,%sp), %d0
 ; CHECK-NEXT:    move.b (7,%sp), %d1
 ; CHECK-NEXT:    ror.b %d0, %d1
-; CHECK-NEXT:    move.l %d1, %d0
-; CHECK-NEXT:    and.l #255, %d0
+; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    move.b %d1, %d0
 ; CHECK-NEXT:    rts
   %1 = tail call i8 @llvm.fshr.i8(i8 %a, i8 %a, i8 %b)
   ret i8 %1
@@ -26,8 +26,8 @@ define zeroext i16 @rorw(i16 zeroext %a, i16 zeroext %b) nounwind {
 ; CHECK-NEXT:    move.w (10,%sp), %d0
 ; CHECK-NEXT:    move.w (6,%sp), %d1
 ; CHECK-NEXT:    ror.w %d0, %d1
-; CHECK-NEXT:    move.l %d1, %d0
-; CHECK-NEXT:    and.l #65535, %d0
+; CHECK-NEXT:    moveq #0, %d0
+; CHECK-NEXT:    move.w %d1, %d0
 ; CHECK-NEXT:    rts
   %1 = tail call i16 @llvm.fshr.i16(i16 %a, i16 %a, i16 %b)
   ret i16 %1
@@ -62,7 +62,9 @@ define zeroext i16 @roriw(i16 zeroext %a) nounwind {
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    move.w (6,%sp), %d0
 ; CHECK-NEXT:    ror.w #5, %d0
-; CHECK-NEXT:    and.l #65535, %d0
+; CHECK-NEXT:    swap %d0
+; CHECK-NEXT:    clr.w %d0
+; CHECK-NEXT:    swap %d0
 ; CHECK-NEXT:    rts
   %1 = tail call i16 @llvm.fshr.i16(i16 %a, i16 %a, i16 5)
   ret i16 %1

--- a/llvm/test/CodeGen/M68k/register-spills.ll
+++ b/llvm/test/CodeGen/M68k/register-spills.ll
@@ -194,11 +194,15 @@ define void @test_force_spill_16() {
 ; CHECK-NEXT:    jsr get16
 ; CHECK-NEXT:    movem.w (64,%sp), %a1
 ; CHECK-NEXT:    movem.w (66,%sp), %d1
-; CHECK-NEXT:    and.l #65535, %d0
+; CHECK-NEXT:    swap %d0
+; CHECK-NEXT:    clr.w %d0
+; CHECK-NEXT:    swap %d0
 ; CHECK-NEXT:    move.l %sp, %a0
 ; CHECK-NEXT:    move.l %d0, (60,%a0)
 ; CHECK-NEXT:    movem.w (68,%sp), %d0
-; CHECK-NEXT:    and.l #65535, %d0
+; CHECK-NEXT:    swap %d0
+; CHECK-NEXT:    clr.w %d0
+; CHECK-NEXT:    swap %d0
 ; CHECK-NEXT:    move.l %d0, (56,%a0)
 ; CHECK-NEXT:    movem.w (70,%sp), %d0
 ; CHECK-NEXT:    and.l #65535, %a6
@@ -211,23 +215,39 @@ define void @test_force_spill_16() {
 ; CHECK-NEXT:    move.l %a3, (40,%a0)
 ; CHECK-NEXT:    and.l #65535, %a2
 ; CHECK-NEXT:    move.l %a2, (36,%a0)
-; CHECK-NEXT:    and.l #65535, %d7
+; CHECK-NEXT:    swap %d7
+; CHECK-NEXT:    clr.w %d7
+; CHECK-NEXT:    swap %d7
 ; CHECK-NEXT:    move.l %d7, (32,%a0)
-; CHECK-NEXT:    and.l #65535, %d6
+; CHECK-NEXT:    swap %d6
+; CHECK-NEXT:    clr.w %d6
+; CHECK-NEXT:    swap %d6
 ; CHECK-NEXT:    move.l %d6, (28,%a0)
-; CHECK-NEXT:    and.l #65535, %d5
+; CHECK-NEXT:    swap %d5
+; CHECK-NEXT:    clr.w %d5
+; CHECK-NEXT:    swap %d5
 ; CHECK-NEXT:    move.l %d5, (24,%a0)
-; CHECK-NEXT:    and.l #65535, %d4
+; CHECK-NEXT:    swap %d4
+; CHECK-NEXT:    clr.w %d4
+; CHECK-NEXT:    swap %d4
 ; CHECK-NEXT:    move.l %d4, (20,%a0)
-; CHECK-NEXT:    and.l #65535, %d3
+; CHECK-NEXT:    swap %d3
+; CHECK-NEXT:    clr.w %d3
+; CHECK-NEXT:    swap %d3
 ; CHECK-NEXT:    move.l %d3, (16,%a0)
-; CHECK-NEXT:    and.l #65535, %d2
+; CHECK-NEXT:    swap %d2
+; CHECK-NEXT:    clr.w %d2
+; CHECK-NEXT:    swap %d2
 ; CHECK-NEXT:    move.l %d2, (12,%a0)
 ; CHECK-NEXT:    and.l #65535, %a1
 ; CHECK-NEXT:    move.l %a1, (8,%a0)
-; CHECK-NEXT:    and.l #65535, %d1
+; CHECK-NEXT:    swap %d1
+; CHECK-NEXT:    clr.w %d1
+; CHECK-NEXT:    swap %d1
 ; CHECK-NEXT:    move.l %d1, (4,%a0)
-; CHECK-NEXT:    and.l #65535, %d0
+; CHECK-NEXT:    swap %d0
+; CHECK-NEXT:    clr.w %d0
+; CHECK-NEXT:    swap %d0
 ; CHECK-NEXT:    move.l %d0, (%a0)
 ; CHECK-NEXT:    jsr test_force_spill_16_consumer
 ; CHECK-NEXT:    movem.l (72,%sp), %d2-%d7/%a2-%a6 ; 48-byte Folded Reload
@@ -390,19 +410,25 @@ define void @test_force_spill_mixed() {
 ; CHECK-NEXT:    jsr get16
 ; CHECK-NEXT:    movem.l (80,%sp), %a1
 ; CHECK-NEXT:    movem.w (86,%sp), %d1
-; CHECK-NEXT:    and.l #65535, %d0
+; CHECK-NEXT:    swap %d0
+; CHECK-NEXT:    clr.w %d0
+; CHECK-NEXT:    swap %d0
 ; CHECK-NEXT:    move.l %sp, %a0
 ; CHECK-NEXT:    move.l %d0, (76,%a0)
 ; CHECK-NEXT:    movem.l (88,%sp), %d0
 ; CHECK-NEXT:    move.l %d0, (72,%a0)
 ; CHECK-NEXT:    movem.w (94,%sp), %d0
-; CHECK-NEXT:    and.l #65535, %d0
+; CHECK-NEXT:    swap %d0
+; CHECK-NEXT:    clr.w %d0
+; CHECK-NEXT:    swap %d0
 ; CHECK-NEXT:    move.l %d0, (68,%a0)
 ; CHECK-NEXT:    movem.w (96,%sp), %d0
 ; CHECK-NEXT:    and.l #255, %d0
 ; CHECK-NEXT:    move.l %d0, (64,%a0)
 ; CHECK-NEXT:    movem.w (98,%sp), %d0
-; CHECK-NEXT:    and.l #65535, %d0
+; CHECK-NEXT:    swap %d0
+; CHECK-NEXT:    clr.w %d0
+; CHECK-NEXT:    swap %d0
 ; CHECK-NEXT:    move.l %d0, (60,%a0)
 ; CHECK-NEXT:    movem.w (100,%sp), %d0
 ; CHECK-NEXT:    move.l %a6, (56,%a0)
@@ -418,17 +444,25 @@ define void @test_force_spill_mixed() {
 ; CHECK-NEXT:    move.l %a2, (36,%a0)
 ; CHECK-NEXT:    and.l #255, %d7
 ; CHECK-NEXT:    move.l %d7, (32,%a0)
-; CHECK-NEXT:    and.l #65535, %d6
+; CHECK-NEXT:    swap %d6
+; CHECK-NEXT:    clr.w %d6
+; CHECK-NEXT:    swap %d6
 ; CHECK-NEXT:    move.l %d6, (28,%a0)
 ; CHECK-NEXT:    move.l %d5, (24,%a0)
-; CHECK-NEXT:    and.l #65535, %d4
+; CHECK-NEXT:    swap %d4
+; CHECK-NEXT:    clr.w %d4
+; CHECK-NEXT:    swap %d4
 ; CHECK-NEXT:    move.l %d4, (20,%a0)
 ; CHECK-NEXT:    and.l #255, %d3
 ; CHECK-NEXT:    move.l %d3, (16,%a0)
-; CHECK-NEXT:    and.l #65535, %d2
+; CHECK-NEXT:    swap %d2
+; CHECK-NEXT:    clr.w %d2
+; CHECK-NEXT:    swap %d2
 ; CHECK-NEXT:    move.l %d2, (12,%a0)
 ; CHECK-NEXT:    move.l %a1, (8,%a0)
-; CHECK-NEXT:    and.l #65535, %d1
+; CHECK-NEXT:    swap %d1
+; CHECK-NEXT:    clr.w %d1
+; CHECK-NEXT:    swap %d1
 ; CHECK-NEXT:    move.l %d1, (4,%a0)
 ; CHECK-NEXT:    and.l #255, %d0
 ; CHECK-NEXT:    move.l %d0, (%a0)


### PR DESCRIPTION
This adds instruction encoding for `CLR` and incorporates common uses of the instruction into existing pseudo expansion functions.

- Storing 0 to memory will favor `clr` over storing an immediate.
- `buildClearRegister()` override is implemented, using `clr` to clear byte/word, and `moveq` to clear long.
- `MOVI` pseudo will use `buildClearRegister()` if the immediate is zero.
- `MOVZX` pseudo will, if possible, clear the destination first and then move the source, rather than the other way around (which inefficiently requires an `AND` mask).
- On 68000, an in-place i16/i32 zext is done via `swap -> clr.w -> swap` which is more efficient than `and.l #$ffff`.
- Left-shifting an i32 by 16 bits lowers to `swap -> clr.w`.

There are so many tests in the diff because `MOVZX` and moving a zero immediate are really common operations, so it's just a lot of single instructions getting replaced by their more efficient counterparts.