### PR TITLE
[mlir][x86] Fix - Instrincs selection for hf8 and bf8.

### DIFF
--- a/mlir/include/mlir/Dialect/X86/X86.td
+++ b/mlir/include/mlir/Dialect/X86/X86.td
@@ -1005,9 +1005,9 @@ def TileMulFOp : AMX_Op<"tile_mulf", [Pure,
       } else if (elementType.isBF16()) {
         intr += "bf16";
       } else if (elementType.isF8E4M3FN() || elementType.isF8E5M2()) {
-        intr += elementType.isF8E4M3FN() ? "b" : "h";
+        intr += elementType.isF8E4M3FN() ? "h" : "b";
         if (elementType != elementTypeRhs)
-          intr += elementTypeRhs.isF8E4M3FN() ? "b" : "h";
+          intr += elementTypeRhs.isF8E4M3FN() ? "h" : "b";
         intr += "f8";
       }
 

--- a/mlir/test/Dialect/X86/AMX/legalize-for-llvm.mlir
+++ b/mlir/test/Dialect/X86/AMX/legalize-for-llvm.mlir
@@ -64,7 +64,7 @@ func.func @mulfp16(%arg0: memref<?x?xf16>, %arg1: memref<?x?xf32>) {
 // CHECK: llvm.call_intrinsic "llvm.x86.tilezero.internal"
 // CHECK: llvm.call_intrinsic "llvm.x86.tileloadd64.internal"
 // CHECK: llvm.call_intrinsic "llvm.x86.tileloadd64.internal"
-// CHECK: llvm.call_intrinsic "llvm.x86.tdpbf8ps.internal"
+// CHECK: llvm.call_intrinsic "llvm.x86.tdphf8ps.internal"
 // CHECK: llvm.call_intrinsic "llvm.x86.tilestored64.internal"
 func.func @mulf8E4M3FN(%arg0: memref<?x?xf8E4M3FN>, %arg1: memref<?x?xf32>) {
   %0 = arith.constant 0 : index
@@ -80,7 +80,7 @@ func.func @mulf8E4M3FN(%arg0: memref<?x?xf8E4M3FN>, %arg1: memref<?x?xf32>) {
 // CHECK: llvm.call_intrinsic "llvm.x86.tilezero.internal"
 // CHECK: llvm.call_intrinsic "llvm.x86.tileloadd64.internal"
 // CHECK: llvm.call_intrinsic "llvm.x86.tileloadd64.internal"
-// CHECK: llvm.call_intrinsic "llvm.x86.tdpbhf8ps.internal"
+// CHECK: llvm.call_intrinsic "llvm.x86.tdphbf8ps.internal"
 // CHECK: llvm.call_intrinsic "llvm.x86.tilestored64.internal"
 func.func @mulf8E4M3FNxf8E5M2(%arg0: memref<?x?xf8E5M2>, %arg1: memref<?x?xf32>) {
   %0 = arith.constant 0 : index
@@ -96,7 +96,7 @@ func.func @mulf8E4M3FNxf8E5M2(%arg0: memref<?x?xf8E5M2>, %arg1: memref<?x?xf32>)
 // CHECK: llvm.call_intrinsic "llvm.x86.tilezero.internal"
 // CHECK: llvm.call_intrinsic "llvm.x86.tileloadd64.internal"
 // CHECK: llvm.call_intrinsic "llvm.x86.tileloadd64.internal"
-// CHECK: llvm.call_intrinsic "llvm.x86.tdphbf8ps.internal"
+// CHECK: llvm.call_intrinsic "llvm.x86.tdpbhf8ps.internal"
 // CHECK: llvm.call_intrinsic "llvm.x86.tilestored64.internal"
 func.func @mulf8E5M2xf8E4M3FN(%arg0: memref<?x?xf8E4M3FN>, %arg1: memref<?x?xf32>) {
   %0 = arith.constant 0 : index
@@ -112,7 +112,7 @@ func.func @mulf8E5M2xf8E4M3FN(%arg0: memref<?x?xf8E4M3FN>, %arg1: memref<?x?xf32
 // CHECK: llvm.call_intrinsic "llvm.x86.tilezero.internal"
 // CHECK: llvm.call_intrinsic "llvm.x86.tileloadd64.internal"
 // CHECK: llvm.call_intrinsic "llvm.x86.tileloadd64.internal"
-// CHECK: llvm.call_intrinsic "llvm.x86.tdphf8ps.internal"
+// CHECK: llvm.call_intrinsic "llvm.x86.tdpbf8ps.internal"
 // CHECK: llvm.call_intrinsic "llvm.x86.tilestored64.internal"
 func.func @mulf8E5M2(%arg0: memref<?x?xf8E5M2>, %arg1: memref<?x?xf32>) {
   %0 = arith.constant 0 : index

--- a/mlir/test/Target/LLVMIR/amx.mlir
+++ b/mlir/test/Target/LLVMIR/amx.mlir
@@ -86,10 +86,10 @@ func.func @amx_tile_mulf_f8(
   %tB = x86.amx.tile_load %matB[%idx, %idx] : memref<?x?xf8E5M2> into !x86.amx.tile<16x64xf8E5M2>
   %tA1 = x86.amx.tile_load %matA[%c0, %c0] : memref<?x?xf8E4M3FN> into !x86.amx.tile<16x64xf8E4M3FN>
   %tB1 = x86.amx.tile_load %matB[%c0, %c0] : memref<?x?xf8E5M2> into !x86.amx.tile<16x64xf8E5M2>
-  // CHECK: call x86_amx @llvm.x86.tdpbf8ps.internal
-  // CHECK: call x86_amx @llvm.x86.tdpbhf8ps.internal
-  // CHECK: call x86_amx @llvm.x86.tdphbf8ps.internal
   // CHECK: call x86_amx @llvm.x86.tdphf8ps.internal
+  // CHECK: call x86_amx @llvm.x86.tdphbf8ps.internal
+  // CHECK: call x86_amx @llvm.x86.tdpbhf8ps.internal
+  // CHECK: call x86_amx @llvm.x86.tdpbf8ps.internal
   %tRes = x86.amx.tile_mulf %tA, %tA1, %acc
     : !x86.amx.tile<16x64xf8E4M3FN>, !x86.amx.tile<16x64xf8E4M3FN>, !x86.amx.tile<16x16xf32>
   %tRes1 = x86.amx.tile_mulf %tA, %tB, %acc


### PR DESCRIPTION
This patch fixes the error instrincs selection for `bf8` and `hf8` types.

- Intel AMX naming: `bf8 == E5M2`, `hf8 == E4M3FN`.