### PR TITLE
[NFC][MemProf] Replace memprofraw with YAML in memprofmissingfunc.ll test

### DIFF
--- a/llvm/test/Transforms/PGOProfile/memprofmissingfunc.ll
+++ b/llvm/test/Transforms/PGOProfile/memprofmissingfunc.ll
@@ -1,20 +1,14 @@
 ;; Tests that we get a missing memprof error for a function not in profile when
 ;; using -pgo-warn-missing-function.
 
-;; Avoid failures on big-endian systems that can't read the raw profile properly
-; REQUIRES: x86_64-linux
+; RUN: rm -rf %t && split-file %s %t
 
-;; TODO: Use text profile inputs once that is available for memprof.
-
-;; The raw profiles have been generated from the source used for the memprof.ll
-;; test (see comments at the top of that file).
-
-; RUN: llvm-profdata merge %S/Inputs/memprof.memprofraw --profiled-binary %S/Inputs/memprof.exe -o %t.memprofdata
-
-; RUN: opt < %s -passes='memprof-use<profile-filename=%t.memprofdata>' -pgo-warn-missing-function -S 2>&1 | FileCheck %s
+; RUN: llvm-profdata merge %t/a.yaml -o %t/a.memprofdata
+; RUN: opt < %t/a.ll -passes='memprof-use<profile-filename=%t/a.memprofdata>' -pgo-warn-missing-function -S 2>&1 | FileCheck %s
 
 ; CHECK: memprof record not found for function hash {{.*}} _Z16funcnotinprofilev
 
+;--- a.ll
 ; ModuleID = 'memprofmissingfunc.cc'
 source_filename = "memprofmissingfunc.cc"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
@@ -26,3 +20,11 @@ entry:
   ret void
 }
 
+;--- a.yaml
+---
+HeapProfileRecords:
+  - GUID:            main
+    CallSites:
+      - Frames:
+          - { Function: main, LineOffset: 1, Column: 3, IsInlineFrame: false }
+...


### PR DESCRIPTION
Use split-file to create a basic `.memprofdata` file to be used in the test.  This also allows us to remove the REQUIRES because we are no longer reading a binary file.