### PR TITLE
[libc++] disable hwasan for the 'set_new_handler' test 

### DIFF
--- a/libcxx/test/std/language.support/support.dynamic/alloc.errors/set.new.handler/set_new_handler.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/alloc.errors/set.new.handler/set_new_handler.pass.cpp
@@ -8,7 +8,7 @@
 
 // a test will allocate an impossible amount of memory on purpose
 // and it will trigger an expected failure
-// UNSUPPORTED: asan, msan, tsan
+// UNSUPPORTED: asan, msan, tsan, hwasan
 
 // test set_new_handler
 


### PR DESCRIPTION
Disable Hardware-assisted AddressSanitizer for the `set_new_handler` test to prevent test failure when it is enabled.