### PR TITLE
AArch64: Fix csel-fold crash on an undef register

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -916,7 +916,7 @@ bool llvm::optimizeTerminators(MachineBasicBlock *MBB,
 static unsigned removeCopies(const MachineRegisterInfo &MRI, unsigned VReg) {
   while (Register::isVirtualRegister(VReg)) {
     const MachineInstr *DefMI = MRI.getVRegDef(VReg);
-    if (!DefMI->isFullCopy())
+    if (!DefMI || !DefMI->isFullCopy())
       return VReg;
     VReg = DefMI->getOperand(1).getReg();
   }
@@ -934,6 +934,8 @@ static unsigned canFoldIntoCSel(const MachineRegisterInfo &MRI, unsigned VReg,
 
   bool Is64Bit = AArch64::GPR64allRegClass.hasSubClassEq(MRI.getRegClass(VReg));
   const MachineInstr *DefMI = MRI.getVRegDef(VReg);
+  if (!DefMI)
+    return 0;
   unsigned Opc = 0;
   unsigned SrcReg = 0;
   switch (DefMI->getOpcode()) {

--- a/llvm/test/CodeGen/AArch64/early-ifcvt-same-value.mir
+++ b/llvm/test/CodeGen/AArch64/early-ifcvt-same-value.mir
@@ -249,3 +249,43 @@ body:             |
     RET_ReallyLR implicit $x2
 
 ...
+---
+name:            csel_fold_undef
+tracksRegLiveness: true
+body: |
+  ; A csel-fold operand that is a copy of an undef register has no defining
+  ; instruction and must not be dereferenced.
+  ; CHECK-LABEL: name: csel_fold_undef
+  ; CHECK: bb.0:
+  ; CHECK:   liveins: $w0, $w1
+  ; CHECK:   [[COPY:%[0-9]+]]:gpr32common = COPY $w0
+  ; CHECK:   [[COPY1:%[0-9]+]]:gpr32 = COPY $w1
+  ; CHECK:   [[SUBSWri:%[0-9]+]]:gpr32 = SUBSWri [[COPY]], 1, 0, implicit-def $nzcv
+  ; CHECK:   [[COPY2:%[0-9]+]]:gpr32 = COPY [[COPY1]]
+  ; CHECK:   [[COPY3:%[0-9]+]]:gpr32 = COPY undef %4:gpr32
+  ; CHECK:   [[CSELWr:%[0-9]+]]:gpr32 = CSELWr [[COPY2]], [[COPY3]], 1, implicit $nzcv
+  ; CHECK:   $w0 = COPY [[CSELWr]]
+  ; CHECK:   RET_ReallyLR implicit $w0
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1
+    %0:gpr32common = COPY $w0
+    %6:gpr32 = COPY $w1
+    %1:gpr32 = SUBSWri %0, 1, 0, implicit-def $nzcv
+    Bcc 1, %bb.2, implicit $nzcv
+    B %bb.1
+
+  bb.1:
+    successors: %bb.3
+    %2:gpr32 = COPY undef %3:gpr32
+    B %bb.3
+
+  bb.2:
+    successors: %bb.3
+    %4:gpr32 = COPY %6
+
+  bb.3:
+    %5:gpr32 = PHI %4, %bb.2, %2, %bb.1
+    $w0 = COPY %5
+    RET_ReallyLR implicit $w0
+...


### PR DESCRIPTION
removeCopies and canFoldIntoCSel dereference getVRegDef() while checking
whether a select operand can be folded into a csel during early
if-conversion.

Found by AI while working on something else.

Co-authored-by: Claude (Opus 4.8) <noreply@anthropic.com>