### PR TITLE
[lldb] Make Process::ReadMemory non-virtual

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -1603,9 +1603,9 @@ public:
   /// This function will read memory from the current process's address space
   /// and remove any traps that may have been inserted into the memory.
   ///
-  /// This function is not meant to be overridden by Process subclasses, the
-  /// subclasses should implement Process::DoReadMemory(const ProcessAddress &,
-  /// void *, size_t, Status &).
+  /// Process subclasses implement Process::DoReadMemory(const ProcessAddress &,
+  /// void *, size_t, Status &) instead of this function, and override
+  /// Process::ShouldUseMemoryCache to keep their reads out of the memory cache.
   ///
   /// \param[in] vm_addr
   ///     A virtual load address that indicates where to start reading
@@ -1630,8 +1630,8 @@ public:
   ///     size, then this function will get called again with \a
   ///     vm_addr, \a buf, and \a size updated appropriately. Zero is
   ///     returned in the case of an error.
-  virtual size_t ReadMemory(const ProcessAddress &process_addr, void *buf,
-                            size_t size, Status &error);
+  size_t ReadMemory(const ProcessAddress &process_addr, void *buf, size_t size,
+                    Status &error);
 
   /// Read from multiple memory ranges and write the results into buffer.
   ///
@@ -3025,6 +3025,12 @@ protected:
   ///     \b true if the new thread list could be generated, \b false otherwise.
   virtual bool DoUpdateThreadList(ThreadList &old_thread_list,
                                   ThreadList &new_thread_list) = 0;
+
+  /// Whether ReadMemory should serve reads of \a process_addr out of the
+  /// memory cache.
+  virtual bool ShouldUseMemoryCache(const ProcessAddress &process_addr) {
+    return true;
+  }
 
   /// Actually do the reading of memory from a process.
   ///

--- a/lldb/include/lldb/Target/ProcessTrace.h
+++ b/lldb/include/lldb/Target/ProcessTrace.h
@@ -54,8 +54,7 @@ public:
 
   bool WarnBeforeDetach() const override { return false; }
 
-  size_t ReadMemory(const ProcessAddress &addr, void *buf, size_t size,
-                    Status &error) override;
+  bool ShouldUseMemoryCache(const ProcessAddress &process_addr) override;
 
   size_t DoReadMemory(const ProcessAddress &addr, void *buf, size_t size,
                       Status &error) override;

--- a/lldb/source/Plugins/Process/elf-core/ProcessElfCore.cpp
+++ b/lldb/source/Plugins/Process/elf-core/ProcessElfCore.cpp
@@ -16,7 +16,6 @@
 #include "lldb/Core/ModuleSpec.h"
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Core/Section.h"
-#include "lldb/Target/ABI.h"
 #include "lldb/Target/DynamicLoader.h"
 #include "lldb/Target/MemoryRegionInfo.h"
 #include "lldb/Target/Target.h"
@@ -524,15 +523,9 @@ Status ProcessElfCore::DoDestroy() { return Status(); }
 bool ProcessElfCore::IsAlive() { return true; }
 
 // Process Memory
