### PR TITLE
[libc] Make classification functions use the emulated float128 type

### DIFF
--- a/libc/config/baremetal/aarch64/entrypoints.txt
+++ b/libc/config/baremetal/aarch64/entrypoints.txt
@@ -482,6 +482,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.iscanonicall
     libc.src.math.isnan
     libc.src.math.isnanf
+    libc.src.math.isnanf128
     libc.src.math.isnanl
     libc.src.math.issignaling
     libc.src.math.issignalingf
@@ -776,7 +777,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fsubf128
     libc.src.math.getpayloadf128
     libc.src.math.ilogbf128
-    libc.src.math.isnanf128
     libc.src.math.issignalingf128
     libc.src.math.ldexpf128
     libc.src.math.llogbf128

--- a/libc/config/baremetal/aarch64/entrypoints.txt
+++ b/libc/config/baremetal/aarch64/entrypoints.txt
@@ -478,6 +478,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ilogbl
     libc.src.math.iscanonical
     libc.src.math.iscanonicalf
+    libc.src.math.iscanonicalf128
     libc.src.math.iscanonicall
     libc.src.math.isnan
     libc.src.math.isnanf
@@ -775,7 +776,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fsubf128
     libc.src.math.getpayloadf128
     libc.src.math.ilogbf128
-    libc.src.math.iscanonicalf128
     libc.src.math.isnanf128
     libc.src.math.issignalingf128
     libc.src.math.ldexpf128

--- a/libc/config/baremetal/aarch64/entrypoints.txt
+++ b/libc/config/baremetal/aarch64/entrypoints.txt
@@ -486,6 +486,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.isnanl
     libc.src.math.issignaling
     libc.src.math.issignalingf
+    libc.src.math.issignalingf128
     libc.src.math.issignalingl
     libc.src.math.ldexp
     libc.src.math.ldexpf
@@ -777,7 +778,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fsubf128
     libc.src.math.getpayloadf128
     libc.src.math.ilogbf128
-    libc.src.math.issignalingf128
     libc.src.math.ldexpf128
     libc.src.math.llogbf128
     libc.src.math.logbf128

--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -498,6 +498,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.isnanl
     libc.src.math.issignaling
     libc.src.math.issignalingf
+    libc.src.math.issignalingf128
     libc.src.math.issignalingl
     libc.src.math.ldexp
     libc.src.math.ldexpf
@@ -788,7 +789,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fsubf128
     libc.src.math.getpayloadf128
     libc.src.math.ilogbf128
-    libc.src.math.issignalingf128
     libc.src.math.ldexpf128
     libc.src.math.llogbf128
     libc.src.math.logbf128

--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -494,6 +494,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.iscanonicall
     libc.src.math.isnan
     libc.src.math.isnanf
+    libc.src.math.isnanf128
     libc.src.math.isnanl
     libc.src.math.issignaling
     libc.src.math.issignalingf
@@ -787,7 +788,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fsubf128
     libc.src.math.getpayloadf128
     libc.src.math.ilogbf128
-    libc.src.math.isnanf128
     libc.src.math.issignalingf128
     libc.src.math.ldexpf128
     libc.src.math.llogbf128

--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -490,6 +490,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ilogbl
     libc.src.math.iscanonical
     libc.src.math.iscanonicalf
+    libc.src.math.iscanonicalf128
     libc.src.math.iscanonicall
     libc.src.math.isnan
     libc.src.math.isnanf
@@ -786,7 +787,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fsubf128
     libc.src.math.getpayloadf128
     libc.src.math.ilogbf128
-    libc.src.math.iscanonicalf128
     libc.src.math.isnanf128
     libc.src.math.issignalingf128
     libc.src.math.ldexpf128

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -494,6 +494,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.isnanl
     libc.src.math.issignaling
     libc.src.math.issignalingf
+    libc.src.math.issignalingf128
     libc.src.math.issignalingl
     libc.src.math.ldexp
     libc.src.math.ldexpf
@@ -785,7 +786,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fsubf128
     libc.src.math.getpayloadf128
     libc.src.math.ilogbf128
-    libc.src.math.issignalingf128
     libc.src.math.ldexpf128
     libc.src.math.llogbf128
     libc.src.math.logbf128

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -486,6 +486,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ilogbl
     libc.src.math.iscanonical
     libc.src.math.iscanonicalf
+    libc.src.math.iscanonicalf128
     libc.src.math.iscanonicall
     libc.src.math.isnan
     libc.src.math.isnanf
@@ -783,7 +784,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fsubf128
     libc.src.math.getpayloadf128
     libc.src.math.ilogbf128
-    libc.src.math.iscanonicalf128
     libc.src.math.isnanf128
     libc.src.math.issignalingf128
     libc.src.math.ldexpf128

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -490,6 +490,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.iscanonicall
     libc.src.math.isnan
     libc.src.math.isnanf
+    libc.src.math.isnanf128
     libc.src.math.isnanl
     libc.src.math.issignaling
     libc.src.math.issignalingf
@@ -784,7 +785,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fsubf128
     libc.src.math.getpayloadf128
     libc.src.math.ilogbf128
-    libc.src.math.isnanf128
     libc.src.math.issignalingf128
     libc.src.math.ldexpf128
     libc.src.math.llogbf128

--- a/libc/config/darwin/aarch64/entrypoints.txt
+++ b/libc/config/darwin/aarch64/entrypoints.txt
@@ -305,6 +305,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.isnanl
     libc.src.math.issignaling
     libc.src.math.issignalingf
+    libc.src.math.issignalingf128
     libc.src.math.issignalingl
     libc.src.math.ldexp
     libc.src.math.ldexpf
@@ -597,7 +598,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fsubf128
     libc.src.math.getpayloadf128
     libc.src.math.ilogbf128
-    libc.src.math.issignalingf128
     libc.src.math.ldexpf128
     libc.src.math.llogbf128
     libc.src.math.logbf128

