### PR TITLE
[AMDGPU] Make LowerModuleLDS a noop on an already lowered module

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPULowerModuleLDSPass.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerModuleLDSPass.cpp
@@ -1078,11 +1078,9 @@ public:
   }
 
   bool runOnModuleNormal(Module &M) {
-    // Nothing left to lower on the codegen-partition rerun.
-    if (none_of(M.globals(), isNotYetLoweredLDSVariable))
-      return false;
+    bool Changed = superAlignLDSGlobals(M);
 
-    superAlignLDSGlobals(M);
+    Changed |= any_of(M.globals(), isNotYetLoweredLDSVariable);
 
     CallGraph CG(M);
 
@@ -1268,7 +1266,7 @@ public:
           GV.eraseFromParent();
       }
 
-    return true;
+    return Changed;
   }
 
 private:

--- a/llvm/lib/Target/AMDGPU/AMDGPULowerModuleLDSPass.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerModuleLDSPass.cpp
@@ -1078,11 +1078,16 @@ public:
   }
 
   bool runOnModuleNormal(Module &M) {
-    CallGraph CG = CallGraph(M);
     bool Changed = superAlignLDSGlobals(M);
 
-    Changed |=
-        eliminateGVConstantExprUsesFromAllInstructions(M, isLDSVariableToLower);
+    // Nothing left to lower on the codegen-partition rerun.
+    if (none_of(M.globals(), isNotYetLoweredLDSVariable))
+      return Changed;
+
+    CallGraph CG = CallGraph(M);
+
+    Changed |= eliminateGVConstantExprUsesFromAllInstructions(
+        M, isNotYetLoweredLDSVariable);
 
     Changed = true; // todo: narrow this down
 
@@ -1258,7 +1263,7 @@ public:
     }
 
     for (auto &GV : make_early_inc_range(M.globals()))
-      if (AMDGPU::isLDSVariableToLower(GV)) {
+      if (isNotYetLoweredLDSVariable(GV)) {
         // probably want to remove from used lists
         GV.removeDeadConstantUsers();
         if (GV.use_empty())
@@ -1269,6 +1274,11 @@ public:
   }
 
 private:
+  // An absolute address means a previous run already placed the variable.
+  static bool isNotYetLoweredLDSVariable(const GlobalVariable &GV) {
+    return isLDSVariableToLower(GV) && !GV.isAbsoluteSymbolRef();
+  }
+
   // Increase the alignment of LDS globals if necessary to maximise the chance
   // that we can use aligned LDS instructions to access them.
   static bool superAlignLDSGlobals(Module &M) {

--- a/llvm/lib/Target/AMDGPU/AMDGPULowerModuleLDSPass.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerModuleLDSPass.cpp
@@ -1093,7 +1093,8 @@ public:
 
     // For each kernel, what variables does it access directly or through
     // callees
-    GVUsesInfoTy LDSUsesInfo = getTransitiveUsesOfLDSForLowering(CG, M);
+    GVUsesInfoTy LDSUsesInfo =
+        getTransitiveUsesOfGV(CG, M, isNotYetLoweredLDSVariable);
 
     // For each variable accessed through callees, which kernels access it
     VariableFunctionMap LDSToKernelsThatNeedToAccessItIndirectly;

--- a/llvm/lib/Target/AMDGPU/AMDGPULowerModuleLDSPass.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerModuleLDSPass.cpp
@@ -1078,13 +1078,13 @@ public:
   }
 
   bool runOnModuleNormal(Module &M) {
-    bool Changed = superAlignLDSGlobals(M);
-
     // Nothing left to lower on the codegen-partition rerun.
     if (none_of(M.globals(), isNotYetLoweredLDSVariable))
-      return Changed;
+      return false;
 
-    CallGraph CG = CallGraph(M);
+    bool Changed = superAlignLDSGlobals(M);
+
+    CallGraph CG(M);
 
     Changed |= eliminateGVConstantExprUsesFromAllInstructions(
         M, isNotYetLoweredLDSVariable);
@@ -1093,8 +1093,7 @@ public:
 
     // For each kernel, what variables does it access directly or through
     // callees
-    GVUsesInfoTy LDSUsesInfo =
-        getTransitiveUsesOfGV(CG, M, isNotYetLoweredLDSVariable);
+    GVUsesInfoTy LDSUsesInfo = getTransitiveUsesOfLDSForLowering(CG, M);
 
     // For each variable accessed through callees, which kernels access it
     VariableFunctionMap LDSToKernelsThatNeedToAccessItIndirectly;

--- a/llvm/lib/Target/AMDGPU/AMDGPULowerModuleLDSPass.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerModuleLDSPass.cpp
@@ -1082,14 +1082,12 @@ public:
     if (none_of(M.globals(), isNotYetLoweredLDSVariable))
       return false;
 
-    bool Changed = superAlignLDSGlobals(M);
+    superAlignLDSGlobals(M);
 
     CallGraph CG(M);
 
-    Changed |= eliminateGVConstantExprUsesFromAllInstructions(
-        M, isNotYetLoweredLDSVariable);
-
-    Changed = true; // todo: narrow this down
+    eliminateGVConstantExprUsesFromAllInstructions(M,
+                                                   isNotYetLoweredLDSVariable);
 
     // For each kernel, what variables does it access directly or through
     // callees
@@ -1270,7 +1268,7 @@ public:
           GV.eraseFromParent();
       }
 
-    return Changed;
+    return true;
   }
 
 private:

