### PR TITLE
[lldb] End to end test for address spaces using lldb-server mock accelerator  plugin

### DIFF
--- a/lldb/test/API/accelerator/mock/TestMockAcceleratorAddressSpaces.py
+++ b/lldb/test/API/accelerator/mock/TestMockAcceleratorAddressSpaces.py
@@ -1,0 +1,85 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import configuration
+
+
+class MockAcceleratorAddressSpacesTestCase(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def setUp(self):
+        super().setUp()
+        if "mock-accelerator" not in configuration.enabled_plugins:
+            self.skipTest("mock-accelerator plugin is not enabled")
+
+    def accelerator_target(self, native_target):
+        for i in range(self.dbg.GetNumTargets()):
+            candidate = self.dbg.GetTargetAtIndex(i)
+            if candidate != native_target:
+                return candidate
+        return None
+
+    @skipIfRemote
+    @add_test_categories(["llgs"])
+    def test_address_spaces_from_process_plugin(self):
+        """The accelerator process reports its address spaces to the client."""
+        self.build()
+        target = self.dbg.CreateTarget(self.getBuildArtifact("a.out"))
+        self.assertTrue(target, VALID_TARGET)
+
+        # Launch stops at the plugin's initialize breakpoint; continuing reaches
+        # the connection hook that creates the accelerator target.
+        process = target.LaunchSimple(None, None, self.get_process_working_directory())
+        self.assertTrue(process, PROCESS_IS_VALID)
+        self.assertState(process.GetState(), lldb.eStateStopped)
+        process.Continue()
+        self.assertState(process.GetState(), lldb.eStateStopped)
+
+        self.assertEqual(self.dbg.GetNumTargets(), 2)
+        accelerator_process = self.accelerator_target(target).GetProcess()
+        self.assertTrue(accelerator_process.IsValid())
+
+        # ProcessMockAccelerator reports "global" (id 1) and "local" (id 2).
+        error = lldb.SBError()
+        self.assertEqual(accelerator_process.GetAddressSpaceID("global", error), 1)
+        self.assertSuccess(error)
+        self.assertEqual(accelerator_process.GetAddressSpaceID("local", error), 2)
+        self.assertSuccess(error)
+
+        # An unknown name is an error rather than a silent default.
+        accelerator_process.GetAddressSpaceID("nonexistent", error)
+        self.assertTrue(error.Fail())
+
+        # The native process has no address spaces, so the same lookup fails
+        # there even though both targets talk to an lldb-server.
+        process.GetAddressSpaceID("global", error)
+        self.assertTrue(error.Fail())
+
+        # Read the same numeric address from both spaces. The mock process
+        # answers with the address space in byte 0 and the thread in byte 1, so
+        # these show what actually reached the far side of the connection.
+        thread = accelerator_process.GetThreadAtIndex(0)
+        self.assertTrue(thread.IsValid())
+        tid = thread.GetThreadID()
+
+        # "global" is not thread specific, so no thread is sent.
+        global_bytes = accelerator_process.ReadMemory(
+            lldb.SBProcessAddress(0x1000, 1), 4, error
+        )
+        self.assertSuccess(error)
+        self.assertEqual(global_bytes, bytes([1, 0, 0, 0]))
+
+        # "local" is thread specific, so the thread rides along with the read.
+        local_bytes = accelerator_process.ReadMemory(
+            lldb.SBProcessAddress(0x1000, 2, thread), 4, error
+        )
+        self.assertSuccess(error)
+        self.assertEqual(local_bytes, bytes([2, tid & 0xFF, 0, 0]))
+
+        self.assertNotEqual(global_bytes, local_bytes)
+
+        # Reading a thread specific space without a thread never reaches the
+        # server.
+        accelerator_process.ReadMemory(lldb.SBProcessAddress(0x1000, 2), 4, error)
+        self.assertTrue(error.Fail())
+        self.assertIn("thread specific", error.GetCString())

--- a/lldb/test/API/accelerator/mock/TestMockAcceleratorAddressSpaces.py
+++ b/lldb/test/API/accelerator/mock/TestMockAcceleratorAddressSpaces.py
@@ -13,8 +13,7 @@ class MockAcceleratorAddressSpacesTestCase(TestBase):
             self.skipTest("mock-accelerator plugin is not enabled")
 
     def accelerator_target(self, native_target):
-        for i in range(self.dbg.GetNumTargets()):
-            candidate = self.dbg.GetTargetAtIndex(i)
+        for candidate in self.dbg:
             if candidate != native_target:
                 return candidate
         return None

--- a/lldb/tools/lldb-server/Plugins/Accelerator/Mock/ProcessMockAccelerator.cpp
+++ b/lldb/tools/lldb-server/Plugins/Accelerator/Mock/ProcessMockAccelerator.cpp
@@ -13,6 +13,8 @@
 #include "lldb/Host/ProcessLaunchInfo.h"
 #include "llvm/Support/Error.h"
 
+#include <cstring>
+
 using namespace lldb;
 using namespace lldb_private;
 using namespace lldb_private::lldb_server;
@@ -62,8 +64,18 @@ Status ProcessMockAccelerator::Kill() { return Status(); }
 Status ProcessMockAccelerator::ReadMemory(const ProcessAddress &process_addr,
                                           void *buf, size_t size,
                                           size_t &bytes_read) {
-  bytes_read = 0;
-  return Status::FromErrorString("unimplemented");
+  // No real memory to read, so synthesize bytes that identify the address the
+  // request arrived with: byte 0 is the address space and byte 1 is the thread
+  // (zero when the read was not thread specific). That lets a test tell reads
+  // of the same numeric address apart.
+  uint8_t *bytes = static_cast<uint8_t *>(buf);
+  std::memset(bytes, 0, size);
+  if (size > 0)
+    bytes[0] = static_cast<uint8_t>(process_addr.GetAddressSpace());
+  if (size > 1)
+    bytes[1] = static_cast<uint8_t>(process_addr.GetThreadID().value_or(0));
+  bytes_read = size;
+  return Status();
 }
 
 Status ProcessMockAccelerator::DoWriteMemory(lldb::addr_t addr, const void *buf,
@@ -111,4 +123,9 @@ Status
 ProcessMockAccelerator::GetFileLoadAddress(const llvm::StringRef &file_name,
                                            lldb::addr_t &load_addr) {
   return Status::FromErrorString("unimplemented");
+}
+
+std::vector<AddressSpaceInfo> ProcessMockAccelerator::GetAddressSpaces() {
+  return {{"global", 1, /*is_thread_specific=*/false},
+          {"local", 2, /*is_thread_specific=*/true}};
 }

--- a/lldb/tools/lldb-server/Plugins/Accelerator/Mock/ProcessMockAccelerator.h
+++ b/lldb/tools/lldb-server/Plugins/Accelerator/Mock/ProcessMockAccelerator.h
@@ -30,6 +30,10 @@ public:
 
     llvm::Expected<std::unique_ptr<NativeProcessProtocol>>
     Attach(lldb::pid_t pid, NativeDelegate &native_delegate) override;
+
+    Extension GetSupportedExtensions() const override {
+      return Extension::address_spaces;
+    }
   };
 
   ProcessMockAccelerator(lldb::pid_t pid, NativeDelegate &delegate);
@@ -59,6 +63,8 @@ public:
                                  FileSpec &file_spec) override;
   Status GetFileLoadAddress(const llvm::StringRef &file_name,
                             lldb::addr_t &load_addr) override;
+
+  std::vector<AddressSpaceInfo> GetAddressSpaces() override;
 
 private:
   mutable ArchSpec m_arch;


### PR DESCRIPTION
Relevant RFC: https://discourse.llvm.org/t/rfc-address-spaces-support-in-lldb/91222/

Add an end to end test using a mock accelerator that advertises multiple address spaces. 



