### PR TITLE
[flang][OpenACC] Rematerialize fir.absent in outlined regions.

### DIFF
--- a/flang/lib/Optimizer/OpenACC/Support/RegisterOpenACCExtensions.cpp
+++ b/flang/lib/Optimizer/OpenACC/Support/RegisterOpenACCExtensions.cpp
@@ -89,6 +89,8 @@ void registerOpenACCExtensions(mlir::DialectRegistry &registry) {
         *ctx);
     fir::SliceOp::attachInterface<OutlineRematerializationModel<fir::SliceOp>>(
         *ctx);
+    fir::AbsentOp::attachInterface<
+        OutlineRematerializationModel<fir::AbsentOp>>(*ctx);
   });
 
   // Register HLFIR operation interfaces

--- a/flang/test/Fir/CUDA/cuf-offload-livein-value-canonicalization.fir
+++ b/flang/test/Fir/CUDA/cuf-offload-livein-value-canonicalization.fir
@@ -77,3 +77,44 @@ func.func @test_2d_shape_sink() {
 // CHECK-LABEL: @test_2d_shape_sink
 // CHECK: cuf.kernel
 // CHECK:   fir.shape
+
+// -----
+
+// Test fir.absent rematerialization.
+func.func @test_absent_sink_1() {
+  %c1 = arith.constant 1 : index
+  %c32 = arith.constant 32 : index
+  %0 = fir.absent !fir.boxchar<1>
+  cuf.kernel<<<*, *>>> (%arg0 : index) = (%c1 : index) to (%c32 : index) step (%c1 : index) {
+    fir.call @func_with_optional_boxchar_(%0) : (!fir.boxchar<1>) -> none
+    "fir.end"() : () -> ()
+  }
+  return
+}
+
+// CHECK-LABEL: @test_absent_sink_1
+// CHECK: cuf.kernel
+// CHECK: %[[BOX:.*]] = fir.absent !fir.boxchar<1>
+// CHECK: fir.call @func_with_optional_boxchar_(%[[BOX]]) : (!fir.boxchar<1>) -> none
+
+// -----
+
+// Test fir.absent rematerialization (used both inside and outside region).
+func.func @test_absent_sink_2() {
+  %c1 = arith.constant 1 : index
+  %c32 = arith.constant 32 : index
+  %0 = fir.absent !fir.boxchar<1>
+  fir.call @func_with_optional_boxchar_(%0) : (!fir.boxchar<1>) -> none
+  cuf.kernel<<<*, *>>> (%arg0 : index) = (%c1 : index) to (%c32 : index) step (%c1 : index) {
+    fir.call @func_with_optional_boxchar_(%0) : (!fir.boxchar<1>) -> none
+    "fir.end"() : () -> ()
+  }
+  return
+}
+
+// CHECK-LABEL: @test_absent_sink_2
+// CHECK: %[[BOX1:.*]] = fir.absent !fir.boxchar<1>
+// CHECK: fir.call @func_with_optional_boxchar_(%[[BOX1]]) : (!fir.boxchar<1>) -> none
+// CHECK: cuf.kernel
+// CHECK: %[[BOX2:.*]] = fir.absent !fir.boxchar<1>
+// CHECK: fir.call @func_with_optional_boxchar_(%[[BOX2]]) : (!fir.boxchar<1>) -> none

--- a/flang/test/Fir/OpenACC/offload-livein-value-canonicalization.fir
+++ b/flang/test/Fir/OpenACC/offload-livein-value-canonicalization.fir
@@ -539,3 +539,41 @@ func.func @test_dummy_scope_rematerialize() {
 // CHECK-DAG:   fir.address_of(@global_for_dummy_scope_remat)
 // CHECK-DAG:   %[[DECL_INNER:.*]] = fir.declare %{{.*}} {uniq_name = "global"} : (!fir.ref<i32>) -> !fir.ref<i32>
 // CHECK:   fir.call @use_ref(%[[DECL_INNER]])
+
+
+// -----
+
+// Test fir.absent rematerialization.
+func.func @test_absent_sink_1() {
+  %0 = fir.absent !fir.boxchar<1>
+  acc.serial {
+    fir.call @func_with_optional_boxchar_(%0) : (!fir.boxchar<1>) -> none
+    acc.yield
+  }
+  return
+}
+
+// CHECK-LABEL: @test_absent_sink_1
+// CHECK: acc.serial
+// CHECK: %[[BOX:.*]] = fir.absent !fir.boxchar<1>
+// CHECK: fir.call @func_with_optional_boxchar_(%[[BOX]]) : (!fir.boxchar<1>) -> none
+
+// -----
+
+// Test fir.absent rematerialization (used both inside and outside region).
+func.func @test_absent_sink_2() {
+  %0 = fir.absent !fir.boxchar<1>
+  fir.call @func_with_optional_boxchar_(%0) : (!fir.boxchar<1>) -> none
+  acc.serial {
+    fir.call @func_with_optional_boxchar_(%0) : (!fir.boxchar<1>) -> none
+    acc.yield
+  }
+  return
+}
+
+// CHECK-LABEL: @test_absent_sink_2
+// CHECK: %[[BOX1:.*]] = fir.absent !fir.boxchar<1>
+// CHECK: fir.call @func_with_optional_boxchar_(%[[BOX1]]) : (!fir.boxchar<1>) -> none
+// CHECK: acc.serial
+// CHECK: %[[BOX2:.*]] = fir.absent !fir.boxchar<1>
+// CHECK: fir.call @func_with_optional_boxchar_(%[[BOX2]]) : (!fir.boxchar<1>) -> none


### PR DESCRIPTION
`OffloadTargetVerifier` complains about `!fir.boxchar<>` live-in
produced by `fir.absent`. It should be always legal and profitable
to rematerialize `fir.absent` inside the outlined regions.
