### PR TITLE
[orc-rt] Use StringOutputStream in executor error messages

### DIFF
--- a/orc-rt/lib/executor/ExecutorProcessInfo.cpp
+++ b/orc-rt/lib/executor/ExecutorProcessInfo.cpp
@@ -76,9 +76,10 @@ Expected<size_t> ExecutorProcessInfo::detectPageSize() noexcept {
   if (PageSize == -1)
     return make_error<StringError>(strerror(errno));
   if (!isPowerOf2(PageSize))
-    return make_error<StringError>("reported page size " +
-                                   std::to_string(PageSize) +
-                                   " is not a power of two");
+    return make_error<StringError>((StringOutputStream()
+                                    << "reported page size " << PageSize
+                                    << " is not a power of two")
+                                       .str());
   return static_cast<size_t>(PageSize);
 }
 

--- a/orc-rt/lib/executor/NativeDylibManager.cpp
+++ b/orc-rt/lib/executor/NativeDylibManager.cpp
@@ -13,8 +13,6 @@
 #include "orc-rt/NativeDylibManager.h"
 #include "orc-rt/Session.h"
 
-#include <sstream> // For NativeDylibAPIs.inc.
-
 #if defined(__APPLE__) || defined(__linux__)
 #include "Unix/NativeDylibAPIs.inc"
 #else

--- a/orc-rt/lib/executor/SimpleNativeMemoryMap.cpp
+++ b/orc-rt/lib/executor/SimpleNativeMemoryMap.cpp
@@ -15,9 +15,9 @@
 
 #include "orc-rt/SimpleNativeMemoryMap.h"
 #include "orc-rt/Session.h"
+#include "orc-rt/StringExtras.h"
 
 #include <optional>
-#include <sstream>
 
 #if defined(__APPLE__) || defined(__linux__)
 #include "Unix/NativeMemoryAPIs.inc"
