### PR TITLE
[clang-tidy] Fix modernize-raw-string-literal crash on raw literal operators

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/RawStringLiteralCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/RawStringLiteralCheck.cpp
@@ -40,6 +40,19 @@ static bool isRawStringLiteral(StringRef Text) {
   return (QuotePos > 0) && (Text[QuotePos - 1] == 'R');
 }
 
+// Clang synthesizes StringLiteral nodes that are not spelled as a string in
+// the source, e.g. the argument of a raw literal operator call (`12_w` is
+// treated as `operator""_w("12")`). Such a node points at a non-string token,
+// so its source text must not be analyzed as a string literal.
+static bool isSpelledAsStringLiteral(const StringLiteral *Literal,
+                                     const SourceManager &SM,
+                                     const LangOptions &LangOpts) {
+  Token T;
+  if (Lexer::getRawToken(Literal->getBeginLoc(), T, SM, LangOpts))
+    return false;
+  return tok::isStringLiteral(T.getKind());
+}
+
 static bool containsEscapedCharacters(const MatchFinder::MatchResult &Result,
                                       const StringLiteral *Literal,
                                       const CharsBitSet &DisallowedChars) {
@@ -50,6 +63,10 @@ static bool containsEscapedCharacters(const MatchFinder::MatchResult &Result,
   for (const unsigned char C : Literal->getBytes())
     if (DisallowedChars.test(C))
       return false;
+
+  if (!isSpelledAsStringLiteral(Literal, *Result.SourceManager,
+                                Result.Context->getLangOpts()))
+    return false;
 
   const CharSourceRange CharRange = Lexer::makeFileCharRange(
       CharSourceRange::getTokenRange(Literal->getSourceRange()),

--- a/clang-tools-extra/docs/ReleaseNotes.md
+++ b/clang-tools-extra/docs/ReleaseNotes.md
@@ -148,6 +148,10 @@ infrastructure are described first, followed by tool-specific sections.
   nested expressions involving different macros or a mix of macro and
   non-macro operands.
 
+- Fixed a crash in {doc}`modernize-raw-string-literal
+  <clang-tidy/checks/modernize/raw-string-literal>` on synthetic string
+  literals created for raw user-defined literal operators, such as `12_w`.
+
 - Improved {doc}`modernize-return-braced-init-list
   <clang-tidy/checks/modernize/return-braced-init-list>` check to no longer
   rewrite the return value when the constructed type has a

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/raw-string-literal.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/raw-string-literal.cpp
@@ -142,3 +142,8 @@ auto UserDefinedLiteral = "foo\\bar"_abc;
 // CHECK-MESSAGES: :[[@LINE-1]]:27: warning: {{.*}} can be written as a raw string literal
 // CHECK-FIXES: auto UserDefinedLiteral = R"(foo\bar)"_abc;
 } // namespace gh97243
+
+namespace gh213891 {
+unsigned operator""_w(const char *);
+auto v = 12_w;
+} // namespace gh213891


### PR DESCRIPTION
Fixes #213891.

Raw user-defined literals like `12_w` can produce a synthetic `StringLiteral` whose source text is not actually a string literal. This caused `modernize-raw-string-literal` to look for quotes that were not present and crash.

Check that the source token is a string literal before analyzing its source text.

AI assistance: I used ChatGPT and Claude Code for codebase navigation, investigation, implementation planning, and drafting parts of the change. I reviewed and tested the final implementation and understand the submitted changes.
