### PR TITLE
[clang][lex] Do not translate repeated include into import

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -416,6 +416,7 @@ features cannot lower the translation-unit ABI level;
 - Fixed an ICE that occurred when a structured binding pack is expanded outside the lambda where it was declared. (#GH214160)
 - Fixed a bug where a stray closing curley brace in an OpenMP/OpenACC pragma could cause pragma parsing issues when inside of a member function. (#GH214195)
 - Fixed a bug where preprocessor directives following comments were not correctly recognized when using -C. (#GH48361)
+- Fixed a bug where repeated #imports of modular headers in non-modular compilation were translated to #pragma clang module import. (#GH216924)
 
 #### Bug Fixes to Compiler Builtins
 

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -2590,7 +2590,8 @@ Preprocessor::ImportAction Preprocessor::HandleHeaderIncludeOrImport(
     if (UsableHeaderUnit && !getLangOpts().CompilingPCH)
       Action = TrackGMFState.inGMF() ? Import : Skip;
     else
-      Action = (ModuleToImport && !getLangOpts().CompilingPCH) ? Import : Skip;
+      Action = (UsableClangHeaderModule && !getLangOpts().CompilingPCH) ? Import
+                                                                        : Skip;
   }
 
   // Check for circular inclusion of the main file.

--- a/clang/test/Modules/non-modular-with-module-file.c
+++ b/clang/test/Modules/non-modular-with-module-file.c
@@ -1,0 +1,31 @@
+// Check that repeated inclusion of a modular header doesn't get translated
+// into an import in textual compilation.
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: %clang_cc1 -E %t/tu.c -o %t/tu.ii -I %t -fmodule-map-file=%t/module.modulemap
+
+// RUN: FileCheck --input-file=%t/tu.ii %s -DPREFIX=%/t
+
+// CHECK:      # 1 "[[PREFIX]]/tu.c"
+// CHECK-NEXT: # 1 "<built-in>" 1
+// CHECK-NEXT: # 1 "<built-in>" 3
+// CHECK-NEXT: # {{[0-9]+}} "<built-in>" 3
+// CHECK-NEXT: # 1 "<command line>" 1
+// CHECK-NEXT: # 1 "<built-in>" 2
+// CHECK-NEXT: # 1 "[[PREFIX]]/tu.c" 2
+// CHECK-NEXT: # 1 "[[PREFIX]]/Mod.h" 1
+// CHECK-NEXT: #pragma clang module begin Mod
+// CHECK-NEXT: # 2 "[[PREFIX]]/tu.c" 2
+// CHECK-NEXT: # 1 "[[PREFIX]]/tu.c"
+// CHECK-NEXT: #pragma clang module end /*Mod*/
+// CHECK-NOT:  #pragma clang module import
+
+//--- module.modulemap
+module Mod { header "Mod.h" }
+//--- Mod.h
+#pragma once
+//--- tu.c
+#include "Mod.h"
+#include "Mod.h"

--- a/clang/test/Modules/non-modular-with-module-file.c
+++ b/clang/test/Modules/non-modular-with-module-file.c
@@ -6,7 +6,7 @@
 
 // RUN: %clang_cc1 -E %t/tu.c -o %t/tu.ii -I %t -fmodule-map-file=%t/module.modulemap
 
-// RUN: FileCheck --input-file=%t/tu.ii %s -DPREFIX=%/t
+// RUN: FileCheck --input-file=%t/tu.ii %s -DPREFIX=%t
 
 // CHECK:      # 1 "[[PREFIX]]{{/|\\}}tu.c"
 // CHECK-NEXT: # 1 "<built-in>" 1

--- a/clang/test/Modules/non-modular-with-module-file.c
+++ b/clang/test/Modules/non-modular-with-module-file.c
@@ -8,17 +8,17 @@
 
 // RUN: FileCheck --input-file=%t/tu.ii %s -DPREFIX=%/t
 
-// CHECK:      # 1 "[[PREFIX]]/tu.c"
+// CHECK:      # 1 "[[PREFIX]]{{/|\\}}tu.c"
 // CHECK-NEXT: # 1 "<built-in>" 1
 // CHECK-NEXT: # 1 "<built-in>" 3
 // CHECK-NEXT: # {{[0-9]+}} "<built-in>" 3
 // CHECK-NEXT: # 1 "<command line>" 1
 // CHECK-NEXT: # 1 "<built-in>" 2
-// CHECK-NEXT: # 1 "[[PREFIX]]/tu.c" 2
-// CHECK-NEXT: # 1 "[[PREFIX]]/Mod.h" 1
+// CHECK-NEXT: # 1 "[[PREFIX]]{{/|\\}}tu.c" 2
+// CHECK-NEXT: # 1 "[[PREFIX]]{{/|\\}}Mod.h" 1
 // CHECK-NEXT: #pragma clang module begin Mod
-// CHECK-NEXT: # 2 "[[PREFIX]]/tu.c" 2
-// CHECK-NEXT: # 1 "[[PREFIX]]/tu.c"
+// CHECK-NEXT: # 2 "[[PREFIX]]{{/|\\}}tu.c" 2
+// CHECK-NEXT: # 1 "[[PREFIX]]{{/|\\}}tu.c"
 // CHECK-NEXT: #pragma clang module end /*Mod*/
 // CHECK-NOT:  #pragma clang module import
 


### PR DESCRIPTION
Using `ModuleToImport` when deciding whether to turn a repeated include into an import, or whether to skip it, isn't right. We have `ModuleToImport=true` even without `-fmodules` in textual compilations. This PR starts checking `UsableClangHeaderModule`, matching what we do for the first inclusion of that header.

rdar://184549117