### PR TITLE
[lldb] Read a repeated range in ReadMemoryRanges only once

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -1647,6 +1647,9 @@ public:
   ///     of the slice indicates how many bytes were read successfully. Partial
   ///     reads are always performed from the start of the requested range,
   ///     never from the middle or end.
+  ///
+  ///     A repeated range is read once and each repeat returns the same slice,
+  ///     so callers must treat the slices as read-only.
   llvm::SmallVector<llvm::MutableArrayRef<uint8_t>>
   ReadMemoryRanges(llvm::ArrayRef<Range<lldb::addr_t, size_t>> ranges,
                    llvm::MutableArrayRef<uint8_t> buffer);

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -11,6 +11,7 @@
 #include <mutex>
 #include <optional>
 
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/Support/ScopedPrinter.h"
 #include "llvm/Support/Threading.h"
@@ -2082,14 +2083,37 @@ size_t Process::ReadMemory(addr_t addr, void *buf, size_t size, Status &error) {
 llvm::SmallVector<llvm::MutableArrayRef<uint8_t>>
 Process::ReadMemoryRanges(llvm::ArrayRef<Range<lldb::addr_t, size_t>> ranges,
                           llvm::MutableArrayRef<uint8_t> buffer) {
-  llvm::SmallVector<Range<lldb::addr_t, size_t>> fixed_ranges;
-  fixed_ranges.reserve(ranges.size());
-  for (const Range<lldb::addr_t, size_t> &range : ranges)
-    fixed_ranges.emplace_back(FixAnyAddress(range.GetRangeBase()),
-                              range.GetByteSize());
-  if (!GetDisableMemoryCache())
-    return m_memory_cache.ReadRanges(fixed_ranges, buffer);
-  return DoReadMemoryRanges(fixed_ranges, buffer);
+  // Callers can name the same range twice, when several objects share a value.
+  llvm::SmallVector<Range<lldb::addr_t, size_t>> unique_ranges;
+  llvm::SmallVector<unsigned> range_to_unique;
+  llvm::DenseMap<std::pair<lldb::addr_t, size_t>, unsigned> unique_index;
+  unique_ranges.reserve(ranges.size());
+  range_to_unique.reserve(ranges.size());
+  for (const Range<lldb::addr_t, size_t> &range : ranges) {
+    Range<lldb::addr_t, size_t> fixed(FixAnyAddress(range.GetRangeBase()),
+                                      range.GetByteSize());
+    auto [pos, inserted] = unique_index.try_emplace(
+        {fixed.GetRangeBase(), fixed.GetByteSize()}, unique_ranges.size());
+    if (inserted)
+      unique_ranges.push_back(fixed);
+    range_to_unique.push_back(pos->second);
+  }
+
+  llvm::SmallVector<llvm::MutableArrayRef<uint8_t>> unique_results =
+      GetDisableMemoryCache()
+          ? DoReadMemoryRanges(unique_ranges, buffer)
+          : m_memory_cache.ReadRanges(unique_ranges, buffer);
+  assert(unique_results.size() == unique_ranges.size() &&
+         "expected one result per unique range");
+
+  if (unique_ranges.size() == ranges.size())
+    return unique_results;
+
+  llvm::SmallVector<llvm::MutableArrayRef<uint8_t>> results;
+  results.reserve(ranges.size());
+  for (unsigned idx : range_to_unique)
+    results.push_back(unique_results[idx]);
+  return results;
 }
 
 llvm::SmallVector<llvm::MutableArrayRef<uint8_t>>

--- a/lldb/unittests/Target/MemoryTest.cpp
+++ b/lldb/unittests/Target/MemoryTest.cpp
@@ -468,9 +468,11 @@ public:
   // reading smaller chunks until it gets nothing back.
   bool read_less_than_requested = false;
   bool read_more_than_requested = false;
+  size_t num_reads = 0;
 
   size_t DoReadMemory(lldb::addr_t vm_addr, void *buf, size_t size,
                       Status &error) override {
+    num_reads++;
     if (read_less_than_requested && size > 0)
       size--;
     if (read_more_than_requested)
@@ -489,6 +491,47 @@ public:
   bool DoUpdateThreadList(ThreadList &, ThreadList &) override { return false; }
   llvm::StringRef GetPluginName() override { return "Dummy"; }
 };
+
+TEST_F(MemoryTest, TestReadMemoryRangesDeduplicatesRepeatedRanges) {
+  ArchSpec arch("x86_64-apple-macosx-");
+
+  Platform::SetHostPlatform(PlatformRemoteMacOSX::CreateInstance(true, &arch));
+
+  DebuggerSP debugger_sp = Debugger::CreateInstance();
+  ASSERT_TRUE(debugger_sp);
+
+  TargetSP target_sp = CreateTarget(debugger_sp, arch);
+  ASSERT_TRUE(target_sp);
+
+  ListenerSP listener_sp(Listener::MakeListener("dummy"));
+  auto process_sp =
+      std::make_shared<DummyReaderProcess>(target_sp, listener_sp);
+  ASSERT_TRUE(process_sp);
+
+  llvm::SmallVector<Range<addr_t, size_t>> ranges = {
+      {0x1000, 64}, {0x2000, 64}, {0x1000, 64},
+      {0x3000, 64}, {0x1000, 64}, {0x2000, 64}};
+  llvm::SmallVector<uint8_t, 0> buffer(64 * ranges.size(), 0);
+
+  llvm::SmallVector<llvm::MutableArrayRef<uint8_t>> read_results =
+      process_sp->ReadMemoryRanges(ranges, buffer);
+
+  ASSERT_EQ(read_results.size(), ranges.size());
+  for (auto [range, memory] : llvm::zip(ranges, read_results)) {
+    ASSERT_EQ(memory.size(), 64u);
+    addr_t range_base = range.GetRangeBase();
+    for (auto [idx, byte] : llvm::enumerate(memory))
+      ASSERT_EQ(byte, static_cast<uint8_t>(range_base + idx));
+  }
+
+  // Only the three distinct ranges reached the inferior, and each repeat got
+  // the slice its first occurrence was read into.
+  EXPECT_EQ(process_sp->num_reads, 3u);
+
+  EXPECT_EQ(read_results[0].data(), read_results[2].data());
+  EXPECT_EQ(read_results[0].data(), read_results[4].data());
+  EXPECT_EQ(read_results[1].data(), read_results[5].data());
+}
 
 TEST_F(MemoryTest, TestReadMemoryRanges) {
   ArchSpec arch("x86_64-apple-macosx-");


### PR DESCRIPTION
`Process::ReadMemoryRanges` returns one result per requested range and reads
every range that misses the memory cache, so a range named twice in one batch is
read twice.

`ClassDescriptorV2::method_t::ReadNames` reads a class's method names and type
encodings as one batch: the name pointer of every method, followed by the type
pointer of every method.  Methods that share a signature share one type encoding
string, so a type pointer can repeat.  Running the `po` expression from
`TestObjCMethodsNSError.test_runtime_types` under `log enable gdb-remote
packets` catches a batch for two methods, four `address,length` pairs with
`100` a length of 256 bytes:

```
send packet: $MultiMemRead:ranges:1fe0802a1,100,1fe0802db,100,20177e73c,100,20177e73c,100;
```

The first two addresses are the two names and the last two are the two types.
The two type addresses are equal, so this one packet reads the same 256 bytes
twice:

```
(lldb) memory read --format c-string --count 1 0x1fe0802a1
0x1fe0802a1: "_supportsGetValueWithNameForKey:perhapsByOverridingClass:"
(lldb) memory read --format c-string --count 1 0x1fe0802db
0x1fe0802db: "_supportsGetValueWithUniqueIDForKey:perhapsByOverridingClass:"
(lldb) memory read --format c-string --count 1 0x20177e73c
0x20177e73c: "q32@0:8@16#24"
```

Both methods take an object and a Class and return a long long, so the one
encoding at `0x20177e73c` describes both.  Over the whole expression the client
sends 4690 `MultiMemRead` ranges, 28 of them repeats within their own packet.

Deduplicate in `ReadMemoryRanges`, above both the cached and the uncached path,
so every caller benefits: read each distinct range once and return that slice
for each of its repeats.  Callers only read from the returned slices, so sharing
one is not observable.  The same expression now sends 4662 ranges and no
repeats.
