### PR TITLE
[ADT] Clean up FoldingSet (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/FoldingSet.h
+++ b/llvm/include/llvm/ADT/FoldingSet.h
@@ -31,7 +31,7 @@
 
 namespace llvm {
 
-/// This folding set used for two purposes:
+/// This folding set is used for two purposes:
 ///   1. Given information about a node we want to create, look up the unique
 ///      instance of the node in the set.  If the node already exists, return
 ///      it, otherwise return the bucket it should be inserted into.
@@ -97,7 +97,8 @@ namespace llvm {
 /// 3) If you get a NULL result from FindNodeOrInsertPos then you can insert a
 /// new node with InsertNode;
 ///
-///    MyFoldingSet.InsertNode(M, InsertPoint);
+///    MyNode *N = new MyNode(Name, Value);
+///    MyFoldingSet.InsertNode(N, InsertPoint);
 ///
 /// 4) Finally, if you want to remove a node from the folding set call;
 ///
@@ -380,7 +381,7 @@ protected:
   /// was removed or false if the node was not in the folding set.
   LLVM_ABI bool RemoveNode(Node *N);
 
-  /// If there is an existing simple Node exactly equal to the node \p N,
+  /// If there is an existing node exactly equal to the node \p N,
   /// return it.  Otherwise, insert \p N and return it instead.
   LLVM_ABI Node *GetOrInsertNode(Node *N, const FoldingSetInfo &Info);
 
@@ -464,7 +465,7 @@ public:
   /// was removed or false if the node was not in the folding set.
   bool RemoveNode(T *N) { return FoldingSetBase::RemoveNode(N); }
 
-  /// If there is an existing simple Node exactly equal to the specified node,
+  /// If there is an existing node exactly equal to the specified node,
   /// return it.  Otherwise, insert 'N' and return it instead.
   T *GetOrInsertNode(T *N) {
     return static_cast<T *>(
@@ -641,7 +642,7 @@ public:
     return Set.FindNodeOrInsertPos(ID, InsertPos);
   }
 
-  /// If there is an existing simple Node exactly equal to the specified node,
+  /// If there is an existing node exactly equal to the specified node,
   /// return it.  Otherwise, insert 'N' and return it instead.
   T *GetOrInsertNode(T *N) {
     T *Result = Set.GetOrInsertNode(N);

--- a/llvm/lib/Support/FoldingSet.cpp
+++ b/llvm/lib/Support/FoldingSet.cpp
@@ -15,7 +15,6 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Allocator.h"
-#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/SwapByteOrder.h"
 #include <cassert>
@@ -164,7 +163,7 @@ static void **GetBucketFor(unsigned Hash, void **Buckets, unsigned NumBuckets) {
   return Buckets + BucketNum;
 }
 
-/// AllocateBuckets - Allocated initialized bucket memory.
+/// AllocateBuckets - Allocate initialized bucket memory.
 static void **AllocateBuckets(unsigned NumBuckets) {
   void **Buckets =
       static_cast<void **>(safe_calloc(NumBuckets + 1, sizeof(void *)));
@@ -225,7 +224,6 @@ void FoldingSetBase::GrowBucketCount(unsigned NewBucketCount,
 
   // Clear out new buckets.
   Buckets = AllocateBuckets(NewBucketCount);
-  // Set NumBuckets only if allocation of new buckets was successful.
   NumBuckets = NewBucketCount;
   NumNodes = 0;
 
@@ -356,8 +354,7 @@ bool FoldingSetBase::RemoveNode(Node *N) {
 }
 
 FoldingSetBase::Node *
-FoldingSetBase::GetOrInsertNode(FoldingSetBase::Node *N,
-                                const FoldingSetInfo &Info) {
+FoldingSetBase::GetOrInsertNode(Node *N, const FoldingSetInfo &Info) {
   FoldingSetNodeID ID;
   Info.GetNodeProfile(this, N, ID);
   void *IP;


### PR DESCRIPTION
- Remove the word "simple" from comments referring to "simple Node",
  which is a 20-year-old leftover from SelectionDAGCSEMap.

- AllocateBuckets, based on safe_calloc, never returns nullptr.

- In FoldingSetBase::GetOrInsertNode, the parameter type
  FoldingSetBase::Node * is simplified to Node * because we are
  already in the scope of FoldingSetBase.

Other changes should be self-explanatory.
