### PR TITLE
[AMDGPU] Generalize scratch SGPR CFI emission

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIFrameLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFrameLowering.cpp
@@ -406,31 +406,9 @@ class PrologEpilogSGPRSpillBuilder {
         .addReg(SuperReg)
         .setMIFlag(MachineInstr::FrameSetup);
     if (NeedsFrameMoves) {
-      const TargetRegisterClass *RC = TRI.getPhysRegBaseClass(DstReg);
-      ArrayRef<int16_t> DstSplitParts = TRI.getRegSplitParts(RC, EltSize);
-      assert(NumSubRegs == (DstSplitParts.empty() ? 1 : DstSplitParts.size()));
       MCRegister CFISuperReg = getCFISuperReg();
-      if (!CFISuperReg)
-        CFISuperReg = SuperReg;
-      int64_t DwarfCFISuperReg = MCRI->getDwarfRegNum(CFISuperReg, false);
-      int64_t DwarfDstSuperReg = MCRI->getDwarfRegNum(DstReg, false);
-      if (DwarfCFISuperReg >= 0 && DwarfDstSuperReg >= 0) {
-        TFI->buildCFI(MBB, MI, DL,
-                      MCCFIInstruction::createRegister(
-                          nullptr, DwarfCFISuperReg, DwarfDstSuperReg));
-      } else if (isExec(CFISuperReg)) {
-        assert(NumSubRegs == 2 && "EXEC larger than 64-bit");
-        TFI->buildCFIForRegToSGPRPairSpill(MBB, MI, DL, CFISuperReg, DstReg);
-      } else {
-        for (unsigned I = 0; I < NumSubRegs; ++I) {
-          MCRegister SrcSubReg = TRI.getSubReg(SuperReg, SplitParts[I]);
-          MCRegister DstSubReg = TRI.getSubReg(DstReg, DstSplitParts[I]);
-          TFI->buildCFI(MBB, MI, DL,
-                        MCCFIInstruction::createRegister(
-                            nullptr, MCRI->getDwarfRegNum(SrcSubReg, false),
-                            MCRI->getDwarfRegNum(DstSubReg, false)));
-        }
-      }
+      TFI->buildCFIForSRegToSRegSpill(
+          MBB, MI, DL, CFISuperReg ? CFISuperReg : SuperReg.asMCReg(), DstReg);
     }
   }
 
