### PR TITLE
[IR] Speed up standalone function printing

### DIFF
--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -800,6 +800,7 @@ private:
   const Function* TheFunction = nullptr;
   bool FunctionProcessed = false;
   bool ShouldInitializeAllMetadata;
+  bool ShouldInitializeMetadataThroughFunction = false;
 
   std::function<void(AbstractSlotTrackerStorage *, const Module *, bool)>
       ProcessModuleHookFn;
@@ -853,9 +854,9 @@ public:
 
   /// Construct from a function, starting out in incorp state.
   ///
-  /// If \c ShouldInitializeAllMetadata, initializes all metadata in all
-  /// functions, giving correct numbering for metadata referenced only from
-  /// within a function (even if no functions have been initialized).
+  /// If \c ShouldInitializeAllMetadata, initializes metadata in module order
+  /// through this function, giving the same numbering for its metadata as a
+  /// module-level slot tracker.
   explicit SlotTracker(const Function *F,
                        bool ShouldInitializeAllMetadata = false);
 
@@ -957,9 +958,6 @@ private:
 
   /// Add all of the metadata from a function.
   void processFunctionMetadata(const Function &F);
-
-  /// Add all of the metadata from an instruction.
-  void processInstructionMetadata(const Instruction &I);
 
   /// Add all of the metadata from a DbgRecord.
   void processDbgRecordMetadata(const DbgRecord &DVR);
@@ -1063,7 +1061,8 @@ SlotTracker::SlotTracker(const Module *M, bool ShouldInitializeAllMetadata)
 // function provided to be added to the slot table.
 SlotTracker::SlotTracker(const Function *F, bool ShouldInitializeAllMetadata)
     : TheModule(F ? F->getParent() : nullptr), TheFunction(F),
-      ShouldInitializeAllMetadata(ShouldInitializeAllMetadata) {}
+      ShouldInitializeAllMetadata(ShouldInitializeAllMetadata),
+      ShouldInitializeMetadataThroughFunction(ShouldInitializeAllMetadata) {}
 
 SlotTracker::SlotTracker(const ModuleSummaryIndex *Index)
     : TheModule(nullptr), ShouldInitializeAllMetadata(false), TheIndex(Index) {}
@@ -1118,13 +1117,18 @@ void SlotTracker::processModule() {
       CreateMetadataSlot(N);
   }
 
