### PR TITLE
[compiler-rt] Add clang_rt library path to LIB env var for profile lit

### DIFF
--- a/compiler-rt/test/profile/lit.cfg.py
+++ b/compiler-rt/test/profile/lit.cfg.py
@@ -32,6 +32,11 @@ if (
 
 target_is_msvc = bool(re.match(r".*-windows-msvc$", config.target_triple))
 
+if target_is_msvc:
+    config.environment["LIB"] = os.path.pathsep.join(
+        [config.compiler_rt_libdir, config.environment.get("LIB", "")]
+    )
+
 if config.target_os in ["Linux"]:
     extra_link_flags = ["-ldl"]
 elif target_is_msvc:


### PR DESCRIPTION
When trying to add more tests to compiler-rt profile lit test suite on Windows, we encountered linker error complaining profile lib couldn't be found. This PR followed asan lit.cfg.py approach to add compiler-rt path to LIB env var.