### PR TITLE
[MLIR][Arith] Enable strict property assembly format (NFC)

### DIFF
--- a/mlir/include/mlir/Dialect/Arith/IR/ArithBase.td
+++ b/mlir/include/mlir/Dialect/Arith/IR/ArithBase.td
@@ -14,6 +14,7 @@ include "mlir/IR/OpBase.td"
 
 def Arith_Dialect : Dialect {
   let name = "arith";
+  let useStrictPropertiesInAssemblyFormat = 1;
   let cppNamespace = "::mlir::arith";
   let description = [{
     The arith dialect is intended to hold basic integer and floating point

--- a/mlir/test/Conversion/ArithToLLVM/arith-to-llvm.mlir
+++ b/mlir/test/Conversion/ArithToLLVM/arith-to-llvm.mlir
@@ -557,7 +557,7 @@ func.func @fcmp(f32, f32) -> () {
   %13 = arith.cmpf une, %arg0, %arg1 : f32
   %14 = arith.cmpf uno, %arg0, %arg1 : f32
 
-  %15 = arith.cmpf oeq, %arg0, %arg1 {fastmath = #arith.fastmath<fast>} : f32
+  %15 = arith.cmpf oeq, %arg0, %arg1 fastmath<fast> : f32
 
   return
 }
@@ -981,4 +981,3 @@ func.func @supported_fp_type(%arg0: f32, %arg1: vector<4xf32>, %arg2: vector<4x8
   %3 = arith.cmpf oeq, %arg0, %arg3 : f32
   return
 }
-

--- a/mlir/test/Examples/transform/ChH/full.mlir
+++ b/mlir/test/Examples/transform/ChH/full.mlir
@@ -61,8 +61,8 @@ func.func @conv(
     // Note the fastmath attributes that allow operations to be recombined into
     //   %0 = math.fma %in, %f, %b : f32
     // later on and to reorder reductions.
-    %m1 = arith.mulf %in, %f  {fastmath = #arith.fastmath<fast>} : f32
-    %0 = arith.addf %b, %m1  {fastmath = #arith.fastmath<fast>} : f32
+    %m1 = arith.mulf %in, %f fastmath<fast> : f32
+    %0 = arith.addf %b, %m1 fastmath<fast> : f32
     linalg.yield %0 : f32
   } -> !toutput
 


### PR DESCRIPTION
Enable the strict properties assembly format mode for the Arith dialect. Update tests that still used attr-dict spelling for fastmath attributes to use the existing declarative fastmath assembly form.

Assisted-by: Codex