### PR TITLE
GlobalISel: Add m_PosZeroFP matcher and use it in AArch64 selector

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/MIPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/MIPatternMatch.h
@@ -190,6 +190,23 @@ m_GFCstOrSplat(std::optional<FPValueAndVReg> &FPValReg) {
   return GFCstOrSplatGFCstMatch(FPValReg);
 }
 
+/// Matches an FP constant whose value satisfies the given predicate.
+template <typename Pred> struct GFCstPredMatch {
+  Pred P;
+  GFCstPredMatch(Pred P) : P(P) {}
+  bool match(const MachineRegisterInfo &MRI, Register Reg) {
+    if (const ConstantFP *FPImm = getConstantFPVRegVal(Reg, MRI))
+      return P(FPImm->getValueAPF());
+    return false;
+  }
+};
+template <typename Pred> GFCstPredMatch(Pred) -> GFCstPredMatch<Pred>;
+
+/// Matches a floating-point positive zero.
+inline auto m_PosZeroFP() {
+  return GFCstPredMatch([](const APFloat &V) { return V.isPosZero(); });
+}
+
 /// Matcher for a specific constant value.
 struct SpecificConstantMatch {
   APInt RequestedVal;

--- a/llvm/lib/Target/AArch64/GISel/AArch64InstructionSelector.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64InstructionSelector.cpp
@@ -4477,8 +4477,7 @@ MachineInstr *AArch64InstructionSelector::emitFPCompare(
 
   // If this is a compare against +0.0, then we don't have
   // to explicitly materialize a constant.
-  const ConstantFP *FPImm = getConstantFPVRegVal(RHS, MRI);
-  bool ShouldUseImm = FPImm && (FPImm->isZero() && !FPImm->isNegative());
+  bool ShouldUseImm = mi_match(RHS, MRI, m_PosZeroFP());
 
   auto IsEqualityPred = [](CmpInst::Predicate P) {
     return P == CmpInst::FCMP_OEQ || P == CmpInst::FCMP_ONE ||
@@ -4486,8 +4485,7 @@ MachineInstr *AArch64InstructionSelector::emitFPCompare(
   };
   if (!ShouldUseImm && Pred && IsEqualityPred(*Pred)) {
     // Try commuting the operands.
-    const ConstantFP *LHSImm = getConstantFPVRegVal(LHS, MRI);
-    if (LHSImm && (LHSImm->isZero() && !LHSImm->isNegative())) {
+    if (mi_match(LHS, MRI, m_PosZeroFP())) {
       ShouldUseImm = true;
       std::swap(LHS, RHS);
     }


### PR DESCRIPTION
Add an FP-constant predicate matcher m_PosZeroFP, mirroring the IR
PatternMatch helper, and use it in emitFPCompare instead of binding the
ConstantFP just to test for +0.0. NFC.

Co-authored-by: Claude (Opus 4.8) <noreply@anthropic.com>