### PR TITLE
[lldb] Add GDB remote register vector types

### DIFF
--- a/lldb/include/lldb/Core/DumpRegisterValue.h
+++ b/lldb/include/lldb/Core/DumpRegisterValue.h
@@ -22,14 +22,14 @@ class Stream;
 
 // The default value of 0 for reg_name_right_align_at means no alignment at
 // all.
-// Set print_flags to true to print register fields if they are available.
+// Set print_type to true to print a structured value if one is available.
 // If you do so, target_sp must be non-null for it to work.
 void DumpRegisterValue(const RegisterValue &reg_val, Stream &s,
                        const RegisterInfo &reg_info, bool prefix_with_name,
                        bool prefix_with_alt_name, lldb::Format format,
                        uint32_t reg_name_right_align_at = 0,
                        ExecutionContextScope *exe_scope = nullptr,
-                       bool print_flags = false,
+                       bool print_type = false,
                        lldb::TargetSP target_sp = nullptr);
 
 } // namespace lldb_private

--- a/lldb/include/lldb/Utility/RegisterType.h
+++ b/lldb/include/lldb/Utility/RegisterType.h
@@ -9,7 +9,10 @@
 #ifndef LLDB_UTILITY_REGISTERTYPE_H
 #define LLDB_UTILITY_REGISTERTYPE_H
 
+#include "lldb/lldb-enumerations.h"
+
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -24,6 +27,8 @@ public:
   enum RegisterTypeKind {
     eRegisterTypeKindFlags,
     eRegisterTypeKindEnum,
+    eRegisterTypeKindBuiltin,
+    eRegisterTypeKindVector,
   };
 
   RegisterTypeKind getKind() const { return m_kind; }
@@ -37,8 +42,7 @@ public:
   /// Output XML that describes this type, to be inserted into a target XML
   /// file. Reserved characters like "<" are replaced with their XML safe
   /// equivalents like "&gt;".
-  void ToXML(Stream &strm,
-             std::unordered_set<const RegisterType *> &previously_emitted,
+  void ToXML(Stream &strm, std::unordered_set<std::string> &previously_emitted,
              const RegisterType *user = nullptr) const;
 
   virtual ~RegisterType() = default;
@@ -56,6 +60,9 @@ public:
   /// reused after this instance is destroyed.
   uint64_t GetUID() const { return m_uid; }
 
+  /// Return this type's size in bytes when the target description defines it.
+  virtual std::optional<uint64_t> GetByteSize() const { return std::nullopt; }
+
   void SetDependencies(std::vector<const RegisterType *> dependencies) {
     m_dependencies = dependencies;
   }
@@ -65,6 +72,54 @@ private:
   const std::string m_id;
   const uint64_t m_uid;
   std::vector<const RegisterType *> m_dependencies;
+};
+
+/// A predefined GDB target-description type.
+class RegisterTypeBuiltin : public RegisterType {
+public:
+  /// A byte size of zero means the size is target-dependent.
+  RegisterTypeBuiltin(std::string id, lldb::Encoding encoding,
+                      lldb::Format format, uint32_t byte_size);
+
+  lldb::Encoding GetEncoding() const { return m_encoding; }
+  lldb::Format GetFormat() const { return m_format; }
+  std::optional<uint64_t> GetByteSize() const override {
+    return m_byte_size ? std::optional<uint64_t>(m_byte_size) : std::nullopt;
+  }
+
+  void ToXMLElement(Stream &strm,
+                    const RegisterType *user = nullptr) const override;
+
+  static bool classof(const RegisterType *type) {
+    return type->getKind() == eRegisterTypeKindBuiltin;
+  }
+
+private:
+  lldb::Encoding m_encoding;
+  lldb::Format m_format;
+  uint32_t m_byte_size;
+};
+
+/// A GDB target-description vector type. The element type must outlive it.
+class RegisterTypeVector : public RegisterType {
+public:
+  RegisterTypeVector(std::string id, const RegisterType *element_type,
+                     uint32_t count);
+
+  const RegisterType *GetElementType() const { return m_element_type; }
+  uint32_t GetCount() const { return m_count; }
+  std::optional<uint64_t> GetByteSize() const override;
+
+  void ToXMLElement(Stream &strm,
+                    const RegisterType *user = nullptr) const override;
+
+  static bool classof(const RegisterType *type) {
+    return type->getKind() == eRegisterTypeKindVector;
+  }
+
+private:
+  const RegisterType *m_element_type;
+  uint32_t m_count;
 };
 
 } // namespace lldb_private

--- a/lldb/include/lldb/Utility/RegisterValue.h
+++ b/lldb/include/lldb/Utility/RegisterValue.h
@@ -99,6 +99,10 @@ public:
 
   bool GetData(DataExtractor &data) const;
 
+  /// Copy this value using the requested target byte order.
+  bool GetData(DataExtractor &data, const RegisterInfo &reg_info,
+               lldb::ByteOrder byte_order) const;
+
   // Copy the register value from this object into a buffer in "dst" and obey
   // the "dst_byte_order" when copying the data. Also watch out in case
   // "dst_len" is longer or shorter than the register value described by

