### PR TITLE
[GlobalISel] Combine G_SEXT_INREG(G_ZEXT) -> G_SEXT through unmerge

### DIFF
--- a/llvm/include/llvm/Target/GlobalISel/Combine.td
+++ b/llvm/include/llvm/Target/GlobalISel/Combine.td
@@ -961,6 +961,28 @@ class redundant_ext_sext_inreg<Instruction Ext>: GICombineRule <
 def redundant_zext_sext_inreg : redundant_ext_sext_inreg<G_ZEXT>;
 def redundant_aext_sext_inreg : redundant_ext_sext_inreg<G_ANYEXT>;
 
+// Convert G_SEXT_INREG(G_ZEXT(G_UNMERGE(G_ZEXT))) -> G_SEXT(G_UNMERGE(G_SEXT))
+class redundant_ext_unmerge_sext_inreg<Instruction Ext>: GICombineRule <
+  (defs root:$root),
+  (match (Ext $tmp1, $src),
+         (G_UNMERGE_VALUES $tmp2, $tmp3, $tmp1):$unmerge,
+         (Ext $tmp4, $tmp2),
+         (G_SEXT_INREG $dst, $tmp4, $amt):$root,
+         [{ LLT SrcTy = MRI.getType(${src}.getReg());
+            return ${amt}.getImm() <= SrcTy.getScalarSizeInBits() &&
+                   MRI.getType(${tmp2}.getReg()).getScalarType() ==
+                     MRI.getType(${tmp1}.getReg()).getScalarType() &&
+                   VT->computeNumSignBits(${src}.getReg()) >=
+                     (SrcTy.getScalarSizeInBits() - ${amt}.getImm() + 1); }]),
+  (apply [{ auto SExt1 = Helper.getBuilder().buildSExt(MRI.getType(${tmp1}.getReg()), ${src}.getReg());
+            auto Unmerge = Helper.getBuilder().buildUnmerge(MRI.getType(${tmp2}.getReg()), SExt1);
+            unsigned UnmergeDef = ${tmp2}.getReg() == ${unmerge}->getOperand(0).getReg() ? 0 : 1;
+            Helper.getBuilder().buildSExt(${dst}.getReg(), Unmerge.getReg(UnmergeDef));
+            ${root}->eraseFromParent(); }])
+>;
+def redundant_zext_unmerge_sext_inreg : redundant_ext_unmerge_sext_inreg<G_ZEXT>;
+def redundant_aext_unmerge_sext_inreg : redundant_ext_unmerge_sext_inreg<G_ANYEXT>;
+
 // Fold (anyext (trunc x)) -> x if the source type is same as
 // the destination type.
 def anyext_trunc_fold: GICombineRule <
