### PR TITLE
[APInt] Extend APIntOps::gcd to take IsSigned argument

### DIFF
--- a/llvm/include/llvm/ADT/APInt.h
+++ b/llvm/include/llvm/ADT/APInt.h
@@ -2339,7 +2339,8 @@ LLVM_ABI APInt pow(const APInt &X, int64_t N);
 /// \returns the greatest common divisor of A and B.
 LLVM_ABI APInt GreatestCommonDivisor(APInt A, APInt B);
 
-/// Compute GCD of two signed APInt values.
+/// Compute GCD of two signed APInt values. It takes the absolute value of the
+/// both \p A and \p B, and returns the unsigned greatest common divisor.
 LLVM_ABI APInt SGreatestCommonDivisor(APInt A, APInt B);
 
 /// Converts the given APInt to a double value.

--- a/llvm/include/llvm/ADT/APInt.h
+++ b/llvm/include/llvm/ADT/APInt.h
@@ -2331,17 +2331,15 @@ LLVM_ABI APInt muluExtended(const APInt &C1, const APInt &C2);
 /// 0^0 is supported and returns 1.
 LLVM_ABI APInt pow(const APInt &X, int64_t N);
 
-/// Compute GCD of two unsigned APInt values.
+/// Compute GCD of two APInt values.
 ///
 /// This function returns the greatest common divisor of the two APInt values
 /// using Stein's algorithm.
 ///
-/// \returns the greatest common divisor of A and B.
-LLVM_ABI APInt GreatestCommonDivisor(APInt A, APInt B);
-
-/// Compute GCD of two signed APInt values. It takes the absolute value of the
-/// both \p A and \p B, and returns the unsigned greatest common divisor.
-LLVM_ABI APInt SGreatestCommonDivisor(APInt A, APInt B);
+/// \returns the greatest common divisor of A and B. If \p Signed is true, it
+/// takes the absolute value of the both arguments, and returns the unsigned
+/// greatest common divisor.
+LLVM_ABI APInt GreatestCommonDivisor(APInt A, APInt B, bool IsSigned = false);
 
 /// Converts the given APInt to a double value.
 ///

--- a/llvm/include/llvm/ADT/APInt.h
+++ b/llvm/include/llvm/ADT/APInt.h
@@ -2339,6 +2339,9 @@ LLVM_ABI APInt pow(const APInt &X, int64_t N);
 /// \returns the greatest common divisor of A and B.
 LLVM_ABI APInt GreatestCommonDivisor(APInt A, APInt B);
 
+/// Compute GCD of two signed APInt values.
+LLVM_ABI APInt SGreatestCommonDivisor(APInt A, APInt B);
+
 /// Converts the given APInt to a double value.
 ///
 /// Treats the APInt as an unsigned value for conversion purposes.

