### PR TITLE
[flang][Lower] Rewrite present of device variable to deviceptr

### DIFF
--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -797,22 +797,24 @@ getWholeArrayBase(const Fortran::semantics::MaybeExpr &designator,
 }
 
 template <typename Op>
-static void
-genDataOperandOperations(const Fortran::parser::AccObjectList &objectList,
-                         Fortran::lower::AbstractConverter &converter,
-                         Fortran::semantics::SemanticsContext &semanticsContext,
-                         Fortran::lower::StatementContext &stmtCtx,
-                         llvm::SmallVectorImpl<mlir::Value> &dataOperands,
-                         mlir::acc::DataClause dataClause, bool structured,
-                         bool implicit, llvm::ArrayRef<mlir::Value> async,
-                         llvm::ArrayRef<mlir::Attribute> asyncDeviceTypes,
-                         llvm::ArrayRef<mlir::Attribute> asyncOnlyDeviceTypes,
-                         bool setDeclareAttr = false,
-                         AccDataMap *dataMap = nullptr) {
+static void genDataOperandOperations(
+    const Fortran::parser::AccObjectList &objectList,
+    Fortran::lower::AbstractConverter &converter,
+    Fortran::semantics::SemanticsContext &semanticsContext,
+    Fortran::lower::StatementContext &stmtCtx,
+    llvm::SmallVectorImpl<mlir::Value> &dataOperands,
+    mlir::acc::DataClause dataClause, bool structured, bool implicit,
+    llvm::ArrayRef<mlir::Value> async,
+    llvm::ArrayRef<mlir::Attribute> asyncDeviceTypes,
+    llvm::ArrayRef<mlir::Attribute> asyncOnlyDeviceTypes,
+    bool setDeclareAttr = false, AccDataMap *dataMap = nullptr,
+    std::function<bool(const Fortran::parser::AccObject &)> filter = {}) {
   fir::FirOpBuilder &builder = converter.getFirOpBuilder();
   Fortran::evaluate::ExpressionAnalyzer ea{semanticsContext};
   const bool unwrapBoxAddr = true;
   for (const auto &accObject : objectList.v) {
+    if (filter && !filter(accObject))
+      continue;
     llvm::SmallVector<mlir::Value> bounds;
     std::stringstream asFortran;
     mlir::Location operandLocation = genOperandLocation(converter, accObject);
@@ -2857,12 +2859,28 @@ static Op createComputeOp(
     } else if (const auto *presentClause =
                    std::get_if<Fortran::parser::AccClause::Present>(
                        &clause.u)) {
+      // CUDA device variables (DataAttribute::Device) are always present on
+      // the device, no need for a present check - use deviceptr instead.
+      auto isCUDADevice = [](const Fortran::parser::AccObject &obj) {
+        return Fortran::semantics::IsCUDADevice(
+            getSymbolFromAccObject(obj).GetUltimate());
+      };
+      genDataOperandOperations<mlir::acc::DevicePtrOp>(
+          presentClause->v, converter, semanticsContext, stmtCtx,
+          dataClauseOperands, mlir::acc::DataClause::acc_deviceptr,
+          /*structured=*/true, /*implicit=*/false, async, asyncDeviceTypes,
+          asyncOnlyDeviceTypes, /*setDeclareAttr=*/false, &dataMap,
+          /*filter=*/isCUDADevice);
+      // DevicePtrOp requires no exit operation. Track only the PresentOp ones.
       auto crtDataStart = dataClauseOperands.size();
       genDataOperandOperations<mlir::acc::PresentOp>(
           presentClause->v, converter, semanticsContext, stmtCtx,
           dataClauseOperands, mlir::acc::DataClause::acc_present,
           /*structured=*/true, /*implicit=*/false, async, asyncDeviceTypes,
-          asyncOnlyDeviceTypes, /*setDeclareAttr=*/false, &dataMap);
+          asyncOnlyDeviceTypes, /*setDeclareAttr=*/false, &dataMap,
+          /*filter=*/[&](const Fortran::parser::AccObject &obj) {
+            return !isCUDADevice(obj);
+          });
       presentEntryOperands.append(dataClauseOperands.begin() + crtDataStart,
                                   dataClauseOperands.end());
     } else if (const auto *devicePtrClause =
@@ -3151,13 +3169,29 @@ static void genACCDataOp(Fortran::lower::AbstractConverter &converter,
     } else if (const auto *presentClause =
                    std::get_if<Fortran::parser::AccClause::Present>(
                        &clause.u)) {
-      auto crtDataStart = dataClauseOperands.size();
+      // CUDA device variables (DataAttribute::Device) are always present on
+      // the device, no need for a present check - use deviceptr instead.
+      auto isCUDADevice = [](const Fortran::parser::AccObject &obj) {
+        return Fortran::semantics::IsCUDADevice(
+            getSymbolFromAccObject(obj).GetUltimate());
+      };
+      genDataOperandOperations<mlir::acc::DevicePtrOp>(
+          presentClause->v, converter, semanticsContext, stmtCtx,
+          dataClauseOperands, mlir::acc::DataClause::acc_deviceptr,
+          /*structured=*/true, /*implicit=*/false, async, asyncDeviceTypes,
+          asyncOnlyDeviceTypes, /*setDeclareAttr=*/false, /*dataMap=*/nullptr,
+          /*filter=*/isCUDADevice);
+      // DevicePtrOp requires no exit operation. Track only the PresentOp ones.
+      auto crtPresentStart = dataClauseOperands.size();
       genDataOperandOperations<mlir::acc::PresentOp>(
           presentClause->v, converter, semanticsContext, stmtCtx,
           dataClauseOperands, mlir::acc::DataClause::acc_present,
           /*structured=*/true, /*implicit=*/false, async, asyncDeviceTypes,
-          asyncOnlyDeviceTypes);
-      presentEntryOperands.append(dataClauseOperands.begin() + crtDataStart,
+          asyncOnlyDeviceTypes, /*setDeclareAttr=*/false, /*dataMap=*/nullptr,
+          /*filter=*/[&](const Fortran::parser::AccObject &obj) {
+            return !isCUDADevice(obj);
+          });
+      presentEntryOperands.append(dataClauseOperands.begin() + crtPresentStart,
                                   dataClauseOperands.end());
     } else if (const auto *deviceptrClause =
                    std::get_if<Fortran::parser::AccClause::Deviceptr>(

--- a/flang/test/Lower/OpenACC/acc-present-cuda-device.f90
+++ b/flang/test/Lower/OpenACC/acc-present-cuda-device.f90
@@ -1,0 +1,55 @@
+! RUN: bbc -fopenacc -fcuda -emit-hlfir %s -o - | FileCheck %s
+
+! CHECK-LABEL: func.func @_QPtest_parallel(
+! CHECK: acc.deviceptr{{.*}}name = "b"
+! CHECK: acc.present{{.*}}name = "a"
+! CHECK: acc.delete{{.*}}name = "a"
+subroutine test_parallel(a, b, n)
+  real(8), intent(inout) :: a(:)
+  real(8), device, intent(in) :: b(:)
+  integer :: n
+  !$acc parallel present(a, b)
+  a(1) = b(1)
+  !$acc end parallel
+end subroutine
+
+! CHECK-LABEL: func.func @_QPtest_data(
+! CHECK: acc.deviceptr{{.*}}name = "b"
+! CHECK: acc.present{{.*}}name = "a"
+! CHECK: acc.delete{{.*}}name = "a"
+subroutine test_data(a, b, n)
+  real(8), intent(inout) :: a(:)
+  real(8), device, intent(in) :: b(:)
+  integer :: n
+  !$acc data present(a, b)
+  a(1) = b(1)
+  !$acc end data
+end subroutine
+
+! CHECK-LABEL: func.func @_QPtest_managed(
+! CHECK: acc.present{{.*}}name = "a"
+! CHECK: acc.present{{.*}}name = "b"
+! CHECK: acc.delete{{.*}}name = "a"
+! CHECK: acc.delete{{.*}}name = "b"
+subroutine test_managed(a, b, n)
+  real(8), intent(inout) :: a(:)
+  real(8), managed, intent(in) :: b(:)
+  integer :: n
+  !$acc parallel present(a, b)
+  a(1) = b(1)
+  !$acc end parallel
+end subroutine
+
+! CHECK-LABEL: func.func @_QPtest_unified(
+! CHECK: acc.present{{.*}}name = "a"
+! CHECK: acc.present{{.*}}name = "b"
+! CHECK: acc.delete{{.*}}name = "a"
+! CHECK: acc.delete{{.*}}name = "b"
+subroutine test_unified(a, b, n)
+  real(8), intent(inout) :: a(:)
+  real(8), unified, intent(in) :: b(:)
+  integer :: n
+  !$acc parallel present(a, b)
+  a(1) = b(1)
+  !$acc end parallel
+end subroutine


### PR DESCRIPTION
A cuda device variable is always "present" on the device. Rewrite such occurrences to deviceptr in the front end while we still have the information about which variable is a cuda device variable.