### PR TITLE
[MLIR][WasmSSA] Enable strict property assembly format

### DIFF
--- a/mlir/include/mlir/Dialect/WasmSSA/IR/WasmSSABase.td
+++ b/mlir/include/mlir/Dialect/WasmSSA/IR/WasmSSABase.td
@@ -14,6 +14,7 @@ include "mlir/IR/OpBase.td"
 
 def WasmSSA_Dialect : Dialect {
   let name = "wasmssa";
+  let useStrictPropertiesInAssemblyFormat = 1;
   let cppNamespace = "::mlir::wasmssa";
   let description = [{
     The `wasmssa` dialect is intended to represent WebAssembly

--- a/mlir/include/mlir/Dialect/WasmSSA/IR/WasmSSAOps.td
+++ b/mlir/include/mlir/Dialect/WasmSSA/IR/WasmSSAOps.td
@@ -283,7 +283,9 @@ def WasmSSA_FuncImportOp : WasmSSA_Op<"import_func", [
                    "StringRef":$importName,
                    "FunctionType": $type)>
   ];
-  let assemblyFormat = "$importName `from` $moduleName `as` $sym_name attr-dict";
+  let assemblyFormat = "$importName `from` $moduleName `as` $sym_name `:` $type "
+                       "(`arg_attrs` `=` $arg_attrs^)? "
+                       "(`res_attrs` `=` $res_attrs^)? attr-dict";
 }
 
 def WasmSSA_GlobalOp : WasmSSA_Op<"global", [
@@ -577,7 +579,7 @@ def WasmSSA_MemImportOp : WasmSSA_Op<"import_mem", [Symbol, ImportOpInterface]> 
        return ::mlir::SymbolTable::Visibility::Nested;
       };
    }];
-  let assemblyFormat = "$importName `from` $moduleName `as` $sym_name attr-dict";
+  let assemblyFormat = "$importName `from` $moduleName `as` $sym_name $limits attr-dict";
 }
 
 def WasmSSA_TableOp : WasmSSA_Op<"table", [Symbol]> {
@@ -617,7 +619,7 @@ def WasmSSA_TableImportOp : WasmSSA_Op<"import_table", [Symbol, ImportOpInterfac
        return ::mlir::SymbolTable::Visibility::Nested;
     };
   }];
-  let assemblyFormat = "$importName `from` $moduleName `as` $sym_name attr-dict";
+  let assemblyFormat = "$importName `from` $moduleName `as` $sym_name $type attr-dict";
 }
 
 def WasmSSA_ReturnOp : WasmSSA_Op<"return", [Terminator]> {

--- a/mlir/test/Conversion/RaiseWasm/wasm-func-to-func.mlir
+++ b/mlir/test/Conversion/RaiseWasm/wasm-func-to-func.mlir
@@ -24,7 +24,7 @@ wasmssa.return %0 : i32
 }
 
 // CHECK-LABEL:         func.func private @"my_module::foo"() -> i32
