### PR TITLE
[profile] hoist length check before use of pointer

### DIFF
--- a/compiler-rt/lib/profile/InstrProfilingMerge.c
+++ b/compiler-rt/lib/profile/InstrProfilingMerge.c
@@ -49,15 +49,15 @@ uint64_t lprofGetLoadModuleSignature(void) {
 COMPILER_RT_VISIBILITY
 int __llvm_profile_check_compatibility(const char *ProfileData,
                                        uint64_t ProfileSize) {
+  if (ProfileSize < sizeof(__llvm_profile_header))
+    return 1;
+
   __llvm_profile_header *Header = (__llvm_profile_header *)ProfileData;
   __llvm_profile_data *SrcDataStart, *SrcDataEnd, *SrcData, *DstData;
   SrcDataStart =
       (__llvm_profile_data *)(ProfileData + sizeof(__llvm_profile_header) +
                               Header->BinaryIdsSize);
   SrcDataEnd = SrcDataStart + Header->NumData;
-
-  if (ProfileSize < sizeof(__llvm_profile_header))
-    return 1;
 
   /* Check the header first.  */
   if (Header->Magic != __llvm_profile_get_magic() ||


### PR DESCRIPTION
If a truncated profile is passed into this endpoint (say, 1 byte), we unconditionally do `((__llvm_profile_header *)ProfileData)->BinaryIdsSize`, which reaches outside of the `char` array passed to this function.

Hoisting the check prevents the out-of-bounds read.