### PR TITLE
[Clang] Prevent an assertion failure when instantiating an invalid friend function template

### DIFF
--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -2818,7 +2818,8 @@ TemplateDeclInstantiator::VisitFunctionTemplateDecl(FunctionTemplateDecl *D) {
   if (!isFriend) {
     Owner->addDecl(InstTemplate);
   } else if (InstTemplate->getDeclContext()->isRecord() &&
-             !getPreviousDeclForInstantiation(D)) {
+             !getPreviousDeclForInstantiation(D) &&
+             isa<CXXMethodDecl>(InstTemplate->getTemplatedDecl())) {
     SemaRef.CheckFriendAccess(InstTemplate);
   }
 

--- a/clang/test/CXX/temp/temp.decls/temp.friend/p6.cpp
+++ b/clang/test/CXX/temp/temp.decls/temp.friend/p6.cpp
@@ -25,3 +25,12 @@ void t3() {
     // expected-error@-1 {{templates cannot be declared inside of a local class}}
   };
 }
+
+template <class T> void t4() {
+  struct S {
+    template <class U> friend void f(T);
+    // expected-error@-1 {{templates can only be declared in namespace or class scope}}
+  };
+}
+
+template void t4<int>();


### PR DESCRIPTION
Fixes #216694

---

This patch addresses an assertion failure that occurs when instantiating an invalid friend function template by marking its `FriendDecl` wrapper as invalid.