### PR TITLE
[lldb] Fix GetNumChildren for references to empty structs

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -5376,19 +5376,16 @@ TypeSystemClang::GetNumChildren(lldb::opaque_compiler_type_t type,
   case clang::Type::ObjCObjectPointer: {
     CompilerType pointee_clang_type(GetPointeeType(type));
 
-    uint32_t num_pointee_children = 0;
     if (pointee_clang_type.IsAggregateType()) {
       auto num_children_or_err =
           pointee_clang_type.GetNumChildren(omit_empty_base_classes, exe_ctx);
       if (!num_children_or_err)
         return num_children_or_err;
-      num_pointee_children = *num_children_or_err;
-    }
-    // If this type points to a simple type, then it has 1 child
-    if (num_pointee_children == 0)
+      num_children = *num_children_or_err;
+    } else {
+      // If this type points to a simple type, then it has 1 child
       num_children = 1;
-    else
-      num_children = num_pointee_children;
+    }
   } break;
 
   case clang::Type::Vector:

--- a/lldb/test/API/lang/cpp/reference-to-struct/Makefile
+++ b/lldb/test/API/lang/cpp/reference-to-struct/Makefile
@@ -1,0 +1,3 @@
+CXX_SOURCES := main.cpp
+
+include Makefile.rules

--- a/lldb/test/API/lang/cpp/reference-to-struct/TestReferenceToStruct.py
+++ b/lldb/test/API/lang/cpp/reference-to-struct/TestReferenceToStruct.py
@@ -1,0 +1,48 @@
+
+# Tests correct behaviour of GetNumChildren and GetChildAtIndex
+# for references to struct
+
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestReferenceToStruct(TestBase):
+    def test(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.cpp")
+        )
+
+        frame = self.frame()
+
+        # A reference to an aggregate is displayed transparently, so it must
+        # report the same number of children as the referent.
+
+        # GetNumChildren should return 0 for reference to empty struct
+
+        e_ref = frame.FindVariable("e_ref")
+        self.assertEqual(e_ref.GetNumChildren(), 0)
+
+        # GetNumChildren should return 1 for reference to struct containing
+        # a single child
+
+        s_ref = frame.FindVariable("s_ref")
+        self.assertEqual(s_ref.GetNumChildren(), 1)
+        child = s_ref.GetChildAtIndex(0)
+        self.assertTrue(child.IsValid())
+        self.assertEqual(child.GetName(), "x")
+
+        # GetNumChildren should return 2 for reference to struct containing
+        # two children
+
+        t_ref = frame.FindVariable("t_ref")
+        self.assertEqual(t_ref.GetNumChildren(), 2)
+
+        child1 = t_ref.GetChildAtIndex(0)
+        self.assertTrue(child1.IsValid())
+        self.assertEqual(child1.GetName(), "x")
+
+        child2 = t_ref.GetChildAtIndex(1)
+        self.assertTrue(child2.IsValid())
+        self.assertEqual(child2.GetName(), "y")

--- a/lldb/test/API/lang/cpp/reference-to-struct/main.cpp
+++ b/lldb/test/API/lang/cpp/reference-to-struct/main.cpp
@@ -1,0 +1,23 @@
+struct EmptyStruct {};
+
+struct SingleChildStruct {
+  int x;
+};
+
+struct TwoChildrenStruct {
+  int x;
+  int y;
+};
+
+int main() {
+  EmptyStruct e;
+  EmptyStruct &e_ref = e;
+
+  SingleChildStruct s{0};
+  SingleChildStruct &s_ref = s;
+
+  TwoChildrenStruct t{0};
+  TwoChildrenStruct &t_ref = t;
+
+  return 0; // break here
+}


### PR DESCRIPTION
For references to aggregate types, `GetNumChildren` checks the number of children in the referenced type but returns 1 when that number is 0. That causes an inconsistency with `GetChildAtIndex`, which cannot fetch a child at index 0 and returns an invalid value.

`GetNumChildren` should always return the number of children in the referenced type for aggregate types. The PR also contains an API test that checks the correctness of the values returned by `GetNumChildren` for references to structs.