### PR TITLE
[NFC][CodeQL] Suppress CodeQL warning on intentional ITT collector library loading

### DIFF
--- a/openmp/runtime/src/thirdparty/ittnotify/ittnotify_static.cpp
+++ b/openmp/runtime/src/thirdparty/ittnotify/ittnotify_static.cpp
@@ -1385,6 +1385,19 @@ ITT_EXTERN_C int _N_(init_ittlib)(const char *lib_name,
         }
         groups = __itt_get_groups();
         if (DL_SYMBOLS && (groups != __itt_group_none || lib_name != NULL)) {
+          /* CodeQL reports this __itt_load_lib call as an "Uncontrolled
+           * process operation": uncontrolled external input (the
+           * INTEL_LIBITTNOTIFY{32,64} environment variable) is passed to a
+           * library-loading function. This appears to be intended, matching
+           * the guidance in Intel's "Compile and Link with ITT API"
+           * documentation, which describes the env var as a path to a library
+           * to load:
+           * https://intel.github.io/ittapi/src/compile-and-link-with-itt-api.html
+           * CodeQL reference error:
+           * https://codeql.github.com/codeql-query-help/cpp/cpp-uncontrolled-process-operation/
+           * The warning issuppressed below.
+           */
+          // codeql[cpp/uncontrolled-process-operation]
           _N_(_ittapi_global).lib = __itt_load_lib(
               (lib_name == NULL) ? ittnotify_lib_name : lib_name);
 


### PR DESCRIPTION
**Context:** Hey folks, I'm from the MSVC ASan team, which forks LLVM. We're getting some internal static analysis alerts about some code in LLVM. This PR aims to make non-functional changes to make those security alerts go away. I hope these are welcomed changes, let me know if not.

**The alert:**

CodeQL flags passing the library to load in `_N_(init_ittlib)` through the `INTEL_LIBITTNOTIFY32` or `INTEL_LIBITTNOTIFY64` environment variable as dangerous because the environment variable is technically uncontrolled external input.

As far as I can tell, this behavior is intentional, as selecting an ITT collector library through an environment variable matches the pattern described in Intel's ITT API documentation.

**This PR** suppresses the warning in this case using:

// codeql[cpp/uncontrolled-process-operation]

**Intel ITT documentation:**
https://intel.github.io/ittapi/src/compile-and-link-with-itt-api.html

**CodeQL warning docs:**
https://codeql.github.com/codeql-query-help/cpp/cpp-uncontrolled-process-operation/