### PR TITLE
[orc-rt] Rename "managed code" to "keepalive". NFC.

### DIFF
--- a/orc-rt/docs/Design.md
+++ b/orc-rt/docs/Design.md
@@ -64,33 +64,33 @@ to abandon any fine-grained book-keeping that is only needed to service
 controller requests. Many Services will implement `onDetach` as a no-op.
 
 The `onShutdown` operation will be called at `Session` destruction time, after
-all in-flight managed code calls have completed. Services should release all
+all outstanding keepalives have been released. Services should release all
 held resources during `onShutdown`.
 
-### Managed code execution and shutdown
+### Keepalives and shutdown
 
 Session teardown must not proceed while JIT'd code is still live on a stack:
 freeing the JIT'd code (and the resources it runs against) out from under those
 frames would crash the moment control returns to them.
 
-To help enforce this the Session carries a managed-code `TaskGroup`. Code that
-is about to run JIT'd code obtains a `TaskGroup::Token` from the group to
-bracket that execution, and the group delays Session shutdown until every Token
-has been released. `Session::callManagedCode` acquires and holds a Token for you
-around a synchronous call; Tokens can also be acquired manually from the
-`TokenSource` returned by `Session::managedCodeTokenSource`.
+To help enforce this the Session carries a keepalive `TaskGroup`. Code that
+is about to run JIT'd code obtains a `TaskGroup::Token` -- a *keepalive* -- from
+the group to bracket that execution, and the group delays Session shutdown until
+every keepalive has been released. `Session::callWithKeepalive` acquires and
+holds one for you around a synchronous call; keepalives can also be acquired
+manually from the `TokenSource` returned by `Session::keepaliveTokenSource`.
 