-size_t ProcessElfCore::ReadMemory(const ProcessAddress &process_addr, void *buf,
-                                  size_t size, Status &error) {
-  lldb::addr_t addr = process_addr.GetValue();
-  if (lldb::ABISP abi_sp = GetABI())
-    addr = abi_sp->FixAnyAddress(addr);
-
-  // Don't allow the caching that lldb_private::Process::ReadMemory does since
-  // in core files we have it all cached our our core file anyway.
-  return DoReadMemory(addr, buf, size, error);
+bool ProcessElfCore::ShouldUseMemoryCache(const ProcessAddress &process_addr) {
+  // The core file is already a local copy of this memory.
+  return false;
 }
 
 Status ProcessElfCore::DoGetMemoryRegionInfo(lldb::addr_t load_addr,

--- a/lldb/source/Plugins/Process/elf-core/ProcessElfCore.h
+++ b/lldb/source/Plugins/Process/elf-core/ProcessElfCore.h
@@ -82,8 +82,8 @@ public:
   bool WarnBeforeDetach() const override { return false; }
 
   // Process Memory
-  size_t ReadMemory(const lldb_private::ProcessAddress &addr, void *buf,
-                    size_t size, lldb_private::Status &error) override;
+  bool ShouldUseMemoryCache(
+      const lldb_private::ProcessAddress &process_addr) override;
 
   size_t DoReadMemory(const lldb_private::ProcessAddress &addr, void *buf,
                       size_t size, lldb_private::Status &error) override;

--- a/lldb/source/Plugins/Process/mach-core/ProcessMachCore.cpp
+++ b/lldb/source/Plugins/Process/mach-core/ProcessMachCore.cpp
@@ -721,12 +721,9 @@ bool ProcessMachCore::IsAlive() { return true; }
 bool ProcessMachCore::WarnBeforeDetach() const { return false; }
 
 // Process Memory
-size_t ProcessMachCore::ReadMemory(const ProcessAddress &process_addr,
-                                   void *buf, size_t size, Status &error) {
-  lldb::addr_t addr = process_addr.GetValue();
-  // Don't allow the caching that lldb_private::Process::ReadMemory does since
-  // in core files we have it all cached our our core file anyway.
-  return DoReadMemory(FixAnyAddress(addr), buf, size, error);
+bool ProcessMachCore::ShouldUseMemoryCache(const ProcessAddress &process_addr) {
+  // The core file is already a local copy of this memory.
+  return false;
 }
 
 size_t ProcessMachCore::DoReadMemory(const ProcessAddress &process_addr,

--- a/lldb/source/Plugins/Process/mach-core/ProcessMachCore.h
+++ b/lldb/source/Plugins/Process/mach-core/ProcessMachCore.h
@@ -62,8 +62,8 @@ public:
   bool WarnBeforeDetach() const override;
 
   // Process Memory
-  size_t ReadMemory(const lldb_private::ProcessAddress &addr, void *buf,
-                    size_t size, lldb_private::Status &error) override;
+  bool ShouldUseMemoryCache(
+      const lldb_private::ProcessAddress &process_addr) override;
 
   size_t DoReadMemory(const lldb_private::ProcessAddress &addr, void *buf,
                       size_t size, lldb_private::Status &error) override;

--- a/lldb/source/Plugins/Process/minidump/ProcessMinidump.cpp
+++ b/lldb/source/Plugins/Process/minidump/ProcessMinidump.cpp
@@ -314,12 +314,9 @@ bool ProcessMinidump::IsAlive() { return true; }
 
 bool ProcessMinidump::WarnBeforeDetach() const { return false; }
 
-size_t ProcessMinidump::ReadMemory(const ProcessAddress &process_addr,
-                                   void *buf, size_t size, Status &error) {
-  lldb::addr_t addr = process_addr.GetValue();
-  // Don't allow the caching that lldb_private::Process::ReadMemory does since
-  // we have it all cached in our dump file anyway.
-  return DoReadMemory(addr, buf, size, error);
+bool ProcessMinidump::ShouldUseMemoryCache(const ProcessAddress &process_addr) {
+  // The dump file is already a local copy of this memory.
+  return false;
 }
 
 size_t ProcessMinidump::DoReadMemory(const ProcessAddress &process_addr,

--- a/lldb/source/Plugins/Process/minidump/ProcessMinidump.h
+++ b/lldb/source/Plugins/Process/minidump/ProcessMinidump.h
@@ -68,8 +68,7 @@ public:
 
   bool WarnBeforeDetach() const override;
 
-  size_t ReadMemory(const ProcessAddress &addr, void *buf, size_t size,
-                    Status &error) override;
+  bool ShouldUseMemoryCache(const ProcessAddress &process_addr) override;
 
   size_t DoReadMemory(const ProcessAddress &addr, void *buf, size_t size,
                       Status &error) override;

--- a/lldb/source/Plugins/Process/wasm/ProcessWasm.cpp
+++ b/lldb/source/Plugins/Process/wasm/ProcessWasm.cpp
@@ -127,15 +127,31 @@ size_t ProcessWasm::ReadGlobal(uint32_t module_id, uint32_t index, void *buf,
   return size;
 }
 
-size_t ProcessWasm::ReadMemory(const ProcessAddress &process_addr, void *buf,
-                               size_t size, Status &error) {
+bool ProcessWasm::ShouldUseMemoryCache(const ProcessAddress &process_addr) {
+  wasm_addr_t wasm_addr(process_addr.GetValue());
+
+  switch (wasm_addr.GetType()) {
+  case WasmAddressType::Memory:
+  case WasmAddressType::Object:
+    return ProcessGDBRemote::ShouldUseMemoryCache(process_addr);
+  case WasmAddressType::Global:
+  case WasmAddressType::Invalid:
+    // A global's address holds an index, not an offset into addressable
+    // storage, so the cache's aligned reads would name a different global.
+    return false;
+  }
+  llvm_unreachable("Fully covered switch above!");
+}
+
+size_t ProcessWasm::DoReadMemory(const ProcessAddress &process_addr, void *buf,
+                                 size_t size, Status &error) {
   lldb::addr_t vm_addr = process_addr.GetValue();
   wasm_addr_t wasm_addr(vm_addr);
 
   switch (wasm_addr.GetType()) {
   case WasmAddressType::Memory:
   case WasmAddressType::Object:
-    return ProcessGDBRemote::ReadMemory(vm_addr, buf, size, error);
+    return ProcessGDBRemote::DoReadMemory(vm_addr, buf, size, error);
   case WasmAddressType::Global:
     return ReadGlobal(wasm_addr.GetModuleID(), wasm_addr.GetOffset(), buf, size,
                       error);

--- a/lldb/source/Plugins/Process/wasm/ProcessWasm.h
+++ b/lldb/source/Plugins/Process/wasm/ProcessWasm.h
@@ -37,8 +37,10 @@ public:
 
   llvm::StringRef GetPluginName() override;
 
-  size_t ReadMemory(const ProcessAddress &vm_addr, void *buf, size_t size,
-                    Status &error) override;
+  bool ShouldUseMemoryCache(const ProcessAddress &process_addr) override;
+
+  size_t DoReadMemory(const ProcessAddress &vm_addr, void *buf, size_t size,
+                      Status &error) override;
 
   bool CanDebug(lldb::TargetSP target_sp,
                 bool plugin_specified_by_name) override;

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -2037,48 +2037,46 @@ Status Process::DisableSoftwareBreakpoint(BreakpointSite *bp_site) {
 
 size_t Process::ReadMemory(const ProcessAddress &process_addr, void *buf,
                            size_t size, Status &error) {
-  lldb::addr_t addr = process_addr.GetValue();
-  if (ABISP abi_sp = GetABI())
-    addr = abi_sp->FixAnyAddress(addr);
+  const lldb::addr_t addr = FixAnyAddress(process_addr.GetValue());
 
   error.Clear();
-  if (!GetDisableMemoryCache()) {
-#if defined(VERIFY_MEMORY_READS)
-    // Memory caching is enabled, with debug verification
+  if (!ShouldUseMemoryCache(addr))
+    return DoReadMemory(addr, buf, size, error);
 
-    if (buf && size) {
-      // Uncomment the line below to make sure memory caching is working.
-      // I ran this through the test suite and got no assertions, so I am
-      // pretty confident this is working well. If any changes are made to
-      // memory caching, uncomment the line below and test your changes!
-
-      // Verify all memory reads by using the cache first, then redundantly
-      // reading the same memory from the inferior and comparing to make sure
-      // everything is exactly the same.
-      std::string verify_buf(size, '\0');
-      assert(verify_buf.size() == size);
-      const size_t cache_bytes_read =
-          m_memory_cache.Read(this, addr, buf, size, error);
-      Status verify_error;
-      const size_t verify_bytes_read =
-          ReadMemoryFromInferior(addr, const_cast<char *>(verify_buf.data()),
-                                 verify_buf.size(), verify_error);
-      assert(cache_bytes_read == verify_bytes_read);
-      assert(memcmp(buf, verify_buf.data(), verify_buf.size()) == 0);
-      assert(verify_error.Success() == error.Success());
-      return cache_bytes_read;
-    }
-    return 0;
-#else  // !defined(VERIFY_MEMORY_READS)
-    // Memory caching is enabled, without debug verification
-
-    return m_memory_cache.Read(addr, buf, size, error);
-#endif // defined (VERIFY_MEMORY_READS)
-  } else {
-    // Memory caching is disabled
-
+  if (GetDisableMemoryCache())
     return ReadMemoryFromInferior(addr, buf, size, error);
+
+#if defined(VERIFY_MEMORY_READS)
+  // Memory caching is enabled, with debug verification
+
+  if (buf && size) {
+    // Uncomment the line below to make sure memory caching is working.
+    // I ran this through the test suite and got no assertions, so I am
+    // pretty confident this is working well. If any changes are made to
+    // memory caching, uncomment the line below and test your changes!
+
+    // Verify all memory reads by using the cache first, then redundantly
+    // reading the same memory from the inferior and comparing to make sure
+    // everything is exactly the same.
+    std::string verify_buf(size, '\0');
+    assert(verify_buf.size() == size);
+    const size_t cache_bytes_read =
+        m_memory_cache.Read(this, addr, buf, size, error);
+    Status verify_error;
+    const size_t verify_bytes_read =
+        ReadMemoryFromInferior(addr, const_cast<char *>(verify_buf.data()),
+                               verify_buf.size(), verify_error);
+    assert(cache_bytes_read == verify_bytes_read);
+    assert(memcmp(buf, verify_buf.data(), verify_buf.size()) == 0);
+    assert(verify_error.Success() == error.Success());
+    return cache_bytes_read;
   }
+  return 0;
+#else  // !defined(VERIFY_MEMORY_READS)
+  // Memory caching is enabled, without debug verification
+
+  return m_memory_cache.Read(addr, buf, size, error);
+#endif // defined (VERIFY_MEMORY_READS)
 }
 
 llvm::SmallVector<llvm::MutableArrayRef<uint8_t>>

--- a/lldb/source/Target/ProcessTrace.cpp
+++ b/lldb/source/Target/ProcessTrace.cpp
@@ -13,7 +13,6 @@
 #include "lldb/Core/Module.h"
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Core/Section.h"
-#include "lldb/Target/ABI.h"
 #include "lldb/Target/SectionLoadList.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Utility/LLDBLog.h"
@@ -93,15 +92,9 @@ void ProcessTrace::RefreshStateAfterStop() {}
 
 Status ProcessTrace::DoDestroy() { return Status(); }
 
-size_t ProcessTrace::ReadMemory(const ProcessAddress &process_addr, void *buf,
-                                size_t size, Status &error) {
-  lldb::addr_t addr = process_addr.GetValue();
-  if (const ABISP &abi = GetABI())
-    addr = abi->FixAnyAddress(addr);
-
-  // Don't allow the caching that lldb_private::Process::ReadMemory does since
-  // we have it all cached in the trace files.
-  return DoReadMemory(addr, buf, size, error);
+bool ProcessTrace::ShouldUseMemoryCache(const ProcessAddress &process_addr) {
+  // The trace files are already a local copy of this memory.
+  return false;
 }
 
 void ProcessTrace::Clear() { m_thread_list.Clear(); }

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2201,6 +2201,7 @@ size_t Target::ReadMemory(const Address &addr, void *dst, size_t dst_len,
   if (file_cache_read_buffer && file_cache_bytes_read > 0) {
     // Reading from the process failed. If we've previously succeeded in reading
     // something from the file cache, then copy that over and return that.
+    error.Clear();
     std::memcpy(dst, file_cache_read_buffer.get(), file_cache_bytes_read);
     return file_cache_bytes_read;
   }

--- a/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidumpYaml.py
+++ b/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidumpYaml.py
@@ -30,9 +30,16 @@ class ProcessSaveCoreMinidumpTestCaseYaml(TestBase):
 
     @skipIfWindows
     def validate_regions_saved_correctly(
-        self, core_process, expected_region, expected_invalid_region=None
+        self,
+        core_process,
+        expected_region,
+        expected_invalid_region=None,
+        expected_invalid_bytes_read=0,
     ):
-        """Validate that the expected_region is saved in the core_proc, and that the expected invalid region is not saved, if not not none."""
+        """Validate that the expected_region is saved in the core_proc, and that
+        the expected invalid region is not saved, if not not none.
+        expected_invalid_bytes_read is how much of the invalid region survived
+        the save, zero when none of it is readable."""
 
         # Validate we can read the entire expected_region
         error = lldb.SBError()
@@ -51,13 +58,18 @@ class ProcessSaveCoreMinidumpTestCaseYaml(TestBase):
         if expected_invalid_region is None:
             return
 
-        # Validate we can't read the original_region
-        core_process.ReadMemory(
+        # Validate only the saved part of the original_region can be read back.
+        content = core_process.ReadMemory(
             expected_invalid_region.begin,
             expected_invalid_region.end - expected_invalid_region.begin,
             error,
         )
-        self.assertTrue(error.Fail(), error.GetCString())
+        if expected_invalid_bytes_read == 0:
+            self.assertIsNone(content)
+            self.assertTrue(error.Fail(), error.GetCString())
+        else:
+            self.assertTrue(error.Success(), error.GetCString())
+            self.assertEqual(len(content), expected_invalid_bytes_read)
 
     @skipIfWindows
     def test_saving_sub_memory_range(self):
@@ -89,7 +101,10 @@ class ProcessSaveCoreMinidumpTestCaseYaml(TestBase):
         expected_address_range = AddressRange(begin, end)
         expected_invalid_range = AddressRange(begin, 0x2020)
         self.validate_regions_saved_correctly(
-            core_process, expected_address_range, expected_invalid_range
+            core_process,
+            expected_address_range,
+            expected_invalid_range,
+            expected_invalid_bytes_read=size,
         )
 
     @skipIfWindows
@@ -243,5 +258,8 @@ class ProcessSaveCoreMinidumpTestCaseYaml(TestBase):
         expected_address_range = AddressRange(begin, end)
         expected_invalid_range = AddressRange(begin, begin + 0x1000)
         self.validate_regions_saved_correctly(
-            core_process, expected_address_range, expected_invalid_range
+            core_process,
+            expected_address_range,
+            expected_invalid_range,
+            expected_invalid_bytes_read=size,
         )

--- a/lldb/unittests/Expression/DWARFExpressionTest.cpp
+++ b/lldb/unittests/Expression/DWARFExpressionTest.cpp
@@ -139,7 +139,7 @@ private:
   std::unordered_map<Request, std::vector<uint8_t>, Request::Hash> m_memory;
 };
 
-/// A Process whose `ReadMemory` override queries MockMemory.
+/// A Process whose `DoReadMemory` override queries MockMemory.
 struct MockProcess : Process {
   using addr_t = lldb::addr_t;
 
@@ -160,10 +160,7 @@ struct MockProcess : Process {
     std::memcpy(buf, expected_memory->data(), expected_memory->size());
     return size;
   }
-  size_t ReadMemory(const ProcessAddress &process_addr, void *buf, size_t size,
-                    Status &status) override {
-    return DoReadMemory(process_addr, buf, size, status);
-  }
+  bool ShouldUseMemoryCache(const ProcessAddress &) override { return false; }
   bool CanDebug(lldb::TargetSP, bool) override { return true; }
   Status DoDestroy() override { return Status(); }
   llvm::StringRef GetPluginName() override { return ""; }

--- a/lldb/unittests/Target/MemoryTest.cpp
+++ b/lldb/unittests/Target/MemoryTest.cpp
@@ -1036,3 +1036,205 @@ LoadCommands:
             12u);
   EXPECT_TRUE(short_error.Fail());
 }
+
+// A process that does not clear the Status it is handed
+class StatusPreservingProcess : public Process {
+public:
+  StatusPreservingProcess(lldb::TargetSP target_sp,
+                          lldb::ListenerSP listener_sp)
+      : Process(target_sp, listener_sp) {}
+
+  // Doesn't clear error.
+  size_t DoReadMemory(const ProcessAddress &, void *buf, size_t size,
+                      Status &) override {
+    if (!m_can_read)
+      return 0;
+    memset(buf, 'B', size);
+    return size;
+  }
+
+  bool ShouldUseMemoryCache(const ProcessAddress &) override { return false; }
+
+  void SetCanRead(bool can_read) { m_can_read = can_read; }
+
+  // Boilerplate.
+  bool CanDebug(lldb::TargetSP, bool) override { return true; }
+  Status DoDestroy() override { return {}; }
+  void RefreshStateAfterStop() override {}
+  bool IsAlive() override { return true; }
+  bool DoUpdateThreadList(ThreadList &, ThreadList &) override { return false; }
+  llvm::StringRef GetPluginName() override { return "status-preserving"; }
+
+private:
+  bool m_can_read = true;
+};
+
+// Test that a filecache read that sets the error is cleared when reading from
+// the process.
+TEST_F(MemoryTest, TestReadMemoryClearsStaleFileCacheError) {
+  SubsystemRAII<ObjectFileMachO> subsystems;
+
+  ArchSpec arch("x86_64-apple-macosx-");
+  Platform::SetHostPlatform(PlatformRemoteMacOSX::CreateInstance(true, &arch));
+
+  DebuggerSP debugger_sp = Debugger::CreateInstance();
+  ASSERT_TRUE(debugger_sp);
+
+  TargetSP target_sp = CreateTarget(debugger_sp, arch);
+  ASSERT_TRUE(target_sp);
+
+  ListenerSP listener_sp(Listener::MakeListener("dummy"));
+  auto process_sp =
+      std::make_shared<StatusPreservingProcess>(target_sp, listener_sp);
+  struct TargetHack : public Target {
+    void SetProcess(lldb::ProcessSP process) { m_process_sp = process; }
+  };
+  static_cast<TargetHack *>(target_sp.get())->SetProcess(process_sp);
+
+  // A read-only section whose file contents are absent, so the file cache
+  // cannot read from it.
+  auto expected_file = TestFile::fromYaml(R"(
+--- !mach-o
+FileHeader:
+  magic:           0xFEEDFACF
+  cputype:         0x1000007
+  cpusubtype:      0x3
+  filetype:        0x2
+  ncmds:           1
+  sizeofcmds:      152
+  flags:           0x200085
+  reserved:        0x0
+LoadCommands:
+  - cmd:             LC_SEGMENT_64
+    cmdsize:         152
+    segname:         __TEXT
+    vmaddr:          0x100001000
+    vmsize:          0xC
+    fileoff:         0x0
+    filesize:        0x0
+    maxprot:         5
+    initprot:        5
+    nsects:          1
+    flags:           0
+    Sections:
+      - sectname:        __const
+        segname:         __TEXT
+        addr:            0x100001000
+        size:            12
+        offset:          0x0
+        align:           0
+        reloff:          0x0
+        nreloc:          0
+        flags:           0x0
+        reserved1:       0x0
+        reserved2:       0x0
+        reserved3:       0x0
+...
+)");
+  ASSERT_THAT_EXPECTED(expected_file, llvm::Succeeded());
+
+  ModuleSP module_sp = std::make_shared<Module>(expected_file->moduleSpec());
+  target_sp->GetImages().Append(module_sp, /*notify=*/false);
+
+  SectionList *sections = module_sp->GetSectionList();
+  ASSERT_TRUE(sections);
+  SectionSP section_sp = sections->FindSectionByName(ConstString("__const"));
+  ASSERT_TRUE(section_sp);
+  // The file-cache path only runs for a read-only section.
+  ASSERT_FALSE(Flags(section_sp->GetPermissions()).Test(ePermissionsWritable));
+  target_sp->SetSectionLoadAddress(section_sp, section_sp->GetFileAddress());
+
+  Address addr;
+  ASSERT_TRUE(
+      target_sp->ResolveLoadAddress(section_sp->GetFileAddress(), addr));
+
+  // force_live_memory defaults to false, so the read-only file-cache path runs
+  // first and fails, leaving an error for the live read to supersede.
+  char buf[5] = {};
+  Status error;
+  EXPECT_EQ(target_sp->ReadMemory(addr, buf, sizeof(buf), error), sizeof(buf));
+  EXPECT_TRUE(error.Success()) << error.AsCString();
+  // The filler proves the bytes came from the process, not the file.
+  EXPECT_EQ(llvm::StringRef(buf, sizeof(buf)), "BBBBB");
+
+  // Clearing the stale error must not mask a genuine failure.
+  process_sp->SetCanRead(false);
+  char unread[5] = {};
+  Status fail_error;
+  EXPECT_EQ(target_sp->ReadMemory(addr, unread, sizeof(unread), fail_error),
+            0u);
+  EXPECT_TRUE(fail_error.Fail());
+}
+
+// A process that opts some of its addresses out of the memory cache, the way a
+// plugin with a non-cacheable address space does.
+class SelectivelyCachedProcess : public Process {
+public:
+  static constexpr lldb::addr_t g_cached_addr = 0x1000;
+  static constexpr lldb::addr_t g_uncached_addr = 0x2000;
+
+  SelectivelyCachedProcess(lldb::TargetSP target_sp,
+                           lldb::ListenerSP listener_sp)
+      : Process(target_sp, listener_sp) {}
+
+  bool ShouldUseMemoryCache(const ProcessAddress &process_addr) override {
+    return process_addr.GetValue() != g_uncached_addr;
+  }
+
+  size_t DoReadMemory(const ProcessAddress &process_addr, void *buf,
+                      size_t size, Status &) override {
+    m_reads.emplace_back(process_addr.GetValue(), size);
+    memset(buf, 'B', size);
+    return size;
+  }
+
+  // Boilerplate.
+  bool CanDebug(lldb::TargetSP, bool) override { return true; }
+  Status DoDestroy() override { return {}; }
+  void RefreshStateAfterStop() override {}
+  bool IsAlive() override { return true; }
+  bool DoUpdateThreadList(ThreadList &, ThreadList &) override { return false; }
+  llvm::StringRef GetPluginName() override { return "selectively-cached"; }
+
+  std::vector<std::pair<lldb::addr_t, size_t>> m_reads;
+};
+
+// Test that a read the process doesn't want cached reaches the plugin
+// unchanged, while the others still go through the cache.
+TEST_F(MemoryTest, TestShouldUseMemoryCache) {
+  ArchSpec arch("x86_64-apple-macosx-");
+  Platform::SetHostPlatform(PlatformRemoteMacOSX::CreateInstance(true, &arch));
+
+  DebuggerSP debugger_sp = Debugger::CreateInstance();
+  ASSERT_TRUE(debugger_sp);
+
+  TargetSP target_sp = CreateTarget(debugger_sp, arch);
+  ASSERT_TRUE(target_sp);
+
+  ListenerSP listener_sp(Listener::MakeListener("dummy"));
+  auto process_sp =
+      std::make_shared<SelectivelyCachedProcess>(target_sp, listener_sp);
+
+  // A cached read is served by a whole cache line, not by the requested size.
+  char buf[4] = {};
+  Status error;
+  EXPECT_EQ(process_sp->ReadMemory(SelectivelyCachedProcess::g_cached_addr, buf,
+                                   sizeof(buf), error),
+            sizeof(buf));
+  EXPECT_TRUE(error.Success()) << error.AsCString();
+  ASSERT_EQ(process_sp->m_reads.size(), 1u);
+  EXPECT_EQ(process_sp->m_reads[0].first,
+            SelectivelyCachedProcess::g_cached_addr);
+  EXPECT_GT(process_sp->m_reads[0].second, sizeof(buf));
+
+  // An uncached read asks the plugin for exactly what the caller wanted.
+  process_sp->m_reads.clear();
+  EXPECT_EQ(process_sp->ReadMemory(SelectivelyCachedProcess::g_uncached_addr,
+                                   buf, sizeof(buf), error),
+            sizeof(buf));
+  EXPECT_TRUE(error.Success()) << error.AsCString();
+  ASSERT_EQ(process_sp->m_reads.size(), 1u);
+  EXPECT_EQ(process_sp->m_reads[0].first,
+            SelectivelyCachedProcess::g_uncached_addr);
+  EXPECT_EQ(process_sp->m_reads[0].second, sizeof(buf));
+}


### PR DESCRIPTION
Add Process::ShouldUseMemoryCache so a plugin can keep its reads out of
the memory cache instead of overriding ReadMemory. The plugins that
overrode ReadMemory now implement DoReadMemory, and ReadMemory clears
the error once for all of them.

Assisted-by: Claude