### PR TITLE
[lldb][NFC] Fix GetPointeeDataTest after the ProcessAddress migration

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -1604,8 +1604,8 @@ public:
   /// and remove any traps that may have been inserted into the memory.
   ///
   /// This function is not meant to be overridden by Process subclasses, the
-  /// subclasses should implement Process::DoReadMemory (lldb::addr_t, size_t,
-  /// void *).
+  /// subclasses should implement Process::DoReadMemory(const ProcessAddress &,
+  /// void *, size_t, Status &).
   ///
   /// \param[in] vm_addr
   ///     A virtual load address that indicates where to start reading

--- a/lldb/unittests/ValueObject/GetPointeeDataTest.cpp
+++ b/lldb/unittests/ValueObject/GetPointeeDataTest.cpp
@@ -57,7 +57,8 @@ struct SentinelProcess : Process {
   Status DoDestroy() override { return {}; }
   void RefreshStateAfterStop() override {}
   bool DoUpdateThreadList(ThreadList &, ThreadList &) override { return false; }
-  size_t DoReadMemory(addr_t, void *buf, size_t size, Status &error) override {
+  size_t DoReadMemory(const ProcessAddress &, void *buf, size_t size,
+                      Status &error) override {
     if (fail_reads) {
       error = Status::FromErrorString("no live memory at this address");
       return 0;


### PR DESCRIPTION
One unit-test override was missed when `Process::DoReadMemory` was changed to accept `const ProcessAddress &`. `SentinelProcess` in `GetPointeeDataTest.cpp` still uses `lldb::addr_t`, so the override does not match, the mock remains abstract, and `check-lldb` fails to build.

Update the parameter type and the remaining stale `Process.h` documentation. This is a quick NFC fix for the broken build.

## Testing

`check-lldb` builds successfully.