-A Token brackets a single span of execution on a stack -- *not* a whole chain of
-asynchronous operations. When an asynchronous operation captures a continuation,
-whoever later invokes that continuation must obtain a fresh Token to bracket the
-invocation (the continuation can't do it itself: its entry point may already be
-JIT'd code).
+A keepalive brackets a single span of execution on a stack -- *not* a whole
+chain of asynchronous operations. When an asynchronous operation captures a
+continuation, whoever later invokes that continuation must obtain a fresh
+keepalive to bracket the invocation (the continuation can't do it itself: its
+entry point may already be JIT'd code).
 
-Token acquisition fails once Session shutdown has been requested -- and it can
-fail even for a nested or resumed call whose caller already holds a Token. So
+Keepalive acquisition fails once Session shutdown has been requested -- and it
+can fail even for a nested or resumed call whose caller already holds one. So
 every caller of JIT'd code needs a way to abort and unwind when acquisition is
-denied; `callManagedCode` reports denial through its return value, which callers
-must check.
+denied; `callWithKeepalive` reports denial through its return value, which
+callers must check.
 
 ### TaskDispatcher
 

--- a/orc-rt/include/orc-rt/Session.h
+++ b/orc-rt/include/orc-rt/Session.h
@@ -48,8 +48,8 @@ inline Session *unwrap(orc_rt_SessionRef S) noexcept {
 /// Represents an ORC executor Session.
 class Session {
 private:
-  // Implementation helper for callManagedCode (non-void version).
-  template <typename RetT> struct ManagedCodeCaller {
+  // Implementation helper for callWithKeepalive (non-void version).
+  template <typename RetT> struct KeepaliveCaller {
     template <typename FnT, typename... ArgTs>
     static std::optional<RetT> call(TaskGroup::Token Tok, FnT &&Fn,
                                     ArgTs &&...Args) {
@@ -59,8 +59,8 @@ private:
     }
   };
 
-  // Implementation helper for callManagedCode (void version).
-  template <> struct ManagedCodeCaller<void> {
+  // Implementation helper for callWithKeepalive (void version).
+  template <> struct KeepaliveCaller<void> {
     template <typename FnT, typename... ArgTs>
     static bool call(TaskGroup::Token Tok, FnT &&Fn, ArgTs &&...Args) {
       if (!Tok)
@@ -104,10 +104,10 @@ public:
     /// ControllerAccess implementations hold these for pending calls but cannot
     /// invoke them directly. Each must be completed exactly once, via one of
     /// three Session-provided paths, so the handler runs in a context where it
-    /// may safely touch managed code:
+    /// may safely enter Session-managed code:
     ///
     ///   - handleControllerCallResult(OnComplete, ResultBytes): the controller
-    ///     returned a result. Dispatches the handler under a fresh managed-code
+    ///     returned a result. Dispatches the handler under a fresh keepalive
     ///     token.
     ///
     ///   - failPendingControllerCall(OnComplete): a call that was enqueued
@@ -180,7 +180,7 @@ public:
     ///
     /// When disconnecting, a ControllerAccess must fail every still-pending
     /// controller call via failPendingControllerCall(OnComplete). This drain
-    /// must complete before notifyDisconnected, while the managed-code group is
+    /// must complete before notifyDisconnected, while the keepalive group is
     /// still open, so the completions are dispatched rather than dropped
     /// (failPendingControllerCall dispatches under a token and asserts the
     /// group is open). The drain must be serialized with the disconnecting
@@ -209,9 +209,9 @@ public:
     /// Because the disconnecting case completes the handler inline, the handler
     /// may run before callController returns, on the calling thread; callers
     /// must tolerate this. It is safe: the caller is still on the stack, so a
-    /// managed-code caller's token still covers the handler, and a non-managed
-    /// caller needs none (a handler that re-enters managed code must acquire
-    /// its own token and handle denial).
+    /// keepalive-holding caller's token still covers the handler, and a caller
+    /// without one needs none (a handler that enters Session-managed code must
+    /// acquire its own keepalive and handle denial).
     virtual void callController(OnControllerCallReturn OnComplete,
                                 orc_rt_ControllerHandlerTag T,
                                 WrapperFunctionBuffer ArgBytes) = 0;
@@ -243,8 +243,8 @@ public:
     }
 
     /// Complete a controller call with a result the controller returned, by
-    /// dispatching its handler under a fresh managed-code token. Must be called
-    /// while the managed-code group is still open -- i.e. before
+    /// dispatching its handler under a fresh keepalive token. Must be called
+    /// while the keepalive group is still open -- i.e. before
     /// notifyDisconnected; the Session asserts this.
     ///
     /// To fail a pending call on disconnect, use failPendingControllerCall.
@@ -266,7 +266,7 @@ public:
     }
 
     /// Fail a controller call by running its handler inline, on the current
-    /// thread, with a disconnect error -- without acquiring a managed-code
+    /// thread, with a disconnect error -- without acquiring a keepalive
     /// token.
     ///
     /// Use ONLY from within callController, to fail a call that arrives while
@@ -408,8 +408,8 @@ public:
   /// Shutdown proceeds through the following phases:
   ///   1. Detach: If not already detached, disconnects the controller and
   ///      notifies all Services via onDetach.
-  ///   2. Drain: Waits for all in-flight tasks accessing managed code to
-  ///      complete (via ManagedCodeTaskGroup).
+  ///   2. Drain: Waits for all outstanding keepalives to be released (via
+  ///      KeepaliveTaskGroup).
   ///   3. Shutdown services: Calls onShutdown on all Services in reverse
   ///      order.
   ///
@@ -425,36 +425,35 @@ public:
   /// Session has already shut down, the callback will be called immediately.
   void addOnShutdown(OnShutdownFn OnShutdown);
 
-  /// Return a TokenSource for this Session's ManagedCodeTaskGroup.
+  /// Return a TokenSource for this Session's keepalive TaskGroup.
   ///
   /// When calling code managed by a Session (e.g. JIT'd code, or library code
-  /// loaded on behalf of JIT'd code), clients should hold a token for this
-  /// group, which can be constructed from the returned TokenSource. That token
-  /// will delay Session teardown until all tasks accessing managed code have
-  /// completed.
+  /// loaded on behalf of JIT'd code), clients should hold a keepalive token for
+  /// this group, which can be constructed from the returned TokenSource. That
+  /// token will delay Session teardown until it is released.
   ///
-  /// Clients should prefer using callManagedCode to automatically acquire
+  /// Clients should prefer using callWithKeepalive to automatically acquire
   /// and hold a token for the duration of a call.
-  TaskGroup::TokenSource managedCodeTokenSource() const {
-    return ManagedCodeTaskGroup;
+  TaskGroup::TokenSource keepaliveTokenSource() const {
+    return KeepaliveTaskGroup;
   }
 
-  /// Call managed code.
+  /// Call Session-managed code while holding a keepalive.
   ///
-  /// This helper tries to acquire a ManagedCodeTaskGroup token and, if
-  /// successful, calls the given function object with the given arguments
-  /// while holding the token.
+  /// This helper tries to acquire a keepalive token and, if successful, calls
+  /// the given function object with the given arguments while holding the
+  /// token.
   ///
   /// The token is held only for the duration of the (synchronous) call to Fn,
   /// and released as soon as Fn returns; anything Fn runs inline on this thread
   /// before returning is covered by it. Work Fn defers past its return --
   /// stashed to run later, or handed to another thread -- is NOT covered: it
   /// runs on a stack the token no longer guards. Whoever runs such deferred
-  /// work is responsible for ensuring a token covers it, typically by acquiring
-  /// one (e.g. from a TokenSource, see managedCodeTokenSource) and aborting the
-  /// work if the acquire is denied, exactly as for any entry into managed code.
-  /// (A resumed continuation cannot bracket its own entry, since its landing
-  /// point may itself be managed code.)
+  /// work is responsible for ensuring a keepalive covers it, typically by
+  /// acquiring one (e.g. from a TokenSource, see keepaliveTokenSource) and
+  /// aborting the work if the acquire is denied, exactly as for any entry into
+  /// Session-managed code. (A resumed continuation cannot bracket its own
+  /// entry, since its landing point may itself be Session-managed code.)
   ///
   /// If the token is successfully acquired then this function returns the
   /// result of the call to Fn as a std::optional<T> (for a non-void return
@@ -466,12 +465,12 @@ public:
   /// function returns std::nullopt (for a non-void return type) or boolean
   /// false (for void returns).
   ///
-  /// See the "Managed code execution and shutdown" section of docs/Design.md
-  /// for the model behind managed-code tokens and shutdown.
+  /// See the "Keepalives and shutdown" section of docs/Design.md for the model
+  /// behind keepalive tokens and shutdown.
   template <typename FnT, typename... ArgTs>
-  decltype(auto) callManagedCode(FnT &&Fn, ArgTs &&...Args) {
-    return ManagedCodeCaller<std::invoke_result_t<FnT, ArgTs...>>::call(
-        TaskGroup::Token(ManagedCodeTaskGroup), std::forward<FnT>(Fn),
+  decltype(auto) callWithKeepalive(FnT &&Fn, ArgTs &&...Args) {
+    return KeepaliveCaller<std::invoke_result_t<FnT, ArgTs...>>::call(
+        TaskGroup::Token(KeepaliveTaskGroup), std::forward<FnT>(Fn),
         std::forward<ArgTs>(Args)...);
   }
 
@@ -554,16 +553,16 @@ private:
   void detachServices(std::vector<Service *> ToNotify, bool ShutdownRequested);
   void completeDetach();
 
-  void waitForManagedCodeTasksThenShutdown();
+  void waitForKeepalivesThenShutdown();
   void proceedToShutdown();
   void shutdownServices(std::vector<Service *> ToNotify);
   void completeShutdown();
 
   void handleWrapperCall(orc_rt_WrapperFunction Fn,
                          WrapperFunctionBuffer ArgBytes, uint64_t CallId) {
-    TaskGroup::Token T(ManagedCodeTaskGroup);
+    TaskGroup::Token T(KeepaliveTaskGroup);
     if (!T) {
-      // The ManagedCodeTaskGroup is only closed after detach, so if token
+      // The KeepaliveTaskGroup is only closed after detach, so if token
       // acquisition fails we don't try to return an error: the controller
       // should already have signalled error to the caller, and we have no
       // way to transmit an error anyway.
@@ -579,7 +578,7 @@ private:
   void handleControllerCallResult(
       ControllerAccess::OnControllerCallReturn OnComplete,
       WrapperFunctionBuffer ResultBytes) {
-    TaskGroup::Token T(ManagedCodeTaskGroup);
+    TaskGroup::Token T(KeepaliveTaskGroup);
 
     if (!T) {
       // Contract violation: a deferred completion must precede
@@ -588,7 +587,7 @@ private:
       // one of those was broken; falling through would run the handler
       // unbracketed into a possibly-torn-down Session. Fail loudly.
       assert(false && "handleControllerCallResult on a closed "
-                      "ManagedCodeTaskGroup");
+                      "KeepaliveTaskGroup");
       abort();
     }
 
@@ -625,7 +624,7 @@ private:
 
   ExecutorProcessInfo EPI;
   DispatchFn Dispatch;
-  std::shared_ptr<TaskGroup> ManagedCodeTaskGroup = TaskGroup::Create();
+  std::shared_ptr<TaskGroup> KeepaliveTaskGroup = TaskGroup::Create();
   std::shared_ptr<ControllerAccess> CA;
   ErrorReporterFn ReportError;
 

--- a/orc-rt/lib/executor/Session.cpp
+++ b/orc-rt/lib/executor/Session.cpp
@@ -200,7 +200,7 @@ void Session::shutdown(OnShutdownFn OnShutdown) {
       break;
     case State::Detached:
       Lock.unlock();
-      waitForManagedCodeTasksThenShutdown();
+      waitForKeepalivesThenShutdown();
       return;
     default:
       assert(false && "Illegal state");
@@ -329,13 +329,13 @@ void Session::completeDetach() {
     assert(TargetState == State::Shutdown);
   }
 
-  waitForManagedCodeTasksThenShutdown();
+  waitForKeepalivesThenShutdown();
 }
 
-void Session::waitForManagedCodeTasksThenShutdown() {
-  ORC_RT_LOG(Info, Session, "Session %p waiting for managed tasks", this);
-  ManagedCodeTaskGroup->addOnComplete([this]() { proceedToShutdown(); });
-  ManagedCodeTaskGroup->close();
+void Session::waitForKeepalivesThenShutdown() {
+  ORC_RT_LOG(Info, Session, "Session %p waiting for keepalives", this);
+  KeepaliveTaskGroup->addOnComplete([this]() { proceedToShutdown(); });
+  KeepaliveTaskGroup->close();
 }
 
 void Session::proceedToShutdown() {

--- a/orc-rt/test/unit/CommonTestUtils.h
+++ b/orc-rt/test/unit/CommonTestUtils.h
@@ -50,7 +50,7 @@ inline orc_rt::ExecutorProcessInfo mockExecutorProcessInfo() noexcept {
 
 /// DispatchFn for tests that should never dispatch a task. Records a test
 /// failure on invocation, then runs the task inline so that any caller
-/// awaiting a result unblocks (rather than hanging) and the managed-code token
+/// awaiting a result unblocks (rather than hanging) and the keepalive token
 /// is released, even in -Asserts builds or when the dispatch arrives on a
 /// non-test thread.
 inline void noDispatch(orc_rt::Session::Task T) {

--- a/orc-rt/test/unit/SessionTest.cpp
+++ b/orc-rt/test/unit/SessionTest.cpp
@@ -437,7 +437,7 @@ TEST(SessionTest, RedundantAsyncShutdown) {
   EXPECT_TRUE(RedundantCallbackRan);
 }
 
-TEST(SessionTest, ExpectedShutdownSequenceWithNoActiveManagedCodeCalls) {
+TEST(SessionTest, ExpectedShutdownSequenceWithNoOutstandingKeepalives) {
   // Check that Session shutdown results in...
   // 1. Services being shut down.
   // 2. A call to OnShutdownComplete.
@@ -463,7 +463,7 @@ TEST(SessionTest, ExpectedShutdownSequenceWithNoActiveManagedCodeCalls) {
   EXPECT_TRUE(SessionShutdownComplete);
 }
 
-TEST(SessionTest, ActiveManagedCallsDelayShutdown) {
+TEST(SessionTest, OutstandingKeepalivesDelayShutdown) {
   QueueingRunner<>::WorkQueue Tasks;
   Session S(mockExecutorProcessInfo(), QueueingRunner(Tasks), noErrors);
 
@@ -475,11 +475,11 @@ TEST(SessionTest, ActiveManagedCallsDelayShutdown) {
   ASSERT_FALSE(DetachOpIdx);
   ASSERT_FALSE(ShutdownOpIdx);
 
-  // Take a managed code call token. This should succeed.
-  auto Tok = TaskGroup::Token(S.managedCodeTokenSource());
+  // Take a keepalive. This should succeed.
+  auto Tok = TaskGroup::Token(S.keepaliveTokenSource());
   ASSERT_TRUE(Tok);
 
-  // We expect shutdown to wait for any active managed calls to complete.
+  // We expect shutdown to wait for any outstanding keepalives to be released.
   bool ShutdownComplete = false;
   S.shutdown([&]() { ShutdownComplete = true; });
 
@@ -488,9 +488,9 @@ TEST(SessionTest, ActiveManagedCallsDelayShutdown) {
   EXPECT_FALSE(ShutdownOpIdx);
   EXPECT_FALSE(ShutdownComplete);
 
-  // The managed calls code group should have been closed. Assert that we
+  // The keepalive group should have been closed. Assert that we
   // can't get a new token.
-  ASSERT_FALSE(TaskGroup::Token(S.managedCodeTokenSource()));
+  ASSERT_FALSE(TaskGroup::Token(S.keepaliveTokenSource()));
 
   Tok = TaskGroup::Token(); // Reset token.
 
@@ -501,15 +501,15 @@ TEST(SessionTest, ActiveManagedCallsDelayShutdown) {
 
 static void managedVoidFunction(int *P) { *P = 42; }
 
-TEST(SessionTest, CallManagedCodeVoidFn) {
-  // Test calls to a void function while holding a ManagedCodeTaskGroup token.
+TEST(SessionTest, CallWithKeepaliveVoidFn) {
+  // Test calls to a void function while holding a KeepaliveTaskGroup token.
   Session S(mockExecutorProcessInfo(), noDispatch, noErrors);
 
   {
     // Pre-shutdown we expect token acquisition to succeed and the function to
     // run.
     int X = 0;
-    bool CallSucceeded = S.callManagedCode(managedVoidFunction, &X);
+    bool CallSucceeded = S.callWithKeepalive(managedVoidFunction, &X);
 
     EXPECT_TRUE(CallSucceeded);
     EXPECT_EQ(X, 42U);
@@ -519,9 +519,9 @@ TEST(SessionTest, CallManagedCodeVoidFn) {
 
   {
     // Post-shutdown we expect token acquisition to fail, and
-    // callManagedCode to return false.
+    // callWithKeepalive to return false.
     int X = 0;
-    bool CallSucceeded = S.callManagedCode(managedVoidFunction, &X);
+    bool CallSucceeded = S.callWithKeepalive(managedVoidFunction, &X);
 
     EXPECT_FALSE(CallSucceeded);
   }
@@ -529,15 +529,15 @@ TEST(SessionTest, CallManagedCodeVoidFn) {
 
 static int managedNonVoidFunction(int N) { return N + 1; }
 
-TEST(SessionTest, CallManagedCodeNonVoidFn) {
-  // Test calls to a non-void function while holding a ManagedCodeTaskGroup
+TEST(SessionTest, CallWithKeepaliveNonVoidFn) {
+  // Test calls to a non-void function while holding a KeepaliveTaskGroup
   // token.
   Session S(mockExecutorProcessInfo(), noDispatch, noErrors);
 
   {
     // Pre-shutdown we expect token acquisition to succeed, the function to be
     // run, and the result to be returned.
-    auto Result = S.callManagedCode(managedNonVoidFunction, 41);
+    auto Result = S.callWithKeepalive(managedNonVoidFunction, 41);
 
     EXPECT_TRUE(Result);
     EXPECT_EQ(*Result, 42U);
@@ -547,8 +547,8 @@ TEST(SessionTest, CallManagedCodeNonVoidFn) {
 
   {
     // Post-shutdown we expect token acquisition to fail, and
-    // callManagedCode to return std::nullopt.
-    auto Result = S.callManagedCode(managedNonVoidFunction, 41);
+    // callWithKeepalive to return std::nullopt.
+    auto Result = S.callWithKeepalive(managedNonVoidFunction, 41);
 
     EXPECT_EQ(Result, std::nullopt);
   }
@@ -558,8 +558,8 @@ static void managedAsyncFunction(move_only_function<void(int)> Return, int *P) {
   Return(++*P);
 }
 
-TEST(SessionTest, CallManagedCodeAsyncFn) {
-  // Test that calls to managed async functions via callManagedCode work.
+TEST(SessionTest, CallWithKeepaliveAsyncFn) {
+  // Test that calls to managed async functions via callWithKeepalive work.
   Session S(mockExecutorProcessInfo(), noDispatch, noErrors);
 
   {
@@ -567,7 +567,7 @@ TEST(SessionTest, CallManagedCodeAsyncFn) {
     // and Return callback to be run.
     int N = 41;
     std::optional<int> Result;
-    S.callManagedCode(managedAsyncFunction, [&](int N) { Result = N; }, &N);
+    S.callWithKeepalive(managedAsyncFunction, [&](int N) { Result = N; }, &N);
     EXPECT_TRUE(Result);
     EXPECT_EQ(*Result, 42U);
     EXPECT_EQ(N, 42U);
@@ -580,7 +580,7 @@ TEST(SessionTest, CallManagedCodeAsyncFn) {
     // with `std::nullopt` and the function should not be called.
     int N = 41;
     std::optional<int> Result;
-    S.callManagedCode(managedAsyncFunction, [&](int N) { Result = N; }, &N);
+    S.callWithKeepalive(managedAsyncFunction, [&](int N) { Result = N; }, &N);
     EXPECT_EQ(Result, std::nullopt);
     EXPECT_EQ(N, 41U);
   }
@@ -816,9 +816,9 @@ static void deferred_wrapper(orc_rt_SessionRef S,
 }
 
 TEST(ControllerAccessTest, WrapperCallTokenReleasedWhenFnReturns) {
-  // A managed-code token acquired for an incoming wrapper call must bracket
+  // A keepalive acquired for an incoming wrapper call must bracket
   // only the (synchronous) span of Fn's execution -- not the whole
-  // call/response chain -- per the "Managed code execution and shutdown"
+  // call/response chain -- per the "Keepalives and shutdown"
   // policy in docs/Design.md. Check this by having Fn defer its Return call
   // past its own return, then confirming that Session shutdown's drain phase
   // does not wait on that deferred call.
@@ -846,7 +846,7 @@ TEST(ControllerAccessTest, WrapperCallTokenReleasedWhenFnReturns) {
   ASSERT_TRUE(DeferredReturn);
   EXPECT_FALSE(GotResult);
 
-  // Fn has already returned, so its managed-code token should have been
+  // Fn has already returned, so its keepalive should have been
   // released even though the call is still logically outstanding. Shutdown's
   // drain phase should therefore complete without waiting on the deferred
   // Return call.


### PR DESCRIPTION
Renames the Session's managed-code task group and its helpers so that they name the mechanism -- the barrier that holds the Session open -- rather than a category of code:

  ManagedCodeTaskGroup                 -> KeepaliveTaskGroup
  Session::callManagedCode             -> Session::callWithKeepalive
  Session::managedCodeTokenSource      -> Session::keepaliveTokenSource
  waitForManagedCodeTasksThenShutdown  -> waitForKeepalivesThenShutdown
  ManagedCodeCaller                    -> KeepaliveCaller

and retitles the corresponding section of docs/Design.md from "Managed code execution and shutdown" to "Keepalives and shutdown".

"Managed code" collides with the established .NET sense of the term, which risks confusion. Naming the mechanism instead makes the purpose clear at the call site: callWithKeepalive says that the Session is held open across the call.

Where the documentation still needs a noun for the code itself it now says "Session-managed code", which keeps the original meaning (JIT'd code, plus library code loaded on its behalf) without the bare term's collision.

TaskGroup itself is unchanged and remains generic: a keepalive is the Session's use of a token, not a new kind of token.