### PR TITLE
[BPF] Fix miscompile when conditional branch targets empty MBB

### DIFF
--- a/llvm/lib/Target/BPF/BPFMIPeephole.cpp
+++ b/llvm/lib/Target/BPF/BPFMIPeephole.cpp
@@ -23,6 +23,8 @@
 #include "BPF.h"
 #include "BPFInstrInfo.h"
 #include "BPFTargetMachine.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/CodeGen/LivePhysRegs.h"
@@ -337,6 +339,7 @@ private:
   bool adjustBranch();
   bool insertMissingCallerSavedSpills();
   bool removeMayGotoZero();
+  bool addExitToEmptyBranchTargets();
   bool addExitAfterUnreachable();
 
 public:
@@ -349,6 +352,7 @@ public:
       Changed |= adjustBranch();
     Changed |= insertMissingCallerSavedSpills();
     Changed |= removeMayGotoZero();
+    Changed |= addExitToEmptyBranchTargets();
     Changed |= addExitAfterUnreachable();
     return Changed;
   }
@@ -752,6 +756,58 @@ bool BPFMIPreEmitPeepholeImpl::removeMayGotoZero() {
     }
   }
 
+  return Changed;
+}
+
+static bool emitsBPFCode(const MachineInstr &MI) {
+  if (MI.isDebugInstr() || MI.isMetaInstruction())
+    return false;
+  switch (MI.getOpcode()) {
+  case TargetOpcode::INLINEASM:
+  case TargetOpcode::INLINEASM_BR:
+  case TargetOpcode::MEMBARRIER:
+  case TargetOpcode::IMPLICIT_DEF:
+  case TargetOpcode::KILL:
+  case TargetOpcode::FAKE_USE:
+    return false;
+  default:
+    return true;
+  }
+}
+
+static bool isZeroInstructionMBB(const MachineBasicBlock &MBB) {
+  return !any_of(MBB.instrs(), emitsBPFCode);
+}
+
+static void collectCondBranchTargets(
+    MachineFunction &MF, SmallPtrSet<MachineBasicBlock *, 8> &Targets) {
+  for (MachineBasicBlock &MBB : MF) {
+    for (MachineInstr &Term : MBB.terminators()) {
+      if (!Term.isConditionalBranch())
+        continue;
+      for (const MachineOperand &MO : Term.operands()) {
+        if (MO.isMBB())
+          Targets.insert(MO.getMBB());
+      }
+    }
+  }
+}
+
+// Empty MBBs still get labels (see AsmPrinter::shouldEmitLabelForBasicBlock)
+// but may emit no BPF bytes, so PC-relative branch fixups resolve to the wrong
+// address. Materialize exit in zero-instruction conditional branch targets.
+bool BPFMIPreEmitPeepholeImpl::addExitToEmptyBranchTargets() {
+  SmallPtrSet<MachineBasicBlock *, 8> CondTargets;
+  collectCondBranchTargets(*MF, CondTargets);
+
+  bool Changed = false;
+  for (MachineBasicBlock *MBB : CondTargets) {
+    if (!isZeroInstructionMBB(*MBB))
+      continue;
+    BuildMI(*MBB, MBB->begin(), MBB->findDebugLoc(MBB->begin()),
+            TII->get(BPF::RET));
+    Changed = true;
+  }
   return Changed;
 }
 

--- a/llvm/lib/Target/BPF/BPFMIPeephole.cpp
+++ b/llvm/lib/Target/BPF/BPFMIPeephole.cpp
@@ -779,8 +779,9 @@ static bool isZeroInstructionMBB(const MachineBasicBlock &MBB) {
   return !any_of(MBB.instrs(), emitsBPFCode);
 }
 
