### PR TITLE
[compiler-rt] Guard sanitizer DlsymAlloc::Free from nullptr

### DIFF
--- a/compiler-rt/lib/asan/asan_malloc_linux.cpp
+++ b/compiler-rt/lib/asan/asan_malloc_linux.cpp
@@ -46,6 +46,8 @@ struct DlsymAlloc : public DlSymAllocator<DlsymAlloc> {
 };
 
 INTERCEPTOR(void, free, void* ptr) {
+  if (UNLIKELY(!ptr))
+    return;
   if (DlsymAlloc::PointerIsMine(ptr))
     return DlsymAlloc::Free(ptr);
   GET_STACK_TRACE_FREE;
@@ -54,6 +56,8 @@ INTERCEPTOR(void, free, void* ptr) {
 
 #  if SANITIZER_INTERCEPT_CFREE
 INTERCEPTOR(void, cfree, void* ptr) {
+  if (UNLIKELY(!ptr))
+    return;
   if (DlsymAlloc::PointerIsMine(ptr))
     return DlsymAlloc::Free(ptr);
   GET_STACK_TRACE_FREE;

--- a/compiler-rt/lib/memprof/memprof_malloc_linux.cpp
+++ b/compiler-rt/lib/memprof/memprof_malloc_linux.cpp
@@ -35,6 +35,8 @@ struct DlsymAlloc : public DlSymAllocator<DlsymAlloc> {
 };
 
 INTERCEPTOR(void, free, void *ptr) {
+  if (UNLIKELY(!ptr))
+    return;
   if (DlsymAlloc::PointerIsMine(ptr))
     return DlsymAlloc::Free(ptr);
   GET_STACK_TRACE_FREE;
@@ -43,6 +45,8 @@ INTERCEPTOR(void, free, void *ptr) {
 
 #if SANITIZER_INTERCEPT_CFREE
 INTERCEPTOR(void, cfree, void *ptr) {
+  if (UNLIKELY(!ptr))
+    return;
   if (DlsymAlloc::PointerIsMine(ptr))
     return DlsymAlloc::Free(ptr);
   GET_STACK_TRACE_FREE;
@@ -52,6 +56,8 @@ INTERCEPTOR(void, cfree, void *ptr) {
 
 #if SANITIZER_INTERCEPT_FREE_SIZED
 INTERCEPTOR(void, free_sized, void *ptr, uptr size) {
+  if (UNLIKELY(!ptr))
+    return;
   if (DlsymAlloc::PointerIsMine(ptr))
     return DlsymAlloc::Free(ptr);
   GET_STACK_TRACE_FREE;
@@ -61,6 +67,8 @@ INTERCEPTOR(void, free_sized, void *ptr, uptr size) {
 
 #if SANITIZER_INTERCEPT_FREE_ALIGNED_SIZED
 INTERCEPTOR(void, free_aligned_sized, void *ptr, uptr alignment, uptr size) {
+  if (UNLIKELY(!ptr))
+    return;
   if (DlsymAlloc::PointerIsMine(ptr))
     return DlsymAlloc::Free(ptr);
   GET_STACK_TRACE_FREE;

--- a/compiler-rt/lib/tysan/tysan_interceptors.cpp
+++ b/compiler-rt/lib/tysan/tysan_interceptors.cpp
@@ -125,6 +125,8 @@ INTERCEPTOR(void *, calloc, uptr nmemb, uptr size) {
 }
 
 INTERCEPTOR(void, free, void *ptr) {
+  if (UNLIKELY(!ptr))
+    return;
   if (DlsymAlloc::PointerIsMine(ptr))
     return DlsymAlloc::Free(ptr);
   REAL(free)(ptr);


### PR DESCRIPTION
Passing `nullptr` to `DlsmAlloc::Free` crashes on some systems. Guard against this by checking for `nullptr` first in any `free` interceptors.

This was discovered for rtsan when enabling `sanitizer_common/TestCases/dlsym_alloc.c`, circling back to fix the others to match the standard established in the other interceptors. 


I considered fixing this in `DlsmAlloc::Free` directly, but I think this pattern is preferable. I think in most (all?) cases, standardizing on `free`-ing a nullptr under all sanitizers and before/during/after dlsym would be good. I'm completely open to the other approach though.



Existing examples of this check that exist on main: (generated with copilot)

| Sanitizer | Interceptor | Source |
| --- | --- | --- |
| DFSan | free | [link](https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/dfsan/dfsan_interceptors.cpp#L67) | 
| DFSan | cfree | [link](https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/dfsan/dfsan_interceptors.cpp#L75) |
 | HWASan | free | [link](https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/hwasan/hwasan_allocation_functions.cpp#L80) | | HWASan | cfree | [link](https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/hwasan/hwasan_allocation_functions.cpp#L90) | 
| HWASan | free_sized | [link](https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/hwasan/hwasan_allocation_functions.cpp#L102) | 
| HWASan | free_aligned_sized | [link](https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/hwasan/hwasan_allocation_functions.cpp#L114) |
 | LSan | free | [link](https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/lsan/lsan_interceptors.cpp#L78) | 
| LSan | free_sized | [link](https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/lsan/lsan_interceptors.cpp#L88) |
 | LSan | free_aligned_sized | [link](https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/lsan/lsan_interceptors.cpp#L102) | 
| MSan | free | [link](https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/msan/msan_interceptors.cpp#L210) |
 | MSan | free_sized | [link](https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/msan/msan_interceptors.cpp#L220) | 
| MSan | free_aligned_sized | [link](https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/msan/msan_interceptors.cpp#L234) |
 | MSan | cfree | [link](https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/msan/msan_interceptors.cpp#L249) | 
| NSan | free | [link](https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/nsan/nsan_malloc_linux.cpp#L42) |
 | RTSan | free | [link](https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/rtsan/rtsan_interceptors_posix.cpp#L871) | 
| RTSan | free_sized | [link](https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/rtsan/rtsan_interceptors_posix.cpp#L889) |
 | RTSan | free_aligned_sized | [link](https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/rtsan/rtsan_interceptors_posix.cpp#L911) | 
| TSan | free | [link](https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp#L728) | 
| TSan | free_sized | [link](https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp#L741) |
 | TSan | free_aligned_sized | [link](https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp#L758) |
 | TSan | cfree | [link](https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp#L775) |