### PR TITLE
[orc-rt] Report the disconnection mode to Session clients

### DIFF
--- a/orc-rt/include/orc-rt/Session.h
+++ b/orc-rt/include/orc-rt/Session.h
@@ -72,6 +72,7 @@ private:
 
 public:
   using ErrorReporterFn = move_only_function<void(Error)>;
+  using OnDisconnectFn = move_only_function<void(Error)>;
   using OnDetachFn = move_only_function<void()>;
   using OnShutdownFn = move_only_function<void()>;
 
@@ -226,13 +227,34 @@ public:
     /// when the controller disconnects, whether initiated by a call to
     /// disconnect, by the controller, or by a communication failure.
     ///
+    /// Err describes the mode of disconnection, which clients may observe by
+    /// installing a handler via Session::setOnDisconnect:
+    ///
+    ///   - Success: the disconnection was orderly. Either it was requested
+    ///     locally via disconnect, or the controller announced that it was
+    ///     going away (e.g. by sending an explicit hangup message).
+    ///
+    ///   - Failure: the disconnection was abnormal, and Err describes what was
+    ///     observed: a communication failure, a protocol error, or the
+    ///     controller vanishing without announcing it (e.g. end-of-file on a
+    ///     transport whose protocol requires an explicit hangup). The cause of
+    ///     an abnormal disconnection is generally unknowable -- the controller
+    ///     may have crashed, been killed, or become unreachable -- so Err
+    ///     should describe what was observed rather than assert a cause.
+    ///
+    /// Pass the terminal error here rather than to reportError: if no
+    /// on-disconnect handler is installed the Session forwards Err to the error
+    /// reporter, so doing both would report it twice. Only one Err can be
+    /// reported, so if both a local failure and an error announced by the
+    /// controller occur, pick whichever better describes why the session ended.
+    ///
     /// It is the ControllerAccess implementation's responsibility to ensure
     /// exactly-once semantics for this method, even when disconnect is called
     /// concurrently with controller-initiated disconnection.
     ///
     /// No calls should be made to reportError, handleWrapperCall, or
     /// handleControllerCallResult after this method is called.
-    void notifyDisconnected() { S.handleDisconnect(); }
+    void notifyDisconnected(Error Err) { S.handleDisconnect(std::move(Err)); }
 
     /// Ask the Session to run the given wrapper function.
     ///
@@ -317,6 +339,58 @@ public:
 
   /// Report an error via the ErrorReporter function.
   void reportError(Error Err) { ReportError(std::move(Err)); }
+
+  /// Set a handler to be called when the Session's controller connection ends.
+  ///
+  /// The handler is called exactly once, as the Session detaches and before any
+  /// Service is notified via onDetach. Every Session calls it, including one
+  /// that never attached a controller.
+  ///
+  /// The Error it receives describes how the connection ended:
+  ///
+  ///   - Success: the disconnection was orderly -- it was requested locally,
+  ///     the controller announced that it was going away, or no controller was
+  ///     ever attached (with no connection to lose, the disconnect trivially
+  ///     succeeds).
+  ///
+  ///   - Failure: the disconnection was abnormal -- a failure to connect in
+  ///     the first place, a communication failure, or the controller vanishing
+  ///     without announcing it.
+  ///
+  /// The handler takes ownership of the Error and must consume it. Note that
+  /// success covers both an orderly disconnection and never having attached; a
+  /// client that needs to tell those apart knows which it did.
+  ///
+  /// This is where a client decides what the end of the connection means for
+  /// the Session. The expected use is to call shutdown, turning "the controller
+  /// is gone" into "finish outstanding work and exit" rather than idling on an
+  /// empty task queue waiting for instructions that will never arrive. Calling
+  /// shutdown here is supported: it schedules the shutdown, which proceeds once
+  /// the detach completes. The Error is available to make that conditional --
+  /// e.g. to exit with a failure status if the controller was lost
+  /// unexpectedly.
+  ///
+  /// If no handler is installed, an abnormal disconnection is reported via the
+  /// Session's error reporter and an orderly one is ignored. Installing a
+  /// handler
+  /// takes over this routing entirely: the error reporter will not also see the
+  /// disconnection error.
+  ///
+  /// The handler runs synchronously, on whichever thread drove the
+  /// disconnection -- for a remote controller, typically a listener thread. It
+  /// must not block, because the detach cannot proceed until it returns: both
+  /// waiting for the shutdown it scheduled and destroying the Session (~Session
+  /// waits for the Session lifecycle to complete) deadlock. If a controller was
+  /// attached, it is guaranteed to outlive the call.
+  ///
+  /// Must be called prior to attach: a disconnection during attach would
+  /// otherwise be routed to the error reporter before the handler is installed.
+  void setOnDisconnect(OnDisconnectFn OnDisconnect) {
+    std::scoped_lock<std::mutex> Lock(M);
+    assert(CurrentState == State::Start && TargetState == State::None &&
+           "Must be called prior to attach");
+    this->OnDisconnect = std::move(OnDisconnect);
+  }
 
   /// Add a Service to the session.
   template <typename ServiceT>
