### PR TITLE
SPARC: Disable generic codegen tests that depend on libcalls

### DIFF
--- a/llvm/test/CodeGen/Generic/2008-02-04-Ctlz.ll
+++ b/llvm/test/CodeGen/Generic/2008-02-04-Ctlz.ll
@@ -1,4 +1,5 @@
 ; RUN: llc < %s
+; UNSUPPORTED: target=sparc{{.*}}
 
 @.str = internal constant [14 x i8] c"%lld %d %d %d\00"
 

--- a/llvm/test/CodeGen/Generic/llvm-ct-intrinsics.ll
+++ b/llvm/test/CodeGen/Generic/llvm-ct-intrinsics.ll
@@ -1,5 +1,6 @@
 ; Make sure this testcase is supported by all code generators
 ; RUN: llc < %s
+; UNSUPPORTED: target=sparc{{.*}}
 
 declare i64 @llvm.ctpop.i64(i64)
 


### PR DESCRIPTION
The module doesn't get the triple set without any target argument,
so the assumed set of libcalls is empty