### PR TITLE
[clang-repl] Stop interpreter init on action failure

### DIFF
--- a/clang/lib/Interpreter/Interpreter.cpp
+++ b/clang/lib/Interpreter/Interpreter.cpp
@@ -206,6 +206,15 @@ CreateCI(const llvm::opt::ArgStringList &Argv) {
   return std::move(Clang);
 }
 
+static llvm::Error ExecuteIncrementalAction(CompilerInstance &CI,
+                                            IncrementalAction &Act) {
+  if (!CI.ExecuteAction(Act) || CI.getDiagnostics().hasErrorOccurred()) {
+    return llvm::createStringError(llvm::errc::not_supported,
+                                   "Failed to execute incremental action");
+  }
+  return llvm::Error::success();
+}
+
 } // anonymous namespace
 
 namespace clang {
@@ -349,7 +358,10 @@ Interpreter::Interpreter(std::unique_ptr<CompilerInstance> Instance,
   if (ErrOut)
     return;
 
-  CI->ExecuteAction(*Act);
+  if (llvm::Error E = ExecuteIncrementalAction(*CI, *Act)) {
+    ErrOut = joinErrors(std::move(ErrOut), std::move(E));
+    return;
+  }
 
   IncrParser =
       std::make_unique<IncrementalParser>(*CI, Act.get(), ErrOut, PTUs);
@@ -490,7 +502,8 @@ Interpreter::createWithCUDA(std::unique_ptr<CompilerInstance> CI,
 
   Interp->DeviceAct = std::move(DeviceAct);
 
-  DCI->ExecuteAction(*Interp->DeviceAct);
+  if (llvm::Error E = ExecuteIncrementalAction(*DCI, *Interp->DeviceAct))
+    return std::move(E);
 
   Interp->DeviceCI = std::move(DCI);
 

--- a/clang/test/Interpreter/stale-pch.cpp
+++ b/clang/test/Interpreter/stale-pch.cpp
@@ -1,0 +1,23 @@
+// REQUIRES: host-supports-jit
+// UNSUPPORTED: system-aix
+//
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: split-file %s %t
+//
+// RUN: %if system-windows %{ \
+// RUN: %clang -fmax-type-align=16 -Xclang -fdeprecated-macro -fno-stack-protector -Xclang -fwrapv -Xclang -fblocks -Xclang -fskip-odr-check-in-gmf -fexceptions -fcxx-exceptions -fgnuc-version=0 -target %host-jit-triple -Xclang -fblocks -Xclang -fmax-type-align=8 -Xclang -fincremental-extensions -Xclang -emit-pch -x c++-header -o %t/include.pch %t/include.hpp \
+// RUN: %} \
+// RUN: %else %{ \
+// RUN: %clang -fPIC -fmax-type-align=16 -Xclang -fdeprecated-macro -fno-stack-protector -Xclang -fwrapv -Xclang -fblocks -Xclang -fskip-odr-check-in-gmf -fexceptions -fcxx-exceptions -fgnuc-version=0 -target %host-jit-triple -Xclang -fblocks -Xclang -fmax-type-align=8 -Xclang -fincremental-extensions -Xclang -emit-pch -x c++-header -o %t/include.pch %t/include.hpp \
+// RUN: %}
+// RUN: echo '// changed after PCH creation' >> %t/include.hpp
+//
+// RUN: not clang-repl -Xcc -fgnuc-version=0 -Xcc -fno-stack-protector -Xcc -fwrapv -Xcc -fblocks -Xcc -fskip-odr-check-in-gmf -Xcc -fmax-type-align=8 -Xcc -include-pch -Xcc %t/include.pch < /dev/null 2>&1 | FileCheck %s
+
+//--- include.hpp
+
+int f_pch() { return 5; }
+
+// CHECK: fatal error: file '{{.*}}include.hpp' has been modified since the precompiled header
+// CHECK: clang-repl: Failed to execute incremental action


### PR DESCRIPTION
`clang::Interpreter` previously ignored the result of its initial `CompilerInstance::ExecuteAction()` call and always constructed the `IncrementalParser`. When the initial action failed, the parser could be created from an invalid compiler state.

In practice, this failure happens if the incremental PCH included has expired, due to system headers changing. This happens quite regularly, after system updates, and is affecting jank users.

To fix this, the `Interpreter` now returns an error immediately when the initial action fails or records a diagnostic error. This allows jank to add a diagnostic consumer to detect PCH-related errors and rebuild the PCH as needed.

----
I used Github copilot to help me diagnose and fix the issue. I have manually reviewed the code, manually executed the test, and have verified that the fix works locally for jank. I understand the change completely.