### PR TITLE
[MLIR][MemRef] Enable strict property assembly format

### DIFF
--- a/mlir/docs/Bufferization.md
+++ b/mlir/docs/Bufferization.md
@@ -456,11 +456,11 @@ func.func @test(%arg0: f32, %arg1: f32, %arg2: index, %arg3: index) -> (f32, mem
   %c2 = arith.constant 2 : index
   %c1 = arith.constant 1 : index
   %c0 = arith.constant 0 : index
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<3xf32>
+  %alloc = memref.alloc() alignment = 64 : memref<3xf32>
   memref.store %arg0, %alloc[%c0] : memref<3xf32>
   memref.store %arg0, %alloc[%c1] : memref<3xf32>
   memref.store %arg0, %alloc[%c2] : memref<3xf32>
-  %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<3xf32>
+  %alloc_0 = memref.alloc() alignment = 64 : memref<3xf32>
   memref.copy %alloc, %alloc_0 : memref<3xf32> to memref<3xf32>
   memref.store %arg1, %alloc_0[%arg2] : memref<3xf32>
   %0 = memref.load %alloc[%arg3] : memref<3xf32>

--- a/mlir/include/mlir/Dialect/MemRef/IR/MemRefBase.td
+++ b/mlir/include/mlir/Dialect/MemRef/IR/MemRefBase.td
@@ -14,6 +14,7 @@ include "mlir/IR/OpBase.td"
 def MemRef_Dialect : Dialect {
   let name = "memref";
   let cppNamespace = "::mlir::memref";
+  let useStrictPropertiesInAssemblyFormat = 1;
   let description = [{
     The `memref` dialect is intended to hold core memref creation and
     manipulation ops, which are not strongly associated with any particular

--- a/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
+++ b/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
@@ -134,7 +134,8 @@ class AllocLikeOp<string mnemonic,
   }];
 
   let assemblyFormat = [{
-    `(`$dynamicSizes`)` (`` `[` $symbolOperands^ `]`)? attr-dict `:` type($memref)
+    `(`$dynamicSizes`)` (`` `[` $symbolOperands^ `]`)?
+    (`alignment` `=` $alignment^)? attr-dict `:` type($memref)
   }];
 
   let hasCanonicalizer = 1;
@@ -261,7 +262,7 @@ def MemRef_AllocOp : AllocLikeOp<"alloc", DefaultResource, [
     boundary.
 
     ```mlir
-    %0 = memref.alloc()[%s] {alignment = 8} :
+    %0 = memref.alloc()[%s] alignment = 8 :
       memref<8x64xf32, affine_map<(d0, d1)[s0] -> ((d0 + s0), d1)>, 1>
     ```
   }];
@@ -320,7 +321,7 @@ def MemRef_ReallocOp : MemRef_Op<"realloc",
     aligned_realloc.
 
     ```mlir
-    %3 = memref.realloc %src {alignment = 8} : memref<64xf32> to memref<124xf32>
+    %3 = memref.realloc %src alignment = 8 : memref<64xf32> to memref<124xf32>
     ```
 
     Referencing the memref through the old SSA value after realloc is undefined
@@ -360,7 +361,8 @@ def MemRef_ReallocOp : MemRef_Op<"realloc",
   }];
 
   let assemblyFormat = [{
-    $source (`(` $dynamicResultSize^ `)`)? attr-dict
+    $source (`(` $dynamicResultSize^ `)`)?
+    (`alignment` `=` $alignment^)? attr-dict
     `:` type($source) `to` type(results)
   }];
 
@@ -1215,7 +1217,7 @@ def MemRef_GlobalOp : MemRef_Op<"global", [Symbol,
     memref.global "private" @x : memref<2xf32> = dense<[0.0, 2.0]>
 
     // Private variable with an initial value and an alignment (power of 2).
-    memref.global "private" @x : memref<2xf32> = dense<[0.0, 2.0]> {alignment = 64}
+    memref.global "private" @x : memref<2xf32> = dense<[0.0, 2.0]> alignment = 64
 
     // Declaration of an external variable.
     memref.global "private" @y : memref<4xi32>
@@ -1240,7 +1242,7 @@ def MemRef_GlobalOp : MemRef_Op<"global", [Symbol,
        (`constant` $constant^)?
        $sym_name `:`
        custom<GlobalMemrefOpTypeAndInitialValue>($type, $initial_value)
-       attr-dict
+       (`alignment` `=` $alignment^)? attr-dict
   }];
 
   let extraClassDeclaration = [{
@@ -1358,7 +1360,15 @@ def LoadOp : MemRef_Op<"load",
 
   let hasFolder = 1;
 
-  let assemblyFormat = "$memref `[` $indices `]` attr-dict `:` type($memref)";
+  let assemblyFormat = [{
+    $memref `[` $indices `]`
+    oilist(
+      `alignment` `(` $alignment `)` |
+      `nontemporal` `(` custom<BoolAttr>($nontemporal) `)` |
+      `invariant` `(` custom<BoolAttr>($invariant) `)`
+    )
+    attr-dict `:` type($memref)
+  }];
 }
 
 //===----------------------------------------------------------------------===//
@@ -2127,7 +2137,12 @@ def MemRef_StoreOp : MemRef_Op<"store",
   let hasFolder = 1;
 
   let assemblyFormat = [{
-    $value `,` $memref `[` $indices `]` attr-dict `:` type($memref)
+    $value `,` $memref `[` $indices `]`
+    oilist(
+      `alignment` `(` $alignment `)` |
+      `nontemporal` `(` custom<BoolAttr>($nontemporal) `)`
+    )
+    attr-dict `:` type($memref)
   }];
 }
 

--- a/mlir/lib/Dialect/MemRef/IR/MemRefOps.cpp
+++ b/mlir/lib/Dialect/MemRef/IR/MemRefOps.cpp
@@ -1803,6 +1803,21 @@ GetGlobalOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 // LoadOp
 //===----------------------------------------------------------------------===//
 
