### PR TITLE
[mlir][SPIR-V][Shard] Migrate to explicit attribute APIs

### DIFF
--- a/mlir/include/mlir/Dialect/Shard/Transforms/Simplify.h
+++ b/mlir/include/mlir/Dialect/Shard/Transforms/Simplify.h
@@ -64,8 +64,7 @@ void populateAllReduceEndomorphismSimplifyPatterns(RewritePatternSet &patterns,
       return false;
     auto inType = cast<ShapedType>(allReduceOp.getInput().getType());
     auto outType = cast<ShapedType>(allReduceOp.getResult().getType());
-    if (inType.getElementType() != outType.getElementType() ||
-        allReduceOp.getReduction() != reduction) {
+    if (inType.getElementType() != outType.getElementType()) {
       return false;
     }
 
@@ -78,13 +77,17 @@ void populateAllReduceEndomorphismSimplifyPatterns(RewritePatternSet &patterns,
       return false;
     }
 
-    if (!referenceOp) {
-      return true;
-    }
+    if (!referenceOp)
+      return allReduceOp.getReduction() == reduction;
 
     auto refAllReduceOp = llvm::dyn_cast<AllReduceOp>(referenceOp.value());
     auto refType = cast<ShapedType>(refAllReduceOp.getResult().getType());
-    return refAllReduceOp->getAttrs() == allReduceOp->getAttrs() &&
+    return refAllReduceOp.getGridAttr() == allReduceOp.getGridAttr() &&
+           refAllReduceOp.getGridAxesAttr() == allReduceOp.getGridAxesAttr() &&
+           refAllReduceOp.getReductionAttr() ==
+               allReduceOp.getReductionAttr() &&
+           refAllReduceOp->getDiscardableAttrDictionary() ==
+               allReduceOp->getDiscardableAttrDictionary() &&
            inType.getElementType() == refType.getElementType();
   };
   auto isAlgebraicOp = [](Operation *op) { return isa<AlgebraicOp>(op); };

--- a/mlir/include/mlir/IR/Operation.h
+++ b/mlir/include/mlir/IR/Operation.h
@@ -481,6 +481,26 @@ public:
   /// discardable attribute does not exist.
   Attribute getDiscardableAttr(StringAttr name) { return attrs.get(name); }
 
+  /// Access a discardable attribute by name and cast it to `AttrClass`.
+  template <typename AttrClass>
+  AttrClass getDiscardableAttrOfType(StringRef name) {
+    return llvm::dyn_cast_or_null<AttrClass>(getDiscardableAttr(name));
+  }
+  template <typename AttrClass>
+  AttrClass getDiscardableAttrOfType(StringAttr name) {
+    return llvm::dyn_cast_or_null<AttrClass>(getDiscardableAttr(name));
+  }
+
+  /// Return true if this operation has a discardable attribute with the
+  /// provided name.
+  bool hasDiscardableAttr(StringRef name) { return bool(attrs.get(name)); }
+  bool hasDiscardableAttr(StringAttr name) { return bool(attrs.get(name)); }
+  template <typename AttrClass, typename NameT>
+  bool hasDiscardableAttrOfType(NameT &&name) {
+    return static_cast<bool>(
+        getDiscardableAttrOfType<AttrClass>(std::forward<NameT>(name)));
+  }
+
   /// Set a discardable attribute by name.
   void setDiscardableAttr(StringAttr name, Attribute value) {
     NamedAttrList attributes(attrs);

--- a/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
+++ b/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
@@ -214,12 +214,14 @@ struct ElementwiseArithOpPattern final : OpConversionPattern<Op> {
         op, dstType, adaptor.getOperands());
 
     if (bitEnumContainsAny(overflowFlags, arith::IntegerOverflowFlags::nsw))
-      newOp->setAttr(getDecorationString(spirv::Decoration::NoSignedWrap),
-                     rewriter.getUnitAttr());
+      newOp->setDiscardableAttr(
+          getDecorationString(spirv::Decoration::NoSignedWrap),
+          rewriter.getUnitAttr());
 
     if (bitEnumContainsAny(overflowFlags, arith::IntegerOverflowFlags::nuw))
-      newOp->setAttr(getDecorationString(spirv::Decoration::NoUnsignedWrap),
-                     rewriter.getUnitAttr());
+      newOp->setDiscardableAttr(
+          getDecorationString(spirv::Decoration::NoUnsignedWrap),
+          rewriter.getUnitAttr());
 
     return success();
   }
@@ -1059,7 +1061,7 @@ struct TypeCastingOpPattern final : public OpConversionPattern<Op> {
       auto newOp = rewriter.template replaceOpWithNewOp<SPIRVOp>(
           op, dstType, adaptor.getOperands());
       if (rm) {
-        newOp->setAttr(
+        newOp->setDiscardableAttr(
             getDecorationString(spirv::Decoration::FPRoundingMode),
             spirv::FPRoundingModeAttr::get(rewriter.getContext(), *rm));
       }

--- a/mlir/lib/Conversion/FuncToSPIRV/FuncToSPIRV.cpp
+++ b/mlir/lib/Conversion/FuncToSPIRV/FuncToSPIRV.cpp
@@ -68,11 +68,15 @@ public:
           getTypeConverter()->convertType(callOp.getResult(0).getType());
       if (!resultType)
         return failure();
-      rewriter.replaceOpWithNewOp<spirv::FunctionCallOp>(
-          callOp, resultType, adaptor.getOperands(), callOp->getAttrs());
+      auto newCall = rewriter.replaceOpWithNewOp<spirv::FunctionCallOp>(
+          callOp, resultType, callOp.getCalleeAttr(), adaptor.getOperands(),
+          callOp.getArgAttrsAttr(), callOp.getResAttrsAttr());
+      newCall->setDiscardableAttrs(callOp->getDiscardableAttrDictionary());
     } else {
-      rewriter.replaceOpWithNewOp<spirv::FunctionCallOp>(
-          callOp, TypeRange(), adaptor.getOperands(), callOp->getAttrs());
+      auto newCall = rewriter.replaceOpWithNewOp<spirv::FunctionCallOp>(
+          callOp, TypeRange(), callOp.getCalleeAttr(), adaptor.getOperands(),
+          callOp.getArgAttrsAttr(), callOp.getResAttrsAttr());
+      newCall->setDiscardableAttrs(callOp->getDiscardableAttrDictionary());
     }
     return success();
   }

--- a/mlir/lib/Conversion/GPUToSPIRV/GPUToSPIRV.cpp
+++ b/mlir/lib/Conversion/GPUToSPIRV/GPUToSPIRV.cpp
@@ -294,11 +294,35 @@ lowerAsEntryFunction(gpu::GPUFuncOp funcOp, const TypeConverter &typeConverter,
   auto newFuncOp = spirv::FuncOp::create(
       rewriter, funcOp.getLoc(), funcOp.getName(),
       rewriter.getFunctionType(signatureConverter.getConvertedTypes(), {}));
-  for (const auto &namedAttr : funcOp->getAttrs()) {
-    if (namedAttr.getName() == funcOp.getFunctionTypeAttrName() ||
-        namedAttr.getName() == SymbolTable::getSymbolAttrName())
+  newFuncOp.setArgAttrsAttr(funcOp.getArgAttrsAttr());
+  newFuncOp.setResAttrsAttr(funcOp.getResAttrsAttr());
+  cast<SymbolOpInterface>(newFuncOp.getOperation())
+      .setVisibility(
+          cast<SymbolOpInterface>(funcOp.getOperation()).getVisibility());
+
+  auto copyGPUProperty = [&](StringAttr name, Attribute value) {
+    if (value)
+      newFuncOp->setDiscardableAttr(name, value);
+  };
+  copyGPUProperty(funcOp.getWorkgroupAttribAttrsAttrName(),
+                  funcOp.getWorkgroupAttribAttrsAttr());
+  copyGPUProperty(funcOp.getPrivateAttribAttrsAttrName(),
+                  funcOp.getPrivateAttribAttrsAttr());
+  copyGPUProperty(funcOp.getKnownBlockSizeAttrName(),
+                  funcOp.getKnownBlockSizeAttr());
+  copyGPUProperty(funcOp.getKnownGridSizeAttrName(),
+                  funcOp.getKnownGridSizeAttr());
+  copyGPUProperty(funcOp.getKnownClusterSizeAttrName(),
+                  funcOp.getKnownClusterSizeAttr());
+  copyGPUProperty(funcOp.getWorkgroupAttributionsAttrName(),
+                  funcOp.getWorkgroupAttributionsAttr());
+  for (const auto &discardableAttr :
+       funcOp->getDiscardableAttrDictionary().getValue()) {
+    if (discardableAttr.getName() == funcOp.getFunctionTypeAttrName() ||
+        discardableAttr.getName() == SymbolTable::getSymbolAttrName())
       continue;
-    newFuncOp->setAttr(namedAttr.getName(), namedAttr.getValue());
+    newFuncOp->setDiscardableAttr(discardableAttr.getName(),
+                                  discardableAttr.getValue());
   }
 
   rewriter.inlineRegionBefore(funcOp.getBody(), newFuncOp.getBody(),
@@ -313,7 +337,8 @@ lowerAsEntryFunction(gpu::GPUFuncOp funcOp, const TypeConverter &typeConverter,
   for (auto argIndex : llvm::seq<unsigned>(0, argABIInfo.size())) {
     newFuncOp.setArgAttr(argIndex, argABIAttrName, argABIInfo[argIndex]);
   }
-  newFuncOp->setAttr(spirv::getEntryPointABIAttrName(), entryPointInfo);
+  newFuncOp->setDiscardableAttr(spirv::getEntryPointABIAttrName(),
+                                entryPointInfo);
 
   return newFuncOp;
 }
@@ -378,7 +403,7 @@ LogicalResult GPUFuncOpConversion::matchAndRewrite(
       funcOp, *getTypeConverter(), rewriter, entryPointAttr, argABI);
   if (!newFuncOp)
     return failure();
-  newFuncOp->removeAttr(
+  newFuncOp->removeDiscardableAttr(
       rewriter.getStringAttr(gpu::GPUDialect::getKernelFuncAttrName()));
   return success();
 }
@@ -416,14 +441,15 @@ LogicalResult GPUModuleConversion::matchAndRewrite(
   // will fail if called after GPUModuleConversion and we don't preserve
   // `TargetEnv` attribute.
   // Copy TargetEnvAttr only if it is attached directly to the GPUModuleOp.
-  if (auto attr = moduleOp->getAttrOfType<spirv::TargetEnvAttr>(
+  if (auto attr = moduleOp->getDiscardableAttrOfType<spirv::TargetEnvAttr>(
           spirv::getTargetEnvAttrName()))
-    spvModule->setAttr(spirv::getTargetEnvAttrName(), attr);
+    spvModule->setDiscardableAttr(spirv::getTargetEnvAttrName(), attr);
   if (ArrayAttr targets = moduleOp.getTargetsAttr()) {
     for (Attribute targetAttr : targets)
       if (auto spirvTargetEnvAttr =
               dyn_cast<spirv::TargetEnvAttr>(targetAttr)) {
-        spvModule->setAttr(spirv::getTargetEnvAttrName(), spirvTargetEnvAttr);
+        spvModule->setDiscardableAttr(spirv::getTargetEnvAttrName(),
+                                      spirvTargetEnvAttr);
         break;
       }
   }
@@ -986,7 +1012,7 @@ LogicalResult GPUPrintfConversion::matchAndRewrite(
         rewriter, loc, ptrType, globalVarName,
         FlatSymbolRefAttr::get(specCstComposite));
 
-    globalVar->setAttr("Constant", rewriter.getUnitAttr());
+    globalVar->setDiscardableAttr("Constant", rewriter.getUnitAttr());
   }
   // Get SSA value of Global variable and create pointer to i8 to point to
   // the format string.

--- a/mlir/lib/Conversion/GPUToSPIRV/GPUToSPIRVPass.cpp
+++ b/mlir/lib/Conversion/GPUToSPIRV/GPUToSPIRVPass.cpp
@@ -177,8 +177,8 @@ void GPUToSPIRVPass::runOnOperation() {
         auto entryBlock = newFuncOp.addEntryBlock();
         builder.setInsertionPointToEnd(entryBlock);
         func::ReturnOp::create(builder, funcOp.getLoc());
-        newFuncOp->setAttr(gpu::GPUDialect::getKernelFuncAttrName(),
-                           builder.getUnitAttr());
+        newFuncOp->setDiscardableAttr(gpu::GPUDialect::getKernelFuncAttrName(),
+                                      builder.getUnitAttr());
         funcOp.erase();
       });
     }

--- a/mlir/lib/Conversion/MemRefToSPIRV/MapMemRefStorageClassPass.cpp
+++ b/mlir/lib/Conversion/MemRefToSPIRV/MapMemRefStorageClassPass.cpp
@@ -230,9 +230,9 @@ static bool isLegalOp(Operation *op) {
                         isLegalType);
   }
 
-  auto attrs = llvm::map_range(op->getAttrs(), [](const NamedAttribute &attr) {
-    return attr.getValue();
-  });
+  auto attrs = llvm::map_range(
+      op->getDiscardableAttrDictionary().getValue(),
+      [](const NamedAttribute &attr) { return attr.getValue(); });
 
   return llvm::all_of(op->getOperandTypes(), isLegalType) &&
          llvm::all_of(op->getResultTypes(), isLegalType) &&

--- a/mlir/lib/Conversion/SCFToSPIRV/SCFToSPIRV.cpp
+++ b/mlir/lib/Conversion/SCFToSPIRV/SCFToSPIRV.cpp
@@ -137,7 +137,7 @@ struct ForOpConversion final : SCFToSPIRVPattern<scf::ForOp> {
     // from header to merge.
     auto loc = forOp.getLoc();
     auto loopControl = spirv::LoopControl::None;
-    if (auto attr = forOp->getAttrOfType<spirv::LoopControlAttr>(
+    if (auto attr = forOp->getDiscardableAttrOfType<spirv::LoopControlAttr>(
             spirv::getLoopControlAttrName()))
       loopControl = attr.getValue();
     auto loopOp = spirv::LoopOp::create(rewriter, loc, loopControl);
@@ -260,7 +260,7 @@ struct IfOpConversion : SCFToSPIRVPattern<scf::IfOp> {
     // Create `spirv.selection` operation, selection header block and merge
     // block.
     auto selectionControl = spirv::SelectionControl::None;
-    if (auto attr = ifOp->getAttrOfType<spirv::SelectionControlAttr>(
+    if (auto attr = ifOp->getDiscardableAttrOfType<spirv::SelectionControlAttr>(
             spirv::getSelectionControlAttrName()))
       selectionControl = attr.getValue();
     auto selectionOp =
@@ -339,8 +339,9 @@ struct IndexSwitchOpConversion final : SCFToSPIRVPattern<scf::IndexSwitchOp> {
 
     // Create the `spirv.mlir.selection` op, its header block, and merge block.
     auto selectionControl = spirv::SelectionControl::None;
-    if (auto attr = switchOp->getAttrOfType<spirv::SelectionControlAttr>(
-            spirv::getSelectionControlAttrName()))
+    if (auto attr =
+            switchOp->getDiscardableAttrOfType<spirv::SelectionControlAttr>(
+                spirv::getSelectionControlAttrName()))
       selectionControl = attr.getValue();
     auto selectionOp =
         spirv::SelectionOp::create(rewriter, loc, selectionControl);
@@ -451,7 +452,7 @@ struct WhileOpConversion final : SCFToSPIRVPattern<scf::WhileOp> {
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = whileOp.getLoc();
     auto loopControl = spirv::LoopControl::None;
-    if (auto attr = whileOp->getAttrOfType<spirv::LoopControlAttr>(
+    if (auto attr = whileOp->getDiscardableAttrOfType<spirv::LoopControlAttr>(
             spirv::getLoopControlAttrName()))
       loopControl = attr.getValue();
     auto loopOp = spirv::LoopOp::create(rewriter, loc, loopControl);

--- a/mlir/lib/Conversion/SPIRVToLLVM/ConvertLaunchFuncToLLVMCalls.cpp
+++ b/mlir/lib/Conversion/SPIRVToLLVM/ConvertLaunchFuncToLLVMCalls.cpp
@@ -44,24 +44,13 @@ static constexpr const char kSPIRVModule[] = "__spv__";
 // Utility functions
 //===----------------------------------------------------------------------===//
 
-/// Returns the string name of the `DescriptorSet` decoration.
-static std::string descriptorSetName() {
-  return spirv::getDecorationString(spirv::Decoration::DescriptorSet);
-}
-
-/// Returns the string name of the `Binding` decoration.
-static std::string bindingName() {
-  return spirv::getDecorationString(spirv::Decoration::Binding);
-}
-
 /// Calculates the index of the kernel's operand that is represented by the
 /// given global variable with the `bind` attribute. We assume that the index of
 /// each kernel's operand is mapped to (descriptorSet, binding) by the map:
 ///   i -> (0, i)
 /// which is implemented under `LowerABIAttributesPass`.
 static unsigned calculateGlobalIndex(spirv::GlobalVariableOp op) {
-  IntegerAttr binding = op->getAttrOfType<IntegerAttr>(bindingName());
-  return binding.getInt();
+  return *op.getBinding();
 }
 
 /// Copies the given number of bytes from src to dst pointers.
@@ -78,22 +67,16 @@ static void copy(Location loc, Value dst, Value src, Value size,
 static std::string
 createGlobalVariableWithBindName(spirv::GlobalVariableOp op,
                                  StringRef kernelModuleName) {
-  IntegerAttr descriptorSet =
-      op->getAttrOfType<IntegerAttr>(descriptorSetName());
-  IntegerAttr binding = op->getAttrOfType<IntegerAttr>(bindingName());
   return llvm::formatv("{0}_{1}_descriptor_set{2}_binding{3}",
                        kernelModuleName.str(), op.getSymName().str(),
-                       std::to_string(descriptorSet.getInt()),
-                       std::to_string(binding.getInt()));
+                       std::to_string(*op.getDescriptorSet()),
+                       std::to_string(*op.getBinding()));
 }
 
 /// Returns true if the given global variable has both a descriptor set number
 /// and a binding number.
 static bool hasDescriptorSetAndBinding(spirv::GlobalVariableOp op) {
-  IntegerAttr descriptorSet =
-      op->getAttrOfType<IntegerAttr>(descriptorSetName());
-  IntegerAttr binding = op->getAttrOfType<IntegerAttr>(bindingName());
-  return descriptorSet && binding;
+  return op.getDescriptorSetAttr() && op.getBindingAttr();
 }
 
 /// Fills `globalVariableMap` with SPIR-V global variables that represent kernel
@@ -289,8 +272,8 @@ public:
 
     // Request C wrapper emission.
     for (auto func : module.getOps<func::FuncOp>()) {
-      func->setAttr(LLVM::LLVMDialect::getEmitCWrapperAttrName(),
-                    UnitAttr::get(&getContext()));
+      func->setDiscardableAttr(LLVM::LLVMDialect::getEmitCWrapperAttrName(),
+                               UnitAttr::get(&getContext()));
     }
 
     // Specify options to lower to LLVM and pull in the conversion patterns.

--- a/mlir/lib/Conversion/SPIRVToLLVM/SPIRVToLLVM.cpp
+++ b/mlir/lib/Conversion/SPIRVToLLVM/SPIRVToLLVM.cpp
@@ -303,6 +303,15 @@ static Type convertStructType(spirv::StructType type,
 
 namespace {
 
+template <typename OpTy>
+static NamedAttrList collectAttrsForConversion(OpTy op) {
+  NamedAttrList attrs(op->getDiscardableAttrDictionary());
+  if (auto properties =
+          dyn_cast_or_null<DictionaryAttr>(op->getPropertiesAsAttribute()))
+    attrs.append(properties.getValue());
+  return attrs;
+}
+
 class AccessChainPattern : public SPIRVToLLVMConversion<spirv::AccessChainOp> {
 public:
   using SPIRVToLLVMConversion<spirv::AccessChainOp>::SPIRVToLLVMConversion;
@@ -434,7 +443,8 @@ public:
       return success();
     }
     rewriter.replaceOpWithNewOp<LLVM::ConstantOp>(
-        constOp, dstType, adaptor.getOperands(), constOp->getAttrs());
+        constOp, dstType, adaptor.getOperands(),
+        collectAttrsForConversion(constOp));
     return success();
   }
 };
@@ -644,7 +654,7 @@ public:
     if (!dstType)
       return rewriter.notifyMatchFailure(op, "type conversion failed");
     rewriter.template replaceOpWithNewOp<LLVMOp>(
-        op, dstType, adaptor.getOperands(), op->getAttrs());
+        op, dstType, adaptor.getOperands(), collectAttrsForConversion(op));
     return success();
   }
 };
@@ -828,7 +838,7 @@ public:
 
     // Attach location attribute if applicable
     if (locationAttr)
-      newGlobalOp->setAttr(locationAttrName, locationAttr);
+      newGlobalOp->setDiscardableAttr(locationAttrName, locationAttr);
 
     return success();
   }
@@ -879,7 +889,8 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     if (callOp.getNumResults() == 0) {
       auto newOp = rewriter.replaceOpWithNewOp<LLVM::CallOp>(
-          callOp, TypeRange(), adaptor.getOperands(), callOp->getAttrs());
+          callOp, TypeRange(), adaptor.getOperands(),
+          collectAttrsForConversion(callOp));
       newOp.getProperties().operandSegmentSizes = {
           static_cast<int32_t>(adaptor.getOperands().size()), 0};
       newOp.getProperties().op_bundle_sizes = rewriter.getDenseI32ArrayAttr({});
@@ -891,7 +902,8 @@ public:
     if (!dstType)
       return rewriter.notifyMatchFailure(callOp, "type conversion failed");
     auto newOp = rewriter.replaceOpWithNewOp<LLVM::CallOp>(
-        callOp, dstType, adaptor.getOperands(), callOp->getAttrs());
+        callOp, dstType, adaptor.getOperands(),
+        collectAttrsForConversion(callOp));
     newOp.getProperties().operandSegmentSizes = {
         static_cast<int32_t>(adaptor.getOperands().size()), 0};
     newOp.getProperties().op_bundle_sizes = rewriter.getDenseI32ArrayAttr({});
@@ -1940,7 +1952,8 @@ public:
     }
 
     rewriter.replaceOpWithNewOp<LLVM::BitcastOp>(
-        bitcastOp, dstType, adaptor.getOperands(), bitcastOp->getAttrs());
+        bitcastOp, dstType, adaptor.getOperands(),
+        collectAttrsForConversion(bitcastOp));
     return success();
   }
 };
@@ -1986,7 +1999,8 @@ public:
 
 #define DISPATCH(functionControl, llvmAttr)                                    \
   case functionControl:                                                        \
-    newFuncOp->setAttr("passthrough", ArrayAttr::get(context, {llvmAttr}));    \
+    newFuncOp->setDiscardableAttr("passthrough",                               \
+                                  ArrayAttr::get(context, {llvmAttr}));        \
     break;
 
       DISPATCH(spirv::FunctionControl::Pure,
@@ -2382,15 +2396,12 @@ void mlir::populateSPIRVToLLVMModuleConversionPatterns(
 //===----------------------------------------------------------------------===//
 
 /// Hook for descriptor set and binding number encoding.
-static constexpr StringRef kBinding = "binding";
-static constexpr StringRef kDescriptorSet = "descriptor_set";
 void mlir::encodeBindAttribute(ModuleOp module) {
   auto spvModules = module.getOps<spirv::ModuleOp>();
   for (auto spvModule : spvModules) {
     spvModule.walk([&](spirv::GlobalVariableOp op) {
-      IntegerAttr descriptorSet =
-          op->getAttrOfType<IntegerAttr>(kDescriptorSet);
-      IntegerAttr binding = op->getAttrOfType<IntegerAttr>(kBinding);
+      IntegerAttr descriptorSet = op.getDescriptorSetAttr();
+      IntegerAttr binding = op.getBindingAttr();
       // For every global variable in the module, get the ones with descriptor
       // set and binding numbers.
       if (descriptorSet && binding) {
@@ -2411,8 +2422,8 @@ void mlir::encodeBindAttribute(ModuleOp module) {
         if (failed(SymbolTable::replaceAllSymbolUses(op, nameAttr, spvModule)))
           op.emitError("unable to replace all symbol uses for ") << name;
         SymbolTable::setSymbolName(op, nameAttr);
-        op->removeAttr(kDescriptorSet);
-        op->removeAttr(kBinding);
+        op.removeDescriptorSetAttr();
+        op.removeBindingAttr();
       }
     });
   }

--- a/mlir/lib/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosa.cpp
+++ b/mlir/lib/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosa.cpp
@@ -34,7 +34,7 @@ void copyFuncAttrsToGraph(func::FuncOp funcOp, func::FuncOpAdaptor adaptor,
                            attrName))
       continue;
 
-    graphOp->setAttr(attr.getName(), attr.getValue());
+    graphOp->setDiscardableAttr(attr.getName(), attr.getValue());
   }
 }
 
@@ -109,7 +109,7 @@ public:
         rewriter, funcOp.getLoc(), spirv::AddressingModel::Logical,
         spirv::MemoryModel::Vulkan, std::nullopt,
         ("_spirv_tosa_" + name).str());
-    spvModule->setAttr(spirv::getTargetEnvAttrName(), targetAttr);
+    spvModule->setDiscardableAttr(spirv::getTargetEnvAttrName(), targetAttr);
 
     rewriter.setInsertionPoint(spvModule.getBody(), spvModule.begin());
 

--- a/mlir/lib/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosaConstants.cpp
+++ b/mlir/lib/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosaConstants.cpp
@@ -51,7 +51,8 @@ bool shouldMarkGraphConstant(Operation *op) {
 
 void setGraphConstantId(Operation *op, uint32_t id) {
   auto i32Type = IntegerType::get(op->getContext(), 32);
-  op->setAttr(graphARMGraphConstantIdAttrName, IntegerAttr::get(i32Type, id));
+  op->setDiscardableAttr(graphARMGraphConstantIdAttrName,
+                         IntegerAttr::get(i32Type, id));
 }
 
 struct TosaToSPIRVTosaMarkGraphConstants final
@@ -64,7 +65,7 @@ struct TosaToSPIRVTosaMarkGraphConstants final
           if (!isa<tosa::ConstOp, tosa::ConstShapeOp>(op))
             return WalkResult::advance();
 
-          if (op->hasAttr(graphARMGraphConstantIdAttrName)) {
+          if (op->hasDiscardableAttr(graphARMGraphConstantIdAttrName)) {
             op->emitOpError()
                 << "already has `" << graphARMGraphConstantIdAttrName
                 << "`; this pass assigns graph constant IDs automatically and "

--- a/mlir/lib/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosaPass.cpp
+++ b/mlir/lib/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosaPass.cpp
@@ -145,8 +145,8 @@ LogicalResult verifyGraphConstantIdAttrs(Operation *op) {
     if (!isa<tosa::ConstOp, tosa::ConstShapeOp>(op))
       return WalkResult::advance();
 
-    auto graphConstantId =
-        op->getAttrOfType<IntegerAttr>(graphARMGraphConstantIdAttrName);
+    auto graphConstantId = op->getDiscardableAttrOfType<IntegerAttr>(
+        graphARMGraphConstantIdAttrName);
     if (!graphConstantId)
       return WalkResult::advance();
 

--- a/mlir/lib/Dialect/SPIRV/IR/AtomicOps.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/AtomicOps.cpp
@@ -42,11 +42,7 @@ static LogicalResult verifyAtomicUpdateOp(Operation *op) {
                              << stringifyTypeName<ExpectedElementType>()
                              << " value, found " << elementType;
 
-  StringAttr semanticsAttrName =
-      AtomicOpTy::getSemanticsAttrName(op->getName());
-  auto memorySemantics =
-      op->getAttrOfType<spirv::MemorySemanticsAttr>(semanticsAttrName)
-          .getValue();
+  spirv::MemorySemantics memorySemantics = cast<AtomicOpTy>(op).getSemantics();
   if (failed(verifyMemorySemantics(op, memorySemantics))) {
     return failure();
   }

--- a/mlir/lib/Dialect/SPIRV/IR/ControlFlowOps.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/ControlFlowOps.cpp
@@ -204,11 +204,11 @@ FunctionCallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 }
 
 CallInterfaceCallable FunctionCallOp::getCallableForCallee() {
-  return (*this)->getAttrOfType<SymbolRefAttr>(getCalleeAttrName());
+  return getCalleeAttr();
 }
 
 void FunctionCallOp::setCalleeFromCallable(CallInterfaceCallable callee) {
-  (*this)->setAttr(getCalleeAttrName(), cast<SymbolRefAttr>(callee));
+  setCalleeAttr(cast<FlatSymbolRefAttr>(cast<SymbolRefAttr>(callee)));
 }
 
 Operation::operand_range FunctionCallOp::getArgOperands() {

--- a/mlir/lib/Dialect/SPIRV/IR/DotProductOps.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/DotProductOps.cpp
@@ -72,11 +72,9 @@ static LogicalResult verifyIntegerDotProduct(Operation *op) {
   // ODS enforces that vector 1 and vector 2, and result and the accumulator
   // have the same types.
   Type factorTy = op->getOperand(0).getType();
-  StringAttr packedVectorFormatAttrName =
-      IntegerDotProductOpTy::getFormatAttrName(op->getName());
+  auto dotOp = cast<IntegerDotProductOpTy>(op);
   if (auto intTy = dyn_cast<IntegerType>(factorTy)) {
-    auto packedVectorFormat = dyn_cast_or_null<spirv::PackedVectorFormatAttr>(
-        op->getAttr(packedVectorFormatAttrName));
+    spirv::PackedVectorFormatAttr packedVectorFormat = dotOp.getFormatAttr();
     if (!packedVectorFormat)
       return op->emitOpError("requires Packed Vector Format attribute for "
                              "integer vector operands");
@@ -90,7 +88,7 @@ static LogicalResult verifyIntegerDotProduct(Operation *op) {
                         "integer vector operands to be 32-bits wide",
                         packedVectorFormat.getValue()));
   } else {
-    if (op->hasAttr(packedVectorFormatAttrName))
+    if (dotOp.getFormatAttr())
       return op->emitOpError(llvm::formatv(
           "with invalid format attribute for vector operands of type '{0}'",
           factorTy));
@@ -132,11 +130,9 @@ getIntegerDotProductCapabilities(Operation *op) {
   SmallVector<ArrayRef<spirv::Capability>, 1> capabilities = {dotProductCap};
 
   Type factorTy = op->getOperand(0).getType();
-  StringAttr packedVectorFormatAttrName =
-      IntegerDotProductOpTy::getFormatAttrName(op->getName());
+  auto dotOp = cast<IntegerDotProductOpTy>(op);
   if (auto intTy = dyn_cast<IntegerType>(factorTy)) {
-    auto formatAttr = cast<spirv::PackedVectorFormatAttr>(
-        op->getAttr(packedVectorFormatAttrName));
+    spirv::PackedVectorFormatAttr formatAttr = dotOp.getFormatAttr();
     if (formatAttr.getValue() ==
         spirv::PackedVectorFormat::PackedVectorFormat4x8Bit)
       capabilities.push_back(dotProductInput4x8BitPackedCap);

--- a/mlir/lib/Dialect/SPIRV/IR/GroupOps.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/GroupOps.cpp
@@ -22,11 +22,7 @@ namespace mlir::spirv {
 
 template <typename OpTy>
 static LogicalResult verifyGroupNonUniformArithmeticOp(Operation *groupOp) {
-  GroupOperation operation =
-      groupOp
-          ->getAttrOfType<GroupOperationAttr>(
-              OpTy::getGroupOperationAttrName(groupOp->getName()))
-          .getValue();
+  GroupOperation operation = cast<OpTy>(groupOp).getGroupOperation();
   if (operation == GroupOperation::ClusteredReduce &&
       groupOp->getNumOperands() == 1)
     return groupOp->emitOpError("cluster size operand must be provided for "

--- a/mlir/lib/Dialect/SPIRV/IR/MemoryOps.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/MemoryOps.cpp
@@ -177,12 +177,11 @@ static LogicalResult verifyMemoryAccessAttribute(MemoryOpTy memoryOp) {
   // ODS checks for attributes values. Just need to verify that if the
   // memory-access attribute is Aligned, then the alignment attribute must be
   // present.
-  auto *op = memoryOp.getOperation();
-  auto memAccessAttr = op->getAttr(memoryOp.getMemoryAccessAttrName());
+  spirv::MemoryAccessAttr memAccessAttr = memoryOp.getMemoryAccessAttr();
   if (!memAccessAttr) {
     // Alignment attribute shouldn't be present if memory access attribute is
     // not present.
-    if (op->getAttr(memoryOp.getAlignmentAttrName())) {
+    if (memoryOp.getAlignmentAttr()) {
       return memoryOp.emitOpError(
           "invalid alignment specification without aligned memory access "
           "specification");
@@ -190,7 +189,7 @@ static LogicalResult verifyMemoryAccessAttribute(MemoryOpTy memoryOp) {
     return success();
   }
 
-  auto memAccess = cast<spirv::MemoryAccessAttr>(memAccessAttr);
+  spirv::MemoryAccessAttr memAccess = memAccessAttr;
 
   if (!memAccess) {
     return memoryOp.emitOpError("invalid memory access specifier: ")
@@ -199,11 +198,11 @@ static LogicalResult verifyMemoryAccessAttribute(MemoryOpTy memoryOp) {
 
   if (spirv::bitEnumContainsAll(memAccess.getValue(),
                                 spirv::MemoryAccess::Aligned)) {
-    if (!op->getAttr(memoryOp.getAlignmentAttrName())) {
+    if (!memoryOp.getAlignmentAttr()) {
       return memoryOp.emitOpError("missing alignment value");
     }
   } else {
-    if (op->getAttr(memoryOp.getAlignmentAttrName())) {
+    if (memoryOp.getAlignmentAttr()) {
       return memoryOp.emitOpError(
           "invalid alignment specification with non-aligned memory access "
           "specification");
@@ -221,12 +220,11 @@ static LogicalResult verifySourceMemoryAccessAttribute(MemoryOpTy memoryOp) {
   // ODS checks for attributes values. Just need to verify that if the
   // memory-access attribute is Aligned, then the alignment attribute must be
   // present.
-  auto *op = memoryOp.getOperation();
-  auto memAccessAttr = op->getAttr(memoryOp.getSourceMemoryAccessAttrName());
+  spirv::MemoryAccessAttr memAccessAttr = memoryOp.getSourceMemoryAccessAttr();
   if (!memAccessAttr) {
     // Alignment attribute shouldn't be present if memory access attribute is
     // not present.
-    if (op->getAttr(memoryOp.getSourceAlignmentAttrName())) {
+    if (memoryOp.getSourceAlignmentAttr()) {
       return memoryOp.emitOpError(
           "invalid alignment specification without aligned memory access "
           "specification");
@@ -234,7 +232,7 @@ static LogicalResult verifySourceMemoryAccessAttribute(MemoryOpTy memoryOp) {
     return success();
   }
 
-  auto memAccess = cast<spirv::MemoryAccessAttr>(memAccessAttr);
+  spirv::MemoryAccessAttr memAccess = memAccessAttr;
 
   if (!memAccess) {
     return memoryOp.emitOpError("invalid memory access specifier: ")
@@ -243,11 +241,11 @@ static LogicalResult verifySourceMemoryAccessAttribute(MemoryOpTy memoryOp) {
 
   if (spirv::bitEnumContainsAll(memAccess.getValue(),
                                 spirv::MemoryAccess::Aligned)) {
-    if (!op->getAttr(memoryOp.getSourceAlignmentAttrName())) {
+    if (!memoryOp.getSourceAlignmentAttr()) {
       return memoryOp.emitOpError("missing alignment value");
     }
   } else {
-    if (op->getAttr(memoryOp.getSourceAlignmentAttrName())) {
+    if (memoryOp.getSourceAlignmentAttr()) {
       return memoryOp.emitOpError(
           "invalid alignment specification with non-aligned memory access "
           "specification");
@@ -406,7 +404,8 @@ void LoadOp::print(OpAsmPrinter &printer) {
 
   printMemoryAccessAttribute(*this, printer, elidedAttrs);
 
-  printer.printOptionalAttrDict((*this)->getAttrs(), elidedAttrs);
+  printer.printOptionalAttrDict(
+      (*this)->getDiscardableAttrDictionary().getValue(), elidedAttrs);
   printer << " : " << getType();
 }
 
@@ -454,7 +453,8 @@ void StoreOp::print(OpAsmPrinter &printer) {
   printMemoryAccessAttribute(*this, printer, elidedAttrs);
 
   printer << " : " << getValue().getType();
-  printer.printOptionalAttrDict((*this)->getAttrs(), elidedAttrs);
+  printer.printOptionalAttrDict(
+      (*this)->getDiscardableAttrDictionary().getValue(), elidedAttrs);
 }
 
 LogicalResult StoreOp::verify() {
@@ -486,7 +486,8 @@ void CopyMemoryOp::print(OpAsmPrinter &printer) {
                                    getSourceMemoryAccess(),
                                    getSourceAlignment());
 
-  printer.printOptionalAttrDict((*this)->getAttrs(), elidedAttrs);
+  printer.printOptionalAttrDict(
+      (*this)->getDiscardableAttrDictionary().getValue(), elidedAttrs);
 
   Type pointeeType =
       cast<spirv::PointerType>(getTarget().getType()).getPointeeType();
@@ -672,7 +673,7 @@ LogicalResult VariableOp::verify() {
   }
 
   auto getDecorationAttr = [op = getOperation()](spirv::Decoration decoration) {
-    return op->getAttr(spirv::getDecorationString(decoration));
+    return op->getDiscardableAttr(spirv::getDecorationString(decoration));
   };
 
   // TODO: generate these strings using ODS.

--- a/mlir/lib/Dialect/SPIRV/IR/SPIRVCanonicalization.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/SPIRVCanonicalization.cpp
@@ -1284,14 +1284,15 @@ struct ConvertSelectionOpToSelect final : OpRewritePattern<spirv::SelectionOp> {
     Value trueValue = getSrcValue(trueBlock);
     Value falseValue = getSrcValue(falseBlock);
     Value ptrValue = getDstPtr(trueBlock);
-    auto storeOpAttributes =
-        cast<spirv::StoreOp>(trueBlock->front())->getAttrs();
+    auto storeOp = cast<spirv::StoreOp>(trueBlock->front());
 
     auto selectOp = spirv::SelectOp::create(
         rewriter, selectionOp.getLoc(), trueValue.getType(),
         brConditionalOp.getCondition(), trueValue, falseValue);
-    spirv::StoreOp::create(rewriter, selectOp.getLoc(), ptrValue,
-                           selectOp.getResult(), storeOpAttributes);
+    auto newStore = spirv::StoreOp::create(
+        rewriter, selectOp.getLoc(), ptrValue, selectOp.getResult(),
+        storeOp.getMemoryAccessAttr(), storeOp.getAlignmentAttr());
+    newStore->setDiscardableAttrs(storeOp->getDiscardableAttrDictionary());
 
     // `spirv.mlir.selection` is not needed anymore.
     rewriter.eraseOp(op);

--- a/mlir/lib/Dialect/SPIRV/IR/SPIRVOps.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/SPIRVOps.cpp
@@ -109,7 +109,7 @@ LogicalResult spirv::verifyPhysicalStorageBufferDecorations(Operation *op,
     return success();
 
   auto getDecorationAttr = [op](spirv::Decoration decoration) {
-    return op->getAttr(spirv::getDecorationString(decoration));
+    return op->getDiscardableAttr(spirv::getDecorationString(decoration));
   };
 
   bool hasAliasedPtr =
@@ -132,13 +132,17 @@ LogicalResult spirv::verifyPhysicalStorageBufferDecorations(Operation *op,
 
 void spirv::printVariableDecorations(Operation *op, OpAsmPrinter &printer,
                                      SmallVectorImpl<StringRef> &elidedAttrs) {
+  NamedAttrList attrs(op->getDiscardableAttrDictionary().getValue());
+  op->getName().populateInherentAttrs(op, attrs);
+
   // Print optional descriptor binding
   auto descriptorSetName = llvm::convertToSnakeFromCamelCase(
       stringifyDecoration(spirv::Decoration::DescriptorSet));
   auto bindingName = llvm::convertToSnakeFromCamelCase(
       stringifyDecoration(spirv::Decoration::Binding));
-  auto descriptorSet = op->getAttrOfType<IntegerAttr>(descriptorSetName);
-  auto binding = op->getAttrOfType<IntegerAttr>(bindingName);
+  auto descriptorSet =
+      dyn_cast_or_null<IntegerAttr>(attrs.get(descriptorSetName));
+  auto binding = dyn_cast_or_null<IntegerAttr>(attrs.get(bindingName));
   if (descriptorSet && binding) {
     elidedAttrs.push_back(descriptorSetName);
     elidedAttrs.push_back(bindingName);
@@ -149,12 +153,12 @@ void spirv::printVariableDecorations(Operation *op, OpAsmPrinter &printer,
   // Print BuiltIn attribute if present
   auto builtInName = llvm::convertToSnakeFromCamelCase(
       stringifyDecoration(spirv::Decoration::BuiltIn));
-  if (auto builtin = op->getAttrOfType<StringAttr>(builtInName)) {
+  if (auto builtin = dyn_cast_or_null<StringAttr>(attrs.get(builtInName))) {
     printer << " " << builtInName << "(\"" << builtin.getValue() << "\")";
     elidedAttrs.push_back(builtInName);
   }
 
-  printer.printOptionalAttrDict(op->getAttrs(), elidedAttrs);
+  printer.printOptionalAttrDict(attrs, elidedAttrs);
 }
 
 static ParseResult parseOneResultSameOperandTypeOp(OpAsmParser &parser,
@@ -200,7 +204,7 @@ static void printOneResultOp(Operation *op, OpAsmPrinter &p) {
 
   p << ' ';
   p.printOperands(op->getOperands());
-  p.printOptionalAttrDict(op->getAttrs());
+  p.printOptionalAttrDict(op->getDiscardableAttrDictionary().getValue());
   // Now we can output only one type for all operands and the result.
   p << " : " << resultType;
 }
@@ -330,7 +334,7 @@ static ParseResult parseArithmeticExtendedBinaryOp(OpAsmParser &parser,
 static void printArithmeticExtendedBinaryOp(Operation *op,
                                             OpAsmPrinter &printer) {
   printer << ' ';
-  printer.printOptionalAttrDict(op->getAttrs());
+  printer.printOptionalAttrDict(op->getDiscardableAttrDictionary().getValue());
   printer.printOperands(op->getOperands());
   printer << " : " << op->getResultTypes().front();
 }
@@ -1498,8 +1502,7 @@ LogicalResult spirv::GlobalVariableOp::verify() {
     }
   }
 
-  if (auto init = (*this)->getAttrOfType<FlatSymbolRefAttr>(
-          this->getInitializerAttrName())) {
+  if (FlatSymbolRefAttr init = getInitializerAttr()) {
     Operation *initOp = SymbolTable::lookupNearestSymbolFrom(
         (*this)->getParentOp(), init.getAttr());
     // TODO: Currently only variable initialization with specialization
@@ -1753,7 +1756,8 @@ void spirv::ModuleOp::print(OpAsmPrinter &printer) {
     elidedAttrs.push_back(spirv::ModuleOp::getVCETripleAttrName());
   }
 
-  printer.printOptionalAttrDictWithKeyword((*this)->getAttrs(), elidedAttrs);
+  printer.printOptionalAttrDictWithKeyword(
+      (*this)->getDiscardableAttrDictionary().getValue(), elidedAttrs);
   printer << ' ';
   printer.printRegion(getRegion());
 }
@@ -1889,13 +1893,15 @@ ParseResult spirv::SpecConstantOp::parse(OpAsmParser &parser,
 void spirv::SpecConstantOp::print(OpAsmPrinter &printer) {
   printer << ' ';
   printer.printSymbolName(getSymName());
-  if (auto specID = (*this)->getAttrOfType<IntegerAttr>(kSpecIdAttrName))
+  if (auto specID =
+          (*this)->getDiscardableAttrOfType<IntegerAttr>(kSpecIdAttrName))
     printer << ' ' << kSpecIdAttrName << '(' << specID.getInt() << ')';
   printer << " = " << getDefaultValue();
 }
 
 LogicalResult spirv::SpecConstantOp::verify() {
-  if (auto specID = (*this)->getAttrOfType<IntegerAttr>(kSpecIdAttrName))
+  if (auto specID =
+          (*this)->getDiscardableAttrOfType<IntegerAttr>(kSpecIdAttrName))
     if (specID.getValue().isNegative())
       return emitOpError("SpecId cannot be negative");
 

--- a/mlir/lib/Dialect/SPIRV/IR/TargetAndABI.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/TargetAndABI.cpp
@@ -134,7 +134,7 @@ spirv::EntryPointABIAttr spirv::lookupEntryPointABI(Operation *op) {
   if (!op)
     return {};
 
-  if (auto attr = op->getAttrOfType<spirv::EntryPointABIAttr>(
+  if (auto attr = op->getDiscardableAttrOfType<spirv::EntryPointABIAttr>(
           spirv::getEntryPointABIAttrName()))
     return attr;
 
@@ -189,7 +189,7 @@ spirv::TargetEnvAttr spirv::lookupTargetEnv(Operation *op) {
     if (!op)
       break;
 
-    if (auto attr = op->getAttrOfType<spirv::TargetEnvAttr>(
+    if (auto attr = op->getDiscardableAttrOfType<spirv::TargetEnvAttr>(
             spirv::getTargetEnvAttrName()))
       return attr;
 

--- a/mlir/lib/Dialect/SPIRV/Linking/ModuleCombiner/ModuleCombiner.cpp
+++ b/mlir/lib/Dialect/SPIRV/Linking/ModuleCombiner/ModuleCombiner.cpp
@@ -70,10 +70,11 @@ static LogicalResult updateSymbolAndAllUses(SymbolOpInterface op,
 /// variable and a spec constant as duplicates because their descriptor set +
 /// binding and spec_id, respectively, happen to hash to the same value.
 static llvm::hash_code computeHash(SymbolOpInterface symbolOp) {
-  auto range =
-      llvm::make_filter_range(symbolOp->getAttrs(), [](NamedAttribute attr) {
-        return attr.getName() != SymbolTable::getSymbolAttrName();
-      });
+  NamedAttrList attrs(symbolOp->getDiscardableAttrDictionary());
+  symbolOp->getName().populateInherentAttrs(symbolOp, attrs);
+  auto range = llvm::make_filter_range(attrs, [](NamedAttribute attr) {
+    return attr.getName() != SymbolTable::getSymbolAttrName();
+  });
 
   return llvm::hash_combine(symbolOp->getName(),
                             llvm::hash_combine_range(range));

--- a/mlir/lib/Dialect/SPIRV/Transforms/DecorateCompositeTypeLayoutPass.cpp
+++ b/mlir/lib/Dialect/SPIRV/Transforms/DecorateCompositeTypeLayoutPass.cpp
@@ -40,7 +40,8 @@ public:
 
   LogicalResult matchAndRewrite(spirv::GlobalVariableOp op,
                                 PatternRewriter &rewriter) const override {
-    SmallVector<NamedAttribute, 4> globalVarAttrs;
+    NamedAttrList globalVarAttrs(op->getDiscardableAttrDictionary());
+    op->getName().populateInherentAttrs(op, globalVarAttrs);
 
     auto ptrType = cast<spirv::PointerType>(op.getType());
     auto pointeeType = cast<spirv::StructType>(ptrType.getPointeeType());
@@ -53,12 +54,8 @@ public:
     auto decoratedType =
         spirv::PointerType::get(structType, ptrType.getStorageClass());
 
-    // Save all named attributes except "type" attribute.
-    for (const auto &attr : op->getAttrs()) {
-      if (attr.getName() == "type")
-        continue;
-      globalVarAttrs.push_back(attr);
-    }
+    // The new type is passed through the operation-specific builder below.
+    globalVarAttrs.erase("type");
 
     rewriter.replaceOpWithNewOp<spirv::GlobalVariableOp>(
         op, TypeAttr::get(decoratedType), globalVarAttrs);

--- a/mlir/lib/Dialect/SPIRV/Transforms/LowerABIAttributesPass.cpp
+++ b/mlir/lib/Dialect/SPIRV/Transforms/LowerABIAttributesPass.cpp
@@ -158,7 +158,8 @@ static LogicalResult lowerEntryPointABIAttr(spirv::FuncOp funcOp,
                                             OpBuilder &builder) {
   auto entryPointAttrName = spirv::getEntryPointABIAttrName();
   auto entryPointAttr =
-      funcOp->getAttrOfType<spirv::EntryPointABIAttr>(entryPointAttrName);
+      funcOp->getDiscardableAttrOfType<spirv::EntryPointABIAttr>(
+          entryPointAttrName);
   if (!entryPointAttr) {
     return failure();
   }
@@ -228,9 +229,9 @@ static LogicalResult lowerEntryPointABIAttr(spirv::FuncOp funcOp,
   }
   if (entryPointAttr.getWorkgroupSize() || entryPointAttr.getSubgroupSize() ||
       entryPointAttr.getTargetWidth())
-    funcOp->setAttr(entryPointAttrName, entryPointAttr);
+    funcOp->setDiscardableAttr(entryPointAttrName, entryPointAttr);
   else
-    funcOp->removeAttr(entryPointAttrName);
+    funcOp->removeDiscardableAttr(entryPointAttrName);
   return success();
 }
 
@@ -277,7 +278,7 @@ class LowerABIAttributesPass final
 LogicalResult ProcessInterfaceVarABI::matchAndRewrite(
     spirv::FuncOp funcOp, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
-  if (!funcOp->getAttrOfType<spirv::EntryPointABIAttr>(
+  if (!funcOp->getDiscardableAttrOfType<spirv::EntryPointABIAttr>(
           spirv::getEntryPointABIAttrName())) {
     // TODO: Non-entry point functions are not handled.
     return failure();
@@ -458,7 +459,8 @@ void LowerABIAttributesPass::runOnOperation() {
   SmallVector<spirv::FuncOp, 1> entryPointFns;
   auto entryPointAttrName = spirv::getEntryPointABIAttrName();
   module.walk([&](spirv::FuncOp funcOp) {
-    if (funcOp->getAttrOfType<spirv::EntryPointABIAttr>(entryPointAttrName)) {
+    if (funcOp->getDiscardableAttrOfType<spirv::EntryPointABIAttr>(
+            entryPointAttrName)) {
       entryPointFns.push_back(funcOp);
     }
   });

--- a/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
+++ b/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
@@ -868,9 +868,7 @@ static spirv::GlobalVariableOp getBuiltinVariable(Block &body,
   // Look through all global variables in the given `body` block and check if
   // there is a spirv.GlobalVariable that has the same `builtin` attribute.
   for (auto varOp : body.getOps<spirv::GlobalVariableOp>()) {
-    if (auto builtinAttr = varOp->getAttrOfType<StringAttr>(
-            spirv::SPIRVDialect::getAttributeName(
-                spirv::Decoration::BuiltIn))) {
+    if (StringAttr builtinAttr = varOp.getBuiltInAttr()) {
       auto varBuiltIn = spirv::symbolizeBuiltIn(builtinAttr.getValue());
       if (varBuiltIn == builtin) {
         return varOp;
@@ -1023,11 +1021,19 @@ struct FuncOpConversion final : OpConversionPattern<func::FuncOp> {
                                  resultType ? TypeRange(resultType)
                                             : TypeRange()));
 
+    newFuncOp.setArgAttrsAttr(funcOp.getArgAttrsAttr());
+    newFuncOp.setResAttrsAttr(funcOp.getResAttrsAttr());
+    cast<SymbolOpInterface>(newFuncOp.getOperation())
+        .setVisibility(
+            cast<SymbolOpInterface>(funcOp.getOperation()).getVisibility());
+
     // Copy over all attributes other than the function name and type.
-    for (NamedAttribute namedAttr : funcOp->getAttrs()) {
+    for (NamedAttribute namedAttr :
+         funcOp->getDiscardableAttrDictionary().getValue()) {
       if (namedAttr.getName() != funcOp.getFunctionTypeAttrName() &&
           namedAttr.getName() != SymbolTable::getSymbolAttrName())
-        newFuncOp->setAttr(namedAttr.getName(), namedAttr.getValue());
+        newFuncOp->setDiscardableAttr(namedAttr.getName(),
+                                      namedAttr.getValue());
     }
 
     rewriter.inlineRegionBefore(funcOp.getBody(), newFuncOp.getBody(),
@@ -1289,11 +1295,13 @@ static void addNoWrapDecorations(Operation *op,
                                  spirv::LinearizedIndexNoWrapFlags flags,
                                  OpBuilder &builder) {
   if (flags.noSignedWrap)
-    op->setAttr(spirv::getDecorationString(spirv::Decoration::NoSignedWrap),
-                builder.getUnitAttr());
+    op->setDiscardableAttr(
+        spirv::getDecorationString(spirv::Decoration::NoSignedWrap),
+        builder.getUnitAttr());
   if (flags.noUnsignedWrap)
-    op->setAttr(spirv::getDecorationString(spirv::Decoration::NoUnsignedWrap),
-                builder.getUnitAttr());
+    op->setDiscardableAttr(
+        spirv::getDecorationString(spirv::Decoration::NoUnsignedWrap),
+        builder.getUnitAttr());
 }
 
 static std::optional<uint64_t> getMaxLinearizedIndex(ArrayRef<int64_t> shape,

--- a/mlir/lib/Dialect/SPIRV/Transforms/UnifyAliasedResourcePass.cpp
+++ b/mlir/lib/Dialect/SPIRV/Transforms/UnifyAliasedResourcePass.cpp
@@ -47,7 +47,7 @@ using AliasedResourceMap =
 static AliasedResourceMap collectAliasedResources(spirv::ModuleOp moduleOp) {
   AliasedResourceMap aliasedResources;
   moduleOp->walk([&aliasedResources](spirv::GlobalVariableOp varOp) {
-    if (varOp->getAttrOfType<UnitAttr>("aliased")) {
+    if (varOp->getDiscardableAttrOfType<UnitAttr>("aliased")) {
       std::optional<uint32_t> set = varOp.getDescriptorSet();
       std::optional<uint32_t> binding = varOp.getBinding();
       if (set && binding)
@@ -559,8 +559,10 @@ struct ConvertStore : public ConvertAliasResource<spirv::StoreOp> {
     Value value = adaptor.getValue();
     if (srcElemType != dstElemType)
       value = spirv::BitcastOp::create(rewriter, loc, dstElemType, value);
-    rewriter.replaceOpWithNewOp<spirv::StoreOp>(storeOp, adaptor.getPtr(),
-                                                value, storeOp->getAttrs());
+    auto newStore = rewriter.replaceOpWithNewOp<spirv::StoreOp>(
+        storeOp, adaptor.getPtr(), value, storeOp.getMemoryAccessAttr(),
+        storeOp.getAlignmentAttr());
+    newStore->setDiscardableAttrs(storeOp->getDiscardableAttrDictionary());
     return success();
   }
 };
@@ -626,7 +628,7 @@ void UnifyAliasedResourcePass::runOnOperation() {
   for (const auto &dr : resourceMap) {
     const auto &resources = dr.second;
     if (resources.size() == 1)
-      resources.front()->removeAttr("aliased");
+      resources.front()->removeDiscardableAttr("aliased");
   }
 }
 } // namespace

--- a/mlir/lib/Dialect/SPIRV/Transforms/UpdateVCEPass.cpp
+++ b/mlir/lib/Dialect/SPIRV/Transforms/UpdateVCEPass.cpp
@@ -259,5 +259,5 @@ void UpdateVCEPass::runOnOperation() {
   auto triple = spirv::VerCapExtAttr::get(
       deducedVersion, deducedCapabilities.getArrayRef(),
       deducedExtensions.getArrayRef(), &getContext());
-  module->setAttr(spirv::ModuleOp::getVCETripleAttrName(), triple);
+  module.setVceTripleAttr(triple);
 }

--- a/mlir/lib/Target/SPIRV/Deserialization/Deserializer.cpp
+++ b/mlir/lib/Target/SPIRV/Deserialization/Deserializer.cpp
@@ -44,6 +44,15 @@ static inline bool isFnEntryBlock(Block *block) {
          isa_and_nonnull<spirv::FuncOp>(block->getParentOp());
 }
 
+static void setInherentOrDiscardableAttr(Operation *op, StringAttr name,
+                                         Attribute value) {
+  if (op->getName().getInherentAttr(op, name).has_value()) {
+    op->getName().setInherentAttr(op, name, value);
+    return;
+  }
+  op->setDiscardableAttr(name, value);
+}
+
 //===----------------------------------------------------------------------===//
 // Deserializer Method Definitions
 //===----------------------------------------------------------------------===//
@@ -208,10 +217,8 @@ spirv::Deserializer::processExtInstImport(ArrayRef<uint32_t> words) {
 }
 
 void spirv::Deserializer::attachVCETriple() {
-  (*module)->setAttr(
-      spirv::ModuleOp::getVCETripleAttrName(),
-      spirv::VerCapExtAttr::get(version, capabilities.getArrayRef(),
-                                extensions.getArrayRef(), context));
+  module->setVceTripleAttr(spirv::VerCapExtAttr::get(
+      version, capabilities.getArrayRef(), extensions.getArrayRef(), context));
 }
 
 LogicalResult
@@ -219,14 +226,10 @@ spirv::Deserializer::processMemoryModel(ArrayRef<uint32_t> operands) {
   if (operands.size() != 2)
     return emitError(unknownLoc, "OpMemoryModel must have two operands");
 
-  (*module)->setAttr(
-      module->getAddressingModelAttrName(),
-      opBuilder.getAttr<spirv::AddressingModelAttr>(
-          static_cast<spirv::AddressingModel>(operands.front())));
+  module->setAddressingModel(
+      static_cast<spirv::AddressingModel>(operands.front()));
 
-  (*module)->setAttr(module->getMemoryModelAttrName(),
-                     opBuilder.getAttr<spirv::MemoryModelAttr>(
-                         static_cast<spirv::MemoryModel>(operands.back())));
+  module->setMemoryModel(static_cast<spirv::MemoryModel>(operands.back()));
 
   return success();
 }
@@ -438,7 +441,7 @@ LogicalResult spirv::Deserializer::resolveDeferredIdDecorations() {
              << decorationName << " references unknown target <id> "
              << entry.targetID;
 
-    targetOp->setAttr(symbol, symRef);
+    setInherentOrDiscardableAttr(targetOp, symbol, symRef);
   }
   return success();
 }
@@ -580,7 +583,7 @@ spirv::Deserializer::processFunction(ArrayRef<uint32_t> operands) {
   // Processing other function attributes.
   if (decorations.count(fnID)) {
     for (auto attr : decorations[fnID].getAttrs()) {
-      funcOp->setAttr(attr.getName(), attr.getValue());
+      setInherentOrDiscardableAttr(funcOp, attr.getName(), attr.getValue());
     }
   }
   curFunction = funcMap[fnID] = funcOp;
@@ -986,7 +989,7 @@ spirv::Deserializer::createSpecConstant(Location loc, uint32_t resultID,
                                           defaultValue);
   if (decorations.count(resultID)) {
     for (auto attr : decorations[resultID].getAttrs())
-      op->setAttr(attr.getName(), attr.getValue());
+      setInherentOrDiscardableAttr(op, attr.getName(), attr.getValue());
   }
   specConstMap[resultID] = op;
   return op;
@@ -1073,7 +1076,7 @@ spirv::Deserializer::processGlobalVariable(ArrayRef<uint32_t> operands) {
   // Decorations.
   if (decorations.count(variableID)) {
     for (auto attr : decorations[variableID].getAttrs())
-      varOp->setAttr(attr.getName(), attr.getValue());
+      setInherentOrDiscardableAttr(varOp, attr.getName(), attr.getValue());
   }
   globalVariableMap[variableID] = varOp;
   return success();

--- a/mlir/lib/Target/SPIRV/Serialization/SerializeOps.cpp
+++ b/mlir/lib/Target/SPIRV/Serialization/SerializeOps.cpp
@@ -109,7 +109,7 @@ LogicalResult Serializer::processSpecConstantOp(spirv::SpecConstantOp op) {
   if (auto resultID = prepareConstantScalar(op.getLoc(), op.getDefaultValue(),
                                             /*isSpec=*/true)) {
     // Emit the OpDecorate instruction for SpecId.
-    if (auto specID = op->getAttrOfType<IntegerAttr>("spec_id")) {
+    if (auto specID = op->getDiscardableAttrOfType<IntegerAttr>("spec_id")) {
       auto val = static_cast<uint32_t>(specID.getInt());
       if (failed(emitDecoration(resultID, spirv::Decoration::SpecId, {val})))
         return failure();
@@ -393,7 +393,9 @@ LogicalResult Serializer::processFuncOp(spirv::FuncOp op) {
   // Only attributes we should be considering for decoration are the
   // ::mlir::spirv::Decoration attributes.
 
-  for (auto attr : op->getAttrs()) {
+  NamedAttrList attrs(op->getDiscardableAttrDictionary().getValue());
+  op->getName().populateInherentAttrs(op, attrs);
+  for (auto attr : attrs) {
     // Only generate OpDecorate op for spirv::Decoration attributes.
     auto isValidDecoration = mlir::spirv::symbolizeEnum<spirv::Decoration>(
         llvm::convertToCamelFromSnakeCase(attr.getName().strref(),
@@ -669,11 +671,7 @@ LogicalResult Serializer::processVariableOp(spirv::VariableOp op) {
   resultID = getNextID();
   valueIDMap[op.getResult()] = resultID;
   operands.push_back(resultID);
-  auto attr = op->getAttr(spirv::attributeName<spirv::StorageClass>());
-  if (attr) {
-    operands.push_back(
-        static_cast<uint32_t>(cast<spirv::StorageClassAttr>(attr).getValue()));
-  }
+  operands.push_back(static_cast<uint32_t>(op.getStorageClass()));
   elidedAttrs.push_back(spirv::attributeName<spirv::StorageClass>());
   for (auto arg : op.getODSOperands(0)) {
     auto argID = getValueID(arg);
@@ -685,7 +683,7 @@ LogicalResult Serializer::processVariableOp(spirv::VariableOp op) {
   if (failed(emitDebugLine(functionHeader, op.getLoc())))
     return failure();
   encodeInstructionInto(functionHeader, spirv::Opcode::OpVariable, operands);
-  for (auto attr : op->getAttrs()) {
+  for (auto attr : op->getDiscardableAttrDictionary().getValue()) {
     if (llvm::any_of(elidedAttrs, [&](StringRef elided) {
           return attr.getName() == elided;
         })) {
@@ -728,7 +726,7 @@ Serializer::processGlobalVariableOp(spirv::GlobalVariableOp varOp) {
   StringRef initAttrName = varOp.getInitializerAttrName().getValue();
   if (std::optional<StringRef> initSymbolName = varOp.getInitializer()) {
     uint32_t initializerID = 0;
-    auto initRef = varOp->getAttrOfType<FlatSymbolRefAttr>(initAttrName);
+    FlatSymbolRefAttr initRef = varOp.getInitializerAttr();
     Operation *initOp = SymbolTable::lookupNearestSymbolFrom(
         varOp->getParentOp(), initRef.getAttr());
 
@@ -752,7 +750,9 @@ Serializer::processGlobalVariableOp(spirv::GlobalVariableOp varOp) {
   elidedAttrs.push_back(initAttrName);
 
   // Encode decorations.
-  for (auto attr : varOp->getAttrs()) {
+  NamedAttrList attrs(varOp->getDiscardableAttrDictionary().getValue());
+  varOp->getName().populateInherentAttrs(varOp, attrs);
+  for (auto attr : attrs) {
     if (llvm::any_of(elidedAttrs, [&](StringRef elided) {
           return attr.getName() == elided;
         })) {
@@ -1111,34 +1111,26 @@ Serializer::processOp<spirv::CopyMemoryOp>(spirv::CopyMemoryOp op) {
   }
 
   StringAttr memoryAccess = op.getMemoryAccessAttrName();
-  if (auto attr = op->getAttr(memoryAccess)) {
-    operands.push_back(
-        static_cast<uint32_t>(cast<spirv::MemoryAccessAttr>(attr).getValue()));
-  }
+  if (std::optional<spirv::MemoryAccess> value = op.getMemoryAccess())
+    operands.push_back(static_cast<uint32_t>(*value));
 
   elidedAttrs.push_back(memoryAccess.strref());
 
   StringAttr alignment = op.getAlignmentAttrName();
-  if (auto attr = op->getAttr(alignment)) {
-    operands.push_back(static_cast<uint32_t>(
-        cast<IntegerAttr>(attr).getValue().getZExtValue()));
-  }
+  if (std::optional<uint32_t> value = op.getAlignment())
+    operands.push_back(*value);
 
   elidedAttrs.push_back(alignment.strref());
 
   StringAttr sourceMemoryAccess = op.getSourceMemoryAccessAttrName();
-  if (auto attr = op->getAttr(sourceMemoryAccess)) {
-    operands.push_back(
-        static_cast<uint32_t>(cast<spirv::MemoryAccessAttr>(attr).getValue()));
-  }
+  if (std::optional<spirv::MemoryAccess> value = op.getSourceMemoryAccess())
+    operands.push_back(static_cast<uint32_t>(*value));
 
   elidedAttrs.push_back(sourceMemoryAccess.strref());
 
   StringAttr sourceAlignment = op.getSourceAlignmentAttrName();
-  if (auto attr = op->getAttr(sourceAlignment)) {
-    operands.push_back(static_cast<uint32_t>(
-        cast<IntegerAttr>(attr).getValue().getZExtValue()));
-  }
+  if (std::optional<uint32_t> value = op.getSourceAlignment())
+    operands.push_back(*value);
 
   elidedAttrs.push_back(sourceAlignment.strref());
   if (failed(emitDebugLine(functionBody, op.getLoc())))

--- a/mlir/lib/Target/SPIRV/Serialization/Serializer.cpp
+++ b/mlir/lib/Target/SPIRV/Serialization/Serializer.cpp
@@ -290,15 +290,8 @@ LogicalResult Serializer::processExtension() {
 }
 
 void Serializer::processMemoryModel() {
-  StringAttr memoryModelName = module.getMemoryModelAttrName();
-  auto mm = static_cast<uint32_t>(
-      module->getAttrOfType<spirv::MemoryModelAttr>(memoryModelName)
-          .getValue());
-
-  StringAttr addressingModelName = module.getAddressingModelAttrName();
-  auto am = static_cast<uint32_t>(
-      module->getAttrOfType<spirv::AddressingModelAttr>(addressingModelName)
-          .getValue());
+  auto mm = static_cast<uint32_t>(module.getMemoryModel());
+  auto am = static_cast<uint32_t>(module.getAddressingModel());
 
   encodeInstructionInto(memoryModel, spirv::Opcode::OpMemoryModel, {am, mm});
 }
@@ -1738,7 +1731,7 @@ Serializer::processCompositeConstructOp(spirv::CompositeConstructOp op) {
   encodeInstructionWithContinuationInto(
       functionBody, spirv::Opcode::OpCompositeConstruct, operands);
 
-  for (auto attr : op->getAttrs()) {
+  for (auto attr : op->getDiscardableAttrDictionary().getValue()) {
     if (failed(processDecoration(loc, resultID, attr)))
       return failure();
   }
@@ -1781,7 +1774,7 @@ LogicalResult Serializer::processOpWithoutGrammarAttr(Operation *op,
   }
 
   if (op->getNumResults() != 0) {
-    for (auto attr : op->getAttrs()) {
+    for (auto attr : op->getDiscardableAttrDictionary().getValue()) {
       if (failed(processDecoration(loc, resultID, attr)))
         return failure();
     }

--- a/mlir/test/Dialect/Shard/simplify.mlir
+++ b/mlir/test/Dialect/Shard/simplify.mlir
@@ -213,6 +213,24 @@ func.func @all_reduce_arith_addf_no_endomorphism_wrong_reduction_kind(
   return %2 : tensor<5xf32>
 }
 
+// CHECK-LABEL: func.func @all_reduce_arith_addf_no_endomorphism_different_reduction_kind
+func.func @all_reduce_arith_addf_no_endomorphism_different_reduction_kind(
+    // CHECK-SAME: %[[ARG0:[A-Za-z0-9_]*]]: tensor<5xf32>
+    %arg0: tensor<5xf32>,
+    // CHECK-SAME: %[[ARG1:[A-Za-z0-9_]*]]: tensor<5xf32>
+    %arg1: tensor<5xf32>) -> tensor<5xf32> {
+  // CHECK: %[[ALL_REDUCE0:[A-Za-z0-9_]*]] = shard.all_reduce %[[ARG0]] on @grid0 grid_axes = [0]
+  %0 = shard.all_reduce %arg0 on @grid0 grid_axes = [0]
+    : tensor<5xf32> -> tensor<5xf32>
+  // CHECK: %[[ALL_REDUCE1:[A-Za-z0-9_]*]] = shard.all_reduce %[[ARG1]] on @grid0 grid_axes = [0] reduction = max
+  %1 = shard.all_reduce %arg1 on @grid0 grid_axes = [0] reduction = max
+    : tensor<5xf32> -> tensor<5xf32>
+  // CHECK: %[[ADD_RES:[A-Za-z0-9_]*]] = arith.addf %[[ALL_REDUCE0]], %[[ALL_REDUCE1]]
+  %2 = arith.addf %0, %1 : tensor<5xf32>
+  // CHECK: return %[[ADD_RES]]
+  return %2 : tensor<5xf32>
+}
+
 // CHECK-LABEL: func.func @all_reduce_arith_addf_no_endomorphism_different_operand_result_element_types
 func.func @all_reduce_arith_addf_no_endomorphism_different_operand_result_element_types(
     // CHECK-SAME: %[[ARG0:[A-Za-z0-9_]*]]: tensor<5xf32>

--- a/mlir/test/lib/Dialect/SPIRV/TestAvailability.cpp
+++ b/mlir/test/lib/Dialect/SPIRV/TestAvailability.cpp
@@ -208,8 +208,9 @@ struct ConvertToIntegerDotProd : RewritePattern {
 
   LogicalResult matchAndRewrite(Operation *op,
                                 PatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<SPIRVOp>(op, op->getResultTypes(),
-                                         op->getOperands(), op->getAttrs());
+    rewriter.replaceOpWithNewOp<SPIRVOp>(
+        op, op->getResultTypes(), op->getOperands(),
+        op->getDiscardableAttrDictionary().getValue());
     return success();
   }
 };

--- a/mlir/test/lib/Dialect/SPIRV/TestEntryPointAbi.cpp
+++ b/mlir/test/lib/Dialect/SPIRV/TestEntryPointAbi.cpp
@@ -69,13 +69,13 @@ void TestSpirvEntryPointABIPass::runOnOperation() {
     SmallVector<int32_t, 3> workgroupSizeVec(workgroupSize.begin(),
                                              workgroupSize.end());
     workgroupSizeVec.resize(3, 1);
-    gpuFunc->setAttr(attrName,
-                     spirv::getEntryPointABIAttr(
-                         context, workgroupSizeVec,
-                         (subgroupSize == 0) ? std::nullopt
-                                             : std::optional<int>(subgroupSize),
-                         (targetWidth == 0) ? std::nullopt
-                                            : std::optional<int>(targetWidth)));
+    gpuFunc->setDiscardableAttr(
+        attrName, spirv::getEntryPointABIAttr(
+                      context, workgroupSizeVec,
+                      (subgroupSize == 0) ? std::nullopt
+                                          : std::optional<int>(subgroupSize),
+                      (targetWidth == 0) ? std::nullopt
+                                         : std::optional<int>(targetWidth)));
   }
 }
 

--- a/mlir/tools/mlir-tblgen/SPIRVUtilsGen.cpp
+++ b/mlir/tools/mlir-tblgen/SPIRVUtilsGen.cpp
@@ -514,9 +514,9 @@ constexpr llvm::StringLiteral constantIdEnumAttrs[] = {
 static void emitAttributeSerialization(const Attribute &attr,
                                        ArrayRef<SMLoc> loc, StringRef tabs,
                                        StringRef opVar, StringRef operandList,
-                                       StringRef attrName, raw_ostream &os) {
+                                       StringRef getterName, raw_ostream &os) {
   os << tabs
-     << formatv("if (auto attr = {0}->getAttr(\"{1}\")) {{\n", opVar, attrName);
+     << formatv("if (auto attr = {0}.{1}Attr()) {{\n", opVar, getterName);
   if (llvm::is_contained(constantIdEnumAttrs, attr.getAttrDefName())) {
     EnumInfo baseEnum(attr.getDef().getValueAsDef("enum"));
     os << tabs
@@ -628,7 +628,7 @@ static void emitArgumentSerialization(const Operator &op, ArrayRef<SMLoc> loc,
     for (const NamedAttribute &attr : op.getAttributes()) {
       emitAttributeSerialization(
           (attr.attr.isOptional() ? attr.attr.getBaseAttr() : attr.attr), loc,
-          tabs, opVar, operands, attr.name, os);
+          tabs, opVar, operands, op.getGetterName(attr.name), os);
       os << tabs
          << formatv("{0}.push_back(\"{1}\");\n", elidedAttrs, attr.name);
     }
@@ -659,7 +659,7 @@ static void emitArgumentSerialization(const Operator &op, ArrayRef<SMLoc> loc,
       auto newtabs = tabs.str() + "  ";
       emitAttributeSerialization(
           (attr->attr.isOptional() ? attr->attr.getBaseAttr() : attr->attr),
-          loc, newtabs, opVar, operands, attr->name, os);
+          loc, newtabs, opVar, operands, op.getGetterName(attr->name), os);
       os << newtabs
          << formatv("{0}.push_back(\"{1}\");\n", elidedAttrs, attr->name);
     }
@@ -702,7 +702,10 @@ static void emitDecorationSerialization(const Operator &op, StringRef tabs,
                                         StringRef resultID, raw_ostream &os) {
   if (op.getNumResults() == 1) {
     // All non-argument attributes translated into OpDecorate instruction
-    os << tabs << formatv("for (auto attr : {0}->getAttrs()) {{\n", opVar);
+    os << tabs
+       << formatv("for (auto attr : "
+                  "{0}->getDiscardableAttrDictionary().getValue()) {{\n",
+                  opVar);
     os << tabs
        << formatv("  if (llvm::is_contained({0}, attr.getName())) {{",
                   elidedAttrs);

--- a/mlir/unittests/Dialect/SPIRV/SerializationTest.cpp
+++ b/mlir/unittests/Dialect/SPIRV/SerializationTest.cpp
@@ -531,7 +531,7 @@ TEST_F(SerializationTest, LongCompositeDoesNotDuplicateDeclaredCapability) {
   // Pre-declare LongCompositesINTEL / SPV_INTEL_long_composites in the VCE
   // triple. The serializer must not emit a second OpCapability/OpExtension
   // when a long composite triggers `addLongCompositesCapability()`.
-  module->getOperation()->setAttr(
+  module->getOperation()->setDiscardableAttr(
       spirv::ModuleOp::getVCETripleAttrName(),
       spirv::VerCapExtAttr::get(
           spirv::Version::V_1_0, {spirv::Capability::LongCompositesINTEL},


### PR DESCRIPTION
Use explicit discardable and inherent attribute access throughout the SPIR-V
ecosystem and Shard simplification. Add typed discardable-attribute query
helpers used by this and the follow-up migration branches.

Assisted-by: Codex