### PR TITLE
[libc] Drop .unit/.hermetic suffix from test support libraries

### DIFF
--- a/libc/benchmarks/gpu/CMakeLists.txt
+++ b/libc/benchmarks/gpu/CMakeLists.txt
@@ -18,7 +18,7 @@ function(add_benchmark benchmark_name)
     ${benchmark_name}
     IS_GPU_BENCHMARK
     LINK_LIBRARIES
-      LibcGpuBenchmark.hermetic
+      LibcGpuBenchmark
       ${BENCHMARK_LINK_LIBRARIES}
     DEPENDS
       libc.src.stdio.printf
@@ -46,33 +46,23 @@ function(add_benchmark_framework_library name)
       "header only libraries, use 'add_header_library'")
   endif()
 
-  foreach(lib IN ITEMS ${name}.hermetic)
-    add_library(
-      ${lib}
-      STATIC
-      EXCLUDE_FROM_ALL
-        ${TEST_LIB_SRCS}
-        ${TEST_LIB_HDRS}
-    )
-    target_include_directories(${lib} PRIVATE ${LIBC_SOURCE_DIR})
-    if(TARGET libc.src.time.clock)
-      target_compile_definitions(${lib} PRIVATE TARGET_SUPPORTS_CLOCK)
-    endif()
-  endforeach()
+  add_library(
+    ${name}
+    STATIC
+    EXCLUDE_FROM_ALL
+      ${TEST_LIB_SRCS}
+      ${TEST_LIB_HDRS}
+  )
+  target_include_directories(${name} PRIVATE ${LIBC_SOURCE_DIR})
+  if(TARGET libc.src.time.clock)
+    target_compile_definitions(${name} PRIVATE TARGET_SUPPORTS_CLOCK)
+  endif()
 
   _get_hermetic_test_compile_options(compile_options "")
-  target_include_directories(${name}.hermetic PRIVATE ${LIBC_INCLUDE_DIR})
-  target_compile_options(${name}.hermetic PRIVATE ${compile_options} -nostdinc++)
+  target_include_directories(${name} PRIVATE ${LIBC_INCLUDE_DIR})
+  target_compile_options(${name} PRIVATE ${compile_options} -nostdinc++)
 
-  if(TEST_LIB_DEPENDS)
-    foreach(dep IN ITEMS ${TEST_LIB_DEPENDS})
-      if(TARGET ${dep}.hermetic)
-        add_dependencies(${name}.hermetic ${dep}.hermetic)
-      else()
-        add_dependencies(${name}.hermetic ${dep})
-      endif()
-    endforeach()
-  endif()
+  add_dependencies(${name} ${TEST_LIB_DEPENDS})
 endfunction()
 
 add_benchmark_framework_library(

--- a/libc/cmake/modules/LLVMLibCTestRules.cmake
+++ b/libc/cmake/modules/LLVMLibCTestRules.cmake
@@ -355,13 +355,7 @@ function(create_libc_unittest fq_target_name)
 
   set(link_libraries ${link_object_files})
   # Test object files will depend on LINK_LIBRARIES passed down from `add_fp_unittest`
-  foreach(lib IN LISTS LIBC_UNITTEST_LINK_LIBRARIES)
-    if(TARGET ${lib}.unit)
-      list(APPEND link_libraries ${lib}.unit)
-    else()
-      list(APPEND link_libraries ${lib})
-    endif()
-  endforeach()
+  list(APPEND link_libraries ${LIBC_UNITTEST_LINK_LIBRARIES})
 
   set_target_properties(${fq_build_target_name}
     PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
@@ -371,10 +365,10 @@ function(create_libc_unittest fq_target_name)
     ${fq_deps_list}
   )
 
-  # LibcUnitTest should not depend on anything in LINK_LIBRARIES.
-  list(APPEND link_libraries LibcTest.unit)
+  # LibcTest should not depend on anything in LINK_LIBRARIES.
+  list(APPEND link_libraries LibcTest)
   if(NOT LIBC_UNITTEST_C_TEST)
-    list(APPEND link_libraries LibcDeathTestExecutors.unit)
+    list(APPEND link_libraries LibcDeathTestExecutors)
   endif()
 
   target_link_libraries(${fq_build_target_name} PRIVATE ${link_libraries})
@@ -881,15 +875,7 @@ function(add_libc_hermetic test_name)
     ${compile_options}
     ${HERMETIC_TEST_COMPILE_OPTIONS})
 
