### PR TITLE
[flang][cuda] Allow call to len intrinsic on host with device argument

### DIFF
--- a/flang/lib/Semantics/check-call.cpp
+++ b/flang/lib/Semantics/check-call.cpp
@@ -354,8 +354,8 @@ static bool DefersSameTypeParameters(
 // arguments.
 static const llvm::StringSet<> cudaSkippedIntrinsics = {"__builtin_c_devloc",
     "__builtin_c_f_pointer", "__builtin_c_loc", "__builtin_show_descriptor",
-    "allocated", "associated", "kind", "lbound", "loc", "present", "shape",
-    "size", "sizeof", "ubound"};
+    "allocated", "associated", "kind", "len", "lbound", "loc", "present",
+    "shape", "size", "sizeof", "ubound"};
 
 static void CheckExplicitDataArg(const characteristics::DummyDataObject &dummy,
     const std::string &dummyName, evaluate::Expr<evaluate::SomeType> &actual,

--- a/flang/test/Semantics/CUDA/cuf23.cuf
+++ b/flang/test/Semantics/CUDA/cuf23.cuf
@@ -89,6 +89,13 @@ subroutine intrinsic_error_skip_show_descriptor(n)
   call show_descriptor(d) ! ok, descriptor in managed memory
 end subroutine
 
+subroutine intrinsic_error_skip_len(cdchar)
+  character(len=*), device :: cdchar
+  integer :: ibuffsize
+  ibuffsize = len(cdchar) ! ok, descriptor is in managed memory
+end subroutine intrinsic_error_skip_len
+
+
 double complex function acc_routine_check(n, x, y)
   !$acc routine(acc_routine_check) vector
   implicit none


### PR DESCRIPTION
This is fine to call `len` intrinsic on the host with a device actual argument since the descriptor is allocated in managed memory. 