### PR TITLE
[MLIR][X86] Enable strict property assembly format

### DIFF
--- a/mlir/include/mlir/Dialect/X86/X86.td
+++ b/mlir/include/mlir/Dialect/X86/X86.td
@@ -25,6 +25,7 @@ include "mlir/IR/BuiltinTypes.td"
 
 def X86_Dialect : Dialect {
   let name = "x86";
+  let useStrictPropertiesInAssemblyFormat = 1;
   let cppNamespace = "::mlir::x86";
 
   let useDefaultTypePrinterParser = 1;
@@ -77,7 +78,8 @@ def MaskCompressOp : AVX512_Op<"mask.compress", [Pure,
                    OptionalAttr<ElementsAttr>:$constant_src);
   let results = (outs VectorOfLengthAndType<[16, 8],
                                             [F32, I32, F64, I64]>:$dst);
-  let assemblyFormat = "$k `,` $a (`,` $src^)? attr-dict"
+  let assemblyFormat = "$k `,` $a (`,` $src^)? "
+                       "(`constant_src` `=` $constant_src^)? attr-dict"
                        " `:` type($dst) (`,` type($src)^)?";
   let hasVerifier = 1;
 

--- a/mlir/test/Dialect/X86/legalize-for-llvm.mlir
+++ b/mlir/test/Dialect/X86/legalize-for-llvm.mlir
@@ -33,7 +33,7 @@ func.func @avx512_mask_compress(
   // CHECK: llvm.mlir.constant(dense<5.000000e+00> : vector<16xf32>)
   // CHECK: llvm.call_intrinsic "llvm.x86.avx512.mask.compress"
   %1 = x86.avx512.mask.compress %k1, %a1
-    {constant_src = dense<5.0> : vector<16xf32>} : vector<16xf32>
+    constant_src = dense<5.0> : vector<16xf32>: vector<16xf32>
   // CHECK: llvm.call_intrinsic "llvm.x86.avx512.mask.compress"
   %2 = x86.avx512.mask.compress %k2, %a2, %a2 : vector<8xi64>, vector<8xi64>
   return %0, %1, %2 : vector<16xf32>, vector<16xf32>, vector<8xi64>

--- a/mlir/test/Dialect/X86/roundtrip.mlir
+++ b/mlir/test/Dialect/X86/roundtrip.mlir
@@ -41,7 +41,7 @@ func.func @avx512_mask_compress(%k1: vector<16xi1>, %a1: vector<16xf32>,
   // CHECK: x86.avx512.mask.compress {{.*}} : vector<16xf32>
   %0 = x86.avx512.mask.compress %k1, %a1 : vector<16xf32>
   // CHECK: x86.avx512.mask.compress {{.*}} : vector<16xf32>
-  %1 = x86.avx512.mask.compress %k1, %a1 {constant_src = dense<5.0> : vector<16xf32>} : vector<16xf32>
+  %1 = x86.avx512.mask.compress %k1, %a1 constant_src = dense<5.0> : vector<16xf32>: vector<16xf32>
   // CHECK: x86.avx512.mask.compress {{.*}} : vector<8xi64>
   %2 = x86.avx512.mask.compress %k2, %a2, %a2 : vector<8xi64>, vector<8xi64>
   return %0, %1, %2 : vector<16xf32>, vector<16xf32>, vector<8xi64>


### PR DESCRIPTION
Enable the strict properties assembly format mode for the X86 dialect. Spell the mask-compress constant source attribute directly in the assembly format so it is not parsed from attr-dict in strict mode.

Assisted-by: Codex