### PR TITLE
[lldb] Interpret the DW_OP_plus_uconst addend in the popped operand's…

### DIFF
--- a/lldb/source/Expression/DWARFExpression.cpp
+++ b/lldb/source/Expression/DWARFExpression.cpp
@@ -1630,9 +1630,17 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
 
     case DW_OP_plus_uconst: {
       const uint64_t uconst_value = op->getRawOperand(0);
-      // Implicit conversion from a UINT to a Scalar...
-      stack.back().GetScalar() += uconst_value;
-      if (!stack.back().GetScalar().IsValid())
+      Scalar &operand = stack.back().GetScalar();
+      Scalar addend(uconst_value);
+      // The addend is interpreted as the same type as the popped operand
+      // (DWARF v5, 2.5.1.4). Give it the operand's exact integer type so
+      // the addition keeps the operand's width and wraparound semantics
+      // instead of promoting to a 64-bit unsigned value.
+      if (operand.GetType() == Scalar::e_int)
+        addend.TruncOrExtendTo(operand.GetAPSInt().getBitWidth(),
+                               operand.GetAPSInt().isSigned());
+      operand += addend;
+      if (!operand.IsValid())
         return llvm::createStringError("DW_OP_plus_uconst failed");
     } break;
 

--- a/lldb/unittests/Expression/DWARFExpressionTest.cpp
+++ b/lldb/unittests/Expression/DWARFExpressionTest.cpp
@@ -959,6 +959,55 @@ TEST(DWARFExpression, DW_OP_plus_uconst) {
                        ExpectScalar(static_cast<int32_t>(-5)));
 }
 
