### PR TITLE
RISCV: Fix using getVRegDef on a physical register

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVVectorPeephole.cpp
+++ b/llvm/lib/Target/RISCV/RISCVVectorPeephole.cpp
@@ -111,6 +111,8 @@ RISCVVectorPeephole::getConstant(const MachineOperand &VL) const {
   if (VL.isImm())
     return VL.getImm();
 
+  if (!VL.getReg().isVirtual())
+    return std::nullopt;
   MachineInstr *Def = MRI->getVRegDef(VL.getReg());
   if (!Def || Def->getOpcode() != RISCV::ADDI || !Def->getOperand(1).isReg() ||
       Def->getOperand(1).getReg() != RISCV::X0)


### PR DESCRIPTION
This was looking through a VL operand to find a materialized
ADDI $x0, imm. The VL register can be physical, so avoid calling
getVRegDef.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>