--- a/llvm/lib/Support/APInt.cpp
+++ b/llvm/lib/Support/APInt.cpp
@@ -866,14 +866,7 @@ APInt llvm::APIntOps::GreatestCommonDivisor(APInt A, APInt B) {
 }
 
 APInt llvm::APIntOps::SGreatestCommonDivisor(APInt A, APInt B) {
-  if (A.isNegative()) {
-    if (B.isNegative())
-      return GreatestCommonDivisor(-A, -B);
-    return -GreatestCommonDivisor(-A, B);
-  }
-  if (B.isNegative())
-    return -GreatestCommonDivisor(A, -B);
-  return GreatestCommonDivisor(A, B);
+  return GreatestCommonDivisor(A.abs(), B.abs());
 }
 
 APInt llvm::APIntOps::RoundDoubleToAPInt(double Double, unsigned width) {

--- a/llvm/lib/Support/APInt.cpp
+++ b/llvm/lib/Support/APInt.cpp
@@ -865,6 +865,17 @@ APInt llvm::APIntOps::GreatestCommonDivisor(APInt A, APInt B) {
   return A;
 }
 
+APInt llvm::APIntOps::SGreatestCommonDivisor(APInt A, APInt B) {
+  if (A.isNegative()) {
+    if (B.isNegative())
+      return GreatestCommonDivisor(-A, -B);
+    return -GreatestCommonDivisor(-A, B);
+  }
+  if (B.isNegative())
+    return -GreatestCommonDivisor(A, -B);
+  return GreatestCommonDivisor(A, B);
+}
+
 APInt llvm::APIntOps::RoundDoubleToAPInt(double Double, unsigned width) {
   uint64_t I = bit_cast<uint64_t>(Double);
 

--- a/llvm/lib/Support/APInt.cpp
+++ b/llvm/lib/Support/APInt.cpp
@@ -822,7 +822,13 @@ APInt APInt::reverseBits() const {
   return Result;
 }
 
-APInt llvm::APIntOps::GreatestCommonDivisor(APInt A, APInt B) {
+APInt llvm::APIntOps::GreatestCommonDivisor(APInt A, APInt B, bool IsSigned) {
+  // Take absolute value if IsSigned.
+  if (IsSigned) {
+    A = A.abs();
+    B = B.abs();
+  }
+
   // Fast-path a common case.
   if (A == B) return A;
 
@@ -863,10 +869,6 @@ APInt llvm::APIntOps::GreatestCommonDivisor(APInt A, APInt B) {
   }
 
   return A;
-}
-
-APInt llvm::APIntOps::SGreatestCommonDivisor(APInt A, APInt B) {
-  return GreatestCommonDivisor(A.abs(), B.abs());
 }
 
 APInt llvm::APIntOps::RoundDoubleToAPInt(double Double, unsigned width) {

--- a/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
@@ -1405,9 +1405,7 @@ Instruction *InstCombinerImpl::commonIDivTransforms(BinaryOperator &I) {
 
       // (X * C1) / C2 -> (X * (C1/D)) / (C2/D) if D = gcd(C1, C2) > 1.
       if (Op0->hasOneUse()) {
-        APInt GCD = IsSigned
-                        ? APIntOps::GreatestCommonDivisor(C1->abs(), C2->abs())
-                        : APIntOps::GreatestCommonDivisor(*C1, *C2);
+        APInt GCD = APIntOps::GreatestCommonDivisor(*C1, *C2, IsSigned);
         if (GCD.ugt(1)) {
           APInt NewC1 = IsSigned ? C1->sdiv(GCD) : C1->udiv(GCD);
           APInt NewC2 = IsSigned ? C2->sdiv(GCD) : C2->udiv(GCD);

--- a/llvm/unittests/ADT/APIntTest.cpp
+++ b/llvm/unittests/ADT/APIntTest.cpp
@@ -2920,6 +2920,15 @@ TEST(APIntTest, GCD) {
       EXPECT_EQ(SGreatestCommonDivisor(MinusTwo, Max), One);
       EXPECT_EQ(SGreatestCommonDivisor(Max, Max), One);
 
+      // Test some corner cases near the minimum signed value.
+      APInt SMin = APInt::getSignedMinValue(Bits);
+      EXPECT_EQ(SGreatestCommonDivisor(Zero, SMin), SMin);
+      EXPECT_EQ(SGreatestCommonDivisor(MinusOne, SMin), One);
+      EXPECT_EQ(SGreatestCommonDivisor(MinusTwo, SMin), Two);
+      EXPECT_EQ(SGreatestCommonDivisor(One, SMin), MinusOne);
+      EXPECT_EQ(SGreatestCommonDivisor(Two, SMin), MinusTwo);
+      EXPECT_EQ(SGreatestCommonDivisor(SMin, SMin), SMin);
+
       APInt MaxOver2 = Max.udiv(Two);
       EXPECT_EQ(GreatestCommonDivisor(MaxOver2, Max), One);
       // Max - 1 == Max / 2 * 2, because Max is odd.

--- a/llvm/unittests/ADT/APIntTest.cpp
+++ b/llvm/unittests/ADT/APIntTest.cpp
@@ -2905,7 +2905,7 @@ TEST(APIntTest, GCD) {
       EXPECT_EQ(SGreatestCommonDivisor(Zero, MinusTwo), Two);
       EXPECT_EQ(SGreatestCommonDivisor(MinusOne, MinusTwo), One);
       EXPECT_EQ(SGreatestCommonDivisor(One, MinusTwo), One);
-      EXPECT_EQ(GreatestCommonDivisor(MinusTwo, MinusTwo), MinusTwo);
+      EXPECT_EQ(SGreatestCommonDivisor(MinusTwo, MinusTwo), Two);
 
       // Test some corner cases near the highest representable value.
       APInt Max(Bits, 0);

--- a/llvm/unittests/ADT/APIntTest.cpp
+++ b/llvm/unittests/ADT/APIntTest.cpp
@@ -2902,9 +2902,9 @@ TEST(APIntTest, GCD) {
       EXPECT_EQ(GreatestCommonDivisor(One, Two), One);
       EXPECT_EQ(GreatestCommonDivisor(Two, Two), Two);
 
-      EXPECT_EQ(SGreatestCommonDivisor(Zero, MinusTwo), MinusTwo);
+      EXPECT_EQ(SGreatestCommonDivisor(Zero, MinusTwo), Two);
       EXPECT_EQ(SGreatestCommonDivisor(MinusOne, MinusTwo), One);
-      EXPECT_EQ(SGreatestCommonDivisor(One, MinusTwo), MinusOne);
+      EXPECT_EQ(SGreatestCommonDivisor(One, MinusTwo), One);
       EXPECT_EQ(GreatestCommonDivisor(MinusTwo, MinusTwo), MinusTwo);
 
       // Test some corner cases near the highest representable value.
@@ -2915,7 +2915,7 @@ TEST(APIntTest, GCD) {
       EXPECT_EQ(GreatestCommonDivisor(Two, Max), One);
       EXPECT_EQ(GreatestCommonDivisor(Max, Max), Max);
 
-      EXPECT_EQ(SGreatestCommonDivisor(Zero, Max), Max);
+      EXPECT_EQ(SGreatestCommonDivisor(Zero, Max), One);
       EXPECT_EQ(SGreatestCommonDivisor(MinusOne, Max), One);
       EXPECT_EQ(SGreatestCommonDivisor(MinusTwo, Max), One);
       EXPECT_EQ(SGreatestCommonDivisor(Max, Max), One);
@@ -2925,8 +2925,8 @@ TEST(APIntTest, GCD) {
       EXPECT_EQ(SGreatestCommonDivisor(Zero, SMin), SMin);
       EXPECT_EQ(SGreatestCommonDivisor(MinusOne, SMin), One);
       EXPECT_EQ(SGreatestCommonDivisor(MinusTwo, SMin), Two);
-      EXPECT_EQ(SGreatestCommonDivisor(One, SMin), MinusOne);
-      EXPECT_EQ(SGreatestCommonDivisor(Two, SMin), MinusTwo);
+      EXPECT_EQ(SGreatestCommonDivisor(One, SMin), One);
+      EXPECT_EQ(SGreatestCommonDivisor(Two, SMin), Two);
       EXPECT_EQ(SGreatestCommonDivisor(SMin, SMin), SMin);
 
       APInt MaxOver2 = Max.udiv(Two);

--- a/llvm/unittests/ADT/APIntTest.cpp
+++ b/llvm/unittests/ADT/APIntTest.cpp
@@ -2886,7 +2886,6 @@ TEST(APIntTest, abdu) {
 
 TEST(APIntTest, GCD) {
   using APIntOps::GreatestCommonDivisor;
-  using APIntOps::SGreatestCommonDivisor;
 
   for (unsigned Bits : {1, 2, 32, 63, 64, 65}) {
     // Test some corner cases near zero.
@@ -2902,10 +2901,12 @@ TEST(APIntTest, GCD) {
       EXPECT_EQ(GreatestCommonDivisor(One, Two), One);
       EXPECT_EQ(GreatestCommonDivisor(Two, Two), Two);
 
-      EXPECT_EQ(SGreatestCommonDivisor(Zero, MinusTwo), Two);
-      EXPECT_EQ(SGreatestCommonDivisor(MinusOne, MinusTwo), One);
-      EXPECT_EQ(SGreatestCommonDivisor(One, MinusTwo), One);
-      EXPECT_EQ(SGreatestCommonDivisor(MinusTwo, MinusTwo), Two);
+      EXPECT_EQ(GreatestCommonDivisor(Zero, MinusTwo, /*IsSigned=*/true), Two);
+      EXPECT_EQ(GreatestCommonDivisor(MinusOne, MinusTwo, /*IsSigned=*/true),
+                One);
+      EXPECT_EQ(GreatestCommonDivisor(One, MinusTwo, /*IsSigned=*/true), One);
+      EXPECT_EQ(GreatestCommonDivisor(MinusTwo, MinusTwo, /*IsSigned=*/true),
+                Two);
 
       // Test some corner cases near the highest representable value.
       APInt Max(Bits, 0);
@@ -2915,19 +2916,19 @@ TEST(APIntTest, GCD) {
       EXPECT_EQ(GreatestCommonDivisor(Two, Max), One);
       EXPECT_EQ(GreatestCommonDivisor(Max, Max), Max);
 
-      EXPECT_EQ(SGreatestCommonDivisor(Zero, Max), One);
-      EXPECT_EQ(SGreatestCommonDivisor(MinusOne, Max), One);
-      EXPECT_EQ(SGreatestCommonDivisor(MinusTwo, Max), One);
-      EXPECT_EQ(SGreatestCommonDivisor(Max, Max), One);
+      EXPECT_EQ(GreatestCommonDivisor(Zero, Max, /*IsSigned=*/true), One);
+      EXPECT_EQ(GreatestCommonDivisor(MinusOne, Max, /*IsSigned=*/true), One);
+      EXPECT_EQ(GreatestCommonDivisor(MinusTwo, Max, /*IsSigned=*/true), One);
+      EXPECT_EQ(GreatestCommonDivisor(Max, Max, /*IsSigned=*/true), One);
 
       // Test some corner cases near the minimum signed value.
       APInt SMin = APInt::getSignedMinValue(Bits);
-      EXPECT_EQ(SGreatestCommonDivisor(Zero, SMin), SMin);
-      EXPECT_EQ(SGreatestCommonDivisor(MinusOne, SMin), One);
-      EXPECT_EQ(SGreatestCommonDivisor(MinusTwo, SMin), Two);
-      EXPECT_EQ(SGreatestCommonDivisor(One, SMin), One);
-      EXPECT_EQ(SGreatestCommonDivisor(Two, SMin), Two);
-      EXPECT_EQ(SGreatestCommonDivisor(SMin, SMin), SMin);
+      EXPECT_EQ(GreatestCommonDivisor(Zero, SMin, /*IsSigned=*/true), SMin);
+      EXPECT_EQ(GreatestCommonDivisor(MinusOne, SMin, /*IsSigned=*/true), One);
+      EXPECT_EQ(GreatestCommonDivisor(MinusTwo, SMin, /*IsSigned=*/true), Two);
+      EXPECT_EQ(GreatestCommonDivisor(One, SMin, /*IsSigned=*/true), One);
+      EXPECT_EQ(GreatestCommonDivisor(Two, SMin, /*IsSigned=*/true), Two);
+      EXPECT_EQ(GreatestCommonDivisor(SMin, SMin, /*IsSigned=*/true), SMin);
 
       APInt MaxOver2 = Max.udiv(Two);
       EXPECT_EQ(GreatestCommonDivisor(MaxOver2, Max), One);
@@ -2947,7 +2948,7 @@ TEST(APIntTest, GCD) {
   APInt SB = HugePrime * APInt(BitWidth, -123456, true);
   APInt C = GreatestCommonDivisor(A, B);
   EXPECT_EQ(C, HugePrime);
-  APInt SC = SGreatestCommonDivisor(SA, SB);
+  APInt SC = GreatestCommonDivisor(SA, SB, /*IsSigned=*/true);
   EXPECT_EQ(SC, HugePrime);
 }
 

--- a/llvm/unittests/ADT/APIntTest.cpp
+++ b/llvm/unittests/ADT/APIntTest.cpp
@@ -2886,20 +2886,26 @@ TEST(APIntTest, abdu) {
 
 TEST(APIntTest, GCD) {
   using APIntOps::GreatestCommonDivisor;
+  using APIntOps::SGreatestCommonDivisor;
 
   for (unsigned Bits : {1, 2, 32, 63, 64, 65}) {
     // Test some corner cases near zero.
-    APInt Zero(Bits, 0), One(Bits, 1);
+    APInt Zero(Bits, 0), One(Bits, 1), MinusOne(Bits, -1, true);
     EXPECT_EQ(GreatestCommonDivisor(Zero, Zero), Zero);
     EXPECT_EQ(GreatestCommonDivisor(Zero, One), One);
     EXPECT_EQ(GreatestCommonDivisor(One, Zero), One);
     EXPECT_EQ(GreatestCommonDivisor(One, One), One);
 
     if (Bits > 1) {
-      APInt Two(Bits, 2);
+      APInt Two(Bits, 2), MinusTwo(Bits, -2, true);
       EXPECT_EQ(GreatestCommonDivisor(Zero, Two), Two);
       EXPECT_EQ(GreatestCommonDivisor(One, Two), One);
       EXPECT_EQ(GreatestCommonDivisor(Two, Two), Two);
+
+      EXPECT_EQ(SGreatestCommonDivisor(Zero, MinusTwo), MinusTwo);
+      EXPECT_EQ(SGreatestCommonDivisor(MinusOne, MinusTwo), One);
+      EXPECT_EQ(SGreatestCommonDivisor(One, MinusTwo), MinusOne);
+      EXPECT_EQ(GreatestCommonDivisor(MinusTwo, MinusTwo), MinusTwo);
 
       // Test some corner cases near the highest representable value.
       APInt Max(Bits, 0);
@@ -2908,6 +2914,11 @@ TEST(APIntTest, GCD) {
       EXPECT_EQ(GreatestCommonDivisor(One, Max), One);
       EXPECT_EQ(GreatestCommonDivisor(Two, Max), One);
       EXPECT_EQ(GreatestCommonDivisor(Max, Max), Max);
+
+      EXPECT_EQ(SGreatestCommonDivisor(Zero, Max), Max);
+      EXPECT_EQ(SGreatestCommonDivisor(MinusOne, Max), One);
+      EXPECT_EQ(SGreatestCommonDivisor(MinusTwo, Max), One);
+      EXPECT_EQ(SGreatestCommonDivisor(Max, Max), One);
 
       APInt MaxOver2 = Max.udiv(Two);
       EXPECT_EQ(GreatestCommonDivisor(MaxOver2, Max), One);
@@ -2923,8 +2934,12 @@ TEST(APIntTest, GCD) {
   // 9931 and 123456 are coprime.
   APInt A = HugePrime * APInt(BitWidth, 9931);
   APInt B = HugePrime * APInt(BitWidth, 123456);
+  APInt SA = HugePrime * APInt(BitWidth, -9931, true);
+  APInt SB = HugePrime * APInt(BitWidth, -123456, true);
   APInt C = GreatestCommonDivisor(A, B);
   EXPECT_EQ(C, HugePrime);
+  APInt SC = SGreatestCommonDivisor(SA, SB);
+  EXPECT_EQ(SC, HugePrime);
 }
 
 TEST(APIntTest, LogicalRightShift) {


### PR DESCRIPTION
This clarifies the semantics of APIntOps::GreatestCommonDivisor for signed arguments.