### PR TITLE
[HLSL][LongVec] enable support for all elementwise apis

### DIFF
--- a/clang/include/clang/Basic/HLSLIntrinsics.td
+++ b/clang/include/clang/Basic/HLSLIntrinsics.td
@@ -354,6 +354,7 @@ def hlsl_acos : HLSLOneArgBuiltin<"acos", "__builtin_elementwise_acos"> {
 \param Val The input value.
 }];
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -437,6 +438,7 @@ def hlsl_asin : HLSLOneArgBuiltin<"asin", "__builtin_elementwise_asin"> {
 \param Val The input value.
 }];
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -448,6 +450,7 @@ def hlsl_atan : HLSLOneArgBuiltin<"atan", "__builtin_elementwise_atan"> {
 \param Val The input value.
 }];
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -462,6 +465,7 @@ determine the correct quadrant.
 \param x The x-coordinate.
 }];
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
 }
 
 // Returns the smallest integer value that is greater than or equal to the
@@ -474,6 +478,7 @@ the input value, \a Val.
 \param Val The input value.
 }];
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -506,6 +511,7 @@ For values of -INF or INF, clamp will behave as expected.
 However for values of NaN, the results are undefined.
 }];
   let VaryingTypes = AllNumericTypes;
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -518,6 +524,7 @@ def hlsl_clip : HLSLOneArgBuiltin<"clip", "__builtin_hlsl_elementwise_clip"> {
 }];
   let ReturnType = VoidTy;
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -529,6 +536,7 @@ def hlsl_cos : HLSLOneArgBuiltin<"cos", "__builtin_elementwise_cos"> {
 \param Val The input value.
 }];
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -540,6 +548,7 @@ def hlsl_cosh : HLSLOneArgBuiltin<"cosh", "__builtin_elementwise_cosh"> {
 \param Val The input value.
 }];
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -557,6 +566,7 @@ def hlsl_countbits : HLSLBuiltin<"countbits"> {
   let VaryingTypes = AllIntTypes;
   let VaryingScalar = 1;
   let VaryingVecSizes = [2, 3, 4];
+  let VaryingLongVector = 1;
 }
 
 // Converts a floating-point, 4D vector set by a D3DCOLOR to a UBYTE4.
@@ -612,6 +622,7 @@ The return value is a floating point scalar or vector containing the low
 prevision partial derivative of the input value.
 }];
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -629,6 +640,7 @@ The return value is a floating point scalar or vector containing the high
 prevision partial derivative of the input value.
 }];
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -659,6 +671,7 @@ The return value is a floating point scalar or vector containing the low
 prevision partial derivative of the input value.
 }];
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -676,6 +689,7 @@ The return value is a floating point scalar or vector containing the high
 prevision partial derivative of the input value.
 }];
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -829,6 +843,7 @@ def hlsl_exp : HLSLOneArgBuiltin<"exp", "__builtin_elementwise_exp"> {
 The return value is the base-e exponential of the \a x parameter.
 }];
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -842,6 +857,7 @@ def hlsl_exp2 : HLSLOneArgBuiltin<"exp2", "__builtin_elementwise_exp2"> {
 The base 2 exponential of the \a x parameter.
 }];
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -860,6 +876,7 @@ parameter.
 }];
   let ReturnType = VaryingShape<FloatTy>;
   let VaryingTypes = [UIntTy];
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -878,6 +895,7 @@ The return value is a uint containing the converted half value in the low
 }];
   let ReturnType = VaryingShape<UIntTy>;
   let VaryingTypes = [FloatTy];
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -910,6 +928,7 @@ def hlsl_fma : HLSLThreeArgBuiltin<"fma", "__builtin_elementwise_fma"> {
 \param c The third value in the fused multiply-addition.
 }];
   let VaryingTypes = [DoubleTy];
+  let VaryingLongVector = 1;
 }
 
 // Returns the location of the first set bit starting from the lowest order bit
@@ -924,6 +943,7 @@ order bit and working upward, per component.
 }];
   let ReturnType = VaryingShape<UIntTy>;
   let VaryingTypes = AllIntTypes;
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -937,6 +957,7 @@ value, \a Val.
 \param Val The input value.
 }];
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -981,6 +1002,7 @@ def hlsl_frac : HLSLOneArgBuiltin<"frac", "__builtin_hlsl_elementwise_frac"> {
 If \a the return value is greater than or equal to 0 and less than 1.
 }];
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -1088,6 +1110,7 @@ to True if the x parameter is +INF or -INF. Otherwise, False.
 }];
   let ReturnType = VaryingShape<BoolTy>;
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
 }
 
 // Determines if the specified value x is Not a Number.
@@ -1102,6 +1125,7 @@ to True if the x parameter is NaN or QNaN. Otherwise, False.
 }];
   let ReturnType = VaryingShape<BoolTy>;
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
 }
 
 // Returns the result of multiplying the specified value by two raised
@@ -1204,6 +1228,7 @@ If \a Val is negative, this result is undefined. If \a Val is 0, this
 function returns negative infinity.
 }];
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -1218,6 +1243,7 @@ If \a Val is negative, this result is undefined. If \a Val is 0, this
 function returns negative infinity.
 }];
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -1232,6 +1258,7 @@ If \a Val is negative, this result is undefined. If \a Val is 0, this
 function returns negative infinity.
 }];
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -1257,6 +1284,7 @@ def hlsl_max : HLSLTwoArgBuiltin<"max", "__builtin_elementwise_max"> {
 \param Y The Y input value.
 }];
   let VaryingTypes = AllNumericTypes;
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -1269,6 +1297,7 @@ def hlsl_min : HLSLTwoArgBuiltin<"min", "__builtin_elementwise_min"> {
 \param Y The Y input value.
 }];
   let VaryingTypes = AllNumericTypes;
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -1321,6 +1350,7 @@ def hlsl_pow : HLSLTwoArgBuiltin<"pow", "__builtin_elementwise_pow"> {
 \param Pow The specified power.
 }];
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
 }
 
 // Reads the value from the lane across the X axis of the quad.