-  set(link_libraries "")
   set(compiler_runtime "")
-  foreach(lib IN LISTS HERMETIC_TEST_LINK_LIBRARIES)
-    if(TARGET ${lib}.hermetic)
-      list(APPEND link_libraries ${lib}.hermetic)
-    else()
-      list(APPEND link_libraries ${lib})
-    endif()
-  endforeach()
 
   if(LIBC_TARGET_ARCHITECTURE_IS_AMDGPU)
     target_link_options(${fq_build_target_name} PRIVATE
@@ -930,9 +916,9 @@ function(add_libc_hermetic test_name)
     ${fq_build_target_name}
     PRIVATE
       libc.startup.${LIBC_TARGET_OS}.crt1
-      ${link_libraries}
+      ${HERMETIC_TEST_LINK_LIBRARIES}
       ${fq_target_name}.__libc__
-      LibcHermeticTestSupport.hermetic
+      LibcHermeticTestSupport
       # Working around dependency issues caused by compiler introduced libcalls.
       # We need to repeat the libc target so that we can resolve libcalls which
       # pull in functions from LibcHermeticTestSupport (which then foward to
@@ -942,7 +928,7 @@ function(add_libc_hermetic test_name)
       ${compiler_runtime}
   )
   add_dependencies(${fq_build_target_name}
-    LibcTest.hermetic
+    LibcTest
     libc.test.UnitTest.ErrnoSetterMatcher
     ${fq_deps_list})
 
@@ -1034,8 +1020,8 @@ function(add_libc_test test_name)
       add_libc_hermetic(
         ${test_name}
         LINK_LIBRARIES
-          LibcTest.hermetic
-          LibcDeathTestExecutors.hermetic
+          LibcTest
+          LibcDeathTestExecutors
           ${LIBC_TEST_UNPARSED_ARGUMENTS}
       )
     endif()

--- a/libc/test/UnitTest/CMakeLists.txt
+++ b/libc/test/UnitTest/CMakeLists.txt
@@ -51,8 +51,8 @@ function(add_unittest_framework_library name)
     target_compile_options(${name} PRIVATE ${compile_options})
   endif()
 
-  if(TEST_LIBC_DEPENDS)
-    add_dependencies(${name} ${TEST_LIBC_DEPENDS})
+  if(TEST_LIB_DEPENDS)
+    add_dependencies(${name} ${TEST_LIB_DEPENDS})
   endif()
 endfunction()
 

--- a/libc/test/UnitTest/CMakeLists.txt
+++ b/libc/test/UnitTest/CMakeLists.txt
@@ -11,68 +11,48 @@ function(add_unittest_framework_library name)
       "header only libraries, use 'add_header_library'")
   endif()
 
-  foreach(lib IN ITEMS ${name}.unit ${name}.hermetic)
-    add_library(
-      ${lib}
-      STATIC
-      EXCLUDE_FROM_ALL
-        ${TEST_LIB_SRCS}
-        ${TEST_LIB_HDRS}
-    )
-    target_include_directories(${lib} PRIVATE ${LIBC_SOURCE_DIR})
-    if(TARGET libc.src.time.clock)
-      target_compile_definitions(${lib} PRIVATE TARGET_SUPPORTS_CLOCK)
-    endif()
+  add_library(
+    ${name}
+    STATIC
+    EXCLUDE_FROM_ALL
+      ${TEST_LIB_SRCS}
+      ${TEST_LIB_HDRS}
+  )
+  target_include_directories(${name} PRIVATE ${LIBC_SOURCE_DIR})
+  if(TARGET libc.src.time.clock)
+    target_compile_definitions(${name} PRIVATE TARGET_SUPPORTS_CLOCK)
+  endif()
 
