### PR TITLE
[asan][test] Fix invalid-pointer-pairs-vector-extract.cpp breakage after #210729

### DIFF
--- a/compiler-rt/test/asan/TestCases/invalid-pointer-pairs-vector-extract.cpp
+++ b/compiler-rt/test/asan/TestCases/invalid-pointer-pairs-vector-extract.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: asserts
-// RUN: %clangxx_asan -O2 %s -o %t -mllvm -asan-detect-invalid-pointer-pair
+// RUN: %clangxx_asan -O2 %s -o %t -mllvm -asan-detect-invalid-pointer-pair -fwrapv-pointer
 // RUN: %env_asan_opts=detect_invalid_pointer_pairs=1:halt_on_error=0 %run %t 2>&1 | FileCheck %s
 // RUN: %env_asan_opts=detect_invalid_pointer_pairs=2:halt_on_error=0 %run %t 2>&1 | FileCheck %s
 


### PR DESCRIPTION
compiler-rt/test/asan/TestCases/invalid-pointer-pairs-vector-extract.cpp (introduced in #216532) started failing (or rather, unexpectedly passing) after #210729 (e.g., https://lab.llvm.org/buildbot/#/builders/66/builds/35645, https://lab.llvm.org/buildbot/#/builders/51/builds/42365), because it changes the codegen for pointer subtraction if -fwrapv-pointer is not set.

This patch fixes the test case by adding -fwrapv-pointer.