### PR TITLE
[MLIR][Async] Enable strict property assembly format

### DIFF
--- a/mlir/include/mlir/Dialect/Async/IR/AsyncDialect.td
+++ b/mlir/include/mlir/Dialect/Async/IR/AsyncDialect.td
@@ -21,6 +21,7 @@ include "mlir/IR/OpBase.td"
 
 def AsyncDialect : Dialect {
   let name = "async";
+  let useStrictPropertiesInAssemblyFormat = 1;
   let cppNamespace = "::mlir::async";
 
   let summary = "Types and operations for async dialect";

--- a/mlir/include/mlir/Dialect/Async/IR/AsyncOps.td
+++ b/mlir/include/mlir/Dialect/Async/IR/AsyncOps.td
@@ -271,7 +271,10 @@ def Async_CallOp : Async_Op<"call",
   }];
 
   let assemblyFormat = [{
-    $callee `(` $operands `)` attr-dict `:` functional-type($operands, results)
+    $callee `(` $operands `)`
+    (`arg_attrs` `=` $arg_attrs^)?
+    (`res_attrs` `=` $res_attrs^)?
+    attr-dict `:` functional-type($operands, results)
   }];
 }
 
@@ -705,7 +708,7 @@ def Async_RuntimeAddRefOp : Async_Op<"runtime.add_ref"> {
                        ConfinedAttr<I64Attr, [IntPositive]>:$count);
 
   let assemblyFormat = [{
-    $operand attr-dict `:` type($operand)
+    $operand `count` `=` $count attr-dict `:` type($operand)
   }];
 }
 
@@ -720,7 +723,7 @@ def Async_RuntimeDropRefOp : Async_Op<"runtime.drop_ref"> {
                        ConfinedAttr<I64Attr, [IntPositive]>:$count);
 
   let assemblyFormat = [{
-    $operand attr-dict `:` type($operand)
+    $operand `count` `=` $count attr-dict `:` type($operand)
   }];
 }
 

--- a/mlir/test/Conversion/AsyncToLLVM/convert-to-llvm.mlir
+++ b/mlir/test/Conversion/AsyncToLLVM/convert-to-llvm.mlir
@@ -4,11 +4,11 @@
 func.func @reference_counting(%arg0: !async.token) {
   // CHECK: %[[C2:.*]] = arith.constant 2 : i64
   // CHECK: call @mlirAsyncRuntimeAddRef(%arg0, %[[C2]])
-  async.runtime.add_ref %arg0 {count = 2 : i64} : !async.token
+  async.runtime.add_ref %arg0 count = 2 : !async.token
 
   // CHECK: %[[C1:.*]] = arith.constant 1 : i64
   // CHECK: call @mlirAsyncRuntimeDropRef(%arg0, %[[C1]])
-  async.runtime.drop_ref %arg0 {count = 1 : i64} : !async.token
+  async.runtime.drop_ref %arg0 count = 1 : !async.token
 
   return
 }

