### PR TITLE
[libc] Make bf16 arithmetic function family use the emulated float128 type

### DIFF
--- a/libc/config/baremetal/aarch64/entrypoints.txt
+++ b/libc/config/baremetal/aarch64/entrypoints.txt
@@ -363,6 +363,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.atan
     libc.src.math.atanf
     libc.src.math.atanhf
+    libc.src.math.bf16addf128
     libc.src.math.canonicalize
     libc.src.math.canonicalizef
     libc.src.math.canonicalizel
@@ -881,7 +882,6 @@ list(APPEND TARGET_LIBM_ENTRYPOINTS
 if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
   list(APPEND TARGET_LIBM_ENTRYPOINTS
     # math.h C++23 mixed bfloat16 and _Float128 entrypoints
-    libc.src.math.bf16addf128
     libc.src.math.bf16divf128
     libc.src.math.bf16fmaf128
     libc.src.math.bf16mulf128

--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -375,6 +375,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.atan
     libc.src.math.atanf
     libc.src.math.atanhf
+    libc.src.math.bf16addf128
     libc.src.math.canonicalize
     libc.src.math.canonicalizef
     libc.src.math.canonicalizel
@@ -892,7 +893,6 @@ list(APPEND TARGET_LIBM_ENTRYPOINTS
 if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
   list(APPEND TARGET_LIBM_ENTRYPOINTS
     # math.h C++23 mixed bfloat16 and _Float128 entrypoints
-    libc.src.math.bf16addf128
     libc.src.math.bf16divf128
     libc.src.math.bf16fmaf128
     libc.src.math.bf16mulf128

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -371,6 +371,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.atan
     libc.src.math.atanf
     libc.src.math.atanhf
+    libc.src.math.bf16addf128
     libc.src.math.canonicalize
     libc.src.math.canonicalizef
     libc.src.math.canonicalizel
@@ -889,7 +890,6 @@ list(APPEND TARGET_LIBM_ENTRYPOINTS
 if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
   list(APPEND TARGET_LIBM_ENTRYPOINTS
     # math.h C++23 mixed bfloat16 and _Float128 entrypoints
-    libc.src.math.bf16addf128
     libc.src.math.bf16divf128
     libc.src.math.bf16fmaf128
     libc.src.math.bf16mulf128

--- a/libc/config/darwin/aarch64/entrypoints.txt
+++ b/libc/config/darwin/aarch64/entrypoints.txt
@@ -182,6 +182,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.atan
     libc.src.math.atanf
     libc.src.math.atanhf
+    libc.src.math.bf16addf128
     libc.src.math.canonicalize
     libc.src.math.canonicalizef
     libc.src.math.canonicalizel
@@ -701,7 +702,6 @@ list(APPEND TARGET_LIBM_ENTRYPOINTS
 if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
   list(APPEND TARGET_LIBM_ENTRYPOINTS
     # math.h C++23 mixed bfloat16 and _Float128 entrypoints
-    libc.src.math.bf16addf128
     libc.src.math.bf16mulf128
     libc.src.math.bf16subf128
   )

--- a/libc/config/darwin/x86_64/entrypoints.txt
+++ b/libc/config/darwin/x86_64/entrypoints.txt
@@ -118,6 +118,7 @@ set(TARGET_LIBM_ENTRYPOINTS
 
     ## Currently disabled for failing tests.
     # math.h entrypoints
+    #libc.src.math.bf16addf128
     #libc.src.math.copysign
     #libc.src.math.copysignf
     #libc.src.math.copysignl

--- a/libc/config/freebsd/x86_64/entrypoints.txt
+++ b/libc/config/freebsd/x86_64/entrypoints.txt
@@ -127,6 +127,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.atan2f
     libc.src.math.atanf
     libc.src.math.atanhf
+    libc.src.math.bf16addf128
     libc.src.math.cbrt
     libc.src.math.cbrtf
     libc.src.math.copysign
@@ -638,7 +639,6 @@ list(APPEND TARGET_LIBM_ENTRYPOINTS
 
 if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
   list(APPEND TARGET_LIBM_ENTRYPOINTS
-    libc.src.math.bf16addf128
     libc.src.math.bf16divf128
     libc.src.math.bf16fmaf128
     libc.src.math.bf16mulf128

--- a/libc/config/gpu/amdgpu/entrypoints.txt
+++ b/libc/config/gpu/amdgpu/entrypoints.txt
@@ -314,6 +314,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.atan2l
     libc.src.math.atanf
     libc.src.math.atanhf
+    libc.src.math.bf16addf128
     libc.src.math.canonicalize
     libc.src.math.canonicalizef
     libc.src.math.canonicalizel

--- a/libc/config/gpu/nvptx/entrypoints.txt
+++ b/libc/config/gpu/nvptx/entrypoints.txt
@@ -310,6 +310,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.atan2l
     libc.src.math.atanf
     libc.src.math.atanhf
+    libc.src.math.bf16addf128
     libc.src.math.canonicalize
     libc.src.math.canonicalizef
     libc.src.math.canonicalizel

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -520,6 +520,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.atan
     libc.src.math.atanf
     libc.src.math.atanhf
+    libc.src.math.bf16addf128
     libc.src.math.canonicalize
     libc.src.math.canonicalizef
     libc.src.math.canonicalizel
@@ -1028,7 +1029,6 @@ list(APPEND TARGET_LIBM_ENTRYPOINTS
 if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
   list(APPEND TARGET_LIBM_ENTRYPOINTS
     # math.h C++23 mixed bfloat16 and _Float128 entrypoints
-    libc.src.math.bf16addf128
     libc.src.math.bf16divf128
     libc.src.math.bf16fmaf128
     libc.src.math.bf16mulf128

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -360,6 +360,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.atan
     libc.src.math.atanf
     libc.src.math.atanhf
+    libc.src.math.bf16addf128
     libc.src.math.cbrt
     libc.src.math.cbrtf
     libc.src.math.cbrtbf16

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -589,6 +589,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.atan
     libc.src.math.atanf
     libc.src.math.atanhf
+    libc.src.math.bf16addf128
     libc.src.math.canonicalize
     libc.src.math.canonicalizef
     libc.src.math.canonicalizel
@@ -1118,7 +1119,6 @@ list(APPEND TARGET_LIBM_ENTRYPOINTS
 if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
   list(APPEND TARGET_LIBM_ENTRYPOINTS
     # math.h C++23 mixed bfloat16 and _Float128 entrypoints
-    libc.src.math.bf16addf128
     libc.src.math.bf16divf128
     libc.src.math.bf16fmaf128
     libc.src.math.bf16mulf128

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -594,6 +594,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.atan
     libc.src.math.atanf
     libc.src.math.atanhf
+    libc.src.math.bf16addf128
     libc.src.math.canonicalize
     libc.src.math.canonicalizef
     libc.src.math.canonicalizel
@@ -1123,7 +1124,6 @@ list(APPEND TARGET_LIBM_ENTRYPOINTS
 if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
   list(APPEND TARGET_LIBM_ENTRYPOINTS
     # math.h C++23 mixed bfloat16 and _Float128 entrypoints
-    libc.src.math.bf16addf128
     libc.src.math.bf16divf128
     libc.src.math.bf16fmaf128
     libc.src.math.bf16mulf128

--- a/libc/config/windows/entrypoints.txt
+++ b/libc/config/windows/entrypoints.txt
@@ -158,6 +158,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.atan
     libc.src.math.atanf
     libc.src.math.atanhf
+    libc.src.math.bf16addf128
     libc.src.math.cbrt
     libc.src.math.cbrtf
     libc.src.math.cbrtbf16

--- a/libc/shared/math/bf16addf128.h
+++ b/libc/shared/math/bf16addf128.h
@@ -9,10 +9,6 @@
 #ifndef LLVM_LIBC_SHARED_MATH_BF16ADDF128_H
 #define LLVM_LIBC_SHARED_MATH_BF16ADDF128_H
 
-#include "include/llvm-libc-types/float128.h"
-
-#ifdef LIBC_TYPES_HAS_NATIVE_FLOAT128
-
 #include "shared/libc_common.h"
 #include "src/__support/math/bf16addf128.h"
 
@@ -23,7 +19,5 @@ using math::bf16addf128;
 
 } // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
-
-#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 #endif // LLVM_LIBC_SHARED_MATH_BF16ADDF128_H

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -509,6 +509,7 @@ add_header_library(
     bf16addf128.h
   DEPENDS
     libc.src.__support.FPUtil.bfloat16
+    libc.src.__support.FPUtil.float128
     libc.src.__support.FPUtil.generic.add_sub
     libc.src.__support.macros.config
 )

--- a/libc/src/__support/math/bf16addf128.h
+++ b/libc/src/__support/math/bf16addf128.h
@@ -13,7 +13,6 @@
 #include "src/__support/FPUtil/float128.h"
 #include "src/__support/FPUtil/generic/add_sub.h"
 #include "src/__support/macros/config.h"
-#include "src/__support/macros/properties/types.h"
 
 namespace LIBC_NAMESPACE_DECL {
 namespace math {

--- a/libc/src/__support/math/bf16addf128.h
+++ b/libc/src/__support/math/bf16addf128.h
@@ -9,24 +9,22 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_MATH_BF16ADDF128_H
 #define LLVM_LIBC_SRC___SUPPORT_MATH_BF16ADDF128_H
 
-#include "src/__support/macros/properties/types.h"
-
-#ifdef LIBC_TYPES_HAS_NATIVE_FLOAT128
-
 #include "src/__support/FPUtil/bfloat16.h"
+#include "src/__support/FPUtil/float128.h"
 #include "src/__support/FPUtil/generic/add_sub.h"
 #include "src/__support/macros/config.h"
+#include "src/__support/macros/properties/types.h"
 
 namespace LIBC_NAMESPACE_DECL {
 namespace math {
 
-LIBC_INLINE bfloat16 bf16addf128(float128 x, float128 y) {
+using LIBC_NAMESPACE::fputil::Float128;
+
+LIBC_INLINE bfloat16 bf16addf128(Float128 x, Float128 y) {
   return fputil::generic::add<bfloat16>(x, y);
 }
 
 } // namespace math
 } // namespace LIBC_NAMESPACE_DECL
-
-#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 #endif // LLVM_LIBC_SRC___SUPPORT_MATH_BF16ADDF128_H

--- a/libc/src/math/bf16addf128.h
+++ b/libc/src/math/bf16addf128.h
@@ -9,10 +9,15 @@
 #ifndef LLVM_LIBC_SRC_MATH_BF16ADDF128_H
 #define LLVM_LIBC_SRC_MATH_BF16ADDF128_H
 
+#include "src/__support/FPUtil/float128.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/types.h"
 
 namespace LIBC_NAMESPACE_DECL {
+
+#ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128
+using float128 = LIBC_NAMESPACE::fputil::Float128;
+#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 bfloat16 bf16addf128(float128 x, float128 y);
 

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -4870,6 +4870,7 @@ add_entrypoint_object(
   HDRS
     ../bf16addf128.h
   DEPENDS
+    libc.src.__support.CPP.bit
     libc.src.__support.math.bf16addf128
 )
 

--- a/libc/src/math/generic/bf16addf128.cpp
+++ b/libc/src/math/generic/bf16addf128.cpp
@@ -7,12 +7,16 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/math/bf16addf128.h"
+#include "src/__support/CPP/bit.h"
 #include "src/__support/math/bf16addf128.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
+using LIBC_NAMESPACE::fputil::Float128;
+
 LLVM_LIBC_FUNCTION(bfloat16, bf16addf128, (float128 x, float128 y)) {
-  return math::bf16addf128(x, y);
+  return math::bf16addf128(cpp::bit_cast<Float128>(x),
+                           cpp::bit_cast<Float128>(y));
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -582,6 +582,9 @@ TEST(LlvmLibcSharedMathTest, AllLongDouble) {
 // Emulated float128 tests
 TEST(LlvmLibcSharedMathTest, AllEmuFloat128) {
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::ceilf128(Float128(0.0)));
+
+  EXPECT_FP_EQ(bfloat16(5.0), LIBC_NAMESPACE::shared::bf16addf128(
+                                  Float128(2.0), Float128(3.0)));
 }
 
 #ifdef LIBC_TYPES_HAS_NATIVE_FLOAT128
@@ -611,9 +614,6 @@ TEST(LlvmLibcSharedMathTest, AllFloat128) {
   EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::dsqrtf128(float128(0.0)));
 
   EXPECT_EQ(0L, LIBC_NAMESPACE::shared::llogbf128(float128(1.0)));
-
-  EXPECT_FP_EQ(bfloat16(5.0), LIBC_NAMESPACE::shared::bf16addf128(
-                                  float128(2.0), float128(3.0)));
 
   float128 canonicalizef128_cx = float128(0.0);
   float128 canonicalizef128_x = float128(0.0);

--- a/libc/test/src/math/CMakeLists.txt
+++ b/libc/test/src/math/CMakeLists.txt
@@ -3430,6 +3430,7 @@ add_fp_unittest(
   HDRS
     AddTest.h
   DEPENDS
+    libc.src.__support.FPUtil.float128
     libc.src.math.bf16addf128
     libc.src.__support.FPUtil.bfloat16
 )

--- a/libc/test/src/math/bf16addf128_test.cpp
+++ b/libc/test/src/math/bf16addf128_test.cpp
@@ -7,8 +7,13 @@
 //===----------------------------------------------------------------------===//
 
 #include "AddTest.h"
+#include "src/__support/FPUtil/float128.h"
 
 #include "src/__support/FPUtil/bfloat16.h"
 #include "src/math/bf16addf128.h"
+
+#ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128
+using float128 = LIBC_NAMESPACE::fputil::Float128;
+#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 LIST_ADD_TESTS(bfloat16, float128, LIBC_NAMESPACE::bf16addf128)

--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -6506,6 +6506,7 @@ add_fp_unittest(
   DEPENDS
     libc.hdr.errno_macros
     libc.hdr.fenv_macros
+    libc.src.__support.FPUtil.float128
     libc.src.math.bf16addf128
     libc.src.__support.FPUtil.bfloat16
     libc.src.__support.macros.properties.os

--- a/libc/test/src/math/smoke/bf16addf128_test.cpp
+++ b/libc/test/src/math/smoke/bf16addf128_test.cpp
@@ -7,8 +7,13 @@
 //===----------------------------------------------------------------------===//
 
 #include "AddTest.h"
+#include "src/__support/FPUtil/float128.h"
 
 #include "src/__support/FPUtil/bfloat16.h"
 #include "src/math/bf16addf128.h"
+
+#ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128
+using float128 = LIBC_NAMESPACE::fputil::Float128;
+#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 LIST_ADD_TESTS(bfloat16, float128, LIBC_NAMESPACE::bf16addf128)


### PR DESCRIPTION
*  `bf16addf128`
*  `bf16subf128`
*  `bf16mulf128`
*  `bf16divf128`
*  `bf16fmaf128`