### PR TITLE
[lldb] Fix use-after-free of a scripted frame's register info

### DIFF
--- a/lldb/source/Plugins/OperatingSystem/Python/OperatingSystemPython.cpp
+++ b/lldb/source/Plugins/OperatingSystem/Python/OperatingSystemPython.cpp
@@ -74,7 +74,7 @@ llvm::StringRef OperatingSystemPython::GetPluginDescriptionStatic() {
 
 OperatingSystemPython::OperatingSystemPython(lldb_private::Process *process,
                                              const FileSpec &python_module_path)
-    : OperatingSystem(process), m_thread_list_valobj_sp(), m_register_info_up(),
+    : OperatingSystem(process), m_thread_list_valobj_sp(),
       m_interpreter(nullptr), m_script_object_sp() {
   if (!process)
     return;
@@ -142,29 +142,29 @@ OperatingSystemPython::OperatingSystemPython(lldb_private::Process *process,
 
 OperatingSystemPython::~OperatingSystemPython() = default;
 
-DynamicRegisterInfo *OperatingSystemPython::GetDynamicRegisterInfo() {
-  if (m_register_info_up == nullptr) {
-    if (!m_interpreter || !m_operating_system_interface_sp)
-      return nullptr;
-    Log *log = GetLog(LLDBLog::OS);
+DynamicRegisterInfoSP OperatingSystemPython::GetDynamicRegisterInfo() {
+  if (!m_interpreter || !m_operating_system_interface_sp)
+    return nullptr;
 
-    LLDB_LOGF(log,
-              "OperatingSystemPython::GetDynamicRegisterInfo() fetching "
-              "thread register definitions from python for pid %" PRIu64,
-              m_process->GetID());
+  Log *log = GetLog(LLDBLog::OS);
 
-    StructuredData::DictionarySP dictionary =
-        m_operating_system_interface_sp->GetRegisterInfo();
-    if (!dictionary)
-      return nullptr;
+  LLDB_LOGF(log,
+            "OperatingSystemPython::GetDynamicRegisterInfo() fetching "
+            "thread register definitions from python for pid %" PRIu64,
+            m_process->GetID());
 
-    m_register_info_up = DynamicRegisterInfo::Create(
-        *dictionary, m_process->GetTarget().GetArchitecture());
-    assert(m_register_info_up);
-    assert(m_register_info_up->GetNumRegisters() > 0);
-    assert(m_register_info_up->GetNumRegisterSets() > 0);
-  }
-  return m_register_info_up.get();
+  StructuredData::DictionarySP dictionary =
+      m_operating_system_interface_sp->GetRegisterInfo();
+  if (!dictionary)
+    return nullptr;
+
+  DynamicRegisterInfoSP register_info_sp = DynamicRegisterInfo::Create(
+      *dictionary, m_process->GetTarget().GetArchitecture());
+  assert(register_info_sp);
+  assert(register_info_sp->GetNumRegisters() > 0);
+  assert(register_info_sp->GetNumRegisterSets() > 0);
+
+  return register_info_sp;
 }
 
 bool OperatingSystemPython::UpdateThreadList(ThreadList &old_thread_list,
@@ -312,7 +312,7 @@ OperatingSystemPython::CreateRegisterContextForThread(Thread *thread,
               ") creating memory register context",
               thread->GetID(), thread->GetProtocolID(), reg_data_addr);
     reg_ctx_sp = std::make_shared<RegisterContextMemory>(
-        *thread, 0, *GetDynamicRegisterInfo(), reg_data_addr);
+        *thread, 0, GetDynamicRegisterInfo(), reg_data_addr);
   } else {
     // No register data address is provided, query the python plug-in to let it
     // make up the data as it sees fit
@@ -330,7 +330,7 @@ OperatingSystemPython::CreateRegisterContextForThread(Thread *thread,
       DataBufferSP data_sp(new DataBufferHeap(value.c_str(), value.length()));
       if (data_sp->GetByteSize()) {
         RegisterContextMemory *reg_ctx_memory = new RegisterContextMemory(
-            *thread, 0, *GetDynamicRegisterInfo(), LLDB_INVALID_ADDRESS);
+            *thread, 0, GetDynamicRegisterInfo(), LLDB_INVALID_ADDRESS);
         if (reg_ctx_memory) {
           reg_ctx_sp.reset(reg_ctx_memory);
           reg_ctx_memory->SetAllRegisterData(data_sp);

--- a/lldb/source/Plugins/OperatingSystem/Python/OperatingSystemPython.h
+++ b/lldb/source/Plugins/OperatingSystem/Python/OperatingSystemPython.h
@@ -73,10 +73,9 @@ protected:
       lldb_private::ThreadList &old_thread_list,
       std::vector<bool> &core_used_map, bool *did_create_ptr);
 
-  lldb_private::DynamicRegisterInfo *GetDynamicRegisterInfo();
+  lldb::DynamicRegisterInfoSP GetDynamicRegisterInfo();
 
   lldb::ValueObjectSP m_thread_list_valobj_sp;
-  std::unique_ptr<lldb_private::DynamicRegisterInfo> m_register_info_up;
   lldb_private::ScriptInterpreter *m_interpreter = nullptr;
   lldb::OperatingSystemInterfaceSP m_operating_system_interface_sp = nullptr;
   lldb_private::StructuredData::GenericSP m_script_object_sp = nullptr;

--- a/lldb/source/Plugins/Process/Utility/RegisterContextMemory.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterContextMemory.cpp
@@ -20,20 +20,21 @@ using namespace lldb_private;
 // RegisterContextMemory constructor
 RegisterContextMemory::RegisterContextMemory(Thread &thread,
                                              uint32_t concrete_frame_idx,
-                                             DynamicRegisterInfo &reg_infos,
+                                             DynamicRegisterInfoSP reg_infos_sp,
                                              addr_t reg_data_addr)
-    : RegisterContext(thread, concrete_frame_idx), m_reg_infos(reg_infos),
-      m_reg_valid(), m_reg_data(), m_reg_data_addr(reg_data_addr) {
+    : RegisterContext(thread, concrete_frame_idx),
+      m_reg_infos_sp(std::move(reg_infos_sp)), m_reg_valid(), m_reg_data(),
+      m_reg_data_addr(reg_data_addr) {
   // Resize our vector of bools to contain one bool for every register. We will
   // use these boolean values to know when a register value is valid in
   // m_reg_data.
-  const size_t num_regs = reg_infos.GetNumRegisters();
+  const size_t num_regs = m_reg_infos_sp->GetNumRegisters();
   assert(num_regs > 0);
   m_reg_valid.resize(num_regs);
 
   // Make a heap based buffer that is big enough to store all registers
-  m_data =
-      std::make_shared<DataBufferHeap>(reg_infos.GetRegisterDataByteSize(), 0);
+  m_data = std::make_shared<DataBufferHeap>(
+      m_reg_infos_sp->GetRegisterDataByteSize(), 0);
   m_reg_data.SetData(m_data);
 }
 
@@ -52,24 +53,24 @@ void RegisterContextMemory::SetAllRegisterValid(bool b) {
 }
 
 size_t RegisterContextMemory::GetRegisterCount() {
-  return m_reg_infos.GetNumRegisters();
+  return m_reg_infos_sp->GetNumRegisters();
 }
 
 const RegisterInfo *RegisterContextMemory::GetRegisterInfoAtIndex(size_t reg) {
-  return m_reg_infos.GetRegisterInfoAtIndex(reg);
+  return m_reg_infos_sp->GetRegisterInfoAtIndex(reg);
 }
 
 size_t RegisterContextMemory::GetRegisterSetCount() {
-  return m_reg_infos.GetNumRegisterSets();
+  return m_reg_infos_sp->GetNumRegisterSets();
 }
 
 const RegisterSet *RegisterContextMemory::GetRegisterSet(size_t reg_set) {
-  return m_reg_infos.GetRegisterSet(reg_set);
+  return m_reg_infos_sp->GetRegisterSet(reg_set);
 }
 
 uint32_t RegisterContextMemory::ConvertRegisterKindToRegisterNumber(
     lldb::RegisterKind kind, uint32_t num) {
-  return m_reg_infos.ConvertRegisterKindToRegisterNumber(kind, num);
+  return m_reg_infos_sp->ConvertRegisterKindToRegisterNumber(kind, num);
 }
 
 bool RegisterContextMemory::ReadRegister(const RegisterInfo *reg_info,

--- a/lldb/source/Plugins/Process/Utility/RegisterContextMemory.h
+++ b/lldb/source/Plugins/Process/Utility/RegisterContextMemory.h
@@ -20,7 +20,7 @@ class RegisterContextMemory : public lldb_private::RegisterContext {
 public:
   RegisterContextMemory(lldb_private::Thread &thread,
                         uint32_t concrete_frame_idx,
-                        lldb_private::DynamicRegisterInfo &reg_info,
+                        lldb::DynamicRegisterInfoSP reg_info_sp,
                         lldb::addr_t reg_data_addr);
 
   ~RegisterContextMemory() override;
@@ -59,7 +59,7 @@ public:
 protected:
   void SetAllRegisterValid(bool b);
 
-  lldb_private::DynamicRegisterInfo &m_reg_infos;
+  lldb::DynamicRegisterInfoSP m_reg_infos_sp;
   std::vector<bool> m_reg_valid;
   lldb::WritableDataBufferSP m_data;
   lldb_private::DataExtractor m_reg_data;

--- a/lldb/source/Plugins/Process/scripted/ScriptedFrame.cpp
+++ b/lldb/source/Plugins/Process/scripted/ScriptedFrame.cpp
@@ -116,16 +116,8 @@ ScriptedFrame::Create(ThreadSP thread_sp,
   if (maybe_sym_ctx)
     sc = *maybe_sym_ctx;
 
-  lldb::RegisterContextSP reg_ctx_sp;
-  auto regs_or_err =
-      CreateRegisterContext(*scripted_frame_interface, *thread_sp, frame_id);
-  if (!regs_or_err)
-    LLDB_LOG_ERROR(GetLog(LLDBLog::Thread), regs_or_err.takeError(), "{0}");
-  else
-    reg_ctx_sp = *regs_or_err;
-
   return std::make_shared<ScriptedFrame>(thread_sp, scripted_frame_interface,
-                                         frame_id, pc, sc, reg_ctx_sp,
+                                         frame_id, pc, sc,
                                          owned_script_object_sp);
 }
 
@@ -133,16 +125,29 @@ ScriptedFrame::ScriptedFrame(ThreadSP thread_sp,
                              ScriptedFrameInterfaceSP interface_sp,
                              lldb::user_id_t id, lldb::addr_t pc,
                              SymbolContext &sym_ctx,
-                             lldb::RegisterContextSP reg_ctx_sp,
                              StructuredData::GenericSP script_object_sp)
     : StackFrame(thread_sp, /*frame_idx=*/id,
-                 /*concrete_frame_idx=*/id, /*reg_context_sp=*/reg_ctx_sp,
+                 /*concrete_frame_idx=*/id, /*reg_context_sp=*/nullptr,
                  /*cfa=*/0, /*pc=*/pc,
                  /*behaves_like_zeroth_frame=*/!id, /*symbol_ctx=*/&sym_ctx),
       m_scripted_frame_interface_sp(interface_sp),
       m_script_object_sp(script_object_sp) {
   // FIXME: This should be part of the base class constructor.
   m_stack_frame_kind = StackFrame::Kind::Synthetic;
+
+  llvm::Expected<lldb::RegisterContextSP> reg_ctx_or_err =
+      CreateRegisterContext();
+  if (!reg_ctx_or_err) {
+    std::optional<lldb::user_id_t> debugger_id;
+    if (ProcessSP process_sp = thread_sp->GetProcess())
+      debugger_id = process_sp->GetTarget().GetDebugger().GetID();
+    Debugger::ReportError("failed to create scripted frame register context: " +
+                              llvm::toString(reg_ctx_or_err.takeError()),
+                          debugger_id);
+    return;
+  }
+
+  m_reg_context_sp = *reg_ctx_or_err;
 }
 
 ScriptedFrame::~ScriptedFrame() {}
@@ -176,57 +181,45 @@ lldb::ScriptedFrameInterfaceSP ScriptedFrame::GetInterface() const {
   return m_scripted_frame_interface_sp;
 }
 
-std::shared_ptr<DynamicRegisterInfo> ScriptedFrame::GetDynamicRegisterInfo() {
+llvm::Expected<DynamicRegisterInfoSP> ScriptedFrame::GetDynamicRegisterInfo() {
   CheckInterpreterAndScriptObject();
 
   StructuredData::DictionarySP reg_info = GetInterface()->GetRegisterInfo();
-
-  Status error;
-  if (!reg_info)
-    return ScriptedInterface::ErrorWithMessage<
-        std::shared_ptr<DynamicRegisterInfo>>(
-        LLVM_PRETTY_FUNCTION, "failed to get scripted frame registers info",
-        error, LLDBLog::Thread);
-
-  ThreadSP thread_sp = m_thread_wp.lock();
-  if (!thread_sp || !thread_sp->IsValid())
-    return ScriptedInterface::ErrorWithMessage<
-        std::shared_ptr<DynamicRegisterInfo>>(
-        LLVM_PRETTY_FUNCTION,
-        "failed to get scripted frame registers info: invalid thread", error,
-        LLDBLog::Thread);
-
-  ProcessSP process_sp = thread_sp->GetProcess();
-  if (!process_sp || !process_sp->IsValid())
-    return ScriptedInterface::ErrorWithMessage<
-        std::shared_ptr<DynamicRegisterInfo>>(
-        LLVM_PRETTY_FUNCTION,
-        "failed to get scripted frame registers info: invalid process", error,
-        LLDBLog::Thread);
-
-  return DynamicRegisterInfo::Create(*reg_info,
-                                     process_sp->GetTarget().GetArchitecture());
-}
-
-llvm::Expected<lldb::RegisterContextSP>
-ScriptedFrame::CreateRegisterContext(ScriptedFrameInterface &interface,
-                                     Thread &thread, lldb::user_id_t frame_id) {
-  StructuredData::DictionarySP reg_info = interface.GetRegisterInfo();
-
   if (!reg_info)
     return llvm::createStringError(
         "failed to get scripted frame registers info");
 
-  std::shared_ptr<DynamicRegisterInfo> register_info_sp =
-      DynamicRegisterInfo::Create(
-          *reg_info, thread.GetProcess()->GetTarget().GetArchitecture());
+  ThreadSP thread_sp = m_thread_wp.lock();
+  if (!thread_sp || !thread_sp->IsValid())
+    return llvm::createStringError("invalid thread");
 
-  lldb::RegisterContextSP reg_ctx_sp;
+  ProcessSP process_sp = thread_sp->GetProcess();
+  if (!process_sp || !process_sp->IsValid())
+    return llvm::createStringError("invalid process");
 
-  std::optional<std::string> reg_data = interface.GetRegisterContext();
-  if (!reg_data)
+  DynamicRegisterInfoSP register_info_sp = DynamicRegisterInfo::Create(
+      *reg_info, process_sp->GetTarget().GetArchitecture());
+  if (!register_info_sp)
     return llvm::createStringError(
-        "failed to get scripted frame registers data");
+        "failed to create scripted frame registers info");
+
+  return register_info_sp;
+}
+
+llvm::Expected<lldb::RegisterContextSP> ScriptedFrame::CreateRegisterContext() {
+  if (!m_scripted_frame_interface_sp)
+    return llvm::createStringError("invalid scripted frame interface");
+
+  ThreadSP thread_sp = GetThread();
+  if (!thread_sp)
+    return llvm::createStringError("invalid thread");
+
+  // A frame that reports no register data has no register context. That is a
+  // valid state, not a failure: only frames that expose registers implement it.
+  std::optional<std::string> reg_data =
+      m_scripted_frame_interface_sp->GetRegisterContext();
+  if (!reg_data)
+    return lldb::RegisterContextSP();
 
   DataBufferSP data_sp(
       std::make_shared<DataBufferHeap>(reg_data->c_str(), reg_data->size()));
@@ -234,45 +227,22 @@ ScriptedFrame::CreateRegisterContext(ScriptedFrameInterface &interface,
   if (!data_sp->GetByteSize())
     return llvm::createStringError("failed to copy raw registers data");
 
+  llvm::Expected<DynamicRegisterInfoSP> register_info_or_err =
+      GetDynamicRegisterInfo();
+  if (!register_info_or_err)
+    return register_info_or_err.takeError();
+
   std::shared_ptr<RegisterContextMemory> reg_ctx_memory =
-      std::make_shared<RegisterContextMemory>(
-          thread, frame_id, *register_info_sp, LLDB_INVALID_ADDRESS);
+      std::make_shared<RegisterContextMemory>(*thread_sp, GetFrameIndex(),
+                                              std::move(*register_info_or_err),
+                                              LLDB_INVALID_ADDRESS);
 
   reg_ctx_memory->SetAllRegisterData(data_sp);
-  reg_ctx_sp = reg_ctx_memory;
 
-  return reg_ctx_sp;
+  return reg_ctx_memory;
 }
 
 lldb::RegisterContextSP ScriptedFrame::GetRegisterContext() {
-  if (!m_reg_context_sp) {
-    Status error;
-    if (!m_scripted_frame_interface_sp)
-      return ScriptedInterface::ErrorWithMessage<RegisterContextSP>(
-          LLVM_PRETTY_FUNCTION,
-          "failed to get scripted frame registers context: invalid interface",
-          error, LLDBLog::Thread);
-
-    ThreadSP thread_sp = GetThread();
-    if (!thread_sp)
-      return ScriptedInterface::ErrorWithMessage<RegisterContextSP>(
-          LLVM_PRETTY_FUNCTION,
-          "failed to get scripted frame registers context: invalid thread",
-          error, LLDBLog::Thread);
-
-    auto regs_or_err = CreateRegisterContext(*m_scripted_frame_interface_sp,
-                                             *thread_sp, GetFrameIndex());
-    if (!regs_or_err) {
-      error = Status::FromError(regs_or_err.takeError());
-      return ScriptedInterface::ErrorWithMessage<RegisterContextSP>(
-          LLVM_PRETTY_FUNCTION,
-          "failed to get scripted frame registers context", error,
-          LLDBLog::Thread);
-    }
-
-    m_reg_context_sp = *regs_or_err;
-  }
-
   return m_reg_context_sp;
 }
 

--- a/lldb/source/Plugins/Process/scripted/ScriptedFrame.h
+++ b/lldb/source/Plugins/Process/scripted/ScriptedFrame.h
@@ -25,7 +25,7 @@ public:
   ScriptedFrame(lldb::ThreadSP thread_sp,
                 lldb::ScriptedFrameInterfaceSP interface_sp,
                 lldb::user_id_t frame_idx, lldb::addr_t pc,
-                SymbolContext &sym_ctx, lldb::RegisterContextSP reg_ctx_sp,
+                SymbolContext &sym_ctx,
                 StructuredData::GenericSP script_object_sp = nullptr);
 
   ~ScriptedFrame() override;
@@ -90,9 +90,7 @@ public:
 private:
   void CheckInterpreterAndScriptObject() const;
   lldb::ScriptedFrameInterfaceSP GetInterface() const;
-  static llvm::Expected<lldb::RegisterContextSP>
-  CreateRegisterContext(ScriptedFrameInterface &interface, Thread &thread,
-                        lldb::user_id_t frame_id);
+  llvm::Expected<lldb::RegisterContextSP> CreateRegisterContext();
 
   // Populate m_variable_list_sp from the scripted frame interface. The boolean
   // controls if we should try to fabricate Variable objects for each of the
@@ -104,7 +102,7 @@ private:
   ScriptedFrame(const ScriptedFrame &) = delete;
   const ScriptedFrame &operator=(const ScriptedFrame &) = delete;
 
-  std::shared_ptr<DynamicRegisterInfo> GetDynamicRegisterInfo();
+  llvm::Expected<lldb::DynamicRegisterInfoSP> GetDynamicRegisterInfo();
 
   lldb::ScriptedFrameInterfaceSP m_scripted_frame_interface_sp;
   lldb_private::StructuredData::GenericSP m_script_object_sp;

--- a/lldb/source/Plugins/Process/scripted/ScriptedThread.cpp
+++ b/lldb/source/Plugins/Process/scripted/ScriptedThread.cpp
@@ -146,9 +146,16 @@ ScriptedThread::CreateRegisterContextForFrame(StackFrame *frame) {
         LLVM_PRETTY_FUNCTION, "Failed to copy raw registers data.", error,
         LLDBLog::Thread);
 
+  DynamicRegisterInfoSP register_info_sp = GetDynamicRegisterInfo();
+  if (!register_info_sp)
+    return ScriptedInterface::ErrorWithMessage<lldb::RegisterContextSP>(
+        LLVM_PRETTY_FUNCTION,
+        "Failed to create scripted thread registers info.", error,
+        LLDBLog::Thread);
+
   std::shared_ptr<RegisterContextMemory> reg_ctx_memory =
       std::make_shared<RegisterContextMemory>(
-          *this, 0, *GetDynamicRegisterInfo(), LLDB_INVALID_ADDRESS);
+          *this, 0, std::move(register_info_sp), LLDB_INVALID_ADDRESS);
   if (!reg_ctx_memory)
     return ScriptedInterface::ErrorWithMessage<lldb::RegisterContextSP>(
         LLVM_PRETTY_FUNCTION, "Failed to create a register context.", error,
@@ -435,24 +442,19 @@ lldb::ScriptedThreadInterfaceSP ScriptedThread::GetInterface() const {
   return m_scripted_thread_interface_sp;
 }
 
-std::shared_ptr<DynamicRegisterInfo> ScriptedThread::GetDynamicRegisterInfo() {
+DynamicRegisterInfoSP ScriptedThread::GetDynamicRegisterInfo() {
   CheckInterpreterAndScriptObject();
 
-  if (!m_register_info_sp) {
-    StructuredData::DictionarySP reg_info = GetInterface()->GetRegisterInfo();
+  StructuredData::DictionarySP reg_info = GetInterface()->GetRegisterInfo();
 
-    Status error;
-    if (!reg_info)
-      return ScriptedInterface::ErrorWithMessage<
-          std::shared_ptr<DynamicRegisterInfo>>(
-          LLVM_PRETTY_FUNCTION, "Failed to get scripted thread registers info.",
-          error, LLDBLog::Thread);
+  Status error;
+  if (!reg_info)
+    return ScriptedInterface::ErrorWithMessage<DynamicRegisterInfoSP>(
+        LLVM_PRETTY_FUNCTION, "Failed to get scripted thread registers info.",
+        error, LLDBLog::Thread);
 
-    m_register_info_sp = DynamicRegisterInfo::Create(
-        *reg_info, m_scripted_process.GetTarget().GetArchitecture());
-  }
-
-  return m_register_info_sp;
+  return DynamicRegisterInfo::Create(
+      *reg_info, m_scripted_process.GetTarget().GetArchitecture());
 }
 
 StructuredData::ObjectSP ScriptedThread::FetchThreadExtendedInfo() {

--- a/lldb/source/Plugins/Process/scripted/ScriptedThread.h
+++ b/lldb/source/Plugins/Process/scripted/ScriptedThread.h
@@ -70,12 +70,11 @@ private:
   ScriptedThread(const ScriptedThread &) = delete;
   const ScriptedThread &operator=(const ScriptedThread &) = delete;
 
-  std::shared_ptr<DynamicRegisterInfo> GetDynamicRegisterInfo();
+  lldb::DynamicRegisterInfoSP GetDynamicRegisterInfo();
 
   const ScriptedProcess &m_scripted_process;
   lldb::ScriptedThreadInterfaceSP m_scripted_thread_interface_sp = nullptr;
   lldb_private::StructuredData::GenericSP m_script_object_sp = nullptr;
-  std::shared_ptr<DynamicRegisterInfo> m_register_info_sp = nullptr;
 };
 
 } // namespace lldb_private

--- a/lldb/test/API/functionalities/scripted_frame_provider/wrapped_frame_register_context/Makefile
+++ b/lldb/test/API/functionalities/scripted_frame_provider/wrapped_frame_register_context/Makefile
@@ -1,0 +1,4 @@
+C_SOURCES := main.c
+CFLAGS_EXTRAS := -std=c99
+
+include Makefile.rules

--- a/lldb/test/API/functionalities/scripted_frame_provider/wrapped_frame_register_context/TestFrameProviderWrappedFrameRegisterContext.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/wrapped_frame_register_context/TestFrameProviderWrappedFrameRegisterContext.py
@@ -1,0 +1,35 @@
+"""
+Test that a scripted frame reporting a register context can format its frame
+without crashing.
+"""
+
+import os
+
+import lldb
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.lldbtest import *
+
+
+class TestFrameProviderWrappedFrameRegisterContext(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def test_backtrace_with_forwarded_register_context(self):
+        self.build()
+        target, process, _, _ = lldbutil.run_to_source_breakpoint(
+            self, "Break here", lldb.SBFileSpec("main.c")
+        )
+
+        self.runCmd(
+            "command script import "
+            + os.path.join(self.getSourceDir(), "frame_provider.py")
+        )
+        error = lldb.SBError()
+        target.RegisterScriptedFrameProvider(
+            "frame_provider.WrapVariablesProvider", lldb.SBStructuredData(), error
+        )
+        self.assertSuccess(error, "Failed to register the frame provider")
+
+        # Formatting the arguments evaluates their DWARF location expressions,
+        # which reads registers through the scripted frame's register context.
+        # Checking the values, not just for a crash, proves the lookup worked.
+        self.expect("bt", substrs=["compute(a=3, b=4)", "main"])

--- a/lldb/test/API/functionalities/scripted_frame_provider/wrapped_frame_register_context/frame_provider.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/wrapped_frame_register_context/frame_provider.py
@@ -1,0 +1,83 @@
+"""
+Frame provider whose scripted frame replaces a native frame and forwards that
+frame's registers through get_register_context.
+
+Reporting a register context is what makes LLDB evaluate the frame's DWARF
+location expressions when it formats variables.
+"""
+
+import struct
+
+import lldb
+from lldb.plugins.scripted_frame_provider import ScriptedFrameProvider
+from lldb.plugins.scripted_process import ScriptedFrame
+
+WRAPPED_FUNCTION = "compute"
+
+
+class WrappedFrame(ScriptedFrame):
+    def __init__(self, thread, frame, idx):
+        super().__init__(thread, lldb.SBStructuredData())
+        self._frame = frame
+        self._idx = idx
+
+    def get_id(self):
+        return self._idx
+
+    def get_pc(self):
+        return self._frame.GetPC()
+
+    def get_symbol_context(self):
+        return self._frame.GetSymbolContext(lldb.eSymbolContextEverything)
+
+    def get_function_name(self):
+        return self._frame.GetFunctionName() or "<wrapped>"
+
+    def is_artificial(self):
+        return False
+
+    def is_hidden(self):
+        return False
+
+    def get_register_context(self):
+        """Forward the wrapped frame's GPRs, packed in register_info order."""
+        regs = {}
+        for reg_set in self._frame.registers:
+            if "general purpose" in reg_set.name.lower():
+                for reg in reg_set:
+                    regs[reg.name] = int(reg.value, 16) if reg.value else 0
+                break
+        if not regs:
+            return None
+
+        info = self.get_register_info()["registers"]
+
+        def read(entry):
+            # A register set reports a register under the name LLDB displays,
+            # which can be an alias of the architectural name the register info
+            # uses. The register info carries that alias in "alt-name".
+            if entry["name"] in regs:
+                return regs[entry["name"]]
+            return regs.get(entry.get("alt-name", ""), 0)
+
+        return struct.pack(f"{len(info)}Q", *(read(r) for r in info))
+
+
+class WrapVariablesProvider(ScriptedFrameProvider):
+    @staticmethod
+    def get_description():
+        return f"Wrap the {WRAPPED_FUNCTION!r} frame and forward its registers"
+
+    def get_frame_at_index(self, index):
+        if index >= self.input_frames.GetSize():
+            return None
+
+        frame = self.input_frames.GetFrameAtIndex(index)
+        if not frame.IsValid():
+            return None
+
+        if frame.GetFunctionName() == WRAPPED_FUNCTION:
+            return WrappedFrame(self.thread, frame, index)
+
+        # Returning an int reuses the input frame at that index unchanged.
+        return index

--- a/lldb/test/API/functionalities/scripted_frame_provider/wrapped_frame_register_context/main.c
+++ b/lldb/test/API/functionalities/scripted_frame_provider/wrapped_frame_register_context/main.c
@@ -1,0 +1,6 @@
+int compute(int a, int b) {
+  int sum = a + b;
+  return sum; // Break here.
+}
+
+int main(void) { return compute(3, 4) == 7 ? 0 : 1; }


### PR DESCRIPTION
`ScriptedFrame::CreateRegisterContext` built the frame's `DynamicRegisterInfo` in a local `shared_ptr` and passed it to `RegisterContextMemory`, which kept a `DynamicRegisterInfo` reference and did not own it. That function was the sole owner, so the register info died as soon as it returned, leaving the register context it had just produced with a dangling reference.

The frame survives creation because `SetAllRegisterData` runs while the register info is still alive. It crashes later, on the first register lookup driven by a DWARF location expression, for instance when a backtrace formats the frame's arguments.

This patch makes `RegisterContextMemory` own its register info: it takes a `shared_ptr` and keeps it for its own lifetime, so a register context is self-contained and nothing else has to stay alive on its behalf. `ScriptedThread` and `OperatingSystemPython` both kept the register info in a member to back the reference they handed out, so both members are gone.

Previously, `CreateRegisterContext` was static and ran before the frame was created. Now the constructor calls it and stores the result, and `GetRegisterContext` just hands that back.

This patch also improves error reporting: the register context creation propagates llvm::Error instead of logging at each step and returning null. `GetDynamicRegisterInfo` and `CreateRegisterContext` both return `Expected`, and the constructor reports what actually went wrong with `Debugger::ReportError` rather than leaving it buried in the thread log.