### PR TITLE
[analyzer] Move the lifetime checkers from alpha.cplusplus to alpha.core

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -680,6 +680,8 @@ features cannot lower the translation-unit ABI level;
 
 #### Moved checkers
 
+The `alpha.cplusplus.UseAfterLifetimeEnd` checker was renamed to `alpha.core.UseAfterLifetimeEnd`.
+
 #### Diagnostic changes
 
 - For self-assignments during initialization (`T v = v;`), `core.uninitialized.Assign` will not report them as uninitialized accesses (except C++ reference types), and the checks will be delayed until the first accesses of these variables; `deadcode.DeadStores` will not report them as dead stores. (#GH187530)

--- a/clang/docs/analyzer/checkers.md
+++ b/clang/docs/analyzer/checkers.md
@@ -3198,6 +3198,66 @@ void test() {
 }
 ```
 
+(alpha-core-danglingptrderef)=
+
+#### alpha.core.DanglingPtrDeref (C, C++)
+
+Check for dereferences of pointers that refer to an object whose
+lifetime has already ended. Such a pointer is dangling. The checker
+reports it when it is dereferenced and when it is passed to a function.
+A return statement that does not dereference the pointer does not lead to a report.
+Such a case is reported by the {ref}`core-StackAddressEscape` checker.
+
+Each object is reported at most once on an execution path. If the same dangling
+pointer is used several times then only the first use is reported. Setting the pointer
+to null when the object goes out of scope avoids the dangling pointer and suppresses
+the report.
+
+```cpp
+void test_deref() {
+  int *ptr = 0;
+  {
+    int num = 5;
+    ptr = &num;
+  } // note: 'num' is destroyed here
+  *ptr = 6; // warn: use of 'num' after its lifetime ended
+}
+
+void test_in_scope() {
+  int num = 5;
+  int *ptr = &num;
+  {
+    *ptr = 6; // no warning, 'num' is still in scope
+  }
+}
+```
+
+The `-analyzer-config cfg-lifetime=true` option is a prerequisite for these
+reports. Without it the checker does not report anything and no error is emitted
+by the analyzer.
+
+**Limitations**
+
+If the analyzer cannot analyze the body of the called function, for example because
+its definition is not available in the given translation unit, then a dangling
+pointer passed to it is reported even if the function would never dereference
+it. This can lead to false positives.
+
+```cpp
+// The definition of the function is not available that is why the analyzer
+// assumes the pointer is used.
+int is_null(int *p);
+
+void argument_example() {
+  int *ptr = 0;
+  {
+    int num = 5;
+    ptr = &num;
+  }
+  is_null(ptr); // false positive: the pointer is compared, not dereferenced
+}
+```
+
 (alpha-core-dynamictypechecker)=
 
 #### alpha.core.DynamicTypeChecker (ObjC)
@@ -3300,65 +3360,6 @@ remove the const qualifier from the original declaration or use a mutable copy.
 
 ### alpha.cplusplus
 
-(alpha-cplusplus-danglingptrderef)=
-
-#### alpha.cplusplus.DanglingPtrDeref (C++)
-
-Check for dereferences of pointers that refer to an object whose
-lifetime has already ended. Such a pointer is dangling. The checker
-reports it when it is dereferenced and when it is passed to a function.
-A return statement that does not dereference the pointer does not lead to a report.
-Such a case is reported by the {ref}`core-StackAddressEscape` checker.
-
-Each object is reported at most once on an execution path. If the same dangling
-pointer is used several times then only the first use is reported. Setting the pointer
-to null when the object goes out of scope avoids the dangling pointer and suppresses
-the report.
-
-```cpp
-void test_deref() {
-  int *ptr = 0;
-  {
-    int num = 5;
-    ptr = &num;
-  } // note: 'num' is destroyed here
-  *ptr = 6; // warn: use of 'num' after its lifetime ended
-}
-
-void test_in_scope() {
-  int num = 5;
-  int *ptr = &num;
-  {
-    *ptr = 6; // no warning, 'num' is still in scope
-  }
-}
-```
-
-The `-analyzer-config cfg-lifetime=true` option is a prerequisite for these
-reports. Without it the checker does not report anything and no error is emitted
-by the analyzer.
-
-**Limitations**
-
-If the analyzer cannot analyze the body of the called function, for example because
-its definition is not available in the given translation unit, then a dangling
-pointer passed to it is reported even if the function would never dereference
-it. This can lead to false positives.
-
-```cpp
-// The definition of the function is not available that is why the analyzer
-// assumes the pointer is used.
-int is_null(int *p);
-
-void argument_example() {
-  int *ptr = 0;
-  {
-    int num = 5;
-    ptr = &num;
-  }
-  is_null(ptr); // false positive: the pointer is compared, not dereferenced
-}
-```
 (alpha-cplusplus-deletewithnonvirtualdtor)=
 
 #### alpha.cplusplus.DeleteWithNonVirtualDtor (C++)

--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -289,6 +289,22 @@ def StdVariantChecker : Checker<"StdVariant">,
   HelpText<"Check for bad type access for std::variant.">,
   Documentation<HasDocumentation>;
 
+def LifetimeModeling : Checker<"LifetimeModeling">,
+  HelpText<"Model lifetime annotations for other checkers">,
+  Documentation<NotDocumented>,
+  Hidden;
+
+def DanglingPtrDeref : Checker<"DanglingPtrDeref">,
+  HelpText<"Check for dereferences of a dangling pointer">,
+  Dependencies<[LifetimeModeling]>,
+  Documentation<HasDocumentation>;
+
+def UseAfterLifetimeEnd : Checker<"UseAfterLifetimeEnd">,
+  HelpText<"Check for uses of references or pointers that "
+           "outlive their bound object">,
+  Dependencies<[LifetimeModeling]>,
+  Documentation<NotDocumented>;
+
 } // end "alpha.core"
 
 //===----------------------------------------------------------------------===//
@@ -800,22 +816,6 @@ def MismatchedIteratorChecker : Checker<"MismatchedIterator">,
 def SmartPtrChecker: Checker<"SmartPtr">,
   HelpText<"Find the dereference of null SmrtPtr">,
   Dependencies<[SmartPtrModeling]>,
-  Documentation<HasDocumentation>;
-
-def LifetimeModeling : Checker<"LifetimeModeling">,
-  HelpText<"Model lifetime annotations for other checkers">,
-  Documentation<NotDocumented>,
-  Hidden;
-
-def UseAfterLifetimeEnd : Checker<"UseAfterLifetimeEnd">,
-  HelpText<"Check for uses of references or pointers that "
-           "outlive their bound object">,
-  Dependencies<[LifetimeModeling]>,
-  Documentation<NotDocumented>;
-
-def DanglingPtrDeref : Checker<"DanglingPtrDeref">,
-  HelpText<"Check for dereferences of a dangling pointer">,
-  Dependencies<[LifetimeModeling]>,
   Documentation<HasDocumentation>;
 
 } // end: "alpha.cplusplus"

--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -305,12 +305,6 @@ def DanglingPtrDeref : Checker<"DanglingPtrDeref">,
   Dependencies<[LifetimeModeling]>,
   Documentation<HasDocumentation>;
 
-def UseAfterLifetimeEnd : Checker<"UseAfterLifetimeEnd">,
-  HelpText<"Check for uses of references or pointers that "
-           "outlive their bound object">,
-  Dependencies<[LifetimeModeling]>,
-  Documentation<NotDocumented>;
-
 } // end "alpha.core"
 
 //===----------------------------------------------------------------------===//

--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -294,6 +294,12 @@ def LifetimeModeling : Checker<"LifetimeModeling">,
   Documentation<NotDocumented>,
   Hidden;
 
+def UseAfterLifetimeEnd : Checker<"UseAfterLifetimeEnd">,
+  HelpText<"Check for uses of references or pointers that "
+           "outlive their bound object">,
+  Dependencies<[LifetimeModeling]>,
+  Documentation<NotDocumented>;
+
 def DanglingPtrDeref : Checker<"DanglingPtrDeref">,
   HelpText<"Check for dereferences of a dangling pointer">,
   Dependencies<[LifetimeModeling]>,

--- a/clang/test/Analysis/dangling-ptr-deref.cpp
+++ b/clang/test/Analysis/dangling-ptr-deref.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_analyze_cc1 -analyzer-checker=core,alpha.cplusplus.DanglingPtrDeref \
+// RUN: %clang_analyze_cc1 -analyzer-checker=core,alpha.core.DanglingPtrDeref \
 // RUN:   -analyzer-config cfg-lifetime=true -analyzer-output=text -verify %s
 
 void test_case_one() {

--- a/clang/test/Analysis/debug-lifetime-bound.cpp
+++ b/clang/test/Analysis/debug-lifetime-bound.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_analyze_cc1 -analyzer-checker=core,alpha.cplusplus.UseAfterLifetimeEnd,debug.DebugLifetimeModeling -verify %s
+// RUN: %clang_analyze_cc1 -analyzer-checker=core,alpha.core.UseAfterLifetimeEnd,debug.DebugLifetimeModeling -verify %s
 
 // expected-no-diagnostics
 

--- a/clang/test/Analysis/lifetime-bound.cpp
+++ b/clang/test/Analysis/lifetime-bound.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_analyze_cc1 -analyzer-checker=core,alpha.cplusplus.UseAfterLifetimeEnd,debug.DebugLifetimeModeling \
+// RUN: %clang_analyze_cc1 -analyzer-checker=core,alpha.core.UseAfterLifetimeEnd,debug.DebugLifetimeModeling \
 // RUN:   -analyzer-config cfg-lifetime=true -analyzer-output=text -verify %s
-// RUN: %clang_analyze_cc1 -analyzer-checker=core,alpha.cplusplus.UseAfterLifetimeEnd,debug.DebugLifetimeModeling \
+// RUN: %clang_analyze_cc1 -analyzer-checker=core,alpha.core.UseAfterLifetimeEnd,debug.DebugLifetimeModeling \
 // RUN:   -analyzer-output=text %s 2>&1 | FileCheck --strict-whitespace %s
 struct A {};
 


### PR DESCRIPTION
This PR moves the lifetime checkers from `alpha.cplusplus` to `alpha.core`. This PR is the beginning of future PRs that will bring the lifetime checkers from `alpha` to `core`. To meet the requirements of a `core` checker there are still missing works for these checkers that is the reason this PR only moves them from `alpha.cplusplus` to `alpha.core`.