### PR TITLE
[flang][Driver] Forward negative sum reassociation flag

### DIFF
--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -337,8 +337,8 @@ void Flang::addCodegenOptions(const ArgList &Args,
 
   Args.addOptInFlag(CmdArgs, options::OPT_fexperimental_loop_fusion,
                     options::OPT_fno_experimental_loop_fusion);
-  Args.addOptInFlag(CmdArgs, options::OPT_ffp_sum_reassociation,
-                    options::OPT_fno_fp_sum_reassociation);
+  Args.AddLastArg(CmdArgs, options::OPT_ffp_sum_reassociation,
+                  options::OPT_fno_fp_sum_reassociation);
 
   handleInterchangeLoopsArgs(Args, CmdArgs);
   handleVectorizeLoopsArgs(Args, CmdArgs);

--- a/flang/test/Driver/sum-reassociation.f90
+++ b/flang/test/Driver/sum-reassociation.f90
@@ -2,7 +2,7 @@
 ! -fno-fp-sum-reassociation, including the old hidden aliases.
 
 ! RUN: %flang -fsyntax-only -### %s -o %t 2>&1 \
-! RUN:   | FileCheck %s --check-prefix=DISABLED
+! RUN:   | FileCheck %s --check-prefix=OMITTED
 
 ! RUN: %flang -fsyntax-only -### %s -o %t 2>&1 \
 ! RUN:     -ffp-sum-reassociation \
@@ -36,8 +36,14 @@
 ! RUN:     -fno-fp-sum-reassociation -freal-sum-reassociation \
 ! RUN:   | FileCheck %s --check-prefix=ENABLED
 
+! OMITTED: "-fc1"
+! OMITTED-NOT: "-ffp-sum-reassociation"
+! OMITTED-NOT: "-fno-fp-sum-reassociation"
+
 ! DISABLED: "-fc1"
+! DISABLED-SAME: "-fno-fp-sum-reassociation"
 ! DISABLED-NOT: "-ffp-sum-reassociation"
 
 ! ENABLED: "-fc1"
 ! ENABLED-SAME: "-ffp-sum-reassociation"
+! ENABLED-NOT: "-fno-fp-sum-reassociation"


### PR DESCRIPTION
Previously, only a flag which alters the default was forwarded to the frontend driver. This works upstream, but it meant that the negation flag was not forwarded (as negation is the default) which then breaks as soon as the default is changed. This led to some confusion when I tested a downstream branch with the flag enabled by default.

Instead, forward the last explicit sum reassociation option to the frontend driver so the negative spelling is not lost by the driver.

Assisted-by: Codex