### PR TITLE
[LLVMOffload] Fix unitialized variable in test from #212373

### DIFF
--- a/offload/test/offloading/CUDA/basic_launch_blocks_and_threads.cu
+++ b/offload/test/offloading/CUDA/basic_launch_blocks_and_threads.cu
@@ -14,17 +14,19 @@
 
 #include <stdio.h>
 
-__global__ void square(int *A) {
+__global__ void incrementCounter(int *A) {
   __scoped_atomic_fetch_add(A, 1, __ATOMIC_SEQ_CST, __MEMORY_SCOPE_DEVICE);
 }
 
 int main(int argc, char **argv) {
   int DevNo = 0;
   int *Ptr, I;
-  cudaMalloc(&Ptr, 4);
+  cudaMalloc(&Ptr, sizeof(int));
   printf("Ptr %p\n", Ptr);
   // CHECK: Ptr [[Ptr:0x.*]]
-  square<<<7, 6>>>(Ptr);
+  int Zero = 0;
+  cudaMemcpy(Ptr, &Zero, sizeof(int), cudaMemcpyHostToDevice);
+  incrementCounter<<<7, 6>>>(Ptr);
   cudaMemcpy(&I, Ptr, sizeof(int), cudaMemcpyDeviceToHost);
   printf("I: %i\n", I);
   // CHECK: I: 42

--- a/offload/test/offloading/HIP/basic_launch_blocks_and_threads.hip
+++ b/offload/test/offloading/HIP/basic_launch_blocks_and_threads.hip
@@ -14,17 +14,19 @@
 
 #include <stdio.h>
 
-__global__ void square(int *A) {
+__global__ void incrementCounter(int *A) {
   __scoped_atomic_fetch_add(A, 1, __ATOMIC_SEQ_CST, __MEMORY_SCOPE_DEVICE);
 }
 
 int main(int argc, char **argv) {
   int DevNo = 0;
   int *Ptr, I;
-  hipMalloc(&Ptr, 4);
+  hipMalloc(&Ptr, sizeof(int));
   printf("Ptr %p\n", Ptr);
   // CHECK: Ptr [[Ptr:0x.*]]
-  square<<<7, 6>>>(Ptr);
+  int Zero = 0;
+  hipMemcpy(Ptr, &Zero, sizeof(int), hipMemcpyHostToDevice);
+  incrementCounter<<<7, 6>>>(Ptr);
   hipMemcpy(&I, Ptr, sizeof(int), hipMemcpyDeviceToHost);
   printf("I: %i\n", I);
   // CHECK: I: 42


### PR DESCRIPTION
This test was flaky due to using an uninitialized variable, leading to buildbot failures. This PR initializes it to zero and renames the kernel to `incrementCounter` to match. 