### PR TITLE
[RISCV] Turn certain cases of masked.load into vp.load + vp.merge

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -2025,6 +2025,7 @@ RISCVTargetLowering::RISCVTargetLowering(const TargetMachine &TM,
                          ISD::VECTOR_MATCH,
                          ISD::MGATHER,
                          ISD::MSCATTER,
+                         ISD::MLOAD,
                          ISD::VP_GATHER,
                          ISD::VP_SCATTER,
                          ISD::SRL,
@@ -20906,6 +20907,62 @@ static SDValue performVP_STORECombine(SDNode *N, SelectionDAG &DAG,
       VPStore->isCompressingStore());
 }
 
+/// Given
+/// ```
+/// %s = <0, 1, 2, 3, ...>
+/// %M = splat %m
+/// %p = setcc ult %s, %M
+/// %v = mask.load %addr, %p, %passthru
+/// ```
+/// we can turn this use a vp.load + vp.merge instead to avoid
+/// emitting mask. The VL of these two vp operations would be
+/// `min(%m, <number of vector elements>)`
+static SDValue performMaskedLoadToVPLoadCombine(MaskedLoadSDNode *MLoad,
+                                                SelectionDAG &DAG) {
+  using namespace SDPatternMatch;
+  EVT MaskVT = MLoad->getMask().getValueType();
+  assert(MaskVT.isVector());
+  if (!MaskVT.isFixedLengthVector())
+    return SDValue();
+  unsigned NumElements = MaskVT.getVectorNumElements();
+  SDLoc DL(MLoad);
+
+  SDValue SetCCLHS, SetCCRHS;
+  ISD::CondCode CC;
+  if (!sd_match(MLoad->getMask(), m_SetCC(m_Value(SetCCLHS), m_Value(SetCCRHS),
+                                          m_CondCode(CC))) ||
+      SetCCLHS->getOpcode() != ISD::BUILD_VECTOR ||
+      !(CC == ISD::SETULT || CC == ISD::SETLT) ||
+      !SetCCLHS.getValueType().isInteger())
+    return SDValue();
+  bool IsSigned = ISD::isSignedIntSetCC(CC);
+
+  SDValue Boundary = DAG.getSplatValue(SetCCRHS, /*LegalizeType=*/true);
+  if (!Boundary)
+    return SDValue();
+
+  // Return {a,n} from a build_vector sequence of {a, a+n, a+2n, a+3n, ....}
+  auto StepVector = cast<BuildVectorSDNode>(SetCCLHS)->isArithmeticSequence();
+  if (!StepVector || !StepVector->first.isZero() || !StepVector->second.isOne())
+    return SDValue();
+  EVT LenVT = Boundary.getValueType();
+
+  SDValue VL = DAG.getNode(IsSigned ? ISD::SMIN : ISD::UMIN, DL, LenVT,
+                           Boundary, DAG.getConstant(NumElements, DL, LenVT));
+
+  SDValue VPLoad = DAG.getLoadVP(
+      MLoad->getValueType(0), DL, MLoad->getChain(), MLoad->getBasePtr(),
+      DAG.getAllOnesConstant(DL, MaskVT), VL, MLoad->getPointerInfo(),
+      MLoad->getBaseAlign(), MLoad->getMemOperand()->getFlags(), AAMDNodes());
+  if (MLoad->getPassThru().isUndef())
+    return DAG.getMergeValues({VPLoad, VPLoad.getValue(1)}, DL);
+  // Insert vp.merge if there is a passthru.
+  SDValue VPMerge = DAG.getNode(ISD::VP_MERGE, DL, MLoad->getValueType(0),
+                                DAG.getAllOnesConstant(DL, MaskVT), VPLoad,
+                                MLoad->getPassThru(), VL);
+  return DAG.getMergeValues({VPMerge, VPLoad.getValue(1)}, DL);
+}
+
 // Convert from one FMA opcode to another based on whether we are negating the
 // multiply result and/or the accumulator.
 // NOTE: Only supports RVV operations with VL.
@@ -24369,6 +24426,8 @@ SDValue RISCVTargetLowering::PerformDAGCombine(SDNode *N,
                        DAG.getConstant(1, DL, XLenVT), N->getOperand(3),
                        N->getOperand(4));
   }
+  case ISD::MLOAD:
+    return performMaskedLoadToVPLoadCombine(cast<MaskedLoadSDNode>(N), DAG);
   }
 
   return SDValue();

