### PR TITLE
[Flang][Driver] Add support for option -f[no-]split-machine-functions in flang

### DIFF
--- a/clang/include/clang/Driver/CommonArgs.h
+++ b/clang/include/clang/Driver/CommonArgs.h
@@ -257,6 +257,11 @@ void addMachineOutlinerArgs(const Driver &D, const llvm::opt::ArgList &Args,
                             const llvm::Triple &Triple, bool IsLTO,
                             const StringRef PluginOptPrefix = "");
 
+void addSplitMachineFunctionsArgs(const Driver &D,
+                                  const llvm::opt::ArgList &Args,
+                                  llvm::opt::ArgStringList &CmdArgs,
+                                  const llvm::Triple &Triple);
+
 void addOpenMPDeviceRTL(const Driver &D, const llvm::opt::ArgList &DriverArgs,
                         llvm::opt::ArgStringList &CC1Args,
                         StringRef BitcodeSuffix, const llvm::Triple &Triple,

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -5068,8 +5068,8 @@ defm separate_named_sections : BoolFOption<"separate-named-sections",
 
 defm split_machine_functions: BoolFOption<"split-machine-functions",
   CodeGenOpts<"SplitMachineFunctions">, DefaultFalse,
-  PosFlag<SetTrue, [], [ClangOption, CC1Option], "Enable">,
-  NegFlag<SetFalse, [], [ClangOption], "Disable">,
+  PosFlag<SetTrue, [], [ClangOption, CC1Option, FlangOption, FC1Option], "Enable">,
+  NegFlag<SetFalse, [], [ClangOption, FlangOption], "Disable">,
   BothFlags<[], [ClangOption], " late function splitting using profile information (x86 and aarch64 ELF)">>;
 
 defm partition_static_data_sections: BoolFOption<"partition-static-data-sections",

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6618,17 +6618,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   Args.addOptInFlag(CmdArgs, options::OPT_funique_basic_block_section_names,
                     options::OPT_fno_unique_basic_block_section_names);
 
-  if (Arg *A = Args.getLastArg(options::OPT_fsplit_machine_functions,
-                               options::OPT_fno_split_machine_functions)) {
-    if (!A->getOption().matches(options::OPT_fno_split_machine_functions)) {
-      // This codegen pass is only available on x86 and AArch64 ELF targets.
-      if ((Triple.isX86() || Triple.isAArch64()) && Triple.isOSBinFormatELF())
-        A->render(Args, CmdArgs);
-      else
-        D.Diag(diag::err_drv_unsupported_opt_for_target)
-            << A->getAsString(Args) << TripleStr;
-    }
-  }
+  addSplitMachineFunctionsArgs(D, Args, CmdArgs, Triple);
 
   if (Arg *A =
           Args.getLastArg(options::OPT_fpartition_static_data_sections,

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -3086,6 +3086,23 @@ void tools::addMachineOutlinerArgs(const Driver &D,
     addArg(Twine("-codegen-data-use-path=") + CodeGenDataUseArg->getValue());
 }
 
+void tools::addSplitMachineFunctionsArgs(const Driver &D,
+                                         const llvm::opt::ArgList &Args,
+                                         llvm::opt::ArgStringList &CmdArgs,
+                                         const llvm::Triple &Triple) {
+  if (Arg *A = Args.getLastArg(options::OPT_fsplit_machine_functions,
+                               options::OPT_fno_split_machine_functions)) {
+    if (!A->getOption().matches(options::OPT_fno_split_machine_functions)) {
+      // This codegen pass is only available on x86 and AArch64 ELF targets.
+      if ((Triple.isX86() || Triple.isAArch64()) && Triple.isOSBinFormatELF())
+        A->render(Args, CmdArgs);
+      else
+        D.Diag(diag::err_drv_unsupported_opt_for_target)
+            << A->getAsString(Args) << Triple.getTriple();
+    }
+  }
+}
+
 void tools::addOpenMPDeviceRTL(const Driver &D,
                                const llvm::opt::ArgList &DriverArgs,
                                llvm::opt::ArgStringList &CC1Args,

--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -1233,6 +1233,8 @@ static void addPGOAndCoverageFlags(const ToolChain &TC, const JobAction &JA,
   if (Args.hasFlag(options::OPT_fpseudo_probe_for_profiling,
                    options::OPT_fno_pseudo_probe_for_profiling, false))
     CmdArgs.push_back("-fpseudo-probe-for-profiling");
+
+  addSplitMachineFunctionsArgs(TC.getDriver(), Args, CmdArgs, TC.getTriple());
 }
 
 void Flang::ConstructJob(Compilation &C, const JobAction &JA,

--- a/flang/include/flang/Frontend/TargetOptions.h
+++ b/flang/include/flang/Frontend/TargetOptions.h
@@ -54,6 +54,9 @@ public:
   /// Print verbose assembly
   bool asmVerbose = false;
 
+  /// Enable splitting of machine functions using profile information.
+  bool SplitMachineFunctions = false;
+
   /// Atomic control options
   bool atomicIgnoreDenormalMode = false;
   bool atomicRemoteMemory = false;

--- a/flang/lib/Frontend/CompilerInstance.cpp
+++ b/flang/lib/Frontend/CompilerInstance.cpp
@@ -381,6 +381,7 @@ bool CompilerInstance::setUpTargetMachine() {
 
   llvm::TargetOptions tOpts = llvm::TargetOptions();
   tOpts.EnableAIXExtendedAltivecABI = targetOpts.EnableAIXExtendedAltivecABI;
+  tOpts.EnableMachineFunctionSplitter = targetOpts.SplitMachineFunctions;
   tOpts.VecLib = convertDriverVectorLibraryToVectorLibrary(CGOpts.getVecLib());
   tOpts.DisableIntegratedAS = CGOpts.DisableIntegratedAS;
   tOpts.FunctionSections = CGOpts.FunctionSections;

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -610,6 +610,9 @@ static void parseTargetArgs(TargetOptions &opts, llvm::opt::ArgList &args) {
     }
   }
 
+  opts.SplitMachineFunctions =
+      args.hasArg(clang::options::OPT_fsplit_machine_functions);
+
   opts.asmVerbose = args.hasFlag(clang::options::OPT_fverbose_asm,
                                  clang::options::OPT_fno_verbose_asm, false);
 }

--- a/flang/test/Driver/fsplit-machine-functions.f90
+++ b/flang/test/Driver/fsplit-machine-functions.f90
@@ -1,11 +1,11 @@
 ! Test handling of -fsplit-machine-functions and -fno-split-machine-functions.
 
-! RUN: %flang_fc1 -emit-llvm -triple x86_64-unknown-linux-gnu %s -o - | FileCheck %s --check-prefix=NEG_FLAG
-! RUN: %flang -### --target=x86_64-unknown-linux-gnu -fsplit-machine-functions %s 2>&1 | FileCheck %s --check-prefix=POS_FLAG
-! RUN: %flang -### --target=x86_64-unknown-linux-gnu -fno-split-machine-functions %s 2>&1 | FileCheck %s --check-prefix=NEG_FLAG
-! RUN: %flang -### --target=x86_64-unknown-linux-gnu -fsplit-machine-functions -fno-split-machine-functions %s 2>&1 | FileCheck %s --check-prefix=NEG_FLAG
-! RUN: %flang -### --target=x86_64-unknown-linux-gnu -fno-split-machine-functions -fsplit-machine-functions %s 2>&1 | FileCheck %s --check-prefix=POS_FLAG
-! RUN: not %flang -### --target=arm-unknown-linux-gnueabi -fsplit-machine-functions %s 2>&1 | FileCheck %s --check-prefix=CHECK_ERROR
+! RUN: %if x86-registered-target %{ %flang_fc1 -emit-llvm -triple x86_64-unknown-linux-gnu %s -o - | FileCheck %s --check-prefix=NEG_FLAG %}
+! RUN: %if x86-registered-target %{ %flang -### --target=x86_64-unknown-linux-gnu -fsplit-machine-functions %s 2>&1 | FileCheck %s --check-prefix=POS_FLAG %}
+! RUN: %if x86-registered-target %{ %flang -### --target=x86_64-unknown-linux-gnu -fno-split-machine-functions %s 2>&1 | FileCheck %s --check-prefix=NEG_FLAG %}
+! RUN: %if x86-registered-target %{ %flang -### --target=x86_64-unknown-linux-gnu -fsplit-machine-functions -fno-split-machine-functions %s 2>&1 | FileCheck %s --check-prefix=NEG_FLAG %}
+! RUN: %if x86-registered-target %{ %flang -### --target=x86_64-unknown-linux-gnu -fno-split-machine-functions -fsplit-machine-functions %s 2>&1 | FileCheck %s --check-prefix=POS_FLAG %}
+! RUN: %if arm-registered-target %{ not %flang -### --target=arm-unknown-linux-gnueabi -fsplit-machine-functions %s 2>&1 | FileCheck %s --check-prefix=CHECK_ERROR %}
 
 ! POS_FLAG: "-fsplit-machine-functions"
 ! NEG_FLAG-NOT: "-fsplit-machine-functions"

--- a/flang/test/Driver/fsplit-machine-functions.f90
+++ b/flang/test/Driver/fsplit-machine-functions.f90
@@ -1,0 +1,16 @@
+! Test handling of -fsplit-machine-functions and -fno-split-machine-functions.
+
+! RUN: %flang_fc1 -emit-llvm -triple x86_64-unknown-linux-gnu %s -o - | FileCheck %s --check-prefix=NEG_FLAG
+! RUN: %flang -### --target=x86_64-unknown-linux-gnu -fsplit-machine-functions %s 2>&1 | FileCheck %s --check-prefix=POS_FLAG
+! RUN: %flang -### --target=x86_64-unknown-linux-gnu -fno-split-machine-functions %s 2>&1 | FileCheck %s --check-prefix=NEG_FLAG
+! RUN: %flang -### --target=x86_64-unknown-linux-gnu -fsplit-machine-functions -fno-split-machine-functions %s 2>&1 | FileCheck %s --check-prefix=NEG_FLAG
+! RUN: %flang -### --target=x86_64-unknown-linux-gnu -fno-split-machine-functions -fsplit-machine-functions %s 2>&1 | FileCheck %s --check-prefix=POS_FLAG
+! RUN: not %flang -### --target=arm-unknown-linux-gnueabi -fsplit-machine-functions %s 2>&1 | FileCheck %s --check-prefix=CHECK_ERROR
+
+! POS_FLAG: "-fsplit-machine-functions"
+! NEG_FLAG-NOT: "-fsplit-machine-functions"
+! CHECK_ERROR: error: unsupported option '-fsplit-machine-functions' for target
+
+subroutine test(x)
+    integer, intent(in) :: x
+end subroutine test

--- a/flang/test/Driver/fsplit-machine-functions.f90
+++ b/flang/test/Driver/fsplit-machine-functions.f90
@@ -1,16 +1,14 @@
 ! Test handling of -fsplit-machine-functions and -fno-split-machine-functions.
 
-! RUN: %if x86-registered-target %{ %flang_fc1 -emit-llvm -triple x86_64-unknown-linux-gnu %s -o - | FileCheck %s --check-prefix=NEG_FLAG %}
-! RUN: %if x86-registered-target %{ %flang -### --target=x86_64-unknown-linux-gnu -fsplit-machine-functions %s 2>&1 | FileCheck %s --check-prefix=POS_FLAG %}
-! RUN: %if x86-registered-target %{ %flang -### --target=x86_64-unknown-linux-gnu -fno-split-machine-functions %s 2>&1 | FileCheck %s --check-prefix=NEG_FLAG %}
-! RUN: %if x86-registered-target %{ %flang -### --target=x86_64-unknown-linux-gnu -fsplit-machine-functions -fno-split-machine-functions %s 2>&1 | FileCheck %s --check-prefix=NEG_FLAG %}
-! RUN: %if x86-registered-target %{ %flang -### --target=x86_64-unknown-linux-gnu -fno-split-machine-functions -fsplit-machine-functions %s 2>&1 | FileCheck %s --check-prefix=POS_FLAG %}
-! RUN: %if arm-registered-target %{ not %flang -### --target=arm-unknown-linux-gnueabi -fsplit-machine-functions %s 2>&1 | FileCheck %s --check-prefix=CHECK_ERROR %}
+! RUN: %if x86-registered-target %{ %flang -### --target=x86_64-unknown-linux-gnu %s 2>&1 | FileCheck %s --check-prefix=NO-SPLIT-MACHINE-FUNCTIONS  %}
+! RUN: %if x86-registered-target %{ %flang -### --target=x86_64-unknown-linux-gnu -fsplit-machine-functions %s 2>&1 | FileCheck %s --check-prefix=SPLIT-MACHINE-FUNCTIONS  %}
+! RUN: %if x86-registered-target %{ %flang -### --target=x86_64-unknown-linux-gnu -fno-split-machine-functions %s 2>&1 | FileCheck %s --check-prefix=NO-SPLIT-MACHINE-FUNCTIONS  %}
+! RUN: %if x86-registered-target %{ %flang -### --target=x86_64-unknown-linux-gnu -fsplit-machine-functions -fno-split-machine-functions %s 2>&1 | FileCheck %s --check-prefix=NO-SPLIT-MACHINE-FUNCTIONS  %}
+! RUN: %if x86-registered-target %{ %flang -### --target=x86_64-unknown-linux-gnu -fno-split-machine-functions -fsplit-machine-functions %s 2>&1 | FileCheck %s --check-prefix=SPLIT-MACHINE-FUNCTIONS  %}
+! RUN: %if arm-registered-target %{ not %flang -### --target=arm-unknown-linux -fsplit-machine-functions %s 2>&1 | FileCheck %s --check-prefix=UNSUPPORTED-OPT %}
+! RUN: %if arm-registered-target %{ %flang -### --target=arm-unknown-linux -fno-split-machine-functions %s 2>&1 | FileCheck %s --check-prefix=NO-SPLIT-MACHINE-FUNCTIONS %}
 
-! POS_FLAG: "-fsplit-machine-functions"
-! NEG_FLAG-NOT: "-fsplit-machine-functions"
-! CHECK_ERROR: error: unsupported option '-fsplit-machine-functions' for target
+! SPLIT-MACHINE-FUNCTIONS: "-fsplit-machine-functions"
+! NO-SPLIT-MACHINE-FUNCTIONS-NOT: "-fsplit-machine-functions"
+! UNSUPPORTED-OPT: error: unsupported option '-fsplit-machine-functions' for target
 
-subroutine test(x)
-    integer, intent(in) :: x
-end subroutine test

--- a/flang/test/Driver/split-machine-function-pass.f90
+++ b/flang/test/Driver/split-machine-function-pass.f90
@@ -2,19 +2,11 @@
 
 ! REQUIRES: x86-registered-target
 
-! RUN: %flang_fc1 -S -fsplit-machine-functions %s \
-! RUN:   -triple x86_64-unknown-linux-gnu \
-! RUN:   -mllvm -debug-pass=Structure -o %t 2>&1 \
-! RUN:   | FileCheck %s --check-prefix=ENABLED
+! RUN: %flang_fc1 -S -fsplit-machine-functions %s -triple x86_64-unknown-linux-gnu -mllvm -debug-pass=Structure -o /dev/null 2>&1 | FileCheck %s --check-prefix=SPLIT
+! RUN: %flang_fc1 -S %s -triple x86_64-unknown-linux-gnu -mllvm -debug-pass=Structure -o /dev/null 2>&1 | FileCheck %s --check-prefix=NO-SPLIT
 
-! RUN: %flang_fc1 -S %s \
-! RUN:   -triple x86_64-unknown-linux-gnu \
-! RUN:   -mllvm -debug-pass=Structure -o %t 2>&1 \
-! RUN:   | FileCheck %s --check-prefix=DISABLED
+! SPLIT: Machine Function Splitter Transformation
+! NO-SPLIT-NOT: Machine Function Splitter Transformation
 
-! ENABLED: Machine Function Splitter Transformation
-! DISABLED-NOT: Machine Function Splitter Transformation
-
-subroutine test(x)
-    integer, intent(in) :: x
-  end subroutine test
+subroutine test
+end subroutine test

--- a/flang/test/Driver/split-machine-function-pass.f90
+++ b/flang/test/Driver/split-machine-function-pass.f90
@@ -1,0 +1,20 @@
+! Verify that the MachineFunctionSplitter pass is enabled while passing -fsplit-machine-functions.
+
+! REQUIRES: x86-registered-target
+
+! RUN: %flang_fc1 -S -fsplit-machine-functions %s \
+! RUN:   -triple x86_64-unknown-linux-gnu \
+! RUN:   -mllvm -debug-pass=Structure -o %t 2>&1 \
+! RUN:   | FileCheck %s --check-prefix=ENABLED
+
+! RUN: %flang_fc1 -S %s \
+! RUN:   -triple x86_64-unknown-linux-gnu \
+! RUN:   -mllvm -debug-pass=Structure -o %t 2>&1 \
+! RUN:   | FileCheck %s --check-prefix=DISABLED
+
+! ENABLED: Machine Function Splitter Transformation
+! DISABLED-NOT: Machine Function Splitter Transformation
+
+subroutine test(x)
+    integer, intent(in) :: x
+  end subroutine test


### PR DESCRIPTION
This patch adds support for the `-fsplit-machine-functions` flag in the Flang driver.

-  The Flang driver forwards `-fsplit-machine-functions` to `-fc1` and the negative flag `-fno-split-machine-functions` is used at the driver level only.
-  Flang fc1 driver sets `TargetOptions.EnableMachineFunctionSplitter`, which causes LLVM's MachineFunctionSplitterPass to be added to the codegen pipeline
