### PR TITLE
[Mips] Fix getInstSizeInBytes for instructions with delay slots

### DIFF
--- a/llvm/lib/Target/Mips/MipsInstrInfo.cpp
+++ b/llvm/lib/Target/Mips/MipsInstrInfo.cpp
@@ -710,7 +710,7 @@ unsigned MipsInstrInfo::getInstSizeInBytes(const MachineInstr &MI) const {
   default:
     if (MI.hasDelaySlot()) {
       // instr + 1 nop
-      return 8;
+      return MI.getDesc().getSize() + 4;
     }
     return MI.getDesc().getSize();
   case  TargetOpcode::INLINEASM:

--- a/llvm/lib/Target/Mips/MipsInstrInfo.cpp
+++ b/llvm/lib/Target/Mips/MipsInstrInfo.cpp
@@ -708,6 +708,10 @@ bool MipsInstrInfo::isAsCheapAsAMove(const MachineInstr &MI) const {
 unsigned MipsInstrInfo::getInstSizeInBytes(const MachineInstr &MI) const {
   switch (MI.getOpcode()) {
   default:
+    if (MI.hasDelaySlot()) {
+      // instr + 1 nop
+      return 8;
+    }
     return MI.getDesc().getSize();
   case  TargetOpcode::INLINEASM:
   case  TargetOpcode::INLINEASM_BR: {       // Inline Asm: Variable size.


### PR DESCRIPTION
MIPS branch/jump instructions (B, BEQ, JALR64Pseudo, PseudoReturn64, etc.) have a delay slot. The actual encoded size is 8 bytes (instr + NOP). This fixes "out of range PC16 fixup" errors on large functions.

This issue was exposed in llvm 23 by commit pr #191460 which changed MipsBranchExpansion to use MBB::iterator instead of instr_iterator, making the MBB size calculation more accurate and revealing the pre-existing bug.

Thanks for the pr #187703 `AllowOverEstimate` to help find instr which actual size mismatch expected size .

Fix #112010.