### PR TITLE
[mlir][scf] Do not coalesce when an inner loop reads an outer iter_arg

### DIFF
--- a/mlir/lib/Dialect/SCF/Utils/Utils.cpp
+++ b/mlir/lib/Dialect/SCF/Utils/Utils.cpp
@@ -1007,14 +1007,10 @@ LogicalResult mlir::coalesceLoops(RewriterBase &rewriter,
     }
   }
 
-  // Bail out if an iteration argument of an enclosing loop is read anywhere
-  // other than as the init operand of the loop nested in it. Coalescing maps
-  // the iteration arguments of every loop in the band onto the ones of the
-  // outermost loop, which turns such a read into a read of the value carried by
-  // the coalesced loop. That value is updated on every iteration, whereas the
-  // one being read is fixed for a whole run of the inner loop. This covers both
-  // a read inside the inner loop's region and, in an imperfect nest, one from
-  // an operation sitting between the two loops.
+  // Conservatively decline if an iteration argument of an enclosing loop is
+  // read anywhere but as the init operand of the loop nested in it: coalescing
+  // would replace that value, fixed for a whole run of the inner loop, with the
+  // one carried by the coalesced loop, which changes on every iteration.
   for (unsigned i = 1, e = loops.size(); i < e; ++i) {
     Operation *innerLoop = loops[i].getOperation();
     for (BlockArgument iterArg : loops[i - 1].getRegionIterArgs()) {

--- a/mlir/lib/Dialect/SCF/Utils/Utils.cpp
+++ b/mlir/lib/Dialect/SCF/Utils/Utils.cpp
@@ -1007,18 +1007,19 @@ LogicalResult mlir::coalesceLoops(RewriterBase &rewriter,
     }
   }
 
-  // Bail out if the region of an inner loop reads an iteration argument of an
-  // enclosing loop other than through its own iteration arguments. Coalescing
-  // maps the iteration arguments of every loop in the band onto the ones of the
+  // Bail out if an iteration argument of an enclosing loop is read anywhere
+  // other than as the init operand of the loop nested in it. Coalescing maps
+  // the iteration arguments of every loop in the band onto the ones of the
   // outermost loop, which turns such a read into a read of the value carried by
   // the coalesced loop. That value is updated on every iteration, whereas the
-  // one the inner loop reads is fixed for a whole run of that loop.
+  // one being read is fixed for a whole run of the inner loop. This covers both
+  // a read inside the inner loop's region and, in an imperfect nest, one from
+  // an operation sitting between the two loops.
   for (unsigned i = 1, e = loops.size(); i < e; ++i) {
-    scf::ForOp innerLoop = loops[i];
+    Operation *innerLoop = loops[i].getOperation();
     for (BlockArgument iterArg : loops[i - 1].getRegionIterArgs()) {
-      if (llvm::any_of(iterArg.getUsers(), [&](Operation *user) {
-            return innerLoop->isProperAncestor(user);
-          }))
+      if (llvm::any_of(iterArg.getUsers(),
+                       [&](Operation *user) { return user != innerLoop; }))
         return failure();
     }
   }

--- a/mlir/lib/Dialect/SCF/Utils/Utils.cpp
+++ b/mlir/lib/Dialect/SCF/Utils/Utils.cpp
@@ -1006,6 +1006,23 @@ LogicalResult mlir::coalesceLoops(RewriterBase &rewriter,
       }
     }
   }
