### PR TITLE
[MLIR] Fix control-flow sinking through nested regions

### DIFF
--- a/mlir/lib/Transforms/Utils/ControlFlowSinkUtils.cpp
+++ b/mlir/lib/Transforms/Utils/ControlFlowSinkUtils.cpp
@@ -110,8 +110,7 @@ void Sinker::tryToSinkPredecessors(Operation *user, Region *region,
 
 void Sinker::sinkRegion(Region *region) {
   // Initialize the work queue with all the ops in the region, including
-  // nested regions. Seed from all operations so that uses in non-entry and
-  // nested blocks trigger sinking.
+  // nested regions.
   std::vector<Operation *> stack;
   region->walk([&](Operation *op) { stack.push_back(op); });
 

--- a/mlir/lib/Transforms/Utils/ControlFlowSinkUtils.cpp
+++ b/mlir/lib/Transforms/Utils/ControlFlowSinkUtils.cpp
@@ -80,8 +80,11 @@ bool Sinker::allUsersDominatedBy(Operation *op, Region *region) {
          "expected op to be defined outside the region");
   return llvm::all_of(op->getUsers(), [&](Operation *user) {
     // The user is dominated by the region if its containing block is dominated
-    // by the region's entry block.
-    return domInfo.dominates(&region->front(), user->getBlock());
+    // by the region's entry block. Additionally, allow users that are in
+    // descendant regions of the region (e.g., nested loops) since those
+    // should still permit sinking into the outer region.
+    return domInfo.dominates(&region->front(), user->getBlock()) ||
+           region->isAncestor(user->getParentRegion());
   });
 }
 
@@ -91,12 +94,13 @@ void Sinker::tryToSinkPredecessors(Operation *user, Region *region,
          << OpWithFlags(user, OpPrintingFlags().skipRegions());
   for (Value value : user->getOperands()) {
     Operation *op = value.getDefiningOp();
-    // Ignore block arguments and ops that are already inside the region.
-    if (!op || op->getParentRegion() == region)
+    // Ignore block arguments and ops already contained in the target region,
+    // including ops in nested regions. Only consider defs outside the target
+    // region.
+    if (!op || region->isAncestor(op->getParentRegion()))
       continue;
     LDBG() << "Try to sink:\n"
            << OpWithFlags(op, OpPrintingFlags().skipRegions());
-
     // If the op's users are all in the region and it can be moved, then do so.
     if (allUsersDominatedBy(op, region) && shouldMoveIntoRegion(op, region)) {
       moveIntoRegion(op, region);
@@ -108,12 +112,11 @@ void Sinker::tryToSinkPredecessors(Operation *user, Region *region,
 }
 
 void Sinker::sinkRegion(Region *region) {
-  // Initialize the work queue with all the ops in the region.
+  // Initialize the work queue with all the ops in the region, including
+  // nested regions. Seed from all operations so that uses in non-entry and
+  // nested blocks trigger sinking.
   std::vector<Operation *> stack;
-  for (Block &block : *region)
-    // Seed from all block so that uses in non-entry blocks and trigger sinking
-    for (Operation &op : block)
-      stack.push_back(&op);
+  region->walk([&](Operation *op) { stack.push_back(op); });
 
   // Process all the ops depth-first. This ensures that nodes of subgraphs are
   // sunk in the correct order.

--- a/mlir/lib/Transforms/Utils/ControlFlowSinkUtils.cpp
+++ b/mlir/lib/Transforms/Utils/ControlFlowSinkUtils.cpp
@@ -80,7 +80,7 @@ bool Sinker::allUsersDominatedBy(Operation *op, Region *region) {
          "expected op to be defined outside the region");
   return llvm::all_of(op->getUsers(), [&](Operation *user) {
     // The user is dominated by the region if its containing block is dominated
-    // by the region's entry block
+    // by the region's entry block.
     return domInfo.dominates(&region->front(), user->getBlock());
   });
 }

--- a/mlir/lib/Transforms/Utils/ControlFlowSinkUtils.cpp
+++ b/mlir/lib/Transforms/Utils/ControlFlowSinkUtils.cpp
@@ -93,7 +93,6 @@ void Sinker::tryToSinkPredecessors(Operation *user, Region *region,
     Operation *op = value.getDefiningOp();
     // Ignore block arguments and ops already contained in the target region,
     // including ops in nested regions.
-    // region.
     if (!op || region->isAncestor(op->getParentRegion()))
       continue;
     LDBG() << "Try to sink:\n"

--- a/mlir/lib/Transforms/Utils/ControlFlowSinkUtils.cpp
+++ b/mlir/lib/Transforms/Utils/ControlFlowSinkUtils.cpp
@@ -92,7 +92,7 @@ void Sinker::tryToSinkPredecessors(Operation *user, Region *region,
   for (Value value : user->getOperands()) {
     Operation *op = value.getDefiningOp();
     // Ignore block arguments and ops already contained in the target region,
-    // including ops in nested regions. Only consider defs outside the target
+    // including ops in nested regions.
     // region.
     if (!op || region->isAncestor(op->getParentRegion()))
       continue;

--- a/mlir/lib/Transforms/Utils/ControlFlowSinkUtils.cpp
+++ b/mlir/lib/Transforms/Utils/ControlFlowSinkUtils.cpp
@@ -80,11 +80,8 @@ bool Sinker::allUsersDominatedBy(Operation *op, Region *region) {
          "expected op to be defined outside the region");
   return llvm::all_of(op->getUsers(), [&](Operation *user) {
     // The user is dominated by the region if its containing block is dominated
-    // by the region's entry block. Additionally, allow users that are in
-    // descendant regions of the region (e.g., nested loops) since those
-    // should still permit sinking into the outer region.
-    return domInfo.dominates(&region->front(), user->getBlock()) ||
-           region->isAncestor(user->getParentRegion());
+    // by the region's entry block
+    return domInfo.dominates(&region->front(), user->getBlock());
   });
 }
 

--- a/mlir/test/Dialect/SCF/control-flow-sink.mlir
+++ b/mlir/test/Dialect/SCF/control-flow-sink.mlir
@@ -80,3 +80,27 @@ func.func @test_scf_execute_region_multiblock_sink(%arg0: i32, %arg1: i32) {
   }
   return
 }
+
+// -----
+
+func.func private @sink_i32(i32)
+
+// CHECK-LABEL: @test_scf_if_sink_through_loop
+// CHECK-SAME: (%[[ARG0:.*]]: i1, %[[ARG1:.*]]: index, %[[ARG2:.*]]: i32, %[[ARG3:.*]]: i32)
+// CHECK: scf.if %[[ARG0]]
+// CHECK:   %[[V0:.*]] = arith.muli %[[ARG2]], %[[ARG3]]
+// CHECK:   scf.for
+// CHECK:     call @sink_i32(%[[V0]])
+
+func.func @test_scf_if_sink_through_loop(
+    %arg0: i1, %arg1: index, %arg2: i32, %arg3: i32) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %0 = arith.muli %arg2, %arg3 : i32
+  scf.if %arg0 {
+    scf.for %arg4 = %c0 to %arg1 step %c1 {
+      func.call @sink_i32(%0) : (i32) -> ()
+    }
+  }
+  return
+}

--- a/mlir/test/Dialect/SCF/control-flow-sink.mlir
+++ b/mlir/test/Dialect/SCF/control-flow-sink.mlir
@@ -104,3 +104,24 @@ func.func @test_scf_if_sink_through_loop(
   }
   return
 }
+
+// CHECK-LABEL: @test_scf_if_sink_through_loop_with_external_use
+// CHECK: %[[V0:.*]] = arith.muli %{{.*}}, %{{.*}}
+// CHECK: scf.if
+// CHECK:   scf.for
+// CHECK:     call @sink_i32(%[[V0]])
+// CHECK: call @sink_i32(%[[V0]])
+
+func.func @test_scf_if_sink_through_loop_with_external_use(
+    %arg0: i1, %arg1: index, %arg2: i32, %arg3: i32) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %0 = arith.muli %arg2, %arg3 : i32
+  scf.if %arg0 {
+    scf.for %arg4 = %c0 to %arg1 step %c1 {
+      func.call @sink_i32(%0) : (i32) -> ()
+    }
+  }
+  func.call @sink_i32(%0) : (i32) -> ()
+  return
+}


### PR DESCRIPTION
Fix control-flow sinking through nested regions.

This allows operations used in nested regions to be sunk into their enclosing region and adds a regression test for `scf.if` containing `scf.for`.

Fixes #216912

Assisted by ChatGPT (GPT-5.6 Luna). The final code and tests were reviewed by the author.