### PR TITLE
[orc-rt] Add StringOutputStream for <sstream>-free messages

### DIFF
--- a/orc-rt/include/orc-rt/StringExtras.h
+++ b/orc-rt/include/orc-rt/StringExtras.h
@@ -10,10 +10,16 @@
 #define ORC_RT_STRINGEXTRAS_H
 
 #include <cassert>
+#include <charconv>
+#include <cstdint>
 #include <iterator>
 #include <string>
+#include <string_view>
 #include <type_traits>
+#include <utility>
+
 namespace orc_rt {
+
 /// A simplification of what is in llvm/ADT/StringExtras.h
 /// Preserves the behaviour but removes tag dispatch
 /// Will assert if iterator is not a forward iterator.
@@ -52,5 +58,88 @@ inline std::string join(std::initializer_list<std::string_view> Elements,
                         std::string_view Separator) {
   return join(Elements.begin(), Elements.end(), Separator);
 }
+
+/// A minimal, locale-free stand-in for std::ostringstream for building
+/// diagnostic/error messages without dragging in <sstream> (and with it the
+/// iostreams + locale machinery, which isn't freestanding-friendly). Integers
+/// and pointers are formatted via std::to_chars, so there's no locale
+/// dependence and no allocation beyond growing the result string.
+class StringOutputStream {
+public:
+  template <typename T> struct HexFmt {
+    T Value;
+  };
+
+  StringOutputStream &operator<<(char C) {
+    S.push_back(C);
+    return *this;
+  }
+  StringOutputStream &operator<<(bool B) {
+    S.append(B ? "true" : "false");
+    return *this;
+  }
+  StringOutputStream &operator<<(const char *Str) {
+    S.append(Str);
+    return *this;
+  }
+  StringOutputStream &operator<<(std::string_view Str) {
+    S.append(Str);
+    return *this;
+  }
+
+  StringOutputStream &operator<<(const void *P) {
+    appendHex(reinterpret_cast<std::uintptr_t>(P));
+    return *this;
+  }
+
+  template <typename T, std::enable_if_t<std::is_integral_v<T>, int> = 0>
+  StringOutputStream &operator<<(T Value) {
+    // 3*sizeof(T) over-approximates decimal digits (~2.41/byte), + sign +
+    // slack. Sized from the type so to_chars can never overflow, even for
+    // extended integer types (e.g. __int128 under GNU extensions).
+    char Buf[3 * sizeof(T) + 2];
+    auto [Ptr, EC] = std::to_chars(Buf, std::end(Buf), Value);
+    assert(EC == std::errc{} && "Buf outgrew its provable bound?");
+    (void)EC;
+    S.append(Buf, Ptr);
+    return *this;
+  }
+
+  template <typename T> StringOutputStream &operator<<(HexFmt<T> H) {
+    // hex() guarantees T is a non-bool integer, so make_unsigned_t is valid.
+    appendHex(static_cast<std::make_unsigned_t<T>>(H.Value));
+    return *this;
+  }
+
+  /// Access the accumulated string (mirrors std::ostringstream::str()).
+  const std::string &str() const & { return S; }
+  std::string str() && { return std::move(S); }
+
+private:
+  /// Append V as "0x"-prefixed lowercase hex. Leading zeros are dropped, so the
+  /// printed width reflects the value, not the type.
+  void appendHex(std::uintptr_t V) {
+    char Buf[2 * sizeof(V)]; // Exact: 2 hex digits per byte, unsigned, no sign.
+    auto [Ptr, EC] = std::to_chars(Buf, std::end(Buf), V, 16);
+    assert(EC == std::errc{} && "hex buffer too small?");
+    (void)EC;
+    S.append("0x");
+    S.append(Buf, Ptr);
+  }
+
+  std::string S;
+};
+
+/// Wrap an integer so StringOutputStream prints it as "0x"-prefixed lowercase
+/// hex (formatted as its unsigned bit pattern). Pointers are already printed in
+/// hex by the default operator<<, so hex() is for integers only.
+template <typename T> StringOutputStream::HexFmt<T> hex(T Value) {
+  static_assert(std::is_integral_v<T> && !std::is_same_v<T, bool>,
+                "hex() is for integers; pointers already print in hex by "
+                "default, and bool is not a numeric value");
+  return {Value};
+}
+
 } // namespace orc_rt
+
 #endif

--- a/orc-rt/test/unit/StringExtrasTest.cpp
+++ b/orc-rt/test/unit/StringExtrasTest.cpp
@@ -13,6 +13,11 @@
 #include "orc-rt/StringExtras.h"
 #include "gtest/gtest.h"
 
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <string_view>
+
 using namespace orc_rt;
 
 TEST(StringExtrasTest, JoinSingleString) { EXPECT_EQ(join({"x"}, "-"), "x"); }
