### PR TITLE
[BOLT] Fix overflow issue when using absolute addressing in LSDA

### DIFF
--- a/bolt/lib/Core/BinaryEmitter.cpp
+++ b/bolt/lib/Core/BinaryEmitter.cpp
@@ -1037,7 +1037,7 @@ void BinaryEmitter::emitLSDA(BinaryFunction &BF, const FunctionFragment &FF) {
   // Emit encoding of entries in the call site table. The format is used for the
   // call site start, length, and corresponding landing pad.
   if (!LPStartSymbol)
-    Streamer.emitIntValue(dwarf::DW_EH_PE_sdata4, 1);
+    Streamer.emitIntValue(dwarf::DW_EH_PE_udata4, 1);
   else
     Streamer.emitIntValue(dwarf::DW_EH_PE_uleb128, 1);
 

--- a/bolt/test/X86/split-all-lptrampoline.s
+++ b/bolt/test/X86/split-all-lptrampoline.s
@@ -7,6 +7,17 @@
 # RUN: llvm-bolt %t.exe --split-functions --split-strategy=all --split-eh \
 # RUN:         -o %t.bolt --print-split --print-only=main 2>&1 | FileCheck %s
 
+# RUN: %clangxx -fuse-ld=lld -no-pie %t.o -o %t.nopie.exe -Wl,-q
+# RUN: llvm-bolt %t.nopie.exe --split-functions --split-strategy=all --split-eh \
+# RUN:   --custom-allocation-vma=0x80000000 -o %t.nopie.bolt -v=2 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=CHECK-ABS
+# RUN: llvm-readelf -x .gcc_except_table %t.nopie.bolt | \
+# RUN:   FileCheck %s --check-prefix=CHECK-ABS-LSDA
+# RUN: %t.nopie.bolt
+
+# CHECK-ABS: falling back to generating absolute-address exception ranges for main
+# CHECK-ABS-LSDA: 03000000 00{{....}}03
+
 # CHECK: -------   HOT-COLD SPLIT POINT   -------
 # CHECK: .LFT0
 # CHECK: Landing Pads: .LBB0

--- a/bolt/test/X86/split-all-lptrampoline.s
+++ b/bolt/test/X86/split-all-lptrampoline.s
@@ -7,17 +7,6 @@
 # RUN: llvm-bolt %t.exe --split-functions --split-strategy=all --split-eh \
 # RUN:         -o %t.bolt --print-split --print-only=main 2>&1 | FileCheck %s
 
-# RUN: %clangxx -fuse-ld=lld -no-pie %t.o -o %t.nopie.exe -Wl,-q
-# RUN: llvm-bolt %t.nopie.exe --split-functions --split-strategy=all --split-eh \
-# RUN:   --custom-allocation-vma=0x80000000 -o %t.nopie.bolt -v=2 2>&1 | \
-# RUN:   FileCheck %s --check-prefix=CHECK-ABS
-# RUN: llvm-readelf -x .gcc_except_table %t.nopie.bolt | \
-# RUN:   FileCheck %s --check-prefix=CHECK-ABS-LSDA
-# RUN: %t.nopie.bolt
-
-# CHECK-ABS: falling back to generating absolute-address exception ranges for main
-# CHECK-ABS-LSDA: 03000000 00{{....}}03
-
 # CHECK: -------   HOT-COLD SPLIT POINT   -------
 # CHECK: .LFT0
 # CHECK: Landing Pads: .LBB0

--- a/bolt/test/runtime/X86/lsda-absolute-udata4.test
+++ b/bolt/test/runtime/X86/lsda-absolute-udata4.test
@@ -1,0 +1,18 @@
+# REQUIRES: x86_64-linux
+
+## This test verifies that when emitting LSDA with absolute addresses allocated
+## above 0x7fffffff, the udata encoding is used, preventing
+## incorrect sign extension.
+
+# RUN: llvm-mc --filetype=obj --triple x86_64-unknown-linux \
+# RUN:   %S/../../X86/split-all-lptrampoline.s -o %t.o
+# RUN: %clangxx -fuse-ld=lld -no-pie %t.o -o %t.exe -Wl,-q
+# RUN: llvm-bolt %t.exe --split-functions --split-strategy=all --split-eh \
+# RUN:   --custom-allocation-vma=0x80000000 -o %t.bolt -v=2 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=CHECK-BOLT
+# RUN: llvm-readelf -x .gcc_except_table %t.bolt | \
+# RUN:   FileCheck %s --check-prefix=CHECK-LSDA
+# RUN: %t.bolt
+
+# CHECK-BOLT: falling back to generating absolute-address exception ranges for main
+# CHECK-LSDA: 03000000 00{{....}}03


### PR DESCRIPTION
Currently, in the emitLSDA() flow, signed data is used when using absolute addresses to update the LSDA for non PIE/DSO. But when the PC is higher than 0x7fffffff(2GB), this will be sign-extended into an invalid 64-bit address. Especially when the output binary is large, silent errors can easily occur (we have met this problem in real scenarios).

So this patch changes the signed data to unsigned data, thereby fixing the incorrect address extension like this:
```
.gcc_except_table
  LSDA:
    LPStartEncoding: DW_EH_PE_omit   // No LPStart
    CallSiteEncoding: DW_EH_PE_sdata4 -> udata4   // Changed from sdata4 to udata4
    call-site table:
      call-site 1:
        start = ...
        length = ...
        landing_pad = 0x80000001  // Absolute 32-bit address > 2GB
        // [Before]: sdata4 -> sign-extended to 0xfffffff80000001  (Crash!)
        // [After] : udata4 -> zero-extended to 0x0000000080000001  (Safe)
```