### PR TITLE
[LinkerWrapper] Do not mistake ld64's -lto_library for -l<libname>

### DIFF
--- a/clang/test/OffloadTools/clang-linker-wrapper/linker-wrapper.c
+++ b/clang/test/OffloadTools/clang-linker-wrapper/linker-wrapper.c
@@ -77,6 +77,15 @@ __attribute__((visibility("protected"), used)) int x;
 // HOST-LINK: ld.lld{{.*}}-a -b -c {{.*}}.o -o a.out
 // HOST-LINK-NOT: ld.lld{{.*}}-abc
 
+// The ld64 options that begin with `-l` or `-o` must not be mistaken for
+// `-l<libname>` and `-o <path>`; clang's Darwin toolchain passes them.
+// RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t.o
+// RUN: clang-linker-wrapper --dry-run --host-triple=x86_64-apple-macosx15.0.0 \
+// RUN:   --linker-path=/usr/bin/ld -lto_library /lib/libLTO.dylib \
+// RUN:   -object_path_lto /tmp/lto.o %t.o -o a.out 2>&1 | FileCheck %s --check-prefix=LD64-LINK
+
+// LD64-LINK: ld{{.*}}-lto_library /lib/libLTO.dylib -object_path_lto /tmp/lto.o {{.*}}.o -o a.out
+
 // RUN: llvm-offload-binary -o %t-lib.out \
 // RUN:   --image=file=%t.elf.o,kind=openmp,triple=nvptx64-nvidia-cuda,arch=sm_70 \
 // RUN:   --image=file=%t.elf.o,kind=cuda,triple=nvptx64-nvidia-cuda,arch=sm_52

--- a/clang/tools/clang-linker-wrapper/LinkerWrapperOpts.td
+++ b/clang/tools/clang-linker-wrapper/LinkerWrapperOpts.td
@@ -136,6 +136,14 @@ def relocatable : Flag<["--", "-"], "relocatable">,
     HelpText<"Link device code to create a relocatable offloading application">;
 def r : Flag<["-"], "r">, Alias<relocatable>;
 
+// ld64-style (Darwin) linker options. These are only defined so that they are
+// not mistaken for the options they are a prefix of, `-l<libname>` and
+// `-o <path>`; they are forwarded to the linker unchanged.
+def lto_library : Separate<["-"], "lto_library">, Flags<[HelpHidden]>,
+  MetaVarName<"<path>">, HelpText<"Path to libLTO.dylib for ld64">;
+def object_path_lto : Separate<["-"], "object_path_lto">, Flags<[HelpHidden]>,
+  MetaVarName<"<path>">, HelpText<"Path ld64 writes its LTO output to">;
+
 // link.exe-style linker options.
 def out : Joined<["/", "-", "/?", "-?"], "out:">, Flags<[HelpHidden]>;
 def libpath : Joined<["/", "-", "/?", "-?"], "libpath:">, Flags<[HelpHidden]>;


### PR DESCRIPTION
The linker wrapper is handed the command line the host linker would have been given, and on Darwin that command line comes from `Darwin::Linker::ConstructJob`, which adds

```cpp
    CmdArgs.push_back("-lto_library");
    CmdArgs.push_back(C.getArgs().MakeArgString(LibLTOPath));
```

to every ld64 link, and `-object_path_lto <path>` to every LTO link (`clang/lib/Driver/ToolChains/Darwin.cpp`).

`LinkerWrapperOpts.td` defines `-l` and `-o` as `JoinedOrSeparate`, so the wrapper reads the first as the library `to_library`:

```
$ clang-linker-wrapper --host-triple=x86_64-apple-macosx15.0.0 \
    --linker-path=/usr/bin/ld -lto_library /lib/libLTO.dylib t.o -o a.out
clang-linker-wrapper: error: unable to find library -lto_library
```

and the second as an output file, which it then forwards to the linker in that form, along with the wrapped device images that get inserted after `-o`:

```
$ clang-linker-wrapper --dry-run --host-triple=x86_64-apple-macosx15.0.0 \
    --linker-path=/usr/bin/ld -object_path_lto /tmp/lto.o t.o -o a.out
 "/usr/bin/ld" -o bject_path_lto /tmp/lto.o t.o -o a.out
```

This defines both as the separate-argument options they are, so they are parsed and forwarded unchanged.

The other ld64 options that start with `-l` (`-lazy_library`, `-lazy_framework`, `-load_hidden`) name libraries that can hold offloading code, so they want to be searched rather than only forwarded; that is left for a follow up.

Follow up to #183991.
