### PR TITLE
[SPIR-V] Fix storage class mismatch for globals initialized with a function pointer

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -237,7 +237,8 @@ class SPIRVEmitIntrinsicsImpl
                                      bool UnknownElemTypeI8);
   Type *deduceElementTypeByValueDeep(Type *ValueTy, Value *Operand,
                                      SmallPtrSetImpl<Value *> &Visited,
-                                     bool UnknownElemTypeI8);
+                                     bool UnknownElemTypeI8,
+                                     std::optional<unsigned> AddrSpace = {});
   Type *deduceElementTypeByUsersDeep(Value *Op,
                                      SmallPtrSetImpl<Value *> &Visited,
                                      bool UnknownElemTypeI8);
@@ -707,13 +708,14 @@ Type *SPIRVEmitIntrinsicsImpl::deduceElementTypeByValueDeep(
 
 Type *SPIRVEmitIntrinsicsImpl::deduceElementTypeByValueDeep(
     Type *ValueTy, Value *Operand, SmallPtrSetImpl<Value *> &Visited,
-    bool UnknownElemTypeI8) {
+    bool UnknownElemTypeI8, std::optional<unsigned> AddrSpace) {
   Type *Ty = ValueTy;
   if (Operand) {
     if (auto *PtrTy = dyn_cast<PointerType>(Ty)) {
       if (Type *NestedTy =
               deduceElementTypeHelper(Operand, Visited, UnknownElemTypeI8))
-        Ty = getTypedPointerWrapper(NestedTy, PtrTy->getAddressSpace());
+        Ty = getTypedPointerWrapper(
+            NestedTy, AddrSpace.value_or(PtrTy->getAddressSpace()));
     } else {
       Ty = deduceNestedTypeHelper(dyn_cast<User>(Operand), Ty, Visited,
                                   UnknownElemTypeI8);
@@ -988,18 +990,19 @@ Type *SPIRVEmitIntrinsicsImpl::deduceElementTypeHelper(
       GR->addDeducedElementType(I, Ty);
     } else {
       Value *Op = Ref->getNumOperands() > 0 ? Ref->getOperand(0) : nullptr;
-      if (isa_and_nonnull<Function>(Op) &&
-          TM.getSubtargetImpl()->canUseExtension(
-              SPIRV::Extension::SPV_INTEL_function_pointers)) {
-        if (Type *NestedTy =
-                deduceElementTypeHelper(Op, Visited, UnknownElemTypeI8))
-          Ty = getTypedPointerWrapper(
-              NestedTy, storageClassToAddressSpace(
-                            SPIRV::StorageClass::CodeSectionINTEL));
-      } else {
-        Ty = deduceElementTypeByValueDeep(Ref->getValueType(), Op, Visited,
-                                          UnknownElemTypeI8);
+      // Code lives in the program address space, not in the address space of
+      // the global. Program address space 0 means the data layout omits it.
+      std::optional<unsigned> ProgramAS;
+      if (isa_and_nonnull<Function>(Op)) {
+        if (unsigned AS = CurrF->getDataLayout().getProgramAddressSpace())
+          ProgramAS = AS;
+        else if (TM.getSubtargetImpl()->canUseExtension(
+                     SPIRV::Extension::SPV_INTEL_function_pointers))
+          ProgramAS =
+              storageClassToAddressSpace(SPIRV::StorageClass::CodeSectionINTEL);
       }
+      Ty = deduceElementTypeByValueDeep(Ref->getValueType(), Op, Visited,
+                                        UnknownElemTypeI8, ProgramAS);
     }
   } else if (auto *Ref = dyn_cast<AddrSpaceCastInst>(I)) {
     Type *RefTy = deduceElementTypeHelper(Ref->getPointerOperand(), Visited,

--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -987,10 +987,19 @@ Type *SPIRVEmitIntrinsicsImpl::deduceElementTypeHelper(
       Ty = SPIRV::getOriginalFunctionType(*Fn);
       GR->addDeducedElementType(I, Ty);
     } else {
-      Ty = deduceElementTypeByValueDeep(
-          Ref->getValueType(),
-          Ref->getNumOperands() > 0 ? Ref->getOperand(0) : nullptr, Visited,
-          UnknownElemTypeI8);
+      Value *Op = Ref->getNumOperands() > 0 ? Ref->getOperand(0) : nullptr;
+      if (isa_and_nonnull<Function>(Op) &&
+          TM.getSubtargetImpl()->canUseExtension(
+              SPIRV::Extension::SPV_INTEL_function_pointers)) {
+        if (Type *NestedTy =
+                deduceElementTypeHelper(Op, Visited, UnknownElemTypeI8))
+          Ty = getTypedPointerWrapper(
+              NestedTy, storageClassToAddressSpace(
+                            SPIRV::StorageClass::CodeSectionINTEL));
+      } else {
+        Ty = deduceElementTypeByValueDeep(Ref->getValueType(), Op, Visited,
+                                          UnknownElemTypeI8);
+      }
     }
   } else if (auto *Ref = dyn_cast<AddrSpaceCastInst>(I)) {
     Type *RefTy = deduceElementTypeHelper(Ref->getPointerOperand(), Visited,

--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -991,7 +991,8 @@ Type *SPIRVEmitIntrinsicsImpl::deduceElementTypeHelper(
     } else {
       Value *Op = Ref->getNumOperands() > 0 ? Ref->getOperand(0) : nullptr;
       // Code lives in the program address space, not in the address space of
-      // the global. Program address space 0 means the data layout omits it.
+      // the global. For known SPIR-V targets, program address space 0 maps
+      // to Function/Private, which cannot hold code, so treat it as unset.
       std::optional<unsigned> ProgramAS;
       if (isa_and_nonnull<Function>(Op)) {
         if (unsigned AS = CurrF->getDataLayout().getProgramAddressSpace())

--- a/llvm/test/CodeGen/SPIRV/pointers/fun-ptr-to-itself.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/fun-ptr-to-itself.ll
@@ -12,6 +12,14 @@
 ; CHECK-DAG: %[[#CodePtrTy:]] = OpTypePointer CodeSectionINTEL %[[#FnTy]]
 ; CHECK-DAG: %[[#Null:]] = OpConstantNull %[[#Int8PtrTy]]
 ; CHECK-DAG: %[[#FnPtr:]] = OpConstantFunctionPointerINTEL %[[#CodePtrTy]] %[[#FnDef:]]
+; The OpVariable for @fp must use CodeSectionINTEL to match its OpConstantFunctionPointerINTEL initializer.
+; CHECK-DAG: %[[#Int32:]] = OpTypeInt 32 0
+; CHECK-DAG: %[[#FunTy2:]] = OpTypeFunction %[[#Int32]] %[[#Int32]]
+; CHECK-DAG: %[[#CodePtrTy2:]] = OpTypePointer CodeSectionINTEL %[[#FunTy2]]
+; CHECK-DAG: %[[#GenPtrTy2:]] = OpTypePointer Generic %[[#FunTy2]]
+; CHECK-DAG: %[[#GenPtrPtrTy2:]] = OpTypePointer Function %[[#GenPtrTy2]]
+; CHECK-DAG: %[[#VarTy2:]] = OpTypePointer Function %[[#CodePtrTy2]]
+; CHECK-DAG: %[[#FnPtr2:]] = OpConstantFunctionPointerINTEL %[[#CodePtrTy2]] %[[#Callback:]]
 ; CHECK:     %[[#FnDef]] = OpFunction %[[#Void]] None %[[#FnTy]]
 ; CHECK:     %[[#Cast:]] = OpPtrCastToGeneric %[[#GenPtrTy]] %[[#FnPtr]]
 ; CHECK:     %[[#BC:]] = OpBitcast %[[#GenPtrPtrTy]] %[[#Null]]
@@ -23,4 +31,22 @@ define void @foo() {
 entry:
   store ptr addrspace(4) addrspacecast (ptr @foo to ptr addrspace(4)), ptr null, align 8
   ret void
+}
+
+; CHECK:     %[[#Fp:]] = OpVariable %[[#VarTy2]] Function %[[#FnPtr2]]
+; CHECK:     %[[#BC2:]] = OpBitcast %[[#GenPtrPtrTy2]] %[[#Fp]]
+; CHECK:     %[[#Ptr:]] = OpLoad %[[#GenPtrTy2]] %[[#BC2]]
+; CHECK:     OpFunctionPointerCallINTEL %[[#Int32]] %[[#Ptr]]
+
+@fp = global ptr addrspace(4) @callback
+
+define void @caller() {
+  %ptr = load ptr addrspace(4), ptr @fp
+  %r = call addrspace(4) i32 %ptr(i32 0)
+  ret void
+}
+
+; CHECK: %[[#Callback]] = OpFunction %[[#Int32]] None %[[#FunTy2]]
+define i32 @callback(i32 %x) addrspace(4) {
+  ret i32 %x
 }


### PR DESCRIPTION
Related to https://github.com/llvm/llvm-project/pull/216638