--- a/lldb/source/Commands/CommandObjectRegister.cpp
+++ b/lldb/source/Commands/CommandObjectRegister.cpp
@@ -101,7 +101,7 @@ public:
         m_format_options(eFormatDefault, UINT64_MAX, UINT64_MAX,
                          {{CommandArgumentType::eArgTypeFormat,
                            "Specify a format to be used for display. If this "
-                           "is set, register fields will not be displayed."}}) {
+                           "is set, typed output will not be displayed."}}) {
     AddSimpleArgumentList(eArgTypeRegisterName, eArgRepeatStar);
 
     // Add the "--format"
@@ -127,7 +127,7 @@ public:
 
   bool DumpRegister(const ExecutionContext &exe_ctx, Stream &strm,
                     RegisterContext &reg_ctx, const RegisterInfo &reg_info,
-                    bool print_flags, size_t reg_name_right_align_at) {
+                    bool print_type, size_t reg_name_right_align_at) {
     RegisterValue reg_value;
     if (!reg_ctx.ReadRegister(&reg_info, reg_value))
       return false;
@@ -139,7 +139,7 @@ public:
     DumpRegisterValue(reg_value, strm, reg_info, prefix_with_name,
                       prefix_with_altname, m_format_options.GetFormat(),
                       reg_name_right_align_at,
-                      exe_ctx.GetBestExecutionContextScope(), print_flags,
+                      exe_ctx.GetBestExecutionContextScope(), print_type,
                       exe_ctx.GetTargetSP());
     if ((reg_info.encoding == eEncodingUint) ||
         (reg_info.encoding == eEncodingSint)) {
@@ -187,7 +187,7 @@ public:
 
         if (reg_info &&
             DumpRegister(exe_ctx, strm, *reg_ctx, *reg_info,
-                         /*print_flags=*/false, reg_name_right_align_at))
+                         /*print_type=*/false, reg_name_right_align_at))
           ++available_count;
         else
           ++unavailable_count;
@@ -267,10 +267,9 @@ protected:
           if (const RegisterInfo *reg_info =
                   reg_ctx->GetRegisterInfoByName(arg_str)) {
             // If they have asked for a specific format don't obscure that by
-            // printing flags afterwards.
-            bool print_flags =
-                !m_format_options.GetFormatValue().OptionWasSet();
-            if (!DumpRegister(m_exe_ctx, strm, *reg_ctx, *reg_info, print_flags,
+            // printing a structured value afterwards.
+            bool print_type = !m_format_options.GetFormatValue().OptionWasSet();
+            if (!DumpRegister(m_exe_ctx, strm, *reg_ctx, *reg_info, print_type,
                               reg_name_right_align_at))
               strm.Printf("%-12s = error: unavailable\n", reg_info->name);
           } else {

--- a/lldb/source/Core/DumpRegisterInfo.cpp
+++ b/lldb/source/Core/DumpRegisterInfo.cpp
@@ -8,6 +8,7 @@
 
 #include "lldb/Core/DumpRegisterInfo.h"
 #include "lldb/Target/RegisterContext.h"
+#include "lldb/Utility/RegisterType.h"
 #include "lldb/Utility/RegisterTypeFlags.h"
 #include "lldb/Utility/Stream.h"
 
@@ -120,5 +121,8 @@ void lldb_private::DoDumpRegisterInfo(
     std::string enumerators = flags_type->DumpEnums(terminal_width);
     if (enumerators.size())
       strm << "\n\n" << enumerators;
+  } else if (auto *vector_type =
+                 llvm::dyn_cast_if_present<RegisterTypeVector>(register_type)) {
+    strm.Printf("\n\n  Vector elements: %u", vector_type->GetCount());
   }
 }

--- a/lldb/source/Core/DumpRegisterValue.cpp
+++ b/lldb/source/Core/DumpRegisterValue.cpp
@@ -11,6 +11,7 @@
 #include "lldb/DataFormatters/DumpValueObjectOptions.h"
 #include "lldb/Utility/DataExtractor.h"
 #include "lldb/Utility/Endian.h"
+#include "lldb/Utility/RegisterType.h"
 #include "lldb/Utility/RegisterTypeFlags.h"
 #include "lldb/Utility/RegisterValue.h"
 #include "lldb/Utility/StreamString.h"
@@ -60,13 +61,26 @@ static void dump_type_value(const lldb_private::RegisterTypeFlags &flags_type,
     strm << "error: " << toString(std::move(error));
 }
 
+static void dump_type_value(lldb_private::CompilerType &type,
+                            const lldb_private::DataExtractor &data_extractor,
+                            lldb_private::ExecutionContextScope *exe_scope,
+                            lldb_private::Stream &strm) {
+  lldb::ValueObjectSP vobj_sp = lldb_private::ValueObjectConstResult::Create(
+      exe_scope, type, lldb_private::ConstString(), data_extractor);
+  lldb_private::DumpValueObjectOptions dump_options;
+  dump_options.SetHideRootType(true).SetShowSummary(false);
+
+  if (llvm::Error error = vobj_sp->Dump(strm, dump_options))
+    strm << "error: " << toString(std::move(error));
+}
+
 void lldb_private::DumpRegisterValue(const RegisterValue &reg_val, Stream &s,
                                      const RegisterInfo &reg_info,
                                      bool prefix_with_name,
                                      bool prefix_with_alt_name, Format format,
                                      uint32_t reg_name_right_align_at,
                                      ExecutionContextScope *exe_scope,
-                                     bool print_flags, TargetSP target_sp) {
+                                     bool print_type, TargetSP target_sp) {
   DataExtractor data;
   if (!reg_val.GetData(data))
     return;
@@ -123,10 +137,14 @@ void lldb_private::DumpRegisterValue(const RegisterValue &reg_val, Stream &s,
                     0,                    // item_bit_offset
                     exe_scope);
 
+  if (!print_type || !exe_scope || !target_sp)
+    return;
+
   const RegisterTypeFlags *flags_type =
       llvm::dyn_cast_if_present<RegisterTypeFlags>(reg_info.register_type);
-  if (!print_flags || !flags_type || !exe_scope || !target_sp ||
-      (reg_info.byte_size != 4 && reg_info.byte_size != 8))
+  const RegisterTypeVector *vector_type =
+      llvm::dyn_cast_if_present<RegisterTypeVector>(reg_info.register_type);
+  if (!flags_type && !vector_type)
     return;
 
   CompilerType register_compiler_type = target_sp->GetRegisterType(reg_info);
@@ -136,12 +154,27 @@ void lldb_private::DumpRegisterValue(const RegisterValue &reg_val, Stream &s,
   // Use a new stream so we can remove a trailing newline later.
   StreamString register_type_stream;
 
-  if (reg_info.byte_size == 4) {
-    dump_type_value(*flags_type, register_compiler_type, reg_val.GetAsUInt32(),
-                    exe_scope, register_type_stream);
+  if (flags_type) {
+    if (reg_info.byte_size == 4) {
+      dump_type_value(*flags_type, register_compiler_type,
+                      reg_val.GetAsUInt32(), exe_scope, register_type_stream);
+    } else if (reg_info.byte_size == 8) {
+      dump_type_value(*flags_type, register_compiler_type,
+                      reg_val.GetAsUInt64(), exe_scope, register_type_stream);
+    } else {
+      return;
+    }
   } else {
-    dump_type_value(*flags_type, register_compiler_type, reg_val.GetAsUInt64(),
-                    exe_scope, register_type_stream);
+    lldb::ProcessSP process_sp = exe_scope->CalculateProcess();
+    if (!process_sp)
+      return;
+
+    DataExtractor structured_data;
+    if (!reg_val.GetData(structured_data, reg_info, process_sp->GetByteOrder()))
+      return;
+    structured_data.SetAddressByteSize(process_sp->GetAddressByteSize());
+    dump_type_value(register_compiler_type, structured_data, exe_scope,
+                    register_type_stream);
   }
 
   // Registers are indented like:
@@ -151,8 +184,11 @@ void lldb_private::DumpRegisterValue(const RegisterValue &reg_val, Stream &s,
 
   // First drop the extra newline that the value printer added. The register
   // command will add one itself.
-  llvm::StringRef register_type_str =
-      register_type_stream.GetString().drop_back();
+  llvm::StringRef register_type_str = register_type_stream.GetString();
+  if (register_type_str.ends_with('\n'))
+    register_type_str = register_type_str.drop_back();
+  if (register_type_str.empty())
+    return;
 
   // End the line that contains "    foo = 0x12345678".
   s.EOL();

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
@@ -3332,7 +3332,7 @@ GDBRemoteCommunicationServerLLGS::BuildTargetXml() {
   if (registers_count)
     response.IndentMore();
 
-  std::unordered_set<const RegisterType *> register_types_emitted;
+  std::unordered_set<std::string> register_types_emitted;
   for (int reg_index = 0; reg_index < registers_count; reg_index++) {
     const RegisterInfo *reg_info =
         reg_context.GetRegisterInfoAtIndex(reg_index);
@@ -3367,7 +3367,9 @@ GDBRemoteCommunicationServerLLGS::BuildTargetXml() {
       response << "format=\"" << format << "\" ";
 
     if (reg_info->register_type)
-      response << "type=\"" << reg_info->register_type->GetID() << "\" ";
+      response << "type=\""
+               << XMLEncodeAttributeValue(reg_info->register_type->GetID())
+               << "\" ";
 
     const char *const register_set_name =
         reg_context.GetRegisterSetNameForRegisterAtIndex(reg_index);
@@ -4453,6 +4455,9 @@ std::string GDBRemoteCommunicationServerLLGS::XMLEncodeAttributeValue(
   std::string result;
   for (const char &c : value) {
     switch (c) {
+    case '&':
+      result += "&amp;";
+      break;
     case '\'':
       result += "&apos;";
       break;

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -76,6 +76,7 @@
 #include "lldb/Utility/FileSpecList.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/RegisterTypeFlags.h"
+#include "lldb/Utility/RegisterValue.h"
 #include "lldb/Utility/State.h"
 #include "lldb/Utility/StreamString.h"
 #include "lldb/Utility/Timer.h"
@@ -5313,6 +5314,163 @@ void ParseFlags(
       });
 }
 
+static const RegisterTypeBuiltin *
+ResolveGDBBuiltinType(llvm::StringRef type_name) {
+  static const RegisterTypeBuiltin bool_type("bool", eEncodingUint,
+                                             eFormatBoolean, 1);
+  static const RegisterTypeBuiltin int8_type("int8", eEncodingSint,
+                                             eFormatDecimal, 1);
+  static const RegisterTypeBuiltin int16_type("int16", eEncodingSint,
+                                              eFormatDecimal, 2);
+  static const RegisterTypeBuiltin int32_type("int32", eEncodingSint,
+                                              eFormatDecimal, 4);
+  static const RegisterTypeBuiltin int64_type("int64", eEncodingSint,
+                                              eFormatDecimal, 8);
+  static const RegisterTypeBuiltin int128_type("int128", eEncodingSint,
+                                               eFormatDecimal, 16);
+  static const RegisterTypeBuiltin uint8_type("uint8", eEncodingUint,
+                                              eFormatHex, 1);
+  static const RegisterTypeBuiltin uint16_type("uint16", eEncodingUint,
+                                               eFormatHex, 2);
+  static const RegisterTypeBuiltin uint32_type("uint32", eEncodingUint,
+                                               eFormatHex, 4);
+  static const RegisterTypeBuiltin uint64_type("uint64", eEncodingUint,
+                                               eFormatHex, 8);
+  static const RegisterTypeBuiltin uint128_type("uint128", eEncodingUint,
+                                                eFormatHex, 16);
+  static const RegisterTypeBuiltin code_ptr_type("code_ptr", eEncodingUint,
+                                                 eFormatAddressInfo, 0);
+  static const RegisterTypeBuiltin data_ptr_type("data_ptr", eEncodingUint,
+                                                 eFormatAddressInfo, 0);
+  static const RegisterTypeBuiltin ieee_half_type("ieee_half", eEncodingIEEE754,
+                                                  eFormatFloat, 2);
+  static const RegisterTypeBuiltin ieee_single_type(
+      "ieee_single", eEncodingIEEE754, eFormatFloat, 4);
+  static const RegisterTypeBuiltin ieee_double_type(
+      "ieee_double", eEncodingIEEE754, eFormatFloat, 8);
+  static const RegisterTypeBuiltin arm_fpa_ext_type(
+      "arm_fpa_ext", eEncodingIEEE754, eFormatFloat, 12);
+  static const RegisterTypeBuiltin i387_ext_type("i387_ext", eEncodingIEEE754,
+                                                 eFormatFloat, 10);
+  static const RegisterTypeBuiltin bfloat16_type("bfloat16", eEncodingIEEE754,
+                                                 eFormatFloat, 2);
+
+  return llvm::StringSwitch<const RegisterTypeBuiltin *>(type_name)
+      .Case("bool", &bool_type)
+      .Case("int8", &int8_type)
+      .Case("int16", &int16_type)
+      .Case("int32", &int32_type)
+      .Case("int64", &int64_type)
+      .Case("int128", &int128_type)
+      .Case("uint8", &uint8_type)
+      .Case("uint16", &uint16_type)
+      .Case("uint32", &uint32_type)
+      .Case("uint64", &uint64_type)
+      .Case("uint128", &uint128_type)
+      .Case("code_ptr", &code_ptr_type)
+      .Case("data_ptr", &data_ptr_type)
+      .Case("ieee_half", &ieee_half_type)
+      .Case("ieee_single", &ieee_single_type)
+      .Case("ieee_double", &ieee_double_type)
+      .Case("arm_fpa_ext", &arm_fpa_ext_type)
+      .Case("i387_ext", &i387_ext_type)
+      .Case("bfloat16", &bfloat16_type)
+      .Default(nullptr);
+}
+
+static const RegisterType *
+ResolveGDBType(llvm::StringRef type_name,
+               const RegisterTypeMap &feature_register_types) {
+  auto type_it = feature_register_types.find(type_name);
+  if (type_it != feature_register_types.end())
+    return type_it->second;
+  return ResolveGDBBuiltinType(type_name);
+}
+
+static void
+ParseVector(const XMLNode &vector_node, RegisterTypeMap &feature_register_types,
+            std::vector<std::unique_ptr<RegisterType>> &owned_register_types) {
+  Log *log(GetLog(GDBRLog::Process));
+  std::optional<llvm::StringRef> id;
+  std::optional<llvm::StringRef> element_type_name;
+  std::optional<uint32_t> count;
+
+  vector_node.ForEachAttribute(
+      [&id, &element_type_name, &count, log](llvm::StringRef name,
+                                             llvm::StringRef value) {
+        if (name == "id") {
+          id = value;
+        } else if (name == "type") {
+          element_type_name = value;
+        } else if (name == "count") {
+          uint32_t parsed_count = 0;
+          if (llvm::to_integer(value, parsed_count))
+            count = parsed_count;
+          else
+            LLDB_LOG(log, "ProcessGDBRemote::ParseVector Invalid count \"{0}\"",
+                     value);
+        } else {
+          LLDB_LOG(log,
+                   "ProcessGDBRemote::ParseVector Ignoring unknown attribute "
+                   "\"{0}\"",
+                   name);
+        }
+        return true;
+      });
+
+  constexpr uint32_t max_vector_count = 65536;
+  if (!id || id->empty() || !element_type_name || element_type_name->empty() ||
+      !count || *count == 0 || *count > max_vector_count) {
+    LLDB_LOG(log, "ProcessGDBRemote::ParseVector Ignoring vector with invalid "
+                  "id, type, or count");
+    return;
+  }
+
+  if (feature_register_types.contains(*id)) {
+    LLDB_LOG(log,
+             "ProcessGDBRemote::ParseVector Ignoring duplicate type \"{0}\"",
+             *id);
+    return;
+  }
+
+  const RegisterType *element_type =
+      ResolveGDBType(*element_type_name, feature_register_types);
+  if (!element_type || (!llvm::isa<RegisterTypeBuiltin>(element_type) &&
+                        !llvm::isa<RegisterTypeVector>(element_type))) {
+    LLDB_LOG(log,
+             "ProcessGDBRemote::ParseVector Could not resolve element type "
+             "\"{0}\" for vector \"{1}\"",
+             *element_type_name, *id);
+    return;
+  }
+
+  std::optional<uint64_t> element_size = element_type->GetByteSize();
+  if (element_size &&
+      *element_size > RegisterValue::kMaxRegisterByteSize / *count) {
+    LLDB_LOG(log,
+             "ProcessGDBRemote::ParseVector Size of vector \"{0}\" is too "
+             "large",
+             *id);
+    return;
+  }
+
+  auto vector_type =
+      std::make_unique<RegisterTypeVector>(id->str(), element_type, *count);
+  feature_register_types.try_emplace(*id, vector_type.get());
+  owned_register_types.push_back(std::move(vector_type));
+}
+
+static void
+ParseVectors(XMLNode feature_node, RegisterTypeMap &feature_register_types,
+             std::vector<std::unique_ptr<RegisterType>> &owned_register_types) {
+  feature_node.ForEachChildElementWithName(
+      "vector", [&feature_register_types,
+                 &owned_register_types](const XMLNode &vector_node) {
+        ParseVector(vector_node, feature_register_types, owned_register_types);
+        return true;
+      });
+}
+
 bool ParseRegisters(
     XMLNode feature_node, GdbServerTargetInfo &target_info,
     std::vector<DynamicRegisterInfo::Register> &registers,
@@ -5335,6 +5493,8 @@ bool ParseRegisters(
     if (const auto *flags_type =
             llvm::dyn_cast<RegisterTypeFlags>(register_type.second))
       flags_type->DumpToLog(log);
+
+  ParseVectors(feature_node, feature_register_types, owned_register_types);
 
   feature_node.ForEachChildElementWithName(
       "reg",
@@ -5416,11 +5576,37 @@ bool ParseRegisters(
         });
 
         if (!gdb_type.empty()) {
-          // gdb_type could reference some flags type defined in XML.
           auto it = feature_register_types.find(gdb_type);
           if (it != feature_register_types.end()) {
-            if (const auto *flags_type =
-                    llvm::dyn_cast<RegisterTypeFlags>(it->second)) {
+            if (const auto *vector_type =
+                    llvm::dyn_cast<RegisterTypeVector>(it->second)) {
+              std::optional<uint64_t> type_size = vector_type->GetByteSize();
+              if (reg_info.byte_size > RegisterValue::kMaxRegisterByteSize) {
+                LLDB_LOG(log,
+                         "ProcessGDBRemote::ParseRegisters Register {0} is "
+                         "too large for vector type {1}",
+                         reg_info.name, vector_type->GetID());
+              } else if (!type_size || *type_size == reg_info.byte_size) {
+                reg_info.register_type = vector_type;
+                if (!encoding_set) {
+                  reg_info.encoding = eEncodingVector;
+                  encoding_set = true;
+                }
+                if (!format_set) {
+                  reg_info.format = eFormatVectorOfUInt8;
+                  format_set = true;
+                }
+              } else {
+                LLDB_LOG(
+                    log,
+                    "ProcessGDBRemote::ParseRegisters Size of register type "
+                    "{0} ({1} bytes) for register {2} does not match the "
+                    "register size ({3} bytes). Ignoring this type.",
+                    vector_type->GetID(), *type_size, reg_info.name,
+                    reg_info.byte_size);
+              }
+            } else if (const auto *flags_type =
+                           llvm::dyn_cast<RegisterTypeFlags>(it->second)) {
               if (reg_info.byte_size == flags_type->GetSize())
                 reg_info.register_type = flags_type;
               else
@@ -5434,10 +5620,7 @@ bool ParseRegisters(
             }
           }
 
-          // There's a slim chance that the gdb_type name is both a flags type
-          // and a simple type. Just in case, look for that too (setting both
-          // does no harm).
-          if (!gdb_type.empty() && !(encoding_set || format_set)) {
+          if (!(encoding_set || format_set)) {
             if (llvm::StringRef(gdb_type).starts_with("int")) {
               reg_info.format = eFormatHex;
               reg_info.encoding = eEncodingUint;
@@ -5460,6 +5643,18 @@ bool ParseRegisters(
               // registers.
               reg_info.format = eFormatVectorOfUInt8;
               reg_info.encoding = eEncodingVector;
+            } else if (const RegisterTypeBuiltin *builtin_type =
+                           ResolveGDBBuiltinType(gdb_type)) {
+              if (builtin_type->GetEncoding() != eEncodingIEEE754) {
+                reg_info.format = builtin_type->GetFormat();
+                reg_info.encoding = builtin_type->GetEncoding();
+              } else {
+                LLDB_LOG(log,
+                         "ProcessGDBRemote::ParseRegisters Keeping "
+                         "unsupported floating-point gdb type {0} as a raw "
+                         "integer",
+                         gdb_type);
+              }
             } else {
               LLDB_LOGF(
                   log,

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -5348,8 +5348,6 @@ ResolveGDBBuiltinType(llvm::StringRef type_name) {
       "ieee_single", eEncodingIEEE754, eFormatFloat, 4);
   static const RegisterTypeBuiltin ieee_double_type(
       "ieee_double", eEncodingIEEE754, eFormatFloat, 8);
-  static const RegisterTypeBuiltin arm_fpa_ext_type(
-      "arm_fpa_ext", eEncodingIEEE754, eFormatFloat, 12);
   static const RegisterTypeBuiltin i387_ext_type("i387_ext", eEncodingIEEE754,
                                                  eFormatFloat, 10);
   static const RegisterTypeBuiltin bfloat16_type("bfloat16", eEncodingIEEE754,
@@ -5372,7 +5370,6 @@ ResolveGDBBuiltinType(llvm::StringRef type_name) {
       .Case("ieee_half", &ieee_half_type)
       .Case("ieee_single", &ieee_single_type)
       .Case("ieee_double", &ieee_double_type)
-      .Case("arm_fpa_ext", &arm_fpa_ext_type)
       .Case("i387_ext", &i387_ext_type)
       .Case("bfloat16", &bfloat16_type)
       .Default(nullptr);

--- a/lldb/source/Plugins/RegisterTypeBuilder/RegisterTypeBuilderClang.cpp
+++ b/lldb/source/Plugins/RegisterTypeBuilder/RegisterTypeBuilderClang.cpp
@@ -10,7 +10,9 @@
 
 #include "RegisterTypeBuilderClang.h"
 #include "lldb/Core/PluginManager.h"
+#include "lldb/Utility/RegisterType.h"
 #include "lldb/lldb-enumerations.h"
+#include "llvm/ADT/bit.h"
 
 using namespace lldb_private;
 
@@ -32,6 +34,38 @@ RegisterTypeBuilderClang::CreateInstance(Target &target) {
 
 RegisterTypeBuilderClang::RegisterTypeBuilderClang(Target &target)
     : m_target(target) {}
+
+CompilerType RegisterTypeBuilderClang::BuildBuiltinType(
+    const RegisterTypeBuiltin *builtin_type, uint32_t available_byte_size,
+    lldb::TypeSystemClangSP type_system) {
+  if (auto type = GetExistingCompilerType(builtin_type, available_byte_size))
+    return *type;
+
+  CompilerType compiler_type;
+  clang::ASTContext &ast = type_system->getASTContext();
+  if (builtin_type->GetID() == "data_ptr" ||
+      builtin_type->GetID() == "code_ptr")
+    compiler_type = type_system->GetType(ast.VoidPtrTy);
+  else if (builtin_type->GetID() == "bfloat16")
+    compiler_type = type_system->GetType(ast.BFloat16Ty);
+  else if (builtin_type->GetID() == "ieee_half")
+    compiler_type = type_system->GetType(ast.HalfTy);
+  else if (builtin_type->GetID() == "bool")
+    compiler_type = type_system->GetType(ast.BoolTy);
+  else if (std::optional<uint64_t> byte_size = builtin_type->GetByteSize())
+    compiler_type = type_system->GetBuiltinTypeForEncodingAndBitSize(
+        builtin_type->GetEncoding(), *byte_size * 8);
+
+  if (!compiler_type.IsValid() ||
+      llvm::expectedToOptional(compiler_type.GetByteSize(nullptr)) !=
+          available_byte_size)
+    return {};
+
+  m_type_cache.try_emplace(
+      std::make_pair(builtin_type->GetUID(), available_byte_size),
+      compiler_type);
+  return compiler_type;
+}
 
 CompilerType
 RegisterTypeBuilderClang::BuildEnumType(const RegisterTypeEnum *enum_type_info,
@@ -110,6 +144,75 @@ CompilerType RegisterTypeBuilderClang::BuildFlagsType(
 }
 
 CompilerType
+RegisterTypeBuilderClang::BuildVectorType(const RegisterTypeVector *vector_type,
+                                          uint32_t available_byte_size,
+                                          lldb::TypeSystemClangSP type_system) {
+  if (!available_byte_size)
+    return {};
+  if (auto type = GetExistingCompilerType(vector_type, available_byte_size))
+    return *type;
+
+  std::optional<uint64_t> element_size =
+      vector_type->GetElementType()->GetByteSize();
+  if (!element_size) {
+    if (available_byte_size % vector_type->GetCount())
+      return {};
+    element_size = available_byte_size / vector_type->GetCount();
+  }
+  if (*element_size > UINT32_MAX ||
+      available_byte_size % vector_type->GetCount() ||
+      *element_size != available_byte_size / vector_type->GetCount())
+    return {};
+
+  CompilerType element_type;
+  const RegisterType *element_register_type = vector_type->GetElementType();
+  switch (element_register_type->getKind()) {
+  case RegisterType::eRegisterTypeKindBuiltin:
+    element_type =
+        BuildBuiltinType(llvm::cast<RegisterTypeBuiltin>(element_register_type),
+                         *element_size, type_system);
+    break;
+  case RegisterType::eRegisterTypeKindVector:
+    element_type =
+        BuildVectorType(llvm::cast<RegisterTypeVector>(element_register_type),
+                        *element_size, type_system);
+    break;
+  case RegisterType::eRegisterTypeKindEnum:
+  case RegisterType::eRegisterTypeKindFlags:
+    return {};
+  }
+  if (!element_type.IsValid())
+    return {};
+
+  const auto *builtin_element =
+      llvm::dyn_cast<RegisterTypeBuiltin>(element_register_type);
+  bool pointer_element =
+      builtin_element && (builtin_element->GetID() == "data_ptr" ||
+                          builtin_element->GetID() == "code_ptr");
+  bool use_vector = builtin_element && !pointer_element &&
+                    builtin_element->GetID() != "bool" &&
+                    llvm::has_single_bit(vector_type->GetCount());
+  CompilerType compiler_type = type_system->CreateArrayType(
+      element_type, vector_type->GetCount(), use_vector);
+
+  auto compiler_size =
+      llvm::expectedToOptional(compiler_type.GetByteSize(nullptr));
+  if (compiler_size != available_byte_size) {
+    compiler_type = type_system->CreateArrayType(
+        element_type, vector_type->GetCount(), /*is_vector=*/false);
+    compiler_size =
+        llvm::expectedToOptional(compiler_type.GetByteSize(nullptr));
+  }
+  if (compiler_size != available_byte_size)
+    return {};
+
+  m_type_cache.try_emplace(
+      std::make_pair(vector_type->GetUID(), available_byte_size),
+      compiler_type);
+  return compiler_type;
+}
+
+CompilerType
 RegisterTypeBuilderClang::GetRegisterType(const RegisterInfo &reg_info) {
   lldb::TypeSystemClangSP type_system =
       ScratchTypeSystemClang::GetForTarget(m_target);
@@ -128,6 +231,10 @@ RegisterTypeBuilderClang::GetRegisterType(const RegisterInfo &reg_info) {
   // methods may call each other (Flags may use Enums for example).
 
   switch (reg_info.register_type->getKind()) {
+  case RegisterType::eRegisterTypeKindBuiltin:
+    return BuildBuiltinType(
+        llvm::cast<RegisterTypeBuiltin>(reg_info.register_type),
+        reg_info.byte_size, type_system);
   case RegisterType::eRegisterTypeKindFlags:
     return BuildFlagsType(
         llvm::dyn_cast<RegisterTypeFlags>(reg_info.register_type),
@@ -135,6 +242,10 @@ RegisterTypeBuilderClang::GetRegisterType(const RegisterInfo &reg_info) {
   case RegisterType::eRegisterTypeKindEnum:
     return BuildEnumType(
         llvm::dyn_cast<RegisterTypeEnum>(reg_info.register_type),
+        reg_info.byte_size, type_system);
+  case RegisterType::eRegisterTypeKindVector:
+    return BuildVectorType(
+        llvm::cast<RegisterTypeVector>(reg_info.register_type),
         reg_info.byte_size, type_system);
   }
 }

--- a/lldb/source/Plugins/RegisterTypeBuilder/RegisterTypeBuilderClang.h
+++ b/lldb/source/Plugins/RegisterTypeBuilder/RegisterTypeBuilderClang.h
@@ -33,6 +33,10 @@ public:
   CompilerType GetRegisterType(const RegisterInfo &reg_info) override;
 
 private:
+  CompilerType BuildBuiltinType(const RegisterTypeBuiltin *builtin_type,
+                                uint32_t available_byte_size,
+                                lldb::TypeSystemClangSP type_system);
+
   CompilerType BuildEnumType(const RegisterTypeEnum *enum_type_info,
                              uint32_t register_byte_size,
                              lldb::TypeSystemClangSP type_system);
@@ -40,6 +44,10 @@ private:
   CompilerType BuildFlagsType(const RegisterTypeFlags *flags_info,
                               uint32_t register_byte_size,
                               lldb::TypeSystemClangSP type_system);
+
+  CompilerType BuildVectorType(const RegisterTypeVector *vector_type,
+                               uint32_t available_byte_size,
+                               lldb::TypeSystemClangSP type_system);
 
   Target &m_target;
 

--- a/lldb/source/Utility/RegisterType.cpp
+++ b/lldb/source/Utility/RegisterType.cpp
@@ -8,27 +8,82 @@
 
 #include "lldb/Utility/RegisterType.h"
 
+#include "lldb/Utility/Stream.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/Support/raw_ostream.h"
+
 #include <atomic>
+#include <cassert>
+#include <cinttypes>
+#include <limits>
 
 using namespace lldb_private;
 
-static std::atomic<uint64_t> g_next_register_type_uid{1};
+namespace {
+
+std::atomic<uint64_t> g_next_register_type_uid{1};
+
+void PrintXMLAttributeValue(Stream &strm, llvm::StringRef value) {
+  std::string escaped;
+  llvm::raw_string_ostream escape_strm(escaped);
+  llvm::printHTMLEscaped(value, escape_strm);
+  strm << escaped;
+}
+
+} // namespace
 
 RegisterType::RegisterType(RegisterTypeKind kind, std::string id)
     : m_kind(kind), m_id(std::move(id)),
       m_uid(g_next_register_type_uid.fetch_add(1, std::memory_order_relaxed)) {}
 
-void RegisterType::ToXML(
-    Stream &strm, std::unordered_set<const RegisterType *> &previously_emitted,
-    const RegisterType *user) const {
-  // If we already emitted this, don't emit it again.
-  if (!previously_emitted.insert(this).second)
+void RegisterType::ToXML(Stream &strm,
+                         std::unordered_set<std::string> &previously_emitted,
+                         const RegisterType *user) const {
+  if (getKind() == eRegisterTypeKindBuiltin)
     return;
 
-  // Emit this type's dependencies first.
+  if (!previously_emitted.insert(GetID()).second)
+    return;
+
   for (auto dep : m_dependencies)
     dep->ToXML(strm, previously_emitted, this);
 
-  // Finally emit this type.
   ToXMLElement(strm, user);
+}
+
+RegisterTypeBuiltin::RegisterTypeBuiltin(std::string id,
+                                         lldb::Encoding encoding,
+                                         lldb::Format format,
+                                         uint32_t byte_size)
+    : RegisterType(eRegisterTypeKindBuiltin, std::move(id)),
+      m_encoding(encoding), m_format(format), m_byte_size(byte_size) {}
+
+void RegisterTypeBuiltin::ToXMLElement(Stream &, const RegisterType *) const {}
+
+RegisterTypeVector::RegisterTypeVector(std::string id,
+                                       const RegisterType *element_type,
+                                       uint32_t count)
+    : RegisterType(eRegisterTypeKindVector, std::move(id)),
+      m_element_type(element_type), m_count(count) {
+  assert(m_element_type && "Vector element type cannot be null");
+  assert(m_count && "Vector element count cannot be zero");
+  SetDependencies({m_element_type});
+}
+
+std::optional<uint64_t> RegisterTypeVector::GetByteSize() const {
+  std::optional<uint64_t> element_size = m_element_type->GetByteSize();
+  if (!element_size ||
+      *element_size > std::numeric_limits<uint64_t>::max() / m_count)
+    return std::nullopt;
+  return *element_size * m_count;
+}
+
+void RegisterTypeVector::ToXMLElement(Stream &strm,
+                                      const RegisterType *) const {
+  strm.Indent();
+  strm << "<vector id=\"";
+  PrintXMLAttributeValue(strm, GetID());
+  strm << "\" type=\"";
+  PrintXMLAttributeValue(strm, m_element_type->GetID());
+  strm.Printf("\" count=\"%" PRIu32 "\"/>\n", m_count);
 }

--- a/lldb/source/Utility/RegisterTypeFlags.cpp
+++ b/lldb/source/Utility/RegisterTypeFlags.cpp
@@ -21,6 +21,17 @@
 
 using namespace lldb_private;
 
+namespace {
+
+void PrintXMLAttributeValue(Stream &strm, llvm::StringRef value) {
+  std::string escaped;
+  llvm::raw_string_ostream escape_strm(escaped);
+  llvm::printHTMLEscaped(value, escape_strm);
+  strm << escaped;
+}
+
+} // namespace
+
 RegisterTypeFlags::Field::Field(std::string name, unsigned start, unsigned end)
     : m_name(std::move(name)), m_start(start), m_end(end),
       m_enum_type(nullptr) {
@@ -335,7 +346,9 @@ void RegisterTypeEnum::ToXMLElement(Stream &strm,
   // it.
 
   strm.Indent();
-  strm << "<enum id=\"" << GetID() << "\"";
+  strm << "<enum id=\"";
+  PrintXMLAttributeValue(strm, GetID());
+  strm << "\"";
 
   // We don't expect the user of an enum type to be anything but a register,
   // but we cannot crash if that isn't true.
@@ -389,7 +402,9 @@ void RegisterTypeFlags::ToXMLElement(Stream &strm,
   //   <field name="incorrect" start="0" end="0"/>
   // </flags>
   strm.Indent();
-  strm << "<flags id=\"" << GetID() << "\" ";
+  strm << "<flags id=\"";
+  PrintXMLAttributeValue(strm, GetID());
+  strm << "\" ";
   strm.Printf("size=\"%d\"", GetSize());
   strm << ">";
   for (const Field &field : m_fields) {
@@ -421,8 +436,11 @@ void RegisterTypeFlags::Field::ToXMLElement(Stream &strm) const {
 
   strm.Printf("start=\"%d\" end=\"%d\"", GetStart(), GetEnd());
 
-  if (const RegisterTypeEnum *enum_type = GetEnum())
-    strm << " type=\"" << enum_type->GetID() << "\"";
+  if (const RegisterTypeEnum *enum_type = GetEnum()) {
+    strm << " type=\"";
+    PrintXMLAttributeValue(strm, enum_type->GetID());
+    strm << "\"";
+  }
 
   strm << "/>";
 }

--- a/lldb/source/Utility/RegisterValue.cpp
+++ b/lldb/source/Utility/RegisterValue.cpp
@@ -8,6 +8,7 @@
 
 #include "lldb/Utility/RegisterValue.h"
 
+#include "lldb/Utility/DataBufferHeap.h"
 #include "lldb/Utility/DataExtractor.h"
 #include "lldb/Utility/Scalar.h"
 #include "lldb/Utility/Status.h"
@@ -19,6 +20,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <string>
 #include <tuple>
@@ -33,6 +35,36 @@ using namespace lldb_private;
 
 bool RegisterValue::GetData(DataExtractor &data) const {
   return data.SetData(GetBytes(), GetByteSize(), GetByteOrder()) > 0;
+}
+
+bool RegisterValue::GetData(DataExtractor &data, const RegisterInfo &reg_info,
+                            lldb::ByteOrder byte_order) const {
+  DataExtractor source;
+  if (!GetData(source) || source.GetByteSize() < reg_info.byte_size)
+    return false;
+
+  const lldb::ByteOrder source_byte_order = source.GetByteOrder();
+  if ((source_byte_order != lldb::eByteOrderBig &&
+       source_byte_order != lldb::eByteOrderLittle) ||
+      (byte_order != lldb::eByteOrderBig &&
+       byte_order != lldb::eByteOrderLittle))
+    return false;
+
+  auto buffer_sp = std::make_shared<DataBufferHeap>(reg_info.byte_size, 0);
+  size_t source_offset = source_byte_order == lldb::eByteOrderBig
+                             ? source.GetByteSize() - reg_info.byte_size
+                             : 0;
+  const uint8_t *source_bytes = source.GetDataStart() + source_offset;
+  uint8_t *destination_bytes = buffer_sp->GetBytes();
+  if (source_byte_order == byte_order)
+    std::copy_n(source_bytes, reg_info.byte_size, destination_bytes);
+  else
+    std::reverse_copy(source_bytes, source_bytes + reg_info.byte_size,
+                      destination_bytes);
+
+  data.Clear();
+  data.SetByteOrder(byte_order);
+  return data.SetData(buffer_sp) == reg_info.byte_size;
 }
 
 uint32_t RegisterValue::GetAsMemoryData(const RegisterInfo &reg_info, void *dst,

--- a/lldb/source/ValueObject/ValueObjectRegister.cpp
+++ b/lldb/source/ValueObject/ValueObjectRegister.cpp
@@ -20,6 +20,7 @@
 #include "lldb/Utility/DataExtractor.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
+#include "lldb/Utility/RegisterType.h"
 #include "lldb/Utility/Scalar.h"
 #include "lldb/Utility/Status.h"
 #include "lldb/Utility/Stream.h"
@@ -207,27 +208,38 @@ ValueObjectRegister::ValueObjectRegister(ExecutionContextScope *exe_scope,
 ValueObjectRegister::~ValueObjectRegister() = default;
 
 CompilerType ValueObjectRegister::GetCompilerTypeImpl() {
-  if (!m_compiler_type.IsValid()) {
-    ExecutionContext exe_ctx(GetExecutionContextRef());
-    if (auto *target = exe_ctx.GetTargetPtr()) {
-      if (auto *exe_module = target->GetExecutableModulePointer()) {
-        auto type_system_or_err =
-            exe_module->GetTypeSystemForLanguage(eLanguageTypeC);
-        if (auto err = type_system_or_err.takeError()) {
-          LLDB_LOG_ERROR(GetLog(LLDBLog::Types), std::move(err),
-                         "Unable to get CompilerType from TypeSystem: {0}");
-        } else {
-          if (auto ts = *type_system_or_err)
-            m_compiler_type = ts->GetBuiltinTypeForEncodingAndBitSize(
-                m_reg_info.encoding, m_reg_info.byte_size * 8);
-        }
-      }
+  ExecutionContext exe_ctx(GetExecutionContextRef());
+  Target *target = exe_ctx.GetTargetPtr();
+  if (target && llvm::isa_and_present<RegisterTypeBuiltin, RegisterTypeVector>(
+                    m_reg_info.register_type)) {
+    CompilerType register_type = target->GetRegisterType(m_reg_info);
+    if (register_type.IsValid())
+      return register_type;
+  }
+
+  if (!m_compiler_type.IsValid() && target) {
+    auto *exe_module = target->GetExecutableModulePointer();
+    if (!exe_module)
+      return m_compiler_type;
+    auto type_system_or_err =
+        exe_module->GetTypeSystemForLanguage(eLanguageTypeC);
+    if (auto err = type_system_or_err.takeError()) {
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Types), std::move(err),
+                     "Unable to get CompilerType from TypeSystem: {0}");
+    } else {
+      if (auto ts = *type_system_or_err)
+        m_compiler_type = ts->GetBuiltinTypeForEncodingAndBitSize(
+            m_reg_info.encoding, m_reg_info.byte_size * 8);
     }
   }
   return m_compiler_type;
 }
 
 ConstString ValueObjectRegister::GetTypeName() {
+  if (llvm::isa_and_present<RegisterTypeBuiltin, RegisterTypeVector>(
+          m_reg_info.register_type))
+    return GetCompilerType().GetTypeName();
+
   if (m_type_name.IsEmpty())
     m_type_name = GetCompilerType().GetTypeName();
   return m_type_name;

--- a/lldb/test/API/functionalities/gdb_remote_client/TestXMLRegisterVector.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestXMLRegisterVector.py
@@ -333,17 +333,17 @@ class TestXMLRegisterVector(GDBRemoteTestBase):
             """\
             <reg name="half" regnum="0" bitsize="16" type="ieee_half"/>
             <reg name="bfloat" regnum="1" bitsize="16" type="bfloat16"/>
-            <reg name="fpa" regnum="2" bitsize="96" type="arm_fpa_ext"/>
+            <reg name="x87" regnum="2" bitsize="80" type="i387_ext"/>
             <reg name="pc" bitsize="64"/>""",
-            "0102" "0304" "05060708090a0b0c0d0e0f10" "0000000000000000",
+            "0102" "0304" "05060708090a0b0c0d0e" "0000000000000000",
         )
 
         frame = process.GetThreadAtIndex(0).GetFrameAtIndex(0)
         self.assertEqual(frame.FindRegister("half").GetData().uint8[:2], [1, 2])
         self.assertEqual(frame.FindRegister("bfloat").GetData().uint8[:2], [3, 4])
         self.assertEqual(
-            frame.FindRegister("fpa").GetData().uint8[:12],
-            list(range(5, 17)),
+            frame.FindRegister("x87").GetData().uint8[:10],
+            list(range(5, 15)),
         )
 
     @skipIfXmlSupportMissing

--- a/lldb/test/API/functionalities/gdb_remote_client/TestXMLRegisterVector.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestXMLRegisterVector.py
@@ -1,0 +1,439 @@
+"""Test vectors from GDB remote target description XML."""
+
+from textwrap import dedent
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.gdbclientutils import *
+from lldbsuite.test.lldbgdbclient import GDBRemoteTestBase
+from lldbsuite.test.lldbtest import *
+
+
+class MultiDocResponder(MockGDBServerResponder):
+    def __init__(self, docs, register_data):
+        super().__init__()
+        self.docs = docs
+        self.register_data = register_data
+
+    def qXferRead(self, obj, annex, offset, length):
+        try:
+            return self.docs[annex], False
+        except KeyError:
+            return (None,)
+
+    def readRegister(self, regnum):
+        return "E01"
+
+    def readRegisters(self):
+        return self.register_data
+
+
+class TestXMLRegisterVector(GDBRemoteTestBase):
+    def setup_multidoc_test(self, docs, register_data):
+        self.server.responder = MultiDocResponder(docs, register_data)
+        target = self.dbg.CreateTarget("")
+
+        if self.TraceOn():
+            self.runCmd("log enable gdb-remote packets process")
+            self.addTearDownHook(
+                lambda: self.runCmd("log disable gdb-remote packets process")
+            )
+
+        process = self.connect(target)
+        lldbutil.expect_state_changes(
+            self, self.dbg.GetListener(), process, [lldb.eStateStopped]
+        )
+        return process
+
+    def setup_register_test(self, definitions, register_data, architecture="aarch64"):
+        return self.setup_multidoc_test(
+            {
+                "target.xml": dedent(
+                    """\
+                <?xml version="1.0"?>
+                <target version="1.0">
+                  <architecture>{}</architecture>
+                  <feature name="test.register.vectors">
+                    {}
+                  </feature>
+                </target>"""
+                ).format(architecture, definitions)
+            },
+            register_data,
+        )
+
+    def assert_float_children(self, value, expected):
+        self.assertTrue(value.IsValid())
+        self.assertTrue(value.MightHaveChildren())
+        self.assertEqual(value.GetNumChildren(), len(expected))
+        for index, expected_value in enumerate(expected):
+            child = value.GetChildAtIndex(index)
+            self.assertTrue(child.IsValid())
+            self.assertEqual(child.GetName(), "[{}]".format(index))
+            self.assertEqual(child.GetTypeName(), "float")
+            self.assertAlmostEqual(child.GetData().float[0], expected_value)
+            self.assertAlmostEqual(float(child.GetValue()), expected_value)
+
+    @skipIfXmlSupportMissing
+    @skipIfRemote
+    def test_direct_vector_cli_and_sb_api(self):
+        process = self.setup_register_test(
+            """\
+            <vector id="v4f" type="ieee_single" count="4"/>
+            <reg name="v0" regnum="0" bitsize="128" type="v4f"/>
+            <reg name="pc" bitsize="64"/>""",
+            "0000c03f000020400000604000009040" "0000000000000000",
+        )
+
+        self.expect(
+            "register read v0",
+            substrs=[
+                "v0 = {0x00 0x00 0xc0 0x3f",
+                "[0] = 1.5",
+                "[1] = 2.5",
+                "[2] = 3.5",
+                "[3] = 4.5",
+            ],
+        )
+        self.expect("register info v0", substrs=["Vector elements: 4"])
+
+        frame = process.GetThreadAtIndex(0).GetFrameAtIndex(0)
+        vector = frame.FindRegister("v0")
+        self.assertEqual(vector.GetName(), "v0")
+        self.assertEqual(vector.GetByteSize(), 16)
+        self.assertTrue(vector.GetType().IsValid())
+        self.assertEqual(vector.GetType().GetByteSize(), 16)
+        self.assertIn("float", vector.GetTypeName())
+        self.assert_float_children(vector, [1.5, 2.5, 3.5, 4.5])
+
+        lane = vector.GetValueForExpressionPath("[2]")
+        self.assertTrue(lane.IsValid())
+        self.assertAlmostEqual(lane.GetData().float[0], 3.5)
+
+        self.assertFalse(vector.IsDynamic())
+        self.assertTrue(vector.IsSynthetic())
+        self.assertTrue(vector.GetDynamicValue(lldb.eDynamicCanRunTarget).IsValid())
+        self.assertTrue(vector.GetSyntheticValue().IsValid())
+        self.assertTrue(vector.GetNonSyntheticValue().IsValid())
+        self.assertFalse(vector.GetNonSyntheticValue().IsSynthetic())
+        self.assertFalse(frame.FindRegister("v0[2]").IsValid())
+        self.assertFalse(frame.FindRegister("does_not_exist").IsValid())
+
+    @skipIfXmlSupportMissing
+    @skipIfRemote
+    def test_byte_vector_sb_api(self):
+        process = self.setup_register_test(
+            """\
+            <vector id="bytes32" type="uint8" count="32"/>
+            <reg name="bytes" regnum="0" bitsize="256" type="bytes32"/>
+            <reg name="pc" bitsize="64"/>""",
+            "".join("{:02x}".format(value) for value in range(32)) + "0000000000000000",
+        )
+
+        frame = process.GetThreadAtIndex(0).GetFrameAtIndex(0)
+        vector = frame.FindRegister("bytes")
+        self.assertEqual(vector.GetByteSize(), 32)
+        self.assertEqual(vector.GetNumChildren(), 32)
+        self.assertEqual(vector.GetData().uint8[:32], list(range(32)))
+
+        lane = vector.GetValueForExpressionPath("[16]")
+        self.assertTrue(lane.IsValid())
+        error = lldb.SBError()
+        self.assertEqual(lane.GetValueAsUnsigned(error, 0xDEADBEEF), 0x10)
+        self.assertTrue(error.Success())
+
+    @skipIfXmlSupportMissing
+    @skipIfRemote
+    def test_three_lane_vector_exact_layout(self):
+        process = self.setup_register_test(
+            """\
+            <vector id="v3f" type="ieee_single" count="3"/>
+            <reg name="v0" regnum="0" bitsize="96" type="v3f"/>
+            <reg name="pc" bitsize="64"/>""",
+            "0000c03f0000204000006040" "0000000000000000",
+        )
+
+        self.expect(
+            "register read v0",
+            substrs=[
+                "v0 = {0x00 0x00 0xc0 0x3f",
+                "[0] = 1.5",
+                "[1] = 2.5",
+                "[2] = 3.5",
+            ],
+        )
+
+        vector = process.GetThreadAtIndex(0).GetFrameAtIndex(0).FindRegister("v0")
+        self.assertEqual(vector.GetByteSize(), 12)
+        self.assertEqual(vector.GetTypeName(), "float[3]")
+        self.assert_float_children(vector, [1.5, 2.5, 3.5])
+
+    @skipIfXmlSupportMissing
+    @skipIfRemote
+    def test_nested_vectors(self):
+        process = self.setup_register_test(
+            """\
+            <vector id="v2f" type="ieee_single" count="2"/>
+            <vector id="v2v2f" type="v2f" count="2"/>
+            <reg name="v0" regnum="0" bitsize="128" type="v2v2f"/>
+            <reg name="pc" bitsize="64"/>""",
+            "0000c03f000020400000604000009040" "0000000000000000",
+        )
+
+        self.expect(
+            "register read v0",
+            substrs=[
+                "[0] = ([0] = 1.5, [1] = 2.5)",
+                "[1] = ([0] = 3.5, [1] = 4.5)",
+            ],
+        )
+
+        vector = process.GetThreadAtIndex(0).GetFrameAtIndex(0).FindRegister("v0")
+        self.assertEqual(vector.GetNumChildren(), 2)
+        self.assert_float_children(vector.GetChildAtIndex(0), [1.5, 2.5])
+        self.assert_float_children(vector.GetChildAtIndex(1), [3.5, 4.5])
+        lane = vector.GetValueForExpressionPath("[1][0]")
+        self.assertTrue(lane.IsValid())
+        self.assertAlmostEqual(lane.GetData().float[0], 3.5)
+
+    @skipIfXmlSupportMissing
+    @skipIfRemote
+    def test_invalid_vectors_are_ignored(self):
+        process = self.setup_register_test(
+            """\
+            <vector id="bad_count" type="ieee_single" count="nope"/>
+            <vector id="zero" type="ieee_single" count="0"/>
+            <vector id="too_many" type="ieee_single" count="65537"/>
+            <vector id="unknown" type="missing" count="2"/>
+            <vector id="forward" type="later" count="1"/>
+            <vector id="missing_type" count="2"/>
+            <vector id="missing_count" type="ieee_single"/>
+            <vector id="too_large" type="uint128" count="4097"/>
+            <vector type="ieee_single" count="2"/>
+            <vector id="later" type="ieee_single" count="2"/>
+            <flags id="flags" size="8">
+              <field name="bit" start="0" end="0"/>
+            </flags>
+            <vector id="flags_vector" type="flags" count="2"/>
+            <vector id="v4f" type="ieee_single" count="4"/>
+            <reg name="bad_count" regnum="0" bitsize="64" type="bad_count"/>
+            <reg name="zero" regnum="1" bitsize="64" type="zero"/>
+            <reg name="too_many" regnum="2" bitsize="64" type="too_many"/>
+            <reg name="unknown" regnum="3" bitsize="64" type="unknown"/>
+            <reg name="forward" regnum="4" bitsize="64" type="forward"/>
+            <reg name="missing_type" regnum="5" bitsize="64"
+                 type="missing_type"/>
+            <reg name="missing_count" regnum="6" bitsize="64"
+                 type="missing_count"/>
+            <reg name="too_large" regnum="7" bitsize="64" type="too_large"/>
+            <reg name="later" regnum="8" bitsize="64" type="later"/>
+            <reg name="flags_vector" regnum="9" bitsize="128"
+                 type="flags_vector"/>
+            <reg name="bad_size" regnum="10" bitsize="64" type="v4f"/>
+            <reg name="pc" bitsize="64"/>""",
+            "0000000000000000" * 8
+            + "0000c03f00002040"
+            + "00" * 16
+            + "0000000000000000" * 2,
+        )
+
+        frame = process.GetThreadAtIndex(0).GetFrameAtIndex(0)
+        for name in [
+            "bad_count",
+            "zero",
+            "too_many",
+            "unknown",
+            "forward",
+            "missing_type",
+            "missing_count",
+            "too_large",
+            "flags_vector",
+            "bad_size",
+        ]:
+            value = frame.FindRegister(name)
+            self.assertTrue(value.IsValid())
+            self.assertEqual(value.GetNumChildren(), 0)
+
+        self.assert_float_children(frame.FindRegister("later"), [1.5, 2.5])
+
+    @skipIfXmlSupportMissing
+    @skipIfRemote
+    def test_duplicate_vector_id_uses_first_definition(self):
+        process = self.setup_register_test(
+            """\
+            <vector id="shared" type="ieee_single" count="2"/>
+            <vector id="shared" type="ieee_single" count="4"/>
+            <reg name="v0" regnum="0" bitsize="64" type="shared"/>
+            <reg name="pc" bitsize="64"/>""",
+            "0000c03f00002040" "0000000000000000",
+        )
+
+        vector = process.GetThreadAtIndex(0).GetFrameAtIndex(0).FindRegister("v0")
+        self.assert_float_children(vector, [1.5, 2.5])
+
+    @skipIfXmlSupportMissing
+    @skipIfRemote
+    def test_target_type_precedes_builtin_type(self):
+        process = self.setup_register_test(
+            """\
+            <vector id="ieee_single" type="uint16" count="2"/>
+            <vector id="nested" type="ieee_single" count="2"/>
+            <reg name="v0" regnum="0" bitsize="64" type="nested"/>
+            <reg name="pc" bitsize="64"/>""",
+            "0100020003000400" "0000000000000000",
+        )
+
+        vector = process.GetThreadAtIndex(0).GetFrameAtIndex(0).FindRegister("v0")
+        self.assertEqual(vector.GetNumChildren(), 2)
+        self.assertEqual(
+            [
+                vector.GetChildAtIndex(outer)
+                .GetChildAtIndex(inner)
+                .GetValueAsUnsigned()
+                for outer in range(2)
+                for inner in range(2)
+            ],
+            [1, 2, 3, 4],
+        )
+
+    @skipIfXmlSupportMissing
+    @skipIfRemote
+    def test_bool_and_single_uint128_vectors(self):
+        process = self.setup_register_test(
+            """\
+            <vector id="v4b" type="bool" count="4"/>
+            <vector id="v1u128" type="uint128" count="1"/>
+            <reg name="bools" regnum="0" bitsize="32" type="v4b"/>
+            <reg name="wide" regnum="1" bitsize="128" type="v1u128"/>
+            <reg name="pc" bitsize="64"/>""",
+            "00010100" "01000000000000000000000000000000" "0000000000000000",
+        )
+
+        frame = process.GetThreadAtIndex(0).GetFrameAtIndex(0)
+        bools = frame.FindRegister("bools")
+        self.assertEqual(bools.GetTypeName(), "bool[4]")
+        self.assertEqual(bools.GetNumChildren(), 4)
+        self.assertEqual(
+            [bools.GetChildAtIndex(i).GetValueAsUnsigned() for i in range(4)],
+            [0, 1, 1, 0],
+        )
+
+        wide = frame.FindRegister("wide")
+        self.assertEqual(wide.GetNumChildren(), 1)
+        wide_child = wide.GetChildAtIndex(0)
+        expected_bytes = [1] + [0] * 15
+        self.assertEqual(wide.GetData().uint8[:16], expected_bytes)
+        self.assertEqual(wide_child.GetData().uint8[:16], expected_bytes)
+        self.assertEqual(wide_child.GetValue(), "1")
+
+    @skipIfXmlSupportMissing
+    @skipIfRemote
+    def test_unsupported_direct_float_builtins_remain_readable(self):
+        process = self.setup_register_test(
+            """\
+            <reg name="half" regnum="0" bitsize="16" type="ieee_half"/>
+            <reg name="bfloat" regnum="1" bitsize="16" type="bfloat16"/>
+            <reg name="fpa" regnum="2" bitsize="96" type="arm_fpa_ext"/>
+            <reg name="pc" bitsize="64"/>""",
+            "0102" "0304" "05060708090a0b0c0d0e0f10" "0000000000000000",
+        )
+
+        frame = process.GetThreadAtIndex(0).GetFrameAtIndex(0)
+        self.assertEqual(frame.FindRegister("half").GetData().uint8[:2], [1, 2])
+        self.assertEqual(frame.FindRegister("bfloat").GetData().uint8[:2], [3, 4])
+        self.assertEqual(
+            frame.FindRegister("fpa").GetData().uint8[:12],
+            list(range(5, 17)),
+        )
+
+    @skipIfXmlSupportMissing
+    @skipIfRemote
+    def test_vector_ids_are_scoped_to_included_feature(self):
+        process = self.setup_multidoc_test(
+            {
+                "target.xml": dedent(
+                    """\
+                <?xml version="1.0"?>
+                <target version="1.0">
+                  <architecture>aarch64</architecture>
+                  <xi:include href="first.xml"/>
+                  <xi:include href="second.xml"/>
+                  <xi:include href="third.xml"/>
+                </target>"""
+                ),
+                "first.xml": dedent(
+                    """\
+                <?xml version="1.0"?>
+                <feature name="feature.first">
+                  <vector id="shared" type="ieee_single" count="2"/>
+                  <reg name="first" regnum="0" bitsize="64" type="shared"/>
+                </feature>"""
+                ),
+                "second.xml": dedent(
+                    """\
+                <?xml version="1.0"?>
+                <feature name="feature.second">
+                  <vector id="shared" type="ieee_single" count="4"/>
+                  <reg name="second" regnum="1" bitsize="128" type="shared"/>
+                </feature>"""
+                ),
+                "third.xml": dedent(
+                    """\
+                <?xml version="1.0"?>
+                <feature name="feature.third">
+                  <reg name="unresolved" regnum="2" bitsize="64" type="shared"/>
+                  <reg name="pc" bitsize="64"/>
+                </feature>"""
+                ),
+            },
+            "0000c03f00002040"
+            "0000c03f000020400000604000009040"
+            "0100000000000000"
+            "0000000000000000",
+        )
+
+        frame = process.GetThreadAtIndex(0).GetFrameAtIndex(0)
+        self.assert_float_children(frame.FindRegister("first"), [1.5, 2.5])
+        self.assert_float_children(frame.FindRegister("second"), [1.5, 2.5, 3.5, 4.5])
+        self.assertEqual(frame.FindRegister("unresolved").GetNumChildren(), 0)
+
+    @skipIfXmlSupportMissing
+    @skipIfRemote
+    def test_explicit_format_suppresses_typed_output(self):
+        self.setup_register_test(
+            """\
+            <vector id="v4f" type="ieee_single" count="4"/>
+            <reg name="v0" regnum="0" bitsize="128" type="v4f"/>
+            <reg name="pc" bitsize="64"/>""",
+            "0000c03f000020400000604000009040" "0000000000000000",
+        )
+
+        self.expect(
+            "register read -f hex v0",
+            substrs=["v0 = 0x4090000040600000402000003fc00000"],
+        )
+        self.expect("register read -f hex v0", matching=False, substrs=["[0] ="])
+
+    @skipIfXmlSupportMissing
+    @skipIfRemote
+    @skipIfLLVMTargetMissing("SystemZ")
+    def test_big_endian_vector(self):
+        process = self.setup_register_test(
+            """\
+            <vector id="v2f" type="ieee_single" count="2"/>
+            <reg name="v0" regnum="0" bitsize="64" type="v2f"/>
+            <reg name="pswa" bitsize="64"/>""",
+            "3fc0000040200000" "0000000000000000",
+            architecture="s390x",
+        )
+
+        self.expect(
+            "register read v0",
+            substrs=[
+                "v0 = {0x3f 0xc0 0x00 0x00 0x40 0x20 0x00 0x00}",
+                "[0] = 1.5",
+                "[1] = 2.5",
+            ],
+        )
+        vector = process.GetThreadAtIndex(0).GetFrameAtIndex(0).FindRegister("v0")
+        self.assert_float_children(vector, [1.5, 2.5])

--- a/lldb/unittests/Core/DumpRegisterInfoTest.cpp
+++ b/lldb/unittests/Core/DumpRegisterInfoTest.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "lldb/Core/DumpRegisterInfo.h"
+#include "lldb/Utility/RegisterType.h"
 #include "lldb/Utility/RegisterTypeFlags.h"
 #include "lldb/Utility/StreamString.h"
 #include "gtest/gtest.h"
@@ -132,4 +133,17 @@ TEST(DoDumpRegisterInfoTest, Enumerators) {
             "A: 0 = an_enumerator\n"
             "\n"
             "C: 1 = another_enumerator, 2 = another_enumerator_2");
+}
+
+TEST(DoDumpRegisterInfoTest, VectorElements) {
+  StreamString strm;
+  RegisterTypeBuiltin element_type("ieee_single", lldb::eEncodingIEEE754,
+                                   lldb::eFormatFloat, 4);
+  RegisterTypeVector vector_type("v4f", &element_type, 4);
+
+  DoDumpRegisterInfo(strm, "v0", nullptr, 16, {}, {}, {}, &vector_type, 100);
+  ASSERT_EQ(strm.GetString(), "       Name: v0\n"
+                              "       Size: 16 bytes (128 bits)\n"
+                              "\n"
+                              "  Vector elements: 4");
 }

--- a/lldb/unittests/Target/RegisterTypeBuilderClangTest.cpp
+++ b/lldb/unittests/Target/RegisterTypeBuilderClangTest.cpp
@@ -16,6 +16,7 @@
 #include "lldb/Host/HostInfo.h"
 #include "lldb/Utility/ArchSpec.h"
 #include "lldb/Utility/RegisterInfo.h"
+#include "lldb/Utility/RegisterType.h"
 #include "lldb/Utility/RegisterTypeFlags.h"
 #include "gtest/gtest.h"
 
@@ -158,6 +159,122 @@ TEST_F(RegisterTypeBuilderClangTest, CacheFollowsScratchTypeSystem) {
   ASSERT_TRUE(second_type_system);
   EXPECT_NE(first_type_system, second_type_system);
   EXPECT_NE(first, second);
+}
+
+TEST_F(RegisterTypeBuilderClangTest, BuildsPowerOfTwoVector) {
+  Target &target = m_debugger_sp->GetDummyTarget();
+  RegisterTypeBuiltin element_type("ieee_single", eEncodingIEEE754,
+                                   eFormatFloat, 4);
+  RegisterTypeVector vector_type("v4f", &element_type, 4);
+  RegisterTypeBuilderClang builder(target);
+
+  CompilerType type =
+      builder.GetRegisterType(MakeRegisterInfo(vector_type, 16));
+
+  ASSERT_TRUE(type);
+  EXPECT_EQ(llvm::expectedToOptional(type.GetByteSize(nullptr)), 16u);
+  EXPECT_NE(type.GetTypeInfo() & eTypeIsVector, 0u);
+  EXPECT_EQ(llvm::expectedToOptional(type.GetNumChildren(true, nullptr)), 4u);
+}
+
+TEST_F(RegisterTypeBuilderClangTest, PreservesThreeLaneVectorLayout) {
+  Target &target = m_debugger_sp->GetDummyTarget();
+  RegisterTypeBuiltin element_type("ieee_single", eEncodingIEEE754,
+                                   eFormatFloat, 4);
+  RegisterTypeVector vector_type("v3f", &element_type, 3);
+  RegisterTypeBuilderClang builder(target);
+
+  CompilerType type =
+      builder.GetRegisterType(MakeRegisterInfo(vector_type, 12));
+
+  ASSERT_TRUE(type);
+  EXPECT_EQ(llvm::expectedToOptional(type.GetByteSize(nullptr)), 12u);
+  EXPECT_NE(type.GetTypeInfo() & eTypeIsArray, 0u);
+  EXPECT_EQ(type.GetTypeInfo() & eTypeIsVector, 0u);
+  EXPECT_EQ(llvm::expectedToOptional(type.GetNumChildren(true, nullptr)), 3u);
+}
+
+TEST_F(RegisterTypeBuilderClangTest, BuildsNestedVectors) {
+  Target &target = m_debugger_sp->GetDummyTarget();
+  RegisterTypeBuiltin element_type("ieee_single", eEncodingIEEE754,
+                                   eFormatFloat, 4);
+  RegisterTypeVector inner_type("v2f", &element_type, 2);
+  RegisterTypeVector outer_type("v2v2f", &inner_type, 2);
+  RegisterTypeBuilderClang builder(target);
+
+  CompilerType type = builder.GetRegisterType(MakeRegisterInfo(outer_type, 16));
+
+  ASSERT_TRUE(type);
+  EXPECT_EQ(llvm::expectedToOptional(type.GetByteSize(nullptr)), 16u);
+  EXPECT_NE(type.GetTypeInfo() & eTypeIsArray, 0u);
+  EXPECT_EQ(llvm::expectedToOptional(type.GetNumChildren(true, nullptr)), 2u);
+
+  CompilerType inner = type.GetArrayElementType(nullptr);
+  ASSERT_TRUE(inner);
+  EXPECT_NE(inner.GetTypeInfo() & eTypeIsVector, 0u);
+  EXPECT_EQ(llvm::expectedToOptional(inner.GetNumChildren(true, nullptr)), 2u);
+}
+
+TEST_F(RegisterTypeBuilderClangTest, BuildsTargetSizedPointerVector) {
+  Target &target = m_debugger_sp->GetDummyTarget();
+  RegisterTypeBuiltin pointer_type("data_ptr", eEncodingUint,
+                                   eFormatAddressInfo, 0);
+  RegisterTypeVector vector_type("v2p", &pointer_type, 2);
+  RegisterTypeBuilderClang builder(target);
+
+  CompilerType type =
+      builder.GetRegisterType(MakeRegisterInfo(vector_type, 16));
+
+  ASSERT_TRUE(type);
+  EXPECT_EQ(llvm::expectedToOptional(type.GetByteSize(nullptr)), 16u);
+  EXPECT_NE(type.GetTypeInfo() & eTypeIsArray, 0u);
+  EXPECT_EQ(llvm::expectedToOptional(type.GetNumChildren(true, nullptr)), 2u);
+}
+
+TEST_F(RegisterTypeBuilderClangTest, BuildsBoolVectorAsArray) {
+  Target &target = m_debugger_sp->GetDummyTarget();
+  RegisterTypeBuiltin element_type("bool", eEncodingUint, eFormatBoolean, 1);
+  RegisterTypeVector vector_type("v4b", &element_type, 4);
+  RegisterTypeBuilderClang builder(target);
+
+  CompilerType type = builder.GetRegisterType(MakeRegisterInfo(vector_type, 4));
+
+  ASSERT_TRUE(type);
+  EXPECT_EQ(llvm::expectedToOptional(type.GetByteSize(nullptr)), 4u);
+  EXPECT_NE(type.GetTypeInfo() & eTypeIsArray, 0u);
+  EXPECT_EQ(type.GetTypeInfo() & eTypeIsVector, 0u);
+  EXPECT_EQ(llvm::expectedToOptional(type.GetNumChildren(true, nullptr)), 4u);
+}
+
+TEST_F(RegisterTypeBuilderClangTest, BuildsSingleUint128Vector) {
+  Target &target = m_debugger_sp->GetDummyTarget();
+  RegisterTypeBuiltin element_type("uint128", eEncodingUint, eFormatHex, 16);
+  RegisterTypeVector vector_type("v1u128", &element_type, 1);
+  RegisterTypeBuilderClang builder(target);
+
+  CompilerType type =
+      builder.GetRegisterType(MakeRegisterInfo(vector_type, 16));
+
+  ASSERT_TRUE(type);
+  EXPECT_EQ(llvm::expectedToOptional(type.GetByteSize(nullptr)), 16u);
+  EXPECT_NE(type.GetTypeInfo() & eTypeIsVector, 0u);
+  EXPECT_EQ(llvm::expectedToOptional(type.GetNumChildren(true, nullptr)), 1u);
+}
+
+TEST_F(RegisterTypeBuilderClangTest, RejectsVectorSizeMismatch) {
+  Target &target = m_debugger_sp->GetDummyTarget();
+  RegisterTypeBuiltin float_type("ieee_single", eEncodingIEEE754, eFormatFloat,
+                                 4);
+  RegisterTypeVector float_vector("v4f", &float_type, 4);
+  RegisterTypeBuiltin pointer_type("data_ptr", eEncodingUint,
+                                   eFormatAddressInfo, 0);
+  RegisterTypeVector pointer_vector("v2p", &pointer_type, 2);
+  RegisterTypeBuilderClang builder(target);
+
+  EXPECT_FALSE(builder.GetRegisterType(MakeRegisterInfo(float_vector, 12)));
+  EXPECT_FALSE(builder.GetRegisterType(MakeRegisterInfo(float_vector, 20)));
+  EXPECT_FALSE(builder.GetRegisterType(MakeRegisterInfo(pointer_vector, 0)));
+  EXPECT_FALSE(builder.GetRegisterType(MakeRegisterInfo(pointer_vector, 15)));
 }
 
 } // namespace

--- a/lldb/unittests/Utility/RegisterTypeTest.cpp
+++ b/lldb/unittests/Utility/RegisterTypeTest.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "lldb/Utility/RegisterType.h"
 #include "lldb/Utility/RegisterTypeFlags.h"
 #include "lldb/Utility/StreamString.h"
 #include "gmock/gmock.h"
@@ -499,9 +500,6 @@ TEST(RegisterTypeTest, RegisterTypeFlagsToXML) {
   // then the flags set itself. There should only be one definition of each
   // enum, even if it is used by multiple fields.
 
-  // In the server we assume that each type has a unqiue address and use
-  // that to deduplicate them. So here we heap allocate them to simulate that.
-
   StreamString strm;
   auto enum_a = std::make_shared<RegisterTypeEnum>(
       "enum_a",
@@ -513,9 +511,9 @@ TEST(RegisterTypeTest, RegisterTypeFlagsToXML) {
       "enum_c",
       RegisterTypeEnum::Enumerators{RegisterTypeEnum::Enumerator(2, "two")});
 
-  std::unordered_set<const RegisterType *> previously_emitted;
+  std::unordered_set<std::string> previously_emitted;
   // Pretend that enum_c was already emitted for a different flag set.
-  previously_emitted.insert(enum_c.get());
+  previously_emitted.insert(enum_c->GetID());
 
   std::vector<RegisterTypeFlags::Field> fields{
       RegisterTypeFlags::Field("f1", 31, 31, enum_a.get()),
@@ -524,7 +522,7 @@ TEST(RegisterTypeTest, RegisterTypeFlagsToXML) {
       RegisterTypeFlags::Field("f4", 27, 28, enum_c.get()),
   };
 
-  auto TestFlags = std::make_shared<RegisterTypeFlags>("Test", 4, fields);
+  auto TestFlags = std::make_shared<RegisterTypeFlags>("Test2", 4, fields);
   TestFlags->ToXML(strm, previously_emitted);
   ASSERT_EQ(strm.GetString(),
             "<enum id=\"enum_a\" size=\"4\">\n"
@@ -533,7 +531,7 @@ TEST(RegisterTypeTest, RegisterTypeFlagsToXML) {
             "<enum id=\"enum_b\" size=\"4\">\n"
             "  <evalue name=\"one\" value=\"1\"/>\n"
             "</enum>\n"
-            "<flags id=\"Test\" size=\"4\">\n"
+            "<flags id=\"Test2\" size=\"4\">\n"
             "  <field name=\"f1\" start=\"31\" end=\"31\" type=\"enum_a\"/>\n"
             "  <field name=\"f2\" start=\"30\" end=\"30\" type=\"enum_a\"/>\n"
             "  <field name=\"f3\" start=\"29\" end=\"29\" type=\"enum_b\"/>\n"
@@ -566,4 +564,111 @@ TEST(RegisterTypeTest, RegisterTypeFlagsToXML) {
   strm.Clear();
   TestFlags2->ToXML(strm, previously_emitted);
   ASSERT_EQ(strm.GetString(), "");
+}
+
+TEST(RegisterTypeBuiltinTest, Construction) {
+  RegisterTypeBuiltin type("ieee_single", eEncodingIEEE754, eFormatFloat, 4);
+  EXPECT_EQ(type.GetID(), "ieee_single");
+  EXPECT_EQ(type.GetEncoding(), eEncodingIEEE754);
+  EXPECT_EQ(type.GetFormat(), eFormatFloat);
+  ASSERT_TRUE(type.GetByteSize());
+  EXPECT_EQ(*type.GetByteSize(), 4u);
+
+  StreamString strm;
+  std::unordered_set<std::string> previously_emitted;
+  type.ToXML(strm, previously_emitted);
+  EXPECT_TRUE(strm.GetString().empty());
+}
+
+TEST(RegisterTypeBuiltinTest, TargetDependentByteSize) {
+  RegisterTypeBuiltin pointer_type("data_ptr", eEncodingUint,
+                                   eFormatAddressInfo, 0);
+  EXPECT_FALSE(pointer_type.GetByteSize());
+
+  RegisterTypeVector vector_type("pointers", &pointer_type, 2);
+  EXPECT_FALSE(vector_type.GetByteSize());
+}
+
+TEST(RegisterTypeVectorTest, ConstructionAndXML) {
+  RegisterTypeBuiltin element_type("ieee_single", eEncodingIEEE754,
+                                   eFormatFloat, 4);
+  RegisterTypeVector vector_type("v4f", &element_type, 4);
+
+  EXPECT_EQ(vector_type.GetID(), "v4f");
+  EXPECT_EQ(vector_type.GetElementType(), &element_type);
+  EXPECT_EQ(vector_type.GetCount(), 4u);
+  ASSERT_TRUE(vector_type.GetByteSize());
+  EXPECT_EQ(*vector_type.GetByteSize(), 16u);
+
+  StreamString strm;
+  std::unordered_set<std::string> previously_emitted;
+  vector_type.ToXML(strm, previously_emitted);
+  EXPECT_EQ(strm.GetString(),
+            "<vector id=\"v4f\" type=\"ieee_single\" count=\"4\"/>\n");
+}
+
+TEST(RegisterTypeVectorTest, NestedVectorXML) {
+  RegisterTypeBuiltin element_type("ieee_single", eEncodingIEEE754,
+                                   eFormatFloat, 4);
+  RegisterTypeVector inner_type("v2f", &element_type, 2);
+  RegisterTypeVector outer_type("v2v2f", &inner_type, 2);
+
+  ASSERT_TRUE(outer_type.GetByteSize());
+  EXPECT_EQ(*outer_type.GetByteSize(), 16u);
+
+  StreamString strm;
+  std::unordered_set<std::string> previously_emitted;
+  outer_type.ToXML(strm, previously_emitted);
+  EXPECT_EQ(strm.GetString(),
+            "<vector id=\"v2f\" type=\"ieee_single\" count=\"2\"/>\n"
+            "<vector id=\"v2v2f\" type=\"v2f\" count=\"2\"/>\n");
+}
+
+TEST(RegisterTypeVectorTest, ByteSizeOverflow) {
+  RegisterTypeBuiltin large_element("large", eEncodingUint, eFormatHex,
+                                    UINT32_MAX);
+  RegisterTypeVector large_vector("large_vector", &large_element, UINT32_MAX);
+  ASSERT_TRUE(large_vector.GetByteSize());
+
+  RegisterTypeVector overflow("overflow", &large_vector, 2);
+  EXPECT_FALSE(overflow.GetByteSize());
+}
+
+TEST(RegisterTypeVectorTest, XMLAttributeEscaping) {
+  RegisterTypeBuiltin element_type("u<&\"'", eEncodingUint, eFormatHex, 1);
+  RegisterTypeVector vector_type("v<&\"'", &element_type, 4);
+
+  StreamString strm;
+  std::unordered_set<std::string> previously_emitted;
+  vector_type.ToXML(strm, previously_emitted);
+  EXPECT_EQ(strm.GetString(),
+            "<vector id=\"v&lt;&amp;&quot;&apos;\" "
+            "type=\"u&lt;&amp;&quot;&apos;\" count=\"4\"/>\n");
+}
+
+TEST(RegisterTypeVectorTest, XMLDefinitionsAreDeduplicatedByID) {
+  RegisterTypeBuiltin element_type("uint8", eEncodingUint, eFormatHex, 1);
+  RegisterTypeVector first("same_id", &element_type, 2);
+  RegisterTypeVector second("same_id", &element_type, 4);
+
+  StreamString strm;
+  std::unordered_set<std::string> previously_emitted;
+  first.ToXML(strm, previously_emitted);
+  second.ToXML(strm, previously_emitted);
+  EXPECT_EQ(strm.GetString(),
+            "<vector id=\"same_id\" type=\"uint8\" count=\"2\"/>\n");
+}
+
+TEST(RegisterTypeVectorTest, BuiltinDependencyDoesNotReserveID) {
+  RegisterTypeBuiltin builtin("uint8", eEncodingUint, eFormatHex, 1);
+  RegisterTypeVector uses_builtin("bytes", &builtin, 2);
+  RegisterTypeVector shadows_builtin("uint8", &builtin, 4);
+
+  StreamString strm;
+  std::unordered_set<std::string> previously_emitted;
+  uses_builtin.ToXML(strm, previously_emitted);
+  shadows_builtin.ToXML(strm, previously_emitted);
+  EXPECT_EQ(strm.GetString(),
+            "<vector id=\"bytes\" type=\"uint8\" count=\"2\"/>\n"
+            "<vector id=\"uint8\" type=\"uint8\" count=\"4\"/>\n");
 }

--- a/lldb/unittests/Utility/RegisterValueTest.cpp
+++ b/lldb/unittests/Utility/RegisterValueTest.cpp
@@ -57,6 +57,99 @@ TEST(RegisterValueTest, GetScalarValue) {
                    APInt(128, 0x7766554433221100)));
 }
 
+TEST(RegisterValueTest, GetDataInTargetByteOrder) {
+  uint8_t big_endian_bytes[] = {0x01, 0x02, 0x03};
+  RegisterInfo reg_info{"test",
+                        nullptr,
+                        sizeof(big_endian_bytes),
+                        0,
+                        lldb::eEncodingUint,
+                        lldb::eFormatHex,
+                        {0, 0, 0, LLDB_INVALID_REGNUM, 0},
+                        nullptr,
+                        nullptr,
+                        nullptr};
+  DataExtractor source(big_endian_bytes, sizeof(big_endian_bytes),
+                       lldb::eByteOrderBig, 8);
+  RegisterValue value;
+  ASSERT_TRUE(value.SetValueFromData(reg_info, source, 0, false).Success());
+
+  DataExtractor target_data;
+  ASSERT_TRUE(value.GetData(target_data, reg_info, lldb::eByteOrderBig));
+  EXPECT_EQ(target_data.GetByteOrder(), lldb::eByteOrderBig);
+  EXPECT_EQ(
+      llvm::ArrayRef(target_data.GetDataStart(), target_data.GetByteSize()),
+      llvm::ArrayRef(big_endian_bytes));
+
+  ASSERT_TRUE(value.GetData(target_data, reg_info, lldb::eByteOrderLittle));
+  EXPECT_EQ(target_data.GetByteOrder(), lldb::eByteOrderLittle);
+  uint8_t little_endian_bytes[] = {0x03, 0x02, 0x01};
+  EXPECT_EQ(
+      llvm::ArrayRef(target_data.GetDataStart(), target_data.GetByteSize()),
+      llvm::ArrayRef(little_endian_bytes));
+
+  uint8_t padded_big_endian_bytes[] = {0x00, 0x01, 0x02, 0x03};
+  RegisterValue padded_value(llvm::ArrayRef(padded_big_endian_bytes),
+                             lldb::eByteOrderBig);
+  ASSERT_TRUE(padded_value.GetData(target_data, reg_info, lldb::eByteOrderBig));
+  EXPECT_EQ(
+      llvm::ArrayRef(target_data.GetDataStart(), target_data.GetByteSize()),
+      llvm::ArrayRef(big_endian_bytes));
+}
+
+TEST(RegisterValueTest, GetDataRejectsUnsupportedByteOrder) {
+  uint8_t bytes[] = {0x01, 0x02, 0x03};
+  RegisterInfo reg_info{"test",
+                        nullptr,
+                        sizeof(bytes),
+                        0,
+                        lldb::eEncodingUint,
+                        lldb::eFormatHex,
+                        {0, 0, 0, LLDB_INVALID_REGNUM, 0},
+                        nullptr,
+                        nullptr,
+                        nullptr};
+  DataExtractor data;
+
+  RegisterValue invalid_source(llvm::ArrayRef(bytes), lldb::eByteOrderInvalid);
+  EXPECT_FALSE(invalid_source.GetData(data, reg_info, lldb::eByteOrderLittle));
+
+  RegisterValue pdp_source(llvm::ArrayRef(bytes), lldb::eByteOrderPDP);
+  EXPECT_FALSE(pdp_source.GetData(data, reg_info, lldb::eByteOrderLittle));
+
+  RegisterValue little_source(llvm::ArrayRef(bytes), lldb::eByteOrderLittle);
+  EXPECT_FALSE(little_source.GetData(data, reg_info, lldb::eByteOrderInvalid));
+  EXPECT_FALSE(little_source.GetData(data, reg_info, lldb::eByteOrderPDP));
+}
+
+TEST(RegisterValueTest, GetScalarDataInTargetByteOrder) {
+  RegisterInfo reg_info{"test",
+                        nullptr,
+                        8,
+                        0,
+                        lldb::eEncodingUint,
+                        lldb::eFormatHex,
+                        {0, 0, 0, LLDB_INVALID_REGNUM, 0},
+                        nullptr,
+                        nullptr,
+                        nullptr};
+  RegisterValue value(uint64_t{0x0102030405060708});
+  DataExtractor target_data;
+
+  uint8_t big_endian_bytes[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+  ASSERT_TRUE(value.GetData(target_data, reg_info, lldb::eByteOrderBig));
+  EXPECT_EQ(
+      llvm::ArrayRef(target_data.GetDataStart(), target_data.GetByteSize()),
+      llvm::ArrayRef(big_endian_bytes));
+
+  uint8_t little_endian_bytes[] = {0x08, 0x07, 0x06, 0x05,
+                                   0x04, 0x03, 0x02, 0x01};
+  ASSERT_TRUE(value.GetData(target_data, reg_info, lldb::eByteOrderLittle));
+  EXPECT_EQ(
+      llvm::ArrayRef(target_data.GetDataStart(), target_data.GetByteSize()),
+      llvm::ArrayRef(little_endian_bytes));
+}
+
 void TestSetValueFromData(const Scalar &etalon, void *src, size_t src_byte_size,
                           const lldb::ByteOrder endianness,
                           const RegisterValue::Type register_value_type) {


### PR DESCRIPTION
Add support for GDB remote target description `<vector>` register types.

This commit will allow to do the following:
- Resolves GDB predefined scalar types used as vector elements.
- Parses direct and nested vector definitions.
- Validates element counts, sizes, duplicate IDs, and forward references.
- Builds exact Clang vector types, using arrays when vector padding would change the XML layout.
- Preserves target byte order when exposing register data.
- Displays raw register bytes followed by structured lane values.
- Exposes vector lanes through the `SBValue ` API.
- Serializes vector definitions through `lldb-server` target XML.
- Falls back to raw register display when an exact compiler type cannot be built.

Examples:
```
<vector id="v4f" type="ieee_single" count="4"/>
<reg name="v0" bitsize="128" type="v4f"/>

(lldb) register read v0
v0 = {0x00 0x00 0xc0 0x3f ...}
     = ([0] = 1.5, [1] = 2.5, [2] = 3.5, [3] = 4.5)
```

The SB APi can also access individual lanes:
```
v0 = frame.FindRegister("v0")
v0.GetNumChildren() # 4
v0.GetChildAtIndex(2).GetValue() # "3.5"
v0.GetValueForExpressionPath("[2]").GetValue() # "3.5"
```

Non power of 2 vectors preserve their exact layouf as well `<vector id="v3f" type="ieee_single" count="3"/>` will produce a 12 byte `float[3]` rather than a padded 16 byye vector. 