-static void collectCondBranchTargets(
-    MachineFunction &MF, SmallPtrSet<MachineBasicBlock *, 8> &Targets) {
+static void
+collectCondBranchTargets(MachineFunction &MF,
+                         SmallPtrSet<MachineBasicBlock *, 8> &Targets) {
   for (MachineBasicBlock &MBB : MF) {
     for (MachineInstr &Term : MBB.terminators()) {
       if (!Term.isConditionalBranch())

--- a/llvm/test/CodeGen/BPF/branch-empty-successor.ll
+++ b/llvm/test/CodeGen/BPF/branch-empty-successor.ll
@@ -1,0 +1,77 @@
+; RUN: llc -mtriple=bpfel -mcpu=v4 -verify-machineinstrs -filetype=obj -o - %s \
+; RUN:   | llvm-objdump --no-show-raw-insn -d - | FileCheck %s
+; RUN: llc -mtriple=bpfel -mcpu=v2 -verify-machineinstrs -filetype=obj -o - %s \
+; RUN:   | llvm-objdump --no-show-raw-insn -d - | FileCheck %s
+
+; Test fix for GitHub issue #208984: conditional branches to basic blocks that
+; lower to zero BPF instructions must not resolve to the wrong PC.
+
+target triple = "bpf"
+
+; Case 1: branch to bare unreachable block (minbug.ll from #208984).
+define void @f(i1 %c) {
+  br i1 %c, label %empty, label %fall
+fall:
+  store i32 0, ptr null, align 4
+  unreachable
+empty:
+  unreachable
+}
+
+define void @next() { ret void }
+
+; Case 2: branch to barrier-only block (C reproducer shape from #208984).
+define void @g(i1 %cond) {
+entry:
+  br i1 %cond, label %skip, label %raise
+raise:
+  tail call void @raise_fn()
+  unreachable
+skip:
+  tail call void asm sideeffect "", "~{memory}"()
+  unreachable
+}
+
+declare void @raise_fn() #0
+attributes #0 = { noreturn }
+
+; Case 3: conditional branch target with debug info only (no BPF code).
+define void @h(i1 %c) !dbg !6 {
+entry:
+  br i1 %c, label %skip, label %fall, !dbg !10
+fall:
+  store i32 0, ptr null, align 4, !dbg !10
+  unreachable
+skip:
+  call void @llvm.dbg.value(metadata i1 %c, metadata !11, metadata !DIExpression()), !dbg !10
+  unreachable
+}
+
+declare void @llvm.dbg.value(metadata, metadata, metadata) #1
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+
+!llvm.dbg.cu = !{!0}
+!0 = distinct !DICompileUnit(language: DW_LANG_C, file: !1, producer: "clang", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "branch-empty-successor.ll", directory: "/tmp")
+!6 = distinct !DISubprogram(name: "h", scope: !1, file: !1, line: 1, type: !7, scopeLine: 1, spFlags: DISPFlagDefinition, unit: !0)
+!7 = !DISubroutineType(types: !8)
+!8 = !{null, !9}
+!9 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!10 = !DILocation(line: 1, column: 1, scope: !6)
+!11 = !DILocalVariable(name: "c", arg: 1, scope: !6, file: !1, line: 1, type: !9)
+
+; CHECK-LABEL: <f>:
+; CHECK:       goto
+; CHECK:       exit
+; CHECK-NOT:   <next>
+; CHECK-LABEL: <next>:
+; CHECK:       exit
+
+; CHECK-LABEL: <g>:
+; CHECK:       goto
+; CHECK:       exit
+; CHECK-NOT:   call
+
+; CHECK-LABEL: <h>:
+; CHECK:       goto
+; CHECK:       exit


### PR DESCRIPTION
## Summary

Fixes a silent BPF backend miscompile ([issue #208984](https://github.com/llvm/llvm-project/issues/208984)) where a conditional branch whose target basic block lowers to zero BPF instructions (e.g. `unreachable` or an empty inline-asm memory barrier) lands on the wrong address. The skip path could jump into a `call` or the next function instead of the intended successor.

Empty blocks still get assembly labels (`AsmPrinter::shouldEmitLabelForBasicBlock`), but emit no instructions, so PC-relative branch fixups resolve to the wrong offset. The fix materializes an `exit` in any zero-instruction MBB that is a conditional-branch target, during `BPFMIPreEmitPeephole`, so every branch target has a real in-function instruction address.

Fixes #208984

## Test plan

- [x] `llvm-lit llvm/test/CodeGen/BPF/branch-empty-successor.ll` (minbug.ll shape, barrier-only block, debug-only target block; v2 and v4)