@@ -1381,6 +1411,7 @@ def hlsl_rcp : HLSLOneArgBuiltin<"rcp", "__builtin_hlsl_elementwise_rcp"> {
 The return value is the reciprocal of the \a x parameter.
 }];
   let VaryingTypes = AllFloatTypes;
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -1455,6 +1486,7 @@ def hlsl_reversebits : HLSLOneArgBuiltin<"reversebits", "__builtin_elementwise_b
 \param Val The input value.
 }];
   let VaryingTypes = AllIntTypes;
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -1470,6 +1502,7 @@ within a floating-point type. Halfway cases are
 rounded to the nearest even value.
 }];
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -1485,6 +1518,7 @@ ie 1 / sqrt( \a x).
 This function uses the following formula: 1 / sqrt(x).
 }];
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -1497,6 +1531,7 @@ to 1.0f.
 \param Val The input value.
 }];
   let VaryingTypes = AllFloatTypes;
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -1511,6 +1546,7 @@ def hlsl_sign : HLSLOneArgBuiltin<"sign", "__builtin_hlsl_elementwise_sign"> {
 }];
   let ReturnType = VaryingShape<IntTy>;
   let VaryingTypes = AllNumericTypes;
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -1522,6 +1558,7 @@ def hlsl_sin : HLSLOneArgBuiltin<"sin", "__builtin_elementwise_sin"> {
 \param Val The input value.
 }];
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -1533,6 +1570,7 @@ def hlsl_sinh : HLSLOneArgBuiltin<"sinh", "__builtin_elementwise_sinh"> {
 \param Val The input value.
 }];
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -1563,6 +1601,7 @@ def hlsl_sqrt : HLSLOneArgBuiltin<"sqrt", "__builtin_elementwise_sqrt"> {
 \param Val The input value.
 }];
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -1591,6 +1630,7 @@ def hlsl_tan : HLSLOneArgBuiltin<"tan", "__builtin_elementwise_tan"> {
 \param Val The input value.
 }];
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -1602,6 +1642,7 @@ def hlsl_tanh : HLSLOneArgBuiltin<"tanh", "__builtin_elementwise_tanh"> {
 \param Val The input value.
 }];
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 
@@ -1613,6 +1654,7 @@ def hlsl_trunc : HLSLOneArgBuiltin<"trunc", "__builtin_elementwise_trunc"> {
 \param Val The input value.
 }];
   let VaryingTypes = [HalfTy, FloatTy];
+  let VaryingLongVector = 1;
   let VaryingMatDims = [];
 }
 

