### PR TITLE
[MLIR][Math] Enable strict property assembly format

### DIFF
--- a/mlir/include/mlir/Dialect/Math/IR/MathBase.td
+++ b/mlir/include/mlir/Dialect/Math/IR/MathBase.td
@@ -10,6 +10,7 @@
 include "mlir/IR/OpBase.td"
 def Math_Dialect : Dialect {
   let name = "math";
+  let useStrictPropertiesInAssemblyFormat = 1;
   let cppNamespace = "::mlir::math";
   let description = [{
     The math dialect is intended to hold mathematical operations on integer and

--- a/mlir/include/mlir/Dialect/Math/IR/MathOps.td
+++ b/mlir/include/mlir/Dialect/Math/IR/MathOps.td
@@ -48,7 +48,8 @@ class Math_FloatClassificationOp<string mnemonic, list<Trait> traits = []> :
                         "::mlir::arith::FastMathFlags::none">:$fastmath);
   let results = (outs BoolLike:$result);
 
-  let assemblyFormat = "$operand attr-dict `:` type($operand)";
+  let assemblyFormat = [{ $operand (`fastmath` `` $fastmath^)?
+                          attr-dict `:` type($operand) }];
 }
 
 // Base class for unary math operations on floating point types. Require an

--- a/mlir/test/Dialect/Math/ops.mlir
+++ b/mlir/test/Dialect/Math/ops.mlir
@@ -329,6 +329,8 @@ func.func @fpclassify(%f: f32, %d: f64, %v: vector<4xf32>, %t: tensor<4x?xf32>) 
   math.isfinite %d : f64
   math.isfinite %v : vector<4xf32>
   math.isfinite %t : tensor<4x?xf32>
+  // CHECK: math.isfinite %[[F]] fastmath<nnan> : f32
+  math.isfinite %f fastmath<nnan> : f32
   // CHECK: math.isinf %[[F]] : f32
   // CHECK: math.isinf %[[D]] : f64
   // CHECK: math.isinf %[[V]] : vector<4xf32>
@@ -337,6 +339,8 @@ func.func @fpclassify(%f: f32, %d: f64, %v: vector<4xf32>, %t: tensor<4x?xf32>) 
   math.isinf %d : f64
   math.isinf %v : vector<4xf32>
   math.isinf %t : tensor<4x?xf32>
+  // CHECK: math.isinf %[[D]] fastmath<ninf> : f64
+  math.isinf %d fastmath<ninf> : f64
   // CHECK: math.isnan %[[F]] : f32
   // CHECK: math.isnan %[[D]] : f64
   // CHECK: math.isnan %[[V]] : vector<4xf32>
@@ -345,6 +349,8 @@ func.func @fpclassify(%f: f32, %d: f64, %v: vector<4xf32>, %t: tensor<4x?xf32>) 
   math.isnan %d : f64
   math.isnan %v : vector<4xf32>
   math.isnan %t : tensor<4x?xf32>
+  // CHECK: math.isnan %[[V]] fastmath<nnan> : vector<4xf32>
+  math.isnan %v fastmath<nnan> : vector<4xf32>
   // CHECK: math.isnormal %[[F]] : f32
   // CHECK: math.isnormal %[[D]] : f64
   // CHECK: math.isnormal %[[V]] : vector<4xf32>
@@ -353,6 +359,8 @@ func.func @fpclassify(%f: f32, %d: f64, %v: vector<4xf32>, %t: tensor<4x?xf32>) 
   math.isnormal %d : f64
   math.isnormal %v : vector<4xf32>
   math.isnormal %t : tensor<4x?xf32>
+  // CHECK: math.isnormal %[[T]] fastmath<fast> : tensor<4x?xf32>
+  math.isnormal %t fastmath<fast> : tensor<4x?xf32>
   return
 }
 


### PR DESCRIPTION
Enable the strict properties assembly format mode for the Math dialect. Spell the classification fast-math attribute in the declarative format so it is not parsed from attr-dict in strict mode.

Assisted-by: Codex