### PR TITLE
[MLIR][OpenACC] Enable strict property assembly format

### DIFF
--- a/flang/test/Analysis/AliasAnalysis/alias-analysis-acc.mlir
+++ b/flang/test/Analysis/AliasAnalysis/alias-analysis-acc.mlir
@@ -11,8 +11,8 @@ func.func @testBothOutsideCopyinDistinctHosts() {
   %b = fir.alloca f32 {uniq_name = "_QFEb"}
   %da = fir.declare %a {uniq_name = "_QFEa"} : (!fir.ref<f32>) -> !fir.ref<f32>
   %db = fir.declare %b {uniq_name = "_QFEb"} : (!fir.ref<f32>) -> !fir.ref<f32>
-  %ca = acc.copyin varPtr(%da : !fir.ref<f32>) -> !fir.ref<f32> {name = "a", test.ptr = "cin_a"}
-  %cb = acc.copyin varPtr(%db : !fir.ref<f32>) -> !fir.ref<f32> {name = "b", test.ptr = "cin_b"}
+  %ca = acc.copyin varPtr(%da : !fir.ref<f32>) name("a") -> !fir.ref<f32> {test.ptr = "cin_a"}
+  %cb = acc.copyin varPtr(%db : !fir.ref<f32>) name("b") -> !fir.ref<f32> {test.ptr = "cin_b"}
   return
 }
 
@@ -27,8 +27,8 @@ func.func @testBothOutsideCopyinTargetDummyArgsMayAlias(%arg0: !fir.ref<f32> {fi
   %ds = fir.dummy_scope : !fir.dscope
   %dx = fir.declare %arg0 dummy_scope %ds arg 1 {fortran_attrs = #fir.var_attrs<target>, uniq_name = "_QFEex"} : (!fir.ref<f32>, !fir.dscope) -> !fir.ref<f32>
   %dy = fir.declare %arg1 dummy_scope %ds arg 2 {fortran_attrs = #fir.var_attrs<target>, uniq_name = "_QFEey"} : (!fir.ref<f32>, !fir.dscope) -> !fir.ref<f32>
-  %cx = acc.copyin varPtr(%dx : !fir.ref<f32>) -> !fir.ref<f32> {name = "x", test.ptr = "arg_cp_a"}
-  %cy = acc.copyin varPtr(%dy : !fir.ref<f32>) -> !fir.ref<f32> {name = "y", test.ptr = "arg_cp_b"}
+  %cx = acc.copyin varPtr(%dx : !fir.ref<f32>) name("x") -> !fir.ref<f32> {test.ptr = "arg_cp_a"}
+  %cy = acc.copyin varPtr(%dy : !fir.ref<f32>) name("y") -> !fir.ref<f32> {test.ptr = "arg_cp_b"}
   return
 }
 
@@ -41,8 +41,8 @@ func.func @testBothOutsideCopyinTargetDummyArgsMayAlias(%arg0: !fir.ref<f32> {fi
 func.func @testBothOutsideCopyinSameHostMustAlias() {
   %a = fir.alloca f32 {uniq_name = "_QFEa"}
   %da = fir.declare %a {uniq_name = "_QFEa"} : (!fir.ref<f32>) -> !fir.ref<f32>
-  %ca1 = acc.copyin varPtr(%da : !fir.ref<f32>) -> !fir.ref<f32> {name = "a", test.ptr = "out_must_a"}
-  %ca2 = acc.copyin varPtr(%da : !fir.ref<f32>) -> !fir.ref<f32> {name = "a", test.ptr = "out_must_b"}
+  %ca1 = acc.copyin varPtr(%da : !fir.ref<f32>) name("a") -> !fir.ref<f32> {test.ptr = "out_must_a"}
+  %ca2 = acc.copyin varPtr(%da : !fir.ref<f32>) name("a") -> !fir.ref<f32> {test.ptr = "out_must_b"}
   return
 }
 
@@ -56,8 +56,8 @@ func.func @testBothOutsideCreateDistinctHosts() {
   %b = fir.alloca f32 {uniq_name = "_QFEb"}
   %da = fir.declare %a {uniq_name = "_QFEa"} : (!fir.ref<f32>) -> !fir.ref<f32>
   %db = fir.declare %b {uniq_name = "_QFEb"} : (!fir.ref<f32>) -> !fir.ref<f32>
-  %ta = acc.create varPtr(%da : !fir.ref<f32>) -> !fir.ref<f32> {name = "a", test.ptr = "crt_a"}
-  %tb = acc.create varPtr(%db : !fir.ref<f32>) -> !fir.ref<f32> {name = "b", test.ptr = "crt_b"}
+  %ta = acc.create varPtr(%da : !fir.ref<f32>) name("a") -> !fir.ref<f32> {test.ptr = "crt_a"}
+  %tb = acc.create varPtr(%db : !fir.ref<f32>) name("b") -> !fir.ref<f32> {test.ptr = "crt_b"}
   return
 }
 
@@ -73,8 +73,8 @@ func.func @testComputeRegionCopyinDistinctHostsInsideConvert() {
   %b = fir.alloca f32 {uniq_name = "_QFEb"}
   %da = fir.declare %a {uniq_name = "_QFEa"} : (!fir.ref<f32>) -> !fir.ref<f32>
   %db = fir.declare %b {uniq_name = "_QFEb"} : (!fir.ref<f32>) -> !fir.ref<f32>
-  %ca = acc.copyin varPtr(%da : !fir.ref<f32>) -> !fir.ref<f32> {name = "a"}
-  %cb = acc.copyin varPtr(%db : !fir.ref<f32>) -> !fir.ref<f32> {name = "b"}
+  %ca = acc.copyin varPtr(%da : !fir.ref<f32>) name("a") -> !fir.ref<f32>
+  %cb = acc.copyin varPtr(%db : !fir.ref<f32>) name("b") -> !fir.ref<f32>
   acc.compute_region ins(%arg0 = %ca, %arg1 = %cb) : (!fir.ref<f32>, !fir.ref<f32>) {
     %va = fir.convert %arg0 {test.ptr = "cr_dist_a"} : (!fir.ref<f32>) -> !fir.ref<f32>
     %vb = fir.convert %arg1 {test.ptr = "cr_dist_b"} : (!fir.ref<f32>) -> !fir.ref<f32>
@@ -93,8 +93,8 @@ func.func @testComputeRegionCreateDistinctHostsInsideConvert() {
   %b = fir.alloca f32 {uniq_name = "_QFEb"}
   %da = fir.declare %a {uniq_name = "_QFEa"} : (!fir.ref<f32>) -> !fir.ref<f32>
   %db = fir.declare %b {uniq_name = "_QFEb"} : (!fir.ref<f32>) -> !fir.ref<f32>
-  %ta = acc.create varPtr(%da : !fir.ref<f32>) -> !fir.ref<f32> {name = "a"}
-  %tb = acc.create varPtr(%db : !fir.ref<f32>) -> !fir.ref<f32> {name = "b"}
+  %ta = acc.create varPtr(%da : !fir.ref<f32>) name("a") -> !fir.ref<f32>
+  %tb = acc.create varPtr(%db : !fir.ref<f32>) name("b") -> !fir.ref<f32>
   acc.compute_region ins(%arg0 = %ta, %arg1 = %tb) : (!fir.ref<f32>, !fir.ref<f32>) {
     %va = fir.convert %arg0 {test.ptr = "cr_crt_a"} : (!fir.ref<f32>) -> !fir.ref<f32>
     %vb = fir.convert %arg1 {test.ptr = "cr_crt_b"} : (!fir.ref<f32>) -> !fir.ref<f32>
@@ -114,8 +114,8 @@ func.func @testComputeRegionCopyinTargetDummiesMayAliasInsideConvert(%arg0: !fir
   %ds = fir.dummy_scope : !fir.dscope
   %dx = fir.declare %arg0 dummy_scope %ds arg 1 {fortran_attrs = #fir.var_attrs<target>, uniq_name = "_QFEex"} : (!fir.ref<f32>, !fir.dscope) -> !fir.ref<f32>
   %dy = fir.declare %arg1 dummy_scope %ds arg 2 {fortran_attrs = #fir.var_attrs<target>, uniq_name = "_QFEey"} : (!fir.ref<f32>, !fir.dscope) -> !fir.ref<f32>
-  %cx = acc.copyin varPtr(%dx : !fir.ref<f32>) -> !fir.ref<f32> {name = "x"}
-  %cy = acc.copyin varPtr(%dy : !fir.ref<f32>) -> !fir.ref<f32> {name = "y"}
+  %cx = acc.copyin varPtr(%dx : !fir.ref<f32>) name("x") -> !fir.ref<f32>
+  %cy = acc.copyin varPtr(%dy : !fir.ref<f32>) name("y") -> !fir.ref<f32>
   acc.compute_region ins(%cr0 = %cx, %cr1 = %cy) : (!fir.ref<f32>, !fir.ref<f32>) {
     %va = fir.convert %cr0 {test.ptr = "cr_tgt_a"} : (!fir.ref<f32>) -> !fir.ref<f32>
     %vb = fir.convert %cr1 {test.ptr = "cr_tgt_b"} : (!fir.ref<f32>) -> !fir.ref<f32>
@@ -134,7 +134,7 @@ func.func @testComputeRegionCopyinTargetDummiesMayAliasInsideConvert(%arg0: !fir
 func.func @testComputeRegionCopyinSameHostMustAliasInsideConvert() {
   %a = fir.alloca f32 {uniq_name = "_QFEa"}
   %da = fir.declare %a {uniq_name = "_QFEa"} : (!fir.ref<f32>) -> !fir.ref<f32>
-  %ca = acc.copyin varPtr(%da : !fir.ref<f32>) -> !fir.ref<f32> {name = "a"}
+  %ca = acc.copyin varPtr(%da : !fir.ref<f32>) name("a") -> !fir.ref<f32>
   acc.compute_region ins(%arg0 = %ca, %arg1 = %ca) : (!fir.ref<f32>, !fir.ref<f32>) {
     %va = fir.convert %arg0 {test.ptr = "cr_must_a"} : (!fir.ref<f32>) -> !fir.ref<f32>
     %vb = fir.convert %arg1 {test.ptr = "cr_must_b"} : (!fir.ref<f32>) -> !fir.ref<f32>
@@ -154,8 +154,8 @@ func.func @testKernelsCopyinDistinctHostsInsideConvert() {
   %b = fir.alloca f32 {uniq_name = "_QFEb"}
   %da = fir.declare %a {uniq_name = "_QFEa"} : (!fir.ref<f32>) -> !fir.ref<f32>
   %db = fir.declare %b {uniq_name = "_QFEb"} : (!fir.ref<f32>) -> !fir.ref<f32>
-  %ca = acc.copyin varPtr(%da : !fir.ref<f32>) -> !fir.ref<f32> {name = "a"}
-  %cb = acc.copyin varPtr(%db : !fir.ref<f32>) -> !fir.ref<f32> {name = "b"}
+  %ca = acc.copyin varPtr(%da : !fir.ref<f32>) name("a") -> !fir.ref<f32>
+  %cb = acc.copyin varPtr(%db : !fir.ref<f32>) name("b") -> !fir.ref<f32>
   acc.kernels dataOperands(%ca, %cb : !fir.ref<f32>, !fir.ref<f32>) {
     %va = fir.convert %ca {test.ptr = "kern_dist_a"} : (!fir.ref<f32>) -> !fir.ref<f32>
     %vb = fir.convert %cb {test.ptr = "kern_dist_b"} : (!fir.ref<f32>) -> !fir.ref<f32>
@@ -174,8 +174,8 @@ func.func @testKernelsCreateDistinctHostsInsideConvert() {
   %b = fir.alloca f32 {uniq_name = "_QFEb"}
   %da = fir.declare %a {uniq_name = "_QFEa"} : (!fir.ref<f32>) -> !fir.ref<f32>
   %db = fir.declare %b {uniq_name = "_QFEb"} : (!fir.ref<f32>) -> !fir.ref<f32>
-  %ta = acc.create varPtr(%da : !fir.ref<f32>) -> !fir.ref<f32> {name = "a"}
-  %tb = acc.create varPtr(%db : !fir.ref<f32>) -> !fir.ref<f32> {name = "b"}
+  %ta = acc.create varPtr(%da : !fir.ref<f32>) name("a") -> !fir.ref<f32>
+  %tb = acc.create varPtr(%db : !fir.ref<f32>) name("b") -> !fir.ref<f32>
   acc.kernels dataOperands(%ta, %tb : !fir.ref<f32>, !fir.ref<f32>) {
     %va = fir.convert %ta {test.ptr = "kern_crt_a"} : (!fir.ref<f32>) -> !fir.ref<f32>
     %vb = fir.convert %tb {test.ptr = "kern_crt_b"} : (!fir.ref<f32>) -> !fir.ref<f32>
@@ -194,8 +194,8 @@ func.func @testKernelsCopyinTargetDummiesMayAliasInsideConvert(%arg0: !fir.ref<f
   %ds = fir.dummy_scope : !fir.dscope
   %dx = fir.declare %arg0 dummy_scope %ds arg 1 {fortran_attrs = #fir.var_attrs<target>, uniq_name = "_QFEex"} : (!fir.ref<f32>, !fir.dscope) -> !fir.ref<f32>
   %dy = fir.declare %arg1 dummy_scope %ds arg 2 {fortran_attrs = #fir.var_attrs<target>, uniq_name = "_QFEey"} : (!fir.ref<f32>, !fir.dscope) -> !fir.ref<f32>
-  %cx = acc.copyin varPtr(%dx : !fir.ref<f32>) -> !fir.ref<f32> {name = "x"}
-  %cy = acc.copyin varPtr(%dy : !fir.ref<f32>) -> !fir.ref<f32> {name = "y"}
+  %cx = acc.copyin varPtr(%dx : !fir.ref<f32>) name("x") -> !fir.ref<f32>
+  %cy = acc.copyin varPtr(%dy : !fir.ref<f32>) name("y") -> !fir.ref<f32>
   acc.kernels dataOperands(%cx, %cy : !fir.ref<f32>, !fir.ref<f32>) {
     %va = fir.convert %cx {test.ptr = "kern_tgt_a"} : (!fir.ref<f32>) -> !fir.ref<f32>
     %vb = fir.convert %cy {test.ptr = "kern_tgt_b"} : (!fir.ref<f32>) -> !fir.ref<f32>
@@ -213,7 +213,7 @@ func.func @testKernelsCopyinTargetDummiesMayAliasInsideConvert(%arg0: !fir.ref<f
 func.func @testKernelsCopyinSameHostMustAliasInsideConvert() {
   %a = fir.alloca f32 {uniq_name = "_QFEa"}
   %da = fir.declare %a {uniq_name = "_QFEa"} : (!fir.ref<f32>) -> !fir.ref<f32>
-  %ca = acc.copyin varPtr(%da : !fir.ref<f32>) -> !fir.ref<f32> {name = "a"}
+  %ca = acc.copyin varPtr(%da : !fir.ref<f32>) name("a") -> !fir.ref<f32>
   acc.kernels dataOperands(%ca : !fir.ref<f32>) {
     %va = fir.convert %ca {test.ptr = "kern_must_a"} : (!fir.ref<f32>) -> !fir.ref<f32>
     %vb = fir.convert %ca {test.ptr = "kern_must_b"} : (!fir.ref<f32>) -> !fir.ref<f32>
@@ -235,8 +235,8 @@ func.func @testComputeRegionPrivateInsideConvert() {
   %b = fir.alloca f32 {uniq_name = "_QFEb"}
   %da = fir.declare %a {uniq_name = "_QFEa"} : (!fir.ref<f32>) -> !fir.ref<f32>
   %db = fir.declare %b {uniq_name = "_QFEb"} : (!fir.ref<f32>) -> !fir.ref<f32>
-  %pa = acc.private varPtr(%da : !fir.ref<f32>) -> !fir.ref<f32> {name = "a"}
-  %pb = acc.private varPtr(%db : !fir.ref<f32>) -> !fir.ref<f32> {name = "b"}
+  %pa = acc.private varPtr(%da : !fir.ref<f32>) name("a") -> !fir.ref<f32>
+  %pb = acc.private varPtr(%db : !fir.ref<f32>) name("b") -> !fir.ref<f32>
   acc.compute_region ins(%arg0 = %pa, %arg1 = %pb) : (!fir.ref<f32>, !fir.ref<f32>) {
     %va = fir.convert %arg0 {test.ptr = "cr_priv_a"} : (!fir.ref<f32>) -> !fir.ref<f32>
     %vb = fir.convert %arg1 {test.ptr = "cr_priv_b"} : (!fir.ref<f32>) -> !fir.ref<f32>
@@ -255,8 +255,8 @@ func.func @testComputeRegionPrivateInsideConvert() {
 func.func @testComputeRegionCopyinVsPrivateSameHostNoAlias() {
   %a = fir.alloca f32 {uniq_name = "_QFEa"}
   %da = fir.declare %a {uniq_name = "_QFEa"} : (!fir.ref<f32>) -> !fir.ref<f32>
-  %ca = acc.copyin varPtr(%da : !fir.ref<f32>) -> !fir.ref<f32> {name = "a"}
-  %pp = acc.private varPtr(%da : !fir.ref<f32>) -> !fir.ref<f32> {name = "a"}
+  %ca = acc.copyin varPtr(%da : !fir.ref<f32>) name("a") -> !fir.ref<f32>
+  %pp = acc.private varPtr(%da : !fir.ref<f32>) name("a") -> !fir.ref<f32>
   acc.compute_region ins(%arg0 = %ca, %arg1 = %pp) : (!fir.ref<f32>, !fir.ref<f32>) {
     %va = fir.convert %arg0 {test.ptr = "cr_mix_cp"} : (!fir.ref<f32>) -> !fir.ref<f32>
     %vb = fir.convert %arg1 {test.ptr = "cr_mix_pr"} : (!fir.ref<f32>) -> !fir.ref<f32>
@@ -273,8 +273,8 @@ func.func @testComputeRegionCopyinVsPrivateSameHostNoAlias() {
 func.func @testComputeRegionCreateVsPrivateSameHostNoAlias() {
   %a = fir.alloca f32 {uniq_name = "_QFEa"}
   %da = fir.declare %a {uniq_name = "_QFEa"} : (!fir.ref<f32>) -> !fir.ref<f32>
-  %ta = acc.create varPtr(%da : !fir.ref<f32>) -> !fir.ref<f32> {name = "a"}
-  %pp = acc.private varPtr(%da : !fir.ref<f32>) -> !fir.ref<f32> {name = "a"}
+  %ta = acc.create varPtr(%da : !fir.ref<f32>) name("a") -> !fir.ref<f32>
+  %pp = acc.private varPtr(%da : !fir.ref<f32>) name("a") -> !fir.ref<f32>
   acc.compute_region ins(%arg0 = %ta, %arg1 = %pp) : (!fir.ref<f32>, !fir.ref<f32>) {
     %va = fir.convert %arg0 {test.ptr = "cr_mix_cr"} : (!fir.ref<f32>) -> !fir.ref<f32>
     %vb = fir.convert %arg1 {test.ptr = "cr_mix_pr2"} : (!fir.ref<f32>) -> !fir.ref<f32>
@@ -292,8 +292,8 @@ func.func @testComputeRegionCreateVsPrivateSameHostNoAlias() {
 func.func @testComputeRegionCopyinVsFirstprivateSameHostNoAlias() {
   %a = fir.alloca f32 {uniq_name = "_QFEa"}
   %da = fir.declare %a {uniq_name = "_QFEa"} : (!fir.ref<f32>) -> !fir.ref<f32>
-  %ca = acc.copyin varPtr(%da : !fir.ref<f32>) -> !fir.ref<f32> {name = "a"}
-  %pf = acc.firstprivate varPtr(%da : !fir.ref<f32>) -> !fir.ref<f32> {name = "a"}
+  %ca = acc.copyin varPtr(%da : !fir.ref<f32>) name("a") -> !fir.ref<f32>
+  %pf = acc.firstprivate varPtr(%da : !fir.ref<f32>) name("a") -> !fir.ref<f32>
   acc.compute_region ins(%arg0 = %ca, %arg1 = %pf) : (!fir.ref<f32>, !fir.ref<f32>) {
     %va = fir.convert %arg0 {test.ptr = "cr_fp_cp"} : (!fir.ref<f32>) -> !fir.ref<f32>
     %vb = fir.convert %arg1 {test.ptr = "cr_fp_pr"} : (!fir.ref<f32>) -> !fir.ref<f32>
@@ -311,8 +311,8 @@ func.func @testComputeRegionCopyinVsFirstprivateSameHostNoAlias() {
 func.func @testComputeRegionCopyinVsFirstprivateMapSameHostNoAlias() {
   %a = fir.alloca f32 {uniq_name = "_QFEa"}
   %da = fir.declare %a {uniq_name = "_QFEa"} : (!fir.ref<f32>) -> !fir.ref<f32>
-  %fm = acc.firstprivate_map varPtr(%da : !fir.ref<f32>) varType(f32) -> !fir.ref<f32> {name = "a"}
-  %ca = acc.copyin varPtr(%da : !fir.ref<f32>) -> !fir.ref<f32> {name = "a"}
+  %fm = acc.firstprivate_map varPtr(%da : !fir.ref<f32>) varType(f32) name("a") -> !fir.ref<f32>
+  %ca = acc.copyin varPtr(%da : !fir.ref<f32>) name("a") -> !fir.ref<f32>
   acc.compute_region ins(%arg0 = %ca, %arg1 = %fm) : (!fir.ref<f32>, !fir.ref<f32>) {
     %va = fir.convert %arg0 {test.ptr = "cr_fpm_cp"} : (!fir.ref<f32>) -> !fir.ref<f32>
     %vb = fir.convert %arg1 {test.ptr = "cr_fpm_fm"} : (!fir.ref<f32>) -> !fir.ref<f32>
@@ -330,8 +330,8 @@ func.func @testComputeRegionCopyinVsFirstprivateMapSameHostNoAlias() {
 func.func @testKernelsCopyinVsPrivateSameHostNoAlias() {
   %a = fir.alloca f32 {uniq_name = "_QFEa"}
   %da = fir.declare %a {uniq_name = "_QFEa"} : (!fir.ref<f32>) -> !fir.ref<f32>
-  %ca = acc.copyin varPtr(%da : !fir.ref<f32>) -> !fir.ref<f32> {name = "a"}
-  %pp = acc.private varPtr(%da : !fir.ref<f32>) -> !fir.ref<f32> {name = "a"}
+  %ca = acc.copyin varPtr(%da : !fir.ref<f32>) name("a") -> !fir.ref<f32>
+  %pp = acc.private varPtr(%da : !fir.ref<f32>) name("a") -> !fir.ref<f32>
   acc.kernels dataOperands(%ca : !fir.ref<f32>) private(%pp : !fir.ref<f32>) {
     %va = fir.convert %ca {test.ptr = "k_mix_cp"} : (!fir.ref<f32>) -> !fir.ref<f32>
     %vb = fir.convert %pp {test.ptr = "k_mix_pr"} : (!fir.ref<f32>) -> !fir.ref<f32>
@@ -348,8 +348,8 @@ func.func @testKernelsCopyinVsPrivateSameHostNoAlias() {
 func.func @testKernelsCreateVsPrivateSameHostNoAlias() {
   %a = fir.alloca f32 {uniq_name = "_QFEa"}
   %da = fir.declare %a {uniq_name = "_QFEa"} : (!fir.ref<f32>) -> !fir.ref<f32>
-  %ta = acc.create varPtr(%da : !fir.ref<f32>) -> !fir.ref<f32> {name = "a"}
-  %pp = acc.private varPtr(%da : !fir.ref<f32>) -> !fir.ref<f32> {name = "a"}
+  %ta = acc.create varPtr(%da : !fir.ref<f32>) name("a") -> !fir.ref<f32>
+  %pp = acc.private varPtr(%da : !fir.ref<f32>) name("a") -> !fir.ref<f32>
   acc.kernels dataOperands(%ta : !fir.ref<f32>) private(%pp : !fir.ref<f32>) {
     %va = fir.convert %ta {test.ptr = "k_mix_cr"} : (!fir.ref<f32>) -> !fir.ref<f32>
     %vb = fir.convert %pp {test.ptr = "k_mix_pr2"} : (!fir.ref<f32>) -> !fir.ref<f32>
@@ -367,8 +367,8 @@ func.func @testKernelsCreateVsPrivateSameHostNoAlias() {
 func.func @testKernelsCopyinVsFirstprivateSameHostNoAlias() {
   %a = fir.alloca f32 {uniq_name = "_QFEa"}
   %da = fir.declare %a {uniq_name = "_QFEa"} : (!fir.ref<f32>) -> !fir.ref<f32>
-  %ca = acc.copyin varPtr(%da : !fir.ref<f32>) -> !fir.ref<f32> {name = "a"}
-  %pf = acc.firstprivate varPtr(%da : !fir.ref<f32>) -> !fir.ref<f32> {name = "a"}
+  %ca = acc.copyin varPtr(%da : !fir.ref<f32>) name("a") -> !fir.ref<f32>
+  %pf = acc.firstprivate varPtr(%da : !fir.ref<f32>) name("a") -> !fir.ref<f32>
   acc.kernels dataOperands(%ca : !fir.ref<f32>) firstprivate(%pf : !fir.ref<f32>) {
     %va = fir.convert %ca {test.ptr = "k_fp_cp"} : (!fir.ref<f32>) -> !fir.ref<f32>
     %vb = fir.convert %pf {test.ptr = "k_fp_pr"} : (!fir.ref<f32>) -> !fir.ref<f32>
@@ -386,8 +386,8 @@ func.func @testKernelsCopyinVsFirstprivateSameHostNoAlias() {
 func.func @testKernelsCopyinVsFirstprivateMapSameHostNoAlias() {
   %a = fir.alloca f32 {uniq_name = "_QFEa"}
   %da = fir.declare %a {uniq_name = "_QFEa"} : (!fir.ref<f32>) -> !fir.ref<f32>
-  %fm = acc.firstprivate_map varPtr(%da : !fir.ref<f32>) varType(f32) -> !fir.ref<f32> {name = "a"}
-  %ca = acc.copyin varPtr(%da : !fir.ref<f32>) -> !fir.ref<f32> {name = "a"}
+  %fm = acc.firstprivate_map varPtr(%da : !fir.ref<f32>) varType(f32) name("a") -> !fir.ref<f32>
+  %ca = acc.copyin varPtr(%da : !fir.ref<f32>) name("a") -> !fir.ref<f32>
   acc.kernels dataOperands(%ca : !fir.ref<f32>) firstprivate(%fm : !fir.ref<f32>) {
     %va = fir.convert %ca {test.ptr = "k_fpm_cp"} : (!fir.ref<f32>) -> !fir.ref<f32>
     %vb = fir.convert %fm {test.ptr = "k_fpm_fm"} : (!fir.ref<f32>) -> !fir.ref<f32>
@@ -405,9 +405,9 @@ func.func @testKernelsCopyinVsFirstprivateMapSameHostNoAlias() {
 func.func @testComputeRegionPrivateOpInsideVsInsCreateNoAlias() {
   %a = fir.alloca f32 {uniq_name = "_QFEa"}
   %da = fir.declare %a {uniq_name = "_QFEa"} : (!fir.ref<f32>) -> !fir.ref<f32>
-  %tc = acc.create varPtr(%da : !fir.ref<f32>) -> !fir.ref<f32> {name = "a"}
+  %tc = acc.create varPtr(%da : !fir.ref<f32>) name("a") -> !fir.ref<f32>
   acc.compute_region ins(%arg0 = %tc) : (!fir.ref<f32>) {
-    %pv = acc.private varPtr(%arg0 : !fir.ref<f32>) -> !fir.ref<f32> {name = "a"}
+    %pv = acc.private varPtr(%arg0 : !fir.ref<f32>) name("a") -> !fir.ref<f32>
     %vb = fir.convert %pv {test.ptr = "cr_body_pr"} : (!fir.ref<f32>) -> !fir.ref<f32>
     %vc = fir.convert %arg0 {test.ptr = "cr_body_cr"} : (!fir.ref<f32>) -> !fir.ref<f32>
     acc.yield
@@ -424,9 +424,9 @@ func.func @testComputeRegionPrivateOpInsideVsInsCreateNoAlias() {
 func.func @testKernelsPrivateOpInsideVsDataCopyinNoAlias() {
   %a = fir.alloca f32 {uniq_name = "_QFEa"}
   %da = fir.declare %a {uniq_name = "_QFEa"} : (!fir.ref<f32>) -> !fir.ref<f32>
-  %ca = acc.copyin varPtr(%da : !fir.ref<f32>) -> !fir.ref<f32> {name = "a"}
+  %ca = acc.copyin varPtr(%da : !fir.ref<f32>) name("a") -> !fir.ref<f32>
   acc.kernels dataOperands(%ca : !fir.ref<f32>) {
-    %pv = acc.private varPtr(%ca : !fir.ref<f32>) -> !fir.ref<f32> {name = "a"}
+    %pv = acc.private varPtr(%ca : !fir.ref<f32>) name("a") -> !fir.ref<f32>
     %vb = fir.convert %pv {test.ptr = "k_body_pr"} : (!fir.ref<f32>) -> !fir.ref<f32>
     %vc = fir.convert %ca {test.ptr = "k_body_cp"} : (!fir.ref<f32>) -> !fir.ref<f32>
     acc.terminator
@@ -458,8 +458,8 @@ func.func @testBothOutsideReductionDistinctHosts() {
   %b = fir.alloca f32 {uniq_name = "_QFEb"}
   %da = fir.declare %a {uniq_name = "_QFEa"} : (!fir.ref<f32>) -> !fir.ref<f32>
   %db = fir.declare %b {uniq_name = "_QFEb"} : (!fir.ref<f32>) -> !fir.ref<f32>
-  %ra = acc.reduction varPtr(%da : !fir.ref<f32>) recipe(@red_f32_aa) -> !fir.ref<f32> {name = "a", test.ptr = "red_a"}
-  %rb = acc.reduction varPtr(%db : !fir.ref<f32>) recipe(@red_f32_aa) -> !fir.ref<f32> {name = "b", test.ptr = "red_b"}
+  %ra = acc.reduction varPtr(%da : !fir.ref<f32>) recipe(@red_f32_aa) name("a") -> !fir.ref<f32> {test.ptr = "red_a"}
+  %rb = acc.reduction varPtr(%db : !fir.ref<f32>) recipe(@red_f32_aa) name("b") -> !fir.ref<f32> {test.ptr = "red_b"}
   return
 }
 
@@ -471,8 +471,8 @@ func.func @testComputeRegionReductionDistinctHostsInsideConvert() {
   %b = fir.alloca f32 {uniq_name = "_QFEb"}
   %da = fir.declare %a {uniq_name = "_QFEa"} : (!fir.ref<f32>) -> !fir.ref<f32>
   %db = fir.declare %b {uniq_name = "_QFEb"} : (!fir.ref<f32>) -> !fir.ref<f32>
-  %ra = acc.reduction varPtr(%da : !fir.ref<f32>) recipe(@red_f32_aa) -> !fir.ref<f32> {name = "a"}
-  %rb = acc.reduction varPtr(%db : !fir.ref<f32>) recipe(@red_f32_aa) -> !fir.ref<f32> {name = "b"}
+  %ra = acc.reduction varPtr(%da : !fir.ref<f32>) recipe(@red_f32_aa) name("a") -> !fir.ref<f32>
+  %rb = acc.reduction varPtr(%db : !fir.ref<f32>) recipe(@red_f32_aa) name("b") -> !fir.ref<f32>
   acc.compute_region ins(%arg0 = %ra, %arg1 = %rb) : (!fir.ref<f32>, !fir.ref<f32>) {
     %va = fir.convert %arg0 {test.ptr = "cr_red_a"} : (!fir.ref<f32>) -> !fir.ref<f32>
     %vb = fir.convert %arg1 {test.ptr = "cr_red_b"} : (!fir.ref<f32>) -> !fir.ref<f32>
@@ -489,8 +489,8 @@ func.func @testKernelsReductionDistinctHostsInsideConvert() {
   %b = fir.alloca f32 {uniq_name = "_QFEb"}
   %da = fir.declare %a {uniq_name = "_QFEa"} : (!fir.ref<f32>) -> !fir.ref<f32>
   %db = fir.declare %b {uniq_name = "_QFEb"} : (!fir.ref<f32>) -> !fir.ref<f32>
-  %ra = acc.reduction varPtr(%da : !fir.ref<f32>) recipe(@red_f32_aa) -> !fir.ref<f32> {name = "a"}
-  %rb = acc.reduction varPtr(%db : !fir.ref<f32>) recipe(@red_f32_aa) -> !fir.ref<f32> {name = "b"}
+  %ra = acc.reduction varPtr(%da : !fir.ref<f32>) recipe(@red_f32_aa) name("a") -> !fir.ref<f32>
+  %rb = acc.reduction varPtr(%db : !fir.ref<f32>) recipe(@red_f32_aa) name("b") -> !fir.ref<f32>
   acc.kernels reduction(%ra, %rb : !fir.ref<f32>, !fir.ref<f32>) {
     %va = fir.convert %ra {test.ptr = "kern_red_a"} : (!fir.ref<f32>) -> !fir.ref<f32>
     %vb = fir.convert %rb {test.ptr = "kern_red_b"} : (!fir.ref<f32>) -> !fir.ref<f32>
@@ -505,8 +505,8 @@ func.func @testKernelsReductionDistinctHostsInsideConvert() {
 func.func @testComputeRegionReductionVsPrivateSameHostNoAlias() {
   %a = fir.alloca f32 {uniq_name = "_QFEa"}
   %da = fir.declare %a {uniq_name = "_QFEa"} : (!fir.ref<f32>) -> !fir.ref<f32>
-  %ra = acc.reduction varPtr(%da : !fir.ref<f32>) recipe(@red_f32_aa) -> !fir.ref<f32> {name = "a"}
-  %pp = acc.private varPtr(%da : !fir.ref<f32>) -> !fir.ref<f32> {name = "a"}
+  %ra = acc.reduction varPtr(%da : !fir.ref<f32>) recipe(@red_f32_aa) name("a") -> !fir.ref<f32>
+  %pp = acc.private varPtr(%da : !fir.ref<f32>) name("a") -> !fir.ref<f32>
   acc.compute_region ins(%arg0 = %ra, %arg1 = %pp) : (!fir.ref<f32>, !fir.ref<f32>) {
     %va = fir.convert %arg0 {test.ptr = "cr_mix_rd"} : (!fir.ref<f32>) -> !fir.ref<f32>
     %vb = fir.convert %arg1 {test.ptr = "cr_mix_pr3"} : (!fir.ref<f32>) -> !fir.ref<f32>
@@ -552,7 +552,7 @@ func.func @testBothInsideKernels() {
 // CHECK-LABEL: Testing : "test_acc_routine__0"
 // CHECK-DAG: arg_a#0 <-> arg_b#0: NoAlias
 func.func @test_acc_routine__0(%arg0: !fir.ref<f32> {fir.bindc_name = "a"}, %arg1: !fir.ref<f32> {fir.bindc_name = "b"}) attributes {acc.specialized_routine = #acc.specialized_routine<@acc_routine_0, <vector>, "test_acc_routine_">, fir.internal_name = "_QPtest_acc_routine"} {
-  %0 = acc.par_width {par_dim = #acc.par_dim<thread_x>}
+  %0 = acc.par_width par_dim(#acc.par_dim<thread_x>)
   acc.compute_region launch(%arg2 = %0) ins(%arg3 = %arg0, %arg4 = %arg1) : (!fir.ref<f32>, !fir.ref<f32>) {
     %1 = fir.dummy_scope : !fir.dscope
     %2 = fir.declare %arg3 dummy_scope %1 arg 1 {uniq_name = "_QFtest_acc_routineEa", test.ptr = "arg_a"} : (!fir.ref<f32>, !fir.dscope) -> !fir.ref<f32>
@@ -578,8 +578,8 @@ func.func @test_acc_compute_region_box_load(%arg0: !fir.ref<!fir.box<!fir.heap<!
   %0 = fir.dummy_scope : !fir.dscope
   %dx = fir.declare %arg0 dummy_scope %0 arg 1 {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFtestEx"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>, !fir.dscope) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
   %dy = fir.declare %arg1 dummy_scope %0 arg 2 {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFtestEy"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>, !fir.dscope) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
-  %cx = acc.copyin varPtr(%dx : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "x"}
-  %cy = acc.copyin varPtr(%dy : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "y"}
+  %cx = acc.copyin varPtr(%dx : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) dataClause(acc_copy) implicit(true) name("x") -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+  %cy = acc.copyin varPtr(%dy : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) dataClause(acc_copy) implicit(true) name("y") -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
   acc.kernel_environment dataOperands(%cx, %cy : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) {
     acc.compute_region ins(%arg2 = %cx, %arg3 = %cy) : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) {
       %lx = fir.load %arg2 {test.ptr = "load_x"} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>

--- a/flang/test/Driver/bbc-implicit-use-module.f90
+++ b/flang/test/Driver/bbc-implicit-use-module.f90
@@ -57,4 +57,4 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPuse_implicit()
 ! CHECK-DAG: fir.address_of(@_QMimplicit_modEmodule_value) : !fir.ref<i32>
 ! CHECK-DAG: %[[COMMON:.*]] = fir.address_of(@implicit_common_) : !fir.ref<!fir.array<4xi8>>
-! CHECK-DAG: acc.copyin varPtr(%[[COMMON]] : !fir.ref<!fir.array<4xi8>>) -> !fir.ref<!fir.array<4xi8>>  {dataClause = #acc<data_clause acc_copy>, name = "implicit_common"}
+! CHECK-DAG: acc.copyin varPtr(%[[COMMON]] : !fir.ref<!fir.array<4xi8>>) dataClause(acc_copy) name("implicit_common") -> !fir.ref<!fir.array<4xi8>>

--- a/flang/test/Fir/CUDA/cuda-code-gen.mlir
+++ b/flang/test/Fir/CUDA/cuda-code-gen.mlir
@@ -484,8 +484,8 @@ module attributes {gpu.container_module} {
     %0 = fir.address_of(@_QMm1Eda) : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>
     %1 = fir.load %0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>
     %2 = fircg.ext_rebox %1 : (!fir.box<!fir.heap<!fir.array<?x?xf32>>>) -> !fir.box<!fir.array<?x?xf32>>
-    %3 = acc.present var(%2 : !fir.box<!fir.array<?x?xf32>>) -> !fir.box<!fir.array<?x?xf32>> {name = "uf"}
-    acc.delete accVar(%3 : !fir.box<!fir.array<?x?xf32>>) {dataClause = #acc<data_clause acc_present>, name = "uf"}
+    %3 = acc.present var(%2 : !fir.box<!fir.array<?x?xf32>>) name("uf") -> !fir.box<!fir.array<?x?xf32>>
+    acc.delete accVar(%3 : !fir.box<!fir.array<?x?xf32>>) dataClause(acc_present) name("uf")
     return
   }
   gpu.module @cuda_device_mod {

--- a/flang/test/Fir/CUDA/predefined-variables.mlir
+++ b/flang/test/Fir/CUDA/predefined-variables.mlir
@@ -346,8 +346,8 @@ func.func @_QMoutermodPouter(%arg0: !fir.ref<!fir.array<?x?xf64>> {fir.bindc_nam
   %15 = fir.embox %14(%13) : (!fir.ref<!fir.array<?x?xf64>>, !fir.shape<2>) -> !fir.box<!fir.array<?x?xf64>>
   %16 = fir.declare %arg1(%13) dummy_scope %0 arg 2 {fortran_attrs = #fir.var_attrs<intent_out>, uniq_name = "_QMoutermodFouterEb"} : (!fir.ref<!fir.array<?x?xf64>>, !fir.shape<2>, !fir.dscope) -> !fir.ref<!fir.array<?x?xf64>>
   %17 = fir.embox %16(%13) : (!fir.ref<!fir.array<?x?xf64>>, !fir.shape<2>) -> !fir.box<!fir.array<?x?xf64>>
-  %18 = acc.present var(%15 : !fir.box<!fir.array<?x?xf64>>) -> !fir.box<!fir.array<?x?xf64>> {name = "a"}
-  %19 = acc.present var(%17 : !fir.box<!fir.array<?x?xf64>>) -> !fir.box<!fir.array<?x?xf64>> {name = "b"}
+  %18 = acc.present var(%15 : !fir.box<!fir.array<?x?xf64>>) name("a") -> !fir.box<!fir.array<?x?xf64>>
+  %19 = acc.present var(%17 : !fir.box<!fir.array<?x?xf64>>) name("b") -> !fir.box<!fir.array<?x?xf64>>
   acc.parallel combined(loop) dataOperands(%18, %19 : !fir.box<!fir.array<?x?xf64>>, !fir.box<!fir.array<?x?xf64>>) {
     %20 = fir.box_addr %18 : (!fir.box<!fir.array<?x?xf64>>) -> !fir.ref<!fir.array<?x?xf64>>
     %21 = fir.dummy_scope : !fir.dscope
@@ -355,7 +355,7 @@ func.func @_QMoutermodPouter(%arg0: !fir.ref<!fir.array<?x?xf64>> {fir.bindc_nam
     %23 = fir.box_addr %19 : (!fir.box<!fir.array<?x?xf64>>) -> !fir.ref<!fir.array<?x?xf64>>
     %24 = fir.declare %23(%13) dummy_scope %21 arg 2 {fortran_attrs = #fir.var_attrs<intent_out>, uniq_name = "_QMoutermodFouterEb"} : (!fir.ref<!fir.array<?x?xf64>>, !fir.shape<2>, !fir.dscope) -> !fir.ref<!fir.array<?x?xf64>>
     %25 = fir.load %4 : !fir.ref<i32>
-    %26 = acc.private varPtr(%6 : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "j"}
+    %26 = acc.private varPtr(%6 : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("j") -> !fir.ref<i32>
     %27 = fir.load %2 : !fir.ref<i32>
     %28 = fir.address_of(@_QM__fortran_builtinsE__builtin_blockdim) : !fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_dim3{x:i32,y:i32,z:i32}>>
     %29 = fir.address_of(@_QM__fortran_builtinsE__builtin_blockidx) : !fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_dim3{x:i32,y:i32,z:i32}>>
@@ -405,11 +405,11 @@ func.func @_QMoutermodPouter(%arg0: !fir.ref<!fir.array<?x?xf64>> {fir.bindc_nam
       }
       fir.store %57 to %45 : !fir.ref<i32>
       acc.yield
-    } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+    } inclusiveUpperbound(array<i1: true>) independent
     acc.yield
   }
-  acc.delete accVar(%18 : !fir.box<!fir.array<?x?xf64>>) {dataClause = #acc<data_clause acc_present>, name = "a"}
-  acc.delete accVar(%19 : !fir.box<!fir.array<?x?xf64>>) {dataClause = #acc<data_clause acc_present>, name = "b"}
+  acc.delete accVar(%18 : !fir.box<!fir.array<?x?xf64>>) dataClause(acc_present) name("a")
+  acc.delete accVar(%19 : !fir.box<!fir.array<?x?xf64>>) dataClause(acc_present) name("b")
   return
 }
 

--- a/flang/test/Fir/OpenACC/acc-declare-ctor-dtor-conversion.fir
+++ b/flang/test/Fir/OpenACC/acc-declare-ctor-dtor-conversion.fir
@@ -43,28 +43,28 @@ module attributes {gpu.container_module} {
   }
   acc.global_ctor @_QMmmEarr_acc_ctor {
     %0 = fir.address_of(@_QMmmEarr) {acc.declare = #acc.declare<dataClause =  acc_create>} : !fir.ref<!fir.array<7xf32>>
-    %1 = acc.create varPtr(%0 : !fir.ref<!fir.array<7xf32>>) -> !fir.ref<!fir.array<7xf32>> {name = "arr", structured = false}
+    %1 = acc.create varPtr(%0 : !fir.ref<!fir.array<7xf32>>) structured(false) name("arr") -> !fir.ref<!fir.array<7xf32>>
     %2 = acc.declare_enter dataOperands(%1 : !fir.ref<!fir.array<7xf32>>)
     acc.terminator
   }
   acc.global_ctor @_QMmmEotherEarr_acc_ctor {
     %0 = fir.address_of(@_QMmmEotherEarr) {acc.declare = #acc.declare<dataClause =  acc_create>} : !fir.ref<!fir.array<3xf32>>
-    %1 = acc.create varPtr(%0 : !fir.ref<!fir.array<3xf32>>) -> !fir.ref<!fir.array<3xf32>> {name = "other_arr", structured = false}
+    %1 = acc.create varPtr(%0 : !fir.ref<!fir.array<3xf32>>) structured(false) name("other_arr") -> !fir.ref<!fir.array<3xf32>>
     %2 = acc.declare_enter dataOperands(%1 : !fir.ref<!fir.array<3xf32>>)
     acc.terminator
   }
   acc.global_dtor @_QMmmEarr_acc_dtor {
     %0 = fir.address_of(@_QMmmEarr) {acc.declare = #acc.declare<dataClause =  acc_create>} : !fir.ref<!fir.array<7xf32>>
-    %1 = acc.getdeviceptr varPtr(%0 : !fir.ref<!fir.array<7xf32>>) -> !fir.ref<!fir.array<7xf32>> {dataClause = #acc<data_clause acc_create>, name = "arr", structured = false}
+    %1 = acc.getdeviceptr varPtr(%0 : !fir.ref<!fir.array<7xf32>>) dataClause(acc_create) structured(false) name("arr") -> !fir.ref<!fir.array<7xf32>>
     acc.declare_exit dataOperands(%1 : !fir.ref<!fir.array<7xf32>>)
-    acc.delete accPtr(%1 : !fir.ref<!fir.array<7xf32>>) {dataClause = #acc<data_clause acc_create>, name = "arr", structured = false}
+    acc.delete accPtr(%1 : !fir.ref<!fir.array<7xf32>>) dataClause(acc_create) structured(false) name("arr")
     acc.terminator
   }
   acc.global_dtor @_QMmmEotherEarr_acc_dtor {
     %0 = fir.address_of(@_QMmmEotherEarr) {acc.declare = #acc.declare<dataClause =  acc_create>} : !fir.ref<!fir.array<3xf32>>
-    %1 = acc.getdeviceptr varPtr(%0 : !fir.ref<!fir.array<3xf32>>) -> !fir.ref<!fir.array<3xf32>> {dataClause = #acc<data_clause acc_create>, name = "other_arr", structured = false}
+    %1 = acc.getdeviceptr varPtr(%0 : !fir.ref<!fir.array<3xf32>>) dataClause(acc_create) structured(false) name("other_arr") -> !fir.ref<!fir.array<3xf32>>
     acc.declare_exit dataOperands(%1 : !fir.ref<!fir.array<3xf32>>)
-    acc.delete accPtr(%1 : !fir.ref<!fir.array<3xf32>>) {dataClause = #acc<data_clause acc_create>, name = "other_arr", structured = false}
+    acc.delete accPtr(%1 : !fir.ref<!fir.array<3xf32>>) dataClause(acc_create) structured(false) name("other_arr")
     acc.terminator
   }
   func.func private @_FortranAProgramEndStatement()

--- a/flang/test/Fir/OpenACC/device-ptr-to-cuf-kernel.mlir
+++ b/flang/test/Fir/OpenACC/device-ptr-to-cuf-kernel.mlir
@@ -9,7 +9,7 @@ func.func @static_array() {
   %0 = fir.alloca !fir.array<100xi32> {bindc_name = "a", uniq_name = "_QFEa"}
   %sh = fir.shape %c100 : (index) -> !fir.shape<1>
   %1 = fir.declare %0(%sh) {uniq_name = "_QFEa"} : (!fir.ref<!fir.array<100xi32>>, !fir.shape<1>) -> !fir.ref<!fir.array<100xi32>>
-  %2 = acc.copyin varPtr(%1 : !fir.ref<!fir.array<100xi32>>) -> !fir.ref<!fir.array<100xi32>> {name = "a"}
+  %2 = acc.copyin varPtr(%1 : !fir.ref<!fir.array<100xi32>>) name("a") -> !fir.ref<!fir.array<100xi32>>
   acc.data dataOperands(%2 : !fir.ref<!fir.array<100xi32>>) {
     cuf.kernel_launch @kernel<<<%c1, %c1, %c1, %c1, %c1, %c1>>>(%1) : (!fir.ref<!fir.array<100xi32>>)
     acc.terminator
@@ -23,7 +23,7 @@ func.func @static_array() {
 // CHECK: %[[DEV:.*]] = acc.use_device varPtr(%[[DECL]] : !fir.ref<!fir.array<100xi32>>)
 // CHECK: acc.host_data dataOperands(%[[DEV]]
 // CHECK: cuf.kernel_launch @kernel<<<{{.*}}>>>(%[[DEV]]) : (!fir.ref<!fir.array<100xi32>>)
-// CHECK: attributes {ifPresent}
+// CHECK: ifPresent
 
 // -----
 
@@ -39,7 +39,7 @@ func.func @array_section() {
   %0 = fir.alloca !fir.array<100xi32> {uniq_name = "_QFEa"}
   %sh = fir.shape %c100 : (index) -> !fir.shape<1>
   %1 = fir.declare %0(%sh) {uniq_name = "_QFEa"} : (!fir.ref<!fir.array<100xi32>>, !fir.shape<1>) -> !fir.ref<!fir.array<100xi32>>
-  %2 = acc.copyin varPtr(%1 : !fir.ref<!fir.array<100xi32>>) -> !fir.ref<!fir.array<100xi32>> {name = "a"}
+  %2 = acc.copyin varPtr(%1 : !fir.ref<!fir.array<100xi32>>) name("a") -> !fir.ref<!fir.array<100xi32>>
   acc.data dataOperands(%2 : !fir.ref<!fir.array<100xi32>>) {
     %3 = fir.array_coor %1(%sh) %c3 : (!fir.ref<!fir.array<100xi32>>, !fir.shape<1>, index) -> !fir.ref<i32>
     %4 = fir.convert %3 : (!fir.ref<i32>) -> !fir.ref<!fir.array<?xi32>>
@@ -57,7 +57,7 @@ func.func @array_section() {
 // CHECK: %[[DEV:.*]] = acc.use_device varPtr(%[[CONV]] : !fir.ref<!fir.array<?xi32>>)
 // CHECK: acc.host_data dataOperands(%[[DEV]]
 // CHECK: cuf.kernel_launch @kernel<<<{{.*}}>>>(%[[DEV]], {{.*}}) : (!fir.ref<!fir.array<?xi32>>, i32)
-// CHECK: attributes {ifPresent}
+// CHECK: ifPresent
 
 // -----
 
@@ -70,7 +70,7 @@ func.func @descriptor_array() {
   %c1 = arith.constant 1 : i32
   %0 = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>> {bindc_name = "h", uniq_name = "_QFEh"}
   %1 = fir.declare %0 {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFEh"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-  %2 = acc.create varPtr(%1 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> {name = "h"}
+  %2 = acc.create varPtr(%1 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) name("h") -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
   acc.data dataOperands(%2 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) {
     %3 = fir.load %1 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
     %4 = fir.box_addr %3 : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
@@ -90,7 +90,7 @@ func.func @descriptor_array() {
 // CHECK: %[[DEV:.*]] = acc.use_device varPtr(%[[CONV]] : !fir.ref<!fir.array<?xi32>>)
 // CHECK: acc.host_data dataOperands(%[[DEV]]
 // CHECK: cuf.kernel_launch @kernel<<<{{.*}}>>>(%[[DEV]]) : (!fir.ref<!fir.array<?xi32>>)
-// CHECK: attributes {ifPresent}
+// CHECK: ifPresent
 
 // -----
 
@@ -122,7 +122,7 @@ func.func @unmapped_arg() {
   %1 = fir.declare %0(%sh) {uniq_name = "_QFEa"} : (!fir.ref<!fir.array<100xi32>>, !fir.shape<1>) -> !fir.ref<!fir.array<100xi32>>
   %2 = fir.alloca !fir.array<100xi32> {uniq_name = "_QFEb"}
   %3 = fir.declare %2(%sh) {uniq_name = "_QFEb"} : (!fir.ref<!fir.array<100xi32>>, !fir.shape<1>) -> !fir.ref<!fir.array<100xi32>>
-  %4 = acc.copyin varPtr(%3 : !fir.ref<!fir.array<100xi32>>) -> !fir.ref<!fir.array<100xi32>> {name = "b"}
+  %4 = acc.copyin varPtr(%3 : !fir.ref<!fir.array<100xi32>>) name("b") -> !fir.ref<!fir.array<100xi32>>
   acc.data dataOperands(%4 : !fir.ref<!fir.array<100xi32>>) {
     cuf.kernel_launch @kernel<<<%c1, %c1, %c1, %c1, %c1, %c1>>>(%1) : (!fir.ref<!fir.array<100xi32>>)
     acc.terminator

--- a/flang/test/Fir/OpenACC/legalize-data.fir
+++ b/flang/test/Fir/OpenACC/legalize-data.fir
@@ -2,32 +2,32 @@
 
 func.func @_QPsub1(%arg0: !fir.ref<i32> {fir.bindc_name = "i"}) {
   %0:2 = hlfir.declare %arg0 {uniq_name = "_QFsub1Ei"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-  %1 = acc.copyin varPtr(%0#0 : !fir.ref<i32>) -> !fir.ref<i32> {dataClause = #acc<data_clause acc_copy>, name = "i"}
+  %1 = acc.copyin varPtr(%0#0 : !fir.ref<i32>) dataClause(acc_copy) name("i") -> !fir.ref<i32>
   acc.parallel dataOperands(%1 : !fir.ref<i32>) {
     %c0_i32 = arith.constant 0 : i32
     hlfir.assign %c0_i32 to %0#0 : i32, !fir.ref<i32>
     acc.yield
   }
-  acc.copyout accPtr(%1 : !fir.ref<i32>) to varPtr(%0#0 : !fir.ref<i32>) {dataClause = #acc<data_clause acc_copy>, name = "i"}
+  acc.copyout accPtr(%1 : !fir.ref<i32>) to varPtr(%0#0 : !fir.ref<i32>) dataClause(acc_copy) name("i")
   return
 }
 
 // CHECK-LABEL: func.func @_QPsub1
 // CHECK-SAME: (%[[ARG0:.*]]: !fir.ref<i32> {fir.bindc_name = "i"})
 // CHECK: %[[I:.*]]:2 = hlfir.declare %[[ARG0]] {uniq_name = "_QFsub1Ei"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr(%[[I]]#0 : !fir.ref<i32>) -> !fir.ref<i32> {dataClause = #acc<data_clause acc_copy>, name = "i"}
+// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr(%[[I]]#0 : !fir.ref<i32>) dataClause(acc_copy) name("i") -> !fir.ref<i32>
 // CHECK: acc.parallel dataOperands(%[[COPYIN]] : !fir.ref<i32>) {
 // CHECK:   %c0_i32 = arith.constant 0 : i32
 // CHECK:   hlfir.assign %c0{{.*}} to %[[COPYIN]] : i32, !fir.ref<i32>
 // CHECK:   acc.yield
 // CHECK: }
-// CHECK: acc.copyout accPtr(%[[COPYIN]] : !fir.ref<i32>) to varPtr(%[[I]]#0 : !fir.ref<i32>) {dataClause = #acc<data_clause acc_copy>, name = "i"}
+// CHECK: acc.copyout accPtr(%[[COPYIN]] : !fir.ref<i32>) to varPtr(%[[I]]#0 : !fir.ref<i32>) dataClause(acc_copy) name("i")
 
 // -----
 
 func.func @_QPsub1(%arg0: !fir.ref<i32> {fir.bindc_name = "i"}) {
   %0:2 = hlfir.declare %arg0 {uniq_name = "_QFsub1Ei"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-  %1 = acc.copyin varPtr(%0#0 : !fir.ref<i32>) -> !fir.ref<i32> {dataClause = #acc<data_clause acc_copy>, name = "i"}
+  %1 = acc.copyin varPtr(%0#0 : !fir.ref<i32>) dataClause(acc_copy) name("i") -> !fir.ref<i32>
   acc.data dataOperands(%1 : !fir.ref<i32>) {
     %c0_i32 = arith.constant 0 : i32
     hlfir.assign %c0_i32 to %0#0 : i32, !fir.ref<i32>
@@ -37,14 +37,14 @@ func.func @_QPsub1(%arg0: !fir.ref<i32> {fir.bindc_name = "i"}) {
     }
     acc.terminator
   }
-  acc.copyout accPtr(%1 : !fir.ref<i32>) to varPtr(%0#0 : !fir.ref<i32>) {dataClause = #acc<data_clause acc_copy>, name = "i"}
+  acc.copyout accPtr(%1 : !fir.ref<i32>) to varPtr(%0#0 : !fir.ref<i32>) dataClause(acc_copy) name("i")
   return
 }
 
 // CHECK-LABEL: func.func @_QPsub1
 // CHECK-SAME: (%[[ARG0:.*]]: !fir.ref<i32> {fir.bindc_name = "i"})
 // CHECK: %[[I:.*]]:2 = hlfir.declare %[[ARG0]] {uniq_name = "_QFsub1Ei"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr(%[[I]]#0 : !fir.ref<i32>) -> !fir.ref<i32> {dataClause = #acc<data_clause acc_copy>, name = "i"}
+// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr(%[[I]]#0 : !fir.ref<i32>) dataClause(acc_copy) name("i") -> !fir.ref<i32>
 // CHECK: acc.data dataOperands(%[[COPYIN]] : !fir.ref<i32>) {
 // CHECK:   %[[C0:.*]] = arith.constant 0 : i32
 // CHECK:   hlfir.assign %[[C0]] to %0#0 : i32, !fir.ref<i32>
@@ -54,4 +54,4 @@ func.func @_QPsub1(%arg0: !fir.ref<i32> {fir.bindc_name = "i"}) {
 // CHECK:   }
 // CHECK:   acc.terminator
 // CHECK: }
-// CHECK: acc.copyout accPtr(%[[COPYIN]] : !fir.ref<i32>) to varPtr(%[[I]]#0 : !fir.ref<i32>) {dataClause = #acc<data_clause acc_copy>, name = "i"}
+// CHECK: acc.copyout accPtr(%[[COPYIN]] : !fir.ref<i32>) to varPtr(%[[I]]#0 : !fir.ref<i32>) dataClause(acc_copy) name("i")

--- a/flang/test/Fir/OpenACC/openacc-mappable.fir
+++ b/flang/test/Fir/OpenACC/openacc-mappable.fir
@@ -11,19 +11,19 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<f16 = dense<16> : vector<2xi64>,
     %2 = fir.declare %0(%1) {uniq_name = "_QFsubEarr"} : (!fir.ref<!fir.array<10xf32>>, !fir.shapeshift<1>) -> !fir.ref<!fir.array<10xf32>>
     %3 = fir.embox %2(%1) : (!fir.ref<!fir.array<10xf32>>, !fir.shapeshift<1>) -> !fir.box<!fir.array<10xf32>>
     %4 = fir.box_addr %3 : (!fir.box<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>>
-    %5 = acc.copyin var(%3 : !fir.box<!fir.array<10xf32>>) -> !fir.box<!fir.array<10xf32>> {name = "arr", structured = false}
-    %6 = acc.copyin varPtr(%4 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "arr", structured = false}
+    %5 = acc.copyin var(%3 : !fir.box<!fir.array<10xf32>>) structured(false) name("arr") -> !fir.box<!fir.array<10xf32>>
+    %6 = acc.copyin varPtr(%4 : !fir.ref<!fir.array<10xf32>>) structured(false) name("arr") -> !fir.ref<!fir.array<10xf32>>
     acc.enter_data dataOperands(%5, %6 : !fir.box<!fir.array<10xf32>>, !fir.ref<!fir.array<10xf32>>)
     return
   }
 
-  // CHECK: Visiting: %{{.*}} = acc.copyin var(%{{.*}} : !fir.box<!fir.array<10xf32>>) -> !fir.box<!fir.array<10xf32>> {name = "arr", structured = false}
+  // CHECK: Visiting: %{{.*}} = acc.copyin var(%{{.*}} : !fir.box<!fir.array<10xf32>>) structured(false) name("arr") -> !fir.box<!fir.array<10xf32>>
   // CHECK: Mappable: !fir.box<!fir.array<10xf32>>
   // CHECK: Type category: array
   // CHECK: Size: 40
   // CHECK: Has unknown dimensions: false
 
-  // CHECK: Visiting: %{{.*}} = acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "arr", structured = false}
+  // CHECK: Visiting: %{{.*}} = acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.array<10xf32>>) structured(false) name("arr") -> !fir.ref<!fir.array<10xf32>>
   // CHECK: Pointer-like and Mappable: !fir.ref<!fir.array<10xf32>>
   // CHECK: Type category: array
   // CHECK: Size: 40
@@ -54,14 +54,14 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<f16 = dense<16> : vector<2xi64>,
     %13 = arith.select %12, %11, %c0 : index
     %14 = fir.shape_shift %c2, %13 : (index, index) -> !fir.shapeshift<1>
     %15:2 = hlfir.declare %arg1(%14) dummy_scope %0 {uniq_name = "_QFacc_explicit_shapeEarr2"} : (!fir.ref<!fir.array<?xf32>>, !fir.shapeshift<1>, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.ref<!fir.array<?xf32>>)
-    %16 = acc.copyin var(%10#1 : !fir.ref<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>> {name = "arr1", structured = false}
-    %17 = acc.copyin var(%15#1 : !fir.ref<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>> {name = "arr2", structured = false}
-    %18 = acc.copyin varPtr(%4#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "arr3", structured = false}
+    %16 = acc.copyin var(%10#1 : !fir.ref<!fir.array<?xf32>>) structured(false) name("arr1") -> !fir.ref<!fir.array<?xf32>>
+    %17 = acc.copyin var(%15#1 : !fir.ref<!fir.array<?xf32>>) structured(false) name("arr2") -> !fir.ref<!fir.array<?xf32>>
+    %18 = acc.copyin varPtr(%4#0 : !fir.ref<!fir.array<10xf32>>) structured(false) name("arr3") -> !fir.ref<!fir.array<10xf32>>
     acc.enter_data dataOperands(%16, %17, %18 : !fir.ref<!fir.array<?xf32>>, !fir.ref<!fir.array<?xf32>>, !fir.ref<!fir.array<10xf32>>)
     return
   }
 
-  // CHECK: Visiting: %{{.*}} = acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>> {name = "arr1", structured = false}
+  // CHECK: Visiting: %{{.*}} = acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.array<?xf32>>) structured(false) name("arr1") -> !fir.ref<!fir.array<?xf32>>
   // CHECK: Pointer-like and Mappable: !fir.ref<!fir.array<?xf32>>
   // CHECK: Type category: array
   // CHECK: Has unknown dimensions: true
@@ -70,7 +70,7 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<f16 = dense<16> : vector<2xi64>,
   // CHECK: Lower bound: %[[LB1]] = arith.constant 0 : index
   // CHECK: Upper bound: %[[UB1]] = arith.subi %[[EXTENT1]], %c1{{.*}} : index
 
-  // CHECK: Visiting: %{{.*}} = acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>> {name = "arr2", structured = false}
+  // CHECK: Visiting: %{{.*}} = acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.array<?xf32>>) structured(false) name("arr2") -> !fir.ref<!fir.array<?xf32>>
   // CHECK: Pointer-like and Mappable: !fir.ref<!fir.array<?xf32>>
   // CHECK: Type category: array
   // CHECK: Has unknown dimensions: true
@@ -79,7 +79,7 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<f16 = dense<16> : vector<2xi64>,
   // CHECK: Lower bound: %[[LB2]] = arith.constant 0 : index
   // CHECK: Upper bound: %[[UB2]] = arith.subi %[[EXTENT2]], %c1{{.*}} : index
 
-  // CHECK: Visiting: %{{.*}} = acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "arr3", structured = false}
+  // CHECK: Visiting: %{{.*}} = acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.array<10xf32>>) structured(false) name("arr3") -> !fir.ref<!fir.array<10xf32>>
   // CHECK: Pointer-like and Mappable: !fir.ref<!fir.array<10xf32>>
   // CHECK: Type category: array
   // CHECK: Size: 40
@@ -94,39 +94,39 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<f16 = dense<16> : vector<2xi64>,
   func.func @_QPtest_opaque_box_hlfir(%arg0: !fir.box<!fir.array<?x?xf32>> {fir.bindc_name = "x"}) {
     %0 = fir.dummy_scope : !fir.dscope
     %1:2 = hlfir.declare %arg0 dummy_scope %0 arg 1 {uniq_name = "_QFtest_opaque_boxEx"} : (!fir.box<!fir.array<?x?xf32>>, !fir.dscope) -> (!fir.box<!fir.array<?x?xf32>>, !fir.box<!fir.array<?x?xf32>>)
-    %2 = acc.copyin var(%1#0 : !fir.box<!fir.array<?x?xf32>>) -> !fir.box<!fir.array<?x?xf32>> {name = "x", structured = false}
+    %2 = acc.copyin var(%1#0 : !fir.box<!fir.array<?x?xf32>>) structured(false) name("x") -> !fir.box<!fir.array<?x?xf32>>
     acc.enter_data dataOperands(%2 : !fir.box<!fir.array<?x?xf32>>)
     return
   }
-  // CHECK: Visiting: %{{.*}} = acc.copyin var(%[[VAR:.*]]#0 : !fir.box<!fir.array<?x?xf32>>) -> !fir.box<!fir.array<?x?xf32>> {name = "x", structured = false}
+  // CHECK: Visiting: %{{.*}} = acc.copyin var(%[[VAR:.*]]#0 : !fir.box<!fir.array<?x?xf32>>) structured(false) name("x") -> !fir.box<!fir.array<?x?xf32>>
   // CHECK: Var: %[[VAR]]:2 = hlfir.declare %{{.*}} dummy_scope %{{.*}} arg 1 {uniq_name = "_QFtest_opaque_boxEx"} : (!fir.box<!fir.array<?x?xf32>>, !fir.dscope) -> (!fir.box<!fir.array<?x?xf32>>, !fir.box<!fir.array<?x?xf32>>)
   // CHECK: Mappable: !fir.box<!fir.array<?x?xf32>>
   // CHECK: Type category: array
   // CHECK: Has unknown dimensions: false
   // CHECK: Shape: <<NULL VALUE>>
   // CHECK: Bound[0]: %{{.*}} = acc.bounds lowerbound(%[[LB0:.*]] : index) upperbound(%[[UB0:.*]] : index) extent(%[[DIM0:.*]]#1 : index)
-  // CHECK-SAME: stride(%[[DIM0]]#2 : index) startIdx(%c1{{.*}} : index) {strideInBytes = true}
+  // CHECK-SAME: stride(%[[DIM0]]#2 : index) startIdx(%c1{{.*}} : index) strideInBytes(true)
   // CHECK: Lower bound: %[[LB0]] = arith.constant 0 : index
   // CHECK: Upper bound: %[[UB0]] = arith.subi %[[DIM0]]#1, %c1{{.*}} : index
   // CHECK: Bound[1]: %{{.*}} = acc.bounds lowerbound(%[[LB1:.*]] : index) upperbound(%[[UB1:.*]] : index) extent(%[[DIM1:.*]]#1 : index)
-  // CHECK-SAME: stride(%{{.*}} : index) startIdx(%c1{{.*}} : index) {strideInBytes = true}
+  // CHECK-SAME: stride(%{{.*}} : index) startIdx(%c1{{.*}} : index) strideInBytes(true)
   // CHECK: Lower bound: %[[LB1]] = arith.constant 0 : index
   // CHECK: Upper bound: %[[UB1]] = arith.subi %[[DIM1]]#1, %c1{{.*}} : index
 
   func.func @_QPtest_optional(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x", fir.optional}) {
     %0 = fir.dummy_scope : !fir.dscope
     %1:2 = hlfir.declare %arg0 dummy_scope %0 arg 1 {fortran_attrs = #fir.var_attrs<optional>, uniq_name = "_QFtest_optionalEx"} : (!fir.box<!fir.array<?xf32>>, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.box<!fir.array<?xf32>>)
-    %2 = acc.copyin var(%1#0 : !fir.box<!fir.array<?xf32>>) -> !fir.box<!fir.array<?xf32>> {name = "x", structured = false}
+    %2 = acc.copyin var(%1#0 : !fir.box<!fir.array<?xf32>>) structured(false) name("x") -> !fir.box<!fir.array<?xf32>>
     acc.enter_data dataOperands(%2 : !fir.box<!fir.array<?xf32>>)
     return
   }
-  // CHECK: Visiting: %{{.*}} = acc.copyin var(%[[VAR:.*]]#0 : !fir.box<!fir.array<?xf32>>) -> !fir.box<!fir.array<?xf32>> {name = "x", structured = false}
+  // CHECK: Visiting: %{{.*}} = acc.copyin var(%[[VAR:.*]]#0 : !fir.box<!fir.array<?xf32>>) structured(false) name("x") -> !fir.box<!fir.array<?xf32>>
   // CHECK: Var: %[[VAR]]:2 = hlfir.declare %{{.*}} dummy_scope %{{.*}} arg 1 {fortran_attrs = #fir.var_attrs<optional>, uniq_name = "_QFtest_optionalEx"} : (!fir.box<!fir.array<?xf32>>, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.box<!fir.array<?xf32>>)
   // CHECK: Mappable: !fir.box<!fir.array<?xf32>>
   // CHECK: Type category: array
   // CHECK: Has unknown dimensions: false
   // CHECK: Shape: <<NULL VALUE>>
-  // CHECK: Bound[0]: %{{.*}} = acc.bounds lowerbound(%[[IF:.*]]#0 : index) upperbound(%[[IF]]#1 : index) extent(%[[IF]]#2 : index) stride(%[[IF]]#3 : index) startIdx(%[[IF]]#4 : index) {strideInBytes = true}
+  // CHECK: Bound[0]: %{{.*}} = acc.bounds lowerbound(%[[IF:.*]]#0 : index) upperbound(%[[IF]]#1 : index) extent(%[[IF]]#2 : index) stride(%[[IF]]#3 : index) startIdx(%[[IF]]#4 : index) strideInBytes(true)
   // CHECK: Lower bound: %[[IF]]:5 = fir.if %[[PRESENT:.*]] -> (index, index, index, index, index) {
   // CHECK: %[[ONE:.*]] = arith.constant 1 : index
   // CHECK: %[[ZERO1:.*]] = arith.constant 0 : index
@@ -147,11 +147,11 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<f16 = dense<16> : vector<2xi64>,
   // (so no shape is recoverable). It must produce no bounds.
   func.func @_QPassumed_size_no_descriptor(%arg0: !fir.ref<!fir.array<?x?xf32>> {fir.bindc_name = "a"}) {
     %0 = fir.convert %arg0 : (!fir.ref<!fir.array<?x?xf32>>) -> !fir.ref<!fir.array<?x?xf32>>
-    %1 = acc.copyin varPtr(%0 : !fir.ref<!fir.array<?x?xf32>>) -> !fir.ref<!fir.array<?x?xf32>> {name = "a", structured = false}
+    %1 = acc.copyin varPtr(%0 : !fir.ref<!fir.array<?x?xf32>>) structured(false) name("a") -> !fir.ref<!fir.array<?x?xf32>>
     acc.enter_data dataOperands(%1 : !fir.ref<!fir.array<?x?xf32>>)
     return
   }
-  // CHECK: Visiting: %{{.*}} = acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.array<?x?xf32>>) -> !fir.ref<!fir.array<?x?xf32>> {name = "a", structured = false}
+  // CHECK: Visiting: %{{.*}} = acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.array<?x?xf32>>) structured(false) name("a") -> !fir.ref<!fir.array<?x?xf32>>
   // CHECK: Pointer-like and Mappable: !fir.ref<!fir.array<?x?xf32>>
   // CHECK: Type category: array
   // CHECK: Has unknown dimensions: true

--- a/flang/test/Fir/OpenACC/openacc-type-categories-class.f90
+++ b/flang/test/Fir/OpenACC/openacc-type-categories-class.f90
@@ -25,19 +25,19 @@ contains
   end subroutine
 end module
 
-! CHECK: Visiting: {{.*}} acc.copyin {{.*}} {name = "this", structured = false}
+! CHECK: Visiting: {{.*}} acc.copyin {{.*}} structured(false) name("this")
 ! CHECK: Mappable: !fir.class<!fir.type<_QMmmTpolyty{field:f32}>>
 ! CHECK: Type category: composite
-! CHECK: Visiting: {{.*}} acc.copyin {{.*}} {name = "this%field", structured = false}
+! CHECK: Visiting: {{.*}} acc.copyin {{.*}} structured(false) name("this%field")
 ! CHECK: Pointer-like and Mappable: !fir.ref<f32>
 ! CHECK: Type category: composite
 
 ! For unlimited polymorphic entities and assumed types - they effectively have
 ! no declared type. Thus the type categorizer cannot categorize it.
-! CHECK: Visiting: {{.*}} = acc.copyin {{.*}} {name = "var", structured = false}
+! CHECK: Visiting: {{.*}} = acc.copyin {{.*}} structured(false) name("var")
 ! CHECK: Pointer-like and Mappable: !fir.ref<none>
 ! CHECK: Type category: uncategorized
-! CHECK: Visiting: {{.*}} = acc.copyin {{.*}} {name = "this", structured = false}
+! CHECK: Visiting: {{.*}} = acc.copyin {{.*}} structured(false) name("this")
 ! CHECK: Mappable: !fir.class<none>
 ! CHECK: Type category: uncategorized
 

--- a/flang/test/Fir/OpenACC/openacc-type-categories-declare-storage.mlir
+++ b/flang/test/Fir/OpenACC/openacc-type-categories-declare-storage.mlir
@@ -11,12 +11,12 @@ module {
     %view = fir.declare %elem_f32 storage(%arr[0]) {uniq_name = "_QFpi"}
       : (!fir.ref<f32>, !fir.ref<!fir.array<4xi8>>) -> !fir.ref<f32>
     // Force interface query through an acc op that prints type category
-    %cp = acc.copyin varPtr(%view : !fir.ref<f32>) -> !fir.ref<f32> {name = "pi", structured = false}
+    %cp = acc.copyin varPtr(%view : !fir.ref<f32>) structured(false) name("pi") -> !fir.ref<f32>
     acc.enter_data dataOperands(%cp : !fir.ref<f32>)
     return
   }
 
-  // CHECK: Visiting: %{{.*}} = acc.copyin varPtr(%{{.*}} : !fir.ref<f32>) -> !fir.ref<f32> {name = "pi", structured = false}
+  // CHECK: Visiting: %{{.*}} = acc.copyin varPtr(%{{.*}} : !fir.ref<f32>) structured(false) name("pi") -> !fir.ref<f32>
   // CHECK: Pointer-like and Mappable: !fir.ref<f32>
   // CHECK: Type category: array
 }

--- a/flang/test/Fir/OpenACC/openacc-type-categories.f90
+++ b/flang/test/Fir/OpenACC/openacc-type-categories.f90
@@ -17,33 +17,33 @@ program main
   !$acc enter data copyin(complexvar, charvar, ttvar%field, ttvar%fieldarray, arrayconstsize(1))
 end program
 
-! CHECK: Visiting: {{.*}} acc.copyin {{.*}} {name = "scalar", structured = false}
+! CHECK: Visiting: {{.*}} acc.copyin {{.*}} structured(false) name("scalar")
 ! CHECK: Pointer-like and Mappable: !fir.ref<f32>
 ! CHECK: Type category: scalar
-! CHECK: Visiting: {{.*}} acc.copyin {{.*}} {name = "scalaralloc", structured = false}
+! CHECK: Visiting: {{.*}} acc.copyin {{.*}} structured(false) name("scalaralloc")
 ! CHECK: Pointer-like and Mappable: !fir.ref<!fir.box<!fir.heap<f32>>>
 ! CHECK: Type category: nonscalar
-! CHECK: Visiting: {{.*}} acc.copyin {{.*}} {name = "ttvar", structured = false}
+! CHECK: Visiting: {{.*}} acc.copyin {{.*}} structured(false) name("ttvar")
 ! CHECK: Pointer-like and Mappable: !fir.ref<!fir.type<_QFTtt{field:f32,fieldarray:!fir.array<10xf32>}>>
 ! CHECK: Type category: composite
-! CHECK: Visiting: {{.*}} acc.copyin {{.*}} {name = "arrayconstsize", structured = false}
+! CHECK: Visiting: {{.*}} acc.copyin {{.*}} structured(false) name("arrayconstsize")
 ! CHECK: Pointer-like and Mappable: !fir.ref<!fir.array<10xf32>>
 ! CHECK: Type category: array
-! CHECK: Visiting: {{.*}} acc.copyin {{.*}} {name = "arrayalloc", structured = false}
+! CHECK: Visiting: {{.*}} acc.copyin {{.*}} structured(false) name("arrayalloc")
 ! CHECK: Pointer-like and Mappable: !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
 ! CHECK: Type category: array
-! CHECK: Visiting: {{.*}} acc.copyin {{.*}} {name = "complexvar", structured = false}
+! CHECK: Visiting: {{.*}} acc.copyin {{.*}} structured(false) name("complexvar")
 ! CHECK: Pointer-like and Mappable: !fir.ref<complex<f32>>
 ! CHECK: Type category: scalar
-! CHECK: Visiting: {{.*}} acc.copyin {{.*}} {name = "charvar", structured = false}
+! CHECK: Visiting: {{.*}} acc.copyin {{.*}} structured(false) name("charvar")
 ! CHECK: Pointer-like and Mappable: !fir.ref<!fir.char<1>>
 ! CHECK: Type category: nonscalar
-! CHECK: Visiting: {{.*}} acc.copyin {{.*}} {name = "ttvar%field", structured = false}
+! CHECK: Visiting: {{.*}} acc.copyin {{.*}} structured(false) name("ttvar%field")
 ! CHECK: Pointer-like and Mappable: !fir.ref<f32>
 ! CHECK: Type category: composite
-! CHECK: Visiting: {{.*}} acc.copyin {{.*}} {name = "ttvar%fieldarray", structured = false}
+! CHECK: Visiting: {{.*}} acc.copyin {{.*}} structured(false) name("ttvar%fieldarray")
 ! CHECK: Pointer-like and Mappable: !fir.ref<!fir.array<10xf32>>
 ! CHECK: Type category: array
-! CHECK: Visiting: {{.*}} acc.copyin {{.*}} {name = "arrayconstsize(1)", structured = false}
+! CHECK: Visiting: {{.*}} acc.copyin {{.*}} structured(false) name("arrayconstsize(1)")
 ! CHECK: Pointer-like and Mappable: !fir.ref<!fir.array<10xf32>>
 ! CHECK: Type category: array

--- a/flang/test/Fir/OpenACC/openacc-type-categories.mlir
+++ b/flang/test/Fir/OpenACC/openacc-type-categories.mlir
@@ -11,12 +11,12 @@ module {
   func.func @_QPtest_global_string_ptr() {
     %0 = fir.address_of(@test_string) : !fir.ref<!fir.char<1,26>>
     %1 = fir.convert %0 : (!fir.ref<!fir.char<1,26>>) -> !fir.ref<i8>
-    %2 = acc.copyin varPtr(%1 : !fir.ref<i8>) -> !fir.ref<i8> {name = "test_string", structured = false}
+    %2 = acc.copyin varPtr(%1 : !fir.ref<i8>) structured(false) name("test_string") -> !fir.ref<i8>
     acc.enter_data dataOperands(%2 : !fir.ref<i8>)
     return
   }
 
-  // CHECK: Visiting: %{{.*}} = acc.copyin varPtr(%{{.*}} : !fir.ref<i8>) -> !fir.ref<i8> {name = "test_string", structured = false}
+  // CHECK: Visiting: %{{.*}} = acc.copyin varPtr(%{{.*}} : !fir.ref<i8>) structured(false) name("test_string") -> !fir.ref<i8>
   // CHECK: Pointer-like and Mappable: !fir.ref<i8>
   // CHECK: Type category: nonscalar
 
@@ -25,12 +25,12 @@ module {
     %c10 = arith.constant 10 : index
     %0 = fir.alloca !fir.array<10xf32> {bindc_name = "local_array", uniq_name = "_QFtest_alloca_array_ptrElocal_array"}
     %1 = fir.convert %0 : (!fir.ref<!fir.array<10xf32>>) -> !fir.ref<i8>
-    %2 = acc.copyin varPtr(%1 : !fir.ref<i8>) -> !fir.ref<i8> {name = "local_array", structured = false}
+    %2 = acc.copyin varPtr(%1 : !fir.ref<i8>) structured(false) name("local_array") -> !fir.ref<i8>
     acc.enter_data dataOperands(%2 : !fir.ref<i8>)
     return
   }
 
-  // CHECK: Visiting: %{{.*}} = acc.copyin varPtr(%{{.*}} : !fir.ref<i8>) -> !fir.ref<i8> {name = "local_array", structured = false}
+  // CHECK: Visiting: %{{.*}} = acc.copyin varPtr(%{{.*}} : !fir.ref<i8>) structured(false) name("local_array") -> !fir.ref<i8>
   // CHECK: Pointer-like and Mappable: !fir.ref<i8>
   // CHECK: Type category: array
 }

--- a/flang/test/Fir/OpenACC/propagate-attr-folding.fir
+++ b/flang/test/Fir/OpenACC/propagate-attr-folding.fir
@@ -21,13 +21,13 @@ func.func @_QPsub1(%arg0: !fir.ref<!fir.array<?x?xf32>> {fir.bindc_name = "a"}, 
   %12 = fir.embox %11(%10) : (!fir.ref<!fir.array<?x?xf32>>, !fir.shape<2>) -> !fir.box<!fir.array<?x?xf32>>
   %13:3 = fir.box_dims %12, %c0 : (!fir.box<!fir.array<?x?xf32>>, index) -> (index, index, index)
   %14 = arith.subi %13#1, %c1 : index
-  %15 = acc.bounds lowerbound(%c0 : index) upperbound(%14 : index) extent(%13#1 : index) stride(%13#2 : index) startIdx(%c1 : index) {strideInBytes = true}
+  %15 = acc.bounds lowerbound(%c0 : index) upperbound(%14 : index) extent(%13#1 : index) stride(%13#2 : index) startIdx(%c1 : index) strideInBytes(true)
   %16 = arith.muli %13#2, %13#1 : index
   %17:3 = fir.box_dims %12, %c1 : (!fir.box<!fir.array<?x?xf32>>, index) -> (index, index, index)
   %18 = arith.subi %17#1, %c1 : index
-  %19 = acc.bounds lowerbound(%c0 : index) upperbound(%18 : index) extent(%17#1 : index) stride(%16 : index) startIdx(%c1 : index) {strideInBytes = true}
+  %19 = acc.bounds lowerbound(%c0 : index) upperbound(%18 : index) extent(%17#1 : index) stride(%16 : index) startIdx(%c1 : index) strideInBytes(true)
   %20 = fir.box_addr %12 {acc.declare = #acc.declare<dataClause =  acc_present>} : (!fir.box<!fir.array<?x?xf32>>) -> !fir.ref<!fir.array<?x?xf32>>
-  %21 = acc.present varPtr(%20 : !fir.ref<!fir.array<?x?xf32>>) bounds(%15, %19) -> !fir.ref<!fir.array<?x?xf32>> {name = "a"}
+  %21 = acc.present varPtr(%20 : !fir.ref<!fir.array<?x?xf32>>) bounds(%15, %19) name("a") -> !fir.ref<!fir.array<?x?xf32>>
   %22 = acc.declare_enter dataOperands(%21 : !fir.ref<!fir.array<?x?xf32>>)
   acc.declare_exit token(%22)
   return
@@ -36,5 +36,5 @@ func.func @_QPsub1(%arg0: !fir.ref<!fir.array<?x?xf32>> {fir.bindc_name = "a"}, 
 // CHECK-LABEL: func.func @_QPsub1(
 // CHECK-SAME: %[[ARG0:.*]]: !fir.ref<!fir.array<?x?xf32>> {fir.bindc_name = "a"}
 // CHECK: %[[DECL:.*]] = fir.declare %[[ARG0]](%{{.*}}) {acc.declare = #acc.declare<dataClause =  acc_present>, uniq_name = "_QFsub1Ea"} : (!fir.ref<!fir.array<?x?xf32>>, !fir.shape<2>) -> !fir.ref<!fir.array<?x?xf32>>
-// CHECK: %[[PRES:.*]] = acc.present varPtr(%[[DECL]] : !fir.ref<!fir.array<?x?xf32>>) bounds(%{{.*}}, %{{.*}}) -> !fir.ref<!fir.array<?x?xf32>> {name = "a"}
+// CHECK: %[[PRES:.*]] = acc.present varPtr(%[[DECL]] : !fir.ref<!fir.array<?x?xf32>>) bounds(%{{.*}}, %{{.*}}) name("a") -> !fir.ref<!fir.array<?x?xf32>>
 // CHECK: %{{.*}} = acc.declare_enter dataOperands(%[[PRES]] : !fir.ref<!fir.array<?x?xf32>>)

--- a/flang/test/Fir/OpenACC/recipe-bufferization.mlir
+++ b/flang/test/Fir/OpenACC/recipe-bufferization.mlir
@@ -240,8 +240,8 @@ func.func @_QPfoo(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x"}) {
   %2 = fir.declare %1 {uniq_name = "_QFfooEi"} : (!fir.ref<i32>) -> !fir.ref<i32>
   %3 = fir.declare %arg0 dummy_scope %0 {uniq_name = "_QFfooEx"} : (!fir.box<!fir.array<?xf32>>, !fir.dscope) -> !fir.box<!fir.array<?xf32>>
   acc.parallel combined(loop) {
-    %4 = acc.private var(%3 : !fir.box<!fir.array<?xf32>>) recipe(@privatization_box_Uxf32) -> !fir.box<!fir.array<?xf32>> {name = "x"}
-    %5 = acc.private varPtr(%2 : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+    %4 = acc.private var(%3 : !fir.box<!fir.array<?xf32>>) recipe(@privatization_box_Uxf32) name("x") -> !fir.box<!fir.array<?xf32>>
+    %5 = acc.private varPtr(%2 : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
     acc.loop combined(parallel) private(%4, %5 : !fir.box<!fir.array<?xf32>>, !fir.ref<i32>) control(%arg1 : i32) = (%c1_i32 : i32) to (%c200_i32 : i32)  step (%c1_i32 : i32) {
       %6 = fir.dummy_scope : !fir.dscope
       %7 = fir.declare %4 dummy_scope %6 {uniq_name = "_QFfooEx"} : (!fir.box<!fir.array<?xf32>>, !fir.dscope) -> !fir.box<!fir.array<?xf32>>
@@ -251,7 +251,7 @@ func.func @_QPfoo(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x"}) {
       %11 = fir.array_coor %7 %10 : (!fir.box<!fir.array<?xf32>>, i64) -> !fir.ref<f32>
       fir.store %9 to %11 : !fir.ref<f32>
       acc.yield
-    } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+    } inclusiveUpperbound(array<i1: true>) independent
     acc.yield
   }
   return
@@ -297,8 +297,8 @@ func.func @_QPfoo(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x"}) {
 // CHECK:           %[[VAL_6:.*]] = fir.alloca !fir.box<!fir.array<?xf32>>
 // CHECK:           fir.store %[[VAL_5]] to %[[VAL_6]] : !fir.ref<!fir.box<!fir.array<?xf32>>>
 // CHECK:           acc.parallel combined(loop) {
-// CHECK:             %[[VAL_7:.*]] = acc.private varPtr(%[[VAL_6]] : !fir.ref<!fir.box<!fir.array<?xf32>>>) recipe(@privatization_box_Uxf32) -> !fir.ref<!fir.box<!fir.array<?xf32>>> {name = "x"}
-// CHECK:             %[[VAL_8:.*]] = acc.private varPtr(%[[VAL_4]] : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+// CHECK:             %[[VAL_7:.*]] = acc.private varPtr(%[[VAL_6]] : !fir.ref<!fir.box<!fir.array<?xf32>>>) recipe(@privatization_box_Uxf32) name("x") -> !fir.ref<!fir.box<!fir.array<?xf32>>>
+// CHECK:             %[[VAL_8:.*]] = acc.private varPtr(%[[VAL_4]] : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 // CHECK:             acc.loop combined(parallel) private(%[[VAL_7]], %[[VAL_8]] : !fir.ref<!fir.box<!fir.array<?xf32>>>, !fir.ref<i32>) control(%[[VAL_9:.*]] : i32) = (%[[VAL_1]] : i32) to (%[[VAL_0]] : i32)  step (%[[VAL_1]] : i32) {
 // CHECK:               %[[VAL_10:.*]] = fir.dummy_scope : !fir.dscope
 // CHECK:               %[[VAL_11:.*]] = fir.load %[[VAL_7]] : !fir.ref<!fir.box<!fir.array<?xf32>>>
@@ -309,7 +309,7 @@ func.func @_QPfoo(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x"}) {
 // CHECK:               %[[VAL_16:.*]] = fir.array_coor %[[VAL_12]] %[[VAL_15]] : (!fir.box<!fir.array<?xf32>>, i64) -> !fir.ref<f32>
 // CHECK:               fir.store %[[VAL_14]] to %[[VAL_16]] : !fir.ref<f32>
 // CHECK:               acc.yield
-// CHECK:             } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+// CHECK:             } inclusiveUpperbound(array<i1: true>) independent
 // CHECK:             acc.yield
 // CHECK:           }
 // CHECK:           return

--- a/flang/test/Fir/OpenACC/use-device-canonicalizer.mlir
+++ b/flang/test/Fir/OpenACC/use-device-canonicalizer.mlir
@@ -6,7 +6,7 @@
 func.func @test_host_data_hoisting_function_call(%arg0: !fir.ref<!fir.box<!fir.heap<!fir.array<?xf64>>>>) {
   // CHECK: %[[LOADED:.*]] = fir.load %arg0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf64>>>>
   // CHECK: %[[ADDR:.*]] = fir.box_addr %[[LOADED]] : (!fir.box<!fir.heap<!fir.array<?xf64>>>) -> !fir.heap<!fir.array<?xf64>>
-  // CHECK: %[[DEV_PTR:.*]] = acc.use_device varPtr(%[[ADDR]] : !fir.heap<!fir.array<?xf64>>) varType(!fir.box<!fir.heap<!fir.array<?xf64>>>) -> !fir.heap<!fir.array<?xf64>>
+  // CHECK: %[[DEV_PTR:.*]] = acc.use_device varPtr(%[[ADDR]] : !fir.heap<!fir.array<?xf64>>) varType(!fir.box<!fir.heap<!fir.array<?xf64>>>) name("a") -> !fir.heap<!fir.array<?xf64>>
   // CHECK: acc.host_data dataOperands(%[[DEV_PTR]]
   // CHECK: %[[EMBOX:.*]] = fir.embox %[[DEV_PTR]]
   // CHECK: %[[ALLOCA:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xf64>>>
@@ -15,7 +15,7 @@ func.func @test_host_data_hoisting_function_call(%arg0: !fir.ref<!fir.box<!fir.h
   // CHECK: %[[DEV_PTRADDR:.*]] = fir.box_addr %[[LOAD2]] : (!fir.box<!fir.heap<!fir.array<?xf64>>>
   // CHECK: %[[CONV:.*]] = fir.convert %[[DEV_PTRADDR]] : (!fir.heap<!fir.array<?xf64>>) -> !fir.ref<!fir.array<?xf64>>
   // CHECK: fir.call @_QMmPvadd(%[[CONV]]
-  %dev_ptr = acc.use_device varPtr(%arg0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf64>>>>) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf64>>>> {name = "a"}
+  %dev_ptr = acc.use_device varPtr(%arg0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf64>>>>) name("a") -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf64>>>>
   acc.host_data dataOperands(%dev_ptr : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf64>>>>) {
     %loaded = fir.load %dev_ptr : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf64>>>>
     %addr = fir.box_addr %loaded : (!fir.box<!fir.heap<!fir.array<?xf64>>>) -> !fir.heap<!fir.array<?xf64>>
@@ -41,7 +41,7 @@ func.func @test_host_data_hoisting_load(%arg0: !fir.ref<!fir.box<!fir.heap<!fir.
   // CHECK: %[[DEV_PTRADDR:.*]] = fir.box_addr %[[LOAD2]] : (!fir.box<!fir.heap<!fir.array<?xf64>>>
   // CHECK: %[[CONV:.*]] = fir.convert %[[DEV_PTRADDR]] : (!fir.heap<!fir.array<?xf64>>) -> !fir.ref<!fir.array<?xf64>>
   // CHECK: %[[VAL:.*]] = fir.load %[[CONV]]
-  %dev_ptr = acc.use_device varPtr(%arg0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf64>>>>) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf64>>>> {name = "a"}
+  %dev_ptr = acc.use_device varPtr(%arg0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf64>>>>) name("a") -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf64>>>>
   acc.host_data dataOperands(%dev_ptr : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf64>>>>) {
     %loaded = fir.load %dev_ptr : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf64>>>>
     %addr = fir.box_addr %loaded : (!fir.box<!fir.heap<!fir.array<?xf64>>>) -> !fir.heap<!fir.array<?xf64>>
@@ -72,7 +72,7 @@ func.func @test_host_data_hoisting_ref_to_box() {
   fir.store %8 to %ptr2_decl : !fir.ref<!fir.box<!fir.ptr<i32>>>
   // CHECK: %[[LOAD:.*]] = fir.load %[[DECLARE]]
   // CHECK: %[[BOXADDR:.*]] = fir.box_addr %[[LOAD]]
-  // CHECK: %[[DEV_PTR:.*]] = acc.use_device varPtr(%[[BOXADDR]] : !fir.ptr<i32>) varType(!fir.box<!fir.ptr<i32>>) -> !fir.ptr<i32> {name = "ptr"}
+  // CHECK: %[[DEV_PTR:.*]] = acc.use_device varPtr(%[[BOXADDR]] : !fir.ptr<i32>) varType(!fir.box<!fir.ptr<i32>>) name("ptr") -> !fir.ptr<i32>
   // CHECK: acc.host_data dataOperands(%[[DEV_PTR]] : !fir.ptr<i32>) {
   // CHECK: %[[EMBOX:.*]] = fir.embox %[[DEV_PTR]] : (!fir.ptr<i32>) -> !fir.box<!fir.ptr<i32>>
   // CHECK: %[[ALLOCA2:.*]] = fir.alloca !fir.box<!fir.ptr<i32>>
@@ -81,9 +81,9 @@ func.func @test_host_data_hoisting_ref_to_box() {
   // CHECK: %[[DEV_PTRADDR:.*]] = fir.box_addr %[[LOAD2]] : (!fir.box<!fir.ptr<i32>>) -> !fir.ptr<i32>
   // CHECK: %[[CONV:.*]] = fir.convert %[[DEV_PTRADDR]] : (!fir.ptr<i32>) -> i64
   // CHECK: fir.call @foo(%[[CONV]]) : (i64) -> ()
-  %9 = acc.use_device varPtr(%4 : !fir.ref<!fir.box<!fir.ptr<i32>>>) -> !fir.ref<!fir.box<!fir.ptr<i32>>> {name = "ptr"}
+  %9 = acc.use_device varPtr(%4 : !fir.ref<!fir.box<!fir.ptr<i32>>>) name("ptr") -> !fir.ref<!fir.box<!fir.ptr<i32>>>
   // This use_device clause is for a different variable (ptr2) and has no uses - should be removed
-  %12 = acc.use_device varPtr(%ptr2_decl : !fir.ref<!fir.box<!fir.ptr<i32>>>) -> !fir.ref<!fir.box<!fir.ptr<i32>>> {name = "ptr2"}
+  %12 = acc.use_device varPtr(%ptr2_decl : !fir.ref<!fir.box<!fir.ptr<i32>>>) name("ptr2") -> !fir.ref<!fir.box<!fir.ptr<i32>>>
   acc.host_data dataOperands(%9, %12 : !fir.ref<!fir.box<!fir.ptr<i32>>>, !fir.ref<!fir.box<!fir.ptr<i32>>>) {
     %14 = fir.load %9 : !fir.ref<!fir.box<!fir.ptr<i32>>>
     %15 = fir.box_addr %14 : (!fir.box<!fir.ptr<i32>>) -> !fir.ptr<i32>
@@ -102,7 +102,7 @@ func.func @multiple_host_data_(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_nam
   %0 = fir.dummy_scope : !fir.dscope
   %1 = fir.declare %arg0 dummy_scope %0 arg 1 {uniq_name = "_QFmultiple_host_dataEarr"} : (!fir.box<!fir.array<?xf32>>, !fir.dscope) -> !fir.box<!fir.array<?xf32>>
   %2 = fir.rebox %1 : (!fir.box<!fir.array<?xf32>>) -> !fir.box<!fir.array<?xf32>>
-  %3 = acc.use_device var(%2 : !fir.box<!fir.array<?xf32>>) -> !fir.box<!fir.array<?xf32>> {name = "arr"}
+  %3 = acc.use_device var(%2 : !fir.box<!fir.array<?xf32>>) name("arr") -> !fir.box<!fir.array<?xf32>>
   acc.host_data dataOperands(%3 : !fir.box<!fir.array<?xf32>>) {
     %4 = fir.dummy_scope : !fir.dscope
     %5 = fir.declare %3 dummy_scope %4 arg 1 {uniq_name = "_QFmultiple_host_dataEarr"} : (!fir.box<!fir.array<?xf32>>, !fir.dscope) -> !fir.box<!fir.array<?xf32>>
@@ -119,11 +119,11 @@ func.func @multiple_host_data_(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_nam
 // CHECK-SAME: %arg0: !fir.box<!fir.array<?xf32>>
 // CHECK: fir.box_addr %2
 // CHECK: fir.box_addr %2
-// CHECK: %[[USE_DEVICE_1:.*]] = acc.use_device varPtr({{.*}} : !fir.ref<!fir.array<?xf32>>) varType(!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>> {name = "arr"}
+// CHECK: %[[USE_DEVICE_1:.*]] = acc.use_device varPtr({{.*}} : !fir.ref<!fir.array<?xf32>>) varType(!fir.box<!fir.array<?xf32>>) name("arr") -> !fir.ref<!fir.array<?xf32>>
 // CHECK: acc.host_data dataOperands(%[[USE_DEVICE_1]] : !fir.ref<!fir.array<?xf32>>) {
 // CHECK: acc.terminator
 // CHECK: }
-// CHECK: %[[USE_DEVICE_2:.*]] = acc.use_device varPtr({{.*}} : !fir.ref<!fir.array<?xf32>>) varType(!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>> {name = "arr"}
+// CHECK: %[[USE_DEVICE_2:.*]] = acc.use_device varPtr({{.*}} : !fir.ref<!fir.array<?xf32>>) varType(!fir.box<!fir.array<?xf32>>) name("arr") -> !fir.ref<!fir.array<?xf32>>
 // CHECK: acc.host_data dataOperands(%[[USE_DEVICE_2]] : !fir.ref<!fir.array<?xf32>>) {
 // CHECK: acc.terminator
 // CHECK: }
@@ -138,7 +138,7 @@ func.func @test_ref_to_box_multiple_host_data() {
   %6 = fir.declare %5 {fortran_attrs = #fir.var_attrs<target>, uniq_name = "_QFEtgt"} : (!fir.ref<i32>) -> !fir.ref<i32>
   %8 = fir.embox %6 : (!fir.ref<i32>) -> !fir.box<!fir.ptr<i32>>
   fir.store %8 to %4 : !fir.ref<!fir.box<!fir.ptr<i32>>>
-  %9 = acc.use_device varPtr(%4 : !fir.ref<!fir.box<!fir.ptr<i32>>>) -> !fir.ref<!fir.box<!fir.ptr<i32>>> {name = "ptr"}
+  %9 = acc.use_device varPtr(%4 : !fir.ref<!fir.box<!fir.ptr<i32>>>) name("ptr") -> !fir.ref<!fir.box<!fir.ptr<i32>>>
   acc.host_data dataOperands(%9 : !fir.ref<!fir.box<!fir.ptr<i32>>>) {
     %14 = fir.load %9 : !fir.ref<!fir.box<!fir.ptr<i32>>>
     %15 = fir.box_addr %14 : (!fir.box<!fir.ptr<i32>>) -> !fir.ptr<i32>
@@ -158,11 +158,11 @@ func.func @test_ref_to_box_multiple_host_data() {
 // CHECK-LABEL: func.func @test_ref_to_box_multiple_host_data
 // CHECK: fir.load %{{.*}}
 // CHECK: fir.box_addr %{{.*}}
-// CHECK: %[[USE_DEVICE_1:.*]] = acc.use_device varPtr({{.*}} : !fir.ptr<i32>) varType(!fir.box<!fir.ptr<i32>>) -> !fir.ptr<i32> {name = "ptr"}
+// CHECK: %[[USE_DEVICE_1:.*]] = acc.use_device varPtr({{.*}} : !fir.ptr<i32>) varType(!fir.box<!fir.ptr<i32>>) name("ptr") -> !fir.ptr<i32>
 // CHECK: acc.host_data dataOperands(%[[USE_DEVICE_1]] : !fir.ptr<i32>) {
 // CHECK: acc.terminator
 // CHECK: }
-// CHECK: %[[USE_DEVICE_2:.*]] = acc.use_device varPtr({{.*}} : !fir.ptr<i32>) varType(!fir.box<!fir.ptr<i32>>) -> !fir.ptr<i32> {name = "ptr"}
+// CHECK: %[[USE_DEVICE_2:.*]] = acc.use_device varPtr({{.*}} : !fir.ptr<i32>) varType(!fir.box<!fir.ptr<i32>>) name("ptr") -> !fir.ptr<i32>
 // CHECK: acc.host_data dataOperands(%[[USE_DEVICE_2]] : !fir.ptr<i32>) {
 // CHECK: acc.terminator
 // CHECK: }

--- a/flang/test/Fir/array-coor-canonicalization-acc.fir
+++ b/flang/test/Fir/array-coor-canonicalization-acc.fir
@@ -21,13 +21,13 @@
 func.func @test_acc_copyin_preserves_rebox(%arg0: !fir.box<!fir.array<?xf32>>, %arg1: f32) -> !fir.ref<f32> {
   %c1 = arith.constant 1 : index
   %0 = fir.rebox %arg0 : (!fir.box<!fir.array<?xf32>>) -> !fir.box<!fir.array<?xf32>>
-  %1 = acc.copyin var(%0 : !fir.box<!fir.array<?xf32>>) -> !fir.box<!fir.array<?xf32>> {dataClause = #acc<data_clause acc_copy>, name = "array"}
+  %1 = acc.copyin var(%0 : !fir.box<!fir.array<?xf32>>) dataClause(acc_copy) name("array") -> !fir.box<!fir.array<?xf32>>
   acc.parallel dataOperands(%1 : !fir.box<!fir.array<?xf32>>) {
     %2 = fir.array_coor %0 %c1 : (!fir.box<!fir.array<?xf32>>, index) -> !fir.ref<f32>
     fir.store %arg1 to %2 : !fir.ref<f32>
     acc.yield
-  } attributes {defaultAttr = #acc<defaultvalue none>}
-  acc.copyout accPtr(%1 : !fir.box<!fir.array<?xf32>>) to varPtr(%0 : !fir.box<!fir.array<?xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "array"}
+  } defaultAttr(none)
+  acc.copyout accPtr(%1 : !fir.box<!fir.array<?xf32>>) to varPtr(%0 : !fir.box<!fir.array<?xf32>>) dataClause(acc_copy) name("array")
   %3 = fir.array_coor %0 %c1 : (!fir.box<!fir.array<?xf32>>, index) -> !fir.ref<f32>
   return %3 : !fir.ref<f32>
 }

--- a/flang/test/Lower/OpenACC/acc-bounds.f90
+++ b/flang/test/Lower/OpenACC/acc-bounds.f90
@@ -26,7 +26,7 @@ contains
 ! CHECK: %[[VAL_1:.*]] = fir.alloca !fir.type<_QMopenacc_boundsTt1{array_comp:!fir.box<!fir.ptr<!fir.array<?xi32>>>}> {bindc_name = "d", uniq_name = "_QMopenacc_boundsFacc_derived_type_component_pointer_arrayEd"}
 ! CHECK: %[[VAL_2:.*]]:2 = hlfir.declare %[[VAL_1]] {uniq_name = "_QMopenacc_boundsFacc_derived_type_component_pointer_arrayEd"} : (!fir.ref<!fir.type<_QMopenacc_boundsTt1{array_comp:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>) -> (!fir.ref<!fir.type<_QMopenacc_boundsTt1{array_comp:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>, !fir.ref<!fir.type<_QMopenacc_boundsTt1{array_comp:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>)
 ! CHECK: %[[VAL_4:.*]] = hlfir.designate %[[VAL_2]]#0{"array_comp"}   {fortran_attrs = #fir.var_attrs<pointer>} : (!fir.ref<!fir.type<_QMopenacc_boundsTt1{array_comp:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
-! CHECK: %[[VAL_6:.*]] = acc.create varPtr(%[[VAL_4]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>> {name = "d%array_comp", structured = false}
+! CHECK: %[[VAL_6:.*]] = acc.create varPtr(%[[VAL_4]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>) structured(false) name("d%array_comp") -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
 ! CHECK: acc.enter_data dataOperands(%[[VAL_6]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>)
 ! CHECK: return
 ! CHECK: }
@@ -46,7 +46,7 @@ contains
 ! CHECK: %[[C0:.*]] = arith.constant 0 : index
 ! CHECK: %[[UB:.*]] = arith.subi %[[C10]], %[[C1]] : index
 ! CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[C0]] : index) upperbound(%[[UB]] : index) extent(%[[C10]] : index) stride(%[[C1]] : index) startIdx(%[[C1]] : index)
-! CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[COORD]] : !fir.ref<!fir.array<10xi32>>) bounds(%[[BOUND]]) -> !fir.ref<!fir.array<10xi32>> {name = "d%array_comp", structured = false}
+! CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[COORD]] : !fir.ref<!fir.array<10xi32>>) bounds(%[[BOUND]]) structured(false) name("d%array_comp") -> !fir.ref<!fir.array<10xi32>>
 ! CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.ref<!fir.array<10xi32>>)
 ! CHECK: return
 ! CHECK: }
@@ -60,7 +60,7 @@ contains
 ! CHECK: %[[D:.*]] = fir.alloca !fir.type<_QMopenacc_boundsTt3{array_comp:!fir.box<!fir.heap<!fir.array<?xi32>>>}> {bindc_name = "d", uniq_name = "_QMopenacc_boundsFacc_derived_type_component_allocatable_arrayEd"}
 ! CHECK: %[[DECL_D:.*]]:2 = hlfir.declare %[[D]] {uniq_name = "_QMopenacc_boundsFacc_derived_type_component_allocatable_arrayEd"} : (!fir.ref<!fir.type<_QMopenacc_boundsTt3{array_comp:!fir.box<!fir.heap<!fir.array<?xi32>>>}>>) -> (!fir.ref<!fir.type<_QMopenacc_boundsTt3{array_comp:!fir.box<!fir.heap<!fir.array<?xi32>>>}>>, !fir.ref<!fir.type<_QMopenacc_boundsTt3{array_comp:!fir.box<!fir.heap<!fir.array<?xi32>>>}>>)
 ! CHECK: %[[COORD:.*]] = hlfir.designate %[[DECL_D]]#0{"array_comp"}   {fortran_attrs = #fir.var_attrs<allocatable>} : (!fir.ref<!fir.type<_QMopenacc_boundsTt3{array_comp:!fir.box<!fir.heap<!fir.array<?xi32>>>}>>) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[COORD]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> {name = "d%[[VAL_15:.*]]", structured = false}
+! CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[COORD]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) structured(false) name("d%[[VAL_15:.*]]") -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
 ! CHECK: return
 ! CHECK: }
@@ -77,8 +77,8 @@ contains
 ! CHECK: %[[DECL_ARG0:.*]]:2 = hlfir.declare %[[ARG0]](%{{.*}}) dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {uniq_name = "_QMopenacc_boundsFacc_undefined_extentEa"} : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.ref<!fir.array<?xf32>>)
 ! CHECK: %[[DIMS0:.*]]:3 = fir.box_dims %[[DECL_ARG0]]#0, %c0{{.*}} : (!fir.box<!fir.array<?xf32>>, index) -> (index, index, index)
 ! CHECK: %[[UB:.*]] = arith.subi %[[DIMS0]]#1, %c1{{.*}} : index
-! CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%c0{{.*}} : index) upperbound(%[[UB]] : index) extent(%[[DIMS0]]#1 : index) stride(%[[DIMS0]]#2 : index) startIdx(%c1{{.*}} : index) {strideInBytes = true}
-! CHECK: %[[PRESENT:.*]] = acc.present var(%[[DECL_ARG0]]#0 : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND]]) -> !fir.box<!fir.array<?xf32>> {name = "a"}
+! CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%c0{{.*}} : index) upperbound(%[[UB]] : index) extent(%[[DIMS0]]#1 : index) stride(%[[DIMS0]]#2 : index) startIdx(%c1{{.*}} : index) strideInBytes(true)
+! CHECK: %[[PRESENT:.*]] = acc.present var(%[[DECL_ARG0]]#0 : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND]]) name("a") -> !fir.box<!fir.array<?xf32>>
 ! CHECK: acc.kernels dataOperands(%[[PRESENT]] : !fir.box<!fir.array<?xf32>>) {
 
   subroutine acc_multi_strides(a)
@@ -92,14 +92,14 @@ contains
 ! CHECK-SAME: %[[ARG0:.*]]: !fir.box<!fir.array<?x?x?xf32>> {fir.bindc_name = "a"})
 ! CHECK: %[[DECL_ARG0:.*]]:2 = hlfir.declare %[[ARG0]] dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {uniq_name = "_QMopenacc_boundsFacc_multi_stridesEa"} : (!fir.box<!fir.array<?x?x?xf32>>, !fir.dscope) -> (!fir.box<!fir.array<?x?x?xf32>>, !fir.box<!fir.array<?x?x?xf32>>)
 ! CHECK: %[[BOX_DIMS0:.*]]:3 = fir.box_dims %[[DECL_ARG0]]#0, %c0{{.*}} : (!fir.box<!fir.array<?x?x?xf32>>, index) -> (index, index, index)
-! CHECK: %[[BOUNDS0:.*]] = acc.bounds lowerbound(%{{.*}} : index) upperbound(%{{.*}} : index) extent(%[[BOX_DIMS0]]#1 : index) stride(%[[BOX_DIMS0]]#2 : index) startIdx(%{{.*}} : index) {strideInBytes = true}
+! CHECK: %[[BOUNDS0:.*]] = acc.bounds lowerbound(%{{.*}} : index) upperbound(%{{.*}} : index) extent(%[[BOX_DIMS0]]#1 : index) stride(%[[BOX_DIMS0]]#2 : index) startIdx(%{{.*}} : index) strideInBytes(true)
 ! CHECK: %[[STRIDE1:.*]] = arith.muli %[[BOX_DIMS0]]#2, %[[BOX_DIMS0]]#1 : index
 ! CHECK: %[[BOX_DIMS1:.*]]:3 = fir.box_dims %[[DECL_ARG0]]#0, %c1{{.*}} : (!fir.box<!fir.array<?x?x?xf32>>, index) -> (index, index, index)
-! CHECK: %[[BOUNDS1:.*]] = acc.bounds lowerbound(%{{.*}} : index) upperbound(%{{.*}} : index) extent(%[[BOX_DIMS1]]#1 : index) stride(%[[STRIDE1]] : index) startIdx(%{{.*}} : index) {strideInBytes = true}
+! CHECK: %[[BOUNDS1:.*]] = acc.bounds lowerbound(%{{.*}} : index) upperbound(%{{.*}} : index) extent(%[[BOX_DIMS1]]#1 : index) stride(%[[STRIDE1]] : index) startIdx(%{{.*}} : index) strideInBytes(true)
 ! CHECK: %[[STRIDE2:.*]] = arith.muli %[[STRIDE1]], %[[BOX_DIMS1]]#1 : index
 ! CHECK: %[[BOX_DIMS2:.*]]:3 = fir.box_dims %[[DECL_ARG0]]#0, %c2{{.*}} : (!fir.box<!fir.array<?x?x?xf32>>, index) -> (index, index, index)
-! CHECK: %[[BOUNDS2:.*]] = acc.bounds lowerbound(%{{.*}} : index) upperbound(%{{.*}} : index) extent(%[[BOX_DIMS2]]#1 : index) stride(%[[STRIDE2]] : index) startIdx(%{{.*}} : index) {strideInBytes = true}
-! CHECK: %[[PRESENT:.*]] = acc.present var(%[[DECL_ARG0]]#0 : !fir.box<!fir.array<?x?x?xf32>>) bounds(%[[BOUNDS0]], %[[BOUNDS1]], %[[BOUNDS2]]) -> !fir.box<!fir.array<?x?x?xf32>> {name = "a"}
+! CHECK: %[[BOUNDS2:.*]] = acc.bounds lowerbound(%{{.*}} : index) upperbound(%{{.*}} : index) extent(%[[BOX_DIMS2]]#1 : index) stride(%[[STRIDE2]] : index) startIdx(%{{.*}} : index) strideInBytes(true)
+! CHECK: %[[PRESENT:.*]] = acc.present var(%[[DECL_ARG0]]#0 : !fir.box<!fir.array<?x?x?xf32>>) bounds(%[[BOUNDS0]], %[[BOUNDS1]], %[[BOUNDS2]]) name("a") -> !fir.box<!fir.array<?x?x?xf32>>
 ! CHECK: acc.kernels dataOperands(%[[PRESENT]] : !fir.box<!fir.array<?x?x?xf32>>) {
 
   subroutine acc_optional_data(a)
@@ -120,8 +120,8 @@ contains
 ! CHECK:   %[[CM1:.*]] = arith.constant -1 : index
 ! CHECK:   fir.result %[[C0]], %[[CM1]], %[[C0]], %[[C0]], %[[C0]] : index, index, index, index, index
 ! CHECK: }
-! CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[RES]]#0 : index) upperbound(%[[RES]]#1 : index) extent(%[[RES]]#2 : index) stride(%[[RES]]#3 : index) startIdx(%[[RES]]#4 : index) {strideInBytes = true}
-! CHECK: %[[ATTACH:.*]] = acc.attach varPtr(%[[ARG0_DECL]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) bounds(%[[BOUND]]) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>> {name = "a"}
+! CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[RES]]#0 : index) upperbound(%[[RES]]#1 : index) extent(%[[RES]]#2 : index) stride(%[[RES]]#3 : index) startIdx(%[[RES]]#4 : index) strideInBytes(true)
+! CHECK: %[[ATTACH:.*]] = acc.attach varPtr(%[[ARG0_DECL]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) bounds(%[[BOUND]]) name("a") -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
 ! CHECK: acc.data dataOperands(%[[ATTACH]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) {
 
   subroutine acc_optional_data2(a, n)
@@ -134,7 +134,7 @@ contains
 ! CHECK-LABEL: func.func @_QMopenacc_boundsPacc_optional_data2(
 ! CHECK-SAME: %[[A:.*]]: !fir.ref<!fir.array<?xf32>> {fir.bindc_name = "a", fir.optional}, %[[N:.*]]: !fir.ref<i32> {fir.bindc_name = "n"}) {
 ! CHECK: %[[DECL_A:.*]]:2 = hlfir.declare %[[A]](%{{.*}}) dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {fortran_attrs = #fir.var_attrs<optional>, uniq_name = "_QMopenacc_boundsFacc_optional_data2Ea"} : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.ref<!fir.array<?xf32>>)
-! CHECK: %[[NO_CREATE:.*]] = acc.nocreate varPtr(%[[DECL_A]]#1 : !fir.ref<!fir.array<?xf32>>) bounds(%{{[0-9]+}}) -> !fir.ref<!fir.array<?xf32>> {name = "a"}
+! CHECK: %[[NO_CREATE:.*]] = acc.nocreate varPtr(%[[DECL_A]]#1 : !fir.ref<!fir.array<?xf32>>) bounds(%{{[0-9]+}}) name("a") -> !fir.ref<!fir.array<?xf32>>
 ! CHECK: acc.data dataOperands(%[[NO_CREATE]] : !fir.ref<!fir.array<?xf32>>) {
 
   subroutine acc_optional_data3(a, n)
@@ -154,8 +154,8 @@ contains
 ! CHECK: } else {
 ! CHECK:   fir.result %c0{{.*}} : index
 ! CHECK: }
-! CHECK: %[[BOUNDS:.*]] = acc.bounds lowerbound(%c0{{.*}} : index) upperbound(%{{.*}} : index) extent(%{{.*}} : index) stride(%[[STRIDE]] : index) startIdx(%c1 : index) {strideInBytes = true}
-! CHECK: %[[NOCREATE:.*]] = acc.nocreate varPtr(%[[DECL_A]]#1 : !fir.ref<!fir.array<?xf32>>) bounds(%[[BOUNDS]]) -> !fir.ref<!fir.array<?xf32>> {name = "a(1:n)"}
+! CHECK: %[[BOUNDS:.*]] = acc.bounds lowerbound(%c0{{.*}} : index) upperbound(%{{.*}} : index) extent(%{{.*}} : index) stride(%[[STRIDE]] : index) startIdx(%c1 : index) strideInBytes(true)
+! CHECK: %[[NOCREATE:.*]] = acc.nocreate varPtr(%[[DECL_A]]#1 : !fir.ref<!fir.array<?xf32>>) bounds(%[[BOUNDS]]) name("a(1:n)") -> !fir.ref<!fir.array<?xf32>>
 ! CHECK: acc.data dataOperands(%[[NOCREATE]] : !fir.ref<!fir.array<?xf32>>) {
 
   subroutine acc_explicit_shape_3d(arr)
@@ -170,7 +170,7 @@ contains
 ! CHECK: %[[BOUND1:.*]] = acc.bounds lowerbound(%c0 : index) upperbound(%c999 : index) extent(%c1000 : index) stride(%c1{{.*}} : index) startIdx(%c1 : index)
 ! CHECK: %[[BOUND2:.*]] = acc.bounds lowerbound(%c0 : index) upperbound(%c99 : index) extent(%c100 : index) stride(%c1000{{.*}} : index) startIdx(%c1 : index)
 ! CHECK: %[[BOUND3:.*]] = acc.bounds lowerbound(%c0 : index) upperbound(%c9 : index) extent(%c10 : index) stride(%c100000{{.*}} : index) startIdx(%c1 : index)
-! CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : !fir.ref<!fir.array<1000x100x10xf32>>) bounds(%[[BOUND1]], %[[BOUND2]], %[[BOUND3]]) -> !fir.ref<!fir.array<1000x100x10xf32>> {name = "arr(:1000,:100,:10)"}
+! CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : !fir.ref<!fir.array<1000x100x10xf32>>) bounds(%[[BOUND1]], %[[BOUND2]], %[[BOUND3]]) name("arr(:1000,:100,:10)") -> !fir.ref<!fir.array<1000x100x10xf32>>
 ! CHECK: acc.data dataOperands(%[[COPYIN]] : !fir.ref<!fir.array<1000x100x10xf32>>) {
 
   subroutine acc_explicit_shape_scalar_dims(arr)
@@ -185,7 +185,7 @@ contains
 ! CHECK: %[[B1:.*]] = acc.bounds lowerbound(%c0{{.*}} : index) upperbound(%c0{{.*}} : index) extent(%c1{{.*}} : index) stride(%c10{{.*}} : index) startIdx(%c1{{.*}} : index)
 ! CHECK: %[[B2:.*]] = acc.bounds lowerbound(%c0{{.*}} : index) upperbound(%{{.*}} : index) extent(%c10{{.*}} : index) stride(%c100{{.*}} : index) startIdx(%c1{{.*}} : index)
 ! CHECK: %[[B3:.*]] = acc.bounds lowerbound(%c3{{.*}} : index) upperbound(%c3{{.*}} : index) extent(%c1{{.*}} : index) stride(%c1000{{.*}} : index) startIdx(%c1{{.*}} : index)
-! CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : !fir.ref<!fir.array<10x10x10x10xf32>>) bounds(%[[B0]], %[[B1]], %[[B2]], %[[B3]]) -> !fir.ref<!fir.array<10x10x10x10xf32>> {name = "arr(:,1,:,4)"}
+! CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : !fir.ref<!fir.array<10x10x10x10xf32>>) bounds(%[[B0]], %[[B1]], %[[B2]], %[[B3]]) name("arr(:,1,:,4)") -> !fir.ref<!fir.array<10x10x10x10xf32>>
 
   subroutine acc_explicit_shape_leading_scalar(arr)
     real :: arr(2,3,4)
@@ -197,6 +197,6 @@ contains
 ! CHECK: %[[B0:.*]] = acc.bounds lowerbound(%c1{{.*}} : index) upperbound(%c1{{.*}} : index) extent(%c1{{.*}} : index) stride(%c1{{.*}} : index) startIdx(%c1{{.*}} : index)
 ! CHECK: %[[B1:.*]] = acc.bounds lowerbound(%c0{{.*}} : index) upperbound(%{{.*}} : index) extent(%c3{{.*}} : index) stride(%c2{{.*}} : index) startIdx(%c1{{.*}} : index)
 ! CHECK: %[[B2:.*]] = acc.bounds lowerbound(%c0{{.*}} : index) upperbound(%{{.*}} : index) extent(%c4{{.*}} : index) stride(%c6{{.*}} : index) startIdx(%c1{{.*}} : index)
-! CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : !fir.ref<!fir.array<2x3x4xf32>>) bounds(%[[B0]], %[[B1]], %[[B2]]) -> !fir.ref<!fir.array<2x3x4xf32>> {name = "arr(2,:,:)"}
+! CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : !fir.ref<!fir.array<2x3x4xf32>>) bounds(%[[B0]], %[[B1]], %[[B2]]) name("arr(2,:,:)") -> !fir.ref<!fir.array<2x3x4xf32>>
 
 end module

--- a/flang/test/Lower/OpenACC/acc-cache.f90
+++ b/flang/test/Lower/OpenACC/acc-cache.f90
@@ -17,7 +17,7 @@ subroutine test_cache_basic()
   end do
 
 ! CHECK: acc.loop
-! CHECK: %[[CACHE:.*]] = acc.cache varPtr(%{{.*}} : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {{{.*}}name = "b"
+! CHECK: %[[CACHE:.*]] = acc.cache varPtr(%{{.*}} : !fir.ref<!fir.array<10xf32>>) structured(false) name("b") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK: %[[DECL:.*]]:2 = hlfir.declare %[[CACHE]](%{{.*}}) {uniq_name = "_QFtest_cache_basicEb"}
 ! Loop body uses the cached reference
 ! CHECK: %[[ELEM:.*]] = hlfir.designate %[[DECL]]#0 (%{{.*}}) : (!fir.ref<!fir.array<10xf32>>, i64) -> !fir.ref<f32>
@@ -41,7 +41,7 @@ subroutine test_cache_readonly()
   end do
 
 ! CHECK: acc.loop
-! CHECK: %[[CACHE:.*]] = acc.cache varPtr(%{{.*}} : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {modifiers = #acc<data_clause_modifier readonly>, name = "b"
+! CHECK: %[[CACHE:.*]] = acc.cache varPtr(%{{.*}} : !fir.ref<!fir.array<10xf32>>) structured(false) name("b") <{modifiers = #acc<data_clause_modifier readonly>}> -> !fir.ref<!fir.array<10xf32>>
 ! CHECK: %[[DECL:.*]]:2 = hlfir.declare %[[CACHE]](%{{.*}}) {uniq_name = "_QFtest_cache_readonlyEb"}
 ! Loop body uses the cached readonly reference
 ! CHECK: %[[ELEM:.*]] = hlfir.designate %[[DECL]]#0 (%{{.*}}) : (!fir.ref<!fir.array<10xf32>>, i64) -> !fir.ref<f32>
@@ -74,7 +74,7 @@ subroutine test_cache_array_section()
 ! CHECK: %[[LB:.*]] = arith.constant 1 : index
 ! CHECK: %[[UB:.*]] = arith.constant 4 : index
 ! CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%{{.*}} : index) stride(%[[C1]] : index) startIdx(%[[C1]] : index)
-! CHECK: %[[CACHE:.*]] = acc.cache varPtr(%{{.*}} : !fir.ref<!fir.array<10xf32>>) bounds(%[[BOUND]]) -> !fir.ref<!fir.array<10xf32>> {{{.*}}name = "b
+! CHECK: %[[CACHE:.*]] = acc.cache varPtr(%{{.*}} : !fir.ref<!fir.array<10xf32>>) bounds(%[[BOUND]]) structured(false) name("b{{.*}}") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK: %[[DECL:.*]]:2 = hlfir.declare %[[CACHE]](%{{.*}}) {uniq_name = "_QFtest_cache_array_sectionEb"}
 ! Unstructured control flow: IF condition generates fir.if
 ! CHECK: %[[CMP:.*]] = arith.cmpi sgt, %{{.*}}, %{{.*}} : i32
@@ -107,9 +107,9 @@ subroutine test_cache_multiple()
   end do
 
 ! CHECK: acc.loop
-! CHECK: %[[CACHE_B:.*]] = acc.cache varPtr(%{{.*}} : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {{{.*}}name = "b"
+! CHECK: %[[CACHE_B:.*]] = acc.cache varPtr(%{{.*}} : !fir.ref<!fir.array<10xf32>>) structured(false) name("b") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK: %[[DECL_B:.*]]:2 = hlfir.declare %[[CACHE_B]](%{{.*}}) {uniq_name = "_QFtest_cache_multipleEb"}
-! CHECK: %[[CACHE_C:.*]] = acc.cache varPtr(%{{.*}} : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {{{.*}}name = "c"
+! CHECK: %[[CACHE_C:.*]] = acc.cache varPtr(%{{.*}} : !fir.ref<!fir.array<10xf32>>) structured(false) name("c") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK: %[[DECL_C:.*]]:2 = hlfir.declare %[[CACHE_C]](%{{.*}}) {uniq_name = "_QFtest_cache_multipleEc"}
 ! Unstructured control flow: IF-ELSE generates fir.if with else region
 ! CHECK: %[[CMP:.*]] = arith.cmpi slt, %{{.*}}, %{{.*}} : i32
@@ -160,7 +160,7 @@ subroutine test_cache_2d_array()
 ! CHECK: %[[C0_2:.*]] = arith.constant 0 : index
 ! CHECK: %[[C4_2:.*]] = arith.constant 4 : index
 ! CHECK: %[[BOUND2:.*]] = acc.bounds lowerbound(%[[C0_2]] : index) upperbound(%[[C4_2]] : index) extent(%{{.*}} : index) stride(%[[C1]] : index) startIdx(%[[C1]] : index)
-! CHECK: %[[CACHE:.*]] = acc.cache varPtr(%{{.*}} : !fir.ref<!fir.array<10x10xf32>>) bounds(%[[BOUND1]], %[[BOUND2]]) -> !fir.ref<!fir.array<10x10xf32>> {{{.*}}name = "b
+! CHECK: %[[CACHE:.*]] = acc.cache varPtr(%{{.*}} : !fir.ref<!fir.array<10x10xf32>>) bounds(%[[BOUND1]], %[[BOUND2]]) structured(false) name("b{{.*}}") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK: %[[DECL:.*]]:2 = hlfir.declare %[[CACHE]](%{{.*}}) {uniq_name = "_QFtest_cache_2d_arrayEb"}
 ! Nested loop uses the cached 2D array
 ! CHECK: fir.do_loop
@@ -205,7 +205,7 @@ subroutine test_cache_loop_var()
 ! Compute upperbound = (i+2) - 1
 ! CHECK: %[[UB:.*]] = arith.subi %[[UB_IDX]], %[[C1]] : index
 ! CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%{{.*}} : index) stride(%[[C1]] : index) startIdx(%[[C1]] : index)
-! CHECK: %[[CACHE:.*]] = acc.cache varPtr(%{{.*}} : !fir.ref<!fir.array<10xf32>>) bounds(%[[BOUND]]) -> !fir.ref<!fir.array<10xf32>> {{{.*}}name = "b
+! CHECK: %[[CACHE:.*]] = acc.cache varPtr(%{{.*}} : !fir.ref<!fir.array<10xf32>>) bounds(%[[BOUND]]) structured(false) name("b{{.*}}") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK: %[[DECL:.*]]:2 = hlfir.declare %[[CACHE]](%{{.*}}) {uniq_name = "_QFtest_cache_loop_varEb"}
 ! Loop body uses the cached reference for b(i), b(i+1), b(i+2)
 ! CHECK: hlfir.designate %[[DECL]]#0
@@ -249,7 +249,7 @@ subroutine test_cache_2d_loop_vars()
 ! CHECK: %[[BOUND1:.*]] = acc.bounds lowerbound(%{{.*}} : index) upperbound(%{{.*}} : index) extent(%{{.*}} : index) stride(%{{.*}} : index) startIdx(%{{.*}} : index)
 ! Dimension 2 bounds from i: lowerbound = i-1, upperbound = i
 ! CHECK: %[[BOUND2:.*]] = acc.bounds lowerbound(%{{.*}} : index) upperbound(%{{.*}} : index) extent(%{{.*}} : index) stride(%{{.*}} : index) startIdx(%{{.*}} : index)
-! CHECK: %[[CACHE:.*]] = acc.cache varPtr(%{{.*}} : !fir.ref<!fir.array<10x10xf32>>) bounds(%[[BOUND1]], %[[BOUND2]]) -> !fir.ref<!fir.array<10x10xf32>> {{{.*}}name = "b
+! CHECK: %[[CACHE:.*]] = acc.cache varPtr(%{{.*}} : !fir.ref<!fir.array<10x10xf32>>) bounds(%[[BOUND1]], %[[BOUND2]]) structured(false) name("b{{.*}}") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK: %[[DECL:.*]]:2 = hlfir.declare %[[CACHE]](%{{.*}}) {uniq_name = "_QFtest_cache_2d_loop_varsEb"}
 ! Loop body uses the cached 2D reference
 ! CHECK: hlfir.designate %[[DECL]]#0
@@ -280,7 +280,7 @@ subroutine test_cache_single_element()
     if (a(i) > 100.0) exit
   end do
 
-! Unstructured loop with EXIT: acc.loop becomes unstructured with cf.br/cf.cond_br
+! Unstructured loop with EXIT: acc.loop becomes unstructured  with cf.br/cf.cond_br
 ! CHECK: acc.loop private({{.*}}) {
 ! The privatized iterator is declared
 ! CHECK: %[[I_DECL:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "_QFtest_cache_single_elementEi"}
@@ -297,7 +297,7 @@ subroutine test_cache_single_element()
 ! Compute lowerbound = i - 1 (single element: upperbound = lowerbound)
 ! CHECK: %[[LB:.*]] = arith.subi %[[I_IDX]], %[[C1]] : index
 ! CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[LB]] : index) extent(%[[C1]] : index) stride(%[[C1]] : index) startIdx(%[[C1]] : index)
-! CHECK: %[[CACHE:.*]] = acc.cache varPtr(%{{.*}} : !fir.ref<!fir.array<10xf32>>) bounds(%[[BOUND]]) -> !fir.ref<!fir.array<10xf32>> {{{.*}}name = "b
+! CHECK: %[[CACHE:.*]] = acc.cache varPtr(%{{.*}} : !fir.ref<!fir.array<10xf32>>) bounds(%[[BOUND]]) structured(false) name("b{{.*}}") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK: %[[DECL:.*]]:2 = hlfir.declare %[[CACHE]](%{{.*}}) {uniq_name = "_QFtest_cache_single_elementEb"}
 ! Loop body uses the cached single element
 ! CHECK: hlfir.designate %[[DECL]]#0
@@ -315,7 +315,7 @@ subroutine test_cache_single_element()
 ! CHECK: ^[[YIELD]]:
 ! Scope termination: acc.yield marks end of cache scope
 ! CHECK: acc.yield
-! CHECK-NEXT: } attributes {{{.*}}unstructured}
+! CHECK-NEXT: } {{.*}}unstructured{{.*}}
 end subroutine
 
 ! CHECK-LABEL: func.func @_QPtest_cache_mixed_bounds()
@@ -347,7 +347,7 @@ subroutine test_cache_mixed_bounds()
 ! Compute upperbound = i - 1
 ! CHECK: %[[UB:.*]] = arith.subi %[[I_IDX]], %[[C1]] : index
 ! CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[C0]] : index) upperbound(%[[UB]] : index) extent(%{{.*}} : index) stride(%[[C1]] : index) startIdx(%[[C1]] : index)
-! CHECK: %[[CACHE:.*]] = acc.cache varPtr(%{{.*}} : !fir.ref<!fir.array<10xf32>>) bounds(%[[BOUND]]) -> !fir.ref<!fir.array<10xf32>> {{{.*}}name = "b
+! CHECK: %[[CACHE:.*]] = acc.cache varPtr(%{{.*}} : !fir.ref<!fir.array<10xf32>>) bounds(%[[BOUND]]) structured(false) name("b{{.*}}") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK: %[[DECL:.*]]:2 = hlfir.declare %[[CACHE]](%{{.*}}) {uniq_name = "_QFtest_cache_mixed_boundsEb"}
 ! Unstructured control flow: CYCLE generates inverted fir.if (body executes when NOT cycling)
 ! CHECK: %[[MOD:.*]] = arith.remsi %{{.*}}, %{{.*}} : i32
@@ -398,9 +398,9 @@ subroutine test_cache_nonunit_lb()
 ! CHECK: %[[C15:.*]] = arith.constant 15 : index
 ! CHECK: %[[LB:.*]] = arith.subi %[[C15]], %{{.*}} : index
 ! Single element: upperbound equals lowerbound, startIdx = 10
-! CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[LB]] : index) extent(%[[C1]] : index) stride(%{{.*}} : index) startIdx(%{{.*}} : index) {strideInBytes = true}
+! CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[LB]] : index) extent(%[[C1]] : index) stride(%{{.*}} : index) startIdx(%{{.*}} : index) strideInBytes(true)
 ! For non-unit lower bound arrays, acc.cache uses the box type from hlfir.declare
-! CHECK: %[[CACHE:.*]] = acc.cache var(%{{.*}} : !fir.box<!fir.array<11xi32>>) bounds(%[[BOUND]]) -> !fir.box<!fir.array<11xi32>> {{{.*}}name = "arr
+! CHECK: %[[CACHE:.*]] = acc.cache var(%{{.*}} : !fir.box<!fir.array<11xi32>>) bounds(%[[BOUND]]) structured(false) name("arr{{.*}}") -> !fir.box<!fir.array<11xi32>>
 ! CHECK: %[[DECL:.*]]:2 = hlfir.declare %[[CACHE]](%{{.*}}) {uniq_name = "_QFtest_cache_nonunit_lbEarr"}
 ! Unstructured control flow: SELECT CASE generates fir.select_case
 ! CHECK: %[[MOD:.*]] = arith.remsi %{{.*}}, %{{.*}} : i32
@@ -426,7 +426,7 @@ subroutine test_cache_nonunit_lb()
 ! CHECK: ^[[EXIT]]:
 ! Scope termination: acc.yield marks end of cache scope
 ! CHECK: acc.yield
-! CHECK-NEXT: } attributes {{{.*}}unstructured}
+! CHECK-NEXT: } {{.*}}unstructured{{.*}}
 end subroutine
 
 ! CHECK-LABEL: func.func @_QPtest_cache_use_after_region()
@@ -581,7 +581,7 @@ subroutine test_cache_derived_type()
 ! CHECK: acc.loop
 ! CHECK: %[[ARRAY_COORD:.*]] = hlfir.designate %{{.*}}{"array"} shape %{{.*}} : (!fir.ref<!fir.type<_QFtest_cache_derived_typeTdt{array:!fir.array<100xf32>}>>, !fir.shape<1>) -> !fir.ref<!fir.array<100xf32>>
 ! CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%{{.*}} : index) upperbound(%{{.*}} : index) extent(%{{.*}} : index) stride(%{{.*}} : index) startIdx(%{{.*}} : index)
-! CHECK: %[[CACHE:.*]] = acc.cache varPtr(%[[ARRAY_COORD]] : !fir.ref<!fir.array<100xf32>>) bounds(%[[BOUND]]) -> !fir.ref<!fir.array<100xf32>> {name = "data%array(i-4_4:i+4_4)", structured = false}
+! CHECK: %[[CACHE:.*]] = acc.cache varPtr(%[[ARRAY_COORD]] : !fir.ref<!fir.array<100xf32>>) bounds(%[[BOUND]]) structured(false) name("data%array(i-4_4:i+4_4)") -> !fir.ref<!fir.array<100xf32>>
 ! CHECK: acc.yield
 end subroutine
 
@@ -605,7 +605,7 @@ subroutine test_cache_derived_type_readonly()
 ! CHECK: acc.loop
 ! CHECK: %[[ARRAY_COORD:.*]] = hlfir.designate %{{.*}}{"array"} shape %{{.*}} : (!fir.ref<!fir.type<_QFtest_cache_derived_type_readonlyTdt{array:!fir.array<100xf32>}>>, !fir.shape<1>) -> !fir.ref<!fir.array<100xf32>>
 ! CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%{{.*}} : index) upperbound(%{{.*}} : index) extent(%{{.*}} : index) stride(%{{.*}} : index) startIdx(%{{.*}} : index)
-! CHECK: %[[CACHE:.*]] = acc.cache varPtr(%[[ARRAY_COORD]] : !fir.ref<!fir.array<100xf32>>) bounds(%[[BOUND]]) -> !fir.ref<!fir.array<100xf32>> {modifiers = #acc<data_clause_modifier readonly>, name = "data%array(i-4_4:i+4_4)", structured = false}
+! CHECK: %[[CACHE:.*]] = acc.cache varPtr(%[[ARRAY_COORD]] : !fir.ref<!fir.array<100xf32>>) bounds(%[[BOUND]]) structured(false) name("data%array(i-4_4:i+4_4)") <{modifiers = #acc<data_clause_modifier readonly>}> -> !fir.ref<!fir.array<100xf32>>
 ! CHECK: acc.yield
 end subroutine
 
@@ -634,7 +634,7 @@ subroutine test_cache_nested_derived_type()
 ! CHECK: %[[IN_COORD:.*]] = hlfir.designate %{{.*}}{"in"} : (!fir.ref<!fir.type<_QFtest_cache_nested_derived_typeTouter{in:!fir.type<_QFtest_cache_nested_derived_typeTinner{arr:!fir.array<50xf32>}>}>>) -> !fir.ref<!fir.type<_QFtest_cache_nested_derived_typeTinner{arr:!fir.array<50xf32>}>>
 ! CHECK: %[[ARR_COORD:.*]] = hlfir.designate %[[IN_COORD]]{"arr"} shape %{{.*}} : (!fir.ref<!fir.type<_QFtest_cache_nested_derived_typeTinner{arr:!fir.array<50xf32>}>>, !fir.shape<1>) -> !fir.ref<!fir.array<50xf32>>
 ! CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%{{.*}} : index) upperbound(%{{.*}} : index) extent(%{{.*}} : index) stride(%{{.*}} : index) startIdx(%{{.*}} : index)
-! CHECK: %[[CACHE:.*]] = acc.cache varPtr(%[[ARR_COORD]] : !fir.ref<!fir.array<50xf32>>) bounds(%[[BOUND]]) -> !fir.ref<!fir.array<50xf32>> {name = "obj%in%arr(i)", structured = false}
+! CHECK: %[[CACHE:.*]] = acc.cache varPtr(%[[ARR_COORD]] : !fir.ref<!fir.array<50xf32>>) bounds(%[[BOUND]]) structured(false) name("obj%in%arr(i)") -> !fir.ref<!fir.array<50xf32>>
 ! CHECK: acc.yield
 end subroutine
 
@@ -658,7 +658,7 @@ subroutine test_cache_combined_allocatable(data, C, M)
 
 ! CHECK: acc.parallel {{.*}} {
 ! CHECK: acc.loop
-! CHECK: acc.cache varPtr(%{{.*}}) bounds(%{{.*}}) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>> {name = "data%a(i-4_4:i+4_4)", structured = false}
+! CHECK: acc.cache varPtr(%{{.*}}) bounds(%{{.*}}) structured(false) name("data%a(i-4_4:i+4_4)") -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
 ! CHECK: hlfir.declare %{{.*}} {{{.*}}uniq_name = "data%a(i-4_4:i+4_4)"}
 ! CHECK: acc.yield
 end subroutine
@@ -683,7 +683,7 @@ subroutine test_cache_parallel_copy_struct(data, M)
 
 ! CHECK: acc.parallel {{.*}} {
 ! CHECK: acc.loop
-! CHECK: acc.cache varPtr(%{{.*}}) bounds(%{{.*}}) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>> {name = "data%a(i)", structured = false}
+! CHECK: acc.cache varPtr(%{{.*}}) bounds(%{{.*}}) structured(false) name("data%a(i)") -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
 ! CHECK: hlfir.declare %{{.*}} {{{.*}}uniq_name = "data%a(i)"}
 ! CHECK: acc.yield
 end subroutine
@@ -712,7 +712,7 @@ subroutine test_cache_nested_parallel(obj, N)
 
 ! CHECK: acc.parallel {{.*}} {
 ! CHECK: acc.loop
-! CHECK: acc.cache varPtr(%{{.*}}) bounds(%{{.*}}) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>> {name = "obj%in%arr(i)", structured = false}
+! CHECK: acc.cache varPtr(%{{.*}}) bounds(%{{.*}}) structured(false) name("obj%in%arr(i)") -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
 ! CHECK: hlfir.declare %{{.*}} {{{.*}}uniq_name = "obj%in%arr(i)"}
 ! CHECK: acc.yield
 end subroutine
@@ -737,7 +737,7 @@ subroutine test_cache_explicit_shape_comp(data, C, M)
 
 ! CHECK: acc.parallel {{.*}} {
 ! CHECK: acc.loop
-! CHECK: acc.cache varPtr(%{{.*}}) bounds(%{{.*}}) -> !fir.ref<!fir.array<10xf32>> {name = "data%a(i:i+4_4)", structured = false}
+! CHECK: acc.cache varPtr(%{{.*}}) bounds(%{{.*}}) structured(false) name("data%a(i:i+4_4)") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK: hlfir.declare %{{.*}}(%{{.*}}) {uniq_name = "data%a(i:i+4_4)"}
 ! CHECK: acc.yield
 end subroutine
@@ -761,7 +761,7 @@ subroutine test_cache_temp_in_designator(data, a)
 ! CHECK: %[[ELEMENTAL:.*]] = hlfir.elemental
 ! CHECK: %[[MAXLOC:.*]] = hlfir.maxloc %[[ELEMENTAL]]
 ! CHECK: %[[BOUND:.*]] = acc.bounds lowerbound({{.*}}) upperbound({{.*}})
-! CHECK: %[[CACHE:.*]] = acc.cache varPtr(%{{.*}}) bounds(%[[BOUND]]) -> !fir.ref<!fir.array<100xf32>> {modifiers = #acc<data_clause_modifier readonly>, name = "data(1:maxloc(a+a,dim=1_4))", structured = false}
+! CHECK: %[[CACHE:.*]] = acc.cache varPtr(%{{.*}}) bounds(%[[BOUND]]) structured(false) name("data(1:maxloc(a+a,dim=1_4))") <{modifiers = #acc<data_clause_modifier readonly>}> -> !fir.ref<!fir.array<100xf32>>
 ! CHECK: %[[DECL:.*]]:2 = hlfir.declare %[[CACHE]]
 ! CHECK: hlfir.destroy %[[ELEMENTAL]]
 ! CHECK: hlfir.designate %[[DECL]]#0
@@ -807,7 +807,7 @@ end subroutine
 ! CHECK: %[[EXT:.*]] = arith.constant 11 : index
 ! CHECK: %[[SHAPE:.*]] = fir.shape_shift %[[LB]], %[[EXT]] : (index, index) -> !fir.shapeshift<1>
 ! CHECK: %[[ARR:.*]]:2 = hlfir.declare %{{.*}}(%[[SHAPE]]) {uniq_name = "_QFtest_cache_nonunit_lb_boxEarr"} : (!fir.ref<!fir.array<11xi32>>, !fir.shapeshift<1>) -> (!fir.box<!fir.array<11xi32>>, !fir.ref<!fir.array<11xi32>>)
-! CHECK: %[[CACHE:.*]] = acc.cache var(%[[ARR]]#0 : !fir.box<!fir.array<11xi32>>) bounds(%{{.*}}) -> !fir.box<!fir.array<11xi32>> {name = "arr(12:18)"
+! CHECK: %[[CACHE:.*]] = acc.cache var(%[[ARR]]#0 : !fir.box<!fir.array<11xi32>>) bounds(%{{.*}}) structured(false) name("arr(12:18)") -> !fir.box<!fir.array<11xi32>>
 ! The cached re-declaration reuses the SAME lower bound (10) with NO extent: a
 ! fir.shift on %[[LB]], never a fir.shape_shift.
 ! CHECK-NOT: fir.shape_shift
@@ -835,7 +835,7 @@ end subroutine
 ! CHECK: %[[C0B:.*]] = arith.constant 0 : i64
 ! CHECK: %[[LB1:.*]] = fir.convert %[[C0B]] : (i64) -> index
 ! CHECK: %[[ARR:.*]]:2 = hlfir.declare %arg0(%{{.*}}) dummy_scope %{{.*}} {{.*}}uniq_name = "_QFtest_cache_assumed_shape_boxEarr"}
-! CHECK: %[[CACHE:.*]] = acc.cache var(%[[ARR]]#0 : !fir.box<!fir.array<?x?xf64>>) bounds(%{{.*}}, %{{.*}}) -> !fir.box<!fir.array<?x?xf64>> {name = "arr(3:8,0:4)"
+! CHECK: %[[CACHE:.*]] = acc.cache var(%[[ARR]]#0 : !fir.box<!fir.array<?x?xf64>>) bounds(%{{.*}}, %{{.*}}) structured(false) name("arr(3:8,0:4)") -> !fir.box<!fir.array<?x?xf64>>
 ! The cached re-declaration reuses the SAME two lower bounds (0, 0) with no
 ! extents: a fir.shift on %[[LB0]], %[[LB1]], never a fir.shape_shift.
 ! CHECK-NOT: fir.shape_shift

--- a/flang/test/Lower/OpenACC/acc-data-operands-remapping-common.f90
+++ b/flang/test/Lower/OpenACC/acc-data-operands-remapping-common.f90
@@ -15,7 +15,7 @@ subroutine test
 end subroutine
 ! CHECK-LABEL:   func.func @_QPtest() {
 ! CHECK:           %[[ADDRESS_OF_0:.*]] = fir.address_of(@comm_)
-! CHECK:           %[[COPYIN_0:.*]] = acc.copyin varPtr(%[[ADDRESS_OF_0]] : !fir.ref<!fir.array<800xi8>>) -> !fir.ref<!fir.array<800xi8>> {name = "comm"}
+! CHECK:           %[[COPYIN_0:.*]] = acc.copyin varPtr(%[[ADDRESS_OF_0]] : !fir.ref<!fir.array<800xi8>>) name("comm") -> !fir.ref<!fir.array<800xi8>>
 ! CHECK:           acc.parallel combined(loop) dataOperands(%[[COPYIN_0]] : !fir.ref<!fir.array<800xi8>>) {
 ! CHECK:             %[[CONSTANT_8:.*]] = arith.constant 196 : index
 ! CHECK:             %[[COORDINATE_OF_4:.*]] = fir.coordinate_of %[[COPYIN_0]], %{{.*}} : (!fir.ref<!fir.array<800xi8>>, index) -> !fir.ref<i8>

--- a/flang/test/Lower/OpenACC/acc-data-operands-remapping-selector.f90
+++ b/flang/test/Lower/OpenACC/acc-data-operands-remapping-selector.f90
@@ -18,7 +18,7 @@ end subroutine
 end module
 ! CHECK-LABEL:  func.func @_QMcopyin_selectorPfoo(
 ! CHECK:    fir.select_type
-! CHECK:    %[[COPYIN:.*]] = acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.type<_QMcopyin_selectorTt{i:i32}>>) -> !fir.ref<!fir.type<_QMcopyin_selectorTt{i:i32}>> {name = "x"}
+! CHECK:    %[[COPYIN:.*]] = acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.type<_QMcopyin_selectorTt{i:i32}>>) name("x") -> !fir.ref<!fir.type<_QMcopyin_selectorTt{i:i32}>>
 ! CHECK:    acc.parallel dataOperands(%[[COPYIN]] : !fir.ref<!fir.type<_QMcopyin_selectorTt{i:i32}>>) {
 ! CHECK:      %[[DECL:.*]]:2 = hlfir.declare %[[COPYIN]] {uniq_name = "_QMcopyin_selectorFfooEx"} : (!fir.ref<!fir.type<_QMcopyin_selectorTt{i:i32}>>) -> (!fir.ref<!fir.type<_QMcopyin_selectorTt{i:i32}>>, !fir.ref<!fir.type<_QMcopyin_selectorTt{i:i32}>>)
 ! CHECK:      fir.call @_QPbar(%[[DECL]]#0)

--- a/flang/test/Lower/OpenACC/acc-data-operands-remapping.f90
+++ b/flang/test/Lower/OpenACC/acc-data-operands-remapping.f90
@@ -188,14 +188,14 @@ end module
 ! CHECK-SAME:      %[[ARG0:.*]]: !fir.ref<f32> {fir.bindc_name = "x"}) {
 ! CHECK:           %[[VAL_0:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK:           %[[VAL_1:.*]]:2 = hlfir.declare %[[ARG0]] dummy_scope %[[VAL_0]] arg {{[0-9]+}} {uniq_name = "_QMmFtest_scalarEx"} : (!fir.ref<f32>, !fir.dscope) -> (!fir.ref<f32>, !fir.ref<f32>)
-! CHECK:           %[[VAL_2:.*]] = acc.copyin varPtr(%[[VAL_1]]#0 : !fir.ref<f32>) -> !fir.ref<f32> {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           %[[VAL_2:.*]] = acc.copyin varPtr(%[[VAL_1]]#0 : !fir.ref<f32>) dataClause(acc_copy) name("x") -> !fir.ref<f32>
 ! CHECK:           acc.parallel dataOperands(%[[VAL_2]] : !fir.ref<f32>) {
 ! CHECK:             %[[VAL_3:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK:             %[[VAL_4:.*]]:2 = hlfir.declare %[[VAL_2]] dummy_scope %[[VAL_3]] arg {{[0-9]+}} {uniq_name = "_QMmFtest_scalarEx"} : (!fir.ref<f32>, !fir.dscope) -> (!fir.ref<f32>, !fir.ref<f32>)
 ! CHECK:             fir.call @_QPtakes_scalar(%[[VAL_4]]#0) fastmath<contract> : (!fir.ref<f32>) -> ()
 ! CHECK:             acc.yield
 ! CHECK:           }
-! CHECK:           acc.copyout accPtr(%[[VAL_2]] : !fir.ref<f32>) to varPtr(%[[VAL_1]]#0 : !fir.ref<f32>) {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           acc.copyout accPtr(%[[VAL_2]] : !fir.ref<f32>) to varPtr(%[[VAL_1]]#0 : !fir.ref<f32>) dataClause(acc_copy) name("x")
 ! CHECK:           return
 ! CHECK:         }
 
@@ -212,7 +212,7 @@ end module
 ! CHECK:           %[[VAL_7:.*]] = arith.cmpi sgt, %[[VAL_5]], %[[VAL_6]] : i32
 ! CHECK:           %[[VAL_8:.*]] = arith.select %[[VAL_7]], %[[VAL_5]], %[[VAL_6]] : i32
 ! CHECK:           %[[VAL_9:.*]]:2 = hlfir.declare %[[VAL_4]]#0 typeparams %[[VAL_8]] dummy_scope %[[VAL_0]] arg {{[0-9]+}} {uniq_name = "_QMmFtest_scalar_characterEc"} : (!fir.ref<!fir.char<1,?>>, i32, !fir.dscope) -> (!fir.boxchar<1>, !fir.ref<!fir.char<1,?>>)
-! CHECK:           %[[VAL_10:.*]] = acc.copyin varPtr(%[[VAL_3]]#0 : !fir.ref<f32>) -> !fir.ref<f32> {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           %[[VAL_10:.*]] = acc.copyin varPtr(%[[VAL_3]]#0 : !fir.ref<f32>) dataClause(acc_copy) name("x") -> !fir.ref<f32>
 ! CHECK:           acc.parallel dataOperands(%[[VAL_10]] : !fir.ref<f32>) {
 ! CHECK:             %[[VAL_11:.*]]:2 = hlfir.declare %[[VAL_10]] {uniq_name = "_QMmFtest_scalar_characterEx"} : (!fir.ref<f32>) -> (!fir.ref<f32>, !fir.ref<f32>)
 ! CHECK:             %[[VAL_12:.*]]:3 = hlfir.associate %[[VAL_8]] {adapt.valuebyref} : (i32) -> (!fir.ref<i32>, !fir.ref<i32>, i1)
@@ -220,7 +220,7 @@ end module
 ! CHECK:             hlfir.end_associate %[[VAL_12]]#1, %[[VAL_12]]#2 : !fir.ref<i32>, i1
 ! CHECK:             acc.yield
 ! CHECK:           }
-! CHECK:           acc.copyout accPtr(%[[VAL_10]] : !fir.ref<f32>) to varPtr(%[[VAL_3]]#0 : !fir.ref<f32>) {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           acc.copyout accPtr(%[[VAL_10]] : !fir.ref<f32>) to varPtr(%[[VAL_3]]#0 : !fir.ref<f32>) dataClause(acc_copy) name("x")
 ! CHECK:           return
 ! CHECK:         }
 
@@ -230,14 +230,14 @@ end module
 ! CHECK:           %[[VAL_1:.*]] = arith.constant 100 : index
 ! CHECK:           %[[VAL_2:.*]] = fir.shape %[[VAL_1]] : (index) -> !fir.shape<1>
 ! CHECK:           %[[VAL_3:.*]]:2 = hlfir.declare %[[ARG0]](%[[VAL_2]]) dummy_scope %[[VAL_0]] arg {{[0-9]+}} {uniq_name = "_QMmFtest_cst_shapeEx"} : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>, !fir.dscope) -> (!fir.ref<!fir.array<100xf32>>, !fir.ref<!fir.array<100xf32>>)
-! CHECK:           %[[VAL_4:.*]] = acc.copyin varPtr(%[[VAL_3]]#0 : !fir.ref<!fir.array<100xf32>>) -> !fir.ref<!fir.array<100xf32>> {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           %[[VAL_4:.*]] = acc.copyin varPtr(%[[VAL_3]]#0 : !fir.ref<!fir.array<100xf32>>) dataClause(acc_copy) name("x") -> !fir.ref<!fir.array<100xf32>>
 ! CHECK:           acc.parallel dataOperands(%[[VAL_4]] : !fir.ref<!fir.array<100xf32>>) {
 ! CHECK:             %[[VAL_5:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK:             %[[VAL_6:.*]]:2 = hlfir.declare %[[VAL_4]](%[[VAL_2]]) dummy_scope %[[VAL_5]] arg {{[0-9]+}} {uniq_name = "_QMmFtest_cst_shapeEx"} : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>, !fir.dscope) -> (!fir.ref<!fir.array<100xf32>>, !fir.ref<!fir.array<100xf32>>)
 ! CHECK:             fir.call @_QPtakes_explicit_cst_shape(%[[VAL_6]]#0) fastmath<contract> : (!fir.ref<!fir.array<100xf32>>) -> ()
 ! CHECK:             acc.yield
 ! CHECK:           }
-! CHECK:           acc.copyout accPtr(%[[VAL_4]] : !fir.ref<!fir.array<100xf32>>) to varPtr(%[[VAL_3]]#0 : !fir.ref<!fir.array<100xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           acc.copyout accPtr(%[[VAL_4]] : !fir.ref<!fir.array<100xf32>>) to varPtr(%[[VAL_3]]#0 : !fir.ref<!fir.array<100xf32>>) dataClause(acc_copy) name("x")
 ! CHECK:           return
 ! CHECK:         }
 
@@ -254,7 +254,7 @@ end module
 ! CHECK:           %[[VAL_7:.*]] = arith.select %[[VAL_6]], %[[VAL_4]], %[[VAL_5]] : index
 ! CHECK:           %[[VAL_8:.*]] = fir.shape %[[VAL_7]] : (index) -> !fir.shape<1>
 ! CHECK:           %[[VAL_9:.*]]:2 = hlfir.declare %[[ARG0]](%[[VAL_8]]) dummy_scope %[[VAL_0]] arg {{[0-9]+}} {uniq_name = "_QMmFtest_explicit_shapeEx"} : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.ref<!fir.array<?xf32>>)
-! CHECK:           %[[VAL_10:.*]] = acc.copyin var(%[[VAL_9]]#0 : !fir.box<!fir.array<?xf32>>) -> !fir.box<!fir.array<?xf32>> {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           %[[VAL_10:.*]] = acc.copyin var(%[[VAL_9]]#0 : !fir.box<!fir.array<?xf32>>) dataClause(acc_copy) name("x") -> !fir.box<!fir.array<?xf32>>
 ! CHECK:           acc.parallel dataOperands(%[[VAL_10]] : !fir.box<!fir.array<?xf32>>) {
 ! CHECK:             %[[VAL_11:.*]] = fir.box_addr %[[VAL_10]] : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
 ! CHECK:             %[[VAL_12:.*]] = fir.dummy_scope : !fir.dscope
@@ -266,7 +266,7 @@ end module
 ! CHECK:             hlfir.end_associate %[[VAL_16]]#1, %[[VAL_16]]#2 : !fir.ref<i32>, i1
 ! CHECK:             acc.yield
 ! CHECK:           }
-! CHECK:           acc.copyout accVar(%[[VAL_10]] : !fir.box<!fir.array<?xf32>>) to var(%[[VAL_9]]#0 : !fir.box<!fir.array<?xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           acc.copyout accVar(%[[VAL_10]] : !fir.box<!fir.array<?xf32>>) to var(%[[VAL_9]]#0 : !fir.box<!fir.array<?xf32>>) dataClause(acc_copy) name("x")
 ! CHECK:           return
 ! CHECK:         }
 
@@ -276,14 +276,14 @@ end module
 ! CHECK:           %[[VAL_0:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK:           %[[VAL_1:.*]]:2 = hlfir.declare %[[ARG1]] dummy_scope %[[VAL_0]] arg {{[0-9]+}} {uniq_name = "_QMmFtest_assumed_shapeEn"} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK:           %[[VAL_2:.*]]:2 = hlfir.declare %[[ARG0]] dummy_scope %[[VAL_0]] arg {{[0-9]+}} {uniq_name = "_QMmFtest_assumed_shapeEx"} : (!fir.box<!fir.array<?xf32>>, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.box<!fir.array<?xf32>>)
-! CHECK:           %[[VAL_3:.*]] = acc.copyin var(%[[VAL_2]]#0 : !fir.box<!fir.array<?xf32>>) -> !fir.box<!fir.array<?xf32>> {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           %[[VAL_3:.*]] = acc.copyin var(%[[VAL_2]]#0 : !fir.box<!fir.array<?xf32>>) dataClause(acc_copy) name("x") -> !fir.box<!fir.array<?xf32>>
 ! CHECK:           acc.parallel dataOperands(%[[VAL_3]] : !fir.box<!fir.array<?xf32>>) {
 ! CHECK:             %[[VAL_4:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK:             %[[VAL_5:.*]]:2 = hlfir.declare %[[VAL_3]] dummy_scope %[[VAL_4]] arg {{[0-9]+}} skip_rebox {uniq_name = "_QMmFtest_assumed_shapeEx"} : (!fir.box<!fir.array<?xf32>>, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.box<!fir.array<?xf32>>)
 ! CHECK:             fir.call @_QPtakes_assumed_shape(%[[VAL_5]]#0) fastmath<contract> : (!fir.box<!fir.array<?xf32>>) -> ()
 ! CHECK:             acc.yield
 ! CHECK:           }
-! CHECK:           acc.copyout accVar(%[[VAL_3]] : !fir.box<!fir.array<?xf32>>) to var(%[[VAL_2]]#0 : !fir.box<!fir.array<?xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           acc.copyout accVar(%[[VAL_3]] : !fir.box<!fir.array<?xf32>>) to var(%[[VAL_2]]#0 : !fir.box<!fir.array<?xf32>>) dataClause(acc_copy) name("x")
 ! CHECK:           return
 ! CHECK:         }
 
@@ -298,7 +298,7 @@ end module
 ! CHECK:           %[[VAL_5:.*]] = arith.constant 1 : index
 ! CHECK:           %[[VAL_6:.*]] = fir.shape_shift %[[VAL_5]], %[[VAL_4]]#1 : (index, index) -> !fir.shapeshift<1>
 ! CHECK:           %[[VAL_7:.*]]:2 = hlfir.declare %[[VAL_2]](%[[VAL_6]]) dummy_scope %[[VAL_0]] arg {{[0-9]+}} {fortran_attrs = #fir.var_attrs<contiguous>, uniq_name = "_QMmFtest_contiguous_assumed_shapeEx"} : (!fir.ref<!fir.array<?xf32>>, !fir.shapeshift<1>, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.ref<!fir.array<?xf32>>)
-! CHECK:           %[[VAL_8:.*]] = acc.copyin var(%[[VAL_7]]#0 : !fir.box<!fir.array<?xf32>>) -> !fir.box<!fir.array<?xf32>> {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           %[[VAL_8:.*]] = acc.copyin var(%[[VAL_7]]#0 : !fir.box<!fir.array<?xf32>>) dataClause(acc_copy) name("x") -> !fir.box<!fir.array<?xf32>>
 ! CHECK:           acc.parallel dataOperands(%[[VAL_8]] : !fir.box<!fir.array<?xf32>>) {
 ! CHECK:             %[[VAL_9:.*]] = fir.box_addr %[[VAL_8]] : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
 ! CHECK:             %[[VAL_10:.*]] = fir.dummy_scope : !fir.dscope
@@ -310,7 +310,7 @@ end module
 ! CHECK:             hlfir.end_associate %[[VAL_14]]#1, %[[VAL_14]]#2 : !fir.ref<i32>, i1
 ! CHECK:             acc.yield
 ! CHECK:           }
-! CHECK:           acc.copyout accVar(%[[VAL_8]] : !fir.box<!fir.array<?xf32>>) to var(%[[VAL_7]]#0 : !fir.box<!fir.array<?xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           acc.copyout accVar(%[[VAL_8]] : !fir.box<!fir.array<?xf32>>) to var(%[[VAL_7]]#0 : !fir.box<!fir.array<?xf32>>) dataClause(acc_copy) name("x")
 ! CHECK:           return
 ! CHECK:         }
 
@@ -320,14 +320,14 @@ end module
 ! CHECK:           %[[VAL_0:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK:           %[[VAL_1:.*]]:2 = hlfir.declare %[[ARG1]] dummy_scope %[[VAL_0]] arg {{[0-9]+}} {uniq_name = "_QMmFtest_pointerEn"} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK:           %[[VAL_2:.*]]:2 = hlfir.declare %[[ARG0]] dummy_scope %[[VAL_0]] arg {{[0-9]+}} {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QMmFtest_pointerEx"} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>)
-! CHECK:           %[[VAL_3:.*]] = acc.copyin varPtr(%[[VAL_2]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>> {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           %[[VAL_3:.*]] = acc.copyin varPtr(%[[VAL_2]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) dataClause(acc_copy) name("x") -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
 ! CHECK:           acc.parallel dataOperands(%[[VAL_3]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) {
 ! CHECK:             %[[VAL_4:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK:             %[[VAL_5:.*]]:2 = hlfir.declare %[[VAL_3]] dummy_scope %[[VAL_4]] arg {{[0-9]+}} {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QMmFtest_pointerEx"} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>)
 ! CHECK:             fir.call @_QPtakes_pointer(%[[VAL_5]]#0) fastmath<contract> : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) -> ()
 ! CHECK:             acc.yield
 ! CHECK:           }
-! CHECK:           acc.copyout accPtr(%[[VAL_3]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) to varPtr(%[[VAL_2]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           acc.copyout accPtr(%[[VAL_3]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) to varPtr(%[[VAL_2]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) dataClause(acc_copy) name("x")
 ! CHECK:           return
 ! CHECK:         }
 
@@ -344,7 +344,7 @@ end module
 ! CHECK:           %[[VAL_7:.*]] = arith.select %[[VAL_6]], %[[VAL_4]], %[[VAL_5]] : index
 ! CHECK:           %[[VAL_8:.*]] = fir.shape %[[VAL_7]] : (index) -> !fir.shape<1>
 ! CHECK:           %[[VAL_9:.*]]:2 = hlfir.declare %[[ARG0]](%[[VAL_8]]) dummy_scope %[[VAL_0]] arg {{[0-9]+}} {uniq_name = "_QMmFtest_using_both_resultsEx"} : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.ref<!fir.array<?xf32>>)
-! CHECK:           %[[VAL_10:.*]] = acc.copyin var(%[[VAL_9]]#0 : !fir.box<!fir.array<?xf32>>) -> !fir.box<!fir.array<?xf32>> {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           %[[VAL_10:.*]] = acc.copyin var(%[[VAL_9]]#0 : !fir.box<!fir.array<?xf32>>) dataClause(acc_copy) name("x") -> !fir.box<!fir.array<?xf32>>
 ! CHECK:           acc.parallel dataOperands(%[[VAL_10]] : !fir.box<!fir.array<?xf32>>) {
 ! CHECK:             %[[VAL_11:.*]] = fir.box_addr %[[VAL_10]] : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
 ! CHECK:             %[[VAL_12:.*]] = fir.dummy_scope : !fir.dscope
@@ -357,7 +357,7 @@ end module
 ! CHECK:             hlfir.end_associate %[[VAL_16]]#1, %[[VAL_16]]#2 : !fir.ref<i32>, i1
 ! CHECK:             acc.yield
 ! CHECK:           }
-! CHECK:           acc.copyout accVar(%[[VAL_10]] : !fir.box<!fir.array<?xf32>>) to var(%[[VAL_9]]#0 : !fir.box<!fir.array<?xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           acc.copyout accVar(%[[VAL_10]] : !fir.box<!fir.array<?xf32>>) to var(%[[VAL_9]]#0 : !fir.box<!fir.array<?xf32>>) dataClause(acc_copy) name("x")
 ! CHECK:           return
 ! CHECK:         }
 
@@ -368,7 +368,7 @@ end module
 ! CHECK:           %[[VAL_2:.*]] = arith.constant 20 : index
 ! CHECK:           %[[VAL_3:.*]] = fir.shape %[[VAL_1]], %[[VAL_2]] : (index, index) -> !fir.shape<2>
 ! CHECK:           %[[VAL_4:.*]]:2 = hlfir.declare %[[ARG0]](%[[VAL_3]]) dummy_scope %[[VAL_0]] arg {{[0-9]+}} {uniq_name = "_QMmFaddressing_cst_shapeEx"} : (!fir.ref<!fir.array<10x20xf32>>, !fir.shape<2>, !fir.dscope) -> (!fir.ref<!fir.array<10x20xf32>>, !fir.ref<!fir.array<10x20xf32>>)
-! CHECK:           %[[VAL_5:.*]] = acc.copyin varPtr(%[[VAL_4]]#0 : !fir.ref<!fir.array<10x20xf32>>) -> !fir.ref<!fir.array<10x20xf32>> {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           %[[VAL_5:.*]] = acc.copyin varPtr(%[[VAL_4]]#0 : !fir.ref<!fir.array<10x20xf32>>) dataClause(acc_copy) name("x") -> !fir.ref<!fir.array<10x20xf32>>
 ! CHECK:           acc.parallel dataOperands(%[[VAL_5]] : !fir.ref<!fir.array<10x20xf32>>) {
 ! CHECK:             %[[VAL_6:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK:             %[[VAL_7:.*]]:2 = hlfir.declare %[[VAL_5]](%[[VAL_3]]) dummy_scope %[[VAL_6]] {{.*}} {uniq_name = "_QMmFaddressing_cst_shapeEx"} : (!fir.ref<!fir.array<10x20xf32>>, !fir.shape<2>, !fir.dscope) -> (!fir.ref<!fir.array<10x20xf32>>, !fir.ref<!fir.array<10x20xf32>>)
@@ -378,7 +378,7 @@ end module
 ! CHECK:             fir.call @_QPtakes_scalar(%[[VAL_10]]) fastmath<contract> : (!fir.ref<f32>) -> ()
 ! CHECK:             acc.yield
 ! CHECK:           }
-! CHECK:           acc.copyout accPtr(%[[VAL_5]] : !fir.ref<!fir.array<10x20xf32>>) to varPtr(%[[VAL_4]]#0 : !fir.ref<!fir.array<10x20xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           acc.copyout accPtr(%[[VAL_5]] : !fir.ref<!fir.array<10x20xf32>>) to varPtr(%[[VAL_4]]#0 : !fir.ref<!fir.array<10x20xf32>>) dataClause(acc_copy) name("x")
 ! CHECK:           return
 ! CHECK:         }
 
@@ -403,7 +403,7 @@ end module
 ! CHECK:           %[[VAL_14:.*]] = arith.select %[[VAL_13]], %[[VAL_11]], %[[VAL_12]] : index
 ! CHECK:           %[[VAL_15:.*]] = fir.shape %[[VAL_8]], %[[VAL_14]] : (index, index) -> !fir.shape<2>
 ! CHECK:           %[[VAL_16:.*]]:2 = hlfir.declare %[[ARG0]](%[[VAL_15]]) dummy_scope %[[VAL_0]] arg {{[0-9]+}} {uniq_name = "_QMmFaddressing_explicit_shapeEx"} : (!fir.ref<!fir.array<?x?xf32>>, !fir.shape<2>, !fir.dscope) -> (!fir.box<!fir.array<?x?xf32>>, !fir.ref<!fir.array<?x?xf32>>)
-! CHECK:           %[[VAL_17:.*]] = acc.copyin var(%[[VAL_16]]#0 : !fir.box<!fir.array<?x?xf32>>) -> !fir.box<!fir.array<?x?xf32>> {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           %[[VAL_17:.*]] = acc.copyin var(%[[VAL_16]]#0 : !fir.box<!fir.array<?x?xf32>>) dataClause(acc_copy) name("x") -> !fir.box<!fir.array<?x?xf32>>
 ! CHECK:           acc.parallel dataOperands(%[[VAL_17]] : !fir.box<!fir.array<?x?xf32>>) {
 ! CHECK:             %[[VAL_18:.*]] = fir.box_addr %[[VAL_17]] : (!fir.box<!fir.array<?x?xf32>>) -> !fir.ref<!fir.array<?x?xf32>>
 ! CHECK:             %[[VAL_19:.*]] = fir.dummy_scope : !fir.dscope
@@ -414,7 +414,7 @@ end module
 ! CHECK:             fir.call @_QPtakes_scalar(%[[VAL_23]]) fastmath<contract> : (!fir.ref<f32>) -> ()
 ! CHECK:             acc.yield
 ! CHECK:           }
-! CHECK:           acc.copyout accVar(%[[VAL_17]] : !fir.box<!fir.array<?x?xf32>>) to var(%[[VAL_16]]#0 : !fir.box<!fir.array<?x?xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           acc.copyout accVar(%[[VAL_17]] : !fir.box<!fir.array<?x?xf32>>) to var(%[[VAL_16]]#0 : !fir.box<!fir.array<?x?xf32>>) dataClause(acc_copy) name("x")
 ! CHECK:           return
 ! CHECK:         }
 
@@ -424,7 +424,7 @@ end module
 ! CHECK:           %[[VAL_0:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK:           %[[VAL_1:.*]]:2 = hlfir.declare %[[ARG1]] dummy_scope %[[VAL_0]] arg {{[0-9]+}} {uniq_name = "_QMmFaddressing_assumed_shapeEn"} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK:           %[[VAL_2:.*]]:2 = hlfir.declare %[[ARG0]] dummy_scope %[[VAL_0]] arg {{[0-9]+}} {uniq_name = "_QMmFaddressing_assumed_shapeEx"} : (!fir.box<!fir.array<?x?xf32>>, !fir.dscope) -> (!fir.box<!fir.array<?x?xf32>>, !fir.box<!fir.array<?x?xf32>>)
-! CHECK:           %[[VAL_3:.*]] = acc.copyin var(%[[VAL_2]]#0 : !fir.box<!fir.array<?x?xf32>>) -> !fir.box<!fir.array<?x?xf32>> {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           %[[VAL_3:.*]] = acc.copyin var(%[[VAL_2]]#0 : !fir.box<!fir.array<?x?xf32>>) dataClause(acc_copy) name("x") -> !fir.box<!fir.array<?x?xf32>>
 ! CHECK:           acc.parallel dataOperands(%[[VAL_3]] : !fir.box<!fir.array<?x?xf32>>) {
 ! CHECK:             %[[VAL_4:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK:             %[[VAL_5:.*]]:2 = hlfir.declare %[[VAL_3]] dummy_scope %[[VAL_4]] arg {{[0-9]+}} skip_rebox {uniq_name = "_QMmFaddressing_assumed_shapeEx"} : (!fir.box<!fir.array<?x?xf32>>, !fir.dscope) -> (!fir.box<!fir.array<?x?xf32>>, !fir.box<!fir.array<?x?xf32>>)
@@ -434,7 +434,7 @@ end module
 ! CHECK:             fir.call @_QPtakes_scalar(%[[VAL_8]]) fastmath<contract> : (!fir.ref<f32>) -> ()
 ! CHECK:             acc.yield
 ! CHECK:           }
-! CHECK:           acc.copyout accVar(%[[VAL_3]] : !fir.box<!fir.array<?x?xf32>>) to var(%[[VAL_2]]#0 : !fir.box<!fir.array<?x?xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           acc.copyout accVar(%[[VAL_3]] : !fir.box<!fir.array<?x?xf32>>) to var(%[[VAL_2]]#0 : !fir.box<!fir.array<?x?xf32>>) dataClause(acc_copy) name("x")
 ! CHECK:           return
 ! CHECK:         }
 
@@ -452,7 +452,7 @@ end module
 ! CHECK:           %[[VAL_8:.*]] = arith.constant 1 : index
 ! CHECK:           %[[VAL_9:.*]] = fir.shape_shift %[[VAL_5]], %[[VAL_4]]#1, %[[VAL_8]], %[[VAL_7]]#1 : (index, index, index, index) -> !fir.shapeshift<2>
 ! CHECK:           %[[VAL_10:.*]]:2 = hlfir.declare %[[VAL_2]](%[[VAL_9]]) dummy_scope %[[VAL_0]] arg {{[0-9]+}} {fortran_attrs = #fir.var_attrs<contiguous>, uniq_name = "_QMmFaddressing_contiguous_assumed_shapeEx"} : (!fir.ref<!fir.array<?x?xf32>>, !fir.shapeshift<2>, !fir.dscope) -> (!fir.box<!fir.array<?x?xf32>>, !fir.ref<!fir.array<?x?xf32>>)
-! CHECK:           %[[VAL_11:.*]] = acc.copyin var(%[[VAL_10]]#0 : !fir.box<!fir.array<?x?xf32>>) -> !fir.box<!fir.array<?x?xf32>> {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           %[[VAL_11:.*]] = acc.copyin var(%[[VAL_10]]#0 : !fir.box<!fir.array<?x?xf32>>) dataClause(acc_copy) name("x") -> !fir.box<!fir.array<?x?xf32>>
 ! CHECK:           acc.parallel dataOperands(%[[VAL_11]] : !fir.box<!fir.array<?x?xf32>>) {
 ! CHECK:             %[[VAL_12:.*]] = fir.box_addr %[[VAL_11]] : (!fir.box<!fir.array<?x?xf32>>) -> !fir.ref<!fir.array<?x?xf32>>
 ! CHECK:             %[[VAL_13:.*]] = fir.dummy_scope : !fir.dscope
@@ -463,7 +463,7 @@ end module
 ! CHECK:             fir.call @_QPtakes_scalar(%[[VAL_17]]) fastmath<contract> : (!fir.ref<f32>) -> ()
 ! CHECK:             acc.yield
 ! CHECK:           }
-! CHECK:           acc.copyout accVar(%[[VAL_11]] : !fir.box<!fir.array<?x?xf32>>) to var(%[[VAL_10]]#0 : !fir.box<!fir.array<?x?xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           acc.copyout accVar(%[[VAL_11]] : !fir.box<!fir.array<?x?xf32>>) to var(%[[VAL_10]]#0 : !fir.box<!fir.array<?x?xf32>>) dataClause(acc_copy) name("x")
 ! CHECK:           return
 ! CHECK:         }
 
@@ -471,7 +471,7 @@ end module
 ! CHECK-SAME:      %[[ARG0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>> {fir.bindc_name = "x"}) {
 ! CHECK:           %[[VAL_0:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK:           %[[VAL_1:.*]]:2 = hlfir.declare %[[ARG0]] dummy_scope %[[VAL_0]] arg {{[0-9]+}} {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QMmFaddressing_pointerEx"} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>)
-! CHECK:           %[[VAL_2:.*]] = acc.copyin varPtr(%[[VAL_1]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>> {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           %[[VAL_2:.*]] = acc.copyin varPtr(%[[VAL_1]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>) dataClause(acc_copy) name("x") -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>
 ! CHECK:           acc.parallel dataOperands(%[[VAL_2]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>) {
 ! CHECK:             %[[VAL_3:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK:             %[[VAL_4:.*]]:2 = hlfir.declare %[[VAL_2]] dummy_scope %[[VAL_3]] arg {{[0-9]+}} {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QMmFaddressing_pointerEx"} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>)
@@ -482,7 +482,7 @@ end module
 ! CHECK:             fir.call @_QPtakes_scalar(%[[VAL_8]]) fastmath<contract> : (!fir.ref<f32>) -> ()
 ! CHECK:             acc.yield
 ! CHECK:           }
-! CHECK:           acc.copyout accPtr(%[[VAL_2]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>) to varPtr(%[[VAL_1]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>) {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           acc.copyout accPtr(%[[VAL_2]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>) to varPtr(%[[VAL_1]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>) dataClause(acc_copy) name("x")
 ! CHECK:           return
 ! CHECK:         }
 
@@ -490,7 +490,7 @@ end module
 ! CHECK-SAME:      %[[ARG0:.*]]: !fir.ref<f32> {fir.bindc_name = "x", fir.optional}) {
 ! CHECK:           %[[VAL_0:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK:           %[[VAL_1:.*]]:2 = hlfir.declare %[[ARG0]] dummy_scope %[[VAL_0]] arg {{[0-9]+}} {fortran_attrs = #fir.var_attrs<optional>, uniq_name = "_QMmFtest_optional_scalarEx"} : (!fir.ref<f32>, !fir.dscope) -> (!fir.ref<f32>, !fir.ref<f32>)
-! CHECK:           %[[VAL_2:.*]] = acc.copyin varPtr(%[[VAL_1]]#0 : !fir.ref<f32>) -> !fir.ref<f32> {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           %[[VAL_2:.*]] = acc.copyin varPtr(%[[VAL_1]]#0 : !fir.ref<f32>) dataClause(acc_copy) name("x") -> !fir.ref<f32>
 ! CHECK:           acc.parallel dataOperands(%[[VAL_2]] : !fir.ref<f32>) {
 ! CHECK:             %[[VAL_3:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK:             %[[VAL_4:.*]]:2 = hlfir.declare %[[VAL_2]] dummy_scope %[[VAL_3]] arg {{[0-9]+}} {fortran_attrs = #fir.var_attrs<optional>, uniq_name = "_QMmFtest_optional_scalarEx"} : (!fir.ref<f32>, !fir.dscope) -> (!fir.ref<f32>, !fir.ref<f32>)
@@ -504,7 +504,7 @@ end module
 ! CHECK:             fir.call @_QPtakes_optional_scalar(%[[VAL_6]]) fastmath<contract> : (!fir.ref<f32>) -> ()
 ! CHECK:             acc.yield
 ! CHECK:           }
-! CHECK:           acc.copyout accPtr(%[[VAL_2]] : !fir.ref<f32>) to varPtr(%[[VAL_1]]#0 : !fir.ref<f32>) {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           acc.copyout accPtr(%[[VAL_2]] : !fir.ref<f32>) to varPtr(%[[VAL_1]]#0 : !fir.ref<f32>) dataClause(acc_copy) name("x")
 ! CHECK:           return
 ! CHECK:         }
 
@@ -514,7 +514,7 @@ end module
 ! CHECK:           %[[VAL_1:.*]] = arith.constant 100 : index
 ! CHECK:           %[[VAL_2:.*]] = fir.shape %[[VAL_1]] : (index) -> !fir.shape<1>
 ! CHECK:           %[[VAL_3:.*]]:2 = hlfir.declare %[[ARG0]](%[[VAL_2]]) dummy_scope %[[VAL_0]] arg {{[0-9]+}} {fortran_attrs = #fir.var_attrs<optional>, uniq_name = "_QMmFtest_optional_explicit_cst_shapeEx"} : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>, !fir.dscope) -> (!fir.ref<!fir.array<100xf32>>, !fir.ref<!fir.array<100xf32>>)
-! CHECK:           %[[VAL_4:.*]] = acc.copyin varPtr(%[[VAL_3]]#0 : !fir.ref<!fir.array<100xf32>>) -> !fir.ref<!fir.array<100xf32>> {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           %[[VAL_4:.*]] = acc.copyin varPtr(%[[VAL_3]]#0 : !fir.ref<!fir.array<100xf32>>) dataClause(acc_copy) name("x") -> !fir.ref<!fir.array<100xf32>>
 ! CHECK:           acc.parallel dataOperands(%[[VAL_4]] : !fir.ref<!fir.array<100xf32>>) {
 ! CHECK:             %[[VAL_5:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK:             %[[VAL_6:.*]]:2 = hlfir.declare %[[VAL_4]](%[[VAL_2]]) dummy_scope %[[VAL_5]] arg {{[0-9]+}} {fortran_attrs = #fir.var_attrs<optional>, uniq_name = "_QMmFtest_optional_explicit_cst_shapeEx"} : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>, !fir.dscope) -> (!fir.ref<!fir.array<100xf32>>, !fir.ref<!fir.array<100xf32>>)
@@ -528,7 +528,7 @@ end module
 ! CHECK:             fir.call @_QPtakes_optional_explicit_cst_shape(%[[VAL_8]]) fastmath<contract> : (!fir.ref<!fir.array<100xf32>>) -> ()
 ! CHECK:             acc.yield
 ! CHECK:           }
-! CHECK:           acc.copyout accPtr(%[[VAL_4]] : !fir.ref<!fir.array<100xf32>>) to varPtr(%[[VAL_3]]#0 : !fir.ref<!fir.array<100xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           acc.copyout accPtr(%[[VAL_4]] : !fir.ref<!fir.array<100xf32>>) to varPtr(%[[VAL_3]]#0 : !fir.ref<!fir.array<100xf32>>) dataClause(acc_copy) name("x")
 ! CHECK:           return
 ! CHECK:         }
 
@@ -545,7 +545,7 @@ end module
 ! CHECK:           %[[VAL_7:.*]] = arith.select %[[VAL_6]], %[[VAL_4]], %[[VAL_5]] : index
 ! CHECK:           %[[VAL_8:.*]] = fir.shape %[[VAL_7]] : (index) -> !fir.shape<1>
 ! CHECK:           %[[VAL_9:.*]]:2 = hlfir.declare %[[ARG0]](%[[VAL_8]]) dummy_scope %[[VAL_0]] arg {{[0-9]+}} {fortran_attrs = #fir.var_attrs<optional>, uniq_name = "_QMmFtest_optional_explicit_shapeEx"} : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.ref<!fir.array<?xf32>>)
-! CHECK:           %[[VAL_10:.*]] = acc.copyin varPtr(%[[VAL_9]]#1 : !fir.ref<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>> {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           %[[VAL_10:.*]] = acc.copyin varPtr(%[[VAL_9]]#1 : !fir.ref<!fir.array<?xf32>>) dataClause(acc_copy) name("x") -> !fir.ref<!fir.array<?xf32>>
 ! CHECK:           acc.parallel dataOperands(%[[VAL_10]] : !fir.ref<!fir.array<?xf32>>) {
 ! CHECK:             %[[VAL_11:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK:             %[[VAL_12:.*]]:2 = hlfir.declare %[[VAL_10]](%[[VAL_8]]) dummy_scope %[[VAL_11]] {{.*}} {fortran_attrs = #fir.var_attrs<optional>, uniq_name = "_QMmFtest_optional_explicit_shapeEx"} : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.ref<!fir.array<?xf32>>)
@@ -559,7 +559,7 @@ end module
 ! CHECK:             fir.call @_QPtakes_optional_explicit_shape(%[[VAL_14]], %[[VAL_1]]#0) fastmath<contract> : (!fir.ref<!fir.array<?xf32>>, !fir.ref<i32>) -> ()
 ! CHECK:             acc.yield
 ! CHECK:           }
-! CHECK:           acc.copyout accPtr(%[[VAL_10]] : !fir.ref<!fir.array<?xf32>>) to varPtr(%[[VAL_9]]#1 : !fir.ref<!fir.array<?xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           acc.copyout accPtr(%[[VAL_10]] : !fir.ref<!fir.array<?xf32>>) to varPtr(%[[VAL_9]]#1 : !fir.ref<!fir.array<?xf32>>) dataClause(acc_copy) name("x")
 ! CHECK:           return
 ! CHECK:         }
 
@@ -567,7 +567,7 @@ end module
 ! CHECK-SAME:      %[[ARG0:.*]]: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x", fir.optional}) {
 ! CHECK:           %[[VAL_0:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK:           %[[VAL_1:.*]]:2 = hlfir.declare %[[ARG0]] dummy_scope %[[VAL_0]] arg {{[0-9]+}} {fortran_attrs = #fir.var_attrs<optional>, uniq_name = "_QMmFtest_optional_assumed_shapeEx"} : (!fir.box<!fir.array<?xf32>>, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.box<!fir.array<?xf32>>)
-! CHECK:           %[[VAL_2:.*]] = acc.copyin var(%[[VAL_1]]#0 : !fir.box<!fir.array<?xf32>>) -> !fir.box<!fir.array<?xf32>> {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           %[[VAL_2:.*]] = acc.copyin var(%[[VAL_1]]#0 : !fir.box<!fir.array<?xf32>>) dataClause(acc_copy) name("x") -> !fir.box<!fir.array<?xf32>>
 ! CHECK:           acc.parallel dataOperands(%[[VAL_2]] : !fir.box<!fir.array<?xf32>>) {
 ! CHECK:             %[[VAL_3:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK:             %[[VAL_4:.*]]:2 = hlfir.declare %[[VAL_2]] dummy_scope %[[VAL_3]] arg {{[0-9]+}} skip_rebox {fortran_attrs = #fir.var_attrs<optional>, uniq_name = "_QMmFtest_optional_assumed_shapeEx"} : (!fir.box<!fir.array<?xf32>>, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.box<!fir.array<?xf32>>)
@@ -581,7 +581,7 @@ end module
 ! CHECK:             fir.call @_QPtakes_optional_assumed_shape(%[[VAL_6]]) fastmath<contract> : (!fir.box<!fir.array<?xf32>>) -> ()
 ! CHECK:             acc.yield
 ! CHECK:           }
-! CHECK:           acc.copyout accVar(%[[VAL_2]] : !fir.box<!fir.array<?xf32>>) to var(%[[VAL_1]]#0 : !fir.box<!fir.array<?xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           acc.copyout accVar(%[[VAL_2]] : !fir.box<!fir.array<?xf32>>) to var(%[[VAL_1]]#0 : !fir.box<!fir.array<?xf32>>) dataClause(acc_copy) name("x")
 ! CHECK:           return
 ! CHECK:         }
 
@@ -589,13 +589,13 @@ end module
 ! CHECK-SAME:      %[[ARG0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>> {fir.bindc_name = "x", fir.optional}) {
 ! CHECK:           %[[VAL_0:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK:           %[[VAL_1:.*]]:2 = hlfir.declare %[[ARG0]] dummy_scope %[[VAL_0]] arg {{[0-9]+}} {fortran_attrs = #fir.var_attrs<optional, pointer>, uniq_name = "_QMmFtest_optional_pointerEx"} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>)
-! CHECK:           %[[VAL_2:.*]] = acc.copyin varPtr(%[[VAL_1]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>> {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           %[[VAL_2:.*]] = acc.copyin varPtr(%[[VAL_1]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) dataClause(acc_copy) name("x") -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
 ! CHECK:           acc.parallel dataOperands(%[[VAL_2]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) {
 ! CHECK:             %[[VAL_3:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK:             %[[VAL_4:.*]]:2 = hlfir.declare %[[VAL_2]] dummy_scope %[[VAL_3]] arg {{[0-9]+}} {fortran_attrs = #fir.var_attrs<optional, pointer>, uniq_name = "_QMmFtest_optional_pointerEx"} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>)
 ! CHECK:             fir.call @_QPtakes_optional_pointer(%[[VAL_4]]#0) fastmath<contract> : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) -> ()
 ! CHECK:             acc.yield
 ! CHECK:           }
-! CHECK:           acc.copyout accPtr(%[[VAL_2]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) to varPtr(%[[VAL_1]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) {dataClause = #acc<data_clause acc_copy>, name = "x"}
+! CHECK:           acc.copyout accPtr(%[[VAL_2]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) to varPtr(%[[VAL_1]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) dataClause(acc_copy) name("x")
 ! CHECK:           return
 ! CHECK:         }

--- a/flang/test/Lower/OpenACC/acc-data-operands.f90
+++ b/flang/test/Lower/OpenACC/acc-data-operands.f90
@@ -26,17 +26,17 @@ end subroutine
 ! CHECK: %[[LB:.*]] = arith.constant 0 : index
 ! CHECK: %[[UB:.*]] = arith.constant 49 : index
 ! CHECK: %[[BOUND_1_50:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%[[EXT]] : index) stride(%[[ONE]] : index) startIdx(%[[ONE]] : index)
-! CHECK: %[[COPYIN:.*]] = acc.copyin varPtr(%[[DECL]]#0 : !fir.ref<!fir.array<100xf32>>) bounds(%[[BOUND_1_50]]) -> !fir.ref<!fir.array<100xf32>> {name = "a(1:50)"}
+! CHECK: %[[COPYIN:.*]] = acc.copyin varPtr(%[[DECL]]#0 : !fir.ref<!fir.array<100xf32>>) bounds(%[[BOUND_1_50]]) name("a(1:50)") -> !fir.ref<!fir.array<100xf32>>
 ! CHECK: %[[ONE:.*]] = arith.constant 1 : index
 ! CHECK: %[[LB:.*]] = arith.constant 50 : index
 ! CHECK: %[[UB:.*]] = arith.constant 99 : index
 ! CHECK: %[[BOUND_51_100:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%[[EXT]] : index) stride(%[[ONE]] : index) startIdx(%[[ONE]] : index)
-! CHECK: %[[COPYOUT_CREATE:.*]] = acc.create varPtr(%[[DECL]]#0 : !fir.ref<!fir.array<100xf32>>) bounds(%[[BOUND_51_100]]) -> !fir.ref<!fir.array<100xf32>> {dataClause = #acc<data_clause acc_copyout>, name = "a(51:100)"}
+! CHECK: %[[COPYOUT_CREATE:.*]] = acc.create varPtr(%[[DECL]]#0 : !fir.ref<!fir.array<100xf32>>) bounds(%[[BOUND_51_100]]) dataClause(acc_copyout) name("a(51:100)") -> !fir.ref<!fir.array<100xf32>>
 ! CHECK: acc.data dataOperands(%[[COPYIN]], %[[COPYOUT_CREATE]] : !fir.ref<!fir.array<100xf32>>, !fir.ref<!fir.array<100xf32>>) {
 ! CHECK:   acc.terminator
 ! CHECK: }
-! CHECK: acc.delete accPtr(%[[COPYIN]] : !fir.ref<!fir.array<100xf32>>) bounds(%[[BOUND_1_50]]) {dataClause = #acc<data_clause acc_copyin>, name = "a(1:50)"}
-! CHECK: acc.copyout accPtr(%[[COPYOUT_CREATE]] : !fir.ref<!fir.array<100xf32>>) bounds(%[[BOUND_51_100]]) to varPtr(%[[DECL]]#0 : !fir.ref<!fir.array<100xf32>>) {name = "a(51:100)"}
+! CHECK: acc.delete accPtr(%[[COPYIN]] : !fir.ref<!fir.array<100xf32>>) bounds(%[[BOUND_1_50]]) dataClause(acc_copyin) name("a(1:50)")
+! CHECK: acc.copyout accPtr(%[[COPYOUT_CREATE]] : !fir.ref<!fir.array<100xf32>>) bounds(%[[BOUND_51_100]]) to varPtr(%[[DECL]]#0 : !fir.ref<!fir.array<100xf32>>) name("a(51:100)")
 
 ! Testing array sections of a derived-type component
 subroutine acc_operand_array_section_component()
@@ -56,11 +56,11 @@ end subroutine
 ! CHECK: %[[LB:.*]] = arith.constant 0 : index
 ! CHECK: %[[UB:.*]] = arith.constant 19 : index
 ! CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%[[EXT]] : index) stride(%[[ONE]] : index) startIdx(%[[ONE]] : index)
-! CHECK: %[[COPY_COPYIN:.*]] = acc.copyin varPtr(%[[COORD_DATA]] : !fir.ref<!fir.array<100xf32>>) bounds(%[[BOUND]]) -> !fir.ref<!fir.array<100xf32>> {dataClause = #acc<data_clause acc_copy>, name = "w%data(1:20)"}
+! CHECK: %[[COPY_COPYIN:.*]] = acc.copyin varPtr(%[[COORD_DATA]] : !fir.ref<!fir.array<100xf32>>) bounds(%[[BOUND]]) dataClause(acc_copy) name("w%data(1:20)") -> !fir.ref<!fir.array<100xf32>>
 ! CHECK: acc.data dataOperands(%[[COPY_COPYIN]] : !fir.ref<!fir.array<100xf32>>) {
 ! CHECK:   acc.terminator
 ! CHECK: }
-! CHECK: acc.copyout accPtr(%[[COPY_COPYIN]] : !fir.ref<!fir.array<100xf32>>) bounds(%[[BOUND]]) to varPtr(%[[COORD_DATA]] : !fir.ref<!fir.array<100xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "w%data(1:20)"}
+! CHECK: acc.copyout accPtr(%[[COPY_COPYIN]] : !fir.ref<!fir.array<100xf32>>) bounds(%[[BOUND]]) to varPtr(%[[COORD_DATA]] : !fir.ref<!fir.array<100xf32>>) dataClause(acc_copy) name("w%data(1:20)")
 
 ! Testing derived-type component without section
 subroutine acc_operand_derived_type_component()
@@ -74,11 +74,11 @@ end subroutine
 ! CHECK: %[[W:.*]] = fir.alloca !fir.type<_QMacc_data_operandTwrapper{data:!fir.array<100xf32>}> {bindc_name = "w", uniq_name = "_QMacc_data_operandFacc_operand_derived_type_componentEw"}
 ! CHECK: %[[DECLW:.*]]:2 = hlfir.declare %[[W]]
 ! CHECK: %[[COORD_DATA:.*]] = hlfir.designate %[[DECLW]]#0{"data"}   shape %{{.*}} : (!fir.ref<!fir.type<_QMacc_data_operandTwrapper{data:!fir.array<100xf32>}>>, !fir.shape<1>) -> !fir.ref<!fir.array<100xf32>>
-! CHECK: %[[COPY_COPYIN:.*]] = acc.copyin varPtr(%[[COORD_DATA]] : !fir.ref<!fir.array<100xf32>>) -> !fir.ref<!fir.array<100xf32>> {dataClause = #acc<data_clause acc_copy>, name = "w%data"}
+! CHECK: %[[COPY_COPYIN:.*]] = acc.copyin varPtr(%[[COORD_DATA]] : !fir.ref<!fir.array<100xf32>>) dataClause(acc_copy) name("w%data") -> !fir.ref<!fir.array<100xf32>>
 ! CHECK: acc.data dataOperands(%[[COPY_COPYIN]] : !fir.ref<!fir.array<100xf32>>) {
 ! CHECK:   acc.terminator
 ! CHECK: }
-! CHECK: acc.copyout accPtr(%[[COPY_COPYIN]] : !fir.ref<!fir.array<100xf32>>) to varPtr(%[[COORD_DATA]] : !fir.ref<!fir.array<100xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "w%data"}
+! CHECK: acc.copyout accPtr(%[[COPY_COPYIN]] : !fir.ref<!fir.array<100xf32>>) to varPtr(%[[COORD_DATA]] : !fir.ref<!fir.array<100xf32>>) dataClause(acc_copy) name("w%data")
 
 
 ! Testing array of derived-type component without section
@@ -95,11 +95,11 @@ end subroutine
 ! CHECK: %[[C1:.*]] = arith.constant 1 : index
 ! CHECK: %[[W_1:.*]] = hlfir.designate %[[DECLW]]#0 (%[[C1]])  : (!fir.ref<!fir.array<10x!fir.type<_QMacc_data_operandTwrapper{data:!fir.array<100xf32>}>>>, index) -> !fir.ref<!fir.type<_QMacc_data_operandTwrapper{data:!fir.array<100xf32>}>>
 ! CHECK: %[[COORD_W1_DATA:.*]] = hlfir.designate %[[W_1]]{"data"}   shape %{{.*}} : (!fir.ref<!fir.type<_QMacc_data_operandTwrapper{data:!fir.array<100xf32>}>>, !fir.shape<1>) -> !fir.ref<!fir.array<100xf32>>
-! CHECK: %[[COPY_COPYIN:.*]] = acc.copyin varPtr(%[[COORD_W1_DATA]] : !fir.ref<!fir.array<100xf32>>) -> !fir.ref<!fir.array<100xf32>> {dataClause = #acc<data_clause acc_copy>, name = "w(1_8)%data"}
+! CHECK: %[[COPY_COPYIN:.*]] = acc.copyin varPtr(%[[COORD_W1_DATA]] : !fir.ref<!fir.array<100xf32>>) dataClause(acc_copy) name("w(1_8)%data") -> !fir.ref<!fir.array<100xf32>>
 ! CHECK: acc.data dataOperands(%[[COPY_COPYIN]] : !fir.ref<!fir.array<100xf32>>) {
 ! CHECK:   acc.terminator
 ! CHECK: }
-! CHECK: acc.copyout accPtr(%[[COPY_COPYIN]] : !fir.ref<!fir.array<100xf32>>) to varPtr(%[[COORD_W1_DATA]] : !fir.ref<!fir.array<100xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "w(1_8)%data"}
+! CHECK: acc.copyout accPtr(%[[COPY_COPYIN]] : !fir.ref<!fir.array<100xf32>>) to varPtr(%[[COORD_W1_DATA]] : !fir.ref<!fir.array<100xf32>>) dataClause(acc_copy) name("w(1_8)%data")
 
 ! Testing array sections on allocatable array
 subroutine acc_operand_array_section_allocatable()
@@ -129,8 +129,8 @@ end subroutine
 ! CHECK: %[[LOAD_BOX_A_2:.*]] = fir.load %[[DECLA]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
 ! CHECK: %[[C0:.*]] = arith.constant 0 : index
 ! CHECK: %[[DIMS0_2:.*]]:3 = fir.box_dims %[[LOAD_BOX_A_2]], %[[C0]] : (!fir.box<!fir.heap<!fir.array<?xf32>>>, index) -> (index, index, index)
-! CHECK: %[[BOUND_1_50:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%[[DIMS0_2]]#1 : index) stride(%[[DIMS0_1]]#2 : index) startIdx(%[[DIMS0_0]]#0 : index) {strideInBytes = true}
-! CHECK: %[[COPYIN:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) bounds(%[[BOUND_1_50]]) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>> {name = "a(1:50)"}
+! CHECK: %[[BOUND_1_50:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%[[DIMS0_2]]#1 : index) stride(%[[DIMS0_1]]#2 : index) startIdx(%[[DIMS0_0]]#0 : index) strideInBytes(true)
+! CHECK: %[[COPYIN:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) bounds(%[[BOUND_1_50]]) name("a(1:50)") -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
 ! CHECK: %[[LOAD_BOX_A_1:.*]] = fir.load %[[DECLA]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
 ! CHECK: %[[C0:.*]] = arith.constant 0 : index
 ! CHECK: %[[DIMS0_0:.*]]:3 = fir.box_dims %[[LOAD_BOX_A_1]], %[[C0]] : (!fir.box<!fir.heap<!fir.array<?xf32>>>, index) -> (index, index, index)
@@ -144,13 +144,13 @@ end subroutine
 ! CHECK: %[[LOAD_BOX_A_2:.*]] = fir.load %[[DECLA]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
 ! CHECK: %[[C0:.*]] = arith.constant 0 : index
 ! CHECK: %[[DIMS0_2:.*]]:3 = fir.box_dims %[[LOAD_BOX_A_2]], %[[C0]] : (!fir.box<!fir.heap<!fir.array<?xf32>>>, index) -> (index, index, index)
-! CHECK: %[[BOUND_51_100:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%[[DIMS0_2]]#1 : index) stride(%[[DIMS0_1]]#2 : index) startIdx(%[[DIMS0_0]]#0 : index) {strideInBytes = true}
-! CHECK: %[[COPYOUT_CREATE:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) bounds(%[[BOUND_51_100]]) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>> {dataClause = #acc<data_clause acc_copyout>, name = "a(51:100)"}
+! CHECK: %[[BOUND_51_100:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%[[DIMS0_2]]#1 : index) stride(%[[DIMS0_1]]#2 : index) startIdx(%[[DIMS0_0]]#0 : index) strideInBytes(true)
+! CHECK: %[[COPYOUT_CREATE:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) bounds(%[[BOUND_51_100]]) dataClause(acc_copyout) name("a(51:100)") -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
 ! CHECK: acc.data dataOperands(%[[COPYIN]], %[[COPYOUT_CREATE]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) {
 ! CHECK:   acc.terminator
 ! CHECK: }
-! CHECK: acc.delete accPtr(%[[COPYIN]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) bounds(%[[BOUND_1_50]]) {dataClause = #acc<data_clause acc_copyin>, name = "a(1:50)"}
-! CHECK: acc.copyout accPtr(%[[COPYOUT_CREATE]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) bounds(%[[BOUND_51_100]]) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) {name = "a(51:100)"}
+! CHECK: acc.delete accPtr(%[[COPYIN]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) bounds(%[[BOUND_1_50]]) dataClause(acc_copyin) name("a(1:50)")
+! CHECK: acc.copyout accPtr(%[[COPYOUT_CREATE]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) bounds(%[[BOUND_51_100]]) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) name("a(51:100)")
 
 
 ! Testing array sections on pointer array
@@ -180,11 +180,11 @@ end subroutine
 ! CHECK: %[[LOAD_BOX_P_2:.*]] = fir.load %[[DECLP]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
 ! CHECK: %[[C0:.*]] = arith.constant 0 : index
 ! CHECK: %[[DIMS0_2:.*]]:3 = fir.box_dims %[[LOAD_BOX_P_2]], %[[C0]] : (!fir.box<!fir.ptr<!fir.array<?xf32>>>, index) -> (index, index, index)
-! CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%[[DIMS0_2]]#1 : index) stride(%[[DIMS0_1]]#2 : index) startIdx(%[[DIMS0_0]]#0 : index) {strideInBytes = true}
-! CHECK: %[[COPYIN:.*]] = acc.copyin varPtr(%[[DECLP]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) bounds(%[[BOUND]]) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>> {name = "p(1:50)"}
+! CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%[[DIMS0_2]]#1 : index) stride(%[[DIMS0_1]]#2 : index) startIdx(%[[DIMS0_0]]#0 : index) strideInBytes(true)
+! CHECK: %[[COPYIN:.*]] = acc.copyin varPtr(%[[DECLP]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) bounds(%[[BOUND]]) name("p(1:50)") -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
 ! CHECK: acc.data dataOperands(%[[COPYIN]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) {
 ! CHECK:   acc.terminator
 ! CHECK: }
-! CHECK: acc.delete accPtr(%[[COPYIN]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) bounds(%[[BOUND]]) {dataClause = #acc<data_clause acc_copyin>, name = "p(1:50)"}
+! CHECK: acc.delete accPtr(%[[COPYIN]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) bounds(%[[BOUND]]) dataClause(acc_copyin) name("p(1:50)")
 
 end module

--- a/flang/test/Lower/OpenACC/acc-data.f90
+++ b/flang/test/Lower/OpenACC/acc-data.f90
@@ -22,112 +22,112 @@ subroutine acc_data
   !$acc end data
 
 ! CHECK:      %[[IF1:.*]] = arith.constant true
-! CHECK:     %[[COPYIN:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "a"}
+! CHECK:     %[[COPYIN:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.data if(%[[IF1]]) dataOperands(%[[COPYIN]] : !fir.ref<!fir.array<10x10xf32>>)  {
 ! CHECK:        acc.terminator
 ! CHECK-NEXT: }{{$}}
-! CHECK:acc.copyout accPtr(%[[COPYIN]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "a"}
+! CHECK:acc.copyout accPtr(%[[COPYIN]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("a")
 
   !$acc data copy(a) if(ifCondition)
   !$acc end data
 
-! CHECK:     %[[COPYIN:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "a"}
+! CHECK:     %[[COPYIN:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      %[[IFCOND:.*]] = fir.load %{{.*}} : !fir.ref<!fir.logical<4>>
 ! CHECK:      %[[IF2:.*]] = fir.convert %[[IFCOND]] : (!fir.logical<4>) -> i1
 ! CHECK:      acc.data if(%[[IF2]]) dataOperands(%[[COPYIN]] : !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.terminator
 ! CHECK-NEXT: }{{$}}
-! CHECK:acc.copyout accPtr(%[[COPYIN]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "a"}
+! CHECK:acc.copyout accPtr(%[[COPYIN]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("a")
 
   !$acc data copy(a, b, c)
   !$acc end data
 
-! CHECK:     %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "a"}
-! CHECK:     %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "b"}
-! CHECK:     %[[COPYIN_C:.*]] = acc.copyin varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "c"}
+! CHECK:     %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:     %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:     %[[COPYIN_C:.*]] = acc.copyin varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.data dataOperands(%[[COPYIN_A]], %[[COPYIN_B]], %[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.terminator
 ! CHECK-NEXT: }{{$}}
-! CHECK:acc.copyout accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "a"}
-! CHECK:acc.copyout accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "b"}
-! CHECK:acc.copyout accPtr(%[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "c"}
+! CHECK:acc.copyout accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("a")
+! CHECK:acc.copyout accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("b")
+! CHECK:acc.copyout accPtr(%[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("c")
 
   !$acc data copy(a) copy(b) copy(c)
   !$acc end data
 
-! CHECK:     %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "a"}
-! CHECK:     %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "b"}
-! CHECK:     %[[COPYIN_C:.*]] = acc.copyin varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "c"}
+! CHECK:     %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:     %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:     %[[COPYIN_C:.*]] = acc.copyin varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.data dataOperands(%[[COPYIN_A]], %[[COPYIN_B]], %[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.terminator
 ! CHECK-NEXT: }{{$}}
-! CHECK:acc.copyout accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "a"}
-! CHECK:acc.copyout accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "b"}
-! CHECK:acc.copyout accPtr(%[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "c"}
+! CHECK:acc.copyout accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("a")
+! CHECK:acc.copyout accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("b")
+! CHECK:acc.copyout accPtr(%[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("c")
 
   !$acc data copyin(a) copyin(readonly: b, c)
   !$acc end data
 
-! CHECK:     %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "a"}
-! CHECK:     %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copyin_readonly>, name = "b"}
-! CHECK:     %[[COPYIN_C:.*]] = acc.copyin varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copyin_readonly>, name = "c"}
+! CHECK:     %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:     %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyin_readonly) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:     %[[COPYIN_C:.*]] = acc.copyin varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyin_readonly) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.data dataOperands(%[[COPYIN_A]], %[[COPYIN_B]], %[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.terminator
 ! CHECK-NEXT: }{{$}}
-! CHECK: acc.delete accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copyin>, name = "a"}
-! CHECK: acc.delete accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copyin_readonly>, name = "b"}
-! CHECK: acc.delete accPtr(%[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copyin_readonly>, name = "c"}
+! CHECK: acc.delete accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyin) name("a")
+! CHECK: acc.delete accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyin_readonly) name("b")
+! CHECK: acc.delete accPtr(%[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyin_readonly) name("c")
 
   !$acc data copyout(a) copyout(zero: b) copyout(c)
   !$acc end data
 
-! CHECK:     %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copyout>, name = "a"}
-! CHECK:     %[[CREATE_B:.*]] = acc.create varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copyout_zero>, name = "b"}
-! CHECK:     %[[CREATE_C:.*]] = acc.create varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copyout>, name = "c"}
+! CHECK:     %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyout) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:     %[[CREATE_B:.*]] = acc.create varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyout_zero) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:     %[[CREATE_C:.*]] = acc.create varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyout) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.data dataOperands(%[[CREATE_A]], %[[CREATE_B]], %[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.terminator
 ! CHECK-NEXT: }{{$}}
-! CHECK:acc.copyout accPtr(%[[CREATE_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) {name = "a"}
-! CHECK:acc.copyout accPtr(%[[CREATE_B]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copyout_zero>, name = "b"}
-! CHECK:acc.copyout accPtr(%[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) {name = "c"}
+! CHECK:acc.copyout accPtr(%[[CREATE_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("a")
+! CHECK:acc.copyout accPtr(%[[CREATE_B]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyout_zero) name("b")
+! CHECK:acc.copyout accPtr(%[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("c")
 
   !$acc data create(a, b) create(zero: c)
   !$acc end data
 
-! CHECK:     %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "a"}
-! CHECK:     %[[CREATE_B:.*]] = acc.create varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "b"}
-! CHECK:     %[[CREATE_C:.*]] = acc.create varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_create_zero>, name = "c"}
+! CHECK:     %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:     %[[CREATE_B:.*]] = acc.create varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:     %[[CREATE_C:.*]] = acc.create varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_create_zero) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.data dataOperands(%[[CREATE_A]], %[[CREATE_B]], %[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.terminator
 ! CHECK-NEXT: }{{$}}
-! CHECK: acc.delete accPtr(%[[CREATE_A]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_create>, name = "a"}
-! CHECK: acc.delete accPtr(%[[CREATE_B]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_create>, name = "b"}
-! CHECK: acc.delete accPtr(%[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_create_zero>, name = "c"}
+! CHECK: acc.delete accPtr(%[[CREATE_A]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_create) name("a")
+! CHECK: acc.delete accPtr(%[[CREATE_B]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_create) name("b")
+! CHECK: acc.delete accPtr(%[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_create_zero) name("c")
 
   !$acc data create(c) copy(b) create(a)
   !$acc end data
-! CHECK:%[[CREATE_C:.*]] = acc.create varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "c"}
-! CHECK:%[[COPY_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "b"}
-! CHECK:%[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "a"}
+! CHECK:%[[CREATE_C:.*]] = acc.create varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("c") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:%[[COPY_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:%[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK: acc.data dataOperands(%[[CREATE_C]], %[[COPY_B]], %[[CREATE_A]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 
   !$acc data no_create(a, b) create(zero: c)
   !$acc end data
 
-! CHECK:     %[[NO_CREATE_A:.*]] = acc.nocreate varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "a"}
-! CHECK:     %[[NO_CREATE_B:.*]] = acc.nocreate varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "b"}
-! CHECK:     %[[CREATE_C:.*]] = acc.create varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_create_zero>, name = "c"}
+! CHECK:     %[[NO_CREATE_A:.*]] = acc.nocreate varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:     %[[NO_CREATE_B:.*]] = acc.nocreate varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:     %[[CREATE_C:.*]] = acc.create varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_create_zero) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.data dataOperands(%[[NO_CREATE_A]], %[[NO_CREATE_B]], %[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.terminator
 ! CHECK-NEXT: }{{$}}
-! CHECK: acc.delete accPtr(%[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_create_zero>, name = "c"}
+! CHECK: acc.delete accPtr(%[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_create_zero) name("c")
 
   !$acc data present(a, b, c)
   !$acc end data
 
-! CHECK:     %[[PRESENT_A:.*]] = acc.present varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "a"}
-! CHECK:     %[[PRESENT_B:.*]] = acc.present varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "b"}
-! CHECK:     %[[PRESENT_C:.*]] = acc.present varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "c"}
+! CHECK:     %[[PRESENT_A:.*]] = acc.present varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:     %[[PRESENT_B:.*]] = acc.present varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:     %[[PRESENT_C:.*]] = acc.present varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.data dataOperands(%[[PRESENT_A]], %[[PRESENT_B]], %[[PRESENT_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.terminator
 ! CHECK-NEXT: }{{$}}
@@ -135,8 +135,8 @@ subroutine acc_data
   !$acc data deviceptr(b, c)
   !$acc end data
 
-! CHECK:     %[[DEVICEPTR_B:.*]] = acc.deviceptr varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "b"}
-! CHECK:     %[[DEVICEPTR_C:.*]] = acc.deviceptr varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "c"}
+! CHECK:     %[[DEVICEPTR_B:.*]] = acc.deviceptr varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:     %[[DEVICEPTR_C:.*]] = acc.deviceptr varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.data dataOperands(%[[DEVICEPTR_B]], %[[DEVICEPTR_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.terminator
 ! CHECK-NEXT: }{{$}}
@@ -144,13 +144,13 @@ subroutine acc_data
   !$acc data attach(d, e)
   !$acc end data
 
-! CHECK:      %[[ATTACH_D:.*]] = acc.attach varPtr(%{{.*}} : !fir.ref<!fir.box<!fir.ptr<f32>>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>> {name = "d"}
-! CHECK:      %[[ATTACH_E:.*]] = acc.attach varPtr(%{{.*}} : !fir.ref<!fir.box<!fir.ptr<f32>>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>> {name = "e"}
+! CHECK:      %[[ATTACH_D:.*]] = acc.attach varPtr(%{{.*}} : !fir.ref<!fir.box<!fir.ptr<f32>>>) name("d") -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+! CHECK:      %[[ATTACH_E:.*]] = acc.attach varPtr(%{{.*}} : !fir.ref<!fir.box<!fir.ptr<f32>>>) name("e") -> !fir.ref<!fir.box<!fir.ptr<f32>>>
 ! CHECK:      acc.data dataOperands(%[[ATTACH_D]], %[[ATTACH_E]] : !fir.ref<!fir.box<!fir.ptr<f32>>>, !fir.ref<!fir.box<!fir.ptr<f32>>>) {
 ! CHECK:        acc.terminator
 ! CHECK-NEXT: }{{$}}
-! CHECK: acc.detach accPtr(%[[ATTACH_D]] : !fir.ref<!fir.box<!fir.ptr<f32>>>) {dataClause = #acc<data_clause acc_attach>, name = "d"}
-! CHECK: acc.detach accPtr(%[[ATTACH_E]] : !fir.ref<!fir.box<!fir.ptr<f32>>>) {dataClause = #acc<data_clause acc_attach>, name = "e"}
+! CHECK: acc.detach accPtr(%[[ATTACH_D]] : !fir.ref<!fir.box<!fir.ptr<f32>>>) dataClause(acc_attach) name("d")
+! CHECK: acc.detach accPtr(%[[ATTACH_E]] : !fir.ref<!fir.box<!fir.ptr<f32>>>) dataClause(acc_attach) name("e")
 
   !$acc data present(a) async
   !$acc end data
@@ -161,10 +161,10 @@ subroutine acc_data
   !$acc data copy(a) async(1)
   !$acc end data
 
-! CHECK: %[[COPYIN:.*]] = acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.array<10x10xf32>>) async(%[[ASYNC:.*]] : i32) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "a"}
+! CHECK: %[[COPYIN:.*]] = acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.array<10x10xf32>>) async(%[[ASYNC:.*]] : i32) dataClause(acc_copy) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK: acc.data async(%[[ASYNC]] : i32) dataOperands(%[[COPYIN]] : !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK: }{{$}}
-! CHECK: acc.copyout accPtr(%[[COPYIN]] : !fir.ref<!fir.array<10x10xf32>>) async(%[[ASYNC]] : i32) to varPtr(%{{.*}} : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "a"}
+! CHECK: acc.copyout accPtr(%[[COPYIN]] : !fir.ref<!fir.array<10x10xf32>>) async(%[[ASYNC]] : i32) to varPtr(%{{.*}} : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("a")
 
   !$acc data present(a) wait
   !$acc end data
@@ -189,14 +189,14 @@ subroutine acc_data
 
 ! CHECK: acc.data {
 ! CHECK:   acc.terminator
-! CHECK: } attributes {defaultAttr = #acc<defaultvalue none>}
+! CHECK: } defaultAttr(none)
 
   !$acc data default(present)
   !$acc end data
 
 ! CHECK: acc.data {
 ! CHECK:   acc.terminator
-! CHECK: } attributes {defaultAttr = #acc<defaultvalue present>}
+! CHECK: } defaultAttr(present)
 
   !$acc data
   !$acc end data

--- a/flang/test/Lower/OpenACC/acc-declare-common-in-function.f90
+++ b/flang/test/Lower/OpenACC/acc-declare-common-in-function.f90
@@ -20,9 +20,9 @@ program p
 
 ! CHECK-DAG: acc.global_dtor @{{.*}}_acc_dtor {
 ! CHECK-DAG: %[[ADDR1:.*]] = fir.address_of(@{{.*}}) {acc.declare = #acc.declare<dataClause = acc_copyin>} : !fir.ref<tuple<f32>>
-! CHECK-DAG: %[[GDP:.*]] = acc.getdeviceptr varPtr(%[[ADDR1]] : !fir.ref<tuple<f32>>) -> !fir.ref<tuple<f32>> {dataClause = #acc<data_clause acc_copyin>, {{.*}}}
+! CHECK-DAG: %[[GDP:.*]] = acc.getdeviceptr varPtr(%[[ADDR1]] : !fir.ref<tuple<f32>>) dataClause(acc_copyin) structured(false) name("com") -> !fir.ref<tuple<f32>>
 ! CHECK-DAG: acc.declare_exit dataOperands(%[[GDP]] : !fir.ref<tuple<f32>>)
-! CHECK-DAG: acc.delete accPtr(%[[GDP]] : !fir.ref<tuple<f32>>) {dataClause = #acc<data_clause acc_copyin>{{.*}}}
+! CHECK-DAG: acc.delete accPtr(%[[GDP]] : !fir.ref<tuple<f32>>) dataClause(acc_copyin) structured(false) name("com")
 ! CHECK-DAG: acc.terminator
 ! CHECK-DAG: }
 
@@ -36,5 +36,4 @@ contains
   end subroutine s
 
 end program p
-
 

--- a/flang/test/Lower/OpenACC/acc-declare-common-present-in-function.f90
+++ b/flang/test/Lower/OpenACC/acc-declare-common-present-in-function.f90
@@ -18,7 +18,7 @@ contains
 ! CHECK-LABEL: func.func private @_QFPs()
 ! CHECK-DAG: hlfir.declare
 ! CHECK-DAG: %[[ADDR:.*]] = fir.address_of(@com_){{.*}} : !fir.ref<!fir.array<4xi8>>
-! CHECK-DAG: %[[PRESENT:.*]] = acc.present varPtr(%[[ADDR]] : !fir.ref<!fir.array<4xi8>>) -> !fir.ref<!fir.array<4xi8>> {name = "com"}
+! CHECK-DAG: %[[PRESENT:.*]] = acc.present varPtr(%[[ADDR]] : !fir.ref<!fir.array<4xi8>>) name("com") -> !fir.ref<!fir.array<4xi8>>
 ! CHECK-DAG: %[[TOK:.*]] = acc.declare_enter dataOperands(%[[PRESENT]] : !fir.ref<!fir.array<4xi8>>)
 ! CHECK: acc.declare_exit token(%[[TOK]]) dataOperands(%[[PRESENT]] : !fir.ref<!fir.array<4xi8>>)
   end subroutine s

--- a/flang/test/Lower/OpenACC/acc-declare-cuda-pinned-deallocate.f90
+++ b/flang/test/Lower/OpenACC/acc-declare-cuda-pinned-deallocate.f90
@@ -19,5 +19,5 @@ end subroutine
 
 ! CHECK-LABEL: func.func private @{{.*}}_acc_declare_post_dealloc(
 ! CHECK-SAME: %[[POST_DEALLOC_ARG:.*]]: !fir.ref<!fir.box<!fir.heap<f32>>>)
-! CHECK: acc.getdeviceptr varPtr(%[[POST_DEALLOC_ARG]] : !fir.ref<!fir.box<!fir.heap<f32>>>){{.*}}implicit = true
+! CHECK: acc.getdeviceptr varPtr(%[[POST_DEALLOC_ARG]] : !fir.ref<!fir.box<!fir.heap<f32>>>){{.*}}implicit(true)
 ! CHECK: acc.declare_exit

--- a/flang/test/Lower/OpenACC/acc-declare-cuda-pinned.f90
+++ b/flang/test/Lower/OpenACC/acc-declare-cuda-pinned.f90
@@ -25,5 +25,5 @@ end program
 
 ! CHECK-LABEL: func.func private @{{.*}}_acc_declare_post_dealloc(
 ! CHECK-SAME: %[[POST_DEALLOC_ARG:.*]]: !fir.ref<!fir.box<!fir.heap<f32>>>)
-! CHECK: acc.getdeviceptr varPtr(%[[POST_DEALLOC_ARG]] : !fir.ref<!fir.box<!fir.heap<f32>>>){{.*}}implicit = true
+! CHECK: acc.getdeviceptr varPtr(%[[POST_DEALLOC_ARG]] : !fir.ref<!fir.box<!fir.heap<f32>>>){{.*}}implicit(true)
 ! CHECK: acc.declare_exit

--- a/flang/test/Lower/OpenACC/acc-declare-globals.f90
+++ b/flang/test/Lower/OpenACC/acc-declare-globals.f90
@@ -46,16 +46,16 @@ end module
 
 ! CHECK-LABEL: acc.global_ctor @_QMacc_declare_testEdata1_acc_ctor {
 ! CHECK:         %[[GLOBAL_ADDR:.*]] = fir.address_of(@_QMacc_declare_testEdata1) {acc.declare = #acc.declare<dataClause = acc_create>} : !fir.ref<!fir.array<100000xf32>>
-! CHECK:         %[[CREATE:.*]] = acc.create varPtr(%[[GLOBAL_ADDR]] : !fir.ref<!fir.array<100000xf32>>) -> !fir.ref<!fir.array<100000xf32>> {name = "data1", structured = false}
+! CHECK:         %[[CREATE:.*]] = acc.create varPtr(%[[GLOBAL_ADDR]] : !fir.ref<!fir.array<100000xf32>>) structured(false) name("data1") -> !fir.ref<!fir.array<100000xf32>>
 ! CHECK:         acc.declare_enter dataOperands(%[[CREATE]] : !fir.ref<!fir.array<100000xf32>>)
 ! CHECK:         acc.terminator
 ! CHECK:       }
 
 ! CHECK-LABEL: acc.global_dtor @_QMacc_declare_testEdata1_acc_dtor {
 ! CHECK:         %[[GLOBAL_ADDR:.*]] = fir.address_of(@_QMacc_declare_testEdata1) {acc.declare = #acc.declare<dataClause = acc_create>} : !fir.ref<!fir.array<100000xf32>>
-! CHECK:         %[[DEVICEPTR:.*]] = acc.getdeviceptr varPtr(%[[GLOBAL_ADDR]] : !fir.ref<!fir.array<100000xf32>>) -> !fir.ref<!fir.array<100000xf32>> {dataClause = #acc<data_clause acc_create>, name = "data1", structured = false}
+! CHECK:         %[[DEVICEPTR:.*]] = acc.getdeviceptr varPtr(%[[GLOBAL_ADDR]] : !fir.ref<!fir.array<100000xf32>>) dataClause(acc_create) structured(false) name("data1") -> !fir.ref<!fir.array<100000xf32>>
 ! CHECK:         acc.declare_exit dataOperands(%[[DEVICEPTR]] : !fir.ref<!fir.array<100000xf32>>)
-! CHECK:         acc.delete accPtr(%[[DEVICEPTR]] : !fir.ref<!fir.array<100000xf32>>) {dataClause = #acc<data_clause acc_create>, name = "data1", structured = false}
+! CHECK:         acc.delete accPtr(%[[DEVICEPTR]] : !fir.ref<!fir.array<100000xf32>>) dataClause(acc_create) structured(false) name("data1")
 ! CHECK:         acc.terminator
 ! CHECK:       }
 
@@ -67,16 +67,16 @@ end module
 
 ! CHECK-LABEL: acc.global_ctor @_QMacc_declare_copyin_testEdata1_acc_ctor {
 ! CHECK:         %[[GLOBAL_ADDR:.*]] = fir.address_of(@_QMacc_declare_copyin_testEdata1) {acc.declare = #acc.declare<dataClause =  acc_copyin>} : !fir.ref<!fir.array<100000xf32>>
-! CHECK:         %[[COPYIN:.*]] = acc.copyin varPtr(%[[GLOBAL_ADDR]] : !fir.ref<!fir.array<100000xf32>>) -> !fir.ref<!fir.array<100000xf32>> {name = "data1", structured = false}
+! CHECK:         %[[COPYIN:.*]] = acc.copyin varPtr(%[[GLOBAL_ADDR]] : !fir.ref<!fir.array<100000xf32>>) structured(false) name("data1") -> !fir.ref<!fir.array<100000xf32>>
 ! CHECK:         acc.declare_enter dataOperands(%[[COPYIN]] : !fir.ref<!fir.array<100000xf32>>)
 ! CHECK:         acc.terminator
 ! CHECK:       }
 
 ! CHECK-LABEL: acc.global_dtor @_QMacc_declare_copyin_testEdata1_acc_dtor {
 ! CHECK:         %[[GLOBAL_ADDR:.*]] = fir.address_of(@_QMacc_declare_copyin_testEdata1) {acc.declare = #acc.declare<dataClause = acc_copyin>} : !fir.ref<!fir.array<100000xf32>>
-! CHECK:         %[[DEVICEPTR:.*]] = acc.getdeviceptr varPtr(%[[GLOBAL_ADDR]] : !fir.ref<!fir.array<100000xf32>>) -> !fir.ref<!fir.array<100000xf32>> {dataClause = #acc<data_clause acc_copyin>, name = "data1", structured = false}
+! CHECK:         %[[DEVICEPTR:.*]] = acc.getdeviceptr varPtr(%[[GLOBAL_ADDR]] : !fir.ref<!fir.array<100000xf32>>) dataClause(acc_copyin) structured(false) name("data1") -> !fir.ref<!fir.array<100000xf32>>
 ! CHECK:         acc.declare_exit dataOperands(%[[DEVICEPTR]] : !fir.ref<!fir.array<100000xf32>>)
-! CHECK:         acc.delete accPtr(%[[DEVICEPTR]] : !fir.ref<!fir.array<100000xf32>>) {dataClause = #acc<data_clause acc_copyin>, name = "data1", structured = false}
+! CHECK:         acc.delete accPtr(%[[DEVICEPTR]] : !fir.ref<!fir.array<100000xf32>>) dataClause(acc_copyin) structured(false) name("data1")
 ! CHECK:         acc.terminator
 ! CHECK:       }
 
@@ -90,16 +90,16 @@ end module
 
 ! CHECK-LABEL: acc.global_ctor @_QMacc_declare_device_resident_testEdata1_acc_ctor {
 ! CHECK:         %[[GLOBAL_ADDR:.*]] = fir.address_of(@_QMacc_declare_device_resident_testEdata1) {acc.declare = #acc.declare<dataClause =  acc_declare_device_resident>} : !fir.ref<!fir.array<5000xi32>>
-! CHECK:         %[[DEVICERESIDENT:.*]] = acc.declare_device_resident varPtr(%0 : !fir.ref<!fir.array<5000xi32>>) -> !fir.ref<!fir.array<5000xi32>> {name = "data1", structured = false}
+! CHECK:         %[[DEVICERESIDENT:.*]] = acc.declare_device_resident varPtr(%0 : !fir.ref<!fir.array<5000xi32>>) structured(false) name("data1") -> !fir.ref<!fir.array<5000xi32>>
 ! CHECK:         acc.declare_enter dataOperands(%[[DEVICERESIDENT]] : !fir.ref<!fir.array<5000xi32>>)
 ! CHECK:         acc.terminator
 ! CHECK:       }
 
 ! CHECK-LABEL: acc.global_dtor @_QMacc_declare_device_resident_testEdata1_acc_dtor {
 ! CHECK:         %[[GLOBAL_ADDR:.*]] = fir.address_of(@_QMacc_declare_device_resident_testEdata1) {acc.declare = #acc.declare<dataClause =  acc_declare_device_resident>} : !fir.ref<!fir.array<5000xi32>>
-! CHECK:         %[[DEVPTR:.*]] = acc.getdeviceptr varPtr(%[[GLOBAL_ADDR]] : !fir.ref<!fir.array<5000xi32>>)   -> !fir.ref<!fir.array<5000xi32>> {dataClause = #acc<data_clause acc_declare_device_resident>, name = "data1", structured = false}
+! CHECK:         %[[DEVPTR:.*]] = acc.getdeviceptr varPtr(%[[GLOBAL_ADDR]] : !fir.ref<!fir.array<5000xi32>>) dataClause(acc_declare_device_resident) structured(false) name("data1") -> !fir.ref<!fir.array<5000xi32>>
 ! CHECK:         acc.declare_exit dataOperands(%[[DEVICEPTR]] : !fir.ref<!fir.array<5000xi32>>)
-! CHECK:         acc.delete accPtr(%[[DEVICEPTR]] : !fir.ref<!fir.array<5000xi32>>)   {dataClause = #acc<data_clause acc_declare_device_resident>, name = "data1", structured = false}
+! CHECK:         acc.delete accPtr(%[[DEVICEPTR]] : !fir.ref<!fir.array<5000xi32>>)   dataClause(acc_declare_device_resident) structured(false) name("data1")
 ! CHECK:         acc.terminator
 ! CHECK:       }
 
@@ -113,7 +113,7 @@ end module
 
 ! CHECK-LABEL: acc.global_ctor @_QMacc_declare_device_link_testEdata1_acc_ctor {
 ! CHECK:         %[[GLOBAL_ADDR:.*]] = fir.address_of(@_QMacc_declare_device_link_testEdata1) {acc.declare = #acc.declare<dataClause =  acc_declare_link>} : !fir.ref<!fir.array<5000xi32>>
-! CHECK:         %[[LINK:.*]] = acc.declare_link varPtr(%[[GLOBAL_ADDR]] : !fir.ref<!fir.array<5000xi32>>) -> !fir.ref<!fir.array<5000xi32>> {name = "data1", structured = false}
+! CHECK:         %[[LINK:.*]] = acc.declare_link varPtr(%[[GLOBAL_ADDR]] : !fir.ref<!fir.array<5000xi32>>) structured(false) name("data1") -> !fir.ref<!fir.array<5000xi32>>
 ! CHECK:         acc.declare_enter dataOperands(%[[LINK]] : !fir.ref<!fir.array<5000xi32>>)
 ! CHECK:         acc.terminator
 ! CHECK:       }

--- a/flang/test/Lower/OpenACC/acc-declare.f90
+++ b/flang/test/Lower/OpenACC/acc-declare.f90
@@ -18,12 +18,12 @@ module acc_declare
 ! CHECK-LABEL: func.func @_QMacc_declarePacc_declare_copy()
 ! CHECK: %[[ALLOCA:.*]] = fir.alloca !fir.array<100xi32> {bindc_name = "a", uniq_name = "_QMacc_declareFacc_declare_copyEa"}
 ! CHECK: %[[DECL:.*]]:2 = hlfir.declare %[[ALLOCA]](%{{.*}}) {acc.declare = #acc.declare<dataClause =  acc_copy>, uniq_name = "_QMacc_declareFacc_declare_copyEa"} : (!fir.ref<!fir.array<100xi32>>, !fir.shape<1>) -> (!fir.ref<!fir.array<100xi32>>, !fir.ref<!fir.array<100xi32>>)
-! CHECK: %[[COPYIN:.*]] = acc.copyin varPtr(%[[DECL]]#0 : !fir.ref<!fir.array<100xi32>>) -> !fir.ref<!fir.array<100xi32>> {dataClause = #acc<data_clause acc_copy>, name = "a"}
+! CHECK: %[[COPYIN:.*]] = acc.copyin varPtr(%[[DECL]]#0 : !fir.ref<!fir.array<100xi32>>) dataClause(acc_copy) name("a") -> !fir.ref<!fir.array<100xi32>>
 ! CHECK: %[[TOKEN:.*]] = acc.declare_enter dataOperands(%[[COPYIN]] : !fir.ref<!fir.array<100xi32>>)
 ! CHECK: fir.do_loop %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
 ! CHECK: }
 ! CHECK: acc.declare_exit token(%[[TOKEN]]) dataOperands(%[[COPYIN]] : !fir.ref<!fir.array<100xi32>>)
-! CHECK: acc.copyout accPtr(%[[COPYIN]] : !fir.ref<!fir.array<100xi32>>) to varPtr(%[[DECL]]#0 : !fir.ref<!fir.array<100xi32>>) {dataClause = #acc<data_clause acc_copy>, name = "a"}
+! CHECK: acc.copyout accPtr(%[[COPYIN]] : !fir.ref<!fir.array<100xi32>>) to varPtr(%[[DECL]]#0 : !fir.ref<!fir.array<100xi32>>) dataClause(acc_copy) name("a")
 ! CHECK: return
 
   subroutine acc_declare_create()
@@ -38,12 +38,12 @@ module acc_declare
 ! CHECK-LABEL: func.func @_QMacc_declarePacc_declare_create() {
 ! CHECK: %[[ALLOCA:.*]] = fir.alloca !fir.array<100xi32> {bindc_name = "a", uniq_name = "_QMacc_declareFacc_declare_createEa"}
 ! CHECK: %[[DECL:.*]]:2 = hlfir.declare %[[ALLOCA]](%{{.*}}) {acc.declare = #acc.declare<dataClause =  acc_create>, uniq_name = "_QMacc_declareFacc_declare_createEa"} : (!fir.ref<!fir.array<100xi32>>, !fir.shape<1>) -> (!fir.ref<!fir.array<100xi32>>, !fir.ref<!fir.array<100xi32>>)
-! CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[DECL]]#0 : !fir.ref<!fir.array<100xi32>>) -> !fir.ref<!fir.array<100xi32>> {name = "a"}
+! CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[DECL]]#0 : !fir.ref<!fir.array<100xi32>>) name("a") -> !fir.ref<!fir.array<100xi32>>
 ! CHECK: %[[TOKEN:.*]] = acc.declare_enter dataOperands(%[[CREATE]] : !fir.ref<!fir.array<100xi32>>)
 ! CHECK: fir.do_loop %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
 ! CHECK: }
 ! CHECK: acc.declare_exit token(%[[TOKEN]]) dataOperands(%[[CREATE]] : !fir.ref<!fir.array<100xi32>>)
-! CHECK: acc.delete accPtr(%[[CREATE]] : !fir.ref<!fir.array<100xi32>>) {dataClause = #acc<data_clause acc_create>, name = "a"}
+! CHECK: acc.delete accPtr(%[[CREATE]] : !fir.ref<!fir.array<100xi32>>) dataClause(acc_create) name("a")
 ! CHECK: return
 
   subroutine acc_declare_present(a)
@@ -58,11 +58,11 @@ module acc_declare
 ! CHECK-LABEL: func.func @_QMacc_declarePacc_declare_present(
 ! CHECK-SAME: %[[ARG0:.*]]: !fir.ref<!fir.array<100xi32>> {fir.bindc_name = "a"})
 ! CHECK: %[[DECL:.*]]:2 = hlfir.declare %[[ARG0]](%{{.*}}) dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {acc.declare = #acc.declare<dataClause =  acc_present>, uniq_name = "_QMacc_declareFacc_declare_presentEa"} : (!fir.ref<!fir.array<100xi32>>, !fir.shape<1>, !fir.dscope) -> (!fir.ref<!fir.array<100xi32>>, !fir.ref<!fir.array<100xi32>>)
-! CHECK: %[[PRESENT:.*]] = acc.present varPtr(%[[DECL]]#0 : !fir.ref<!fir.array<100xi32>>) -> !fir.ref<!fir.array<100xi32>> {name = "a"}
+! CHECK: %[[PRESENT:.*]] = acc.present varPtr(%[[DECL]]#0 : !fir.ref<!fir.array<100xi32>>) name("a") -> !fir.ref<!fir.array<100xi32>>
 ! CHECK: %[[TOKEN:.*]] = acc.declare_enter dataOperands(%[[PRESENT]] : !fir.ref<!fir.array<100xi32>>)
 ! CHECK: fir.do_loop %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
 ! CHECK: acc.declare_exit token(%[[TOKEN]]) dataOperands(%[[PRESENT]] : !fir.ref<!fir.array<100xi32>>)
-! CHECK: acc.delete accPtr(%[[PRESENT]] : !fir.ref<!fir.array<100xi32>>) {dataClause = #acc<data_clause acc_present>, name = "a"}
+! CHECK: acc.delete accPtr(%[[PRESENT]] : !fir.ref<!fir.array<100xi32>>) dataClause(acc_present) name("a")
 
   subroutine acc_declare_present_host_and_comp(host, coeffs)
     type :: dt_box
@@ -76,9 +76,9 @@ module acc_declare
 ! CHECK-LABEL: func.func @_QMacc_declarePacc_declare_present_host_and_comp(
 ! CHECK-SAME: %[[ARGHOST:.*]]: !fir.ref<!fir.type<_QMacc_declare{{.*}}Tdt_box{{.*}}>> {fir.bindc_name = "host"},
 ! CHECK-SAME: %[[ARGCOEFF:.*]]: !fir.ref<!fir.array<10xf32>> {fir.bindc_name = "coeffs"})
-! CHECK-DAG: acc.present{{.*}}name = "host"
-! CHECK-DAG: acc.present{{.*}}name = "host%buf"
-! CHECK-DAG: acc.present{{.*}}name = "coeffs"
+! CHECK-DAG: acc.present{{.*}}name("host")
+! CHECK-DAG: acc.present{{.*}}name("host%buf")
+! CHECK-DAG: acc.present{{.*}}name("coeffs")
 ! CHECK: acc.declare_enter dataOperands(%{{.*}}, %{{.*}}, %{{.*}} :
 
   subroutine acc_declare_copyin()
@@ -95,12 +95,12 @@ module acc_declare
 ! CHECK: %[[ADECL:.*]]:2 = hlfir.declare %[[A]](%{{.*}}) {acc.declare = #acc.declare<dataClause =  acc_copyin>, uniq_name = "_QMacc_declareFacc_declare_copyinEa"} : (!fir.ref<!fir.array<100xi32>>, !fir.shape<1>) -> (!fir.ref<!fir.array<100xi32>>, !fir.ref<!fir.array<100xi32>>)
 ! CHECK: %[[B:.*]] = fir.alloca !fir.array<10xi32> {bindc_name = "b", uniq_name = "_QMacc_declareFacc_declare_copyinEb"}
 ! CHECK: %[[BDECL:.*]]:2 = hlfir.declare %[[B]](%{{.*}}) {acc.declare = #acc.declare<dataClause =  acc_copyin_readonly>, uniq_name = "_QMacc_declareFacc_declare_copyinEb"} : (!fir.ref<!fir.array<10xi32>>, !fir.shape<1>) -> (!fir.ref<!fir.array<10xi32>>, !fir.ref<!fir.array<10xi32>>)
-! CHECK: %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[ADECL]]#0 : !fir.ref<!fir.array<100xi32>>) -> !fir.ref<!fir.array<100xi32>> {name = "a"}
-! CHECK: %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[BDECL]]#0 : !fir.ref<!fir.array<10xi32>>) -> !fir.ref<!fir.array<10xi32>> {dataClause = #acc<data_clause acc_copyin_readonly>, name = "b"}
+! CHECK: %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[ADECL]]#0 : !fir.ref<!fir.array<100xi32>>) name("a") -> !fir.ref<!fir.array<100xi32>>
+! CHECK: %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[BDECL]]#0 : !fir.ref<!fir.array<10xi32>>) dataClause(acc_copyin_readonly) name("b") -> !fir.ref<!fir.array<10xi32>>
 ! CHECK: acc.declare_enter dataOperands(%[[COPYIN_A]], %[[COPYIN_B]] : !fir.ref<!fir.array<100xi32>>, !fir.ref<!fir.array<10xi32>>)
 ! CHECK: fir.do_loop %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
-! CHECK: acc.delete accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<100xi32>>) {dataClause = #acc<data_clause acc_copyin>, name = "a"}
-! CHECK: acc.delete accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10xi32>>) {dataClause = #acc<data_clause acc_copyin_readonly>, name = "b"}
+! CHECK: acc.delete accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<100xi32>>) dataClause(acc_copyin) name("a")
+! CHECK: acc.delete accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10xi32>>) dataClause(acc_copyin_readonly) name("b")
 
   subroutine acc_declare_copyout()
     integer :: a(100), i
@@ -114,11 +114,11 @@ module acc_declare
 ! CHECK-LABEL: func.func @_QMacc_declarePacc_declare_copyout()
 ! CHECK: %[[A:.*]] = fir.alloca !fir.array<100xi32> {bindc_name = "a", uniq_name = "_QMacc_declareFacc_declare_copyoutEa"}
 ! CHECK: %[[ADECL:.*]]:2 = hlfir.declare %[[A]](%{{.*}}) {acc.declare = #acc.declare<dataClause =  acc_copyout>, uniq_name = "_QMacc_declareFacc_declare_copyoutEa"} : (!fir.ref<!fir.array<100xi32>>, !fir.shape<1>) -> (!fir.ref<!fir.array<100xi32>>, !fir.ref<!fir.array<100xi32>>)
-! CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[ADECL]]#0 : !fir.ref<!fir.array<100xi32>>) -> !fir.ref<!fir.array<100xi32>> {dataClause = #acc<data_clause acc_copyout>, name = "a"}
+! CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[ADECL]]#0 : !fir.ref<!fir.array<100xi32>>) dataClause(acc_copyout) name("a") -> !fir.ref<!fir.array<100xi32>>
 ! CHECK: %[[TOKEN:.*]] = acc.declare_enter dataOperands(%[[CREATE]] : !fir.ref<!fir.array<100xi32>>)
 ! CHECK: fir.do_loop %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
 ! CHECK: acc.declare_exit token(%[[TOKEN]]) dataOperands(%[[CREATE]] : !fir.ref<!fir.array<100xi32>>)
-! CHECK: acc.copyout accPtr(%[[CREATE]] : !fir.ref<!fir.array<100xi32>>) to varPtr(%[[ADECL]]#0 : !fir.ref<!fir.array<100xi32>>) {name = "a"}
+! CHECK: acc.copyout accPtr(%[[CREATE]] : !fir.ref<!fir.array<100xi32>>) to varPtr(%[[ADECL]]#0 : !fir.ref<!fir.array<100xi32>>) name("a")
 ! CHECK: return
 
   subroutine acc_declare_deviceptr(a)
@@ -133,7 +133,7 @@ module acc_declare
 ! CHECK-LABEL: func.func @_QMacc_declarePacc_declare_deviceptr(
 ! CHECK-SAME: %[[ARG0:.*]]: !fir.ref<!fir.array<100xi32>> {fir.bindc_name = "a"}) {
 ! CHECK: %[[DECL:.*]]:2 = hlfir.declare %[[ARG0]](%{{.*}}) dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {acc.declare = #acc.declare<dataClause =  acc_deviceptr>, uniq_name = "_QMacc_declareFacc_declare_deviceptrEa"} : (!fir.ref<!fir.array<100xi32>>, !fir.shape<1>, !fir.dscope) -> (!fir.ref<!fir.array<100xi32>>, !fir.ref<!fir.array<100xi32>>)
-! CHECK: %[[DEVICEPTR:.*]] = acc.deviceptr varPtr(%[[DECL]]#0 : !fir.ref<!fir.array<100xi32>>) -> !fir.ref<!fir.array<100xi32>> {name = "a"}
+! CHECK: %[[DEVICEPTR:.*]] = acc.deviceptr varPtr(%[[DECL]]#0 : !fir.ref<!fir.array<100xi32>>) name("a") -> !fir.ref<!fir.array<100xi32>>
 ! CHECK: acc.declare_enter dataOperands(%[[DEVICEPTR]] : !fir.ref<!fir.array<100xi32>>)
 ! CHECK: fir.do_loop %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
 
@@ -149,7 +149,7 @@ module acc_declare
 ! CHECK-LABEL: func.func @_QMacc_declarePacc_declare_link(
 ! CHECK-SAME: %[[ARG0:.*]]: !fir.ref<!fir.array<100xi32>> {fir.bindc_name = "a"})
 ! CHECK: %[[DECL:.*]]:2 = hlfir.declare %[[ARG0]](%{{.*}}) dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {acc.declare = #acc.declare<dataClause =  acc_declare_link>, uniq_name = "_QMacc_declareFacc_declare_linkEa"} : (!fir.ref<!fir.array<100xi32>>, !fir.shape<1>, !fir.dscope) -> (!fir.ref<!fir.array<100xi32>>, !fir.ref<!fir.array<100xi32>>)
-! CHECK: %[[LINK:.*]] = acc.declare_link varPtr(%[[DECL]]#0 : !fir.ref<!fir.array<100xi32>>) -> !fir.ref<!fir.array<100xi32>> {name = "a"}
+! CHECK: %[[LINK:.*]] = acc.declare_link varPtr(%[[DECL]]#0 : !fir.ref<!fir.array<100xi32>>) name("a") -> !fir.ref<!fir.array<100xi32>>
 ! CHECK: acc.declare_enter dataOperands(%[[LINK]] : !fir.ref<!fir.array<100xi32>>)
 ! CHECK: fir.do_loop %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
 
@@ -165,11 +165,11 @@ module acc_declare
 ! CHECK-LABEL: func.func @_QMacc_declarePacc_declare_device_resident(
 ! CHECK-SAME: %[[ARG0:.*]]: !fir.ref<!fir.array<100xi32>> {fir.bindc_name = "a"})
 ! CHECK: %[[DECL:.*]]:2 = hlfir.declare %[[ARG0]](%{{.*}}) dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {acc.declare = #acc.declare<dataClause =  acc_declare_device_resident>, uniq_name = "_QMacc_declareFacc_declare_device_residentEa"} : (!fir.ref<!fir.array<100xi32>>, !fir.shape<1>, !fir.dscope) -> (!fir.ref<!fir.array<100xi32>>, !fir.ref<!fir.array<100xi32>>)
-! CHECK: %[[DEVICERES:.*]] = acc.declare_device_resident varPtr(%[[DECL]]#0 : !fir.ref<!fir.array<100xi32>>) -> !fir.ref<!fir.array<100xi32>> {name = "a"}
+! CHECK: %[[DEVICERES:.*]] = acc.declare_device_resident varPtr(%[[DECL]]#0 : !fir.ref<!fir.array<100xi32>>) name("a") -> !fir.ref<!fir.array<100xi32>>
 ! CHECK: %[[TOKEN:.*]] = acc.declare_enter dataOperands(%[[DEVICERES]] : !fir.ref<!fir.array<100xi32>>)
 ! CHECK: fir.do_loop %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
 ! CHECK: acc.declare_exit token(%[[TOKEN]]) dataOperands(%[[DEVICERES]] : !fir.ref<!fir.array<100xi32>>)
-! CHECK: acc.delete accPtr(%[[DEVICERES]] : !fir.ref<!fir.array<100xi32>>) {dataClause = #acc<data_clause acc_declare_device_resident>, name = "a"}
+! CHECK: acc.delete accPtr(%[[DEVICERES]] : !fir.ref<!fir.array<100xi32>>) dataClause(acc_declare_device_resident) name("a")
 
   subroutine acc_declare_device_resident2()
     integer, parameter :: n = 100
@@ -180,10 +180,10 @@ module acc_declare
 ! CHECK-LABEL: func.func @_QMacc_declarePacc_declare_device_resident2()
 ! CHECK: %[[ALLOCA:.*]] = fir.alloca !fir.array<100xf32> {bindc_name = "dataparam", uniq_name = "_QMacc_declareFacc_declare_device_resident2Edataparam"}
 ! CHECK: %[[DECL:.*]]:2 = hlfir.declare %[[ALLOCA]](%{{.*}}) {acc.declare = #acc.declare<dataClause =  acc_declare_device_resident>, uniq_name = "_QMacc_declareFacc_declare_device_resident2Edataparam"} : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>) -> (!fir.ref<!fir.array<100xf32>>, !fir.ref<!fir.array<100xf32>>)
-! CHECK: %[[DEVICERES:.*]] = acc.declare_device_resident varPtr(%[[DECL]]#0 : !fir.ref<!fir.array<100xf32>>) -> !fir.ref<!fir.array<100xf32>> {name = "dataparam"}
+! CHECK: %[[DEVICERES:.*]] = acc.declare_device_resident varPtr(%[[DECL]]#0 : !fir.ref<!fir.array<100xf32>>) name("dataparam") -> !fir.ref<!fir.array<100xf32>>
 ! CHECK: %[[TOKEN:.*]] = acc.declare_enter dataOperands(%[[DEVICERES]] : !fir.ref<!fir.array<100xf32>>)
 ! CHECK: acc.declare_exit token(%[[TOKEN]]) dataOperands(%[[DEVICERES]] : !fir.ref<!fir.array<100xf32>>)
-! CHECK: acc.delete accPtr(%[[DEVICERES]] : !fir.ref<!fir.array<100xf32>>) {dataClause = #acc<data_clause acc_declare_device_resident>, name = "dataparam"}
+! CHECK: acc.delete accPtr(%[[DEVICERES]] : !fir.ref<!fir.array<100xf32>>) dataClause(acc_declare_device_resident) name("dataparam")
 
   subroutine acc_declare_link2()
     integer, parameter :: n = 100
@@ -194,7 +194,7 @@ module acc_declare
 ! CHECK-LABEL: func.func @_QMacc_declarePacc_declare_link2()
 ! CHECK: %[[ALLOCA:.*]] = fir.alloca !fir.array<100xf32> {bindc_name = "dataparam", uniq_name = "_QMacc_declareFacc_declare_link2Edataparam"}
 ! CHECK: %[[DECL:.*]]:2 = hlfir.declare %[[ALLOCA]](%{{.*}}) {acc.declare = #acc.declare<dataClause =  acc_declare_link>, uniq_name = "_QMacc_declareFacc_declare_link2Edataparam"} : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>) -> (!fir.ref<!fir.array<100xf32>>, !fir.ref<!fir.array<100xf32>>)
-! CHECK: %[[LINK:.*]] = acc.declare_link varPtr(%[[DECL]]#0 : !fir.ref<!fir.array<100xf32>>) -> !fir.ref<!fir.array<100xf32>> {name = "dataparam"}
+! CHECK: %[[LINK:.*]] = acc.declare_link varPtr(%[[DECL]]#0 : !fir.ref<!fir.array<100xf32>>) name("dataparam") -> !fir.ref<!fir.array<100xf32>>
 ! CHECK: acc.declare_enter dataOperands(%[[LINK]] : !fir.ref<!fir.array<100xf32>>)
 
   subroutine acc_declare_deviceptr2()
@@ -206,7 +206,7 @@ module acc_declare
 ! CHECK-LABEL: func.func @_QMacc_declarePacc_declare_deviceptr2()
 ! CHECK: %[[ALLOCA:.*]] = fir.alloca !fir.array<100xf32> {bindc_name = "dataparam", uniq_name = "_QMacc_declareFacc_declare_deviceptr2Edataparam"}
 ! CHECK: %[[DECL:.*]]:2 = hlfir.declare %[[ALLOCA]](%{{.*}}) {acc.declare = #acc.declare<dataClause =  acc_deviceptr>, uniq_name = "_QMacc_declareFacc_declare_deviceptr2Edataparam"} : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>) -> (!fir.ref<!fir.array<100xf32>>, !fir.ref<!fir.array<100xf32>>)
-! CHECK: %[[DEVICEPTR:.*]] = acc.deviceptr varPtr(%[[DECL]]#0 : !fir.ref<!fir.array<100xf32>>) -> !fir.ref<!fir.array<100xf32>> {name = "dataparam"}
+! CHECK: %[[DEVICEPTR:.*]] = acc.deviceptr varPtr(%[[DECL]]#0 : !fir.ref<!fir.array<100xf32>>) name("dataparam") -> !fir.ref<!fir.array<100xf32>>
 ! CHECK: acc.declare_enter dataOperands(%[[DEVICEPTR]] : !fir.ref<!fir.array<100xf32>>)
 
   function acc_declare_in_func()
@@ -215,11 +215,11 @@ module acc_declare
   end function
 
 ! CHECK-LABEL: func.func @_QMacc_declarePacc_declare_in_func() -> f32 {
-! CHECK: %[[DEVICE_RESIDENT:.*]] = acc.declare_device_resident varPtr(%{{.*}}#0 : !fir.ref<!fir.array<1024xf32>>) -> !fir.ref<!fir.array<1024xf32>> {name = "a"}
+! CHECK: %[[DEVICE_RESIDENT:.*]] = acc.declare_device_resident varPtr(%{{.*}}#0 : !fir.ref<!fir.array<1024xf32>>) name("a") -> !fir.ref<!fir.array<1024xf32>>
 ! CHECK: %[[TOKEN:.*]] = acc.declare_enter dataOperands(%[[DEVICE_RESIDENT]] : !fir.ref<!fir.array<1024xf32>>)
 ! CHECK: %[[LOAD:.*]] = fir.load %{{.*}}#0 : !fir.ref<f32>
 ! CHECK: acc.declare_exit token(%[[TOKEN]]) dataOperands(%[[DEVICE_RESIDENT]] : !fir.ref<!fir.array<1024xf32>>)
-! CHECK: acc.delete accPtr(%[[DEVICE_RESIDENT]] : !fir.ref<!fir.array<1024xf32>>) {dataClause = #acc<data_clause acc_declare_device_resident>, name = "a"}
+! CHECK: acc.delete accPtr(%[[DEVICE_RESIDENT]] : !fir.ref<!fir.array<1024xf32>>) dataClause(acc_declare_device_resident) name("a")
 ! CHECK: return %[[LOAD]] : f32
 ! CHECK: }
 
@@ -233,12 +233,12 @@ module acc_declare
 ! CHECK-LABEL: func.func @_QMacc_declarePacc_declare_in_func2(%arg0: !fir.ref<i32> {fir.bindc_name = "i"}) -> f32 {
 ! CHECK: %[[ALLOCA_A:.*]] = fir.alloca !fir.array<1024xf32> {bindc_name = "a", uniq_name = "_QMacc_declareFacc_declare_in_func2Ea"}
 ! CHECK: %[[DECL_A:.*]]:2 = hlfir.declare %[[ALLOCA_A]](%{{.*}}) {acc.declare = #acc.declare<dataClause =  acc_create>, uniq_name = "_QMacc_declareFacc_declare_in_func2Ea"} : (!fir.ref<!fir.array<1024xf32>>, !fir.shape<1>) -> (!fir.ref<!fir.array<1024xf32>>, !fir.ref<!fir.array<1024xf32>>)
-! CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[DECL_A]]#0 : !fir.ref<!fir.array<1024xf32>>) -> !fir.ref<!fir.array<1024xf32>> {name = "a"}
+! CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[DECL_A]]#0 : !fir.ref<!fir.array<1024xf32>>) name("a") -> !fir.ref<!fir.array<1024xf32>>
 ! CHECK: %[[TOKEN:.*]] = acc.declare_enter dataOperands(%[[CREATE]] : !fir.ref<!fir.array<1024xf32>>)
 ! CHECK:   cf.br ^bb1
 ! CHECK: ^bb1:
 ! CHECK: acc.declare_exit token(%[[TOKEN]]) dataOperands(%[[CREATE]] : !fir.ref<!fir.array<1024xf32>>)
-! CHECK: acc.delete accPtr(%[[CREATE]] : !fir.ref<!fir.array<1024xf32>>) {dataClause = #acc<data_clause acc_create>, name = "a"}
+! CHECK: acc.delete accPtr(%[[CREATE]] : !fir.ref<!fir.array<1024xf32>>) dataClause(acc_create) name("a")
 ! CHECK:   return %{{.*}} : f32
 ! CHECK: }
 
@@ -267,14 +267,14 @@ module acc_declare
 
 ! CHECK-LABEL: func.func private @_QMacc_declareFacc_declare_allocateEa_acc_declare_post_alloc(
 ! CHECK-SAME:    %[[ARG0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) {
-! CHECK:         %[[CREATE_DESC:.*]] = acc.create varPtr(%[[ARG0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> {implicit = true, name = "a", structured = false}
+! CHECK:         %[[CREATE_DESC:.*]] = acc.create varPtr(%[[ARG0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) structured(false) implicit(true) name("a") -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:         acc.declare_enter dataOperands(%[[CREATE_DESC]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
 ! CHECK:         return
 ! CHECK:       }
 
 ! CHECK-LABEL: func.func private @_QMacc_declareFacc_declare_allocateEa_acc_declare_post_dealloc(
 ! CHECK-SAME:    %[[ARG0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) {
-! CHECK:         %[[DEVPTR:.*]] = acc.getdeviceptr varPtr(%[[ARG0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> {dataClause = #acc<data_clause acc_create>, implicit = true, name = "a", structured = false}
+! CHECK:         %[[DEVPTR:.*]] = acc.getdeviceptr varPtr(%[[ARG0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) dataClause(acc_create) structured(false) implicit(true) name("a") -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:         acc.declare_exit dataOperands(%[[DEVPTR]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
 ! CHECK:         return
 ! CHECK:       }
@@ -293,14 +293,14 @@ module acc_declare
 ! CHECK-SAME: %[[ARG0:.*]]: !fir.ref<!fir.array<100xi32>> {fir.bindc_name = "a"}, %[[ARG1:.*]]: !fir.ref<!fir.array<100xi32>> {fir.bindc_name = "b"}) {
 ! CHECK: %[[DECL_A:.*]]:2 = hlfir.declare %[[ARG0]](%{{.*}}) dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {acc.declare = #acc.declare<dataClause =  acc_copy>, uniq_name = "_QMacc_declareFacc_declare_multiple_directiveEa"} : (!fir.ref<!fir.array<100xi32>>, !fir.shape<1>, !fir.dscope) -> (!fir.ref<!fir.array<100xi32>>, !fir.ref<!fir.array<100xi32>>)
 ! CHECK: %[[DECL_B:.*]]:2 = hlfir.declare %[[ARG1]](%{{.*}}) dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {acc.declare = #acc.declare<dataClause =  acc_copyout>, uniq_name = "_QMacc_declareFacc_declare_multiple_directiveEb"} : (!fir.ref<!fir.array<100xi32>>, !fir.shape<1>, !fir.dscope) -> (!fir.ref<!fir.array<100xi32>>, !fir.ref<!fir.array<100xi32>>)
-! CHECK: %[[COPYIN:.*]] = acc.copyin varPtr(%[[DECL_A]]#0 : !fir.ref<!fir.array<100xi32>>) -> !fir.ref<!fir.array<100xi32>> {dataClause = #acc<data_clause acc_copy>, name = "a"}
-! CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[DECL_B]]#0 : !fir.ref<!fir.array<100xi32>>) -> !fir.ref<!fir.array<100xi32>> {dataClause = #acc<data_clause acc_copyout>, name = "b"}
+! CHECK: %[[COPYIN:.*]] = acc.copyin varPtr(%[[DECL_A]]#0 : !fir.ref<!fir.array<100xi32>>) dataClause(acc_copy) name("a") -> !fir.ref<!fir.array<100xi32>>
+! CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[DECL_B]]#0 : !fir.ref<!fir.array<100xi32>>) dataClause(acc_copyout) name("b") -> !fir.ref<!fir.array<100xi32>>
 ! CHECK: acc.declare_enter dataOperands(%[[COPYIN]], %[[CREATE]] : !fir.ref<!fir.array<100xi32>>, !fir.ref<!fir.array<100xi32>>)
 ! CHECK: fir.do_loop %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
 
 
-! CHECK: acc.copyout accPtr(%[[CREATE]] : !fir.ref<!fir.array<100xi32>>) to varPtr(%[[DECL_B]]#0 : !fir.ref<!fir.array<100xi32>>) {name = "b"}
-! CHECK: acc.copyout accPtr(%[[COPYIN]] : !fir.ref<!fir.array<100xi32>>) to varPtr(%[[DECL_A]]#0 : !fir.ref<!fir.array<100xi32>>) {dataClause = #acc<data_clause acc_copy>, name = "a"}
+! CHECK: acc.copyout accPtr(%[[CREATE]] : !fir.ref<!fir.array<100xi32>>) to varPtr(%[[DECL_B]]#0 : !fir.ref<!fir.array<100xi32>>) name("b")
+! CHECK: acc.copyout accPtr(%[[COPYIN]] : !fir.ref<!fir.array<100xi32>>) to varPtr(%[[DECL_A]]#0 : !fir.ref<!fir.array<100xi32>>) dataClause(acc_copy) name("a")
 
   subroutine acc_declare_array_section(a)
     integer :: a(:)
@@ -314,10 +314,10 @@ module acc_declare
 ! CHECK-LABEL: func.func @_QMacc_declarePacc_declare_array_section(
 ! CHECK-SAME:    %[[ARG0:.*]]: !fir.box<!fir.array<?xi32>> {fir.bindc_name = "a"}) {
 ! CHECK: %[[DECL_A:.*]]:2 = hlfir.declare %[[ARG0]] dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {acc.declare = #acc.declare<dataClause = acc_copy>, uniq_name = "_QMacc_declareFacc_declare_array_sectionEa"} : (!fir.box<!fir.array<?xi32>>, !fir.dscope) -> (!fir.box<!fir.array<?xi32>>, !fir.box<!fir.array<?xi32>>)
-! CHECK: %[[COPYIN:.*]] = acc.copyin var(%[[DECL_A]]#0 : !fir.box<!fir.array<?xi32>>) bounds(%{{.*}}) -> !fir.box<!fir.array<?xi32>> {dataClause = #acc<data_clause acc_copy>, name = "a(1:10)"}
+! CHECK: %[[COPYIN:.*]] = acc.copyin var(%[[DECL_A]]#0 : !fir.box<!fir.array<?xi32>>) bounds(%{{.*}}) dataClause(acc_copy) name("a(1:10)") -> !fir.box<!fir.array<?xi32>>
 ! CHECK: acc.declare_enter dataOperands(%[[COPYIN]] : !fir.box<!fir.array<?xi32>>)
 
-! CHECK: acc.copyout accVar(%[[COPYIN]] : !fir.box<!fir.array<?xi32>>) bounds(%{{.*}}) to var(%[[DECL_A]]#0 : !fir.box<!fir.array<?xi32>>) {dataClause = #acc<data_clause acc_copy>, name = "a(1:10)"}
+! CHECK: acc.copyout accVar(%[[COPYIN]] : !fir.box<!fir.array<?xi32>>) bounds(%{{.*}}) to var(%[[DECL_A]]#0 : !fir.box<!fir.array<?xi32>>) dataClause(acc_copy) name("a(1:10)")
 
   subroutine acc_declare_allocate_with_stat()
     integer :: status
@@ -413,58 +413,58 @@ end module
 
 ! CHECK-LABEL: acc.global_ctor @_QMacc_declare_allocatable_testEdata1_acc_ctor {
 ! CHECK:         %[[GLOBAL_ADDR:.*]] = fir.address_of(@_QMacc_declare_allocatable_testEdata1) {acc.declare = #acc.declare<dataClause =  acc_create>} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:         %[[COPYIN:.*]] = acc.copyin varPtr(%[[GLOBAL_ADDR]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)   -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> {dataClause = #acc<data_clause acc_create>, implicit = true, name = "data1", structured = false}
+! CHECK:         %[[COPYIN:.*]] = acc.copyin varPtr(%[[GLOBAL_ADDR]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) dataClause(acc_create) structured(false) implicit(true) name("data1") -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:         acc.declare_enter dataOperands(%[[COPYIN]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
 ! CHECK:         acc.terminator
 ! CHECK:       }
 
 ! CHECK-LABEL: func.func @_QMacc_declare_allocatable_testEdata1_acc_declare_post_alloc() attributes {acc.declare_action} {
 ! CHECK:         %[[GLOBAL_ADDR:.*]] = fir.address_of(@_QMacc_declare_allocatable_testEdata1) : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:         %[[CREATE_DESC:.*]] = acc.create varPtr(%[[GLOBAL_ADDR]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> {implicit = true, name = "data1", structured = false}
+! CHECK:         %[[CREATE_DESC:.*]] = acc.create varPtr(%[[GLOBAL_ADDR]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) structured(false) implicit(true) name("data1") -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:         acc.declare_enter dataOperands(%[[CREATE_DESC]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
 ! CHECK:         return
 ! CHECK:       }
 
 ! CHECK-LABEL: func.func @_QMacc_declare_allocatable_testEdata1_acc_declare_post_dealloc() attributes {acc.declare_action} {
 ! CHECK:         %[[GLOBAL_ADDR:.*]] = fir.address_of(@_QMacc_declare_allocatable_testEdata1) : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:         %[[DEVPTR:.*]] = acc.getdeviceptr varPtr(%[[GLOBAL_ADDR]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)   -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> {dataClause = #acc<data_clause acc_create>, implicit = true, name = "data1", structured = false}
+! CHECK:         %[[DEVPTR:.*]] = acc.getdeviceptr varPtr(%[[GLOBAL_ADDR]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) dataClause(acc_create) structured(false) implicit(true) name("data1") -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:         acc.declare_exit dataOperands(%[[DEVPTR]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
 ! CHECK:         return
 ! CHECK:       }
 
 ! CHECK-LABEL: acc.global_dtor @_QMacc_declare_allocatable_testEdata1_acc_dtor {
 ! CHECK:         %[[GLOBAL_ADDR:.*]] = fir.address_of(@_QMacc_declare_allocatable_testEdata1) {acc.declare = #acc.declare<dataClause =  acc_create>} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:         %[[DEVICEPTR:.*]] = acc.getdeviceptr varPtr(%[[GLOBAL_ADDR]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)   -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> {dataClause = #acc<data_clause acc_create>, name = "data1", structured = false}
+! CHECK:         %[[DEVICEPTR:.*]] = acc.getdeviceptr varPtr(%[[GLOBAL_ADDR]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) dataClause(acc_create) structured(false) name("data1") -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:         acc.declare_exit dataOperands(%[[DEVICEPTR]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
-! CHECK:         acc.delete accPtr(%[[DEVICEPTR]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) {dataClause = #acc<data_clause acc_create>, name = "data1", structured = false}
+! CHECK:         acc.delete accPtr(%[[DEVICEPTR]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) dataClause(acc_create) structured(false) name("data1")
 ! CHECK:         acc.terminator
 ! CHECK:       }
 
 
 ! CHECK-LABEL: acc.global_ctor @_QMacc_declare_equivalentEv2_acc_ctor {
 ! CHECK:         %[[ADDR:.*]] = fir.address_of(@_QMacc_declare_equivalentEv1) {acc.declare = #acc.declare<dataClause = acc_create>} : !fir.ref<!fir.array<40xi8>>
-! CHECK:         %[[CREATE:.*]] = acc.create varPtr(%[[ADDR]] : !fir.ref<!fir.array<40xi8>>) -> !fir.ref<!fir.array<40xi8>> {name = "v2", structured = false}
+! CHECK:         %[[CREATE:.*]] = acc.create varPtr(%[[ADDR]] : !fir.ref<!fir.array<40xi8>>) structured(false) name("v2") -> !fir.ref<!fir.array<40xi8>>
 ! CHECK:         acc.declare_enter dataOperands(%[[CREATE]] : !fir.ref<!fir.array<40xi8>>)
 ! CHECK:         acc.terminator
 ! CHECK:       }
 ! CHECK-LABEL: acc.global_dtor @_QMacc_declare_equivalentEv2_acc_dtor {
 ! CHECK:         %[[ADDR:.*]] = fir.address_of(@_QMacc_declare_equivalentEv1) {acc.declare = #acc.declare<dataClause =  acc_create>} : !fir.ref<!fir.array<40xi8>>
-! CHECK:         %[[DEVICEPTR:.*]] = acc.getdeviceptr varPtr(%[[ADDR]] : !fir.ref<!fir.array<40xi8>>) -> !fir.ref<!fir.array<40xi8>> {dataClause = #acc<data_clause acc_create>, name = "v2", structured = false}
+! CHECK:         %[[DEVICEPTR:.*]] = acc.getdeviceptr varPtr(%[[ADDR]] : !fir.ref<!fir.array<40xi8>>) dataClause(acc_create) structured(false) name("v2") -> !fir.ref<!fir.array<40xi8>>
 ! CHECK:         acc.declare_exit dataOperands(%[[DEVICEPTR]] : !fir.ref<!fir.array<40xi8>>)
-! CHECK:         acc.delete accPtr(%[[DEVICEPTR]] : !fir.ref<!fir.array<40xi8>>) {dataClause = #acc<data_clause acc_create>, name = "v2", structured = false}
+! CHECK:         acc.delete accPtr(%[[DEVICEPTR]] : !fir.ref<!fir.array<40xi8>>) dataClause(acc_create) structured(false) name("v2")
 ! CHECK:         acc.terminator
 ! CHECK:       }
 ! CHECK-LABEL: acc.global_ctor @_QMacc_declare_equivalent2Ev2_acc_ctor {
 ! CHECK:         %[[ADDR:.*]] = fir.address_of(@_QMacc_declare_equivalent2Ev1) {acc.declare = #acc.declare<dataClause =  acc_create>} : !fir.ref<!fir.array<40xi8>>
-! CHECK:         %[[CREATE:.*]] = acc.create varPtr(%[[ADDR]] : !fir.ref<!fir.array<40xi8>>) -> !fir.ref<!fir.array<40xi8>> {name = "v2", structured = false}
+! CHECK:         %[[CREATE:.*]] = acc.create varPtr(%[[ADDR]] : !fir.ref<!fir.array<40xi8>>) structured(false) name("v2") -> !fir.ref<!fir.array<40xi8>>
 ! CHECK:         acc.declare_enter dataOperands(%[[CREATE]] : !fir.ref<!fir.array<40xi8>>)
 ! CHECK:         acc.terminator
 ! CHECK:       }
 ! CHECK-LABEL: acc.global_dtor @_QMacc_declare_equivalent2Ev2_acc_dtor {
 ! CHECK:         %[[ADDR:.*]] = fir.address_of(@_QMacc_declare_equivalent2Ev1) {acc.declare = #acc.declare<dataClause =  acc_create>} : !fir.ref<!fir.array<40xi8>>
-! CHECK:         %[[DEVICEPTR:.*]] = acc.getdeviceptr varPtr(%[[ADDR]] : !fir.ref<!fir.array<40xi8>>) -> !fir.ref<!fir.array<40xi8>> {dataClause = #acc<data_clause acc_create>, name = "v2", structured = false}
+! CHECK:         %[[DEVICEPTR:.*]] = acc.getdeviceptr varPtr(%[[ADDR]] : !fir.ref<!fir.array<40xi8>>) dataClause(acc_create) structured(false) name("v2") -> !fir.ref<!fir.array<40xi8>>
 ! CHECK:         acc.declare_exit dataOperands(%[[DEVICEPTR]] : !fir.ref<!fir.array<40xi8>>)
-! CHECK:         acc.delete accPtr(%[[DEVICEPTR]] : !fir.ref<!fir.array<40xi8>>) {dataClause = #acc<data_clause acc_create>, name = "v2", structured = false}
+! CHECK:         acc.delete accPtr(%[[DEVICEPTR]] : !fir.ref<!fir.array<40xi8>>) dataClause(acc_create) structured(false) name("v2")
 ! CHECK:         acc.terminator
 ! CHECK:       }
 

--- a/flang/test/Lower/OpenACC/acc-dedup-private.f90
+++ b/flang/test/Lower/OpenACC/acc-dedup-private.f90
@@ -16,8 +16,8 @@ end subroutine
 
 ! CHECK-LABEL: func.func @_QPtest_private_pair
 ! x is privatized exactly once.
-! CHECK: acc.private varPtr({{.*}}) recipe(@privatization_ref_i32) -> !fir.ref<i32> {name = "x"}
-! CHECK-NOT: acc.private varPtr({{.*}}) recipe(@privatization_ref_i32) -> !fir.ref<i32> {name = "x"}
+! CHECK: acc.private varPtr({{.*}}) recipe(@privatization_ref_i32) name("x") -> !fir.ref<i32>
+! CHECK-NOT: acc.private varPtr({{.*}}) recipe(@privatization_ref_i32) name("x") -> !fir.ref<i32>
 
 ! -----------------------------------------------------------------------
 ! private(x, x, x) -- two duplicates (from the triple-occurrence review note)
@@ -31,8 +31,8 @@ end subroutine
 
 ! CHECK-LABEL: func.func @_QPtest_private_triple
 ! x is privatized exactly once even with three source occurrences.
-! CHECK: acc.private varPtr({{.*}}) recipe(@privatization_ref_i32) -> !fir.ref<i32> {name = "x"}
-! CHECK-NOT: acc.private varPtr({{.*}}) recipe(@privatization_ref_i32) -> !fir.ref<i32> {name = "x"}
+! CHECK: acc.private varPtr({{.*}}) recipe(@privatization_ref_i32) name("x") -> !fir.ref<i32>
+! CHECK-NOT: acc.private varPtr({{.*}}) recipe(@privatization_ref_i32) name("x") -> !fir.ref<i32>
 
 ! -----------------------------------------------------------------------
 ! private(x) private(x) -- duplicate across two separate clauses
@@ -45,8 +45,8 @@ subroutine test_private_two_clauses(i)
 end subroutine
 
 ! CHECK-LABEL: func.func @_QPtest_private_two_clauses
-! CHECK: acc.private varPtr({{.*}}) recipe(@privatization_ref_i32) -> !fir.ref<i32> {name = "x"}
-! CHECK-NOT: acc.private varPtr({{.*}}) recipe(@privatization_ref_i32) -> !fir.ref<i32> {name = "x"}
+! CHECK: acc.private varPtr({{.*}}) recipe(@privatization_ref_i32) name("x") -> !fir.ref<i32>
+! CHECK-NOT: acc.private varPtr({{.*}}) recipe(@privatization_ref_i32) name("x") -> !fir.ref<i32>
 
 ! -----------------------------------------------------------------------
 ! firstprivate(x, x)
@@ -59,5 +59,5 @@ subroutine test_firstprivate_pair(i)
 end subroutine
 
 ! CHECK-LABEL: func.func @_QPtest_firstprivate_pair
-! CHECK: acc.firstprivate varPtr({{.*}}) recipe(@firstprivatization_ref_i32) -> !fir.ref<i32> {name = "x"}
-! CHECK-NOT: acc.firstprivate varPtr({{.*}}) recipe(@firstprivatization_ref_i32) -> !fir.ref<i32> {name = "x"}
+! CHECK: acc.firstprivate varPtr({{.*}}) recipe(@firstprivatization_ref_i32) name("x") -> !fir.ref<i32>
+! CHECK-NOT: acc.firstprivate varPtr({{.*}}) recipe(@firstprivatization_ref_i32) name("x") -> !fir.ref<i32>

--- a/flang/test/Lower/OpenACC/acc-deviceptr.f90
+++ b/flang/test/Lower/OpenACC/acc-deviceptr.f90
@@ -11,8 +11,8 @@ end subroutine
 ! CHECK-LABEL:   func.func @_QPtest(
 ! CHECK:           %[[DECLARE_0:.*]]:2 = hlfir.declare {{.*}}"_QFtestEa"
 ! CHECK:           %[[DECLARE_1:.*]]:2 = hlfir.declare {{.*}}"_QFtestEb"
-! CHECK:           %[[DEVICEPTR_0:.*]] = acc.deviceptr var(%[[DECLARE_0]]#0 : !fir.box<!fir.array<?xf64>>) -> !fir.box<!fir.array<?xf64>> {name = "a"}
-! CHECK:           %[[DEVICEPTR_1:.*]] = acc.deviceptr var(%[[DECLARE_1]]#0 : !fir.box<!fir.array<?xf64>>) -> !fir.box<!fir.array<?xf64>> {name = "b"}
+! CHECK:           %[[DEVICEPTR_0:.*]] = acc.deviceptr var(%[[DECLARE_0]]#0 : !fir.box<!fir.array<?xf64>>) name("a") -> !fir.box<!fir.array<?xf64>>
+! CHECK:           %[[DEVICEPTR_1:.*]] = acc.deviceptr var(%[[DECLARE_1]]#0 : !fir.box<!fir.array<?xf64>>) name("b") -> !fir.box<!fir.array<?xf64>>
 ! CHECK:           acc.parallel combined(loop) dataOperands(%[[DEVICEPTR_0]], %[[DEVICEPTR_1]] : !fir.box<!fir.array<?xf64>>, !fir.box<!fir.array<?xf64>>) {
 ! CHECK:             %[[DECLARE_4:.*]]:2 = hlfir.declare %[[DEVICEPTR_0]]
 ! CHECK:             %[[DECLARE_5:.*]]:2 = hlfir.declare %[[DEVICEPTR_1]]

--- a/flang/test/Lower/OpenACC/acc-do-concurrent-locality.f90
+++ b/flang/test/Lower/OpenACC/acc-do-concurrent-locality.f90
@@ -25,9 +25,9 @@ subroutine reduce_kernels_region()
 end subroutine
 
 ! CHECK: acc.kernels {
-! CHECK: %[[RED:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_add{{.*}}) -> !fir.ref<f32> {name = "s"}
+! CHECK: %[[RED:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_add{{.*}}) name("s") -> !fir.ref<f32>
 ! CHECK: acc.loop {{.*}}reduction(%[[RED]] : !fir.ref<f32>)
-! CHECK: } attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+! CHECK: } inclusiveUpperbound(array<i1: true>) auto_
 
 ! Scalar reduction in parallel region (no explicit loop → independent)
 ! CHECK-LABEL: func.func @_QPreduce_parallel_region
@@ -43,9 +43,9 @@ subroutine reduce_parallel_region()
 end subroutine
 
 ! CHECK: acc.parallel {
-! CHECK: %[[RED:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_add{{.*}}) -> !fir.ref<f32> {name = "s"}
+! CHECK: %[[RED:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_add{{.*}}) name("s") -> !fir.ref<f32>
 ! CHECK: acc.loop {{.*}}reduction(%[[RED]] : !fir.ref<f32>)
-! CHECK: } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK: } inclusiveUpperbound(array<i1: true>) independent
 
 ! Combined kernels loop with reduce (auto)
 ! CHECK-LABEL: func.func @_QPreduce_kernels_loop
@@ -61,9 +61,9 @@ subroutine reduce_kernels_loop()
 end subroutine
 
 ! CHECK: acc.kernels combined(loop)
-! CHECK: %[[RED:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_add{{.*}}) -> !fir.ref<f32> {name = "s"}
+! CHECK: %[[RED:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_add{{.*}}) name("s") -> !fir.ref<f32>
 ! CHECK: acc.loop combined(kernels) {{.*}}reduction(%[[RED]] : !fir.ref<f32>)
-! CHECK: } attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true, true>}
+! CHECK: } inclusiveUpperbound(array<i1: true, true>) auto_
 
 ! Combined parallel loop with reduce (independent)
 ! CHECK-LABEL: func.func @_QPreduce_parallel_loop
@@ -78,9 +78,9 @@ subroutine reduce_parallel_loop()
 end subroutine
 
 ! CHECK: acc.parallel combined(loop)
-! CHECK: %[[RED:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_add{{.*}}) -> !fir.ref<f32> {name = "s"}
+! CHECK: %[[RED:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_add{{.*}}) name("s") -> !fir.ref<f32>
 ! CHECK: acc.loop combined(parallel) {{.*}}reduction(%[[RED]] : !fir.ref<f32>)
-! CHECK: } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK: } inclusiveUpperbound(array<i1: true>) independent
 
 ! Multiple reductions (add + multiply)
 ! CHECK-LABEL: func.func @_QPmulti_reduce
@@ -97,8 +97,8 @@ subroutine multi_reduce()
 end subroutine
 
 ! CHECK: acc.parallel combined(loop)
-! CHECK-DAG: acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_add{{.*}}) -> !fir.ref<f32> {name = "s"}
-! CHECK-DAG: acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_mul{{.*}}) -> !fir.ref<f32> {name = "p"}
+! CHECK-DAG: acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_add{{.*}}) name("s") -> !fir.ref<f32>
+! CHECK-DAG: acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_mul{{.*}}) name("p") -> !fir.ref<f32>
 ! CHECK: acc.loop {{.*}}reduction(
 
 ! Max/min reductions
@@ -116,8 +116,8 @@ subroutine reduce_max_min()
 end subroutine
 
 ! CHECK: acc.kernels combined(loop)
-! CHECK-DAG: acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_max{{.*}}) -> !fir.ref<f32> {name = "mx"}
-! CHECK-DAG: acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_min{{.*}}) -> !fir.ref<f32> {name = "mn"}
+! CHECK-DAG: acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_max{{.*}}) name("mx") -> !fir.ref<f32>
+! CHECK-DAG: acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_min{{.*}}) name("mn") -> !fir.ref<f32>
 ! CHECK: acc.loop {{.*}}reduction(
 
 ! Integer multiply reduction
@@ -132,7 +132,7 @@ subroutine int_reduce()
 end subroutine
 
 ! CHECK: acc.kernels combined(loop)
-! CHECK: acc.reduction varPtr(%{{.*}} : !fir.ref<i32>) recipe(@reduction_mul{{.*}}) -> !fir.ref<i32> {name = "prod"}
+! CHECK: acc.reduction varPtr(%{{.*}} : !fir.ref<i32>) recipe(@reduction_mul{{.*}}) name("prod") -> !fir.ref<i32>
 
 ! ---------------------------------------------------------------------------
 ! LOCAL locality spec → acc.private
@@ -152,9 +152,9 @@ subroutine local_kernels_region()
 end subroutine
 
 ! CHECK: acc.kernels {
-! CHECK: %[[PRIV:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<f32>) recipe(@privatization_ref_f32) -> !fir.ref<f32> {name = "tmp"}
+! CHECK: %[[PRIV:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<f32>) recipe(@privatization_ref_f32) name("tmp") -> !fir.ref<f32>
 ! CHECK: acc.loop private(%[[PRIV]],
-! CHECK: } attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+! CHECK: } inclusiveUpperbound(array<i1: true>) auto_
 
 ! LOCAL in parallel region (independent)
 ! CHECK-LABEL: func.func @_QPlocal_parallel_region
@@ -170,9 +170,9 @@ subroutine local_parallel_region()
 end subroutine
 
 ! CHECK: acc.parallel {
-! CHECK: %[[PRIV:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<f32>) recipe(@privatization_ref_f32) -> !fir.ref<f32> {name = "tmp"}
+! CHECK: %[[PRIV:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<f32>) recipe(@privatization_ref_f32) name("tmp") -> !fir.ref<f32>
 ! CHECK: acc.loop private(%[[PRIV]],
-! CHECK: } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK: } inclusiveUpperbound(array<i1: true>) independent
 
 ! ---------------------------------------------------------------------------
 ! LOCAL_INIT locality spec → acc.firstprivate
@@ -192,9 +192,9 @@ subroutine local_init_kernels_region()
 end subroutine
 
 ! CHECK: acc.kernels {
-! CHECK: %[[FP:.*]] = acc.firstprivate varPtr(%{{.*}} : !fir.ref<f32>) recipe(@firstprivatization_ref_f32) -> !fir.ref<f32> {name = "scale"}
+! CHECK: %[[FP:.*]] = acc.firstprivate varPtr(%{{.*}} : !fir.ref<f32>) recipe(@firstprivatization_ref_f32) name("scale") -> !fir.ref<f32>
 ! CHECK: acc.loop {{.*}}firstprivate(%[[FP]] : !fir.ref<f32>)
-! CHECK: } attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+! CHECK: } inclusiveUpperbound(array<i1: true>) auto_
 
 ! ---------------------------------------------------------------------------
 ! Mixed locality specs: REDUCE + LOCAL
@@ -213,10 +213,10 @@ subroutine mixed_locality()
 end subroutine
 
 ! CHECK: acc.parallel combined(loop)
-! CHECK-DAG: %[[RED:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_add{{.*}}) -> !fir.ref<f32> {name = "s"}
-! CHECK-DAG: %[[PRIV:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<f32>) recipe(@privatization_ref_f32) -> !fir.ref<f32> {name = "tmp"}
+! CHECK-DAG: %[[RED:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_add{{.*}}) name("s") -> !fir.ref<f32>
+! CHECK-DAG: %[[PRIV:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<f32>) recipe(@privatization_ref_f32) name("tmp") -> !fir.ref<f32>
 ! CHECK: acc.loop {{.*}}reduction(%[[RED]] : !fir.ref<f32>)
-! CHECK: } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK: } inclusiveUpperbound(array<i1: true>) independent
 
 ! ---------------------------------------------------------------------------
 ! Reduce combined with explicit ACC reduction clause
@@ -236,8 +236,8 @@ subroutine reduce_with_acc_clause()
 end subroutine
 
 ! CHECK: acc.parallel combined(loop)
-! CHECK-DAG: acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_add{{.*}}) -> !fir.ref<f32> {name = "s1"}
-! CHECK-DAG: acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_add{{.*}}) -> !fir.ref<f32> {name = "s2"}
+! CHECK-DAG: acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_add{{.*}}) name("s1") -> !fir.ref<f32>
+! CHECK-DAG: acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_add{{.*}}) name("s2") -> !fir.ref<f32>
 ! CHECK: acc.loop {{.*}}reduction(
 
 ! ---------------------------------------------------------------------------
@@ -257,9 +257,9 @@ subroutine reduce_kernels_loop_auto()
 end subroutine
 
 ! CHECK: acc.kernels combined(loop)
-! CHECK: %[[RED:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_add{{.*}}) -> !fir.ref<f32> {name = "s"}
+! CHECK: %[[RED:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_add{{.*}}) name("s") -> !fir.ref<f32>
 ! CHECK: acc.loop combined(kernels) {{.*}}reduction(%[[RED]] : !fir.ref<f32>)
-! CHECK: } attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+! CHECK: } inclusiveUpperbound(array<i1: true>) auto_
 
 ! kernels loop seq with reduce
 ! CHECK-LABEL: func.func @_QPreduce_kernels_loop_seq
@@ -274,9 +274,9 @@ subroutine reduce_kernels_loop_seq()
 end subroutine
 
 ! CHECK: acc.kernels combined(loop)
-! CHECK: %[[RED:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_add{{.*}}) -> !fir.ref<f32> {name = "s"}
+! CHECK: %[[RED:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_add{{.*}}) name("s") -> !fir.ref<f32>
 ! CHECK: acc.loop combined(kernels) {{.*}}reduction(%[[RED]] : !fir.ref<f32>)
-! CHECK: } attributes {inclusiveUpperbound = array<i1: true>, seq = [#acc.device_type<none>]}
+! CHECK: } inclusiveUpperbound(array<i1: true>) seq
 
 ! kernels loop independent with reduce
 ! CHECK-LABEL: func.func @_QPreduce_kernels_loop_independent
@@ -291,6 +291,6 @@ subroutine reduce_kernels_loop_independent()
 end subroutine
 
 ! CHECK: acc.kernels combined(loop)
-! CHECK: %[[RED:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_add{{.*}}) -> !fir.ref<f32> {name = "s"}
+! CHECK: %[[RED:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_add{{.*}}) name("s") -> !fir.ref<f32>
 ! CHECK: acc.loop combined(kernels) {{.*}}reduction(%[[RED]] : !fir.ref<f32>)
-! CHECK: } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK: } inclusiveUpperbound(array<i1: true>) independent

--- a/flang/test/Lower/OpenACC/acc-enter-data.f90
+++ b/flang/test/Lower/OpenACC/acc-enter-data.f90
@@ -28,73 +28,73 @@ subroutine acc_enter_data
 !CHECK: %[[DECLD:.*]]:2 = hlfir.declare %[[D]]
 
   !$acc enter data create(a)
-!CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "a", structured = false}
+!CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE_A]] : !fir.ref<!fir.array<10x10xf32>>){{$}}
 
   !$acc enter data create(a) if(.true.)
-!CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "a", structured = false}
+!CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 !CHECK: [[IF1:%.*]] = arith.constant true
 !CHECK: acc.enter_data if([[IF1]]) dataOperands(%[[CREATE_A]] : !fir.ref<!fir.array<10x10xf32>>){{$}}
 
   !$acc enter data create(a) if(ifCondition)
-!CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "a", structured = false}
+!CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 !CHECK: [[IFCOND:%.*]] = fir.load %{{.*}} : !fir.ref<!fir.logical<4>>
 !CHECK: [[IF2:%.*]] = fir.convert [[IFCOND]] : (!fir.logical<4>) -> i1
 !CHECK: acc.enter_data if([[IF2]]) dataOperands(%[[CREATE_A]] : !fir.ref<!fir.array<10x10xf32>>){{$}}
 
   !$acc enter data create(a) create(b) create(c)
-!CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "a", structured = false}
-!CHECK: %[[CREATE_B:.*]] = acc.create varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "b", structured = false}
-!CHECK: %[[CREATE_C:.*]] = acc.create varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "c", structured = false}
+!CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+!CHECK: %[[CREATE_B:.*]] = acc.create varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+!CHECK: %[[CREATE_C:.*]] = acc.create varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE_A]], %[[CREATE_B]], %[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>){{$}}
 
   !$acc enter data create(a) create(b) create(zero: c)
-!CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "a", structured = false}
-!CHECK: %[[CREATE_B:.*]] = acc.create varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "b", structured = false}
-!CHECK: %[[CREATE_C:.*]] = acc.create varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_create_zero>, name = "c", structured = false}
+!CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+!CHECK: %[[CREATE_B:.*]] = acc.create varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+!CHECK: %[[CREATE_C:.*]] = acc.create varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_create_zero) structured(false) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE_A]], %[[CREATE_B]], %[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>){{$}}
 
   !$acc enter data copyin(a) create(b) attach(d)
-!CHECK: %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "a", structured = false}
-!CHECK: %[[CREATE_B:.*]] = acc.create varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "b", structured = false}
-!CHECK: %[[ATTACH_D:.*]] = acc.attach varPtr(%[[DECLD]]#0 : !fir.ref<!fir.box<!fir.ptr<f32>>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>> {name = "d", structured = false}
+!CHECK: %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+!CHECK: %[[CREATE_B:.*]] = acc.create varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+!CHECK: %[[ATTACH_D:.*]] = acc.attach varPtr(%[[DECLD]]#0 : !fir.ref<!fir.box<!fir.ptr<f32>>>) structured(false) name("d") -> !fir.ref<!fir.box<!fir.ptr<f32>>>
 !CHECK: acc.enter_data dataOperands(%[[COPYIN_A]], %[[CREATE_B]], %[[ATTACH_D]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.box<!fir.ptr<f32>>>){{$}}
 
   !$acc enter data create(a) async
-!CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) async -> !fir.ref<!fir.array<10x10xf32>> {name = "a", structured = false}
+!CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) async structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 !CHECK: acc.enter_data async dataOperands(%[[CREATE_A]] : !fir.ref<!fir.array<10x10xf32>>)
 
   !$acc enter data create(a) wait
-!CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "a", structured = false}
+!CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 !CHECK: acc.enter_data wait dataOperands(%[[CREATE_A]] : !fir.ref<!fir.array<10x10xf32>>)
 
   !$acc enter data create(a) async wait
-!CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) async -> !fir.ref<!fir.array<10x10xf32>> {name = "a", structured = false}
+!CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) async structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 !CHECK: acc.enter_data async wait dataOperands(%[[CREATE_A]] : !fir.ref<!fir.array<10x10xf32>>)
 
   !$acc enter data create(a) async(1)
 !CHECK: %[[ASYNC1:.*]] = arith.constant 1 : i32
-!CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) async(%[[ASYNC1]] : i32) -> !fir.ref<!fir.array<10x10xf32>> {name = "a", structured = false}
+!CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) async(%[[ASYNC1]] : i32) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 !CHECK: acc.enter_data async(%[[ASYNC1]] : i32) dataOperands(%[[CREATE_A]] : !fir.ref<!fir.array<10x10xf32>>)
 
   !$acc enter data create(a) async(async)
 !CHECK: %[[ASYNC2:.*]] = fir.load %{{.*}} : !fir.ref<i32>
-!CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) async(%[[ASYNC2]] : i32) -> !fir.ref<!fir.array<10x10xf32>> {name = "a", structured = false}
+!CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) async(%[[ASYNC2]] : i32) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 !CHECK: acc.enter_data async(%[[ASYNC2]] : i32) dataOperands(%[[CREATE_A]] : !fir.ref<!fir.array<10x10xf32>>)
 
   !$acc enter data create(a) wait(1)
-!CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "a", structured = false}
+!CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 !CHECK: %[[WAIT1:.*]] = arith.constant 1 : i32
 !CHECK: acc.enter_data wait(%[[WAIT1]] : i32) dataOperands(%[[CREATE_A]] : !fir.ref<!fir.array<10x10xf32>>)
 
   !$acc enter data create(a) wait(queues: 1, 2)
-!CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "a", structured = false}
+!CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 !CHECK: %[[WAIT2:.*]] = arith.constant 1 : i32
 !CHECK: %[[WAIT3:.*]] = arith.constant 2 : i32
 !CHECK: acc.enter_data wait(%[[WAIT2]], %[[WAIT3]] : i32, i32) dataOperands(%[[CREATE_A]] : !fir.ref<!fir.array<10x10xf32>>)
 
   !$acc enter data create(a) wait(devnum: 1: queues: 1, 2)
-!CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "a", structured = false}
+!CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 !CHECK: %[[WAIT4:.*]] = arith.constant 1 : i32
 !CHECK: %[[WAIT5:.*]] = arith.constant 2 : i32
 !CHECK: %[[WAIT6:.*]] = arith.constant 1 : i32
@@ -103,7 +103,7 @@ subroutine acc_enter_data
   !$acc enter data copyin(a(1:10,1:5))
 !CHECK: %[[BOUND0:.*]] = acc.bounds lowerbound(%{{.*}} : index) upperbound(%{{.*}} : index) extent(%[[C10]] : index) stride(%c1{{.*}} : index) startIdx(%{{.*}} : index)
 !CHECK: %[[BOUND1:.*]] = acc.bounds lowerbound(%{{.*}} : index) upperbound(%{{.*}} : index) extent(%[[EXTENT_C10]] : index) stride(%c1{{.*}} : index) startIdx(%{{.*}} : index)
-!CHECK: %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) bounds(%[[BOUND0]], %[[BOUND1]]) -> !fir.ref<!fir.array<10x10xf32>> {name = "a(1:10,1:5)", structured = false}
+!CHECK: %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) bounds(%[[BOUND0]], %[[BOUND1]]) structured(false) name("a(1:10,1:5)") -> !fir.ref<!fir.array<10x10xf32>>
 !CHECK: acc.enter_data dataOperands(%[[COPYIN_A]] : !fir.ref<!fir.array<10x10xf32>>)
 
   !$acc enter data copyin(a(1:,1:5))
@@ -114,7 +114,7 @@ subroutine acc_enter_data
 !CHECK: %[[LB2:.*]] = arith.constant 0 : index
 !CHECK: %[[UB2:.*]] = arith.constant 4 : index
 !CHECK: %[[BOUND2:.*]] = acc.bounds lowerbound(%[[LB2]] : index) upperbound(%[[UB2]] : index) extent(%[[EXTENT_C10]] : index) stride(%c1{{.*}} : index) startIdx(%c1{{.*}} : index)
-!CHECK: %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) bounds(%[[BOUND1]], %[[BOUND2]]) -> !fir.ref<!fir.array<10x10xf32>> {name = "a(1:,1:5)", structured = false}
+!CHECK: %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) bounds(%[[BOUND1]], %[[BOUND2]]) structured(false) name("a(1:,1:5)") -> !fir.ref<!fir.array<10x10xf32>>
 !CHECK: acc.enter_data   dataOperands(%[[COPYIN_A]] : !fir.ref<!fir.array<10x10xf32>>)
 
   !$acc enter data copyin(a(:10,1:5))
@@ -125,7 +125,7 @@ subroutine acc_enter_data
 !CHECK: %[[LB:.*]] = arith.constant 0 : index
 !CHECK: %[[UB2:.*]] = arith.constant 4 : index
 !CHECK: %[[BOUND2:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB2]] : index) extent(%[[EXTENT_C10]] : index) stride(%c1{{.*}} : index) startIdx(%[[ONE]] : index)
-!CHECK: %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) bounds(%[[BOUND1]], %[[BOUND2]]) -> !fir.ref<!fir.array<10x10xf32>> {name = "a(:10,1:5)", structured = false}
+!CHECK: %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) bounds(%[[BOUND1]], %[[BOUND2]]) structured(false) name("a(:10,1:5)") -> !fir.ref<!fir.array<10x10xf32>>
 !CHECK: acc.enter_data dataOperands(%[[COPYIN_A]] : !fir.ref<!fir.array<10x10xf32>>)
 
   !$acc enter data copyin(a(:,:))
@@ -135,7 +135,7 @@ subroutine acc_enter_data
 !CHECK: %[[BOUND1:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%c10{{.*}} : index) stride(%[[ONE]] : index) startIdx(%[[ONE]] : index)
 !CHECK: %[[UB:.*]] = arith.subi %c10{{.*}}, %[[ONE]] : index
 !CHECK: %[[BOUND2:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%c10{{.*}} : index) stride(%c1{{.*}} : index) startIdx(%c1{{.*}} : index)
-!CHECK: %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) bounds(%[[BOUND1]], %[[BOUND2]]) -> !fir.ref<!fir.array<10x10xf32>> {name = "a(:,:)", structured = false}
+!CHECK: %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) bounds(%[[BOUND1]], %[[BOUND2]]) structured(false) name("a(:,:)") -> !fir.ref<!fir.array<10x10xf32>>
 end subroutine acc_enter_data
 
 subroutine acc_enter_data_dummy(a, b, n, m)
@@ -164,11 +164,11 @@ subroutine acc_enter_data_dummy(a, b, n, m)
 !CHECK: %[[DECLB:.*]]:2 = hlfir.declare %[[B]]
 
   !$acc enter data create(a)
-!CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "a", structured = false}
+!CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) structured(false) name("a") -> !fir.ref<!fir.array<10xf32>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.ref<!fir.array<10xf32>>)
 
   !$acc enter data create(b)
-!CHECK: %[[CREATE:.*]] = acc.create var(%[[DECLB]]#0 : !fir.box<!fir.array<?xf32>>) -> !fir.box<!fir.array<?xf32>> {name = "b", structured = false}
+!CHECK: %[[CREATE:.*]] = acc.create var(%[[DECLB]]#0 : !fir.box<!fir.array<?xf32>>) structured(false) name("b") -> !fir.box<!fir.array<?xf32>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.box<!fir.array<?xf32>>)
 
   !$acc enter data create(a(5:10))
@@ -176,7 +176,7 @@ subroutine acc_enter_data_dummy(a, b, n, m)
 !CHECK: %[[LB1:.*]] = arith.constant 4 : index
 !CHECK: %[[UB1:.*]] = arith.constant 9 : index
 !CHECK: %[[BOUND1:.*]] = acc.bounds lowerbound(%[[LB1]] : index) upperbound(%[[UB1]] : index) extent(%c10{{.*}} : index) stride(%[[ONE]] : index) startIdx(%c1{{.*}} : index)
-!CHECK: %[[CREATE1:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) bounds(%[[BOUND1]]) -> !fir.ref<!fir.array<10xf32>> {name = "a(5:10)", structured = false}
+!CHECK: %[[CREATE1:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) bounds(%[[BOUND1]]) structured(false) name("a(5:10)") -> !fir.ref<!fir.array<10xf32>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE1]] : !fir.ref<!fir.array<10xf32>>)
 
   !$acc enter data create(b(n:m))
@@ -189,8 +189,8 @@ subroutine acc_enter_data_dummy(a, b, n, m)
 !CHECK: %[[M_CONV1:.*]] = fir.convert %[[LOAD_M]] : (i32) -> i64
 !CHECK: %[[M_CONV2:.*]] = fir.convert %[[M_CONV1]] : (i64) -> index
 !CHECK: %[[UB:.*]] = arith.subi %[[M_CONV2]], %[[N_IDX]] : index
-!CHECK: %[[BOUND1:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%[[EXT_B]] : index) stride(%[[DIMS0]]#2 : index) startIdx(%[[N_IDX]] : index) {strideInBytes = true}
-!CHECK: %[[CREATE1:.*]] = acc.create var(%[[DECLB]]#0 : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND1]]) -> !fir.box<!fir.array<?xf32>> {name = "b(n:m)", structured = false}
+!CHECK: %[[BOUND1:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%[[EXT_B]] : index) stride(%[[DIMS0]]#2 : index) startIdx(%[[N_IDX]] : index) strideInBytes(true)
+!CHECK: %[[CREATE1:.*]] = acc.create var(%[[DECLB]]#0 : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND1]]) structured(false) name("b(n:m)") -> !fir.box<!fir.array<?xf32>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE1]] : !fir.box<!fir.array<?xf32>>)
 
   !$acc enter data create(b(n:))
@@ -201,8 +201,8 @@ subroutine acc_enter_data_dummy(a, b, n, m)
 !CHECK: %[[CONVERT2_N:.*]] = fir.convert %[[CONVERT1_N]] : (i64) -> index
 !CHECK: %[[LB:.*]] = arith.subi %[[CONVERT2_N]], %[[N_IDX]] : index
 !CHECK: %[[UB:.*]] = arith.subi %[[EXT_B]], %c1{{.*}} : index
-!CHECK: %[[BOUND1:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%[[EXT_B]] : index) stride(%[[DIMS0]]#2 : index) startIdx(%[[N_IDX]] : index) {strideInBytes = true}
-!CHECK: %[[CREATE1:.*]] = acc.create var(%[[DECLB]]#0 : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND1]]) -> !fir.box<!fir.array<?xf32>> {name = "b(n:)", structured = false}
+!CHECK: %[[BOUND1:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%[[EXT_B]] : index) stride(%[[DIMS0]]#2 : index) startIdx(%[[N_IDX]] : index) strideInBytes(true)
+!CHECK: %[[CREATE1:.*]] = acc.create var(%[[DECLB]]#0 : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND1]]) structured(false) name("b(n:)") -> !fir.box<!fir.array<?xf32>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE1]] : !fir.box<!fir.array<?xf32>>)
 
   !$acc enter data create(b(:))
@@ -210,8 +210,8 @@ subroutine acc_enter_data_dummy(a, b, n, m)
 !CHECK: %[[ONE:.*]] = arith.constant 1 : index
 !CHECK: %[[DIMS0:.*]]:3 = fir.box_dims %[[DECLB]]#0, %c0{{.*}} : (!fir.box<!fir.array<?xf32>>, index) -> (index, index, index)
 !CHECK: %[[UB:.*]] = arith.subi %[[EXT_B]], %[[ONE]] : index
-!CHECK: %[[BOUND1:.*]] = acc.bounds lowerbound(%[[ZERO]] : index) upperbound(%[[UB]] : index) extent(%[[EXT_B]] : index) stride(%[[DIMS0]]#2 : index) startIdx(%[[N_IDX]] : index) {strideInBytes = true}
-!CHECK: %[[CREATE1:.*]] = acc.create var(%[[DECLB]]#0 : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND1]]) -> !fir.box<!fir.array<?xf32>> {name = "b(:)", structured = false}
+!CHECK: %[[BOUND1:.*]] = acc.bounds lowerbound(%[[ZERO]] : index) upperbound(%[[UB]] : index) extent(%[[EXT_B]] : index) stride(%[[DIMS0]]#2 : index) startIdx(%[[N_IDX]] : index) strideInBytes(true)
+!CHECK: %[[CREATE1:.*]] = acc.create var(%[[DECLB]]#0 : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND1]]) structured(false) name("b(:)") -> !fir.box<!fir.array<?xf32>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE1]] : !fir.box<!fir.array<?xf32>>)
 
 end subroutine
@@ -235,7 +235,7 @@ subroutine acc_enter_data_non_default_lb()
 !CHECK: %[[SECTIONUB:.*]] = arith.constant 9 : index
 !CHECK: %[[UB:.*]] = arith.subi %[[SECTIONUB]], %[[BASELB]] : index
 !CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%c10{{.*}} : index) stride(%{{.*}} : index) startIdx(%[[BASELB]] : index)
-!CHECK: %[[CREATE:.*]] = acc.create var(%[[DECLA]]#0 : !fir.box<!fir.array<10xi32>>) bounds(%[[BOUND]]) -> !fir.box<!fir.array<10xi32>> {name = "a(5:9)", structured = false}
+!CHECK: %[[CREATE:.*]] = acc.create var(%[[DECLA]]#0 : !fir.box<!fir.array<10xi32>>) bounds(%[[BOUND]]) structured(false) name("a(5:9)") -> !fir.box<!fir.array<10xi32>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.box<!fir.array<10xi32>>)
 
   !$acc enter data create(a(:))
@@ -243,7 +243,7 @@ subroutine acc_enter_data_non_default_lb()
 !CHECK: %[[ONE:.*]] = arith.constant 1 : index
 !CHECK: %[[UB:.*]] = arith.subi %[[EXTENT_C10]], %[[ONE]] : index
 !CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[ZERO]] : index) upperbound(%[[UB]] : index) extent(%[[EXTENT_C10]] : index) stride(%{{.*}} : index) startIdx(%[[BASELB]] : index)
-!CHECK: %[[CREATE:.*]] = acc.create var(%[[DECLA]]#0 : !fir.box<!fir.array<10xi32>>) bounds(%[[BOUND]]) -> !fir.box<!fir.array<10xi32>> {name = "a(:)", structured = false}
+!CHECK: %[[CREATE:.*]] = acc.create var(%[[DECLA]]#0 : !fir.box<!fir.array<10xi32>>) bounds(%[[BOUND]]) structured(false) name("a(:)") -> !fir.box<!fir.array<10xi32>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.box<!fir.array<10xi32>>)
 
   !$acc enter data create(a(:6))
@@ -251,7 +251,7 @@ subroutine acc_enter_data_non_default_lb()
 !CHECK: %[[SECTIONUB:.*]] = arith.constant 6 : index
 !CHECK: %[[UB:.*]] = arith.subi %[[SECTIONUB]], %[[BASELB]] : index
 !CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[ZERO]] : index) upperbound(%[[UB]] : index) extent(%c10{{.*}} : index) stride(%{{.*}} : index) startIdx(%[[BASELB]] : index)
-!CHECK: %[[CREATE:.*]] = acc.create var(%[[DECLA]]#0 : !fir.box<!fir.array<10xi32>>) bounds(%[[BOUND]]) -> !fir.box<!fir.array<10xi32>> {name = "a(:6)", structured = false}
+!CHECK: %[[CREATE:.*]] = acc.create var(%[[DECLA]]#0 : !fir.box<!fir.array<10xi32>>) bounds(%[[BOUND]]) structured(false) name("a(:6)") -> !fir.box<!fir.array<10xi32>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.box<!fir.array<10xi32>>)
 
   !$acc enter data create(a(4:))
@@ -260,11 +260,11 @@ subroutine acc_enter_data_non_default_lb()
 !CHECK: %[[LB:.*]] = arith.subi %[[SECTIONLB]], %[[BASELB]] : index
 !CHECK: %[[UB:.*]] = arith.subi %[[EXTENT_C10]], %[[ONE]] : index
 !CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%[[EXTENT_C10]] : index) stride(%{{.*}} : index) startIdx(%[[BASELB]] : index)
-!CHECK: %[[CREATE:.*]] = acc.create var(%[[DECLA]]#0 : !fir.box<!fir.array<10xi32>>) bounds(%[[BOUND]]) -> !fir.box<!fir.array<10xi32>> {name = "a(4:)", structured = false}
+!CHECK: %[[CREATE:.*]] = acc.create var(%[[DECLA]]#0 : !fir.box<!fir.array<10xi32>>) bounds(%[[BOUND]]) structured(false) name("a(4:)") -> !fir.box<!fir.array<10xi32>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.box<!fir.array<10xi32>>)
 
   !$acc enter data create(b)
-!CHECK: %[[CREATE:.*]] = acc.create var(%[[DECLB]]#0 : !fir.box<!fir.array<10xi32>>) -> !fir.box<!fir.array<10xi32>> {name = "b", structured = false}
+!CHECK: %[[CREATE:.*]] = acc.create var(%[[DECLB]]#0 : !fir.box<!fir.array<10xi32>>) structured(false) name("b") -> !fir.box<!fir.array<10xi32>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.box<!fir.array<10xi32>>)
 
 end subroutine
@@ -285,7 +285,7 @@ subroutine acc_enter_data_assumed(a, b, n, m)
 !CHECK: %[[DECLN:.*]]:2 = hlfir.declare %[[N]]
 
   !$acc enter data create(a)
-!CHECK: %[[CREATE:.*]] = acc.create var(%[[DECLA]]#0 : !fir.box<!fir.array<?xf32>>) -> !fir.box<!fir.array<?xf32>> {name = "a", structured = false}
+!CHECK: %[[CREATE:.*]] = acc.create var(%[[DECLA]]#0 : !fir.box<!fir.array<?xf32>>) structured(false) name("a") -> !fir.box<!fir.array<?xf32>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.box<!fir.array<?xf32>>)
 
   !$acc enter data create(a(:))
@@ -298,9 +298,9 @@ subroutine acc_enter_data_assumed(a, b, n, m)
 
 !CHECK: %[[DIMS1:.*]]:3 = fir.box_dims %[[DECLA]]#1, %[[C0]] : (!fir.box<!fir.array<?xf32>>, index) -> (index, index, index)
 !CHECK: %[[UB:.*]] = arith.subi %[[DIMS1]]#1, %[[ONE]] : index
-!CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%[[DIMS1]]#1 : index) stride(%[[DIMS0]]#2 : index) startIdx(%[[ONE]] : index) {strideInBytes = true}
+!CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%[[DIMS1]]#1 : index) stride(%[[DIMS0]]#2 : index) startIdx(%[[ONE]] : index) strideInBytes(true)
 
-!CHECK: %[[CREATE:.*]] = acc.create var(%[[DECLA]]#0 : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND]]) -> !fir.box<!fir.array<?xf32>> {name = "a(:)", structured = false}
+!CHECK: %[[CREATE:.*]] = acc.create var(%[[DECLA]]#0 : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND]]) structured(false) name("a(:)") -> !fir.box<!fir.array<?xf32>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.box<!fir.array<?xf32>>)
 
   !$acc enter data create(a(2:))
@@ -313,9 +313,9 @@ subroutine acc_enter_data_assumed(a, b, n, m)
 
 !CHECK: %[[DIMS1:.*]]:3 = fir.box_dims %[[DECLA]]#1, %[[C0]] : (!fir.box<!fir.array<?xf32>>, index) -> (index, index, index)
 !CHECK: %[[UB:.*]] = arith.subi %[[DIMS1]]#1, %[[ONE]] : index
-!CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%[[DIMS1]]#1 : index) stride(%[[DIMS0]]#2 : index) startIdx(%[[ONE]] : index) {strideInBytes = true}
+!CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%[[DIMS1]]#1 : index) stride(%[[DIMS0]]#2 : index) startIdx(%[[ONE]] : index) strideInBytes(true)
 
-!CHECK: %[[CREATE:.*]] = acc.create var(%[[DECLA]]#0 : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND]]) -> !fir.box<!fir.array<?xf32>> {name = "a(2:)", structured = false}
+!CHECK: %[[CREATE:.*]] = acc.create var(%[[DECLA]]#0 : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND]]) structured(false) name("a(2:)") -> !fir.box<!fir.array<?xf32>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.box<!fir.array<?xf32>>)
 
   !$acc enter data create(a(:4))
@@ -326,8 +326,8 @@ subroutine acc_enter_data_assumed(a, b, n, m)
 !CHECK: %[[DIMS0:.*]]:3 = fir.box_dims %[[DECLA]]#0, %[[C0]] : (!fir.box<!fir.array<?xf32>>, index) -> (index, index, index)
 !CHECK: %[[UB:.*]] = arith.constant 3 : index
 !CHECK: %[[DIMS1:.*]]:3 = fir.box_dims %[[DECLA]]#1, %{{.*}} : (!fir.box<!fir.array<?xf32>>, index) -> (index, index, index)
-!CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%[[DIMS1]]#1 : index) stride(%[[DIMS0]]#2 : index) startIdx(%[[ONE]] : index) {strideInBytes = true}
-!CHECK: %[[CREATE:.*]] = acc.create var(%[[DECLA]]#0 : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND]]) -> !fir.box<!fir.array<?xf32>> {name = "a(:4)", structured = false}
+!CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%[[DIMS1]]#1 : index) stride(%[[DIMS0]]#2 : index) startIdx(%[[ONE]] : index) strideInBytes(true)
+!CHECK: %[[CREATE:.*]] = acc.create var(%[[DECLA]]#0 : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND]]) structured(false) name("a(:4)") -> !fir.box<!fir.array<?xf32>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.box<!fir.array<?xf32>>)
 
   !$acc enter data create(a(6:10))
@@ -337,8 +337,8 @@ subroutine acc_enter_data_assumed(a, b, n, m)
 !CHECK: %[[LB:.*]] = arith.constant 5 : index
 !CHECK: %[[UB:.*]] = arith.constant 9 : index
 !CHECK: %[[DIMS1:.*]]:3 = fir.box_dims %[[DECLA]]#1, %{{.*}} : (!fir.box<!fir.array<?xf32>>, index) -> (index, index, index)
-!CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%[[DIMS1]]#1 : index) stride(%[[DIMS0]]#2 : index) startIdx(%[[ONE]] : index) {strideInBytes = true}
-!CHECK: %[[CREATE:.*]] = acc.create var(%[[DECLA]]#0 : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND]]) -> !fir.box<!fir.array<?xf32>> {name = "a(6:10)", structured = false}
+!CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%[[DIMS1]]#1 : index) stride(%[[DIMS0]]#2 : index) startIdx(%[[ONE]] : index) strideInBytes(true)
+!CHECK: %[[CREATE:.*]] = acc.create var(%[[DECLA]]#0 : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND]]) structured(false) name("a(6:10)") -> !fir.box<!fir.array<?xf32>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.box<!fir.array<?xf32>>)
 
   !$acc enter data create(a(n:))
@@ -352,8 +352,8 @@ subroutine acc_enter_data_assumed(a, b, n, m)
 !CHECK: %[[C0:.*]] = arith.constant 0 : index
 !CHECK: %[[DIMS:.*]]:3 = fir.box_dims %[[DECLA]]#1, %[[C0]] : (!fir.box<!fir.array<?xf32>>, index) -> (index, index, index)
 !CHECK: %[[UB:.*]] = arith.subi %[[DIMS]]#1, %[[ONE]] : index
-!CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%[[DIMS]]#1 : index) stride(%[[DIMS0]]#2 : index) startIdx(%[[ONE]] : index) {strideInBytes = true}
-!CHECK: %[[CREATE:.*]] = acc.create var(%[[DECLA]]#0 : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND]]) -> !fir.box<!fir.array<?xf32>> {name = "a(n:)", structured = false}
+!CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%[[DIMS]]#1 : index) stride(%[[DIMS0]]#2 : index) startIdx(%[[ONE]] : index) strideInBytes(true)
+!CHECK: %[[CREATE:.*]] = acc.create var(%[[DECLA]]#0 : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND]]) structured(false) name("a(n:)") -> !fir.box<!fir.array<?xf32>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.box<!fir.array<?xf32>>)
 
   !$acc enter data create(a(:m))
@@ -366,8 +366,8 @@ subroutine acc_enter_data_assumed(a, b, n, m)
 !CHECK: %[[CONVERT2_M:.*]] = fir.convert %[[CONVERT1_M]] : (i64) -> index
 !CHECK: %[[UB:.*]] = arith.subi %[[CONVERT2_M]], %[[ONE]] : index
 !CHECK: %[[DIMS1:.*]]:3 = fir.box_dims %[[DECLA]]#1, %{{.*}} : (!fir.box<!fir.array<?xf32>>, index) -> (index, index, index)
-!CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[BASELB]] : index) upperbound(%[[UB]] : index) extent(%[[DIMS1]]#1 : index) stride(%[[DIMS0]]#2 : index) startIdx(%[[ONE]] : index) {strideInBytes = true}
-!CHECK: %[[CREATE:.*]] = acc.create var(%[[DECLA]]#0 : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND]]) -> !fir.box<!fir.array<?xf32>> {name = "a(:m)", structured = false}
+!CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[BASELB]] : index) upperbound(%[[UB]] : index) extent(%[[DIMS1]]#1 : index) stride(%[[DIMS0]]#2 : index) startIdx(%[[ONE]] : index) strideInBytes(true)
+!CHECK: %[[CREATE:.*]] = acc.create var(%[[DECLA]]#0 : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND]]) structured(false) name("a(:m)") -> !fir.box<!fir.array<?xf32>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.box<!fir.array<?xf32>>)
 
   !$acc enter data create(a(n:m))
@@ -383,8 +383,8 @@ subroutine acc_enter_data_assumed(a, b, n, m)
 !CHECK: %[[CONVERT2_M:.*]] = fir.convert %[[CONVERT1_M]] : (i64) -> index
 !CHECK: %[[UB:.*]] = arith.subi %[[CONVERT2_M]], %[[ONE]] : index
 !CHECK: %[[DIMS1:.*]]:3 = fir.box_dims %[[DECLA]]#1, %{{.*}} : (!fir.box<!fir.array<?xf32>>, index) -> (index, index, index)
-!CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%[[DIMS1]]#1 : index) stride(%[[DIMS0]]#2 : index) startIdx(%[[ONE]] : index) {strideInBytes = true}
-!CHECK: %[[CREATE:.*]] = acc.create var(%[[DECLA]]#0 : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND]]) -> !fir.box<!fir.array<?xf32>> {name = "a(n:m)", structured = false}
+!CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%[[DIMS1]]#1 : index) stride(%[[DIMS0]]#2 : index) startIdx(%[[ONE]] : index) strideInBytes(true)
+!CHECK: %[[CREATE:.*]] = acc.create var(%[[DECLA]]#0 : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND]]) structured(false) name("a(n:m)") -> !fir.box<!fir.array<?xf32>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.box<!fir.array<?xf32>>)
 
   !$acc enter data create(b(:m))
@@ -396,12 +396,12 @@ subroutine acc_enter_data_assumed(a, b, n, m)
 !CHECK: %[[CONVERT2_M:.*]] = fir.convert %[[CONVERT1_M]] : (i64) -> index
 !CHECK: %[[UB:.*]] = arith.subi %[[CONVERT2_M]], %[[LB_C10_IDX]] : index
 !CHECK: %[[DIMS1:.*]]:3 = fir.box_dims %[[DECLB]]#1, %{{.*}} : (!fir.box<!fir.array<?xf32>>, index) -> (index, index, index)
-!CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[ZERO]] : index) upperbound(%[[UB]] : index) extent(%[[DIMS1]]#1 : index) stride(%[[DIMS0]]#2 : index) startIdx(%[[LB_C10_IDX]] : index) {strideInBytes = true}
-!CHECK: %[[CREATE:.*]] = acc.create var(%[[DECLB]]#0 : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND]]) -> !fir.box<!fir.array<?xf32>> {name = "b(:m)", structured = false}
+!CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[ZERO]] : index) upperbound(%[[UB]] : index) extent(%[[DIMS1]]#1 : index) stride(%[[DIMS0]]#2 : index) startIdx(%[[LB_C10_IDX]] : index) strideInBytes(true)
+!CHECK: %[[CREATE:.*]] = acc.create var(%[[DECLB]]#0 : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND]]) structured(false) name("b(:m)") -> !fir.box<!fir.array<?xf32>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.box<!fir.array<?xf32>>)
 
   !$acc enter data create(b)
-!CHECK: %[[CREATE:.*]] = acc.create var(%[[DECLB]]#0 : !fir.box<!fir.array<?xf32>>) -> !fir.box<!fir.array<?xf32>> {name = "b", structured = false}
+!CHECK: %[[CREATE:.*]] = acc.create var(%[[DECLB]]#0 : !fir.box<!fir.array<?xf32>>) structured(false) name("b") -> !fir.box<!fir.array<?xf32>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.box<!fir.array<?xf32>>)
 
 end subroutine
@@ -418,7 +418,7 @@ subroutine acc_enter_data_allocatable()
 
   !$acc enter data create(a)
 
-!CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>> {name = "a", structured = false}
+!CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) structured(false) name("a") -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>)
 
   !$acc enter data create(a(:))
@@ -435,8 +435,8 @@ subroutine acc_enter_data_allocatable()
 !CHECK: %[[C0:.*]] = arith.constant 0 : index
 !CHECK: %[[DIMS2:.*]]:3 = fir.box_dims %[[BOX_A_2]], %[[C0]] : (!fir.box<!fir.heap<!fir.array<?xf32>>>, index) -> (index, index, index)
 !CHECK: %[[UB:.*]] = arith.subi %[[DIMS2]]#1, %[[ONE]] : index
-!CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[ZERO]] : index) upperbound(%[[UB:.*]] : index) extent(%[[DIMS2]]#1 : index) stride(%[[DIMS1]]#2 : index) startIdx(%[[DIMS0]]#0 : index) {strideInBytes = true}
-!CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) bounds(%[[BOUND]]) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>> {name = "a(:)", structured = false}
+!CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[ZERO]] : index) upperbound(%[[UB:.*]] : index) extent(%[[DIMS2]]#1 : index) stride(%[[DIMS1]]#2 : index) startIdx(%[[DIMS0]]#0 : index) strideInBytes(true)
+!CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) bounds(%[[BOUND]]) structured(false) name("a(:)") -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>)
 
   !$acc enter data create(a(2:5))
@@ -454,8 +454,8 @@ subroutine acc_enter_data_allocatable()
 !CHECK: %[[BOX_A_2:.*]] = fir.load %[[DECLA]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
 !CHECK: %[[C0:.*]] = arith.constant 0 : index
 !CHECK: %[[DIMS2:.*]]:3 = fir.box_dims %[[BOX_A_2]], %[[C0]] : (!fir.box<!fir.heap<!fir.array<?xf32>>>, index) -> (index, index, index)
-!CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%[[DIMS2]]#1 : index) stride(%[[DIMS1]]#2 : index) startIdx(%[[DIMS0]]#0 : index) {strideInBytes = true}
-!CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) bounds(%[[BOUND]]) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>> {name = "a(2:5)", structured = false}
+!CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%[[DIMS2]]#1 : index) stride(%[[DIMS1]]#2 : index) startIdx(%[[DIMS0]]#0 : index) strideInBytes(true)
+!CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) bounds(%[[BOUND]]) structured(false) name("a(2:5)") -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>)
 
   !$acc enter data create(a(3:))
@@ -473,8 +473,8 @@ subroutine acc_enter_data_allocatable()
 !CHECK: %[[C0:.*]] = arith.constant 0 : index
 !CHECK: %[[DIMS2:.*]]:3 = fir.box_dims %[[BOX_A_2]], %[[C0]] : (!fir.box<!fir.heap<!fir.array<?xf32>>>, index) -> (index, index, index)
 !CHECK: %[[UB:.*]] = arith.subi %[[DIMS2]]#1, %[[ONE]] : index
-!CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%[[DIMS2]]#1 : index) stride(%[[DIMS1]]#2 : index) startIdx(%[[DIMS0]]#0 : index) {strideInBytes = true}
-!CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) bounds(%[[BOUND]]) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>> {name = "a(3:)", structured = false}
+!CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%[[DIMS2]]#1 : index) stride(%[[DIMS1]]#2 : index) startIdx(%[[DIMS0]]#0 : index) strideInBytes(true)
+!CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) bounds(%[[BOUND]]) structured(false) name("a(3:)") -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>)
 
   !$acc enter data create(a(:7))
@@ -491,13 +491,13 @@ subroutine acc_enter_data_allocatable()
 !CHECK: %[[BOX_A_2:.*]] = fir.load %[[DECLA]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
 !CHECK: %[[C0:.*]] = arith.constant 0 : index
 !CHECK: %[[DIMS2:.*]]:3 = fir.box_dims %[[BOX_A_2]], %[[C0]] : (!fir.box<!fir.heap<!fir.array<?xf32>>>, index) -> (index, index, index)
-!CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[ZERO]] : index) upperbound(%[[UB]] : index) extent(%[[DIMS2]]#1 : index) stride(%[[DIMS1]]#2 : index) startIdx(%[[DIMS0]]#0 : index) {strideInBytes = true}
-!CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) bounds(%[[BOUND]]) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>> {name = "a(:7)", structured = false}
+!CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[ZERO]] : index) upperbound(%[[UB]] : index) extent(%[[DIMS2]]#1 : index) stride(%[[DIMS1]]#2 : index) startIdx(%[[DIMS0]]#0 : index) strideInBytes(true)
+!CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) bounds(%[[BOUND]]) structured(false) name("a(:7)") -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>)
 
   !$acc enter data create(i)
 
-!CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[DECLI]]#0 : !fir.ref<!fir.box<!fir.heap<i32>>>) -> !fir.ref<!fir.box<!fir.heap<i32>>> {name = "i", structured = false}
+!CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[DECLI]]#0 : !fir.ref<!fir.box<!fir.heap<i32>>>) structured(false) name("i") -> !fir.ref<!fir.box<!fir.heap<i32>>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.ref<!fir.box<!fir.heap<i32>>>)
 
 end subroutine
@@ -542,7 +542,7 @@ subroutine acc_enter_data_derived_type()
 
 
 !CHECK: %[[DATA_COORD:.*]] = hlfir.designate %[[DECLA]]#0{"data"}   : (!fir.ref<!fir.type<_QFacc_enter_data_derived_typeTdt{data:f32,array:!fir.array<10xf32>}>>) -> !fir.ref<f32>
-!CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[DATA_COORD]] : !fir.ref<f32>) -> !fir.ref<f32> {name = "a%data", structured = false}
+!CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[DATA_COORD]] : !fir.ref<f32>) structured(false) name("a%data") -> !fir.ref<f32>
 !CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.ref<f32>)
 
   !$acc enter data create(b%d%data)
@@ -551,14 +551,14 @@ subroutine acc_enter_data_derived_type()
 
 !CHECK: %[[D_COORD:.*]] = hlfir.designate %[[DECLB]]#0{"d"}   : (!fir.ref<!fir.type<_QFacc_enter_data_derived_typeTt{d:!fir.type<_QFacc_enter_data_derived_typeTdt{data:f32,array:!fir.array<10xf32>}>}>>) -> !fir.ref<!fir.type<_QFacc_enter_data_derived_typeTdt{data:f32,array:!fir.array<10xf32>}>>
 !CHECK: %[[DATA_COORD:.*]] = hlfir.designate %[[D_COORD]]{"data"}   : (!fir.ref<!fir.type<_QFacc_enter_data_derived_typeTdt{data:f32,array:!fir.array<10xf32>}>>) -> !fir.ref<f32>
-!CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[DATA_COORD]] : !fir.ref<f32>) -> !fir.ref<f32> {name = "b%d%data", structured = false}
+!CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[DATA_COORD]] : !fir.ref<f32>) structured(false) name("b%d%data") -> !fir.ref<f32>
 !CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.ref<f32>)
 
   !$acc enter data create(a%array)
 
 
 !CHECK: %[[ARRAY_COORD:.*]] = hlfir.designate %[[DECLA]]#0{"array"}   shape %{{.*}} : (!fir.ref<!fir.type<_QFacc_enter_data_derived_typeTdt{data:f32,array:!fir.array<10xf32>}>>, !fir.shape<1>) -> !fir.ref<!fir.array<10xf32>>
-!CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[ARRAY_COORD]] : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "a%array", structured = false}
+!CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[ARRAY_COORD]] : !fir.ref<!fir.array<10xf32>>) structured(false) name("a%array") -> !fir.ref<!fir.array<10xf32>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.ref<!fir.array<10xf32>>)
 
   !$acc enter data create(a%array(:))
@@ -570,7 +570,7 @@ subroutine acc_enter_data_derived_type()
 !CHECK: %[[C1:.*]] = arith.constant 1 : index
 !CHECK: %[[UB:.*]] = arith.subi %[[C10]], %[[C1]] : index
 !CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%[[C10]] : index) stride(%[[C1]] : index) startIdx(%[[C1]] : index)
-!CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[ARRAY_COORD]] : !fir.ref<!fir.array<10xf32>>) bounds(%[[BOUND]]) -> !fir.ref<!fir.array<10xf32>> {name = "a%array(:)", structured = false}
+!CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[ARRAY_COORD]] : !fir.ref<!fir.array<10xf32>>) bounds(%[[BOUND]]) structured(false) name("a%array(:)") -> !fir.ref<!fir.array<10xf32>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.ref<!fir.array<10xf32>>)
 
   !$acc enter data create(a%array(1:5))
@@ -581,7 +581,7 @@ subroutine acc_enter_data_derived_type()
 !CHECK: %[[C0:.*]] = arith.constant 0 : index
 !CHECK: %[[C4:.*]] = arith.constant 4 : index
 !CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[C0]] : index) upperbound(%[[C4]] : index)  extent(%[[C10]] : index) stride(%[[C1]] : index) startIdx(%[[C1]] : index)
-!CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[ARRAY_COORD]] : !fir.ref<!fir.array<10xf32>>) bounds(%[[BOUND]]) -> !fir.ref<!fir.array<10xf32>> {name = "a%array(1:5)", structured = false}
+!CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[ARRAY_COORD]] : !fir.ref<!fir.array<10xf32>>) bounds(%[[BOUND]]) structured(false) name("a%array(1:5)") -> !fir.ref<!fir.array<10xf32>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.ref<!fir.array<10xf32>>)
 
   !$acc enter data create(a%array(:5))
@@ -592,7 +592,7 @@ subroutine acc_enter_data_derived_type()
 !CHECK: %[[C1:.*]] = arith.constant 1 : index
 !CHECK: %[[C4:.*]] = arith.constant 4 : index
 !CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[C4]] : index) extent(%[[C10]] : index) stride(%[[C1]] : index) startIdx(%[[C1]] : index)
-!CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[ARRAY_COORD]] : !fir.ref<!fir.array<10xf32>>) bounds(%[[BOUND]]) -> !fir.ref<!fir.array<10xf32>> {name = "a%array(:5)", structured = false}
+!CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[ARRAY_COORD]] : !fir.ref<!fir.array<10xf32>>) bounds(%[[BOUND]]) structured(false) name("a%array(:5)") -> !fir.ref<!fir.array<10xf32>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.ref<!fir.array<10xf32>>)
 
   !$acc enter data create(a%array(2:))
@@ -604,7 +604,7 @@ subroutine acc_enter_data_derived_type()
 !CHECK: %[[LB:.*]] = arith.constant 1 : index
 !CHECK: %[[UB:.*]] = arith.subi %[[C10]], %[[ONE]] : index
 !CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%[[C10]] : index) stride(%[[ONE]] : index) startIdx(%[[ONE]] : index)
-!CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[ARRAY_COORD]] : !fir.ref<!fir.array<10xf32>>) bounds(%[[BOUND]]) -> !fir.ref<!fir.array<10xf32>> {name = "a%array(2:)", structured = false}
+!CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[ARRAY_COORD]] : !fir.ref<!fir.array<10xf32>>) bounds(%[[BOUND]]) structured(false) name("a%array(2:)") -> !fir.ref<!fir.array<10xf32>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.ref<!fir.array<10xf32>>)
 
 !$acc enter data create(b%d%array)
@@ -613,13 +613,13 @@ subroutine acc_enter_data_derived_type()
 
 !CHECK: %[[D_COORD:.*]] = hlfir.designate %[[DECLB]]#0{"d"}   : (!fir.ref<!fir.type<_QFacc_enter_data_derived_typeTt{d:!fir.type<_QFacc_enter_data_derived_typeTdt{data:f32,array:!fir.array<10xf32>}>}>>) -> !fir.ref<!fir.type<_QFacc_enter_data_derived_typeTdt{data:f32,array:!fir.array<10xf32>}>>
 !CHECK: %[[ARRAY_COORD:.*]] = hlfir.designate %[[D_COORD]]{"array"}   shape %{{.*}} : (!fir.ref<!fir.type<_QFacc_enter_data_derived_typeTdt{data:f32,array:!fir.array<10xf32>}>>, !fir.shape<1>) -> !fir.ref<!fir.array<10xf32>>
-!CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[ARRAY_COORD]] : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "b%d%array", structured = false}
+!CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[ARRAY_COORD]] : !fir.ref<!fir.array<10xf32>>) structured(false) name("b%d%array") -> !fir.ref<!fir.array<10xf32>>
 
   !$acc enter data create(c%data)
 
 
 !CHECK: %[[DATA_COORD:.*]] = hlfir.designate %[[DECLC]]#0{"data"}   {fortran_attrs = #fir.var_attrs<allocatable>} : (!fir.ref<!fir.type<_QFacc_enter_data_derived_typeTz{data:!fir.box<!fir.heap<!fir.array<?xi32>>>}>>) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-!CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[DATA_COORD]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> {name = "c%data", structured = false}
+!CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[DATA_COORD]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) structured(false) name("c%data") -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
 
   !$acc enter data create (d%d(1)%array)
@@ -627,7 +627,7 @@ subroutine acc_enter_data_derived_type()
 !CHECK: %[[ONE:.*]] = arith.constant 1 : index
 !CHECK: %[[D1_COORD:.*]] = hlfir.designate %[[DECLD]]#0{"d"} <%{{.*}}> (%[[ONE]])  : (!fir.ref<!fir.type<_QFacc_enter_data_derived_typeTtt{d:!fir.array<10x!fir.type<_QFacc_enter_data_derived_typeTdt{data:f32,array:!fir.array<10xf32>}>>}>>, !fir.shape<1>, index) -> !fir.ref<!fir.type<_QFacc_enter_data_derived_typeTdt{data:f32,array:!fir.array<10xf32>}>>
 !CHECK: %[[ARRAY_COORD:.*]] = hlfir.designate %[[D1_COORD]]{"array"}   shape %{{.*}} : (!fir.ref<!fir.type<_QFacc_enter_data_derived_typeTdt{data:f32,array:!fir.array<10xf32>}>>, !fir.shape<1>) -> !fir.ref<!fir.array<10xf32>>
-!CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[ARRAY_COORD]] : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "d%d(1_8)%array", structured = false}
+!CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[ARRAY_COORD]] : !fir.ref<!fir.array<10xf32>>) structured(false) name("d%d(1_8)%array") -> !fir.ref<!fir.array<10xf32>>
 !CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.ref<!fir.array<10xf32>>)
 
 end subroutine
@@ -653,7 +653,7 @@ subroutine acc_enter_data_single_array_element()
 ! CHECK-DAG:       %[[BOX_DIMS_1:.*]]:3 = fir.box_dims %[[LOAD_3]], %[[CONSTANT_13]] : (!fir.box<!fir.heap<!fir.array<?x?xf32>>>, index) -> (index, index, index)
 ! CHECK-DAG:       %[[CONSTANT_14:.*]] = arith.constant 1 : index
 ! CHECK-DAG:       %[[SUBI_0:.*]] = arith.subi %[[CONSTANT_14]], %[[BOX_DIMS_0]]#0 : index
-! CHECK-DAG:       %[[BOUNDS_0:.*]] = acc.bounds lowerbound(%[[SUBI_0]] : index) upperbound(%[[SUBI_0]] : index) extent(%[[CONSTANT_11]] : index) stride(%[[BOX_DIMS_1]]#2 : index) startIdx(%[[BOX_DIMS_0]]#0 : index) {strideInBytes = true}
+! CHECK-DAG:       %[[BOUNDS_0:.*]] = acc.bounds lowerbound(%[[SUBI_0]] : index) upperbound(%[[SUBI_0]] : index) extent(%[[CONSTANT_11]] : index) stride(%[[BOX_DIMS_1]]#2 : index) startIdx(%[[BOX_DIMS_0]]#0 : index) strideInBytes(true)
 ! CHECK-DAG:       %[[LOAD_4:.*]] = fir.load %[[DESIGNATE_3]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>
 ! CHECK-DAG:       %[[CONSTANT_15:.*]] = arith.constant 1 : index
 ! CHECK-DAG:       %[[BOX_DIMS_2:.*]]:3 = fir.box_dims %[[LOAD_4]], %[[CONSTANT_15]] : (!fir.box<!fir.heap<!fir.array<?x?xf32>>>, index) -> (index, index, index)
@@ -662,8 +662,8 @@ subroutine acc_enter_data_single_array_element()
 ! CHECK-DAG:       %[[BOX_DIMS_3:.*]]:3 = fir.box_dims %[[LOAD_5]], %[[CONSTANT_16]] : (!fir.box<!fir.heap<!fir.array<?x?xf32>>>, index) -> (index, index, index)
 ! CHECK-DAG:       %[[CONSTANT_17:.*]] = arith.constant 2 : index
 ! CHECK-DAG:       %[[SUBI_1:.*]] = arith.subi %[[CONSTANT_17]], %[[BOX_DIMS_2]]#0 : index
-! CHECK-DAG:       %[[BOUNDS_1:.*]] = acc.bounds lowerbound(%[[SUBI_1]] : index) upperbound(%[[SUBI_1]] : index) extent(%[[CONSTANT_11]] : index) stride(%[[BOX_DIMS_3]]#2 : index) startIdx(%[[BOX_DIMS_2]]#0 : index) {strideInBytes = true}
-! CHECK:           %[[CREATE_0:.*]] = acc.create varPtr(%[[DESIGNATE_3]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>) bounds(%[[BOUNDS_0]], %[[BOUNDS_1]]) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>> {name = "e(2_8)%[[VAL_0:.*]](1,2)", structured = false}
+! CHECK-DAG:       %[[BOUNDS_1:.*]] = acc.bounds lowerbound(%[[SUBI_1]] : index) upperbound(%[[SUBI_1]] : index) extent(%[[CONSTANT_11]] : index) stride(%[[BOX_DIMS_3]]#2 : index) startIdx(%[[BOX_DIMS_2]]#0 : index) strideInBytes(true)
+! CHECK:           %[[CREATE_0:.*]] = acc.create varPtr(%[[DESIGNATE_3]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>) bounds(%[[BOUNDS_0]], %[[BOUNDS_1]]) structured(false) name("e(2_8)%[[VAL_0:.*]](1,2)") -> !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>
 ! CHECK:           acc.enter_data dataOperands(%[[CREATE_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>)
 
 end subroutine
@@ -677,5 +677,5 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPtest_class(
 ! CHECK-SAME: %[[ARG0:.*]]: !fir.class<!fir.type<_QMmod1Tderived{m:f32}>> {fir.bindc_name = "a"}) {
 ! CHECK: %[[DECL_ARG0:.*]]:2 = hlfir.declare %[[ARG0]] dummy_scope %0 {{.*}} {uniq_name = "_QFtest_classEa"} : (!fir.class<!fir.type<_QMmod1Tderived{m:f32}>>, !fir.dscope) -> (!fir.class<!fir.type<_QMmod1Tderived{m:f32}>>, !fir.class<!fir.type<_QMmod1Tderived{m:f32}>>)
-! CHECK: %[[COPYIN:.*]] = acc.copyin var(%[[DECL_ARG0]]#0 : !fir.class<!fir.type<_QMmod1Tderived{m:f32}>>) -> !fir.class<!fir.type<_QMmod1Tderived{m:f32}>> {name = "a", structured = false}
+! CHECK: %[[COPYIN:.*]] = acc.copyin var(%[[DECL_ARG0]]#0 : !fir.class<!fir.type<_QMmod1Tderived{m:f32}>>) structured(false) name("a") -> !fir.class<!fir.type<_QMmod1Tderived{m:f32}>>
 ! CHECK: acc.enter_data dataOperands(%[[COPYIN]] : !fir.class<!fir.type<_QMmod1Tderived{m:f32}>>)

--- a/flang/test/Lower/OpenACC/acc-exit-data.f90
+++ b/flang/test/Lower/OpenACC/acc-exit-data.f90
@@ -18,93 +18,93 @@ subroutine acc_exit_data
 !CHECK: %[[DECLD:.*]]:2 = hlfir.declare %[[D]]
 
   !$acc exit data delete(a)
-!CHECK: %[[DEVPTR:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_delete>, name = "a", structured = false}
+!CHECK: %[[DEVPTR:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_delete) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 !CHECK: acc.exit_data dataOperands(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>)
-!CHECK: acc.delete accPtr(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>) {name = "a", structured = false}
+!CHECK: acc.delete accPtr(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("a")
 
   !$acc exit data delete(a) if(.true.)
-!CHECK: %[[DEVPTR:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_delete>, name = "a", structured = false}
+!CHECK: %[[DEVPTR:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_delete) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 !CHECK: %[[IF1:.*]] = arith.constant true
 !CHECK: acc.exit_data if(%[[IF1]]) dataOperands(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>)
-!CHECK: acc.delete accPtr(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>) {name = "a", structured = false}
+!CHECK: acc.delete accPtr(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("a")
 
   !$acc exit data delete(a) if(ifCondition)
-!CHECK: %[[DEVPTR:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_delete>, name = "a", structured = false}
+!CHECK: %[[DEVPTR:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_delete) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 !CHECK: %[[IFCOND:.*]] = fir.load %{{.*}} : !fir.ref<!fir.logical<4>>
 !CHECK: %[[IF2:.*]] = fir.convert %[[IFCOND]] : (!fir.logical<4>) -> i1
 !CHECK: acc.exit_data if(%[[IF2]]) dataOperands(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>){{$}}
-!CHECK: acc.delete accPtr(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>) {name = "a", structured = false}
+!CHECK: acc.delete accPtr(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("a")
 
   !$acc exit data delete(a) delete(b) delete(c)
-!CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_delete>, name = "a", structured = false}
-!CHECK: %[[DEVPTR_B:.*]] = acc.getdeviceptr varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_delete>, name = "b", structured = false}
-!CHECK: %[[DEVPTR_C:.*]] = acc.getdeviceptr varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_delete>, name = "c", structured = false}
+!CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_delete) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+!CHECK: %[[DEVPTR_B:.*]] = acc.getdeviceptr varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_delete) structured(false) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+!CHECK: %[[DEVPTR_C:.*]] = acc.getdeviceptr varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_delete) structured(false) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 !CHECK: acc.exit_data dataOperands(%[[DEVPTR_A]], %[[DEVPTR_B]], %[[DEVPTR_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>){{$}}
-!CHECK: acc.delete accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) {name = "a", structured = false}
-!CHECK: acc.delete accPtr(%[[DEVPTR_B]] : !fir.ref<!fir.array<10x10xf32>>) {name = "b", structured = false}
-!CHECK: acc.delete accPtr(%[[DEVPTR_C]] : !fir.ref<!fir.array<10x10xf32>>) {name = "c", structured = false}
+!CHECK: acc.delete accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("a")
+!CHECK: acc.delete accPtr(%[[DEVPTR_B]] : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("b")
+!CHECK: acc.delete accPtr(%[[DEVPTR_C]] : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("c")
 
   !$acc exit data copyout(a) delete(b) detach(d)
-!CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copyout>, name = "a", structured = false}
-!CHECK: %[[DEVPTR_B:.*]] = acc.getdeviceptr varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_delete>, name = "b", structured = false}
-!CHECK: %[[DEVPTR_D:.*]] = acc.getdeviceptr varPtr(%[[DECLD]]#0 : !fir.ref<!fir.box<!fir.ptr<f32>>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>> {dataClause = #acc<data_clause acc_detach>, name = "d", structured = false}
+!CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyout) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+!CHECK: %[[DEVPTR_B:.*]] = acc.getdeviceptr varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_delete) structured(false) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+!CHECK: %[[DEVPTR_D:.*]] = acc.getdeviceptr varPtr(%[[DECLD]]#0 : !fir.ref<!fir.box<!fir.ptr<f32>>>) dataClause(acc_detach) structured(false) name("d") -> !fir.ref<!fir.box<!fir.ptr<f32>>>
 !CHECK: acc.exit_data dataOperands(%[[DEVPTR_A]], %[[DEVPTR_B]], %[[DEVPTR_D]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.box<!fir.ptr<f32>>>)
-!CHECK: acc.copyout accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) {name = "a", structured = false}
-!CHECK: acc.delete accPtr(%[[DEVPTR_B]] : !fir.ref<!fir.array<10x10xf32>>) {name = "b", structured = false}
-!CHECK: acc.detach accPtr(%[[DEVPTR_D]] : !fir.ref<!fir.box<!fir.ptr<f32>>>) {name = "d", structured = false}
+!CHECK: acc.copyout accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("a")
+!CHECK: acc.delete accPtr(%[[DEVPTR_B]] : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("b")
+!CHECK: acc.detach accPtr(%[[DEVPTR_D]] : !fir.ref<!fir.box<!fir.ptr<f32>>>) structured(false) name("d")
 
   !$acc exit data delete(a) async
-!CHECK: %[[DEVPTR:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) async -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_delete>, name = "a", structured = false}
+!CHECK: %[[DEVPTR:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) async dataClause(acc_delete) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 !CHECK: acc.exit_data async dataOperands(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>)
-!CHECK: acc.delete accPtr(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>) async {name = "a", structured = false}
+!CHECK: acc.delete accPtr(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>) async structured(false) name("a")
 
   !$acc exit data delete(a) wait
-!CHECK: %[[DEVPTR:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_delete>, name = "a", structured = false}
+!CHECK: %[[DEVPTR:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_delete) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 !CHECK: acc.exit_data wait dataOperands(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>)
-!CHECK: acc.delete accPtr(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>) {name = "a", structured = false}
+!CHECK: acc.delete accPtr(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("a")
 
   !$acc exit data delete(a) async wait
-!CHECK: %[[DEVPTR:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) async -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_delete>, name = "a", structured = false}
+!CHECK: %[[DEVPTR:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) async dataClause(acc_delete) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 !CHECK: acc.exit_data async wait dataOperands(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>)
-!CHECK: acc.delete accPtr(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>) async {name = "a", structured = false}
+!CHECK: acc.delete accPtr(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>) async structured(false) name("a")
 
   !$acc exit data delete(a) async(1)
 !CHECK: %[[ASYNC1:.*]] = arith.constant 1 : i32
-!CHECK: %[[DEVPTR:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) async(%[[ASYNC1]] : i32) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_delete>, name = "a", structured = false}
+!CHECK: %[[DEVPTR:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) async(%[[ASYNC1]] : i32) dataClause(acc_delete) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 !CHECK: acc.exit_data async(%[[ASYNC1]] : i32) dataOperands(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>)
-!CHECK: acc.delete accPtr(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>) async(%[[ASYNC1]] : i32) {name = "a", structured = false}
+!CHECK: acc.delete accPtr(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>) async(%[[ASYNC1]] : i32) structured(false) name("a")
 
 
   !$acc exit data delete(a) async(async)
 !CHECK: %[[ASYNC2:.*]] = fir.load %{{.*}} : !fir.ref<i32>
-!CHECK: %[[DEVPTR:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) async(%[[ASYNC2]] : i32) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_delete>, name = "a", structured = false}
+!CHECK: %[[DEVPTR:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) async(%[[ASYNC2]] : i32) dataClause(acc_delete) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 !CHECK: acc.exit_data async(%[[ASYNC2]] : i32) dataOperands(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>)
-!CHECK: acc.delete accPtr(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>) async(%[[ASYNC2]] : i32) {name = "a", structured = false}
+!CHECK: acc.delete accPtr(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>) async(%[[ASYNC2]] : i32) structured(false) name("a")
 
   !$acc exit data delete(a) wait(1)
-!CHECK: %[[DEVPTR:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_delete>, name = "a", structured = false}
+!CHECK: %[[DEVPTR:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_delete) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 !CHECK: %[[WAIT1:.*]] = arith.constant 1 : i32
 !CHECK: acc.exit_data wait(%[[WAIT1]] : i32) dataOperands(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>)
-!CHECK: acc.delete accPtr(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>) {name = "a", structured = false}
+!CHECK: acc.delete accPtr(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("a")
 
   !$acc exit data delete(a) wait(queues: 1, 2)
-!CHECK: %[[DEVPTR:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_delete>, name = "a", structured = false}
+!CHECK: %[[DEVPTR:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_delete) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 !CHECK: %[[WAIT2:.*]] = arith.constant 1 : i32
 !CHECK: %[[WAIT3:.*]] = arith.constant 2 : i32
 !CHECK: acc.exit_data wait(%[[WAIT2]], %[[WAIT3]] : i32, i32) dataOperands(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>)
-!CHECK: acc.delete accPtr(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>) {name = "a", structured = false}
+!CHECK: acc.delete accPtr(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("a")
 
   !$acc exit data delete(a) wait(devnum: 1: queues: 1, 2)
-!CHECK: %[[DEVPTR:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_delete>, name = "a", structured = false}
+!CHECK: %[[DEVPTR:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_delete) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 !CHECK: %[[WAIT4:.*]] = arith.constant 1 : i32
 !CHECK: %[[WAIT5:.*]] = arith.constant 2 : i32
 !CHECK: %[[WAIT6:.*]] = arith.constant 1 : i32
 !CHECK: acc.exit_data wait_devnum(%[[WAIT6]] : i32) wait(%[[WAIT4]], %[[WAIT5]] : i32, i32) dataOperands(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>)
-!CHECK: acc.delete accPtr(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>) {name = "a", structured = false}
+!CHECK: acc.delete accPtr(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("a")
 
   !$acc exit data delete(a) finalize
-!CHECK: acc.exit_data dataOperands(%{{.*}} : !fir.ref<!fir.array<10x10xf32>>) attributes {finalize}
+!CHECK: acc.exit_data dataOperands(%{{.*}} : !fir.ref<!fir.array<10x10xf32>>) finalize
 
   !$acc exit data delete(a) finalize finalize
-!CHECK: acc.exit_data dataOperands(%{{.*}} : !fir.ref<!fir.array<10x10xf32>>) attributes {finalize}
+!CHECK: acc.exit_data dataOperands(%{{.*}} : !fir.ref<!fir.array<10x10xf32>>) finalize
 end subroutine acc_exit_data

--- a/flang/test/Lower/OpenACC/acc-firstprivate-derived-allocatable-component.f90
+++ b/flang/test/Lower/OpenACC/acc-firstprivate-derived-allocatable-component.f90
@@ -44,14 +44,14 @@ module m_firstprivate_derived_alloc_comp
 ! CHECK:           %[[VAL_3:.*]]:2 = hlfir.declare %[[VAL_2]] {uniq_name = "_QMm_firstprivate_derived_alloc_compFtestEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK:           %[[VAL_4:.*]] = fir.alloca i32 {bindc_name = "n", uniq_name = "_QMm_firstprivate_derived_alloc_compFtestEn"}
 ! CHECK:           %[[VAL_5:.*]]:2 = hlfir.declare %[[VAL_4]] {uniq_name = "_QMm_firstprivate_derived_alloc_compFtestEn"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK:           %[[VAL_6:.*]] = acc.firstprivate varPtr(%[[VAL_1]]#0 : !fir.ref<!fir.type<_QMm_firstprivate_derived_alloc_compTpoint{x:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>) recipe(@firstprivatization_ref_rec__QMm_firstprivate_derived_alloc_compTpoint) -> !fir.ref<!fir.type<_QMm_firstprivate_derived_alloc_compTpoint{x:!fir.box<!fir.heap<!fir.array<?xf32>>>}>> {name = "a"}
+! CHECK:           %[[VAL_6:.*]] = acc.firstprivate varPtr(%[[VAL_1]]#0 : !fir.ref<!fir.type<_QMm_firstprivate_derived_alloc_compTpoint{x:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>) recipe(@firstprivatization_ref_rec__QMm_firstprivate_derived_alloc_compTpoint) name("a") -> !fir.ref<!fir.type<_QMm_firstprivate_derived_alloc_compTpoint{x:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>
 ! CHECK:           acc.parallel combined(loop) firstprivate(%[[VAL_6]] : !fir.ref<!fir.type<_QMm_firstprivate_derived_alloc_compTpoint{x:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>) {
 ! CHECK:             %[[VAL_7:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK:             %[[VAL_8:.*]]:2 = hlfir.declare %[[VAL_6]] dummy_scope %[[VAL_7]] {uniq_name = "_QMm_firstprivate_derived_alloc_compFtestEa"} : (!fir.ref<!fir.type<_QMm_firstprivate_derived_alloc_compTpoint{x:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>, !fir.dscope) -> (!fir.ref<!fir.type<_QMm_firstprivate_derived_alloc_compTpoint{x:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>, !fir.ref<!fir.type<_QMm_firstprivate_derived_alloc_compTpoint{x:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>)
 ! CHECK:             %[[VAL_9:.*]] = arith.constant 1 : i32
 ! CHECK:             %[[VAL_10:.*]] = fir.load %[[VAL_5]]#0 : !fir.ref<i32>
 ! CHECK:             %[[VAL_11:.*]] = arith.constant 1 : i32
-! CHECK:             %[[VAL_12:.*]] = acc.private varPtr(%[[VAL_3]]#0 : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK:             %[[VAL_12:.*]] = acc.private varPtr(%[[VAL_3]]#0 : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK:             acc.loop combined(parallel) private(%[[VAL_12]] : !fir.ref<i32>) control(%[[VAL_14:.*]] : i32) = (%[[VAL_9]] : i32) to (%[[VAL_10]] : i32)  step (%[[VAL_11]] : i32) {
 ! CHECK:               %[[VAL_13:.*]]:2 = hlfir.declare %[[VAL_12]] {uniq_name = "_QMm_firstprivate_derived_alloc_compFtestEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK:               fir.store %[[VAL_14]] to %[[VAL_13]]#0 : !fir.ref<i32>
@@ -62,7 +62,7 @@ module m_firstprivate_derived_alloc_comp
 ! CHECK:               %[[VAL_19:.*]] = hlfir.designate %[[VAL_17]] (%[[VAL_18]])  : (!fir.box<!fir.heap<!fir.array<?xf32>>>, index) -> !fir.ref<f32>
 ! CHECK:               hlfir.assign %[[VAL_15]] to %[[VAL_19]] : f32, !fir.ref<f32>
 ! CHECK:               acc.yield
-! CHECK:             } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK:             } inclusiveUpperbound(array<i1: true>) independent
 ! CHECK:             acc.yield
 ! CHECK:           }
 ! CHECK:           return

--- a/flang/test/Lower/OpenACC/acc-firstprivate-derived-user-assign.f90
+++ b/flang/test/Lower/OpenACC/acc-firstprivate-derived-user-assign.f90
@@ -52,13 +52,13 @@ module m_firstprivate_derived_user_def
 ! CHECK:           %[[VAL_4:.*]]:2 = hlfir.declare %[[VAL_3]] {uniq_name = "_QMm_firstprivate_derived_user_defFtestEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK:           %[[VAL_5:.*]] = fir.alloca i32 {bindc_name = "n", uniq_name = "_QMm_firstprivate_derived_user_defFtestEn"}
 ! CHECK:           %[[VAL_6:.*]]:2 = hlfir.declare %[[VAL_5]] {uniq_name = "_QMm_firstprivate_derived_user_defFtestEn"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK:           %[[VAL_7:.*]] = acc.firstprivate varPtr(%[[VAL_2]]#0 : !fir.ref<!fir.type<_QMm_firstprivate_derived_user_defTpoint{x:f32,y:f32,z:f32}>>) recipe(@firstprivatization_ref_rec__QMm_firstprivate_derived_user_defTpoint) -> !fir.ref<!fir.type<_QMm_firstprivate_derived_user_defTpoint{x:f32,y:f32,z:f32}>> {name = "a"}
+! CHECK:           %[[VAL_7:.*]] = acc.firstprivate varPtr(%[[VAL_2]]#0 : !fir.ref<!fir.type<_QMm_firstprivate_derived_user_defTpoint{x:f32,y:f32,z:f32}>>) recipe(@firstprivatization_ref_rec__QMm_firstprivate_derived_user_defTpoint) name("a") -> !fir.ref<!fir.type<_QMm_firstprivate_derived_user_defTpoint{x:f32,y:f32,z:f32}>>
 ! CHECK:           acc.parallel combined(loop) firstprivate(%[[VAL_7]] : !fir.ref<!fir.type<_QMm_firstprivate_derived_user_defTpoint{x:f32,y:f32,z:f32}>>) {
 ! CHECK:             %[[VAL_8:.*]]:2 = hlfir.declare %[[VAL_7]] {uniq_name = "_QMm_firstprivate_derived_user_defFtestEa"} : (!fir.ref<!fir.type<_QMm_firstprivate_derived_user_defTpoint{x:f32,y:f32,z:f32}>>) -> (!fir.ref<!fir.type<_QMm_firstprivate_derived_user_defTpoint{x:f32,y:f32,z:f32}>>, !fir.ref<!fir.type<_QMm_firstprivate_derived_user_defTpoint{x:f32,y:f32,z:f32}>>)
 ! CHECK:             %[[VAL_9:.*]] = arith.constant 1 : i32
 ! CHECK:             %[[VAL_10:.*]] = fir.load %[[VAL_6]]#0 : !fir.ref<i32>
 ! CHECK:             %[[VAL_11:.*]] = arith.constant 1 : i32
-! CHECK:             %[[VAL_12:.*]] = acc.private varPtr(%[[VAL_4]]#0 : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK:             %[[VAL_12:.*]] = acc.private varPtr(%[[VAL_4]]#0 : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK:             acc.loop combined(parallel) private(%[[VAL_12]] : !fir.ref<i32>) control(%[[VAL_14:.*]] : i32) = (%[[VAL_9]] : i32) to (%[[VAL_10]] : i32)  step (%[[VAL_11]] : i32) {
   ! CHECK:             %[[VAL_13:.*]]:2 = hlfir.declare %[[VAL_12]] {uniq_name = "_QMm_firstprivate_derived_user_defFtestEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK:               fir.store %[[VAL_14]] to %[[VAL_13]]#0 : !fir.ref<i32>
@@ -66,7 +66,7 @@ module m_firstprivate_derived_user_def
 ! CHECK:               %[[VAL_16:.*]] = hlfir.designate %[[VAL_8]]#0{"x"}   : (!fir.ref<!fir.type<_QMm_firstprivate_derived_user_defTpoint{x:f32,y:f32,z:f32}>>) -> !fir.ref<f32>
 ! CHECK:               hlfir.assign %[[VAL_15]] to %[[VAL_16]] : f32, !fir.ref<f32>
 ! CHECK:               acc.yield
-! CHECK:             } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK:             } inclusiveUpperbound(array<i1: true>) independent
 ! CHECK:             acc.yield
 ! CHECK:           }
 ! CHECK:           return

--- a/flang/test/Lower/OpenACC/acc-firstprivate-derived.f90
+++ b/flang/test/Lower/OpenACC/acc-firstprivate-derived.f90
@@ -38,13 +38,13 @@ module m_firstprivate_derived
 ! CHECK:           %[[VAL_4:.*]]:2 = hlfir.declare %[[VAL_3]] {uniq_name = "_QMm_firstprivate_derivedFtestEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK:           %[[VAL_5:.*]] = fir.alloca i32 {bindc_name = "n", uniq_name = "_QMm_firstprivate_derivedFtestEn"}
 ! CHECK:           %[[VAL_6:.*]]:2 = hlfir.declare %[[VAL_5]] {uniq_name = "_QMm_firstprivate_derivedFtestEn"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK:           %[[VAL_7:.*]] = acc.firstprivate varPtr(%[[VAL_2]]#0 : !fir.ref<!fir.type<_QMm_firstprivate_derivedTpoint{x:f32,y:f32,z:f32}>>) recipe(@firstprivatization_ref_rec__QMm_firstprivate_derivedTpoint) -> !fir.ref<!fir.type<_QMm_firstprivate_derivedTpoint{x:f32,y:f32,z:f32}>> {name = "a"}
+! CHECK:           %[[VAL_7:.*]] = acc.firstprivate varPtr(%[[VAL_2]]#0 : !fir.ref<!fir.type<_QMm_firstprivate_derivedTpoint{x:f32,y:f32,z:f32}>>) recipe(@firstprivatization_ref_rec__QMm_firstprivate_derivedTpoint) name("a") -> !fir.ref<!fir.type<_QMm_firstprivate_derivedTpoint{x:f32,y:f32,z:f32}>>
 ! CHECK:           acc.parallel combined(loop) firstprivate(%[[VAL_7]] : !fir.ref<!fir.type<_QMm_firstprivate_derivedTpoint{x:f32,y:f32,z:f32}>>) {
 ! CHECK:             %[[VAL_8:.*]]:2 = hlfir.declare %[[VAL_7]] {uniq_name = "_QMm_firstprivate_derivedFtestEa"} : (!fir.ref<!fir.type<_QMm_firstprivate_derivedTpoint{x:f32,y:f32,z:f32}>>) -> (!fir.ref<!fir.type<_QMm_firstprivate_derivedTpoint{x:f32,y:f32,z:f32}>>, !fir.ref<!fir.type<_QMm_firstprivate_derivedTpoint{x:f32,y:f32,z:f32}>>)
 ! CHECK:             %[[VAL_9:.*]] = arith.constant 1 : i32
 ! CHECK:             %[[VAL_10:.*]] = fir.load %[[VAL_6]]#0 : !fir.ref<i32>
 ! CHECK:             %[[VAL_11:.*]] = arith.constant 1 : i32
-! CHECK:             %[[VAL_12:.*]] = acc.private varPtr(%[[VAL_4]]#0 : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK:             %[[VAL_12:.*]] = acc.private varPtr(%[[VAL_4]]#0 : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK:             acc.loop combined(parallel) private(%[[VAL_12]] : !fir.ref<i32>) control(%[[VAL_14:.*]] : i32) = (%[[VAL_9]] : i32) to (%[[VAL_10]] : i32)  step (%[[VAL_11]] : i32) {
   ! CHECK:             %[[VAL_13:.*]]:2 = hlfir.declare %[[VAL_12]] {uniq_name = "_QMm_firstprivate_derivedFtestEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK:               fir.store %[[VAL_14]] to %[[VAL_13]]#0 : !fir.ref<i32>
@@ -52,7 +52,7 @@ module m_firstprivate_derived
 ! CHECK:               %[[VAL_16:.*]] = hlfir.designate %[[VAL_8]]#0{"x"}   : (!fir.ref<!fir.type<_QMm_firstprivate_derivedTpoint{x:f32,y:f32,z:f32}>>) -> !fir.ref<f32>
 ! CHECK:               hlfir.assign %[[VAL_15]] to %[[VAL_16]] : f32, !fir.ref<f32>
 ! CHECK:               acc.yield
-! CHECK:             } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK:             } inclusiveUpperbound(array<i1: true>) independent
 ! CHECK:             acc.yield
 ! CHECK:           }
 ! CHECK:           return

--- a/flang/test/Lower/OpenACC/acc-host-data.f90
+++ b/flang/test/Lower/OpenACC/acc-host-data.f90
@@ -15,25 +15,25 @@ subroutine acc_host_data()
   !$acc host_data use_device(a)
   !$acc end host_data
 
-! CHECK: %[[DA0:.*]] = acc.use_device varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "a"}
+! CHECK: %[[DA0:.*]] = acc.use_device varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) name("a") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK: acc.host_data dataOperands(%[[DA0]] : !fir.ref<!fir.array<10xf32>>)
 
   !$acc host_data use_device(a) if_present
   !$acc end host_data
 
-! CHECK: %[[DA0:.*]] = acc.use_device varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "a"}
+! CHECK: %[[DA0:.*]] = acc.use_device varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) name("a") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK: acc.host_data dataOperands(%[[DA0]] : !fir.ref<!fir.array<10xf32>>)
-! CHECK: } attributes {ifPresent}
+! CHECK: } ifPresent
 
   !$acc host_data use_device(a) if_present
   !$acc end host_data
 ! CHECK: acc.host_data dataOperands(%{{.*}} : !fir.ref<!fir.array<10xf32>>) {
-! CHECK: } attributes {ifPresent}
+! CHECK: } ifPresent
 
   !$acc host_data use_device(a) if(ifCondition)
   !$acc end host_data
 
-! CHECK: %[[DA0:.*]] = acc.use_device varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "a"}
+! CHECK: %[[DA0:.*]] = acc.use_device varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) name("a") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK: %[[LOAD_IFCOND:.*]] = fir.load %[[DECLIFCOND]]#0 : !fir.ref<!fir.logical<4>>
 ! CHECK: %[[IFCOND_I1:.*]] = fir.convert %[[LOAD_IFCOND]] : (!fir.logical<4>) -> i1
 ! CHECK: acc.host_data if(%[[IFCOND_I1]]) dataOperands(%[[DA0]] : !fir.ref<!fir.array<10xf32>>)
@@ -41,7 +41,7 @@ subroutine acc_host_data()
   !$acc host_data use_device(a) if(.true.)
   !$acc end host_data
 
-! CHECK: %[[DA:.*]] = acc.use_device varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "a"}
+! CHECK: %[[DA:.*]] = acc.use_device varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) name("a") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK: acc.host_data dataOperands(%[[DA]] : !fir.ref<!fir.array<10xf32>>)
 
   !$acc host_data use_device(a) if(.false.)

--- a/flang/test/Lower/OpenACC/acc-init.f90
+++ b/flang/test/Lower/OpenACC/acc-init.f90
@@ -25,7 +25,7 @@ subroutine acc_init
 
   !$acc init device_num(1) device_type(host, multicore)
 !CHECK: [[DEVNUM:%.*]] = arith.constant 1 : i32
-!CHECK: acc.init device_num([[DEVNUM]] : i32) attributes {device_types = [#acc.device_type<host>, #acc.device_type<multicore>]}
+!CHECK: acc.init device_num([[DEVNUM]] : i32) device_types([#acc.device_type<host>, #acc.device_type<multicore>])
 
   !$acc init if(ifInt)
 !CHECK: %[[IFINT:.*]] = fir.load %{{.*}} : !fir.ref<i32>
@@ -33,9 +33,9 @@ subroutine acc_init
 !CHECK: acc.init if(%[[CONV]])
 
    !$acc init device_type(nvidia)
-!CHECK: acc.init attributes {device_types = [#acc.device_type<nvidia>]}
+!CHECK: acc.init device_types([#acc.device_type<nvidia>])
 
   !$acc init device_type(host) device_type(multicore)
-!CHECK: acc.init attributes {device_types = [#acc.device_type<host>, #acc.device_type<multicore>]}
+!CHECK: acc.init device_types([#acc.device_type<host>, #acc.device_type<multicore>])
 
 end subroutine acc_init

--- a/flang/test/Lower/OpenACC/acc-kernels-loop.f90
+++ b/flang/test/Lower/OpenACC/acc-kernels-loop.f90
@@ -47,9 +47,9 @@ subroutine acc_kernels_loop
 ! CHECK:      acc.kernels {
 ! CHECK:        acc.loop private{{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {auto_ = [#acc.device_type<none>]{{.*}}}
+! CHECK-NEXT:   } {{.*}}auto_{{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop
   DO i = 1, n
@@ -59,9 +59,9 @@ subroutine acc_kernels_loop
 ! CHECK:      acc.kernels combined(loop) {
 ! CHECK:        acc.loop combined(kernels) private{{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {auto_ = [#acc.device_type<none>]{{.*}}}
+! CHECK-NEXT:   } {{.*}}auto_{{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop async
   DO i = 1, n
@@ -72,7 +72,7 @@ subroutine acc_kernels_loop
 ! CHECK:      acc.kernels {{.*}} async {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) auto_
 ! CHECK:        acc.terminator
 ! CHECK-NEXT: }
 
@@ -85,9 +85,9 @@ subroutine acc_kernels_loop
 ! CHECK:      acc.kernels {{.*}} async([[ASYNC1]] : i32) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop async(async)
   DO i = 1, n
@@ -98,9 +98,9 @@ subroutine acc_kernels_loop
 ! CHECK:      acc.kernels {{.*}} async([[ASYNC2]] : i32) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop async(async) device_type(nvidia) async(1)
   DO i = 1, n
@@ -116,7 +116,7 @@ subroutine acc_kernels_loop
 ! CHECK:      acc.kernels {{.*}} wait {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.terminator
 ! CHECK-NEXT: }
 
@@ -129,9 +129,9 @@ subroutine acc_kernels_loop
 ! CHECK:      acc.kernels {{.*}} wait({[[WAIT1]] : i32}) {
 ! CHECK:        acc.loop
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop wait(1, 2)
   DO i = 1, n
@@ -143,9 +143,9 @@ subroutine acc_kernels_loop
 ! CHECK:      acc.kernels {{.*}} wait({[[WAIT2]] : i32, [[WAIT3]] : i32}) {
 ! CHECK:        acc.loop
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop wait(wait1, wait2)
   DO i = 1, n
@@ -157,9 +157,9 @@ subroutine acc_kernels_loop
 ! CHECK:      acc.kernels {{.*}} wait({[[WAIT4]] : i32, [[WAIT5]] : i32}) {
 ! CHECK:        acc.loop
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop num_gangs(1)
   DO i = 1, n
@@ -170,9 +170,9 @@ subroutine acc_kernels_loop
 ! CHECK:      acc.kernels {{.*}} num_gangs({[[NUMGANGS1]] : i32}) {
 ! CHECK:        acc.loop
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop num_gangs(numGangs)
   DO i = 1, n
@@ -183,9 +183,9 @@ subroutine acc_kernels_loop
 ! CHECK:      acc.kernels {{.*}} num_gangs({[[NUMGANGS2]] : i32}) {
 ! CHECK:        acc.loop
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop num_workers(10)
   DO i = 1, n
@@ -196,9 +196,9 @@ subroutine acc_kernels_loop
 ! CHECK:      acc.kernels {{.*}} num_workers([[NUMWORKERS1]] : i32) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop num_workers(numWorkers)
   DO i = 1, n
@@ -209,9 +209,9 @@ subroutine acc_kernels_loop
 ! CHECK:      acc.kernels {{.*}} num_workers([[NUMWORKERS2]] : i32) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop vector_length(128)
   DO i = 1, n
@@ -222,9 +222,9 @@ subroutine acc_kernels_loop
 ! CHECK:      acc.kernels {{.*}} vector_length([[VECTORLENGTH1]] : i32) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop vector_length(vectorLength)
   DO i = 1, n
@@ -235,9 +235,9 @@ subroutine acc_kernels_loop
 ! CHECK:      acc.kernels {{.*}} vector_length([[VECTORLENGTH2]] : i32) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop if(.TRUE.)
   DO i = 1, n
@@ -248,9 +248,9 @@ subroutine acc_kernels_loop
 ! CHECK:      acc.kernels {{.*}} if([[IF1]]) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop if(ifCondition)
   DO i = 1, n
@@ -262,9 +262,9 @@ subroutine acc_kernels_loop
 ! CHECK:      acc.kernels {{.*}} if([[IF2]]) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop self(.TRUE.)
   DO i = 1, n
@@ -275,9 +275,9 @@ subroutine acc_kernels_loop
 ! CHECK:      acc.kernels {{.*}} self([[SELF1]]) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop self
   DO i = 1, n
@@ -287,9 +287,9 @@ subroutine acc_kernels_loop
 ! CHECK:      acc.kernels {{.*}}{
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: } attributes {selfAttr}
+! CHECK-NEXT: } selfAttr
 
   !$acc kernels loop self(ifCondition)
   DO i = 1, n
@@ -301,9 +301,9 @@ subroutine acc_kernels_loop
 ! CHECK:      acc.kernels {{.*}} self(%[[SELF2]]) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop copy(a, b)
   DO i = 1, n
@@ -311,140 +311,140 @@ subroutine acc_kernels_loop
   END DO
 
 
-! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "a"}
-! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "b"}
+! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) name("a") -> !fir.ref<!fir.array<10xf32>>
+! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) name("b") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK:      acc.kernels {{.*}} dataOperands(%[[COPYIN_A]], %[[COPYIN_B]] : !fir.ref<!fir.array<10xf32>>, !fir.ref<!fir.array<10xf32>>) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
-! CHECK:      acc.copyout accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "a"}
-! CHECK:      acc.copyout accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "b"}
+! CHECK-NEXT: }{{.*}}
+! CHECK:      acc.copyout accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) name("a")
+! CHECK:      acc.copyout accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) name("b")
 
   !$acc kernels loop copy(a) copy(b)
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "a"}
-! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "b"}
+! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) name("a") -> !fir.ref<!fir.array<10xf32>>
+! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) name("b") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK:      acc.kernels {{.*}} dataOperands(%[[COPYIN_A]], %[[COPYIN_B]] : !fir.ref<!fir.array<10xf32>>, !fir.ref<!fir.array<10xf32>>) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
-! CHECK:      acc.copyout accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "a"}
-! CHECK:      acc.copyout accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "b"}
+! CHECK-NEXT: }{{.*}}
+! CHECK:      acc.copyout accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) name("a")
+! CHECK:      acc.copyout accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) name("b")
 
   !$acc kernels loop copyin(a) copyin(readonly: b)
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "a"}
-! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {dataClause = #acc<data_clause acc_copyin_readonly>, name = "b"}
+! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) name("a") -> !fir.ref<!fir.array<10xf32>>
+! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copyin_readonly) name("b") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK:      acc.kernels {{.*}} dataOperands(%[[COPYIN_A]], %[[COPYIN_B]] : !fir.ref<!fir.array<10xf32>>, !fir.ref<!fir.array<10xf32>>) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
-! CHECK:      acc.delete accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_copyin>, name = "a"}
-! CHECK:      acc.delete accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_copyin_readonly>, name = "b"}
+! CHECK-NEXT: }{{.*}}
+! CHECK:      acc.delete accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copyin) name("a")
+! CHECK:      acc.delete accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copyin_readonly) name("b")
 
   !$acc kernels loop copyout(a) copyout(zero: b)
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {dataClause = #acc<data_clause acc_copyout>, name = "a"}
-! CHECK:      %[[CREATE_B:.*]] = acc.create varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {dataClause = #acc<data_clause acc_copyout_zero>, name = "b"}
+! CHECK:      %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copyout) name("a") -> !fir.ref<!fir.array<10xf32>>
+! CHECK:      %[[CREATE_B:.*]] = acc.create varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copyout_zero) name("b") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK:      acc.kernels {{.*}} dataOperands(%[[CREATE_A]], %[[CREATE_B]] : !fir.ref<!fir.array<10xf32>>, !fir.ref<!fir.array<10xf32>>) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
-! CHECK:      acc.copyout accPtr(%[[CREATE_A]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) {name = "a"}
-! CHECK:      acc.copyout accPtr(%[[CREATE_B]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_copyout_zero>, name = "b"}
+! CHECK-NEXT: }{{.*}}
+! CHECK:      acc.copyout accPtr(%[[CREATE_A]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) name("a")
+! CHECK:      acc.copyout accPtr(%[[CREATE_B]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copyout_zero) name("b")
 
   !$acc kernels loop create(b) create(zero: a)
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[CREATE_B:.*]] = acc.create varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "b"}
-! CHECK:      %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {dataClause = #acc<data_clause acc_create_zero>, name = "a"}
+! CHECK:      %[[CREATE_B:.*]] = acc.create varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) name("b") -> !fir.ref<!fir.array<10xf32>>
+! CHECK:      %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_create_zero) name("a") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK:      acc.kernels {{.*}} dataOperands(%[[CREATE_B]], %[[CREATE_A]] : !fir.ref<!fir.array<10xf32>>, !fir.ref<!fir.array<10xf32>>) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
-! CHECK:      acc.delete accPtr(%[[CREATE_B]] : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_create>, name = "b"}
-! CHECK:      acc.delete accPtr(%[[CREATE_A]] : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_create_zero>, name = "a"}
+! CHECK-NEXT: }{{.*}}
+! CHECK:      acc.delete accPtr(%[[CREATE_B]] : !fir.ref<!fir.array<10xf32>>) dataClause(acc_create) name("b")
+! CHECK:      acc.delete accPtr(%[[CREATE_A]] : !fir.ref<!fir.array<10xf32>>) dataClause(acc_create_zero) name("a")
 
   !$acc kernels loop no_create(a, b)
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[NOCREATE_A:.*]] = acc.nocreate varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "a"}
-! CHECK:      %[[NOCREATE_B:.*]] = acc.nocreate varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "b"}
+! CHECK:      %[[NOCREATE_A:.*]] = acc.nocreate varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) name("a") -> !fir.ref<!fir.array<10xf32>>
+! CHECK:      %[[NOCREATE_B:.*]] = acc.nocreate varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) name("b") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK:      acc.kernels {{.*}} dataOperands(%[[NOCREATE_A]], %[[NOCREATE_B]] : !fir.ref<!fir.array<10xf32>>, !fir.ref<!fir.array<10xf32>>) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
-! CHECK:      acc.delete accPtr(%[[NOCREATE_A]] : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_no_create>, name = "a"}
-! CHECK:      acc.delete accPtr(%[[NOCREATE_B]] : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_no_create>, name = "b"}
+! CHECK-NEXT: }{{.*}}
+! CHECK:      acc.delete accPtr(%[[NOCREATE_A]] : !fir.ref<!fir.array<10xf32>>) dataClause(acc_no_create) name("a")
+! CHECK:      acc.delete accPtr(%[[NOCREATE_B]] : !fir.ref<!fir.array<10xf32>>) dataClause(acc_no_create) name("b")
 
   !$acc kernels loop present(a, b)
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[PRESENT_A:.*]] = acc.present varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "a"}
-! CHECK:      %[[PRESENT_B:.*]] = acc.present varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "b"}
+! CHECK:      %[[PRESENT_A:.*]] = acc.present varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) name("a") -> !fir.ref<!fir.array<10xf32>>
+! CHECK:      %[[PRESENT_B:.*]] = acc.present varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) name("b") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK:      acc.kernels {{.*}} dataOperands(%[[PRESENT_A]], %[[PRESENT_B]] : !fir.ref<!fir.array<10xf32>>, !fir.ref<!fir.array<10xf32>>) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
-! CHECK:      acc.delete accPtr(%[[PRESENT_A]] : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_present>, name = "a"}
-! CHECK:      acc.delete accPtr(%[[PRESENT_B]] : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_present>, name = "b"}
+! CHECK-NEXT: }{{.*}}
+! CHECK:      acc.delete accPtr(%[[PRESENT_A]] : !fir.ref<!fir.array<10xf32>>) dataClause(acc_present) name("a")
+! CHECK:      acc.delete accPtr(%[[PRESENT_B]] : !fir.ref<!fir.array<10xf32>>) dataClause(acc_present) name("b")
 
   !$acc kernels loop deviceptr(a) deviceptr(b)
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[DEVICEPTR_A:.*]] = acc.deviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "a"}
-! CHECK:      %[[DEVICEPTR_B:.*]] = acc.deviceptr varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "b"}
+! CHECK:      %[[DEVICEPTR_A:.*]] = acc.deviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) name("a") -> !fir.ref<!fir.array<10xf32>>
+! CHECK:      %[[DEVICEPTR_B:.*]] = acc.deviceptr varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) name("b") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK:      acc.kernels {{.*}} dataOperands(%[[DEVICEPTR_A]], %[[DEVICEPTR_B]] : !fir.ref<!fir.array<10xf32>>, !fir.ref<!fir.array<10xf32>>) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop attach(f, g)
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[ATTACH_F:.*]] = acc.attach varPtr(%[[DECLF]]#0 : !fir.ref<!fir.box<!fir.ptr<f32>>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>> {name = "f"}
-! CHECK:      %[[ATTACH_G:.*]] = acc.attach varPtr(%[[DECLG]]#0 : !fir.ref<!fir.box<!fir.ptr<f32>>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>> {name = "g"}
+! CHECK:      %[[ATTACH_F:.*]] = acc.attach varPtr(%[[DECLF]]#0 : !fir.ref<!fir.box<!fir.ptr<f32>>>) name("f") -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+! CHECK:      %[[ATTACH_G:.*]] = acc.attach varPtr(%[[DECLG]]#0 : !fir.ref<!fir.box<!fir.ptr<f32>>>) name("g") -> !fir.ref<!fir.box<!fir.ptr<f32>>>
 ! CHECK:      acc.kernels {{.*}} dataOperands(%[[ATTACH_F]], %[[ATTACH_G]] : !fir.ref<!fir.box<!fir.ptr<f32>>>, !fir.ref<!fir.box<!fir.ptr<f32>>>) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop seq
   DO i = 1, n
@@ -454,9 +454,9 @@ subroutine acc_kernels_loop
 ! CHECK:      acc.kernels {{.*}} {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {inclusiveUpperbound = array<i1: true>, seq = [#acc.device_type<none>]}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) seq
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop auto
   DO i = 1, n
@@ -466,9 +466,9 @@ subroutine acc_kernels_loop
 ! CHECK:      acc.kernels {{.*}} {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) auto_
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop independent
   DO i = 1, n
@@ -478,9 +478,9 @@ subroutine acc_kernels_loop
 ! CHECK:      acc.kernels {{.*}} {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) independent
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop gang
   DO i = 1, n
@@ -490,9 +490,9 @@ subroutine acc_kernels_loop
 ! CHECK:      acc.kernels {{.*}} {
 ! CHECK:        acc.loop {{.*}} gang {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) auto_
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop gang(num: 8)
   DO i = 1, n
@@ -503,9 +503,9 @@ subroutine acc_kernels_loop
 ! CHECK:        [[GANGNUM1:%.*]] = arith.constant 8 : i32
 ! CHECK:        acc.loop {{.*}} gang({num=[[GANGNUM1]] : i32}) {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) auto_
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop gang(num: gangNum)
   DO i = 1, n
@@ -516,9 +516,9 @@ subroutine acc_kernels_loop
 ! CHECK:        [[GANGNUM2:%.*]] = fir.load %{{.*}} : !fir.ref<i32>
 ! CHECK:        acc.loop {{.*}} gang({num=[[GANGNUM2]] : i32}) {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) auto_
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
  !$acc kernels loop gang(num: gangNum, static: gangStatic)
   DO i = 1, n
@@ -528,9 +528,9 @@ subroutine acc_kernels_loop
 ! CHECK:      acc.kernels {{.*}} {
 ! CHECK:        acc.loop {{.*}} gang({num=%{{.*}} : i32, static=%{{.*}} : i32})
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) auto_
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop vector
   DO i = 1, n
@@ -540,9 +540,9 @@ subroutine acc_kernels_loop
 ! CHECK:      acc.kernels {{.*}} {
 ! CHECK:        acc.loop {{.*}} vector {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) auto_
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop vector(128)
   DO i = 1, n
@@ -553,9 +553,9 @@ subroutine acc_kernels_loop
 ! CHECK:        [[CONSTANT128:%.*]] = arith.constant 128 : i32
 ! CHECK:        acc.loop {{.*}} vector([[CONSTANT128]] : i32) {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) auto_
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop vector(vectorLength)
   DO i = 1, n
@@ -566,9 +566,9 @@ subroutine acc_kernels_loop
 ! CHECK:        [[VECTORLENGTH:%.*]] = fir.load %{{.*}} : !fir.ref<i32>
 ! CHECK:        acc.loop {{.*}} vector([[VECTORLENGTH]] : i32) {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) auto_
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop worker
   DO i = 1, n
@@ -578,9 +578,9 @@ subroutine acc_kernels_loop
 ! CHECK:      acc.kernels {{.*}} {
 ! CHECK:        acc.loop {{.*}} worker {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) auto_
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop worker(128)
   DO i = 1, n
@@ -591,9 +591,9 @@ subroutine acc_kernels_loop
 ! CHECK:        [[WORKER128:%.*]] = arith.constant 128 : i32
 ! CHECK:        acc.loop {{.*}} worker([[WORKER128]] : i32) {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) auto_
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop collapse(2)
   DO i = 1, n
@@ -605,9 +605,9 @@ subroutine acc_kernels_loop
 ! CHECK:      acc.kernels {{.*}} {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {{{.*}}collapse = [2], collapseDeviceType = [#acc.device_type<none>]{{.*}}}
+! CHECK-NEXT:   } {{.*}}collapse([2]){{.*}}collapseDeviceType([#acc.device_type<none>]){{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop
   DO i = 1, n
@@ -621,11 +621,11 @@ subroutine acc_kernels_loop
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:            acc.loop {{.*}} {
 ! CHECK:              acc.yield
-! CHECK-NEXT:     } attributes {auto_ = [#acc.device_type<none>]{{.*}}}
+! CHECK-NEXT:     } {{.*}}auto_{{.*}}
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {auto_ = [#acc.device_type<none>]{{.*}}}
+! CHECK-NEXT:   } {{.*}}auto_{{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
  !$acc kernels loop tile(2)
   DO i = 1, n
@@ -636,9 +636,9 @@ subroutine acc_kernels_loop
 ! CHECK:        [[TILESIZE:%.*]] = arith.constant 2 : i32
 ! CHECK:        acc.loop {{.*}} tile({[[TILESIZE]] : i32}) {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
  !$acc kernels loop tile(*)
   DO i = 1, n
@@ -649,9 +649,9 @@ subroutine acc_kernels_loop
 ! CHECK:        [[TILESIZEM1:%.*]] = arith.constant -1 : i32
 ! CHECK:        acc.loop {{.*}} tile({[[TILESIZEM1]] : i32}) {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop tile(2, 2)
   DO i = 1, n
@@ -665,9 +665,9 @@ subroutine acc_kernels_loop
 ! CHECK:        [[TILESIZE2:%.*]] = arith.constant 2 : i32
 ! CHECK:        acc.loop {{.*}} tile({[[TILESIZE1]] : i32, [[TILESIZE2]] : i32}) control(%arg0 : i32, %arg1 : i32) {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop tile(tileSize)
   DO i = 1, n
@@ -677,9 +677,9 @@ subroutine acc_kernels_loop
 ! CHECK:      acc.kernels {{.*}} {
 ! CHECK:        acc.loop {{.*}} tile({%{{.*}} : i32}) {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop tile(tileSize, tileSize)
   DO i = 1, n
@@ -691,9 +691,9 @@ subroutine acc_kernels_loop
 ! CHECK:      acc.kernels {{.*}} {
 ! CHECK:        acc.loop {{.*}} tile({%{{.*}} : i32, %{{.*}} : i32}) control(%arg0 : i32, %arg1 : i32) {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc kernels loop reduction(+:reduction_r) reduction(*:reduction_i)
   do i = 1, n
@@ -701,17 +701,17 @@ subroutine acc_kernels_loop
     reduction_i = 1
   end do
 
-! CHECK:      %[[COPYINREDR:.*]] = acc.copyin varPtr(%{{.*}} : !fir.ref<f32>) -> !fir.ref<f32> {dataClause = #acc<data_clause acc_reduction>, implicit = true, name = "reduction_r"}
-! CHECK:      %[[COPYINREDI:.*]] = acc.copyin varPtr(%{{.*}} : !fir.ref<i32>) -> !fir.ref<i32> {dataClause = #acc<data_clause acc_reduction>, implicit = true, name = "reduction_i"}
+! CHECK:      %[[COPYINREDR:.*]] = acc.copyin varPtr(%{{.*}} : !fir.ref<f32>) dataClause(acc_reduction) implicit(true) name("reduction_r") -> !fir.ref<f32>
+! CHECK:      %[[COPYINREDI:.*]] = acc.copyin varPtr(%{{.*}} : !fir.ref<i32>) dataClause(acc_reduction) implicit(true) name("reduction_i") -> !fir.ref<i32>
 ! CHECK:      acc.kernels {{.*}} dataOperands(%[[COPYINREDR]], %[[COPYINREDI]] : !fir.ref<f32>, !fir.ref<i32>) {
-! CHECK:        %[[REDUCTION_R:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_add_ref_f32) -> !fir.ref<f32> {name = "reduction_r"}
-! CHECK:        %[[REDUCTION_I:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<i32>) recipe(@reduction_mul_ref_i32) -> !fir.ref<i32> {name = "reduction_i"}
+! CHECK:        %[[REDUCTION_R:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_add_ref_f32) name("reduction_r") -> !fir.ref<f32>
+! CHECK:        %[[REDUCTION_I:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<i32>) recipe(@reduction_mul_ref_i32) name("reduction_i") -> !fir.ref<i32>
 ! CHECK:        acc.loop {{.*}} reduction(%[[REDUCTION_R]], %[[REDUCTION_I]] : !fir.ref<f32>, !fir.ref<i32>) {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.terminator
-! CHECK-NEXT: }{{$}}
-! CHECK:      acc.copyout accPtr(%[[COPYINREDR]] : !fir.ref<f32>) to varPtr(%{{.*}} : !fir.ref<f32>) {dataClause = #acc<data_clause acc_reduction>, implicit = true, name = "reduction_r"}
-! CHECK:      acc.copyout accPtr(%[[COPYINREDI]] : !fir.ref<i32>) to varPtr(%{{.*}} : !fir.ref<i32>) {dataClause = #acc<data_clause acc_reduction>, implicit = true, name = "reduction_i"}
+! CHECK-NEXT: }{{.*}}
+! CHECK:      acc.copyout accPtr(%[[COPYINREDR]] : !fir.ref<f32>) to varPtr(%{{.*}} : !fir.ref<f32>) dataClause(acc_reduction) implicit(true) name("reduction_r")
+! CHECK:      acc.copyout accPtr(%[[COPYINREDI]] : !fir.ref<i32>) to varPtr(%{{.*}} : !fir.ref<i32>) dataClause(acc_reduction) implicit(true) name("reduction_i")
 
 end subroutine

--- a/flang/test/Lower/OpenACC/acc-kernels.f90
+++ b/flang/test/Lower/OpenACC/acc-kernels.f90
@@ -169,7 +169,7 @@ subroutine acc_kernels
 
 ! CHECK:      acc.kernels  {
 ! CHECK:        acc.terminator
-! CHECK-NEXT: } attributes {selfAttr}
+! CHECK-NEXT: } selfAttr
 
   !$acc kernels self(ifCondition)
   !$acc end kernels
@@ -182,99 +182,99 @@ subroutine acc_kernels
   !$acc kernels copy(a, b, c)
   !$acc end kernels
 
-! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "a"}
-! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "b"}
-! CHECK:      %[[COPYIN_C:.*]] = acc.copyin varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "c"}
+! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:      %[[COPYIN_C:.*]] = acc.copyin varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.kernels  dataOperands(%[[COPYIN_A]], %[[COPYIN_B]], %[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.terminator
 ! CHECK-NEXT: }{{$}}
-! CHECK:      acc.copyout accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "a"}
-! CHECK:      acc.copyout accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "b"}
-! CHECK:      acc.copyout accPtr(%[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "c"}
+! CHECK:      acc.copyout accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("a")
+! CHECK:      acc.copyout accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("b")
+! CHECK:      acc.copyout accPtr(%[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("c")
 
   !$acc kernels copy(a) copy(b) copy(c)
   !$acc end kernels
 
-! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "a"}
-! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "b"}
-! CHECK:      %[[COPYIN_C:.*]] = acc.copyin varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "c"}
+! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:      %[[COPYIN_C:.*]] = acc.copyin varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.kernels dataOperands(%[[COPYIN_A]], %[[COPYIN_B]], %[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.terminator
 ! CHECK-NEXT: }{{$}}
-! CHECK:      acc.copyout accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "a"}
-! CHECK:      acc.copyout accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "b"}
-! CHECK:      acc.copyout accPtr(%[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "c"}
+! CHECK:      acc.copyout accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("a")
+! CHECK:      acc.copyout accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("b")
+! CHECK:      acc.copyout accPtr(%[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("c")
 
   !$acc kernels copyin(a) copyin(readonly: b, c)
   !$acc end kernels
 
-! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "a"}
-! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copyin_readonly>, name = "b"}
-! CHECK:      %[[COPYIN_C:.*]] = acc.copyin varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copyin_readonly>, name = "c"}
+! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyin_readonly) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:      %[[COPYIN_C:.*]] = acc.copyin varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyin_readonly) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.kernels dataOperands(%[[COPYIN_A]], %[[COPYIN_B]], %[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.terminator
 ! CHECK-NEXT: }{{$}}
-! CHECK:      acc.delete accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copyin>, name = "a"}
-! CHECK:      acc.delete accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copyin_readonly>, name = "b"}
-! CHECK:      acc.delete accPtr(%[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copyin_readonly>, name = "c"}
+! CHECK:      acc.delete accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyin) name("a")
+! CHECK:      acc.delete accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyin_readonly) name("b")
+! CHECK:      acc.delete accPtr(%[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyin_readonly) name("c")
 
   !$acc kernels copyout(a) copyout(zero: b) copyout(c)
   !$acc end kernels
 
-! CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copyout>, name = "a"}
-! CHECK: %[[CREATE_B:.*]] = acc.create varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copyout_zero>, name = "b"}
-! CHECK: %[[CREATE_C:.*]] = acc.create varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copyout>, name = "c"}
+! CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyout) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK: %[[CREATE_B:.*]] = acc.create varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyout_zero) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK: %[[CREATE_C:.*]] = acc.create varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyout) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.kernels dataOperands(%[[CREATE_A]], %[[CREATE_B]], %[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.terminator
 ! CHECK-NEXT: }{{$}}
-! CHECK: acc.copyout accPtr(%[[CREATE_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) {name = "a"}
-! CHECK: acc.copyout accPtr(%[[CREATE_B]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copyout_zero>, name = "b"}
-! CHECK: acc.copyout accPtr(%[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) {name = "c"}
+! CHECK: acc.copyout accPtr(%[[CREATE_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("a")
+! CHECK: acc.copyout accPtr(%[[CREATE_B]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyout_zero) name("b")
+! CHECK: acc.copyout accPtr(%[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("c")
 
   !$acc kernels create(a, b) create(zero: c)
   !$acc end kernels
 
-! CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "a"}
-! CHECK: %[[CREATE_B:.*]] = acc.create varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "b"}
-! CHECK: %[[CREATE_C:.*]] = acc.create varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_create_zero>, name = "c"}
+! CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK: %[[CREATE_B:.*]] = acc.create varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK: %[[CREATE_C:.*]] = acc.create varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_create_zero) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.kernels dataOperands(%[[CREATE_A]], %[[CREATE_B]], %[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.terminator
 ! CHECK-NEXT: }{{$}}
-! CHECK:   acc.delete accPtr(%[[CREATE_A]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_create>, name = "a"}
-! CHECK: acc.delete accPtr(%[[CREATE_B]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_create>, name = "b"}
-! CHECK: acc.delete accPtr(%[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_create_zero>, name = "c"}
+! CHECK:   acc.delete accPtr(%[[CREATE_A]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_create) name("a")
+! CHECK: acc.delete accPtr(%[[CREATE_B]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_create) name("b")
+! CHECK: acc.delete accPtr(%[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_create_zero) name("c")
 
   !$acc kernels no_create(a, b) create(zero: c)
   !$acc end kernels
 
-! CHECK: %[[NO_CREATE_A:.*]] = acc.nocreate varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "a"}
-! CHECK: %[[NO_CREATE_B:.*]] = acc.nocreate varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "b"}
-! CHECK: %[[CREATE_C:.*]] = acc.create varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_create_zero>, name = "c"}
+! CHECK: %[[NO_CREATE_A:.*]] = acc.nocreate varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK: %[[NO_CREATE_B:.*]] = acc.nocreate varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK: %[[CREATE_C:.*]] = acc.create varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_create_zero) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.kernels dataOperands(%[[NO_CREATE_A]], %[[NO_CREATE_B]], %[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.terminator
 ! CHECK-NEXT: }{{$}}
-! CHECK: acc.delete accPtr(%[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_create_zero>, name = "c"}
-! CHECK: acc.delete accPtr(%[[NO_CREATE_A]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_no_create>, name = "a"}
-! CHECK: acc.delete accPtr(%[[NO_CREATE_B]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_no_create>, name = "b"}
+! CHECK: acc.delete accPtr(%[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_create_zero) name("c")
+! CHECK: acc.delete accPtr(%[[NO_CREATE_A]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_no_create) name("a")
+! CHECK: acc.delete accPtr(%[[NO_CREATE_B]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_no_create) name("b")
 
   !$acc kernels present(a, b, c)
   !$acc end kernels
 
-! CHECK: %[[PRESENT_A:.*]] = acc.present varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "a"}
-! CHECK: %[[PRESENT_B:.*]] = acc.present varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "b"}
-! CHECK: %[[PRESENT_C:.*]] = acc.present varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "c"}
+! CHECK: %[[PRESENT_A:.*]] = acc.present varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK: %[[PRESENT_B:.*]] = acc.present varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK: %[[PRESENT_C:.*]] = acc.present varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.kernels dataOperands(%[[PRESENT_A]], %[[PRESENT_B]], %[[PRESENT_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.terminator
 ! CHECK-NEXT: }{{$}}
-! CHECK: acc.delete accPtr(%[[PRESENT_A]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_present>, name = "a"}
-! CHECK: acc.delete accPtr(%[[PRESENT_B]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_present>, name = "b"}
-! CHECK: acc.delete accPtr(%[[PRESENT_C]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_present>, name = "c"}
+! CHECK: acc.delete accPtr(%[[PRESENT_A]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_present) name("a")
+! CHECK: acc.delete accPtr(%[[PRESENT_B]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_present) name("b")
+! CHECK: acc.delete accPtr(%[[PRESENT_C]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_present) name("c")
 
   !$acc kernels deviceptr(a) deviceptr(c)
   !$acc end kernels
 
-! CHECK:      %[[DEVICEPTR_A:.*]] = acc.deviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "a"}
-! CHECK:      %[[DEVICEPTR_C:.*]] = acc.deviceptr varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "c"}
+! CHECK:      %[[DEVICEPTR_A:.*]] = acc.deviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:      %[[DEVICEPTR_C:.*]] = acc.deviceptr varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.kernels dataOperands(%[[DEVICEPTR_A]], %[[DEVICEPTR_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.terminator
 ! CHECK-NEXT: }{{$}}
@@ -282,8 +282,8 @@ subroutine acc_kernels
   !$acc kernels attach(d, e)
   !$acc end kernels
 
-! CHECK:      %[[ATTACH_D:.*]] = acc.attach varPtr(%[[DECLD]]#0 : !fir.ref<!fir.box<!fir.ptr<f32>>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>> {name = "d"}
-! CHECK:      %[[ATTACH_E:.*]] = acc.attach varPtr(%[[DECLE]]#0 : !fir.ref<!fir.box<!fir.ptr<f32>>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>> {name = "e"}
+! CHECK:      %[[ATTACH_D:.*]] = acc.attach varPtr(%[[DECLD]]#0 : !fir.ref<!fir.box<!fir.ptr<f32>>>) name("d") -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+! CHECK:      %[[ATTACH_E:.*]] = acc.attach varPtr(%[[DECLE]]#0 : !fir.ref<!fir.box<!fir.ptr<f32>>>) name("e") -> !fir.ref<!fir.box<!fir.ptr<f32>>>
 ! CHECK:      acc.kernels dataOperands(%[[ATTACH_D]], %[[ATTACH_E]] : !fir.ref<!fir.box<!fir.ptr<f32>>>, !fir.ref<!fir.box<!fir.ptr<f32>>>) {
 ! CHECK:        acc.terminator
 ! CHECK-NEXT: }{{$}}
@@ -292,12 +292,12 @@ subroutine acc_kernels
 !$acc end kernels
 
 ! CHECK: acc.kernels {
-! CHECK: } attributes {defaultAttr = #acc<defaultvalue none>}
+! CHECK: } defaultAttr(none)
 
 !$acc kernels default(present)
 !$acc end kernels
 
 ! CHECK: acc.kernels {
-! CHECK: } attributes {defaultAttr = #acc<defaultvalue present>}
+! CHECK: } defaultAttr(present)
 
 end subroutine acc_kernels

--- a/flang/test/Lower/OpenACC/acc-loop-collapse-force-lowering.f90
+++ b/flang/test/Lower/OpenACC/acc-loop-collapse-force-lowering.f90
@@ -31,4 +31,4 @@ end subroutine
 ! CHECK: hlfir.assign
 ! CHECK: arith.constant 7.300000e+00
 ! CHECK: hlfir.assign
-! CHECK: collapse = [2]
+! CHECK: collapse([2])

--- a/flang/test/Lower/OpenACC/acc-loop-collapse-force-non-tightly-nested.f90
+++ b/flang/test/Lower/OpenACC/acc-loop-collapse-force-non-tightly-nested.f90
@@ -32,7 +32,7 @@ end subroutine
 ! Body assignment inside the loop body
 ! CHECK: hlfir.designate
 ! CHECK: hlfir.assign
-! CHECK: collapse = [3]
+! CHECK: collapse([3])
 
 ! -----
 
@@ -66,7 +66,7 @@ end subroutine
 ! CHECK: acc.loop
 ! CHECK: acc.yield
 ! Outer has collapse = [2]
-! CHECK: collapse = [2]
+! CHECK: collapse([2])
 
 ! -----
 
@@ -109,4 +109,4 @@ end subroutine
 ! CHECK: acc.loop
 ! CHECK: acc.yield
 ! Outer has collapse = [3]
-! CHECK: collapse = [3]
+! CHECK: collapse([3])

--- a/flang/test/Lower/OpenACC/acc-loop-directive-annotation.f90
+++ b/flang/test/Lower/OpenACC/acc-loop-directive-annotation.f90
@@ -5,7 +5,7 @@
 
 ! CHECK-LABEL: func.func @_QPacc_loop_unroll
 ! CHECK: acc.loop {{.*}} {
-! CHECK: } attributes {{{.*}}llvm.loop_annotation = #llvm.loop_annotation<unroll = <disable = false, full = true>>}
+! CHECK: } {{.*}}attributes {{{.*}}llvm.loop_annotation = #llvm.loop_annotation<unroll = <disable = false, full = true>>}
 
 subroutine acc_loop_unroll(a, n)
   real :: a(n)
@@ -19,7 +19,7 @@ end subroutine
 
 ! CHECK-LABEL: func.func @_QPunroll_acc_loop
 ! CHECK: acc.loop {{.*}} {
-! CHECK: } attributes {{{.*}}llvm.loop_annotation = #llvm.loop_annotation<unroll = <disable = false, full = true>>}
+! CHECK: } {{.*}}attributes {{{.*}}llvm.loop_annotation = #llvm.loop_annotation<unroll = <disable = false, full = true>>}
 
 subroutine unroll_acc_loop(a, n)
   real :: a(n)
@@ -33,7 +33,7 @@ end subroutine
 
 ! CHECK-LABEL: func.func @_QPacc_loop_unroll_count
 ! CHECK: acc.loop {{.*}} {
-! CHECK: } attributes {{{.*}}llvm.loop_annotation = #llvm.loop_annotation<unroll = <disable = false, count = 4 : i64>>}
+! CHECK: } {{.*}}attributes {{{.*}}llvm.loop_annotation = #llvm.loop_annotation<unroll = <disable = false, count = 4 : i64>>}
 
 subroutine acc_loop_unroll_count(a, n)
   real :: a(n)
@@ -47,7 +47,7 @@ end subroutine
 
 ! CHECK-LABEL: func.func @_QPunroll_count_acc_loop
 ! CHECK: acc.loop {{.*}} {
-! CHECK: } attributes {{{.*}}llvm.loop_annotation = #llvm.loop_annotation<unroll = <disable = false, count = 4 : i64>>}
+! CHECK: } {{.*}}attributes {{{.*}}llvm.loop_annotation = #llvm.loop_annotation<unroll = <disable = false, count = 4 : i64>>}
 
 subroutine unroll_count_acc_loop(a, n)
   real :: a(n)
@@ -61,7 +61,7 @@ end subroutine
 
 ! CHECK-LABEL: func.func @_QPacc_parallel_loop_unroll
 ! CHECK: acc.loop {{.*}} {
-! CHECK: } attributes {{{.*}}llvm.loop_annotation = #llvm.loop_annotation<unroll = <disable = false, full = true>>}
+! CHECK: } {{.*}}attributes {{{.*}}llvm.loop_annotation = #llvm.loop_annotation<unroll = <disable = false, full = true>>}
 
 subroutine acc_parallel_loop_unroll(a, n)
   real :: a(n)
@@ -75,7 +75,7 @@ end subroutine
 
 ! CHECK-LABEL: func.func @_QPunroll_acc_parallel_loop
 ! CHECK: acc.loop {{.*}} {
-! CHECK: } attributes {{{.*}}llvm.loop_annotation = #llvm.loop_annotation<unroll = <disable = false, full = true>>}
+! CHECK: } {{.*}}attributes {{{.*}}llvm.loop_annotation = #llvm.loop_annotation<unroll = <disable = false, full = true>>}
 
 subroutine unroll_acc_parallel_loop(a, n)
   real :: a(n)
@@ -89,7 +89,7 @@ end subroutine
 
 ! CHECK-LABEL: func.func @_QPacc_parallel_loop_unroll_count
 ! CHECK: acc.loop {{.*}} {
-! CHECK: } attributes {{{.*}}llvm.loop_annotation = #llvm.loop_annotation<unroll = <disable = false, count = 4 : i64>>}
+! CHECK: } {{.*}}attributes {{{.*}}llvm.loop_annotation = #llvm.loop_annotation<unroll = <disable = false, count = 4 : i64>>}
 
 subroutine acc_parallel_loop_unroll_count(a, n)
   real :: a(n)
@@ -103,7 +103,7 @@ end subroutine
 
 ! CHECK-LABEL: func.func @_QPunroll_count_acc_parallel_loop
 ! CHECK: acc.loop {{.*}} {
-! CHECK: } attributes {{{.*}}llvm.loop_annotation = #llvm.loop_annotation<unroll = <disable = false, count = 4 : i64>>}
+! CHECK: } {{.*}}attributes {{{.*}}llvm.loop_annotation = #llvm.loop_annotation<unroll = <disable = false, count = 4 : i64>>}
 
 subroutine unroll_count_acc_parallel_loop(a, n)
   real :: a(n)
@@ -118,7 +118,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPacc_parallel_unroll
 ! CHECK: acc.parallel {
 ! CHECK: acc.loop {{.*}} {
-! CHECK: } attributes {{{.*}}llvm.loop_annotation = #llvm.loop_annotation<unroll = <disable = false, full = true>>}
+! CHECK: } {{.*}}attributes {{{.*}}llvm.loop_annotation = #llvm.loop_annotation<unroll = <disable = false, full = true>>}
 
 subroutine acc_parallel_unroll(a, n)
   real :: a(n)
@@ -134,7 +134,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPunroll_acc_parallel
 ! CHECK: acc.parallel {
 ! CHECK: acc.loop {{.*}} {
-! CHECK: } attributes {{{.*}}llvm.loop_annotation = #llvm.loop_annotation<unroll = <disable = false, full = true>>}
+! CHECK: } {{.*}}attributes {{{.*}}llvm.loop_annotation = #llvm.loop_annotation<unroll = <disable = false, full = true>>}
 
 subroutine unroll_acc_parallel(a, n)
   real :: a(n)
@@ -150,7 +150,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPacc_parallel_unroll_count
 ! CHECK: acc.parallel {
 ! CHECK: acc.loop {{.*}} {
-! CHECK: } attributes {{{.*}}llvm.loop_annotation = #llvm.loop_annotation<unroll = <disable = false, count = 4 : i64>>}
+! CHECK: } {{.*}}attributes {{{.*}}llvm.loop_annotation = #llvm.loop_annotation<unroll = <disable = false, count = 4 : i64>>}
 
 subroutine acc_parallel_unroll_count(a, n)
   real :: a(n)
@@ -166,7 +166,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPunroll_count_acc_parallel
 ! CHECK: acc.parallel {
 ! CHECK: acc.loop {{.*}} {
-! CHECK: } attributes {{{.*}}llvm.loop_annotation = #llvm.loop_annotation<unroll = <disable = false, count = 4 : i64>>}
+! CHECK: } {{.*}}attributes {{{.*}}llvm.loop_annotation = #llvm.loop_annotation<unroll = <disable = false, count = 4 : i64>>}
 
 subroutine unroll_count_acc_parallel(a, n)
   real :: a(n)

--- a/flang/test/Lower/OpenACC/acc-loop.f90
+++ b/flang/test/Lower/OpenACC/acc-loop.f90
@@ -27,50 +27,50 @@ program acc_loop
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK:      acc.loop private(%[[PRIVATE_I]] : !fir.ref<i32>) control(%arg0 : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32) {
 ! CHECK:        acc.yield
-! CHECK-NEXT: } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}{{$}}
+! CHECK-NEXT: } inclusiveUpperbound(array<i1: true>) independent  {{$}}
 
  !$acc loop seq
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK:      acc.loop private(%[[PRIVATE_I]] : !fir.ref<i32>) control(%arg0 : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32) {
 ! CHECK:        acc.yield
-! CHECK-NEXT: } attributes {inclusiveUpperbound = array<i1: true>, seq = [#acc.device_type<none>]}
+! CHECK-NEXT: } inclusiveUpperbound(array<i1: true>) seq
 
   !$acc loop auto
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK:      acc.loop private(%[[PRIVATE_I]] : !fir.ref<i32>) control(%arg0 : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32) {
 ! CHECK:        acc.yield
-! CHECK-NEXT: } attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+! CHECK-NEXT: } inclusiveUpperbound(array<i1: true>) auto_
 
   !$acc loop independent
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK:      acc.loop private(%[[PRIVATE_I]] : !fir.ref<i32>) control(%arg0 : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32) {
 ! CHECK:        acc.yield
-! CHECK-NEXT: } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT: } inclusiveUpperbound(array<i1: true>) independent
 
   !$acc loop gang
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK:      acc.loop gang private(%[[PRIVATE_I]] : !fir.ref<i32>) control(%arg0 : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32) {
 ! CHECK:        acc.yield
-! CHECK-NEXT: } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT: } inclusiveUpperbound(array<i1: true>) independent
 
   !$acc loop gang(num: 8)
   DO i = 1, n
@@ -78,10 +78,10 @@ program acc_loop
   END DO
 
 ! CHECK:      [[GANGNUM1:%.*]] = arith.constant 8 : i32
-! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK:      acc.loop gang({num=[[GANGNUM1]] : i32}) private(%[[PRIVATE_I]] : !fir.ref<i32>) control(%arg0 : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32) {
 ! CHECK:        acc.yield
-! CHECK-NEXT: } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT: } inclusiveUpperbound(array<i1: true>) independent
 
   !$acc loop gang(num: gangNum)
   DO i = 1, n
@@ -89,30 +89,30 @@ program acc_loop
   END DO
 
 ! CHECK:      [[GANGNUM2:%.*]] = fir.load %{{.*}} : !fir.ref<i32>
-! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK:      acc.loop gang({num=[[GANGNUM2]] : i32}) private(%[[PRIVATE_I]] : !fir.ref<i32>) control(%arg0 : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32) {
 ! CHECK:        acc.yield
-! CHECK-NEXT: } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT: } inclusiveUpperbound(array<i1: true>) independent
 
  !$acc loop gang(num: gangNum, static: gangStatic)
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK:      acc.loop gang({num=%{{.*}} : i32, static=%{{.*}} : i32}) private(%[[PRIVATE_I]] : !fir.ref<i32>) control(%arg0 : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32) {
 ! CHECK:        acc.yield
-! CHECK-NEXT: } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT: } inclusiveUpperbound(array<i1: true>) independent
 
   !$acc loop vector
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK:      acc.loop vector private(%[[PRIVATE_I]] : !fir.ref<i32>) control(%arg0 : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32) {
 ! CHECK:        acc.yield
-! CHECK-NEXT: } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT: } inclusiveUpperbound(array<i1: true>) independent
 
   !$acc loop vector(128)
   DO i = 1, n
@@ -120,10 +120,10 @@ program acc_loop
   END DO
 
 ! CHECK:      [[CONSTANT128:%.*]] = arith.constant 128 : i32
-! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK:      acc.loop vector([[CONSTANT128]] : i32) private(%[[PRIVATE_I]] : !fir.ref<i32>) control(%arg0 : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32) {
 ! CHECK:        acc.yield
-! CHECK-NEXT: } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT: } inclusiveUpperbound(array<i1: true>) independent
 
   !$acc loop vector(vectorLength)
   DO i = 1, n
@@ -131,20 +131,20 @@ program acc_loop
   END DO
 
 ! CHECK:      [[VECTORLENGTH:%.*]] = fir.load %{{.*}} : !fir.ref<i32>
-! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK:      acc.loop vector([[VECTORLENGTH]] : i32) private(%[[PRIVATE_I]] : !fir.ref<i32>) control(%arg0 : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32) {
 ! CHECK:        acc.yield
-! CHECK-NEXT: } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT: } inclusiveUpperbound(array<i1: true>) independent
 
 !$acc loop worker
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK:      acc.loop worker private(%[[PRIVATE_I]] : !fir.ref<i32>) control(%arg0 : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32) {
 ! CHECK:        acc.yield
-! CHECK-NEXT: } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT: } inclusiveUpperbound(array<i1: true>) independent
 
   !$acc loop worker(128)
   DO i = 1, n
@@ -152,21 +152,21 @@ program acc_loop
   END DO
 
 ! CHECK:      [[WORKER128:%.*]] = arith.constant 128 : i32
-! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK:      acc.loop worker([[WORKER128]] : i32) private(%[[PRIVATE_I]] : !fir.ref<i32>) control(%arg0 : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32) {
 ! CHECK:        acc.yield
-! CHECK-NEXT: } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT: } inclusiveUpperbound(array<i1: true>) independent
 
   !$acc loop private(c)
   DO i = 1, n
     c(:,i) = d(:,i)
   END DO
 
-! CHECK:      %[[PRIVATE_C:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<!fir.array<10x10xf32>>) recipe(@privatization_ref_10x10xf32) -> !fir.ref<!fir.array<10x10xf32>> {name = "c"}
-! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK:      %[[PRIVATE_C:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<!fir.array<10x10xf32>>) recipe(@privatization_ref_10x10xf32) name("c") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK:      acc.loop private(%[[PRIVATE_C]], %[[PRIVATE_I]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<i32>) control(%arg0 : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32) {
 ! CHECK:        acc.yield
-! CHECK-NEXT: } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT: } inclusiveUpperbound(array<i1: true>) independent
 
   ! When the induction variable is explicitly private - only a single private entry should be created.
   !$acc loop private(i)
@@ -174,34 +174,34 @@ program acc_loop
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {name = "i"}
+! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) name("i") -> !fir.ref<i32>
 ! CHECK:      acc.loop private(%[[PRIVATE_I]] : !fir.ref<i32>) control(%arg0 : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32) {
 ! CHECK:        acc.yield
-! CHECK-NEXT: } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT: } inclusiveUpperbound(array<i1: true>) independent
 
   !$acc loop private(c, d)
   DO i = 1, n
     c(:,i) = d(:,i)
   END DO
 
-! CHECK:      %[[PRIVATE_C:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<!fir.array<10x10xf32>>) recipe(@privatization_ref_10x10xf32) -> !fir.ref<!fir.array<10x10xf32>> {name = "c"}
-! CHECK:      %[[PRIVATE_D:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<!fir.array<10x10xf32>>) recipe(@privatization_ref_10x10xf32) -> !fir.ref<!fir.array<10x10xf32>> {name = "d"}
-! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK:      %[[PRIVATE_C:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<!fir.array<10x10xf32>>) recipe(@privatization_ref_10x10xf32) name("c") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:      %[[PRIVATE_D:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<!fir.array<10x10xf32>>) recipe(@privatization_ref_10x10xf32) name("d") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK:      acc.loop private(%[[PRIVATE_C]], %[[PRIVATE_D]], %[[PRIVATE_I]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<i32>) control(%arg0 : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32) {
 ! CHECK:        acc.yield
-! CHECK-NEXT: } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT: } inclusiveUpperbound(array<i1: true>) independent
 
   !$acc loop private(c) private(d)
   DO i = 1, n
     c(:,i) = d(:,i)
   END DO
 
-! CHECK:      %[[PRIVATE_C:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<!fir.array<10x10xf32>>) recipe(@privatization_ref_10x10xf32) -> !fir.ref<!fir.array<10x10xf32>> {name = "c"}
-! CHECK:      %[[PRIVATE_D:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<!fir.array<10x10xf32>>) recipe(@privatization_ref_10x10xf32) -> !fir.ref<!fir.array<10x10xf32>> {name = "d"}
-! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK:      %[[PRIVATE_C:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<!fir.array<10x10xf32>>) recipe(@privatization_ref_10x10xf32) name("c") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:      %[[PRIVATE_D:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<!fir.array<10x10xf32>>) recipe(@privatization_ref_10x10xf32) name("d") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK:      acc.loop private(%[[PRIVATE_C]], %[[PRIVATE_D]], %[[PRIVATE_I]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<i32>) control(%arg0 : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32) {
 ! CHECK:        acc.yield
-! CHECK-NEXT: } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT: } inclusiveUpperbound(array<i1: true>) independent
 
   !$acc loop tile(2)
   DO i = 1, n
@@ -211,7 +211,7 @@ program acc_loop
 ! CHECK:      [[TILESIZE:%.*]] = arith.constant 2 : i32
 ! CHECK:      acc.loop {{.*}} tile({[[TILESIZE]] : i32}) control(%arg0 : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32) {
 ! CHECK:        acc.yield
-! CHECK-NEXT: } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT: } inclusiveUpperbound(array<i1: true>) independent
 
  !$acc loop tile(*)
   DO i = 1, n
@@ -220,7 +220,7 @@ program acc_loop
 ! CHECK:      [[TILESIZEM1:%.*]] = arith.constant -1 : i32
 ! CHECK:      acc.loop {{.*}} tile({[[TILESIZEM1]] : i32}) control(%arg0 : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32) {
 ! CHECK:        acc.yield
-! CHECK-NEXT: } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT: } inclusiveUpperbound(array<i1: true>) independent
 
   !$acc loop tile(2, 2)
   DO i = 1, n
@@ -233,7 +233,7 @@ program acc_loop
 ! CHECK:      [[TILESIZE2:%.*]] = arith.constant 2 : i32
 ! CHECK:      acc.loop {{.*}} tile({[[TILESIZE1]] : i32, [[TILESIZE2]] : i32}) control(%arg0 : i32, %arg1 : i32) = (%{{.*}} : i32, i32) to (%{{.*}} : i32, i32) step (%{{.*}} : i32, i32) {
 ! CHECK:        acc.yield
-! CHECK-NEXT: } attributes {inclusiveUpperbound = array<i1: true, true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT: } inclusiveUpperbound(array<i1: true, true>) independent
 
   !$acc loop tile(tileSize)
   DO i = 1, n
@@ -242,7 +242,7 @@ program acc_loop
 
 ! CHECK:      acc.loop {{.*}} tile({%{{.*}} : i32}) control(%arg0 : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32) {
 ! CHECK:        acc.yield
-! CHECK-NEXT: } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT: } inclusiveUpperbound(array<i1: true>) independent
 
   !$acc loop tile(tileSize, tileSize)
   DO i = 1, n
@@ -253,7 +253,7 @@ program acc_loop
 
 ! CHECK:      acc.loop {{.*}} tile({%{{.*}} : i32, %{{.*}} : i32}) control(%arg0 : i32, %arg1 : i32) = (%{{.*}} : i32, i32) to (%{{.*}} : i32, i32) step (%{{.*}} : i32, i32) {
 ! CHECK:        acc.yield
-! CHECK-NEXT: } attributes {inclusiveUpperbound = array<i1: true, true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT: } inclusiveUpperbound(array<i1: true, true>) independent
 
   !$acc loop collapse(2)
   DO i = 1, n
@@ -266,7 +266,7 @@ program acc_loop
 ! CHECK:        fir.store %arg0 to %{{.*}} : !fir.ref<i32>
 ! CHECK:        fir.store %arg1 to %{{.*}} : !fir.ref<i32>
 ! CHECK:        acc.yield
-! CHECK-NEXT: } attributes {collapse = [2], collapseDeviceType = [#acc.device_type<none>]{{.*}}}
+! CHECK-NEXT: } {{.*}}collapse([2]) collapseDeviceType([#acc.device_type<none>]){{.*}}
 
   !$acc loop collapse(2) tile(tileSize)
   DO i = 1, n
@@ -279,7 +279,7 @@ program acc_loop
 ! CHECK:        fir.store %arg0 to %{{.*}} : !fir.ref<i32>
 ! CHECK:        fir.store %arg1 to %{{.*}} : !fir.ref<i32>
 ! CHECK:        acc.yield
-! CHECK-NEXT: } attributes {collapse = [2], collapseDeviceType = [#acc.device_type<none>]{{.*}}}
+! CHECK-NEXT: } {{.*}}collapse([2]){{.*}}collapseDeviceType([#acc.device_type<none>]){{.*}}
 
   !$acc loop collapse(2) tile(tileSize, tileSize, tileSize)
   DO i = 1, n
@@ -295,7 +295,7 @@ program acc_loop
 ! CHECK:        fir.store %arg1 to %{{.*}} : !fir.ref<i32>
 ! CHECK:        fir.store %arg2 to %{{.*}} : !fir.ref<i32>
 ! CHECK:        acc.yield
-! CHECK-NEXT: } attributes {collapse = [2], collapseDeviceType = [#acc.device_type<none>]{{.*}}}
+! CHECK-NEXT: } {{.*}}collapse([2]){{.*}}collapseDeviceType([#acc.device_type<none>]){{.*}}
 
 !$acc loop collapse(3) tile(tileSize, tileSize)
   DO i = 1, n
@@ -311,7 +311,7 @@ program acc_loop
 ! CHECK:        fir.store %arg1 to %{{.*}} : !fir.ref<i32>
 ! CHECK:        fir.store %arg2 to %{{.*}} : !fir.ref<i32>
 ! CHECK:        acc.yield
-! CHECK-NEXT: } attributes {collapse = [3], collapseDeviceType = [#acc.device_type<none>]{{.*}}}
+! CHECK-NEXT: } {{.*}}collapse([3]){{.*}}collapseDeviceType([#acc.device_type<none>]){{.*}}
 
   !$acc loop
   DO i = 1, n
@@ -324,9 +324,9 @@ program acc_loop
 ! CHECK:      acc.loop {{.*}} control(%arg0 : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32) {
 ! CHECK:          acc.loop {{.*}} control(%arg1 : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32) {
 ! CHECK:            acc.yield
-! CHECK-NEXT:   } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) independent
 ! CHECK:        acc.yield
-! CHECK-NEXT: } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT: } inclusiveUpperbound(array<i1: true>) independent
 
   !$acc loop reduction(+:reduction_r) reduction(*:reduction_i)
   do i = 1, n
@@ -334,12 +334,12 @@ program acc_loop
     reduction_i = 1
   end do
 
-! CHECK:      %[[REDUCTION_R:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_add_ref_f32) -> !fir.ref<f32> {name = "reduction_r"}
-! CHECK:      %[[REDUCTION_I:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<i32>) recipe(@reduction_mul_ref_i32) -> !fir.ref<i32> {name = "reduction_i"}
-! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK:      %[[REDUCTION_R:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_add_ref_f32) name("reduction_r") -> !fir.ref<f32>
+! CHECK:      %[[REDUCTION_I:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<i32>) recipe(@reduction_mul_ref_i32) name("reduction_i") -> !fir.ref<i32>
+! CHECK:      %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK:      acc.loop private(%[[PRIVATE_I]] : !fir.ref<i32>) reduction(%[[REDUCTION_R]], %[[REDUCTION_I]] : !fir.ref<f32>, !fir.ref<i32>) control(%arg0 : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32) {
 ! CHECK:        acc.yield
-! CHECK-NEXT: } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT: } inclusiveUpperbound(array<i1: true>) independent
 
  !$acc loop gang(dim: gangDim, static: gangStatic)
   DO i = 1, n
@@ -348,7 +348,7 @@ program acc_loop
 
 ! CHECK: acc.loop gang({dim=%{{.*}}, static=%{{.*}} : i32}) {{.*}} control(%arg0 : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32) {
 ! CHECK:        acc.yield
-! CHECK-NEXT: } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT: } inclusiveUpperbound(array<i1: true>) independent
 
   !$acc loop gang(dim: 1)
   DO i = 1, n
@@ -357,7 +357,7 @@ program acc_loop
 
 ! CHECK:      acc.loop gang({dim={{.*}} : i32}) {{.*}} control(%arg0 : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32) {
 ! CHECK:        acc.yield
-! CHECK-NEXT: } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT: } inclusiveUpperbound(array<i1: true>) independent
 
   !$acc loop
   do 100 i=0, n
@@ -395,8 +395,8 @@ end subroutine
 ! CHECK-DAG: %[[ALLOCA_I:.*]] = fir.alloca i32 {bindc_name = "i"}
 ! CHECK-DAG: %[[ALLOCA_J:.*]] = fir.alloca i32 {bindc_name = "j"}
 ! CHECK-DAG: %[[ALLOCA_K:.*]] = fir.alloca i32 {bindc_name = "k"}
-! CHECK: %[[P_I:.*]] = acc.private varPtr(%[[ALLOCA_I]] : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
-! CHECK: %[[P_J:.*]] = acc.private varPtr(%[[ALLOCA_J]] : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "j"}
-! CHECK: %[[P_K:.*]] = acc.private varPtr(%[[ALLOCA_K]] : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "k"}
+! CHECK: %[[P_I:.*]] = acc.private varPtr(%[[ALLOCA_I]] : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
+! CHECK: %[[P_J:.*]] = acc.private varPtr(%[[ALLOCA_J]] : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("j") -> !fir.ref<i32>
+! CHECK: %[[P_K:.*]] = acc.private varPtr(%[[ALLOCA_K]] : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("k") -> !fir.ref<i32>
 ! CHECK: acc.loop combined(parallel) private(%[[P_I]], %[[P_J]], %[[P_K]] : !fir.ref<i32>, !fir.ref<i32>, !fir.ref<i32>) control(%{{.*}} : i32, %{{.*}} : i32, %{{.*}} : i32) = (%c1{{.*}}, %c1{{.*}}, %c1{{.*}} : i32, i32, i32) to (%c10{{.*}}, %c100{{.*}}, %c200{{.*}} : i32, i32, i32)  step (%c1{{.*}}, %c1{{.*}}, %c1{{.*}} : i32, i32, i32)
-! CHECK: } attributes {inclusiveUpperbound = array<i1: true, true, true>, independent = [#acc.device_type<none>]}
+! CHECK: } inclusiveUpperbound(array<i1: true, true, true>) independent

--- a/flang/test/Lower/OpenACC/acc-no-create-array-section.f90
+++ b/flang/test/Lower/OpenACC/acc-no-create-array-section.f90
@@ -11,11 +11,11 @@ end subroutine
 ! CHECK-LABEL:   func.func @_QPfoo(
 ! CHECK:           %[[SHAPE_0:.*]] = fir.shape
 ! CHECK:           %[[BOUNDS_0:.*]] = acc.bounds
-! CHECK:           %[[NOCREATE_0:.*]] = acc.nocreate var(%{{.*}} : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUNDS_0]]) -> !fir.box<!fir.array<?xf32>> {name = "a(11:20)"}
+! CHECK:           %[[NOCREATE_0:.*]] = acc.nocreate var(%{{.*}} : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUNDS_0]]) name("a(11:20)") -> !fir.box<!fir.array<?xf32>>
 ! CHECK:           acc.parallel dataOperands(%[[NOCREATE_0]] : !fir.box<!fir.array<?xf32>>) {
 ! CHECK:             %[[BOX_ADDR_0:.*]] = fir.box_addr %[[NOCREATE_0]] : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
 ! CHECK:             %[[DECLARE_2:.*]]:2 = hlfir.declare %[[BOX_ADDR_0]](%[[SHAPE_0]]) {uniq_name = "_QFfooEa"} : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>) -> (!fir.box<!fir.array<?xf32>>, !fir.ref<!fir.array<?xf32>>)
 ! CHECK:             fir.call @_QPbar(%[[DECLARE_2]]#1) fastmath<contract> : (!fir.ref<!fir.array<?xf32>>) -> ()
 ! CHECK:             acc.yield
 ! CHECK:           }
-! CHECK:           acc.delete accVar(%[[NOCREATE_0]] : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUNDS_0]]) {dataClause = #acc<data_clause acc_no_create>, name = "a(11:20)"}
+! CHECK:           acc.delete accVar(%[[NOCREATE_0]] : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUNDS_0]]) dataClause(acc_no_create) name("a(11:20)")

--- a/flang/test/Lower/OpenACC/acc-parallel-loop.f90
+++ b/flang/test/Lower/OpenACC/acc-parallel-loop.f90
@@ -49,9 +49,9 @@ subroutine acc_parallel_loop
 ! CHECK:      acc.parallel {
 ! CHECK:        acc.loop private{{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {{{.*}}independent = [#acc.device_type<none>]}
+! CHECK-NEXT:   } {{.*}}independent
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop
   DO i = 1, n
@@ -61,9 +61,9 @@ subroutine acc_parallel_loop
 ! CHECK:      acc.parallel combined(loop) {
 ! CHECK:        acc.loop combined(parallel) private{{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {{{.*}}independent = [#acc.device_type<none>]}
+! CHECK-NEXT:   } {{.*}}independent{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop async
   DO i = 1, n
@@ -74,7 +74,7 @@ subroutine acc_parallel_loop
 ! CHECK:      acc.parallel {{.*}} async {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) independent
 ! CHECK:        acc.yield
 ! CHECK-NEXT: }
 
@@ -87,9 +87,9 @@ subroutine acc_parallel_loop
 ! CHECK:      acc.parallel {{.*}} async([[ASYNC1]] : i32) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop async(async)
   DO i = 1, n
@@ -100,9 +100,9 @@ subroutine acc_parallel_loop
 ! CHECK:      acc.parallel {{.*}} async([[ASYNC2]] : i32) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop async(async) device_type(nvidia) async(1)
   DO i = 1, n
@@ -118,7 +118,7 @@ subroutine acc_parallel_loop
 ! CHECK:      acc.parallel {{.*}} wait {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
 ! CHECK-NEXT: }
 
@@ -131,9 +131,9 @@ subroutine acc_parallel_loop
 ! CHECK:      acc.parallel {{.*}} wait({[[WAIT1]] : i32}) {
 ! CHECK:        acc.loop
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop wait(1, 2)
   DO i = 1, n
@@ -145,9 +145,9 @@ subroutine acc_parallel_loop
 ! CHECK:      acc.parallel {{.*}} wait({[[WAIT2]] : i32, [[WAIT3]] : i32}) {
 ! CHECK:        acc.loop
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop wait(wait1, wait2)
   DO i = 1, n
@@ -159,9 +159,9 @@ subroutine acc_parallel_loop
 ! CHECK:      acc.parallel {{.*}} wait({[[WAIT4]] : i32, [[WAIT5]] : i32}) {
 ! CHECK:        acc.loop
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop num_gangs(1)
   DO i = 1, n
@@ -172,9 +172,9 @@ subroutine acc_parallel_loop
 ! CHECK:      acc.parallel {{.*}} num_gangs({[[NUMGANGS1]] : i32}) {
 ! CHECK:        acc.loop
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop num_gangs(numGangs)
   DO i = 1, n
@@ -185,9 +185,9 @@ subroutine acc_parallel_loop
 ! CHECK:      acc.parallel {{.*}} num_gangs({[[NUMGANGS2]] : i32}) {
 ! CHECK:        acc.loop
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop num_workers(10)
   DO i = 1, n
@@ -198,9 +198,9 @@ subroutine acc_parallel_loop
 ! CHECK:      acc.parallel {{.*}} num_workers([[NUMWORKERS1]] : i32) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop num_workers(numWorkers)
   DO i = 1, n
@@ -211,9 +211,9 @@ subroutine acc_parallel_loop
 ! CHECK:      acc.parallel {{.*}} num_workers([[NUMWORKERS2]] : i32) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop vector_length(128)
   DO i = 1, n
@@ -224,9 +224,9 @@ subroutine acc_parallel_loop
 ! CHECK:      acc.parallel {{.*}} vector_length([[VECTORLENGTH1]] : i32) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop vector_length(vectorLength)
   DO i = 1, n
@@ -237,9 +237,9 @@ subroutine acc_parallel_loop
 ! CHECK:      acc.parallel {{.*}} vector_length([[VECTORLENGTH2]] : i32) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop if(.TRUE.)
   DO i = 1, n
@@ -250,9 +250,9 @@ subroutine acc_parallel_loop
 ! CHECK:      acc.parallel {{.*}} if([[IF1]]) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop if(ifCondition)
   DO i = 1, n
@@ -264,9 +264,9 @@ subroutine acc_parallel_loop
 ! CHECK:      acc.parallel {{.*}} if([[IF2]]) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop self(.TRUE.)
   DO i = 1, n
@@ -277,9 +277,9 @@ subroutine acc_parallel_loop
 ! CHECK:      acc.parallel {{.*}} self([[SELF1]]) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop self
   DO i = 1, n
@@ -289,9 +289,9 @@ subroutine acc_parallel_loop
 ! CHECK:      acc.parallel {{.*}} {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: } attributes {selfAttr}
+! CHECK-NEXT: } selfAttr
 
   !$acc parallel loop self(ifCondition)
   DO i = 1, n
@@ -302,164 +302,164 @@ subroutine acc_parallel_loop
 ! CHECK:      acc.parallel {{.*}} self(%[[SELF2]]) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop copy(a, b)
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "a"}
-! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "b"}
+! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) name("a") -> !fir.ref<!fir.array<10xf32>>
+! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) name("b") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK:      acc.parallel {{.*}} dataOperands(%[[COPYIN_A]], %[[COPYIN_B]] : !fir.ref<!fir.array<10xf32>>, !fir.ref<!fir.array<10xf32>>) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
-! CHECK:      acc.copyout accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "a"}
-! CHECK:      acc.copyout accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "b"}
+! CHECK-NEXT: }{{.*}}
+! CHECK:      acc.copyout accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) name("a")
+! CHECK:      acc.copyout accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) name("b")
 
   !$acc parallel loop copy(a) copy(b)
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "a"}
-! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "b"}
+! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) name("a") -> !fir.ref<!fir.array<10xf32>>
+! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) name("b") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK:      acc.parallel {{.*}} dataOperands(%[[COPYIN_A]], %[[COPYIN_B]] : !fir.ref<!fir.array<10xf32>>, !fir.ref<!fir.array<10xf32>>) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
-! CHECK:      acc.copyout accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "a"}
-! CHECK:      acc.copyout accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "b"}
+! CHECK-NEXT: }{{.*}}
+! CHECK:      acc.copyout accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) name("a")
+! CHECK:      acc.copyout accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) name("b")
 
   !$acc parallel loop copyin(a) copyin(readonly: b)
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "a"}
-! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {dataClause = #acc<data_clause acc_copyin_readonly>, name = "b"}
+! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) name("a") -> !fir.ref<!fir.array<10xf32>>
+! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copyin_readonly) name("b") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK:      acc.parallel {{.*}} dataOperands(%[[COPYIN_A]], %[[COPYIN_B]] : !fir.ref<!fir.array<10xf32>>, !fir.ref<!fir.array<10xf32>>) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
-! CHECK:      acc.delete accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_copyin>, name = "a"}
-! CHECK:      acc.delete accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_copyin_readonly>, name = "b"}
+! CHECK-NEXT: }{{.*}}
+! CHECK:      acc.delete accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copyin) name("a")
+! CHECK:      acc.delete accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copyin_readonly) name("b")
 
   !$acc parallel loop copyout(a) copyout(zero: b)
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {dataClause = #acc<data_clause acc_copyout>, name = "a"}
-! CHECK:      %[[CREATE_B:.*]] = acc.create varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {dataClause = #acc<data_clause acc_copyout_zero>, name = "b"}
+! CHECK:      %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copyout) name("a") -> !fir.ref<!fir.array<10xf32>>
+! CHECK:      %[[CREATE_B:.*]] = acc.create varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copyout_zero) name("b") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK:      acc.parallel {{.*}} dataOperands(%[[CREATE_A]], %[[CREATE_B]] : !fir.ref<!fir.array<10xf32>>, !fir.ref<!fir.array<10xf32>>) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
-! CHECK:      acc.copyout accPtr(%[[CREATE_A]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) {name = "a"}
-! CHECK:      acc.copyout accPtr(%[[CREATE_B]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_copyout_zero>, name = "b"}
+! CHECK-NEXT: }{{.*}}
+! CHECK:      acc.copyout accPtr(%[[CREATE_A]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) name("a")
+! CHECK:      acc.copyout accPtr(%[[CREATE_B]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copyout_zero) name("b")
 
   !$acc parallel loop create(b) create(zero: a)
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[CREATE_B:.*]] = acc.create varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "b"}
-! CHECK:      %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {dataClause = #acc<data_clause acc_create_zero>, name = "a"}
+! CHECK:      %[[CREATE_B:.*]] = acc.create varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) name("b") -> !fir.ref<!fir.array<10xf32>>
+! CHECK:      %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_create_zero) name("a") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK:      acc.parallel {{.*}} dataOperands(%[[CREATE_B]], %[[CREATE_A]] : !fir.ref<!fir.array<10xf32>>, !fir.ref<!fir.array<10xf32>>) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
-! CHECK:      acc.delete accPtr(%[[CREATE_B]] : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_create>, name = "b"}
-! CHECK:      acc.delete accPtr(%[[CREATE_A]] : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_create_zero>, name = "a"}
+! CHECK-NEXT: }{{.*}}
+! CHECK:      acc.delete accPtr(%[[CREATE_B]] : !fir.ref<!fir.array<10xf32>>) dataClause(acc_create) name("b")
+! CHECK:      acc.delete accPtr(%[[CREATE_A]] : !fir.ref<!fir.array<10xf32>>) dataClause(acc_create_zero) name("a")
 
   !$acc parallel loop no_create(a, b)
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[NOCREATE_A:.*]] = acc.nocreate varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "a"}
-! CHECK:      %[[NOCREATE_B:.*]] = acc.nocreate varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "b"}
+! CHECK:      %[[NOCREATE_A:.*]] = acc.nocreate varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) name("a") -> !fir.ref<!fir.array<10xf32>>
+! CHECK:      %[[NOCREATE_B:.*]] = acc.nocreate varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) name("b") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK:      acc.parallel {{.*}} dataOperands(%[[NOCREATE_A]], %[[NOCREATE_B]] : !fir.ref<!fir.array<10xf32>>, !fir.ref<!fir.array<10xf32>>) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
-! CHECK:      acc.delete accPtr(%[[NOCREATE_A]] : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_no_create>, name = "a"}
-! CHECK:      acc.delete accPtr(%[[NOCREATE_B]] : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_no_create>, name = "b"}
+! CHECK-NEXT: }{{.*}}
+! CHECK:      acc.delete accPtr(%[[NOCREATE_A]] : !fir.ref<!fir.array<10xf32>>) dataClause(acc_no_create) name("a")
+! CHECK:      acc.delete accPtr(%[[NOCREATE_B]] : !fir.ref<!fir.array<10xf32>>) dataClause(acc_no_create) name("b")
 
   !$acc parallel loop present(a, b)
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[PRESENT_A:.*]] = acc.present varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "a"}
-! CHECK:      %[[PRESENT_B:.*]] = acc.present varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "b"}
+! CHECK:      %[[PRESENT_A:.*]] = acc.present varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) name("a") -> !fir.ref<!fir.array<10xf32>>
+! CHECK:      %[[PRESENT_B:.*]] = acc.present varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) name("b") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK:      acc.parallel {{.*}} dataOperands(%[[PRESENT_A]], %[[PRESENT_B]] : !fir.ref<!fir.array<10xf32>>, !fir.ref<!fir.array<10xf32>>) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
-! CHECK:      acc.delete accPtr(%[[PRESENT_A]] : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_present>, name = "a"}
-! CHECK:      acc.delete accPtr(%[[PRESENT_B]] : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_present>, name = "b"}
+! CHECK-NEXT: }{{.*}}
+! CHECK:      acc.delete accPtr(%[[PRESENT_A]] : !fir.ref<!fir.array<10xf32>>) dataClause(acc_present) name("a")
+! CHECK:      acc.delete accPtr(%[[PRESENT_B]] : !fir.ref<!fir.array<10xf32>>) dataClause(acc_present) name("b")
 
   !$acc parallel loop deviceptr(a) deviceptr(b)
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[DEVICEPTR_A:.*]] = acc.deviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "a"}
-! CHECK:      %[[DEVICEPTR_B:.*]] = acc.deviceptr varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "b"}
+! CHECK:      %[[DEVICEPTR_A:.*]] = acc.deviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) name("a") -> !fir.ref<!fir.array<10xf32>>
+! CHECK:      %[[DEVICEPTR_B:.*]] = acc.deviceptr varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) name("b") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK:      acc.parallel {{.*}} dataOperands(%[[DEVICEPTR_A]], %[[DEVICEPTR_B]] : !fir.ref<!fir.array<10xf32>>, !fir.ref<!fir.array<10xf32>>) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop attach(f, g)
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[ATTACH_F:.*]] = acc.attach varPtr(%[[DECLF]]#0 : !fir.ref<!fir.box<!fir.ptr<f32>>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>> {name = "f"}
-! CHECK:      %[[ATTACH_G:.*]] = acc.attach varPtr(%[[DECLG]]#0 : !fir.ref<!fir.box<!fir.ptr<f32>>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>> {name = "g"}
+! CHECK:      %[[ATTACH_F:.*]] = acc.attach varPtr(%[[DECLF]]#0 : !fir.ref<!fir.box<!fir.ptr<f32>>>) name("f") -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+! CHECK:      %[[ATTACH_G:.*]] = acc.attach varPtr(%[[DECLG]]#0 : !fir.ref<!fir.box<!fir.ptr<f32>>>) name("g") -> !fir.ref<!fir.box<!fir.ptr<f32>>>
 ! CHECK:      acc.parallel {{.*}} dataOperands(%[[ATTACH_F]], %[[ATTACH_G]] : !fir.ref<!fir.box<!fir.ptr<f32>>>, !fir.ref<!fir.box<!fir.ptr<f32>>>) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop private(a) firstprivate(b)
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[ACC_PRIVATE_B:.*]] = acc.firstprivate varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) recipe(@firstprivatization_ref_10xf32) -> !fir.ref<!fir.array<10xf32>> {name = "b"}
+! CHECK:      %[[ACC_PRIVATE_B:.*]] = acc.firstprivate varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) recipe(@firstprivatization_ref_10xf32) name("b") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK:      acc.parallel {{.*}} firstprivate(%[[ACC_PRIVATE_B]] : !fir.ref<!fir.array<10xf32>>) {
-! CHECK:        %[[ACC_PRIVATE_A:.*]] = acc.private varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) recipe(@privatization_ref_10xf32) -> !fir.ref<!fir.array<10xf32>> {name = "a"}
+! CHECK:        %[[ACC_PRIVATE_A:.*]] = acc.private varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) recipe(@privatization_ref_10xf32) name("a") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK:        acc.loop {{.*}} private(%[[ACC_PRIVATE_A]]{{.*}} : !fir.ref<!fir.array<10xf32>>{{.*}})
 ! CHECK-NOT:      fir.do_loop
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop seq
   DO i = 1, n
@@ -469,9 +469,9 @@ subroutine acc_parallel_loop
 ! CHECK:      acc.parallel {{.*}} {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {inclusiveUpperbound = array<i1: true>, seq = [#acc.device_type<none>]}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) seq
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop auto
   DO i = 1, n
@@ -481,9 +481,9 @@ subroutine acc_parallel_loop
 ! CHECK:      acc.parallel {{.*}} {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) auto_
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop independent
   DO i = 1, n
@@ -493,9 +493,9 @@ subroutine acc_parallel_loop
 ! CHECK:      acc.parallel {{.*}} {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) independent
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop gang
   DO i = 1, n
@@ -505,9 +505,9 @@ subroutine acc_parallel_loop
 ! CHECK:      acc.parallel {{.*}} {
 ! CHECK:        acc.loop {{.*}} gang
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) independent
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop gang(num: 8)
   DO i = 1, n
@@ -518,9 +518,9 @@ subroutine acc_parallel_loop
 ! CHECK:        [[GANGNUM1:%.*]] = arith.constant 8 : i32
 ! CHECK:        acc.loop {{.*}} gang({num=[[GANGNUM1]] : i32})
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) independent
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop gang(num: gangNum)
   DO i = 1, n
@@ -531,9 +531,9 @@ subroutine acc_parallel_loop
 ! CHECK:        [[GANGNUM2:%.*]] = fir.load %{{.*}} : !fir.ref<i32>
 ! CHECK:        acc.loop {{.*}} gang({num=[[GANGNUM2]] : i32})
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) independent
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
  !$acc parallel loop gang(num: gangNum, static: gangStatic)
   DO i = 1, n
@@ -543,9 +543,9 @@ subroutine acc_parallel_loop
 ! CHECK:      acc.parallel {{.*}} {
 ! CHECK:        acc.loop {{.*}} gang({num=%{{.*}} : i32, static=%{{.*}} : i32})
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) independent
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop vector
   DO i = 1, n
@@ -555,9 +555,9 @@ subroutine acc_parallel_loop
 ! CHECK:      acc.parallel {{.*}} {
 ! CHECK:        acc.loop {{.*}} vector
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) independent
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop vector(128)
   DO i = 1, n
@@ -568,9 +568,9 @@ subroutine acc_parallel_loop
 ! CHECK:        [[CONSTANT128:%.*]] = arith.constant 128 : i32
 ! CHECK:        acc.loop {{.*}} vector([[CONSTANT128]] : i32) {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) independent
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop vector(vectorLength)
   DO i = 1, n
@@ -582,9 +582,9 @@ subroutine acc_parallel_loop
 ! CHECK:        acc.loop {{.*}} vector([[VECTORLENGTH]] : i32) {{.*}} {
 ! CHECK-NOT:      fir.do_loop
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) independent
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop worker
   DO i = 1, n
@@ -595,9 +595,9 @@ subroutine acc_parallel_loop
 ! CHECK:        acc.loop {{.*}} worker {{.*}} {
 ! CHECK-NOT:      fir.do_loop
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) independent
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop worker(128)
   DO i = 1, n
@@ -609,9 +609,9 @@ subroutine acc_parallel_loop
 ! CHECK:        acc.loop {{.*}} worker([[WORKER128]] : i32) {{.*}} {
 ! CHECK-NOT:      fir.do_loop
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) independent
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop collapse(2)
   DO i = 1, n
@@ -623,9 +623,9 @@ subroutine acc_parallel_loop
 ! CHECK:      acc.parallel {{.*}} {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {{{.*}}collapse = [2], collapseDeviceType = [#acc.device_type<none>]{{.*}}}
+! CHECK-NEXT:   } {{.*}}collapse([2]){{.*}}collapseDeviceType([#acc.device_type<none>]){{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop
   DO i = 1, n
@@ -639,11 +639,11 @@ subroutine acc_parallel_loop
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:            acc.loop {{.*}} {
 ! CHECK:              acc.yield
-! CHECK-NEXT:     } attributes {{{.*}}independent = [#acc.device_type<none>]}
+! CHECK-NEXT:     } {{.*}}independent{{.*}}
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {{{.*}}independent = [#acc.device_type<none>]}
+! CHECK-NEXT:   } {{.*}}independent{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
  !$acc parallel loop tile(2)
   DO i = 1, n
@@ -654,9 +654,9 @@ subroutine acc_parallel_loop
 ! CHECK:        [[TILESIZE:%.*]] = arith.constant 2 : i32
 ! CHECK:        acc.loop {{.*}} tile({[[TILESIZE]] : i32}) {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
  !$acc parallel loop tile(*)
   DO i = 1, n
@@ -667,9 +667,9 @@ subroutine acc_parallel_loop
 ! CHECK:        [[TILESIZEM1:%.*]] = arith.constant -1 : i32
 ! CHECK:        acc.loop {{.*}} tile({[[TILESIZEM1]] : i32}) {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop tile(2, 2)
   DO i = 1, n
@@ -683,9 +683,9 @@ subroutine acc_parallel_loop
 ! CHECK:        [[TILESIZE2:%.*]] = arith.constant 2 : i32
 ! CHECK:        acc.loop {{.*}} tile({[[TILESIZE1]] : i32, [[TILESIZE2]] : i32}) control(%arg0 : i32, %arg1 : i32) {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop tile(tileSize)
   DO i = 1, n
@@ -695,9 +695,9 @@ subroutine acc_parallel_loop
 ! CHECK:      acc.parallel {{.*}} {
 ! CHECK:        acc.loop {{.*}} tile({%{{.*}} : i32}) {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop tile(tileSize, tileSize)
   DO i = 1, n
@@ -709,9 +709,9 @@ subroutine acc_parallel_loop
 ! CHECK:      acc.parallel {{.*}} {
 ! CHECK:        acc.loop {{.*}} tile({%{{.*}} : i32, %{{.*}} : i32}) control(%arg0 : i32, %arg1 : i32) {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc parallel loop reduction(+:reduction_r) reduction(*:reduction_i)
   do i = 1, n
@@ -719,18 +719,18 @@ subroutine acc_parallel_loop
     reduction_i = 1
   end do
 
-! CHECK:      %[[COPYINREDR:.*]] = acc.copyin varPtr(%{{.*}} : !fir.ref<f32>) -> !fir.ref<f32> {dataClause = #acc<data_clause acc_reduction>, implicit = true, name = "reduction_r"}
-! CHECK:      %[[COPYINREDI:.*]] = acc.copyin varPtr(%{{.*}} : !fir.ref<i32>) -> !fir.ref<i32> {dataClause = #acc<data_clause acc_reduction>, implicit = true, name = "reduction_i"}
+! CHECK:      %[[COPYINREDR:.*]] = acc.copyin varPtr(%{{.*}} : !fir.ref<f32>) dataClause(acc_reduction) implicit(true) name("reduction_r") -> !fir.ref<f32>
+! CHECK:      %[[COPYINREDI:.*]] = acc.copyin varPtr(%{{.*}} : !fir.ref<i32>) dataClause(acc_reduction) implicit(true) name("reduction_i") -> !fir.ref<i32>
 ! CHECK:      acc.parallel {{.*}} dataOperands(%[[COPYINREDR]], %[[COPYINREDI]] : !fir.ref<f32>, !fir.ref<i32>) {
-! CHECK:        %[[REDUCTION_R:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_add_ref_f32) -> !fir.ref<f32> {name = "reduction_r"}
-! CHECK:        %[[REDUCTION_I:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<i32>) recipe(@reduction_mul_ref_i32) -> !fir.ref<i32> {name = "reduction_i"}
+! CHECK:        %[[REDUCTION_R:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_add_ref_f32) name("reduction_r") -> !fir.ref<f32>
+! CHECK:        %[[REDUCTION_I:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<i32>) recipe(@reduction_mul_ref_i32) name("reduction_i") -> !fir.ref<i32>
 ! CHECK:        acc.loop {{.*}} reduction(%[[REDUCTION_R]], %[[REDUCTION_I]] : !fir.ref<f32>, !fir.ref<i32>) {{.*}}
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
-! CHECK:      acc.copyout accPtr(%[[COPYINREDR]] : !fir.ref<f32>) to varPtr(%{{.*}} : !fir.ref<f32>) {dataClause = #acc<data_clause acc_reduction>, implicit = true, name = "reduction_r"}
-! CHECK:      acc.copyout accPtr(%[[COPYINREDI]] : !fir.ref<i32>) to varPtr(%{{.*}} : !fir.ref<i32>) {dataClause = #acc<data_clause acc_reduction>, implicit = true, name = "reduction_i"}
+! CHECK-NEXT: }{{.*}}
+! CHECK:      acc.copyout accPtr(%[[COPYINREDR]] : !fir.ref<f32>) to varPtr(%{{.*}} : !fir.ref<f32>) dataClause(acc_reduction) implicit(true) name("reduction_r")
+! CHECK:      acc.copyout accPtr(%[[COPYINREDI]] : !fir.ref<i32>) to varPtr(%{{.*}} : !fir.ref<i32>) dataClause(acc_reduction) implicit(true) name("reduction_i")
 
 
   !$acc parallel loop

--- a/flang/test/Lower/OpenACC/acc-parallel.f90
+++ b/flang/test/Lower/OpenACC/acc-parallel.f90
@@ -195,7 +195,7 @@ subroutine acc_parallel
 
 ! CHECK:      acc.parallel {
 ! CHECK:        acc.yield
-! CHECK-NEXT: } attributes {selfAttr}
+! CHECK-NEXT: } selfAttr
 
   !$acc parallel self(ifCondition)
   !$acc end parallel
@@ -208,107 +208,107 @@ subroutine acc_parallel
   !$acc parallel copy(a, b, c)
   !$acc end parallel
 
-! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "a"}
-! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "b"}
-! CHECK:      %[[COPYIN_C:.*]] = acc.copyin varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "c"}
+! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:      %[[COPYIN_C:.*]] = acc.copyin varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.parallel dataOperands(%[[COPYIN_A]], %[[COPYIN_B]], %[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.yield
 ! CHECK-NEXT: }{{$}}
-! CHECK:      acc.copyout accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "a"}
-! CHECK:      acc.copyout accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "b"}
-! CHECK:      acc.copyout accPtr(%[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "c"}
+! CHECK:      acc.copyout accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("a")
+! CHECK:      acc.copyout accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("b")
+! CHECK:      acc.copyout accPtr(%[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("c")
 
   !$acc parallel copy(a) copy(b) copy(c)
   !$acc end parallel
 
 
-! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "a"}
-! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "b"}
-! CHECK:      %[[COPYIN_C:.*]] = acc.copyin varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "c"}
+! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:      %[[COPYIN_C:.*]] = acc.copyin varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.parallel dataOperands(%[[COPYIN_A]], %[[COPYIN_B]], %[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.yield
 ! CHECK-NEXT: }{{$}}
-! CHECK:      acc.copyout accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "a"}
-! CHECK:      acc.copyout accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "b"}
-! CHECK:      acc.copyout accPtr(%[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "c"}
+! CHECK:      acc.copyout accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("a")
+! CHECK:      acc.copyout accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("b")
+! CHECK:      acc.copyout accPtr(%[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("c")
 
   !$acc parallel copyin(a) copyin(readonly: b, c)
   !$acc end parallel
 
-! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "a"}
-! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copyin_readonly>, name = "b"}
-! CHECK:      %[[COPYIN_C:.*]] = acc.copyin varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copyin_readonly>, name = "c"}
+! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyin_readonly) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:      %[[COPYIN_C:.*]] = acc.copyin varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyin_readonly) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.parallel dataOperands(%[[COPYIN_A]], %[[COPYIN_B]], %[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.yield
 ! CHECK-NEXT: }{{$}}
-! CHECK:      acc.delete accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copyin>, name = "a"}
-! CHECK:      acc.delete accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copyin_readonly>, name = "b"}
-! CHECK:      acc.delete accPtr(%[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copyin_readonly>, name = "c"}
+! CHECK:      acc.delete accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyin) name("a")
+! CHECK:      acc.delete accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyin_readonly) name("b")
+! CHECK:      acc.delete accPtr(%[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyin_readonly) name("c")
 
   !$acc parallel copyout(a) copyout(zero: b) copyout(c)
   !$acc end parallel
 
-! CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copyout>, name = "a"}
-! CHECK: %[[CREATE_B:.*]] = acc.create varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copyout_zero>, name = "b"}
-! CHECK: %[[CREATE_C:.*]] = acc.create varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copyout>, name = "c"}
+! CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyout) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK: %[[CREATE_B:.*]] = acc.create varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyout_zero) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK: %[[CREATE_C:.*]] = acc.create varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyout) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.parallel dataOperands(%[[CREATE_A]], %[[CREATE_B]], %[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.yield
 ! CHECK-NEXT: }{{$}}
-! CHECK: acc.copyout accPtr(%[[CREATE_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) {name = "a"}
-! CHECK: acc.copyout accPtr(%[[CREATE_B]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copyout_zero>, name = "b"}
-! CHECK: acc.copyout accPtr(%[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) {name = "c"}
+! CHECK: acc.copyout accPtr(%[[CREATE_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("a")
+! CHECK: acc.copyout accPtr(%[[CREATE_B]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyout_zero) name("b")
+! CHECK: acc.copyout accPtr(%[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("c")
 
   !$acc parallel create(a, b) create(zero: c)
   !$acc end parallel
 
-! CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "a"}
-! CHECK: %[[CREATE_B:.*]] = acc.create varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "b"}
-! CHECK: %[[CREATE_C:.*]] = acc.create varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_create_zero>, name = "c"}
+! CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK: %[[CREATE_B:.*]] = acc.create varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK: %[[CREATE_C:.*]] = acc.create varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_create_zero) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.parallel dataOperands(%[[CREATE_A]], %[[CREATE_B]], %[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.yield
 ! CHECK-NEXT: }{{$}}
-! CHECK: acc.delete accPtr(%[[CREATE_A]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_create>, name = "a"}
-! CHECK: acc.delete accPtr(%[[CREATE_B]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_create>, name = "b"}
-! CHECK: acc.delete accPtr(%[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_create_zero>, name = "c"}
+! CHECK: acc.delete accPtr(%[[CREATE_A]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_create) name("a")
+! CHECK: acc.delete accPtr(%[[CREATE_B]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_create) name("b")
+! CHECK: acc.delete accPtr(%[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_create_zero) name("c")
 
   !$acc parallel create(c) copy(b) create(a)
   !$acc end parallel
-! CHECK: %[[CREATE_C:.*]] = acc.create varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "c"}
-! CHECK: %[[COPY_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "b"}
-! CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "a"}
+! CHECK: %[[CREATE_C:.*]] = acc.create varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("c") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK: %[[COPY_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK: acc.parallel   dataOperands(%[[CREATE_C]], %[[COPY_B]], %[[CREATE_A]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 
   !$acc parallel no_create(a, b) create(zero: c)
   !$acc end parallel
 
-! CHECK: %[[NO_CREATE_A:.*]] = acc.nocreate varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "a"}
-! CHECK: %[[NO_CREATE_B:.*]] = acc.nocreate varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "b"}
-! CHECK: %[[CREATE_C:.*]] = acc.create varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_create_zero>, name = "c"}
+! CHECK: %[[NO_CREATE_A:.*]] = acc.nocreate varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK: %[[NO_CREATE_B:.*]] = acc.nocreate varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK: %[[CREATE_C:.*]] = acc.create varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_create_zero) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.parallel dataOperands(%[[NO_CREATE_A]], %[[NO_CREATE_B]], %[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.yield
 ! CHECK-NEXT: }{{$}}
-! CHECK: acc.delete accPtr(%[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_create_zero>, name = "c"}
-! CHECK: acc.delete accPtr(%[[NO_CREATE_A]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_no_create>, name = "a"}
-! CHECK: acc.delete accPtr(%[[NO_CREATE_B]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_no_create>, name = "b"}
+! CHECK: acc.delete accPtr(%[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_create_zero) name("c")
+! CHECK: acc.delete accPtr(%[[NO_CREATE_A]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_no_create) name("a")
+! CHECK: acc.delete accPtr(%[[NO_CREATE_B]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_no_create) name("b")
 
   !$acc parallel present(a, b, c)
   !$acc end parallel
 
-! CHECK: %[[PRESENT_A:.*]] = acc.present varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "a"}
-! CHECK: %[[PRESENT_B:.*]] = acc.present varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "b"}
-! CHECK: %[[PRESENT_C:.*]] = acc.present varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "c"}
+! CHECK: %[[PRESENT_A:.*]] = acc.present varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK: %[[PRESENT_B:.*]] = acc.present varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK: %[[PRESENT_C:.*]] = acc.present varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.parallel dataOperands(%[[PRESENT_A]], %[[PRESENT_B]], %[[PRESENT_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.yield
 ! CHECK-NEXT: }{{$}}
-! CHECK: acc.delete accPtr(%[[PRESENT_A]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_present>, name = "a"}
-! CHECK: acc.delete accPtr(%[[PRESENT_B]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_present>, name = "b"}
-! CHECK: acc.delete accPtr(%[[PRESENT_C]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_present>, name = "c"}
+! CHECK: acc.delete accPtr(%[[PRESENT_A]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_present) name("a")
+! CHECK: acc.delete accPtr(%[[PRESENT_B]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_present) name("b")
+! CHECK: acc.delete accPtr(%[[PRESENT_C]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_present) name("c")
 
   !$acc parallel deviceptr(a) deviceptr(c)
   !$acc end parallel
 
-! CHECK: %[[DEVICEPTR_A:.*]] = acc.deviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "a"}
-! CHECK: %[[DEVICEPTR_C:.*]] = acc.deviceptr varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "c"}
+! CHECK: %[[DEVICEPTR_A:.*]] = acc.deviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK: %[[DEVICEPTR_C:.*]] = acc.deviceptr varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.parallel dataOperands(%[[DEVICEPTR_A]], %[[DEVICEPTR_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.yield
 ! CHECK-NEXT: }{{$}}
@@ -316,20 +316,20 @@ subroutine acc_parallel
   !$acc parallel attach(d, e)
   !$acc end parallel
 
-! CHECK: %[[ATTACH_D:.*]] = acc.attach varPtr(%[[DECLD]]#0 : !fir.ref<!fir.box<!fir.ptr<f32>>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>> {name = "d"}
-! CHECK: %[[ATTACH_E:.*]] = acc.attach varPtr(%[[DECLE]]#0 : !fir.ref<!fir.box<!fir.ptr<f32>>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>> {name = "e"}
+! CHECK: %[[ATTACH_D:.*]] = acc.attach varPtr(%[[DECLD]]#0 : !fir.ref<!fir.box<!fir.ptr<f32>>>) name("d") -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+! CHECK: %[[ATTACH_E:.*]] = acc.attach varPtr(%[[DECLE]]#0 : !fir.ref<!fir.box<!fir.ptr<f32>>>) name("e") -> !fir.ref<!fir.box<!fir.ptr<f32>>>
 ! CHECK: acc.parallel dataOperands(%[[ATTACH_D]], %[[ATTACH_E]] : !fir.ref<!fir.box<!fir.ptr<f32>>>, !fir.ref<!fir.box<!fir.ptr<f32>>>) {
 ! CHECK:        acc.yield
 ! CHECK-NEXT: }{{$}}
-! CHECK: acc.detach accPtr(%[[ATTACH_D]] : !fir.ref<!fir.box<!fir.ptr<f32>>>) {dataClause = #acc<data_clause acc_attach>, name = "d"}
-! CHECK: acc.detach accPtr(%[[ATTACH_E]] : !fir.ref<!fir.box<!fir.ptr<f32>>>) {dataClause = #acc<data_clause acc_attach>, name = "e"}
+! CHECK: acc.detach accPtr(%[[ATTACH_D]] : !fir.ref<!fir.box<!fir.ptr<f32>>>) dataClause(acc_attach) name("d")
+! CHECK: acc.detach accPtr(%[[ATTACH_E]] : !fir.ref<!fir.box<!fir.ptr<f32>>>) dataClause(acc_attach) name("e")
 
 !$acc parallel private(a) firstprivate(b) private(c) async(1)
 !$acc end parallel
 
-! CHECK:      %[[ACC_PRIVATE_A:.*]] = acc.private varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) async([[ASYNC3:%.*]]) recipe(@privatization_ref_10x10xf32) -> !fir.ref<!fir.array<10x10xf32>> {name = "a"}
-! CHECK:      %[[ACC_FPRIVATE_B:.*]] = acc.firstprivate varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) async([[ASYNC3]]) recipe(@firstprivatization_ref_10x10xf32) -> !fir.ref<!fir.array<10x10xf32>> {name = "b"}
-! CHECK:      %[[ACC_PRIVATE_C:.*]] = acc.private varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) async([[ASYNC3]]) recipe(@privatization_ref_10x10xf32) -> !fir.ref<!fir.array<10x10xf32>> {name = "c"}
+! CHECK:      %[[ACC_PRIVATE_A:.*]] = acc.private varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) async([[ASYNC3:%.*]]) recipe(@privatization_ref_10x10xf32) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:      %[[ACC_FPRIVATE_B:.*]] = acc.firstprivate varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) async([[ASYNC3]]) recipe(@firstprivatization_ref_10x10xf32) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:      %[[ACC_PRIVATE_C:.*]] = acc.private varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) async([[ASYNC3]]) recipe(@privatization_ref_10x10xf32) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.parallel async([[ASYNC3]]) firstprivate(%[[ACC_FPRIVATE_B]] : !fir.ref<!fir.array<10x10xf32>>) private(%[[ACC_PRIVATE_A]], %[[ACC_PRIVATE_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.yield
 ! CHECK-NEXT: }{{$}}
@@ -337,8 +337,8 @@ subroutine acc_parallel
 !$acc parallel reduction(+:reduction_r) reduction(*:reduction_i)
 !$acc end parallel
 
-! CHECK:      %[[REDUCTION_R:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_add_ref_f32) -> !fir.ref<f32>
-! CHECK:      %[[REDUCTION_I:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<i32>) recipe(@reduction_mul_ref_i32) -> !fir.ref<i32>
+! CHECK:      %[[REDUCTION_R:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_add_ref_f32) name("reduction_r") -> !fir.ref<f32>
+! CHECK:      %[[REDUCTION_I:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<i32>) recipe(@reduction_mul_ref_i32) name("reduction_i") -> !fir.ref<i32>
 ! CHECK:      acc.parallel reduction(%[[REDUCTION_R]], %[[REDUCTION_I]] : !fir.ref<f32>, !fir.ref<i32>) {
 ! CHECK:        acc.yield
 ! CHECK-NEXT: }{{$}}
@@ -347,12 +347,12 @@ subroutine acc_parallel
 !$acc end parallel
 
 ! CHECK: acc.parallel {
-! CHECK: } attributes {defaultAttr = #acc<defaultvalue none>}
+! CHECK: } defaultAttr(none)
 
 !$acc parallel default(present)
 !$acc end parallel
 
 ! CHECK: acc.parallel {
-! CHECK: } attributes {defaultAttr = #acc<defaultvalue present>}
+! CHECK: } defaultAttr(present)
 
 end subroutine acc_parallel

--- a/flang/test/Lower/OpenACC/acc-present-cuda-device.f90
+++ b/flang/test/Lower/OpenACC/acc-present-cuda-device.f90
@@ -1,9 +1,9 @@
 ! RUN: bbc -fopenacc -fcuda -emit-hlfir %s -o - | FileCheck %s
 
 ! CHECK-LABEL: func.func @_QPtest_parallel(
-! CHECK: acc.deviceptr{{.*}}name = "b"
-! CHECK: acc.present{{.*}}name = "a"
-! CHECK: acc.delete{{.*}}name = "a"
+! CHECK: acc.deviceptr{{.*}}name("b")
+! CHECK: acc.present{{.*}}name("a")
+! CHECK: acc.delete{{.*}}name("a")
 subroutine test_parallel(a, b, n)
   real(8), intent(inout) :: a(:)
   real(8), device, intent(in) :: b(:)
@@ -14,9 +14,9 @@ subroutine test_parallel(a, b, n)
 end subroutine
 
 ! CHECK-LABEL: func.func @_QPtest_data(
-! CHECK: acc.deviceptr{{.*}}name = "b"
-! CHECK: acc.present{{.*}}name = "a"
-! CHECK: acc.delete{{.*}}name = "a"
+! CHECK: acc.deviceptr{{.*}}name("b")
+! CHECK: acc.present{{.*}}name("a")
+! CHECK: acc.delete{{.*}}name("a")
 subroutine test_data(a, b, n)
   real(8), intent(inout) :: a(:)
   real(8), device, intent(in) :: b(:)
@@ -27,10 +27,10 @@ subroutine test_data(a, b, n)
 end subroutine
 
 ! CHECK-LABEL: func.func @_QPtest_managed(
-! CHECK: acc.present{{.*}}name = "a"
-! CHECK: acc.present{{.*}}name = "b"
-! CHECK: acc.delete{{.*}}name = "a"
-! CHECK: acc.delete{{.*}}name = "b"
+! CHECK: acc.present{{.*}}name("a")
+! CHECK: acc.present{{.*}}name("b")
+! CHECK: acc.delete{{.*}}name("a")
+! CHECK: acc.delete{{.*}}name("b")
 subroutine test_managed(a, b, n)
   real(8), intent(inout) :: a(:)
   real(8), managed, intent(in) :: b(:)
@@ -41,10 +41,10 @@ subroutine test_managed(a, b, n)
 end subroutine
 
 ! CHECK-LABEL: func.func @_QPtest_unified(
-! CHECK: acc.present{{.*}}name = "a"
-! CHECK: acc.present{{.*}}name = "b"
-! CHECK: acc.delete{{.*}}name = "a"
-! CHECK: acc.delete{{.*}}name = "b"
+! CHECK: acc.present{{.*}}name("a")
+! CHECK: acc.present{{.*}}name("b")
+! CHECK: acc.delete{{.*}}name("a")
+! CHECK: acc.delete{{.*}}name("b")
 subroutine test_unified(a, b, n)
   real(8), intent(inout) :: a(:)
   real(8), unified, intent(in) :: b(:)

--- a/flang/test/Lower/OpenACC/acc-private.f90
+++ b/flang/test/Lower/OpenACC/acc-private.f90
@@ -384,7 +384,7 @@ program acc_private
     a(i) = b(i) + c
   END DO
 
-! CHECK: %[[C_PRIVATE:.*]] = acc.private varPtr(%[[DECLC]]#0 : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {name = "c"}
+! CHECK: %[[C_PRIVATE:.*]] = acc.private varPtr(%[[DECLC]]#0 : !fir.ref<i32>) recipe(@privatization_ref_i32) name("c") -> !fir.ref<i32>
 ! CHECK: acc.loop private(%[[C_PRIVATE]]{{.*}} : !fir.ref<i32>{{.*}})
 ! CHECK: acc.yield
 
@@ -394,7 +394,7 @@ program acc_private
     a(i) = b(i) + c
   END DO
 
-! CHECK: %[[B_PRIVATE:.*]] = acc.private varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<100xf32>>) recipe(@privatization_ref_100xf32) -> !fir.ref<!fir.array<100xf32>> {name = "b"}
+! CHECK: %[[B_PRIVATE:.*]] = acc.private varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<100xf32>>) recipe(@privatization_ref_100xf32) name("b") -> !fir.ref<!fir.array<100xf32>>
 ! CHECK: acc.loop private(%[[B_PRIVATE]]{{.*}} : !fir.ref<!fir.array<100xf32>>{{.*}})
 ! CHECK: acc.yield
 
@@ -408,7 +408,7 @@ program acc_private
 ! CHECK: %[[LB:.*]] = arith.constant 0 : index
 ! CHECK: %[[UB:.*]] = arith.constant 49 : index
 ! CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%{{.*}} : index) stride(%[[C1]] : index) startIdx(%[[C1]] : index)
-! CHECK: %[[B_PRIVATE:.*]] = acc.private varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<100xf32>>) bounds(%[[BOUND]]) recipe(@privatization_section_lb0.ub49_ref_100xf32) -> !fir.ref<!fir.array<100xf32>> {name = "b(1:50)"}
+! CHECK: %[[B_PRIVATE:.*]] = acc.private varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<100xf32>>) bounds(%[[BOUND]]) recipe(@privatization_section_lb0.ub49_ref_100xf32) name("b(1:50)") -> !fir.ref<!fir.array<100xf32>>
 ! CHECK: acc.loop private(%[[B_PRIVATE]]{{.*}} : !fir.ref<!fir.array<100xf32>>{{.*}})
 
   !$acc parallel loop firstprivate(c)
@@ -417,7 +417,7 @@ program acc_private
     a(i) = b(i) + c
   END DO
 
-! CHECK: %[[FP_C:.*]] = acc.firstprivate varPtr(%[[DECLC]]#0 : !fir.ref<i32>) recipe(@firstprivatization_ref_i32) -> !fir.ref<i32> {name = "c"}
+! CHECK: %[[FP_C:.*]] = acc.firstprivate varPtr(%[[DECLC]]#0 : !fir.ref<i32>) recipe(@firstprivatization_ref_i32) name("c") -> !fir.ref<i32>
 ! CHECK: acc.parallel {{.*}} firstprivate(%[[FP_C]] : !fir.ref<i32>)
 ! CHECK: acc.yield
 
@@ -427,7 +427,7 @@ program acc_private
     a(i) = b(i) + c
   END DO
 
-! CHECK: %[[FP_B:.*]] = acc.firstprivate varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<100xf32>>) recipe(@firstprivatization_ref_100xf32) -> !fir.ref<!fir.array<100xf32>> {name = "b"}
+! CHECK: %[[FP_B:.*]] = acc.firstprivate varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<100xf32>>) recipe(@firstprivatization_ref_100xf32) name("b") -> !fir.ref<!fir.array<100xf32>>
 ! CHECK: acc.parallel {{.*}} firstprivate(%[[FP_B]] : !fir.ref<!fir.array<100xf32>>)
 ! CHECK: acc.yield
 
@@ -441,7 +441,7 @@ program acc_private
 ! CHECK: %[[LB:.*]] = arith.constant 50 : index
 ! CHECK: %[[UB:.*]] = arith.constant 99 : index
 ! CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%{{.*}} : index) stride(%[[C1]] : index) startIdx(%[[C1]] : index)
-! CHECK: %[[FP_B:.*]] = acc.firstprivate varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<100xf32>>) bounds(%[[BOUND]]) recipe(@firstprivatization_section_lb50.ub99_ref_100xf32) -> !fir.ref<!fir.array<100xf32>> {name = "b(51:100)"}
+! CHECK: %[[FP_B:.*]] = acc.firstprivate varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<100xf32>>) bounds(%[[BOUND]]) recipe(@firstprivatization_section_lb50.ub99_ref_100xf32) name("b(51:100)") -> !fir.ref<!fir.array<100xf32>>
 ! CHECK: acc.parallel {{.*}} firstprivate(%[[FP_B]] : !fir.ref<!fir.array<100xf32>>)
 
 end program
@@ -459,7 +459,7 @@ end subroutine
 ! CHECK-SAME:    %[[ARG0:.*]]: !fir.box<!fir.array<?xi32>> {fir.bindc_name = "a"}
 ! CHECK: %[[DECL_A:.*]]:2 = hlfir.declare %[[ARG0]] dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {uniq_name = "_QFacc_private_assumed_shapeEa"} : (!fir.box<!fir.array<?xi32>>, !fir.dscope) -> (!fir.box<!fir.array<?xi32>>, !fir.box<!fir.array<?xi32>>)
 ! CHECK: acc.parallel {{.*}} {
-! CHECK: %[[PRIVATE:.*]] = acc.private var(%[[DECL_A]]#0 : !fir.box<!fir.array<?xi32>>) recipe(@privatization_box_Uxi32) -> !fir.box<!fir.array<?xi32>> {name = "a"}
+! CHECK: %[[PRIVATE:.*]] = acc.private var(%[[DECL_A]]#0 : !fir.box<!fir.array<?xi32>>) recipe(@privatization_box_Uxi32) name("a") -> !fir.box<!fir.array<?xi32>>
 ! CHECK: acc.loop {{.*}} private(%[[PRIVATE]]{{.*}} : !fir.box<!fir.array<?xi32>>{{.*}})
 
 subroutine acc_private_allocatable_array(a, n)
@@ -480,9 +480,9 @@ end subroutine
 ! CHECK-SAME: %[[ARG0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> {fir.bindc_name = "a"}
 ! CHECK: %[[DECLA_A:.*]]:2 = hlfir.declare %[[ARG0]] dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFacc_private_allocatable_arrayEa"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
 ! CHECK: acc.parallel {{.*}} {
-! CHECK: %[[PRIVATE:.*]] = acc.private varPtr(%[[DECLA_A]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) recipe(@privatization_ref_box_heap_Uxi32) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> {name = "a"}
+! CHECK: %[[PRIVATE:.*]] = acc.private varPtr(%[[DECLA_A]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) recipe(@privatization_ref_box_heap_Uxi32) name("a") -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK: acc.loop {{.*}} private(%[[PRIVATE]]{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>{{.*}})
-! CHECK: %[[PRIVATE_SERIAL:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) recipe(@privatization_ref_box_heap_Uxi32) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK: %[[PRIVATE_SERIAL:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) recipe(@privatization_ref_box_heap_Uxi32) name("a") -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK: acc.serial private(%[[PRIVATE_SERIAL]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
 
 subroutine acc_private_allocatable_scalar(b, a, n)
@@ -504,9 +504,9 @@ end subroutine
 ! CHECK-SAME: %[[ARG0:.*]]: !fir.ref<!fir.box<!fir.heap<i32>>> {fir.bindc_name = "b"}
 ! CHECK: %[[DECLA_B:.*]]:2 = hlfir.declare %arg0 dummy_scope %0 {{.*}} {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFacc_private_allocatable_scalarEb"} : (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
 ! CHECK: acc.parallel {{.*}} {
-! CHECK: %[[PRIVATE:.*]] = acc.private varPtr(%[[DECLA_B]]#0 : !fir.ref<!fir.box<!fir.heap<i32>>>) recipe(@privatization_ref_box_heap_i32) -> !fir.ref<!fir.box<!fir.heap<i32>>> {name = "b"}
+! CHECK: %[[PRIVATE:.*]] = acc.private varPtr(%[[DECLA_B]]#0 : !fir.ref<!fir.box<!fir.heap<i32>>>) recipe(@privatization_ref_box_heap_i32) name("b") -> !fir.ref<!fir.box<!fir.heap<i32>>>
 ! CHECK: acc.loop {{.*}} private(%[[PRIVATE]]{{.*}} : !fir.ref<!fir.box<!fir.heap<i32>>>{{.*}})
-! CHECK: %[[PRIVATE_SERIAL:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<!fir.box<!fir.heap<i32>>>) recipe(@privatization_ref_box_heap_i32) -> !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK: %[[PRIVATE_SERIAL:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<!fir.box<!fir.heap<i32>>>) recipe(@privatization_ref_box_heap_i32) name("b") -> !fir.ref<!fir.box<!fir.heap<i32>>>
 ! CHECK: acc.serial private(%[[PRIVATE_SERIAL]] : !fir.ref<!fir.box<!fir.heap<i32>>>) {
 
 subroutine acc_private_pointer_array(a, n)
@@ -523,7 +523,7 @@ end subroutine
 ! CHECK-SAME: %[[ARG0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>> {fir.bindc_name = "a"}, %arg1: !fir.ref<i32> {fir.bindc_name = "n"}) {
 ! CHECK: %[[DECL_A:.*]]:2 = hlfir.declare %arg0 dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QFacc_private_pointer_arrayEa"} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>)
 ! CHECK: acc.parallel {{.*}} {
-! CHECK: %[[PRIVATE:.*]] = acc.private varPtr(%[[DECLA_A]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>) recipe(@privatization_ref_box_ptr_Uxi32) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>> {name = "a"}
+! CHECK: %[[PRIVATE:.*]] = acc.private varPtr(%[[DECLA_A]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>) recipe(@privatization_ref_box_ptr_Uxi32) name("a") -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
 ! CHECK: acc.loop {{.*}} private(%[[PRIVATE]]{{.*}} : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>{{.*}})
 
 subroutine acc_private_dynamic_extent(a, n)
@@ -541,7 +541,7 @@ end subroutine
 ! CHECK: %[[DECL_N:.*]]:2 = hlfir.declare %[[ARG1]] dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {uniq_name = "_QFacc_private_dynamic_extentEn"} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK: %[[DECL_A:.*]]:2 = hlfir.declare %[[ARG0]](%{{.*}}) dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {uniq_name = "_QFacc_private_dynamic_extentEa"} : (!fir.ref<!fir.array<?x?x2xi32>>, !fir.shape<3>, !fir.dscope) -> (!fir.box<!fir.array<?x?x2xi32>>, !fir.ref<!fir.array<?x?x2xi32>>)
 ! CHECK: acc.parallel {{.*}} {
-! CHECK: %[[PRIV:.*]] = acc.private var(%[[DECL_A]]#0 : !fir.box<!fir.array<?x?x2xi32>>) recipe(@privatization_box_UxUx2xi32) -> !fir.box<!fir.array<?x?x2xi32>> {name = "a"}
+! CHECK: %[[PRIV:.*]] = acc.private var(%[[DECL_A]]#0 : !fir.box<!fir.array<?x?x2xi32>>) recipe(@privatization_box_UxUx2xi32) name("a") -> !fir.box<!fir.array<?x?x2xi32>>
 ! CHECK: acc.loop {{.*}} private(%[[PRIV]]{{.*}} : !fir.box<!fir.array<?x?x2xi32>>{{.*}})
 
 subroutine acc_firstprivate_assumed_shape(a, n)
@@ -554,7 +554,7 @@ subroutine acc_firstprivate_assumed_shape(a, n)
 end subroutine
 
 ! CHECK-LABEL: func.func @_QPacc_firstprivate_assumed_shape
-! CHECK: %[[FIRSTPRIVATE_A:.*]] = acc.firstprivate var(%{{.*}} : !fir.box<!fir.array<?xi32>>) recipe(@firstprivatization_box_Uxi32) -> !fir.box<!fir.array<?xi32>> {name = "a"}
+! CHECK: %[[FIRSTPRIVATE_A:.*]] = acc.firstprivate var(%{{.*}} : !fir.box<!fir.array<?xi32>>) recipe(@firstprivatization_box_Uxi32) name("a") -> !fir.box<!fir.array<?xi32>>
 ! CHECK: acc.parallel {{.*}}firstprivate(%[[FIRSTPRIVATE_A]] : !fir.box<!fir.array<?xi32>>) {
 
 subroutine acc_firstprivate_assumed_shape_with_section(a, n)
@@ -567,7 +567,7 @@ subroutine acc_firstprivate_assumed_shape_with_section(a, n)
 end subroutine
 
 ! CHECK-LABEL: func.func @_QPacc_firstprivate_assumed_shape_with_section
-! CHECK: %[[FIRSTPRIVATE_A:.*]] = acc.firstprivate var(%{{.*}} : !fir.box<!fir.array<?xi32>>) bounds(%{{.*}}) recipe(@firstprivatization_section_lb4.ub9_box_Uxi32) -> !fir.box<!fir.array<?xi32>> {name = "a(5:10)"}
+! CHECK: %[[FIRSTPRIVATE_A:.*]] = acc.firstprivate var(%{{.*}} : !fir.box<!fir.array<?xi32>>) bounds(%{{.*}}) recipe(@firstprivatization_section_lb4.ub9_box_Uxi32) name("a(5:10)") -> !fir.box<!fir.array<?xi32>>
 ! CHECK: acc.parallel {{.*}}firstprivate(%[[FIRSTPRIVATE_A]] : !fir.box<!fir.array<?xi32>>)
 
 subroutine acc_firstprivate_dynamic_extent(a, n)
@@ -581,7 +581,7 @@ subroutine acc_firstprivate_dynamic_extent(a, n)
 end subroutine
 
 ! CHECK-LABEL: func.func @_QPacc_firstprivate_dynamic_extent
-! CHECK: %[[FIRSTPRIVATE_A:.*]] = acc.firstprivate var(%{{.*}} : !fir.box<!fir.array<?x?x2xi32>>) recipe(@firstprivatization_box_UxUx2xi32) -> !fir.box<!fir.array<?x?x2xi32>> {name = "a"}
+! CHECK: %[[FIRSTPRIVATE_A:.*]] = acc.firstprivate var(%{{.*}} : !fir.box<!fir.array<?x?x2xi32>>) recipe(@firstprivatization_box_UxUx2xi32) name("a") -> !fir.box<!fir.array<?x?x2xi32>>
 ! CHECK: acc.parallel {{.*}}firstprivate(%[[FIRSTPRIVATE_A]] : !fir.box<!fir.array<?x?x2xi32>>)
 
 module acc_declare_equivalent
@@ -596,7 +596,7 @@ contains
   end subroutine
 end module
 
-! CHECK: %[[PRIVATE_V2:.*]] = acc.private varPtr(%{{.*}} : !fir.ptr<!fir.array<10xf32>>) recipe(@privatization_ptr_10xf32) -> !fir.ptr<!fir.array<10xf32>>
+! CHECK: %[[PRIVATE_V2:.*]] = acc.private varPtr(%{{.*}} : !fir.ptr<!fir.array<10xf32>>) recipe(@privatization_ptr_10xf32) name("v2") -> !fir.ptr<!fir.array<10xf32>>
 ! CHECK: acc.parallel private(%[[PRIVATE_V2]] : !fir.ptr<!fir.array<10xf32>>)
 
 subroutine acc_private_use()
@@ -612,7 +612,7 @@ end
 ! CHECK: %[[I:.*]] = fir.alloca i32 {bindc_name = "i", uniq_name = "_QFacc_private_useEi"}
 ! CHECK: %[[DECL_I:.*]]:2 = hlfir.declare %[[I]] {uniq_name = "_QFacc_private_useEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK: acc.parallel
-! CHECK: %[[PRIV_I:.*]] = acc.private varPtr(%[[DECL_I]]#0 : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK: %[[PRIV_I:.*]] = acc.private varPtr(%[[DECL_I]]#0 : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK: acc.loop {{.*}} private(%[[PRIV_I]] : !fir.ref<i32>) control(%[[IV0:.*]] : i32) = (%c1{{.*}} : i32) to (%c10{{.*}} : i32) step (%c1{{.*}} : i32)
 ! CHECK:   %[[DECL_PRIV_I:.*]]:2 = hlfir.declare %[[PRIV_I]] {uniq_name = "_QFacc_private_useEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK:   fir.store %[[IV0]] to %[[DECL_PRIV_I]]#0 : !fir.ref<i32>

--- a/flang/test/Lower/OpenACC/acc-reduction-remapping.f90
+++ b/flang/test/Lower/OpenACC/acc-reduction-remapping.f90
@@ -84,11 +84,11 @@ end subroutine
 ! CHECK-LABEL:   func.func @_QPscalar_combined(
 ! CHECK:           %[[DUMMY_SCOPE_0:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK:           %[[DECLARE_Y:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[DUMMY_SCOPE_0]] arg 2 {uniq_name = "_QFscalar_combinedEy"} : (!fir.ref<f32>, !fir.dscope) -> (!fir.ref<f32>, !fir.ref<f32>)
-! CHECK:           %[[REDUCTION_Y:.*]] = acc.reduction varPtr(%[[DECLARE_Y]]#0 : !fir.ref<f32>) recipe(@reduction_add_ref_f32) -> !fir.ref<f32> {name = "y"}
+! CHECK:           %[[REDUCTION_Y:.*]] = acc.reduction varPtr(%[[DECLARE_Y]]#0 : !fir.ref<f32>) recipe(@reduction_add_ref_f32) name("y") -> !fir.ref<f32>
 ! CHECK:           acc.parallel {{.*}} reduction(%[[REDUCTION_Y]] : !fir.ref<f32>) {
 ! CHECK:             %[[DUMMY_SCOPE_1:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK:             %[[DECLARE_RED_PAR:.*]]:2 = hlfir.declare %[[REDUCTION_Y]] dummy_scope %[[DUMMY_SCOPE_1]] arg 2 {uniq_name = "_QFscalar_combinedEy"} : (!fir.ref<f32>, !fir.dscope) -> (!fir.ref<f32>, !fir.ref<f32>)
-! CHECK:             %[[PRIVATE_I:.*]] = acc.private varPtr({{.*}}) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK:             %[[PRIVATE_I:.*]] = acc.private varPtr({{.*}}) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK:             acc.loop private(%[[PRIVATE_I]] : !fir.ref<i32>) {{.*}} {
 ! CHECK:               %[[DECLARE_I:.*]]:2 = hlfir.declare %[[PRIVATE_I]] {uniq_name = "_QFscalar_combinedEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK:               fir.store %[[VAL_0:.*]] to %[[DECLARE_I]]#0 : !fir.ref<i32>
@@ -108,12 +108,12 @@ end subroutine
 ! CHECK-LABEL:   func.func @_QPscalar_split(
 ! CHECK:           %[[DUMMY_SCOPE_0:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK:           %[[DECLARE_Y:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[DUMMY_SCOPE_0]] arg 2 {uniq_name = "_QFscalar_splitEy"} : (!fir.ref<f32>, !fir.dscope) -> (!fir.ref<f32>, !fir.ref<f32>)
-! CHECK:           %[[CREATE_Y:.*]] = acc.create varPtr(%[[DECLARE_Y]]#0 : !fir.ref<f32>) -> !fir.ref<f32> {dataClause = #acc<data_clause acc_copyout>, name = "y"}
+! CHECK:           %[[CREATE_Y:.*]] = acc.create varPtr(%[[DECLARE_Y]]#0 : !fir.ref<f32>) dataClause(acc_copyout) name("y") -> !fir.ref<f32>
 ! CHECK:           acc.parallel dataOperands({{.*}}%[[CREATE_Y]] : {{.*}}) {
 ! CHECK:             %[[DUMMY_SCOPE_1:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK:             %[[DECLARE_Y_PAR:.*]]:2 = hlfir.declare %[[CREATE_Y]] dummy_scope %[[DUMMY_SCOPE_1]] arg 2 {uniq_name = "_QFscalar_splitEy"} : (!fir.ref<f32>, !fir.dscope) -> (!fir.ref<f32>, !fir.ref<f32>)
-! CHECK:             %[[REDUCTION_Y:.*]] = acc.reduction varPtr(%[[DECLARE_Y_PAR]]#0 : !fir.ref<f32>) recipe(@reduction_add_ref_f32) -> !fir.ref<f32> {name = "y"}
-! CHECK:             %[[PRIVATE_I:.*]] = acc.private varPtr({{.*}}) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK:             %[[REDUCTION_Y:.*]] = acc.reduction varPtr(%[[DECLARE_Y_PAR]]#0 : !fir.ref<f32>) recipe(@reduction_add_ref_f32) name("y") -> !fir.ref<f32>
+! CHECK:             %[[PRIVATE_I:.*]] = acc.private varPtr({{.*}}) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK:             acc.loop private(%[[PRIVATE_I]] : !fir.ref<i32>) reduction(%[[REDUCTION_Y]] : !fir.ref<f32>) {{.*}} {
 ! CHECK:               %[[DUMMY_SCOPE_2:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK:               %[[DECLARE_RED:.*]]:2 = hlfir.declare %[[REDUCTION_Y]] dummy_scope %[[DUMMY_SCOPE_2]] arg 2 {uniq_name = "_QFscalar_splitEy"} : (!fir.ref<f32>, !fir.dscope) -> (!fir.ref<f32>, !fir.ref<f32>)
@@ -132,14 +132,14 @@ end subroutine
 ! CHECK:           %[[DUMMY_SCOPE_0:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK:           %[[DECLARE_N:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[DUMMY_SCOPE_0]] arg 3 {uniq_name = "_QFarray_combinedEn"} : (!fir.ref<i64>, !fir.dscope) -> (!fir.ref<i64>, !fir.ref<i64>)
 ! CHECK:           %[[DECLARE_Y:.*]]:2 = hlfir.declare %{{.*}}({{.*}}) dummy_scope %[[DUMMY_SCOPE_0]] arg 2 {uniq_name = "_QFarray_combinedEy"} : (!fir.ref<!fir.array<?xf32>>, {{.*}}, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.ref<!fir.array<?xf32>>)
-! CHECK:           %[[REDUCTION_Y:.*]] = acc.reduction var(%[[DECLARE_Y]]#0 : !fir.box<!fir.array<?xf32>>) recipe(@reduction_add_box_Uxf32) -> !fir.box<!fir.array<?xf32>> {name = "y"}
+! CHECK:           %[[REDUCTION_Y:.*]] = acc.reduction var(%[[DECLARE_Y]]#0 : !fir.box<!fir.array<?xf32>>) recipe(@reduction_add_box_Uxf32) name("y") -> !fir.box<!fir.array<?xf32>>
 ! CHECK:           acc.parallel dataOperands({{.*}}) reduction(%[[REDUCTION_Y]] : !fir.box<!fir.array<?xf32>>) {
 ! CHECK:             %[[DUMMY_SCOPE_1:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK:             %[[BOX_ADDR_RED:.*]] = fir.box_addr %[[REDUCTION_Y]] : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
 ! CHECK:             %[[DECLARE_Y_PAR:.*]]:2 = hlfir.declare %[[BOX_ADDR_RED]]({{.*}}) dummy_scope %[[DUMMY_SCOPE_1]] arg 2 {uniq_name = "_QFarray_combinedEy"} : (!fir.ref<!fir.array<?xf32>>, {{.*}}, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.ref<!fir.array<?xf32>>)
-! CHECK:             %[[PRIVATE_J:.*]] = acc.private varPtr({{.*}}) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "j"}
+! CHECK:             %[[PRIVATE_J:.*]] = acc.private varPtr({{.*}}) recipe(@privatization_ref_i32) implicit(true) name("j") -> !fir.ref<i32>
 ! CHECK:             acc.loop private(%[[PRIVATE_J]] : !fir.ref<i32>) {{.*}} {
-! CHECK:               %[[PRIVATE_I:.*]] = acc.private varPtr({{.*}}) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK:               %[[PRIVATE_I:.*]] = acc.private varPtr({{.*}}) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK:               acc.loop private(%[[PRIVATE_I]] : !fir.ref<i32>) {{.*}} {
 ! CHECK:                 %[[DESIGNATE_RED:.*]] = hlfir.designate %[[DECLARE_Y_PAR]]#0 ({{.*}})  : (!fir.box<!fir.array<?xf32>>, i64) -> !fir.ref<f32>
 ! CHECK:                 %[[LOAD_OLD:.*]] = fir.load %[[DESIGNATE_RED]] : !fir.ref<f32>
@@ -161,18 +161,18 @@ end subroutine
 ! CHECK-LABEL:   func.func @_QParray_split(
 ! CHECK:           %[[DUMMY_SCOPE_0:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK:           %[[DECLARE_Y:.*]]:2 = hlfir.declare %{{.*}}({{.*}}) dummy_scope %[[DUMMY_SCOPE_0]] arg 2 {uniq_name = "_QFarray_splitEy"} : (!fir.ref<!fir.array<?xf32>>, {{.*}}, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.ref<!fir.array<?xf32>>)
-! CHECK:           %[[CREATE_Y:.*]] = acc.create var(%[[DECLARE_Y]]#0 : !fir.box<!fir.array<?xf32>>) -> !fir.box<!fir.array<?xf32>> {dataClause = #acc<data_clause acc_copyout>, name = "y"}
+! CHECK:           %[[CREATE_Y:.*]] = acc.create var(%[[DECLARE_Y]]#0 : !fir.box<!fir.array<?xf32>>) dataClause(acc_copyout) name("y") -> !fir.box<!fir.array<?xf32>>
 ! CHECK:           acc.parallel dataOperands({{.*}}%[[CREATE_Y]] : {{.*}}) {
 ! CHECK:             %[[DUMMY_SCOPE_1:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK:             %[[BOX_ADDR_Y:.*]] = fir.box_addr %[[CREATE_Y]] : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
 ! CHECK:             %[[DECLARE_Y_PAR:.*]]:2 = hlfir.declare %[[BOX_ADDR_Y]]({{.*}}) dummy_scope %[[DUMMY_SCOPE_1]] arg 2 {uniq_name = "_QFarray_splitEy"} : (!fir.ref<!fir.array<?xf32>>, {{.*}}, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.ref<!fir.array<?xf32>>)
-! CHECK:             %[[REDUCTION_Y:.*]] = acc.reduction var(%[[DECLARE_Y_PAR]]#0 : !fir.box<!fir.array<?xf32>>) recipe(@reduction_add_box_Uxf32) -> !fir.box<!fir.array<?xf32>> {name = "y"}
-! CHECK:             %[[PRIVATE_J:.*]] = acc.private varPtr({{.*}}) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "j"}
+! CHECK:             %[[REDUCTION_Y:.*]] = acc.reduction var(%[[DECLARE_Y_PAR]]#0 : !fir.box<!fir.array<?xf32>>) recipe(@reduction_add_box_Uxf32) name("y") -> !fir.box<!fir.array<?xf32>>
+! CHECK:             %[[PRIVATE_J:.*]] = acc.private varPtr({{.*}}) recipe(@privatization_ref_i32) implicit(true) name("j") -> !fir.ref<i32>
 ! CHECK:             acc.loop private(%[[PRIVATE_J]] : !fir.ref<i32>) reduction(%[[REDUCTION_Y]] : !fir.box<!fir.array<?xf32>>) {{.*}} {
 ! CHECK:               %[[BOX_ADDR_RED:.*]] = fir.box_addr %[[REDUCTION_Y]] : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
 ! CHECK:               %[[DUMMY_SCOPE_2:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK:               %[[DECLARE_Y_LOOP_PAR:.*]]:2 = hlfir.declare %[[BOX_ADDR_RED]]({{.*}}) dummy_scope %[[DUMMY_SCOPE_2]] arg 2 {uniq_name = "_QFarray_splitEy"} : (!fir.ref<!fir.array<?xf32>>, {{.*}}, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.ref<!fir.array<?xf32>>)
-! CHECK:               %[[PRIVATE_I:.*]] = acc.private varPtr({{.*}}) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK:               %[[PRIVATE_I:.*]] = acc.private varPtr({{.*}}) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK:               acc.loop private(%[[PRIVATE_I]] : !fir.ref<i32>) {{.*}} {
 ! CHECK:                 %[[DESIGNATE_RED:.*]] = hlfir.designate %[[DECLARE_Y_LOOP_PAR]]#0 ({{.*}})  : (!fir.box<!fir.array<?xf32>>, i64) -> !fir.ref<f32>
 ! CHECK:                 %[[LOAD_OLD:.*]] = fir.load %[[DESIGNATE_RED]] : !fir.ref<f32>
@@ -194,12 +194,12 @@ end subroutine
 ! CHECK-LABEL:   func.func @_QParray_section_combined(
 ! CHECK:           %[[DECLARE_A:.*]]:2 = hlfir.declare %{{.*}}({{.*}}) dummy_scope {{.*}} arg 1 {uniq_name = "_QFarray_section_combinedEa"} : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.ref<!fir.array<?xf32>>)
 ! CHECK:           %[[BOUND0:.*]] = acc.bounds {{.*}}
-! CHECK:           %[[COPYIN:.*]] = acc.copyin var(%[[DECLARE_A]]#0 : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND0]]) -> !fir.box<!fir.array<?xf32>> {dataClause = #acc<data_clause acc_reduction>, implicit = true, name = "a(1:16)"}
+! CHECK:           %[[COPYIN:.*]] = acc.copyin var(%[[DECLARE_A]]#0 : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND0]]) dataClause(acc_reduction) implicit(true) name("a(1:16)") -> !fir.box<!fir.array<?xf32>>
 ! CHECK:           acc.parallel combined(loop) dataOperands(%[[COPYIN]] : !fir.box<!fir.array<?xf32>>) {
 ! CHECK:             %[[BOX_ADDR_PAR:.*]] = fir.box_addr %[[COPYIN]] : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
 ! CHECK:             %[[DECLARE_A_PAR:.*]]:2 = hlfir.declare %[[BOX_ADDR_PAR]]({{.*}}) dummy_scope {{.*}} arg 1 {uniq_name = "_QFarray_section_combinedEa"}
 ! CHECK:             %[[BOUND1:.*]] = acc.bounds {{.*}}
-! CHECK:             %[[RED:.*]] = acc.reduction var(%[[DECLARE_A_PAR]]#0 : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND1]]) recipe(@reduction_add_section_lb0.ub15_box_Uxf32) -> !fir.box<!fir.array<?xf32>> {name = "a(1:16)"}
+! CHECK:             %[[RED:.*]] = acc.reduction var(%[[DECLARE_A_PAR]]#0 : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND1]]) recipe(@reduction_add_section_lb0.ub15_box_Uxf32) name("a(1:16)") -> !fir.box<!fir.array<?xf32>>
 ! CHECK:             acc.loop combined(parallel) {{.*}} reduction(%[[RED]] : !fir.box<!fir.array<?xf32>>) {{.*}} {
 ! CHECK:               %[[BOX_ADDR_RED:.*]] = fir.box_addr %[[RED]] : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
 ! CHECK:               %[[DECLARE_A_RED:.*]]:2 = hlfir.declare %[[BOX_ADDR_RED]]({{.*}}) dummy_scope {{.*}} arg 1 {uniq_name = "_QFarray_section_combinedEa"}
@@ -214,7 +214,7 @@ end subroutine
 ! CHECK:             }
 ! CHECK:             acc.yield
 ! CHECK:           }
-! CHECK:           acc.copyout accVar(%[[COPYIN]] : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND0]]) to var(%[[DECLARE_A]]#0 : !fir.box<!fir.array<?xf32>>) {dataClause = #acc<data_clause acc_reduction>, implicit = true, name = "a(1:16)"}
+! CHECK:           acc.copyout accVar(%[[COPYIN]] : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND0]]) to var(%[[DECLARE_A]]#0 : !fir.box<!fir.array<?xf32>>) dataClause(acc_reduction) implicit(true) name("a(1:16)")
 ! CHECK:           return
 ! CHECK:         }
 
@@ -222,12 +222,12 @@ end subroutine
 ! CHECK-LABEL:   func.func @_QParray_section_shifted(
 ! CHECK:           %[[DECLARE_A:.*]]:2 = hlfir.declare %{{.*}}({{.*}}) dummy_scope {{.*}} arg 1 {uniq_name = "_QFarray_section_shiftedEa"} : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.ref<!fir.array<?xf32>>)
 ! CHECK:           %[[BOUND0:.*]] = acc.bounds lowerbound(%c10{{.*}} : index) upperbound(%c19{{.*}} : index) {{.*}}
-! CHECK:           %[[COPYIN:.*]] = acc.copyin var(%[[DECLARE_A]]#0 : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND0]]) -> !fir.box<!fir.array<?xf32>> {dataClause = #acc<data_clause acc_reduction>, implicit = true, name = "a(11:20)"}
+! CHECK:           %[[COPYIN:.*]] = acc.copyin var(%[[DECLARE_A]]#0 : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND0]]) dataClause(acc_reduction) implicit(true) name("a(11:20)") -> !fir.box<!fir.array<?xf32>>
 ! CHECK:           acc.parallel combined(loop) dataOperands(%[[COPYIN]] : !fir.box<!fir.array<?xf32>>) {
 ! CHECK:             %[[BOX_ADDR_PAR:.*]] = fir.box_addr %[[COPYIN]] : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
 ! CHECK:             %[[DECLARE_A_PAR:.*]]:2 = hlfir.declare %[[BOX_ADDR_PAR]]({{.*}}) dummy_scope {{.*}} arg 1 {uniq_name = "_QFarray_section_shiftedEa"}
 ! CHECK:             %[[BOUND1:.*]] = acc.bounds lowerbound(%c10{{.*}} : index) upperbound(%c19{{.*}} : index) {{.*}}
-! CHECK:             %[[RED:.*]] = acc.reduction var(%[[DECLARE_A_PAR]]#0 : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND1]]) recipe(@reduction_add_section_lb10.ub19_box_Uxf32) -> !fir.box<!fir.array<?xf32>> {name = "a(11:20)"}
+! CHECK:             %[[RED:.*]] = acc.reduction var(%[[DECLARE_A_PAR]]#0 : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND1]]) recipe(@reduction_add_section_lb10.ub19_box_Uxf32) name("a(11:20)") -> !fir.box<!fir.array<?xf32>>
 ! CHECK:             acc.loop combined(parallel) {{.*}} reduction(%[[RED]] : !fir.box<!fir.array<?xf32>>) {{.*}} {
 ! CHECK:               %[[BOX_ADDR_RED:.*]] = fir.box_addr %[[RED]] : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
 ! CHECK:               %[[DECLARE_A_RED:.*]]:2 = hlfir.declare %[[BOX_ADDR_RED]]({{.*}}) dummy_scope {{.*}} arg 1 {uniq_name = "_QFarray_section_shiftedEa"}
@@ -242,6 +242,6 @@ end subroutine
 ! CHECK:             }
 ! CHECK:             acc.yield
 ! CHECK:           }
-! CHECK:           acc.copyout accVar(%[[COPYIN]] : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND0]]) to var(%[[DECLARE_A]]#0 : !fir.box<!fir.array<?xf32>>) {dataClause = #acc<data_clause acc_reduction>, implicit = true, name = "a(11:20)"}
+! CHECK:           acc.copyout accVar(%[[COPYIN]] : !fir.box<!fir.array<?xf32>>) bounds(%[[BOUND0]]) to var(%[[DECLARE_A]]#0 : !fir.box<!fir.array<?xf32>>) dataClause(acc_reduction) implicit(true) name("a(11:20)")
 ! CHECK:           return
 ! CHECK:         }

--- a/flang/test/Lower/OpenACC/acc-reduction.f90
+++ b/flang/test/Lower/OpenACC/acc-reduction.f90
@@ -1238,7 +1238,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPacc_reduction_add_int(
 ! CHECK-SAME:  %{{.*}}: !fir.ref<!fir.array<100xi32>> {fir.bindc_name = "a"}, %[[B:.*]]: !fir.ref<i32> {fir.bindc_name = "b"})
 ! CHECK:       %[[DECLB:.*]]:2 = hlfir.declare %[[B]]
-! CHECK:       %[[RED_B:.*]] = acc.reduction varPtr(%[[DECLB]]#0 : !fir.ref<i32>) recipe(@reduction_add_ref_i32) -> !fir.ref<i32> {name = "b"}
+! CHECK:       %[[RED_B:.*]] = acc.reduction varPtr(%[[DECLB]]#0 : !fir.ref<i32>) recipe(@reduction_add_ref_i32) name("b") -> !fir.ref<i32>
 ! CHECK:       acc.loop {{.*}} reduction(%[[RED_B]] : !fir.ref<i32>)
 
 ! The non-standard '-' reduction operator is treated as '+', so it reuses the
@@ -1256,7 +1256,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPacc_reduction_minus_int(
 ! CHECK-SAME:  %{{.*}}: !fir.ref<!fir.array<100xi32>> {fir.bindc_name = "a"}, %[[B:.*]]: !fir.ref<i32> {fir.bindc_name = "b"})
 ! CHECK:       %[[DECLB:.*]]:2 = hlfir.declare %[[B]]
-! CHECK:       %[[RED_B:.*]] = acc.reduction varPtr(%[[DECLB]]#0 : !fir.ref<i32>) recipe(@reduction_add_ref_i32) -> !fir.ref<i32> {name = "b"}
+! CHECK:       %[[RED_B:.*]] = acc.reduction varPtr(%[[DECLB]]#0 : !fir.ref<i32>) recipe(@reduction_add_ref_i32) name("b") -> !fir.ref<i32>
 ! CHECK:       acc.loop {{.*}} reduction(%[[RED_B]] : !fir.ref<i32>)
 
 subroutine acc_reduction_add_int_array_1d(a, b)
@@ -1272,7 +1272,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPacc_reduction_add_int_array_1d(
 ! CHECK-SAME:  %{{.*}}: !fir.ref<!fir.array<100xi32>> {fir.bindc_name = "a"}, %[[B:.*]]: !fir.ref<!fir.array<100xi32>> {fir.bindc_name = "b"})
 ! CHECK:       %[[DECLB:.*]]:2 = hlfir.declare %[[B]]
-! CHECK:       %[[RED_B:.*]] = acc.reduction varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<100xi32>>) recipe(@reduction_add_ref_100xi32) -> !fir.ref<!fir.array<100xi32>> {name = "b"}
+! CHECK:       %[[RED_B:.*]] = acc.reduction varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<100xi32>>) recipe(@reduction_add_ref_100xi32) name("b") -> !fir.ref<!fir.array<100xi32>>
 ! CHECK:       acc.loop {{.*}} reduction(%[[RED_B]] : !fir.ref<!fir.array<100xi32>>)
 
 subroutine acc_reduction_add_int_array_2d(a, b)
@@ -1290,9 +1290,9 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPacc_reduction_add_int_array_2d(
 ! CHECK-SAME:  %[[ARG0:.*]]: !fir.ref<!fir.array<100x10xi32>> {fir.bindc_name = "a"}, %[[ARG1:.*]]: !fir.ref<!fir.array<100x10xi32>> {fir.bindc_name = "b"}) {
 ! CHECK:       %[[DECLARG1:.*]]:2 = hlfir.declare %[[ARG1]]
-! CHECK:       %[[RED_ARG1:.*]] = acc.reduction varPtr(%[[DECLARG1]]#0 : !fir.ref<!fir.array<100x10xi32>>) recipe(@reduction_add_ref_100x10xi32) -> !fir.ref<!fir.array<100x10xi32>> {name = "b"}
+! CHECK:       %[[RED_ARG1:.*]] = acc.reduction varPtr(%[[DECLARG1]]#0 : !fir.ref<!fir.array<100x10xi32>>) recipe(@reduction_add_ref_100x10xi32) name("b") -> !fir.ref<!fir.array<100x10xi32>>
 ! CHECK:       acc.loop {{.*}} reduction(%[[RED_ARG1]] : !fir.ref<!fir.array<100x10xi32>>)
-! CHECK: } attributes {collapse = [2]{{.*}}
+! CHECK: } {{.*}}collapse([2]){{.*}}
 
 subroutine acc_reduction_add_int_array_3d(a, b)
   integer :: a(100, 10, 2), b(100, 10, 2)
@@ -1311,9 +1311,9 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPacc_reduction_add_int_array_3d(
 ! CHECK-SAME: %{{.*}}: !fir.ref<!fir.array<100x10x2xi32>> {fir.bindc_name = "a"}, %[[ARG1:.*]]: !fir.ref<!fir.array<100x10x2xi32>> {fir.bindc_name = "b"})
 ! CHECK: %[[DECLARG1:.*]]:2 = hlfir.declare %[[ARG1]]
-! CHECK: %[[RED_ARG1:.*]] = acc.reduction varPtr(%[[DECLARG1]]#0 : !fir.ref<!fir.array<100x10x2xi32>>) recipe(@reduction_add_ref_100x10x2xi32) -> !fir.ref<!fir.array<100x10x2xi32>> {name = "b"}
+! CHECK: %[[RED_ARG1:.*]] = acc.reduction varPtr(%[[DECLARG1]]#0 : !fir.ref<!fir.array<100x10x2xi32>>) recipe(@reduction_add_ref_100x10x2xi32) name("b") -> !fir.ref<!fir.array<100x10x2xi32>>
 ! CHECK: acc.loop {{.*}} reduction(%[[RED_ARG1]] : !fir.ref<!fir.array<100x10x2xi32>>)
-! CHECK: } attributes {collapse = [3]{{.*}}
+! CHECK: } {{.*}}collapse([3]){{.*}}
 
 subroutine acc_reduction_add_float(a, b)
   real :: a(100), b
@@ -1328,7 +1328,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPacc_reduction_add_float(
 ! CHECK-SAME:  %{{.*}}: !fir.ref<!fir.array<100xf32>> {fir.bindc_name = "a"}, %[[B:.*]]: !fir.ref<f32> {fir.bindc_name = "b"})
 ! CHECK:       %[[DECLB:.*]]:2 = hlfir.declare %[[B]]
-! CHECK:       %[[RED_B:.*]] = acc.reduction varPtr(%[[DECLB]]#0 : !fir.ref<f32>) recipe(@reduction_add_ref_f32) -> !fir.ref<f32> {name = "b"}
+! CHECK:       %[[RED_B:.*]] = acc.reduction varPtr(%[[DECLB]]#0 : !fir.ref<f32>) recipe(@reduction_add_ref_f32) name("b") -> !fir.ref<f32>
 ! CHECK:       acc.loop {{.*}} reduction(%[[RED_B]] : !fir.ref<f32>)
 
 subroutine acc_reduction_add_float_array_1d(a, b)
@@ -1344,7 +1344,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPacc_reduction_add_float_array_1d(
 ! CHECK-SAME:  %{{.*}}: !fir.ref<!fir.array<100xf32>> {fir.bindc_name = "a"}, %[[B:.*]]: !fir.ref<!fir.array<100xf32>> {fir.bindc_name = "b"})
 ! CHECK: %[[DECLB:.*]]:2 = hlfir.declare %[[B]]
-! CHECK: %[[RED_B:.*]] = acc.reduction varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<100xf32>>) recipe(@reduction_add_ref_100xf32) -> !fir.ref<!fir.array<100xf32>> {name = "b"}
+! CHECK: %[[RED_B:.*]] = acc.reduction varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<100xf32>>) recipe(@reduction_add_ref_100xf32) name("b") -> !fir.ref<!fir.array<100xf32>>
 ! CHECK:       acc.loop {{.*}} reduction(%[[RED_B]] : !fir.ref<!fir.array<100xf32>>)
 
 subroutine acc_reduction_mul_int(a, b)
@@ -1360,7 +1360,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPacc_reduction_mul_int(
 ! CHECK-SAME:  %{{.*}}: !fir.ref<!fir.array<100xi32>> {fir.bindc_name = "a"}, %[[B:.*]]: !fir.ref<i32> {fir.bindc_name = "b"})
 ! CHECK:       %[[DECLB:.*]]:2 = hlfir.declare %[[B]]
-! CHECK:       %[[RED_B:.*]] = acc.reduction varPtr(%[[DECLB]]#0 : !fir.ref<i32>) recipe(@reduction_mul_ref_i32) -> !fir.ref<i32> {name = "b"}
+! CHECK:       %[[RED_B:.*]] = acc.reduction varPtr(%[[DECLB]]#0 : !fir.ref<i32>) recipe(@reduction_mul_ref_i32) name("b") -> !fir.ref<i32>
 ! CHECK:       acc.loop {{.*}} reduction(%[[RED_B]] : !fir.ref<i32>)
 
 subroutine acc_reduction_mul_int_array_1d(a, b)
@@ -1376,7 +1376,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPacc_reduction_mul_int_array_1d(
 ! CHECK-SAME:  %{{.*}}: !fir.ref<!fir.array<100xi32>> {fir.bindc_name = "a"}, %[[B:.*]]: !fir.ref<!fir.array<100xi32>> {fir.bindc_name = "b"})
 ! CHECK:       %[[DECLB:.*]]:2 = hlfir.declare %[[B]]
-! CHECK:       %[[RED_B:.*]] = acc.reduction varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<100xi32>>) recipe(@reduction_mul_ref_100xi32) -> !fir.ref<!fir.array<100xi32>> {name = "b"}
+! CHECK:       %[[RED_B:.*]] = acc.reduction varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<100xi32>>) recipe(@reduction_mul_ref_100xi32) name("b") -> !fir.ref<!fir.array<100xi32>>
 ! CHECK:       acc.loop {{.*}} reduction(%[[RED_B]] : !fir.ref<!fir.array<100xi32>>)
 
 subroutine acc_reduction_mul_float(a, b)
@@ -1392,7 +1392,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPacc_reduction_mul_float(
 ! CHECK-SAME:  %{{.*}}: !fir.ref<!fir.array<100xf32>> {fir.bindc_name = "a"}, %[[B:.*]]: !fir.ref<f32> {fir.bindc_name = "b"})
 ! CHECK:       %[[DECLB:.*]]:2 = hlfir.declare %[[B]]
-! CHECK:       %[[RED_B:.*]] = acc.reduction varPtr(%[[DECLB]]#0 : !fir.ref<f32>) recipe(@reduction_mul_ref_f32) -> !fir.ref<f32> {name = "b"}
+! CHECK:       %[[RED_B:.*]] = acc.reduction varPtr(%[[DECLB]]#0 : !fir.ref<f32>) recipe(@reduction_mul_ref_f32) name("b") -> !fir.ref<f32>
 ! CHECK:       acc.loop {{.*}} reduction(%[[RED_B]] : !fir.ref<f32>)
 
 subroutine acc_reduction_mul_float_array_1d(a, b)
@@ -1408,7 +1408,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPacc_reduction_mul_float_array_1d(
 ! CHECK-SAME:  %{{.*}}: !fir.ref<!fir.array<100xf32>> {fir.bindc_name = "a"}, %[[B:.*]]: !fir.ref<!fir.array<100xf32>> {fir.bindc_name = "b"})
 ! CHECK:       %[[DECLB:.*]]:2 = hlfir.declare %[[B]]
-! CHECK:       %[[RED_B:.*]] = acc.reduction varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<100xf32>>) recipe(@reduction_mul_ref_100xf32) -> !fir.ref<!fir.array<100xf32>> {name = "b"}
+! CHECK:       %[[RED_B:.*]] = acc.reduction varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<100xf32>>) recipe(@reduction_mul_ref_100xf32) name("b") -> !fir.ref<!fir.array<100xf32>>
 ! CHECK:       acc.loop {{.*}} reduction(%[[RED_B]] : !fir.ref<!fir.array<100xf32>>)
 
 subroutine acc_reduction_min_int(a, b)
@@ -1424,7 +1424,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPacc_reduction_min_int(
 ! CHECK-SAME:  %{{.*}}: !fir.ref<!fir.array<100xi32>> {fir.bindc_name = "a"}, %[[B:.*]]: !fir.ref<i32> {fir.bindc_name = "b"})
 ! CHECK:       %[[DECLB:.*]]:2 = hlfir.declare %[[B]]
-! CHECK:       %[[RED_B:.*]] = acc.reduction varPtr(%[[DECLB]]#0 : !fir.ref<i32>) recipe(@reduction_min_ref_i32) -> !fir.ref<i32> {name = "b"}
+! CHECK:       %[[RED_B:.*]] = acc.reduction varPtr(%[[DECLB]]#0 : !fir.ref<i32>) recipe(@reduction_min_ref_i32) name("b") -> !fir.ref<i32>
 ! CHECK:       acc.loop {{.*}} reduction(%[[RED_B]] : !fir.ref<i32>)
 
 subroutine acc_reduction_min_int_array_1d(a, b)
@@ -1440,7 +1440,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPacc_reduction_min_int_array_1d(
 ! CHECK-SAME: %{{.*}}: !fir.ref<!fir.array<100xi32>> {fir.bindc_name = "a"}, %[[ARG1:.*]]: !fir.ref<!fir.array<100xi32>> {fir.bindc_name = "b"})
 ! CHECK: %[[DECLARG1:.*]]:2 = hlfir.declare %[[ARG1]]
-! CHECK: %[[RED_ARG1:.*]] = acc.reduction varPtr(%[[DECLARG1]]#0 : !fir.ref<!fir.array<100xi32>>) recipe(@reduction_min_ref_100xi32) -> !fir.ref<!fir.array<100xi32>> {name = "b"}
+! CHECK: %[[RED_ARG1:.*]] = acc.reduction varPtr(%[[DECLARG1]]#0 : !fir.ref<!fir.array<100xi32>>) recipe(@reduction_min_ref_100xi32) name("b") -> !fir.ref<!fir.array<100xi32>>
 ! CHECK: acc.loop {{.*}} reduction(%[[RED_ARG1]] : !fir.ref<!fir.array<100xi32>>)
 
 subroutine acc_reduction_min_float(a, b)
@@ -1456,7 +1456,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPacc_reduction_min_float(
 ! CHECK-SAME:  %{{.*}}: !fir.ref<!fir.array<100xf32>> {fir.bindc_name = "a"}, %[[B:.*]]: !fir.ref<f32> {fir.bindc_name = "b"})
 ! CHECK:       %[[DECLB:.*]]:2 = hlfir.declare %[[B]]
-! CHECK:       %[[RED_B:.*]] = acc.reduction varPtr(%[[DECLB]]#0 : !fir.ref<f32>) recipe(@reduction_min_ref_f32) -> !fir.ref<f32> {name = "b"}
+! CHECK:       %[[RED_B:.*]] = acc.reduction varPtr(%[[DECLB]]#0 : !fir.ref<f32>) recipe(@reduction_min_ref_f32) name("b") -> !fir.ref<f32>
 ! CHECK:       acc.loop {{.*}} reduction(%[[RED_B]] : !fir.ref<f32>)
 
 subroutine acc_reduction_min_float_array2d(a, b)
@@ -1474,9 +1474,9 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPacc_reduction_min_float_array2d(
 ! CHECK-SAME: %{{.*}}: !fir.ref<!fir.array<100x10xf32>> {fir.bindc_name = "a"}, %[[ARG1:.*]]: !fir.ref<!fir.array<100x10xf32>> {fir.bindc_name = "b"})
 ! CHECK: %[[DECLARG1:.*]]:2 = hlfir.declare %[[ARG1]]
-! CHECK: %[[RED_ARG1:.*]] = acc.reduction varPtr(%[[DECLARG1]]#0 : !fir.ref<!fir.array<100x10xf32>>) recipe(@reduction_min_ref_100x10xf32) -> !fir.ref<!fir.array<100x10xf32>> {name = "b"}
+! CHECK: %[[RED_ARG1:.*]] = acc.reduction varPtr(%[[DECLARG1]]#0 : !fir.ref<!fir.array<100x10xf32>>) recipe(@reduction_min_ref_100x10xf32) name("b") -> !fir.ref<!fir.array<100x10xf32>>
 ! CHECK: acc.loop {{.*}} reduction(%[[RED_ARG1]] : !fir.ref<!fir.array<100x10xf32>>)
-! CHECK: attributes {collapse = [2]{{.*}}
+! CHECK: {{.*}}collapse([2]){{.*}}
 
 subroutine acc_reduction_max_int(a, b)
   integer :: a(100)
@@ -1491,7 +1491,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPacc_reduction_max_int(
 ! CHECK-SAME:  %{{.*}}: !fir.ref<!fir.array<100xi32>> {fir.bindc_name = "a"}, %[[B:.*]]: !fir.ref<i32> {fir.bindc_name = "b"})
 ! CHECK:       %[[DECLB:.*]]:2 = hlfir.declare %[[B]]
-! CHECK:       %[[RED_B:.*]] = acc.reduction varPtr(%[[DECLB]]#0 : !fir.ref<i32>) recipe(@reduction_max_ref_i32) -> !fir.ref<i32> {name = "b"}
+! CHECK:       %[[RED_B:.*]] = acc.reduction varPtr(%[[DECLB]]#0 : !fir.ref<i32>) recipe(@reduction_max_ref_i32) name("b") -> !fir.ref<i32>
 ! CHECK:       acc.loop {{.*}} reduction(%[[RED_B]] : !fir.ref<i32>)
 
 subroutine acc_reduction_max_int_array2d(a, b)
@@ -1509,7 +1509,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPacc_reduction_max_int_array2d(
 ! CHECK-SAME: %{{.*}}: !fir.ref<!fir.array<100x10xi32>> {fir.bindc_name = "a"}, %[[ARG1:.*]]: !fir.ref<!fir.array<100x10xi32>> {fir.bindc_name = "b"})
 ! CHECK: %[[DECLARG1:.*]]:2 = hlfir.declare %[[ARG1]]
-! CHECK: %[[RED_ARG1:.*]] = acc.reduction varPtr(%[[DECLARG1]]#0 : !fir.ref<!fir.array<100x10xi32>>) recipe(@reduction_max_ref_100x10xi32) -> !fir.ref<!fir.array<100x10xi32>> {name = "b"}
+! CHECK: %[[RED_ARG1:.*]] = acc.reduction varPtr(%[[DECLARG1]]#0 : !fir.ref<!fir.array<100x10xi32>>) recipe(@reduction_max_ref_100x10xi32) name("b") -> !fir.ref<!fir.array<100x10xi32>>
 ! CHECK: acc.loop {{.*}} reduction(%[[RED_ARG1]] : !fir.ref<!fir.array<100x10xi32>>)
 
 subroutine acc_reduction_max_float(a, b)
@@ -1525,7 +1525,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPacc_reduction_max_float(
 ! CHECK-SAME:  %{{.*}}: !fir.ref<!fir.array<100xf32>> {fir.bindc_name = "a"}, %[[B:.*]]: !fir.ref<f32> {fir.bindc_name = "b"})
 ! CHECK:       %[[DECLB:.*]]:2 = hlfir.declare %[[B]]
-! CHECK:       %[[RED_B:.*]] = acc.reduction varPtr(%[[DECLB]]#0 : !fir.ref<f32>) recipe(@reduction_max_ref_f32) -> !fir.ref<f32> {name = "b"}
+! CHECK:       %[[RED_B:.*]] = acc.reduction varPtr(%[[DECLB]]#0 : !fir.ref<f32>) recipe(@reduction_max_ref_f32) name("b") -> !fir.ref<f32>
 ! CHECK:       acc.loop {{.*}} reduction(%[[RED_B]] : !fir.ref<f32>)
 
 subroutine acc_reduction_max_float_array1d(a, b)
@@ -1541,7 +1541,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPacc_reduction_max_float_array1d(
 ! CHECK-SAME:  %{{.*}}: !fir.ref<!fir.array<100xf32>> {fir.bindc_name = "a"}, %[[ARG1:.*]]: !fir.ref<!fir.array<100xf32>> {fir.bindc_name = "b"})
 ! CHECK:       %[[DECLARG1:.*]]:2 = hlfir.declare %[[ARG1]]
-! CHECK:       %[[RED_ARG1:.*]] = acc.reduction varPtr(%[[DECLARG1]]#0 : !fir.ref<!fir.array<100xf32>>) recipe(@reduction_max_ref_100xf32) -> !fir.ref<!fir.array<100xf32>> {name = "b"}
+! CHECK:       %[[RED_ARG1:.*]] = acc.reduction varPtr(%[[DECLARG1]]#0 : !fir.ref<!fir.array<100xf32>>) recipe(@reduction_max_ref_100xf32) name("b") -> !fir.ref<!fir.array<100xf32>>
 ! CHECK:       acc.loop {{.*}} reduction(%[[RED_ARG1]] : !fir.ref<!fir.array<100xf32>>)
 
 subroutine acc_reduction_iand()
@@ -1551,7 +1551,7 @@ subroutine acc_reduction_iand()
 end subroutine
 
 ! CHECK-LABEL: func.func @_QPacc_reduction_iand()
-! CHECK: %[[RED:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<i32>) recipe(@reduction_iand_ref_i32) -> !fir.ref<i32> {name = "i"}
+! CHECK: %[[RED:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<i32>) recipe(@reduction_iand_ref_i32) name("i") -> !fir.ref<i32>
 ! CHECK: acc.parallel   reduction(%[[RED]] : !fir.ref<i32>)
 
 subroutine acc_reduction_ior()
@@ -1561,7 +1561,7 @@ subroutine acc_reduction_ior()
 end subroutine
 
 ! CHECK-LABEL: func.func @_QPacc_reduction_ior()
-! CHECK: %[[RED:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<i32>) recipe(@reduction_ior_ref_i32) -> !fir.ref<i32> {name = "i"}
+! CHECK: %[[RED:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<i32>) recipe(@reduction_ior_ref_i32) name("i") -> !fir.ref<i32>
 ! CHECK: acc.parallel reduction(%[[RED]] : !fir.ref<i32>)
 
 subroutine acc_reduction_ieor()
@@ -1571,7 +1571,7 @@ subroutine acc_reduction_ieor()
 end subroutine
 
 ! CHECK-LABEL: func.func @_QPacc_reduction_ieor()
-! CHECK: %[[RED:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<i32>) recipe(@reduction_xor_ref_i32) -> !fir.ref<i32> {name = "i"}
+! CHECK: %[[RED:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<i32>) recipe(@reduction_xor_ref_i32) name("i") -> !fir.ref<i32>
 ! CHECK: acc.parallel reduction(%[[RED]] : !fir.ref<i32>)
 
 subroutine acc_reduction_and()
@@ -1583,7 +1583,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPacc_reduction_and()
 ! CHECK: %[[L:.*]] = fir.alloca !fir.logical<4> {bindc_name = "l", uniq_name = "_QFacc_reduction_andEl"}
 ! CHECK: %[[DECLL:.*]]:2 = hlfir.declare %[[L]]
-! CHECK: %[[RED:.*]] = acc.reduction varPtr(%[[DECLL]]#0 : !fir.ref<!fir.logical<4>>) recipe(@reduction_land_ref_l32) -> !fir.ref<!fir.logical<4>> {name = "l"}
+! CHECK: %[[RED:.*]] = acc.reduction varPtr(%[[DECLL]]#0 : !fir.ref<!fir.logical<4>>) recipe(@reduction_land_ref_l32) name("l") -> !fir.ref<!fir.logical<4>>
 ! CHECK: acc.parallel reduction(%[[RED]] : !fir.ref<!fir.logical<4>>)
 
 subroutine acc_reduction_or()
@@ -1593,7 +1593,7 @@ subroutine acc_reduction_or()
 end subroutine
 
 ! CHECK-LABEL: func.func @_QPacc_reduction_or()
-! CHECK: %[[RED:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<!fir.logical<4>>) recipe(@reduction_lor_ref_l32) -> !fir.ref<!fir.logical<4>> {name = "l"}
+! CHECK: %[[RED:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<!fir.logical<4>>) recipe(@reduction_lor_ref_l32) name("l") -> !fir.ref<!fir.logical<4>>
 ! CHECK: acc.parallel reduction(%[[RED]] : !fir.ref<!fir.logical<4>>)
 
 subroutine acc_reduction_eqv()
@@ -1603,7 +1603,7 @@ subroutine acc_reduction_eqv()
 end subroutine
 
 ! CHECK-LABEL: func.func @_QPacc_reduction_eqv()
-! CHECK: %[[RED:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<!fir.logical<4>>) recipe(@reduction_eqv_ref_l32) -> !fir.ref<!fir.logical<4>> {name = "l"}
+! CHECK: %[[RED:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<!fir.logical<4>>) recipe(@reduction_eqv_ref_l32) name("l") -> !fir.ref<!fir.logical<4>>
 ! CHECK: acc.parallel reduction(%[[RED]] : !fir.ref<!fir.logical<4>>)
 
 subroutine acc_reduction_neqv()
@@ -1613,7 +1613,7 @@ subroutine acc_reduction_neqv()
 end subroutine
 
 ! CHECK-LABEL: func.func @_QPacc_reduction_neqv()
-! CHECK: %[[RED:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<!fir.logical<4>>) recipe(@reduction_neqv_ref_l32) -> !fir.ref<!fir.logical<4>> {name = "l"}
+! CHECK: %[[RED:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<!fir.logical<4>>) recipe(@reduction_neqv_ref_l32) name("l") -> !fir.ref<!fir.logical<4>>
 ! CHECK: acc.parallel reduction(%[[RED]] : !fir.ref<!fir.logical<4>>)
 
 subroutine acc_reduction_add_cmplx()
@@ -1623,7 +1623,7 @@ subroutine acc_reduction_add_cmplx()
 end subroutine
 
 ! CHECK-LABEL: func.func @_QPacc_reduction_add_cmplx()
-! CHECK: %[[RED:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<complex<f32>>) recipe(@reduction_add_ref_z32) -> !fir.ref<complex<f32>> {name = "c"}
+! CHECK: %[[RED:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<complex<f32>>) recipe(@reduction_add_ref_z32) name("c") -> !fir.ref<complex<f32>>
 ! CHECK: acc.parallel reduction(%[[RED]] : !fir.ref<complex<f32>>)
 
 subroutine acc_reduction_mul_cmplx()
@@ -1633,7 +1633,7 @@ subroutine acc_reduction_mul_cmplx()
 end subroutine
 
 ! CHECK-LABEL: func.func @_QPacc_reduction_mul_cmplx()
-! CHECK: %[[RED:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<complex<f32>>) recipe(@reduction_mul_ref_z32) -> !fir.ref<complex<f32>> {name = "c"}
+! CHECK: %[[RED:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<complex<f32>>) recipe(@reduction_mul_ref_z32) name("c") -> !fir.ref<complex<f32>>
 ! CHECK: acc.parallel reduction(%[[RED]] : !fir.ref<complex<f32>>)
 
 subroutine acc_reduction_add_alloc()
@@ -1646,7 +1646,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPacc_reduction_add_alloc()
 ! CHECK: %[[ALLOCA:.*]] = fir.alloca !fir.box<!fir.heap<i32>> {bindc_name = "i", uniq_name = "_QFacc_reduction_add_allocEi"}
 ! CHECK: %[[DECL:.*]]:2 = hlfir.declare %[[ALLOCA]]
-! CHECK: %[[RED:.*]] = acc.reduction varPtr(%[[DECL]]#0 : !fir.ref<!fir.box<!fir.heap<i32>>>) recipe(@reduction_add_ref_box_heap_i32) -> !fir.ref<!fir.box<!fir.heap<i32>>> {name = "i"}
+! CHECK: %[[RED:.*]] = acc.reduction varPtr(%[[DECL]]#0 : !fir.ref<!fir.box<!fir.heap<i32>>>) recipe(@reduction_add_ref_box_heap_i32) name("i") -> !fir.ref<!fir.box<!fir.heap<i32>>>
 ! CHECK: acc.parallel reduction(%[[RED]] : !fir.ref<!fir.box<!fir.heap<i32>>>)
 
 subroutine acc_reduction_add_pointer(i)
@@ -1658,7 +1658,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPacc_reduction_add_pointer(
 ! CHECK-SAME: %[[ARG0:.*]]: !fir.ref<!fir.box<!fir.ptr<i32>>> {fir.bindc_name = "i"})
 ! CHECK: %[[DECLARG0:.*]]:2 = hlfir.declare %[[ARG0]]
-! CHECK: %[[RED:.*]] = acc.reduction varPtr(%[[DECLARG0]]#0 : !fir.ref<!fir.box<!fir.ptr<i32>>>) recipe(@reduction_add_ref_box_ptr_i32) -> !fir.ref<!fir.box<!fir.ptr<i32>>> {name = "i"}
+! CHECK: %[[RED:.*]] = acc.reduction varPtr(%[[DECLARG0]]#0 : !fir.ref<!fir.box<!fir.ptr<i32>>>) recipe(@reduction_add_ref_box_ptr_i32) name("i") -> !fir.ref<!fir.box<!fir.ptr<i32>>>
 ! CHECK: acc.parallel reduction(%[[RED]] : !fir.ref<!fir.box<!fir.ptr<i32>>>)
 
 subroutine acc_reduction_add_static_slice(a)
@@ -1675,7 +1675,7 @@ end subroutine
 ! CHECK: %[[LB:.*]] = arith.constant 10 : index
 ! CHECK: %[[UB:.*]] = arith.constant 19 : index
 ! CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%[[LB]] : index) upperbound(%[[UB]] : index) extent(%[[C100]] : index) stride(%[[C1]] : index) startIdx(%[[C1]] : index)
-! CHECK: %[[RED:.*]] = acc.reduction varPtr(%[[DECLARG0]]#0 : !fir.ref<!fir.array<100xi32>>) bounds(%[[BOUND]]) recipe(@reduction_add_section_lb10.ub19_ref_100xi32) -> !fir.ref<!fir.array<100xi32>> {name = "a(11:20)"}
+! CHECK: %[[RED:.*]] = acc.reduction varPtr(%[[DECLARG0]]#0 : !fir.ref<!fir.array<100xi32>>) bounds(%[[BOUND]]) recipe(@reduction_add_section_lb10.ub19_ref_100xi32) name("a(11:20)") -> !fir.ref<!fir.array<100xi32>>
 ! CHECK: acc.parallel reduction(%[[RED]] : !fir.ref<!fir.array<100xi32>>)
 
 subroutine acc_reduction_add_static_slice_2d(a)
@@ -1687,7 +1687,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPacc_reduction_add_static_slice_2d(
 ! CHECK-SAME: %[[ARG0:.*]]: !fir.ref<!fir.array<10x20xi32>> {fir.bindc_name = "a"})
 ! CHECK: %[[DECLARG0:.*]]:2 = hlfir.declare %[[ARG0]]
-! CHECK: %[[RED:.*]] = acc.reduction varPtr(%[[DECLARG0]]#0 : !fir.ref<!fir.array<10x20xi32>>) recipe(@reduction_add_ref_10x20xi32) -> !fir.ref<!fir.array<10x20xi32>> {name = "a"}
+! CHECK: %[[RED:.*]] = acc.reduction varPtr(%[[DECLARG0]]#0 : !fir.ref<!fir.array<10x20xi32>>) recipe(@reduction_add_ref_10x20xi32) name("a") -> !fir.ref<!fir.array<10x20xi32>>
 ! CHECK: acc.parallel reduction(%[[RED]] : !fir.ref<!fir.array<10x20xi32>>)
 
 subroutine acc_reduction_add_static_colon(a)
@@ -1699,7 +1699,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPacc_reduction_add_static_colon(
 ! CHECK-SAME: %[[ARG0:.*]]: !fir.ref<!fir.array<10xi32>> {fir.bindc_name = "a"})
 ! CHECK: %[[DECLARG0:.*]]:2 = hlfir.declare %[[ARG0]]
-! CHECK: %[[RED:.*]] = acc.reduction varPtr(%[[DECLARG0]]#0 : !fir.ref<!fir.array<10xi32>>) recipe(@reduction_add_ref_10xi32) -> !fir.ref<!fir.array<10xi32>> {name = "a"}
+! CHECK: %[[RED:.*]] = acc.reduction varPtr(%[[DECLARG0]]#0 : !fir.ref<!fir.array<10xi32>>) recipe(@reduction_add_ref_10xi32) name("a") -> !fir.ref<!fir.array<10xi32>>
 ! CHECK: acc.parallel reduction(%[[RED]] : !fir.ref<!fir.array<10xi32>>)
 
 subroutine acc_reduction_add_static_colon_2d(a)
@@ -1711,7 +1711,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPacc_reduction_add_static_colon_2d(
 ! CHECK-SAME: %[[ARG0:.*]]: !fir.ref<!fir.array<10x20xi32>> {fir.bindc_name = "a"})
 ! CHECK: %[[DECLARG0:.*]]:2 = hlfir.declare %[[ARG0]]
-! CHECK: %[[RED:.*]] = acc.reduction varPtr(%[[DECLARG0]]#0 : !fir.ref<!fir.array<10x20xi32>>) recipe(@reduction_add_ref_10x20xi32) -> !fir.ref<!fir.array<10x20xi32>> {name = "a"}
+! CHECK: %[[RED:.*]] = acc.reduction varPtr(%[[DECLARG0]]#0 : !fir.ref<!fir.array<10x20xi32>>) recipe(@reduction_add_ref_10x20xi32) name("a") -> !fir.ref<!fir.array<10x20xi32>>
 ! CHECK: acc.parallel reduction(%[[RED]] : !fir.ref<!fir.array<10x20xi32>>)
 
 subroutine acc_reduction_add_dynamic_extent_add(a)
@@ -1723,7 +1723,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPacc_reduction_add_dynamic_extent_add(
 ! CHECK-SAME: %[[ARG0:.*]]: !fir.box<!fir.array<?xi32>> {fir.bindc_name = "a"})
 ! CHECK: %[[DECLARG0:.*]]:2 = hlfir.declare %[[ARG0]]
-! CHECK: %[[RED:.*]] = acc.reduction var(%{{.*}} : !fir.box<!fir.array<?xi32>>) recipe(@reduction_add_box_Uxi32) -> !fir.box<!fir.array<?xi32>> {name = "a"}
+! CHECK: %[[RED:.*]] = acc.reduction var(%{{.*}} : !fir.box<!fir.array<?xi32>>) recipe(@reduction_add_box_Uxi32) name("a") -> !fir.box<!fir.array<?xi32>>
 ! CHECK: acc.parallel reduction(%[[RED:.*]] : !fir.box<!fir.array<?xi32>>)
 
 subroutine acc_reduction_add_dynamic_extent_colon(a)
@@ -1735,7 +1735,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPacc_reduction_add_dynamic_extent_colon(
 ! CHECK-SAME: %[[ARG0:.*]]: !fir.box<!fir.array<?xi32>> {fir.bindc_name = "a"})
 ! CHECK: %[[DECLARG0:.*]]:2 = hlfir.declare %[[ARG0]]
-! CHECK: %[[RED:.*]] = acc.reduction var(%{{.*}} : !fir.box<!fir.array<?xi32>>) recipe(@reduction_add_box_Uxi32) -> !fir.box<!fir.array<?xi32>> {name = "a"}
+! CHECK: %[[RED:.*]] = acc.reduction var(%{{.*}} : !fir.box<!fir.array<?xi32>>) recipe(@reduction_add_box_Uxi32) name("a") -> !fir.box<!fir.array<?xi32>>
 ! CHECK: acc.parallel reduction(%[[RED]] : !fir.box<!fir.array<?xi32>>)
 
 subroutine acc_reduction_add_assumed_shape_max(a)
@@ -1747,7 +1747,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPacc_reduction_add_assumed_shape_max(
 ! CHECK-SAME: %[[ARG0:.*]]: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "a"})
 ! CHECK: %[[DECLARG0:.*]]:2 = hlfir.declare %[[ARG0]]
-! CHECK: %[[RED:.*]] = acc.reduction var(%{{.*}} : !fir.box<!fir.array<?xf32>>) recipe(@reduction_max_box_Uxf32) -> !fir.box<!fir.array<?xf32>> {name = "a"}
+! CHECK: %[[RED:.*]] = acc.reduction var(%{{.*}} : !fir.box<!fir.array<?xf32>>) recipe(@reduction_max_box_Uxf32) name("a") -> !fir.box<!fir.array<?xf32>>
 ! CHECK: acc.parallel reduction(%[[RED]] : !fir.box<!fir.array<?xf32>>) {
 
 subroutine acc_reduction_add_dynamic_extent_add_with_section(a)
@@ -1759,8 +1759,8 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPacc_reduction_add_dynamic_extent_add_with_section(
 ! CHECK-SAME: %[[ARG0:.*]]: !fir.box<!fir.array<?xi32>> {fir.bindc_name = "a"})
 ! CHECK: %[[DECL:.*]]:2 = hlfir.declare %[[ARG0]] dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {uniq_name = "_QFacc_reduction_add_dynamic_extent_add_with_sectionEa"} : (!fir.box<!fir.array<?xi32>>, !fir.dscope) -> (!fir.box<!fir.array<?xi32>>, !fir.box<!fir.array<?xi32>>)
-! CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%c1{{.*}} : index) upperbound(%c3{{.*}} : index) extent(%{{.*}}#1 : index) stride(%{{.*}}#2 : index) startIdx(%{{.*}} : index) {strideInBytes = true}
-! CHECK: %[[RED:.*]] = acc.reduction var(%[[DECL]]#0 : !fir.box<!fir.array<?xi32>>) bounds(%[[BOUND]]) recipe(@reduction_add_section_lb1.ub3_box_Uxi32) -> !fir.box<!fir.array<?xi32>> {name = "a(2:4)"}
+! CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%c1{{.*}} : index) upperbound(%c3{{.*}} : index) extent(%{{.*}}#1 : index) stride(%{{.*}}#2 : index) startIdx(%{{.*}} : index) strideInBytes(true)
+! CHECK: %[[RED:.*]] = acc.reduction var(%[[DECL]]#0 : !fir.box<!fir.array<?xi32>>) bounds(%[[BOUND]]) recipe(@reduction_add_section_lb1.ub3_box_Uxi32) name("a(2:4)") -> !fir.box<!fir.array<?xi32>>
 ! CHECK: acc.parallel reduction(%[[RED]] : !fir.box<!fir.array<?xi32>>)
 
 subroutine acc_reduction_add_allocatable(a)
@@ -1772,7 +1772,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPacc_reduction_add_allocatable(
 ! CHECK-SAME: %[[ARG0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>> {fir.bindc_name = "a"})
 ! CHECK: %[[DECL:.*]]:2 = hlfir.declare %[[ARG0]] dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFacc_reduction_add_allocatableEa"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>)
-! CHECK: %[[RED:.*]] = acc.reduction varPtr(%[[DECL]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) recipe(@reduction_max_ref_box_heap_Uxf32) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>> {name = "a"}
+! CHECK: %[[RED:.*]] = acc.reduction varPtr(%[[DECL]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) recipe(@reduction_max_ref_box_heap_Uxf32) name("a") -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
 ! CHECK: acc.parallel reduction(%[[RED]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>)
 
 subroutine acc_reduction_add_pointer_array(a)
@@ -1784,7 +1784,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPacc_reduction_add_pointer_array(
 ! CHECK-SAME: %[[ARG0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>> {fir.bindc_name = "a"})
 ! CHECK: %[[DECL:.*]]:2 = hlfir.declare %[[ARG0]] dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QFacc_reduction_add_pointer_arrayEa"} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>)
-! CHECK: %[[RED:.*]] = acc.reduction varPtr(%[[DECL]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) recipe(@reduction_max_ref_box_ptr_Uxf32) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>> {name = "a"}
+! CHECK: %[[RED:.*]] = acc.reduction varPtr(%[[DECL]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) recipe(@reduction_max_ref_box_ptr_Uxf32) name("a") -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
 ! CHECK: acc.parallel reduction(%[[RED]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>)
 
 subroutine acc_reduction_max_dynamic_extent_max(a, n)
@@ -1797,7 +1797,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPacc_reduction_max_dynamic_extent_max(
 ! CHECK-SAME: %[[ARG0:.*]]: !fir.ref<!fir.array<?x?xf32>> {fir.bindc_name = "a"}, %{{.*}}: !fir.ref<i32> {fir.bindc_name = "n"})
 ! CHECK: %[[DECL_A:.*]]:2 = hlfir.declare %[[ARG0]](%{{.*}}) dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {uniq_name = "_QFacc_reduction_max_dynamic_extent_maxEa"} : (!fir.ref<!fir.array<?x?xf32>>, !fir.shape<2>, !fir.dscope) -> (!fir.box<!fir.array<?x?xf32>>, !fir.ref<!fir.array<?x?xf32>>)
-! CHECK: %[[RED:.*]] = acc.reduction var(%[[DECL_A]]#0 : !fir.box<!fir.array<?x?xf32>>) recipe(@reduction_max_box_UxUxf32) -> !fir.box<!fir.array<?x?xf32>> {name = "a"}
+! CHECK: %[[RED:.*]] = acc.reduction var(%[[DECL_A]]#0 : !fir.box<!fir.array<?x?xf32>>) recipe(@reduction_max_box_UxUxf32) name("a") -> !fir.box<!fir.array<?x?xf32>>
 ! CHECK: acc.parallel reduction(%[[RED]] : !fir.box<!fir.array<?x?xf32>>)
 
 subroutine acc_reduction_logical_allocatable(l)
@@ -1806,5 +1806,5 @@ subroutine acc_reduction_logical_allocatable(l)
   !$acc end parallel
 end subroutine
 ! CHECK-LABEL:   func.func @_QPacc_reduction_logical_allocatable(
-! CHECK:           %[[REDUCTION_0:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.logical<4>>>>) recipe(@reduction_lor_ref_box_heap_l32) -> !fir.ref<!fir.box<!fir.heap<!fir.logical<4>>>> {name = "l"}
+! CHECK:           %[[REDUCTION_0:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.logical<4>>>>) recipe(@reduction_lor_ref_box_heap_l32) name("l") -> !fir.ref<!fir.box<!fir.heap<!fir.logical<4>>>>
 ! CHECK:           acc.parallel reduction(%[[REDUCTION_0]] : !fir.ref<!fir.box<!fir.heap<!fir.logical<4>>>>)

--- a/flang/test/Lower/OpenACC/acc-serial-loop.f90
+++ b/flang/test/Lower/OpenACC/acc-serial-loop.f90
@@ -64,9 +64,9 @@ subroutine acc_serial_loop
 ! CHECK:      acc.serial {
 ! CHECK:        acc.loop private{{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {{{.*}}seq = [#acc.device_type<none>]}
+! CHECK-NEXT:   } {{.*}}seq
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc serial loop
   DO i = 1, n
@@ -76,9 +76,9 @@ subroutine acc_serial_loop
 ! CHECK:      acc.serial combined(loop) {
 ! CHECK:        acc.loop combined(serial) private{{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {{{.*}}seq = [#acc.device_type<none>]}
+! CHECK-NEXT:   } {{.*}}seq{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc serial loop async
   DO i = 1, n
@@ -89,7 +89,7 @@ subroutine acc_serial_loop
 ! CHECK:      acc.serial {{.*}} async {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) seq
 ! CHECK:        acc.yield
 ! CHECK-NEXT: }
 
@@ -102,9 +102,9 @@ subroutine acc_serial_loop
 ! CHECK:      acc.serial {{.*}} async([[ASYNC1]] : i32) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc serial loop async(async)
   DO i = 1, n
@@ -115,9 +115,9 @@ subroutine acc_serial_loop
 ! CHECK:      acc.serial {{.*}} async([[ASYNC2]] : i32) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc serial loop async(async) device_type(nvidia) async(1)
   DO i = 1, n
@@ -133,7 +133,7 @@ subroutine acc_serial_loop
 ! CHECK:      acc.serial {{.*}} wait {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
 ! CHECK-NEXT: }
 
@@ -146,9 +146,9 @@ subroutine acc_serial_loop
 ! CHECK:      acc.serial {{.*}} wait({[[WAIT1]] : i32}) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc serial loop wait(1, 2)
   DO i = 1, n
@@ -160,9 +160,9 @@ subroutine acc_serial_loop
 ! CHECK:      acc.serial {{.*}} wait({[[WAIT2]] : i32, [[WAIT3]] : i32}) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc serial loop wait(wait1, wait2)
   DO i = 1, n
@@ -174,9 +174,9 @@ subroutine acc_serial_loop
 ! CHECK:      acc.serial {{.*}} wait({[[WAIT4]] : i32, [[WAIT5]] : i32}) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc serial loop if(.TRUE.)
   DO i = 1, n
@@ -187,9 +187,9 @@ subroutine acc_serial_loop
 ! CHECK:      acc.serial {{.*}} if([[IF1]]) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc serial loop if(ifCondition)
   DO i = 1, n
@@ -201,9 +201,9 @@ subroutine acc_serial_loop
 ! CHECK:      acc.serial {{.*}} if([[IF2]]) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc serial loop self(.TRUE.)
   DO i = 1, n
@@ -214,9 +214,9 @@ subroutine acc_serial_loop
 ! CHECK:      acc.serial {{.*}} self([[SELF1]]) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc serial loop self
   DO i = 1, n
@@ -226,9 +226,9 @@ subroutine acc_serial_loop
 ! CHECK:      acc.serial {{.*}} {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: } attributes {selfAttr}
+! CHECK-NEXT: } selfAttr
 
   !$acc serial loop self(ifCondition)
   DO i = 1, n
@@ -239,164 +239,164 @@ subroutine acc_serial_loop
 ! CHECK:      acc.serial {{.*}} self(%[[SELF2]]) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc serial loop copy(a, b)
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "a"}
-! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "b"}
+! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) name("a") -> !fir.ref<!fir.array<10xf32>>
+! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) name("b") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK:      acc.serial {{.*}} dataOperands(%[[COPYIN_A]], %[[COPYIN_B]] : !fir.ref<!fir.array<10xf32>>, !fir.ref<!fir.array<10xf32>>) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
-! CHECK:      acc.copyout accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "a"}
-! CHECK:      acc.copyout accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "b"}
+! CHECK-NEXT: }{{.*}}
+! CHECK:      acc.copyout accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) name("a")
+! CHECK:      acc.copyout accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) name("b")
 
   !$acc serial loop copy(a) copy(b)
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "a"}
-! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "b"}
+! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) name("a") -> !fir.ref<!fir.array<10xf32>>
+! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) name("b") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK:      acc.serial {{.*}} dataOperands(%[[COPYIN_A]], %[[COPYIN_B]] : !fir.ref<!fir.array<10xf32>>, !fir.ref<!fir.array<10xf32>>) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
-! CHECK:      acc.copyout accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "a"}
-! CHECK:      acc.copyout accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "b"}
+! CHECK-NEXT: }{{.*}}
+! CHECK:      acc.copyout accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) name("a")
+! CHECK:      acc.copyout accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) name("b")
 
   !$acc serial loop copyin(a) copyin(readonly: b)
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "a"}
-! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {dataClause = #acc<data_clause acc_copyin_readonly>, name = "b"}
+! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) name("a") -> !fir.ref<!fir.array<10xf32>>
+! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copyin_readonly) name("b") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK:      acc.serial {{.*}} dataOperands(%[[COPYIN_A]], %[[COPYIN_B]] : !fir.ref<!fir.array<10xf32>>, !fir.ref<!fir.array<10xf32>>) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
-! CHECK:      acc.delete accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_copyin>, name = "a"}
-! CHECK:      acc.delete accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_copyin_readonly>, name = "b"}
+! CHECK-NEXT: }{{.*}}
+! CHECK:      acc.delete accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copyin) name("a")
+! CHECK:      acc.delete accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copyin_readonly) name("b")
 
   !$acc serial loop copyout(a) copyout(zero: b)
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {dataClause = #acc<data_clause acc_copyout>, name = "a"}
-! CHECK:      %[[CREATE_B:.*]] = acc.create varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {dataClause = #acc<data_clause acc_copyout_zero>, name = "b"}
+! CHECK:      %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copyout) name("a") -> !fir.ref<!fir.array<10xf32>>
+! CHECK:      %[[CREATE_B:.*]] = acc.create varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copyout_zero) name("b") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK:      acc.serial {{.*}} dataOperands(%[[CREATE_A]], %[[CREATE_B]] : !fir.ref<!fir.array<10xf32>>, !fir.ref<!fir.array<10xf32>>) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
-! CHECK:      acc.copyout accPtr(%[[CREATE_A]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) {name = "a"}
-! CHECK:      acc.copyout accPtr(%[[CREATE_B]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_copyout_zero>, name = "b"}
+! CHECK-NEXT: }{{.*}}
+! CHECK:      acc.copyout accPtr(%[[CREATE_A]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) name("a")
+! CHECK:      acc.copyout accPtr(%[[CREATE_B]] : !fir.ref<!fir.array<10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copyout_zero) name("b")
 
   !$acc serial loop create(b) create(zero: a)
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[CREATE_B:.*]] = acc.create varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "b"}
-! CHECK:      %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {dataClause = #acc<data_clause acc_create_zero>, name = "a"}
+! CHECK:      %[[CREATE_B:.*]] = acc.create varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) name("b") -> !fir.ref<!fir.array<10xf32>>
+! CHECK:      %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) dataClause(acc_create_zero) name("a") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK:      acc.serial {{.*}} dataOperands(%[[CREATE_B]], %[[CREATE_A]] : !fir.ref<!fir.array<10xf32>>, !fir.ref<!fir.array<10xf32>>) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
-! CHECK:      acc.delete accPtr(%[[CREATE_B]] : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_create>, name = "b"}
-! CHECK:      acc.delete accPtr(%[[CREATE_A]] : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_create_zero>, name = "a"}
+! CHECK-NEXT: }{{.*}}
+! CHECK:      acc.delete accPtr(%[[CREATE_B]] : !fir.ref<!fir.array<10xf32>>) dataClause(acc_create) name("b")
+! CHECK:      acc.delete accPtr(%[[CREATE_A]] : !fir.ref<!fir.array<10xf32>>) dataClause(acc_create_zero) name("a")
 
   !$acc serial loop no_create(a, b)
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[NOCREATE_A:.*]] = acc.nocreate varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "a"}
-! CHECK:      %[[NOCREATE_B:.*]] = acc.nocreate varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "b"}
+! CHECK:      %[[NOCREATE_A:.*]] = acc.nocreate varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) name("a") -> !fir.ref<!fir.array<10xf32>>
+! CHECK:      %[[NOCREATE_B:.*]] = acc.nocreate varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) name("b") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK:      acc.serial {{.*}} dataOperands(%[[NOCREATE_A]], %[[NOCREATE_B]] : !fir.ref<!fir.array<10xf32>>, !fir.ref<!fir.array<10xf32>>) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
-! CHECK:      acc.delete accPtr(%[[NOCREATE_A]] : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_no_create>, name = "a"}
-! CHECK:      acc.delete accPtr(%[[NOCREATE_B]] : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_no_create>, name = "b"}
+! CHECK-NEXT: }{{.*}}
+! CHECK:      acc.delete accPtr(%[[NOCREATE_A]] : !fir.ref<!fir.array<10xf32>>) dataClause(acc_no_create) name("a")
+! CHECK:      acc.delete accPtr(%[[NOCREATE_B]] : !fir.ref<!fir.array<10xf32>>) dataClause(acc_no_create) name("b")
 
   !$acc serial loop present(a, b)
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[PRESENT_A:.*]] = acc.present varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "a"}
-! CHECK:      %[[PRESENT_B:.*]] = acc.present varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "b"}
+! CHECK:      %[[PRESENT_A:.*]] = acc.present varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) name("a") -> !fir.ref<!fir.array<10xf32>>
+! CHECK:      %[[PRESENT_B:.*]] = acc.present varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) name("b") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK:      acc.serial {{.*}} dataOperands(%[[PRESENT_A]], %[[PRESENT_B]] : !fir.ref<!fir.array<10xf32>>, !fir.ref<!fir.array<10xf32>>) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
-! CHECK:      acc.delete accPtr(%[[PRESENT_A]] : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_present>, name = "a"}
-! CHECK:      acc.delete accPtr(%[[PRESENT_B]] : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_present>, name = "b"}
+! CHECK-NEXT: }{{.*}}
+! CHECK:      acc.delete accPtr(%[[PRESENT_A]] : !fir.ref<!fir.array<10xf32>>) dataClause(acc_present) name("a")
+! CHECK:      acc.delete accPtr(%[[PRESENT_B]] : !fir.ref<!fir.array<10xf32>>) dataClause(acc_present) name("b")
 
   !$acc serial loop deviceptr(a) deviceptr(b)
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[DEVICEPTR_A:.*]] = acc.deviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "a"}
-! CHECK:      %[[DEVICEPTR_B:.*]] = acc.deviceptr varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "b"}
+! CHECK:      %[[DEVICEPTR_A:.*]] = acc.deviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) name("a") -> !fir.ref<!fir.array<10xf32>>
+! CHECK:      %[[DEVICEPTR_B:.*]] = acc.deviceptr varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) name("b") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK:      acc.serial {{.*}} dataOperands(%[[DEVICEPTR_A]], %[[DEVICEPTR_B]] : !fir.ref<!fir.array<10xf32>>, !fir.ref<!fir.array<10xf32>>) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc serial loop attach(f, g)
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[ATTACH_F:.*]] = acc.attach varPtr(%[[DECLF]]#0 : !fir.ref<!fir.box<!fir.ptr<f32>>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>> {name = "f"}
-! CHECK:      %[[ATTACH_G:.*]] = acc.attach varPtr(%[[DECLG]]#0 : !fir.ref<!fir.box<!fir.ptr<f32>>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>> {name = "g"}
+! CHECK:      %[[ATTACH_F:.*]] = acc.attach varPtr(%[[DECLF]]#0 : !fir.ref<!fir.box<!fir.ptr<f32>>>) name("f") -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+! CHECK:      %[[ATTACH_G:.*]] = acc.attach varPtr(%[[DECLG]]#0 : !fir.ref<!fir.box<!fir.ptr<f32>>>) name("g") -> !fir.ref<!fir.box<!fir.ptr<f32>>>
 ! CHECK:      acc.serial {{.*}} dataOperands(%[[ATTACH_F]], %[[ATTACH_G]] : !fir.ref<!fir.box<!fir.ptr<f32>>>, !fir.ref<!fir.box<!fir.ptr<f32>>>) {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc serial loop private(a) firstprivate(b)
   DO i = 1, n
     a(i) = b(i)
   END DO
 
-! CHECK:      %[[ACC_FPRIVATE_B:.*]] = acc.firstprivate varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) recipe(@firstprivatization_ref_10xf32) -> !fir.ref<!fir.array<10xf32>> {name = "b"}
+! CHECK:      %[[ACC_FPRIVATE_B:.*]] = acc.firstprivate varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10xf32>>) recipe(@firstprivatization_ref_10xf32) name("b") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK:      acc.serial {{.*}} firstprivate(%[[ACC_FPRIVATE_B]] : !fir.ref<!fir.array<10xf32>>) {
-! CHECK:      %[[ACC_PRIVATE_A:.*]] = acc.private varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) recipe(@privatization_ref_10xf32) -> !fir.ref<!fir.array<10xf32>> {name = "a"}
+! CHECK:      %[[ACC_PRIVATE_A:.*]] = acc.private varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) recipe(@privatization_ref_10xf32) name("a") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK:        acc.loop {{.*}} private(%[[ACC_PRIVATE_A]]{{.*}} : !fir.ref<!fir.array<10xf32>>{{.*}})
 ! CHECK-NOT:          fir.do_loop
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc serial loop seq
   DO i = 1, n
@@ -406,9 +406,9 @@ subroutine acc_serial_loop
 ! CHECK:      acc.serial {{.*}} {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {inclusiveUpperbound = array<i1: true>, seq = [#acc.device_type<none>]}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) seq
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc serial loop auto
   DO i = 1, n
@@ -418,9 +418,9 @@ subroutine acc_serial_loop
 ! CHECK:      acc.serial {{.*}} {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) auto_
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc serial loop independent
   DO i = 1, n
@@ -430,9 +430,9 @@ subroutine acc_serial_loop
 ! CHECK:      acc.serial {{.*}} {
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) independent
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc serial loop gang
   DO i = 1, n
@@ -442,9 +442,9 @@ subroutine acc_serial_loop
 ! CHECK:      acc.serial {{.*}} {
 ! CHECK:        acc.loop {{.*}} gang {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) auto_
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc serial loop gang(num: 8)
   DO i = 1, n
@@ -455,9 +455,9 @@ subroutine acc_serial_loop
 ! CHECK:        [[GANGNUM1:%.*]] = arith.constant 8 : i32
 ! CHECK:        acc.loop {{.*}} gang({num=[[GANGNUM1]] : i32}) {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) auto_
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc serial loop gang(num: gangNum)
   DO i = 1, n
@@ -468,9 +468,9 @@ subroutine acc_serial_loop
 ! CHECK:        [[GANGNUM2:%.*]] = fir.load %{{.*}} : !fir.ref<i32>
 ! CHECK:        acc.loop {{.*}} gang({num=[[GANGNUM2]] : i32}) {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) auto_
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
  !$acc serial loop gang(num: gangNum, static: gangStatic)
   DO i = 1, n
@@ -480,9 +480,9 @@ subroutine acc_serial_loop
 ! CHECK:      acc.serial {{.*}} {
 ! CHECK:        acc.loop {{.*}} gang({num=%{{.*}} : i32, static=%{{.*}} : i32}) {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) auto_
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc serial loop vector
   DO i = 1, n
@@ -492,9 +492,9 @@ subroutine acc_serial_loop
 ! CHECK:      acc.serial {{.*}} {
 ! CHECK:        acc.loop {{.*}} vector {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) auto_
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc serial loop vector(128)
   DO i = 1, n
@@ -505,9 +505,9 @@ subroutine acc_serial_loop
 ! CHECK:        [[CONSTANT128:%.*]] = arith.constant 128 : i32
 ! CHECK:        acc.loop {{.*}} vector([[CONSTANT128]] : i32) {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) auto_
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc serial loop vector(vectorLength)
   DO i = 1, n
@@ -518,9 +518,9 @@ subroutine acc_serial_loop
 ! CHECK:        [[VECTORLENGTH:%.*]] = fir.load %{{.*}} : !fir.ref<i32>
 ! CHECK:        acc.loop {{.*}} vector([[VECTORLENGTH]] : i32) {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) auto_
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc serial loop worker
   DO i = 1, n
@@ -530,9 +530,9 @@ subroutine acc_serial_loop
 ! CHECK:      acc.serial {{.*}} {
 ! CHECK:        acc.loop {{.*}} worker {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) auto_
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc serial loop worker(128)
   DO i = 1, n
@@ -543,9 +543,9 @@ subroutine acc_serial_loop
 ! CHECK:        [[WORKER128:%.*]] = arith.constant 128 : i32
 ! CHECK:        acc.loop {{.*}} worker([[WORKER128]] : i32) {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+! CHECK-NEXT:   } inclusiveUpperbound(array<i1: true>) auto_
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc serial loop collapse(2)
   DO i = 1, n
@@ -558,9 +558,9 @@ subroutine acc_serial_loop
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK-NOT:            fir.do_loop
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {{{.*}}collapse = [2], collapseDeviceType = [#acc.device_type<none>]{{.*}}}
+! CHECK-NEXT:   } {{.*}}collapse([2]){{.*}}collapseDeviceType([#acc.device_type<none>]){{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc serial loop
   DO i = 1, n
@@ -574,11 +574,11 @@ subroutine acc_serial_loop
 ! CHECK:        acc.loop {{.*}} {
 ! CHECK:            acc.loop {{.*}} {
 ! CHECK:              acc.yield
-! CHECK-NEXT:     } attributes {{{.*}}seq = [#acc.device_type<none>]}
+! CHECK-NEXT:     } {{.*}}seq{{.*}}
 ! CHECK:          acc.yield
-! CHECK-NEXT:   } attributes {{{.*}}seq = [#acc.device_type<none>]}
+! CHECK-NEXT:   } {{.*}}seq{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
  !$acc serial loop tile(2)
   DO i = 1, n
@@ -589,9 +589,9 @@ subroutine acc_serial_loop
 ! CHECK:        [[TILESIZE:%.*]] = arith.constant 2 : i32
 ! CHECK:        acc.loop {{.*}} tile({[[TILESIZE]] : i32}) {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
  !$acc serial loop tile(*)
   DO i = 1, n
@@ -602,9 +602,9 @@ subroutine acc_serial_loop
 ! CHECK:        [[TILESIZEM1:%.*]] = arith.constant -1 : i32
 ! CHECK:        acc.loop {{.*}} tile({[[TILESIZEM1]] : i32}) {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc serial loop tile(2, 2)
   DO i = 1, n
@@ -618,9 +618,9 @@ subroutine acc_serial_loop
 ! CHECK:        [[TILESIZE2:%.*]] = arith.constant 2 : i32
 ! CHECK:        acc.loop {{.*}} tile({[[TILESIZE1]] : i32, [[TILESIZE2]] : i32}) control(%arg0 : i32, %arg1 : i32) {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc serial loop tile(tileSize)
   DO i = 1, n
@@ -630,9 +630,9 @@ subroutine acc_serial_loop
 ! CHECK:      acc.serial {{.*}} {
 ! CHECK:        acc.loop {{.*}} tile({%{{.*}} : i32}) {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc serial loop tile(tileSize, tileSize)
   DO i = 1, n
@@ -644,9 +644,9 @@ subroutine acc_serial_loop
 ! CHECK:      acc.serial {{.*}} {
 ! CHECK:        acc.loop {{.*}} tile({%{{.*}} : i32, %{{.*}} : i32}) control(%arg0 : i32, %arg1 : i32) {{.*}} {
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
+! CHECK-NEXT: }{{.*}}
 
   !$acc serial loop reduction(+:reduction_r) reduction(*:reduction_i)
   do i = 1, n
@@ -654,18 +654,18 @@ subroutine acc_serial_loop
     reduction_i = 1
   end do
 
-! CHECK:      %[[COPYINREDR:.*]] = acc.copyin varPtr(%{{.*}} : !fir.ref<f32>) -> !fir.ref<f32> {dataClause = #acc<data_clause acc_reduction>, implicit = true, name = "reduction_r"}
-! CHECK:      %[[COPYINREDI:.*]] = acc.copyin varPtr(%{{.*}} : !fir.ref<i32>) -> !fir.ref<i32> {dataClause = #acc<data_clause acc_reduction>, implicit = true, name = "reduction_i"}
+! CHECK:      %[[COPYINREDR:.*]] = acc.copyin varPtr(%{{.*}} : !fir.ref<f32>) dataClause(acc_reduction) implicit(true) name("reduction_r") -> !fir.ref<f32>
+! CHECK:      %[[COPYINREDI:.*]] = acc.copyin varPtr(%{{.*}} : !fir.ref<i32>) dataClause(acc_reduction) implicit(true) name("reduction_i") -> !fir.ref<i32>
 ! CHECK:      acc.serial {{.*}} dataOperands(%[[COPYINREDR]], %[[COPYINREDI]] : !fir.ref<f32>, !fir.ref<i32>) {
-! CHECK:        %[[REDUCTION_R:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_add_ref_f32) -> !fir.ref<f32> {name = "reduction_r"}
-! CHECK:        %[[REDUCTION_I:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<i32>) recipe(@reduction_mul_ref_i32) -> !fir.ref<i32> {name = "reduction_i"}
+! CHECK:        %[[REDUCTION_R:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_add_ref_f32) name("reduction_r") -> !fir.ref<f32>
+! CHECK:        %[[REDUCTION_I:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<i32>) recipe(@reduction_mul_ref_i32) name("reduction_i") -> !fir.ref<i32>
 ! CHECK:        acc.loop {{.*}} reduction(%[[REDUCTION_R]], %[[REDUCTION_I]] : !fir.ref<f32>, !fir.ref<i32>)
 ! CHECK-NOT:      fir.do_loop
 ! CHECK:          acc.yield
-! CHECK-NEXT:   }{{$}}
+! CHECK-NEXT:   }{{.*}}
 ! CHECK:        acc.yield
-! CHECK-NEXT: }{{$}}
-! CHECK:      acc.copyout accPtr(%[[COPYINREDR]] : !fir.ref<f32>) to varPtr(%{{.*}} : !fir.ref<f32>) {dataClause = #acc<data_clause acc_reduction>, implicit = true, name = "reduction_r"}
-! CHECK:      acc.copyout accPtr(%[[COPYINREDI]] : !fir.ref<i32>) to varPtr(%{{.*}} : !fir.ref<i32>) {dataClause = #acc<data_clause acc_reduction>, implicit = true, name = "reduction_i"}
+! CHECK-NEXT: }{{.*}}
+! CHECK:      acc.copyout accPtr(%[[COPYINREDR]] : !fir.ref<f32>) to varPtr(%{{.*}} : !fir.ref<f32>) dataClause(acc_reduction) implicit(true) name("reduction_r")
+! CHECK:      acc.copyout accPtr(%[[COPYINREDI]] : !fir.ref<i32>) to varPtr(%{{.*}} : !fir.ref<i32>) dataClause(acc_reduction) implicit(true) name("reduction_i")
 
 end subroutine acc_serial_loop

--- a/flang/test/Lower/OpenACC/acc-serial.f90
+++ b/flang/test/Lower/OpenACC/acc-serial.f90
@@ -145,7 +145,7 @@ subroutine acc_serial
 
 ! CHECK:      acc.serial {
 ! CHECK:        acc.yield
-! CHECK-NEXT: } attributes {selfAttr}
+! CHECK-NEXT: } selfAttr
 
   !$acc serial self(ifCondition)
   !$acc end serial
@@ -158,99 +158,99 @@ subroutine acc_serial
   !$acc serial copy(a, b, c)
   !$acc end serial
 
-! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "a"}
-! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "b"}
-! CHECK:      %[[COPYIN_C:.*]] = acc.copyin varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "c"}
+! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:      %[[COPYIN_C:.*]] = acc.copyin varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.serial dataOperands(%[[COPYIN_A]], %[[COPYIN_B]], %[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.yield
 ! CHECK-NEXT: }{{$}}
-! CHECK:      acc.copyout accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "a"}
-! CHECK:      acc.copyout accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "b"}
-! CHECK:      acc.copyout accPtr(%[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "c"}
+! CHECK:      acc.copyout accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("a")
+! CHECK:      acc.copyout accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("b")
+! CHECK:      acc.copyout accPtr(%[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("c")
 
   !$acc serial copy(a) copy(b) copy(c)
   !$acc end serial
 
-! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "a"}
-! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "b"}
-! CHECK:      %[[COPYIN_C:.*]] = acc.copyin varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "c"}
+! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:      %[[COPYIN_C:.*]] = acc.copyin varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.serial dataOperands(%[[COPYIN_A]], %[[COPYIN_B]], %[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.yield
 ! CHECK-NEXT: }{{$}}
-! CHECK:      acc.copyout accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "a"}
-! CHECK:      acc.copyout accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "b"}
-! CHECK:      acc.copyout accPtr(%[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "c"}
+! CHECK:      acc.copyout accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("a")
+! CHECK:      acc.copyout accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("b")
+! CHECK:      acc.copyout accPtr(%[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copy) name("c")
 
   !$acc serial copyin(a) copyin(readonly: b, c)
   !$acc end serial
 
-! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "a"}
-! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copyin_readonly>, name = "b"}
-! CHECK:      %[[COPYIN_C:.*]] = acc.copyin varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copyin_readonly>, name = "c"}
+! CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyin_readonly) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:      %[[COPYIN_C:.*]] = acc.copyin varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyin_readonly) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.serial dataOperands(%[[COPYIN_A]], %[[COPYIN_B]], %[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.yield
 ! CHECK-NEXT: }{{$}}
-! CHECK: acc.delete accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copyin>, name = "a"}
-! CHECK: acc.delete accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copyin_readonly>, name = "b"}
-! CHECK: acc.delete accPtr(%[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copyin_readonly>, name = "c"}
+! CHECK: acc.delete accPtr(%[[COPYIN_A]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyin) name("a")
+! CHECK: acc.delete accPtr(%[[COPYIN_B]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyin_readonly) name("b")
+! CHECK: acc.delete accPtr(%[[COPYIN_C]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyin_readonly) name("c")
 
   !$acc serial copyout(a) copyout(zero: b) copyout(c)
   !$acc end serial
 
-! CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copyout>, name = "a"}
-! CHECK: %[[CREATE_B:.*]] = acc.create varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copyout_zero>, name = "b"}
-! CHECK: %[[CREATE_C:.*]] = acc.create varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_copyout>, name = "c"}
+! CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyout) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK: %[[CREATE_B:.*]] = acc.create varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyout_zero) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK: %[[CREATE_C:.*]] = acc.create varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyout) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.serial dataOperands(%[[CREATE_A]], %[[CREATE_B]], %[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.yield
 ! CHECK-NEXT: }{{$}}
-! CHECK: acc.copyout accPtr(%[[CREATE_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) {name = "a"}
-! CHECK: acc.copyout accPtr(%[[CREATE_B]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_copyout_zero>, name = "b"}
-! CHECK: acc.copyout accPtr(%[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) {name = "c"}
+! CHECK: acc.copyout accPtr(%[[CREATE_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("a")
+! CHECK: acc.copyout accPtr(%[[CREATE_B]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_copyout_zero) name("b")
+! CHECK: acc.copyout accPtr(%[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("c")
 
   !$acc serial create(a, b) create(zero: c)
   !$acc end serial
 
-! CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "a"}
-! CHECK: %[[CREATE_B:.*]] = acc.create varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "b"}
-! CHECK: %[[CREATE_C:.*]] = acc.create varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_create_zero>, name = "c"}
+! CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK: %[[CREATE_B:.*]] = acc.create varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK: %[[CREATE_C:.*]] = acc.create varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_create_zero) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.serial dataOperands(%[[CREATE_A]], %[[CREATE_B]], %[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.yield
 ! CHECK-NEXT: }{{$}}
-! CHECK: acc.delete accPtr(%[[CREATE_A]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_create>, name = "a"}
-! CHECK: acc.delete accPtr(%[[CREATE_B]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_create>, name = "b"}
-! CHECK: acc.delete accPtr(%[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_create_zero>, name = "c"}
+! CHECK: acc.delete accPtr(%[[CREATE_A]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_create) name("a")
+! CHECK: acc.delete accPtr(%[[CREATE_B]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_create) name("b")
+! CHECK: acc.delete accPtr(%[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_create_zero) name("c")
 
   !$acc serial no_create(a, b) create(zero: c)
   !$acc end serial
 
-! CHECK: %[[NO_CREATE_A:.*]] = acc.nocreate varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "a"}
-! CHECK: %[[NO_CREATE_B:.*]] = acc.nocreate varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "b"}
-! CHECK: %[[CREATE_C:.*]] = acc.create varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_create_zero>, name = "c"}
+! CHECK: %[[NO_CREATE_A:.*]] = acc.nocreate varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK: %[[NO_CREATE_B:.*]] = acc.nocreate varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK: %[[CREATE_C:.*]] = acc.create varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_create_zero) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.serial dataOperands(%[[NO_CREATE_A]], %[[NO_CREATE_B]], %[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.yield
 ! CHECK-NEXT: }{{$}}
-! CHECK: acc.delete accPtr(%[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_create_zero>, name = "c"}
-! CHECK: acc.delete accPtr(%[[NO_CREATE_A]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_no_create>, name = "a"}
-! CHECK: acc.delete accPtr(%[[NO_CREATE_B]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_no_create>, name = "b"}
+! CHECK: acc.delete accPtr(%[[CREATE_C]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_create_zero) name("c")
+! CHECK: acc.delete accPtr(%[[NO_CREATE_A]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_no_create) name("a")
+! CHECK: acc.delete accPtr(%[[NO_CREATE_B]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_no_create) name("b")
 
   !$acc serial present(a, b, c)
   !$acc end serial
 
-! CHECK: %[[PRESENT_A:.*]] = acc.present varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "a"}
-! CHECK: %[[PRESENT_B:.*]] = acc.present varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "b"}
-! CHECK: %[[PRESENT_C:.*]] = acc.present varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "c"}
+! CHECK: %[[PRESENT_A:.*]] = acc.present varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK: %[[PRESENT_B:.*]] = acc.present varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK: %[[PRESENT_C:.*]] = acc.present varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.serial dataOperands(%[[PRESENT_A]], %[[PRESENT_B]], %[[PRESENT_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.yield
 ! CHECK-NEXT: }{{$}}
-! CHECK: acc.delete accPtr(%[[PRESENT_A]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_present>, name = "a"}
-! CHECK: acc.delete accPtr(%[[PRESENT_B]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_present>, name = "b"}
-! CHECK: acc.delete accPtr(%[[PRESENT_C]] : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_present>, name = "c"}
+! CHECK: acc.delete accPtr(%[[PRESENT_A]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_present) name("a")
+! CHECK: acc.delete accPtr(%[[PRESENT_B]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_present) name("b")
+! CHECK: acc.delete accPtr(%[[PRESENT_C]] : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_present) name("c")
 
   !$acc serial deviceptr(a) deviceptr(c)
   !$acc end serial
 
-! CHECK: %[[DEVICEPTR_A:.*]] = acc.deviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "a"}
-! CHECK: %[[DEVICEPTR_C:.*]] = acc.deviceptr varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "c"}
+! CHECK: %[[DEVICEPTR_A:.*]] = acc.deviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK: %[[DEVICEPTR_C:.*]] = acc.deviceptr varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.serial dataOperands(%[[DEVICEPTR_A]], %[[DEVICEPTR_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.yield
 ! CHECK-NEXT: }{{$}}
@@ -258,20 +258,20 @@ subroutine acc_serial
   !$acc serial attach(d, e)
   !$acc end serial
 
-! CHECK: %[[ATTACH_D:.*]] = acc.attach varPtr(%[[DECLD]]#0 : !fir.ref<!fir.box<!fir.ptr<f32>>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>> {name = "d"}
-! CHECK: %[[ATTACH_E:.*]] = acc.attach varPtr(%[[DECLE]]#0 : !fir.ref<!fir.box<!fir.ptr<f32>>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>> {name = "e"}
+! CHECK: %[[ATTACH_D:.*]] = acc.attach varPtr(%[[DECLD]]#0 : !fir.ref<!fir.box<!fir.ptr<f32>>>) name("d") -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+! CHECK: %[[ATTACH_E:.*]] = acc.attach varPtr(%[[DECLE]]#0 : !fir.ref<!fir.box<!fir.ptr<f32>>>) name("e") -> !fir.ref<!fir.box<!fir.ptr<f32>>>
 ! CHECK:      acc.serial dataOperands(%[[ATTACH_D]], %[[ATTACH_E]] : !fir.ref<!fir.box<!fir.ptr<f32>>>, !fir.ref<!fir.box<!fir.ptr<f32>>>) {
 ! CHECK:        acc.yield
 ! CHECK-NEXT: }{{$}}
-! CHECK: acc.detach accPtr(%[[ATTACH_D]] : !fir.ref<!fir.box<!fir.ptr<f32>>>) {dataClause = #acc<data_clause acc_attach>, name = "d"}
-! CHECK: acc.detach accPtr(%[[ATTACH_E]] : !fir.ref<!fir.box<!fir.ptr<f32>>>) {dataClause = #acc<data_clause acc_attach>, name = "e"}
+! CHECK: acc.detach accPtr(%[[ATTACH_D]] : !fir.ref<!fir.box<!fir.ptr<f32>>>) dataClause(acc_attach) name("d")
+! CHECK: acc.detach accPtr(%[[ATTACH_E]] : !fir.ref<!fir.box<!fir.ptr<f32>>>) dataClause(acc_attach) name("e")
 
   !$acc serial private(a) firstprivate(b) private(c)
   !$acc end serial
 
-! CHECK:      %[[ACC_PRIVATE_A:.*]] = acc.private varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) recipe(@privatization_ref_10x10xf32) -> !fir.ref<!fir.array<10x10xf32>> {name = "a"}
-! CHECK:      %[[ACC_FPRIVATE_B:.*]] = acc.firstprivate varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) recipe(@firstprivatization_ref_10x10xf32) -> !fir.ref<!fir.array<10x10xf32>> {name = "b"}
-! CHECK:      %[[ACC_PRIVATE_C:.*]] = acc.private varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) recipe(@privatization_ref_10x10xf32) -> !fir.ref<!fir.array<10x10xf32>> {name = "c"}
+! CHECK:      %[[ACC_PRIVATE_A:.*]] = acc.private varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) recipe(@privatization_ref_10x10xf32) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:      %[[ACC_FPRIVATE_B:.*]] = acc.firstprivate varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) recipe(@firstprivatization_ref_10x10xf32) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK:      %[[ACC_PRIVATE_C:.*]] = acc.private varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) recipe(@privatization_ref_10x10xf32) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK:      acc.serial firstprivate(%[[ACC_FPRIVATE_B]] : !fir.ref<!fir.array<10x10xf32>>) private(%[[ACC_PRIVATE_A]], %[[ACC_PRIVATE_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
 ! CHECK:        acc.yield
 ! CHECK-NEXT: }{{$}}
@@ -279,8 +279,8 @@ subroutine acc_serial
 !$acc serial reduction(+:reduction_r) reduction(*:reduction_i)
 !$acc end serial
 
-! CHECK:      %[[REDUCTION_R:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_add_ref_f32) -> !fir.ref<f32> {name = "reduction_r"}
-! CHECK:      %[[REDUCTION_I:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<i32>) recipe(@reduction_mul_ref_i32) -> !fir.ref<i32> {name = "reduction_i"}
+! CHECK:      %[[REDUCTION_R:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<f32>) recipe(@reduction_add_ref_f32) name("reduction_r") -> !fir.ref<f32>
+! CHECK:      %[[REDUCTION_I:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<i32>) recipe(@reduction_mul_ref_i32) name("reduction_i") -> !fir.ref<i32>
 ! CHECK:      acc.serial reduction(%[[REDUCTION_R]], %[[REDUCTION_I]] : !fir.ref<f32>, !fir.ref<i32>) {
 ! CHECK:        acc.yield
 ! CHECK-NEXT: }{{$}}
@@ -289,12 +289,12 @@ subroutine acc_serial
 !$acc end serial
 
 ! CHECK: acc.serial {
-! CHECK: } attributes {defaultAttr = #acc<defaultvalue none>}
+! CHECK: } defaultAttr(none)
 
 !$acc serial default(present)
 !$acc end serial
 
 ! CHECK: acc.serial {
-! CHECK: } attributes {defaultAttr = #acc<defaultvalue present>}
+! CHECK: } defaultAttr(present)
 
 end subroutine

--- a/flang/test/Lower/OpenACC/acc-set.f90
+++ b/flang/test/Lower/OpenACC/acc-set.f90
@@ -32,8 +32,8 @@ end
 ! CHECK: %[[C0:.*]] = arith.constant 0 : i32
 ! CHECK: acc.set device_num(%[[C0]] : i32)
 
-! CHECK: acc.set attributes {device_type = #acc.device_type<star>}
+! CHECK: acc.set device_type(#acc.device_type<star>)
 
-! CHECK: acc.set attributes {device_type = #acc.device_type<multicore>}
+! CHECK: acc.set device_type(#acc.device_type<multicore>)
 
 

--- a/flang/test/Lower/OpenACC/acc-shutdown.f90
+++ b/flang/test/Lower/OpenACC/acc-shutdown.f90
@@ -23,9 +23,9 @@ subroutine acc_shutdown
 
   !$acc shutdown device_num(1) device_type(default, nvidia)
 !CHECK: [[DEVNUM:%.*]] = arith.constant 1 : i32
-!CHECK: acc.shutdown device_num([[DEVNUM]] : i32) attributes {device_types = [#acc.device_type<default>, #acc.device_type<nvidia>]}
+!CHECK: acc.shutdown device_num([[DEVNUM]] : i32) device_types([#acc.device_type<default>, #acc.device_type<nvidia>])
 
   !$acc shutdown device_type(default) device_type(nvidia)
-!CHECK: acc.shutdown attributes {device_types = [#acc.device_type<default>, #acc.device_type<nvidia>]}
+!CHECK: acc.shutdown device_types([#acc.device_type<default>, #acc.device_type<nvidia>])
 
 end subroutine acc_shutdown

--- a/flang/test/Lower/OpenACC/acc-unstructured.f90
+++ b/flang/test/Lower/OpenACC/acc-unstructured.f90
@@ -41,7 +41,7 @@ end subroutine
 
 ! Body looks unstructured (if/stop) but the wrap-in-execute-region pass hides
 ! the unstructured CFG inside scf.execute_region, so the DOs lower as
-! structured acc.loop control(...) = ... (no `unstructured` attribute). GOTO
+! structured acc.loop control(...) = ... (no `unstructured ` attribute). GOTO
 ! exiting a combined OpenACC region is not yet implemented in lowering, so
 ! there's no genuinely-unstructured counterpart for this combined form.
 subroutine test_unstructured2(a, b, c)
@@ -185,7 +185,7 @@ end subroutine
 ! CHECK: arith.cmpf ogt
 ! CHECK: fir.store %{{.*}} to %{{.*}} : !fir.ref<i32>
 ! CHECK: acc.yield
-! CHECK: } attributes {seq = [#acc.device_type<none>], unstructured}
+! CHECK: } seq unstructured
 
 ! Test GOTO exiting acc.loop with intermediate code between loop end and
 ! target. A jump table (exit selector + dispatch) skips the intermediate code.
@@ -210,7 +210,7 @@ end subroutine
 ! CHECK: acc.loop
 ! CHECK: fir.store %{{.*}} to %{{.*}} : !fir.ref<i32>
 ! CHECK: acc.yield
-! CHECK: } attributes {seq = [#acc.device_type<none>], unstructured}
+! CHECK: } seq unstructured
 ! Jump table after inner loop:
 ! CHECK: fir.load %{{.*}} : !fir.ref<i32>
 ! CHECK: arith.cmpi eq
@@ -273,8 +273,8 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPtest_unstructured_collapse_cycle
 ! CHECK: acc.serial combined(loop)
 ! Both induction variables (j and i) are privatized:
-! CHECK: %[[PRIVJ:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "j"}
-! CHECK: %[[PRIVI:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK: %[[PRIVJ:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("j") -> !fir.ref<i32>
+! CHECK: %[[PRIVI:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! No control(...) on acc.loop — bounds are not on the op:
 ! CHECK: acc.loop combined(serial) private(%[[PRIVJ]], %[[PRIVI]] : !fir.ref<i32>, !fir.ref<i32>) {
 ! Outer loop trip-count test (j) emitted as cf:
@@ -291,7 +291,7 @@ end subroutine
 
 ! `acc serial loop collapse(N)` with STOP in body: wrap-in-execute-region hides
 ! the unstructured if/stop and the three collapsed iterators lower as a single
-! structured acc.loop control(...) (no `unstructured` attribute).
+! structured acc.loop control(...) (no `unstructured ` attribute).
 subroutine test_unstructured_collapse_stop(a)
   integer :: i, j, k
   real :: a(:,:,:)
@@ -307,14 +307,14 @@ end subroutine
 
 ! CHECK-LABEL: func.func @_QPtest_unstructured_collapse_stop
 ! All three IVs privatized:
-! CHECK: acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
-! CHECK: acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "j"}
-! CHECK: acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "k"}
+! CHECK: acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
+! CHECK: acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("j") -> !fir.ref<i32>
+! CHECK: acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("k") -> !fir.ref<i32>
 ! CHECK: acc.loop combined(serial) private({{.*}}) control({{.*}}) = ({{.*}}) to ({{.*}}) step ({{.*}}) {
 ! CHECK: scf.execute_region
 ! CHECK: fir.call @_FortranAStopStatementText
 ! CHECK-NOT: unstructured
-! CHECK: } attributes {collapse = [3]{{.*}}}
+! CHECK: } {{.*}}collapse([3]){{.*}}
 
 ! Test orphaned `acc loop collapse(N)`
 subroutine test_unstructured_collapse_loop_only(a)
@@ -336,7 +336,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPtest_unstructured_collapse_loop_only
 ! Standalone acc.loop (no `combined(...)`):
 ! CHECK: acc.loop private(%{{.*}}, %{{.*}} : !fir.ref<i32>, !fir.ref<i32>) {
-! CHECK: } attributes {collapse = [2], collapseDeviceType = [#acc.device_type<none>], independent = [#acc.device_type<none>], unstructured}
+! CHECK: } collapse([2]) collapseDeviceType([#acc.device_type<none>]) independent unstructured
 
 ! Standalone `acc loop seq` with STOP: wrap-in-execute-region hides the
 ! if/stop and the DO lowers as structured acc.loop control(...) (no
@@ -357,10 +357,10 @@ end subroutine
 ! CHECK: scf.execute_region
 ! CHECK: fir.call @_FortranAStopStatementText
 ! CHECK-NOT: unstructured
-! CHECK: } attributes {{{.*}}seq = [#acc.device_type<none>]{{.*}}}
+! CHECK: } {{.*}}seq{{.*}}
 
 ! Same loop but the if-construct has a GOTO exiting all loops, so the
-! if-construct is not wrappable, the DO remains unstructured, and acc.loop
+! if-construct is not wrappable, the DO remains unstructured , and acc.loop
 ! emits the unstructured form with the `unstructured` attribute.
 subroutine test_unstructured_loop_seq_goto(a)
   integer :: i, j
@@ -377,7 +377,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPtest_unstructured_loop_seq_goto
 ! CHECK: acc.loop private({{.*}}) {
 ! CHECK: cf.br
-! CHECK: } attributes {{{.*}}seq = [#acc.device_type<none>], unstructured}
+! CHECK: } {{.*}}seq{{.*}}unstructured
 
 ! Standalone `acc loop auto` with STOP: same wrap-makes-structured behavior.
 subroutine test_unstructured_loop_auto_stop(a)
@@ -396,7 +396,7 @@ end subroutine
 ! CHECK: scf.execute_region
 ! CHECK: fir.call @_FortranAStopStatementText
 ! CHECK-NOT: unstructured
-! CHECK: } attributes {auto_ = [#acc.device_type<none>]{{.*}}}
+! CHECK: } {{.*}}auto_{{.*}}
 
 ! Same loop with GOTO exit: genuinely unstructured, `unstructured` attribute
 ! is emitted on acc.loop.
@@ -415,7 +415,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPtest_unstructured_loop_auto_goto
 ! CHECK: acc.loop private({{.*}}) {
 ! CHECK: cf.br
-! CHECK: } attributes {auto_ = [#acc.device_type<none>], {{.*}}unstructured}
+! CHECK: } {{.*}}auto_{{.*}}unstructured
 
 ! Standalone `acc loop` inside `acc serial` with STOP: wrap-makes-structured.
 subroutine test_unstructured_loop_in_serial_stop(a)
@@ -472,7 +472,7 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPtest_unstructured_orphan_loop_in_seq_routine_goto
 ! CHECK: acc.loop private({{.*}}) {
 ! CHECK: cf.br
-! CHECK: } attributes {{{.*}}seq = [#acc.device_type<none>], unstructured}
+! CHECK: } {{.*}}seq{{.*}}unstructured
 
 ! DO loop with STOP inside `!$acc kernels`. Previously flagged as
 ! "unstructured do loop in acc kernels" (TODO); wrap-in-execute-region now

--- a/flang/test/Lower/OpenACC/acc-update.f90
+++ b/flang/test/Lower/OpenACC/acc-update.f90
@@ -15,101 +15,101 @@ subroutine acc_update
 ! CHECK: %[[DECLC:.*]]:2 = hlfir.declare %[[C]]
 
   !$acc update host(a)
-! CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_update_host>, name = "a", structured = false}
+! CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_update_host) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK: acc.update dataOperands(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>){{$}}
-! CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) {name = "a", structured = false}
+! CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("a")
 
   !$acc update host(a) if_present
-! CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_update_host>, name = "a", structured = false}
-! CHECK: acc.update dataOperands(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) attributes {ifPresent}{{$}}
-! CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) {name = "a", structured = false}
+! CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_update_host) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK: acc.update dataOperands(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) ifPresent
+! CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("a")
 
   !$acc update host(a) if_present if_present
-! CHECK: acc.update dataOperands(%{{.*}} : !fir.ref<!fir.array<10x10xf32>>) attributes {ifPresent}{{$}}
+! CHECK: acc.update dataOperands(%{{.*}} : !fir.ref<!fir.array<10x10xf32>>) ifPresent
 
   !$acc update self(a)
-! CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_update_self>, name = "a", structured = false}
+! CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_update_self) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK: acc.update dataOperands(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>){{$}}
-! CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) {dataClause = #acc<data_clause acc_update_self>, name = "a", structured = false}
+! CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_update_self) structured(false) name("a")
 
   !$acc update host(a) if(.true.)
-! CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_update_host>, name = "a", structured = false}
+! CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_update_host) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK: %[[IF1:.*]] = arith.constant true
 ! CHECK: acc.update if(%[[IF1]]) dataOperands(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>){{$}}
-! CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) {name = "a", structured = false}
+! CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("a")
 
   !$acc update host(a) if(ifCondition)
-! CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_update_host>, name = "a", structured = false}
+! CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_update_host) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK: %[[IFCOND:.*]] = fir.load %{{.*}} : !fir.ref<!fir.logical<4>>
 ! CHECK: %[[IF2:.*]] = fir.convert %[[IFCOND]] : (!fir.logical<4>) -> i1
 ! CHECK: acc.update if(%[[IF2]]) dataOperands(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>){{$}}
-! CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) {name = "a", structured = false}
+! CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("a")
 
   !$acc update host(a) host(b) host(c)
-! CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_update_host>, name = "a", structured = false}
-! CHECK: %[[DEVPTR_B:.*]] = acc.getdeviceptr varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_update_host>, name = "b", structured = false}
-! CHECK: %[[DEVPTR_C:.*]] = acc.getdeviceptr varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_update_host>, name = "c", structured = false}
+! CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_update_host) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK: %[[DEVPTR_B:.*]] = acc.getdeviceptr varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_update_host) structured(false) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK: %[[DEVPTR_C:.*]] = acc.getdeviceptr varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_update_host) structured(false) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK: acc.update dataOperands(%[[DEVPTR_A]], %[[DEVPTR_B]], %[[DEVPTR_C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>){{$}}
-! CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) {name = "a", structured = false}
-! CHECK: acc.update_host accPtr(%[[DEVPTR_B]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) {name = "b", structured = false}
-! CHECK: acc.update_host accPtr(%[[DEVPTR_C]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) {name = "c", structured = false}
+! CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("a")
+! CHECK: acc.update_host accPtr(%[[DEVPTR_B]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("b")
+! CHECK: acc.update_host accPtr(%[[DEVPTR_C]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("c")
 
   !$acc update host(a) host(b) device(c)
-! CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_update_host>, name = "a", structured = false}
-! CHECK: %[[DEVPTR_B:.*]] = acc.getdeviceptr varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_update_host>, name = "b", structured = false}
-! CHECK: %[[DEVPTR_C:.*]] = acc.update_device varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {name = "c", structured = false}
+! CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_update_host) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK: %[[DEVPTR_B:.*]] = acc.getdeviceptr varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_update_host) structured(false) name("b") -> !fir.ref<!fir.array<10x10xf32>>
+! CHECK: %[[DEVPTR_C:.*]] = acc.update_device varPtr(%[[DECLC]]#0 : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("c") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK: acc.update dataOperands(%[[DEVPTR_C]], %[[DEVPTR_A]], %[[DEVPTR_B]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>){{$}}
-! CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) {name = "a", structured = false}
-! CHECK: acc.update_host accPtr(%[[DEVPTR_B]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) {name = "b", structured = false}
+! CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("a")
+! CHECK: acc.update_host accPtr(%[[DEVPTR_B]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLB]]#0 : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("b")
 
   !$acc update host(a) async
-! CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) async -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_update_host>, name = "a", structured = false}
+! CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) async dataClause(acc_update_host) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK: acc.update async dataOperands(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>)
-! CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) async to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) {name = "a", structured = false}
+! CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) async to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("a")
 
   !$acc update host(a) wait
-! CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_update_host>, name = "a", structured = false}
+! CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_update_host) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK: acc.update wait dataOperands(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>)
-! CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) {name = "a", structured = false}
+! CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("a")
 
   !$acc update host(a) async wait
-! CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) async -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_update_host>, name = "a", structured = false}
+! CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) async dataClause(acc_update_host) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK: acc.update async wait dataOperands(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>)
-! CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) async to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) {name = "a", structured = false}
+! CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) async to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("a")
 
   !$acc update host(a) async(1)
 ! CHECK: [[ASYNC1:%.*]] = arith.constant 1 : i32
-! CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) async([[ASYNC1]] : i32) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_update_host>, name = "a", structured = false}
+! CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) async([[ASYNC1]] : i32) dataClause(acc_update_host) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK: acc.update async([[ASYNC1]] : i32) dataOperands(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>)
-! CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) async([[ASYNC1]] : i32) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) {name = "a", structured = false}
+! CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) async([[ASYNC1]] : i32) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("a")
 
   !$acc update host(a) async(async)
 ! CHECK: [[ASYNC2:%.*]] = fir.load %{{.*}} : !fir.ref<i32>
-! CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) async([[ASYNC2]] : i32) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_update_host>, name = "a", structured = false}
+! CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) async([[ASYNC2]] : i32) dataClause(acc_update_host) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK: acc.update async([[ASYNC2]] : i32) dataOperands(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>)
-! CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) async([[ASYNC2]] : i32) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) {name = "a", structured = false}
+! CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) async([[ASYNC2]] : i32) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("a")
 
   !$acc update host(a) wait(1)
 ! CHECK: [[WAIT1:%.*]] = arith.constant 1 : i32
-! CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_update_host>, name = "a", structured = false}
+! CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_update_host) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK: acc.update wait({[[WAIT1]] : i32}) dataOperands(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>)
-! CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) {name = "a", structured = false}
+! CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("a")
 
   !$acc update host(a) wait(queues: 1, 2)
 ! CHECK: [[WAIT2:%.*]] = arith.constant 1 : i32
 ! CHECK: [[WAIT3:%.*]] = arith.constant 2 : i32
-! CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_update_host>, name = "a", structured = false}
+! CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_update_host) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK: acc.update wait({[[WAIT2]] : i32, [[WAIT3]] : i32}) dataOperands(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>)
-! CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) {name = "a", structured = false}
+! CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("a")
 
   !$acc update host(a) wait(devnum: 1: queues: 1, 2)
-! CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_update_host>, name = "a", structured = false}
+! CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) dataClause(acc_update_host) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK: acc.update wait({devnum: %c1{{.*}} : i32, %c1{{.*}} : i32, %c2{{.*}} : i32}) dataOperands(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>)
-! CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) {name = "a", structured = false}
+! CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("a")
 
   !$acc update host(a) device_type(host, nvidia) async
-! CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) async([#acc.device_type<host>, #acc.device_type<nvidia>]) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_update_host>, name = "a", structured = false}
+! CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) async([#acc.device_type<host>, #acc.device_type<nvidia>]) dataClause(acc_update_host) structured(false) name("a") -> !fir.ref<!fir.array<10x10xf32>>
 ! CHECK: acc.update async([#acc.device_type<host>, #acc.device_type<nvidia>]) dataOperands(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>)
-! CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) async([#acc.device_type<host>, #acc.device_type<nvidia>]) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) {name = "a", structured = false}
+! CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) async([#acc.device_type<host>, #acc.device_type<nvidia>]) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) structured(false) name("a")
 
 end subroutine acc_update

--- a/flang/test/Lower/OpenACC/acc-use-device-remapping.f90
+++ b/flang/test/Lower/OpenACC/acc-use-device-remapping.f90
@@ -73,7 +73,7 @@ end subroutine
 ! CHECK:           %[[DUMMY_SCOPE_0:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK:           %[[DECLARE_0:.*]]:2 = hlfir.declare %[[ARG0]] dummy_scope %[[DUMMY_SCOPE_0]] arg 1 {uniq_name = "_QFtest_scalar_compEobj"} : (!fir.ref<!fir.type<_QMmhdata_typesTt_scalar{x:i32,y:f32}>>, !fir.dscope) -> (!fir.ref<!fir.type<_QMmhdata_typesTt_scalar{x:i32,y:f32}>>, !fir.ref<!fir.type<_QMmhdata_typesTt_scalar{x:i32,y:f32}>>)
 ! CHECK:           %[[DESIGNATE_0:.*]] = hlfir.designate %[[DECLARE_0]]#0{"y"}   : (!fir.ref<!fir.type<_QMmhdata_typesTt_scalar{x:i32,y:f32}>>) -> !fir.ref<f32>
-! CHECK:           %[[USE_DEVICE_0:.*]] = acc.use_device varPtr(%[[DESIGNATE_0]] : !fir.ref<f32>) -> !fir.ref<f32> {name = "obj%y"}
+! CHECK:           %[[USE_DEVICE_0:.*]] = acc.use_device varPtr(%[[DESIGNATE_0]] : !fir.ref<f32>) name("obj%y") -> !fir.ref<f32>
 ! CHECK:           acc.host_data dataOperands(%[[USE_DEVICE_0]] : !fir.ref<f32>) {
 ! CHECK:             %[[DECLARE_1:.*]]:2 = hlfir.declare %[[USE_DEVICE_0]] {uniq_name = "obj%y"} : (!fir.ref<f32>) -> (!fir.ref<f32>, !fir.ref<f32>)
 ! CHECK:             fir.call @_QPfoo_scalar(%[[DECLARE_1]]#0) fastmath<contract> : (!fir.ref<f32>) -> ()
@@ -89,7 +89,7 @@ end subroutine
 ! CHECK:           %[[CONSTANT_0:.*]] = arith.constant 10 : index
 ! CHECK:           %[[SHAPE_0:.*]] = fir.shape %[[CONSTANT_0]] : (index) -> !fir.shape<1>
 ! CHECK:           %[[DESIGNATE_0:.*]] = hlfir.designate %[[DECLARE_0]]#0{"y"}   shape %[[SHAPE_0]] : (!fir.ref<!fir.type<_QMmhdata_typesTt_array{x:i32,y:!fir.array<10xf32>}>>, !fir.shape<1>) -> !fir.ref<!fir.array<10xf32>>
-! CHECK:           %[[USE_DEVICE_0:.*]] = acc.use_device varPtr(%[[DESIGNATE_0]] : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "obj%y"}
+! CHECK:           %[[USE_DEVICE_0:.*]] = acc.use_device varPtr(%[[DESIGNATE_0]] : !fir.ref<!fir.array<10xf32>>) name("obj%y") -> !fir.ref<!fir.array<10xf32>>
 ! CHECK:           acc.host_data dataOperands(%[[USE_DEVICE_0]] : !fir.ref<!fir.array<10xf32>>) {
 ! CHECK:             %[[DECLARE_1:.*]]:2 = hlfir.declare %[[USE_DEVICE_0]](%[[SHAPE_0]]) {uniq_name = "obj%y"} : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> (!fir.ref<!fir.array<10xf32>>, !fir.ref<!fir.array<10xf32>>)
 ! CHECK:             fir.call @_QPfoo_array(%[[DECLARE_1]]#0) fastmath<contract> : (!fir.ref<!fir.array<10xf32>>) -> ()
@@ -104,7 +104,7 @@ end subroutine
 ! CHECK:           %[[DECLARE_0:.*]]:2 = hlfir.declare %[[ARG0]] dummy_scope %[[DUMMY_SCOPE_0]] arg 1 {uniq_name = "_QFtest_character_compEobj"} : (!fir.ref<!fir.type<_QMmhdata_typesTt_character{x:i32,y:!fir.char<1,5>}>>, !fir.dscope) -> (!fir.ref<!fir.type<_QMmhdata_typesTt_character{x:i32,y:!fir.char<1,5>}>>, !fir.ref<!fir.type<_QMmhdata_typesTt_character{x:i32,y:!fir.char<1,5>}>>)
 ! CHECK:           %[[CONSTANT_0:.*]] = arith.constant 5 : index
 ! CHECK:           %[[DESIGNATE_0:.*]] = hlfir.designate %[[DECLARE_0]]#0{"y"}   typeparams %[[CONSTANT_0]] : (!fir.ref<!fir.type<_QMmhdata_typesTt_character{x:i32,y:!fir.char<1,5>}>>, index) -> !fir.ref<!fir.char<1,5>>
-! CHECK:           %[[USE_DEVICE_0:.*]] = acc.use_device varPtr(%[[DESIGNATE_0]] : !fir.ref<!fir.char<1,5>>) -> !fir.ref<!fir.char<1,5>> {name = "obj%y"}
+! CHECK:           %[[USE_DEVICE_0:.*]] = acc.use_device varPtr(%[[DESIGNATE_0]] : !fir.ref<!fir.char<1,5>>) name("obj%y") -> !fir.ref<!fir.char<1,5>>
 ! CHECK:           acc.host_data dataOperands(%[[USE_DEVICE_0]] : !fir.ref<!fir.char<1,5>>) {
 ! CHECK:             %[[DECLARE_1:.*]]:2 = hlfir.declare %[[USE_DEVICE_0]] typeparams %[[CONSTANT_0]] {uniq_name = "obj%y"} : (!fir.ref<!fir.char<1,5>>, index) -> (!fir.ref<!fir.char<1,5>>, !fir.ref<!fir.char<1,5>>)
 ! CHECK:             %[[EMBOXCHAR_0:.*]] = fir.emboxchar %[[DECLARE_1]]#0, %[[CONSTANT_0]] : (!fir.ref<!fir.char<1,5>>, index) -> !fir.boxchar<1>
@@ -119,7 +119,7 @@ end subroutine
 ! CHECK:           %[[DUMMY_SCOPE_0:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK:           %[[DECLARE_0:.*]]:2 = hlfir.declare %[[ARG0]] dummy_scope %[[DUMMY_SCOPE_0]] arg 1 {uniq_name = "_QFtest_pointer_compEobj"} : (!fir.ref<!fir.type<_QMmhdata_typesTt_pointer{x:i32,y:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>, !fir.dscope) -> (!fir.ref<!fir.type<_QMmhdata_typesTt_pointer{x:i32,y:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>, !fir.ref<!fir.type<_QMmhdata_typesTt_pointer{x:i32,y:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>)
 ! CHECK:           %[[DESIGNATE_0:.*]] = hlfir.designate %[[DECLARE_0]]#0{"y"}   {fortran_attrs = #fir.var_attrs<pointer>} : (!fir.ref<!fir.type<_QMmhdata_typesTt_pointer{x:i32,y:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
-! CHECK:           %[[USE_DEVICE_0:.*]] = acc.use_device varPtr(%[[DESIGNATE_0]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>> {name = "obj%y"}
+! CHECK:           %[[USE_DEVICE_0:.*]] = acc.use_device varPtr(%[[DESIGNATE_0]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) name("obj%y") -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
 ! CHECK:           acc.host_data dataOperands(%[[USE_DEVICE_0]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) {
 ! CHECK:             %[[DECLARE_1:.*]]:2 = hlfir.declare %[[USE_DEVICE_0]] {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "obj%y"} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>)
 ! CHECK:             fir.call @_QPfoo_pointer(%[[DECLARE_1]]#0) fastmath<contract> : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) -> ()

--- a/flang/test/Lower/OpenACC/acc-use-device.f90
+++ b/flang/test/Lower/OpenACC/acc-use-device.f90
@@ -11,19 +11,19 @@ subroutine test()
 ! CHECK: %[[A:.*]]:2 = hlfir.declare %[[A0]](%[[A1]]) {uniq_name = "_QFtestEb"} : (!fir.ref<!fir.array<?xf64>>, !fir.shapeshift<1>) -> (!fir.box<!fir.array<?xf64>>, !fir.ref<!fir.array<?xf64>>)
 
   !$acc data copy(b)
-! CHECK: %[[B:.*]] = acc.copyin var(%[[A]]#0 : !fir.box<!fir.array<?xf64>>) -> !fir.box<!fir.array<?xf64>> {dataClause = #acc<data_clause acc_copy>, name = "b"}
+! CHECK: %[[B:.*]] = acc.copyin var(%[[A]]#0 : !fir.box<!fir.array<?xf64>>) dataClause(acc_copy) name("b") -> !fir.box<!fir.array<?xf64>>
 ! CHECK: acc.data dataOperands(%[[B]] : !fir.box<!fir.array<?xf64>>) {
 
   !$acc host_data use_device(b)
   call vadd(b)
   !$acc end host_data
-! CHECK: %[[C:.*]] = acc.use_device var(%[[A]]#0 : !fir.box<!fir.array<?xf64>>) -> !fir.box<!fir.array<?xf64>> {name = "b"}
+! CHECK: %[[C:.*]] = acc.use_device var(%[[A]]#0 : !fir.box<!fir.array<?xf64>>) name("b") -> !fir.box<!fir.array<?xf64>>
 ! CHECK: acc.host_data dataOperands(%[[C]] : !fir.box<!fir.array<?xf64>>) {
 ! CHECK: %[[ADDR:.*]] = fir.box_addr %[[C]] 
 ! CHECK: %[[REDCLARE:.*]]:2 = hlfir.declare %[[ADDR]]
 ! CHECK: fir.call @_QPvadd(%[[REDCLARE]]#1) fastmath<contract> : (!fir.ref<!fir.array<?xf64>>) -> ()
   !$acc end data
-! CHECK: acc.copyout accVar(%[[B]] : !fir.box<!fir.array<?xf64>>) to var(%[[A]]#0 : !fir.box<!fir.array<?xf64>>) {dataClause = #acc<data_clause acc_copy>, name = "b"}
+! CHECK: acc.copyout accVar(%[[B]] : !fir.box<!fir.array<?xf64>>) to var(%[[A]]#0 : !fir.box<!fir.array<?xf64>>) dataClause(acc_copy) name("b")
 end
 
 ! Test for allocatable, pointer and assumed-shape variables appearing in use_device clause.
@@ -46,9 +46,9 @@ subroutine test2(a, b, c)
   call vadd2(a,b,c)
   !$acc end host_data
 
-! CHECK: %[[H:.*]] = acc.use_device varPtr(%[[E]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf64>>>>) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf64>>>> {name = "a"}
-! CHECK: %[[J:.*]] = acc.use_device var(%[[F]]#0 : !fir.box<!fir.array<?xf64>>) -> !fir.box<!fir.array<?xf64>> {name = "b"}
-! CHECK: %[[L:.*]] = acc.use_device varPtr(%[[G]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>> {name = "c"}
+! CHECK: %[[H:.*]] = acc.use_device varPtr(%[[E]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf64>>>>) name("a") -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf64>>>>
+! CHECK: %[[J:.*]] = acc.use_device var(%[[F]]#0 : !fir.box<!fir.array<?xf64>>) name("b") -> !fir.box<!fir.array<?xf64>>
+! CHECK: %[[L:.*]] = acc.use_device varPtr(%[[G]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>) name("c") -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>
 ! CHECK: acc.host_data dataOperands(%[[H]], %[[J]], %[[L]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf64>>>>, !fir.box<!fir.array<?xf64>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>) {
 
 

--- a/flang/test/Lower/OpenACC/do-concurrent-collapse.f90
+++ b/flang/test/Lower/OpenACC/do-concurrent-collapse.f90
@@ -22,7 +22,7 @@ end subroutine
 ! CHECK: hlfir.designate
 ! CHECK: arith.addi %{{.*}}, %{{.*}} : i32
 ! CHECK: hlfir.assign %{{.*}} to %{{.*}} : i32, !fir.ref<i32>
-! CHECK: collapse = [3]
+! CHECK: collapse([3])
 
 ! collapse(force:N) on a DO CONCURRENT must lower the body too (force takes a
 ! different path in Bridge.cpp).
@@ -41,4 +41,4 @@ end subroutine
 ! CHECK: acc.loop combined(parallel)
 ! CHECK-SAME: control(%{{[a-z_0-9]+}} : i32, %{{[a-z_0-9]+}} : i32, %{{[a-z_0-9]+}} : i32)
 ! CHECK: hlfir.assign %{{.*}} to %{{.*}} : i32, !fir.ref<i32>
-! CHECK: collapse = [3]
+! CHECK: collapse([3])

--- a/flang/test/Lower/OpenACC/do-loops-to-acc-loops.f90
+++ b/flang/test/Lower/OpenACC/do-loops-to-acc-loops.f90
@@ -18,14 +18,14 @@ subroutine basic_do_loop()
   !$acc end kernels
 
 ! CHECK: acc.kernels {
-! CHECK: %[[PRIVATE_IV:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK: %[[PRIVATE_IV:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK: acc.loop private(%[[PRIVATE_IV]] : !fir.ref<i32>) control(%{{.*}} : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32)
 ! CHECK: %[[PRIVATE_DECLARE:.*]]:2 = hlfir.declare %[[PRIVATE_IV]] {uniq_name = "_QFbasic_do_loopEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK: fir.store %{{.*}} to %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: %{{.*}} = fir.load %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: %{{.*}} = fir.load %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: acc.yield
-! CHECK: attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+! CHECK: inclusiveUpperbound(array<i1: true>) auto_
 
 ! CHECK-NOACCLOOP-LABEL: func.func @_QPbasic_do_loop
 ! CHECK-NOACCLOOP: acc.kernels {
@@ -47,14 +47,14 @@ subroutine basic_do_concurrent()
   !$acc end kernels
 
 ! CHECK: acc.kernels {
-! CHECK: %[[PRIVATE_IV:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK: %[[PRIVATE_IV:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK: acc.loop private(%[[PRIVATE_IV]] : !fir.ref<i32>) control(%{{.*}} : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32)
 ! CHECK: %[[PRIVATE_DECLARE:.*]]:2 = hlfir.declare %[[PRIVATE_IV]] {uniq_name = "_QFbasic_do_concurrentEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK: fir.store %{{.*}} to %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: %{{.*}} = fir.load %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: %{{.*}} = fir.load %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: acc.yield
-! CHECK: attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+! CHECK: inclusiveUpperbound(array<i1: true>) auto_
 
 ! CHECK-NOACCLOOP-LABEL: func.func @_QPbasic_do_concurrent
 ! CHECK-NOACCLOOP: acc.kernels {
@@ -76,14 +76,14 @@ subroutine basic_do_loop_parallel()
   !$acc end parallel
 
 ! CHECK: acc.parallel {
-! CHECK: %[[PRIVATE_IV:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK: %[[PRIVATE_IV:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK: acc.loop private(%[[PRIVATE_IV]] : !fir.ref<i32>) control(%{{.*}} : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32)
 ! CHECK: %[[PRIVATE_DECLARE:.*]]:2 = hlfir.declare %[[PRIVATE_IV]] {uniq_name = "_QFbasic_do_loop_parallelEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK: fir.store %{{.*}} to %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: %{{.*}} = fir.load %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: %{{.*}} = fir.load %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: acc.yield
-! CHECK: attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+! CHECK: inclusiveUpperbound(array<i1: true>) auto_
 
 ! CHECK-NOACCLOOP-LABEL: func.func @_QPbasic_do_loop_parallel
 ! CHECK-NOACCLOOP: acc.parallel {
@@ -105,14 +105,14 @@ subroutine basic_do_loop_serial()
   !$acc end serial
 
 ! CHECK: acc.serial {
-! CHECK: %[[PRIVATE_IV:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK: %[[PRIVATE_IV:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK: acc.loop private(%[[PRIVATE_IV]] : !fir.ref<i32>) control(%{{.*}} : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32)
 ! CHECK: %[[PRIVATE_DECLARE:.*]]:2 = hlfir.declare %[[PRIVATE_IV]] {uniq_name = "_QFbasic_do_loop_serialEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK: fir.store %{{.*}} to %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: %{{.*}} = fir.load %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: %{{.*}} = fir.load %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: acc.yield
-! CHECK: attributes {inclusiveUpperbound = array<i1: true>, seq = [#acc.device_type<none>]}
+! CHECK: inclusiveUpperbound(array<i1: true>) seq
 
 ! CHECK-NOACCLOOP-LABEL: func.func @_QPbasic_do_loop_serial
 ! CHECK-NOACCLOOP: acc.serial {
@@ -134,14 +134,14 @@ subroutine basic_do_concurrent_parallel()
   !$acc end parallel
 
 ! CHECK: acc.parallel {
-! CHECK: %[[PRIVATE_IV:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK: %[[PRIVATE_IV:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK: acc.loop private(%[[PRIVATE_IV]] : !fir.ref<i32>) control(%{{.*}} : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32)
 ! CHECK: %[[PRIVATE_DECLARE:.*]]:2 = hlfir.declare %[[PRIVATE_IV]] {uniq_name = "_QFbasic_do_concurrent_parallelEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK: fir.store %{{.*}} to %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: %{{.*}} = fir.load %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: %{{.*}} = fir.load %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: acc.yield
-! CHECK: attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK: inclusiveUpperbound(array<i1: true>) independent
 
 ! CHECK-NOACCLOOP-LABEL: func.func @_QPbasic_do_concurrent_parallel
 ! CHECK-NOACCLOOP: acc.parallel {
@@ -163,14 +163,14 @@ subroutine basic_do_concurrent_serial()
   !$acc end serial
 
 ! CHECK: acc.serial {
-! CHECK: %[[PRIVATE_IV:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK: %[[PRIVATE_IV:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK: acc.loop private(%[[PRIVATE_IV]] : !fir.ref<i32>) control(%{{.*}} : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32)
 ! CHECK: %[[PRIVATE_DECLARE:.*]]:2 = hlfir.declare %[[PRIVATE_IV]] {uniq_name = "_QFbasic_do_concurrent_serialEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK: fir.store %{{.*}} to %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: %{{.*}} = fir.load %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: %{{.*}} = fir.load %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: acc.yield
-! CHECK: attributes {inclusiveUpperbound = array<i1: true>, seq = [#acc.device_type<none>]}
+! CHECK: inclusiveUpperbound(array<i1: true>) seq
 
 ! CHECK-NOACCLOOP-LABEL: func.func @_QPbasic_do_concurrent_serial
 ! CHECK-NOACCLOOP: acc.serial {
@@ -192,9 +192,9 @@ subroutine multi_dimension_do_concurrent()
   !$acc end kernels
 
 ! CHECK: acc.kernels {
-! CHECK-DAG: %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
-! CHECK-DAG: %[[PRIVATE_J:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "j"}
-! CHECK-DAG: %[[PRIVATE_K:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "k"}
+! CHECK-DAG: %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
+! CHECK-DAG: %[[PRIVATE_J:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("j") -> !fir.ref<i32>
+! CHECK-DAG: %[[PRIVATE_K:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("k") -> !fir.ref<i32>
 ! CHECK: acc.loop private(%[[PRIVATE_I]], %[[PRIVATE_J]], %[[PRIVATE_K]] : !fir.ref<i32>, !fir.ref<i32>, !fir.ref<i32>) control(%{{.*}} : i32, %{{.*}} : i32, %{{.*}} : i32) = (%c1{{.*}}, %c1{{.*}}, %c1{{.*}} : i32, i32, i32) to (%{{.*}}, %{{.*}}, %{{.*}} : i32, i32, i32) step (%c1{{.*}}, %c1{{.*}}, %c1{{.*}} : i32, i32, i32)
 ! CHECK-DAG: %[[PRIVATE_I_DECLARE:.*]]:2 = hlfir.declare %[[PRIVATE_I]] {uniq_name = "_QFmulti_dimension_do_concurrentEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK-DAG: %[[PRIVATE_J_DECLARE:.*]]:2 = hlfir.declare %[[PRIVATE_J]] {uniq_name = "_QFmulti_dimension_do_concurrentEj"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
@@ -209,7 +209,7 @@ subroutine multi_dimension_do_concurrent()
 ! CHECK: %{{.*}} = fir.load %[[PRIVATE_J_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: %{{.*}} = fir.load %[[PRIVATE_K_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: acc.yield
-! CHECK: attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true, true, true>}
+! CHECK: inclusiveUpperbound(array<i1: true, true, true>) auto_
 
 ! CHECK-NOACCLOOP-LABEL: func.func @_QPmulti_dimension_do_concurrent
 ! CHECK-NOACCLOOP: acc.kernels {
@@ -234,11 +234,11 @@ subroutine nested_do_loops()
   !$acc end kernels
 
 ! CHECK: acc.kernels {
-! CHECK-DAG: %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK-DAG: %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK: acc.loop private(%[[PRIVATE_I]] : !fir.ref<i32>) control(%{{.*}} : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32)
 ! CHECK-DAG: %[[PRIVATE_I_DECLARE:.*]]:2 = hlfir.declare %[[PRIVATE_I]] {uniq_name = "_QFnested_do_loopsEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK: fir.store %{{.*}} to %[[PRIVATE_I_DECLARE]]#0 : !fir.ref<i32>
-! CHECK-DAG: %[[PRIVATE_J:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "j"}
+! CHECK-DAG: %[[PRIVATE_J:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("j") -> !fir.ref<i32>
 ! CHECK: acc.loop private(%[[PRIVATE_J]] : !fir.ref<i32>) control(%{{.*}} : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32)
 ! CHECK-DAG: %[[PRIVATE_J_DECLARE:.*]]:2 = hlfir.declare %[[PRIVATE_J]] {uniq_name = "_QFnested_do_loopsEj"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK: fir.store %{{.*}} to %[[PRIVATE_J_DECLARE]]#0 : !fir.ref<i32>
@@ -247,9 +247,9 @@ subroutine nested_do_loops()
 ! CHECK: %{{.*}} = fir.load %[[PRIVATE_I_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: %{{.*}} = fir.load %[[PRIVATE_J_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: acc.yield
-! CHECK: attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+! CHECK: inclusiveUpperbound(array<i1: true>) auto_
 ! CHECK: acc.yield
-! CHECK: attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+! CHECK: inclusiveUpperbound(array<i1: true>) auto_
 
 ! CHECK-NOACCLOOP-LABEL: func.func @_QPnested_do_loops
 ! CHECK-NOACCLOOP: acc.kernels {
@@ -271,14 +271,14 @@ subroutine variable_bounds_and_step(n, start_val, step_val)
   !$acc end kernels
 
 ! CHECK: acc.kernels {
-! CHECK: %[[PRIVATE_IV:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK: %[[PRIVATE_IV:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK: acc.loop private(%[[PRIVATE_IV]] : !fir.ref<i32>) control(%{{.*}} : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32)
 ! CHECK: %[[PRIVATE_DECLARE:.*]]:2 = hlfir.declare %[[PRIVATE_IV]] {uniq_name = "_QFvariable_bounds_and_stepEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK: fir.store %{{.*}} to %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: %{{.*}} = fir.load %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: %{{.*}} = fir.load %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: acc.yield
-! CHECK: attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+! CHECK: inclusiveUpperbound(array<i1: true>) auto_
 
 ! CHECK-NOACCLOOP-LABEL: func.func @_QPvariable_bounds_and_step
 ! CHECK-NOACCLOOP: acc.kernels {
@@ -314,21 +314,21 @@ subroutine different_iv_types()
   !$acc end kernels
 
 ! CHECK: acc.kernels {
-! CHECK: %[[PRIVATE_I8:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i64>) recipe(@privatization_ref_i64) -> !fir.ref<i64> {implicit = true, name = "i8"}
+! CHECK: %[[PRIVATE_I8:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i64>) recipe(@privatization_ref_i64) implicit(true) name("i8") -> !fir.ref<i64>
 ! CHECK: acc.loop private(%[[PRIVATE_I8]] : !fir.ref<i64>) control(%{{.*}} : i64) = (%{{.*}} : i64) to (%{{.*}} : i64) step (%{{.*}} : i64)
 ! CHECK: %[[PRIVATE_I8_DECLARE:.*]]:2 = hlfir.declare %[[PRIVATE_I8]] {uniq_name = "_QFdifferent_iv_typesEi8"} : (!fir.ref<i64>) -> (!fir.ref<i64>, !fir.ref<i64>)
 ! CHECK: fir.store %{{.*}} to %[[PRIVATE_I8_DECLARE]]#0 : !fir.ref<i64>
 ! CHECK: %{{.*}} = fir.load %[[PRIVATE_I8_DECLARE]]#0 : !fir.ref<i64>
 ! CHECK: %{{.*}} = fir.load %[[PRIVATE_I8_DECLARE]]#0 : !fir.ref<i64>
 ! CHECK: acc.kernels {
-! CHECK: %[[PRIVATE_I4:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i4"}
+! CHECK: %[[PRIVATE_I4:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i4") -> !fir.ref<i32>
 ! CHECK: acc.loop private(%[[PRIVATE_I4]] : !fir.ref<i32>) control(%{{.*}} : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32)
 ! CHECK: %[[PRIVATE_I4_DECLARE:.*]]:2 = hlfir.declare %[[PRIVATE_I4]] {uniq_name = "_QFdifferent_iv_typesEi4"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK: fir.store %{{.*}} to %[[PRIVATE_I4_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: %{{.*}} = fir.load %[[PRIVATE_I4_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: %{{.*}} = fir.load %[[PRIVATE_I4_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: acc.kernels {
-! CHECK: %[[PRIVATE_I2:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i16>) recipe(@privatization_ref_i16) -> !fir.ref<i16> {implicit = true, name = "i2"}
+! CHECK: %[[PRIVATE_I2:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i16>) recipe(@privatization_ref_i16) implicit(true) name("i2") -> !fir.ref<i16>
 ! CHECK: acc.loop private(%[[PRIVATE_I2]] : !fir.ref<i16>) control(%{{.*}} : i16) = (%{{.*}} : i16) to (%{{.*}} : i16) step (%{{.*}} : i16)
 ! CHECK: %[[PRIVATE_I2_DECLARE:.*]]:2 = hlfir.declare %[[PRIVATE_I2]] {uniq_name = "_QFdifferent_iv_typesEi2"} : (!fir.ref<i16>) -> (!fir.ref<i16>, !fir.ref<i16>)
 ! CHECK: fir.store %{{.*}} to %[[PRIVATE_I2_DECLARE]]#0 : !fir.ref<i16>
@@ -359,13 +359,13 @@ subroutine nested_loop_with_reduction(x, y)
   !$acc end parallel
 
 ! CHECK: acc.parallel {
-! CHECK: %[[REDUCTION_X:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<i32>) recipe(@reduction_add_ref_i32) -> !fir.ref<i32> {name = "x"}
-! CHECK: %[[REDUCTION_Y:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<i32>) recipe(@reduction_add_ref_i32) -> !fir.ref<i32> {name = "y"}
-! CHECK: %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK: %[[REDUCTION_X:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<i32>) recipe(@reduction_add_ref_i32) name("x") -> !fir.ref<i32>
+! CHECK: %[[REDUCTION_Y:.*]] = acc.reduction varPtr(%{{.*}} : !fir.ref<i32>) recipe(@reduction_add_ref_i32) name("y") -> !fir.ref<i32>
+! CHECK: %[[PRIVATE_I:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK: acc.loop private(%[[PRIVATE_I]] : !fir.ref<i32>) reduction(%[[REDUCTION_X]], %[[REDUCTION_Y]] : !fir.ref<i32>, !fir.ref<i32>) control(%{{.*}} : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32)
 ! CHECK: %[[PRIVATE_I_DECLARE:.*]]:2 = hlfir.declare %[[PRIVATE_I]] {uniq_name = "_QFnested_loop_with_reductionEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK: fir.store %{{.*}} to %[[PRIVATE_I_DECLARE]]#0 : !fir.ref<i32>
-! CHECK: %[[PRIVATE_J:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "j"}
+! CHECK: %[[PRIVATE_J:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("j") -> !fir.ref<i32>
 ! CHECK: acc.loop private(%[[PRIVATE_J]] : !fir.ref<i32>) control(%{{.*}} : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32)
 ! CHECK: %[[PRIVATE_J_DECLARE:.*]]:2 = hlfir.declare %[[PRIVATE_J]] {uniq_name = "_QFnested_loop_with_reductionEj"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK: fir.store %{{.*}} to %[[PRIVATE_J_DECLARE]]#0 : !fir.ref<i32>
@@ -373,12 +373,12 @@ subroutine nested_loop_with_reduction(x, y)
 ! CHECK: %{{.*}} = arith.addi %{{.*}}, %{{.*}} : i32
 ! CHECK: hlfir.assign %{{.*}} to %{{.*}} : i32, !fir.ref<i32>
 ! CHECK: acc.yield
-! CHECK: attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+! CHECK: inclusiveUpperbound(array<i1: true>) auto_
 ! CHECK: %{{.*}} = fir.load %{{.*}} : !fir.ref<i32>
 ! CHECK: %{{.*}} = arith.addi %{{.*}}, %{{.*}} : i32
 ! CHECK: hlfir.assign %{{.*}} to %{{.*}} : i32, !fir.ref<i32>
 ! CHECK: acc.yield
-! CHECK: attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK: inclusiveUpperbound(array<i1: true>) independent
 
 ! CHECK-NOACCLOOP-LABEL: func.func @_QPnested_loop_with_reduction
 ! CHECK-NOACCLOOP: acc.parallel {
@@ -388,7 +388,7 @@ subroutine nested_loop_with_reduction(x, y)
 end subroutine
 
 ! -----------------------------------------------------------------------------------------
-! Tests for loops that should NOT be converted to acc.loop due to unstructured control flow
+! Tests for loops that should NOT be converted to acc.loop due to unstructured  control flow
 
 ! CHECK-LABEL: func.func @_QPinfinite_loop_no_iv
 subroutine infinite_loop_no_iv()
@@ -443,16 +443,16 @@ subroutine routine_do_loop()
     a(i) = b(i) + 1.0
   end do
 
-! CHECK: %[[PRIVATE_IV:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK: %[[PRIVATE_IV:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK: acc.loop private(%[[PRIVATE_IV]] : !fir.ref<i32>) control(%{{.*}} : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32)
 ! CHECK: %[[PRIVATE_DECLARE:.*]]:2 = hlfir.declare %[[PRIVATE_IV]] {uniq_name = "_QFroutine_do_loopEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK: fir.store %{{.*}} to %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: %{{.*}} = fir.load %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: %{{.*}} = fir.load %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: acc.yield
-! CHECK: attributes {inclusiveUpperbound = array<i1: true>, seq = [#acc.device_type<none>]}
-! CHECK-NOT: auto_ = [#acc.device_type
-! CHECK-NOT: independent = [#acc.device_type
+! CHECK: inclusiveUpperbound(array<i1: true>) seq
+! CHECK-NOT: auto_  = [#acc.device_type
+! CHECK-NOT: independent  = [#acc.device_type
 
 end subroutine
 
@@ -470,15 +470,15 @@ subroutine routine_do_concurrent()
     a(i) = b(i) + 1.0
   end do
 
-! CHECK: %[[PRIVATE_IV:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK: %[[PRIVATE_IV:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK: acc.loop private(%[[PRIVATE_IV]] : !fir.ref<i32>) control(%{{.*}} : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32)
 ! CHECK: %[[PRIVATE_DECLARE:.*]]:2 = hlfir.declare %[[PRIVATE_IV]] {uniq_name = "_QFroutine_do_concurrentEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK: fir.store %{{.*}} to %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: %{{.*}} = fir.load %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: %{{.*}} = fir.load %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: acc.yield
-! CHECK: attributes {inclusiveUpperbound = array<i1: true>, seq = [#acc.device_type<none>]}
-! CHECK-NOT: independent = [#acc.device_type
+! CHECK: inclusiveUpperbound(array<i1: true>) seq
+! CHECK-NOT: independent  = [#acc.device_type
 
 end subroutine
 
@@ -496,16 +496,16 @@ subroutine routine_do_loop_nonseq()
     a(i) = b(i) + 1.0
   end do
 
-! CHECK: %[[PRIVATE_IV:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK: %[[PRIVATE_IV:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK: acc.loop private(%[[PRIVATE_IV]] : !fir.ref<i32>) control(%{{.*}} : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32)
 ! CHECK: %[[PRIVATE_DECLARE:.*]]:2 = hlfir.declare %[[PRIVATE_IV]] {uniq_name = "_QFroutine_do_loop_nonseqEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK: fir.store %{{.*}} to %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: %{{.*}} = fir.load %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: %{{.*}} = fir.load %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: acc.yield
-! CHECK: attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
-! CHECK-NOT: seq = [#acc.device_type
-! CHECK-NOT: independent = [#acc.device_type
+! CHECK: inclusiveUpperbound(array<i1: true>) auto_
+! CHECK-NOT: seq  = [#acc.device_type
+! CHECK-NOT: independent  = [#acc.device_type
 
 end subroutine
 
@@ -523,15 +523,15 @@ subroutine routine_do_concurrent_nonseq()
     a(i) = b(i) + 1.0
   end do
 
-! CHECK: %[[PRIVATE_IV:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK: %[[PRIVATE_IV:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
 ! CHECK: acc.loop private(%[[PRIVATE_IV]] : !fir.ref<i32>) control(%{{.*}} : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32)
 ! CHECK: %[[PRIVATE_DECLARE:.*]]:2 = hlfir.declare %[[PRIVATE_IV]] {uniq_name = "_QFroutine_do_concurrent_nonseqEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK: fir.store %{{.*}} to %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: %{{.*}} = fir.load %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: %{{.*}} = fir.load %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
 ! CHECK: acc.yield
-! CHECK: attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
-! CHECK-NOT: seq = [#acc.device_type
-! CHECK-NOT: auto_ = [#acc.device_type
+! CHECK: inclusiveUpperbound(array<i1: true>) independent
+! CHECK-NOT: seq  = [#acc.device_type
+! CHECK-NOT: auto_  = [#acc.device_type
 
 end subroutine

--- a/flang/test/Lower/OpenACC/locations.f90
+++ b/flang/test/Lower/OpenACC/locations.f90
@@ -53,7 +53,7 @@ module acc_locations
     !CHECK: acc.loop
 
     !CHECK:        acc.yield loc("{{.*}}locations.f90":44:11)
-    !CHECK-NEXT: } attributes {{.*}} loc(fused<#acc.loop_loc<directive = loc("{{[^"]*}}locations.f90":44:11), loops = loc("{{[^"]*}}locations.f90":45:5)>>["{{[^"]*}}locations.f90":44:11, "{{[^"]*}}locations.f90":45:5])
+    !CHECK-NEXT: } {{.*}} loc(fused<#acc.loop_loc<directive = loc("{{[^"]*}}locations.f90":44:11), loops = loc("{{[^"]*}}locations.f90":45:5)>>["{{[^"]*}}locations.f90":44:11, "{{[^"]*}}locations.f90":45:5])
 
     !CHECK:        acc.yield loc("{{.*}}locations.f90":43:11)
     !CHECK-NEXT: } loc("{{.*}}locations.f90":43:11)
@@ -169,7 +169,7 @@ module acc_locations
 
 ! CHECK-LABEL: func.func @_QMacc_locationsPacc_loop_fused_locations
 ! CHECK: acc.loop
-! CHECK: } attributes {collapse = [3]{{.*}}} loc(fused<#acc.loop_loc<directive = loc("{{[^"]*}}locations.f90":160:11), loops = loc("{{[^"]*}}locations.f90":161:5), loc("{{[^"]*}}locations.f90":162:7), loc("{{[^"]*}}locations.f90":163:9)>>["{{[^"]*}}locations.f90":160:11, "{{[^"]*}}locations.f90":161:5, "{{[^"]*}}locations.f90":162:7, "{{[^"]*}}locations.f90":163:9])
+! CHECK: } {{.*}}collapse([3]){{.*}} loc(fused<#acc.loop_loc<directive = loc("{{[^"]*}}locations.f90":160:11), loops = loc("{{[^"]*}}locations.f90":161:5), loc("{{[^"]*}}locations.f90":162:7), loc("{{[^"]*}}locations.f90":163:9)>>["{{[^"]*}}locations.f90":160:11, "{{[^"]*}}locations.f90":161:5, "{{[^"]*}}locations.f90":162:7, "{{[^"]*}}locations.f90":163:9])
 
   subroutine data_end_locations(arr)
     real, dimension(10) :: arr
@@ -196,5 +196,5 @@ module acc_locations
 
 ! CHECK-LABEL: func.func @_QMacc_locationsPacc_kernel_with_loop_locations
 ! CHECK: acc.loop
-! CHECK: } attributes {{.*}} loc(fused<#acc.loop_loc<loops = loc("{{[^"]*}}locations.f90":191:5)>>["{{[^"]*}}locations.f90":191:5])
+! CHECK: } {{.*}} loc(fused<#acc.loop_loc<loops = loc("{{[^"]*}}locations.f90":191:5)>>["{{[^"]*}}locations.f90":191:5])
 end module

--- a/flang/test/Lower/host_module_variable_instantiation_use_device.f90
+++ b/flang/test/Lower/host_module_variable_instantiation_use_device.f90
@@ -38,7 +38,7 @@ end module
 !  CHECK:           %[[CONSTANT_0:.*]] = arith.constant 100 : index
 !  CHECK:           %[[SHAPE_0:.*]] = fir.shape %[[CONSTANT_0]] : (index) -> !fir.shape<1>
 !  CHECK:           %[[DECLARE_0:.*]]:2 = hlfir.declare %[[ADDRESS_OF_0]](%[[SHAPE_0]]) {uniq_name = "_QMtest_use_deviceEa"} : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>) -> (!fir.ref<!fir.array<100xf32>>, !fir.ref<!fir.array<100xf32>>)
-!  CHECK:           %[[USE_DEVICE_0:.*]] = acc.use_device varPtr(%[[DECLARE_0]]#0 : !fir.ref<!fir.array<100xf32>>) -> !fir.ref<!fir.array<100xf32>> {name = "a"}
+!  CHECK:           %[[USE_DEVICE_0:.*]] = acc.use_device varPtr(%[[DECLARE_0]]#0 : !fir.ref<!fir.array<100xf32>>) name("a") -> !fir.ref<!fir.array<100xf32>>
 !  CHECK:           acc.host_data dataOperands(%[[USE_DEVICE_0]] : !fir.ref<!fir.array<100xf32>>) {
 !  CHECK:             %[[DECLARE_1:.*]]:2 = hlfir.declare %[[USE_DEVICE_0]](%[[SHAPE_0]]) {uniq_name = "_QMtest_use_deviceEa"} : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>) -> (!fir.ref<!fir.array<100xf32>>, !fir.ref<!fir.array<100xf32>>)
 !  CHECK:             fir.call @_QPsomething(%[[DECLARE_1]]#0)

--- a/flang/test/Transforms/OpenACC/acc-compute-region-licm.fir
+++ b/flang/test/Transforms/OpenACC/acc-compute-region-licm.fir
@@ -30,7 +30,7 @@ func.func @test_parallel_canMoveOutOf(%arg0: !fir.ref<!fir.array<10xf32>>) {
         %idx = fir.convert %iv : (i32) -> index
         memref.store %cst, %cvt_ref[%idx] : memref<10xf32>
         acc.yield
-      } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+      } inclusiveUpperbound(array<i1: true>) independent
       acc.yield
     }
   }
@@ -63,7 +63,7 @@ func.func @test_kernels_canMoveOutOf(%arg0: !fir.ref<!fir.array<10xf32>>) {
         %idx = fir.convert %iv : (i32) -> index
         memref.store %cst, %cvt_ref[%idx] : memref<10xf32>
         acc.yield
-      } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+      } inclusiveUpperbound(array<i1: true>) independent
       acc.terminator
     }
   }
@@ -96,7 +96,7 @@ func.func @test_serial_canMoveOutOf(%arg0: !fir.ref<!fir.array<10xf32>>) {
         %idx = fir.convert %iv : (i32) -> index
         memref.store %cst, %cvt_ref[%idx] : memref<10xf32>
         acc.yield
-      } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+      } inclusiveUpperbound(array<i1: true>) independent
       acc.yield
     }
   }
@@ -138,7 +138,7 @@ func.func @test_parallel_transitive_canMoveOutOf(%arg0: !fir.ref<!fir.array<10xf
         %ref = fir.convert %addr : (i64) -> !fir.ref<f32>
         fir.store %cst to %ref : !fir.ref<f32>
         acc.yield
-      } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+      } inclusiveUpperbound(array<i1: true>) independent
       acc.yield
     }
   }

--- a/flang/test/Transforms/OpenACC/acc-emit-nyi-flang.fir
+++ b/flang/test/Transforms/OpenACC/acc-emit-nyi-flang.fir
@@ -33,7 +33,7 @@ func.func @directives(%ptr: !llvm.ptr, %v: memref<i32>,
     acc.loop combined(parallel) control(%iv : index) = (%c0 : index)
         to (%c1 : index) step (%c1 : index) {
       acc.yield
-    } attributes {independent = [#acc.device_type<none>]}
+    } independent
     acc.terminator
   }
   // expected-error @+1 {{not yet implemented: OpenACC kernels loop directive}}
@@ -42,7 +42,7 @@ func.func @directives(%ptr: !llvm.ptr, %v: memref<i32>,
     acc.loop combined(kernels) control(%iv : index) = (%c0 : index)
         to (%c1 : index) step (%c1 : index) {
       acc.yield
-    } attributes {independent = [#acc.device_type<none>]}
+    } independent
     acc.terminator
   }
   // expected-error @+1 {{not yet implemented: OpenACC serial loop directive}}
@@ -51,19 +51,19 @@ func.func @directives(%ptr: !llvm.ptr, %v: memref<i32>,
     acc.loop combined(serial) control(%iv : index) = (%c0 : index)
         to (%c1 : index) step (%c1 : index) {
       acc.yield
-    } attributes {independent = [#acc.device_type<none>]}
+    } independent
     acc.terminator
   }
 
   // expected-error @+1 {{not yet implemented: OpenACC data directive}}
   acc.data {
     acc.terminator
-  } attributes {defaultAttr = #acc<defaultvalue none>}
+  } defaultAttr(none)
   // expected-error @+1 {{not yet implemented: OpenACC loop directive}}
   acc.loop control(%iv : index) = (%c0 : index) to (%c1 : index)
       step (%c1 : index) {
     acc.yield
-  } attributes {independent = [#acc.device_type<none>]}
+  } independent
 
   // expected-error @+1 {{not yet implemented: OpenACC operation acc.copyin}}
   %copyin = acc.copyin varPtr(%ptr : !llvm.ptr) varType(i32) -> !llvm.ptr
@@ -86,7 +86,7 @@ func.func @directives(%ptr: !llvm.ptr, %v: memref<i32>,
   // expected-error @+1 {{not yet implemented: OpenACC shutdown directive}}
   acc.shutdown
   // expected-error @+1 {{not yet implemented: OpenACC set directive}}
-  acc.set attributes {device_type = #acc.device_type<nvidia>}
+  acc.set device_type(#acc.device_type<nvidia>)
   // expected-error @+1 {{not yet implemented: OpenACC wait directive}}
   acc.wait
 

--- a/flang/test/Transforms/OpenACC/acc-implicit-copy-reduction.fir
+++ b/flang/test/Transforms/OpenACC/acc-implicit-copy-reduction.fir
@@ -39,25 +39,25 @@ func.func @test_reduction_implicit_copy() {
   fir.store %c0_i32 to %r_decl : !fir.ref<i32>
 
   acc.parallel {
-    %red_var = acc.reduction varPtr(%r_decl : !fir.ref<i32>) recipe(@reduction_add_ref_i32) -> !fir.ref<i32> {name = "r"}
+    %red_var = acc.reduction varPtr(%r_decl : !fir.ref<i32>) recipe(@reduction_add_ref_i32) name("r") -> !fir.ref<i32>
     acc.loop reduction(%red_var : !fir.ref<i32>) control(%iv : i32) = (%c1_i32 : i32) to (%cN : i32) step (%c1_i32 : i32) {
       fir.store %iv to %i_decl : !fir.ref<i32>
       %cur_r = fir.load %red_var : !fir.ref<i32>
       %new_r = arith.addi %cur_r, %c1_i32 : i32
       fir.store %new_r to %red_var : !fir.ref<i32>
       acc.yield
-    } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+    } inclusiveUpperbound(array<i1: true>) independent
     acc.yield
   }
   return
 }
 
 // When enable-implicit-reduction-copy=true: expect copyin/copyout for reduction variable
-// COPY: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : !fir.ref<i32>) -> !fir.ref<i32> {dataClause = #acc<data_clause acc_reduction>, implicit = true, name = "r"}
-// COPY: acc.copyout accPtr(%[[COPYIN]] : !fir.ref<i32>) to varPtr({{.*}} : !fir.ref<i32>) {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "r"}
+// COPY: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : !fir.ref<i32>) dataClause(acc_reduction) implicit(true) name("r") -> !fir.ref<i32>
+// COPY: acc.copyout accPtr(%[[COPYIN]] : !fir.ref<i32>) to varPtr({{.*}} : !fir.ref<i32>) dataClause(acc_copy) implicit(true) name("r")
 
 // When enable-implicit-reduction-copy=false: expect firstprivate for reduction variable
-// FIRSTPRIVATE: acc.firstprivate varPtr({{.*}} : !fir.ref<i32>) recipe({{.*}}) -> !fir.ref<i32> {implicit = true, name = "r"}
+// FIRSTPRIVATE: acc.firstprivate varPtr({{.*}} : !fir.ref<i32>) recipe({{.*}}) implicit(true) name("r") -> !fir.ref<i32>
 // FIRSTPRIVATE-NOT: acc.copyin
 // FIRSTPRIVATE-NOT: acc.copyout
 
@@ -104,31 +104,31 @@ func.func @test_reduction_with_usage_outside_loop() {
   %out_decl = fir.declare %out {uniq_name = "_QFEout"} : (!fir.ref<i32>) -> !fir.ref<i32>
   fir.store %c0_i32 to %r_decl : !fir.ref<i32>
 
-  %out_copyout = acc.create varPtr(%out_decl : !fir.ref<i32>) -> !fir.ref<i32> {dataClause = #acc<data_clause acc_copyout>, name = "out"}
+  %out_copyout = acc.create varPtr(%out_decl : !fir.ref<i32>) dataClause(acc_copyout) name("out") -> !fir.ref<i32>
   acc.parallel dataOperands(%out_copyout : !fir.ref<i32>) {
-    %red_var = acc.reduction varPtr(%r_decl : !fir.ref<i32>) recipe(@reduction_add_ref_i32) -> !fir.ref<i32> {name = "r"}
+    %red_var = acc.reduction varPtr(%r_decl : !fir.ref<i32>) recipe(@reduction_add_ref_i32) name("r") -> !fir.ref<i32>
     acc.loop reduction(%red_var : !fir.ref<i32>) control(%iv : i32) = (%c1_i32 : i32) to (%cN : i32) step (%c1_i32 : i32) {
       fir.store %iv to %i_decl : !fir.ref<i32>
       %cur_r = fir.load %red_var : !fir.ref<i32>
       %new_r = arith.addi %cur_r, %c1_i32 : i32
       fir.store %new_r to %red_var : !fir.ref<i32>
       acc.yield
-    } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+    } inclusiveUpperbound(array<i1: true>) independent
     // out = r (usage of r outside the loop)
     %final_r = fir.load %r_decl : !fir.ref<i32>
     fir.store %final_r to %out_copyout : !fir.ref<i32>
     acc.yield
   }
-  acc.copyout accPtr(%out_copyout : !fir.ref<i32>) to varPtr(%out_decl : !fir.ref<i32>) {dataClause = #acc<data_clause acc_copyout>, name = "out"}
+  acc.copyout accPtr(%out_copyout : !fir.ref<i32>) to varPtr(%out_decl : !fir.ref<i32>) dataClause(acc_copyout) name("out")
   return
 }
 
 // In this case, r should be firstprivate regardless of the flag setting because it's used outside the reduction context
 // COPY-LABEL: func.func @test_reduction_with_usage_outside_loop
-// COPY: acc.firstprivate varPtr({{.*}} : !fir.ref<i32>) recipe({{.*}}) -> !fir.ref<i32> {implicit = true, name = "r"}
+// COPY: acc.firstprivate varPtr({{.*}} : !fir.ref<i32>) recipe({{.*}}) implicit(true) name("r") -> !fir.ref<i32>
 // COPY-NOT: acc.copyin varPtr({{.*}} : !fir.ref<i32>) -> !fir.ref<i32> {{.*}} name = "r"
 
 // FIRSTPRIVATE-LABEL: func.func @test_reduction_with_usage_outside_loop
-// FIRSTPRIVATE: acc.firstprivate varPtr({{.*}} : !fir.ref<i32>) recipe({{.*}}) -> !fir.ref<i32> {implicit = true, name = "r"}
+// FIRSTPRIVATE: acc.firstprivate varPtr({{.*}} : !fir.ref<i32>) recipe({{.*}}) implicit(true) name("r") -> !fir.ref<i32>
 // FIRSTPRIVATE-NOT: acc.copyin varPtr({{.*}} : !fir.ref<i32>) -> !fir.ref<i32> {{.*}} name = "r"
 

--- a/flang/test/Transforms/OpenACC/acc-implicit-data-derived-type-member.F90
+++ b/flang/test/Transforms/OpenACC/acc-implicit-data-derived-type-member.F90
@@ -27,12 +27,12 @@ program test
   !$acc end serial
 end program
 
-!CHECK: acc.copyin {{.*}} {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "d2"}
-!CHECK: acc.copyin {{.*}} {name = "d2%member0"}
-!CHECK: acc.copyin {{.*}} {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "d4"}
-!CHECK: acc.create {{.*}} {dataClause = #acc<data_clause acc_copyout>, name = "d4%member0"}
-!CHECK: acc.delete {{.*}} {dataClause = #acc<data_clause acc_copyin>, name = "d2%member0"}
-!CHECK: acc.copyout {{.*}} {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "d2"}
-!CHECK: acc.copyout {{.*}} {name = "d4%member0"}
-!CHECK: acc.copyout {{.*}} {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "d4"}
+!CHECK: acc.copyin {{.*}} dataClause(acc_copy) implicit(true) name("d2")
+!CHECK: acc.copyin {{.*}} name("d2%member0")
+!CHECK: acc.copyin {{.*}} dataClause(acc_copy) implicit(true) name("d4")
+!CHECK: acc.create {{.*}} dataClause(acc_copyout) name("d4%member0")
+!CHECK: acc.delete {{.*}} dataClause(acc_copyin) name("d2%member0")
+!CHECK: acc.copyout {{.*}} dataClause(acc_copy) implicit(true) name("d2")
+!CHECK: acc.copyout {{.*}} name("d4%member0")
+!CHECK: acc.copyout {{.*}} dataClause(acc_copy) implicit(true) name("d4")
 

--- a/flang/test/Transforms/OpenACC/acc-implicit-data-fortran.F90
+++ b/flang/test/Transforms/OpenACC/acc-implicit-data-fortran.F90
@@ -48,32 +48,32 @@ program main
 end program
 
 !CHECKHLFIR-LABEL: @_QQmain
-!CHECKHLFIR-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.type<_QFTaggr{field:f32}>>) -> !fir.ref<!fir.type<_QFTaggr{field:f32}>> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "aggrvar"}
-!CHECKHLFIR-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "arrayvar"}
-!CHECKHLFIR-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.type<_QFTnested{outer:!fir.type<_QFTaggr{field:f32}>}>>) -> !fir.ref<!fir.type<_QFTnested{outer:!fir.type<_QFTaggr{field:f32}>}>> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "nestaggrvar"}
-!CHECKHLFIR-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<complex<f32>>) -> !fir.ref<complex<f32>> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "scalarcomp"}
-!CHECKHLFIR-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<f32>) -> !fir.ref<f32> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "scalarvar"}
+!CHECKHLFIR-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.type<_QFTaggr{field:f32}>>) dataClause(acc_copy) implicit(true) name("aggrvar") -> !fir.ref<!fir.type<_QFTaggr{field:f32}>>
+!CHECKHLFIR-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) implicit(true) name("arrayvar") -> !fir.ref<!fir.array<10xf32>>
+!CHECKHLFIR-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.type<_QFTnested{outer:!fir.type<_QFTaggr{field:f32}>}>>) dataClause(acc_copy) implicit(true) name("nestaggrvar") -> !fir.ref<!fir.type<_QFTnested{outer:!fir.type<_QFTaggr{field:f32}>}>>
+!CHECKHLFIR-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<complex<f32>>) dataClause(acc_copy) implicit(true) name("scalarcomp") -> !fir.ref<complex<f32>>
+!CHECKHLFIR-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<f32>) dataClause(acc_copy) implicit(true) name("scalarvar") -> !fir.ref<f32>
 !CHECKHLFIR: acc.kernels
-!CHECKHLFIR-DAG: acc.copyin varPtr(%{{.*}}  : !fir.ref<!fir.type<_QFTaggr{field:f32}>>) -> !fir.ref<!fir.type<_QFTaggr{field:f32}>> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "aggrvar"}
-!CHECKHLFIR-DAG: acc.copyin varPtr(%{{.*}}  : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "arrayvar"}
-!CHECKHLFIR-DAG: acc.copyin varPtr(%{{.*}}  : !fir.ref<!fir.type<_QFTnested{outer:!fir.type<_QFTaggr{field:f32}>}>>) -> !fir.ref<!fir.type<_QFTnested{outer:!fir.type<_QFTaggr{field:f32}>}>> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "nestaggrvar"}
-!CHECKHLFIR-DAG: acc.firstprivate varPtr(%{{.*}}  : !fir.ref<complex<f32>>) recipe({{.*}}) -> !fir.ref<complex<f32>> {implicit = true, name = "scalarcomp"}
-!CHECKHLFIR-DAG: acc.firstprivate varPtr(%{{.*}}  : !fir.ref<f32>) recipe({{.*}}) -> !fir.ref<f32> {implicit = true, name = "scalarvar"}
+!CHECKHLFIR-DAG: acc.copyin varPtr(%{{.*}}  : !fir.ref<!fir.type<_QFTaggr{field:f32}>>) dataClause(acc_copy) implicit(true) name("aggrvar") -> !fir.ref<!fir.type<_QFTaggr{field:f32}>>
+!CHECKHLFIR-DAG: acc.copyin varPtr(%{{.*}}  : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) implicit(true) name("arrayvar") -> !fir.ref<!fir.array<10xf32>>
+!CHECKHLFIR-DAG: acc.copyin varPtr(%{{.*}}  : !fir.ref<!fir.type<_QFTnested{outer:!fir.type<_QFTaggr{field:f32}>}>>) dataClause(acc_copy) implicit(true) name("nestaggrvar") -> !fir.ref<!fir.type<_QFTnested{outer:!fir.type<_QFTaggr{field:f32}>}>>
+!CHECKHLFIR-DAG: acc.firstprivate varPtr(%{{.*}}  : !fir.ref<complex<f32>>) recipe({{.*}}) implicit(true) name("scalarcomp") -> !fir.ref<complex<f32>>
+!CHECKHLFIR-DAG: acc.firstprivate varPtr(%{{.*}}  : !fir.ref<f32>) recipe({{.*}}) implicit(true) name("scalarvar") -> !fir.ref<f32>
 !CHECKHLFIR: acc.parallel
 
 !CHECKCSE-LABEL: @_QQmain
-!CHECKCSE-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "arrayvar"}
-!CHECKCSE-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<complex<f32>>) -> !fir.ref<complex<f32>> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "scalarcomp"}
-!CHECKCSE-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<f32>) -> !fir.ref<f32> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "scalarvar"}
-!CHECKCSE-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<f32>) -> !fir.ref<f32> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "aggrvar%field"}
-!CHECKCSE-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<f32>) -> !fir.ref<f32> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "nestaggrvar%outer%field"}
-!CHECKCSE-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<f32>) -> !fir.ref<f32> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "arrayvar(2)"}
+!CHECKCSE-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) implicit(true) name("arrayvar") -> !fir.ref<!fir.array<10xf32>>
+!CHECKCSE-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<complex<f32>>) dataClause(acc_copy) implicit(true) name("scalarcomp") -> !fir.ref<complex<f32>>
+!CHECKCSE-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<f32>) dataClause(acc_copy) implicit(true) name("scalarvar") -> !fir.ref<f32>
+!CHECKCSE-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<f32>) dataClause(acc_copy) implicit(true) name("aggrvar%field") -> !fir.ref<f32>
+!CHECKCSE-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<f32>) dataClause(acc_copy) implicit(true) name("nestaggrvar%outer%field") -> !fir.ref<f32>
+!CHECKCSE-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<f32>) dataClause(acc_copy) implicit(true) name("arrayvar(2)") -> !fir.ref<f32>
 !CHECKCSE: acc.kernels
-!CHECKCSE-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "arrayvar"}
-!CHECKCSE-DAG: acc.firstprivate varPtr(%{{.*}} : !fir.ref<complex<f32>>) recipe({{.*}}) -> !fir.ref<complex<f32>> {implicit = true, name = "scalarcomp"}
-!CHECKCSE-DAG: acc.firstprivate varPtr(%{{.*}} : !fir.ref<f32>) recipe({{.*}}) -> !fir.ref<f32> {implicit = true, name = "scalarvar"}
-!CHECKCSE-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<f32>) -> !fir.ref<f32> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "aggrvar%field"}
-!CHECKCSE-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<f32>) -> !fir.ref<f32> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "nestaggrvar%outer%field"}
-!CHECKCSE-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<f32>) -> !fir.ref<f32> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "arrayvar(2)"}
+!CHECKCSE-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) implicit(true) name("arrayvar") -> !fir.ref<!fir.array<10xf32>>
+!CHECKCSE-DAG: acc.firstprivate varPtr(%{{.*}} : !fir.ref<complex<f32>>) recipe({{.*}}) implicit(true) name("scalarcomp") -> !fir.ref<complex<f32>>
+!CHECKCSE-DAG: acc.firstprivate varPtr(%{{.*}} : !fir.ref<f32>) recipe({{.*}}) implicit(true) name("scalarvar") -> !fir.ref<f32>
+!CHECKCSE-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<f32>) dataClause(acc_copy) implicit(true) name("aggrvar%field") -> !fir.ref<f32>
+!CHECKCSE-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<f32>) dataClause(acc_copy) implicit(true) name("nestaggrvar%outer%field") -> !fir.ref<f32>
+!CHECKCSE-DAG: acc.copyin varPtr(%{{.*}} : !fir.ref<f32>) dataClause(acc_copy) implicit(true) name("arrayvar(2)") -> !fir.ref<f32>
 !CHECKCSE: acc.parallel
 

--- a/flang/test/Transforms/OpenACC/acc-implicit-data.fir
+++ b/flang/test/Transforms/OpenACC/acc-implicit-data.fir
@@ -11,7 +11,7 @@ func.func @test_fir_scalar_in_serial() {
   return
 }
 
-// CHECK: acc.firstprivate varPtr({{.*}} : !fir.ref<i64>) recipe({{.*}}) -> !fir.ref<i64> {implicit = true, name = "scalarvar"}
+// CHECK: acc.firstprivate varPtr({{.*}} : !fir.ref<i64>) recipe({{.*}}) implicit(true) name("scalarvar") -> !fir.ref<i64>
 
 // -----
 
@@ -24,7 +24,7 @@ func.func @test_fir_scalar_in_parallel() {
   return
 }
 
-// CHECK: acc.firstprivate varPtr({{.*}} : !fir.ref<f32>) recipe({{.*}}) -> !fir.ref<f32> {implicit = true, name = "scalarvar"}
+// CHECK: acc.firstprivate varPtr({{.*}} : !fir.ref<f32>) recipe({{.*}}) implicit(true) name("scalarvar") -> !fir.ref<f32>
 
 // -----
 
@@ -37,8 +37,8 @@ func.func @test_fir_scalar_in_kernels() {
   return
 }
 
-// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : !fir.ref<f64>) -> !fir.ref<f64> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "scalarvar"}
-// CHECK: acc.copyout accPtr(%[[COPYIN]] : !fir.ref<f64>) to varPtr({{.*}} : !fir.ref<f64>) {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "scalarvar"}
+// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : !fir.ref<f64>) dataClause(acc_copy) implicit(true) name("scalarvar") -> !fir.ref<f64>
+// CHECK: acc.copyout accPtr(%[[COPYIN]] : !fir.ref<f64>) to varPtr({{.*}} : !fir.ref<f64>) dataClause(acc_copy) implicit(true) name("scalarvar")
 
 // -----
 
@@ -47,7 +47,7 @@ func.func @test_fir_scalar_in_parallel_defaultnone() {
   acc.parallel {
     %load = fir.load %livein : !fir.ref<f32>
     acc.yield
-  } attributes {defaultAttr = #acc<defaultvalue none>}
+  } defaultAttr(none)
   return
 }
 
@@ -60,7 +60,7 @@ func.func @test_fir_scalar_in_kernels_defaultnone() {
   acc.kernels {
     %load = fir.load %livein : !fir.ref<f64>
     acc.terminator
-  } attributes {defaultAttr = #acc<defaultvalue none>}
+  } defaultAttr(none)
   return
 }
 
@@ -77,8 +77,8 @@ func.func @test_fir_derivedtype_in_parallel() {
   return
 }
 
-// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : !fir.ref<!fir.type<_QFTaggr{field:f32}>>) -> !fir.ref<!fir.type<_QFTaggr{field:f32}>> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "aggrvar"}
-// CHECK: acc.copyout accPtr(%[[COPYIN]] : !fir.ref<!fir.type<_QFTaggr{field:f32}>>) to varPtr({{.*}} : !fir.ref<!fir.type<_QFTaggr{field:f32}>>) {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "aggrvar"}
+// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : !fir.ref<!fir.type<_QFTaggr{field:f32}>>) dataClause(acc_copy) implicit(true) name("aggrvar") -> !fir.ref<!fir.type<_QFTaggr{field:f32}>>
+// CHECK: acc.copyout accPtr(%[[COPYIN]] : !fir.ref<!fir.type<_QFTaggr{field:f32}>>) to varPtr({{.*}} : !fir.ref<!fir.type<_QFTaggr{field:f32}>>) dataClause(acc_copy) implicit(true) name("aggrvar")
 
 // -----
 
@@ -91,8 +91,8 @@ func.func @test_fir_derivedtype_in_kernels() {
   return
 }
 
-// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : !fir.ref<!fir.type<_QFTaggr{field:f32}>>) -> !fir.ref<!fir.type<_QFTaggr{field:f32}>> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "aggrvar"}
-// CHECK: acc.copyout accPtr(%[[COPYIN]] : !fir.ref<!fir.type<_QFTaggr{field:f32}>>) to varPtr({{.*}} : !fir.ref<!fir.type<_QFTaggr{field:f32}>>) {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "aggrvar"}
+// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : !fir.ref<!fir.type<_QFTaggr{field:f32}>>) dataClause(acc_copy) implicit(true) name("aggrvar") -> !fir.ref<!fir.type<_QFTaggr{field:f32}>>
+// CHECK: acc.copyout accPtr(%[[COPYIN]] : !fir.ref<!fir.type<_QFTaggr{field:f32}>>) to varPtr({{.*}} : !fir.ref<!fir.type<_QFTaggr{field:f32}>>) dataClause(acc_copy) implicit(true) name("aggrvar")
 
 // -----
 
@@ -105,8 +105,8 @@ func.func @test_fir_array_in_parallel() {
   return
 }
 
-// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "arrayvar"}
-// CHECK: acc.copyout accPtr(%[[COPYIN]] : !fir.ref<!fir.array<10xf32>>) to varPtr({{.*}} : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "arrayvar"}
+// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) implicit(true) name("arrayvar") -> !fir.ref<!fir.array<10xf32>>
+// CHECK: acc.copyout accPtr(%[[COPYIN]] : !fir.ref<!fir.array<10xf32>>) to varPtr({{.*}} : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) implicit(true) name("arrayvar")
 
 // -----
 
@@ -119,8 +119,8 @@ func.func @test_fir_array_in_kernels() {
   return
 }
 
-// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "arrayvar"}
-// CHECK: acc.copyout accPtr(%[[COPYIN]] : !fir.ref<!fir.array<10xf32>>) to varPtr({{.*}} : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "arrayvar"}
+// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) implicit(true) name("arrayvar") -> !fir.ref<!fir.array<10xf32>>
+// CHECK: acc.copyout accPtr(%[[COPYIN]] : !fir.ref<!fir.array<10xf32>>) to varPtr({{.*}} : !fir.ref<!fir.array<10xf32>>) dataClause(acc_copy) implicit(true) name("arrayvar")
 
 // -----
 
@@ -129,12 +129,12 @@ func.func @test_fir_derivedtype_in_parallel_defaultpresent() {
   acc.parallel {
     %load = fir.load %livein : !fir.ref<!fir.type<_QFTaggr{field:f32}>>
     acc.yield
-  } attributes {defaultAttr = #acc<defaultvalue present>}
+  } defaultAttr(present)
   return
 }
 
-// CHECK: %[[PRESENT:.*]] = acc.present varPtr({{.*}} : !fir.ref<!fir.type<_QFTaggr{field:f32}>>) -> !fir.ref<!fir.type<_QFTaggr{field:f32}>> {acc.from_default, implicit = true, name = "aggrvar"}
-// CHECK: acc.delete accPtr(%[[PRESENT]] : !fir.ref<!fir.type<_QFTaggr{field:f32}>>) {dataClause = #acc<data_clause acc_present>, implicit = true, name = "aggrvar"}
+// CHECK: %[[PRESENT:.*]] = acc.present varPtr({{.*}} : !fir.ref<!fir.type<_QFTaggr{field:f32}>>) implicit(true) name("aggrvar") -> !fir.ref<!fir.type<_QFTaggr{field:f32}>> {acc.from_default}
+// CHECK: acc.delete accPtr(%[[PRESENT]] : !fir.ref<!fir.type<_QFTaggr{field:f32}>>) dataClause(acc_present) implicit(true) name("aggrvar")
 
 // -----
 
@@ -143,12 +143,12 @@ func.func @test_fir_derivedtype_in_kernels_defaultpresent() {
   acc.kernels {
     %load = fir.load %livein : !fir.ref<!fir.type<_QFTaggr{field:f32}>>
     acc.terminator
-  } attributes {defaultAttr = #acc<defaultvalue present>}
+  } defaultAttr(present)
   return
 }
 
-// CHECK: %[[PRESENT:.*]] = acc.present varPtr({{.*}} : !fir.ref<!fir.type<_QFTaggr{field:f32}>>) -> !fir.ref<!fir.type<_QFTaggr{field:f32}>> {acc.from_default, implicit = true, name = "aggrvar"}
-// CHECK: acc.delete accPtr(%[[PRESENT]] : !fir.ref<!fir.type<_QFTaggr{field:f32}>>) {dataClause = #acc<data_clause acc_present>, implicit = true, name = "aggrvar"}
+// CHECK: %[[PRESENT:.*]] = acc.present varPtr({{.*}} : !fir.ref<!fir.type<_QFTaggr{field:f32}>>) implicit(true) name("aggrvar") -> !fir.ref<!fir.type<_QFTaggr{field:f32}>> {acc.from_default}
+// CHECK: acc.delete accPtr(%[[PRESENT]] : !fir.ref<!fir.type<_QFTaggr{field:f32}>>) dataClause(acc_present) implicit(true) name("aggrvar")
 
 // -----
 
@@ -157,12 +157,12 @@ func.func @test_fir_array_in_parallel_defaultpresent() {
   acc.parallel {
     %load = fir.load %livein : !fir.ref<!fir.array<10xf32>>
     acc.yield
-  } attributes {defaultAttr = #acc<defaultvalue present>}
+  } defaultAttr(present)
   return
 }
 
-// CHECK: %[[PRESENT:.*]] = acc.present varPtr({{.*}} : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {acc.from_default, implicit = true, name = "arrayvar"}
-// CHECK: acc.delete accPtr(%[[PRESENT]] : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_present>, implicit = true, name = "arrayvar"}
+// CHECK: %[[PRESENT:.*]] = acc.present varPtr({{.*}} : !fir.ref<!fir.array<10xf32>>) implicit(true) name("arrayvar") -> !fir.ref<!fir.array<10xf32>> {acc.from_default}
+// CHECK: acc.delete accPtr(%[[PRESENT]] : !fir.ref<!fir.array<10xf32>>) dataClause(acc_present) implicit(true) name("arrayvar")
 
 // -----
 
@@ -171,12 +171,12 @@ func.func @test_fir_array_in_kernels_defaultpresent() {
   acc.kernels {
     %load = fir.load %livein : !fir.ref<!fir.array<10xf32>>
     acc.terminator
-  } attributes {defaultAttr = #acc<defaultvalue present>}
+  } defaultAttr(present)
   return
 }
 
-// CHECK: %[[PRESENT:.*]] = acc.present varPtr({{.*}} : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {acc.from_default, implicit = true, name = "arrayvar"}
-// CHECK: acc.delete accPtr(%[[PRESENT]] : !fir.ref<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_present>, implicit = true, name = "arrayvar"}
+// CHECK: %[[PRESENT:.*]] = acc.present varPtr({{.*}} : !fir.ref<!fir.array<10xf32>>) implicit(true) name("arrayvar") -> !fir.ref<!fir.array<10xf32>> {acc.from_default}
+// CHECK: acc.delete accPtr(%[[PRESENT]] : !fir.ref<!fir.array<10xf32>>) dataClause(acc_present) implicit(true) name("arrayvar")
 
 // -----
 
@@ -185,11 +185,11 @@ func.func @test_fir_scalar_in_parallel_defaultpresent() {
   acc.parallel {
     %load = fir.load %livein : !fir.ref<f32>
     acc.yield
-  } attributes {defaultAttr = #acc<defaultvalue present>}
+  } defaultAttr(present)
   return
 }
 
-// CHECK: acc.firstprivate varPtr({{.*}} : !fir.ref<f32>) recipe({{.*}}) -> !fir.ref<f32> {implicit = true, name = "scalarvar"}
+// CHECK: acc.firstprivate varPtr({{.*}} : !fir.ref<f32>) recipe({{.*}}) implicit(true) name("scalarvar") -> !fir.ref<f32>
 
 // -----
 
@@ -198,12 +198,12 @@ func.func @test_fir_scalar_in_kernels_defaultpresent() {
   acc.kernels {
     %load = fir.load %livein : !fir.ref<f64>
     acc.terminator
-  } attributes {defaultAttr = #acc<defaultvalue present>}
+  } defaultAttr(present)
   return
 }
 
-// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : !fir.ref<f64>) -> !fir.ref<f64> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "scalarvar"}
-// CHECK: acc.copyout accPtr(%[[COPYIN]] : !fir.ref<f64>) to varPtr({{.*}} : !fir.ref<f64>) {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "scalarvar"}
+// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : !fir.ref<f64>) dataClause(acc_copy) implicit(true) name("scalarvar") -> !fir.ref<f64>
+// CHECK: acc.copyout accPtr(%[[COPYIN]] : !fir.ref<f64>) to varPtr({{.*}} : !fir.ref<f64>) dataClause(acc_copy) implicit(true) name("scalarvar")
 
 // -----
 
@@ -216,8 +216,8 @@ func.func @test_fir_box_ref() {
   return
 }
 
-// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : !fir.ref<!fir.box<!fir.array<?xi32>>>) -> !fir.ref<!fir.box<!fir.array<?xi32>>> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "descriptor"}
-// CHECK: acc.copyout accPtr(%[[COPYIN]] : !fir.ref<!fir.box<!fir.array<?xi32>>>) to varPtr({{.*}} : !fir.ref<!fir.box<!fir.array<?xi32>>>) {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "descriptor"}
+// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : !fir.ref<!fir.box<!fir.array<?xi32>>>) dataClause(acc_copy) implicit(true) name("descriptor") -> !fir.ref<!fir.box<!fir.array<?xi32>>>
+// CHECK: acc.copyout accPtr(%[[COPYIN]] : !fir.ref<!fir.box<!fir.array<?xi32>>>) to varPtr({{.*}} : !fir.ref<!fir.box<!fir.array<?xi32>>>) dataClause(acc_copy) implicit(true) name("descriptor")
 
 // -----
 
@@ -231,8 +231,8 @@ func.func @test_fir_box_val() {
   return
 }
 
-// CHECK: %[[COPYIN:.*]] = acc.copyin var({{.*}} : !fir.box<!fir.array<?xi32>>) -> !fir.box<!fir.array<?xi32>> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "descriptor"}
-// CHECK: acc.copyout accVar(%[[COPYIN]] : !fir.box<!fir.array<?xi32>>) to var({{.*}} : !fir.box<!fir.array<?xi32>>) {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "descriptor"}
+// CHECK: %[[COPYIN:.*]] = acc.copyin var({{.*}} : !fir.box<!fir.array<?xi32>>) dataClause(acc_copy) implicit(true) name("descriptor") -> !fir.box<!fir.array<?xi32>>
+// CHECK: acc.copyout accVar(%[[COPYIN]] : !fir.box<!fir.array<?xi32>>) to var({{.*}} : !fir.box<!fir.array<?xi32>>) dataClause(acc_copy) implicit(true) name("descriptor")
 
 
 // -----
@@ -247,17 +247,17 @@ func.func @test_explicit_box_implicit_ptr() {
   %shape = fir.shape %c10 : (index) -> !fir.shape<1>
   %arr_decl = fir.declare %arr(%shape) {uniq_name = "aa"} : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.ref<!fir.array<10xf32>>
   %box = fir.embox %arr_decl(%shape) : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.box<!fir.array<10xf32>>
-  %copyin = acc.copyin var(%box : !fir.box<!fir.array<10xf32>>) -> !fir.box<!fir.array<10xf32>> {dataClause = #acc<data_clause acc_copy>, name = "aa"}
+  %copyin = acc.copyin var(%box : !fir.box<!fir.array<10xf32>>) dataClause(acc_copy) name("aa") -> !fir.box<!fir.array<10xf32>>
   acc.serial dataOperands(%copyin : !fir.box<!fir.array<10xf32>>) {
     // Use the pointer, not the box
     %elem = fir.array_coor %arr_decl(%shape) %c1 : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
     acc.yield
   }
-  acc.copyout accVar(%copyin : !fir.box<!fir.array<10xf32>>) to var(%box : !fir.box<!fir.array<10xf32>>) {dataClause = #acc<data_clause acc_copy>, name = "aa"}
+  acc.copyout accVar(%copyin : !fir.box<!fir.array<10xf32>>) to var(%box : !fir.box<!fir.array<10xf32>>) dataClause(acc_copy) name("aa")
   return
 }
 
-// CHECK: acc.present varPtr(%{{.*}} : !fir.ref<!fir.array<10xf32>>){{.*}}-> !fir.ref<!fir.array<10xf32>> {implicit = true, name = "aa"}
+// CHECK: acc.present varPtr(%{{.*}} : !fir.ref<!fir.array<10xf32>>){{.*}} implicit(true) name("aa") -> !fir.ref<!fir.array<10xf32>>
 
 // -----
 
@@ -312,7 +312,7 @@ func.func @_QParray(%arg0: !fir.ref<!fir.array<?xf32>> {fir.bindc_name = "aa"}, 
 // CHECK: %[[CMPI:.*]] = arith.cmpi sgt, %[[ADDI]], %c0{{.*}} : index
 // CHECK: %[[SELECT:.*]] = arith.select %[[CMPI]], %[[ADDI]], %c0{{.*}} : index
 // CHECK: %[[BOUNDS:.*]] = acc.bounds lowerbound(%c0{{.*}} : index) upperbound(%{{.*}} : index) extent(%[[SELECT]] : index) stride(%c1{{.*}} : index) startIdx(%[[C10]] : index)
-// CHECK: acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.array<?xf32>>) bounds(%[[BOUNDS]]) -> !fir.ref<!fir.array<?xf32>> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "aa"}
+// CHECK: acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.array<?xf32>>) bounds(%[[BOUNDS]]) dataClause(acc_copy) implicit(true) name("aa") -> !fir.ref<!fir.array<?xf32>>
 
 // -----
 
@@ -322,7 +322,7 @@ func.func @test_deviceptr_no_implicit_copy() {
   %arr = fir.alloca !fir.array<10xf64> {bindc_name = "a"}
   %shape = fir.shape %c10 : (index) -> !fir.shape<1>
   %arr_box = fir.embox %arr(%shape) : (!fir.ref<!fir.array<10xf64>>, !fir.shape<1>) -> !fir.box<!fir.array<10xf64>>
-  %devptr = acc.deviceptr var(%arr_box : !fir.box<!fir.array<10xf64>>) -> !fir.box<!fir.array<10xf64>> {name = "a"}
+  %devptr = acc.deviceptr var(%arr_box : !fir.box<!fir.array<10xf64>>) name("a") -> !fir.box<!fir.array<10xf64>>
   acc.parallel dataOperands(%devptr : !fir.box<!fir.array<10xf64>>) {
     %elem = fir.box_addr %arr_box : (!fir.box<!fir.array<10xf64>>) -> !fir.ref<!fir.array<10xf64>>
     acc.yield
@@ -341,7 +341,7 @@ func.func @test_acc_declare_deviceptr() {
   %arr = fir.alloca !fir.array<10xf64> {bindc_name = "a"}
   %shape = fir.shape %c10 : (index) -> !fir.shape<1>
   %arr_box = fir.embox %arr(%shape) : (!fir.ref<!fir.array<10xf64>>, !fir.shape<1>) -> !fir.box<!fir.array<10xf64>>
-  %devptr = acc.deviceptr var(%arr_box : !fir.box<!fir.array<10xf64>>) -> !fir.box<!fir.array<10xf64>> {name = "a"}
+  %devptr = acc.deviceptr var(%arr_box : !fir.box<!fir.array<10xf64>>) name("a") -> !fir.box<!fir.array<10xf64>>
   %token = acc.declare_enter dataOperands(%devptr : !fir.box<!fir.array<10xf64>>)
   acc.parallel {
     %elem = fir.box_addr %arr_box : (!fir.box<!fir.array<10xf64>>) -> !fir.ref<!fir.array<10xf64>>
@@ -403,7 +403,7 @@ func.func @test_fir_declare_deviceptr_arg_in_parallel(%arg0: !fir.ref<!fir.array
   %shape = fir.shape %c10 : (index) -> !fir.shape<1>
   %arr_decl = fir.declare %arg0(%shape) {acc.declare = #acc.declare<dataClause = acc_deviceptr>, uniq_name = "_QFtestEa"} : (!fir.ref<!fir.array<10xf64>>, !fir.shape<1>) -> !fir.ref<!fir.array<10xf64>>
   %arr_box = fir.embox %arr_decl(%shape) : (!fir.ref<!fir.array<10xf64>>, !fir.shape<1>) -> !fir.box<!fir.array<10xf64>>
-  %devptr = acc.deviceptr var(%arr_box : !fir.box<!fir.array<10xf64>>) -> !fir.box<!fir.array<10xf64>> {name = "a"}
+  %devptr = acc.deviceptr var(%arr_box : !fir.box<!fir.array<10xf64>>) name("a") -> !fir.box<!fir.array<10xf64>>
   %token = acc.declare_enter dataOperands(%devptr : !fir.box<!fir.array<10xf64>>)
   acc.parallel {
     %addr = fir.box_addr %arr_box : (!fir.box<!fir.array<10xf64>>) -> !fir.ref<!fir.array<10xf64>>
@@ -417,10 +417,10 @@ func.func @test_fir_declare_deviceptr_arg_in_parallel(%arg0: !fir.ref<!fir.array
 // CHECK-LABEL: func.func @test_fir_declare_deviceptr_arg_in_parallel
 // CHECK: %[[DECL:.*]] = fir.declare %{{.*}}{{.*}}{acc.declare = #acc.declare<dataClause = acc_deviceptr>{{.*}}
 // CHECK: %[[BOX:.*]] = fir.embox %[[DECL]]
-// CHECK: %[[DEVPTR:.*]] = acc.deviceptr var(%[[BOX]] : !fir.box<!fir.array<10xf64>>) -> !fir.box<!fir.array<10xf64>> {name = "a"}
+// CHECK: %[[DEVPTR:.*]] = acc.deviceptr var(%[[BOX]] : !fir.box<!fir.array<10xf64>>) name("a") -> !fir.box<!fir.array<10xf64>>
 // CHECK: %[[TOKEN:.*]] = acc.declare_enter dataOperands(%[[DEVPTR]] : !fir.box<!fir.array<10xf64>>)
-// CHECK: %[[IMPLICIT_BOX:.*]] = acc.deviceptr var(%[[BOX]] : !fir.box<!fir.array<10xf64>>) -> !fir.box<!fir.array<10xf64>> {implicit = true, name = "a"}
-// CHECK: %[[IMPLICIT_REF:.*]] = acc.deviceptr varPtr(%[[DECL]] : !fir.ref<!fir.array<10xf64>>) -> !fir.ref<!fir.array<10xf64>> {implicit = true, name = "a"}
+// CHECK: %[[IMPLICIT_BOX:.*]] = acc.deviceptr var(%[[BOX]] : !fir.box<!fir.array<10xf64>>) implicit(true) name("a") -> !fir.box<!fir.array<10xf64>>
+// CHECK: %[[IMPLICIT_REF:.*]] = acc.deviceptr varPtr(%[[DECL]] : !fir.ref<!fir.array<10xf64>>) implicit(true) name("a") -> !fir.ref<!fir.array<10xf64>>
 // CHECK: acc.parallel dataOperands(%[[IMPLICIT_BOX]], %[[IMPLICIT_REF]] : !fir.box<!fir.array<10xf64>>, !fir.ref<!fir.array<10xf64>>) {
 // CHECK: fir.box_addr %[[IMPLICIT_BOX]] : (!fir.box<!fir.array<10xf64>>) -> !fir.ref<!fir.array<10xf64>>
 // CHECK: fir.array_coor %[[IMPLICIT_REF]]
@@ -449,7 +449,7 @@ func.func @test_serial_inside_data_deviceptr_embox() {
   %shape = fir.shape %c10 : (index) -> !fir.shape<1>
   %arr_decl = fir.declare %arr(%shape) {uniq_name = "b"} : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.ref<!fir.array<10xf32>>
   %box = fir.embox %arr_decl(%shape) : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.box<!fir.array<10xf32>>
-  %devptr = acc.deviceptr var(%box : !fir.box<!fir.array<10xf32>>) -> !fir.box<!fir.array<10xf32>> {name = "b(1:10)"}
+  %devptr = acc.deviceptr var(%box : !fir.box<!fir.array<10xf32>>) name("b(1:10)") -> !fir.box<!fir.array<10xf32>>
   acc.data dataOperands(%devptr : !fir.box<!fir.array<10xf32>>) {
     acc.serial {
       %elem = fir.array_coor %arr_decl(%shape) %c1 : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
@@ -462,9 +462,9 @@ func.func @test_serial_inside_data_deviceptr_embox() {
 }
 
 // CHECK-LABEL: func.func @test_serial_inside_data_deviceptr_embox
-// CHECK: acc.deviceptr var({{.*}} : !fir.box<!fir.array<10xf32>>) -> !fir.box<!fir.array<10xf32>> {name = "b(1:10)"}
+// CHECK: acc.deviceptr var({{.*}} : !fir.box<!fir.array<10xf32>>) name("b(1:10)") -> !fir.box<!fir.array<10xf32>>
 // CHECK: acc.data
-// CHECK: acc.deviceptr varPtr({{.*}} : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {implicit = true, name = "b"}
+// CHECK: acc.deviceptr varPtr({{.*}} : !fir.ref<!fir.array<10xf32>>) implicit(true) name("b") -> !fir.ref<!fir.array<10xf32>>
 // CHECK: acc.serial dataOperands({{.*}} : !fir.ref<!fir.array<10xf32>>)
 // CHECK-NOT: acc.copyin
 // CHECK-NOT: acc.copyout

--- a/flang/test/Transforms/OpenACC/acc-implicit-firstprivate.fir
+++ b/flang/test/Transforms/OpenACC/acc-implicit-firstprivate.fir
@@ -26,7 +26,7 @@ func.func @test_i32_scalar_in_parallel() {
   return
 }
 
-// CHECK: %[[FIRSTPRIV:.*]] = acc.firstprivate varPtr(%{{.*}} : !fir.ref<i32>) recipe(@firstprivatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i32_var"}
+// CHECK: %[[FIRSTPRIV:.*]] = acc.firstprivate varPtr(%{{.*}} : !fir.ref<i32>) recipe(@firstprivatization_ref_i32) implicit(true) name("i32_var") -> !fir.ref<i32>
 // CHECK: acc.parallel firstprivate(%[[FIRSTPRIV]] : !fir.ref<i32>)
 
 // -----
@@ -52,7 +52,7 @@ func.func @test_i64_scalar_in_parallel() {
   return
 }
 
-// CHECK: %[[FIRSTPRIV:.*]] = acc.firstprivate varPtr(%{{.*}} : !fir.ref<i64>) recipe(@firstprivatization_ref_i64) -> !fir.ref<i64> {implicit = true, name = "i64_var"}
+// CHECK: %[[FIRSTPRIV:.*]] = acc.firstprivate varPtr(%{{.*}} : !fir.ref<i64>) recipe(@firstprivatization_ref_i64) implicit(true) name("i64_var") -> !fir.ref<i64>
 // CHECK: acc.parallel firstprivate(%[[FIRSTPRIV]] : !fir.ref<i64>)
 
 // -----
@@ -78,7 +78,7 @@ func.func @test_f32_scalar_in_parallel() {
   return
 }
 
-// CHECK: %[[FIRSTPRIV:.*]] = acc.firstprivate varPtr(%{{.*}} : !fir.ref<f32>) recipe(@firstprivatization_ref_f32) -> !fir.ref<f32> {implicit = true, name = "f32_var"}
+// CHECK: %[[FIRSTPRIV:.*]] = acc.firstprivate varPtr(%{{.*}} : !fir.ref<f32>) recipe(@firstprivatization_ref_f32) implicit(true) name("f32_var") -> !fir.ref<f32>
 // CHECK: acc.parallel firstprivate(%[[FIRSTPRIV]] : !fir.ref<f32>)
 
 // -----
@@ -104,7 +104,7 @@ func.func @test_f64_scalar_in_parallel() {
   return
 }
 
-// CHECK: %[[FIRSTPRIV:.*]] = acc.firstprivate varPtr(%{{.*}} : !fir.ref<f64>) recipe(@firstprivatization_ref_f64) -> !fir.ref<f64> {implicit = true, name = "f64_var"}
+// CHECK: %[[FIRSTPRIV:.*]] = acc.firstprivate varPtr(%{{.*}} : !fir.ref<f64>) recipe(@firstprivatization_ref_f64) implicit(true) name("f64_var") -> !fir.ref<f64>
 // CHECK: acc.parallel firstprivate(%[[FIRSTPRIV]] : !fir.ref<f64>)
 
 // -----
@@ -130,7 +130,7 @@ func.func @test_logical_scalar_in_parallel() {
   return
 }
 
-// CHECK: %[[FIRSTPRIV:.*]] = acc.firstprivate varPtr(%{{.*}} : !fir.ref<!fir.logical<4>>) recipe(@firstprivatization_ref_l32) -> !fir.ref<!fir.logical<4>> {implicit = true, name = "logical_var"}
+// CHECK: %[[FIRSTPRIV:.*]] = acc.firstprivate varPtr(%{{.*}} : !fir.ref<!fir.logical<4>>) recipe(@firstprivatization_ref_l32) implicit(true) name("logical_var") -> !fir.ref<!fir.logical<4>>
 // CHECK: acc.parallel firstprivate(%[[FIRSTPRIV]] : !fir.ref<!fir.logical<4>>)
 
 // -----
@@ -156,7 +156,7 @@ func.func @test_complex_scalar_in_parallel() {
   return
 }
 
-// CHECK: %[[FIRSTPRIV:.*]] = acc.firstprivate varPtr(%{{.*}} : !fir.ref<complex<f32>>) recipe(@firstprivatization_ref_z32) -> !fir.ref<complex<f32>> {implicit = true, name = "complex_var"}
+// CHECK: %[[FIRSTPRIV:.*]] = acc.firstprivate varPtr(%{{.*}} : !fir.ref<complex<f32>>) recipe(@firstprivatization_ref_z32) implicit(true) name("complex_var") -> !fir.ref<complex<f32>>
 // CHECK: acc.parallel firstprivate(%[[FIRSTPRIV]] : !fir.ref<complex<f32>>)
 
 // -----
@@ -182,7 +182,7 @@ func.func @test_complex8_scalar_in_parallel() {
   return
 }
 
-// CHECK: %[[FIRSTPRIV:.*]] = acc.firstprivate varPtr(%{{.*}} : !fir.ref<complex<f64>>) recipe(@firstprivatization_ref_z64) -> !fir.ref<complex<f64>> {implicit = true, name = "complex8_var"}
+// CHECK: %[[FIRSTPRIV:.*]] = acc.firstprivate varPtr(%{{.*}} : !fir.ref<complex<f64>>) recipe(@firstprivatization_ref_z64) implicit(true) name("complex8_var") -> !fir.ref<complex<f64>>
 // CHECK: acc.parallel firstprivate(%[[FIRSTPRIV]] : !fir.ref<complex<f64>>)
 
 // -----
@@ -199,7 +199,7 @@ func.func @test_i32_scalar_in_serial() {
   return
 }
 
-// CHECK: %[[FIRSTPRIV:.*]] = acc.firstprivate varPtr(%{{.*}} : !fir.ref<i32>) recipe(@firstprivatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "serial_i32_var"}
+// CHECK: %[[FIRSTPRIV:.*]] = acc.firstprivate varPtr(%{{.*}} : !fir.ref<i32>) recipe(@firstprivatization_ref_i32) implicit(true) name("serial_i32_var") -> !fir.ref<i32>
 // CHECK: acc.serial firstprivate(%[[FIRSTPRIV]] : !fir.ref<i32>)
 
 // -----
@@ -216,7 +216,7 @@ func.func @test_f64_scalar_in_serial() {
   return
 }
 
-// CHECK: %[[FIRSTPRIV:.*]] = acc.firstprivate varPtr(%{{.*}} : !fir.ref<f64>) recipe(@firstprivatization_ref_f64) -> !fir.ref<f64> {implicit = true, name = "serial_f64_var"}
+// CHECK: %[[FIRSTPRIV:.*]] = acc.firstprivate varPtr(%{{.*}} : !fir.ref<f64>) recipe(@firstprivatization_ref_f64) implicit(true) name("serial_f64_var") -> !fir.ref<f64>
 // CHECK: acc.serial firstprivate(%[[FIRSTPRIV]] : !fir.ref<f64>)
 
 // -----
@@ -244,7 +244,7 @@ func.func @test_i8_scalar_in_parallel() {
   return
 }
 
-// CHECK: %[[FIRSTPRIV:.*]] = acc.firstprivate varPtr(%{{.*}} : !fir.ref<i8>) recipe(@firstprivatization_ref_i8) -> !fir.ref<i8> {implicit = true, name = "i8_var"}
+// CHECK: %[[FIRSTPRIV:.*]] = acc.firstprivate varPtr(%{{.*}} : !fir.ref<i8>) recipe(@firstprivatization_ref_i8) implicit(true) name("i8_var") -> !fir.ref<i8>
 // CHECK: acc.parallel firstprivate(%[[FIRSTPRIV]] : !fir.ref<i8>)
 
 // -----
@@ -270,6 +270,6 @@ func.func @test_i16_scalar_in_parallel() {
   return
 }
 
-// CHECK: %[[FIRSTPRIV:.*]] = acc.firstprivate varPtr(%{{.*}} : !fir.ref<i16>) recipe(@firstprivatization_ref_i16) -> !fir.ref<i16> {implicit = true, name = "i16_var"}
+// CHECK: %[[FIRSTPRIV:.*]] = acc.firstprivate varPtr(%{{.*}} : !fir.ref<i16>) recipe(@firstprivatization_ref_i16) implicit(true) name("i16_var") -> !fir.ref<i16>
 // CHECK: acc.parallel firstprivate(%[[FIRSTPRIV]] : !fir.ref<i16>)
 

--- a/flang/test/Transforms/OpenACC/acc-recipe-materialization-firstprivate-derived.fir
+++ b/flang/test/Transforms/OpenACC/acc-recipe-materialization-firstprivate-derived.fir
@@ -29,10 +29,10 @@ module {
     %3 = fir.alloca i32 {bindc_name = "n", uniq_name = "_QFtestEn"}
     %4 = fir.declare %3 {uniq_name = "_QFtestEn"} : (!fir.ref<i32>) -> !fir.ref<i32>
     %5 = fir.declare %arg0 dummy_scope %0 {uniq_name = "_QFtestEp"} : (!fir.ref<!fir.type<_QFtestTpoint{x:f32}>>, !fir.dscope) -> !fir.ref<!fir.type<_QFtestTpoint{x:f32}>>
-    %6 = acc.firstprivate varPtr(%5 : !fir.ref<!fir.type<_QFtestTpoint{x:f32}>>) recipe(@firstprivatization_ref_rec__QFtestTpoint) -> !fir.ref<!fir.type<_QFtestTpoint{x:f32}>> {name = "p"}
+    %6 = acc.firstprivate varPtr(%5 : !fir.ref<!fir.type<_QFtestTpoint{x:f32}>>) recipe(@firstprivatization_ref_rec__QFtestTpoint) name("p") -> !fir.ref<!fir.type<_QFtestTpoint{x:f32}>>
     acc.parallel firstprivate(%6 : !fir.ref<!fir.type<_QFtestTpoint{x:f32}>>) {
       %7 = fir.load %4 : !fir.ref<i32>
-      %8 = acc.private varPtr(%2 : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+      %8 = acc.private varPtr(%2 : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
       acc.loop private(%8 : !fir.ref<i32>) control(%arg1 : i32) = (%c1_i32 : i32) to (%7 : i32)  step (%c1_i32 : i32) {
         %9 = fir.declare %8 {uniq_name = "_QFtestEi"} : (!fir.ref<i32>) -> !fir.ref<i32>
         fir.store %arg1 to %9 : !fir.ref<i32>
@@ -42,14 +42,14 @@ module {
         %13 = fir.coordinate_of %5, x : (!fir.ref<!fir.type<_QFtestTpoint{x:f32}>>) -> !fir.ref<f32>
         fir.store %11 to %13 : !fir.ref<f32>
         acc.yield
-      } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+      } inclusiveUpperbound(array<i1: true>) independent
       acc.yield
     }
     return
   }
 }
 
-// CHECK:           %[[VAL_7:.*]] = acc.firstprivate_map varPtr(%{{.*}} : !fir.ref<!fir.type<_QFtestTpoint{x:f32}>>) -> !fir.ref<!fir.type<_QFtestTpoint{x:f32}>>
+// CHECK:           %[[VAL_7:.*]] = acc.firstprivate_map varPtr(%{{.*}} : !fir.ref<!fir.type<_QFtestTpoint{x:f32}>>) name("p") -> !fir.ref<!fir.type<_QFtestTpoint{x:f32}>>
 // CHECK:           acc.parallel {
 // CHECK:             %[[VAL_8:.*]] = fir.alloca !fir.type<_QFtestTpoint{x:f32}>
 // CHECK:             %[[VAL_9:.*]] = fir.declare %[[VAL_8]] {acc.var_name = #acc.var_name<"p">, uniq_name = "acc.private.init"} : (!fir.ref<!fir.type<_QFtestTpoint{x:f32}>>) -> !fir.ref<!fir.type<_QFtestTpoint{x:f32}>>

--- a/flang/test/Transforms/OpenACC/acc-recipe-materialization-firstprivate.fir
+++ b/flang/test/Transforms/OpenACC/acc-recipe-materialization-firstprivate.fir
@@ -23,7 +23,7 @@ module {
     %1 = fir.alloca i32 {bindc_name = "t", uniq_name = "_QFfirstprivEt"}
     %2 = fir.declare %1 {uniq_name = "_QFfirstprivEt"} : (!fir.ref<i32>) -> !fir.ref<i32>
     fir.store %c1336_i32 to %2 : !fir.ref<i32>
-    %3 = acc.firstprivate varPtr(%2 : !fir.ref<i32>) recipe(@firstprivatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "t"}
+    %3 = acc.firstprivate varPtr(%2 : !fir.ref<i32>) recipe(@firstprivatization_ref_i32) implicit(true) name("t") -> !fir.ref<i32>
     acc.parallel firstprivate(%3 : !fir.ref<i32>) {
       %c1_i32 = arith.constant 1 : i32
       %4 = fir.load %3 : !fir.ref<i32>

--- a/flang/test/Transforms/OpenACC/acc-recipe-materialization-kernel-private.fir
+++ b/flang/test/Transforms/OpenACC/acc-recipe-materialization-kernel-private.fir
@@ -22,8 +22,8 @@ func.func @kpriv_(%arg0: !fir.ref<i32> {fir.bindc_name = "start"}, %arg1: !fir.r
   %7 = fir.declare %arg0 dummy_scope %0 arg 1 {fortran_attrs = #fir.var_attrs<intent_in>, uniq_name = "_QFkprivEstart"} : (!fir.ref<i32>, !fir.dscope) -> !fir.ref<i32>
   %8 = fir.load %7 : !fir.ref<i32>
   fir.store %8 to %6 : !fir.ref<i32>
-  %9 = acc.copyin varPtr(%2 : !fir.ref<!fir.array<32xi32>>) -> !fir.ref<!fir.array<32xi32>> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "a"}
-  %10 = acc.private varPtr(%6 : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "s"}
+  %9 = acc.copyin varPtr(%2 : !fir.ref<!fir.array<32xi32>>) dataClause(acc_copy) implicit(true) name("a") -> !fir.ref<!fir.array<32xi32>>
+  %10 = acc.private varPtr(%6 : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("s") -> !fir.ref<i32>
   acc.kernels dataOperands(%9 : !fir.ref<!fir.array<32xi32>>) private(%10 : !fir.ref<i32>) {
     %11 = fir.shape %c32 : (index) -> !fir.shape<1>
     acc.loop control(%arg2 : index) = (%c1 : index) to (%c32 : index) step (%c1 : index) {
@@ -37,9 +37,9 @@ func.func @kpriv_(%arg0: !fir.ref<i32> {fir.bindc_name = "start"}, %arg1: !fir.r
       %18 = fir.array_coor %9(%11) %17 : (!fir.ref<!fir.array<32xi32>>, !fir.shape<1>, i64) -> !fir.ref<i32>
       fir.store %15 to %18 : !fir.ref<i32>
       acc.yield
-    } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+    } inclusiveUpperbound(array<i1: true>) independent
     acc.terminator
   }
-  acc.copyout accPtr(%9 : !fir.ref<!fir.array<32xi32>>) to varPtr(%2 : !fir.ref<!fir.array<32xi32>>) {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "a"}
+  acc.copyout accPtr(%9 : !fir.ref<!fir.array<32xi32>>) to varPtr(%2 : !fir.ref<!fir.array<32xi32>>) dataClause(acc_copy) implicit(true) name("a")
   return
 }

--- a/flang/test/Transforms/OpenACC/acc-recipe-materialization-parallel.fir
+++ b/flang/test/Transforms/OpenACC/acc-recipe-materialization-parallel.fir
@@ -39,7 +39,7 @@ func.func @par_reduction_clause_(%arg0: !fir.ref<f64> {fir.bindc_name = "tmp"}) 
   %cst = arith.constant 1.000000e+00 : f64
   %0 = fir.dummy_scope : !fir.dscope
   %1 = fir.declare %arg0 dummy_scope %0 {uniq_name = "_QFpar_reduction_clauseEtmp"} : (!fir.ref<f64>, !fir.dscope) -> !fir.ref<f64>
-  %2 = acc.reduction varPtr(%1 : !fir.ref<f64>) recipe(@reduction_add_ref_f64) -> !fir.ref<f64> {name = "tmp"}
+  %2 = acc.reduction varPtr(%1 : !fir.ref<f64>) recipe(@reduction_add_ref_f64) name("tmp") -> !fir.ref<f64>
   acc.parallel reduction(%2 : !fir.ref<f64>) {
     %3 = fir.load %2 : !fir.ref<f64>
     %4 = arith.addf %3, %cst fastmath<contract> : f64

--- a/flang/test/Transforms/OpenACC/acc-recipe-materialization-private.fir
+++ b/flang/test/Transforms/OpenACC/acc-recipe-materialization-private.fir
@@ -15,12 +15,12 @@ acc.private.recipe @privatization_ref_i64 : !fir.ref<i64> init {
 func.func @private_i64(%arg0 : !fir.ref<i64>) {
   %c16_i32 = arith.constant 16 : i32
   %c1_i32 = arith.constant 1 : i32
-  %priv = acc.private varPtr(%arg0 : !fir.ref<i64>) recipe(@privatization_ref_i64) -> !fir.ref<i64> {implicit = true, name = ""}
+  %priv = acc.private varPtr(%arg0 : !fir.ref<i64>) recipe(@privatization_ref_i64) implicit(true) name("") -> !fir.ref<i64>
   acc.loop private(%priv : !fir.ref<i64>) control(%siv : i64) = (%c1_i32 : i32) to (%c16_i32 : i32) step (%c1_i32 : i32) {
     %priv_decl = fir.declare %priv {uniq_name = "_private_arg0"} : (!fir.ref<i64>) -> !fir.ref<i64>
     fir.store %siv to %priv_decl : !fir.ref<i64>
     acc.yield
-  } attributes {independent = [#acc.device_type<none>]}
+  } independent
   return
 }
 
@@ -34,13 +34,13 @@ func.func @private_i64(%arg0 : !fir.ref<i64>) {
 func.func @par_private_i64(%arg0 : !fir.ref<i64>) {
   %c16_i32 = arith.constant 16 : i32
   %c1_i32 = arith.constant 1 : i32
-  %priv = acc.private varPtr(%arg0 : !fir.ref<i64>) recipe(@privatization_ref_i64) -> !fir.ref<i64> {implicit = true, name = ""}
+  %priv = acc.private varPtr(%arg0 : !fir.ref<i64>) recipe(@privatization_ref_i64) implicit(true) name("") -> !fir.ref<i64>
   acc.parallel private(%priv : !fir.ref<i64>) {
     %priv_decl = fir.declare %priv {uniq_name = "_private_arg0"} : (!fir.ref<i64>) -> !fir.ref<i64>
     acc.loop control(%siv : i64) = (%c1_i32 : i32) to (%c16_i32 : i32) step (%c1_i32 : i32) {
       fir.store %siv to %priv_decl : !fir.ref<i64>
       acc.yield
-    } attributes {independent = [#acc.device_type<none>]}
+    } independent
     acc.yield
   }
   return

--- a/flang/test/Transforms/OpenACC/acc-recipe-materialization-reduction.fir
+++ b/flang/test/Transforms/OpenACC/acc-recipe-materialization-reduction.fir
@@ -39,7 +39,7 @@ func.func @par_reduction_clause_(%arg0: !fir.ref<f64> {fir.bindc_name = "tmp"}) 
   %cst = arith.constant 1.000000e+00 : f64
   %0 = fir.dummy_scope : !fir.dscope
   %1 = fir.declare %arg0 dummy_scope %0 {uniq_name = "_QFpar_reduction_clauseEtmp"} : (!fir.ref<f64>, !fir.dscope) -> !fir.ref<f64>
-  %2 = acc.reduction varPtr(%1 : !fir.ref<f64>) recipe(@reduction_add_ref_f64) -> !fir.ref<f64> {name = "tmp"}
+  %2 = acc.reduction varPtr(%1 : !fir.ref<f64>) recipe(@reduction_add_ref_f64) name("tmp") -> !fir.ref<f64>
   acc.parallel reduction(%2 : !fir.ref<f64>) {
     %3 = fir.load %2 : !fir.ref<f64>
     %4 = arith.addf %3, %cst fastmath<contract> : f64

--- a/flang/test/Transforms/OpenACC/optional-firstprivate-recipe.fir
+++ b/flang/test/Transforms/OpenACC/optional-firstprivate-recipe.fir
@@ -35,5 +35,5 @@ func.func @test_optional_firstprivate_f32(%arg0: !fir.ref<f32> {fir.bindc_name =
 // CHECK: }
 
 // bindc_name on the arg does not always flow into acc.firstprivate's name=; minimal FIR gets name = "".
-// CHECK: acc.firstprivate varPtr({{.*}} : !fir.ref<f32>) recipe(@firstprivatization_optional_ref_f32) -> !fir.ref<f32> {implicit = true, name = ""}
+// CHECK: acc.firstprivate varPtr({{.*}} : !fir.ref<f32>) recipe(@firstprivatization_optional_ref_f32) implicit(true) name("") -> !fir.ref<f32>
 // CHECK: acc.parallel firstprivate(

--- a/flang/test/Transforms/licm-acc-compute-region.fir
+++ b/flang/test/Transforms/licm-acc-compute-region.fir
@@ -8,7 +8,7 @@
 // CHECK:           %[[DUMMY_SCOPE_0:.*]] = fir.dummy_scope : !fir.dscope
 // CHECK:           %[[DECLARE_0:.*]] = fir.declare %[[ARG0]] dummy_scope %[[DUMMY_SCOPE_0]] arg 1 {uniq_name = "_QFtestEx"} : (!fir.box<!fir.array<?xf32>>, !fir.dscope) -> !fir.box<!fir.array<?xf32>>
 // CHECK:           %[[REBOX_0:.*]] = fir.rebox %[[DECLARE_0]] : (!fir.box<!fir.array<?xf32>>) -> !fir.box<!fir.array<?xf32>>
-// CHECK:           %[[COPYIN_0:.*]] = acc.copyin var(%[[REBOX_0]] : !fir.box<!fir.array<?xf32>>) -> !fir.box<!fir.array<?xf32>> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "x"}
+// CHECK:           %[[COPYIN_0:.*]] = acc.copyin var(%[[REBOX_0]] : !fir.box<!fir.array<?xf32>>) dataClause(acc_copy) implicit(true) name("x") -> !fir.box<!fir.array<?xf32>>
 // CHECK:           acc.kernel_environment dataOperands(%[[COPYIN_0]] : !fir.box<!fir.array<?xf32>>) {
 // CHECK:             acc.compute_region ins(%[[VAL_0:.*]] = %[[ARG1]], %[[VAL_1:.*]] = %[[COPYIN_0]]) : (index, !fir.box<!fir.array<?xf32>>) {
 // CHECK:               %[[BOX_ADDR_0:.*]] = fir.box_addr %[[VAL_1]] : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
@@ -23,14 +23,14 @@
 // CHECK:               acc.yield
 // CHECK:             } {origin = "acc.kernels"}
 // CHECK:           }
-// CHECK:           acc.copyout accVar(%[[COPYIN_0]] : !fir.box<!fir.array<?xf32>>) to var(%[[REBOX_0]] : !fir.box<!fir.array<?xf32>>) {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "x"}
+// CHECK:           acc.copyout accVar(%[[COPYIN_0]] : !fir.box<!fir.array<?xf32>>) to var(%[[REBOX_0]] : !fir.box<!fir.array<?xf32>>) dataClause(acc_copy) implicit(true) name("x")
 // CHECK:           return
 // CHECK:         }
 func.func @test_(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x"}, %arg1: index {fir.bindc_name = "n"}) {
   %0 = fir.dummy_scope : !fir.dscope
   %4 = fir.declare %arg0 dummy_scope %0 arg 1 {uniq_name = "_QFtestEx"} : (!fir.box<!fir.array<?xf32>>, !fir.dscope) -> !fir.box<!fir.array<?xf32>>
   %5 = fir.rebox %4 : (!fir.box<!fir.array<?xf32>>) -> !fir.box<!fir.array<?xf32>>
-  %7 = acc.copyin var(%5 : !fir.box<!fir.array<?xf32>>) -> !fir.box<!fir.array<?xf32>> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "x"}
+  %7 = acc.copyin var(%5 : !fir.box<!fir.array<?xf32>>) dataClause(acc_copy) implicit(true) name("x") -> !fir.box<!fir.array<?xf32>>
   acc.kernel_environment dataOperands(%7 : !fir.box<!fir.array<?xf32>>) {
     acc.compute_region ins(%arg2 = %arg1, %arg3 = %7) : (index, !fir.box<!fir.array<?xf32>>) {
       %c1 = arith.constant 1 : index
@@ -48,6 +48,6 @@ func.func @test_(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x"}, %arg
       acc.yield
     } {origin = "acc.kernels"}
   }
-  acc.copyout accVar(%7 : !fir.box<!fir.array<?xf32>>) to var(%5 : !fir.box<!fir.array<?xf32>>) {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "x"}
+  acc.copyout accVar(%7 : !fir.box<!fir.array<?xf32>>) to var(%5 : !fir.box<!fir.array<?xf32>>) dataClause(acc_copy) implicit(true) name("x")
   return
 }

--- a/flang/test/Transforms/licm.fir
+++ b/flang/test/Transforms/licm.fir
@@ -1681,8 +1681,8 @@ func.func @test_if_hoisting(%arg0: !fir.ref<!fir.array<?xi32>> {fir.bindc_name =
 // CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !fir.ref<f32> {fir.bindc_name = "a"},
 // CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !fir.ref<i32> {fir.bindc_name = "n"}) {
 // CHECK:           acc.parallel private(%{{.*}} : !fir.box<!fir.array<?xf32>>) {
-// CHECK:             %[[PRIVATE_1:.*]] = acc.private var(%{{.*}} : !fir.box<!fir.array<?xf32>>) recipe(@{{.*}}) -> !fir.box<!fir.array<?xf32>> {name = "b"}
-// CHECK:             %[[PRIVATE_2:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@{{.*}}) -> !fir.ref<i32> {implicit = true, name = "i"}
+// CHECK:             %[[PRIVATE_1:.*]] = acc.private var(%{{.*}} : !fir.box<!fir.array<?xf32>>) recipe(@{{.*}}) name("b") -> !fir.box<!fir.array<?xf32>>
+// CHECK:             %[[PRIVATE_2:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@{{.*}}) implicit(true) name("i") -> !fir.ref<i32>
 // CHECK-NOT:         fir.box_addr %[[PRIVATE_1]]
 // CHECK:             acc.loop private(%[[PRIVATE_1]], %[[PRIVATE_2]] : !fir.box<!fir.array<?xf32>>, !fir.ref<i32>) {{.*}} {
 // CHECK:               %[[BOX_ADDR_1:.*]] = fir.box_addr %[[PRIVATE_1]] : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
@@ -1705,13 +1705,13 @@ func.func @_QPtest_acc_loop_with_private(%arg0: !fir.ref<f32> {fir.bindc_name = 
   %10 = fir.shape %8 : (index) -> !fir.shape<1>
   %11 = fir.declare %9(%10) {uniq_name = "_QFtest_acc_loop_with_privateEb"} : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.ref<!fir.array<?xf32>>
   %12 = fir.embox %11(%10) : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.array<?xf32>>
-  %13 = acc.private var(%12 : !fir.box<!fir.array<?xf32>>) recipe(@privatization_box_Uxf32) -> !fir.box<!fir.array<?xf32>> {name = "b"}
+  %13 = acc.private var(%12 : !fir.box<!fir.array<?xf32>>) recipe(@privatization_box_Uxf32) name("b") -> !fir.box<!fir.array<?xf32>>
   acc.parallel private(%13 : !fir.box<!fir.array<?xf32>>) {
     %14 = fir.box_addr %13 : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
     %15 = fir.declare %14(%10) {uniq_name = "_QFtest_acc_loop_with_privateEb"} : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.ref<!fir.array<?xf32>>
     %16 = fir.embox %15(%10) : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.array<?xf32>>
-    %17 = acc.private var(%16 : !fir.box<!fir.array<?xf32>>) recipe(@privatization_box_Uxf32) -> !fir.box<!fir.array<?xf32>> {name = "b"}
-    %18 = acc.private varPtr(%4 : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+    %17 = acc.private var(%16 : !fir.box<!fir.array<?xf32>>) recipe(@privatization_box_Uxf32) name("b") -> !fir.box<!fir.array<?xf32>>
+    %18 = acc.private varPtr(%4 : !fir.ref<i32>) recipe(@privatization_ref_i32) implicit(true) name("i") -> !fir.ref<i32>
     acc.loop private(%17, %18 : !fir.box<!fir.array<?xf32>>, !fir.ref<i32>) control(%arg2 : i32) = (%c1_i32 : i32) to (%c10_i32 : i32)  step (%c1_i32 : i32) {
       %19 = fir.box_addr %17 : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
       %20 = fir.declare %19(%10) {uniq_name = "_QFtest_acc_loop_with_privateEb"} : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.ref<!fir.array<?xf32>>
@@ -1723,7 +1723,7 @@ func.func @_QPtest_acc_loop_with_private(%arg0: !fir.ref<f32> {fir.bindc_name = 
       %25 = fir.array_coor %20(%10) %24 : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>, i64) -> !fir.ref<f32>
       fir.store %cst to %25 : !fir.ref<f32>
       acc.yield
-    } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+    } inclusiveUpperbound(array<i1: true>) independent
     acc.yield
   }
   return
@@ -1912,13 +1912,13 @@ func.func @test_acc_loop_private_hoisting() {
   %1 = fir.alloca f32 {bindc_name = "b", uniq_name = "_QFtestEb"}
   %2 = fir.declare %1 {uniq_name = "_QFtestEb"} : (!fir.ref<f32>) -> !fir.ref<f32>
   acc.parallel combined(loop) {
-    %5 = acc.private varPtr(%2 : !fir.ref<f32>) recipe(@privatization_ref_f32) -> !fir.ref<f32> {name = "b"}
+    %5 = acc.private varPtr(%2 : !fir.ref<f32>) recipe(@privatization_ref_f32) name("b") -> !fir.ref<f32>
     acc.loop combined(parallel) private(%5 : !fir.ref<f32>) control(%arg0 : i32) = (%c1_i32 : i32) to (%c10_i32 : i32)  step (%c1_i32 : i32) {
       %cvt = fir.convert %5 : (!fir.ref<f32>) -> !fir.ref<f32>
       %7 = fir.declare %cvt {uniq_name = "_QFtestEb"} : (!fir.ref<f32>) -> !fir.ref<f32>
       fir.store %cst to %7 : !fir.ref<f32>
       acc.yield
-    } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+    } inclusiveUpperbound(array<i1: true>) independent
     acc.yield
   }
   return
@@ -1937,13 +1937,13 @@ func.func @test_acc_loop_firstprivate_hoisting() {
   %1 = fir.alloca f32 {bindc_name = "b", uniq_name = "_QFtestEb"}
   %2 = fir.declare %1 {uniq_name = "_QFtestEb"} : (!fir.ref<f32>) -> !fir.ref<f32>
   acc.parallel combined(loop) {
-    %5 = acc.firstprivate varPtr(%2 : !fir.ref<f32>) recipe(@privatization_ref_f32) -> !fir.ref<f32> {name = "b"}
+    %5 = acc.firstprivate varPtr(%2 : !fir.ref<f32>) recipe(@privatization_ref_f32) name("b") -> !fir.ref<f32>
     acc.loop combined(parallel) firstprivate(%5 : !fir.ref<f32>) control(%arg0 : i32) = (%c1_i32 : i32) to (%c10_i32 : i32)  step (%c1_i32 : i32) {
       %cvt = fir.convert %5 : (!fir.ref<f32>) -> !fir.ref<f32>
       %7 = fir.declare %cvt {uniq_name = "_QFtestEb"} : (!fir.ref<f32>) -> !fir.ref<f32>
       fir.store %cst to %7 : !fir.ref<f32>
       acc.yield
-    } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+    } inclusiveUpperbound(array<i1: true>) independent
     acc.yield
   }
   return
@@ -1962,13 +1962,13 @@ func.func @test_acc_loop_reduction_hoisting() {
   %1 = fir.alloca f32 {bindc_name = "b", uniq_name = "_QFtestEb"}
   %2 = fir.declare %1 {uniq_name = "_QFtestEb"} : (!fir.ref<f32>) -> !fir.ref<f32>
   acc.parallel combined(loop) {
-  %5 = acc.reduction varPtr(%2 : !fir.ref<f32>) recipe(@reduction_add_ref_f32) -> !fir.ref<f32> {name = "b"}
+  %5 = acc.reduction varPtr(%2 : !fir.ref<f32>) recipe(@reduction_add_ref_f32) name("b") -> !fir.ref<f32>
     acc.loop combined(parallel) reduction(%5 : !fir.ref<f32>) control(%arg0 : i32) = (%c1_i32 : i32) to (%c10_i32 : i32)  step (%c1_i32 : i32) {
       %cvt = fir.convert %5 : (!fir.ref<f32>) -> !fir.ref<f32>
       %7 = fir.declare %cvt {uniq_name = "_QFtestEb"} : (!fir.ref<f32>) -> !fir.ref<f32>
       fir.store %cst to %7 : !fir.ref<f32>
       acc.yield
-    } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+    } inclusiveUpperbound(array<i1: true>) independent
     acc.yield
   }
   return
@@ -1998,8 +1998,8 @@ func.func @test_acc_loop_private2_hoisting() {
   %3 = fir.alloca f32 {bindc_name = "a", uniq_name = "_QFtestEa"}
   %4 = fir.declare %3 {uniq_name = "_QFtestEa"} : (!fir.ref<f32>) -> !fir.ref<f32>
   acc.parallel combined(loop) {
-    %5 = acc.private varPtr(%2 : !fir.ref<f32>) recipe(@privatization_ref_f32) -> !fir.ref<f32> {name = "b"}
-    %6 = acc.private varPtr(%4 : !fir.ref<f32>) recipe(@privatization_ref_f32) -> !fir.ref<f32> {name = "a"}
+    %5 = acc.private varPtr(%2 : !fir.ref<f32>) recipe(@privatization_ref_f32) name("b") -> !fir.ref<f32>
+    %6 = acc.private varPtr(%4 : !fir.ref<f32>) recipe(@privatization_ref_f32) name("a") -> !fir.ref<f32>
     acc.loop combined(parallel) private(%5, %6 : !fir.ref<f32>, !fir.ref<f32>) control(%arg0 : i32) = (%c1_i32 : i32) to (%c10_i32 : i32)  step (%c1_i32 : i32) {
       %cvt = fir.convert %5 : (!fir.ref<f32>) -> !fir.ref<f32>
       %7 = fir.declare %cvt {uniq_name = "_QFtestEb"} : (!fir.ref<f32>) -> !fir.ref<f32>
@@ -2008,7 +2008,7 @@ func.func @test_acc_loop_private2_hoisting() {
       %8 = fir.declare %cvt2 {uniq_name = "_QFtestEa"} : (!fir.ref<f32>) -> !fir.ref<f32>
       fir.store %cst to %8 : !fir.ref<f32>
       acc.yield
-    } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+    } inclusiveUpperbound(array<i1: true>) independent
     acc.yield
   }
   return
@@ -2375,7 +2375,7 @@ func.func @test_acc_loop_nested_canMoveOutOf(%arg0: !fir.ref<!fir.array<10xf32>>
   %1 = fir.alloca f32 {bindc_name = "b", uniq_name = "_QFtestEb"}
   %2 = fir.declare %1 {uniq_name = "_QFtestEb"} : (!fir.ref<f32>) -> !fir.ref<f32>
   acc.parallel combined(loop) {
-    %priv = acc.private varPtr(%2 : !fir.ref<f32>) recipe(@privatization_ref_f32) -> !fir.ref<f32> {name = "b"}
+    %priv = acc.private varPtr(%2 : !fir.ref<f32>) recipe(@privatization_ref_f32) name("b") -> !fir.ref<f32>
     acc.loop combined(parallel) private(%priv : !fir.ref<f32>) control(%arg1 : i32) = (%c1_i32 : i32) to (%c10_i32 : i32)  step (%c1_i32 : i32) {
       %cond = arith.cmpi slt, %arg1, %c5_i32 : i32
       scf.if %cond {
@@ -2386,7 +2386,7 @@ func.func @test_acc_loop_nested_canMoveOutOf(%arg0: !fir.ref<!fir.array<10xf32>>
         memref.store %cst, %cvt_arg[%idx] : memref<10xf32>
       }
       acc.yield
-    } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+    } inclusiveUpperbound(array<i1: true>) independent
     acc.yield
   }
   return

--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCBase.td
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCBase.td
@@ -19,6 +19,7 @@ include "mlir/IR/AttrTypeBase.td"
 def OpenACC_Dialect : Dialect {
   let name = "acc";
   let useDefaultAttributePrinterParser = 1;
+  let useStrictPropertiesInAssemblyFormat = 1;
   let useDefaultTypePrinterParser = 1;
   let cppNamespace = "::mlir::acc";
   let dependentDialects = ["::mlir::memref::MemRefDialect",

--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCCGOps.td
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCCGOps.td
@@ -170,7 +170,7 @@ def OpenACC_ReductionAccumulateOp
       }
     } {acc.par_dims = #acc<par_dims[thread_x]>}
     acc.reduction_accumulate %partial to %private <add>
-        : i32 -> memref<i32> {par_dims = #acc<par_dims[thread_x]>}
+        : i32 -> memref<i32> <{par_dims = #acc<par_dims[thread_x]>}>
     acc.reduction_combine %private into %shared <add> : memref<i32>
         {acc.par_dims = #acc<par_dims[thread_x]>}
     ```
@@ -182,7 +182,8 @@ def OpenACC_ReductionAccumulateOp
                        OpenACC_ReductionOperatorAttr:$reductionOperator,
                        OpenACC_GPUParallelDimsAttr:$par_dims);
   let assemblyFormat = [{
-    $value `to` $memref $reductionOperator `:` type($value) `->` type($memref) attr-dict
+    $value `to` $memref $reductionOperator `:` type($value) `->`
+    type($memref) prop-dict attr-dict
   }];
   let hasVerifier = 1;
 }
@@ -205,7 +206,8 @@ def OpenACC_ReductionAccumulateArrayOp
                        OpenACC_ReductionOperatorAttr:$reductionOperator,
                        OpenACC_GPUParallelDimsAttr:$par_dims);
   let assemblyFormat = [{
-    $memref `bounds` `(` $bounds `)` $reductionOperator `:` type($memref) attr-dict
+    $memref `bounds` `(` $bounds `)` $reductionOperator `:`
+    type($memref) prop-dict attr-dict
   }];
   let hasVerifier = 1;
 }
@@ -409,17 +411,17 @@ def OpenACC_ParWidthOp
 
     ```mlir
     // Known width from SSA value
-    %w1 = acc.par_width %vector_len {par_dim = #acc.par_dim<thread_x>}
+    %w1 = acc.par_width %vector_len par_dim(#acc.par_dim<thread_x>)
 
     // Unknown width (to be computed later)
-    %w2 = acc.par_width {par_dim = #acc.par_dim<block_x>}
+    %w2 = acc.par_width par_dim(#acc.par_dim<block_x>)
     ```
   }];
   let arguments = (ins Optional<Index>:$launchArg,
                        OpenACC_GPUParallelDimAttr:$par_dim);
   let results = (outs Index:$output);
   let assemblyFormat = [{
-    ($launchArg^)? attr-dict
+    ($launchArg^)? `par_dim` `(` qualified($par_dim) `)` attr-dict
   }];
 }
 
@@ -482,10 +484,10 @@ def OpenACC_GPUSharedMemoryOp : OpenACC_Op<"gpu_shared_memory"> {
     ```mlir
     %sz = arith.constant 128 : index
     %cache = acc.gpu_shared_memory(%sz)
-        {num_copies = 1 : i64,
+        <{num_copies = 1 : i64,
          static_upper_bound_bytes = 1560 : i64,
          dynamic_shared_memory_scaling_bytes = 12 : i64,
-         dynamic_shared_memory_fixed_bytes = 24 : i64}
+         dynamic_shared_memory_fixed_bytes = 24 : i64}>
         : (index) -> memref<?xf32, #gpu.address_space<workgroup>>
     ```
   }];
@@ -499,7 +501,8 @@ def OpenACC_GPUSharedMemoryOp : OpenACC_Op<"gpu_shared_memory"> {
   let results = (outs Res<AnyMemRef, "", [MemAlloc<DefaultResource, 0,
                                            FullEffect>]>:$result);
   let assemblyFormat = [{
-    (`(` $dynamic_sizes^ `)`)? attr-dict `:` functional-type(operands, results)
+    (`(` $dynamic_sizes^ `)`)? prop-dict attr-dict
+    `:` functional-type(operands, results)
   }];
   let builders = [
     OpBuilder<(ins "::mlir::Type":$resultType,
@@ -573,8 +576,8 @@ def OpenACC_ComputeRegionOp
     Example:
 
     ```mlir
-    %w0 = acc.par_width %c128 {par_dim = #acc.par_dim<thread_x>}
-    %w1 = acc.par_width %c8 {par_dim = #acc.par_dim<block_x>}
+    %w0 = acc.par_width %c128 par_dim(#acc.par_dim<thread_x>)
+    %w1 = acc.par_width %c8 par_dim(#acc.par_dim<block_x>)
     acc.compute_region launch(%arg0 = %w0, %arg1 = %w1)
         ins(%arg2 = %data) : (memref<1024xf32>) {
       %c0 = arith.constant 0 : index

--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCOps.td
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCOps.td
@@ -594,7 +594,7 @@ def OpenACC_DataBoundsOp : OpenACC_Op<"bounds",
       | `extent` `(` $extent `:` type($extent) `)`
       | `stride` `(` $stride `:` type($stride) `)`
       | `startIdx` `(` $startIdx `:` type($startIdx) `)`
-    ) attr-dict
+    ) (`strideInBytes` `(` $strideInBytes^ `)`)? attr-dict
   }];
 
   let hasVerifier = 1;
@@ -817,7 +817,11 @@ class OpenACC_DataEntryOp<string mnemonic, string clause,
       | `async` `` custom<DeviceTypeOperandsWithKeywordOnly>($asyncOperands,
             type($asyncOperands), $asyncOperandsDeviceType, $asyncOnly)
       | `recipe` `(` custom<RecipeSym>($recipe) `)`
-    ) `->` type($accVar) attr-dict
+      | `dataClause` `(` qualified($dataClause) `)`
+      | `structured` `(` $structured `)`
+      | `implicit` `(` $implicit `)`
+      | `name` `(` $name `)`
+    ) prop-dict `->` type($accVar) attr-dict
   }];
 
   let hasVerifier = 1;
@@ -1206,7 +1210,13 @@ class OpenACC_DataExitOpWithVarPtr<string mnemonic, string clause>
     (`async` `` custom<DeviceTypeOperandsWithKeywordOnly>($asyncOperands,
             type($asyncOperands), $asyncOperandsDeviceType, $asyncOnly)^)?
     `to` custom<Var>($var) `:` custom<VarPtrType>(type($var), $varType)
-    attr-dict
+    oilist(
+        `dataClause` `(` qualified($dataClause) `)`
+      | `structured` `(` $structured `)`
+      | `implicit` `(` $implicit `)`
+      | `name` `(` $name `)`
+    )
+    prop-dict attr-dict
   }];
 
   let builders = [
@@ -1278,7 +1288,13 @@ class OpenACC_DataExitOpNoVarPtr<string mnemonic, string clause>
     (`bounds` `(` $bounds^ `)` )?
     (`async` `` custom<DeviceTypeOperandsWithKeywordOnly>($asyncOperands,
             type($asyncOperands), $asyncOperandsDeviceType, $asyncOnly)^)?
-    attr-dict
+    oilist(
+        `dataClause` `(` qualified($dataClause) `)`
+      | `structured` `(` $structured `)`
+      | `implicit` `(` $implicit `)`
+      | `name` `(` $name `)`
+    )
+    prop-dict attr-dict
   }];
 
   let builders = [
@@ -1925,7 +1941,12 @@ def OpenACC_ParallelOp
       | `if` `(` $ifCond `)`
       | `reduction` `(` $reductionOperands `:` type($reductionOperands) `)`
     )
-    $region attr-dict-with-keyword
+    $region
+    oilist(
+        `defaultAttr` `(` qualified($defaultAttr) `)`
+      | `selfAttr` $selfAttr
+    )
+    attr-dict-with-keyword
   }];
 
   let hasVerifier = 1;
@@ -2067,7 +2088,12 @@ def OpenACC_SerialOp
       | `if` `(` $ifCond `)`
       | `reduction` `(` $reductionOperands `:` type($reductionOperands) `)`
     )
-    $region attr-dict-with-keyword
+    $region
+    oilist(
+        `defaultAttr` `(` qualified($defaultAttr) `)`
+      | `selfAttr` $selfAttr
+    )
+    attr-dict-with-keyword
   }];
 
   let hasVerifier = 1;
@@ -2258,7 +2284,12 @@ def OpenACC_KernelsOp
       | `if` `(` $ifCond `)`
       | `reduction` `(` $reductionOperands `:` type($reductionOperands) `)`
     )
-    $region attr-dict-with-keyword
+    $region
+    oilist(
+        `defaultAttr` `(` qualified($defaultAttr) `)`
+      | `selfAttr` $selfAttr
+    )
+    attr-dict-with-keyword
   }];
 
   let hasVerifier = 1;
@@ -2374,7 +2405,9 @@ def OpenACC_DataOp
           $waitOperandsDeviceType, $waitOperandsSegments, $hasWaitDevnum,
           $waitOnly)
     )
-    $region attr-dict-with-keyword
+    $region
+    (`defaultAttr` `(` qualified($defaultAttr)^ `)`)?
+    attr-dict-with-keyword
   }];
   let hasVerifier = 1;
 }
@@ -2534,6 +2567,7 @@ def OpenACC_ExitDataOp : OpenACC_Op<"exit_data",
       | `wait` `` custom<OperandsWithKeywordOnly>($waitOperands,
             type($waitOperands), $wait)
       | `dataOperands` `(` $dataClauseOperands `:` type($dataClauseOperands) `)`
+      | `finalize` $finalize
     )
     attr-dict-with-keyword
   }];
@@ -2579,7 +2613,7 @@ def OpenACC_HostDataOp
         `if` `(` $ifCond `)`
       | `dataOperands` `(` $dataClauseOperands `:` type($dataClauseOperands) `)`
     )
-    $region attr-dict-with-keyword
+    $region (`ifPresent` $ifPresent^)? attr-dict-with-keyword
   }];
 
   let hasVerifier = 1;
@@ -2876,6 +2910,15 @@ def OpenACC_LoopOp
     custom<LoopControl>($region, $lowerbound, type($lowerbound), $upperbound,
         type($upperbound), $step, type($step))
     ( `(` type($results)^ `)` )?
+    oilist(
+        `inclusiveUpperbound` `(` custom<DenseBoolArrayAttr>($inclusiveUpperbound) `)`
+      | `collapse` `(` custom<ArrayAttr>($collapse) `)`
+      | `collapseDeviceType` `(` custom<ArrayAttr>($collapseDeviceType) `)`
+      | `seq` custom<DeviceTypeArrayAttr>($seq)
+      | `independent` custom<DeviceTypeArrayAttr>($independent)
+      | `auto_` custom<DeviceTypeArrayAttr>($auto_)
+      | `unstructured` $unstructured
+    )
     attr-dict-with-keyword
   }];
 
@@ -3506,6 +3549,7 @@ def OpenACC_InitOp : OpenACC_Op<"init", [AttrSizedOperandSegments]> {
   let assemblyFormat = [{
     oilist(`device_num` `(` $deviceNum `:` type($deviceNum) `)`
       | `if` `(` $ifCond `)`
+      | `device_types` `(` qualified($device_types) `)`
     ) attr-dict-with-keyword
   }];
   let hasVerifier = 1;
@@ -3542,6 +3586,7 @@ def OpenACC_ShutdownOp : OpenACC_Op<"shutdown", [AttrSizedOperandSegments]> {
   let assemblyFormat = [{
     oilist(`device_num` `(` $deviceNum `:` type($deviceNum) `)`
     |`if` `(` $ifCond `)`
+    | `device_types` `(` qualified($device_types) `)`
     ) attr-dict-with-keyword
   }];
   let hasVerifier = 1;
@@ -3574,6 +3619,7 @@ def OpenACC_SetOp : OpenACC_Op<"set", [AttrSizedOperandSegments,
     oilist(`default_async` `(` $defaultAsync `:` type($defaultAsync) `)`
     | `device_num` `(` $deviceNum `:` type($deviceNum) `)`
     | `if` `(` $ifCond `)`
+    | `device_type` `(` qualified($device_type) `)`
     ) attr-dict-with-keyword
   }];
   let hasVerifier = 1;
@@ -3678,6 +3724,7 @@ def OpenACC_UpdateOp : OpenACC_Op<"update",
           $waitOperandsDeviceType, $waitOperandsSegments, $hasWaitDevnum,
           $waitOnly)
       | `dataOperands` `(` $dataClauseOperands `:` type($dataClauseOperands) `)`
+      | `ifPresent` $ifPresent
     )
     attr-dict-with-keyword
   }];

--- a/mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp
+++ b/mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp
@@ -940,6 +940,26 @@ static void printRecipeSym(mlir::OpAsmPrinter &p, mlir::Operation *op,
   p << recipeAttr;
 }
 
+static ParseResult parseDenseBoolArrayAttr(mlir::OpAsmParser &parser,
+                                           mlir::DenseBoolArrayAttr &attr) {
+  return parser.parseAttribute(attr);
+}
+
+static void printDenseBoolArrayAttr(mlir::OpAsmPrinter &p, mlir::Operation *op,
+                                    mlir::DenseBoolArrayAttr attr) {
+  p << attr;
+}
+
+static ParseResult parseArrayAttr(mlir::OpAsmParser &parser,
+                                  mlir::ArrayAttr &attr) {
+  return parser.parseAttribute(attr);
+}
+
+static void printArrayAttr(mlir::OpAsmPrinter &p, mlir::Operation *op,
+                           mlir::ArrayAttr attr) {
+  p << attr;
+}
+
 //===----------------------------------------------------------------------===//
 // DataBoundsOp
 //===----------------------------------------------------------------------===//
@@ -2715,11 +2735,17 @@ static ParseResult parseDeviceTypeOperandsWithKeywordOnly(
       return failure();
     if (parser.parseRSquare())
       return failure();
+    keywordOnlyDeviceType =
+        ArrayAttr::get(parser.getContext(), keywordOnlyDeviceTypeAttributes);
     needCommaBeforeOperands = true;
   }
 
-  if (needCommaBeforeOperands && failed(parser.parseComma()))
-    return failure();
+  if (needCommaBeforeOperands) {
+    if (succeeded(parser.parseOptionalRParen()))
+      return success();
+    if (failed(parser.parseComma()))
+      return failure();
+  }
 
   llvm::SmallVector<DeviceTypeAttr> attributes;
   if (failed(parser.parseCommaSeparatedList([&]() {

--- a/mlir/test/Conversion/OpenACCToLLVM/init-shutdown-set.mlir
+++ b/mlir/test/Conversion/OpenACCToLLVM/init-shutdown-set.mlir
@@ -31,10 +31,10 @@
 module {
   func.func @test_init_shutdown() {
     %c2_i32 = arith.constant 2 : i32
-    acc.init device_num(%c2_i32 : i32) attributes {device_types = [#acc.device_type<nvidia>]}
-    acc.shutdown device_num(%c2_i32 : i32) attributes {device_types = [#acc.device_type<nvidia>]}
-    acc.init attributes {device_types = [#acc.device_type<nvidia>, #acc.device_type<host>]}
-    acc.shutdown attributes {device_types = [#acc.device_type<nvidia>, #acc.device_type<host>]}
+    acc.init device_num(%c2_i32 : i32) device_types([#acc.device_type<nvidia>])
+    acc.shutdown device_num(%c2_i32 : i32) device_types([#acc.device_type<nvidia>])
+    acc.init device_types([#acc.device_type<nvidia>, #acc.device_type<host>])
+    acc.shutdown device_types([#acc.device_type<nvidia>, #acc.device_type<host>])
     acc.init device_num(%c2_i32 : i32)
     acc.shutdown device_num(%c2_i32 : i32)
     acc.init
@@ -54,7 +54,7 @@ module {
   func.func @test_set() {
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32
-    acc.set default_async(%c1_i32 : i32) device_num(%c0_i32 : i32) attributes {device_type = #acc.device_type<nvidia>}
+    acc.set default_async(%c1_i32 : i32) device_num(%c0_i32 : i32) device_type(#acc.device_type<nvidia>)
     return
   }
 }
@@ -67,7 +67,7 @@ module {
 
 module {
   func.func @test_set_device_type() {
-    acc.set attributes {device_type = #acc.device_type<host>}
+    acc.set device_type(#acc.device_type<host>)
     return
   }
 }
@@ -83,7 +83,7 @@ module {
 
 module {
   func.func @test_if(%cond: i1) {
-    acc.init if(%cond) attributes {device_types = [#acc.device_type<nvidia>]}
+    acc.init if(%cond) device_types([#acc.device_type<nvidia>])
     return
   }
 }

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-barrier-gang-private-init.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-barrier-gang-private-init.mlir
@@ -14,9 +14,9 @@ func.func @test_gang_private_init_barrier(%arg0: memref<100x100xf32>) {
   %c10 = arith.constant 10 : index
   %c8 = arith.constant 8 : index
   %c100 = arith.constant 100 : index
-  %12 = acc.copyin varPtr(%arg0 : memref<100x100xf32>) -> memref<100x100xf32> {dataClause = #acc<data_clause acc_copy>, name = "gp"}
-  %13 = acc.par_width %c10 {par_dim = #acc.par_dim<block_x>}
-  %14 = acc.par_width %c128 {par_dim = #acc.par_dim<thread_x>}
+  %12 = acc.copyin varPtr(%arg0 : memref<100x100xf32>) dataClause(acc_copy) name("gp") -> memref<100x100xf32>
+  %13 = acc.par_width %c10 par_dim(#acc.par_dim<block_x>)
+  %14 = acc.par_width %c128 par_dim(#acc.par_dim<thread_x>)
   acc.kernel_environment dataOperands(%12 : memref<100x100xf32>) {
     %15 = acc.privatize [#acc<par_dims[block_x]>] : () -> !acc.private_type<memref<8xf32>>
     acc.compute_region launch(%arg1 = %13, %arg2 = %14) ins(%arg10 = %12, %arg11 = %15) : (memref<100x100xf32>, !acc.private_type<memref<8xf32>>) {
@@ -67,9 +67,9 @@ func.func @test_thread_private_init_no_barrier(%arg0: memref<100x100xf32>) {
   %c10 = arith.constant 10 : index
   %c8 = arith.constant 8 : index
   %c100 = arith.constant 100 : index
-  %12 = acc.copyin varPtr(%arg0 : memref<100x100xf32>) -> memref<100x100xf32> {dataClause = #acc<data_clause acc_copy>, name = "gp"}
-  %13 = acc.par_width %c10 {par_dim = #acc.par_dim<block_x>}
-  %14 = acc.par_width %c128 {par_dim = #acc.par_dim<thread_x>}
+  %12 = acc.copyin varPtr(%arg0 : memref<100x100xf32>) dataClause(acc_copy) name("gp") -> memref<100x100xf32>
+  %13 = acc.par_width %c10 par_dim(#acc.par_dim<block_x>)
+  %14 = acc.par_width %c128 par_dim(#acc.par_dim<thread_x>)
   acc.kernel_environment dataOperands(%12 : memref<100x100xf32>) {
     %15 = acc.privatize [#acc<par_dims[block_x, thread_x]>] : () -> !acc.private_type<memref<8xf32>>
     acc.compute_region launch(%arg1 = %13, %arg2 = %14) ins(%arg10 = %12, %arg11 = %15) : (memref<100x100xf32>, !acc.private_type<memref<8xf32>>) {

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-block-redundant-seq-gang-private.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-block-redundant-seq-gang-private.mlir
@@ -14,9 +14,9 @@
 func.func @block_redundant_seq_gang_private(%arg0: memref<32xi32>) {
   %c32_pw = arith.constant 32 : index
   %c1_pw = arith.constant 1 : index
-  %par_bx = acc.par_width %c32_pw {par_dim = #acc.par_dim<block_x>}
-  %par_ty = acc.par_width %c1_pw {par_dim = #acc.par_dim<thread_y>}
-  %par_tx = acc.par_width %c32_pw {par_dim = #acc.par_dim<thread_x>}
+  %par_bx = acc.par_width %c32_pw par_dim(#acc.par_dim<block_x>)
+  %par_ty = acc.par_width %c1_pw par_dim(#acc.par_dim<thread_y>)
+  %par_tx = acc.par_width %c32_pw par_dim(#acc.par_dim<thread_x>)
   acc.kernel_environment {
     %priv = acc.privatize : () -> !acc.private_type<memref<32xi32>>
     acc.compute_region launch(%grid = %par_bx, %worker = %par_ty, %block = %par_tx)

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-block-redundant.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-block-redundant.mlir
@@ -16,8 +16,8 @@
 
 func.func @block_redundant_vector_no_predicate(%arg0: memref<32xi32>) {
   %c32 = arith.constant 32 : index
-  %par_bx = acc.par_width %c32 {par_dim = #acc.par_dim<block_x>}
-  %par_tx = acc.par_width %c32 {par_dim = #acc.par_dim<thread_x>}
+  %par_bx = acc.par_width %c32 par_dim(#acc.par_dim<block_x>)
+  %par_tx = acc.par_width %c32 par_dim(#acc.par_dim<thread_x>)
   acc.kernel_environment {
     acc.compute_region launch(%grid = %par_bx, %block = %par_tx)
         ins(%arg10 = %arg0) : (memref<32xi32>) {

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-bound-routine-call.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-bound-routine-call.mlir
@@ -11,7 +11,7 @@
 // CHECK: func.call @bound_vector
 func.func @bound_vector_call(%arg0: memref<4xf32>) {
   %c32 = arith.constant 32 : index
-  %thread_x = acc.par_width %c32 {par_dim = #acc.par_dim<thread_x>}
+  %thread_x = acc.par_width %c32 par_dim(#acc.par_dim<thread_x>)
   acc.compute_region launch(%tx = %thread_x) ins(%arg10 = %arg0) : (memref<4xf32>) {
     acc.predicate_region {
       func.call @wrapped_vector(%arg10) : (memref<4xf32>) -> ()

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-launch-mapping.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-launch-mapping.mlir
@@ -133,8 +133,8 @@ func.func @par2_1_loop() {
 // CHECK: scf.parallel (%[[iv2:.*]]) = (%[[c1]]) to (%[[c4:.*]]) step (%[[c1]])
 // CHECK: arith.addi %[[iv2]], %[[tidx]]
 func.func @par2_0_1_loop() {
-  %par_dim1 = acc.par_width {par_dim = #acc.par_dim<thread_x>}
-  %par_dim2 = acc.par_width {par_dim = #acc.par_dim<thread_y>}
+  %par_dim1 = acc.par_width par_dim(#acc.par_dim<thread_x>)
+  %par_dim2 = acc.par_width par_dim(#acc.par_dim<thread_y>)
   acc.compute_region launch(%arg0 = %par_dim1, %arg1 = %par_dim2) {
     %c1 = arith.constant 1 : index
     %c4 = arith.constant 4 : index
@@ -188,7 +188,7 @@ func.func @empty() {
 // CHECK-SAME: in (%[[bdimx:[a-z0-9_]+]] = %[[bdimx_val]], %[[bdimy:[a-z0-9_]+]] = %[[bdimy_val:[a-z0-9_]+]], %[[bdimz:[a-z0-9_]+]] = %[[bdimz_val:[a-z0-9_]+]])
 func.func @empty_some_known_launch_arg() {
   %c32 = arith.constant 32 : index
-  %par_dim1 = acc.par_width %c32 {par_dim = #acc.par_dim<thread_x>}
+  %par_dim1 = acc.par_width %c32 par_dim(#acc.par_dim<thread_x>)
   acc.compute_region launch(%arg0 = %par_dim1) {
     acc.yield
   } {origin = "acc.parallel"}
@@ -223,12 +223,12 @@ func.func @empty_all_known_launch_arg() {
   %c32 = arith.constant 32 : index
   %c128 = arith.constant 128 : index
 
-  %par_dim1 = acc.par_width %c2 {par_dim = #acc.par_dim<thread_x>}
-  %par_dim2 = acc.par_width %c4 {par_dim = #acc.par_dim<thread_y>}
-  %par_dim3 = acc.par_width %c8 {par_dim = #acc.par_dim<thread_z>}
-  %par_dim4 = acc.par_width %c16 {par_dim = #acc.par_dim<block_x>}
-  %par_dim5 = acc.par_width %c32 {par_dim = #acc.par_dim<block_y>}
-  %par_dim6 = acc.par_width %c128 {par_dim = #acc.par_dim<block_z>}
+  %par_dim1 = acc.par_width %c2 par_dim(#acc.par_dim<thread_x>)
+  %par_dim2 = acc.par_width %c4 par_dim(#acc.par_dim<thread_y>)
+  %par_dim3 = acc.par_width %c8 par_dim(#acc.par_dim<thread_z>)
+  %par_dim4 = acc.par_width %c16 par_dim(#acc.par_dim<block_x>)
+  %par_dim5 = acc.par_width %c32 par_dim(#acc.par_dim<block_y>)
+  %par_dim6 = acc.par_width %c128 par_dim(#acc.par_dim<block_z>)
   acc.compute_region launch(%tx = %par_dim1, %ty = %par_dim2, %tz = %par_dim3, %bx = %par_dim4, %by = %par_dim5, %bz = %par_dim6) {
     acc.yield
   } {origin = "acc.parallel"}
@@ -252,12 +252,12 @@ func.func @using_block_args(%arr : memref<?xf32>) {
   %c32_pw = arith.constant 32 : index
   %c128_pw = arith.constant 128 : index
 
-  %par_dim1 = acc.par_width %c2_pw {par_dim = #acc.par_dim<thread_x>}
-  %par_dim2 = acc.par_width %c4_pw {par_dim = #acc.par_dim<thread_y>}
-  %par_dim3 = acc.par_width %c8_pw {par_dim = #acc.par_dim<thread_z>}
-  %par_dim4 = acc.par_width %c16_pw {par_dim = #acc.par_dim<block_x>}
-  %par_dim5 = acc.par_width %c32_pw {par_dim = #acc.par_dim<block_y>}
-  %par_dim6 = acc.par_width %c128_pw {par_dim = #acc.par_dim<block_z>}
+  %par_dim1 = acc.par_width %c2_pw par_dim(#acc.par_dim<thread_x>)
+  %par_dim2 = acc.par_width %c4_pw par_dim(#acc.par_dim<thread_y>)
+  %par_dim3 = acc.par_width %c8_pw par_dim(#acc.par_dim<thread_z>)
+  %par_dim4 = acc.par_width %c16_pw par_dim(#acc.par_dim<block_x>)
+  %par_dim5 = acc.par_width %c32_pw par_dim(#acc.par_dim<block_y>)
+  %par_dim6 = acc.par_width %c128_pw par_dim(#acc.par_dim<block_z>)
   acc.compute_region launch(%tx = %par_dim1, %ty = %par_dim2, %tz = %par_dim3, %bx = %par_dim4, %by = %par_dim5, %bz = %par_dim6) ins(%arg10 = %arr) : (memref<?xf32>) {
     %c0 = arith.constant 0 : index
     %c2 = arith.constant 2 : index

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-predicate-region-reuse-barrier.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-predicate-region-reuse-barrier.mlir
@@ -17,8 +17,8 @@
 func.func @reuse_barrier_in_block_seq_loop() {
   %c256_pw = arith.constant 256 : index
   %c1024_pw = arith.constant 1024 : index
-  %par_bx = acc.par_width %c256_pw {par_dim = #acc.par_dim<block_x>}
-  %par_tx = acc.par_width %c1024_pw {par_dim = #acc.par_dim<thread_x>}
+  %par_bx = acc.par_width %c256_pw par_dim(#acc.par_dim<block_x>)
+  %par_tx = acc.par_width %c1024_pw par_dim(#acc.par_dim<thread_x>)
   acc.kernel_environment {
     %priv0 = acc.privatize : () -> !acc.private_type<memref<i64>>
     acc.compute_region launch(%grid = %par_bx, %block = %par_tx) ins(%arg10 = %priv0) : (!acc.private_type<memref<i64>>) {
@@ -56,8 +56,8 @@ func.func @reuse_barrier_in_block_seq_loop() {
 func.func @no_reuse_barrier_outside_seq_loop() {
   %c256_pw = arith.constant 256 : index
   %c1024_pw = arith.constant 1024 : index
-  %par_bx = acc.par_width %c256_pw {par_dim = #acc.par_dim<block_x>}
-  %par_tx = acc.par_width %c1024_pw {par_dim = #acc.par_dim<thread_x>}
+  %par_bx = acc.par_width %c256_pw par_dim(#acc.par_dim<block_x>)
+  %par_tx = acc.par_width %c1024_pw par_dim(#acc.par_dim<thread_x>)
   acc.kernel_environment {
     %priv0 = acc.privatize : () -> !acc.private_type<memref<i64>>
     acc.compute_region launch(%grid = %par_bx, %block = %par_tx) ins(%arg10 = %priv0) : (!acc.private_type<memref<i64>>) {

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-predicate-region.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-predicate-region.mlir
@@ -7,9 +7,9 @@
 
 func.func @predicate_region_reduction(%arg0: memref<i32>) {
   %c1 = arith.constant 1 : index
-  %0 = acc.par_width %c1 {par_dim = #acc.par_dim<block_x>}
-  %1 = acc.par_width %c1 {par_dim = #acc.par_dim<thread_y>}
-  %2 = acc.par_width %c1 {par_dim = #acc.par_dim<thread_x>}
+  %0 = acc.par_width %c1 par_dim(#acc.par_dim<block_x>)
+  %1 = acc.par_width %c1 par_dim(#acc.par_dim<thread_y>)
+  %2 = acc.par_width %c1 par_dim(#acc.par_dim<thread_x>)
   acc.kernel_environment {
     acc.compute_region launch(%arg1 = %0, %arg2 = %1, %arg3 = %2) ins(%arg10 = %arg0) : (memref<i32>) {
       %c0_i32 = arith.constant 0 : i32

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-private-local-gang-redundant.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-private-local-gang-redundant.mlir
@@ -15,9 +15,9 @@
 func.func @gang_redundant_worker_private() {
   %c1 = arith.constant 1 : index
   %c4 = arith.constant 4 : index
-  %0 = acc.par_width %c4 {par_dim = #acc.par_dim<block_x>}
-  %1 = acc.par_width %c4 {par_dim = #acc.par_dim<thread_y>}
-  %2 = acc.par_width %c1 {par_dim = #acc.par_dim<thread_x>}
+  %0 = acc.par_width %c4 par_dim(#acc.par_dim<block_x>)
+  %1 = acc.par_width %c4 par_dim(#acc.par_dim<thread_y>)
+  %2 = acc.par_width %c1 par_dim(#acc.par_dim<thread_x>)
   %3 = acc.privatize [#acc<par_dims[thread_y]>] : () -> !acc.private_type<memref<1xi32>>
   acc.kernel_environment {
     acc.compute_region launch(%arg0 = %0, %arg1 = %1, %arg2 = %2) ins(%arg10 = %3) : (!acc.private_type<memref<1xi32>>) {

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-privatize-local.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-privatize-local.mlir
@@ -10,8 +10,8 @@ module attributes {gpu.container_module} {
     gpu.func @test()
         attributes {acc.specialized_routine = #acc.specialized_routine<@test_routine, <worker>, "test">} {
       %c1 = arith.constant 1 : index
-      %1 = acc.par_width %c1 {par_dim = #acc.par_dim<thread_x>}
-      %2 = acc.par_width %c1 {par_dim = #acc.par_dim<block_x>}
+      %1 = acc.par_width %c1 par_dim(#acc.par_dim<thread_x>)
+      %2 = acc.par_width %c1 par_dim(#acc.par_dim<block_x>)
       %4 = acc.privatize : () -> !acc.private_type<memref<4xi8>>
       acc.compute_region launch(%arg3 = %1, %arg4 = %2) ins(%arg10 = %4) : (!acc.private_type<memref<4xi8>>) {
         %8 = acc.private_local %arg10 : (!acc.private_type<memref<4xi8>>) -> memref<f32>

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-privatize-routine-seq.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-privatize-routine-seq.mlir
@@ -22,7 +22,7 @@ module attributes {gpu.container_module} {
     gpu.func @seq_routine()
         attributes {acc.specialized_routine = #acc.specialized_routine<@routine_seq, <seq>, "seq_routine">} {
       %c1 = arith.constant 1 : index
-      %0 = acc.par_width %c1 {par_dim = #acc.par_dim<sequential>}
+      %0 = acc.par_width %c1 par_dim(#acc.par_dim<sequential>)
       // CHECK: memref.alloca() : memref<10xi32>
       // CHECK-NOT: memref.store {{.*}} #gpu.address_space<workgroup>
       %1 = acc.privatize : () -> !acc.private_type<memref<10xi32>>

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-privatize-threadprivate.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-privatize-threadprivate.mlir
@@ -37,8 +37,8 @@ func.func @threadprivate(%host: memref<i32>) {
 func.func @dynamic_threadprivate(%n: index) {
   %c4 = arith.constant 4 : index
   %c128 = arith.constant 128 : index
-  %bx = acc.par_width %c4 {par_dim = #acc.par_dim<block_x>}
-  %tx = acc.par_width %c128 {par_dim = #acc.par_dim<thread_x>}
+  %bx = acc.par_width %c4 par_dim(#acc.par_dim<block_x>)
+  %tx = acc.par_width %c128 par_dim(#acc.par_dim<thread_x>)
   %private = acc.privatize(%n) [#acc<par_dims[block_x, thread_x]>]
       : (index) -> !acc.private_type<memref<?xi32>>
 

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-array-shared.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-array-shared.mlir
@@ -16,12 +16,12 @@
 // CHECK-NOT: acc.bounds
 
 func.func @array_reduction_shared(%arg0: memref<8192xi32>) {
-  %0 = acc.copyin varPtr(%arg0 : memref<8192xi32>) -> memref<8192xi32> {dataClause = #acc<data_clause acc_reduction>, implicit = true, name = "r"}
+  %0 = acc.copyin varPtr(%arg0 : memref<8192xi32>) dataClause(acc_reduction) implicit(true) name("r") -> memref<8192xi32>
   acc.kernel_environment dataOperands(%0 : memref<8192xi32>) {
     %c1_pw = arith.constant 1 : index
     %c128 = arith.constant 128 : index
-    %bx = acc.par_width %c1_pw {par_dim = #acc.par_dim<block_x>}
-    %tx = acc.par_width %c128 {par_dim = #acc.par_dim<thread_x>}
+    %bx = acc.par_width %c1_pw par_dim(#acc.par_dim<block_x>)
+    %tx = acc.par_width %c128 par_dim(#acc.par_dim<thread_x>)
     acc.compute_region launch(%kbx = %bx, %ktx = %tx) ins(%arg2 = %0) : (memref<8192xi32>) {
       %c8192 = arith.constant 8192 : index
       %c0_i32 = arith.constant 0 : i32
@@ -46,7 +46,7 @@ func.func @array_reduction_shared(%arg0: memref<8192xi32>) {
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_x]>}
       %b = acc.bounds extent(%c8192 : index)
-      acc.reduction_accumulate_array %2 bounds(%b) <add> : memref<8192xi32> {par_dims = #acc<par_dims[block_x, thread_x]>}
+      acc.reduction_accumulate_array %2 bounds(%b) <add> : memref<8192xi32> <{par_dims = #acc<par_dims[block_x, thread_x]>}>
       acc.reduction_combine_region %2 into %arg2 : memref<8192xi32> {
         scf.for %i = %c0 to %c8192 step %c1 {
           %3 = memref.load %2[%i] : memref<8192xi32>
@@ -58,7 +58,7 @@ func.func @array_reduction_shared(%arg0: memref<8192xi32>) {
       acc.yield
     } {origin = "acc.parallel"}
   }
-  acc.copyout accPtr(%0 : memref<8192xi32>) to varPtr(%arg0 : memref<8192xi32>) {dataClause = #acc<data_clause acc_reduction>, implicit = true, name = "r"}
+  acc.copyout accPtr(%0 : memref<8192xi32>) to varPtr(%arg0 : memref<8192xi32>) dataClause(acc_reduction) implicit(true) name("r")
   return
 }
 
@@ -72,12 +72,12 @@ func.func @array_reduction_shared(%arg0: memref<8192xi32>) {
 // CHECK-NOT: acc.reduction_accumulate_array
 
 func.func @array_reduction_shared_partitioned(%arg0: memref<8192xi32>) {
-  %0 = acc.copyin varPtr(%arg0 : memref<8192xi32>) -> memref<8192xi32> {dataClause = #acc<data_clause acc_reduction>, implicit = true, name = "r"}
+  %0 = acc.copyin varPtr(%arg0 : memref<8192xi32>) dataClause(acc_reduction) implicit(true) name("r") -> memref<8192xi32>
   acc.kernel_environment dataOperands(%0 : memref<8192xi32>) {
     %c1_pw = arith.constant 1 : index
     %c128 = arith.constant 128 : index
-    %bx = acc.par_width %c1_pw {par_dim = #acc.par_dim<block_x>}
-    %tx = acc.par_width %c128 {par_dim = #acc.par_dim<thread_x>}
+    %bx = acc.par_width %c1_pw par_dim(#acc.par_dim<block_x>)
+    %tx = acc.par_width %c128 par_dim(#acc.par_dim<thread_x>)
     acc.compute_region launch(%kbx = %bx, %ktx = %tx) ins(%arg2 = %0) : (memref<8192xi32>) {
       %c8192 = arith.constant 8192 : index
       %c0_i32 = arith.constant 0 : i32
@@ -102,7 +102,7 @@ func.func @array_reduction_shared_partitioned(%arg0: memref<8192xi32>) {
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_x]>}
       %b = acc.bounds extent(%c8192 : index)
-      acc.reduction_accumulate_array %2 bounds(%b) <add> : memref<8192xi32> {par_dims = #acc<par_dims[block_x, thread_x]>}
+      acc.reduction_accumulate_array %2 bounds(%b) <add> : memref<8192xi32> <{par_dims = #acc<par_dims[block_x, thread_x]>}>
       acc.reduction_combine_region %2 into %arg2 : memref<8192xi32> {
         scf.for %i = %c0 to %c8192 step %c1 {
           %3 = memref.load %2[%i] : memref<8192xi32>
@@ -114,7 +114,7 @@ func.func @array_reduction_shared_partitioned(%arg0: memref<8192xi32>) {
       acc.yield
     } {origin = "acc.parallel"}
   }
-  acc.copyout accPtr(%0 : memref<8192xi32>) to varPtr(%arg0 : memref<8192xi32>) {dataClause = #acc<data_clause acc_reduction>, implicit = true, name = "r"}
+  acc.copyout accPtr(%0 : memref<8192xi32>) to varPtr(%arg0 : memref<8192xi32>) dataClause(acc_reduction) implicit(true) name("r")
   return
 }
 
@@ -130,14 +130,14 @@ func.func @array_reduction_shared_partitioned(%arg0: memref<8192xi32>) {
 // CHECK-NOT: acc.reduction_accumulate_array
 
 func.func @array_reduction_gang_storage_thread_accum(%arg0: memref<4xi32>) {
-  %0 = acc.copyin varPtr(%arg0 : memref<4xi32>) -> memref<4xi32> {dataClause = #acc<data_clause acc_reduction>, implicit = true, name = "r"}
+  %0 = acc.copyin varPtr(%arg0 : memref<4xi32>) dataClause(acc_reduction) implicit(true) name("r") -> memref<4xi32>
   acc.kernel_environment dataOperands(%0 : memref<4xi32>) {
     %c2 = arith.constant 2 : index
     %c4 = arith.constant 4 : index
     %c32 = arith.constant 32 : index
-    %bx = acc.par_width %c2 {par_dim = #acc.par_dim<block_x>}
-    %wy = acc.par_width %c4 {par_dim = #acc.par_dim<thread_y>}
-    %tx = acc.par_width %c32 {par_dim = #acc.par_dim<thread_x>}
+    %bx = acc.par_width %c2 par_dim(#acc.par_dim<block_x>)
+    %wy = acc.par_width %c4 par_dim(#acc.par_dim<thread_y>)
+    %tx = acc.par_width %c32 par_dim(#acc.par_dim<thread_x>)
     %private = acc.privatize [#acc<par_dims[block_x]>] : () -> !acc.private_type<memref<4xi32>>
     acc.compute_region launch(%kbx = %bx, %kwy = %wy, %ktx = %tx) ins(%arg2 = %0, %priv = %private) : (memref<4xi32>, !acc.private_type<memref<4xi32>>) {
       %c0 = arith.constant 0 : index
@@ -157,12 +157,12 @@ func.func @array_reduction_gang_storage_thread_accum(%arg0: memref<4xi32>) {
           scf.reduce
         } {acc.par_dims = #acc<par_dims[thread_y]>}
         %b = acc.bounds extent(%c4_idx : index)
-        acc.reduction_accumulate_array %local bounds(%b) <add> : memref<4xi32> {par_dims = #acc<par_dims[thread_y]>}
+        acc.reduction_accumulate_array %local bounds(%b) <add> : memref<4xi32> <{par_dims = #acc<par_dims[thread_y]>}>
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_x]>}
       acc.yield
     } {origin = "acc.parallel"}
   }
-  acc.copyout accPtr(%0 : memref<4xi32>) to varPtr(%arg0 : memref<4xi32>) {dataClause = #acc<data_clause acc_reduction>, implicit = true, name = "r"}
+  acc.copyout accPtr(%0 : memref<4xi32>) to varPtr(%arg0 : memref<4xi32>) dataClause(acc_reduction) implicit(true) name("r")
   return
 }

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-array.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-array.mlir
@@ -17,12 +17,12 @@
 // CHECK: }
 
 func.func @array_reduction(%arg0: memref<2xi32>) {
-  %0 = acc.copyin varPtr(%arg0 : memref<2xi32>) -> memref<2xi32> {dataClause = #acc<data_clause acc_reduction>, implicit = true, name = "r"}
+  %0 = acc.copyin varPtr(%arg0 : memref<2xi32>) dataClause(acc_reduction) implicit(true) name("r") -> memref<2xi32>
   acc.kernel_environment dataOperands(%0 : memref<2xi32>) {
     %c1_pw = arith.constant 1 : index
     %c128 = arith.constant 128 : index
-    %bx = acc.par_width %c1_pw {par_dim = #acc.par_dim<block_x>}
-    %tx = acc.par_width %c128 {par_dim = #acc.par_dim<thread_x>}
+    %bx = acc.par_width %c1_pw par_dim(#acc.par_dim<block_x>)
+    %tx = acc.par_width %c128 par_dim(#acc.par_dim<thread_x>)
     acc.compute_region launch(%kbx = %bx, %ktx = %tx) ins(%arg2 = %0) : (memref<2xi32>) {
       %c2 = arith.constant 2 : index
       %c0_i32 = arith.constant 0 : i32
@@ -47,7 +47,7 @@ func.func @array_reduction(%arg0: memref<2xi32>) {
         scf.reduce
       } {acc.par_dims = #acc<par_dims[block_x]>}
       %b = acc.bounds extent(%c2 : index)
-      acc.reduction_accumulate_array %2 bounds(%b) <add> : memref<2xi32> {par_dims = #acc<par_dims[block_x, thread_x]>}
+      acc.reduction_accumulate_array %2 bounds(%b) <add> : memref<2xi32> <{par_dims = #acc<par_dims[block_x, thread_x]>}>
       acc.reduction_combine_region %2 into %arg2 : memref<2xi32> {
         scf.for %i = %c0 to %c2 step %c1 {
           %3 = memref.load %2[%i] : memref<2xi32>
@@ -59,7 +59,7 @@ func.func @array_reduction(%arg0: memref<2xi32>) {
       acc.yield
     } {origin = "acc.parallel"}
   }
-  acc.copyout accPtr(%0 : memref<2xi32>) to varPtr(%arg0 : memref<2xi32>) {dataClause = #acc<data_clause acc_reduction>, implicit = true, name = "r"}
+  acc.copyout accPtr(%0 : memref<2xi32>) to varPtr(%arg0 : memref<2xi32>) dataClause(acc_reduction) implicit(true) name("r")
   return
 }
 
@@ -70,14 +70,14 @@ func.func @array_reduction(%arg0: memref<2xi32>) {
 func.func @array_reduction_small_shared() {
   %c1 = arith.constant 1 : index
   %c128 = arith.constant 128 : index
-  %bx = acc.par_width %c1 {par_dim = #acc.par_dim<block_x>}
-  %tx = acc.par_width %c128 {par_dim = #acc.par_dim<thread_x>}
+  %bx = acc.par_width %c1 par_dim(#acc.par_dim<block_x>)
+  %tx = acc.par_width %c128 par_dim(#acc.par_dim<thread_x>)
   acc.compute_region launch(%kbx = %bx, %ktx = %tx) {
     %c2 = arith.constant 2 : index
     %shared = memref.alloc() : memref<2xi32>
     %bounds = acc.bounds extent(%c2 : index)
     acc.reduction_accumulate_array %shared bounds(%bounds) <add>
-        : memref<2xi32> {par_dims = #acc<par_dims[block_x, thread_x]>}
+        : memref<2xi32> <{par_dims = #acc<par_dims[block_x, thread_x]>}>
     memref.dealloc %shared : memref<2xi32>
     acc.yield
   } {origin = "acc.parallel"}
@@ -95,8 +95,8 @@ func.func @array_reduction_small_shared() {
 func.func @array_reduction_strided_extent() {
   %c1 = arith.constant 1 : index
   %c128 = arith.constant 128 : index
-  %bx = acc.par_width %c1 {par_dim = #acc.par_dim<block_x>}
-  %tx = acc.par_width %c128 {par_dim = #acc.par_dim<thread_x>}
+  %bx = acc.par_width %c1 par_dim(#acc.par_dim<block_x>)
+  %tx = acc.par_width %c128 par_dim(#acc.par_dim<thread_x>)
   acc.compute_region launch(%kbx = %bx, %ktx = %tx) {
     %c1_b = arith.constant 1 : index
     %c2 = arith.constant 2 : index
@@ -105,7 +105,7 @@ func.func @array_reduction_strided_extent() {
     %bounds = acc.bounds lowerbound(%c1_b : index) extent(%c3 : index)
         stride(%c2 : index)
     acc.reduction_accumulate_array %local bounds(%bounds) <add>
-        : memref<8xi32> {par_dims = #acc<par_dims[block_x, thread_x]>}
+        : memref<8xi32> <{par_dims = #acc<par_dims[block_x, thread_x]>}>
     acc.yield
   } {origin = "acc.parallel"}
   return
@@ -121,15 +121,15 @@ func.func @array_reduction_strided_extent() {
 func.func @array_reduction_dynamic_par_dims(%buf: memref<?xi32>, %n: index) {
   %c1 = arith.constant 1 : index
   %c128 = arith.constant 128 : index
-  %bx = acc.par_width %c1 {par_dim = #acc.par_dim<block_x>}
-  %tx = acc.par_width %c128 {par_dim = #acc.par_dim<thread_x>}
+  %bx = acc.par_width %c1 par_dim(#acc.par_dim<block_x>)
+  %tx = acc.par_width %c128 par_dim(#acc.par_dim<thread_x>)
   acc.compute_region launch(%kbx = %bx, %ktx = %tx) ins(%arg0 = %buf, %ext = %n) : (memref<?xi32>, index) {
     %view = memref.reinterpret_cast %arg0 to offset: [0], sizes: [%ext], strides: [1]
         : memref<?xi32> to memref<?xi32, strided<[1]>>
     %bounds = acc.bounds extent(%ext : index)
     acc.reduction_accumulate_array %view bounds(%bounds) <add>
         : memref<?xi32, strided<[1]>>
-        {par_dims = #acc<par_dims[block_x, thread_x]>}
+        <{par_dims = #acc<par_dims[block_x, thread_x]>}>
     acc.yield
   } {origin = "acc.parallel"}
   return
@@ -151,14 +151,14 @@ func.func @array_reduction_dynamic_par_dims(%buf: memref<?xi32>, %n: index) {
 func.func @rank_two_array_reduction() {
   %c1 = arith.constant 1 : index
   %c128 = arith.constant 128 : index
-  %bx = acc.par_width %c1 {par_dim = #acc.par_dim<block_x>}
-  %tx = acc.par_width %c128 {par_dim = #acc.par_dim<thread_x>}
+  %bx = acc.par_width %c1 par_dim(#acc.par_dim<block_x>)
+  %tx = acc.par_width %c128 par_dim(#acc.par_dim<thread_x>)
   %private = acc.privatize [#acc<par_dims[block_x, thread_x]>] : () -> !acc.private_type<memref<2x3xi32>>
   acc.compute_region launch(%kbx = %bx, %ktx = %tx) ins(%arg0 = %private) : (!acc.private_type<memref<2x3xi32>>) {
     %c6 = arith.constant 6 : index
     %local = acc.private_local %arg0 {acc.par_dims = #acc<par_dims[block_x, thread_x]>} : (!acc.private_type<memref<2x3xi32>>) -> memref<2x3xi32>
     %bounds = acc.bounds extent(%c6 : index)
-    acc.reduction_accumulate_array %local bounds(%bounds) <add> : memref<2x3xi32> {par_dims = #acc<par_dims[block_x, thread_x]>}
+    acc.reduction_accumulate_array %local bounds(%bounds) <add> : memref<2x3xi32> <{par_dims = #acc<par_dims[block_x, thread_x]>}>
     acc.yield
   } {origin = "acc.parallel"}
   return
@@ -183,14 +183,14 @@ func.func @rank_two_array_reduction() {
 func.func @rank_three_array_reduction() {
   %c1 = arith.constant 1 : index
   %c128 = arith.constant 128 : index
-  %bx = acc.par_width %c1 {par_dim = #acc.par_dim<block_x>}
-  %tx = acc.par_width %c128 {par_dim = #acc.par_dim<thread_x>}
+  %bx = acc.par_width %c1 par_dim(#acc.par_dim<block_x>)
+  %tx = acc.par_width %c128 par_dim(#acc.par_dim<thread_x>)
   %private = acc.privatize [#acc<par_dims[block_x, thread_x]>] : () -> !acc.private_type<memref<2x2x2xi32>>
   acc.compute_region launch(%kbx = %bx, %ktx = %tx) ins(%arg0 = %private) : (!acc.private_type<memref<2x2x2xi32>>) {
     %c8 = arith.constant 8 : index
     %local = acc.private_local %arg0 {acc.par_dims = #acc<par_dims[block_x, thread_x]>} : (!acc.private_type<memref<2x2x2xi32>>) -> memref<2x2x2xi32>
     %bounds = acc.bounds extent(%c8 : index)
-    acc.reduction_accumulate_array %local bounds(%bounds) <add> : memref<2x2x2xi32> {par_dims = #acc<par_dims[block_x, thread_x]>}
+    acc.reduction_accumulate_array %local bounds(%bounds) <add> : memref<2x2x2xi32> <{par_dims = #acc<par_dims[block_x, thread_x]>}>
     acc.yield
   } {origin = "acc.parallel"}
   return
@@ -210,15 +210,15 @@ func.func @dynamic_rank_two_array_reduction(
     %local: memref<2x?xi32>, %n: index) {
   %c1 = arith.constant 1 : index
   %c128 = arith.constant 128 : index
-  %bx = acc.par_width %c1 {par_dim = #acc.par_dim<block_x>}
-  %tx = acc.par_width %c128 {par_dim = #acc.par_dim<thread_x>}
+  %bx = acc.par_width %c1 par_dim(#acc.par_dim<block_x>)
+  %tx = acc.par_width %c128 par_dim(#acc.par_dim<thread_x>)
   acc.compute_region launch(%kbx = %bx, %ktx = %tx)
       ins(%arg0 = %local, %arg1 = %n)
       : (memref<2x?xi32>, index) {
     %c2 = arith.constant 2 : index
     %extent = arith.muli %c2, %arg1 : index
     %bounds = acc.bounds extent(%extent : index)
-    acc.reduction_accumulate_array %arg0 bounds(%bounds) <add> : memref<2x?xi32> {par_dims = #acc<par_dims[block_x, thread_x]>}
+    acc.reduction_accumulate_array %arg0 bounds(%bounds) <add> : memref<2x?xi32> <{par_dims = #acc<par_dims[block_x, thread_x]>}>
     acc.yield
   } {origin = "acc.parallel"}
   return
@@ -239,8 +239,8 @@ func.func @dynamic_rank_two_array_reduction(
 func.func @rank_two_partial_bounds_strided_layout() {
   %c1 = arith.constant 1 : index
   %c128 = arith.constant 128 : index
-  %bx = acc.par_width %c1 {par_dim = #acc.par_dim<block_x>}
-  %tx = acc.par_width %c128 {par_dim = #acc.par_dim<thread_x>}
+  %bx = acc.par_width %c1 par_dim(#acc.par_dim<block_x>)
+  %tx = acc.par_width %c128 par_dim(#acc.par_dim<thread_x>)
   acc.compute_region launch(%kbx = %bx, %ktx = %tx) {
     %lb = arith.constant 5 : index
     %step = arith.constant 2 : index
@@ -250,7 +250,7 @@ func.func @rank_two_partial_bounds_strided_layout() {
         stride(%step : index)
     acc.reduction_accumulate_array %local bounds(%bounds) <add>
         : memref<3x4xi32, strided<[8, 2]>>
-        {par_dims = #acc<par_dims[block_x, thread_x]>}
+        <{par_dims = #acc<par_dims[block_x, thread_x]>}>
     acc.yield
   } {origin = "acc.parallel"}
   return
@@ -265,14 +265,14 @@ func.func @rank_two_partial_bounds_strided_layout() {
 func.func @partial_thread_x_reduction() {
   %c1 = arith.constant 1 : index
   %c16 = arith.constant 16 : index
-  %bx = acc.par_width %c1 {par_dim = #acc.par_dim<block_x>}
-  %tx = acc.par_width %c16 {par_dim = #acc.par_dim<thread_x>}
+  %bx = acc.par_width %c1 par_dim(#acc.par_dim<block_x>)
+  %tx = acc.par_width %c16 par_dim(#acc.par_dim<thread_x>)
   acc.compute_region launch(%kbx = %bx, %ktx = %tx) {
     %c2 = arith.constant 2 : index
     %local = memref.alloca() : memref<2xi32>
     %bounds = acc.bounds extent(%c2 : index)
     acc.reduction_accumulate_array %local bounds(%bounds) <add>
-        : memref<2xi32> {par_dims = #acc<par_dims[block_x, thread_x]>}
+        : memref<2xi32> <{par_dims = #acc<par_dims[block_x, thread_x]>}>
     acc.yield
   } {origin = "acc.parallel"}
   return
@@ -285,14 +285,14 @@ func.func @partial_thread_x_reduction() {
 func.func @thread_y_reduction_still_aligned() {
   %c1 = arith.constant 1 : index
   %c16 = arith.constant 16 : index
-  %bx = acc.par_width %c1 {par_dim = #acc.par_dim<block_x>}
-  %ty = acc.par_width %c16 {par_dim = #acc.par_dim<thread_y>}
+  %bx = acc.par_width %c1 par_dim(#acc.par_dim<block_x>)
+  %ty = acc.par_width %c16 par_dim(#acc.par_dim<thread_y>)
   acc.compute_region launch(%kbx = %bx, %kty = %ty) {
     %c0_i32 = arith.constant 0 : i32
     %local = memref.alloca() : memref<i32>
     acc.reduction_accumulate %c0_i32 to %local <add>
         : i32 -> memref<i32>
-        {par_dims = #acc<par_dims[block_x, thread_y]>}
+        <{par_dims = #acc<par_dims[block_x, thread_y]>}>
     acc.yield
   } {origin = "acc.parallel"}
   return
@@ -309,15 +309,15 @@ func.func @thread_x_reduction_with_thread_y_width() {
   %c1 = arith.constant 1 : index
   %c2 = arith.constant 2 : index
   %c16 = arith.constant 16 : index
-  %bx = acc.par_width %c1 {par_dim = #acc.par_dim<block_x>}
-  %tx = acc.par_width %c16 {par_dim = #acc.par_dim<thread_x>}
-  %ty = acc.par_width %c2 {par_dim = #acc.par_dim<thread_y>}
+  %bx = acc.par_width %c1 par_dim(#acc.par_dim<block_x>)
+  %tx = acc.par_width %c16 par_dim(#acc.par_dim<thread_x>)
+  %ty = acc.par_width %c2 par_dim(#acc.par_dim<thread_y>)
   acc.compute_region launch(%kbx = %bx, %ktx = %tx, %kty = %ty) {
     %c0_i32 = arith.constant 0 : i32
     %local = memref.alloca() : memref<i32>
     acc.reduction_accumulate %c0_i32 to %local <add>
         : i32 -> memref<i32>
-        {par_dims = #acc<par_dims[block_x, thread_x]>}
+        <{par_dims = #acc<par_dims[block_x, thread_x]>}>
     acc.yield
   } {origin = "acc.parallel"}
   return
@@ -334,15 +334,15 @@ func.func @thread_x_reduction_with_thread_z_width() {
   %c1 = arith.constant 1 : index
   %c3 = arith.constant 3 : index
   %c341 = arith.constant 341 : index
-  %bx = acc.par_width %c1 {par_dim = #acc.par_dim<block_x>}
-  %tx = acc.par_width %c341 {par_dim = #acc.par_dim<thread_x>}
-  %tz = acc.par_width %c3 {par_dim = #acc.par_dim<thread_z>}
+  %bx = acc.par_width %c1 par_dim(#acc.par_dim<block_x>)
+  %tx = acc.par_width %c341 par_dim(#acc.par_dim<thread_x>)
+  %tz = acc.par_width %c3 par_dim(#acc.par_dim<thread_z>)
   acc.compute_region launch(%kbx = %bx, %ktx = %tx, %ktz = %tz) {
     %c0_i32 = arith.constant 0 : i32
     %local = memref.alloca() : memref<i32>
     acc.reduction_accumulate %c0_i32 to %local <add>
         : i32 -> memref<i32>
-        {par_dims = #acc<par_dims[block_x, thread_x]>}
+        <{par_dims = #acc<par_dims[block_x, thread_x]>}>
     acc.yield
   } {origin = "acc.parallel"}
   return
@@ -360,7 +360,7 @@ func.func @thread_x_reduction_with_thread_z_width() {
 // CHECK: }
 func.func @thread_only_array_reduction_single_block() {
   %c128 = arith.constant 128 : index
-  %tx = acc.par_width %c128 {par_dim = #acc.par_dim<thread_x>}
+  %tx = acc.par_width %c128 par_dim(#acc.par_dim<thread_x>)
   acc.compute_region launch(%ktx = %tx) {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
@@ -372,7 +372,7 @@ func.func @thread_only_array_reduction_single_block() {
     }
     %bounds = acc.bounds extent(%c8 : index)
     acc.reduction_accumulate_array %local bounds(%bounds) <add>
-        : memref<8xi32> {par_dims = #acc<par_dims[thread_x]>}
+        : memref<8xi32> <{par_dims = #acc<par_dims[thread_x]>}>
     acc.yield
   } {origin = "acc.parallel"}
   return

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-block-combine-no-reload.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-block-combine-no-reload.mlir
@@ -24,8 +24,8 @@ module attributes {gpu.container_module} {
   func.func @test_block_combine_no_reload(%arg_slot: memref<i32>, %arg_res: memref<i32>) {
     %c1_pw = arith.constant 1 : index
     %c128 = arith.constant 128 : index
-    %bx = acc.par_width %c1_pw {par_dim = #acc.par_dim<block_x>}
-    %tx = acc.par_width %c128 {par_dim = #acc.par_dim<thread_x>}
+    %bx = acc.par_width %c1_pw par_dim(#acc.par_dim<block_x>)
+    %tx = acc.par_width %c128 par_dim(#acc.par_dim<thread_x>)
     acc.compute_region launch(%kbx = %bx, %ktx = %tx) ins(%a_slot = %arg_slot, %a_res = %arg_res) : (memref<i32>, memref<i32>) {
       %c0 = arith.constant 0 : index
       %c1 = arith.constant 1 : index
@@ -47,7 +47,7 @@ module attributes {gpu.container_module} {
               scf.reduce.return %sum : i32
             }
           } {acc.par_dims = #acc<par_dims[sequential]>}
-          acc.reduction_accumulate %inner_red to %a_slot <add> : i32 -> memref<i32> {par_dims = #acc<par_dims[block_x, thread_x]>}
+          acc.reduction_accumulate %inner_red to %a_slot <add> : i32 -> memref<i32> <{par_dims = #acc<par_dims[block_x, thread_x]>}>
           scf.reduce
         } {acc.par_dims = #acc<par_dims[thread_x]>}
         scf.reduce

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-combine-region-private-dest.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reduction-combine-region-private-dest.mlir
@@ -19,8 +19,8 @@
 func.func @combine_region_private_dest(%arg: memref<i32>) {
   %c1_pw = arith.constant 1 : index
   %c128 = arith.constant 128 : index
-  %bx = acc.par_width %c1_pw {par_dim = #acc.par_dim<block_x>}
-  %tx = acc.par_width %c128 {par_dim = #acc.par_dim<thread_x>}
+  %bx = acc.par_width %c1_pw par_dim(#acc.par_dim<block_x>)
+  %tx = acc.par_width %c128 par_dim(#acc.par_dim<thread_x>)
   %pv_outer = acc.privatize {acc.par_dims = #acc<par_dims[block_x, thread_x]>} : () -> !acc.private_type<memref<i32>>
   %pv_inner = acc.privatize {acc.par_dims = #acc<par_dims[block_x, thread_x]>} : () -> !acc.private_type<memref<i32>>
   acc.compute_region launch(%kbx = %bx, %ktx = %tx) ins(%a_res = %arg, %po = %pv_outer, %pi = %pv_inner) : (memref<i32>, !acc.private_type<memref<i32>>, !acc.private_type<memref<i32>>) {
@@ -49,7 +49,7 @@ func.func @combine_region_private_dest(%arg: memref<i32>) {
             memref.store %c1_i32, %inner[] : memref<i32>
           }
           %v = memref.load %inner[] : memref<i32>
-          acc.reduction_accumulate %v to %inner <add> : i32 -> memref<i32> {par_dims = #acc<par_dims[block_x, thread_x]>}
+          acc.reduction_accumulate %v to %inner <add> : i32 -> memref<i32> <{par_dims = #acc<par_dims[block_x, thread_x]>}>
           acc.predicate_region {
             acc.reduction_combine_region %inner into %outer : memref<i32> {
               %la = memref.load %outer[] : memref<i32>
@@ -62,7 +62,7 @@ func.func @combine_region_private_dest(%arg: memref<i32>) {
           scf.reduce
         } {acc.par_dims = #acc<par_dims[sequential]>}
         %ov = memref.load %outer[] : memref<i32>
-        acc.reduction_accumulate %ov to %outer <add> : i32 -> memref<i32> {par_dims = #acc<par_dims[block_x, thread_x]>}
+        acc.reduction_accumulate %ov to %outer <add> : i32 -> memref<i32> <{par_dims = #acc<par_dims[block_x, thread_x]>}>
         scf.reduce
       } {acc.par_dims = #acc<par_dims[thread_x]>}
       scf.reduce

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reuse-barrier-sibling-region-privatize.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-reuse-barrier-sibling-region-privatize.mlir
@@ -22,8 +22,8 @@
 func.func @sibling_regions_share_seq_loop() {
   %c256_pw = arith.constant 256 : index
   %c1024_pw = arith.constant 1024 : index
-  %par_bx = acc.par_width %c256_pw {par_dim = #acc.par_dim<block_x>}
-  %par_tx = acc.par_width %c1024_pw {par_dim = #acc.par_dim<thread_x>}
+  %par_bx = acc.par_width %c256_pw par_dim(#acc.par_dim<block_x>)
+  %par_tx = acc.par_width %c1024_pw par_dim(#acc.par_dim<thread_x>)
   acc.kernel_environment {
     %priv0 = acc.privatize : () -> !acc.private_type<memref<i64>>
     %priv1 = acc.privatize : () -> !acc.private_type<memref<i64>>

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-routine-worker-call-with-thread-y-reduction.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-routine-worker-call-with-thread-y-reduction.mlir
@@ -34,9 +34,9 @@ module attributes {gpu.container_module} {
   func.func @test_worker_routine_with_thread_y_reduction(%arg0: memref<16xi32>) {
     %c4 = arith.constant 4 : index
     %c32 = arith.constant 32 : index
-    %bx = acc.par_width %c4 {par_dim = #acc.par_dim<block_x>}
-    %tx = acc.par_width %c32 {par_dim = #acc.par_dim<thread_x>}
-    %ty = acc.par_width %c4 {par_dim = #acc.par_dim<thread_y>}
+    %bx = acc.par_width %c4 par_dim(#acc.par_dim<block_x>)
+    %tx = acc.par_width %c32 par_dim(#acc.par_dim<thread_x>)
+    %ty = acc.par_width %c4 par_dim(#acc.par_dim<thread_y>)
     %priv = acc.privatize : () -> !acc.private_type<memref<i32>>
     acc.compute_region launch(%kbx = %bx, %ktx = %tx, %kty = %ty)
         ins(%arg10 = %priv, %arg11 = %arg0)
@@ -62,7 +62,7 @@ module attributes {gpu.container_module} {
               scf.reduce.return %sum : i32
             }
           } {acc.par_dims = #acc<par_dims[sequential]>}
-          acc.reduction_accumulate %loop_red to %out_priv <add> : i32 -> memref<i32> {par_dims = #acc<par_dims[thread_y]>}
+          acc.reduction_accumulate %loop_red to %out_priv <add> : i32 -> memref<i32> <{par_dims = #acc<par_dims[thread_y]>}>
           scf.reduce
         } {acc.par_dims = #acc<par_dims[thread_y]>}
         scf.reduce

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-private-dynamic-nw.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-private-dynamic-nw.mlir
@@ -6,9 +6,9 @@
 func.func @test_worker_private_dynamic_nw(%nw: index) {
   %c32 = arith.constant 32 : index
   %c5 = arith.constant 5 : index
-  %block_x = acc.par_width %c5 {par_dim = #acc.par_dim<block_x>}
-  %thread_y = acc.par_width %nw {par_dim = #acc.par_dim<thread_y>}
-  %thread_x = acc.par_width %c32 {par_dim = #acc.par_dim<thread_x>}
+  %block_x = acc.par_width %c5 par_dim(#acc.par_dim<block_x>)
+  %thread_y = acc.par_width %nw par_dim(#acc.par_dim<thread_y>)
+  %thread_x = acc.par_width %c32 par_dim(#acc.par_dim<thread_x>)
   acc.kernel_environment {
     %priv = acc.privatize : () -> !acc.private_type<memref<2xi32>>
     // expected-error @below {{failed to legalize operation 'acc.compute_region'}}

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-private-foldable-nw.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-private-foldable-nw.mlir
@@ -9,9 +9,9 @@ func.func @test_worker_private_foldable_nw() {
   %c5 = arith.constant 5 : index
   %c32 = arith.constant 32 : index
   %nw = arith.addi %c1, %c1 : index
-  %block_x = acc.par_width %c5 {par_dim = #acc.par_dim<block_x>}
-  %thread_y = acc.par_width %nw {par_dim = #acc.par_dim<thread_y>}
-  %thread_x = acc.par_width %c32 {par_dim = #acc.par_dim<thread_x>}
+  %block_x = acc.par_width %c5 par_dim(#acc.par_dim<block_x>)
+  %thread_y = acc.par_width %nw par_dim(#acc.par_dim<thread_y>)
+  %thread_x = acc.par_width %c32 par_dim(#acc.par_dim<thread_x>)
   acc.kernel_environment {
     %priv = acc.privatize : () -> !acc.private_type<memref<2xi32>>
     acc.compute_region launch(%arg0 = %block_x, %arg1 = %thread_y, %arg2 = %thread_x) ins(%arg10 = %priv) : (!acc.private_type<memref<2xi32>>) {

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine-mixed-scope.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine-mixed-scope.mlir
@@ -6,9 +6,9 @@ func.func @mixed_scope_worker_reduction_combine(
   %c1 = arith.constant 1 : index
   %c4 = arith.constant 4 : index
   %c32 = arith.constant 32 : index
-  %block_y = acc.par_width %c1 {par_dim = #acc.par_dim<block_y>}
-  %thread_y = acc.par_width %c4 {par_dim = #acc.par_dim<thread_y>}
-  %thread_x = acc.par_width %c32 {par_dim = #acc.par_dim<thread_x>}
+  %block_y = acc.par_width %c1 par_dim(#acc.par_dim<block_y>)
+  %thread_y = acc.par_width %c4 par_dim(#acc.par_dim<thread_y>)
+  %thread_x = acc.par_width %c32 par_dim(#acc.par_dim<thread_x>)
   acc.kernel_environment {
     %private = acc.privatize [#acc<par_dims[thread_y]>]
         : () -> !acc.private_type<memref<i32>>
@@ -46,9 +46,9 @@ func.func @worker_combine_with_single_store(%result: memref<i32>) {
   %c1 = arith.constant 1 : index
   %c4 = arith.constant 4 : index
   %c32 = arith.constant 32 : index
-  %block_y = acc.par_width %c1 {par_dim = #acc.par_dim<block_y>}
-  %thread_y = acc.par_width %c4 {par_dim = #acc.par_dim<thread_y>}
-  %thread_x = acc.par_width %c32 {par_dim = #acc.par_dim<thread_x>}
+  %block_y = acc.par_width %c1 par_dim(#acc.par_dim<block_y>)
+  %thread_y = acc.par_width %c4 par_dim(#acc.par_dim<thread_y>)
+  %thread_x = acc.par_width %c32 par_dim(#acc.par_dim<thread_x>)
   acc.kernel_environment {
     %private = acc.privatize [#acc<par_dims[thread_y]>]
         : () -> !acc.private_type<memref<i32>>
@@ -86,9 +86,9 @@ func.func @worker_combine_with_atomic_update(%result: memref<i32>) {
   %c1 = arith.constant 1 : index
   %c4 = arith.constant 4 : index
   %c32 = arith.constant 32 : index
-  %block_y = acc.par_width %c1 {par_dim = #acc.par_dim<block_y>}
-  %thread_y = acc.par_width %c4 {par_dim = #acc.par_dim<thread_y>}
-  %thread_x = acc.par_width %c32 {par_dim = #acc.par_dim<thread_x>}
+  %block_y = acc.par_width %c1 par_dim(#acc.par_dim<block_y>)
+  %thread_y = acc.par_width %c4 par_dim(#acc.par_dim<thread_y>)
+  %thread_x = acc.par_width %c32 par_dim(#acc.par_dim<thread_x>)
   acc.kernel_environment {
     %private = acc.privatize [#acc<par_dims[thread_y]>]
         : () -> !acc.private_type<memref<i32>>

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-combine.mlir
@@ -15,9 +15,9 @@ func.func @worker_reduction_combine(%result: memref<i32>) {
   %c1 = arith.constant 1 : index
   %c4 = arith.constant 4 : index
   %c32 = arith.constant 32 : index
-  %block_y = acc.par_width %c1 {par_dim = #acc.par_dim<block_y>}
-  %thread_y = acc.par_width %c4 {par_dim = #acc.par_dim<thread_y>}
-  %thread_x = acc.par_width %c32 {par_dim = #acc.par_dim<thread_x>}
+  %block_y = acc.par_width %c1 par_dim(#acc.par_dim<block_y>)
+  %thread_y = acc.par_width %c4 par_dim(#acc.par_dim<thread_y>)
+  %thread_x = acc.par_width %c32 par_dim(#acc.par_dim<thread_x>)
   acc.kernel_environment {
     %private = acc.privatize [#acc<par_dims[thread_y]>]
         : () -> !acc.private_type<memref<i32>>
@@ -59,9 +59,9 @@ func.func @worker_reduction_combine_region(%result: memref<i32>) {
   %c1 = arith.constant 1 : index
   %c4 = arith.constant 4 : index
   %c32 = arith.constant 32 : index
-  %block_y = acc.par_width %c1 {par_dim = #acc.par_dim<block_y>}
-  %thread_y = acc.par_width %c4 {par_dim = #acc.par_dim<thread_y>}
-  %thread_x = acc.par_width %c32 {par_dim = #acc.par_dim<thread_x>}
+  %block_y = acc.par_width %c1 par_dim(#acc.par_dim<block_y>)
+  %thread_y = acc.par_width %c4 par_dim(#acc.par_dim<thread_y>)
+  %thread_x = acc.par_width %c32 par_dim(#acc.par_dim<thread_x>)
   acc.kernel_environment {
     %private = acc.privatize [#acc<par_dims[thread_y]>]
         : () -> !acc.private_type<memref<i32>>
@@ -109,9 +109,9 @@ func.func @nested_worker_reduction_combines(
   %c1 = arith.constant 1 : index
   %c4 = arith.constant 4 : index
   %c32 = arith.constant 32 : index
-  %block_y = acc.par_width %c1 {par_dim = #acc.par_dim<block_y>}
-  %thread_y = acc.par_width %c4 {par_dim = #acc.par_dim<thread_y>}
-  %thread_x = acc.par_width %c32 {par_dim = #acc.par_dim<thread_x>}
+  %block_y = acc.par_width %c1 par_dim(#acc.par_dim<block_y>)
+  %thread_y = acc.par_width %c4 par_dim(#acc.par_dim<thread_y>)
+  %thread_x = acc.par_width %c32 par_dim(#acc.par_dim<thread_x>)
   acc.kernel_environment {
     %private = acc.privatize [#acc<par_dims[thread_y]>]
         : () -> !acc.private_type<memref<i32>>
@@ -157,9 +157,9 @@ func.func @worker_combine_in_scf_if(%result: memref<i32>) {
   %c1 = arith.constant 1 : index
   %c4 = arith.constant 4 : index
   %c32 = arith.constant 32 : index
-  %block_y = acc.par_width %c1 {par_dim = #acc.par_dim<block_y>}
-  %thread_y = acc.par_width %c4 {par_dim = #acc.par_dim<thread_y>}
-  %thread_x = acc.par_width %c32 {par_dim = #acc.par_dim<thread_x>}
+  %block_y = acc.par_width %c1 par_dim(#acc.par_dim<block_y>)
+  %thread_y = acc.par_width %c4 par_dim(#acc.par_dim<thread_y>)
+  %thread_x = acc.par_width %c32 par_dim(#acc.par_dim<thread_x>)
   acc.kernel_environment {
     %private = acc.privatize [#acc<par_dims[thread_y]>]
         : () -> !acc.private_type<memref<i32>>

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-private.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-reduction-private.mlir
@@ -8,9 +8,9 @@ func.func @worker_reduction_private() {
   %c2 = arith.constant 2 : index
   %c4 = arith.constant 4 : index
   %c32 = arith.constant 32 : index
-  %block = acc.par_width %c2 {par_dim = #acc.par_dim<block_x>}
-  %worker = acc.par_width %c4 {par_dim = #acc.par_dim<thread_y>}
-  %vector = acc.par_width %c32 {par_dim = #acc.par_dim<thread_x>}
+  %block = acc.par_width %c2 par_dim(#acc.par_dim<block_x>)
+  %worker = acc.par_width %c4 par_dim(#acc.par_dim<thread_y>)
+  %vector = acc.par_width %c32 par_dim(#acc.par_dim<thread_x>)
   acc.kernel_environment {
     %private = acc.privatize [#acc<par_dims[thread_y]>] : () -> !acc.private_type<memref<i32>>
     acc.compute_region launch(%bx = %block, %wy = %worker, %vx = %vector)
@@ -29,7 +29,7 @@ func.func @worker_reduction_private() {
           } {acc.par_dims = #acc<par_dims[thread_y]>}
           %value = memref.load %local[] : memref<i32>
           acc.reduction_accumulate %value to %local <add>
-              : i32 -> memref<i32> {par_dims = #acc<par_dims[thread_y]>}
+              : i32 -> memref<i32> <{par_dims = #acc<par_dims[thread_y]>}>
           scf.reduce
         } {acc.par_dims = #acc<par_dims[sequential]>}
         scf.reduce

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-vector-reuse-barrier.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-vector-reuse-barrier.mlir
@@ -26,9 +26,9 @@ func.func @worker_seq_vector_reuse() {
   %c256_pw = arith.constant 256 : index
   %c4_pw = arith.constant 4 : index
   %c32_pw = arith.constant 32 : index
-  %par_bx = acc.par_width %c256_pw {par_dim = #acc.par_dim<block_x>}
-  %par_ty = acc.par_width %c4_pw {par_dim = #acc.par_dim<thread_y>}
-  %par_tx = acc.par_width %c32_pw {par_dim = #acc.par_dim<thread_x>}
+  %par_bx = acc.par_width %c256_pw par_dim(#acc.par_dim<block_x>)
+  %par_ty = acc.par_width %c4_pw par_dim(#acc.par_dim<thread_y>)
+  %par_tx = acc.par_width %c32_pw par_dim(#acc.par_dim<thread_x>)
   acc.kernel_environment {
     %priv0 = acc.privatize : () -> !acc.private_type<memref<32xf32>>
     acc.compute_region launch(%grid = %par_bx, %worker = %par_ty, %block = %par_tx) ins(%arg10 = %priv0) : (!acc.private_type<memref<32xf32>>) {

--- a/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-vector-subgroup-align.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-cg-to-gpu-worker-vector-subgroup-align.mlir
@@ -18,9 +18,9 @@ func.func @worker_divergent_subgroup_barrier() {
   %c256_pw = arith.constant 256 : index
   %c4_pw = arith.constant 4 : index
   %c16_pw = arith.constant 16 : index
-  %par_bx = acc.par_width %c256_pw {par_dim = #acc.par_dim<block_x>}
-  %par_ty = acc.par_width %c4_pw {par_dim = #acc.par_dim<thread_y>}
-  %par_tx = acc.par_width %c16_pw {par_dim = #acc.par_dim<thread_x>}
+  %par_bx = acc.par_width %c256_pw par_dim(#acc.par_dim<block_x>)
+  %par_ty = acc.par_width %c4_pw par_dim(#acc.par_dim<thread_y>)
+  %par_tx = acc.par_width %c16_pw par_dim(#acc.par_dim<thread_x>)
   acc.kernel_environment {
     %priv0 = acc.privatize : () -> !acc.private_type<memref<64xf32>>
     acc.compute_region launch(%grid = %par_bx, %worker = %par_ty, %block = %par_tx) ins(%arg10 = %priv0) : (!acc.private_type<memref<64xf32>>) {

--- a/mlir/test/Dialect/OpenACC/acc-compute-lowering-compute-device-type.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-compute-lowering-compute-device-type.mlir
@@ -10,14 +10,14 @@ func.func @parallel_default_gangs_nvidia_vector_length(%buf: memref<4xi32>) {
   %c32_i32 = arith.constant 32 : i32
 
   %dev = acc.copyin varPtr(%buf : memref<4xi32>) -> memref<4xi32>
-  // CHECK-NOT: acc.par_width {{.*}} {par_dim = #acc.par_dim<block_x>}
-  // CHECK: acc.par_width {{.*}} {par_dim = #acc.par_dim<thread_x>}
+  // CHECK-NOT: acc.par_width {{.*}} par_dim(#acc.par_dim<block_x>)
+  // CHECK: acc.par_width {{.*}} par_dim(#acc.par_dim<thread_x>)
   acc.parallel num_gangs({%c4_i32 : i32}) vector_length(%c32_i32 : i32 [#acc.device_type<nvidia>]) dataOperands(%dev : memref<4xi32>) {
     acc.loop control(%i : index) = (%c0 : index) to (%c4 : index) step (%c1 : index) {
       %vi = arith.index_cast %i : index to i32
       memref.store %vi, %dev[%i] : memref<4xi32>
       acc.yield
-    } attributes {independent = [#acc.device_type<none>]}
+    } independent
     acc.yield
   }
   acc.copyout accPtr(%dev : memref<4xi32>) to varPtr(%buf : memref<4xi32>)

--- a/mlir/test/Dialect/OpenACC/acc-compute-lowering-compute.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-compute-lowering-compute.mlir
@@ -10,7 +10,7 @@ func.func @parallel_gang_loop(%buf: memref<1xi32>) {
   %dev = acc.copyin varPtr(%buf : memref<1xi32>) -> memref<1xi32>
   // CHECK-NOT: acc.parallel
   // CHECK: acc.kernel_environment
-  // CHECK: acc.par_width {{.*}} {par_dim = #acc.par_dim<block_x>}
+  // CHECK: acc.par_width {{.*}} par_dim(#acc.par_dim<block_x>)
   // CHECK: acc.compute_region launch(
   // CHECK: scf.parallel
   // CHECK: acc.par_dims = #acc<par_dims[block_x]>
@@ -18,7 +18,7 @@ func.func @parallel_gang_loop(%buf: memref<1xi32>) {
     acc.loop gang control(%arg0 : i32) = (%c1_i32 : i32) to (%c100_i32 : i32) step (%c1_i32 : i32) {
       memref.store %arg0, %dev[%c0] : memref<1xi32>
       acc.yield
-    } attributes {independent = [#acc.device_type<none>]}
+    } independent
     acc.yield
   }
   acc.copyout accPtr(%dev : memref<1xi32>) to varPtr(%buf : memref<1xi32>)
@@ -37,7 +37,7 @@ func.func @parallel_seq_loop(%buf: memref<4xi32>) {
   %dev = acc.copyin varPtr(%buf : memref<4xi32>) -> memref<4xi32>
   // CHECK-NOT: acc.parallel
   // CHECK: acc.kernel_environment
-  // CHECK: acc.par_width {{.*}} {par_dim = #acc.par_dim<block_x>}
+  // CHECK: acc.par_width {{.*}} par_dim(#acc.par_dim<block_x>)
   // CHECK: acc.compute_region launch(
   // CHECK: scf.for
   // CHECK: acc.par_dims = #acc<par_dims[sequential]>
@@ -46,7 +46,7 @@ func.func @parallel_seq_loop(%buf: memref<4xi32>) {
       %vi = arith.index_cast %i : index to i32
       memref.store %vi, %dev[%i] : memref<4xi32>
       acc.yield
-    } attributes {seq = [#acc.device_type<none>]}
+    } seq
     acc.yield
   }
   acc.copyout accPtr(%dev : memref<4xi32>) to varPtr(%buf : memref<4xi32>)
@@ -64,7 +64,7 @@ func.func @serial_loop(%buf: memref<4xi32>) {
   %dev = acc.copyin varPtr(%buf : memref<4xi32>) -> memref<4xi32>
   // CHECK-NOT: acc.serial
   // CHECK: acc.kernel_environment
-  // CHECK: acc.par_width {par_dim = #acc.par_dim<sequential>}
+  // CHECK: acc.par_width par_dim(#acc.par_dim<sequential>)
   // CHECK: acc.compute_region launch(
   // CHECK: scf.for
   // CHECK: acc.par_dims = #acc<par_dims[sequential]>
@@ -73,7 +73,7 @@ func.func @serial_loop(%buf: memref<4xi32>) {
       %vi = arith.index_cast %i : index to i32
       memref.store %vi, %dev[%i] : memref<4xi32>
       acc.yield
-    } attributes {independent = [#acc.device_type<none>]}
+    } independent
     acc.yield
   }
   acc.copyout accPtr(%dev : memref<4xi32>) to varPtr(%buf : memref<4xi32>)
@@ -99,7 +99,7 @@ func.func @kernels_loop(%buf: memref<8xi32>) {
       %vi = arith.index_cast %i : index to i32
       memref.store %vi, %dev[%i] : memref<8xi32>
       acc.yield
-    } attributes {independent = [#acc.device_type<none>]}
+    } independent
     acc.terminator
   }
   acc.copyout accPtr(%dev : memref<8xi32>) to varPtr(%buf : memref<8xi32>)
@@ -117,7 +117,7 @@ func.func @constant_livein_materialized_into_compute_region(%buf: memref<1xi32>)
   %c42 = arith.constant 42 : i32
   %dev = acc.copyin varPtr(%buf : memref<1xi32>) -> memref<1xi32>
   // CHECK: acc.kernel_environment
-  // CHECK: acc.par_width {par_dim = #acc.par_dim<sequential>}
+  // CHECK: acc.par_width par_dim(#acc.par_dim<sequential>)
   // CHECK: acc.compute_region launch(
   // CHECK-SAME: ins({{.*}}) : (memref<1xi32>) {
   // CHECK-DAG: arith.constant 42 : i32
@@ -148,7 +148,7 @@ func.func @parallel_unit_launch_serial_loops(%buf: memref<4xi32>) {
   %dev = acc.copyin varPtr(%buf : memref<4xi32>) -> memref<4xi32>
   // CHECK-NOT: acc.parallel
   // CHECK: acc.kernel_environment
-  // CHECK: acc.par_width {par_dim = #acc.par_dim<sequential>}
+  // CHECK: acc.par_width par_dim(#acc.par_dim<sequential>)
   // CHECK: acc.compute_region launch(
   // CHECK: scf.for
   // CHECK: acc.par_dims = #acc<par_dims[sequential]>
@@ -157,7 +157,7 @@ func.func @parallel_unit_launch_serial_loops(%buf: memref<4xi32>) {
       %vi = arith.index_cast %i : index to i32
       memref.store %vi, %dev[%i] : memref<4xi32>
       acc.yield
-    } attributes {independent = [#acc.device_type<none>]}
+    } independent
     acc.yield
   }
   acc.copyout accPtr(%dev : memref<4xi32>) to varPtr(%buf : memref<4xi32>)
@@ -180,7 +180,7 @@ func.func @kernels_unit_launch_serial_loops(%buf: memref<4xi32>) {
   %dev = acc.copyin varPtr(%buf : memref<4xi32>) -> memref<4xi32>
   // CHECK-NOT: acc.kernels
   // CHECK: acc.kernel_environment
-  // CHECK: acc.par_width {par_dim = #acc.par_dim<sequential>}
+  // CHECK: acc.par_width par_dim(#acc.par_dim<sequential>)
   // CHECK: acc.compute_region launch(
   // CHECK: scf.for
   // CHECK: acc.par_dims = #acc<par_dims[sequential]>
@@ -189,7 +189,7 @@ func.func @kernels_unit_launch_serial_loops(%buf: memref<4xi32>) {
       %vi = arith.index_cast %i : index to i32
       memref.store %vi, %dev[%i] : memref<4xi32>
       acc.yield
-    } attributes {independent = [#acc.device_type<none>]}
+    } independent
     acc.terminator
   }
   acc.copyout accPtr(%dev : memref<4xi32>) to varPtr(%buf : memref<4xi32>)
@@ -210,11 +210,11 @@ func.func @parallel_vector_length32_independent(%buf: memref<4xi32>) {
   // CHECK-NOT: acc.par_dims = #acc<par_dims[sequential]>
   // CHECK: acc.par_dims = #acc<par_dims[thread_x]>
   acc.parallel num_gangs({%c1_i32 : i32}) num_workers(%c1_i32 : i32) vector_length(%c32_i32 : i32) dataOperands(%dev : memref<4xi32>) {
-    acc.loop control(%i : index) = (%c0 : index) to (%c4 : index) step (%c1 : index) {
+    acc.loop vector control(%i : index) = (%c0 : index) to (%c4 : index) step (%c1 : index) {
       %vi = arith.index_cast %i : index to i32
       memref.store %vi, %dev[%i] : memref<4xi32>
       acc.yield
-    } attributes {independent = [#acc.device_type<none>], vector = [#acc.device_type<none>]}
+    } independent
     acc.yield
   }
   acc.copyout accPtr(%dev : memref<4xi32>) to varPtr(%buf : memref<4xi32>)
@@ -235,11 +235,11 @@ func.func @kernels_num_gangs4_independent(%buf: memref<4xi32>) {
   // CHECK-NOT: acc.par_dims = #acc<par_dims[sequential]>
   // CHECK: acc.par_dims = #acc<par_dims[thread_x]>
   acc.kernels num_gangs({%c4_i32 : i32}) num_workers(%c1_i32 : i32) vector_length(%c1_i32 : i32) dataOperands(%dev : memref<4xi32>) {
-    acc.loop control(%i : index) = (%c0 : index) to (%c4 : index) step (%c1 : index) {
+    acc.loop vector control(%i : index) = (%c0 : index) to (%c4 : index) step (%c1 : index) {
       %vi = arith.index_cast %i : index to i32
       memref.store %vi, %dev[%i] : memref<4xi32>
       acc.yield
-    } attributes {independent = [#acc.device_type<none>], vector = [#acc.device_type<none>]}
+    } independent
     acc.terminator
   }
   acc.copyout accPtr(%dev : memref<4xi32>) to varPtr(%buf : memref<4xi32>)
@@ -260,11 +260,11 @@ func.func @parallel_num_gangs_1_2_independent(%buf: memref<4xi32>) {
   // CHECK-NOT: acc.par_dims = #acc<par_dims[sequential]>
   // CHECK: acc.par_dims = #acc<par_dims[thread_x]>
   acc.parallel num_gangs({%c1_i32 : i32, %c2_i32 : i32}) num_workers(%c1_i32 : i32) vector_length(%c1_i32 : i32) dataOperands(%dev : memref<4xi32>) {
-    acc.loop control(%i : index) = (%c0 : index) to (%c4 : index) step (%c1 : index) {
+    acc.loop vector control(%i : index) = (%c0 : index) to (%c4 : index) step (%c1 : index) {
       %vi = arith.index_cast %i : index to i32
       memref.store %vi, %dev[%i] : memref<4xi32>
       acc.yield
-    } attributes {independent = [#acc.device_type<none>], vector = [#acc.device_type<none>]}
+    } independent
     acc.yield
   }
   acc.copyout accPtr(%dev : memref<4xi32>) to varPtr(%buf : memref<4xi32>)

--- a/mlir/test/Dialect/OpenACC/acc-compute-lowering-loop-device-type.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-compute-lowering-loop-device-type.mlir
@@ -12,10 +12,10 @@ func.func @parallel_loop_gang_default_vector_nvidia(%buf: memref<1xi32>) {
   // CHECK-NOT: acc.par_dims = #acc<par_dims[block_x]>
   // CHECK: acc.par_dims = #acc<par_dims[thread_x]>
   acc.parallel num_gangs({%c10_i32 : i32}) dataOperands(%dev : memref<1xi32>) {
-    acc.loop gang control(%arg0 : i32) = (%c1_i32 : i32) to (%c100_i32 : i32) step (%c1_i32 : i32) {
+    acc.loop gang vector([#acc.device_type<nvidia>]) control(%arg0 : i32) = (%c1_i32 : i32) to (%c100_i32 : i32) step (%c1_i32 : i32) {
       memref.store %arg0, %dev[%c0] : memref<1xi32>
       acc.yield
-    } attributes {auto_ = [#acc.device_type<none>], gang = [#acc.device_type<none>], vector = [#acc.device_type<nvidia>]}
+    } auto_
     acc.yield
   }
   acc.copyout accPtr(%dev : memref<1xi32>) to varPtr(%buf : memref<1xi32>)

--- a/mlir/test/Dialect/OpenACC/acc-compute-lowering-loop.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-compute-lowering-loop.mlir
@@ -17,7 +17,7 @@ func.func @parallel_independent_loop(%buf: memref<16xi32>) {
       %vi = arith.index_cast %i : index to i32
       memref.store %vi, %dev[%i] : memref<16xi32>
       acc.yield
-    } attributes {independent = [#acc.device_type<none>]}
+    } independent
     acc.yield
   }
   acc.copyout accPtr(%dev : memref<16xi32>) to varPtr(%buf : memref<16xi32>)
@@ -46,7 +46,7 @@ func.func @parallel_loop_multi_block_body(%buf: memref<4xi32>) {
       cf.br ^bb1
     ^bb1:
       acc.yield
-    } attributes {independent = [#acc.device_type<none>]}
+    } independent
     acc.yield
   }
   acc.copyout accPtr(%dev : memref<4xi32>) to varPtr(%buf : memref<4xi32>)
@@ -74,7 +74,7 @@ func.func @parallel_loop_auto_collapse(%buf: memref<1xi32>, %lb0 : index, %ub0 :
       %vi = arith.index_cast %i : index to i32
       memref.store %vi, %dev[%c0] : memref<1xi32>
       acc.yield
-    } attributes {auto_ = [#acc.device_type<none>]}
+    } auto_
     acc.yield
   }
   acc.copyout accPtr(%dev : memref<1xi32>) to varPtr(%buf : memref<1xi32>)
@@ -102,7 +102,7 @@ func.func @parallel_loop_collapse(%buf: memref<1xi32>, %lb0 : index, %ub0 : inde
       %vi = arith.index_cast %i : index to i32
       memref.store %vi, %dev[%c0] : memref<1xi32>
       acc.yield
-    } attributes {independent = [#acc.device_type<none>]}
+    } independent
     acc.yield
   }
   acc.copyout accPtr(%dev : memref<1xi32>) to varPtr(%buf : memref<1xi32>)
@@ -121,7 +121,7 @@ func.func @serial_loop_normalized(%buf: memref<1xi32>) {
   %dev = acc.copyin varPtr(%buf : memref<1xi32>) -> memref<1xi32>
   // CHECK-NOT: acc.serial
   // CHECK: acc.kernel_environment
-  // CHECK: acc.par_width {par_dim = #acc.par_dim<sequential>}
+  // CHECK: acc.par_width par_dim(#acc.par_dim<sequential>)
   // CHECK: acc.compute_region launch(
   // CHECK: scf.for
   // CHECK-DAG: arith.muli
@@ -132,7 +132,7 @@ func.func @serial_loop_normalized(%buf: memref<1xi32>) {
       %vi = arith.index_cast %i : index to i32
       memref.store %vi, %dev[%c0] : memref<1xi32>
       acc.yield
-    } attributes {independent = [#acc.device_type<none>]}
+    } independent
     acc.yield
   }
   acc.copyout accPtr(%dev : memref<1xi32>) to varPtr(%buf : memref<1xi32>)
@@ -154,7 +154,7 @@ func.func @orphan_loop(%buf: memref<8xi32>) {
   acc.loop control(%i : index) = (%c0 : index) to (%c8 : index) step (%c1 : index) {
     memref.store %c0_i32, %buf[%i] : memref<8xi32>
     acc.yield
-  } attributes {independent = [#acc.device_type<none>]}
+  } independent
   return
 }
 
@@ -177,7 +177,7 @@ func.func @device_routine_with_loop(%buf: memref<8xi32>) attributes {acc.special
   acc.loop control(%i : index) = (%c0 : index) to (%c8 : index) step (%c1 : index) {
     memref.store %c0_i32, %buf[%i] : memref<8xi32>
     acc.yield
-  } attributes {independent = [#acc.device_type<none>]}
+  } independent
   return
 }
 
@@ -197,10 +197,10 @@ func.func @device_routine_vector_with_loop(%buf: memref<8xi32>) attributes {acc.
   %c8 = arith.constant 8 : index
   %c0_i32 = arith.constant 0 : i32
 
-  acc.loop control(%i : index) = (%c0 : index) to (%c8 : index) step (%c1 : index) {
+  acc.loop vector control(%i : index) = (%c0 : index) to (%c8 : index) step (%c1 : index) {
     memref.store %c0_i32, %buf[%i] : memref<8xi32>
     acc.yield
-  } attributes {independent = [#acc.device_type<none>], vector = [#acc.device_type<none>]}
+  } independent
   return
 }
 
@@ -217,7 +217,7 @@ func.func @parallel_loop_auto_gang(%buf: memref<1xi32>) {
   %dev = acc.copyin varPtr(%buf : memref<1xi32>) -> memref<1xi32>
   // CHECK-NOT: acc.parallel
   // CHECK: acc.kernel_environment
-  // CHECK: acc.par_width {{.*}} {par_dim = #acc.par_dim<block_x>}
+  // CHECK: acc.par_width {{.*}} par_dim(#acc.par_dim<block_x>)
   // CHECK: acc.compute_region launch(
   // CHECK: scf.for
   // CHECK-NOT: scf.parallel
@@ -226,7 +226,7 @@ func.func @parallel_loop_auto_gang(%buf: memref<1xi32>) {
     acc.loop gang control(%arg0 : i32) = (%c1_i32 : i32) to (%c100_i32 : i32) step (%c1_i32 : i32) {
       memref.store %arg0, %dev[%c0] : memref<1xi32>
       acc.yield
-    } attributes {auto_ = [#acc.device_type<none>]}
+    } auto_
     acc.yield
   }
   acc.copyout accPtr(%dev : memref<1xi32>) to varPtr(%buf : memref<1xi32>)

--- a/mlir/test/Dialect/OpenACC/acc-compute-lowering-unstructured.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-compute-lowering-unstructured.mlir
@@ -26,7 +26,7 @@ func.func @parallel_unstructured_loop(%buf: memref<10xi32>) {
       cf.br ^header(%iv_next : index)
     ^exit:
       acc.yield
-    } attributes {independent = [#acc.device_type<none>], unstructured}
+    } independent unstructured
     acc.yield
   }
   acc.copyout accPtr(%dev : memref<10xi32>) to varPtr(%buf : memref<10xi32>)

--- a/mlir/test/Dialect/OpenACC/acc-declare-ctor-dtor-conversion.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-declare-ctor-dtor-conversion.mlir
@@ -39,14 +39,14 @@ acc.global_ctor @other_arr_acc_ctor {
 }
 acc.global_dtor @arr_acc_dtor {
   %0 = llvm.mlir.addressof @arr {acc.declare = #acc.declare<dataClause = acc_create>} : !llvm.ptr
-  %1 = acc.getdeviceptr varPtr(%0 : !llvm.ptr) varType(!llvm.array<7 x f32>) -> !llvm.ptr {dataClause = #acc<data_clause acc_create>}
+  %1 = acc.getdeviceptr varPtr(%0 : !llvm.ptr) varType(!llvm.array<7 x f32>) dataClause(acc_create) -> !llvm.ptr
   acc.declare_exit dataOperands(%1 : !llvm.ptr)
   acc.delete accPtr(%1 : !llvm.ptr)
   acc.terminator
 }
 acc.global_dtor @other_arr_acc_dtor {
   %0 = llvm.mlir.addressof @other_arr {acc.declare = #acc.declare<dataClause = acc_create>} : !llvm.ptr
-  %1 = acc.getdeviceptr varPtr(%0 : !llvm.ptr) varType(!llvm.array<3 x f32>) -> !llvm.ptr {dataClause = #acc<data_clause acc_create>}
+  %1 = acc.getdeviceptr varPtr(%0 : !llvm.ptr) varType(!llvm.array<3 x f32>) dataClause(acc_create) -> !llvm.ptr
   acc.declare_exit dataOperands(%1 : !llvm.ptr)
   acc.delete accPtr(%1 : !llvm.ptr)
   acc.terminator

--- a/mlir/test/Dialect/OpenACC/acc-emit-remarks-data.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-emit-remarks-data.mlir
@@ -44,41 +44,29 @@ func.func @structured_data(
     %arg6: memref<f32>, %arg7: memref<f32>, %arg8: memref<f32>,
     %arg9: memref<f32>, %arg10: memref<f32>, %arg11: memref<f32>) {
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=structured_data | Remark="Generating copyin(a) [if not already present]"
-  %copyin = acc.copyin varPtr(%arg0 : memref<f32>) -> memref<f32>
-      {name = "a"}
+  %copyin = acc.copyin varPtr(%arg0 : memref<f32>) name("a") -> memref<f32>
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=structured_data | Remark="Generating copyin(readonly:b) [if not already present]"
-  %copyin_readonly = acc.copyin varPtr(%arg1 : memref<f32>) -> memref<f32>
-      {dataClause = #acc<data_clause acc_copyin_readonly>, name = "b"}
+  %copyin_readonly = acc.copyin varPtr(%arg1 : memref<f32>) dataClause(acc_copyin_readonly) name("b") -> memref<f32>
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=structured_data | Remark="Generating copy(c) [if not already present]"
-  %copy = acc.copyin varPtr(%arg2 : memref<f32>) -> memref<f32>
-      {dataClause = #acc<data_clause acc_copy>, name = "c"}
+  %copy = acc.copyin varPtr(%arg2 : memref<f32>) dataClause(acc_copy) name("c") -> memref<f32>
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=structured_data | Remark="Generating copyout(d) [if not already present]"
-  %copyout = acc.create varPtr(%arg3 : memref<f32>) -> memref<f32>
-      {dataClause = #acc<data_clause acc_copyout>, name = "d"}
+  %copyout = acc.create varPtr(%arg3 : memref<f32>) dataClause(acc_copyout) name("d") -> memref<f32>
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=structured_data | Remark="Generating copyout(zero:e) [if not already present]"
-  %copyout_zero = acc.create varPtr(%arg4 : memref<f32>) -> memref<f32>
-      {dataClause = #acc<data_clause acc_copyout_zero>, name = "e"}
+  %copyout_zero = acc.create varPtr(%arg4 : memref<f32>) dataClause(acc_copyout_zero) name("e") -> memref<f32>
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=structured_data | Remark="Generating present(f)"
-  %present = acc.present varPtr(%arg5 : memref<f32>) -> memref<f32>
-      {name = "f"}
+  %present = acc.present varPtr(%arg5 : memref<f32>) name("f") -> memref<f32>
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=structured_data | Remark="Generating create(g) [if not already present]"
-  %create = acc.create varPtr(%arg6 : memref<f32>) -> memref<f32>
-      {name = "g"}
+  %create = acc.create varPtr(%arg6 : memref<f32>) name("g") -> memref<f32>
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=structured_data | Remark="Generating create(zero:h) [if not already present]"
-  %create_zero = acc.create varPtr(%arg7 : memref<f32>) -> memref<f32>
-      {dataClause = #acc<data_clause acc_create_zero>, name = "h"}
+  %create_zero = acc.create varPtr(%arg7 : memref<f32>) dataClause(acc_create_zero) name("h") -> memref<f32>
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=structured_data | Remark="Generating attach(i)"
-  %attach = acc.attach varPtr(%arg8 : memref<f32>) -> memref<f32>
-      {name = "i"}
+  %attach = acc.attach varPtr(%arg8 : memref<f32>) name("i") -> memref<f32>
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=structured_data | Remark="Generating no_create(j) [if not already present]"
-  %no_create = acc.nocreate varPtr(%arg9 : memref<f32>) -> memref<f32>
-      {name = "j"}
+  %no_create = acc.nocreate varPtr(%arg9 : memref<f32>) name("j") -> memref<f32>
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=structured_data | Remark="Generating deviceptr(k)"
-  %deviceptr = acc.deviceptr varPtr(%arg10 : memref<f32>) -> memref<f32>
-      {name = "k"}
+  %deviceptr = acc.deviceptr varPtr(%arg10 : memref<f32>) name("k") -> memref<f32>
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=structured_data | Remark="Generating copy(l) [if not already present]"
-  %reduction_copy = acc.copyin varPtr(%arg11 : memref<f32>) -> memref<f32>
-      {dataClause = #acc<data_clause acc_reduction>, name = "l"}
+  %reduction_copy = acc.copyin varPtr(%arg11 : memref<f32>) dataClause(acc_reduction) name("l") -> memref<f32>
   acc.data dataOperands(%copyin, %copyin_readonly, %copy, %copyout,
       %copyout_zero, %present, %create, %create_zero, %attach, %no_create,
       %deviceptr, %reduction_copy : memref<f32>, memref<f32>, memref<f32>,
@@ -92,14 +80,12 @@ func.func @structured_data(
 // Each data construct in a function is reported independently.
 func.func @multiple_data_constructs(%arg0: memref<f32>, %arg1: memref<f32>) {
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=multiple_data_constructs | Remark="Generating copyin(a) [if not already present]"
-  %copyin0 = acc.copyin varPtr(%arg0 : memref<f32>) -> memref<f32>
-      {name = "a"}
+  %copyin0 = acc.copyin varPtr(%arg0 : memref<f32>) name("a") -> memref<f32>
   acc.data dataOperands(%copyin0 : memref<f32>) {
     acc.terminator
   }
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=multiple_data_constructs | Remark="Generating copyin(b) [if not already present]"
-  %copyin1 = acc.copyin varPtr(%arg1 : memref<f32>) -> memref<f32>
-      {name = "b"}
+  %copyin1 = acc.copyin varPtr(%arg1 : memref<f32>) name("b") -> memref<f32>
   acc.data dataOperands(%copyin1 : memref<f32>) {
     acc.terminator
   }
@@ -113,26 +99,22 @@ func.func @kernel_environment(
     %arg3: memref<f32>, %arg4: memref<f32>, %arg5: memref<f32>,
     %arg6: memref<f32>) {
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=kernel_environment | Remark="Generating copyin(a) [if not already present]"
-  %copyin = acc.copyin varPtr(%arg0 : memref<f32>) -> memref<f32>
-      {name = "a"}
+  %copyin = acc.copyin varPtr(%arg0 : memref<f32>) name("a") -> memref<f32>
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=kernel_environment | Remark="Generating private(b)"
   %private = acc.private varPtr(%arg1 : memref<f32>)
-      recipe(@privatization_memref_f32) -> memref<f32> {name = "b"}
+      recipe(@privatization_memref_f32) name("b") -> memref<f32>
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=kernel_environment | Remark="Generating firstprivate(c)"
   %firstprivate = acc.firstprivate varPtr(%arg2 : memref<f32>)
-      recipe(@firstprivatization_memref_f32) -> memref<f32> {name = "c"}
+      recipe(@firstprivatization_memref_f32) name("c") -> memref<f32>
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=kernel_environment | Remark="Generating use_device(d)"
-  %use_device = acc.use_device varPtr(%arg3 : memref<f32>) -> memref<f32>
-      {name = "d"}
+  %use_device = acc.use_device varPtr(%arg3 : memref<f32>) name("d") -> memref<f32>
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=kernel_environment | Remark="Generating reduction(e)"
   %reduction = acc.reduction varPtr(%arg4 : memref<f32>)
-      recipe(@reduction_add_memref_f32) -> memref<f32> {name = "e"}
+      recipe(@reduction_add_memref_f32) name("e") -> memref<f32>
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=kernel_environment | Remark="Generating cache(f)"
-  %cache = acc.cache varPtr(%arg5 : memref<f32>) -> memref<f32>
-      {name = "f"}
+  %cache = acc.cache varPtr(%arg5 : memref<f32>) name("f") -> memref<f32>
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=kernel_environment | Remark="Generating cache(readonly:g)"
-  %cache_readonly = acc.cache varPtr(%arg6 : memref<f32>) -> memref<f32>
-      {dataClause = #acc<data_clause acc_cache_readonly>, name = "g"}
+  %cache_readonly = acc.cache varPtr(%arg6 : memref<f32>) dataClause(acc_cache_readonly) name("g") -> memref<f32>
   acc.kernel_environment dataOperands(%copyin, %private, %firstprivate,
       %use_device, %reduction, %cache, %cache_readonly : memref<f32>,
       memref<f32>, memref<f32>, memref<f32>, memref<f32>, memref<f32>,
@@ -148,19 +130,17 @@ func.func @kernel_environment(
 func.func @structured_declare(
     %arg0: memref<f32>, %arg1: memref<f32>, %arg2: memref<f32>) {
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=structured_declare | Remark="Generating create(a) [if not already present]"
-  %create = acc.create varPtr(%arg0 : memref<f32>) -> memref<f32>
-      {name = "a"}
+  %create = acc.create varPtr(%arg0 : memref<f32>) name("a") -> memref<f32>
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=structured_declare | Remark="Generating device_resident(b)"
   %device_resident = acc.declare_device_resident varPtr(%arg1 : memref<f32>)
-      -> memref<f32> {name = "b"}
+      name("b") -> memref<f32>
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=structured_declare | Remark="Generating link(c)"
-  %link = acc.declare_link varPtr(%arg2 : memref<f32>) -> memref<f32>
-      {name = "c"}
+  %link = acc.declare_link varPtr(%arg2 : memref<f32>) name("c") -> memref<f32>
   %token = acc.declare_enter dataOperands(%create, %device_resident, %link
       : memref<f32>, memref<f32>, memref<f32>)
   acc.declare_exit token(%token) dataOperands(%create : memref<f32>)
   acc.delete accPtr(%create : memref<f32>)
-      {dataClause = #acc<data_clause acc_create>}
+      dataClause(acc_create)
   return
 }
 
@@ -168,14 +148,11 @@ func.func @structured_declare(
 func.func @enter_data(
     %arg0: memref<f32>, %arg1: memref<f32>, %arg2: memref<f32>) {
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=enter_data | Remark="Generating enter data copyin(a) [if not already present]"
-  %copyin = acc.copyin varPtr(%arg0 : memref<f32>) -> memref<f32>
-      {name = "a"}
+  %copyin = acc.copyin varPtr(%arg0 : memref<f32>) name("a") -> memref<f32>
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=enter_data | Remark="Generating enter data create(b) [if not already present]"
-  %create = acc.create varPtr(%arg1 : memref<f32>) -> memref<f32>
-      {name = "b"}
+  %create = acc.create varPtr(%arg1 : memref<f32>) name("b") -> memref<f32>
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=enter_data | Remark="Generating enter data attach(c)"
-  %attach = acc.attach varPtr(%arg2 : memref<f32>) -> memref<f32>
-      {name = "c"}
+  %attach = acc.attach varPtr(%arg2 : memref<f32>) name("c") -> memref<f32>
   acc.enter_data dataOperands(%copyin, %create, %attach
       : memref<f32>, memref<f32>, memref<f32>)
   return
@@ -184,14 +161,11 @@ func.func @enter_data(
 func.func @exit_data(
     %arg0: memref<f32>, %arg1: memref<f32>, %arg2: memref<f32>) {
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=exit_data | Remark="Generating exit data copyout(a) [if not already present]"
-  %copyout = acc.getdeviceptr varPtr(%arg0 : memref<f32>) -> memref<f32>
-      {dataClause = #acc<data_clause acc_copyout>, name = "a"}
+  %copyout = acc.getdeviceptr varPtr(%arg0 : memref<f32>) dataClause(acc_copyout) name("a") -> memref<f32>
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=exit_data | Remark="Generating exit data delete(b)"
-  %delete = acc.getdeviceptr varPtr(%arg1 : memref<f32>) -> memref<f32>
-      {dataClause = #acc<data_clause acc_delete>, name = "b"}
+  %delete = acc.getdeviceptr varPtr(%arg1 : memref<f32>) dataClause(acc_delete) name("b") -> memref<f32>
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=exit_data | Remark="Generating exit data detach(c)"
-  %detach = acc.getdeviceptr varPtr(%arg2 : memref<f32>) -> memref<f32>
-      {dataClause = #acc<data_clause acc_detach>, name = "c"}
+  %detach = acc.getdeviceptr varPtr(%arg2 : memref<f32>) dataClause(acc_detach) name("c") -> memref<f32>
   acc.exit_data dataOperands(%copyout, %delete, %detach
       : memref<f32>, memref<f32>, memref<f32>)
   acc.copyout accPtr(%copyout : memref<f32>) to varPtr(%arg0 : memref<f32>)
@@ -204,21 +178,18 @@ func.func @exit_data(
 func.func @update(
     %arg0: memref<f32>, %arg1: memref<f32>, %arg2: memref<f32>) {
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=update | Remark="Generating update_host(a)"
-  %update_host = acc.getdeviceptr varPtr(%arg0 : memref<f32>) -> memref<f32>
-      {dataClause = #acc<data_clause acc_update_host>, name = "a"}
+  %update_host = acc.getdeviceptr varPtr(%arg0 : memref<f32>) dataClause(acc_update_host) name("a") -> memref<f32>
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=update | Remark="Generating update_self(b)"
-  %update_self = acc.getdeviceptr varPtr(%arg1 : memref<f32>) -> memref<f32>
-      {dataClause = #acc<data_clause acc_update_self>, name = "b"}
+  %update_self = acc.getdeviceptr varPtr(%arg1 : memref<f32>) dataClause(acc_update_self) name("b") -> memref<f32>
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=update | Remark="Generating update_device(c)"
-  %update_device = acc.update_device varPtr(%arg2 : memref<f32>) -> memref<f32>
-      {name = "c"}
+  %update_device = acc.update_device varPtr(%arg2 : memref<f32>) name("c") -> memref<f32>
   acc.update dataOperands(%update_host, %update_self, %update_device
       : memref<f32>, memref<f32>, memref<f32>)
   acc.update_host accPtr(%update_host : memref<f32>)
       to varPtr(%arg0 : memref<f32>)
   acc.update_host accPtr(%update_self : memref<f32>)
       to varPtr(%arg1 : memref<f32>)
-      {dataClause = #acc<data_clause acc_update_self>}
+      dataClause(acc_update_self)
   return
 }
 
@@ -226,11 +197,10 @@ func.func @update(
 // from a default clause are marked as default.
 func.func @implicit_and_default(%arg0: memref<f32>, %arg1: memref<f32>) {
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=implicit_and_default | Remark="Generating default copyin(a) [if not already present]"
-  %from_default = acc.copyin varPtr(%arg0 : memref<f32>) -> memref<f32>
-      {acc.from_default, name = "a"}
+  %from_default = acc.copyin varPtr(%arg0 : memref<f32>) name("a") -> memref<f32>
+      {acc.from_default}
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=implicit_and_default | Remark="Generating implicit present(b)"
-  %implicit = acc.present varPtr(%arg1 : memref<f32>) -> memref<f32>
-      {implicit = true, name = "b"}
+  %implicit = acc.present varPtr(%arg1 : memref<f32>) implicit(true) name("b") -> memref<f32>
   acc.data dataOperands(%from_default, %implicit : memref<f32>, memref<f32>) {
     acc.terminator
   }
@@ -243,19 +213,14 @@ func.func @implicit_and_default(%arg0: memref<f32>, %arg1: memref<f32>) {
 func.func @grouping_and_sorting(
     %arg0: memref<f32>, %arg1: memref<f32>, %arg2: memref<f32>,
     %arg3: memref<f32>, %arg4: memref<f32>) {
-  %copyin_z = acc.copyin varPtr(%arg0 : memref<f32>) -> memref<f32>
-      {name = "z"}
+  %copyin_z = acc.copyin varPtr(%arg0 : memref<f32>) name("z") -> memref<f32>
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=grouping_and_sorting | Remark="Generating copyin(x, y, z) [if not already present]"
-  %copyin_x = acc.copyin varPtr(%arg1 : memref<f32>) -> memref<f32>
-      {name = "x"}
-  %copyin_y = acc.copyin varPtr(%arg2 : memref<f32>) -> memref<f32>
-      {name = "y"}
+  %copyin_x = acc.copyin varPtr(%arg1 : memref<f32>) name("x") -> memref<f32>
+  %copyin_y = acc.copyin varPtr(%arg2 : memref<f32>) name("y") -> memref<f32>
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=grouping_and_sorting | Remark="Generating implicit copyin(i) [if not already present]"
-  %copyin_i = acc.copyin varPtr(%arg3 : memref<f32>) -> memref<f32>
-      {implicit = true, name = "i"}
+  %copyin_i = acc.copyin varPtr(%arg3 : memref<f32>) implicit(true) name("i") -> memref<f32>
   // CHECK: [[@LINE+1]]:{{[0-9]+}}: remark: [Passed] openacc | Category:acc-emit-remarks-data | Function=grouping_and_sorting | Remark="Generating present(p)"
-  %present = acc.present varPtr(%arg4 : memref<f32>) -> memref<f32>
-      {name = "p"}
+  %present = acc.present varPtr(%arg4 : memref<f32>) name("p") -> memref<f32>
   acc.data dataOperands(%copyin_z, %copyin_x, %copyin_y, %copyin_i, %present
       : memref<f32>, memref<f32>, memref<f32>, memref<f32>, memref<f32>) {
     acc.terminator
@@ -274,8 +239,7 @@ func.func @grouping_and_sorting(
 // The synthetic getdeviceptr clause and clauses without a variable name are
 // not reported.
 func.func @not_reportable_clauses(%arg0: memref<f32>, %arg1: memref<f32>) {
-  %synthetic = acc.getdeviceptr varPtr(%arg0 : memref<f32>) -> memref<f32>
-      {name = "synthetic"}
+  %synthetic = acc.getdeviceptr varPtr(%arg0 : memref<f32>) name("synthetic") -> memref<f32>
   %unnamed = acc.copyin varPtr(%arg1 : memref<f32>) -> memref<f32>
   acc.data dataOperands(%synthetic, %unnamed : memref<f32>, memref<f32>) {
     acc.terminator
@@ -287,15 +251,14 @@ func.func @not_reportable_clauses(%arg0: memref<f32>, %arg1: memref<f32>) {
 func.func @default_only_data() {
   acc.data {
     acc.terminator
-  } attributes {defaultAttr = #acc<defaultvalue none>}
+  } defaultAttr(none)
   return
 }
 
 // A declare enter whose token is unused registers the variables for the whole
 // program instead of a region, and is not reported.
 func.func @unstructured_declare(%arg0: memref<f32>) {
-  %create = acc.create varPtr(%arg0 : memref<f32>) -> memref<f32>
-      {name = "a"}
+  %create = acc.create varPtr(%arg0 : memref<f32>) name("a") -> memref<f32>
   acc.declare_enter dataOperands(%create : memref<f32>)
   return
 }
@@ -304,8 +267,7 @@ func.func @unstructured_declare(%arg0: memref<f32>) {
 // are reported at the declare enter, and an unstructured declare exit only
 // unregisters variables.
 func.func @declare_exit(%arg0: memref<f32>) {
-  %delete = acc.getdeviceptr varPtr(%arg0 : memref<f32>) -> memref<f32>
-      {dataClause = #acc<data_clause acc_delete>, name = "a"}
+  %delete = acc.getdeviceptr varPtr(%arg0 : memref<f32>) dataClause(acc_delete) name("a") -> memref<f32>
   acc.declare_exit dataOperands(%delete : memref<f32>)
   acc.delete accPtr(%delete : memref<f32>)
   return
@@ -314,8 +276,7 @@ func.func @declare_exit(%arg0: memref<f32>) {
 // Data clauses on a compute construct are not reported by this pass - they are
 // reported once they are outlined into a kernel environment.
 func.func @compute_construct(%arg0: memref<f32>) {
-  %copyin = acc.copyin varPtr(%arg0 : memref<f32>) -> memref<f32>
-      {name = "a"}
+  %copyin = acc.copyin varPtr(%arg0 : memref<f32>) name("a") -> memref<f32>
   acc.parallel dataOperands(%copyin : memref<f32>) {
     acc.yield
   }

--- a/mlir/test/Dialect/OpenACC/acc-emit-remarks-loop-pipeline.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-emit-remarks-loop-pipeline.mlir
@@ -12,7 +12,7 @@ func.func @parallel_gang_loop(%buf: memref<1xi32>) {
     acc.loop gang control(%arg0 : i32) = (%c1_i32 : i32) to (%c100_i32 : i32) step (%c1_i32 : i32) {
       memref.store %arg0, %dev[%c0] : memref<1xi32>
       acc.yield
-    } attributes {independent = [#acc.device_type<none>]}
+    } independent
     acc.yield
   }
   acc.copyout accPtr(%dev : memref<1xi32>) to varPtr(%buf : memref<1xi32>)
@@ -32,7 +32,7 @@ func.func @parallel_loop_auto_collapse(%buf: memref<1xi32>, %lb0 : index, %ub0 :
       %vi = arith.index_cast %i : index to i32
       memref.store %vi, %dev[%c0] : memref<1xi32>
       acc.yield
-    } attributes {auto_ = [#acc.device_type<none>]}
+    } auto_
     acc.yield
   }
   acc.copyout accPtr(%dev : memref<1xi32>) to varPtr(%buf : memref<1xi32>)

--- a/mlir/test/Dialect/OpenACC/acc-emit-remarks-loop.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-emit-remarks-loop.mlir
@@ -5,7 +5,7 @@
 func.func @vector_loop() {
   %c128 = arith.constant 128 : index
   acc.kernel_environment {
-    %w0 = acc.par_width %c128 {par_dim = #acc.par_dim<thread_x>}
+    %w0 = acc.par_width %c128 par_dim(#acc.par_dim<thread_x>)
     acc.compute_region launch(%arg0 = %w0) {
       %c0 = arith.constant 0 : index
       %c1 = arith.constant 1 : index
@@ -25,7 +25,7 @@ func.func @vector_loop() {
 func.func @gang_loop() {
   %c8 = arith.constant 8 : index
   acc.kernel_environment {
-    %w0 = acc.par_width %c8 {par_dim = #acc.par_dim<block_x>}
+    %w0 = acc.par_width %c8 par_dim(#acc.par_dim<block_x>)
     acc.compute_region launch(%arg0 = %w0) {
       %c0 = arith.constant 0 : index
       %c1 = arith.constant 1 : index
@@ -45,7 +45,7 @@ func.func @gang_loop() {
 func.func @worker_loop() {
   %c4 = arith.constant 4 : index
   acc.kernel_environment {
-    %w0 = acc.par_width %c4 {par_dim = #acc.par_dim<thread_y>}
+    %w0 = acc.par_width %c4 par_dim(#acc.par_dim<thread_y>)
     acc.compute_region launch(%arg0 = %w0) {
       %c0 = arith.constant 0 : index
       %c1 = arith.constant 1 : index
@@ -84,8 +84,8 @@ func.func @block_and_vector() {
   %c8 = arith.constant 8 : index
   %c128 = arith.constant 128 : index
   acc.kernel_environment {
-    %w0 = acc.par_width %c8 {par_dim = #acc.par_dim<block_x>}
-    %w1 = acc.par_width %c128 {par_dim = #acc.par_dim<thread_x>}
+    %w0 = acc.par_width %c8 par_dim(#acc.par_dim<block_x>)
+    %w1 = acc.par_width %c128 par_dim(#acc.par_dim<thread_x>)
     acc.compute_region launch(%arg0 = %w0, %arg1 = %w1) {
       %c0 = arith.constant 0 : index
       %c1 = arith.constant 1 : index
@@ -140,7 +140,7 @@ func.func @collapse_loop() {
 func.func @percent_separator() {
   %c128 = arith.constant 128 : index
   acc.kernel_environment {
-    %w0 = acc.par_width %c128 {par_dim = #acc.par_dim<thread_x>}
+    %w0 = acc.par_width %c128 par_dim(#acc.par_dim<thread_x>)
     acc.compute_region launch(%arg0 = %w0) {
       %c0 = arith.constant 0 : index
       %c1 = arith.constant 1 : index

--- a/mlir/test/Dialect/OpenACC/acc-emit-remarks-private.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-emit-remarks-private.mlir
@@ -39,7 +39,7 @@ func.func @firstpriv_implicit() {
   %c1336 = arith.constant 1336 : i32
   %alloc = memref.alloca() : memref<i32>
   memref.store %c1336, %alloc[] : memref<i32>
-  %fp = acc.firstprivate varPtr(%alloc : memref<i32>) recipe(@firstprivatization_memref_i32) -> memref<i32> {implicit = true, name = "t"}
+  %fp = acc.firstprivate varPtr(%alloc : memref<i32>) recipe(@firstprivatization_memref_i32) implicit(true) name("t") -> memref<i32>
   acc.parallel firstprivate(%fp : memref<i32>) {
     %c1 = arith.constant 1 : i32
     %v = memref.load %fp[] : memref<i32>
@@ -55,7 +55,7 @@ func.func @firstpriv_explicit() {
   %c1336 = arith.constant 1336 : i32
   %alloc = memref.alloca() : memref<i32>
   memref.store %c1336, %alloc[] : memref<i32>
-  %fp = acc.firstprivate varPtr(%alloc : memref<i32>) recipe(@firstprivatization_memref_i32) -> memref<i32> {name = "t"}
+  %fp = acc.firstprivate varPtr(%alloc : memref<i32>) recipe(@firstprivatization_memref_i32) name("t") -> memref<i32>
   acc.parallel firstprivate(%fp : memref<i32>) {
     %c1 = arith.constant 1 : i32
     %v = memref.load %fp[] : memref<i32>
@@ -70,12 +70,12 @@ func.func @firstpriv_explicit() {
 func.func @private_loop_implicit(%arg0 : memref<i64>) {
   %c16 = arith.constant 16 : index
   %c1 = arith.constant 1 : index
-  %priv = acc.private varPtr(%arg0 : memref<i64>) recipe(@privatization_memref_i64) -> memref<i64> {implicit = true, name = "x"}
+  %priv = acc.private varPtr(%arg0 : memref<i64>) recipe(@privatization_memref_i64) implicit(true) name("x") -> memref<i64>
   acc.loop private(%priv : memref<i64>) control(%siv : index) = (%c1 : index) to (%c16 : index) step (%c1 : index) {
     %iv_i64 = arith.index_cast %siv : index to i64
     memref.store %iv_i64, %priv[] : memref<i64>
     acc.yield
-  } attributes {independent = [#acc.device_type<none>]}
+  } independent
   return
 }
 
@@ -83,12 +83,12 @@ func.func @private_loop_implicit(%arg0 : memref<i64>) {
 func.func @private_loop_unknown(%arg0 : memref<i64>) {
   %c16 = arith.constant 16 : index
   %c1 = arith.constant 1 : index
-  %priv = acc.private varPtr(%arg0 : memref<i64>) recipe(@privatization_memref_i64) -> memref<i64> {implicit = true, name = ""}
+  %priv = acc.private varPtr(%arg0 : memref<i64>) recipe(@privatization_memref_i64) implicit(true) name("") -> memref<i64>
   acc.loop private(%priv : memref<i64>) control(%siv : index) = (%c1 : index) to (%c16 : index) step (%c1 : index) {
     %iv_i64 = arith.index_cast %siv : index to i64
     memref.store %iv_i64, %priv[] : memref<i64>
     acc.yield
-  } attributes {independent = [#acc.device_type<none>]}
+  } independent
   return
 }
 
@@ -96,13 +96,13 @@ func.func @private_loop_unknown(%arg0 : memref<i64>) {
 func.func @private_explicit(%arg0 : memref<i64>) {
   %c16 = arith.constant 16 : index
   %c1 = arith.constant 1 : index
-  %priv = acc.private varPtr(%arg0 : memref<i64>) recipe(@privatization_memref_i64) -> memref<i64> {name = "x"}
+  %priv = acc.private varPtr(%arg0 : memref<i64>) recipe(@privatization_memref_i64) name("x") -> memref<i64>
   acc.parallel private(%priv : memref<i64>) {
     acc.loop control(%siv : index) = (%c1 : index) to (%c16 : index) step (%c1 : index) {
       %iv_i64 = arith.index_cast %siv : index to i64
       memref.store %iv_i64, %priv[] : memref<i64>
       acc.yield
-    } attributes {independent = [#acc.device_type<none>]}
+    } independent
     acc.yield
   }
   return
@@ -110,8 +110,8 @@ func.func @private_explicit(%arg0 : memref<i64>) {
 
 // CHECK-LABEL: func.func @multi_private_implicit
 func.func @multi_private_implicit(%arg0 : memref<i64>, %arg1 : memref<i64>) {
-  %privA = acc.private varPtr(%arg0 : memref<i64>) recipe(@privatization_memref_i64) -> memref<i64> {implicit = true, name = "a"}
-  %privB = acc.private varPtr(%arg1 : memref<i64>) recipe(@privatization_memref_i64) -> memref<i64> {implicit = true, name = "b"}
+  %privA = acc.private varPtr(%arg0 : memref<i64>) recipe(@privatization_memref_i64) implicit(true) name("a") -> memref<i64>
+  %privB = acc.private varPtr(%arg1 : memref<i64>) recipe(@privatization_memref_i64) implicit(true) name("b") -> memref<i64>
   acc.parallel private(%privA, %privB : memref<i64>, memref<i64>) {
     acc.yield
   }

--- a/mlir/test/Dialect/OpenACC/acc-if-clause-lowering.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-if-clause-lowering.mlir
@@ -8,12 +8,12 @@ func.func @test_parallel_if(%arg0: memref<10xi32>, %cond: i1) {
   %c10 = arith.constant 10 : index
 
   %copyin = acc.copyin varPtr(%arg0 : memref<10xi32>) -> memref<10xi32>
-  %create = acc.create varPtr(%arg0 : memref<10xi32>) -> memref<10xi32> {dataClause = #acc<data_clause acc_copyout>}
+  %create = acc.create varPtr(%arg0 : memref<10xi32>) dataClause(acc_copyout) -> memref<10xi32>
 
   // CHECK-NOT: acc.parallel if
   // CHECK: scf.if %{{.*}} {
   // CHECK:   %[[COPYIN:.*]] = acc.copyin varPtr(%{{.*}}) -> memref<10xi32>
-  // CHECK:   %[[CREATE:.*]] = acc.create varPtr(%{{.*}}) -> memref<10xi32>
+  // CHECK:   %[[CREATE:.*]] = acc.create varPtr(%{{.*}}) dataClause(acc_copyout) -> memref<10xi32>
   // CHECK:   acc.parallel dataOperands(%[[COPYIN]], %[[CREATE]] : memref<10xi32>, memref<10xi32>) {
   // CHECK:     scf.for
   // CHECK:     acc.yield
@@ -81,7 +81,7 @@ func.func @test_kernels_if(%arg0: memref<5xi32>, %cond: i1) {
   %c5 = arith.constant 5 : index
 
   %copyin = acc.copyin varPtr(%arg0 : memref<5xi32>) -> memref<5xi32>
-  %create = acc.create varPtr(%arg0 : memref<5xi32>) -> memref<5xi32> {dataClause = #acc<data_clause acc_copyout>}
+  %create = acc.create varPtr(%arg0 : memref<5xi32>) dataClause(acc_copyout) -> memref<5xi32>
 
   // CHECK-NOT: acc.kernels if
   // CHECK: scf.if %{{.*}} {
@@ -118,7 +118,7 @@ func.func @test_serial_if(%arg0: memref<8xi32>, %cond: i1) {
   %c8 = arith.constant 8 : index
 
   %copyin = acc.copyin varPtr(%arg0 : memref<8xi32>) -> memref<8xi32>
-  %create = acc.create varPtr(%arg0 : memref<8xi32>) -> memref<8xi32> {dataClause = #acc<data_clause acc_copyout>}
+  %create = acc.create varPtr(%arg0 : memref<8xi32>) dataClause(acc_copyout) -> memref<8xi32>
 
   // CHECK-NOT: acc.serial if
   // CHECK: scf.if %{{.*}} {
@@ -198,7 +198,7 @@ func.func @test_reduction_if(%r: memref<f32>, %a: memref<8xf32>, %cond: i1) {
   %c8_i32 = arith.constant 8 : i32
   %c1_i32 = arith.constant 1 : i32
 
-  %copyin = acc.copyin varPtr(%r : memref<f32>) -> memref<f32> {dataClause = #acc<data_clause acc_reduction>, implicit = true}
+  %copyin = acc.copyin varPtr(%r : memref<f32>) dataClause(acc_reduction) implicit(true) -> memref<f32>
 
   // CHECK: scf.if
   // CHECK:   acc.parallel
@@ -221,11 +221,11 @@ func.func @test_reduction_if(%r: memref<f32>, %a: memref<8xf32>, %cond: i1) {
       %new_r = arith.addf %r_val, %elem : f32
       memref.store %new_r, %r[] : memref<f32>
       acc.yield
-    } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+    } inclusiveUpperbound(array<i1: true>) independent
     acc.yield
   }
 
-  acc.copyout accPtr(%copyin : memref<f32>) to varPtr(%r : memref<f32>) {dataClause = #acc<data_clause acc_reduction>, implicit = true}
+  acc.copyout accPtr(%copyin : memref<f32>) to varPtr(%r : memref<f32>) dataClause(acc_reduction) implicit(true)
   return
 }
 

--- a/mlir/test/Dialect/OpenACC/acc-implicit-data-defaultnone.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-implicit-data-defaultnone.mlir
@@ -11,7 +11,7 @@ func.func @test_scalar_parallel_defaultnone() {
   acc.parallel {
     %load = memref.load %alloc[] : memref<f32>
     acc.yield
-  } attributes {defaultAttr = #acc<defaultvalue none>}
+  } defaultAttr(none)
   return
 }
 
@@ -20,4 +20,4 @@ func.func @test_scalar_parallel_defaultnone() {
 // CHECK-NOT: acc.copyin
 
 // ENABLED-LABEL: func.func @test_scalar_parallel_defaultnone
-// ENABLED: acc.firstprivate varPtr({{.*}} : memref<f32>) recipe({{.*}}) -> memref<f32> {implicit = true, name = ""}
+// ENABLED: acc.firstprivate varPtr({{.*}} : memref<f32>) recipe({{.*}}) implicit(true) name("") -> memref<f32>

--- a/mlir/test/Dialect/OpenACC/acc-implicit-data-reduction.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-implicit-data-reduction.mlir
@@ -28,13 +28,13 @@ func.func @test_reduction_implicit_copy() {
   memref.store %c0_i32, %r[] : memref<i32>
 
   acc.parallel {
-    %red_var = acc.reduction varPtr(%r : memref<i32>) recipe(@reduction_add_memref_i32) -> memref<i32> {name = "r"}
+    %red_var = acc.reduction varPtr(%r : memref<i32>) recipe(@reduction_add_memref_i32) name("r") -> memref<i32>
     acc.loop reduction(%red_var : memref<i32>) control(%iv : i32) = (%c1_i32 : i32) to (%c100_i32 : i32) step (%c1_i32 : i32) {
       %load = memref.load %red_var[] : memref<i32>
       %add = arith.addi %load, %c1_i32 : i32
       memref.store %add, %red_var[] : memref<i32>
       acc.yield
-    } attributes {independent = [#acc.device_type<none>]}
+    } independent
     acc.yield
   }
   return
@@ -42,12 +42,12 @@ func.func @test_reduction_implicit_copy() {
 
 // When enable-implicit-reduction-copy=true: expect copyin/copyout for reduction variable
 // COPY-LABEL: func.func @test_reduction_implicit_copy
-// COPY: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : memref<i32>) -> memref<i32> {dataClause = #acc<data_clause acc_reduction>, implicit = true, name = ""}
-// COPY: acc.copyout accPtr(%[[COPYIN]] : memref<i32>) to varPtr({{.*}} : memref<i32>) {dataClause = #acc<data_clause acc_copy>, implicit = true, name = ""}
+// COPY: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : memref<i32>) dataClause(acc_reduction) implicit(true) name("") -> memref<i32>
+// COPY: acc.copyout accPtr(%[[COPYIN]] : memref<i32>) to varPtr({{.*}} : memref<i32>) dataClause(acc_copy) implicit(true) name("")
 
 // When enable-implicit-reduction-copy=false: expect firstprivate for reduction variable  
 // FIRSTPRIVATE-LABEL: func.func @test_reduction_implicit_copy
-// FIRSTPRIVATE: acc.firstprivate varPtr({{.*}} : memref<i32>) recipe({{.*}}) -> memref<i32> {implicit = true, name = ""}
+// FIRSTPRIVATE: acc.firstprivate varPtr({{.*}} : memref<i32>) recipe({{.*}}) implicit(true) name("") -> memref<i32>
 // FIRSTPRIVATE-NOT: acc.copyin
 // FIRSTPRIVATE-NOT: acc.copyout
 
@@ -79,31 +79,31 @@ func.func @test_reduction_with_usage_outside_loop() {
   %out = memref.alloca() : memref<i32>
   memref.store %c0_i32, %r[] : memref<i32>
 
-  %out_create = acc.create varPtr(%out : memref<i32>) -> memref<i32> {dataClause = #acc<data_clause acc_copyout>, name = "out"}
+  %out_create = acc.create varPtr(%out : memref<i32>) dataClause(acc_copyout) name("out") -> memref<i32>
   acc.parallel dataOperands(%out_create : memref<i32>) {
-    %red_var = acc.reduction varPtr(%r : memref<i32>) recipe(@reduction_add_memref_i32_2) -> memref<i32> {name = "r"}
+    %red_var = acc.reduction varPtr(%r : memref<i32>) recipe(@reduction_add_memref_i32_2) name("r") -> memref<i32>
     acc.loop reduction(%red_var : memref<i32>) control(%iv : i32) = (%c1_i32 : i32) to (%c100_i32 : i32) step (%c1_i32 : i32) {
       %load = memref.load %red_var[] : memref<i32>
       %add = arith.addi %load, %c1_i32 : i32
       memref.store %add, %red_var[] : memref<i32>
       acc.yield
-    } attributes {independent = [#acc.device_type<none>]}
+    } independent
     // out = r (usage of r outside the loop)
     %final_r = memref.load %r[] : memref<i32>
     memref.store %final_r, %out_create[] : memref<i32>
     acc.yield
   }
-  acc.copyout accPtr(%out_create : memref<i32>) to varPtr(%out : memref<i32>) {dataClause = #acc<data_clause acc_copyout>, name = "out"}
+  acc.copyout accPtr(%out_create : memref<i32>) to varPtr(%out : memref<i32>) dataClause(acc_copyout) name("out")
   return
 }
 
 // In this case, r should be firstprivate regardless of the flag setting 
 // because it's used outside the reduction context
 // COPY-LABEL: func.func @test_reduction_with_usage_outside_loop
-// COPY: acc.firstprivate varPtr({{.*}} : memref<i32>) recipe({{.*}}) -> memref<i32> {implicit = true, name = ""}
+// COPY: acc.firstprivate varPtr({{.*}} : memref<i32>) recipe({{.*}}) implicit(true) name("") -> memref<i32>
 // COPY-NOT: acc.copyin varPtr({{.*}} : memref<i32>) -> memref<i32> {{.*}} name = ""
 
 // FIRSTPRIVATE-LABEL: func.func @test_reduction_with_usage_outside_loop
-// FIRSTPRIVATE: acc.firstprivate varPtr({{.*}} : memref<i32>) recipe({{.*}}) -> memref<i32> {implicit = true, name = ""}
+// FIRSTPRIVATE: acc.firstprivate varPtr({{.*}} : memref<i32>) recipe({{.*}}) implicit(true) name("") -> memref<i32>
 // FIRSTPRIVATE-NOT: acc.copyin varPtr({{.*}} : memref<i32>) -> memref<i32> {{.*}} name = ""
 

--- a/mlir/test/Dialect/OpenACC/acc-implicit-data.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-implicit-data.mlir
@@ -13,7 +13,7 @@ func.func @test_scalar_in_serial() {
 }
 
 // CHECK-LABEL: func.func @test_scalar_in_serial
-// CHECK: acc.firstprivate varPtr({{.*}} : memref<i64>) recipe({{.*}}) -> memref<i64> {implicit = true, name = ""}
+// CHECK: acc.firstprivate varPtr({{.*}} : memref<i64>) recipe({{.*}}) implicit(true) name("") -> memref<i64>
 
 // -----
 
@@ -28,7 +28,7 @@ func.func @test_scalar_in_parallel() {
 }
 
 // CHECK-LABEL: func.func @test_scalar_in_parallel
-// CHECK: acc.firstprivate varPtr({{.*}} : memref<f32>) recipe({{.*}}) -> memref<f32> {implicit = true, name = ""}
+// CHECK: acc.firstprivate varPtr({{.*}} : memref<f32>) recipe({{.*}}) implicit(true) name("") -> memref<f32>
 
 // -----
 
@@ -43,8 +43,8 @@ func.func @test_scalar_in_kernels() {
 }
 
 // CHECK-LABEL: func.func @test_scalar_in_kernels
-// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : memref<f64>) -> memref<f64> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = ""}
-// CHECK: acc.copyout accPtr(%[[COPYIN]] : memref<f64>) to varPtr({{.*}} : memref<f64>) {dataClause = #acc<data_clause acc_copy>, implicit = true, name = ""}
+// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : memref<f64>) dataClause(acc_copy) implicit(true) name("") -> memref<f64>
+// CHECK: acc.copyout accPtr(%[[COPYIN]] : memref<f64>) to varPtr({{.*}} : memref<f64>) dataClause(acc_copy) implicit(true) name("")
 
 // -----
 
@@ -54,7 +54,7 @@ func.func @test_scalar_parallel_defaultnone() {
   acc.parallel {
     %load = memref.load %alloc[] : memref<f32>
     acc.yield
-  } attributes {defaultAttr = #acc<defaultvalue none>}
+  } defaultAttr(none)
   return
 }
 
@@ -76,8 +76,8 @@ func.func @test_array_in_parallel() {
 }
 
 // CHECK-LABEL: func.func @test_array_in_parallel
-// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : memref<10xf32>) -> memref<10xf32> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = ""}
-// CHECK: acc.copyout accPtr(%[[COPYIN]] : memref<10xf32>) to varPtr({{.*}} : memref<10xf32>) {dataClause = #acc<data_clause acc_copy>, implicit = true, name = ""}
+// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : memref<10xf32>) dataClause(acc_copy) implicit(true) name("") -> memref<10xf32>
+// CHECK: acc.copyout accPtr(%[[COPYIN]] : memref<10xf32>) to varPtr({{.*}} : memref<10xf32>) dataClause(acc_copy) implicit(true) name("")
 
 // -----
 
@@ -93,8 +93,8 @@ func.func @test_array_in_kernels() {
 }
 
 // CHECK-LABEL: func.func @test_array_in_kernels
-// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : memref<20xi32>) -> memref<20xi32> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = ""}
-// CHECK: acc.copyout accPtr(%[[COPYIN]] : memref<20xi32>) to varPtr({{.*}} : memref<20xi32>) {dataClause = #acc<data_clause acc_copy>, implicit = true, name = ""}
+// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : memref<20xi32>) dataClause(acc_copy) implicit(true) name("") -> memref<20xi32>
+// CHECK: acc.copyout accPtr(%[[COPYIN]] : memref<20xi32>) to varPtr({{.*}} : memref<20xi32>) dataClause(acc_copy) implicit(true) name("")
 
 // -----
 
@@ -105,13 +105,13 @@ func.func @test_array_parallel_defaultpresent() {
     %c0 = arith.constant 0 : index
     %load = memref.load %alloc[%c0] : memref<10xf32>
     acc.yield
-  } attributes {defaultAttr = #acc<defaultvalue present>}
+  } defaultAttr(present)
   return
 }
 
 // CHECK-LABEL: func.func @test_array_parallel_defaultpresent
-// CHECK: %[[PRESENT:.*]] = acc.present varPtr({{.*}} : memref<10xf32>) -> memref<10xf32> {acc.from_default, implicit = true, name = ""}
-// CHECK: acc.delete accPtr(%[[PRESENT]] : memref<10xf32>) {dataClause = #acc<data_clause acc_present>, implicit = true, name = ""}
+// CHECK: %[[PRESENT:.*]] = acc.present varPtr({{.*}} : memref<10xf32>) implicit(true) name("") -> memref<10xf32> {acc.from_default}
+// CHECK: acc.delete accPtr(%[[PRESENT]] : memref<10xf32>) dataClause(acc_present) implicit(true) name("")
 
 // -----
 
@@ -121,12 +121,12 @@ func.func @test_scalar_parallel_defaultpresent() {
   acc.parallel {
     %load = memref.load %alloc[] : memref<f32>
     acc.yield
-  } attributes {defaultAttr = #acc<defaultvalue present>}
+  } defaultAttr(present)
   return
 }
 
 // CHECK-LABEL: func.func @test_scalar_parallel_defaultpresent
-// CHECK: acc.firstprivate varPtr({{.*}} : memref<f32>) recipe({{.*}}) -> memref<f32> {implicit = true, name = ""}
+// CHECK: acc.firstprivate varPtr({{.*}} : memref<f32>) recipe({{.*}}) implicit(true) name("") -> memref<f32>
 
 // -----
 
@@ -143,8 +143,8 @@ func.func @test_multidim_array_in_parallel() {
 }
 
 // CHECK-LABEL: func.func @test_multidim_array_in_parallel
-// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : memref<8x16xf32>) -> memref<8x16xf32> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = ""}
-// CHECK: acc.copyout accPtr(%[[COPYIN]] : memref<8x16xf32>) to varPtr({{.*}} : memref<8x16xf32>) {dataClause = #acc<data_clause acc_copy>, implicit = true, name = ""}
+// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : memref<8x16xf32>) dataClause(acc_copy) implicit(true) name("") -> memref<8x16xf32>
+// CHECK: acc.copyout accPtr(%[[COPYIN]] : memref<8x16xf32>) to varPtr({{.*}} : memref<8x16xf32>) dataClause(acc_copy) implicit(true) name("")
 
 // -----
 
@@ -160,26 +160,26 @@ func.func @test_dynamic_array(%size: index) {
 }
 
 // CHECK-LABEL: func.func @test_dynamic_array
-// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : memref<?xf64>) -> memref<?xf64> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = ""}
-// CHECK: acc.copyout accPtr(%[[COPYIN]] : memref<?xf64>) to varPtr({{.*}} : memref<?xf64>) {dataClause = #acc<data_clause acc_copy>, implicit = true, name = ""}
+// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : memref<?xf64>) dataClause(acc_copy) implicit(true) name("") -> memref<?xf64>
+// CHECK: acc.copyout accPtr(%[[COPYIN]] : memref<?xf64>) to varPtr({{.*}} : memref<?xf64>) dataClause(acc_copy) implicit(true) name("")
 
 // -----
 
 // Test variable with explicit data clause - implicit should recognize it
 func.func @test_with_explicit_copyin() {
   %alloc = memref.alloca() : memref<100xf32>
-  %copyin = acc.copyin varPtr(%alloc : memref<100xf32>) -> memref<100xf32> {name = "explicit"}
+  %copyin = acc.copyin varPtr(%alloc : memref<100xf32>) name("explicit") -> memref<100xf32>
   acc.parallel dataOperands(%copyin : memref<100xf32>) {
     %c0 = arith.constant 0 : index
     %load = memref.load %alloc[%c0] : memref<100xf32>
     acc.yield
   }
-  acc.copyout accPtr(%copyin : memref<100xf32>) to varPtr(%alloc : memref<100xf32>) {name = "explicit"}
+  acc.copyout accPtr(%copyin : memref<100xf32>) to varPtr(%alloc : memref<100xf32>) name("explicit")
   return
 }
 
 // CHECK-LABEL: func.func @test_with_explicit_copyin
-// CHECK: acc.present varPtr({{.*}} : memref<100xf32>) -> memref<100xf32> {implicit = true, name = ""}
+// CHECK: acc.present varPtr({{.*}} : memref<100xf32>) implicit(true) name("") -> memref<100xf32>
 
 // -----
 
@@ -197,9 +197,9 @@ func.func @test_multiple_variables() {
 }
 
 // CHECK-LABEL: func.func @test_multiple_variables
-// CHECK: acc.firstprivate varPtr({{.*}} : memref<f32>) recipe({{.*}}) -> memref<f32> {implicit = true, name = ""}
-// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : memref<10xi32>) -> memref<10xi32> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = ""}
-// CHECK: acc.copyout accPtr(%[[COPYIN]] : memref<10xi32>) to varPtr({{.*}} : memref<10xi32>) {dataClause = #acc<data_clause acc_copy>, implicit = true, name = ""}
+// CHECK: acc.firstprivate varPtr({{.*}} : memref<f32>) recipe({{.*}}) implicit(true) name("") -> memref<f32>
+// CHECK: %[[COPYIN:.*]] = acc.copyin varPtr({{.*}} : memref<10xi32>) dataClause(acc_copy) implicit(true) name("") -> memref<10xi32>
+// CHECK: acc.copyout accPtr(%[[COPYIN]] : memref<10xi32>) to varPtr({{.*}} : memref<10xi32>) dataClause(acc_copy) implicit(true) name("")
 
 // -----
 
@@ -207,7 +207,7 @@ func.func @test_multiple_variables() {
 func.func @test_memref_view(%size: index) {
   %c0 = arith.constant 0 : index
   %buffer = memref.alloca(%size) : memref<?xi8>
-  %copyin = acc.copyin varPtr(%buffer : memref<?xi8>) -> memref<?xi8> {name = "buffer"}
+  %copyin = acc.copyin varPtr(%buffer : memref<?xi8>) name("buffer") -> memref<?xi8>
   %view = memref.view %buffer[%c0][] : memref<?xi8> to memref<8x64xf32>
   acc.kernels dataOperands(%copyin : memref<?xi8>) {
     %c0_0 = arith.constant 0 : index
@@ -215,12 +215,12 @@ func.func @test_memref_view(%size: index) {
     %load = memref.load %view[%c0_0, %c0_1] : memref<8x64xf32>
     acc.terminator
   }
-  acc.copyout accPtr(%copyin : memref<?xi8>) to varPtr(%buffer : memref<?xi8>) {name = "buffer"}
+  acc.copyout accPtr(%copyin : memref<?xi8>) to varPtr(%buffer : memref<?xi8>) name("buffer")
   return
 }
 
 // CHECK-LABEL: func.func @test_memref_view
-// CHECK: acc.present varPtr({{.*}} : memref<8x64xf32>) -> memref<8x64xf32> {implicit = true, name = ""}
+// CHECK: acc.present varPtr({{.*}} : memref<8x64xf32>) implicit(true) name("") -> memref<8x64xf32>
 
 // -----
 
@@ -236,7 +236,7 @@ func.func @test_device_data_in_parallel() {
 }
 
 // CHECK-LABEL: func.func @test_device_data_in_parallel
-// CHECK: acc.deviceptr varPtr({{.*}} : memref<10xf32, #gpu.address_space<global>>) -> memref<10xf32, #gpu.address_space<global>> {implicit = true, name = ""}
+// CHECK: acc.deviceptr varPtr({{.*}} : memref<10xf32, #gpu.address_space<global>>) implicit(true) name("") -> memref<10xf32, #gpu.address_space<global>>
 // CHECK-NOT: acc.copyin
 // CHECK-NOT: acc.copyout
 
@@ -256,7 +256,7 @@ func.func @test_device_global_in_parallel() {
 }
 
 // CHECK-LABEL: func.func @test_device_global_in_parallel
-// CHECK: acc.deviceptr varPtr({{.*}} : memref<10xf32, #gpu.address_space<global>>) -> memref<10xf32, #gpu.address_space<global>> {implicit = true, name = ""}
+// CHECK: acc.deviceptr varPtr({{.*}} : memref<10xf32, #gpu.address_space<global>>) implicit(true) name("") -> memref<10xf32, #gpu.address_space<global>>
 // CHECK-NOT: acc.copyin
 // CHECK-NOT: acc.copyout
 
@@ -266,7 +266,7 @@ func.func @test_device_global_in_parallel() {
 func.func @test_declare_deviceptr_arg_in_parallel(%arg0: memref<?xi8>) {
   %c0 = arith.constant 0 : index
   %view = memref.view %arg0[%c0][] {acc.declare = #acc.declare<dataClause = acc_deviceptr>} : memref<?xi8> to memref<10xf32>
-  %devptr = acc.deviceptr varPtr(%view : memref<10xf32>) -> memref<10xf32> {name = "arg0"}
+  %devptr = acc.deviceptr varPtr(%view : memref<10xf32>) name("arg0") -> memref<10xf32>
   %token = acc.declare_enter dataOperands(%devptr : memref<10xf32>)
   acc.parallel {
     %c0_1 = arith.constant 0 : index
@@ -279,9 +279,9 @@ func.func @test_declare_deviceptr_arg_in_parallel(%arg0: memref<?xi8>) {
 
 // CHECK-LABEL: func.func @test_declare_deviceptr_arg_in_parallel
 // CHECK: %[[VIEW:.*]] = memref.view %{{.*}}[{{.*}}][] {acc.declare = #acc.declare<dataClause = acc_deviceptr>} : memref<?xi8> to memref<10xf32>
-// CHECK: %[[DEVPTR:.*]] = acc.deviceptr varPtr(%[[VIEW]] : memref<10xf32>) -> memref<10xf32> {name = "arg0"}
+// CHECK: %[[DEVPTR:.*]] = acc.deviceptr varPtr(%[[VIEW]] : memref<10xf32>) name("arg0") -> memref<10xf32>
 // CHECK: %[[TOKEN:.*]] = acc.declare_enter dataOperands(%[[DEVPTR]] : memref<10xf32>)
-// CHECK: %[[IMPLICIT_DEVPTR:.*]] = acc.deviceptr varPtr(%{{.*}} : memref<?xi8>) -> memref<?xi8> {implicit = true, name = ""}
+// CHECK: %[[IMPLICIT_DEVPTR:.*]] = acc.deviceptr varPtr(%{{.*}} : memref<?xi8>) implicit(true) name("") -> memref<?xi8>
 // CHECK: acc.parallel dataOperands(%[[IMPLICIT_DEVPTR]] : memref<?xi8>) {
 // CHECK: memref.load %[[IMPLICIT_DEVPTR]][{{.*}}] : memref<?xi8>
 // CHECK: acc.declare_exit token(%[[TOKEN]]) dataOperands(%[[DEVPTR]] : memref<10xf32>)

--- a/mlir/test/Dialect/OpenACC/acc-implicit-routine.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-implicit-routine.mlir
@@ -61,7 +61,7 @@ module {
       acc.loop control(%i : index) = (%c1 : index) to (%c10 : index) step (%c1 : index) {
         func.call @loop_callee() : () -> ()
         acc.yield
-      } attributes {independent = [#acc.device_type<none>]}
+      } independent
       acc.yield
     }
     return

--- a/mlir/test/Dialect/OpenACC/acc-loop-tiling-invalid.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-loop-tiling-invalid.mlir
@@ -10,7 +10,7 @@ func.func @tile_wider_than_iv(%arg0: memref<100xf32>) {
   // expected-error @+1 {{not yet implemented: tile size type (i64) is wider than loop IV type (i32)}}
   acc.loop tile({%c4_i64 : i64}) control(%i : i32) = (%c0 : i32) to (%c100 : i32) step (%c1 : i32) {
     acc.yield
-  } attributes {independent = [#acc.device_type<none>]}
+  } independent
   return
 }
 
@@ -33,6 +33,6 @@ func.func @tile_with_collapse(%arg0: memref<100x50xf32>) {
     %fval = arith.sitofp %val : i32 to f32
     memref.store %fval, %arg0[%i, %j] : memref<100x50xf32>
     acc.yield
-  } attributes {collapse = [2], collapseDeviceType = [#acc.device_type<none>], independent = [#acc.device_type<none>]}
+  } collapse([2]) collapseDeviceType([#acc.device_type<none>]) independent
   return
 }

--- a/mlir/test/Dialect/OpenACC/acc-loop-tiling-remarks.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-loop-tiling-remarks.mlir
@@ -13,7 +13,7 @@ func.func @single_loop_remark(%arg0: memref<100xf32>) {
     %fval = arith.sitofp %val : i32 to f32
     memref.store %fval, %arg0[%i] : memref<100xf32>
     acc.yield
-  } attributes {independent = [#acc.device_type<none>]}
+  } independent
   return
 }
 
@@ -31,7 +31,7 @@ func.func @nested_loop_remark(%arg0: memref<100x50xf32>) {
     %fval = arith.sitofp %val : i32 to f32
     memref.store %fval, %arg0[%i, %j] : memref<100x50xf32>
     acc.yield
-  } attributes {independent = [#acc.device_type<none>]}
+  } independent
   return
 }
 
@@ -50,7 +50,7 @@ func.func @unknown_tile_remark(%arg0: memref<1000xf32>) {
     %fval = arith.sitofp %val : i32 to f32
     memref.store %fval, %arg0[%i] : memref<1000xf32>
     acc.yield
-  } attributes {independent = [#acc.device_type<none>]}
+  } independent
   return
 }
 
@@ -70,6 +70,6 @@ func.func @multiple_unknown_tiles_remark(%arg0: memref<100x100xf32>) {
     %fval = arith.sitofp %val : i32 to f32
     memref.store %fval, %arg0[%i, %j] : memref<100x100xf32>
     acc.yield
-  } attributes {independent = [#acc.device_type<none>]}
+  } independent
   return
 }

--- a/mlir/test/Dialect/OpenACC/acc-loop-tiling.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-loop-tiling.mlir
@@ -14,9 +14,9 @@
 // CHECK:           %[[MIN_UB:.*]] = arith.minsi %[[NEW_UB]], %[[C10]] : index
 // CHECK:           acc.loop control(%[[INNER_IV:.*]] : index) = (%[[IV]] : index) to (%[[MIN_UB]] : index) step (%[[C1]] : index) {
 // CHECK:             acc.yield
-// CHECK:           } attributes {independent = [#acc.device_type<none>]}
+// CHECK:           } independent
 // CHECK:           acc.yield
-// CHECK:         } attributes {independent = [#acc.device_type<none>]}
+// CHECK:         } independent
 func.func @single_loop_tile(%arg0: memref<10xf32>) {
   %c0 = arith.constant 0 : index
   %c10 = arith.constant 10 : index
@@ -27,7 +27,7 @@ func.func @single_loop_tile(%arg0: memref<10xf32>) {
     %fval = arith.sitofp %val : i32 to f32
     memref.store %fval, %arg0[%i] : memref<10xf32>
     acc.yield
-  } attributes {independent = [#acc.device_type<none>]}
+  } independent
   return
 }
 
@@ -49,9 +49,9 @@ func.func @single_loop_tile(%arg0: memref<10xf32>) {
 // Element-group loop with vector.
 // CHECK:           acc.loop vector control(%{{.*}} : index, %{{.*}} : index) = (%[[I]], %[[J]] : index, index) to (%[[MUB0]], %[[MUB1]] : index, index) step (%[[C1]], %[[C1]] : index, index) {
 // CHECK:             acc.yield
-// CHECK:           } attributes {independent = [#acc.device_type<none>]}
+// CHECK:           } independent
 // CHECK:           acc.yield
-// CHECK:         } attributes {independent = [#acc.device_type<none>]}
+// CHECK:         } independent
 func.func @nested_loop_tile(%arg0: memref<100x50xf32>) {
   %c0 = arith.constant 0 : index
   %c100 = arith.constant 100 : index
@@ -65,7 +65,7 @@ func.func @nested_loop_tile(%arg0: memref<100x50xf32>) {
     %fval = arith.sitofp %val : i32 to f32
     memref.store %fval, %arg0[%i, %j] : memref<100x50xf32>
     acc.yield
-  } attributes {independent = [#acc.device_type<none>]}
+  } independent
   return
 }
 
@@ -81,9 +81,9 @@ func.func @nested_loop_tile(%arg0: memref<100x50xf32>) {
 // CHECK:           acc.loop control(%{{.*}} : index, %{{.*}} : index) = (%[[I]], %[[J]] : index, index) to ({{.*}}) step ({{.*}}) {
 // CHECK-NOT:         gang
 // CHECK:             acc.yield
-// CHECK:           } attributes {independent = [#acc.device_type<none>]}
+// CHECK:           } independent
 // CHECK:           acc.yield
-// CHECK:         } attributes {independent = [#acc.device_type<none>]}
+// CHECK:         } independent
 func.func @gang_static_with_multi_dim_tile(%arg0: memref<100x50xf32>) {
   %c0 = arith.constant 0 : index
   %c100 = arith.constant 100 : index
@@ -98,7 +98,7 @@ func.func @gang_static_with_multi_dim_tile(%arg0: memref<100x50xf32>) {
     %fval = arith.sitofp %val : i32 to f32
     memref.store %fval, %arg0[%i, %j] : memref<100x50xf32>
     acc.yield
-  } attributes {independent = [#acc.device_type<none>]}
+  } independent
   return
 }
 
@@ -116,9 +116,9 @@ func.func @gang_static_with_multi_dim_tile(%arg0: memref<100x50xf32>) {
 // CHECK:           acc.loop vector control(%{{.*}} : index, %{{.*}} : index) = (%[[I]], %[[J]] : index, index) to ({{.*}}) step ({{.*}}) {
 // CHECK-NOT:         worker
 // CHECK:             acc.yield
-// CHECK:           } attributes {independent = [#acc.device_type<none>]}
+// CHECK:           } independent
 // CHECK:           acc.yield
-// CHECK:         } attributes {independent = [#acc.device_type<none>]}
+// CHECK:         } independent
 func.func @worker_num_with_multi_dim_tile(%arg0: memref<100x50xf32>) {
   %c0 = arith.constant 0 : index
   %c100 = arith.constant 100 : index
@@ -133,7 +133,7 @@ func.func @worker_num_with_multi_dim_tile(%arg0: memref<100x50xf32>) {
     %fval = arith.sitofp %val : i32 to f32
     memref.store %fval, %arg0[%i, %j] : memref<100x50xf32>
     acc.yield
-  } attributes {independent = [#acc.device_type<none>]}
+  } independent
   return
 }
 
@@ -162,7 +162,7 @@ func.func @unknown_tile_size(%arg0: memref<1000xf32>) {
     %fval = arith.sitofp %val : i32 to f32
     memref.store %fval, %arg0[%i] : memref<1000xf32>
     acc.yield
-  } attributes {independent = [#acc.device_type<none>]}
+  } independent
   return
 }
 
@@ -179,7 +179,7 @@ func.func @no_tile_values() {
   %c1 = arith.constant 1 : index
   acc.loop control(%i : index) = (%c0 : index) to (%c10 : index) step (%c1 : index) {
     acc.yield
-  } attributes {independent = [#acc.device_type<none>]}
+  } independent
   return
 }
 
@@ -213,6 +213,6 @@ func.func @body_with_nested_region(%arg0: memref<10xi32>) {
     }
     memref.store %val, %arg0[%i] : memref<10xi32>
     acc.yield
-  } attributes {independent = [#acc.device_type<none>]}
+  } independent
   return
 }

--- a/mlir/test/Dialect/OpenACC/acc-recipe-materialization-firstprivate-two-allocs.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-recipe-materialization-firstprivate-two-allocs.mlir
@@ -27,7 +27,7 @@ acc.firstprivate.recipe @firstprivatization_two_allocs : memref<i32> init {
 
 func.func @firstpriv_two_allocs() {
   %alloc = memref.alloca() : memref<i32>
-  %fp = acc.firstprivate varPtr(%alloc : memref<i32>) recipe(@firstprivatization_two_allocs) -> memref<i32> {name = "t"}
+  %fp = acc.firstprivate varPtr(%alloc : memref<i32>) recipe(@firstprivatization_two_allocs) name("t") -> memref<i32>
   acc.parallel firstprivate(%fp : memref<i32>) {
     acc.yield
   }
@@ -44,7 +44,7 @@ func.func @firstpriv_two_allocs() {
 
 func.func @firstpriv_two_allocs_no_name() {
   %alloc = memref.alloca() : memref<i32>
-  %fp = acc.firstprivate varPtr(%alloc : memref<i32>) recipe(@firstprivatization_two_allocs) -> memref<i32> {name = ""}
+  %fp = acc.firstprivate varPtr(%alloc : memref<i32>) recipe(@firstprivatization_two_allocs) name("") -> memref<i32>
   acc.parallel firstprivate(%fp : memref<i32>) {
     acc.yield
   }

--- a/mlir/test/Dialect/OpenACC/acc-recipe-materialization-firstprivate.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-recipe-materialization-firstprivate.mlir
@@ -37,7 +37,7 @@ func.func @firstpriv() {
   %c1336 = arith.constant 1336 : i32
   %alloc = memref.alloca() : memref<i32>
   memref.store %c1336, %alloc[] : memref<i32>
-  %fp = acc.firstprivate varPtr(%alloc : memref<i32>) recipe(@firstprivatization_memref_i32) -> memref<i32> {implicit = true, name = "t"}
+  %fp = acc.firstprivate varPtr(%alloc : memref<i32>) recipe(@firstprivatization_memref_i32) implicit(true) name("t") -> memref<i32>
   acc.parallel firstprivate(%fp : memref<i32>) {
     %c1 = arith.constant 1 : i32
     %v = memref.load %fp[] : memref<i32>

--- a/mlir/test/Dialect/OpenACC/acc-recipe-materialization-kernel-private.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-recipe-materialization-kernel-private.mlir
@@ -17,8 +17,8 @@ func.func @kpriv_(%arg0: memref<i32>, %arg1: memref<32xi32>) {
   %iv_alloc = memref.alloca() : memref<i32>
   %start = memref.load %arg0[] : memref<i32>
   memref.store %start, %iv_alloc[] : memref<i32>
-  %copy = acc.copyin varPtr(%arg1 : memref<32xi32>) -> memref<32xi32> {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "a"}
-  %priv = acc.private varPtr(%iv_alloc : memref<i32>) recipe(@privatization_memref_i32) -> memref<i32> {implicit = true, name = "s"}
+  %copy = acc.copyin varPtr(%arg1 : memref<32xi32>) dataClause(acc_copy) implicit(true) name("a") -> memref<32xi32>
+  %priv = acc.private varPtr(%iv_alloc : memref<i32>) recipe(@privatization_memref_i32) implicit(true) name("s") -> memref<i32>
   acc.kernels dataOperands(%copy : memref<32xi32>) private(%priv : memref<i32>) {
     acc.loop control(%arg2 : index) = (%c1 : index) to (%c32 : index) step (%c1 : index) {
       %iv = arith.index_cast %arg2 : index to i32
@@ -26,9 +26,9 @@ func.func @kpriv_(%arg0: memref<i32>, %arg1: memref<32xi32>) {
       %s_val = memref.load %priv[] : memref<i32>
       memref.store %s_val, %copy[%arg2] : memref<32xi32>
       acc.yield
-    } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+    } inclusiveUpperbound(array<i1: true>) independent
     acc.terminator
   }
-  acc.copyout accPtr(%copy : memref<32xi32>) to varPtr(%arg1 : memref<32xi32>) {dataClause = #acc<data_clause acc_copy>, implicit = true, name = "a"}
+  acc.copyout accPtr(%copy : memref<32xi32>) to varPtr(%arg1 : memref<32xi32>) dataClause(acc_copy) implicit(true) name("a")
   return
 }

--- a/mlir/test/Dialect/OpenACC/acc-recipe-materialization-loc.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-recipe-materialization-loc.mlir
@@ -47,12 +47,12 @@ acc.reduction.recipe @reduction_add_memref_index : memref<index> reduction_opera
 
 func.func @private_loc(%arg0: memref<index>) {
   %c1 = arith.constant 1 : index
-  %0 = acc.private varPtr(%arg0 : memref<index>) recipe(@privatization_memref_index) -> memref<index> {implicit = true, name = "priv0"}
+  %0 = acc.private varPtr(%arg0 : memref<index>) recipe(@privatization_memref_index) implicit(true) name("priv0") -> memref<index>
   acc.parallel private(%0 : memref<index>) {
     memref.store %c1, %0[] : memref<index>
     acc.yield
   } attributes {independent = [#acc.device_type<none>]}
-  %1 = acc.private varPtr(%arg0 : memref<index>) recipe(@privatization_memref_index) -> memref<index> {implicit = true, name = "priv1"}
+  %1 = acc.private varPtr(%arg0 : memref<index>) recipe(@privatization_memref_index) implicit(true) name("priv1") -> memref<index>
   acc.parallel private(%1 : memref<index>) {
     memref.store %c1, %1[] : memref<index>
     acc.yield
@@ -73,12 +73,12 @@ func.func @firstprivate_loc() {
   %c1 = arith.constant 1 : index
   %alloca = memref.alloca() : memref<index>
   memref.store %c0, %alloca[] : memref<index>
-  %0 = acc.firstprivate varPtr(%alloca : memref<index>) recipe(@firstprivatization_memref_index) -> memref<index> {implicit = true, name = "firstpriv0"}
+  %0 = acc.firstprivate varPtr(%alloca : memref<index>) recipe(@firstprivatization_memref_index) implicit(true) name("firstpriv0") -> memref<index>
   acc.parallel firstprivate(%0 : memref<index>) {
     memref.store %c1, %0[] : memref<index>
     acc.yield
   }
-  %1 = acc.firstprivate varPtr(%alloca : memref<index>) recipe(@firstprivatization_memref_index) -> memref<index> {implicit = true, name = "firstpriv1"}
+  %1 = acc.firstprivate varPtr(%alloca : memref<index>) recipe(@firstprivatization_memref_index) implicit(true) name("firstpriv1") -> memref<index>
   acc.parallel firstprivate(%1 : memref<index>) {
     memref.store %c1, %1[] : memref<index>
     acc.yield
@@ -99,12 +99,12 @@ func.func @firstprivate_loc() {
 
 func.func @reduction_loc(%arg0: memref<index>) {
   %c1 = arith.constant 1 : index
-  %0 = acc.reduction varPtr(%arg0 : memref<index>) recipe(@reduction_add_memref_index) -> memref<index> {name = "r0"}
+  %0 = acc.reduction varPtr(%arg0 : memref<index>) recipe(@reduction_add_memref_index) name("r0") -> memref<index>
   acc.parallel reduction(%0 : memref<index>) {
     memref.store %c1, %0[] : memref<index>
     acc.yield
   }
-  %1 = acc.reduction varPtr(%arg0 : memref<index>) recipe(@reduction_add_memref_index) -> memref<index> {name = "r1"}
+  %1 = acc.reduction varPtr(%arg0 : memref<index>) recipe(@reduction_add_memref_index) name("r1") -> memref<index>
   acc.parallel reduction(%1 : memref<index>) {
     memref.store %c1, %1[] : memref<index>
     acc.yield

--- a/mlir/test/Dialect/OpenACC/acc-recipe-materialization-parallel.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-recipe-materialization-parallel.mlir
@@ -35,7 +35,7 @@ acc.reduction.recipe @reduction_add_memref_f64 : memref<f64> reduction_operator 
 }
 func.func @par_reduction_clause_(%arg0: memref<f64>) {
   %cst = arith.constant 1.000000e+00 : f64
-  %0 = acc.reduction varPtr(%arg0 : memref<f64>) recipe(@reduction_add_memref_f64) -> memref<f64> {name = "tmp"}
+  %0 = acc.reduction varPtr(%arg0 : memref<f64>) recipe(@reduction_add_memref_f64) name("tmp") -> memref<f64>
   acc.parallel reduction(%0 : memref<f64>) {
     %1 = memref.load %0[] : memref<f64>
     %2 = arith.addf %1, %cst fastmath<contract> : f64

--- a/mlir/test/Dialect/OpenACC/acc-recipe-materialization-private.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-recipe-materialization-private.mlir
@@ -19,12 +19,12 @@ acc.private.recipe @privatization_memref_i64 : memref<i64> init {
 func.func @private_i64(%arg0 : memref<i64>) {
   %c16 = arith.constant 16 : index
   %c1 = arith.constant 1 : index
-  %priv = acc.private varPtr(%arg0 : memref<i64>) recipe(@privatization_memref_i64) -> memref<i64> {implicit = true, name = ""}
+  %priv = acc.private varPtr(%arg0 : memref<i64>) recipe(@privatization_memref_i64) implicit(true) name("") -> memref<i64>
   acc.loop private(%priv : memref<i64>) control(%siv : index) = (%c1 : index) to (%c16 : index) step (%c1 : index) {
     %iv_i64 = arith.index_cast %siv : index to i64
     memref.store %iv_i64, %priv[] : memref<i64>
     acc.yield
-  } attributes {independent = [#acc.device_type<none>]}
+  } independent
   return
 }
 
@@ -37,13 +37,13 @@ func.func @private_i64(%arg0 : memref<i64>) {
 func.func @par_private_i64(%arg0 : memref<i64>) {
   %c16 = arith.constant 16 : index
   %c1 = arith.constant 1 : index
-  %priv = acc.private varPtr(%arg0 : memref<i64>) recipe(@privatization_memref_i64) -> memref<i64> {implicit = true, name = ""}
+  %priv = acc.private varPtr(%arg0 : memref<i64>) recipe(@privatization_memref_i64) implicit(true) name("") -> memref<i64>
   acc.parallel private(%priv : memref<i64>) {
     acc.loop control(%siv : index) = (%c1 : index) to (%c16 : index) step (%c1 : index) {
       %iv_i64 = arith.index_cast %siv : index to i64
       memref.store %iv_i64, %priv[] : memref<i64>
       acc.yield
-    } attributes {independent = [#acc.device_type<none>]}
+    } independent
     acc.yield
   }
   return

--- a/mlir/test/Dialect/OpenACC/acc-recipe-materialization-reduction.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-recipe-materialization-reduction.mlir
@@ -42,7 +42,7 @@ acc.reduction.recipe @reduction_add_memref_f64 : memref<f64> reduction_operator 
 
 func.func @par_reduction_clause_(%arg0: memref<f64>) {
   %cst = arith.constant 1.000000e+00 : f64
-  %red = acc.reduction varPtr(%arg0 : memref<f64>) recipe(@reduction_add_memref_f64) -> memref<f64> {name = "tmp"}
+  %red = acc.reduction varPtr(%arg0 : memref<f64>) recipe(@reduction_add_memref_f64) name("tmp") -> memref<f64>
   acc.parallel reduction(%red : memref<f64>) {
     %3 = memref.load %red[] : memref<f64>
     %4 = arith.addf %3, %cst fastmath<contract> : f64
@@ -74,7 +74,7 @@ func.func @par_reduction_clause_(%arg0: memref<f64>) {
 func.func @par_reduction_clause_serial(%arg0: memref<f64>) {
   %c1_i32 = arith.constant 1 : i32
   %cst = arith.constant 1.000000e+00 : f64
-  %red = acc.reduction varPtr(%arg0 : memref<f64>) recipe(@reduction_add_memref_f64) -> memref<f64> {name = "tmp"}
+  %red = acc.reduction varPtr(%arg0 : memref<f64>) recipe(@reduction_add_memref_f64) name("tmp") -> memref<f64>
   acc.parallel num_gangs({%c1_i32 : i32}) num_workers(%c1_i32 : i32) vector_length(%c1_i32 : i32) reduction(%red : memref<f64>) {
     %3 = memref.load %red[] : memref<f64>
     %4 = arith.addf %3, %cst fastmath<contract> : f64

--- a/mlir/test/Dialect/OpenACC/acc-routine-lowering.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-routine-lowering.mlir
@@ -6,7 +6,7 @@ acc.routine @routine_seq func(@host_foo) seq
 // CHECK: acc.routine @routine_seq func(@
 // CHECK: acc.specialized_routine = #acc.specialized_routine<@routine_seq, <seq>, "host_foo">
 // CHECK-NOT: acc.kernel_environment
-// CHECK: acc.par_width {par_dim = #acc.par_dim<sequential>}
+// CHECK: acc.par_width par_dim(#acc.par_dim<sequential>)
 // CHECK: acc.compute_region
 // CHECK: origin = "acc.routine"
 func.func @host_foo(%buf: memref<8xi32>) {
@@ -23,7 +23,7 @@ acc.routine @routine_vec func(@host_bar) vector
 // CHECK: acc.routine @routine_vec func(@
 // CHECK: acc.specialized_routine = #acc.specialized_routine<@routine_vec, <vector>, "host_bar">
 // CHECK-NOT: acc.kernel_environment
-// CHECK: acc.par_width {par_dim = #acc.par_dim<thread_x>}
+// CHECK: acc.par_width par_dim(#acc.par_dim<thread_x>)
 // CHECK: acc.compute_region
 // CHECK: origin = "acc.routine"
 func.func @host_bar(%buf: memref<4xi32>) {
@@ -39,7 +39,7 @@ func.func @host_bar(%buf: memref<4xi32>) {
 acc.routine @routine_worker func(@host_worker) worker
 // CHECK: acc.routine @routine_worker func(@
 // CHECK: acc.specialized_routine = #acc.specialized_routine<@routine_worker, <worker>, "host_worker">
-// CHECK: acc.par_width {par_dim = #acc.par_dim<thread_y>}
+// CHECK: acc.par_width par_dim(#acc.par_dim<thread_y>)
 // CHECK: acc.compute_region
 // CHECK: origin = "acc.routine"
 func.func @host_worker(%x: i32) {
@@ -52,7 +52,7 @@ func.func @host_worker(%x: i32) {
 acc.routine @routine_gang func(@host_gang) gang
 // CHECK: acc.routine @routine_gang func(@
 // CHECK: acc.specialized_routine = #acc.specialized_routine<@routine_gang, <gang_dim1>, "host_gang">
-// CHECK: acc.par_width {par_dim = #acc.par_dim<block_x>}
+// CHECK: acc.par_width par_dim(#acc.par_dim<block_x>)
 // CHECK: acc.compute_region
 // CHECK: origin = "acc.routine"
 func.func @host_gang() {
@@ -81,7 +81,7 @@ func.func @host_ret(%cond: i1) -> i32 {
 acc.routine @routine_cf func(@host_cf) seq
 // CHECK: acc.routine @routine_cf func(@
 // CHECK: acc.specialized_routine = #acc.specialized_routine<@routine_cf, <seq>, "host_cf">
-// CHECK: acc.par_width {par_dim = #acc.par_dim<sequential>}
+// CHECK: acc.par_width par_dim(#acc.par_dim<sequential>)
 // CHECK: %[[CR:[0-9]+]] = acc.compute_region
 // CHECK: %[[EXE:[0-9]+]] = scf.execute_region
 // CHECK: scf.yield %{{.*}} : i32
@@ -116,10 +116,10 @@ acc.routine @r_a func(@f_a) seq
 acc.routine @r_b func(@f_a) vector
 // CHECK: acc.routine @r_a func(@
 // CHECK: acc.specialized_routine = #acc.specialized_routine<@r_a, <seq>, "f_a">
-// CHECK: acc.par_width {par_dim = #acc.par_dim<sequential>}
+// CHECK: acc.par_width par_dim(#acc.par_dim<sequential>)
 // CHECK: acc.routine @r_b func(@
 // CHECK: acc.specialized_routine = #acc.specialized_routine<@r_b, <vector>, "f_a">
-// CHECK: acc.par_width {par_dim = #acc.par_dim<thread_x>}
+// CHECK: acc.par_width par_dim(#acc.par_dim<thread_x>)
 func.func @f_a() {
   return
 }

--- a/mlir/test/Dialect/OpenACC/acc-specialize-for-host-deep-nesting.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-specialize-for-host-deep-nesting.mlir
@@ -30,36 +30,36 @@ func.func @deeply_nested_orphan_loops(%arg0 : memref<i32>) attributes {acc.routi
                                 acc.loop control(%iv15 : i32) = (%c0 : i32) to (%c10 : i32) step (%c1 : i32) {
                                   memref.store %iv15, %arg0[] : memref<i32>
                                 acc.yield
-                                } attributes {inclusiveUpperbound = array<i1: true>, seq = [#acc.device_type<none>]}
+                                } inclusiveUpperbound(array<i1: true>) seq
                               acc.yield
-                              } attributes {inclusiveUpperbound = array<i1: true>, seq = [#acc.device_type<none>]}
+                              } inclusiveUpperbound(array<i1: true>) seq
                             acc.yield
-                            } attributes {inclusiveUpperbound = array<i1: true>, seq = [#acc.device_type<none>]}
+                            } inclusiveUpperbound(array<i1: true>) seq
                           acc.yield
-                          } attributes {inclusiveUpperbound = array<i1: true>, seq = [#acc.device_type<none>]}
+                          } inclusiveUpperbound(array<i1: true>) seq
                         acc.yield
-                        } attributes {inclusiveUpperbound = array<i1: true>, seq = [#acc.device_type<none>]}
+                        } inclusiveUpperbound(array<i1: true>) seq
                       acc.yield
-                      } attributes {inclusiveUpperbound = array<i1: true>, seq = [#acc.device_type<none>]}
+                      } inclusiveUpperbound(array<i1: true>) seq
                     acc.yield
-                    } attributes {inclusiveUpperbound = array<i1: true>, seq = [#acc.device_type<none>]}
+                    } inclusiveUpperbound(array<i1: true>) seq
                   acc.yield
-                  } attributes {inclusiveUpperbound = array<i1: true>, seq = [#acc.device_type<none>]}
+                  } inclusiveUpperbound(array<i1: true>) seq
                 acc.yield
-                } attributes {inclusiveUpperbound = array<i1: true>, seq = [#acc.device_type<none>]}
+                } inclusiveUpperbound(array<i1: true>) seq
               acc.yield
-              } attributes {inclusiveUpperbound = array<i1: true>, seq = [#acc.device_type<none>]}
+              } inclusiveUpperbound(array<i1: true>) seq
             acc.yield
-            } attributes {inclusiveUpperbound = array<i1: true>, seq = [#acc.device_type<none>]}
+            } inclusiveUpperbound(array<i1: true>) seq
           acc.yield
-          } attributes {inclusiveUpperbound = array<i1: true>, seq = [#acc.device_type<none>]}
+          } inclusiveUpperbound(array<i1: true>) seq
         acc.yield
-        } attributes {inclusiveUpperbound = array<i1: true>, seq = [#acc.device_type<none>]}
+        } inclusiveUpperbound(array<i1: true>) seq
       acc.yield
-      } attributes {inclusiveUpperbound = array<i1: true>, seq = [#acc.device_type<none>]}
+      } inclusiveUpperbound(array<i1: true>) seq
     acc.yield
-    } attributes {inclusiveUpperbound = array<i1: true>, seq = [#acc.device_type<none>]}
+    } inclusiveUpperbound(array<i1: true>) seq
   acc.yield
-  } attributes {inclusiveUpperbound = array<i1: true>, seq = [#acc.device_type<none>]}
+  } inclusiveUpperbound(array<i1: true>) seq
   return
 }

--- a/mlir/test/Dialect/OpenACC/acc-specialize-for-host.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-specialize-for-host.mlir
@@ -167,7 +167,7 @@ func.func @loop_inside_parallel(%arg0 : memref<i32>) attributes {acc.routine_inf
       %c5 = arith.constant 5 : i32
       memref.store %c5, %arg0[] : memref<i32>
       acc.yield
-    } attributes {inclusiveUpperbound = array<i1: true>, seq = [#acc.device_type<none>]}
+    } inclusiveUpperbound(array<i1: true>) seq
     acc.yield
   }
   return
@@ -192,7 +192,7 @@ func.func @private_attached_to_loop(%arg0 : memref<i32>) attributes {acc.routine
     %c1_i32 = arith.constant 1 : i32
     memref.store %c1_i32, %0[] : memref<i32>
     acc.yield
-  } attributes {inclusiveUpperbound = array<i1: true>, seq = [#acc.device_type<none>]}
+  } inclusiveUpperbound(array<i1: true>) seq
   return
 }
 
@@ -212,7 +212,7 @@ func.func @orphan_loop(%arg0 : memref<i32>) attributes {acc.routine_info = #acc.
   acc.loop control(%iv : i32) = (%c0 : i32) to (%c10 : i32) step (%c1 : i32) {
     memref.store %iv, %arg0[] : memref<i32>
     acc.yield
-  } attributes {inclusiveUpperbound = array<i1: true>, seq = [#acc.device_type<none>]}
+  } inclusiveUpperbound(array<i1: true>) seq
   return
 }
 
@@ -230,7 +230,7 @@ func.func @nested_orphan_loop(%arg0 : memref<i32>) attributes {acc.routine_info 
     %sum = arith.addi %iv0, %iv1 : i32
     memref.store %sum, %arg0[] : memref<i32>
     acc.yield
-  } attributes {inclusiveUpperbound = array<i1: true, true>, seq = [#acc.device_type<none>]}
+  } inclusiveUpperbound(array<i1: true, true>) seq
   return
 }
 
@@ -275,7 +275,7 @@ func.func @orphan_unstructured_loop(%arg0 : memref<32xi32>) attributes {acc.rout
     cf.br ^bb1
   ^bb3:
     acc.yield
-  } attributes {independent = [#acc.device_type<none>], unstructured}
+  } independent unstructured
   return
 }
 
@@ -304,7 +304,7 @@ func.func @orphan_loop_with_reduction(%arg0 : memref<i32>, %arg1 : memref<100xi3
     %new_r = arith.addi %r_val, %elem : i32
     memref.store %new_r, %arg0[] : memref<i32>
     acc.yield
-  } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+  } inclusiveUpperbound(array<i1: true>) independent
   return
 }
 
@@ -325,7 +325,7 @@ func.func @orphan_loop_variable_bounds(%arg0 : memref<i32>, %arg1 : memref<i32>,
   acc.loop vector control(%iv : i32) = (%lb : i32) to (%ub : i32) step (%c1 : i32) {
     memref.store %iv, %arg2[] : memref<i32>
     acc.yield
-  } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+  } inclusiveUpperbound(array<i1: true>) independent
   return
 }
 
@@ -370,7 +370,7 @@ func.func @orphan_between_compute_regions(%arg0 : memref<i32>, %arg1 : memref<8x
       %idx = arith.index_cast %iv : i32 to index
       memref.store %c1_i32, %arg1[%idx] : memref<8xi32>
       acc.yield
-    } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+    } inclusiveUpperbound(array<i1: true>) independent
     acc.yield
   }
 
@@ -387,7 +387,7 @@ func.func @orphan_between_compute_regions(%arg0 : memref<i32>, %arg1 : memref<8x
     %mul = arith.muli %t, %c2_i32 : i32
     memref.store %mul, %arg0[] : memref<i32>
     acc.yield
-  } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+  } inclusiveUpperbound(array<i1: true>) independent
 
   // Second compute region - should NOT be converted
   acc.parallel combined(loop) {
@@ -397,7 +397,7 @@ func.func @orphan_between_compute_regions(%arg0 : memref<i32>, %arg1 : memref<8x
       %idx = arith.index_cast %iv : i32 to index
       memref.store %iv, %arg1[%idx] : memref<8xi32>
       acc.yield
-    } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+    } inclusiveUpperbound(array<i1: true>) independent
     acc.yield
   }
   return

--- a/mlir/test/Dialect/OpenACC/canonicalize.mlir
+++ b/mlir/test/Dialect/OpenACC/canonicalize.mlir
@@ -116,10 +116,10 @@ func.func @testhostdataop(%a: memref<f32>, %ifCond: i1) -> () {
   acc.host_data dataOperands(%0 : memref<f32>) if(%false) {
     acc.loop control(%iv : i32) = (%1 : i32) to (%2 : i32) step (%1 : i32) {
       acc.yield
-    } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+    } inclusiveUpperbound(array<i1: true>) independent
     acc.loop control(%iv : i32) = (%1 : i32) to (%2 : i32) step (%1 : i32) {
       acc.yield
-    } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+    } inclusiveUpperbound(array<i1: true>) independent
     acc.terminator
   }
   return
@@ -243,6 +243,6 @@ func.func @kernel_environment_canonicalization(%q1: i32, %q2: i32, %q3: i32) {
 // CHECK-SAME: ([[Q1:%.*]]: i32, [[Q2:%.*]]: i32, [[Q3:%.*]]: i32)
 // CHECK-NOT: acc.kernel_environment
 // CHECK: acc.wait([[Q1]], [[Q2]] : i32, i32)
-// CHECK: acc.wait
+// CHECK: acc.wait{{ *$}}
 // CHECK: acc.wait([[Q3]] : i32)
 // CHECK: return

--- a/mlir/test/Dialect/OpenACC/cse.mlir
+++ b/mlir/test/Dialect/OpenACC/cse.mlir
@@ -23,9 +23,9 @@ func.func @cse_across_acc_set(%a: memref<10xf32>, %i: index) -> (f32, f32) {
 // distinct workgroup-memory slot.
 // CHECK-LABEL: @cse_gpu_shared_memory_not_merged
 func.func @cse_gpu_shared_memory_not_merged() -> (memref<8xf32, #gpu.address_space<workgroup>>, memref<8xf32, #gpu.address_space<workgroup>>) {
-  %0 = acc.gpu_shared_memory {num_copies = 1 : i64, static_upper_bound_bytes = 256 : i64}
+  %0 = acc.gpu_shared_memory <{num_copies = 1 : i64, static_upper_bound_bytes = 256 : i64}>
       : () -> memref<8xf32, #gpu.address_space<workgroup>>
-  %1 = acc.gpu_shared_memory {num_copies = 1 : i64, static_upper_bound_bytes = 256 : i64}
+  %1 = acc.gpu_shared_memory <{num_copies = 1 : i64, static_upper_bound_bytes = 256 : i64}>
       : () -> memref<8xf32, #gpu.address_space<workgroup>>
   // CHECK: acc.gpu_shared_memory
   // CHECK: acc.gpu_shared_memory

--- a/mlir/test/Dialect/OpenACC/invalid-cg.mlir
+++ b/mlir/test/Dialect/OpenACC/invalid-cg.mlir
@@ -32,12 +32,12 @@ acc.compute_region launch(%arg0 = %c32) {
 
 // Use generic form to introduce an extra block argument.
 %c64 = arith.constant 64 : index
-%w = acc.par_width %c64 {par_dim = #acc.par_dim<thread_x>}
+%w = acc.par_width %c64 par_dim(#acc.par_dim<thread_x>)
 // expected-error@+1 {{'acc.compute_region' op expected 1 block arguments (launch + input), got 2}}
-"acc.compute_region"(%w) <{operandSegmentSizes = array<i32: 1, 0, 0>}> ({
+"acc.compute_region"(%w) <{operandSegmentSizes = array<i32: 1, 0, 0>, origin = "acc.parallel"}> ({
 ^bb0(%arg0: index, %extra: index):
   "acc.yield"() : () -> ()
-}) {origin = "acc.parallel"} : (index) -> ()
+}) : (index) -> ()
 
 // -----
 
@@ -45,7 +45,7 @@ func.func @reduction_accumulate_invalid_operator() {
   %partial = arith.constant 1.0 : f32
   %private = memref.alloca() : memref<f32>
   acc.reduction_accumulate %partial to %private <addi>
-      : f32 -> memref<f32> {par_dims = #acc<par_dims[thread_x]>}
+      : f32 -> memref<f32> <{par_dims = #acc<par_dims[thread_x]>}>
   // expected-error@-2 {{expected ::mlir::acc::ReductionOperator to be one of}}
   // expected-error@-3 {{failed to parse OpenACC_ReductionOperatorAttr}}
   return
@@ -58,7 +58,7 @@ func.func @reduction_accumulate_type_mismatch() {
   %private_i32 = memref.alloca() : memref<i32>
   // expected-error@+1 {{pointer-like element type must match value type}}
   acc.reduction_accumulate %wrong_ty to %private_i32 <add>
-      : f32 -> memref<i32> {par_dims = #acc<par_dims[thread_x]>}
+      : f32 -> memref<i32> <{par_dims = #acc<par_dims[thread_x]>}>
   return
 }
 
@@ -69,7 +69,7 @@ func.func @reduction_accumulate_empty_par_dims() {
   %private4 = memref.alloca() : memref<i32>
   // expected-error@+1 {{par_dims must specify at least one parallel dimension}}
   acc.reduction_accumulate %partial3 to %private4 <add>
-      : i32 -> memref<i32> {par_dims = #acc<par_dims[]>}
+      : i32 -> memref<i32> <{par_dims = #acc<par_dims[]>}>
   return
 }
 
@@ -77,7 +77,7 @@ func.func @reduction_accumulate_empty_par_dims() {
 
 func.func @reduction_accumulate_array_invalid_operator(%private: memref<4xi32>, %bounds: !acc.data_bounds_ty) {
   acc.reduction_accumulate_array %private bounds(%bounds) <addi>
-      : memref<4xi32> {par_dims = #acc<par_dims[thread_x]>}
+      : memref<4xi32> <{par_dims = #acc<par_dims[thread_x]>}>
   // expected-error@-2 {{expected ::mlir::acc::ReductionOperator to be one of}}
   // expected-error@-3 {{failed to parse OpenACC_ReductionOperatorAttr}}
   return
@@ -88,7 +88,7 @@ func.func @reduction_accumulate_array_invalid_operator(%private: memref<4xi32>, 
 func.func @reduction_accumulate_array_empty_par_dims(%private: memref<4xi32>, %bounds: !acc.data_bounds_ty) {
   // expected-error@+1 {{par_dims must specify at least one parallel dimension}}
   acc.reduction_accumulate_array %private bounds(%bounds) <add>
-      : memref<4xi32> {par_dims = #acc<par_dims[]>}
+      : memref<4xi32> <{par_dims = #acc<par_dims[]>}>
   return
 }
 
@@ -133,9 +133,9 @@ func.func @predicate_region_outside_compute_region() {
 func.func @gpu_shared_memory_mismatched_runtime_attrs() {
   // expected-error@+1 {{dynamic_shared_memory_scaling_bytes and dynamic_shared_memory_fixed_bytes must both be present or both be absent}}
   %sm = acc.gpu_shared_memory()
-      {num_copies = 1 : i64,
+      <{num_copies = 1 : i64,
        static_upper_bound_bytes = 512 : i64,
-       dynamic_shared_memory_scaling_bytes = 4 : i64}
+       dynamic_shared_memory_scaling_bytes = 4 : i64}>
       : () -> memref<8xf32, #gpu.address_space<workgroup>>
   return
 }
@@ -145,7 +145,7 @@ func.func @gpu_shared_memory_mismatched_runtime_attrs() {
 func.func @gpu_shared_memory_non_workgroup_memref() {
   // expected-error@+1 {{result memref must use #gpu.address_space<workgroup>}}
   %sm = acc.gpu_shared_memory()
-      {num_copies = 1 : i64, static_upper_bound_bytes = 512 : i64}
+      <{num_copies = 1 : i64, static_upper_bound_bytes = 512 : i64}>
       : () -> memref<8xf32>
   return
 }
@@ -155,7 +155,7 @@ func.func @gpu_shared_memory_non_workgroup_memref() {
 func.func @gpu_shared_memory_zero_num_copies() {
   // expected-error@+1 {{num_copies must be positive}}
   %sm = acc.gpu_shared_memory()
-      {num_copies = 0 : i64, static_upper_bound_bytes = 512 : i64}
+      <{num_copies = 0 : i64, static_upper_bound_bytes = 512 : i64}>
       : () -> memref<8xf32, #gpu.address_space<workgroup>>
   return
 }
@@ -165,10 +165,10 @@ func.func @gpu_shared_memory_zero_num_copies() {
 func.func @gpu_shared_memory_negative_scaling_bytes() {
   // expected-error@+1 {{dynamic_shared_memory_scaling_bytes must be non-negative}}
   %sm = acc.gpu_shared_memory()
-      {num_copies = 1 : i64,
+      <{num_copies = 1 : i64,
        static_upper_bound_bytes = 512 : i64,
        dynamic_shared_memory_scaling_bytes = -1 : i64,
-       dynamic_shared_memory_fixed_bytes = 24 : i64}
+       dynamic_shared_memory_fixed_bytes = 24 : i64}>
       : () -> memref<8xf32, #gpu.address_space<workgroup>>
   return
 }
@@ -178,10 +178,10 @@ func.func @gpu_shared_memory_negative_scaling_bytes() {
 func.func @gpu_shared_memory_negative_fixed_bytes() {
   // expected-error@+1 {{dynamic_shared_memory_fixed_bytes must be non-negative}}
   %sm = acc.gpu_shared_memory()
-      {num_copies = 1 : i64,
+      <{num_copies = 1 : i64,
        static_upper_bound_bytes = 512 : i64,
        dynamic_shared_memory_scaling_bytes = 12 : i64,
-       dynamic_shared_memory_fixed_bytes = -1 : i64}
+       dynamic_shared_memory_fixed_bytes = -1 : i64}>
       : () -> memref<8xf32, #gpu.address_space<workgroup>>
   return
 }

--- a/mlir/test/Dialect/OpenACC/invalid.mlir
+++ b/mlir/test/Dialect/OpenACC/invalid.mlir
@@ -3,111 +3,111 @@
 %1 = arith.constant 1 : i32
 %2 = arith.constant 10 : i32
 // expected-error@+1 {{gang, worker or vector cannot appear with seq}}
-acc.loop control(%iv : i32) = (%1 : i32) to (%2 : i32) step (%1 : i32) {
+acc.loop gang control(%iv : i32) = (%1 : i32) to (%2 : i32) step (%1 : i32) {
   "test.openacc_dummy_op"() : () -> ()
   acc.yield
-} attributes {seq = [#acc.device_type<none>], gang = [#acc.device_type<none>]}
+} seq
 
 // -----
 
 %1 = arith.constant 1 : i32
 %2 = arith.constant 10 : i32
 // expected-error@+1 {{gang, worker or vector cannot appear with seq}}
-acc.loop control(%iv : i32) = (%1 : i32) to (%2 : i32) step (%1 : i32) {
+acc.loop worker control(%iv : i32) = (%1 : i32) to (%2 : i32) step (%1 : i32) {
   "test.openacc_dummy_op"() : () -> ()
   acc.yield
-} attributes {seq = [#acc.device_type<none>], worker = [#acc.device_type<none>]}
+} seq
 
 // -----
 
 %1 = arith.constant 1 : i32
 %2 = arith.constant 10 : i32
 // expected-error@+1 {{gang, worker or vector cannot appear with seq}}
-acc.loop control(%iv : i32) = (%1 : i32) to (%2 : i32) step (%1 : i32) {
+acc.loop vector control(%iv : i32) = (%1 : i32) to (%2 : i32) step (%1 : i32) {
   "test.openacc_dummy_op"() : () -> ()
   acc.yield
-} attributes {seq = [#acc.device_type<none>], vector = [#acc.device_type<none>]}
+} seq
 
 // -----
 
 %1 = arith.constant 1 : i32
 %2 = arith.constant 10 : i32
 // expected-error@+1 {{gang, worker or vector cannot appear with seq}}
-acc.loop control(%iv : i32) = (%1 : i32) to (%2 : i32) step (%1 : i32) {
+acc.loop gang worker control(%iv : i32) = (%1 : i32) to (%2 : i32) step (%1 : i32) {
   "test.openacc_dummy_op"() : () -> ()
   acc.yield
-} attributes {seq = [#acc.device_type<none>], worker = [#acc.device_type<none>], gang = [#acc.device_type<none>]}
+} seq
 
 // -----
 
 %1 = arith.constant 1 : i32
 %2 = arith.constant 10 : i32
 // expected-error@+1 {{gang, worker or vector cannot appear with seq}}
-acc.loop control(%iv : i32) = (%1 : i32) to (%2 : i32) step (%1 : i32) {
+acc.loop gang vector control(%iv : i32) = (%1 : i32) to (%2 : i32) step (%1 : i32) {
   "test.openacc_dummy_op"() : () -> ()
   acc.yield
-} attributes {seq = [#acc.device_type<none>], vector = [#acc.device_type<none>], gang = [#acc.device_type<none>]}
+} seq
 
 // -----
 
 %1 = arith.constant 1 : i32
 %2 = arith.constant 10 : i32
 // expected-error@+1 {{gang, worker or vector cannot appear with seq}}
-acc.loop control(%iv : i32) = (%1 : i32) to (%2 : i32) step (%1 : i32) {
+acc.loop worker vector control(%iv : i32) = (%1 : i32) to (%2 : i32) step (%1 : i32) {
   "test.openacc_dummy_op"() : () -> ()
   acc.yield
-} attributes {seq = [#acc.device_type<none>], vector = [#acc.device_type<none>], worker = [#acc.device_type<none>]}
+} seq
 
 // -----
 
 %1 = arith.constant 1 : i32
 %2 = arith.constant 10 : i32
 // expected-error@+1 {{gang, worker or vector cannot appear with seq}}
-acc.loop {
+acc.loop gang worker vector {
   "test.openacc_dummy_op"() : () -> ()
   acc.yield
-} attributes {seq = [#acc.device_type<none>], vector = [#acc.device_type<none>], worker = [#acc.device_type<none>], gang = [#acc.device_type<none>]}
+} seq
 
 // -----
 
 // expected-error@+1 {{expected non-empty body.}}
 acc.loop {
-} attributes {independent = [#acc.device_type<none>]}
+} independent
 
 // -----
 
 // expected-error@+1 {{'acc.loop' op duplicate device_type `none` found in gang attribute}}
-acc.loop {
+acc.loop gang([#acc.device_type<none>, #acc.device_type<none>]) {
   acc.yield
-} attributes {gang = [#acc.device_type<none>, #acc.device_type<none>]}
+}
 
 // -----
 
 // expected-error@+1 {{'acc.loop' op duplicate device_type `none` found in worker attribute}}
-acc.loop {
-  acc.yield
-} attributes {worker = [#acc.device_type<none>, #acc.device_type<none>]}
+"acc.loop"() <{operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>, worker = [#acc.device_type<none>, #acc.device_type<none>]}> ({
+  "acc.yield"() : () -> ()
+}) : () -> ()
 
 // -----
 
 // expected-error@+1 {{'acc.loop' op duplicate device_type `none` found in vector attribute}}
-acc.loop {
-  acc.yield
-} attributes {vector = [#acc.device_type<none>, #acc.device_type<none>]}
+"acc.loop"() <{operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>, vector = [#acc.device_type<none>, #acc.device_type<none>]}> ({
+  "acc.yield"() : () -> ()
+}) : () -> ()
 
 // -----
 
 // expected-error@+1 {{'acc.loop' op duplicate device_type `nvidia` found in gang attribute}}
-acc.loop {
+acc.loop gang([#acc.device_type<nvidia>, #acc.device_type<nvidia>]) {
   acc.yield
-} attributes {gang = [#acc.device_type<nvidia>, #acc.device_type<nvidia>]}
+}
 
 // -----
 
 // expected-error@+1 {{'acc.loop' op duplicate device_type `none` found in collapseDeviceType attribute}}
 acc.loop {
   acc.yield
-} attributes {collapse = [1, 1], collapseDeviceType = [#acc.device_type<none>, #acc.device_type<none>], independent = [#acc.device_type<none>]}
+} collapse([1, 1]) collapseDeviceType([#acc.device_type<none>, #acc.device_type<none>]) independent
 
 // -----
 
@@ -115,7 +115,7 @@ acc.loop {
 // expected-error@+1 {{'acc.loop' op duplicate device_type `none` found in workerNumOperandsDeviceType attribute}}
 acc.loop worker(%i64value: i64, %i64value: i64) {
   acc.yield
-} attributes {workerNumOperandsDeviceType = [#acc.device_type<none>, #acc.device_type<none>], independent = [#acc.device_type<none>]}
+} independent
 
 // -----
 
@@ -123,7 +123,7 @@ acc.loop worker(%i64value: i64, %i64value: i64) {
 // expected-error@+1 {{'acc.loop' op duplicate device_type `none` found in vectorOperandsDeviceType attribute}}
 acc.loop vector(%i64value: i64, %i64value: i64) {
   acc.yield
-} attributes {vectorOperandsDeviceType = [#acc.device_type<none>, #acc.device_type<none>], independent = [#acc.device_type<none>]}
+} independent
 
 // -----
 
@@ -140,7 +140,7 @@ func.func @acc_routine_parallelism() -> () {
 // expected-error@+1 {{only one of auto, independent, seq can be present at the same time}}
 acc.loop control(%iv : i32) = (%1 : i32) to (%2 : i32) step (%1 : i32) {
   acc.yield
-} attributes {auto_ = [#acc.device_type<none>], seq = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+} auto_ seq inclusiveUpperbound(array<i1: true>)
 
 // -----
 
@@ -168,7 +168,7 @@ acc.update
 %value = memref.alloc() : memref<f32>
 %0 = acc.update_device varPtr(%value : memref<f32>) -> memref<f32>
 // expected-error@+1 {{asyncOnly attribute cannot appear with asyncOperand}}
-acc.update async(%cst: index) dataOperands(%0 : memref<f32>) attributes {asyncOnly = [#acc.device_type<none>]}
+"acc.update"(%cst, %0) <{operandSegmentSizes = array<i32: 0, 1, 0, 1>, asyncOperandsDeviceType = [#acc.device_type<none>], asyncOnly = [#acc.device_type<none>]}> : (index, memref<f32>) -> ()
 
 // -----
 
@@ -176,7 +176,7 @@ acc.update async(%cst: index) dataOperands(%0 : memref<f32>) attributes {asyncOn
 %value = memref.alloc() : memref<f32>
 %0 = acc.update_device varPtr(%value : memref<f32>) -> memref<f32>
 // expected-error@+1 {{wait attribute cannot appear with waitOperands}}
-acc.update wait({%cst: index}) dataOperands(%0: memref<f32>) attributes {waitOnly = [#acc.device_type<none>]}
+"acc.update"(%cst, %0) <{operandSegmentSizes = array<i32: 0, 0, 1, 1>, waitOperandsDeviceType = [#acc.device_type<none>], waitOperandsSegments = array<i32: 1>, hasWaitDevnum = [false], waitOnly = [#acc.device_type<none>]}> : (index, memref<f32>) -> ()
 
 // -----
 
@@ -188,7 +188,7 @@ acc.wait wait_devnum(%cst: index)
 
 %cst = arith.constant 1 : index
 // expected-error@+1 {{async attribute cannot appear with asyncOperand}}
-acc.wait async(%cst: index) attributes {async}
+"acc.wait"(%cst) <{operandSegmentSizes = array<i32: 0, 1, 0, 0>, async}> : (index) -> ()
 
 // -----
 
@@ -206,7 +206,7 @@ acc.loop control(%iv : i32) = (%1 : i32) to (%2 : i32) step (%1 : i32){
 // expected-error@+1 {{'acc.init' op cannot be nested in a compute operation}}
   acc.init
   acc.yield
-} attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+} inclusiveUpperbound(array<i1: true>) independent
 
 // -----
 
@@ -224,7 +224,7 @@ acc.loop control(%iv : i32) = (%1 : i32) to (%2 : i32) step (%1 : i32) {
 // expected-error@+1 {{'acc.shutdown' op cannot be nested in a compute operation}}
   acc.shutdown
   acc.yield
-} attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+} inclusiveUpperbound(array<i1: true>) independent
 
 // -----
 
@@ -236,12 +236,12 @@ acc.loop control(%iv : i32) = (%1 : i32) to (%2 : i32) step (%1 : i32) {
     acc.shutdown
   }) : () -> ()
   acc.yield
-} attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+} inclusiveUpperbound(array<i1: true>) independent
 
 // -----
 
 // expected-error@+1 {{at least one operand must be present in dataOperands on the exit data operation}}
-acc.exit_data attributes {async}
+acc.exit_data async
 
 // -----
 
@@ -249,7 +249,7 @@ acc.exit_data attributes {async}
 %value = memref.alloc() : memref<f32>
 %0 = acc.getdeviceptr varPtr(%value : memref<f32>) -> memref<f32>
 // expected-error@+1 {{async attribute cannot appear with asyncOperand}}
-acc.exit_data async(%cst: index) dataOperands(%0 : memref<f32>) attributes {async}
+"acc.exit_data"(%cst, %0) <{operandSegmentSizes = array<i32: 0, 1, 0, 0, 1>, async}> : (index, memref<f32>) -> ()
 acc.delete accPtr(%0 : memref<f32>)
 
 // -----
@@ -264,7 +264,7 @@ acc.delete accPtr(%0 : memref<f32>)
 // -----
 
 // expected-error@+1 {{at least one operand must be present in dataOperands on the enter data operation}}
-acc.enter_data attributes {async}
+acc.enter_data async
 
 // -----
 
@@ -272,7 +272,7 @@ acc.enter_data attributes {async}
 %value = memref.alloc() : memref<f32>
 %0 = acc.create varPtr(%value : memref<f32>) -> memref<f32>
 // expected-error@+1 {{async attribute cannot appear with asyncOperand}}
-acc.enter_data async(%cst: index) dataOperands(%0 : memref<f32>) attributes {async}
+"acc.enter_data"(%cst, %0) <{operandSegmentSizes = array<i32: 0, 1, 0, 0, 1>, async}> : (index, memref<f32>) -> ()
 
 // -----
 
@@ -280,7 +280,7 @@ acc.enter_data async(%cst: index) dataOperands(%0 : memref<f32>) attributes {asy
 %value = memref.alloc() : memref<f32>
 %0 = acc.create varPtr(%value : memref<f32>) -> memref<f32>
 // expected-error@+1 {{wait attribute cannot appear with waitOperands}}
-acc.enter_data wait(%cst: index) dataOperands(%0 : memref<f32>) attributes {wait}
+"acc.enter_data"(%cst, %0) <{operandSegmentSizes = array<i32: 0, 0, 0, 1, 1>, wait}> : (index, memref<f32>) -> ()
 
 // -----
 
@@ -526,7 +526,7 @@ acc.loop gang({static=%i64Value: i64, ) control(%iv : i32) = (%1 : i32) to (%2 :
 // expected-error@+1 {{unstructured acc.loop must not have induction variables}}
 acc.loop control(%iv : i32) = (%i1 : i32) to (%i2 : i32) step (%i1 : i32) {
   acc.yield
-} attributes {independent = [#acc.device_type<none>], unstructured}
+} independent unstructured
 
 // -----
 
@@ -555,7 +555,7 @@ acc.parallel num_gangs({%i64value: i64, %i64value : i64, %i64value : i64, %i64va
 %i64value = arith.constant 1 : i64
 acc.parallel {
 // expected-error@+1 {{'acc.set' op cannot be nested in a compute operation}}
-  acc.set attributes {device_type = #acc.device_type<nvidia>}
+  acc.set device_type(#acc.device_type<nvidia>)
   acc.yield
 }
 
@@ -835,7 +835,7 @@ func.func @acc_loop_container() {
         scf.yield
     }
     acc.yield
-  } attributes { collapse = [2], collapseDeviceType = [#acc.device_type<none>], independent = [#acc.device_type<none>]}
+  } collapse([2]) collapseDeviceType([#acc.device_type<none>]) independent
   return
 }
 
@@ -854,7 +854,7 @@ func.func @acc_loop_container() {
       scf.yield
     }
     acc.yield
-  } attributes { collapse = [3], collapseDeviceType = [#acc.device_type<none>], independent = [#acc.device_type<none>]}
+  } collapse([3]) collapseDeviceType([#acc.device_type<none>]) independent
   return
 }
 
@@ -862,13 +862,13 @@ func.func @acc_loop_container() {
 
 %value = memref.alloc() : memref<f32>
 // expected-error @below {{no data clause modifiers are allowed}}
-%0 = acc.private varPtr(%value : memref<f32>) -> memref<f32> {modifiers = #acc<data_clause_modifier zero>}
+%0 = acc.private varPtr(%value : memref<f32>) <{modifiers = #acc<data_clause_modifier zero>}> -> memref<f32>
 
 // -----
 
 %value = memref.alloc() : memref<f32>
 // expected-error @below {{invalid data clause modifiers: readonly}}
-%0 = acc.create varPtr(%value : memref<f32>) -> memref<f32> {modifiers = #acc<data_clause_modifier readonly,zero,capture,always>}
+%0 = acc.create varPtr(%value : memref<f32>) <{modifiers = #acc<data_clause_modifier readonly,zero,capture,always>}> -> memref<f32>
 
 // -----
 

--- a/mlir/test/Dialect/OpenACC/legalize-data.mlir
+++ b/mlir/test/Dialect/OpenACC/legalize-data.mlir
@@ -96,7 +96,7 @@ func.func @test(%a: memref<10xf32>) {
     acc.loop control(%i : index) = (%lb : index) to (%c10 : index) step (%st : index) {
       %ci = memref.load %a[%i] : memref<10xf32>
       acc.yield
-    } attributes {independent = [#acc.device_type<none>]}
+    } independent
     acc.yield
   }
   return
@@ -109,7 +109,7 @@ func.func @test(%a: memref<10xf32>) {
 // CHECK:   acc.loop control(%[[I:.*]] : index) = (%{{.*}} : index) to (%{{.*}} : index)  step (%{{.*}} : index) {
 // DEVICE:    %{{.*}} = memref.load %[[CREATE:.*]][%[[I]]] : memref<10xf32>
 // CHECK:     acc.yield
-// CHECK:   } attributes {independent = [#acc.device_type<none>]}
+// CHECK:   } independent
 // CHECK:   acc.yield
 // CHECK: }
 
@@ -134,7 +134,7 @@ func.func @test(%a: memref<10xf32>) {
     acc.loop control(%i : index) = (%lb : index) to (%c10 : index) step (%st : index) {
       %ci = memref.load %a[%i] : memref<10xf32>
       acc.yield
-    } attributes {independent = [#acc.device_type<none>]}
+    } independent
     acc.yield
   }
   return
@@ -147,7 +147,7 @@ func.func @test(%a: memref<10xf32>) {
 // CHECK:   acc.loop control(%[[I:.*]] : index) = (%{{.*}} : index) to (%{{.*}} : index)  step (%{{.*}} : index) {
 // DEVICE:    %{{.*}} = memref.load %[[PRIVATE:.*]][%[[I]]] : memref<10xf32>
 // CHECK:     acc.yield
-// CHECK:   } attributes {independent = [#acc.device_type<none>]}
+// CHECK:   } independent
 // CHECK:   acc.yield
 // CHECK: }
 
@@ -172,7 +172,7 @@ func.func @test(%a: memref<10xf32>) {
     acc.loop private(%p1 : memref<10xf32>) control(%i : index) = (%lb : index) to (%c10 : index) step (%st : index) {
       %ci = memref.load %a[%i] : memref<10xf32>
       acc.yield
-    } attributes {independent = [#acc.device_type<none>]}
+    } independent
     acc.yield
   }
   return
@@ -185,7 +185,7 @@ func.func @test(%a: memref<10xf32>) {
 // CHECK:   acc.loop private(%[[PRIVATE]] : memref<10xf32>) control(%[[I:.*]] : index) = (%{{.*}} : index) to (%{{.*}} : index)  step (%{{.*}} : index) {
 // DEVICE:    %{{.*}} = memref.load %[[PRIVATE:.*]][%[[I]]] : memref<10xf32>
 // CHECK:     acc.yield
-// CHECK:   } attributes {independent = [#acc.device_type<none>]}
+// CHECK:   } independent
 // CHECK:   acc.yield
 // CHECK: }
 
@@ -210,7 +210,7 @@ func.func @test(%a: memref<10xf32>) {
     acc.loop control(%i : index) = (%lb : index) to (%c10 : index) step (%st : index) {
       %ci = memref.load %a[%i] : memref<10xf32>
       acc.yield
-    } attributes {seq = [#acc.device_type<none>]}
+    } seq
     acc.yield
   }
   return
@@ -223,7 +223,7 @@ func.func @test(%a: memref<10xf32>) {
 // CHECK:   acc.loop control(%[[I:.*]] : index) = (%{{.*}} : index) to (%{{.*}} : index)  step (%{{.*}} : index) {
 // DEVICE:    %{{.*}} = memref.load %[[PRIVATE:.*]][%[[I]]] : memref<10xf32>
 // CHECK:     acc.yield
-// CHECK:   } attributes {seq = [#acc.device_type<none>]}
+// CHECK:   } seq
 // CHECK:   acc.yield
 // CHECK: }
 
@@ -250,7 +250,7 @@ func.func private @foo(memref<10xf32>)
 // -----
 
 func.func @test(%a: memref<10xf32>) {
-  %declare = acc.create varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) -> memref<10xf32> {name = "arr"}
+  %declare = acc.create varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) name("arr") -> memref<10xf32>
   %token = acc.declare_enter dataOperands(%declare : memref<10xf32>)
   acc.kernels dataOperands(%declare : memref<10xf32>) {
     %c0 = arith.constant 0 : index
@@ -264,7 +264,7 @@ func.func @test(%a: memref<10xf32>) {
 
 // CHECK-LABEL: func.func @test
 // CHECK-SAME: (%[[A:.*]]: memref<10xf32>)
-// CHECK: %[[DECLARE:.*]] = acc.create varPtr(%[[A]] : memref<10xf32>) varType(tensor<10xf32>) -> memref<10xf32> {name = "arr"}
+// CHECK: %[[DECLARE:.*]] = acc.create varPtr(%[[A]] : memref<10xf32>) varType(tensor<10xf32>) name("arr") -> memref<10xf32>
 // CHECK: %[[TOKEN:.*]] = acc.declare_enter dataOperands(%[[DECLARE]] : memref<10xf32>)
 // CHECK: acc.kernels dataOperands(%[[DECLARE]] : memref<10xf32>) {
 // DEVICE:   memref.store %{{.*}}, %[[DECLARE]][%{{.*}}] : memref<10xf32>

--- a/mlir/test/Dialect/OpenACC/legalize-serial.mlir
+++ b/mlir/test/Dialect/OpenACC/legalize-serial.mlir
@@ -80,7 +80,7 @@ acc.reduction.recipe @reduction_add_memref_i64 : memref<i64> reduction_operator<
 // CHECK:           %[[VAL_9:.*]] = acc.private varPtr(%[[VAL_2]] : memref<10x10xf32>) recipe(@privatization_memref_10_10_f32) -> memref<10x10xf32>
 // CHECK:           acc.parallel firstprivate(%[[VAL_6]] : memref<10xf32>) num_gangs({%[[VAL_4]] : i32}) num_workers(%[[VAL_4]] : i32) private(%[[VAL_9]] : memref<10x10xf32>) vector_length(%[[VAL_4]] : i32) {
 // CHECK:           }
-// CHECK:           %[[VAL_7:.*]] = acc.copyin varPtr(%[[VAL_0]] : memref<10xf32>) -> memref<10xf32> {dataClause = #acc<data_clause acc_copy>}
+// CHECK:           %[[VAL_7:.*]] = acc.copyin varPtr(%[[VAL_0]] : memref<10xf32>) dataClause(acc_copy) -> memref<10xf32>
 // CHECK:           acc.parallel dataOperands(%[[VAL_7]] : memref<10xf32>) num_gangs({%[[VAL_4]] : i32}) num_workers(%[[VAL_4]] : i32) vector_length(%[[VAL_4]] : i32) {
 // CHECK:           }
 // CHECK:           %[[I64MEM:.*]] = memref.alloca() : memref<i64>
@@ -91,22 +91,22 @@ acc.reduction.recipe @reduction_add_memref_i64 : memref<i64> reduction_operator<
 // CHECK:           acc.parallel combined(loop) num_gangs({%[[VAL_4]] : i32}) num_workers(%[[VAL_4]] : i32) vector_length(%[[VAL_4]] : i32) {
 // CHECK:             acc.loop combined(serial) control(%{{.*}} : index) = (%[[VAL_5]] : index) to (%[[VAL_5]] : index) step (%[[VAL_5]] : index) {
 // CHECK:               acc.yield
-// CHECK:             } attributes {seq = [#acc.device_type<none>]}
+// CHECK:             } seq
 // CHECK:             acc.terminator
 // CHECK:           }
 // CHECK:           acc.parallel num_gangs({%[[VAL_4]] : i32}) num_workers(%[[VAL_4]] : i32) vector_length(%[[VAL_4]] : i32) {
-// CHECK:           } attributes {defaultAttr = #acc<defaultvalue none>}
+// CHECK:           } defaultAttr(none)
 // CHECK:           acc.parallel num_gangs({%[[VAL_4]] : i32}) num_workers(%[[VAL_4]] : i32) vector_length(%[[VAL_4]] : i32) {
-// CHECK:           } attributes {defaultAttr = #acc<defaultvalue present>}
-// CHECK:           acc.parallel num_gangs({%[[VAL_4]] : i32}) num_workers(%[[VAL_4]] : i32) vector_length(%[[VAL_4]] : i32) {
+// CHECK:           } defaultAttr(present)
+// CHECK:           acc.parallel async num_gangs({%[[VAL_4]] : i32}) num_workers(%[[VAL_4]] : i32) vector_length(%[[VAL_4]] : i32) {
+// CHECK:           }
+// CHECK:           acc.parallel num_gangs({%[[VAL_4]] : i32}) num_workers(%[[VAL_4]] : i32) vector_length(%[[VAL_4]] : i32) wait {
 // CHECK:           }
 // CHECK:           acc.parallel num_gangs({%[[VAL_4]] : i32}) num_workers(%[[VAL_4]] : i32) vector_length(%[[VAL_4]] : i32) {
-// CHECK:           }
-// CHECK:           acc.parallel num_gangs({%[[VAL_4]] : i32}) num_workers(%[[VAL_4]] : i32) vector_length(%[[VAL_4]] : i32) {
-// CHECK:           } attributes {selfAttr}
+// CHECK:           } selfAttr
 // CHECK:           acc.parallel num_gangs({%[[VAL_4]] : i32}) num_workers(%[[VAL_4]] : i32) vector_length(%[[VAL_4]] : i32) {
 // CHECK:             acc.yield
-// CHECK:           } attributes {selfAttr}
+// CHECK:           } selfAttr
 // CHECK:           return
 // CHECK:         }
 
@@ -132,7 +132,7 @@ func.func @testserialop(%a: memref<10xf32>, %b: memref<10xf32>, %c: memref<10x10
   %c_private = acc.private varPtr(%c : memref<10x10xf32>) recipe(@privatization_memref_10_10_f32) -> memref<10x10xf32>
   acc.serial private(%c_private : memref<10x10xf32>) firstprivate(%firstprivate : memref<10xf32>) {
   }
-  %copyinfromcopy = acc.copyin varPtr(%a : memref<10xf32>) -> memref<10xf32> {dataClause = #acc<data_clause acc_copy>}
+  %copyinfromcopy = acc.copyin varPtr(%a : memref<10xf32>) dataClause(acc_copy) -> memref<10xf32>
   acc.serial dataOperands(%copyinfromcopy : memref<10xf32>) {
   }
   %i64mem = memref.alloca() : memref<i64>
@@ -143,22 +143,21 @@ func.func @testserialop(%a: memref<10xf32>, %b: memref<10xf32>, %c: memref<10x10
   acc.serial combined(loop) {
     acc.loop combined(serial) control(%arg3 : index) = (%idxValue : index) to (%idxValue : index) step (%idxValue : index) {
       acc.yield
-    } attributes {seq = [#acc.device_type<none>]}
+    } seq
     acc.terminator
   }
   acc.serial {
-  } attributes {defaultAttr = #acc<defaultvalue none>}
+  } defaultAttr(none)
   acc.serial {
-  } attributes {defaultAttr = #acc<defaultvalue present>}
+  } defaultAttr(present)
+  acc.serial async {
+  }
+  acc.serial wait {
+  }
   acc.serial {
-  } attributes {asyncAttr}
-  acc.serial {
-  } attributes {waitAttr}
-  acc.serial {
-  } attributes {selfAttr}
+  } selfAttr
   acc.serial {
     acc.yield
-  } attributes {selfAttr}
+  } selfAttr
   return
 }
-

--- a/mlir/test/Dialect/OpenACC/ops-cg-privatization.mlir
+++ b/mlir/test/Dialect/OpenACC/ops-cg-privatization.mlir
@@ -92,7 +92,7 @@ func.func @privatize_inside_compute_region(%data : memref<64xf32>) {
   %copy = acc.copyin varPtr(%data : memref<64xf32>) -> memref<64xf32>
   acc.kernel_environment dataOperands(%copy : memref<64xf32>) {
     %c64_kw = arith.constant 64 : index
-    %w = acc.par_width %c64_kw {par_dim = #acc.par_dim<thread_x>}
+    %w = acc.par_width %c64_kw par_dim(#acc.par_dim<thread_x>)
     acc.compute_region launch(%lw = %w) ins(%d = %copy) : (memref<64xf32>) {
       %priv = acc.privatize [#acc<par_dims[thread_x]>] : () -> !acc.private_type<memref<f32>>
       %c0 = arith.constant 0 : index

--- a/mlir/test/Dialect/OpenACC/ops-cg.mlir
+++ b/mlir/test/Dialect/OpenACC/ops-cg.mlir
@@ -98,9 +98,9 @@ func.func @compute_region_single_dim(%data: memref<1024xf32>,
                                      %result: memref<f32>) {
   %c128 = arith.constant 128 : index
   %copyin = acc.copyin varPtr(%data : memref<1024xf32>) -> memref<1024xf32>
-  %copy = acc.copyin varPtr(%result : memref<f32>) -> memref<f32> {dataClause = #acc<data_clause acc_copy>}
+  %copy = acc.copyin varPtr(%result : memref<f32>) dataClause(acc_copy) -> memref<f32>
   acc.kernel_environment dataOperands(%copyin, %copy : memref<1024xf32>, memref<f32>) {
-    %w0 = acc.par_width %c128 {par_dim = #acc.par_dim<thread_x>}
+    %w0 = acc.par_width %c128 par_dim(#acc.par_dim<thread_x>)
     acc.compute_region launch(%arg0 = %w0)
         ins(%arg1 = %copyin, %arg2 = %copy) : (memref<1024xf32>, memref<f32>) {
       %c0 = arith.constant 0 : index
@@ -118,11 +118,11 @@ func.func @compute_region_single_dim(%data: memref<1024xf32>,
       acc.yield
     } {origin = "acc.parallel"}
   }
-  acc.copyout accPtr(%copy : memref<f32>) to varPtr(%result : memref<f32>) {dataClause = #acc<data_clause acc_copy>}
+  acc.copyout accPtr(%copy : memref<f32>) to varPtr(%result : memref<f32>) dataClause(acc_copy)
   acc.delete accPtr(%copyin : memref<1024xf32>)
   return
 }
-// CHECK: %[[W:.*]] = acc.par_width %{{.*}} {par_dim = #acc.par_dim<thread_x>}
+// CHECK: %[[W:.*]] = acc.par_width %{{.*}} par_dim(#acc.par_dim<thread_x>)
 // CHECK: acc.compute_region launch(%{{.*}} = %[[W]]) ins({{.*}}) : (memref<1024xf32>, memref<f32>) {
 // CHECK:   acc.yield
 // CHECK: } {origin = "acc.parallel"}
@@ -135,10 +135,10 @@ func.func @compute_region_two_dims(%data: memref<8xi32>,
   %c8 = arith.constant 8 : index
   %c128 = arith.constant 128 : index
   %copyin_data = acc.copyin varPtr(%data : memref<8xi32>) -> memref<8xi32>
-  %copyin_red = acc.copyin varPtr(%reduction_var : memref<i32>) -> memref<i32> {dataClause = #acc<data_clause acc_reduction>}
+  %copyin_red = acc.copyin varPtr(%reduction_var : memref<i32>) dataClause(acc_reduction) -> memref<i32>
   acc.kernel_environment dataOperands(%copyin_data, %copyin_red : memref<8xi32>, memref<i32>) {
-    %w0 = acc.par_width %c8 {par_dim = #acc.par_dim<block_x>}
-    %w1 = acc.par_width %c128 {par_dim = #acc.par_dim<thread_x>}
+    %w0 = acc.par_width %c8 par_dim(#acc.par_dim<block_x>)
+    %w1 = acc.par_width %c128 par_dim(#acc.par_dim<thread_x>)
     acc.compute_region launch(%arg0 = %w0, %arg1 = %w1)
         ins(%arg2 = %copyin_data, %arg3 = %copyin_red) : (memref<8xi32>, memref<i32>) {
       %c0 = arith.constant 0 : index
@@ -161,12 +161,12 @@ func.func @compute_region_two_dims(%data: memref<8xi32>,
       acc.yield
     } {origin = "acc.parallel"}
   }
-  acc.copyout accPtr(%copyin_red : memref<i32>) to varPtr(%reduction_var : memref<i32>) {dataClause = #acc<data_clause acc_reduction>}
+  acc.copyout accPtr(%copyin_red : memref<i32>) to varPtr(%reduction_var : memref<i32>) dataClause(acc_reduction)
   acc.delete accPtr(%copyin_data : memref<8xi32>)
   return
 }
-// CHECK: %[[W0:.*]] = acc.par_width %{{.*}} {par_dim = #acc.par_dim<block_x>}
-// CHECK: %[[W1:.*]] = acc.par_width %{{.*}} {par_dim = #acc.par_dim<thread_x>}
+// CHECK: %[[W0:.*]] = acc.par_width %{{.*}} par_dim(#acc.par_dim<block_x>)
+// CHECK: %[[W1:.*]] = acc.par_width %{{.*}} par_dim(#acc.par_dim<thread_x>)
 // CHECK: acc.compute_region launch(%{{.*}} = %[[W0]], %{{.*}} = %[[W1]]) ins({{.*}}) : (memref<8xi32>, memref<i32>) {
 // CHECK:   acc.yield
 // CHECK: } {origin = "acc.parallel"}
@@ -191,7 +191,7 @@ func.func @reduction_init_with_bounds(%arg0: memref<?xi32>, %lb: index, %ext: in
 func.func @compute_region_unknown_width(%data: memref<100xf32>) {
   %copyin = acc.copyin varPtr(%data : memref<100xf32>) -> memref<100xf32>
   acc.kernel_environment dataOperands(%copyin : memref<100xf32>) {
-    %w0 = acc.par_width {par_dim = #acc.par_dim<thread_x>}
+    %w0 = acc.par_width par_dim(#acc.par_dim<thread_x>)
     acc.compute_region launch(%arg0 = %w0)
         ins(%arg1 = %copyin) : (memref<100xf32>) {
       %c0 = arith.constant 0 : index
@@ -206,7 +206,7 @@ func.func @compute_region_unknown_width(%data: memref<100xf32>) {
   acc.delete accPtr(%copyin : memref<100xf32>)
   return
 }
-// CHECK: %[[W:.*]] = acc.par_width {par_dim = #acc.par_dim<thread_x>}
+// CHECK: %[[W:.*]] = acc.par_width par_dim(#acc.par_dim<thread_x>)
 // CHECK: acc.compute_region launch(%{{.*}} = %[[W]]) ins({{.*}}) : (memref<100xf32>) {
 // CHECK:   acc.yield
 // CHECK: } {origin = "acc.kernels"}
@@ -215,8 +215,8 @@ func.func @compute_region_unknown_width(%data: memref<100xf32>) {
 
 // CHECK-LABEL: func @compute_region_no_launch
 func.func @compute_region_no_launch(%a: memref<i32>, %b: memref<i32>) {
-  %copy_a = acc.copyin varPtr(%a : memref<i32>) -> memref<i32> {dataClause = #acc<data_clause acc_copy>}
-  %copy_b = acc.copyin varPtr(%b : memref<i32>) -> memref<i32> {dataClause = #acc<data_clause acc_copy>}
+  %copy_a = acc.copyin varPtr(%a : memref<i32>) dataClause(acc_copy) -> memref<i32>
+  %copy_b = acc.copyin varPtr(%b : memref<i32>) dataClause(acc_copy) -> memref<i32>
   acc.kernel_environment dataOperands(%copy_a, %copy_b : memref<i32>, memref<i32>) {
     acc.compute_region
         ins(%arg0 = %copy_a, %arg1 = %copy_b) : (memref<i32>, memref<i32>) {
@@ -226,8 +226,8 @@ func.func @compute_region_no_launch(%a: memref<i32>, %b: memref<i32>) {
       acc.yield
     } {origin = "acc.serial"}
   }
-  acc.copyout accPtr(%copy_a : memref<i32>) to varPtr(%a : memref<i32>) {dataClause = #acc<data_clause acc_copy>}
-  acc.copyout accPtr(%copy_b : memref<i32>) to varPtr(%b : memref<i32>) {dataClause = #acc<data_clause acc_copy>}
+  acc.copyout accPtr(%copy_a : memref<i32>) to varPtr(%a : memref<i32>) dataClause(acc_copy)
+  acc.copyout accPtr(%copy_b : memref<i32>) to varPtr(%b : memref<i32>) dataClause(acc_copy)
   return
 }
 // CHECK: acc.compute_region ins({{.*}}) : (memref<i32>, memref<i32>) {
@@ -239,13 +239,13 @@ func.func @compute_region_no_launch(%a: memref<i32>, %b: memref<i32>) {
 // CHECK-LABEL: func @compute_region_launch_only
 func.func @compute_region_launch_only() {
   %c32 = arith.constant 32 : index
-  %w0 = acc.par_width %c32 {par_dim = #acc.par_dim<thread_x>}
+  %w0 = acc.par_width %c32 par_dim(#acc.par_dim<thread_x>)
   acc.compute_region launch(%arg0 = %w0) {
     acc.yield
   } {origin = "acc.parallel"}
   return
 }
-// CHECK: %[[W:.*]] = acc.par_width %{{.*}} {par_dim = #acc.par_dim<thread_x>}
+// CHECK: %[[W:.*]] = acc.par_width %{{.*}} par_dim(#acc.par_dim<thread_x>)
 // CHECK: acc.compute_region launch(%{{.*}} = %[[W]]) {
 // CHECK:   acc.yield
 // CHECK: } {origin = "acc.parallel"}
@@ -272,8 +272,8 @@ func.func @compute_region_all_fields(%data: memref<1024xf32>,
   %c8 = arith.constant 8 : index
   %copyin = acc.copyin varPtr(%data : memref<1024xf32>) -> memref<1024xf32>
   acc.kernel_environment dataOperands(%copyin : memref<1024xf32>) {
-    %w0 = acc.par_width %c8 {par_dim = #acc.par_dim<block_x>}
-    %w1 = acc.par_width %c128 {par_dim = #acc.par_dim<thread_x>}
+    %w0 = acc.par_width %c8 par_dim(#acc.par_dim<block_x>)
+    %w1 = acc.par_width %c128 par_dim(#acc.par_dim<thread_x>)
     acc.compute_region stream(%stream : !gpu.async.token)
         launch(%arg0 = %w0, %arg1 = %w1)
         ins(%arg2 = %copyin) : (memref<1024xf32>) {
@@ -289,8 +289,8 @@ func.func @compute_region_all_fields(%data: memref<1024xf32>,
   acc.delete accPtr(%copyin : memref<1024xf32>)
   return
 }
-// CHECK: %[[W0:.*]] = acc.par_width %{{.*}} {par_dim = #acc.par_dim<block_x>}
-// CHECK: %[[W1:.*]] = acc.par_width %{{.*}} {par_dim = #acc.par_dim<thread_x>}
+// CHECK: %[[W0:.*]] = acc.par_width %{{.*}} par_dim(#acc.par_dim<block_x>)
+// CHECK: %[[W1:.*]] = acc.par_width %{{.*}} par_dim(#acc.par_dim<thread_x>)
 // CHECK: acc.compute_region stream(%[[STREAM]] : !gpu.async.token) launch(%{{.*}} = %[[W0]], %{{.*}} = %[[W1]]) ins({{.*}}) : (memref<1024xf32>) {
 // CHECK:   acc.yield
 // CHECK: } {kernel_func_name = @compute_kernel, kernel_module_name = @device_module, origin = "acc.parallel"}
@@ -314,7 +314,7 @@ func.func @parallel_reduction_pattern(%data: memref<8xi32>, %shared: memref<i32>
     }
   } {acc.par_dims = #acc<par_dims[thread_x]>}
   acc.reduction_accumulate %partial to %private <add>
-      : i32 -> memref<i32> {par_dims = #acc<par_dims[thread_x]>}
+      : i32 -> memref<i32> <{par_dims = #acc<par_dims[thread_x]>}>
   acc.reduction_combine %private into %shared <add> : memref<i32>
       {acc.par_dims = #acc<par_dims[thread_x]>}
   return
@@ -322,7 +322,7 @@ func.func @parallel_reduction_pattern(%data: memref<8xi32>, %shared: memref<i32>
 // CHECK: memref.alloca() {acc.par_dims = #acc<par_dims[thread_x]>}
 // CHECK: scf.parallel
 // CHECK: scf.reduce
-// CHECK: acc.reduction_accumulate %{{.*}} to %{{.*}} <add> : i32 -> memref<i32> {par_dims = #acc<par_dims[thread_x]>}
+// CHECK: acc.reduction_accumulate %{{.*}} to %{{.*}} <add> : i32 -> memref<i32> <{par_dims = #acc<par_dims[thread_x]>}>
 // CHECK: acc.reduction_combine %{{.*}} into %{{.*}} <add> : memref<i32> {acc.par_dims = #acc<par_dims[thread_x]>}
 
 // -----
@@ -330,42 +330,42 @@ func.func @parallel_reduction_pattern(%data: memref<8xi32>, %shared: memref<i32>
 // CHECK-LABEL: func @reduction_accumulate_thread_x
 func.func @reduction_accumulate_thread_x(%partial: f32, %private: memref<f32>) {
   acc.reduction_accumulate %partial to %private <add>
-      : f32 -> memref<f32> {par_dims = #acc<par_dims[thread_x]>}
+      : f32 -> memref<f32> <{par_dims = #acc<par_dims[thread_x]>}>
   return
 }
-// CHECK: acc.reduction_accumulate %{{.*}} to %{{.*}} <add> : f32 -> memref<f32> {par_dims = #acc<par_dims[thread_x]>}
+// CHECK: acc.reduction_accumulate %{{.*}} to %{{.*}} <add> : f32 -> memref<f32> <{par_dims = #acc<par_dims[thread_x]>}>
 
 // -----
 
 // CHECK-LABEL: func @reduction_accumulate_block_thread
 func.func @reduction_accumulate_block_thread(%partial: i32, %private: memref<i32>) {
   acc.reduction_accumulate %partial to %private <add>
-      : i32 -> memref<i32> {par_dims = #acc<par_dims[block_x, thread_x]>}
+      : i32 -> memref<i32> <{par_dims = #acc<par_dims[block_x, thread_x]>}>
   return
 }
-// CHECK: acc.reduction_accumulate %{{.*}} to %{{.*}} <add> : i32 -> memref<i32> {par_dims = #acc<par_dims[block_x, thread_x]>}
+// CHECK: acc.reduction_accumulate %{{.*}} to %{{.*}} <add> : i32 -> memref<i32> <{par_dims = #acc<par_dims[block_x, thread_x]>}>
 
 // -----
 
 // CHECK-LABEL: func @reduction_accumulate_array
 func.func @reduction_accumulate_array(%private: memref<4xi32>, %bounds: !acc.data_bounds_ty) {
-  acc.reduction_accumulate_array %private bounds(%bounds) <add> : memref<4xi32> {par_dims = #acc<par_dims[block_x, thread_x]>}
+  acc.reduction_accumulate_array %private bounds(%bounds) <add> : memref<4xi32> <{par_dims = #acc<par_dims[block_x, thread_x]>}>
   return
 }
-// CHECK: acc.reduction_accumulate_array  %{{.*}} bounds(%{{.*}}) <add> : memref<4xi32> {par_dims = #acc<par_dims[block_x, thread_x]>}
+// CHECK: acc.reduction_accumulate_array  %{{.*}} bounds(%{{.*}}) <add> : memref<4xi32> <{par_dims = #acc<par_dims[block_x, thread_x]>}>
 
 // -----
 
 // CHECK-LABEL: func @compute_region_with_results
 func.func @compute_region_with_results() -> i32 {
-  %w0 = acc.par_width {par_dim = #acc.par_dim<thread_x>}
+  %w0 = acc.par_width par_dim(#acc.par_dim<thread_x>)
   %0 = acc.compute_region launch(%arg0 = %w0) -> i32 {
     %c0_i32 = arith.constant 0 : i32
     acc.yield %c0_i32 : i32
   } {origin = "acc.parallel"}
   return %0 : i32
 }
-// CHECK: %[[W:.*]] = acc.par_width {par_dim = #acc.par_dim<thread_x>}
+// CHECK: %[[W:.*]] = acc.par_width par_dim(#acc.par_dim<thread_x>)
 // CHECK: {{.*}} = acc.compute_region launch(%{{.*}} = %[[W]]) -> i32 {
 // CHECK:   acc.yield
 // CHECK: } {origin = "acc.parallel"}
@@ -376,11 +376,11 @@ func.func @compute_region_with_results() -> i32 {
 func.func @predicate_region_gang_vector_atomics(%c1: memref<i32>, %c2: memref<i32>) {
   %c3 = arith.constant 3 : index
   %c16 = arith.constant 16 : index
-  %copy_c1 = acc.copyin varPtr(%c1 : memref<i32>) -> memref<i32> {dataClause = #acc<data_clause acc_copy>}
-  %copy_c2 = acc.copyin varPtr(%c2 : memref<i32>) -> memref<i32> {dataClause = #acc<data_clause acc_copy>}
+  %copy_c1 = acc.copyin varPtr(%c1 : memref<i32>) dataClause(acc_copy) -> memref<i32>
+  %copy_c2 = acc.copyin varPtr(%c2 : memref<i32>) dataClause(acc_copy) -> memref<i32>
   acc.kernel_environment dataOperands(%copy_c1, %copy_c2 : memref<i32>, memref<i32>) {
-    %w_gang = acc.par_width %c3 {par_dim = #acc.par_dim<block_x>}
-    %w_vector = acc.par_width %c16 {par_dim = #acc.par_dim<thread_x>}
+    %w_gang = acc.par_width %c3 par_dim(#acc.par_dim<block_x>)
+    %w_vector = acc.par_width %c16 par_dim(#acc.par_dim<thread_x>)
     acc.compute_region launch(%arg0 = %w_gang, %arg1 = %w_vector)
         ins(%arg2 = %copy_c1, %arg3 = %copy_c2) : (memref<i32>, memref<i32>) {
       %c1_idx = arith.constant 1 : index
@@ -408,8 +408,8 @@ func.func @predicate_region_gang_vector_atomics(%c1: memref<i32>, %c2: memref<i3
       acc.yield
     } {origin = "acc.parallel"}
   }
-  acc.copyout accPtr(%copy_c1 : memref<i32>) to varPtr(%c1 : memref<i32>) {dataClause = #acc<data_clause acc_copy>}
-  acc.copyout accPtr(%copy_c2 : memref<i32>) to varPtr(%c2 : memref<i32>) {dataClause = #acc<data_clause acc_copy>}
+  acc.copyout accPtr(%copy_c1 : memref<i32>) to varPtr(%c1 : memref<i32>) dataClause(acc_copy)
+  acc.copyout accPtr(%copy_c2 : memref<i32>) to varPtr(%c2 : memref<i32>) dataClause(acc_copy)
   return
 }
 // CHECK: acc.predicate_region {
@@ -422,11 +422,11 @@ func.func @predicate_region_gang_vector_atomics(%c1: memref<i32>, %c2: memref<i3
 func.func @predicate_region_gang_redundant_setup(%idx: memref<i32>, %table: memref<10xi32>) {
   %c3 = arith.constant 3 : index
   %c16 = arith.constant 16 : index
-  %copy_idx = acc.copyin varPtr(%idx : memref<i32>) -> memref<i32> {dataClause = #acc<data_clause acc_copy>}
+  %copy_idx = acc.copyin varPtr(%idx : memref<i32>) dataClause(acc_copy) -> memref<i32>
   %copy_table = acc.copyin varPtr(%table : memref<10xi32>) -> memref<10xi32>
   acc.kernel_environment dataOperands(%copy_idx, %copy_table : memref<i32>, memref<10xi32>) {
-    %w_gang = acc.par_width %c3 {par_dim = #acc.par_dim<block_x>}
-    %w_vector = acc.par_width %c16 {par_dim = #acc.par_dim<thread_x>}
+    %w_gang = acc.par_width %c3 par_dim(#acc.par_dim<block_x>)
+    %w_vector = acc.par_width %c16 par_dim(#acc.par_dim<thread_x>)
     acc.compute_region launch(%arg0 = %w_gang, %arg1 = %w_vector)
         ins(%arg2 = %copy_idx, %arg3 = %copy_table) : (memref<i32>, memref<10xi32>) {
       %c0 = arith.constant 0 : index
@@ -448,7 +448,7 @@ func.func @predicate_region_gang_redundant_setup(%idx: memref<i32>, %table: memr
       acc.yield
     } {origin = "acc.kernels"}
   }
-  acc.copyout accPtr(%copy_idx : memref<i32>) to varPtr(%idx : memref<i32>) {dataClause = #acc<data_clause acc_copy>}
+  acc.copyout accPtr(%copy_idx : memref<i32>) to varPtr(%idx : memref<i32>) dataClause(acc_copy)
   acc.delete accPtr(%copy_table : memref<10xi32>)
   return
 }
@@ -462,11 +462,11 @@ func.func @predicate_region_gang_redundant_setup(%idx: memref<i32>, %table: memr
 func.func @gpu_shared_memory_static() {
   %c1024 = arith.constant 1024 : index
   %sm = acc.gpu_shared_memory(%c1024)
-      {num_copies = 1 : i64, static_upper_bound_bytes = 4096 : i64}
+      <{num_copies = 1 : i64, static_upper_bound_bytes = 4096 : i64}>
       : (index) -> memref<?xf32, #gpu.address_space<workgroup>>
   return
 }
-// CHECK: acc.gpu_shared_memory(%{{.*}}) {num_copies = 1 : i64, static_upper_bound_bytes = 4096 : i64}
+// CHECK: acc.gpu_shared_memory(%{{.*}}) <{num_copies = 1 : i64, static_upper_bound_bytes = 4096 : i64}>
 // CHECK-SAME: : (index) -> memref<?xf32, #gpu.address_space<workgroup>>
 
 // -----
@@ -475,22 +475,22 @@ func.func @gpu_shared_memory_static() {
 func.func @gpu_shared_memory_runtime_sized() {
   %c128 = arith.constant 128 : index
   %sm = acc.gpu_shared_memory(%c128)
-      {num_copies = 1 : i64,
+      <{num_copies = 1 : i64,
        static_upper_bound_bytes = 1560 : i64,
        dynamic_shared_memory_scaling_bytes = 12 : i64,
-       dynamic_shared_memory_fixed_bytes = 24 : i64}
+       dynamic_shared_memory_fixed_bytes = 24 : i64}>
       : (index) -> memref<?xf32, #gpu.address_space<workgroup>>
   return
 }
-// CHECK: acc.gpu_shared_memory(%{{.*}}) {dynamic_shared_memory_fixed_bytes = 24 : i64, dynamic_shared_memory_scaling_bytes = 12 : i64, num_copies = 1 : i64, static_upper_bound_bytes = 1560 : i64}
+// CHECK: acc.gpu_shared_memory(%{{.*}}) <{dynamic_shared_memory_fixed_bytes = 24 : i64, dynamic_shared_memory_scaling_bytes = 12 : i64, num_copies = 1 : i64, static_upper_bound_bytes = 1560 : i64}>
 
 // -----
 
 // CHECK-LABEL: func @gpu_shared_memory_worker_copies
 func.func @gpu_shared_memory_worker_copies() {
   %sm = acc.gpu_shared_memory()
-      {num_copies = 4 : i64, static_upper_bound_bytes = 256 : i64}
+      <{num_copies = 4 : i64, static_upper_bound_bytes = 256 : i64}>
       : () -> memref<8xf32, #gpu.address_space<workgroup>>
   return
 }
-// CHECK: acc.gpu_shared_memory {num_copies = 4 : i64, static_upper_bound_bytes = 256 : i64}
+// CHECK: acc.gpu_shared_memory <{num_copies = 4 : i64, static_upper_bound_bytes = 256 : i64}>

--- a/mlir/test/Dialect/OpenACC/ops.mlir
+++ b/mlir/test/Dialect/OpenACC/ops.mlir
@@ -19,7 +19,7 @@ func.func @compute1(%A: memref<10x10xf32>, %B: memref<10x10xf32>, %C: memref<10x
       %co = arith.addf %cij, %p : f32
       memref.store %co, %C[%arg3, %arg4] : memref<10x10xf32>
       acc.yield
-    } attributes { collapse = [3], collapseDeviceType = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true, true, true>, independent = [#acc.device_type<none>]}
+    } collapse([3]) collapseDeviceType([#acc.device_type<none>]) inclusiveUpperbound(array<i1: true, true, true>) independent
     acc.yield
   }
 
@@ -40,7 +40,7 @@ func.func @compute1(%A: memref<10x10xf32>, %B: memref<10x10xf32>, %C: memref<10x
 //  CHECK-NEXT:       %{{.*}} = arith.addf %{{.*}}, %{{.*}} : f32
 //  CHECK-NEXT:       memref.store %{{.*}}, %{{.*}}[%{{.*}}, %{{.*}}] : memref<10x10xf32>
 //  CHECK-NEXT:       acc.yield
-//  CHECK-NEXT:     } attributes {collapse = [3], collapseDeviceType = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true, true, true>, independent = [#acc.device_type<none>]}
+//  CHECK-NEXT:     } inclusiveUpperbound(array<i1: true, true, true>) collapse([3]) collapseDeviceType([#acc.device_type<none>]) independent
 //  CHECK-NEXT:     acc.yield
 //  CHECK-NEXT:   }
 //  CHECK-NEXT:   return %{{.*}} : memref<10x10xf32>
@@ -66,7 +66,7 @@ func.func @compute2(%A: memref<10x10xf32>, %B: memref<10x10xf32>, %C: memref<10x
         }
       }
       acc.yield
-    } attributes {seq = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+    } seq inclusiveUpperbound(array<i1: true>)
     acc.yield
   }
 
@@ -90,7 +90,7 @@ func.func @compute2(%A: memref<10x10xf32>, %B: memref<10x10xf32>, %C: memref<10x
 //  CHECK-NEXT:         }
 //  CHECK-NEXT:       }
 //  CHECK-NEXT:       acc.yield
-//  CHECK-NEXT:     } attributes {inclusiveUpperbound = array<i1: true>, seq = [#acc.device_type<none>]}
+//  CHECK-NEXT:     } inclusiveUpperbound(array<i1: true>) seq
 //  CHECK-NEXT:     acc.yield
 //  CHECK-NEXT:   }
 //  CHECK-NEXT:   return %{{.*}} : memref<10x10xf32>
@@ -129,7 +129,7 @@ func.func @compute3(%a: memref<10x10xf32>, %b: memref<10x10xf32>, %c: memref<10x
           %tmp = arith.addf %axy, %bxy : f32
           memref.store %tmp, %c[%y] : memref<10xf32>
           acc.yield
-        } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+        } inclusiveUpperbound(array<i1: true>) independent
 
         acc.loop control(%i : index) = (%lb : index) to (%c10 : index) step (%st : index) {
           // for i = 0 to 10 step 1
@@ -139,9 +139,9 @@ func.func @compute3(%a: memref<10x10xf32>, %b: memref<10x10xf32>, %c: memref<10x
           %z = arith.addf %ci, %dx : f32
           memref.store %z, %d[%x] : memref<10xf32>
           acc.yield
-        } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>], seq = [#acc.device_type<nvidia>]}
+        } inclusiveUpperbound(array<i1: true>) independent seq([#acc.device_type<nvidia>])
         acc.yield
-      } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+      } inclusiveUpperbound(array<i1: true>) independent
       acc.yield
     }
     acc.terminator
@@ -166,16 +166,16 @@ func.func @compute3(%a: memref<10x10xf32>, %b: memref<10x10xf32>, %c: memref<10x
 // CHECK-NEXT:           %{{.*}} = arith.addf %{{.*}}, %{{.*}} : f32
 // CHECK-NEXT:           memref.store %{{.*}}, %{{.*}}[%{{.*}}] : memref<10xf32>
 // CHECK-NEXT:           acc.yield
-// CHECK-NEXT:         } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+// CHECK-NEXT:         } inclusiveUpperbound(array<i1: true>) independent
 // CHECK-NEXT:         acc.loop control(%{{.*}}) = (%{{.*}}) to (%{{.*}}) step (%{{.*}}) {
 // CHECK-NEXT:           %{{.*}} = memref.load %{{.*}}[%{{.*}}] : memref<10xf32>
 // CHECK-NEXT:           %{{.*}} = memref.load %{{.*}}[%{{.*}}] : memref<10xf32>
 // CHECK-NEXT:           %{{.*}} = arith.addf %{{.*}}, %{{.*}} : f32
 // CHECK-NEXT:           memref.store %{{.*}}, %{{.*}}[%{{.*}}] : memref<10xf32>
 // CHECK-NEXT:           acc.yield
-// CHECK-NEXT:         } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>], seq = [#acc.device_type<nvidia>]}
+// CHECK-NEXT:         } inclusiveUpperbound(array<i1: true>) seq ([#acc.device_type<nvidia>]) independent
 // CHECK-NEXT:         acc.yield
-// CHECK-NEXT:       } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+// CHECK-NEXT:       } inclusiveUpperbound(array<i1: true>) independent
 // CHECK-NEXT:       acc.yield
 // CHECK-NEXT:     }
 // CHECK-NEXT:     acc.terminator
@@ -196,72 +196,72 @@ func.func @testloopop(%a : memref<10xf32>) -> () {
   acc.loop gang vector worker control(%iv : index) = (%c0 : index) to (%c10 : index) step (%c1 : index) {
     "test.openacc_dummy_op"() : () -> ()
     acc.yield
-  } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+  } inclusiveUpperbound(array<i1: true>) independent
   acc.loop gang({num=%i64Value: i64}) control(%iv : index) = (%c0 : index) to (%c10 : index) step (%c1 : index) {
     "test.openacc_dummy_op"() : () -> ()
     acc.yield
-  } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+  } inclusiveUpperbound(array<i1: true>) independent
   acc.loop gang({static=%i64Value: i64}) control(%iv : index) = (%c0 : index) to (%c10 : index) step (%c1 : index) {
     "test.openacc_dummy_op"() : () -> ()
     acc.yield
-  } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+  } inclusiveUpperbound(array<i1: true>) independent
   acc.loop worker(%i64Value: i64) control(%iv : index) = (%c0 : index) to (%c10 : index) step (%c1 : index) {
     "test.openacc_dummy_op"() : () -> ()
     acc.yield
-  } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+  } inclusiveUpperbound(array<i1: true>) independent
   acc.loop worker(%i32Value: i32) control(%iv : index) = (%c0 : index) to (%c10 : index) step (%c1 : index) {
     "test.openacc_dummy_op"() : () -> ()
     acc.yield
-  } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+  } inclusiveUpperbound(array<i1: true>) independent
   acc.loop worker(%idxValue: index) control(%iv : index) = (%c0 : index) to (%c10 : index) step (%c1 : index) {
     "test.openacc_dummy_op"() : () -> ()
     acc.yield
-  } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+  } inclusiveUpperbound(array<i1: true>) independent
   acc.loop vector(%i64Value: i64) control(%iv : index) = (%c0 : index) to (%c10 : index) step (%c1 : index) {
     "test.openacc_dummy_op"() : () -> ()
     acc.yield
-  } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+  } inclusiveUpperbound(array<i1: true>) independent
   acc.loop vector(%i32Value: i32) control(%iv : index) = (%c0 : index) to (%c10 : index) step (%c1 : index) {
     "test.openacc_dummy_op"() : () -> ()
     acc.yield
-  } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+  } inclusiveUpperbound(array<i1: true>) independent
   acc.loop vector(%idxValue: index) control(%iv : index) = (%c0 : index) to (%c10 : index) step (%c1 : index) {
     "test.openacc_dummy_op"() : () -> ()
     acc.yield
-  } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+  } inclusiveUpperbound(array<i1: true>) independent
   acc.loop gang({num=%i64Value: i64}) worker vector control(%iv : index) = (%c0 : index) to (%c10 : index) step (%c1 : index) {
     "test.openacc_dummy_op"() : () -> ()
     acc.yield
-  } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+  } inclusiveUpperbound(array<i1: true>) independent
   acc.loop gang({num=%i64Value: i64, static=%i64Value: i64}) worker(%i64Value: i64) vector(%i64Value: i64) control(%iv : index) = (%c0 : index) to (%c10 : index) step (%c1 : index) {
     "test.openacc_dummy_op"() : () -> ()
     acc.yield
-  } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+  } inclusiveUpperbound(array<i1: true>) independent
   acc.loop gang({num=%i32Value: i32, static=%idxValue: index}) control(%iv : index) = (%c0 : index) to (%c10 : index) step (%c1 : index) {
     "test.openacc_dummy_op"() : () -> ()
     acc.yield
-  } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+  } inclusiveUpperbound(array<i1: true>) independent
   acc.loop tile({%i64Value : i64, %i64Value : i64}) control(%iv : index) = (%c0 : index) to (%c10 : index) step (%c1 : index) {
     "test.openacc_dummy_op"() : () -> ()
     acc.yield
-  } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+  } inclusiveUpperbound(array<i1: true>) independent
   acc.loop tile({%i32Value : i32, %i32Value : i32}) control(%iv : index) = (%c0 : index) to (%c10 : index) step (%c1 : index) {
     "test.openacc_dummy_op"() : () -> ()
     acc.yield
-  } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+  } inclusiveUpperbound(array<i1: true>) independent
   acc.loop gang({static=%i64Value: i64, num=%i64Value: i64}) control(%iv : index) = (%c0 : index) to (%c10 : index) step (%c1 : index) {
     "test.openacc_dummy_op"() : () -> ()
     acc.yield
-  } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+  } inclusiveUpperbound(array<i1: true>) independent
   acc.loop gang({dim=%i64Value : i64, static=%i64Value: i64}) control(%iv : index) = (%c0 : index) to (%c10 : index) step (%c1 : index) {
     "test.openacc_dummy_op"() : () -> ()
     acc.yield
-  } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+  } inclusiveUpperbound(array<i1: true>) independent
   %b = acc.cache varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) -> memref<10xf32>
   acc.loop cache(%b : memref<10xf32>) control(%iv : index) = (%c0 : index) to (%c10 : index) step (%c1 : index) {
     "test.openacc_dummy_op"() : () -> ()
     acc.yield
-  } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+  } inclusiveUpperbound(array<i1: true>) independent
   return
 }
 
@@ -271,7 +271,7 @@ func.func @testloopop(%a : memref<10xf32>) -> () {
 // CHECK:      acc.loop
 // CHECK-NEXT:   "test.openacc_dummy_op"() : () -> ()
 // CHECK-NEXT:   acc.yield
-// CHECK-NEXT: attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+// CHECK-NEXT: inclusiveUpperbound(array<i1: true>) independent
 // CHECK:      acc.loop gang({num=[[I64VALUE]] : i64})
 // CHECK-NEXT:   "test.openacc_dummy_op"() : () -> ()
 // CHECK-NEXT:   acc.yield
@@ -343,7 +343,7 @@ func.func @acc_loop_multiple_block() {
       cf.br ^bb1(%22 : index)
     ^bb3:
       acc.yield
-    } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+    } inclusiveUpperbound(array<i1: true>) independent
     acc.yield
   }
   return
@@ -379,7 +379,7 @@ func.func @testloopfirstprivate(%a: memref<10xf32>, %b: memref<10xf32>) -> () {
   acc.loop firstprivate(%firstprivate : memref<10xf32>) control(%iv : index) = (%c0 : index) to (%c10 : index) step (%c1 : index) {
     "test.openacc_dummy_op"() : () -> ()
     acc.yield
-  } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+  } inclusiveUpperbound(array<i1: true>) independent
   return
 }
 
@@ -389,7 +389,7 @@ func.func @testloopfirstprivate(%a: memref<10xf32>, %b: memref<10xf32>) -> () {
 // CHECK:         acc.loop firstprivate(%[[FIRSTPRIVATE]] : memref<10xf32>) control(%{{.*}}) = (%{{.*}}) to (%{{.*}}) step (%{{.*}}) {
 // CHECK:           "test.openacc_dummy_op"() : () -> ()
 // CHECK:           acc.yield
-// CHECK:         } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+// CHECK:         } inclusiveUpperbound(array<i1: true>) independent
 
 // -----
 
@@ -470,15 +470,15 @@ func.func @testparallelop(%a: memref<10xf32>, %b: memref<10xf32>, %c: memref<10x
   acc.parallel private(%private_a, %private_c : memref<10xf32>, memref<10x10xf32>) firstprivate(%firstprivate_b : memref<10xf32>) {
   }
   acc.parallel {
-  } attributes {defaultAttr = #acc<defaultvalue none>}
+  } defaultAttr(none)
   acc.parallel {
-  } attributes {defaultAttr = #acc<defaultvalue present>}
+  } defaultAttr(present)
   acc.parallel async {
   }
   acc.parallel wait {
   }
   acc.parallel {
-  } attributes {selfAttr}
+  } selfAttr
   return
 }
 
@@ -526,15 +526,15 @@ func.func @testparallelop(%a: memref<10xf32>, %b: memref<10xf32>, %c: memref<10x
 // CHECK-NEXT: acc.parallel firstprivate(%[[FIRSTPRIVATE_B]] : memref<10xf32>) private(%[[PRIVATE_A]], %[[PRIVATE_C]] : memref<10xf32>, memref<10x10xf32>) {
 // CHECK-NEXT: }
 // CHECK:      acc.parallel {
-// CHECK-NEXT: } attributes {defaultAttr = #acc<defaultvalue none>}
+// CHECK-NEXT: } defaultAttr(none)
 // CHECK:      acc.parallel {
-// CHECK-NEXT: } attributes {defaultAttr = #acc<defaultvalue present>}
+// CHECK-NEXT: } defaultAttr(present)
 // CHECK:      acc.parallel async {
 // CHECK-NEXT: }
 // CHECK:      acc.parallel wait {
 // CHECK-NEXT: }
 // CHECK:      acc.parallel {
-// CHECK-NEXT: } attributes {selfAttr}
+// CHECK-NEXT: } selfAttr
 
 // -----
 
@@ -608,18 +608,18 @@ func.func @testserialop(%a: memref<10xf32>, %b: memref<10xf32>, %c: memref<10x10
   acc.serial private(%private_a, %private_c : memref<10xf32>, memref<10x10xf32>) firstprivate(%firstprivate : memref<10xf32>) {
   }
   acc.serial {
-  } attributes {defaultAttr = #acc<defaultvalue none>}
+  } defaultAttr(none)
   acc.serial {
-  } attributes {defaultAttr = #acc<defaultvalue present>}
+  } defaultAttr(present)
   acc.serial async {
   }
   acc.serial wait {
   }
   acc.serial {
-  } attributes {selfAttr}
+  } selfAttr
   acc.serial {
     acc.yield
-  } attributes {selfAttr}
+  } selfAttr
   return
 }
 
@@ -647,18 +647,18 @@ func.func @testserialop(%a: memref<10xf32>, %b: memref<10xf32>, %c: memref<10x10
 // CHECK-NEXT: acc.serial firstprivate(%[[FIRSTP]] : memref<10xf32>) private(%[[PRIVATE_A]], %[[PRIVATE_C]] : memref<10xf32>, memref<10x10xf32>) {
 // CHECK-NEXT: }
 // CHECK:      acc.serial {
-// CHECK-NEXT: } attributes {defaultAttr = #acc<defaultvalue none>}
+// CHECK-NEXT: } defaultAttr(none)
 // CHECK:      acc.serial {
-// CHECK-NEXT: } attributes {defaultAttr = #acc<defaultvalue present>}
+// CHECK-NEXT: } defaultAttr(present)
 // CHECK:      acc.serial async {
 // CHECK-NEXT: }
 // CHECK:      acc.serial wait {
 // CHECK-NEXT: }
 // CHECK:      acc.serial {
-// CHECK-NEXT: } attributes {selfAttr}
+// CHECK-NEXT: } selfAttr
 // CHECK:      acc.serial {
 // CHECK:        acc.yield
-// CHECK-NEXT: } attributes {selfAttr}
+// CHECK-NEXT: } selfAttr
 
 // -----
 
@@ -682,18 +682,18 @@ func.func @testserialop(%a: memref<10xf32>, %b: memref<10xf32>, %c: memref<10x10
   acc.kernels wait({%i64value : i64, %i32value : i32, %idxValue : index}) {
   }
   acc.kernels {
-  } attributes {defaultAttr = #acc<defaultvalue none>}
+  } defaultAttr(none)
   acc.kernels {
-  } attributes {defaultAttr = #acc<defaultvalue present>}
+  } defaultAttr(present)
   acc.kernels async {
   }
   acc.kernels wait {
   }
   acc.kernels {
-  } attributes {selfAttr}
+  } selfAttr
   acc.kernels {
     acc.terminator
-  } attributes {selfAttr}
+  } selfAttr
   return
 }
 
@@ -716,18 +716,18 @@ func.func @testserialop(%a: memref<10xf32>, %b: memref<10xf32>, %c: memref<10x10
 // CHECK:      acc.kernels wait({[[I64VALUE]] : i64, [[I32VALUE]] : i32, [[IDXVALUE]] : index}) {
 // CHECK-NEXT: }
 // CHECK:      acc.kernels {
-// CHECK-NEXT: } attributes {defaultAttr = #acc<defaultvalue none>}
+// CHECK-NEXT: } defaultAttr(none)
 // CHECK:      acc.kernels {
-// CHECK-NEXT: } attributes {defaultAttr = #acc<defaultvalue present>}
+// CHECK-NEXT: } defaultAttr(present)
 // CHECK:      acc.kernels async {
 // CHECK-NEXT: }
 // CHECK:      acc.kernels wait {
 // CHECK-NEXT: }
 // CHECK:      acc.kernels {
-// CHECK-NEXT: } attributes {selfAttr}
+// CHECK-NEXT: } selfAttr
 // CHECK:      acc.kernels {
 // CHECK:        acc.terminator
-// CHECK-NEXT: } attributes {selfAttr}
+// CHECK-NEXT: } selfAttr
 
 // -----
 
@@ -807,47 +807,47 @@ func.func @testdataop(%a: memref<f32>, %b: memref<f32>, %c: memref<f32>) -> () {
   acc.data dataOperands(%5, %6, %7 : memref<f32>, memref<f32>, memref<f32>) {
   }
 
-  %8 = acc.copyin varPtr(%a : memref<f32>) -> memref<f32> {dataClause = #acc<data_clause acc_copyin_readonly>}
-  %9 = acc.copyin varPtr(%b : memref<f32>) -> memref<f32> {dataClause = #acc<data_clause acc_copyin_readonly>}
-  %10 = acc.copyin varPtr(%c : memref<f32>) -> memref<f32> {dataClause = #acc<data_clause acc_copyin_readonly>}
+  %8 = acc.copyin varPtr(%a : memref<f32>) dataClause(acc_copyin_readonly) -> memref<f32>
+  %9 = acc.copyin varPtr(%b : memref<f32>) dataClause(acc_copyin_readonly) -> memref<f32>
+  %10 = acc.copyin varPtr(%c : memref<f32>) dataClause(acc_copyin_readonly) -> memref<f32>
   acc.data dataOperands(%8, %9, %10 : memref<f32>, memref<f32>, memref<f32>) {
   }
 
-  %11 = acc.create varPtr(%a : memref<f32>) -> memref<f32> {dataClause = #acc<data_clause acc_copyout>}
-  %12 = acc.create varPtr(%b : memref<f32>) -> memref<f32> {dataClause = #acc<data_clause acc_copyout>}
-  %13 = acc.create varPtr(%c : memref<f32>) -> memref<f32> {dataClause = #acc<data_clause acc_copyout>}
+  %11 = acc.create varPtr(%a : memref<f32>) dataClause(acc_copyout) -> memref<f32>
+  %12 = acc.create varPtr(%b : memref<f32>) dataClause(acc_copyout) -> memref<f32>
+  %13 = acc.create varPtr(%c : memref<f32>) dataClause(acc_copyout) -> memref<f32>
   acc.data dataOperands(%11, %12, %13 : memref<f32>, memref<f32>, memref<f32>) {
   }
   acc.copyout accPtr(%11 : memref<f32>) to varPtr(%a : memref<f32>)
   acc.copyout accPtr(%12 : memref<f32>) to varPtr(%b : memref<f32>)
   acc.copyout accPtr(%13 : memref<f32>) to varPtr(%c : memref<f32>)
 
-  %14 = acc.create varPtr(%a : memref<f32>) -> memref<f32> {dataClause = #acc<data_clause acc_copyout_zero>}
-  %15 = acc.create varPtr(%b : memref<f32>) -> memref<f32> {dataClause = #acc<data_clause acc_copyout_zero>}
-  %16 = acc.create varPtr(%c : memref<f32>) -> memref<f32> {dataClause = #acc<data_clause acc_copyout_zero>}
+  %14 = acc.create varPtr(%a : memref<f32>) dataClause(acc_copyout_zero) -> memref<f32>
+  %15 = acc.create varPtr(%b : memref<f32>) dataClause(acc_copyout_zero) -> memref<f32>
+  %16 = acc.create varPtr(%c : memref<f32>) dataClause(acc_copyout_zero) -> memref<f32>
   acc.data dataOperands(%14, %15, %16 : memref<f32>, memref<f32>, memref<f32>) {
   }
-  acc.copyout accPtr(%14 : memref<f32>) to varPtr(%a : memref<f32>) {dataClause = #acc<data_clause acc_copyout_zero>}
-  acc.copyout accPtr(%15 : memref<f32>) to varPtr(%b : memref<f32>) {dataClause = #acc<data_clause acc_copyout_zero>}
-  acc.copyout accPtr(%16 : memref<f32>) to varPtr(%c : memref<f32>) {dataClause = #acc<data_clause acc_copyout_zero>}
+  acc.copyout accPtr(%14 : memref<f32>) to varPtr(%a : memref<f32>) dataClause(acc_copyout_zero)
+  acc.copyout accPtr(%15 : memref<f32>) to varPtr(%b : memref<f32>) dataClause(acc_copyout_zero)
+  acc.copyout accPtr(%16 : memref<f32>) to varPtr(%c : memref<f32>) dataClause(acc_copyout_zero)
 
   %17 = acc.create varPtr(%a : memref<f32>) -> memref<f32>
   %18 = acc.create varPtr(%b : memref<f32>) -> memref<f32>
   %19 = acc.create varPtr(%c : memref<f32>) -> memref<f32>
   acc.data dataOperands(%17, %18, %19 : memref<f32>, memref<f32>, memref<f32>) {
   }
-  acc.delete accPtr(%17 : memref<f32>) {dataClause = #acc<data_clause acc_create>}
-  acc.delete accPtr(%18 : memref<f32>) {dataClause = #acc<data_clause acc_create>}
-  acc.delete accPtr(%19 : memref<f32>) {dataClause = #acc<data_clause acc_create>}
+  acc.delete accPtr(%17 : memref<f32>) dataClause(acc_create)
+  acc.delete accPtr(%18 : memref<f32>) dataClause(acc_create)
+  acc.delete accPtr(%19 : memref<f32>) dataClause(acc_create)
   
-  %20 = acc.create varPtr(%a : memref<f32>) -> memref<f32> {dataClause = #acc<data_clause acc_create_zero>}
-  %21 = acc.create varPtr(%b : memref<f32>) -> memref<f32> {dataClause = #acc<data_clause acc_create_zero>}
-  %22 = acc.create varPtr(%c : memref<f32>) -> memref<f32> {dataClause = #acc<data_clause acc_create_zero>}
+  %20 = acc.create varPtr(%a : memref<f32>) dataClause(acc_create_zero) -> memref<f32>
+  %21 = acc.create varPtr(%b : memref<f32>) dataClause(acc_create_zero) -> memref<f32>
+  %22 = acc.create varPtr(%c : memref<f32>) dataClause(acc_create_zero) -> memref<f32>
   acc.data dataOperands(%20, %21, %22 : memref<f32>, memref<f32>, memref<f32>) {
   }
-  acc.delete accPtr(%20 : memref<f32>) {dataClause = #acc<data_clause acc_create_zero>}
-  acc.delete accPtr(%21 : memref<f32>) {dataClause = #acc<data_clause acc_create_zero>}
-  acc.delete accPtr(%22 : memref<f32>) {dataClause = #acc<data_clause acc_create_zero>}
+  acc.delete accPtr(%20 : memref<f32>) dataClause(acc_create_zero)
+  acc.delete accPtr(%21 : memref<f32>) dataClause(acc_create_zero)
+  acc.delete accPtr(%22 : memref<f32>) dataClause(acc_create_zero)
 
   %23 = acc.nocreate varPtr(%a : memref<f32>) -> memref<f32>
   %24 = acc.nocreate varPtr(%b : memref<f32>) -> memref<f32>
@@ -868,7 +868,7 @@ func.func @testdataop(%a: memref<f32>, %b: memref<f32>, %c: memref<f32>) -> () {
   }
 
   %32 = acc.copyin varPtr(%a : memref<f32>) -> memref<f32>
-  %33 = acc.create varPtr(%b : memref<f32>) -> memref<f32> {dataClause = #acc<data_clause acc_copyout>}
+  %33 = acc.create varPtr(%b : memref<f32>) dataClause(acc_copyout) -> memref<f32>
   %34 = acc.present varPtr(%c : memref<f32>) -> memref<f32>
   acc.data dataOperands(%32, %33, %34 : memref<f32>, memref<f32>, memref<f32>) {
   }
@@ -876,33 +876,33 @@ func.func @testdataop(%a: memref<f32>, %b: memref<f32>, %c: memref<f32>) -> () {
 
   %35 = acc.present varPtr(%a : memref<f32>) -> memref<f32>
   acc.data dataOperands(%35 : memref<f32>) {
-  } attributes { defaultAttr = #acc<defaultvalue none> }
+  } defaultAttr(none)
   
 
   %36 = acc.present varPtr(%a : memref<f32>) -> memref<f32>
   acc.data dataOperands(%36 : memref<f32>) {
-  } attributes { defaultAttr = #acc<defaultvalue present> }
+  } defaultAttr(present)
 
   acc.data {
-  } attributes { defaultAttr = #acc<defaultvalue none> }
+  } defaultAttr(none)
 
   acc.data async {
-  } attributes { defaultAttr = #acc<defaultvalue none> }
+  } defaultAttr(none)
 
   %a1 = arith.constant 1 : i64
   acc.data async(%a1 : i64) {
-  } attributes { defaultAttr = #acc<defaultvalue none> }
+  } defaultAttr(none)
 
   acc.data wait {
-  } attributes { defaultAttr = #acc<defaultvalue none> }
+  } defaultAttr(none)
 
   %w1 = arith.constant 1 : i64
   acc.data wait({%w1 : i64}) {
-  } attributes { defaultAttr = #acc<defaultvalue none> }
+  } defaultAttr(none)
 
   %wd1 = arith.constant 1 : i64
   acc.data wait({devnum: %wd1 : i64, %w1 : i64}) {
-  } attributes { defaultAttr = #acc<defaultvalue none> }
+  } defaultAttr(none)
 
   return
 }
@@ -930,29 +930,29 @@ func.func @testdataop(%a: memref<f32>, %b: memref<f32>, %c: memref<f32>) -> () {
 // CHECK:      acc.data dataOperands(%[[COPYIN_A]], %[[COPYIN_B]], %[[COPYIN_C]] : memref<f32>, memref<f32>, memref<f32>) {
 // CHECK-NEXT: }
 
-// CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[ARGA]] : memref<f32>) -> memref<f32> {dataClause = #acc<data_clause acc_copyin_readonly>}
-// CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[ARGB]] : memref<f32>) -> memref<f32> {dataClause = #acc<data_clause acc_copyin_readonly>}
-// CHECK:      %[[COPYIN_C:.*]] = acc.copyin varPtr(%[[ARGC]] : memref<f32>) -> memref<f32> {dataClause = #acc<data_clause acc_copyin_readonly>}
+// CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[ARGA]] : memref<f32>) dataClause(acc_copyin_readonly) -> memref<f32>
+// CHECK:      %[[COPYIN_B:.*]] = acc.copyin varPtr(%[[ARGB]] : memref<f32>) dataClause(acc_copyin_readonly) -> memref<f32>
+// CHECK:      %[[COPYIN_C:.*]] = acc.copyin varPtr(%[[ARGC]] : memref<f32>) dataClause(acc_copyin_readonly) -> memref<f32>
 // CHECK:      acc.data dataOperands(%[[COPYIN_A]], %[[COPYIN_B]], %[[COPYIN_C]] : memref<f32>, memref<f32>, memref<f32>) {
 // CHECK-NEXT: }
 
-// CHECK:      %[[CREATE_A:.*]] = acc.create varPtr(%[[ARGA]] : memref<f32>) -> memref<f32> {dataClause = #acc<data_clause acc_copyout>}
-// CHECK:      %[[CREATE_B:.*]] = acc.create varPtr(%[[ARGB]] : memref<f32>) -> memref<f32> {dataClause = #acc<data_clause acc_copyout>}
-// CHECK:      %[[CREATE_C:.*]] = acc.create varPtr(%[[ARGC]] : memref<f32>) -> memref<f32> {dataClause = #acc<data_clause acc_copyout>}
+// CHECK:      %[[CREATE_A:.*]] = acc.create varPtr(%[[ARGA]] : memref<f32>) dataClause(acc_copyout) -> memref<f32>
+// CHECK:      %[[CREATE_B:.*]] = acc.create varPtr(%[[ARGB]] : memref<f32>) dataClause(acc_copyout) -> memref<f32>
+// CHECK:      %[[CREATE_C:.*]] = acc.create varPtr(%[[ARGC]] : memref<f32>) dataClause(acc_copyout) -> memref<f32>
 // CHECK:      acc.data dataOperands(%[[CREATE_A]], %[[CREATE_B]], %[[CREATE_C]] : memref<f32>, memref<f32>, memref<f32>) {
 // CHECK-NEXT: }
 // CHECK:      acc.copyout accPtr(%[[CREATE_A]] : memref<f32>) to varPtr(%[[ARGA]] : memref<f32>)
 // CHECK:      acc.copyout accPtr(%[[CREATE_B]] : memref<f32>) to varPtr(%[[ARGB]] : memref<f32>)
 // CHECK:      acc.copyout accPtr(%[[CREATE_C]] : memref<f32>) to varPtr(%[[ARGC]] : memref<f32>)
 
-// CHECK:      %[[CREATE_A:.*]] = acc.create varPtr(%[[ARGA]] : memref<f32>) -> memref<f32> {dataClause = #acc<data_clause acc_copyout_zero>}
-// CHECK:      %[[CREATE_B:.*]] = acc.create varPtr(%[[ARGB]] : memref<f32>) -> memref<f32> {dataClause = #acc<data_clause acc_copyout_zero>}
-// CHECK:      %[[CREATE_C:.*]] = acc.create varPtr(%[[ARGC]] : memref<f32>) -> memref<f32> {dataClause = #acc<data_clause acc_copyout_zero>}
+// CHECK:      %[[CREATE_A:.*]] = acc.create varPtr(%[[ARGA]] : memref<f32>) dataClause(acc_copyout_zero) -> memref<f32>
+// CHECK:      %[[CREATE_B:.*]] = acc.create varPtr(%[[ARGB]] : memref<f32>) dataClause(acc_copyout_zero) -> memref<f32>
+// CHECK:      %[[CREATE_C:.*]] = acc.create varPtr(%[[ARGC]] : memref<f32>) dataClause(acc_copyout_zero) -> memref<f32>
 // CHECK:      acc.data dataOperands(%[[CREATE_A]], %[[CREATE_B]], %[[CREATE_C]] : memref<f32>, memref<f32>, memref<f32>) {
 // CHECK-NEXT: }
-// CHECK:      acc.copyout accPtr(%[[CREATE_A]] : memref<f32>) to varPtr(%[[ARGA]] : memref<f32>) {dataClause = #acc<data_clause acc_copyout_zero>}
-// CHECK:      acc.copyout accPtr(%[[CREATE_B]] : memref<f32>) to varPtr(%[[ARGB]] : memref<f32>) {dataClause = #acc<data_clause acc_copyout_zero>}
-// CHECK:      acc.copyout accPtr(%[[CREATE_C]] : memref<f32>) to varPtr(%[[ARGC]] : memref<f32>) {dataClause = #acc<data_clause acc_copyout_zero>}
+// CHECK:      acc.copyout accPtr(%[[CREATE_A]] : memref<f32>) to varPtr(%[[ARGA]] : memref<f32>) dataClause(acc_copyout_zero)
+// CHECK:      acc.copyout accPtr(%[[CREATE_B]] : memref<f32>) to varPtr(%[[ARGB]] : memref<f32>) dataClause(acc_copyout_zero)
+// CHECK:      acc.copyout accPtr(%[[CREATE_C]] : memref<f32>) to varPtr(%[[ARGC]] : memref<f32>) dataClause(acc_copyout_zero)
 
 // CHECK:      %[[CREATE_A:.*]] = acc.create varPtr(%[[ARGA]] : memref<f32>) -> memref<f32>
 // CHECK:      %[[CREATE_B:.*]] = acc.create varPtr(%[[ARGB]] : memref<f32>) -> memref<f32>
@@ -960,9 +960,9 @@ func.func @testdataop(%a: memref<f32>, %b: memref<f32>, %c: memref<f32>) -> () {
 // CHECK:      acc.data dataOperands(%[[CREATE_A]], %[[CREATE_B]], %[[CREATE_C]] : memref<f32>, memref<f32>, memref<f32>) {
 // CHECK-NEXT: }
 
-// CHECK:      %[[CREATE_A:.*]] = acc.create varPtr(%[[ARGA]] : memref<f32>) -> memref<f32> {dataClause = #acc<data_clause acc_create_zero>}
-// CHECK:      %[[CREATE_B:.*]] = acc.create varPtr(%[[ARGB]] : memref<f32>) -> memref<f32> {dataClause = #acc<data_clause acc_create_zero>}
-// CHECK:      %[[CREATE_C:.*]] = acc.create varPtr(%[[ARGC]] : memref<f32>) -> memref<f32> {dataClause = #acc<data_clause acc_create_zero>}
+// CHECK:      %[[CREATE_A:.*]] = acc.create varPtr(%[[ARGA]] : memref<f32>) dataClause(acc_create_zero) -> memref<f32>
+// CHECK:      %[[CREATE_B:.*]] = acc.create varPtr(%[[ARGB]] : memref<f32>) dataClause(acc_create_zero) -> memref<f32>
+// CHECK:      %[[CREATE_C:.*]] = acc.create varPtr(%[[ARGC]] : memref<f32>) dataClause(acc_create_zero) -> memref<f32>
 // CHECK:      acc.data dataOperands(%[[CREATE_A]], %[[CREATE_B]], %[[CREATE_C]] : memref<f32>, memref<f32>, memref<f32>) {
 // CHECK-NEXT: }
 
@@ -986,7 +986,7 @@ func.func @testdataop(%a: memref<f32>, %b: memref<f32>, %c: memref<f32>) -> () {
 
 
 // CHECK:      %[[COPYIN_A:.*]] = acc.copyin varPtr(%[[ARGA]] : memref<f32>) -> memref<f32>
-// CHECK:      %[[CREATE_B:.*]] = acc.create varPtr(%[[ARGB]] : memref<f32>) -> memref<f32> {dataClause = #acc<data_clause acc_copyout>}
+// CHECK:      %[[CREATE_B:.*]] = acc.create varPtr(%[[ARGB]] : memref<f32>) dataClause(acc_copyout) -> memref<f32>
 // CHECK:      %[[PRESENT_C:.*]] = acc.present varPtr(%[[ARGC]] : memref<f32>) -> memref<f32>
 // CHECK:      acc.data dataOperands(%[[COPYIN_A]], %[[CREATE_B]], %[[PRESENT_C]] : memref<f32>, memref<f32>, memref<f32>) {
 // CHECK-NEXT: }
@@ -994,54 +994,54 @@ func.func @testdataop(%a: memref<f32>, %b: memref<f32>, %c: memref<f32>) -> () {
 
 // CHECK:      %[[PRESENT_A:.*]] = acc.present varPtr(%[[ARGA]] : memref<f32>) -> memref<f32>
 // CHECK:      acc.data dataOperands(%[[PRESENT_A]] : memref<f32>) {
-// CHECK-NEXT: } attributes {defaultAttr = #acc<defaultvalue none>}
+// CHECK-NEXT: } defaultAttr(none)
 
 // CHECK:      %[[PRESENT_A:.*]] = acc.present varPtr(%[[ARGA]] : memref<f32>) -> memref<f32>
 // CHECK:      acc.data dataOperands(%[[PRESENT_A]] : memref<f32>) {
-// CHECK-NEXT: } attributes {defaultAttr = #acc<defaultvalue present>}
+// CHECK-NEXT: } defaultAttr(present)
 
 // CHECK:      acc.data {
-// CHECK-NEXT: } attributes {defaultAttr = #acc<defaultvalue none>}
+// CHECK-NEXT: } defaultAttr(none)
 
 // CHECK:      acc.data async {
-// CHECK-NEXT: } attributes {defaultAttr = #acc<defaultvalue none>}
+// CHECK-NEXT: } defaultAttr(none)
 
 // CHECK:      acc.data async(%{{.*}} : i64) {
-// CHECK-NEXT: } attributes {defaultAttr = #acc<defaultvalue none>}
+// CHECK-NEXT: } defaultAttr(none)
 
 // CHECK:      acc.data wait {
-// CHECK-NEXT: } attributes {defaultAttr = #acc<defaultvalue none>}
+// CHECK-NEXT: } defaultAttr(none)
 
 // CHECK:      acc.data wait({%{{.*}} : i64}) {
-// CHECK-NEXT: } attributes {defaultAttr = #acc<defaultvalue none>}
+// CHECK-NEXT: } defaultAttr(none)
 
 // CHECK:      acc.data wait({devnum: %{{.*}} : i64, %{{.*}} : i64}) {
-// CHECK-NEXT: } attributes {defaultAttr = #acc<defaultvalue none>}
+// CHECK-NEXT: } defaultAttr(none)
 
 // -----
 
 func.func @testdataopmodifiers(%a: memref<f32>, %b: memref<f32>, %c: memref<f32>) -> () {
-  %0 = acc.create varPtr(%a : memref<f32>) -> memref<f32> {modifiers = #acc<data_clause_modifier capture,zero>}
-  %1 = acc.copyin varPtr(%b : memref<f32>) -> memref<f32> {modifiers = #acc<data_clause_modifier readonly,capture,always>}
-  %2 = acc.copyin varPtr(%c : memref<f32>) -> memref<f32> {modifiers = #acc<data_clause_modifier always>}
-  %3 = acc.create varPtr(%c : memref<f32>) -> memref<f32> {modifiers = #acc<data_clause_modifier always>}
+  %0 = acc.create varPtr(%a : memref<f32>) <{modifiers = #acc<data_clause_modifier capture,zero>}> -> memref<f32>
+  %1 = acc.copyin varPtr(%b : memref<f32>) <{modifiers = #acc<data_clause_modifier readonly,capture,always>}> -> memref<f32>
+  %2 = acc.copyin varPtr(%c : memref<f32>) <{modifiers = #acc<data_clause_modifier always>}> -> memref<f32>
+  %3 = acc.create varPtr(%c : memref<f32>) <{modifiers = #acc<data_clause_modifier always>}> -> memref<f32>
   acc.data dataOperands(%0, %1, %2, %3 : memref<f32>, memref<f32>, memref<f32>, memref<f32>) {
   }
-  acc.copyout accPtr(%0 : memref<f32>) to varPtr(%a : memref<f32>) {modifiers = #acc<data_clause_modifier zero,capture,always>}
-  acc.delete accPtr(%2 : memref<f32>) {modifiers = #acc<data_clause_modifier always>}
-  acc.copyout accPtr(%3 : memref<f32>) to varPtr(%c : memref<f32>) {modifiers = #acc<data_clause_modifier always>}
+  acc.copyout accPtr(%0 : memref<f32>) to varPtr(%a : memref<f32>) <{modifiers = #acc<data_clause_modifier zero,capture,always>}>
+  acc.delete accPtr(%2 : memref<f32>) <{modifiers = #acc<data_clause_modifier always>}>
+  acc.copyout accPtr(%3 : memref<f32>) to varPtr(%c : memref<f32>) <{modifiers = #acc<data_clause_modifier always>}>
 
   func.return
 }
 
 // CHECK:      func @testdataopmodifiers(%[[ARGA:.*]]: memref<f32>, %[[ARGB:.*]]: memref<f32>, %[[ARGC:.*]]: memref<f32>) {
-// CHECK:      %[[CREATEA:.*]] = acc.create varPtr(%[[ARGA]] : memref<f32>) -> memref<f32> {modifiers = #acc<data_clause_modifier zero,capture>}
-// CHECK:      %[[COPYINB:.*]] = acc.copyin varPtr(%[[ARGB]] : memref<f32>) -> memref<f32> {modifiers = #acc<data_clause_modifier always,readonly,capture>}
-// CHECK:      %[[COPYINC:.*]] = acc.copyin varPtr(%[[ARGC]] : memref<f32>) -> memref<f32> {modifiers = #acc<data_clause_modifier always>}
-// CHECK:      %[[CREATEC:.*]] = acc.create varPtr(%[[ARGC]] : memref<f32>) -> memref<f32> {modifiers = #acc<data_clause_modifier always>}
-// CHECK:      acc.copyout accPtr(%[[CREATEA]] : memref<f32>) to varPtr(%[[ARGA]] : memref<f32>) {modifiers = #acc<data_clause_modifier always,zero,capture>}
-// CHECK:      acc.delete accPtr(%[[COPYINC]] : memref<f32>) {modifiers = #acc<data_clause_modifier always>}
-// CHECK:      acc.copyout accPtr(%[[CREATEC]] : memref<f32>) to varPtr(%[[ARGC]] : memref<f32>) {modifiers = #acc<data_clause_modifier always>}
+// CHECK:      %[[CREATEA:.*]] = acc.create varPtr(%[[ARGA]] : memref<f32>) <{modifiers = #acc<data_clause_modifier zero,capture>}> -> memref<f32>
+// CHECK:      %[[COPYINB:.*]] = acc.copyin varPtr(%[[ARGB]] : memref<f32>) <{modifiers = #acc<data_clause_modifier always,readonly,capture>}> -> memref<f32>
+// CHECK:      %[[COPYINC:.*]] = acc.copyin varPtr(%[[ARGC]] : memref<f32>) <{modifiers = #acc<data_clause_modifier always>}> -> memref<f32>
+// CHECK:      %[[CREATEC:.*]] = acc.create varPtr(%[[ARGC]] : memref<f32>) <{modifiers = #acc<data_clause_modifier always>}> -> memref<f32>
+// CHECK:      acc.copyout accPtr(%[[CREATEA]] : memref<f32>) to varPtr(%[[ARGA]] : memref<f32>) <{modifiers = #acc<data_clause_modifier always,zero,capture>}>
+// CHECK:      acc.delete accPtr(%[[COPYINC]] : memref<f32>) <{modifiers = #acc<data_clause_modifier always>}>
+// CHECK:      acc.copyout accPtr(%[[CREATEC]] : memref<f32>) to varPtr(%[[ARGC]] : memref<f32>) <{modifiers = #acc<data_clause_modifier always>}>
 
 // -----
 
@@ -1064,7 +1064,7 @@ func.func @testupdateop(%a: memref<f32>, %b: memref<f32>, %c: memref<f32>) -> ()
   acc.update dataOperands(%0, %1, %2 : memref<f32>, memref<f32>, memref<f32>)
   acc.update async dataOperands(%0, %1, %2 : memref<f32>, memref<f32>, memref<f32>)
   acc.update wait dataOperands(%0, %1, %2 : memref<f32>, memref<f32>, memref<f32>)
-  acc.update dataOperands(%0, %1, %2 : memref<f32>, memref<f32>, memref<f32>) attributes {ifPresent}
+  acc.update dataOperands(%0, %1, %2 : memref<f32>, memref<f32>, memref<f32>) ifPresent
   return
 }
 
@@ -1083,7 +1083,7 @@ func.func @testupdateop(%a: memref<f32>, %b: memref<f32>, %c: memref<f32>) -> ()
 // CHECK:   acc.update dataOperands(%{{.*}}, %{{.*}}, %{{.*}} : memref<f32>, memref<f32>, memref<f32>)
 // CHECK:   acc.update async dataOperands(%{{.*}}, %{{.*}}, %{{.*}} : memref<f32>, memref<f32>, memref<f32>)
 // CHECK:   acc.update wait dataOperands(%{{.*}}, %{{.*}}, %{{.*}} : memref<f32>, memref<f32>, memref<f32>)
-// CHECK:   acc.update dataOperands(%{{.*}}, %{{.*}}, %{{.*}} : memref<f32>, memref<f32>, memref<f32>) attributes {ifPresent}
+// CHECK:   acc.update dataOperands(%{{.*}}, %{{.*}}, %{{.*}} : memref<f32>, memref<f32>, memref<f32>) ifPresent
 
 // -----
 
@@ -1214,7 +1214,7 @@ func.func @testexitdataop(%a: !llvm.ptr) -> () {
   acc.delete accPtr(%1 : !llvm.ptr)
 
   %2 = acc.getdeviceptr varPtr(%a : !llvm.ptr) varType(f64) -> !llvm.ptr
-  acc.exit_data async dataOperands(%2 : !llvm.ptr) attributes {finalize}
+  acc.exit_data async dataOperands(%2 : !llvm.ptr) finalize
   acc.delete accPtr(%2 : !llvm.ptr)
 
   %3 = acc.getdeviceptr varPtr(%a : !llvm.ptr) varType(f64) -> !llvm.ptr
@@ -1263,7 +1263,7 @@ func.func @testexitdataop(%a: !llvm.ptr) -> () {
 // CHECK: acc.delete accPtr(%[[DEVPTR]] : !llvm.ptr)
 
 // CHECK: %[[DEVPTR:.*]] = acc.getdeviceptr varPtr(%[[ARGA]] : !llvm.ptr) varType(f64) -> !llvm.ptr
-// CHECK: acc.exit_data async dataOperands(%[[DEVPTR]] : !llvm.ptr) attributes {finalize}
+// CHECK: acc.exit_data async dataOperands(%[[DEVPTR]] : !llvm.ptr) finalize
 // CHECK: acc.delete accPtr(%[[DEVPTR]] : !llvm.ptr)
 
 // CHECK: %[[DEVPTR:.*]] = acc.getdeviceptr varPtr(%[[ARGA]] : !llvm.ptr) varType(f64) -> !llvm.ptr
@@ -1306,8 +1306,8 @@ func.func @testenterdataop(%a: !llvm.ptr, %b: !llvm.ptr, %c: !llvm.ptr) -> () {
   %0 = acc.copyin varPtr(%a : !llvm.ptr) varType(f64) -> !llvm.ptr
   acc.enter_data dataOperands(%0 : !llvm.ptr)
   %1 = acc.create varPtr(%a : !llvm.ptr) varType(f64) -> !llvm.ptr
-  %2 = acc.create varPtr(%b : !llvm.ptr) varType(f64) -> !llvm.ptr {dataClause = #acc<data_clause acc_create_zero>}
-  %3 = acc.create varPtr(%c : !llvm.ptr) varType(f64) -> !llvm.ptr {dataClause = #acc<data_clause acc_create_zero>}
+  %2 = acc.create varPtr(%b : !llvm.ptr) varType(f64) dataClause(acc_create_zero) -> !llvm.ptr<0>
+  %3 = acc.create varPtr(%c : !llvm.ptr) varType(f64) dataClause(acc_create_zero) -> !llvm.ptr<0>
   acc.enter_data dataOperands(%1, %2, %3 : !llvm.ptr, !llvm.ptr, !llvm.ptr)
   %4 = acc.attach varPtr(%a : !llvm.ptr) varType(f64) -> !llvm.ptr
   acc.enter_data dataOperands(%4 : !llvm.ptr)
@@ -1335,8 +1335,8 @@ func.func @testenterdataop(%a: !llvm.ptr, %b: !llvm.ptr, %c: !llvm.ptr) -> () {
 // CHECK: %[[COPYIN:.*]] = acc.copyin varPtr(%[[ARGA]] : !llvm.ptr) varType(f64) -> !llvm.ptr
 // CHECK: acc.enter_data dataOperands(%[[COPYIN]] : !llvm.ptr)
 // CHECK: %[[CREATE_A:.*]] = acc.create varPtr(%[[ARGA]] : !llvm.ptr) varType(f64) -> !llvm.ptr
-// CHECK: %[[CREATE_B:.*]] = acc.create varPtr(%[[ARGB]] : !llvm.ptr) varType(f64) -> !llvm.ptr {dataClause = #acc<data_clause acc_create_zero>}
-// CHECK: %[[CREATE_C:.*]] = acc.create varPtr(%[[ARGC]] : !llvm.ptr) varType(f64) -> !llvm.ptr {dataClause = #acc<data_clause acc_create_zero>}
+// CHECK: %[[CREATE_B:.*]] = acc.create varPtr(%[[ARGB]] : !llvm.ptr) varType(f64) dataClause(acc_create_zero) -> !llvm.ptr
+// CHECK: %[[CREATE_C:.*]] = acc.create varPtr(%[[ARGC]] : !llvm.ptr) varType(f64) dataClause(acc_create_zero) -> !llvm.ptr
 // CHECK: acc.enter_data dataOperands(%[[CREATE_A]], %[[CREATE_B]], %[[CREATE_C]] : !llvm.ptr, !llvm.ptr, !llvm.ptr)
 // CHECK: %[[ATTACH:.*]] = acc.attach varPtr(%[[ARGA]] : !llvm.ptr) varType(f64) -> !llvm.ptr
 // CHECK: acc.enter_data dataOperands(%[[ATTACH]] : !llvm.ptr)
@@ -1356,7 +1356,7 @@ func.func @testenterdataop(%a: !llvm.ptr, %b: !llvm.ptr, %c: !llvm.ptr) -> () {
 // -----
 
 func.func @teststructureddataclauseops(%a: memref<10xf32>, %b: memref<memref<10xf32>>, %c: memref<10x20xf32>) -> () {
-  %deviceptr = acc.deviceptr varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) -> memref<10xf32> {name = "arrayA"}
+  %deviceptr = acc.deviceptr varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) name("arrayA") -> memref<10xf32>
   acc.parallel dataOperands(%deviceptr : memref<10xf32>) {
   }
 
@@ -1368,36 +1368,36 @@ func.func @teststructureddataclauseops(%a: memref<10xf32>, %b: memref<memref<10x
   acc.parallel dataOperands(%copyin : memref<10xf32>) {
   }
 
-  %copyinreadonly = acc.copyin varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) -> memref<10xf32> {dataClause = #acc<data_clause acc_copyin_readonly>}
+  %copyinreadonly = acc.copyin varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) dataClause(acc_copyin_readonly) -> memref<10xf32>
   acc.kernels dataOperands(%copyinreadonly : memref<10xf32>) {
   }
 
-  %copyinfromcopy = acc.copyin varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) -> memref<10xf32> {dataClause = #acc<data_clause acc_copy>}
+  %copyinfromcopy = acc.copyin varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) dataClause(acc_copy) -> memref<10xf32>
   acc.serial dataOperands(%copyinfromcopy : memref<10xf32>) {
   }
-  acc.copyout accPtr(%copyinfromcopy : memref<10xf32>) to varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) {dataClause = #acc<data_clause acc_copy>}
+  acc.copyout accPtr(%copyinfromcopy : memref<10xf32>) to varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) dataClause(acc_copy)
 
   %create = acc.create varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) -> memref<10xf32>
-  %createimplicit = acc.create varPtr(%c : memref<10x20xf32>) varType(tensor<10x20xf32>) -> memref<10x20xf32> {implicit = true}
+  %createimplicit = acc.create varPtr(%c : memref<10x20xf32>) varType(tensor<10x20xf32>) implicit(true) -> memref<10x20xf32>
   acc.parallel dataOperands(%create, %createimplicit : memref<10xf32>, memref<10x20xf32>) {
   }
-  acc.delete accPtr(%create : memref<10xf32>) {dataClause = #acc<data_clause acc_create>}
-  acc.delete accPtr(%createimplicit : memref<10x20xf32>) {dataClause = #acc<data_clause acc_create>, implicit = true}
+  acc.delete accPtr(%create : memref<10xf32>) dataClause(acc_create)
+  acc.delete accPtr(%createimplicit : memref<10x20xf32>) dataClause(acc_create) implicit(true)
 
-  %copyoutzero = acc.create varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) -> memref<10xf32> {dataClause = #acc<data_clause acc_copyout_zero>}
+  %copyoutzero = acc.create varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) dataClause(acc_copyout_zero) -> memref<10xf32>
   acc.parallel dataOperands(%copyoutzero: memref<10xf32>) {
   }
-  acc.copyout accPtr(%copyoutzero : memref<10xf32>) to varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) {dataClause = #acc<data_clause acc_copyout_zero>}
+  acc.copyout accPtr(%copyoutzero : memref<10xf32>) to varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) dataClause(acc_copyout_zero)
 
   %attach = acc.attach varPtr(%b : memref<memref<10xf32>>) -> memref<memref<10xf32>>
   acc.parallel dataOperands(%attach : memref<memref<10xf32>>) {
   }
-  acc.detach accPtr(%attach : memref<memref<10xf32>>) {dataClause = #acc<data_clause acc_attach>}
+  acc.detach accPtr(%attach : memref<memref<10xf32>>) dataClause(acc_attach)
 
-  %copyinparent = acc.copyin varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) varPtrPtr(%b : memref<memref<10xf32>>) -> memref<10xf32> {dataClause = #acc<data_clause acc_copy>}
+  %copyinparent = acc.copyin varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) varPtrPtr(%b : memref<memref<10xf32>>) dataClause(acc_copy) -> memref<10xf32>
   acc.parallel dataOperands(%copyinparent : memref<10xf32>) {
   }
-  acc.copyout accPtr(%copyinparent : memref<10xf32>) to varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) {dataClause = #acc<data_clause acc_copy>}
+  acc.copyout accPtr(%copyinparent : memref<10xf32>) to varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) dataClause(acc_copy)
 
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
@@ -1407,24 +1407,24 @@ func.func @teststructureddataclauseops(%a: memref<10xf32>, %b: memref<memref<10x
   %c20 = arith.constant 20 : index
 
   %bounds1full = acc.bounds lowerbound(%c0 : index) upperbound(%c9 : index) stride(%c1 : index)
-  %copyinfullslice1 = acc.copyin varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) bounds(%bounds1full) -> memref<10xf32> {name = "arrayA[0:9]"}
+  %copyinfullslice1 = acc.copyin varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) bounds(%bounds1full) name("arrayA[0:9]") -> memref<10xf32>
   // Specify full-bounds but assume that startIdx of array reference is 1.
-  %bounds2full = acc.bounds lowerbound(%c1 : index) upperbound(%c20 : index) extent(%c20 : index) stride(%c4 : index) startIdx(%c1 : index) {strideInBytes = true}
+  %bounds2full = acc.bounds lowerbound(%c1 : index) upperbound(%c20 : index) extent(%c20 : index) stride(%c4 : index) startIdx(%c1 : index) strideInBytes(true)
   %copyinfullslice2 = acc.copyin varPtr(%c : memref<10x20xf32>) varType(tensor<10x20xf32>) bounds(%bounds1full, %bounds2full) -> memref<10x20xf32>
   acc.parallel dataOperands(%copyinfullslice1, %copyinfullslice2 : memref<10xf32>, memref<10x20xf32>) {
   }
 
   %bounds1partial = acc.bounds lowerbound(%c4 : index) upperbound(%c9 : index) stride(%c1 : index)
-  %copyinpartial = acc.copyin varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) bounds(%bounds1partial) -> memref<10xf32> {dataClause = #acc<data_clause acc_copy>}
+  %copyinpartial = acc.copyin varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) bounds(%bounds1partial) dataClause(acc_copy) -> memref<10xf32>
   acc.parallel dataOperands(%copyinpartial : memref<10xf32>) {
   }
-  acc.copyout accPtr(%copyinpartial : memref<10xf32>) bounds(%bounds1partial) to varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) {dataClause = #acc<data_clause acc_copy>}
+  acc.copyout accPtr(%copyinpartial : memref<10xf32>) bounds(%bounds1partial) to varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) dataClause(acc_copy)
 
   return
 }
 
 // CHECK: func.func @teststructureddataclauseops([[ARGA:%.*]]: memref<10xf32>, [[ARGB:%.*]]: memref<memref<10xf32>>, [[ARGC:%.*]]: memref<10x20xf32>) {
-// CHECK: [[DEVICEPTR:%.*]] = acc.deviceptr varPtr([[ARGA]] : memref<10xf32>) varType(tensor<10xf32>) -> memref<10xf32> {name = "arrayA"}
+// CHECK: [[DEVICEPTR:%.*]] = acc.deviceptr varPtr([[ARGA]] : memref<10xf32>) varType(tensor<10xf32>) name("arrayA") -> memref<10xf32>
 // CHECK-NEXT: acc.parallel dataOperands([[DEVICEPTR]] : memref<10xf32>) {
 // CHECK-NEXT: }
 // CHECK: [[PRESENT:%.*]] = acc.present varPtr([[ARGA]] : memref<10xf32>) varType(tensor<10xf32>) -> memref<10xf32>
@@ -1433,73 +1433,73 @@ func.func @teststructureddataclauseops(%a: memref<10xf32>, %b: memref<memref<10x
 // CHECK: [[COPYIN:%.*]] = acc.copyin varPtr([[ARGA]] : memref<10xf32>) varType(tensor<10xf32>) -> memref<10xf32>
 // CHECK-NEXT: acc.parallel dataOperands([[COPYIN]] : memref<10xf32>) {
 // CHECK-NEXT: }
-// CHECK: [[COPYINRO:%.*]] = acc.copyin varPtr([[ARGA]] : memref<10xf32>) varType(tensor<10xf32>) -> memref<10xf32> {dataClause = #acc<data_clause acc_copyin_readonly>}
+// CHECK: [[COPYINRO:%.*]] = acc.copyin varPtr([[ARGA]] : memref<10xf32>) varType(tensor<10xf32>) dataClause(acc_copyin_readonly) -> memref<10xf32>
 // CHECK-NEXT: acc.kernels dataOperands([[COPYINRO]] : memref<10xf32>) {
 // CHECK-NEXT: }
-// CHECK: [[COPYINCOPY:%.*]] = acc.copyin varPtr([[ARGA]] : memref<10xf32>) varType(tensor<10xf32>) -> memref<10xf32> {dataClause = #acc<data_clause acc_copy>}
+// CHECK: [[COPYINCOPY:%.*]] = acc.copyin varPtr([[ARGA]] : memref<10xf32>) varType(tensor<10xf32>) dataClause(acc_copy) -> memref<10xf32>
 // CHECK-NEXT: acc.serial dataOperands([[COPYINCOPY]] : memref<10xf32>) {
 // CHECK-NEXT: }
-// CHECK-NEXT: acc.copyout accPtr([[COPYINCOPY]] : memref<10xf32>) to varPtr([[ARGA]] : memref<10xf32>) varType(tensor<10xf32>) {dataClause = #acc<data_clause acc_copy>}
+// CHECK-NEXT: acc.copyout accPtr([[COPYINCOPY]] : memref<10xf32>) to varPtr([[ARGA]] : memref<10xf32>) varType(tensor<10xf32>) dataClause(acc_copy)
 // CHECK: [[CREATE:%.*]] = acc.create varPtr([[ARGA]] : memref<10xf32>) varType(tensor<10xf32>) -> memref<10xf32>
-// CHECK-NEXT: [[CREATEIMP:%.*]] = acc.create varPtr([[ARGC]] : memref<10x20xf32>) varType(tensor<10x20xf32>) -> memref<10x20xf32> {implicit = true}
+// CHECK-NEXT: [[CREATEIMP:%.*]] = acc.create varPtr([[ARGC]] : memref<10x20xf32>) varType(tensor<10x20xf32>) implicit(true) -> memref<10x20xf32>
 // CHECK-NEXT: acc.parallel dataOperands([[CREATE]], [[CREATEIMP]] : memref<10xf32>, memref<10x20xf32>) {
 // CHECK-NEXT: }
-// CHECK-NEXT: acc.delete accPtr([[CREATE]] : memref<10xf32>) {dataClause = #acc<data_clause acc_create>}
-// CHECK-NEXT: acc.delete accPtr([[CREATEIMP]] : memref<10x20xf32>) {dataClause = #acc<data_clause acc_create>, implicit = true}
-// CHECK: [[COPYOUTZ:%.*]] = acc.create varPtr([[ARGA]] : memref<10xf32>) varType(tensor<10xf32>) -> memref<10xf32> {dataClause = #acc<data_clause acc_copyout_zero>}
+// CHECK-NEXT: acc.delete accPtr([[CREATE]] : memref<10xf32>) dataClause(acc_create)
+// CHECK-NEXT: acc.delete accPtr([[CREATEIMP]] : memref<10x20xf32>) dataClause(acc_create) implicit(true)
+// CHECK: [[COPYOUTZ:%.*]] = acc.create varPtr([[ARGA]] : memref<10xf32>) varType(tensor<10xf32>) dataClause(acc_copyout_zero) -> memref<10xf32>
 // CHECK-NEXT: acc.parallel dataOperands([[COPYOUTZ]] : memref<10xf32>) {
 // CHECK-NEXT: }
-// CHECK-NEXT: acc.copyout accPtr([[COPYOUTZ]] : memref<10xf32>) to varPtr([[ARGA]] : memref<10xf32>) varType(tensor<10xf32>) {dataClause = #acc<data_clause acc_copyout_zero>}
+// CHECK-NEXT: acc.copyout accPtr([[COPYOUTZ]] : memref<10xf32>) to varPtr([[ARGA]] : memref<10xf32>) varType(tensor<10xf32>) dataClause(acc_copyout_zero)
 // CHECK: [[ATTACH:%.*]] = acc.attach varPtr([[ARGB]] : memref<memref<10xf32>>) -> memref<memref<10xf32>>
 // CHECK-NEXT: acc.parallel dataOperands([[ATTACH]] : memref<memref<10xf32>>) {
 // CHECK-NEXT: }
-// CHECK-NEXT: acc.detach accPtr([[ATTACH]] : memref<memref<10xf32>>) {dataClause = #acc<data_clause acc_attach>}
-// CHECK: [[COPYINP:%.*]] = acc.copyin varPtr([[ARGA]] : memref<10xf32>) varType(tensor<10xf32>) varPtrPtr([[ARGB]] : memref<memref<10xf32>>) -> memref<10xf32> {dataClause = #acc<data_clause acc_copy>}
+// CHECK-NEXT: acc.detach accPtr([[ATTACH]] : memref<memref<10xf32>>) dataClause(acc_attach)
+// CHECK: [[COPYINP:%.*]] = acc.copyin varPtr([[ARGA]] : memref<10xf32>) varType(tensor<10xf32>) varPtrPtr([[ARGB]] : memref<memref<10xf32>>) dataClause(acc_copy) -> memref<10xf32>
 // CHECK-NEXT: acc.parallel dataOperands([[COPYINP]] : memref<10xf32>) {
 // CHECK-NEXT: }
-// CHECK-NEXT: acc.copyout accPtr([[COPYINP]] : memref<10xf32>) to varPtr([[ARGA]] : memref<10xf32>) varType(tensor<10xf32>) {dataClause = #acc<data_clause acc_copy>}
+// CHECK-NEXT: acc.copyout accPtr([[COPYINP]] : memref<10xf32>) to varPtr([[ARGA]] : memref<10xf32>) varType(tensor<10xf32>) dataClause(acc_copy)
 // CHECK-DAG: [[CON0:%.*]] = arith.constant 0 : index
 // CHECK-DAG: [[CON1:%.*]] = arith.constant 1 : index
 // CHECK-DAG: [[CON4:%.*]] = arith.constant 4 : index
 // CHECK-DAG: [[CON9:%.*]] = arith.constant 9 : index
 // CHECK-DAG: [[CON20:%.*]] = arith.constant 20 : index
 // CHECK: [[BOUNDS1F:%.*]] = acc.bounds lowerbound([[CON0]] : index) upperbound([[CON9]] : index) stride([[CON1]] : index)
-// CHECK-NEXT: [[COPYINF1:%.*]] = acc.copyin varPtr([[ARGA]] : memref<10xf32>) varType(tensor<10xf32>) bounds([[BOUNDS1F]]) -> memref<10xf32> {name = "arrayA[0:9]"}
-// CHECK-NEXT: [[BOUNDS2F:%.*]] = acc.bounds lowerbound([[CON1]] : index) upperbound([[CON20]] : index) extent([[CON20]] : index) stride([[CON4]] : index) startIdx([[CON1]] : index) {strideInBytes = true}
+// CHECK-NEXT: [[COPYINF1:%.*]] = acc.copyin varPtr([[ARGA]] : memref<10xf32>) varType(tensor<10xf32>) bounds([[BOUNDS1F]]) name("arrayA[0:9]") -> memref<10xf32>
+// CHECK-NEXT: [[BOUNDS2F:%.*]] = acc.bounds lowerbound([[CON1]] : index) upperbound([[CON20]] : index) extent([[CON20]] : index) stride([[CON4]] : index) startIdx([[CON1]] : index) strideInBytes(true)
 // CHECK-NEXT: [[COPYINF2:%.*]] = acc.copyin varPtr([[ARGC]] : memref<10x20xf32>) varType(tensor<10x20xf32>) bounds([[BOUNDS1F]], [[BOUNDS2F]]) -> memref<10x20xf32>
 // CHECK-NEXT: acc.parallel dataOperands([[COPYINF1]], [[COPYINF2]] : memref<10xf32>, memref<10x20xf32>) {
 // CHECK-NEXT: }
 // CHECK: [[BOUNDS1P:%.*]] = acc.bounds lowerbound([[CON4]] : index) upperbound([[CON9]] : index) stride([[CON1]] : index)
-// CHECK-NEXT: [[COPYINPART:%.*]] = acc.copyin varPtr([[ARGA]] : memref<10xf32>) varType(tensor<10xf32>) bounds([[BOUNDS1P]]) -> memref<10xf32> {dataClause = #acc<data_clause acc_copy>}
+// CHECK-NEXT: [[COPYINPART:%.*]] = acc.copyin varPtr([[ARGA]] : memref<10xf32>) varType(tensor<10xf32>) bounds([[BOUNDS1P]]) dataClause(acc_copy) -> memref<10xf32>
 // CHECK-NEXT: acc.parallel dataOperands([[COPYINPART]] : memref<10xf32>) {
 // CHECK-NEXT: }
-// CHECK-NEXT: acc.copyout accPtr([[COPYINPART]] : memref<10xf32>) bounds([[BOUNDS1P]]) to varPtr([[ARGA]] : memref<10xf32>) varType(tensor<10xf32>) {dataClause = #acc<data_clause acc_copy>}
+// CHECK-NEXT: acc.copyout accPtr([[COPYINPART]] : memref<10xf32>) bounds([[BOUNDS1P]]) to varPtr([[ARGA]] : memref<10xf32>) varType(tensor<10xf32>) dataClause(acc_copy)
 
 // -----
 
 func.func @testunstructuredclauseops(%a: memref<10xf32>) -> () {
-  %copyin = acc.copyin varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) -> memref<10xf32> {structured = false}
+  %copyin = acc.copyin varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) structured(false) -> memref<10xf32>
   acc.enter_data dataOperands(%copyin : memref<10xf32>)
 
-  %devptr = acc.getdeviceptr varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) -> memref<10xf32> {dataClause = #acc<data_clause acc_copyout>}
+  %devptr = acc.getdeviceptr varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) dataClause(acc_copyout) -> memref<10xf32>
   acc.exit_data dataOperands(%devptr : memref<10xf32>)
-  acc.copyout accPtr(%devptr : memref<10xf32>) to varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) {structured = false}
+  acc.copyout accPtr(%devptr : memref<10xf32>) to varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) structured(false)
 
   return
 }
 
 // CHECK: func.func @testunstructuredclauseops([[ARGA:%.*]]: memref<10xf32>) {
-// CHECK: [[COPYIN:%.*]] = acc.copyin varPtr([[ARGA]] : memref<10xf32>) varType(tensor<10xf32>) -> memref<10xf32> {structured = false}
+// CHECK: [[COPYIN:%.*]] = acc.copyin varPtr([[ARGA]] : memref<10xf32>) varType(tensor<10xf32>) structured(false) -> memref<10xf32>
 // CHECK-NEXT: acc.enter_data dataOperands([[COPYIN]] : memref<10xf32>)
-// CHECK: [[DEVPTR:%.*]] = acc.getdeviceptr varPtr([[ARGA]] : memref<10xf32>) varType(tensor<10xf32>) -> memref<10xf32> {dataClause = #acc<data_clause acc_copyout>}
+// CHECK: [[DEVPTR:%.*]] = acc.getdeviceptr varPtr([[ARGA]] : memref<10xf32>) varType(tensor<10xf32>) dataClause(acc_copyout) -> memref<10xf32>
 // CHECK-NEXT: acc.exit_data dataOperands([[DEVPTR]] : memref<10xf32>)
-// CHECK-NEXT: acc.copyout accPtr([[DEVPTR]] : memref<10xf32>) to varPtr([[ARGA]] : memref<10xf32>) varType(tensor<10xf32>) {structured = false}
+// CHECK-NEXT: acc.copyout accPtr([[DEVPTR]] : memref<10xf32>) to varPtr([[ARGA]] : memref<10xf32>) varType(tensor<10xf32>) structured(false)
 
 // -----
 
 func.func @host_device_ops(%a: memref<f32>) -> () {
   %devptr = acc.getdeviceptr varPtr(%a : memref<f32>) -> memref<f32>
-  acc.update_host accPtr(%devptr : memref<f32>) to varPtr(%a : memref<f32>) {structured = false}
+  acc.update_host accPtr(%devptr : memref<f32>) to varPtr(%a : memref<f32>) structured(false)
   acc.update dataOperands(%devptr : memref<f32>)
 
   %accPtr = acc.update_device varPtr(%a : memref<f32>) -> memref<f32>
@@ -1510,7 +1510,7 @@ func.func @host_device_ops(%a: memref<f32>) -> () {
 // CHECK-LABEL: func.func @host_device_ops(
 // CHECK-SAME:    %[[A:.*]]: memref<f32>)
 // CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[A]] : memref<f32>)   -> memref<f32>
-// CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : memref<f32>) to varPtr(%[[A]] : memref<f32>) {structured = false}
+// CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : memref<f32>) to varPtr(%[[A]] : memref<f32>) structured(false)
 // CHECK: acc.update dataOperands(%[[DEVPTR_A]] : memref<f32>)
 // CHECK: %[[DEVPTR_A:.*]] = acc.update_device varPtr(%[[A]] : memref<f32>)   -> memref<f32>
 // CHECK: acc.update dataOperands(%[[DEVPTR_A]] : memref<f32>)
@@ -1522,7 +1522,7 @@ func.func @host_data_ops(%a: !llvm.ptr, %ifCond: i1) -> () {
   acc.host_data dataOperands(%0: !llvm.ptr) {
   }
   acc.host_data dataOperands(%0: !llvm.ptr) {
-  } attributes {if_present}
+  } ifPresent
   acc.host_data if(%ifCond) dataOperands(%0: !llvm.ptr) {
   }
   return
@@ -1533,7 +1533,7 @@ func.func @host_data_ops(%a: !llvm.ptr, %ifCond: i1) -> () {
 // CHECK: %[[PTR:.*]] = acc.use_device varPtr(%[[A]] : !llvm.ptr) varType(f64) -> !llvm.ptr
 // CHECK: acc.host_data dataOperands(%[[PTR]] : !llvm.ptr)
 // CHECK: acc.host_data dataOperands(%[[PTR]] : !llvm.ptr) {
-// CHECK: } attributes {if_present}
+// CHECK: } ifPresent
 // CHECK: acc.host_data if(%[[IFCOND]]) dataOperands(%[[PTR]] : !llvm.ptr)
 
 // -----
@@ -1624,7 +1624,7 @@ func.func @acc_reduc_test(%a : memref<i64>) -> () {
   acc.parallel reduction(%reduction_a :  memref<i64>) {
     acc.loop reduction(%reduction_a :  memref<i64>) control(%iv : index) = (%c0 : index) to (%c10 : index) step (%c1 : index) {
       acc.yield
-    } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+    } inclusiveUpperbound(array<i1: true>) independent
     acc.yield
   }
   return
@@ -1699,14 +1699,14 @@ func.func @acc_kernels_reduc_test(%a : memref<i64>) -> () {
 func.func @testdeclareop(%a: memref<f32>, %b: memref<f32>, %c: memref<f32>) -> () {
   %0 = acc.copyin varPtr(%a : memref<f32>) -> memref<f32>
   // copyin(zero)
-  %1 = acc.copyin varPtr(%b : memref<f32>) -> memref<f32> {dataClause = #acc<data_clause acc_copyin_readonly>}
+  %1 = acc.copyin varPtr(%b : memref<f32>) dataClause(acc_copyin_readonly) -> memref<f32>
   // copy
-  %2 = acc.copyin varPtr(%c : memref<f32>) -> memref<f32> {dataClause = #acc<data_clause acc_copy>}
+  %2 = acc.copyin varPtr(%c : memref<f32>) dataClause(acc_copy) -> memref<f32>
   acc.declare_enter dataOperands(%0, %1, %2 : memref<f32>, memref<f32>, memref<f32>)
 
   %3 = acc.create varPtr(%a : memref<f32>) -> memref<f32>
   // copyout
-  %4 = acc.create varPtr(%b : memref<f32>) -> memref<f32> {dataClause = #acc<data_clause acc_copyout>}
+  %4 = acc.create varPtr(%b : memref<f32>) dataClause(acc_copyout) -> memref<f32>
   %5 = acc.present varPtr(%c : memref<f32>) -> memref<f32>
   acc.declare_enter dataOperands(%3, %4, %5 : memref<f32>, memref<f32>, memref<f32>)
 
@@ -1716,18 +1716,18 @@ func.func @testdeclareop(%a: memref<f32>, %b: memref<f32>, %c: memref<f32>) -> (
   acc.declare_enter dataOperands(%6, %7, %8 : memref<f32>, memref<f32>, memref<f32>)
 
   acc.declare_exit dataOperands(%7, %8 : memref<f32>, memref<f32>)
-  acc.delete accPtr(%7 : memref<f32>) {dataClause = #acc<data_clause acc_declare_device_resident> }
-  acc.delete accPtr(%8 : memref<f32>) {dataClause = #acc<data_clause acc_declare_link> }
+  acc.delete accPtr(%7 : memref<f32>) dataClause(acc_declare_device_resident)
+  acc.delete accPtr(%8 : memref<f32>) dataClause(acc_declare_link)
 
   acc.declare_exit dataOperands(%3, %4, %5 : memref<f32>, memref<f32>, memref<f32>)
-  acc.delete accPtr(%3 : memref<f32>) {dataClause = #acc<data_clause acc_create> }
+  acc.delete accPtr(%3 : memref<f32>) dataClause(acc_create)
   acc.copyout accPtr(%4 : memref<f32>) to varPtr(%b : memref<f32>)
-  acc.delete accPtr(%5 : memref<f32>) {dataClause = #acc<data_clause acc_present> }
+  acc.delete accPtr(%5 : memref<f32>) dataClause(acc_present)
 
   acc.declare_exit dataOperands(%0, %1, %2 : memref<f32>, memref<f32>, memref<f32>)
-  acc.delete accPtr(%0 : memref<f32>) {dataClause = #acc<data_clause acc_copyin> }
-  acc.delete accPtr(%1 : memref<f32>) {dataClause = #acc<data_clause acc_copyin_readonly> }
-  acc.copyout accPtr(%2 : memref<f32>) to varPtr(%c : memref<f32>) { dataClause = #acc<data_clause acc_copy> }
+  acc.delete accPtr(%0 : memref<f32>) dataClause(acc_copyin)
+  acc.delete accPtr(%1 : memref<f32>) dataClause(acc_copyin_readonly)
+  acc.copyout accPtr(%2 : memref<f32>) to varPtr(%c : memref<f32>) dataClause(acc_copy)
 
   return
 }
@@ -1735,11 +1735,11 @@ func.func @testdeclareop(%a: memref<f32>, %b: memref<f32>, %c: memref<f32>) -> (
 // CHECK-LABEL: func.func @testdeclareop(
 // CHECK-SAME: %[[ARGA:.*]]: memref<f32>, %[[ARGB:.*]]: memref<f32>, %[[ARGC:.*]]: memref<f32>)
 // CHECK: %[[COPYIN:.*]] = acc.copyin varPtr(%[[ARGA]] : memref<f32>) -> memref<f32>
-// CHECK-NEXT: %[[COPYINRO:.*]] = acc.copyin varPtr(%[[ARGB]] : memref<f32>) -> memref<f32> {dataClause = #acc<data_clause acc_copyin_readonly>}
-// CHECK-NEXT: %[[COPY:.*]] = acc.copyin varPtr(%[[ARGC]] : memref<f32>) -> memref<f32> {dataClause = #acc<data_clause acc_copy>}
+// CHECK-NEXT: %[[COPYINRO:.*]] = acc.copyin varPtr(%[[ARGB]] : memref<f32>) dataClause(acc_copyin_readonly) -> memref<f32>
+// CHECK-NEXT: %[[COPY:.*]] = acc.copyin varPtr(%[[ARGC]] : memref<f32>) dataClause(acc_copy) -> memref<f32>
 // CHECK-NEXT: acc.declare_enter dataOperands(%[[COPYIN]], %[[COPYINRO]], %[[COPY]] : memref<f32>, memref<f32>, memref<f32>)
 // CHECK: %[[CREATE:.*]] = acc.create varPtr(%[[ARGA]] : memref<f32>) -> memref<f32>
-// CHECK-NEXT: %[[COPYOUT:.*]] = acc.create varPtr(%[[ARGB]] : memref<f32>) -> memref<f32> {dataClause = #acc<data_clause acc_copyout>}
+// CHECK-NEXT: %[[COPYOUT:.*]] = acc.create varPtr(%[[ARGB]] : memref<f32>) dataClause(acc_copyout) -> memref<f32>
 // CHECK-NEXT: %[[PRESENT:.*]] = acc.present varPtr(%[[ARGC]] : memref<f32>) -> memref<f32>
 // CHECK-NEXT: acc.declare_enter dataOperands(%[[CREATE]], %[[COPYOUT]], %[[PRESENT]] : memref<f32>, memref<f32>, memref<f32>)
 // CHECK: %[[DEVICEPTR:.*]] = acc.deviceptr varPtr(%[[ARGA]] : memref<f32>) -> memref<f32>
@@ -1747,16 +1747,16 @@ func.func @testdeclareop(%a: memref<f32>, %b: memref<f32>, %c: memref<f32>) -> (
 // CHECK-NEXT: %[[LINK:.*]] = acc.declare_link varPtr(%[[ARGC]] : memref<f32>) -> memref<f32>
 // CHECK-NEXT: acc.declare_enter dataOperands(%[[DEVICEPTR]], %[[DEVICERES]], %[[LINK]] : memref<f32>, memref<f32>, memref<f32>)
 // CHECK: acc.declare_exit dataOperands(%[[DEVICERES]], %[[LINK]] : memref<f32>, memref<f32>)
-// CHECK-NEXT: acc.delete accPtr(%[[DEVICERES]] : memref<f32>) {dataClause = #acc<data_clause acc_declare_device_resident>}
-// CHECK-NEXT: acc.delete accPtr(%[[LINK]] : memref<f32>) {dataClause = #acc<data_clause acc_declare_link>}
+// CHECK-NEXT: acc.delete accPtr(%[[DEVICERES]] : memref<f32>) dataClause(acc_declare_device_resident)
+// CHECK-NEXT: acc.delete accPtr(%[[LINK]] : memref<f32>) dataClause(acc_declare_link)
 // CHECK: acc.declare_exit dataOperands(%[[CREATE]], %[[COPYOUT]], %[[PRESENT]] : memref<f32>, memref<f32>, memref<f32>)
-// CHECK-NEXT: acc.delete accPtr(%[[CREATE]] : memref<f32>) {dataClause = #acc<data_clause acc_create>}
+// CHECK-NEXT: acc.delete accPtr(%[[CREATE]] : memref<f32>) dataClause(acc_create)
 // CHECK-NEXT: acc.copyout accPtr(%[[COPYOUT]] : memref<f32>) to varPtr(%[[ARGB]] : memref<f32>)
-// CHECK-NEXT: acc.delete accPtr(%[[PRESENT]] : memref<f32>) {dataClause = #acc<data_clause acc_present>}
+// CHECK-NEXT: acc.delete accPtr(%[[PRESENT]] : memref<f32>) dataClause(acc_present)
 // CHECK: acc.declare_exit dataOperands(%[[COPYIN]], %[[COPYINRO]], %[[COPY]] : memref<f32>, memref<f32>, memref<f32>)
-// CHECK-NEXT: acc.delete accPtr(%[[COPYIN]] : memref<f32>) {dataClause = #acc<data_clause acc_copyin>}
-// CHECK-NEXT: acc.delete accPtr(%[[COPYINRO]] : memref<f32>) {dataClause = #acc<data_clause acc_copyin_readonly>}
-// CHECK-NEXT: acc.copyout accPtr(%[[COPY]] : memref<f32>) to varPtr(%[[ARGC]] : memref<f32>) {dataClause = #acc<data_clause acc_copy>}
+// CHECK-NEXT: acc.delete accPtr(%[[COPYIN]] : memref<f32>) dataClause(acc_copyin)
+// CHECK-NEXT: acc.delete accPtr(%[[COPYINRO]] : memref<f32>) dataClause(acc_copyin_readonly)
+// CHECK-NEXT: acc.copyout accPtr(%[[COPY]] : memref<f32>) to varPtr(%[[ARGC]] : memref<f32>) dataClause(acc_copy)
 
 // -----
 
@@ -1774,7 +1774,7 @@ acc.global_ctor @acc_constructor {
 
 acc.global_dtor @acc_destructor {
   %0 = llvm.mlir.addressof @globalvar { acc.declare = #acc.declare<dataClause = acc_create> } : !llvm.ptr
-  %1 = acc.getdeviceptr varPtr(%0 : !llvm.ptr) varType(i32) -> !llvm.ptr {dataClause = #acc<data_clause acc_create>}
+  %1 = acc.getdeviceptr varPtr(%0 : !llvm.ptr) varType(i32) dataClause(acc_create) -> !llvm.ptr<0>
   acc.declare_exit dataOperands(%1 : !llvm.ptr)
   acc.delete accPtr(%1 : !llvm.ptr)
   acc.terminator
@@ -1786,7 +1786,7 @@ acc.global_dtor @acc_destructor {
 // CHECK-NEXT: acc.declare_enter dataOperands(%[[CREATE]] : !llvm.ptr)
 // CHECK: acc.global_dtor @acc_destructor
 // CHECK: %[[ADDR:.*]] = llvm.mlir.addressof @globalvar {acc.declare = #acc.declare<dataClause = acc_create>} : !llvm.ptr
-// CHECK-NEXT: %[[DELETE:.*]] = acc.getdeviceptr varPtr(%[[ADDR]] : !llvm.ptr) varType(i32) -> !llvm.ptr {dataClause = #acc<data_clause acc_create>}
+// CHECK-NEXT: %[[DELETE:.*]] = acc.getdeviceptr varPtr(%[[ADDR]] : !llvm.ptr) varType(i32) dataClause(acc_create) -> !llvm.ptr
 // CHECK-NEXT: acc.declare_exit dataOperands(%[[DELETE]] : !llvm.ptr)
 // CHECK-NEXT: acc.delete accPtr(%[[DELETE]] : !llvm.ptr)
 
@@ -1894,7 +1894,7 @@ func.func @compute3(%a: memref<10x10xf32>, %b: memref<10x10xf32>, %c: memref<10x
 
   %c20 = arith.constant 20 : i32
   %alloc = llvm.alloca %c20 x i32 { acc.declare = #acc.declare<dataClause = acc_create, implicit = true> } : (i32) -> !llvm.ptr
-  %createlocal = acc.create varPtr(%alloc : !llvm.ptr) varType(!llvm.array<20 x i32>) -> !llvm.ptr {implicit = true}
+  %createlocal = acc.create varPtr(%alloc : !llvm.ptr) varType(!llvm.array<20 x i32>) implicit(true) -> !llvm.ptr<0>
 
   %pa = acc.present varPtr(%a : memref<10x10xf32>) varType(tensor<10x10xf32>) -> memref<10x10xf32>
   %pb = acc.present varPtr(%b : memref<10x10xf32>) varType(tensor<10x10xf32>) -> memref<10x10xf32>
@@ -1916,7 +1916,7 @@ func.func @compute3(%a: memref<10x10xf32>, %b: memref<10x10xf32>, %c: memref<10x
 %i32Value2 = arith.constant 2 : i32
 %idxValue = arith.constant 1 : index
 %ifCond = arith.constant true
-acc.set attributes {device_type = #acc.device_type<nvidia>}
+acc.set device_type(#acc.device_type<nvidia>)
 acc.set device_num(%i64Value : i64)
 acc.set device_num(%i32Value : i32)
 acc.set device_num(%idxValue : index)
@@ -1928,7 +1928,7 @@ acc.set default_async(%i32Value : i32)
 // CHECK: [[I32VALUE2:%.*]] = arith.constant 2 : i32
 // CHECK: [[IDXVALUE:%.*]] = arith.constant 1 : index
 // CHECK: [[IFCOND:%.*]] = arith.constant true
-// CHECK: acc.set attributes {device_type = #acc.device_type<nvidia>}
+// CHECK: acc.set device_type(#acc.device_type<nvidia>)
 // CHECK: acc.set device_num([[I64VALUE]] : i64)
 // CHECK: acc.set device_num([[I32VALUE]] : i32)
 // CHECK: acc.set device_num([[IDXVALUE]] : index)
@@ -2142,21 +2142,21 @@ func.func @acc_combined() {
   acc.parallel combined(loop) {
     acc.loop combined(parallel) control(%arg3 : index) = (%c0 : index) to (%c10 : index) step (%c1 : index) {
       acc.yield
-    } attributes {independent = [#acc.device_type<none>]}
+    } independent
     acc.terminator
   }
 
   acc.kernels combined(loop) {
     acc.loop combined(kernels) control(%arg3 : index) = (%c0 : index) to (%c10 : index) step (%c1 : index) {
       acc.yield
-    } attributes {auto_ = [#acc.device_type<none>]}
+    } auto_
     acc.terminator
   }
 
   acc.serial combined(loop) {
     acc.loop combined(serial) control(%arg3 : index) = (%c0 : index) to (%c10 : index) step (%c1 : index) {
       acc.yield
-    } attributes {seq = [#acc.device_type<none>]}
+    } seq
     acc.terminator
   }
 
@@ -2286,7 +2286,7 @@ func.func @acc_loop_container() {
       scf.yield
     }
     acc.yield
-  } attributes {independent = [#acc.device_type<none>]}
+  } independent
   return
 }
 
@@ -2308,7 +2308,7 @@ func.func @acc_loop_container() {
       scf.yield
     }
     acc.yield
-  } attributes { collapse = [2], collapseDeviceType = [#acc.device_type<none>], independent = [#acc.device_type<none>]}
+  } collapse([2]) collapseDeviceType([#acc.device_type<none>]) independent
   return
 }
 
@@ -2322,14 +2322,14 @@ func.func @acc_loop_container() {
 func.func @acc_unstructured_loop() {
   acc.loop {
     acc.yield
-  } attributes {independent = [#acc.device_type<none>], unstructured}
+  } independent unstructured
   return
 }
 
 // CHECK-LABEL: func.func @acc_unstructured_loop
 // CHECK:       acc.loop
 // CHECK:         acc.yield
-// CHECK:       } attributes {independent = [#acc.device_type<none>], unstructured}
+// CHECK:       } independent unstructured
 
 // -----
 

--- a/mlir/test/Dialect/OpenACC/region-branchop-interface.mlir
+++ b/mlir/test/Dialect/OpenACC/region-branchop-interface.mlir
@@ -82,7 +82,7 @@ func.func @last_mod_openacc_data(%arg0: memref<f32>, %mapped: memref<f32>) -> me
   memref.load %arg0[] {tag = "acc_data_before"} : memref<f32>
   acc.data {
     acc.terminator
-  } attributes {defaultAttr = #acc<defaultvalue none>}
+  } defaultAttr(none)
   memref.load %arg0[] {tag = "acc_data_after"} : memref<f32>
   return %arg0 : memref<f32>
 }
@@ -141,7 +141,7 @@ func.func @last_mod_openacc_loop(%arg0: memref<f32>) -> memref<f32> {
     memref.store %one, %arg0[] {tag_name = "loop_region"} : memref<f32>
     memref.load %arg0[] {tag = "acc_loop_inside"} : memref<f32>
     acc.yield
-  } attributes {auto_ = [#acc.device_type<none>]}
+  } auto_
   memref.load %arg0[] {tag = "acc_loop_after"} : memref<f32>
   memref.store %zero, %arg0[] {tag_name = "post_loop"} : memref<f32>
   memref.load %arg0[] {tag = "acc_loop_post"} : memref<f32>
@@ -191,7 +191,7 @@ func.func @last_mod_openacc_loop_unstructured(%arg0: memref<f32>) -> memref<f32>
   ^normal_exit:
     memref.store %one, %arg0[] {tag_name = "loop_unstructured_normal"} : memref<f32>
     acc.yield
-  } attributes {auto_ = [#acc.device_type<none>], unstructured}
+  } auto_ unstructured
   memref.load %arg0[] {tag = "acc_loop_unstructured_after"} : memref<f32>
   return %arg0 : memref<f32>
 }

--- a/mlir/test/Dialect/OpenACC/support-analysis-varname.mlir
+++ b/mlir/test/Dialect/OpenACC/support-analysis-varname.mlir
@@ -76,7 +76,7 @@ func.func @test_copyin_name() {
   %0 = memref.alloca() : memref<10xf32>
 
   // Create an acc.copyin operation with a name
-  %1 = acc.copyin varPtr(%0 : memref<10xf32>) -> memref<10xf32> {name = "input_data"}
+  %1 = acc.copyin varPtr(%0 : memref<10xf32>) name("input_data") -> memref<10xf32>
 
   // Mark with test attribute - should find name from copyin operation
   %2 = memref.cast %1 {test.var_name} : memref<10xf32> to memref<?xf32>

--- a/mlir/test/python/dialects/openacc.py
+++ b/mlir/test/python/dialects/openacc.py
@@ -162,7 +162,7 @@ def testParallelMemcpy():
     # CHECK:               %[[LOAD_0:.*]] = memref.load %[[COPYIN_0]]{{\[}}%[[INDEX_CAST_0]]] : memref<?xf32>
     # CHECK:               memref.store %[[LOAD_0]], %[[CREATE_0]]{{\[}}%[[INDEX_CAST_0]]] : memref<?xf32>
     # CHECK:               acc.yield
-    # CHECK:             } attributes {independent = [#acc.device_type<none>]}
+    # CHECK:             } independent
     # CHECK:             acc.yield
     # CHECK:           }
     # CHECK:           acc.delete accPtr(%[[COPYIN_0]] : memref<?xf32>)


### PR DESCRIPTION
Enable strict property assembly format mode for the OpenACC dialect. Bind OpenACC operation properties directly in declarative assembly formats so the printed syntax stays explicit under strict parsing.

Add small OpenACC attribute helpers for direct loop property clauses, handle property-only dictionaries where direct bit-enum syntax is ambiguous, and update tests to use the strict property spelling.

Assisted-by: Codex