+TEST(DWARFExpression, DW_OP_plus_uconst_typed) {
+  class TypedDwarfDelegate : public MockDwarfDelegate {
+  public:
+    enum : uint8_t {
+      UnsignedChar = 1,
+      SignedChar = 2,
+    };
+
+    llvm::Expected<std::pair<uint64_t, bool>>
+    GetDIEBitSizeAndSign(uint64_t relative_die_offset) const override {
+      switch (relative_die_offset) {
+      case UnsignedChar:
+        return std::pair<uint64_t, bool>{8, false};
+      case SignedChar:
+        return std::pair<uint64_t, bool>{8, true};
+      default:
+        return llvm::createStringError("unknown base type offset");
+      }
+    }
+  };
+  TypedDwarfDelegate unit;
+
+  // The addend is interpreted as the same type as the popped operand
+  // (DWARF v5, 2.5.1.4), so the addition wraps within that type.
+  // (unsigned char)0xff + 1 == 0
+  EXPECT_THAT_EXPECTED(Evaluate({DW_OP_const1u, 0xff, DW_OP_convert,
+                                 TypedDwarfDelegate::UnsignedChar,
+                                 DW_OP_plus_uconst, 1, DW_OP_stack_value},
+                                {}, &unit),
+                       ExpectScalar(8, 0, /*sign=*/false));
+
+  // (signed char)0x7f + 1 == -128
+  EXPECT_THAT_EXPECTED(Evaluate({DW_OP_const1u, 0x7f, DW_OP_convert,
+                                 TypedDwarfDelegate::SignedChar,
+                                 DW_OP_plus_uconst, 1, DW_OP_stack_value},
+                                {}, &unit),
+                       ExpectScalar(8, 0x80, /*sign=*/true));
+
+  // The reproducer from the issue: if 0xff + 1 fails to wrap to zero, the
+  // subsequent right shift produces 1 instead of 0.
+  EXPECT_THAT_EXPECTED(
+      Evaluate({DW_OP_const8u, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                DW_OP_convert, TypedDwarfDelegate::UnsignedChar,
+                DW_OP_plus_uconst, 1, DW_OP_const1u, 7, DW_OP_convert,
+                TypedDwarfDelegate::UnsignedChar, DW_OP_shr, DW_OP_stack_value},
+               {}, &unit),
+      ExpectScalar(8, 0, /*sign=*/false));
+}
+
 TEST(DWARFExpression, DW_OP_and) {
   EXPECT_THAT_EXPECTED(
       Evaluate({DW_OP_const1u, 0x0F, DW_OP_const1u, 0x33, DW_OP_and}),

--- a/lldb/unittests/Expression/DWARFExpressionTest.cpp
+++ b/lldb/unittests/Expression/DWARFExpressionTest.cpp
@@ -984,28 +984,34 @@ TEST(DWARFExpression, DW_OP_plus_uconst_typed) {
   // The addend is interpreted as the same type as the popped operand
   // (DWARF v5, 2.5.1.4), so the addition wraps within that type.
   // (unsigned char)0xff + 1 == 0
-  EXPECT_THAT_EXPECTED(Evaluate({DW_OP_const1u, 0xff, DW_OP_convert,
-                                 TypedDwarfDelegate::UnsignedChar,
-                                 DW_OP_plus_uconst, 1, DW_OP_stack_value},
-                                {}, &unit),
-                       ExpectScalar(8, 0, /*sign=*/false));
+  auto result = Evaluate({DW_OP_const1u, 0xff, DW_OP_convert,
+                          TypedDwarfDelegate::UnsignedChar, DW_OP_plus_uconst,
+                          1, DW_OP_stack_value},
+                         {}, &unit);
+  ASSERT_THAT_EXPECTED(result, ExpectScalar(8, 0, /*sign=*/false));
+  EXPECT_EQ(result->GetScalar().GetAPSInt().getBitWidth(), 8u);
+  EXPECT_FALSE(result->GetScalar().IsSigned());
 
   // (signed char)0x7f + 1 == -128
-  EXPECT_THAT_EXPECTED(Evaluate({DW_OP_const1u, 0x7f, DW_OP_convert,
-                                 TypedDwarfDelegate::SignedChar,
-                                 DW_OP_plus_uconst, 1, DW_OP_stack_value},
-                                {}, &unit),
-                       ExpectScalar(8, 0x80, /*sign=*/true));
+  result = Evaluate({DW_OP_const1u, 0x7f, DW_OP_convert,
+                     TypedDwarfDelegate::SignedChar, DW_OP_plus_uconst, 1,
+                     DW_OP_stack_value},
+                    {}, &unit);
+  ASSERT_THAT_EXPECTED(result, ExpectScalar(8, 0x80, /*sign=*/true));
+  EXPECT_EQ(result->GetScalar().GetAPSInt().getBitWidth(), 8u);
+  EXPECT_TRUE(result->GetScalar().IsSigned());
 
   // The reproducer from the issue: if 0xff + 1 fails to wrap to zero, the
   // subsequent right shift produces 1 instead of 0.
-  EXPECT_THAT_EXPECTED(
+  result =
       Evaluate({DW_OP_const8u, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
                 DW_OP_convert, TypedDwarfDelegate::UnsignedChar,
                 DW_OP_plus_uconst, 1, DW_OP_const1u, 7, DW_OP_convert,
                 TypedDwarfDelegate::UnsignedChar, DW_OP_shr, DW_OP_stack_value},
-               {}, &unit),
-      ExpectScalar(8, 0, /*sign=*/false));
+               {}, &unit);
+  ASSERT_THAT_EXPECTED(result, ExpectScalar(8, 0, /*sign=*/false));
+  EXPECT_EQ(result->GetScalar().GetAPSInt().getBitWidth(), 8u);
+  EXPECT_FALSE(result->GetScalar().IsSigned());
 }
 
 TEST(DWARFExpression, DW_OP_and) {


### PR DESCRIPTION
… typeFor typed DWARF values, `DW_OP_plus_uconst` must add the ULEB128 addend
in the same explicit base type as the popped operand (DWARF v5, 2.5.1.4).

LLDB forwarded the operation to `uint64_t` `Scalar` arithmetic: the
addend was implicitly converted to a 64-bit unsigned `Scalar`, and
`Scalar::operator+=` then promoted the narrow operand to 64 bits before
adding. This destroys the wraparound semantics of the original base
type, e.g. `(unsigned char)0xff + 1` evaluated to `0x100` instead of 0.

Construct the addend with the popped operand's exact integer type (bit
width and signedness) so the addition is performed in that type and
wraps accordingly. Non-integer operands keep the existing promotion
behavior.

Adds a `DW_OP_plus_uconst_typed` unit test covering unsigned and signed
narrow wraparound as well as the reproducer from the issue.

Fixes #204520