--- a/llvm/test/CodeGen/RISCV/rvv/masked-load-vl-predicatable.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/masked-load-vl-predicatable.ll
@@ -4,13 +4,14 @@
 define <16 x float> @masked_load(ptr %p, i32 signext %n, i32 signext %iv) nounwind {
 ; CHECK-LABEL: masked_load:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 16, e32, m4, ta, mu
-; CHECK-NEXT:    vid.v v8
+; CHECK-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; CHECK-NEXT:    vmv.v.i v8, 0
 ; CHECK-NEXT:    maxu a1, a1, a2
 ; CHECK-NEXT:    sub a1, a1, a2
-; CHECK-NEXT:    vmsltu.vx v0, v8, a1
-; CHECK-NEXT:    vmv.v.i v8, 0
-; CHECK-NEXT:    vle32.v v8, (a0), v0.t
+; CHECK-NEXT:    li a2, 16
+; CHECK-NEXT:    minu a1, a1, a2
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, tu, ma
+; CHECK-NEXT:    vle32.v v8, (a0)
 ; CHECK-NEXT:    ret
   %11 = insertelement <16 x i32> poison, i32 %iv, i32 0
   %12 = shufflevector <16 x i32> %11, <16 x i32> poison, <16 x i32> zeroinitializer
@@ -25,12 +26,12 @@ define <16 x float> @masked_load(ptr %p, i32 signext %n, i32 signext %iv) nounwi
 define <16 x float> @masked_load_no_passthru(ptr %p, i32 signext %n, i32 signext %iv) nounwind {
 ; CHECK-LABEL: masked_load_no_passthru:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; CHECK-NEXT:    vid.v v8
 ; CHECK-NEXT:    maxu a1, a1, a2
 ; CHECK-NEXT:    sub a1, a1, a2
-; CHECK-NEXT:    vmsltu.vx v0, v8, a1
-; CHECK-NEXT:    vle32.v v8, (a0), v0.t
+; CHECK-NEXT:    li a2, 16
+; CHECK-NEXT:    minu a1, a1, a2
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, ta, ma
+; CHECK-NEXT:    vle32.v v8, (a0)
 ; CHECK-NEXT:    ret
   %11 = insertelement <16 x i32> poison, i32 %iv, i32 0
   %12 = shufflevector <16 x i32> %11, <16 x i32> poison, <16 x i32> zeroinitializer
@@ -45,13 +46,14 @@ define <16 x float> @masked_load_no_passthru(ptr %p, i32 signext %n, i32 signext
 define <16 x float> @masked_load_add(ptr %p, i32 signext %n, i32 signext %iv) nounwind {
 ; CHECK-LABEL: masked_load_add:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 16, e32, m4, ta, mu
-; CHECK-NEXT:    vid.v v8
+; CHECK-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; CHECK-NEXT:    vmv.v.i v8, 0
 ; CHECK-NEXT:    maxu a1, a1, a2
 ; CHECK-NEXT:    sub a1, a1, a2
-; CHECK-NEXT:    vmsltu.vx v0, v8, a1
-; CHECK-NEXT:    vmv.v.i v8, 0
-; CHECK-NEXT:    vle32.v v8, (a0), v0.t
+; CHECK-NEXT:    li a2, 16
+; CHECK-NEXT:    minu a1, a1, a2
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, tu, ma
+; CHECK-NEXT:    vle32.v v8, (a0)
 ; CHECK-NEXT:    ret
   %11 = insertelement <16 x i32> poison, i32 %iv, i32 0
   %12 = shufflevector <16 x i32> %11, <16 x i32> poison, <16 x i32> zeroinitializer
@@ -66,13 +68,14 @@ define <16 x float> @masked_load_add(ptr %p, i32 signext %n, i32 signext %iv) no
 define <16 x float> @masked_load_gt(ptr %p, i32 signext %n, i32 signext %iv) nounwind {
 ; CHECK-LABEL: masked_load_gt:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 16, e32, m4, ta, mu
-; CHECK-NEXT:    vid.v v8
+; CHECK-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; CHECK-NEXT:    vmv.v.i v8, 0
 ; CHECK-NEXT:    maxu a1, a1, a2
 ; CHECK-NEXT:    sub a1, a1, a2
-; CHECK-NEXT:    vmsltu.vx v0, v8, a1
-; CHECK-NEXT:    vmv.v.i v8, 0
-; CHECK-NEXT:    vle32.v v8, (a0), v0.t
+; CHECK-NEXT:    li a2, 16
+; CHECK-NEXT:    minu a1, a1, a2
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, tu, ma
+; CHECK-NEXT:    vle32.v v8, (a0)
 ; CHECK-NEXT:    ret
   %11 = insertelement <16 x i32> poison, i32 %iv, i32 0
   %12 = shufflevector <16 x i32> %11, <16 x i32> poison, <16 x i32> zeroinitializer
@@ -87,13 +90,14 @@ define <16 x float> @masked_load_gt(ptr %p, i32 signext %n, i32 signext %iv) nou
 define <16 x float> @masked_load_signed_cmp(ptr %p, i32 signext %n, i32 signext %iv) nounwind {
 ; CHECK-LABEL: masked_load_signed_cmp:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 16, e32, m4, ta, mu
-; CHECK-NEXT:    vid.v v8
+; CHECK-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; CHECK-NEXT:    vmv.v.i v8, 0
 ; CHECK-NEXT:    min a2, a1, a2
 ; CHECK-NEXT:    sub a1, a1, a2
-; CHECK-NEXT:    vmslt.vx v0, v8, a1
-; CHECK-NEXT:    vmv.v.i v8, 0
-; CHECK-NEXT:    vle32.v v8, (a0), v0.t
+; CHECK-NEXT:    li a2, 16
+; CHECK-NEXT:    min a1, a1, a2
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, tu, ma
+; CHECK-NEXT:    vle32.v v8, (a0)
 ; CHECK-NEXT:    ret
   %11 = insertelement <16 x i32> poison, i32 %iv, i32 0
   %12 = shufflevector <16 x i32> %11, <16 x i32> poison, <16 x i32> zeroinitializer
@@ -108,13 +112,14 @@ define <16 x float> @masked_load_signed_cmp(ptr %p, i32 signext %n, i32 signext 
 define <16 x float> @masked_load_sgt(ptr %p, i32 signext %n, i32 signext %iv) nounwind {
 ; CHECK-LABEL: masked_load_sgt:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 16, e32, m4, ta, mu
-; CHECK-NEXT:    vid.v v8
+; CHECK-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; CHECK-NEXT:    vmv.v.i v8, 0
 ; CHECK-NEXT:    min a2, a1, a2
 ; CHECK-NEXT:    sub a1, a1, a2
-; CHECK-NEXT:    vmslt.vx v0, v8, a1
-; CHECK-NEXT:    vmv.v.i v8, 0
-; CHECK-NEXT:    vle32.v v8, (a0), v0.t
+; CHECK-NEXT:    li a2, 16
+; CHECK-NEXT:    min a1, a1, a2
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, tu, ma
+; CHECK-NEXT:    vle32.v v8, (a0)
 ; CHECK-NEXT:    ret
   %11 = insertelement <16 x i32> poison, i32 %iv, i32 0
   %12 = shufflevector <16 x i32> %11, <16 x i32> poison, <16 x i32> zeroinitializer
@@ -129,14 +134,15 @@ define <16 x float> @masked_load_sgt(ptr %p, i32 signext %n, i32 signext %iv) no
 define <16 x float> @masked_load_get_active_lane(ptr %p, i32 signext %n, i32 signext %iv) nounwind {
 ; CHECK-LABEL: masked_load_get_active_lane:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 16, e32, m4, ta, mu
-; CHECK-NEXT:    vid.v v8
+; CHECK-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; CHECK-NEXT:    vmv.v.i v8, 0
 ; CHECK-NEXT:    slliw a2, a2, 4
 ; CHECK-NEXT:    maxu a1, a1, a2
 ; CHECK-NEXT:    sub a1, a1, a2
-; CHECK-NEXT:    vmsltu.vx v0, v8, a1
-; CHECK-NEXT:    vmv.v.i v8, 0
-; CHECK-NEXT:    vle32.v v8, (a0), v0.t
+; CHECK-NEXT:    li a2, 16
+; CHECK-NEXT:    minu a1, a1, a2
+; CHECK-NEXT:    vsetvli zero, a1, e32, m4, tu, ma
+; CHECK-NEXT:    vle32.v v8, (a0)
 ; CHECK-NEXT:    ret
   %s = shl i32 %iv, 4
   %m = tail call <16 x i1> @llvm.get.active.lane.mask(i32 %s, i32 %n)
@@ -148,18 +154,21 @@ define <64 x float> @masked_load_wide(ptr %p, i32 signext %n, i32 signext %iv) n
 ; CHECK-LABEL: masked_load_wide:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    li a3, 32
-; CHECK-NEXT:    vsetvli zero, a3, e32, m8, ta, mu
-; CHECK-NEXT:    vid.v v24
-; CHECK-NEXT:    vadd.vx v16, v24, a3
+; CHECK-NEXT:    vsetvli zero, a3, e32, m8, ta, ma
+; CHECK-NEXT:    vmv.v.i v16, 0
 ; CHECK-NEXT:    vmv.v.i v8, 0
 ; CHECK-NEXT:    maxu a1, a1, a2
 ; CHECK-NEXT:    sub a1, a1, a2
-; CHECK-NEXT:    vmsltu.vx v0, v16, a1
-; CHECK-NEXT:    vmv.v.i v16, 0
-; CHECK-NEXT:    addi a2, a0, 128
-; CHECK-NEXT:    vle32.v v16, (a2), v0.t
-; CHECK-NEXT:    vmsltu.vx v0, v24, a1
-; CHECK-NEXT:    vle32.v v8, (a0), v0.t
+; CHECK-NEXT:    minu a2, a1, a3
+; CHECK-NEXT:    vsetvli zero, a2, e32, m8, tu, ma
+; CHECK-NEXT:    vle32.v v8, (a0)
+; CHECK-NEXT:    li a2, 64
+; CHECK-NEXT:    minu a1, a1, a2
+; CHECK-NEXT:    maxu a1, a1, a3
+; CHECK-NEXT:    addi a0, a0, 128
+; CHECK-NEXT:    addi a1, a1, -32
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, tu, ma
+; CHECK-NEXT:    vle32.v v16, (a0)
 ; CHECK-NEXT:    ret
   %11 = insertelement <64 x i32> poison, i32 %iv, i32 0
   %12 = shufflevector <64 x i32> %11, <64 x i32> poison, <64 x i32> zeroinitializer
@@ -175,19 +184,22 @@ define <64 x float> @masked_load_get_active_lane_wide(ptr %p, i32 signext %n, i3
 ; CHECK-LABEL: masked_load_get_active_lane_wide:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    li a3, 32
-; CHECK-NEXT:    vsetvli zero, a3, e32, m8, ta, mu
-; CHECK-NEXT:    vid.v v24
-; CHECK-NEXT:    vadd.vx v16, v24, a3
+; CHECK-NEXT:    vsetvli zero, a3, e32, m8, ta, ma
+; CHECK-NEXT:    vmv.v.i v16, 0
 ; CHECK-NEXT:    vmv.v.i v8, 0
 ; CHECK-NEXT:    slliw a2, a2, 6
 ; CHECK-NEXT:    maxu a1, a1, a2
 ; CHECK-NEXT:    sub a1, a1, a2
-; CHECK-NEXT:    vmsltu.vx v0, v16, a1
-; CHECK-NEXT:    vmv.v.i v16, 0
-; CHECK-NEXT:    addi a2, a0, 128
-; CHECK-NEXT:    vle32.v v16, (a2), v0.t
-; CHECK-NEXT:    vmsltu.vx v0, v24, a1
-; CHECK-NEXT:    vle32.v v8, (a0), v0.t
+; CHECK-NEXT:    minu a2, a1, a3
+; CHECK-NEXT:    vsetvli zero, a2, e32, m8, tu, ma
+; CHECK-NEXT:    vle32.v v8, (a0)
+; CHECK-NEXT:    li a2, 64
+; CHECK-NEXT:    minu a1, a1, a2
+; CHECK-NEXT:    maxu a1, a1, a3
+; CHECK-NEXT:    addi a0, a0, 128
+; CHECK-NEXT:    addi a1, a1, -32
+; CHECK-NEXT:    vsetvli zero, a1, e32, m8, tu, ma
+; CHECK-NEXT:    vle32.v v16, (a0)
 ; CHECK-NEXT:    ret
   %s = shl i32 %iv, 6
   %m = tail call <64 x i1> @llvm.get.active.lane.mask(i32 %s, i32 %n)


### PR DESCRIPTION
(This is the rebased version of #214350 , it was somehow closed by previously merged stacked PR, and also because I want to move the branch into llvm-project just in case I need to create a stacked PR again)

Though RISC-V's loop vectorizer would never generate this, but I found that other frontends like MLIR might generate "SVE-style" fixed vector masked.load that looks like this:
```
%b = splat %base
%s = <0, 1, 2, 3, ...>
%a = add nuw %b, %s
%N = splat %n
%m = icmp ult %a, %N
%v = mask.load %p, %m, %passthru
```
By default RISC-V lowers this sequence verbatim and thus emitting masks. To avoid masks, I think we could use vp.load + vp.merge instead with VL equals to
```
min(%n - min(%n, %base + %offset), numElements)
```
where %offset is the start value of step vector %s and numElements is the fixed vector size.