@@ -419,6 +493,17 @@ public:
   /// Register a callback to be called when the Session detaches from the
   /// controller. If the Session has already detached, the callback will be
   /// called immediately.
+  ///
+  /// Callbacks may call shutdown: this is supported, and is the usual way to
+  /// turn a detach into "finish outstanding work and exit". It schedules the
+  /// shutdown, which proceeds once the detach completes -- every onDetach
+  /// callback runs before any onShutdown callback. A callback must not block
+  /// waiting for that shutdown to complete, since the shutdown cannot start
+  /// until the callback returns.
+  ///
+  /// Any number of callbacks may be registered, and unlike the on-disconnect
+  /// handler (see setOnDisconnect) they carry no indication of how the
+  /// controller connection ended.
   void addOnDetach(OnDetachFn OnDetach);
 
   /// Register a callback to be called when the Session shuts down. If the
@@ -547,9 +632,10 @@ private:
   /// object: clients never hold a ControllerAccess directly.
   void doAttach(std::shared_ptr<ControllerAccess> CA, BootstrapInfo BI);
 
-  void handleDisconnect();
+  void handleDisconnect(Error Err);
   void proceedToDetach(std::unique_lock<std::mutex> &Lock,
-                       std::shared_ptr<ControllerAccess> TmpCA);
+                       std::shared_ptr<ControllerAccess> TmpCA,
+                       Error DisconnectErr);
   void detachServices(std::vector<Service *> ToNotify, bool ShutdownRequested);
   void completeDetach();
 
@@ -627,6 +713,7 @@ private:
   std::shared_ptr<TaskGroup> KeepaliveTaskGroup = TaskGroup::Create();
   std::shared_ptr<ControllerAccess> CA;
   ErrorReporterFn ReportError;
+  OnDisconnectFn OnDisconnect;
 
   mutable std::mutex M;
   std::condition_variable CV;

--- a/orc-rt/lib/executor/InProcessControllerAccess.cpp
+++ b/orc-rt/lib/executor/InProcessControllerAccess.cpp
@@ -240,7 +240,7 @@ void InProcessControllerAccess::doDisconnect() {
   for (auto &[_, H] : ToDrain)
     failPendingControllerCall(std::move(H));
 
-  notifyDisconnected();
+  notifyDisconnected(Error::success());
 }
 
 void InProcessControllerAccess::callWrapper(

--- a/orc-rt/lib/executor/Session.cpp
+++ b/orc-rt/lib/executor/Session.cpp
@@ -160,7 +160,9 @@ void Session::detach(OnDetachFn OnDetach) {
       TmpCA = std::atomic_load(&this->CA);
     } else {
       assert(CurrentState == State::Start);
-      proceedToDetach(Lock, std::atomic_exchange(&this->CA, {}));
+      // No controller was ever attached, so the disconnect trivially succeeds.
+      proceedToDetach(Lock, std::atomic_exchange(&this->CA, {}),
+                      Error::success());
       return;
     }
   }
