### PR TITLE
[libc++][test] Remove `XFAIL` mark for LLVM libc on `system`

### DIFF
--- a/libcxx/test/std/depr/depr.c.headers/stdlib_h.pass.cpp
+++ b/libcxx/test/std/depr/depr.c.headers/stdlib_h.pass.cpp
@@ -13,9 +13,6 @@
 // updated.
 // UNSUPPORTED: LIBCXX-ANDROID-FIXME && target={{.+}}-android{{(eabi)?(21|22|23|24|25)}}
 
-// Use of undeclared identifier 'system'.
-// XFAIL: LLVM-LIBC-FIXME
-
 #include <stdlib.h>
 #include <cassert>
 #include <type_traits>

--- a/libcxx/test/std/language.support/support.runtime/cstdlib.pass.cpp
+++ b/libcxx/test/std/language.support/support.runtime/cstdlib.pass.cpp
@@ -13,9 +13,6 @@
 // updated.
 // UNSUPPORTED: LIBCXX-ANDROID-FIXME && target={{.+}}-android{{(eabi)?(21|22|23|24|25)}}
 
-// Use of undeclared identifier 'system'.
-// XFAIL: LLVM-LIBC-FIXME
-
 #include <cstdlib>
 #include <cassert>
 #include <type_traits>


### PR DESCRIPTION
Recently, LLVM libc has `system` implemented in 8c28e298827d1777009f4599ae161abef9491f34, so the tests for `<cstdlib>` and `<stdlib.h>` pass now.