### PR TITLE
[GlobalISel] Scan attributes once in CallLowering (NFC)

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/CallLowering.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/CallLowering.cpp
@@ -37,46 +37,66 @@ static void addFlagsFromAttrSet(ISD::ArgFlagsTy &Flags, AttributeSet Attrs) {
     return;
 
   // TODO: There are missing flags. Add them here.
-  if (Attrs.hasAttribute(Attribute::SExt))
-    Flags.setSExt();
-  if (Attrs.hasAttribute(Attribute::ZExt))
-    Flags.setZExt();
-  if (Attrs.hasAttribute(Attribute::InReg))
-    Flags.setInReg();
-  if (Attrs.hasAttribute(Attribute::StructRet))
-    Flags.setSRet();
-  if (Attrs.hasAttribute(Attribute::Nest))
-    Flags.setNest();
-  if (Attrs.hasAttribute(Attribute::ByVal))
-    Flags.setByVal();
-  if (Attrs.hasAttribute(Attribute::ByRef))
-    Flags.setByRef();
-  if (Attrs.hasAttribute(Attribute::InAlloca)) {
-    Flags.setInAlloca();
-    // Set the byval flag for CCAssignFn callbacks that don't know about
-    // inalloca.  This way we can know how many bytes we should've allocated
-    // and how many bytes a callee cleanup function will pop.  If we port
-    // inalloca to more targets, we'll have to add custom inalloca handling
-    // in the various CC lowering callbacks.
-    Flags.setByVal();
+  for (Attribute Attr : Attrs) {
+    if (Attr.isStringAttribute())
+      continue;
+
+    switch (Attr.getKindAsEnum()) {
+    case Attribute::SExt:
+      Flags.setSExt();
+      break;
+    case Attribute::ZExt:
+      Flags.setZExt();
+      break;
+    case Attribute::InReg:
+      Flags.setInReg();
+      break;
+    case Attribute::StructRet:
+      Flags.setSRet();
+      break;
+    case Attribute::Nest:
+      Flags.setNest();
+      break;
+    case Attribute::ByVal:
+      Flags.setByVal();
+      break;
+    case Attribute::ByRef:
+      Flags.setByRef();
+      break;
+    case Attribute::InAlloca:
+      Flags.setInAlloca();
+      // Set the byval flag for CCAssignFn callbacks that don't know about
+      // inalloca.  This way we can know how many bytes we should've allocated
+      // and how many bytes a callee cleanup function will pop.  If we port
+      // inalloca to more targets, we'll have to add custom inalloca handling
+      // in the various CC lowering callbacks.
+      Flags.setByVal();
+      break;
+    case Attribute::Preallocated:
+      Flags.setPreallocated();
+      // Set the byval flag for CCAssignFn callbacks that don't know about
+      // preallocated.  This way we can know how many bytes we should've
+      // allocated and how many bytes a callee cleanup function will pop.  If
+      // we port preallocated to more targets, we'll have to add custom
+      // preallocated handling in the various CC lowering callbacks.
+      Flags.setByVal();
+      break;
+    case Attribute::Returned:
+      Flags.setReturned();
+      break;
+    case Attribute::SwiftSelf:
+      Flags.setSwiftSelf();
+      break;
+    case Attribute::SwiftAsync:
+      Flags.setSwiftAsync();
+      break;
+    case Attribute::SwiftError:
+      Flags.setSwiftError();
+      break;
+    default:
+      break;
+    }
   }
-  if (Attrs.hasAttribute(Attribute::Preallocated)) {
-    Flags.setPreallocated();
-    // Set the byval flag for CCAssignFn callbacks that don't know about
-    // preallocated.  This way we can know how many bytes we should've
-    // allocated and how many bytes a callee cleanup function will pop.  If
-    // we port preallocated to more targets, we'll have to add custom
-    // preallocated handling in the various CC lowering callbacks.
-    Flags.setByVal();
-  }
-  if (Attrs.hasAttribute(Attribute::Returned))
-    Flags.setReturned();
-  if (Attrs.hasAttribute(Attribute::SwiftSelf))
-    Flags.setSwiftSelf();
-  if (Attrs.hasAttribute(Attribute::SwiftAsync))
-    Flags.setSwiftAsync();
-  if (Attrs.hasAttribute(Attribute::SwiftError))
-    Flags.setSwiftError();
 }
 
 ISD::ArgFlagsTy CallLowering::getAttributesForArgIdx(const CallBase &Call,


### PR DESCRIPTION
Profiling tramp3d on aarch64-O0-g shows AttributeSet::hasAttribute is hot below CallLowering::lowerCall. addFlagsFromAttrSet does 13 enum attribute lookups. Invert this to instead walk the attributes once and set the flags with a switch.

Improves CTMark geomean -0.07%, sqlite -0.13%, and tramp3d-v4 -0.11%.

https://llvm-compile-time-tracker.com/compare.php?from=b025f5b75941fcf2e719535473c51b5e0617c4f9&to=780a10dba2415886d8daf2fe52ad66109c5aa4ff&stat=instructions%3Au

Assisted-by: codex