### PR TITLE
GlobalISel: Match loads by pointer operand in CombinerHelper

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/MIPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/MIPatternMatch.h
@@ -439,6 +439,14 @@ struct MIFlagsRef {
 
 inline MIFlagsRef m_MIFlags(uint32_t &Flags) { return {Flags}; }
 
+/// Optional trailing operand for a load matcher (e.g. m_GLoad(m_Reg(Ptr),
+/// m_MMO(MMO))) that binds the matched instruction's MachineMemOperand.
+struct MMORef {
+  const MachineMemOperand *&MMO;
+};
+
+inline MMORef m_MMO(const MachineMemOperand *&MMO) { return {MMO}; }
+
 template <typename BindTy> struct deferred_helper {
   static bool match(const MachineRegisterInfo &MRI, BindTy &VR, BindTy &V) {
     return VR == V;
@@ -525,6 +533,57 @@ struct GConstantBitsMatch {
 
 inline GConstantBitsMatch m_GConstantOrFConstantBits(APInt &Bits) {
   return {Bits};
+}
+
+/// Match a load of type \p Class, binding its pointer operand (like IR's
+/// m_Load), and optionally the instruction and/or its MachineMemOperand.
+template <typename Class, typename PtrP> struct LoadOp_match {
+  PtrP Ptr;
+  Class **InstOut = nullptr;
+  const MachineMemOperand **MMOOut = nullptr;
+
+  LoadOp_match(const PtrP &Ptr) : Ptr(Ptr) {}
+  LoadOp_match(const PtrP &Ptr, MMORef MMO) : Ptr(Ptr), MMOOut(&MMO.MMO) {}
+  LoadOp_match(Class *&Inst, const PtrP &Ptr) : Ptr(Ptr), InstOut(&Inst) {}
+  LoadOp_match(Class *&Inst, const PtrP &Ptr, MMORef MMO)
+      : Ptr(Ptr), InstOut(&Inst), MMOOut(&MMO.MMO) {}
+
+  bool match(const MachineRegisterInfo &MRI, Register Reg) {
+    MachineInstr *TmpMI;
+    if (!mi_match(Reg, MRI, m_MInstr(TmpMI)))
+      return false;
+    auto *Load = dyn_cast<Class>(TmpMI);
+    if (!Load || !Ptr.match(MRI, Load->getPointerReg()))
+      return false;
+    if (InstOut)
+      *InstOut = Load;
+    if (MMOOut)
+      *MMOOut = &Load->getMMO();
+    return true;
+  }
+};
+
+template <typename PtrP>
+inline LoadOp_match<GAnyLoad, PtrP> m_GAnyLoad(const PtrP &Ptr) {
+  return LoadOp_match<GAnyLoad, PtrP>(Ptr);
+}
+template <typename PtrP>
+inline LoadOp_match<GAnyLoad, PtrP> m_GAnyLoad(GAnyLoad *&Inst,
+                                               const PtrP &Ptr) {
+  return LoadOp_match<GAnyLoad, PtrP>(Inst, Ptr);
+}
+template <typename PtrP>
+inline LoadOp_match<GAnyLoad, PtrP> m_GAnyLoad(GAnyLoad *&Inst, const PtrP &Ptr,
+                                               MMORef MMO) {
+  return LoadOp_match<GAnyLoad, PtrP>(Inst, Ptr, MMO);
+}
+template <typename PtrP>
+inline LoadOp_match<GLoad, PtrP> m_GLoad(const PtrP &Ptr) {
+  return LoadOp_match<GLoad, PtrP>(Ptr);
+}
+template <typename PtrP>
+inline LoadOp_match<GLoad, PtrP> m_GLoad(const PtrP &Ptr, MMORef MMO) {
+  return LoadOp_match<GLoad, PtrP>(Ptr, MMO);
 }
 
 /// Instruction binders for ops with no operand-form matcher (constant-immediate

--- a/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
@@ -1000,15 +1000,16 @@ bool CombinerHelper::matchCombineLoadWithAndMask(MachineInstr &MI,
   Register SrcReg = MI.getOperand(1).getReg();
   // Don't use getOpcodeDef() here since intermediate instructions may have
   // multiple users.
-  GAnyLoad *LoadMI = dyn_cast<GAnyLoad>(MRI.getVRegDef(SrcReg));
-  if (!LoadMI)
+  GAnyLoad *LoadMI;
+  Register PtrReg;
+  const MachineMemOperand *MMO;
+  if (!mi_match(SrcReg, MRI, m_GAnyLoad(LoadMI, m_Reg(PtrReg), m_MMO(MMO))))
     return false;
 
   Register LoadReg = LoadMI->getDstReg();
   LLT RegTy = MRI.getType(LoadReg);
-  Register PtrReg = LoadMI->getPointerReg();
   unsigned RegSize = RegTy.getSizeInBits();
-  unsigned LoadSizeBits = LoadMI->getMemSizeInBits().getValue();
+  unsigned LoadSizeBits = MMO->getSizeInBits().getValue();
   unsigned MaskSizeBits = MaskVal.countr_one();
 
   if ((isa<GSExtLoad>(LoadMI) || MaskSizeBits < LoadSizeBits) &&
@@ -1030,12 +1031,11 @@ bool CombinerHelper::matchCombineLoadWithAndMask(MachineInstr &MI,
   if (MaskSizeBits < 8 || !isPowerOf2_32(MaskSizeBits))
     return false;
 
-  const MachineMemOperand &MMO = LoadMI->getMMO();
-  LegalityQuery::MemDesc MemDesc(MMO);
+  LegalityQuery::MemDesc MemDesc(*MMO);
 
   // Don't modify the memory access size if this is atomic/volatile, but we can
   // still adjust the opcode to indicate the high bit behavior.
-  if (LoadMI->isSimple())
+  if (!MMO->isAtomic() && !MMO->isVolatile())
     MemDesc.MemoryTy = LLT::scalar(MaskSizeBits);
   else if (LoadSizeBits > MaskSizeBits || LoadSizeBits == RegSize)
     return false;
@@ -1048,8 +1048,8 @@ bool CombinerHelper::matchCombineLoadWithAndMask(MachineInstr &MI,
   MatchInfo = [=](MachineIRBuilder &B) {
     B.setInstrAndDebugLoc(*LoadMI);
     auto &MF = B.getMF();
-    auto PtrInfo = MMO.getPointerInfo();
-    auto *NewMMO = MF.getMachineMemOperand(&MMO, PtrInfo, MemDesc.MemoryTy);
+    auto PtrInfo = MMO->getPointerInfo();
+    auto *NewMMO = MF.getMachineMemOperand(MMO, PtrInfo, MemDesc.MemoryTy);
     B.buildLoadInstr(TargetOpcode::G_ZEXTLOAD, Dst, PtrReg, *NewMMO);
     replaceRegWith(MRI, LoadReg, Dst);
     LoadMI->eraseFromParent();
@@ -1130,11 +1130,12 @@ bool CombinerHelper::matchSextInRegOfLoad(
     return false;
 
   Register SrcReg = MI.getOperand(1).getReg();
-  auto *LoadDef = dyn_cast<GLoad>(MRI.getVRegDef(SrcReg));
-  if (!LoadDef)
+  Register PtrReg;
+  const MachineMemOperand *MMO;
+  if (!mi_match(SrcReg, MRI, m_GLoad(m_Reg(PtrReg), m_MMO(MMO))))
     return false;
 
-  uint64_t MemBits = LoadDef->getMemSizeInBits().getValue();
+  uint64_t MemBits = MMO->getSizeInBits().getValue();
   uint64_t ExtFrom = MI.getOperand(2).getImm();
 
   if (MemBits > ExtFrom && !MRI.hasOneNonDBGUse(SrcReg))
@@ -1153,24 +1154,21 @@ bool CombinerHelper::matchSextInRegOfLoad(
   if (!isPowerOf2_32(NewSizeBits))
     return false;
 
-  const MachineMemOperand &MMO = LoadDef->getMMO();
-  LegalityQuery::MemDesc MMDesc(MMO);
+  LegalityQuery::MemDesc MMDesc(*MMO);
 
   // Don't modify the memory access size if this is atomic/volatile, but we can
   // still adjust the opcode to indicate the high bit behavior.
-  if (LoadDef->isSimple())
+  if (!MMO->isAtomic() && !MMO->isVolatile())
     MMDesc.MemoryTy = LLT::scalar(NewSizeBits);
   else if (MemBits > NewSizeBits || MemBits == RegTy.getSizeInBits())
     return false;
 
   // TODO: Could check if it's legal with the reduced or original memory size.
-  if (!isLegalOrBeforeLegalizer({TargetOpcode::G_SEXTLOAD,
-                                 {MRI.getType(LoadDef->getDstReg()),
-                                  MRI.getType(LoadDef->getPointerReg())},
-                                 {MMDesc}}))
+  if (!isLegalOrBeforeLegalizer(
+          {TargetOpcode::G_SEXTLOAD, {RegTy, MRI.getType(PtrReg)}, {MMDesc}}))
     return false;
 
-  MatchInfo = std::make_tuple(LoadDef->getDstReg(), NewSizeBits);
+  MatchInfo = std::make_tuple(SrcReg, NewSizeBits);
   return true;
 }
 


### PR DESCRIPTION
Add a load matcher that binds the pointer operand (like IR's m_Load), with
optional outputs for the load instruction and its MachineMemOperand via m_MMO.
Use it to replace the getVRegDef + dyn_cast idiom in the load combines.

Co-authored-by: Claude (Opus 4.8) <noreply@anthropic.com>