### PR TITLE
Fix AppVerifier GetThreadId(NULL) error in llvm::thread

### DIFF
--- a/llvm/lib/Support/Windows/Threading.inc
+++ b/llvm/lib/Support/Windows/Threading.inc
@@ -49,7 +49,15 @@ void llvm_thread_detach_impl(HANDLE hThread) {
     ReportLastErrorFatal("CloseHandle failed");
 }
 
-DWORD llvm_thread_get_id_impl(HANDLE hThread) { return ::GetThreadId(hThread); }
+DWORD llvm_thread_get_id_impl(HANDLE hThread) {
+  // AppVerifier (runtime verification tool from Windows SDK) reports an error
+  // when GetThreadId(NULL) is called. Suppress this by manually checking for
+  // NULL. Return 0 as this is what's returned (by documentation) if
+  // GetThreadId() fails.
+  if (!hThread)
+    return 0;
+  return ::GetThreadId(hThread);
+}
 
 DWORD llvm_thread_get_current_id_impl() { return ::GetCurrentThreadId(); }
 


### PR DESCRIPTION
A recent change (64be34c562a23761dcb48a0a6a0b3ef0576c14c4) brought up a behaviour change to the way llvm::thread checks if it is joinable. Prior to the patch, a thread handle is checked if it's valid. The new behaviour is to query a thread id and check if it's non-zero.

On Windows, the new behaviour means calling GetThreadId(handle) to retrieve the thread id. This, however, results in errors  when the thread handle is not pointing to any active thread (NULL) and when running applications under AppVerifier as it reports that a "system function is called with a NULL handle". For applications using LLVM infrastructure (in our case it is a MLIR-based compiler), the call stack looks like:
```
vrfcore!VerifierStopMessageEx+0x858
vfbasics!AVrfpHandleSanityChecks+0x3c
vfbasics!AVrfpNtQueryInformationThread+0x46
KERNELBASE!GetThreadId+0x33
my_app!llvm::llvm_thread_get_id_impl
my_app!llvm::StdThreadPool::asyncEnqueue+0x146
my_app!llvm::ThreadPoolInterface::asyncImpl<void>+0x224 [llvm/Support/ThreadPool.h @ 116]
my_app!mlir::OpBuilder::tryFold+0x121d   (nearest-symbol match)
my_app!mlir::verify+0x1190              (nearest-symbol match)
my_app!mlir::verify+0x178b              (nearest-symbol match)
my_app!mlir::verify+0x15b2              (nearest-symbol match)
```
The StdThreadPool internally uses a vector of llvm::thread objects to maintain a pool. During the program run, this vector can be reallocated (to run more tasks in parallel) and, when this happens, various llvm::thread special member functions (move-assignment and destructors) are called. Destroying a moved-from llvm::thread (as well as a default-constructed one) means querying GetThreadId() with a NULL handle which causes the error above. This is due to llvm::thread by default not being associated with any running thread (and so the handle is by default NULL).

As this is a perfectly normal situation in general - we can tell if a thread is joinable if its ID is not 0 - and the verification error seems to be strictly related to Windows, the reasonable fix is to manually check if the handle is NULL before calling the related Win API in the Windows implementation. That way, other systems are not pessimized by any additional checks.