### PR TITLE
[libc][realpath][test] Allow test directory to contain symlinks

### DIFF
--- a/libc/test/src/stdlib/CMakeLists.txt
+++ b/libc/test/src/stdlib/CMakeLists.txt
@@ -391,6 +391,7 @@ add_libc_test(
     libc.src.__support.CPP.string
     libc.src.__support.CPP.string_view
     libc.src.__support.CPP.utility
+    libc.src.__support.c_string
     libc.src.__support.fixedvector
     libc.src.__support.libc_assert
     libc.src.__support.libc_errno

--- a/libc/test/src/stdlib/realpath_test.cpp
+++ b/libc/test/src/stdlib/realpath_test.cpp
@@ -19,6 +19,7 @@
 #include "src/__support/CPP/string_view.h"
 #include "src/__support/CPP/utility.h"
 #include "src/__support/OSUtil/path.h"
+#include "src/__support/c_string.h"
 #include "src/__support/fixedvector.h"
 #include "src/__support/libc_assert.h"
 #include "src/__support/libc_errno.h"
@@ -39,6 +40,7 @@
 
 namespace cpp = LIBC_NAMESPACE::cpp;
 namespace path = LIBC_NAMESPACE::path;
+using LIBC_NAMESPACE::CString;
 using LIBC_NAMESPACE::FixedVector;
 using LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 using LIBC_NAMESPACE::testing::tlog;
@@ -220,9 +222,17 @@ public:
   // While we would prefer to return cpp::optional<TestDir> here,
   // LLVM-libc's optional expects types to be trivially destructible.
   [[nodiscard]] bool create_test_dir(const char *name, TestDir &dst) {
-    // Use /tmp instead of the typical libc_make_test_file_path to ensure
-    // the path is absolute and does not contain symlinks.
-    cpp::string test_dir_path = "/tmp/LlvmLibcRealpathTest.";
+    CString test_dir = libc_make_test_file_path(".");
+    char buf[PATH_MAX];
+    // Some test setups will have symlinks in their test directory.
+    // In order for tests to compute the an expected result, the path returned
+    // by create_test_dir needs to be canonical itself.
+    char *test_dir_abspath = LIBC_NAMESPACE::realpath(test_dir, buf);
+    if (libc_errno != 0)
+      return false;
+
+    cpp::string test_dir_path(test_dir_abspath);
+    test_dir_path += "/LlvmLibcRealpathTest.";
     test_dir_path += name;
     test_dir_path += ".";
 

--- a/libc/test/src/stdlib/realpath_test.cpp
+++ b/libc/test/src/stdlib/realpath_test.cpp
@@ -224,9 +224,9 @@ public:
   [[nodiscard]] bool create_test_dir(const char *name, TestDir &dst) {
     CString test_dir = libc_make_test_file_path(".");
     char buf[PATH_MAX];
-    // Some test setups will have symlinks in their test directory.
-    // In order for tests to compute the an expected result, the path returned
-    // by create_test_dir needs to be canonical itself.
+    // Some test environments will have symlinks in their test directory.
+    // In order for tests to compute an expected canonical path,
+    // the path returned by create_test_dir needs to be canonical itself.
     char *test_dir_abspath = LIBC_NAMESPACE::realpath(test_dir, buf);
     if (libc_errno != 0)
       return false;

--- a/utils/bazel/llvm-project-overlay/libc/test/src/stdlib/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/stdlib/BUILD.bazel
@@ -143,6 +143,7 @@ libc_test(
     name = "realpath_test",
     srcs = ["realpath_test.cpp"],
     deps = [
+        "//libc:__support_c_string",
         "//libc:__support_cpp_string",
         "//libc:__support_cpp_string_view",
         "//libc:__support_cpp_utility",


### PR DESCRIPTION
CI for https://github.com/llvm/llvm-project/pull/212925 failed because the `libc-riscv32-qemu-yocto-fullbuild-dbg` buildbot on Yocto uses a symlink for `/tmp` to `/var/volatile/tmp` ([source](https://github.com/openembedded/openembedded-core/blob/07a342aa80c7349dd014f743a695a5e006add8df/meta/recipes-core/initscripts/initscripts-1.0/volatiles#L32)). It's fair enough that a system may define `/tmp` as a symlink, so this PR updates the realpath tests to call `realpath` on the test directory to resolve symlinks.

This PR also updates the test to use `libc_make_test_file_path` instead of `/tmp`. Previously, the tests used `/tmp` because `libc_make_test_file_path` might have symlinks in it. Since we fully resolve symlinks now, we can use the more standard approach now.