### PR TITLE
release/23.x: [SSAF] Fix Expected return type in TypeConstrainedPointers deserialization (gcc 7.5.0)

### DIFF
--- a/clang/lib/ScalableStaticAnalysis/Analyses/TypeConstrainedPointers/TypeConstrainedPointers.cpp
+++ b/clang/lib/ScalableStaticAnalysis/Analyses/TypeConstrainedPointers/TypeConstrainedPointers.cpp
@@ -212,7 +212,7 @@ deserializeSummary(const llvm::json::Object &Data, EntityIdTable &,
       std::make_unique<TypeConstrainedPointersEntitySummary>();
 
   Sum->Entities = std::move(*EntityIDSet);
-  return Sum;
+  return std::unique_ptr<EntitySummary>(std::move(Sum));
 }
 
 struct TypeConstrainedPointersJSONFormatInfo final : JSONFormat::FormatInfo {
@@ -246,7 +246,7 @@ deserializeAnalysisResult(const llvm::json::Object &Data,
       std::make_unique<TypeConstrainedPointersAnalysisResult>();
 
   AR->Entities = std::move(*EntityIDSet);
-  return AR;
+  return std::unique_ptr<AnalysisResult>(std::move(AR));
 }
 
 JSONFormat::AnalysisResultRegistry::Add<TypeConstrainedPointersAnalysisResult>


### PR DESCRIPTION
Backport of: https://github.com/llvm/llvm-project/commit/8b0eab156025a55819868daf76ff32e28829d06a

Without this change build breaks on older GCCs (minimum required for implicit move on return is GCC 8.1).
Backporting this change **fixes build failures** with SLES15.4 which uses a system compiler of GCC7.5