### PR TITLE
RISCV/GlobalISel: Use mi_match for constant checks

### DIFF
--- a/llvm/lib/Target/RISCV/GISel/RISCVInstructionSelector.cpp
+++ b/llvm/lib/Target/RISCV/GISel/RISCVInstructionSelector.cpp
@@ -535,11 +535,9 @@ RISCVInstructionSelector::selectSHXADD_UWOp(MachineOperand &Root,
 InstructionSelector::ComplexRendererFns
 RISCVInstructionSelector::renderVLOp(MachineOperand &Root) const {
   assert(Root.isReg() && "Expected operand to be a Register");
-  MachineInstr *RootDef = MRI->getVRegDef(Root.getReg());
-
-  if (RootDef->getOpcode() == TargetOpcode::G_CONSTANT) {
-    auto C = RootDef->getOperand(1).getCImm();
-    if (C->getValue().isAllOnes())
+  std::optional<ValueAndVReg> C;
+  if (mi_match(Root.getReg(), *MRI, m_GCst(C))) {
+    if (C->Value.isAllOnes())
       // If the operand is a G_CONSTANT with value of all ones it is larger than
       // VLMAX. We convert it to an immediate with value VLMaxSentinel. This is
       // recognized specially by the vsetvli insertion pass.
@@ -547,8 +545,8 @@ RISCVInstructionSelector::renderVLOp(MachineOperand &Root) const {
         MIB.addImm(RISCV::VLMaxSentinel);
       }}};
 
-    if (isUInt<5>(C->getZExtValue())) {
-      uint64_t ZExtC = C->getZExtValue();
+    if (isUInt<5>(C->Value.getZExtValue())) {
+      uint64_t ZExtC = C->Value.getZExtValue();
       return {{[=](MachineInstrBuilder &MIB) { MIB.addImm(ZExtC); }}};
     }
   }

--- a/llvm/lib/Target/RISCV/GISel/RISCVPostLegalizerCombiner.cpp
+++ b/llvm/lib/Target/RISCV/GISel/RISCVPostLegalizerCombiner.cpp
@@ -23,6 +23,7 @@
 #include "llvm/CodeGen/GlobalISel/CombinerInfo.h"
 #include "llvm/CodeGen/GlobalISel/GIMatchTableExecutorImpl.h"
 #include "llvm/CodeGen/GlobalISel/GISelValueTracking.h"
+#include "llvm/CodeGen/GlobalISel/MIPatternMatch.h"
 #include "llvm/CodeGen/GlobalISel/MachineIRBuilder.h"
 #include "llvm/CodeGen/MachineDominators.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
@@ -36,6 +37,7 @@
 #define DEBUG_TYPE "riscv-postlegalizer-combiner"
 
 using namespace llvm;
+using namespace MIPatternMatch;
 
 namespace {
 
@@ -54,12 +56,7 @@ bool matchFoldFPZeroStore(MachineInstr &MI, MachineRegisterInfo &MRI,
   if (!SrcReg.isVirtual())
     return false;
 
-  MachineInstr *Def = MRI.getVRegDef(SrcReg);
-  if (!Def || Def->getOpcode() != TargetOpcode::G_FCONSTANT)
-    return false;
-
-  auto *CFP = Def->getOperand(1).getFPImm();
-  if (!CFP || !CFP->getValueAPF().isPosZero())
+  if (!mi_match(SrcReg, MRI, m_PosZeroFP()))
     return false;
 
   unsigned ValBits = MRI.getType(SrcReg).getSizeInBits();


### PR DESCRIPTION
Co-authored-by: Claude (Opus 4.8) <noreply@anthropic.com>