### PR TITLE
[flang][OpenACC] Fix crash on ATTACH/DETACH with an unresolved name

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -1774,6 +1774,11 @@ void AccAttributeVisitor::EnsureAllocatableOrPointer(
         common::visitors{
             [&](const parser::Designator &designator) {
               const auto &lastName{GetLastName(designator)};
+              if (!lastName.symbol) {
+                // Name resolution failed for this designator and has already
+                // emitted an error; there is nothing left to check.
+                return;
+              }
               if (!IsAllocatableOrObjectPointer(lastName.symbol)) {
                 context_.Say(designator.source,
                     "Argument `%s` on the %s clause must be a variable or "

--- a/flang/test/Semantics/OpenACC/acc-attach-unresolved.f90
+++ b/flang/test/Semantics/OpenACC/acc-attach-unresolved.f90
@@ -1,0 +1,17 @@
+! RUN: %python %S/../test_errors.py %s %flang -fopenacc
+
+! Check that an ATTACH/DETACH argument whose name could not be resolved is
+! diagnosed instead of crashing the compiler.
+
+subroutine test_attach_unresolved
+  type :: ty
+    integer :: i
+  end type ty
+  type(ty) :: x
+
+  !ERROR: Component 'bad' not found in derived type 'ty'
+  !$acc enter data attach(x%bad)
+
+  !ERROR: Component 'bad' not found in derived type 'ty'
+  !$acc exit data detach(x%bad)
+end subroutine test_attach_unresolved


### PR DESCRIPTION
`AccAttributeVisitor::EnsureAllocatableOrPointer()` passes the last name of the
designator to `IsAllocatableOrObjectPointer()`, which accepts a null `Symbol`
pointer and returns `false` for it. When the argument of an `ATTACH` or `DETACH`
clause fails name resolution -- for example a component reference whose derived
type could not be resolved -- that name's symbol is null, so control reaches the
error-reporting path, which then dereferences the same null symbol and crashes
the compiler.

Because the crash happens during name resolution, it precedes the point where
semantic diagnostics are emitted, so the compiler dies with no output at all
rather than reporting the errors that caused the name to be unresolved.

Reproducer:

```fortran
subroutine test_attach_unresolved
  type :: ty
    integer :: i
  end type ty
  type(ty) :: x
  !$acc enter data attach(x%bad)
end subroutine test_attach_unresolved
```

`flang -fsyntax-only -fopenacc` on the above segfaults. With this change it
reports the expected `Component 'bad' not found in derived type 'ty'`.

Fix: skip the check when the name is unresolved. Name resolution has already
reported an error for it, so there is nothing left to diagnose.

A regression test is added covering both `ATTACH` and `DETACH`.