### PR TITLE
[llvm] Propagate dso_local for jump table aliases

### DIFF
--- a/llvm/lib/Transforms/IPO/LowerTypeTests.cpp
+++ b/llvm/lib/Transforms/IPO/LowerTypeTests.cpp
@@ -1115,6 +1115,7 @@ void LowerTypeTestsModule::importFunction(Function *F,
     FDecl = Function::Create(F->getFunctionType(), GlobalValue::ExternalLinkage,
                              F->getAddressSpace(), Name, &M);
     FDecl->setVisibility(Visibility);
+    FDecl->setDSOLocal(F->isDSOLocal());
     Visibility = GlobalValue::HiddenVisibility;
 
     // Update aliases pointing to this function to also include the ".cfi" suffix,
@@ -1129,6 +1130,7 @@ void LowerTypeTestsModule::importFunction(Function *F,
         AliasDecl->takeName(A);
         A->replaceAllUsesWith(AliasDecl);
         A->setName(AliasName);
+        AliasDecl->setDSOLocal(A->isDSOLocal());
       }
     }
   }
@@ -1829,6 +1831,7 @@ void LowerTypeTestsModule::buildBitSetsFromFunctionsNative(
           GlobalAlias::create(JumpTableEntryType, 0, F->getLinkage(), "",
                               CombinedGlobalElemPtr, &M);
       FAlias->setVisibility(F->getVisibility());
+      FAlias->setDSOLocal(F->isDSOLocal());
       FAlias->takeName(F);
       if (FAlias->hasName()) {
         F->setName(FAlias->getName() + ".cfi");
@@ -2276,6 +2279,16 @@ bool LowerTypeTestsModule::lower() {
           F->setMetadata(
               LLVMContext::MD_guid,
               MDTuple::get(M.getContext(), {FuncMD->getOperand(2).get()}));
+          if (ExportSummary) {
+            GlobalValue::GUID GUID =
+                cast<ConstantAsMetadata>(FuncMD->getOperand(2))
+                    ->getValue()
+                    ->getUniqueInteger()
+                    .getZExtValue();
+            if (auto VI = ExportSummary->getValueInfo(GUID))
+              F->setDSOLocal(
+                  VI.isDSOLocal(ExportSummary->withDSOLocalPropagation()));
+          }
         }
         // If the function is available_externally, remove its definition so
         // that it is handled the same way as a declaration. Later we will try
@@ -2549,6 +2562,7 @@ bool LowerTypeTestsModule::lower() {
     auto *AliasGA = GlobalAlias::create("", Target);
     AliasGA->setVisibility(A.Alias->getVisibility());
     AliasGA->setLinkage(A.Alias->getLinkage());
+    AliasGA->setDSOLocal(A.Alias->isDSOLocal());
     AliasGA->takeName(A.Alias);
     A.Alias->replaceAllUsesWith(AliasGA);
     A.Alias->eraseFromParent();

--- a/llvm/test/Transforms/LowerTypeTests/Inputs/exported-funcs.yaml
+++ b/llvm/test/Transforms/LowerTypeTests/Inputs/exported-funcs.yaml
@@ -2,7 +2,7 @@
 GlobalValueMap:
   42:
     - Live: true
-      Refs: [16594175687743574550, 2415377257478301385] # guid("external_addrtaken"), guid("external_addrtaken2")
+      Refs: [16594175687743574550, 2415377257478301385, 4497425064003378793] # guid("external_addrtaken"), guid("external_addrtaken2"), guid("external_addrtaken_dso_local")
       TypeTests: [14276520915468743435, 15427464259790519041] # guid("typeid1"), guid("typeid2")
   5224464028922159466: # guid("external")
     - Linkage: 0 # external
@@ -27,4 +27,13 @@ GlobalValueMap:
     - Linkage: 0 # weak
       Live: true
       Aliasee: 16594175687743574550 # guid("external_addrtaken")
+  4497425064003378793: # guid("external_addrtaken_dso_local")
+    - Linkage: 0 # external
+      Live: true
+      Local: true
+  15765058181946593837: # guid("alias_dso_local")
+    - Linkage: 4 # weak
+      Live: true
+      Local: true
+      Aliasee: 4497425064003378793 # guid("external_addrtaken_dso_local")
 ...

--- a/llvm/test/Transforms/LowerTypeTests/Inputs/import-alias.yaml
+++ b/llvm/test/Transforms/LowerTypeTests/Inputs/import-alias.yaml
@@ -8,4 +8,6 @@ WithGlobalValueDeadStripping: false
 CfiFunctionDefs:
 - Name: f
   GUID: 14740650423002898831
+- Name: f_dso_local
+  GUID: 16617365750458309383
 CfiFunctionDecls: null

--- a/llvm/test/Transforms/LowerTypeTests/export-alias.ll
+++ b/llvm/test/Transforms/LowerTypeTests/export-alias.ll
@@ -1,14 +1,17 @@
 ; RUN: opt -S %s -passes=lowertypetests -lowertypetests-summary-action=export -lowertypetests-read-summary=%S/Inputs/exported-funcs.yaml | FileCheck %s
 ;
+; CHECK: @external_addrtaken = alias [8 x i8], ptr @[[JT:.*]]
+; CHECK: @external_addrtaken_dso_local = dso_local alias [8 x i8], {{.*}}ptr @[[JT]]
 ; CHECK: @alias1 = alias [8 x i8], ptr @external_addrtaken
 ; CHECK: @alias2 = alias [8 x i8], ptr @external_addrtaken
+; CHECK: @alias_dso_local = dso_local alias [8 x i8], ptr @external_addrtaken_dso_local
 ; CHECK-NOT: @alias3 = alias
 ; CHECK-NOT: @not_present
 
 target triple = "x86_64-unknown-linux"
 
-!cfi.functions = !{!0, !2, !3, !4}
-!aliases = !{!5, !6}
+!cfi.functions = !{!0, !2, !3, !4, !7, !8}
+!aliases = !{!5, !6, !9}
 
 !0 = !{!"external_addrtaken", i8 0, i64 16594175687743574550, !1}
 !1 = !{i64 0, !"typeid1"}
@@ -17,3 +20,6 @@ target triple = "x86_64-unknown-linux"
 !4 = !{!"alias3", i8 0, i64 9766217518394409673, !1}
 !5 = !{!"external_addrtaken", !"alias1", !"alias2"}
 !6 = !{!"not_present", !"alias3"}
+!7 = !{!"external_addrtaken_dso_local", i8 0, i64 4497425064003378793, !1}
+!8 = !{!"alias_dso_local", i8 0, i64 15765058181946593837, !1}
+!9 = !{!"external_addrtaken_dso_local", !"alias_dso_local"}

--- a/llvm/test/Transforms/LowerTypeTests/import-alias.ll
+++ b/llvm/test/Transforms/LowerTypeTests/import-alias.ll
@@ -3,14 +3,19 @@
 ; Check that the definitions for @f and @f_alias are removed from this module
 ; but @g_alias remains.
 ;
+; CHECK: @f_dso_local_alias.cfi = dso_local alias void (), ptr @f_dso_local.cfi
 ; CHECK: @g_alias = alias void (), ptr @g
-; CHECK: define hidden void @f.cfi
+; CHECK: define hidden void @f.cfi()
+; CHECK: define hidden void @f_dso_local.cfi()
 ; CHECK: declare void @f()
 ; CHECK: declare void @f_alias()
+; CHECK: declare dso_local void @f_dso_local()
+; CHECK: declare dso_local void @f_dso_local_alias()
 
 target triple = "x86_64-unknown-linux"
 
 @f_alias = alias void (), ptr @f
+@f_dso_local_alias = dso_local alias void (), ptr @f_dso_local
 @g_alias = alias void (), ptr @g
 
 ; Definition moved to the merged module
@@ -23,8 +28,13 @@ define void @g() {
   ret void
 }
 
+define dso_local void @f_dso_local() {
+  ret void
+}
+
 define void @uses_aliases() {
   call void @f_alias()
+  call void @f_dso_local_alias()
   call void @g_alias()
   ret void
 }

--- a/llvm/test/Transforms/LowerTypeTests/x86-jumptable.ll
+++ b/llvm/test/Transforms/LowerTypeTests/x86-jumptable.ll
@@ -3,13 +3,17 @@
 ; RUN: opt -S -passes=lowertypetests -mtriple=i686 %s | FileCheck --check-prefixes=X86_32 %s
 ; RUN: opt -S -passes=lowertypetests -mtriple=x86_64 %s | FileCheck --check-prefixes=X86_64 %s
 
-@0 = private unnamed_addr constant [2 x ptr] [ptr @f, ptr @g], align 16
+@0 = private unnamed_addr constant [3 x ptr] [ptr @f, ptr @g, ptr @h], align 16
 
 define void @f() !type !0 {
   ret void
 }
 
 define internal void @g() !type !0 {
+  ret void
+}
+
+define dso_local void @h() !type !0 {
   ret void
 }
 
@@ -25,15 +29,17 @@ define i1 @foo(ptr %p) {
 !1 = !{i32 8, !"cf-protection-branch", i32 1}
 
 ;.
-; X86_32: @[[GLOB0:[0-9]+]] = private unnamed_addr constant [2 x ptr] [ptr @f, ptr @g], align 16
+; X86_32: @[[GLOB0:[0-9]+]] = private unnamed_addr constant [3 x ptr] [ptr @f, ptr @g, ptr @h], align 16
 ; X86_32: @[[GLOB1:[0-9]+]] = private constant [0 x i8] zeroinitializer
 ; X86_32: @f = alias [16 x i8], ptr @.cfi.jumptable
-; X86_32: @g = internal alias [16 x i8], getelementptr inbounds ([2 x [16 x i8]], ptr @.cfi.jumptable, i32 0, i32 1)
+; X86_32: @g = internal alias [16 x i8], getelementptr inbounds ([3 x [16 x i8]], ptr @.cfi.jumptable, i32 0, i32 1)
+; X86_32: @h = dso_local alias [16 x i8], getelementptr inbounds ([3 x [16 x i8]], ptr @.cfi.jumptable, i32 0, i32 2)
 ;.
-; X86_64: @[[GLOB0:[0-9]+]] = private unnamed_addr constant [2 x ptr] [ptr @f, ptr @g], align 16
+; X86_64: @[[GLOB0:[0-9]+]] = private unnamed_addr constant [3 x ptr] [ptr @f, ptr @g, ptr @h], align 16
 ; X86_64: @[[GLOB1:[0-9]+]] = private constant [0 x i8] zeroinitializer
 ; X86_64: @f = alias [16 x i8], ptr @.cfi.jumptable
-; X86_64: @g = internal alias [16 x i8], getelementptr inbounds ([2 x [16 x i8]], ptr @.cfi.jumptable, i64 0, i64 1)
+; X86_64: @g = internal alias [16 x i8], getelementptr inbounds ([3 x [16 x i8]], ptr @.cfi.jumptable, i64 0, i64 1)
+; X86_64: @h = dso_local alias [16 x i8], getelementptr inbounds ([3 x [16 x i8]], ptr @.cfi.jumptable, i64 0, i64 2)
 ;.
 ; X86_32-LABEL: @f.cfi(
 ; X86_32-NEXT:    ret void
@@ -43,11 +49,15 @@ define i1 @foo(ptr %p) {
 ; X86_32-NEXT:    ret void
 ;
 ;
+; X86_32-LABEL: @h.cfi(
+; X86_32-NEXT:    ret void
+;
+;
 ; X86_32-LABEL: @foo(
 ; X86_32-NEXT:    [[TMP1:%.*]] = ptrtoint ptr [[P:%.*]] to i32
-; X86_32-NEXT:    [[TMP2:%.*]] = sub i32 ptrtoint (ptr getelementptr (i8, ptr @.cfi.jumptable, i32 16) to i32), [[TMP1]]
+; X86_32-NEXT:    [[TMP2:%.*]] = sub i32 ptrtoint (ptr getelementptr (i8, ptr @.cfi.jumptable, i32 32) to i32), [[TMP1]]
 ; X86_32-NEXT:    [[TMP3:%.*]] = call i32 @llvm.fshr.i32(i32 [[TMP2]], i32 [[TMP2]], i32 4)
-; X86_32-NEXT:    [[TMP4:%.*]] = icmp ule i32 [[TMP3]], 1
+; X86_32-NEXT:    [[TMP4:%.*]] = icmp ule i32 [[TMP3]], 2
 ; X86_32-NEXT:    ret i1 [[TMP4]]
 ;
 ;
@@ -55,6 +65,7 @@ define i1 @foo(ptr %p) {
 ; X86_32-NEXT:  entry:
 ; X86_32-NEXT:    call void asm sideeffect "endbr32\0Ajmp ${0:c}@plt\0A.balign 16, 0xcc\0A", "s"(ptr @f.cfi)
 ; X86_32-NEXT:    call void asm sideeffect "endbr32\0Ajmp ${0:c}@plt\0A.balign 16, 0xcc\0A", "s"(ptr @g.cfi)
+; X86_32-NEXT:    call void asm sideeffect "endbr32\0Ajmp ${0:c}@plt\0A.balign 16, 0xcc\0A", "s"(ptr @h.cfi)
 ; X86_32-NEXT:    unreachable
 ;
 ;
@@ -66,11 +77,15 @@ define i1 @foo(ptr %p) {
 ; X86_64-NEXT:    ret void
 ;
 ;
+; X86_64-LABEL: @h.cfi(
+; X86_64-NEXT:    ret void
+;
+;
 ; X86_64-LABEL: @foo(
 ; X86_64-NEXT:    [[TMP1:%.*]] = ptrtoint ptr [[P:%.*]] to i64
-; X86_64-NEXT:    [[TMP2:%.*]] = sub i64 ptrtoint (ptr getelementptr (i8, ptr @.cfi.jumptable, i64 16) to i64), [[TMP1]]
+; X86_64-NEXT:    [[TMP2:%.*]] = sub i64 ptrtoint (ptr getelementptr (i8, ptr @.cfi.jumptable, i64 32) to i64), [[TMP1]]
 ; X86_64-NEXT:    [[TMP3:%.*]] = call i64 @llvm.fshr.i64(i64 [[TMP2]], i64 [[TMP2]], i64 4)
-; X86_64-NEXT:    [[TMP4:%.*]] = icmp ule i64 [[TMP3]], 1
+; X86_64-NEXT:    [[TMP4:%.*]] = icmp ule i64 [[TMP3]], 2
 ; X86_64-NEXT:    ret i1 [[TMP4]]
 ;
 ;
@@ -78,6 +93,7 @@ define i1 @foo(ptr %p) {
 ; X86_64-NEXT:  entry:
 ; X86_64-NEXT:    call void asm sideeffect "endbr64\0Ajmp ${0:c}@plt\0A.balign 16, 0xcc\0A", "s"(ptr @f.cfi)
 ; X86_64-NEXT:    call void asm sideeffect "endbr64\0Ajmp ${0:c}@plt\0A.balign 16, 0xcc\0A", "s"(ptr @g.cfi)
+; X86_64-NEXT:    call void asm sideeffect "endbr64\0Ajmp ${0:c}@plt\0A.balign 16, 0xcc\0A", "s"(ptr @h.cfi)
 ; X86_64-NEXT:    unreachable
 ;
 ;.


### PR DESCRIPTION
LowerTypeTests should propagate dso_local if the original function it would generate an alias for was also dso_local. The benefit here is that references to the alias can now use PCREL relocs which could prevent some GOT-generating relocs. Note this is independent of the visibility and linkage so the types of symbols this would benefit are external non-hidden dso_local functions.

Gemini was used to help generate tests. I reviewed this to the best of my ability before posting a PR.