### PR TITLE
[flang][PFT] do not record a FORMAT statement as an assigned GO TO target

### DIFF
--- a/flang/lib/Lower/PFTBuilder.cpp
+++ b/flang/lib/Lower/PFTBuilder.cpp
@@ -1049,11 +1049,25 @@ private:
             // Mark every possible target of the assigned GO TO so that
             // wrappability analyses can see any escape from an enclosing
             // construct.
+            //
+            // A FORMAT statement is not a branch target, so it is not marked
+            // here. Marking it would give it a block, and lowering selects
+            // the targets of the generated branch by testing for one, so a
+            // program that assigns a FORMAT label and then branches to it
+            // would silently jump into the FORMAT instead of reaching the
+            // run-time error it is supposed to get.
+            auto markIfBranchTarget = [&](parser::Label label) {
+              lower::pft::Evaluation *target{
+                  labelEvaluationMap->find(label)->second};
+              assert(target && "missing branch target evaluation");
+              if (!target->isA<parser::FormatStmt>())
+                markBranchTarget(eval, *target);
+            };
             const auto &labelList = std::get<std::list<parser::Label>>(s.t);
             if (!labelList.empty()) {
               // Explicit target list: `go to v, (l1, l2, ...)`.
               for (const auto &label : labelList)
-                markBranchTarget(eval, label);
+                markIfBranchTarget(label);
             } else {
               // No explicit list (`go to v`): fall back to the set of labels
               // that have been previously ASSIGN'd to v.
@@ -1065,7 +1079,7 @@ private:
                 auto iter = assignSymbolLabelMap->find(*sym);
                 if (iter != assignSymbolLabelMap->end())
                   for (auto label : iter->second)
-                    markBranchTarget(eval, label);
+                    markIfBranchTarget(label);
               }
             }
             eval.isUnstructured = true;

--- a/flang/test/Lower/assigned-goto-format-target.f90
+++ b/flang/test/Lower/assigned-goto-format-target.f90
@@ -1,0 +1,48 @@
+! RUN: bbc -emit-fir -o - %s | FileCheck %s
+
+! A FORMAT statement is not a branch target.  Branching to a label that was
+! ASSIGN'd from one is not conforming, and the program is meant to reach the
+! run-time error rather than jump into the FORMAT statement.
+
+! The only label assigned to j is a FORMAT, so no target survives and no
+! branch is generated at all.
+! CHECK-LABEL: func.func @_QPfmt_only(
+! CHECK:         %[[J:.*]] = fir.declare %arg0
+! CHECK:         fir.store %c1{{.*}} to %[[J]]
+! CHECK-NOT:     fir.select
+! CHECK-NOT:     ^bb
+! CHECK:         fir.call @_FortranAReportFatalUserError
+! CHECK-NEXT:    fir.unreachable
+subroutine fmt_only(j)
+  integer :: j
+  assign 1 to j
+  go to j
+1 format("fmt")
+end subroutine
+
+! Both labels are assigned to j, but only 20 is a branch target.  The select
+! carries exactly one case, for 20; label 1 does not appear.
+! CHECK-LABEL: func.func @_QPfmt_and_real(
+! CHECK:         %[[J:.*]] = fir.declare %arg0
+! CHECK:         fir.store %c1{{.*}} to %[[J]]
+! CHECK:         fir.store %c20{{.*}} to %[[J]]
+! CHECK:         %[[V:.*]] = fir.load %[[J]]
+! CHECK:         fir.select %[[V]] : i32 [20, ^bb[[TGT:[0-9]+]], unit, ^bb[[ERR:[0-9]+]]]
+!
+! The default destination reports the error and terminates.
+! CHECK:       ^bb[[ERR]]:
+! CHECK:         fir.call @_FortranAReportFatalUserError
+! CHECK-NEXT:    fir.unreachable
+!
+! The one real target is the PRINT at label 20, which returns normally.
+! CHECK:       ^bb[[TGT]]:
+! CHECK:         fir.call @_FortranAioBeginExternalListOutput
+! CHECK:         return
+subroutine fmt_and_real(j)
+  integer :: j
+  assign 1 to j
+  assign 20 to j
+  go to j
+1 format("fmt")
+20 print *, "twenty"
+end subroutine

--- a/flang/test/Semantics/assign07.f90
+++ b/flang/test/Semantics/assign07.f90
@@ -26,10 +26,16 @@ program main
     if (n==1) goto lab(1,666)
     !ERROR: Label '2' was not found
     if (n==1) goto lab(1,2)
+    ! Label 3 is a FORMAT statement in this scope.  It can be assigned and
+    ! used as a format, but naming it in the label list of an assigned GOTO
+    ! is an error: a FORMAT statement is not a branch target.  The diagnostic
+    ! is reported on the FORMAT statement itself, below.
+    if (n==1) goto lab(1,3)
     assign 3 to lab
     write(*,fmt=lab) ! ok
     write(*,fmt=implicitlab3) ! ok
 1   continue
+    !ERROR: Label '3' is not a branch target
 3   format('yes')
   end subroutine test
 end program


### PR DESCRIPTION
A FORMAT statement is not a branch target, so a program that assigns its label to a variable and then branches to that variable is not conforming and is meant to reach a run-time error.

Skip FORMAT statements when recording the targets, the same way the AssignStmt case already does.

Only the `go to v` form needs this: in `go to v, (l1, l2, ...)` a FORMAT label is rejected during semantic checking, so it never reaches the PFT. assign07.f90 is extended to test this semantic check.

Co-Authored-By: Claude.