### PR TITLE
[lldb][NativePDB] Build parent map on demand

### DIFF
--- a/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
@@ -437,7 +437,6 @@ void SymbolFileNativePDB::InitializeObject() {
   } else {
     if (auto ts = *ts_or_err)
       ts->SetSymbolFile(this);
-    BuildParentMap();
   }
 }
 
@@ -2293,6 +2292,8 @@ void SymbolFileNativePDB::FindTypes(const lldb_private::TypeQuery &query,
 
   std::lock_guard<std::recursive_mutex> guard(GetModuleMutex());
 
+  BuildParentMap();
+
   // We can't query for the full name because the type might reside
   // in an anonymous namespace. Search for the basename in our map and check the
   // matching types afterwards.
@@ -2829,6 +2830,10 @@ uint64_t SymbolFileNativePDB::GetDebugInfoSize(bool load_all_debug_info) {
 }
 
 void SymbolFileNativePDB::BuildParentMap() {
+  if (m_parent_map_built)
+    return;
+  m_parent_map_built = true;
+
   LazyRandomTypeCollection &types = m_index->tpi().typeCollection();
 
   llvm::DenseMap<TypeIndex, TypeIndex> forward_to_full;
@@ -3008,6 +3013,7 @@ SymbolFileNativePDB::FindSymbolScope(PdbCompilandSymId id) {
 
 std::optional<llvm::codeview::TypeIndex>
 SymbolFileNativePDB::GetParentType(llvm::codeview::TypeIndex ti) {
+  BuildParentMap();
   auto parent_iter = m_parent_types.find(ti);
   if (parent_iter == m_parent_types.end())
     return std::nullopt;

--- a/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.h
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.h
@@ -314,6 +314,8 @@ private:
   llvm::DenseMap<llvm::codeview::TypeIndex, llvm::codeview::TypeIndex>
       m_parent_types;
 
+  bool m_parent_map_built = false;
+
   struct UdtDeclaration {
     /// This could either be an index into the `/names` section (string table,
     /// LF_UDT_MOD_SRC_LINE) or, this could be an index into the IPI stream to a


### PR DESCRIPTION
Currently, the PDB plugin builds a map from nested structs to parents, because such a mapping is not available in the TPI stream. To do this, we're walking the entire TPI stream. If that stream is large, this can take time. We've been doing this in `InitializeObject`, so it immediately ran. Inside the same function, we're also scanning the basenames of types for `FindTypes`.

When the debugger starts, we usually don't need this information, as we don't create/query any types at that point. Thus, I made this lazy.

Running `build-rel/bin/lldb build-dbg/bin/lldb -o r -o q -- -o q` goes from 8.8s to 7.6s. The majority of time is still spent in `Symtab::InitNameIndexes` preloading symbols. We could try to parallelize that if we have some worker threads to spare. Which, in this case, we do.