### PR TITLE
[orc-rt] Drop iostreams from CommandLine.h via formatHelp

### DIFF
--- a/orc-rt/include/orc-rt-utils/CommandLine.h
+++ b/orc-rt/include/orc-rt-utils/CommandLine.h
@@ -14,7 +14,6 @@
 #include <algorithm>
 #include <charconv>
 #include <functional>
-#include <iomanip>
 #include <numeric>
 #include <optional>
 #include <string>
@@ -22,6 +21,7 @@
 #include <vector>
 
 #include "orc-rt/Error.h"
+#include "orc-rt/StringExtras.h"
 
 namespace orc_rt {
 namespace detail {
@@ -109,7 +109,8 @@ public:
     return *this;
   }
 
-  void printHelp(std::ostream &OS, std::string_view ProgramName) const {
+  std::string formatHelp(std::string_view ProgramName) const {
+    StringOutputStream OS;
     OS << "Usage: " << ProgramName << " [options] [positional arguments]\n\n";
     OS << "OPTIONS:\n";
 
@@ -143,8 +144,10 @@ public:
       if (Opt.Kind == OptionKind::Value)
         FlagStr += " <value>";
 
-      OS << std::left << std::setw(MaxWidth + 2) << FlagStr << Opt.Desc << "\n";
+      OS << ljust(FlagStr, MaxWidth + 2) << Opt.Desc << "\n";
     }
+
+    return std::move(OS).str();
   }
 
   template <typename I> orc_rt::Error parse(I Begin, I End) {

--- a/orc-rt/include/orc-rt/StringExtras.h
+++ b/orc-rt/include/orc-rt/StringExtras.h
@@ -70,6 +70,14 @@ public:
     T Value;
   };
 
+  /// A string field to be padded to a fixed width (see ljust / rjust).
+  struct Justified {
+    std::string_view Str;
+    std::size_t Width;
+    char Fill;
+    bool Left;
+  };
+
   StringOutputStream &operator<<(char C) {
     S.push_back(C);
     return *this;
@@ -111,6 +119,16 @@ public:
     return *this;
   }
 
+  StringOutputStream &operator<<(Justified J) {
+    std::size_t Pad = J.Str.size() < J.Width ? J.Width - J.Str.size() : 0;
+    if (!J.Left)
+      S.append(Pad, J.Fill);
+    S.append(J.Str);
+    if (J.Left)
+      S.append(Pad, J.Fill);
+    return *this;
+  }
+
   /// Access the accumulated string (mirrors std::ostringstream::str()).
   const std::string &str() const & { return S; }
   std::string str() && { return std::move(S); }
@@ -138,6 +156,22 @@ template <typename T> StringOutputStream::HexFmt<T> hex(T Value) {
                 "hex() is for integers; pointers already print in hex by "
                 "default, and bool is not a numeric value");
   return {Value};
+}
+
+/// Wrap Str so StringOutputStream prints it left-justified in a field of the
+/// given width, padded on the right with Fill. Strings wider than Width are
+/// printed in full (never truncated).
+inline StringOutputStream::Justified ljust(std::string_view Str,
+                                           std::size_t Width, char Fill = ' ') {
+  return {Str, Width, Fill, /*Left=*/true};
+}
+
+/// Wrap Str so StringOutputStream prints it right-justified in a field of the
+/// given width, padded on the left with Fill. Strings wider than Width are
+/// printed in full (never truncated).
+inline StringOutputStream::Justified rjust(std::string_view Str,
+                                           std::size_t Width, char Fill = ' ') {
+  return {Str, Width, Fill, /*Left=*/false};
 }
 
 } // namespace orc_rt

--- a/orc-rt/test/tools/orc-rt-log-check.cpp
+++ b/orc-rt/test/tools/orc-rt-log-check.cpp
@@ -80,17 +80,17 @@ int main(int argc, char *argv[]) {
 
     if (auto Err = P.parse(argc, argv)) {
       std::cerr << "error: " << orc_rt::toString(std::move(Err)) << "\n";
-      P.printHelp(std::cerr, argv[0]);
+      std::cerr << P.formatHelp(argv[0]);
       return 1;
     }
 
     if ((PrintBackend && PrintEnabledLevels) || !P.positionals().empty()) {
-      P.printHelp(std::cerr, argv[0]);
+      std::cerr << P.formatHelp(argv[0]);
       return 1;
     }
 
     if (PrintHelp) {
-      P.printHelp(std::cerr, argv[0]);
+      std::cerr << P.formatHelp(argv[0]);
       return 0;
     }
   }

