### PR TITLE
CodeGen: Use getDefBlock in MachineLoop::isLoopInvariant

### DIFF
--- a/llvm/lib/CodeGen/MachineLoopInfo.cpp
+++ b/llvm/lib/CodeGen/MachineLoopInfo.cpp
@@ -286,12 +286,12 @@ bool MachineLoop::isLoopInvariant(MachineInstr &I,
     if (!MO.readsReg())
       continue;
 
-    assert(MRI->getVRegDef(Reg) &&
-           "Machine instr not mapped for this vreg?!");
+    MachineBasicBlock *DefBlock = MRI->getDefBlock(Reg);
+    assert(DefBlock && "Machine instr not mapped for this vreg?!");
 
     // If the loop contains the definition of an operand, then the instruction
     // isn't loop invariant.
-    if (contains(MRI->getVRegDef(Reg)))
+    if (contains(DefBlock))
       return false;
   }
 


### PR DESCRIPTION
Look up the defining block of an operand's register directly with
getDefBlock() instead of calling getVRegDef() twice and relying on
contains() to walk to the instruction's parent. NFC.

Co-Authored-By: Claude <noreply@anthropic.com> claude-opus-4.8