### PR TITLE
[clang-format] Add BraceWrapping.AfterExportBlock option

### DIFF
--- a/clang/docs/ClangFormatStyleOptions.md
+++ b/clang/docs/ClangFormatStyleOptions.md
@@ -2582,6 +2582,16 @@ the configuration (without a prefix: `Auto`).
     }
     ```
 
+  - `bool AfterExportBlock` Wrap export blocks.
+
+    ```c++
+    true:                            false:
+    export             vs.           export {
+    {                                  int foo();
+      int foo();                     }
+    }
+    ```
+
   - `bool AfterExternBlock` Wrap extern blocks.
 
     ```c++
@@ -2594,16 +2604,6 @@ the configuration (without a prefix: `Auto`).
     false:
     extern "C" {
     int foo();
-    }
-    ```
-
-  - `bool AfterExportBlock` Wrap export blocks.
-
-    ```c++
-    true:                            false:
-    export                           export {
-    {                                  int foo();
-      int foo();                     }
     }
     ```
 

--- a/clang/docs/ClangFormatStyleOptions.md
+++ b/clang/docs/ClangFormatStyleOptions.md
@@ -2597,6 +2597,16 @@ the configuration (without a prefix: `Auto`).
     }
     ```
 
+  - `bool AfterExportBlock` Wrap export blocks.
+
+    ```c++
+    true:                            false:
+    export                           export {
+    {                                  int foo();
+      int foo();                     }
+    }
+    ```
+
   - `bool BeforeCatch` Wrap before `catch`.
 
     ```c++

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -1558,7 +1558,6 @@ struct FormatStyle {
     ///   }
     /// \endcode
     bool AfterExternBlock; // Partially superseded by IndentExternBlock
-
     /// Wrap before `catch`.
     /// \code
     ///   true:

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -1535,6 +1535,15 @@ struct FormatStyle {
     ///   }
     /// \endcode
     bool AfterUnion;
+    /// Wrap export blocks.
+    /// \code
+    ///   true:                            false:
+    ///   export             vs.           export {
+    ///   {                                  int foo();
+    ///     int foo();                     }
+    ///   }
+    /// \endcode
+    bool AfterExportBlock;
     /// Wrap extern blocks.
     /// \code
     ///   true:
@@ -1549,15 +1558,7 @@ struct FormatStyle {
     ///   }
     /// \endcode
     bool AfterExternBlock; // Partially superseded by IndentExternBlock
-    /// Wrap export blocks.
-    /// \code
-    ///   true:                            false:
-    ///   export                           export {
-    ///   {                                  int foo();
-    ///     int foo();                     }
-    ///   }
-    /// \endcode
-    bool AfterExportBlock;
+
     /// Wrap before `catch`.
     /// \code
     ///   true:

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -1549,6 +1549,15 @@ struct FormatStyle {
     ///   }
     /// \endcode
     bool AfterExternBlock; // Partially superseded by IndentExternBlock
+    /// Wrap export blocks.
+    /// \code
+    ///   true:                            false:
+    ///   export                           export {
+    ///   {                                  int foo();
+    ///     int foo();                     }
+    ///   }
+    /// \endcode
+    bool AfterExportBlock;
     /// Wrap before `catch`.
     /// \code
     ///   true:

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -1725,8 +1725,8 @@ static void expandPresetsBraceWrapping(FormatStyle &Expanded) {
                             /*AfterObjCDeclaration=*/false,
                             /*AfterStruct=*/false,
                             /*AfterUnion=*/false,
-                            /*AfterExternBlock=*/false,
                             /*AfterExportBlock=*/false,
+                            /*AfterExternBlock=*/false,
                             /*BeforeCatch=*/false,
                             /*BeforeElse=*/false,
                             /*BeforeLambdaBody=*/false,
@@ -1747,8 +1747,8 @@ static void expandPresetsBraceWrapping(FormatStyle &Expanded) {
     Expanded.BraceWrapping.AfterFunction = true;
     Expanded.BraceWrapping.AfterStruct = true;
     Expanded.BraceWrapping.AfterUnion = true;
-    Expanded.BraceWrapping.AfterExternBlock = true;
     Expanded.BraceWrapping.AfterExportBlock = true;
+    Expanded.BraceWrapping.AfterExternBlock = true;
     Expanded.BraceWrapping.SplitEmptyFunction = true;
     Expanded.BraceWrapping.SplitEmptyRecord = false;
     break;
@@ -1767,8 +1767,8 @@ static void expandPresetsBraceWrapping(FormatStyle &Expanded) {
     Expanded.BraceWrapping.AfterObjCDeclaration = true;
     Expanded.BraceWrapping.AfterStruct = true;
     Expanded.BraceWrapping.AfterUnion = true;
-    Expanded.BraceWrapping.AfterExternBlock = true;
     Expanded.BraceWrapping.AfterExportBlock = true;
+    Expanded.BraceWrapping.AfterExternBlock = true;
     Expanded.BraceWrapping.BeforeCatch = true;
     Expanded.BraceWrapping.BeforeElse = true;
     Expanded.BraceWrapping.BeforeLambdaBody = true;
@@ -1798,8 +1798,8 @@ static void expandPresetsBraceWrapping(FormatStyle &Expanded) {
         /*AfterObjCDeclaration=*/true,
         /*AfterStruct=*/true,
         /*AfterUnion=*/true,
-        /*AfterExternBlock=*/true,
         /*AfterExportBlock=*/true,
+        /*AfterExternBlock=*/true,
         /*BeforeCatch=*/true,
         /*BeforeElse=*/true,
         /*BeforeLambdaBody=*/true,
@@ -1901,8 +1901,8 @@ FormatStyle getLLVMStyle(FormatStyle::LanguageKind Language) {
                              /*AfterObjCDeclaration=*/false,
                              /*AfterStruct=*/false,
                              /*AfterUnion=*/false,
-                             /*AfterExternBlock=*/false,
                              /*AfterExportBlock=*/false,
+                             /*AfterExternBlock=*/false,
                              /*BeforeCatch=*/false,
                              /*BeforeElse=*/false,
                              /*BeforeLambdaBody=*/false,

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -220,6 +220,7 @@ template <> struct MappingTraits<FormatStyle::BraceWrappingFlags> {
     IO.mapOptional("AfterControlStatement", Wrapping.AfterControlStatement);
     IO.mapOptional("AfterEnum", Wrapping.AfterEnum);
     IO.mapOptional("AfterExternBlock", Wrapping.AfterExternBlock);
+    IO.mapOptional("AfterExportBlock", Wrapping.AfterExportBlock);
     IO.mapOptional("AfterFunction", Wrapping.AfterFunction);
     IO.mapOptional("AfterNamespace", Wrapping.AfterNamespace);
     IO.mapOptional("AfterObjCDeclaration", Wrapping.AfterObjCDeclaration);
@@ -1725,6 +1726,7 @@ static void expandPresetsBraceWrapping(FormatStyle &Expanded) {
                             /*AfterStruct=*/false,
                             /*AfterUnion=*/false,
                             /*AfterExternBlock=*/false,
+                            /*AfterExportBlock=*/false,
                             /*BeforeCatch=*/false,
                             /*BeforeElse=*/false,
                             /*BeforeLambdaBody=*/false,
@@ -1746,6 +1748,7 @@ static void expandPresetsBraceWrapping(FormatStyle &Expanded) {
     Expanded.BraceWrapping.AfterStruct = true;
     Expanded.BraceWrapping.AfterUnion = true;
     Expanded.BraceWrapping.AfterExternBlock = true;
+    Expanded.BraceWrapping.AfterExportBlock = true;
     Expanded.BraceWrapping.SplitEmptyFunction = true;
     Expanded.BraceWrapping.SplitEmptyRecord = false;
     break;
@@ -1765,6 +1768,7 @@ static void expandPresetsBraceWrapping(FormatStyle &Expanded) {
     Expanded.BraceWrapping.AfterStruct = true;
     Expanded.BraceWrapping.AfterUnion = true;
     Expanded.BraceWrapping.AfterExternBlock = true;
+    Expanded.BraceWrapping.AfterExportBlock = true;
     Expanded.BraceWrapping.BeforeCatch = true;
     Expanded.BraceWrapping.BeforeElse = true;
     Expanded.BraceWrapping.BeforeLambdaBody = true;
@@ -1795,6 +1799,7 @@ static void expandPresetsBraceWrapping(FormatStyle &Expanded) {
         /*AfterStruct=*/true,
         /*AfterUnion=*/true,
         /*AfterExternBlock=*/true,
+        /*AfterExportBlock=*/true,
         /*BeforeCatch=*/true,
         /*BeforeElse=*/true,
         /*BeforeLambdaBody=*/true,
@@ -1897,6 +1902,7 @@ FormatStyle getLLVMStyle(FormatStyle::LanguageKind Language) {
                              /*AfterStruct=*/false,
                              /*AfterUnion=*/false,
                              /*AfterExternBlock=*/false,
+                             /*AfterExportBlock=*/false,
                              /*BeforeCatch=*/false,
                              /*BeforeElse=*/false,
                              /*BeforeLambdaBody=*/false,

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -219,8 +219,8 @@ template <> struct MappingTraits<FormatStyle::BraceWrappingFlags> {
     IO.mapOptional("AfterClass", Wrapping.AfterClass);
     IO.mapOptional("AfterControlStatement", Wrapping.AfterControlStatement);
     IO.mapOptional("AfterEnum", Wrapping.AfterEnum);
-    IO.mapOptional("AfterExternBlock", Wrapping.AfterExternBlock);
     IO.mapOptional("AfterExportBlock", Wrapping.AfterExportBlock);
+    IO.mapOptional("AfterExternBlock", Wrapping.AfterExternBlock);
     IO.mapOptional("AfterFunction", Wrapping.AfterFunction);
     IO.mapOptional("AfterNamespace", Wrapping.AfterNamespace);
     IO.mapOptional("AfterObjCDeclaration", Wrapping.AfterObjCDeclaration);

--- a/clang/lib/Format/FormatToken.h
+++ b/clang/lib/Format/FormatToken.h
@@ -80,6 +80,7 @@ namespace format {
   TYPE(EnumLBrace)                                                             \
   TYPE(EnumRBrace)                                                             \
   TYPE(EnumUnderlyingTypeColon)                                                \
+  TYPE(ExportLBrace)                                                           \
   TYPE(FatArrow)                                                               \
   TYPE(ForEachMacro)                                                           \
   TYPE(FunctionAnnotationRParen)                                               \

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -2137,7 +2137,7 @@ private:
             TT_RecordLBrace, TT_StructLBrace, TT_UnionLBrace, TT_RequiresClause,
             TT_RequiresClauseInARequiresExpression, TT_RequiresExpression,
             TT_RequiresExpressionLParen, TT_RequiresExpressionLBrace,
-            TT_CompoundRequirementLBrace, TT_BracedListLBrace, TT_ExportLBrace,
+            TT_CompoundRequirementLBrace, TT_BracedListLBrace,
             TT_FunctionLikeMacro)) {
       CurrentToken->setType(TT_Unknown);
     }

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -2137,7 +2137,7 @@ private:
             TT_RecordLBrace, TT_StructLBrace, TT_UnionLBrace, TT_RequiresClause,
             TT_RequiresClauseInARequiresExpression, TT_RequiresExpression,
             TT_RequiresExpressionLParen, TT_RequiresExpressionLBrace,
-            TT_CompoundRequirementLBrace, TT_BracedListLBrace,
+            TT_CompoundRequirementLBrace, TT_BracedListLBrace, TT_ExportLBrace,
             TT_FunctionLikeMacro)) {
       CurrentToken->setType(TT_Unknown);
     }

--- a/clang/lib/Format/TokenAnnotator.h
+++ b/clang/lib/Format/TokenAnnotator.h
@@ -157,11 +157,6 @@ public:
            startsWith(tok::kw_export, tok::kw_namespace);
   }
 
-  /// \c true if this line starts a C++ export block.
-  bool startsWithExportBlock() const {
-    return startsWith(tok::kw_export, tok::l_brace);
-  }
-
   FormatToken *getFirstNonComment() const {
     assert(First);
     return First->is(tok::comment) ? First->getNextNonComment() : First;

--- a/clang/lib/Format/TokenAnnotator.h
+++ b/clang/lib/Format/TokenAnnotator.h
@@ -157,6 +157,11 @@ public:
            startsWith(tok::kw_export, tok::kw_namespace);
   }
 
+  /// \c true if this line starts a C++ export block.
+  bool startsWithExportBlock() const {
+    return startsWith(tok::kw_export, tok::l_brace);
+  }
+
   FormatToken *getFirstNonComment() const {
     assert(First);
     return First->is(tok::comment) ? First->getNextNonComment() : First;

--- a/clang/lib/Format/TokenAnnotator.h
+++ b/clang/lib/Format/TokenAnnotator.h
@@ -157,7 +157,6 @@ public:
            startsWith(tok::kw_export, tok::kw_namespace);
   }
 
-
   FormatToken *getFirstNonComment() const {
     assert(First);
     return First->is(tok::comment) ? First->getNextNonComment() : First;

--- a/clang/lib/Format/TokenAnnotator.h
+++ b/clang/lib/Format/TokenAnnotator.h
@@ -157,10 +157,6 @@ public:
            startsWith(tok::kw_export, tok::kw_namespace);
   }
 
-  /// \c true if this line starts a C++ export block.
-  bool startsWithExportBlock() const {
-    return startsWith(tok::kw_export, tok::l_brace);
-  }
 
   FormatToken *getFirstNonComment() const {
     assert(First);

--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -893,7 +893,7 @@ private:
         Line.First->isOneOf(tok::kw_try, tok::kw___try, tok::kw_catch,
                             tok::kw___finally, tok::r_brace,
                             Keywords.kw___except) ||
-        Line.First->is(TT_ExportLBrace) || Line.Last->is(TT_ExportLBrace)) {
+        Line.Last->is(TT_ExportLBrace)) {
       if (IsSplitBlock)
         return 0;
       // Don't merge when we can't except the case when

--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -444,7 +444,7 @@ private:
     if (TheLine->Last->is(tok::l_brace) && FirstNonComment != TheLine->Last &&
         (FirstNonComment->isOneOf(tok::kw_if, tok::kw_while, tok::kw_for,
                                   TT_ForEachMacro) ||
-         (TheLine->startsWithExportBlock() &&
+         (TheLine->Last->is(TT_ExportLBrace) &&
           !Style.BraceWrapping.AfterExportBlock))) {
       return Style.AllowShortBlocksOnASingleLine != FormatStyle::SBS_Never
                  ? tryMergeSimpleBlock(I, E, Limit)
@@ -893,7 +893,7 @@ private:
         Line.First->isOneOf(tok::kw_try, tok::kw___try, tok::kw_catch,
                             tok::kw___finally, tok::r_brace,
                             Keywords.kw___except) ||
-        Line.startsWithExportBlock()) {
+        Line.First->is(TT_ExportLBrace) || Line.Last->is(TT_ExportLBrace)) {
       if (IsSplitBlock)
         return 0;
       // Don't merge when we can't except the case when

--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -938,7 +938,6 @@ private:
     }
 
     if (Line.endsWith(tok::l_brace)) {
-
       if (Style.BraceWrapping.AfterExportBlock &&
           Line.First->is(TT_ExportLBrace)) {
         return 0;

--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -444,7 +444,8 @@ private:
     if (TheLine->Last->is(tok::l_brace) && FirstNonComment != TheLine->Last &&
         (FirstNonComment->isOneOf(tok::kw_if, tok::kw_while, tok::kw_for,
                                   TT_ForEachMacro) ||
-         TheLine->startsWithExportBlock())) {
+         (TheLine->startsWithExportBlock() &&
+          !Style.BraceWrapping.AfterExportBlock))) {
       return Style.AllowShortBlocksOnASingleLine != FormatStyle::SBS_Never
                  ? tryMergeSimpleBlock(I, E, Limit)
                  : 0;
@@ -937,6 +938,14 @@ private:
     }
 
     if (Line.endsWith(tok::l_brace)) {
+      // Refuse to merge export blocks if the style requires the brace to be on
+      // a new line.
+      if (Style.BraceWrapping.AfterExportBlock &&
+          Line.First->is(tok::l_brace) && I > AnnotatedLines.begin() &&
+          I[-1]->startsWith(tok::kw_export)) {
+        return 0;
+      }
+
       if (Style.AllowShortBlocksOnASingleLine == FormatStyle::SBS_Never &&
           Line.First->is(TT_BlockLBrace)) {
         return 0;

--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -938,11 +938,9 @@ private:
     }
 
     if (Line.endsWith(tok::l_brace)) {
-      // Refuse to merge export blocks if the style requires the brace to be on
-      // a new line.
+
       if (Style.BraceWrapping.AfterExportBlock &&
-          Line.First->is(tok::l_brace) && I > AnnotatedLines.begin() &&
-          I[-1]->startsWith(tok::kw_export)) {
+          Line.First->is(TT_ExportLBrace)) {
         return 0;
       }
 

--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -3311,12 +3311,11 @@ void UnwrappedLineParser::parseNamespace() {
 }
 
 void UnwrappedLineParser::parseCppExportBlock() {
-
   if (FormatTok->is(tok::l_brace)) {
+    FormatTok->setType(TT_ExportLBrace);
     if (Style.BraceWrapping.AfterExportBlock)
       addUnwrappedLine();
   }
-
   parseNamespaceOrExportBlock(/*AddLevels=*/Style.IndentExportBlock ? 1 : 0);
 }
 

--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -3311,6 +3311,12 @@ void UnwrappedLineParser::parseNamespace() {
 }
 
 void UnwrappedLineParser::parseCppExportBlock() {
+
+  if (FormatTok->is(tok::l_brace)) {
+    if (Style.BraceWrapping.AfterExportBlock)
+      addUnwrappedLine();
+  }
+
   parseNamespaceOrExportBlock(/*AddLevels=*/Style.IndentExportBlock ? 1 : 0);
 }
 

--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -3312,7 +3312,7 @@ void UnwrappedLineParser::parseNamespace() {
 
 void UnwrappedLineParser::parseCppExportBlock() {
   if (FormatTok->is(tok::l_brace)) {
-    FormatTok->setType(TT_ExportLBrace);
+    FormatTok->setFinalizedType(TT_ExportLBrace);
     if (Style.BraceWrapping.AfterExportBlock)
       addUnwrappedLine();
   }

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -238,6 +238,7 @@ TEST(ConfigParseTest, ParsesConfigurationBools) {
   CHECK_PARSE_NESTED_BOOL(BraceWrapping, AfterCaseLabel);
   CHECK_PARSE_NESTED_BOOL(BraceWrapping, AfterClass);
   CHECK_PARSE_NESTED_BOOL(BraceWrapping, AfterEnum);
+  CHECK_PARSE_NESTED_BOOL(BraceWrapping, AfterExportBlock);
   CHECK_PARSE_NESTED_BOOL(BraceWrapping, AfterFunction);
   CHECK_PARSE_NESTED_BOOL(BraceWrapping, AfterNamespace);
   CHECK_PARSE_NESTED_BOOL(BraceWrapping, AfterObjCDeclaration);

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -4942,7 +4942,7 @@ TEST_F(FormatTest, BraceWrappingAfterExportBlock) {
                "  int foo();\n"
                "}",
                Style);
-               
+
   Style.BraceWrapping.AfterExportBlock = false;
   verifyFormat("export {\n"
                "  int foo();\n"

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -4930,6 +4930,7 @@ TEST_F(FormatTest, IndentExternBlockStyle) {
                "}",
                Style);
 }
+
 TEST_F(FormatTest, BraceWrappingAfterExportBlock) {
   FormatStyle Style = getLLVMStyle();
   Style.BreakBeforeBraces = FormatStyle::BS_Custom;
@@ -4949,6 +4950,7 @@ TEST_F(FormatTest, BraceWrappingAfterExportBlock) {
                "}",
                Style);
 }
+
 TEST_F(FormatTest, FormatsInlineASM) {
   verifyFormat("asm(\"xyz\" : \"=a\"(a), \"=d\"(b) : \"a\"(data));");
   verifyFormat("asm(\"nop\" ::: \"memory\");");

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -4930,11 +4930,9 @@ TEST_F(FormatTest, IndentExternBlockStyle) {
                "}",
                Style);
 }
-
 TEST_F(FormatTest, BraceWrappingAfterExportBlock) {
   FormatStyle Style = getLLVMStyle();
   Style.BreakBeforeBraces = FormatStyle::BS_Custom;
-
   Style.BraceWrapping.AfterExportBlock = true;
   verifyFormat("export\n"
                "{\n"
@@ -4944,14 +4942,13 @@ TEST_F(FormatTest, BraceWrappingAfterExportBlock) {
                "  int foo();\n"
                "}",
                Style);
-
+               
   Style.BraceWrapping.AfterExportBlock = false;
   verifyFormat("export {\n"
                "  int foo();\n"
                "}",
                Style);
 }
-
 TEST_F(FormatTest, FormatsInlineASM) {
   verifyFormat("asm(\"xyz\" : \"=a\"(a), \"=d\"(b) : \"a\"(data));");
   verifyFormat("asm(\"nop\" ::: \"memory\");");

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -4931,6 +4931,27 @@ TEST_F(FormatTest, IndentExternBlockStyle) {
                Style);
 }
 
+TEST_F(FormatTest, BraceWrappingAfterExportBlock) {
+  FormatStyle Style = getLLVMStyle();
+  Style.BreakBeforeBraces = FormatStyle::BS_Custom;
+
+  Style.BraceWrapping.AfterExportBlock = true;
+  verifyFormat("export\n"
+               "{\n"
+               "  int foo();\n"
+               "}",
+               "export {\n"
+               "  int foo();\n"
+               "}",
+               Style);
+
+  Style.BraceWrapping.AfterExportBlock = false;
+  verifyFormat("export {\n"
+               "  int foo();\n"
+               "}",
+               Style);
+}
+
 TEST_F(FormatTest, FormatsInlineASM) {
   verifyFormat("asm(\"xyz\" : \"=a\"(a), \"=d\"(b) : \"a\"(data));");
   verifyFormat("asm(\"nop\" ::: \"memory\");");

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -694,6 +694,14 @@ TEST_F(TokenAnnotatorTest, UnderstandsEnums) {
   EXPECT_TOKEN(Tokens[3], tok::r_brace, TT_EnumRBrace);
 }
 
+TEST_F(TokenAnnotatorTest, UnderstandsExportBlock) {
+  auto Tokens = annotate("export {\n"
+                         "int foo();\n"
+                         "}");
+  ASSERT_EQ(Tokens.size(), 9u);
+  EXPECT_TOKEN(Tokens[1], tok::l_brace, TT_ExportLBrace);
+}
+
 TEST_F(TokenAnnotatorTest, UnderstandsDefaultedAndDeletedFunctions) {
   auto Tokens = annotate("auto operator<=>(const T &) const & = default;");
   ASSERT_EQ(Tokens.size(), 14u) << Tokens;

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -698,7 +698,7 @@ TEST_F(TokenAnnotatorTest, UnderstandsExportBlock) {
   auto Tokens = annotate("export {\n"
                          "int foo();\n"
                          "}");
-  ASSERT_EQ(Tokens.size(), 9u);
+  ASSERT_EQ(Tokens.size(), 9u) << Tokens;
   EXPECT_TOKEN(Tokens[1], tok::l_brace, TT_ExportLBrace);
 }
 


### PR DESCRIPTION
### Summary
Adds the `BraceWrapping.AfterExportBlock` option to `clang-format`. This allows users configuring `BreakBeforeBraces: Custom` to specify whether the opening brace of a C++20 `export` block should be wrapped onto a new line.
Fixes #216785

### Examples
```c++
// BraceWrapping.AfterExportBlock = true
export
{
  int foo();
}

// BraceWrapping.AfterExportBlock = false
export {
  int foo();
}

