### PR TITLE
[AArch64][NeoverseV1] Model multi-cycle micro-ops correctly (NumMicro…

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64SchedNeoverseV1.td
+++ b/llvm/lib/Target/AArch64/AArch64SchedNeoverseV1.td
@@ -93,7 +93,6 @@ def : WriteRes<WriteHint,    []> { let Latency = 1; }
 
 let Latency = 0, NumMicroOps = 0 in
 def V1Write_0c_0Z : SchedWriteRes<[]>;
-
 def V1Write_0c : SchedWriteRes<[]> { let Latency = 0; }
 
 //===----------------------------------------------------------------------===//
@@ -104,374 +103,257 @@ def V1Write_1c_1I      : SchedWriteRes<[V1UnitI]>   { let Latency = 1; }
 def V1Write_1c_1I_1Flg : SchedWriteRes<[V1UnitI, V1UnitFlg]>   { let Latency = 1; }
 def V1Write_4c_1L      : SchedWriteRes<[V1UnitL]>   { let Latency = 4; }
 def V1Write_6c_1L      : SchedWriteRes<[V1UnitL]>   { let Latency = 6; }
+def V1Write_6c2_1L     : SchedWriteRes<[V1UnitL]>   { let Latency = 6;
+						      let ReleaseAtCycles = [2]; }
+def V1Write_6c3_1L     : SchedWriteRes<[V1UnitL]>   { let Latency = 6;
+						      let ReleaseAtCycles = [3]; }
+def V1Write_7c4_1L     : SchedWriteRes<[V1UnitL]>   { let Latency = 7;
+						      let ReleaseAtCycles = [4]; }
 def V1Write_1c_1L01    : SchedWriteRes<[V1UnitL01]> { let Latency = 1; }
 def V1Write_4c_1L01    : SchedWriteRes<[V1UnitL01]> { let Latency = 4; }
 def V1Write_6c_1L01    : SchedWriteRes<[V1UnitL01]> { let Latency = 6; }
 def V1Write_2c_1M      : SchedWriteRes<[V1UnitM]>   { let Latency = 2; }
-def V1Write_2c_1M_1Flg : SchedWriteRes<[V1UnitM, V1UnitFlg]>   { let Latency = 2; }
 def V1Write_3c_1M      : SchedWriteRes<[V1UnitM]>   { let Latency = 3; }
 def V1Write_4c_1M      : SchedWriteRes<[V1UnitM]>   { let Latency = 4; }
+def V1Write_2c_1M_1Flg : SchedWriteRes<[V1UnitM, V1UnitFlg]>   { let Latency = 2; }
 def V1Write_1c_1M0     : SchedWriteRes<[V1UnitM0]>  { let Latency = 1; }
 def V1Write_2c_1M0     : SchedWriteRes<[V1UnitM0]>  { let Latency = 2; }
+def V1Write_2c2_1M0    : SchedWriteRes<[V1UnitM0]>  { let Latency = 2;
+						      let ReleaseAtCycles = [2]; }
 def V1Write_3c_1M0     : SchedWriteRes<[V1UnitM0]>  { let Latency = 3; }
+def V1Write_3c2_1M0    : SchedWriteRes<[V1UnitM0]>  { let Latency = 3;
+						      let ReleaseAtCycles = [2]; }
 def V1Write_5c_1M0     : SchedWriteRes<[V1UnitM0]>  { let Latency = 5; }
 def V1Write_12c5_1M0   : SchedWriteRes<[V1UnitM0]>  { let Latency = 12;
-                                                      let ReleaseAtCycles = [5]; }
+						      let ReleaseAtCycles = [5]; }
 def V1Write_20c5_1M0   : SchedWriteRes<[V1UnitM0]>  { let Latency = 20;
-                                                      let ReleaseAtCycles = [5]; }
+						      let ReleaseAtCycles = [5]; }
 def V1Write_2c_1V      : SchedWriteRes<[V1UnitV]>   { let Latency = 2; }
 def V1Write_3c_1V      : SchedWriteRes<[V1UnitV]>   { let Latency = 3; }
 def V1Write_4c_1V      : SchedWriteRes<[V1UnitV]>   { let Latency = 4; }
+def V1Write_4c2_1V     : SchedWriteRes<[V1UnitV]>   { let Latency = 4;
+						      let ReleaseAtCycles = [2]; }
 def V1Write_5c_1V      : SchedWriteRes<[V1UnitV]>   { let Latency = 5; }
+def V1Write_6c3_1V     : SchedWriteRes<[V1UnitV]>   { let Latency = 6;
+						      let ReleaseAtCycles = [3]; }
 def V1Write_2c_1V0     : SchedWriteRes<[V1UnitV0]>  { let Latency = 2; }
 def V1Write_3c_1V0     : SchedWriteRes<[V1UnitV0]>  { let Latency = 3; }
 def V1Write_4c_1V0     : SchedWriteRes<[V1UnitV0]>  { let Latency = 4; }
+def V1Write_4c2_1V0    : SchedWriteRes<[V1UnitV0]>  { let Latency = 4;
+						      let ReleaseAtCycles = [2]; }
+def V1Write_5c2_1V0    : SchedWriteRes<[V1UnitV0]>  { let Latency = 5;
+						      let ReleaseAtCycles = [2]; }
 def V1Write_6c_1V0     : SchedWriteRes<[V1UnitV0]>  { let Latency = 6; }
+def V1Write_6c4_1V0    : SchedWriteRes<[V1UnitV0]>  { let Latency = 6;
+						      let ReleaseAtCycles = [4]; }
 def V1Write_10c7_1V0   : SchedWriteRes<[V1UnitV0]>  { let Latency = 10;
-                                                      let ReleaseAtCycles = [7]; }
+						      let ReleaseAtCycles = [7]; }
+def V1Write_11c10_1V0  : SchedWriteRes<[V1UnitV0]>  { let Latency = 11;
+						      let ReleaseAtCycles = [10]; }
 def V1Write_12c7_1V0   : SchedWriteRes<[V1UnitV0]>  { let Latency = 12;
-                                                      let ReleaseAtCycles = [7]; }
+						      let ReleaseAtCycles = [7]; }
 def V1Write_13c10_1V0  : SchedWriteRes<[V1UnitV0]>  { let Latency = 13;
-                                                      let ReleaseAtCycles = [10]; }
+						      let ReleaseAtCycles = [10]; }
 def V1Write_15c7_1V0   : SchedWriteRes<[V1UnitV0]>  { let Latency = 15;
-                                                      let ReleaseAtCycles = [7]; }
+						      let ReleaseAtCycles = [7]; }
 def V1Write_16c7_1V0   : SchedWriteRes<[V1UnitV0]>  { let Latency = 16;
-                                                      let ReleaseAtCycles = [7]; }
+						      let ReleaseAtCycles = [7]; }
+def V1Write_19c18_1V0  : SchedWriteRes<[V1UnitV0]>  { let Latency = 19;
+						      let ReleaseAtCycles = [18]; }
 def V1Write_20c7_1V0   : SchedWriteRes<[V1UnitV0]>  { let Latency = 20;
-                                                      let ReleaseAtCycles = [7]; }
+						      let ReleaseAtCycles = [7]; }
 def V1Write_2c_1V01    : SchedWriteRes<[V1UnitV01]> { let Latency = 2; }
+def V1Write_2c2_1V01   : SchedWriteRes<[V1UnitV01]> { let Latency = 2;
+						      let ReleaseAtCycles = [2]; }
 def V1Write_3c_1V01    : SchedWriteRes<[V1UnitV01]> { let Latency = 3; }
 def V1Write_4c_1V01    : SchedWriteRes<[V1UnitV01]> { let Latency = 4; }
+def V1Write_4c2_1V01   : SchedWriteRes<[V1UnitV01]> { let Latency = 4;
+						      let ReleaseAtCycles = [2]; }
+def V1Write_4c3_1V01   : SchedWriteRes<[V1UnitV01]> { let Latency = 4;
+						      let ReleaseAtCycles = [3]; }
 def V1Write_5c_1V01    : SchedWriteRes<[V1UnitV01]> { let Latency = 5; }
+def V1Write_6c3_1V01   : SchedWriteRes<[V1UnitV01]> { let Latency = 6;
+						      let ReleaseAtCycles = [3]; }
+def V1Write_6c5_1V01   : SchedWriteRes<[V1UnitV01]> { let Latency = 6;
+						      let ReleaseAtCycles = [5]; }
+def V1Write_8c3_1V01   : SchedWriteRes<[V1UnitV01]> { let Latency = 8;
+						      let ReleaseAtCycles = [3]; }
+def V1Write_12c4_1V01  : SchedWriteRes<[V1UnitV01]> { let Latency = 12;
+						      let ReleaseAtCycles = [4]; }
+def V1Write_13c6_1V01  : SchedWriteRes<[V1UnitV01]> { let Latency = 13;
+						      let ReleaseAtCycles = [6]; }
 def V1Write_3c_1V02    : SchedWriteRes<[V1UnitV02]> { let Latency = 3; }
 def V1Write_4c_1V02    : SchedWriteRes<[V1UnitV02]> { let Latency = 4; }
+def V1Write_4c2_1V02   : SchedWriteRes<[V1UnitV02]> { let Latency = 4;
+						      let ReleaseAtCycles = [2]; }
+def V1Write_6c2_1V02   : SchedWriteRes<[V1UnitV02]> { let Latency = 6;
+						      let ReleaseAtCycles = [2]; }
 def V1Write_7c7_1V02   : SchedWriteRes<[V1UnitV02]> { let Latency = 7;
-                                                      let ReleaseAtCycles = [7]; }
+						      let ReleaseAtCycles = [7]; }
 def V1Write_10c7_1V02  : SchedWriteRes<[V1UnitV02]> { let Latency = 10;
-                                                      let ReleaseAtCycles = [7]; }
+						      let ReleaseAtCycles = [7]; }
 def V1Write_13c5_1V02  : SchedWriteRes<[V1UnitV02]> { let Latency = 13;
-                                                      let ReleaseAtCycles = [5]; }
+						      let ReleaseAtCycles = [5]; }
 def V1Write_13c11_1V02 : SchedWriteRes<[V1UnitV02]> { let Latency = 13;
-                                                      let ReleaseAtCycles = [11]; }
+						      let ReleaseAtCycles = [11]; }
 def V1Write_15c7_1V02  : SchedWriteRes<[V1UnitV02]> { let Latency = 15;
-                                                      let ReleaseAtCycles = [7]; }
+						      let ReleaseAtCycles = [7]; }
 def V1Write_16c7_1V02  : SchedWriteRes<[V1UnitV02]> { let Latency = 16;
-                                                      let ReleaseAtCycles = [7]; }
+						      let ReleaseAtCycles = [7]; }
 def V1Write_2c_1V1     : SchedWriteRes<[V1UnitV1]>  { let Latency = 2; }
 def V1Write_3c_1V1     : SchedWriteRes<[V1UnitV1]>  { let Latency = 3; }
 def V1Write_4c_1V1     : SchedWriteRes<[V1UnitV1]>  { let Latency = 4; }
 def V1Write_2c_1V13    : SchedWriteRes<[V1UnitV13]> { let Latency = 2; }
 def V1Write_4c_1V13    : SchedWriteRes<[V1UnitV13]> { let Latency = 4; }
+def V1Write_4c2_1V13   : SchedWriteRes<[V1UnitV13]> { let Latency = 4;
+						      let ReleaseAtCycles = [2]; }
 
 //===----------------------------------------------------------------------===//
 // Define generic 2 micro-op types
 
-let Latency = 1, NumMicroOps = 2 in
-def V1Write_1c_1B_1S     : SchedWriteRes<[V1UnitB, V1UnitS]>;
 let Latency = 6, NumMicroOps = 2 in
-def V1Write_6c_1B_1M0    : SchedWriteRes<[V1UnitB, V1UnitM0]>;
-let Latency = 3, NumMicroOps = 2 in
-def V1Write_3c_1I_1M     : SchedWriteRes<[V1UnitI, V1UnitM]>;
+def V1Write_6c_1B_1M0 : SchedWriteRes<[V1UnitB, V1UnitM0]>;
+let Latency = 1, NumMicroOps = 2 in
+def V1Write_1c_1B_1S : SchedWriteRes<[V1UnitB, V1UnitS]>;
 let Latency = 5, NumMicroOps = 2 in
-def V1Write_5c_1I_1L     : SchedWriteRes<[V1UnitI, V1UnitL]>;
+def V1Write_5c_1I_1L : SchedWriteRes<[V1UnitI, V1UnitL]>;
 let Latency = 7, NumMicroOps = 2 in
-def V1Write_7c_1I_1L     : SchedWriteRes<[V1UnitI, V1UnitL]>;
+def V1Write_7c_1I_1L : SchedWriteRes<[V1UnitI, V1UnitL]>;
+let Latency = 3, NumMicroOps = 2 in
+def V1Write_3c_1I_1M : SchedWriteRes<[V1UnitI, V1UnitM]>;
 let Latency = 6, NumMicroOps = 2 in
-def V1Write_6c_2L        : SchedWriteRes<[V1UnitL, V1UnitL]>;
-let Latency = 6, NumMicroOps = 2 in
-def V1Write_6c_1L_1M     : SchedWriteRes<[V1UnitL, V1UnitM]>;
+def V1Write_6c_1L_1M : SchedWriteRes<[V1UnitL, V1UnitM]>;
+let Latency = 6, NumMicroOps = 2, ReleaseAtCycles = [3,3] in
+def V1Write_6c3_1L_1V : SchedWriteRes<[V1UnitL, V1UnitV]>;
 let Latency = 8, NumMicroOps = 2 in
-def V1Write_8c_1L_1V     : SchedWriteRes<[V1UnitL, V1UnitV]>;
+def V1Write_8c_1L_1V : SchedWriteRes<[V1UnitL, V1UnitV]>;
+let Latency = 8, NumMicroOps = 2, ReleaseAtCycles = [1,2] in
+def V1Write_8c2_1L_2V : SchedWriteRes<[V1UnitL, V1UnitV]>;
+let Latency = 8, NumMicroOps = 2, ReleaseAtCycles = [2,2] in
+def V1Write_8c2_1L_1V : SchedWriteRes<[V1UnitL, V1UnitV]>;
+let Latency = 8, NumMicroOps = 2, ReleaseAtCycles = [2,3] in
+def V1Write_8c3_2L_3V : SchedWriteRes<[V1UnitL, V1UnitV]>;
+let Latency = 8, NumMicroOps = 2, ReleaseAtCycles = [3,3] in
+def V1Write_8c3_1L_1V : SchedWriteRes<[V1UnitL, V1UnitV]>;
+let Latency = 8, NumMicroOps = 2, ReleaseAtCycles = [3,4] in
+def V1Write_8c4_3L_4V : SchedWriteRes<[V1UnitL, V1UnitV]>;
 let Latency = 9, NumMicroOps = 2 in
-def V1Write_9c_1L_1V     : SchedWriteRes<[V1UnitL, V1UnitV]>;
+def V1Write_9c_1L_1V : SchedWriteRes<[V1UnitL, V1UnitV]>;
+let Latency = 9, NumMicroOps = 2, ReleaseAtCycles = [2,2] in
+def V1Write_9c2_1L_1V : SchedWriteRes<[V1UnitL, V1UnitV]>;
+let Latency = 9, NumMicroOps = 2, ReleaseAtCycles = [4,4] in
+def V1Write_9c4_1L_1V : SchedWriteRes<[V1UnitL, V1UnitV]>;
 let Latency = 11, NumMicroOps = 2 in
-def V1Write_11c_1L_1V     : SchedWriteRes<[V1UnitL, V1UnitV]>;
+def V1Write_11c_1L_1V : SchedWriteRes<[V1UnitL, V1UnitV]>;
+let Latency = 11, NumMicroOps = 2, ReleaseAtCycles = [2,2] in
+def V1Write_11c2_1L_1V : SchedWriteRes<[V1UnitL, V1UnitV]>;
 let Latency = 1, NumMicroOps = 2 in
-def V1Write_1c_1L01_1D   : SchedWriteRes<[V1UnitL01, V1UnitD]>;
+def V1Write_1c_1L01_1D : SchedWriteRes<[V1UnitL01, V1UnitD]>;
 let Latency = 6, NumMicroOps = 2 in
-def V1Write_6c_1L01_1S   : SchedWriteRes<[V1UnitL01, V1UnitS]>;
+def V1Write_6c_1L01_1S : SchedWriteRes<[V1UnitL01, V1UnitS]>;
 let Latency = 7, NumMicroOps = 2 in
-def V1Write_7c_1L01_1S   : SchedWriteRes<[V1UnitL01, V1UnitS]>;
+def V1Write_7c_1L01_1S : SchedWriteRes<[V1UnitL01, V1UnitS]>;
 let Latency = 2, NumMicroOps = 2 in
-def V1Write_2c_1L01_1V   : SchedWriteRes<[V1UnitL01, V1UnitV]>;
+def V1Write_2c_1L01_1V : SchedWriteRes<[V1UnitL01, V1UnitV]>;
 let Latency = 4, NumMicroOps = 2 in
-def V1Write_4c_1L01_1V   : SchedWriteRes<[V1UnitL01, V1UnitV]>;
+def V1Write_4c_1L01_1V : SchedWriteRes<[V1UnitL01, V1UnitV]>;
 let Latency = 6, NumMicroOps = 2 in
-def V1Write_6c_1L01_1V   : SchedWriteRes<[V1UnitL01, V1UnitV]>;
+def V1Write_6c_1L01_1V : SchedWriteRes<[V1UnitL01, V1UnitV]>;
+let Latency = 7, NumMicroOps = 2, ReleaseAtCycles = [5,5] in
+def V1Write_7c5_1L01_1V : SchedWriteRes<[V1UnitL01, V1UnitV]>;
+let Latency = 10, NumMicroOps = 2, ReleaseAtCycles = [2,2] in
+def V1Write_10c2_1L01_1V : SchedWriteRes<[V1UnitL01, V1UnitV]>;
+let Latency = 19, NumMicroOps = 2, ReleaseAtCycles = [9,9] in
+def V1Write_19c9_1L01_1V : SchedWriteRes<[V1UnitL01, V1UnitV]>;
 let Latency = 2, NumMicroOps = 2 in
 def V1Write_2c_1L01_1V01 : SchedWriteRes<[V1UnitL01, V1UnitV01]>;
+let Latency = 2, NumMicroOps = 2, ReleaseAtCycles = [2,1] in
+def V1Write_2c2_2L01_1V01 : SchedWriteRes<[V1UnitL01, V1UnitV01]>;
+let Latency = 2, NumMicroOps = 2, ReleaseAtCycles = [2,2] in
+def V1Write_2c2_1L01_1V01 : SchedWriteRes<[V1UnitL01, V1UnitV01]>;
+let Latency = 2, NumMicroOps = 2, ReleaseAtCycles = [3,3] in
+def V1Write_2c3_1L01_1V01 : SchedWriteRes<[V1UnitL01, V1UnitV01]>;
+let Latency = 2, NumMicroOps = 2, ReleaseAtCycles = [4,4] in
+def V1Write_2c4_1L01_1V01 : SchedWriteRes<[V1UnitL01, V1UnitV01]>;
 let Latency = 4, NumMicroOps = 2 in
 def V1Write_4c_1L01_1V01 : SchedWriteRes<[V1UnitL01, V1UnitV01]>;
-let Latency = 2, NumMicroOps = 2 in
-def V1Write_2c_2M0       : SchedWriteRes<[V1UnitM0, V1UnitM0]>;
-let Latency = 3, NumMicroOps = 2 in
-def V1Write_3c_2M0       : SchedWriteRes<[V1UnitM0, V1UnitM0]>;
+let Latency = 4, NumMicroOps = 2, ReleaseAtCycles = [2,2] in
+def V1Write_4c2_1L01_1V01 : SchedWriteRes<[V1UnitL01, V1UnitV01]>;
+let Latency = 4, NumMicroOps = 2, ReleaseAtCycles = [4,4] in
+def V1Write_4c4_1L01_1V01 : SchedWriteRes<[V1UnitL01, V1UnitV01]>;
+let Latency = 5, NumMicroOps = 2, ReleaseAtCycles = [3,3] in
+def V1Write_5c3_1L01_1V01 : SchedWriteRes<[V1UnitL01, V1UnitV01]>;
+let Latency = 6, NumMicroOps = 2, ReleaseAtCycles = [3,3] in
+def V1Write_6c3_1L01_1V01 : SchedWriteRes<[V1UnitL01, V1UnitV01]>;
+let Latency = 7, NumMicroOps = 2, ReleaseAtCycles = [6,6] in
+def V1Write_7c6_1L01_1V01 : SchedWriteRes<[V1UnitL01, V1UnitV01]>;
+let Latency = 8, NumMicroOps = 2, ReleaseAtCycles = [2,2] in
+def V1Write_8c2_1L01_1V01 : SchedWriteRes<[V1UnitL01, V1UnitV01]>;
+let Latency = 9, NumMicroOps = 2, ReleaseAtCycles = [2,2] in
+def V1Write_9c2_1L01_1V01 : SchedWriteRes<[V1UnitL01, V1UnitV01]>;
+let Latency = 10, NumMicroOps = 2, ReleaseAtCycles = [2,2] in
+def V1Write_10c2_1L01_1V01 : SchedWriteRes<[V1UnitL01, V1UnitV01]>;
+let Latency = 11, NumMicroOps = 2, ReleaseAtCycles = [3,3] in
+def V1Write_11c3_1L01_1V01 : SchedWriteRes<[V1UnitL01, V1UnitV01]>;
+let Latency = 12, NumMicroOps = 2, ReleaseAtCycles = [4,4] in
+def V1Write_12c4_1L01_1V01 : SchedWriteRes<[V1UnitL01, V1UnitV01]>;
 let Latency = 9, NumMicroOps = 2 in
-def V1Write_9c_1M0_1L    : SchedWriteRes<[V1UnitM0, V1UnitL]>;
+def V1Write_9c_1M0_1L : SchedWriteRes<[V1UnitM0, V1UnitL]>;
 let Latency = 5, NumMicroOps = 2 in
-def V1Write_5c_1M0_1V    : SchedWriteRes<[V1UnitM0, V1UnitV]>;
+def V1Write_5c_1M0_1V : SchedWriteRes<[V1UnitM0, V1UnitV]>;
 let Latency = 4, NumMicroOps = 2 in
-def V1Write_4c_1M0_1V0    : SchedWriteRes<[V1UnitM0, V1UnitV0]>;
+def V1Write_4c_1M0_1V0 : SchedWriteRes<[V1UnitM0, V1UnitV0]>;
+let Latency = 8, NumMicroOps = 2, ReleaseAtCycles = [2,2] in
+def V1Write_8c2_1M0_1V0 : SchedWriteRes<[V1UnitM0, V1UnitV0]>;
+let Latency = 5, NumMicroOps = 2 in
+def V1Write_5c_1M0_1V01 : SchedWriteRes<[V1UnitM0, V1UnitV01]>;
+let Latency = 7, NumMicroOps = 2, ReleaseAtCycles = [2,1] in
+def V1Write_7c2_2M0_1V01 : SchedWriteRes<[V1UnitM0, V1UnitV01]>;
+let Latency = 6, NumMicroOps = 2 in
+def V1Write_6c_1M0_1V1 : SchedWriteRes<[V1UnitM0, V1UnitV1]>;
 let Latency = 7, NumMicroOps = 2 in
-def V1Write_7c_1M0_1V0   : SchedWriteRes<[V1UnitM0, V1UnitV1]>;
-let Latency = 5, NumMicroOps = 2 in
-def V1Write_5c_1M0_1V01    : SchedWriteRes<[V1UnitM0, V1UnitV01]>;
-let Latency = 6, NumMicroOps = 2 in
-def V1Write_6c_1M0_1V1   : SchedWriteRes<[V1UnitM0, V1UnitV1]>;
+def V1Write_7c_1M0_1V1 : SchedWriteRes<[V1UnitM0, V1UnitV1]>;
 let Latency = 9, NumMicroOps = 2 in
-def V1Write_9c_1M0_1V1    : SchedWriteRes<[V1UnitM0, V1UnitV1]>;
-let Latency = 4, NumMicroOps = 2 in
-def V1Write_4c_2V        : SchedWriteRes<[V1UnitV, V1UnitV]>;
+def V1Write_9c_1M0_1V1 : SchedWriteRes<[V1UnitM0, V1UnitV1]>;
 let Latency = 8, NumMicroOps = 2 in
-def V1Write_8c_1V_1V01   : SchedWriteRes<[V1UnitV, V1UnitV01]>;
+def V1Write_8c_1V_1V01 : SchedWriteRes<[V1UnitV, V1UnitV01]>;
+let Latency = 9, NumMicroOps = 2, ReleaseAtCycles = [1,4] in
+def V1Write_9c4_1V_4V01 : SchedWriteRes<[V1UnitV, V1UnitV01]>;
+let Latency = 11, NumMicroOps = 2, ReleaseAtCycles = [1,5] in
+def V1Write_11c5_1V_5V01 : SchedWriteRes<[V1UnitV, V1UnitV01]>;
 let Latency = 4, NumMicroOps = 2 in
-def V1Write_4c_2V0       : SchedWriteRes<[V1UnitV0, V1UnitV0]>;
-let Latency = 5, NumMicroOps = 2 in
-def V1Write_5c_2V0       : SchedWriteRes<[V1UnitV0, V1UnitV0]>;
-let Latency = 2, NumMicroOps = 2 in
-def V1Write_2c_2V01      : SchedWriteRes<[V1UnitV01, V1UnitV01]>;
-let Latency = 4, NumMicroOps = 2 in
-def V1Write_4c_2V01      : SchedWriteRes<[V1UnitV01, V1UnitV01]>;
-let Latency = 4, NumMicroOps = 2 in
-def V1Write_4c_2V02      : SchedWriteRes<[V1UnitV02, V1UnitV02]>;
-let Latency = 6, NumMicroOps = 2 in
-def V1Write_6c_2V02      : SchedWriteRes<[V1UnitV02, V1UnitV02]>;
-let Latency = 4, NumMicroOps = 2 in
-def V1Write_4c_1V13_1V   : SchedWriteRes<[V1UnitV13, V1UnitV]>;
-let Latency = 4, NumMicroOps = 2 in
-def V1Write_4c_2V13      : SchedWriteRes<[V1UnitV13, V1UnitV13]>;
+def V1Write_4c_1V13_1V : SchedWriteRes<[V1UnitV13, V1UnitV]>;
 
 //===----------------------------------------------------------------------===//
 // Define generic 3 micro-op types
 
 let Latency = 2, NumMicroOps = 3 in
 def V1Write_2c_1I_1L01_1V01 : SchedWriteRes<[V1UnitI, V1UnitL01, V1UnitV01]>;
-let Latency = 7, NumMicroOps = 3 in
-def V1Write_7c_2M0_1V01     : SchedWriteRes<[V1UnitM0, V1UnitM0, V1UnitV01]>;
-let Latency = 8, NumMicroOps = 3 in
-def V1Write_8c_1L_2V        : SchedWriteRes<[V1UnitL, V1UnitV, V1UnitV]>;
-let Latency = 6, NumMicroOps = 3 in
-def V1Write_6c_3L           : SchedWriteRes<[V1UnitL, V1UnitL, V1UnitL]>;
 let Latency = 2, NumMicroOps = 3 in
-def V1Write_2c_1L01_1S_1V   : SchedWriteRes<[V1UnitL01, V1UnitS, V1UnitV]>;
+def V1Write_2c_1L01_1S_1V : SchedWriteRes<[V1UnitL01, V1UnitS, V1UnitV]>;
 let Latency = 4, NumMicroOps = 3 in
-def V1Write_4c_1L01_1S_1V   : SchedWriteRes<[V1UnitL01, V1UnitS, V1UnitV]>;
-let Latency = 2, NumMicroOps = 3 in
-def V1Write_2c_2L01_1V01    : SchedWriteRes<[V1UnitL01, V1UnitL01, V1UnitV01]>;
-let Latency = 6, NumMicroOps = 3 in
-def V1Write_6c_3V           : SchedWriteRes<[V1UnitV, V1UnitV, V1UnitV]>;
-let Latency = 4, NumMicroOps = 3 in
-def V1Write_4c_3V01         : SchedWriteRes<[V1UnitV01, V1UnitV01, V1UnitV01]>;
-let Latency = 6, NumMicroOps = 3 in
-def V1Write_6c_3V01         : SchedWriteRes<[V1UnitV01, V1UnitV01, V1UnitV01]>;
-let Latency = 8, NumMicroOps = 3 in
-def V1Write_8c_3V01         : SchedWriteRes<[V1UnitV01, V1UnitV01, V1UnitV01]>;
+def V1Write_4c_1L01_1S_1V : SchedWriteRes<[V1UnitL01, V1UnitS, V1UnitV]>;
+let Latency = 7, NumMicroOps = 3, ReleaseAtCycles = [5,5,5] in
+def V1Write_7c5_1L01_1S_1V : SchedWriteRes<[V1UnitL01, V1UnitS, V1UnitV]>;
+let Latency = 11, NumMicroOps = 3, ReleaseAtCycles = [9,9,9] in
+def V1Write_11c9_1L01_1S_1V : SchedWriteRes<[V1UnitL01, V1UnitS, V1UnitV]>;
+let Latency = 8, NumMicroOps = 3, ReleaseAtCycles = [3,1,3] in
+def V1Write_8c3_3L01_1S_3V01 : SchedWriteRes<[V1UnitL01, V1UnitS, V1UnitV01]>;
+let Latency = 13, NumMicroOps = 3, ReleaseAtCycles = [4,2,4] in
+def V1Write_13c4_4L01_2S_4V01 : SchedWriteRes<[V1UnitL01, V1UnitS, V1UnitV01]>;
+let Latency = 10, NumMicroOps = 3, ReleaseAtCycles = [1,1,2] in
+def V1Write_10c2_1V_1V01_2V1 : SchedWriteRes<[V1UnitV, V1UnitV01, V1UnitV1]>;
+let Latency = 12, NumMicroOps = 3, ReleaseAtCycles = [1,1,2] in
+def V1Write_12c2_1V_1V01_2V1 : SchedWriteRes<[V1UnitV, V1UnitV01, V1UnitV1]>;
 
 //===----------------------------------------------------------------------===//
 // Define generic 4 micro-op types
 
-let Latency = 8, NumMicroOps = 4 in
-def V1Write_8c_2M0_2V0   : SchedWriteRes<[V1UnitM0, V1UnitM0,
-                                          V1UnitV0, V1UnitV0]>;
-let Latency = 7, NumMicroOps = 4 in
-def V1Write_7c_4L        : SchedWriteRes<[V1UnitL, V1UnitL, V1UnitL, V1UnitL]>;
-let Latency = 8, NumMicroOps = 4 in
-def V1Write_8c_2L_2V        : SchedWriteRes<[V1UnitL, V1UnitL,
-                                             V1UnitV, V1UnitV]>;
-let Latency = 9, NumMicroOps = 4 in
-def V1Write_9c_2L_2V        : SchedWriteRes<[V1UnitL, V1UnitL,
-                                             V1UnitV, V1UnitV]>;
-let Latency = 11, NumMicroOps = 4 in
-def V1Write_11c_2L_2V       : SchedWriteRes<[V1UnitL, V1UnitL,
-                                             V1UnitV, V1UnitV]>;
-let Latency = 10, NumMicroOps = 4 in
-def V1Write_10c_2L01_2V     : SchedWriteRes<[V1UnitL01, V1UnitL01,
-                                             V1UnitV, V1UnitV]>;
-let Latency = 2, NumMicroOps = 4 in
-def V1Write_2c_2L01_2V01    : SchedWriteRes<[V1UnitL01, V1UnitL01,
-                                             V1UnitV01, V1UnitV01]>;
-let Latency = 4, NumMicroOps = 4 in
-def V1Write_4c_2L01_2V01    : SchedWriteRes<[V1UnitL01, V1UnitL01,
-                                             V1UnitV01, V1UnitV01]>;
-let Latency = 8, NumMicroOps = 4 in
-def V1Write_8c_2L01_2V01    : SchedWriteRes<[V1UnitL01, V1UnitL01,
-                                             V1UnitV01, V1UnitV01]>;
-let Latency = 9, NumMicroOps = 4 in
-def V1Write_9c_2L01_2V01    : SchedWriteRes<[V1UnitL01, V1UnitL01,
-                                             V1UnitV01, V1UnitV01]>;
-let Latency = 10, NumMicroOps = 4 in
-def V1Write_10c_2L01_2V01   : SchedWriteRes<[V1UnitL01, V1UnitL01,
-                                             V1UnitV01, V1UnitV01]>;
-let Latency = 10, NumMicroOps = 4 in
-def V1Write_10c_1V_1V01_2V1 : SchedWriteRes<[V1UnitV, V1UnitV01,
-                                             V1UnitV1, V1UnitV1]>;
-let Latency = 12, NumMicroOps = 4 in
-def V1Write_12c_1V_1V01_2V1 : SchedWriteRes<[V1UnitV, V1UnitV01,
-                                             V1UnitV1, V1UnitV1]>;
-let Latency = 6, NumMicroOps = 4 in
-def V1Write_6c_4V0          : SchedWriteRes<[V1UnitV0, V1UnitV0,
-                                             V1UnitV0, V1UnitV0]>;
-let Latency = 12, NumMicroOps = 4 in
-def V1Write_12c_4V01        : SchedWriteRes<[V1UnitV01, V1UnitV01,
-                                             V1UnitV01, V1UnitV01]>;
-let Latency = 6, NumMicroOps = 4 in
-def V1Write_6c_4V02         : SchedWriteRes<[V1UnitV02, V1UnitV02]>;
-
-//===----------------------------------------------------------------------===//
-// Define generic 5 micro-op types
-
-let Latency = 8, NumMicroOps = 5 in
-def V1Write_8c_2L_3V            : SchedWriteRes<[V1UnitL, V1UnitL,
-                                                 V1UnitV, V1UnitV, V1UnitV]>;
-let Latency = 14, NumMicroOps = 5 in
-def V1Write_14c_1V_1V0_2V1_1V13 : SchedWriteRes<[V1UnitV,
-                                                 V1UnitV0,
-                                                 V1UnitV1, V1UnitV1,
-                                                 V1UnitV13]>;
-let Latency = 9, NumMicroOps = 5 in
-def V1Write_9c_1V_4V01          : SchedWriteRes<[V1UnitV,
-                                                 V1UnitV01, V1UnitV01,
-                                                 V1UnitV01, V1UnitV01]>;
-let Latency = 6, NumMicroOps = 5 in
-def V1Write_6c_5V01             : SchedWriteRes<[V1UnitV01, V1UnitV01,
-                                                 V1UnitV01, V1UnitV01, V1UnitV01]>;
-
-//===----------------------------------------------------------------------===//
-// Define generic 6 micro-op types
-
-let Latency = 6, NumMicroOps = 6 in
-def V1Write_6c_3L_3V      : SchedWriteRes<[V1UnitL, V1UnitL, V1UnitL,
-                                           V1UnitV, V1UnitV, V1UnitV]>;
-let Latency = 8, NumMicroOps = 6 in
-def V1Write_8c_3L_3V      : SchedWriteRes<[V1UnitL, V1UnitL, V1UnitL,
-                                           V1UnitV, V1UnitV, V1UnitV]>;
-let Latency = 2, NumMicroOps = 6 in
-def V1Write_2c_3L01_3V01  : SchedWriteRes<[V1UnitL01, V1UnitL01, V1UnitL01,
-                                           V1UnitV01, V1UnitV01, V1UnitV01]>;
-let Latency = 5, NumMicroOps = 6 in
-def V1Write_5c_3L01_3V01  : SchedWriteRes<[V1UnitL01, V1UnitL01, V1UnitL01,
-                                           V1UnitV01, V1UnitV01, V1UnitV01]>;
-let Latency = 6, NumMicroOps = 6 in
-def V1Write_6c_3L01_3V01  : SchedWriteRes<[V1UnitL01, V1UnitL01, V1UnitL01,
-                                           V1UnitV01, V1UnitV01, V1UnitV01]>;
-let Latency = 11, NumMicroOps = 6 in
-def V1Write_11c_3L01_3V01 : SchedWriteRes<[V1UnitL01, V1UnitL01, V1UnitL01,
-                                           V1UnitV01, V1UnitV01, V1UnitV01]>;
-let Latency = 11, NumMicroOps = 6 in
-def V1Write_11c_1V_5V01   : SchedWriteRes<[V1UnitV,
-                                           V1UnitV01, V1UnitV01,
-                                           V1UnitV01, V1UnitV01, V1UnitV01]>;
-let Latency = 13, NumMicroOps = 6 in
-def V1Write_13c_6V01      : SchedWriteRes<[V1UnitV01, V1UnitV01, V1UnitV01,
-                                           V1UnitV01, V1UnitV01, V1UnitV01]>;
-
-//===----------------------------------------------------------------------===//
-// Define generic 7 micro-op types
-
-let Latency = 8, NumMicroOps = 7 in
-def V1Write_8c_3L_4V         : SchedWriteRes<[V1UnitL, V1UnitL, V1UnitL,
-                                              V1UnitV, V1UnitV, V1UnitV, V1UnitV]>;
-let Latency = 8, NumMicroOps = 7 in
-def V1Write_13c_3L01_1S_3V01 : SchedWriteRes<[V1UnitL01, V1UnitL01, V1UnitL01,
-                                              V1UnitS,
-                                              V1UnitV01, V1UnitV01, V1UnitV01]>;
-
-//===----------------------------------------------------------------------===//
-// Define generic 8 micro-op types
-
-let Latency = 9, NumMicroOps = 8 in
-def V1Write_9c_4L_4V      : SchedWriteRes<[V1UnitL, V1UnitL,
-                                           V1UnitL, V1UnitL,
-                                           V1UnitV, V1UnitV,
-                                           V1UnitV, V1UnitV]>;
-let Latency = 2, NumMicroOps = 8 in
-def V1Write_2c_4L01_4V01  : SchedWriteRes<[V1UnitL01, V1UnitL01,
-                                           V1UnitL01, V1UnitL01,
-                                           V1UnitV01, V1UnitV01,
-                                           V1UnitV01, V1UnitV01]>;
-let Latency = 4, NumMicroOps = 8 in
-def V1Write_4c_4L01_4V01  : SchedWriteRes<[V1UnitL01, V1UnitL01,
-                                           V1UnitL01, V1UnitL01,
-                                           V1UnitV01, V1UnitV01,
-                                           V1UnitV01, V1UnitV01]>;
-let Latency = 12, NumMicroOps = 8 in
-def V1Write_12c_4L01_4V01 : SchedWriteRes<[V1UnitL01, V1UnitL01,
-                                           V1UnitL01, V1UnitL01,
-                                           V1UnitV01, V1UnitV01,
-                                           V1UnitV01, V1UnitV01]>;
-
-//===----------------------------------------------------------------------===//
-// Define generic 10 micro-op types
-
-let Latency = 13, NumMicroOps = 10 in
-def V1Write_13c_4L01_2S_4V01 : SchedWriteRes<[V1UnitL01, V1UnitL01,
-                                              V1UnitL01, V1UnitL01,
-                                              V1UnitS, V1UnitS,
-                                              V1UnitV01, V1UnitV01,
-                                              V1UnitV01, V1UnitV01]>;
-let Latency = 7, NumMicroOps = 10 in
-def V1Write_7c_5L01_5V       : SchedWriteRes<[V1UnitL01, V1UnitL01,
-                                              V1UnitL01, V1UnitL01, V1UnitL01,
-                                              V1UnitV, V1UnitV,
-                                              V1UnitV, V1UnitV, V1UnitV]>;
-let Latency = 11, NumMicroOps = 10 in
-def V1Write_11c_10V0         : SchedWriteRes<[V1UnitV0,
-                                              V1UnitV0, V1UnitV0, V1UnitV0,
-                                              V1UnitV0, V1UnitV0, V1UnitV0,
-                                              V1UnitV0, V1UnitV0, V1UnitV0]>;
-
-//===----------------------------------------------------------------------===//
-// Define generic 12 micro-op types
-
-let Latency = 7, NumMicroOps = 12 in
-def V1Write_7c_6L01_6V01 : SchedWriteRes<[V1UnitL01, V1UnitL01, V1UnitL01,
-                                          V1UnitL01, V1UnitL01, V1UnitL01,
-                                          V1UnitV01, V1UnitV01, V1UnitV01,
-                                          V1UnitV01, V1UnitV01, V1UnitV01]>;
-
-//===----------------------------------------------------------------------===//
-// Define generic 15 micro-op types
-
-let Latency = 7, NumMicroOps = 15 in
-def V1Write_7c_5L01_5S_5V : SchedWriteRes<[V1UnitL01, V1UnitL01,
-                                           V1UnitL01, V1UnitL01, V1UnitL01,
-                                           V1UnitS, V1UnitS,
-                                           V1UnitS, V1UnitS, V1UnitS,
-                                           V1UnitV, V1UnitV,
-                                           V1UnitV, V1UnitV, V1UnitV]>;
-
-
-//===----------------------------------------------------------------------===//
-// Define generic 18 micro-op types
-
-let Latency = 19, NumMicroOps = 18 in
-def V1Write_11c_9L01_9V : SchedWriteRes<[V1UnitL01, V1UnitL01, V1UnitL01,
-                                         V1UnitL01, V1UnitL01, V1UnitL01, 
-                                         V1UnitL01, V1UnitL01, V1UnitL01,
-                                         V1UnitV, V1UnitV, V1UnitV, 
-                                         V1UnitV, V1UnitV, V1UnitV,
-                                         V1UnitV, V1UnitV, V1UnitV]>;
-let Latency = 19, NumMicroOps = 18 in
-def V1Write_19c_18V0    : SchedWriteRes<[V1UnitV0, V1UnitV0, V1UnitV0,
-                                         V1UnitV0, V1UnitV0, V1UnitV0, 
-                                         V1UnitV0, V1UnitV0, V1UnitV0,
-                                         V1UnitV0, V1UnitV0, V1UnitV0, 
-                                         V1UnitV0, V1UnitV0, V1UnitV0,
-                                         V1UnitV0, V1UnitV0, V1UnitV0]>;
-
-//===----------------------------------------------------------------------===//
-// Define generic 27 micro-op types
-
-let Latency = 11, NumMicroOps = 27 in
-def V1Write_11c_9L01_9S_9V : SchedWriteRes<[V1UnitL01, V1UnitL01, V1UnitL01,
-                                            V1UnitL01, V1UnitL01, V1UnitL01, 
-                                            V1UnitL01, V1UnitL01, V1UnitL01,
-                                            V1UnitS, V1UnitS, V1UnitS, 
-                                            V1UnitS, V1UnitS, V1UnitS,
-                                            V1UnitS, V1UnitS, V1UnitS,
-                                            V1UnitV, V1UnitV, V1UnitV, 
-                                            V1UnitV, V1UnitV, V1UnitV,
-                                            V1UnitV, V1UnitV, V1UnitV]>;
+let Latency = 14, NumMicroOps = 4, ReleaseAtCycles = [1,1,2,1] in
+def V1Write_14c2_1V_1V0_2V1_1V13 : SchedWriteRes<[V1UnitV,
+						  V1UnitV0,
+						  V1UnitV1,
+						  V1UnitV13]>;
 
 //===----------------------------------------------------------------------===//
 // Define predicate-controlled types
@@ -905,7 +787,7 @@ def : InstRW<[WriteAdr, V1Write_2c_1L01_1V01],
 
 // Store vector pair, immed post-index, Q-form
 // Store vector pair, immed pre-index, Q-form
-def : InstRW<[WriteAdr, V1Write_2c_2L01_1V01], (instrs STPQpre, STPQpost)>;
+def : InstRW<[WriteAdr, V1Write_2c2_2L01_1V01], (instrs STPQpre, STPQpost)>;
 
 
 // ASIMD integer instructions
@@ -939,7 +821,7 @@ def : InstRW<[V1Write_4c_1V13_1V], (instregex "^(ADD|[SU]ADDL)Vv8(i8|i16)v$",
 
 // ASIMD arith, reduce, 16B
 // ASIMD max/min, reduce, 16B
-def : InstRW<[V1Write_4c_2V13], (instregex "^(ADD|[SU]ADDL)Vv16i8v$",
+def : InstRW<[V1Write_4c2_1V13], (instregex "^(ADD|[SU]ADDL)Vv16i8v$",
                                            "[SU](MAX|MIN)Vv16i8v$")>;
 
 // ASIMD dot product
@@ -1016,13 +898,13 @@ def : InstRW<[V1Wr_FPMA, V1Rd_FPMA], (instregex "^FML[AS]v")>;
 def : InstRW<[V1Wr_FPMAL, V1Rd_FPMAL], (instregex "^FML[AS]L2?v")>;
 
 // ASIMD FP convert, long (F16 to F32)
-def : InstRW<[V1Write_4c_2V02], (instregex "^FCVTLv[48]i16$")>;
+def : InstRW<[V1Write_4c2_1V02], (instregex "^FCVTLv[48]i16$")>;
 
 // ASIMD FP convert, long (F32 to F64)
 def : InstRW<[V1Write_3c_1V02], (instregex "^FCVTLv[24]i32$")>;
 
 // ASIMD FP convert, narrow (F32 to F16)
-def : InstRW<[V1Write_4c_2V02], (instregex "^FCVTNv[48]i16$")>;
+def : InstRW<[V1Write_4c2_1V02], (instregex "^FCVTNv[48]i16$")>;
 
 // ASIMD FP convert, narrow (F64 to F32)
 def : InstRW<[V1Write_3c_1V02], (instregex "^FCVTNv[24]i32$",
@@ -1039,7 +921,7 @@ def : InstRW<[V1Write_3c_1V02], (instregex "^FCVT[AMNPZ][SU]v2f(32|64)$",
                                            "^[SU]CVTFd$")>;
 
 // ASIMD FP convert, other, D-form F16 and Q-form F32
-def : InstRW<[V1Write_4c_2V02], (instregex "^FCVT[AMNPZ][SU]v4f(16|32)$",
+def : InstRW<[V1Write_4c2_1V02], (instregex "^FCVT[AMNPZ][SU]v4f(16|32)$",
                                            "^FCVT[AMNPZ][SU]v4i(16|32)_shift$",
                                            "^FCVT[AMNPZ][SU]v1i32$",
                                            "^FCVTZ[SU]s$",
@@ -1049,7 +931,7 @@ def : InstRW<[V1Write_4c_2V02], (instregex "^FCVT[AMNPZ][SU]v4f(16|32)$",
                                            "^[SU]CVTFs$")>;
 
 // ASIMD FP convert, other, Q-form F16
-def : InstRW<[V1Write_6c_4V02], (instregex "^FCVT[AMNPZ][SU]v8f16$",
+def : InstRW<[V1Write_6c2_1V02], (instregex "^FCVT[AMNPZ][SU]v8f16$",
                                            "^FCVT[AMNPZ][SU]v8i16_shift$",
                                            "^FCVT[AMNPZ][SU]v1f16$",
                                            "^FCVTZ[SU]h$",
@@ -1080,19 +962,19 @@ def : InstRW<[V1Write_13c11_1V02], (instrs FSQRTv8f16)>;
 def : InstRW<[V1Write_16c7_1V02], (instrs FSQRTv2f64)>;
 
 // ASIMD FP max/min, reduce, F32 and D-form F16
-def : InstRW<[V1Write_4c_2V], (instregex "^F(MAX|MIN)(NM)?Vv4(i16|i32)v$")>;
+def : InstRW<[V1Write_4c2_1V], (instregex "^F(MAX|MIN)(NM)?Vv4(i16|i32)v$")>;
 
 // ASIMD FP max/min, reduce, Q-form F16
-def : InstRW<[V1Write_6c_3V], (instregex "^F(MAX|MIN)(NM)?Vv8i16v$")>;
+def : InstRW<[V1Write_6c3_1V], (instregex "^F(MAX|MIN)(NM)?Vv8i16v$")>;
 
 // ASIMD FP round, D-form F32 and Q-form F64
 def : InstRW<[V1Write_3c_1V02], (instregex "^FRINT[AIMNPXZ]v2f(32|64)$")>;
 
 // ASIMD FP round, D-form F16 and Q-form F32
-def : InstRW<[V1Write_4c_2V02], (instregex "^FRINT[AIMNPXZ]v4f(16|32)$")>;
+def : InstRW<[V1Write_4c2_1V02], (instregex "^FRINT[AIMNPXZ]v4f(16|32)$")>;
 
 // ASIMD FP round, Q-form F16
-def : InstRW<[V1Write_6c_4V02], (instregex "^FRINT[AIMNPXZ]v8f16$")>;
+def : InstRW<[V1Write_6c2_1V02], (instregex "^FRINT[AIMNPXZ]v8f16$")>;
 
 
 // ASIMD BF instructions
@@ -1158,7 +1040,7 @@ def : InstRW<[V1Write_4c_1V02], (instrs URECPEv4i32,
                                         FRSQRTEv4f32, FRSQRTEv2f64)>;
 
 // ASIMD reciprocal and square root estimate, Q-form F16
-def : InstRW<[V1Write_6c_2V02], (instrs FRECPEv8f16,
+def : InstRW<[V1Write_6c2_1V02], (instrs FRECPEv8f16,
                                         FRSQRTEv8f16)>;
 
 // ASIMD reciprocal exponent
@@ -1170,22 +1052,22 @@ def : InstRW<[V1Write_4c_1V], (instregex "^FRECPS(16|32|64)$", "^FRECPSv",
 
 // ASIMD table lookup, 1 or 2 table regs
 // ASIMD table lookup extension, 1 table reg
-def : InstRW<[V1Write_2c_2V01], (instregex "^TBLv(8|16)i8(One|Two)$",
+def : InstRW<[V1Write_2c2_1V01], (instregex "^TBLv(8|16)i8(One|Two)$",
                                            "^TBXv(8|16)i8One$")>;
 
 // ASIMD table lookup, 3 table regs
 // ASIMD table lookup extension, 2 table reg
-def : InstRW<[V1Write_4c_2V01], (instrs TBLv8i8Three, TBLv16i8Three,
+def : InstRW<[V1Write_4c2_1V01], (instrs TBLv8i8Three, TBLv16i8Three,
                                         TBXv8i8Two, TBXv16i8Two)>;
 
 // ASIMD table lookup, 4 table regs
-def : InstRW<[V1Write_4c_3V01], (instrs TBLv8i8Four, TBLv16i8Four)>;
+def : InstRW<[V1Write_4c3_1V01], (instrs TBLv8i8Four, TBLv16i8Four)>;
 
 // ASIMD table lookup extension, 3 table reg
-def : InstRW<[V1Write_6c_3V01], (instrs TBXv8i8Three, TBXv16i8Three)>;
+def : InstRW<[V1Write_6c3_1V01], (instrs TBXv8i8Three, TBXv16i8Three)>;
 
 // ASIMD table lookup extension, 4 table reg
-def : InstRW<[V1Write_6c_5V01], (instrs TBXv8i8Four, TBXv16i8Four)>;
+def : InstRW<[V1Write_6c5_1V01], (instrs TBXv8i8Four, TBXv16i8Four)>;
 
 // ASIMD transfer, element to gen reg
 def : InstRW<[V1Write_2c_1V], (instregex "^SMOVvi(((8|16)to(32|64))|32to64)$",
@@ -1205,27 +1087,27 @@ def : InstRW<[WriteAdr, V1Write_6c_1L],
              (instregex "^LD1Onev(8b|16b|4h|8h|2s|4s|1d|2d)_POST$")>;
 
 // ASIMD load, 1 element, multiple, 2 reg
-def : InstRW<[V1Write_6c_2L],
+def : InstRW<[V1Write_6c2_1L],
              (instregex "^LD1Twov(8b|16b|4h|8h|2s|4s|1d|2d)$")>;
-def : InstRW<[WriteAdr, V1Write_6c_2L],
+def : InstRW<[WriteAdr, V1Write_6c2_1L],
              (instregex "^LD1Twov(8b|16b|4h|8h|2s|4s|1d|2d)_POST$")>;
 
 // ASIMD load, 1 element, multiple, 3 reg
-def : InstRW<[V1Write_6c_3L],
+def : InstRW<[V1Write_6c3_1L],
              (instregex "^LD1Threev(8b|16b|4h|8h|2s|4s|1d|2d)$")>;
-def : InstRW<[WriteAdr, V1Write_6c_3L],
+def : InstRW<[WriteAdr, V1Write_6c3_1L],
              (instregex "^LD1Threev(8b|16b|4h|8h|2s|4s|1d|2d)_POST$")>;
 
 // ASIMD load, 1 element, multiple, 4 reg, D-form
-def : InstRW<[V1Write_6c_2L],
+def : InstRW<[V1Write_6c2_1L],
              (instregex "^LD1Fourv(8b|4h|2s|1d)$")>;
-def : InstRW<[WriteAdr, V1Write_6c_2L],
+def : InstRW<[WriteAdr, V1Write_6c2_1L],
              (instregex "^LD1Fourv(8b|4h|2s|1d)_POST$")>;
 
 // ASIMD load, 1 element, multiple, 4 reg, Q-form
-def : InstRW<[V1Write_7c_4L],
+def : InstRW<[V1Write_7c4_1L],
              (instregex "^LD1Fourv(16b|8h|4s|2d)$")>;
-def : InstRW<[WriteAdr, V1Write_7c_4L],
+def : InstRW<[WriteAdr, V1Write_7c4_1L],
              (instregex "^LD1Fourv(16b|8h|4s|2d)_POST$")>;
 
 // ASIMD load, 1 element, one lane
@@ -1238,60 +1120,60 @@ def : InstRW<[WriteAdr, V1Write_8c_1L_1V],
                         "^LD1Rv(8b|16b|4h|8h|2s|4s|1d|2d)_POST$")>;
 
 // ASIMD load, 2 element, multiple, D-form
-def : InstRW<[V1Write_8c_1L_2V],
+def : InstRW<[V1Write_8c2_1L_2V],
              (instregex "^LD2Twov(8b|4h|2s)$")>;
-def : InstRW<[WriteAdr, V1Write_8c_1L_2V],
+def : InstRW<[WriteAdr, V1Write_8c2_1L_2V],
              (instregex "^LD2Twov(8b|4h|2s)_POST$")>;
                         
 // ASIMD load, 2 element, multiple, Q-form
-def : InstRW<[V1Write_8c_2L_2V],
+def : InstRW<[V1Write_8c2_1L_1V],
              (instregex "^LD2Twov(16b|8h|4s|2d)$")>;
-def : InstRW<[WriteAdr, V1Write_8c_2L_2V],
+def : InstRW<[WriteAdr, V1Write_8c2_1L_1V],
              (instregex "^LD2Twov(16b|8h|4s|2d)_POST$")>;
                         
 // ASIMD load, 2 element, one lane
 // ASIMD load, 2 element, all lanes
-def : InstRW<[V1Write_8c_1L_2V],
+def : InstRW<[V1Write_8c2_1L_2V],
              (instregex "^LD2i(8|16|32|64)$",
                         "^LD2Rv(8b|16b|4h|8h|2s|4s|1d|2d)$")>;
-def : InstRW<[WriteAdr, V1Write_8c_1L_2V],
+def : InstRW<[WriteAdr, V1Write_8c2_1L_2V],
              (instregex "^LD2i(8|16|32|64)_POST$",
                         "^LD2Rv(8b|16b|4h|8h|2s|4s|1d|2d)_POST$")>;
                         
 // ASIMD load, 3 element, multiple, D-form
 // ASIMD load, 3 element, one lane
 // ASIMD load, 3 element, all lanes
-def : InstRW<[V1Write_8c_2L_3V],
+def : InstRW<[V1Write_8c3_2L_3V],
              (instregex "^LD3Threev(8b|4h|2s)$",
                         "^LD3i(8|16|32|64)$",
                         "^LD3Rv(8b|16b|4h|8h|2s|4s|1d|2d)$")>;
-def : InstRW<[WriteAdr, V1Write_8c_2L_3V],
+def : InstRW<[WriteAdr, V1Write_8c3_2L_3V],
              (instregex "^LD3Threev(8b|4h|2s)_POST$",
                         "^LD3i(8|16|32|64)_POST$",
                         "^LD3Rv(8b|16b|4h|8h|2s|4s|1d|2d)_POST$")>;
 
 // ASIMD load, 3 element, multiple, Q-form
-def : InstRW<[V1Write_8c_3L_3V],
+def : InstRW<[V1Write_8c3_1L_1V],
              (instregex "^LD3Threev(16b|8h|4s|2d)$")>;
-def : InstRW<[WriteAdr, V1Write_8c_3L_3V],
+def : InstRW<[WriteAdr, V1Write_8c3_1L_1V],
              (instregex "^LD3Threev(16b|8h|4s|2d)_POST$")>;
 
 // ASIMD load, 4 element, multiple, D-form
 // ASIMD load, 4 element, one lane
 // ASIMD load, 4 element, all lanes
-def : InstRW<[V1Write_8c_3L_4V],
+def : InstRW<[V1Write_8c4_3L_4V],
              (instregex "^LD4Fourv(8b|4h|2s)$",
                         "^LD4i(8|16|32|64)$",
                         "^LD4Rv(8b|16b|4h|8h|2s|4s|1d|2d)$")>;
-def : InstRW<[WriteAdr, V1Write_8c_3L_4V],
+def : InstRW<[WriteAdr, V1Write_8c4_3L_4V],
              (instregex "^LD4Fourv(8b|4h|2s)_POST$",
                         "^LD4i(8|16|32|64)_POST$",
                         "^LD4Rv(8b|16b|4h|8h|2s|4s|1d|2d)_POST$")>;
 
 // ASIMD load, 4 element, multiple, Q-form
-def : InstRW<[V1Write_9c_4L_4V],
+def : InstRW<[V1Write_9c4_1L_1V],
              (instregex "^LD4Fourv(16b|8h|4s|2d)$")>;
-def : InstRW<[WriteAdr, V1Write_9c_4L_4V],
+def : InstRW<[WriteAdr, V1Write_9c4_1L_1V],
              (instregex "^LD4Fourv(16b|8h|4s|2d)_POST$")>;
 
 
@@ -1310,25 +1192,25 @@ def : InstRW<[WriteAdr, V1Write_2c_1L01_1V01],
 // ASIMD store, 1 element, multiple, 2 reg, Q-form
 // ASIMD store, 1 element, multiple, 3 reg, D-form
 // ASIMD store, 1 element, multiple, 4 reg, D-form
-def : InstRW<[V1Write_2c_2L01_2V01],
+def : InstRW<[V1Write_2c2_1L01_1V01],
              (instregex "^ST1Twov(16b|8h|4s|2d)$",
                         "^ST1Threev(8b|4h|2s|1d)$",
                         "^ST1Fourv(8b|4h|2s|1d)$")>;
-def : InstRW<[WriteAdr, V1Write_2c_2L01_2V01],
+def : InstRW<[WriteAdr, V1Write_2c2_1L01_1V01],
              (instregex "^ST1Twov(16b|8h|4s|2d)_POST$",
                         "^ST1Threev(8b|4h|2s|1d)_POST$",
                         "^ST1Fourv(8b|4h|2s|1d)_POST$")>;
 
 // ASIMD store, 1 element, multiple, 3 reg, Q-form
-def : InstRW<[V1Write_2c_3L01_3V01],
+def : InstRW<[V1Write_2c3_1L01_1V01],
              (instregex "^ST1Threev(16b|8h|4s|2d)$")>;
-def : InstRW<[WriteAdr, V1Write_2c_3L01_3V01],
+def : InstRW<[WriteAdr, V1Write_2c3_1L01_1V01],
              (instregex "^ST1Threev(16b|8h|4s|2d)_POST$")>;
 
 // ASIMD store, 1 element, multiple, 4 reg, Q-form
-def : InstRW<[V1Write_2c_4L01_4V01],
+def : InstRW<[V1Write_2c4_1L01_1V01],
              (instregex "^ST1Fourv(16b|8h|4s|2d)$")>;
-def : InstRW<[WriteAdr, V1Write_2c_4L01_4V01],
+def : InstRW<[WriteAdr, V1Write_2c4_1L01_1V01],
              (instregex "^ST1Fourv(16b|8h|4s|2d)_POST$")>;
 
 // ASIMD store, 1 element, one lane
@@ -1347,45 +1229,45 @@ def : InstRW<[WriteAdr, V1Write_4c_1L01_1V01],
 // ASIMD store, 3 element, multiple, D-form
 // ASIMD store, 3 element, one lane
 // ASIMD store, 4 element, one lane, D
-def : InstRW<[V1Write_4c_2L01_2V01],
+def : InstRW<[V1Write_4c2_1L01_1V01],
              (instregex "^ST2Twov(16b|8h|4s|2d)$",
                         "^ST3Threev(8b|4h|2s)$",
                         "^ST3i(8|16|32|64)$",
                         "^ST4i64$")>;
-def : InstRW<[WriteAdr, V1Write_4c_2L01_2V01],
+def : InstRW<[WriteAdr, V1Write_4c2_1L01_1V01],
              (instregex "^ST2Twov(16b|8h|4s|2d)_POST$",
                         "^ST3Threev(8b|4h|2s)_POST$",
                         "^ST3i(8|16|32|64)_POST$",
                         "^ST4i64_POST$")>;
 
 // ASIMD store, 3 element, multiple, Q-form
-def : InstRW<[V1Write_5c_3L01_3V01],
+def : InstRW<[V1Write_5c3_1L01_1V01],
              (instregex "^ST3Threev(16b|8h|4s|2d)$")>;
-def : InstRW<[WriteAdr, V1Write_5c_3L01_3V01],
+def : InstRW<[WriteAdr, V1Write_5c3_1L01_1V01],
              (instregex "^ST3Threev(16b|8h|4s|2d)_POST$")>;
 
 // ASIMD store, 4 element, multiple, D-form
-def : InstRW<[V1Write_6c_3L01_3V01],
+def : InstRW<[V1Write_6c3_1L01_1V01],
              (instregex "^ST4Fourv(8b|4h|2s)$")>;
-def : InstRW<[WriteAdr, V1Write_6c_3L01_3V01],
+def : InstRW<[WriteAdr, V1Write_6c3_1L01_1V01],
              (instregex "^ST4Fourv(8b|4h|2s)_POST$")>;
 
 // ASIMD store, 4 element, multiple, Q-form, B/H/S
-def : InstRW<[V1Write_7c_6L01_6V01],
+def : InstRW<[V1Write_7c6_1L01_1V01],
              (instregex "^ST4Fourv(16b|8h|4s)$")>;
-def : InstRW<[WriteAdr, V1Write_7c_6L01_6V01],
+def : InstRW<[WriteAdr, V1Write_7c6_1L01_1V01],
              (instregex "^ST4Fourv(16b|8h|4s)_POST$")>;
 
 // ASIMD store, 4 element, multiple, Q-form, D
-def : InstRW<[V1Write_4c_4L01_4V01],
+def : InstRW<[V1Write_4c4_1L01_1V01],
              (instrs ST4Fourv2d)>;
-def : InstRW<[WriteAdr, V1Write_4c_4L01_4V01],
+def : InstRW<[WriteAdr, V1Write_4c4_1L01_1V01],
              (instrs ST4Fourv2d_POST)>;
 
 // ASIMD store, 4 element, one lane, B/H/S
-def : InstRW<[V1Write_6c_3L_3V],
+def : InstRW<[V1Write_6c3_1L_1V],
              (instregex "^ST4i(8|16|32)$")>;
-def : InstRW<[WriteAdr, V1Write_6c_3L_3V],
+def : InstRW<[WriteAdr, V1Write_6c3_1L_1V],
              (instregex "^ST4i(8|16|32)_POST$")>;
 
 
@@ -1437,11 +1319,11 @@ def : InstRW<[V1Write_2c_1M0], (instregex "^BRK[AB]_PP[mz]P$")>;
 def : InstRW<[V1Write_2c_1M0], (instrs BRKN_PPzP, BRKPA_PPzPP, BRKPB_PPzPP)>;
 
 // Loop control, based on predicate and flag setting
-def : InstRW<[V1Write_3c_2M0], (instrs BRKAS_PPzP, BRKBS_PPzP, BRKNS_PPzP,
+def : InstRW<[V1Write_3c2_1M0], (instrs BRKAS_PPzP, BRKBS_PPzP, BRKNS_PPzP,
                                        BRKPAS_PPzPP, BRKPBS_PPzPP)>;
 
 // Loop control, based on GPR
-def : InstRW<[V1Write_3c_2M0], (instregex "^WHILE(LE|LO|LS|LT)_P(WW|XX)_[BHSD]$")>;
+def : InstRW<[V1Write_3c2_1M0], (instregex "^WHILE(LE|LO|LS|LT)_P(WW|XX)_[BHSD]$")>;
 
 // Loop terminate
 def : InstRW<[V1Write_1c_1M0], (instregex "^CTERM(EQ|NE)_(WW|XX)$")>;
@@ -1458,14 +1340,14 @@ def : InstRW<[V1Write_2c_1M0], (instregex "^(CNT|([SU]Q)?(DEC|INC))[BHWD]_XPiI$"
                                           "^[SU]Q(DEC|INC)P_XPWd_[BHSD]$")>;
 
 // Predicate counting vector, active predicate
-def : InstRW<[V1Write_7c_2M0_1V01], (instregex "^([SU]Q)?(DEC|INC)P_ZP_[HSD]$")>;
+def : InstRW<[V1Write_7c2_2M0_1V01], (instregex "^([SU]Q)?(DEC|INC)P_ZP_[HSD]$")>;
 
 // Predicate logical
 def : InstRW<[V1Write_1c_1M0],
              (instregex "^(AND|BIC|EOR|NAND|NOR|ORN|ORR)_PPzPP$")>;
 
 // Predicate logical, flag setting
-def : InstRW<[V1Write_2c_2M0],
+def : InstRW<[V1Write_2c2_1M0],
              (instregex "^(AND|BIC|EOR|NAND|NOR|ORN|ORR)S_PPzPP$")>;
 
 // Predicate reverse
@@ -1488,7 +1370,7 @@ def : InstRW<[V1Write_2c_1M0], (instrs PTEST_PP, PTEST_PP_ANY, PTEST_PP_FIRST,
 def : InstRW<[V1Write_1c_1M0], (instrs SEL_PPPP)>;
 
 // Predicate set/initialize, set flags
-def : InstRW<[V1Write_3c_2M0], (instregex "^PTRUES_[BHSD]$")>;
+def : InstRW<[V1Write_3c2_1M0], (instregex "^PTRUES_[BHSD]$")>;
 
 
 
@@ -1546,10 +1428,10 @@ def : InstRW<[V1Write_3c_1V0], (instregex "^[SU]CVTF_ZPmZ_Dto[HSD]",
                                           "^[SU]CVTF_ZPmZ_StoD")>;
 
 // Convert to floating point, 32b to single or half
-def : InstRW<[V1Write_4c_2V0], (instregex "^[SU]CVTF_ZPmZ_Sto[HS]")>;
+def : InstRW<[V1Write_4c2_1V0], (instregex "^[SU]CVTF_ZPmZ_Sto[HS]")>;
 
 // Convert to floating point, 16b to half
-def : InstRW<[V1Write_6c_4V0], (instregex "^[SU]CVTF_ZPmZ_HtoH")>;
+def : InstRW<[V1Write_6c4_1V0], (instregex "^[SU]CVTF_ZPmZ_HtoH")>;
 
 // Copy, scalar
 def : InstRW<[V1Write_5c_1M0_1V01], (instregex "^CPY_ZPmR_[BHSD]$")>;
@@ -1602,13 +1484,13 @@ def : InstRW<[V1Write_6c_1M0_1V1], (instregex "^LAST[AB]_RPZ_[BHSD]$",
 def : InstRW<[V1Write_4c_1V0], (instregex "^INDEX_II_[BHS]$")>;
 
 // Horizontal operations, B, H, S form, scalar, imm / scalar / imm, scalar
-def : InstRW<[V1Write_7c_1M0_1V0], (instregex "^INDEX_(IR|RI|RR)_[BHS]$")>;
+def : InstRW<[V1Write_7c_1M0_1V1], (instregex "^INDEX_(IR|RI|RR)_[BHS]$")>;
 
 // Horizontal operations, D form, imm, imm
-def : InstRW<[V1Write_5c_2V0], (instrs INDEX_II_D)>;
+def : InstRW<[V1Write_5c2_1V0], (instrs INDEX_II_D)>;
 
 // Horizontal operations, D form, scalar, imm / scalar / imm, scalar
-def : InstRW<[V1Write_8c_2M0_2V0], (instregex "^INDEX_(IR|RI|RR)_D$")>;
+def : InstRW<[V1Write_8c2_1M0_1V0], (instregex "^INDEX_(IR|RI|RR)_D$")>;
 
 // Move prefix
 def : InstRW<[V1Write_2c_1V01], (instregex "^MOVPRFX_ZP[mz]Z_[BHSD]$",
@@ -1624,7 +1506,7 @@ def : InstRW<[V1Write_4c_1V0], (instregex "^MUL_(ZI|ZPmZ|ZZZI|ZZZ)_[BHS]",
                                           "^[SU]MULH_ZPZZ_[BHS]")>;
 
 // Multiply, D element size
-def : InstRW<[V1Write_5c_2V0], (instregex "^MUL_(ZI|ZPmZ|ZZZI|ZZZ)_D",
+def : InstRW<[V1Write_5c2_1V0], (instregex "^MUL_(ZI|ZPmZ|ZZZI|ZZZ)_D",
                                           "^MUL_ZPZZ_D",
                                           "^[SU]MULH_(ZPmZ|ZZZ)_D",
                                           "^[SU]MULH_ZPZZ_D")>;
@@ -1643,15 +1525,15 @@ def : InstRW<[V1Write_4c_1V0], (instregex "^(ML[AS]|MAD|MSB)_(ZPmZZ|ZPZZZ)_[BHS]
 def : InstRW<[V1Write_2c_1V0], (instregex "^([SU]Q)?(DEC|INC)[HWD]_ZPiI$")>;
 
 // Reduction, arithmetic, B form
-def : InstRW<[V1Write_14c_1V_1V0_2V1_1V13],
+def : InstRW<[V1Write_14c2_1V_1V0_2V1_1V13],
              (instregex "^[SU](ADD|MAX|MIN)V_VPZ_B")>;
 
 // Reduction, arithmetic, H form
-def : InstRW<[V1Write_12c_1V_1V01_2V1],
+def : InstRW<[V1Write_12c2_1V_1V01_2V1],
              (instregex "^[SU](ADD|MAX|MIN)V_VPZ_H")>;
 
 // Reduction, arithmetic, S form
-def : InstRW<[V1Write_10c_1V_1V01_2V1],
+def : InstRW<[V1Write_10c2_1V_1V01_2V1],
              (instregex "^[SU](ADD|MAX|MIN)V_VPZ_S")>;
 
 // Reduction, arithmetic, D form
@@ -1659,7 +1541,7 @@ def : InstRW<[V1Write_8c_1V_1V01],
              (instregex "^[SU](ADD|MAX|MIN)V_VPZ_D")>;
 
 // Reduction, logical
-def : InstRW<[V1Write_12c_4V01], (instregex "^(AND|EOR|OR)V_VPZ_[BHSD]$")>;
+def : InstRW<[V1Write_12c4_1V01], (instregex "^(AND|EOR|OR)V_VPZ_[BHSD]$")>;
 
 // Reverse, vector
 def : InstRW<[V1Write_2c_1V01], (instregex "^REV_ZZ_[BHSD]$",
@@ -1697,13 +1579,13 @@ def : InstRW<[V1Write_2c_1V01], (instregex "^F(ADD|SUB)_(ZPm[IZ]|ZZZ)_[HSD]",
                                            "^FSUBR_(ZPZI|ZPZZ)_[HSD]")>;
 
 // Floating point associative add, F16
-def : InstRW<[V1Write_19c_18V0], (instrs FADDA_VPZ_H)>;
+def : InstRW<[V1Write_19c18_1V0], (instrs FADDA_VPZ_H)>;
 
 // Floating point associative add, F32
-def : InstRW<[V1Write_11c_10V0], (instrs FADDA_VPZ_S)>;
+def : InstRW<[V1Write_11c10_1V0], (instrs FADDA_VPZ_S)>;
 
 // Floating point associative add, F64
-def : InstRW<[V1Write_8c_3V01], (instrs FADDA_VPZ_D)>;
+def : InstRW<[V1Write_8c3_1V01], (instrs FADDA_VPZ_D)>;
 
 // Floating point compare
 def : InstRW<[V1Write_2c_1V0], (instregex "^FAC(GE|GT)_PPzZZ_[HSD]$",
@@ -1719,7 +1601,7 @@ def : InstRW<[V1Wr_ZFCMA, V1Rd_ZFCMA],              (instregex "^FCMLA_ZZZI_[HS]
 
 // Floating point convert, long or narrow (F16 to F32 or F32 to F16)
 // Floating point convert to integer, F32
-def : InstRW<[V1Write_4c_2V0], (instregex "^FCVT_ZPmZ_(HtoS|StoH)",
+def : InstRW<[V1Write_4c2_1V0], (instregex "^FCVT_ZPmZ_(HtoS|StoH)",
                                           "^FCVTZ[SU]_ZPmZ_(HtoS|StoS)")>;
 
 // Floating point convert, long or narrow (F16 to F64, F32 to F64, F64 to F32 or F64 to F16)
@@ -1728,7 +1610,7 @@ def : InstRW<[V1Write_3c_1V0], (instregex "^FCVT_ZPmZ_(HtoD|StoD|DtoS|DtoH)",
                                           "^FCVTZ[SU]_ZPmZ_(HtoD|StoD|DtoS|DtoD)")>;
 
 // Floating point convert to integer, F16
-def : InstRW<[V1Write_6c_4V0], (instregex "^FCVTZ[SU]_ZPmZ_HtoH")>;
+def : InstRW<[V1Write_6c4_1V0], (instregex "^FCVTZ[SU]_ZPmZ_HtoH")>;
 
 // Floating point copy
 def : InstRW<[V1Write_2c_1V01], (instregex "^FCPY_ZPmI_[HSD]$",
@@ -1765,10 +1647,10 @@ def : InstRW<[V1Wr_ZFMA, V1Rd_ZFMA],
 def : InstRW<[V1Write_4c_1V01], (instregex "^F(RECPS|RSQRTS)_ZZZ_[HSD]")>;
 
 // Floating point reciprocal estimate, F16
-def : InstRW<[V1Write_6c_4V0], (instrs FRECPE_ZZ_H, FRSQRTE_ZZ_H)>;
+def : InstRW<[V1Write_6c4_1V0], (instrs FRECPE_ZZ_H, FRSQRTE_ZZ_H)>;
 
 // Floating point reciprocal estimate, F32
-def : InstRW<[V1Write_4c_2V0], (instrs FRECPE_ZZ_S, FRSQRTE_ZZ_S)>;
+def : InstRW<[V1Write_4c2_1V0], (instrs FRECPE_ZZ_S, FRSQRTE_ZZ_S)>;
 
 // Floating point reciprocal estimate, F64
 def : InstRW<[V1Write_3c_1V0], (instrs FRECPE_ZZ_D, FRSQRTE_ZZ_D)>;
@@ -1777,13 +1659,13 @@ def : InstRW<[V1Write_3c_1V0], (instrs FRECPE_ZZ_D, FRSQRTE_ZZ_D)>;
 def : InstRW<[V1Write_3c_1V0], (instregex "^FRECPX_ZPmZ_[HSD]")>;
 
 // Floating point reduction, F16
-def : InstRW<[V1Write_13c_6V01], (instregex "^F(ADD|((MAX|MIN)(NM)?))V_VPZ_H$")>;
+def : InstRW<[V1Write_13c6_1V01], (instregex "^F(ADD|((MAX|MIN)(NM)?))V_VPZ_H$")>;
 
 // Floating point reduction, F32
-def : InstRW<[V1Write_11c_1V_5V01], (instregex "^F(ADD|((MAX|MIN)(NM)?))V_VPZ_S$")>;
+def : InstRW<[V1Write_11c5_1V_5V01], (instregex "^F(ADD|((MAX|MIN)(NM)?))V_VPZ_S$")>;
 
 // Floating point reduction, F64
-def : InstRW<[V1Write_9c_1V_4V01], (instregex "^F(ADD|((MAX|MIN)(NM)?))V_VPZ_D$")>;
+def : InstRW<[V1Write_9c4_1V_4V01], (instregex "^F(ADD|((MAX|MIN)(NM)?))V_VPZ_D$")>;
 
 // Floating point round to integral, F16
 def : InstRW<[V1Write_6c_1V0], (instregex "^FRINT[AIMNPXZ]_ZPmZ_H")>;
@@ -1877,37 +1759,37 @@ def : InstRW<[V1Write_6c_1L01], (instregex "^LDNF1[BHWD]_IMM$",
                                            "^LDNF1S?W_D_IMM$")>;
 
 // Contiguous Load two structures to two vectors, scalar + imm
-def : InstRW<[V1Write_8c_2L01_2V01], (instregex "^LD2[BHWD]_IMM$")>;
+def : InstRW<[V1Write_8c2_1L01_1V01], (instregex "^LD2[BHWD]_IMM$")>;
 
 // Contiguous Load two structures to two vectors, scalar + scalar
-def : InstRW<[V1Write_10c_2L01_2V01], (instrs LD2H)>;
-def : InstRW<[V1Write_9c_2L01_2V01],  (instregex "^LD2[BWD]$")>;
+def : InstRW<[V1Write_10c2_1L01_1V01], (instrs LD2H)>;
+def : InstRW<[V1Write_9c2_1L01_1V01],  (instregex "^LD2[BWD]$")>;
 
 // Contiguous Load three structures to three vectors, scalar + imm
-def : InstRW<[V1Write_11c_3L01_3V01], (instregex "^LD3[BHWD]_IMM$")>;
+def : InstRW<[V1Write_11c3_1L01_1V01], (instregex "^LD3[BHWD]_IMM$")>;
 
 // Contiguous Load three structures to three vectors, scalar + scalar
-def : InstRW<[V1Write_13c_3L01_1S_3V01], (instregex "^LD3[BHWD]$")>;
+def : InstRW<[V1Write_8c3_3L01_1S_3V01], (instregex "^LD3[BHWD]$")>;
 
 // Contiguous Load four structures to four vectors, scalar + imm
-def : InstRW<[V1Write_12c_4L01_4V01], (instregex "^LD4[BHWD]_IMM$")>;
+def : InstRW<[V1Write_12c4_1L01_1V01], (instregex "^LD4[BHWD]_IMM$")>;
 
 // Contiguous Load four structures to four vectors, scalar + scalar
-def : InstRW<[V1Write_13c_4L01_2S_4V01], (instregex "^LD4[BHWD]$")>;
+def : InstRW<[V1Write_13c4_4L01_2S_4V01], (instregex "^LD4[BHWD]$")>;
 
 // Gather load, vector + imm, 32-bit element size
 def : InstRW<[V1Write_11c_1L_1V], (instregex "^GLD(FF)?1S?[BH]_S_IMM$",
                                              "^GLD(FF)?1W_IMM$")>;
 
 // Gather load, vector + imm, 64-bit element size
-def : InstRW<[V1Write_9c_2L_2V],
+def : InstRW<[V1Write_9c2_1L_1V],
              (instregex "^GLD(FF)?1S?[BHW]_D_IMM$",
                         "^GLD(FF)?1S?[BHW]_D(_[SU]XTW)?(_SCALED)?$",
                         "^GLD(FF)?1D_IMM$",
                         "^GLD(FF)?1D(_[SU]XTW)?(_SCALED)?$")>;
 
 // Gather load, 32-bit scaled offset
-def : InstRW<[V1Write_11c_2L_2V],
+def : InstRW<[V1Write_11c2_1L_1V],
              (instregex "^GLD(FF)?1S?[HW]_S_[SU]XTW_SCALED$",
                         "^GLD(FF)?1W_[SU]XTW_SCALED")>;
 
@@ -1948,16 +1830,16 @@ def : InstRW<[V1Write_4c_1L01_1V], (instregex "^ST2[BHWD]_IMM$",
 def : InstRW<[V1Write_4c_1L01_1S_1V], (instrs ST2H)>;
 
 // Contiguous store three structures from three vectors, scalar + imm
-def : InstRW<[V1Write_7c_5L01_5V], (instregex "^ST3[BHWD]_IMM$")>;
+def : InstRW<[V1Write_7c5_1L01_1V], (instregex "^ST3[BHWD]_IMM$")>;
 
 // Contiguous store three structures from three vectors, scalar + scalar
-def : InstRW<[V1Write_7c_5L01_5S_5V], (instregex "^ST3[BHWD]$")>;
+def : InstRW<[V1Write_7c5_1L01_1S_1V], (instregex "^ST3[BHWD]$")>;
 
 // Contiguous store four structures from four vectors, scalar + imm
-def : InstRW<[V1Write_11c_9L01_9V], (instregex "^ST4[BHWD]_IMM$")>;
+def : InstRW<[V1Write_19c9_1L01_1V], (instregex "^ST4[BHWD]_IMM$")>;
 
 // Contiguous store four structures from four vectors, scalar + scalar
-def : InstRW<[V1Write_11c_9L01_9S_9V], (instregex "^ST4[BHWD]$")>;
+def : InstRW<[V1Write_11c9_1L01_1S_1V], (instregex "^ST4[BHWD]$")>;
 
 // Non temporal store, scalar + imm
 // Non temporal store, scalar + scalar
@@ -1968,7 +1850,7 @@ def : InstRW<[V1Write_2c_1L01_1S_1V], (instrs STNT1H_ZRR)>;
 // Scatter store vector + imm 32-bit element size
 // Scatter store, 32-bit scaled offset
 // Scatter store, 32-bit unscaled offset
-def : InstRW<[V1Write_10c_2L01_2V], (instregex "^SST1[BH]_S_IMM$",
+def : InstRW<[V1Write_10c2_1L01_1V], (instregex "^SST1[BH]_S_IMM$",
                                                "^SST1W_IMM$",
                                                "^SST1(H_S|W)_[SU]XTW_SCALED$",
                                                "^SST1[BH]_S_[SU]XTW$",
@@ -2003,7 +1885,7 @@ def : InstRW<[V1Write_2c_1M0], (instrs RDFFR_P,
                                        WRFFR)>;
 
 // Read first fault register, predicated
-def : InstRW<[V1Write_3c_2M0], (instrs RDFFR_PPz)>;
+def : InstRW<[V1Write_3c2_1M0], (instrs RDFFR_PPz)>;
 
 // Read first fault register and set flags
 def : InstRW<[V1Write_4c_1M], (instrs RDFFRS_PPz)>;

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/V1-basic-instructions.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/V1-basic-instructions.s
@@ -1140,8 +1140,8 @@
 # CHECK-NEXT:  3      2     0.50           *            stp	d3, d5, [x9], #504
 # CHECK-NEXT:  3      2     0.50           *            stp	d7, d11, [x10], #-512
 # CHECK-NEXT:  2      6     0.33    *                   ldp	d2, d3, [x30], #-8
-# CHECK-NEXT:  4      2     1.00           *            stp	q3, q5, [sp], #0
-# CHECK-NEXT:  4      2     1.00           *            stp	q17, q19, [sp], #1008
+# CHECK-NEXT:  3      2     1.00           *            stp	q3, q5, [sp], #0
+# CHECK-NEXT:  3      2     1.00           *            stp	q17, q19, [sp], #1008
 # CHECK-NEXT:  3      6     0.67    *                   ldp	q23, q29, [x1], #-1024
 # CHECK-NEXT:  2      4     0.33    *                   ldp	w3, w5, [sp, #0]!
 # CHECK-NEXT:  3      1     0.50           *            stp	wzr, w9, [sp, #252]!
@@ -1159,8 +1159,8 @@
 # CHECK-NEXT:  3      2     0.50           *            stp	d3, d5, [x9, #504]!
 # CHECK-NEXT:  3      2     0.50           *            stp	d7, d11, [x10, #-512]!
 # CHECK-NEXT:  2      6     0.33    *                   ldp	d2, d3, [x30, #-8]!
-# CHECK-NEXT:  4      2     1.00           *            stp	q3, q5, [sp, #0]!
-# CHECK-NEXT:  4      2     1.00           *            stp	q17, q19, [sp, #1008]!
+# CHECK-NEXT:  3      2     1.00           *            stp	q3, q5, [sp, #0]!
+# CHECK-NEXT:  3      2     1.00           *            stp	q17, q19, [sp, #1008]!
 # CHECK-NEXT:  3      6     0.67    *                   ldp	q23, q29, [x1, #-1024]!
 # CHECK-NEXT:  1      4     0.33    *                   ldnp	w3, w5, [sp]
 # CHECK-NEXT:  2      1     0.50           *            stnp	wzr, w9, [sp, #252]

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/V1-forwarding.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/V1-forwarding.s
@@ -921,10 +921,10 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      400
 # CHECK-NEXT: Total Cycles:      1203
-# CHECK-NEXT: Total uOps:        500
+# CHECK-NEXT: Total uOps:        400
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    0.42
+# CHECK-NEXT: uOps Per Cycle:    0.33
 # CHECK-NEXT: IPC:               0.33
 # CHECK-NEXT: Block RThroughput: 2.0
 
@@ -938,8 +938,8 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: [0,3]     D=========eeeER.    .    ..   sdot	z0.s, z0.b, z1.b
 # CHECK-NEXT: [1,0]     D============eeeeeER.    ..   mul	z0.d, p0/m, z0.d, z0.d
 # CHECK-NEXT: [1,1]     D=================eeeER  ..   sdot	z0.s, z1.b, z2.b
-# CHECK-NEXT: [1,2]     .D=================eeeER ..   sdot	z0.s, z1.b, z2.b
-# CHECK-NEXT: [1,3]     .D====================eeeER   sdot	z0.s, z0.b, z1.b
+# CHECK-NEXT: [1,2]     D==================eeeER ..   sdot	z0.s, z1.b, z2.b
+# CHECK-NEXT: [1,3]     D=====================eeeER   sdot	z0.s, z0.b, z1.b
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -950,19 +950,19 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     7.0    0.5    0.0       mul	z0.d, p0/m, z0.d, z0.d
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       sdot	z0.s, z1.b, z2.b
-# CHECK-NEXT: 2.     2     12.5   0.0    0.0       sdot	z0.s, z1.b, z2.b
-# CHECK-NEXT: 3.     2     15.5   0.0    0.0       sdot	z0.s, z0.b, z1.b
-# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
+# CHECK-NEXT: 2.     2     13.0   0.0    0.0       sdot	z0.s, z1.b, z2.b
+# CHECK-NEXT: 3.     2     16.0   0.0    0.0       sdot	z0.s, z0.b, z1.b
+# CHECK-NEXT:        8     12.0   0.1    0.0       <total>
 
 # CHECK:      [18] Code Region - Z sudot
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      400
 # CHECK-NEXT: Total Cycles:      1203
-# CHECK-NEXT: Total uOps:        500
+# CHECK-NEXT: Total uOps:        400
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    0.42
+# CHECK-NEXT: uOps Per Cycle:    0.33
 # CHECK-NEXT: IPC:               0.33
 # CHECK-NEXT: Block RThroughput: 2.0
 
@@ -976,8 +976,8 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: [0,3]     D=========eeeER.    .    ..   sdot	z0.s, z0.b, z1.b[1]
 # CHECK-NEXT: [1,0]     D============eeeeeER.    ..   mul	z0.d, p0/m, z0.d, z0.d
 # CHECK-NEXT: [1,1]     D=================eeeER  ..   sdot	z0.s, z1.b, z2.b[1]
-# CHECK-NEXT: [1,2]     .D=================eeeER ..   sdot	z0.s, z1.b, z2.b[1]
-# CHECK-NEXT: [1,3]     .D====================eeeER   sdot	z0.s, z0.b, z1.b[1]
+# CHECK-NEXT: [1,2]     D==================eeeER ..   sdot	z0.s, z1.b, z2.b[1]
+# CHECK-NEXT: [1,3]     D=====================eeeER   sdot	z0.s, z0.b, z1.b[1]
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -988,19 +988,19 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     7.0    0.5    0.0       mul	z0.d, p0/m, z0.d, z0.d
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       sdot	z0.s, z1.b, z2.b[1]
-# CHECK-NEXT: 2.     2     12.5   0.0    0.0       sdot	z0.s, z1.b, z2.b[1]
-# CHECK-NEXT: 3.     2     15.5   0.0    0.0       sdot	z0.s, z0.b, z1.b[1]
-# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
+# CHECK-NEXT: 2.     2     13.0   0.0    0.0       sdot	z0.s, z1.b, z2.b[1]
+# CHECK-NEXT: 3.     2     16.0   0.0    0.0       sdot	z0.s, z0.b, z1.b[1]
+# CHECK-NEXT:        8     12.0   0.1    0.0       <total>
 
 # CHECK:      [19] Code Region - Z sdot.d
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      400
 # CHECK-NEXT: Total Cycles:      1403
-# CHECK-NEXT: Total uOps:        500
+# CHECK-NEXT: Total uOps:        400
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    0.36
+# CHECK-NEXT: uOps Per Cycle:    0.29
 # CHECK-NEXT: IPC:               0.29
 # CHECK-NEXT: Block RThroughput: 5.0
 
@@ -1014,8 +1014,8 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: [0,3]     D==========eeeeER   .    .    .   sdot	z0.d, z0.h, z1.h
 # CHECK-NEXT: [1,0]     D==============eeeeeER   .    .   mul	z0.d, p0/m, z0.d, z0.d
 # CHECK-NEXT: [1,1]     D===================eeeeER    .   sdot	z0.d, z1.h, z2.h
-# CHECK-NEXT: [1,2]     .D===================eeeeER   .   sdot	z0.d, z1.h, z2.h
-# CHECK-NEXT: [1,3]     .D=======================eeeeER   sdot	z0.d, z0.h, z1.h
+# CHECK-NEXT: [1,2]     D====================eeeeER   .   sdot	z0.d, z1.h, z2.h
+# CHECK-NEXT: [1,3]     D========================eeeeER   sdot	z0.d, z0.h, z1.h
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -1026,19 +1026,19 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     8.0    0.5    0.0       mul	z0.d, p0/m, z0.d, z0.d
 # CHECK-NEXT: 1.     2     13.0   0.0    0.0       sdot	z0.d, z1.h, z2.h
-# CHECK-NEXT: 2.     2     13.5   0.0    0.0       sdot	z0.d, z1.h, z2.h
-# CHECK-NEXT: 3.     2     17.5   0.0    0.0       sdot	z0.d, z0.h, z1.h
-# CHECK-NEXT:        8     13.0   0.1    0.0       <total>
+# CHECK-NEXT: 2.     2     14.0   0.0    0.0       sdot	z0.d, z1.h, z2.h
+# CHECK-NEXT: 3.     2     18.0   0.0    0.0       sdot	z0.d, z0.h, z1.h
+# CHECK-NEXT:        8     13.3   0.1    0.0       <total>
 
 # CHECK:      [20] Code Region - Z smmla
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      400
 # CHECK-NEXT: Total Cycles:      1203
-# CHECK-NEXT: Total uOps:        500
+# CHECK-NEXT: Total uOps:        400
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    0.42
+# CHECK-NEXT: uOps Per Cycle:    0.33
 # CHECK-NEXT: IPC:               0.33
 # CHECK-NEXT: Block RThroughput: 2.0
 
@@ -1052,8 +1052,8 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: [0,3]     D=========eeeER.    .    ..   smmla	z0.s, z0.b, z1.b
 # CHECK-NEXT: [1,0]     D============eeeeeER.    ..   mul	z0.d, p0/m, z0.d, z0.d
 # CHECK-NEXT: [1,1]     D=================eeeER  ..   smmla	z0.s, z1.b, z2.b
-# CHECK-NEXT: [1,2]     .D=================eeeER ..   smmla	z0.s, z1.b, z2.b
-# CHECK-NEXT: [1,3]     .D====================eeeER   smmla	z0.s, z0.b, z1.b
+# CHECK-NEXT: [1,2]     D==================eeeER ..   smmla	z0.s, z1.b, z2.b
+# CHECK-NEXT: [1,3]     D=====================eeeER   smmla	z0.s, z0.b, z1.b
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -1064,19 +1064,19 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     7.0    0.5    0.0       mul	z0.d, p0/m, z0.d, z0.d
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       smmla	z0.s, z1.b, z2.b
-# CHECK-NEXT: 2.     2     12.5   0.0    0.0       smmla	z0.s, z1.b, z2.b
-# CHECK-NEXT: 3.     2     15.5   0.0    0.0       smmla	z0.s, z0.b, z1.b
-# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
+# CHECK-NEXT: 2.     2     13.0   0.0    0.0       smmla	z0.s, z1.b, z2.b
+# CHECK-NEXT: 3.     2     16.0   0.0    0.0       smmla	z0.s, z0.b, z1.b
+# CHECK-NEXT:        8     12.0   0.1    0.0       <total>
 
 # CHECK:      [21] Code Region - Z mla.d
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      400
 # CHECK-NEXT: Total Cycles:      1703
-# CHECK-NEXT: Total uOps:        800
+# CHECK-NEXT: Total uOps:        700
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    0.47
+# CHECK-NEXT: uOps Per Cycle:    0.41
 # CHECK-NEXT: IPC:               0.23
 # CHECK-NEXT: Block RThroughput: 8.0
 
@@ -1088,7 +1088,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: [0,1]     D=====eeeeeER  .    .    .    .    ..   mla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: [0,2]     D=======eeeeeER.    .    .    .    ..   mla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: [0,3]     D============eeeeeER.    .    .    ..   mla	z0.d, p0/m, z0.d, z1.d
-# CHECK-NEXT: [1,0]     .D================eeeeeER.    .    ..   mul	z0.d, p0/m, z0.d, z0.d
+# CHECK-NEXT: [1,0]     D=================eeeeeER.    .    ..   mul	z0.d, p0/m, z0.d, z0.d
 # CHECK-NEXT: [1,1]     .D=====================eeeeeER.    ..   mla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: [1,2]     .D=======================eeeeeER   ..   mla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: [1,3]     .D============================eeeeeER   mla	z0.d, p0/m, z0.d, z1.d
@@ -1100,21 +1100,21 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: [3]: Average time elapsed from WB until retire stage
 
 # CHECK:            [0]    [1]    [2]    [3]
-# CHECK-NEXT: 0.     2     9.0    0.5    0.0       mul	z0.d, p0/m, z0.d, z0.d
+# CHECK-NEXT: 0.     2     9.5    0.5    0.0       mul	z0.d, p0/m, z0.d, z0.d
 # CHECK-NEXT: 1.     2     14.0   0.0    0.0       mla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 2.     2     16.0   0.0    0.0       mla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 3.     2     21.0   0.0    0.0       mla	z0.d, p0/m, z0.d, z1.d
-# CHECK-NEXT:        8     15.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     15.1   0.1    0.0       <total>
 
 # CHECK:      [22] Code Region - Z mad.d
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      400
 # CHECK-NEXT: Total Cycles:      1703
-# CHECK-NEXT: Total uOps:        800
+# CHECK-NEXT: Total uOps:        700
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    0.47
+# CHECK-NEXT: uOps Per Cycle:    0.41
 # CHECK-NEXT: IPC:               0.23
 # CHECK-NEXT: Block RThroughput: 8.0
 
@@ -1126,7 +1126,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: [0,1]     D=====eeeeeER  .    .    .    .    ..   mad	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: [0,2]     D=======eeeeeER.    .    .    .    ..   mad	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: [0,3]     D============eeeeeER.    .    .    ..   mad	z0.d, p0/m, z0.d, z1.d
-# CHECK-NEXT: [1,0]     .D================eeeeeER.    .    ..   mul	z0.d, p0/m, z0.d, z0.d
+# CHECK-NEXT: [1,0]     D=================eeeeeER.    .    ..   mul	z0.d, p0/m, z0.d, z0.d
 # CHECK-NEXT: [1,1]     .D=====================eeeeeER.    ..   mad	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: [1,2]     .D=======================eeeeeER   ..   mad	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: [1,3]     .D============================eeeeeER   mad	z0.d, p0/m, z0.d, z1.d
@@ -1138,21 +1138,21 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: [3]: Average time elapsed from WB until retire stage
 
 # CHECK:            [0]    [1]    [2]    [3]
-# CHECK-NEXT: 0.     2     9.0    0.5    0.0       mul	z0.d, p0/m, z0.d, z0.d
+# CHECK-NEXT: 0.     2     9.5    0.5    0.0       mul	z0.d, p0/m, z0.d, z0.d
 # CHECK-NEXT: 1.     2     14.0   0.0    0.0       mad	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 2.     2     16.0   0.0    0.0       mad	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 3.     2     21.0   0.0    0.0       mad	z0.d, p0/m, z0.d, z1.d
-# CHECK-NEXT:        8     15.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     15.1   0.1    0.0       <total>
 
 # CHECK:      [23] Code Region - Z msb.d
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      400
 # CHECK-NEXT: Total Cycles:      1703
-# CHECK-NEXT: Total uOps:        800
+# CHECK-NEXT: Total uOps:        700
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    0.47
+# CHECK-NEXT: uOps Per Cycle:    0.41
 # CHECK-NEXT: IPC:               0.23
 # CHECK-NEXT: Block RThroughput: 8.0
 
@@ -1164,7 +1164,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: [0,1]     D=====eeeeeER  .    .    .    .    ..   msb	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: [0,2]     D=======eeeeeER.    .    .    .    ..   msb	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: [0,3]     D============eeeeeER.    .    .    ..   msb	z0.d, p0/m, z0.d, z1.d
-# CHECK-NEXT: [1,0]     .D================eeeeeER.    .    ..   mul	z0.d, p0/m, z0.d, z0.d
+# CHECK-NEXT: [1,0]     D=================eeeeeER.    .    ..   mul	z0.d, p0/m, z0.d, z0.d
 # CHECK-NEXT: [1,1]     .D=====================eeeeeER.    ..   msb	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: [1,2]     .D=======================eeeeeER   ..   msb	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: [1,3]     .D============================eeeeeER   msb	z0.d, p0/m, z0.d, z1.d
@@ -1176,11 +1176,11 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: [3]: Average time elapsed from WB until retire stage
 
 # CHECK:            [0]    [1]    [2]    [3]
-# CHECK-NEXT: 0.     2     9.0    0.5    0.0       mul	z0.d, p0/m, z0.d, z0.d
+# CHECK-NEXT: 0.     2     9.5    0.5    0.0       mul	z0.d, p0/m, z0.d, z0.d
 # CHECK-NEXT: 1.     2     14.0   0.0    0.0       msb	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 2.     2     16.0   0.0    0.0       msb	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 3.     2     21.0   0.0    0.0       msb	z0.d, p0/m, z0.d, z1.d
-# CHECK-NEXT:        8     15.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     15.1   0.1    0.0       <total>
 
 # CHECK:      [24] Code Region - Z fcmla ZPmZZ
 

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/V1-neon-instructions.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/V1-neon-instructions.s
@@ -34,7 +34,7 @@
 # CHECK-NEXT:  1      2     0.50                        addv	h0, v0.4h
 # CHECK-NEXT:  2      4     0.50                        addv	h0, v0.8h
 # CHECK-NEXT:  2      4     0.50                        addv	b0, v0.8b
-# CHECK-NEXT:  2      4     1.00                        addv	b0, v0.16b
+# CHECK-NEXT:  1      4     1.00                        addv	b0, v0.16b
 # CHECK-NEXT:  1      2     0.25                        aesd	v0.16b, v0.16b
 # CHECK-NEXT:  1      2     0.25                        aese	v0.16b, v0.16b
 # CHECK-NEXT:  1      2     0.25                        aesimc	v0.16b, v0.16b
@@ -192,112 +192,112 @@
 # CHECK-NEXT:  1      2     0.25                        fcmlt	v8.4h, v2.4h, #0.0
 # CHECK-NEXT:  1      2     0.25                        fcmlt	v7.2d, v16.2d, #0.0
 # CHECK-NEXT:  1      3     0.50                        fcvtas	d21, d14
-# CHECK-NEXT:  2      4     1.00                        fcvtas	s12, s13
-# CHECK-NEXT:  4      6     1.00                        fcvtas	h12, h13
+# CHECK-NEXT:  1      4     1.00                        fcvtas	s12, s13
+# CHECK-NEXT:  1      6     1.00                        fcvtas	h12, h13
 # CHECK-NEXT:  1      3     0.50                        fcvtas	v0.2d, v0.2d
 # CHECK-NEXT:  1      3     0.50                        fcvtas	v0.2s, v0.2s
-# CHECK-NEXT:  2      4     1.00                        fcvtas	v0.4h, v0.4h
-# CHECK-NEXT:  2      4     1.00                        fcvtas	v0.4s, v0.4s
-# CHECK-NEXT:  4      6     1.00                        fcvtas	v0.8h, v0.8h
+# CHECK-NEXT:  1      4     1.00                        fcvtas	v0.4h, v0.4h
+# CHECK-NEXT:  1      4     1.00                        fcvtas	v0.4s, v0.4s
+# CHECK-NEXT:  1      6     1.00                        fcvtas	v0.8h, v0.8h
 # CHECK-NEXT:  1      3     0.50                        fcvtau	d21, d14
-# CHECK-NEXT:  2      4     1.00                        fcvtau	s12, s13
-# CHECK-NEXT:  4      6     1.00                        fcvtau	h12, h13
+# CHECK-NEXT:  1      4     1.00                        fcvtau	s12, s13
+# CHECK-NEXT:  1      6     1.00                        fcvtau	h12, h13
 # CHECK-NEXT:  1      3     0.50                        fcvtau	v0.2d, v0.2d
 # CHECK-NEXT:  1      3     0.50                        fcvtau	v0.2s, v0.2s
-# CHECK-NEXT:  2      4     1.00                        fcvtau	v0.4h, v0.4h
-# CHECK-NEXT:  2      4     1.00                        fcvtau	v0.4s, v0.4s
-# CHECK-NEXT:  4      6     1.00                        fcvtau	v0.8h, v0.8h
+# CHECK-NEXT:  1      4     1.00                        fcvtau	v0.4h, v0.4h
+# CHECK-NEXT:  1      4     1.00                        fcvtau	v0.4s, v0.4s
+# CHECK-NEXT:  1      6     1.00                        fcvtau	v0.8h, v0.8h
 # CHECK-NEXT:  1      3     0.50                        fcvtl	v0.2d, v0.2s
-# CHECK-NEXT:  2      4     1.00                        fcvtl	v0.4s, v0.4h
+# CHECK-NEXT:  1      4     1.00                        fcvtl	v0.4s, v0.4h
 # CHECK-NEXT:  1      3     0.50                        fcvtl2	v0.2d, v0.4s
-# CHECK-NEXT:  2      4     1.00                        fcvtl2	v0.4s, v0.8h
+# CHECK-NEXT:  1      4     1.00                        fcvtl2	v0.4s, v0.8h
 # CHECK-NEXT:  1      3     0.50                        fcvtms	d21, d14
-# CHECK-NEXT:  2      4     1.00                        fcvtms	s22, s13
-# CHECK-NEXT:  4      6     1.00                        fcvtms	h22, h13
+# CHECK-NEXT:  1      4     1.00                        fcvtms	s22, s13
+# CHECK-NEXT:  1      6     1.00                        fcvtms	h22, h13
 # CHECK-NEXT:  1      3     0.50                        fcvtms	v0.2d, v0.2d
 # CHECK-NEXT:  1      3     0.50                        fcvtms	v0.2s, v0.2s
-# CHECK-NEXT:  2      4     1.00                        fcvtms	v0.4h, v0.4h
-# CHECK-NEXT:  2      4     1.00                        fcvtms	v0.4s, v0.4s
-# CHECK-NEXT:  4      6     1.00                        fcvtms	v0.8h, v0.8h
+# CHECK-NEXT:  1      4     1.00                        fcvtms	v0.4h, v0.4h
+# CHECK-NEXT:  1      4     1.00                        fcvtms	v0.4s, v0.4s
+# CHECK-NEXT:  1      6     1.00                        fcvtms	v0.8h, v0.8h
 # CHECK-NEXT:  1      3     0.50                        fcvtmu	d21, d14
-# CHECK-NEXT:  2      4     1.00                        fcvtmu	s12, s13
-# CHECK-NEXT:  4      6     1.00                        fcvtmu	h12, h13
+# CHECK-NEXT:  1      4     1.00                        fcvtmu	s12, s13
+# CHECK-NEXT:  1      6     1.00                        fcvtmu	h12, h13
 # CHECK-NEXT:  1      3     0.50                        fcvtmu	v0.2d, v0.2d
 # CHECK-NEXT:  1      3     0.50                        fcvtmu	v0.2s, v0.2s
-# CHECK-NEXT:  2      4     1.00                        fcvtmu	v0.4h, v0.4h
-# CHECK-NEXT:  2      4     1.00                        fcvtmu	v0.4s, v0.4s
-# CHECK-NEXT:  4      6     1.00                        fcvtmu	v0.8h, v0.8h
+# CHECK-NEXT:  1      4     1.00                        fcvtmu	v0.4h, v0.4h
+# CHECK-NEXT:  1      4     1.00                        fcvtmu	v0.4s, v0.4s
+# CHECK-NEXT:  1      6     1.00                        fcvtmu	v0.8h, v0.8h
 # CHECK-NEXT:  1      3     0.50                        fcvtn	v0.2s, v0.2d
-# CHECK-NEXT:  2      4     1.00                        fcvtn	v0.4h, v0.4s
+# CHECK-NEXT:  1      4     1.00                        fcvtn	v0.4h, v0.4s
 # CHECK-NEXT:  1      3     0.50                        fcvtn2	v0.4s, v0.2d
-# CHECK-NEXT:  2      4     1.00                        fcvtn2	v0.8h, v0.4s
+# CHECK-NEXT:  1      4     1.00                        fcvtn2	v0.8h, v0.4s
 # CHECK-NEXT:  1      3     0.50                        fcvtns	d21, d14
-# CHECK-NEXT:  2      4     1.00                        fcvtns	s22, s13
-# CHECK-NEXT:  4      6     1.00                        fcvtns	h22, h13
+# CHECK-NEXT:  1      4     1.00                        fcvtns	s22, s13
+# CHECK-NEXT:  1      6     1.00                        fcvtns	h22, h13
 # CHECK-NEXT:  1      3     0.50                        fcvtns	v0.2d, v0.2d
 # CHECK-NEXT:  1      3     0.50                        fcvtns	v0.2s, v0.2s
-# CHECK-NEXT:  2      4     1.00                        fcvtns	v0.4h, v0.4h
-# CHECK-NEXT:  2      4     1.00                        fcvtns	v0.4s, v0.4s
-# CHECK-NEXT:  4      6     1.00                        fcvtns	v0.8h, v0.8h
+# CHECK-NEXT:  1      4     1.00                        fcvtns	v0.4h, v0.4h
+# CHECK-NEXT:  1      4     1.00                        fcvtns	v0.4s, v0.4s
+# CHECK-NEXT:  1      6     1.00                        fcvtns	v0.8h, v0.8h
 # CHECK-NEXT:  1      3     0.50                        fcvtnu	d21, d14
-# CHECK-NEXT:  2      4     1.00                        fcvtnu	s12, s13
-# CHECK-NEXT:  4      6     1.00                        fcvtnu	h12, h13
+# CHECK-NEXT:  1      4     1.00                        fcvtnu	s12, s13
+# CHECK-NEXT:  1      6     1.00                        fcvtnu	h12, h13
 # CHECK-NEXT:  1      3     0.50                        fcvtnu	v0.2d, v0.2d
 # CHECK-NEXT:  1      3     0.50                        fcvtnu	v0.2s, v0.2s
-# CHECK-NEXT:  2      4     1.00                        fcvtnu	v0.4h, v0.4h
-# CHECK-NEXT:  2      4     1.00                        fcvtnu	v0.4s, v0.4s
-# CHECK-NEXT:  4      6     1.00                        fcvtnu	v0.8h, v0.8h
+# CHECK-NEXT:  1      4     1.00                        fcvtnu	v0.4h, v0.4h
+# CHECK-NEXT:  1      4     1.00                        fcvtnu	v0.4s, v0.4s
+# CHECK-NEXT:  1      6     1.00                        fcvtnu	v0.8h, v0.8h
 # CHECK-NEXT:  1      3     0.50                        fcvtps	d21, d14
-# CHECK-NEXT:  2      4     1.00                        fcvtps	s22, s13
-# CHECK-NEXT:  4      6     1.00                        fcvtps	h22, h13
+# CHECK-NEXT:  1      4     1.00                        fcvtps	s22, s13
+# CHECK-NEXT:  1      6     1.00                        fcvtps	h22, h13
 # CHECK-NEXT:  1      3     0.50                        fcvtps	v0.2d, v0.2d
 # CHECK-NEXT:  1      3     0.50                        fcvtps	v0.2s, v0.2s
-# CHECK-NEXT:  2      4     1.00                        fcvtps	v0.4h, v0.4h
-# CHECK-NEXT:  2      4     1.00                        fcvtps	v0.4s, v0.4s
-# CHECK-NEXT:  4      6     1.00                        fcvtps	v0.8h, v0.8h
+# CHECK-NEXT:  1      4     1.00                        fcvtps	v0.4h, v0.4h
+# CHECK-NEXT:  1      4     1.00                        fcvtps	v0.4s, v0.4s
+# CHECK-NEXT:  1      6     1.00                        fcvtps	v0.8h, v0.8h
 # CHECK-NEXT:  1      3     0.50                        fcvtpu	d21, d14
-# CHECK-NEXT:  2      4     1.00                        fcvtpu	s12, s13
-# CHECK-NEXT:  4      6     1.00                        fcvtpu	h12, h13
+# CHECK-NEXT:  1      4     1.00                        fcvtpu	s12, s13
+# CHECK-NEXT:  1      6     1.00                        fcvtpu	h12, h13
 # CHECK-NEXT:  1      3     0.50                        fcvtpu	v0.2d, v0.2d
 # CHECK-NEXT:  1      3     0.50                        fcvtpu	v0.2s, v0.2s
-# CHECK-NEXT:  2      4     1.00                        fcvtpu	v0.4h, v0.4h
-# CHECK-NEXT:  2      4     1.00                        fcvtpu	v0.4s, v0.4s
-# CHECK-NEXT:  4      6     1.00                        fcvtpu	v0.8h, v0.8h
+# CHECK-NEXT:  1      4     1.00                        fcvtpu	v0.4h, v0.4h
+# CHECK-NEXT:  1      4     1.00                        fcvtpu	v0.4s, v0.4s
+# CHECK-NEXT:  1      6     1.00                        fcvtpu	v0.8h, v0.8h
 # CHECK-NEXT:  1      3     0.50                        fcvtxn	s22, d13
 # CHECK-NEXT:  1      3     0.50                        fcvtxn	v0.2s, v0.2d
 # CHECK-NEXT:  1      3     0.50                        fcvtxn2	v0.4s, v0.2d
 # CHECK-NEXT:  1      3     0.50                        fcvtzs	d21, d12, #1
 # CHECK-NEXT:  1      3     0.50                        fcvtzs	d21, d14
-# CHECK-NEXT:  2      4     1.00                        fcvtzs	s12, s13
-# CHECK-NEXT:  2      4     1.00                        fcvtzs	s21, s12, #1
-# CHECK-NEXT:  4      6     1.00                        fcvtzs	h21, h14
-# CHECK-NEXT:  4      6     1.00                        fcvtzs	h21, h12, #1
+# CHECK-NEXT:  1      4     1.00                        fcvtzs	s12, s13
+# CHECK-NEXT:  1      4     1.00                        fcvtzs	s21, s12, #1
+# CHECK-NEXT:  1      6     1.00                        fcvtzs	h21, h14
+# CHECK-NEXT:  1      6     1.00                        fcvtzs	h21, h12, #1
 # CHECK-NEXT:  1      3     0.50                        fcvtzs	v0.2d, v0.2d
 # CHECK-NEXT:  1      3     0.50                        fcvtzs	v0.2d, v0.2d, #3
 # CHECK-NEXT:  1      3     0.50                        fcvtzs	v0.2s, v0.2s
 # CHECK-NEXT:  1      3     0.50                        fcvtzs	v0.2s, v0.2s, #3
-# CHECK-NEXT:  2      4     1.00                        fcvtzs	v0.4h, v0.4h
-# CHECK-NEXT:  2      4     1.00                        fcvtzs	v20.4h, v24.4h, #11
-# CHECK-NEXT:  2      4     1.00                        fcvtzs	v0.4s, v0.4s
-# CHECK-NEXT:  2      4     1.00                        fcvtzs	v0.4s, v0.4s, #3
-# CHECK-NEXT:  4      6     1.00                        fcvtzs	v0.8h, v0.8h
-# CHECK-NEXT:  4      6     1.00                        fcvtzs	v18.8h, v10.8h, #7
+# CHECK-NEXT:  1      4     1.00                        fcvtzs	v0.4h, v0.4h
+# CHECK-NEXT:  1      4     1.00                        fcvtzs	v20.4h, v24.4h, #11
+# CHECK-NEXT:  1      4     1.00                        fcvtzs	v0.4s, v0.4s
+# CHECK-NEXT:  1      4     1.00                        fcvtzs	v0.4s, v0.4s, #3
+# CHECK-NEXT:  1      6     1.00                        fcvtzs	v0.8h, v0.8h
+# CHECK-NEXT:  1      6     1.00                        fcvtzs	v18.8h, v10.8h, #7
 # CHECK-NEXT:  1      3     0.50                        fcvtzu	d21, d12, #1
 # CHECK-NEXT:  1      3     0.50                        fcvtzu	d21, d14
-# CHECK-NEXT:  2      4     1.00                        fcvtzu	s12, s13
-# CHECK-NEXT:  2      4     1.00                        fcvtzu	s21, s12, #1
-# CHECK-NEXT:  4      6     1.00                        fcvtzu	h12, h13
-# CHECK-NEXT:  4      6     1.00                        fcvtzu	h21, h12, #1
+# CHECK-NEXT:  1      4     1.00                        fcvtzu	s12, s13
+# CHECK-NEXT:  1      4     1.00                        fcvtzu	s21, s12, #1
+# CHECK-NEXT:  1      6     1.00                        fcvtzu	h12, h13
+# CHECK-NEXT:  1      6     1.00                        fcvtzu	h21, h12, #1
 # CHECK-NEXT:  1      3     0.50                        fcvtzu	v0.2d, v0.2d
 # CHECK-NEXT:  1      3     0.50                        fcvtzu	v0.2d, v0.2d, #3
 # CHECK-NEXT:  1      3     0.50                        fcvtzu	v0.2s, v0.2s
 # CHECK-NEXT:  1      3     0.50                        fcvtzu	v0.2s, v0.2s, #3
-# CHECK-NEXT:  2      4     1.00                        fcvtzu	v0.4h, v0.4h
-# CHECK-NEXT:  2      4     1.00                        fcvtzu	v19.4h, v26.4h, #9
-# CHECK-NEXT:  2      4     1.00                        fcvtzu	v0.4s, v0.4s
-# CHECK-NEXT:  2      4     1.00                        fcvtzu	v0.4s, v0.4s, #3
-# CHECK-NEXT:  4      6     1.00                        fcvtzu	v0.8h, v0.8h
-# CHECK-NEXT:  4      6     1.00                        fcvtzu	v27.8h, v6.8h, #11
+# CHECK-NEXT:  1      4     1.00                        fcvtzu	v0.4h, v0.4h
+# CHECK-NEXT:  1      4     1.00                        fcvtzu	v19.4h, v26.4h, #9
+# CHECK-NEXT:  1      4     1.00                        fcvtzu	v0.4s, v0.4s
+# CHECK-NEXT:  1      4     1.00                        fcvtzu	v0.4s, v0.4s, #3
+# CHECK-NEXT:  1      6     1.00                        fcvtzu	v0.8h, v0.8h
+# CHECK-NEXT:  1      6     1.00                        fcvtzu	v27.8h, v6.8h, #11
 # CHECK-NEXT:  1      15    3.50                        fdiv	v0.2d, v0.2d, v0.2d
 # CHECK-NEXT:  1      10    3.50                        fdiv	v0.2s, v0.2s, v0.2s
 # CHECK-NEXT:  1      7     3.50                        fdiv	v0.4h, v0.4h, v0.4h
@@ -314,17 +314,17 @@
 # CHECK-NEXT:  1      2     0.25                        fmaxnmp	v0.2d, v0.2d, v0.2d
 # CHECK-NEXT:  1      2     0.25                        fmaxnmp	v0.2s, v0.2s, v0.2s
 # CHECK-NEXT:  1      2     0.25                        fmaxnmp	v0.4s, v0.4s, v0.4s
-# CHECK-NEXT:  2      4     0.50                        fmaxnmv	h0, v13.4h
-# CHECK-NEXT:  3      6     0.75                        fmaxnmv	h12, v11.8h
-# CHECK-NEXT:  2      4     0.50                        fmaxnmv	s28, v31.4s
+# CHECK-NEXT:  1      4     0.50                        fmaxnmv	h0, v13.4h
+# CHECK-NEXT:  1      6     0.75                        fmaxnmv	h12, v11.8h
+# CHECK-NEXT:  1      4     0.50                        fmaxnmv	s28, v31.4s
 # CHECK-NEXT:  1      2     0.25                        fmaxp	v0.2d, v0.2d, v0.2d
 # CHECK-NEXT:  1      2     0.25                        fmaxp	v0.2s, v0.2s, v0.2s
 # CHECK-NEXT:  1      2     0.25                        fmaxp	v0.4s, v0.4s, v0.4s
 # CHECK-NEXT:  1      2     0.25                        fmaxp	h15, v25.2h
 # CHECK-NEXT:  1      2     0.25                        fmaxp	s6, v2.2s
-# CHECK-NEXT:  2      4     0.50                        fmaxv	h0, v0.4h
-# CHECK-NEXT:  3      6     0.75                        fmaxv	h0, v0.8h
-# CHECK-NEXT:  2      4     0.50                        fmaxv	s0, v0.4s
+# CHECK-NEXT:  1      4     0.50                        fmaxv	h0, v0.4h
+# CHECK-NEXT:  1      6     0.75                        fmaxv	h0, v0.8h
+# CHECK-NEXT:  1      4     0.50                        fmaxv	s0, v0.4s
 # CHECK-NEXT:  1      2     0.25                        fmin	v0.2d, v0.2d, v0.2d
 # CHECK-NEXT:  1      2     0.25                        fmin	v0.2s, v0.2s, v0.2s
 # CHECK-NEXT:  1      2     0.25                        fmin	v0.4s, v0.4s, v0.4s
@@ -336,17 +336,17 @@
 # CHECK-NEXT:  1      2     0.25                        fminnmp	v0.2d, v0.2d, v0.2d
 # CHECK-NEXT:  1      2     0.25                        fminnmp	v0.2s, v0.2s, v0.2s
 # CHECK-NEXT:  1      2     0.25                        fminnmp	v0.4s, v0.4s, v0.4s
-# CHECK-NEXT:  2      4     0.50                        fminnmv	h19, v25.4h
-# CHECK-NEXT:  3      6     0.75                        fminnmv	h23, v17.8h
-# CHECK-NEXT:  2      4     0.50                        fminnmv	s29, v17.4s
+# CHECK-NEXT:  1      4     0.50                        fminnmv	h19, v25.4h
+# CHECK-NEXT:  1      6     0.75                        fminnmv	h23, v17.8h
+# CHECK-NEXT:  1      4     0.50                        fminnmv	s29, v17.4s
 # CHECK-NEXT:  1      2     0.25                        fminp	v0.2d, v0.2d, v0.2d
 # CHECK-NEXT:  1      2     0.25                        fminp	v0.2s, v0.2s, v0.2s
 # CHECK-NEXT:  1      2     0.25                        fminp	v0.4s, v0.4s, v0.4s
 # CHECK-NEXT:  1      2     0.25                        fminp	h7, v10.2h
 # CHECK-NEXT:  1      2     0.25                        fminp	s17, v7.2s
-# CHECK-NEXT:  2      4     0.50                        fminv	h3, v30.4h
-# CHECK-NEXT:  3      6     0.75                        fminv	h29, v12.8h
-# CHECK-NEXT:  2      4     0.50                        fminv	s16, v19.4s
+# CHECK-NEXT:  1      4     0.50                        fminv	h3, v30.4h
+# CHECK-NEXT:  1      6     0.75                        fminv	h29, v12.8h
+# CHECK-NEXT:  1      4     0.50                        fminv	s16, v19.4s
 # CHECK-NEXT:  1      4     0.25                        fmla	d0, d1, v0.d[1]
 # CHECK-NEXT:  1      4     0.25                        fmla	h23, h24, v15.h[4]
 # CHECK-NEXT:  1      4     0.25                        fmla	s0, s1, v0.s[3]
@@ -402,7 +402,7 @@
 # CHECK-NEXT:  1      3     0.50                        frecpe	v0.2s, v0.2s
 # CHECK-NEXT:  1      4     0.50                        frecpe	v0.4h, v0.4h
 # CHECK-NEXT:  1      4     0.50                        frecpe	v0.4s, v0.4s
-# CHECK-NEXT:  2      6     1.00                        frecpe	v0.8h, v0.8h
+# CHECK-NEXT:  1      6     1.00                        frecpe	v0.8h, v0.8h
 # CHECK-NEXT:  1      4     0.25                        frecps	h29, h19, h8
 # CHECK-NEXT:  1      3     0.50                        frecpx	h18, h11
 # CHECK-NEXT:  1      4     0.25                        frecps	v12.8h, v25.8h, v4.8h
@@ -414,39 +414,39 @@
 # CHECK-NEXT:  1      3     0.50                        frecpx	s18, s10
 # CHECK-NEXT:  1      3     0.50                        frinta	v0.2d, v0.2d
 # CHECK-NEXT:  1      3     0.50                        frinta	v0.2s, v0.2s
-# CHECK-NEXT:  2      4     1.00                        frinta	v0.4h, v0.4h
-# CHECK-NEXT:  2      4     1.00                        frinta	v0.4s, v0.4s
-# CHECK-NEXT:  4      6     1.00                        frinta	v0.8h, v0.8h
+# CHECK-NEXT:  1      4     1.00                        frinta	v0.4h, v0.4h
+# CHECK-NEXT:  1      4     1.00                        frinta	v0.4s, v0.4s
+# CHECK-NEXT:  1      6     1.00                        frinta	v0.8h, v0.8h
 # CHECK-NEXT:  1      3     0.50                        frinti	v0.2d, v0.2d
 # CHECK-NEXT:  1      3     0.50                        frinti	v0.2s, v0.2s
-# CHECK-NEXT:  2      4     1.00                        frinti	v0.4h, v0.4h
-# CHECK-NEXT:  2      4     1.00                        frinti	v0.4s, v0.4s
-# CHECK-NEXT:  4      6     1.00                        frinti	v0.8h, v0.8h
+# CHECK-NEXT:  1      4     1.00                        frinti	v0.4h, v0.4h
+# CHECK-NEXT:  1      4     1.00                        frinti	v0.4s, v0.4s
+# CHECK-NEXT:  1      6     1.00                        frinti	v0.8h, v0.8h
 # CHECK-NEXT:  1      3     0.50                        frintm	v0.2d, v0.2d
 # CHECK-NEXT:  1      3     0.50                        frintm	v0.2s, v0.2s
-# CHECK-NEXT:  2      4     1.00                        frintm	v0.4h, v0.4h
-# CHECK-NEXT:  2      4     1.00                        frintm	v0.4s, v0.4s
-# CHECK-NEXT:  4      6     1.00                        frintm	v0.8h, v0.8h
+# CHECK-NEXT:  1      4     1.00                        frintm	v0.4h, v0.4h
+# CHECK-NEXT:  1      4     1.00                        frintm	v0.4s, v0.4s
+# CHECK-NEXT:  1      6     1.00                        frintm	v0.8h, v0.8h
 # CHECK-NEXT:  1      3     0.50                        frintn	v0.2d, v0.2d
 # CHECK-NEXT:  1      3     0.50                        frintn	v0.2s, v0.2s
-# CHECK-NEXT:  2      4     1.00                        frintn	v0.4h, v0.4h
-# CHECK-NEXT:  2      4     1.00                        frintn	v0.4s, v0.4s
-# CHECK-NEXT:  4      6     1.00                        frintn	v0.8h, v0.8h
+# CHECK-NEXT:  1      4     1.00                        frintn	v0.4h, v0.4h
+# CHECK-NEXT:  1      4     1.00                        frintn	v0.4s, v0.4s
+# CHECK-NEXT:  1      6     1.00                        frintn	v0.8h, v0.8h
 # CHECK-NEXT:  1      3     0.50                        frintp	v0.2d, v0.2d
 # CHECK-NEXT:  1      3     0.50                        frintp	v0.2s, v0.2s
-# CHECK-NEXT:  2      4     1.00                        frintp	v0.4h, v0.4h
-# CHECK-NEXT:  2      4     1.00                        frintp	v0.4s, v0.4s
-# CHECK-NEXT:  4      6     1.00                        frintp	v0.8h, v0.8h
+# CHECK-NEXT:  1      4     1.00                        frintp	v0.4h, v0.4h
+# CHECK-NEXT:  1      4     1.00                        frintp	v0.4s, v0.4s
+# CHECK-NEXT:  1      6     1.00                        frintp	v0.8h, v0.8h
 # CHECK-NEXT:  1      3     0.50                        frintx	v0.2d, v0.2d
 # CHECK-NEXT:  1      3     0.50                        frintx	v0.2s, v0.2s
-# CHECK-NEXT:  2      4     1.00                        frintx	v0.4h, v0.4h
-# CHECK-NEXT:  2      4     1.00                        frintx	v0.4s, v0.4s
-# CHECK-NEXT:  4      6     1.00                        frintx	v0.8h, v0.8h
+# CHECK-NEXT:  1      4     1.00                        frintx	v0.4h, v0.4h
+# CHECK-NEXT:  1      4     1.00                        frintx	v0.4s, v0.4s
+# CHECK-NEXT:  1      6     1.00                        frintx	v0.8h, v0.8h
 # CHECK-NEXT:  1      3     0.50                        frintz	v0.2d, v0.2d
 # CHECK-NEXT:  1      3     0.50                        frintz	v0.2s, v0.2s
-# CHECK-NEXT:  2      4     1.00                        frintz	v0.4h, v0.4h
-# CHECK-NEXT:  2      4     1.00                        frintz	v0.4s, v0.4s
-# CHECK-NEXT:  4      6     1.00                        frintz	v0.8h, v0.8h
+# CHECK-NEXT:  1      4     1.00                        frintz	v0.4h, v0.4h
+# CHECK-NEXT:  1      4     1.00                        frintz	v0.4s, v0.4s
+# CHECK-NEXT:  1      6     1.00                        frintz	v0.8h, v0.8h
 # CHECK-NEXT:  1      4     0.50                        frsqrte	h23, h26
 # CHECK-NEXT:  1      3     0.50                        frsqrte	d21, d12
 # CHECK-NEXT:  1      3     0.50                        frsqrte	s22, s13
@@ -456,7 +456,7 @@
 # CHECK-NEXT:  1      4     0.50                        frsqrte	v0.4s, v0.4s
 # CHECK-NEXT:  1      4     0.25                        frsqrts	v20.4s, v26.4s, v27.4s
 # CHECK-NEXT:  1      4     0.25                        frsqrts	v8.4h, v9.4h, v30.4h
-# CHECK-NEXT:  2      6     1.00                        frsqrte	v0.8h, v0.8h
+# CHECK-NEXT:  1      6     1.00                        frsqrte	v0.8h, v0.8h
 # CHECK-NEXT:  1      4     0.25                        frsqrts	h28, h26, h1
 # CHECK-NEXT:  1      4     0.25                        frsqrts	d8, d22, d18
 # CHECK-NEXT:  1      4     0.25                        frsqrts	s21, s5, s12
@@ -469,40 +469,40 @@
 # CHECK-NEXT:  1      2     0.25                        fsub	v13.8h, v15.8h, v17.8h
 # CHECK-NEXT:  1      2     0.25                        fsub	v0.2s, v0.2s, v0.2s
 # CHECK-NEXT:  1      6     0.33    *                   ld1	{ v0.16b }, [x0]
-# CHECK-NEXT:  2      6     0.67    *                   ld1	{ v0.16b, v1.16b }, [x14]
-# CHECK-NEXT:  3      6     1.00    *                   ld1	{ v19.16b, v20.16b, v21.16b }, [x10]
-# CHECK-NEXT:  4      7     1.33    *                   ld1	{ v13.16b, v14.16b, v15.16b, v16.16b }, [x9]
+# CHECK-NEXT:  1      6     0.67    *                   ld1	{ v0.16b, v1.16b }, [x14]
+# CHECK-NEXT:  1      6     1.00    *                   ld1	{ v19.16b, v20.16b, v21.16b }, [x10]
+# CHECK-NEXT:  1      7     1.33    *                   ld1	{ v13.16b, v14.16b, v15.16b, v16.16b }, [x9]
 # CHECK-NEXT:  1      6     0.33    *                   ld1	{ v24.8h }, [x27]
-# CHECK-NEXT:  2      6     0.67    *                   ld1	{ v1.8h, v2.8h }, [x27]
-# CHECK-NEXT:  3      6     0.67    *                   ld1	{ v0.8h, v1.8h }, [sp], #32
-# CHECK-NEXT:  3      6     1.00    *                   ld1	{ v21.8h, v22.8h, v23.8h }, [x22]
-# CHECK-NEXT:  4      7     1.33    *                   ld1	{ v0.8h, v1.8h, v2.8h, v3.8h }, [x21]
+# CHECK-NEXT:  1      6     0.67    *                   ld1	{ v1.8h, v2.8h }, [x27]
+# CHECK-NEXT:  2      6     0.67    *                   ld1	{ v0.8h, v1.8h }, [sp], #32
+# CHECK-NEXT:  1      6     1.00    *                   ld1	{ v21.8h, v22.8h, v23.8h }, [x22]
+# CHECK-NEXT:  1      7     1.33    *                   ld1	{ v0.8h, v1.8h, v2.8h, v3.8h }, [x21]
 # CHECK-NEXT:  1      6     0.33    *                   ld1	{ v3.4s }, [x4]
-# CHECK-NEXT:  2      6     0.67    *                   ld1	{ v11.4s, v12.4s }, [x30]
-# CHECK-NEXT:  3      6     1.00    *                   ld1	{ v0.4s, v1.4s, v2.4s }, [x24]
-# CHECK-NEXT:  4      7     1.33    *                   ld1	{ v15.4s, v16.4s, v17.4s, v18.4s }, [x28]
-# CHECK-NEXT:  4      6     1.00    *                   ld1	{ v0.4s, v1.4s, v2.4s }, [x0], #48
+# CHECK-NEXT:  1      6     0.67    *                   ld1	{ v11.4s, v12.4s }, [x30]
+# CHECK-NEXT:  1      6     1.00    *                   ld1	{ v0.4s, v1.4s, v2.4s }, [x24]
+# CHECK-NEXT:  1      7     1.33    *                   ld1	{ v15.4s, v16.4s, v17.4s, v18.4s }, [x28]
+# CHECK-NEXT:  2      6     1.00    *                   ld1	{ v0.4s, v1.4s, v2.4s }, [x0], #48
 # CHECK-NEXT:  1      6     0.33    *                   ld1	{ v3.2d }, [x28]
-# CHECK-NEXT:  2      6     0.67    *                   ld1	{ v13.2d, v14.2d }, [x13]
-# CHECK-NEXT:  3      6     1.00    *                   ld1	{ v12.2d, v13.2d, v14.2d }, [x15]
-# CHECK-NEXT:  4      6     1.00    *                   ld1	{ v0.2d, v1.2d, v2.2d }, [x0], #48
-# CHECK-NEXT:  4      7     1.33    *                   ld1	{ v0.2d, v1.2d, v2.2d, v3.2d }, [x0]
+# CHECK-NEXT:  1      6     0.67    *                   ld1	{ v13.2d, v14.2d }, [x13]
+# CHECK-NEXT:  1      6     1.00    *                   ld1	{ v12.2d, v13.2d, v14.2d }, [x15]
+# CHECK-NEXT:  2      6     1.00    *                   ld1	{ v0.2d, v1.2d, v2.2d }, [x0], #48
+# CHECK-NEXT:  1      7     1.33    *                   ld1	{ v0.2d, v1.2d, v2.2d, v3.2d }, [x0]
 # CHECK-NEXT:  2      6     0.33    *                   ld1	{ v0.1d }, [x15], x2
-# CHECK-NEXT:  2      6     0.67    *                   ld1	{ v27.1d, v28.1d }, [x7]
-# CHECK-NEXT:  3      6     1.00    *                   ld1	{ v14.1d, v15.1d, v16.1d }, [x3]
-# CHECK-NEXT:  2      6     0.67    *                   ld1	{ v22.1d, v23.1d, v24.1d, v25.1d }, [x4]
-# CHECK-NEXT:  2      6     0.67    *                   ld1	{ v0.2s, v1.2s }, [x15]
-# CHECK-NEXT:  3      6     1.00    *                   ld1	{ v16.2s, v17.2s, v18.2s }, [x27]
-# CHECK-NEXT:  2      6     0.67    *                   ld1	{ v21.2s, v22.2s, v23.2s, v24.2s }, [x21]
-# CHECK-NEXT:  2      6     0.67    *                   ld1	{ v25.4h, v26.4h }, [x3]
-# CHECK-NEXT:  2      6     0.67    *                   ld1	{ v20.4h, v21.4h, v22.4h, v23.4h }, [x15]
-# CHECK-NEXT:  3      6     1.00    *                   ld1	{ v0.4h, v1.4h, v2.4h }, [sp]
-# CHECK-NEXT:  2      6     0.67    *                   ld1	{ v24.8b, v25.8b }, [x6]
-# CHECK-NEXT:  3      6     1.00    *                   ld1	{ v7.8b, v8.8b, v9.8b }, [x12]
-# CHECK-NEXT:  2      6     0.67    *                   ld1	{ v4.8b, v5.8b, v6.8b, v7.8b }, [x13]
-# CHECK-NEXT:  3      6     0.67    *                   ld1	{ v0.4s, v1.4s }, [sp], #32
-# CHECK-NEXT:  3      6     1.00    *                   ld1	{ v0.4s, v1.4s, v2.4s }, [sp]
-# CHECK-NEXT:  3      6     0.67    *                   ld1	{ v0.8b, v1.8b, v2.8b, v3.8b }, [x0], x3
+# CHECK-NEXT:  1      6     0.67    *                   ld1	{ v27.1d, v28.1d }, [x7]
+# CHECK-NEXT:  1      6     1.00    *                   ld1	{ v14.1d, v15.1d, v16.1d }, [x3]
+# CHECK-NEXT:  1      6     0.67    *                   ld1	{ v22.1d, v23.1d, v24.1d, v25.1d }, [x4]
+# CHECK-NEXT:  1      6     0.67    *                   ld1	{ v0.2s, v1.2s }, [x15]
+# CHECK-NEXT:  1      6     1.00    *                   ld1	{ v16.2s, v17.2s, v18.2s }, [x27]
+# CHECK-NEXT:  1      6     0.67    *                   ld1	{ v21.2s, v22.2s, v23.2s, v24.2s }, [x21]
+# CHECK-NEXT:  1      6     0.67    *                   ld1	{ v25.4h, v26.4h }, [x3]
+# CHECK-NEXT:  1      6     0.67    *                   ld1	{ v20.4h, v21.4h, v22.4h, v23.4h }, [x15]
+# CHECK-NEXT:  1      6     1.00    *                   ld1	{ v0.4h, v1.4h, v2.4h }, [sp]
+# CHECK-NEXT:  1      6     0.67    *                   ld1	{ v24.8b, v25.8b }, [x6]
+# CHECK-NEXT:  1      6     1.00    *                   ld1	{ v7.8b, v8.8b, v9.8b }, [x12]
+# CHECK-NEXT:  1      6     0.67    *                   ld1	{ v4.8b, v5.8b, v6.8b, v7.8b }, [x13]
+# CHECK-NEXT:  2      6     0.67    *                   ld1	{ v0.4s, v1.4s }, [sp], #32
+# CHECK-NEXT:  1      6     1.00    *                   ld1	{ v0.4s, v1.4s, v2.4s }, [sp]
+# CHECK-NEXT:  2      6     0.67    *                   ld1	{ v0.8b, v1.8b, v2.8b, v3.8b }, [x0], x3
 # CHECK-NEXT:  2      8     0.33    *                   ld1	{ v0.b }[7], [x0]
 # CHECK-NEXT:  3      8     0.33    *                   ld1	{ v0.h }[3], [x0], #2
 # CHECK-NEXT:  2      8     0.33    *                   ld1	{ v18.h }[3], [x1]
@@ -510,7 +510,7 @@
 # CHECK-NEXT:  3      8     0.33    *                   ld1	{ v0.d }[0], [x15], #8
 # CHECK-NEXT:  2      8     0.33    *                   ld1	{ v11.d }[0], [x13]
 # CHECK-NEXT:  2      6     0.33    *                   ld1	{ v0.8h }, [x15], x2
-# CHECK-NEXT:  2      6     0.67    *                   ld1	{ v0.8h, v1.8h }, [x15]
+# CHECK-NEXT:  1      6     0.67    *                   ld1	{ v0.8h, v1.8h }, [x15]
 # CHECK-NEXT:  2      8     0.33    *                   ld1	{ v0.b }[9], [x0]
 # CHECK-NEXT:  3      8     0.33    *                   ld1	{ v0.b }[9], [x0], #1
 # CHECK-NEXT:  2      8     0.33    *                   ld1r	{ v0.16b }, [x0]
@@ -523,93 +523,93 @@
 # CHECK-NEXT:  2      8     0.33    *                   ld1r	{ v28.4h }, [x9]
 # CHECK-NEXT:  2      8     0.33    *                   ld1r	{ v3.8h }, [x16]
 # CHECK-NEXT:  2      8     0.33    *                   ld1r	{ v10.2s }, [x20]
-# CHECK-NEXT:  3      8     0.50    *                   ld2	{ v0.4h, v1.4h }, [x21]
-# CHECK-NEXT:  4      8     0.67    *                   ld2	{ v8.8h, v9.8h }, [x28]
-# CHECK-NEXT:  3      8     0.50    *                   ld2	{ v2.2s, v3.2s }, [x16]
-# CHECK-NEXT:  4      8     0.67    *                   ld2	{ v22.4s, v23.4s }, [x4]
-# CHECK-NEXT:  4      8     0.67    *                   ld2	{ v22.2d, v23.2d }, [x17]
-# CHECK-NEXT:  3      8     0.50    *                   ld2	{ v29.b, v30.b }[3], [x1]
-# CHECK-NEXT:  3      8     0.50    *                   ld2	{ v26.s, v27.s }[1], [x17]
-# CHECK-NEXT:  3      8     0.50    *                   ld2	{ v1.d, v2.d }[0], [x10]
-# CHECK-NEXT:  4      8     0.67    *                   ld2	{ v0.16b, v1.16b }, [x0]
-# CHECK-NEXT:  3      8     0.50    *                   ld2	{ v13.8b, v14.8b }, [x4]
-# CHECK-NEXT:  4      8     0.50    *                   ld2	{ v0.8b, v1.8b }, [x0], #16
+# CHECK-NEXT:  2      8     0.50    *                   ld2	{ v0.4h, v1.4h }, [x21]
+# CHECK-NEXT:  2      8     0.67    *                   ld2	{ v8.8h, v9.8h }, [x28]
+# CHECK-NEXT:  2      8     0.50    *                   ld2	{ v2.2s, v3.2s }, [x16]
+# CHECK-NEXT:  2      8     0.67    *                   ld2	{ v22.4s, v23.4s }, [x4]
+# CHECK-NEXT:  2      8     0.67    *                   ld2	{ v22.2d, v23.2d }, [x17]
+# CHECK-NEXT:  2      8     0.50    *                   ld2	{ v29.b, v30.b }[3], [x1]
+# CHECK-NEXT:  2      8     0.50    *                   ld2	{ v26.s, v27.s }[1], [x17]
+# CHECK-NEXT:  2      8     0.50    *                   ld2	{ v1.d, v2.d }[0], [x10]
+# CHECK-NEXT:  2      8     0.67    *                   ld2	{ v0.16b, v1.16b }, [x0]
+# CHECK-NEXT:  2      8     0.50    *                   ld2	{ v13.8b, v14.8b }, [x4]
+# CHECK-NEXT:  3      8     0.50    *                   ld2	{ v0.8b, v1.8b }, [x0], #16
 # CHECK-NEXT:  3      8     0.33    *                   ld1r	{ v0.16b }, [x0], #1
 # CHECK-NEXT:  2      8     0.33    *                   ld1r	{ v0.8h }, [x15]
 # CHECK-NEXT:  3      8     0.33    *                   ld1r	{ v0.8h }, [x15], #2
-# CHECK-NEXT:  5      8     0.67    *                   ld2	{ v0.16b, v1.16b }, [x0], x1
-# CHECK-NEXT:  3      8     0.50    *                   ld2	{ v0.8b, v1.8b }, [x0]
-# CHECK-NEXT:  3      8     0.50    *                   ld2	{ v0.h, v1.h }[7], [x15]
-# CHECK-NEXT:  4      8     0.50    *                   ld2	{ v0.h, v1.h }[7], [x15], x8
-# CHECK-NEXT:  4      8     0.50    *                   ld2	{ v0.h, v1.h }[7], [x15], #4
-# CHECK-NEXT:  3      8     0.50    *                   ld2r	{ v0.8b, v1.8b }, [x0]
-# CHECK-NEXT:  3      8     0.50    *                   ld2r	{ v10.16b, v11.16b }, [x23]
-# CHECK-NEXT:  4      8     0.50    *                   ld2r	{ v0.4h, v1.4h }, [x0], #4
-# CHECK-NEXT:  3      8     0.50    *                   ld2r	{ v25.4h, v26.4h }, [x11]
-# CHECK-NEXT:  3      8     0.50    *                   ld2r	{ v23.8h, v24.8h }, [x10]
-# CHECK-NEXT:  3      8     0.50    *                   ld2r	{ v0.2s, v1.2s }, [sp]
-# CHECK-NEXT:  3      8     0.50    *                   ld2r	{ v8.4s, v9.4s }, [x17]
-# CHECK-NEXT:  4      8     0.50    *                   ld2r	{ v0.1d, v1.1d }, [sp], x8
-# CHECK-NEXT:  3      8     0.50    *                   ld2r	{ v9.1d, v10.1d }, [x25]
-# CHECK-NEXT:  3      8     0.50    *                   ld2r	{ v26.2d, v27.2d }, [x8]
-# CHECK-NEXT:  5      8     0.75    *                   ld3	{ v8.8b, v9.8b, v10.8b }, [x0]
-# CHECK-NEXT:  6      8     1.00    *                   ld3	{ v15.16b, v16.16b, v17.16b }, [x5]
-# CHECK-NEXT:  3      8     0.50    *                   ld2r	{ v0.2d, v1.2d }, [x0]
-# CHECK-NEXT:  4      8     0.50    *                   ld2r	{ v0.2d, v1.2d }, [x0], #16
-# CHECK-NEXT:  3      8     0.50    *                   ld2r	{ v0.4s, v1.4s }, [sp]
-# CHECK-NEXT:  4      8     0.50    *                   ld2r	{ v0.4s, v1.4s }, [sp], #8
-# CHECK-NEXT:  5      8     0.75    *                   ld3	{ v0.4h, v1.4h, v2.4h }, [x15]
-# CHECK-NEXT:  7      8     1.00    *                   ld3	{ v0.8h, v1.8h, v2.8h }, [x15], #48
-# CHECK-NEXT:  6      8     1.00    *                   ld3	{ v7.8h, v8.8h, v9.8h }, [x21]
-# CHECK-NEXT:  5      8     0.75    *                   ld3	{ v16.2s, v17.2s, v18.2s }, [x0]
-# CHECK-NEXT:  6      8     1.00    *                   ld3	{ v12.4s, v13.4s, v14.4s }, [x25]
-# CHECK-NEXT:  5      8     0.75    *                   ld3	{ v17.b, v18.b, v19.b }[2], [x27]
-# CHECK-NEXT:  5      8     0.75    *                   ld3	{ v18.h, v19.h, v20.h }[5], [x16]
-# CHECK-NEXT:  6      8     1.00    *                   ld3	{ v10.2d, v11.2d, v12.2d }, [x18]
-# CHECK-NEXT:  7      8     1.00    *                   ld3	{ v0.8h, v1.8h, v2.8h }, [x15], x2
-# CHECK-NEXT:  5      8     0.75    *                   ld3	{ v0.s, v1.s, v2.s }[3], [sp]
-# CHECK-NEXT:  6      8     0.75    *                   ld3	{ v0.s, v1.s, v2.s }[3], [sp], x3
-# CHECK-NEXT:  5      8     0.75    *                   ld3	{ v5.d, v6.d, v7.d }[1], [x14]
-# CHECK-NEXT:  5      8     0.75    *                   ld3r	{ v0.8b, v1.8b, v2.8b }, [x15]
-# CHECK-NEXT:  5      8     0.75    *                   ld3r	{ v17.16b, v18.16b, v19.16b }, [x3]
-# CHECK-NEXT:  5      8     0.75    *                   ld3r	{ v0.4h, v1.4h, v2.4h }, [x15]
-# CHECK-NEXT:  6      8     0.75    *                   ld3r	{ v0.4h, v1.4h, v2.4h }, [x15], #6
-# CHECK-NEXT:  5      8     0.75    *                   ld3r	{ v3.4h, v4.4h, v5.4h }, [x1]
-# CHECK-NEXT:  5      8     0.75    *                   ld3r	{ v6.8h, v7.8h, v8.8h }, [x28]
-# CHECK-NEXT:  5      8     0.75    *                   ld3r	{ v0.2s, v1.2s, v2.2s }, [x0]
-# CHECK-NEXT:  5      8     0.75    *                   ld3r	{ v28.4s, v29.4s, v30.4s }, [x2]
-# CHECK-NEXT:  6      8     0.75    *                   ld3r	{ v0.1d, v1.1d, v2.1d }, [x0], x0
-# CHECK-NEXT:  5      8     0.75    *                   ld3r	{ v1.1d, v2.1d, v3.1d }, [x28]
-# CHECK-NEXT:  5      8     0.75    *                   ld3r	{ v8.2d, v9.2d, v10.2d }, [x3]
-# CHECK-NEXT:  7      8     1.00    *                   ld4	{ v6.8b, v7.8b, v8.8b, v9.8b }, [x27]
-# CHECK-NEXT:  8      9     1.33    *                   ld4	{ v11.16b, v12.16b, v13.16b, v14.16b }, [x5]
-# CHECK-NEXT:  7      8     1.00    *                   ld4	{ v21.4h, v22.4h, v23.4h, v24.4h }, [x14]
-# CHECK-NEXT:  8      9     1.33    *                   ld4	{ v9.8h, v10.8h, v11.8h, v12.8h }, [x1]
-# CHECK-NEXT:  8      9     1.33    *                   ld4	{ v17.4s, v18.4s, v19.4s, v20.4s }, [x4]
-# CHECK-NEXT:  5      8     0.75    *                   ld3r	{ v0.8b, v1.8b, v2.8b }, [x0]
-# CHECK-NEXT:  6      8     0.75    *                   ld3r	{ v0.8b, v1.8b, v2.8b }, [x0], #3
-# CHECK-NEXT:  7      8     1.00    *                   ld4	{ v0.2s, v1.2s, v2.2s, v3.2s }, [sp]
-# CHECK-NEXT:  9      9     1.33    *                   ld4	{ v0.4s, v1.4s, v2.4s, v3.4s }, [sp], #64
-# CHECK-NEXT:  7      8     1.00    *                   ld4	{ v0.d, v1.d, v2.d, v3.d }[1], [x0]
-# CHECK-NEXT:  8      9     1.33    *                   ld4	{ v2.2d, v3.2d, v4.2d, v5.2d }, [x24]
-# CHECK-NEXT:  7      8     1.00    *                   ld4	{ v4.b, v5.b, v6.b, v7.b }[12], [x27]
-# CHECK-NEXT:  7      8     1.00    *                   ld4	{ v5.h, v6.h, v7.h, v8.h }[0], [x4]
-# CHECK-NEXT:  8      8     1.00    *                   ld4	{ v0.d, v1.d, v2.d, v3.d }[1], [x0], #32
-# CHECK-NEXT:  8      8     1.00    *                   ld4	{ v0.h, v1.h, v2.h, v3.h }[7], [x0], x0
-# CHECK-NEXT:  7      8     1.00    *                   ld4	{ v0.s, v1.s, v2.s, v3.s }[0], [x26]
-# CHECK-NEXT:  7      8     1.00    *                   ld4r	{ v20.8b, v21.8b, v22.8b, v23.8b }, [x23]
-# CHECK-NEXT:  7      8     1.00    *                   ld4r	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x25]
-# CHECK-NEXT:  7      8     1.00    *                   ld4r	{ v16.4h, v17.4h, v18.4h, v19.4h }, [x6]
-# CHECK-NEXT:  7      8     1.00    *                   ld4r	{ v0.1d, v1.1d, v2.1d, v3.1d }, [sp]
-# CHECK-NEXT:  7      8     1.00    *                   ld4r	{ v0.2d, v1.2d, v2.2d, v3.2d }, [sp]
-# CHECK-NEXT:  7      8     1.00    *                   ld4r	{ v4.8h, v5.8h, v6.8h, v7.8h }, [x23]
-# CHECK-NEXT:  7      8     1.00    *                   ld4r	{ v0.2s, v1.2s, v2.2s, v3.2s }, [x30]
-# CHECK-NEXT:  8      8     1.00    *                   ld4r	{ v0.2s, v1.2s, v2.2s, v3.2s }, [sp], #16
-# CHECK-NEXT:  7      8     1.00    *                   ld4r	{ v7.4s, v8.4s, v9.4s, v10.4s }, [x23]
-# CHECK-NEXT:  8      8     1.00    *                   ld4r	{ v0.4s, v1.4s, v2.4s, v3.4s }, [sp], x8
-# CHECK-NEXT:  8      8     1.00    *                   ld4r	{ v0.1d, v1.1d, v2.1d, v3.1d }, [sp], x7
-# CHECK-NEXT:  7      8     1.00    *                   ld4r	{ v0.2s, v1.2s, v2.2s, v3.2s }, [sp]
-# CHECK-NEXT:  8      8     1.00    *                   ld4r	{ v0.2s, v1.2s, v2.2s, v3.2s }, [sp], x30
+# CHECK-NEXT:  3      8     0.67    *                   ld2	{ v0.16b, v1.16b }, [x0], x1
+# CHECK-NEXT:  2      8     0.50    *                   ld2	{ v0.8b, v1.8b }, [x0]
+# CHECK-NEXT:  2      8     0.50    *                   ld2	{ v0.h, v1.h }[7], [x15]
+# CHECK-NEXT:  3      8     0.50    *                   ld2	{ v0.h, v1.h }[7], [x15], x8
+# CHECK-NEXT:  3      8     0.50    *                   ld2	{ v0.h, v1.h }[7], [x15], #4
+# CHECK-NEXT:  2      8     0.50    *                   ld2r	{ v0.8b, v1.8b }, [x0]
+# CHECK-NEXT:  2      8     0.50    *                   ld2r	{ v10.16b, v11.16b }, [x23]
+# CHECK-NEXT:  3      8     0.50    *                   ld2r	{ v0.4h, v1.4h }, [x0], #4
+# CHECK-NEXT:  2      8     0.50    *                   ld2r	{ v25.4h, v26.4h }, [x11]
+# CHECK-NEXT:  2      8     0.50    *                   ld2r	{ v23.8h, v24.8h }, [x10]
+# CHECK-NEXT:  2      8     0.50    *                   ld2r	{ v0.2s, v1.2s }, [sp]
+# CHECK-NEXT:  2      8     0.50    *                   ld2r	{ v8.4s, v9.4s }, [x17]
+# CHECK-NEXT:  3      8     0.50    *                   ld2r	{ v0.1d, v1.1d }, [sp], x8
+# CHECK-NEXT:  2      8     0.50    *                   ld2r	{ v9.1d, v10.1d }, [x25]
+# CHECK-NEXT:  2      8     0.50    *                   ld2r	{ v26.2d, v27.2d }, [x8]
+# CHECK-NEXT:  2      8     0.75    *                   ld3	{ v8.8b, v9.8b, v10.8b }, [x0]
+# CHECK-NEXT:  2      8     1.00    *                   ld3	{ v15.16b, v16.16b, v17.16b }, [x5]
+# CHECK-NEXT:  2      8     0.50    *                   ld2r	{ v0.2d, v1.2d }, [x0]
+# CHECK-NEXT:  3      8     0.50    *                   ld2r	{ v0.2d, v1.2d }, [x0], #16
+# CHECK-NEXT:  2      8     0.50    *                   ld2r	{ v0.4s, v1.4s }, [sp]
+# CHECK-NEXT:  3      8     0.50    *                   ld2r	{ v0.4s, v1.4s }, [sp], #8
+# CHECK-NEXT:  2      8     0.75    *                   ld3	{ v0.4h, v1.4h, v2.4h }, [x15]
+# CHECK-NEXT:  3      8     1.00    *                   ld3	{ v0.8h, v1.8h, v2.8h }, [x15], #48
+# CHECK-NEXT:  2      8     1.00    *                   ld3	{ v7.8h, v8.8h, v9.8h }, [x21]
+# CHECK-NEXT:  2      8     0.75    *                   ld3	{ v16.2s, v17.2s, v18.2s }, [x0]
+# CHECK-NEXT:  2      8     1.00    *                   ld3	{ v12.4s, v13.4s, v14.4s }, [x25]
+# CHECK-NEXT:  2      8     0.75    *                   ld3	{ v17.b, v18.b, v19.b }[2], [x27]
+# CHECK-NEXT:  2      8     0.75    *                   ld3	{ v18.h, v19.h, v20.h }[5], [x16]
+# CHECK-NEXT:  2      8     1.00    *                   ld3	{ v10.2d, v11.2d, v12.2d }, [x18]
+# CHECK-NEXT:  3      8     1.00    *                   ld3	{ v0.8h, v1.8h, v2.8h }, [x15], x2
+# CHECK-NEXT:  2      8     0.75    *                   ld3	{ v0.s, v1.s, v2.s }[3], [sp]
+# CHECK-NEXT:  3      8     0.75    *                   ld3	{ v0.s, v1.s, v2.s }[3], [sp], x3
+# CHECK-NEXT:  2      8     0.75    *                   ld3	{ v5.d, v6.d, v7.d }[1], [x14]
+# CHECK-NEXT:  2      8     0.75    *                   ld3r	{ v0.8b, v1.8b, v2.8b }, [x15]
+# CHECK-NEXT:  2      8     0.75    *                   ld3r	{ v17.16b, v18.16b, v19.16b }, [x3]
+# CHECK-NEXT:  2      8     0.75    *                   ld3r	{ v0.4h, v1.4h, v2.4h }, [x15]
+# CHECK-NEXT:  3      8     0.75    *                   ld3r	{ v0.4h, v1.4h, v2.4h }, [x15], #6
+# CHECK-NEXT:  2      8     0.75    *                   ld3r	{ v3.4h, v4.4h, v5.4h }, [x1]
+# CHECK-NEXT:  2      8     0.75    *                   ld3r	{ v6.8h, v7.8h, v8.8h }, [x28]
+# CHECK-NEXT:  2      8     0.75    *                   ld3r	{ v0.2s, v1.2s, v2.2s }, [x0]
+# CHECK-NEXT:  2      8     0.75    *                   ld3r	{ v28.4s, v29.4s, v30.4s }, [x2]
+# CHECK-NEXT:  3      8     0.75    *                   ld3r	{ v0.1d, v1.1d, v2.1d }, [x0], x0
+# CHECK-NEXT:  2      8     0.75    *                   ld3r	{ v1.1d, v2.1d, v3.1d }, [x28]
+# CHECK-NEXT:  2      8     0.75    *                   ld3r	{ v8.2d, v9.2d, v10.2d }, [x3]
+# CHECK-NEXT:  2      8     1.00    *                   ld4	{ v6.8b, v7.8b, v8.8b, v9.8b }, [x27]
+# CHECK-NEXT:  2      9     1.33    *                   ld4	{ v11.16b, v12.16b, v13.16b, v14.16b }, [x5]
+# CHECK-NEXT:  2      8     1.00    *                   ld4	{ v21.4h, v22.4h, v23.4h, v24.4h }, [x14]
+# CHECK-NEXT:  2      9     1.33    *                   ld4	{ v9.8h, v10.8h, v11.8h, v12.8h }, [x1]
+# CHECK-NEXT:  2      9     1.33    *                   ld4	{ v17.4s, v18.4s, v19.4s, v20.4s }, [x4]
+# CHECK-NEXT:  2      8     0.75    *                   ld3r	{ v0.8b, v1.8b, v2.8b }, [x0]
+# CHECK-NEXT:  3      8     0.75    *                   ld3r	{ v0.8b, v1.8b, v2.8b }, [x0], #3
+# CHECK-NEXT:  2      8     1.00    *                   ld4	{ v0.2s, v1.2s, v2.2s, v3.2s }, [sp]
+# CHECK-NEXT:  3      9     1.33    *                   ld4	{ v0.4s, v1.4s, v2.4s, v3.4s }, [sp], #64
+# CHECK-NEXT:  2      8     1.00    *                   ld4	{ v0.d, v1.d, v2.d, v3.d }[1], [x0]
+# CHECK-NEXT:  2      9     1.33    *                   ld4	{ v2.2d, v3.2d, v4.2d, v5.2d }, [x24]
+# CHECK-NEXT:  2      8     1.00    *                   ld4	{ v4.b, v5.b, v6.b, v7.b }[12], [x27]
+# CHECK-NEXT:  2      8     1.00    *                   ld4	{ v5.h, v6.h, v7.h, v8.h }[0], [x4]
+# CHECK-NEXT:  3      8     1.00    *                   ld4	{ v0.d, v1.d, v2.d, v3.d }[1], [x0], #32
+# CHECK-NEXT:  3      8     1.00    *                   ld4	{ v0.h, v1.h, v2.h, v3.h }[7], [x0], x0
+# CHECK-NEXT:  2      8     1.00    *                   ld4	{ v0.s, v1.s, v2.s, v3.s }[0], [x26]
+# CHECK-NEXT:  2      8     1.00    *                   ld4r	{ v20.8b, v21.8b, v22.8b, v23.8b }, [x23]
+# CHECK-NEXT:  2      8     1.00    *                   ld4r	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x25]
+# CHECK-NEXT:  2      8     1.00    *                   ld4r	{ v16.4h, v17.4h, v18.4h, v19.4h }, [x6]
+# CHECK-NEXT:  2      8     1.00    *                   ld4r	{ v0.1d, v1.1d, v2.1d, v3.1d }, [sp]
+# CHECK-NEXT:  2      8     1.00    *                   ld4r	{ v0.2d, v1.2d, v2.2d, v3.2d }, [sp]
+# CHECK-NEXT:  2      8     1.00    *                   ld4r	{ v4.8h, v5.8h, v6.8h, v7.8h }, [x23]
+# CHECK-NEXT:  2      8     1.00    *                   ld4r	{ v0.2s, v1.2s, v2.2s, v3.2s }, [x30]
+# CHECK-NEXT:  3      8     1.00    *                   ld4r	{ v0.2s, v1.2s, v2.2s, v3.2s }, [sp], #16
+# CHECK-NEXT:  2      8     1.00    *                   ld4r	{ v7.4s, v8.4s, v9.4s, v10.4s }, [x23]
+# CHECK-NEXT:  3      8     1.00    *                   ld4r	{ v0.4s, v1.4s, v2.4s, v3.4s }, [sp], x8
+# CHECK-NEXT:  3      8     1.00    *                   ld4r	{ v0.1d, v1.1d, v2.1d, v3.1d }, [sp], x7
+# CHECK-NEXT:  2      8     1.00    *                   ld4r	{ v0.2s, v1.2s, v2.2s, v3.2s }, [sp]
+# CHECK-NEXT:  3      8     1.00    *                   ld4r	{ v0.2s, v1.2s, v2.2s, v3.2s }, [sp], x30
 # CHECK-NEXT:  1      4     0.50                        mla	v0.8b, v0.8b, v0.8b
 # CHECK-NEXT:  1      4     0.50                        mla	v15.8h, v22.8h, v4.h[3]
 # CHECK-NEXT:  1      4     0.50                        mla	v28.2s, v10.2s, v2.s[0]
@@ -744,29 +744,29 @@
 # CHECK-NEXT:  1      2     0.50                        saddlv	s0, v0.4h
 # CHECK-NEXT:  2      4     0.50                        saddlv	s0, v0.8h
 # CHECK-NEXT:  2      4     0.50                        saddlv	h0, v0.8b
-# CHECK-NEXT:  2      4     1.00                        saddlv	h0, v0.16b
+# CHECK-NEXT:  1      4     1.00                        saddlv	h0, v0.16b
 # CHECK-NEXT:  1      2     0.25                        saddw	v0.2d, v0.2d, v0.2s
 # CHECK-NEXT:  1      2     0.25                        saddw	v0.4s, v0.4s, v0.4h
 # CHECK-NEXT:  1      2     0.25                        saddw	v0.8h, v0.8h, v0.8b
 # CHECK-NEXT:  1      2     0.25                        saddw2	v0.2d, v0.2d, v0.4s
 # CHECK-NEXT:  1      2     0.25                        saddw2	v0.4s, v0.4s, v0.8h
 # CHECK-NEXT:  1      2     0.25                        saddw2	v0.8h, v0.8h, v0.16b
-# CHECK-NEXT:  4      6     1.00                        scvtf	h4, h8, #9
-# CHECK-NEXT:  4      6     1.00                        scvtf	h5, h14
+# CHECK-NEXT:  1      6     1.00                        scvtf	h4, h8, #9
+# CHECK-NEXT:  1      6     1.00                        scvtf	h5, h14
 # CHECK-NEXT:  1      3     0.50                        scvtf	d21, d12
 # CHECK-NEXT:  1      3     0.50                        scvtf	d21, d12, #64
-# CHECK-NEXT:  2      4     1.00                        scvtf	s22, s13
-# CHECK-NEXT:  2      4     1.00                        scvtf	s22, s13, #32
+# CHECK-NEXT:  1      4     1.00                        scvtf	s22, s13
+# CHECK-NEXT:  1      4     1.00                        scvtf	s22, s13, #32
 # CHECK-NEXT:  1      3     0.50                        scvtf	v0.2d, v0.2d
 # CHECK-NEXT:  1      3     0.50                        scvtf	v0.2d, v0.2d, #3
 # CHECK-NEXT:  1      3     0.50                        scvtf	v0.2s, v0.2s
 # CHECK-NEXT:  1      3     0.50                        scvtf	v0.2s, v0.2s, #3
-# CHECK-NEXT:  2      4     1.00                        scvtf	v0.4h, v0.4h
-# CHECK-NEXT:  2      4     1.00                        scvtf	v0.4s, v0.4s
-# CHECK-NEXT:  2      4     1.00                        scvtf	v0.4s, v0.4s, #3
-# CHECK-NEXT:  2      4     1.00                        scvtf	v25.4h, v13.4h, #8
-# CHECK-NEXT:  4      6     1.00                        scvtf	v0.8h, v0.8h
-# CHECK-NEXT:  4      6     1.00                        scvtf	v4.8h, v8.8h, #10
+# CHECK-NEXT:  1      4     1.00                        scvtf	v0.4h, v0.4h
+# CHECK-NEXT:  1      4     1.00                        scvtf	v0.4s, v0.4s
+# CHECK-NEXT:  1      4     1.00                        scvtf	v0.4s, v0.4s, #3
+# CHECK-NEXT:  1      4     1.00                        scvtf	v25.4h, v13.4h, #8
+# CHECK-NEXT:  1      6     1.00                        scvtf	v0.8h, v0.8h
+# CHECK-NEXT:  1      6     1.00                        scvtf	v4.8h, v8.8h, #10
 # CHECK-NEXT:  1      3     0.25                        sdot	v0.2s, v0.8b, v0.4b[2]
 # CHECK-NEXT:  1      3     0.25                        sdot	v0.2s, v0.8b, v0.8b
 # CHECK-NEXT:  1      3     0.25                        sdot	v0.4s, v0.16b, v0.16b
@@ -812,7 +812,7 @@
 # CHECK-NEXT:  1      2     0.25                        smaxp	v21.8h, v16.8h, v7.8h
 # CHECK-NEXT:  1      2     0.25                        smaxp	v0.8b, v0.8b, v0.8b
 # CHECK-NEXT:  2      4     0.50                        smaxv	b0, v0.8b
-# CHECK-NEXT:  2      4     1.00                        smaxv	b0, v0.16b
+# CHECK-NEXT:  1      4     1.00                        smaxv	b0, v0.16b
 # CHECK-NEXT:  1      2     0.50                        smaxv	h0, v0.4h
 # CHECK-NEXT:  2      4     0.50                        smaxv	h0, v0.8h
 # CHECK-NEXT:  1      2     0.50                        smaxv	s0, v0.4s
@@ -823,7 +823,7 @@
 # CHECK-NEXT:  1      2     0.25                        sminp	v0.4s, v0.4s, v0.4s
 # CHECK-NEXT:  1      2     0.25                        sminp	v0.8h, v0.8h, v0.8h
 # CHECK-NEXT:  2      4     0.50                        sminv	b0, v0.8b
-# CHECK-NEXT:  2      4     1.00                        sminv	b0, v0.16b
+# CHECK-NEXT:  1      4     1.00                        sminv	b0, v0.16b
 # CHECK-NEXT:  1      2     0.50                        sminv	h0, v0.4h
 # CHECK-NEXT:  2      4     0.50                        sminv	h0, v0.8h
 # CHECK-NEXT:  1      2     0.50                        sminv	s0, v0.4s
@@ -1126,89 +1126,89 @@
 # CHECK-NEXT:  1      2     0.25                        ssubw2	v0.8h, v0.8h, v0.16b
 # CHECK-NEXT:  2      2     0.50           *            st1	{ v18.8b }, [x15]
 # CHECK-NEXT:  2      2     0.50           *            st1	{ v8.8b, v9.8b }, [x18]
-# CHECK-NEXT:  4      2     1.00           *            st1	{ v15.8b, v16.8b, v17.8b }, [x0]
-# CHECK-NEXT:  4      2     1.00           *            st1	{ v21.8b, v22.8b, v23.8b, v24.8b }, [x14]
+# CHECK-NEXT:  2      2     1.00           *            st1	{ v15.8b, v16.8b, v17.8b }, [x0]
+# CHECK-NEXT:  2      2     1.00           *            st1	{ v21.8b, v22.8b, v23.8b, v24.8b }, [x14]
 # CHECK-NEXT:  2      2     0.50           *            st1	{ v0.16b }, [x0]
-# CHECK-NEXT:  4      2     1.00           *            st1	{ v1.16b, v2.16b }, [x4]
-# CHECK-NEXT:  6      2     1.50           *            st1	{ v27.16b, v28.16b, v29.16b }, [x18]
-# CHECK-NEXT:  8      2     2.00           *            st1	{ v18.16b, v19.16b, v20.16b, v21.16b }, [x29]
+# CHECK-NEXT:  2      2     1.00           *            st1	{ v1.16b, v2.16b }, [x4]
+# CHECK-NEXT:  2      2     1.50           *            st1	{ v27.16b, v28.16b, v29.16b }, [x18]
+# CHECK-NEXT:  2      2     2.00           *            st1	{ v18.16b, v19.16b, v20.16b, v21.16b }, [x29]
 # CHECK-NEXT:  2      2     0.50           *            st1	{ v19.4h }, [x7]
 # CHECK-NEXT:  2      2     0.50           *            st1	{ v22.4h, v23.4h }, [x22]
-# CHECK-NEXT:  4      2     1.00           *            st1	{ v13.4h, v14.4h, v15.4h }, [x7]
-# CHECK-NEXT:  4      2     1.00           *            st1	{ v23.4h, v24.4h, v25.4h, v26.4h }, [x24]
+# CHECK-NEXT:  2      2     1.00           *            st1	{ v13.4h, v14.4h, v15.4h }, [x7]
+# CHECK-NEXT:  2      2     1.00           *            st1	{ v23.4h, v24.4h, v25.4h, v26.4h }, [x24]
 # CHECK-NEXT:  2      2     0.50           *            st1	{ v27.8h }, [x17]
-# CHECK-NEXT:  6      2     1.50           *            st1	{ v8.8h, v9.8h, v10.8h }, [x16]
-# CHECK-NEXT:  8      2     2.00           *            st1	{ v7.8h, v8.8h, v9.8h, v10.8h }, [x19]
+# CHECK-NEXT:  2      2     1.50           *            st1	{ v8.8h, v9.8h, v10.8h }, [x16]
+# CHECK-NEXT:  2      2     2.00           *            st1	{ v7.8h, v8.8h, v9.8h, v10.8h }, [x19]
 # CHECK-NEXT:  2      2     0.50           *            st1	{ v25.2s }, [x6]
 # CHECK-NEXT:  2      2     0.50           *            st1	{ v13.2s, v14.2s }, [x9]
-# CHECK-NEXT:  4      2     1.00           *            st1	{ v12.2s, v13.2s, v14.2s }, [x3]
-# CHECK-NEXT:  4      2     1.00           *            st1	{ v6.2s, v7.2s, v8.2s, v9.2s }, [x13]
-# CHECK-NEXT:  5      2     1.00           *            st1	{ v0.4s, v1.4s }, [sp], #32
+# CHECK-NEXT:  2      2     1.00           *            st1	{ v12.2s, v13.2s, v14.2s }, [x3]
+# CHECK-NEXT:  2      2     1.00           *            st1	{ v6.2s, v7.2s, v8.2s, v9.2s }, [x13]
+# CHECK-NEXT:  3      2     1.00           *            st1	{ v0.4s, v1.4s }, [sp], #32
 # CHECK-NEXT:  2      2     0.50           *            st1	{ v22.4s }, [x19]
-# CHECK-NEXT:  4      2     1.00           *            st1	{ v15.4s, v16.4s }, [x12]
-# CHECK-NEXT:  8      2     2.00           *            st1	{ v26.4s, v27.4s, v28.4s, v29.4s }, [x12]
+# CHECK-NEXT:  2      2     1.00           *            st1	{ v15.4s, v16.4s }, [x12]
+# CHECK-NEXT:  2      2     2.00           *            st1	{ v26.4s, v27.4s, v28.4s, v29.4s }, [x12]
 # CHECK-NEXT:  2      2     0.50           *            st1	{ v20.1d }, [x10]
 # CHECK-NEXT:  2      2     0.50           *            st1	{ v21.1d, v22.1d }, [x29]
-# CHECK-NEXT:  4      2     1.00           *            st1	{ v5.1d, v6.1d, v7.1d }, [x3]
-# CHECK-NEXT:  4      2     1.00           *            st1	{ v0.1d, v1.1d, v2.1d, v3.1d }, [x10]
-# CHECK-NEXT:  4      2     1.00           *            st1	{ v26.2d, v27.2d }, [x28]
-# CHECK-NEXT:  7      2     1.50           *            st1	{ v0.2d, v1.2d, v2.2d }, [x0], #48
-# CHECK-NEXT:  6      2     1.50           *            st1	{ v13.2d, v14.2d, v15.2d }, [x27]
-# CHECK-NEXT:  8      2     2.00           *            st1	{ v0.2d, v1.2d, v2.2d, v3.2d }, [x0]
+# CHECK-NEXT:  2      2     1.00           *            st1	{ v5.1d, v6.1d, v7.1d }, [x3]
+# CHECK-NEXT:  2      2     1.00           *            st1	{ v0.1d, v1.1d, v2.1d, v3.1d }, [x10]
+# CHECK-NEXT:  2      2     1.00           *            st1	{ v26.2d, v27.2d }, [x28]
+# CHECK-NEXT:  3      2     1.50           *            st1	{ v0.2d, v1.2d, v2.2d }, [x0], #48
+# CHECK-NEXT:  2      2     1.50           *            st1	{ v13.2d, v14.2d, v15.2d }, [x27]
+# CHECK-NEXT:  2      2     2.00           *            st1	{ v0.2d, v1.2d, v2.2d, v3.2d }, [x0]
 # CHECK-NEXT:  2      2     0.50           *            st1	{ v8.2d }, [x15]
 # CHECK-NEXT:  3      2     0.50           *            st1	{ v0.8h }, [x15], x2
-# CHECK-NEXT:  4      2     1.00           *            st1	{ v0.8h, v1.8h }, [x15]
-# CHECK-NEXT:  5      2     1.00           *            st1	{ v0.4s, v1.4s }, [sp], #32
-# CHECK-NEXT:  6      2     1.50           *            st1	{ v0.4s, v1.4s, v2.4s }, [sp]
-# CHECK-NEXT:  5      2     1.00           *            st1	{ v0.8b, v1.8b, v2.8b, v3.8b }, [x0], x3
+# CHECK-NEXT:  2      2     1.00           *            st1	{ v0.8h, v1.8h }, [x15]
+# CHECK-NEXT:  3      2     1.00           *            st1	{ v0.4s, v1.4s }, [sp], #32
+# CHECK-NEXT:  2      2     1.50           *            st1	{ v0.4s, v1.4s, v2.4s }, [sp]
+# CHECK-NEXT:  3      2     1.00           *            st1	{ v0.8b, v1.8b, v2.8b, v3.8b }, [x0], x3
 # CHECK-NEXT:  2      4     0.50           *            st1	{ v1.b }[5], [x1]
 # CHECK-NEXT:  2      4     0.50           *            st1	{ v0.h }[2], [x1]
 # CHECK-NEXT:  2      4     0.50           *            st1	{ v31.s }[1], [x16]
 # CHECK-NEXT:  3      2     0.50           *            st1	{ v0.8h }, [x15], x2
-# CHECK-NEXT:  4      2     1.00           *            st1	{ v0.8h, v1.8h }, [x15]
+# CHECK-NEXT:  2      2     1.00           *            st1	{ v0.8h, v1.8h }, [x15]
 # CHECK-NEXT:  2      4     0.50           *            st1	{ v0.d }[1], [x0]
 # CHECK-NEXT:  3      4     0.50           *            st1	{ v0.d }[1], [x0], #8
-# CHECK-NEXT:  5      4     1.00           *            st2	{ v0.16b, v1.16b }, [x0], x1
+# CHECK-NEXT:  3      4     1.00           *            st2	{ v0.16b, v1.16b }, [x0], x1
 # CHECK-NEXT:  2      4     0.50           *            st2	{ v0.8b, v1.8b }, [x0]
-# CHECK-NEXT:  4      4     1.00           *            st2	{ v6.16b, v7.16b }, [x23]
+# CHECK-NEXT:  2      4     1.00           *            st2	{ v6.16b, v7.16b }, [x23]
 # CHECK-NEXT:  2      4     0.50           *            st2	{ v10.4h, v11.4h }, [x18]
-# CHECK-NEXT:  4      4     1.00           *            st2	{ v10.8h, v11.8h }, [x18]
+# CHECK-NEXT:  2      4     1.00           *            st2	{ v10.8h, v11.8h }, [x18]
 # CHECK-NEXT:  2      4     0.50           *            st2	{ v25.2s, v26.2s }, [x29]
-# CHECK-NEXT:  4      4     1.00           *            st2	{ v26.4s, v27.4s }, [x14]
-# CHECK-NEXT:  4      4     1.00           *            st2	{ v10.2d, v11.2d }, [x1]
+# CHECK-NEXT:  2      4     1.00           *            st2	{ v26.4s, v27.4s }, [x14]
+# CHECK-NEXT:  2      4     1.00           *            st2	{ v10.2d, v11.2d }, [x1]
 # CHECK-NEXT:  2      4     0.50           *            st2	{ v21.b, v22.b }[15], [x15]
 # CHECK-NEXT:  2      4     0.50           *            st2	{ v28.h, v29.h }[2], [x6]
 # CHECK-NEXT:  2      4     0.50           *            st2	{ v0.s, v1.s }[3], [sp]
 # CHECK-NEXT:  3      4     0.50           *            st2	{ v0.s, v1.s }[3], [sp], #8
 # CHECK-NEXT:  2      4     0.50           *            st2	{ v17.d, v18.d }[1], [x1]
-# CHECK-NEXT:  4      4     1.00           *            st3	{ v10.8b, v11.8b, v12.8b }, [x18]
-# CHECK-NEXT:  6      5     1.50           *            st3	{ v26.16b, v27.16b, v28.16b }, [x4]
-# CHECK-NEXT:  4      4     1.00           *            st3	{ v0.4h, v1.4h, v2.4h }, [x15]
-# CHECK-NEXT:  7      5     1.50           *            st3	{ v0.8h, v1.8h, v2.8h }, [x15], x2
-# CHECK-NEXT:  6      5     1.50           *            st3	{ v0.8h, v1.8h, v2.8h }, [x0]
-# CHECK-NEXT:  4      4     1.00           *            st3	{ v19.2s, v20.2s, v21.2s }, [x30]
-# CHECK-NEXT:  6      5     1.50           *            st3	{ v24.4s, v25.4s, v26.4s }, [x8]
-# CHECK-NEXT:  6      5     1.50           *            st3	{ v24.2d, v25.2d, v26.2d }, [x25]
-# CHECK-NEXT:  4      4     1.00           *            st3	{ v8.b, v9.b, v10.b }[4], [x18]
-# CHECK-NEXT:  4      4     1.00           *            st3	{ v0.h, v1.h, v2.h }[7], [x15]
-# CHECK-NEXT:  5      4     1.00           *            st3	{ v0.h, v1.h, v2.h }[7], [x15], #6
-# CHECK-NEXT:  4      4     1.00           *            st3	{ v9.s, v10.s, v11.s }[2], [x20]
-# CHECK-NEXT:  4      4     1.00           *            st3	{ v16.d, v17.d, v18.d }[0], [x13]
-# CHECK-NEXT:  6      6     1.50           *            st4	{ v17.8b, v18.8b, v19.8b, v20.8b }, [x8]
-# CHECK-NEXT:  12     7     3.00           *            st4	{ v7.16b, v8.16b, v9.16b, v10.16b }, [x15]
-# CHECK-NEXT:  6      6     1.50           *            st4	{ v5.4h, v6.4h, v7.4h, v8.4h }, [x13]
-# CHECK-NEXT:  12     7     3.00           *            st4	{ v11.8h, v12.8h, v13.8h, v14.8h }, [x1]
-# CHECK-NEXT:  6      6     1.50           *            st4	{ v0.2s, v1.2s, v2.2s, v3.2s }, [sp]
-# CHECK-NEXT:  13     7     3.00           *            st4	{ v0.4s, v1.4s, v2.4s, v3.4s }, [sp], #64
-# CHECK-NEXT:  12     7     3.00           *            st4	{ v21.4s, v22.4s, v23.4s, v24.4s }, [x6]
-# CHECK-NEXT:  8      4     2.00           *            st4	{ v25.2d, v26.2d, v27.2d, v28.2d }, [x16]
-# CHECK-NEXT:  6      6     1.00           *            st4	{ v0.b, v1.b, v2.b, v3.b }[15], [x0]
-# CHECK-NEXT:  6      6     1.00           *            st4	{ v5.h, v6.h, v7.h, v8.h }[4], [x13]
-# CHECK-NEXT:  6      6     1.00           *            st4	{ v22.s, v23.s, v24.s, v25.s }[0], [x7]
-# CHECK-NEXT:  4      4     1.00           *            st4	{ v23.d, v24.d, v25.d, v26.d }[1], [x5]
-# CHECK-NEXT:  6      6     1.00           *            st4	{ v0.b, v1.b, v2.b, v3.b }[9], [x0]
-# CHECK-NEXT:  7      6     1.00           *            st4	{ v0.b, v1.b, v2.b, v3.b }[9], [x0], x5
-# CHECK-NEXT:  5      4     1.00           *            st4	{ v0.d, v1.d, v2.d, v3.d }[1], [x0], x5
+# CHECK-NEXT:  2      4     1.00           *            st3	{ v10.8b, v11.8b, v12.8b }, [x18]
+# CHECK-NEXT:  2      5     1.50           *            st3	{ v26.16b, v27.16b, v28.16b }, [x4]
+# CHECK-NEXT:  2      4     1.00           *            st3	{ v0.4h, v1.4h, v2.4h }, [x15]
+# CHECK-NEXT:  3      5     1.50           *            st3	{ v0.8h, v1.8h, v2.8h }, [x15], x2
+# CHECK-NEXT:  2      5     1.50           *            st3	{ v0.8h, v1.8h, v2.8h }, [x0]
+# CHECK-NEXT:  2      4     1.00           *            st3	{ v19.2s, v20.2s, v21.2s }, [x30]
+# CHECK-NEXT:  2      5     1.50           *            st3	{ v24.4s, v25.4s, v26.4s }, [x8]
+# CHECK-NEXT:  2      5     1.50           *            st3	{ v24.2d, v25.2d, v26.2d }, [x25]
+# CHECK-NEXT:  2      4     1.00           *            st3	{ v8.b, v9.b, v10.b }[4], [x18]
+# CHECK-NEXT:  2      4     1.00           *            st3	{ v0.h, v1.h, v2.h }[7], [x15]
+# CHECK-NEXT:  3      4     1.00           *            st3	{ v0.h, v1.h, v2.h }[7], [x15], #6
+# CHECK-NEXT:  2      4     1.00           *            st3	{ v9.s, v10.s, v11.s }[2], [x20]
+# CHECK-NEXT:  2      4     1.00           *            st3	{ v16.d, v17.d, v18.d }[0], [x13]
+# CHECK-NEXT:  2      6     1.50           *            st4	{ v17.8b, v18.8b, v19.8b, v20.8b }, [x8]
+# CHECK-NEXT:  2      7     3.00           *            st4	{ v7.16b, v8.16b, v9.16b, v10.16b }, [x15]
+# CHECK-NEXT:  2      6     1.50           *            st4	{ v5.4h, v6.4h, v7.4h, v8.4h }, [x13]
+# CHECK-NEXT:  2      7     3.00           *            st4	{ v11.8h, v12.8h, v13.8h, v14.8h }, [x1]
+# CHECK-NEXT:  2      6     1.50           *            st4	{ v0.2s, v1.2s, v2.2s, v3.2s }, [sp]
+# CHECK-NEXT:  3      7     3.00           *            st4	{ v0.4s, v1.4s, v2.4s, v3.4s }, [sp], #64
+# CHECK-NEXT:  2      7     3.00           *            st4	{ v21.4s, v22.4s, v23.4s, v24.4s }, [x6]
+# CHECK-NEXT:  2      4     2.00           *            st4	{ v25.2d, v26.2d, v27.2d, v28.2d }, [x16]
+# CHECK-NEXT:  2      6     1.00           *            st4	{ v0.b, v1.b, v2.b, v3.b }[15], [x0]
+# CHECK-NEXT:  2      6     1.00           *            st4	{ v5.h, v6.h, v7.h, v8.h }[4], [x13]
+# CHECK-NEXT:  2      6     1.00           *            st4	{ v22.s, v23.s, v24.s, v25.s }[0], [x7]
+# CHECK-NEXT:  2      4     1.00           *            st4	{ v23.d, v24.d, v25.d, v26.d }[1], [x5]
+# CHECK-NEXT:  2      6     1.00           *            st4	{ v0.b, v1.b, v2.b, v3.b }[9], [x0]
+# CHECK-NEXT:  3      6     1.00           *            st4	{ v0.b, v1.b, v2.b, v3.b }[9], [x0], x5
+# CHECK-NEXT:  3      4     1.00           *            st4	{ v0.d, v1.d, v2.d, v3.d }[1], [x0], x5
 # CHECK-NEXT:  1      2     0.25                        sub	d15, d5, d16
 # CHECK-NEXT:  1      2     0.25                        sub	v0.2d, v0.2d, v0.2d
 # CHECK-NEXT:  1      2     0.25                        sub	v15.2s, v14.2s, v11.2s
@@ -1225,22 +1225,22 @@
 # CHECK-NEXT:  1      2     0.25                        suqadd	v0.4s, v0.4s
 # CHECK-NEXT:  1      2     0.25                        suqadd	v0.8b, v0.8b
 # CHECK-NEXT:  1      2     0.25                        suqadd	v0.8h, v0.8h
-# CHECK-NEXT:  2      2     1.00                        tbl	v0.16b, { v0.16b }, v0.16b
-# CHECK-NEXT:  2      2     1.00                        tbl	v0.16b, { v0.16b, v1.16b }, v0.16b
-# CHECK-NEXT:  2      4     1.00                        tbl	v0.16b, { v0.16b, v1.16b, v2.16b }, v0.16b
-# CHECK-NEXT:  3      4     1.50                        tbl	v0.16b, { v0.16b, v1.16b, v2.16b, v3.16b }, v0.16b
-# CHECK-NEXT:  2      2     1.00                        tbl	v0.8b, { v0.16b }, v0.8b
-# CHECK-NEXT:  2      2     1.00                        tbl	v0.8b, { v0.16b, v1.16b }, v0.8b
-# CHECK-NEXT:  2      4     1.00                        tbl	v0.8b, { v0.16b, v1.16b, v2.16b }, v0.8b
-# CHECK-NEXT:  3      4     1.50                        tbl	v0.8b, { v0.16b, v1.16b, v2.16b, v3.16b }, v0.8b
-# CHECK-NEXT:  2      2     1.00                        tbx	v0.16b, { v0.16b }, v0.16b
-# CHECK-NEXT:  2      4     1.00                        tbx	v0.16b, { v0.16b, v1.16b }, v0.16b
-# CHECK-NEXT:  3      6     1.50                        tbx	v0.16b, { v0.16b, v1.16b, v2.16b }, v0.16b
-# CHECK-NEXT:  5      6     2.50                        tbx	v0.16b, { v0.16b, v1.16b, v2.16b, v3.16b }, v0.16b
-# CHECK-NEXT:  2      2     1.00                        tbx	v0.8b, { v0.16b }, v0.8b
-# CHECK-NEXT:  2      4     1.00                        tbx	v0.8b, { v0.16b, v1.16b }, v0.8b
-# CHECK-NEXT:  3      6     1.50                        tbx	v0.8b, { v0.16b, v1.16b, v2.16b }, v0.8b
-# CHECK-NEXT:  5      6     2.50                        tbx	v0.8b, { v0.16b, v1.16b, v2.16b, v3.16b }, v0.8b
+# CHECK-NEXT:  1      2     1.00                        tbl	v0.16b, { v0.16b }, v0.16b
+# CHECK-NEXT:  1      2     1.00                        tbl	v0.16b, { v0.16b, v1.16b }, v0.16b
+# CHECK-NEXT:  1      4     1.00                        tbl	v0.16b, { v0.16b, v1.16b, v2.16b }, v0.16b
+# CHECK-NEXT:  1      4     1.50                        tbl	v0.16b, { v0.16b, v1.16b, v2.16b, v3.16b }, v0.16b
+# CHECK-NEXT:  1      2     1.00                        tbl	v0.8b, { v0.16b }, v0.8b
+# CHECK-NEXT:  1      2     1.00                        tbl	v0.8b, { v0.16b, v1.16b }, v0.8b
+# CHECK-NEXT:  1      4     1.00                        tbl	v0.8b, { v0.16b, v1.16b, v2.16b }, v0.8b
+# CHECK-NEXT:  1      4     1.50                        tbl	v0.8b, { v0.16b, v1.16b, v2.16b, v3.16b }, v0.8b
+# CHECK-NEXT:  1      2     1.00                        tbx	v0.16b, { v0.16b }, v0.16b
+# CHECK-NEXT:  1      4     1.00                        tbx	v0.16b, { v0.16b, v1.16b }, v0.16b
+# CHECK-NEXT:  1      6     1.50                        tbx	v0.16b, { v0.16b, v1.16b, v2.16b }, v0.16b
+# CHECK-NEXT:  1      6     2.50                        tbx	v0.16b, { v0.16b, v1.16b, v2.16b, v3.16b }, v0.16b
+# CHECK-NEXT:  1      2     1.00                        tbx	v0.8b, { v0.16b }, v0.8b
+# CHECK-NEXT:  1      4     1.00                        tbx	v0.8b, { v0.16b, v1.16b }, v0.8b
+# CHECK-NEXT:  1      6     1.50                        tbx	v0.8b, { v0.16b, v1.16b, v2.16b }, v0.8b
+# CHECK-NEXT:  1      6     2.50                        tbx	v0.8b, { v0.16b, v1.16b, v2.16b, v3.16b }, v0.8b
 # CHECK-NEXT:  1      2     0.25                        trn1	v0.16b, v0.16b, v0.16b
 # CHECK-NEXT:  1      2     0.25                        trn1	v0.2d, v0.2d, v0.2d
 # CHECK-NEXT:  1      2     0.25                        trn1	v0.2s, v0.2s, v0.2s
@@ -1293,7 +1293,7 @@
 # CHECK-NEXT:  1      2     0.50                        uaddlv	s0, v0.4h
 # CHECK-NEXT:  2      4     0.50                        uaddlv	s0, v0.8h
 # CHECK-NEXT:  2      4     0.50                        uaddlv	h0, v0.8b
-# CHECK-NEXT:  2      4     1.00                        uaddlv	h0, v0.16b
+# CHECK-NEXT:  1      4     1.00                        uaddlv	h0, v0.16b
 # CHECK-NEXT:  1      2     0.25                        uaddw	v0.2d, v0.2d, v0.2s
 # CHECK-NEXT:  1      2     0.25                        uaddw	v0.4s, v0.4s, v0.4h
 # CHECK-NEXT:  1      2     0.25                        uaddw	v0.8h, v0.8h, v0.8b
@@ -1301,23 +1301,23 @@
 # CHECK-NEXT:  1      2     0.25                        uaddw2	v0.4s, v0.4s, v0.8h
 # CHECK-NEXT:  1      2     0.25                        uaddw2	v0.8h, v0.8h, v0.16b
 # CHECK-NEXT:  1      3     1.00                        ucvtf	h17, x12
-# CHECK-NEXT:  4      6     1.00                        ucvtf	h22, h16, #11
-# CHECK-NEXT:  4      6     1.00                        ucvtf	h7, h21
+# CHECK-NEXT:  1      6     1.00                        ucvtf	h22, h16, #11
+# CHECK-NEXT:  1      6     1.00                        ucvtf	h7, h21
 # CHECK-NEXT:  1      3     0.50                        ucvtf	d21, d14
 # CHECK-NEXT:  1      3     0.50                        ucvtf	d21, d14, #64
 # CHECK-NEXT:  1      3     1.00                        ucvtf	s8, x0
-# CHECK-NEXT:  2      4     1.00                        ucvtf	s22, s13
-# CHECK-NEXT:  2      4     1.00                        ucvtf	s22, s13, #32
+# CHECK-NEXT:  1      4     1.00                        ucvtf	s22, s13
+# CHECK-NEXT:  1      4     1.00                        ucvtf	s22, s13, #32
 # CHECK-NEXT:  1      3     0.50                        ucvtf	v0.2d, v0.2d
 # CHECK-NEXT:  1      3     0.50                        ucvtf	v0.2d, v0.2d, #3
 # CHECK-NEXT:  1      3     0.50                        ucvtf	v0.2s, v0.2s
 # CHECK-NEXT:  1      3     0.50                        ucvtf	v0.2s, v0.2s, #3
-# CHECK-NEXT:  2      4     1.00                        ucvtf	v0.4h, v0.4h
-# CHECK-NEXT:  2      4     1.00                        ucvtf	v0.4s, v0.4s
-# CHECK-NEXT:  2      4     1.00                        ucvtf	v0.4s, v0.4s, #3
-# CHECK-NEXT:  2      4     1.00                        ucvtf	v18.4h, v11.4h, #7
-# CHECK-NEXT:  4      6     1.00                        ucvtf	v0.8h, v0.8h
-# CHECK-NEXT:  4      6     1.00                        ucvtf	v22.8h, v20.8h, #10
+# CHECK-NEXT:  1      4     1.00                        ucvtf	v0.4h, v0.4h
+# CHECK-NEXT:  1      4     1.00                        ucvtf	v0.4s, v0.4s
+# CHECK-NEXT:  1      4     1.00                        ucvtf	v0.4s, v0.4s, #3
+# CHECK-NEXT:  1      4     1.00                        ucvtf	v18.4h, v11.4h, #7
+# CHECK-NEXT:  1      6     1.00                        ucvtf	v0.8h, v0.8h
+# CHECK-NEXT:  1      6     1.00                        ucvtf	v22.8h, v20.8h, #10
 # CHECK-NEXT:  1      3     0.25                        udot	v0.2s, v0.8b, v0.4b[2]
 # CHECK-NEXT:  1      3     0.25                        udot	v0.2s, v0.8b, v0.8b
 # CHECK-NEXT:  1      3     0.25                        udot	v0.4s, v0.16b, v0.16b
@@ -1333,7 +1333,7 @@
 # CHECK-NEXT:  1      2     0.25                        umaxp	v0.4s, v0.4s, v0.4s
 # CHECK-NEXT:  1      2     0.25                        umaxp	v0.8h, v0.8h, v0.8h
 # CHECK-NEXT:  2      4     0.50                        umaxv	b0, v0.8b
-# CHECK-NEXT:  2      4     1.00                        umaxv	b0, v0.16b
+# CHECK-NEXT:  1      4     1.00                        umaxv	b0, v0.16b
 # CHECK-NEXT:  1      2     0.50                        umaxv	h0, v0.4h
 # CHECK-NEXT:  2      4     0.50                        umaxv	h0, v0.8h
 # CHECK-NEXT:  1      2     0.50                        umaxv	s0, v0.4s
@@ -1346,7 +1346,7 @@
 # CHECK-NEXT:  1      2     0.25                        uminp	v0.4h, v0.4h, v0.4h
 # CHECK-NEXT:  1      2     0.25                        uminp	v0.8b, v0.8b, v0.8b
 # CHECK-NEXT:  2      4     0.50                        uminv	b0, v0.8b
-# CHECK-NEXT:  2      4     1.00                        uminv	b0, v0.16b
+# CHECK-NEXT:  1      4     1.00                        uminv	b0, v0.16b
 # CHECK-NEXT:  1      2     0.50                        uminv	h0, v0.4h
 # CHECK-NEXT:  2      4     0.50                        uminv	h0, v0.8h
 # CHECK-NEXT:  1      2     0.50                        uminv	s0, v0.4s

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/V1-sve-instructions.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/V1-sve-instructions.s
@@ -2591,11 +2591,11 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          AND_ZPmZ_S                 and	z31.s, p7/m, z31.s, z31.s
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          AND_ZI                     and	z5.b, z5.b, #0x6
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          AND_ZI                     and	z5.b, z5.b, #0xf9
-# CHECK-NEXT:  2      2     2.00                         2     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          ANDS_PPzPP                 ands	p0.b, p0/z, p0.b, p1.b
-# CHECK-NEXT:  4      12    2.00                         12    V1UnitV[4],V1UnitV01[4]                    ANDV_VPZ_B                 andv	b0, p7, z31.b
-# CHECK-NEXT:  4      12    2.00                         12    V1UnitV[4],V1UnitV01[4]                    ANDV_VPZ_D                 andv	d0, p7, z31.d
-# CHECK-NEXT:  4      12    2.00                         12    V1UnitV[4],V1UnitV01[4]                    ANDV_VPZ_H                 andv	h0, p7, z31.h
-# CHECK-NEXT:  4      12    2.00                         12    V1UnitV[4],V1UnitV01[4]                    ANDV_VPZ_S                 andv	s0, p7, z31.s
+# CHECK-NEXT:  1      2     2.00                         2     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          ANDS_PPzPP                 ands	p0.b, p0/z, p0.b, p1.b
+# CHECK-NEXT:  1      12    2.00                         12    V1UnitV[4],V1UnitV01[4]                    ANDV_VPZ_B                 andv	b0, p7, z31.b
+# CHECK-NEXT:  1      12    2.00                         12    V1UnitV[4],V1UnitV01[4]                    ANDV_VPZ_D                 andv	d0, p7, z31.d
+# CHECK-NEXT:  1      12    2.00                         12    V1UnitV[4],V1UnitV01[4]                    ANDV_VPZ_H                 andv	h0, p7, z31.h
+# CHECK-NEXT:  1      12    2.00                         12    V1UnitV[4],V1UnitV01[4]                    ANDV_VPZ_S                 andv	s0, p7, z31.s
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitV,V1UnitV1,V1UnitV01,V1UnitV13       ASR_ZPmI_B                 asr	z0.b, p0/m, z0.b, #1
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitV,V1UnitV1,V1UnitV01,V1UnitV13       ASR_ZPmZ_B                 asr	z0.b, p0/m, z0.b, z0.b
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitV,V1UnitV1,V1UnitV01,V1UnitV13       ASR_WIDE_ZPmZ_B            asr	z0.b, p0/m, z0.b, z1.d
@@ -2658,26 +2658,26 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          BIC_ZPmZ_D                 bic	z31.d, p7/m, z31.d, z31.d
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          BIC_ZPmZ_H                 bic	z31.h, p7/m, z31.h, z31.h
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          BIC_ZPmZ_S                 bic	z31.s, p7/m, z31.s, z31.s
-# CHECK-NEXT:  2      2     2.00                         2     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          BICS_PPzPP                 bics	p0.b, p0/z, p0.b, p0.b
-# CHECK-NEXT:  2      2     2.00                         2     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          BICS_PPzPP                 bics	p15.b, p15/z, p15.b, p15.b
+# CHECK-NEXT:  1      2     2.00                         2     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          BICS_PPzPP                 bics	p0.b, p0/z, p0.b, p0.b
+# CHECK-NEXT:  1      2     2.00                         2     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          BICS_PPzPP                 bics	p15.b, p15/z, p15.b, p15.b
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   BRKA_PPmP                  brka	p0.b, p15/m, p15.b
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   BRKA_PPzP                  brka	p0.b, p15/z, p15.b
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          BRKAS_PPzP                 brkas	p0.b, p15/z, p15.b
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          BRKAS_PPzP                 brkas	p0.b, p15/z, p15.b
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   BRKB_PPmP                  brkb	p0.b, p15/m, p15.b
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   BRKB_PPzP                  brkb	p0.b, p15/z, p15.b
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          BRKBS_PPzP                 brkbs	p0.b, p15/z, p15.b
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          BRKBS_PPzP                 brkbs	p0.b, p15/z, p15.b
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   BRKN_PPzP                  brkn	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   BRKN_PPzP                  brkn	p15.b, p15/z, p15.b, p15.b
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          BRKNS_PPzP                 brkns	p0.b, p15/z, p1.b, p0.b
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          BRKNS_PPzP                 brkns	p15.b, p15/z, p15.b, p15.b
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          BRKNS_PPzP                 brkns	p0.b, p15/z, p1.b, p0.b
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          BRKNS_PPzP                 brkns	p15.b, p15/z, p15.b, p15.b
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   BRKPA_PPzPP                brkpa	p0.b, p15/z, p1.b, p2.b
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   BRKPA_PPzPP                brkpa	p15.b, p15/z, p15.b, p15.b
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          BRKPAS_PPzPP               brkpas	p0.b, p15/z, p1.b, p2.b
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          BRKPAS_PPzPP               brkpas	p15.b, p15/z, p15.b, p15.b
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          BRKPAS_PPzPP               brkpas	p0.b, p15/z, p1.b, p2.b
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          BRKPAS_PPzPP               brkpas	p15.b, p15/z, p15.b, p15.b
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   BRKPB_PPzPP                brkpb	p0.b, p15/z, p1.b, p2.b
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   BRKPB_PPzPP                brkpb	p15.b, p15/z, p15.b, p15.b
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          BRKPBS_PPzPP               brkpbs	p0.b, p15/z, p1.b, p2.b
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          BRKPBS_PPzPP               brkpbs	p15.b, p15/z, p15.b, p15.b
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          BRKPBS_PPzPP               brkpbs	p0.b, p15/z, p1.b, p2.b
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          BRKPBS_PPzPP               brkpbs	p15.b, p15/z, p15.b, p15.b
 # CHECK-NEXT:  1      3     1.00                         3     V1UnitV,V1UnitV1,V1UnitV01,V1UnitV13       CLASTA_VPZ_B               clasta	b0, p7, b0, z31.b
 # CHECK-NEXT:  1      3     1.00                         3     V1UnitV,V1UnitV1,V1UnitV01,V1UnitV13       CLASTA_VPZ_D               clasta	d0, p7, d0, z31.d
 # CHECK-NEXT:  1      3     1.00                         3     V1UnitV,V1UnitV1,V1UnitV01,V1UnitV13       CLASTA_VPZ_H               clasta	h0, p7, h0, z31.h
@@ -2926,10 +2926,10 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   DECP_XP_H                  decp	xzr, p15.h
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   DECP_XP_S                  decp	xzr, p15.s
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       DECD_ZPiI                  decd	z19.d
-# CHECK-NEXT:  3      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 DECP_ZP_D         decp	z31.d, p15.d
+# CHECK-NEXT:  2      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 DECP_ZP_D         decp	z31.d, p15.d
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       DECH_ZPiI                  dech	z23.h
-# CHECK-NEXT:  3      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 DECP_ZP_H         decp	z31.h, p15.h
-# CHECK-NEXT:  3      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 DECP_ZP_S         decp	z31.s, p15.s
+# CHECK-NEXT:  2      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 DECP_ZP_H         decp	z31.h, p15.h
+# CHECK-NEXT:  2      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 DECP_ZP_S         decp	z31.s, p15.s
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       DECW_ZPiI                  decw	z8.s
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   DECW_XPiI                  decw	x0
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   DECW_XPiI                  decw	x0, #14
@@ -2963,11 +2963,11 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          EOR_ZPmZ_S                 eor	z31.s, p7/m, z31.s, z31.s
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          EOR_ZI                     eor	z5.b, z5.b, #0x6
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          EOR_ZI                     eor	z5.b, z5.b, #0xf9
-# CHECK-NEXT:  2      2     2.00                         2     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          EORS_PPzPP                 eors	p0.b, p0/z, p0.b, p1.b
-# CHECK-NEXT:  4      12    2.00                         12    V1UnitV[4],V1UnitV01[4]                    EORV_VPZ_B                 eorv	b0, p7, z31.b
-# CHECK-NEXT:  4      12    2.00                         12    V1UnitV[4],V1UnitV01[4]                    EORV_VPZ_D                 eorv	d0, p7, z31.d
-# CHECK-NEXT:  4      12    2.00                         12    V1UnitV[4],V1UnitV01[4]                    EORV_VPZ_H                 eorv	h0, p7, z31.h
-# CHECK-NEXT:  4      12    2.00                         12    V1UnitV[4],V1UnitV01[4]                    EORV_VPZ_S                 eorv	s0, p7, z31.s
+# CHECK-NEXT:  1      2     2.00                         2     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          EORS_PPzPP                 eors	p0.b, p0/z, p0.b, p1.b
+# CHECK-NEXT:  1      12    2.00                         12    V1UnitV[4],V1UnitV01[4]                    EORV_VPZ_B                 eorv	b0, p7, z31.b
+# CHECK-NEXT:  1      12    2.00                         12    V1UnitV[4],V1UnitV01[4]                    EORV_VPZ_D                 eorv	d0, p7, z31.d
+# CHECK-NEXT:  1      12    2.00                         12    V1UnitV[4],V1UnitV01[4]                    EORV_VPZ_H                 eorv	h0, p7, z31.h
+# CHECK-NEXT:  1      12    2.00                         12    V1UnitV[4],V1UnitV01[4]                    EORV_VPZ_S                 eorv	s0, p7, z31.s
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          EXT_ZZI                    ext	z31.b, z31.b, z0.b, #0
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          EXT_ZZI                    ext	z31.b, z31.b, z0.b, #255
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          FABD_ZPmZ_D                fabd	z0.d, p7/m, z0.d, z31.d
@@ -3000,12 +3000,12 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          FADD_ZPmI_D                fadd	z31.d, p7/m, z31.d, #1.0
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          FADD_ZPmI_H                fadd	z31.h, p7/m, z31.h, #1.0
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          FADD_ZPmI_S                fadd	z31.s, p7/m, z31.s, #1.0
-# CHECK-NEXT:  3      8     1.50                         8     V1UnitV[3],V1UnitV01[3]                    FADDA_VPZ_D                fadda	d0, p7, d0, z31.d
-# CHECK-NEXT:  18     19    18.00                        19    V1UnitV[18],V1UnitV0[18],V1UnitV01[18],V1UnitV02[18] FADDA_VPZ_H      fadda	h0, p7, h0, z31.h
-# CHECK-NEXT:  10     11    10.00                        11    V1UnitV[10],V1UnitV0[10],V1UnitV01[10],V1UnitV02[10] FADDA_VPZ_S      fadda	s0, p7, s0, z31.s
-# CHECK-NEXT:  5      9     2.00                         9     V1UnitV[5],V1UnitV01[4]                    FADDV_VPZ_D                faddv	d0, p7, z31.d
-# CHECK-NEXT:  6      13    3.00                         13    V1UnitV[6],V1UnitV01[6]                    FADDV_VPZ_H                faddv	h0, p7, z31.h
-# CHECK-NEXT:  6      11    2.50                         11    V1UnitV[6],V1UnitV01[5]                    FADDV_VPZ_S                faddv	s0, p7, z31.s
+# CHECK-NEXT:  1      8     1.50                         8     V1UnitV[3],V1UnitV01[3]                    FADDA_VPZ_D                fadda	d0, p7, d0, z31.d
+# CHECK-NEXT:  1      19    18.00                        19    V1UnitV[18],V1UnitV0[18],V1UnitV01[18],V1UnitV02[18] FADDA_VPZ_H      fadda	h0, p7, h0, z31.h
+# CHECK-NEXT:  1      11    10.00                        11    V1UnitV[10],V1UnitV0[10],V1UnitV01[10],V1UnitV02[10] FADDA_VPZ_S      fadda	s0, p7, s0, z31.s
+# CHECK-NEXT:  2      9     2.00                         9     V1UnitV[5],V1UnitV01[4]                    FADDV_VPZ_D                faddv	d0, p7, z31.d
+# CHECK-NEXT:  1      13    3.00                         13    V1UnitV[6],V1UnitV01[6]                    FADDV_VPZ_H                faddv	h0, p7, z31.h
+# CHECK-NEXT:  2      11    2.50                         11    V1UnitV[6],V1UnitV01[5]                    FADDV_VPZ_S                faddv	s0, p7, z31.s
 # CHECK-NEXT:  1      3     0.50                         3     V1UnitV,V1UnitV01                          FCADD_ZPmZ_D               fcadd	z0.d, p0/m, z0.d, z0.d, #90
 # CHECK-NEXT:  1      3     0.50                         3     V1UnitV,V1UnitV01                          FCADD_ZPmZ_H               fcadd	z0.h, p0/m, z0.h, z0.h, #90
 # CHECK-NEXT:  1      3     0.50                         3     V1UnitV,V1UnitV01                          FCADD_ZPmZ_S               fcadd	z0.s, p0/m, z0.s, z0.s, #90
@@ -3070,23 +3070,23 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      3     1.00                         3     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       FCVT_ZPmZ_HtoD             fcvt	z0.d, p0/m, z0.h
 # CHECK-NEXT:  1      3     1.00                         3     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       FCVT_ZPmZ_StoD             fcvt	z0.d, p0/m, z0.s
 # CHECK-NEXT:  1      3     1.00                         3     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       FCVT_ZPmZ_DtoH             fcvt	z0.h, p0/m, z0.d
-# CHECK-NEXT:  2      4     2.00                         4     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] FCVT_ZPmZ_StoH       fcvt	z0.h, p0/m, z0.s
+# CHECK-NEXT:  1      4     2.00                         4     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] FCVT_ZPmZ_StoH       fcvt	z0.h, p0/m, z0.s
 # CHECK-NEXT:  1      3     1.00                         3     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       FCVT_ZPmZ_DtoS             fcvt	z0.s, p0/m, z0.d
-# CHECK-NEXT:  2      4     2.00                         4     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] FCVT_ZPmZ_HtoS       fcvt	z0.s, p0/m, z0.h
+# CHECK-NEXT:  1      4     2.00                         4     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] FCVT_ZPmZ_HtoS       fcvt	z0.s, p0/m, z0.h
 # CHECK-NEXT:  1      3     1.00                         3     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       FCVTZS_ZPmZ_DtoD           fcvtzs	z0.d, p0/m, z0.d
 # CHECK-NEXT:  1      3     1.00                         3     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       FCVTZS_ZPmZ_HtoD           fcvtzs	z0.d, p0/m, z0.h
 # CHECK-NEXT:  1      3     1.00                         3     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       FCVTZS_ZPmZ_StoD           fcvtzs	z0.d, p0/m, z0.s
-# CHECK-NEXT:  4      6     4.00                         6     V1UnitV[4],V1UnitV0[4],V1UnitV01[4],V1UnitV02[4] FCVTZS_ZPmZ_HtoH     fcvtzs	z0.h, p0/m, z0.h
+# CHECK-NEXT:  1      6     4.00                         6     V1UnitV[4],V1UnitV0[4],V1UnitV01[4],V1UnitV02[4] FCVTZS_ZPmZ_HtoH     fcvtzs	z0.h, p0/m, z0.h
 # CHECK-NEXT:  1      3     1.00                         3     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       FCVTZS_ZPmZ_DtoS           fcvtzs	z0.s, p0/m, z0.d
-# CHECK-NEXT:  2      4     2.00                         4     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] FCVTZS_ZPmZ_HtoS     fcvtzs	z0.s, p0/m, z0.h
-# CHECK-NEXT:  2      4     2.00                         4     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] FCVTZS_ZPmZ_StoS     fcvtzs	z0.s, p0/m, z0.s
+# CHECK-NEXT:  1      4     2.00                         4     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] FCVTZS_ZPmZ_HtoS     fcvtzs	z0.s, p0/m, z0.h
+# CHECK-NEXT:  1      4     2.00                         4     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] FCVTZS_ZPmZ_StoS     fcvtzs	z0.s, p0/m, z0.s
 # CHECK-NEXT:  1      3     1.00                         3     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       FCVTZU_ZPmZ_DtoD           fcvtzu	z0.d, p0/m, z0.d
 # CHECK-NEXT:  1      3     1.00                         3     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       FCVTZU_ZPmZ_HtoD           fcvtzu	z0.d, p0/m, z0.h
 # CHECK-NEXT:  1      3     1.00                         3     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       FCVTZU_ZPmZ_StoD           fcvtzu	z0.d, p0/m, z0.s
-# CHECK-NEXT:  4      6     4.00                         6     V1UnitV[4],V1UnitV0[4],V1UnitV01[4],V1UnitV02[4] FCVTZU_ZPmZ_HtoH     fcvtzu	z0.h, p0/m, z0.h
+# CHECK-NEXT:  1      6     4.00                         6     V1UnitV[4],V1UnitV0[4],V1UnitV01[4],V1UnitV02[4] FCVTZU_ZPmZ_HtoH     fcvtzu	z0.h, p0/m, z0.h
 # CHECK-NEXT:  1      3     1.00                         3     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       FCVTZU_ZPmZ_DtoS           fcvtzu	z0.s, p0/m, z0.d
-# CHECK-NEXT:  2      4     2.00                         4     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] FCVTZU_ZPmZ_HtoS     fcvtzu	z0.s, p0/m, z0.h
-# CHECK-NEXT:  2      4     2.00                         4     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] FCVTZU_ZPmZ_StoS     fcvtzu	z0.s, p0/m, z0.s
+# CHECK-NEXT:  1      4     2.00                         4     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] FCVTZU_ZPmZ_HtoS     fcvtzu	z0.s, p0/m, z0.h
+# CHECK-NEXT:  1      4     2.00                         4     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] FCVTZU_ZPmZ_StoS     fcvtzu	z0.s, p0/m, z0.s
 # CHECK-NEXT:  1      15    7.00                         15    V1UnitV[7],V1UnitV0[7],V1UnitV01[7],V1UnitV02[7] FDIV_ZPmZ_D          fdiv	z0.d, p7/m, z0.d, z31.d
 # CHECK-NEXT:  1      13    10.00                        13    V1UnitV[10],V1UnitV0[10],V1UnitV01[10],V1UnitV02[10] FDIV_ZPmZ_H      fdiv	z0.h, p7/m, z0.h, z31.h
 # CHECK-NEXT:  1      10    7.00                         10    V1UnitV[7],V1UnitV0[7],V1UnitV01[7],V1UnitV02[7] FDIV_ZPmZ_S          fdiv	z0.s, p7/m, z0.s, z31.s
@@ -3117,12 +3117,12 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          FMAXNM_ZPmI_D              fmaxnm	z31.d, p7/m, z31.d, #1.0
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          FMAXNM_ZPmI_H              fmaxnm	z31.h, p7/m, z31.h, #1.0
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          FMAXNM_ZPmI_S              fmaxnm	z31.s, p7/m, z31.s, #1.0
-# CHECK-NEXT:  5      9     2.00                         9     V1UnitV[5],V1UnitV01[4]                    FMAXNMV_VPZ_D              fmaxnmv	d0, p7, z31.d
-# CHECK-NEXT:  6      13    3.00                         13    V1UnitV[6],V1UnitV01[6]                    FMAXNMV_VPZ_H              fmaxnmv	h0, p7, z31.h
-# CHECK-NEXT:  6      11    2.50                         11    V1UnitV[6],V1UnitV01[5]                    FMAXNMV_VPZ_S              fmaxnmv	s0, p7, z31.s
-# CHECK-NEXT:  5      9     2.00                         9     V1UnitV[5],V1UnitV01[4]                    FMAXV_VPZ_D                fmaxv	d0, p7, z31.d
-# CHECK-NEXT:  6      13    3.00                         13    V1UnitV[6],V1UnitV01[6]                    FMAXV_VPZ_H                fmaxv	h0, p7, z31.h
-# CHECK-NEXT:  6      11    2.50                         11    V1UnitV[6],V1UnitV01[5]                    FMAXV_VPZ_S                fmaxv	s0, p7, z31.s
+# CHECK-NEXT:  2      9     2.00                         9     V1UnitV[5],V1UnitV01[4]                    FMAXNMV_VPZ_D              fmaxnmv	d0, p7, z31.d
+# CHECK-NEXT:  1      13    3.00                         13    V1UnitV[6],V1UnitV01[6]                    FMAXNMV_VPZ_H              fmaxnmv	h0, p7, z31.h
+# CHECK-NEXT:  2      11    2.50                         11    V1UnitV[6],V1UnitV01[5]                    FMAXNMV_VPZ_S              fmaxnmv	s0, p7, z31.s
+# CHECK-NEXT:  2      9     2.00                         9     V1UnitV[5],V1UnitV01[4]                    FMAXV_VPZ_D                fmaxv	d0, p7, z31.d
+# CHECK-NEXT:  1      13    3.00                         13    V1UnitV[6],V1UnitV01[6]                    FMAXV_VPZ_H                fmaxv	h0, p7, z31.h
+# CHECK-NEXT:  2      11    2.50                         11    V1UnitV[6],V1UnitV01[5]                    FMAXV_VPZ_S                fmaxv	s0, p7, z31.s
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          FMIN_ZPmI_D                fmin	z0.d, p0/m, z0.d, #0.0
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          FMIN_ZPmZ_D                fmin	z0.d, p7/m, z0.d, z31.d
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          FMIN_ZPmI_H                fmin	z0.h, p0/m, z0.h, #0.0
@@ -3141,12 +3141,12 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          FMINNM_ZPmI_D              fminnm	z31.d, p7/m, z31.d, #1.0
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          FMINNM_ZPmI_H              fminnm	z31.h, p7/m, z31.h, #1.0
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          FMINNM_ZPmI_S              fminnm	z31.s, p7/m, z31.s, #1.0
-# CHECK-NEXT:  5      9     2.00                         9     V1UnitV[5],V1UnitV01[4]                    FMINNMV_VPZ_D              fminnmv	d0, p7, z31.d
-# CHECK-NEXT:  6      13    3.00                         13    V1UnitV[6],V1UnitV01[6]                    FMINNMV_VPZ_H              fminnmv	h0, p7, z31.h
-# CHECK-NEXT:  6      11    2.50                         11    V1UnitV[6],V1UnitV01[5]                    FMINNMV_VPZ_S              fminnmv	s0, p7, z31.s
-# CHECK-NEXT:  5      9     2.00                         9     V1UnitV[5],V1UnitV01[4]                    FMINV_VPZ_D                fminv	d0, p7, z31.d
-# CHECK-NEXT:  6      13    3.00                         13    V1UnitV[6],V1UnitV01[6]                    FMINV_VPZ_H                fminv	h0, p7, z31.h
-# CHECK-NEXT:  6      11    2.50                         11    V1UnitV[6],V1UnitV01[5]                    FMINV_VPZ_S                fminv	s0, p7, z31.s
+# CHECK-NEXT:  2      9     2.00                         9     V1UnitV[5],V1UnitV01[4]                    FMINNMV_VPZ_D              fminnmv	d0, p7, z31.d
+# CHECK-NEXT:  1      13    3.00                         13    V1UnitV[6],V1UnitV01[6]                    FMINNMV_VPZ_H              fminnmv	h0, p7, z31.h
+# CHECK-NEXT:  2      11    2.50                         11    V1UnitV[6],V1UnitV01[5]                    FMINNMV_VPZ_S              fminnmv	s0, p7, z31.s
+# CHECK-NEXT:  2      9     2.00                         9     V1UnitV[5],V1UnitV01[4]                    FMINV_VPZ_D                fminv	d0, p7, z31.d
+# CHECK-NEXT:  1      13    3.00                         13    V1UnitV[6],V1UnitV01[6]                    FMINV_VPZ_H                fminv	h0, p7, z31.h
+# CHECK-NEXT:  2      11    2.50                         11    V1UnitV[6],V1UnitV01[5]                    FMINV_VPZ_S                fminv	s0, p7, z31.s
 # CHECK-NEXT:  1      4     0.50                         2     V1UnitV,V1UnitV01                          FMLA_ZPmZZ_D               fmla	z0.d, p7/m, z1.d, z31.d
 # CHECK-NEXT:  1      4     0.50                         2     V1UnitV,V1UnitV01                          FMLA_ZZZI_D                fmla	z0.d, z1.d, z7.d[1]
 # CHECK-NEXT:  1      4     0.50                         2     V1UnitV,V1UnitV01                          FMLA_ZPmZZ_H               fmla	z0.h, p7/m, z1.h, z31.h
@@ -3207,8 +3207,8 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      4     0.50                         2     V1UnitV,V1UnitV01                          FNMSB_ZPmZZ_H              fnmsb	z0.h, p7/m, z1.h, z31.h
 # CHECK-NEXT:  1      4     0.50                         2     V1UnitV,V1UnitV01                          FNMSB_ZPmZZ_S              fnmsb	z0.s, p7/m, z1.s, z31.s
 # CHECK-NEXT:  1      3     1.00                         3     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       FRECPE_ZZ_D                frecpe	z0.d, z31.d
-# CHECK-NEXT:  4      6     4.00                         6     V1UnitV[4],V1UnitV0[4],V1UnitV01[4],V1UnitV02[4] FRECPE_ZZ_H          frecpe	z0.h, z31.h
-# CHECK-NEXT:  2      4     2.00                         4     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] FRECPE_ZZ_S          frecpe	z0.s, z31.s
+# CHECK-NEXT:  1      6     4.00                         6     V1UnitV[4],V1UnitV0[4],V1UnitV01[4],V1UnitV02[4] FRECPE_ZZ_H          frecpe	z0.h, z31.h
+# CHECK-NEXT:  1      4     2.00                         4     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] FRECPE_ZZ_S          frecpe	z0.s, z31.s
 # CHECK-NEXT:  1      4     0.50                         4     V1UnitV,V1UnitV01                          FRECPS_ZZZ_D               frecps	z0.d, z1.d, z31.d
 # CHECK-NEXT:  1      4     0.50                         4     V1UnitV,V1UnitV01                          FRECPS_ZZZ_H               frecps	z0.h, z1.h, z31.h
 # CHECK-NEXT:  1      4     0.50                         4     V1UnitV,V1UnitV01                          FRECPS_ZZZ_S               frecps	z0.s, z1.s, z31.s
@@ -3237,8 +3237,8 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      6     1.00                         6     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       FRINTZ_ZPmZ_H              frintz	z31.h, p7/m, z31.h
 # CHECK-NEXT:  1      4     1.00                         4     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       FRINTZ_ZPmZ_S              frintz	z31.s, p7/m, z31.s
 # CHECK-NEXT:  1      3     1.00                         3     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       FRSQRTE_ZZ_D               frsqrte	z0.d, z31.d
-# CHECK-NEXT:  4      6     4.00                         6     V1UnitV[4],V1UnitV0[4],V1UnitV01[4],V1UnitV02[4] FRSQRTE_ZZ_H         frsqrte	z0.h, z31.h
-# CHECK-NEXT:  2      4     2.00                         4     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] FRSQRTE_ZZ_S         frsqrte	z0.s, z31.s
+# CHECK-NEXT:  1      6     4.00                         6     V1UnitV[4],V1UnitV0[4],V1UnitV01[4],V1UnitV02[4] FRSQRTE_ZZ_H         frsqrte	z0.h, z31.h
+# CHECK-NEXT:  1      4     2.00                         4     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] FRSQRTE_ZZ_S         frsqrte	z0.s, z31.s
 # CHECK-NEXT:  1      4     0.50                         4     V1UnitV,V1UnitV01                          FRSQRTS_ZZZ_D              frsqrts	z0.d, z1.d, z31.d
 # CHECK-NEXT:  1      4     0.50                         4     V1UnitV,V1UnitV01                          FRSQRTS_ZZZ_H              frsqrts	z0.h, z1.h, z31.h
 # CHECK-NEXT:  1      4     0.50                         4     V1UnitV,V1UnitV01                          FRSQRTS_ZZZ_S              frsqrts	z0.s, z1.s, z31.s
@@ -3305,9 +3305,9 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   INCP_XP_D                  incp	xzr, p15.d
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   INCP_XP_H                  incp	xzr, p15.h
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   INCP_XP_S                  incp	xzr, p15.s
-# CHECK-NEXT:  3      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 INCP_ZP_D         incp	z31.d, p15.d
-# CHECK-NEXT:  3      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 INCP_ZP_H         incp	z31.h, p15.h
-# CHECK-NEXT:  3      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 INCP_ZP_S         incp	z31.s, p15.s
+# CHECK-NEXT:  2      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 INCP_ZP_D         incp	z31.d, p15.d
+# CHECK-NEXT:  2      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 INCP_ZP_H         incp	z31.h, p15.h
+# CHECK-NEXT:  2      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 INCP_ZP_S         incp	z31.s, p15.s
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   INCW_XPiI                  incw	x0
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   INCW_XPiI                  incw	x0, #14
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   INCW_XPiI                  incw	x0, all, mul #16
@@ -3316,17 +3316,17 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       INCW_ZPiI                  incw	z0.s
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       INCW_ZPiI                  incw	z0.s, all, mul #16
 # CHECK-NEXT:  1      4     1.00                         4     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       INDEX_II_B                 index	z0.b, #0, #0
-# CHECK-NEXT:  2      5     2.00                         5     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] INDEX_II_D           index	z0.d, #0, #0
+# CHECK-NEXT:  1      5     2.00                         5     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] INDEX_II_D           index	z0.d, #0, #0
 # CHECK-NEXT:  1      4     1.00                         4     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       INDEX_II_H                 index	z0.h, #0, #0
 # CHECK-NEXT:  2      7     1.00                         7     V1UnitI,V1UnitM,V1UnitM0,V1UnitV,V1UnitV1,V1UnitV01,V1UnitV13 INDEX_RR_H index	z0.h, w0, w0
 # CHECK-NEXT:  1      4     1.00                         4     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       INDEX_II_S                 index	z0.s, #0, #0
 # CHECK-NEXT:  2      7     1.00                         7     V1UnitI,V1UnitM,V1UnitM0,V1UnitV,V1UnitV1,V1UnitV01,V1UnitV13 INDEX_RR_B index	z21.b, w10, w21
-# CHECK-NEXT:  4      8     2.00                         8     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] INDEX_RR_D index	z21.d, x10, x21
+# CHECK-NEXT:  2      8     2.00                         8     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] INDEX_RR_D index	z21.d, x10, x21
 # CHECK-NEXT:  2      7     1.00                         7     V1UnitI,V1UnitM,V1UnitM0,V1UnitV,V1UnitV1,V1UnitV01,V1UnitV13 INDEX_RR_S index	z21.s, w10, w21
 # CHECK-NEXT:  2      7     1.00                         7     V1UnitI,V1UnitM,V1UnitM0,V1UnitV,V1UnitV1,V1UnitV01,V1UnitV13 INDEX_IR_B index	z23.b, #13, w8
 # CHECK-NEXT:  2      7     1.00                         7     V1UnitI,V1UnitM,V1UnitM0,V1UnitV,V1UnitV1,V1UnitV01,V1UnitV13 INDEX_RI_B index	z23.b, w13, #8
-# CHECK-NEXT:  4      8     2.00                         8     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] INDEX_IR_D index	z23.d, #13, x8
-# CHECK-NEXT:  4      8     2.00                         8     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] INDEX_RI_D index	z23.d, x13, #8
+# CHECK-NEXT:  2      8     2.00                         8     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] INDEX_IR_D index	z23.d, #13, x8
+# CHECK-NEXT:  2      8     2.00                         8     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] INDEX_RI_D index	z23.d, x13, #8
 # CHECK-NEXT:  2      7     1.00                         7     V1UnitI,V1UnitM,V1UnitM0,V1UnitV,V1UnitV1,V1UnitV01,V1UnitV13 INDEX_IR_H index	z23.h, #13, w8
 # CHECK-NEXT:  2      7     1.00                         7     V1UnitI,V1UnitM,V1UnitM0,V1UnitV,V1UnitV1,V1UnitV01,V1UnitV13 INDEX_RI_H index	z23.h, w13, #8
 # CHECK-NEXT:  2      7     1.00                         7     V1UnitI,V1UnitM,V1UnitM0,V1UnitV,V1UnitV1,V1UnitV01,V1UnitV13 INDEX_IR_S index	z23.s, #13, w8
@@ -3335,10 +3335,10 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  2      7     1.00                         7     V1UnitI,V1UnitM,V1UnitM0,V1UnitV,V1UnitV1,V1UnitV01,V1UnitV13 INDEX_IR_B index	z31.b, #-1, wzr
 # CHECK-NEXT:  2      7     1.00                         7     V1UnitI,V1UnitM,V1UnitM0,V1UnitV,V1UnitV1,V1UnitV01,V1UnitV13 INDEX_RI_B index	z31.b, wzr, #-1
 # CHECK-NEXT:  2      7     1.00                         7     V1UnitI,V1UnitM,V1UnitM0,V1UnitV,V1UnitV1,V1UnitV01,V1UnitV13 INDEX_RR_B index	z31.b, wzr, wzr
-# CHECK-NEXT:  2      5     2.00                         5     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] INDEX_II_D           index	z31.d, #-1, #-1
-# CHECK-NEXT:  4      8     2.00                         8     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] INDEX_IR_D index	z31.d, #-1, xzr
-# CHECK-NEXT:  4      8     2.00                         8     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] INDEX_RI_D index	z31.d, xzr, #-1
-# CHECK-NEXT:  4      8     2.00                         8     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] INDEX_RR_D index	z31.d, xzr, xzr
+# CHECK-NEXT:  1      5     2.00                         5     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] INDEX_II_D           index	z31.d, #-1, #-1
+# CHECK-NEXT:  2      8     2.00                         8     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] INDEX_IR_D index	z31.d, #-1, xzr
+# CHECK-NEXT:  2      8     2.00                         8     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] INDEX_RI_D index	z31.d, xzr, #-1
+# CHECK-NEXT:  2      8     2.00                         8     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] INDEX_RR_D index	z31.d, xzr, xzr
 # CHECK-NEXT:  1      4     1.00                         4     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       INDEX_II_H                 index	z31.h, #-1, #-1
 # CHECK-NEXT:  2      7     1.00                         7     V1UnitI,V1UnitM,V1UnitM0,V1UnitV,V1UnitV1,V1UnitV01,V1UnitV13 INDEX_IR_H index	z31.h, #-1, wzr
 # CHECK-NEXT:  2      7     1.00                         7     V1UnitI,V1UnitM,V1UnitM0,V1UnitV,V1UnitV1,V1UnitV01,V1UnitV13 INDEX_RI_H index	z31.h, wzr, #-1
@@ -3379,7 +3379,7 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1B                       ld1b	{ z0.b }, p0/z, [x0, x0]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1B_IMM                   ld1b	{ z0.b }, p0/z, [x0]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1B_D_IMM                 ld1b	{ z0.d }, p0/z, [x0]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1B_D_IMM                ld1b	{ z0.d }, p0/z, [z0.d]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1B_D_IMM                ld1b	{ z0.d }, p0/z, [z0.d]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1B_H_IMM                 ld1b	{ z0.h }, p0/z, [x0]
 # CHECK-NEXT:  2      9     0.33    *                    9     V1UnitL,V1UnitV                            GLD1B_S_SXTW               ld1b	{ z0.s }, p0/z, [x0, z0.s, sxtw]
 # CHECK-NEXT:  2      9     0.33    *                    9     V1UnitL,V1UnitV                            GLD1B_S_UXTW               ld1b	{ z0.s }, p0/z, [x0, z0.s, uxtw]
@@ -3387,57 +3387,57 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  2      11    0.33    *                    11    V1UnitL,V1UnitV                            GLD1B_S_IMM                ld1b	{ z0.s }, p0/z, [z0.s]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1B_IMM                   ld1b	{ z21.b }, p5/z, [x10, #5, mul vl]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1B_D_IMM                 ld1b	{ z21.d }, p5/z, [x10, #5, mul vl]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1B_D_SXTW               ld1b	{ z21.d }, p5/z, [x10, z21.d, sxtw]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1B_D_UXTW               ld1b	{ z21.d }, p5/z, [x10, z21.d, uxtw]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1B_D_SXTW               ld1b	{ z21.d }, p5/z, [x10, z21.d, sxtw]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1B_D_UXTW               ld1b	{ z21.d }, p5/z, [x10, z21.d, uxtw]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1B_H_IMM                 ld1b	{ z21.h }, p5/z, [x10, #5, mul vl]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1B_S_IMM                 ld1b	{ z21.s }, p5/z, [x10, #5, mul vl]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1B_S                     ld1b	{ z21.s }, p5/z, [x10, x21]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1B_D                     ld1b	{ z23.d }, p3/z, [x13, x8]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1B_IMM                   ld1b	{ z31.b }, p7/z, [sp, #-1, mul vl]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1B_D_IMM                 ld1b	{ z31.d }, p7/z, [sp, #-1, mul vl]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1B_D                    ld1b	{ z31.d }, p7/z, [sp, z31.d]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1B_D_IMM                ld1b	{ z31.d }, p7/z, [z31.d, #31]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1B_D                    ld1b	{ z31.d }, p7/z, [sp, z31.d]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1B_D_IMM                ld1b	{ z31.d }, p7/z, [z31.d, #31]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1B_H_IMM                 ld1b	{ z31.h }, p7/z, [sp, #-1, mul vl]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1B_S_IMM                 ld1b	{ z31.s }, p7/z, [sp, #-1, mul vl]
 # CHECK-NEXT:  2      11    0.33    *                    11    V1UnitL,V1UnitV                            GLD1B_S_IMM                ld1b	{ z31.s }, p7/z, [z31.s, #31]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1B_H                     ld1b	{ z5.h }, p3/z, [x17, x16]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1D_SXTW_SCALED          ld1d	{ z0.d }, p0/z, [x0, z0.d, sxtw #3]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1D_UXTW_SCALED          ld1d	{ z0.d }, p0/z, [x0, z0.d, uxtw #3]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1D_SXTW_SCALED          ld1d	{ z0.d }, p0/z, [x0, z0.d, sxtw #3]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1D_UXTW_SCALED          ld1d	{ z0.d }, p0/z, [x0, z0.d, uxtw #3]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1D_IMM                   ld1d	{ z0.d }, p0/z, [x0]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1D_IMM                  ld1d	{ z0.d }, p0/z, [z0.d]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1D_IMM                  ld1d	{ z0.d }, p0/z, [z0.d]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1D_IMM                   ld1d	{ z21.d }, p5/z, [x10, #5, mul vl]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1D_SXTW                 ld1d	{ z21.d }, p5/z, [x10, z21.d, sxtw]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1D_UXTW                 ld1d	{ z21.d }, p5/z, [x10, z21.d, uxtw]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1D_SXTW                 ld1d	{ z21.d }, p5/z, [x10, z21.d, sxtw]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1D_UXTW                 ld1d	{ z21.d }, p5/z, [x10, z21.d, uxtw]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1D                       ld1d	{ z23.d }, p3/z, [sp, x8, lsl #3]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1D                       ld1d	{ z23.d }, p3/z, [x13, x8, lsl #3]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1D_SCALED               ld1d	{ z23.d }, p3/z, [x13, z8.d, lsl #3]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1D_SCALED               ld1d	{ z23.d }, p3/z, [x13, z8.d, lsl #3]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1D_IMM                   ld1d	{ z31.d }, p7/z, [sp, #-1, mul vl]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1D                      ld1d	{ z31.d }, p7/z, [sp, z31.d]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1D_IMM                  ld1d	{ z31.d }, p7/z, [z31.d, #248]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1H_D_SXTW_SCALED        ld1h	{ z0.d }, p0/z, [x0, z0.d, sxtw #1]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1H_D_UXTW_SCALED        ld1h	{ z0.d }, p0/z, [x0, z0.d, uxtw #1]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1D                      ld1d	{ z31.d }, p7/z, [sp, z31.d]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1D_IMM                  ld1d	{ z31.d }, p7/z, [z31.d, #248]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1H_D_SXTW_SCALED        ld1h	{ z0.d }, p0/z, [x0, z0.d, sxtw #1]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1H_D_UXTW_SCALED        ld1h	{ z0.d }, p0/z, [x0, z0.d, uxtw #1]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1H_D_IMM                 ld1h	{ z0.d }, p0/z, [x0]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1H_D_IMM                ld1h	{ z0.d }, p0/z, [z0.d]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1H_D_IMM                ld1h	{ z0.d }, p0/z, [z0.d]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1H_IMM                   ld1h	{ z0.h }, p0/z, [x0]
 # CHECK-NEXT:  2      9     0.33    *                    9     V1UnitL,V1UnitV                            GLD1H_S_SXTW               ld1h	{ z0.s }, p0/z, [x0, z0.s, sxtw]
 # CHECK-NEXT:  2      9     0.33    *                    9     V1UnitL,V1UnitV                            GLD1H_S_UXTW               ld1h	{ z0.s }, p0/z, [x0, z0.s, uxtw]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1H_S_IMM                 ld1h	{ z0.s }, p0/z, [x0]
 # CHECK-NEXT:  2      11    0.33    *                    11    V1UnitL,V1UnitV                            GLD1H_S_IMM                ld1h	{ z0.s }, p0/z, [z0.s]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1H_D_IMM                 ld1h	{ z21.d }, p5/z, [x10, #5, mul vl]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1H_D_SXTW               ld1h	{ z21.d }, p5/z, [x10, z21.d, sxtw]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1H_D_UXTW               ld1h	{ z21.d }, p5/z, [x10, z21.d, uxtw]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1H_D_SXTW               ld1h	{ z21.d }, p5/z, [x10, z21.d, sxtw]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1H_D_UXTW               ld1h	{ z21.d }, p5/z, [x10, z21.d, uxtw]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1H_IMM                   ld1h	{ z21.h }, p5/z, [x10, #5, mul vl]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1H_S_IMM                 ld1h	{ z21.s }, p5/z, [x10, #5, mul vl]
 # CHECK-NEXT:  2      7     0.50    *                    7     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LD1H_S                     ld1h	{ z21.s }, p5/z, [x10, x21, lsl #1]
 # CHECK-NEXT:  2      7     0.50    *                    7     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LD1H_D                     ld1h	{ z23.d }, p3/z, [x13, x8, lsl #1]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1H_D_SCALED             ld1h	{ z23.d }, p3/z, [x13, z8.d, lsl #1]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1H_D_SCALED             ld1h	{ z23.d }, p3/z, [x13, z8.d, lsl #1]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1H_D_IMM                 ld1h	{ z31.d }, p7/z, [sp, #-1, mul vl]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1H_D                    ld1h	{ z31.d }, p7/z, [sp, z31.d]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1H_D_IMM                ld1h	{ z31.d }, p7/z, [z31.d, #62]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1H_D                    ld1h	{ z31.d }, p7/z, [sp, z31.d]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1H_D_IMM                ld1h	{ z31.d }, p7/z, [z31.d, #62]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1H_IMM                   ld1h	{ z31.h }, p7/z, [sp, #-1, mul vl]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1H_S_IMM                 ld1h	{ z31.s }, p7/z, [sp, #-1, mul vl]
-# CHECK-NEXT:  4      11    0.67    *                    11    V1UnitL[2],V1UnitV[2]                      GLD1H_S_SXTW_SCALED        ld1h	{ z31.s }, p7/z, [sp, z31.s, sxtw #1]
-# CHECK-NEXT:  4      11    0.67    *                    11    V1UnitL[2],V1UnitV[2]                      GLD1H_S_UXTW_SCALED        ld1h	{ z31.s }, p7/z, [sp, z31.s, uxtw #1]
+# CHECK-NEXT:  2      11    0.67    *                    11    V1UnitL[2],V1UnitV[2]                      GLD1H_S_SXTW_SCALED        ld1h	{ z31.s }, p7/z, [sp, z31.s, sxtw #1]
+# CHECK-NEXT:  2      11    0.67    *                    11    V1UnitL[2],V1UnitV[2]                      GLD1H_S_UXTW_SCALED        ld1h	{ z31.s }, p7/z, [sp, z31.s, uxtw #1]
 # CHECK-NEXT:  2      11    0.33    *                    11    V1UnitL,V1UnitV                            GLD1H_S_IMM                ld1h	{ z31.s }, p7/z, [z31.s, #62]
 # CHECK-NEXT:  2      7     0.50    *                    7     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LD1H                       ld1h	{ z5.h }, p3/z, [sp, x16, lsl #1]
 # CHECK-NEXT:  2      7     0.50    *                    7     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LD1H                       ld1h	{ z5.h }, p3/z, [x17, x16, lsl #1]
@@ -3494,7 +3494,7 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1RW_D_IMM                ld1rw	{ z31.d }, p7/z, [sp, #252]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1RW_IMM                  ld1rw	{ z31.s }, p7/z, [sp, #252]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1SB_D_IMM                ld1sb	{ z0.d }, p0/z, [x0]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SB_D_IMM               ld1sb	{ z0.d }, p0/z, [z0.d]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SB_D_IMM               ld1sb	{ z0.d }, p0/z, [z0.d]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1SB_H                    ld1sb	{ z0.h }, p0/z, [sp, x0]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1SB_H                    ld1sb	{ z0.h }, p0/z, [x0, x0]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1SB_H_IMM                ld1sb	{ z0.h }, p0/z, [x0]
@@ -3502,243 +3502,243 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1SB_S_IMM                ld1sb	{ z0.s }, p0/z, [x0]
 # CHECK-NEXT:  2      11    0.33    *                    11    V1UnitL,V1UnitV                            GLD1SB_S_IMM               ld1sb	{ z0.s }, p0/z, [z0.s]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1SB_D_IMM                ld1sb	{ z21.d }, p5/z, [x10, #5, mul vl]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SB_D_SXTW              ld1sb	{ z21.d }, p5/z, [x10, z21.d, sxtw]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SB_D_UXTW              ld1sb	{ z21.d }, p5/z, [x10, z21.d, uxtw]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SB_D_SXTW              ld1sb	{ z21.d }, p5/z, [x10, z21.d, sxtw]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SB_D_UXTW              ld1sb	{ z21.d }, p5/z, [x10, z21.d, uxtw]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1SB_H_IMM                ld1sb	{ z21.h }, p5/z, [x10, #5, mul vl]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1SB_S_IMM                ld1sb	{ z21.s }, p5/z, [x10, #5, mul vl]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1SB_S                    ld1sb	{ z21.s }, p5/z, [x10, x21]
 # CHECK-NEXT:  2      9     0.33    *                    9     V1UnitL,V1UnitV                            GLD1SB_S_UXTW              ld1sb	{ z23.s }, p5/z, [x17, z10.s, uxtw]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1SB_D                    ld1sb	{ z23.d }, p3/z, [x13, x8]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1SB_D_IMM                ld1sb	{ z31.d }, p7/z, [sp, #-1, mul vl]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SB_D                   ld1sb	{ z31.d }, p7/z, [sp, z31.d]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SB_D_IMM               ld1sb	{ z31.d }, p7/z, [z31.d, #31]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SB_D                   ld1sb	{ z31.d }, p7/z, [sp, z31.d]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SB_D_IMM               ld1sb	{ z31.d }, p7/z, [z31.d, #31]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1SB_H_IMM                ld1sb	{ z31.h }, p7/z, [sp, #-1, mul vl]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1SB_S_IMM                ld1sb	{ z31.s }, p7/z, [sp, #-1, mul vl]
 # CHECK-NEXT:  2      11    0.33    *                    11    V1UnitL,V1UnitV                            GLD1SB_S_IMM               ld1sb	{ z31.s }, p7/z, [z31.s, #31]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SH_D_SXTW_SCALED       ld1sh	{ z0.d }, p0/z, [x0, z0.d, sxtw #1]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SH_D_UXTW_SCALED       ld1sh	{ z0.d }, p0/z, [x0, z0.d, uxtw #1]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SH_D_SXTW_SCALED       ld1sh	{ z0.d }, p0/z, [x0, z0.d, sxtw #1]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SH_D_UXTW_SCALED       ld1sh	{ z0.d }, p0/z, [x0, z0.d, uxtw #1]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1SH_D_IMM                ld1sh	{ z0.d }, p0/z, [x0]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SH_D_IMM               ld1sh	{ z0.d }, p0/z, [z0.d]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SH_D_IMM               ld1sh	{ z0.d }, p0/z, [z0.d]
 # CHECK-NEXT:  2      9     0.33    *                    9     V1UnitL,V1UnitV                            GLD1SH_S_SXTW              ld1sh	{ z0.s }, p0/z, [x0, z0.s, sxtw]
 # CHECK-NEXT:  2      9     0.33    *                    9     V1UnitL,V1UnitV                            GLD1SH_S_UXTW              ld1sh	{ z0.s }, p0/z, [x0, z0.s, uxtw]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1SH_S_IMM                ld1sh	{ z0.s }, p0/z, [x0]
 # CHECK-NEXT:  2      11    0.33    *                    11    V1UnitL,V1UnitV                            GLD1SH_S_IMM               ld1sh	{ z0.s }, p0/z, [z0.s]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1SH_D_IMM                ld1sh	{ z21.d }, p5/z, [x10, #5, mul vl]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SH_D_SXTW              ld1sh	{ z21.d }, p5/z, [x10, z21.d, sxtw]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SH_D_UXTW              ld1sh	{ z21.d }, p5/z, [x10, z21.d, uxtw]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SH_D_SXTW              ld1sh	{ z21.d }, p5/z, [x10, z21.d, sxtw]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SH_D_UXTW              ld1sh	{ z21.d }, p5/z, [x10, z21.d, uxtw]
 # CHECK-NEXT:  2      7     0.50    *                    7     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LD1SH_S                    ld1sh	{ z21.s }, p5/z, [sp, x21, lsl #1]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1SH_S_IMM                ld1sh	{ z21.s }, p5/z, [x10, #5, mul vl]
 # CHECK-NEXT:  2      7     0.50    *                    7     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LD1SH_S                    ld1sh	{ z21.s }, p5/z, [x10, x21, lsl #1]
 # CHECK-NEXT:  2      7     0.50    *                    7     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LD1SH_D                    ld1sh	{ z23.d }, p3/z, [x13, x8, lsl #1]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SH_D_SCALED            ld1sh	{ z23.d }, p3/z, [x13, z8.d, lsl #1]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SH_D_SCALED            ld1sh	{ z23.d }, p3/z, [x13, z8.d, lsl #1]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1SH_D_IMM                ld1sh	{ z31.d }, p7/z, [sp, #-1, mul vl]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SH_D                   ld1sh	{ z31.d }, p7/z, [sp, z31.d]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SH_D_IMM               ld1sh	{ z31.d }, p7/z, [z31.d, #62]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SH_D                   ld1sh	{ z31.d }, p7/z, [sp, z31.d]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SH_D_IMM               ld1sh	{ z31.d }, p7/z, [z31.d, #62]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1SH_S_IMM                ld1sh	{ z31.s }, p7/z, [sp, #-1, mul vl]
-# CHECK-NEXT:  4      11    0.67    *                    11    V1UnitL[2],V1UnitV[2]                      GLD1SH_S_SXTW_SCALED       ld1sh	{ z31.s }, p7/z, [sp, z31.s, sxtw #1]
-# CHECK-NEXT:  4      11    0.67    *                    11    V1UnitL[2],V1UnitV[2]                      GLD1SH_S_UXTW_SCALED       ld1sh	{ z31.s }, p7/z, [sp, z31.s, uxtw #1]
+# CHECK-NEXT:  2      11    0.67    *                    11    V1UnitL[2],V1UnitV[2]                      GLD1SH_S_SXTW_SCALED       ld1sh	{ z31.s }, p7/z, [sp, z31.s, sxtw #1]
+# CHECK-NEXT:  2      11    0.67    *                    11    V1UnitL[2],V1UnitV[2]                      GLD1SH_S_UXTW_SCALED       ld1sh	{ z31.s }, p7/z, [sp, z31.s, uxtw #1]
 # CHECK-NEXT:  2      11    0.33    *                    11    V1UnitL,V1UnitV                            GLD1SH_S_IMM               ld1sh	{ z31.s }, p7/z, [z31.s, #62]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SW_D_SXTW_SCALED       ld1sw	{ z0.d }, p0/z, [x0, z0.d, sxtw #2]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SW_D_UXTW_SCALED       ld1sw	{ z0.d }, p0/z, [x0, z0.d, uxtw #2]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SW_D_SXTW_SCALED       ld1sw	{ z0.d }, p0/z, [x0, z0.d, sxtw #2]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SW_D_UXTW_SCALED       ld1sw	{ z0.d }, p0/z, [x0, z0.d, uxtw #2]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1SW_D_IMM                ld1sw	{ z0.d }, p0/z, [x0]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SW_D_IMM               ld1sw	{ z0.d }, p0/z, [z0.d]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SW_D_IMM               ld1sw	{ z0.d }, p0/z, [z0.d]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1SW_D_IMM                ld1sw	{ z21.d }, p5/z, [x10, #5, mul vl]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SW_D_SXTW              ld1sw	{ z21.d }, p5/z, [x10, z21.d, sxtw]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SW_D_UXTW              ld1sw	{ z21.d }, p5/z, [x10, z21.d, uxtw]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SW_D_SXTW              ld1sw	{ z21.d }, p5/z, [x10, z21.d, sxtw]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SW_D_UXTW              ld1sw	{ z21.d }, p5/z, [x10, z21.d, uxtw]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1SW_D                    ld1sw	{ z23.d }, p3/z, [sp, x8, lsl #2]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1SW_D                    ld1sw	{ z23.d }, p3/z, [x13, x8, lsl #2]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SW_D_SCALED            ld1sw	{ z23.d }, p3/z, [x13, z8.d, lsl #2]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SW_D_SCALED            ld1sw	{ z23.d }, p3/z, [x13, z8.d, lsl #2]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1SW_D_IMM                ld1sw	{ z31.d }, p7/z, [sp, #-1, mul vl]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SW_D                   ld1sw	{ z31.d }, p7/z, [sp, z31.d]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SW_D_IMM               ld1sw	{ z31.d }, p7/z, [z31.d, #124]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1W_D_SXTW_SCALED        ld1w	{ z0.d }, p0/z, [x0, z0.d, sxtw #2]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1W_D_UXTW_SCALED        ld1w	{ z0.d }, p0/z, [x0, z0.d, uxtw #2]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SW_D                   ld1sw	{ z31.d }, p7/z, [sp, z31.d]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1SW_D_IMM               ld1sw	{ z31.d }, p7/z, [z31.d, #124]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1W_D_SXTW_SCALED        ld1w	{ z0.d }, p0/z, [x0, z0.d, sxtw #2]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1W_D_UXTW_SCALED        ld1w	{ z0.d }, p0/z, [x0, z0.d, uxtw #2]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1W_D_IMM                 ld1w	{ z0.d }, p0/z, [x0]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1W_D_IMM                ld1w	{ z0.d }, p0/z, [z0.d]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1W_D_IMM                ld1w	{ z0.d }, p0/z, [z0.d]
 # CHECK-NEXT:  2      9     0.33    *                    9     V1UnitL,V1UnitV                            GLD1W_SXTW                 ld1w	{ z0.s }, p0/z, [x0, z0.s, sxtw]
 # CHECK-NEXT:  2      9     0.33    *                    9     V1UnitL,V1UnitV                            GLD1W_UXTW                 ld1w	{ z0.s }, p0/z, [x0, z0.s, uxtw]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1W_IMM                   ld1w	{ z0.s }, p0/z, [x0]
 # CHECK-NEXT:  2      11    0.33    *                    11    V1UnitL,V1UnitV                            GLD1W_IMM                  ld1w	{ z0.s }, p0/z, [z0.s]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1W_D_IMM                 ld1w	{ z21.d }, p5/z, [x10, #5, mul vl]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1W_D_SXTW               ld1w	{ z21.d }, p5/z, [x10, z21.d, sxtw]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1W_D_UXTW               ld1w	{ z21.d }, p5/z, [x10, z21.d, uxtw]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1W_D_SXTW               ld1w	{ z21.d }, p5/z, [x10, z21.d, sxtw]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1W_D_UXTW               ld1w	{ z21.d }, p5/z, [x10, z21.d, uxtw]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1W                       ld1w	{ z21.s }, p5/z, [sp, x21, lsl #2]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1W_IMM                   ld1w	{ z21.s }, p5/z, [x10, #5, mul vl]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1W                       ld1w	{ z21.s }, p5/z, [x10, x21, lsl #2]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1W_D                     ld1w	{ z23.d }, p3/z, [x13, x8, lsl #2]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1W_D_SCALED             ld1w	{ z23.d }, p3/z, [x13, z8.d, lsl #2]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1W_D_SCALED             ld1w	{ z23.d }, p3/z, [x13, z8.d, lsl #2]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1W_D_IMM                 ld1w	{ z31.d }, p7/z, [sp, #-1, mul vl]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1W_D                    ld1w	{ z31.d }, p7/z, [sp, z31.d]
-# CHECK-NEXT:  4      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1W_D_IMM                ld1w	{ z31.d }, p7/z, [z31.d, #124]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1W_D                    ld1w	{ z31.d }, p7/z, [sp, z31.d]
+# CHECK-NEXT:  2      9     0.67    *                    9     V1UnitL[2],V1UnitV[2]                      GLD1W_D_IMM                ld1w	{ z31.d }, p7/z, [z31.d, #124]
 # CHECK-NEXT:  1      6     0.50    *                    6     V1UnitL,V1UnitL01                          LD1W_IMM                   ld1w	{ z31.s }, p7/z, [sp, #-1, mul vl]
-# CHECK-NEXT:  4      11    0.67    *                    11    V1UnitL[2],V1UnitV[2]                      GLD1W_SXTW_SCALED          ld1w	{ z31.s }, p7/z, [sp, z31.s, sxtw #2]
-# CHECK-NEXT:  4      11    0.67    *                    11    V1UnitL[2],V1UnitV[2]                      GLD1W_UXTW_SCALED          ld1w	{ z31.s }, p7/z, [sp, z31.s, uxtw #2]
+# CHECK-NEXT:  2      11    0.67    *                    11    V1UnitL[2],V1UnitV[2]                      GLD1W_SXTW_SCALED          ld1w	{ z31.s }, p7/z, [sp, z31.s, sxtw #2]
+# CHECK-NEXT:  2      11    0.67    *                    11    V1UnitL[2],V1UnitV[2]                      GLD1W_UXTW_SCALED          ld1w	{ z31.s }, p7/z, [sp, z31.s, uxtw #2]
 # CHECK-NEXT:  2      11    0.33    *                    11    V1UnitL,V1UnitV                            GLD1W_IMM                  ld1w	{ z31.s }, p7/z, [z31.s, #124]
-# CHECK-NEXT:  4      9     1.00    *                    9     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2B                  ld2b	{ z0.b, z1.b }, p0/z, [x0, x0]
-# CHECK-NEXT:  4      8     1.00    *                    8     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2B_IMM              ld2b	{ z0.b, z1.b }, p0/z, [x0]
-# CHECK-NEXT:  4      8     1.00    *                    8     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2B_IMM              ld2b	{ z21.b, z22.b }, p5/z, [x10, #10, mul vl]
-# CHECK-NEXT:  4      8     1.00    *                    8     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2B_IMM              ld2b	{ z23.b, z24.b }, p3/z, [x13, #-16, mul vl]
-# CHECK-NEXT:  4      9     1.00    *                    9     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2B                  ld2b	{ z5.b, z6.b }, p3/z, [x17, x16]
-# CHECK-NEXT:  4      9     1.00    *                    9     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2D                  ld2d	{ z0.d, z1.d }, p0/z, [x0, x0, lsl #3]
-# CHECK-NEXT:  4      8     1.00    *                    8     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2D_IMM              ld2d	{ z0.d, z1.d }, p0/z, [x0]
-# CHECK-NEXT:  4      8     1.00    *                    8     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2D_IMM              ld2d	{ z21.d, z22.d }, p5/z, [x10, #10, mul vl]
-# CHECK-NEXT:  4      8     1.00    *                    8     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2D_IMM              ld2d	{ z23.d, z24.d }, p3/z, [x13, #-16, mul vl]
-# CHECK-NEXT:  4      9     1.00    *                    9     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2D                  ld2d	{ z5.d, z6.d }, p3/z, [x17, x16, lsl #3]
-# CHECK-NEXT:  4      10    1.00    *                    10    V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2H                  ld2h	{ z0.h, z1.h }, p0/z, [x0, x0, lsl #1]
-# CHECK-NEXT:  4      8     1.00    *                    8     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2H_IMM              ld2h	{ z0.h, z1.h }, p0/z, [x0]
-# CHECK-NEXT:  4      8     1.00    *                    8     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2H_IMM              ld2h	{ z21.h, z22.h }, p5/z, [x10, #10, mul vl]
-# CHECK-NEXT:  4      8     1.00    *                    8     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2H_IMM              ld2h	{ z23.h, z24.h }, p3/z, [x13, #-16, mul vl]
-# CHECK-NEXT:  4      10    1.00    *                    10    V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2H                  ld2h	{ z5.h, z6.h }, p3/z, [x17, x16, lsl #1]
-# CHECK-NEXT:  4      9     1.00    *                    9     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2W                  ld2w	{ z0.s, z1.s }, p0/z, [x0, x0, lsl #2]
-# CHECK-NEXT:  4      8     1.00    *                    8     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2W_IMM              ld2w	{ z0.s, z1.s }, p0/z, [x0]
-# CHECK-NEXT:  4      8     1.00    *                    8     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2W_IMM              ld2w	{ z21.s, z22.s }, p5/z, [x10, #10, mul vl]
-# CHECK-NEXT:  4      8     1.00    *                    8     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2W_IMM              ld2w	{ z23.s, z24.s }, p3/z, [x13, #-16, mul vl]
-# CHECK-NEXT:  4      9     1.00    *                    9     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2W                  ld2w	{ z5.s, z6.s }, p3/z, [x17, x16, lsl #2]
-# CHECK-NEXT:  7      8     1.50    *                    8     V1UnitI,V1UnitL[3],V1UnitL01[3],V1UnitS,V1UnitV[3],V1UnitV01[3] LD3B  ld3b	{ z0.b - z2.b }, p0/z, [x0, x0]
-# CHECK-NEXT:  6      11    1.50    *                    11    V1UnitL[3],V1UnitL01[3],V1UnitV[3],V1UnitV01[3] LD3B_IMM              ld3b	{ z0.b - z2.b }, p0/z, [x0]
-# CHECK-NEXT:  6      11    1.50    *                    11    V1UnitL[3],V1UnitL01[3],V1UnitV[3],V1UnitV01[3] LD3B_IMM              ld3b	{ z21.b - z23.b }, p5/z, [x10, #15, mul vl]
-# CHECK-NEXT:  6      11    1.50    *                    11    V1UnitL[3],V1UnitL01[3],V1UnitV[3],V1UnitV01[3] LD3B_IMM              ld3b	{ z23.b - z25.b }, p3/z, [x13, #-24, mul vl]
-# CHECK-NEXT:  7      8     1.50    *                    8     V1UnitI,V1UnitL[3],V1UnitL01[3],V1UnitS,V1UnitV[3],V1UnitV01[3] LD3B  ld3b	{ z5.b - z7.b }, p3/z, [x17, x16]
-# CHECK-NEXT:  7      8     1.50    *                    8     V1UnitI,V1UnitL[3],V1UnitL01[3],V1UnitS,V1UnitV[3],V1UnitV01[3] LD3D  ld3d	{ z0.d - z2.d }, p0/z, [x0, x0, lsl #3]
-# CHECK-NEXT:  6      11    1.50    *                    11    V1UnitL[3],V1UnitL01[3],V1UnitV[3],V1UnitV01[3] LD3D_IMM              ld3d	{ z0.d - z2.d }, p0/z, [x0]
-# CHECK-NEXT:  6      11    1.50    *                    11    V1UnitL[3],V1UnitL01[3],V1UnitV[3],V1UnitV01[3] LD3D_IMM              ld3d	{ z21.d - z23.d }, p5/z, [x10, #15, mul vl]
-# CHECK-NEXT:  6      11    1.50    *                    11    V1UnitL[3],V1UnitL01[3],V1UnitV[3],V1UnitV01[3] LD3D_IMM              ld3d	{ z23.d - z25.d }, p3/z, [x13, #-24, mul vl]
-# CHECK-NEXT:  7      8     1.50    *                    8     V1UnitI,V1UnitL[3],V1UnitL01[3],V1UnitS,V1UnitV[3],V1UnitV01[3] LD3D  ld3d	{ z5.d - z7.d }, p3/z, [x17, x16, lsl #3]
-# CHECK-NEXT:  7      8     1.50    *                    8     V1UnitI,V1UnitL[3],V1UnitL01[3],V1UnitS,V1UnitV[3],V1UnitV01[3] LD3H  ld3h	{ z0.h - z2.h }, p0/z, [x0, x0, lsl #1]
-# CHECK-NEXT:  6      11    1.50    *                    11    V1UnitL[3],V1UnitL01[3],V1UnitV[3],V1UnitV01[3] LD3H_IMM              ld3h	{ z0.h - z2.h }, p0/z, [x0]
-# CHECK-NEXT:  6      11    1.50    *                    11    V1UnitL[3],V1UnitL01[3],V1UnitV[3],V1UnitV01[3] LD3H_IMM              ld3h	{ z21.h - z23.h }, p5/z, [x10, #15, mul vl]
-# CHECK-NEXT:  6      11    1.50    *                    11    V1UnitL[3],V1UnitL01[3],V1UnitV[3],V1UnitV01[3] LD3H_IMM              ld3h	{ z23.h - z25.h }, p3/z, [x13, #-24, mul vl]
-# CHECK-NEXT:  7      8     1.50    *                    8     V1UnitI,V1UnitL[3],V1UnitL01[3],V1UnitS,V1UnitV[3],V1UnitV01[3] LD3H  ld3h	{ z5.h - z7.h }, p3/z, [x17, x16, lsl #1]
-# CHECK-NEXT:  7      8     1.50    *                    8     V1UnitI,V1UnitL[3],V1UnitL01[3],V1UnitS,V1UnitV[3],V1UnitV01[3] LD3W  ld3w	{ z0.s - z2.s }, p0/z, [x0, x0, lsl #2]
-# CHECK-NEXT:  6      11    1.50    *                    11    V1UnitL[3],V1UnitL01[3],V1UnitV[3],V1UnitV01[3] LD3W_IMM              ld3w	{ z0.s - z2.s }, p0/z, [x0]
-# CHECK-NEXT:  6      11    1.50    *                    11    V1UnitL[3],V1UnitL01[3],V1UnitV[3],V1UnitV01[3] LD3W_IMM              ld3w	{ z21.s - z23.s }, p5/z, [x10, #15, mul vl]
-# CHECK-NEXT:  6      11    1.50    *                    11    V1UnitL[3],V1UnitL01[3],V1UnitV[3],V1UnitV01[3] LD3W_IMM              ld3w	{ z23.s - z25.s }, p3/z, [x13, #-24, mul vl]
-# CHECK-NEXT:  7      8     1.50    *                    8     V1UnitI,V1UnitL[3],V1UnitL01[3],V1UnitS,V1UnitV[3],V1UnitV01[3] LD3W  ld3w	{ z5.s - z7.s }, p3/z, [x17, x16, lsl #2]
-# CHECK-NEXT:  10     13    2.00    *                    13    V1UnitI[2],V1UnitL[4],V1UnitL01[4],V1UnitS[2],V1UnitV[4],V1UnitV01[4] LD4B ld4b	{ z0.b - z3.b }, p0/z, [x0, x0]
-# CHECK-NEXT:  8      12    2.00    *                    12    V1UnitL[4],V1UnitL01[4],V1UnitV[4],V1UnitV01[4] LD4B_IMM              ld4b	{ z0.b - z3.b }, p0/z, [x0]
-# CHECK-NEXT:  8      12    2.00    *                    12    V1UnitL[4],V1UnitL01[4],V1UnitV[4],V1UnitV01[4] LD4B_IMM              ld4b	{ z21.b - z24.b }, p5/z, [x10, #20, mul vl]
-# CHECK-NEXT:  8      12    2.00    *                    12    V1UnitL[4],V1UnitL01[4],V1UnitV[4],V1UnitV01[4] LD4B_IMM              ld4b	{ z23.b - z26.b }, p3/z, [x13, #-32, mul vl]
-# CHECK-NEXT:  10     13    2.00    *                    13    V1UnitI[2],V1UnitL[4],V1UnitL01[4],V1UnitS[2],V1UnitV[4],V1UnitV01[4] LD4B ld4b	{ z5.b - z8.b }, p3/z, [x17, x16]
-# CHECK-NEXT:  10     13    2.00    *                    13    V1UnitI[2],V1UnitL[4],V1UnitL01[4],V1UnitS[2],V1UnitV[4],V1UnitV01[4] LD4D ld4d	{ z0.d - z3.d }, p0/z, [x0, x0, lsl #3]
-# CHECK-NEXT:  8      12    2.00    *                    12    V1UnitL[4],V1UnitL01[4],V1UnitV[4],V1UnitV01[4] LD4D_IMM              ld4d	{ z0.d - z3.d }, p0/z, [x0]
-# CHECK-NEXT:  8      12    2.00    *                    12    V1UnitL[4],V1UnitL01[4],V1UnitV[4],V1UnitV01[4] LD4D_IMM              ld4d	{ z21.d - z24.d }, p5/z, [x10, #20, mul vl]
-# CHECK-NEXT:  8      12    2.00    *                    12    V1UnitL[4],V1UnitL01[4],V1UnitV[4],V1UnitV01[4] LD4D_IMM              ld4d	{ z23.d - z26.d }, p3/z, [x13, #-32, mul vl]
-# CHECK-NEXT:  10     13    2.00    *                    13    V1UnitI[2],V1UnitL[4],V1UnitL01[4],V1UnitS[2],V1UnitV[4],V1UnitV01[4] LD4D ld4d	{ z5.d - z8.d }, p3/z, [x17, x16, lsl #3]
-# CHECK-NEXT:  10     13    2.00    *                    13    V1UnitI[2],V1UnitL[4],V1UnitL01[4],V1UnitS[2],V1UnitV[4],V1UnitV01[4] LD4H ld4h	{ z0.h - z3.h }, p0/z, [x0, x0, lsl #1]
-# CHECK-NEXT:  8      12    2.00    *                    12    V1UnitL[4],V1UnitL01[4],V1UnitV[4],V1UnitV01[4] LD4H_IMM              ld4h	{ z0.h - z3.h }, p0/z, [x0]
-# CHECK-NEXT:  8      12    2.00    *                    12    V1UnitL[4],V1UnitL01[4],V1UnitV[4],V1UnitV01[4] LD4H_IMM              ld4h	{ z21.h - z24.h }, p5/z, [x10, #20, mul vl]
-# CHECK-NEXT:  8      12    2.00    *                    12    V1UnitL[4],V1UnitL01[4],V1UnitV[4],V1UnitV01[4] LD4H_IMM              ld4h	{ z23.h - z26.h }, p3/z, [x13, #-32, mul vl]
-# CHECK-NEXT:  10     13    2.00    *                    13    V1UnitI[2],V1UnitL[4],V1UnitL01[4],V1UnitS[2],V1UnitV[4],V1UnitV01[4] LD4H ld4h	{ z5.h - z8.h }, p3/z, [x17, x16, lsl #1]
-# CHECK-NEXT:  10     13    2.00    *                    13    V1UnitI[2],V1UnitL[4],V1UnitL01[4],V1UnitS[2],V1UnitV[4],V1UnitV01[4] LD4W ld4w	{ z0.s - z3.s }, p0/z, [x0, x0, lsl #2]
-# CHECK-NEXT:  8      12    2.00    *                    12    V1UnitL[4],V1UnitL01[4],V1UnitV[4],V1UnitV01[4] LD4W_IMM              ld4w	{ z0.s - z3.s }, p0/z, [x0]
-# CHECK-NEXT:  8      12    2.00    *                    12    V1UnitL[4],V1UnitL01[4],V1UnitV[4],V1UnitV01[4] LD4W_IMM              ld4w	{ z21.s - z24.s }, p5/z, [x10, #20, mul vl]
-# CHECK-NEXT:  8      12    2.00    *                    12    V1UnitL[4],V1UnitL01[4],V1UnitV[4],V1UnitV01[4] LD4W_IMM              ld4w	{ z23.s - z26.s }, p3/z, [x13, #-32, mul vl]
-# CHECK-NEXT:  10     13    2.00    *                    13    V1UnitI[2],V1UnitL[4],V1UnitL01[4],V1UnitS[2],V1UnitV[4],V1UnitV01[4] LD4W ld4w	{ z5.s - z8.s }, p3/z, [x17, x16, lsl #2]
+# CHECK-NEXT:  2      9     1.00    *                    9     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2B                  ld2b	{ z0.b, z1.b }, p0/z, [x0, x0]
+# CHECK-NEXT:  2      8     1.00    *                    8     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2B_IMM              ld2b	{ z0.b, z1.b }, p0/z, [x0]
+# CHECK-NEXT:  2      8     1.00    *                    8     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2B_IMM              ld2b	{ z21.b, z22.b }, p5/z, [x10, #10, mul vl]
+# CHECK-NEXT:  2      8     1.00    *                    8     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2B_IMM              ld2b	{ z23.b, z24.b }, p3/z, [x13, #-16, mul vl]
+# CHECK-NEXT:  2      9     1.00    *                    9     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2B                  ld2b	{ z5.b, z6.b }, p3/z, [x17, x16]
+# CHECK-NEXT:  2      9     1.00    *                    9     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2D                  ld2d	{ z0.d, z1.d }, p0/z, [x0, x0, lsl #3]
+# CHECK-NEXT:  2      8     1.00    *                    8     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2D_IMM              ld2d	{ z0.d, z1.d }, p0/z, [x0]
+# CHECK-NEXT:  2      8     1.00    *                    8     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2D_IMM              ld2d	{ z21.d, z22.d }, p5/z, [x10, #10, mul vl]
+# CHECK-NEXT:  2      8     1.00    *                    8     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2D_IMM              ld2d	{ z23.d, z24.d }, p3/z, [x13, #-16, mul vl]
+# CHECK-NEXT:  2      9     1.00    *                    9     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2D                  ld2d	{ z5.d, z6.d }, p3/z, [x17, x16, lsl #3]
+# CHECK-NEXT:  2      10    1.00    *                    10    V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2H                  ld2h	{ z0.h, z1.h }, p0/z, [x0, x0, lsl #1]
+# CHECK-NEXT:  2      8     1.00    *                    8     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2H_IMM              ld2h	{ z0.h, z1.h }, p0/z, [x0]
+# CHECK-NEXT:  2      8     1.00    *                    8     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2H_IMM              ld2h	{ z21.h, z22.h }, p5/z, [x10, #10, mul vl]
+# CHECK-NEXT:  2      8     1.00    *                    8     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2H_IMM              ld2h	{ z23.h, z24.h }, p3/z, [x13, #-16, mul vl]
+# CHECK-NEXT:  2      10    1.00    *                    10    V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2H                  ld2h	{ z5.h, z6.h }, p3/z, [x17, x16, lsl #1]
+# CHECK-NEXT:  2      9     1.00    *                    9     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2W                  ld2w	{ z0.s, z1.s }, p0/z, [x0, x0, lsl #2]
+# CHECK-NEXT:  2      8     1.00    *                    8     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2W_IMM              ld2w	{ z0.s, z1.s }, p0/z, [x0]
+# CHECK-NEXT:  2      8     1.00    *                    8     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2W_IMM              ld2w	{ z21.s, z22.s }, p5/z, [x10, #10, mul vl]
+# CHECK-NEXT:  2      8     1.00    *                    8     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2W_IMM              ld2w	{ z23.s, z24.s }, p3/z, [x13, #-16, mul vl]
+# CHECK-NEXT:  2      9     1.00    *                    9     V1UnitL[2],V1UnitL01[2],V1UnitV[2],V1UnitV01[2] LD2W                  ld2w	{ z5.s, z6.s }, p3/z, [x17, x16, lsl #2]
+# CHECK-NEXT:  3      8     1.50    *                    8     V1UnitI,V1UnitL[3],V1UnitL01[3],V1UnitS,V1UnitV[3],V1UnitV01[3] LD3B  ld3b	{ z0.b - z2.b }, p0/z, [x0, x0]
+# CHECK-NEXT:  2      11    1.50    *                    11    V1UnitL[3],V1UnitL01[3],V1UnitV[3],V1UnitV01[3] LD3B_IMM              ld3b	{ z0.b - z2.b }, p0/z, [x0]
+# CHECK-NEXT:  2      11    1.50    *                    11    V1UnitL[3],V1UnitL01[3],V1UnitV[3],V1UnitV01[3] LD3B_IMM              ld3b	{ z21.b - z23.b }, p5/z, [x10, #15, mul vl]
+# CHECK-NEXT:  2      11    1.50    *                    11    V1UnitL[3],V1UnitL01[3],V1UnitV[3],V1UnitV01[3] LD3B_IMM              ld3b	{ z23.b - z25.b }, p3/z, [x13, #-24, mul vl]
+# CHECK-NEXT:  3      8     1.50    *                    8     V1UnitI,V1UnitL[3],V1UnitL01[3],V1UnitS,V1UnitV[3],V1UnitV01[3] LD3B  ld3b	{ z5.b - z7.b }, p3/z, [x17, x16]
+# CHECK-NEXT:  3      8     1.50    *                    8     V1UnitI,V1UnitL[3],V1UnitL01[3],V1UnitS,V1UnitV[3],V1UnitV01[3] LD3D  ld3d	{ z0.d - z2.d }, p0/z, [x0, x0, lsl #3]
+# CHECK-NEXT:  2      11    1.50    *                    11    V1UnitL[3],V1UnitL01[3],V1UnitV[3],V1UnitV01[3] LD3D_IMM              ld3d	{ z0.d - z2.d }, p0/z, [x0]
+# CHECK-NEXT:  2      11    1.50    *                    11    V1UnitL[3],V1UnitL01[3],V1UnitV[3],V1UnitV01[3] LD3D_IMM              ld3d	{ z21.d - z23.d }, p5/z, [x10, #15, mul vl]
+# CHECK-NEXT:  2      11    1.50    *                    11    V1UnitL[3],V1UnitL01[3],V1UnitV[3],V1UnitV01[3] LD3D_IMM              ld3d	{ z23.d - z25.d }, p3/z, [x13, #-24, mul vl]
+# CHECK-NEXT:  3      8     1.50    *                    8     V1UnitI,V1UnitL[3],V1UnitL01[3],V1UnitS,V1UnitV[3],V1UnitV01[3] LD3D  ld3d	{ z5.d - z7.d }, p3/z, [x17, x16, lsl #3]
+# CHECK-NEXT:  3      8     1.50    *                    8     V1UnitI,V1UnitL[3],V1UnitL01[3],V1UnitS,V1UnitV[3],V1UnitV01[3] LD3H  ld3h	{ z0.h - z2.h }, p0/z, [x0, x0, lsl #1]
+# CHECK-NEXT:  2      11    1.50    *                    11    V1UnitL[3],V1UnitL01[3],V1UnitV[3],V1UnitV01[3] LD3H_IMM              ld3h	{ z0.h - z2.h }, p0/z, [x0]
+# CHECK-NEXT:  2      11    1.50    *                    11    V1UnitL[3],V1UnitL01[3],V1UnitV[3],V1UnitV01[3] LD3H_IMM              ld3h	{ z21.h - z23.h }, p5/z, [x10, #15, mul vl]
+# CHECK-NEXT:  2      11    1.50    *                    11    V1UnitL[3],V1UnitL01[3],V1UnitV[3],V1UnitV01[3] LD3H_IMM              ld3h	{ z23.h - z25.h }, p3/z, [x13, #-24, mul vl]
+# CHECK-NEXT:  3      8     1.50    *                    8     V1UnitI,V1UnitL[3],V1UnitL01[3],V1UnitS,V1UnitV[3],V1UnitV01[3] LD3H  ld3h	{ z5.h - z7.h }, p3/z, [x17, x16, lsl #1]
+# CHECK-NEXT:  3      8     1.50    *                    8     V1UnitI,V1UnitL[3],V1UnitL01[3],V1UnitS,V1UnitV[3],V1UnitV01[3] LD3W  ld3w	{ z0.s - z2.s }, p0/z, [x0, x0, lsl #2]
+# CHECK-NEXT:  2      11    1.50    *                    11    V1UnitL[3],V1UnitL01[3],V1UnitV[3],V1UnitV01[3] LD3W_IMM              ld3w	{ z0.s - z2.s }, p0/z, [x0]
+# CHECK-NEXT:  2      11    1.50    *                    11    V1UnitL[3],V1UnitL01[3],V1UnitV[3],V1UnitV01[3] LD3W_IMM              ld3w	{ z21.s - z23.s }, p5/z, [x10, #15, mul vl]
+# CHECK-NEXT:  2      11    1.50    *                    11    V1UnitL[3],V1UnitL01[3],V1UnitV[3],V1UnitV01[3] LD3W_IMM              ld3w	{ z23.s - z25.s }, p3/z, [x13, #-24, mul vl]
+# CHECK-NEXT:  3      8     1.50    *                    8     V1UnitI,V1UnitL[3],V1UnitL01[3],V1UnitS,V1UnitV[3],V1UnitV01[3] LD3W  ld3w	{ z5.s - z7.s }, p3/z, [x17, x16, lsl #2]
+# CHECK-NEXT:  3      13    2.00    *                    13    V1UnitI[2],V1UnitL[4],V1UnitL01[4],V1UnitS[2],V1UnitV[4],V1UnitV01[4] LD4B ld4b	{ z0.b - z3.b }, p0/z, [x0, x0]
+# CHECK-NEXT:  2      12    2.00    *                    12    V1UnitL[4],V1UnitL01[4],V1UnitV[4],V1UnitV01[4] LD4B_IMM              ld4b	{ z0.b - z3.b }, p0/z, [x0]
+# CHECK-NEXT:  2      12    2.00    *                    12    V1UnitL[4],V1UnitL01[4],V1UnitV[4],V1UnitV01[4] LD4B_IMM              ld4b	{ z21.b - z24.b }, p5/z, [x10, #20, mul vl]
+# CHECK-NEXT:  2      12    2.00    *                    12    V1UnitL[4],V1UnitL01[4],V1UnitV[4],V1UnitV01[4] LD4B_IMM              ld4b	{ z23.b - z26.b }, p3/z, [x13, #-32, mul vl]
+# CHECK-NEXT:  3      13    2.00    *                    13    V1UnitI[2],V1UnitL[4],V1UnitL01[4],V1UnitS[2],V1UnitV[4],V1UnitV01[4] LD4B ld4b	{ z5.b - z8.b }, p3/z, [x17, x16]
+# CHECK-NEXT:  3      13    2.00    *                    13    V1UnitI[2],V1UnitL[4],V1UnitL01[4],V1UnitS[2],V1UnitV[4],V1UnitV01[4] LD4D ld4d	{ z0.d - z3.d }, p0/z, [x0, x0, lsl #3]
+# CHECK-NEXT:  2      12    2.00    *                    12    V1UnitL[4],V1UnitL01[4],V1UnitV[4],V1UnitV01[4] LD4D_IMM              ld4d	{ z0.d - z3.d }, p0/z, [x0]
+# CHECK-NEXT:  2      12    2.00    *                    12    V1UnitL[4],V1UnitL01[4],V1UnitV[4],V1UnitV01[4] LD4D_IMM              ld4d	{ z21.d - z24.d }, p5/z, [x10, #20, mul vl]
+# CHECK-NEXT:  2      12    2.00    *                    12    V1UnitL[4],V1UnitL01[4],V1UnitV[4],V1UnitV01[4] LD4D_IMM              ld4d	{ z23.d - z26.d }, p3/z, [x13, #-32, mul vl]
+# CHECK-NEXT:  3      13    2.00    *                    13    V1UnitI[2],V1UnitL[4],V1UnitL01[4],V1UnitS[2],V1UnitV[4],V1UnitV01[4] LD4D ld4d	{ z5.d - z8.d }, p3/z, [x17, x16, lsl #3]
+# CHECK-NEXT:  3      13    2.00    *                    13    V1UnitI[2],V1UnitL[4],V1UnitL01[4],V1UnitS[2],V1UnitV[4],V1UnitV01[4] LD4H ld4h	{ z0.h - z3.h }, p0/z, [x0, x0, lsl #1]
+# CHECK-NEXT:  2      12    2.00    *                    12    V1UnitL[4],V1UnitL01[4],V1UnitV[4],V1UnitV01[4] LD4H_IMM              ld4h	{ z0.h - z3.h }, p0/z, [x0]
+# CHECK-NEXT:  2      12    2.00    *                    12    V1UnitL[4],V1UnitL01[4],V1UnitV[4],V1UnitV01[4] LD4H_IMM              ld4h	{ z21.h - z24.h }, p5/z, [x10, #20, mul vl]
+# CHECK-NEXT:  2      12    2.00    *                    12    V1UnitL[4],V1UnitL01[4],V1UnitV[4],V1UnitV01[4] LD4H_IMM              ld4h	{ z23.h - z26.h }, p3/z, [x13, #-32, mul vl]
+# CHECK-NEXT:  3      13    2.00    *                    13    V1UnitI[2],V1UnitL[4],V1UnitL01[4],V1UnitS[2],V1UnitV[4],V1UnitV01[4] LD4H ld4h	{ z5.h - z8.h }, p3/z, [x17, x16, lsl #1]
+# CHECK-NEXT:  3      13    2.00    *                    13    V1UnitI[2],V1UnitL[4],V1UnitL01[4],V1UnitS[2],V1UnitV[4],V1UnitV01[4] LD4W ld4w	{ z0.s - z3.s }, p0/z, [x0, x0, lsl #2]
+# CHECK-NEXT:  2      12    2.00    *                    12    V1UnitL[4],V1UnitL01[4],V1UnitV[4],V1UnitV01[4] LD4W_IMM              ld4w	{ z0.s - z3.s }, p0/z, [x0]
+# CHECK-NEXT:  2      12    2.00    *                    12    V1UnitL[4],V1UnitL01[4],V1UnitV[4],V1UnitV01[4] LD4W_IMM              ld4w	{ z21.s - z24.s }, p5/z, [x10, #20, mul vl]
+# CHECK-NEXT:  2      12    2.00    *                    12    V1UnitL[4],V1UnitL01[4],V1UnitV[4],V1UnitV01[4] LD4W_IMM              ld4w	{ z23.s - z26.s }, p3/z, [x13, #-32, mul vl]
+# CHECK-NEXT:  3      13    2.00    *                    13    V1UnitI[2],V1UnitL[4],V1UnitL01[4],V1UnitS[2],V1UnitV[4],V1UnitV01[4] LD4W ld4w	{ z5.s - z8.s }, p3/z, [x17, x16, lsl #2]
 # CHECK-NEXT:  2      6     0.50    *             U      6     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LDFF1B_D                   ldff1b	{ z0.d }, p0/z, [x0, x0]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1B_D_IMM              ldff1b	{ z0.d }, p0/z, [z0.d]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1B_D_IMM              ldff1b	{ z0.d }, p0/z, [z0.d]
 # CHECK-NEXT:  2      6     0.50    *             U      6     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LDFF1B_H                   ldff1b	{ z0.h }, p0/z, [x0, x0]
 # CHECK-NEXT:  2      6     0.50    *             U      6     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LDFF1B_S                   ldff1b	{ z0.s }, p0/z, [x0, x0]
 # CHECK-NEXT:  2      9     0.33    *             U      9     V1UnitL,V1UnitV                            GLDFF1B_S_SXTW             ldff1b	{ z0.s }, p0/z, [x0, z0.s, sxtw]
 # CHECK-NEXT:  2      9     0.33    *             U      9     V1UnitL,V1UnitV                            GLDFF1B_S_UXTW             ldff1b	{ z0.s }, p0/z, [x0, z0.s, uxtw]
 # CHECK-NEXT:  2      11    0.33    *             U      11    V1UnitL,V1UnitV                            GLDFF1B_S_IMM              ldff1b	{ z0.s }, p0/z, [z0.s]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1B_D_SXTW             ldff1b	{ z21.d }, p5/z, [x10, z21.d, sxtw]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1B_D_UXTW             ldff1b	{ z21.d }, p5/z, [x10, z21.d, uxtw]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1B_D_SXTW             ldff1b	{ z21.d }, p5/z, [x10, z21.d, sxtw]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1B_D_UXTW             ldff1b	{ z21.d }, p5/z, [x10, z21.d, uxtw]
 # CHECK-NEXT:  2      6     0.50    *             U      6     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LDFF1B                     ldff1b	{ z31.b }, p7/z, [sp]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1B_D                  ldff1b	{ z31.d }, p7/z, [sp, z31.d]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1B_D                  ldff1b	{ z31.d }, p7/z, [sp, z31.d]
 # CHECK-NEXT:  2      6     0.50    *             U      6     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LDFF1B_D                   ldff1b	{ z31.d }, p7/z, [sp]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1B_D_IMM              ldff1b	{ z31.d }, p7/z, [z31.d, #31]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1B_D_IMM              ldff1b	{ z31.d }, p7/z, [z31.d, #31]
 # CHECK-NEXT:  2      6     0.50    *             U      6     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LDFF1B_H                   ldff1b	{ z31.h }, p7/z, [sp]
 # CHECK-NEXT:  2      6     0.50    *             U      6     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LDFF1B_S                   ldff1b	{ z31.s }, p7/z, [sp]
 # CHECK-NEXT:  2      11    0.33    *             U      11    V1UnitL,V1UnitV                            GLDFF1B_S_IMM              ldff1b	{ z31.s }, p7/z, [z31.s, #31]
 # CHECK-NEXT:  2      6     0.50    *             U      6     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LDFF1D                     ldff1d	{ z0.d }, p0/z, [x0, x0, lsl #3]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1D_SXTW_SCALED        ldff1d	{ z0.d }, p0/z, [x0, z0.d, sxtw #3]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1D_UXTW_SCALED        ldff1d	{ z0.d }, p0/z, [x0, z0.d, uxtw #3]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1D_IMM                ldff1d	{ z0.d }, p0/z, [z0.d]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1D_SXTW               ldff1d	{ z21.d }, p5/z, [x10, z21.d, sxtw]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1D_UXTW               ldff1d	{ z21.d }, p5/z, [x10, z21.d, uxtw]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1D_SCALED             ldff1d	{ z23.d }, p3/z, [x13, z8.d, lsl #3]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1D                    ldff1d	{ z31.d }, p7/z, [sp, z31.d]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1D_SXTW_SCALED        ldff1d	{ z0.d }, p0/z, [x0, z0.d, sxtw #3]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1D_UXTW_SCALED        ldff1d	{ z0.d }, p0/z, [x0, z0.d, uxtw #3]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1D_IMM                ldff1d	{ z0.d }, p0/z, [z0.d]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1D_SXTW               ldff1d	{ z21.d }, p5/z, [x10, z21.d, sxtw]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1D_UXTW               ldff1d	{ z21.d }, p5/z, [x10, z21.d, uxtw]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1D_SCALED             ldff1d	{ z23.d }, p3/z, [x13, z8.d, lsl #3]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1D                    ldff1d	{ z31.d }, p7/z, [sp, z31.d]
 # CHECK-NEXT:  2      6     0.50    *             U      6     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LDFF1D                     ldff1d	{ z31.d }, p7/z, [sp]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1D_IMM                ldff1d	{ z31.d }, p7/z, [z31.d, #248]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1D_IMM                ldff1d	{ z31.d }, p7/z, [z31.d, #248]
 # CHECK-NEXT:  2      7     0.50    *             U      7     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LDFF1H_D                   ldff1h	{ z0.d }, p0/z, [x0, x0, lsl #1]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1H_D_SXTW_SCALED      ldff1h	{ z0.d }, p0/z, [x0, z0.d, sxtw #1]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1H_D_UXTW_SCALED      ldff1h	{ z0.d }, p0/z, [x0, z0.d, uxtw #1]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1H_D_IMM              ldff1h	{ z0.d }, p0/z, [z0.d]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1H_D_SXTW_SCALED      ldff1h	{ z0.d }, p0/z, [x0, z0.d, sxtw #1]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1H_D_UXTW_SCALED      ldff1h	{ z0.d }, p0/z, [x0, z0.d, uxtw #1]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1H_D_IMM              ldff1h	{ z0.d }, p0/z, [z0.d]
 # CHECK-NEXT:  2      7     0.50    *             U      7     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LDFF1H                     ldff1h	{ z0.h }, p0/z, [x0, x0, lsl #1]
 # CHECK-NEXT:  2      7     0.50    *             U      7     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LDFF1H_S                   ldff1h	{ z0.s }, p0/z, [x0, x0, lsl #1]
 # CHECK-NEXT:  2      9     0.33    *             U      9     V1UnitL,V1UnitV                            GLDFF1H_S_SXTW             ldff1h	{ z0.s }, p0/z, [x0, z0.s, sxtw]
 # CHECK-NEXT:  2      9     0.33    *             U      9     V1UnitL,V1UnitV                            GLDFF1H_S_UXTW             ldff1h	{ z0.s }, p0/z, [x0, z0.s, uxtw]
 # CHECK-NEXT:  2      11    0.33    *             U      11    V1UnitL,V1UnitV                            GLDFF1H_S_IMM              ldff1h	{ z0.s }, p0/z, [z0.s]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1H_D_SXTW             ldff1h	{ z21.d }, p5/z, [x10, z21.d, sxtw]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1H_D_UXTW             ldff1h	{ z21.d }, p5/z, [x10, z21.d, uxtw]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1H_D_SCALED           ldff1h	{ z23.d }, p3/z, [x13, z8.d, lsl #1]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1H_D                  ldff1h	{ z31.d }, p7/z, [sp, z31.d]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1H_D_SXTW             ldff1h	{ z21.d }, p5/z, [x10, z21.d, sxtw]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1H_D_UXTW             ldff1h	{ z21.d }, p5/z, [x10, z21.d, uxtw]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1H_D_SCALED           ldff1h	{ z23.d }, p3/z, [x13, z8.d, lsl #1]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1H_D                  ldff1h	{ z31.d }, p7/z, [sp, z31.d]
 # CHECK-NEXT:  2      7     0.50    *             U      7     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LDFF1H_D                   ldff1h	{ z31.d }, p7/z, [sp]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1H_D_IMM              ldff1h	{ z31.d }, p7/z, [z31.d, #62]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1H_D_IMM              ldff1h	{ z31.d }, p7/z, [z31.d, #62]
 # CHECK-NEXT:  2      7     0.50    *             U      7     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LDFF1H                     ldff1h	{ z31.h }, p7/z, [sp]
-# CHECK-NEXT:  4      11    0.67    *             U      11    V1UnitL[2],V1UnitV[2]                      GLDFF1H_S_SXTW_SCALED      ldff1h	{ z31.s }, p7/z, [sp, z31.s, sxtw #1]
-# CHECK-NEXT:  4      11    0.67    *             U      11    V1UnitL[2],V1UnitV[2]                      GLDFF1H_S_UXTW_SCALED      ldff1h	{ z31.s }, p7/z, [sp, z31.s, uxtw #1]
+# CHECK-NEXT:  2      11    0.67    *             U      11    V1UnitL[2],V1UnitV[2]                      GLDFF1H_S_SXTW_SCALED      ldff1h	{ z31.s }, p7/z, [sp, z31.s, sxtw #1]
+# CHECK-NEXT:  2      11    0.67    *             U      11    V1UnitL[2],V1UnitV[2]                      GLDFF1H_S_UXTW_SCALED      ldff1h	{ z31.s }, p7/z, [sp, z31.s, uxtw #1]
 # CHECK-NEXT:  2      7     0.50    *             U      7     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LDFF1H_S                   ldff1h	{ z31.s }, p7/z, [sp]
 # CHECK-NEXT:  2      11    0.33    *             U      11    V1UnitL,V1UnitV                            GLDFF1H_S_IMM              ldff1h	{ z31.s }, p7/z, [z31.s, #62]
 # CHECK-NEXT:  2      6     0.50    *             U      6     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LDFF1SB_D                  ldff1sb	{ z0.d }, p0/z, [x0, x0]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SB_D_IMM             ldff1sb	{ z0.d }, p0/z, [z0.d]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SB_D_IMM             ldff1sb	{ z0.d }, p0/z, [z0.d]
 # CHECK-NEXT:  2      6     0.50    *             U      6     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LDFF1SB_H                  ldff1sb	{ z0.h }, p0/z, [x0, x0]
 # CHECK-NEXT:  2      6     0.50    *             U      6     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LDFF1SB_S                  ldff1sb	{ z0.s }, p0/z, [x0, x0]
 # CHECK-NEXT:  2      9     0.33    *             U      9     V1UnitL,V1UnitV                            GLDFF1SB_S_SXTW            ldff1sb	{ z0.s }, p0/z, [x0, z0.s, sxtw]
 # CHECK-NEXT:  2      9     0.33    *             U      9     V1UnitL,V1UnitV                            GLDFF1SB_S_UXTW            ldff1sb	{ z0.s }, p0/z, [x0, z0.s, uxtw]
 # CHECK-NEXT:  2      11    0.33    *             U      11    V1UnitL,V1UnitV                            GLDFF1SB_S_IMM             ldff1sb	{ z0.s }, p0/z, [z0.s]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SB_D_SXTW            ldff1sb	{ z21.d }, p5/z, [x10, z21.d, sxtw]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SB_D_UXTW            ldff1sb	{ z21.d }, p5/z, [x10, z21.d, uxtw]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SB_D                 ldff1sb	{ z31.d }, p7/z, [sp, z31.d]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SB_D_SXTW            ldff1sb	{ z21.d }, p5/z, [x10, z21.d, sxtw]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SB_D_UXTW            ldff1sb	{ z21.d }, p5/z, [x10, z21.d, uxtw]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SB_D                 ldff1sb	{ z31.d }, p7/z, [sp, z31.d]
 # CHECK-NEXT:  2      6     0.50    *             U      6     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LDFF1SB_D                  ldff1sb	{ z31.d }, p7/z, [sp]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SB_D_IMM             ldff1sb	{ z31.d }, p7/z, [z31.d, #31]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SB_D_IMM             ldff1sb	{ z31.d }, p7/z, [z31.d, #31]
 # CHECK-NEXT:  2      6     0.50    *             U      6     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LDFF1SB_H                  ldff1sb	{ z31.h }, p7/z, [sp]
 # CHECK-NEXT:  2      6     0.50    *             U      6     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LDFF1SB_S                  ldff1sb	{ z31.s }, p7/z, [sp]
 # CHECK-NEXT:  2      11    0.33    *             U      11    V1UnitL,V1UnitV                            GLDFF1SB_S_IMM             ldff1sb	{ z31.s }, p7/z, [z31.s, #31]
 # CHECK-NEXT:  2      7     0.50    *             U      7     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LDFF1SH_D                  ldff1sh	{ z0.d }, p0/z, [x0, x0, lsl #1]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SH_D_SXTW_SCALED     ldff1sh	{ z0.d }, p0/z, [x0, z0.d, sxtw #1]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SH_D_UXTW_SCALED     ldff1sh	{ z0.d }, p0/z, [x0, z0.d, uxtw #1]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SH_D_IMM             ldff1sh	{ z0.d }, p0/z, [z0.d]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SH_D_SXTW_SCALED     ldff1sh	{ z0.d }, p0/z, [x0, z0.d, sxtw #1]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SH_D_UXTW_SCALED     ldff1sh	{ z0.d }, p0/z, [x0, z0.d, uxtw #1]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SH_D_IMM             ldff1sh	{ z0.d }, p0/z, [z0.d]
 # CHECK-NEXT:  2      7     0.50    *             U      7     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LDFF1SH_S                  ldff1sh	{ z0.s }, p0/z, [x0, x0, lsl #1]
 # CHECK-NEXT:  2      9     0.33    *             U      9     V1UnitL,V1UnitV                            GLDFF1SH_S_SXTW            ldff1sh	{ z0.s }, p0/z, [x0, z0.s, sxtw]
 # CHECK-NEXT:  2      9     0.33    *             U      9     V1UnitL,V1UnitV                            GLDFF1SH_S_UXTW            ldff1sh	{ z0.s }, p0/z, [x0, z0.s, uxtw]
 # CHECK-NEXT:  2      11    0.33    *             U      11    V1UnitL,V1UnitV                            GLDFF1SH_S_IMM             ldff1sh	{ z0.s }, p0/z, [z0.s]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SH_D_SXTW            ldff1sh	{ z21.d }, p5/z, [x10, z21.d, sxtw]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SH_D_UXTW            ldff1sh	{ z21.d }, p5/z, [x10, z21.d, uxtw]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SH_D_SCALED          ldff1sh	{ z23.d }, p3/z, [x13, z8.d, lsl #1]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SH_D                 ldff1sh	{ z31.d }, p7/z, [sp, z31.d]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SH_D_SXTW            ldff1sh	{ z21.d }, p5/z, [x10, z21.d, sxtw]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SH_D_UXTW            ldff1sh	{ z21.d }, p5/z, [x10, z21.d, uxtw]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SH_D_SCALED          ldff1sh	{ z23.d }, p3/z, [x13, z8.d, lsl #1]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SH_D                 ldff1sh	{ z31.d }, p7/z, [sp, z31.d]
 # CHECK-NEXT:  2      7     0.50    *             U      7     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LDFF1SH_D                  ldff1sh	{ z31.d }, p7/z, [sp]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SH_D_IMM             ldff1sh	{ z31.d }, p7/z, [z31.d, #62]
-# CHECK-NEXT:  4      11    0.67    *             U      11    V1UnitL[2],V1UnitV[2]                      GLDFF1SH_S_SXTW_SCALED     ldff1sh	{ z31.s }, p7/z, [sp, z31.s, sxtw #1]
-# CHECK-NEXT:  4      11    0.67    *             U      11    V1UnitL[2],V1UnitV[2]                      GLDFF1SH_S_UXTW_SCALED     ldff1sh	{ z31.s }, p7/z, [sp, z31.s, uxtw #1]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SH_D_IMM             ldff1sh	{ z31.d }, p7/z, [z31.d, #62]
+# CHECK-NEXT:  2      11    0.67    *             U      11    V1UnitL[2],V1UnitV[2]                      GLDFF1SH_S_SXTW_SCALED     ldff1sh	{ z31.s }, p7/z, [sp, z31.s, sxtw #1]
+# CHECK-NEXT:  2      11    0.67    *             U      11    V1UnitL[2],V1UnitV[2]                      GLDFF1SH_S_UXTW_SCALED     ldff1sh	{ z31.s }, p7/z, [sp, z31.s, uxtw #1]
 # CHECK-NEXT:  2      7     0.50    *             U      7     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LDFF1SH_S                  ldff1sh	{ z31.s }, p7/z, [sp]
 # CHECK-NEXT:  2      11    0.33    *             U      11    V1UnitL,V1UnitV                            GLDFF1SH_S_IMM             ldff1sh	{ z31.s }, p7/z, [z31.s, #62]
 # CHECK-NEXT:  2      6     0.50    *             U      6     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LDFF1SW_D                  ldff1sw	{ z0.d }, p0/z, [x0, x0, lsl #2]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SW_D_SXTW_SCALED     ldff1sw	{ z0.d }, p0/z, [x0, z0.d, sxtw #2]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SW_D_UXTW_SCALED     ldff1sw	{ z0.d }, p0/z, [x0, z0.d, uxtw #2]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SW_D_IMM             ldff1sw	{ z0.d }, p0/z, [z0.d]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SW_D_SXTW            ldff1sw	{ z21.d }, p5/z, [x10, z21.d, sxtw]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SW_D_UXTW            ldff1sw	{ z21.d }, p5/z, [x10, z21.d, uxtw]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SW_D_SCALED          ldff1sw	{ z23.d }, p3/z, [x13, z8.d, lsl #2]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SW_D                 ldff1sw	{ z31.d }, p7/z, [sp, z31.d]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SW_D_SXTW_SCALED     ldff1sw	{ z0.d }, p0/z, [x0, z0.d, sxtw #2]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SW_D_UXTW_SCALED     ldff1sw	{ z0.d }, p0/z, [x0, z0.d, uxtw #2]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SW_D_IMM             ldff1sw	{ z0.d }, p0/z, [z0.d]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SW_D_SXTW            ldff1sw	{ z21.d }, p5/z, [x10, z21.d, sxtw]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SW_D_UXTW            ldff1sw	{ z21.d }, p5/z, [x10, z21.d, uxtw]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SW_D_SCALED          ldff1sw	{ z23.d }, p3/z, [x13, z8.d, lsl #2]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SW_D                 ldff1sw	{ z31.d }, p7/z, [sp, z31.d]
 # CHECK-NEXT:  2      6     0.50    *             U      6     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LDFF1SW_D                  ldff1sw	{ z31.d }, p7/z, [sp]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SW_D_IMM             ldff1sw	{ z31.d }, p7/z, [z31.d, #124]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1SW_D_IMM             ldff1sw	{ z31.d }, p7/z, [z31.d, #124]
 # CHECK-NEXT:  2      6     0.50    *             U      6     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LDFF1W_D                   ldff1w	{ z0.d }, p0/z, [x0, x0, lsl #2]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1W_D_SXTW_SCALED      ldff1w	{ z0.d }, p0/z, [x0, z0.d, sxtw #2]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1W_D_UXTW_SCALED      ldff1w	{ z0.d }, p0/z, [x0, z0.d, uxtw #2]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1W_D_IMM              ldff1w	{ z0.d }, p0/z, [z0.d]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1W_D_SXTW_SCALED      ldff1w	{ z0.d }, p0/z, [x0, z0.d, sxtw #2]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1W_D_UXTW_SCALED      ldff1w	{ z0.d }, p0/z, [x0, z0.d, uxtw #2]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1W_D_IMM              ldff1w	{ z0.d }, p0/z, [z0.d]
 # CHECK-NEXT:  2      6     0.50    *             U      6     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LDFF1W                     ldff1w	{ z0.s }, p0/z, [x0, x0, lsl #2]
 # CHECK-NEXT:  2      9     0.33    *             U      9     V1UnitL,V1UnitV                            GLDFF1W_SXTW               ldff1w	{ z0.s }, p0/z, [x0, z0.s, sxtw]
 # CHECK-NEXT:  2      9     0.33    *             U      9     V1UnitL,V1UnitV                            GLDFF1W_UXTW               ldff1w	{ z0.s }, p0/z, [x0, z0.s, uxtw]
 # CHECK-NEXT:  2      11    0.33    *             U      11    V1UnitL,V1UnitV                            GLDFF1W_IMM                ldff1w	{ z0.s }, p0/z, [z0.s]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1W_D_SXTW             ldff1w	{ z21.d }, p5/z, [x10, z21.d, sxtw]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1W_D_UXTW             ldff1w	{ z21.d }, p5/z, [x10, z21.d, uxtw]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1W_D_SCALED           ldff1w	{ z23.d }, p3/z, [x13, z8.d, lsl #2]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1W_D                  ldff1w	{ z31.d }, p7/z, [sp, z31.d]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1W_D_SXTW             ldff1w	{ z21.d }, p5/z, [x10, z21.d, sxtw]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1W_D_UXTW             ldff1w	{ z21.d }, p5/z, [x10, z21.d, uxtw]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1W_D_SCALED           ldff1w	{ z23.d }, p3/z, [x13, z8.d, lsl #2]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1W_D                  ldff1w	{ z31.d }, p7/z, [sp, z31.d]
 # CHECK-NEXT:  2      6     0.50    *             U      6     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LDFF1W_D                   ldff1w	{ z31.d }, p7/z, [sp]
-# CHECK-NEXT:  4      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1W_D_IMM              ldff1w	{ z31.d }, p7/z, [z31.d, #124]
-# CHECK-NEXT:  4      11    0.67    *             U      11    V1UnitL[2],V1UnitV[2]                      GLDFF1W_SXTW_SCALED        ldff1w	{ z31.s }, p7/z, [sp, z31.s, sxtw #2]
-# CHECK-NEXT:  4      11    0.67    *             U      11    V1UnitL[2],V1UnitV[2]                      GLDFF1W_UXTW_SCALED        ldff1w	{ z31.s }, p7/z, [sp, z31.s, uxtw #2]
+# CHECK-NEXT:  2      9     0.67    *             U      9     V1UnitL[2],V1UnitV[2]                      GLDFF1W_D_IMM              ldff1w	{ z31.d }, p7/z, [z31.d, #124]
+# CHECK-NEXT:  2      11    0.67    *             U      11    V1UnitL[2],V1UnitV[2]                      GLDFF1W_SXTW_SCALED        ldff1w	{ z31.s }, p7/z, [sp, z31.s, sxtw #2]
+# CHECK-NEXT:  2      11    0.67    *             U      11    V1UnitL[2],V1UnitV[2]                      GLDFF1W_UXTW_SCALED        ldff1w	{ z31.s }, p7/z, [sp, z31.s, uxtw #2]
 # CHECK-NEXT:  2      6     0.50    *             U      6     V1UnitI,V1UnitL,V1UnitL01,V1UnitS          LDFF1W                     ldff1w	{ z31.s }, p7/z, [sp]
 # CHECK-NEXT:  2      11    0.33    *             U      11    V1UnitL,V1UnitV                            GLDFF1W_IMM                ldff1w	{ z31.s }, p7/z, [z31.s, #124]
 # CHECK-NEXT:  1      6     0.50    *             U      6     V1UnitL,V1UnitL01                          LDNF1B_IMM                 ldnf1b	{ z0.b }, p0/z, [x0]
@@ -3987,10 +3987,10 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          DUP_ZI_H                   mov	z5.h, #-6
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          DUP_ZZI_Q                  mov	z5.q, z17.q[3]
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          DUP_ZI_S                   mov	z5.s, #-6
-# CHECK-NEXT:  2      2     2.00                         2     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          ORRS_PPzPP                 movs	p0.b, p0.b
-# CHECK-NEXT:  2      2     2.00                         2     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          ANDS_PPzPP                 movs	p0.b, p0/z, p0.b
-# CHECK-NEXT:  2      2     2.00                         2     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          ORRS_PPzPP                 movs	p15.b, p15.b
-# CHECK-NEXT:  2      2     2.00                         2     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          ANDS_PPzPP                 movs	p15.b, p15/z, p15.b
+# CHECK-NEXT:  1      2     2.00                         2     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          ORRS_PPzPP                 movs	p0.b, p0.b
+# CHECK-NEXT:  1      2     2.00                         2     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          ANDS_PPzPP                 movs	p0.b, p0/z, p0.b
+# CHECK-NEXT:  1      2     2.00                         2     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          ORRS_PPzPP                 movs	p15.b, p15.b
+# CHECK-NEXT:  1      2     2.00                         2     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          ANDS_PPzPP                 movs	p15.b, p15/z, p15.b
 # CHECK-NEXT:  1      1     0.13                  U      1                                                MRS                        mrs	x3, ID_AA64ZFR0_EL1
 # CHECK-NEXT:  1      1     0.13                  U      1                                                MRS                        mrs	x3, ZCR_EL1
 # CHECK-NEXT:  1      1     0.13                  U      1                                                MRS                        mrs	x3, ZCR_EL12
@@ -4005,21 +4005,21 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      1     0.13                  U      1                                                MSR                        msr	ZCR_EL2, x3
 # CHECK-NEXT:  1      1     0.13                  U      1                                                MSR                        msr	ZCR_EL3, x3
 # CHECK-NEXT:  1      4     1.00                         4     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       MUL_ZPmZ_B                 mul	z0.b, p7/m, z0.b, z31.b
-# CHECK-NEXT:  2      5     2.00                         5     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] MUL_ZPmZ_D           mul	z0.d, p7/m, z0.d, z31.d
+# CHECK-NEXT:  1      5     2.00                         5     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] MUL_ZPmZ_D           mul	z0.d, p7/m, z0.d, z31.d
 # CHECK-NEXT:  1      4     1.00                         4     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       MUL_ZPmZ_H                 mul	z0.h, p7/m, z0.h, z31.h
 # CHECK-NEXT:  1      4     1.00                         4     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       MUL_ZPmZ_S                 mul	z0.s, p7/m, z0.s, z31.s
 # CHECK-NEXT:  1      4     1.00                         4     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       MUL_ZI_B                   mul	z31.b, z31.b, #-128
 # CHECK-NEXT:  1      4     1.00                         4     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       MUL_ZI_B                   mul	z31.b, z31.b, #127
-# CHECK-NEXT:  2      5     2.00                         5     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] MUL_ZI_D             mul	z31.d, z31.d, #-128
-# CHECK-NEXT:  2      5     2.00                         5     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] MUL_ZI_D             mul	z31.d, z31.d, #127
+# CHECK-NEXT:  1      5     2.00                         5     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] MUL_ZI_D             mul	z31.d, z31.d, #-128
+# CHECK-NEXT:  1      5     2.00                         5     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] MUL_ZI_D             mul	z31.d, z31.d, #127
 # CHECK-NEXT:  1      4     1.00                         4     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       MUL_ZI_H                   mul	z31.h, z31.h, #-128
 # CHECK-NEXT:  1      4     1.00                         4     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       MUL_ZI_H                   mul	z31.h, z31.h, #127
 # CHECK-NEXT:  1      4     1.00                         4     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       MUL_ZI_S                   mul	z31.s, z31.s, #-128
 # CHECK-NEXT:  1      4     1.00                         4     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       MUL_ZI_S                   mul	z31.s, z31.s, #127
 # CHECK-NEXT:  1      1     1.00                         1     V1UnitI,V1UnitM,V1UnitM0                   NAND_PPzPP                 nand	p0.b, p0/z, p0.b, p0.b
 # CHECK-NEXT:  1      1     1.00                         1     V1UnitI,V1UnitM,V1UnitM0                   NAND_PPzPP                 nand	p15.b, p15/z, p15.b, p15.b
-# CHECK-NEXT:  2      2     2.00                         2     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          NANDS_PPzPP                nands	p0.b, p0/z, p0.b, p0.b
-# CHECK-NEXT:  2      2     2.00                         2     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          NANDS_PPzPP                nands	p15.b, p15/z, p15.b, p15.b
+# CHECK-NEXT:  1      2     2.00                         2     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          NANDS_PPzPP                nands	p0.b, p0/z, p0.b, p0.b
+# CHECK-NEXT:  1      2     2.00                         2     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          NANDS_PPzPP                nands	p15.b, p15/z, p15.b, p15.b
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          NEG_ZPmZ_B                 neg	z0.b, p0/m, z0.b
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          NEG_ZPmZ_D                 neg	z0.d, p0/m, z0.d
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          NEG_ZPmZ_H                 neg	z0.h, p0/m, z0.h
@@ -4030,20 +4030,20 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          NEG_ZPmZ_S                 neg	z31.s, p7/m, z31.s
 # CHECK-NEXT:  1      1     1.00                         1     V1UnitI,V1UnitM,V1UnitM0                   NOR_PPzPP                  nor	p0.b, p0/z, p0.b, p0.b
 # CHECK-NEXT:  1      1     1.00                         1     V1UnitI,V1UnitM,V1UnitM0                   NOR_PPzPP                  nor	p15.b, p15/z, p15.b, p15.b
-# CHECK-NEXT:  2      2     2.00                         2     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          NORS_PPzPP                 nors	p0.b, p0/z, p0.b, p0.b
-# CHECK-NEXT:  2      2     2.00                         2     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          NORS_PPzPP                 nors	p15.b, p15/z, p15.b, p15.b
+# CHECK-NEXT:  1      2     2.00                         2     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          NORS_PPzPP                 nors	p0.b, p0/z, p0.b, p0.b
+# CHECK-NEXT:  1      2     2.00                         2     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          NORS_PPzPP                 nors	p15.b, p15/z, p15.b, p15.b
 # CHECK-NEXT:  1      1     1.00                         1     V1UnitI,V1UnitM,V1UnitM0                   EOR_PPzPP                  not	p0.b, p0/z, p0.b
 # CHECK-NEXT:  1      1     1.00                         1     V1UnitI,V1UnitM,V1UnitM0                   EOR_PPzPP                  not	p15.b, p15/z, p15.b
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          NOT_ZPmZ_B                 not	z31.b, p7/m, z31.b
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          NOT_ZPmZ_D                 not	z31.d, p7/m, z31.d
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          NOT_ZPmZ_H                 not	z31.h, p7/m, z31.h
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          NOT_ZPmZ_S                 not	z31.s, p7/m, z31.s
-# CHECK-NEXT:  2      2     2.00                         2     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          EORS_PPzPP                 nots	p0.b, p0/z, p0.b
-# CHECK-NEXT:  2      2     2.00                         2     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          EORS_PPzPP                 nots	p15.b, p15/z, p15.b
+# CHECK-NEXT:  1      2     2.00                         2     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          EORS_PPzPP                 nots	p0.b, p0/z, p0.b
+# CHECK-NEXT:  1      2     2.00                         2     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          EORS_PPzPP                 nots	p15.b, p15/z, p15.b
 # CHECK-NEXT:  1      1     1.00                         1     V1UnitI,V1UnitM,V1UnitM0                   ORN_PPzPP                  orn	p0.b, p0/z, p0.b, p0.b
 # CHECK-NEXT:  1      1     1.00                         1     V1UnitI,V1UnitM,V1UnitM0                   ORN_PPzPP                  orn	p15.b, p15/z, p15.b, p15.b
-# CHECK-NEXT:  2      2     2.00                         2     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          ORNS_PPzPP                 orns	p0.b, p0/z, p0.b, p0.b
-# CHECK-NEXT:  2      2     2.00                         2     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          ORNS_PPzPP                 orns	p15.b, p15/z, p15.b, p15.b
+# CHECK-NEXT:  1      2     2.00                         2     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          ORNS_PPzPP                 orns	p0.b, p0/z, p0.b, p0.b
+# CHECK-NEXT:  1      2     2.00                         2     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          ORNS_PPzPP                 orns	p15.b, p15/z, p15.b, p15.b
 # CHECK-NEXT:  1      1     1.00                         1     V1UnitI,V1UnitM,V1UnitM0                   ORR_PPzPP                  orr	p0.b, p0/z, p0.b, p1.b
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          ORR_ZI                     orr	z0.d, z0.d, #0x6
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          ORR_ZI                     orr	z0.d, z0.d, #0xfffffffffffffff9
@@ -4058,11 +4058,11 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          ORR_ZPmZ_S                 orr	z31.s, p7/m, z31.s, z31.s
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          ORR_ZI                     orr	z5.b, z5.b, #0x6
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          ORR_ZI                     orr	z5.b, z5.b, #0xf9
-# CHECK-NEXT:  2      2     2.00                         2     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          ORRS_PPzPP                 orrs	p0.b, p0/z, p0.b, p1.b
-# CHECK-NEXT:  4      12    2.00                         12    V1UnitV[4],V1UnitV01[4]                    ORV_VPZ_B                  orv	b0, p7, z31.b
-# CHECK-NEXT:  4      12    2.00                         12    V1UnitV[4],V1UnitV01[4]                    ORV_VPZ_D                  orv	d0, p7, z31.d
-# CHECK-NEXT:  4      12    2.00                         12    V1UnitV[4],V1UnitV01[4]                    ORV_VPZ_H                  orv	h0, p7, z31.h
-# CHECK-NEXT:  4      12    2.00                         12    V1UnitV[4],V1UnitV01[4]                    ORV_VPZ_S                  orv	s0, p7, z31.s
+# CHECK-NEXT:  1      2     2.00                         2     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          ORRS_PPzPP                 orrs	p0.b, p0/z, p0.b, p1.b
+# CHECK-NEXT:  1      12    2.00                         12    V1UnitV[4],V1UnitV01[4]                    ORV_VPZ_B                  orv	b0, p7, z31.b
+# CHECK-NEXT:  1      12    2.00                         12    V1UnitV[4],V1UnitV01[4]                    ORV_VPZ_D                  orv	d0, p7, z31.d
+# CHECK-NEXT:  1      12    2.00                         12    V1UnitV[4],V1UnitV01[4]                    ORV_VPZ_H                  orv	h0, p7, z31.h
+# CHECK-NEXT:  1      12    2.00                         12    V1UnitV[4],V1UnitV01[4]                    ORV_VPZ_S                  orv	s0, p7, z31.s
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   PFALSE                     pfalse	p15.b
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   PFIRST_B                   pfirst	p0.b, p15, p0.b
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   PFIRST_B                   pfirst	p15.b, p15, p15.b
@@ -4142,45 +4142,45 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   PTRUE_S                    ptrue	p7.s, vl64
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   PTRUE_S                    ptrue	p7.s, vl7
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   PTRUE_S                    ptrue	p7.s, vl8
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_B                   ptrues	p0.b, pow2
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_D                   ptrues	p0.d, pow2
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_H                   ptrues	p0.h, pow2
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p0.s, pow2
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_B                   ptrues	p15.b
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_D                   ptrues	p15.d
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_H                   ptrues	p15.h
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p15.s
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, #14
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, #15
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, #16
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, #17
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, #18
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, #19
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, #20
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, #21
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, #22
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, #23
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, #24
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, #25
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, #26
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, #27
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, #28
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, mul3
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, mul4
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, vl1
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, vl128
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, vl16
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, vl2
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, vl256
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, vl3
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, vl32
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, vl4
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, vl5
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, vl6
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, vl64
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, vl7
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, vl8
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_B                   ptrues	p0.b, pow2
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_D                   ptrues	p0.d, pow2
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_H                   ptrues	p0.h, pow2
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p0.s, pow2
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_B                   ptrues	p15.b
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_D                   ptrues	p15.d
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_H                   ptrues	p15.h
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p15.s
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, #14
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, #15
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, #16
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, #17
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, #18
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, #19
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, #20
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, #21
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, #22
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, #23
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, #24
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, #25
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, #26
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, #27
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, #28
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, mul3
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, mul4
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, vl1
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, vl128
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, vl16
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, vl2
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, vl256
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, vl3
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, vl32
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, vl4
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, vl5
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, vl6
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, vl64
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, vl7
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          PTRUES_S                   ptrues	p7.s, vl8
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   PUNPKHI_PP                 punpkhi	p0.h, p0.b
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   PUNPKHI_PP                 punpkhi	p15.h, p15.b
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   PUNPKLO_PP                 punpklo	p0.h, p0.b
@@ -4190,9 +4190,9 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          RBIT_ZPmZ_H                rbit	z0.h, p7/m, z31.h
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          RBIT_ZPmZ_S                rbit	z0.s, p7/m, z31.s
 # CHECK-NEXT:  1      2     1.00    *             U      2     V1UnitI,V1UnitM,V1UnitM0                   RDFFR_P                    rdffr	p0.b
-# CHECK-NEXT:  2      3     2.00    *             U      3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          RDFFR_PPz                  rdffr	p0.b, p0/z
+# CHECK-NEXT:  1      3     2.00    *             U      3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          RDFFR_PPz                  rdffr	p0.b, p0/z
 # CHECK-NEXT:  1      2     1.00    *             U      2     V1UnitI,V1UnitM,V1UnitM0                   RDFFR_P                    rdffr	p15.b
-# CHECK-NEXT:  2      3     2.00    *             U      3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          RDFFR_PPz                  rdffr	p15.b, p15/z
+# CHECK-NEXT:  1      3     2.00    *             U      3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          RDFFR_PPz                  rdffr	p15.b, p15/z
 # CHECK-NEXT:  1      4     0.50                  U      4     V1UnitI,V1UnitM                            RDFFRS_PPz                 rdffrs	p0.b, p0/z
 # CHECK-NEXT:  1      4     0.50                  U      4     V1UnitI,V1UnitM                            RDFFRS_PPz                 rdffrs	p15.b, p15/z
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   RDVLI_XI                   rdvl	x0, #0
@@ -4214,16 +4214,16 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          SABD_ZPmZ_D                sabd	z31.d, p7/m, z31.d, z31.d
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          SABD_ZPmZ_H                sabd	z31.h, p7/m, z31.h, z31.h
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          SABD_ZPmZ_S                sabd	z31.s, p7/m, z31.s, z31.s
-# CHECK-NEXT:  5      14    2.00                         14    V1UnitV[5],V1UnitV0,V1UnitV1[2],V1UnitV01[3],V1UnitV02,V1UnitV13[3] SADDV_VPZ_B saddv	d0, p7, z31.b
-# CHECK-NEXT:  4      12    2.00                         12    V1UnitV[4],V1UnitV1[2],V1UnitV01[3],V1UnitV13[2] SADDV_VPZ_H          saddv	d0, p7, z31.h
-# CHECK-NEXT:  4      10    2.00                         10    V1UnitV[4],V1UnitV1[2],V1UnitV01[3],V1UnitV13[2] SADDV_VPZ_S          saddv	d0, p7, z31.s
+# CHECK-NEXT:  4      14    2.00                         14    V1UnitV[5],V1UnitV0,V1UnitV1[2],V1UnitV01[3],V1UnitV02,V1UnitV13[3] SADDV_VPZ_B saddv	d0, p7, z31.b
+# CHECK-NEXT:  3      12    2.00                         12    V1UnitV[4],V1UnitV1[2],V1UnitV01[3],V1UnitV13[2] SADDV_VPZ_H          saddv	d0, p7, z31.h
+# CHECK-NEXT:  3      10    2.00                         10    V1UnitV[4],V1UnitV1[2],V1UnitV01[3],V1UnitV13[2] SADDV_VPZ_S          saddv	d0, p7, z31.s
 # CHECK-NEXT:  1      3     1.00                         3     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       SCVTF_ZPmZ_DtoD            scvtf	z0.d, p0/m, z0.d
 # CHECK-NEXT:  1      3     1.00                         3     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       SCVTF_ZPmZ_StoD            scvtf	z18.d, p3/m, z16.s
-# CHECK-NEXT:  4      6     4.00                         6     V1UnitV[4],V1UnitV0[4],V1UnitV01[4],V1UnitV02[4] SCVTF_ZPmZ_HtoH      scvtf	z0.h, p0/m, z0.h
-# CHECK-NEXT:  2      4     2.00                         4     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] SCVTF_ZPmZ_StoH      scvtf	z0.h, p0/m, z0.s
+# CHECK-NEXT:  1      6     4.00                         6     V1UnitV[4],V1UnitV0[4],V1UnitV01[4],V1UnitV02[4] SCVTF_ZPmZ_HtoH      scvtf	z0.h, p0/m, z0.h
+# CHECK-NEXT:  1      4     2.00                         4     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] SCVTF_ZPmZ_StoH      scvtf	z0.h, p0/m, z0.s
 # CHECK-NEXT:  1      3     1.00                         3     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       SCVTF_ZPmZ_DtoH            scvtf	z18.h, p1/m, z14.d
 # CHECK-NEXT:  1      3     1.00                         3     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       SCVTF_ZPmZ_DtoS            scvtf	z0.s, p0/m, z0.d
-# CHECK-NEXT:  2      4     2.00                         4     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] SCVTF_ZPmZ_StoS      scvtf	z0.s, p0/m, z0.s
+# CHECK-NEXT:  1      4     2.00                         4     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] SCVTF_ZPmZ_StoS      scvtf	z0.s, p0/m, z0.s
 # CHECK-NEXT:  1      20    7.00                         20    V1UnitV[7],V1UnitV0[7],V1UnitV01[7],V1UnitV02[7] SDIV_ZPmZ_D          sdiv	z0.d, p7/m, z0.d, z31.d
 # CHECK-NEXT:  1      12    7.00                         12    V1UnitV[7],V1UnitV0[7],V1UnitV01[7],V1UnitV02[7] SDIV_ZPmZ_S          sdiv	z0.s, p7/m, z0.s, z31.s
 # CHECK-NEXT:  1      20    7.00                         20    V1UnitV[7],V1UnitV0[7],V1UnitV01[7],V1UnitV02[7] SDIVR_ZPmZ_D         sdivr	z0.d, p7/m, z0.d, z31.d
@@ -4249,9 +4249,9 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          SMAX_ZI_H                  smax	z31.h, z31.h, #127
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          SMAX_ZPmZ_S                smax	z31.s, p7/m, z31.s, z31.s
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          SMAX_ZI_S                  smax	z31.s, z31.s, #127
-# CHECK-NEXT:  5      14    2.00                         14    V1UnitV[5],V1UnitV0,V1UnitV1[2],V1UnitV01[3],V1UnitV02,V1UnitV13[3] SMAXV_VPZ_B smaxv	b0, p7, z31.b
-# CHECK-NEXT:  4      12    2.00                         12    V1UnitV[4],V1UnitV1[2],V1UnitV01[3],V1UnitV13[2] SMAXV_VPZ_H          smaxv	h0, p7, z31.h
-# CHECK-NEXT:  4      10    2.00                         10    V1UnitV[4],V1UnitV1[2],V1UnitV01[3],V1UnitV13[2] SMAXV_VPZ_S          smaxv	s0, p7, z31.s
+# CHECK-NEXT:  4      14    2.00                         14    V1UnitV[5],V1UnitV0,V1UnitV1[2],V1UnitV01[3],V1UnitV02,V1UnitV13[3] SMAXV_VPZ_B smaxv	b0, p7, z31.b
+# CHECK-NEXT:  3      12    2.00                         12    V1UnitV[4],V1UnitV1[2],V1UnitV01[3],V1UnitV13[2] SMAXV_VPZ_H          smaxv	h0, p7, z31.h
+# CHECK-NEXT:  3      10    2.00                         10    V1UnitV[4],V1UnitV1[2],V1UnitV01[3],V1UnitV13[2] SMAXV_VPZ_S          smaxv	s0, p7, z31.s
 # CHECK-NEXT:  2      8     0.50                         8     V1UnitV[2],V1UnitV01                       SMAXV_VPZ_D                smaxv	d24, p5, z24.d
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          SMIN_ZI_B                  smin	z0.b, z0.b, #-128
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          SMIN_ZI_D                  smin	z0.d, z0.d, #-128
@@ -4265,13 +4265,13 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          SMIN_ZI_H                  smin	z31.h, z31.h, #127
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          SMIN_ZPmZ_S                smin	z31.s, p7/m, z31.s, z31.s
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          SMIN_ZI_S                  smin	z31.s, z31.s, #127
-# CHECK-NEXT:  5      14    2.00                         14    V1UnitV[5],V1UnitV0,V1UnitV1[2],V1UnitV01[3],V1UnitV02,V1UnitV13[3] SMINV_VPZ_B sminv	b0, p7, z31.b
-# CHECK-NEXT:  4      12    2.00                         12    V1UnitV[4],V1UnitV1[2],V1UnitV01[3],V1UnitV13[2] SMINV_VPZ_H          sminv	h0, p7, z31.h
-# CHECK-NEXT:  4      10    2.00                         10    V1UnitV[4],V1UnitV1[2],V1UnitV01[3],V1UnitV13[2] SMINV_VPZ_S          sminv	s0, p7, z31.s
+# CHECK-NEXT:  4      14    2.00                         14    V1UnitV[5],V1UnitV0,V1UnitV1[2],V1UnitV01[3],V1UnitV02,V1UnitV13[3] SMINV_VPZ_B sminv	b0, p7, z31.b
+# CHECK-NEXT:  3      12    2.00                         12    V1UnitV[4],V1UnitV1[2],V1UnitV01[3],V1UnitV13[2] SMINV_VPZ_H          sminv	h0, p7, z31.h
+# CHECK-NEXT:  3      10    2.00                         10    V1UnitV[4],V1UnitV1[2],V1UnitV01[3],V1UnitV13[2] SMINV_VPZ_S          sminv	s0, p7, z31.s
 # CHECK-NEXT:  2      8     0.50                         8     V1UnitV[2],V1UnitV01                       SMINV_VPZ_D                sminv	d17, p2, z18.d
 # CHECK-NEXT:  1      3     0.50                         1     V1UnitV,V1UnitV01                          SMMLA_ZZZ                  smmla	z0.s, z1.b, z2.b
 # CHECK-NEXT:  1      4     1.00                         4     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       SMULH_ZPmZ_B               smulh	z0.b, p7/m, z0.b, z31.b
-# CHECK-NEXT:  2      5     2.00                         5     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] SMULH_ZPmZ_D         smulh	z0.d, p7/m, z0.d, z31.d
+# CHECK-NEXT:  1      5     2.00                         5     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] SMULH_ZPmZ_D         smulh	z0.d, p7/m, z0.d, z31.d
 # CHECK-NEXT:  1      4     1.00                         4     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       SMULH_ZPmZ_H               smulh	z0.h, p7/m, z0.h, z31.h
 # CHECK-NEXT:  1      4     1.00                         4     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       SMULH_ZPmZ_S               smulh	z0.s, p7/m, z0.s, z31.s
 # CHECK-NEXT:  1      3     1.00                         3     V1UnitV,V1UnitV1,V1UnitV01,V1UnitV13       SPLICE_ZPZ_B               splice	z31.b, p7, z31.b, z31.b
@@ -4336,9 +4336,9 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   SQDECP_XPWd_D              sqdecp	xzr, p15.d, wzr
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   SQDECP_XPWd_H              sqdecp	xzr, p15.h, wzr
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   SQDECP_XPWd_S              sqdecp	xzr, p15.s, wzr
-# CHECK-NEXT:  3      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 SQDECP_ZP_D       sqdecp	z0.d, p0.d
-# CHECK-NEXT:  3      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 SQDECP_ZP_H       sqdecp	z0.h, p0.h
-# CHECK-NEXT:  3      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 SQDECP_ZP_S       sqdecp	z0.s, p0.s
+# CHECK-NEXT:  2      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 SQDECP_ZP_D       sqdecp	z0.d, p0.d
+# CHECK-NEXT:  2      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 SQDECP_ZP_H       sqdecp	z0.h, p0.h
+# CHECK-NEXT:  2      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 SQDECP_ZP_S       sqdecp	z0.s, p0.s
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   SQDECW_XPiI                sqdecw	x0
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   SQDECW_XPiI                sqdecw	x0, #14
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   SQDECW_XPiI                sqdecw	x0, all, mul #16
@@ -4395,9 +4395,9 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   SQINCP_XPWd_D              sqincp	xzr, p15.d, wzr
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   SQINCP_XPWd_H              sqincp	xzr, p15.h, wzr
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   SQINCP_XPWd_S              sqincp	xzr, p15.s, wzr
-# CHECK-NEXT:  3      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 SQINCP_ZP_D       sqincp	z0.d, p0.d
-# CHECK-NEXT:  3      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 SQINCP_ZP_H       sqincp	z0.h, p0.h
-# CHECK-NEXT:  3      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 SQINCP_ZP_S       sqincp	z0.s, p0.s
+# CHECK-NEXT:  2      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 SQINCP_ZP_D       sqincp	z0.d, p0.d
+# CHECK-NEXT:  2      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 SQINCP_ZP_H       sqincp	z0.h, p0.h
+# CHECK-NEXT:  2      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 SQINCP_ZP_S       sqincp	z0.s, p0.s
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   SQINCW_XPiI                sqincw	x0
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   SQINCW_XPiI                sqincw	x0, #14
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   SQINCW_XPiI                sqincw	x0, all, mul #16
@@ -4437,10 +4437,10 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  2      2     0.50           *             2     V1UnitL,V1UnitL01,V1UnitV                  ST1B_H                     st1b	{ z0.h }, p0, [x0, x0]
 # CHECK-NEXT:  2      2     0.50           *             2     V1UnitL,V1UnitL01,V1UnitV                  ST1B_H_IMM                 st1b	{ z0.h }, p0, [x0]
 # CHECK-NEXT:  2      2     0.50           *             2     V1UnitL,V1UnitL01,V1UnitV                  ST1B_S                     st1b	{ z0.s }, p0, [x0, x0]
-# CHECK-NEXT:  4      10    1.00           *             10    V1UnitL[2],V1UnitL01[2],V1UnitV[2]         SST1B_S_SXTW               st1b	{ z0.s }, p0, [x0, z0.s, sxtw]
-# CHECK-NEXT:  4      10    1.00           *             10    V1UnitL[2],V1UnitL01[2],V1UnitV[2]         SST1B_S_UXTW               st1b	{ z0.s }, p0, [x0, z0.s, uxtw]
+# CHECK-NEXT:  2      10    1.00           *             10    V1UnitL[2],V1UnitL01[2],V1UnitV[2]         SST1B_S_SXTW               st1b	{ z0.s }, p0, [x0, z0.s, sxtw]
+# CHECK-NEXT:  2      10    1.00           *             10    V1UnitL[2],V1UnitL01[2],V1UnitV[2]         SST1B_S_UXTW               st1b	{ z0.s }, p0, [x0, z0.s, uxtw]
 # CHECK-NEXT:  2      2     0.50           *             2     V1UnitL,V1UnitL01,V1UnitV                  ST1B_S_IMM                 st1b	{ z0.s }, p0, [x0]
-# CHECK-NEXT:  4      10    1.00           *             10    V1UnitL[2],V1UnitL01[2],V1UnitV[2]         SST1B_S_IMM                st1b	{ z0.s }, p7, [z0.s]
+# CHECK-NEXT:  2      10    1.00           *             10    V1UnitL[2],V1UnitL01[2],V1UnitV[2]         SST1B_S_IMM                st1b	{ z0.s }, p7, [z0.s]
 # CHECK-NEXT:  2      2     0.50           *             2     V1UnitL,V1UnitL01,V1UnitV                  ST1B_IMM                   st1b	{ z21.b }, p5, [x10, #5, mul vl]
 # CHECK-NEXT:  2      2     0.50           *             2     V1UnitL,V1UnitL01,V1UnitV                  ST1B_D_IMM                 st1b	{ z21.d }, p5, [x10, #5, mul vl]
 # CHECK-NEXT:  2      2     0.50           *             2     V1UnitL,V1UnitL01,V1UnitV                  ST1B_H_IMM                 st1b	{ z21.h }, p5, [x10, #5, mul vl]
@@ -4450,7 +4450,7 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  2      6     0.50           *             6     V1UnitL,V1UnitL01,V1UnitV                  SST1B_D_IMM                st1b	{ z31.d }, p7, [z31.d, #31]
 # CHECK-NEXT:  2      2     0.50           *             2     V1UnitL,V1UnitL01,V1UnitV                  ST1B_H_IMM                 st1b	{ z31.h }, p7, [sp, #-1, mul vl]
 # CHECK-NEXT:  2      2     0.50           *             2     V1UnitL,V1UnitL01,V1UnitV                  ST1B_S_IMM                 st1b	{ z31.s }, p7, [sp, #-1, mul vl]
-# CHECK-NEXT:  4      10    1.00           *             10    V1UnitL[2],V1UnitL01[2],V1UnitV[2]         SST1B_S_IMM                st1b	{ z31.s }, p7, [z31.s, #31]
+# CHECK-NEXT:  2      10    1.00           *             10    V1UnitL[2],V1UnitL01[2],V1UnitV[2]         SST1B_S_IMM                st1b	{ z31.s }, p7, [z31.s, #31]
 # CHECK-NEXT:  2      2     0.50           *             2     V1UnitL,V1UnitL01,V1UnitV                  ST1D                       st1d	{ z0.d }, p0, [x0, x0, lsl #3]
 # CHECK-NEXT:  2      6     0.50           *             6     V1UnitL,V1UnitL01,V1UnitV                  SST1D_SCALED               st1d	{ z0.d }, p0, [x0, z0.d, lsl #3]
 # CHECK-NEXT:  2      6     0.50           *             6     V1UnitL,V1UnitL01,V1UnitV                  SST1D_SXTW_SCALED          st1d	{ z0.d }, p0, [x0, z0.d, sxtw #3]
@@ -4475,12 +4475,12 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  3      2     0.50           *             2     V1UnitI,V1UnitL,V1UnitL01,V1UnitS,V1UnitV  ST1H                       st1h	{ z0.h }, p0, [x0, x0, lsl #1]
 # CHECK-NEXT:  2      2     0.50           *             2     V1UnitL,V1UnitL01,V1UnitV                  ST1H_IMM                   st1h	{ z0.h }, p0, [x0]
 # CHECK-NEXT:  3      2     0.50           *             2     V1UnitI,V1UnitL,V1UnitL01,V1UnitS,V1UnitV  ST1H_S                     st1h	{ z0.s }, p0, [x0, x0, lsl #1]
-# CHECK-NEXT:  4      10    1.00           *             10    V1UnitL[2],V1UnitL01[2],V1UnitV[2]         SST1H_S_SXTW_SCALED        st1h	{ z0.s }, p0, [x0, z0.s, sxtw #1]
-# CHECK-NEXT:  4      10    1.00           *             10    V1UnitL[2],V1UnitL01[2],V1UnitV[2]         SST1H_S_SXTW               st1h	{ z0.s }, p0, [x0, z0.s, sxtw]
-# CHECK-NEXT:  4      10    1.00           *             10    V1UnitL[2],V1UnitL01[2],V1UnitV[2]         SST1H_S_UXTW_SCALED        st1h	{ z0.s }, p0, [x0, z0.s, uxtw #1]
-# CHECK-NEXT:  4      10    1.00           *             10    V1UnitL[2],V1UnitL01[2],V1UnitV[2]         SST1H_S_UXTW               st1h	{ z0.s }, p0, [x0, z0.s, uxtw]
+# CHECK-NEXT:  2      10    1.00           *             10    V1UnitL[2],V1UnitL01[2],V1UnitV[2]         SST1H_S_SXTW_SCALED        st1h	{ z0.s }, p0, [x0, z0.s, sxtw #1]
+# CHECK-NEXT:  2      10    1.00           *             10    V1UnitL[2],V1UnitL01[2],V1UnitV[2]         SST1H_S_SXTW               st1h	{ z0.s }, p0, [x0, z0.s, sxtw]
+# CHECK-NEXT:  2      10    1.00           *             10    V1UnitL[2],V1UnitL01[2],V1UnitV[2]         SST1H_S_UXTW_SCALED        st1h	{ z0.s }, p0, [x0, z0.s, uxtw #1]
+# CHECK-NEXT:  2      10    1.00           *             10    V1UnitL[2],V1UnitL01[2],V1UnitV[2]         SST1H_S_UXTW               st1h	{ z0.s }, p0, [x0, z0.s, uxtw]
 # CHECK-NEXT:  2      2     0.50           *             2     V1UnitL,V1UnitL01,V1UnitV                  ST1H_S_IMM                 st1h	{ z0.s }, p0, [x0]
-# CHECK-NEXT:  4      10    1.00           *             10    V1UnitL[2],V1UnitL01[2],V1UnitV[2]         SST1H_S_IMM                st1h	{ z0.s }, p7, [z0.s]
+# CHECK-NEXT:  2      10    1.00           *             10    V1UnitL[2],V1UnitL01[2],V1UnitV[2]         SST1H_S_IMM                st1h	{ z0.s }, p7, [z0.s]
 # CHECK-NEXT:  2      2     0.50           *             2     V1UnitL,V1UnitL01,V1UnitV                  ST1H_D_IMM                 st1h	{ z21.d }, p5, [x10, #5, mul vl]
 # CHECK-NEXT:  2      2     0.50           *             2     V1UnitL,V1UnitL01,V1UnitV                  ST1H_IMM                   st1h	{ z21.h }, p5, [x10, #5, mul vl]
 # CHECK-NEXT:  2      2     0.50           *             2     V1UnitL,V1UnitL01,V1UnitV                  ST1H_S_IMM                 st1h	{ z21.s }, p5, [x10, #5, mul vl]
@@ -4488,7 +4488,7 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  2      6     0.50           *             6     V1UnitL,V1UnitL01,V1UnitV                  SST1H_D_IMM                st1h	{ z31.d }, p7, [z31.d, #62]
 # CHECK-NEXT:  2      2     0.50           *             2     V1UnitL,V1UnitL01,V1UnitV                  ST1H_IMM                   st1h	{ z31.h }, p7, [sp, #-1, mul vl]
 # CHECK-NEXT:  2      2     0.50           *             2     V1UnitL,V1UnitL01,V1UnitV                  ST1H_S_IMM                 st1h	{ z31.s }, p7, [sp, #-1, mul vl]
-# CHECK-NEXT:  4      10    1.00           *             10    V1UnitL[2],V1UnitL01[2],V1UnitV[2]         SST1H_S_IMM                st1h	{ z31.s }, p7, [z31.s, #62]
+# CHECK-NEXT:  2      10    1.00           *             10    V1UnitL[2],V1UnitL01[2],V1UnitV[2]         SST1H_S_IMM                st1h	{ z31.s }, p7, [z31.s, #62]
 # CHECK-NEXT:  2      2     0.50           *             2     V1UnitL,V1UnitL01,V1UnitV                  ST1W_D                     st1w	{ z0.d }, p0, [x0, x0, lsl #2]
 # CHECK-NEXT:  2      6     0.50           *             6     V1UnitL,V1UnitL01,V1UnitV                  SST1W_D_SCALED             st1w	{ z0.d }, p0, [x0, z0.d, lsl #2]
 # CHECK-NEXT:  2      6     0.50           *             6     V1UnitL,V1UnitL01,V1UnitV                  SST1W_D_SXTW_SCALED        st1w	{ z0.d }, p0, [x0, z0.d, sxtw #2]
@@ -4499,18 +4499,18 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  2      2     0.50           *             2     V1UnitL,V1UnitL01,V1UnitV                  ST1W_D_IMM                 st1w	{ z0.d }, p0, [x0]
 # CHECK-NEXT:  2      6     0.50           *             6     V1UnitL,V1UnitL01,V1UnitV                  SST1W_D_IMM                st1w	{ z0.d }, p7, [z0.d]
 # CHECK-NEXT:  2      2     0.50           *             2     V1UnitL,V1UnitL01,V1UnitV                  ST1W                       st1w	{ z0.s }, p0, [x0, x0, lsl #2]
-# CHECK-NEXT:  4      10    1.00           *             10    V1UnitL[2],V1UnitL01[2],V1UnitV[2]         SST1W_SXTW_SCALED          st1w	{ z0.s }, p0, [x0, z0.s, sxtw #2]
-# CHECK-NEXT:  4      10    1.00           *             10    V1UnitL[2],V1UnitL01[2],V1UnitV[2]         SST1W_SXTW                 st1w	{ z0.s }, p0, [x0, z0.s, sxtw]
-# CHECK-NEXT:  4      10    1.00           *             10    V1UnitL[2],V1UnitL01[2],V1UnitV[2]         SST1W_UXTW_SCALED          st1w	{ z0.s }, p0, [x0, z0.s, uxtw #2]
-# CHECK-NEXT:  4      10    1.00           *             10    V1UnitL[2],V1UnitL01[2],V1UnitV[2]         SST1W_UXTW                 st1w	{ z0.s }, p0, [x0, z0.s, uxtw]
+# CHECK-NEXT:  2      10    1.00           *             10    V1UnitL[2],V1UnitL01[2],V1UnitV[2]         SST1W_SXTW_SCALED          st1w	{ z0.s }, p0, [x0, z0.s, sxtw #2]
+# CHECK-NEXT:  2      10    1.00           *             10    V1UnitL[2],V1UnitL01[2],V1UnitV[2]         SST1W_SXTW                 st1w	{ z0.s }, p0, [x0, z0.s, sxtw]
+# CHECK-NEXT:  2      10    1.00           *             10    V1UnitL[2],V1UnitL01[2],V1UnitV[2]         SST1W_UXTW_SCALED          st1w	{ z0.s }, p0, [x0, z0.s, uxtw #2]
+# CHECK-NEXT:  2      10    1.00           *             10    V1UnitL[2],V1UnitL01[2],V1UnitV[2]         SST1W_UXTW                 st1w	{ z0.s }, p0, [x0, z0.s, uxtw]
 # CHECK-NEXT:  2      2     0.50           *             2     V1UnitL,V1UnitL01,V1UnitV                  ST1W_IMM                   st1w	{ z0.s }, p0, [x0]
-# CHECK-NEXT:  4      10    1.00           *             10    V1UnitL[2],V1UnitL01[2],V1UnitV[2]         SST1W_IMM                  st1w	{ z0.s }, p7, [z0.s]
+# CHECK-NEXT:  2      10    1.00           *             10    V1UnitL[2],V1UnitL01[2],V1UnitV[2]         SST1W_IMM                  st1w	{ z0.s }, p7, [z0.s]
 # CHECK-NEXT:  2      2     0.50           *             2     V1UnitL,V1UnitL01,V1UnitV                  ST1W_D_IMM                 st1w	{ z21.d }, p5, [x10, #5, mul vl]
 # CHECK-NEXT:  2      2     0.50           *             2     V1UnitL,V1UnitL01,V1UnitV                  ST1W_IMM                   st1w	{ z21.s }, p5, [x10, #5, mul vl]
 # CHECK-NEXT:  2      2     0.50           *             2     V1UnitL,V1UnitL01,V1UnitV                  ST1W_D_IMM                 st1w	{ z31.d }, p7, [sp, #-1, mul vl]
 # CHECK-NEXT:  2      6     0.50           *             6     V1UnitL,V1UnitL01,V1UnitV                  SST1W_D_IMM                st1w	{ z31.d }, p7, [z31.d, #124]
 # CHECK-NEXT:  2      2     0.50           *             2     V1UnitL,V1UnitL01,V1UnitV                  ST1W_IMM                   st1w	{ z31.s }, p7, [sp, #-1, mul vl]
-# CHECK-NEXT:  4      10    1.00           *             10    V1UnitL[2],V1UnitL01[2],V1UnitV[2]         SST1W_IMM                  st1w	{ z31.s }, p7, [z31.s, #124]
+# CHECK-NEXT:  2      10    1.00           *             10    V1UnitL[2],V1UnitL01[2],V1UnitV[2]         SST1W_IMM                  st1w	{ z31.s }, p7, [z31.s, #124]
 # CHECK-NEXT:  2      4     0.50           *             4     V1UnitL,V1UnitL01,V1UnitV                  ST2B                       st2b	{ z0.b, z1.b }, p0, [x0, x0]
 # CHECK-NEXT:  2      4     0.50           *             4     V1UnitL,V1UnitL01,V1UnitV                  ST2B_IMM                   st2b	{ z0.b, z1.b }, p0, [x0]
 # CHECK-NEXT:  2      4     0.50           *             4     V1UnitL,V1UnitL01,V1UnitV                  ST2B_IMM                   st2b	{ z21.b, z22.b }, p5, [x10, #10, mul vl]
@@ -4531,46 +4531,46 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  2      4     0.50           *             4     V1UnitL,V1UnitL01,V1UnitV                  ST2W_IMM                   st2w	{ z21.s, z22.s }, p5, [x10, #10, mul vl]
 # CHECK-NEXT:  2      4     0.50           *             4     V1UnitL,V1UnitL01,V1UnitV                  ST2W_IMM                   st2w	{ z23.s, z24.s }, p3, [x13, #-16, mul vl]
 # CHECK-NEXT:  2      4     0.50           *             4     V1UnitL,V1UnitL01,V1UnitV                  ST2W                       st2w	{ z5.s, z6.s }, p3, [x17, x16, lsl #2]
-# CHECK-NEXT:  15     7     2.50           *             7     V1UnitI[5],V1UnitL[5],V1UnitL01[5],V1UnitS[5],V1UnitV[5] ST3B         st3b	{ z0.b - z2.b }, p0, [x0, x0]
-# CHECK-NEXT:  10     7     2.50           *             7     V1UnitL[5],V1UnitL01[5],V1UnitV[5]         ST3B_IMM                   st3b	{ z0.b - z2.b }, p0, [x0]
-# CHECK-NEXT:  10     7     2.50           *             7     V1UnitL[5],V1UnitL01[5],V1UnitV[5]         ST3B_IMM                   st3b	{ z21.b - z23.b }, p5, [x10, #15, mul vl]
-# CHECK-NEXT:  10     7     2.50           *             7     V1UnitL[5],V1UnitL01[5],V1UnitV[5]         ST3B_IMM                   st3b	{ z23.b - z25.b }, p3, [x13, #-24, mul vl]
-# CHECK-NEXT:  15     7     2.50           *             7     V1UnitI[5],V1UnitL[5],V1UnitL01[5],V1UnitS[5],V1UnitV[5] ST3B         st3b	{ z5.b - z7.b }, p3, [x17, x16]
-# CHECK-NEXT:  15     7     2.50           *             7     V1UnitI[5],V1UnitL[5],V1UnitL01[5],V1UnitS[5],V1UnitV[5] ST3D         st3d	{ z0.d - z2.d }, p0, [x0, x0, lsl #3]
-# CHECK-NEXT:  10     7     2.50           *             7     V1UnitL[5],V1UnitL01[5],V1UnitV[5]         ST3D_IMM                   st3d	{ z0.d - z2.d }, p0, [x0]
-# CHECK-NEXT:  10     7     2.50           *             7     V1UnitL[5],V1UnitL01[5],V1UnitV[5]         ST3D_IMM                   st3d	{ z21.d - z23.d }, p5, [x10, #15, mul vl]
-# CHECK-NEXT:  10     7     2.50           *             7     V1UnitL[5],V1UnitL01[5],V1UnitV[5]         ST3D_IMM                   st3d	{ z23.d - z25.d }, p3, [x13, #-24, mul vl]
-# CHECK-NEXT:  15     7     2.50           *             7     V1UnitI[5],V1UnitL[5],V1UnitL01[5],V1UnitS[5],V1UnitV[5] ST3D         st3d	{ z5.d - z7.d }, p3, [x17, x16, lsl #3]
-# CHECK-NEXT:  15     7     2.50           *             7     V1UnitI[5],V1UnitL[5],V1UnitL01[5],V1UnitS[5],V1UnitV[5] ST3H         st3h	{ z0.h - z2.h }, p0, [x0, x0, lsl #1]
-# CHECK-NEXT:  10     7     2.50           *             7     V1UnitL[5],V1UnitL01[5],V1UnitV[5]         ST3H_IMM                   st3h	{ z0.h - z2.h }, p0, [x0]
-# CHECK-NEXT:  10     7     2.50           *             7     V1UnitL[5],V1UnitL01[5],V1UnitV[5]         ST3H_IMM                   st3h	{ z21.h - z23.h }, p5, [x10, #15, mul vl]
-# CHECK-NEXT:  10     7     2.50           *             7     V1UnitL[5],V1UnitL01[5],V1UnitV[5]         ST3H_IMM                   st3h	{ z23.h - z25.h }, p3, [x13, #-24, mul vl]
-# CHECK-NEXT:  15     7     2.50           *             7     V1UnitI[5],V1UnitL[5],V1UnitL01[5],V1UnitS[5],V1UnitV[5] ST3H         st3h	{ z5.h - z7.h }, p3, [x17, x16, lsl #1]
-# CHECK-NEXT:  15     7     2.50           *             7     V1UnitI[5],V1UnitL[5],V1UnitL01[5],V1UnitS[5],V1UnitV[5] ST3W         st3w	{ z0.s - z2.s }, p0, [x0, x0, lsl #2]
-# CHECK-NEXT:  10     7     2.50           *             7     V1UnitL[5],V1UnitL01[5],V1UnitV[5]         ST3W_IMM                   st3w	{ z0.s - z2.s }, p0, [x0]
-# CHECK-NEXT:  10     7     2.50           *             7     V1UnitL[5],V1UnitL01[5],V1UnitV[5]         ST3W_IMM                   st3w	{ z21.s - z23.s }, p5, [x10, #15, mul vl]
-# CHECK-NEXT:  10     7     2.50           *             7     V1UnitL[5],V1UnitL01[5],V1UnitV[5]         ST3W_IMM                   st3w	{ z23.s - z25.s }, p3, [x13, #-24, mul vl]
-# CHECK-NEXT:  15     7     2.50           *             7     V1UnitI[5],V1UnitL[5],V1UnitL01[5],V1UnitS[5],V1UnitV[5] ST3W         st3w	{ z5.s - z7.s }, p3, [x17, x16, lsl #2]
-# CHECK-NEXT:  27     11    4.50           *             11    V1UnitI[9],V1UnitL[9],V1UnitL01[9],V1UnitS[9],V1UnitV[9] ST4B         st4b	{ z0.b - z3.b }, p0, [x0, x0]
-# CHECK-NEXT:  18     19    4.50           *             19    V1UnitL[9],V1UnitL01[9],V1UnitV[9]         ST4B_IMM                   st4b	{ z0.b - z3.b }, p0, [x0]
-# CHECK-NEXT:  18     19    4.50           *             19    V1UnitL[9],V1UnitL01[9],V1UnitV[9]         ST4B_IMM                   st4b	{ z21.b - z24.b }, p5, [x10, #20, mul vl]
-# CHECK-NEXT:  18     19    4.50           *             19    V1UnitL[9],V1UnitL01[9],V1UnitV[9]         ST4B_IMM                   st4b	{ z23.b - z26.b }, p3, [x13, #-32, mul vl]
-# CHECK-NEXT:  27     11    4.50           *             11    V1UnitI[9],V1UnitL[9],V1UnitL01[9],V1UnitS[9],V1UnitV[9] ST4B         st4b	{ z5.b - z8.b }, p3, [x17, x16]
-# CHECK-NEXT:  27     11    4.50           *             11    V1UnitI[9],V1UnitL[9],V1UnitL01[9],V1UnitS[9],V1UnitV[9] ST4D         st4d	{ z0.d - z3.d }, p0, [x0, x0, lsl #3]
-# CHECK-NEXT:  18     19    4.50           *             19    V1UnitL[9],V1UnitL01[9],V1UnitV[9]         ST4D_IMM                   st4d	{ z0.d - z3.d }, p0, [x0]
-# CHECK-NEXT:  18     19    4.50           *             19    V1UnitL[9],V1UnitL01[9],V1UnitV[9]         ST4D_IMM                   st4d	{ z21.d - z24.d }, p5, [x10, #20, mul vl]
-# CHECK-NEXT:  18     19    4.50           *             19    V1UnitL[9],V1UnitL01[9],V1UnitV[9]         ST4D_IMM                   st4d	{ z23.d - z26.d }, p3, [x13, #-32, mul vl]
-# CHECK-NEXT:  27     11    4.50           *             11    V1UnitI[9],V1UnitL[9],V1UnitL01[9],V1UnitS[9],V1UnitV[9] ST4D         st4d	{ z5.d - z8.d }, p3, [x17, x16, lsl #3]
-# CHECK-NEXT:  27     11    4.50           *             11    V1UnitI[9],V1UnitL[9],V1UnitL01[9],V1UnitS[9],V1UnitV[9] ST4H         st4h	{ z0.h - z3.h }, p0, [x0, x0, lsl #1]
-# CHECK-NEXT:  18     19    4.50           *             19    V1UnitL[9],V1UnitL01[9],V1UnitV[9]         ST4H_IMM                   st4h	{ z0.h - z3.h }, p0, [x0]
-# CHECK-NEXT:  18     19    4.50           *             19    V1UnitL[9],V1UnitL01[9],V1UnitV[9]         ST4H_IMM                   st4h	{ z21.h - z24.h }, p5, [x10, #20, mul vl]
-# CHECK-NEXT:  18     19    4.50           *             19    V1UnitL[9],V1UnitL01[9],V1UnitV[9]         ST4H_IMM                   st4h	{ z23.h - z26.h }, p3, [x13, #-32, mul vl]
-# CHECK-NEXT:  27     11    4.50           *             11    V1UnitI[9],V1UnitL[9],V1UnitL01[9],V1UnitS[9],V1UnitV[9] ST4H         st4h	{ z5.h - z8.h }, p3, [x17, x16, lsl #1]
-# CHECK-NEXT:  27     11    4.50           *             11    V1UnitI[9],V1UnitL[9],V1UnitL01[9],V1UnitS[9],V1UnitV[9] ST4W         st4w	{ z0.s - z3.s }, p0, [x0, x0, lsl #2]
-# CHECK-NEXT:  18     19    4.50           *             19    V1UnitL[9],V1UnitL01[9],V1UnitV[9]         ST4W_IMM                   st4w	{ z0.s - z3.s }, p0, [x0]
-# CHECK-NEXT:  18     19    4.50           *             19    V1UnitL[9],V1UnitL01[9],V1UnitV[9]         ST4W_IMM                   st4w	{ z21.s - z24.s }, p5, [x10, #20, mul vl]
-# CHECK-NEXT:  18     19    4.50           *             19    V1UnitL[9],V1UnitL01[9],V1UnitV[9]         ST4W_IMM                   st4w	{ z23.s - z26.s }, p3, [x13, #-32, mul vl]
-# CHECK-NEXT:  27     11    4.50           *             11    V1UnitI[9],V1UnitL[9],V1UnitL01[9],V1UnitS[9],V1UnitV[9] ST4W         st4w	{ z5.s - z8.s }, p3, [x17, x16, lsl #2]
+# CHECK-NEXT:  3      7     2.50           *             7     V1UnitI[5],V1UnitL[5],V1UnitL01[5],V1UnitS[5],V1UnitV[5] ST3B         st3b	{ z0.b - z2.b }, p0, [x0, x0]
+# CHECK-NEXT:  2      7     2.50           *             7     V1UnitL[5],V1UnitL01[5],V1UnitV[5]         ST3B_IMM                   st3b	{ z0.b - z2.b }, p0, [x0]
+# CHECK-NEXT:  2      7     2.50           *             7     V1UnitL[5],V1UnitL01[5],V1UnitV[5]         ST3B_IMM                   st3b	{ z21.b - z23.b }, p5, [x10, #15, mul vl]
+# CHECK-NEXT:  2      7     2.50           *             7     V1UnitL[5],V1UnitL01[5],V1UnitV[5]         ST3B_IMM                   st3b	{ z23.b - z25.b }, p3, [x13, #-24, mul vl]
+# CHECK-NEXT:  3      7     2.50           *             7     V1UnitI[5],V1UnitL[5],V1UnitL01[5],V1UnitS[5],V1UnitV[5] ST3B         st3b	{ z5.b - z7.b }, p3, [x17, x16]
+# CHECK-NEXT:  3      7     2.50           *             7     V1UnitI[5],V1UnitL[5],V1UnitL01[5],V1UnitS[5],V1UnitV[5] ST3D         st3d	{ z0.d - z2.d }, p0, [x0, x0, lsl #3]
+# CHECK-NEXT:  2      7     2.50           *             7     V1UnitL[5],V1UnitL01[5],V1UnitV[5]         ST3D_IMM                   st3d	{ z0.d - z2.d }, p0, [x0]
+# CHECK-NEXT:  2      7     2.50           *             7     V1UnitL[5],V1UnitL01[5],V1UnitV[5]         ST3D_IMM                   st3d	{ z21.d - z23.d }, p5, [x10, #15, mul vl]
+# CHECK-NEXT:  2      7     2.50           *             7     V1UnitL[5],V1UnitL01[5],V1UnitV[5]         ST3D_IMM                   st3d	{ z23.d - z25.d }, p3, [x13, #-24, mul vl]
+# CHECK-NEXT:  3      7     2.50           *             7     V1UnitI[5],V1UnitL[5],V1UnitL01[5],V1UnitS[5],V1UnitV[5] ST3D         st3d	{ z5.d - z7.d }, p3, [x17, x16, lsl #3]
+# CHECK-NEXT:  3      7     2.50           *             7     V1UnitI[5],V1UnitL[5],V1UnitL01[5],V1UnitS[5],V1UnitV[5] ST3H         st3h	{ z0.h - z2.h }, p0, [x0, x0, lsl #1]
+# CHECK-NEXT:  2      7     2.50           *             7     V1UnitL[5],V1UnitL01[5],V1UnitV[5]         ST3H_IMM                   st3h	{ z0.h - z2.h }, p0, [x0]
+# CHECK-NEXT:  2      7     2.50           *             7     V1UnitL[5],V1UnitL01[5],V1UnitV[5]         ST3H_IMM                   st3h	{ z21.h - z23.h }, p5, [x10, #15, mul vl]
+# CHECK-NEXT:  2      7     2.50           *             7     V1UnitL[5],V1UnitL01[5],V1UnitV[5]         ST3H_IMM                   st3h	{ z23.h - z25.h }, p3, [x13, #-24, mul vl]
+# CHECK-NEXT:  3      7     2.50           *             7     V1UnitI[5],V1UnitL[5],V1UnitL01[5],V1UnitS[5],V1UnitV[5] ST3H         st3h	{ z5.h - z7.h }, p3, [x17, x16, lsl #1]
+# CHECK-NEXT:  3      7     2.50           *             7     V1UnitI[5],V1UnitL[5],V1UnitL01[5],V1UnitS[5],V1UnitV[5] ST3W         st3w	{ z0.s - z2.s }, p0, [x0, x0, lsl #2]
+# CHECK-NEXT:  2      7     2.50           *             7     V1UnitL[5],V1UnitL01[5],V1UnitV[5]         ST3W_IMM                   st3w	{ z0.s - z2.s }, p0, [x0]
+# CHECK-NEXT:  2      7     2.50           *             7     V1UnitL[5],V1UnitL01[5],V1UnitV[5]         ST3W_IMM                   st3w	{ z21.s - z23.s }, p5, [x10, #15, mul vl]
+# CHECK-NEXT:  2      7     2.50           *             7     V1UnitL[5],V1UnitL01[5],V1UnitV[5]         ST3W_IMM                   st3w	{ z23.s - z25.s }, p3, [x13, #-24, mul vl]
+# CHECK-NEXT:  3      7     2.50           *             7     V1UnitI[5],V1UnitL[5],V1UnitL01[5],V1UnitS[5],V1UnitV[5] ST3W         st3w	{ z5.s - z7.s }, p3, [x17, x16, lsl #2]
+# CHECK-NEXT:  3      11    4.50           *             11    V1UnitI[9],V1UnitL[9],V1UnitL01[9],V1UnitS[9],V1UnitV[9] ST4B         st4b	{ z0.b - z3.b }, p0, [x0, x0]
+# CHECK-NEXT:  2      19    4.50           *             19    V1UnitL[9],V1UnitL01[9],V1UnitV[9]         ST4B_IMM                   st4b	{ z0.b - z3.b }, p0, [x0]
+# CHECK-NEXT:  2      19    4.50           *             19    V1UnitL[9],V1UnitL01[9],V1UnitV[9]         ST4B_IMM                   st4b	{ z21.b - z24.b }, p5, [x10, #20, mul vl]
+# CHECK-NEXT:  2      19    4.50           *             19    V1UnitL[9],V1UnitL01[9],V1UnitV[9]         ST4B_IMM                   st4b	{ z23.b - z26.b }, p3, [x13, #-32, mul vl]
+# CHECK-NEXT:  3      11    4.50           *             11    V1UnitI[9],V1UnitL[9],V1UnitL01[9],V1UnitS[9],V1UnitV[9] ST4B         st4b	{ z5.b - z8.b }, p3, [x17, x16]
+# CHECK-NEXT:  3      11    4.50           *             11    V1UnitI[9],V1UnitL[9],V1UnitL01[9],V1UnitS[9],V1UnitV[9] ST4D         st4d	{ z0.d - z3.d }, p0, [x0, x0, lsl #3]
+# CHECK-NEXT:  2      19    4.50           *             19    V1UnitL[9],V1UnitL01[9],V1UnitV[9]         ST4D_IMM                   st4d	{ z0.d - z3.d }, p0, [x0]
+# CHECK-NEXT:  2      19    4.50           *             19    V1UnitL[9],V1UnitL01[9],V1UnitV[9]         ST4D_IMM                   st4d	{ z21.d - z24.d }, p5, [x10, #20, mul vl]
+# CHECK-NEXT:  2      19    4.50           *             19    V1UnitL[9],V1UnitL01[9],V1UnitV[9]         ST4D_IMM                   st4d	{ z23.d - z26.d }, p3, [x13, #-32, mul vl]
+# CHECK-NEXT:  3      11    4.50           *             11    V1UnitI[9],V1UnitL[9],V1UnitL01[9],V1UnitS[9],V1UnitV[9] ST4D         st4d	{ z5.d - z8.d }, p3, [x17, x16, lsl #3]
+# CHECK-NEXT:  3      11    4.50           *             11    V1UnitI[9],V1UnitL[9],V1UnitL01[9],V1UnitS[9],V1UnitV[9] ST4H         st4h	{ z0.h - z3.h }, p0, [x0, x0, lsl #1]
+# CHECK-NEXT:  2      19    4.50           *             19    V1UnitL[9],V1UnitL01[9],V1UnitV[9]         ST4H_IMM                   st4h	{ z0.h - z3.h }, p0, [x0]
+# CHECK-NEXT:  2      19    4.50           *             19    V1UnitL[9],V1UnitL01[9],V1UnitV[9]         ST4H_IMM                   st4h	{ z21.h - z24.h }, p5, [x10, #20, mul vl]
+# CHECK-NEXT:  2      19    4.50           *             19    V1UnitL[9],V1UnitL01[9],V1UnitV[9]         ST4H_IMM                   st4h	{ z23.h - z26.h }, p3, [x13, #-32, mul vl]
+# CHECK-NEXT:  3      11    4.50           *             11    V1UnitI[9],V1UnitL[9],V1UnitL01[9],V1UnitS[9],V1UnitV[9] ST4H         st4h	{ z5.h - z8.h }, p3, [x17, x16, lsl #1]
+# CHECK-NEXT:  3      11    4.50           *             11    V1UnitI[9],V1UnitL[9],V1UnitL01[9],V1UnitS[9],V1UnitV[9] ST4W         st4w	{ z0.s - z3.s }, p0, [x0, x0, lsl #2]
+# CHECK-NEXT:  2      19    4.50           *             19    V1UnitL[9],V1UnitL01[9],V1UnitV[9]         ST4W_IMM                   st4w	{ z0.s - z3.s }, p0, [x0]
+# CHECK-NEXT:  2      19    4.50           *             19    V1UnitL[9],V1UnitL01[9],V1UnitV[9]         ST4W_IMM                   st4w	{ z21.s - z24.s }, p5, [x10, #20, mul vl]
+# CHECK-NEXT:  2      19    4.50           *             19    V1UnitL[9],V1UnitL01[9],V1UnitV[9]         ST4W_IMM                   st4w	{ z23.s - z26.s }, p3, [x13, #-32, mul vl]
+# CHECK-NEXT:  3      11    4.50           *             11    V1UnitI[9],V1UnitL[9],V1UnitL01[9],V1UnitS[9],V1UnitV[9] ST4W         st4w	{ z5.s - z8.s }, p3, [x17, x16, lsl #2]
 # CHECK-NEXT:  2      2     0.50           *             2     V1UnitL,V1UnitL01,V1UnitV                  STNT1B_ZRR                 stnt1b	{ z0.b }, p0, [x0, x0]
 # CHECK-NEXT:  2      2     0.50           *             2     V1UnitL,V1UnitL01,V1UnitV                  STNT1B_ZRI                 stnt1b	{ z0.b }, p0, [x0]
 # CHECK-NEXT:  2      2     0.50           *             2     V1UnitL,V1UnitL01,V1UnitV                  STNT1B_ZRI                 stnt1b	{ z21.b }, p5, [x10, #7, mul vl]
@@ -4694,16 +4694,16 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          UABD_ZPmZ_D                uabd	z31.d, p7/m, z31.d, z31.d
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          UABD_ZPmZ_H                uabd	z31.h, p7/m, z31.h, z31.h
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          UABD_ZPmZ_S                uabd	z31.s, p7/m, z31.s, z31.s
-# CHECK-NEXT:  5      14    2.00                         14    V1UnitV[5],V1UnitV0,V1UnitV1[2],V1UnitV01[3],V1UnitV02,V1UnitV13[3] UADDV_VPZ_B uaddv	d0, p7, z31.b
-# CHECK-NEXT:  4      12    2.00                         12    V1UnitV[4],V1UnitV1[2],V1UnitV01[3],V1UnitV13[2] UADDV_VPZ_H          uaddv	d0, p7, z31.h
-# CHECK-NEXT:  4      10    2.00                         10    V1UnitV[4],V1UnitV1[2],V1UnitV01[3],V1UnitV13[2] UADDV_VPZ_S          uaddv	d0, p7, z31.s
+# CHECK-NEXT:  4      14    2.00                         14    V1UnitV[5],V1UnitV0,V1UnitV1[2],V1UnitV01[3],V1UnitV02,V1UnitV13[3] UADDV_VPZ_B uaddv	d0, p7, z31.b
+# CHECK-NEXT:  3      12    2.00                         12    V1UnitV[4],V1UnitV1[2],V1UnitV01[3],V1UnitV13[2] UADDV_VPZ_H          uaddv	d0, p7, z31.h
+# CHECK-NEXT:  3      10    2.00                         10    V1UnitV[4],V1UnitV1[2],V1UnitV01[3],V1UnitV13[2] UADDV_VPZ_S          uaddv	d0, p7, z31.s
 # CHECK-NEXT:  2      8     0.50                         8     V1UnitV[2],V1UnitV01                       UADDV_VPZ_D                uaddv	d28, p6, z6.d
 # CHECK-NEXT:  1      3     1.00                         3     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       UCVTF_ZPmZ_DtoD            ucvtf	z0.d, p0/m, z0.d
-# CHECK-NEXT:  4      6     4.00                         6     V1UnitV[4],V1UnitV0[4],V1UnitV01[4],V1UnitV02[4] UCVTF_ZPmZ_HtoH      ucvtf	z0.h, p0/m, z0.h
-# CHECK-NEXT:  2      4     2.00                         4     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] UCVTF_ZPmZ_StoH      ucvtf	z0.h, p0/m, z0.s
+# CHECK-NEXT:  1      6     4.00                         6     V1UnitV[4],V1UnitV0[4],V1UnitV01[4],V1UnitV02[4] UCVTF_ZPmZ_HtoH      ucvtf	z0.h, p0/m, z0.h
+# CHECK-NEXT:  1      4     2.00                         4     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] UCVTF_ZPmZ_StoH      ucvtf	z0.h, p0/m, z0.s
 # CHECK-NEXT:  1      3     1.00                         3     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       UCVTF_ZPmZ_DtoH            ucvtf	z30.h, p2/m, z24.d
 # CHECK-NEXT:  1      3     1.00                         3     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       UCVTF_ZPmZ_DtoS            ucvtf	z0.s, p0/m, z0.d
-# CHECK-NEXT:  2      4     2.00                         4     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] UCVTF_ZPmZ_StoS      ucvtf	z0.s, p0/m, z0.s
+# CHECK-NEXT:  1      4     2.00                         4     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] UCVTF_ZPmZ_StoS      ucvtf	z0.s, p0/m, z0.s
 # CHECK-NEXT:  1      20    7.00                         20    V1UnitV[7],V1UnitV0[7],V1UnitV01[7],V1UnitV02[7] UDIV_ZPmZ_D          udiv	z0.d, p7/m, z0.d, z31.d
 # CHECK-NEXT:  1      12    7.00                         12    V1UnitV[7],V1UnitV0[7],V1UnitV01[7],V1UnitV02[7] UDIV_ZPmZ_S          udiv	z0.s, p7/m, z0.s, z31.s
 # CHECK-NEXT:  1      20    7.00                         20    V1UnitV[7],V1UnitV0[7],V1UnitV01[7],V1UnitV02[7] UDIVR_ZPmZ_D         udivr	z0.d, p7/m, z0.d, z31.d
@@ -4719,9 +4719,9 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          UMAX_ZPmZ_D                umax	z31.d, p7/m, z31.d, z31.d
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          UMAX_ZPmZ_H                umax	z31.h, p7/m, z31.h, z31.h
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          UMAX_ZPmZ_S                umax	z31.s, p7/m, z31.s, z31.s
-# CHECK-NEXT:  5      14    2.00                         14    V1UnitV[5],V1UnitV0,V1UnitV1[2],V1UnitV01[3],V1UnitV02,V1UnitV13[3] UMAXV_VPZ_B umaxv	b0, p7, z31.b
-# CHECK-NEXT:  4      12    2.00                         12    V1UnitV[4],V1UnitV1[2],V1UnitV01[3],V1UnitV13[2] UMAXV_VPZ_H          umaxv	h0, p7, z31.h
-# CHECK-NEXT:  4      10    2.00                         10    V1UnitV[4],V1UnitV1[2],V1UnitV01[3],V1UnitV13[2] UMAXV_VPZ_S          umaxv	s0, p7, z31.s
+# CHECK-NEXT:  4      14    2.00                         14    V1UnitV[5],V1UnitV0,V1UnitV1[2],V1UnitV01[3],V1UnitV02,V1UnitV13[3] UMAXV_VPZ_B umaxv	b0, p7, z31.b
+# CHECK-NEXT:  3      12    2.00                         12    V1UnitV[4],V1UnitV1[2],V1UnitV01[3],V1UnitV13[2] UMAXV_VPZ_H          umaxv	h0, p7, z31.h
+# CHECK-NEXT:  3      10    2.00                         10    V1UnitV[4],V1UnitV1[2],V1UnitV01[3],V1UnitV13[2] UMAXV_VPZ_S          umaxv	s0, p7, z31.s
 # CHECK-NEXT:  2      8     0.50                         8     V1UnitV[2],V1UnitV01                       UMAXV_VPZ_D                umaxv	d11, p4, z11.d
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          UMIN_ZI_B                  umin	z0.b, z0.b, #0
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          UMIN_ZPmZ_B                umin	z31.b, p7/m, z31.b, z31.b
@@ -4730,13 +4730,13 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          UMIN_ZPmZ_H                umin	z31.h, p7/m, z31.h, z31.h
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          UMIN_ZPmZ_S                umin	z31.s, p7/m, z31.s, z31.s
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          UMIN_ZI_S                  umin	z21.s, z21.s, #139
-# CHECK-NEXT:  5      14    2.00                         14    V1UnitV[5],V1UnitV0,V1UnitV1[2],V1UnitV01[3],V1UnitV02,V1UnitV13[3] UMINV_VPZ_B uminv	b0, p7, z31.b
-# CHECK-NEXT:  4      12    2.00                         12    V1UnitV[4],V1UnitV1[2],V1UnitV01[3],V1UnitV13[2] UMINV_VPZ_H          uminv	h0, p7, z31.h
-# CHECK-NEXT:  4      10    2.00                         10    V1UnitV[4],V1UnitV1[2],V1UnitV01[3],V1UnitV13[2] UMINV_VPZ_S          uminv	s0, p7, z31.s
+# CHECK-NEXT:  4      14    2.00                         14    V1UnitV[5],V1UnitV0,V1UnitV1[2],V1UnitV01[3],V1UnitV02,V1UnitV13[3] UMINV_VPZ_B uminv	b0, p7, z31.b
+# CHECK-NEXT:  3      12    2.00                         12    V1UnitV[4],V1UnitV1[2],V1UnitV01[3],V1UnitV13[2] UMINV_VPZ_H          uminv	h0, p7, z31.h
+# CHECK-NEXT:  3      10    2.00                         10    V1UnitV[4],V1UnitV1[2],V1UnitV01[3],V1UnitV13[2] UMINV_VPZ_S          uminv	s0, p7, z31.s
 # CHECK-NEXT:  2      8     0.50                         8     V1UnitV[2],V1UnitV01                       UMINV_VPZ_D                uminv	d24, p5, z29.d
 # CHECK-NEXT:  1      3     0.50                         1     V1UnitV,V1UnitV01                          UMMLA_ZZZ                  ummla	z0.s, z1.b, z2.b
 # CHECK-NEXT:  1      4     1.00                         4     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       UMULH_ZPmZ_B               umulh	z0.b, p7/m, z0.b, z31.b
-# CHECK-NEXT:  2      5     2.00                         5     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] UMULH_ZPmZ_D         umulh	z0.d, p7/m, z0.d, z31.d
+# CHECK-NEXT:  1      5     2.00                         5     V1UnitV[2],V1UnitV0[2],V1UnitV01[2],V1UnitV02[2] UMULH_ZPmZ_D         umulh	z0.d, p7/m, z0.d, z31.d
 # CHECK-NEXT:  1      4     1.00                         4     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       UMULH_ZPmZ_H               umulh	z0.h, p7/m, z0.h, z31.h
 # CHECK-NEXT:  1      4     1.00                         4     V1UnitV,V1UnitV0,V1UnitV01,V1UnitV02       UMULH_ZPmZ_S               umulh	z0.s, p7/m, z0.s, z31.s
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          UQADD_ZI_B                 uqadd	z0.b, z0.b, #0
@@ -4797,9 +4797,9 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   UQDECP_XP_D                uqdecp	x0, p0.d
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   UQDECP_XP_H                uqdecp	x0, p0.h
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   UQDECP_XP_S                uqdecp	x0, p0.s
-# CHECK-NEXT:  3      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 UQDECP_ZP_D       uqdecp	z0.d, p0.d
-# CHECK-NEXT:  3      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 UQDECP_ZP_H       uqdecp	z0.h, p0.h
-# CHECK-NEXT:  3      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 UQDECP_ZP_S       uqdecp	z0.s, p0.s
+# CHECK-NEXT:  2      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 UQDECP_ZP_D       uqdecp	z0.d, p0.d
+# CHECK-NEXT:  2      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 UQDECP_ZP_H       uqdecp	z0.h, p0.h
+# CHECK-NEXT:  2      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 UQDECP_ZP_S       uqdecp	z0.s, p0.s
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   UQDECW_WPiI                uqdecw	w0
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   UQDECW_WPiI                uqdecw	w0, all, mul #16
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   UQDECW_WPiI                uqdecw	w0, pow2
@@ -4856,9 +4856,9 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   UQINCP_XP_D                uqincp	x0, p0.d
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   UQINCP_XP_H                uqincp	x0, p0.h
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   UQINCP_XP_S                uqincp	x0, p0.s
-# CHECK-NEXT:  3      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 UQINCP_ZP_D       uqincp	z0.d, p0.d
-# CHECK-NEXT:  3      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 UQINCP_ZP_H       uqincp	z0.h, p0.h
-# CHECK-NEXT:  3      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 UQINCP_ZP_S       uqincp	z0.s, p0.s
+# CHECK-NEXT:  2      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 UQINCP_ZP_D       uqincp	z0.d, p0.d
+# CHECK-NEXT:  2      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 UQINCP_ZP_H       uqincp	z0.h, p0.h
+# CHECK-NEXT:  2      7     2.00                         7     V1UnitI[2],V1UnitM[2],V1UnitM0[2],V1UnitV,V1UnitV01 UQINCP_ZP_S       uqincp	z0.s, p0.s
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   UQINCW_WPiI                uqincw	w0
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   UQINCW_WPiI                uqincw	w0, all, mul #16
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   UQINCW_WPiI                uqincw	w0, pow2
@@ -4924,13 +4924,13 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          UZP2_ZZZ_D                 uzp2	z31.d, z31.d, z31.d
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          UZP2_ZZZ_H                 uzp2	z31.h, z31.h, z31.h
 # CHECK-NEXT:  1      2     0.50                         2     V1UnitV,V1UnitV01                          UZP2_ZZZ_S                 uzp2	z31.s, z31.s, z31.s
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          WHILELE_PWW_B              whilele	p0.b, w30, wzr
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          WHILELE_PXX_H              whilele	p6.h, x28, x30
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          WHILELO_PXX_D              whilelo	p15.d, xzr, x30
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          WHILELO_PXX_B              whilelo	p3.b, x9, x7
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          WHILELS_PWW_B              whilels	p4.b, w4, w20
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          WHILELS_PWW_H              whilels	p0.h, w30, wzr
-# CHECK-NEXT:  2      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          WHILELT_PXX_S              whilelt	p15.s, xzr, x30
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          WHILELE_PWW_B              whilele	p0.b, w30, wzr
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          WHILELE_PXX_H              whilele	p6.h, x28, x30
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          WHILELO_PXX_D              whilelo	p15.d, xzr, x30
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          WHILELO_PXX_B              whilelo	p3.b, x9, x7
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          WHILELS_PWW_B              whilels	p4.b, w4, w20
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          WHILELS_PWW_H              whilels	p0.h, w30, wzr
+# CHECK-NEXT:  1      3     2.00                         3     V1UnitI[2],V1UnitM[2],V1UnitM0[2]          WHILELT_PXX_S              whilelt	p15.s, xzr, x30
 # CHECK-NEXT:  1      2     1.00           *      U      2     V1UnitI,V1UnitM,V1UnitM0                   WRFFR                      wrffr	p0.b
 # CHECK-NEXT:  1      2     1.00           *      U      2     V1UnitI,V1UnitM,V1UnitM0                   WRFFR                      wrffr	p15.b
 # CHECK-NEXT:  1      2     1.00                         2     V1UnitI,V1UnitM,V1UnitM0                   ZIP1_PPP_B                 zip1	p0.b, p0.b, p0.b

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/V1-writeback.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/V1-writeback.s
@@ -1301,10 +1301,10 @@ add x0, x27, 1
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      508
-# CHECK-NEXT: Total uOps:        1900
+# CHECK-NEXT: Total uOps:        1500
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    3.74
+# CHECK-NEXT: uOps Per Cycle:    2.95
 # CHECK-NEXT: IPC:               1.97
 # CHECK-NEXT: Block RThroughput: 3.0
 
@@ -1316,12 +1316,12 @@ add x0, x27, 1
 # CHECK-NEXT: [0,1]     D=eE----R . .   add	x0, x27, #1
 # CHECK-NEXT: [0,2]     D=eeeeeeER. .   ld1	{ v1.1d, v2.1d }, [x27], #16
 # CHECK-NEXT: [0,3]     D==eE----R. .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     .D=eeeeeeER .   ld1	{ v1.2d, v2.2d }, [x27], #32
+# CHECK-NEXT: [0,4]     D==eeeeeeER .   ld1	{ v1.2d, v2.2d }, [x27], #32
 # CHECK-NEXT: [0,5]     .D==eE----R .   add	x0, x27, #1
 # CHECK-NEXT: [0,6]     .D==eeeeeeER.   ld1	{ v1.2s, v2.2s }, [x27], #16
 # CHECK-NEXT: [0,7]     .D===eE----R.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     . D==eeeeeeER   ld1	{ v1.4h, v2.4h }, [x27], #16
-# CHECK-NEXT: [0,9]     . D===eE----R   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     .D===eeeeeeER   ld1	{ v1.4h, v2.4h }, [x27], #16
+# CHECK-NEXT: [0,9]     .D====eE----R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -1334,23 +1334,23 @@ add x0, x27, 1
 # CHECK-NEXT: 1.     1     2.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.1d, v2.1d }, [x27], #16
 # CHECK-NEXT: 3.     1     3.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     2.0    0.0    0.0       ld1	{ v1.2d, v2.2d }, [x27], #32
+# CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld1	{ v1.2d, v2.2d }, [x27], #32
 # CHECK-NEXT: 5.     1     3.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 6.     1     3.0    0.0    0.0       ld1	{ v1.2s, v2.2s }, [x27], #16
 # CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     3.0    0.0    0.0       ld1	{ v1.4h, v2.4h }, [x27], #16
-# CHECK-NEXT: 9.     1     4.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        10    2.7    0.1    2.0       <total>
+# CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld1	{ v1.4h, v2.4h }, [x27], #16
+# CHECK-NEXT: 9.     1     5.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT:        10    3.0    0.1    2.0       <total>
 
 # CHECK:      [4] Code Region - G05
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      508
-# CHECK-NEXT: Total uOps:        2000
+# CHECK-NEXT: Total uOps:        1500
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    3.94
+# CHECK-NEXT: uOps Per Cycle:    2.95
 # CHECK-NEXT: IPC:               1.97
 # CHECK-NEXT: Block RThroughput: 3.3
 
@@ -1362,12 +1362,12 @@ add x0, x27, 1
 # CHECK-NEXT: [0,1]     D=eE----R . .   add	x0, x27, #1
 # CHECK-NEXT: [0,2]     D=eeeeeeER. .   ld1	{ v1.8b, v2.8b }, [x27], #16
 # CHECK-NEXT: [0,3]     D==eE----R. .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     .D=eeeeeeER .   ld1	{ v1.8h, v2.8h }, [x27], #32
+# CHECK-NEXT: [0,4]     D==eeeeeeER .   ld1	{ v1.8h, v2.8h }, [x27], #32
 # CHECK-NEXT: [0,5]     .D==eE----R .   add	x0, x27, #1
 # CHECK-NEXT: [0,6]     .D==eeeeeeER.   ld1	{ v1.16b, v2.16b }, [x27], #32
 # CHECK-NEXT: [0,7]     .D===eE----R.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     . D==eeeeeeER   ld1	{ v1.1d, v2.1d }, [x27], x28
-# CHECK-NEXT: [0,9]     . D===eE----R   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     .D===eeeeeeER   ld1	{ v1.1d, v2.1d }, [x27], x28
+# CHECK-NEXT: [0,9]     .D====eE----R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -1380,23 +1380,23 @@ add x0, x27, 1
 # CHECK-NEXT: 1.     1     2.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.8b, v2.8b }, [x27], #16
 # CHECK-NEXT: 3.     1     3.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     2.0    0.0    0.0       ld1	{ v1.8h, v2.8h }, [x27], #32
+# CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld1	{ v1.8h, v2.8h }, [x27], #32
 # CHECK-NEXT: 5.     1     3.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 6.     1     3.0    0.0    0.0       ld1	{ v1.16b, v2.16b }, [x27], #32
 # CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     3.0    0.0    0.0       ld1	{ v1.1d, v2.1d }, [x27], x28
-# CHECK-NEXT: 9.     1     4.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        10    2.7    0.1    2.0       <total>
+# CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld1	{ v1.1d, v2.1d }, [x27], x28
+# CHECK-NEXT: 9.     1     5.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT:        10    3.0    0.1    2.0       <total>
 
 # CHECK:      [5] Code Region - G06
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      508
-# CHECK-NEXT: Total uOps:        2000
+# CHECK-NEXT: Total uOps:        1500
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    3.94
+# CHECK-NEXT: uOps Per Cycle:    2.95
 # CHECK-NEXT: IPC:               1.97
 # CHECK-NEXT: Block RThroughput: 3.3
 
@@ -1408,12 +1408,12 @@ add x0, x27, 1
 # CHECK-NEXT: [0,1]     D=eE----R . .   add	x0, x27, #1
 # CHECK-NEXT: [0,2]     D=eeeeeeER. .   ld1	{ v1.2s, v2.2s }, [x27], x28
 # CHECK-NEXT: [0,3]     D==eE----R. .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     .D=eeeeeeER .   ld1	{ v1.4h, v2.4h }, [x27], x28
+# CHECK-NEXT: [0,4]     D==eeeeeeER .   ld1	{ v1.4h, v2.4h }, [x27], x28
 # CHECK-NEXT: [0,5]     .D==eE----R .   add	x0, x27, #1
 # CHECK-NEXT: [0,6]     .D==eeeeeeER.   ld1	{ v1.4s, v2.4s }, [x27], x28
 # CHECK-NEXT: [0,7]     .D===eE----R.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     . D==eeeeeeER   ld1	{ v1.8b, v2.8b }, [x27], x28
-# CHECK-NEXT: [0,9]     . D===eE----R   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     .D===eeeeeeER   ld1	{ v1.8b, v2.8b }, [x27], x28
+# CHECK-NEXT: [0,9]     .D====eE----R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -1426,23 +1426,23 @@ add x0, x27, 1
 # CHECK-NEXT: 1.     1     2.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.2s, v2.2s }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     2.0    0.0    0.0       ld1	{ v1.4h, v2.4h }, [x27], x28
+# CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld1	{ v1.4h, v2.4h }, [x27], x28
 # CHECK-NEXT: 5.     1     3.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 6.     1     3.0    0.0    0.0       ld1	{ v1.4s, v2.4s }, [x27], x28
 # CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     3.0    0.0    0.0       ld1	{ v1.8b, v2.8b }, [x27], x28
-# CHECK-NEXT: 9.     1     4.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        10    2.7    0.1    2.0       <total>
+# CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld1	{ v1.8b, v2.8b }, [x27], x28
+# CHECK-NEXT: 9.     1     5.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT:        10    3.0    0.1    2.0       <total>
 
 # CHECK:      [6] Code Region - G07
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      508
-# CHECK-NEXT: Total uOps:        2300
+# CHECK-NEXT: Total uOps:        1500
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    4.53
+# CHECK-NEXT: uOps Per Cycle:    2.95
 # CHECK-NEXT: IPC:               1.97
 # CHECK-NEXT: Block RThroughput: 4.3
 
@@ -1454,12 +1454,12 @@ add x0, x27, 1
 # CHECK-NEXT: [0,1]     D=eE----R . .   add	x0, x27, #1
 # CHECK-NEXT: [0,2]     D=eeeeeeER. .   ld1	{ v1.16b, v2.16b }, [x27], x28
 # CHECK-NEXT: [0,3]     D==eE----R. .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     .D=eeeeeeER .   ld1	{ v1.1d, v2.1d, v3.1d }, [x27], #24
+# CHECK-NEXT: [0,4]     D==eeeeeeER .   ld1	{ v1.1d, v2.1d, v3.1d }, [x27], #24
 # CHECK-NEXT: [0,5]     .D==eE----R .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     . D=eeeeeeER.   ld1	{ v1.2d, v2.2d, v3.2d }, [x27], #48
-# CHECK-NEXT: [0,7]     . D==eE----R.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .  D=eeeeeeER   ld1	{ v1.2s, v2.2s, v3.2s }, [x27], #24
-# CHECK-NEXT: [0,9]     .  D==eE----R   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeeeeeER.   ld1	{ v1.2d, v2.2d, v3.2d }, [x27], #48
+# CHECK-NEXT: [0,7]     .D===eE----R.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     .D===eeeeeeER   ld1	{ v1.2s, v2.2s, v3.2s }, [x27], #24
+# CHECK-NEXT: [0,9]     .D====eE----R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -1472,23 +1472,23 @@ add x0, x27, 1
 # CHECK-NEXT: 1.     1     2.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.16b, v2.16b }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     2.0    0.0    0.0       ld1	{ v1.1d, v2.1d, v3.1d }, [x27], #24
+# CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld1	{ v1.1d, v2.1d, v3.1d }, [x27], #24
 # CHECK-NEXT: 5.     1     3.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     2.0    0.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d }, [x27], #48
-# CHECK-NEXT: 7.     1     3.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     2.0    0.0    0.0       ld1	{ v1.2s, v2.2s, v3.2s }, [x27], #24
-# CHECK-NEXT: 9.     1     3.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        10    2.3    0.1    2.0       <total>
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d }, [x27], #48
+# CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld1	{ v1.2s, v2.2s, v3.2s }, [x27], #24
+# CHECK-NEXT: 9.     1     5.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT:        10    3.0    0.1    2.0       <total>
 
 # CHECK:      [7] Code Region - G08
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      508
-# CHECK-NEXT: Total uOps:        2500
+# CHECK-NEXT: Total uOps:        1500
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    4.92
+# CHECK-NEXT: uOps Per Cycle:    2.95
 # CHECK-NEXT: IPC:               1.97
 # CHECK-NEXT: Block RThroughput: 5.0
 
@@ -1498,14 +1498,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeeeeeER . .   ld1	{ v1.4h, v2.4h, v3.4h }, [x27], #24
 # CHECK-NEXT: [0,1]     D=eE----R . .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeeeeeER. .   ld1	{ v1.4s, v2.4s, v3.4s }, [x27], #48
-# CHECK-NEXT: [0,3]     .D=eE----R. .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . DeeeeeeER .   ld1	{ v1.8b, v2.8b, v3.8b }, [x27], #24
-# CHECK-NEXT: [0,5]     . D=eE----R .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  DeeeeeeER.   ld1	{ v1.8h, v2.8h, v3.8h }, [x27], #48
-# CHECK-NEXT: [0,7]     .  D=eE----R.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .   DeeeeeeER   ld1	{ v1.16b, v2.16b, v3.16b }, [x27], #48
-# CHECK-NEXT: [0,9]     .   D=eE----R   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeeeER. .   ld1	{ v1.4s, v2.4s, v3.4s }, [x27], #48
+# CHECK-NEXT: [0,3]     D==eE----R. .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     D==eeeeeeER .   ld1	{ v1.8b, v2.8b, v3.8b }, [x27], #24
+# CHECK-NEXT: [0,5]     .D==eE----R .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeeeeeER.   ld1	{ v1.8h, v2.8h, v3.8h }, [x27], #48
+# CHECK-NEXT: [0,7]     .D===eE----R.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     .D===eeeeeeER   ld1	{ v1.16b, v2.16b, v3.16b }, [x27], #48
+# CHECK-NEXT: [0,9]     .D====eE----R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -1516,25 +1516,25 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ld1	{ v1.4h, v2.4h, v3.4h }, [x27], #24
 # CHECK-NEXT: 1.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld1	{ v1.4s, v2.4s, v3.4s }, [x27], #48
-# CHECK-NEXT: 3.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld1	{ v1.8b, v2.8b, v3.8b }, [x27], #24
-# CHECK-NEXT: 5.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     1.0    0.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h }, [x27], #48
-# CHECK-NEXT: 7.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld1	{ v1.16b, v2.16b, v3.16b }, [x27], #48
-# CHECK-NEXT: 9.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.5    0.1    2.0       <total>
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.4s, v2.4s, v3.4s }, [x27], #48
+# CHECK-NEXT: 3.     1     3.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld1	{ v1.8b, v2.8b, v3.8b }, [x27], #24
+# CHECK-NEXT: 5.     1     3.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h }, [x27], #48
+# CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld1	{ v1.16b, v2.16b, v3.16b }, [x27], #48
+# CHECK-NEXT: 9.     1     5.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT:        10    3.0    0.1    2.0       <total>
 
 # CHECK:      [8] Code Region - G09
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      508
-# CHECK-NEXT: Total uOps:        2500
+# CHECK-NEXT: Total uOps:        1500
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    4.92
+# CHECK-NEXT: uOps Per Cycle:    2.95
 # CHECK-NEXT: IPC:               1.97
 # CHECK-NEXT: Block RThroughput: 5.0
 
@@ -1544,14 +1544,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeeeeeER . .   ld1	{ v1.1d, v2.1d, v3.1d }, [x27], x28
 # CHECK-NEXT: [0,1]     D=eE----R . .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeeeeeER. .   ld1	{ v1.2d, v2.2d, v3.2d }, [x27], x28
-# CHECK-NEXT: [0,3]     .D=eE----R. .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . DeeeeeeER .   ld1	{ v1.2s, v2.2s, v3.2s }, [x27], x28
-# CHECK-NEXT: [0,5]     . D=eE----R .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  DeeeeeeER.   ld1	{ v1.4h, v2.4h, v3.4h }, [x27], x28
-# CHECK-NEXT: [0,7]     .  D=eE----R.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .   DeeeeeeER   ld1	{ v1.4s, v2.4s, v3.4s }, [x27], x28
-# CHECK-NEXT: [0,9]     .   D=eE----R   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeeeER. .   ld1	{ v1.2d, v2.2d, v3.2d }, [x27], x28
+# CHECK-NEXT: [0,3]     D==eE----R. .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     D==eeeeeeER .   ld1	{ v1.2s, v2.2s, v3.2s }, [x27], x28
+# CHECK-NEXT: [0,5]     .D==eE----R .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeeeeeER.   ld1	{ v1.4h, v2.4h, v3.4h }, [x27], x28
+# CHECK-NEXT: [0,7]     .D===eE----R.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     .D===eeeeeeER   ld1	{ v1.4s, v2.4s, v3.4s }, [x27], x28
+# CHECK-NEXT: [0,9]     .D====eE----R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -1562,25 +1562,25 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ld1	{ v1.1d, v2.1d, v3.1d }, [x27], x28
 # CHECK-NEXT: 1.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d }, [x27], x28
-# CHECK-NEXT: 3.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld1	{ v1.2s, v2.2s, v3.2s }, [x27], x28
-# CHECK-NEXT: 5.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     1.0    0.0    0.0       ld1	{ v1.4h, v2.4h, v3.4h }, [x27], x28
-# CHECK-NEXT: 7.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld1	{ v1.4s, v2.4s, v3.4s }, [x27], x28
-# CHECK-NEXT: 9.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.5    0.1    2.0       <total>
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d }, [x27], x28
+# CHECK-NEXT: 3.     1     3.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld1	{ v1.2s, v2.2s, v3.2s }, [x27], x28
+# CHECK-NEXT: 5.     1     3.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       ld1	{ v1.4h, v2.4h, v3.4h }, [x27], x28
+# CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld1	{ v1.4s, v2.4s, v3.4s }, [x27], x28
+# CHECK-NEXT: 9.     1     5.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT:        10    3.0    0.1    2.0       <total>
 
 # CHECK:      [9] Code Region - G10
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      608
-# CHECK-NEXT: Total uOps:        2500
+# CHECK-NEXT: Total uOps:        1500
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    4.11
+# CHECK-NEXT: uOps Per Cycle:    2.47
 # CHECK-NEXT: IPC:               1.64
 # CHECK-NEXT: Block RThroughput: 5.0
 
@@ -1590,14 +1590,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeeeeeER .  .   ld1	{ v1.8b, v2.8b, v3.8b }, [x27], x28
 # CHECK-NEXT: [0,1]     D=eE----R .  .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeeeeeER.  .   ld1	{ v1.8h, v2.8h, v3.8h }, [x27], x28
-# CHECK-NEXT: [0,3]     .D=eE----R.  .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . DeeeeeeER  .   ld1	{ v1.16b, v2.16b, v3.16b }, [x27], x28
-# CHECK-NEXT: [0,5]     . D=eE----R  .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     . D=eeeeeeER .   ld1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], #32
-# CHECK-NEXT: [0,7]     .  D=eE----R .   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .  D=eeeeeeeER   ld1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
-# CHECK-NEXT: [0,9]     .  D==eE-----R   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeeeER.  .   ld1	{ v1.8h, v2.8h, v3.8h }, [x27], x28
+# CHECK-NEXT: [0,3]     D==eE----R.  .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     D==eeeeeeER  .   ld1	{ v1.16b, v2.16b, v3.16b }, [x27], x28
+# CHECK-NEXT: [0,5]     .D==eE----R  .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeeeeeER .   ld1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], #32
+# CHECK-NEXT: [0,7]     .D===eE----R .   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     .D===eeeeeeeER   ld1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
+# CHECK-NEXT: [0,9]     .D====eE-----R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -1608,25 +1608,25 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ld1	{ v1.8b, v2.8b, v3.8b }, [x27], x28
 # CHECK-NEXT: 1.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h }, [x27], x28
-# CHECK-NEXT: 3.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld1	{ v1.16b, v2.16b, v3.16b }, [x27], x28
-# CHECK-NEXT: 5.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     2.0    0.0    0.0       ld1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], #32
-# CHECK-NEXT: 7.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     2.0    0.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
-# CHECK-NEXT: 9.     1     3.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.8    0.1    2.1       <total>
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h }, [x27], x28
+# CHECK-NEXT: 3.     1     3.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld1	{ v1.16b, v2.16b, v3.16b }, [x27], x28
+# CHECK-NEXT: 5.     1     3.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       ld1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], #32
+# CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
+# CHECK-NEXT: 9.     1     5.0    0.0    5.0       add	x0, x27, #1
+# CHECK-NEXT:        10    3.0    0.1    2.1       <total>
 
 # CHECK:      [10] Code Region - G11
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      509
-# CHECK-NEXT: Total uOps:        2400
+# CHECK-NEXT: Total uOps:        1500
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    4.72
+# CHECK-NEXT: uOps Per Cycle:    2.95
 # CHECK-NEXT: IPC:               1.96
 # CHECK-NEXT: Block RThroughput: 4.7
 
@@ -1638,12 +1638,12 @@ add x0, x27, 1
 # CHECK-NEXT: [0,1]     D=eE----R .  .   add	x0, x27, #1
 # CHECK-NEXT: [0,2]     D=eeeeeeER.  .   ld1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #32
 # CHECK-NEXT: [0,3]     D==eE----R.  .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     .D=eeeeeeeER .   ld1	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
+# CHECK-NEXT: [0,4]     D==eeeeeeeER .   ld1	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
 # CHECK-NEXT: [0,5]     .D==eE-----R .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     . D=eeeeeeER .   ld1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #32
-# CHECK-NEXT: [0,7]     . D==eE----R .   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .  D=eeeeeeeER   ld1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
-# CHECK-NEXT: [0,9]     .  D==eE-----R   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeeeeeER .   ld1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #32
+# CHECK-NEXT: [0,7]     .D===eE----R .   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     .D===eeeeeeeER   ld1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
+# CHECK-NEXT: [0,9]     .D====eE-----R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -1656,23 +1656,23 @@ add x0, x27, 1
 # CHECK-NEXT: 1.     1     2.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #32
 # CHECK-NEXT: 3.     1     3.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     2.0    0.0    0.0       ld1	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
+# CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld1	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
 # CHECK-NEXT: 5.     1     3.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     2.0    0.0    0.0       ld1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #32
-# CHECK-NEXT: 7.     1     3.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     2.0    0.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
-# CHECK-NEXT: 9.     1     3.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        10    2.3    0.1    2.2       <total>
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       ld1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #32
+# CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
+# CHECK-NEXT: 9.     1     5.0    0.0    5.0       add	x0, x27, #1
+# CHECK-NEXT:        10    3.0    0.1    2.2       <total>
 
 # CHECK:      [11] Code Region - G12
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      508
-# CHECK-NEXT: Total uOps:        2400
+# CHECK-NEXT: Total uOps:        1500
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    4.72
+# CHECK-NEXT: uOps Per Cycle:    2.95
 # CHECK-NEXT: IPC:               1.97
 # CHECK-NEXT: Block RThroughput: 4.7
 
@@ -1682,14 +1682,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeeeeeeER. .   ld1	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
 # CHECK-NEXT: [0,1]     D=eE-----R. .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeeeeeER. .   ld1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], x28
-# CHECK-NEXT: [0,3]     .D=eE----R. .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . DeeeeeeeER.   ld1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], x28
-# CHECK-NEXT: [0,5]     . D=eE-----R.   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  DeeeeeeER.   ld1	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
-# CHECK-NEXT: [0,7]     .  D=eE----R.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .  D=eeeeeeER   ld1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
-# CHECK-NEXT: [0,9]     .  D==eE----R   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeeeER. .   ld1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], x28
+# CHECK-NEXT: [0,3]     D==eE----R. .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     D==eeeeeeeER.   ld1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], x28
+# CHECK-NEXT: [0,5]     .D==eE-----R.   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeeeeeER.   ld1	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
+# CHECK-NEXT: [0,7]     .D===eE----R.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     .D===eeeeeeER   ld1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
+# CHECK-NEXT: [0,9]     .D====eE----R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -1700,25 +1700,25 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ld1	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
 # CHECK-NEXT: 1.     1     2.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], x28
-# CHECK-NEXT: 3.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], x28
-# CHECK-NEXT: 5.     1     2.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     1.0    0.0    0.0       ld1	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
-# CHECK-NEXT: 7.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     2.0    0.0    0.0       ld1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
-# CHECK-NEXT: 9.     1     3.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.7    0.1    2.2       <total>
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], x28
+# CHECK-NEXT: 3.     1     3.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], x28
+# CHECK-NEXT: 5.     1     3.0    0.0    5.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       ld1	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
+# CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
+# CHECK-NEXT: 9.     1     5.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT:        10    3.0    0.1    2.2       <total>
 
 # CHECK:      [12] Code Region - G13
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      1110
-# CHECK-NEXT: Total uOps:        2600
+# CHECK-NEXT: Total uOps:        1600
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    2.34
+# CHECK-NEXT: uOps Per Cycle:    1.44
 # CHECK-NEXT: IPC:               0.90
 # CHECK-NEXT: Block RThroughput: 5.0
 
@@ -1728,14 +1728,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeeeeeeER.    .    .   ld1	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
 # CHECK-NEXT: [0,1]     D=eE-----R.    .    .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeeeeeER.    .    .   ld1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
-# CHECK-NEXT: [0,3]     .D=eE----R.    .    .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . DeeeeeeeER   .    .   ld1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], x28
-# CHECK-NEXT: [0,5]     . D=eE-----R   .    .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  DeeeeeeeER  .    .   ld1	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
-# CHECK-NEXT: [0,7]     .  D=eE-----R  .    .   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .   D======eeeeeeeeER   ld1	{ v1.b }[0], [x27], #1
-# CHECK-NEXT: [0,9]     .   D=======eE------R   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeeeER.    .    .   ld1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
+# CHECK-NEXT: [0,3]     D==eE----R.    .    .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     D==eeeeeeeER   .    .   ld1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], x28
+# CHECK-NEXT: [0,5]     .D==eE-----R   .    .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeeeeeeER  .    .   ld1	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
+# CHECK-NEXT: [0,7]     .D===eE-----R  .    .   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     .D=========eeeeeeeeER   ld1	{ v1.b }[0], [x27], #1
+# CHECK-NEXT: [0,9]     .D==========eE------R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -1746,15 +1746,15 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ld1	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
 # CHECK-NEXT: 1.     1     2.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
-# CHECK-NEXT: 3.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], x28
-# CHECK-NEXT: 5.     1     2.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     1.0    0.0    0.0       ld1	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
-# CHECK-NEXT: 7.     1     2.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     7.0    0.0    0.0       ld1	{ v1.b }[0], [x27], #1
-# CHECK-NEXT: 9.     1     8.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        10    2.7    0.1    2.5       <total>
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
+# CHECK-NEXT: 3.     1     3.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], x28
+# CHECK-NEXT: 5.     1     3.0    0.0    5.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       ld1	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
+# CHECK-NEXT: 7.     1     4.0    0.0    5.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     10.0   0.0    0.0       ld1	{ v1.b }[0], [x27], #1
+# CHECK-NEXT: 9.     1     11.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT:        10    4.2    0.1    2.5       <total>
 
 # CHECK:      [13] Code Region - G14
 
@@ -1991,12 +1991,12 @@ add x0, x27, 1
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      510
-# CHECK-NEXT: Total uOps:        2400
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    4.71
+# CHECK-NEXT: uOps Per Cycle:    3.92
 # CHECK-NEXT: IPC:               1.96
-# CHECK-NEXT: Block RThroughput: 3.0
+# CHECK-NEXT: Block RThroughput: 2.5
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     01234
@@ -2008,10 +2008,10 @@ add x0, x27, 1
 # CHECK-NEXT: [0,3]     D==eE------R  .   add	x0, x27, #1
 # CHECK-NEXT: [0,4]     .D=eeeeeeeeER .   ld2	{ v1.2d, v2.2d }, [x27], #32
 # CHECK-NEXT: [0,5]     .D==eE------R .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     . D=eeeeeeeeER.   ld2	{ v1.2s, v2.2s }, [x27], #16
-# CHECK-NEXT: [0,7]     . D==eE------R.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .  D=eeeeeeeeER   ld2	{ v1.4h, v2.4h }, [x27], #16
-# CHECK-NEXT: [0,9]     .  D==eE------R   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeeeeeeeER.   ld2	{ v1.2s, v2.2s }, [x27], #16
+# CHECK-NEXT: [0,7]     .D===eE------R.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D==eeeeeeeeER   ld2	{ v1.4h, v2.4h }, [x27], #16
+# CHECK-NEXT: [0,9]     . D===eE------R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -2026,23 +2026,23 @@ add x0, x27, 1
 # CHECK-NEXT: 3.     1     3.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 4.     1     2.0    0.0    0.0       ld2	{ v1.2d, v2.2d }, [x27], #32
 # CHECK-NEXT: 5.     1     3.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     2.0    0.0    0.0       ld2	{ v1.2s, v2.2s }, [x27], #16
-# CHECK-NEXT: 7.     1     3.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     2.0    0.0    0.0       ld2	{ v1.4h, v2.4h }, [x27], #16
-# CHECK-NEXT: 9.     1     3.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        10    2.3    0.1    3.0       <total>
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       ld2	{ v1.2s, v2.2s }, [x27], #16
+# CHECK-NEXT: 7.     1     4.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     3.0    0.0    0.0       ld2	{ v1.4h, v2.4h }, [x27], #16
+# CHECK-NEXT: 9.     1     4.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT:        10    2.7    0.1    3.0       <total>
 
 # CHECK:      [19] Code Region - G20
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      510
-# CHECK-NEXT: Total uOps:        2900
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    5.69
+# CHECK-NEXT: uOps Per Cycle:    3.92
 # CHECK-NEXT: IPC:               1.96
-# CHECK-NEXT: Block RThroughput: 3.6
+# CHECK-NEXT: Block RThroughput: 3.0
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     01234
@@ -2050,14 +2050,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeeeeeeeER   .   ld2	{ v1.4s, v2.4s }, [x27], #32
 # CHECK-NEXT: [0,1]     D=eE------R   .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeeeeeeeER  .   ld2	{ v1.8b, v2.8b }, [x27], #16
-# CHECK-NEXT: [0,3]     .D=eE------R  .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . DeeeeeeeeER .   ld2	{ v1.8h, v2.8h }, [x27], #32
-# CHECK-NEXT: [0,5]     . D=eE------R .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  DeeeeeeeeER.   ld2	{ v1.16b, v2.16b }, [x27], #32
-# CHECK-NEXT: [0,7]     .  D=eE------R.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .   DeeeeeeeeER   ld2	{ v1.2d, v2.2d }, [x27], x28
-# CHECK-NEXT: [0,9]     .   D=eE------R   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeeeeeER  .   ld2	{ v1.8b, v2.8b }, [x27], #16
+# CHECK-NEXT: [0,3]     D==eE------R  .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D=eeeeeeeeER .   ld2	{ v1.8h, v2.8h }, [x27], #32
+# CHECK-NEXT: [0,5]     .D==eE------R .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeeeeeeeER.   ld2	{ v1.16b, v2.16b }, [x27], #32
+# CHECK-NEXT: [0,7]     .D===eE------R.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D==eeeeeeeeER   ld2	{ v1.2d, v2.2d }, [x27], x28
+# CHECK-NEXT: [0,9]     . D===eE------R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -2068,27 +2068,27 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ld2	{ v1.4s, v2.4s }, [x27], #32
 # CHECK-NEXT: 1.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld2	{ v1.8b, v2.8b }, [x27], #16
-# CHECK-NEXT: 3.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld2	{ v1.8h, v2.8h }, [x27], #32
-# CHECK-NEXT: 5.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     1.0    0.0    0.0       ld2	{ v1.16b, v2.16b }, [x27], #32
-# CHECK-NEXT: 7.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld2	{ v1.2d, v2.2d }, [x27], x28
-# CHECK-NEXT: 9.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.5    0.1    3.0       <total>
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld2	{ v1.8b, v2.8b }, [x27], #16
+# CHECK-NEXT: 3.     1     3.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     2.0    0.0    0.0       ld2	{ v1.8h, v2.8h }, [x27], #32
+# CHECK-NEXT: 5.     1     3.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       ld2	{ v1.16b, v2.16b }, [x27], #32
+# CHECK-NEXT: 7.     1     4.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     3.0    0.0    0.0       ld2	{ v1.2d, v2.2d }, [x27], x28
+# CHECK-NEXT: 9.     1     4.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT:        10    2.7    0.1    3.0       <total>
 
 # CHECK:      [20] Code Region - G21
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      510
-# CHECK-NEXT: Total uOps:        2700
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    5.29
+# CHECK-NEXT: uOps Per Cycle:    3.92
 # CHECK-NEXT: IPC:               1.96
-# CHECK-NEXT: Block RThroughput: 3.4
+# CHECK-NEXT: Block RThroughput: 2.5
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     01234
@@ -2096,14 +2096,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeeeeeeeER   .   ld2	{ v1.2s, v2.2s }, [x27], x28
 # CHECK-NEXT: [0,1]     D=eE------R   .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeeeeeeeER  .   ld2	{ v1.4h, v2.4h }, [x27], x28
-# CHECK-NEXT: [0,3]     .D=eE------R  .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . DeeeeeeeeER .   ld2	{ v1.4s, v2.4s }, [x27], x28
-# CHECK-NEXT: [0,5]     . D=eE------R .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  DeeeeeeeeER.   ld2	{ v1.8b, v2.8b }, [x27], x28
-# CHECK-NEXT: [0,7]     .  D=eE------R.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .   DeeeeeeeeER   ld2	{ v1.8h, v2.8h }, [x27], x28
-# CHECK-NEXT: [0,9]     .   D=eE------R   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeeeeeER  .   ld2	{ v1.4h, v2.4h }, [x27], x28
+# CHECK-NEXT: [0,3]     D==eE------R  .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D=eeeeeeeeER .   ld2	{ v1.4s, v2.4s }, [x27], x28
+# CHECK-NEXT: [0,5]     .D==eE------R .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeeeeeeeER.   ld2	{ v1.8b, v2.8b }, [x27], x28
+# CHECK-NEXT: [0,7]     .D===eE------R.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D==eeeeeeeeER   ld2	{ v1.8h, v2.8h }, [x27], x28
+# CHECK-NEXT: [0,9]     . D===eE------R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -2114,27 +2114,27 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ld2	{ v1.2s, v2.2s }, [x27], x28
 # CHECK-NEXT: 1.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld2	{ v1.4h, v2.4h }, [x27], x28
-# CHECK-NEXT: 3.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld2	{ v1.4s, v2.4s }, [x27], x28
-# CHECK-NEXT: 5.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     1.0    0.0    0.0       ld2	{ v1.8b, v2.8b }, [x27], x28
-# CHECK-NEXT: 7.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld2	{ v1.8h, v2.8h }, [x27], x28
-# CHECK-NEXT: 9.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.5    0.1    3.0       <total>
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld2	{ v1.4h, v2.4h }, [x27], x28
+# CHECK-NEXT: 3.     1     3.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     2.0    0.0    0.0       ld2	{ v1.4s, v2.4s }, [x27], x28
+# CHECK-NEXT: 5.     1     3.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       ld2	{ v1.8b, v2.8b }, [x27], x28
+# CHECK-NEXT: 7.     1     4.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     3.0    0.0    0.0       ld2	{ v1.8h, v2.8h }, [x27], x28
+# CHECK-NEXT: 9.     1     4.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT:        10    2.7    0.1    3.0       <total>
 
 # CHECK:      [21] Code Region - G22
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      3310
-# CHECK-NEXT: Total uOps:        2600
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    0.79
+# CHECK-NEXT: uOps Per Cycle:    0.60
 # CHECK-NEXT: IPC:               0.30
-# CHECK-NEXT: Block RThroughput: 3.3
+# CHECK-NEXT: Block RThroughput: 2.5
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     0123456789          0123456789
@@ -2142,14 +2142,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeeeeeeeER    .    .    .    .    .    . .   ld2	{ v1.16b, v2.16b }, [x27], x28
 # CHECK-NEXT: [0,1]     D=eE------R    .    .    .    .    .    . .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .D=======eeeeeeeeER .    .    .    .    . .   ld2	{ v1.b, v2.b }[0], [x27], #2
-# CHECK-NEXT: [0,3]     .D========eE------R .    .    .    .    . .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . D==============eeeeeeeeER   .    .    . .   ld2	{ v1.b, v2.b }[8], [x27], #2
-# CHECK-NEXT: [0,5]     . D===============eE------R   .    .    . .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  D=====================eeeeeeeeER.    . .   ld2	{ v1.b, v2.b }[0], [x27], x28
-# CHECK-NEXT: [0,7]     .  D======================eE------R.    . .   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .   D============================eeeeeeeeER   ld2	{ v1.b, v2.b }[8], [x27], x28
-# CHECK-NEXT: [0,9]     .   D=============================eE------R   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D========eeeeeeeeER .    .    .    .    . .   ld2	{ v1.b, v2.b }[0], [x27], #2
+# CHECK-NEXT: [0,3]     D=========eE------R .    .    .    .    . .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D===============eeeeeeeeER   .    .    . .   ld2	{ v1.b, v2.b }[8], [x27], #2
+# CHECK-NEXT: [0,5]     .D================eE------R   .    .    . .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D=======================eeeeeeeeER.    . .   ld2	{ v1.b, v2.b }[0], [x27], x28
+# CHECK-NEXT: [0,7]     .D========================eE------R.    . .   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D==============================eeeeeeeeER   ld2	{ v1.b, v2.b }[8], [x27], x28
+# CHECK-NEXT: [0,9]     . D===============================eE------R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -2160,27 +2160,27 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ld2	{ v1.16b, v2.16b }, [x27], x28
 # CHECK-NEXT: 1.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     8.0    0.0    0.0       ld2	{ v1.b, v2.b }[0], [x27], #2
-# CHECK-NEXT: 3.     1     9.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     15.0   0.0    0.0       ld2	{ v1.b, v2.b }[8], [x27], #2
-# CHECK-NEXT: 5.     1     16.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     22.0   0.0    0.0       ld2	{ v1.b, v2.b }[0], [x27], x28
-# CHECK-NEXT: 7.     1     23.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     29.0   0.0    0.0       ld2	{ v1.b, v2.b }[8], [x27], x28
-# CHECK-NEXT: 9.     1     30.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        10    15.5   0.1    3.0       <total>
+# CHECK-NEXT: 2.     1     9.0    0.0    0.0       ld2	{ v1.b, v2.b }[0], [x27], #2
+# CHECK-NEXT: 3.     1     10.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     16.0   0.0    0.0       ld2	{ v1.b, v2.b }[8], [x27], #2
+# CHECK-NEXT: 5.     1     17.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     24.0   0.0    0.0       ld2	{ v1.b, v2.b }[0], [x27], x28
+# CHECK-NEXT: 7.     1     25.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     31.0   0.0    0.0       ld2	{ v1.b, v2.b }[8], [x27], x28
+# CHECK-NEXT: 9.     1     32.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT:        10    16.7   0.1    3.0       <total>
 
 # CHECK:      [22] Code Region - G23
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      4003
-# CHECK-NEXT: Total uOps:        2500
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    0.62
+# CHECK-NEXT: uOps Per Cycle:    0.50
 # CHECK-NEXT: IPC:               0.25
-# CHECK-NEXT: Block RThroughput: 3.1
+# CHECK-NEXT: Block RThroughput: 2.5
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     0123456789          0123456789
@@ -2188,14 +2188,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeeeeeeeER    .    .    .    .    .    . .   ld2	{ v1.h, v2.h }[0], [x27], #4
 # CHECK-NEXT: [0,1]     D=eE------R    .    .    .    .    .    . .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .D=======eeeeeeeeER .    .    .    .    . .   ld2	{ v1.h, v2.h }[4], [x27], #4
-# CHECK-NEXT: [0,3]     .D========eE------R .    .    .    .    . .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . D==============eeeeeeeeER   .    .    . .   ld2	{ v1.h, v2.h }[0], [x27], x28
-# CHECK-NEXT: [0,5]     . D===============eE------R   .    .    . .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  D=====================eeeeeeeeER.    . .   ld2	{ v1.h, v2.h }[4], [x27], x28
-# CHECK-NEXT: [0,7]     .  D======================eE------R.    . .   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .   D============================eeeeeeeeER   ld2	{ v1.s, v2.s }[0], [x27], #8
-# CHECK-NEXT: [0,9]     .   D=============================eE------R   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D========eeeeeeeeER .    .    .    .    . .   ld2	{ v1.h, v2.h }[4], [x27], #4
+# CHECK-NEXT: [0,3]     D=========eE------R .    .    .    .    . .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D===============eeeeeeeeER   .    .    . .   ld2	{ v1.h, v2.h }[0], [x27], x28
+# CHECK-NEXT: [0,5]     .D================eE------R   .    .    . .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D=======================eeeeeeeeER.    . .   ld2	{ v1.h, v2.h }[4], [x27], x28
+# CHECK-NEXT: [0,7]     .D========================eE------R.    . .   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D==============================eeeeeeeeER   ld2	{ v1.s, v2.s }[0], [x27], #8
+# CHECK-NEXT: [0,9]     . D===============================eE------R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -2206,27 +2206,27 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ld2	{ v1.h, v2.h }[0], [x27], #4
 # CHECK-NEXT: 1.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     8.0    0.0    0.0       ld2	{ v1.h, v2.h }[4], [x27], #4
-# CHECK-NEXT: 3.     1     9.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     15.0   0.0    0.0       ld2	{ v1.h, v2.h }[0], [x27], x28
-# CHECK-NEXT: 5.     1     16.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     22.0   0.0    0.0       ld2	{ v1.h, v2.h }[4], [x27], x28
-# CHECK-NEXT: 7.     1     23.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     29.0   0.0    0.0       ld2	{ v1.s, v2.s }[0], [x27], #8
-# CHECK-NEXT: 9.     1     30.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        10    15.5   0.1    3.0       <total>
+# CHECK-NEXT: 2.     1     9.0    0.0    0.0       ld2	{ v1.h, v2.h }[4], [x27], #4
+# CHECK-NEXT: 3.     1     10.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     16.0   0.0    0.0       ld2	{ v1.h, v2.h }[0], [x27], x28
+# CHECK-NEXT: 5.     1     17.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     24.0   0.0    0.0       ld2	{ v1.h, v2.h }[4], [x27], x28
+# CHECK-NEXT: 7.     1     25.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     31.0   0.0    0.0       ld2	{ v1.s, v2.s }[0], [x27], #8
+# CHECK-NEXT: 9.     1     32.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT:        10    16.7   0.1    3.0       <total>
 
 # CHECK:      [23] Code Region - G24
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      2603
-# CHECK-NEXT: Total uOps:        2500
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    0.96
+# CHECK-NEXT: uOps Per Cycle:    0.77
 # CHECK-NEXT: IPC:               0.38
-# CHECK-NEXT: Block RThroughput: 3.1
+# CHECK-NEXT: Block RThroughput: 2.5
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     0123456789
@@ -2234,14 +2234,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeeeeeeeER    .    .    .  .   ld2	{ v1.s, v2.s }[0], [x27], x28
 # CHECK-NEXT: [0,1]     D=eE------R    .    .    .  .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .D=======eeeeeeeeER .    .  .   ld2	{ v1.d, v2.d }[0], [x27], #16
-# CHECK-NEXT: [0,3]     .D========eE------R .    .  .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . D==============eeeeeeeeER .   ld2	{ v1.d, v2.d }[0], [x27], x28
-# CHECK-NEXT: [0,5]     . D===============eE------R .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  D==============eeeeeeeeER.   ld2r	{ v1.1d, v2.1d }, [x27], #16
-# CHECK-NEXT: [0,7]     .  D===============eE------R.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .   D==============eeeeeeeeER   ld2r	{ v1.2d, v2.2d }, [x27], #16
-# CHECK-NEXT: [0,9]     .   D===============eE------R   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D========eeeeeeeeER .    .  .   ld2	{ v1.d, v2.d }[0], [x27], #16
+# CHECK-NEXT: [0,3]     D=========eE------R .    .  .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D===============eeeeeeeeER .   ld2	{ v1.d, v2.d }[0], [x27], x28
+# CHECK-NEXT: [0,5]     .D================eE------R .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D================eeeeeeeeER.   ld2r	{ v1.1d, v2.1d }, [x27], #16
+# CHECK-NEXT: [0,7]     .D=================eE------R.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D================eeeeeeeeER   ld2r	{ v1.2d, v2.2d }, [x27], #16
+# CHECK-NEXT: [0,9]     . D=================eE------R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -2252,27 +2252,27 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ld2	{ v1.s, v2.s }[0], [x27], x28
 # CHECK-NEXT: 1.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     8.0    0.0    0.0       ld2	{ v1.d, v2.d }[0], [x27], #16
-# CHECK-NEXT: 3.     1     9.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     15.0   0.0    0.0       ld2	{ v1.d, v2.d }[0], [x27], x28
-# CHECK-NEXT: 5.     1     16.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     15.0   0.0    0.0       ld2r	{ v1.1d, v2.1d }, [x27], #16
-# CHECK-NEXT: 7.     1     16.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     15.0   0.0    0.0       ld2r	{ v1.2d, v2.2d }, [x27], #16
-# CHECK-NEXT: 9.     1     16.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        10    11.3   0.1    3.0       <total>
+# CHECK-NEXT: 2.     1     9.0    0.0    0.0       ld2	{ v1.d, v2.d }[0], [x27], #16
+# CHECK-NEXT: 3.     1     10.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     16.0   0.0    0.0       ld2	{ v1.d, v2.d }[0], [x27], x28
+# CHECK-NEXT: 5.     1     17.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     17.0   0.0    0.0       ld2r	{ v1.1d, v2.1d }, [x27], #16
+# CHECK-NEXT: 7.     1     18.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     17.0   0.0    0.0       ld2r	{ v1.2d, v2.2d }, [x27], #16
+# CHECK-NEXT: 9.     1     18.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT:        10    12.5   0.1    3.0       <total>
 
 # CHECK:      [24] Code Region - G25
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      510
-# CHECK-NEXT: Total uOps:        2500
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    4.90
+# CHECK-NEXT: uOps Per Cycle:    3.92
 # CHECK-NEXT: IPC:               1.96
-# CHECK-NEXT: Block RThroughput: 3.1
+# CHECK-NEXT: Block RThroughput: 2.5
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     01234
@@ -2280,14 +2280,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeeeeeeeER   .   ld2r	{ v1.2s, v2.2s }, [x27], #8
 # CHECK-NEXT: [0,1]     D=eE------R   .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeeeeeeeER  .   ld2r	{ v1.4h, v2.4h }, [x27], #4
-# CHECK-NEXT: [0,3]     .D=eE------R  .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . DeeeeeeeeER .   ld2r	{ v1.4s, v2.4s }, [x27], #8
-# CHECK-NEXT: [0,5]     . D=eE------R .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  DeeeeeeeeER.   ld2r	{ v1.8b, v2.8b }, [x27], #2
-# CHECK-NEXT: [0,7]     .  D=eE------R.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .   DeeeeeeeeER   ld2r	{ v1.8h, v2.8h }, [x27], #4
-# CHECK-NEXT: [0,9]     .   D=eE------R   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeeeeeER  .   ld2r	{ v1.4h, v2.4h }, [x27], #4
+# CHECK-NEXT: [0,3]     D==eE------R  .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D=eeeeeeeeER .   ld2r	{ v1.4s, v2.4s }, [x27], #8
+# CHECK-NEXT: [0,5]     .D==eE------R .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeeeeeeeER.   ld2r	{ v1.8b, v2.8b }, [x27], #2
+# CHECK-NEXT: [0,7]     .D===eE------R.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D==eeeeeeeeER   ld2r	{ v1.8h, v2.8h }, [x27], #4
+# CHECK-NEXT: [0,9]     . D===eE------R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -2298,27 +2298,27 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ld2r	{ v1.2s, v2.2s }, [x27], #8
 # CHECK-NEXT: 1.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld2r	{ v1.4h, v2.4h }, [x27], #4
-# CHECK-NEXT: 3.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld2r	{ v1.4s, v2.4s }, [x27], #8
-# CHECK-NEXT: 5.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     1.0    0.0    0.0       ld2r	{ v1.8b, v2.8b }, [x27], #2
-# CHECK-NEXT: 7.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld2r	{ v1.8h, v2.8h }, [x27], #4
-# CHECK-NEXT: 9.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.5    0.1    3.0       <total>
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld2r	{ v1.4h, v2.4h }, [x27], #4
+# CHECK-NEXT: 3.     1     3.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     2.0    0.0    0.0       ld2r	{ v1.4s, v2.4s }, [x27], #8
+# CHECK-NEXT: 5.     1     3.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       ld2r	{ v1.8b, v2.8b }, [x27], #2
+# CHECK-NEXT: 7.     1     4.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     3.0    0.0    0.0       ld2r	{ v1.8h, v2.8h }, [x27], #4
+# CHECK-NEXT: 9.     1     4.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT:        10    2.7    0.1    3.0       <total>
 
 # CHECK:      [25] Code Region - G26
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      510
-# CHECK-NEXT: Total uOps:        2500
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    4.90
+# CHECK-NEXT: uOps Per Cycle:    3.92
 # CHECK-NEXT: IPC:               1.96
-# CHECK-NEXT: Block RThroughput: 3.1
+# CHECK-NEXT: Block RThroughput: 2.5
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     01234
@@ -2326,14 +2326,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeeeeeeeER   .   ld2r	{ v1.16b, v2.16b }, [x27], #2
 # CHECK-NEXT: [0,1]     D=eE------R   .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeeeeeeeER  .   ld2r	{ v1.1d, v2.1d }, [x27], x28
-# CHECK-NEXT: [0,3]     .D=eE------R  .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . DeeeeeeeeER .   ld2r	{ v1.2d, v2.2d }, [x27], x28
-# CHECK-NEXT: [0,5]     . D=eE------R .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  DeeeeeeeeER.   ld2r	{ v1.2s, v2.2s }, [x27], x28
-# CHECK-NEXT: [0,7]     .  D=eE------R.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .   DeeeeeeeeER   ld2r	{ v1.4h, v2.4h }, [x27], x28
-# CHECK-NEXT: [0,9]     .   D=eE------R   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeeeeeER  .   ld2r	{ v1.1d, v2.1d }, [x27], x28
+# CHECK-NEXT: [0,3]     D==eE------R  .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D=eeeeeeeeER .   ld2r	{ v1.2d, v2.2d }, [x27], x28
+# CHECK-NEXT: [0,5]     .D==eE------R .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeeeeeeeER.   ld2r	{ v1.2s, v2.2s }, [x27], x28
+# CHECK-NEXT: [0,7]     .D===eE------R.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D==eeeeeeeeER   ld2r	{ v1.4h, v2.4h }, [x27], x28
+# CHECK-NEXT: [0,9]     . D===eE------R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -2344,27 +2344,27 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ld2r	{ v1.16b, v2.16b }, [x27], #2
 # CHECK-NEXT: 1.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld2r	{ v1.1d, v2.1d }, [x27], x28
-# CHECK-NEXT: 3.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld2r	{ v1.2d, v2.2d }, [x27], x28
-# CHECK-NEXT: 5.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     1.0    0.0    0.0       ld2r	{ v1.2s, v2.2s }, [x27], x28
-# CHECK-NEXT: 7.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld2r	{ v1.4h, v2.4h }, [x27], x28
-# CHECK-NEXT: 9.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.5    0.1    3.0       <total>
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld2r	{ v1.1d, v2.1d }, [x27], x28
+# CHECK-NEXT: 3.     1     3.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     2.0    0.0    0.0       ld2r	{ v1.2d, v2.2d }, [x27], x28
+# CHECK-NEXT: 5.     1     3.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       ld2r	{ v1.2s, v2.2s }, [x27], x28
+# CHECK-NEXT: 7.     1     4.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     3.0    0.0    0.0       ld2r	{ v1.4h, v2.4h }, [x27], x28
+# CHECK-NEXT: 9.     1     4.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT:        10    2.7    0.1    3.0       <total>
 
 # CHECK:      [26] Code Region - G27
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      510
-# CHECK-NEXT: Total uOps:        2800
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    5.49
+# CHECK-NEXT: uOps Per Cycle:    3.92
 # CHECK-NEXT: IPC:               1.96
-# CHECK-NEXT: Block RThroughput: 3.5
+# CHECK-NEXT: Block RThroughput: 2.8
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     01234
@@ -2372,14 +2372,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeeeeeeeER   .   ld2r	{ v1.4s, v2.4s }, [x27], x28
 # CHECK-NEXT: [0,1]     D=eE------R   .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeeeeeeeER  .   ld2r	{ v1.8b, v2.8b }, [x27], x28
-# CHECK-NEXT: [0,3]     .D=eE------R  .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . DeeeeeeeeER .   ld2r	{ v1.8h, v2.8h }, [x27], x28
-# CHECK-NEXT: [0,5]     . D=eE------R .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  DeeeeeeeeER.   ld2r	{ v1.16b, v2.16b }, [x27], x28
-# CHECK-NEXT: [0,7]     .  D=eE------R.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .   DeeeeeeeeER   ld3	{ v1.2d, v2.2d, v3.2d }, [x27], #48
-# CHECK-NEXT: [0,9]     .   D=eE------R   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeeeeeER  .   ld2r	{ v1.8b, v2.8b }, [x27], x28
+# CHECK-NEXT: [0,3]     D==eE------R  .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D=eeeeeeeeER .   ld2r	{ v1.8h, v2.8h }, [x27], x28
+# CHECK-NEXT: [0,5]     .D==eE------R .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeeeeeeeER.   ld2r	{ v1.16b, v2.16b }, [x27], x28
+# CHECK-NEXT: [0,7]     .D===eE------R.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D==eeeeeeeeER   ld3	{ v1.2d, v2.2d, v3.2d }, [x27], #48
+# CHECK-NEXT: [0,9]     . D===eE------R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -2390,27 +2390,27 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ld2r	{ v1.4s, v2.4s }, [x27], x28
 # CHECK-NEXT: 1.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld2r	{ v1.8b, v2.8b }, [x27], x28
-# CHECK-NEXT: 3.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld2r	{ v1.8h, v2.8h }, [x27], x28
-# CHECK-NEXT: 5.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     1.0    0.0    0.0       ld2r	{ v1.16b, v2.16b }, [x27], x28
-# CHECK-NEXT: 7.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld3	{ v1.2d, v2.2d, v3.2d }, [x27], #48
-# CHECK-NEXT: 9.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.5    0.1    3.0       <total>
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld2r	{ v1.8b, v2.8b }, [x27], x28
+# CHECK-NEXT: 3.     1     3.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     2.0    0.0    0.0       ld2r	{ v1.8h, v2.8h }, [x27], x28
+# CHECK-NEXT: 5.     1     3.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       ld2r	{ v1.16b, v2.16b }, [x27], x28
+# CHECK-NEXT: 7.     1     4.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     3.0    0.0    0.0       ld3	{ v1.2d, v2.2d, v3.2d }, [x27], #48
+# CHECK-NEXT: 9.     1     4.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT:        10    2.7    0.1    3.0       <total>
 
 # CHECK:      [27] Code Region - G28
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      510
-# CHECK-NEXT: Total uOps:        3700
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    7.25
+# CHECK-NEXT: uOps Per Cycle:    3.92
 # CHECK-NEXT: IPC:               1.96
-# CHECK-NEXT: Block RThroughput: 4.6
+# CHECK-NEXT: Block RThroughput: 4.0
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     01234
@@ -2418,14 +2418,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeeeeeeeER   .   ld3	{ v1.2s, v2.2s, v3.2s }, [x27], #24
 # CHECK-NEXT: [0,1]     D=eE------R   .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeeeeeeeER  .   ld3	{ v1.4h, v2.4h, v3.4h }, [x27], #24
-# CHECK-NEXT: [0,3]     .D=eE------R  .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . DeeeeeeeeER .   ld3	{ v1.4s, v2.4s, v3.4s }, [x27], #48
-# CHECK-NEXT: [0,5]     . D=eE------R .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  DeeeeeeeeER.   ld3	{ v1.8b, v2.8b, v3.8b }, [x27], #24
-# CHECK-NEXT: [0,7]     .  D=eE------R.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .   DeeeeeeeeER   ld3	{ v1.8h, v2.8h, v3.8h }, [x27], #48
-# CHECK-NEXT: [0,9]     .   D=eE------R   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeeeeeER  .   ld3	{ v1.4h, v2.4h, v3.4h }, [x27], #24
+# CHECK-NEXT: [0,3]     D==eE------R  .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D=eeeeeeeeER .   ld3	{ v1.4s, v2.4s, v3.4s }, [x27], #48
+# CHECK-NEXT: [0,5]     .D==eE------R .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeeeeeeeER.   ld3	{ v1.8b, v2.8b, v3.8b }, [x27], #24
+# CHECK-NEXT: [0,7]     .D===eE------R.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D==eeeeeeeeER   ld3	{ v1.8h, v2.8h, v3.8h }, [x27], #48
+# CHECK-NEXT: [0,9]     . D===eE------R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -2436,27 +2436,27 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ld3	{ v1.2s, v2.2s, v3.2s }, [x27], #24
 # CHECK-NEXT: 1.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld3	{ v1.4h, v2.4h, v3.4h }, [x27], #24
-# CHECK-NEXT: 3.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld3	{ v1.4s, v2.4s, v3.4s }, [x27], #48
-# CHECK-NEXT: 5.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     1.0    0.0    0.0       ld3	{ v1.8b, v2.8b, v3.8b }, [x27], #24
-# CHECK-NEXT: 7.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld3	{ v1.8h, v2.8h, v3.8h }, [x27], #48
-# CHECK-NEXT: 9.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.5    0.1    3.0       <total>
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld3	{ v1.4h, v2.4h, v3.4h }, [x27], #24
+# CHECK-NEXT: 3.     1     3.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     2.0    0.0    0.0       ld3	{ v1.4s, v2.4s, v3.4s }, [x27], #48
+# CHECK-NEXT: 5.     1     3.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       ld3	{ v1.8b, v2.8b, v3.8b }, [x27], #24
+# CHECK-NEXT: 7.     1     4.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     3.0    0.0    0.0       ld3	{ v1.8h, v2.8h, v3.8h }, [x27], #48
+# CHECK-NEXT: 9.     1     4.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT:        10    2.7    0.1    3.0       <total>
 
 # CHECK:      [28] Code Region - G29
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      510
-# CHECK-NEXT: Total uOps:        3800
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    7.45
+# CHECK-NEXT: uOps Per Cycle:    3.92
 # CHECK-NEXT: IPC:               1.96
-# CHECK-NEXT: Block RThroughput: 4.8
+# CHECK-NEXT: Block RThroughput: 4.3
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     01234
@@ -2464,14 +2464,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeeeeeeeER   .   ld3	{ v1.16b, v2.16b, v3.16b }, [x27], #48
 # CHECK-NEXT: [0,1]     D=eE------R   .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeeeeeeeER  .   ld3	{ v1.2d, v2.2d, v3.2d }, [x27], x28
-# CHECK-NEXT: [0,3]     .D=eE------R  .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . DeeeeeeeeER .   ld3	{ v1.2s, v2.2s, v3.2s }, [x27], x28
-# CHECK-NEXT: [0,5]     . D=eE------R .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  DeeeeeeeeER.   ld3	{ v1.4h, v2.4h, v3.4h }, [x27], x28
-# CHECK-NEXT: [0,7]     .  D=eE------R.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .   DeeeeeeeeER   ld3	{ v1.4s, v2.4s, v3.4s }, [x27], x28
-# CHECK-NEXT: [0,9]     .   D=eE------R   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeeeeeER  .   ld3	{ v1.2d, v2.2d, v3.2d }, [x27], x28
+# CHECK-NEXT: [0,3]     D==eE------R  .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D=eeeeeeeeER .   ld3	{ v1.2s, v2.2s, v3.2s }, [x27], x28
+# CHECK-NEXT: [0,5]     .D==eE------R .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeeeeeeeER.   ld3	{ v1.4h, v2.4h, v3.4h }, [x27], x28
+# CHECK-NEXT: [0,7]     .D===eE------R.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D==eeeeeeeeER   ld3	{ v1.4s, v2.4s, v3.4s }, [x27], x28
+# CHECK-NEXT: [0,9]     . D===eE------R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -2482,27 +2482,27 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ld3	{ v1.16b, v2.16b, v3.16b }, [x27], #48
 # CHECK-NEXT: 1.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld3	{ v1.2d, v2.2d, v3.2d }, [x27], x28
-# CHECK-NEXT: 3.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld3	{ v1.2s, v2.2s, v3.2s }, [x27], x28
-# CHECK-NEXT: 5.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     1.0    0.0    0.0       ld3	{ v1.4h, v2.4h, v3.4h }, [x27], x28
-# CHECK-NEXT: 7.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld3	{ v1.4s, v2.4s, v3.4s }, [x27], x28
-# CHECK-NEXT: 9.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.5    0.1    3.0       <total>
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld3	{ v1.2d, v2.2d, v3.2d }, [x27], x28
+# CHECK-NEXT: 3.     1     3.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     2.0    0.0    0.0       ld3	{ v1.2s, v2.2s, v3.2s }, [x27], x28
+# CHECK-NEXT: 5.     1     3.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       ld3	{ v1.4h, v2.4h, v3.4h }, [x27], x28
+# CHECK-NEXT: 7.     1     4.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     3.0    0.0    0.0       ld3	{ v1.4s, v2.4s, v3.4s }, [x27], x28
+# CHECK-NEXT: 9.     1     4.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT:        10    2.7    0.1    3.0       <total>
 
 # CHECK:      [29] Code Region - G30
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      1910
-# CHECK-NEXT: Total uOps:        3700
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    1.94
+# CHECK-NEXT: uOps Per Cycle:    1.05
 # CHECK-NEXT: IPC:               0.52
-# CHECK-NEXT: Block RThroughput: 4.6
+# CHECK-NEXT: Block RThroughput: 4.0
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     0123456789
@@ -2510,14 +2510,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeeeeeeeER    .    .    .  .   ld3	{ v1.8b, v2.8b, v3.8b }, [x27], x28
 # CHECK-NEXT: [0,1]     D=eE------R    .    .    .  .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeeeeeeeER   .    .    .  .   ld3	{ v1.8h, v2.8h, v3.8h }, [x27], x28
-# CHECK-NEXT: [0,3]     .D=eE------R   .    .    .  .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . DeeeeeeeeER  .    .    .  .   ld3	{ v1.16b, v2.16b, v3.16b }, [x27], x28
-# CHECK-NEXT: [0,5]     . D=eE------R  .    .    .  .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  D=======eeeeeeeeER    .  .   ld3	{ v1.b, v2.b, v3.b }[0], [x27], #3
-# CHECK-NEXT: [0,7]     .  D========eE------R    .  .   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .   D==============eeeeeeeeER   ld3	{ v1.b, v2.b, v3.b }[8], [x27], #3
-# CHECK-NEXT: [0,9]     .   D===============eE------R   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeeeeeER   .    .    .  .   ld3	{ v1.8h, v2.8h, v3.8h }, [x27], x28
+# CHECK-NEXT: [0,3]     D==eE------R   .    .    .  .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D=eeeeeeeeER  .    .    .  .   ld3	{ v1.16b, v2.16b, v3.16b }, [x27], x28
+# CHECK-NEXT: [0,5]     .D==eE------R  .    .    .  .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D=========eeeeeeeeER    .  .   ld3	{ v1.b, v2.b, v3.b }[0], [x27], #3
+# CHECK-NEXT: [0,7]     .D==========eE------R    .  .   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D================eeeeeeeeER   ld3	{ v1.b, v2.b, v3.b }[8], [x27], #3
+# CHECK-NEXT: [0,9]     . D=================eE------R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -2528,27 +2528,27 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ld3	{ v1.8b, v2.8b, v3.8b }, [x27], x28
 # CHECK-NEXT: 1.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld3	{ v1.8h, v2.8h, v3.8h }, [x27], x28
-# CHECK-NEXT: 3.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld3	{ v1.16b, v2.16b, v3.16b }, [x27], x28
-# CHECK-NEXT: 5.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     8.0    0.0    0.0       ld3	{ v1.b, v2.b, v3.b }[0], [x27], #3
-# CHECK-NEXT: 7.     1     9.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     15.0   0.0    0.0       ld3	{ v1.b, v2.b, v3.b }[8], [x27], #3
-# CHECK-NEXT: 9.     1     16.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        10    5.7    0.1    3.0       <total>
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld3	{ v1.8h, v2.8h, v3.8h }, [x27], x28
+# CHECK-NEXT: 3.     1     3.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     2.0    0.0    0.0       ld3	{ v1.16b, v2.16b, v3.16b }, [x27], x28
+# CHECK-NEXT: 5.     1     3.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     10.0   0.0    0.0       ld3	{ v1.b, v2.b, v3.b }[0], [x27], #3
+# CHECK-NEXT: 7.     1     11.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     17.0   0.0    0.0       ld3	{ v1.b, v2.b, v3.b }[8], [x27], #3
+# CHECK-NEXT: 9.     1     18.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT:        10    6.9    0.1    3.0       <total>
 
 # CHECK:      [30] Code Region - G31
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      4003
-# CHECK-NEXT: Total uOps:        3500
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    0.87
+# CHECK-NEXT: uOps Per Cycle:    0.50
 # CHECK-NEXT: IPC:               0.25
-# CHECK-NEXT: Block RThroughput: 4.4
+# CHECK-NEXT: Block RThroughput: 3.8
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     0123456789          0123456789
@@ -2556,14 +2556,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeeeeeeeER    .    .    .    .    .    . .   ld3	{ v1.b, v2.b, v3.b }[0], [x27], x28
 # CHECK-NEXT: [0,1]     D=eE------R    .    .    .    .    .    . .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .D=======eeeeeeeeER .    .    .    .    . .   ld3	{ v1.b, v2.b, v3.b }[8], [x27], x28
-# CHECK-NEXT: [0,3]     .D========eE------R .    .    .    .    . .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . D==============eeeeeeeeER   .    .    . .   ld3	{ v1.h, v2.h, v3.h }[0], [x27], #6
-# CHECK-NEXT: [0,5]     . D===============eE------R   .    .    . .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  D=====================eeeeeeeeER.    . .   ld3	{ v1.h, v2.h, v3.h }[4], [x27], #6
-# CHECK-NEXT: [0,7]     .  D======================eE------R.    . .   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .   D============================eeeeeeeeER   ld3	{ v1.h, v2.h, v3.h }[0], [x27], x28
-# CHECK-NEXT: [0,9]     .   D=============================eE------R   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D========eeeeeeeeER .    .    .    .    . .   ld3	{ v1.b, v2.b, v3.b }[8], [x27], x28
+# CHECK-NEXT: [0,3]     D=========eE------R .    .    .    .    . .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D===============eeeeeeeeER   .    .    . .   ld3	{ v1.h, v2.h, v3.h }[0], [x27], #6
+# CHECK-NEXT: [0,5]     .D================eE------R   .    .    . .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D=======================eeeeeeeeER.    . .   ld3	{ v1.h, v2.h, v3.h }[4], [x27], #6
+# CHECK-NEXT: [0,7]     .D========================eE------R.    . .   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D==============================eeeeeeeeER   ld3	{ v1.h, v2.h, v3.h }[0], [x27], x28
+# CHECK-NEXT: [0,9]     . D===============================eE------R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -2574,27 +2574,27 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ld3	{ v1.b, v2.b, v3.b }[0], [x27], x28
 # CHECK-NEXT: 1.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     8.0    0.0    0.0       ld3	{ v1.b, v2.b, v3.b }[8], [x27], x28
-# CHECK-NEXT: 3.     1     9.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     15.0   0.0    0.0       ld3	{ v1.h, v2.h, v3.h }[0], [x27], #6
-# CHECK-NEXT: 5.     1     16.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     22.0   0.0    0.0       ld3	{ v1.h, v2.h, v3.h }[4], [x27], #6
-# CHECK-NEXT: 7.     1     23.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     29.0   0.0    0.0       ld3	{ v1.h, v2.h, v3.h }[0], [x27], x28
-# CHECK-NEXT: 9.     1     30.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        10    15.5   0.1    3.0       <total>
+# CHECK-NEXT: 2.     1     9.0    0.0    0.0       ld3	{ v1.b, v2.b, v3.b }[8], [x27], x28
+# CHECK-NEXT: 3.     1     10.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     16.0   0.0    0.0       ld3	{ v1.h, v2.h, v3.h }[0], [x27], #6
+# CHECK-NEXT: 5.     1     17.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     24.0   0.0    0.0       ld3	{ v1.h, v2.h, v3.h }[4], [x27], #6
+# CHECK-NEXT: 7.     1     25.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     31.0   0.0    0.0       ld3	{ v1.h, v2.h, v3.h }[0], [x27], x28
+# CHECK-NEXT: 9.     1     32.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT:        10    16.7   0.1    3.0       <total>
 
 # CHECK:      [31] Code Region - G32
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      4003
-# CHECK-NEXT: Total uOps:        3500
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    0.87
+# CHECK-NEXT: uOps Per Cycle:    0.50
 # CHECK-NEXT: IPC:               0.25
-# CHECK-NEXT: Block RThroughput: 4.4
+# CHECK-NEXT: Block RThroughput: 3.8
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     0123456789          0123456789
@@ -2602,14 +2602,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeeeeeeeER    .    .    .    .    .    . .   ld3	{ v1.h, v2.h, v3.h }[4], [x27], x28
 # CHECK-NEXT: [0,1]     D=eE------R    .    .    .    .    .    . .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .D=======eeeeeeeeER .    .    .    .    . .   ld3	{ v1.s, v2.s, v3.s }[0], [x27], #12
-# CHECK-NEXT: [0,3]     .D========eE------R .    .    .    .    . .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . D==============eeeeeeeeER   .    .    . .   ld3	{ v1.s, v2.s, v3.s }[0], [x27], x28
-# CHECK-NEXT: [0,5]     . D===============eE------R   .    .    . .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  D=====================eeeeeeeeER.    . .   ld3	{ v1.d, v2.d, v3.d }[0], [x27], #24
-# CHECK-NEXT: [0,7]     .  D======================eE------R.    . .   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .   D============================eeeeeeeeER   ld3	{ v1.d, v2.d, v3.d }[0], [x27], x28
-# CHECK-NEXT: [0,9]     .   D=============================eE------R   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D========eeeeeeeeER .    .    .    .    . .   ld3	{ v1.s, v2.s, v3.s }[0], [x27], #12
+# CHECK-NEXT: [0,3]     D=========eE------R .    .    .    .    . .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D===============eeeeeeeeER   .    .    . .   ld3	{ v1.s, v2.s, v3.s }[0], [x27], x28
+# CHECK-NEXT: [0,5]     .D================eE------R   .    .    . .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D=======================eeeeeeeeER.    . .   ld3	{ v1.d, v2.d, v3.d }[0], [x27], #24
+# CHECK-NEXT: [0,7]     .D========================eE------R.    . .   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D==============================eeeeeeeeER   ld3	{ v1.d, v2.d, v3.d }[0], [x27], x28
+# CHECK-NEXT: [0,9]     . D===============================eE------R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -2620,27 +2620,27 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ld3	{ v1.h, v2.h, v3.h }[4], [x27], x28
 # CHECK-NEXT: 1.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     8.0    0.0    0.0       ld3	{ v1.s, v2.s, v3.s }[0], [x27], #12
-# CHECK-NEXT: 3.     1     9.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     15.0   0.0    0.0       ld3	{ v1.s, v2.s, v3.s }[0], [x27], x28
-# CHECK-NEXT: 5.     1     16.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     22.0   0.0    0.0       ld3	{ v1.d, v2.d, v3.d }[0], [x27], #24
-# CHECK-NEXT: 7.     1     23.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     29.0   0.0    0.0       ld3	{ v1.d, v2.d, v3.d }[0], [x27], x28
-# CHECK-NEXT: 9.     1     30.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        10    15.5   0.1    3.0       <total>
+# CHECK-NEXT: 2.     1     9.0    0.0    0.0       ld3	{ v1.s, v2.s, v3.s }[0], [x27], #12
+# CHECK-NEXT: 3.     1     10.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     16.0   0.0    0.0       ld3	{ v1.s, v2.s, v3.s }[0], [x27], x28
+# CHECK-NEXT: 5.     1     17.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     24.0   0.0    0.0       ld3	{ v1.d, v2.d, v3.d }[0], [x27], #24
+# CHECK-NEXT: 7.     1     25.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     31.0   0.0    0.0       ld3	{ v1.d, v2.d, v3.d }[0], [x27], x28
+# CHECK-NEXT: 9.     1     32.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT:        10    16.7   0.1    3.0       <total>
 
 # CHECK:      [32] Code Region - G33
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      510
-# CHECK-NEXT: Total uOps:        3500
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    6.86
+# CHECK-NEXT: uOps Per Cycle:    3.92
 # CHECK-NEXT: IPC:               1.96
-# CHECK-NEXT: Block RThroughput: 4.4
+# CHECK-NEXT: Block RThroughput: 3.8
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     01234
@@ -2648,14 +2648,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeeeeeeeER   .   ld3r	{ v1.1d, v2.1d, v3.1d }, [x27], #24
 # CHECK-NEXT: [0,1]     D=eE------R   .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeeeeeeeER  .   ld3r	{ v1.2d, v2.2d, v3.2d }, [x27], #24
-# CHECK-NEXT: [0,3]     .D=eE------R  .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . DeeeeeeeeER .   ld3r	{ v1.2s, v2.2s, v3.2s }, [x27], #12
-# CHECK-NEXT: [0,5]     . D=eE------R .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  DeeeeeeeeER.   ld3r	{ v1.4h, v2.4h, v3.4h }, [x27], #6
-# CHECK-NEXT: [0,7]     .  D=eE------R.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .   DeeeeeeeeER   ld3r	{ v1.4s, v2.4s, v3.4s }, [x27], #12
-# CHECK-NEXT: [0,9]     .   D=eE------R   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeeeeeER  .   ld3r	{ v1.2d, v2.2d, v3.2d }, [x27], #24
+# CHECK-NEXT: [0,3]     D==eE------R  .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D=eeeeeeeeER .   ld3r	{ v1.2s, v2.2s, v3.2s }, [x27], #12
+# CHECK-NEXT: [0,5]     .D==eE------R .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeeeeeeeER.   ld3r	{ v1.4h, v2.4h, v3.4h }, [x27], #6
+# CHECK-NEXT: [0,7]     .D===eE------R.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D==eeeeeeeeER   ld3r	{ v1.4s, v2.4s, v3.4s }, [x27], #12
+# CHECK-NEXT: [0,9]     . D===eE------R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -2666,27 +2666,27 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ld3r	{ v1.1d, v2.1d, v3.1d }, [x27], #24
 # CHECK-NEXT: 1.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld3r	{ v1.2d, v2.2d, v3.2d }, [x27], #24
-# CHECK-NEXT: 3.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld3r	{ v1.2s, v2.2s, v3.2s }, [x27], #12
-# CHECK-NEXT: 5.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     1.0    0.0    0.0       ld3r	{ v1.4h, v2.4h, v3.4h }, [x27], #6
-# CHECK-NEXT: 7.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld3r	{ v1.4s, v2.4s, v3.4s }, [x27], #12
-# CHECK-NEXT: 9.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.5    0.1    3.0       <total>
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld3r	{ v1.2d, v2.2d, v3.2d }, [x27], #24
+# CHECK-NEXT: 3.     1     3.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     2.0    0.0    0.0       ld3r	{ v1.2s, v2.2s, v3.2s }, [x27], #12
+# CHECK-NEXT: 5.     1     3.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       ld3r	{ v1.4h, v2.4h, v3.4h }, [x27], #6
+# CHECK-NEXT: 7.     1     4.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     3.0    0.0    0.0       ld3r	{ v1.4s, v2.4s, v3.4s }, [x27], #12
+# CHECK-NEXT: 9.     1     4.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT:        10    2.7    0.1    3.0       <total>
 
 # CHECK:      [33] Code Region - G34
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      510
-# CHECK-NEXT: Total uOps:        3500
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    6.86
+# CHECK-NEXT: uOps Per Cycle:    3.92
 # CHECK-NEXT: IPC:               1.96
-# CHECK-NEXT: Block RThroughput: 4.4
+# CHECK-NEXT: Block RThroughput: 3.8
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     01234
@@ -2694,14 +2694,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeeeeeeeER   .   ld3r	{ v1.8b, v2.8b, v3.8b }, [x27], #3
 # CHECK-NEXT: [0,1]     D=eE------R   .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeeeeeeeER  .   ld3r	{ v1.8h, v2.8h, v3.8h }, [x27], #6
-# CHECK-NEXT: [0,3]     .D=eE------R  .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . DeeeeeeeeER .   ld3r	{ v1.16b, v2.16b, v3.16b }, [x27], #3
-# CHECK-NEXT: [0,5]     . D=eE------R .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  DeeeeeeeeER.   ld3r	{ v1.1d, v2.1d, v3.1d }, [x27], x28
-# CHECK-NEXT: [0,7]     .  D=eE------R.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .   DeeeeeeeeER   ld3r	{ v1.2d, v2.2d, v3.2d }, [x27], x28
-# CHECK-NEXT: [0,9]     .   D=eE------R   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeeeeeER  .   ld3r	{ v1.8h, v2.8h, v3.8h }, [x27], #6
+# CHECK-NEXT: [0,3]     D==eE------R  .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D=eeeeeeeeER .   ld3r	{ v1.16b, v2.16b, v3.16b }, [x27], #3
+# CHECK-NEXT: [0,5]     .D==eE------R .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeeeeeeeER.   ld3r	{ v1.1d, v2.1d, v3.1d }, [x27], x28
+# CHECK-NEXT: [0,7]     .D===eE------R.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D==eeeeeeeeER   ld3r	{ v1.2d, v2.2d, v3.2d }, [x27], x28
+# CHECK-NEXT: [0,9]     . D===eE------R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -2712,27 +2712,27 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ld3r	{ v1.8b, v2.8b, v3.8b }, [x27], #3
 # CHECK-NEXT: 1.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld3r	{ v1.8h, v2.8h, v3.8h }, [x27], #6
-# CHECK-NEXT: 3.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld3r	{ v1.16b, v2.16b, v3.16b }, [x27], #3
-# CHECK-NEXT: 5.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     1.0    0.0    0.0       ld3r	{ v1.1d, v2.1d, v3.1d }, [x27], x28
-# CHECK-NEXT: 7.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld3r	{ v1.2d, v2.2d, v3.2d }, [x27], x28
-# CHECK-NEXT: 9.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.5    0.1    3.0       <total>
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld3r	{ v1.8h, v2.8h, v3.8h }, [x27], #6
+# CHECK-NEXT: 3.     1     3.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     2.0    0.0    0.0       ld3r	{ v1.16b, v2.16b, v3.16b }, [x27], #3
+# CHECK-NEXT: 5.     1     3.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       ld3r	{ v1.1d, v2.1d, v3.1d }, [x27], x28
+# CHECK-NEXT: 7.     1     4.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     3.0    0.0    0.0       ld3r	{ v1.2d, v2.2d, v3.2d }, [x27], x28
+# CHECK-NEXT: 9.     1     4.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT:        10    2.7    0.1    3.0       <total>
 
 # CHECK:      [34] Code Region - G35
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      510
-# CHECK-NEXT: Total uOps:        3500
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    6.86
+# CHECK-NEXT: uOps Per Cycle:    3.92
 # CHECK-NEXT: IPC:               1.96
-# CHECK-NEXT: Block RThroughput: 4.4
+# CHECK-NEXT: Block RThroughput: 3.8
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     01234
@@ -2740,14 +2740,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeeeeeeeER   .   ld3r	{ v1.2s, v2.2s, v3.2s }, [x27], x28
 # CHECK-NEXT: [0,1]     D=eE------R   .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeeeeeeeER  .   ld3r	{ v1.4h, v2.4h, v3.4h }, [x27], x28
-# CHECK-NEXT: [0,3]     .D=eE------R  .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . DeeeeeeeeER .   ld3r	{ v1.4s, v2.4s, v3.4s }, [x27], x28
-# CHECK-NEXT: [0,5]     . D=eE------R .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  DeeeeeeeeER.   ld3r	{ v1.8b, v2.8b, v3.8b }, [x27], x28
-# CHECK-NEXT: [0,7]     .  D=eE------R.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .   DeeeeeeeeER   ld3r	{ v1.8h, v2.8h, v3.8h }, [x27], x28
-# CHECK-NEXT: [0,9]     .   D=eE------R   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeeeeeER  .   ld3r	{ v1.4h, v2.4h, v3.4h }, [x27], x28
+# CHECK-NEXT: [0,3]     D==eE------R  .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D=eeeeeeeeER .   ld3r	{ v1.4s, v2.4s, v3.4s }, [x27], x28
+# CHECK-NEXT: [0,5]     .D==eE------R .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeeeeeeeER.   ld3r	{ v1.8b, v2.8b, v3.8b }, [x27], x28
+# CHECK-NEXT: [0,7]     .D===eE------R.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D==eeeeeeeeER   ld3r	{ v1.8h, v2.8h, v3.8h }, [x27], x28
+# CHECK-NEXT: [0,9]     . D===eE------R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -2758,42 +2758,42 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ld3r	{ v1.2s, v2.2s, v3.2s }, [x27], x28
 # CHECK-NEXT: 1.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld3r	{ v1.4h, v2.4h, v3.4h }, [x27], x28
-# CHECK-NEXT: 3.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld3r	{ v1.4s, v2.4s, v3.4s }, [x27], x28
-# CHECK-NEXT: 5.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     1.0    0.0    0.0       ld3r	{ v1.8b, v2.8b, v3.8b }, [x27], x28
-# CHECK-NEXT: 7.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld3r	{ v1.8h, v2.8h, v3.8h }, [x27], x28
-# CHECK-NEXT: 9.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.5    0.1    3.0       <total>
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld3r	{ v1.4h, v2.4h, v3.4h }, [x27], x28
+# CHECK-NEXT: 3.     1     3.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     2.0    0.0    0.0       ld3r	{ v1.4s, v2.4s, v3.4s }, [x27], x28
+# CHECK-NEXT: 5.     1     3.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       ld3r	{ v1.8b, v2.8b, v3.8b }, [x27], x28
+# CHECK-NEXT: 7.     1     4.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     3.0    0.0    0.0       ld3r	{ v1.8h, v2.8h, v3.8h }, [x27], x28
+# CHECK-NEXT: 9.     1     4.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT:        10    2.7    0.1    3.0       <total>
 
 # CHECK:      [35] Code Region - G36
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
-# CHECK-NEXT: Total Cycles:      910
-# CHECK-NEXT: Total uOps:        4500
+# CHECK-NEXT: Total Cycles:      611
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    4.95
-# CHECK-NEXT: IPC:               1.10
-# CHECK-NEXT: Block RThroughput: 5.6
+# CHECK-NEXT: uOps Per Cycle:    3.27
+# CHECK-NEXT: IPC:               1.64
+# CHECK-NEXT: Block RThroughput: 5.3
 
 # CHECK:      Timeline view:
-# CHECK-NEXT:                     012345678
+# CHECK-NEXT:                     0123456
 # CHECK-NEXT: Index     0123456789
 
-# CHECK:      [0,0]     DeeeeeeeeER    .  .   ld3r	{ v1.16b, v2.16b, v3.16b }, [x27], x28
-# CHECK-NEXT: [0,1]     D=eE------R    .  .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeeeeeeeeER  .  .   ld4	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
-# CHECK-NEXT: [0,3]     . DeE-------R  .  .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     .  DeeeeeeeeER .  .   ld4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
-# CHECK-NEXT: [0,5]     .   DeE------R .  .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .    DeeeeeeeeER  .   ld4	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #32
-# CHECK-NEXT: [0,7]     .    .DeE------R  .   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .    . DeeeeeeeeeER   ld4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
-# CHECK-NEXT: [0,9]     .    .  DeE-------R   add	x0, x27, #1
+# CHECK:      [0,0]     DeeeeeeeeER    ..   ld3r	{ v1.16b, v2.16b, v3.16b }, [x27], x28
+# CHECK-NEXT: [0,1]     D=eE------R    ..   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeeeeeeER  ..   ld4	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
+# CHECK-NEXT: [0,3]     D==eE-------R  ..   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D=eeeeeeeeER  ..   ld4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
+# CHECK-NEXT: [0,5]     .D==eE------R  ..   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeeeeeeeER ..   ld4	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #32
+# CHECK-NEXT: [0,7]     .D===eE------R ..   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D===eeeeeeeeeER   ld4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
+# CHECK-NEXT: [0,9]     . D====eE-------R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -2804,42 +2804,42 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ld3r	{ v1.16b, v2.16b, v3.16b }, [x27], x28
 # CHECK-NEXT: 1.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld4	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
-# CHECK-NEXT: 3.     1     1.0    0.0    7.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    1.0    0.0       ld4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
-# CHECK-NEXT: 5.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     1.0    1.0    0.0       ld4	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #32
-# CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
-# CHECK-NEXT: 9.     1     1.0    0.0    7.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.1    0.4    3.2       <total>
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld4	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
+# CHECK-NEXT: 3.     1     3.0    0.0    7.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     2.0    0.0    0.0       ld4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
+# CHECK-NEXT: 5.     1     3.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       ld4	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #32
+# CHECK-NEXT: 7.     1     4.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     4.0    1.0    0.0       ld4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
+# CHECK-NEXT: 9.     1     5.0    0.0    7.0       add	x0, x27, #1
+# CHECK-NEXT:        10    2.9    0.2    3.2       <total>
 
 # CHECK:      [36] Code Region - G37
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
-# CHECK-NEXT: Total Cycles:      1009
-# CHECK-NEXT: Total uOps:        4800
+# CHECK-NEXT: Total Cycles:      610
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    4.76
-# CHECK-NEXT: IPC:               0.99
+# CHECK-NEXT: uOps Per Cycle:    3.28
+# CHECK-NEXT: IPC:               1.64
 # CHECK-NEXT: Block RThroughput: 6.0
 
 # CHECK:      Timeline view:
-# CHECK-NEXT:                     012345678
+# CHECK-NEXT:                     012345
 # CHECK-NEXT: Index     0123456789
 
-# CHECK:      [0,0]     DeeeeeeeeER    .  .   ld4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #32
-# CHECK-NEXT: [0,1]     .DeE------R    .  .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     . DeeeeeeeeeER .  .   ld4	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
-# CHECK-NEXT: [0,3]     .  DeE-------R .  .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     .   DeeeeeeeeeER  .   ld4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
-# CHECK-NEXT: [0,5]     .    DeE-------R  .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .    .DeeeeeeeeeER.   ld4	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], x28
-# CHECK-NEXT: [0,7]     .    . DeE-------R.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .    .  DeeeeeeeeER   ld4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
-# CHECK-NEXT: [0,9]     .    .   DeE------R   add	x0, x27, #1
+# CHECK:      [0,0]     DeeeeeeeeER    .   ld4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #32
+# CHECK-NEXT: [0,1]     D=eE------R    .   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeeeeeeER  .   ld4	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
+# CHECK-NEXT: [0,3]     D==eE-------R  .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D=eeeeeeeeeER .   ld4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
+# CHECK-NEXT: [0,5]     .D==eE-------R .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeeeeeeeeER.   ld4	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], x28
+# CHECK-NEXT: [0,7]     .D===eE-------R.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D===eeeeeeeeER   ld4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
+# CHECK-NEXT: [0,9]     . D====eE------R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -2849,43 +2849,43 @@ add x0, x27, 1
 
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ld4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #32
-# CHECK-NEXT: 1.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    1.0    0.0       ld4	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
-# CHECK-NEXT: 3.     1     1.0    0.0    7.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    1.0    0.0       ld4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
-# CHECK-NEXT: 5.     1     1.0    0.0    7.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     1.0    1.0    0.0       ld4	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], x28
-# CHECK-NEXT: 7.     1     1.0    0.0    7.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
-# CHECK-NEXT: 9.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.0    0.5    3.3       <total>
+# CHECK-NEXT: 1.     1     2.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld4	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
+# CHECK-NEXT: 3.     1     3.0    0.0    7.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     2.0    0.0    0.0       ld4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
+# CHECK-NEXT: 5.     1     3.0    0.0    7.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       ld4	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], x28
+# CHECK-NEXT: 7.     1     4.0    0.0    7.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     4.0    1.0    0.0       ld4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
+# CHECK-NEXT: 9.     1     5.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT:        10    2.9    0.2    3.3       <total>
 
 # CHECK:      [37] Code Region - G38
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
-# CHECK-NEXT: Total Cycles:      1010
-# CHECK-NEXT: Total uOps:        4800
+# CHECK-NEXT: Total Cycles:      660
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    4.75
-# CHECK-NEXT: IPC:               0.99
+# CHECK-NEXT: uOps Per Cycle:    3.03
+# CHECK-NEXT: IPC:               1.52
 # CHECK-NEXT: Block RThroughput: 6.0
 
 # CHECK:      Timeline view:
-# CHECK-NEXT:                     0123456789
+# CHECK-NEXT:                     0123456
 # CHECK-NEXT: Index     0123456789
 
-# CHECK:      [0,0]     DeeeeeeeeER    .   .   ld4	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
-# CHECK-NEXT: [0,1]     .DeE------R    .   .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     . DeeeeeeeeeER .   .   ld4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
-# CHECK-NEXT: [0,3]     .  DeE-------R .   .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     .   DeeeeeeeeER.   .   ld4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
-# CHECK-NEXT: [0,5]     .    DeE------R.   .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .    .DeeeeeeeeeER .   ld4	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], x28
-# CHECK-NEXT: [0,7]     .    . DeE-------R .   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .    .  DeeeeeeeeeER   ld4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
-# CHECK-NEXT: [0,9]     .    .   DeE-------R   add	x0, x27, #1
+# CHECK:      [0,0]     DeeeeeeeeER    ..   ld4	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
+# CHECK-NEXT: [0,1]     D=eE------R    ..   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeeeeeeER  ..   ld4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
+# CHECK-NEXT: [0,3]     D==eE-------R  ..   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D=eeeeeeeeER  ..   ld4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
+# CHECK-NEXT: [0,5]     .D==eE------R  ..   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeeeeeeeeER..   ld4	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], x28
+# CHECK-NEXT: [0,7]     .D===eE-------R..   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D===eeeeeeeeeER   ld4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
+# CHECK-NEXT: [0,9]     . D====eE-------R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -2895,43 +2895,43 @@ add x0, x27, 1
 
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ld4	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
-# CHECK-NEXT: 1.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    1.0    0.0       ld4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
-# CHECK-NEXT: 3.     1     1.0    0.0    7.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    1.0    0.0       ld4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
-# CHECK-NEXT: 5.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     1.0    1.0    0.0       ld4	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], x28
-# CHECK-NEXT: 7.     1     1.0    0.0    7.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
-# CHECK-NEXT: 9.     1     1.0    0.0    7.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.0    0.5    3.3       <total>
+# CHECK-NEXT: 1.     1     2.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
+# CHECK-NEXT: 3.     1     3.0    0.0    7.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     2.0    0.0    0.0       ld4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
+# CHECK-NEXT: 5.     1     3.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       ld4	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], x28
+# CHECK-NEXT: 7.     1     4.0    0.0    7.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     4.0    1.0    0.0       ld4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
+# CHECK-NEXT: 9.     1     5.0    0.0    7.0       add	x0, x27, #1
+# CHECK-NEXT:        10    2.9    0.2    3.3       <total>
 
 # CHECK:      [38] Code Region - G39
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      4003
-# CHECK-NEXT: Total uOps:        4500
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    1.12
+# CHECK-NEXT: uOps Per Cycle:    0.50
 # CHECK-NEXT: IPC:               0.25
-# CHECK-NEXT: Block RThroughput: 5.6
+# CHECK-NEXT: Block RThroughput: 5.0
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     0123456789          0123456789
 # CHECK-NEXT: Index     0123456789          0123456789          012
 
 # CHECK:      [0,0]     DeeeeeeeeER    .    .    .    .    .    . .   ld4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], #4
-# CHECK-NEXT: [0,1]     .DeE------R    .    .    .    .    .    . .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     . D======eeeeeeeeER .    .    .    .    . .   ld4	{ v1.b, v2.b, v3.b, v4.b }[8], [x27], #4
-# CHECK-NEXT: [0,3]     .  D======eE------R .    .    .    .    . .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     .   D============eeeeeeeeER   .    .    . .   ld4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], x28
-# CHECK-NEXT: [0,5]     .    D============eE------R   .    .    . .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .    .D==================eeeeeeeeER.    . .   ld4	{ v1.b, v2.b, v3.b, v4.b }[8], [x27], x28
-# CHECK-NEXT: [0,7]     .    . D==================eE------R.    . .   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .    .  D========================eeeeeeeeER   ld4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], #8
-# CHECK-NEXT: [0,9]     .    .   D========================eE------R   add	x0, x27, #1
+# CHECK-NEXT: [0,1]     D=eE------R    .    .    .    .    .    . .   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D========eeeeeeeeER .    .    .    .    . .   ld4	{ v1.b, v2.b, v3.b, v4.b }[8], [x27], #4
+# CHECK-NEXT: [0,3]     D=========eE------R .    .    .    .    . .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D===============eeeeeeeeER   .    .    . .   ld4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], x28
+# CHECK-NEXT: [0,5]     .D================eE------R   .    .    . .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D=======================eeeeeeeeER.    . .   ld4	{ v1.b, v2.b, v3.b, v4.b }[8], [x27], x28
+# CHECK-NEXT: [0,7]     .D========================eE------R.    . .   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D==============================eeeeeeeeER   ld4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], #8
+# CHECK-NEXT: [0,9]     . D===============================eE------R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -2941,43 +2941,43 @@ add x0, x27, 1
 
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ld4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], #4
-# CHECK-NEXT: 1.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     7.0    0.0    0.0       ld4	{ v1.b, v2.b, v3.b, v4.b }[8], [x27], #4
-# CHECK-NEXT: 3.     1     7.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     13.0   0.0    0.0       ld4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], x28
-# CHECK-NEXT: 5.     1     13.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     19.0   0.0    0.0       ld4	{ v1.b, v2.b, v3.b, v4.b }[8], [x27], x28
-# CHECK-NEXT: 7.     1     19.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     25.0   0.0    0.0       ld4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], #8
-# CHECK-NEXT: 9.     1     25.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        10    13.0   0.1    3.0       <total>
+# CHECK-NEXT: 1.     1     2.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 2.     1     9.0    0.0    0.0       ld4	{ v1.b, v2.b, v3.b, v4.b }[8], [x27], #4
+# CHECK-NEXT: 3.     1     10.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     16.0   0.0    0.0       ld4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], x28
+# CHECK-NEXT: 5.     1     17.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     24.0   0.0    0.0       ld4	{ v1.b, v2.b, v3.b, v4.b }[8], [x27], x28
+# CHECK-NEXT: 7.     1     25.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     31.0   0.0    0.0       ld4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], #8
+# CHECK-NEXT: 9.     1     32.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT:        10    16.7   0.1    3.0       <total>
 
 # CHECK:      [39] Code Region - G40
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      4003
-# CHECK-NEXT: Total uOps:        4500
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    1.12
+# CHECK-NEXT: uOps Per Cycle:    0.50
 # CHECK-NEXT: IPC:               0.25
-# CHECK-NEXT: Block RThroughput: 5.6
+# CHECK-NEXT: Block RThroughput: 5.0
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     0123456789          0123456789
 # CHECK-NEXT: Index     0123456789          0123456789          012
 
 # CHECK:      [0,0]     DeeeeeeeeER    .    .    .    .    .    . .   ld4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], #8
-# CHECK-NEXT: [0,1]     .DeE------R    .    .    .    .    .    . .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     . D======eeeeeeeeER .    .    .    .    . .   ld4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], x28
-# CHECK-NEXT: [0,3]     .  D======eE------R .    .    .    .    . .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     .   D============eeeeeeeeER   .    .    . .   ld4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], x28
-# CHECK-NEXT: [0,5]     .    D============eE------R   .    .    . .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .    .D==================eeeeeeeeER.    . .   ld4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], #16
-# CHECK-NEXT: [0,7]     .    . D==================eE------R.    . .   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .    .  D========================eeeeeeeeER   ld4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], x28
-# CHECK-NEXT: [0,9]     .    .   D========================eE------R   add	x0, x27, #1
+# CHECK-NEXT: [0,1]     D=eE------R    .    .    .    .    .    . .   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D========eeeeeeeeER .    .    .    .    . .   ld4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], x28
+# CHECK-NEXT: [0,3]     D=========eE------R .    .    .    .    . .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D===============eeeeeeeeER   .    .    . .   ld4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], x28
+# CHECK-NEXT: [0,5]     .D================eE------R   .    .    . .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D=======================eeeeeeeeER.    . .   ld4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], #16
+# CHECK-NEXT: [0,7]     .D========================eE------R.    . .   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D==============================eeeeeeeeER   ld4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], x28
+# CHECK-NEXT: [0,9]     . D===============================eE------R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -2987,43 +2987,43 @@ add x0, x27, 1
 
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ld4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], #8
-# CHECK-NEXT: 1.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     7.0    0.0    0.0       ld4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], x28
-# CHECK-NEXT: 3.     1     7.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     13.0   0.0    0.0       ld4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], x28
-# CHECK-NEXT: 5.     1     13.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     19.0   0.0    0.0       ld4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], #16
-# CHECK-NEXT: 7.     1     19.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     25.0   0.0    0.0       ld4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], x28
-# CHECK-NEXT: 9.     1     25.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        10    13.0   0.1    3.0       <total>
+# CHECK-NEXT: 1.     1     2.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 2.     1     9.0    0.0    0.0       ld4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], x28
+# CHECK-NEXT: 3.     1     10.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     16.0   0.0    0.0       ld4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], x28
+# CHECK-NEXT: 5.     1     17.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     24.0   0.0    0.0       ld4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], #16
+# CHECK-NEXT: 7.     1     25.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     31.0   0.0    0.0       ld4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], x28
+# CHECK-NEXT: 9.     1     32.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT:        10    16.7   0.1    3.0       <total>
 
 # CHECK:      [40] Code Region - G41
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      1903
-# CHECK-NEXT: Total uOps:        4500
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    2.36
+# CHECK-NEXT: uOps Per Cycle:    1.05
 # CHECK-NEXT: IPC:               0.53
-# CHECK-NEXT: Block RThroughput: 5.6
+# CHECK-NEXT: Block RThroughput: 5.0
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     0123456789
 # CHECK-NEXT: Index     0123456789          01
 
 # CHECK:      [0,0]     DeeeeeeeeER    .    ..   ld4	{ v1.d, v2.d, v3.d, v4.d }[0], [x27], #32
-# CHECK-NEXT: [0,1]     .DeE------R    .    ..   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     . D======eeeeeeeeER ..   ld4	{ v1.d, v2.d, v3.d, v4.d }[0], [x27], x28
-# CHECK-NEXT: [0,3]     .  D======eE------R ..   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     .   D=====eeeeeeeeER..   ld4r	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], #32
-# CHECK-NEXT: [0,5]     .    D=====eE------R..   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .    .D====eeeeeeeeER.   ld4r	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #32
-# CHECK-NEXT: [0,7]     .    . D====eE------R.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .    .  D===eeeeeeeeER   ld4r	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #16
-# CHECK-NEXT: [0,9]     .    .   D===eE------R   add	x0, x27, #1
+# CHECK-NEXT: [0,1]     D=eE------R    .    ..   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D========eeeeeeeeER ..   ld4	{ v1.d, v2.d, v3.d, v4.d }[0], [x27], x28
+# CHECK-NEXT: [0,3]     D=========eE------R ..   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D========eeeeeeeeER..   ld4r	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], #32
+# CHECK-NEXT: [0,5]     .D=========eE------R..   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D=========eeeeeeeeER.   ld4r	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #32
+# CHECK-NEXT: [0,7]     .D==========eE------R.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D=========eeeeeeeeER   ld4r	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #16
+# CHECK-NEXT: [0,9]     . D==========eE------R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -3033,43 +3033,43 @@ add x0, x27, 1
 
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ld4	{ v1.d, v2.d, v3.d, v4.d }[0], [x27], #32
-# CHECK-NEXT: 1.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     7.0    0.0    0.0       ld4	{ v1.d, v2.d, v3.d, v4.d }[0], [x27], x28
-# CHECK-NEXT: 3.     1     7.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     6.0    0.0    0.0       ld4r	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], #32
-# CHECK-NEXT: 5.     1     6.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     5.0    0.0    0.0       ld4r	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #32
-# CHECK-NEXT: 7.     1     5.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld4r	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #16
-# CHECK-NEXT: 9.     1     4.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        10    4.6    0.1    3.0       <total>
+# CHECK-NEXT: 1.     1     2.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 2.     1     9.0    0.0    0.0       ld4	{ v1.d, v2.d, v3.d, v4.d }[0], [x27], x28
+# CHECK-NEXT: 3.     1     10.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     9.0    0.0    0.0       ld4r	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], #32
+# CHECK-NEXT: 5.     1     10.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     10.0   0.0    0.0       ld4r	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #32
+# CHECK-NEXT: 7.     1     11.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     10.0   0.0    0.0       ld4r	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #16
+# CHECK-NEXT: 9.     1     11.0   0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT:        10    8.3    0.1    3.0       <total>
 
 # CHECK:      [41] Code Region - G42
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
-# CHECK-NEXT: Total Cycles:      1009
-# CHECK-NEXT: Total uOps:        4500
+# CHECK-NEXT: Total Cycles:      510
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    4.46
-# CHECK-NEXT: IPC:               0.99
-# CHECK-NEXT: Block RThroughput: 5.6
+# CHECK-NEXT: uOps Per Cycle:    3.92
+# CHECK-NEXT: IPC:               1.96
+# CHECK-NEXT: Block RThroughput: 5.0
 
 # CHECK:      Timeline view:
-# CHECK-NEXT:                     012345678
+# CHECK-NEXT:                     01234
 # CHECK-NEXT: Index     0123456789
 
-# CHECK:      [0,0]     DeeeeeeeeER    .  .   ld4r	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #8
-# CHECK-NEXT: [0,1]     .DeE------R    .  .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     . DeeeeeeeeER  .  .   ld4r	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #16
-# CHECK-NEXT: [0,3]     .  DeE------R  .  .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     .   DeeeeeeeeER.  .   ld4r	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #4
-# CHECK-NEXT: [0,5]     .    DeE------R.  .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .    .DeeeeeeeeER .   ld4r	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #8
-# CHECK-NEXT: [0,7]     .    . DeE------R .   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .    .  DeeeeeeeeER   ld4r	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #4
-# CHECK-NEXT: [0,9]     .    .   DeE------R   add	x0, x27, #1
+# CHECK:      [0,0]     DeeeeeeeeER   .   ld4r	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #8
+# CHECK-NEXT: [0,1]     D=eE------R   .   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeeeeeER  .   ld4r	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #16
+# CHECK-NEXT: [0,3]     D==eE------R  .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D=eeeeeeeeER .   ld4r	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #4
+# CHECK-NEXT: [0,5]     .D==eE------R .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeeeeeeeER.   ld4r	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #8
+# CHECK-NEXT: [0,7]     .D===eE------R.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D==eeeeeeeeER   ld4r	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #4
+# CHECK-NEXT: [0,9]     . D===eE------R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -3079,43 +3079,43 @@ add x0, x27, 1
 
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ld4r	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #8
-# CHECK-NEXT: 1.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    1.0    0.0       ld4r	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #16
-# CHECK-NEXT: 3.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    1.0    0.0       ld4r	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #4
-# CHECK-NEXT: 5.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     1.0    1.0    0.0       ld4r	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #8
-# CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld4r	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #4
-# CHECK-NEXT: 9.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.0    0.5    3.0       <total>
+# CHECK-NEXT: 1.     1     2.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld4r	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #16
+# CHECK-NEXT: 3.     1     3.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     2.0    0.0    0.0       ld4r	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #4
+# CHECK-NEXT: 5.     1     3.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       ld4r	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #8
+# CHECK-NEXT: 7.     1     4.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     3.0    0.0    0.0       ld4r	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #4
+# CHECK-NEXT: 9.     1     4.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT:        10    2.7    0.1    3.0       <total>
 
 # CHECK:      [42] Code Region - G43
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
-# CHECK-NEXT: Total Cycles:      1009
-# CHECK-NEXT: Total uOps:        4500
+# CHECK-NEXT: Total Cycles:      510
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    4.46
-# CHECK-NEXT: IPC:               0.99
-# CHECK-NEXT: Block RThroughput: 5.6
+# CHECK-NEXT: uOps Per Cycle:    3.92
+# CHECK-NEXT: IPC:               1.96
+# CHECK-NEXT: Block RThroughput: 5.0
 
 # CHECK:      Timeline view:
-# CHECK-NEXT:                     012345678
+# CHECK-NEXT:                     01234
 # CHECK-NEXT: Index     0123456789
 
-# CHECK:      [0,0]     DeeeeeeeeER    .  .   ld4r	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], x28
-# CHECK-NEXT: [0,1]     .DeE------R    .  .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     . DeeeeeeeeER  .  .   ld4r	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], x28
-# CHECK-NEXT: [0,3]     .  DeE------R  .  .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     .   DeeeeeeeeER.  .   ld4r	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
-# CHECK-NEXT: [0,5]     .    DeE------R.  .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .    .DeeeeeeeeER .   ld4r	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
-# CHECK-NEXT: [0,7]     .    . DeE------R .   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .    .  DeeeeeeeeER   ld4r	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
-# CHECK-NEXT: [0,9]     .    .   DeE------R   add	x0, x27, #1
+# CHECK:      [0,0]     DeeeeeeeeER   .   ld4r	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], x28
+# CHECK-NEXT: [0,1]     D=eE------R   .   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeeeeeER  .   ld4r	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], x28
+# CHECK-NEXT: [0,3]     D==eE------R  .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D=eeeeeeeeER .   ld4r	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
+# CHECK-NEXT: [0,5]     .D==eE------R .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeeeeeeeER.   ld4r	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
+# CHECK-NEXT: [0,7]     .D===eE------R.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D==eeeeeeeeER   ld4r	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
+# CHECK-NEXT: [0,9]     . D===eE------R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -3125,43 +3125,43 @@ add x0, x27, 1
 
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ld4r	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], x28
-# CHECK-NEXT: 1.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    1.0    0.0       ld4r	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], x28
-# CHECK-NEXT: 3.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    1.0    0.0       ld4r	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
-# CHECK-NEXT: 5.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     1.0    1.0    0.0       ld4r	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
-# CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld4r	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
-# CHECK-NEXT: 9.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.0    0.5    3.0       <total>
+# CHECK-NEXT: 1.     1     2.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld4r	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], x28
+# CHECK-NEXT: 3.     1     3.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     2.0    0.0    0.0       ld4r	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
+# CHECK-NEXT: 5.     1     3.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       ld4r	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
+# CHECK-NEXT: 7.     1     4.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     3.0    0.0    0.0       ld4r	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
+# CHECK-NEXT: 9.     1     4.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT:        10    2.7    0.1    3.0       <total>
 
 # CHECK:      [43] Code Region - G44
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
-# CHECK-NEXT: Total Cycles:      609
-# CHECK-NEXT: Total uOps:        3300
+# CHECK-NEXT: Total Cycles:      508
+# CHECK-NEXT: Total uOps:        1800
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    5.42
-# CHECK-NEXT: IPC:               1.64
-# CHECK-NEXT: Block RThroughput: 4.1
+# CHECK-NEXT: uOps Per Cycle:    3.54
+# CHECK-NEXT: IPC:               1.97
+# CHECK-NEXT: Block RThroughput: 3.7
 
 # CHECK:      Timeline view:
-# CHECK-NEXT:                     01234
+# CHECK-NEXT:                     012
 # CHECK-NEXT: Index     0123456789
 
-# CHECK:      [0,0]     DeeeeeeeeER   .   ld4r	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
-# CHECK-NEXT: [0,1]     .DeE------R   .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     . DeeeeeeeeER .   ld4r	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], x28
-# CHECK-NEXT: [0,3]     .  DeE------R .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     .   DeeeeeeeeER   ld4r	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
-# CHECK-NEXT: [0,5]     .    DeE------R   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .    DeeeeeeE-R   ldp	s1, s2, [x27], #248
-# CHECK-NEXT: [0,7]     .    D=eE-----R   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .    D=eeeeeeER   ldp	d1, d2, [x27], #496
-# CHECK-NEXT: [0,9]     .    D==eE----R   add	x0, x27, #1
+# CHECK:      [0,0]     DeeeeeeeeER .   ld4r	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
+# CHECK-NEXT: [0,1]     D=eE------R .   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeeeeeER.   ld4r	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], x28
+# CHECK-NEXT: [0,3]     D==eE------R.   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D=eeeeeeeeER   ld4r	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
+# CHECK-NEXT: [0,5]     .D==eE------R   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeeeeeE-R   ldp	s1, s2, [x27], #248
+# CHECK-NEXT: [0,7]     .D===eE-----R   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D==eeeeeeER   ldp	d1, d2, [x27], #496
+# CHECK-NEXT: [0,9]     . D===eE----R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -3171,16 +3171,16 @@ add x0, x27, 1
 
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ld4r	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
-# CHECK-NEXT: 1.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    1.0    0.0       ld4r	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], x28
-# CHECK-NEXT: 3.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    1.0    0.0       ld4r	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
-# CHECK-NEXT: 5.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     1.0    0.0    1.0       ldp	s1, s2, [x27], #248
-# CHECK-NEXT: 7.     1     2.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     2.0    0.0    0.0       ldp	d1, d2, [x27], #496
-# CHECK-NEXT: 9.     1     3.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.4    0.3    2.8       <total>
+# CHECK-NEXT: 1.     1     2.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld4r	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], x28
+# CHECK-NEXT: 3.     1     3.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     2.0    0.0    0.0       ld4r	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
+# CHECK-NEXT: 5.     1     3.0    0.0    6.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     3.0    0.0    1.0       ldp	s1, s2, [x27], #248
+# CHECK-NEXT: 7.     1     4.0    0.0    5.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     3.0    0.0    0.0       ldp	d1, d2, [x27], #496
+# CHECK-NEXT: 9.     1     4.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT:        10    2.7    0.1    2.8       <total>
 
 # CHECK:      [44] Code Region - G45
 
@@ -3689,10 +3689,10 @@ add x0, x27, 1
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      504
-# CHECK-NEXT: Total uOps:        2400
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    4.76
+# CHECK-NEXT: uOps Per Cycle:    3.97
 # CHECK-NEXT: IPC:               1.98
 # CHECK-NEXT: Block RThroughput: 3.5
 
@@ -3701,14 +3701,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeER.  .   st1	{ v1.2d, v2.2d }, [x27], #32
 # CHECK-NEXT: [0,1]     D=eER.  .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeER  .   st1	{ v1.2s, v2.2s }, [x27], #16
-# CHECK-NEXT: [0,3]     .D=eER  .   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeER  .   st1	{ v1.2s, v2.2s }, [x27], #16
+# CHECK-NEXT: [0,3]     D==eER  .   add	x0, x27, #1
 # CHECK-NEXT: [0,4]     .D=eeER .   st1	{ v1.4h, v2.4h }, [x27], #16
 # CHECK-NEXT: [0,5]     .D==eER .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     . D=eeER.   st1	{ v1.4s, v2.4s }, [x27], #32
-# CHECK-NEXT: [0,7]     . D==eER.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .  D=eeER   st1	{ v1.8b, v2.8b }, [x27], #16
-# CHECK-NEXT: [0,9]     .  D==eER   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeER.   st1	{ v1.4s, v2.4s }, [x27], #32
+# CHECK-NEXT: [0,7]     .D===eER.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D==eeER   st1	{ v1.8b, v2.8b }, [x27], #16
+# CHECK-NEXT: [0,9]     . D===eER   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -3719,25 +3719,25 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       st1	{ v1.2d, v2.2d }, [x27], #32
 # CHECK-NEXT: 1.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       st1	{ v1.2s, v2.2s }, [x27], #16
-# CHECK-NEXT: 3.     1     2.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.2s, v2.2s }, [x27], #16
+# CHECK-NEXT: 3.     1     3.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 4.     1     2.0    0.0    0.0       st1	{ v1.4h, v2.4h }, [x27], #16
 # CHECK-NEXT: 5.     1     3.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     2.0    0.0    0.0       st1	{ v1.4s, v2.4s }, [x27], #32
-# CHECK-NEXT: 7.     1     3.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     2.0    0.0    0.0       st1	{ v1.8b, v2.8b }, [x27], #16
-# CHECK-NEXT: 9.     1     3.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        10    2.1    0.1    0.0       <total>
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       st1	{ v1.4s, v2.4s }, [x27], #32
+# CHECK-NEXT: 7.     1     4.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     3.0    0.0    0.0       st1	{ v1.8b, v2.8b }, [x27], #16
+# CHECK-NEXT: 9.     1     4.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT:        10    2.7    0.1    0.0       <total>
 
 # CHECK:      [56] Code Region - G57
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      504
-# CHECK-NEXT: Total uOps:        2600
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    5.16
+# CHECK-NEXT: uOps Per Cycle:    3.97
 # CHECK-NEXT: IPC:               1.98
 # CHECK-NEXT: Block RThroughput: 4.0
 
@@ -3746,14 +3746,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeER.  .   st1	{ v1.8h, v2.8h }, [x27], #32
 # CHECK-NEXT: [0,1]     D=eER.  .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeER  .   st1	{ v1.16b, v2.16b }, [x27], #32
-# CHECK-NEXT: [0,3]     .D=eER  .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . DeeER .   st1	{ v1.1d, v2.1d }, [x27], x28
-# CHECK-NEXT: [0,5]     . D=eER .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  DeeER.   st1	{ v1.2d, v2.2d }, [x27], x28
-# CHECK-NEXT: [0,7]     .  D=eER.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .   DeeER   st1	{ v1.2s, v2.2s }, [x27], x28
-# CHECK-NEXT: [0,9]     .   D=eER   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeER  .   st1	{ v1.16b, v2.16b }, [x27], #32
+# CHECK-NEXT: [0,3]     D==eER  .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D=eeER .   st1	{ v1.1d, v2.1d }, [x27], x28
+# CHECK-NEXT: [0,5]     .D==eER .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeER.   st1	{ v1.2d, v2.2d }, [x27], x28
+# CHECK-NEXT: [0,7]     .D===eER.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D==eeER   st1	{ v1.2s, v2.2s }, [x27], x28
+# CHECK-NEXT: [0,9]     . D===eER   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -3764,25 +3764,25 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       st1	{ v1.8h, v2.8h }, [x27], #32
 # CHECK-NEXT: 1.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       st1	{ v1.16b, v2.16b }, [x27], #32
-# CHECK-NEXT: 3.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    0.0    0.0       st1	{ v1.1d, v2.1d }, [x27], x28
-# CHECK-NEXT: 5.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     1.0    0.0    0.0       st1	{ v1.2d, v2.2d }, [x27], x28
-# CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     1.0    0.0    0.0       st1	{ v1.2s, v2.2s }, [x27], x28
-# CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.5    0.1    0.0       <total>
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.16b, v2.16b }, [x27], #32
+# CHECK-NEXT: 3.     1     3.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     2.0    0.0    0.0       st1	{ v1.1d, v2.1d }, [x27], x28
+# CHECK-NEXT: 5.     1     3.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       st1	{ v1.2d, v2.2d }, [x27], x28
+# CHECK-NEXT: 7.     1     4.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     3.0    0.0    0.0       st1	{ v1.2s, v2.2s }, [x27], x28
+# CHECK-NEXT: 9.     1     4.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT:        10    2.7    0.1    0.0       <total>
 
 # CHECK:      [57] Code Region - G58
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      504
-# CHECK-NEXT: Total uOps:        2600
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    5.16
+# CHECK-NEXT: uOps Per Cycle:    3.97
 # CHECK-NEXT: IPC:               1.98
 # CHECK-NEXT: Block RThroughput: 4.0
 
@@ -3791,14 +3791,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeER.  .   st1	{ v1.4h, v2.4h }, [x27], x28
 # CHECK-NEXT: [0,1]     D=eER.  .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeER  .   st1	{ v1.4s, v2.4s }, [x27], x28
-# CHECK-NEXT: [0,3]     .D=eER  .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . DeeER .   st1	{ v1.8b, v2.8b }, [x27], x28
-# CHECK-NEXT: [0,5]     . D=eER .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  DeeER.   st1	{ v1.8h, v2.8h }, [x27], x28
-# CHECK-NEXT: [0,7]     .  D=eER.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .   DeeER   st1	{ v1.16b, v2.16b }, [x27], x28
-# CHECK-NEXT: [0,9]     .   D=eER   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeER  .   st1	{ v1.4s, v2.4s }, [x27], x28
+# CHECK-NEXT: [0,3]     D==eER  .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D=eeER .   st1	{ v1.8b, v2.8b }, [x27], x28
+# CHECK-NEXT: [0,5]     .D==eER .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeER.   st1	{ v1.8h, v2.8h }, [x27], x28
+# CHECK-NEXT: [0,7]     .D===eER.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D==eeER   st1	{ v1.16b, v2.16b }, [x27], x28
+# CHECK-NEXT: [0,9]     . D===eER   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -3809,25 +3809,25 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       st1	{ v1.4h, v2.4h }, [x27], x28
 # CHECK-NEXT: 1.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       st1	{ v1.4s, v2.4s }, [x27], x28
-# CHECK-NEXT: 3.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    0.0    0.0       st1	{ v1.8b, v2.8b }, [x27], x28
-# CHECK-NEXT: 5.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     1.0    0.0    0.0       st1	{ v1.8h, v2.8h }, [x27], x28
-# CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     1.0    0.0    0.0       st1	{ v1.16b, v2.16b }, [x27], x28
-# CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.5    0.1    0.0       <total>
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.4s, v2.4s }, [x27], x28
+# CHECK-NEXT: 3.     1     3.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     2.0    0.0    0.0       st1	{ v1.8b, v2.8b }, [x27], x28
+# CHECK-NEXT: 5.     1     3.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       st1	{ v1.8h, v2.8h }, [x27], x28
+# CHECK-NEXT: 7.     1     4.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     3.0    0.0    0.0       st1	{ v1.16b, v2.16b }, [x27], x28
+# CHECK-NEXT: 9.     1     4.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT:        10    2.7    0.1    0.0       <total>
 
 # CHECK:      [58] Code Region - G59
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      703
-# CHECK-NEXT: Total uOps:        3400
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    4.84
+# CHECK-NEXT: uOps Per Cycle:    2.84
 # CHECK-NEXT: IPC:               1.42
 # CHECK-NEXT: Block RThroughput: 6.0
 
@@ -3836,14 +3836,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeER.   .   st1	{ v1.1d, v2.1d, v3.1d }, [x27], #24
 # CHECK-NEXT: [0,1]     D=eER.   .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeER   .   st1	{ v1.2d, v2.2d, v3.2d }, [x27], #48
-# CHECK-NEXT: [0,3]     .D=eER   .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . DeeER  .   st1	{ v1.2s, v2.2s, v3.2s }, [x27], #24
-# CHECK-NEXT: [0,5]     . D=eER  .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  D=eeER.   st1	{ v1.4h, v2.4h, v3.4h }, [x27], #24
-# CHECK-NEXT: [0,7]     .  D==eER.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .   D=eeER   st1	{ v1.4s, v2.4s, v3.4s }, [x27], #48
-# CHECK-NEXT: [0,9]     .   D==eER   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeER   .   st1	{ v1.2d, v2.2d, v3.2d }, [x27], #48
+# CHECK-NEXT: [0,3]     D==eER   .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D=eeER  .   st1	{ v1.2s, v2.2s, v3.2s }, [x27], #24
+# CHECK-NEXT: [0,5]     .D==eER  .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D===eeER.   st1	{ v1.4h, v2.4h, v3.4h }, [x27], #24
+# CHECK-NEXT: [0,7]     .D====eER.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D===eeER   st1	{ v1.4s, v2.4s, v3.4s }, [x27], #48
+# CHECK-NEXT: [0,9]     . D====eER   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -3854,25 +3854,25 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       st1	{ v1.1d, v2.1d, v3.1d }, [x27], #24
 # CHECK-NEXT: 1.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       st1	{ v1.2d, v2.2d, v3.2d }, [x27], #48
-# CHECK-NEXT: 3.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    0.0    0.0       st1	{ v1.2s, v2.2s, v3.2s }, [x27], #24
-# CHECK-NEXT: 5.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     2.0    1.0    0.0       st1	{ v1.4h, v2.4h, v3.4h }, [x27], #24
-# CHECK-NEXT: 7.     1     3.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     2.0    0.0    0.0       st1	{ v1.4s, v2.4s, v3.4s }, [x27], #48
-# CHECK-NEXT: 9.     1     3.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.9    0.2    0.0       <total>
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.2d, v2.2d, v3.2d }, [x27], #48
+# CHECK-NEXT: 3.     1     3.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     2.0    0.0    0.0       st1	{ v1.2s, v2.2s, v3.2s }, [x27], #24
+# CHECK-NEXT: 5.     1     3.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     4.0    1.0    0.0       st1	{ v1.4h, v2.4h, v3.4h }, [x27], #24
+# CHECK-NEXT: 7.     1     5.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     4.0    0.0    0.0       st1	{ v1.4s, v2.4s, v3.4s }, [x27], #48
+# CHECK-NEXT: 9.     1     5.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT:        10    3.1    0.2    0.0       <total>
 
 # CHECK:      [59] Code Region - G60
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      703
-# CHECK-NEXT: Total uOps:        3600
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    5.12
+# CHECK-NEXT: uOps Per Cycle:    2.84
 # CHECK-NEXT: IPC:               1.42
 # CHECK-NEXT: Block RThroughput: 6.5
 
@@ -3881,14 +3881,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeER.   .   st1	{ v1.8b, v2.8b, v3.8b }, [x27], #24
 # CHECK-NEXT: [0,1]     D=eER.   .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeER   .   st1	{ v1.8h, v2.8h, v3.8h }, [x27], #48
-# CHECK-NEXT: [0,3]     .D=eER   .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . DeeER  .   st1	{ v1.16b, v2.16b, v3.16b }, [x27], #48
-# CHECK-NEXT: [0,5]     . D=eER  .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  D=eeER.   st1	{ v1.1d, v2.1d, v3.1d }, [x27], x28
-# CHECK-NEXT: [0,7]     .  D==eER.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .   D=eeER   st1	{ v1.2d, v2.2d, v3.2d }, [x27], x28
-# CHECK-NEXT: [0,9]     .   D==eER   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeER   .   st1	{ v1.8h, v2.8h, v3.8h }, [x27], #48
+# CHECK-NEXT: [0,3]     D==eER   .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D=eeER  .   st1	{ v1.16b, v2.16b, v3.16b }, [x27], #48
+# CHECK-NEXT: [0,5]     .D==eER  .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D===eeER.   st1	{ v1.1d, v2.1d, v3.1d }, [x27], x28
+# CHECK-NEXT: [0,7]     .D====eER.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D===eeER   st1	{ v1.2d, v2.2d, v3.2d }, [x27], x28
+# CHECK-NEXT: [0,9]     . D====eER   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -3899,25 +3899,25 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       st1	{ v1.8b, v2.8b, v3.8b }, [x27], #24
 # CHECK-NEXT: 1.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       st1	{ v1.8h, v2.8h, v3.8h }, [x27], #48
-# CHECK-NEXT: 3.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    0.0    0.0       st1	{ v1.16b, v2.16b, v3.16b }, [x27], #48
-# CHECK-NEXT: 5.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     2.0    1.0    0.0       st1	{ v1.1d, v2.1d, v3.1d }, [x27], x28
-# CHECK-NEXT: 7.     1     3.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     2.0    0.0    0.0       st1	{ v1.2d, v2.2d, v3.2d }, [x27], x28
-# CHECK-NEXT: 9.     1     3.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.9    0.2    0.0       <total>
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.8h, v2.8h, v3.8h }, [x27], #48
+# CHECK-NEXT: 3.     1     3.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     2.0    0.0    0.0       st1	{ v1.16b, v2.16b, v3.16b }, [x27], #48
+# CHECK-NEXT: 5.     1     3.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     4.0    1.0    0.0       st1	{ v1.1d, v2.1d, v3.1d }, [x27], x28
+# CHECK-NEXT: 7.     1     5.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     4.0    0.0    0.0       st1	{ v1.2d, v2.2d, v3.2d }, [x27], x28
+# CHECK-NEXT: 9.     1     5.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT:        10    3.1    0.2    0.0       <total>
 
 # CHECK:      [60] Code Region - G61
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      703
-# CHECK-NEXT: Total uOps:        3400
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    4.84
+# CHECK-NEXT: uOps Per Cycle:    2.84
 # CHECK-NEXT: IPC:               1.42
 # CHECK-NEXT: Block RThroughput: 6.0
 
@@ -3926,14 +3926,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeER.   .   st1	{ v1.2s, v2.2s, v3.2s }, [x27], x28
 # CHECK-NEXT: [0,1]     D=eER.   .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeER   .   st1	{ v1.4h, v2.4h, v3.4h }, [x27], x28
-# CHECK-NEXT: [0,3]     .D=eER   .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . DeeER  .   st1	{ v1.4s, v2.4s, v3.4s }, [x27], x28
-# CHECK-NEXT: [0,5]     . D=eER  .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  DeeER .   st1	{ v1.8b, v2.8b, v3.8b }, [x27], x28
-# CHECK-NEXT: [0,7]     .  D=eER .   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .   D=eeER   st1	{ v1.8h, v2.8h, v3.8h }, [x27], x28
-# CHECK-NEXT: [0,9]     .   D==eER   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeER   .   st1	{ v1.4h, v2.4h, v3.4h }, [x27], x28
+# CHECK-NEXT: [0,3]     D==eER   .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D=eeER  .   st1	{ v1.4s, v2.4s, v3.4s }, [x27], x28
+# CHECK-NEXT: [0,5]     .D==eER  .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeER .   st1	{ v1.8b, v2.8b, v3.8b }, [x27], x28
+# CHECK-NEXT: [0,7]     .D===eER .   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D===eeER   st1	{ v1.8h, v2.8h, v3.8h }, [x27], x28
+# CHECK-NEXT: [0,9]     . D====eER   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -3944,25 +3944,25 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       st1	{ v1.2s, v2.2s, v3.2s }, [x27], x28
 # CHECK-NEXT: 1.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       st1	{ v1.4h, v2.4h, v3.4h }, [x27], x28
-# CHECK-NEXT: 3.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    0.0    0.0       st1	{ v1.4s, v2.4s, v3.4s }, [x27], x28
-# CHECK-NEXT: 5.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     1.0    0.0    0.0       st1	{ v1.8b, v2.8b, v3.8b }, [x27], x28
-# CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     2.0    1.0    0.0       st1	{ v1.8h, v2.8h, v3.8h }, [x27], x28
-# CHECK-NEXT: 9.     1     3.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.7    0.2    0.0       <total>
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.4h, v2.4h, v3.4h }, [x27], x28
+# CHECK-NEXT: 3.     1     3.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     2.0    0.0    0.0       st1	{ v1.4s, v2.4s, v3.4s }, [x27], x28
+# CHECK-NEXT: 5.     1     3.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       st1	{ v1.8b, v2.8b, v3.8b }, [x27], x28
+# CHECK-NEXT: 7.     1     4.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     4.0    1.0    0.0       st1	{ v1.8h, v2.8h, v3.8h }, [x27], x28
+# CHECK-NEXT: 9.     1     5.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT:        10    2.9    0.2    0.0       <total>
 
 # CHECK:      [61] Code Region - G62
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      704
-# CHECK-NEXT: Total uOps:        3600
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    5.11
+# CHECK-NEXT: uOps Per Cycle:    2.84
 # CHECK-NEXT: IPC:               1.42
 # CHECK-NEXT: Block RThroughput: 6.5
 
@@ -3972,14 +3972,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeER.    .   st1	{ v1.16b, v2.16b, v3.16b }, [x27], x28
 # CHECK-NEXT: [0,1]     D=eER.    .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeER    .   st1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], #32
-# CHECK-NEXT: [0,3]     .D=eER    .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . D=eeER  .   st1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
-# CHECK-NEXT: [0,5]     .  D=eER  .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  D=eeER .   st1	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
-# CHECK-NEXT: [0,7]     .  D==eER .   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .   D==eeER   st1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #32
-# CHECK-NEXT: [0,9]     .   D===eER   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeER    .   st1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], #32
+# CHECK-NEXT: [0,3]     D==eER    .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D==eeER  .   st1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
+# CHECK-NEXT: [0,5]     .D===eER  .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D===eeER .   st1	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
+# CHECK-NEXT: [0,7]     .D====eER .   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D====eeER   st1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #32
+# CHECK-NEXT: [0,9]     . D=====eER   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -3990,25 +3990,25 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       st1	{ v1.16b, v2.16b, v3.16b }, [x27], x28
 # CHECK-NEXT: 1.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       st1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], #32
-# CHECK-NEXT: 3.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     2.0    1.0    0.0       st1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
-# CHECK-NEXT: 5.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     2.0    0.0    0.0       st1	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
-# CHECK-NEXT: 7.     1     3.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     3.0    1.0    0.0       st1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #32
-# CHECK-NEXT: 9.     1     4.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        10    2.2    0.3    0.0       <total>
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], #32
+# CHECK-NEXT: 3.     1     3.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     3.0    1.0    0.0       st1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
+# CHECK-NEXT: 5.     1     4.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     4.0    0.0    0.0       st1	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
+# CHECK-NEXT: 7.     1     5.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     5.0    1.0    0.0       st1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #32
+# CHECK-NEXT: 9.     1     6.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT:        10    3.5    0.3    0.0       <total>
 
 # CHECK:      [62] Code Region - G63
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      804
-# CHECK-NEXT: Total uOps:        4200
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    5.22
+# CHECK-NEXT: uOps Per Cycle:    2.49
 # CHECK-NEXT: IPC:               1.24
 # CHECK-NEXT: Block RThroughput: 8.0
 
@@ -4017,15 +4017,15 @@ add x0, x27, 1
 # CHECK-NEXT: Index     0123456789
 
 # CHECK:      [0,0]     DeeER.    ..   st1	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
-# CHECK-NEXT: [0,1]     .DeER.    ..   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeER    ..   st1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #32
-# CHECK-NEXT: [0,3]     .D=eER    ..   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . D=eeER  ..   st1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
-# CHECK-NEXT: [0,5]     .  D=eER  ..   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .   DeeER ..   st1	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
-# CHECK-NEXT: [0,7]     .    DeER ..   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .    D==eeER   st1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], x28
-# CHECK-NEXT: [0,9]     .    D===eER   add	x0, x27, #1
+# CHECK-NEXT: [0,1]     D=eER.    ..   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeER    ..   st1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #32
+# CHECK-NEXT: [0,3]     D==eER    ..   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D==eeER  ..   st1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
+# CHECK-NEXT: [0,5]     .D===eER  ..   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D===eeER ..   st1	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
+# CHECK-NEXT: [0,7]     .D====eER ..   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D=====eeER   st1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], x28
+# CHECK-NEXT: [0,9]     . D======eER   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -4035,26 +4035,26 @@ add x0, x27, 1
 
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       st1	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
-# CHECK-NEXT: 1.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       st1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #32
-# CHECK-NEXT: 3.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     2.0    1.0    0.0       st1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
-# CHECK-NEXT: 5.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     1.0    0.0    0.0       st1	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
-# CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     3.0    2.0    0.0       st1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], x28
-# CHECK-NEXT: 9.     1     4.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.8    0.4    0.0       <total>
+# CHECK-NEXT: 1.     1     2.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #32
+# CHECK-NEXT: 3.     1     3.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     3.0    1.0    0.0       st1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
+# CHECK-NEXT: 5.     1     4.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     4.0    0.0    0.0       st1	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
+# CHECK-NEXT: 7.     1     5.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     6.0    2.0    0.0       st1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], x28
+# CHECK-NEXT: 9.     1     7.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT:        10    3.7    0.4    0.0       <total>
 
 # CHECK:      [63] Code Region - G64
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      703
-# CHECK-NEXT: Total uOps:        3800
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    5.41
+# CHECK-NEXT: uOps Per Cycle:    2.84
 # CHECK-NEXT: IPC:               1.42
 # CHECK-NEXT: Block RThroughput: 7.0
 
@@ -4062,15 +4062,15 @@ add x0, x27, 1
 # CHECK-NEXT: Index     0123456789
 
 # CHECK:      [0,0]     DeeER.   .   st1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], x28
-# CHECK-NEXT: [0,1]     .DeER.   .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeER   .   st1	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
-# CHECK-NEXT: [0,3]     .D=eER   .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . D=eeER .   st1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
-# CHECK-NEXT: [0,5]     . D==eER .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  D=eeER.   st1	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
-# CHECK-NEXT: [0,7]     .   D=eER.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .   D=eeER   st1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
-# CHECK-NEXT: [0,9]     .   D==eER   add	x0, x27, #1
+# CHECK-NEXT: [0,1]     D=eER.   .   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeER   .   st1	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
+# CHECK-NEXT: [0,3]     D==eER   .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D==eeER .   st1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
+# CHECK-NEXT: [0,5]     .D===eER .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D===eeER.   st1	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
+# CHECK-NEXT: [0,7]     .D====eER.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D===eeER   st1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
+# CHECK-NEXT: [0,9]     . D====eER   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -4080,26 +4080,26 @@ add x0, x27, 1
 
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       st1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], x28
-# CHECK-NEXT: 1.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       st1	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
-# CHECK-NEXT: 3.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     2.0    1.0    0.0       st1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
-# CHECK-NEXT: 5.     1     3.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     2.0    0.0    0.0       st1	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
-# CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     2.0    0.0    0.0       st1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
-# CHECK-NEXT: 9.     1     3.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.9    0.2    0.0       <total>
+# CHECK-NEXT: 1.     1     2.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
+# CHECK-NEXT: 3.     1     3.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     3.0    1.0    0.0       st1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
+# CHECK-NEXT: 5.     1     4.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     4.0    0.0    0.0       st1	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
+# CHECK-NEXT: 7.     1     5.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     4.0    0.0    0.0       st1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
+# CHECK-NEXT: 9.     1     5.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT:        10    3.3    0.2    0.0       <total>
 
 # CHECK:      [64] Code Region - G65
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      706
-# CHECK-NEXT: Total uOps:        3200
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    4.53
+# CHECK-NEXT: uOps Per Cycle:    2.83
 # CHECK-NEXT: IPC:               1.42
 # CHECK-NEXT: Block RThroughput: 5.5
 
@@ -4108,15 +4108,15 @@ add x0, x27, 1
 # CHECK-NEXT: Index     0123456789
 
 # CHECK:      [0,0]     DeeER.    . .   st1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], x28
-# CHECK-NEXT: [0,1]     .DeER.    . .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     . DeeER   . .   st1	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
-# CHECK-NEXT: [0,3]     .  DeER   . .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     .  D=eeeeER .   st1	{ v1.b }[0], [x27], #1
-# CHECK-NEXT: [0,5]     .  D==eE--R .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .   D=eeeeER.   st1	{ v1.b }[8], [x27], #1
-# CHECK-NEXT: [0,7]     .   D==eE--R.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .   D==eeeeER   st1	{ v1.b }[0], [x27], x28
-# CHECK-NEXT: [0,9]     .   D===eE--R   add	x0, x27, #1
+# CHECK-NEXT: [0,1]     D=eER.    . .   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeER    . .   st1	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
+# CHECK-NEXT: [0,3]     D==eER    . .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D===eeeeER .   st1	{ v1.b }[0], [x27], #1
+# CHECK-NEXT: [0,5]     .D====eE--R .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D====eeeeER.   st1	{ v1.b }[8], [x27], #1
+# CHECK-NEXT: [0,7]     .D=====eE--R.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D====eeeeER   st1	{ v1.b }[0], [x27], x28
+# CHECK-NEXT: [0,9]     . D=====eE--R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -4126,16 +4126,16 @@ add x0, x27, 1
 
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       st1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], x28
-# CHECK-NEXT: 1.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    1.0    0.0       st1	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
-# CHECK-NEXT: 3.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     2.0    1.0    0.0       st1	{ v1.b }[0], [x27], #1
-# CHECK-NEXT: 5.     1     3.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     2.0    0.0    0.0       st1	{ v1.b }[8], [x27], #1
-# CHECK-NEXT: 7.     1     3.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     3.0    0.0    0.0       st1	{ v1.b }[0], [x27], x28
-# CHECK-NEXT: 9.     1     4.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        10    2.1    0.3    0.6       <total>
+# CHECK-NEXT: 1.     1     2.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
+# CHECK-NEXT: 3.     1     3.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     4.0    2.0    0.0       st1	{ v1.b }[0], [x27], #1
+# CHECK-NEXT: 5.     1     5.0    0.0    2.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     5.0    0.0    0.0       st1	{ v1.b }[8], [x27], #1
+# CHECK-NEXT: 7.     1     6.0    0.0    2.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     5.0    0.0    0.0       st1	{ v1.b }[0], [x27], x28
+# CHECK-NEXT: 9.     1     6.0    0.0    2.0       add	x0, x27, #1
+# CHECK-NEXT:        10    3.9    0.3    0.6       <total>
 
 # CHECK:      [65] Code Region - G66
 
@@ -4188,10 +4188,10 @@ add x0, x27, 1
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      506
-# CHECK-NEXT: Total uOps:        2200
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    4.35
+# CHECK-NEXT: uOps Per Cycle:    3.95
 # CHECK-NEXT: IPC:               1.98
 # CHECK-NEXT: Block RThroughput: 3.0
 
@@ -4234,10 +4234,10 @@ add x0, x27, 1
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      506
-# CHECK-NEXT: Total uOps:        2400
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    4.74
+# CHECK-NEXT: uOps Per Cycle:    3.95
 # CHECK-NEXT: IPC:               1.98
 # CHECK-NEXT: Block RThroughput: 3.5
 
@@ -4251,10 +4251,10 @@ add x0, x27, 1
 # CHECK-NEXT: [0,3]     D==eE--R  .   add	x0, x27, #1
 # CHECK-NEXT: [0,4]     .D=eeeeER .   st2	{ v1.4s, v2.4s }, [x27], #32
 # CHECK-NEXT: [0,5]     .D==eE--R .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     . D=eeeeER.   st2	{ v1.8b, v2.8b }, [x27], #16
-# CHECK-NEXT: [0,7]     . D==eE--R.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .  D=eeeeER   st2	{ v1.8h, v2.8h }, [x27], #32
-# CHECK-NEXT: [0,9]     .  D==eE--R   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeeeER.   st2	{ v1.8b, v2.8b }, [x27], #16
+# CHECK-NEXT: [0,7]     .D===eE--R.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D==eeeeER   st2	{ v1.8h, v2.8h }, [x27], #32
+# CHECK-NEXT: [0,9]     . D===eE--R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -4269,21 +4269,21 @@ add x0, x27, 1
 # CHECK-NEXT: 3.     1     3.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 4.     1     2.0    0.0    0.0       st2	{ v1.4s, v2.4s }, [x27], #32
 # CHECK-NEXT: 5.     1     3.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     2.0    0.0    0.0       st2	{ v1.8b, v2.8b }, [x27], #16
-# CHECK-NEXT: 7.     1     3.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     2.0    0.0    0.0       st2	{ v1.8h, v2.8h }, [x27], #32
-# CHECK-NEXT: 9.     1     3.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        10    2.3    0.1    1.0       <total>
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       st2	{ v1.8b, v2.8b }, [x27], #16
+# CHECK-NEXT: 7.     1     4.0    0.0    2.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     3.0    0.0    0.0       st2	{ v1.8h, v2.8h }, [x27], #32
+# CHECK-NEXT: 9.     1     4.0    0.0    2.0       add	x0, x27, #1
+# CHECK-NEXT:        10    2.7    0.1    1.0       <total>
 
 # CHECK:      [68] Code Region - G69
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      506
-# CHECK-NEXT: Total uOps:        2600
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    5.14
+# CHECK-NEXT: uOps Per Cycle:    3.95
 # CHECK-NEXT: IPC:               1.98
 # CHECK-NEXT: Block RThroughput: 4.0
 
@@ -4293,14 +4293,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeeeER   .   st2	{ v1.16b, v2.16b }, [x27], #32
 # CHECK-NEXT: [0,1]     D=eE--R   .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeeeER  .   st2	{ v1.2d, v2.2d }, [x27], x28
-# CHECK-NEXT: [0,3]     .D=eE--R  .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . DeeeeER .   st2	{ v1.2s, v2.2s }, [x27], x28
-# CHECK-NEXT: [0,5]     . D=eE--R .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     . D=eeeeER.   st2	{ v1.4h, v2.4h }, [x27], x28
-# CHECK-NEXT: [0,7]     . D==eE--R.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .  D=eeeeER   st2	{ v1.4s, v2.4s }, [x27], x28
-# CHECK-NEXT: [0,9]     .  D==eE--R   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeER  .   st2	{ v1.2d, v2.2d }, [x27], x28
+# CHECK-NEXT: [0,3]     D==eE--R  .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D=eeeeER .   st2	{ v1.2s, v2.2s }, [x27], x28
+# CHECK-NEXT: [0,5]     .D==eE--R .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeeeER.   st2	{ v1.4h, v2.4h }, [x27], x28
+# CHECK-NEXT: [0,7]     .D===eE--R.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D==eeeeER   st2	{ v1.4s, v2.4s }, [x27], x28
+# CHECK-NEXT: [0,9]     . D===eE--R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -4311,25 +4311,25 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       st2	{ v1.16b, v2.16b }, [x27], #32
 # CHECK-NEXT: 1.     1     2.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       st2	{ v1.2d, v2.2d }, [x27], x28
-# CHECK-NEXT: 3.     1     2.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    0.0    0.0       st2	{ v1.2s, v2.2s }, [x27], x28
-# CHECK-NEXT: 5.     1     2.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     2.0    0.0    0.0       st2	{ v1.4h, v2.4h }, [x27], x28
-# CHECK-NEXT: 7.     1     3.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     2.0    0.0    0.0       st2	{ v1.4s, v2.4s }, [x27], x28
-# CHECK-NEXT: 9.     1     3.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.9    0.1    1.0       <total>
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       st2	{ v1.2d, v2.2d }, [x27], x28
+# CHECK-NEXT: 3.     1     3.0    0.0    2.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     2.0    0.0    0.0       st2	{ v1.2s, v2.2s }, [x27], x28
+# CHECK-NEXT: 5.     1     3.0    0.0    2.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       st2	{ v1.4h, v2.4h }, [x27], x28
+# CHECK-NEXT: 7.     1     4.0    0.0    2.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     3.0    0.0    0.0       st2	{ v1.4s, v2.4s }, [x27], x28
+# CHECK-NEXT: 9.     1     4.0    0.0    2.0       add	x0, x27, #1
+# CHECK-NEXT:        10    2.7    0.1    1.0       <total>
 
 # CHECK:      [69] Code Region - G70
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      506
-# CHECK-NEXT: Total uOps:        2400
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    4.74
+# CHECK-NEXT: uOps Per Cycle:    3.95
 # CHECK-NEXT: IPC:               1.98
 # CHECK-NEXT: Block RThroughput: 3.5
 
@@ -4339,14 +4339,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeeeER   .   st2	{ v1.8b, v2.8b }, [x27], x28
 # CHECK-NEXT: [0,1]     D=eE--R   .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeeeER  .   st2	{ v1.8h, v2.8h }, [x27], x28
-# CHECK-NEXT: [0,3]     .D=eE--R  .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . DeeeeER .   st2	{ v1.16b, v2.16b }, [x27], x28
-# CHECK-NEXT: [0,5]     . D=eE--R .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  DeeeeER.   st2	{ v1.b, v2.b }[0], [x27], #2
-# CHECK-NEXT: [0,7]     .  D=eE--R.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .  D=eeeeER   st2	{ v1.b, v2.b }[8], [x27], #2
-# CHECK-NEXT: [0,9]     .  D==eE--R   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeER  .   st2	{ v1.8h, v2.8h }, [x27], x28
+# CHECK-NEXT: [0,3]     D==eE--R  .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D=eeeeER .   st2	{ v1.16b, v2.16b }, [x27], x28
+# CHECK-NEXT: [0,5]     .D==eE--R .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeeeER.   st2	{ v1.b, v2.b }[0], [x27], #2
+# CHECK-NEXT: [0,7]     .D===eE--R.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D==eeeeER   st2	{ v1.b, v2.b }[8], [x27], #2
+# CHECK-NEXT: [0,9]     . D===eE--R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -4357,15 +4357,15 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       st2	{ v1.8b, v2.8b }, [x27], x28
 # CHECK-NEXT: 1.     1     2.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       st2	{ v1.8h, v2.8h }, [x27], x28
-# CHECK-NEXT: 3.     1     2.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    0.0    0.0       st2	{ v1.16b, v2.16b }, [x27], x28
-# CHECK-NEXT: 5.     1     2.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     1.0    0.0    0.0       st2	{ v1.b, v2.b }[0], [x27], #2
-# CHECK-NEXT: 7.     1     2.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     2.0    0.0    0.0       st2	{ v1.b, v2.b }[8], [x27], #2
-# CHECK-NEXT: 9.     1     3.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.7    0.1    1.0       <total>
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       st2	{ v1.8h, v2.8h }, [x27], x28
+# CHECK-NEXT: 3.     1     3.0    0.0    2.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     2.0    0.0    0.0       st2	{ v1.16b, v2.16b }, [x27], x28
+# CHECK-NEXT: 5.     1     3.0    0.0    2.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       st2	{ v1.b, v2.b }[0], [x27], #2
+# CHECK-NEXT: 7.     1     4.0    0.0    2.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     3.0    0.0    0.0       st2	{ v1.b, v2.b }[8], [x27], #2
+# CHECK-NEXT: 9.     1     4.0    0.0    2.0       add	x0, x27, #1
+# CHECK-NEXT:        10    2.7    0.1    1.0       <total>
 
 # CHECK:      [70] Code Region - G71
 
@@ -4464,10 +4464,10 @@ add x0, x27, 1
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      600
 # CHECK-NEXT: Total Cycles:      406
-# CHECK-NEXT: Total uOps:        2000
+# CHECK-NEXT: Total uOps:        1200
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    4.93
+# CHECK-NEXT: uOps Per Cycle:    2.96
 # CHECK-NEXT: IPC:               1.48
 # CHECK-NEXT: Block RThroughput: 3.5
 
@@ -4476,10 +4476,10 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeeeeER .   st3	{ v1.2d, v2.2d, v3.2d }, [x27], #48
 # CHECK-NEXT: [0,1]     D=eE---R .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeeeER .   st3	{ v1.2s, v2.2s, v3.2s }, [x27], #24
-# CHECK-NEXT: [0,3]     .D=eE--R .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . D=eeeeER   st3	{ v1.4h, v2.4h, v3.4h }, [x27], #24
-# CHECK-NEXT: [0,5]     . D==eE--R   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeER .   st3	{ v1.2s, v2.2s, v3.2s }, [x27], #24
+# CHECK-NEXT: [0,3]     D==eE--R .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D==eeeeER   st3	{ v1.4h, v2.4h, v3.4h }, [x27], #24
+# CHECK-NEXT: [0,5]     .D===eE--R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -4490,21 +4490,21 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       st3	{ v1.2d, v2.2d, v3.2d }, [x27], #48
 # CHECK-NEXT: 1.     1     2.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       st3	{ v1.2s, v2.2s, v3.2s }, [x27], #24
-# CHECK-NEXT: 3.     1     2.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     2.0    1.0    0.0       st3	{ v1.4h, v2.4h, v3.4h }, [x27], #24
-# CHECK-NEXT: 5.     1     3.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        6     1.8    0.3    1.2       <total>
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       st3	{ v1.2s, v2.2s, v3.2s }, [x27], #24
+# CHECK-NEXT: 3.     1     3.0    0.0    2.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     3.0    1.0    0.0       st3	{ v1.4h, v2.4h, v3.4h }, [x27], #24
+# CHECK-NEXT: 5.     1     4.0    0.0    2.0       add	x0, x27, #1
+# CHECK-NEXT:        6     2.5    0.3    1.2       <total>
 
 # CHECK:      [73] Code Region - G74
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      707
-# CHECK-NEXT: Total uOps:        3800
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    5.37
+# CHECK-NEXT: uOps Per Cycle:    2.83
 # CHECK-NEXT: IPC:               1.41
 # CHECK-NEXT: Block RThroughput: 7.0
 
@@ -4514,14 +4514,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeeeeER  .  .   st3	{ v1.4s, v2.4s, v3.4s }, [x27], #48
 # CHECK-NEXT: [0,1]     D=eE---R  .  .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeeeER  .  .   st3	{ v1.8b, v2.8b, v3.8b }, [x27], #24
-# CHECK-NEXT: [0,3]     .D=eE--R  .  .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . D=eeeeeER  .   st3	{ v1.8h, v2.8h, v3.8h }, [x27], #48
-# CHECK-NEXT: [0,5]     . D==eE---R  .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  D=eeeeeER .   st3	{ v1.16b, v2.16b, v3.16b }, [x27], #48
-# CHECK-NEXT: [0,7]     .  D==eE---R .   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .   D==eeeeeER   st3	{ v1.2d, v2.2d, v3.2d }, [x27], x28
-# CHECK-NEXT: [0,9]     .   D===eE---R   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeER  .  .   st3	{ v1.8b, v2.8b, v3.8b }, [x27], #24
+# CHECK-NEXT: [0,3]     D==eE--R  .  .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D==eeeeeER  .   st3	{ v1.8h, v2.8h, v3.8h }, [x27], #48
+# CHECK-NEXT: [0,5]     .D===eE---R  .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D===eeeeeER .   st3	{ v1.16b, v2.16b, v3.16b }, [x27], #48
+# CHECK-NEXT: [0,7]     .D====eE---R .   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D====eeeeeER   st3	{ v1.2d, v2.2d, v3.2d }, [x27], x28
+# CHECK-NEXT: [0,9]     . D=====eE---R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -4532,25 +4532,25 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       st3	{ v1.4s, v2.4s, v3.4s }, [x27], #48
 # CHECK-NEXT: 1.     1     2.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       st3	{ v1.8b, v2.8b, v3.8b }, [x27], #24
-# CHECK-NEXT: 3.     1     2.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     2.0    1.0    0.0       st3	{ v1.8h, v2.8h, v3.8h }, [x27], #48
-# CHECK-NEXT: 5.     1     3.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     2.0    0.0    0.0       st3	{ v1.16b, v2.16b, v3.16b }, [x27], #48
-# CHECK-NEXT: 7.     1     3.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     3.0    1.0    0.0       st3	{ v1.2d, v2.2d, v3.2d }, [x27], x28
-# CHECK-NEXT: 9.     1     4.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        10    2.3    0.3    1.4       <total>
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       st3	{ v1.8b, v2.8b, v3.8b }, [x27], #24
+# CHECK-NEXT: 3.     1     3.0    0.0    2.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     3.0    1.0    0.0       st3	{ v1.8h, v2.8h, v3.8h }, [x27], #48
+# CHECK-NEXT: 5.     1     4.0    0.0    3.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     4.0    0.0    0.0       st3	{ v1.16b, v2.16b, v3.16b }, [x27], #48
+# CHECK-NEXT: 7.     1     5.0    0.0    3.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     5.0    1.0    0.0       st3	{ v1.2d, v2.2d, v3.2d }, [x27], x28
+# CHECK-NEXT: 9.     1     6.0    0.0    3.0       add	x0, x27, #1
+# CHECK-NEXT:        10    3.5    0.3    1.4       <total>
 
 # CHECK:      [74] Code Region - G75
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      706
-# CHECK-NEXT: Total uOps:        3400
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    4.82
+# CHECK-NEXT: uOps Per Cycle:    2.83
 # CHECK-NEXT: IPC:               1.42
 # CHECK-NEXT: Block RThroughput: 6.0
 
@@ -4560,14 +4560,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeeeER   . .   st3	{ v1.2s, v2.2s, v3.2s }, [x27], x28
 # CHECK-NEXT: [0,1]     D=eE--R   . .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeeeER  . .   st3	{ v1.4h, v2.4h, v3.4h }, [x27], x28
-# CHECK-NEXT: [0,3]     .D=eE--R  . .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . DeeeeeER. .   st3	{ v1.4s, v2.4s, v3.4s }, [x27], x28
-# CHECK-NEXT: [0,5]     . D=eE---R. .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  DeeeeER. .   st3	{ v1.8b, v2.8b, v3.8b }, [x27], x28
-# CHECK-NEXT: [0,7]     .  D=eE--R. .   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .   D=eeeeeER   st3	{ v1.8h, v2.8h, v3.8h }, [x27], x28
-# CHECK-NEXT: [0,9]     .   D==eE---R   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeER  . .   st3	{ v1.4h, v2.4h, v3.4h }, [x27], x28
+# CHECK-NEXT: [0,3]     D==eE--R  . .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D=eeeeeER. .   st3	{ v1.4s, v2.4s, v3.4s }, [x27], x28
+# CHECK-NEXT: [0,5]     .D==eE---R. .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeeeER. .   st3	{ v1.8b, v2.8b, v3.8b }, [x27], x28
+# CHECK-NEXT: [0,7]     .D===eE--R. .   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D===eeeeeER   st3	{ v1.8h, v2.8h, v3.8h }, [x27], x28
+# CHECK-NEXT: [0,9]     . D====eE---R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -4578,25 +4578,25 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       st3	{ v1.2s, v2.2s, v3.2s }, [x27], x28
 # CHECK-NEXT: 1.     1     2.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       st3	{ v1.4h, v2.4h, v3.4h }, [x27], x28
-# CHECK-NEXT: 3.     1     2.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    0.0    0.0       st3	{ v1.4s, v2.4s, v3.4s }, [x27], x28
-# CHECK-NEXT: 5.     1     2.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     1.0    0.0    0.0       st3	{ v1.8b, v2.8b, v3.8b }, [x27], x28
-# CHECK-NEXT: 7.     1     2.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     2.0    1.0    0.0       st3	{ v1.8h, v2.8h, v3.8h }, [x27], x28
-# CHECK-NEXT: 9.     1     3.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.7    0.2    1.2       <total>
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       st3	{ v1.4h, v2.4h, v3.4h }, [x27], x28
+# CHECK-NEXT: 3.     1     3.0    0.0    2.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     2.0    0.0    0.0       st3	{ v1.4s, v2.4s, v3.4s }, [x27], x28
+# CHECK-NEXT: 5.     1     3.0    0.0    3.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       st3	{ v1.8b, v2.8b, v3.8b }, [x27], x28
+# CHECK-NEXT: 7.     1     4.0    0.0    2.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     4.0    1.0    0.0       st3	{ v1.8h, v2.8h, v3.8h }, [x27], x28
+# CHECK-NEXT: 9.     1     5.0    0.0    3.0       add	x0, x27, #1
+# CHECK-NEXT:        10    2.9    0.2    1.2       <total>
 
 # CHECK:      [75] Code Region - G76
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      606
-# CHECK-NEXT: Total uOps:        3200
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    5.28
+# CHECK-NEXT: uOps Per Cycle:    3.30
 # CHECK-NEXT: IPC:               1.65
 # CHECK-NEXT: Block RThroughput: 5.5
 
@@ -4606,14 +4606,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeeeeER  ..   st3	{ v1.16b, v2.16b, v3.16b }, [x27], x28
 # CHECK-NEXT: [0,1]     D=eE---R  ..   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeeeER  ..   st3	{ v1.b, v2.b, v3.b }[0], [x27], #3
-# CHECK-NEXT: [0,3]     .D=eE--R  ..   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . D=eeeeER..   st3	{ v1.b, v2.b, v3.b }[8], [x27], #3
-# CHECK-NEXT: [0,5]     . D==eE--R..   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  D=eeeeER.   st3	{ v1.b, v2.b, v3.b }[0], [x27], x28
-# CHECK-NEXT: [0,7]     .  D==eE--R.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .   D=eeeeER   st3	{ v1.b, v2.b, v3.b }[8], [x27], x28
-# CHECK-NEXT: [0,9]     .   D==eE--R   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeER  ..   st3	{ v1.b, v2.b, v3.b }[0], [x27], #3
+# CHECK-NEXT: [0,3]     D==eE--R  ..   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D==eeeeER..   st3	{ v1.b, v2.b, v3.b }[8], [x27], #3
+# CHECK-NEXT: [0,5]     .D===eE--R..   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D===eeeeER.   st3	{ v1.b, v2.b, v3.b }[0], [x27], x28
+# CHECK-NEXT: [0,7]     .D====eE--R.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D===eeeeER   st3	{ v1.b, v2.b, v3.b }[8], [x27], x28
+# CHECK-NEXT: [0,9]     . D====eE--R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -4624,25 +4624,25 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       st3	{ v1.16b, v2.16b, v3.16b }, [x27], x28
 # CHECK-NEXT: 1.     1     2.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       st3	{ v1.b, v2.b, v3.b }[0], [x27], #3
-# CHECK-NEXT: 3.     1     2.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     2.0    1.0    0.0       st3	{ v1.b, v2.b, v3.b }[8], [x27], #3
-# CHECK-NEXT: 5.     1     3.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     2.0    0.0    0.0       st3	{ v1.b, v2.b, v3.b }[0], [x27], x28
-# CHECK-NEXT: 7.     1     3.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     2.0    0.0    0.0       st3	{ v1.b, v2.b, v3.b }[8], [x27], x28
-# CHECK-NEXT: 9.     1     3.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        10    2.1    0.2    1.1       <total>
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       st3	{ v1.b, v2.b, v3.b }[0], [x27], #3
+# CHECK-NEXT: 3.     1     3.0    0.0    2.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     3.0    1.0    0.0       st3	{ v1.b, v2.b, v3.b }[8], [x27], #3
+# CHECK-NEXT: 5.     1     4.0    0.0    2.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     4.0    0.0    0.0       st3	{ v1.b, v2.b, v3.b }[0], [x27], x28
+# CHECK-NEXT: 7.     1     5.0    0.0    2.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     4.0    0.0    0.0       st3	{ v1.b, v2.b, v3.b }[8], [x27], x28
+# CHECK-NEXT: 9.     1     5.0    0.0    2.0       add	x0, x27, #1
+# CHECK-NEXT:        10    3.3    0.2    1.1       <total>
 
 # CHECK:      [76] Code Region - G77
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      506
-# CHECK-NEXT: Total uOps:        3000
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    5.93
+# CHECK-NEXT: uOps Per Cycle:    3.95
 # CHECK-NEXT: IPC:               1.98
 # CHECK-NEXT: Block RThroughput: 5.0
 
@@ -4652,14 +4652,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeeeER   .   st3	{ v1.h, v2.h, v3.h }[0], [x27], #6
 # CHECK-NEXT: [0,1]     D=eE--R   .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeeeER  .   st3	{ v1.h, v2.h, v3.h }[4], [x27], #6
-# CHECK-NEXT: [0,3]     .D=eE--R  .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . DeeeeER .   st3	{ v1.h, v2.h, v3.h }[0], [x27], x28
-# CHECK-NEXT: [0,5]     . D=eE--R .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  DeeeeER.   st3	{ v1.h, v2.h, v3.h }[4], [x27], x28
-# CHECK-NEXT: [0,7]     .  D=eE--R.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .   DeeeeER   st3	{ v1.s, v2.s, v3.s }[0], [x27], #12
-# CHECK-NEXT: [0,9]     .   D=eE--R   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeER  .   st3	{ v1.h, v2.h, v3.h }[4], [x27], #6
+# CHECK-NEXT: [0,3]     D==eE--R  .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D=eeeeER .   st3	{ v1.h, v2.h, v3.h }[0], [x27], x28
+# CHECK-NEXT: [0,5]     .D==eE--R .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeeeER.   st3	{ v1.h, v2.h, v3.h }[4], [x27], x28
+# CHECK-NEXT: [0,7]     .D===eE--R.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D==eeeeER   st3	{ v1.s, v2.s, v3.s }[0], [x27], #12
+# CHECK-NEXT: [0,9]     . D===eE--R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -4670,42 +4670,42 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       st3	{ v1.h, v2.h, v3.h }[0], [x27], #6
 # CHECK-NEXT: 1.     1     2.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       st3	{ v1.h, v2.h, v3.h }[4], [x27], #6
-# CHECK-NEXT: 3.     1     2.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    0.0    0.0       st3	{ v1.h, v2.h, v3.h }[0], [x27], x28
-# CHECK-NEXT: 5.     1     2.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     1.0    0.0    0.0       st3	{ v1.h, v2.h, v3.h }[4], [x27], x28
-# CHECK-NEXT: 7.     1     2.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     1.0    0.0    0.0       st3	{ v1.s, v2.s, v3.s }[0], [x27], #12
-# CHECK-NEXT: 9.     1     2.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.5    0.1    1.0       <total>
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       st3	{ v1.h, v2.h, v3.h }[4], [x27], #6
+# CHECK-NEXT: 3.     1     3.0    0.0    2.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     2.0    0.0    0.0       st3	{ v1.h, v2.h, v3.h }[0], [x27], x28
+# CHECK-NEXT: 5.     1     3.0    0.0    2.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       st3	{ v1.h, v2.h, v3.h }[4], [x27], x28
+# CHECK-NEXT: 7.     1     4.0    0.0    2.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     3.0    0.0    0.0       st3	{ v1.s, v2.s, v3.s }[0], [x27], #12
+# CHECK-NEXT: 9.     1     4.0    0.0    2.0       add	x0, x27, #1
+# CHECK-NEXT:        10    2.7    0.1    1.0       <total>
 
 # CHECK:      [77] Code Region - G78
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      706
-# CHECK-NEXT: Total uOps:        3600
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    5.10
+# CHECK-NEXT: uOps Per Cycle:    2.83
 # CHECK-NEXT: IPC:               1.42
 # CHECK-NEXT: Block RThroughput: 6.5
 
 # CHECK:      Timeline view:
-# CHECK-NEXT:                     0123
+# CHECK-NEXT:                     012
 # CHECK-NEXT: Index     0123456789
 
-# CHECK:      [0,0]     DeeeeER   .  .   st3	{ v1.s, v2.s, v3.s }[0], [x27], x28
-# CHECK-NEXT: [0,1]     D=eE--R   .  .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeeeER  .  .   st3	{ v1.d, v2.d, v3.d }[0], [x27], #24
-# CHECK-NEXT: [0,3]     .D=eE--R  .  .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . DeeeeER .  .   st3	{ v1.d, v2.d, v3.d }[0], [x27], x28
-# CHECK-NEXT: [0,5]     . D=eE--R .  .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  DeeeeER.  .   st4	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
-# CHECK-NEXT: [0,7]     .   DeE--R.  .   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .    DeeeeeeER   st4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
-# CHECK-NEXT: [0,9]     .    D=eE----R   add	x0, x27, #1
+# CHECK:      [0,0]     DeeeeER   . .   st3	{ v1.s, v2.s, v3.s }[0], [x27], x28
+# CHECK-NEXT: [0,1]     D=eE--R   . .   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeER  . .   st3	{ v1.d, v2.d, v3.d }[0], [x27], #24
+# CHECK-NEXT: [0,3]     D==eE--R  . .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D=eeeeER . .   st3	{ v1.d, v2.d, v3.d }[0], [x27], x28
+# CHECK-NEXT: [0,5]     .D==eE--R . .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeeeER. .   st4	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
+# CHECK-NEXT: [0,7]     .D===eE--R. .   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D==eeeeeeER   st4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
+# CHECK-NEXT: [0,9]     . D===eE----R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -4716,25 +4716,25 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       st3	{ v1.s, v2.s, v3.s }[0], [x27], x28
 # CHECK-NEXT: 1.     1     2.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       st3	{ v1.d, v2.d, v3.d }[0], [x27], #24
-# CHECK-NEXT: 3.     1     2.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    0.0    0.0       st3	{ v1.d, v2.d, v3.d }[0], [x27], x28
-# CHECK-NEXT: 5.     1     2.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     1.0    0.0    0.0       st4	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
-# CHECK-NEXT: 7.     1     1.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     1.0    1.0    0.0       st4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
-# CHECK-NEXT: 9.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.4    0.2    1.2       <total>
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       st3	{ v1.d, v2.d, v3.d }[0], [x27], #24
+# CHECK-NEXT: 3.     1     3.0    0.0    2.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     2.0    0.0    0.0       st3	{ v1.d, v2.d, v3.d }[0], [x27], x28
+# CHECK-NEXT: 5.     1     3.0    0.0    2.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       st4	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
+# CHECK-NEXT: 7.     1     4.0    0.0    2.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     3.0    0.0    0.0       st4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
+# CHECK-NEXT: 9.     1     4.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT:        10    2.7    0.1    1.2       <total>
 
 # CHECK:      [78] Code Region - G79
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      1205
-# CHECK-NEXT: Total uOps:        5800
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    4.81
+# CHECK-NEXT: uOps Per Cycle:    1.66
 # CHECK-NEXT: IPC:               0.83
 # CHECK-NEXT: Block RThroughput: 12.0
 
@@ -4744,14 +4744,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeeeeeER .    ..   st4	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #32
 # CHECK-NEXT: [0,1]     D=eE----R .    ..   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeeeeeeER    ..   st4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
-# CHECK-NEXT: [0,3]     . DeE-----R    ..   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     .  DeeeeeeER   ..   st4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #32
-# CHECK-NEXT: [0,5]     .  D=eE----R   ..   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .   D==eeeeeeeER.   st4	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
-# CHECK-NEXT: [0,7]     .    D==eE-----R.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .    .D=eeeeeeeER   st4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
-# CHECK-NEXT: [0,9]     .    . D=eE-----R   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeeeeER    ..   st4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
+# CHECK-NEXT: [0,3]     D==eE-----R    ..   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D==eeeeeeER   ..   st4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #32
+# CHECK-NEXT: [0,5]     .D===eE----R   ..   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D=====eeeeeeeER.   st4	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
+# CHECK-NEXT: [0,7]     .D======eE-----R.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D=====eeeeeeeER   st4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
+# CHECK-NEXT: [0,9]     . D======eE-----R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -4762,25 +4762,25 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       st4	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #32
 # CHECK-NEXT: 1.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       st4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
-# CHECK-NEXT: 3.     1     1.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    1.0    0.0       st4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #32
-# CHECK-NEXT: 5.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     3.0    2.0    0.0       st4	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
-# CHECK-NEXT: 7.     1     3.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     2.0    0.0    0.0       st4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
-# CHECK-NEXT: 9.     1     2.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.8    0.4    2.3       <total>
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       st4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
+# CHECK-NEXT: 3.     1     3.0    0.0    5.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     3.0    1.0    0.0       st4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #32
+# CHECK-NEXT: 5.     1     4.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     6.0    2.0    0.0       st4	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
+# CHECK-NEXT: 7.     1     7.0    0.0    5.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     6.0    0.0    0.0       st4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
+# CHECK-NEXT: 9.     1     7.0    0.0    5.0       add	x0, x27, #1
+# CHECK-NEXT:        10    4.1    0.4    2.3       <total>
 
 # CHECK:      [79] Code Region - G80
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      1006
-# CHECK-NEXT: Total uOps:        4800
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    4.77
+# CHECK-NEXT: uOps Per Cycle:    1.99
 # CHECK-NEXT: IPC:               0.99
 # CHECK-NEXT: Block RThroughput: 9.5
 
@@ -4789,15 +4789,15 @@ add x0, x27, 1
 # CHECK-NEXT: Index     0123456789
 
 # CHECK:      [0,0]     DeeeeER   .    .   st4	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], x28
-# CHECK-NEXT: [0,1]     .DeE--R   .    .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     . DeeeeeeER    .   st4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
-# CHECK-NEXT: [0,3]     . D=eE----R    .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     .  D=eeeeeeER  .   st4	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
-# CHECK-NEXT: [0,5]     .  D==eE----R  .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .   D=eeeeeeeER.   st4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
-# CHECK-NEXT: [0,7]     .    D=eE-----R.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .    .D=eeeeeeER   st4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
-# CHECK-NEXT: [0,9]     .    .D==eE----R   add	x0, x27, #1
+# CHECK-NEXT: [0,1]     D=eE--R   .    .   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeeeER.    .   st4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
+# CHECK-NEXT: [0,3]     D==eE----R.    .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D===eeeeeeER  .   st4	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
+# CHECK-NEXT: [0,5]     .D====eE----R  .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D====eeeeeeeER.   st4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
+# CHECK-NEXT: [0,7]     .D=====eE-----R.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D=====eeeeeeER   st4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
+# CHECK-NEXT: [0,9]     . D======eE----R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -4807,43 +4807,43 @@ add x0, x27, 1
 
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       st4	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], x28
-# CHECK-NEXT: 1.     1     1.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    1.0    0.0       st4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
-# CHECK-NEXT: 3.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     2.0    1.0    0.0       st4	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
-# CHECK-NEXT: 5.     1     3.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     2.0    0.0    0.0       st4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
-# CHECK-NEXT: 7.     1     2.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     2.0    1.0    0.0       st4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
-# CHECK-NEXT: 9.     1     3.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.9    0.4    1.9       <total>
+# CHECK-NEXT: 1.     1     2.0    0.0    2.0       add	x0, x27, #1
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       st4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
+# CHECK-NEXT: 3.     1     3.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     4.0    2.0    0.0       st4	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
+# CHECK-NEXT: 5.     1     5.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     5.0    0.0    0.0       st4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
+# CHECK-NEXT: 7.     1     6.0    0.0    5.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     6.0    1.0    0.0       st4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
+# CHECK-NEXT: 9.     1     7.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT:        10    4.1    0.4    1.9       <total>
 
 # CHECK:      [80] Code Region - G81
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
-# CHECK-NEXT: Total Cycles:      808
-# CHECK-NEXT: Total uOps:        5200
+# CHECK-NEXT: Total Cycles:      807
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    6.44
+# CHECK-NEXT: uOps Per Cycle:    2.48
 # CHECK-NEXT: IPC:               1.24
-# CHECK-NEXT: Block RThroughput: 6.5
+# CHECK-NEXT: Block RThroughput: 6.0
 
 # CHECK:      Timeline view:
-# CHECK-NEXT:                     012345
+# CHECK-NEXT:                     01234
 # CHECK-NEXT: Index     0123456789
 
-# CHECK:      [0,0]     DeeeeeeeER.    .   st4	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], x28
-# CHECK-NEXT: [0,1]     .DeE-----R.    .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     . DeeeeeeeER   .   st4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
-# CHECK-NEXT: [0,3]     .  DeE-----R   .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     .   DeeeeeeER  .   st4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], #4
-# CHECK-NEXT: [0,5]     .   D=eE----R  .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .    D=eeeeeeER.   st4	{ v1.b, v2.b, v3.b, v4.b }[8], [x27], #4
-# CHECK-NEXT: [0,7]     .    D==eE----R.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .    .D=eeeeeeER   st4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], x28
-# CHECK-NEXT: [0,9]     .    .D==eE----R   add	x0, x27, #1
+# CHECK:      [0,0]     DeeeeeeeER.   .   st4	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], x28
+# CHECK-NEXT: [0,1]     D=eE-----R.   .   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeeeeER   .   st4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
+# CHECK-NEXT: [0,3]     D==eE-----R   .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D=eeeeeeER   .   st4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], #4
+# CHECK-NEXT: [0,5]     .D==eE----R   .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D====eeeeeeER.   st4	{ v1.b, v2.b, v3.b, v4.b }[8], [x27], #4
+# CHECK-NEXT: [0,7]     .D=====eE----R.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D====eeeeeeER   st4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], x28
+# CHECK-NEXT: [0,9]     . D=====eE----R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -4853,26 +4853,26 @@ add x0, x27, 1
 
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       st4	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], x28
-# CHECK-NEXT: 1.     1     1.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    1.0    0.0       st4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
-# CHECK-NEXT: 3.     1     1.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    1.0    0.0       st4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], #4
-# CHECK-NEXT: 5.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     2.0    1.0    0.0       st4	{ v1.b, v2.b, v3.b, v4.b }[8], [x27], #4
-# CHECK-NEXT: 7.     1     3.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     2.0    0.0    0.0       st4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], x28
-# CHECK-NEXT: 9.     1     3.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.7    0.4    2.2       <total>
+# CHECK-NEXT: 1.     1     2.0    0.0    5.0       add	x0, x27, #1
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       st4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
+# CHECK-NEXT: 3.     1     3.0    0.0    5.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     2.0    0.0    0.0       st4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], #4
+# CHECK-NEXT: 5.     1     3.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     5.0    2.0    0.0       st4	{ v1.b, v2.b, v3.b, v4.b }[8], [x27], #4
+# CHECK-NEXT: 7.     1     6.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     5.0    0.0    0.0       st4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], x28
+# CHECK-NEXT: 9.     1     6.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT:        10    3.5    0.3    2.2       <total>
 
 # CHECK:      [81] Code Region - G82
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      508
-# CHECK-NEXT: Total uOps:        4000
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    7.87
+# CHECK-NEXT: uOps Per Cycle:    3.94
 # CHECK-NEXT: IPC:               1.97
 # CHECK-NEXT: Block RThroughput: 5.0
 
@@ -4882,14 +4882,14 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeeeeeER . .   st4	{ v1.b, v2.b, v3.b, v4.b }[8], [x27], x28
 # CHECK-NEXT: [0,1]     D=eE----R . .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeeeeeER. .   st4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], #8
-# CHECK-NEXT: [0,3]     .D=eE----R. .   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . DeeeeeeER .   st4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], #8
-# CHECK-NEXT: [0,5]     . D=eE----R .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  DeeeeeeER.   st4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], x28
-# CHECK-NEXT: [0,7]     .  D=eE----R.   add	x0, x27, #1
-# CHECK-NEXT: [0,8]     .   DeeeeeeER   st4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], x28
-# CHECK-NEXT: [0,9]     .   D=eE----R   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeeeER. .   st4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], #8
+# CHECK-NEXT: [0,3]     D==eE----R. .   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D=eeeeeeER .   st4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], #8
+# CHECK-NEXT: [0,5]     .D==eE----R .   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeeeeeER.   st4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], x28
+# CHECK-NEXT: [0,7]     .D===eE----R.   add	x0, x27, #1
+# CHECK-NEXT: [0,8]     . D==eeeeeeER   st4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], x28
+# CHECK-NEXT: [0,9]     . D===eE----R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -4900,27 +4900,27 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       st4	{ v1.b, v2.b, v3.b, v4.b }[8], [x27], x28
 # CHECK-NEXT: 1.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], #8
-# CHECK-NEXT: 3.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     1.0    0.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], #8
-# CHECK-NEXT: 5.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     1.0    0.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], x28
-# CHECK-NEXT: 7.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 8.     1     1.0    0.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], x28
-# CHECK-NEXT: 9.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        10    1.5    0.1    2.0       <total>
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], #8
+# CHECK-NEXT: 3.     1     3.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     2.0    0.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], #8
+# CHECK-NEXT: 5.     1     3.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], x28
+# CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT: 8.     1     3.0    0.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], x28
+# CHECK-NEXT: 9.     1     4.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT:        10    2.7    0.1    2.0       <total>
 
 # CHECK:      [82] Code Region - G83
 
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      800
 # CHECK-NEXT: Total Cycles:      506
-# CHECK-NEXT: Total uOps:        2800
+# CHECK-NEXT: Total uOps:        1600
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    5.53
+# CHECK-NEXT: uOps Per Cycle:    3.16
 # CHECK-NEXT: IPC:               1.58
-# CHECK-NEXT: Block RThroughput: 3.5
+# CHECK-NEXT: Block RThroughput: 2.0
 
 # CHECK:      Timeline view:
 # CHECK-NEXT:                     0
@@ -4928,12 +4928,12 @@ add x0, x27, 1
 
 # CHECK:      [0,0]     DeeeeeeER .   st4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], #16
 # CHECK-NEXT: [0,1]     D=eE----R .   add	x0, x27, #1
-# CHECK-NEXT: [0,2]     .DeeeeeeER.   st4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], x28
-# CHECK-NEXT: [0,3]     .D=eE----R.   add	x0, x27, #1
-# CHECK-NEXT: [0,4]     . D=eeeeER.   st4	{ v1.d, v2.d, v3.d, v4.d }[0], [x27], #32
-# CHECK-NEXT: [0,5]     . D==eE--R.   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     .  D=eeeeER   st4	{ v1.d, v2.d, v3.d, v4.d }[0], [x27], x28
-# CHECK-NEXT: [0,7]     .  D==eE--R   add	x0, x27, #1
+# CHECK-NEXT: [0,2]     D=eeeeeeER.   st4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], x28
+# CHECK-NEXT: [0,3]     D==eE----R.   add	x0, x27, #1
+# CHECK-NEXT: [0,4]     .D==eeeeER.   st4	{ v1.d, v2.d, v3.d, v4.d }[0], [x27], #32
+# CHECK-NEXT: [0,5]     .D===eE--R.   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D===eeeeER   st4	{ v1.d, v2.d, v3.d, v4.d }[0], [x27], x28
+# CHECK-NEXT: [0,7]     .D====eE--R   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -4944,13 +4944,13 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       st4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], #16
 # CHECK-NEXT: 1.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 2.     1     1.0    0.0    0.0       st4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], x28
-# CHECK-NEXT: 3.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT: 4.     1     2.0    1.0    0.0       st4	{ v1.d, v2.d, v3.d, v4.d }[0], [x27], #32
-# CHECK-NEXT: 5.     1     3.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     2.0    0.0    0.0       st4	{ v1.d, v2.d, v3.d, v4.d }[0], [x27], x28
-# CHECK-NEXT: 7.     1     3.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        8     2.0    0.3    1.5       <total>
+# CHECK-NEXT: 2.     1     2.0    0.0    0.0       st4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], x28
+# CHECK-NEXT: 3.     1     3.0    0.0    4.0       add	x0, x27, #1
+# CHECK-NEXT: 4.     1     3.0    1.0    0.0       st4	{ v1.d, v2.d, v3.d, v4.d }[0], [x27], #32
+# CHECK-NEXT: 5.     1     4.0    0.0    2.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     4.0    0.0    0.0       st4	{ v1.d, v2.d, v3.d, v4.d }[0], [x27], x28
+# CHECK-NEXT: 7.     1     5.0    0.0    2.0       add	x0, x27, #1
+# CHECK-NEXT:        8     3.0    0.3    1.5       <total>
 
 # CHECK:      [83] Code Region - G84
 
@@ -4990,10 +4990,10 @@ add x0, x27, 1
 # CHECK:      Iterations:        100
 # CHECK-NEXT: Instructions:      1000
 # CHECK-NEXT: Total Cycles:      504
-# CHECK-NEXT: Total uOps:        2200
+# CHECK-NEXT: Total uOps:        2000
 
 # CHECK:      Dispatch Width:    8
-# CHECK-NEXT: uOps Per Cycle:    4.37
+# CHECK-NEXT: uOps Per Cycle:    3.97
 # CHECK-NEXT: IPC:               1.98
 # CHECK-NEXT: Block RThroughput: 3.5
 
@@ -5003,13 +5003,13 @@ add x0, x27, 1
 # CHECK:      [0,0]     DeeER.  .   stp	q1, q2, [x27], #992
 # CHECK-NEXT: [0,1]     D=eER.  .   add	x0, x27, #1
 # CHECK-NEXT: [0,2]     D=eeER  .   stp	s1, s2, [x27, #248]!
-# CHECK-NEXT: [0,3]     .D=eER  .   add	x0, x27, #1
+# CHECK-NEXT: [0,3]     D==eER  .   add	x0, x27, #1
 # CHECK-NEXT: [0,4]     .D=eeER .   stp	d1, d2, [x27, #496]!
 # CHECK-NEXT: [0,5]     .D==eER .   add	x0, x27, #1
-# CHECK-NEXT: [0,6]     . D=eeER.   stp	q1, q2, [x27, #992]!
-# CHECK-NEXT: [0,7]     . D==eER.   add	x0, x27, #1
+# CHECK-NEXT: [0,6]     .D==eeER.   stp	q1, q2, [x27, #992]!
+# CHECK-NEXT: [0,7]     .D===eER.   add	x0, x27, #1
 # CHECK-NEXT: [0,8]     . D==eER.   stp	w1, w2, [x27], #248
-# CHECK-NEXT: [0,9]     .  D==eER   add	x0, x27, #1
+# CHECK-NEXT: [0,9]     . D===eER   add	x0, x27, #1
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions
@@ -5021,14 +5021,14 @@ add x0, x27, 1
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       stp	q1, q2, [x27], #992
 # CHECK-NEXT: 1.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       stp	s1, s2, [x27, #248]!
-# CHECK-NEXT: 3.     1     2.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT: 3.     1     3.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 4.     1     2.0    0.0    0.0       stp	d1, d2, [x27, #496]!
 # CHECK-NEXT: 5.     1     3.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT: 6.     1     2.0    0.0    0.0       stp	q1, q2, [x27, #992]!
-# CHECK-NEXT: 7.     1     3.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT: 6.     1     3.0    0.0    0.0       stp	q1, q2, [x27, #992]!
+# CHECK-NEXT: 7.     1     4.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       stp	w1, w2, [x27], #248
-# CHECK-NEXT: 9.     1     3.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        10    2.3    0.1    0.0       <total>
+# CHECK-NEXT: 9.     1     4.0    0.0    0.0       add	x0, x27, #1
+# CHECK-NEXT:        10    2.7    0.1    0.0       <total>
 
 # CHECK:      [85] Code Region - G86
 


### PR DESCRIPTION
…Ops only)

Several SchedWriteRes definitions represented instructions holding a resource for N cycles as N separate 1-cycle micro-ops, rather than 1 micro-op with ReleaseAtCycles=[N]. This inflates NumMicroOps, which causes SchedBoundary::checkHazard() to treat these instructions as monopolizing issue slots (checked against IssueWidth) that are, in reality, free for unrelated neighboring instructions.

This patch changes NumMicroOps and its resource representation only -- Latency and RThroughput are unaffected by construction (occupied cycles per resource are preserved by the transformation) and unchanged in practice, verified across all regenerated llvm-mca test outputs.

Naming convention for the new/renamed SchedWriteRes classes: V1Write_<Latency>c<N>_<Q1><Res1>_<Q2><Res2>...
  - If ReleaseAtCycles is uniform across all resources (or absent, i.e. 1 cycle each): <N> is that common value (omitted if 1), and each <Qi> is the micro-op count on that resource (normally 1 after this patch).
  - If ReleaseAtCycles differs between resources: <N> is max(ReleaseAtCycles), and each <Qi> is that resource's own ReleaseAtCycles value (not a micro-op count), e.g. V1Write_8c3_2L_3V for ReleaseAtCycles=[2,3]. This distinguishes classes that would otherwise look identical from their name alone despite different per-resource occupancy (see V1Write_8c3_1L_1V [3,3] vs V1Write_8c3_2L_3V [2,3]: merging them, tested experimentally, regresses LD3 D-form RThroughput from 0.75 to 1.00).
  
  This patch has bigger impact on instructions with large number of micro ops like ST4 and others.
  
This is the follow-up to PR #126707.
@davemgreen, @Asher8118 and @c-rhodes reviewed PR #126707 (one year ago, sorry).