### PR TITLE
[lldb] Don't merge a frame provider's frames into the unwinder frame list

### DIFF
--- a/lldb/source/Target/StackFrameList.cpp
+++ b/lldb/source/Target/StackFrameList.cpp
@@ -15,6 +15,7 @@
 #include "lldb/Symbol/Block.h"
 #include "lldb/Symbol/Function.h"
 #include "lldb/Symbol/Symbol.h"
+#include "lldb/Target/BorrowedStackFrame.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/RegisterContext.h"
 #include "lldb/Target/StackFrame.h"
@@ -636,6 +637,14 @@ bool StackFrameList::FetchFramesUpTo(uint32_t end_idx,
       // Check the stack ID to make sure they are equal.
       if (curr_frame->GetStackID() != prev_frame->GetStackID())
         break;
+
+      // Never adopt a frame borrowed from another StackFrameList, which only a
+      // provider's SyntheticStackFrameList hands out: it keeps reporting the
+      // index of the frame it borrows, and the update below cannot change
+      // that. Skipping it is safe because the merge only carries cached state
+      // onto a frame this list has already unwound correctly.
+      if (llvm::isa<BorrowedStackFrame>(prev_frame))
+        continue;
 
       prev_frame->UpdatePreviousFrameFromCurrentFrame(*curr_frame);
       // Now copy the fixed up previous frame into the current frames so the

--- a/lldb/test/API/functionalities/scripted_frame_provider/frame_index_after_depth_change/Makefile
+++ b/lldb/test/API/functionalities/scripted_frame_provider/frame_index_after_depth_change/Makefile
@@ -1,0 +1,4 @@
+C_SOURCES := main.c
+CFLAGS_EXTRAS := -std=c99
+
+include Makefile.rules

--- a/lldb/test/API/functionalities/scripted_frame_provider/frame_index_after_depth_change/TestFrameProviderFrameIndexAfterDepthChange.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/frame_index_after_depth_change/TestFrameProviderFrameIndexAfterDepthChange.py
@@ -1,0 +1,49 @@
+"""
+Test that the unwinder renumbers its own frames when the stack gets deeper
+between two stops while a scripted frame provider is registered.
+"""
+
+import os
+import re
+
+import lldb
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.lldbtest import *
+
+
+class TestFrameProviderFrameIndexAfterDepthChange(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def test_unwinder_indices_after_stack_grows(self):
+        self.build()
+        target, process, _, _ = lldbutil.run_to_name_breakpoint(self, "shallow")
+
+        self.runCmd(
+            "command script import "
+            + os.path.join(self.getSourceDir(), "frame_provider.py")
+        )
+        error = lldb.SBError()
+        target.RegisterScriptedFrameProvider(
+            "frame_provider.IdentityProvider", lldb.SBStructuredData(), error
+        )
+        self.assertSuccess(error, "Failed to register the frame provider")
+
+        # Only a fully fetched list is kept as the next stop's predecessor, and
+        # that predecessor is what the next unwinder list merges against.
+        self.runCmd("bt")
+
+        # Stop deeper down, so the outermost frames no longer belong at the
+        # indices they had at the shallow stop.
+        lldbutil.run_break_set_by_symbol(self, "deep")
+        process.Continue()
+        self.assertState(process.GetState(), lldb.eStateStopped)
+
+        # 'bt --provider *' prints one section per provider, the base unwinder
+        # first. Its frames must still be numbered sequentially.
+        self.runCmd("bt --provider '*'")
+        output = self.res.GetOutput()
+        unwinder = output.split("=== Provider 1")[0]
+        indices = [int(idx) for idx in re.findall(r"frame #(\d+)", unwinder)]
+
+        self.assertTrue(indices, "Found no frames for the base unwinder")
+        self.assertEqual(indices, list(range(len(indices))), output)

--- a/lldb/test/API/functionalities/scripted_frame_provider/frame_index_after_depth_change/frame_provider.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/frame_index_after_depth_change/frame_provider.py
@@ -1,0 +1,21 @@
+"""
+Frame provider that forwards every input frame under its own index.
+
+Identity forwarding still wraps each frame in a BorrowedStackFrame, which is
+what this test needs: those wrappers end up cached in the thread's public frame
+list, and that list becomes the predecessor the next unwinder list merges
+against.
+"""
+
+from lldb.plugins.scripted_frame_provider import ScriptedFrameProvider
+
+
+class IdentityProvider(ScriptedFrameProvider):
+    @staticmethod
+    def get_description():
+        return "Provider that forwards each frame under its own index"
+
+    def get_frame_at_index(self, index):
+        if index < len(self.input_frames):
+            return index
+        return None

--- a/lldb/test/API/functionalities/scripted_frame_provider/frame_index_after_depth_change/main.c
+++ b/lldb/test/API/functionalities/scripted_frame_provider/frame_index_after_depth_change/main.c
@@ -1,0 +1,20 @@
+// The stack is shallower at the first stop than at the second, so the outermost
+// frames have to be renumbered in between.
+
+void shallow(void) {
+  int shallow_local = 1;
+  (void)shallow_local; // Shallow breakpoint.
+}
+
+void deep(void) {
+  int deep_local = 2;
+  (void)deep_local; // Deep breakpoint.
+}
+
+void middle(void) { deep(); }
+
+int main(void) {
+  shallow();
+  middle();
+  return 0;
+}


### PR DESCRIPTION
`Thread::ClearStackFrames` keeps the previous public frame list as the predecessor of the next unwinder list. When a scripted frame provider is registered, that public list is a `SyntheticStackFrameList` holding `BorrowedStackFrames`, and the unwinder list's merge step reuses a predecessor frame whenever the stack IDs match, so it adopted frames belonging to the provider's list.

`UpdatePreviousFrameFromCurrentFrame` refreshes `StackFrame::m_frame_index`, but `BorrowedStackFrame::GetFrameIndex()` returns its own `m_new_frame_index`, which supersedes it. The adopted frame keeps reporting its index from the previous stop, so once the stack grows the backtrace stops counting up:

```
  frame #1: middle
  frame #1: main
  frame #2: start
```

Such a frame also delegates its stack ID, register context and symbol context to a frame from the previous stop that the merge never refreshes, so it could report stale state as well. In the backtrace above, main also lost its source location.

When the merge finds a matching predecessor frame that is a `BorrowedStackFrame`, keep the freshly unwound frame instead of adopting it. Only providers create BorrowedStackFrames, so this never drops a frame the unwinder built itself.