### PR TITLE
[sanitizer] Skip hanging tests on NetBSD

### DIFF
--- a/compiler-rt/lib/msan/tests/msan_test.cpp
+++ b/compiler-rt/lib/msan/tests/msan_test.cpp
@@ -3279,6 +3279,7 @@ TEST(MemorySanitizer, scanf) {
   delete d;
 }
 
+#if !defined(__NetBSD__)
 static void *SimpleThread_threadfn(void* data) {
   return new int;
 }
@@ -3344,6 +3345,7 @@ TEST(MemorySanitizer, SmallPreAllocatedStackThread) {
   res = pthread_attr_destroy(&attr);
   ASSERT_EQ(0, res);
 }
+#endif
 
 TEST(MemorySanitizer, pthread_attr_get) {
   pthread_attr_t attr;
@@ -3430,6 +3432,7 @@ TEST(MemorySanitizer, pthread_key_create) {
   ASSERT_EQ(0, res);
 }
 
+#if !defined(__NetBSD__)
 namespace {
 struct SignalCondArg {
   pthread_cond_t* cond;
@@ -3475,6 +3478,7 @@ TEST(MemorySanitizer, pthread_cond_wait) {
   pthread_mutex_destroy(&mu);
   pthread_cond_destroy(&cond);
 }
+#endif
 
 TEST(MemorySanitizer, tmpnam) {
   char s[L_tmpnam];

--- a/compiler-rt/test/fuzzer/reload.test
+++ b/compiler-rt/test/fuzzer/reload.test
@@ -1,5 +1,6 @@
 RUN: %cpp_compiler %S/ReloadTest.cpp -o %t-ReloadTest
 RUN: not %run %t-ReloadTest -max_len=10000 -seed=1 -timeout=15 -len_control=0 -exact_artifact_path=%t.crash 2>&1 | FileCheck %s
+UNSUPPORTED: target={{.*netbsd.*}}
 
 CHECK: Test unit written to {{.*}}reload.test.tmp.crash
 

--- a/compiler-rt/test/msan/zero_alloc.cpp
+++ b/compiler-rt/test/msan/zero_alloc.cpp
@@ -4,6 +4,8 @@
 // RUN:     | FileCheck %s --check-prefixes=CHECK,DISCOUNT
 // RUN: %clang_msan -Wno-alloc-size -fsanitize-recover=memory -fsanitize-memory-track-origins=2 %s -o %t && not %run %t 2>&1 \
 // RUN:     | FileCheck %s --check-prefixes=CHECK,ORIGINS
+// Hangs.
+// UNSUPPORTED: target={{.*netbsd.*}}
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/compiler-rt/test/tsan/signal_cond.cpp
+++ b/compiler-rt/test/tsan/signal_cond.cpp
@@ -1,4 +1,6 @@
 // RUN: %clang_tsan -O1 %s -o %t && %run %t 2>&1 | FileCheck %s
+// Hangs
+// UNSUPPORTED: target={{.*netbsd.*}}
 #include "test.h"
 #include <signal.h>
 #include <unistd.h>


### PR DESCRIPTION
Several sanitizer tests hang indefinitely on NetBSD:

```
MemorySanitizer-Unit :: ./Msan-x86_64-Test
MemorySanitizer-Unit :: ./Msan-x86_64-with-call-Test
MemorySanitizer-X86_64 :: zero_alloc.cpp
ThreadSanitizer-x86_64 :: signal_cond.cpp
libFuzzer-x86_64-default-NetBSD :: reload.test
```

All of them loop and don't time out, so they need to be terminated manually for `ninja check-all` to complete.  To avoid this, this patch skips the affected tests or subtests.  Unfortunately, the Msan unit tests still hang on exit in `__cxa_finalize` even if all subtests are skipped with `llvm-lit -gtest_filter=-*`.

Tested on  `x86_64-pc-netbsd11.0`, `x86_64-pc-freebsd15.1`, and `x86_64-pc-linux-gnu`.