### PR TITLE
[MLIR][PDL] Enable strict property assembly format

### DIFF
--- a/mlir/include/mlir/Dialect/PDL/IR/PDLDialect.td
+++ b/mlir/include/mlir/Dialect/PDL/IR/PDLDialect.td
@@ -63,6 +63,7 @@ def PDL_Dialect : Dialect {
   }];
 
   let name = "pdl";
+  let useStrictPropertiesInAssemblyFormat = 1;
   let cppNamespace = "::mlir::pdl";
 
   let useDefaultTypePrinterParser = 1;

--- a/mlir/include/mlir/Dialect/PDL/IR/PDLOps.td
+++ b/mlir/include/mlir/Dialect/PDL/IR/PDLOps.td
@@ -52,7 +52,8 @@ def PDL_ApplyNativeConstraintOp
                        DefaultValuedAttr<BoolAttr, "false">:$isNegated);
   let results = (outs Variadic<PDL_AnyType>:$results);
   let assemblyFormat = [{
-    $name `(` $args `:` type($args) `)` (`:`  type($results)^ )? attr-dict
+    $name `(` $args `:` type($args) `)`
+    (`is_negated` `=` $isNegated^)? (`:`  type($results)^ )? attr-dict
   }];
   let hasVerifier = 1;
 }

--- a/mlir/test/Conversion/PDLToPDLInterp/pdl-to-pdl-interp-matcher.mlir
+++ b/mlir/test/Conversion/PDLToPDLInterp/pdl-to-pdl-interp-matcher.mlir
@@ -137,7 +137,7 @@ module @negated_constraint {
   // CHECK: pdl_interp.record_match @rewriters::@pdl_generated_rewriter(%[[ROOT]] : !pdl.operation)
   pdl.pattern : benefit(1) {
     %root = operation
-    pdl.apply_native_constraint "constraint"(%root : !pdl.operation) {isNegated = true}
+    pdl.apply_native_constraint "constraint"(%root : !pdl.operation) is_negated = true
     rewrite %root with "rewriter"
   }
 }

--- a/mlir/test/mlir-pdll/CodeGen/MLIR/expr.pdll
+++ b/mlir/test/mlir-pdll/CodeGen/MLIR/expr.pdll
@@ -38,7 +38,7 @@ Pattern TestExternalCall => replace root: Op with TestRewrite(root);
 
 // CHECK: pdl.pattern @TestExternalNegatedCall
 // CHECK: %[[ROOT:.*]] = operation
-// CHECK: apply_native_constraint  "TestConstraint"(%[[ROOT]] : !pdl.operation) {isNegated = true}
+// CHECK: apply_native_constraint "TestConstraint"(%[[ROOT]] : !pdl.operation) is_negated = true
 // CHECK: rewrite %[[ROOT]]
 // CHECK: erase %[[ROOT]]
 Constraint TestConstraint(op: Op);


### PR DESCRIPTION
Enable the strict properties assembly format mode for the PDL dialect. Spell the default-valued isNegated attribute directly in the assembly format so it is no longer parsed from attr-dict in strict mode.

Assisted-by: Codex