### PR TITLE
[AArch64][GlobalISel] Add an initial fast path for common legal operations

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/LegalizerInfo.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/LegalizerInfo.h
@@ -1400,6 +1400,14 @@ public:
   bool isLegalOrCustom(const MachineInstr &MI,
                        const MachineRegisterInfo &MRI) const;
 
+  /// Return true if \p MI is known to be legal without consulting the
+  /// legalization rules. This is intended as a fast path for the most common
+  /// operations.
+  virtual bool isKnownLegal(const MachineInstr &MI,
+                            const MachineRegisterInfo &MRI) const {
+    return false;
+  }
+
   /// Called for instructions with the Custom LegalizationAction.
   virtual bool legalizeCustom(LegalizerHelper &Helper, MachineInstr &MI,
                               LostDebugLocObserver &LocObserver) const {

--- a/llvm/lib/CodeGen/GlobalISel/Legalizer.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/Legalizer.cpp
@@ -199,7 +199,7 @@ Legalizer::MFResult Legalizer::legalizeMachineFunction(
         continue;
       if (isArtifact(MI))
         ArtifactList.deferred_insert(&MI);
-      else
+      else if (!LI.isKnownLegal(MI, MRI))
         InstList.deferred_insert(&MI);
     }
   }
@@ -234,6 +234,10 @@ Legalizer::MFResult Legalizer::legalizeMachineFunction(
         eraseInstr(MI, MRI, &LocObserver);
         continue;
       }
+
+      // We can skip known-legal instructions created during legalization.
+      if (LI.isKnownLegal(MI, MRI))
+        continue;
 
       // Do the legalization for this instruction.
       auto Res = Helper.legalizeInstrStep(MI, LocObserver);

--- a/llvm/lib/Target/AArch64/GISel/AArch64LegalizerInfo.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64LegalizerInfo.cpp
@@ -1547,6 +1547,54 @@ AArch64LegalizerInfo::AArch64LegalizerInfo(const AArch64Subtarget &ST)
   verify(*ST.getInstrInfo());
 }
 