+  bool ProcessFunctionMetadata = ShouldInitializeAllMetadata;
   for (const Function &F : *TheModule) {
     if (!F.hasName())
       // Add all the unnamed functions to the table.
       CreateModuleSlot(&F);
 
-    if (ShouldInitializeAllMetadata)
+    if (ProcessFunctionMetadata)
       processFunctionMetadata(F);
+
+    // Metadata in later functions cannot affect slots used by TheFunction.
+    if (ShouldInitializeMetadataThroughFunction && &F == TheFunction)
+      ProcessFunctionMetadata = false;
 
     // Add all the function attributes to the table.
     // FIXME: Add attributes of other objects?
@@ -1229,11 +1233,27 @@ void SlotTracker::processGlobalObjectMetadata(const GlobalObject &GO) {
 
 void SlotTracker::processFunctionMetadata(const Function &F) {
   processGlobalObjectMetadata(F);
+  SmallVector<std::pair<unsigned, MDNode *>, 4> MDs;
   for (auto &BB : F) {
     for (auto &I : BB) {
       for (const DbgRecord &DR : I.getDbgRecordRange())
         processDbgRecordMetadata(DR);
-      processInstructionMetadata(I);
+
+      // Process metadata used directly by intrinsics.
+      if (const auto *CI = dyn_cast<CallInst>(&I))
+        if (Function *Callee = CI->getCalledFunction())
+          if (Callee->isIntrinsic())
+            for (auto &Op : I.operands())
+              if (auto *V = dyn_cast_or_null<MetadataAsValue>(Op))
+                if (auto *N = dyn_cast<MDNode>(V->getMetadata()))
+                  CreateMetadataSlot(N);
+
+      // Process metadata attached to this instruction.
+      if (!I.hasMetadata())
+        continue;
+      I.getAllMetadata(MDs);
+      for (auto &MD : MDs)
+        CreateMetadataSlot(MD.second);
     }
   }
 }
@@ -1265,23 +1285,6 @@ void SlotTracker::processDbgRecordMetadata(const DbgRecord &DR) {
   }
   if (DR.getDebugLoc())
     CreateMetadataSlot(DR.getDebugLoc().getAsMDNode());
-}
-
-void SlotTracker::processInstructionMetadata(const Instruction &I) {
-  // Process metadata used directly by intrinsics.
-  if (const auto *CI = dyn_cast<CallInst>(&I))
-    if (Function *F = CI->getCalledFunction())
-      if (F->isIntrinsic())
-        for (auto &Op : I.operands())
-          if (auto *V = dyn_cast_or_null<MetadataAsValue>(Op))
-            if (auto *N = dyn_cast<MDNode>(V->getMetadata()))
-              CreateMetadataSlot(N);
-
-  // Process metadata attached to this instruction.
-  SmallVector<std::pair<unsigned, MDNode *>, 4> MDs;
-  I.getAllMetadata(MDs);
-  for (auto &MD : MDs)
-    CreateMetadataSlot(MD.second);
 }
 
 /// Clean up after incorporating a function. This is the only way to get out of
@@ -5262,10 +5265,18 @@ void DbgLabelRecord::print(raw_ostream &ROS, ModuleSlotTracker &MST,
 }
 
 void Value::print(raw_ostream &ROS, bool IsForDebug) const {
+  if (const auto *F = dyn_cast<Function>(this)) {
+    formatted_raw_ostream OS(ROS);
+    SlotTracker SlotTable(F, /*ShouldInitializeAllMetadata=*/true);
+    AssemblyWriter W(OS, SlotTable, F->getParent(), nullptr, IsForDebug);
+    W.printFunction(F);
+    return;
+  }
+
   bool ShouldInitializeAllMetadata = false;
   if (auto *I = dyn_cast<Instruction>(this))
     ShouldInitializeAllMetadata = isReferencingMDNode(*I);
-  else if (isa<Function>(this) || isa<MetadataAsValue>(this))
+  else if (isa<MetadataAsValue>(this))
     ShouldInitializeAllMetadata = true;
 
   ModuleSlotTracker MST(getModuleFromVal(this), ShouldInitializeAllMetadata);

--- a/llvm/unittests/IR/AsmWriterTest.cpp
+++ b/llvm/unittests/IR/AsmWriterTest.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+#include "llvm/AsmParser/Parser.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/IR/DebugInfoMetadata.h"
 #include "llvm/IR/Function.h"
@@ -12,6 +13,8 @@
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/MDBuilder.h"
 #include "llvm/IR/Module.h"
+#include "llvm/IR/ModuleSlotTracker.h"
+#include "llvm/Support/SourceMgr.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -102,5 +105,60 @@ TEST(AsmWriterTest, PrintNullOperandBundle) {
   raw_string_ostream OS(S);
   Invoke->print(OS);
   EXPECT_THAT(S, HasSubstr("<null operand bundle!>"));
+}
+
+TEST(AsmWriterTest, FunctionPrintMatchesFullModuleSlotTracker) {
+  LLVMContext Ctx;
+  SMDiagnostic Err;
+  std::unique_ptr<Module> M = parseAssemblyString(R"(
+    define i32 @first(i32 %arg) #0 {
+      %value = add i32 %arg, 1, !annotation !0
+      ret i32 %value
+    }
+
+    define i32 @second(i32 %arg) #1 {
+      %value = mul i32 %arg, 2, !annotation !1
+      ret i32 %value
+    }
+
+    define i32 @third(i32 %arg) #2 {
+      %value = sub i32 %arg, 3, !annotation !2
+      ret i32 %value
+    }
+
+    attributes #0 = { nounwind }
+    attributes #1 = { noinline }
+    attributes #2 = { alwaysinline }
+
+    !0 = !{!"first metadata"}
+    !1 = !{!"second metadata"}
+    !2 = !{!"third metadata"}
+  )",
+                                                  Err, Ctx);
+  ASSERT_TRUE(M);
+
+  for (const Function &F : *M) {
+    std::string Expected;
+    raw_string_ostream ExpectedOS(Expected);
+    ModuleSlotTracker MST(M.get(), /*ShouldInitializeAllMetadata=*/true);
+    static_cast<const Value &>(F).print(ExpectedOS, MST);
+
+    std::string Actual;
+    raw_string_ostream ActualOS(Actual);
+    static_cast<const Value &>(F).print(ActualOS);
+
+    EXPECT_EQ(Expected, Actual);
+  }
+
+  ModuleSlotTracker MST(M.get(), /*ShouldInitializeAllMetadata=*/true);
+  auto PrintFirstInstruction = [&](const Function &F) {
+    std::string S;
+    raw_string_ostream OS(S);
+    static_cast<const Value &>(F.front().front()).print(OS, MST);
+    return S;
+  };
+  PrintFirstInstruction(*M->getFunction("first"));
+  EXPECT_THAT(PrintFirstInstruction(*M->getFunction("third")),
+              HasSubstr("!annotation !2"));
 }
 }


### PR DESCRIPTION
Printing a function through `Value::print` initializes metadata slots for
every function in the module. This makes repeated function snapshots
expensive.

Use a function-aware slot tracker and stop collecting metadata after the
target function. Metadata in later functions cannot affect its slot
numbers. Reuse the metadata attachment buffer while walking instructions.

The printed IR is unchanged. This adds no cache or cross-pass state.
Normal module slot trackers continue to initialize metadata for the full
module, including when they are reused across functions.

On 2026-08-17 at 14:16 EDT, an alternating seven-run test on `medium.ll`
(4,833,763 input bytes and 687 defined functions) measured these medians:

| Version | Time |
| --- | ---: |
| `origin/main` | 1.392799 s |
| This patch | 0.489288 s |

This is a 2.85x speedup. Every run produced 4,459,658 bytes. A separate
check compared all 687 function strings with a fully initialized
`ModuleSlotTracker`; all outputs matched exactly.

The measurement used a Release build at `9da823c884ec9` in
`ghcr.io/llvm/ci-ubuntu-24.04@sha256:b6eb0f84e352348fb2135e587dca1cc0f15113db9f04a8c64b8a4d40cccf512c`.