--- a/clang/test/CodeGenHLSL/builtins/acos.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/acos.hlsl
@@ -57,3 +57,9 @@ float3 test_acos_float3 ( float3 p0 ) {
 float4 test_acos_float4 ( float4 p0 ) {
   return acos ( p0 );
 }
+
+// CHECK-LABEL: test_acos_float5
+// CHECK: call reassoc nnan ninf nsz arcp afn <5 x float> @llvm.acos.v5f32
+vector<float, 5> test_acos_float5(vector<float, 5> p0) {
+  return acos(p0);
+}

--- a/clang/test/CodeGenHLSL/builtins/asin.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/asin.hlsl
@@ -57,3 +57,9 @@ float3 test_asin_float3 ( float3 p0 ) {
 float4 test_asin_float4 ( float4 p0 ) {
   return asin ( p0 );
 }
+
+// CHECK-LABEL: test_asin_float5
+// CHECK: call reassoc nnan ninf nsz arcp afn <5 x float> @llvm.asin.v5f32
+vector<float, 5> test_asin_float5(vector<float, 5> p0) {
+  return asin(p0);
+}

--- a/clang/test/CodeGenHLSL/builtins/atan.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/atan.hlsl
@@ -57,3 +57,9 @@ float3 test_atan_float3 ( float3 p0 ) {
 float4 test_atan_float4 ( float4 p0 ) {
   return atan ( p0 );
 }
+
+// CHECK-LABEL: test_atan_float5
+// CHECK: call reassoc nnan ninf nsz arcp afn <5 x float> @llvm.atan.v5f32
+vector<float, 5> test_atan_float5(vector<float, 5> p0) {
+  return atan(p0);
+}

--- a/clang/test/CodeGenHLSL/builtins/atan2.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/atan2.hlsl
@@ -57,3 +57,10 @@ float3 test_atan2_float3 (float3 p0, float3 p1) {
 float4 test_atan2_float4 (float4 p0, float4 p1) {
   return atan2(p0, p1);
 }
+
+// CHECK-LABEL: test_atan2_float5
+// CHECK: call reassoc nnan ninf nsz arcp afn <5 x float> @llvm.atan2.v5f32
+vector<float, 5> test_atan2_float5(vector<float, 5> p0,
+                                   vector<float, 5> p1) {
+  return atan2(p0, p1);
+}

--- a/clang/test/CodeGenHLSL/builtins/ceil.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/ceil.hlsl
@@ -40,3 +40,7 @@ float3 test_ceil_float3(float3 p0) { return ceil(p0); }
 // CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> @_Z16test_ceil_float4
 // CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.ceil.v4f32(
 float4 test_ceil_float4(float4 p0) { return ceil(p0); }
+
+// CHECK-LABEL: test_ceil_float5
+// CHECK: call reassoc nnan ninf nsz arcp afn <5 x float> @llvm.ceil.v5f32
+vector<float, 5> test_ceil_float5(vector<float, 5> p0) { return ceil(p0); }

--- a/clang/test/CodeGenHLSL/builtins/clamp.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/clamp.hlsl
@@ -56,6 +56,12 @@ int3 test_clamp_int3(int3 p0, int3 p1) { return clamp(p0, p1,p1); }
 // CHECK: call <4 x i32> @llvm.[[TARGET]].sclamp.v4i32
 int4 test_clamp_int4(int4 p0, int4 p1) { return clamp(p0, p1,p1); }
 
+// CHECK: define [[FNATTRS]] <5 x i32> @
+// CHECK: call <5 x i32> @llvm.[[TARGET]].sclamp.v5i32
+vector<int, 5> test_clamp_int5(vector<int, 5> p0, vector<int, 5> p1) {
+	return clamp(p0, p1, p1);
+}
+
 // CHECK: define [[FNATTRS]] i32 @_Z15test_clamp_uint
 // CHECK: call i32 @llvm.[[TARGET]].uclamp.i32(
 int test_clamp_uint(uint p0, uint p1) { return clamp(p0, p1,p1); }

--- a/clang/test/CodeGenHLSL/builtins/clip.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/clip.hlsl
@@ -2,7 +2,7 @@
 // RUN: %clang_cc1 -finclude-default-header -triple spirv-vulkan-library %s -fnative-half-type -fnative-int16-type -emit-llvm -o - | FileCheck %s --check-prefix=SPIRV
 
 
-void test_scalar(float Buf) {
+void test_clip_scalar(float Buf) {
   // CHECK:      define hidden void @{{.*}}test_scalar{{.*}}(float {{.*}} [[VALP:%.*]])
   // CHECK:      [[LOAD:%.*]] = load float, ptr [[VALP]].addr
   // CHECK-NEXT: [[FCMP:%.*]] = fcmp reassoc nnan ninf nsz arcp afn olt float [[LOAD]], 0.000000e+00
@@ -20,7 +20,7 @@ void test_scalar(float Buf) {
   clip(Buf);
 }
 
-void test_vector4(float4 Buf) {
+void test_clip_vector4(float4 Buf) {
   // CHECK:      define hidden void @{{.*}}test_vector{{.*}}(<4 x float> {{.*}} [[VALP:%.*]])
   // CHECK:      [[LOAD:%.*]] = load <4 x float>, ptr [[VALP]].addr
   // CHECK-NEXT: [[FCMP:%.*]] = fcmp reassoc nnan ninf nsz arcp afn olt <4 x float> [[LOAD]], zeroinitializer
@@ -38,7 +38,7 @@ void test_vector4(float4 Buf) {
   clip(Buf);
 }
 
-void test_vector5(vector<float, 5> Buf) {
+void test_clip_vector5(vector<float, 5> Buf) {
   // CHECK:      define hidden void @{{.*}}test_vector5{{.*}}(<5 x float> {{.*}} [[VALP:%.*]])
   // CHECK:      [[LOAD:%.*]] = load <5 x float>, ptr [[VALP]].addr
   // CHECK-NEXT: [[FCMP:%.*]] = fcmp reassoc nnan ninf nsz arcp afn olt <5 x float> [[LOAD]], zeroinitializer

--- a/clang/test/CodeGenHLSL/builtins/clip.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/clip.hlsl
@@ -3,13 +3,13 @@
 
 
 void test_clip_scalar(float Buf) {
-  // CHECK:      define hidden void @{{.*}}test_scalar{{.*}}(float {{.*}} [[VALP:%.*]])
+  // CHECK:      define hidden void @{{.*}}test_clip_scalar{{.*}}(float {{.*}} [[VALP:%.*]])
   // CHECK:      [[LOAD:%.*]] = load float, ptr [[VALP]].addr
   // CHECK-NEXT: [[FCMP:%.*]] = fcmp reassoc nnan ninf nsz arcp afn olt float [[LOAD]], 0.000000e+00
   // CHECK-NO:   call i1 @llvm.dx.any
   // CHECK-NEXT: call void @llvm.dx.discard(i1 [[FCMP]])
   //
-  // SPIRV:      define hidden spir_func void @{{.*}}test_scalar{{.*}}(float {{.*}} [[VALP:%.*]])
+  // SPIRV:      define hidden spir_func void @{{.*}}test_clip_scalar{{.*}}(float {{.*}} [[VALP:%.*]])
   // SPIRV:      [[LOAD:%.*]] = load float, ptr [[VALP]].addr
   // SPIRV-NEXT: [[FCMP:%.*]] = fcmp reassoc nnan ninf nsz arcp afn olt float [[LOAD]], 0.000000e+00
   // SPIRV-NO:   call i1 @llvm.spv.any
@@ -21,13 +21,13 @@ void test_clip_scalar(float Buf) {
 }
 
 void test_clip_vector4(float4 Buf) {
-  // CHECK:      define hidden void @{{.*}}test_vector{{.*}}(<4 x float> {{.*}} [[VALP:%.*]])
+  // CHECK:      define hidden void @{{.*}}test_clip_vector4{{.*}}(<4 x float> {{.*}} [[VALP:%.*]])
   // CHECK:      [[LOAD:%.*]] = load <4 x float>, ptr [[VALP]].addr
   // CHECK-NEXT: [[FCMP:%.*]] = fcmp reassoc nnan ninf nsz arcp afn olt <4 x float> [[LOAD]], zeroinitializer
   // CHECK-NEXT: [[ANYC:%.*]] = call i1 @llvm.dx.any.v4i1(<4 x i1> [[FCMP]])
   // CHECK-NEXT: call void @llvm.dx.discard(i1 [[ANYC]])
   //
-  // SPIRV:      define hidden spir_func void @{{.*}}test_vector{{.*}}(<4 x float> {{.*}} [[VALP:%.*]])
+  // SPIRV:      define hidden spir_func void @{{.*}}test_clip_vector4{{.*}}(<4 x float> {{.*}} [[VALP:%.*]])
   // SPIRV:      [[LOAD:%.*]] = load <4 x float>, ptr [[VALP]].addr
   // SPIRV-NEXT: [[FCMP:%.*]] = fcmp reassoc nnan ninf nsz arcp afn olt <4 x float> [[LOAD]], zeroinitializer
   // SPIRV-NEXT: [[ANYC:%.*]] = call i1 @llvm.spv.any.v4i1(<4 x i1> [[FCMP]])
@@ -39,13 +39,13 @@ void test_clip_vector4(float4 Buf) {
 }
 
 void test_clip_vector5(vector<float, 5> Buf) {
-  // CHECK:      define hidden void @{{.*}}test_vector5{{.*}}(<5 x float> {{.*}} [[VALP:%.*]])
+  // CHECK:      define hidden void @{{.*}}test_clip_vector5{{.*}}(<5 x float> {{.*}} [[VALP:%.*]])
   // CHECK:      [[LOAD:%.*]] = load <5 x float>, ptr [[VALP]].addr
   // CHECK-NEXT: [[FCMP:%.*]] = fcmp reassoc nnan ninf nsz arcp afn olt <5 x float> [[LOAD]], zeroinitializer
   // CHECK-NEXT: [[ANYC:%.*]] = call i1 @llvm.dx.any.v5i1(<5 x i1> [[FCMP]])
   // CHECK-NEXT: call void @llvm.dx.discard(i1 [[ANYC]])
   //
-  // SPIRV:      define hidden spir_func void @{{.*}}test_vector5{{.*}}(<5 x float> {{.*}} [[VALP:%.*]])
+  // SPIRV:      define hidden spir_func void @{{.*}}test_clip_vector5{{.*}}(<5 x float> {{.*}} [[VALP:%.*]])
   // SPIRV:      [[LOAD:%.*]] = load <5 x float>, ptr [[VALP]].addr
   // SPIRV-NEXT: [[FCMP:%.*]] = fcmp reassoc nnan ninf nsz arcp afn olt <5 x float> [[LOAD]], zeroinitializer
   // SPIRV-NEXT: [[ANYC:%.*]] = call i1 @llvm.spv.any.v5i1(<5 x i1> [[FCMP]])

--- a/clang/test/CodeGenHLSL/builtins/clip.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/clip.hlsl
@@ -37,3 +37,21 @@ void test_vector4(float4 Buf) {
   // SPIRV-NEXT: br label %[[ENDL]]
   clip(Buf);
 }
+
+void test_vector5(vector<float, 5> Buf) {
+  // CHECK:      define hidden void @{{.*}}test_vector5{{.*}}(<5 x float> {{.*}} [[VALP:%.*]])
+  // CHECK:      [[LOAD:%.*]] = load <5 x float>, ptr [[VALP]].addr
+  // CHECK-NEXT: [[FCMP:%.*]] = fcmp reassoc nnan ninf nsz arcp afn olt <5 x float> [[LOAD]], zeroinitializer
+  // CHECK-NEXT: [[ANYC:%.*]] = call i1 @llvm.dx.any.v5i1(<5 x i1> [[FCMP]])
+  // CHECK-NEXT: call void @llvm.dx.discard(i1 [[ANYC]])
+  //
+  // SPIRV:      define hidden spir_func void @{{.*}}test_vector5{{.*}}(<5 x float> {{.*}} [[VALP:%.*]])
+  // SPIRV:      [[LOAD:%.*]] = load <5 x float>, ptr [[VALP]].addr
+  // SPIRV-NEXT: [[FCMP:%.*]] = fcmp reassoc nnan ninf nsz arcp afn olt <5 x float> [[LOAD]], zeroinitializer
+  // SPIRV-NEXT: [[ANYC:%.*]] = call i1 @llvm.spv.any.v5i1(<5 x i1> [[FCMP]])
+  // SPIRV-NEXT: br i1 [[ANYC]], label %[[LTL:.*]], label %[[ENDL:.*]]
+  // SPIRV:      [[LTL]]: ; preds = %entry
+  // SPIRV-NEXT: call void @llvm.spv.discard()
+  // SPIRV-NEXT: br label %[[ENDL]]
+  clip(Buf);
+}

--- a/clang/test/CodeGenHLSL/builtins/cos.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/cos.hlsl
@@ -38,3 +38,7 @@ float3 test_cos_float3(float3 p0) { return cos(p0); }
 // CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> @_Z15test_cos_float4
 // CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.cos.v4f32
 float4 test_cos_float4(float4 p0) { return cos(p0); }
+
+// CHECK-LABEL: test_cos_float5
+// CHECK: call reassoc nnan ninf nsz arcp afn <5 x float> @llvm.cos.v5f32
+vector<float, 5> test_cos_float5(vector<float, 5> p0) { return cos(p0); }

--- a/clang/test/CodeGenHLSL/builtins/cosh.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/cosh.hlsl
@@ -57,3 +57,9 @@ float3 test_cosh_float3 ( float3 p0 ) {
 float4 test_cosh_float4 ( float4 p0 ) {
   return cosh ( p0 );
 }
+
+// CHECK-LABEL: test_cosh_float5
+// CHECK: call reassoc nnan ninf nsz arcp afn <5 x float> @llvm.cosh.v5f32
+vector<float, 5> test_cosh_float5(vector<float, 5> p0) {
+  return cosh(p0);
+}

--- a/clang/test/CodeGenHLSL/builtins/countbits.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/countbits.hlsl
@@ -71,6 +71,12 @@ uint4 test_countbits_uint4(uint4 p0)
 	return countbits(p0);
 }
 
+// CHECK-LABEL: test_countbits_uint5
+// CHECK: call <5 x i32> @llvm.ctpop.v5i32
+vector<uint, 5> test_countbits_uint5(vector<uint, 5> p0) {
+	return countbits(p0);
+}
+
 // CHECK-LABEL: test_countbits_long
 // CHECK: [[A:%.*]] = call i64 @llvm.ctpop.i64
 // CHECK-NEXT: trunc i64 [[A]] to i32

--- a/clang/test/CodeGenHLSL/builtins/ddx-coarse.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/ddx-coarse.hlsl
@@ -60,3 +60,10 @@ float3 test_f32_ddx_coarse3(float3 val) {
 float4 test_f32_ddx_coarse4(float4 val) {
     return ddx_coarse(val);
 }
+
+// CHECK-LABEL: <5 x float> @{{.*}}test_f32_ddx_coarse5
+// CHECK: %hlsl.ddx.coarse = call {{.*}} <5 x float> @llvm.[[TGT]].ddx.coarse.v5f32(<5 x float> %{{.*}})
+// CHECK: ret <5 x float> %hlsl.ddx.coarse
+vector<float, 5> test_f32_ddx_coarse5(vector<float, 5> val) {
+    return ddx_coarse(val);
+}

--- a/clang/test/CodeGenHLSL/builtins/ddx-fine.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/ddx-fine.hlsl
@@ -60,3 +60,10 @@ float3 test_f32_ddx_fine3(float3 val) {
 float4 test_f32_ddx_fine4(float4 val) {
     return ddx_fine(val);
 }
+
+// CHECK-LABEL: <5 x float> @{{.*}}test_f32_ddx_fine5
+// CHECK: %hlsl.ddx.fine = call {{.*}} <5 x float> @llvm.[[TGT]].ddx.fine.v5f32(<5 x float> %{{.*}})
+// CHECK: ret <5 x float> %hlsl.ddx.fine
+vector<float, 5> test_f32_ddx_fine5(vector<float, 5> val) {
+    return ddx_fine(val);
+}

--- a/clang/test/CodeGenHLSL/builtins/ddy-coarse.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/ddy-coarse.hlsl
@@ -60,3 +60,10 @@ float3 test_f32_ddy_coarse3(float3 val) {
 float4 test_f32_ddy_coarse4(float4 val) {
     return ddy_coarse(val);
 }
+
+// CHECK-LABEL: <5 x float> @{{.*}}test_f32_ddy_coarse5
+// CHECK: %hlsl.ddy.coarse = call {{.*}} <5 x float> @llvm.[[TGT]].ddy.coarse.v5f32(<5 x float> %{{.*}})
+// CHECK: ret <5 x float> %hlsl.ddy.coarse
+vector<float, 5> test_f32_ddy_coarse5(vector<float, 5> val) {
+    return ddy_coarse(val);
+}

--- a/clang/test/CodeGenHLSL/builtins/ddy-fine.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/ddy-fine.hlsl
@@ -60,3 +60,10 @@ float3 test_f32_ddy_fine3(float3 val) {
 float4 test_f32_ddy_fine4(float4 val) {
     return ddy_fine(val);
 }
+
+// CHECK-LABEL: <5 x float> @{{.*}}test_f32_ddy_fine5
+// CHECK: %hlsl.ddy.fine = call {{.*}} <5 x float> @llvm.[[TGT]].ddy.fine.v5f32(<5 x float> %{{.*}})
+// CHECK: ret <5 x float> %hlsl.ddy.fine
+vector<float, 5> test_f32_ddy_fine5(vector<float, 5> val) {
+    return ddy_fine(val);
+}

--- a/clang/test/CodeGenHLSL/builtins/exp.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/exp.hlsl
@@ -52,5 +52,6 @@ float3 test_exp_float3(float3 p0) { return exp(p0); }
 float4 test_exp_float4(float4 p0) { return exp(p0); }
 
 // CHECK-LABEL: test_exp_float5
-// CHECK: call reassoc nnan ninf nsz arcp afn <5 x float> @llvm.exp.v5f32
+// CHECK: [[EXP:%.*]] = call reassoc nnan ninf nsz arcp afn <5 x float> @llvm.exp.v5f32
+// CHECK: ret <5 x float> [[EXP]]
 vector<float, 5> test_exp_float5(vector<float, 5> p0) { return exp(p0); }

--- a/clang/test/CodeGenHLSL/builtins/exp.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/exp.hlsl
@@ -50,3 +50,7 @@ float3 test_exp_float3(float3 p0) { return exp(p0); }
 // CHECK: [[EXP:%.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.exp.v4f32
 // CHECK: ret <4 x float> [[EXP]]
 float4 test_exp_float4(float4 p0) { return exp(p0); }
+
+// CHECK-LABEL: test_exp_float5
+// CHECK: call reassoc nnan ninf nsz arcp afn <5 x float> @llvm.exp.v5f32
+vector<float, 5> test_exp_float5(vector<float, 5> p0) { return exp(p0); }

--- a/clang/test/CodeGenHLSL/builtins/exp2.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/exp2.hlsl
@@ -52,5 +52,6 @@ float3 test_exp2_float3(float3 p0) { return exp2(p0); }
 float4 test_exp2_float4(float4 p0) { return exp2(p0); }
 
 // CHECK-LABEL: test_exp2_float5
-// CHECK: call reassoc nnan ninf nsz arcp afn <5 x float> @llvm.exp2.v5f32
+// CHECK: [[EXP2:%.*]] = call reassoc nnan ninf nsz arcp afn <5 x float> @llvm.exp2.v5f32
+// CHECK: ret <5 x float> [[EXP2]]
 vector<float, 5> test_exp2_float5(vector<float, 5> p0) { return exp2(p0); }

--- a/clang/test/CodeGenHLSL/builtins/exp2.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/exp2.hlsl
@@ -50,3 +50,7 @@ float3 test_exp2_float3(float3 p0) { return exp2(p0); }
 // CHECK: [[EXP2:%.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.exp2.v4f32
 // CHECK: ret <4 x float> [[EXP2]]
 float4 test_exp2_float4(float4 p0) { return exp2(p0); }
+
+// CHECK-LABEL: test_exp2_float5
+// CHECK: call reassoc nnan ninf nsz arcp afn <5 x float> @llvm.exp2.v5f32
+vector<float, 5> test_exp2_float5(vector<float, 5> p0) { return exp2(p0); }

--- a/clang/test/CodeGenHLSL/builtins/f16tof32.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/f16tof32.hlsl
@@ -49,3 +49,13 @@ float3 test_uint3(uint3 p0) { return f16tof32(p0); }
 // SPRIV-NOT: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.spv.unpackhalf2x16.v2f32(i32 %[[#]])
 // SPRIV: ret <4 x float> %[[#]]
 float4 test_uint4(uint4 p0) { return f16tof32(p0); }
+
+// CHECK: define hidden noundef nofpclass(nan inf) <5 x float> @
+// CHECK: %hlsl.f16tof32 = call reassoc nnan ninf nsz arcp afn <5 x float> @llvm.dx.legacyf16tof32.v5i32(<5 x i32> %[[#]])
+// CHECK: ret <5 x float> %hlsl.f16tof32
+// CHECK: declare <5 x float> @llvm.dx.legacyf16tof32.v5i32(<5 x i32>)
+//
+// SPIRV: define hidden spir_func noundef nofpclass(nan inf) <5 x float> @{{.*}}test_uint5
+// SPIRV-COUNT-5: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.spv.unpackhalf2x16.v2f32(i32 %[[#]])
+// SPIRV: ret <5 x float>
+vector<float, 5> test_uint5(vector<uint, 5> p0) { return f16tof32(p0); }

--- a/clang/test/CodeGenHLSL/builtins/f32tof16.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/f32tof16.hlsl
@@ -49,3 +49,13 @@ uint3 test_uint3(float3 p0) { return f32tof16(p0); }
 // SPIRV-NOT: call i32 @llvm.spv.packhalf2x16.i32.v2f32(<2 x float> %[[#]])
 // SPIRV: ret <4 x i32> %[[#]]
 uint4 test_uint4(float4 p0) { return f32tof16(p0); }
+
+// CHECK: define hidden noundef <5 x i32> @{{.*}}test_uint5
+// CHECK: %hlsl.f32tof16 = call <5 x i32> @llvm.dx.legacyf32tof16.v5f32(<5 x float> %[[#]])
+// CHECK: ret <5 x i32> %hlsl.f32tof16
+// CHECK: declare <5 x i32> @llvm.dx.legacyf32tof16.v5f32(<5 x float>)
+//
+// SPIRV: define hidden spir_func noundef <5 x i32> @{{.*}}test_uint5
+// SPIRV-COUNT-5: call i32 @llvm.spv.packhalf2x16.i32.v2f32(<2 x float> %[[#]])
+// SPIRV: ret <5 x i32>
+vector<uint, 5> test_uint5(vector<float, 5> p0) { return f32tof16(p0); }

--- a/clang/test/CodeGenHLSL/builtins/firstbitlow.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/firstbitlow.hlsl
@@ -80,6 +80,12 @@ uint4 test_firstbitlow_uint4(uint4 p0) {
   return firstbitlow(p0);
 }
 
+// CHECK-LABEL: test_firstbitlow_uint5
+// CHECK: call <5 x i32> @llvm.[[TARGET]].firstbitlow.v5i32
+vector<uint, 5> test_firstbitlow_uint5(vector<uint, 5> p0) {
+  return firstbitlow(p0);
+}
+
 // CHECK-LABEL: test_firstbitlow_ulong
 // CHECK: call i32 @llvm.[[TARGET]].firstbitlow.i64
 uint test_firstbitlow_ulong(uint64_t p0) {

--- a/clang/test/CodeGenHLSL/builtins/floor.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/floor.hlsl
@@ -40,3 +40,7 @@ float3 test_floor_float3(float3 p0) { return floor(p0); }
 // CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> @_Z17test_floor_float4
 // CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.floor.v4f32(
 float4 test_floor_float4(float4 p0) { return floor(p0); }
+
+// CHECK-LABEL: test_floor_float5
+// CHECK: call reassoc nnan ninf nsz arcp afn <5 x float> @llvm.floor.v5f32
+vector<float, 5> test_floor_float5(vector<float, 5> p0) { return floor(p0); }

--- a/clang/test/CodeGenHLSL/builtins/fma.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/fma.hlsl
@@ -25,6 +25,14 @@ double3 fma_double3(double3 a, double3 b, double3 c) { return fma(a, b, c); }
 // CHECK: ret <4 x double>
 double4 fma_double4(double4 a, double4 b, double4 c) { return fma(a, b, c); }
 
+// CHECK-LABEL: define {{.*}} <5 x double> @{{.*}}fma_double5{{.*}}(
+// CHECK: call reassoc nnan ninf nsz arcp afn <5 x double> @llvm.fma.v5f64(<5 x double>
+// CHECK: ret <5 x double>
+vector<double, 5> fma_double5(vector<double, 5> a, vector<double, 5> b,
+                              vector<double, 5> c) {
+  return fma(a, b, c);
+}
+
 // No double1x1 fma overload exists, so overload resolution picks the scalar
 // double overload. The double1x1 matrix arguments are truncated to scalar.
 // CHECK-LABEL: define {{.*}} double @{{.*}}fma_double1x1{{.*}}(

--- a/clang/test/CodeGenHLSL/builtins/frac.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/frac.hlsl
@@ -62,3 +62,8 @@ float3 test_frac_float3(float3 p0) { return frac(p0); }
 // CHECK: %hlsl.frac = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].frac.v4f32
 // CHECK: ret <4 x float> %hlsl.frac
 float4 test_frac_float4(float4 p0) { return frac(p0); }
+
+// CHECK: define [[FNATTRS]] <5 x float> @
+// CHECK: %hlsl.frac = call reassoc nnan ninf nsz arcp afn <5 x float> @llvm.[[TARGET]].frac.v5f32
+// CHECK: ret <5 x float> %hlsl.frac
+vector<float, 5> test_frac_float5(vector<float, 5> p0) { return frac(p0); }

--- a/clang/test/CodeGenHLSL/builtins/isinf.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/isinf.hlsl
@@ -60,3 +60,8 @@ bool3 test_isinf_float3(float3 p0) { return isinf(p0); }
 // CHECK: %hlsl.isinf = call <4 x i1> @llvm.[[ICF]].isinf.v4f32
 // CHECK: ret <4 x i1> %hlsl.isinf
 bool4 test_isinf_float4(float4 p0) { return isinf(p0); }
+
+// CHECK: define hidden [[FN_TYPE]]noundef <5 x i1> @
+// CHECK: %hlsl.isinf = call <5 x i1> @llvm.[[ICF]].isinf.v5f32
+// CHECK: ret <5 x i1> %hlsl.isinf
+vector<bool, 5> test_isinf_float5(vector<float, 5> p0) { return isinf(p0); }

--- a/clang/test/CodeGenHLSL/builtins/isnan.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/isnan.hlsl
@@ -60,3 +60,8 @@ bool3 test_isnan_float3(float3 p0) { return isnan(p0); }
 // CHECK: %hlsl.isnan = call <4 x i1> @llvm.[[ICF]].isnan.v4f32
 // CHECK: ret <4 x i1> %hlsl.isnan
 bool4 test_isnan_float4(float4 p0) { return isnan(p0); }
+
+// CHECK: define hidden [[FN_TYPE]]noundef <5 x i1> @
+// CHECK: %hlsl.isnan = call <5 x i1> @llvm.[[ICF]].isnan.v5f32
+// CHECK: ret <5 x i1> %hlsl.isnan
+vector<bool, 5> test_isnan_float5(vector<float, 5> p0) { return isnan(p0); }

--- a/clang/test/CodeGenHLSL/builtins/log.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/log.hlsl
@@ -38,3 +38,7 @@ float3 test_log_float3(float3 p0) { return log(p0); }
 // CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> @_Z15test_log_float4
 // CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.log.v4f32
 float4 test_log_float4(float4 p0) { return log(p0); }
+
+// CHECK-LABEL: test_log_float5
+// CHECK: call reassoc nnan ninf nsz arcp afn <5 x float> @llvm.log.v5f32
+vector<float, 5> test_log_float5(vector<float, 5> p0) { return log(p0); }

--- a/clang/test/CodeGenHLSL/builtins/log10.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/log10.hlsl
@@ -38,3 +38,7 @@ float3 test_log10_float3(float3 p0) { return log10(p0); }
 // CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> @_Z17test_log10_float4
 // CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.log10.v4f32
 float4 test_log10_float4(float4 p0) { return log10(p0); }
+
+// CHECK-LABEL: test_log10_float5
+// CHECK: call reassoc nnan ninf nsz arcp afn <5 x float> @llvm.log10.v5f32
+vector<float, 5> test_log10_float5(vector<float, 5> p0) { return log10(p0); }

--- a/clang/test/CodeGenHLSL/builtins/log2.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/log2.hlsl
@@ -38,3 +38,7 @@ float3 test_log2_float3(float3 p0) { return log2(p0); }
 // CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> @_Z16test_log2_float4
 // CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.log2.v4f32
 float4 test_log2_float4(float4 p0) { return log2(p0); }
+
+// CHECK-LABEL: test_log2_float5
+// CHECK: call reassoc nnan ninf nsz arcp afn <5 x float> @llvm.log2.v5f32
+vector<float, 5> test_log2_float5(vector<float, 5> p0) { return log2(p0); }

--- a/clang/test/CodeGenHLSL/builtins/max.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/max.hlsl
@@ -46,6 +46,12 @@ int3 test_max_int3(int3 p0, int3 p1) { return max(p0, p1); }
 // CHECK: call <4 x i32> @llvm.smax.v4i32
 int4 test_max_int4(int4 p0, int4 p1) { return max(p0, p1); }
 
+// CHECK-LABEL: test_max_int5
+// CHECK: call <5 x i32> @llvm.smax.v5i32
+vector<int, 5> test_max_int5(vector<int, 5> p0, vector<int, 5> p1) {
+	return max(p0, p1);
+}
+
 // CHECK-LABEL: define hidden noundef i32 @_Z13test_max_uint
 // CHECK: call i32 @llvm.umax.i32(
 int test_max_uint(uint p0, uint p1) { return max(p0, p1); }

--- a/clang/test/CodeGenHLSL/builtins/min.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/min.hlsl
@@ -46,6 +46,12 @@ int3 test_min_int3(int3 p0, int3 p1) { return min(p0, p1); }
 // CHECK: call <4 x i32> @llvm.smin.v4i32
 int4 test_min_int4(int4 p0, int4 p1) { return min(p0, p1); }
 
+// CHECK-LABEL: test_min_int5
+// CHECK: call <5 x i32> @llvm.smin.v5i32
+vector<int, 5> test_min_int5(vector<int, 5> p0, vector<int, 5> p1) {
+	return min(p0, p1);
+}
+
 // CHECK-LABEL: define hidden noundef i32 @_Z13test_min_uint
 // CHECK: call i32 @llvm.umin.i32(
 int test_min_uint(uint p0, uint p1) { return min(p0, p1); }

--- a/clang/test/CodeGenHLSL/builtins/pow.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/pow.hlsl
@@ -42,6 +42,6 @@ float4 test_pow_float4(float4 p0, float4 p1) { return pow(p0, p1); }
 // CHECK-LABEL: test_pow_float5
 // CHECK: call reassoc nnan ninf nsz arcp afn <5 x float> @llvm.pow.v5f32
 vector<float, 5> test_pow_float5(vector<float, 5> p0,
-																 vector<float, 5> p1) {
+								 vector<float, 5> p1) {
 	return pow(p0, p1);
 }

--- a/clang/test/CodeGenHLSL/builtins/pow.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/pow.hlsl
@@ -38,3 +38,10 @@ float3 test_pow_float3(float3 p0, float3 p1) { return pow(p0, p1); }
 // CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> @_Z15test_pow_float4
 // CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.pow.v4f32
 float4 test_pow_float4(float4 p0, float4 p1) { return pow(p0, p1); }
+
+// CHECK-LABEL: test_pow_float5
+// CHECK: call reassoc nnan ninf nsz arcp afn <5 x float> @llvm.pow.v5f32
+vector<float, 5> test_pow_float5(vector<float, 5> p0,
+																 vector<float, 5> p1) {
+	return pow(p0, p1);
+}

--- a/clang/test/CodeGenHLSL/builtins/rcp.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/rcp.hlsl
@@ -77,6 +77,12 @@ float3 test_rcp_float3(float3 p0) { return rcp(p0); }
 // CHECK: ret <4 x float> %hlsl.rcp
 float4 test_rcp_float4(float4 p0) { return rcp(p0); }
 
+// DXIL_CHECK: define hidden noundef nofpclass(nan inf) <5 x float> @
+// SPIR_CHECK: define hidden spir_func noundef nofpclass(nan inf) <5 x float> @
+// CHECK: %hlsl.rcp = fdiv reassoc nnan ninf nsz arcp afn <5 x float> splat (float 1.000000e+00), %{{.*}}
+// CHECK: ret <5 x float> %hlsl.rcp
+vector<float, 5> test_rcp_float5(vector<float, 5> p0) { return rcp(p0); }
+
 // DXIL_CHECK: define hidden noundef nofpclass(nan inf) double @
 // SPIR_CHECK: define hidden spir_func noundef nofpclass(nan inf) double @
 // CHECK: %hlsl.rcp = fdiv reassoc nnan ninf nsz arcp afn double 1.000000e+00, %{{.*}} 

--- a/clang/test/CodeGenHLSL/builtins/reversebits.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/reversebits.hlsl
@@ -54,6 +54,12 @@ uint4 test_bitreverse_uint4(uint4 p0)
 	return reversebits(p0);
 }
 
+// CHECK: define hidden noundef <5 x i32> @
+// CHECK: call <5 x i32> @llvm.bitreverse.v5i32
+vector<uint, 5> test_bitreverse_uint5(vector<uint, 5> p0) {
+	return reversebits(p0);
+}
+
 // CHECK: define hidden noundef i64 @
 // CHECK: call i64 @llvm.bitreverse.i64(
 uint64_t test_bitreverse_long(uint64_t p0)

--- a/clang/test/CodeGenHLSL/builtins/round.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/round.hlsl
@@ -50,3 +50,7 @@ float3 test_round_float3(float3 p0) { return round(p0); }
 // CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.roundeven.v4f32
 // CHECK: ret <4 x float> [[ROUNDEVEN]]
 float4 test_round_float4(float4 p0) { return round(p0); }
+
+// CHECK-LABEL: test_round_float5
+// CHECK: call reassoc nnan ninf nsz arcp afn <5 x float> @llvm.roundeven.v5f32
+vector<float, 5> test_round_float5(vector<float, 5> p0) { return round(p0); }

--- a/clang/test/CodeGenHLSL/builtins/rsqrt.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/rsqrt.hlsl
@@ -62,3 +62,8 @@ float3 test_rsqrt_float3(float3 p0) { return rsqrt(p0); }
 // CHECK: %hlsl.rsqrt = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].rsqrt.v4f32
 // CHECK: ret <4 x float> %hlsl.rsqrt
 float4 test_rsqrt_float4(float4 p0) { return rsqrt(p0); }
+
+// CHECK: define [[FNATTRS]] <5 x float> @
+// CHECK: %hlsl.rsqrt = call reassoc nnan ninf nsz arcp afn <5 x float> @llvm.[[TARGET]].rsqrt.v5f32
+// CHECK: ret <5 x float> %hlsl.rsqrt
+vector<float, 5> test_rsqrt_float5(vector<float, 5> p0) { return rsqrt(p0); }

--- a/clang/test/CodeGenHLSL/builtins/saturate.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/saturate.hlsl
@@ -46,6 +46,12 @@ float3 test_saturate_float3(float3 p0) { return saturate(p0); }
 // CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[tar]].saturate.v4f32
 float4 test_saturate_float4(float4 p0) { return saturate(p0); }
 
+// CHECK-LABEL: define{{.*}} <5 x float> @{{.*}}test_saturate_float5{{.*}}(<5 x float>
+// CHECK: call reassoc nnan ninf nsz arcp afn <5 x float> @llvm.[[tar]].saturate.v5f32(
+vector<float, 5> test_saturate_float5(vector<float, 5> p0) {
+	return saturate(p0);
+}
+
 // CHECK-LABEL: define{{.*}} double @_Z20test_saturate_doubled(double
 // CHECK: call reassoc nnan ninf nsz arcp afn double @llvm.[[tar]].saturate.f64(
 double test_saturate_double(double p0) { return saturate(p0); }

--- a/clang/test/CodeGenHLSL/builtins/sign.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/sign.hlsl
@@ -70,6 +70,11 @@ int3 test_sign_float3(float3 p0) { return sign(p0); }
 // CHECK: ret <4 x i32> %hlsl.sign
 int4 test_sign_float4(float4 p0) { return sign(p0); }
 
+// CHECK: define [[FNATTRS]] <5 x i32> @
+// CHECK: %hlsl.sign = call <5 x i32> @llvm.[[TARGET]].sign.v5f32(
+// CHECK: ret <5 x i32> %hlsl.sign
+vector<int, 5> test_sign_float5(vector<float, 5> p0) { return sign(p0); }
+
 
 // CHECK: define [[FNATTRS]] i32 @
 // CHECK: %hlsl.sign = call i32 @llvm.[[TARGET]].sign.f64(

--- a/clang/test/CodeGenHLSL/builtins/sin.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/sin.hlsl
@@ -38,3 +38,7 @@ float3 test_sin_float3(float3 p0) { return sin(p0); }
 // CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> @_Z15test_sin_float4
 // CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.sin.v4f32
 float4 test_sin_float4(float4 p0) { return sin(p0); }
+
+// CHECK-LABEL: test_sin_float5
+// CHECK: call reassoc nnan ninf nsz arcp afn <5 x float> @llvm.sin.v5f32
+vector<float, 5> test_sin_float5(vector<float, 5> p0) { return sin(p0); }

--- a/clang/test/CodeGenHLSL/builtins/sinh.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/sinh.hlsl
@@ -57,3 +57,9 @@ float3 test_sinh_float3 ( float3 p0 ) {
 float4 test_sinh_float4 ( float4 p0 ) {
   return sinh ( p0 );
 }
+
+// CHECK-LABEL: test_sinh_float5
+// CHECK: call reassoc nnan ninf nsz arcp afn <5 x float> @llvm.sinh.v5f32
+vector<float, 5> test_sinh_float5(vector<float, 5> p0) {
+  return sinh(p0);
+}

--- a/clang/test/CodeGenHLSL/builtins/sqrt.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/sqrt.hlsl
@@ -50,3 +50,7 @@ float3 test_sqrt_float3(float3 p0) { return sqrt(p0); }
 // CHECK: %{{.*}} = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.sqrt.v4f32
 // CHECK: ret <4 x float> %{{.*}}
 float4 test_sqrt_float4(float4 p0) { return sqrt(p0); }
+
+// CHECK-LABEL: test_sqrt_float5
+// CHECK: call reassoc nnan ninf nsz arcp afn <5 x float> @llvm.sqrt.v5f32
+vector<float, 5> test_sqrt_float5(vector<float, 5> p0) { return sqrt(p0); }

--- a/clang/test/CodeGenHLSL/builtins/tan.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/tan.hlsl
@@ -57,3 +57,9 @@ float3 test_tan_float3 ( float3 p0 ) {
 float4 test_tan_float4 ( float4 p0 ) {
   return tan ( p0 );
 }
+
+// CHECK-LABEL: test_tan_float5
+// CHECK: call reassoc nnan ninf nsz arcp afn <5 x float> @llvm.tan.v5f32
+vector<float, 5> test_tan_float5(vector<float, 5> p0) {
+  return tan(p0);
+}

--- a/clang/test/CodeGenHLSL/builtins/tanh.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/tanh.hlsl
@@ -57,3 +57,9 @@ float3 test_tanh_float3 ( float3 p0 ) {
 float4 test_tanh_float4 ( float4 p0 ) {
   return tanh ( p0 );
 }
+
+// CHECK-LABEL: test_tanh_float5
+// CHECK: call reassoc nnan ninf nsz arcp afn <5 x float> @llvm.tanh.v5f32
+vector<float, 5> test_tanh_float5(vector<float, 5> p0) {
+  return tanh(p0);
+}

--- a/clang/test/CodeGenHLSL/builtins/trunc.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/trunc.hlsl
@@ -44,3 +44,7 @@ float3 test_trunc_float3(float3 p0) { return trunc(p0); }
 // CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> @_Z17test_trunc_float4
 // CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.trunc.v4f32
 float4 test_trunc_float4(float4 p0) { return trunc(p0); }
+
+// CHECK-LABEL: test_trunc_float5
+// CHECK: call reassoc nnan ninf nsz arcp afn <5 x float> @llvm.trunc.v5f32
+vector<float, 5> test_trunc_float5(vector<float, 5> p0) { return trunc(p0); }

--- a/clang/test/SemaHLSL/BuiltIns/clamp-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/clamp-errors.hlsl
@@ -42,14 +42,6 @@ float2 test_clamp_vector_size_last_arg_mismatch(float3 p0, float2 p1) {
   // expected-warning@-1 2{{implicit conversion truncates vector: 'float3' (aka 'vector<float, 3>') to 'vector<float, 2>' (vector of 2 'float' values)}}
 }
 
-typedef float float5 __attribute__((ext_vector_type(5)));
-
-// check vectors of wrong size are rejected
-float5 vec_too_big(float5 p0) {
-  return clamp(p0, p0, p0);
-  // expected-error@-1 {{call to 'clamp' is ambiguous}}
-}
-
 float2 test_clamp_vector_size_ret_mismatch(float3 p0, float3 p1) {
   return clamp(p0, p0, p1);
   // expected-warning@-1 {{implicit conversion truncates vector: 'float3' (aka 'vector<float, 3>') to 'vector<float, 2>' (vector of 2 'float' values)}}

--- a/clang/test/SemaHLSL/BuiltIns/f16tof32-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/f16tof32-errors.hlsl
@@ -4,12 +4,14 @@ float builtin_f16tof32_too_few_arg() {
   return __builtin_hlsl_elementwise_f16tof32();
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
   // expected-note@hlsl/hlsl_alias_intrinsics_gen.inc:* 4 {{candidate function not viable: requires 1 argument, but 0 were provided}}
+  // expected-note@hlsl/hlsl_alias_intrinsics_gen.inc:* {{candidate function template not viable: requires 1 argument, but 0 were provided}}
 }
 
 float builtin_f16tof32_too_many_arg(uint p0) {
   return __builtin_hlsl_elementwise_f16tof32(p0, p0);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
   // expected-note@hlsl/hlsl_alias_intrinsics_gen.inc:* 4 {{candidate function not viable: requires 1 argument, but 2 were provided}}
+  // expected-note@hlsl/hlsl_alias_intrinsics_gen.inc:* {{candidate function template not viable: requires 1 argument, but 2 were provided}}
 }
 
 float builtin_f16tof32_bool(bool p0) {

--- a/clang/test/SemaHLSL/BuiltIns/f32tof16-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/f32tof16-errors.hlsl
@@ -4,12 +4,14 @@ uint builtin_f32tof16_too_few_arg() {
   return __builtin_hlsl_elementwise_f32tof16();
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
   // expected-note@hlsl/hlsl_alias_intrinsics_gen.inc:* 4 {{candidate function not viable: requires 1 argument, but 0 were provided}}
+  // expected-note@hlsl/hlsl_alias_intrinsics_gen.inc:* {{candidate function template not viable: requires 1 argument, but 0 were provided}}
 }
 
 uint builtin_f32tof16_too_many_arg(uint p0) {
   return __builtin_hlsl_elementwise_f32tof16(p0, p0);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
   // expected-note@hlsl/hlsl_alias_intrinsics_gen.inc:* 4 {{candidate function not viable: requires 1 argument, but 2 were provided}}
+  // expected-note@hlsl/hlsl_alias_intrinsics_gen.inc:* {{candidate function template not viable: requires 1 argument, but 2 were provided}}
 }
 
 uint builtin_f32tof16_bool(bool p0) {


### PR DESCRIPTION
resolves #216103

This change turns on VaryingLongVector for all HLSL intrinsics that map to an elementwise builtin.

assisted by  GPT 5.6-Sol via Copilot