### PR TITLE
MachinePipeliner: Fix using getUniqueVRegDef on a physical register

### DIFF
--- a/llvm/lib/CodeGen/MachinePipeliner.cpp
+++ b/llvm/lib/CodeGen/MachinePipeliner.cpp
@@ -1323,6 +1323,8 @@ void SwingSchedulerDAG::updatePhiDependences() {
         }
       } else if (MO.isUse()) {
         // If the register is defined by a Phi, then create a true dependence.
+        if (!Reg.isVirtual())
+          continue;
         MachineInstr *DefMI = MRI.getUniqueVRegDef(Reg);
         if (DefMI == nullptr)
           continue;

--- a/llvm/lib/CodeGen/MachinePipeliner.cpp
+++ b/llvm/lib/CodeGen/MachinePipeliner.cpp
@@ -1288,6 +1288,9 @@ void SwingSchedulerDAG::updatePhiDependences() {
       if (!MO.isReg())
         continue;
       Register Reg = MO.getReg();
+      if (!Reg.isVirtual())
+        continue;
+
       if (MO.isDef()) {
         // If the register is used by a Phi, then create an anti dependence.
         for (MachineRegisterInfo::use_instr_iterator
@@ -1323,8 +1326,6 @@ void SwingSchedulerDAG::updatePhiDependences() {
         }
       } else if (MO.isUse()) {
         // If the register is defined by a Phi, then create a true dependence.
-        if (!Reg.isVirtual())
-          continue;
         MachineInstr *DefMI = MRI.getUniqueVRegDef(Reg);
         if (DefMI == nullptr)
           continue;


### PR DESCRIPTION
Currently this is permissive and doesn't assert when called with
a physical register, but I'm working on changing this edge case.
No current observable change.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>