### PR TITLE
[SystemZ] Keep patchable function entries at function start

### DIFF
--- a/llvm/lib/Target/SystemZ/SystemZInstrInfo.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZInstrInfo.cpp
@@ -2449,7 +2449,8 @@ bool SystemZInstrInfo::isSchedulingBoundary(const MachineInstr &MI,
                                             const MachineFunction &MF) const {
   if (TargetInstrInfo::isSchedulingBoundary(MI, MBB, MF))
     return true;
-  return MI.getOpcode() == SystemZ::FENCE;
+  return MI.getOpcode() == SystemZ::FENCE ||
+         MI.getOpcode() == TargetOpcode::PATCHABLE_FUNCTION_ENTER;
 }
 
 MCInst SystemZInstrInfo::getNop() const {

--- a/llvm/test/CodeGen/SystemZ/patchable-function-entry.ll
+++ b/llvm/test/CodeGen/SystemZ/patchable-function-entry.ll
@@ -2,6 +2,7 @@
 ; RUN: llc -mtriple=s390x-ibm-linux -function-sections %s -o - | FileCheck %s
 ; RUN: llc -mtriple=s390x-ibm-linux -no-integrated-as -binutils-version=2.35 %s -o - | FileCheck --check-prefix=NOLINK %s
 ; RUN: llc -mtriple=s390x-ibm-linux -no-integrated-as -binutils-version=2.36 %s -o - | FileCheck %s
+; RUN: llc -mtriple=s390x-ibm-linux -mcpu=zEC12 %s -o - | FileCheck %s --check-prefix=ZEC12
 
 ;; GNU ld < 2.36 did not support mixed SHF_LINK_ORDER and non-SHF_LINK_ORDER sections.
 ; NOLINK-NOT: "awo"
@@ -97,5 +98,23 @@ define void @prefix() "patchable-function-entry"="0" "patchable-function-prefix"
 ; CHECK:      .section __patchable_function_entries,"awo",@progbits,prefix{{$}}
 ; CHECK:      .p2align        3, 0x0
 ; CHECK-NEXT: .quad   .Ltmp1
+  ret void
+}
+
+;; Make sure patchable function entry is not moved around.
+declare void @f4_1(i64)
+
+define void @f4_2() "patchable-function-entry"="3" {
+; ZEC12-LABEL: f4_2:
+; ZEC12-NEXT:  [[ENTRY:.Lfunc_begin[0-9]+]]:
+; ZEC12:       # %bb.0:
+; ZEC12-NEXT:  nopr
+; ZEC12-NEXT:  nopr
+; ZEC12-NEXT:  nopr
+; ZEC12-NEXT:  lghi
+; ZEC12:       .section __patchable_function_entries,"awo",@progbits,f4_2
+; ZEC12-NEXT:  .p2align 3, 0x0
+; ZEC12-NEXT:  .quad [[ENTRY]]
+  tail call void (i64) @f4_1(i64 1)
   ret void
 }


### PR DESCRIPTION
Currently SystemZ's PostRA Scheduler is allowed to move PATCHABLE_FUNCTION_ENTER around, defeating its purpose:

    bb.0 (%ir-block.0):
      PATCHABLE_FUNCTION_ENTER
      $r2d = LGHI 1

    [...]

    # *** IR Dump After PostRA Machine Instruction Scheduler (postmisched) ***:

    [...]

    bb.0 (%ir-block.0):
      $r2d = LGHI 1
      PATCHABLE_FUNCTION_ENTER

Fix this by designating it a scheduling boundary, making PostRAScheduler::run() create regions around it.

SystemZ needs this, unlike, e.g., X86, because its PatchableFunction pass runs before PostRAScheduler.

Co-developed-by: Vasily Gorbik <gor@linux.ibm.com>