### PR TITLE
[asan][test] Disable invalid-pointer-pairs-vector-extract.cpp

### DIFF
--- a/compiler-rt/test/asan/TestCases/invalid-pointer-pairs-vector-extract.cpp
+++ b/compiler-rt/test/asan/TestCases/invalid-pointer-pairs-vector-extract.cpp
@@ -3,6 +3,7 @@
 // RUN: %env_asan_opts=detect_invalid_pointer_pairs=1:halt_on_error=0 %run %t 2>&1 | FileCheck %s
 // RUN: %env_asan_opts=detect_invalid_pointer_pairs=2:halt_on_error=0 %run %t 2>&1 | FileCheck %s
 
+// UNSUPPORTED: target={{.*}}
 // UNSUPPORTED: windows
 // UNSUPPORTED: target={{.*solaris.*}}
 


### PR DESCRIPTION
This test (introduced in https://github.com/llvm/llvm-project/pull/216532) has been XPASS'ing on S390X (reported in https://github.com/llvm/llvm-project/pull/216532#issuecomment-5327707172).

There has already been a prior fix-forward (marking Solaris as unsupported: https://github.com/llvm/llvm-project/pull/216606). Since https://github.com/llvm/llvm-project/pull/213546 is expected to make the test pass on all platforms anyway, rather than playing whack-a-mole with marking targets unsupported, this patch disables the test.