### PR TITLE
[libclc] Use generic subnormal_config for spirv-vulkan

### DIFF
--- a/libclc/clc/lib/spirv/CMakeLists.txt
+++ b/libclc/clc/lib/spirv/CMakeLists.txt
@@ -8,5 +8,8 @@ libclc_add_sources(${LIBCLC_CLC_TARGET} FILES
   math/clc_fmin.cl
   math/clc_runtime_has_hw_fma32.cl
   math/clc_sw_fma.cl
-  subnormal_config.cl
 )
+
+if(NOT LIBCLC_TARGET_OS STREQUAL "vulkan")
+  libclc_add_sources(${LIBCLC_CLC_TARGET} FILES subnormal_config.cl)
+endif()


### PR DESCRIPTION
Since clspv properly handles denorm with
https://github.com/google/clspv/pull/1616
we should rely on the generic implementation of subnormal_config.