### PR TITLE
[dyndbg][nfc] use -emit-llvm-only in coverage test

### DIFF
--- a/clang/test/DebugInfo/DynamicDebugging/profile-coverage.c
+++ b/clang/test/DebugInfo/DynamicDebugging/profile-coverage.c
@@ -1,5 +1,5 @@
 // Instrumentation from PGO/code coverage isn't supported yet for dyndbg.
-// RUN: not %clang_cc1 -triple x86_64-unknown-unknown %s -fprofile-instrument=clang -fdynamic-debugging -emit-llvm \
+// RUN: not %clang_cc1 -triple x86_64-unknown-unknown %s -fprofile-instrument=clang -fdynamic-debugging -emit-llvm-only \
 // RUN:    --discard-dynamic-debugging-debug-module 2>&1 \
 // RUN: | FileCheck %s
 // CHECK: error: '-fdynamic-debugging' unsupported with instrumentation (PGO/code coverage)


### PR DESCRIPTION
Follow-up to https://github.com/llvm/llvm-project/pull/216307