@@ -33,4 +38,127 @@ TEST(StringExtrasTest, JoinEmptySeparator) {
 
 TEST(StringExtrasTest, JoinMultiSeparator) {
   EXPECT_EQ(join({"a", "b", "c"}, ", "), "a, b, c");
+}
+
+TEST(StringOutputStreamTest, EmptyByDefault) {
+  StringOutputStream OS;
+  EXPECT_EQ(OS.str(), "");
+}
+
+TEST(StringOutputStreamTest, TextTypes) {
+  const char *CStr = "cstr";
+  std::string Str = "std::string";
+  std::string_view SV = "view";
+  StringOutputStream OS;
+  OS << "lit " << CStr << ' ' << Str << ' ' << SV;
+  EXPECT_EQ(OS.str(), "lit cstr std::string view");
+}
+
+// char and bool must render as a character / "true"|"false", NOT as numbers.
+// This pins the non-template overloads against the integral template.
+TEST(StringOutputStreamTest, CharAndBoolAreNotNumeric) {
+  StringOutputStream OS;
+  OS << 'A' << ':' << true << ',' << false;
+  EXPECT_EQ(OS.str(), "A:true,false");
+}
+
+TEST(StringOutputStreamTest, IntegersAreDecimalByDefault) {
+  StringOutputStream OS;
+  OS << 0 << ' ' << 42 << ' ' << -7 << ' ' << 3000000000u;
+  EXPECT_EQ(OS.str(), "0 42 -7 3000000000");
+}
+
+// Buffer is sized from the type, so the widest built-in integers round-trip.
+TEST(StringOutputStreamTest, IntegerExtremes) {
+  {
+    StringOutputStream OS;
+    OS << std::numeric_limits<int64_t>::min();
+    EXPECT_EQ(OS.str(), "-9223372036854775808");
+  }
+  {
+    StringOutputStream OS;
+    OS << std::numeric_limits<uint64_t>::max();
+    EXPECT_EQ(OS.str(), "18446744073709551615");
+  }
+}
+
+// A bare integer literal 0 is an int (identity match), not a null pointer
+// constant, so it must print "0" rather than routing to the const void*
+// overload as "0x0".
+TEST(StringOutputStreamTest, LiteralZeroIsIntNotPointer) {
+  StringOutputStream OS;
+  OS << 0;
+  EXPECT_EQ(OS.str(), "0");
+}
+
+TEST(StringOutputStreamTest, PointersAreHexByDefault) {
+  StringOutputStream OS;
+  const void *P = reinterpret_cast<const void *>(0xdeadbeefULL);
+  OS << "p=" << P;
+  EXPECT_EQ(OS.str(), "p=0xdeadbeef");
+}
+
+TEST(StringOutputStreamTest, NullPointerPrintsZero) {
+  StringOutputStream OS;
+  OS << static_cast<const void *>(nullptr);
+  EXPECT_EQ(OS.str(), "0x0");
+}
+
+// Typed object pointers bind to the const void* overload (no dedicated
+// template), so they too print as hex.
+TEST(StringOutputStreamTest, TypedPointersAreHex) {
+  int X = 0;
+  StringOutputStream OS;
+  OS << &X;
+  EXPECT_EQ(OS.str().rfind("0x", 0), 0u); // starts with "0x"
+  EXPECT_GT(OS.str().size(), 2u);
+}
+
+TEST(StringOutputStreamTest, HexBasics) {
+  StringOutputStream OS;
+  OS << hex(0) << ' ' << hex(255) << ' ' << hex(0xABCDu);
+  EXPECT_EQ(OS.str(), "0x0 0xff 0xabcd");
+}
+
+// hex() prints the unsigned two's-complement bit pattern, and its width tracks
+// the operand type rather than being widened to a pointer.
+TEST(StringOutputStreamTest, HexNegativeIsTwosComplement) {
+  {
+    StringOutputStream OS;
+    OS << hex(static_cast<int32_t>(-1));
+    EXPECT_EQ(OS.str(), "0xffffffff");
+  }
+  {
+    StringOutputStream OS;
+    OS << hex(static_cast<int64_t>(-1));
+    EXPECT_EQ(OS.str(), "0xffffffffffffffff");
+  }
+  {
+    StringOutputStream OS;
+    OS << hex(static_cast<uint8_t>(0x0f));
+    EXPECT_EQ(OS.str(), "0xf"); // leading zeros dropped
+  }
+}
+
+TEST(StringOutputStreamTest, ChainingReturnsSameStream) {
+  StringOutputStream OS;
+  StringOutputStream &Ref = (OS << "a" << 1 << hex(2));
+  EXPECT_EQ(&Ref, &OS);
+  EXPECT_EQ(OS.str(), "a10x2");
+}
+
+TEST(StringOutputStreamTest, RvalueStrMovesOut) {
+  StringOutputStream OS;
+  OS << "payload " << 123;
+  std::string Moved = std::move(OS).str();
+  EXPECT_EQ(Moved, "payload 123");
+}
+
+TEST(StringOutputStreamTest, RealisticMessage) {
+  int Code = -22;
+  const void *Addr = reinterpret_cast<const void *>(0x1000ULL);
+  StringOutputStream OS;
+  OS << "map failed at " << Addr << " (errno=" << Code
+     << ", flags=" << hex(0x1Bu) << ")";
+  EXPECT_EQ(OS.str(), "map failed at 0x1000 (errno=-22, flags=0x1b)");
 }


### PR DESCRIPTION
Add orc_rt::StringOutputStream to StringExtras.h: a minimal, output-only stream that appends formatted values to a std::string via operator<<, for building diagnostic/error strings without <sstream>.

<sstream> pulls in the iostreams + locale machinery, which is not in the freestanding subset and is undesirable in the executor (which runs on-target, including bare-metal). It is also locale-sensitive and built around exceptions. StringOutputStream formats integers and pointers with std::to_chars, so it has no locale dependence, allocates only to grow the result string, and needs neither <sstream> nor <iostream>.

Integers and pointers are formatted with std::to_chars, so there is no locale dependence and allocation only to grow the result string.

 - Overloads for char, bool, const char*, std::string_view, const void* (hex), and any built-in integer (decimal via to_chars).
 - A free hex() helper prints an integer as "0x"-prefixed lowercase hex (unsigned bit pattern). Pointers already print in hex, so hex() static_asserts against pointer and bool operands.

Tests cover the overload-resolution edges (char/bool not numeric, literal 0 is an int not a null pointer, hex() two's-complement width) and the 64-bit integer extremes.