-wasmssa.import_func "foo" from "my_module" as @func_0 {sym_visibility = "nested", type = () -> (i32)}
+wasmssa.import_func "foo" from "my_module" as @func_0 : () -> (i32) {sym_visibility = "nested"}
 
 // CHECK-LABEL:   func.func @user_of_func0() -> i32 {
 wasmssa.func exported @user_of_func0() -> i32 {

--- a/mlir/test/Dialect/WasmSSA/custom_parser/import.mlir
+++ b/mlir/test/Dialect/WasmSSA/custom_parser/import.mlir
@@ -1,17 +1,17 @@
 // RUN: mlir-opt %s | FileCheck %s
 
 module {
-  wasmssa.import_func "foo" from "my_module" as @func_0 {sym_visibility = "nested", type = (i32) -> ()}
-  wasmssa.import_func "bar" from "my_module" as @func_1 {sym_visibility = "nested", type = (i32) -> ()}
-  wasmssa.import_table "table" from "my_module" as @table_0 {sym_visibility = "nested", type = !wasmssa<tabletype !wasmssa.funcref [2:]>}
-  wasmssa.import_mem "mem" from "my_module" as @mem_0 {limits = !wasmssa<limit[2:]>, sym_visibility = "nested"}
+  wasmssa.import_func "foo" from "my_module" as @func_0 : (i32) -> () {sym_visibility = "nested"}
+  wasmssa.import_func "bar" from "my_module" as @func_1 : (i32) -> () {sym_visibility = "nested"}
+  wasmssa.import_table "table" from "my_module" as @table_0 !wasmssa<tabletype !wasmssa.funcref [2:]> {sym_visibility = "nested"}
+  wasmssa.import_mem "mem" from "my_module" as @mem_0 !wasmssa<limit[2:]> {sym_visibility = "nested"}
   wasmssa.import_global "glob" from "my_module" as @global_0 : i32
   wasmssa.import_global "glob_mut" from "my_other_module" as @global_1 mutable : i32
 }
 
-// CHECK-LABEL:   wasmssa.import_func "foo" from "my_module" as @func_0 {sym_visibility = "nested", type = (i32) -> ()}
-// CHECK:         wasmssa.import_func "bar" from "my_module" as @func_1 {sym_visibility = "nested", type = (i32) -> ()}
-// CHECK:         wasmssa.import_table "table" from "my_module" as @table_0 {sym_visibility = "nested", type = !wasmssa<tabletype !wasmssa.funcref [2:]>}
-// CHECK:         wasmssa.import_mem "mem" from "my_module" as @mem_0 {limits = !wasmssa<limit[2:]>, sym_visibility = "nested"}
+// CHECK-LABEL:   wasmssa.import_func "foo" from "my_module" as @func_0 : (i32) -> () {sym_visibility = "nested"}
+// CHECK:         wasmssa.import_func "bar" from "my_module" as @func_1 : (i32) -> () {sym_visibility = "nested"}
+// CHECK:         wasmssa.import_table "table" from "my_module" as @table_0 !wasmssa<tabletype !wasmssa.funcref [2:]> {sym_visibility = "nested"}
+// CHECK:         wasmssa.import_mem "mem" from "my_module" as @mem_0 !wasmssa<limit[2:]> {sym_visibility = "nested"}
 // CHECK:         wasmssa.import_global "glob" from "my_module" as @global_0 : i32
 // CHECK:         wasmssa.import_global "glob_mut" from "my_other_module" as @global_1 mutable : i32

--- a/mlir/test/Target/Wasm/add_div.mlir
+++ b/mlir/test/Target/Wasm/add_div.mlir
@@ -19,7 +19,7 @@
   (export "add" (func $add)))
 */
 
-// CHECK-LABEL:   wasmssa.import_func "twoTimes" from "env" as @func_0 {type = (i32) -> i32}
+// CHECK-LABEL:   wasmssa.import_func "twoTimes" from "env" as @func_0 : (i32) -> i32
 
 // CHECK-LABEL:   wasmssa.func exported @add(
 // CHECK-SAME:      %[[ARG0:.*]]: !wasmssa<local ref to i32>,

--- a/mlir/test/Target/Wasm/import.mlir
+++ b/mlir/test/Target/Wasm/import.mlir
@@ -11,9 +11,9 @@
 )
 */
 
-// CHECK-LABEL:   wasmssa.import_func "foo" from "my_module" as @func_0 {type = (i32) -> ()}
-// CHECK:         wasmssa.import_func "bar" from "my_module" as @func_1 {type = (i32) -> ()}
-// CHECK:         wasmssa.import_table "table" from "my_module" as @table_0 {type = !wasmssa<tabletype !wasmssa.funcref [2:]>}
-// CHECK:         wasmssa.import_mem "mem" from "my_module" as @mem_0 {limits = !wasmssa<limit[2:]>}
+// CHECK-LABEL:   wasmssa.import_func "foo" from "my_module" as @func_0 : (i32) -> ()
+// CHECK:         wasmssa.import_func "bar" from "my_module" as @func_1 : (i32) -> ()
+// CHECK:         wasmssa.import_table "table" from "my_module" as @table_0 !wasmssa<tabletype !wasmssa.funcref [2:]>
+// CHECK:         wasmssa.import_mem "mem" from "my_module" as @mem_0 !wasmssa<limit[2:]>
 // CHECK:         wasmssa.import_global "glob" from "my_module" as @global_0 : i32
 // CHECK:         wasmssa.import_global "glob_mut" from "my_other_module" as @global_1 mutable : i32


### PR DESCRIPTION
Enable the strict properties assembly format mode for the WasmSSA dialect. Spell import operation type and limit metadata directly in the assembly formats so those inherent attributes are not parsed from attr-dict in strict mode.

Assisted-by: Codex