### PR TITLE
AMDGPU: Capture G_PTR_ADD flags via m_MIFlags in getBaseWithConstantOffset

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUCombinerHelper.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCombinerHelper.cpp
@@ -428,14 +428,13 @@ void AMDGPUCombinerHelper::applyFoldFAbsFptrunc(MachineInstr &Fabs,
 // intermediate fptruncs in the apply function.
 static bool isFPExtFromF16OrConst(const MachineRegisterInfo &MRI,
                                   Register Reg) {
-  const MachineInstr *Def = MRI.getVRegDef(Reg);
-  if (Def->getOpcode() == TargetOpcode::G_FPEXT) {
-    Register SrcReg = Def->getOperand(1).getReg();
+  Register SrcReg;
+  if (mi_match(Reg, MRI, m_GFPExt(m_Reg(SrcReg))))
     return MRI.getType(SrcReg) == LLT::float16();
-  }
 
-  if (Def->getOpcode() == TargetOpcode::G_FCONSTANT) {
-    APFloat Val = Def->getOperand(1).getFPImm()->getValueAPF();
+  const ConstantFP *FPImm;
+  if (mi_match(Reg, MRI, m_GFCst(FPImm))) {
+    APFloat Val = FPImm->getValueAPF();
     bool LosesInfo = true;
     Val.convert(APFloat::IEEEhalf(), APFloat::rmNearestTiesToEven, &LosesInfo);
     return !LosesInfo;

--- a/llvm/lib/Target/AMDGPU/AMDGPUGlobalISelUtils.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUGlobalISelUtils.cpp
@@ -65,9 +65,11 @@ AMDGPU::getBaseWithConstantOffset(MachineRegisterInfo &MRI, Register Reg,
   if (Def->getOpcode() == TargetOpcode::G_PTRTOINT) {
     MachineInstr *Base;
     Register PtrAdd = Def->getOperand(1).getReg();
-    if (mi_match(PtrAdd, MRI, m_GPtrAdd(m_MInstr(Base), m_ICst(Offset)))) {
+    uint32_t Flags;
+    if (mi_match(PtrAdd, MRI,
+                 m_GPtrAdd(m_MInstr(Base), m_ICst(Offset), m_MIFlags(Flags)))) {
       // Same check as for G_ADD; nuw comes from getelementptr inbounds.
-      if (CheckNUW && !MRI.getVRegDef(PtrAdd)->getFlag(MachineInstr::NoUWrap)) {
+      if (CheckNUW && !(Flags & MachineInstr::NoUWrap)) {
         assert(MRI.getType(Reg).getScalarSizeInBits() == 32);
         return std::pair(Reg, 0);
       }

--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
@@ -2920,7 +2920,8 @@ static bool isExtractHiElt(MachineRegisterInfo &MRI, Register In,
   // use an extract hi instruction for the upper 16 bits. We only need to check
   // the size of `In` as all defs are guaranteed to be the same type for
   // GUnmerge.
-  if (auto *Unmerge = dyn_cast<GUnmerge>(MRI.getVRegDef(In))) {
+  GUnmerge *Unmerge;
+  if (mi_match(In, MRI, m_GUnmerge(Unmerge))) {
     if (Unmerge->getNumDefs() == 2 && Unmerge->getOperand(1).getReg() == In &&
         MRI.getType(In).getSizeInBits() == 16) {
       Out = Unmerge->getSourceReg();
@@ -5368,10 +5369,9 @@ std::pair<Register, unsigned> AMDGPUInstructionSelector::selectVOP3PModsImpl(
     return {Stat.first, Mods};
   }
 
-  MachineInstr *MI = MRI.getVRegDef(Stat.first);
-
-  if (MI->getOpcode() != AMDGPU::G_BUILD_VECTOR || MI->getNumOperands() != 3 ||
-      (IsDOT && Subtarget->hasDOTOpSelHazard())) {
+  GBuildVector *MI;
+  if (!mi_match(Stat.first, MRI, m_GBuildVector(MI)) ||
+      MI->getNumOperands() != 3 || (IsDOT && Subtarget->hasDOTOpSelHazard())) {
     Mods |= SISrcMods::OP_SEL_1;
     return {Stat.first, Mods};
   }
@@ -5589,7 +5589,8 @@ AMDGPUInstructionSelector::selectWMMAModsF32NegAbs(MachineOperand &Root) const {
   unsigned Mods = SISrcMods::OP_SEL_1;
   SmallVector<Register, 8> EltsF32;
 
-  if (GBuildVector *BV = dyn_cast<GBuildVector>(MRI->getVRegDef(Src))) {
+  GBuildVector *BV;
+  if (mi_match(Src, *MRI, m_GBuildVector(BV))) {
     assert(BV->getNumSources() > 0);
     // Based on first element decide which mod we match, neg or abs
     MachineInstr *ElF32 = MRI->getVRegDef(BV->getSourceReg(0));
@@ -5620,7 +5621,8 @@ AMDGPUInstructionSelector::selectWMMAModsF16Neg(MachineOperand &Root) const {
   unsigned Mods = SISrcMods::OP_SEL_1;
   SmallVector<Register, 8> EltsV2F16;
 
-  if (GConcatVectors *CV = dyn_cast<GConcatVectors>(MRI->getVRegDef(Src))) {
+  GConcatVectors *CV;
+  if (mi_match(Src, *MRI, m_GConcatVectors(CV))) {
     for (unsigned i = 0; i < CV->getNumSources(); ++i) {
       Register FNegSrc;
       if (!mi_match(CV->getSourceReg(i), *MRI, m_GFNeg(m_Reg(FNegSrc))))
@@ -5646,7 +5648,8 @@ AMDGPUInstructionSelector::selectWMMAModsF16NegAbs(MachineOperand &Root) const {
   unsigned Mods = SISrcMods::OP_SEL_1;
   SmallVector<Register, 8> EltsV2F16;
 
-  if (GConcatVectors *CV = dyn_cast<GConcatVectors>(MRI->getVRegDef(Src))) {
+  GConcatVectors *CV;
+  if (mi_match(Src, *MRI, m_GConcatVectors(CV))) {
     assert(CV->getNumSources() > 0);
     MachineInstr *ElV2F16 = MRI->getVRegDef(CV->getSourceReg(0));
     // Based on first element decide which mod we match, neg or abs

--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalize.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalize.cpp
@@ -274,9 +274,7 @@ bool AMDGPURegBankLegalizeCombiner::tryEliminateReadAnyLane(
     return false;
 
   Register RALDst = Src;
-  MachineInstr &SrcMI = *MRI.getVRegDef(Src);
-  if (SrcMI.getOpcode() == AMDGPU::G_BITCAST)
-    RALDst = SrcMI.getOperand(1).getReg();
+  bool IsBitcast = mi_match(Src, MRI, m_GBitcast(m_Reg(RALDst)));
 
   B.setInstrAndDebugLoc(Copy);
   SmallVector<Register> ReadAnyLaneSrcRegs = getReadAnyLaneSrcs(RALDst);
@@ -293,7 +291,7 @@ bool AMDGPURegBankLegalizeCombiner::tryEliminateReadAnyLane(
     ReadAnyLaneSrc = Merge.getReg(0);
   }
 
-  if (SrcMI.getOpcode() != AMDGPU::G_BITCAST) {
+  if (!IsBitcast) {
     // Src = READANYLANE RALSrc     Src = READANYLANE RALSrc
     // Dst = Copy Src               $Dst = Copy Src
     // ->                           ->


### PR DESCRIPTION
Read the nuw flag from the m_GPtrAdd match itself instead of a redundant
getVRegDef of the pointer register. NFC.

Co-authored-by: Claude (Opus 4.8) <noreply@anthropic.com>