### PR TITLE
[AMDGPU] Add user flag to set min/max number of AGPRs.

### DIFF
--- a/llvm/lib/Target/AMDGPU/GCNSubtarget.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSubtarget.cpp
@@ -675,8 +675,13 @@ GCNSubtarget::getMaxNumVectorRegs(const Function &F) const {
                                         /*OnlyFirstRequired=*/true);
 
     if (MinNumAGPRs == DefaultNumAGPR.first) {
-      // Default to splitting half the registers if AGPRs are required.
-      MinNumAGPRs = MaxNumAGPRs = MaxVectorRegs / 2;
+      if (getWavesPerEU(F).first >= 2) {
+        // At occupancy >= 2, do not use AGPRs.
+        MinNumAGPRs = MaxNumAGPRs = 0;
+      } else {
+        // Default to splitting half the registers if AGPRs are required.
+        MinNumAGPRs = MaxNumAGPRs = MaxVectorRegs / 2;
+      }
     } else {
       // Align to accum_offset's allocation granularity.
       MinNumAGPRs = alignTo(MinNumAGPRs, 4);


### PR DESCRIPTION
When occupancy is 2 or more, users might get AGPR used in generated code for mfmas. For certain user kernels, the cost of moving data to agprs is higher than the gains. This flag enables users to set the desired min and max of AGPRs that should be used in register allocation.

Assisted-By: Cursor (claude).