### PR TITLE
[include-cleaner] Avoid reporting redundant ObjC method and property decls

### DIFF
--- a/clang-tools-extra/include-cleaner/lib/WalkAST.cpp
+++ b/clang-tools-extra/include-cleaner/lib/WalkAST.cpp
@@ -460,29 +460,80 @@ public:
     return true;
   }
 
+  /// Determines whether a protocol is already covered by the receiver's type,
+  /// either through adopted protocol qualifiers (e.g. `id<Proto>` or an
+  /// inheriting sub-protocol) or through class conformance on the receiver
+  /// interface (e.g. `MyClass <Proto>`).
+  bool IsProtocolCoveredByReceiver(ObjCProtocolDecl *Proto,
+                                   const ObjCObjectPointerType *ObjCPtr,
+                                   ObjCInterfaceDecl *IFace) {
+    if (ObjCPtr) {
+      ASTContext &Ctx = Proto->getASTContext();
+      for (auto *ReceiverProto : ObjCPtr->quals())
+        if (Ctx.ProtocolCompatibleWithProtocol(Proto, ReceiverProto))
+          return true;
+    }
+    return IFace && IFace->ClassImplementsProtocol(Proto, true);
+  }
+
+  void ReportMemberDecl(SourceLocation Loc, NamedDecl *Member,
+                        const ObjCObjectPointerType *ObjCPtr,
+                        ObjCInterfaceDecl *ReceiverIFace, bool IsSuperReceiver,
+                        bool IsClassReceiver) {
+    if (!Member)
+      return;
+    auto *DC = Member->getDeclContext();
+    if (auto *Cat = dyn_cast<ObjCCategoryDecl>(DC)) {
+      // Category members (methods, properties, accessors) must be reported so
+      // the category's header is included.
+      report(Loc, Cat);
+    } else if (auto *Proto = dyn_cast<ObjCProtocolDecl>(DC)) {
+      // Report the protocol member unless the receiver's type already covers
+      // conformance to this protocol.
+      if (IsSuperReceiver ||
+          !IsProtocolCoveredByReceiver(Proto, ObjCPtr, ReceiverIFace))
+        report(Loc, Member);
+    } else if (auto *IFace = dyn_cast<ObjCInterfaceDecl>(DC)) {
+      // If the member is declared on the receiver's interface or an inherited
+      // superclass, the receiver's header already provides it.
+      // Report the member explicitly only if there is no receiver interface,
+      // the interface is not an ancestor, it is a class receiver, or super is
+      // used.
+      if (!ReceiverIFace ||
+          (ReceiverIFace != IFace && !IFace->isSuperClassOf(ReceiverIFace)) ||
+          (IsClassReceiver && ReceiverIFace == IFace) || IsSuperReceiver)
+        report(Loc, Member);
+    } else {
+      report(Loc, Member);
+    }
+  }
+
   bool VisitObjCMessageExpr(ObjCMessageExpr *E) {
     auto StartLoc = E->getSelectorStartLoc();
-    // Identify the selector and the method declaration
-    if (auto *Method = E->getMethodDecl()) {
-      // Report the method as a used symbol
-      report(StartLoc, Method);
-    }
+    auto *Method = E->getMethodDecl();
+    auto *ReceiverIFace = E->getReceiverInterface();
+    const auto *ObjCPtr = E->getReceiverType()->getAs<ObjCObjectPointerType>();
+    auto ReceiverKind = E->getReceiverKind();
+    bool IsSuper = ReceiverKind == ObjCMessageExpr::SuperInstance ||
+                   ReceiverKind == ObjCMessageExpr::SuperClass;
+    bool IsClass = ReceiverKind == ObjCMessageExpr::Class;
 
-    // If it's a class message, report the interface/class as used
-    if (E->getReceiverKind() == ObjCMessageExpr::Class) {
-      if (auto *Interface = E->getReceiverInterface()) {
-        report(E->getReceiverRange().getBegin(), Interface);
+    ReportMemberDecl(StartLoc, Method, ObjCPtr, ReceiverIFace, IsSuper,
+                     IsClass);
+
+    switch (ReceiverKind) {
+    case ObjCMessageExpr::Class:
+      report(E->getReceiverRange().getBegin(), ReceiverIFace);
+      break;
+    case ObjCMessageExpr::Instance:
+    case ObjCMessageExpr::SuperInstance:
+    case ObjCMessageExpr::SuperClass:
+      report(StartLoc, ReceiverIFace, RefType::Implicit);
+      if (ObjCPtr) {
+        for (auto *Proto : ObjCPtr->quals())
+          report(StartLoc, Proto, RefType::Implicit);
       }
-      return true;
-    }
-    if (auto *Interface = E->getReceiverInterface()) {
-      report(StartLoc, Interface, RefType::Implicit);
-    }
-    QualType Type = E->getReceiverType();
-    if (const auto *ObjCPtr = Type->getAs<ObjCObjectPointerType>()) {
-      for (auto *Proto : ObjCPtr->quals()) {
-        report(StartLoc, Proto, RefType::Implicit);
-      }
+      break;
     }
     return true;
   }
@@ -493,26 +544,45 @@ public:
   }
 
   bool VisitObjCPropertyRefExpr(ObjCPropertyRefExpr *E) {
-    // Unconditionally report property declarations and their backing accessor
-    // methods. Dot-notation or pseudo-object references (`foo.bar`) require
-    // the underlying property definition or getters/setters to compile.
-    // Bypassing transient compiler state flags (isMessagingGetter/
-    // isMessagingSetter) guarantees that the declaring
-    // header keeps the properties recorded as used.
+    ObjCInterfaceDecl *ReceiverIFace = nullptr;
+    const ObjCObjectPointerType *ObjCPtr = nullptr;
+    bool IsSuper = E->isSuperReceiver();
+    bool IsClass = E->isClassReceiver();
+    auto Loc = E->getLocation();
+    if (IsClass) {
+      ReceiverIFace = E->getClassReceiver();
+      report(E->getReceiverLocation(), ReceiverIFace);
+    } else if (IsSuper) {
+      QualType SuperType = E->getSuperReceiverType();
+      if (const auto *ObjCTy = SuperType->getAs<ObjCObjectType>()) {
+        ReceiverIFace = ObjCTy->getInterface();
+        report(Loc, ReceiverIFace, RefType::Implicit);
+      }
+    } else if (E->isObjectReceiver()) {
+      QualType BaseType = E->getBase()->getType();
+      ObjCPtr = BaseType->getAs<ObjCObjectPointerType>();
+      if (ObjCPtr) {
+        ReceiverIFace = ObjCPtr->getInterfaceDecl();
+        report(Loc, ObjCPtr->getInterfaceDecl(), RefType::Implicit);
+        for (auto *Proto : ObjCPtr->quals())
+          report(Loc, Proto, RefType::Implicit);
+      }
+    }
+
+    NamedDecl *GetterDecl = nullptr;
+    NamedDecl *SetterDecl = nullptr;
     if (E->isExplicitProperty()) {
       if (auto *Prop = E->getExplicitProperty()) {
-        report(E->getLocation(), Prop);
-        if (auto *Getter = Prop->getGetterMethodDecl())
-          report(E->getLocation(), Getter);
-        if (auto *Setter = Prop->getSetterMethodDecl())
-          report(E->getLocation(), Setter);
+        ReportMemberDecl(Loc, Prop, ObjCPtr, ReceiverIFace, IsSuper, IsClass);
+        GetterDecl = Prop->getGetterMethodDecl();
+        SetterDecl = Prop->getSetterMethodDecl();
       }
     } else {
-      if (auto *Getter = E->getImplicitPropertyGetter())
-        report(E->getLocation(), Getter);
-      if (auto *Setter = E->getImplicitPropertySetter())
-        report(E->getLocation(), Setter);
+      GetterDecl = E->getImplicitPropertyGetter();
+      SetterDecl = E->getImplicitPropertySetter();
     }
+    ReportMemberDecl(Loc, GetterDecl, ObjCPtr, ReceiverIFace, IsSuper, IsClass);
+    ReportMemberDecl(Loc, SetterDecl, ObjCPtr, ReceiverIFace, IsSuper, IsClass);
     return true;
   }
 

--- a/clang-tools-extra/include-cleaner/unittests/WalkASTTest.cpp
+++ b/clang-tools-extra/include-cleaner/unittests/WalkASTTest.cpp
@@ -607,7 +607,7 @@ TEST(WalkAST, ObjCImplementationDeclDependsOnInterface) {
 TEST(WalkAST, ObjCMessageExprSelectorLoc) {
   testWalk(R"objc(
     @interface $implicit^MyClass
-    $explicit^- (void)doSomething;
+    - (void)doSomething;
     @end
   )objc",
            R"objc(
@@ -618,10 +618,58 @@ TEST(WalkAST, ObjCMessageExprSelectorLoc) {
            {"-x", "objective-c"});
 }
 
+TEST(WalkAST, ObjCMessageExprInheritedMethod) {
+  testWalk(R"objc(
+    @interface BaseClass
+    - (void)baseMethod;
+    @end
+    @interface $implicit^DerivedClass : BaseClass
+    @end
+  )objc",
+           R"objc(
+    void test(DerivedClass *obj) {
+      [obj ^baseMethod];
+    }
+  )objc",
+           {"-x", "objective-c"});
+}
+
+TEST(WalkAST, ObjCMessageExprInheritedClassMethod) {
+  testWalk(R"objc(
+    @interface BaseClass
+    + (instancetype)message;
+    @end
+    @interface $explicit^DerivedClass : BaseClass
+    @end
+  )objc",
+           R"objc(
+    void test() {
+      [^DerivedClass message];
+    }
+  )objc",
+           {"-x", "objective-c"});
+}
+
+TEST(WalkAST, ObjCMessageExprCategoryMethod) {
+  testWalk(R"objc(
+    @interface $implicit^MyClass
+    @end
+    @interface $explicit^MyClass (MyCategory)
+    - (void)categoryMethod;
+    @end
+  )objc",
+           R"objc(
+    void test(MyClass *obj) {
+      [obj ^categoryMethod];
+    }
+  )objc",
+           {"-x", "objective-c"});
+}
+
 TEST(WalkAST, ObjCMessageExprSelectorLocProtocol) {
   testWalk(R"objc(
     @protocol $implicit^MyProtocol
-    $explicit^- (void)doSomething;
+    - (void)doSomething;
     @end
   )objc",
            R"objc(
@@ -635,7 +683,7 @@ TEST(WalkAST, ObjCMessageExprSelectorLocProtocol) {
 TEST(WalkAST, ObjCMessageExprSelectorLocNestedProtocol) {
   testWalk(R"objc(
     @protocol FirstProtocol
-        $explicit^- (void)doSomething;
+    - (void)doSomething;
     @end
     @protocol $implicit^SecondProtocol <FirstProtocol>
     @end
@@ -653,7 +701,7 @@ TEST(WalkAST, ObjCMessageExprSelectorLocMultipleProtocol) {
     @protocol $implicit^FirstProtocol
     @end
     @protocol $implicit^SecondProtocol
-      $explicit^- (void)doSomething;
+    - (void)doSomething;
     @end
   )objc",
            R"objc(
@@ -664,10 +712,40 @@ TEST(WalkAST, ObjCMessageExprSelectorLocMultipleProtocol) {
            {"-x", "objective-c"});
 }
 
+TEST(WalkAST, ObjCMessageExprSelectorLocUntypedId) {
+  testWalk(R"objc(
+    @protocol MyProtocol
+    $explicit^- (void)doSomething;
+    @end
+  )objc",
+           R"objc(
+    void test(id obj) {
+      [obj ^doSomething];
+    }
+  )objc",
+           {"-x", "objective-c"});
+}
+
+TEST(WalkAST, ObjCMessageExprClassConformsToProtocol) {
+  testWalk(R"objc(
+    @protocol MyProtocol
+    - (void)doSomething;
+    @end
+    @interface $implicit^MyClass <MyProtocol>
+    @end
+  )objc",
+           R"objc(
+    void test(MyClass *obj) {
+      [obj ^doSomething];
+    }
+  )objc",
+           {"-x", "objective-c"});
+}
+
 TEST(WalkAST, ObjCMessageExprSelectorMessageChaining) {
   testWalk(R"objc(
     @interface $implicit^MyClass
-    $explicit^- (void)doSomething;
+    - (void)doSomething;
     @end
     @interface WrapperClass
     - (MyClass *)myClass;
@@ -699,7 +777,39 @@ TEST(WalkAST, ObjCMessageExprClassReceiver) {
 TEST(WalkAST, ObjCPropertyRefExprExplicit) {
   testWalk(R"objc(
     @interface $implicit^MyClass
-    @property(nonatomic) int $explicit^foo;
+    @property(nonatomic) int foo;
+    @end
+  )objc",
+           R"objc(
+    void test(MyClass *obj) {
+      int x = obj.^foo;
+    }
+  )objc",
+           {"-x", "objective-c"});
+}
+
+TEST(WalkAST, ObjCPropertyRefExprInherited) {
+  testWalk(R"objc(
+    @interface BaseClass
+    @property(nonatomic) int foo;
+    @end
+    @interface $implicit^DerivedClass : BaseClass
+    @end
+  )objc",
+           R"objc(
+    void test(DerivedClass *obj) {
+      int x = obj.^foo;
+    }
+  )objc",
+           {"-x", "objective-c"});
+}
+
+TEST(WalkAST, ObjCPropertyRefExprCategory) {
+  testWalk(R"objc(
+    @interface $implicit^MyClass
+    @end
+    @interface $explicit^MyClass (MyCategory)
+    @property(nonatomic) int foo;
     @end
   )objc",
            R"objc(
@@ -713,7 +823,7 @@ TEST(WalkAST, ObjCPropertyRefExprExplicit) {
 TEST(WalkAST, ObjCPropertyRefExprImplicitGetter) {
   testWalk(R"objc(
     @interface $implicit^MyClass
-    $explicit^- (int)foo;
+    - (int)foo;
     @end
   )objc",
            R"objc(
@@ -727,7 +837,7 @@ TEST(WalkAST, ObjCPropertyRefExprImplicitGetter) {
 TEST(WalkAST, ObjCPropertyRefExprImplicitSetter) {
   testWalk(R"objc(
     @interface $implicit^MyClass
-    $explicit^- (void)setFoo:(int)val;
+    - (void)setFoo:(int)val;
     @end
   )objc",
            R"objc(
@@ -741,7 +851,7 @@ TEST(WalkAST, ObjCPropertyRefExprImplicitSetter) {
 TEST(WalkAST, ObjCPropertyRefExprExplicitSetter) {
   testWalk(R"objc(
     @interface $implicit^MyClass
-    @property(nonatomic) int $explicit^foo;
+    @property(nonatomic) int foo;
     @end
   )objc",
            R"objc(
@@ -755,7 +865,7 @@ TEST(WalkAST, ObjCPropertyRefExprExplicitSetter) {
 TEST(WalkAST, ObjCPropertyRefExprDesugaredSetter) {
   testWalk(R"objc(
     @interface $implicit^MyClass
-    @property(nonatomic) int $explicit^foo;
+    @property(nonatomic) int foo;
     @end
   )objc",
            R"objc(
@@ -769,7 +879,7 @@ TEST(WalkAST, ObjCPropertyRefExprDesugaredSetter) {
 TEST(WalkAST, ObjCPropertyRefExprDesugaredGetter) {
   testWalk(R"objc(
     @interface $implicit^MyClass
-    @property(nonatomic) int $explicit^foo;
+    @property(nonatomic) int foo;
     @end
   )objc",
            R"objc(
@@ -782,13 +892,13 @@ TEST(WalkAST, ObjCPropertyRefExprDesugaredGetter) {
 
 TEST(WalkAST, ObjCPropertyRefExprDesugaredClassSetter) {
   testWalk(R"objc(
-    @interface MyClass
-    @property(class) int $explicit^foo;
+    @interface $explicit^MyClass
+    @property(class) int foo;
     @end
   )objc",
            R"objc(
     void test() {
-      [MyClass ^setFoo:42];
+      [^MyClass setFoo:42];
     }
   )objc",
            {"-x", "objective-c"});
@@ -796,13 +906,13 @@ TEST(WalkAST, ObjCPropertyRefExprDesugaredClassSetter) {
 
 TEST(WalkAST, ObjCPropertyRefExprDesugaredClassGetter) {
   testWalk(R"objc(
-    @interface MyClass
-    @property(class) int $explicit^foo;
+    @interface $explicit^MyClass
+    @property(class) int foo;
     @end
   )objc",
            R"objc(
     void test() {
-      [MyClass ^foo];
+      [^MyClass foo];
     }
   )objc",
            {"-x", "objective-c"});
@@ -811,7 +921,7 @@ TEST(WalkAST, ObjCPropertyRefExprDesugaredClassGetter) {
 TEST(WalkAST, ObjCPropertyRefExprProtocol) {
   testWalk(R"objc(
     @protocol $implicit^MyProtocol
-    @property(nonatomic) int $explicit^foo;
+    @property(nonatomic) int foo;
     @end
   )objc",
            R"objc(
@@ -825,7 +935,7 @@ TEST(WalkAST, ObjCPropertyRefExprProtocol) {
 TEST(WalkAST, ObjCPropertyRefExprNestedProtocol) {
   testWalk(R"objc(
     @protocol FirstProtocol
-    @property(nonatomic) int $explicit^foo;
+    @property(nonatomic) int foo;
     @end
     @protocol $implicit^SecondProtocol <FirstProtocol>
     @end
@@ -843,7 +953,7 @@ TEST(WalkAST, ObjCPropertyRefExprMultipleProtocol) {
     @protocol $implicit^FirstProtocol
     @end
     @protocol $implicit^SecondProtocol
-    @property(nonatomic) int $explicit^foo;
+    @property(nonatomic) int foo;
     @end
   )objc",
            R"objc(
@@ -886,6 +996,26 @@ TEST(WalkAST, ObjCPropertyRefExprSuperReceiver) {
   testWalk(R"objc(
     @interface $implicit^ParentClass
     @property(nonatomic) int $explicit^foo;
+    @end
+    @interface MyClass : ParentClass
+    @end
+  )objc",
+           R"objc(
+    @implementation MyClass
+    - (void)testSummary {
+      int x = super.^foo;
+    }
+    @end
+  )objc",
+           {"-x", "objective-c"});
+}
+
+TEST(WalkAST, ObjCPropertyRefExprSuperInherited) {
+  testWalk(R"objc(
+    @interface GrandParentClass
+    @property(nonatomic) int $explicit^foo;
+    @end
+    @interface $implicit^ParentClass : GrandParentClass
     @end
     @interface MyClass : ParentClass
     @end
@@ -1273,7 +1403,7 @@ TEST(WalkAST, ObjCSelectorExprMultiColon) {
 TEST(WalkAST, ObjCPropertyRefExprCustomGetter) {
   testWalk(R"objc(
     @interface $implicit^MyClass
-    @property(getter=isFoo, setter=setTheFoo:, nonatomic) int $explicit^foo;
+    @property(getter=isFoo, setter=setTheFoo:, nonatomic) int foo;
     @end
   )objc",
            R"objc(
@@ -1287,7 +1417,7 @@ TEST(WalkAST, ObjCPropertyRefExprCustomGetter) {
 TEST(WalkAST, ObjCPropertyRefExprCustomSetter) {
   testWalk(R"objc(
     @interface $implicit^MyClass
-    @property(getter=isFoo, setter=setTheFoo:, nonatomic) int $explicit^foo;
+    @property(getter=isFoo, setter=setTheFoo:, nonatomic) int foo;
     @end
   )objc",
            R"objc(


### PR DESCRIPTION
This change refines the AST walking logic for `ObjCMessageExpr` and `ObjCPropertyRefExpr` to avoid flagging unnecessary header dependencies. Specifically, it:

  - Avoids reporting methods or properties declared in a superclass if the receiver's interface is already known, as the receiver's header already imports the superclass.
  - Avoids reporting methods or properties from protocols if the receiver's type already explicitly conforms to or is qualified by those protocols.
  - Ensures category declarations are reported when category-defined methods or properties are used, so that the category's header is correctly included.
  - Updates and adds unit tests to cover these inheritance, protocol, and category scenarios.