### PR TITLE
[LinkerWrapper] Resolve -l the way ld64 does on a MachO host

### DIFF
--- a/clang/test/OffloadTools/clang-linker-wrapper/linker-wrapper.c
+++ b/clang/test/OffloadTools/clang-linker-wrapper/linker-wrapper.c
@@ -190,6 +190,20 @@ __attribute__((visibility("protected"), used)) int x;
 
 // COFF-WHOLE-ARCHIVE: clang{{.*}} --target=nvptx64-nvidia-cuda -march=sm_70 {{[^ ]*}}.o{{$}}
 
+// A MachO host looks for `lib<name>.dylib` and for the text based stub that
+// stands in for one, not for `lib<name>.so`.
+// RUN: llvm-offload-binary -o %t.out \
+// RUN:   --image=file=%t.elf.o,kind=hip,triple=amdgpu9.0a-amd-amdhsa,arch=gfx90a
+// RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t.o -fembed-offload-object=%t.out
+// RUN: rm -rf %t.dir && mkdir -p %t.dir
+// RUN: cp %t.o %t.dir/libfoo.dylib
+// RUN: echo '--- !tapi-tbd' > %t.dir/libbar.tbd
+// RUN: clang-linker-wrapper --host-triple=x86_64-apple-macosx15.0.0 --dry-run \
+// RUN:   --linker-path=/usr/bin/ld -L%t.dir -lfoo -lbar -o a.out 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=MACHO-LIBRARY
+
+// MACHO-LIBRARY: clang{{.*}} --target=amdgpu9.0a-amd-amdhsa -mcpu=gfx90a {{.*}}.o
+
 // RUN: llvm-offload-binary -o %t-lib.out \
 // RUN:   --image=file=%t.elf.o,kind=openmp,triple=amdgpu9.0a-amd-amdhsa,arch=gfx90a
 // RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t.o -fembed-offload-object=%t-lib.out

--- a/clang/test/OffloadTools/clang-linker-wrapper/linker-wrapper.c
+++ b/clang/test/OffloadTools/clang-linker-wrapper/linker-wrapper.c
@@ -204,6 +204,17 @@ __attribute__((visibility("protected"), used)) int x;
 
 // MACHO-LIBRARY: clang{{.*}} --target=amdgpu9.0a-amd-amdhsa -mcpu=gfx90a {{.*}}.o
 