@@ -52,9 +52,8 @@ void SimpleNativeMemoryMap::reserve(OnReserveCompleteFn &&OnComplete,
                                     size_t Size) {
   if (Size % S.processInfo().pageSize()) {
     return OnComplete(make_error<StringError>(
-        (std::ostringstream()
-         << "SimpleNativeMemoryMap error: reserved size " << std::hex << Size
-         << " is not a page-size multiple")
+        (StringOutputStream() << "SimpleNativeMemoryMap error: reserved size "
+                              << hex(Size) << " is not a page-size multiple")
             .str()));
   }
 
@@ -85,11 +84,12 @@ void SimpleNativeMemoryMap::release(OnReleaseCompleteFn &&OnComplete,
   }
 
   if (!SI) {
-    std::ostringstream ErrMsg;
-    ErrMsg << "SimpleNativeMemoryMap error: release called on unrecognized "
-              "address "
-           << Addr;
-    return OnComplete(make_error<StringError>(ErrMsg.str()));
+    return OnComplete(make_error<StringError>(
+        (StringOutputStream()
+         << "SimpleNativeMemoryMap error: release called on unrecognized "
+            "address "
+         << Addr)
+            .str()));
   }
 
   for (auto &[Addr, DAAs] : SI->DeallocActions)
@@ -116,11 +116,11 @@ void SimpleNativeMemoryMap::initialize(OnInitializeCompleteFn &&OnComplete,
 
     if (S.Content.size() > S.Size) {
       return OnComplete(make_error<StringError>(
-          (std::ostringstream()
+          (StringOutputStream()
            << "For segment [" << (void *)S.Address << ".."
            << (void *)(S.Address + S.Size) << "), "
-           << " content size (" << std::hex << S.Content.size()
-           << ") exceeds segment size (" << S.Size << ")")
+           << " content size (" << hex(S.Content.size())
+           << ") exceeds segment size (" << hex(S.Size) << ")")
               .str()));
     }
 
@@ -181,12 +181,12 @@ void SimpleNativeMemoryMap::deinitialize(OnDeinitializeCompleteFn &&OnComplete,
     auto I = SI->DeallocActions.find(Base);
     if (I == SI->DeallocActions.end()) {
       Lock.unlock();
-      std::ostringstream ErrMsg;
-      ErrMsg
-          << "SimpleNativeMemoryMap deinitialize error: no deallocate actions "
-             "registered for segment base address "
-          << Base;
-      return OnComplete(make_error<StringError>(ErrMsg.str()));
+      return OnComplete(make_error<StringError>(
+          (StringOutputStream()
+           << "SimpleNativeMemoryMap deinitialize error: no deallocate actions "
+              "registered for segment base address "
+           << Base)
+              .str()));
     }
 
     DAAs = std::move(I->second);
@@ -302,10 +302,11 @@ void SimpleNativeMemoryMap::shutdownNext(Service::OnCompleteFn OnComplete,
 }
 
 Error SimpleNativeMemoryMap::makeBadSlabError(void *Base, const char *Op) {
-  std::ostringstream ErrMsg;
-  ErrMsg << "SimpleNativeMemoryMap " << Op << " error: segment base address "
-         << Base << " does not fall within an allocated slab";
-  return make_error<StringError>(ErrMsg.str());
+  return make_error<StringError>((StringOutputStream()
+                                  << "SimpleNativeMemoryMap " << Op
+                                  << " error: segment base address " << Base
+                                  << " does not fall within an allocated slab")
+                                     .str());
 }
 
 SimpleNativeMemoryMap::SlabInfo *
@@ -336,10 +337,9 @@ Error SimpleNativeMemoryMap::recordDeallocActions(
   auto I = SI->DeallocActions.find(Base);
   if (I != SI->DeallocActions.end()) {
     Lock.unlock();
-    std::ostringstream ErrMsg;
-    ErrMsg << "SimpleNativeMemoryMap initialize error: segment base address "
-              "reused in subsequent initialize call";
-    return make_error<StringError>(ErrMsg.str());
+    return make_error<StringError>(
+        "SimpleNativeMemoryMap initialize error: segment base address "
+        "reused in subsequent initialize call");
   }
 
   SI->DeallocActions[Base] = std::move(DeallocActions);

--- a/orc-rt/lib/executor/Unix/NativeDylibAPIs.inc
+++ b/orc-rt/lib/executor/Unix/NativeDylibAPIs.inc
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "orc-rt/Error.h"
+#include "orc-rt/StringExtras.h"
 
 #include <dlfcn.h>
 
@@ -21,11 +22,11 @@ inline void *hostOSGetGlobalLookupHandle() { return RTLD_DEFAULT; }
 orc_rt::Expected<void *> hostOSLoadLibrary(const std::string &Path) {
   assert(!Path.empty() && "hostOSLoadLibray doesn't support empty paths");
   void *H = dlopen(Path.c_str(), RTLD_LAZY | RTLD_LOCAL);
-  if (H == nullptr) {
-    std::ostringstream ErrMsg;
-    ErrMsg << "error loading \"" << Path << "\": " << dlerror();
-    return orc_rt::make_error<orc_rt::StringError>(ErrMsg.str());
-  }
+  if (H == nullptr)
+    return orc_rt::make_error<orc_rt::StringError>(
+        (orc_rt::StringOutputStream()
+         << "error loading \"" << Path << "\": " << dlerror())
+            .str());
 
   return H;
 }
@@ -33,7 +34,7 @@ orc_rt::Expected<void *> hostOSLoadLibrary(const std::string &Path) {
 orc_rt::Error hostOSUnloadLibrary(void *Handle) {
   if (dlclose(Handle) != 0)
     return orc_rt::make_error<orc_rt::StringError>(
-        (std::ostringstream()
+        (orc_rt::StringOutputStream()
          << "error unloading " << Handle << ": " << dlerror())
             .str());
   return orc_rt::Error::success();


### PR DESCRIPTION
Replace std::ostringstream and std::to_string in the executor's error-message construction with orc_rt::StringOutputStream, dropping <sstream> (and its iostreams + locale machinery) from the executor, which runs on-target including on freestanding platforms.

Converted SimpleNativeMemoryMap.cpp, ExecutorProcessInfo.cpp, and Unix/NativeDylibAPIs.inc; NativeDylibManager.cpp no longer needs to include <sstream> for the latter. Messages that only feed an error are built from a StringOutputStream temporary; one all-literal message drops the stream entirely.

Hex values now carry a "0x" prefix (StringOutputStream::hex always emits one), where the old std::hex produced bare digits. No test depends on the exact message text.