+static ParseResult parseBoolAttr(OpAsmParser &parser, BoolAttr &result) {
+  Attribute attr;
+  if (parser.parseAttribute(attr))
+    return failure();
+  result = dyn_cast<BoolAttr>(attr);
+  if (!result)
+    return parser.emitError(parser.getCurrentLocation(),
+                            "expected boolean attribute");
+  return success();
+}
+
+static void printBoolAttr(OpAsmPrinter &printer, Operation *, BoolAttr attr) {
+  printer.printAttribute(attr);
+}
+
 OpFoldResult LoadOp::fold(FoldAdaptor adaptor) {
   /// load(memrefcast) -> load
   if (succeeded(foldMemRefCast(*this)))

--- a/mlir/test/Conversion/AffineToStandard/lower-affine.mlir
+++ b/mlir/test/Conversion/AffineToStandard/lower-affine.mlir
@@ -935,9 +935,9 @@ func.func @affine_parallel_with_reductions_i64(%arg0: memref<3x3xi64>, %arg1: me
 
 // CHECK-LABEL: func @affine_load_store_alignment
 func.func @affine_load_store_alignment(%memref: memref<4xi32>) {
-  // CHECK: memref.load {{.*}} {alignment = 16 : i64}
+  // CHECK: memref.load {{.*}} alignment(16)
   %val = affine.load %memref[0] { alignment = 16 } : memref<4xi32>
-  // CHECK: memref.store {{.*}} {alignment = 16 : i64}
+  // CHECK: memref.store {{.*}} alignment(16)
   affine.store %val, %memref[0] { alignment = 16 } : memref<4xi32>
   return
 }

--- a/mlir/test/Conversion/GPUToNVVM/wmma-ops-to-nvvm.mlir
+++ b/mlir/test/Conversion/GPUToNVVM/wmma-ops-to-nvvm.mlir
@@ -8,7 +8,7 @@ gpu.module @test_module {
   // CHECK-SAME: !llvm.struct<(vector<2xf16>, vector<2xf16>, vector<2xf16>, vector<2xf16>, vector<2xf16>, vector<2xf16>, vector<2xf16>, vector<2xf16>)>
   // CHECK32-LABEL: func @gpu_wmma_load_op() ->
   func.func @gpu_wmma_load_op() -> (!gpu.mma_matrix<16x16xf16, "AOp">) {
-    %wg = memref.alloca() {alignment = 32} : memref<32x32xf16, 3>
+    %wg = memref.alloca() alignment = 32 : memref<32x32xf16, 3>
     %i = arith.constant 16 : index
     %j = arith.constant 16 : index
     %0 = gpu.subgroup_mma_load_matrix %wg[%i, %j] {leadDimension = 32 : index, transpose} : memref<32x32xf16, 3> -> !gpu.mma_matrix<16x16xf16, "AOp">
@@ -47,7 +47,7 @@ gpu.module @test_module {
   // CHECK-SAME: !llvm.struct<(i32, i32)>
   // CHECK32-LABEL: func @gpu_wmma_int8_load_op() ->
   func.func @gpu_wmma_int8_load_op() -> (!gpu.mma_matrix<16x16xsi8, "AOp">) {
-    %wg = memref.alloca() {alignment = 32} : memref<32x32xi8, 3>
+    %wg = memref.alloca() alignment = 32 : memref<32x32xi8, 3>
     %i = arith.constant 16 : index
     %j = arith.constant 16 : index
     %0 = gpu.subgroup_mma_load_matrix %wg[%i, %j] {leadDimension = 32 : index, transpose} : memref<32x32xi8, 3> -> !gpu.mma_matrix<16x16xsi8, "AOp">
@@ -86,7 +86,7 @@ gpu.module @test_module {
   // CHECK-SAME: f64
   // CHECK32-LABEL: func @gpu_wmma_f64_load_op() ->
   func.func @gpu_wmma_f64_load_op() -> (!gpu.mma_matrix<8x4xf64, "AOp">) {
-    %wg = memref.alloca() {alignment = 32} : memref<32x32xf64, 3>
+    %wg = memref.alloca() alignment = 32 : memref<32x32xf64, 3>
     %i = arith.constant 16 : index
     %j = arith.constant 16 : index
     %0 = gpu.subgroup_mma_load_matrix %wg[%i, %j] {leadDimension = 32 : index} : memref<32x32xf64, 3> -> !gpu.mma_matrix<8x4xf64, "AOp">
@@ -109,7 +109,7 @@ gpu.module @test_module {
   // CHECK32-LABEL: func @gpu_wmma_store_op
   // CHECK32-SAME: (%[[D:.*]]: !llvm.struct<(vector<2xf16>, vector<2xf16>, vector<2xf16>, vector<2xf16>)>)
   func.func @gpu_wmma_store_op(%arg0 : !gpu.mma_matrix<16x16xf16, "COp">) -> () {
-    %sg = memref.alloca(){alignment = 32} : memref<32x32xf16, 3>
+    %sg = memref.alloca() alignment = 32 : memref<32x32xf16, 3>
     %i = arith.constant 16 : index
     %j = arith.constant 16 : index
     gpu.subgroup_mma_store_matrix %arg0, %sg[%i,%j] {leadDimension= 32 : index, transpose} : !gpu.mma_matrix<16x16xf16, "COp">, memref<32x32xf16, 3>

--- a/mlir/test/Conversion/MemRefToEmitC/memref-to-emitc-alloc-dealloc.mlir
+++ b/mlir/test/Conversion/MemRefToEmitC/memref-to-emitc-alloc-dealloc.mlir
@@ -37,7 +37,7 @@ func.func @alloc_and_dealloc() {
 // NOCPP-NEXT:   return
 
 func.func @alloc_and_dealloc_aligned() {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<999xf32>
+  %alloc = memref.alloc() alignment = 64 : memref<999xf32>
   memref.dealloc %alloc : memref<999xf32>
   return
 }

--- a/mlir/test/Conversion/MemRefToEmitC/memref-to-emitc-failed.mlir
+++ b/mlir/test/Conversion/MemRefToEmitC/memref-to-emitc-failed.mlir
@@ -11,7 +11,7 @@ func.func @alloca_with_dynamic_shape() {
 
 func.func @alloca_with_alignment() {
   // expected-error@+1 {{failed to legalize operation 'memref.alloca'}}
-  %0 = memref.alloca() {alignment = 64 : i64}: memref<4xf32>
+  %0 = memref.alloca() alignment = 64: memref<4xf32>
   return
 }
 

--- a/mlir/test/Conversion/MemRefToLLVM/convert-dynamic-memref-ops.mlir
+++ b/mlir/test/Conversion/MemRefToLLVM/convert-dynamic-memref-ops.mlir
@@ -105,7 +105,7 @@ func.func @dynamic_alloca(%arg0: index, %arg1: index) -> memref<?x?xf32> {
 // CHECK: %[[desc:.*]] = llvm.mlir.poison : !llvm.struct<(ptr, ptr, i64, array<2 x i64>, array<2 x i64>)>
 // CHECK: %[[desc1:.*]] = llvm.insertvalue %[[alloca_aligned]], %[[desc]][0] : !llvm.struct<(ptr, ptr, i64, array<2 x i64>, array<2 x i64>)>
 // CHECK: llvm.insertvalue %[[alloca_aligned]], %[[desc1]][1] : !llvm.struct<(ptr, ptr, i64, array<2 x i64>, array<2 x i64>)>
-  memref.alloca(%arg0, %arg1) {alignment = 32} : memref<?x?xf32>
+  memref.alloca(%arg0, %arg1) alignment = 32 : memref<?x?xf32>
   return %0 : memref<?x?xf32>
 }
 
@@ -133,11 +133,11 @@ func.func @stdlib_aligned_alloc(%N : index) -> memref<32x18xf32> {
 // ALIGNED-ALLOC-NEXT:  %[[bytes:.*]] = llvm.ptrtoint %[[gep]] : !llvm.ptr to i64
 // ALIGNED-ALLOC-NEXT:  %[[alignment:.*]] = llvm.mlir.constant(32 : index) : i64
 // ALIGNED-ALLOC-NEXT:  %[[allocated:.*]] = llvm.call @aligned_alloc(%[[alignment]], %[[bytes]]) : (i64, i64) -> !llvm.ptr
-  %0 = memref.alloc() {alignment = 32} : memref<32x18xf32>
+  %0 = memref.alloc() alignment = 32 : memref<32x18xf32>
   // Do another alloc just to test that we have a unique declaration for
   // aligned_alloc.
   // ALIGNED-ALLOC:  llvm.call @aligned_alloc
-  %1 = memref.alloc() {alignment = 64} : memref<4096xf32>
+  %1 = memref.alloc() alignment = 64 : memref<4096xf32>
 
   // Alignment is to element type boundaries (minimum 16 bytes).
   // ALIGNED-ALLOC:  %[[c32:.*]] = llvm.mlir.constant(32 : index) : i64
@@ -149,7 +149,7 @@ func.func @stdlib_aligned_alloc(%N : index) -> memref<32x18xf32> {
   %3 = memref.alloc() : memref<4096xvector<2xf32>>
   // ALIGNED-ALLOC:  %[[c8:.*]] = llvm.mlir.constant(8 : index) : i64
   // ALIGNED-ALLOC-NEXT:  llvm.call @aligned_alloc(%[[c8]],
-  %4 = memref.alloc() {alignment = 8} : memref<1024xvector<4xf32>>
+  %4 = memref.alloc() alignment = 8 : memref<1024xvector<4xf32>>
   // Bump the memref allocation size if its size is not a multiple of alignment.
   // ALIGNED-ALLOC:       %[[c32:.*]] = llvm.mlir.constant(32 : index) : i64
   // ALIGNED-ALLOC:       llvm.mlir.constant(1 : index) : i64
@@ -158,7 +158,7 @@ func.func @stdlib_aligned_alloc(%N : index) -> memref<32x18xf32> {
   // ALIGNED-ALLOC-NEXT:  llvm.urem
   // ALIGNED-ALLOC-NEXT:  %[[SIZE_ALIGNED:.*]] = llvm.sub
   // ALIGNED-ALLOC-NEXT:  llvm.call @aligned_alloc(%[[c32]], %[[SIZE_ALIGNED]])
-  %5 = memref.alloc() {alignment = 32} : memref<100xf32>
+  %5 = memref.alloc() alignment = 32 : memref<100xf32>
   // Bump alignment to the next power of two if it isn't.
   // ALIGNED-ALLOC:  %[[c128:.*]] = llvm.mlir.constant(128 : index) : i64
   // ALIGNED-ALLOC:  llvm.call @aligned_alloc(%[[c128]]

--- a/mlir/test/Conversion/MemRefToLLVM/convert-static-memref-ops.mlir
+++ b/mlir/test/Conversion/MemRefToLLVM/convert-static-memref-ops.mlir
@@ -54,7 +54,7 @@ func.func @aligned_1d_alloc() -> memref<42xf32> {
 // CHECK: llvm.insertvalue %[[alignedBitCast]], %{{.*}}[1] : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
 // CHECK: %[[c0:.*]] = llvm.mlir.constant(0 : index) : i64
 // CHECK: llvm.insertvalue %[[c0]], %{{.*}}[2] : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
-  %0 = memref.alloc() {alignment = 8} : memref<42xf32>
+  %0 = memref.alloc() alignment = 8 : memref<42xf32>
   return %0 : memref<42xf32>
 }
 
@@ -89,7 +89,7 @@ func.func @static_alloca() -> memref<32x18xf32> {
  // CHECK: %[[desc:.*]] = llvm.mlir.poison : !llvm.struct<(ptr, ptr, i64, array<2 x i64>, array<2 x i64>)>
  // CHECK: %[[desc1:.*]] = llvm.insertvalue %[[alloca_aligned]], %[[desc]][0] : !llvm.struct<(ptr, ptr, i64, array<2 x i64>, array<2 x i64>)>
  // CHECK: llvm.insertvalue %[[alloca_aligned]], %[[desc1]][1] : !llvm.struct<(ptr, ptr, i64, array<2 x i64>, array<2 x i64>)>
- memref.alloca() {alignment = 32} : memref<32x18xf32>
+ memref.alloca() alignment = 32 : memref<32x18xf32>
  return %0 : memref<32x18xf32>
 }
 

--- a/mlir/test/Conversion/MemRefToLLVM/invalid.mlir
+++ b/mlir/test/Conversion/MemRefToLLVM/invalid.mlir
@@ -23,7 +23,7 @@ func.func @bad_address_space(%a: memref<2xindex, "foo">) {
 // CHECK-LABEL: @invalid_int_conversion
 func.func @invalid_int_conversion() {
      // expected-error@unknown{{conversion of memref memory space 1 : ui64 to integer address space failed. Consider adding memory space conversions.}}
-     %alloc = memref.alloc() {alignment = 64 : i64} : memref<10xf32, 1 : ui64> 
+     %alloc = memref.alloc() alignment = 64 : memref<10xf32, 1 : ui64>
     return
 }
 

--- a/mlir/test/Conversion/MemRefToLLVM/memref-to-llvm.mlir
+++ b/mlir/test/Conversion/MemRefToLLVM/memref-to-llvm.mlir
@@ -405,7 +405,7 @@ func.func @get_gv3_memref() {
 // Test scalar memref with an alignment.
 // CHECK: llvm.mlir.global private @gv4(1.000000e+00 : f32) {addr_space = 0 : i32, alignment = 64 : i64} : f32
 // CHECK-INTERFACE: llvm.mlir.global private
-memref.global "private" @gv4 : memref<f32> = dense<1.0> {alignment = 64}
+memref.global "private" @gv4 : memref<f32> = dense<1.0> alignment = 64
 
 // -----
 
@@ -810,7 +810,7 @@ func.func @load_non_temporal(%arg0 : memref<32xf32, affine_map<(d0) -> (d0)>>) {
   %1 = arith.constant 7 : index
   // CHECK: llvm.load %{{.*}} {nontemporal} : !llvm.ptr -> f32
   // CHECK-INTERFACE: llvm.load
-  %2 = memref.load %arg0[%1] {nontemporal = true} : memref<32xf32, affine_map<(d0) -> (d0)>>
+  %2 = memref.load %arg0[%1] nontemporal(true) : memref<32xf32, affine_map<(d0) -> (d0)>>
   func.return
 }
 
@@ -822,7 +822,7 @@ func.func @load_invariant(%arg0 : memref<32xf32, affine_map<(d0) -> (d0)>>) {
   %1 = arith.constant 7 : index
   // CHECK: llvm.load %{{.*}} invariant : !llvm.ptr -> f32
   // CHECK-INTERFACE: llvm.load
-  %2 = memref.load %arg0[%1] {invariant = true} : memref<32xf32, affine_map<(d0) -> (d0)>>
+  %2 = memref.load %arg0[%1] invariant(true) : memref<32xf32, affine_map<(d0) -> (d0)>>
   func.return
 }
 
@@ -833,7 +833,7 @@ func.func @load_invariant(%arg0 : memref<32xf32, affine_map<(d0) -> (d0)>>) {
 func.func @load_with_alignment(%arg0 : memref<32xf32>, %arg1 : index) {
   // CHECK: llvm.load %{{.*}} {alignment = 32 : i64} : !llvm.ptr -> f32
   // CHECK-INTERFACE: llvm.load
-  %1 = memref.load %arg0[%arg1] {alignment = 32} : memref<32xf32>
+  %1 = memref.load %arg0[%arg1] alignment(32) : memref<32xf32>
   func.return
 }
 
@@ -843,10 +843,10 @@ func.func @load_with_alignment(%arg0 : memref<32xf32>, %arg1 : index) {
 // CHECK-INTERFACE-LABEL: func @store_non_temporal(
 func.func @store_non_temporal(%input : memref<32xf32, affine_map<(d0) -> (d0)>>, %output : memref<32xf32, affine_map<(d0) -> (d0)>>) {
   %1 = arith.constant 7 : index
-  %2 = memref.load %input[%1] {nontemporal = true} : memref<32xf32, affine_map<(d0) -> (d0)>>
+  %2 = memref.load %input[%1] nontemporal(true) : memref<32xf32, affine_map<(d0) -> (d0)>>
   // CHECK: llvm.store %{{.*}}, %{{.*}}  {nontemporal} : f32, !llvm.ptr
   // CHECK-INTERFACE: llvm.store
-  memref.store %2, %output[%1] {nontemporal = true} : memref<32xf32, affine_map<(d0) -> (d0)>>
+  memref.store %2, %output[%1] nontemporal(true) : memref<32xf32, affine_map<(d0) -> (d0)>>
   func.return
 }
 
@@ -857,7 +857,7 @@ func.func @store_non_temporal(%input : memref<32xf32, affine_map<(d0) -> (d0)>>,
 func.func @store_with_alignment(%arg0 : memref<32xf32>, %arg1 : f32, %arg2 : index) {
   // CHECK: llvm.store %{{.*}}, %{{.*}} {alignment = 32 : i64} : f32, !llvm.ptr
   // CHECK-INTERFACE: llvm.store
-  memref.store %arg1, %arg0[%arg2] {alignment = 32} : memref<32xf32>
+  memref.store %arg1, %arg0[%arg2] alignment(32) : memref<32xf32>
   func.return
 }
 

--- a/mlir/test/Conversion/MemRefToSPIRV/memref-to-spirv.mlir
+++ b/mlir/test/Conversion/MemRefToSPIRV/memref-to-spirv.mlir
@@ -89,21 +89,21 @@ func.func @load_i1(%src: memref<4xi1, #spirv.storage_class<StorageBuffer>>, %i :
 //  CHECK-SAME: (%[[SRC:.+]]: memref<4xi1, #spirv.storage_class<StorageBuffer>>, %[[IDX:.+]]: index)
 func.func @load_aligned(%src: memref<4xi1, #spirv.storage_class<StorageBuffer>>, %i : index) -> i1 {
   // CHECK: spirv.Load "StorageBuffer" {{.*}} ["Aligned", 32] : i8
-  %0 = memref.load %src[%i] { alignment = 32 } : memref<4xi1, #spirv.storage_class<StorageBuffer>>
+  %0 = memref.load %src[%i] alignment(32) : memref<4xi1, #spirv.storage_class<StorageBuffer>>
   return %0: i1
 }
 
 // CHECK-LABEL: func @load_aligned_nontemporal
 func.func @load_aligned_nontemporal(%src: memref<4xi1, #spirv.storage_class<StorageBuffer>>, %i : index) -> i1 {
   // CHECK: spirv.Load "StorageBuffer" {{.*}} ["Aligned|Nontemporal", 32] : i8
-  %0 = memref.load %src[%i] { alignment = 32, nontemporal = true } : memref<4xi1, #spirv.storage_class<StorageBuffer>>
+  %0 = memref.load %src[%i] alignment(32) nontemporal(true) : memref<4xi1, #spirv.storage_class<StorageBuffer>>
   return %0: i1
 }
 
 // CHECK-LABEL: func @load_aligned_psb
 func.func @load_aligned_psb(%src: memref<4xi1, #spirv.storage_class<PhysicalStorageBuffer>>, %i : index) -> i1 {
   // CHECK: %[[VAL:.+]] = spirv.Load "PhysicalStorageBuffer" {{.*}} ["Aligned", 32] : i8
-  %0 = memref.load %src[%i] { alignment = 32 } : memref<4xi1, #spirv.storage_class<PhysicalStorageBuffer>>
+  %0 = memref.load %src[%i] alignment(32) : memref<4xi1, #spirv.storage_class<PhysicalStorageBuffer>>
   return %0: i1
 }
 
@@ -620,17 +620,17 @@ module attributes {
   ]>, #spirv.resource_limits<>>
 } {
   func.func @load_nontemporal(%arg0: memref<f32, #spirv.storage_class<StorageBuffer>>) {
-    %0 = memref.load %arg0[] {nontemporal = true} : memref<f32, #spirv.storage_class<StorageBuffer>>
+    %0 = memref.load %arg0[] nontemporal(true) : memref<f32, #spirv.storage_class<StorageBuffer>>
 //       CHECK:  spirv.Load "StorageBuffer" %{{.+}} ["Nontemporal"] : f32
-    memref.store %0, %arg0[] {nontemporal = true} : memref<f32, #spirv.storage_class<StorageBuffer>>
+    memref.store %0, %arg0[] nontemporal(true) : memref<f32, #spirv.storage_class<StorageBuffer>>
 //       CHECK:  spirv.Store "StorageBuffer" %{{.+}}, %{{.+}} ["Nontemporal"] : f32
     return
   }
 
   func.func @load_nontemporal_aligned(%arg0: memref<f32, #spirv.storage_class<PhysicalStorageBuffer>>) {
-    %0 = memref.load %arg0[] {nontemporal = true} : memref<f32, #spirv.storage_class<PhysicalStorageBuffer>>
+    %0 = memref.load %arg0[] nontemporal(true) : memref<f32, #spirv.storage_class<PhysicalStorageBuffer>>
 //       CHECK:  spirv.Load "PhysicalStorageBuffer" %{{.+}} ["Aligned|Nontemporal", 4] : f32
-    memref.store %0, %arg0[] {nontemporal = true} : memref<f32, #spirv.storage_class<PhysicalStorageBuffer>>
+    memref.store %0, %arg0[] nontemporal(true) : memref<f32, #spirv.storage_class<PhysicalStorageBuffer>>
 //       CHECK:  spirv.Store "PhysicalStorageBuffer" %{{.+}}, %{{.+}} ["Aligned|Nontemporal", 4] : f32
     return
   }

--- a/mlir/test/Dialect/Affine/access-analysis.mlir
+++ b/mlir/test/Dialect/Affine/access-analysis.mlir
@@ -51,7 +51,7 @@ func.func @loop_unsimplified(%A : memref<100xf32>) {
 #map3 = affine_map<(d0) -> (d0 + 1)>
 
 func.func @tiled(%arg0: memref<*xf32>) {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x224x224x64xf32>
+  %alloc = memref.alloc() alignment = 64 : memref<1x224x224x64xf32>
   %cast = memref.cast %arg0 : memref<*xf32> to memref<64xf32>
   affine.for %arg1 = 0 to 4 {
     affine.for %arg2 = 0 to 224 {

--- a/mlir/test/Dialect/Affine/affine-data-copy.mlir
+++ b/mlir/test/Dialect/Affine/affine-data-copy.mlir
@@ -361,9 +361,9 @@ func.func @arbitrary_memory_space() {
 // CHECK-LABEL: zero_ranked
 func.func @zero_ranked(%3:memref<480xi1>) {
   %false = arith.constant false
-  %4 = memref.alloc() {alignment = 128 : i64} : memref<i1>
+  %4 = memref.alloc() alignment = 128 : memref<i1>
   affine.store %false, %4[] : memref<i1>
-  %5 = memref.alloc() {alignment = 128 : i64} : memref<i1>
+  %5 = memref.alloc() alignment = 128 : memref<i1>
   memref.copy %4, %5 : memref<i1> to memref<i1>
   affine.for %arg0 = 0 to 480 {
     %11 = affine.load %3[%arg0] : memref<480xi1>
@@ -378,11 +378,11 @@ func.func @zero_ranked(%3:memref<480xi1>) {
 // CHECK-LABEL: func @scalar_memref_copy_without_dma
 func.func @scalar_memref_copy_without_dma() {
     %false = arith.constant false
-    %4 = memref.alloc() {alignment = 128 : i64} : memref<i1>
+    %4 = memref.alloc() alignment = 128 : memref<i1>
     affine.store %false, %4[] : memref<i1>
 
     // CHECK: %[[FALSE:.*]] = arith.constant false
-    // CHECK: %[[MEMREF:.*]] = memref.alloc() {alignment = 128 : i64} : memref<i1>
+    // CHECK: %[[MEMREF:.*]] = memref.alloc() alignment = 128 : memref<i1>
     // CHECK: affine.store %[[FALSE]], %[[MEMREF]][] : memref<i1>
     return
 }
@@ -390,9 +390,9 @@ func.func @scalar_memref_copy_without_dma() {
 // CHECK-LABEL: func @scalar_memref_copy_in_loop
 func.func @scalar_memref_copy_in_loop(%3:memref<480xi1>) {
   %false = arith.constant false
-  %4 = memref.alloc() {alignment = 128 : i64} : memref<i1>
+  %4 = memref.alloc() alignment = 128 : memref<i1>
   affine.store %false, %4[] : memref<i1>
-  %5 = memref.alloc() {alignment = 128 : i64} : memref<i1>
+  %5 = memref.alloc() alignment = 128 : memref<i1>
   memref.copy %4, %5 : memref<i1> to memref<i1>
   affine.for %arg0 = 0 to 480 {
     %11 = affine.load %3[%arg0] : memref<480xi1>
@@ -403,9 +403,9 @@ func.func @scalar_memref_copy_in_loop(%3:memref<480xi1>) {
   }
 
   // CHECK: %[[FALSE:.*]] = arith.constant false
-  // CHECK: %[[MEMREF:.*]] = memref.alloc() {alignment = 128 : i64} : memref<i1>
+  // CHECK: %[[MEMREF:.*]] = memref.alloc() alignment = 128 : memref<i1>
   // CHECK: affine.store %[[FALSE]], %[[MEMREF]][] : memref<i1>
-  // CHECK: %[[TARGET:.*]] = memref.alloc() {alignment = 128 : i64} : memref<i1>
+  // CHECK: %[[TARGET:.*]] = memref.alloc() alignment = 128 : memref<i1>
   // CHECK: memref.copy %alloc, %[[TARGET]] : memref<i1> to memref<i1>
   // CHECK: %[[FAST_MEMREF:.*]] = memref.alloc() : memref<480xi1>
   // CHECK: affine.for %{{.*}} = 0 to 480 {
@@ -450,19 +450,19 @@ func.func @memref_def_inside(%arg0: index) {
 
 // Test with uses across multiple blocks.
 
-memref.global "private" constant @__constant_1x2x1xi32_1 : memref<1x2x1xi32> = dense<0> {alignment = 64 : i64}
+memref.global "private" constant @__constant_1x2x1xi32_1 : memref<1x2x1xi32> = dense<0> alignment = 64
 
 // CHECK-LABEL: func @multiple_blocks
 func.func @multiple_blocks(%arg0: index) -> memref<1x2x1xi32> {
   %c1_i32 = arith.constant 1 : i32
   %c3_i32 = arith.constant 3 : i32
   %0 = memref.get_global @__constant_1x2x1xi32_1 : memref<1x2x1xi32>
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x2x1xi32>
+  %alloc = memref.alloc() alignment = 64 : memref<1x2x1xi32>
   memref.copy %0, %alloc : memref<1x2x1xi32> to memref<1x2x1xi32>
   cf.br ^bb1(%alloc : memref<1x2x1xi32>)
 ^bb1(%1: memref<1x2x1xi32>):  // 2 preds: ^bb0, ^bb2
 // CHECK: ^bb1(%[[MEM:.*]]: memref<1x2x1xi32>):
-  %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<1x2x1xi1>
+  %alloc_0 = memref.alloc() alignment = 64 : memref<1x2x1xi1>
   // CHECK: %[[BUF:.*]] = memref.alloc() : memref<1x2x1xi32>
   affine.for %arg1 = 0 to 1 {
     affine.for %arg2 = 0 to 2 {
@@ -479,7 +479,7 @@ func.func @multiple_blocks(%arg0: index) -> memref<1x2x1xi32> {
   cf.cond_br %2, ^bb2, ^bb3
 ^bb2:  // pred: ^bb1
 // CHECK: ^bb2
-  %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<1x2x1xi32>
+  %alloc_1 = memref.alloc() alignment = 64 : memref<1x2x1xi32>
   affine.for %arg1 = 0 to 1 {
     affine.for %arg2 = 0 to 2 {
       affine.for %arg3 = 0 to 1 {

--- a/mlir/test/Dialect/Affine/affine-loop-invariant-code-motion.mlir
+++ b/mlir/test/Dialect/Affine/affine-loop-invariant-code-motion.mlir
@@ -819,18 +819,18 @@ func.func @affine_invariant_use_after_dma(%arg0: memref<10485760xi32>, %arg1: me
   %c320 = arith.constant 320 : index
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
-  %alloc = memref.alloc() {alignment = 16 : i64} : memref<0xi32, 2>
+  %alloc = memref.alloc() alignment = 16 : memref<0xi32, 2>
   %alloc_0 = memref.alloc() : memref<1xi32, 2>
   affine.for %arg3 = 0 to 64 {
     %0 = affine.apply #map(%arg3)
-    %alloc_1 = memref.alloc() {alignment = 16 : i64} : memref<0xi32, 2>
+    %alloc_1 = memref.alloc() alignment = 16 : memref<0xi32, 2>
     %alloc_2 = memref.alloc() : memref<320xi32, 2>
     affine.dma_start %arg0[%0], %alloc_2[%c0], %alloc_1[%c0], %c320 : memref<10485760xi32>, memref<320xi32, 2>, memref<0xi32, 2>
     affine.dma_start %arg1[%c0], %alloc_0[%c0], %alloc[%c0], %c1 : memref<1xi32>, memref<1xi32, 2>, memref<0xi32, 2>
     affine.dma_wait %alloc_1[%c0], %c320 : memref<0xi32, 2>
     affine.dma_wait %alloc[%c0], %c1 : memref<0xi32, 2>
     %1 = affine.apply #map(%arg3)
-    %alloc_3 = memref.alloc() {alignment = 16 : i64} : memref<0xi32, 2>
+    %alloc_3 = memref.alloc() alignment = 16 : memref<0xi32, 2>
     %alloc_4 = memref.alloc() : memref<320xi32, 2>
     affine.for %arg4 = 0 to 320 {
       %2 = affine.load %alloc_2[%arg4] : memref<320xi32, 2>

--- a/mlir/test/Dialect/Affine/load-store-invalid.mlir
+++ b/mlir/test/Dialect/Affine/load-store-invalid.mlir
@@ -144,7 +144,7 @@ func.func @dma_wait_non_affine_tag_index(%arg0 : index) {
 // -----
 
 func.func @invalid_symbol() {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<23x26xf32>
+  %alloc = memref.alloc() alignment = 64 : memref<23x26xf32>
   affine.for %arg1 = 0 to 1 {
     affine.for %arg2 = 0 to 26 {
       affine.for %arg3 = 0 to 23 {

--- a/mlir/test/Dialect/Affine/loop-fusion-4.mlir
+++ b/mlir/test/Dialect/Affine/loop-fusion-4.mlir
@@ -248,7 +248,7 @@ module {
       tensor.yield %cst_f32 : f32
     } : tensor<1x32x32x8xf32> to tensor<1x40x8229x8xf32>
     %1 = bufferization.to_buffer %padded : tensor<1x40x8229x8xf32> to memref<1x40x8229x8xf32>
-    %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<1x32x32x8xf32>
+    %alloc_0 = memref.alloc() alignment = 64 : memref<1x32x32x8xf32>
     affine.for %arg1 = 0 to 1 {
       affine.for %arg2 = 0 to 32 {
         affine.for %arg3 = 0 to 32 {
@@ -267,7 +267,7 @@ module {
         }
       }
     }
-    %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<1x32x32x8xf32>
+    %alloc_1 = memref.alloc() alignment = 64 : memref<1x32x32x8xf32>
     affine.for %arg1 = 0 to 1 {
       affine.for %arg2 = 0 to 32 {
         affine.for %arg3 = 0 to 32 {
@@ -371,9 +371,9 @@ func.func @memref_index_type() {
   %0 = llvm.mlir.constant(2 : index) : i64
   %2 = llvm.mlir.constant(0 : index) : i64
   %3 = builtin.unrealized_conversion_cast %2 : i64 to index
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<8x18xf32>
-  %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<3xf32>
-  %alloc_2 = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
+  %alloc = memref.alloc() alignment = 64 : memref<8x18xf32>
+  %alloc_1 = memref.alloc() alignment = 64 : memref<3xf32>
+  %alloc_2 = memref.alloc() alignment = 64 : memref<3xindex>
   affine.for %arg3 = 0 to 3 {
     %4 = affine.load %alloc_2[%arg3] : memref<3xindex>
     %5 = builtin.unrealized_conversion_cast %4 : index to i64
@@ -562,9 +562,9 @@ func.func @zero_tolerance(%arg0: memref<65536xcomplex<f64>>, %arg1: memref<30x13
   %cst = arith.constant 0.000000e+00 : f64
   %cst_0 = arith.constant 0x4320000000380004 : f64
   %cst_1 = arith.constant 5.000000e-01 : f64
-  %0 = memref.alloc() {alignment = 128 : i64} : memref<30x131072xi64>
-  %1 = memref.alloc() {alignment = 128 : i64} : memref<131072xi1>
-  %2 = memref.alloc() {alignment = 128 : i64} : memref<131072xi128>
+  %0 = memref.alloc() alignment = 128 : memref<30x131072xi64>
+  %1 = memref.alloc() alignment = 128 : memref<131072xi1>
+  %2 = memref.alloc() alignment = 128 : memref<131072xi128>
   // This nest nest shouldn't be fused in when a zero tolerance is specified.
   // ZERO-TOLERANCE: affine.for %{{.*}} = 0 to 131072
   affine.for %arg2 = 0 to 131072 {
@@ -679,7 +679,7 @@ module {
     %cst_0 = arith.constant 2.606200e+03 : f32
     %cst_1 = arith.constant 3.224000e+03 : f32
     %cst_2 = arith.constant 0.000000e+00 : f32
-    %alloc = memref.alloc() {alignment = 64 : i64} : memref<3x7x5x6xf32>
+    %alloc = memref.alloc() alignment = 64 : memref<3x7x5x6xf32>
     affine.for %arg0 = 0 to 3 {
       affine.for %arg1 = 0 to 7 {
         affine.for %arg2 = 0 to 5 {
@@ -689,10 +689,10 @@ module {
         }
       }
     }
-    %alloc_3 = memref.alloc() {alignment = 64 : i64} : memref<3x10x7x6xf32>
+    %alloc_3 = memref.alloc() alignment = 64 : memref<3x10x7x6xf32>
     %subview = memref.subview %alloc_3[0, 2, 1, 0] [3, 7, 5, 6] [1, 1, 1, 1] : memref<3x10x7x6xf32> to memref<3x7x5x6xf32, strided<[420, 42, 6, 1], offset: 90>>
     memref.copy %alloc, %subview : memref<3x7x5x6xf32> to memref<3x7x5x6xf32, strided<[420, 42, 6, 1], offset: 90>>
-    %alloc_4 = memref.alloc() {alignment = 64 : i64} : memref<3x10x3x6x1xf32>
+    %alloc_4 = memref.alloc() alignment = 64 : memref<3x10x3x6x1xf32>
     affine.for %arg0 = 0 to 3 {
       affine.for %arg1 = 0 to 10 {
         affine.for %arg2 = 0 to 3 {
@@ -725,7 +725,7 @@ module {
         }
       }
     }
-    %alloc_5 = memref.alloc() {alignment = 64 : i64} : memref<3x10x3x6xf32>
+    %alloc_5 = memref.alloc() alignment = 64 : memref<3x10x3x6xf32>
     %expand_shape = memref.expand_shape %alloc_5 [[0], [1], [2], [3, 4]] output_shape [3, 10, 3, 6, 1] : memref<3x10x3x6xf32> into memref<3x10x3x6x1xf32>
     affine.for %arg0 = 0 to 3 {
       affine.for %arg1 = 0 to 10 {

--- a/mlir/test/Dialect/Affine/loop-fusion-inner.mlir
+++ b/mlir/test/Dialect/Affine/loop-fusion-inner.mlir
@@ -62,7 +62,7 @@ func.func @fusion_inner_simple_scf(%A : memref<10xf32>) {
 
 // CHECK-LABEL: func @fusion_inner_multiple_nests
 func.func @fusion_inner_multiple_nests() {
-  %alloc_5 = memref.alloc() {alignment = 64 : i64} : memref<4x4xi8>
+  %alloc_5 = memref.alloc() alignment = 64 : memref<4x4xi8>
   %alloc_10 = memref.alloc() : memref<8x4xi32>
   affine.for %arg8 = 0 to 4 {
     %alloc_14 = memref.alloc() : memref<4xi8>
@@ -153,7 +153,7 @@ func.func @fusion_inner_long(%arg0: memref<10x2xf32>, %arg1: memref<10x10xf32>, 
   %c0_i32 = arith.constant 0 : i32
   %0 = memref.get_global @__constant_10x2xf32 : memref<10x2xf32>
   %1 = scf.for %arg3 = %c0_i32 to %c100_i32 step %c1_i32 iter_args(%arg4 = %arg0) -> (memref<10x2xf32>)  : i32 {
-    %alloc = memref.alloc() {alignment = 64 : i64} : memref<10xi32>
+    %alloc = memref.alloc() alignment = 64 : memref<10xi32>
     affine.for %arg5 = 0 to 10 {
       %3 = arith.index_cast %arg5 : index to i32
       affine.store %3, %alloc[%arg5] : memref<10xi32>
@@ -164,19 +164,19 @@ func.func @fusion_inner_long(%arg0: memref<10x2xf32>, %arg1: memref<10x10xf32>, 
         %16 = affine.load %arg4[%s, %arg7] : memref<10x2xf32>
         affine.store %16, %alloc_5[%arg7] : memref<2xf32>
       }
-      %alloc_6 = memref.alloc() {alignment = 64 : i64} : memref<1x2xf32>
+      %alloc_6 = memref.alloc() alignment = 64 : memref<1x2xf32>
       affine.for %arg7 = 0 to 2 {
         %16 = affine.load %alloc_5[%arg7] : memref<2xf32>
         affine.store %16, %alloc_6[0, %arg7] : memref<1x2xf32>
       }
-      %alloc_7 = memref.alloc() {alignment = 64 : i64} : memref<10x2xf32>
+      %alloc_7 = memref.alloc() alignment = 64 : memref<10x2xf32>
       affine.for %arg7 = 0 to 10 {
         affine.for %arg8 = 0 to 2 {
           %16 = affine.load %alloc_6[0, %arg8] : memref<1x2xf32>
           affine.store %16, %alloc_7[%arg7, %arg8] : memref<10x2xf32>
         }
       }
-      %alloc_8 = memref.alloc() {alignment = 64 : i64} : memref<10x2xf32>
+      %alloc_8 = memref.alloc() alignment = 64 : memref<10x2xf32>
       affine.for %arg7 = 0 to 10 {
         affine.for %arg8 = 0 to 2 {
           %16 = affine.load %alloc_7[%arg7, %arg8] : memref<10x2xf32>
@@ -193,13 +193,13 @@ func.func @fusion_inner_long(%arg0: memref<10x2xf32>, %arg1: memref<10x10xf32>, 
       // CHECK-NOT:      affine.for
       // CHECK:          scf.yield
     }
-    %alloc_2 = memref.alloc() {alignment = 64 : i64} : memref<10x2xf32>
+    %alloc_2 = memref.alloc() alignment = 64 : memref<10x2xf32>
     affine.for %arg5 = 0 to 10 {
       affine.for %arg6 = 0 to 2 {
         affine.store %cst_0, %alloc_2[%arg5, %arg6] : memref<10x2xf32>
       }
     }
-    %alloc_3 = memref.alloc() {alignment = 64 : i64} : memref<10x2xf32>
+    %alloc_3 = memref.alloc() alignment = 64 : memref<10x2xf32>
     affine.for %arg5 = 0 to 10 {
       affine.for %arg6 = 0 to 2 {
         %3 = affine.load %alloc_2[%arg5, %arg6] : memref<10x2xf32>

--- a/mlir/test/Dialect/Affine/loop-unswitch.mlir
+++ b/mlir/test/Dialect/Affine/loop-unswitch.mlir
@@ -261,7 +261,7 @@ func.func private @external()
 // CHECK-LABEL: affine_parallel
 func.func @affine_parallel(%arg0: memref<35xf32>) -> memref<35xf32> {
   %0 = llvm.mlir.constant(1.000000e+00 : f32) : f32
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<35xf32>
+  %alloc = memref.alloc() alignment = 64 : memref<35xf32>
   // CHECK: affine.parallel
   affine.parallel (%arg1) = (0) to (35) step (32) {
     // This can't be hoisted further.

--- a/mlir/test/Dialect/Affine/parallelize.mlir
+++ b/mlir/test/Dialect/Affine/parallelize.mlir
@@ -333,7 +333,7 @@ func.func @test_add_inv_or_terminal_symbol(%arg0: memref<9x9xi32>, %arg1: i1) {
   %29 = tensor.empty() : tensor<10xf16>
   memref.alloca_scope {
     %dim_30 = tensor.dim %29, %idx0 : tensor<10xf16>
-    %alloc_31 = memref.alloc(%idx0, %idx0) {alignment = 64 : i64} : memref<?x?xf16>
+    %alloc_31 = memref.alloc(%idx0, %idx0) alignment = 64 : memref<?x?xf16>
     affine.for %arg3 = 0 to %dim_30 {
       %207 = affine.load %alloc_31[%idx0, %idx0] : memref<?x?xf16>
       affine.store %207, %alloc_31[%idx0, %idx0] : memref<?x?xf16>

--- a/mlir/test/Dialect/Affine/scalrep.mlir
+++ b/mlir/test/Dialect/Affine/scalrep.mlir
@@ -988,7 +988,7 @@ func.func @scf_for_if(%arg0: memref<?xi32>, %arg1: i32) -> i32 attributes {llvm.
 func.func @zero_d_memrefs() {
   // CHECK: %[[C0:.*]] = arith.constant 0
   %c0_i32 = arith.constant 0 : i32
-  %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<i32>
+  %alloc_0 = memref.alloc() alignment = 64 : memref<i32>
   affine.store %c0_i32, %alloc_0[] : memref<i32>
   affine.for %arg0 = 0 to 9 {
     %2 = affine.load %alloc_0[] : memref<i32>

--- a/mlir/test/Dialect/Arith/bufferize.mlir
+++ b/mlir/test/Dialect/Arith/bufferize.mlir
@@ -21,7 +21,7 @@ func.func @index_cast(%tensor: tensor<i32>, %scalar: i32) -> (tensor<index>, ind
 // The name isn't load-bearing though.
 
 // CHECK: memref.global "private" constant @__constant_3x4xf32 : memref<3x4xf32> = dense<7.000000e+00>
-// CHECK-SAME: {alignment = 64 : i64}
+// CHECK-SAME: alignment = 64
 
 // CHECK: @basic
 func.func @basic() -> tensor<3x4xf32> {

--- a/mlir/test/Dialect/ArmSVE/legalize-vector-storage.mlir
+++ b/mlir/test/Dialect/ArmSVE/legalize-vector-storage.mlir
@@ -7,7 +7,7 @@
 // CHECK-LABEL: @store_and_reload_sve_predicate_nxv1i1(
 // CHECK-SAME:                                         %[[MASK:.*]]: vector<[1]xi1>)
 func.func @store_and_reload_sve_predicate_nxv1i1(%mask: vector<[1]xi1>) -> vector<[1]xi1> {
-  // CHECK-NEXT: %[[ALLOCA:.*]] = memref.alloca() {alignment = 2 : i64} : memref<vector<[16]xi1>>
+  // CHECK-NEXT: %[[ALLOCA:.*]] = memref.alloca() alignment = 2 : memref<vector<[16]xi1>>
   %alloca = memref.alloca() : memref<vector<[1]xi1>>
   // CHECK-NEXT: %[[SVBOOL:.*]] = arm_sve.convert_to_svbool %[[MASK]] : vector<[1]xi1>
   // CHECK-NEXT: memref.store %[[SVBOOL]], %[[ALLOCA]][] : memref<vector<[16]xi1>>
@@ -24,7 +24,7 @@ func.func @store_and_reload_sve_predicate_nxv1i1(%mask: vector<[1]xi1>) -> vecto
 // CHECK-LABEL: @store_and_reload_sve_predicate_nxv2i1(
 // CHECK-SAME:                                         %[[MASK:.*]]: vector<[2]xi1>)
 func.func @store_and_reload_sve_predicate_nxv2i1(%mask: vector<[2]xi1>) -> vector<[2]xi1> {
-  // CHECK-NEXT: %[[ALLOCA:.*]] = memref.alloca() {alignment = 2 : i64} : memref<vector<[16]xi1>>
+  // CHECK-NEXT: %[[ALLOCA:.*]] = memref.alloca() alignment = 2 : memref<vector<[16]xi1>>
   %alloca = memref.alloca() : memref<vector<[2]xi1>>
   // CHECK-NEXT: %[[SVBOOL:.*]] = arm_sve.convert_to_svbool %[[MASK]] : vector<[2]xi1>
   // CHECK-NEXT: memref.store %[[SVBOOL]], %[[ALLOCA]][] : memref<vector<[16]xi1>>
@@ -41,7 +41,7 @@ func.func @store_and_reload_sve_predicate_nxv2i1(%mask: vector<[2]xi1>) -> vecto
 // CHECK-LABEL: @store_and_reload_sve_predicate_nxv4i1(
 // CHECK-SAME:                                         %[[MASK:.*]]: vector<[4]xi1>)
 func.func @store_and_reload_sve_predicate_nxv4i1(%mask: vector<[4]xi1>) -> vector<[4]xi1> {
-  // CHECK-NEXT: %[[ALLOCA:.*]] = memref.alloca() {alignment = 2 : i64} : memref<vector<[16]xi1>>
+  // CHECK-NEXT: %[[ALLOCA:.*]] = memref.alloca() alignment = 2 : memref<vector<[16]xi1>>
   %alloca = memref.alloca() : memref<vector<[4]xi1>>
   // CHECK-NEXT: %[[SVBOOL:.*]] = arm_sve.convert_to_svbool %[[MASK]] : vector<[4]xi1>
   // CHECK-NEXT: memref.store %[[SVBOOL]], %[[ALLOCA]][] : memref<vector<[16]xi1>>
@@ -58,7 +58,7 @@ func.func @store_and_reload_sve_predicate_nxv4i1(%mask: vector<[4]xi1>) -> vecto
 // CHECK-LABEL: @store_and_reload_sve_predicate_nxv8i1(
 // CHECK-SAME:                                         %[[MASK:.*]]: vector<[8]xi1>)
 func.func @store_and_reload_sve_predicate_nxv8i1(%mask: vector<[8]xi1>) -> vector<[8]xi1> {
-  // CHECK-NEXT: %[[ALLOCA:.*]] = memref.alloca() {alignment = 2 : i64} : memref<vector<[16]xi1>>
+  // CHECK-NEXT: %[[ALLOCA:.*]] = memref.alloca() alignment = 2 : memref<vector<[16]xi1>>
   %alloca = memref.alloca() : memref<vector<[8]xi1>>
   // CHECK-NEXT: %[[SVBOOL:.*]] = arm_sve.convert_to_svbool %[[MASK]] : vector<[8]xi1>
   // CHECK-NEXT: memref.store %[[SVBOOL]], %[[ALLOCA]][] : memref<vector<[16]xi1>>
@@ -75,7 +75,7 @@ func.func @store_and_reload_sve_predicate_nxv8i1(%mask: vector<[8]xi1>) -> vecto
 // CHECK-LABEL: @store_and_reload_sve_predicate_nxv16i1(
 // CHECK-SAME:                                         %[[MASK:.*]]: vector<[16]xi1>)
 func.func @store_and_reload_sve_predicate_nxv16i1(%mask: vector<[16]xi1>) -> vector<[16]xi1> {
-  // CHECK-NEXT: %[[ALLOCA:.*]] = memref.alloca() {alignment = 2 : i64} : memref<vector<[16]xi1>>
+  // CHECK-NEXT: %[[ALLOCA:.*]] = memref.alloca() alignment = 2 : memref<vector<[16]xi1>>
   %alloca = memref.alloca() : memref<vector<[16]xi1>>
   // CHECK-NEXT: memref.store %[[MASK]], %[[ALLOCA]][] : memref<vector<[16]xi1>>
   memref.store %mask, %alloca[] : memref<vector<[16]xi1>>
@@ -93,7 +93,7 @@ func.func @store_and_reload_sve_predicate_nxv16i1(%mask: vector<[16]xi1>) -> vec
 // CHECK-LABEL: @store_and_reload_unsupported_type(
 // CHECK-SAME:                                         %[[MASK:.*]]: vector<[7]xi1>)
 func.func @store_and_reload_unsupported_type(%mask: vector<[7]xi1>) -> vector<[7]xi1> {
-  // CHECK-NEXT: %[[ALLOCA:.*]] = memref.alloca() {alignment = 2 : i64} : memref<vector<[7]xi1>>
+  // CHECK-NEXT: %[[ALLOCA:.*]] = memref.alloca() alignment = 2 : memref<vector<[7]xi1>>
   %alloca = memref.alloca() : memref<vector<[7]xi1>>
   // CHECK-NEXT: memref.store %[[MASK]], %[[ALLOCA]][] : memref<vector<[7]xi1>>
   memref.store %mask, %alloca[] : memref<vector<[7]xi1>>
@@ -110,7 +110,7 @@ func.func @store_and_reload_unsupported_type(%mask: vector<[7]xi1>) -> vector<[7
 func.func @store_2d_mask_and_reload_slice(%mask: vector<3x[8]xi1>) -> vector<[8]xi1> {
   // CHECK-NEXT: %[[C0:.*]] = arith.constant 0 : index
   %c0 = arith.constant 0 : index
-  // CHECK-NEXT: %[[ALLOCA:.*]] = memref.alloca() {alignment = 2 : i64} : memref<vector<3x[16]xi1>>
+  // CHECK-NEXT: %[[ALLOCA:.*]] = memref.alloca() alignment = 2 : memref<vector<3x[16]xi1>>
   %alloca = memref.alloca() : memref<vector<3x[8]xi1>>
   // CHECK-NEXT: %[[SVBOOL:.*]] = arm_sve.convert_to_svbool %[[MASK]] : vector<3x[8]xi1>
   // CHECK-NEXT: memref.store %[[SVBOOL]], %[[ALLOCA]][] : memref<vector<3x[16]xi1>>

--- a/mlir/test/Dialect/Bufferization/Transforms/OwnershipBasedBufferDeallocation/dealloc-memoryeffect-interface.mlir
+++ b/mlir/test/Dialect/Bufferization/Transforms/OwnershipBasedBufferDeallocation/dealloc-memoryeffect-interface.mlir
@@ -162,14 +162,14 @@ func.func @manual_deallocation(%c: i1, %f: f32, %idx: index) -> f32 {
 // CHECK-LABEL: func.func private @properly_creates_deallocations_in_execute_region(
 // CHECK:           %[[true:.*]] = arith.constant true
 // CHECK:           scf.execute_region no_inline {
-// CHECK:             %[[alloc:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x63x378x16xui8>
+// CHECK:             %[[alloc:.*]] = memref.alloc() alignment = 64 : memref<1x63x378x16xui8>
 // CHECK:             bufferization.dealloc (%[[alloc]] : memref<1x63x378x16xui8>) if (%[[true]])
 
 func.func private @properly_creates_deallocations_in_execute_region(%arg1: memref<1x16x252x380xui8> ) -> (memref<1x250x378x16xui8> )  {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x250x378x16xui8>
+  %alloc = memref.alloc() alignment = 64 : memref<1x250x378x16xui8>
   scf.execute_region no_inline {
     %subview = memref.subview %arg1[0, 0, 0, 0] [1, 16, 65, 380] [1, 1, 1, 1] : memref<1x16x252x380xui8> to memref<1x16x65x380xui8, strided<[1532160, 95760, 380, 1]>>
-    %alloc_3 = memref.alloc() {alignment = 64 : i64} : memref<1x63x378x16xui8>    
+    %alloc_3 = memref.alloc() alignment = 64 : memref<1x63x378x16xui8>
     test.buffer_based in(%subview: memref<1x16x65x380xui8, strided<[1532160, 95760, 380, 1]>>) out(%alloc_3: memref<1x63x378x16xui8>)
     %subview_7 = memref.subview %alloc[0, 0, 0, 0] [1, 63, 378, 16] [1, 1, 1, 1] : memref<1x250x378x16xui8> to memref<1x63x378x16xui8, strided<[1512000, 6048, 16, 1]>>
     test.copy(%alloc_3, %subview_7) : (memref<1x63x378x16xui8>, memref<1x63x378x16xui8, strided<[1512000, 6048, 16, 1]>>)

--- a/mlir/test/Dialect/Bufferization/Transforms/one-shot-bufferize-empty-tensor-elimination.mlir
+++ b/mlir/test/Dialect/Bufferization/Transforms/one-shot-bufferize-empty-tensor-elimination.mlir
@@ -372,7 +372,7 @@ func.func @multiple_materialize_in_destination_buffer(%m: memref<5xf32>, %f: f32
 func.func @eliminate_all_empty_tensors() -> tensor<5x6x128xf32> {
   %cst_1 = arith.constant 1.0 : f32
   %cst_2 = arith.constant 2.0 : f32
-  // CHECK: memref.alloc() {alignment = 64 : i64} : memref<5x6x128xf32>
+  // CHECK: memref.alloc() alignment = 64 : memref<5x6x128xf32>
   // CHECK-NOT: memref.alloc
   %empty_1 = tensor.empty() : tensor<5x6x64xf32>
   %res_1 = linalg.fill ins(%cst_1 : f32) outs(%empty_1 : tensor<5x6x64xf32>) -> tensor<5x6x64xf32>
@@ -393,7 +393,7 @@ func.func @eliminate_all_empty_tensors() -> tensor<5x6x128xf32> {
 func.func @eliminate_concatenated_empty_tensors() -> tensor<5x6x128xf32> {
   %cst_1 = arith.constant 1.0 : f32
   %cst_2 = arith.constant 2.0 : f32
-  // CHECK: memref.alloc() {alignment = 64 : i64} : memref<5x6x128xf32>
+  // CHECK: memref.alloc() alignment = 64 : memref<5x6x128xf32>
   // CHECK-NOT: memref.alloc
   %concatenated_empty = tensor.empty() : tensor<5x6x128xf32>
   %empty_1 = tensor.empty() : tensor<5x6x64xf32>
@@ -416,7 +416,7 @@ func.func @eliminate_concatenated_empty_tensors() -> tensor<5x6x128xf32> {
 
 // CHECK-ELIM-LABEL:   func.func @multi_use_of_the_same_tensor_empty
 // CHECK-LABEL:   func.func @multi_use_of_the_same_tensor_empty
-//       CHECK:   memref.alloc() {alignment = 64 : i64} : memref<5x6x128xf32>
+//       CHECK:   memref.alloc() alignment = 64 : memref<5x6x128xf32>
 //   CHECK-NOT:   memref.alloc
 //   CHECK-NOT:   memref.copy
 //  CHECK-ELIM:   tensor.extract_slice {{.*}}[0, 0, 0]
@@ -445,7 +445,7 @@ func.func @multi_use_of_the_same_tensor_empty_creates_non_existent_read(%arg1: t
     -> (tensor<5x6x128xf32>, tensor<5x6x64xf32>) {
   %cst_1 = arith.constant 1.0 : f32
   %empty_1 = tensor.empty() : tensor<5x6x64xf32>
-  // CHECK: memref.alloc() {alignment = 64 : i64} : memref<5x6x64xf32>
+  // CHECK: memref.alloc() alignment = 64 : memref<5x6x64xf32>
   // CHECK-NOT: memref.alloc
   %res_1 = linalg.fill ins(%cst_1 : f32) outs(%empty_1 : tensor<5x6x64xf32>) -> tensor<5x6x64xf32>
   %res_2 = linalg.generic{

--- a/mlir/test/Dialect/Bufferization/Transforms/one-shot-bufferize-encodings.mlir
+++ b/mlir/test/Dialect/Bufferization/Transforms/one-shot-bufferize-encodings.mlir
@@ -7,7 +7,7 @@ func.func @alloc_tesor_with_space_no_encoding() -> tensor<128xf32> {
 
 // CHECK-LABEL: @alloc_tesor_with_space_no_encoding
 //  CHECK-SAME: () -> tensor<128xf32> {
-//       CHECK:     %[[alloc:.+]] = memref.alloc() {alignment = 64 : i64} : memref<128xf32, 1>
+//       CHECK:     %[[alloc:.+]] = memref.alloc() alignment = 64 : memref<128xf32, 1>
 //       CHECK:     %[[v0:.+]] = bufferization.to_tensor %[[alloc]] : memref<128xf32, 1> to tensor<128xf32>
 //       CHECK:     return %[[v0]] : tensor<128xf32>
 
@@ -21,7 +21,7 @@ func.func @alloc_tesor_with_space_and_cast() -> tensor<128xf32, 1> {
 
 // CHECK-LABEL: @alloc_tesor_with_space_and_cast
 //  CHECK-SAME: () -> tensor<128xf32, 1 : i64> {
-//       CHECK:     %[[alloc:.+]] = memref.alloc() {alignment = 64 : i64} : memref<128xf32, 1>
+//       CHECK:     %[[alloc:.+]] = memref.alloc() alignment = 64 : memref<128xf32, 1>
 //       CHECK:     %[[v0:.+]] = bufferization.to_tensor %[[alloc]] : memref<128xf32, 1> to tensor<128xf32, 1 : i64>
 //       CHECK:     return %[[v0]] : tensor<128xf32, 1 : i64>
 
@@ -34,7 +34,7 @@ func.func @alloc_tesor_with_space_with_encoding() -> tensor<128xf32, 1 : i64> {
 
 // CHECK-LABEL: @alloc_tesor_with_space_with_encoding
 //  CHECK-SAME: () -> tensor<128xf32, 1 : i64> {
-//       CHECK:     %[[alloc:.+]] = memref.alloc() {alignment = 64 : i64} : memref<128xf32, 1>
+//       CHECK:     %[[alloc:.+]] = memref.alloc() alignment = 64 : memref<128xf32, 1>
 //       CHECK:     %[[v0:.+]] = bufferization.to_tensor %[[alloc]] : memref<128xf32, 1> to tensor<128xf32, 1 : i64>
 //       CHECK:     return %[[v0]] : tensor<128xf32, 1 : i64>
 
@@ -48,7 +48,7 @@ func.func @alloc_tesor_copy_from_default_space(%arg0: tensor<128xf32>) -> tensor
 // CHECK-LABEL: @alloc_tesor_copy_from_default_space
 //  CHECK-SAME: (%[[arg0:.+]]: tensor<128xf32>) -> tensor<128xf32> {
 //       CHECK:     %[[v0:.+]] = bufferization.to_buffer %[[arg0]] : tensor<128xf32> to memref<128xf32, strided<[?], offset: ?>>
-//       CHECK:     %[[alloc:.+]] = memref.alloc() {alignment = 64 : i64} : memref<128xf32, 1>
+//       CHECK:     %[[alloc:.+]] = memref.alloc() alignment = 64 : memref<128xf32, 1>
 //       CHECK:     memref.copy %[[v0]], %[[alloc]] : memref<128xf32, strided<[?], offset: ?>> to memref<128xf32, 1>
 //       CHECK:     %[[v1:.+]] = bufferization.to_tensor %[[alloc]] : memref<128xf32, 1> to tensor<128xf32>
 //       CHECK:     return %[[v1]] : tensor<128xf32>
@@ -64,7 +64,7 @@ func.func @alloc_tesor_copy_from_non_default_space(%arg0: tensor<128xf32, 1>) ->
 // CHECK-LABEL: @alloc_tesor_copy_from_non_default_space
 //  CHECK-SAME: (%[[arg0:.+]]: tensor<128xf32, 1 : i64>) -> tensor<128xf32, 2 : i64> {
 //       CHECK:     %[[v0:.+]] = bufferization.to_buffer %[[arg0]] : tensor<128xf32, 1 : i64> to memref<128xf32, strided<[?], offset: ?>, 1>
-//       CHECK:     %[[alloc:.+]] = memref.alloc() {alignment = 64 : i64} : memref<128xf32, 2>
+//       CHECK:     %[[alloc:.+]] = memref.alloc() alignment = 64 : memref<128xf32, 2>
 //       CHECK:     memref.copy %[[v0]], %[[alloc]] : memref<128xf32, strided<[?], offset: ?>, 1> to memref<128xf32, 2>
 //       CHECK:     %[[v1:.+]] = bufferization.to_tensor %[[alloc]] : memref<128xf32, 2> to tensor<128xf32, 2 : i64>
 //       CHECK:     return %[[v1]] : tensor<128xf32, 2 : i64>
@@ -85,10 +85,10 @@ func.func @alloc_tesor_copy_from_non_default_space_no_cast(%arg0: tensor<128xf32
 //       CHECK:     %[[v0:.+]] = bufferization.to_buffer %[[arg1]] : tensor<4xf32, 1 : i64> to memref<4xf32, strided<[?], offset: ?>, 1>
 //       CHECK:     %[[v1:.+]] = bufferization.to_buffer %[[arg0]] : tensor<128xf32, 1 : i64> to memref<128xf32, strided<[?], offset: ?>, 1>
 //       CHECK:     %[[v2:.+]] = bufferization.to_buffer %[[arg0]] : tensor<128xf32, 1 : i64> to memref<128xf32, strided<[?], offset: ?>, 1>
-//       CHECK:     %[[alloc:.+]] = memref.alloc() {alignment = 64 : i64} : memref<128xf32, 2>
+//       CHECK:     %[[alloc:.+]] = memref.alloc() alignment = 64 : memref<128xf32, 2>
 //       CHECK:     memref.copy %[[v2]], %[[alloc]] : memref<128xf32, strided<[?], offset: ?>, 1> to memref<128xf32, 2>
 //       CHECK:     %[[v3:.+]] = bufferization.to_tensor %[[alloc]] : memref<128xf32, 2> to tensor<128xf32, 1 : i64>
-//       CHECK:     %[[alloc_0:.+]] = memref.alloc() {alignment = 64 : i64} : memref<128xf32, 1>
+//       CHECK:     %[[alloc_0:.+]] = memref.alloc() alignment = 64 : memref<128xf32, 1>
 //       CHECK:     memref.copy %[[v1]], %[[alloc_0]] : memref<128xf32, strided<[?], offset: ?>, 1> to memref<128xf32, 1>
 //       CHECK:     %[[subview:.+]] = memref.subview %[[alloc_0]][0] [4] [1] : memref<128xf32, 1> to memref<4xf32, strided<[1]>, 1>
 //       CHECK:     memref.copy %[[v0]], %[[subview]] : memref<4xf32, strided<[?], offset: ?>, 1> to memref<4xf32, strided<[1]>, 1>
@@ -105,7 +105,7 @@ func.func @materialize_in_destination(%arg0: tensor<128xf32, 1>) -> tensor<128xf
 // CHECK-LABEL: @materialize_in_destination
 //  CHECK-SAME: (%[[arg0:.+]]: tensor<128xf32, 1 : i64>) -> tensor<128xf32, 2 : i64> {
 //       CHECK:     %[[v0:.+]] = bufferization.to_buffer %[[arg0]] : tensor<128xf32, 1 : i64> to memref<128xf32, strided<[?], offset: ?>, 1>
-//       CHECK:     %[[alloc:.+]] = memref.alloc() {alignment = 64 : i64} : memref<128xf32, 2>
+//       CHECK:     %[[alloc:.+]] = memref.alloc() alignment = 64 : memref<128xf32, 2>
 //       CHECK:     memref.copy %[[v0]], %[[alloc]] : memref<128xf32, strided<[?], offset: ?>, 1> to memref<128xf32, 2>
 //       CHECK:     %[[v1:.+]] = bufferization.to_tensor %[[alloc]] : memref<128xf32, 2> to tensor<128xf32, 2 : i64>
 //       CHECK:     return %[[v1]] : tensor<128xf32, 2 : i64>

--- a/mlir/test/Dialect/Bufferization/Transforms/one-shot-module-bufferize.mlir
+++ b/mlir/test/Dialect/Bufferization/Transforms/one-shot-module-bufferize.mlir
@@ -97,7 +97,7 @@ func.func @foo(%arg0: tensor<3x8xf16>) -> tensor<3x8xf16> {
 // CHECK-NO-LAYOUT-MAP-LABEL:   func.func @call_extract_slice(
 // CHECK-NO-LAYOUT-MAP-SAME:                                  %[[VAL_0:.*]]: memref<4x8xf16>) -> memref<3x8xf16> {
 // CHECK-NO-LAYOUT-MAP:           %[[VAL_1:.*]] = memref.subview %[[VAL_0]][1, 0] [3, 8] [1, 1] : memref<4x8xf16> to memref<3x8xf16, strided<[8, 1], offset: 8>>
-// CHECK-NO-LAYOUT-MAP:           %[[VAL_2:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3x8xf16>
+// CHECK-NO-LAYOUT-MAP:           %[[VAL_2:.*]] = memref.alloc() alignment = 64 : memref<3x8xf16>
 // CHECK-NO-LAYOUT-MAP:           memref.copy %[[VAL_1]], %[[VAL_2]] : memref<3x8xf16, strided<[8, 1], offset: 8>> to memref<3x8xf16>
 // CHECK-NO-LAYOUT-MAP:           %[[VAL_3:.*]] = call @foo(%[[VAL_2]]) : (memref<3x8xf16>) -> memref<3x8xf16>
 // CHECK-NO-LAYOUT-MAP:           return %[[VAL_3]] : memref<3x8xf16>
@@ -488,9 +488,9 @@ func.func @main() {
   %v1 = arith.constant 1.0 : f32
   %v2 = arith.constant 2.0 : f32
 
-  // CHECK-NEXT:   %[[A:.*]] = memref.alloc() {alignment = 64 : i64} : memref<64xf32>
-  // CHECK-NEXT:   %[[B:.*]] = memref.alloc() {alignment = 64 : i64} : memref<64xf32>
-  // CHECK-NEXT:   %[[C:.*]] = memref.alloc() {alignment = 64 : i64} : memref<f32>
+  // CHECK-NEXT:   %[[A:.*]] = memref.alloc() alignment = 64 : memref<64xf32>
+  // CHECK-NEXT:   %[[B:.*]] = memref.alloc() alignment = 64 : memref<64xf32>
+  // CHECK-NEXT:   %[[C:.*]] = memref.alloc() alignment = 64 : memref<f32>
   //  CHECK-DAG:   %[[cA:.*]] = memref.cast %[[A]] : memref<64xf32> to memref<64xf32, strided<[?], offset: ?>>
   //  CHECK-DAG:   %[[cB:.*]] = memref.cast %[[B]] : memref<64xf32> to memref<64xf32, strided<[?], offset: ?>>
   //  CHECK-DAG:   %[[cC:.*]] = memref.cast %[[C]] : memref<f32> to memref<f32, strided<[], offset: ?>>
@@ -751,7 +751,7 @@ func.func @foo(%t: tensor<5xf32>) -> tensor<5xf32> {
   // We are conservative around recursive functions. The analysis cannot handle
   // them, so we have to assume the op operand of the call op bufferizes to a
   // memory read and write. This causes a copy in this test case.
-  // CHECK: %[[copy:.*]] = memref.alloc() {alignment = 64 : i64} : memref<5xf32>
+  // CHECK: %[[copy:.*]] = memref.alloc() alignment = 64 : memref<5xf32>
   // CHECK: memref.copy %[[arg0]], %[[copy]]
   // CHECK: %[[cast:.*]] = memref.cast %[[copy]] : memref<5xf32> to memref<5xf32, strided<[?], offset: ?>>
   // CHECK: %[[call:.*]] = call @foo(%[[cast]])
@@ -797,7 +797,7 @@ func.func @bar(%t: tensor<5xf32>) -> tensor<5xf32>{
 
 // CHECK-LABEL: func @result_type_mismatch({{.*}}) -> memref<5xf32, strided<[?], offset: ?>>
 func.func @result_type_mismatch(%c: i1) -> tensor<5xf32> {
-  // CHECK: %[[alloc:.*]] = memref.alloc() {alignment = 64 : i64} : memref<10xf32>
+  // CHECK: %[[alloc:.*]] = memref.alloc() alignment = 64 : memref<10xf32>
   %t = tensor.empty() : tensor<10xf32>
   cf.cond_br %c, ^bb1, ^bb2
 ^bb1:

--- a/mlir/test/Dialect/Bufferization/Transforms/optimize-allocation-liveness.mlir
+++ b/mlir/test/Dialect/Bufferization/Transforms/optimize-allocation-liveness.mlir
@@ -5,10 +5,10 @@
 // CHECK-SAME:                                               %[[VAL_1:.*]]: memref<24x256xf32, 1>,
 // CHECK-SAME:                                               %[[VAL_2:.*]]: memref<256xf32, 1>) {
 // CHECK:           %[[VAL_3:.*]] = arith.constant 1 : index
-// CHECK:           %[[VAL_4:.*]] = memref.alloc() {alignment = 64 : i64} : memref<45x6144xf32, 1>
+// CHECK:           %[[VAL_4:.*]] = memref.alloc() alignment = 64 : memref<45x6144xf32, 1>
 // CHECK:           %[[VAL_5:.*]] = memref.expand_shape %[[VAL_4]] {{\[\[}}0], [1, 2]] output_shape [45, 24, 256] : memref<45x6144xf32, 1> into memref<45x24x256xf32, 1>
 // CHECK:           memref.dealloc %[[VAL_4]] : memref<45x6144xf32, 1>
-// CHECK:           %[[VAL_6:.*]] = memref.alloc() {alignment = 64 : i64} : memref<24x256xf32, 1>
+// CHECK:           %[[VAL_6:.*]] = memref.alloc() alignment = 64 : memref<24x256xf32, 1>
 // CHECK:           %[[VAL_7:.*]] = arith.constant 1.000000e+00 : f32
 // CHECK:           memref.store %[[VAL_7]], %[[VAL_6]]{{\[}}%[[VAL_3]], %[[VAL_3]]] : memref<24x256xf32, 1>
 // CHECK:           memref.dealloc %[[VAL_6]] : memref<24x256xf32, 1>
@@ -19,9 +19,9 @@
 // This test will optimize the location of the %alloc deallocation
 func.func private @optimize_alloc_location(%arg0: memref<45x24x256xf32, 1> , %arg1: memref<24x256xf32, 1> , %arg2: memref<256xf32, 1>) -> () {
   %c1 = arith.constant 1 : index
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<45x6144xf32, 1>
+  %alloc = memref.alloc() alignment = 64 : memref<45x6144xf32, 1>
   %expand_shape = memref.expand_shape %alloc [[0], [1, 2]] output_shape [45, 24, 256] : memref<45x6144xf32, 1> into memref<45x24x256xf32, 1>
-  %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<24x256xf32, 1>
+  %alloc_1 = memref.alloc() alignment = 64 : memref<24x256xf32, 1>
   %cf1 = arith.constant 1.0 : f32
   memref.store %cf1, %alloc_1[%c1, %c1] : memref<24x256xf32, 1>
   memref.dealloc %alloc : memref<45x6144xf32, 1>
@@ -36,17 +36,17 @@ func.func private @optimize_alloc_location(%arg0: memref<45x24x256xf32, 1> , %ar
 // CHECK-SAME:                                                        %[[VAL_1:.*]]: memref<24x256xf32, 1>,
 // CHECK-SAME:                                                        %[[VAL_2:.*]]: memref<256xf32, 1>) {
 // CHECK:           %[[VAL_3:.*]] = arith.constant 1 : index
-// CHECK:           %[[VAL_4:.*]] = memref.alloc() {alignment = 64 : i64} : memref<45x6144xf32, 1>
+// CHECK:           %[[VAL_4:.*]] = memref.alloc() alignment = 64 : memref<45x6144xf32, 1>
 // CHECK:           %[[VAL_5:.*]] = memref.expand_shape %[[VAL_4]] {{\[\[}}0], [1, 2]] output_shape [45, 24, 256] : memref<45x6144xf32, 1> into memref<45x24x256xf32, 1>
 // CHECK:           memref.dealloc %[[VAL_4]] : memref<45x6144xf32, 1>
-// CHECK:           %[[VAL_6:.*]] = memref.alloc() {alignment = 64 : i64} : memref<24x256xf32, 1>
-// CHECK:           %[[VAL_7:.*]] = memref.alloc() {alignment = 64 : i64} : memref<45x6144xf32, 1>
+// CHECK:           %[[VAL_6:.*]] = memref.alloc() alignment = 64 : memref<24x256xf32, 1>
+// CHECK:           %[[VAL_7:.*]] = memref.alloc() alignment = 64 : memref<45x6144xf32, 1>
 // CHECK:           %[[VAL_8:.*]] = memref.expand_shape %[[VAL_7]] {{\[\[}}0], [1, 2]] output_shape [45, 24, 256] : memref<45x6144xf32, 1> into memref<45x24x256xf32, 1>
 // CHECK:           memref.dealloc %[[VAL_7]] : memref<45x6144xf32, 1>
-// CHECK:           %[[VAL_9:.*]] = memref.alloc() {alignment = 64 : i64} : memref<45x6144xf32, 1>
+// CHECK:           %[[VAL_9:.*]] = memref.alloc() alignment = 64 : memref<45x6144xf32, 1>
 // CHECK:           %[[VAL_10:.*]] = memref.expand_shape %[[VAL_9]] {{\[\[}}0], [1, 2]] output_shape [45, 24, 256] : memref<45x6144xf32, 1> into memref<45x24x256xf32, 1>
 // CHECK:           memref.dealloc %[[VAL_9]] : memref<45x6144xf32, 1>
-// CHECK:           %[[VAL_11:.*]] = memref.alloc() {alignment = 64 : i64} : memref<45x6144xf32, 1>
+// CHECK:           %[[VAL_11:.*]] = memref.alloc() alignment = 64 : memref<45x6144xf32, 1>
 // CHECK:           %[[VAL_12:.*]] = memref.expand_shape %[[VAL_11]] {{\[\[}}0], [1, 2]] output_shape [45, 24, 256] : memref<45x6144xf32, 1> into memref<45x24x256xf32, 1>
 // CHECK:           memref.dealloc %[[VAL_11]] : memref<45x6144xf32, 1>
 // CHECK:           %[[VAL_13:.*]] = arith.constant 1.000000e+00 : f32
@@ -59,14 +59,14 @@ func.func private @optimize_alloc_location(%arg0: memref<45x24x256xf32, 1> , %ar
 // This test creates multiple deallocation rearrangements. 
 func.func private @test_multiple_deallocation_moves(%arg0: memref<45x24x256xf32, 1> , %arg1: memref<24x256xf32, 1> , %arg2: memref<256xf32, 1>) -> () {
   %c1 = arith.constant 1 : index
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<45x6144xf32, 1>
+  %alloc = memref.alloc() alignment = 64 : memref<45x6144xf32, 1>
   %expand_shape = memref.expand_shape %alloc [[0], [1, 2]] output_shape [45, 24, 256] : memref<45x6144xf32, 1> into memref<45x24x256xf32, 1>
-  %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<24x256xf32, 1>
-  %alloc_2 = memref.alloc() {alignment = 64 : i64} : memref<45x6144xf32, 1>
+  %alloc_1 = memref.alloc() alignment = 64 : memref<24x256xf32, 1>
+  %alloc_2 = memref.alloc() alignment = 64 : memref<45x6144xf32, 1>
   %expand_shape2 = memref.expand_shape %alloc_2 [[0], [1, 2]] output_shape [45, 24, 256] : memref<45x6144xf32, 1> into memref<45x24x256xf32, 1>
-  %alloc_3 = memref.alloc() {alignment = 64 : i64} : memref<45x6144xf32, 1>
+  %alloc_3 = memref.alloc() alignment = 64 : memref<45x6144xf32, 1>
   %expand_shape3 = memref.expand_shape %alloc_3 [[0], [1, 2]] output_shape [45, 24, 256] : memref<45x6144xf32, 1> into memref<45x24x256xf32, 1>
-  %alloc_4 = memref.alloc() {alignment = 64 : i64} : memref<45x6144xf32, 1>
+  %alloc_4 = memref.alloc() alignment = 64 : memref<45x6144xf32, 1>
   %expand_shape4 = memref.expand_shape %alloc_4 [[0], [1, 2]] output_shape [45, 24, 256] : memref<45x6144xf32, 1> into memref<45x24x256xf32, 1>
   %cf1 = arith.constant 1.0 : f32
   memref.store %cf1, %alloc_1[%c1, %c1] : memref<24x256xf32, 1>
@@ -83,11 +83,11 @@ func.func private @test_multiple_deallocation_moves(%arg0: memref<45x24x256xf32,
 // CHECK-SAME:                                                                      %[[VAL_0:.*]]: memref<1x20x20xf32, 1>) -> memref<1x32x32xf32, 1> {
 // CHECK:           %[[VAL_1:.*]] = arith.constant 0.000000e+00 : f32
 // CHECK:           %[[VAL_2:.*]] = arith.constant 0 : index
-// CHECK:           %[[VAL_3:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x32x32xf32, 1>
+// CHECK:           %[[VAL_3:.*]] = memref.alloc() alignment = 64 : memref<1x32x32xf32, 1>
 // CHECK:           %[[VAL_4:.*]] = memref.subview %[[VAL_3]][0, 0, 0] [1, 20, 20] [1, 1, 1] : memref<1x32x32xf32, 1> to memref<1x20x20xf32, strided<[1024, 32, 1]>, 1>
 // CHECK:           memref.copy %[[VAL_0]], %[[VAL_4]] : memref<1x20x20xf32, 1> to memref<1x20x20xf32, strided<[1024, 32, 1]>, 1>
-// CHECK:           %[[VAL_5:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x32x32x1xf32, 1>
-// CHECK:           %[[VAL_6:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x8x32x1x4xf32, 1>
+// CHECK:           %[[VAL_5:.*]] = memref.alloc() alignment = 64 : memref<1x32x32x1xf32, 1>
+// CHECK:           %[[VAL_6:.*]] = memref.alloc() alignment = 64 : memref<1x8x32x1x4xf32, 1>
 // CHECK:           linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]} outs(%[[VAL_6]] : memref<1x8x32x1x4xf32, 1>) {
 // CHECK:           ^bb0(%[[VAL_7:.*]]: f32):
 // CHECK:             %[[VAL_8:.*]] = linalg.index 0 : index
@@ -108,11 +108,11 @@ func.func private @test_multiple_deallocation_moves(%arg0: memref<45x24x256xf32,
 func.func private @test_users_in_different_blocks_linalig_generic(%arg0: memref<1x20x20xf32, 1>) -> (memref<1x32x32xf32, 1>) {
   %cst = arith.constant 0.000000e+00 : f32
   %c0 = arith.constant 0 : index
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x32x32xf32, 1>
+  %alloc = memref.alloc() alignment = 64 : memref<1x32x32xf32, 1>
   %subview = memref.subview %alloc[0, 0, 0] [1, 20, 20] [1, 1, 1] : memref<1x32x32xf32, 1> to memref<1x20x20xf32, strided<[1024, 32, 1]>, 1>
   memref.copy %arg0, %subview : memref<1x20x20xf32, 1> to memref<1x20x20xf32, strided<[1024, 32, 1]>, 1>
-  %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<1x32x32x1xf32, 1>
-  %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<1x8x32x1x4xf32, 1>
+  %alloc_0 = memref.alloc() alignment = 64 : memref<1x32x32x1xf32, 1>
+  %alloc_1 = memref.alloc() alignment = 64 : memref<1x8x32x1x4xf32, 1>
   linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]} outs(%alloc_1 : memref<1x8x32x1x4xf32, 1>) {
   ^bb0(%out: f32):
     %0 = linalg.index 0 : index
@@ -135,10 +135,10 @@ func.func private @test_users_in_different_blocks_linalig_generic(%arg0: memref<
 // CHECK:           %[[VAL_5:.*]] = arith.constant 8 : index
 // CHECK:           %[[VAL_6:.*]] = arith.constant 45 : index
 // CHECK:           %[[VAL_7:.*]] = arith.constant 24 : index
-// CHECK:           %[[VAL_8:.*]] = memref.alloc() {alignment = 64 : i64} : memref<45x6144xf32, 1>
+// CHECK:           %[[VAL_8:.*]] = memref.alloc() alignment = 64 : memref<45x6144xf32, 1>
 // CHECK:           %[[VAL_9:.*]] = memref.expand_shape %[[VAL_8]] {{\[\[}}0], [1, 2]] output_shape [45, 24, 256] : memref<45x6144xf32, 1> into memref<45x24x256xf32, 1>
-// CHECK:           %[[VAL_10:.*]] = memref.alloc() {alignment = 64 : i64} : memref<24x256xf32, 1>
-// CHECK:           %[[VAL_11:.*]] = memref.alloc() {alignment = 64 : i64} : memref<45x6144xf32, 1>
+// CHECK:           %[[VAL_10:.*]] = memref.alloc() alignment = 64 : memref<24x256xf32, 1>
+// CHECK:           %[[VAL_11:.*]] = memref.alloc() alignment = 64 : memref<45x6144xf32, 1>
 // CHECK:           %[[VAL_12:.*]] = memref.expand_shape %[[VAL_11]] {{\[\[}}0], [1, 2]] output_shape [45, 24, 256] : memref<45x6144xf32, 1> into memref<45x24x256xf32, 1>
 // CHECK:           memref.dealloc %[[VAL_11]] : memref<45x6144xf32, 1>
 // CHECK:           scf.for %[[VAL_13:.*]] = %[[VAL_3]] to %[[VAL_6]] step %[[VAL_4]] {
@@ -160,10 +160,10 @@ func.func private @test_deallocs_in_different_block_forops(%arg0: memref<45x24x2
   %c8 = arith.constant 8 : index
   %c45 = arith.constant 45 : index
   %c24 = arith.constant 24 : index
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<45x6144xf32, 1>
+  %alloc = memref.alloc() alignment = 64 : memref<45x6144xf32, 1>
   %expand_shape = memref.expand_shape %alloc [[0], [1, 2]] output_shape [45, 24, 256] : memref<45x6144xf32, 1> into memref<45x24x256xf32, 1>
-  %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<24x256xf32, 1>
-  %alloc_2 = memref.alloc() {alignment = 64 : i64} : memref<45x6144xf32, 1>
+  %alloc_1 = memref.alloc() alignment = 64 : memref<24x256xf32, 1>
+  %alloc_2 = memref.alloc() alignment = 64 : memref<45x6144xf32, 1>
   %expand_shape2 = memref.expand_shape %alloc_2 [[0], [1, 2]] output_shape [45, 24, 256] : memref<45x6144xf32, 1> into memref<45x24x256xf32, 1>
   scf.for %arg3 = %c0 to %c45 step %c1 {
     scf.for %arg4 = %c0 to %c24 step %c8 {
@@ -180,11 +180,11 @@ func.func private @test_deallocs_in_different_block_forops(%arg0: memref<45x24x2
 
 // -----
 // CHECK-LABEL:   func.func private @test_conditional_deallocation() -> memref<32xf32, 1> {
-// CHECK:           %[[VAL_0:.*]] = memref.alloc() {alignment = 64 : i64} : memref<32xf32, 1>
+// CHECK:           %[[VAL_0:.*]] = memref.alloc() alignment = 64 : memref<32xf32, 1>
 // CHECK:           %[[VAL_1:.*]] = arith.constant true
 // CHECK:           %[[VAL_2:.*]] = scf.if %[[VAL_1]] -> (memref<32xf32, 1>) {
 // CHECK:             memref.dealloc %[[VAL_0]] : memref<32xf32, 1>
-// CHECK:             %[[VAL_3:.*]] = memref.alloc() {alignment = 64 : i64} : memref<32xf32, 1>
+// CHECK:             %[[VAL_3:.*]] = memref.alloc() alignment = 64 : memref<32xf32, 1>
 // CHECK:             scf.yield %[[VAL_3]] : memref<32xf32, 1>
 // CHECK:           } else {
 // CHECK:             scf.yield %[[VAL_0]] : memref<32xf32, 1>
@@ -195,11 +195,11 @@ func.func private @test_deallocs_in_different_block_forops(%arg0: memref<45x24x2
 // This test will check for a conditional allocation. we dont want to hoist the deallocation
 // in the conditional branch
 func.func private @test_conditional_deallocation() -> memref<32xf32, 1> {
-  %0 = memref.alloc() {alignment = 64 : i64} : memref<32xf32, 1>
+  %0 = memref.alloc() alignment = 64 : memref<32xf32, 1>
   %true = arith.constant true 
   %3 = scf.if %true -> (memref<32xf32, 1>) {
     memref.dealloc %0: memref<32xf32, 1>
-    %1 = memref.alloc() {alignment = 64 : i64} : memref<32xf32, 1>
+    %1 = memref.alloc() alignment = 64 : memref<32xf32, 1>
     scf.yield %1 : memref<32xf32, 1>
   }
   else {

--- a/mlir/test/Dialect/Bufferization/Transforms/static-memory-planner-analysis.mlir
+++ b/mlir/test/Dialect/Bufferization/Transforms/static-memory-planner-analysis.mlir
@@ -7,7 +7,7 @@
 // CHECK-LABEL: func @simple_sequential
 func.func @simple_sequential() {
   // Arena is i8 buffer: 1024*4 + 512*4 = 6144 bytes
-  // CHECK: %[[ARENA:.*]] = memref.alloc() {alignment = 1 : i64} : memref<6144xi8>
+  // CHECK: %[[ARENA:.*]] = memref.alloc() alignment = 1 : memref<6144xi8>
   // First allocation at offset 0
   // CHECK-NEXT: %[[C0:.*]] = arith.constant 0 : index
   // CHECK-NEXT: %[[VIEW0:.*]] = memref.view %[[ARENA]][%[[C0]]][] : memref<6144xi8> to memref<1024xf32>
@@ -29,7 +29,7 @@ func.func @simple_sequential() {
 // CHECK-LABEL: func @non_sequential_pairs
 func.func @non_sequential_pairs() {
   // Arena: 1024*4 + 512*4 = 6144 bytes
-  // CHECK: %[[ARENA:.*]] = memref.alloc() {alignment = 1 : i64} : memref<6144xi8>
+  // CHECK: %[[ARENA:.*]] = memref.alloc() alignment = 1 : memref<6144xi8>
   // First allocation at offset 0
   // CHECK-NEXT: %[[C0:.*]] = arith.constant 0 : index
   // CHECK-NEXT: %[[VIEW0:.*]] = memref.view %[[ARENA]][%[[C0]]][] : memref<6144xi8> to memref<1024xf32>
@@ -51,7 +51,7 @@ func.func @non_sequential_pairs() {
 // CHECK-LABEL: func @interleaved_pairs
 func.func @interleaved_pairs() {
   // Arena: 512*4 + 256*4 + 128*4 = 3584 bytes
-  // CHECK: %[[ARENA:.*]] = memref.alloc() {alignment = 1 : i64} : memref<3584xi8>
+  // CHECK: %[[ARENA:.*]] = memref.alloc() alignment = 1 : memref<3584xi8>
   // First at offset 0
   // CHECK-NEXT: %[[C0:.*]] = arith.constant 0 : index
   // CHECK-NEXT: %[[VIEW0:.*]] = memref.view %[[ARENA]][%[[C0]]][] : memref<3584xi8> to memref<512xf32>
@@ -89,7 +89,7 @@ func.func @dynamic_shape_skipped(%n: index) {
 // CHECK-LABEL: func @multiple_sequential
 func.func @multiple_sequential() {
   // Arena: 1024*4 + 512*4 + 2048*4 = 14336 bytes
-  // CHECK: %[[ARENA:.*]] = memref.alloc() {alignment = 1 : i64} : memref<14336xi8>
+  // CHECK: %[[ARENA:.*]] = memref.alloc() alignment = 1 : memref<14336xi8>
   // First at offset 0
   // CHECK-NEXT: %[[C0:.*]] = arith.constant 0 : index
   // CHECK-NEXT: %[[VIEW0:.*]] = memref.view %[[ARENA]][%[[C0]]][] : memref<14336xi8> to memref<1024xf32>
@@ -116,7 +116,7 @@ func.func @multiple_sequential() {
 // CHECK-LABEL: func @alignment_padding
 func.func @alignment_padding() {
   // Arena: 256*4 + 128*4 + 64*4 = 1792 bytes, alignment = lcm(128,64,128) = 128
-  // CHECK: %[[ARENA:.*]] = memref.alloc() {alignment = 128 : i64} : memref<1792xi8>
+  // CHECK: %[[ARENA:.*]] = memref.alloc() alignment = 128 : memref<1792xi8>
   // First alloc: 256 f32, alignment=128, offset=0 bytes (128-aligned)
   // CHECK-NEXT: %[[C0:.*]] = arith.constant 0 : index
   // CHECK-NEXT: %[[VIEW0:.*]] = memref.view %[[ARENA]][%[[C0]]][] : memref<1792xi8> to memref<256xf32>
@@ -128,11 +128,11 @@ func.func @alignment_padding() {
   // CHECK-NEXT: %[[VIEW2:.*]] = memref.view %[[ARENA]][%[[C1536]]][] : memref<1792xi8> to memref<64xf32>
   // CHECK-NOT: memref.alloc
   // CHECK-NOT: memref.dealloc
-  %alloc0 = memref.alloc() {alignment = 128 : i64} : memref<256xf32>
+  %alloc0 = memref.alloc() alignment = 128 : memref<256xf32>
   memref.dealloc %alloc0 : memref<256xf32>
-  %alloc1 = memref.alloc() {alignment = 64 : i64} : memref<128xf32>
+  %alloc1 = memref.alloc() alignment = 64 : memref<128xf32>
   memref.dealloc %alloc1 : memref<128xf32>
-  %alloc2 = memref.alloc() {alignment = 128 : i64} : memref<64xf32>
+  %alloc2 = memref.alloc() alignment = 128 : memref<64xf32>
   memref.dealloc %alloc2 : memref<64xf32>
   return
 }
@@ -147,7 +147,7 @@ func.func @alignment_padding() {
 func.func @lcm_alignment() {
   // Arena: 3*4 + 3*4 = 24 bytes, but second alloc needs 16-byte offset
   // (alignTo(12, 16) = 16), so total = 28 bytes, alignment = lcm(4,16) = 16
-  // CHECK: %[[ARENA:.*]] = memref.alloc() {alignment = 16 : i64} : memref<28xi8>
+  // CHECK: %[[ARENA:.*]] = memref.alloc() alignment = 16 : memref<28xi8>
   // First at offset 0 (alignment=4, 0 % 4 == 0)
   // CHECK-NEXT: %[[C0:.*]] = arith.constant 0 : index
   // CHECK-NEXT: %[[VIEW0:.*]] = memref.view %[[ARENA]][%[[C0]]][] : memref<28xi8> to memref<3xi32>
@@ -156,9 +156,9 @@ func.func @lcm_alignment() {
   // CHECK-NEXT: %[[VIEW1:.*]] = memref.view %[[ARENA]][%[[C16]]][] : memref<28xi8> to memref<3xi32>
   // CHECK-NOT: memref.alloc
   // CHECK-NOT: memref.dealloc
-  %alloc0 = memref.alloc() {alignment = 4 : i64} : memref<3xi32>
+  %alloc0 = memref.alloc() alignment = 4 : memref<3xi32>
   memref.dealloc %alloc0 : memref<3xi32>
-  %alloc1 = memref.alloc() {alignment = 16 : i64} : memref<3xi32>
+  %alloc1 = memref.alloc() alignment = 16 : memref<3xi32>
   memref.dealloc %alloc1 : memref<3xi32>
   return
 }
@@ -169,7 +169,7 @@ func.func @lcm_alignment() {
 // CHECK-LABEL: func @select_single_alloc
 func.func @select_single_alloc() {
   %c = arith.constant true
-  // CHECK: %[[ARENA:.*]] = memref.alloc() {alignment = 1 : i64} : memref<4096xi8>
+  // CHECK: %[[ARENA:.*]] = memref.alloc() alignment = 1 : memref<4096xi8>
   // CHECK-NEXT: %[[C0:.*]] = arith.constant 0 : index
   // CHECK-NEXT: %[[V:.*]] = memref.view %[[ARENA]][%[[C0]]][] : memref<4096xi8> to memref<1024xf32>
   // CHECK-NOT: memref.alloc
@@ -187,7 +187,7 @@ func.func @select_single_alloc() {
 // CHECK-LABEL: func @select_shared_dealloc
 func.func @select_shared_dealloc() {
   %c = arith.constant true
-  // CHECK: %[[ARENA:.*]] = memref.alloc() {alignment = 1 : i64} : memref<8192xi8>
+  // CHECK: %[[ARENA:.*]] = memref.alloc() alignment = 1 : memref<8192xi8>
   // CHECK-NEXT: %[[C0:.*]] = arith.constant 0 : index
   // CHECK-NEXT: %[[V0:.*]] = memref.view %[[ARENA]][%[[C0]]][] : memref<8192xi8> to memref<1024xf32>
   // CHECK-NEXT: %[[C4096:.*]] = arith.constant 4096 : index
@@ -208,7 +208,7 @@ func.func @select_shared_dealloc() {
 // CHECK-LABEL: func @select_two_deallocs
 func.func @select_two_deallocs() {
   %c = arith.constant true
-  // CHECK: %[[ARENA:.*]] = memref.alloc() {alignment = 1 : i64} : memref<8192xi8>
+  // CHECK: %[[ARENA:.*]] = memref.alloc() alignment = 1 : memref<8192xi8>
   // CHECK-NEXT: %[[C0:.*]] = arith.constant 0 : index
   // CHECK-NEXT: %{{.*}} = memref.view %[[ARENA]][%[[C0]]][] : memref<8192xi8> to memref<1024xf32>
   // CHECK-NEXT: %[[C4096:.*]] = arith.constant 4096 : index
@@ -231,7 +231,7 @@ func.func @select_two_deallocs() {
 // enclosing scf.if, so both are eligible via the buffer view-flow analysis.
 // CHECK-LABEL: func @scf_if_nested_deallocs
 func.func @scf_if_nested_deallocs(%c: i1, %d: i1) {
-  // CHECK: %[[ARENA:.*]] = memref.alloc() {alignment = 1 : i64} : memref<8192xi8>
+  // CHECK: %[[ARENA:.*]] = memref.alloc() alignment = 1 : memref<8192xi8>
   // CHECK-NEXT: %[[C0:.*]] = arith.constant 0 : index
   // CHECK-NEXT: %{{.*}} = memref.view %[[ARENA]][%[[C0]]][] : memref<8192xi8> to memref<1024xf32>
   // CHECK-NEXT: %[[C4096:.*]] = arith.constant 4096 : index
@@ -256,7 +256,7 @@ func.func @scf_if_nested_deallocs(%c: i1, %d: i1) {
 // are planned and the yielded views are rewired automatically.
 // CHECK-LABEL: func @scf_if_result_aliases
 func.func @scf_if_result_aliases(%c: i1) {
-  // CHECK: %[[ARENA:.*]] = memref.alloc() {alignment = 1 : i64} : memref<8192xi8>
+  // CHECK: %[[ARENA:.*]] = memref.alloc() alignment = 1 : memref<8192xi8>
   // CHECK-NEXT: %[[C0:.*]] = arith.constant 0 : index
   // CHECK-NEXT: %[[V0:.*]] = memref.view %[[ARENA]][%[[C0]]][] : memref<8192xi8> to memref<1024xf32>
   // CHECK-NEXT: %[[C4096:.*]] = arith.constant 4096 : index
@@ -416,7 +416,7 @@ func.func @scf_for_orig_alloc_freed_in_body(%lb: index, %ub: index, %step: index
 // left as-is. The two kinds coexist safely in the same function.
 // CHECK-LABEL: func @mixed_static_dynamic
 func.func @mixed_static_dynamic(%n: index) {
-  // CHECK: %[[ARENA:.*]] = memref.alloc() {alignment = 1 : i64} : memref<4096xi8>
+  // CHECK: %[[ARENA:.*]] = memref.alloc() alignment = 1 : memref<4096xi8>
   // CHECK-NEXT: %[[C0:.*]] = arith.constant 0 : index
   // CHECK-NEXT: %{{.*}} = memref.view %[[ARENA]][%[[C0]]][] : memref<4096xi8> to memref<1024xf32>
   // CHECK: memref.alloc(%{{.*}}) : memref<?xf32>
@@ -434,7 +434,7 @@ func.func @mixed_static_dynamic(%n: index) {
 // placed in the arena with both deallocs erased.
 // CHECK-LABEL: func @scf_if_both_branches_dealloc
 func.func @scf_if_both_branches_dealloc(%c: i1) {
-  // CHECK: %[[ARENA:.*]] = memref.alloc() {alignment = 1 : i64} : memref<4096xi8>
+  // CHECK: %[[ARENA:.*]] = memref.alloc() alignment = 1 : memref<4096xi8>
   // CHECK-NEXT: %[[C0:.*]] = arith.constant 0 : index
   // CHECK-NEXT: %{{.*}} = memref.view %[[ARENA]][%[[C0]]][] : memref<4096xi8> to memref<1024xf32>
   // CHECK-NOT: memref.alloc
@@ -455,7 +455,7 @@ func.func @scf_if_both_branches_dealloc(%c: i1) {
 // lifetime conservative. The alloc still transforms correctly.
 // CHECK-LABEL: func @deep_nested_dealloc
 func.func @deep_nested_dealloc(%c1: i1, %c2: i1, %c3: i1) {
-  // CHECK: %[[ARENA:.*]] = memref.alloc() {alignment = 1 : i64} : memref<4096xi8>
+  // CHECK: %[[ARENA:.*]] = memref.alloc() alignment = 1 : memref<4096xi8>
   // CHECK-NEXT: %[[C0:.*]] = arith.constant 0 : index
   // CHECK-NEXT: %{{.*}} = memref.view %[[ARENA]][%[[C0]]][] : memref<4096xi8> to memref<1024xf32>
   // CHECK-NOT: memref.alloc
@@ -478,7 +478,7 @@ func.func @deep_nested_dealloc(%c1: i1, %c2: i1, %c3: i1) {
 // finds the single dealloc on %1, and transforms both allocs into the arena.
 // CHECK-LABEL: func @chained_scf_if_results
 func.func @chained_scf_if_results(%c1: i1, %c2: i1) {
-  // CHECK: %[[ARENA:.*]] = memref.alloc() {alignment = 1 : i64} : memref<8192xi8>
+  // CHECK: %[[ARENA:.*]] = memref.alloc() alignment = 1 : memref<8192xi8>
   // CHECK-NEXT: %[[C0:.*]] = arith.constant 0 : index
   // CHECK-NEXT: %{{.*}} = memref.view %[[ARENA]][%[[C0]]][] : memref<8192xi8> to memref<1024xf32>
   // CHECK-NEXT: %[[C4096:.*]] = arith.constant 4096 : index
@@ -509,7 +509,7 @@ func.func @chained_scf_if_results(%c1: i1, %c2: i1) {
 // RegionBranchOpInterface), so this exercises the unified analysis path.
 // CHECK-LABEL: func @select_chained_into_scf_if
 func.func @select_chained_into_scf_if(%c1: i1, %c2: i1) {
-  // CHECK: %[[ARENA:.*]] = memref.alloc() {alignment = 1 : i64} : memref<8192xi8>
+  // CHECK: %[[ARENA:.*]] = memref.alloc() alignment = 1 : memref<8192xi8>
   // CHECK-NEXT: %[[C0:.*]] = arith.constant 0 : index
   // CHECK-NEXT: %{{.*}} = memref.view %[[ARENA]][%[[C0]]][] : memref<8192xi8> to memref<1024xf32>
   // CHECK-NEXT: %[[C4096:.*]] = arith.constant 4096 : index
@@ -535,7 +535,7 @@ func.func @select_chained_into_scf_if(%c1: i1, %c2: i1) {
 // both are eligible. They share the same arena despite different dealloc styles.
 // CHECK-LABEL: func @mixed_dealloc_locations
 func.func @mixed_dealloc_locations(%c: i1) {
-  // CHECK: %[[ARENA:.*]] = memref.alloc() {alignment = 1 : i64} : memref<6144xi8>
+  // CHECK: %[[ARENA:.*]] = memref.alloc() alignment = 1 : memref<6144xi8>
   // CHECK-NEXT: %[[C0:.*]] = arith.constant 0 : index
   // CHECK-NEXT: %{{.*}} = memref.view %[[ARENA]][%[[C0]]][] : memref<6144xi8> to memref<1024xf32>
   // CHECK-NEXT: %[[C4096:.*]] = arith.constant 4096 : index
@@ -558,7 +558,7 @@ func.func @mixed_dealloc_locations(%c: i1) {
 // and that the alias analysis traverses both sides of conditionals.
 // CHECK-LABEL: func @nested_else_dealloc
 func.func @nested_else_dealloc(%c1: i1, %c2: i1) {
-  // CHECK: %[[ARENA:.*]] = memref.alloc() {alignment = 1 : i64} : memref<4096xi8>
+  // CHECK: %[[ARENA:.*]] = memref.alloc() alignment = 1 : memref<4096xi8>
   // CHECK-NEXT: %[[C0:.*]] = arith.constant 0 : index
   // CHECK-NEXT: %{{.*}} = memref.view %[[ARENA]][%[[C0]]][] : memref<4096xi8> to memref<1024xf32>
   // CHECK-NOT: memref.alloc
@@ -580,7 +580,7 @@ func.func @nested_else_dealloc(%c1: i1, %c2: i1) {
 // transformation applies cleanly and the loop body receives the arena views.
 // CHECK-LABEL: func @scf_for_reads_entry_block_bufs
 func.func @scf_for_reads_entry_block_bufs(%lb: index, %ub: index, %step: index) {
-  // CHECK: %[[ARENA:.*]] = memref.alloc() {alignment = 1 : i64} : memref<8192xi8>
+  // CHECK: %[[ARENA:.*]] = memref.alloc() alignment = 1 : memref<8192xi8>
   // CHECK-NEXT: %[[C0:.*]] = arith.constant 0 : index
   // CHECK-NEXT: %[[VA:.*]] = memref.view %[[ARENA]][%[[C0]]][] : memref<8192xi8> to memref<1024xf32>
   // CHECK-NEXT: %[[C4096:.*]] = arith.constant 4096 : index

--- a/mlir/test/Dialect/Bufferization/Transforms/static-memory-planner-best-fit.mlir
+++ b/mlir/test/Dialect/Bufferization/Transforms/static-memory-planner-best-fit.mlir
@@ -8,7 +8,7 @@
 // CHECK-LABEL: func @reuse_non_overlapping
 func.func @reuse_non_overlapping() {
   // Arena should be 4096 bytes (1024 * 4), not 8192.
-  // CHECK: %[[ARENA:.*]] = memref.alloc() {alignment = 1 : i64} : memref<4096xi8>
+  // CHECK: %[[ARENA:.*]] = memref.alloc() alignment = 1 : memref<4096xi8>
   // First allocation at offset 0
   // CHECK-NEXT: %[[C0_0:.*]] = arith.constant 0 : index
   // CHECK-NEXT: %{{.*}} = memref.view %[[ARENA]][%[[C0_0]]][] : memref<4096xi8> to memref<1024xf32>
@@ -28,7 +28,7 @@ func.func @reuse_non_overlapping() {
 // CHECK-LABEL: func @no_reuse_overlapping
 func.func @no_reuse_overlapping() {
   // Both are live at the same time, so arena = 4096 + 2048 = 6144 bytes.
-  // CHECK: %[[ARENA:.*]] = memref.alloc() {alignment = 1 : i64} : memref<6144xi8>
+  // CHECK: %[[ARENA:.*]] = memref.alloc() alignment = 1 : memref<6144xi8>
   // CHECK-NEXT: %[[C0:.*]] = arith.constant 0 : index
   // CHECK-NEXT: %{{.*}} = memref.view %[[ARENA]][%[[C0]]][] : memref<6144xi8> to memref<1024xf32>
   // CHECK-NEXT: %[[C4096:.*]] = arith.constant 4096 : index
@@ -52,7 +52,7 @@ func.func @no_reuse_overlapping() {
 // Best-fit should pick one of the 1024-byte gaps (smallest fit for 512).
 // CHECK-LABEL: func @best_fit_smallest_gap
 func.func @best_fit_smallest_gap() {
-  // CHECK: %[[ARENA:.*]] = memref.alloc() {alignment = 1 : i64} : memref<10240xi8>
+  // CHECK: %[[ARENA:.*]] = memref.alloc() alignment = 1 : memref<10240xi8>
   // A at offset 0
   // CHECK-NEXT: %{{.*}} = arith.constant 0 : index
   // CHECK-NEXT: %{{.*}} = memref.view %[[ARENA]]
@@ -91,7 +91,7 @@ func.func @best_fit_smallest_gap() {
 //   E must go past the arena high-water mark.
 // CHECK-LABEL: func @best_fit_alignment
 func.func @best_fit_alignment() {
-  // CHECK: %[[ARENA:.*]] = memref.alloc() {alignment = 256 : i64} : memref<576xi8>
+  // CHECK: %[[ARENA:.*]] = memref.alloc() alignment = 256 : memref<576xi8>
   // CHECK-NEXT: %{{.*}} = arith.constant 0 : index
   // CHECK-NEXT: %{{.*}} = memref.view %[[ARENA]]{{.*}} to memref<128xi8>
   // CHECK-NEXT: %{{.*}} = arith.constant 128 : index
@@ -104,12 +104,12 @@ func.func @best_fit_alignment() {
   // E cannot fit in gap (alignment 256), placed at offset 512
   // CHECK-NEXT: %{{.*}} = arith.constant 512 : index
   // CHECK-NEXT: %{{.*}} = memref.view %[[ARENA]]{{.*}} to memref<64xi8>
-  %a = memref.alloc() {alignment = 128 : i64} : memref<128xi8>
+  %a = memref.alloc() alignment = 128 : memref<128xi8>
   %b = memref.alloc() : memref<56xi8>
-  %c = memref.alloc() {alignment = 128 : i64} : memref<128xi8>
+  %c = memref.alloc() alignment = 128 : memref<128xi8>
   memref.dealloc %b : memref<56xi8>
-  %d = memref.alloc() {alignment = 128 : i64} : memref<64xi8>
-  %e = memref.alloc() {alignment = 256 : i64} : memref<64xi8>
+  %d = memref.alloc() alignment = 128 : memref<64xi8>
+  %e = memref.alloc() alignment = 256 : memref<64xi8>
   memref.dealloc %a : memref<128xi8>
   memref.dealloc %c : memref<128xi8>
   memref.dealloc %d : memref<64xi8>

--- a/mlir/test/Dialect/Bufferization/bufferize.mlir
+++ b/mlir/test/Dialect/Bufferization/bufferize.mlir
@@ -2,7 +2,7 @@
 
 // CHECK-LABEL: @alloc_tensor_static
 func.func @alloc_tensor_static() -> tensor<8x16xf32> {
-  // CHECK: %[[ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<8x16xf32>
+  // CHECK: %[[ALLOC:.*]] = memref.alloc() alignment = 64 : memref<8x16xf32>
   // CHECK: return %[[ALLOC]]
   %0 = bufferization.alloc_tensor() : tensor<8x16xf32>
   return %0 : tensor<8x16xf32>
@@ -15,7 +15,7 @@ func.func @alloc_tensor_static() -> tensor<8x16xf32> {
 // CHECK-LABEL: @alloc_tensor_dynamic
 // CHECK-SAME:    %[[D0:.*]]: index
 func.func @alloc_tensor_dynamic(%d0: index) -> tensor<?x16xf32> {
-  // CHECK: %[[ALLOC:.*]] = memref.alloc(%[[D0]]) {alignment = 64 : i64} : memref<?x16xf32>
+  // CHECK: %[[ALLOC:.*]] = memref.alloc(%[[D0]]) alignment = 64 : memref<?x16xf32>
   // CHECK: return %[[ALLOC]]
   %0 = bufferization.alloc_tensor(%d0) : tensor<?x16xf32>
   return %0 : tensor<?x16xf32>
@@ -29,7 +29,7 @@ func.func @alloc_tensor_dynamic(%d0: index) -> tensor<?x16xf32> {
 
 // CHECK-LABEL: @alloc_tensor_memory_space
 func.func @alloc_tensor_memory_space(%i: index) -> f32 {
-  // CHECK: memref.alloc() {alignment = 64 : i64} : memref<8x16xf32, 1>
+  // CHECK: memref.alloc() alignment = 64 : memref<8x16xf32, 1>
   %0 = bufferization.alloc_tensor() {memory_space = 1 : i64} : tensor<8x16xf32>
   %1 = tensor.extract %0[%i, %i] : tensor<8x16xf32>
   return %1 : f32
@@ -42,7 +42,7 @@ func.func @alloc_tensor_memory_space(%i: index) -> f32 {
 // CHECK-LABEL: @alloc_tensor_copy
 // CHECK-SAME:    %[[ARG:.*]]: memref<8x16xf32
 func.func @alloc_tensor_copy(%arg0: tensor<8x16xf32>) -> tensor<8x16xf32> {
-  // CHECK: %[[ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<8x16xf32>
+  // CHECK: %[[ALLOC:.*]] = memref.alloc() alignment = 64 : memref<8x16xf32>
   // CHECK: memref.copy %[[ARG]], %[[ALLOC]]
   // CHECK: return %[[ALLOC]]
   %0 = bufferization.alloc_tensor() copy(%arg0) : tensor<8x16xf32>
@@ -64,7 +64,7 @@ func.func @alloc_tensor_dead() {
 
 // CHECK-LABEL: @dealloc_tensor
 func.func @dealloc_tensor() {
-  // CHECK: %[[ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<8x16xf32>
+  // CHECK: %[[ALLOC:.*]] = memref.alloc() alignment = 64 : memref<8x16xf32>
   // CHECK: memref.dealloc %[[ALLOC]]
   %0 = bufferization.alloc_tensor() : tensor<8x16xf32>
   bufferization.dealloc_tensor %0 : tensor<8x16xf32>

--- a/mlir/test/Dialect/GPU/invalid.mlir
+++ b/mlir/test/Dialect/GPU/invalid.mlir
@@ -814,7 +814,7 @@ func.func @memset_incompatible_shape(%dst : memref<?xf32>, %value : i32) {
 // -----
 
 func.func @mmamatrix_invalid_shape(){
-    %wg = memref.alloca() {alignment = 32} : memref<32x32xf16, 3>
+    %wg = memref.alloca() alignment = 32 : memref<32x32xf16, 3>
     %i = arith.constant 16 : index
     // expected-error @+1 {{MMAMatrixType must have exactly two dimensions}}
     %0 = gpu.subgroup_mma_load_matrix %wg[%i, %i] {leadDimension = 32 : index} : memref<32x32xf16, 3> -> !gpu.mma_matrix<16x16x16xf16, "AOp">
@@ -824,7 +824,7 @@ func.func @mmamatrix_invalid_shape(){
 // -----
 
 func.func @mmamatrix_operand_type(){
-    %wg = memref.alloca() {alignment = 32} : memref<32x32xf16, 3>
+    %wg = memref.alloca() alignment = 32 : memref<32x32xf16, 3>
     %i = arith.constant 16 : index
     // expected-error @+1 {{operand expected to be one of AOp, BOp or COp}}
     %0 = gpu.subgroup_mma_load_matrix %wg[%i, %i] {leadDimension = 32 : index} : memref<32x32xf16, 3> -> !gpu.mma_matrix<16x16xf16, "EOp">
@@ -834,7 +834,7 @@ func.func @mmamatrix_operand_type(){
 // -----
 
 func.func @mmamatrix_invalid_element_type(){
-    %wg = memref.alloca() {alignment = 32} : memref<32x32xf16, 3>
+    %wg = memref.alloca() alignment = 32 : memref<32x32xf16, 3>
     %i = arith.constant 16 : index
     // expected-error @+1 {{MMAMatrixType elements must be SI8, UI8, I32, F16, F32, or F64}}
     %0 = gpu.subgroup_mma_load_matrix %wg[%i, %i] {leadDimension = 32 : index} : memref<32x32xf16, 3> -> !gpu.mma_matrix<16x16xbf16, "AOp">
@@ -846,7 +846,7 @@ func.func @mmamatrix_invalid_element_type(){
 #layout_map_col_major = affine_map<(i, j) -> (j, i)>
 
 func.func @mmaLoadOp_identity_layout(){
-    %wg = memref.alloca() {alignment = 32} : memref<32x32xf16, #layout_map_col_major, 3>
+    %wg = memref.alloca() alignment = 32 : memref<32x32xf16, #layout_map_col_major, 3>
     %i = arith.constant 16 : index
     // expected-error @+1 {{expected source memref most minor dim must have unit stride}}
     %0 = gpu.subgroup_mma_load_matrix %wg[%i, %i] {leadDimension = 32 : index} : memref<32x32xf16, #layout_map_col_major, 3> -> !gpu.mma_matrix<16x16xf16, "AOp">
@@ -866,7 +866,7 @@ func.func @mma_invalid_memref_type(%src: memref<32x4xvector<4x8xf32>>, %i: index
 #layout_map_col_major = affine_map<(i, j) -> (j, i)>
 
 func.func @wmmaStoreOp_invalid_map(%arg0 : !gpu.mma_matrix<16x16xf16, "COp">) -> () {
-    %sg = memref.alloca(){alignment = 32} : memref<32x32xf16, #layout_map_col_major, 3>
+    %sg = memref.alloca() alignment = 32 : memref<32x32xf16, #layout_map_col_major, 3>
     %i = arith.constant 16 : index
     %j = arith.constant 16 : index
     // expected-error @+1 {{expected destination memref most minor dim must have unit stride}}
@@ -877,7 +877,7 @@ func.func @wmmaStoreOp_invalid_map(%arg0 : !gpu.mma_matrix<16x16xf16, "COp">) ->
 // -----
 
 func.func @wmmaStoreOp_invalid_store_operand(%arg0 : !gpu.mma_matrix<16x16xf16, "AOp">) -> () {
-    %sg = memref.alloca(){alignment = 32} : memref<32x32xf16, 3>
+    %sg = memref.alloca() alignment = 32 : memref<32x32xf16, 3>
     %i = arith.constant 16 : index
     %j = arith.constant 16 : index
     // expected-error @+1 {{expected the operand matrix being stored to have 'COp' operand type}}

--- a/mlir/test/Dialect/GPU/ops.mlir
+++ b/mlir/test/Dialect/GPU/ops.mlir
@@ -437,7 +437,7 @@ module attributes {gpu.container_module} {
 
   func.func @mmamatrix_valid_scalar_element_type(%src : memref<32x32xf16, affine_map<(d0, d1) -> (d0 * 64 + d1)>>){
     // CHECK-LABEL: func @mmamatrix_valid_scalar_element_type
-    %wg = memref.alloca() {alignment = 32} : memref<32x32xf16, 3>
+    %wg = memref.alloca() alignment = 32 : memref<32x32xf16, 3>
     // CHECK: %[[wg:.*]] = memref.alloca()
     %i = arith.constant 16 : index
     // CHECK: %[[i:.*]] = arith.constant 16 : index

--- a/mlir/test/Dialect/GPU/subgroup-mma-vector-unroll.mlir
+++ b/mlir/test/Dialect/GPU/subgroup-mma-vector-unroll.mlir
@@ -57,7 +57,7 @@ func.func @gathered_matmul(%lhs: memref<32x32xf32>, %rhs: memref<32x32xf32>, %ou
   %cst_0 = arith.constant 0.000000e+00 : f32
   %cst_1 = arith.constant dense<[0, 1, 2, 3]> : vector<4xindex>
   %cst_2 = arith.constant dense<1> : vector<4x4xindex>
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<32x32xf32>
+  %alloc = memref.alloc() alignment = 64 : memref<32x32xf32>
   %3 = gpu.thread_id x
   %4 = gpu.thread_id y
   %5 = affine.apply affine_map<()[s0] -> (s0 * 16)>()[%4]

--- a/mlir/test/Dialect/Linalg/collapse-dim.mlir
+++ b/mlir/test/Dialect/Linalg/collapse-dim.mlir
@@ -76,7 +76,7 @@ func.func @uncollapsable(%arg0 : tensor<41x3x1x57xf32>, %arg1 : tensor<3x1x57x41
 // CHECK-LABEL:   func.func private @collapsable_memref(
 // CHECK-SAME:                                          %[[VAL_0:.*]]: memref<1x24x32x8xf32>,
 // CHECK-SAME:                                          %[[VAL_1:.*]]: memref<1x24x32x8xf32>) -> memref<1x24x32x8xf32> {
-// CHECK:           %[[VAL_2:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x24x32x8xf32>
+// CHECK:           %[[VAL_2:.*]] = memref.alloc() alignment = 64 : memref<1x24x32x8xf32>
 // CHECK:           %[[VAL_3:.*]] = memref.collapse_shape %[[VAL_0]] {{\[\[}}0], [1], [2, 3]] : memref<1x24x32x8xf32> into memref<1x24x256xf32>
 // CHECK:           %[[VAL_4:.*]] = memref.collapse_shape %[[VAL_1]] {{\[\[}}0], [1], [2, 3]] : memref<1x24x32x8xf32> into memref<1x24x256xf32>
 // CHECK:           %[[VAL_5:.*]] = memref.collapse_shape %[[VAL_2]] {{\[\[}}0], [1], [2, 3]] : memref<1x24x32x8xf32> into memref<1x24x256xf32>
@@ -89,7 +89,7 @@ func.func @uncollapsable(%arg0 : tensor<41x3x1x57xf32>, %arg1 : tensor<3x1x57x41
 // CHECK:         }
 
 func.func private @collapsable_memref(%arg0: memref<1x24x32x8xf32>, %arg1: memref<1x24x32x8xf32>) -> (memref<1x24x32x8xf32>) {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x24x32x8xf32>
+  %alloc = memref.alloc() alignment = 64 : memref<1x24x32x8xf32>
   linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%arg0, %arg1 : memref<1x24x32x8xf32>, memref<1x24x32x8xf32>) outs(%alloc : memref<1x24x32x8xf32>) {
   ^bb0(%in: f32, %in_0: f32, %out: f32):
     %0 = arith.addf %in, %in_0 : f32
@@ -134,7 +134,7 @@ func.func @collapsable_memref_projected_ops(%arg0: memref<1x24x32x8xf32>, %arg1:
 //  CHECK-SAME:       iterator_types = ["parallel", "parallel", "parallel", "parallel"]
 
 func.func @uncollapsable_strided_memref(%arg0: memref<2x6x24x48xi32>, %arg1: memref<2x6x24x48xi32>) -> (memref<2x6x24x48xi32>) {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x6x24x48xi32>
+  %alloc = memref.alloc() alignment = 64 : memref<2x6x24x48xi32>
   %subview = memref.subview %arg0[0, 0, 0, 0] [1, 3, 12, 24] [1, 1, 1, 1] : memref<2x6x24x48xi32> to memref<1x3x12x24xi32, strided<[6912, 1152, 48, 1], offset: 0>>
   %subview0 = memref.subview %arg1[0, 0, 0, 0] [1, 3, 12, 24] [1, 1, 1, 1] : memref<2x6x24x48xi32> to memref<1x3x12x24xi32, strided<[6912, 1152, 48, 1], offset: 0>>
   %subview1 = memref.subview %alloc[0, 0, 0, 0] [1, 3, 12, 24] [1, 1, 1, 1] : memref<2x6x24x48xi32> to memref<1x3x12x24xi32, strided<[6912, 1152, 48, 1], offset: 0>>

--- a/mlir/test/Dialect/Linalg/fold-add-into-dest.mlir
+++ b/mlir/test/Dialect/Linalg/fold-add-into-dest.mlir
@@ -267,12 +267,12 @@ module attributes {transform.with_named_sequence} {
 
 // -----
 
-memref.global "private" constant @big_const : memref<2048x2048xf32> = dense<1.11111104> {alignment = 64 : i64}
+memref.global "private" constant @big_const : memref<2048x2048xf32> = dense<1.11111104> alignment = 64
 func.func @expect_no_fold_due_to_no_memref_support(%arg0: memref<2048x2048xf32>, %arg1: memref<2048x2048xf32>) -> memref<2048x2048xf32> {
   %cst = arith.constant 0.000000e+00 : f32
   %0 = memref.get_global @big_const  : memref<2048x2048xf32>
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<2048x2048xf32>
-  %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<2048x2048xf32>
+  %alloc = memref.alloc() alignment = 64 : memref<2048x2048xf32>
+  %alloc_0 = memref.alloc() alignment = 64 : memref<2048x2048xf32>
   linalg.fill ins(%cst : f32) outs(%alloc_0 : memref<2048x2048xf32>)
   linalg.matmul ins(%arg0, %0 : memref<2048x2048xf32>, memref<2048x2048xf32>) outs(%alloc_0 : memref<2048x2048xf32>)
   linalg.fill ins(%cst : f32) outs(%alloc : memref<2048x2048xf32>)

--- a/mlir/test/Dialect/Linalg/hoisting.mlir
+++ b/mlir/test/Dialect/Linalg/hoisting.mlir
@@ -821,7 +821,7 @@ func.func @no_hoisting_collapse_shape(%in_0: memref<1x20x1xi32>, %1: memref<9x1x
   %c0 = arith.constant 0 : index
   %c4 = arith.constant 4 : index
   %c20 = arith.constant 20 : index
-  %alloca = memref.alloca() {alignment = 64 : i64} : memref<1x4x1xi32>
+  %alloca = memref.alloca() alignment = 64 : memref<1x4x1xi32>
   scf.for %arg0 = %c0 to %c20 step %c4 {
     %subview = memref.subview %in_0[0, %arg0, 0] [1, 4, 1] [1, 1, 1] : memref<1x20x1xi32> to memref<1x4x1xi32, strided<[20, 1, 1], offset: ?>>
     %collapse_shape = memref.collapse_shape %alloca [[0, 1, 2]] : memref<1x4x1xi32> into memref<4xi32>
@@ -858,7 +858,7 @@ func.func @no_hoisting_collapse_shape_2(%vec: vector<1x12x1xi32>) {
   %c0 = arith.constant 0 : index
   %c4 = arith.constant 4 : index
   %c20 = arith.constant 20 : index
-  %alloca = memref.alloca() {alignment = 64 : i64} : memref<1x12x1xi32>
+  %alloca = memref.alloca() alignment = 64 : memref<1x12x1xi32>
   scf.for %arg0 = %c0 to %c20 step %c4 {
     %collapse_shape = memref.collapse_shape %alloca [[0, 1, 2]] : memref<1x12x1xi32> into memref<12xi32>
     vector.transfer_write %vec, %alloca[%c0, %c0, %c0] {in_bounds = [true, true, true]} : vector<1x12x1xi32>, memref<1x12x1xi32>
@@ -902,7 +902,7 @@ func.func @no_hoisting_write_to_buffer(%rhs: i32, %arg1: vector<1xi32>) {
   %c1 = arith.constant 1 : index
   %c4 = arith.constant 4 : index
   %c20 = arith.constant 20 : index
-  %alloca = memref.alloca() {alignment = 64 : i64} : memref<1x1x2xi32>
+  %alloca = memref.alloca() alignment = 64 : memref<1x1x2xi32>
   %cast = memref.cast %alloca : memref<1x1x2xi32> to memref<1x1x2xi32>
   %collapsed_1 = memref.collapse_shape %alloca [[0, 1, 2]] : memref<1x1x2xi32> into memref<2xi32>
   scf.for %_ = %c0 to %c20 step %c4 {

--- a/mlir/test/Dialect/Linalg/one-shot-bufferize.mlir
+++ b/mlir/test/Dialect/Linalg/one-shot-bufferize.mlir
@@ -44,7 +44,7 @@ func.func @not_inplace(
   %f0 = arith.constant 0.0 : f32
 
   //     CHECK: %[[D0:.*]] = memref.dim %[[A]], {{.*}} : memref<?xf32, strided<[?], offset: ?>>
-  //     CHECK: %[[ALLOC:.*]] = memref.alloc(%[[D0]]) {alignment = 64 : i64} : memref<?xf32>
+  //     CHECK: %[[ALLOC:.*]] = memref.alloc(%[[D0]]) alignment = 64 : memref<?xf32>
   //     CHECK: linalg.fill ins(%[[F0]] : f32) outs(%[[ALLOC]] : memref<?xf32>)
   %r = linalg.fill ins(%f0 : f32) outs(%A : tensor<?xf32>) -> tensor<?xf32>
 
@@ -160,7 +160,7 @@ func.func @matmul(
   %c16 = arith.constant 16 : index
 
   // Hoisted alloc.
-  // CHECK: %[[ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<8x16xf32>
+  // CHECK: %[[ALLOC:.*]] = memref.alloc() alignment = 64 : memref<8x16xf32>
 
   // CHECK: scf.for %[[I:.*]] =
   %0 = scf.for %arg3 = %c0 to %c128 step %c8 iter_args(%arg4 = %C) -> (tensor<128x192xf32>) {

--- a/mlir/test/Dialect/Linalg/promote.mlir
+++ b/mlir/test/Dialect/Linalg/promote.mlir
@@ -290,12 +290,12 @@ module attributes {transform.with_named_sequence} {
   // CHECK-SAME:                                                                 %[[VAL_0:.*]]: memref<8x4xf32, 1>,
   // CHECK-SAME:                                                                 %[[VAL_1:.*]]: memref<8x4xf32, 1>) -> memref<8x4xf32, 1> {
 func.func @linalg_generic_update_all_function_inputs_outputs(%arg0: memref<8x4xf32, 1>, %arg1: memref<8x4xf32, 1>) -> memref<8x4xf32, 1> {
-  // CHECK:           %[[VAL_2:.*]] = memref.alloc() {alignment = 64 : i64} : memref<8x4xf32, 1>
+  // CHECK:           %[[VAL_2:.*]] = memref.alloc() alignment = 64 : memref<8x4xf32, 1>
   // CHECK:           %[[VAL_3:.*]] = memref.subview %[[VAL_0]][0, 0] [4, 3] [1, 1] : memref<8x4xf32, 1> to memref<4x3xf32, strided<[4, 1]>, 1>
   // CHECK:           %[[VAL_4:.*]] = memref.subview %[[VAL_1]][0, 0] [4, 3] [1, 1] : memref<8x4xf32, 1> to memref<4x3xf32, strided<[4, 1]>, 1>
   // CHECK:           %[[VAL_5:.*]] = memref.subview %[[VAL_2]][0, 0] [4, 3] [1, 1] : memref<8x4xf32, 1> to memref<4x3xf32, strided<[4, 1]>, 1>
 
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<8x4xf32, 1>
+  %alloc = memref.alloc() alignment = 64 : memref<8x4xf32, 1>
   %subview = memref.subview %arg0[0, 0] [4, 3] [1, 1] : memref<8x4xf32, 1> to memref<4x3xf32, strided<[4, 1]>, 1>
   %subview_0 = memref.subview %arg1[0, 0] [4, 3] [1, 1] : memref<8x4xf32, 1> to memref<4x3xf32, strided<[4, 1]>, 1>
   %subview_1 = memref.subview %alloc[0, 0] [4, 3] [1, 1] : memref<8x4xf32, 1> to memref<4x3xf32, strided<[4, 1]>, 1>

--- a/mlir/test/Dialect/Linalg/transform-op-linalg-copy-to-memref.mlir
+++ b/mlir/test/Dialect/Linalg/transform-op-linalg-copy-to-memref.mlir
@@ -21,14 +21,14 @@ module attributes {transform.with_named_sequence} {
 // -----
 
 // CHECK:  func.func @linalg_copy_to_memref_copy_strides(%[[INPUT:.*]]: memref<128x32xf32>, %[[OUTPUT:.*]]: memref<128x64xf32>) {
-// CHECK:    %[[ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<128x64xf32>
+// CHECK:    %[[ALLOC:.*]] = memref.alloc() alignment = 64 : memref<128x64xf32>
 // CHECK:    %[[SUBVIEW:.*]] = memref.subview %[[ALLOC]][0, 32] [128, 32] [1, 1] : memref<128x64xf32> to memref<128x32xf32, strided<[64, 1], offset: 32>>
 // CHECK:    memref.copy %[[INPUT]], %[[SUBVIEW]] : memref<128x32xf32> to memref<128x32xf32, strided<[64, 1], offset: 32>>
 // CHECK:    return
 // CHECK:  }
 
 func.func @linalg_copy_to_memref_copy_strides(%input : memref<128x32xf32>, %output : memref<128x64xf32>) {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<128x64xf32>
+  %alloc = memref.alloc() alignment = 64 : memref<128x64xf32>
   %subview = memref.subview %alloc[0, 32] [128, 32] [1, 1] : memref<128x64xf32> to memref<128x32xf32, strided<[64, 1], offset: 32>>
   linalg.copy ins(%input : memref<128x32xf32>) outs(%subview : memref<128x32xf32, strided<[64, 1], offset: 32>>)
   return

--- a/mlir/test/Dialect/Linalg/transform-promotion.mlir
+++ b/mlir/test/Dialect/Linalg/transform-promotion.mlir
@@ -145,7 +145,7 @@ func.func @aligned_promote_fill(%arg0: memref<?x?xf32, strided<[?, 1], offset: ?
 // CHECK-LABEL: func @aligned_promote_fill
 // CHECK:         %[[cf:.*]] = arith.constant 1.{{.*}} : f32
 // CHECK:         %[[s0:.*]] = memref.subview {{.*}}: memref<?x?xf32, strided{{.*}}> to memref<?x?xf32, strided{{.*}}>
-// CHECK:         %[[a0:.*]] = memref.alloc() {alignment = 32 : i64} : memref<32000000xi8>
+// CHECK:         %[[a0:.*]] = memref.alloc() alignment = 32 : memref<32000000xi8>
 // CHECK:         %[[v0:.*]] = memref.view %[[a0]]{{.*}} : memref<32000000xi8> to memref<?x?xf32>
 // CHECK:         %[[l0:.*]] = memref.subview %[[v0]][0, 0] [%{{.*}}, %{{.*}}] [1, 1] : memref<?x?xf32> to memref<?x?xf32, strided<[?, 1]>>
 // CHECK:         linalg.fill ins({{.*}} : f32) outs(%[[v0]] : memref<?x?xf32>)
@@ -178,7 +178,7 @@ func.func @aligned_promote_fill_complex(%arg0: memref<?x?xcomplex<f32>, strided<
 // CHECK-LABEL: func @aligned_promote_fill_complex
 // CHECK:         %[[cc:.*]] = complex.create {{.*}} : complex<f32>
 // CHECK:         %[[s0:.*]] = memref.subview {{.*}}: memref<?x?xcomplex<f32>, strided{{.*}}> to memref<?x?xcomplex<f32>, strided{{.*}}>
-// CHECK:         %[[a0:.*]] = memref.alloc() {alignment = 32 : i64} : memref<64000000xi8>
+// CHECK:         %[[a0:.*]] = memref.alloc() alignment = 32 : memref<64000000xi8>
 // CHECK:         %[[v0:.*]] = memref.view %[[a0]]{{.*}} : memref<64000000xi8> to memref<?x?xcomplex<f32>>
 // CHECK:         %[[l0:.*]] = memref.subview %[[v0]][0, 0] [%{{.*}}, %{{.*}}] [1, 1] : memref<?x?xcomplex<f32>> to memref<?x?xcomplex<f32>, strided<[?, 1]>>
 // CHECK:         linalg.fill ins({{.*}} : complex<f32>) outs(%[[v0]] : memref<?x?xcomplex<f32>>)

--- a/mlir/test/Dialect/MLProgram/one-shot-bufferize.mlir
+++ b/mlir/test/Dialect/MLProgram/one-shot-bufferize.mlir
@@ -62,11 +62,11 @@ func.func @global_load_store_tensor() -> tensor<4x75xf32> {
   // CHECK-DAG:     %[[GLOB:.*]] = memref.get_global @state_tensor
   // CHECK:         %[[VAL:.*]] = memref.load %[[GLOB]][%[[C0]], %[[C0]]]
   // CHECK:         %[[ADD:.*]] = arith.addf %[[VAL]], %[[CST]]
-  // CHECK:         %[[ALLOC1:.*]] = memref.alloc() {alignment = 64 : i64}
+  // CHECK:         %[[ALLOC1:.*]] = memref.alloc() alignment = 64
   // CHECK:         memref.copy %[[GLOB]], %[[ALLOC1]] 
   // CHECK:         memref.store %[[ADD]], %[[ALLOC1]][%[[C0]], %[[C0]]] 
   // CHECK:         %[[TENSOR:.*]] = bufferization.to_tensor %[[ALLOC1]] 
-  // CHECK:         %[[ALLOC2:.*]] = memref.alloc() {alignment = 64 : i64}
+  // CHECK:         %[[ALLOC2:.*]] = memref.alloc() alignment = 64
   // CHECK:         memref.copy %[[ALLOC1]], %[[ALLOC2]] 
   // CHECK:         %[[GLOB_REF:.*]] = memref.get_global @state_tensor 
   // CHECK:         memref.copy %[[ALLOC2]], %[[GLOB_REF]] 

--- a/mlir/test/Dialect/MemRef/canonicalize.mlir
+++ b/mlir/test/Dialect/MemRef/canonicalize.mlir
@@ -380,9 +380,9 @@ func.func @alloc_const_fold() -> memref<?xf32> {
 
 // CHECK-LABEL: func @alloc_alignment_const_fold
 func.func @alloc_alignment_const_fold() -> memref<?xf32> {
-  // CHECK-NEXT: memref.alloc() {alignment = 4096 : i64} : memref<4xf32>
+  // CHECK-NEXT: memref.alloc() alignment = 4096 : memref<4xf32>
   %c4 = arith.constant 4 : index
-  %a = memref.alloc(%c4) {alignment = 4096 : i64} : memref<?xf32>
+  %a = memref.alloc(%c4) alignment = 4096 : memref<?xf32>
 
   // CHECK-NEXT: memref.cast %{{.*}} : memref<4xf32> to memref<?xf32>
   // CHECK-NEXT: return %{{.*}} : memref<?xf32>
@@ -1514,10 +1514,10 @@ func.func @fold_trivial_subviews(%m: memref<?xf32, strided<[?], offset: ?>>,
 // CHECK-LABEL: func @load_store_nontemporal(
 func.func @load_store_nontemporal(%input : memref<32xf32, affine_map<(d0) -> (d0)>>, %output : memref<32xf32, affine_map<(d0) -> (d0)>>) {
   %1 = arith.constant 7 : index
-  // CHECK: memref.load %{{.*}}[%{{.*}}] {nontemporal = true} : memref<32xf32>
-  %2 = memref.load %input[%1] {nontemporal = true} : memref<32xf32, affine_map<(d0) -> (d0)>>
-  // CHECK: memref.store %{{.*}}, %{{.*}}[%{{.*}}] {nontemporal = true} : memref<32xf32>
-  memref.store %2, %output[%1] {nontemporal = true} : memref<32xf32, affine_map<(d0) -> (d0)>>
+  // CHECK: memref.load %{{.*}}[%{{.*}}] nontemporal(true) : memref<32xf32>
+  %2 = memref.load %input[%1] nontemporal(true) : memref<32xf32, affine_map<(d0) -> (d0)>>
+  // CHECK: memref.store %{{.*}}, %{{.*}}[%{{.*}}] nontemporal(true) : memref<32xf32>
+  memref.store %2, %output[%1] nontemporal(true) : memref<32xf32, affine_map<(d0) -> (d0)>>
   func.return
 }
 

--- a/mlir/test/Dialect/MemRef/emulate-wide-int.mlir
+++ b/mlir/test/Dialect/MemRef/emulate-wide-int.mlir
@@ -55,15 +55,15 @@ func.func @alloc_load_store_i64() {
 // CHECK-LABEL: func @alloc_load_store_i64_nontemporal
 // CHECK:         [[C1:%.+]] = arith.constant dense<[1, 0]> : vector<2xi32>
 // CHECK-NEXT:    [[M:%.+]]  = memref.alloc() : memref<4xvector<2xi32>, 1>
-// CHECK-NEXT:    [[V:%.+]]  = memref.load [[M]][{{%.+}}] {nontemporal = true} : memref<4xvector<2xi32>, 1>
-// CHECK-NEXT:    memref.store [[C1]], [[M]][{{%.+}}] {nontemporal = true} : memref<4xvector<2xi32>, 1>
+// CHECK-NEXT:    [[V:%.+]]  = memref.load [[M]][{{%.+}}] nontemporal(true) : memref<4xvector<2xi32>, 1>
+// CHECK-NEXT:    memref.store [[C1]], [[M]][{{%.+}}] nontemporal(true) : memref<4xvector<2xi32>, 1>
 // CHECK-NEXT:    return
 func.func @alloc_load_store_i64_nontemporal() {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : i64
     %m = memref.alloc() : memref<4xi64, 1>
-    %v = memref.load %m[%c0] {nontemporal = true} : memref<4xi64, 1>
-    memref.store %c1, %m[%c0] {nontemporal = true} : memref<4xi64, 1>
+    %v = memref.load %m[%c0] nontemporal(true) : memref<4xi64, 1>
+    memref.store %c1, %m[%c0] nontemporal(true) : memref<4xi64, 1>
     return
 }
 

--- a/mlir/test/Dialect/MemRef/expand-realloc.mlir
+++ b/mlir/test/Dialect/MemRef/expand-realloc.mlir
@@ -3,7 +3,7 @@
 
 func.func @reallow_lowering_example(%init_size: index, %new_size: index) -> memref<?xf32> {
   %alloc = memref.alloc(%init_size) : memref<?xf32>
-  %realloc = memref.realloc %alloc (%new_size) {alignment = 8}: memref<?xf32> to memref<?xf32>
+  %realloc = memref.realloc %alloc (%new_size) alignment = 8: memref<?xf32> to memref<?xf32>
   return %realloc : memref<?xf32>
 }
 
@@ -14,7 +14,7 @@ func.func @reallow_lowering_example(%init_size: index, %new_size: index) -> memr
 //  CHECK-NEXT:   [[CURR_SIZE:%.+]] = memref.dim [[OLD_ALLOC]], [[C0]]
 //  CHECK-NEXT:   [[COND:%.+]] = arith.cmpi ult, [[CURR_SIZE]], [[NEW_SIZE]]
 //  CHECK-NEXT:   [[REALLOC:%.+]] = scf.if [[COND]]
-//  CHECK-NEXT:     [[NEW_ALLOC:%.+]] = memref.alloc([[NEW_SIZE]]) {alignment = 8 : i64} : memref<?xf32>
+//  CHECK-NEXT:     [[NEW_ALLOC:%.+]] = memref.alloc([[NEW_SIZE]]) alignment = 8 : memref<?xf32>
 //  CHECK-NEXT:     [[SUBVIEW:%.+]] = memref.subview [[NEW_ALLOC]][0] [[[CURR_SIZE]]] [1]
 //  CHECK-NEXT:     memref.copy [[OLD_ALLOC]], [[SUBVIEW]]
 //  CHECK-NEXT:     memref.dealloc [[OLD_ALLOC]]
@@ -30,7 +30,7 @@ func.func @reallow_lowering_example(%init_size: index, %new_size: index) -> memr
 
 func.func @reallow_lowering_example() -> memref<4xf32> {
   %alloc = memref.alloc() : memref<2xf32>
-  %realloc = memref.realloc %alloc {alignment = 8}: memref<2xf32> to memref<4xf32>
+  %realloc = memref.realloc %alloc alignment = 8: memref<2xf32> to memref<4xf32>
   return %realloc : memref<4xf32>
 }
 
@@ -40,7 +40,7 @@ func.func @reallow_lowering_example() -> memref<4xf32> {
 //  CHECK-NEXT:   [[NEW_SIZE:%.+]] = arith.constant 4
 //  CHECK-NEXT:   [[COND:%.+]] = arith.cmpi ult, [[CURR_SIZE]], [[NEW_SIZE]]
 //  CHECK-NEXT:   [[REALLOC:%.+]] = scf.if [[COND]]
-//  CHECK-NEXT:     [[NEW_ALLOC:%.+]] = memref.alloc() {alignment = 8 : i64} : memref<4xf32>
+//  CHECK-NEXT:     [[NEW_ALLOC:%.+]] = memref.alloc() alignment = 8 : memref<4xf32>
 //  CHECK-NEXT:     [[SUBVIEW:%.+]] = memref.subview [[NEW_ALLOC]][0] [2] [1]
 //  CHECK-NEXT:     memref.copy [[OLD_ALLOC]], [[SUBVIEW]]
 //  CHECK-NEXT:     memref.dealloc [[OLD_ALLOC]]

--- a/mlir/test/Dialect/MemRef/extract-address-computations.mlir
+++ b/mlir/test/Dialect/MemRef/extract-address-computations.mlir
@@ -42,12 +42,12 @@ module attributes {transform.with_named_sequence} {
 // CHECK-SAME: %[[DYN_OFFSET:.*]]: index)
 // CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
 // CHECK-DAG: %[[SUBVIEW:.*]] = memref.subview %[[BASE]][%[[DYN_OFFSET]], 0, 8] [1, 1, 1] [1, 1, 1] : memref<2x16x16xf32> to memref<1x1x1xf32, strided<[256, 16, 1], offset: ?>>
-// CHECK: %[[LOADED_VAL:.*]] = memref.load %[[SUBVIEW]][%[[C0]], %[[C0]], %[[C0]]] {nontemporal = true} : memref<1x1x1xf32, strided<[256, 16, 1], offset: ?>>
+// CHECK: %[[LOADED_VAL:.*]] = memref.load %[[SUBVIEW]][%[[C0]], %[[C0]], %[[C0]]] nontemporal(true) : memref<1x1x1xf32, strided<[256, 16, 1], offset: ?>>
 // CHECK: return %[[LOADED_VAL]] : f32
 func.func @test_load_nontemporal(%base : memref<2x16x16xf32>, %offset : index) -> f32 {
   %c0 = arith.constant 0 : index
   %c8 = arith.constant 8 : index
-  %loaded_val = memref.load %base[%offset, %c0, %c8] {nontemporal = true } : memref<2x16x16xf32>
+  %loaded_val = memref.load %base[%offset, %c0, %c8] nontemporal(true) : memref<2x16x16xf32>
   return %loaded_val : f32
 }
 
@@ -104,13 +104,13 @@ module attributes {transform.with_named_sequence} {
 // CHECK-DAG: %[[CF0:.*]] = arith.constant 0.0{{0*e\+00}} : f32
 // CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
 // CHECK-DAG: %[[SUBVIEW:.*]] = memref.subview %[[BASE]][%[[DYN_OFFSET]], 0, 8] [1, 1, 1] [1, 1, 1] : memref<2x16x16xf32> to memref<1x1x1xf32, strided<[256, 16, 1], offset: ?>>
-// CHECK: memref.store %[[CF0]], %[[SUBVIEW]][%[[C0]], %[[C0]], %[[C0]]] {nontemporal = true} : memref<1x1x1xf32, strided<[256, 16, 1], offset: ?>>
+// CHECK: memref.store %[[CF0]], %[[SUBVIEW]][%[[C0]], %[[C0]], %[[C0]]] nontemporal(true) : memref<1x1x1xf32, strided<[256, 16, 1], offset: ?>>
 // CHECK: return
 func.func @test_store_nontemporal(%base : memref<2x16x16xf32>, %offset : index) -> () {
   %cf0 = arith.constant 0.0 : f32
   %c0 = arith.constant 0 : index
   %c8 = arith.constant 8 : index
-  memref.store %cf0, %base[%offset, %c0, %c8] { nontemporal = true } : memref<2x16x16xf32>
+  memref.store %cf0, %base[%offset, %c0, %c8] nontemporal(true) : memref<2x16x16xf32>
   return
 }
 

--- a/mlir/test/Dialect/MemRef/fold-memref-alias-ops.mlir
+++ b/mlir/test/Dialect/MemRef/fold-memref-alias-ops.mlir
@@ -413,13 +413,13 @@ func.func @fold_masked_vector_transfer_write_with_rank_reducing_subview(
 func.func @fold_dynamic_subview_with_memref_load_expand_shape(%arg0 : memref<16x?xf32, strided<[16, 1]>>, %arg1 : index, %arg2 : index, %sz0: index) -> f32 {
   %c0 = arith.constant 0 : index
   %expand_shape = memref.expand_shape %arg0 [[0, 1], [2, 3]] output_shape [1, 16, %sz0, 1] : memref<16x?xf32, strided<[16, 1]>> into memref<1x16x?x1xf32, strided<[256, 16, 1, 1]>>
-  %0 = memref.load %expand_shape[%c0, %arg1, %arg2, %c0] {nontemporal = true} : memref<1x16x?x1xf32, strided<[256, 16, 1, 1]>>
+  %0 = memref.load %expand_shape[%c0, %arg1, %arg2, %c0] nontemporal(true) : memref<1x16x?x1xf32, strided<[256, 16, 1, 1]>>
   return %0 : f32
 }
 // CHECK-NEXT: %[[C0:.*]] = arith.constant 0
 // CHECK-NEXT: %[[INDEX1:.*]] = affine.linearize_index disjoint [%[[C0]], %[[ARG1]]] by (1, 16)
 // CHECK-NEXT: %[[INDEX2:.*]] = affine.linearize_index disjoint [%[[ARG2]], %[[C0]]] by (%[[ARG3]], 1)
-// CHECK-NEXT: %[[VAL1:.*]] = memref.load %[[ARG0]][%[[INDEX1]], %[[INDEX2]]] {nontemporal = true} : memref<16x?xf32, strided<[16, 1]>>
+// CHECK-NEXT: %[[VAL1:.*]] = memref.load %[[ARG0]][%[[INDEX1]], %[[INDEX2]]] nontemporal(true) : memref<16x?xf32, strided<[16, 1]>>
 // CHECK-NEXT: return %[[VAL1]] : f32
 
 // -----
@@ -430,14 +430,14 @@ func.func @fold_dynamic_subview_with_memref_store_expand_shape(%arg0 : memref<16
   %c0 = arith.constant 0 : index
   %c1f32 = arith.constant 1.0 : f32
   %expand_shape = memref.expand_shape %arg0 [[0, 1], [2, 3]] output_shape [1, 16, %sz0, 1] : memref<16x?xf32, strided<[16, 1]>> into memref<1x16x?x1xf32, strided<[256, 16, 1, 1]>>
-  memref.store %c1f32, %expand_shape[%c0, %arg1, %arg2, %c0] {nontemporal = true} : memref<1x16x?x1xf32, strided<[256, 16, 1, 1]>>
+  memref.store %c1f32, %expand_shape[%c0, %arg1, %arg2, %c0] nontemporal(true) : memref<1x16x?x1xf32, strided<[256, 16, 1, 1]>>
   return
 }
 // CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
 // CHECK-DAG: %[[C1F32:.*]] = arith.constant 1.000000e+00 : f32
 // CHECK-NEXT: %[[INDEX1:.*]] = affine.linearize_index disjoint [%[[C0]], %[[ARG1]]] by (1, 16)
 // CHECK-NEXT: %[[INDEX2:.*]] = affine.linearize_index disjoint [%[[ARG2]], %[[C0]]] by (%[[ARG3]], 1)
-// CHECK-NEXT: memref.store %[[C1F32]], %[[ARG0]][%[[INDEX1]], %[[INDEX2]]] {nontemporal = true} : memref<16x?xf32, strided<[16, 1]>>
+// CHECK-NEXT: memref.store %[[C1F32]], %[[ARG0]][%[[INDEX1]], %[[INDEX2]]] nontemporal(true) : memref<16x?xf32, strided<[16, 1]>>
 // CHECK-NEXT: return
 
 // -----
@@ -531,21 +531,21 @@ func.func @subview_of_subview_rank_reducing_no_unit_stride(%arg0: memref<8x8xf32
 // -----
 
 // CHECK-LABEL: func @fold_load_keep_nontemporal(
-//      CHECK:   memref.load %{{.+}}[%{{.+}}, %{{.+}}] {nontemporal = true}
+//      CHECK:   memref.load %{{.+}}[%{{.+}}, %{{.+}}] nontemporal(true)
 func.func @fold_load_keep_nontemporal(%arg0 : memref<12x32xf32>, %arg1 : index, %arg2 : index, %arg3 : index, %arg4 : index) -> f32 {
   %0 = memref.subview %arg0[%arg1, %arg2][4, 4][2, 3] : memref<12x32xf32> to memref<4x4xf32, strided<[64, 3], offset: ?>>
-  %1 = memref.load %0[%arg3, %arg4] {nontemporal = true }: memref<4x4xf32, strided<[64, 3], offset: ?>>
+  %1 = memref.load %0[%arg3, %arg4] nontemporal(true): memref<4x4xf32, strided<[64, 3], offset: ?>>
   return %1 : f32
 }
 
 // -----
 
 // CHECK-LABEL: func @fold_store_keep_nontemporal(
-//      CHECK:   memref.store %{{.+}}, %{{.+}}[%{{.+}}, %{{.+}}]  {nontemporal = true} : memref<12x32xf32>
+//      CHECK:   memref.store %{{.+}}, %{{.+}}[%{{.+}}, %{{.+}}] nontemporal(true) : memref<12x32xf32>
 func.func @fold_store_keep_nontemporal(%arg0 : memref<12x32xf32>, %arg1 : index, %arg2 : index, %arg3 : index, %arg4 : index, %arg5 : f32) {
   %0 = memref.subview %arg0[%arg1, %arg2][4, 4][2, 3] :
     memref<12x32xf32> to memref<4x4xf32, strided<[64, 3], offset: ?>>
-  memref.store %arg5, %0[%arg3, %arg4] {nontemporal=true}: memref<4x4xf32, strided<[64, 3], offset: ?>>
+  memref.store %arg5, %0[%arg3, %arg4] nontemporal(true): memref<4x4xf32, strided<[64, 3], offset: ?>>
   return
 }
 
@@ -1131,7 +1131,7 @@ func.func @fold_vector_transfer_read_rank_mismatch(
 func.func @fold_memref_load_collapse_shape(
   %arg0 : memref<4x8xf32>, %arg1 : index) -> f32 {
   %0 = memref.collapse_shape %arg0 [[0, 1]] : memref<4x8xf32> into memref<32xf32>
-  %1 = memref.load %0[%arg1] {nontemporal = true} : memref<32xf32>
+  %1 = memref.load %0[%arg1] nontemporal(true) : memref<32xf32>
   return %1 : f32
 }
 
@@ -1139,7 +1139,7 @@ func.func @fold_memref_load_collapse_shape(
 //  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: memref<4x8xf32>
 //  CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
 //       CHECK:   %[[IDXS:.*]]:2 = affine.delinearize_index %[[ARG1]] into (4, 8)
-//       CHECK:   memref.load %[[ARG0]][%[[IDXS]]#0, %[[IDXS]]#1] {nontemporal = true}
+//       CHECK:   memref.load %[[ARG0]][%[[IDXS]]#0, %[[IDXS]]#1] nontemporal(true)
 
 // -----
 
@@ -1178,7 +1178,7 @@ func.func @fold_vector_maskedload_collapse_shape(
 func.func @fold_memref_store_collapse_shape(
   %arg0 : memref<4x8xf32>, %arg1 : index, %val : f32) {
   %0 = memref.collapse_shape %arg0 [[0, 1]] : memref<4x8xf32> into memref<32xf32>
-  memref.store %val, %0[%arg1] {nontemporal = true} : memref<32xf32>
+  memref.store %val, %0[%arg1] nontemporal(true) : memref<32xf32>
   return
 }
 
@@ -1186,7 +1186,7 @@ func.func @fold_memref_store_collapse_shape(
 //  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: memref<4x8xf32>
 //  CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
 //       CHECK:   %[[IDXS:.*]]:2 = affine.delinearize_index %[[ARG1]] into (4, 8)
-//       CHECK:   memref.store %{{.*}}, %[[ARG0]][%[[IDXS]]#0, %[[IDXS]]#1] {nontemporal = true}
+//       CHECK:   memref.store %{{.*}}, %[[ARG0]][%[[IDXS]]#0, %[[IDXS]]#1] nontemporal(true)
 
 // -----
 

--- a/mlir/test/Dialect/MemRef/invalid.mlir
+++ b/mlir/test/Dialect/MemRef/invalid.mlir
@@ -381,7 +381,7 @@ func.func @mismatched_types() {
 // -----
 
 // expected-error @+1 {{'memref.global' op attribute 'alignment' failed to satisfy constraint: 64-bit signless integer attribute whose value is positive and whose value is a power of two > 0}}
-memref.global "private" @gv : memref<4xf32> = dense<1.0> { alignment = 63 }
+memref.global "private" @gv : memref<4xf32> = dense<1.0> alignment = 63
 
 // -----
 
@@ -996,7 +996,7 @@ func.func @test_store_zero_results2(%x: i32, %p: memref<i32>) {
 func.func @invalid_load_alignment(%memref: memref<4xi32>) {
   %c0 = arith.constant 0 : index
   // expected-error @below {{'memref.load' op attribute 'alignment' failed to satisfy constraint: 64-bit signless integer attribute whose value is positive and whose value is a power of two > 0}}
-  %val = memref.load %memref[%c0] { alignment = -1 } : memref<4xi32>
+  %val = memref.load %memref[%c0] alignment(-1) : memref<4xi32>
   return
 }
 
@@ -1005,7 +1005,7 @@ func.func @invalid_load_alignment(%memref: memref<4xi32>) {
 func.func @invalid_store_alignment(%memref: memref<4xi32>, %val: i32) {
   %c0 = arith.constant 0 : index
   // expected-error @below {{'memref.store' op attribute 'alignment' failed to satisfy constraint: 64-bit signless integer attribute whose value is positive and whose value is a power of two > 0}}
-  memref.store %val, %memref[%c0] { alignment = 3 } : memref<4xi32>
+  memref.store %val, %memref[%c0] alignment(3) : memref<4xi32>
   return
 }
 
@@ -1013,7 +1013,7 @@ func.func @invalid_store_alignment(%memref: memref<4xi32>, %val: i32) {
 
 func.func @invalid_alloc_alignment() {
   // expected-error @below {{'memref.alloc' op attribute 'alignment' failed to satisfy constraint: 64-bit signless integer attribute whose value is positive and whose value is a power of two > 0}}
-  %0 = memref.alloc() {alignment = 3} : memref<4xf32>
+  %0 = memref.alloc() alignment = 3 : memref<4xf32>
   return
 }
 
@@ -1021,7 +1021,7 @@ func.func @invalid_alloc_alignment() {
 
 func.func @invalid_realloc_alignment(%src: memref<4xf32>) {
   // expected-error @below {{'memref.realloc' op attribute 'alignment' failed to satisfy constraint: 64-bit signless integer attribute whose value is positive and whose value is a power of two > 0}}
-  %0 = memref.realloc %src {alignment = 7} : memref<4xf32> to memref<8xf32>
+  %0 = memref.realloc %src alignment = 7 : memref<4xf32> to memref<8xf32>
   return
 }
 

--- a/mlir/test/Dialect/MemRef/normalize-memrefs-ops.mlir
+++ b/mlir/test/Dialect/MemRef/normalize-memrefs-ops.mlir
@@ -200,9 +200,9 @@ func.func @test_reinterpret_cast(%arg0: memref<5x7xf32>, %arg1: memref<5x7xf32>,
 
 // CHECK-LABEL: reinterpret_cast_non_zero_offset
 func.func @reinterpret_cast_non_zero_offset(%arg0: index, %arg1: memref<1x10x17xi32, strided<[?, ?, ?], offset: ?>>, %arg2: memref<1x10x17xi32, strided<[?, ?, ?], offset: ?>>, %arg3: memref<1x10x17xi32, strided<[?, ?, ?], offset: ?>>) -> (memref<1x5xf32, strided<[17, 1], offset: 27>>, memref<1x5xf32, strided<[17, 1], offset: 27>>, memref<2x17xf32>, memref<1x10x17xi32>, memref<1x10x17xf32>) {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x10x17xi32>
-  %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<2x17xf32>
-  %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<1x10x17xf32>
+  %alloc = memref.alloc() alignment = 64 : memref<1x10x17xi32>
+  %alloc_0 = memref.alloc() alignment = 64 : memref<2x17xf32>
+  %alloc_1 = memref.alloc() alignment = 64 : memref<1x10x17xf32>
   cf.br ^bb3
 ^bb3:  // pred: ^bb1
   // CHECK: %[[REINTERPRET_CAST:.*]] = memref.reinterpret_cast %{{.*}} to offset: [0], sizes: [32], strides: [1] : memref<2x17xf32> to memref<32xf32>

--- a/mlir/test/Dialect/MemRef/normalize-memrefs.mlir
+++ b/mlir/test/Dialect/MemRef/normalize-memrefs.mlir
@@ -159,8 +159,8 @@ func.func @semi_affine_layout_map(%s0: index, %s1: index) {
 
 // CHECK-LABEL: func @alignment
 func.func @alignment() {
-  %A = memref.alloc() {alignment = 32 : i64}: memref<64x128x256xf32, affine_map<(d0, d1, d2) -> (d2, d0, d1)>>
-  // CHECK-NEXT: memref.alloc() {alignment = 32 : i64} : memref<256x64x128xf32>
+  %A = memref.alloc() alignment = 32: memref<64x128x256xf32, affine_map<(d0, d1, d2) -> (d2, d0, d1)>>
+  // CHECK-NEXT: memref.alloc() alignment = 32 : memref<256x64x128xf32>
   return
 }
 

--- a/mlir/test/Dialect/MemRef/ops.mlir
+++ b/mlir/test/Dialect/MemRef/ops.mlir
@@ -57,8 +57,8 @@ func.func @alloca() {
   %3 = memref.alloca(%c1)[%c0] : memref<2x?xf32, affine_map<(d0, d1)[s0] -> (d0 + s0, d1)>, 1>
 
   // Alloca with no mappings, but with alignment.
-  // CHECK: %{{.*}} = memref.alloca() {alignment = 64 : i64} : memref<2xi32>
-  %4 = memref.alloca() {alignment = 64} : memref<2 x i32>
+  // CHECK: %{{.*}} = memref.alloca() alignment = 64 : memref<2xi32>
+  %4 = memref.alloca() alignment = 64 : memref<2 x i32>
 
   return
 }
@@ -278,18 +278,18 @@ func.func @zero_dim_no_idx(%arg0 : memref<i32>, %arg1 : memref<i32>, %arg2 : mem
 // CHECK-LABEL: func @load_store_alignment
 func.func @load_store_alignment(%memref: memref<4xi32>) {
   %c0 = arith.constant 0 : index
-  // CHECK: memref.load {{.*}} {alignment = 16 : i64}
-  %val = memref.load %memref[%c0] { alignment = 16 } : memref<4xi32>
-  // CHECK: memref.store {{.*}} {alignment = 16 : i64}
-  memref.store %val, %memref[%c0] { alignment = 16 } : memref<4xi32>
+  // CHECK: memref.load {{.*}} alignment(16) nontemporal(true) invariant(true)
+  %val = memref.load %memref[%c0] invariant(true) alignment(16) nontemporal(true) : memref<4xi32>
+  // CHECK: memref.store {{.*}} alignment(16) nontemporal(true)
+  memref.store %val, %memref[%c0] nontemporal(true) alignment(16) : memref<4xi32>
   return
 }
 
 // CHECK-LABEL: func @load_invariant
 func.func @load_invariant(%memref: memref<4xi32>) {
   %c0 = arith.constant 0 : index
-  // CHECK: memref.load {{.*}} {invariant = true}
-  %val = memref.load %memref[%c0] { invariant = true } : memref<4xi32>
+  // CHECK: memref.load {{.*}} invariant(true)
+  %val = memref.load %memref[%c0] invariant(true) : memref<4xi32>
   return
 }
 

--- a/mlir/test/Dialect/MemRef/transform-ops.mlir
+++ b/mlir/test/Dialect/MemRef/transform-ops.mlir
@@ -579,7 +579,7 @@ module attributes {transform.with_named_sequence} {
 func.func @store_to_load(%arg: vector<4xf32>) -> vector<4xf32> {
   %c0 = arith.constant 0 : index
   %cst_1 = arith.constant 0.000000e+00 : f32
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<64xf32>
+  %alloc = memref.alloc() alignment = 64 : memref<64xf32>
   vector.transfer_write %arg, %alloc[%c0] {in_bounds = [true]} : vector<4xf32>, memref<64xf32>
   %r = vector.transfer_read %alloc[%c0], %cst_1 {in_bounds = [true]} : memref<64xf32>, vector<4xf32>
   return %r : vector<4xf32>
@@ -601,7 +601,7 @@ module attributes {transform.with_named_sequence} {
 //   CHECK-NOT:   vector.transfer_write
 func.func @dead_store_through_subview(%arg: vector<4xf32>) {
   %c0 = arith.constant 0 : index
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<64xf32>
+  %alloc = memref.alloc() alignment = 64 : memref<64xf32>
   %subview = memref.subview %alloc[%c0] [4] [1] : memref<64xf32> to memref<4xf32, affine_map<(d0)[s0] -> (d0 + s0)>>
   vector.transfer_write %arg, %subview[%c0] {in_bounds = [true]}
     : vector<4xf32>, memref<4xf32, affine_map<(d0)[s0] -> (d0 + s0)>>
@@ -624,7 +624,7 @@ module attributes {transform.with_named_sequence} {
 //   CHECK-NOT:   vector.transfer_write
 func.func @dead_store_through_expand(%arg: vector<4xf32>) {
   %c0 = arith.constant 0 : index
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<64xf32>
+  %alloc = memref.alloc() alignment = 64 : memref<64xf32>
   %expand = memref.expand_shape %alloc [[0, 1]] output_shape [16, 4] : memref<64xf32> into memref<16x4xf32>
   vector.transfer_write %arg, %expand[%c0, %c0] {in_bounds = [true]} : vector<4xf32>, memref<16x4xf32>
   return
@@ -646,7 +646,7 @@ module attributes {transform.with_named_sequence} {
 //   CHECK-NOT:   vector.transfer_write
 func.func @dead_store_through_collapse(%arg: vector<4xf32>) {
   %c0 = arith.constant 0 : index
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<16x4xf32>
+  %alloc = memref.alloc() alignment = 64 : memref<16x4xf32>
   %collapse = memref.collapse_shape %alloc [[0, 1]] : memref<16x4xf32> into memref<64xf32>
   vector.transfer_write %arg, %collapse[%c0] {in_bounds = [true]} : vector<4xf32>, memref<64xf32>
   return

--- a/mlir/test/Dialect/NVGPU/optimize-shared-memory.mlir
+++ b/mlir/test/Dialect/NVGPU/optimize-shared-memory.mlir
@@ -278,7 +278,7 @@ func.func @test_vector_element_type() {
 // CHECK-LABEL: func @test_int_conversion
 module {
   func.func @test_int_conversion() {
-    %alloc = memref.alloc() {alignment = 64 : i64} : memref<10xf32, 1 : ui64>
+    %alloc = memref.alloc() alignment = 64 : memref<10xf32, 1 : ui64>
     return
   }
 }

--- a/mlir/test/Dialect/SCF/canonicalize.mlir
+++ b/mlir/test/Dialect/SCF/canonicalize.mlir
@@ -1751,11 +1751,11 @@ func.func @func_execute_region_inline_multi_yield() {
 module {
 func.func private @foo()->()
 func.func private @execute_region_yeilding_external_value() -> memref<1x60xui8> {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x60xui8>  
-  %1 = scf.execute_region -> memref<1x60xui8> no_inline {    
+  %alloc = memref.alloc() alignment = 64 : memref<1x60xui8>
+  %1 = scf.execute_region -> memref<1x60xui8> no_inline {
     func.call @foo():()->()
     scf.yield %alloc: memref<1x60xui8>
-  }  
+  }
   return %1 : memref<1x60xui8>
 }
 }
@@ -1767,19 +1767,19 @@ func.func private @execute_region_yeilding_external_value() -> memref<1x60xui8> 
 // Remove just this operand from the op results.
 
 // CHECK:           %[[VAL_1:.*]] = scf.execute_region -> memref<1x120xui8> no_inline {
-// CHECK:             %[[VAL_2:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x120xui8>
+// CHECK:             %[[VAL_2:.*]] = memref.alloc() alignment = 64 : memref<1x120xui8>
 // CHECK:             func.call @foo() : () -> ()
 // CHECK:             scf.yield %[[VAL_2]] : memref<1x120xui8>
 // CHECK:           }
 module {
 func.func private @foo()->()
 func.func private @execute_region_yeilding_external_and_local_values() -> (memref<1x60xui8>, memref<1x120xui8>) {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x60xui8>  
-  %1, %2 = scf.execute_region -> (memref<1x60xui8>, memref<1x120xui8>) no_inline {    
-    %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<1x120xui8>
+  %alloc = memref.alloc() alignment = 64 : memref<1x60xui8>
+  %1, %2 = scf.execute_region -> (memref<1x60xui8>, memref<1x120xui8>) no_inline {
+    %alloc_1 = memref.alloc() alignment = 64 : memref<1x120xui8>
     func.call @foo():()->()
     scf.yield %alloc, %alloc_1: memref<1x60xui8>,  memref<1x120xui8>
-  }  
+  }
   return %1, %2 : memref<1x60xui8>, memref<1x120xui8>
 }
 }
@@ -1802,18 +1802,18 @@ func.func private @execute_region_yeilding_external_and_local_values() -> (memre
 module {
   func.func private @foo()->()
   func.func private @execute_region_multiple_yields_same_operands() -> (memref<1x60xui8>, memref<1x120xui8>) {
-    %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x60xui8>  
-    %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<1x120xui8>  
+    %alloc = memref.alloc() alignment = 64 : memref<1x60xui8>
+    %alloc_1 = memref.alloc() alignment = 64 : memref<1x120xui8>
     %1, %2 = scf.execute_region -> (memref<1x60xui8>, memref<1x120xui8>) no_inline {
       %c = "test.cmp"() : () -> i1
       cf.cond_br %c, ^bb2, ^bb3
-    ^bb2:    
+    ^bb2:
       func.call @foo():()->()
       scf.yield %alloc, %alloc_1 : memref<1x60xui8>, memref<1x120xui8>
-    ^bb3: 
-      func.call @foo():()->()   
+    ^bb3:
+      func.call @foo():()->()
       scf.yield %alloc, %alloc_1 : memref<1x60xui8>, memref<1x120xui8>
-    }  
+    }
     return %1, %2 : memref<1x60xui8>, memref<1x120xui8>
   }
 }
@@ -1832,19 +1832,19 @@ module {
 module {
   func.func private @foo()->()
   func.func private @execute_region_multiple_yields_different_operands() -> (memref<1x60xui8>, memref<1x120xui8>) {
-    %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x60xui8>  
-    %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<1x120xui8>  
-    %alloc_2 = memref.alloc() {alignment = 64 : i64} : memref<1x120xui8>  
+    %alloc = memref.alloc() alignment = 64 : memref<1x60xui8>
+    %alloc_1 = memref.alloc() alignment = 64 : memref<1x120xui8>
+    %alloc_2 = memref.alloc() alignment = 64 : memref<1x120xui8>
     %1, %2 = scf.execute_region -> (memref<1x60xui8>, memref<1x120xui8>) no_inline {
       %c = "test.cmp"() : () -> i1
       cf.cond_br %c, ^bb2, ^bb3
-    ^bb2:    
+    ^bb2:
       func.call @foo():()->()
       scf.yield %alloc, %alloc_1 : memref<1x60xui8>, memref<1x120xui8>
-    ^bb3: 
-      func.call @foo():()->()   
+    ^bb3:
+      func.call @foo():()->()
       scf.yield %alloc, %alloc_2 : memref<1x60xui8>, memref<1x120xui8>
-    }  
+    }
     return %1, %2 : memref<1x60xui8>, memref<1x120xui8>
   }
 }
@@ -1864,18 +1864,18 @@ module {
 module {
 func.func private @foo()->()
 func.func private @execute_region_multiple_yields_different_operands() -> (memref<1x60xui8>) {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x60xui8>  
-  %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<1x60xui8>   
+  %alloc = memref.alloc() alignment = 64 : memref<1x60xui8>
+  %alloc_1 = memref.alloc() alignment = 64 : memref<1x60xui8>
   %1 = scf.execute_region -> (memref<1x60xui8>) no_inline {
     %c = "test.cmp"() : () -> i1
     cf.cond_br %c, ^bb2, ^bb3
-  ^bb2:    
+  ^bb2:
     func.call @foo():()->()
     scf.yield %alloc : memref<1x60xui8>
-  ^bb3:    
+  ^bb3:
     func.call @foo():()->()
     scf.yield %alloc_1 : memref<1x60xui8>
-  }    
+  }
   return %1 : memref<1x60xui8>
 }
 }
@@ -2268,7 +2268,7 @@ func.func @scf_for_all_step_size_0()  {
 //       CHECK:   scf.index_switch %[[arg0]]
 //       CHECK:   case 1 {
 //       CHECK:     memref.store %[[c10]]
-//       CHECK:   } 
+//       CHECK:   }
 //       CHECK:   default {
 //       CHECK:     memref.store %[[c11]]
 //       CHECK:   }

--- a/mlir/test/Dialect/SCF/one-shot-bufferize-encodings.mlir
+++ b/mlir/test/Dialect/SCF/one-shot-bufferize-encodings.mlir
@@ -14,7 +14,7 @@ func.func @scf_for_iter_arg(%arg0: tensor<128xf32, 1>, %arg1: index, %arg2: inde
 // CHECK-LABEL: func.func @scf_for_iter_arg
 //  CHECK-SAME: (%[[arg0:.+]]: tensor<128xf32, 1 : i64>, %[[arg1:.+]]: index, %[[arg2:.+]]: index, %[[arg3:.+]]: index)
 //       CHECK:     %[[v0:.+]] = bufferization.to_buffer %[[arg0]] : tensor<128xf32, 1 : i64> to memref<128xf32, strided<[?], offset: ?>, 1>
-//       CHECK:     %[[alloc:.+]] = memref.alloc() {alignment = 64 : i64} : memref<128xf32, 1>
+//       CHECK:     %[[alloc:.+]] = memref.alloc() alignment = 64 : memref<128xf32, 1>
 //       CHECK:     memref.copy %[[v0]], %[[alloc]] : memref<128xf32, strided<[?], offset: ?>, 1> to memref<128xf32, 1>
 //       CHECK:     %[[cast:.+]] = memref.cast %[[alloc]] : memref<128xf32, 1> to memref<128xf32, strided<[?], offset: ?>, 1>
 //       CHECK:     %[[v1:.+]] = scf.for %{{.+}} = %[[arg1]] to %[[arg2]] step %[[arg3]] iter_args(%[[arg6:.+]] = %[[cast]]) -> (memref<128xf32, strided<[?], offset: ?>, 1>)

--- a/mlir/test/Dialect/SCF/parallel-loop-fusion.mlir
+++ b/mlir/test/Dialect/SCF/parallel-loop-fusion.mlir
@@ -1231,7 +1231,7 @@ func.func @test_fuse_interchanged_loops(%arg0: memref<1x64xf32>) {
   %c1 = arith.constant 1 : index
   %c0 = arith.constant 0 : index
   %alloc_0 = memref.alloc() : memref<1x8x8xf32>
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<8x8x1xf32>
+  %alloc = memref.alloc() alignment = 64 : memref<8x8x1xf32>
   scf.parallel (%arg2, %arg3) = (%c0, %c0) to (%c8, %c8) step (%c1, %c1) {
     %0 = memref.load %alloc_0[%c0, %arg2, %arg3] : memref<1x8x8xf32>
     memref.store %0, %alloc[%arg3, %arg2, %c0] : memref<8x8x1xf32>

--- a/mlir/test/Dialect/SparseTensor/binary_valued.mlir
+++ b/mlir/test/Dialect/SparseTensor/binary_valued.mlir
@@ -37,7 +37,7 @@
 // CHECK-DAG:       %[[VAL_7:.*]] = arith.constant 3 : index
 // CHECK-DAG:       %[[VAL_8:.*]] = arith.constant 2 : index
 // CHECK-DAG:       %[[VAL_9:.*]] = arith.constant 0.000000e+00 : f32
-// CHECK:           %[[VAL_10:.*]] = memref.alloc() {alignment = 64 : i64} : memref<f32>
+// CHECK:           %[[VAL_10:.*]] = memref.alloc() alignment = 64 : memref<f32>
 // CHECK:           linalg.fill ins(%[[VAL_9]] : f32) outs(%[[VAL_10]] : memref<f32>)
 // CHECK:           %[[VAL_11:.*]] = sparse_tensor.storage_specifier.get %[[VAL_3]]
 // CHECK:           %[[VAL_12:.*]] = memref.subview %[[VAL_0]][0] {{\[}}%[[VAL_11]]] [1] : memref<?xindex> to memref<?xindex>
@@ -98,7 +98,7 @@ func.func @sum_squares(%a: tensor<2x3x8xf32, #Sparse>) -> tensor<f32> {
 // CHECK-DAG:       %[[VAL_7:.*]] = arith.constant 3 : index
 // CHECK-DAG:       %[[VAL_8:.*]] = arith.constant 2 : index
 // CHECK-DAG:       %[[VAL_9:.*]] = arith.constant 0.000000e+00 : f32
-// CHECK:           %[[VAL_10:.*]] = memref.alloc() {alignment = 64 : i64} : memref<f32>
+// CHECK:           %[[VAL_10:.*]] = memref.alloc() alignment = 64 : memref<f32>
 // CHECK:           linalg.fill ins(%[[VAL_9]] : f32) outs(%[[VAL_10]] : memref<f32>)
 // CHECK:           %[[VAL_11:.*]] = sparse_tensor.storage_specifier.get %[[VAL_3]]
 // CHECK:           %[[VAL_12:.*]] = memref.subview %[[VAL_0]][0] {{\[}}%[[VAL_11]]] [1] : memref<?xindex> to memref<?xindex>

--- a/mlir/test/Dialect/SparseTensor/encoding_with_symbols.mlir
+++ b/mlir/test/Dialect/SparseTensor/encoding_with_symbols.mlir
@@ -17,7 +17,7 @@
 func.func @tensor_add(%arg0: tensor<8x8xf32, #Sparse>) -> tensor<8x8xf32> {
   %result_out = tensor.empty() : tensor<8x8xf32>
 
-  // CHECK: %[[ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<8x8xf32>
+  // CHECK: %[[ALLOC:.*]] = memref.alloc() alignment = 64 : memref<8x8xf32>
   // CHECK: %[[RES:.*]] = linalg.add ins(%{{.*}}, %{{.*}} : tensor<8x8xf32, #[[$SPARSE_1]]>, tensor<8x8xf32, #[[$SPARSE_1]]>)
   %result = linalg.add
     ins(%arg0, %arg0 : tensor<8x8xf32, #Sparse>, tensor<8x8xf32, #Sparse>)

--- a/mlir/test/Dialect/SparseTensor/pack_copy.mlir
+++ b/mlir/test/Dialect/SparseTensor/pack_copy.mlir
@@ -22,9 +22,9 @@
 // CHECK-SAME: %[[CRD:.*]]: memref<3xi32>,
 // CHECK-SAME: %[[POS:.*]]: memref<11xi32>,
 // CHECK-SAME: %[[VAL:.*]]: memref<3xf64>)
-// CHECK:      %[[ALLOC2:.*]] = memref.alloc() {alignment = 64 : i64} : memref<11xi32>
+// CHECK:      %[[ALLOC2:.*]] = memref.alloc() alignment = 64 : memref<11xi32>
 // CHECK:      memref.copy %[[POS]], %[[ALLOC2]] : memref<11xi32> to memref<11xi32>
-// CHECK:      %[[ALLOC1:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xf64>
+// CHECK:      %[[ALLOC1:.*]] = memref.alloc() alignment = 64 : memref<3xf64>
 // CHECK:      memref.copy %[[VAL]], %[[ALLOC1]] : memref<3xf64> to memref<3xf64>
 // CHECK-NOT:  memref.copy
 // CHECK:      return

--- a/mlir/test/Dialect/Tensor/bufferize.mlir
+++ b/mlir/test/Dialect/Tensor/bufferize.mlir
@@ -541,7 +541,7 @@ func.func @tensor.reshape(%t1: tensor<?x10xf32>) -> tensor<2x2x5xf32> {
   // CHECK: %[[five:.*]] = arith.constant 5 : i64
   %five = arith.constant 5 : i64
 
-  // CHECK: %[[alloc:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xi64>
+  // CHECK: %[[alloc:.*]] = memref.alloc() alignment = 64 : memref<3xi64>
   // CHECK: %[[zero_idx:.*]] = arith.constant 0 : index
   // CHECK: %[[one_idx:.*]] = arith.constant 1 : index
   // CHECK: %[[two_idx:.*]] = arith.constant 2 : index
@@ -726,7 +726,7 @@ func.func @tensor.concat_dynamic_nonconcat_dim(%f: tensor<?x?xf32>, %g: tensor<?
 // CHECK-DAG:       %[[F_MEMREF:.*]] = bufferization.to_buffer %[[F]]
 // CHECK-DAG:       %[[G_MEMREF:.*]] = bufferization.to_buffer %[[G]]
 // CHECK-DAG:       %[[H_MEMREF:.*]] = bufferization.to_buffer %[[H]]
-// CHECK-DAG:       %[[ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<8x10xf32>
+// CHECK-DAG:       %[[ALLOC:.*]] = memref.alloc() alignment = 64 : memref<8x10xf32>
 // CHECK-DAG:       %[[c1:.*]] = arith.constant 1 : index
 // CHECK:           %[[F_DIM:.*]] = memref.dim %[[F_MEMREF]], %[[c1]]
 // CHECK:           %[[SUBVIEW1:.*]] = memref.subview %[[ALLOC]][0, 0] [8, %[[F_DIM]]] [1, 1]

--- a/mlir/test/Dialect/Tensor/one-shot-bufferize.mlir
+++ b/mlir/test/Dialect/Tensor/one-shot-bufferize.mlir
@@ -114,7 +114,7 @@ func.func @insert_slice_fun_not_inplace(
     %t : tensor<4xf32> {bufferization.writable = false})
   -> tensor<?xf32>
 {
-  //      CHECK: %[[ALLOC:.*]] = memref.alloc(%{{.*}}) {alignment = 64 : i64} : memref<?xf32>
+  //      CHECK: %[[ALLOC:.*]] = memref.alloc(%{{.*}}) alignment = 64 : memref<?xf32>
   //      CHECK: memref.copy %[[A]], %[[ALLOC]] : memref<?xf32{{.*}} to memref<?xf32>
   //      CHECK: %[[SV:.*]] = memref.subview %[[ALLOC]][0] [4] [1] : memref<?xf32> to memref<4xf32, strided<[1]>>
   //      CHECK: memref.copy %[[t]], %[[SV]] : memref<4xf32, strided{{.*}}> to memref<4xf32, strided<[1]>>

--- a/mlir/test/Dialect/Transform/test-promote-tensors.mlir
+++ b/mlir/test/Dialect/Transform/test-promote-tensors.mlir
@@ -67,10 +67,10 @@ func.func @promote_in0_out_bufferize(%arg0: tensor<?x42xf32>, %arg1: tensor<42x?
     // CHECK:  %{{.+}} = memref.dim %{{.+}}, %[[C0]] : memref<?x?xf32, strided<[?, ?], offset: ?>>
     // CHECK:  %[[C1:.+]] = arith.constant 1 : index
     // CHECK:  %{{.+}} = memref.dim %{{.+}}, %[[C1]] : memref<?x?xf32, strided<[?, ?], offset: ?>>
-    // CHECK:  %[[ALLOC_OUT:.+]] = memref.alloc(%{{.+}}, %{{.+}}) {alignment = 64 : i64} : memref<?x?xf32, 1>
+    // CHECK:  %[[ALLOC_OUT:.+]] = memref.alloc(%{{.+}}, %{{.+}}) alignment = 64 : memref<?x?xf32, 1>
     // CHECK:  %{{.+}} = arith.constant 0 : index
     // CHECK:  %{{.+}} = memref.dim %{{.+}}, %{{.+}} : memref<?x42xf32, strided<[?, ?], offset: ?>>
-    // CHECK:  %[[ALLOC_IN:.+]] = memref.alloc(%{{.+}}) {alignment = 64 : i64} : memref<?x42xf32, 1>
+    // CHECK:  %[[ALLOC_IN:.+]] = memref.alloc(%{{.+}}) alignment = 64 : memref<?x42xf32, 1>
     // CHECK:  memref.copy %[[IN0]], %[[ALLOC_IN]] : memref<?x42xf32, strided<[?, ?], offset: ?>> to memref<?x42xf32, 1>
     // CHECK: linalg.add ins(%[[ALLOC_IN]], %[[IN1]] : memref<?x42xf32, 1>, memref<42x?xf32, strided<[?, ?], offset: ?>>) outs(%[[ALLOC_OUT]] : memref<?x?xf32, 1>)
     %0 = linalg.add ins(%arg0, %arg1: tensor<?x42xf32>, tensor<42x?xf32>)

--- a/mlir/test/Dialect/Vector/bufferize.mlir
+++ b/mlir/test/Dialect/Vector/bufferize.mlir
@@ -37,7 +37,7 @@ func.func @transfer_write(%t: tensor<?x?xf32>, %o1: index,
 //  CHECK-SAME:     %[[mask:.*]]: vector<16xi1>, %[[value:.*]]: vector<16xf32>) -> tensor<16x16xf32>
 //       CHECK:   %[[buf:.*]] = bufferization.to_buffer %[[base]] : tensor<16x16xf32> to memref<16x16xf32>
 //       CHECK:   %[[c0:.*]] = arith.constant 0 : index
-//       CHECK:   %[[alloc:.*]] = memref.alloc() {alignment = 64 : i64} : memref<16x16xf32>
+//       CHECK:   %[[alloc:.*]] = memref.alloc() alignment = 64 : memref<16x16xf32>
 //       CHECK:   memref.copy %[[buf]], %[[alloc]] : memref<16x16xf32> to memref<16x16xf32>
 //       CHECK:   vector.scatter %[[alloc]][%[[c0]], %[[c0]]] [%[[v]]], %[[mask]], %[[value]] : memref<16x16xf32>, vector<16xi32>, vector<16xi1>, vector<16xf32>
 //       CHECK:   %[[tensor:.*]] = bufferization.to_tensor %[[alloc]] : memref<16x16xf32> to tensor<16x16xf32>

--- a/mlir/test/Dialect/Vector/vector-emulate-masked-load-store.mlir
+++ b/mlir/test/Dialect/Vector/vector-emulate-masked-load-store.mlir
@@ -56,9 +56,9 @@ func.func @vector_maskedload(%arg0 : memref<4x5xf32>) -> vector<4xf32> {
 
 // CHECK-LABEL:  @vector_maskedload_with_alignment
 //       CHECK:       memref.load
-//       CHECK-SAME:  {alignment = 8 : i64}
+//       CHECK-SAME:  alignment(8)
 //       CHECK:       memref.load
-//       CHECK-SAME:  {alignment = 8 : i64}
+//       CHECK-SAME:  alignment(8)
 func.func @vector_maskedload_with_alignment(%arg0 : memref<4x5xf32>) -> vector<4xf32> {
   %idx_0 = arith.constant 0 : index
   %idx_1 = arith.constant 1 : index
@@ -112,9 +112,9 @@ func.func @vector_maskedstore(%arg0 : memref<4x5xf32>, %arg1 : vector<4xf32>) {
 
 // CHECK-LABEL:  @vector_maskedstore_with_alignment
 //       CHECK:       memref.store
-//       CHECK-SAME:  {alignment = 8 : i64}
+//       CHECK-SAME:  alignment(8)
 //       CHECK:       memref.store
-//       CHECK-SAME:  {alignment = 8 : i64}
+//       CHECK-SAME:  alignment(8)
 func.func @vector_maskedstore_with_alignment(%arg0 : memref<4x5xf32>, %arg1 : vector<4xf32>) {
   %idx_0 = arith.constant 0 : index
   %idx_1 = arith.constant 1 : index

--- a/mlir/test/Dialect/Vector/vector-transfer-full-partial-split-copy-transform.mlir
+++ b/mlir/test/Dialect/Vector/vector-transfer-full-partial-split-copy-transform.mlir
@@ -17,7 +17,7 @@ func.func @split_vector_transfer_read_2d(%A: memref<?x8xf32>, %i: index, %j: ind
   //  CHECK-DAG: %[[c4:.*]] = arith.constant 4 : index
   //  CHECK-DAG: %[[c8:.*]] = arith.constant 8 : index
   // alloca for boundary full tile
-  //      CHECK: %[[alloc:.*]] = memref.alloca() {alignment = 32 : i64} : memref<4x8xf32>
+  //      CHECK: %[[alloc:.*]] = memref.alloca() alignment = 32 : memref<4x8xf32>
   // %i + 4 <= dim(%A, 0)
   //      CHECK: %[[idx0:.*]] = affine.apply #[[$map_p4]]()[%[[i]]]
   //      CHECK: %[[d0:.*]] = memref.dim %[[A]], %[[c0]] : memref<?x8xf32>
@@ -69,7 +69,7 @@ func.func @split_vector_transfer_read_strided_2d(
   //  CHECK-DAG: %[[c7:.*]] = arith.constant 7 : index
   //  CHECK-DAG: %[[c8:.*]] = arith.constant 8 : index
   // alloca for boundary full tile
-  //      CHECK: %[[alloc:.*]] = memref.alloca() {alignment = 32 : i64} : memref<4x8xf32>
+  //      CHECK: %[[alloc:.*]] = memref.alloca() alignment = 32 : memref<4x8xf32>
   // %i + 4 <= dim(%A, 0)
   //      CHECK: %[[idx0:.*]] = affine.apply #[[$map_p4]]()[%[[i]]]
   //      CHECK: %[[cmp0:.*]] = arith.cmpi sle, %[[idx0]], %[[c7]] : index
@@ -138,7 +138,7 @@ func.func @split_vector_transfer_write_2d(%V: vector<4x8xf32>, %A: memref<?x8xf3
 // CHECK-DAG:       %[[C0:.*]] = arith.constant 0 : index
 // CHECK-DAG:       %[[C4:.*]] = arith.constant 4 : index
 // CHECK-DAG:       %[[C8:.*]] = arith.constant 8 : index
-// CHECK:           %[[TEMP:.*]] = memref.alloca() {alignment = 32 : i64} : memref<4x8xf32>
+// CHECK:           %[[TEMP:.*]] = memref.alloca() alignment = 32 : memref<4x8xf32>
 // CHECK:           %[[IDX0:.*]] = affine.apply #[[$MAP0]]()[%[[I]]]
 // CHECK:           %[[DIM0:.*]] = memref.dim %[[DEST]], %[[C0]] : memref<?x8xf32>
 // CHECK:           %[[DIM0_IN:.*]] = arith.cmpi sle, %[[IDX0]], %[[DIM0]] : index
@@ -204,7 +204,7 @@ func.func @split_vector_transfer_write_strided_2d(
 // CHECK-DAG:       %[[C7:.*]] = arith.constant 7 : index
 // CHECK-DAG:       %[[C4:.*]] = arith.constant 4 : index
 // CHECK-DAG:       %[[C8:.*]] = arith.constant 8 : index
-// CHECK:           %[[TEMP:.*]] = memref.alloca() {alignment = 32 : i64} : memref<4x8xf32>
+// CHECK:           %[[TEMP:.*]] = memref.alloca() alignment = 32 : memref<4x8xf32>
 // CHECK:           %[[DIM0:.*]] = affine.apply #[[$MAP1]]()[%[[I]]]
 // CHECK:           %[[DIM0_IN:.*]] = arith.cmpi sle, %[[DIM0]], %[[C7]] : index
 // CHECK:           %[[DIM1:.*]] = affine.apply #[[$MAP2]]()[%[[J]]]

--- a/mlir/test/Dialect/Vector/vector-transfer-full-partial-split.mlir
+++ b/mlir/test/Dialect/Vector/vector-transfer-full-partial-split.mlir
@@ -16,7 +16,7 @@ func.func @split_vector_transfer_read_2d(%A: memref<?x8xf32>, %i: index, %j: ind
   //  CHECK-DAG: %[[c8:.*]] = arith.constant 8 : index
   //  CHECK-DAG: %[[c0:.*]] = arith.constant 0 : index
   // alloca for boundary full tile
-  //      CHECK: %[[alloc:.*]] = memref.alloca() {alignment = 32 : i64} : memref<4x8xf32>
+  //      CHECK: %[[alloc:.*]] = memref.alloca() alignment = 32 : memref<4x8xf32>
   // %i + 4 <= dim(%A, 0)
   //      CHECK: %[[idx0:.*]] = affine.apply #[[$map_p4]]()[%[[i]]]
   //      CHECK: %[[d0:.*]] = memref.dim %[[A]], %[[c0]] : memref<?x8xf32>
@@ -64,7 +64,7 @@ func.func @split_vector_transfer_read_strided_2d(
   //  CHECK-DAG: %[[c8:.*]] = arith.constant 8 : index
   //  CHECK-DAG: %[[c0:.*]] = arith.constant 0 : index
   // alloca for boundary full tile
-  //      CHECK: %[[alloc:.*]] = memref.alloca() {alignment = 32 : i64} : memref<4x8xf32>
+  //      CHECK: %[[alloc:.*]] = memref.alloca() alignment = 32 : memref<4x8xf32>
   // %i + 4 <= dim(%A, 0)
   //      CHECK: %[[idx0:.*]] = affine.apply #[[$map_p4]]()[%[[i]]]
   //      CHECK: %[[cmp0:.*]] = arith.cmpi sle, %[[idx0]], %[[c7]] : index
@@ -160,7 +160,7 @@ func.func @split_vector_transfer_write_2d(%V: vector<4x8xf32>, %A: memref<?x8xf3
 // CHECK-DAG:       %[[C8:.*]] = arith.constant 8 : index
 // CHECK-DAG:       %[[C0:.*]] = arith.constant 0 : index
 // CHECK-DAG:       %[[CT:.*]] = arith.constant true
-// CHECK:           %[[TEMP:.*]] = memref.alloca() {alignment = 32 : i64} : memref<4x8xf32>
+// CHECK:           %[[TEMP:.*]] = memref.alloca() alignment = 32 : memref<4x8xf32>
 // CHECK:           %[[VAL_8:.*]] = affine.apply #[[MAP0]]()[%[[I]]]
 // CHECK:           %[[DIM0:.*]] = memref.dim %[[DEST]], %[[C0]] : memref<?x8xf32>
 // CHECK:           %[[DIM0_IN:.*]] = arith.cmpi sle, %[[VAL_8]], %[[DIM0]] : index
@@ -224,7 +224,7 @@ func.func @split_vector_transfer_write_strided_2d(
 // CHECK-DAG:       %[[C8:.*]] = arith.constant 8 : index
 // CHECK-DAG:       %[[C0:.*]] = arith.constant 0 : index
 // CHECK-DAG:       %[[CT:.*]] = arith.constant true
-// CHECK:           %[[TEMP:.*]] = memref.alloca() {alignment = 32 : i64} : memref<4x8xf32>
+// CHECK:           %[[TEMP:.*]] = memref.alloca() alignment = 32 : memref<4x8xf32>
 // CHECK:           %[[DIM0:.*]] = affine.apply #[[MAP1]]()[%[[I]]]
 // CHECK:           %[[DIM0_IN:.*]] = arith.cmpi sle, %[[DIM0]], %[[C7]] : index
 // CHECK:           %[[DIM1:.*]] = affine.apply #[[MAP2]]()[%[[J]]]

--- a/mlir/test/Dialect/Vector/vector-transferop-opt.mlir
+++ b/mlir/test/Dialect/Vector/vector-transferop-opt.mlir
@@ -243,7 +243,7 @@ func.func @collapse_shape_and_read_from_source(%in_0: memref<1x20x1xi32>, %vec: 
   %c4 = arith.constant 4 : index
   %c20 = arith.constant 20 : index
 
-  %alloca = memref.alloca() {alignment = 64 : i64} : memref<1x4x1xi32>
+  %alloca = memref.alloca() alignment = 64 : memref<1x4x1xi32>
   %collapse_shape = memref.collapse_shape %alloca [[0, 1, 2]] : memref<1x4x1xi32> into memref<4xi32>
   scf.for %arg0 = %c0 to %c20 step %c4 {
     %subview = memref.subview %in_0[0, %arg0, 0] [1, 4, 1] [1, 1, 1] : memref<1x20x1xi32> to memref<1x4x1xi32, strided<[20, 1, 1], offset: ?>>
@@ -273,7 +273,7 @@ func.func @expand_shape_and_read_from_source(%in_0: memref<20xi32>, %vec: vector
   %c4 = arith.constant 4 : index
   %c20 = arith.constant 20 : index
 
-  %alloca = memref.alloca() {alignment = 64 : i64} : memref<4xi32>
+  %alloca = memref.alloca() alignment = 64 : memref<4xi32>
   %expand_shape = memref.expand_shape %alloca [[0, 1, 2]] output_shape [1, 4, 1] : memref<4xi32> into memref<1x4x1xi32>
   scf.for %arg0 = %c0 to %c20 step %c4 {
     %subview = memref.subview %in_0[%arg0] [4] [1] : memref<20xi32> to memref<4xi32, strided<[1], offset: ?>>
@@ -304,7 +304,7 @@ func.func @collapse_shape_and_read_from_collapse(%in_0: memref<20xi32>, %vec: ve
   %c4 = arith.constant 4 : index
   %c20 = arith.constant 20 : index
 
-  %alloca = memref.alloca() {alignment = 64 : i64} : memref<1x4x1xi32>
+  %alloca = memref.alloca() alignment = 64 : memref<1x4x1xi32>
   %collapse_shape = memref.collapse_shape %alloca [[0, 1, 2]] : memref<1x4x1xi32> into memref<4xi32>
   scf.for %arg0 = %c0 to %c20 step %c4 {
     %subview = memref.subview %in_0[%arg0] [4] [1] : memref<20xi32> to memref<4xi32, strided<[1], offset: ?>>
@@ -335,7 +335,7 @@ func.func @expand_shape_and_read_from_expand(%in_0: memref<1x20x1xi32>, %vec: ve
   %c4 = arith.constant 4 : index
   %c20 = arith.constant 20 : index
 
-  %alloca = memref.alloca() {alignment = 64 : i64} : memref<4xi32>
+  %alloca = memref.alloca() alignment = 64 : memref<4xi32>
   %expand_shape = memref.expand_shape %alloca [[0, 1, 2]] output_shape [1, 4, 1] : memref<4xi32> into memref<1x4x1xi32>
   scf.for %arg0 = %c0 to %c20 step %c4 {
     %subview = memref.subview %in_0[0, %arg0, 0] [1, 4, 1] [1, 1, 1] : memref<1x20x1xi32> to memref<1x4x1xi32, strided<[20, 1, 1], offset: ?>>

--- a/mlir/test/Dialect/XeGPU/invalid.mlir
+++ b/mlir/test/Dialect/XeGPU/invalid.mlir
@@ -606,7 +606,7 @@ func.func @slice_attr_repeat_dim() {
 
 // -----
 func.func @create_mem_desc_non_slm() {
-  %m = memref.alloca() {alignment = 1024} : memref<2048xi8, 1>
+  %m = memref.alloca() alignment = 1024 : memref<2048xi8, 1>
   // expected-error@+1 {{operand #0 must be reside in share memory and statically shaped memref }}
   %mem_desc = xegpu.create_mem_desc %m : memref<2048xi8, 1> -> !xegpu.mem_desc<16x64xf16>
   return
@@ -614,7 +614,7 @@ func.func @create_mem_desc_non_slm() {
 
 // -----
 func.func @create_mem_desc_mismatch_sizes() {
-  %m = memref.alloca() {alignment = 1024} : memref<2048xi8, 3>
+  %m = memref.alloca() alignment = 1024 : memref<2048xi8, 3>
   // expected-error@+1 {{failed to verify that all of {source, mem_desc} have same size in bits}}
   %mem_desc = xegpu.create_mem_desc %m : memref<2048xi8, 3> -> !xegpu.mem_desc<16x32xf16>
   return
@@ -815,7 +815,7 @@ func.func @contiguity_does_not_divide(%src: i64, %offset: vector<6xindex>, %mask
 
 // -----
 func.func @create_mem_desc_non_contiguous() {
-  %m = memref.alloca() {alignment = 1024} : memref<32x64xf16, 3>
+  %m = memref.alloca() alignment = 1024 : memref<32x64xf16, 3>
   %m_sub = memref.subview %m[0, 0][16, 32][1, 1] : memref<32x64xf16, 3> to memref<16x32xf16, strided<[64, 1]>, 3>
   // expected-error@+1 {{source memref must be contiguous.}}
   %mem_desc = xegpu.create_mem_desc %m_sub : memref<16x32xf16, strided<[64, 1]>, 3> -> !xegpu.mem_desc<16x32xf16>

--- a/mlir/test/Dialect/XeGPU/ops.mlir
+++ b/mlir/test/Dialect/XeGPU/ops.mlir
@@ -540,37 +540,37 @@ gpu.func @fence() {
 
 // CHECK-LABEL: gpu.func @create_mem_desc({{.*}}) {
 gpu.func @create_mem_desc() {
-  //CHECK: [[alloc:%.+]] = memref.alloca() {alignment = 1024 : i64} : memref<2048xi8, 3>
+  //CHECK: [[alloc:%.+]] = memref.alloca() alignment = 1024 : memref<2048xi8, 3>
   //CHECK: [[mdesc:%.+]] = xegpu.create_mem_desc [[alloc]] : memref<2048xi8, 3> -> !xegpu.mem_desc<16x64xf16>
-  %m = memref.alloca() {alignment = 1024} : memref<2048xi8, 3>
+  %m = memref.alloca() alignment = 1024 : memref<2048xi8, 3>
   %mem_desc = xegpu.create_mem_desc %m : memref<2048xi8, 3> -> !xegpu.mem_desc<16x64xf16>
   gpu.return
 }
 
 // CHECK-LABEL: gpu.func @create_mem_desc_with_stride({{.*}}) {
 gpu.func @create_mem_desc_with_stride() {
-  //CHECK: [[alloc:%.+]] = memref.alloca() {alignment = 1024 : i64} : memref<2048xi8, 3>
+  //CHECK: [[alloc:%.+]] = memref.alloca() alignment = 1024 : memref<2048xi8, 3>
   //CHECK: [[mdesc:%.+]] = xegpu.create_mem_desc [[alloc]] : memref<2048xi8, 3> -> !xegpu.mem_desc<16x64xf16, #xegpu.mem_layout<stride = [1, 16]>>
-  %m = memref.alloca() {alignment = 1024} : memref<2048xi8, 3>
+  %m = memref.alloca() alignment = 1024 : memref<2048xi8, 3>
   %mem_desc = xegpu.create_mem_desc %m : memref<2048xi8, 3> -> !xegpu.mem_desc<16x64xf16, #xegpu.mem_layout<stride = [1, 16]>>
   gpu.return
 }
 
 // CHECK-LABEL: gpu.func @create_mem_desc_from_2d_memref({{.*}}) {
 gpu.func @create_mem_desc_from_2d_memref() {
-  //CHECK: [[alloc:%.+]] = memref.alloca() {alignment = 1024 : i64} : memref<16x64xf16, 3>
+  //CHECK: [[alloc:%.+]] = memref.alloca() alignment = 1024 : memref<16x64xf16, 3>
   //CHECK: [[mdesc:%.+]] = xegpu.create_mem_desc [[alloc]] : memref<16x64xf16, 3> -> !xegpu.mem_desc<16x64xf16>
-  %m = memref.alloca() {alignment = 1024} : memref<16x64xf16, 3>
+  %m = memref.alloca() alignment = 1024 : memref<16x64xf16, 3>
   %mem_desc = xegpu.create_mem_desc %m : memref<16x64xf16, 3> -> !xegpu.mem_desc<16x64xf16>
   gpu.return
 }
 
 // CHECK-LABEL: gpu.func @create_mem_desc_with_stride_from_2d_memref({{.*}}) {
 gpu.func @create_mem_desc_with_stride_from_2d_memref() {
-  //CHECK: %[[ALLOC:.+]] = memref.alloca() {alignment = 1024 : i64} : memref<32x64xf16, 3>
+  //CHECK: %[[ALLOC:.+]] = memref.alloca() alignment = 1024 : memref<32x64xf16, 3>
   //CHECK: %[[SUBVIEW:.+]] = memref.subview %[[ALLOC]][16, 0] [16, 64] [1, 1] : memref<32x64xf16, 3> to memref<16x64xf16, strided<[64, 1], offset: 1024>, 3>
   //CHECK: %{{.+}} = xegpu.create_mem_desc %[[SUBVIEW]] : memref<16x64xf16, strided<[64, 1], offset: 1024>, 3> -> !xegpu.mem_desc<16x64xf16, #xegpu.mem_layout<stride = [1, 16]>>
-  %m = memref.alloca() {alignment = 1024} : memref<32x64xf16, 3>
+  %m = memref.alloca() alignment = 1024 : memref<32x64xf16, 3>
   %m_sub = memref.subview %m[16, 0][16, 64][1,1] : memref<32x64xf16, 3> to memref<16x64xf16, strided<[64, 1], offset: 1024>, 3>
   %mem_desc = xegpu.create_mem_desc %m_sub : memref<16x64xf16, strided<[64, 1], offset: 1024>, 3> -> !xegpu.mem_desc<16x64xf16, #xegpu.mem_layout<stride = [1, 16]>>
   gpu.return
@@ -578,9 +578,9 @@ gpu.func @create_mem_desc_with_stride_from_2d_memref() {
 
 // CHECK-LABEL: gpu.func @create_mem_desc_from_3d_memref({{.*}}) {
 gpu.func @create_mem_desc_from_3d_memref() {
-  //CHECK: [[alloc:%.+]] = memref.alloca() {alignment = 1024 : i64} : memref<1x16x64xf16, 3>
+  //CHECK: [[alloc:%.+]] = memref.alloca() alignment = 1024 : memref<1x16x64xf16, 3>
   //CHECK: [[mdesc:%.+]] = xegpu.create_mem_desc [[alloc]] : memref<1x16x64xf16, 3> -> !xegpu.mem_desc<1x16x64xf16>
-  %m = memref.alloca() {alignment = 1024} : memref<1x16x64xf16, 3>
+  %m = memref.alloca() alignment = 1024 : memref<1x16x64xf16, 3>
   %mem_desc = xegpu.create_mem_desc %m : memref<1x16x64xf16, 3> -> !xegpu.mem_desc<1x16x64xf16>
   gpu.return
 }

--- a/mlir/test/Dialect/XeGPU/xegpu-wg-to-sg.mlir
+++ b/mlir/test/Dialect/XeGPU/xegpu-wg-to-sg.mlir
@@ -756,7 +756,7 @@ gpu.module @test_distribution {
 
   // CHECK-LABEL: distribute_load_slice_attr
   gpu.func @distribute_load_slice_attr() {
-    %2 = memref.alloca() {alignment = 1024} : memref<4096xf32>
+    %2 = memref.alloca() alignment = 1024 : memref<4096xf32>
     %offset =  arith.constant dense<0> : vector<256xindex>
     %mask = arith.constant dense<1> : vector<256xi1>
 

--- a/mlir/test/Integration/Dialect/Async/CPU/microbench-linalg-async-parallel-for.mlir
+++ b/mlir/test/Integration/Dialect/Async/CPU/microbench-linalg-async-parallel-for.mlir
@@ -68,9 +68,9 @@ func.func @entry() {
   // Sanity check for the function under test.
   //
 
-  %LHS10 = memref.alloc() {alignment = 64} : memref<1x10xf32>
-  %RHS10 = memref.alloc() {alignment = 64} : memref<1x10xf32>
-  %DST10 = memref.alloc() {alignment = 64} : memref<1x10xf32>
+  %LHS10 = memref.alloc() alignment = 64 : memref<1x10xf32>
+  %RHS10 = memref.alloc() alignment = 64 : memref<1x10xf32>
+  %DST10 = memref.alloc() alignment = 64 : memref<1x10xf32>
 
   linalg.fill ins(%f1 : f32) outs(%LHS10 : memref<1x10xf32>)
   linalg.fill ins(%f1 : f32) outs(%RHS10 : memref<1x10xf32>)
@@ -94,9 +94,9 @@ func.func @entry() {
   // Allocate data for microbenchmarks.
   //
 
-  %LHS1024 = memref.alloc() {alignment = 64} : memref<1024x1024xf32>
-  %RHS1024 = memref.alloc() {alignment = 64} : memref<1024x1024xf32>
-  %DST1024 = memref.alloc() {alignment = 64} : memref<1024x1024xf32>
+  %LHS1024 = memref.alloc() alignment = 64 : memref<1024x1024xf32>
+  %RHS1024 = memref.alloc() alignment = 64 : memref<1024x1024xf32>
+  %DST1024 = memref.alloc() alignment = 64 : memref<1024x1024xf32>
 
   %LHS0 = memref.cast %LHS1024 : memref<1024x1024xf32> to memref<?x?xf32>
   %RHS0 = memref.cast %RHS1024 : memref<1024x1024xf32> to memref<?x?xf32>

--- a/mlir/test/Integration/Dialect/Async/CPU/microbench-scf-async-parallel-for.mlir
+++ b/mlir/test/Integration/Dialect/Async/CPU/microbench-scf-async-parallel-for.mlir
@@ -92,9 +92,9 @@ func.func @entry() {
   // Sanity check for the function under test.
   //
 
-  %LHS10 = memref.alloc() {alignment = 64} : memref<1x10xf32>
-  %RHS10 = memref.alloc() {alignment = 64} : memref<1x10xf32>
-  %DST10 = memref.alloc() {alignment = 64} : memref<1x10xf32>
+  %LHS10 = memref.alloc() alignment = 64 : memref<1x10xf32>
+  %RHS10 = memref.alloc() alignment = 64 : memref<1x10xf32>
+  %DST10 = memref.alloc() alignment = 64 : memref<1x10xf32>
 
   linalg.fill ins(%f1 : f32) outs(%LHS10 : memref<1x10xf32>)
   linalg.fill ins(%f1 : f32) outs(%RHS10 : memref<1x10xf32>)
@@ -118,9 +118,9 @@ func.func @entry() {
   // Allocate data for microbenchmarks.
   //
 
-  %LHS1024 = memref.alloc() {alignment = 64} : memref<1024x1024xf32>
-  %RHS1024 = memref.alloc() {alignment = 64} : memref<1024x1024xf32>
-  %DST1024 = memref.alloc() {alignment = 64} : memref<1024x1024xf32>
+  %LHS1024 = memref.alloc() alignment = 64 : memref<1024x1024xf32>
+  %RHS1024 = memref.alloc() alignment = 64 : memref<1024x1024xf32>
+  %DST1024 = memref.alloc() alignment = 64 : memref<1024x1024xf32>
 
   %LHS0 = memref.cast %LHS1024 : memref<1024x1024xf32> to memref<?x?xf32>
   %RHS0 = memref.cast %RHS1024 : memref<1024x1024xf32> to memref<?x?xf32>

--- a/mlir/test/Integration/Dialect/LLVMIR/CPU/test-complex-sparse-constant.mlir
+++ b/mlir/test/Integration/Dialect/LLVMIR/CPU/test-complex-sparse-constant.mlir
@@ -8,7 +8,7 @@ module attributes {llvm.data_layout = ""} {
   memref.global "private" constant @"__constant_32xcomplex<f32>_0" : memref<32xcomplex<f32>> =
      sparse<[[1], [28], [31]],
             [(1.000000e+00,0.000000e+00), (2.000000e+00,0.000000e+00), (3.000000e+00,0.000000e+00)]
-	    > {alignment = 128 : i64}
+	    > alignment = 128
   llvm.func @entry() {
      %0 = memref.get_global @"__constant_32xcomplex<f32>_0" : memref<32xcomplex<f32>>
      llvm.return

--- a/mlir/test/Integration/Dialect/SparseTensor/GPU/CUDA/sparse-matvec-const.mlir
+++ b/mlir/test/Integration/Dialect/SparseTensor/GPU/CUDA/sparse-matvec-const.mlir
@@ -20,7 +20,7 @@ module {
     return %y_out : tensor<1024xf64>
   }
 
-  memref.global "private" constant @__constant_64xf64 : memref<64xf64> = dense<1.000000e+00> {alignment = 64 : i64}
+  memref.global "private" constant @__constant_64xf64 : memref<64xf64> = dense<1.000000e+00> alignment = 64
 
   func.func @main() {
     %f0 = arith.constant 0.0 : f64

--- a/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/load-store-128-bit-tile.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/load-store-128-bit-tile.mlir
@@ -38,8 +38,8 @@ func.func @test_load_store_zaq0() attributes {llvm.arm_locally_streaming} {
   /// Allocate memory for two 128-bit tiles (A and B) and fill them a constant.
   /// The tiles are allocated as bytes so we can fill and print them, as there's
   /// very little that can be done with 128-bit types directly.
-  %tile_a_bytes = memref.alloca(%zaq_size_bytes) {alignment = 16} : memref<?xi8>
-  %tile_b_bytes = memref.alloca(%zaq_size_bytes) {alignment = 16} : memref<?xi8>
+  %tile_a_bytes = memref.alloca(%zaq_size_bytes) alignment = 16 : memref<?xi8>
+  %tile_b_bytes = memref.alloca(%zaq_size_bytes) alignment = 16 : memref<?xi8>
   %fill_a_i8 = arith.constant 7 : i8
   %fill_b_i8 = arith.constant 64 : i8
   linalg.fill ins(%fill_a_i8 : i8) outs(%tile_a_bytes : memref<?xi8>)

--- a/mlir/test/Integration/Dialect/Vector/CPU/sparse-dot-matvec.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/sparse-dot-matvec.mlir
@@ -106,10 +106,10 @@ func.func @entry() {
   // Allocate.
   //
 
-  %AVAL = memref.alloc()    {alignment = 64} : memref<8xvector<4xf32>>
-  %AIDX = memref.alloc()    {alignment = 64} : memref<8xvector<4xi32>>
-  %X    = memref.alloc(%c8) {alignment = 64} : memref<?xf32>
-  %B    = memref.alloc(%c8) {alignment = 64} : memref<?xf32>
+  %AVAL = memref.alloc() alignment = 64 : memref<8xvector<4xf32>>
+  %AIDX = memref.alloc() alignment = 64 : memref<8xvector<4xi32>>
+  %X    = memref.alloc(%c8) alignment = 64 : memref<?xf32>
+  %B    = memref.alloc(%c8) alignment = 64 : memref<?xf32>
 
   //
   // Initialize.

--- a/mlir/test/Integration/Dialect/Vector/CPU/sparse-saxpy-jagged-matvec.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/sparse-saxpy-jagged-matvec.mlir
@@ -100,10 +100,10 @@ func.func @entry() {
   // Allocate.
   //
 
-  %AVAL = memref.alloc()    {alignment = 64} : memref<4xvector<8xf32>>
-  %AIDX = memref.alloc()    {alignment = 64} : memref<4xvector<8xi32>>
-  %X    = memref.alloc(%c8) {alignment = 64} : memref<?xf32>
-  %B    = memref.alloc()    {alignment = 64} : memref<1xvector<8xf32>>
+  %AVAL = memref.alloc() alignment = 64 : memref<4xvector<8xf32>>
+  %AIDX = memref.alloc() alignment = 64 : memref<4xvector<8xi32>>
+  %X    = memref.alloc(%c8) alignment = 64 : memref<?xf32>
+  %B    = memref.alloc() alignment = 64 : memref<1xvector<8xf32>>
 
   //
   // Initialize.

--- a/mlir/test/Integration/Dialect/Vector/CPU/transfer-write.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/transfer-write.mlir
@@ -71,7 +71,7 @@ func.func @entry() {
   %c0 = arith.constant 0: index
   %c1 = arith.constant 1: index
   %c32 = arith.constant 32: index
-  %A = memref.alloc(%c32) {alignment=64} : memref<?xf32>
+  %A = memref.alloc(%c32) alignment = 64 : memref<?xf32>
   scf.for %i = %c0 to %c32 step %c1 {
     %f = arith.constant 0.0: f32
     memref.store %f, %A[%i] : memref<?xf32>
@@ -121,7 +121,7 @@ func.func @entry() {
 
   // 3D case
   %c4 = arith.constant 4: index
-  %A1 = memref.alloc() {alignment=64} : memref<4x4x4xf32>
+  %A1 = memref.alloc() alignment = 64 : memref<4x4x4xf32>
   scf.for %i = %c0 to %c4 step %c1 {
     scf.for %j = %c0 to %c4 step %c1 {
       scf.for %k = %c0 to %c4 step %c1 {

--- a/mlir/test/Integration/GPU/CUDA/sm90/gemm_f32_f16_f16_128x128x128.mlir
+++ b/mlir/test/Integration/GPU/CUDA/sm90/gemm_f32_f16_f16_128x128x128.mlir
@@ -57,7 +57,7 @@
 
 func.func private @printMemrefF32(memref<*xf32>)
 
-memref.global "private" @accShmem : memref<0xf32, 3> {alignment = 16 : i64}
+memref.global "private" @accShmem : memref<0xf32, 3> alignment = 16
 
 func.func @main() {
   // matrix A (128*64) * matrix B (64*128) * stages(2)

--- a/mlir/test/Integration/GPU/CUDA/sm90/gemm_pred_f32_f16_f16_128x128x128.mlir
+++ b/mlir/test/Integration/GPU/CUDA/sm90/gemm_pred_f32_f16_f16_128x128x128.mlir
@@ -57,7 +57,7 @@
 
 func.func private @printMemrefF32(memref<*xf32>)
 
-memref.global "private" @accShmem : memref<0xf32, 3> {alignment = 16 : i64}
+memref.global "private" @accShmem : memref<0xf32, 3> alignment = 16
 
 func.func @main() {
   // matrix A (128*64) * matrix B (64*128) * stages(2)

--- a/mlir/test/Transforms/promote-buffers-to-stack.mlir
+++ b/mlir/test/Transforms/promote-buffers-to-stack.mlir
@@ -603,13 +603,13 @@ func.func @indexElementType() {
 // CHECK-LABEL: func @bigIndexElementType
 module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<index, 256>>} {
   func.func @bigIndexElementType() {
-    %0 = memref.alloc() {alignment = 64 : i64, custom_attr} : memref<4xindex>
+    %0 = memref.alloc() alignment = 64 {custom_attr} : memref<4xindex>
     return
   }
 }
-// DEFINDEX-NEXT: memref.alloca() {alignment = 64 : i64, custom_attr}
-// LOWLIMIT-NEXT: memref.alloc() {alignment = 64 : i64, custom_attr}
-// RANK-NEXT: memref.alloca() {alignment = 64 : i64, custom_attr}
+// DEFINDEX-NEXT: memref.alloca() alignment = 64 {custom_attr}
+// LOWLIMIT-NEXT: memref.alloc() alignment = 64 {custom_attr}
+// RANK-NEXT: memref.alloca() alignment = 64 {custom_attr}
 // CHECK-NEXT: return
 
 // -----

--- a/mlir/test/Transforms/remove-dead-values.mlir
+++ b/mlir/test/Transforms/remove-dead-values.mlir
@@ -4,8 +4,8 @@
 // The IR is updated regardless of memref.global private constant
 //
 module {
-  // CHECK: memref.global "private" constant @__constant_4xi32 : memref<4xi32> = dense<[1, 2, 3, 4]> {alignment = 16 : i64}
-  memref.global "private" constant @__constant_4xi32 : memref<4xi32> = dense<[1, 2, 3, 4]> {alignment = 16 : i64}
+  // CHECK: memref.global "private" constant @__constant_4xi32 : memref<4xi32> = dense<[1, 2, 3, 4]> alignment = 16
+  memref.global "private" constant @__constant_4xi32 : memref<4xi32> = dense<[1, 2, 3, 4]> alignment = 16
   func.func @main(%arg0: i32) -> i32 {
     %0 = tensor.empty() : tensor<10xbf16>
     // CHECK-NOT: memref.get_global

--- a/mlir/test/mlir-query/logical-operator-test.mlir
+++ b/mlir/test/mlir-query/logical-operator-test.mlir
@@ -2,10 +2,10 @@
 
 func.func @dynamic_alloca(%arg0: index, %arg1: index) -> memref<?x?xf32> {
   %0 = memref.alloca(%arg0, %arg1) : memref<?x?xf32>
-  memref.alloca(%arg0, %arg1) {alignment = 32} : memref<?x?xf32>
+  memref.alloca(%arg0, %arg1) alignment = 32 : memref<?x?xf32>
   return %0 : memref<?x?xf32>
 }
 
 // CHECK: Match #1:
 // CHECK: {{.*}}.mlir:5:3: note: "root" binds here
-// CHECK: memref.alloca(%arg0, %arg1) {alignment = 32} : memref<?x?xf32>
+// CHECK: memref.alloca(%arg0, %arg1) alignment = 32 : memref<?x?xf32>


### PR DESCRIPTION
Enable strict property assembly format mode for the MemRef dialect and spell alignment and nontemporal properties directly in the affected declarative assembly formats.

Refresh MemRef tests and docs so these inherent properties use direct syntax while unrelated attributes remain in attr-dict.

Assisted-by: Codex