### PR TITLE
[sanitizer-common][rtsan] Add rtsan to sanitizer-common suites

### DIFF
--- a/compiler-rt/test/sanitizer_common/CMakeLists.txt
+++ b/compiler-rt/test/sanitizer_common/CMakeLists.txt
@@ -7,7 +7,7 @@ set(SANITIZER_COMMON_TESTSUITES)
 # FIXME(dliew): We should switch to COMPILER_RT_SANITIZERS_TO_BUILD instead of
 # the hard coded `SUPPORTED_TOOLS_INIT` list once we know that the other
 # sanitizers work.
-set(SUPPORTED_TOOLS_INIT asan lsan hwasan msan tsan ubsan)
+set(SUPPORTED_TOOLS_INIT asan lsan hwasan msan tsan ubsan rtsan)
 set(SUPPORTED_TOOLS)
   foreach(SANITIZER_TOOL ${SUPPORTED_TOOLS_INIT})
     string(TOUPPER ${SANITIZER_TOOL} SANITIZER_TOOL_UPPER)

--- a/compiler-rt/test/sanitizer_common/TestCases/Darwin/abort_on_error.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Darwin/abort_on_error.cpp
@@ -14,12 +14,12 @@
 
 int global;
 
-int main() {
+int main() [[clang::nonblocking]] {
 #if defined(USING_ubsan)
   volatile int *null = 0;
   *null = 0;
 #else
-  volatile int *a = new int[100];
+  volatile int *a = new int[100]; // allocation triggers RTSan report
   delete[] a;
   global = a[0]; // use-after-free: triggers ASan/TSan report.
 #endif

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/aligned_alloc-alignment.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/aligned_alloc-alignment.cpp
@@ -14,7 +14,7 @@
 
 // REQUIRES: stable-runtime
 
-// UNSUPPORTED: android, ubsan
+// UNSUPPORTED: android, rtsan, ubsan
 
 #include <assert.h>
 #include <errno.h>

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/decorate_proc_maps.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/decorate_proc_maps.cpp
@@ -3,6 +3,7 @@
 
 // REQUIRES: stable-runtime
 // XFAIL: android && asan
+// UNSUPPORTED: rtsan
 
 #include <errno.h>
 #include <fcntl.h>

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/dump_registers_x86_64.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/dump_registers_x86_64.cpp
@@ -4,6 +4,7 @@
 // RUN: not %run %t 2>&1 | FileCheck %s --check-prefixes=CHECK-DUMP --strict-whitespace
 //
 // REQUIRES: x86_64-target-arch && glibc
+// UNSUPPORTED: rtsan
 
 #include <signal.h>
 

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/ill.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/ill.cpp
@@ -7,6 +7,7 @@
 
 // FIXME: seems to fail on ARM
 // REQUIRES: x86_64-target-arch
+// UNSUPPORTED: rtsan
 #include <assert.h>
 #include <stdio.h>
 #include <sanitizer/asan_interface.h>

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/pvalloc-overflow.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/pvalloc-overflow.cpp
@@ -6,7 +6,7 @@
 
 // REQUIRES: stable-runtime
 
-// UNSUPPORTED: android, target={{.*(freebsd|netbsd).*}}, ubsan
+// UNSUPPORTED: android, rtsan, target={{.*(freebsd|netbsd).*}}, ubsan
 
 // Checks that pvalloc overflows are caught. If the allocator is allowed to
 // return null, the errno should be set to ENOMEM.

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/resize_tls_dynamic.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/resize_tls_dynamic.cpp
@@ -6,7 +6,7 @@
 // UNSUPPORTED: i386-linux
 
 // Do not intercept __tls_get_addr
-// UNSUPPORTED: hwasan, lsan, ubsan, android
+// UNSUPPORTED: hwasan, lsan, ubsan, android, rtsan
 
 // FIXME: Investigate
 // UNSUPPORTED: target=powerpc64{{.*}}

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/tls_get_addr.c
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/tls_get_addr.c
@@ -8,7 +8,7 @@
 // XFAIL: i386-linux
 
 // These don't intercept __tls_get_addr.
-// XFAIL: lsan,hwasan,ubsan
+// XFAIL: lsan,hwasan,ubsan,rtsan
 
 // FIXME: Fails for unknown reasons.
 // UNSUPPORTED: powerpc64le-target-arch

--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/dump_instruction_bytes.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/dump_instruction_bytes.cpp
@@ -6,6 +6,7 @@
 // RUN: not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK-NODUMP
 
 // REQUIRES: x86-target-arch
+// UNSUPPORTED: rtsan
 
 int main() {
 #if defined(__x86_64__)

--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/fpe.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/fpe.cpp
@@ -6,6 +6,7 @@
 
 // FIXME: seems to fail on ARM
 // REQUIRES: x86_64-target-arch
+// UNSUPPORTED: rtsan
 #include <assert.h>
 #include <stdio.h>
 #include <sanitizer/asan_interface.h>

--- a/compiler-rt/test/sanitizer_common/TestCases/reallocarray-overflow.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/reallocarray-overflow.cpp
@@ -2,7 +2,7 @@
 // RUN: %env_tool_opts=allocator_may_return_null=0 not %run %t 2>&1 | FileCheck %s
 // RUN: %env_tool_opts=allocator_may_return_null=1 %run %t 2>&1 | FileCheck %s --check-prefix=CHECK-NULL
 
-// REQUIRES: stable-runtime && !ubsan && !darwin
+// REQUIRES: stable-runtime && !ubsan && !darwin && !rtsan
 
 #include <stdio.h>
 

--- a/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_allowlist_ignorelist.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_allowlist_ignorelist.cpp
@@ -3,7 +3,7 @@
 // options
 
 // REQUIRES: has_sancovcc,stable-runtime
-// UNSUPPORTED: darwin
+// UNSUPPORTED: darwin, rtsan
 // XFAIL: ubsan,tsan
 // XFAIL: android && asan
 

--- a/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_inline8bit_counter_default_impl.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_inline8bit_counter_default_impl.cpp
@@ -2,6 +2,7 @@
 // -fsanitize-coverage=inline-8bit-counters,pc-table
 
 // REQUIRES: has_sancovcc,stable-runtime,linux,x86_64-target-arch
+// UNSUPPORTED: rtsan
 
 /// In glibc 2.39+, fprintf has a nonnull attribute. Disable nonnull-attribute,
 /// which would increase counters for ubsan.

--- a/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_symbolize.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_symbolize.cpp
@@ -2,6 +2,7 @@
 //
 // REQUIRES: x86_64-linux
 // XFAIL: tsan
+// UNSUPPORTED: rtsan
 //
 // RUN: rm -rf %t_workdir
 // RUN: mkdir -p %t_workdir

--- a/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_trace_pc_guard-init.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_trace_pc_guard-init.cpp
@@ -2,6 +2,10 @@
 //
 // REQUIRES: has_sancovcc,stable-runtime,x86_64-linux
 //
+
+// rtsan doesn't currently support coverage
+// UNSUPPORTED: rtsan
+
 // RUN: rm -rf %t_workdir
 // RUN: mkdir -p %t_workdir
 // RUN: cd %t_workdir


### PR DESCRIPTION
Final change in a set of changes cleaning up `rtsan` for inclusion into the sanitizer-common test suites.

Fixes one final test and enables the option.