### PR TITLE
[Clang] Document the interaction of malloc_span and alloc_size

### DIFF
--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -5592,6 +5592,11 @@ members, one of which is a pointer to the start of the allocated memory and
 the other one is either an integer type containing the size of the actually
 allocated memory or a pointer to the end of the allocated region. Note, static
 data members do not impact whether a type is span-like or not.
+
+In combination with the `alloc_size` attribute, if the begin pointer is
+non-null, the size of the returned span-like object has to be greater or equal
+to the number of bytes guaranteed to be dereferenceable by `alloc_size`. It also
+guarantees that the number of dereferenceable bytes is at least size.
   }];
 }
 


### PR DESCRIPTION
The `malloc_span` attribute is intended to be used for `allocate_at_least`-like functions. Part of that interface is a guarantee that the number of bytes returned are actually dereferenceable. Document that, so that we can optimize on it in the future.
