### PR TITLE
[Flang] Handle self-referencing KIND selectors

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -10580,6 +10580,21 @@ void ResolveNamesVisitor::PreSpecificationConstruct(
       spec.u);
 }
 
+static bool IsCallOfDeclaredEntity(
+    const parser::Call &call, const std::list<parser::EntityDecl> &entities) {
+  // Pure query: do not resolve names or modify symbols/scopes.
+  const auto &procDesignator{std::get<parser::ProcedureDesignator>(call.t)};
+  if (const auto *name{std::get_if<parser::Name>(&procDesignator.u)}) {
+    for (const auto &ent : entities) {
+      const auto &objName{std::get<parser::ObjectName>(ent.t)};
+      if (name->source == objName.source) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 void ResolveNamesVisitor::EarlyDummyTypeDeclaration(
     const parser::Statement<common::Indirection<parser::TypeDeclarationStmt>>
         &stmt) {
@@ -10595,6 +10610,10 @@ void ResolveNamesVisitor::EarlyDummyTypeDeclaration(
             // nonempty argument list, to prevent implicitly typing names
             // that might appear.  (TODO: But maybe INTEGER(KIND(n)) after
             // an explicit declaration of 'n' would be useful.)
+            return;
+          }
+          if (IsCallOfDeclaredEntity(*call, entities)) {
+            // Avoid implicitly typing the entity referenced by the KIND call.
             return;
           }
         } else if (!parser::Unwrap<parser::KindSelector::StarSize>(*kind) &&

--- a/flang/test/Semantics/resolve37.f90
+++ b/flang/test/Semantics/resolve37.f90
@@ -47,3 +47,8 @@ integer, parameter :: sok(*)=[1,2]/[1,2]
 !ERROR: Must be a constant value
 integer, parameter :: snok(*)=[1,2]/[1,0]
 end
+
+subroutine kind_selector_name_same_as_declared_entity(a, n)
+  !ERROR: Must be a constant value
+  integer(n()) n
+end


### PR DESCRIPTION
EarlyDummyTypeDeclaration may implicitly type a name referenced by a KIND selector when that name is also declared by the same type declaration statement. This can lead to an inconsistent semantic state and a compiler crash.

Return early when the KIND selector refers to an entity being declared by the same statement.

Add a regression test for this case.

Fixes https://github.com/llvm/llvm-project/issues/209505