### PR TITLE
[clang-repl] Keep access to private nested types in out-of-line members

### DIFF
--- a/clang/lib/Parse/ParseTentative.cpp
+++ b/clang/lib/Parse/ParseTentative.cpp
@@ -35,45 +35,59 @@ bool Parser::isCXXDeclarationStatement(
   case tok::coloncolon:
   case tok::identifier: {
     if (DisambiguatingWithExpression) {
+      {
+        // Suppress access checks: the declaration context of an out-of-line
+        // member is not known yet. On the recognized declaration shapes below
+        // the real parse redoes the checks from the unannotated tokens.
+        RevertingTentativeParsingAction TPA(*this, /*Unannotated=*/true);
+        SuppressAccessChecks AccessSuppressor(*this, /*activate=*/true);
+        // Parse the C++ scope specifier.
+        CXXScopeSpec SS;
+        ParseOptionalCXXScopeSpecifier(SS, /*ObjectType=*/nullptr,
+                                       /*ObjectHasErrors=*/false,
+                                       /*EnteringContext=*/true);
+
+        switch (Tok.getKind()) {
+        case tok::identifier: {
+          IdentifierInfo *II = Tok.getIdentifierInfo();
+          bool isDeductionGuide = Actions.isDeductionGuideName(
+              getCurScope(), *II, Tok.getLocation(), SS, /*Template=*/nullptr);
+          if (Actions.isCurrentClassName(*II, getCurScope(), &SS) ||
+              isDeductionGuide) {
+            if (isConstructorDeclarator(
+                    /*Unqualified=*/SS.isEmpty(), isDeductionGuide,
+                    /*IsFriend=*/DeclSpec::FriendSpecified::No))
+              return true;
+          } else if (SS.isNotEmpty()) {
+            // If the scope is not empty, it could alternatively be something
+            // like a typedef or using declaration. That declaration might be
+            // private in the global context, which would be diagnosed by
+            // calling into isCXXSimpleDeclaration, but may actually be fine in
+            // the context of member functions and static variable definitions.
+            // Check if the next token is also an identifier and assume a
+            // declaration. We cannot check if the scopes match because the
+            // declarations could involve namespaces and friend declarations.
+            if (NextToken().is(tok::identifier))
+              return true;
+          }
+          break;
+        }
+        case tok::kw_operator:
+          return true;
+        case tok::tilde:
+          return true;
+        default:
+          break;
+        }
+      }
+      // Not a recognized declaration shape. Parse the scope specifier again
+      // without suppression, so qualifier access diagnoses as it does for a
+      // statement, and keep the annotations for the checks below.
       RevertingTentativeParsingAction TPA(*this);
-      // Parse the C++ scope specifier.
       CXXScopeSpec SS;
       ParseOptionalCXXScopeSpecifier(SS, /*ObjectType=*/nullptr,
                                      /*ObjectHasErrors=*/false,
                                      /*EnteringContext=*/true);
-
-      switch (Tok.getKind()) {
-      case tok::identifier: {
-        IdentifierInfo *II = Tok.getIdentifierInfo();
-        bool isDeductionGuide = Actions.isDeductionGuideName(
-            getCurScope(), *II, Tok.getLocation(), SS, /*Template=*/nullptr);
-        if (Actions.isCurrentClassName(*II, getCurScope(), &SS) ||
-            isDeductionGuide) {
-          if (isConstructorDeclarator(
-                  /*Unqualified=*/SS.isEmpty(), isDeductionGuide,
-                  /*IsFriend=*/DeclSpec::FriendSpecified::No))
-            return true;
-        } else if (SS.isNotEmpty()) {
-          // If the scope is not empty, it could alternatively be something like
-          // a typedef or using declaration. That declaration might be private
-          // in the global context, which would be diagnosed by calling into
-          // isCXXSimpleDeclaration, but may actually be fine in the context of
-          // member functions and static variable definitions. Check if the next
-          // token is also an identifier and assume a declaration.
-          // We cannot check if the scopes match because the declarations could
-          // involve namespaces and friend declarations.
-          if (NextToken().is(tok::identifier))
-            return true;
-        }
-        break;
-      }
-      case tok::kw_operator:
-        return true;
-      case tok::tilde:
-        return true;
-      default:
-        break;
-      }
     }
   }
     [[fallthrough]];

--- a/clang/test/Interpreter/access.cpp
+++ b/clang/test/Interpreter/access.cpp
@@ -11,5 +11,19 @@ B::u* foo() { return nullptr; }
 B::u * B::foo() { return nullptr; }
 // CHECK-NOT: error: 'u' is a private member of 'B'
 
-int p = B::p; 
+class C { struct S { S(); ~S(); int f(); bool operator!() const; }; };
+
+C::S::S() {}
+// CHECK-NOT: error: 'S' is a private member of 'C'
+
+C::S::~S() {}
+// CHECK-NOT: error: 'S' is a private member of 'C'
+
+int C::S::f() { return 0; }
+// CHECK-NOT: error: 'S' is a private member of 'C'
+
+bool C::S::operator!() const { return true; }
+// CHECK-NOT: error: 'S' is a private member of 'C'
+
+int p = B::p;
 // CHECK: error: 'p' is a private member of 'B'

--- a/clang/test/Interpreter/disambiguate-decl-stmt.cpp
+++ b/clang/test/Interpreter/disambiguate-decl-stmt.cpp
@@ -69,6 +69,12 @@ PrivateUsingFriend::T PrivateUsingFriendMember::f() { return 0; }
 class PrivateUsingFriendVar { static PrivateUsingFriend::T i; };
 PrivateUsingFriend::T PrivateUsingFriendVar::i = 42;
 
+// Out-of-line members of a private nested class
+class PrivateNested { struct Nested { Nested(); ~Nested(); int f(); }; };
+PrivateNested::Nested::Nested() {}
+PrivateNested::Nested::~Nested() {}
+int PrivateNested::Nested::f() { return 0; }
+
 // The following should still diagnose (inspired by PR13642)
 class PR13642 { class Inner { public: static int i; }; };
 // expected-note@-1 {{implicitly declared private here}}


### PR DESCRIPTION
Under `-fincremental-extensions`, `Parser::isCXXDeclarationStatement` parses the nested-name-specifier of its `tok::identifier` branch with immediate access checks. Valid out-of-line constructor, destructor, method, and operator definitions that name a private nested type are rejected during disambiguation:

```cpp
class C { struct S { S(); }; };
C::S::S() {} // error: 'S' is a private member of 'C'
```

The declaration context is not known during disambiguation, so the check must be delayed. f6f0503673b7 (#178842) fixed the same problem only in the keyword/typedef fallthrough branch.

Suppress access checks during the identifier-branch scope parse and revert unannotated. The recognized declaration shapes redo the checks in the correct declarator context during the real parse. When no declaration shape matches, the scope specifier is parsed again without suppression, so statement diagnostics are unchanged (the PR13642 case still diagnoses exactly once).

Red/green: extends `clang/test/Interpreter/access.cpp` and `clang/test/Interpreter/disambiguate-decl-stmt.cpp`; both fail without the parser change.
