### PR TITLE
[MLIR] Document the OperationState properties invariant

### DIFF
--- a/mlir/include/mlir/IR/OperationSupport.h
+++ b/mlir/include/mlir/IR/OperationSupport.h
@@ -984,6 +984,10 @@ struct OperationState {
   Attribute propertiesAttr;
 
 private:
+  /// The deleter and setter are non-null whenever `properties` is, and are
+  /// only called after checking it. Coverity misses this invariant and flags
+  /// the empty `function_ref`s as uninitialized.
+  // coverity[uninit_member]
   PropertyRef properties;
   llvm::function_ref<void(PropertyRef)> propertiesDeleter;
   llvm::function_ref<void(PropertyRef, const PropertyRef)> propertiesSetter;


### PR DESCRIPTION
OperationState keeps `properties` together with the `propertiesDeleter` and `propertiesSetter` hooks: the two `function_ref`s are non-null whenever `properties` is non-null, and they are only ever called after checking `properties`.

Static analyzers do not see that invariant. Because an empty `function_ref` leaves its `callable` field indeterminate, Coverity reports "Uninitialized scalar variable" at every site that copies an OperationState: 6,436 of the 7,201 outstanding findings in the LLVM Coverity project, nearly all in tblgen-generated `Op::create` methods.

Per review feedback, this no longer initializes `function_ref::callable` in ADT. Instead it documents the invariant and suppresses the false positive locally with a `// coverity[uninit_member]` annotation.