### PR TITLE
Add InterlockedMin function and resource methods

### DIFF
--- a/clang/include/clang/Basic/Builtins.td
+++ b/clang/include/clang/Basic/Builtins.td
@@ -5539,6 +5539,12 @@ def HLSLInterlockedAdd : LangBuiltin<"HLSL_LANG"> {
   let Prototype = "void (...)";
 }
 
+def HLSLInterlockedMin : LangBuiltin<"HLSL_LANG"> {
+  let Spellings = ["__builtin_hlsl_interlocked_min"];
+  let Attributes = [NoThrow];
+  let Prototype = "void (...)";
+}
+
 def HLSLInterlockedOr : LangBuiltin<"HLSL_LANG"> {
   let Spellings = ["__builtin_hlsl_interlocked_or"];
   let Attributes = [NoThrow];

--- a/clang/lib/CodeGen/CGHLSLBuiltins.cpp
+++ b/clang/lib/CodeGen/CGHLSLBuiltins.cpp
@@ -1419,6 +1419,13 @@ Value *CodeGenFunction::EmitHLSLBuiltinExpr(unsigned BuiltinID,
     // selectAtomicRMW). No intermediate intrinsic.
     return handleInterlockedOp(*this, E, llvm::AtomicRMWInst::Add);
   }
+  case Builtin::BI__builtin_hlsl_interlocked_min: {
+    llvm::AtomicRMWInst::BinOp Op =
+        E->getArg(0)->getType()->hasSignedIntegerRepresentation()
+            ? llvm::AtomicRMWInst::Min
+            : llvm::AtomicRMWInst::UMin;
+    return handleInterlockedOp(*this, E, Op);
+  }
   case Builtin::BI__builtin_hlsl_interlocked_or: {
     return handleInterlockedOp(*this, E, llvm::AtomicRMWInst::Or);
   }

--- a/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
+++ b/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
@@ -1670,6 +1670,10 @@ BuiltinTypeDeclBuilder::addByteAddressBufferInterlockedMethods() {
   // original-value parameter for each entry.
   addByteAddressBufferInterlockedMethod("InterlockedAdd", AST.UnsignedIntTy,
                                         "__builtin_hlsl_interlocked_add");
+  addByteAddressBufferInterlockedMethod("InterlockedMin", AST.IntTy,
+                                        "__builtin_hlsl_interlocked_min");
+  addByteAddressBufferInterlockedMethod("InterlockedMin", AST.UnsignedIntTy,
+                                        "__builtin_hlsl_interlocked_min");
   addByteAddressBufferInterlockedMethod("InterlockedOr", AST.UnsignedIntTy,
                                         "__builtin_hlsl_interlocked_or");
   addByteAddressBufferInterlockedMethod("InterlockedXor", AST.UnsignedIntTy,
@@ -1685,6 +1689,11 @@ BuiltinTypeDeclBuilder::addByteAddressBufferInterlockedMethods() {
     addByteAddressBufferInterlockedMethod("InterlockedAdd64",
                                           AST.UnsignedLongTy,
                                           "__builtin_hlsl_interlocked_add");
+    addByteAddressBufferInterlockedMethod("InterlockedMin64", AST.LongTy,
+                                          "__builtin_hlsl_interlocked_min");
+    addByteAddressBufferInterlockedMethod("InterlockedMin64",
+                                          AST.UnsignedLongTy,
+                                          "__builtin_hlsl_interlocked_min");
     addByteAddressBufferInterlockedMethod("InterlockedOr64", AST.UnsignedLongTy,
                                           "__builtin_hlsl_interlocked_or");
     addByteAddressBufferInterlockedMethod("InterlockedXor64",

--- a/clang/lib/Sema/HLSLExternalSemaSource.cpp
+++ b/clang/lib/Sema/HLSLExternalSemaSource.cpp
@@ -841,6 +841,8 @@ static void defineHLSLInterlockedFunc(Sema &S, NamespaceDecl *NS,
 void HLSLExternalSemaSource::defineHLSLAtomicIntrinsics() {
   defineHLSLInterlockedFunc(*SemaPtr, HLSLNamespace, "InterlockedAdd",
                             "__builtin_hlsl_interlocked_add");
+  defineHLSLInterlockedFunc(*SemaPtr, HLSLNamespace, "InterlockedMin",
+                            "__builtin_hlsl_interlocked_min");
   defineHLSLInterlockedFunc(*SemaPtr, HLSLNamespace, "InterlockedOr",
                             "__builtin_hlsl_interlocked_or");
   defineHLSLInterlockedFunc(*SemaPtr, HLSLNamespace, "InterlockedXor",

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -4642,6 +4642,7 @@ bool SemaHLSL::CheckBuiltinFunctionCall(unsigned BuiltinID, CallExpr *TheCall) {
     break;
   }
   case Builtin::BI__builtin_hlsl_interlocked_add:
+  case Builtin::BI__builtin_hlsl_interlocked_min:
   case Builtin::BI__builtin_hlsl_interlocked_or:
   case Builtin::BI__builtin_hlsl_interlocked_xor: {
     // The builtin's prototype in Builtins.td is `void (...)`, so direct calls

--- a/clang/test/CodeGenHLSL/builtins/InterlockedMin.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/InterlockedMin.hlsl
@@ -1,0 +1,74 @@
+// RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -triple \
+// RUN:   dxil-pc-shadermodel6.6-library %s -emit-llvm -disable-llvm-passes -o - | \
+// RUN:   FileCheck %s --check-prefixes=CHECK,DXCHECK
+
+// RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -triple \
+// RUN:   spirv-pc-vulkan-library %s -emit-llvm -disable-llvm-passes -o - | \
+// RUN:   FileCheck %s --check-prefixes=CHECK,SPVCHECK
+
+// Test signed and unsigned lowering of HLSL InterlockedMin.
+
+groupshared int gs_i32;
+groupshared uint gs_u32;
+groupshared int64_t gs_i64;
+groupshared uint64_t gs_u64;
+
+// CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_int_2arg
+// DXCHECK:  atomicrmw min ptr addrspace(3) {{.*}}@gs_i32{{.*}}, i32 %{{.*}} syncscope("workgroup") monotonic
+// SPVCHECK: atomicrmw min ptr addrspace(3) {{.*}}@gs_i32{{.*}}, i32 %{{.*}} syncscope("workgroup") monotonic
+export void test_int_2arg(int v) {
+  InterlockedMin(gs_i32, v);
+}
+
+// CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_uint_2arg
+// DXCHECK:  atomicrmw umin ptr addrspace(3) {{.*}}@gs_u32{{.*}}, i32 %{{.*}} syncscope("workgroup") monotonic
+// SPVCHECK: atomicrmw umin ptr addrspace(3) {{.*}}@gs_u32{{.*}}, i32 %{{.*}} syncscope("workgroup") monotonic
+export void test_uint_2arg(uint v) {
+  InterlockedMin(gs_u32, v);
+}
+
+// CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_int_3arg
+// DXCHECK:  %[[R:.*]] = atomicrmw min ptr addrspace(3) {{.*}}@gs_i32{{.*}}, i32 %{{.*}} syncscope("workgroup") monotonic
+// SPVCHECK: %[[R:.*]] = atomicrmw min ptr addrspace(3) {{.*}}@gs_i32{{.*}}, i32 %{{.*}} syncscope("workgroup") monotonic
+// CHECK:    store i32 %[[R]], ptr {{.*}}
+export void test_int_3arg(int v, out int orig) {
+  InterlockedMin(gs_i32, v, orig);
+}
+
+// CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_uint_3arg
+// DXCHECK:  %[[R:.*]] = atomicrmw umin ptr addrspace(3) {{.*}}@gs_u32{{.*}}, i32 %{{.*}} syncscope("workgroup") monotonic
+// SPVCHECK: %[[R:.*]] = atomicrmw umin ptr addrspace(3) {{.*}}@gs_u32{{.*}}, i32 %{{.*}} syncscope("workgroup") monotonic
+// CHECK:    store i32 %[[R]], ptr {{.*}}
+export void test_uint_3arg(uint v, out uint orig) {
+  InterlockedMin(gs_u32, v, orig);
+}
+
+// CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_int64_2arg
+// DXCHECK:  atomicrmw min ptr addrspace(3) {{.*}}@gs_i64{{.*}}, i64 %{{.*}} syncscope("workgroup") monotonic
+// SPVCHECK: atomicrmw min ptr addrspace(3) {{.*}}@gs_i64{{.*}}, i64 %{{.*}} syncscope("workgroup") monotonic
+export void test_int64_2arg(int64_t v) {
+  InterlockedMin(gs_i64, v);
+}
+
+// CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_uint64_2arg
+// DXCHECK:  atomicrmw umin ptr addrspace(3) {{.*}}@gs_u64{{.*}}, i64 %{{.*}} syncscope("workgroup") monotonic
+// SPVCHECK: atomicrmw umin ptr addrspace(3) {{.*}}@gs_u64{{.*}}, i64 %{{.*}} syncscope("workgroup") monotonic
+export void test_uint64_2arg(uint64_t v) {
+  InterlockedMin(gs_u64, v);
+}
+
+// CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_int64_3arg
+// DXCHECK:  %[[R:.*]] = atomicrmw min ptr addrspace(3) {{.*}}@gs_i64{{.*}}, i64 %{{.*}} syncscope("workgroup") monotonic
+// SPVCHECK: %[[R:.*]] = atomicrmw min ptr addrspace(3) {{.*}}@gs_i64{{.*}}, i64 %{{.*}} syncscope("workgroup") monotonic
+// CHECK:    store i64 %[[R]], ptr {{.*}}
+export void test_int64_3arg(int64_t v, out int64_t orig) {
+  InterlockedMin(gs_i64, v, orig);
+}
+
+// CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_uint64_3arg
+// DXCHECK:  %[[R:.*]] = atomicrmw umin ptr addrspace(3) {{.*}}@gs_u64{{.*}}, i64 %{{.*}} syncscope("workgroup") monotonic
+// SPVCHECK: %[[R:.*]] = atomicrmw umin ptr addrspace(3) {{.*}}@gs_u64{{.*}}, i64 %{{.*}} syncscope("workgroup") monotonic
+// CHECK:    store i64 %[[R]], ptr {{.*}}
+export void test_uint64_3arg(uint64_t v, out uint64_t orig) {
+  InterlockedMin(gs_u64, v, orig);
+}

--- a/clang/test/CodeGenHLSL/builtins/RWBuffer-Interlocked.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/RWBuffer-Interlocked.hlsl
@@ -6,8 +6,8 @@
 // RUN:   spirv-pc-vulkan1.3-compute %s -emit-llvm -o - | \
 // RUN:   FileCheck %s --check-prefixes=CHECK,SPVCHECK
 
-// Regression coverage for free-function InterlockedAdd/InterlockedOr on a
-// typed resource subscript (RWBuffer<int>[i]). This exercises the
+// Regression coverage for free-function interlocked operations on a typed
+// resource subscript (RWBuffer<int>[i]). This exercises the
 // LangAS::hlsl_device branch of the dest-argument address-space check in
 // SemaHLSL and ensures the atomicrmw is emitted on the pointer returned by
 // resource.getpointer for a TypedBuffer (as opposed to the RawBuffer path
@@ -23,16 +23,21 @@ RWBuffer<int> Out : register(u0);
 // DXCHECK:  atomicrmw or ptr %[[PTR2]], i32 1 syncscope("device") monotonic
 // DXCHECK:  %[[PTR3:.*]] = call {{.*}} @llvm.dx.resource.getpointer.p0.tdx.TypedBuffer_i32_1_0_1t.i32(target("dx.TypedBuffer", i32, 1, 0, 1) %{{.*}}, i32 %{{.*}})
 // DXCHECK:  atomicrmw xor ptr %[[PTR3]], i32 1 syncscope("device") monotonic
+// DXCHECK:  %[[PTR4:.*]] = call {{.*}} @llvm.dx.resource.getpointer.p0.tdx.TypedBuffer_i32_1_0_1t.i32(target("dx.TypedBuffer", i32, 1, 0, 1) %{{.*}}, i32 %{{.*}})
+// DXCHECK:  atomicrmw min ptr %[[PTR4]], i32 1 syncscope("device") monotonic
 // SPVCHECK: %[[PTR1:.*]] = call {{.*}} @llvm.spv.resource.getpointer.{{.*}}(target("spirv.{{Image|SignedImage}}", i32, {{.*}}) %{{.*}}, i32 %{{.*}})
 // SPVCHECK: atomicrmw add ptr addrspace(11) %[[PTR1]], i32 1 syncscope("device") monotonic
 // SPVCHECK: %[[PTR2:.*]] = call {{.*}} @llvm.spv.resource.getpointer.{{.*}}(target("spirv.{{Image|SignedImage}}", i32, {{.*}}) %{{.*}}, i32 %{{.*}})
 // SPVCHECK: atomicrmw or ptr addrspace(11) %[[PTR2]], i32 1 syncscope("device") monotonic
 // SPVCHECK: %[[PTR3:.*]] = call {{.*}} @llvm.spv.resource.getpointer.{{.*}}(target("spirv.{{Image|SignedImage}}", i32, {{.*}}) %{{.*}}, i32 %{{.*}})
 // SPVCHECK: atomicrmw xor ptr addrspace(11) %[[PTR3]], i32 1 syncscope("device") monotonic
+// SPVCHECK: %[[PTR4:.*]] = call {{.*}} @llvm.spv.resource.getpointer.{{.*}}(target("spirv.{{Image|SignedImage}}", i32, {{.*}}) %{{.*}}, i32 %{{.*}})
+// SPVCHECK: atomicrmw min ptr addrspace(11) %[[PTR4]], i32 1 syncscope("device") monotonic
 [shader("compute")]
 [numthreads(1,1,1)]
 void main(uint3 id : SV_DispatchThreadID) {
   InterlockedAdd(Out[id.x], 1);
   InterlockedOr(Out[id.x], 1);
   InterlockedXor(Out[id.x], 1);
+  InterlockedMin(Out[id.x], 1);
 }

--- a/clang/test/CodeGenHLSL/builtins/RWBuffer-Interlocked.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/RWBuffer-Interlocked.hlsl
@@ -7,14 +7,18 @@
 // RUN:   FileCheck %s --check-prefixes=CHECK,SPVCHECK
 
 // Regression coverage for free-function interlocked operations on a typed
-// resource subscript (RWBuffer<int>[i]). This exercises the
+// resource subscript (RWBuffer<T>[i]). This exercises the
 // LangAS::hlsl_device branch of the dest-argument address-space check in
 // SemaHLSL and ensures the atomicrmw is emitted on the pointer returned by
 // resource.getpointer for a TypedBuffer (as opposed to the RawBuffer path
-// covered by the ByteAddressBuffer tests). Add new intrinsics here as more
+// covered by the ByteAddressBuffer tests). InterlockedMin is called once on
+// a signed buffer and once on an unsigned buffer so that the signed/unsigned
+// atomicrmw selection is pinned to an exactly-named resource handle type
+// (spirv.SignedImage vs spirv.Image). Add new intrinsics here as more
 // InterlockedX operations gain resource support.
 
 RWBuffer<int> Out : register(u0);
+RWBuffer<uint> UOut : register(u1);
 
 // CHECK-LABEL: define void @main
 // DXCHECK:  %[[PTR1:.*]] = call {{.*}} @llvm.dx.resource.getpointer.p0.tdx.TypedBuffer_i32_1_0_1t.i32(target("dx.TypedBuffer", i32, 1, 0, 1) %{{.*}}, i32 %{{.*}})
@@ -25,14 +29,18 @@ RWBuffer<int> Out : register(u0);
 // DXCHECK:  atomicrmw xor ptr %[[PTR3]], i32 1 syncscope("device") monotonic
 // DXCHECK:  %[[PTR4:.*]] = call {{.*}} @llvm.dx.resource.getpointer.p0.tdx.TypedBuffer_i32_1_0_1t.i32(target("dx.TypedBuffer", i32, 1, 0, 1) %{{.*}}, i32 %{{.*}})
 // DXCHECK:  atomicrmw min ptr %[[PTR4]], i32 1 syncscope("device") monotonic
-// SPVCHECK: %[[PTR1:.*]] = call {{.*}} @llvm.spv.resource.getpointer.{{.*}}(target("spirv.{{Image|SignedImage}}", i32, {{.*}}) %{{.*}}, i32 %{{.*}})
+// DXCHECK:  %[[PTR5:.*]] = call {{.*}} @llvm.dx.resource.getpointer.p0.tdx.TypedBuffer_i32_1_0_0t.i32(target("dx.TypedBuffer", i32, 1, 0, 0) %{{.*}}, i32 %{{.*}})
+// DXCHECK:  atomicrmw umin ptr %[[PTR5]], i32 1 syncscope("device") monotonic
+// SPVCHECK: %[[PTR1:.*]] = call {{.*}} @llvm.spv.resource.getpointer.{{.*}}(target("spirv.SignedImage", i32, {{.*}}) %{{.*}}, i32 %{{.*}})
 // SPVCHECK: atomicrmw add ptr addrspace(11) %[[PTR1]], i32 1 syncscope("device") monotonic
-// SPVCHECK: %[[PTR2:.*]] = call {{.*}} @llvm.spv.resource.getpointer.{{.*}}(target("spirv.{{Image|SignedImage}}", i32, {{.*}}) %{{.*}}, i32 %{{.*}})
+// SPVCHECK: %[[PTR2:.*]] = call {{.*}} @llvm.spv.resource.getpointer.{{.*}}(target("spirv.SignedImage", i32, {{.*}}) %{{.*}}, i32 %{{.*}})
 // SPVCHECK: atomicrmw or ptr addrspace(11) %[[PTR2]], i32 1 syncscope("device") monotonic
-// SPVCHECK: %[[PTR3:.*]] = call {{.*}} @llvm.spv.resource.getpointer.{{.*}}(target("spirv.{{Image|SignedImage}}", i32, {{.*}}) %{{.*}}, i32 %{{.*}})
+// SPVCHECK: %[[PTR3:.*]] = call {{.*}} @llvm.spv.resource.getpointer.{{.*}}(target("spirv.SignedImage", i32, {{.*}}) %{{.*}}, i32 %{{.*}})
 // SPVCHECK: atomicrmw xor ptr addrspace(11) %[[PTR3]], i32 1 syncscope("device") monotonic
-// SPVCHECK: %[[PTR4:.*]] = call {{.*}} @llvm.spv.resource.getpointer.{{.*}}(target("spirv.{{Image|SignedImage}}", i32, {{.*}}) %{{.*}}, i32 %{{.*}})
+// SPVCHECK: %[[PTR4:.*]] = call {{.*}} @llvm.spv.resource.getpointer.{{.*}}(target("spirv.SignedImage", i32, {{.*}}) %{{.*}}, i32 %{{.*}})
 // SPVCHECK: atomicrmw min ptr addrspace(11) %[[PTR4]], i32 1 syncscope("device") monotonic
+// SPVCHECK: %[[PTR5:.*]] = call {{.*}} @llvm.spv.resource.getpointer.{{.*}}(target("spirv.Image", i32, {{.*}}) %{{.*}}, i32 %{{.*}})
+// SPVCHECK: atomicrmw umin ptr addrspace(11) %[[PTR5]], i32 1 syncscope("device") monotonic
 [shader("compute")]
 [numthreads(1,1,1)]
 void main(uint3 id : SV_DispatchThreadID) {
@@ -40,4 +48,5 @@ void main(uint3 id : SV_DispatchThreadID) {
   InterlockedOr(Out[id.x], 1);
   InterlockedXor(Out[id.x], 1);
   InterlockedMin(Out[id.x], 1);
+  InterlockedMin(UOut[id.x], 1u);
 }

--- a/clang/test/CodeGenHLSL/builtins/RWByteAddressBuffer-InterlockedMin.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/RWByteAddressBuffer-InterlockedMin.hlsl
@@ -1,0 +1,92 @@
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -triple \
+// RUN:   dxil-pc-shadermodel6.6-library %s -emit-llvm -disable-llvm-passes -o - | \
+// RUN:   FileCheck %s --check-prefixes=CHECK,DXCHECK
+
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -triple \
+// RUN:   spirv-pc-vulkan1.3-library %s -emit-llvm -disable-llvm-passes -o - | \
+// RUN:   FileCheck %s --check-prefixes=CHECK,SPVCHECK
+
+// Test that the signed and unsigned RWByteAddressBuffer::InterlockedMin and
+// InterlockedMin64 methods lower through a resource pointer.
+
+RWByteAddressBuffer BAB : register(u0);
+
+// CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_bab_int
+// DXCHECK:  %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_0t.i32({{.*}})
+// DXCHECK:  atomicrmw min ptr %[[PTR]], i32 %{{.*}} syncscope("device") monotonic
+// SPVCHECK: %[[PTR:.*]] = call ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0i8_12_1t.i32({{.*}})
+// SPVCHECK: atomicrmw min ptr addrspace(11) %[[PTR]], i32 %{{.*}} syncscope("device") monotonic
+export void test_bab_int(uint off, int v) {
+  BAB.InterlockedMin(off, v);
+}
+
+// CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_bab_uint
+// DXCHECK:  %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_0t.i32({{.*}})
+// DXCHECK:  atomicrmw umin ptr %[[PTR]], i32 %{{.*}} syncscope("device") monotonic
+// SPVCHECK: %[[PTR:.*]] = call ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0i8_12_1t.i32({{.*}})
+// SPVCHECK: atomicrmw umin ptr addrspace(11) %[[PTR]], i32 %{{.*}} syncscope("device") monotonic
+export void test_bab_uint(uint off, uint v) {
+  BAB.InterlockedMin(off, v);
+}
+
+// CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_bab_int_orig
+// DXCHECK:  %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_0t.i32({{.*}})
+// DXCHECK:  %[[R:.*]] = atomicrmw min ptr %[[PTR]], i32 %{{.*}} syncscope("device") monotonic
+// DXCHECK:  store i32 %[[R]], ptr {{.*}}
+// SPVCHECK: %[[PTR:.*]] = call ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0i8_12_1t.i32({{.*}})
+// SPVCHECK: %[[R:.*]] = atomicrmw min ptr addrspace(11) %[[PTR]], i32 %{{.*}} syncscope("device") monotonic
+// SPVCHECK: store i32 %[[R]], ptr {{.*}}
+export void test_bab_int_orig(uint off, int v, out int orig) {
+  BAB.InterlockedMin(off, v, orig);
+}
+
+// CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_bab_uint_orig
+// DXCHECK:  %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_0t.i32({{.*}})
+// DXCHECK:  %[[R:.*]] = atomicrmw umin ptr %[[PTR]], i32 %{{.*}} syncscope("device") monotonic
+// DXCHECK:  store i32 %[[R]], ptr {{.*}}
+// SPVCHECK: %[[PTR:.*]] = call ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0i8_12_1t.i32({{.*}})
+// SPVCHECK: %[[R:.*]] = atomicrmw umin ptr addrspace(11) %[[PTR]], i32 %{{.*}} syncscope("device") monotonic
+// SPVCHECK: store i32 %[[R]], ptr {{.*}}
+export void test_bab_uint_orig(uint off, uint v, out uint orig) {
+  BAB.InterlockedMin(off, v, orig);
+}
+
+// CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_bab_int64
+// DXCHECK:  %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_0t.i32({{.*}})
+// DXCHECK:  atomicrmw min ptr %[[PTR]], i64 %{{.*}} syncscope("device") monotonic
+// SPVCHECK: %[[PTR:.*]] = call ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0i8_12_1t.i32({{.*}})
+// SPVCHECK: atomicrmw min ptr addrspace(11) %[[PTR]], i64 %{{.*}} syncscope("device") monotonic
+export void test_bab_int64(uint off, int64_t v) {
+  BAB.InterlockedMin64(off, v);
+}
+
+// CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_bab_uint64
+// DXCHECK:  %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_0t.i32({{.*}})
+// DXCHECK:  atomicrmw umin ptr %[[PTR]], i64 %{{.*}} syncscope("device") monotonic
+// SPVCHECK: %[[PTR:.*]] = call ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0i8_12_1t.i32({{.*}})
+// SPVCHECK: atomicrmw umin ptr addrspace(11) %[[PTR]], i64 %{{.*}} syncscope("device") monotonic
+export void test_bab_uint64(uint off, uint64_t v) {
+  BAB.InterlockedMin64(off, v);
+}
+
+// CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_bab_int64_orig
+// DXCHECK:  %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_0t.i32({{.*}})
+// DXCHECK:  %[[R:.*]] = atomicrmw min ptr %[[PTR]], i64 %{{.*}} syncscope("device") monotonic
+// DXCHECK:  store i64 %[[R]], ptr {{.*}}
+// SPVCHECK: %[[PTR:.*]] = call ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0i8_12_1t.i32({{.*}})
+// SPVCHECK: %[[R:.*]] = atomicrmw min ptr addrspace(11) %[[PTR]], i64 %{{.*}} syncscope("device") monotonic
+// SPVCHECK: store i64 %[[R]], ptr {{.*}}
+export void test_bab_int64_orig(uint off, int64_t v, out int64_t orig) {
+  BAB.InterlockedMin64(off, v, orig);
+}
+
+// CHECK-LABEL: define {{(dso_local |hidden |internal |protected |spir_func )*}}void @{{.*}}test_bab_uint64_orig
+// DXCHECK:  %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_0t.i32({{.*}})
+// DXCHECK:  %[[R:.*]] = atomicrmw umin ptr %[[PTR]], i64 %{{.*}} syncscope("device") monotonic
+// DXCHECK:  store i64 %[[R]], ptr {{.*}}
+// SPVCHECK: %[[PTR:.*]] = call ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0i8_12_1t.i32({{.*}})
+// SPVCHECK: %[[R:.*]] = atomicrmw umin ptr addrspace(11) %[[PTR]], i64 %{{.*}} syncscope("device") monotonic
+// SPVCHECK: store i64 %[[R]], ptr {{.*}}
+export void test_bab_uint64_orig(uint off, uint64_t v, out uint64_t orig) {
+  BAB.InterlockedMin64(off, v, orig);
+}

--- a/clang/test/CodeGenHLSL/builtins/RasterizerOrderedByteAddressBuffer-InterlockedMin.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/RasterizerOrderedByteAddressBuffer-InterlockedMin.hlsl
@@ -1,0 +1,37 @@
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -triple \
+// RUN:   dxil-pc-shadermodel6.6-library %s -emit-llvm -disable-llvm-passes -o - | \
+// RUN:   FileCheck %s --check-prefixes=CHECK,DXCHECK
+
+// SPIR-V codegen for RasterizerOrderedByteAddressBuffer is not implemented.
+
+RasterizerOrderedByteAddressBuffer ROVB : register(u1);
+
+// CHECK-LABEL: define void @{{.*}}test_rovb_int
+// DXCHECK: %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_1t.i32({{.*}})
+// DXCHECK: atomicrmw min ptr %[[PTR]], i32 %{{.*}} syncscope("device") monotonic
+export void test_rovb_int(uint off, int v) {
+  ROVB.InterlockedMin(off, v);
+}
+
+// CHECK-LABEL: define void @{{.*}}test_rovb_uint_orig
+// DXCHECK: %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_1t.i32({{.*}})
+// DXCHECK: %[[R:.*]] = atomicrmw umin ptr %[[PTR]], i32 %{{.*}} syncscope("device") monotonic
+// DXCHECK: store i32 %[[R]], ptr {{.*}}
+export void test_rovb_uint_orig(uint off, uint v, out uint orig) {
+  ROVB.InterlockedMin(off, v, orig);
+}
+
+// CHECK-LABEL: define void @{{.*}}test_rovb_int64
+// DXCHECK: %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_1t.i32({{.*}})
+// DXCHECK: atomicrmw min ptr %[[PTR]], i64 %{{.*}} syncscope("device") monotonic
+export void test_rovb_int64(uint off, int64_t v) {
+  ROVB.InterlockedMin64(off, v);
+}
+
+// CHECK-LABEL: define void @{{.*}}test_rovb_uint64_orig
+// DXCHECK: %[[PTR:.*]] = call ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i8_1_1t.i32({{.*}})
+// DXCHECK: %[[R:.*]] = atomicrmw umin ptr %[[PTR]], i64 %{{.*}} syncscope("device") monotonic
+// DXCHECK: store i64 %[[R]], ptr {{.*}}
+export void test_rovb_uint64_orig(uint off, uint64_t v, out uint64_t orig) {
+  ROVB.InterlockedMin64(off, v, orig);
+}

--- a/clang/test/SemaHLSL/BuiltIns/ByteAddressBuffer-InterlockedMin-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/ByteAddressBuffer-InterlockedMin-errors.hlsl
@@ -1,0 +1,34 @@
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header \
+// RUN:   -triple dxil-pc-shadermodel6.6-library %s -fsyntax-only -verify \
+// RUN:   -verify-ignore-unexpected=note,warning
+
+RWByteAddressBuffer BAB : register(u0);
+RasterizerOrderedByteAddressBuffer ROVB : register(u1);
+
+struct S { int x; };
+
+void too_few(uint off) {
+  BAB.InterlockedMin(off);
+  // expected-error@-1 {{no matching member function for call to 'InterlockedMin'}}
+}
+
+void too_many(uint off, int v, int extra) {
+  int orig;
+  BAB.InterlockedMin(off, v, orig, extra);
+  // expected-error@-1 {{no matching member function for call to 'InterlockedMin'}}
+}
+
+void struct_value(uint off, S v) {
+  BAB.InterlockedMin(off, v);
+  // expected-error@-1 {{no matching member function for call to 'InterlockedMin'}}
+}
+
+void rovb_too_few(uint off) {
+  ROVB.InterlockedMin(off);
+  // expected-error@-1 {{no matching member function for call to 'InterlockedMin'}}
+}
+
+void rovb_struct_value(uint off, S v) {
+  ROVB.InterlockedMin(off, v);
+  // expected-error@-1 {{no matching member function for call to 'InterlockedMin'}}
+}

--- a/clang/test/SemaHLSL/BuiltIns/ByteAddressBuffer-InterlockedMin-sm65-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/ByteAddressBuffer-InterlockedMin-sm65-errors.hlsl
@@ -1,0 +1,26 @@
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header \
+// RUN:   -triple dxil-pc-shadermodel6.5-library %s -fsyntax-only -verify \
+// RUN:   -verify-ignore-unexpected=warning
+
+RWByteAddressBuffer BAB : register(u0);
+RasterizerOrderedByteAddressBuffer ROVB : register(u1);
+
+void sm65_no_bab_min64(uint off, int64_t v) {
+  BAB.InterlockedMin64(off, v);
+  // expected-error@-1 {{no member named 'InterlockedMin64' in 'hlsl::RWByteAddressBuffer'}}
+}
+
+void sm65_no_rovb_min64(uint off, int64_t v) {
+  ROVB.InterlockedMin64(off, v);
+  // expected-error@-1 {{no member named 'InterlockedMin64' in 'hlsl::RasterizerOrderedByteAddressBuffer'}}
+}
+
+void sm65_bab_min32_ok(uint off, int v) {
+  BAB.InterlockedMin(off, v);
+}
+
+groupshared int64_t gs_i64;
+void sm65_direct_builtin(int64_t v) {
+  __builtin_hlsl_interlocked_min(gs_i64, v);
+  // expected-error@-1 {{'__builtin_hlsl_interlocked_min' requires shader model 6.6 or newer}}
+}

--- a/clang/test/SemaHLSL/BuiltIns/InterlockedMin-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/InterlockedMin-errors.hlsl
@@ -1,0 +1,89 @@
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header \
+// RUN:   -triple dxil-pc-shadermodel6.6-library %s -emit-llvm-only \
+// RUN:   -disable-llvm-passes -verify
+
+// InterlockedMin is provided as a set of address-space-qualified overloads
+// (groupshared/device, {int,uint,int64_t,uint64_t}, 2-arg/3-arg).
+
+groupshared int gs_i32;
+groupshared float gs_f32;
+struct S { int x; };
+groupshared S gs_s;
+
+void too_few() {
+  InterlockedMin(gs_i32); // expected-error{{no matching function for call to 'InterlockedMin'}}
+  // expected-note@*:* 16 {{candidate function}}
+}
+
+void too_many(int v, int extra) {
+  int orig;
+  InterlockedMin(gs_i32, v, orig, extra); // expected-error{{no matching function for call to 'InterlockedMin'}}
+  // expected-note@*:* 16 {{candidate function}}
+}
+
+void local_dest(int v) {
+  int dest;
+  InterlockedMin(dest, v); // expected-error{{no matching function for call to 'InterlockedMin'}}
+  // expected-note@*:* 16 {{candidate function}}
+}
+
+void float_dest(float v) {
+  InterlockedMin(gs_f32, v); // expected-error{{no matching function for call to 'InterlockedMin'}}
+  // expected-note@*:* 16 {{candidate function}}
+}
+
+void struct_dest(int v) {
+  InterlockedMin(gs_s, v); // expected-error{{no matching function for call to 'InterlockedMin'}}
+  // expected-note@*:* 16 {{candidate function}}
+}
+
+void mismatched_orig_type(int v) {
+  uint orig;
+  InterlockedMin(gs_i32, v, orig); // expected-error{{no matching function for call to 'InterlockedMin'}}
+  // expected-note@*:* 16 {{candidate function}}
+}
+
+void direct_too_few() {
+  __builtin_hlsl_interlocked_min(gs_i32);
+  // expected-error@-1 {{too few arguments to function call, expected at least 2, have 1}}
+}
+
+void direct_too_many(int v, int extra) {
+  int orig;
+  __builtin_hlsl_interlocked_min(gs_i32, v, orig, extra);
+  // expected-error@-1 {{too many arguments to function call, expected at most 3, have 4}}
+}
+
+void direct_non_integer_dest() {
+  S local_s;
+  __builtin_hlsl_interlocked_min(local_s, 1);
+  // expected-error@-1 {{1st argument must be a scalar integer type (was 'S')}}
+}
+
+void direct_nonlvalue_dest(int v) {
+  __builtin_hlsl_interlocked_min(1, v);
+  // expected-error@-1 {{cannot bind non-lvalue argument '1' to out parameter}}
+}
+
+void direct_mismatched_value() {
+  uint value = 1;
+  __builtin_hlsl_interlocked_min(gs_i32, value);
+  // expected-error@-1 {{passing 'uint' (aka 'unsigned int') to parameter of incompatible type 'int'}}
+}
+
+void direct_mismatched_orig(int v) {
+  uint orig;
+  __builtin_hlsl_interlocked_min(gs_i32, v, orig);
+  // expected-error@-1 {{passing 'uint' (aka 'unsigned int') to parameter of incompatible type 'int'}}
+}
+
+void direct_nonlvalue_orig(int v) {
+  __builtin_hlsl_interlocked_min(gs_i32, v, 1);
+  // expected-error@-1 {{cannot bind non-lvalue argument '1' to out parameter}}
+}
+
+void direct_default_as_dest(int v) {
+  int local;
+  __builtin_hlsl_interlocked_min(local, v);
+  // expected-error@-1 {{1st argument to atomic builtin must reference groupshared or device memory (was 'int')}}
+}


### PR DESCRIPTION
This PR adds the `InterlockedMin` standalone function and resource methods.

Fixes: https://github.com/llvm/llvm-project/issues/99123
Assisted by: Github Copilot