+
+  // Bail out if the region of an inner loop reads an iteration argument of an
+  // enclosing loop other than through its own iteration arguments. Coalescing
+  // maps the iteration arguments of every loop in the band onto the ones of the
+  // outermost loop, which turns such a read into a read of the value carried by
+  // the coalesced loop. That value is updated on every iteration, whereas the
+  // one the inner loop reads is fixed for a whole run of that loop.
+  for (unsigned i = 1, e = loops.size(); i < e; ++i) {
+    scf::ForOp innerLoop = loops[i];
+    for (BlockArgument iterArg : loops[i - 1].getRegionIterArgs()) {
+      if (llvm::any_of(iterArg.getUsers(), [&](Operation *user) {
+            return innerLoop->isProperAncestor(user);
+          }))
+        return failure();
+    }
+  }
+
   // 1. Make sure all loops iterate from 0 to upperBound with step 1.  This
   // allows the following code to assume upperBound is the number of iterations.
   for (auto loop : loops) {

--- a/mlir/test/Dialect/Affine/loop-coalescing.mlir
+++ b/mlir/test/Dialect/Affine/loop-coalescing.mlir
@@ -492,10 +492,7 @@ func.func @inner_loop_yields_induction_var() -> index {
 
 // -----
 
-// Verify that coalescing is not attempted when the body of the inner loop reads
-// an iteration argument of the outer loop directly. That value is fixed for a
-// whole run of the inner loop, whereas the value carried by the coalesced loop
-// is updated on every iteration.
+// The inner loop reads an iteration argument of the outer loop: no coalescing.
 
 // CHECK-LABEL: @no_coalesce_outer_iter_arg_read_in_inner_loop
 // CHECK-SAME:    %[[INIT:[A-Za-z0-9]+]]: i64

--- a/mlir/test/Dialect/Affine/loop-coalescing.mlir
+++ b/mlir/test/Dialect/Affine/loop-coalescing.mlir
@@ -489,3 +489,27 @@ func.func @inner_loop_yields_induction_var() -> index {
   }
   return %r : index
 }
+
+// -----
+
+// Verify that coalescing is not attempted when the body of the inner loop reads
+// an iteration argument of the outer loop directly. That value is fixed for a
+// whole run of the inner loop, whereas the value carried by the coalesced loop
+// is updated on every iteration.
+
+// CHECK-LABEL: @no_coalesce_outer_iter_arg_read_in_inner_loop
+// CHECK-SAME:    %[[INIT:[A-Za-z0-9]+]]: i64
+func.func @no_coalesce_outer_iter_arg_read_in_inner_loop(%init: i64, %lb: index,
+    %ub: index, %step: index) -> i64 {
+  // CHECK: scf.for %{{.*}} iter_args(%[[OUTER:.*]] = %[[INIT]]) -> (i64)
+  %0 = scf.for %i = %lb to %ub step %step iter_args(%outer = %init) -> (i64) {
+    // CHECK: scf.for %{{.*}} iter_args(%[[INNER:.*]] = %[[OUTER]]) -> (i64)
+    %1 = scf.for %j = %lb to %ub step %step iter_args(%inner = %outer) -> (i64) {
+      // CHECK: arith.addi %[[INNER]], %[[OUTER]] : i64
+      %2 = arith.addi %inner, %outer : i64
+      scf.yield %2 : i64
+    }
+    scf.yield %1 : i64
+  }
+  return %0 : i64
+}

--- a/mlir/test/Dialect/SCF/transform-op-coalesce.mlir
+++ b/mlir/test/Dialect/SCF/transform-op-coalesce.mlir
@@ -417,10 +417,8 @@ module attributes {transform.with_named_sequence} {
 
 // -----
 
-// An operation sitting between the two loops of an imperfect nest and reading
-// the outer loop's iteration argument is unsound to coalesce for the same
-// reason as a read from inside the inner loop: after the merge it would see a
-// value updated on every iteration of the coalesced loop.
+// A read of the outer iteration argument between the two loops also blocks
+// coalescing.
 
 func.func @no_coalesce_outer_iter_arg_read_between_loops(%init: f32) -> f32 {
   %c0 = arith.constant 0 : index

--- a/mlir/test/Dialect/SCF/transform-op-coalesce.mlir
+++ b/mlir/test/Dialect/SCF/transform-op-coalesce.mlir
@@ -414,3 +414,35 @@ module attributes {transform.with_named_sequence} {
 //       CHECK:     scf.yield %[[UPDATED]]
 //       CHECK:   }
 //       CHECK:   return %[[RESULT]]
+
+// -----
+
+// An operation sitting between the two loops of an imperfect nest and reading
+// the outer loop's iteration argument is unsound to coalesce for the same
+// reason as a read from inside the inner loop: after the merge it would see a
+// value updated on every iteration of the coalesced loop.
+
+func.func @no_coalesce_outer_iter_arg_read_between_loops(%init: f32) -> f32 {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c3 = arith.constant 3 : index
+  %result = scf.for %i = %c0 to %c3 step %c1 iter_args(%outer = %init) -> (f32) {
+    %read = "use"(%outer) : (f32) -> f32
+    %inner_result = scf.for %j = %c0 to %c3 step %c1 iter_args(%inner = %outer) -> (f32) {
+      %updated = "use"(%inner, %read) : (f32, f32) -> f32
+      scf.yield %updated : f32
+    }
+    scf.yield %inner_result : f32
+  } {coalesce_nested}
+  return %result : f32
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["scf.for"]} attributes {coalesce_nested} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %1 = transform.cast %0 : !transform.any_op to !transform.op<"scf.for">
+    // expected-error @below {{failed to coalesce}}
+    %2 = transform.loop.coalesce_nested %1 : (!transform.op<"scf.for">) -> (!transform.op<"scf.for">)
+    transform.yield
+  }
+}

--- a/mlir/test/Dialect/SCF/transform-op-coalesce.mlir
+++ b/mlir/test/Dialect/SCF/transform-op-coalesce.mlir
@@ -161,7 +161,7 @@ func.func @tensor_loops_first_two(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf3
   %0:2 = scf.for %i = %lb0 to %ub0 step %step0 iter_args(%arg2 = %arg0, %arg3 = %arg1) -> (tensor<?x?xf32>, tensor<?x?xf32>) {
     %1:2 = scf.for %j = %lb1 to %ub1 step %step1 iter_args(%arg4 = %arg2, %arg5 = %arg3) -> (tensor<?x?xf32>, tensor<?x?xf32>) {
       %2:2 = scf.for %k = %lb2 to %ub2 step %step2 iter_args(%arg6 = %arg5, %arg7 = %arg4) -> (tensor<?x?xf32>, tensor<?x?xf32>) {
-        %3:2 = "use"(%arg3, %i, %j, %k) : (tensor<?x?xf32>, index, index, index) -> (tensor<?x?xf32>, tensor<?x?xf32>)
+        %3:2 = "use"(%arg6, %i, %j, %k) : (tensor<?x?xf32>, index, index, index) -> (tensor<?x?xf32>, tensor<?x?xf32>)
         scf.yield %3#0, %3#1 : tensor<?x?xf32>, tensor<?x?xf32>
       }
       scf.yield %2#0, %2#1 : tensor<?x?xf32>, tensor<?x?xf32>
@@ -204,7 +204,7 @@ func.func @tensor_loops_first_two_2(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?x
   %0:2 = scf.for %i = %lb0 to %ub0 step %step0 iter_args(%arg2 = %arg0, %arg3 = %arg1) -> (tensor<?x?xf32>, tensor<?x?xf32>) {
     %1:2 = scf.for %j = %lb1 to %ub1 step %step1 iter_args(%arg4 = %arg2, %arg5 = %arg3) -> (tensor<?x?xf32>, tensor<?x?xf32>) {
       %2:2 = scf.for %k = %lb2 to %ub2 step %step2 iter_args(%arg6 = %arg4, %arg7 = %arg5) -> (tensor<?x?xf32>, tensor<?x?xf32>) {
-        %3:2 = "use"(%arg3, %i, %j, %k) : (tensor<?x?xf32>, index, index, index) -> (tensor<?x?xf32>, tensor<?x?xf32>)
+        %3:2 = "use"(%arg6, %i, %j, %k) : (tensor<?x?xf32>, index, index, index) -> (tensor<?x?xf32>, tensor<?x?xf32>)
         scf.yield %3#0, %3#1 : tensor<?x?xf32>, tensor<?x?xf32>
       }
       scf.yield %2#1, %2#0 : tensor<?x?xf32>, tensor<?x?xf32>


### PR DESCRIPTION
Fixes #216289.

`--affine-loop-coalescing` changes the result of a nested `scf.for` when the
inner body reads the outer loop's iter_arg directly:

```mlir
%r = scf.for %i = %lb to %ub step %st iter_args(%a = %init) -> (i64) {
  %s = scf.for %j = %lb to %ub step %st iter_args(%b = %a) -> (i64) {
    %t = arith.addi %b, %a : i64
    scf.yield %t : i64
  }
  scf.yield %s : i64
}
```

The body becomes `arith.addi %arg5, %arg5`: the two iter_args collapse into one,
though the outer is fixed for a whole run of the inner loop and the inner is not.

The legality test compares SSA identity along the chain and never asks what the
inner region reads from above.

The same read is also unsound one level up. In an imperfect nest an operation
sitting between the two loops can read the outer iter_arg, and
`transform.loop.coalesce_nested` coalesces that shape too. After the merge the
read sees the value carried by the coalesced loop, which is updated on every
iteration, instead of the one fixed for a run of the inner loop. The guard
therefore rejects any use of an outer iteration argument other than the inner
loop's init operand, which covers both shapes; that init operand is a use on the
loop op rather than in its region, so chained nests still coalesce. Each shape
has a negative test.

The guard is deliberately blunt. It also declines shapes that may well be sound,
such as an outer `scf.yield` that passes the argument straight through. For a
correctness fix I preferred that to enumerating the legal cases.

Two existing tests in `transform-op-coalesce.mlir` contain the first pattern by
accident and record the wrong output; without updating them the patch reports
`failed to coalesce` at lines 177 and 220.

Assisted-by: Claude (Anthropic)

AI-assisted, disclosed per the LLVM AI Tool Use Policy.
