### PR TITLE
[BPF] Use fetch insn for relaxed atomics with a used result

### DIFF
--- a/llvm/lib/Target/BPF/BPFInstrInfo.td
+++ b/llvm/lib/Target/BPF/BPFInstrInfo.td
@@ -1008,66 +1008,6 @@ let Constraints = "$dst = $val" in {
   def XFXORD : XFALU64<BPF_DW, BPF_XOR, "u64", "xor">;
 }
 
-let Predicates = [BPFHasALU32] in {
-    foreach P = [// add
-                 [atomic_load_add_i32_monotonic,  XADDW32],
-                 [atomic_load_add_i32_acquire,   XFADDW32],
-                 [atomic_load_add_i32_release,   XFADDW32],
-                 [atomic_load_add_i32_acq_rel,   XFADDW32],
-                 [atomic_load_add_i32_seq_cst,   XFADDW32],
-                 // and
-                 [atomic_load_and_i32_monotonic,  XANDW32],
-                 [atomic_load_and_i32_acquire,   XFANDW32],
-                 [atomic_load_and_i32_release,   XFANDW32],
-                 [atomic_load_and_i32_acq_rel,   XFANDW32],
-                 [atomic_load_and_i32_seq_cst,   XFANDW32],
-                 // or
-                 [atomic_load_or_i32_monotonic,   XORW32],
-                 [atomic_load_or_i32_acquire,    XFORW32],
-                 [atomic_load_or_i32_release,    XFORW32],
-                 [atomic_load_or_i32_acq_rel,    XFORW32],
-                 [atomic_load_or_i32_seq_cst,    XFORW32],
-                 // xor
-                 [atomic_load_xor_i32_monotonic,  XXORW32],
-                 [atomic_load_xor_i32_acquire,   XFXORW32],
-                 [atomic_load_xor_i32_release,   XFXORW32],
-                 [atomic_load_xor_i32_acq_rel,   XFXORW32],
-                 [atomic_load_xor_i32_seq_cst,   XFXORW32],
-                ] in {
-      def : Pat<(P[0] ADDRri:$addr, GPR32:$val), (P[1]  ADDRri:$addr, GPR32:$val)>;
-    }
-
-    // atomic_load_sub can be represented as a neg followed
-    // by an atomic_load_add.
-    foreach P = [[atomic_load_sub_i32_monotonic,  XADDW32],
-                 [atomic_load_sub_i32_acquire,   XFADDW32],
-                 [atomic_load_sub_i32_release,   XFADDW32],
-                 [atomic_load_sub_i32_acq_rel,   XFADDW32],
-                 [atomic_load_sub_i32_seq_cst,   XFADDW32],
-                ] in {
-      def : Pat<(P[0] ADDRri:$addr, GPR32:$val), (P[1]  ADDRri:$addr, (NEG_32 GPR32:$val))>;
-    }
-
-    foreach P = [// add
-                 [atomic_load_add_i64_monotonic,  XADDD],
-                 [atomic_load_add_i64_acquire,   XFADDD],
-                 [atomic_load_add_i64_release,   XFADDD],
-                 [atomic_load_add_i64_acq_rel,   XFADDD],
-                 [atomic_load_add_i64_seq_cst,   XFADDD],
-                ] in {
-      def : Pat<(P[0] ADDRri:$addr, GPR:$val), (P[1]  ADDRri:$addr, GPR:$val)>;
-    }
-}
-
-foreach P = [[atomic_load_sub_i64_monotonic,  XADDD],
-             [atomic_load_sub_i64_acquire,   XFADDD],
-             [atomic_load_sub_i64_release,   XFADDD],
-             [atomic_load_sub_i64_acq_rel,   XFADDD],
-             [atomic_load_sub_i64_seq_cst,   XFADDD],
-            ] in {
-  def : Pat<(P[0] ADDRri:$addr, GPR:$val), (P[1]  ADDRri:$addr, (NEG_64 GPR:$val))>;
-}
-
 // Borrow the idea from X86InstrFragments.td
 class binop_no_use<SDPatternOperator operator>
       : PatFrag<(ops node:$A, node:$B),
