### PR TITLE
[lldb] Don't apply the MS inheritance model to non-CXXRecordDecl DWARF types

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -2239,8 +2239,14 @@ bool DWARFASTParserClang::CompleteRecordType(const DWARFDIE &die,
 
   clang::CXXRecordDecl *record_decl =
       m_ast.GetAsCXXRecordDecl(clang_type.GetOpaqueQualType());
-  if (record_decl)
-    GetClangASTImporter().SetRecordLayout(record_decl, layout_info);
+  // Objective-C interfaces are completed through this path as well, but are
+  // not CXXRecordDecls. Nothing that follows applies to them: they have no
+  // record layout to hand to the importer, no pointer-to-member
+  // representation to infer, and no nested types to resolve.
+  if (!record_decl)
+    return clang_type.IsValid();
+
+  GetClangASTImporter().SetRecordLayout(record_decl, layout_info);
 
   // DWARF doesn't have the attribute, but we can infer the value the same way
   // as Clang Sema does. It's required to calculate the size of pointers to

--- a/lldb/test/Shell/SymbolFile/DWARF/clang-ast-from-dwarf-objc-interface-msvc.m
+++ b/lldb/test/Shell/SymbolFile/DWARF/clang-ast-from-dwarf-objc-interface-msvc.m
@@ -1,0 +1,34 @@
+// REQUIRES: lld, x86
+
+// RUN: %clang --target=x86_64-pc-windows-msvc -gdwarf -c -o %t.obj -- %s
+// RUN: lld-link -debug:dwarf -nodefaultlib -force:unresolved -entry:main \
+// RUN:     -out:%t.exe -- %t.obj
+// RUN: lldb-test symbols -dump-clang-ast %t.exe | FileCheck %s
+
+// CHECK: ObjCInterfaceDecl {{.*}} Base
+// CHECK-NEXT: ObjCIvarDecl {{.*}} base_ivar 'int'
+// CHECK: ObjCInterfaceDecl {{.*}} Derived
+// CHECK-NEXT: super ObjCInterface {{.*}} 'Base'
+// CHECK-NEXT: ObjCIvarDecl {{.*}} derived_ivar 'int'
+
+__attribute__((objc_root_class))
+@interface Base {
+  int base_ivar;
+}
+@end
+
+@implementation Base
+@end
+
+@interface Derived : Base {
+  int derived_ivar;
+}
+@end
+
+@implementation Derived
+@end
+
+int main(void) {
+  Derived *d = 0;
+  return (int)(__SIZE_TYPE__)d;
+}


### PR DESCRIPTION
`DWARFASTParserClang::CompleteRecordType` infers the Microsoft C++ ABI
inheritance model for records when the target uses that ABI, by calling
`calculateInheritanceModel()` on the record's `CXXRecordDecl`.

Objective-C interfaces are completed through the same function, but an
`ObjCInterfaceDecl` is not a `CXXRecordDecl`, so `GetAsCXXRecordDecl` returns
null. `SetRecordLayout` was already null-checked while the Microsoft-ABI block 
below it was not, and dereferenced the null pointer. LLDB segfaulted in 
`clang::CXXRecordDecl::calculateInheritanceModel()` on every completion 
of an Objective-C type from DWARF for an `*-windows-msvc` target, which
in practice means any `frame variable` or `expression` that touches an object.

The solution is to return early when the declaration is not a `CXXRecordDecl`.
As well as guarding the inheritance model, this skips the `contained_type_dies`
walk that follows, which has nothing to do for an Objective-C interface - there is
no record layout to hand to the importer, no pointer-to-member representation
to infer, and no nested types to resolve.

This is not specific to any Objective-C runtime, and nothing about the fix is
GNUstep-specific: it is reachable from any DWARF containing Objective-C types
on a target whose C++ ABI is Microsoft. I hit it debugging Objective-C on
Windows with the GNUstep libobjc2 runtime, where it made every Objective-C
type unusable.

## Testing

`lldb/test/Shell/SymbolFile/DWARF/clang-ast-from-dwarf-objc-interface-msvc.m`
compiles a two-level Objective-C interface hierarchy for `x86_64-pc-windows-msvc`
with `-gdwarf`, links it into a PE with `lld-link-debug:dwarf`, and checks the AST LLDB
builds from that DWARF with `lldb-test symbols -dump-clang-ast`.
I verified it both ways: with the fix reverted it segfaults in `calculateInheritanceModel()`,
and with it the interfaces come out complete with their ivars and superclass link.

It links an image rather than running on the object file because `lldb-test`
reports "Module has no symbol vendor" for a bare COFF `.obj`,  hence the
`REQUIRES: lld, x86`. It cross-compiles, so it runs on any host with the X86
target and lld built, not only on Windows.

---

Assisted-by: Claude Fable 5
