### PR TITLE
[lldb] Canonicalize DW_OP_GNU_const_index to the generic type

### DIFF
--- a/lldb/source/Expression/DWARFExpression.cpp
+++ b/lldb/source/Expression/DWARFExpression.cpp
@@ -2056,7 +2056,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
       uint64_t index = op->getRawOperand(0);
       lldb::addr_t value =
           eval_ctx.dwarf_cu->ReadAddressFromDebugAddrSection(index);
-      stack.push_back(Scalar(value));
+      stack.push_back(to_generic(value));
     } break;
 
     case DW_OP_GNU_entry_value:

--- a/lldb/unittests/Expression/DWARFExpressionTest.cpp
+++ b/lldb/unittests/Expression/DWARFExpressionTest.cpp
@@ -883,6 +883,20 @@ TEST(DWARFExpression, DW_OP_addr_index_address_size) {
   }
 }
 
+TEST(DWARFExpression, DW_OP_GNU_const_index_address_size) {
+  // DW_OP_GNU_const_index pushes a generic value, so it is canonicalized to
+  // the target address size: on this 32-bit target, 0x2a + 0xffffffff + 1
+  // wraps back to 0x2a.
+  MockDwarfDelegate unit(/*version=*/5,
+                         /*debug_addr=*/{{0, 0x11}, {1, 0x2a}});
+  auto result =
+      Evaluate({DW_OP_GNU_const_index, 0x01, DW_OP_const4u, 0xff, 0xff, 0xff,
+                0xff, DW_OP_plus, DW_OP_lit1, DW_OP_plus, DW_OP_stack_value},
+               {}, &unit);
+  ASSERT_THAT_EXPECTED(result, ExpectScalar(32, 0x2a, false));
+  EXPECT_EQ(result->GetScalar().GetAPSInt().getBitWidth(), 32u);
+}
+
 TEST(DWARFExpression, DW_OP_addr_big_endian) {
   // Same operand bytes, big-endian extractor: the address must be read in
   // target byte order.


### PR DESCRIPTION
`DW_OP_GNU_const_index` reads a machine-address-sized constant from the
address table and pushes it as a generic value. The generic type has the
size of an address on the target, so on a 32-bit compilation unit the
pushed value should be a 32-bit scalar.

`DWARFUnit::ReadAddressFromDebugAddrSection` reads the correct number of
bytes, but the evaluator case pushed the result as `Scalar(value)`, where
`value` is a 64-bit `lldb::addr_t`, leaving a 64-bit scalar on the stack
instead of canonicalizing to `8 * address_size` like the other
constant-pushing opcodes.

Use `to_generic`, as `DW_OP_addrx` / `DW_OP_GNU_addr_index` already do,
so the pushed value has the generic type's width.

Adds a `DW_OP_GNU_const_index_address_size` unit test asserting both the
wraparound of generic arithmetic at the 32-bit address size and the exact
bit width of the pushed scalar.

Fixes #211010