--- a/orc-rt/test/tools/orc-rt-process-info-check.cpp
+++ b/orc-rt/test/tools/orc-rt-process-info-check.cpp
@@ -30,12 +30,12 @@ int main(int argc, char *argv[]) {
 
     if (auto Err = P.parse(argc, argv)) {
       std::cerr << "error: " << orc_rt::toString(std::move(Err)) << "\n";
-      P.printHelp(std::cerr, argv[0]);
+      std::cerr << P.formatHelp(argv[0]);
       return 1;
     }
 
     if (PrintHelp) {
-      P.printHelp(std::cerr, argv[0]);
+      std::cerr << P.formatHelp(argv[0]);
       return 0;
     }
   }

--- a/orc-rt/test/unit/CommandLineTest.cpp
+++ b/orc-rt/test/unit/CommandLineTest.cpp
@@ -114,9 +114,7 @@ TEST_F(CommandLineParserTest, PrintHelpAlignmentWithShortFlags) {
   std::string LogFile;
   Parser.addValue("log-file", "Path to log", std::string("out.log"), LogFile);
 
-  std::stringstream SS;
-  Parser.printHelp(SS, "appname");
-  std::string Result = SS.str();
+  std::string Result = Parser.formatHelp("appname");
 
   auto GetColumn = [&](std::string_view SearchTerm) -> size_t {
     size_t Pos = Result.find(SearchTerm);

--- a/orc-rt/test/unit/StringExtrasTest.cpp
+++ b/orc-rt/test/unit/StringExtrasTest.cpp
@@ -162,3 +162,44 @@ TEST(StringOutputStreamTest, RealisticMessage) {
      << ", flags=" << hex(0x1Bu) << ")";
   EXPECT_EQ(OS.str(), "map failed at 0x1000 (errno=-22, flags=0x1b)");
 }
+
+TEST(StringOutputStreamTest, LeftJustifyPadsOnRight) {
+  StringOutputStream OS;
+  OS << '[' << ljust("ab", 5) << ']';
+  EXPECT_EQ(OS.str(), "[ab   ]");
+}
+
+TEST(StringOutputStreamTest, RightJustifyPadsOnLeft) {
+  StringOutputStream OS;
+  OS << '[' << rjust("ab", 5) << ']';
+  EXPECT_EQ(OS.str(), "[   ab]");
+}
+
+TEST(StringOutputStreamTest, JustifyCustomFill) {
+  StringOutputStream OS;
+  OS << ljust("ab", 5, '.') << rjust("cd", 5, '.');
+  EXPECT_EQ(OS.str(), "ab......cd");
+}
+
+// A field at least as wide as the requested width is emitted in full, never
+// truncated, and adds no padding.
+TEST(StringOutputStreamTest, JustifyNoTruncationAtOrOverWidth) {
+  {
+    StringOutputStream OS;
+    OS << '[' << ljust("exact", 5) << ']';
+    EXPECT_EQ(OS.str(), "[exact]");
+  }
+  {
+    StringOutputStream OS;
+    OS << '[' << rjust("toolong", 3) << ']';
+    EXPECT_EQ(OS.str(), "[toolong]");
+  }
+}
+
+// Mirrors printHelp's column layout: a left-justified flag field followed by
+// its description, so descriptions align regardless of flag length.
+TEST(StringOutputStreamTest, JustifyAlignsColumns) {
+  StringOutputStream OS;
+  OS << ljust("--a", 10) << "first\n" << ljust("--bbbbb", 10) << "second\n";
+  EXPECT_EQ(OS.str(), "--a       first\n--bbbbb   second\n");
+}


### PR DESCRIPTION
Add ljust/rjust field-padding helpers to StringOutputStream (a nested Justified type plus free ljust/rjust functions), the string-building analogue of std::setw with std::left/std::right.

Use them to replace CommandLineParser::printHelp(std::ostream &, ...) with formatHelp(std::string_view) -> std::string, built via StringOutputStream. CommandLine.h no longer includes any iostream header (<iomanip> dropped, no <ostream> added); callers that want to print route the returned string themselves, e.g.
  std::cerr << P.formatHelp(argv[0]);

This moves the iostream dependency out of the reusable header and into the leaf tools (host binaries) that opt into it. Updates the two check tools and the unit test, which no longer needs a stringstream.