### PR TITLE
[MLIR][Bufferization] Enable strict property assembly format

### DIFF
--- a/mlir/include/mlir/Dialect/Bufferization/IR/BufferizationBase.td
+++ b/mlir/include/mlir/Dialect/Bufferization/IR/BufferizationBase.td
@@ -31,6 +31,7 @@ def Bufferization_Dialect : Dialect {
     "affine::AffineDialect", "memref::MemRefDialect", "tensor::TensorDialect",
     "arith::ArithDialect"
   ];
+  let useStrictPropertiesInAssemblyFormat = 1;
 
   let extraClassDeclaration = [{
     /// Verify an attribute from this dialect on the argument at 'argIndex' for

--- a/mlir/test/Dialect/Bufferization/Transforms/one-shot-bufferize-analysis.mlir
+++ b/mlir/test/Dialect/Bufferization/Transforms/one-shot-bufferize-analysis.mlir
@@ -112,7 +112,7 @@ func.func @to_buffer_read_only(%idx : index, %f: f32) -> f32 {
   // Some op may write into the result of to_buffer later.
   // CHECK: bufferization.to_buffer
   // CHECK-SAME: {__inplace_operands_attr__ = ["true"]}
-  %m = bufferization.to_buffer %t {read_only} : tensor<5xf32> to memref<5xf32>
+  %m = bufferization.to_buffer %t read_only : tensor<5xf32> to memref<5xf32>
   %2 = tensor.extract %t[%idx] : tensor<5xf32>
   return %2 : f32
 }


### PR DESCRIPTION
Enable strict properties-in-assembly-format mode for Bufferization.

Update the remaining test case that spelled the read_only inherent
attribute through attr-dict so it uses the declarative keyword form.

Assisted-by: Codex