### PR TITLE
[clang][Driver][OpenBSD] Pass -pie for static PIE links

### DIFF
--- a/clang/lib/Driver/ToolChains/OpenBSD.cpp
+++ b/clang/lib/Driver/ToolChains/OpenBSD.cpp
@@ -119,6 +119,8 @@ void openbsd::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   const bool Pie = Args.hasArg(options::OPT_pie);
   const bool Nopie = Args.hasArg(options::OPT_no_pie, options::OPT_nopie);
   const bool Relocatable = Args.hasArg(options::OPT_r);
+  const bool StaticPie =
+      Static && !Shared && !Profiling && !Nopie && !Relocatable;
   ArgStringList CmdArgs;
 
   // Silence warning for "clang -g foo.o -o foo"
@@ -156,7 +158,9 @@ void openbsd::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     }
   }
 
-  if (Pie)
+  // OpenBSD's system linker defaults to PIE, but cross-linkers may not.
+  // Explicitly pass -pie so that rcrt0.o's reference to _DYNAMIC is resolved.
+  if (Pie || StaticPie)
     CmdArgs.push_back("-pie");
   if (Nopie || Profiling)
     CmdArgs.push_back("-nopie");
@@ -180,7 +184,7 @@ void openbsd::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     if (!Shared) {
       if (Profiling)
         crt0 = "gcrt0.o";
-      else if (Static && !Nopie)
+      else if (StaticPie)
         crt0 = "rcrt0.o";
       else
         crt0 = "crt0.o";

--- a/clang/test/Driver/openbsd.c
+++ b/clang/test/Driver/openbsd.c
@@ -104,6 +104,7 @@
 // CHECK-PIE: "{{.*}}crt0.o"
 // CHECK-PIE-NOT: "-nopie"
 // CHECK-PIE-FLAG: "-pie"
+// CHECK-STATIC-PIE: "-pie"
 // CHECK-STATIC-PIE: "{{.*}}rcrt0.o"
 // CHECK-STATIC-PIE-NOT: "-nopie"
 // CHECK-NOPIE: "-nopie" "{{.*}}crt0.o"


### PR DESCRIPTION
## Summary

Pass `-pie` explicitly when the OpenBSD driver selects the static PIE
startup path.

OpenBSD uses `rcrt0.o` for static PIE executables. This startup object
references the linker-defined `_DYNAMIC` symbol.

OpenBSD's system linker defaults to PIE, which previously masked the
missing driver flag. An LLD cross-linker built on a non-OpenBSD host
does not share that default. Consequently,
`clang --target=...-openbsd -static` selects `rcrt0.o`, but LLD does not
create `_DYNAMIC`, causing the link to fail.

Passing `-pie` explicitly makes the target behavior independent of the
linker's build host. Shared, relocatable, profiling, and explicit
`-nopie` links remain unchanged.

## Testing

- `clang-format --dry-run --Werror clang/lib/Driver/ToolChains/OpenBSD.cpp`
- `git diff --check`
- built `OpenBSD.cpp.o` in a minimal Clang/LLVM build
- verified that the new `FileCheck` assertion detects the unpatched driver

---

_AI assistance: Codex (GPT-5.6-Sol) was used while developing this patch; I reviewed and understand the changes._