### PR TITLE
[orc-rt] Add missing `#include <optional>`

### DIFF
--- a/orc-rt/include/orc-rt/NativeDylibManager.h
+++ b/orc-rt/include/orc-rt/NativeDylibManager.h
@@ -17,6 +17,8 @@
 #include "orc-rt/Service.h"
 #include "orc-rt/sps-ci/NativeDylibManagerSPSCI.h"
 
+#include <optional>
+
 namespace orc_rt {
 
 class Session;


### PR DESCRIPTION
`std::optional` in `NativeDylibManager.h`, which was introduced in #201519, causes a compilation error.

```
llvm-project/orc-rt/include/orc-rt/NativeDylibManager.h:74:57: error: no member named 'optional' in namespace 'std'
   74 |       move_only_function<void(Expected<std::vector<std::optional<void *>>>)>;
      |                                                         ^~~~~~~~         
```

I don't know why other users don't encounter this error.