+// A library that lives in the SDK is reached through ld64's `-syslibroot`,
+// which is forwarded to the host linker like the other options it shares.
+// RUN: rm -rf %t.sdk && mkdir -p %t.sdk/usr/lib
+// RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t.sdk/usr/lib/libbaz.dylib
+// RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t.o
+// RUN: clang-linker-wrapper --host-triple=x86_64-apple-macosx15.0.0 --dry-run \
+// RUN:   --linker-path=/usr/bin/ld -syslibroot %t.sdk -lbaz %t.o -o a.out 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=MACHO-SYSLIBROOT
+
+// MACHO-SYSLIBROOT: ld{{.*}} -syslibroot {{.*}}.sdk {{.*}}.o -o a.out
+
 // RUN: llvm-offload-binary -o %t-lib.out \
 // RUN:   --image=file=%t.elf.o,kind=openmp,triple=amdgpu9.0a-amd-amdhsa,arch=gfx90a
 // RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t.o -fembed-offload-object=%t-lib.out

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -1264,11 +1264,17 @@ findFromSearchPaths(StringRef Name, StringRef Root,
 
 std::optional<std::string>
 searchLibraryBaseName(StringRef Name, StringRef Root,
-                      ArrayRef<StringRef> SearchPaths, bool IsWindows) {
+                      ArrayRef<StringRef> SearchPaths,
+                      const llvm::Triple &HostTriple) {
   SmallVector<std::string> Candidates;
-  if (IsWindows)
+  if (HostTriple.isOSWindows())
     Candidates = {"lib" + Name.str() + ".dll.a", Name.str() + ".dll.a",
                   "lib" + Name.str() + ".a", Name.str() + ".lib"};
+  else if (HostTriple.isOSBinFormatMachO())
+    // ld64 looks for the dynamic library, then the text based stub that
+    // describes it, then the static archive.
+    Candidates = {"lib" + Name.str() + ".dylib", "lib" + Name.str() + ".tbd",
+                  "lib" + Name.str() + ".a"};
   else
     Candidates = {"lib" + Name.str() + ".so", "lib" + Name.str() + ".a"};
 
@@ -1283,12 +1289,12 @@ searchLibraryBaseName(StringRef Name, StringRef Root,
 /// `-lfoo` or `-l:libfoo.a`.
 std::optional<std::string> searchLibrary(StringRef Input, StringRef Root,
                                          ArrayRef<StringRef> SearchPaths,
-                                         bool IsWindows) {
+                                         const llvm::Triple &HostTriple) {
   if (Input.starts_with(":"))
     return findFromSearchPaths(Input.drop_front(), Root, SearchPaths);
   if (Input.ends_with(".lib"))
     return findFromSearchPaths(Input, Root, SearchPaths);
-  return searchLibraryBaseName(Input, Root, SearchPaths, IsWindows);
+  return searchLibraryBaseName(Input, Root, SearchPaths, HostTriple);
 }
 
 /// Search for an input file given by name, e.g. `foo.lib`. COFF linkers use
@@ -1401,8 +1407,7 @@ getDeviceInput(const ArgList &Args) {
 
     std::optional<std::string> Filename =
         Arg->getOption().matches(OPT_library)
-            ? searchLibrary(Arg->getValue(), Root, LibraryPaths,
-                            HostTriple.isOSWindows())
+            ? searchLibrary(Arg->getValue(), Root, LibraryPaths, HostTriple)
             : searchInput(Arg->getValue(), Root, InputPaths);
 
     if (!Filename && Arg->getOption().matches(OPT_library))

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -1391,6 +1391,13 @@ getDeviceInput(const ArgList &Args) {
   BumpPtrAllocator Alloc;
   StringSaver Saver(Alloc);
 
+  // ld64 looks for libraries in its default search paths inside each
+  // `-syslibroot`, which is where an SDK keeps the system libraries.
+  if (HostTriple.isOSBinFormatMachO())
+    for (const opt::Arg *Arg : Args.filtered(OPT_syslibroot))
+      for (StringRef Dir : {"/usr/lib", "/usr/local/lib"})
+        LibraryPaths.push_back(Saver.save(Twine(Arg->getValue()) + Dir));
+
   // Try to extract device code from the linker input files.
   bool WholeArchive = Args.hasArg(OPT_wholearchive_flag);
   SmallVector<OffloadFile> ObjectFilesToExtract;

--- a/clang/tools/clang-linker-wrapper/LinkerWrapperOpts.td
+++ b/clang/tools/clang-linker-wrapper/LinkerWrapperOpts.td
@@ -136,6 +136,11 @@ def relocatable : Flag<["--", "-"], "relocatable">,
     HelpText<"Link device code to create a relocatable offloading application">;
 def r : Flag<["-"], "r">, Alias<relocatable>;
 
+// ld64-style (Darwin) linker options.
+def syslibroot : Separate<["-"], "syslibroot">, Flags<[HelpHidden]>,
+  MetaVarName<"<dir>">,
+  HelpText<"Prepend <dir> to ld64's default library search paths">;
+
 // link.exe-style linker options.
 def out : Joined<["/", "-", "/?", "-?"], "out:">, Flags<[HelpHidden]>;
 def libpath : Joined<["/", "-", "/?", "-?"], "libpath:">, Flags<[HelpHidden]>;


### PR DESCRIPTION
`-lfoo` is resolved by looking for `libfoo.so` and `libfoo.a` on every host that is not Windows, and only in the paths given with `-L`. Neither is how ld64 resolves it, so on a Darwin host every `-l` fails:

```
$ clang-linker-wrapper --host-triple=x86_64-apple-macosx15.0.0 \
    --linker-path=/usr/bin/ld -syslibroot /.../MacOSX.sdk -lSystem t.o -o a.out
clang-linker-wrapper: error: unable to find library -lSystem
```

`-lSystem` is on the command line of every Darwin link that clang drives, so this is hit before any of the offloading specific machinery runs.

Two commits:

- ld64 looks for `libfoo.dylib`, then the text based stub `libfoo.tbd` that stands in for one, then `libfoo.a`. A stub holds no offloading code, but finding it is what separates a library there is nothing to extract from from a library that is missing.
- ld64 looks in `/usr/lib` and `/usr/local/lib` under each `-syslibroot`, which is where an SDK keeps the system libraries. The wrapper already models GNU ld's `-L` and `=`-prefixed paths and `link.exe`'s `/libpath:`; this adds ld64's.

`-syslibroot` is parsed and then forwarded to the host linker unchanged, like the other linker options the wrapper reads.

Still missing for full ld64 fidelity, and not fixed here: `-F` framework search paths, ld64's rule that a `-syslibroot` also applies to the paths given with `-L`, and the fact that `-lfoo` is forwarded to the linker in the separate form `-l foo`, which ld64 does not accept.

Follow up to #183991.
