### PR TITLE
[bazel][libc] Removes the unused dependency for `floorf128` 

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -8048,7 +8048,6 @@ libc_support_library(
         ":__support_fputil_float128",
         ":__support_fputil_nearest_integer_operations",
         ":__support_macros_config",
-        ":llvm_libc_types_float128",
     ],
 )
 


### PR DESCRIPTION
Removes the unused dependency for `floorf128`. This was found in #216949, which updates the Bazel files for it.