### PR TITLE
[LV] Make operand bundle test not constant-foldable/dead. NFC

### DIFF
--- a/llvm/test/Transforms/LoopVectorize/X86/funclet.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/funclet.ll
@@ -6,9 +6,9 @@ target triple = "i686-pc-windows-msvc18.0.0"
 
 @sink = external global double
 
-define void @test1() #0 personality ptr @__CxxFrameHandler3 {
+define void @test1(ptr %p) #0 personality ptr @__CxxFrameHandler3 {
 ; CHECK-LABEL: define void @test1(
-; CHECK-SAME: ) #[[ATTR0:[0-9]+]] personality ptr @__CxxFrameHandler3 {
+; CHECK-SAME: ptr [[P:%.*]]) #[[ATTR0:[0-9]+]] personality ptr @__CxxFrameHandler3 {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    invoke void @_CxxThrowException(ptr null, ptr null)
 ; CHECK-NEXT:            to label %[[UNREACHABLE:.*]] unwind label %[[CATCH_DISPATCH:.*]]
@@ -16,19 +16,22 @@ define void @test1() #0 personality ptr @__CxxFrameHandler3 {
 ; CHECK-NEXT:    [[TMP0:%.*]] = catchswitch within none [label %[[CATCH:.*]]] unwind to caller
 ; CHECK:       [[CATCH]]:
 ; CHECK-NEXT:    [[TMP1:%.*]] = catchpad within [[TMP0]] [ptr null, i32 64, ptr null]
-; CHECK-NEXT:    br label %[[FOR_BODY:.*]]
-; CHECK:       [[FOR_BODY]]:
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[FOR_BODY]] ], [ [[INC:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[TMP2:%.*]] = call <16 x double> @llvm.floor.v16f64(<16 x double> splat (double 1.000000e+00)) [ "funclet"(token [[TMP1]]) ]
-; CHECK-NEXT:    [[INC]] = add nuw i32 [[INDEX]], 16
+; CHECK-NEXT:    br label %[[VECTOR_BODY1:.*]]
+; CHECK:       [[VECTOR_BODY1]]:
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_BODY]] ], [ [[INC:%.*]], %[[VECTOR_BODY1]] ]
+; CHECK-NEXT:    [[TMP2:%.*]] = getelementptr double, ptr [[P]], i32 [[INDEX]]
+; CHECK-NEXT:    [[WIDE_LOAD:%.*]] = load <2 x double>, ptr [[TMP2]], align 8
+; CHECK-NEXT:    [[TMP3:%.*]] = call <2 x double> @llvm.floor.v2f64(<2 x double> [[WIDE_LOAD]]) [ "funclet"(token [[TMP1]]) ]
+; CHECK-NEXT:    [[INC]] = add nuw i32 [[INDEX]], 2
 ; CHECK-NEXT:    [[EXITCOND:%.*]] = icmp eq i32 [[INC]], 1024
-; CHECK-NEXT:    br i1 [[EXITCOND]], label %[[TRY_CONT:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP0:![0-9]+]]
-; CHECK:       [[TRY_CONT]]:
-; CHECK-NEXT:    br label %[[EXIT:.*]]
+; CHECK-NEXT:    br i1 [[EXITCOND]], label %[[EXIT:.*]], label %[[VECTOR_BODY1]], !llvm.loop [[LOOP0:![0-9]+]]
 ; CHECK:       [[EXIT]]:
-; CHECK-NEXT:    store double 1.000000e+00, ptr @sink, align 8
+; CHECK-NEXT:    [[CALL_LCSSA:%.*]] = extractelement <2 x double> [[TMP3]], i64 1
+; CHECK-NEXT:    br label %[[EXIT1:.*]]
+; CHECK:       [[EXIT1]]:
+; CHECK-NEXT:    store double [[CALL_LCSSA]], ptr @sink, align 8
 ; CHECK-NEXT:    catchret from [[TMP1]] to label %[[TRY_CONT1:.*]]
 ; CHECK:       [[TRY_CONT1]]:
 ; CHECK-NEXT:    ret void
@@ -48,7 +51,9 @@ catch:
 
 loop:
   %iv = phi i32 [ 0, %catch ], [ %inc, %loop ]
-  %call = call double @floor(double 1.0) #1 [ "funclet"(token %1) ]
+  %gep = getelementptr double, ptr %p, i32 %iv
+  %x = load double, ptr %gep
+  %call = call double @floor(double %x) #1 [ "funclet"(token %1) ]
   %inc = add nuw nsw i32 %iv, 1
   %exitcond = icmp eq i32 %inc, 1024
   br i1 %exitcond, label %exit, label %loop


### PR DESCRIPTION
The test looks like it was originally added to check that operand
bundles were preserved, but the libcall is constant folded away and made
dead. Later PRs may end up removing this, see the conversation in
https://github.com/llvm/llvm-project/pull/212968#discussion_r3702373769