@@ -2624,6 +2646,7 @@ def const_combines : GICombineGroup<[constant_fold_fp_ops, const_ptradd_to_i2p,
 
 def known_bits_simplifications : GICombineGroup<[
   redundant_sext_inreg, redundant_zext_sext_inreg, redundant_aext_sext_inreg,
+  redundant_zext_unmerge_sext_inreg, redundant_aext_unmerge_sext_inreg,
   redundant_and, redundant_or, urem_pow2_to_mask, zext_trunc_fold,
   sext_inreg_to_zext_inreg]>;
 

--- a/llvm/lib/Target/AArch64/AArch64Combine.td
+++ b/llvm/lib/Target/AArch64/AArch64Combine.td
@@ -406,6 +406,7 @@ def AArch64PostLegalizerCombiner
                         extractvecelt_pairwise_add, redundant_or,
                         mul_const, redundant_sext_inreg,
                         redundant_zext_sext_inreg, redundant_aext_sext_inreg,
+                        redundant_aext_unmerge_sext_inreg, redundant_zext_unmerge_sext_inreg,
                         form_bitfield_extract, rotate_out_of_range,
                         icmp_to_true_false_known_bits, overflow_combines,
                         select_combines, select_zero_true, select_zero_false, select_not,

--- a/llvm/test/CodeGen/AArch64/GlobalISel/combine-sext-inreg.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/combine-sext-inreg.mir
@@ -137,3 +137,102 @@ body:             |
     %2:_(i64) = G_SEXT_INREG %1, 32
     $x0 = COPY %2
 ...
+---
+name: zext_unmerge_sextinreg_v4i32
+tracksRegLiveness: true
+legalized:         true
+body:             |
+  bb.0:
+    liveins: $d0
+
+    ; CHECK-LABEL: name: zext_unmerge_sextinreg_v4i32
+    ; CHECK: liveins: $d0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<8 x i8>) = COPY $d0
+    ; CHECK-NEXT: %c:_(<8 x i8>) = G_ICMP intpred(eq), [[COPY]](<8 x i8>), [[COPY]]
+    ; CHECK-NEXT: [[SEXT:%[0-9]+]]:_(<8 x i16>) = G_SEXT %c(<8 x i8>)
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<4 x i16>), [[UV1:%[0-9]+]]:_(<4 x i16>) = G_UNMERGE_VALUES [[SEXT]](<8 x i16>)
+    ; CHECK-NEXT: [[SEXT1:%[0-9]+]]:_(<4 x i32>) = G_SEXT [[UV]](<4 x i16>)
+    ; CHECK-NEXT: $q0 = COPY [[SEXT1]](<4 x i32>)
+    %0:_(<8 x i8>) = COPY $d0
+    %c:_(<8 x i8>) = G_ICMP intpred(eq), %0:_(<8 x i8>), %0
+    %1:_(<8 x i16>) = G_ZEXT %c
+    %2:_(<4 x i16>), %3:_(<4 x i16>) = G_UNMERGE_VALUES %1
+    %4:_(<4 x i32>) = G_ZEXT %2
+    %5:_(<4 x i32>) = G_SEXT_INREG %4, 1
+    $q0 = COPY %5
+...
+---
+name: zext_unmerge_sextinreg_v4i32_unknown
+tracksRegLiveness: true
+legalized:         true
+body:             |
+  bb.0:
+    liveins: $d0
+
+    ; CHECK-LABEL: name: zext_unmerge_sextinreg_v4i32_unknown
+    ; CHECK: liveins: $d0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<8 x i8>) = COPY $d0
+    ; CHECK-NEXT: [[ZEXT:%[0-9]+]]:_(<8 x i16>) = G_ZEXT [[COPY]](<8 x i8>)
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<4 x i16>), [[UV1:%[0-9]+]]:_(<4 x i16>) = G_UNMERGE_VALUES [[ZEXT]](<8 x i16>)
+    ; CHECK-NEXT: [[ZEXT1:%[0-9]+]]:_(<4 x i32>) = G_ZEXT [[UV]](<4 x i16>)
+    ; CHECK-NEXT: [[SEXT_INREG:%[0-9]+]]:_(<4 x i32>) = G_SEXT_INREG [[ZEXT1]], 1
+    ; CHECK-NEXT: $q0 = COPY [[SEXT_INREG]](<4 x i32>)
+    %0:_(<8 x i8>) = COPY $d0
+    %1:_(<8 x i16>) = G_ZEXT %0
+    %2:_(<4 x i16>), %3:_(<4 x i16>) = G_UNMERGE_VALUES %1
+    %4:_(<4 x i32>) = G_ZEXT %2
+    %5:_(<4 x i32>) = G_SEXT_INREG %4, 1
+    $q0 = COPY %5
+...
+---
+name: anyext_unmerge_sextinreg_v4i32
+tracksRegLiveness: true
+legalized:         true
+body:             |
+  bb.0:
+    liveins: $d0
+
+    ; CHECK-LABEL: name: anyext_unmerge_sextinreg_v4i32
+    ; CHECK: liveins: $d0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<8 x i8>) = COPY $d0
+    ; CHECK-NEXT: %c:_(<8 x i8>) = G_ICMP intpred(eq), [[COPY]](<8 x i8>), [[COPY]]
+    ; CHECK-NEXT: [[SEXT:%[0-9]+]]:_(<8 x i16>) = G_SEXT %c(<8 x i8>)
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<4 x i16>), [[UV1:%[0-9]+]]:_(<4 x i16>) = G_UNMERGE_VALUES [[SEXT]](<8 x i16>)
+    ; CHECK-NEXT: [[SEXT1:%[0-9]+]]:_(<4 x i32>) = G_SEXT [[UV]](<4 x i16>)
+    ; CHECK-NEXT: $q0 = COPY [[SEXT1]](<4 x i32>)
+    %0:_(<8 x i8>) = COPY $d0
+    %c:_(<8 x i8>) = G_ICMP intpred(eq), %0:_(<8 x i8>), %0
+    %1:_(<8 x i16>) = G_ANYEXT %c
+    %2:_(<4 x i16>), %3:_(<4 x i16>) = G_UNMERGE_VALUES %1
+    %4:_(<4 x i32>) = G_ANYEXT %2
+    %5:_(<4 x i32>) = G_SEXT_INREG %4, 1
+    $q0 = COPY %5
+...
+---
+name: zext_unmerge_sextinreg_v4i32_result2
+tracksRegLiveness: true
+legalized:         true
+body:             |
+  bb.0:
+    liveins: $d0
+
+    ; CHECK-LABEL: name: zext_unmerge_sextinreg_v4i32_result2
+    ; CHECK: liveins: $d0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<8 x i8>) = COPY $d0
+    ; CHECK-NEXT: %c:_(<8 x i8>) = G_ICMP intpred(eq), [[COPY]](<8 x i8>), [[COPY]]
+    ; CHECK-NEXT: [[SEXT:%[0-9]+]]:_(<8 x i16>) = G_SEXT %c(<8 x i8>)
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<4 x i16>), [[UV1:%[0-9]+]]:_(<4 x i16>) = G_UNMERGE_VALUES [[SEXT]](<8 x i16>)
+    ; CHECK-NEXT: [[SEXT1:%[0-9]+]]:_(<4 x i32>) = G_SEXT [[UV1]](<4 x i16>)
+    ; CHECK-NEXT: $q0 = COPY [[SEXT1]](<4 x i32>)
+    %0:_(<8 x i8>) = COPY $d0
+    %c:_(<8 x i8>) = G_ICMP intpred(eq), %0:_(<8 x i8>), %0
+    %1:_(<8 x i16>) = G_ZEXT %c
+    %2:_(<4 x i16>), %3:_(<4 x i16>) = G_UNMERGE_VALUES %1
+    %4:_(<4 x i32>) = G_ZEXT %3
+    %5:_(<4 x i32>) = G_SEXT_INREG %4, 1
+    $q0 = COPY %5
+...


### PR DESCRIPTION
This extends the code added in #213606 to look through an unmerge, as can be found after type legalization on AArch64. It looks for G_SEXT_INREG(G_ZEXT(G_UNMERGE(G_ZEXT))), converting it to G_SEXT(G_UNMERGE(G_SEXT)).  The apply code uses c++ as it needs to create new temporary virtual registers.