--- a/libc/config/darwin/aarch64/entrypoints.txt
+++ b/libc/config/darwin/aarch64/entrypoints.txt
@@ -301,6 +301,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.iscanonicall
     libc.src.math.isnan
     libc.src.math.isnanf
+    libc.src.math.isnanf128
     libc.src.math.isnanl
     libc.src.math.issignaling
     libc.src.math.issignalingf
@@ -596,7 +597,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fsubf128
     libc.src.math.getpayloadf128
     libc.src.math.ilogbf128
-    libc.src.math.isnanf128
     libc.src.math.issignalingf128
     libc.src.math.ldexpf128
     libc.src.math.llogbf128

--- a/libc/config/darwin/aarch64/entrypoints.txt
+++ b/libc/config/darwin/aarch64/entrypoints.txt
@@ -297,6 +297,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ilogbl
     libc.src.math.iscanonical
     libc.src.math.iscanonicalf
+    libc.src.math.iscanonicalf128
     libc.src.math.iscanonicall
     libc.src.math.isnan
     libc.src.math.isnanf
@@ -595,7 +596,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fsubf128
     libc.src.math.getpayloadf128
     libc.src.math.ilogbf128
-    libc.src.math.iscanonicalf128
     libc.src.math.isnanf128
     libc.src.math.issignalingf128
     libc.src.math.ldexpf128

--- a/libc/config/darwin/x86_64/entrypoints.txt
+++ b/libc/config/darwin/x86_64/entrypoints.txt
@@ -173,6 +173,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     #libc.src.math.ilogb
     #libc.src.math.ilogbf
     #libc.src.math.ilogbl
+    #libc.src.math.iscanonicalf128
     #libc.src.math.llrint
     #libc.src.math.llrintf
     #libc.src.math.llrintf128

--- a/libc/config/darwin/x86_64/entrypoints.txt
+++ b/libc/config/darwin/x86_64/entrypoints.txt
@@ -174,6 +174,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     #libc.src.math.ilogbf
     #libc.src.math.ilogbl
     #libc.src.math.iscanonicalf128
+    #libc.src.math.isnanf128
     #libc.src.math.llrint
     #libc.src.math.llrintf
     #libc.src.math.llrintf128

--- a/libc/config/darwin/x86_64/entrypoints.txt
+++ b/libc/config/darwin/x86_64/entrypoints.txt
@@ -175,6 +175,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     #libc.src.math.ilogbl
     #libc.src.math.iscanonicalf128
     #libc.src.math.isnanf128
+    #libc.src.math.issignalingf128
     #libc.src.math.llrint
     #libc.src.math.llrintf
     #libc.src.math.llrintf128

--- a/libc/config/freebsd/x86_64/entrypoints.txt
+++ b/libc/config/freebsd/x86_64/entrypoints.txt
@@ -219,6 +219,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ilogbl
     libc.src.math.iscanonicalf128
     libc.src.math.isnanf128
+    libc.src.math.issignalingf128
     libc.src.math.ldexp
     libc.src.math.ldexpf
     libc.src.math.ldexpl
@@ -536,7 +537,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fsubf128
     libc.src.math.getpayloadf128
     libc.src.math.ilogbf128
-    libc.src.math.issignalingf128
     libc.src.math.ldexpf128
     libc.src.math.llogbf128
     libc.src.math.logbf128

--- a/libc/config/freebsd/x86_64/entrypoints.txt
+++ b/libc/config/freebsd/x86_64/entrypoints.txt
@@ -217,6 +217,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ilogb
     libc.src.math.ilogbf
     libc.src.math.ilogbl
+    libc.src.math.iscanonicalf128
     libc.src.math.ldexp
     libc.src.math.ldexpf
     libc.src.math.ldexpl
@@ -534,7 +535,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fsubf128
     libc.src.math.getpayloadf128
     libc.src.math.ilogbf128
-    libc.src.math.iscanonicalf128
     libc.src.math.issignalingf128
     libc.src.math.ldexpf128
     libc.src.math.llogbf128

--- a/libc/config/freebsd/x86_64/entrypoints.txt
+++ b/libc/config/freebsd/x86_64/entrypoints.txt
@@ -218,6 +218,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ilogbf
     libc.src.math.ilogbl
     libc.src.math.iscanonicalf128
+    libc.src.math.isnanf128
     libc.src.math.ldexp
     libc.src.math.ldexpf
     libc.src.math.ldexpl

--- a/libc/config/gpu/amdgpu/entrypoints.txt
+++ b/libc/config/gpu/amdgpu/entrypoints.txt
@@ -428,6 +428,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.isnanf
     libc.src.math.isnanf128
     libc.src.math.isnanl
+    libc.src.math.issignalingf128
     libc.src.math.ldexp
     libc.src.math.ldexpf
     libc.src.math.ldexpl

--- a/libc/config/gpu/amdgpu/entrypoints.txt
+++ b/libc/config/gpu/amdgpu/entrypoints.txt
@@ -426,6 +426,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.iscanonicalf128
     libc.src.math.isnan
     libc.src.math.isnanf
+    libc.src.math.isnanf128
     libc.src.math.isnanl
     libc.src.math.ldexp
     libc.src.math.ldexpf

--- a/libc/config/gpu/amdgpu/entrypoints.txt
+++ b/libc/config/gpu/amdgpu/entrypoints.txt
@@ -423,6 +423,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ilogb
     libc.src.math.ilogbf
     libc.src.math.ilogbl
+    libc.src.math.iscanonicalf128
     libc.src.math.isnan
     libc.src.math.isnanf
     libc.src.math.isnanl

--- a/libc/config/gpu/nvptx/entrypoints.txt
+++ b/libc/config/gpu/nvptx/entrypoints.txt
@@ -423,6 +423,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.iscanonicalf128
     libc.src.math.isnan
     libc.src.math.isnanf