@@ -193,7 +195,8 @@ void Session::shutdown(OnShutdownFn OnShutdown) {
 
     switch (CurrentState) {
     case State::Start:
-      proceedToDetach(Lock, nullptr);
+      // No controller was ever attached, so the disconnect trivially succeeds.
+      proceedToDetach(Lock, nullptr, Error::success());
       return;
     case State::Attached:
       TmpCA = std::atomic_load(&this->CA);
@@ -276,17 +279,18 @@ void Session::appendService(std::unique_ptr<Service> Srv) {
   }
 }
 
-void Session::handleDisconnect() {
+void Session::handleDisconnect(Error Err) {
   ORC_RT_LOG(Info, Session, "Session %p handle-disconnect", this);
   // If we get here we _don't_ need to call disconnect.
   std::unique_lock<std::mutex> Lock(M);
   assert(CurrentState <= State::Attached);
   TargetState = std::max(TargetState, State::Detached);
-  proceedToDetach(Lock, std::atomic_exchange(&this->CA, {}));
+  proceedToDetach(Lock, std::atomic_exchange(&this->CA, {}), std::move(Err));
 }
 
 void Session::proceedToDetach(std::unique_lock<std::mutex> &Lock,
-                              std::shared_ptr<ControllerAccess> TmpCA) {
+                              std::shared_ptr<ControllerAccess> TmpCA,
+                              Error DisconnectErr) {
   std::vector<Service *> ToNotify;
   ToNotify.reserve(Services.size());
   for (auto &Srv : Services)
@@ -294,6 +298,34 @@ void Session::proceedToDetach(std::unique_lock<std::mutex> &Lock,
   bool ShutdownRequested = TargetState == State::Shutdown;
   CurrentState = State::Detached;
   Lock.unlock();
+
+  // Report how the controller connection ended: to the on-disconnect handler if
+  // one was installed, otherwise via reportError if it ended abnormally. Every
+  // detach path funnels through here, so this runs exactly once per Session --
+  // including for a Session that never attached, which reports success.
+  //
+  // This runs without holding M, since it is client code: holding M across it
+  // would deadlock any Session call the handler makes. It also runs before the
+  // controller is released below, so the handler can rely on the
+  // ControllerAccess outliving it, and before Services are notified.
+  //
+  // The handler is documented to be able to call shutdown. That works because
+  // CurrentState is already Detached and every caller raises TargetState to at
+  // least Detached before getting here, so a re-entrant shutdown or detach is
+  // absorbed by the early-return in those functions: it registers its callback
+  // and raises TargetState, which completeDetach then acts on. Preserve those
+  // two properties when reordering this.
+  //
+  // OnDisconnect is only ever written before attach, so the unlocked read is
+  // safe.
+  if (OnDisconnect) {
+    OnDisconnect(std::move(DisconnectErr));
+    // Release anything the handler captured now, rather than holding it until
+    // the Session is destroyed. Exactly-once is structural (proceedToDetach
+    // runs once), so this is not guarding against a second call.
+    OnDisconnect = {};
+  } else if (DisconnectErr)
+    reportError(std::move(DisconnectErr));
 
   // Throw away controller if present.
   TmpCA.reset();

--- a/orc-rt/test/unit/SessionTest.cpp
+++ b/orc-rt/test/unit/SessionTest.cpp
@@ -153,12 +153,9 @@ public:
   }
 
   void connect(BootstrapInfo BI) override {
-    if (OnConnect) {
-      if (auto Err = OnConnect(BI)) {
-        reportError(std::move(Err));
-        notifyDisconnected();
-      }
-    }
+    if (OnConnect)
+      if (auto Err = OnConnect(BI))
+        notifyDisconnected(std::move(Err));
   }
 
   void disconnect() override {
@@ -176,7 +173,8 @@ public:
     }
     for (auto &[_, OnComplete] : ToDrain)
       failPendingControllerCall(std::move(OnComplete));
-    notifyDisconnected();
+    // A locally requested disconnect is orderly, so the mode is success.
+    notifyDisconnected(Error::success());
   }
 
   void callController(OnControllerCallReturn OnComplete,
@@ -633,7 +631,7 @@ class DeadControllerAccess : public Session::ControllerAccess {
 public:
   DeadControllerAccess(Session &S) : ControllerAccess(S) {}
   void connect(BootstrapInfo) override {}
-  void disconnect() override { notifyDisconnected(); }
+  void disconnect() override { notifyDisconnected(Error::success()); }
   void callController(OnControllerCallReturn OnComplete,
                       orc_rt_ControllerHandlerTag,
                       WrapperFunctionBuffer) override {
@@ -937,4 +935,260 @@ TEST(ControllerAccessTest, TryAttachFailure) {
       41, 1);
 
   EXPECT_EQ(toString(std::move(CallErr)), "no controller attached");
+}
+
+// A ControllerAccess that reports a caller-supplied disconnection mode, used to
+// exercise the Error that notifyDisconnected passes to the Session (see
+// Session::setOnDisconnect). An empty ErrMsg reports an orderly disconnection,
+// any other value an abnormal one.
+class DisconnectingControllerAccess : public Session::ControllerAccess {
+public:
+  DisconnectingControllerAccess(Session &S, std::string ErrMsg = "",
+                                DisconnectingControllerAccess **Self = nullptr)
+      : ControllerAccess(S), ErrMsg(std::move(ErrMsg)) {
+    // Publish this instance so tests that need to drive a controller-initiated
+    // disconnection can reach it after attach constructs it.
+    if (Self)
+      *Self = this;
+  }
+
+  /// Simulate the controller going away without the Session asking it to.
+  void disconnectFromController() { doDisconnect(); }
+
+  void connect(BootstrapInfo) override {}
+  void disconnect() override { doDisconnect(); }
+  void callController(OnControllerCallReturn OnComplete,
+                      orc_rt_ControllerHandlerTag,
+                      WrapperFunctionBuffer) override {
+    failControllerCallInline(std::move(OnComplete));
+  }
+  void sendWrapperResult(WrapperFunctionBuffer, uint64_t) override {}
+
+private:
+  void doDisconnect() {
+    // notifyDisconnected is exactly-once, so a redundant disconnect -- e.g. a
+    // Session-initiated disconnect racing a controller-initiated one -- must be
+    // a no-op. These tests are single-threaded, so a plain bool suffices.
+    if (Disconnected)
+      return;
+    Disconnected = true;
+    notifyDisconnected(ErrMsg.empty() ? Error::success()
+                                      : make_error<StringError>(ErrMsg));
+  }
+
+  std::string ErrMsg;
+  bool Disconnected = false;
+};
+
+/// Consume Err, returning its message, or "" if Err is a success value.
+static std::string errMsgOrEmpty(Error Err) {
+  if (Err)
+    return toString(std::move(Err));
+  return "";
+}
+
+TEST(ControllerAccessTest, OnDisconnectReportsOrderlyDisconnect) {
+  // An orderly disconnection reports a success Error, exactly once.
+  size_t HandlerRuns = 0;
+  std::string ErrMsg = "<not run>";
+  Session S(mockExecutorProcessInfo(), noDispatch, noErrors);
+  S.setOnDisconnect([&](Error Err) {
+    ++HandlerRuns;
+    ErrMsg = errMsgOrEmpty(std::move(Err));
+  });
+  S.attach<DisconnectingControllerAccess>(BootstrapInfo(S));
+
+  S.detach();
+
+  EXPECT_EQ(HandlerRuns, 1U);
+  EXPECT_EQ(ErrMsg, "");
+}
+
+TEST(ControllerAccessTest, OnDisconnectReportsAbnormalDisconnect) {
+  // An abnormal disconnection reports the ControllerAccess's Error unchanged.
+  std::optional<std::string> ErrMsg;
+  Session S(mockExecutorProcessInfo(), noDispatch, noErrors);
+  S.setOnDisconnect([&](Error Err) { ErrMsg = errMsgOrEmpty(std::move(Err)); });
+  S.attach<DisconnectingControllerAccess>(BootstrapInfo(S),
+                                          "connection closed without hangup");
+
+  S.detach();
+
+  EXPECT_THAT(ErrMsg,
+              Optional(Eq(std::string("connection closed without hangup"))));
+}
+
+TEST(ControllerAccessTest, DisconnectErrorRoutedToErrorReporterWithNoHandler) {
+  // With no on-disconnect handler installed, an abnormal disconnection is
+  // reported via the Session's error reporter -- once, not once per route.
+  std::vector<std::string> ErrMsgs;
+  Session S(mockExecutorProcessInfo(), noDispatch, AccumulateErrors(ErrMsgs));
+  S.attach<DisconnectingControllerAccess>(BootstrapInfo(S),
+                                          "connection closed without hangup");
+
+  S.detach();
+
+  ASSERT_EQ(ErrMsgs.size(), 1U);
+  EXPECT_EQ(ErrMsgs[0], "connection closed without hangup");
+}
+
+TEST(ControllerAccessTest, OrderlyDisconnectNotRoutedToErrorReporter) {
+  // An orderly disconnection is not an error, so nothing is reported.
+  std::vector<std::string> ErrMsgs;
+  Session S(mockExecutorProcessInfo(), noDispatch, AccumulateErrors(ErrMsgs));
+  S.attach<DisconnectingControllerAccess>(BootstrapInfo(S));
+
+  S.detach();
+
+  EXPECT_TRUE(ErrMsgs.empty());
+}
+
+TEST(ControllerAccessTest, OnDisconnectSuppressesErrorReporterRouting) {
+  // Installing a handler takes over routing entirely: the error reporter must
+  // not also see the disconnection error.
+  std::vector<std::string> ErrMsgs;
+  std::optional<std::string> HandlerErrMsg;
+  Session S(mockExecutorProcessInfo(), noDispatch, AccumulateErrors(ErrMsgs));
+  S.setOnDisconnect(
+      [&](Error Err) { HandlerErrMsg = errMsgOrEmpty(std::move(Err)); });
+  S.attach<DisconnectingControllerAccess>(BootstrapInfo(S),
+                                          "connection closed without hangup");
+
+  S.detach();
+
+  EXPECT_THAT(HandlerErrMsg,
+              Optional(Eq(std::string("connection closed without hangup"))));
+  EXPECT_TRUE(ErrMsgs.empty());
+}
+
+TEST(ControllerAccessTest, OnDisconnectReportsConnectFailure) {
+  // A ControllerAccess that fails to connect disconnects during attach, so the
+  // handler sees the connect error.
+  //
+  // This is the boundary between "attempted an attach and failed" and "never
+  // attempted one": both reach proceedToDetach with the Session still in the
+  // Start state, differing only in the Error the caller supplies, so nothing
+  // but this test distinguishes them -- OnDisconnectReportsSuccessWithoutAttach
+  // would still pass if a failed connect were reported as success.
+  std::optional<std::string> ErrMsg;
+  Session S(mockExecutorProcessInfo(), noDispatch, noErrors);
+  S.setOnDisconnect([&](Error Err) { ErrMsg = errMsgOrEmpty(std::move(Err)); });
+
+  S.attach<MockControllerAccess>(
+      BootstrapInfo(S), MockControllerAccess::PostFn{},
+      [](BootstrapInfo &) { return make_error<StringError>("no route"); });
+
+  EXPECT_THAT(ErrMsg, Optional(Eq(std::string("no route"))));
+}
+
+TEST(ControllerAccessTest, OnDisconnectReportsSuccessWithoutAttach) {
+  // A Session that never attached a controller still reports a disconnection,
+  // with success: there was no connection to lose, so it trivially succeeded.
+  // This is what makes the handler total -- a client using it to record the
+  // Session's result never has to account for it not running.
+  //
+  // Note that success here is specific to never having attempted an attach:
+  // an attach whose connect fails reports the connect error instead, which
+  // OnDisconnectReportsConnectFailure covers.
+  size_t HandlerRuns = 0;
+  std::string ErrMsg = "<not run>";
+  {
+    Session S(mockExecutorProcessInfo(), noDispatch, noErrors);
+    S.setOnDisconnect([&](Error Err) {
+      ++HandlerRuns;
+      ErrMsg = errMsgOrEmpty(std::move(Err));
+    });
+  }
+  EXPECT_EQ(HandlerRuns, 1U);
+  EXPECT_EQ(ErrMsg, "");
+}
+
+TEST(ControllerAccessTest, OnDisconnectRunsBeforeDetachAndShutdown) {
+  // The on-disconnect handler reports the loss of the controller connection
+  // specifically, so it runs before Services are notified via onDetach, and
+  // well before shutdown.
+  size_t OpIdx = 0;
+  std::optional<size_t> DisconnectOpIdx;
+  std::optional<size_t> DetachOpIdx;
+  std::optional<size_t> ShutdownOpIdx;
+
+  {
+    Session S(mockExecutorProcessInfo(), noDispatch, noErrors);
+    S.setOnDisconnect([&](Error Err) {
+      DisconnectOpIdx = OpIdx++;
+      cantFail(std::move(Err));
+    });
+    S.addService(
+        std::make_unique<MockService>(DetachOpIdx, ShutdownOpIdx, OpIdx));
+    S.attach<DisconnectingControllerAccess>(BootstrapInfo(S));
+  }
+
+  EXPECT_EQ(OpIdx, 3U);
+  EXPECT_EQ(DisconnectOpIdx, 0U);
+  EXPECT_EQ(DetachOpIdx, 1U);
+  EXPECT_EQ(ShutdownOpIdx, 2U);
+}
+
+TEST(ControllerAccessTest, ShutdownFromOnDisconnectHandler) {
+  // Calling shutdown from the on-disconnect handler is supported, and is the
+  // expected way to turn the loss of the controller into "finish outstanding
+  // work and exit" (see Session::setOnDisconnect). Check that it neither
+  // deadlocks nor detaches twice, and that the scheduled shutdown runs.
+  //
+  // Here the disconnect was requested locally, via detach.
+  size_t OpIdx = 0;
+  std::optional<size_t> DetachOpIdx;
+  std::optional<size_t> ShutdownOpIdx;
+  bool OnShutdownRan = false;
+
+  {
+    Session S(mockExecutorProcessInfo(), noDispatch, noErrors);
+    S.addService(
+        std::make_unique<MockService>(DetachOpIdx, ShutdownOpIdx, OpIdx));
+    S.setOnDisconnect([&](Error Err) {
+      cantFail(std::move(Err));
+      S.shutdown([&]() { OnShutdownRan = true; });
+    });
+    S.attach<DisconnectingControllerAccess>(BootstrapInfo(S));
+
+    S.detach();
+
+    EXPECT_TRUE(OnShutdownRan);
+  }
+
+  // Exactly one onDetach and one onShutdown: no double detach.
+  EXPECT_EQ(OpIdx, 2U);
+  EXPECT_EQ(DetachOpIdx, 0U);
+  EXPECT_EQ(ShutdownOpIdx, 1U);
+}
+
+TEST(ControllerAccessTest, ShutdownFromOnDisconnectHandlerAfterRemoteHangup) {
+  // As above, but for a controller-initiated disconnection, where the Session
+  // did not ask for the detach. The re-entrant shutdown still has to be
+  // absorbed, and Services still detached and shut down exactly once.
+  size_t OpIdx = 0;
+  std::optional<size_t> DetachOpIdx;
+  std::optional<size_t> ShutdownOpIdx;
+  bool OnShutdownRan = false;
+
+  {
+    DisconnectingControllerAccess *CA = nullptr;
+    Session S(mockExecutorProcessInfo(), noDispatch, noErrors);
+    S.addService(
+        std::make_unique<MockService>(DetachOpIdx, ShutdownOpIdx, OpIdx));
+    S.setOnDisconnect([&](Error Err) {
+      cantFail(std::move(Err));
+      S.shutdown([&]() { OnShutdownRan = true; });
+    });
+    S.attach<DisconnectingControllerAccess>(BootstrapInfo(S), "", &CA);
+    ASSERT_TRUE(CA);
+
+    CA->disconnectFromController();
+
+    EXPECT_TRUE(OnShutdownRan);
+  }
+
+  EXPECT_EQ(OpIdx, 2U);
+  EXPECT_EQ(DetachOpIdx, 0U);
+  EXPECT_EQ(ShutdownOpIdx, 1U);
 }


### PR DESCRIPTION
ControllerAccess::notifyDisconnected now takes an Error describing how the controller connection ended: success if the disconnection was orderly, otherwise an Error describing what went wrong. A ControllerAccess passes its terminal error here rather than to reportError; with no on-disconnect handler installed the Session forwards it to the error reporter.

Session::setOnDisconnect installs that handler. It is called exactly once as the Session detaches, including on a Session that never attached a controller (reporting success), so a client can use it both to record the Session's result and to decide whether to shut down.