+static bool isP0(LLT Ty) { return Ty.isPointer() && Ty.getAddressSpace() == 0; }
+
+static bool isKnownLegalScalarOrP0(LLT Ty) {
+  if (isP0(Ty))
+    return true;
+  if (!Ty.isScalar())
+    return false;
+  switch (Ty.getSizeInBits()) {
+  default:
+    return false;
+  case 8:
+  case 16:
+  case 32:
+  case 64:
+    return true;
+  }
+}
+
+bool AArch64LegalizerInfo::isKnownLegal(const MachineInstr &MI,
+                                        const MachineRegisterInfo &MRI) const {
+  switch (MI.getOpcode()) {
+  default:
+    return false;
+  case TargetOpcode::G_BR:
+    return true;
+  case TargetOpcode::G_PTR_ADD:
+    return isP0(MRI.getType(MI.getOperand(0).getReg())) &&
+           MRI.getType(MI.getOperand(2).getReg()) == LLT::scalar(64);
+  case TargetOpcode::G_FRAME_INDEX:
+    return MRI.getType(MI.getOperand(0).getReg()).getAddressSpace() == 0;
+  case TargetOpcode::G_CONSTANT:
+    return isKnownLegalScalarOrP0(MRI.getType(MI.getOperand(0).getReg()));
+  case TargetOpcode::G_LOAD:
+  case TargetOpcode::G_STORE: {
+    LLT ValTy = MRI.getType(MI.getOperand(0).getReg());
+    LLT PtrTy = MRI.getType(MI.getOperand(1).getReg());
+    const MachineMemOperand &MMO = **MI.memoperands_begin();
+    if (!isP0(PtrTy) || MMO.isAtomic())
+      return false;
+
+    LLT MemTy = MMO.getMemoryType();
+    if (!isKnownLegalScalarOrP0(ValTy) && ValTy != LLT::scalar(128))
+      return false;
+    return ValTy.getSizeInBits() == MemTy.getSizeInBits();
+  }
+  }
+}
+
 bool AArch64LegalizerInfo::legalizeCustom(
     LegalizerHelper &Helper, MachineInstr &MI,
     LostDebugLocObserver &LocObserver) const {

--- a/llvm/lib/Target/AArch64/GISel/AArch64LegalizerInfo.h
+++ b/llvm/lib/Target/AArch64/GISel/AArch64LegalizerInfo.h
@@ -33,6 +33,9 @@ public:
   bool legalizeIntrinsic(LegalizerHelper &Helper,
                          MachineInstr &MI) const override;
 
+  bool isKnownLegal(const MachineInstr &MI,
+                    const MachineRegisterInfo &MRI) const override;
+
 private:
   bool legalizeVaArg(MachineInstr &MI, MachineRegisterInfo &MRI,
                      MachineIRBuilder &MIRBuilder) const;

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-bitcast.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-bitcast.mir
@@ -8,6 +8,7 @@ body:             |
   ; CHECK: bb.0:
   ; CHECK-NEXT:   successors: %bb.1(0x80000000)
   ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   {{%[0-9]+}}:_(p0) = G_CONSTANT i64 0
   ; CHECK-NEXT:   G_BR %bb.1
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.1:

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-exceptions.ll
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-exceptions.ll
@@ -13,6 +13,8 @@ define void @bar() personality ptr @__gxx_personality_v0 {
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   successors: %bb.3(0x40000000), %bb.2(0x40000000)
   ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   {{%[0-9]+}}:_(p0) = G_FRAME_INDEX %stack.0.exn.slot
+  ; CHECK-NEXT:   {{%[0-9]+}}:_(p0) = G_FRAME_INDEX %stack.1.ehselector.slot
   ; CHECK-NEXT:   G_INVOKE_REGION_START
   ; CHECK-NEXT:   EH_LABEL <mcsymbol >
   ; CHECK-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-fshl.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-fshl.mir
@@ -203,6 +203,7 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $w0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(i32) = COPY $w1
+    ; CHECK-NEXT: {{%[0-9]+}}:_(i8) = G_CONSTANT i8 10
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 2
     ; CHECK-NEXT: [[SHL:%[0-9]+]]:_(i32) = G_SHL [[COPY]], [[C]](i64)
     ; CHECK-NEXT: [[C1:%[0-9]+]]:_(i32) = G_CONSTANT i32 255
@@ -237,6 +238,7 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $w0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(i32) = COPY $w1
+    ; CHECK-NEXT: {{%[0-9]+}}:_(i8) = G_CONSTANT i8 8
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 0
     ; CHECK-NEXT: [[SHL:%[0-9]+]]:_(i32) = G_SHL [[COPY]], [[C]](i64)
     ; CHECK-NEXT: [[C1:%[0-9]+]]:_(i32) = G_CONSTANT i32 255
@@ -308,6 +310,7 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $w0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(i32) = COPY $w1
+    ; CHECK-NEXT: {{%[0-9]+}}:_(i16) = G_CONSTANT i16 20
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 4
     ; CHECK-NEXT: [[SHL:%[0-9]+]]:_(i32) = G_SHL [[COPY]], [[C]](i64)
     ; CHECK-NEXT: [[C1:%[0-9]+]]:_(i32) = G_CONSTANT i32 65535
@@ -342,6 +345,7 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $w0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(i32) = COPY $w1
+    ; CHECK-NEXT: {{%[0-9]+}}:_(i16) = G_CONSTANT i16 16
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 0
     ; CHECK-NEXT: [[SHL:%[0-9]+]]:_(i32) = G_SHL [[COPY]], [[C]](i64)
     ; CHECK-NEXT: [[C1:%[0-9]+]]:_(i32) = G_CONSTANT i32 65535
@@ -379,6 +383,7 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $w0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(i32) = COPY $w1
+    ; CHECK-NEXT: {{%[0-9]+}}:_(i32) = G_CONSTANT i32 9
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 23
     ; CHECK-NEXT: [[FSHR:%[0-9]+]]:_(i32) = G_FSHR [[COPY]], [[COPY1]], [[C]](i64)
     ; CHECK-NEXT: $w0 = COPY [[FSHR]](i32)
@@ -405,6 +410,7 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $w0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(i32) = COPY $w1
+    ; CHECK-NEXT: {{%[0-9]+}}:_(i32) = G_CONSTANT i32 42
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 22
     ; CHECK-NEXT: [[FSHR:%[0-9]+]]:_(i32) = G_FSHR [[COPY]], [[COPY1]], [[C]](i64)
     ; CHECK-NEXT: $w0 = COPY [[FSHR]](i32)
@@ -431,6 +437,7 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $w0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(i32) = COPY $w1
+    ; CHECK-NEXT: {{%[0-9]+}}:_(i32) = G_CONSTANT i32 32
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 0
     ; CHECK-NEXT: [[SHL:%[0-9]+]]:_(i32) = G_SHL [[COPY]], [[C]](i64)
     ; CHECK-NEXT: [[C1:%[0-9]+]]:_(i64) = G_CONSTANT i64 1
@@ -462,6 +469,7 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(i64) = COPY $x0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(i64) = COPY $x1
+    ; CHECK-NEXT: {{%[0-9]+}}:_(i64) = G_CONSTANT i64 41
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 23
     ; CHECK-NEXT: [[FSHR:%[0-9]+]]:_(i64) = G_FSHR [[COPY]], [[COPY1]], [[C]](i64)
     ; CHECK-NEXT: $x0 = COPY [[FSHR]](i64)
@@ -488,6 +496,7 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(i64) = COPY $x0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(i64) = COPY $x1
+    ; CHECK-NEXT: {{%[0-9]+}}:_(i64) = G_CONSTANT i64 72
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 56
     ; CHECK-NEXT: [[FSHR:%[0-9]+]]:_(i64) = G_FSHR [[COPY]], [[COPY1]], [[C]](i64)
     ; CHECK-NEXT: $x0 = COPY [[FSHR]](i64)
@@ -514,6 +523,7 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(i64) = COPY $x0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(i64) = COPY $x1
+    ; CHECK-NEXT: {{%[0-9]+}}:_(i64) = G_CONSTANT i64 64
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 63
     ; CHECK-NEXT: [[C1:%[0-9]+]]:_(i64) = G_CONSTANT i64 0
     ; CHECK-NEXT: [[C2:%[0-9]+]]:_(i64) = G_CONSTANT i64 1

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-fshr.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-fshr.mir
@@ -203,6 +203,7 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $w0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(i32) = COPY $w1
+    ; CHECK-NEXT: {{%[0-9]+}}:_(i8) = G_CONSTANT i8 10
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 6
     ; CHECK-NEXT: [[SHL:%[0-9]+]]:_(i32) = G_SHL [[COPY]], [[C]](i64)
     ; CHECK-NEXT: [[C1:%[0-9]+]]:_(i32) = G_CONSTANT i32 255
@@ -237,6 +238,7 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $w0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(i32) = COPY $w1
+    ; CHECK-NEXT: {{%[0-9]+}}:_(i8) = G_CONSTANT i8 8
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 1
     ; CHECK-NEXT: [[SHL:%[0-9]+]]:_(i32) = G_SHL [[COPY]], [[C]](i64)
     ; CHECK-NEXT: [[C1:%[0-9]+]]:_(i64) = G_CONSTANT i64 7
@@ -307,6 +309,7 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $w0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(i32) = COPY $w1
+    ; CHECK-NEXT: {{%[0-9]+}}:_(i16) = G_CONSTANT i16 20
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 12
     ; CHECK-NEXT: [[SHL:%[0-9]+]]:_(i32) = G_SHL [[COPY]], [[C]](i64)
     ; CHECK-NEXT: [[C1:%[0-9]+]]:_(i32) = G_CONSTANT i32 65535
@@ -341,6 +344,7 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $w0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(i32) = COPY $w1
+    ; CHECK-NEXT: {{%[0-9]+}}:_(i16) = G_CONSTANT i16 16
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 1
     ; CHECK-NEXT: [[SHL:%[0-9]+]]:_(i32) = G_SHL [[COPY]], [[C]](i64)
     ; CHECK-NEXT: [[C1:%[0-9]+]]:_(i64) = G_CONSTANT i64 15
@@ -377,6 +381,7 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $w0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(i32) = COPY $w1
+    ; CHECK-NEXT: {{%[0-9]+}}:_(i32) = G_CONSTANT i32 9
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 9
     ; CHECK-NEXT: [[FSHR:%[0-9]+]]:_(i32) = G_FSHR [[COPY]], [[COPY1]], [[C]](i64)
     ; CHECK-NEXT: $w0 = COPY [[FSHR]](i32)
@@ -403,6 +408,7 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $w0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(i32) = COPY $w1
+    ; CHECK-NEXT: {{%[0-9]+}}:_(i32) = G_CONSTANT i32 42
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 10
     ; CHECK-NEXT: [[FSHR:%[0-9]+]]:_(i32) = G_FSHR [[COPY]], [[COPY1]], [[C]](i64)
     ; CHECK-NEXT: $w0 = COPY [[FSHR]](i32)
@@ -475,6 +481,7 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(i64) = COPY $x0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(i64) = COPY $x1
+    ; CHECK-NEXT: {{%[0-9]+}}:_(i64) = G_CONSTANT i64 72
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 8
     ; CHECK-NEXT: [[FSHR:%[0-9]+]]:_(i64) = G_FSHR [[COPY]], [[COPY1]], [[C]](i64)
     ; CHECK-NEXT: $x0 = COPY [[FSHR]](i64)
@@ -501,6 +508,7 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(i64) = COPY $x0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(i64) = COPY $x1
+    ; CHECK-NEXT: {{%[0-9]+}}:_(i64) = G_CONSTANT i64 64
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 63
     ; CHECK-NEXT: [[C1:%[0-9]+]]:_(i64) = G_CONSTANT i64 0
     ; CHECK-NEXT: [[C2:%[0-9]+]]:_(i64) = G_CONSTANT i64 1

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-insert-vector-elt.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-insert-vector-elt.mir
@@ -228,6 +228,7 @@ body:             |
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:_(i32) = COPY $w1
   ; CHECK-NEXT:   [[COPY2:%[0-9]+]]:_(i32) = COPY $w2
   ; CHECK-NEXT:   [[COPY3:%[0-9]+]]:_(i32) = COPY $w3
+  ; CHECK-NEXT:   {{%[0-9]+}}:_(i64) = G_CONSTANT i64 0
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(i8) = G_IMPLICIT_DEF
   ; CHECK-NEXT:   [[C:%[0-9]+]]:_(i8) = G_CONSTANT i8 0
   ; CHECK-NEXT: {{  $}}

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-load-store.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-load-store.mir
@@ -20,6 +20,7 @@ body: |
     ; CHECK-NEXT: [[LOAD2:%[0-9]+]]:_(i16) = G_LOAD [[COPY]](p0) :: (load (i16))
     ; CHECK-NEXT: [[ANYEXT2:%[0-9]+]]:_(i32) = G_ANYEXT [[LOAD2]](i16)
     ; CHECK-NEXT: $w0 = COPY [[ANYEXT2]](i32)
+    ; CHECK-NEXT: {{%[0-9]+}}:_(i32) = G_LOAD [[COPY]](p0) :: (load (i32))
     ; CHECK-NEXT: $w0 = COPY [[ANYEXT1]](i32)
     ; CHECK-NEXT: [[LOAD3:%[0-9]+]]:_(i64) = G_LOAD [[COPY]](p0) :: (load (i64))
     ; CHECK-NEXT: $x0 = COPY [[LOAD3]](i64)

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-mul.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-mul.mir
@@ -211,6 +211,7 @@ body:             |
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(p0) = COPY $x0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(i64) = COPY $x1
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(i64) = COPY $x2
+    ; CHECK-NEXT: {{%[0-9]+}}:_(i32) = G_CONSTANT i32 0
     ; CHECK-NEXT: [[FRAME_INDEX:%[0-9]+]]:_(p0) = G_FRAME_INDEX %stack.0
     ; CHECK-NEXT: [[FRAME_INDEX1:%[0-9]+]]:_(p0) = G_FRAME_INDEX %stack.1
     ; CHECK-NEXT: [[FRAME_INDEX2:%[0-9]+]]:_(p0) = G_FRAME_INDEX %stack.3

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-ptr-add.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-ptr-add.mir
@@ -36,6 +36,8 @@ body:             |
     ; CHECK-NEXT: [[PTR_ADD1:%[0-9]+]]:_(<2 x p0>) = G_PTR_ADD [[BUILD_VECTOR1]], [[BUILD_VECTOR3]](<2 x i64>)
     ; CHECK-NEXT: %zero:_(i64) = G_CONSTANT i64 0
     ; CHECK-NEXT: %one:_(i64) = G_CONSTANT i64 1
+    ; CHECK-NEXT: %two:_(i64) = G_CONSTANT i64 2
+    ; CHECK-NEXT: %three:_(i64) = G_CONSTANT i64 3
     ; CHECK-NEXT: %extract0:_(p0) = G_EXTRACT_VECTOR_ELT [[PTR_ADD]](<2 x p0>), %zero(i64)
     ; CHECK-NEXT: %extract1:_(p0) = G_EXTRACT_VECTOR_ELT [[PTR_ADD]](<2 x p0>), %one(i64)
     ; CHECK-NEXT: %extract2:_(p0) = G_EXTRACT_VECTOR_ELT [[PTR_ADD1]](<2 x p0>), %zero(i64)

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-shift.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-shift.mir
@@ -227,6 +227,7 @@ body:             |
     ; CHECK: liveins: $w0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $w0
+    ; CHECK-NEXT: {{%[0-9]+}}:_(i32) = G_CONSTANT i32 8
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 8
     ; CHECK-NEXT: [[SHL:%[0-9]+]]:_(i32) = G_SHL [[COPY]], [[C]](i64)
     ; CHECK-NEXT: $w0 = COPY [[SHL]](i32)
@@ -248,6 +249,7 @@ body:             |
     ; CHECK: liveins: $w0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $w0
+    ; CHECK-NEXT: {{%[0-9]+}}:_(i32) = G_CONSTANT i32 8
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 8
     ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[COPY]], [[C]](i64)
     ; CHECK-NEXT: $w0 = COPY [[LSHR]](i32)
@@ -269,6 +271,7 @@ body:             |
     ; CHECK: liveins: $w0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(i32) = COPY $w0
+    ; CHECK-NEXT: {{%[0-9]+}}:_(i32) = G_CONSTANT i32 8
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 8
     ; CHECK-NEXT: [[ASHR:%[0-9]+]]:_(i32) = G_ASHR [[COPY]], [[C]](i64)
     ; CHECK-NEXT: $w0 = COPY [[ASHR]](i32)


### PR DESCRIPTION
Profiling sqlite on aarch64-O0-g shows ~4.5% of compile-time is spent in the
legalizer. LegalizerInfo::getAction accounts for ~1.25%, and legality
predicates are a little over half of this. This is significant because separate
instrumentation [1] shows that of out 181,305 legalizer visits 164,764 (~90%)
simply return legal. Leaving only 16,541 legalizer visits which are doing
actual legalization work. This is consistent more broadly across CTMark, where
90% of all legalizer visits are legal with some workloads as high as 95%.

The opcode distribution is also highly concentrated, 8 opcodes account for
~87.4% and many of these such as G_FRAME_INDEX are trivial and always legal.
This patch adds an optional 'isKnownLegal' fast path to the legalizer, allowing
targets to bypass the generic legalization rules for the hottest most common
operations. It implements this hook for AArch64 using the most frequent
operation and type combinations identified by [1].

Improves CTMark geomean -0.73%, sqlite -1.67% [2].

Assisted-by: codex

[1] https://github.com/c-rhodes/llvm-tools/blob/main/compile-time/gisel-legalizer-stats/data/llvmorg-23.1.0-rc3/aarch64-O0-g/profile.md#ctmark-globalisel-legalizer-actions
[2] https://llvm-compile-time-tracker.com/compare.php?from=9c7ba7b1d12ed3f395a2317c525a98e5bfcf28e9&to=f5dd2c5018dea396cab04ba3920e76004bfd9947&stat=instructions%3Au