+    libc.src.math.isnanf128
     libc.src.math.isnanl
     libc.src.math.ldexp
     libc.src.math.ldexpf

--- a/libc/config/gpu/nvptx/entrypoints.txt
+++ b/libc/config/gpu/nvptx/entrypoints.txt
@@ -425,6 +425,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.isnanf
     libc.src.math.isnanf128
     libc.src.math.isnanl
+    libc.src.math.issignalingf128
     libc.src.math.ldexp
     libc.src.math.ldexpf
     libc.src.math.ldexpl

--- a/libc/config/gpu/nvptx/entrypoints.txt
+++ b/libc/config/gpu/nvptx/entrypoints.txt
@@ -420,6 +420,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ilogb
     libc.src.math.ilogbf
     libc.src.math.ilogbl
+    libc.src.math.iscanonicalf128
     libc.src.math.isnan
     libc.src.math.isnanf
     libc.src.math.isnanl

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -642,6 +642,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.iscanonicall
     libc.src.math.isnan
     libc.src.math.isnanf
+    libc.src.math.isnanf128
     libc.src.math.isnanl
     libc.src.math.issignaling
     libc.src.math.issignalingf
@@ -930,7 +931,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fsubf128
     libc.src.math.getpayloadf128
     libc.src.math.ilogbf128
-    libc.src.math.isnanf128
     libc.src.math.issignalingf128
     libc.src.math.ldexpf128
     libc.src.math.llogbf128

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -638,6 +638,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ilogbl
     libc.src.math.iscanonical
     libc.src.math.iscanonicalf
+    libc.src.math.iscanonicalf128
     libc.src.math.iscanonicall
     libc.src.math.isnan
     libc.src.math.isnanf
@@ -929,7 +930,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fsubf128
     libc.src.math.getpayloadf128
     libc.src.math.ilogbf128
-    libc.src.math.iscanonicalf128
     libc.src.math.isnanf128
     libc.src.math.issignalingf128
     libc.src.math.ldexpf128

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -646,6 +646,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.isnanl
     libc.src.math.issignaling
     libc.src.math.issignalingf
+    libc.src.math.issignalingf128
     libc.src.math.issignalingl
     libc.src.math.ldexp
     libc.src.math.ldexpf
@@ -931,7 +932,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fsubf128
     libc.src.math.getpayloadf128
     libc.src.math.ilogbf128
-    libc.src.math.issignalingf128
     libc.src.math.ldexpf128
     libc.src.math.llogbf128
     libc.src.math.logbf128

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -460,6 +460,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ilogbf
     libc.src.math.ilogbl
     libc.src.math.iscanonicalf128
+    libc.src.math.isnanf128
     libc.src.math.ldexp
     libc.src.math.ldexpf
     libc.src.math.ldexpl

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -459,6 +459,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ilogb
     libc.src.math.ilogbf
     libc.src.math.ilogbl
+    libc.src.math.iscanonicalf128
     libc.src.math.ldexp
     libc.src.math.ldexpf
     libc.src.math.ldexpl

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -461,6 +461,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ilogbl
     libc.src.math.iscanonicalf128
     libc.src.math.isnanf128
+    libc.src.math.issignalingf128
     libc.src.math.ldexp
     libc.src.math.ldexpf
     libc.src.math.ldexpl

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -710,6 +710,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.iscanonicall
     libc.src.math.isnan
     libc.src.math.isnanf
+    libc.src.math.isnanf128
     libc.src.math.isnanl
     libc.src.math.issignaling
     libc.src.math.issignalingf
@@ -1015,7 +1016,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fsubf128
     libc.src.math.getpayloadf128
     libc.src.math.ilogbf128
-    libc.src.math.isnanf128
     libc.src.math.issignalingf128
     libc.src.math.ldexpf128
     libc.src.math.llogbf128

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -706,6 +706,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ilogbl
     libc.src.math.iscanonical
     libc.src.math.iscanonicalf
+    libc.src.math.iscanonicalf128
     libc.src.math.iscanonicall
     libc.src.math.isnan
     libc.src.math.isnanf
@@ -1014,7 +1015,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fsubf128
     libc.src.math.getpayloadf128
     libc.src.math.ilogbf128
-    libc.src.math.iscanonicalf128
     libc.src.math.isnanf128
     libc.src.math.issignalingf128
     libc.src.math.ldexpf128

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -714,6 +714,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.isnanl
     libc.src.math.issignaling
     libc.src.math.issignalingf
+    libc.src.math.issignalingf128
     libc.src.math.issignalingl
     libc.src.math.ldexp
     libc.src.math.ldexpf
@@ -1016,7 +1017,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fsubf128
     libc.src.math.getpayloadf128
     libc.src.math.ilogbf128
-    libc.src.math.issignalingf128
     libc.src.math.ldexpf128
     libc.src.math.llogbf128
     libc.src.math.logbf128

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -720,6 +720,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.iscanonicall
     libc.src.math.isnan
     libc.src.math.isnanf
+    libc.src.math.isnanf128
     libc.src.math.isnanl
     libc.src.math.issignaling
     libc.src.math.issignalingf
@@ -1025,7 +1026,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fsubf128
     libc.src.math.getpayloadf128
     libc.src.math.ilogbf128
-    libc.src.math.isnanf128
     libc.src.math.issignalingf128
     libc.src.math.ldexpf128
     libc.src.math.llogbf128

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -716,6 +716,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ilogbl
     libc.src.math.iscanonical
     libc.src.math.iscanonicalf
+    libc.src.math.iscanonicalf128
     libc.src.math.iscanonicall
     libc.src.math.isnan
     libc.src.math.isnanf
@@ -1024,7 +1025,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fsubf128
     libc.src.math.getpayloadf128
     libc.src.math.ilogbf128
