### PR TITLE
[cmake] Fix the dead VSINSTALLDIR check in FindDIASDK

### DIFF
--- a/llvm/cmake/config-ix.cmake
+++ b/llvm/cmake/config-ix.cmake
@@ -631,8 +631,21 @@ if( MSVC )
     "If set, argument to clang-cl's /winsysroot")
 
   find_package(DIASDK)
+
+  # An SDK that happens to sit in a Visual Studio installation is not by itself
+  # a request to use it: LLVM loads msdia140.dll by name at run time, and a
+  # developer environment does not put it on PATH, so enabling DIA on the
+  # strength of the environment alone yields a PDB reader that cannot start.
+  # Enable it by default only where the SDK was pointed at deliberately; it can
+  # always be asked for with -DLLVM_ENABLE_DIA_SDK=ON.
+  if(DIASDK_FOUND AND NOT DIASDK_LOCATION_INFERRED)
+    set(LLVM_ENABLE_DIA_SDK_DEFAULT ON)
+  else()
+    set(LLVM_ENABLE_DIA_SDK_DEFAULT OFF)
+  endif()
+
   option(LLVM_ENABLE_DIA_SDK "Use MSVC DIA SDK for debugging if available."
-                             ${DIASDK_FOUND})
+                             ${LLVM_ENABLE_DIA_SDK_DEFAULT})
 
   if(LLVM_ENABLE_DIA_SDK AND NOT DIASDK_FOUND)
     message(FATAL_ERROR "DIA SDK not found. If you have both VS 2012 and 2013 installed, you may need to uninstall the former and re-install the latter afterwards.")

--- a/llvm/cmake/modules/FindDIASDK.cmake
+++ b/llvm/cmake/modules/FindDIASDK.cmake
@@ -20,16 +20,25 @@ if(NOT WIN32)
   return()
 endif()
 
-set(DIASDK_LOCATION_INFERRED FALSE)
+# Cached alongside MSVC_DIA_SDK_DIR: once the path is in the cache the branches
+# below no longer run, so a plain variable would read FALSE on every reconfigure
+# and describe a location nobody chose as one that was chosen deliberately.
+if(NOT DEFINED DIASDK_LOCATION_INFERRED)
+  set(DIASDK_LOCATION_INFERRED FALSE CACHE INTERNAL
+      "Whether MSVC_DIA_SDK_DIR was inferred from the environment")
+endif()
 
 if(LLVM_WINSYSROOT)
   set(MSVC_DIA_SDK_DIR "${LLVM_WINSYSROOT}/DIA SDK" CACHE PATH
       "Path to the DIA SDK")
+  set(DIASDK_LOCATION_INFERRED FALSE CACHE INTERNAL
+      "Whether MSVC_DIA_SDK_DIR was inferred from the environment")
 elseif(NOT DEFINED MSVC_DIA_SDK_DIR)
   if(DEFINED ENV{VSINSTALLDIR})
     set(MSVC_DIA_SDK_DIR "$ENV{VSINSTALLDIR}DIA SDK" CACHE PATH
         "Path to the DIA SDK")
-    set(DIASDK_LOCATION_INFERRED TRUE)
+    set(DIASDK_LOCATION_INFERRED TRUE CACHE INTERNAL
+        "Whether MSVC_DIA_SDK_DIR was inferred from the environment")
   else()
     message(STATUS "MSVC_DIA_SDK_DIR not set, and could not be inferred. DIA "
                    "SDK may not be found.")

--- a/llvm/cmake/modules/FindDIASDK.cmake
+++ b/llvm/cmake/modules/FindDIASDK.cmake
@@ -9,6 +9,8 @@
 #   DIASDK_FOUND
 #   DIASDK_INCLUDE_DIR
 #   DIASDK_LIBRARIES
+#   DIASDK_LOCATION_INFERRED, true if the SDK was located from the environment
+#     rather than from LLVM_WINSYSROOT or MSVC_DIA_SDK_DIR
 #
 # Additionally, the following import target will be defined:
 #   DIASDK::Diaguids
@@ -18,15 +20,20 @@ if(NOT WIN32)
   return()
 endif()
 
+set(DIASDK_LOCATION_INFERRED FALSE)
+
 if(LLVM_WINSYSROOT)
   set(MSVC_DIA_SDK_DIR "${LLVM_WINSYSROOT}/DIA SDK" CACHE PATH
       "Path to the DIA SDK")