@@ -1121,8 +1099,8 @@ void SIFrameLowering::emitPrologueEntryCFI(MachineBasicBlock &MBB,
   emitDefCFA(MBB, MBBI, DL, StackPtrReg, /*AspaceAlreadyDefined=*/true,
              MachineInstr::FrameSetup);
 
-  buildCFIForRegToSGPRPairSpill(MBB, MBBI, DL, AMDGPU::PC_REG,
-                                TRI.getReturnAddressReg(MF));
+  buildCFIForSRegToSRegSpill(MBB, MBBI, DL, AMDGPU::PC_REG,
+                             TRI.getReturnAddressReg(MF));
 
   BitVector IsCalleeSaved(TRI.getNumRegs());
   const MCPhysReg *CSRegs = MRI.getCalleeSavedRegs();
@@ -2634,24 +2612,59 @@ MachineInstr *SIFrameLowering::buildCFIForVGPRToVMEMSpill(
   return buildCFI(MBB, MBBI, DL, std::move(CFIInst));
 }
 
-MachineInstr *SIFrameLowering::buildCFIForRegToSGPRPairSpill(
+static void decomposeDwarfRegs(const SIRegisterInfo &TRI, MCRegister Reg,
+                               SmallVectorImpl<unsigned> &DwarfRegs) {
+  int64_t DwarfReg = TRI.getDwarfRegNum(Reg, /*IsEH=*/false);
+  if (DwarfReg >= 0) {
+    DwarfRegs.push_back(unsigned(DwarfReg));
+    return;
+  }
+
+  const TargetRegisterClass *RC = TRI.getPhysRegBaseClass(Reg);
+  ArrayRef<int16_t> SplitParts = TRI.getRegSplitParts(RC, SGPRByteSize);
+  for (unsigned I = 0; I < SplitParts.size(); ++I) {
+    MCRegister SubReg = TRI.getSubReg(Reg, SplitParts[I]);
+    DwarfReg = TRI.getDwarfRegNum(SubReg, /*IsEH=*/false);
+    if (DwarfReg < 0) {
+      DwarfRegs.clear();
+      return;
+    }
+    DwarfRegs.push_back(unsigned(DwarfReg));
+  }
+}
+
+void SIFrameLowering::buildCFIForSRegToSRegSpill(
     MachineBasicBlock &MBB, MachineBasicBlock::iterator MBBI,
-    const DebugLoc &DL, const MCRegister Reg, const MCRegister SGPRPair) const {
+    const DebugLoc &DL, MCRegister Reg, MCRegister CopyReg) const {
   const MachineFunction &MF = *MBB.getParent();
   const GCNSubtarget &ST = MF.getSubtarget<GCNSubtarget>();
   const SIRegisterInfo &TRI = *ST.getRegisterInfo();
 
-  MCRegister SGPR0 = TRI.getSubReg(SGPRPair, AMDGPU::sub0);
-  MCRegister SGPR1 = TRI.getSubReg(SGPRPair, AMDGPU::sub1);
+  SmallVector<unsigned> DwarfRegs, DwarfCopyRegs;
+  decomposeDwarfRegs(TRI, Reg, DwarfRegs);
+  decomposeDwarfRegs(TRI, CopyReg, DwarfCopyRegs);
 
-  int DwarfReg = TRI.getDwarfRegNum(Reg, false);
-  int DwarfSGPR0 = TRI.getDwarfRegNum(SGPR0, false);
-  int DwarfSGPR1 = TRI.getDwarfRegNum(SGPR1, false);
-  assert(DwarfReg != -1 && DwarfSGPR0 != -1 && DwarfSGPR1 != -1);
+  if (DwarfRegs.size() == DwarfCopyRegs.size()) {
+    for (unsigned I = 0, E = DwarfRegs.size(); I < E; ++I) {
+      auto CFI = MCCFIInstruction::createRegister(nullptr, DwarfRegs[I],
+                                                  DwarfCopyRegs[I]);
+      buildCFI(MBB, MBBI, DL, CFI);
+    }
+    return;
+  }
 
-  auto CFIInst = MCCFIInstruction::createLLVMRegisterPair(
-      nullptr, DwarfReg, DwarfSGPR0, SGPRBitSize, DwarfSGPR1, SGPRBitSize);
-  return buildCFI(MBB, MBBI, DL, std::move(CFIInst));
+  if (DwarfRegs.size() == 1 && DwarfCopyRegs.size() == 2) {
+    auto CFI = MCCFIInstruction::createLLVMRegisterPair(
+        nullptr, DwarfRegs[0], DwarfCopyRegs[0], SGPRBitSize, DwarfCopyRegs[1],
+        SGPRBitSize);
+    buildCFI(MBB, MBBI, DL, CFI);
+    return;
+  }
+
+  for (unsigned I = 0, E = DwarfRegs.size(); I < E; ++I) {
+    auto CFI = MCCFIInstruction::createUndefined(nullptr, DwarfRegs[I]);
+    buildCFI(MBB, MBBI, DL, CFI);
+  }
 }
 
 MachineInstr *SIFrameLowering::buildCFIForSameValue(

--- a/llvm/lib/Target/AMDGPU/SIFrameLowering.h
+++ b/llvm/lib/Target/AMDGPU/SIFrameLowering.h
@@ -173,11 +173,10 @@ public:
                                            MachineBasicBlock::iterator MBBI,
                                            const DebugLoc &DL, MCRegister VGPR,
                                            int64_t Offset) const;
-  MachineInstr *buildCFIForRegToSGPRPairSpill(MachineBasicBlock &MBB,
-                                              MachineBasicBlock::iterator MBBI,
-                                              const DebugLoc &DL,
-                                              MCRegister Reg,
-                                              MCRegister SGPRPair) const;
+  void buildCFIForSRegToSRegSpill(MachineBasicBlock &MBB,
+                                  MachineBasicBlock::iterator MBBI,
+                                  const DebugLoc &DL, MCRegister Reg,
+                                  MCRegister CopyReg) const;
   MachineInstr *buildCFIForSameValue(MachineBasicBlock &MBB,
                                      MachineBasicBlock::iterator MBBI,
                                      const DebugLoc &DL, MCRegister Reg) const;

--- a/llvm/test/CodeGen/AMDGPU/amdgpu-spill-cfi-saved-regs.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgpu-spill-cfi-saved-regs.ll
@@ -3065,6 +3065,169 @@ define void @spill_exec_to_vcc() #3 {
  ret void
 }
 
+define void @spill_exec_to_vcc_hi() #3 {
+; WAVE64-LABEL: spill_exec_to_vcc_hi:
+; WAVE64:       .Lfunc_begin9:
+; WAVE64-NEXT:    .cfi_startproc
+; WAVE64-NEXT:  ; %bb.0:
+; WAVE64-NEXT:    .cfi_llvm_def_aspace_cfa 64, 0, 6
+; WAVE64-NEXT:    .cfi_llvm_register_pair 16, 62, 32, 63, 32
+; WAVE64-NEXT:    .cfi_undefined 36
+; WAVE64-NEXT:    .cfi_undefined 37
+; WAVE64-NEXT:    .cfi_undefined 38
+; WAVE64-NEXT:    .cfi_undefined 39
+; WAVE64-NEXT:    .cfi_undefined 40
+; WAVE64-NEXT:    .cfi_undefined 41
+; WAVE64-NEXT:    .cfi_undefined 42
+; WAVE64-NEXT:    .cfi_undefined 43
+; WAVE64-NEXT:    .cfi_undefined 44
+; WAVE64-NEXT:    .cfi_undefined 45
+; WAVE64-NEXT:    .cfi_undefined 46
+; WAVE64-NEXT:    .cfi_undefined 47
+; WAVE64-NEXT:    .cfi_undefined 48
+; WAVE64-NEXT:    .cfi_undefined 49
+; WAVE64-NEXT:    .cfi_undefined 50
+; WAVE64-NEXT:    .cfi_undefined 51
+; WAVE64-NEXT:    .cfi_undefined 52
+; WAVE64-NEXT:    .cfi_undefined 53
+; WAVE64-NEXT:    .cfi_undefined 54
+; WAVE64-NEXT:    .cfi_undefined 55
+; WAVE64-NEXT:    .cfi_undefined 56
+; WAVE64-NEXT:    .cfi_undefined 57
+; WAVE64-NEXT:    .cfi_undefined 58
+; WAVE64-NEXT:    .cfi_undefined 59
+; WAVE64-NEXT:    .cfi_undefined 60
+; WAVE64-NEXT:    .cfi_undefined 61
+; WAVE64-NEXT:    .cfi_undefined 72
+; WAVE64-NEXT:    .cfi_undefined 73
+; WAVE64-NEXT:    .cfi_undefined 74
+; WAVE64-NEXT:    .cfi_undefined 75
+; WAVE64-NEXT:    .cfi_undefined 76
+; WAVE64-NEXT:    .cfi_undefined 77
+; WAVE64-NEXT:    .cfi_undefined 78
+; WAVE64-NEXT:    .cfi_undefined 79
+; WAVE64-NEXT:    .cfi_undefined 88
+; WAVE64-NEXT:    .cfi_undefined 89
+; WAVE64-NEXT:    .cfi_undefined 90
+; WAVE64-NEXT:    .cfi_undefined 91
+; WAVE64-NEXT:    .cfi_undefined 92
+; WAVE64-NEXT:    .cfi_undefined 93
+; WAVE64-NEXT:    .cfi_undefined 94
+; WAVE64-NEXT:    .cfi_undefined 95
+; WAVE64-NEXT:    .cfi_undefined 1096
+; WAVE64-NEXT:    .cfi_undefined 1097
+; WAVE64-NEXT:    .cfi_undefined 1098
+; WAVE64-NEXT:    .cfi_undefined 1099
+; WAVE64-NEXT:    .cfi_undefined 1100
+; WAVE64-NEXT:    .cfi_undefined 1101
+; WAVE64-NEXT:    .cfi_undefined 1102
+; WAVE64-NEXT:    .cfi_undefined 1103
+; WAVE64-NEXT:    .cfi_undefined 1112
+; WAVE64-NEXT:    .cfi_undefined 1113
+; WAVE64-NEXT:    .cfi_undefined 1114
+; WAVE64-NEXT:    .cfi_undefined 1115
+; WAVE64-NEXT:    .cfi_undefined 1116
+; WAVE64-NEXT:    .cfi_undefined 1117
+; WAVE64-NEXT:    .cfi_undefined 1118
+; WAVE64-NEXT:    .cfi_undefined 1119
+; WAVE64-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; WAVE64-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; WAVE64-NEXT:    buffer_store_dword v0, off, s[0:3], s32 ; 4-byte Folded Spill
+; WAVE64-NEXT:    .cfi_offset 2560, 0
+; WAVE64-NEXT:    s_mov_b64 exec, s[4:5]
+; WAVE64-NEXT:    v_writelane_b32 v0, exec_lo, 0
+; WAVE64-NEXT:    v_writelane_b32 v0, exec_hi, 1
+; WAVE64-NEXT:    .cfi_llvm_vector_registers 17, 2560, 0, 32, 2560, 1, 32
+; WAVE64-NEXT:    ;;#ASMSTART
+; WAVE64-NEXT:    ; clobber scratch SGPRs
+; WAVE64-NEXT:    ;;#ASMEND
+; WAVE64-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; WAVE64-NEXT:    buffer_load_dword v0, off, s[0:3], s32 ; 4-byte Folded Reload
+; WAVE64-NEXT:    s_mov_b64 exec, s[4:5]
+; WAVE64-NEXT:    s_waitcnt vmcnt(0)
+; WAVE64-NEXT:    s_setpc_b64 s[30:31]
+;
+; WAVE32-LABEL: spill_exec_to_vcc_hi:
+; WAVE32:       .Lfunc_begin9:
+; WAVE32-NEXT:    .cfi_startproc
+; WAVE32-NEXT:  ; %bb.0:
+; WAVE32-NEXT:    .cfi_llvm_def_aspace_cfa 64, 0, 6
+; WAVE32-NEXT:    .cfi_llvm_register_pair 16, 62, 32, 63, 32
+; WAVE32-NEXT:    .cfi_undefined 36
+; WAVE32-NEXT:    .cfi_undefined 37
+; WAVE32-NEXT:    .cfi_undefined 38
+; WAVE32-NEXT:    .cfi_undefined 39
+; WAVE32-NEXT:    .cfi_undefined 40
+; WAVE32-NEXT:    .cfi_undefined 41
+; WAVE32-NEXT:    .cfi_undefined 42
+; WAVE32-NEXT:    .cfi_undefined 43
+; WAVE32-NEXT:    .cfi_undefined 44
+; WAVE32-NEXT:    .cfi_undefined 45
+; WAVE32-NEXT:    .cfi_undefined 46
+; WAVE32-NEXT:    .cfi_undefined 47
+; WAVE32-NEXT:    .cfi_undefined 48
+; WAVE32-NEXT:    .cfi_undefined 49
+; WAVE32-NEXT:    .cfi_undefined 50
+; WAVE32-NEXT:    .cfi_undefined 51
+; WAVE32-NEXT:    .cfi_undefined 52
+; WAVE32-NEXT:    .cfi_undefined 53
+; WAVE32-NEXT:    .cfi_undefined 54
+; WAVE32-NEXT:    .cfi_undefined 55
+; WAVE32-NEXT:    .cfi_undefined 56
+; WAVE32-NEXT:    .cfi_undefined 57
+; WAVE32-NEXT:    .cfi_undefined 58
+; WAVE32-NEXT:    .cfi_undefined 59
+; WAVE32-NEXT:    .cfi_undefined 60
+; WAVE32-NEXT:    .cfi_undefined 61
+; WAVE32-NEXT:    .cfi_undefined 72
+; WAVE32-NEXT:    .cfi_undefined 73
+; WAVE32-NEXT:    .cfi_undefined 74
+; WAVE32-NEXT:    .cfi_undefined 75
+; WAVE32-NEXT:    .cfi_undefined 76
+; WAVE32-NEXT:    .cfi_undefined 77
+; WAVE32-NEXT:    .cfi_undefined 78
+; WAVE32-NEXT:    .cfi_undefined 79
+; WAVE32-NEXT:    .cfi_undefined 88
+; WAVE32-NEXT:    .cfi_undefined 89
+; WAVE32-NEXT:    .cfi_undefined 90
+; WAVE32-NEXT:    .cfi_undefined 91
+; WAVE32-NEXT:    .cfi_undefined 92
+; WAVE32-NEXT:    .cfi_undefined 93
+; WAVE32-NEXT:    .cfi_undefined 94
+; WAVE32-NEXT:    .cfi_undefined 95
+; WAVE32-NEXT:    .cfi_undefined 1096
+; WAVE32-NEXT:    .cfi_undefined 1097
+; WAVE32-NEXT:    .cfi_undefined 1098
+; WAVE32-NEXT:    .cfi_undefined 1099
+; WAVE32-NEXT:    .cfi_undefined 1100
+; WAVE32-NEXT:    .cfi_undefined 1101
+; WAVE32-NEXT:    .cfi_undefined 1102
+; WAVE32-NEXT:    .cfi_undefined 1103
+; WAVE32-NEXT:    .cfi_undefined 1112
+; WAVE32-NEXT:    .cfi_undefined 1113
+; WAVE32-NEXT:    .cfi_undefined 1114
+; WAVE32-NEXT:    .cfi_undefined 1115
+; WAVE32-NEXT:    .cfi_undefined 1116
+; WAVE32-NEXT:    .cfi_undefined 1117
+; WAVE32-NEXT:    .cfi_undefined 1118
+; WAVE32-NEXT:    .cfi_undefined 1119
+; WAVE32-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; WAVE32-NEXT:    s_mov_b32 vcc_hi, exec_lo
+; WAVE32-NEXT:    .cfi_undefined 1
+; WAVE32-NEXT:    ;;#ASMSTART
+; WAVE32-NEXT:    ; clobber scratch SGPRs
+; WAVE32-NEXT:    ;;#ASMEND
+; WAVE32-NEXT:    s_setpc_b64 s[30:31]
+  call void asm sideeffect "; clobber scratch SGPRs",
+    "~{s4},~{s5},~{s6},~{s7},~{s8},~{s9},~{s10},~{s11},~{s12},~{s13},~{s14}
+    ,~{s15},~{s16},~{s17},~{s18},~{s19},~{s20},~{s21},~{s22},~{s23},~{s24}
+    ,~{s25},~{s26},~{s27},~{s28},~{s29},~{s40},~{s41},~{s42},~{s43},~{s44}
+    ,~{s45},~{s46},~{s47},~{s56},~{s57},~{s58},~{s59},~{s60},~{s61},~{s62}
+    ,~{s63},~{s72},~{s73},~{s74},~{s75},~{s76},~{s77},~{s78},~{s79},~{s88}
+    ,~{s89},~{s90},~{s91},~{s92},~{s93},~{s94},~{s95},~{vcc_lo}"()
+ ret void
+}
+
 attributes #0 = { nounwind }
 attributes #1 = { nounwind "amdgpu-waves-per-eu"="10,10" }
 attributes #2 = { nounwind "frame-pointer"="all" "amdgpu-waves-per-eu"="10,10" }


### PR DESCRIPTION
It's possible to spill to vcc_hi in wave32, however that isn't representable in dwarf since 64-bit vcc is only usable in wave64. Generate a cfi_undefined for this case for now. Follow up on #213115.