### PR TITLE
[mlir][arith] Clarify the meaning of fastmath flags

### DIFF
--- a/mlir/include/mlir/Dialect/Arith/IR/ArithBase.td
+++ b/mlir/include/mlir/Dialect/Arith/IR/ArithBase.td
@@ -139,6 +139,12 @@ def FastMathFlags : I32BitEnumAttr<
   let cppNamespace = "::mlir::arith";
   let genSpecializedAttr = 0;
   let printBitEnumPrimaryGroups = 1;
+  let description = [{
+    For the `reassoc`, `nnan`, `ninf`, `nsz`, `arcp`, `contract`, `afn`, `fast`
+    flags, the arith dialect follows the same semantics as LLVM IR. Refer to the
+    [LLVM Language Reference](https://llvm.org/docs/LangRef.html#fast-math-flags)
+    for their meaning.
+  }];
 }
 
 def Arith_FastMathAttr :


### PR DESCRIPTION
The arith dialect did not specify the meaning of its fastmath flags.

Provide a description that points to the LLVM Language Reference. I opted to list out the currently available ones explicitly so that if we add a new arith-specific fastmath flag, the description will not point to the lang ref for it.