### PR TITLE
[M68k] Fix build after IRTranslator rename to IRTranslatorLegacy

### DIFF
--- a/llvm/lib/Target/M68k/M68kTargetMachine.cpp
+++ b/llvm/lib/Target/M68k/M68kTargetMachine.cpp
@@ -144,7 +144,7 @@ bool M68kPassConfig::addInstSelector() {
 }
 
 bool M68kPassConfig::addIRTranslator() {
-  addPass(new IRTranslator());
+  addPass(new IRTranslatorLegacy());
   return false;
 }
 


### PR DESCRIPTION
Regression introduced by f442901707f9 ("[NewPM] Port ir-translator"), which renamed the legacy pass but missed the M68k target.