### PR TITLE
[libc][bazel] Add a repo with linux kernel UAPI headers

### DIFF
--- a/utils/bazel/MODULE.bazel
+++ b/utils/bazel/MODULE.bazel
@@ -36,6 +36,7 @@ bazel_dep(name = "llvm", version = "0.8.5", dev_dependency = True)
 llvm_repos_extension = use_extension(":extensions.bzl", "llvm_repos_extension")
 use_repo(
     llvm_repos_extension,
+    "linux_uapi",
     "llvm-raw",
     "pyyaml",
     "vulkan_sdk",

--- a/utils/bazel/MODULE.bazel.lock
+++ b/utils/bazel/MODULE.bazel.lock
@@ -318,7 +318,7 @@
   "moduleExtensions": {
     "//:extensions.bzl%llvm_repos_extension": {
       "general": {
-        "bzlTransitiveDigest": "AfKN+Lbkiv3K+Q5JzNJsTiBryWarkkhFl9xAwjGjVfw=",
+        "bzlTransitiveDigest": "nmqMTTDURvBeR6PLzbfX1EEbe79FTb8wSzrT13UXlFk=",
         "usagesDigest": "X0yUkkWyxQ2Y5oZVDkRSE/K4YkDWo1IjhHsL+1weKyU=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -333,6 +333,10 @@
           },
           "vulkan_sdk": {
             "repoRuleId": "@@//:vulkan_sdk.bzl%vulkan_sdk_setup",
+            "attributes": {}
+          },
+          "linux_uapi": {
+            "repoRuleId": "@@//:linux_uapi.bzl%linux_uapi_setup",
             "attributes": {}
           },
           "pyyaml": {

--- a/utils/bazel/extensions.bzl
+++ b/utils/bazel/extensions.bzl
@@ -6,6 +6,7 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
+load(":linux_uapi.bzl", "linux_uapi_setup")
 load(":vulkan_sdk.bzl", "vulkan_sdk_setup")
 
 _PYYAML_CONTENT = """\
@@ -32,6 +33,7 @@ def _llvm_repos_extension_impl(module_ctx):
         )
 
     vulkan_sdk_setup(name = "vulkan_sdk")
+    linux_uapi_setup(name = "linux_uapi")
 
     http_archive(
         name = "pyyaml",

--- a/utils/bazel/linux_uapi.bzl
+++ b/utils/bazel/linux_uapi.bzl
@@ -1,0 +1,74 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""bzlmod extension for making Linux kernel UAPI headers available in Bazel."""
+
+_SYSTEM_HEADERS_PATH_ENV_VAR = "LINUX_UAPI_INCLUDE_DIR"
+
+_ERROR_MESSAGE_BZL = """\
+def _error_message_impl(ctx):
+    fail(ctx.attr.message)
+
+error_message = rule(
+    implementation = _error_message_impl,
+    attrs = {"message": attr.string()},
+)
+"""
+
+_ERROR_BUILD = """\
+load(":error_message.bzl", "error_message")
+
+error_message(
+    name = "linux_uapi_headers",
+    message = \"""System linux UAPI headers not found.
+
+Pass --repo_env={var_name}=/path/to/your/linux/include to bazel build.
+\"""
+)
+""".format(var_name = _SYSTEM_HEADERS_PATH_ENV_VAR)
+
+_SYSTEM_BUILD = """\
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "linux_uapi_headers",
+    # Builds using /usr/include may have a lot of junk that does not cleanly
+    # compile, so use `textual_hdrs` instead of `hdrs`.
+    textual_hdrs = glob(["include/**"]),
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+)
+"""
+
+def _default_include_dir(repository_ctx):
+    """Returns a default include dir if it looks to have Linux UAPI headers."""
+    include_dir = "/usr/include"
+    if not repository_ctx.path(include_dir + "/linux").exists:
+        return None
+    return include_dir
+
+def _linux_uapi_setup_impl(repository_ctx):
+    """Sets up a repository of UAPI headers from a system directory."""
+    include_dir = repository_ctx.getenv(_SYSTEM_HEADERS_PATH_ENV_VAR, "")
+    if not include_dir:
+        include_dir = _default_include_dir(repository_ctx)
+
+    # If the directory doesn't exist, then set up a dummy rule that just errors.
+    # This defers the error message until an actual build,
+    # rather than failing during repository setup.
+    if not include_dir:
+        repository_ctx.file("error_message.bzl", _ERROR_MESSAGE_BZL)
+        repository_ctx.file("BUILD.bazel", _ERROR_BUILD)
+        return
+
+    if not include_dir.startswith("/"):
+        fail("{} must be absolute, was {}".format(
+            _SYSTEM_HEADERS_PATH_ENV_VAR,
+            include_dir,
+        ))
+
+    repository_ctx.symlink(include_dir, "include")
+    repository_ctx.file("BUILD.bazel", _SYSTEM_BUILD)
+
+linux_uapi_setup = repository_rule(implementation = _linux_uapi_setup_impl)


### PR DESCRIPTION
This PR exposes a target `@linux_uapi//:linux_uapi_headers` that points to a local directory configured by the `LINUX_UAPI_INCLUDE_DIR` environment variable. Linux UAPI headers are required to support libc's `FULL_BUILD` configuration, which uses `-nostdlibinc` and thus requires a copy of linux kernel headers.