### PR TITLE
[lldb][test] Fix skip in TestWriteMemoryWithHWBreakpoint.py

### DIFF
--- a/lldb/test/API/functionalities/breakpoint/hardware_breakpoints/write_memory_with_hw_breakpoint/TestWriteMemoryWithHWBreakpoint.py
+++ b/lldb/test/API/functionalities/breakpoint/hardware_breakpoints/write_memory_with_hw_breakpoint/TestWriteMemoryWithHWBreakpoint.py
@@ -45,4 +45,4 @@ class WriteMemoryWithHWBreakpoint(HardwareBreakpointTestBase):
         error = lldb.SBError()
 
         result = process.WriteMemory(address, data, error)
-        self.assertTrue(error.Success() and result == len(bytes))
+        self.assertTrue(error.Success() and result == len(data))

--- a/lldb/test/API/functionalities/breakpoint/hardware_breakpoints/write_memory_with_hw_breakpoint/TestWriteMemoryWithHWBreakpoint.py
+++ b/lldb/test/API/functionalities/breakpoint/hardware_breakpoints/write_memory_with_hw_breakpoint/TestWriteMemoryWithHWBreakpoint.py
@@ -13,8 +13,7 @@ from functionalities.breakpoint.hardware_breakpoints.base import *
 
 class WriteMemoryWithHWBreakpoint(HardwareBreakpointTestBase):
 
-    @skipTestIfFn(HardwareBreakpointTestBase.supports_hw_breakpoints)
-    @skip
+    @skipTestIfFn(HardwareBreakpointTestBase.hw_breakpoints_unsupported)
     def test_copy_memory_with_hw_break(self):
         self.build()
         exe = self.getBuildArtifact("a.out")


### PR DESCRIPTION
In a87b27fd5161ec43527fc3356852046a321ea82c, the opposite
skip was put in. It should skip if hardware breakpoints are 
*not* supported.

Also that commit added a stray "skip". I have removed that and
fixed the incorrect variable name.