### PR TITLE
To fix test failures.

### DIFF
--- a/clang/test/Driver/flang/lit.local.cfg
+++ b/clang/test/Driver/flang/lit.local.cfg
@@ -1,0 +1,3 @@
+# Flang on AIX supports 64-bit only
+if "system-aix" in config.available_features:
+    config.environment["OBJECT_MODE"] = "64"


### PR DESCRIPTION
This PR is to fix test failure in the AIX buildbot.
Flang supports 64-bit mode only. Add a config file to set OBJECT_MODE.