-    # Find out if the target supports catching signals.
-    if(NOT LLVM_LIBC_FULL_BUILD)
-      # In an overlay build of libc, assume signal.h is available: the host
-      # libc will provide it even if we don't.
-      set(no_signal FALSE)
-    elseif(TARGET libc.src.signal.signal)
-      # In a full build, signal.h only exists if we provide it ourselves, which
-      # we might not on bare metal.
-      get_target_property(no_signal libc.src.signal.signal SKIPPED)
-    else()
-      set(no_signal TRUE)
-    endif()
-    if(NOT no_signal)
-      target_compile_definitions(${lib} PRIVATE TARGET_SUPPORTS_SIGNAL_CATCHING)
-    endif()
-  endforeach()
+  # Find out if the target supports catching signals.
+  if(NOT LLVM_LIBC_FULL_BUILD)
+    # In an overlay build of libc, assume signal.h is available: the host
+    # libc will provide it even if we don't.
+    set(no_signal FALSE)
+  elseif(TARGET libc.src.signal.signal)
+    # In a full build, signal.h only exists if we provide it ourselves, which
+    # we might not on bare metal.
+    get_target_property(no_signal libc.src.signal.signal SKIPPED)
+  else()
+    set(no_signal TRUE)
+  endif()
+  if(NOT no_signal)
+    target_compile_definitions(${name} PRIVATE TARGET_SUPPORTS_SIGNAL_CATCHING)
+  endif()
 
   if(LLVM_LIBC_FULL_BUILD)
-    # TODO: Build test framework with LIBC_FULL_BUILD in full build mode after
-    # making LibcFPExceptionHelpers and LibcDeathTestExecutors hermetic.
-    set(LLVM_LIBC_FULL_BUILD "")
-    _get_common_test_compile_options(compile_options "" "")
-    set(LLVM_LIBC_FULL_BUILD ON)
+    _get_hermetic_test_compile_options(compile_options "" "")
+    target_compile_options(${name} PRIVATE ${compile_options} -nostdinc++)
   else()
     _get_common_test_compile_options(compile_options "" "")
+
+    if(TEST_LIB_COMPILE_OPTIONS)
+      list(APPEND compile_options ${TEST_LIB_COMPILE_OPTIONS})
+    endif()
+    target_compile_options(${name} PRIVATE ${compile_options})
   endif()
 
-  if(TEST_LIB_COMPILE_OPTIONS)
-    list(APPEND compile_options ${TEST_LIB_COMPILE_OPTIONS})
-  endif()
-  target_compile_options(${name}.unit PRIVATE ${compile_options})
-
-  _get_hermetic_test_compile_options(compile_options "" "")
-  target_include_directories(${name}.hermetic PRIVATE ${LIBC_INCLUDE_DIR})
-  target_compile_options(${name}.hermetic PRIVATE ${compile_options} -nostdinc++)
-
-  if(TEST_LIB_DEPENDS)
-    foreach(dep IN ITEMS ${TEST_LIB_DEPENDS})
-      if(TARGET ${dep}.unit)
-        add_dependencies(${name}.unit ${dep}.unit)
-      else()
-        add_dependencies(${name}.unit ${dep})
-      endif()
-      if(TARGET ${dep}.hermetic)
-        add_dependencies(${name}.hermetic ${dep}.hermetic)
-      else()
-        add_dependencies(${name}.hermetic ${dep})
-      endif()
-    endforeach()
+  if(TEST_LIBC_DEPENDS)
+    add_dependencies(${name} ${TEST_LIBC_DEPENDS})
   endif()
 endfunction()
 

--- a/libc/test/src/math/performance_testing/CMakeLists.txt
+++ b/libc/test/src/math/performance_testing/CMakeLists.txt
@@ -66,7 +66,7 @@ function(add_perf_binary target_name)
 
   set(link_libraries ${link_object_files})
   foreach(lib IN LISTS PERF_LINK_LIBRARIES)
