### PR TITLE
[clang][CodeGen] Skip __hip_cuid_ global in incremental(clang-repl) mode

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -1296,9 +1296,10 @@ void CodeGenModule::Release() {
         llvm::ConstantArray::get(ATy, UsedArray), "__clang_gpu_used_external");
     addCompilerUsedGlobal(GV);
   }
-  // Skip __hip_cuid_ under incremental extensions (clang-repl): a repl session is one
-  // semantic TU, so this per-TU marker is useless in host and device IR. On the host it
-  // also collides, as every module shares one CUID and emits the same symbol at JIT link.
+  // Skip __hip_cuid_ under incremental extensions (clang-repl): a repl session
+  // is one semantic TU, so this per-TU marker is useless in host and device IR.
+  // On the host it also collides, as every module shares one CUID and emits the
+  // same symbol at JIT link.
   if (LangOpts.HIP && !LangOpts.IncrementalExtensions) {
     // Emit a unique ID so that host and device binaries from the same
     // compilation unit can be associated.

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -1296,8 +1296,9 @@ void CodeGenModule::Release() {
         llvm::ConstantArray::get(ATy, UsedArray), "__clang_gpu_used_external");
     addCompilerUsedGlobal(GV);
   }
-  // Skip __hip_cuid_ under incremental extensions (clang-repl): its constant
-  // name collides across modules in the same JIT dylib (duplicate symbols).
+  // Skip __hip_cuid_ under incremental extensions (clang-repl): a repl session is one
+  // semantic TU, so this per-TU marker is useless in host and device IR. On the host it
+  // also collides, as every module shares one CUID and emits the same symbol at JIT link.
   if (LangOpts.HIP && !LangOpts.IncrementalExtensions) {
     // Emit a unique ID so that host and device binaries from the same
     // compilation unit can be associated.

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -1296,7 +1296,9 @@ void CodeGenModule::Release() {
         llvm::ConstantArray::get(ATy, UsedArray), "__clang_gpu_used_external");
     addCompilerUsedGlobal(GV);
   }
-  if (LangOpts.HIP) {
+  // Skip __hip_cuid_ under incremental extensions (clang-repl): its constant
+  // name collides across modules in the same JIT dylib (duplicate symbols).
+  if (LangOpts.HIP && !LangOpts.IncrementalExtensions) {
     // Emit a unique ID so that host and device binaries from the same
     // compilation unit can be associated.
     auto *GV = new llvm::GlobalVariable(

--- a/clang/test/CodeGenCUDA/hip-cuid-incremental.hip
+++ b/clang/test/CodeGenCUDA/hip-cuid-incremental.hip
@@ -1,0 +1,14 @@
+// Check that the __hip_cuid_ global is emitted in normal HIP host
+// compilation, but skipped under incremental extensions (clang-repl),
+// where it would otherwise cause duplicate-symbol errors at JIT link time.
+
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -x hip -emit-llvm -cuid=abcd -o - %s | FileCheck --check-prefix=NORMAL %s
+
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -x hip -emit-llvm -fincremental-extensions -cuid=abcd -o - %s | FileCheck --check-prefix=INCR %s
+
+#include "Inputs/cuda.h"
+
+__global__ void kernel() {}
+
+// NORMAL: @__hip_cuid_
+// INCR-NOT: @__hip_cuid_

--- a/clang/test/CodeGenCUDA/hip-cuid-incremental.hip
+++ b/clang/test/CodeGenCUDA/hip-cuid-incremental.hip
@@ -1,10 +1,15 @@
-// Check that the __hip_cuid_ global is emitted in normal HIP host
-// compilation, but skipped under incremental extensions (clang-repl),
-// where it would otherwise cause duplicate-symbol errors at JIT link time.
+// Check that the __hip_cuid_ global is emitted in normal HIP compilation, but
+// skipped under incremental extensions (clang-repl), where it would otherwise
+// cause duplicate-symbol errors at JIT link time. This applies to both host and
+// device code generation.
 
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -x hip -emit-llvm -cuid=abcd -o - %s | FileCheck --check-prefix=NORMAL %s
 
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -x hip -emit-llvm -fincremental-extensions -cuid=abcd -o - %s | FileCheck --check-prefix=INCR %s
+
+// RUN: %clang_cc1 -triple amdgpu-amd-amdhsa -fcuda-is-device -x hip -emit-llvm -cuid=abcd -o - %s | FileCheck --check-prefix=DEV-NORMAL %s
+
+// RUN: %clang_cc1 -triple amdgpu-amd-amdhsa -fcuda-is-device -x hip -emit-llvm -fincremental-extensions -cuid=abcd -o - %s | FileCheck --check-prefix=DEV-INCR %s
 
 #include "Inputs/cuda.h"
 
@@ -12,3 +17,6 @@ __global__ void kernel() {}
 
 // NORMAL: @__hip_cuid_
 // INCR-NOT: @__hip_cuid_
+
+// DEV-NORMAL: @__hip_cuid_
+// DEV-INCR-NOT: @__hip_cuid_


### PR DESCRIPTION
With this patch, when run in incremental mode (clang-repl), Clang skips emitting the `__hip_cuid_` global. This is handled in `clang/lib/CodeGen/CodeGenModule.cpp` on `LangOpts.IncrementalExtensions`.

I have also added a test at `clang/test/CodeGenCUDA/hip-cuid-incremental.hip` which checks that the `__hip_cuid_` global is emitted normally but not in the presence of `-fincremental-extensions`.

Assisted by Claude Opus 4.8