### PR TITLE
[MLIR][PDLInterp] Enable strict property assembly format

### DIFF
--- a/mlir/include/mlir/Dialect/PDLInterp/IR/PDLInterpOps.td
+++ b/mlir/include/mlir/Dialect/PDLInterp/IR/PDLInterpOps.td
@@ -36,6 +36,7 @@ def PDLInterp_Dialect : Dialect {
   }];
 
   let name = "pdl_interp";
+  let useStrictPropertiesInAssemblyFormat = 1;
   let cppNamespace = "::mlir::pdl_interp";
   let dependentDialects = ["pdl::PDLDialect"];
   let extraClassDeclaration = [{
@@ -110,7 +111,8 @@ def PDLInterp_ApplyConstraintOp : PDLInterp_PredicateOp<"apply_constraint"> {
                        DefaultValuedAttr<BoolAttr, "false">:$isNegated);
   let results = (outs Variadic<PDL_AnyType>:$results);
   let assemblyFormat = [{
-    $name `(` $args `:` type($args) `)` (`:` type($results)^)? attr-dict 
+    $name `(` $args `:` type($args) `)`
+    (`is_negated` `=` $isNegated^)? (`:` type($results)^)? attr-dict
     `->` successors
   }];
 }

--- a/mlir/test/Conversion/PDLToPDLInterp/pdl-to-pdl-interp-matcher.mlir
+++ b/mlir/test/Conversion/PDLToPDLInterp/pdl-to-pdl-interp-matcher.mlir
@@ -133,7 +133,7 @@ module @constraint_with_result_multiple {
 // CHECK-LABEL: module @negated_constraint
 module @negated_constraint {
   // CHECK: func @matcher(%[[ROOT:.*]]: !pdl.operation)
-  // CHECK: pdl_interp.apply_constraint "constraint"(%[[ROOT]] : !pdl.operation) {isNegated = true}
+  // CHECK: pdl_interp.apply_constraint "constraint"(%[[ROOT]] : !pdl.operation) is_negated = true
   // CHECK: pdl_interp.record_match @rewriters::@pdl_generated_rewriter(%[[ROOT]] : !pdl.operation)
   pdl.pattern : benefit(1) {
     %root = operation

--- a/mlir/test/Rewrite/pdl-bytecode.mlir
+++ b/mlir/test/Rewrite/pdl-bytecode.mlir
@@ -80,7 +80,7 @@ module @patterns {
     pdl_interp.are_equal %test_attr, %attr : !pdl.attribute -> ^pat, ^end
 
   ^pat:
-    pdl_interp.apply_constraint "single_entity_constraint"(%root : !pdl.operation) {isNegated = true} -> ^pat1, ^end
+    pdl_interp.apply_constraint "single_entity_constraint"(%root : !pdl.operation) is_negated = true -> ^pat1, ^end
 
   ^pat1:
     pdl_interp.record_match @rewriters::@success(%root : !pdl.operation) : benefit(1), loc([%root]) -> ^end


### PR DESCRIPTION
Enable the strict properties assembly format mode for the PDLInterp dialect. Spell the default-valued isNegated attribute directly in the assembly format so it is no longer parsed from attr-dict in strict mode.

Assisted-by: Codex