### PR TITLE
[lldb][Windows] Translate file descriptors between CRT instances

### DIFF
--- a/lldb/include/lldb/API/SBFile.h
+++ b/lldb/include/lldb/API/SBFile.h
@@ -35,6 +35,10 @@ public:
   SBFile(int fd, const char *mode, bool transfer_ownership);
   ~SBFile();
 
+#if defined(_WIN32) && !defined(SWIG)
+  static int OpenFdFromHandle(intptr_t handle, int flags);
+#endif
+
   SBFile &operator=(const SBFile &rhs);
 
   SBError Read(uint8_t *buf, size_t num_bytes, size_t *OUTPUT);

--- a/lldb/source/API/SBFile.cpp
+++ b/lldb/source/API/SBFile.cpp
@@ -69,6 +69,12 @@ SBFile::SBFile(int fd, const char *mode, bool transfer_ownership) {
       std::make_shared<NativeFile>(fd, options.get(), transfer_ownership);
 }
 
+#ifdef _WIN32
+int SBFile::OpenFdFromHandle(intptr_t handle, int flags) {
+  return _open_osfhandle(handle, flags);
+}
+#endif
+
 SBError SBFile::Read(uint8_t *buf, size_t num_bytes, size_t *bytes_read) {
   LLDB_INSTRUMENT_VA(this, buf, num_bytes, bytes_read);
 

--- a/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.cpp
@@ -21,6 +21,10 @@
 #include "llvm/Support/ConvertUTF.h"
 #include "llvm/Support/Errno.h"
 
+#ifdef _WIN32
+#include "lldb/Host/windows/windows.h"
+#endif
+
 #include <cstdio>
 #include <variant>
 
@@ -1000,6 +1004,63 @@ bool PythonFile::Check(PyObject *py_obj) {
   return !!r;
 }
 
+#if defined(_WIN32) && !defined(_DLL)
+// When LLVM is built with a different CRT allocator, it's built against the
+// static C runtime. The official Python builds link to the dynamic C runtime.
+// Since the file descriptors are managed per CRT instance, liblldb and Python
+// have different fd mappings. This translates between the two using the msvcrt
+// module.
+int PythonFile::TranslateFdToPython(int our_fd) {
+  intptr_t handle = _get_osfhandle(our_fd);
+  if (handle == 0 || (HANDLE)handle == INVALID_HANDLE_VALUE)
+    return -1;
+
+  PyObject *msvcrt = PyImport_ImportModule("msvcrt");
+  if (!msvcrt)
+    return -1;
+  PyObject *open_osf = PyObject_GetAttrString(msvcrt, "open_osfhandle");
+  Py_XDECREF(msvcrt);
+  if (!open_osf)
+    return -1;
+  PyObject *fd_obj =
+      PyObject_CallFunction(open_osf, "Li", (long long)handle, 0);
+  Py_XDECREF(open_osf);
+  if (!fd_obj)
+    return -1;
+  if (!PyLong_Check(fd_obj)) {
+    Py_XDECREF(fd_obj);
+    return -1;
+  }
+  long theirs = PyLong_AsLong(fd_obj);
+  Py_XDECREF(fd_obj);
+  return (int)theirs;
+}
+
+int PythonFile::TranslateFdFromPython(int their_fd) {
+  PyObject *msvcrt = PyImport_ImportModule("msvcrt");
+  if (!msvcrt)
+    return -1;
+  PyObject *get_handle = PyObject_GetAttrString(msvcrt, "get_osfhandle");
+  Py_XDECREF(msvcrt);
+  if (!get_handle)
+    return -1;
+  PyObject *handle_obj = PyObject_CallFunction(get_handle, "i", their_fd);
+  Py_XDECREF(get_handle);
+  if (!handle_obj)
+    return -1;
+  if (!PyLong_Check(handle_obj)) {
+    Py_XDECREF(handle_obj);
+    return -1;
+  }
+  size_t handle = PyLong_AsSize_t(handle_obj);
+  Py_XDECREF(handle_obj);
+  return _open_osfhandle((intptr_t)handle, 0);
+}
+#else
+int PythonFile::TranslateFdToPython(int our_fd) { return our_fd; }
+int PythonFile::TranslateFdFromPython(int their_fd) { return their_fd; }
+#endif
+
 const char *PythonException::toCString() const {
   if (!m_repr_bytes)
     return "unknown exception";
@@ -1365,6 +1426,10 @@ llvm::Expected<FileSP> PythonFile::ConvertToFile(bool borrowed) {
     PyErr_Clear();
     return ConvertToFileForcingUseOfScriptingIOMethods(borrowed);
   }
+  fd = TranslateFdFromPython(fd);
+  if (fd < 0)
+    return llvm::createStringError("failed to translate Python fd to our fd");
+
   auto options = GetOptionsForPyObject(*this);
   if (!options)
     return options.takeError();
@@ -1410,6 +1475,9 @@ PythonFile::ConvertToFileForcingUseOfScriptingIOMethods(bool borrowed) {
     PyErr_Clear();
     fd = File::kInvalidDescriptor;
   }
+  fd = TranslateFdFromPython(fd);
+  if (fd < 0)
+    return llvm::createStringError("failed to translate Python fd to our fd");
 
   auto io_module = PythonModule::Import("io");
   if (!io_module)
@@ -1474,8 +1542,8 @@ Expected<PythonFile> PythonFile::FromFile(File &file, const char *mode) {
   }
 
   PyObject *file_obj;
-  file_obj = PyFile_FromFd(file.GetDescriptor(), nullptr, mode, -1, nullptr,
-                           "ignore", nullptr, /*closefd=*/0);
+  file_obj = PyFile_FromFd(TranslateFdToPython(file.GetDescriptor()), nullptr,
+                           mode, -1, nullptr, "ignore", nullptr, /*closefd=*/0);
 
   if (!file_obj)
     return exception();

--- a/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.cpp
@@ -1427,8 +1427,10 @@ llvm::Expected<FileSP> PythonFile::ConvertToFile(bool borrowed) {
     return ConvertToFileForcingUseOfScriptingIOMethods(borrowed);
   }
   fd = TranslateFdFromPython(fd);
-  if (fd < 0)
+  if (fd < 0) {
+    PyErr_Clear();
     return llvm::createStringError("failed to translate Python fd to our fd");
+  }
 
   auto options = GetOptionsForPyObject(*this);
   if (!options)
@@ -1474,10 +1476,13 @@ PythonFile::ConvertToFileForcingUseOfScriptingIOMethods(bool borrowed) {
   if (fd < 0) {
     PyErr_Clear();
     fd = File::kInvalidDescriptor;
+  } else {
+    fd = TranslateFdFromPython(fd);
+    if (fd < 0) {
+      PyErr_Clear();
+      return llvm::createStringError("failed to translate Python fd to our fd");
+    }
   }
-  fd = TranslateFdFromPython(fd);
-  if (fd < 0)
-    return llvm::createStringError("failed to translate Python fd to our fd");
 
   auto io_module = PythonModule::Import("io");
   if (!io_module)

--- a/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.h
@@ -644,6 +644,9 @@ public:
 
   static bool Check(PyObject *py_obj);
 
+  static int TranslateFdToPython(int our_fd);
+  static int TranslateFdFromPython(int their_fd);
+
   static llvm::Expected<PythonFile> FromFile(File &file,
                                              const char *mode = nullptr);
 

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -1087,8 +1087,10 @@ bool ScriptInterpreterPythonImpl::RedirectTerminalHandleThroughLock(
   // terminal) promptly: the pipe descriptor is not a tty, so the default
   // buffering would hold output back until the buffer filled.
   PyObject *pipe_file = PyFile_FromFd(
-      redirect->GetWriteDescriptor(), nullptr, mode, /*buffering=*/1,
-      /*encoding=*/nullptr, /*errors=*/"ignore", /*newline=*/nullptr,
+      PythonFile::TranslateFdToPython(redirect->GetWriteDescriptor()), nullptr,
+      mode, /*buffering=*/1,
+      /*encoding=*/nullptr, /*errors=*/"ignore",
+      /*newline=*/nullptr,
       /*closefd=*/0);
   if (!pipe_file) {
     // Fall back to the raw descriptor. That reopens the statusline race, so

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -1320,11 +1320,22 @@ llvm::Error DAP::InitializeDebugger() {
   llvm::Expected<int> out_fd = out.GetWriteFileDescriptor();
   if (!out_fd)
     return out_fd.takeError();
-  debugger.SetOutputFile(lldb::SBFile(*out_fd, "w", false));
-
   llvm::Expected<int> err_fd = err.GetWriteFileDescriptor();
   if (!err_fd)
     return err_fd.takeError();
+
+#if defined(_WIN32) && !defined(_DLL)
+  // When LLVM is built with a different CRT allocator, it's built against the
+  // static C runtime. Since the C runtime is the one managing the file
+  // descriptors, its state is now local to each module. Here, lldb-dap and
+  // liblldb have two different CRT states and thus different sets of file
+  // descriptors. This translates an lldb-dap fd into a liblldb fd by creating a
+  // mapping of fd -> HANDLE inside liblldb.
+  *out_fd = lldb::SBFile::OpenFdFromHandle(_get_osfhandle(*out_fd), 0);
+  *err_fd = lldb::SBFile::OpenFdFromHandle(_get_osfhandle(*err_fd), 0);
+#endif
+
+  debugger.SetOutputFile(lldb::SBFile(*out_fd, "w", false));
   debugger.SetErrorFile(lldb::SBFile(*err_fd, "w", false));
 
   // The sourceInitFile option is not part of the DAP specification. It is an


### PR DESCRIPTION
The official LLVM and lldb builds use `LLVM_ENABLE_RPMALLOC`. This changes the default CRT allocator to rpmalloc for performance reasons. In doing so, it also changes the CRT linkage from dynamic  (`/MD`) to static (`/MT`).
Since the CRT is the one managing file descriptors on Windows, its universe is now scoped to a module. For lldb, this means we have three fd-spaces: the driver (lldb/lldb-dap), liblldb, and Python.
We usually pass files around as file descriptors. This breaks when we do it between modules.

Fortunately, the C runtime provides us with helpers to translate between the process scoped HANDLEs and file descriptors. This way, we can allocate an fd for a handle passed across modules. For Python, there's the [`msvcrt`](https://docs.python.org/3/library/msvcrt.html) library we can use to translate.

Fixes #216679.