### PR TITLE
[sanitizer] Skip hanging tests on FreeBSD

### DIFF
--- a/compiler-rt/test/msan/fork.cpp
+++ b/compiler-rt/test/msan/fork.cpp
@@ -15,7 +15,7 @@
 // UNSUPPORTED: powerpc64le-target-arch
 
 // Sometimes hangs
-// UNSUPPORTED: target={{.*netbsd.*}}
+// UNSUPPORTED: target={{.*(freebsd|netbsd).*}}
 
 #include <pthread.h>
 #include <unistd.h>

--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/fork_threaded.c
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/fork_threaded.c
@@ -14,6 +14,9 @@
 // UNSUPPORTED: target={{.*netbsd.*}}
 // UNSUPPORTED: target={{.*apple.*}}
 
+// FIXME: Loops indefinitely
+// UNSUPPORTED: target={{.*freebsd.*}} && tsan
+
 // Forking in multithread environment is unsupported. However we already have
 // some workarounds, and will add more, so this is the test.
 // The test try to check two things:

--- a/compiler-rt/test/tsan/fork_multithreaded.cpp
+++ b/compiler-rt/test/tsan/fork_multithreaded.cpp
@@ -1,5 +1,7 @@
 // RUN: %clangxx_tsan -O1 %s -o %t && %run %t 66 2>&1 | FileCheck %s -check-prefix=CHECK-DIE
 // RUN: %clangxx_tsan -O1 %s -o %t && %env_tsan_opts=die_after_fork=0 %run %t 2>&1 | FileCheck %s -check-prefix=CHECK-NODIE
+// FIXME: Loops indefinitely
+// UNSUPPORTED: target={{.*freebsd.*}}
 #include "test.h"
 #include <errno.h>
 #include <sys/types.h>


### PR DESCRIPTION
Three sanitizer tests hang indefinitely on FreeBSD:

```
MemorySanitizer-X86_64 :: fork.cpp
SanitizerCommon-tsan-x86_64-FreeBSD :: Posix/fork_threaded.c
ThreadSanitizer-x86_64 :: fork_multithreaded.cpp
```

All of them loop and don't time out, so they need to be terminated manually for `ninja check-all` to complete.  To avoid this, this patch skips the affected tests.

Tested on `x86_64-pc-freebsd15.1`, `x86_64-pc-netbsd11.0` and `x86_64-pc-linux-gnu`.