-    libc.src.math.iscanonicalf128
     libc.src.math.isnanf128
     libc.src.math.issignalingf128
     libc.src.math.ldexpf128

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -724,6 +724,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.isnanl
     libc.src.math.issignaling
     libc.src.math.issignalingf
+    libc.src.math.issignalingf128
     libc.src.math.issignalingl
     libc.src.math.ldexp
     libc.src.math.ldexpf
@@ -1026,7 +1027,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fsubf128
     libc.src.math.getpayloadf128
     libc.src.math.ilogbf128
-    libc.src.math.issignalingf128
     libc.src.math.ldexpf128
     libc.src.math.llogbf128
     libc.src.math.logbf128

--- a/libc/config/windows/entrypoints.txt
+++ b/libc/config/windows/entrypoints.txt
@@ -251,6 +251,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ilogbf
     libc.src.math.ilogbl
     libc.src.math.iscanonicalf128
+    libc.src.math.isnanf128
     libc.src.math.ldexp
     libc.src.math.ldexpf
     libc.src.math.ldexpl

--- a/libc/config/windows/entrypoints.txt
+++ b/libc/config/windows/entrypoints.txt
@@ -252,6 +252,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ilogbl
     libc.src.math.iscanonicalf128
     libc.src.math.isnanf128
+    libc.src.math.issignalingf128
     libc.src.math.ldexp
     libc.src.math.ldexpf
     libc.src.math.ldexpl

--- a/libc/config/windows/entrypoints.txt
+++ b/libc/config/windows/entrypoints.txt
@@ -250,6 +250,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ilogb
     libc.src.math.ilogbf
     libc.src.math.ilogbl
+    libc.src.math.iscanonicalf128
     libc.src.math.ldexp
     libc.src.math.ldexpf
     libc.src.math.ldexpl

--- a/libc/shared/math/iscanonicalf128.h
+++ b/libc/shared/math/iscanonicalf128.h
@@ -9,10 +9,6 @@
 #ifndef LLVM_LIBC_SHARED_MATH_ISCANONICALF128_H
 #define LLVM_LIBC_SHARED_MATH_ISCANONICALF128_H
 
-#include "include/llvm-libc-types/float128.h"
-
-#ifdef LIBC_TYPES_HAS_NATIVE_FLOAT128
-
 #include "shared/libc_common.h"
 #include "src/__support/math/iscanonicalf128.h"
 
@@ -23,7 +19,5 @@ using math::iscanonicalf128;
 
 } // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
-
-#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 #endif // LLVM_LIBC_SHARED_MATH_ISCANONICALF128_H

--- a/libc/shared/math/isnanf128.h
+++ b/libc/shared/math/isnanf128.h
@@ -9,10 +9,6 @@
 #ifndef LLVM_LIBC_SHARED_MATH_ISNANF128_H
 #define LLVM_LIBC_SHARED_MATH_ISNANF128_H
 
-#include "include/llvm-libc-types/float128.h"
-
-#ifdef LIBC_TYPES_HAS_NATIVE_FLOAT128
-
 #include "shared/libc_common.h"
 #include "src/__support/math/isnanf128.h"
 
@@ -23,7 +19,5 @@ using math::isnanf128;
 
 } // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
-
-#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 #endif // LLVM_LIBC_SHARED_MATH_ISNANF128_H

--- a/libc/shared/math/issignalingf128.h
+++ b/libc/shared/math/issignalingf128.h
@@ -9,10 +9,6 @@
 #ifndef LLVM_LIBC_SHARED_MATH_ISSIGNALINGF128_H
 #define LLVM_LIBC_SHARED_MATH_ISSIGNALINGF128_H
 
-#include "include/llvm-libc-types/float128.h"
-
-#ifdef LIBC_TYPES_HAS_NATIVE_FLOAT128
-
 #include "shared/libc_common.h"
 #include "src/__support/math/issignalingf128.h"
 
@@ -23,7 +19,5 @@ using math::issignalingf128;
 
 } // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
-
-#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 #endif // LLVM_LIBC_SHARED_MATH_ISSIGNALINGF128_H

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -1730,7 +1730,7 @@ add_header_library(
   HDRS
     isnanf128.h
   DEPENDS
-    libc.include.llvm-libc-types.float128
+    libc.src.__support.FPUtil.float128
     libc.src.__support.FPUtil.fp_bits
     libc.src.__support.macros.config
 )

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -1787,7 +1787,7 @@ add_header_library(
   HDRS
     issignalingf128.h
   DEPENDS
-    libc.include.llvm-libc-types.float128
+    libc.src.__support.FPUtil.float128
     libc.src.__support.FPUtil.basic_operations
     libc.src.__support.macros.config
 )

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -1683,7 +1683,7 @@ add_header_library(
   HDRS
     iscanonicalf128.h
   DEPENDS
-    libc.include.llvm-libc-types.float128
+    libc.src.__support.FPUtil.float128
     libc.src.__support.FPUtil.basic_operations
     libc.src.__support.macros.config
 )

--- a/libc/src/__support/math/iscanonicalf128.h
+++ b/libc/src/__support/math/iscanonicalf128.h
@@ -9,24 +9,21 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_MATH_ISCANONICALF128_H
 #define LLVM_LIBC_SRC___SUPPORT_MATH_ISCANONICALF128_H
 
-#include "include/llvm-libc-types/float128.h"
-
-#ifdef LIBC_TYPES_HAS_NATIVE_FLOAT128
-
 #include "src/__support/FPUtil/BasicOperations.h"
+#include "src/__support/FPUtil/float128.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
 namespace math {
 
-LIBC_INLINE constexpr int iscanonicalf128(float128 x) {
-  float128 temp{};
+using LIBC_NAMESPACE::fputil::Float128;
+
+LIBC_INLINE constexpr int iscanonicalf128(Float128 x) {
+  Float128 temp{};
   return fputil::canonicalize(temp, x) == 0;
 }
 
 } // namespace math
 } // namespace LIBC_NAMESPACE_DECL
