### PR TITLE
[fuzzer] Restrict merge-sigusr.test to Linux

### DIFF
--- a/compiler-rt/test/fuzzer/merge-sigusr.test
+++ b/compiler-rt/test/fuzzer/merge-sigusr.test
@@ -1,7 +1,7 @@
 # Check that libFuzzer honors SIGUSR1/SIGUSR2
-# FIXME: Disabled on Windows for now because of reliance on posix only features
-# (eg: export, "&", pkill).
-UNSUPPORTED: darwin, target={{.*windows.*}}
+# Requires Linux features (setsid, ps -o sess=).  Also relies on posix only
+# features (eg: export, "&", pkill).
+REQUIRES: linux
 RUN: rm -rf %t
 RUN: mkdir -p %t
 RUN: %cpp_compiler %S/SleepOneSecondTest.cpp -o %t/LFSIGUSR


### PR DESCRIPTION
The `fuzzer/merge-sigusr.test` test causes the whole `ninja check-all` run on NetBSD to be killed with `SIGUSR2`.

It turns out the test is highly Linux-specific in at least two ways:

- The `setsid` command doesn't exist on any of Darwin, FreeBSD, and NetBSD.

- `ps -o sess= <pid>` is highly unportable, too:

  - FreeBSD `ps` doesn't have the `sess` keyword at all.

  - NetBSD `ps` does, but with different semantics: it's the session pointer, not the session id as on Linux, which leads to randomly killing unrelated processes.

Therefore this patch restricts the test to Linux instead of simply skipping it on Darwin and Windows.

Tested on `x86_64-pc-netbsd11.0`, `x86_64-pc-linux-gnu`, and `x86_64-pc-freebsd15.1`.