### PR TITLE
[libc] Create syslog.h header and add several symbolic constants.

### DIFF
--- a/libc/config/linux/aarch64/headers.txt
+++ b/libc/config/linux/aarch64/headers.txt
@@ -75,6 +75,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.sys_wait
     libc.include.syscall
     libc.include.sysexits
+    libc.include.syslog
     libc.include.termios
     libc.include.threads
     libc.include.time

--- a/libc/config/linux/arm/headers.txt
+++ b/libc/config/linux/arm/headers.txt
@@ -20,6 +20,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.stdlib
     libc.include.string
     libc.include.strings
+    libc.include.syslog
     libc.include.pwd
     libc.include.uchar
     libc.include.unistd

--- a/libc/config/linux/riscv/headers.txt
+++ b/libc/config/linux/riscv/headers.txt
@@ -76,6 +76,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.sys_wait
     libc.include.syscall
     libc.include.sysexits
+    libc.include.syslog
     libc.include.termios
     libc.include.threads
     libc.include.time

--- a/libc/config/linux/x86_64/headers.txt
+++ b/libc/config/linux/x86_64/headers.txt
@@ -79,6 +79,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.sys_wait
     libc.include.syscall
     libc.include.sysexits
+    libc.include.syslog
     libc.include.termios
     libc.include.threads
     libc.include.time

--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -228,6 +228,15 @@ add_header_macro(
 )
 
 add_header_macro(
+  syslog
+  ../libc/include/syslog.yaml
+  syslog.h
+  DEPENDS
+    .llvm_libc_common_h
+    .llvm-libc-macros.syslog_macros
+)
+
+add_header_macro(
   alloca
   ../libc/include/alloca.yaml
   alloca.h

--- a/libc/include/llvm-libc-macros/CMakeLists.txt
+++ b/libc/include/llvm-libc-macros/CMakeLists.txt
@@ -493,3 +493,9 @@ add_macro_header(
   HDR
     alloca-macros.h
 )
+
+add_macro_header(
+  syslog_macros
+  HDR
+    syslog-macros.h
+)

--- a/libc/include/llvm-libc-macros/syslog-macros.h
+++ b/libc/include/llvm-libc-macros/syslog-macros.h
@@ -1,0 +1,53 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definition of macros from syslog.h.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_MACROS_SYSLOG_MACROS_H
+#define LLVM_LIBC_MACROS_SYSLOG_MACROS_H
+
+// Options for openlog
+#define LOG_PID 0x01
+#define LOG_CONS 0x02
+#define LOG_ODELAY 0x04
+#define LOG_NDELAY 0x08
+#define LOG_NOWAIT 0x10
+
+// Facilities for openlog
+#define LOG_KERN (0 << 3)
+#define LOG_USER (1 << 3)
+#define LOG_MAIL (2 << 3)
+#define LOG_DAEMON (3 << 3)
+#define LOG_AUTH (4 << 3)
+#define LOG_LPR (6 << 3)
+#define LOG_NEWS (7 << 3)
+#define LOG_UUCP (8 << 3)
+#define LOG_CRON (9 << 3)
+#define LOG_LOCAL0 (16 << 3)
+#define LOG_LOCAL1 (17 << 3)
+#define LOG_LOCAL2 (18 << 3)
+#define LOG_LOCAL3 (19 << 3)
+#define LOG_LOCAL4 (20 << 3)
+#define LOG_LOCAL5 (21 << 3)
+#define LOG_LOCAL6 (22 << 3)
+#define LOG_LOCAL7 (23 << 3)
+
+// Priorities for syslog
+#define LOG_EMERG 0
+#define LOG_ALERT 1
+#define LOG_CRIT 2
+#define LOG_ERR 3
+#define LOG_WARNING 4
+#define LOG_NOTICE 5
+#define LOG_INFO 6
+#define LOG_DEBUG 7
+
+#endif // LLVM_LIBC_MACROS_SYSLOG_MACROS_H

--- a/libc/include/syslog.yaml
+++ b/libc/include/syslog.yaml
@@ -1,0 +1,68 @@
+header: syslog.h
+standards:
+  - posix
+macros:
+  - macro_name: LOG_PID
+    macro_header: syslog-macros.h
+  - macro_name: LOG_CONS
+    macro_header: syslog-macros.h
+  - macro_name: LOG_NDELAY
+    macro_header: syslog-macros.h
+  - macro_name: LOG_ODELAY
+    macro_header: syslog-macros.h
+  - macro_name: LOG_NOWAIT
+    macro_header: syslog-macros.h
+  - macro_name: LOG_KERN
+    macro_header: syslog-macros.h
+  - macro_name: LOG_USER
+    macro_header: syslog-macros.h
+  - macro_name: LOG_MAIL
+    macro_header: syslog-macros.h
+  - macro_name: LOG_NEWS
+    macro_header: syslog-macros.h
+  - macro_name: LOG_UUCP
+    macro_header: syslog-macros.h
+  - macro_name: LOG_DAEMON
+    macro_header: syslog-macros.h
+  - macro_name: LOG_AUTH
+    macro_header: syslog-macros.h
+  - macro_name: LOG_CRON
+    macro_header: syslog-macros.h
+  - macro_name: LOG_LPR
+    macro_header: syslog-macros.h
+  - macro_name: LOG_LOCAL0
+    macro_header: syslog-macros.h
+  - macro_name: LOG_LOCAL1
+    macro_header: syslog-macros.h
+  - macro_name: LOG_LOCAL2
+    macro_header: syslog-macros.h
+  - macro_name: LOG_LOCAL3
+    macro_header: syslog-macros.h
+  - macro_name: LOG_LOCAL4
+    macro_header: syslog-macros.h
+  - macro_name: LOG_LOCAL5
+    macro_header: syslog-macros.h
+  - macro_name: LOG_LOCAL6
+    macro_header: syslog-macros.h
+  - macro_name: LOG_LOCAL7
+    macro_header: syslog-macros.h
+  - macro_name: LOG_EMERG
+    macro_header: syslog-macros.h
+  - macro_name: LOG_ALERT
+    macro_header: syslog-macros.h
+  - macro_name: LOG_CRIT
+    macro_header: syslog-macros.h
+  - macro_name: LOG_ERR
+    macro_header: syslog-macros.h
+  - macro_name: LOG_WARNING
+    macro_header: syslog-macros.h
+  - macro_name: LOG_NOTICE
+    macro_header: syslog-macros.h
+  - macro_name: LOG_INFO
+    macro_header: syslog-macros.h
+  - macro_name: LOG_DEBUG
+    macro_header: syslog-macros.h
+types: []
+enums: []
+objects: []
+functions: []


### PR DESCRIPTION
Add the `<syslog.h>` public header. For now, just define the constants used for options/priority for `openlog` and for severity in `syslog` functions, but don't implement the functions yet (some client code uses these constants in a different, application-specific context, without relying on OS-level syslog facilities).

Since the values of all `LOG_` macros are identical across POSIX systems, we can define them in a shared llvm-libc-macros/syslog-macros.h file instead of using OS-specific ones.

Assisted by Gemini, human-reviewed.