### PR TITLE
AArch64: Guard optimizeCondBranch against a physical copy source

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -10096,6 +10096,8 @@ bool AArch64InstrInfo::optimizeCondBranch(MachineInstr &MI) const {
   // Look through COPY instructions to find definition.
   while (DefMI->isCopy()) {
     Register CopyVReg = DefMI->getOperand(1).getReg();
+    if (!CopyVReg.isVirtual())
+      return false;
     if (!MRI->hasOneNonDBGUse(CopyVReg))
       return false;
     if (!MRI->hasOneDef(CopyVReg))


### PR DESCRIPTION
optimizeCondBranch walks COPY chains from the branch condition register,
calling getVRegDef on each copy's source operand. A COPY source can be a
physical register which doesn't make sense to pass to getVRegDef.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>