### PR TITLE
[lldb] Add MSVC STL formatters for remaining standard library types

### DIFF
--- a/lldb/source/Plugins/Language/CPlusPlus/CMakeLists.txt
+++ b/lldb/source/Plugins/Language/CPlusPlus/CMakeLists.txt
@@ -41,11 +41,13 @@ add_lldb_library(lldbPluginCPlusPlusLanguage PLUGIN
   MsvcStl.cpp
   MsvcStlAtomic.cpp
   MsvcStlDeque.cpp
+  MsvcStlExpected.cpp
   MsvcStlSmartPointer.cpp
   MsvcStlSpan.cpp
   MsvcStlTree.cpp
   MsvcStlTuple.cpp
   MsvcStlUnordered.cpp
+  MsvcStlValarray.cpp
   MsvcStlVariant.cpp
   MsvcStlVector.cpp
   MSVCUndecoratedNameParser.cpp

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -1725,6 +1725,51 @@ GenericStrongOrderingSummaryProvider(ValueObject &valobj, Stream &stream,
   return LibStdcppStrongOrderingSummaryProvider(valobj, stream, options);
 }
 
+static SyntheticChildrenFrontEnd *
+GenericBitsetSyntheticFrontEndCreator(CXXSyntheticChildren *children,
+                                      lldb::ValueObjectSP valobj_sp) {
+  if (!valobj_sp)
+    return nullptr;
+  if (IsMsvcStlBitset(*valobj_sp))
+    return MsvcStlBitsetSyntheticFrontEndCreator(children, valobj_sp);
+  return LibStdcppBitsetSyntheticFrontEndCreator(children, valobj_sp);
+}
+
+static bool
+GenericSourceLocationSummaryProvider(ValueObject &valobj, Stream &stream,
+                                     const TypeSummaryOptions &options) {
+  if (IsMsvcStlSourceLocation(valobj))
+    return MsvcStlSourceLocationSummaryProvider(valobj, stream, options);
+  return LibStdcppSourceLocationSummaryProvider(valobj, stream, options);
+}
+
+static SyntheticChildrenFrontEnd *
+GenericValarraySyntheticFrontEndCreator(CXXSyntheticChildren *children,
+                                        lldb::ValueObjectSP valobj_sp) {
+  if (!valobj_sp)
+    return nullptr;
+  if (IsMsvcStlValarray(*valobj_sp))
+    return MsvcStlValarraySyntheticFrontEndCreator(children, valobj_sp);
+  return nullptr;
+}
+
+static SyntheticChildrenFrontEnd *
+GenericExpectedSyntheticFrontEndCreator(CXXSyntheticChildren *children,
+                                        lldb::ValueObjectSP valobj_sp) {
+  if (!valobj_sp)
+    return nullptr;
+  if (IsMsvcStlExpected(*valobj_sp))
+    return MsvcStlExpectedSyntheticFrontEndCreator(children, valobj_sp);
+  return nullptr;
+}
+
+static bool GenericExpectedSummaryProvider(ValueObject &valobj, Stream &stream,
+                                           const TypeSummaryOptions &options) {
+  if (IsMsvcStlExpected(valobj))
+    return MsvcStlExpectedSummaryProvider(valobj, stream, options);
+  return false;
+}
+
 /// Load formatters that are formatting types from more than one STL
 static void LoadCommonStlFormatters(lldb::TypeCategoryImplSP cpp_category_sp) {
   if (!cpp_category_sp)
@@ -1947,6 +1992,97 @@ static void LoadCommonStlFormatters(lldb::TypeCategoryImplSP cpp_category_sp) {
                 "MSVC STL/libstdc++ std::strong_ordering summary provider",
                 "std::strong_ordering",
                 eTypeOptionHideChildren | eTypeOptionHideValue, false);
+
+  // Container adaptors store the underlying container in a member named `c`
+  // in both MSVC STL and libstdc++.
+  AddCXXSynthetic(cpp_category_sp, LibcxxQueueFrontEndCreator,
+                  "std::queue synthetic children", "^std::queue<.+>(( )?&)?$",
+                  stl_synth_flags, true);
+  AddCXXSynthetic(cpp_category_sp, LibcxxQueueFrontEndCreator,
+                  "std::stack synthetic children", "^std::stack<.+>(( )?&)?$",
+                  stl_synth_flags, true);
+  AddCXXSynthetic(cpp_category_sp, LibcxxQueueFrontEndCreator,
+                  "std::priority_queue synthetic children",
+                  "^std::priority_queue<.+>(( )?&)?$", stl_synth_flags, true);
+  AddCXXSummary(cpp_category_sp, ContainerSizeSummaryProvider,
+                "std::queue summary provider", "^std::queue<.+>(( )?&)?$",
+                stl_summary_flags, true);
+  AddCXXSummary(cpp_category_sp, ContainerSizeSummaryProvider,
+                "std::stack summary provider", "^std::stack<.+>(( )?&)?$",
+                stl_summary_flags, true);
+  AddCXXSummary(cpp_category_sp, ContainerSizeSummaryProvider,
+                "std::priority_queue summary provider",
+                "^std::priority_queue<.+>(( )?&)?$", stl_summary_flags, true);
+
+  AddCXXSynthetic(cpp_category_sp, GenericBitsetSyntheticFrontEndCreator,
+                  "MSVC STL/libstdc++ std::bitset synthetic children",
+                  "^std::(__debug::)?bitset<.+>(( )?&)?$", stl_deref_flags,
+                  true);
+
+  AddCXXSynthetic(cpp_category_sp, GenericValarraySyntheticFrontEndCreator,
+                  "MSVC STL std::valarray synthetic children",
+                  "^std::valarray<.+>(( )?&)?$", stl_synth_flags, true);
+  AddCXXSummary(cpp_category_sp, ContainerSizeSummaryProvider,
+                "MSVC STL std::valarray summary provider",
+                "^std::valarray<.+>(( )?&)?$", stl_summary_flags, true);
+
+  AddCXXSynthetic(cpp_category_sp, GenericExpectedSyntheticFrontEndCreator,
+                  "MSVC STL std::expected synthetic children",
+                  "^std::expected<.+>(( )?&)?$", stl_synth_flags, true);
+  AddCXXSummary(cpp_category_sp, GenericExpectedSummaryProvider,
+                "MSVC STL std::expected summary provider",
+                "^std::expected<.+>(( )?&)?$", stl_summary_flags, true);
+
+  AddCXXSynthetic(
+      cpp_category_sp, MsvcStlVectorIteratorSyntheticFrontEndCreator,
+      "MSVC STL vector iterator synthetic children",
+      "^std::_Vector(_const)?_iterator<.+>(( )?&)?$", stl_synth_flags, true);
+
+  AddCXXSummary(cpp_category_sp, GenericSourceLocationSummaryProvider,
+                "MSVC STL/libstdc++ std::source_location summary provider",
+                "std::source_location", stl_summary_flags);
+
+  AddCXXSummary(cpp_category_sp, MsvcStlErrorCodeSummaryProvider,
+                "MSVC STL/libstdc++ std::error_code summary provider",
+                "std::error_code",
+                eTypeOptionHideChildren | eTypeOptionHideValue);
+  AddCXXSummary(cpp_category_sp, MsvcStlErrorCodeSummaryProvider,
+                "MSVC STL/libstdc++ std::error_condition summary provider",
+                "std::error_condition",
+                eTypeOptionHideChildren | eTypeOptionHideValue);
+
+  AddCXXSummary(cpp_category_sp, MsvcStlFilesystemPathSummaryProvider,
+                "MSVC STL/libstdc++ std::filesystem::path summary provider",
+                "std::filesystem::path", stl_summary_flags);
+
+  auto add_chrono_duration = [&](const char *type_name, const char *unit) {
+    AddCXXSummary(
+        cpp_category_sp,
+        [unit](ValueObject &valobj, Stream &stream,
+               const TypeSummaryOptions &options) {
+          return GenericChronoDurationSummaryProvider(valobj, stream, options,
+                                                      unit);
+        },
+        "MSVC STL std::chrono duration summary provider", type_name,
+        // Don't hide children: these typedefs are also used by libstdc++,
+        // which does not have `_MyRep`. If the summary callback fails the
+        // raw members must still be visible.
+        TypeSummaryImpl::Flags()
+            .SetCascades(true)
+            .SetDontShowChildren(false)
+            .SetDontShowValue(false)
+            .SetHideItemNames(false));
+  };
+  add_chrono_duration("std::chrono::nanoseconds", "ns");
+  add_chrono_duration("std::chrono::microseconds", "µs");
+  add_chrono_duration("std::chrono::milliseconds", "ms");
+  add_chrono_duration("std::chrono::seconds", "s");
+  add_chrono_duration("std::chrono::minutes", "min");
+  add_chrono_duration("std::chrono::hours", "h");
+  add_chrono_duration("std::chrono::days", "days");
+  add_chrono_duration("std::chrono::weeks", "weeks");
+  add_chrono_duration("std::chrono::months", "months");
+  add_chrono_duration("std::chrono::years", "years");
 }
 
 static void LoadMsvcStlFormatters(lldb::TypeCategoryImplSP cpp_category_sp) {

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -1770,6 +1770,13 @@ static bool GenericExpectedSummaryProvider(ValueObject &valobj, Stream &stream,
   return false;
 }
 
+static bool GenericValarraySummaryProvider(ValueObject &valobj, Stream &stream,
+                                           const TypeSummaryOptions &options) {
+  if (!IsMsvcStlValarray(valobj))
+    return false;
+  return ContainerSizeSummaryProvider(valobj, stream, options);
+}
+
 /// Load formatters that are formatting types from more than one STL
 static void LoadCommonStlFormatters(lldb::TypeCategoryImplSP cpp_category_sp) {
   if (!cpp_category_sp)
@@ -2021,8 +2028,8 @@ static void LoadCommonStlFormatters(lldb::TypeCategoryImplSP cpp_category_sp) {
 
   AddCXXSynthetic(cpp_category_sp, GenericValarraySyntheticFrontEndCreator,
                   "MSVC STL std::valarray synthetic children",
-                  "^std::valarray<.+>(( )?&)?$", stl_synth_flags, true);
-  AddCXXSummary(cpp_category_sp, ContainerSizeSummaryProvider,
+                  "^std::valarray<.+>(( )?&)?$", stl_deref_flags, true);
+  AddCXXSummary(cpp_category_sp, GenericValarraySummaryProvider,
                 "MSVC STL std::valarray summary provider",
                 "^std::valarray<.+>(( )?&)?$", stl_summary_flags, true);
 
@@ -2044,12 +2051,10 @@ static void LoadCommonStlFormatters(lldb::TypeCategoryImplSP cpp_category_sp) {
 
   AddCXXSummary(cpp_category_sp, MsvcStlErrorCodeSummaryProvider,
                 "MSVC STL/libstdc++ std::error_code summary provider",
-                "std::error_code",
-                eTypeOptionHideChildren | eTypeOptionHideValue);
+                "std::error_code", stl_summary_flags);
   AddCXXSummary(cpp_category_sp, MsvcStlErrorCodeSummaryProvider,
                 "MSVC STL/libstdc++ std::error_condition summary provider",
-                "std::error_condition",
-                eTypeOptionHideChildren | eTypeOptionHideValue);
+                "std::error_condition", stl_summary_flags);
 
   AddCXXSummary(cpp_category_sp, MsvcStlFilesystemPathSummaryProvider,
                 "MSVC STL/libstdc++ std::filesystem::path summary provider",
@@ -2083,6 +2088,21 @@ static void LoadCommonStlFormatters(lldb::TypeCategoryImplSP cpp_category_sp) {
   add_chrono_duration("std::chrono::weeks", "weeks");
   add_chrono_duration("std::chrono::months", "months");
   add_chrono_duration("std::chrono::years", "years");
+  AddCXXSummary(
+      cpp_category_sp,
+      [](ValueObject &valobj, Stream &stream,
+         const TypeSummaryOptions &options) {
+        return GenericChronoDurationSummaryProvider(valobj, stream, options,
+                                                    nullptr);
+      },
+      "MSVC STL std::chrono::duration summary provider",
+      "^std::chrono::duration<.+>$",
+      TypeSummaryImpl::Flags()
+          .SetCascades(true)
+          .SetDontShowChildren(false)
+          .SetDontShowValue(false)
+          .SetHideItemNames(false),
+      true);
 }
 
 static void LoadMsvcStlFormatters(lldb::TypeCategoryImplSP cpp_category_sp) {

--- a/lldb/source/Plugins/Language/CPlusPlus/GenericBitset.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/GenericBitset.cpp
@@ -8,6 +8,7 @@
 
 #include "LibCxx.h"
 #include "LibStdcpp.h"
+#include "MsvcStl.h"
 #include "lldb/DataFormatters/FormattersHelpers.h"
 #include "lldb/Target/Target.h"
 #include <optional>
@@ -17,12 +18,14 @@ using namespace lldb_private;
 
 namespace {
 
-/// This class can be used for handling bitsets from both libcxx and libstdcpp.
+/// This class can be used for handling bitsets from libc++, libstdc++, and
+/// MSVC STL.
 class GenericBitsetFrontEnd : public SyntheticChildrenFrontEnd {
 public:
   enum class StdLib {
     LibCxx,
     LibStdcpp,
+    MsvcStl,
   };
 
   GenericBitsetFrontEnd(ValueObject &valobj, StdLib stdlib);
@@ -65,11 +68,14 @@ GenericBitsetFrontEnd::GenericBitsetFrontEnd(ValueObject &valobj, StdLib stdlib)
 llvm::StringRef GenericBitsetFrontEnd::GetDataContainerMemberName() {
   static constexpr llvm::StringLiteral s_libcxx_case("__first_");
   static constexpr llvm::StringLiteral s_libstdcpp_case("_M_w");
+  static constexpr llvm::StringLiteral s_msvcstl_case("_Array");
   switch (m_stdlib) {
   case StdLib::LibCxx:
     return s_libcxx_case;
   case StdLib::LibStdcpp:
     return s_libstdcpp_case;
+  case StdLib::MsvcStl:
+    return s_msvcstl_case;
   }
   llvm_unreachable("Unknown StdLib enum");
 }
@@ -144,5 +150,19 @@ SyntheticChildrenFrontEnd *formatters::LibcxxBitsetSyntheticFrontEndCreator(
   if (valobj_sp)
     return new GenericBitsetFrontEnd(*valobj_sp,
                                      GenericBitsetFrontEnd::StdLib::LibCxx);
+  return nullptr;
+}
+
+bool formatters::IsMsvcStlBitset(ValueObject &valobj) {
+  if (auto valobj_sp = valobj.GetNonSyntheticValue())
+    return valobj_sp->GetChildMemberWithName("_Array") != nullptr;
+  return false;
+}
+
+SyntheticChildrenFrontEnd *formatters::MsvcStlBitsetSyntheticFrontEndCreator(
+    CXXSyntheticChildren *, lldb::ValueObjectSP valobj_sp) {
+  if (valobj_sp)
+    return new GenericBitsetFrontEnd(*valobj_sp,
+                                     GenericBitsetFrontEnd::StdLib::MsvcStl);
   return nullptr;
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/GenericInitializerList.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/GenericInitializerList.cpp
@@ -8,35 +8,29 @@
 
 #include "lldb/DataFormatters/FormattersHelpers.h"
 #include "lldb/Utility/ConstString.h"
+#include "lldb/Utility/LLDBLog.h"
+#include "lldb/Utility/Log.h"
+#include "lldb/Utility/StreamString.h"
 #include "lldb/ValueObject/ValueObject.h"
 #include "llvm/Support/ErrorExtras.h"
-#include <cstddef>
+#include <cinttypes>
+#include <cstdint>
 #include <optional>
-#include <type_traits>
 
 using namespace lldb;
 using namespace lldb_private;
 
-namespace generic_check {
-template <class T>
-using size_func = decltype(T::GetSizeMember(std::declval<ValueObject &>()));
-template <class T>
-using start_func = decltype(T::GetStartMember(std::declval<ValueObject &>()));
 namespace {
-template <typename...> struct check_func : std::true_type {};
-} // namespace
-
-template <typename T>
-using has_functions = check_func<size_func<T>, start_func<T>>;
-} // namespace generic_check
 
 struct LibCxx {
   static ValueObjectSP GetStartMember(ValueObject &backend) {
     return backend.GetChildMemberWithName("__begin_");
   }
 
-  static ValueObjectSP GetSizeMember(ValueObject &backend) {
-    return backend.GetChildMemberWithName("__size_");
+  static uint64_t GetNumElements(ValueObject &backend, uint32_t) {
+    if (ValueObjectSP size_sp = backend.GetChildMemberWithName("__size_"))
+      return size_sp->GetValueAsUnsigned(0);
+    return 0;
   }
 };
 
@@ -45,39 +39,46 @@ struct LibStdcpp {
     return backend.GetChildMemberWithName("_M_array");
   }
 
-  static ValueObjectSP GetSizeMember(ValueObject &backend) {
-    return backend.GetChildMemberWithName("_M_len");
+  static uint64_t GetNumElements(ValueObject &backend, uint32_t) {
+    if (ValueObjectSP size_sp = backend.GetChildMemberWithName("_M_len"))
+      return size_sp->GetValueAsUnsigned(0);
+    return 0;
   }
 };
 
-namespace lldb_private::formatters {
+struct MsvcStl {
+  static ValueObjectSP GetStartMember(ValueObject &backend) {
+    return backend.GetChildMemberWithName("_First");
+  }
+
+  static uint64_t GetNumElements(ValueObject &backend, uint32_t element_size) {
+    ValueObjectSP first_sp = backend.GetChildMemberWithName("_First");
+    ValueObjectSP last_sp = backend.GetChildMemberWithName("_Last");
+    if (!first_sp || !last_sp || element_size == 0)
+      return 0;
+    uint64_t first = first_sp->GetValueAsUnsigned(0);
+    uint64_t last = last_sp->GetValueAsUnsigned(0);
+    if (last < first)
+      return 0;
+    uint64_t bytes = last - first;
+    if (bytes % element_size)
+      return 0;
+    return bytes / element_size;
+  }
+};
 
 template <class StandardImpl>
 class GenericInitializerListSyntheticFrontEnd
     : public SyntheticChildrenFrontEnd {
 public:
-  static_assert(generic_check::has_functions<StandardImpl>::value,
-                "Missing Required Functions.");
-
   GenericInitializerListSyntheticFrontEnd(lldb::ValueObjectSP valobj_sp)
       : SyntheticChildrenFrontEnd(*valobj_sp), m_element_type() {
     if (valobj_sp)
       Update();
   }
 
-  ~GenericInitializerListSyntheticFrontEnd() override {
-    // this needs to stay around because it's a child object who will follow its
-    // parent's life cycle
-    // delete m_start;
-  }
-
   llvm::Expected<uint32_t> CalculateNumChildren() override {
-    m_num_elements = 0;
-
-    const ValueObjectSP size_sp(StandardImpl::GetSizeMember(m_backend));
-    if (size_sp)
-      m_num_elements = size_sp->GetValueAsUnsigned(0);
-    return m_num_elements;
+    return StandardImpl::GetNumElements(m_backend, m_element_size);
   }
 
   lldb::ValueObjectSP GetChildAtIndex(uint32_t idx) override {
@@ -95,7 +96,6 @@ public:
 
   lldb::ChildCacheState Update() override {
     m_start = nullptr;
-    m_num_elements = 0;
     m_element_type = m_backend.GetCompilerType().GetTypeTemplateArgument(0);
     if (!m_element_type.IsValid())
       return lldb::ChildCacheState::eRefetch;
@@ -128,8 +128,11 @@ private:
   ValueObject *m_start = nullptr;
   CompilerType m_element_type;
   uint32_t m_element_size = 0;
-  size_t m_num_elements = 0;
 };
+
+} // namespace
+
+namespace lldb_private::formatters {
 
 SyntheticChildrenFrontEnd *GenericInitializerListSyntheticFrontEndCreator(
     CXXSyntheticChildren * /*unused*/, lldb::ValueObjectSP valobj_sp) {
@@ -138,6 +141,8 @@ SyntheticChildrenFrontEnd *GenericInitializerListSyntheticFrontEndCreator(
 
   if (LibCxx::GetStartMember(*valobj_sp) != nullptr)
     return new GenericInitializerListSyntheticFrontEnd<LibCxx>(valobj_sp);
+  if (MsvcStl::GetStartMember(*valobj_sp) != nullptr)
+    return new GenericInitializerListSyntheticFrontEnd<MsvcStl>(valobj_sp);
 
   return new GenericInitializerListSyntheticFrontEnd<LibStdcpp>(valobj_sp);
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStl.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStl.cpp
@@ -12,10 +12,12 @@
 #include "lldb/Core/FormatEntity.h"
 #include "lldb/DataFormatters/StringPrinter.h"
 #include "lldb/DataFormatters/TypeSummary.h"
+#include "lldb/DataFormatters/VectorIterator.h"
 #include "lldb/Utility/ConstString.h"
 #include "lldb/Utility/Status.h"
 #include "lldb/Utility/Stream.h"
 #include "lldb/ValueObject/ValueObject.h"
+#include "llvm/ADT/StringRef.h"
 
 #include "Plugins/Language/CPlusPlus/CxxStringTypes.h"
 
@@ -304,4 +306,113 @@ bool lldb_private::formatters::MsvcStlStrongOrderingSummaryProvider(
     return false;
   }
   return true;
+}
+
+bool lldb_private::formatters::IsMsvcStlSourceLocation(ValueObject &valobj) {
+  if (auto valobj_sp = valobj.GetNonSyntheticValue())
+    return valobj_sp->GetChildMemberWithName("_File") != nullptr &&
+           valobj_sp->GetChildMemberWithName("_Line") != nullptr;
+  return false;
+}
+
+bool lldb_private::formatters::MsvcStlSourceLocationSummaryProvider(
+    ValueObject &valobj, Stream &stream, const TypeSummaryOptions &) {
+  ValueObjectSP file_sp = valobj.GetChildMemberWithName("_File");
+  ValueObjectSP function_sp = valobj.GetChildMemberWithName("_Function");
+  ValueObjectSP line_sp = valobj.GetChildMemberWithName("_Line");
+  ValueObjectSP column_sp = valobj.GetChildMemberWithName("_Column");
+
+  if (!file_sp || !function_sp || !line_sp || !column_sp)
+    return false;
+
+  bool success = false;
+  uint64_t line = line_sp->GetValueAsUnsigned(0, &success);
+  if (!success)
+    return false;
+
+  uint64_t column = column_sp->GetValueAsUnsigned(0, &success);
+  if (!success)
+    return false;
+
+  const char *file = file_sp->GetSummaryAsCString();
+  // Default-constructed source_location is empty; don't invent a summary.
+  if (line == 0 && column == 0 &&
+      (!file || file[0] == '\0' || llvm::StringRef(file) == "\"\""))
+    return false;
+
+  stream.Format("{0}:{1}:{2}", file ? file : "<unknown>", line, column);
+
+  if (const char *function = function_sp->GetSummaryAsCString())
+    stream.Printf(" (%s)", function);
+
+  return true;
+}
+
+bool lldb_private::formatters::IsMsvcStlErrorCode(ValueObject &valobj) {
+  if (auto valobj_sp = valobj.GetNonSyntheticValue())
+    return valobj_sp->GetChildMemberWithName("_Myval") != nullptr &&
+           valobj_sp->GetChildMemberWithName("_Mycat") != nullptr;
+  return false;
+}
+
+bool lldb_private::formatters::MsvcStlErrorCodeSummaryProvider(
+    ValueObject &valobj, Stream &stream, const TypeSummaryOptions &) {
+  ValueObjectSP value_sp = valobj.GetChildMemberWithName("_Myval");
+  if (!value_sp)
+    value_sp = valobj.GetChildMemberWithName("_M_value");
+  if (!value_sp)
+    return false;
+
+  const char *value = value_sp->GetValueAsCString();
+  if (!value)
+    return false;
+
+  stream.Printf("value=%s", value);
+  return true;
+}
+
+bool lldb_private::formatters::IsMsvcStlFilesystemPath(ValueObject &valobj) {
+  if (auto valobj_sp = valobj.GetNonSyntheticValue())
+    return valobj_sp->GetChildMemberWithName("_Text") != nullptr;
+  return false;
+}
+
+bool lldb_private::formatters::MsvcStlFilesystemPathSummaryProvider(
+    ValueObject &valobj, Stream &stream, const TypeSummaryOptions &) {
+  ValueObjectSP text_sp = valobj.GetChildMemberWithName("_Text");
+  if (!text_sp)
+    text_sp = valobj.GetChildMemberWithName("_M_pathname");
+  if (!text_sp)
+    return false;
+
+  if (const char *summary = text_sp->GetSummaryAsCString()) {
+    stream << summary;
+    return true;
+  }
+  return false;
+}
+
+bool lldb_private::formatters::GenericChronoDurationSummaryProvider(
+    ValueObject &valobj, Stream &stream, const TypeSummaryOptions &,
+    const char *unit) {
+  // MSVC STL stores the tick count in `_MyRep`. Do not match libstdc++
+  // (`__r` / `_M_rep`); those types share the `std::chrono::*` typedef names.
+  ValueObjectSP rep_sp = valobj.GetChildMemberWithName("_MyRep");
+  if (!rep_sp)
+    return false;
+
+  const char *rep = rep_sp->GetValueAsCString();
+  if (!rep)
+    return false;
+
+  stream << rep << ' ' << unit;
+  return true;
+}
+
+SyntheticChildrenFrontEnd *
+lldb_private::formatters::MsvcStlVectorIteratorSyntheticFrontEndCreator(
+    CXXSyntheticChildren *, lldb::ValueObjectSP valobj_sp) {
+  return (valobj_sp ? new VectorIteratorSyntheticFrontEnd(valobj_sp,
+                                                          {ConstString("_Ptr")})
+                    : nullptr);
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStl.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStl.cpp
@@ -405,7 +405,9 @@ bool lldb_private::formatters::GenericChronoDurationSummaryProvider(
   if (!rep)
     return false;
 
-  stream << rep << ' ' << unit;
+  stream << rep;
+  if (unit && unit[0] != '\0')
+    stream << ' ' << unit;
   return true;
 }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStl.h
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStl.h
@@ -142,6 +142,51 @@ SyntheticChildrenFrontEnd *
 MsvcStlSpanSyntheticFrontEndCreator(CXXSyntheticChildren *,
                                     lldb::ValueObjectSP valobj_sp);
 
+// MSVC STL std::bitset<>
+bool IsMsvcStlBitset(ValueObject &valobj);
+SyntheticChildrenFrontEnd *
+MsvcStlBitsetSyntheticFrontEndCreator(CXXSyntheticChildren *,
+                                      lldb::ValueObjectSP valobj_sp);
+
+// MSVC STL std::source_location
+bool IsMsvcStlSourceLocation(ValueObject &valobj);
+bool MsvcStlSourceLocationSummaryProvider(ValueObject &valobj, Stream &stream,
+                                          const TypeSummaryOptions &options);
+
+// MSVC STL std::valarray<>
+bool IsMsvcStlValarray(ValueObject &valobj);
+SyntheticChildrenFrontEnd *
+MsvcStlValarraySyntheticFrontEndCreator(CXXSyntheticChildren *,
+                                        lldb::ValueObjectSP valobj_sp);
+
+// MSVC STL std::expected<>
+bool IsMsvcStlExpected(ValueObject &valobj);
+bool MsvcStlExpectedSummaryProvider(ValueObject &valobj, Stream &stream,
+                                    const TypeSummaryOptions &options);
+SyntheticChildrenFrontEnd *
+MsvcStlExpectedSyntheticFrontEndCreator(CXXSyntheticChildren *,
+                                        lldb::ValueObjectSP valobj_sp);
+
+// MSVC STL vector iterators
+SyntheticChildrenFrontEnd *
+MsvcStlVectorIteratorSyntheticFrontEndCreator(CXXSyntheticChildren *,
+                                              lldb::ValueObjectSP valobj_sp);
+
+// MSVC STL std::error_code / std::error_condition
+bool IsMsvcStlErrorCode(ValueObject &valobj);
+bool MsvcStlErrorCodeSummaryProvider(ValueObject &valobj, Stream &stream,
+                                     const TypeSummaryOptions &options);
+
+// MSVC STL std::filesystem::path
+bool IsMsvcStlFilesystemPath(ValueObject &valobj);
+bool MsvcStlFilesystemPathSummaryProvider(ValueObject &valobj, Stream &stream,
+                                          const TypeSummaryOptions &options);
+
+// MSVC STL chrono duration rep (`_MyRep`)
+bool GenericChronoDurationSummaryProvider(ValueObject &valobj, Stream &stream,
+                                          const TypeSummaryOptions &options,
+                                          const char *unit);
+
 } // namespace formatters
 } // namespace lldb_private
 

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlExpected.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlExpected.cpp
@@ -1,0 +1,108 @@
+//===-- MsvcStlExpected.cpp -----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "MsvcStl.h"
+
+#include "lldb/DataFormatters/FormattersHelpers.h"
+#include "llvm/Support/ErrorExtras.h"
+
+using namespace lldb;
+using namespace lldb_private;
+using namespace lldb_private::formatters;
+
+namespace {
+class MsvcStlExpectedFrontend : public SyntheticChildrenFrontEnd {
+public:
+  MsvcStlExpectedFrontend(ValueObject &valobj)
+      : SyntheticChildrenFrontEnd(valobj) {
+    if (valobj.GetTargetSP())
+      Update();
+  }
+
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
+    if (name == "Value" || name == "Unexpected" || name == "$$dereference$$")
+      return 0;
+    return llvm::createStringErrorV("type has no child named '{0}'", name);
+  }
+
+  llvm::Expected<uint32_t> CalculateNumChildren() override {
+    return m_engaged ? 1U : 0U;
+  }
+
+  ValueObjectSP GetChildAtIndex(uint32_t idx) override {
+    if (!m_engaged || idx != 0)
+      return {};
+
+    ValueObjectSP ns = m_backend.GetNonSyntheticValue();
+    if (!ns)
+      return {};
+
+    if (m_has_value) {
+      if (ValueObjectSP val_sp = ns->GetChildMemberWithName("_Value"))
+        return val_sp->Clone("Value");
+      return {};
+    }
+
+    if (ValueObjectSP err_sp = ns->GetChildMemberWithName("_Unexpected"))
+      return err_sp->Clone("Unexpected");
+    return {};
+  }
+
+  lldb::ChildCacheState Update() override {
+    m_engaged = false;
+    m_has_value = false;
+    ValueObjectSP ns = m_backend.GetNonSyntheticValue();
+    if (!ns)
+      return lldb::ChildCacheState::eRefetch;
+
+    ValueObjectSP has_sp = ns->GetChildMemberWithName("_Has_value");
+    if (!has_sp)
+      return lldb::ChildCacheState::eRefetch;
+
+    m_has_value = has_sp->GetValueAsUnsigned(0) != 0;
+    // expected<void, E> has no value child when engaged.
+    if (m_has_value)
+      m_engaged = ns->GetChildMemberWithName("_Value") != nullptr;
+    else
+      m_engaged = ns->GetChildMemberWithName("_Unexpected") != nullptr;
+    return lldb::ChildCacheState::eRefetch;
+  }
+
+private:
+  bool m_engaged = false;
+  bool m_has_value = false;
+};
+} // namespace
+
+bool formatters::IsMsvcStlExpected(ValueObject &valobj) {
+  if (auto valobj_sp = valobj.GetNonSyntheticValue())
+    return valobj_sp->GetChildMemberWithName("_Has_value") != nullptr &&
+           valobj_sp->GetChildMemberWithName("_Unexpected") != nullptr;
+  return false;
+}
+
+bool formatters::MsvcStlExpectedSummaryProvider(ValueObject &valobj,
+                                                Stream &stream,
+                                                const TypeSummaryOptions &) {
+  ValueObjectSP ns = valobj.GetNonSyntheticValue();
+  if (!ns)
+    return false;
+  ValueObjectSP has_sp = ns->GetChildMemberWithName("_Has_value");
+  if (!has_sp)
+    return false;
+  stream.Printf(" Has Value=%s ",
+                has_sp->GetValueAsUnsigned(0) ? "true" : "false");
+  return true;
+}
+
+SyntheticChildrenFrontEnd *formatters::MsvcStlExpectedSyntheticFrontEndCreator(
+    CXXSyntheticChildren *, lldb::ValueObjectSP valobj_sp) {
+  if (valobj_sp)
+    return new MsvcStlExpectedFrontend(*valobj_sp);
+  return nullptr;
+}

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlExpected.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlExpected.cpp
@@ -16,6 +16,30 @@ using namespace lldb_private;
 using namespace lldb_private::formatters;
 
 namespace {
+
+/// `_Value` / `_Unexpected` live in an anonymous union. Direct
+/// GetChildMemberWithName from the class works on DWARF; PDB often needs the
+/// same parent/index walk GenericOptional uses for `_Value`.
+ValueObjectSP GetExpectedUnionMember(ValueObject &ns, const char *name) {
+  if (ValueObjectSP direct = ns.GetChildMemberWithName(name))
+    return direct;
+
+  ValueObjectSP has_sp = ns.GetChildMemberWithName("_Has_value");
+  if (!has_sp)
+    return {};
+  ValueObject *parent = has_sp->GetParent();
+  if (!parent)
+    return {};
+  ValueObjectSP first_sp = parent->GetChildAtIndex(0);
+  if (!first_sp)
+    return {};
+  if (ValueObjectSP nested = first_sp->GetChildMemberWithName(name))
+    return nested;
+  if (first_sp->GetName() == name)
+    return first_sp;
+  return {};
+}
+
 class MsvcStlExpectedFrontend : public SyntheticChildrenFrontEnd {
 public:
   MsvcStlExpectedFrontend(ValueObject &valobj)
@@ -25,8 +49,14 @@ public:
   }
 
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
-    if (name == "Value" || name == "Unexpected" || name == "$$dereference$$")
+    if (!m_engaged)
+      return llvm::createStringErrorV("type has no child named '{0}'", name);
+    if (m_has_value) {
+      if (name == "Value" || name == "$$dereference$$")
+        return 0;
+    } else if (name == "Unexpected") {
       return 0;
+    }
     return llvm::createStringErrorV("type has no child named '{0}'", name);
   }
 
@@ -43,12 +73,12 @@ public:
       return {};
 
     if (m_has_value) {
-      if (ValueObjectSP val_sp = ns->GetChildMemberWithName("_Value"))
+      if (ValueObjectSP val_sp = GetExpectedUnionMember(*ns, "_Value"))
         return val_sp->Clone("Value");
       return {};
     }
 
-    if (ValueObjectSP err_sp = ns->GetChildMemberWithName("_Unexpected"))
+    if (ValueObjectSP err_sp = GetExpectedUnionMember(*ns, "_Unexpected"))
       return err_sp->Clone("Unexpected");
     return {};
   }
@@ -67,9 +97,9 @@ public:
     m_has_value = has_sp->GetValueAsUnsigned(0) != 0;
     // expected<void, E> has no value child when engaged.
     if (m_has_value)
-      m_engaged = ns->GetChildMemberWithName("_Value") != nullptr;
+      m_engaged = GetExpectedUnionMember(*ns, "_Value") != nullptr;
     else
-      m_engaged = ns->GetChildMemberWithName("_Unexpected") != nullptr;
+      m_engaged = GetExpectedUnionMember(*ns, "_Unexpected") != nullptr;
     return lldb::ChildCacheState::eRefetch;
   }
 
@@ -81,8 +111,7 @@ private:
 
 bool formatters::IsMsvcStlExpected(ValueObject &valobj) {
   if (auto valobj_sp = valobj.GetNonSyntheticValue())
-    return valobj_sp->GetChildMemberWithName("_Has_value") != nullptr &&
-           valobj_sp->GetChildMemberWithName("_Unexpected") != nullptr;
+    return valobj_sp->GetChildMemberWithName("_Has_value") != nullptr;
   return false;
 }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlValarray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlValarray.cpp
@@ -52,21 +52,27 @@ public:
     m_count = 0;
     m_element_size = 0;
 
-    CompilerType type = m_backend.GetCompilerType();
-    if (type.GetNumTemplateArguments() == 0)
+    ValueObjectSP start = m_backend.GetChildMemberWithName("_Myptr");
+    ValueObjectSP size_sp = m_backend.GetChildMemberWithName("_Mysize");
+    if (!start || !size_sp)
       return ChildCacheState::eRefetch;
 
-    m_element_type = type.GetTypeTemplateArgument(0);
+    // Prefer the pointer's pointee type: template arguments are missing on
+    // references unless the frontend asked for a dereference, and PDB may
+    // omit them entirely.
+    m_element_type = start->GetCompilerType().GetPointeeType();
+    if (!m_element_type.IsValid()) {
+      CompilerType type = m_backend.GetCompilerType().GetNonReferenceType();
+      m_element_type = type.GetTypeTemplateArgument(0);
+    }
+    if (!m_element_type.IsValid())
+      return ChildCacheState::eRefetch;
+
     if (std::optional<uint64_t> size =
             llvm::expectedToOptional(m_element_type.GetByteSize(nullptr)))
       m_element_size = *size;
 
     if (m_element_size == 0)
-      return ChildCacheState::eRefetch;
-
-    ValueObjectSP start = m_backend.GetChildMemberWithName("_Myptr");
-    ValueObjectSP size_sp = m_backend.GetChildMemberWithName("_Mysize");
-    if (!start || !size_sp)
       return ChildCacheState::eRefetch;
 
     m_start = start.get();

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlValarray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlValarray.cpp
@@ -1,0 +1,106 @@
+//===-- MsvcStlValarray.cpp -----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "MsvcStl.h"
+
+#include "lldb/DataFormatters/FormattersHelpers.h"
+#include "lldb/Utility/StreamString.h"
+#include "lldb/ValueObject/ValueObject.h"
+#include "llvm/Support/ErrorExtras.h"
+#include <cinttypes>
+#include <optional>
+
+using namespace lldb;
+using namespace lldb_private;
+using namespace lldb_private::formatters;
+
+namespace {
+class MsvcStlValarraySyntheticFrontEnd : public SyntheticChildrenFrontEnd {
+public:
+  MsvcStlValarraySyntheticFrontEnd(lldb::ValueObjectSP valobj_sp)
+      : SyntheticChildrenFrontEnd(*valobj_sp) {
+    if (valobj_sp)
+      Update();
+  }
+
+  llvm::Expected<uint32_t> CalculateNumChildren() override {
+    if (!m_start || m_element_size == 0)
+      return 0;
+    return m_count;
+  }
+
+  lldb::ValueObjectSP GetChildAtIndex(uint32_t idx) override {
+    if (!m_start || idx >= m_count)
+      return {};
+
+    uint64_t offset = m_start->GetValueAsUnsigned(0) +
+                      static_cast<uint64_t>(idx) * m_element_size;
+    StreamString name;
+    name.Printf("[%" PRIu64 "]", (uint64_t)idx);
+    return CreateChildValueObjectFromAddress(name.GetString(), offset,
+                                             m_backend.GetExecutionContextRef(),
+                                             m_element_type);
+  }
+
+  lldb::ChildCacheState Update() override {
+    m_start = nullptr;
+    m_count = 0;
+    m_element_size = 0;
+
+    CompilerType type = m_backend.GetCompilerType();
+    if (type.GetNumTemplateArguments() == 0)
+      return ChildCacheState::eRefetch;
+
+    m_element_type = type.GetTypeTemplateArgument(0);
+    if (std::optional<uint64_t> size =
+            llvm::expectedToOptional(m_element_type.GetByteSize(nullptr)))
+      m_element_size = *size;
+
+    if (m_element_size == 0)
+      return ChildCacheState::eRefetch;
+
+    ValueObjectSP start = m_backend.GetChildMemberWithName("_Myptr");
+    ValueObjectSP size_sp = m_backend.GetChildMemberWithName("_Mysize");
+    if (!start || !size_sp)
+      return ChildCacheState::eRefetch;
+
+    m_start = start.get();
+    m_count = size_sp->GetValueAsUnsigned(0);
+    return ChildCacheState::eRefetch;
+  }
+
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
+    if (!m_start)
+      return llvm::createStringErrorV("type has no child named '{0}'", name);
+    auto optional_idx = ExtractIndexFromString(name.GetCString());
+    if (!optional_idx)
+      return llvm::createStringErrorV("type has no child named '{0}'", name);
+    return *optional_idx;
+  }
+
+private:
+  ValueObject *m_start = nullptr;
+  CompilerType m_element_type;
+  uint32_t m_element_size = 0;
+  uint64_t m_count = 0;
+};
+} // namespace
+
+bool formatters::IsMsvcStlValarray(ValueObject &valobj) {
+  if (auto valobj_sp = valobj.GetNonSyntheticValue())
+    return valobj_sp->GetChildMemberWithName("_Myptr") != nullptr &&
+           valobj_sp->GetChildMemberWithName("_Mysize") != nullptr;
+  return false;
+}
+
+SyntheticChildrenFrontEnd *formatters::MsvcStlValarraySyntheticFrontEndCreator(
+    CXXSyntheticChildren *, lldb::ValueObjectSP valobj_sp) {
+  if (!valobj_sp)
+    return nullptr;
+  return new MsvcStlValarraySyntheticFrontEnd(valobj_sp);
+}

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/bitset/TestDataFormatterGenericBitset.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/bitset/TestDataFormatterGenericBitset.py
@@ -73,6 +73,11 @@ class GenericBitsetDataFormatterTestCase(TestBase):
         self.build(dictionary={"USE_LIBCPP": 1})
         self.do_test_value()
 
+    @add_test_categories(["msvcstl"])
+    def test_value_msvcstl(self):
+        self.build()
+        self.do_test_value()
+
     def do_test_ptr_and_ref(self):
         """Test that ref and ptr to std::bitset is displayed correctly"""
         (_, process, _, bkpt) = lldbutil.run_to_source_breakpoint(
@@ -100,4 +105,9 @@ class GenericBitsetDataFormatterTestCase(TestBase):
     @add_test_categories(["libc++"])
     def test_ptr_and_ref_libcpp(self):
         self.build(dictionary={"USE_LIBCPP": 1})
+        self.do_test_ptr_and_ref()
+
+    @add_test_categories(["msvcstl"])
+    def test_ptr_and_ref_msvcstl(self):
+        self.build()
         self.do_test_ptr_and_ref()

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/chrono/TestDataFormatterStdChrono.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/chrono/TestDataFormatterStdChrono.py
@@ -432,6 +432,23 @@ class StdChronoDataFormatterTestCase(TestBase):
             ],
         )
 
+    @add_test_categories(["msvcstl"])
+    def test_msvcstl_durations(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.cpp", False)
+        )
+        self.expect("frame variable ns", substrs=["ns = 1 ns"])
+        self.expect("frame variable us", substrs=["us = 12 µs"])
+        self.expect("frame variable ms", substrs=["ms = 123 ms"])
+        self.expect("frame variable s", substrs=["s = 1234 s"])
+        self.expect("frame variable min", substrs=["min = 12345 min"])
+        self.expect("frame variable h", substrs=["h = 123456 h"])
+        self.expect("frame variable d", substrs=["d = 654321 days"])
+        self.expect("frame variable w", substrs=["w = 54321 weeks"])
+        self.expect("frame variable m", substrs=["m = 4321 months"])
+        self.expect("frame variable y", substrs=["y = 321 years"])
+
     @skipIf(compiler="clang", compiler_version=["<", "17.0"])
     @add_test_categories(["libc++"])
     def test_libcxx(self):

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/chrono/TestDataFormatterStdChrono.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/chrono/TestDataFormatterStdChrono.py
@@ -432,11 +432,24 @@ class StdChronoDataFormatterTestCase(TestBase):
             ],
         )
 
+    @add_test_categories(["libstdcxx"])
+    def test_libstdcxx_not_stolen_by_msvc(self):
+        """libstdc++ chrono typedefs must not get an MSVC `_MyRep` summary."""
+        self.build(dictionary={"USE_LIBSTDCPP": 1})
+        lldbutil.run_to_source_breakpoint(
+            self, "break after durations", lldb.SBFileSpec("main.cpp", False)
+        )
+        ns = self.frame().FindVariable("ns")
+        self.assertTrue(ns.IsValid())
+        summary = ns.GetSummary() or ""
+        self.assertNotIn("1 ns", summary)
+        self.expect("frame variable ns", matching=False, substrs=["= 1 ns"])
+
     @add_test_categories(["msvcstl"])
     def test_msvcstl_durations(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
-            self, "break here", lldb.SBFileSpec("main.cpp", False)
+            self, "break after durations", lldb.SBFileSpec("main.cpp", False)
         )
         self.expect("frame variable ns", substrs=["ns = 1 ns"])
         self.expect("frame variable us", substrs=["us = 12 µs"])

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/chrono/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/chrono/main.cpp
@@ -14,6 +14,7 @@ int main() {
   std::chrono::weeks w{54321};
   std::chrono::months m{4321};
   std::chrono::years y{321};
+  // break after durations
 
   // sys_seconds aliasses
   std::chrono::time_point<std::chrono::system_clock, std::chrono::seconds>

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/coroutine_handle/TestCoroutineHandle.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/coroutine_handle/TestCoroutineHandle.py
@@ -172,3 +172,8 @@ class TestCoroutineHandle(TestBase):
     def test_libcpp(self):
         self.build(dictionary={"USE_LIBCPP": 1})
         self.do_test()
+
+    @add_test_categories(["msvcstl"])
+    def test_msvcstl(self):
+        self.build()
+        self.do_test()

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/coroutine_handle/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/coroutine_handle/main.cpp
@@ -13,6 +13,12 @@
 #define HAS_CPP_COROUTINES 1
 #endif
 
+// MSVC STL (the un-flagged default for the msvcstl test category).
+#if !defined(USE_LIBSTDCPP) && !defined(USE_LIBCPP)
+#include <coroutine>
+#define HAS_CPP_COROUTINES 1
+#endif
+
 bool is_implementation_supported() {
 #ifdef HAS_CPP_COROUTINES
   return true;

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/initializer_list/TestDataFormatterStdInitializerList.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/initializer_list/TestDataFormatterStdInitializerList.py
@@ -52,3 +52,8 @@ class InitializerListTestCase(TestBase):
     def test_libstdcpp(self):
         self.build(dictionary={"USE_LIBSTDCPP": 1})
         self.do_test()
+
+    @add_test_categories(["msvcstl"])
+    def test_msvcstl(self):
+        self.build()
+        self.do_test()

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/iterator/TestDataFormatterStdIterator.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/iterator/TestDataFormatterStdIterator.py
@@ -77,3 +77,8 @@ class StdIteratorDataFormatterTestCase(TestBase):
     def test_libstdcxx(self):
         self.build(dictionary={"USE_LIBSTDCPP": 1})
         self.do_test()
+
+    @add_test_categories(["msvcstl"])
+    def test_msvcstl(self):
+        self.build()
+        self.do_test()

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/queue/TestDataFormatterStdQueue.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/queue/TestDataFormatterStdQueue.py
@@ -41,6 +41,9 @@ class TestDataFormatterStdQueue(TestBase):
         self.check_variable("q1")
         self.check_variable("q2")
 
+    @expectedFailureAll(
+        bugnumber="llvm.org/pr36109", debug_info="gmodules", triple=".*-android"
+    )
     @add_test_categories(["libc++"])
     def test_libcxx(self):
         """Test that std::queue is displayed correctly"""

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/queue/TestDataFormatterStdQueue.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/queue/TestDataFormatterStdQueue.py
@@ -30,10 +30,32 @@ class TestDataFormatterStdQueue(TestBase):
     @expectedFailureAll(
         bugnumber="llvm.org/pr36109", debug_info="gmodules", triple=".*-android"
     )
+    @add_test_categories(["libstdcxx"])
+    def test_libstdcxx(self):
+        """Test that libstdc++ std::queue is displayed correctly"""
+        self.build(dictionary={"USE_LIBSTDCPP": 1})
+        lldbutil.run_to_source_breakpoint(
+            self, "// break here", lldb.SBFileSpec("main.cpp", False)
+        )
+
+        self.check_variable("q1")
+        self.check_variable("q2")
+
     @add_test_categories(["libc++"])
     def test_libcxx(self):
         """Test that std::queue is displayed correctly"""
         self.build(dictionary={"USE_LIBCPP": 1})
+        lldbutil.run_to_source_breakpoint(
+            self, "// break here", lldb.SBFileSpec("main.cpp", False)
+        )
+
+        self.check_variable("q1")
+        self.check_variable("q2")
+
+    @add_test_categories(["msvcstl"])
+    def test_msvcstl(self):
+        """Test that MSVC STL std::queue is displayed correctly"""
+        self.build()
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.cpp", False)
         )

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/source_location/TestDataFormatterStdSourceLocation.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/source_location/TestDataFormatterStdSourceLocation.py
@@ -51,3 +51,23 @@ class StdSourceLocationTestCase(TestBase):
     def test_libstdcxx(self):
         self.build(dictionary={"USE_LIBSTDCPP": 1})
         self.do_test()
+
+    @add_test_categories(["msvcstl"])
+    def test_msvcstl(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "// break here", lldb.SBFileSpec("main.cpp")
+        )
+
+        frame = self.frame()
+        loc_main = frame.FindVariable("loc_main")
+        self.assertTrue(loc_main.GetError().Success())
+        self.assertRegex(loc_main.summary, r"main\.cpp\":6:\d+")
+
+        loc_foo = frame.FindVariable("loc_foo")
+        self.assertTrue(loc_foo.GetError().Success())
+        self.assertRegex(loc_foo.summary, r"main\.cpp\":3:\d+")
+
+        loc_empty = frame.FindVariable("loc_empty")
+        self.assertTrue(loc_empty.GetError().Success())
+        self.assertTrue(not loc_empty.summary)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/source_location/TestDataFormatterStdSourceLocation.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/source_location/TestDataFormatterStdSourceLocation.py
@@ -62,11 +62,11 @@ class StdSourceLocationTestCase(TestBase):
         frame = self.frame()
         loc_main = frame.FindVariable("loc_main")
         self.assertTrue(loc_main.GetError().Success())
-        self.assertRegex(loc_main.summary, r"main\.cpp\":6:\d+")
+        self.assertRegex(loc_main.summary, r"main\.cpp\":6:\d+.*main")
 
         loc_foo = frame.FindVariable("loc_foo")
         self.assertTrue(loc_foo.GetError().Success())
-        self.assertRegex(loc_foo.summary, r"main\.cpp\":3:\d+")
+        self.assertRegex(loc_foo.summary, r"main\.cpp\":3:\d+.*foo")
 
         loc_empty = frame.FindVariable("loc_empty")
         self.assertTrue(loc_empty.GetError().Success())

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/valarray/TestDataFormatterStdValarray.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/valarray/TestDataFormatterStdValarray.py
@@ -182,3 +182,26 @@ class StdValarrayDataFormatterTestCase(TestBase):
     def test_libcxx(self):
         self.build(dictionary={"USE_LIBCPP": 1})
         self.do_test()
+
+    @add_test_categories(["msvcstl"])
+    def test_msvcstl(self):
+        self.build()
+        (self.target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.cpp", False)
+        )
+        self.expect("frame variable va_int", substrs=["va_int = size=4"])
+        lldbutil.continue_to_breakpoint(process, bkpt)
+        self.expect(
+            "frame variable va_int",
+            substrs=[
+                "va_int = size=4",
+                "[0] = 1",
+                "[1] = 12",
+                "[2] = 123",
+                "[3] = 1234",
+            ],
+        )
+        self.expect(
+            "frame variable va_double",
+            substrs=["va_double = size=4", "[0] = 1", "[1] = 0.5"],
+        )

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/valarray/TestDataFormatterStdValarray.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/valarray/TestDataFormatterStdValarray.py
@@ -183,13 +183,33 @@ class StdValarrayDataFormatterTestCase(TestBase):
         self.build(dictionary={"USE_LIBCPP": 1})
         self.do_test()
 
+    @add_test_categories(["libstdcxx"])
+    def test_libstdcxx_not_stolen_by_msvc(self):
+        """libstdc++ valarray must not get the MSVC size=raw-field-count summary."""
+        self.build(dictionary={"USE_LIBSTDCPP": 1})
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.cpp", False)
+        )
+        va = self.frame().FindVariable("va_int")
+        self.assertTrue(va.IsValid())
+        summary = va.GetSummary() or ""
+        self.assertNotIn("size=2", summary)
+        self.expect("frame variable va_int", matching=False, substrs=["size=2"])
+
     @add_test_categories(["msvcstl"])
     def test_msvcstl(self):
         self.build()
         (self.target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(
             self, "break here", lldb.SBFileSpec("main.cpp", False)
         )
+        va_int = self.frame().FindVariable("va_int")
+        self.assertEqual(va_int.GetNumChildren(), 4)
         self.expect("frame variable va_int", substrs=["va_int = size=4"])
+        va_empty = self.frame().FindVariable("va_empty")
+        self.assertEqual(va_empty.GetNumChildren(), 0)
+        self.expect("frame variable va_empty", substrs=["size=0"])
+        va_ref = self.frame().FindVariable("va_ref")
+        self.assertEqual(va_ref.GetNumChildren(), 4)
         lldbutil.continue_to_breakpoint(process, bkpt)
         self.expect(
             "frame variable va_int",
@@ -201,6 +221,8 @@ class StdValarrayDataFormatterTestCase(TestBase):
                 "[3] = 1234",
             ],
         )
+        self.assertEqual(va_ref.GetNumChildren(), 4)
+        self.assertEqual(va_ref.GetChildAtIndex(3).GetValueAsSigned(), 1234)
         self.expect(
             "frame variable va_double",
             substrs=["va_double = size=4", "[0] = 1", "[1] = 0.5"],

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/valarray/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/valarray/main.cpp
@@ -4,6 +4,8 @@
 int main() {
 
   std::valarray<int> va_int(4);
+  std::valarray<int> va_empty;
+  std::valarray<int> &va_ref = va_int;
   std::cout << "break here";
 
   va_int[0] = 1;

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/msvc-simulators/Makefile
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/msvc-simulators/Makefile
@@ -1,0 +1,3 @@
+CXX_SOURCES := main.cpp
+override CXXFLAGS_EXTRAS += -std=c++17
+include Makefile.rules

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/msvc-simulators/TestDataFormatterMsvcStlSimulator.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/msvc-simulators/TestDataFormatterMsvcStlSimulator.py
@@ -8,54 +8,104 @@ from lldbsuite.test import lldbutil
 class MsvcStlDataFormatterSimulatorTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
+    def check_adaptor(self, name, values):
+        var = self.frame().FindVariable(name)
+        self.assertTrue(var.IsValid(), name)
+        self.assertEqual(var.GetNumChildren(), len(values), name)
+        for i, expected in enumerate(values):
+            child = var.GetChildAtIndex(i)
+            self.assertTrue(child.IsValid(), f"{name}[{i}]")
+            self.assertEqual(child.GetValueAsSigned(), expected, f"{name}[{i}]")
+            self.assertEqual(child.GetName(), f"[{i}]")
+
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
             self, "break here", lldb.SBFileSpec("main.cpp")
         )
 
+        empty_bitset = self.frame().FindVariable("empty_bitset")
+        self.assertEqual(empty_bitset.GetNumChildren(), 0)
         self.expect("frame variable empty_bitset", substrs=["size=0"])
+
+        small_bitset = self.frame().FindVariable("small_bitset")
+        self.assertEqual(small_bitset.GetNumChildren(), 13)
+        self.assertEqual(small_bitset.GetChildAtIndex(2).GetValueAsUnsigned(), 1)
+        self.assertEqual(small_bitset.GetChildAtIndex(11).GetValueAsUnsigned(), 0)
         self.expect(
             "frame variable small_bitset",
             substrs=["size=13", "[2] = true", "[9] = true", "[11] = false"],
         )
 
-        self.expect(
-            "frame variable ili",
-            substrs=["size=5", "[0] = 1", "[4] = 5"],
-        )
+        large_bitset = self.frame().FindVariable("large_bitset")
+        self.assertEqual(large_bitset.GetNumChildren(), 70)
+        self.assertEqual(large_bitset.GetChildAtIndex(0).GetValueAsUnsigned(), 1)
+        self.assertEqual(large_bitset.GetChildAtIndex(1).GetValueAsUnsigned(), 0)
+        # `_Array[1] = 1` sets the first bit of the second word: 32 on LLP64,
+        # 64 on LP64.
+        second_word_bit = None
+        for candidate in (32, 64):
+            child = large_bitset.GetChildAtIndex(candidate)
+            if child.IsValid() and child.GetValueAsUnsigned() == 1:
+                second_word_bit = candidate
+                break
+        self.assertIsNotNone(second_word_bit)
 
-        self.expect(
-            "frame variable vec",
-            substrs=["size=3", "[0] = 10", "[1] = 20", "[2] = 30"],
-        )
-        self.expect(
-            "frame variable q",
-            substrs=["size=3", "[0] = 10", "[2] = 30"],
-        )
-        self.expect(
-            "frame variable st",
-            substrs=["size=3", "[0] = 10", "[2] = 30"],
-        )
-        self.expect(
-            "frame variable pq",
-            substrs=["size=3", "[0] = 10", "[2] = 30"],
-        )
+        ili = self.frame().FindVariable("ili")
+        self.assertEqual(ili.GetNumChildren(), 5)
+        self.assertEqual(ili.GetChildAtIndex(0).GetValueAsSigned(), 1)
+        self.assertEqual(ili.GetChildAtIndex(4).GetValueAsSigned(), 5)
 
-        self.expect(
-            "frame variable va",
-            substrs=["size=4", "[0] = 1", "[3] = 1234"],
-        )
+        vec = self.frame().FindVariable("vec")
+        self.assertEqual(vec.GetNumChildren(), 3)
+        self.check_adaptor("q", [10, 20, 30])
+        self.check_adaptor("st", [10, 20, 30])
+        self.check_adaptor("pq", [10, 20, 30])
 
+        va = self.frame().FindVariable("va")
+        self.assertEqual(va.GetNumChildren(), 4)
+        self.assertEqual(va.GetChildAtIndex(0).GetValueAsSigned(), 1)
+        self.assertEqual(va.GetChildAtIndex(3).GetValueAsSigned(), 1234)
+        self.expect("frame variable va", substrs=["size=4"])
+
+        va_empty = self.frame().FindVariable("va_empty")
+        self.assertEqual(va_empty.GetNumChildren(), 0)
+        self.expect("frame variable va_empty", substrs=["size=0"])
+
+        va_ref = self.frame().FindVariable("va_ref")
+        self.assertEqual(va_ref.GetNumChildren(), 4)
+        self.assertEqual(va_ref.GetChildAtIndex(3).GetValueAsSigned(), 1234)
+        self.expect("frame variable va_ref", substrs=["size=4", "[0] = 1"])
+
+        ok = self.frame().FindVariable("ok")
+        self.assertEqual(ok.GetNumChildren(), 1)
+        self.assertEqual(ok.GetChildAtIndex(0).GetName(), "Value")
+        self.assertEqual(ok.GetChildAtIndex(0).GetValueAsSigned(), 7)
+        self.assertFalse(ok.GetChildMemberWithName("Unexpected").IsValid())
         self.expect("frame variable ok", substrs=["Has Value=true", "Value = 7"])
+
+        err = self.frame().FindVariable("err")
+        self.assertEqual(err.GetNumChildren(), 1)
+        self.assertEqual(err.GetChildAtIndex(0).GetName(), "Unexpected")
+        self.assertFalse(err.GetChildMemberWithName("Value").IsValid())
         self.expect(
             "frame variable err",
             substrs=["Has Value=false", "Unexpected =", "boom"],
         )
 
+        void_ok = self.frame().FindVariable("void_ok")
+        self.assertEqual(void_ok.GetNumChildren(), 0)
+        self.expect("frame variable void_ok", substrs=["Has Value=true"])
+
+        void_err = self.frame().FindVariable("void_err")
+        self.assertEqual(void_err.GetNumChildren(), 1)
+        self.assertEqual(void_err.GetChildAtIndex(0).GetName(), "Unexpected")
+        self.assertEqual(void_err.GetChildAtIndex(0).GetValueAsSigned(), 11)
+        self.expect("frame variable void_err", substrs=["Has Value=false"])
+
         self.expect(
             "frame variable loc",
-            substrs=['"main.cpp":6:1', '"int main()"'],
+            substrs=['"main.cpp":6:1', "__cdecl", "main"],
         )
         loc_empty = self.frame().FindVariable("loc_empty")
         self.assertTrue(loc_empty.GetError().Success())
@@ -63,8 +113,20 @@ class MsvcStlDataFormatterSimulatorTestCase(TestBase):
 
         self.expect("frame variable ns", substrs=["ns = 1 ns"])
         self.expect("frame variable s", substrs=["s = 1234 s"])
+        self.expect("frame variable custom_dur", substrs=["custom_dur = 42"])
 
+        ec = self.frame().FindVariable("ec")
+        self.assertGreaterEqual(ec.GetNumChildren(), 1)
         self.expect("frame variable ec", substrs=["value=2"])
+        econd = self.frame().FindVariable("econd")
+        self.assertGreaterEqual(econd.GetNumChildren(), 1)
+        self.expect("frame variable econd", substrs=["value=7"])
+
         self.expect("frame variable p", substrs=["file.txt"])
 
-        self.expect("frame variable it", substrs=["item = 3"])
+        it = self.frame().FindVariable("it")
+        self.assertEqual(it.GetNumChildren(), 1)
+        self.assertEqual(it.GetChildAtIndex(0).GetName(), "item")
+        self.assertEqual(it.GetChildAtIndex(0).GetValueAsSigned(), 3)
+        cit = self.frame().FindVariable("cit")
+        self.assertEqual(cit.GetChildAtIndex(0).GetValueAsSigned(), 3)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/msvc-simulators/TestDataFormatterMsvcStlSimulator.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/msvc-simulators/TestDataFormatterMsvcStlSimulator.py
@@ -1,0 +1,70 @@
+"""Simulate MSVC STL layouts and check the corresponding LLDB formatters."""
+
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class MsvcStlDataFormatterSimulatorTestCase(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def test(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.cpp")
+        )
+
+        self.expect("frame variable empty_bitset", substrs=["size=0"])
+        self.expect(
+            "frame variable small_bitset",
+            substrs=["size=13", "[2] = true", "[9] = true", "[11] = false"],
+        )
+
+        self.expect(
+            "frame variable ili",
+            substrs=["size=5", "[0] = 1", "[4] = 5"],
+        )
+
+        self.expect(
+            "frame variable vec",
+            substrs=["size=3", "[0] = 10", "[1] = 20", "[2] = 30"],
+        )
+        self.expect(
+            "frame variable q",
+            substrs=["size=3", "[0] = 10", "[2] = 30"],
+        )
+        self.expect(
+            "frame variable st",
+            substrs=["size=3", "[0] = 10", "[2] = 30"],
+        )
+        self.expect(
+            "frame variable pq",
+            substrs=["size=3", "[0] = 10", "[2] = 30"],
+        )
+
+        self.expect(
+            "frame variable va",
+            substrs=["size=4", "[0] = 1", "[3] = 1234"],
+        )
+
+        self.expect("frame variable ok", substrs=["Has Value=true", "Value = 7"])
+        self.expect(
+            "frame variable err",
+            substrs=["Has Value=false", "Unexpected =", "boom"],
+        )
+
+        self.expect(
+            "frame variable loc",
+            substrs=['"main.cpp":6:1', '"int main()"'],
+        )
+        loc_empty = self.frame().FindVariable("loc_empty")
+        self.assertTrue(loc_empty.GetError().Success())
+        self.assertTrue(not loc_empty.summary)
+
+        self.expect("frame variable ns", substrs=["ns = 1 ns"])
+        self.expect("frame variable s", substrs=["s = 1234 s"])
+
+        self.expect("frame variable ec", substrs=["value=2"])
+        self.expect("frame variable p", substrs=["file.txt"])
+
+        self.expect("frame variable it", substrs=["item = 3"])

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/msvc-simulators/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/msvc-simulators/main.cpp
@@ -11,6 +11,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <wchar.h>
 
 namespace std {
 
@@ -66,6 +67,7 @@ public:
 
 template <class T> class valarray {
 public:
+  valarray() : _Myptr(nullptr), _Mysize(0) {}
   valarray(T *ptr, size_t size) : _Myptr(ptr), _Mysize(size) {}
   T *_Myptr;
   size_t _Mysize;
@@ -77,6 +79,16 @@ public:
   expected(const E &error, bool) : _Unexpected(error), _Has_value(false) {}
   union {
     T _Value;
+    E _Unexpected;
+  };
+  bool _Has_value;
+};
+
+template <class E> class expected<void, E> {
+public:
+  expected() : _Has_value(true) {}
+  expected(const E &error, bool) : _Unexpected(error), _Has_value(false) {}
+  union {
     E _Unexpected;
   };
   bool _Has_value;
@@ -94,10 +106,21 @@ struct error_code {
   const void *_Mycat;
 };
 
+struct error_condition {
+  int _Myval;
+  const void *_Mycat;
+};
+
 template <class T> class _Vector_iterator {
 public:
   explicit _Vector_iterator(T *ptr) : _Ptr(ptr) {}
   T *_Ptr;
+};
+
+template <class T> class _Vector_const_iterator {
+public:
+  explicit _Vector_const_iterator(const T *ptr) : _Ptr(ptr) {}
+  const T *_Ptr;
 };
 
 namespace chrono {
@@ -107,11 +130,17 @@ struct nanoseconds {
 struct seconds {
   long long _MyRep;
 };
+
+template <class Rep, class Period = void> class duration {
+public:
+  explicit duration(Rep r) : _MyRep(r) {}
+  Rep _MyRep;
+};
 } // namespace chrono
 
 namespace filesystem {
 struct path {
-  const char *_Text;
+  const wchar_t *_Text;
 };
 } // namespace filesystem
 
@@ -121,6 +150,10 @@ int main() {
   std::bitset<0> empty_bitset;
   std::bitset<13> small_bitset;
   small_bitset._Array[0] = 0b00011111111100UL; // bits 2..9 set
+
+  std::bitset<70> large_bitset;
+  large_bitset._Array[0] = 1UL; // bit 0
+  large_bitset._Array[1] = 1UL; // bit 32 or 64 depending on unsigned long
 
   int init_vals[] = {1, 2, 3, 4, 5};
   std::initializer_list<int> ili(init_vals, init_vals + 5);
@@ -133,21 +166,29 @@ int main() {
 
   int va_vals[] = {1, 12, 123, 1234};
   std::valarray<int> va(va_vals, 4);
+  std::valarray<int> va_empty;
+  std::valarray<int> &va_ref = va;
 
   std::expected<int, const char *> ok(7);
   std::expected<int, const char *> err("boom", true);
+  std::expected<void, int> void_ok;
+  std::expected<void, int> void_err(11, true);
 
-  std::source_location loc{6, 1, "main.cpp", "int main()"};
+  std::source_location loc{6, 1, "main.cpp", "int __cdecl main(void)"};
   std::source_location loc_empty{0, 0, "", ""};
 
   std::chrono::nanoseconds ns{1};
   std::chrono::seconds s{1234};
+  std::chrono::duration<long long> custom_dur{42};
 
   std::error_code ec{2, nullptr};
-  std::filesystem::path p{"C:\\tmp\\file.txt"};
+  std::error_condition econd{7, nullptr};
+  const wchar_t path_text[] = L"C:\\tmp\\file.txt";
+  std::filesystem::path p{path_text};
 
   int item = 3;
   std::_Vector_iterator<int> it(&item);
+  std::_Vector_const_iterator<int> cit(&item);
 
   return 0; // break here
 }

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/msvc-simulators/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/msvc-simulators/main.cpp
@@ -1,0 +1,153 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Layout approximations of MSVC STL types so the data formatters can be
+// exercised without a Windows MSVC toolchain.
+
+#include <stddef.h>
+#include <stdint.h>
+
+namespace std {
+
+template <size_t N> class bitset {
+public:
+  using _Ty = unsigned long;
+  static constexpr size_t _Bitsperword = sizeof(_Ty) * 8;
+  static constexpr size_t _Words = N == 0 ? 0 : (N - 1) / _Bitsperword;
+  _Ty _Array[_Words + 1]{};
+};
+
+template <class T> class initializer_list {
+public:
+  initializer_list(const T *first, const T *last)
+      : _First(first), _Last(last) {}
+  const T *_First;
+  const T *_Last;
+};
+
+template <class T> struct _Vector_val {
+  T *_Myfirst;
+  T *_Mylast;
+  T *_Myend;
+};
+
+template <class T> struct _Compressed_pair {
+  _Vector_val<T> _Myval2;
+};
+
+template <class T> class vector {
+public:
+  vector(T *begin, T *end) : _Mypair{{begin, end, end}} {}
+  _Compressed_pair<T> _Mypair;
+};
+
+template <class T, class C = vector<T>> class queue {
+public:
+  explicit queue(C container) : c(container) {}
+  C c;
+};
+
+template <class T, class C = vector<T>> class stack {
+public:
+  explicit stack(C container) : c(container) {}
+  C c;
+};
+
+template <class T, class C = vector<T>> class priority_queue {
+public:
+  explicit priority_queue(C container) : c(container) {}
+  C c;
+};
+
+template <class T> class valarray {
+public:
+  valarray(T *ptr, size_t size) : _Myptr(ptr), _Mysize(size) {}
+  T *_Myptr;
+  size_t _Mysize;
+};
+
+template <class T, class E> class expected {
+public:
+  expected(const T &value) : _Value(value), _Has_value(true) {}
+  expected(const E &error, bool) : _Unexpected(error), _Has_value(false) {}
+  union {
+    T _Value;
+    E _Unexpected;
+  };
+  bool _Has_value;
+};
+
+struct source_location {
+  uint32_t _Line;
+  uint32_t _Column;
+  const char *_File;
+  const char *_Function;
+};
+
+struct error_code {
+  int _Myval;
+  const void *_Mycat;
+};
+
+template <class T> class _Vector_iterator {
+public:
+  explicit _Vector_iterator(T *ptr) : _Ptr(ptr) {}
+  T *_Ptr;
+};
+
+namespace chrono {
+struct nanoseconds {
+  long long _MyRep;
+};
+struct seconds {
+  long long _MyRep;
+};
+} // namespace chrono
+
+namespace filesystem {
+struct path {
+  const char *_Text;
+};
+} // namespace filesystem
+
+} // namespace std
+
+int main() {
+  std::bitset<0> empty_bitset;
+  std::bitset<13> small_bitset;
+  small_bitset._Array[0] = 0b00011111111100UL; // bits 2..9 set
+
+  int init_vals[] = {1, 2, 3, 4, 5};
+  std::initializer_list<int> ili(init_vals, init_vals + 5);
+
+  int vec_vals[] = {10, 20, 30};
+  std::vector<int> vec(vec_vals, vec_vals + 3);
+  std::queue<int> q(vec);
+  std::stack<int> st(vec);
+  std::priority_queue<int> pq(vec);
+
+  int va_vals[] = {1, 12, 123, 1234};
+  std::valarray<int> va(va_vals, 4);
+
+  std::expected<int, const char *> ok(7);
+  std::expected<int, const char *> err("boom", true);
+
+  std::source_location loc{6, 1, "main.cpp", "int main()"};
+  std::source_location loc_empty{0, 0, "", ""};
+
+  std::chrono::nanoseconds ns{1};
+  std::chrono::seconds s{1234};
+
+  std::error_code ec{2, nullptr};
+  std::filesystem::path p{"C:\\tmp\\file.txt"};
+
+  int item = 3;
+  std::_Vector_iterator<int> it(&item);
+
+  return 0; // break here
+}

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -160,6 +160,12 @@ Makes programs 10x faster by doing Special New Thing.
 * Python 3.11 or later is now required for building LLDB 24 on Windows.
 * For better performance, LLDB now turns off the Windows debug heap by default when debugging.
   If you need the debug heap enabled, set `platform.plugin.windows.disable-debug-heap` to `false`.
+* Data formatters for the MSVC STL now cover the remaining libc++-parity types:
+  `std::bitset`, `std::initializer_list`, `std::queue` / `std::stack` /
+  `std::priority_queue`, `std::valarray`, `std::expected`, `std::source_location`,
+  `std::chrono` duration typedefs, `std::error_code` / `std::error_condition`,
+  `std::filesystem::path`, and `std::_Vector(_const)?_iterator`.
+  Existing formatters already handled the core containers and smart pointers.
 
 ### Changes to BOLT
 


### PR DESCRIPTION
LLDB already formatted the core MSVC STL containers and smart pointers (vector, string, map/set, unordered_*, list, deque, optional, variant, tuple, shared/unique_ptr, span, atomic). This adds first-class formatters for the remaining libc++-parity types.

Because MSVC STL and libstdc++ share std:: names (no inline namespace), matching is layout-based (_Array, _First/_Last, _MyRep, _Has_value + _Unexpected, _Ptr, …) so the wrong STL is not formatted.

Added support for these Types:
- std::bitset
- std::initializer_list
- std::queue / std::stack / std::priority_queue
- std::valarray
- std::expected
- std::source_location
- std::chrono duration typedefs
- std::error_code / std::error_condition
- std::filesystem::path
- std::_Vector(_const)?_iterator

std::coroutine_handle already matched the libstdc++ regex and works for MSVC (_Ptr).

Tests:
- Layout simulator under lldb/test/API/functionalities/data-formatter/data-formatter-stl/msvc-simulators (no MSVC toolchain required)
- msvcstl API tests added next to the existing generic suite (Windows)
- libstdc++ std::queue coverage for the shared adaptor formatter

Part of #24834

CC @Nerixyz @DavidSpickett @Michael137

I've read the LLVM Developer Policy, Code-Review Policy, and [AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html).

AI tool usage: Grok 4.6 was used to help write this change. I reviewed the result and can answer questions about the patch during review.