### PR TITLE
[lldb][debugserver] Fix a bug in FindBreakpointsThatOverlapRange

### DIFF
--- a/lldb/test/API/functionalities/breakpoint/hardware_breakpoints/write_memory_with_hw_breakpoint/TestWriteMemoryWithHWBreakpoint.py
+++ b/lldb/test/API/functionalities/breakpoint/hardware_breakpoints/write_memory_with_hw_breakpoint/TestWriteMemoryWithHWBreakpoint.py
@@ -46,4 +46,4 @@ class WriteMemoryWithHWBreakpoint(HardwareBreakpointTestBase):
 
         result = process.WriteMemory(address, data, error)
         self.assertTrue(error.Success())
-        self.assertEquals(result, len(data))
+        self.assertEqual(result, len(data))

--- a/lldb/test/API/functionalities/breakpoint/hardware_breakpoints/write_memory_with_hw_breakpoint/TestWriteMemoryWithHWBreakpoint.py
+++ b/lldb/test/API/functionalities/breakpoint/hardware_breakpoints/write_memory_with_hw_breakpoint/TestWriteMemoryWithHWBreakpoint.py
@@ -14,7 +14,7 @@ from functionalities.breakpoint.hardware_breakpoints.base import *
 class WriteMemoryWithHWBreakpoint(HardwareBreakpointTestBase):
 
     @skipTestIfFn(HardwareBreakpointTestBase.hw_breakpoints_unsupported)
-    def test_copy_memory_with_hw_break(self):
+    def test_write_memory_with_hw_break(self):
         self.build()
         exe = self.getBuildArtifact("a.out")
 

--- a/lldb/test/API/functionalities/breakpoint/hardware_breakpoints/write_memory_with_hw_breakpoint/TestWriteMemoryWithHWBreakpoint.py
+++ b/lldb/test/API/functionalities/breakpoint/hardware_breakpoints/write_memory_with_hw_breakpoint/TestWriteMemoryWithHWBreakpoint.py
@@ -13,8 +13,7 @@ from functionalities.breakpoint.hardware_breakpoints.base import *
 
 class WriteMemoryWithHWBreakpoint(HardwareBreakpointTestBase):
 
-    @skipTestIfFn(HardwareBreakpointTestBase.supports_hw_breakpoints)
-    @skip
+    @skipTestIfFn(HardwareBreakpointTestBase.hw_breakpoints_unsupported)
     def test_copy_memory_with_hw_break(self):
         self.build()
         exe = self.getBuildArtifact("a.out")
@@ -46,4 +45,5 @@ class WriteMemoryWithHWBreakpoint(HardwareBreakpointTestBase):
         error = lldb.SBError()
 
         result = process.WriteMemory(address, data, error)
-        self.assertTrue(error.Success() and result == len(bytes))
+        self.assertTrue(error.Success())
+        self.assertEquals(result, len(data))

--- a/lldb/tools/debugserver/source/DNBBreakpoint.cpp
+++ b/lldb/tools/debugserver/source/DNBBreakpoint.cpp
@@ -135,7 +135,7 @@ size_t DNBBreakpointList::FindBreakpointsThatOverlapRange(
       iterator prev_pos = pos;
       --prev_pos;
       if (prev_pos->second.IntersectsRange(addr, size, NULL, NULL, NULL))
-        bps.push_back(&prev_pos->second);
+        bps.push_back(&pos->second);
     }
 
     while (pos != end) {

--- a/lldb/tools/debugserver/source/DNBBreakpoint.cpp
+++ b/lldb/tools/debugserver/source/DNBBreakpoint.cpp
@@ -135,7 +135,7 @@ size_t DNBBreakpointList::FindBreakpointsThatOverlapRange(
       iterator prev_pos = pos;
       --prev_pos;
       if (prev_pos->second.IntersectsRange(addr, size, NULL, NULL, NULL))
-        bps.push_back(&pos->second);
+        bps.push_back(&prev_pos->second);
     }
 
     while (pos != end) {
@@ -147,10 +147,10 @@ size_t DNBBreakpointList::FindBreakpointsThatOverlapRange(
         break;
 
       // Check if this breakpoint overlaps, and if it does, add it to the list
-      if (pos->second.IntersectsRange(addr, size, NULL, NULL, NULL)) {
+      if (pos->second.IntersectsRange(addr, size, NULL, NULL, NULL))
         bps.push_back(&pos->second);
-        ++pos;
-      }
+
+      ++pos;
     }
   }
   return bps.size();


### PR DESCRIPTION
This reverts commit a7ef89ad9796e6de3a085ec75a13f0dfec5a8059 to reland #216723,
with a fix for the reported failure on MacOS. I think this was due to a bug in 
`DNBBreakpointList::FindBreakpointsThatOverlapRange`.

In the second loop, `pos` is only incremented if `IntersectsRange` returns true. It will
never return true for a hardware breakpoint because hardware breakpoints are not
placed into actual memory.

This means that it gets stuck in that final while. I think if I had access to the logs, I
would see lldb timing out the write memory request.

I made some small changes to the test case:
* Split the final assertion so we can tell if it failed entirely or partially.
* Renamed the test case, since it's not "copying" anything.