### PR TITLE
[lldb] Keep DWARF dereference results address-sized

### DIFF
--- a/lldb/source/Expression/DWARFExpression.cpp
+++ b/lldb/source/Expression/DWARFExpression.cpp
@@ -1095,6 +1095,9 @@ static llvm::Error Evaluate_DW_OP_deref(EvalContext &eval_ctx,
     return llvm::createStringError("invalid value for %s", op_name);
   }
 
+  // Both operations push a generic, address-sized result.
+  eval_ctx.stack.back().GetScalar().TruncOrExtendTo(size_addr_bytes * 8,
+                                                    /*sign=*/false);
   return llvm::Error::success();
 }
 

--- a/lldb/source/Expression/DWARFExpression.cpp
+++ b/lldb/source/Expression/DWARFExpression.cpp
@@ -1095,7 +1095,11 @@ static llvm::Error Evaluate_DW_OP_deref(EvalContext &eval_ctx,
     return llvm::createStringError("invalid value for %s", op_name);
   }
 
-  // Both operations push a generic, address-sized result.
+  // Both operations push a generic, address-sized result. The truncation to
+  // `size` bytes is unnecessary here because the branches above already limit
+  // the value to `size` bytes; it is only done for consistency with the
+  // Register/Implicit path above.
+  eval_ctx.stack.back().GetScalar().TruncOrExtendTo(size * 8, /*sign=*/false);
   eval_ctx.stack.back().GetScalar().TruncOrExtendTo(size_addr_bytes * 8,
                                                     /*sign=*/false);
   return llvm::Error::success();

--- a/lldb/unittests/Expression/DWARFExpressionTest.cpp
+++ b/lldb/unittests/Expression/DWARFExpressionTest.cpp
@@ -1399,6 +1399,27 @@ TEST_F(DWARFExpressionMockProcessTest, DW_OP_deref) {
                        ExpectScalar(Scalar(4)));
 }
 
+TEST_F(DWARFExpressionMockProcessTest, DW_OP_deref_address_size) {
+  MockMemory::Map memory = {
+      {{0x4, 4}, {0x2a, 0x00, 0x00, 0x00}},
+      {{0x8, 1}, {0xff}},
+  };
+  TestContext test_ctx;
+  ASSERT_TRUE(
+      CreateTestContext(&test_ctx, "i386-pc-linux", {}, std::move(memory)));
+  ExecutionContext exe_ctx(test_ctx.process_sp);
+
+  auto deref_result =
+      Evaluate({DW_OP_lit4, DW_OP_deref, DW_OP_stack_value}, {}, {}, &exe_ctx);
+  ASSERT_THAT_EXPECTED(deref_result, ExpectScalar(32, 0x2a, false));
+  EXPECT_EQ(deref_result->GetScalar().GetAPSInt().getBitWidth(), 32u);
+
+  auto deref_size_result = Evaluate(
+      {DW_OP_lit8, DW_OP_deref_size, 1, DW_OP_stack_value}, {}, {}, &exe_ctx);
+  ASSERT_THAT_EXPECTED(deref_size_result, ExpectScalar(32, 0xff, false));
+  EXPECT_EQ(deref_size_result->GetScalar().GetAPSInt().getBitWidth(), 32u);
+}
+
 TEST_F(DWARFExpressionMockProcessTest, WASM_DW_OP_addr) {
   // Set up a wasm target
   TestContext test_ctx;


### PR DESCRIPTION
`DW_OP_deref` and `DW_OP_deref_size` produce the DWARF generic type, but the
ordinary memory paths left the `uint64_t` returned by `GetMaxU64` on the
expression stack. This made their results 64 bits even when evaluating an
expression for a 32-bit target.

Normalize successful memory dereference results to the target address width
using unsigned extension. Add i386 unit coverage for both operations,
including the `DW_OP_deref_size` zero-extension behavior and explicit APSInt
width checks.

Fixes #210991.