-    list(APPEND link_libraries ${lib}.unit)
+    list(APPEND link_libraries ${lib})
   endforeach()
   target_link_libraries(
     ${fq_target_name}

--- a/libc/test/src/time/CMakeLists.txt
+++ b/libc/test/src/time/CMakeLists.txt
@@ -1,11 +1,5 @@
 add_custom_target(libc_time_unittests)
 
-if(LLVM_LIBC_FULL_BUILD)
-  set(libc_test LibcTest.hermetic)
-else()
-  set(libc_test LibcTest.unit)
-endif()
-
 add_header_library(
   time_test_utils
   HDRS
@@ -15,7 +9,7 @@ add_header_library(
     libc.hdr.types.struct_tm
     libc.src.__support.macros.config
     libc.src.time.time_constants
-    ${libc_test}
+    LibcTest
 )
 
 add_libc_test(

--- a/libc/utils/MPCWrapper/CMakeLists.txt
+++ b/libc/utils/MPCWrapper/CMakeLists.txt
@@ -17,7 +17,7 @@ if(LIBC_TESTS_CAN_USE_MPC)
     libc.src.__support.CPP.type_traits
     libc.src.__support.FPUtil.fp_bits
     libc.src.__support.complex_type
-    LibcTest.unit
+    LibcTest
   )
   if(EXISTS ${LLVM_LIBC_MPFR_INSTALL_PATH})
     target_include_directories(libcMPCWrapper PUBLIC ${LLVM_LIBC_MPFR_INSTALL_PATH}/include)
@@ -28,7 +28,7 @@ if(LIBC_TESTS_CAN_USE_MPC)
     target_link_directories(libcMPCWrapper PUBLIC ${LIBC_MPC_INSTALL_PATH}/lib)
   endif()
   target_include_directories(libcMPCWrapper PUBLIC ${LIBC_SOURCE_DIR})
-  target_link_libraries(libcMPCWrapper PUBLIC libcMPCommon LibcFPTestHelpers.unit LibcTest.unit mpc)
+  target_link_libraries(libcMPCWrapper PUBLIC libcMPCommon LibcFPTestHelpers LibcTest mpc)
 elseif(NOT LIBC_TARGET_OS_IS_GPU AND NOT LLVM_LIBC_FULL_BUILD)
   message(WARNING "Math tests using MPC will be skipped.")
 endif()

--- a/libc/utils/MPFRWrapper/CMakeLists.txt
+++ b/libc/utils/MPFRWrapper/CMakeLists.txt
@@ -23,7 +23,7 @@ if(LIBC_TESTS_CAN_USE_MPFR OR LIBC_TESTS_CAN_USE_MPC)
     target_link_directories(libcMPCommon PUBLIC ${LLVM_LIBC_MPFR_INSTALL_PATH}/lib)
   endif()
   target_include_directories(libcMPCommon PUBLIC ${LIBC_SOURCE_DIR})
-  target_link_libraries(libcMPCommon PUBLIC LibcFPTestHelpers.unit mpfr gmp)
+  target_link_libraries(libcMPCommon PUBLIC LibcFPTestHelpers mpfr gmp)
 elseif(NOT LIBC_TARGET_OS_IS_GPU AND NOT LLVM_LIBC_FULL_BUILD)
   message(WARNING "Math tests using MPFR will be skipped.")
 endif()
@@ -46,14 +46,14 @@ if(LIBC_TESTS_CAN_USE_MPFR)
     libc.src.__support.FPUtil.bfloat16
     libc.src.__support.FPUtil.fp_bits
     libc.src.__support.FPUtil.fpbits_str
-    LibcTest.unit
+    LibcTest
   )
   if(EXISTS ${LLVM_LIBC_MPFR_INSTALL_PATH})
     target_include_directories(libcMPFRWrapper PUBLIC ${LLVM_LIBC_MPFR_INSTALL_PATH}/include)
     target_link_directories(libcMPFRWrapper PUBLIC ${LLVM_LIBC_MPFR_INSTALL_PATH}/lib)
   endif()
   target_include_directories(libcMPFRWrapper PUBLIC ${LIBC_SOURCE_DIR})
-  target_link_libraries(libcMPFRWrapper PUBLIC libcMPCommon LibcFPTestHelpers.unit LibcTest.unit)
+  target_link_libraries(libcMPFRWrapper PUBLIC libcMPCommon LibcFPTestHelpers LibcTest)
 elseif(NOT LIBC_TARGET_OS_IS_GPU AND NOT LLVM_LIBC_FULL_BUILD)
   message(WARNING "Math tests using MPFR will be skipped.")
 endif()


### PR DESCRIPTION
This is not necessary now that we only build one kind of a test in a given build configuration. This also makes it easier to convert to something closer to how other libc libraries work.