### PR TITLE
[LinkerWrapper] Use a four component triple for the host bundle entry

### DIFF
--- a/clang/test/OffloadTools/clang-linker-wrapper/linker-wrapper.c
+++ b/clang/test/OffloadTools/clang-linker-wrapper/linker-wrapper.c
@@ -133,6 +133,16 @@ __attribute__((visibility("protected"), used)) int x;
 // HIP: clang{{.*}} -o [[IMG_GFX908:.+]] -dumpdir a.out.amdgpu9.08.gfx908.img. --target=amdgpu9.08-amd-amdhsa -mcpu=gfx908
 // HIP: clang-offload-bundler{{.*}}-type=o -bundle-align=4096 -compress -compression-level=6 -targets=host-x86_64-unknown-linux-gnu,hip-amdgpu9.0a-amd-amdhsa--gfx90a,hip-amdgpu9.08-amd-amdhsa--gfx908 -input={{/dev/null|NUL}} -input=[[IMG_GFX90A]] -input=[[IMG_GFX908]] -output={{.*}}.hipfb
 
+// The host entry is a bundle entry ID like any other, so it must name a four
+// component triple even if the host triple was spelled with fewer.
+// RUN: llvm-offload-binary -o %t.out \
+// RUN:   --image=file=%t.elf.o,kind=hip,triple=amdgpu9.0a-amd-amdhsa,arch=gfx90a
+// RUN: clang-linker-wrapper --dry-run --host-triple=x86_64-apple-macosx15.0.0 \
+// RUN:   --emit-fatbin-only --linker-path=/usr/bin/ld %t.out -o %t.hipfb 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=HIP-HOST-TRIPLE
+
+// HIP-HOST-TRIPLE: clang-offload-bundler{{.*}} -targets=host-x86_64-apple-macosx15.0.0-unknown,hip-amdgpu9.0a-amd-amdhsa--gfx90a
+
 // RUN: llvm-offload-binary -o %t.out \
 // RUN:   --image=file=%t.elf.o,kind=openmp,triple=amdgpu9.08-amd-amdhsa,arch=gfx908 \
 // RUN:   --image=file=%t.elf.o,kind=openmp,triple=nvptx64-nvidia-cuda,arch=sm_70

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -475,10 +475,14 @@ fatbinary(ArrayRef<std::tuple<StringRef, StringRef, StringRef>> InputFiles,
     CmdArgs.push_back(
         Args.MakeArgString(Twine("-compression-level=") + Arg->getValue()));
 
+  // The bundle entry ID of the host entry must be a four component triple,
+  // just like the device entries, because `clang-offload-bundler` parses every
+  // entry as `<kind>-<arch>-<vendor>-<os>-<env>`.
   llvm::Triple HostTriple(
       Args.getLastArgValue(OPT_host_triple_EQ, sys::getDefaultTargetTriple()));
   SmallVector<StringRef> Targets = {
-      Saver.save("-targets=host-" + HostTriple.normalize())};
+      Saver.save("-targets=host-" +
+                 normalizeForBundler(HostTriple, /*HasTargetID=*/false))};
   for (const auto &[File, TripleRef, Arch] : InputFiles) {
     std::string NormalizedTriple =
         normalizeForBundler(Triple(TripleRef), !Arch.empty());


### PR DESCRIPTION
`clang-offload-bundler` parses every bundle entry ID as `<kind>-<arch>-<vendor>-<os>-<env>` and requires all five fields:

```cpp
  // <kind>-<triple>[-<target id>[:target features]]
  // <triple> := <arch>-<vendor>-<os>-<env>
  SmallVector<StringRef, 6> Components;
  Target.split(Components, '-', /*MaxSplit=*/5);
  assert((Components.size() == 5 || Components.size() == 6) &&
         "malformed target string");
```
(`clang/lib/Driver/OffloadBundler.cpp`, `OffloadTargetInfo::OffloadTargetInfo`)

The device entries the linker wrapper writes go through `normalizeForBundler()`, which normalizes with `CanonicalForm::FOUR_IDENT`. The host entry does not, it uses the default canonical form, which keeps however many components the host triple was spelled with. So a three component host triple produces a four field entry ID:

```
$ clang-linker-wrapper --dry-run --host-triple=x86_64-apple-macosx15.0.0 \
    --emit-fatbin-only --linker-path=/usr/bin/ld hip.out -o out.hipfb
"clang-offload-bundler" -type=o -bundle-align=4096 \
  -targets=host-x86_64-apple-macosx15.0.0,hip-amdgpu9.0a-amd-amdhsa--gfx90a ...
```

Reading that bundle back trips the assertion above, and in a build without assertions the four element `Components` is read as if it had five.

`--host-triple=spirv64-amd-amdhsa`, as used by `linker-wrapper-hip-amdgcnspirv.c`, has the same problem today.

This normalizes the host entry with `normalizeForBundler()` too, so it is spelled the same way as the device entries. Nothing changes for the four component host triples (`x86_64-unknown-linux-gnu`, `x86_64-unknown-windows-msvc`) that the existing tests use. The host entry is a dummy whose input is `/dev/null`, so only its spelling changes, not what can be unbundled out of the fat binary.

That `clang-offload-bundler` asserts on such an entry rather than diagnosing it is a separate problem and is not addressed here.

Follow up to #183991.
