### PR TITLE
[mlir][scf] Declare ControlFlow as a dependent dialect

### DIFF
--- a/mlir/include/mlir/Dialect/SCF/IR/SCFOps.td
+++ b/mlir/include/mlir/Dialect/SCF/IR/SCFOps.td
@@ -42,7 +42,9 @@ def SCF_Dialect : Dialect {
     and then lowered to some final target like LLVM or SPIR-V.
   }];
 
-  let dependentDialects = ["arith::ArithDialect"];
+  // The canonicalization of a multi-block `scf.execute_region` materializes
+  // `cf.br` operations, so the ControlFlow dialect must always be loaded.
+  let dependentDialects = ["arith::ArithDialect", "cf::ControlFlowDialect"];
 }
 
 // Base class for SCF dialect ops.

--- a/mlir/test/Dialect/SCF/canonicalize-dependent-dialects.mlir
+++ b/mlir/test/Dialect/SCF/canonicalize-dependent-dialects.mlir
@@ -11,6 +11,8 @@
 //   CHECK-NOT:   scf.execute_region
 //       CHECK:   llvm.cond_br
 //       CHECK:   llvm.store
+//       CHECK:   cf.br
+//       CHECK:   cf.br
 //       CHECK:   llvm.return
 llvm.func @multi_block_execute_region(%c: i1, %p: !llvm.ptr, %x: i64) {
   scf.execute_region {

--- a/mlir/test/Dialect/SCF/canonicalize-dependent-dialects.mlir
+++ b/mlir/test/Dialect/SCF/canonicalize-dependent-dialects.mlir
@@ -1,0 +1,25 @@
+// RUN: mlir-opt %s --canonicalize | FileCheck %s
+
+// Canonicalizing a multi-block `scf.execute_region` materializes `cf.br` ops,
+// so the SCF dialect has to declare a dependency on the ControlFlow dialect.
+// This test deliberately contains no `cf` operation and does not use
+// `func.func`: parsing a `cf` operation, or loading the Func dialect (whose
+// inliner extension loads ControlFlow), would load the dialect for unrelated
+// reasons and mask the missing dependency.
+
+// CHECK-LABEL: llvm.func @multi_block_execute_region
+//   CHECK-NOT:   scf.execute_region
+//       CHECK:   llvm.cond_br
+//       CHECK:   llvm.store
+//       CHECK:   llvm.return
+llvm.func @multi_block_execute_region(%c: i1, %p: !llvm.ptr, %x: i64) {
+  scf.execute_region {
+    llvm.cond_br %c, ^bb1, ^bb2
+  ^bb1:
+    llvm.store %x, %p : i64, !llvm.ptr
+    scf.yield
+  ^bb2:
+    scf.yield
+  }
+  llvm.return
+}


### PR DESCRIPTION
The canonicalization of a multi-block `scf.execute_region` creates `cf.br`, but
the SCF dialect does not declare `cf::ControlFlowDialect` as a dependent dialect.
When nothing else has loaded ControlFlow, `mlir-opt --canonicalize` fails with

    LLVM ERROR: cf.br created with unregistered dialect.

Prepending an unrelated function that merely mentions `cf.br` makes the same
input canonicalize cleanly, which is the symptom `dependentDialects` prevents.

The test needs a non-`func.func` parent: Func's inliner extension already loads
ControlFlow, which is why no in-tree test caught this.

Assisted-by: Claude (Anthropic)

AI-assisted, disclosed per the LLVM AI Tool Use Policy.
