### PR TITLE
ModuloSchedule: Fix using getVRegDef/getUniqueVRegDef on physregs

### DIFF
--- a/llvm/lib/CodeGen/ModuloSchedule.cpp
+++ b/llvm/lib/CodeGen/ModuloSchedule.cpp
@@ -949,6 +949,8 @@ bool ModuloScheduleExpander::computeDelta(MachineInstr &MI, unsigned &Delta) {
     return false;
 
   Register BaseReg = BaseOp->getReg();
+  if (!BaseReg.isVirtual())
+    return false;
 
   MachineRegisterInfo &MRI = MF.getRegInfo();
   // Check if there is a Phi. If so, get the definition in the loop.
@@ -1722,7 +1724,7 @@ void PeelingModuloScheduleExpander::moveStageBetweenBlocks(
         continue;
       if (auto It = Remaps.find(MO.getReg()); It != Remaps.end())
         MO.setReg(It->second);
-      else {
+      else if (MO.getReg().isVirtual()) {
         // If we are using a phi from the source block we need to add a new phi
         // pointing to the old one.
         MachineInstr *Use = MRI.getUniqueVRegDef(MO.getReg());


### PR DESCRIPTION
These should be invalid to use on physical registers, but are currently
permissive. Avoid calling them so in the future they can assert.

Also this pass seems to run in SSA, so shouldn't really be using
getUniqueVRegDef.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>