### PR TITLE
workflows/commit-access-review: Limit token to current repository

### DIFF
--- a/.github/workflows/commit-access-review.yml
+++ b/.github/workflows/commit-access-review.yml
@@ -31,6 +31,7 @@ jobs:
           client-id: ${{ secrets.LLVM_TOKEN_GENERATOR_CLIENT_ID }}
           private-key: ${{ secrets.LLVM_TOKEN_GENERATOR_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.repository }}
           permission-members: read
           permission-contents: read
       


### PR DESCRIPTION
The token had access to all llvm repositories which was unnecessary since it was only used for llvm-project.

https://github.com/llvm/llvm-project/security/code-scanning/1860