-
-#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 #endif // LLVM_LIBC_SRC___SUPPORT_MATH_ISCANONICALF128_H

--- a/libc/src/__support/math/isnanf128.h
+++ b/libc/src/__support/math/isnanf128.h
@@ -9,23 +9,20 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_MATH_ISNANF128_H
 #define LLVM_LIBC_SRC___SUPPORT_MATH_ISNANF128_H
 
-#include "include/llvm-libc-types/float128.h"
-
-#ifdef LIBC_TYPES_HAS_NATIVE_FLOAT128
-
 #include "src/__support/FPUtil/FPBits.h"
+#include "src/__support/FPUtil/float128.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
 namespace math {
 
-LIBC_INLINE LIBC_CONSTEXPR int isnanf128(float128 x) {
-  return fputil::FPBits<float128>(x).is_nan();
+using LIBC_NAMESPACE::fputil::Float128;
+
+LIBC_INLINE LIBC_CONSTEXPR int isnanf128(Float128 x) {
+  return fputil::FPBits<Float128>(x).is_nan();
 }
 
 } // namespace math
 } // namespace LIBC_NAMESPACE_DECL
-
-#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 #endif // LLVM_LIBC_SRC___SUPPORT_MATH_ISNANF128_H

--- a/libc/src/__support/math/issignalingf128.h
+++ b/libc/src/__support/math/issignalingf128.h
@@ -9,23 +9,20 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_MATH_ISSIGNALINGF128_H
 #define LLVM_LIBC_SRC___SUPPORT_MATH_ISSIGNALINGF128_H
 
-#include "include/llvm-libc-types/float128.h"
-
-#ifdef LIBC_TYPES_HAS_NATIVE_FLOAT128
-
 #include "src/__support/FPUtil/BasicOperations.h"
+#include "src/__support/FPUtil/float128.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
 namespace math {
 
-LIBC_INLINE constexpr int issignalingf128(float128 x) {
+using LIBC_NAMESPACE::fputil::Float128;
+
+LIBC_INLINE constexpr int issignalingf128(Float128 x) {
   return fputil::issignaling_impl(x);
 }
 
 } // namespace math
 } // namespace LIBC_NAMESPACE_DECL
-
-#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 #endif // LLVM_LIBC_SRC___SUPPORT_MATH_ISSIGNALINGF128_H

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -3046,6 +3046,7 @@ add_entrypoint_object(
   HDRS
     ../issignalingf128.h
   DEPENDS
+    libc.src.__support.CPP.bit
     libc.src.__support.math.issignalingf128
 )
 

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -101,6 +101,7 @@ add_entrypoint_object(
   HDRS
     ../iscanonicalf128.h
   DEPENDS
+    libc.src.__support.CPP.bit
     libc.src.__support.math.iscanonicalf128
 )
 

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -3086,6 +3086,7 @@ add_entrypoint_object(
   HDRS
     ../isnanf128.h
   DEPENDS
+    libc.src.__support.CPP.bit
     libc.src.__support.math.isnanf128
 )
 

--- a/libc/src/math/generic/iscanonicalf128.cpp
+++ b/libc/src/math/generic/iscanonicalf128.cpp
@@ -7,12 +7,15 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/math/iscanonicalf128.h"
+#include "src/__support/CPP/bit.h"
 #include "src/__support/math/iscanonicalf128.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
