### PR TITLE
[clang][docs] Add documentation for the DanglingPtrDeref checker

### DIFF
--- a/clang/docs/analyzer/checkers.md
+++ b/clang/docs/analyzer/checkers.md
@@ -3300,6 +3300,73 @@ remove the const qualifier from the original declaration or use a mutable copy.
 
 ### alpha.cplusplus
 
+(alpha-cplusplus-danglingptrderef)=
+
+#### alpha.cplusplus.DanglingPtrDeref (C++)
+
+Check for dereferences of pointers that refer to an object whose
+lifetime has already ended. Such a pointer is dangling. The checker
+reports it when it is dereferenced and when it is passed to a function.
+This includes a dereference in a return statement. A return statement that
+does not dereference the pointer does not lead to a report. Such a case is
+reported by the {ref}`core-StackAddressEscape` checker.
+
+Each object is reported at most once on an execution path. If the same dangling
+pointer is used several times then only the first use is reported.
+
+```cpp
+void test_deref() {
+  int *ptr = 0;
+  {
+    int num = 5;
+    ptr = &num;
+  } // note: 'num' is destroyed here
+  *ptr = 6; // warn: use of 'num' after its lifetime ended
+}
+
+int test_deref_in_return() {
+  int *ptr = 0;
+  {
+    int num = 5;
+    ptr = &num;
+  } // note: 'num' is destroyed here
+  return *ptr; // warn: use of 'num' after its lifetime ended
+}
+
+void test_in_scope() {
+  int num = 5;
+  int *ptr = &num;
+  {
+    *ptr = 6; // no warning, 'num' is still in scope
+  }
+}
+```
+
+The `-analyzer-config cfg-lifetime=true` option is a prerequisite for these
+reports. Without it the checker does not report anything and no error is emitted
+by the analyzer.
+
+**Limitations**
+
+If the analyzer cannot analyze the body of the called function, for example because
+its definition is not available in the given translation unit, then a dangling
+pointer passed to it is reported even if the function would never dereference
+it. This can lead to false positives.
+
+```cpp
+// The definition of the function is not available that is why the analyzer
+// assumes the pointer is used.
+int is_null(int *p);
+
+void argument_example() {
+  int *ptr = 0;
+  {
+    int num = 5;
+    ptr = &num;
+  }
+  is_null(ptr); // false positive: the pointer is compared, not dereferenced
+}
+```
 (alpha-cplusplus-deletewithnonvirtualdtor)=
 
 #### alpha.cplusplus.DeleteWithNonVirtualDtor (C++)

--- a/clang/docs/analyzer/checkers.md
+++ b/clang/docs/analyzer/checkers.md
@@ -3307,9 +3307,8 @@ remove the const qualifier from the original declaration or use a mutable copy.
 Check for dereferences of pointers that refer to an object whose
 lifetime has already ended. Such a pointer is dangling. The checker
 reports it when it is dereferenced and when it is passed to a function.
-This includes a dereference in a return statement. A return statement that
-does not dereference the pointer does not lead to a report. Such a case is
-reported by the {ref}`core-StackAddressEscape` checker.
+A return statement that does not dereference the pointer does not lead to a report.
+Such a case is reported by the {ref}`core-StackAddressEscape` checker.
 
 Each object is reported at most once on an execution path. If the same dangling
 pointer is used several times then only the first use is reported.
@@ -3322,15 +3321,6 @@ void test_deref() {
     ptr = &num;
   } // note: 'num' is destroyed here
   *ptr = 6; // warn: use of 'num' after its lifetime ended
