### PR TITLE
[Clang][Sema] Don't crash on failed aggregate CTAD for aliases

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -443,6 +443,11 @@ features cannot lower the translation-unit ABI level;
 
 #### Bug Fixes to C++ Support
 
+- Fixed a crash when aggregate class template argument deduction was attempted
+  on an alias template after error recovery, for example after a missing
+  include. Clang now fails deduction instead of treating the alias as a class
+  template.
+
 - Fixed an issue where `__typeof__` incorrectly rejected cv-qualified function types.
 
 - Fixed a bug where top-level CV qualifiers (such as ``const``) were dropped from pointers modified by Microsoft pointer attributes (like ``__ptr32`` and ``__ptr64``) and WebAssembly's ``__funcref``.

--- a/clang/lib/Sema/SemaTemplateDeductionGuide.cpp
+++ b/clang/lib/Sema/SemaTemplateDeductionGuide.cpp
@@ -1607,10 +1607,15 @@ CXXDeductionGuideDecl *Sema::DeclareAggregateDeductionGuideFromInitList(
       AggregateDeductionCandidates[Hash] = GD;
       return GD;
     }
+    // Failed alias synthesis must not fall through: the templated decl is a
+    // TypeAliasDecl, not a CXXRecordDecl.
+    return nullptr;
   }
 
-  if (CXXRecordDecl *DefRecord =
-          cast<CXXRecordDecl>(Template->getTemplatedDecl())->getDefinition()) {
+  auto *RD = dyn_cast_or_null<CXXRecordDecl>(Template->getTemplatedDecl());
+  if (!RD)
+    return nullptr;
+  if (CXXRecordDecl *DefRecord = RD->getDefinition()) {
     if (TemplateDecl *DescribedTemplate =
             DefRecord->getDescribedClassTemplate())
       Template = DescribedTemplate;

--- a/clang/test/SemaCXX/ctad-alias-aggregate-recovery.cpp
+++ b/clang/test/SemaCXX/ctad-alias-aggregate-recovery.cpp
@@ -1,8 +1,9 @@
 // RUN: %clang_cc1 -fsyntax-only -std=c++20 -verify %s
 
-// Aggregate CTAD for an alias template after error recovery must not crash.
-// DeclareAggregateDeductionGuideFromInitList used to fall through and
-// llvm::cast the alias's TypeAliasDecl to CXXRecordDecl.
+// A prior fatal diagnostic makes InstantiatingTemplate invalid, so alias
+// aggregate-guide synthesis returns null. The old code then llvm::cast a
+// TypeAliasDecl to CXXRecordDecl. That SIGSEGVs on clang 22.1.8. Rel+Asserts
+// trunk may not crash: the cast is UB and can be optimized into a null return.
 
 template <class T> struct S {
   T v;

--- a/clang/test/SemaCXX/ctad-alias-aggregate-recovery.cpp
+++ b/clang/test/SemaCXX/ctad-alias-aggregate-recovery.cpp
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -fsyntax-only -std=c++20 -verify %s
+
+// Aggregate CTAD for an alias template after error recovery must not crash.
+// DeclareAggregateDeductionGuideFromInitList used to fall through and
+// llvm::cast the alias's TypeAliasDecl to CXXRecordDecl.
+
+template <class T> struct S {
+  T v;
+};
+template <class T>
+using U = S<T>;
+#include "this_header_does_not_exist.h" // expected-error {{'this_header_does_not_exist.h' file not found}}
+U x{0};


### PR DESCRIPTION
When synthesizing an aggregate deduction guide for a type alias template failed, `Sema::DeclareAggregateDeductionGuideFromInitList` fell through and `llvm::cast` the alias's `TypeAliasDecl` to `CXXRecordDecl`. That is UB and SIGSEGVs after error recovery — for example a missing include while parsing `Alias x{...}` for `template<class T> using Alias = Aggr<T>`.

https://github.com/llvm/llvm-project/issues/112953 reported a crash in the same function; that issue was already closed after https://github.com/llvm/llvm-project/issues/111508 / https://github.com/llvm/llvm-project/pull/111804. This is a remaining hole: failed alias-template aggregate synthesis still fell through to the class-template path. The reduced missing-include case still SIGSEGVs on clang 22.1.8.

The sibling `DeclareImplicitDeductionGuides` already returns early for alias templates and uses `dyn_cast_or_null`. Apply the same here.

Minimal repro (crashes 22.1.8; Rel+Asserts trunk may not crash because the bad cast is UB):

```c++
template<class T> struct S { T v; };
template<class T> using U = S<T>;
#include "missing.h"
U x{0};
```

Grok 4.6 was used to help write this change.