### PR TITLE
[compiler-rt][cmake] Change orc-rt target names

### DIFF
--- a/compiler-rt/lib/orc/tests/CMakeLists.txt
+++ b/compiler-rt/lib/orc/tests/CMakeLists.txt
@@ -3,8 +3,8 @@ include(CompilerRTCompile)
 include_directories(..)
 
 # Unit tests target.
-add_custom_target(OrcRTUnitTests)
-set_target_properties(OrcRTUnitTests PROPERTIES FOLDER "compiler-rt/Tests")
+add_custom_target(CompilerRTOrcRTUnitTests)
+set_target_properties(CompilerRTOrcRTUnitTests PROPERTIES FOLDER "compiler-rt/Tests")
 
 # Testing tools target.
 add_custom_target(OrcRTTools)
@@ -69,7 +69,7 @@ macro(add_orc_unittest testname)
       get_orc_lib_for_arch(${arch} ORC_RUNTIME_LIBS)
       if(ORC_RUNTIME_LIBS)
         generate_compiler_rt_tests(TEST_OBJECTS
-          OrcRTUnitTests "${testname}-${arch}-Test" "${arch}"
+          CompilerRTOrcRTUnitTests "${testname}-${arch}-Test" "${arch}"
           SOURCES ${TEST_SOURCES} ${COMPILER_RT_GTEST_SOURCE}
           RUNTIME "${ORC_RUNTIME_LIBS}"
           COMPILE_DEPS ${TEST_HEADERS} ${ORC_HEADERS}

--- a/compiler-rt/test/orc/CMakeLists.txt
+++ b/compiler-rt/test/orc/CMakeLists.txt
@@ -29,6 +29,6 @@ if (COMPILER_RT_BUILD_ORC)
   endforeach()
 endif()
 
-add_lit_testsuite(check-orc-rt "Running the ORC runtime tests"
+add_lit_testsuite(check-compiler-rt-orc-rt "Running the ORC runtime tests"
   ${ORC_TESTSUITES}
   DEPENDS ${ORC_TEST_DEPS})


### PR DESCRIPTION
When configured with `LLVM_ENABLE_RUNTIMES=compiler-rt;orc-rt`, following two CMake errors occur.

```
CMake Error at llvm-project/llvm/cmake/modules/AddLLVM.cmake:2245 (add_custom_target):
  add_custom_target cannot create target "check-orc-rt" because another
  target with the same name already exists.  The existing target is a custom
  target created in source directory
  "llvm-project/compiler-rt/test/orc".  See documentation
  for policy CMP0002 for more details.
Call Stack (most recent call first):
  llvm-project/llvm/cmake/modules/AddLLVM.cmake:2326 (add_lit_target)
  llvm-project/orc-rt/test/CMakeLists.txt:24 (add_lit_testsuite)

CMake Error at llvm-project/orc-rt/test/unit/CMakeLists.txt:1 (add_custom_target):
  add_custom_target cannot create target "OrcRTUnitTests" because another
  target with the same name already exists.  The existing target is a custom
  target created in source directory
  "llvm-project/compiler-rt/lib/orc/tests".  See
  documentation for policy CMP0002 for more details.
```

Both `compiler-rt/lib/orc/tests/CMakeLists.txt` and `orc-rt/test/unit/CMakeLists.txt` define targets named `OrcRTUnitTests`.
Both `compiler-rt/test/orc/CMakeLists.txt` and `orc-rt/test/CMakeLists.txt` define targets named `check-orc-rt`.

This commit changes target names in compiler-rt.