-}
-
-int test_deref_in_return() {
-  int *ptr = 0;
-  {
-    int num = 5;
-    ptr = &num;
-  } // note: 'num' is destroyed here
-  return *ptr; // warn: use of 'num' after its lifetime ended
 }
 
 void test_in_scope() {

--- a/clang/docs/analyzer/checkers.md
+++ b/clang/docs/analyzer/checkers.md
@@ -3311,7 +3311,9 @@ A return statement that does not dereference the pointer does not lead to a repo
 Such a case is reported by the {ref}`core-StackAddressEscape` checker.
 
 Each object is reported at most once on an execution path. If the same dangling
-pointer is used several times then only the first use is reported.
+pointer is used several times then only the first use is reported. Setting the pointer
+to null when the object goes out of scope avoids the dangling pointer and suppresses
+the report.
 
 ```cpp
 void test_deref() {

--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -289,6 +289,16 @@ def StdVariantChecker : Checker<"StdVariant">,
   HelpText<"Check for bad type access for std::variant.">,
   Documentation<HasDocumentation>;
 
+def LifetimeModeling : Checker<"LifetimeModeling">,
+  HelpText<"Model lifetime annotations for other checkers">,
+  Documentation<NotDocumented>,
+  Hidden;
+
+def DanglingPtrDeref : Checker<"DanglingPtrDeref">,
+  HelpText<"Check for dereferences of a dangling pointer">,
+  Dependencies<[LifetimeModeling]>,
+  Documentation<HasDocumentation>;
+
 } // end "alpha.core"
 
 //===----------------------------------------------------------------------===//
@@ -802,19 +812,9 @@ def SmartPtrChecker: Checker<"SmartPtr">,
   Dependencies<[SmartPtrModeling]>,
   Documentation<HasDocumentation>;
 
-def LifetimeModeling : Checker<"LifetimeModeling">,
-  HelpText<"Model lifetime annotations for other checkers">,
-  Documentation<NotDocumented>,
-  Hidden;
-
 def UseAfterLifetimeEnd : Checker<"UseAfterLifetimeEnd">,
   HelpText<"Check for uses of references or pointers that "
            "outlive their bound object">,
-  Dependencies<[LifetimeModeling]>,
-  Documentation<NotDocumented>;
-
-def DanglingPtrDeref : Checker<"DanglingPtrDeref">,
-  HelpText<"Check for dereferences of a dangling pointer">,
   Dependencies<[LifetimeModeling]>,
   Documentation<NotDocumented>;
 

--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -289,16 +289,6 @@ def StdVariantChecker : Checker<"StdVariant">,
   HelpText<"Check for bad type access for std::variant.">,
   Documentation<HasDocumentation>;
 
-def LifetimeModeling : Checker<"LifetimeModeling">,
-  HelpText<"Model lifetime annotations for other checkers">,
-  Documentation<NotDocumented>,
-  Hidden;
-
-def DanglingPtrDeref : Checker<"DanglingPtrDeref">,
-  HelpText<"Check for dereferences of a dangling pointer">,
-  Dependencies<[LifetimeModeling]>,
-  Documentation<HasDocumentation>;
-
 } // end "alpha.core"
 
 //===----------------------------------------------------------------------===//
@@ -812,11 +802,21 @@ def SmartPtrChecker: Checker<"SmartPtr">,
   Dependencies<[SmartPtrModeling]>,
   Documentation<HasDocumentation>;
 
+def LifetimeModeling : Checker<"LifetimeModeling">,
+  HelpText<"Model lifetime annotations for other checkers">,
+  Documentation<NotDocumented>,
+  Hidden;
+
 def UseAfterLifetimeEnd : Checker<"UseAfterLifetimeEnd">,
   HelpText<"Check for uses of references or pointers that "
            "outlive their bound object">,
   Dependencies<[LifetimeModeling]>,
   Documentation<NotDocumented>;
+
+def DanglingPtrDeref : Checker<"DanglingPtrDeref">,
+  HelpText<"Check for dereferences of a dangling pointer">,
+  Dependencies<[LifetimeModeling]>,
+  Documentation<HasDocumentation>;
 
 } // end: "alpha.cplusplus"
 

--- a/clang/test/Analysis/dangling-ptr-deref.cpp
+++ b/clang/test/Analysis/dangling-ptr-deref.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_analyze_cc1 -analyzer-checker=core,alpha.cplusplus.DanglingPtrDeref \
+// RUN: %clang_analyze_cc1 -analyzer-checker=core,alpha.core.DanglingPtrDeref \
 // RUN:   -analyzer-config cfg-lifetime=true -analyzer-output=text -verify %s
 
 void test_case_one() {

--- a/clang/test/Analysis/dangling-ptr-deref.cpp
+++ b/clang/test/Analysis/dangling-ptr-deref.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_analyze_cc1 -analyzer-checker=core,alpha.core.DanglingPtrDeref \
+// RUN: %clang_analyze_cc1 -analyzer-checker=core,alpha.cplusplus.DanglingPtrDeref \
 // RUN:   -analyzer-config cfg-lifetime=true -analyzer-output=text -verify %s
 
 void test_case_one() {


### PR DESCRIPTION
In order to move the `DanglingPtrDeref` checker out of alpha it needs a documentation the user can get information from. This PR added the documentation for the `DanglingPtrDeref` checker and follow up PR will also do the same for the `UseAfterLifetimeEnd` checker. Currently the documentation sits in the `alpha.core` category, but once we move the checker out of alpha stage it should be changed as well.

AI-policy: After I have written the documentation I verified my spellings, grammar with AI.