--- a/mlir/test/Dialect/Async/async-runtime-policy-based-ref-counting.mlir
+++ b/mlir/test/Dialect/Async/async-runtime-policy-based-ref-counting.mlir
@@ -23,7 +23,7 @@ func.func @group_await(%arg0: !async.group) {
 // CHECK:         %[[TOKEN:.*]]: !async.token
 func.func @add_token_to_group(%arg0: !async.group, %arg1: !async.token) {
   // CHECK: async.runtime.add_to_group %[[TOKEN]], %[[GROUP]]
-  // CHECK: async.runtime.drop_ref %[[TOKEN]] {count = 1 : i64}
+  // CHECK: async.runtime.drop_ref %[[TOKEN]] count = 1
   async.runtime.add_to_group %arg1, %arg0 : !async.token
   return
 }
@@ -32,7 +32,7 @@ func.func @add_token_to_group(%arg0: !async.group, %arg1: !async.token) {
 // CHECK:         %[[VALUE:.*]]: !async.value<f32>
 func.func @value_load(%arg0: !async.value<f32>) {
   // CHECK: async.runtime.load %[[VALUE]]
-  // CHECK: async.runtime.drop_ref %[[VALUE]] {count = 1 : i64}
+  // CHECK: async.runtime.drop_ref %[[VALUE]] count = 1
   %0 = async.runtime.load %arg0 : !async.value<f32>
   return
 }
@@ -41,7 +41,7 @@ func.func @value_load(%arg0: !async.value<f32>) {
 // CHECK:         %[[TOKEN:.*]]: !async.token
 func.func @error_check(%arg0: !async.token) {
   // CHECK: async.runtime.is_error %[[TOKEN]]
-  // CHECK: async.runtime.drop_ref %[[TOKEN]] {count = 1 : i64}
+  // CHECK: async.runtime.drop_ref %[[TOKEN]] count = 1
   %0 = async.runtime.is_error %arg0 : !async.token
   return
 }

--- a/mlir/test/Dialect/Async/async-runtime-ref-counting-opt.mlir
+++ b/mlir/test/Dialect/Async/async-runtime-ref-counting-opt.mlir
@@ -6,8 +6,8 @@ func.func private @consume_token(%arg0: !async.token)
 func.func @cancellable_operations_0(%arg0: !async.token) {
   // CHECK-NOT: async.runtime.add_ref
   // CHECK-NOT: async.runtime.drop_ref
-  async.runtime.add_ref %arg0 {count = 1 : i64} : !async.token
-  async.runtime.drop_ref %arg0 {count = 1 : i64} : !async.token
+  async.runtime.add_ref %arg0 count = 1 : !async.token
+  async.runtime.drop_ref %arg0 count = 1 : !async.token
   // CHECK: return
   return
 }
@@ -15,11 +15,11 @@ func.func @cancellable_operations_0(%arg0: !async.token) {
 // CHECK-LABEL: @cancellable_operations_1
 func.func @cancellable_operations_1(%arg0: !async.token) {
   // CHECK-NOT: async.runtime.add_ref
-  async.runtime.add_ref %arg0 {count = 1 : i64} : !async.token
+  async.runtime.add_ref %arg0 count = 1 : !async.token
   // CHECK: call @consume_toke
   call @consume_token(%arg0): (!async.token) -> ()
   // CHECK-NOT: async.runtime.drop_ref
-  async.runtime.drop_ref %arg0 {count = 1 : i64} : !async.token
+  async.runtime.drop_ref %arg0 count = 1 : !async.token
   // CHECK: return
   return
 }
@@ -30,24 +30,24 @@ func.func @cancellable_operations_2(%arg0: !async.token) {
   // CHECK-NEXT: async.runtime.await
   // CHECK-NEXT: async.runtime.await
   // CHECK-NEXT: return
-  async.runtime.add_ref %arg0 {count = 1 : i64} : !async.token
+  async.runtime.add_ref %arg0 count = 1 : !async.token
   async.runtime.await %arg0 : !async.token
-  async.runtime.drop_ref %arg0 {count = 1 : i64} : !async.token
+  async.runtime.drop_ref %arg0 count = 1 : !async.token
   async.runtime.await %arg0 : !async.token
-  async.runtime.add_ref %arg0 {count = 1 : i64} : !async.token
+  async.runtime.add_ref %arg0 count = 1 : !async.token
   async.runtime.await %arg0 : !async.token
-  async.runtime.drop_ref %arg0 {count = 1 : i64} : !async.token
+  async.runtime.drop_ref %arg0 count = 1 : !async.token
   return
 }
 
 // CHECK-LABEL: @cancellable_operations_3
 func.func @cancellable_operations_3(%arg0: !async.token) {
   // CHECK-NOT: add_ref
-  async.runtime.add_ref %arg0 {count = 1 : i64} : !async.token
+  async.runtime.add_ref %arg0 count = 1 : !async.token
   // CHECK: call @consume_toke
   call @consume_token(%arg0): (!async.token) -> ()
   // CHECK-NOT: async.runtime.drop_ref
-  async.runtime.drop_ref %arg0 {count = 1 : i64} : !async.token
+  async.runtime.drop_ref %arg0 count = 1 : !async.token
   // CHECK: async.runtime.await
   async.runtime.await %arg0 : !async.token
   // CHECK: return
@@ -57,13 +57,13 @@ func.func @cancellable_operations_3(%arg0: !async.token) {
 // CHECK-LABEL: @not_cancellable_operations_0
 func.func @not_cancellable_operations_0(%arg0: !async.token) {
   // CHECK: add_ref
-  async.runtime.add_ref %arg0 {count = 1 : i64} : !async.token
+  async.runtime.add_ref %arg0 count = 1 : !async.token
   // CHECK: call @consume_toke
   call @consume_token(%arg0): (!async.token) -> ()
   // CHECK: async.runtime.await
   async.runtime.await %arg0 : !async.token
   // CHECK: async.runtime.drop_ref
-  async.runtime.drop_ref %arg0 {count = 1 : i64} : !async.token
+  async.runtime.drop_ref %arg0 count = 1 : !async.token
   // CHECK: return
   return
 }

--- a/mlir/test/Dialect/Async/async-runtime-ref-counting.mlir
+++ b/mlir/test/Dialect/Async/async-runtime-ref-counting.mlir
@@ -12,14 +12,14 @@ func.func private @take_token(%arg0: !async.token)
 // CHECK-LABEL: @token_arg_no_uses
 // CHECK: %[[TOKEN:.*]]: !async.token
 func.func @token_arg_no_uses(%arg0: !async.token) {
-  // CHECK: async.runtime.drop_ref %[[TOKEN]] {count = 1 : i64}
+  // CHECK: async.runtime.drop_ref %[[TOKEN]] count = 1
   return
 }
 
 // CHECK-LABEL: @token_value_no_uses
 func.func @token_value_no_uses() {
   // CHECK: %[[TOKEN:.*]] = async.runtime.create : !async.token
-  // CHECK: async.runtime.drop_ref %[[TOKEN]] {count = 1 : i64}
+  // CHECK: async.runtime.drop_ref %[[TOKEN]] count = 1
   %0 = async.runtime.create : !async.token
   return
 }
@@ -27,7 +27,7 @@ func.func @token_value_no_uses() {
 // CHECK-LABEL: @token_returned_no_uses
 func.func @token_returned_no_uses() {
   // CHECK: %[[TOKEN:.*]] = call @token
-  // CHECK: async.runtime.drop_ref %[[TOKEN]] {count = 1 : i64}
+  // CHECK: async.runtime.drop_ref %[[TOKEN]] count = 1
   %0 = call @token() : () -> !async.token
   return
 }
@@ -35,9 +35,9 @@ func.func @token_returned_no_uses() {
 // CHECK-LABEL: @token_arg_to_func
 // CHECK: %[[TOKEN:.*]]: !async.token
 func.func @token_arg_to_func(%arg0: !async.token) {
-  // CHECK: async.runtime.add_ref %[[TOKEN]] {count = 1 : i64} : !async.token
+  // CHECK: async.runtime.add_ref %[[TOKEN]] count = 1 : !async.token
   call @take_token(%arg0): (!async.token) -> ()
-  // CHECK: async.runtime.drop_ref %[[TOKEN]] {count = 1 : i64} : !async.token
+  // CHECK: async.runtime.drop_ref %[[TOKEN]] count = 1 : !async.token
   return
 }
 
@@ -45,9 +45,9 @@ func.func @token_arg_to_func(%arg0: !async.token) {
 func.func @token_value_to_func() {
   // CHECK: %[[TOKEN:.*]] = async.runtime.create : !async.token
   %0 = async.runtime.create : !async.token
-  // CHECK: async.runtime.add_ref %[[TOKEN]] {count = 1 : i64} : !async.token
+  // CHECK: async.runtime.add_ref %[[TOKEN]] count = 1 : !async.token
   call @take_token(%0): (!async.token) -> ()
-  // CHECK: async.runtime.drop_ref %[[TOKEN]] {count = 1 : i64}
+  // CHECK: async.runtime.drop_ref %[[TOKEN]] count = 1
   return
 }
 
@@ -64,7 +64,7 @@ func.func @token_arg_cond_br_await_with_fallthough(%arg0: !async.token, %arg1: i
 ^bb2:
   // CHECK: ^[[BB2]]:
   // CHECK:   async.runtime.await %[[TOKEN]]
-  // CHECK:   async.runtime.drop_ref %[[TOKEN]] {count = 1 : i64}
+  // CHECK:   async.runtime.drop_ref %[[TOKEN]] count = 1
   async.runtime.await %arg0 : !async.token
   return
 }
@@ -106,7 +106,7 @@ func.func @token_coro_await_and_resume(%arg0: !async.token) -> !async.token {
   %saved = async.coro.save %hdl
   // CHECK: async.runtime.await_and_resume %[[TOKEN]]
   async.runtime.await_and_resume %arg0, %hdl : !async.token
-  // CHECK-NEXT: async.runtime.drop_ref %[[TOKEN]] {count = 1 : i64}
+  // CHECK-NEXT: async.runtime.drop_ref %[[TOKEN]] count = 1
   async.coro.suspend %saved, ^suspend, ^resume, ^cleanup
 ^resume:
   cf.br ^cleanup
@@ -133,7 +133,7 @@ func.func @value_coro_await_and_resume(%arg0: !async.value<f32>) -> !async.token
 ^resume:
   // CHECK: ^[[RESUME]]:
   // CHECK:   %[[LOADED:.*]] = async.runtime.load %[[VALUE]]
-  // CHECK:   async.runtime.drop_ref %[[VALUE]] {count = 1 : i64}
+  // CHECK:   async.runtime.drop_ref %[[VALUE]] count = 1
   %0 = async.runtime.load %arg0 : !async.value<f32>
   // CHECK:  arith.addf %[[LOADED]], %[[LOADED]]
   %1 = arith.addf %0, %0 : f32
@@ -160,7 +160,7 @@ func.func private @outlined_async_execute(%arg0: !async.token) -> !async.token {
   // CHECK: ^[[RESUME:.*]]:
   %4 = async.coro.save %2
   async.runtime.await_and_resume %arg0, %2 : !async.token
-  // CHECK: async.runtime.drop_ref %[[TOKEN]] {count = 1 : i64}
+  // CHECK: async.runtime.drop_ref %[[TOKEN]] count = 1
   // CHECK: async.coro.suspend
   async.coro.suspend %4, ^suspend, ^resume_1, ^cleanup
 ^resume_1:
@@ -191,7 +191,7 @@ func.func @token_await_inside_nested_region(%arg0: i1) {
     async.runtime.await %token : !async.token
   }
   // CHECK: }
-  // CHECK: async.runtime.drop_ref %[[TOKEN]] {count = 1 : i64}
+  // CHECK: async.runtime.drop_ref %[[TOKEN]] count = 1
   // CHECK: return
   return
 }
@@ -204,7 +204,7 @@ func.func @token_defined_in_the_loop() {
   // CHECK:   %[[TOKEN:.*]] = call @token()
   %token = call @token() : () -> !async.token
   // CHECK:   async.runtime.await %[[TOKEN]]
-  // CHECK:   async.runtime.drop_ref %[[TOKEN]] {count = 1 : i64}
+  // CHECK:   async.runtime.drop_ref %[[TOKEN]] count = 1
   async.runtime.await %token : !async.token
   %0 = call @cond(): () -> (i1)
   cf.cond_br %0, ^bb1, ^bb2
@@ -223,12 +223,12 @@ func.func @divergent_liveness_one_token(%arg0 : i1) {
 ^bb1:
   // CHECK: ^[[LIVE_IN]]:
   // CHECK:   async.runtime.await %[[TOKEN]]
-  // CHECK:   async.runtime.drop_ref %[[TOKEN]] {count = 1 : i64}
+  // CHECK:   async.runtime.drop_ref %[[TOKEN]] count = 1
   // CHECK:   cf.br ^[[RETURN:.*]]
   async.runtime.await %token : !async.token
   cf.br ^bb2
   // CHECK: ^[[REF_COUNTING:.*]]:
-  // CHECK:   async.runtime.drop_ref %[[TOKEN]] {count = 1 : i64}
+  // CHECK:   async.runtime.drop_ref %[[TOKEN]] count = 1
   // CHECK:   cf.br ^[[RETURN:.*]]
 ^bb2:
   // CHECK: ^[[RETURN]]:
@@ -244,13 +244,13 @@ func.func @divergent_liveness_unique_predecessor(%arg0 : i1) {
   cf.cond_br %arg0, ^bb2, ^bb1
 ^bb1:
   // CHECK: ^[[NO_LIVE_IN]]:
-  // CHECK:   async.runtime.drop_ref %[[TOKEN]] {count = 1 : i64}
+  // CHECK:   async.runtime.drop_ref %[[TOKEN]] count = 1
   // CHECK:   cf.br ^[[RETURN:.*]]
   cf.br ^bb3
 ^bb2:
   // CHECK: ^[[LIVE_IN]]:
   // CHECK:   async.runtime.await %[[TOKEN]]
-  // CHECK:   async.runtime.drop_ref %[[TOKEN]] {count = 1 : i64}
+  // CHECK:   async.runtime.drop_ref %[[TOKEN]] count = 1
   // CHECK:   cf.br ^[[RETURN]]
   async.runtime.await %token : !async.token
   cf.br ^bb3
@@ -270,17 +270,17 @@ func.func @divergent_liveness_two_tokens(%arg0 : i1) {
   cf.cond_br %arg0, ^await0, ^await1
 ^await0:
   // CHECK: ^[[AWAIT0]]:
-  // CHECK:   async.runtime.drop_ref %[[TOKEN1]] {count = 1 : i64}
+  // CHECK:   async.runtime.drop_ref %[[TOKEN1]] count = 1
   // CHECK:   async.runtime.await %[[TOKEN0]]
-  // CHECK:   async.runtime.drop_ref %[[TOKEN0]] {count = 1 : i64}
+  // CHECK:   async.runtime.drop_ref %[[TOKEN0]] count = 1
   // CHECK:   cf.br ^[[RETURN:.*]]
   async.runtime.await %token0 : !async.token
   cf.br ^ret
 ^await1:
   // CHECK: ^[[AWAIT1]]:
-  // CHECK:   async.runtime.drop_ref %[[TOKEN0]] {count = 1 : i64}
+  // CHECK:   async.runtime.drop_ref %[[TOKEN0]] count = 1
   // CHECK:   async.runtime.await %[[TOKEN1]]
-  // CHECK:   async.runtime.drop_ref %[[TOKEN1]] {count = 1 : i64}
+  // CHECK:   async.runtime.drop_ref %[[TOKEN1]] count = 1
   // CHECK:   cf.br ^[[RETURN]]
   async.runtime.await %token1 : !async.token
   cf.br ^ret

--- a/mlir/test/Dialect/Async/runtime.mlir
+++ b/mlir/test/Dialect/Async/runtime.mlir
@@ -154,14 +154,14 @@ func.func @add_to_group(%arg0: !async.token, %arg1: !async.value<f32>,
 
 // CHECK-LABEL: @add_ref
 func.func @add_ref(%arg0: !async.token) {
-  // CHECK: async.runtime.add_ref %arg0 {count = 1 : i64}
-  async.runtime.add_ref %arg0 {count = 1 : i64} : !async.token
+  // CHECK: async.runtime.add_ref %arg0 count = 1
+  async.runtime.add_ref %arg0 count = 1 : !async.token
   return
 }
 
 // CHECK-LABEL: @drop_ref
 func.func @drop_ref(%arg0: !async.token) {
-  // CHECK: async.runtime.drop_ref %arg0 {count = 1 : i64}
-  async.runtime.drop_ref %arg0 {count = 1 : i64} : !async.token
+  // CHECK: async.runtime.drop_ref %arg0 count = 1
+  async.runtime.drop_ref %arg0 count = 1 : !async.token
   return
 }


### PR DESCRIPTION
Enable the strict properties assembly format mode for the Async dialect. Spell call argument/result attribute arrays and runtime reference counts directly in assembly formats so they are not parsed from attr-dict in strict mode.

Assisted-by: Codex