@@ -1079,11 +1019,96 @@ class binop_has_use<SDPatternOperator operator>
                 (operator node:$A, node:$B),
                 [{ return !SDValue(N, 0).use_empty(); }]>;
 
-foreach op = [add, and, or, xor] in {
+// For monotonic (relaxed) ordering the no-fetch locked insn may only be used
+// when the result is dead; when the result is live the fetch form is required,
+// since the locked insn does not write the old value back to the register.
+foreach op = [add, sub, and, or, xor] in {
+def atomic_load_ # op # _i32_monotonic_nu:
+    binop_no_use <!cast<SDPatternOperator>("atomic_load_"#op# _i32_monotonic)>;
+def atomic_load_ # op # _i32_monotonic_hu:
+    binop_has_use<!cast<SDPatternOperator>("atomic_load_"#op# _i32_monotonic)>;
 def atomic_load_ # op # _i64_monotonic_nu:
     binop_no_use <!cast<SDPatternOperator>("atomic_load_"#op# _i64_monotonic)>;
 def atomic_load_ # op # _i64_monotonic_hu:
     binop_has_use<!cast<SDPatternOperator>("atomic_load_"#op# _i64_monotonic)>;
+}
+
+let Predicates = [BPFHasALU32] in {
+    foreach P = [// add
+                 [atomic_load_add_i32_monotonic_nu, XADDW32],
+                 [atomic_load_add_i32_monotonic_hu, XFADDW32],
+                 [atomic_load_add_i32_acquire,   XFADDW32],
+                 [atomic_load_add_i32_release,   XFADDW32],
+                 [atomic_load_add_i32_acq_rel,   XFADDW32],
+                 [atomic_load_add_i32_seq_cst,   XFADDW32],
+                 // and
+                 [atomic_load_and_i32_monotonic_nu, XANDW32],
+                 [atomic_load_and_i32_monotonic_hu, XFANDW32],
+                 [atomic_load_and_i32_acquire,   XFANDW32],
+                 [atomic_load_and_i32_release,   XFANDW32],
+                 [atomic_load_and_i32_acq_rel,   XFANDW32],
+                 [atomic_load_and_i32_seq_cst,   XFANDW32],
+                 // or
+                 [atomic_load_or_i32_monotonic_nu, XORW32],
+                 [atomic_load_or_i32_monotonic_hu, XFORW32],
+                 [atomic_load_or_i32_acquire,    XFORW32],
+                 [atomic_load_or_i32_release,    XFORW32],
+                 [atomic_load_or_i32_acq_rel,    XFORW32],
+                 [atomic_load_or_i32_seq_cst,    XFORW32],
+                 // xor
+                 [atomic_load_xor_i32_monotonic_nu, XXORW32],
+                 [atomic_load_xor_i32_monotonic_hu, XFXORW32],
+                 [atomic_load_xor_i32_acquire,   XFXORW32],
+                 [atomic_load_xor_i32_release,   XFXORW32],
+                 [atomic_load_xor_i32_acq_rel,   XFXORW32],
+                 [atomic_load_xor_i32_seq_cst,   XFXORW32],
+                ] in {
+      def : Pat<(P[0] ADDRri:$addr, GPR32:$val), (P[1]  ADDRri:$addr, GPR32:$val)>;
+    }
+
+    // atomic_load_sub can be represented as a neg followed
+    // by an atomic_load_add.
+    foreach P = [[atomic_load_sub_i32_monotonic_nu, XADDW32],
+                 [atomic_load_sub_i32_monotonic_hu, XFADDW32],
+                 [atomic_load_sub_i32_acquire,   XFADDW32],
+                 [atomic_load_sub_i32_release,   XFADDW32],
+                 [atomic_load_sub_i32_acq_rel,   XFADDW32],
+                 [atomic_load_sub_i32_seq_cst,   XFADDW32],
+                ] in {
+      def : Pat<(P[0] ADDRri:$addr, GPR32:$val), (P[1]  ADDRri:$addr, (NEG_32 GPR32:$val))>;
+    }
+
+    foreach P = [// add
+                 [atomic_load_add_i64_monotonic_nu, XADDD],
+                 [atomic_load_add_i64_monotonic_hu, XFADDD],
+                 [atomic_load_add_i64_acquire,   XFADDD],
+                 [atomic_load_add_i64_release,   XFADDD],
+                 [atomic_load_add_i64_acq_rel,   XFADDD],
+                 [atomic_load_add_i64_seq_cst,   XFADDD],
+                ] in {
+      def : Pat<(P[0] ADDRri:$addr, GPR:$val), (P[1]  ADDRri:$addr, GPR:$val)>;
+    }
+
+    foreach P = [[atomic_load_sub_i64_monotonic_nu, XADDD],
+                 [atomic_load_sub_i64_monotonic_hu, XFADDD],
+                ] in {
+      def : Pat<(P[0] ADDRri:$addr, GPR:$val), (P[1]  ADDRri:$addr, (NEG_64 GPR:$val))>;
+    }
+}
+
+let Predicates = [BPFNoALU32] in {
+  // Without the fetch insn the result cannot be returned; keep selecting the
+  // locked insn so BPFMIPreEmitChecking can report a live def as an error.
+  def : Pat<(atomic_load_sub_i64_monotonic ADDRri:$addr, GPR:$val),
+            (XADDD ADDRri:$addr, (NEG_64 GPR:$val))>;
+}
+
+foreach P = [[atomic_load_sub_i64_acquire,   XFADDD],
+             [atomic_load_sub_i64_release,   XFADDD],
+             [atomic_load_sub_i64_acq_rel,   XFADDD],
+             [atomic_load_sub_i64_seq_cst,   XFADDD],
+            ] in {
+  def : Pat<(P[0] ADDRri:$addr, GPR:$val), (P[1]  ADDRri:$addr, (NEG_64 GPR:$val))>;
 }
 
 foreach P = [// and

--- a/llvm/test/CodeGen/BPF/atomics_mem_order_v3.ll
+++ b/llvm/test/CodeGen/BPF/atomics_mem_order_v3.ll
@@ -201,7 +201,7 @@ define dso_local i32 @test_fetch_add_32_ret(ptr nocapture noundef %i) local_unna
 ; CHECK-NEXT:  # %bb.0: # %entry
 ; CHECK-NEXT:    w2 = 10
 ; CHECK-NEXT:    w3 = 10
-; CHECK-NEXT:    lock *(u32 *)(r1 + 0) += w3
+; CHECK-NEXT:    w3 = atomic_fetch_add((u32 *)(r1 + 0), w3)
 ; CHECK-NEXT:    w0 = 10
 ; CHECK-NEXT:    w0 = atomic_fetch_add((u32 *)(r1 + 0), w0)
 ; CHECK-NEXT:    w0 += w3
@@ -261,7 +261,7 @@ define dso_local i64 @test_fetch_add_64_ret(ptr nocapture noundef %i) local_unna
 ; CHECK-NEXT:  # %bb.0: # %entry
 ; CHECK-NEXT:    r2 = 10
 ; CHECK-NEXT:    r3 = 10
-; CHECK-NEXT:    lock *(u64 *)(r1 + 0) += r3
+; CHECK-NEXT:    r3 = atomic_fetch_add((u64 *)(r1 + 0), r3)
 ; CHECK-NEXT:    r0 = 10
 ; CHECK-NEXT:    r0 = atomic_fetch_add((u64 *)(r1 + 0), r0)
 ; CHECK-NEXT:    r0 += r3
@@ -323,7 +323,7 @@ define dso_local i32 @test_fetch_sub_32_ret(ptr nocapture noundef %i) local_unna
 ; CHECK-NEXT:    w2 = 10
 ; CHECK-NEXT:    w2 = -w2
 ; CHECK-NEXT:    w3 = w2
-; CHECK-NEXT:    lock *(u32 *)(r1 + 0) += w3
+; CHECK-NEXT:    w3 = atomic_fetch_add((u32 *)(r1 + 0), w3)
 ; CHECK-NEXT:    w0 = w2
 ; CHECK-NEXT:    w0 = atomic_fetch_add((u32 *)(r1 + 0), w0)
 ; CHECK-NEXT:    w0 += w3
@@ -385,7 +385,7 @@ define dso_local i64 @test_fetch_sub_64_ret(ptr nocapture noundef %i) local_unna
 ; CHECK-NEXT:    r2 = 10
 ; CHECK-NEXT:    r2 = -r2
 ; CHECK-NEXT:    r3 = r2
-; CHECK-NEXT:    lock *(u64 *)(r1 + 0) += r3
+; CHECK-NEXT:    r3 = atomic_fetch_add((u64 *)(r1 + 0), r3)
 ; CHECK-NEXT:    r0 = r2
 ; CHECK-NEXT:    r0 = atomic_fetch_add((u64 *)(r1 + 0), r0)
 ; CHECK-NEXT:    r0 += r3
@@ -445,7 +445,7 @@ define dso_local i32 @test_fetch_and_32_ret(ptr nocapture noundef %i) local_unna
 ; CHECK-NEXT:  # %bb.0: # %entry
 ; CHECK-NEXT:    w2 = 10
 ; CHECK-NEXT:    w3 = 10
-; CHECK-NEXT:    lock *(u32 *)(r1 + 0) &= w3
+; CHECK-NEXT:    w3 = atomic_fetch_and((u32 *)(r1 + 0), w3)
 ; CHECK-NEXT:    w0 = 10
 ; CHECK-NEXT:    w0 = atomic_fetch_and((u32 *)(r1 + 0), w0)
 ; CHECK-NEXT:    w0 += w3
@@ -565,7 +565,7 @@ define dso_local i32 @test_fetch_or_32_ret(ptr nocapture noundef %i) local_unnam
 ; CHECK-NEXT:  # %bb.0: # %entry
 ; CHECK-NEXT:    w2 = 10
 ; CHECK-NEXT:    w3 = 10
-; CHECK-NEXT:    lock *(u32 *)(r1 + 0) |= w3
+; CHECK-NEXT:    w3 = atomic_fetch_or((u32 *)(r1 + 0), w3)
 ; CHECK-NEXT:    w0 = 10
 ; CHECK-NEXT:    w0 = atomic_fetch_or((u32 *)(r1 + 0), w0)
 ; CHECK-NEXT:    w0 += w3
@@ -685,7 +685,7 @@ define dso_local i32 @test_fetch_xor_32_ret(ptr nocapture noundef %i) local_unna
 ; CHECK-NEXT:  # %bb.0: # %entry
 ; CHECK-NEXT:    w2 = 10
 ; CHECK-NEXT:    w3 = 10
-; CHECK-NEXT:    lock *(u32 *)(r1 + 0) ^= w3
+; CHECK-NEXT:    w3 = atomic_fetch_xor((u32 *)(r1 + 0), w3)
 ; CHECK-NEXT:    w0 = 10
 ; CHECK-NEXT:    w0 = atomic_fetch_xor((u32 *)(r1 + 0), w0)
 ; CHECK-NEXT:    w0 += w3

--- a/llvm/test/CodeGen/BPF/atomics_relaxed_ret_v3.ll
+++ b/llvm/test/CodeGen/BPF/atomics_relaxed_ret_v3.ll
@@ -1,0 +1,121 @@
+; RUN: llc -mtriple=bpfel -mcpu=v3 -verify-machineinstrs -show-mc-encoding < %s | FileCheck %s
+; RUN: llc -mtriple=bpfel -mcpu=v4 -verify-machineinstrs -show-mc-encoding < %s | FileCheck %s
+;
+; A relaxed (monotonic) atomicrmw whose result is used must select the
+; BPF_FETCH form, so the destination register receives the value that was in
+; memory before the operation. Selecting the no-fetch "lock" form here leaves
+; the operand in the register and silently returns the wrong value.
+;
+; The same operation with an unused result must keep selecting the compact
+; no-fetch form.
+
+; CHECK-LABEL: test_add_64_ret
+; CHECK: r0 = atomic_fetch_add((u64 *)(r1 + 0), r0)
+; CHECK: encoding: [0xdb,0x01,0x00,0x00,0x01,0x00,0x00,0x00]
+define dso_local i64 @test_add_64_ret(ptr %p, i64 %v) {
+entry:
+  %0 = atomicrmw add ptr %p, i64 %v monotonic
+  ret i64 %0
+}
+
+; CHECK-LABEL: test_add_64_noret
+; CHECK: lock *(u64 *)(r1 + 0) += r2
+; CHECK: encoding: [0xdb,0x21,0x00,0x00,0x00,0x00,0x00,0x00]
+define dso_local void @test_add_64_noret(ptr %p, i64 %v) {
+entry:
+  %0 = atomicrmw add ptr %p, i64 %v monotonic
+  ret void
+}
+
+; CHECK-LABEL: test_add_32_ret
+; CHECK: w0 = atomic_fetch_add((u32 *)(r1 + 0), w0)
+; CHECK: encoding: [0xc3,0x01,0x00,0x00,0x01,0x00,0x00,0x00]
+define dso_local i32 @test_add_32_ret(ptr %p, i32 %v) {
+entry:
+  %0 = atomicrmw add ptr %p, i32 %v monotonic
+  ret i32 %0
+}
+
+; CHECK-LABEL: test_add_32_noret
+; CHECK: lock *(u32 *)(r1 + 0) += w2
+; CHECK: encoding: [0xc3,0x21,0x00,0x00,0x00,0x00,0x00,0x00]
+define dso_local void @test_add_32_noret(ptr %p, i32 %v) {
+entry:
+  %0 = atomicrmw add ptr %p, i32 %v monotonic
+  ret void
+}
+
+; CHECK-LABEL: test_sub_64_ret
+; CHECK: r0 = -r0
+; CHECK: r0 = atomic_fetch_add((u64 *)(r1 + 0), r0)
+define dso_local i64 @test_sub_64_ret(ptr %p, i64 %v) {
+entry:
+  %0 = atomicrmw sub ptr %p, i64 %v monotonic
+  ret i64 %0
+}
+
+; CHECK-LABEL: test_sub_64_noret
+; CHECK: r2 = -r2
+; CHECK: lock *(u64 *)(r1 + 0) += r2
+define dso_local void @test_sub_64_noret(ptr %p, i64 %v) {
+entry:
+  %0 = atomicrmw sub ptr %p, i64 %v monotonic
+  ret void
+}
+
+; CHECK-LABEL: test_sub_32_ret
+; CHECK: w0 = -w0
+; CHECK: w0 = atomic_fetch_add((u32 *)(r1 + 0), w0)
+define dso_local i32 @test_sub_32_ret(ptr %p, i32 %v) {
+entry:
+  %0 = atomicrmw sub ptr %p, i32 %v monotonic
+  ret i32 %0
+}
+
+; CHECK-LABEL: test_and_32_ret
+; CHECK: w0 = atomic_fetch_and((u32 *)(r1 + 0), w0)
+define dso_local i32 @test_and_32_ret(ptr %p, i32 %v) {
+entry:
+  %0 = atomicrmw and ptr %p, i32 %v monotonic
+  ret i32 %0
+}
+
+; CHECK-LABEL: test_and_32_noret
+; CHECK: lock *(u32 *)(r1 + 0) &= w2
+define dso_local void @test_and_32_noret(ptr %p, i32 %v) {
+entry:
+  %0 = atomicrmw and ptr %p, i32 %v monotonic
+  ret void
+}
+
+; CHECK-LABEL: test_or_32_ret
+; CHECK: w0 = atomic_fetch_or((u32 *)(r1 + 0), w0)
+define dso_local i32 @test_or_32_ret(ptr %p, i32 %v) {
+entry:
+  %0 = atomicrmw or ptr %p, i32 %v monotonic
+  ret i32 %0
+}
+
+; CHECK-LABEL: test_xor_32_ret
+; CHECK: w0 = atomic_fetch_xor((u32 *)(r1 + 0), w0)
+define dso_local i32 @test_xor_32_ret(ptr %p, i32 %v) {
+entry:
+  %0 = atomicrmw xor ptr %p, i32 %v monotonic
+  ret i32 %0
+}
+
+; CHECK-LABEL: test_and_64_ret
+; CHECK: r0 = atomic_fetch_and((u64 *)(r1 + 0), r0)
+define dso_local i64 @test_and_64_ret(ptr %p, i64 %v) {
+entry:
+  %0 = atomicrmw and ptr %p, i64 %v monotonic
+  ret i64 %0
+}
+
+; CHECK-LABEL: test_and_64_noret
+; CHECK: lock *(u64 *)(r1 + 0) &= r2
+define dso_local void @test_and_64_noret(ptr %p, i64 %v) {
+entry:
+  %0 = atomicrmw and ptr %p, i64 %v monotonic
+  ret void
+}


### PR DESCRIPTION
At `-mcpu=v3` (and `v4`), a `monotonic` (relaxed) `atomicrmw` whose result is used is selected to the no-fetch "locked" instruction, e.g. `lock *(u64 *)(r1 + 0) += r0`. That instruction does not write the previous memory value back to the register, so the destination still holds the addend, not the old value. The generated code silently computes the wrong result, with no diagnostic.

Before / after (`llc -mcpu=v3 -show-mc-encoding`, i64 add, used result):
```
# before: lock *(u64 *)(r1 + 0) += r0   [0xdb,0x01,0x00,0x00,0x00,0x00,0x00,0x00]
# after:  r0 = atomic_fetch_add((u64 *)(r1 + 0), r0)  [0xdb,0x01,0x00,0x00,0x01,0x00,0x00,0x00]
```
Only the `imm` byte changes, `0x00` -> `0x01` (`BPF_FETCH`), which is what makes the instruction write the previous value back.

This behaviour was already specified, just not fully implemented. #107343
("[BPF] Do atomic_fetch_*() pattern matching with memory ordering") states:

> For monotonic ordering, locked insns are generated if return value is not
> used. Otherwise, atomic_fetch_*() insns are used.

and introduced `binop_no_use`/`binop_has_use` `PatFrag`s for exactly this, but wired them up for i64 `and`/`or`/`xor` only; every other monotonic RMW pattern still mapped unconditionally to the no-fetch instruction. This PR extends the same split to the remaining op/width combinations:

| width | ops                    | monotonic, before | monotonic, after |
|-------|------------------------|------------------|----------------|
| i32   | add, sub, and, or, xor | always no-fetch  | fetch iff result used |
| i64   | add, sub               | always no-fetch  | fetch iff result used |
| i64   | and, or, xor           | already correct  | unchanged |

`-mcpu=v1`/`v2` selection and diagnostics are unchanged: the fetch instruction does not exist before v3, so `BPFMIPreEmitChecking` still reports `Invalid usage of the XADD return value` for a live-result monotonic RMW there. `atomics_mem_order_v1.ll` and `atomics_sub64_relaxed_v1.ll` pass unmodified by this PR.

`atomics_mem_order_v3.ll`'s autogenerated CHECK lines were regenerated (via `update_llc_test_checks.py`) for the 7 cases that change form, and the old, checked-in expectations show the miscompile was already present, just unnoticed: in `test_fetch_add_32_ret` the old block reads
```
lock *(u32 *)(r1 + 0) += w3
...
w0 += w3
```
i.e. `w0 += w3` consumes the addend `w3` as if it were the value previously in memory; this PR changes that site to `w3 = atomic_fetch_add((u32 *)(r1 + 0), w3)`. The other 6 changed lines follow the same pattern (i32 sub/and/or/xor, i64 add/sub); no `_noret` case and no i64 and/or/xor case changed.

Found via the Rust eBPF toolchain (https://github.com/aya-rs/aya/issues/1268). Present since LLVM 20; reproduced with `llc`, `clang`, and `rustc` codegen on LLVM 22, 23, and `main`.

cc @yonghong-song @eddyz87 @peilin-ye
