### PR TITLE
[mlir] Remove dead declarations

### DIFF
--- a/mlir/include/mlir/Dialect/Affine/Analysis/NestedMatcher.h
+++ b/mlir/include/mlir/Dialect/Affine/Analysis/NestedMatcher.h
@@ -187,8 +187,6 @@ NestedPattern For(ArrayRef<NestedPattern> nested = {});
 NestedPattern For(const FilterFunctionType &filter,
                   ArrayRef<NestedPattern> nested = {});
 
-bool isParallelLoop(Operation &op);
-bool isReductionLoop(Operation &op);
 bool isLoadOrStore(Operation &op);
 
 } // namespace matcher


### PR DESCRIPTION
The corresponding function definitions were removed on March 29, 2019
in 4dc7af9da8837a5f9515c4622e093578fb6ab766