-elseif($ENV{VSINSTALLDIR})
-  set(MSVC_DIA_SDK_DIR "$ENV{VSINSTALLDIR}DIA SDK" CACHE PATH
-      "Path to the DIA SDK")
 elseif(NOT DEFINED MSVC_DIA_SDK_DIR)
-  message(STATUS "MSVC_DIA_SDK_DIR not set, and could not be inferred. DIA SDK "
-                 "may not be found.")
+  if(DEFINED ENV{VSINSTALLDIR})
+    set(MSVC_DIA_SDK_DIR "$ENV{VSINSTALLDIR}DIA SDK" CACHE PATH
+        "Path to the DIA SDK")
+    set(DIASDK_LOCATION_INFERRED TRUE)
+  else()
+    message(STATUS "MSVC_DIA_SDK_DIR not set, and could not be inferred. DIA "
+                   "SDK may not be found.")
+  endif()
 endif()
 
 find_path(DIASDK_INCLUDE_DIR

--- a/llvm/docs/CMake.md
+++ b/llvm/docs/CMake.md
@@ -520,7 +520,10 @@ sub-projects. Nearly all of these variable names begin with `LLVM_`.
 **LLVM_ENABLE_DIA_SDK**:BOOL
 
 :   Enable building with MSVC DIA SDK for PDB debugging support. Available only
-    with MSVC. Defaults to ON.
+    with MSVC. Defaults to ON when the SDK is found at a location given by
+    `LLVM_WINSYSROOT` or `MSVC_DIA_SDK_DIR`, and to OFF when it is only found
+    through the `VSINSTALLDIR` environment variable, since using it also
+    requires `msdia140.dll` to be loadable at run time.
 
 **LLVM_ENABLE_DOXYGEN**:BOOL
 


### PR DESCRIPTION
`elseif($ENV{VSINSTALLDIR})` expands the environment variable's *value* into the condition, where CMake reads it as the name of an undefined variable. The branch never runs, so the DIA SDK is never located from a developer command prompt. This tests whether the variable is defined instead.

That one-line fix landed once before, in #208524, and was reverted in #209137 after the Windows LLDB bots went red. The reason is a step further on: `config-ix.cmake` defaults `LLVM_ENABLE_DIA_SDK` to `DIASDK_FOUND`, so repairing detection turned DIA on for every build whose environment happened to contain an SDK, and LLDB's DIA tests need `msdia140.dll`, which LLVM loads by name through `NoRegCoCreate` and a developer environment does not put on `PATH`.

So this PR separates finding the SDK from choosing to use it. The module now reports whether it inferred the location from the environment or was handed one via `LLVM_WINSYSROOT` or `MSVC_DIA_SDK_DIR`, and only a location that was handed to it enables DIA by default. A build that merely has an SDK in its environment keeps today's behavior, which is the case the bots are in.

What it buys is that DIA can be asked for at all. Today `-DLLVM_ENABLE_DIA_SDK=ON` from a developer command prompt trips the option's own consistency check, `FATAL_ERROR "DIA SDK not found. ..."`, so the SDK has to be named by hand even when it sits exactly where CMake was about to look.

`CMake.md` says the option defaults to ON; it has always defaulted to whether the SDK was found, so that line is updated to match.

### Testing

Premerge Windows is itself an instance of the broken case: `VSINSTALLDIR` is set to `C:\BuildTools`, and neither `LLVM_WINSYSROOT` nor `MSVC_DIA_SDK_DIR` is passed, so the dead branch was the only way it could have found the SDK. The configure output changes accordingly:

| build | DIASDK status line |
| --- | --- |
| `main` | `Could NOT find DIASDK (missing: DIASDK_INCLUDE_DIR DIASDK_LIBRARIES)` |
| this PR | `Found DIASDK: C:/BuildTools/DIA SDK/include` |

No DIA sources are compiled in either build, so `DIASDK_FOUND` became true while `LLVM_ENABLE_DIA_SDK` stayed OFF, which is the split this PR is for.

The other configurations are verified by running the module against a fake SDK tree with the MSVC-only pieces stubbed out:

| configuration | before | after |
| --- | --- | --- |
| `MSVC_DIA_SDK_DIR` given | found, option defaults ON | unchanged |
| `LLVM_WINSYSROOT` given | found, option defaults ON | unchanged |
| only `VSINSTALLDIR` in the environment | **not found** | found, option defaults OFF |
| nothing set | not found, status message | unchanged |

Premerge does not build LLDB, so it cannot exercise what caused the revert in #209137. Confirmation on `lldb-x86_64-win` and `lldb-aarch64-windows` would still be welcome.

cc @vangthao95 @charles-zablit @ZhongRuoyu
