### PR TITLE
NVPTX: Fix using getVRegDef on a physical register

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXPeephole.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXPeephole.cpp
@@ -130,8 +130,8 @@ static bool runNVPTXPeephole(MachineFunction &MF) {
   // Remove unnecessary %VRFrame = cvta.local %VRFrameLocal
   const auto &MRI = MF.getRegInfo();
   if (MRI.use_empty(NRI->getFrameRegister(MF))) {
-    if (auto MI = MRI.getUniqueVRegDef(NRI->getFrameRegister(MF))) {
-      MI->eraseFromParent();
+    if (auto *MO = MRI.getOneDef(NRI->getFrameRegister(MF))) {
+      MO->getParent()->eraseFromParent();
       Changed = true;
     }
   }


### PR DESCRIPTION
This was calling getVRegDef on the frame register; change to
getOneDef instead. This still seems like a dubious way to deal
with any kind of frame setup optimization though.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>