### PR TITLE
[AArch64][SVE] Lower extended v2i8 loads using SVE.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -8105,6 +8105,14 @@ SDValue AArch64TargetLowering::LowerLOAD(SDValue Op,
   LoadSDNode *LoadNode = cast<LoadSDNode>(Op);
   assert(LoadNode && "Expected custom lowering of a load node");
 
+  // Extending loads of v2i8 -> v2i32/v2i64 are better lowered using SVE's
+  // extending load instructions as they otherwise require 2 or 3 instructions
+  // to promote.
+  bool OverrideNeon = !Subtarget->isNeonAvailable() ||
+                      cast<LoadSDNode>(Op)->getMemoryVT() == MVT::v2i8;
+  if (useSVEForFixedLengthVectorVT(Op.getValueType(), OverrideNeon))
+    return LowerFixedLengthVectorLoadToSVE(Op, DAG);
+
   if (SDValue Result = tryLowerSmallVectorExtLoad(LoadNode, DAG))
     return Result;
 
@@ -8911,16 +8919,8 @@ SDValue AArch64TargetLowering::LowerOperation(SDValue Op,
     return LowerTRUNCATE(Op, DAG);
   case ISD::MLOAD:
     return LowerMLOAD(Op, DAG);
-  case ISD::LOAD: {
-    // Extending loads of v2i8 -> v2i32 are bettered lowered using SVE's
-    // extending load instructions as they otherwise require 2 instructions to
-    // promote to v2i32.
-    bool OverrideNeon = !Subtarget->isNeonAvailable() ||
-                        cast<LoadSDNode>(Op)->getMemoryVT() == MVT::v2i8;
-    if (useSVEForFixedLengthVectorVT(Op.getValueType(), OverrideNeon))
-      return LowerFixedLengthVectorLoadToSVE(Op, DAG);
+  case ISD::LOAD:
     return LowerLOAD(Op, DAG);
-  }
   case ISD::ADD:
   case ISD::AND:
   case ISD::SUB:

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -8911,11 +8911,16 @@ SDValue AArch64TargetLowering::LowerOperation(SDValue Op,
     return LowerTRUNCATE(Op, DAG);
   case ISD::MLOAD:
     return LowerMLOAD(Op, DAG);
-  case ISD::LOAD:
-    if (useSVEForFixedLengthVectorVT(Op.getValueType(),
-                                     !Subtarget->isNeonAvailable()))
+  case ISD::LOAD: {
+    // Extending loads of v2i8 -> v2i32 are bettered lowered using SVE's
+    // extending load instructions as they otherwise require 2 instructions to
+    // promote to v2i32.
+    bool OverrideNeon = !Subtarget->isNeonAvailable() ||
+                        cast<LoadSDNode>(Op)->getMemoryVT() == MVT::v2i8;
+    if (useSVEForFixedLengthVectorVT(Op.getValueType(), OverrideNeon))
       return LowerFixedLengthVectorLoadToSVE(Op, DAG);
     return LowerLOAD(Op, DAG);
+  }
   case ISD::ADD:
   case ISD::AND:
   case ISD::SUB:

--- a/llvm/test/CodeGen/AArch64/load.ll
+++ b/llvm/test/CodeGen/AArch64/load.ll
@@ -247,6 +247,81 @@ define <2 x i8> @load_v2i8(ptr %ptr, <2 x i8> %b) {
   ret <2 x i8> %a
 }
 
+; Check that when SVE is available it uses SVE's extending loads for v2i8.
+define <2 x i8> @load_v2i8_sve(ptr %ptr) "target-features"="+sve" {
+; CHECK-SD-LABEL: load_v2i8_sve:
+; CHECK-SD:       // %bb.0:
+; CHECK-SD-NEXT:    ptrue p0.s, vl2
+; CHECK-SD-NEXT:    ld1b { z0.s }, p0/z, [x0]
+; CHECK-SD-NEXT:    // kill: def $d0 killed $d0 killed $z0
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: load_v2i8_sve:
+; CHECK-GI:       // %bb.0:
+; CHECK-GI-NEXT:    ld1 { v0.b }[0], [x0]
+; CHECK-GI-NEXT:    ldr b1, [x0, #1]
+; CHECK-GI-NEXT:    mov v0.s[1], v1.s[0]
+; CHECK-GI-NEXT:    // kill: def $d0 killed $d0 killed $q0
+; CHECK-GI-NEXT:    ret
+  %a = load <2 x i8>, ptr %ptr
+  ret <2 x i8> %a
+}
+
+; Check that when SVE is available it uses SVE's extending loads for v2i8.
+define <2 x i64> @load_v2i8_v2u8_sve(ptr %ptr) "target-features"="+sve" {
+; CHECK-SD-LABEL: load_v2i8_v2u8_sve:
+; CHECK-SD:       // %bb.0:
+; CHECK-SD-NEXT:    ptrue p0.d, vl2
+; CHECK-SD-NEXT:    ld1b { z0.d }, p0/z, [x0]
+; CHECK-SD-NEXT:    // kill: def $q0 killed $q0 killed $z0
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: load_v2i8_v2u8_sve:
+; CHECK-GI:       // %bb.0:
+; CHECK-GI-NEXT:    ld1 { v1.b }[0], [x0]
+; CHECK-GI-NEXT:    ldr b2, [x0, #1]
+; CHECK-GI-NEXT:    movi d0, #0x0000ff000000ff
+; CHECK-GI-NEXT:    mov v1.s[1], v2.s[0]
+; CHECK-GI-NEXT:    and v0.8b, v1.8b, v0.8b
+; CHECK-GI-NEXT:    fmov w9, s0
+; CHECK-GI-NEXT:    mov w8, v0.s[1]
+; CHECK-GI-NEXT:    and x9, x9, #0xffff
+; CHECK-GI-NEXT:    fmov d0, x9
+; CHECK-GI-NEXT:    and x8, x8, #0xffff
+; CHECK-GI-NEXT:    mov v0.d[1], x8
+; CHECK-GI-NEXT:    ret
+  %a = load <2 x i8>, ptr %ptr
+  %a.zext = zext <2 x i8> %a to <2 x i64>
+  ret <2 x i64> %a.zext
+}
+
+; Check that when SVE is available it uses SVE's extending loads for v2i8.
+define <2 x i64> @load_v2i8_v2s8_sve(ptr %ptr) "target-features"="+sve" {
+; CHECK-SD-LABEL: load_v2i8_v2s8_sve:
+; CHECK-SD:       // %bb.0:
+; CHECK-SD-NEXT:    ptrue p0.d, vl2
+; CHECK-SD-NEXT:    ld1sb { z0.d }, p0/z, [x0]
+; CHECK-SD-NEXT:    // kill: def $q0 killed $q0 killed $z0
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: load_v2i8_v2s8_sve:
+; CHECK-GI:       // %bb.0:
+; CHECK-GI-NEXT:    ldrb w8, [x0]
+; CHECK-GI-NEXT:    ldrb w9, [x0, #1]
+; CHECK-GI-NEXT:    fmov s0, w8
+; CHECK-GI-NEXT:    mov v0.h[1], w9
+; CHECK-GI-NEXT:    shl v0.4h, v0.4h, #8
+; CHECK-GI-NEXT:    sshr v0.4h, v0.4h, #8
+; CHECK-GI-NEXT:    smov x8, v0.h[0]
+; CHECK-GI-NEXT:    smov x9, v0.h[1]
+; CHECK-GI-NEXT:    fmov d0, x8
+; CHECK-GI-NEXT:    mov v0.d[1], x9
+; CHECK-GI-NEXT:    ret
+  %a = load <2 x i8>, ptr %ptr
+  %a.sext = sext <2 x i8> %a to <2 x i64>
+  ret <2 x i64> %a.sext
+}
+
 define i32 @load_v4i8(ptr %ptr, <4 x i8> %b) {
 ; CHECK-LABEL: load_v4i8:
 ; CHECK:       // %bb.0:

--- a/llvm/test/CodeGen/AArch64/neon-extadd-extract.ll
+++ b/llvm/test/CodeGen/AArch64/neon-extadd-extract.ll
@@ -775,12 +775,11 @@ entry:
 define <2 x i8> @extract_scalable_vec() vscale_range(1,16) "target-features"="+sve" {
 ; CHECK-SD-LABEL: extract_scalable_vec:
 ; CHECK-SD:       // %bb.0: // %entry
+; CHECK-SD-NEXT:    ptrue p0.s, vl2
 ; CHECK-SD-NEXT:    mov x8, xzr
-; CHECK-SD-NEXT:    index z1.s, #2, #3
-; CHECK-SD-NEXT:    ldr h0, [x8]
-; CHECK-SD-NEXT:    ushll v0.8h, v0.8b, #0
-; CHECK-SD-NEXT:    ushll v0.4s, v0.4h, #0
-; CHECK-SD-NEXT:    mul v0.2s, v0.2s, v1.2s
+; CHECK-SD-NEXT:    index z0.s, #2, #3
+; CHECK-SD-NEXT:    ld1b { z1.s }, p0/z, [x8]
+; CHECK-SD-NEXT:    mul v0.2s, v1.2s, v0.2s
 ; CHECK-SD-NEXT:    ret
 ;
 ; CHECK-GI-LABEL: extract_scalable_vec:

--- a/llvm/test/CodeGen/AArch64/sve-fixed-length-masked-gather.ll
+++ b/llvm/test/CodeGen/AArch64/sve-fixed-length-masked-gather.ll
@@ -12,16 +12,14 @@ target triple = "aarch64-unknown-linux-gnu"
 define void @masked_gather_v2i8(ptr %a, ptr %b) vscale_range(2,0) #0 {
 ; CHECK-LABEL: masked_gather_v2i8:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    ldr h0, [x0]
-; CHECK-NEXT:    ptrue p0.d, vl2
-; CHECK-NEXT:    ushll v0.8h, v0.8b, #0
-; CHECK-NEXT:    ushll v0.4s, v0.4h, #0
+; CHECK-NEXT:    ptrue p0.s, vl2
+; CHECK-NEXT:    ptrue p1.d, vl2
+; CHECK-NEXT:    ld1b { z0.s }, p0/z, [x0]
 ; CHECK-NEXT:    cmeq v0.2s, v0.2s, #0
 ; CHECK-NEXT:    sshll v0.2d, v0.2s, #0
-; CHECK-NEXT:    cmpne p1.d, p0/z, z0.d, #0
+; CHECK-NEXT:    cmpne p2.d, p1/z, z0.d, #0
 ; CHECK-NEXT:    ldr q0, [x1]
-; CHECK-NEXT:    ptrue p0.s, vl2
-; CHECK-NEXT:    ld1b { z0.d }, p1/z, [z0.d]
+; CHECK-NEXT:    ld1b { z0.d }, p2/z, [z0.d]
 ; CHECK-NEXT:    xtn v0.2s, v0.2d
 ; CHECK-NEXT:    st1b { z0.s }, p0, [x0]
 ; CHECK-NEXT:    ret

--- a/llvm/test/CodeGen/AArch64/sve-fixed-length-masked-scatter.ll
+++ b/llvm/test/CodeGen/AArch64/sve-fixed-length-masked-scatter.ll
@@ -12,10 +12,9 @@ target triple = "aarch64-unknown-linux-gnu"
 define void @masked_scatter_v2i8(ptr %a, ptr %b) vscale_range(2,0) #0 {
 ; CHECK-LABEL: masked_scatter_v2i8:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    ldr h0, [x0]
+; CHECK-NEXT:    ptrue p0.s, vl2
+; CHECK-NEXT:    ld1b { z0.s }, p0/z, [x0]
 ; CHECK-NEXT:    ptrue p0.d, vl2
-; CHECK-NEXT:    ushll v0.8h, v0.8b, #0
-; CHECK-NEXT:    ushll v0.4s, v0.4h, #0
 ; CHECK-NEXT:    cmeq v1.2s, v0.2s, #0
 ; CHECK-NEXT:    ushll v0.2d, v0.2s, #0
 ; CHECK-NEXT:    sshll v1.2d, v1.2s, #0

--- a/llvm/test/CodeGen/AArch64/sve-insert-vector-to-predicate-load.ll
+++ b/llvm/test/CodeGen/AArch64/sve-insert-vector-to-predicate-load.ll
@@ -172,11 +172,9 @@ define <vscale x 16 x i1> @pred_load_neg5(ptr %addr, <vscale x 2 x i8> %passthru
 define <vscale x 16 x i1> @pred_load_v2i8_multiuse(ptr %addr) #0 {
 ; CHECK-LABEL: pred_load_v2i8_multiuse:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    ldr h0, [x0]
+; CHECK-NEXT:    ptrue p0.d
+; CHECK-NEXT:    ld1b { z0.d }, p0/z, [x0]
 ; CHECK-NEXT:    ldr p0, [x0]
-; CHECK-NEXT:    ushll v0.8h, v0.8b, #0
-; CHECK-NEXT:    ushll v0.4s, v0.4h, #0
-; CHECK-NEXT:    ushll v0.2d, v0.2s, #0
 ; CHECK-NEXT:    // fake_use: $z0
 ; CHECK-NEXT:    ret
   %load = load <2 x i8>, ptr %addr, align 4


### PR DESCRIPTION
Loads of v2i8 are promoted to v2i32, which requires two extend operations; v2i8 -> v2i16, then v2i16 -> v2i32. This comes largely for free when using SVE's extending loads.