+using LIBC_NAMESPACE::fputil::Float128;
+
 LLVM_LIBC_FUNCTION(int, iscanonicalf128, (float128 x)) {
-  return math::iscanonicalf128(x);
+  return math::iscanonicalf128(cpp::bit_cast<Float128>(x));
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/math/generic/isnanf128.cpp
+++ b/libc/src/math/generic/isnanf128.cpp
@@ -7,10 +7,15 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/math/isnanf128.h"
+#include "src/__support/CPP/bit.h"
 #include "src/__support/math/isnanf128.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
-LLVM_LIBC_FUNCTION(int, isnanf128, (float128 x)) { return math::isnanf128(x); }
+using LIBC_NAMESPACE::fputil::Float128;
+
+LLVM_LIBC_FUNCTION(int, isnanf128, (float128 x)) {
+  return math::isnanf128(cpp::bit_cast<Float128>(x));
+}
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/math/generic/issignalingf128.cpp
+++ b/libc/src/math/generic/issignalingf128.cpp
@@ -7,12 +7,15 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/math/issignalingf128.h"
+#include "src/__support/CPP/bit.h"
 #include "src/__support/math/issignalingf128.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
+using LIBC_NAMESPACE::fputil::Float128;
+
 LLVM_LIBC_FUNCTION(int, issignalingf128, (float128 x)) {
-  return math::issignalingf128(x);
+  return math::issignalingf128(cpp::bit_cast<Float128>(x));
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/math/iscanonicalf128.h
+++ b/libc/src/math/iscanonicalf128.h
@@ -9,10 +9,15 @@
 #ifndef LLVM_LIBC_SRC_MATH_ISCANONICALF128_H
 #define LLVM_LIBC_SRC_MATH_ISCANONICALF128_H
 
+#include "src/__support/FPUtil/float128.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/types.h"
 
 namespace LIBC_NAMESPACE_DECL {
+
+#ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128
+using float128 = LIBC_NAMESPACE::fputil::Float128;
+#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 int iscanonicalf128(float128 x);
 

--- a/libc/src/math/isnanf128.h
+++ b/libc/src/math/isnanf128.h
@@ -9,10 +9,15 @@
 #ifndef LLVM_LIBC_SRC_MATH_ISNANF128_H
 #define LLVM_LIBC_SRC_MATH_ISNANF128_H
 
+#include "src/__support/FPUtil/float128.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/types.h"
 
 namespace LIBC_NAMESPACE_DECL {
+
+#ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128
+using float128 = LIBC_NAMESPACE::fputil::Float128;
+#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 int isnanf128(float128 x);
 

--- a/libc/src/math/issignalingf128.h
+++ b/libc/src/math/issignalingf128.h
@@ -9,10 +9,15 @@
 #ifndef LLVM_LIBC_SRC_MATH_ISSIGNALINGF128_H
 #define LLVM_LIBC_SRC_MATH_ISSIGNALINGF128_H
 
+#include "src/__support/FPUtil/float128.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/types.h"
 
 namespace LIBC_NAMESPACE_DECL {
+
+#ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128
+using float128 = LIBC_NAMESPACE::fputil::Float128;
+#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 int issignalingf128(float128 x);
 

--- a/libc/test/shared/shared_math_constexpr_test.cpp
+++ b/libc/test/shared/shared_math_constexpr_test.cpp
@@ -381,15 +381,15 @@ static_assert(0 == LIBC_NAMESPACE::shared::isnanl(0.0L));
 //===----------------------------------------------------------------------===//
 
 static_assert(Float128(0.0) == LIBC_NAMESPACE::shared::ceilf128(Float128(0.0)));
-static_assert(0.0 == LIBC_NAMESPACE::shared::issignalingf128(Float128(0.0)));
-static_assert(0 == LIBC_NAMESPACE::shared::isnanf128(Float128(0.0)));
-static_assert(1 == LIBC_NAMESPACE::shared::iscanonicalf128(Float128(0.0)));
 static_assert(Float128(0.0) ==
               LIBC_NAMESPACE::shared::floorf128(Float128(0.0)));
 static_assert(Float128(0.0) ==
               LIBC_NAMESPACE::shared::fmaxf128(Float128(0.0), Float128(0.0)));
 static_assert(Float128(0.0) ==
               LIBC_NAMESPACE::shared::fminf128(Float128(0.0), Float128(0.0)));
+static_assert(1 == LIBC_NAMESPACE::shared::iscanonicalf128(Float128(0.0)));
+static_assert(0 == LIBC_NAMESPACE::shared::isnanf128(Float128(0.0)));
+static_assert(0.0 == LIBC_NAMESPACE::shared::issignalingf128(Float128(0.0)));
 static_assert(0LL == LIBC_NAMESPACE::shared::llrintf128(Float128(0.0)));
 static_assert(0LL == LIBC_NAMESPACE::shared::llroundf128(Float128(0.0)));
 static_assert(0L == LIBC_NAMESPACE::shared::lrintf128(Float128(0.0)));

--- a/libc/test/shared/shared_math_constexpr_test.cpp
+++ b/libc/test/shared/shared_math_constexpr_test.cpp
@@ -381,6 +381,7 @@ static_assert(0 == LIBC_NAMESPACE::shared::isnanl(0.0L));
 //===----------------------------------------------------------------------===//
 
 static_assert(Float128(0.0) == LIBC_NAMESPACE::shared::ceilf128(Float128(0.0)));
+static_assert(1 == LIBC_NAMESPACE::shared::iscanonicalf128(Float128(0.0)));
 static_assert(Float128(0.0) ==
               LIBC_NAMESPACE::shared::floorf128(Float128(0.0)));
 static_assert(Float128(0.0) ==
@@ -502,7 +503,6 @@ static_assert(0.0f ==
 static_assert(float128(0.0) ==
               LIBC_NAMESPACE::shared::nextafterf128(float128(0.0),
                                                     float128(0.0)));
-static_assert(1 == LIBC_NAMESPACE::shared::iscanonicalf128(float128(0.0)));
 static_assert(0 == LIBC_NAMESPACE::shared::isnanf128(float128(0.0)));
 static_assert(0.0 == LIBC_NAMESPACE::shared::issignalingf128(float128(0.0)));
 static_assert(1 == [] {

--- a/libc/test/shared/shared_math_constexpr_test.cpp
+++ b/libc/test/shared/shared_math_constexpr_test.cpp
@@ -381,6 +381,7 @@ static_assert(0 == LIBC_NAMESPACE::shared::isnanl(0.0L));
 //===----------------------------------------------------------------------===//
 
 static_assert(Float128(0.0) == LIBC_NAMESPACE::shared::ceilf128(Float128(0.0)));
+static_assert(0 == LIBC_NAMESPACE::shared::isnanf128(Float128(0.0)));
 static_assert(1 == LIBC_NAMESPACE::shared::iscanonicalf128(Float128(0.0)));
 static_assert(Float128(0.0) ==
               LIBC_NAMESPACE::shared::floorf128(Float128(0.0)));
@@ -503,7 +504,6 @@ static_assert(0.0f ==
 static_assert(float128(0.0) ==
               LIBC_NAMESPACE::shared::nextafterf128(float128(0.0),
                                                     float128(0.0)));
-static_assert(0 == LIBC_NAMESPACE::shared::isnanf128(float128(0.0)));
 static_assert(0.0 == LIBC_NAMESPACE::shared::issignalingf128(float128(0.0)));
 static_assert(1 == [] {
   const char arg{};

--- a/libc/test/shared/shared_math_constexpr_test.cpp
+++ b/libc/test/shared/shared_math_constexpr_test.cpp
@@ -381,6 +381,7 @@ static_assert(0 == LIBC_NAMESPACE::shared::isnanl(0.0L));
 //===----------------------------------------------------------------------===//
 
 static_assert(Float128(0.0) == LIBC_NAMESPACE::shared::ceilf128(Float128(0.0)));
+static_assert(0.0 == LIBC_NAMESPACE::shared::issignalingf128(Float128(0.0)));
 static_assert(0 == LIBC_NAMESPACE::shared::isnanf128(Float128(0.0)));
 static_assert(1 == LIBC_NAMESPACE::shared::iscanonicalf128(Float128(0.0)));
 static_assert(Float128(0.0) ==
@@ -504,7 +505,6 @@ static_assert(0.0f ==
 static_assert(float128(0.0) ==
               LIBC_NAMESPACE::shared::nextafterf128(float128(0.0),
                                                     float128(0.0)));
-static_assert(0.0 == LIBC_NAMESPACE::shared::issignalingf128(float128(0.0)));
 static_assert(1 == [] {
   const char arg{};
   return LIBC_NAMESPACE::fputil::FPBits<float128>(

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -584,14 +584,14 @@ TEST(LlvmLibcSharedMathTest, AllEmuFloat128) {
   EXPECT_FP_EQ(Float128(0.0),
                LIBC_NAMESPACE::shared::atan2f128(Float128(0.0), Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::ceilf128(Float128(0.0)));
-  EXPECT_EQ(0, LIBC_NAMESPACE::shared::issignalingf128(Float128(0.0)));
-  EXPECT_EQ(0, LIBC_NAMESPACE::shared::isnanf128(Float128(0.0)));
-  EXPECT_EQ(1, LIBC_NAMESPACE::shared::iscanonicalf128(Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::floorf128(Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0),
                LIBC_NAMESPACE::shared::fmaxf128(Float128(0.0), Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0),
                LIBC_NAMESPACE::shared::fminf128(Float128(0.0), Float128(0.0)));
+  EXPECT_EQ(1, LIBC_NAMESPACE::shared::iscanonicalf128(Float128(0.0)));
+  EXPECT_EQ(0, LIBC_NAMESPACE::shared::isnanf128(Float128(0.0)));
+  EXPECT_EQ(0, LIBC_NAMESPACE::shared::issignalingf128(Float128(0.0)));
   EXPECT_EQ(0LL, LIBC_NAMESPACE::shared::llrintf128(Float128(0.0)));
   EXPECT_EQ(0LL, LIBC_NAMESPACE::shared::llroundf128(Float128(0.0)));
   EXPECT_EQ(0L, LIBC_NAMESPACE::shared::lrintf128(Float128(0.0)));

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -584,6 +584,7 @@ TEST(LlvmLibcSharedMathTest, AllEmuFloat128) {
   EXPECT_FP_EQ(Float128(0.0),
                LIBC_NAMESPACE::shared::atan2f128(Float128(0.0), Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::ceilf128(Float128(0.0)));
+  EXPECT_EQ(0, LIBC_NAMESPACE::shared::isnanf128(Float128(0.0)));
   EXPECT_EQ(1, LIBC_NAMESPACE::shared::iscanonicalf128(Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::floorf128(Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0),
@@ -753,7 +754,6 @@ TEST(LlvmLibcSharedMathTest, AllFloat128) {
                LIBC_NAMESPACE::shared::fsubf128(float128(0.0), float128(0.0)));
   EXPECT_FP_EQ(0x0p+0f,
                LIBC_NAMESPACE::shared::fmulf128(float128(0.0), float128(0.0)));
-  EXPECT_EQ(0, LIBC_NAMESPACE::shared::isnanf128(float128(0.0)));
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::issignalingf128(float128(0.0)));
   EXPECT_TRUE(FPBits(LIBC_NAMESPACE::shared::nanf128("")).is_nan());
 }

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -584,6 +584,7 @@ TEST(LlvmLibcSharedMathTest, AllEmuFloat128) {
   EXPECT_FP_EQ(Float128(0.0),
                LIBC_NAMESPACE::shared::atan2f128(Float128(0.0), Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::ceilf128(Float128(0.0)));
+  EXPECT_EQ(0, LIBC_NAMESPACE::shared::issignalingf128(Float128(0.0)));
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::isnanf128(Float128(0.0)));
   EXPECT_EQ(1, LIBC_NAMESPACE::shared::iscanonicalf128(Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::floorf128(Float128(0.0)));
@@ -754,7 +755,6 @@ TEST(LlvmLibcSharedMathTest, AllFloat128) {
                LIBC_NAMESPACE::shared::fsubf128(float128(0.0), float128(0.0)));
   EXPECT_FP_EQ(0x0p+0f,
                LIBC_NAMESPACE::shared::fmulf128(float128(0.0), float128(0.0)));
-  EXPECT_EQ(0, LIBC_NAMESPACE::shared::issignalingf128(float128(0.0)));
   EXPECT_TRUE(FPBits(LIBC_NAMESPACE::shared::nanf128("")).is_nan());
 }
 

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -584,6 +584,7 @@ TEST(LlvmLibcSharedMathTest, AllEmuFloat128) {
   EXPECT_FP_EQ(Float128(0.0),
                LIBC_NAMESPACE::shared::atan2f128(Float128(0.0), Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::ceilf128(Float128(0.0)));
+  EXPECT_EQ(1, LIBC_NAMESPACE::shared::iscanonicalf128(Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::floorf128(Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0),
                LIBC_NAMESPACE::shared::fmaxf128(Float128(0.0), Float128(0.0)));
@@ -752,7 +753,6 @@ TEST(LlvmLibcSharedMathTest, AllFloat128) {
                LIBC_NAMESPACE::shared::fsubf128(float128(0.0), float128(0.0)));
   EXPECT_FP_EQ(0x0p+0f,
                LIBC_NAMESPACE::shared::fmulf128(float128(0.0), float128(0.0)));
-  EXPECT_EQ(1, LIBC_NAMESPACE::shared::iscanonicalf128(float128(0.0)));
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::isnanf128(float128(0.0)));
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::issignalingf128(float128(0.0)));
   EXPECT_TRUE(FPBits(LIBC_NAMESPACE::shared::nanf128("")).is_nan());

--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -554,6 +554,7 @@ add_fp_unittest(
   HDRS
     IsNanTest.h
   DEPENDS
+    libc.src.__support.FPUtil.float128
     libc.src.math.isnanf128
 )
 

--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -528,6 +528,7 @@ add_fp_unittest(
   HDRS
     IsCanonicalTest.h
   DEPENDS
+    libc.src.__support.FPUtil.float128
     libc.src.math.iscanonicalf128
 )
 

--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -2176,6 +2176,7 @@ add_fp_unittest(
   HDRS
     IsSignalingTest.h
   DEPENDS
+    libc.src.__support.FPUtil.float128
     libc.src.math.issignalingf128
 )
 

--- a/libc/test/src/math/smoke/iscanonicalf128_test.cpp
+++ b/libc/test/src/math/smoke/iscanonicalf128_test.cpp
@@ -7,7 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "IsCanonicalTest.h"
+#include "src/__support/FPUtil/float128.h"
 
 #include "src/math/iscanonicalf128.h"
+
+#ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128
+using float128 = LIBC_NAMESPACE::fputil::Float128;
+#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 LIST_ISCANONICAL_TESTS(float128, LIBC_NAMESPACE::iscanonicalf128)

--- a/libc/test/src/math/smoke/iscanonicalf128_test.cpp
+++ b/libc/test/src/math/smoke/iscanonicalf128_test.cpp
@@ -7,8 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "IsCanonicalTest.h"
-#include "src/__support/FPUtil/float128.h"
 
+#include "src/__support/FPUtil/float128.h"
 #include "src/math/iscanonicalf128.h"
 
 #ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128

--- a/libc/test/src/math/smoke/isnanf128_test.cpp
+++ b/libc/test/src/math/smoke/isnanf128_test.cpp
@@ -7,8 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "IsNanTest.h"
-#include "src/__support/FPUtil/float128.h"
 
+#include "src/__support/FPUtil/float128.h"
 #include "src/math/isnanf128.h"
 
 #ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128

--- a/libc/test/src/math/smoke/isnanf128_test.cpp
+++ b/libc/test/src/math/smoke/isnanf128_test.cpp
@@ -7,7 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "IsNanTest.h"
+#include "src/__support/FPUtil/float128.h"
 
 #include "src/math/isnanf128.h"
+
+#ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128
+using float128 = LIBC_NAMESPACE::fputil::Float128;
+#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 LIST_ISNAN_TESTS(float128, LIBC_NAMESPACE::isnanf128)

--- a/libc/test/src/math/smoke/issignalingf128_test.cpp
+++ b/libc/test/src/math/smoke/issignalingf128_test.cpp
@@ -7,8 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "IsSignalingTest.h"
-#include "src/__support/FPUtil/float128.h"
 
+#include "src/__support/FPUtil/float128.h"
 #include "src/math/issignalingf128.h"
 
 #ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128

--- a/libc/test/src/math/smoke/issignalingf128_test.cpp
+++ b/libc/test/src/math/smoke/issignalingf128_test.cpp
@@ -7,7 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "IsSignalingTest.h"
+#include "src/__support/FPUtil/float128.h"
 
 #include "src/math/issignalingf128.h"
+
+#ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128
+using float128 = LIBC_NAMESPACE::fputil::Float128;
+#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 LIST_ISSIGNALING_TESTS(float128, LIBC_NAMESPACE::issignalingf128)

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -6242,9 +6242,9 @@ libc_support_library(
     name = "__support_math_isnanf128",
     hdrs = ["src/__support/math/isnanf128.h"],
     deps = [
+        ":__support_fputil_float128",
         ":__support_fputil_fp_bits",
         ":__support_macros_config",
-        ":llvm_libc_types_float128",
     ],
 )
 
@@ -10962,6 +10962,8 @@ libc_math_function(
 libc_math_function(
     name = "isnanf128",
     additional_deps = [
+        ":__support_cpp_bit",
+        ":__support_fputil_float128",
         ":__support_math_isnanf128",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -6196,8 +6196,8 @@ libc_support_library(
     hdrs = ["src/__support/math/iscanonicalf128.h"],
     deps = [
         ":__support_fputil_basic_operations",
+        ":__support_fputil_float128",
         ":__support_macros_config",
-        ":llvm_libc_types_float128",
     ],
 )
 
@@ -10932,6 +10932,8 @@ libc_math_function(
 libc_math_function(
     name = "iscanonicalf128",
     additional_deps = [
+        ":__support_cpp_bit",
+        ":__support_fputil_float128",
         ":__support_math_iscanonicalf128",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -6300,8 +6300,8 @@ libc_support_library(
     hdrs = ["src/__support/math/issignalingf128.h"],
     deps = [
         ":__support_fputil_basic_operations",
+        ":__support_fputil_float128",
         ":__support_macros_config",
-        ":llvm_libc_types_float128",
     ],
 )
 
@@ -11013,6 +11013,8 @@ libc_math_function(
 libc_math_function(
     name = "issignalingf128",
     additional_deps = [
+        ":__support_cpp_bit",
+        ":__support_fputil_float128",
         ":__support_math_issignalingf128",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
@@ -87,6 +87,14 @@ math_test(
     hdrs = ["IsCanonicalTest.h"],
 )
 
+math_test(
+    name = "iscanonicalf128",
+    hdrs = ["IsCanonicalTest.h"],
+    deps = [
+        "//libc:__support_fputil_float128",
+    ],
+)
+
 math_test(name = "cbrt")
 
 math_test(name = "cbrtf")

--- a/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
@@ -1775,6 +1775,14 @@ math_test(
     hdrs = ["IsSignalingTest.h"],
 )
 
+math_test(
+    name = "issignalingf128",
+    hdrs = ["IsSignalingTest.h"],
+    deps = [
+        "//libc:__support_fputil_float128",
+    ],
+)
+
 math_test(name = "log10f16")
 
 math_test(name = "log2f16")

--- a/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
@@ -1031,6 +1031,9 @@ math_test(
 math_test(
     name = "isnanf128",
     hdrs = ["IsNanTest.h"],
+    deps = [
+        "//libc:__support_fputil_float128",
+    ],
 )
 
 math_test(


### PR DESCRIPTION
* `isnanf128`
* `issignalingf128`
*  `iscanonicalf128`