### PR TITLE
[lldb] Replace ConstString with std::string in SharedCacheImageInfo

### DIFF
--- a/lldb/include/lldb/Host/HostInfoBase.h
+++ b/lldb/include/lldb/Host/HostInfoBase.h
@@ -10,7 +10,6 @@
 #define LLDB_HOST_HOSTINFOBASE_H
 
 #include "lldb/Utility/ArchSpec.h"
-#include "lldb/Utility/ConstString.h"
 #include "lldb/Utility/DataExtractor.h"
 #include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/UUID.h"
@@ -33,15 +32,16 @@ struct SharedCacheImageInfo {
   SharedCacheImageInfo()
       : m_filename(), m_uuid(), m_extractor_sp(),
         m_create_data_extractor(nullptr), m_image_baton(nullptr) {}
-  SharedCacheImageInfo(ConstString filename, UUID uuid,
+  SharedCacheImageInfo(std::string filename, UUID uuid,
                        lldb::DataExtractorSP extractor_sp)
-      : m_filename(filename), m_uuid(uuid), m_extractor_sp(extractor_sp),
-        m_create_data_extractor(nullptr), m_image_baton(nullptr) {}
+      : m_filename(std::move(filename)), m_uuid(uuid),
+        m_extractor_sp(extractor_sp), m_create_data_extractor(nullptr),
+        m_image_baton(nullptr) {}
   SharedCacheImageInfo(
-      ConstString filename, UUID uuid,
+      std::string filename, UUID uuid,
       lldb::DataExtractorSP (*create_data_extractor)(void *image),
       void *image_baton)
-      : m_filename(filename), m_uuid(uuid), m_extractor_sp(),
+      : m_filename(std::move(filename)), m_uuid(uuid), m_extractor_sp(),
         m_create_data_extractor(create_data_extractor),
         m_image_baton(image_baton) {}
 
@@ -50,7 +50,7 @@ struct SharedCacheImageInfo {
       m_extractor_sp = m_create_data_extractor(m_image_baton);
     return m_extractor_sp;
   }
-  ConstString GetFilename() const { return m_filename; }
+  llvm::StringRef GetFilename() const { return m_filename; }
   const UUID &GetUUID() const { return m_uuid; }
   void *GetImageBaton();
   void SetExtractor(lldb::DataExtractorSP extractor_sp) {
@@ -61,7 +61,7 @@ struct SharedCacheImageInfo {
       lldb::DataExtractorSP (*create_data_extractor)(void *image));
 
 private:
-  ConstString m_filename;
+  std::string m_filename;
   UUID m_uuid;
   lldb::DataExtractorSP m_extractor_sp;
   lldb::DataExtractorSP (*m_create_data_extractor)(void *image);
@@ -198,7 +198,7 @@ public:
   ///     cache binary blob directly, needed to keep user settings out of
   ///     Host.
   static SharedCacheImageInfo
-  GetSharedCacheImageInfo(ConstString filepath,
+  GetSharedCacheImageInfo(llvm::StringRef filepath,
                           lldb::SymbolSharedCacheUse sc_mode) {
     return {};
   }
@@ -225,7 +225,7 @@ public:
   ///     cache binary blob directly, needed to keep user settings out of
   ///     Host.
   static SharedCacheImageInfo
-  GetSharedCacheImageInfo(ConstString filepath, const UUID &sc_uuid,
+  GetSharedCacheImageInfo(llvm::StringRef filepath, const UUID &sc_uuid,
                           lldb::SymbolSharedCacheUse sc_mode) {
     return {};
   }
@@ -240,20 +240,6 @@ public:
   ///     Host.
   static SharedCacheImageInfo
   GetSharedCacheImageInfo(const UUID &uuid, const UUID &sc_uuid,
-                          lldb::SymbolSharedCacheUse sc_mode) {
-    return {};
-  }
-
-  /// Return information about module \p image_name if it is loaded in
-  /// the current process's address space using shared cache \p uuid.
-  /// The shared cache UUID must have been previously indexed.
-  ///
-  /// \param[in] use_sc_binary_directly
-  ///     Flag to control if this method can try to read a shared
-  ///     cache binary blob directly, needed to keep user settings out of
-  ///     Host.
-  static SharedCacheImageInfo
-  GetSharedCacheImageInfo(llvm::StringRef image_name, const UUID &uuid,
                           lldb::SymbolSharedCacheUse sc_mode) {
     return {};
   }

--- a/lldb/include/lldb/Host/macosx/HostInfoMacOSX.h
+++ b/lldb/include/lldb/Host/macosx/HostInfoMacOSX.h
@@ -43,13 +43,13 @@ public:
 
   /// Shared cache utilities
   static SharedCacheImageInfo
-  GetSharedCacheImageInfo(ConstString filepath,
+  GetSharedCacheImageInfo(llvm::StringRef filepath,
                           lldb::SymbolSharedCacheUse sc_mode);
   static SharedCacheImageInfo
   GetSharedCacheImageInfo(const UUID &uuid, lldb::SymbolSharedCacheUse sc_mode);
 
   static SharedCacheImageInfo
-  GetSharedCacheImageInfo(ConstString filepath, const UUID &sc_uuid,
+  GetSharedCacheImageInfo(llvm::StringRef filepath, const UUID &sc_uuid,
                           lldb::SymbolSharedCacheUse sc_mode);
   static SharedCacheImageInfo
   GetSharedCacheImageInfo(const UUID &uuid, const UUID &sc_uuid,

--- a/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
+++ b/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
@@ -11,7 +11,6 @@
 #include "lldb/Host/Host.h"
 #include "lldb/Host/HostInfo.h"
 #include "lldb/Utility/Args.h"
-#include "lldb/Utility/ConstString.h"
 #include "lldb/Utility/DataBuffer.h"
 #include "lldb/Utility/DataExtractor.h"
 #include "lldb/Utility/FileSpecList.h"
@@ -749,7 +748,7 @@ const LazyDyldSPIs &GetLazyDyldSPIs() {
 
 class SharedCacheInfo {
 public:
-  SharedCacheImageInfo GetByFilename(UUID sc_uuid, ConstString filename) {
+  SharedCacheImageInfo GetByFilename(UUID sc_uuid, llvm::StringRef filename) {
     llvm::sys::ScopedReader guard(m_mutex);
     if (!sc_uuid)
       sc_uuid = m_host_uuid;
@@ -787,7 +786,7 @@ private:
   // All of the entries for a given shared cache are in m_file_infos.
   // m_filename_map and m_uuid_map have pointers into those entries.
   llvm::SmallDenseMap<UUID, std::vector<SharedCacheImageInfo>> m_file_infos;
-  llvm::SmallDenseMap<UUID, llvm::DenseMap<ConstString, size_t>> m_filename_map;
+  llvm::SmallDenseMap<UUID, llvm::StringMap<size_t>> m_filename_map;
   llvm::SmallDenseMap<UUID, llvm::DenseMap<UUID, size_t>> m_uuid_map;
 
   UUID m_host_uuid;
@@ -942,11 +941,11 @@ bool SharedCacheInfo::CreateSharedCacheImageList(UUID sc_uuid,
         return;
       UUID image_uuid(uuid_tmp, sizeof(uuid_t));
 
-      // Copy the filename into the const string pool to
-      // ensure lifetime.
-      ConstString installname(dyld_image_get_installname(image));
+      const char *installname_cstr = dyld_image_get_installname(image);
+      std::string installname = installname_cstr ? installname_cstr : "";
+
       Log *log = GetLog(LLDBLog::Modules);
-      LLDB_LOGF_VERBOSE(log, "sc file %s image %p", installname.GetCString(),
+      LLDB_LOGF_VERBOSE(log, "sc file %s image %p", installname.c_str(),
                         (void *)image);
 
       dyld.image_retain_4HWTrace(image);
@@ -1052,9 +1051,8 @@ bool SharedCacheInfo::CreateSharedCacheInfoWithInstrospectionSPIs() {
           seg.first - minVmAddr, seg.second, seg.first - minVmAddr));
     lldb::DataExtractorSP extractor_sp =
         std::make_shared<VirtualDataExtractor>(data_sp, table);
-    // Copy the filename into the const string pool to
-    // ensure lifetime.
-    ConstString installname(dyld_image_get_installname(image));
+    const char *installname_cstr = dyld_image_get_installname(image);
+    std::string installname = installname_cstr ? installname_cstr : "";
     m_file_infos[m_host_uuid].push_back(
         SharedCacheImageInfo(installname, UUID(uuid, 16), extractor_sp));
   });
@@ -1076,7 +1074,7 @@ SharedCacheInfo &GetSharedCacheSingleton(SymbolSharedCacheUse sc_mode) {
 }
 
 SharedCacheImageInfo
-HostInfoMacOSX::GetSharedCacheImageInfo(ConstString filepath,
+HostInfoMacOSX::GetSharedCacheImageInfo(llvm::StringRef filepath,
                                         SymbolSharedCacheUse sc_mode) {
   return GetSharedCacheSingleton(sc_mode).GetByFilename(UUID(), filepath);
 }
@@ -1087,8 +1085,10 @@ HostInfoMacOSX::GetSharedCacheImageInfo(const UUID &file_uuid,
   return GetSharedCacheSingleton(sc_mode).GetByUUID(UUID(), file_uuid);
 }
 
-SharedCacheImageInfo HostInfoMacOSX::GetSharedCacheImageInfo(
-    ConstString filepath, const UUID &sc_uuid, SymbolSharedCacheUse sc_mode) {
+SharedCacheImageInfo
+HostInfoMacOSX::GetSharedCacheImageInfo(llvm::StringRef filepath,
+                                        const UUID &sc_uuid,
+                                        SymbolSharedCacheUse sc_mode) {
   return GetSharedCacheSingleton(sc_mode).GetByFilename(sc_uuid, filepath);
 }
 

--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
@@ -152,13 +152,15 @@ ModuleSP DynamicLoaderDarwin::FindTargetModuleForImageInfo(
         image_info = HostInfo::GetSharedCacheImageInfo(module_spec.GetUUID(),
                                                        sc_uuid, sc_mode);
 
-      else
-        image_info = HostInfo::GetSharedCacheImageInfo(
-            ConstString(module_spec.GetFileSpec().GetPath()), sc_uuid, sc_mode);
+      else {
+        std::string filepath = module_spec.GetFileSpec().GetPath();
+        image_info =
+            HostInfo::GetSharedCacheImageInfo(filepath, sc_uuid, sc_mode);
+      }
     } else {
       // Fall back to looking lldb's own shared cache by filename
-      image_info = HostInfo::GetSharedCacheImageInfo(
-          ConstString(module_spec.GetFileSpec().GetPath()), sc_mode);
+      std::string filepath = module_spec.GetFileSpec().GetPath();
+      image_info = HostInfo::GetSharedCacheImageInfo(filepath, sc_mode);
     }
 
     // If we found it and it has the correct UUID, let's proceed with

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -439,15 +439,18 @@ Status PlatformDarwin::GetModuleFromSharedCaches(
       if (module_spec.GetUUID())
         image_info = HostInfo::GetSharedCacheImageInfo(module_spec.GetUUID(),
                                                        sc_uuid, sc_mode);
-      else
-        image_info = HostInfo::GetSharedCacheImageInfo(
-            ConstString(module_spec.GetFileSpec().GetPath()), sc_uuid, sc_mode);
+      else {
+        std::string filepath = module_spec.GetFileSpec().GetPath();
+        image_info =
+            HostInfo::GetSharedCacheImageInfo(filepath, sc_uuid, sc_mode);
+      }
     }
   }
   // Fall back to looking for the file in lldb's own shared cache.
-  if (!image_info.GetUUID())
-    image_info = HostInfo::GetSharedCacheImageInfo(
-        ConstString(module_spec.GetFileSpec().GetPath()), sc_mode);
+  if (!image_info.GetUUID()) {
+    std::string filepath = module_spec.GetFileSpec().GetPath();
+    image_info = HostInfo::GetSharedCacheImageInfo(filepath, sc_mode);
+  }
 
   // If we found it and it has the correct UUID, let's proceed with
   // creating a module from the memory contents.

--- a/lldb/source/Plugins/SymbolLocator/DebugSymbols/SymbolLocatorDebugSymbols.cpp
+++ b/lldb/source/Plugins/SymbolLocator/DebugSymbols/SymbolLocatorDebugSymbols.cpp
@@ -220,8 +220,9 @@ std::optional<ModuleSpec> SymbolLocatorDebugSymbols::LocateExecutableObjectFile(
             SymbolSharedCacheUse sc_mode =
                 ModuleList::GetGlobalModuleListProperties()
                     .GetSharedCacheBinaryLoading();
-            SharedCacheImageInfo image_info = HostInfo::GetSharedCacheImageInfo(
-                ConstString(module_spec.GetFileSpec().GetPath()), sc_mode);
+            std::string filepath = module_spec.GetFileSpec().GetPath();
+            SharedCacheImageInfo image_info =
+                HostInfo::GetSharedCacheImageInfo(filepath, sc_mode);
 
             // If we found it and it has the correct UUID, let's proceed with
             // creating a module from the memory contents.
@@ -647,8 +648,9 @@ static int LocateMacOSXFilesUsingDebugSymbols(const ModuleSpec &module_spec,
             SymbolSharedCacheUse sc_mode =
                 ModuleList::GetGlobalModuleListProperties()
                     .GetSharedCacheBinaryLoading();
-            SharedCacheImageInfo image_info = HostInfo::GetSharedCacheImageInfo(
-                ConstString(module_spec.GetFileSpec().GetPath()), sc_mode);
+            std::string filepath = module_spec.GetFileSpec().GetPath();
+            SharedCacheImageInfo image_info =
+                HostInfo::GetSharedCacheImageInfo(filepath, sc_mode);
 
             // If we found it and it has the correct UUID, let's proceed with
             // creating a module from the memory contents.

--- a/lldb/unittests/ObjectFile/MachO/TestObjectFileMachO.cpp
+++ b/lldb/unittests/ObjectFile/MachO/TestObjectFileMachO.cpp
@@ -45,8 +45,7 @@ TEST_F(ObjectFileMachOTest, ModuleFromSharedCacheInfo) {
   Platform::SetHostPlatform(PlatformRemoteMacOSX::CreateInstance(true, &arch));
 
   SharedCacheImageInfo image_info = HostInfo::GetSharedCacheImageInfo(
-      ConstString("/usr/lib/libobjc.A.dylib"),
-      lldb::eSymbolSharedCacheUseHostSharedCache);
+      "/usr/lib/libobjc.A.dylib", lldb::eSymbolSharedCacheUseHostSharedCache);
   EXPECT_TRUE(image_info.GetUUID());
   EXPECT_TRUE(image_info.GetExtractor());
 
@@ -94,8 +93,7 @@ TEST_F(ObjectFileMachOTest, ModuleFromSharedCacheInfo) {
 
 TEST_F(ObjectFileMachOTest, IndirectSymbolsInTheSharedCache) {
   SharedCacheImageInfo image_info = HostInfo::GetSharedCacheImageInfo(
-      ConstString(
-          "/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit"),
+      "/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit",
       lldb::eSymbolSharedCacheUseHostSharedCache);
   ModuleSpec spec(FileSpec(), UUID(), image_info.GetExtractor());
   lldb::ModuleSP module = std::make_shared<Module>(spec);


### PR DESCRIPTION
Every call to `HostInfo::GetSharedCacheImageInfo` requires us to construct a ConstString of module's full path before we can look anything up (regardless of if it was successful). I changed the interfaces and implementation to not require a ConstString for a lookup.

Going further, the actual SharedCacheImageInfo struct doesn't really benefit from putting the path into a ConstString if the lookups aren't also ConstStrings, so I modified that too.