### PR TITLE
SPIRV: Use mi_match in combiner match functions

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVCombinerHelper.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCombinerHelper.cpp
@@ -40,11 +40,7 @@ bool SPIRVCombinerHelper::matchLengthToDistance(MachineInstr &MI) const {
 
   // First operand of MI is `G_INTRINSIC` so start at operand 2.
   Register SubReg = MI.getOperand(2).getReg();
-  MachineInstr *SubInstr = MRI.getVRegDef(SubReg);
-  if (SubInstr->getOpcode() != TargetOpcode::G_FSUB)
-    return false;
-
-  return true;
+  return mi_match(SubReg, MRI, m_GFSub(m_Reg(), m_Reg()));
 }
 
 void SPIRVCombinerHelper::applySPIRVDistance(MachineInstr &MI) const {
@@ -129,10 +125,9 @@ bool SPIRVCombinerHelper::matchSelectToFaceForward(MachineInstr &MI) const {
   if (!mi_match(TrueReg, MRI, m_GFNeg(m_SpecificReg(FalseReg))) &&
       !mi_match(FalseReg, MRI, m_GFNeg(m_SpecificReg(TrueReg)))) {
     std::optional<FPValueAndVReg> MulConstant;
-    MachineInstr *TrueInstr = MRI.getVRegDef(TrueReg);
-    MachineInstr *FalseInstr = MRI.getVRegDef(FalseReg);
-    if (TrueInstr->getOpcode() == TargetOpcode::G_BUILD_VECTOR &&
-        FalseInstr->getOpcode() == TargetOpcode::G_BUILD_VECTOR &&
+    GBuildVector *TrueInstr, *FalseInstr;
+    if (mi_match(TrueReg, MRI, m_GBuildVector(TrueInstr)) &&
+        mi_match(FalseReg, MRI, m_GBuildVector(FalseInstr)) &&
         TrueInstr->getNumOperands() == FalseInstr->getNumOperands()) {
       for (unsigned I = 1; I < TrueInstr->getNumOperands(); ++I)
         if (!AreNegatedConstantsOrSplats(TrueInstr->getOperand(I).getReg(),


### PR DESCRIPTION
Convert some simple cases away from getVRegDef + opcode
checks which don't require new matchers.

Co-authored-by: Claude (Opus 4.8) <noreply@anthropic.com>