--- a/llvm/test/CodeGen/AMDGPU/lds-run-twice.ll
+++ b/llvm/test/CodeGen/AMDGPU/lds-run-twice.ll
@@ -20,7 +20,7 @@
 @dynlds = external addrspace(3) global [0 x i32], align 4
 
 ; Never lowered, so these survive the first run without an absolute address.
-@const.lds = internal addrspace(3) constant [4 x i32] undef, align 4
+@const.lds = internal addrspace(3) constant [4 x i32] poison, align 4
 @initialized.lds = internal addrspace(3) global i16 0, align 2
 
 ; Escapes into a global initializer, so lowering cannot place it either.

--- a/llvm/test/CodeGen/AMDGPU/lds-run-twice.ll
+++ b/llvm/test/CodeGen/AMDGPU/lds-run-twice.ll
@@ -3,14 +3,50 @@
 ; RUN: diff -ub %t.ll %t.second.ll -I ".*ModuleID.*"
 
 ; Check AMDGPULowerModuleLDS can run more than once on the same module, and that
-; the second run is a no-op.
+; the second run is a no-op, as full LTO reruns it on each codegen partition.
 
-@dynlds = external addrspace(3) global [0 x i32], align 4
+; Kernel-only static LDS. @lds2 pushes @lds to a non-zero offset, so the first
+; run leaves a constexpr GEP, which the second run used to re-expand.
 @lds = internal unnamed_addr addrspace(3) global i32 poison, align 4
+@lds2 = internal unnamed_addr addrspace(3) global i64 poison, align 8
+
+; Called from a function shared by two kernels: module struct plus lookup table.
+@lds.function = internal addrspace(3) global [8 x i16] poison, align 2
+
+; Dynamic LDS from a function lowers to per-kernel shadows plus an offset table.
+@dynlds.function = external hidden addrspace(3) global [0 x float], align 8
+
+; Dynamic LDS used only from a kernel is left in place.
+@dynlds = external addrspace(3) global [0 x i32], align 4
+
+; Never lowered, so these survive the first run without an absolute address.
+@const.lds = internal addrspace(3) constant [4 x i32] undef, align 4
+@initialized.lds = internal addrspace(3) global i16 0, align 2
+
+; Escapes into a global initializer, so lowering cannot place it either.
+@escaped = internal addrspace(3) global i32 poison, align 4
+@escape.ptr = addrspace(1) global ptr addrspace(3) @escaped, align 4
+
+define void @helper() {
+  store i16 1, ptr addrspace(3) getelementptr inbounds ([8 x i16], ptr addrspace(3) @lds.function, i32 0, i32 3), align 2
+  store float 2.0, ptr addrspace(3) @dynlds.function, align 8
+  ret void
+}
 
 define amdgpu_kernel void @test() {
 entry:
+  call void @helper()
   store i32 0, ptr addrspace(3) @dynlds
   store i32 1, ptr addrspace(3) @lds
+  store i64 2, ptr addrspace(3) @lds2
+  store i32 3, ptr addrspace(3) @escaped
+  %c = load i32, ptr addrspace(3) getelementptr inbounds ([4 x i32], ptr addrspace(3) @const.lds, i32 0, i32 2), align 4
+  store i16 9, ptr addrspace(3) @initialized.lds, align 2
+  ret void
+}
+
+define amdgpu_kernel void @test2() {
+entry:
+  call void @helper()
   ret void
 }


### PR DESCRIPTION
Full LTO reruns the pass on each codegen partition, where it matched its own lowered structs and re-expanded their constexpr uses