### PR TITLE
[MLIR][Func] Enable strict property assembly format

### DIFF
--- a/mlir/include/mlir/Dialect/Func/IR/FuncOps.td
+++ b/mlir/include/mlir/Dialect/Func/IR/FuncOps.td
@@ -121,13 +121,7 @@ def CallOp : Func_Op<"call",
   }];
 
   let assemblyFormat = [{
-    $callee `(` $operands `)`
-    oilist<`,`>(
-        `arg_attrs` `=` $arg_attrs
-      | `res_attrs` `=` $res_attrs
-      | `no_inline` $no_inline
-    )
-    attr-dict `:`
+    $callee `(` $operands `)` prop-dict attr-dict `:`
     functional-type($operands, results)
   }];
 }

--- a/mlir/include/mlir/Dialect/Func/IR/FuncOps.td
+++ b/mlir/include/mlir/Dialect/Func/IR/FuncOps.td
@@ -22,6 +22,7 @@ def Func_Dialect : Dialect {
   let name = "func";
   let cppNamespace = "::mlir::func";
   let hasConstantMaterializer = 1;
+  let useStrictPropertiesInAssemblyFormat = 1;
 }
 
 // Base class for Func dialect ops.
@@ -120,7 +121,14 @@ def CallOp : Func_Op<"call",
   }];
 
   let assemblyFormat = [{
-    $callee `(` $operands `)` attr-dict `:` functional-type($operands, results)
+    $callee `(` $operands `)`
+    oilist<`,`>(
+        `arg_attrs` `=` $arg_attrs
+      | `res_attrs` `=` $res_attrs
+      | `no_inline` $no_inline
+    )
+    attr-dict `:`
+    functional-type($operands, results)
   }];
 }
 
@@ -197,7 +205,12 @@ def CallIndirectOp : Func_Op<"call_indirect", [
 
   let hasCanonicalizeMethod = 1;
   let assemblyFormat = [{
-    $callee `(` $callee_operands `)` attr-dict `:` type($callee)
+    $callee `(` $callee_operands `)`
+    oilist<`,`>(
+        `arg_attrs` `=` $arg_attrs
+      | `res_attrs` `=` $res_attrs
+    )
+    attr-dict `:` type($callee)
   }];
 }
 

--- a/mlir/lib/Dialect/Func/IR/FuncOps.cpp
+++ b/mlir/lib/Dialect/Func/IR/FuncOps.cpp
@@ -90,10 +90,16 @@ LogicalResult CallIndirectOp::canonicalize(CallIndirectOp indirectCall,
   if (!matchPattern(indirectCall.getCallee(), m_Constant(&calledFn)))
     return failure();
 
-  // Replace with a direct call.
-  rewriter.replaceOpWithNewOp<CallOp>(indirectCall, calledFn,
-                                      indirectCall.getResultTypes(),
-                                      indirectCall.getArgOperands());
+  // Replace with a direct call, preserving the call-site attributes.
+  auto directCall = CallOp::create(rewriter, indirectCall.getLoc(), calledFn,
+                                   indirectCall.getResultTypes(),
+                                   indirectCall.getArgOperands());
+  if (ArrayAttr argAttrs = indirectCall.getArgAttrsAttr())
+    directCall.setArgAttrsAttr(argAttrs);
+  if (ArrayAttr resAttrs = indirectCall.getResAttrsAttr())
+    directCall.setResAttrsAttr(resAttrs);
+  directCall->setDiscardableAttrs(indirectCall->getDiscardableAttrDictionary());
+  rewriter.replaceOp(indirectCall, directCall.getResults());
   return success();
 }
 

--- a/mlir/lib/Dialect/Func/IR/FuncOps.cpp
+++ b/mlir/lib/Dialect/Func/IR/FuncOps.cpp
@@ -86,14 +86,17 @@ FunctionType CallOp::getCalleeType() {
 LogicalResult CallIndirectOp::canonicalize(CallIndirectOp indirectCall,
                                            PatternRewriter &rewriter) {
   // Check that the callee is a constant callee.
-  SymbolRefAttr calledFn;
+  FlatSymbolRefAttr calledFn;
   if (!matchPattern(indirectCall.getCallee(), m_Constant(&calledFn)))
     return failure();
 
-  // Replace with a direct call.
-  rewriter.replaceOpWithNewOp<CallOp>(indirectCall, calledFn,
-                                      indirectCall.getResultTypes(),
-                                      indirectCall.getArgOperands());
+  // Replace with a direct call, preserving the call-site attributes.
+  auto directCall = CallOp::create(
+      rewriter, indirectCall.getLoc(), indirectCall.getResultTypes(), calledFn,
+      indirectCall.getArgOperands(), indirectCall.getArgAttrsAttr(),
+      indirectCall.getResAttrsAttr());
+  directCall->setDiscardableAttrs(indirectCall->getDiscardableAttrDictionary());
+  rewriter.replaceOp(indirectCall, directCall.getResults());
   return success();
 }
 

--- a/mlir/test/Dialect/Bufferization/Transforms/one-shot-module-bufferize.mlir
+++ b/mlir/test/Dialect/Bufferization/Transforms/one-shot-module-bufferize.mlir
@@ -599,8 +599,8 @@ func.func @equivalent_func_arg(%t0: tensor<?xf32> {bufferization.writable = true
   // CHECK: scf.for {{.*}} iter_args(%[[t1:.*]] = %[[arg0]])
   %1 = scf.for %iv = %c0 to %c10 step %c1 iter_args(%t1 = %t0) -> (tensor<?xf32>) {
     // CHECK: call @inner_func(%[[t1]])
-    // INHERENT: call @inner_func({{.*}}) <no_inline = unit>
-    %3 = func.call @inner_func(%t1) <no_inline = unit> : (tensor<?xf32>) -> tensor<?xf32>
+    // INHERENT: call @inner_func({{.*}}) <no_inline>
+    %3 = func.call @inner_func(%t1) <no_inline> : (tensor<?xf32>) -> tensor<?xf32>
     // CHECK: scf.yield %[[t1]]
     scf.yield %3 : tensor<?xf32>
   }

--- a/mlir/test/Dialect/Bufferization/Transforms/one-shot-module-bufferize.mlir
+++ b/mlir/test/Dialect/Bufferization/Transforms/one-shot-module-bufferize.mlir
@@ -599,8 +599,8 @@ func.func @equivalent_func_arg(%t0: tensor<?xf32> {bufferization.writable = true
   // CHECK: scf.for {{.*}} iter_args(%[[t1:.*]] = %[[arg0]])
   %1 = scf.for %iv = %c0 to %c10 step %c1 iter_args(%t1 = %t0) -> (tensor<?xf32>) {
     // CHECK: call @inner_func(%[[t1]])
-    // INHERENT: call @inner_func({{.*}}) {no_inline}
-    %3 = func.call @inner_func(%t1) {no_inline} : (tensor<?xf32>) -> tensor<?xf32>
+    // INHERENT: call @inner_func({{.*}}) <{no_inline}>
+    %3 = func.call @inner_func(%t1) <{no_inline}> : (tensor<?xf32>) -> tensor<?xf32>
     // CHECK: scf.yield %[[t1]]
     scf.yield %3 : tensor<?xf32>
   }

--- a/mlir/test/Dialect/Bufferization/Transforms/one-shot-module-bufferize.mlir
+++ b/mlir/test/Dialect/Bufferization/Transforms/one-shot-module-bufferize.mlir
@@ -599,8 +599,8 @@ func.func @equivalent_func_arg(%t0: tensor<?xf32> {bufferization.writable = true
   // CHECK: scf.for {{.*}} iter_args(%[[t1:.*]] = %[[arg0]])
   %1 = scf.for %iv = %c0 to %c10 step %c1 iter_args(%t1 = %t0) -> (tensor<?xf32>) {
     // CHECK: call @inner_func(%[[t1]])
-    // INHERENT: call @inner_func({{.*}}) <{no_inline}>
-    %3 = func.call @inner_func(%t1) <{no_inline}> : (tensor<?xf32>) -> tensor<?xf32>
+    // INHERENT: call @inner_func({{.*}}) <no_inline = unit>
+    %3 = func.call @inner_func(%t1) <no_inline = unit> : (tensor<?xf32>) -> tensor<?xf32>
     // CHECK: scf.yield %[[t1]]
     scf.yield %3 : tensor<?xf32>
   }

--- a/mlir/test/IR/core-ops.mlir
+++ b/mlir/test/IR/core-ops.mlir
@@ -212,6 +212,14 @@ func.func @calls(%arg0: i32) {
   %5 = call_indirect %f_0(%arg0) res_attrs = [{test.res = 42 : i64}],
       arg_attrs = [{test.arg}] : (i32) -> i32
 
+  // CHECK: call @affine_apply() <arg_attrs = [], res_attrs = []>
+  // CHECK-SAME: {test.marker} : () -> ()
+  call @affine_apply() <arg_attrs = [], res_attrs = []> {test.marker} : () -> ()
+
+  // CHECK: call_indirect %f() arg_attrs = [], res_attrs = []
+  // CHECK-SAME: {test.marker} : () -> ()
+  call_indirect %f() arg_attrs = [], res_attrs = [] {test.marker} : () -> ()
+
   return
 }
 

--- a/mlir/test/IR/core-ops.mlir
+++ b/mlir/test/IR/core-ops.mlir
@@ -201,6 +201,18 @@ func.func @calls(%arg0: i32) {
   // CHECK: %4 = call_indirect %f_0(%arg0) : (i32) -> i32
   %3 = "func.call_indirect"(%f_0, %arg0) : ((i32) -> i32, i32) -> i32
 
+  // CHECK: %{{.*}} = call @return_op(%arg0)
+  // CHECK-SAME: arg_attrs = [{test.arg}],
+  // CHECK-SAME: res_attrs = [{test.res = 42 : i64}], no_inline : (i32) -> i32
+  %4 = call @return_op(%arg0) res_attrs = [{test.res = 42 : i64}],
+      no_inline, arg_attrs = [{test.arg}] : (i32) -> i32
+
+  // CHECK: %{{.*}} = call_indirect %f_0(%arg0)
+  // CHECK-SAME: arg_attrs = [{test.arg}],
+  // CHECK-SAME: res_attrs = [{test.res = 42 : i64}] : (i32) -> i32
+  %5 = call_indirect %f_0(%arg0) res_attrs = [{test.res = 42 : i64}],
+      arg_attrs = [{test.arg}] : (i32) -> i32
+
   return
 }
 

--- a/mlir/test/IR/core-ops.mlir
+++ b/mlir/test/IR/core-ops.mlir
@@ -201,11 +201,10 @@ func.func @calls(%arg0: i32) {
   // CHECK: %4 = call_indirect %f_0(%arg0) : (i32) -> i32
   %3 = "func.call_indirect"(%f_0, %arg0) : ((i32) -> i32, i32) -> i32
 
-  // CHECK: %{{.*}} = call @return_op(%arg0)
-  // CHECK-SAME: arg_attrs = [{test.arg}],
-  // CHECK-SAME: res_attrs = [{test.res = 42 : i64}], no_inline : (i32) -> i32
-  %4 = call @return_op(%arg0) res_attrs = [{test.res = 42 : i64}],
-      no_inline, arg_attrs = [{test.arg}] : (i32) -> i32
+  // CHECK: %{{.*}} = call @return_op(%arg0) <arg_attrs = [{test.arg}],
+  // CHECK-SAME: res_attrs = [{test.res = 42 : i64}], no_inline = unit> : (i32) -> i32
+  %4 = call @return_op(%arg0) <arg_attrs = [{test.arg}],
+      res_attrs = [{test.res = 42 : i64}], no_inline = unit> : (i32) -> i32
 
   // CHECK: %{{.*}} = call_indirect %f_0(%arg0)
   // CHECK-SAME: arg_attrs = [{test.arg}],

--- a/mlir/test/IR/core-ops.mlir
+++ b/mlir/test/IR/core-ops.mlir
@@ -202,9 +202,9 @@ func.func @calls(%arg0: i32) {
   %3 = "func.call_indirect"(%f_0, %arg0) : ((i32) -> i32, i32) -> i32
 
   // CHECK: %{{.*}} = call @return_op(%arg0) <arg_attrs = [{test.arg}],
-  // CHECK-SAME: res_attrs = [{test.res = 42 : i64}], no_inline = unit> : (i32) -> i32
+  // CHECK-SAME: res_attrs = [{test.res = 42 : i64}], no_inline> : (i32) -> i32
   %4 = call @return_op(%arg0) <arg_attrs = [{test.arg}],
-      res_attrs = [{test.res = 42 : i64}], no_inline = unit> : (i32) -> i32
+      res_attrs = [{test.res = 42 : i64}], no_inline> : (i32) -> i32
 
   // CHECK: %{{.*}} = call_indirect %f_0(%arg0)
   // CHECK-SAME: arg_attrs = [{test.arg}],

--- a/mlir/test/Transforms/canonicalize.mlir
+++ b/mlir/test/Transforms/canonicalize.mlir
@@ -587,6 +587,22 @@ func.func @indirect_call_folding() {
   return
 }
 
+func.func @attributed_indirect_target(%arg: i32) -> i32 {
+  return %arg : i32
+}
+
+// CHECK-LABEL: func @attributed_indirect_call_folding
+// CHECK-SAME: (%[[ARG:.*]]: i32)
+func.func @attributed_indirect_call_folding(%arg: i32) -> i32 {
+  // CHECK: %[[RESULT:.*]] = call @attributed_indirect_target(%[[ARG]])
+  // CHECK-SAME: <arg_attrs = [{test.arg}], res_attrs = [{test.res}]>
+  // CHECK-SAME: {test.discardable} : (i32) -> i32
+  %fn = constant @attributed_indirect_target : (i32) -> i32
+  %result = call_indirect %fn(%arg) arg_attrs = [{test.arg}],
+      res_attrs = [{test.res}] {test.discardable} : (i32) -> i32
+  return %result : i32
+}
+
 //
 // IMPORTANT NOTE: the operations in this test are exactly those produced by
 // lowering affine.apply affine_map<(i) -> (i mod 42)> to standard operations.  Please only

--- a/mlir/test/Transforms/inlining.mlir
+++ b/mlir/test/Transforms/inlining.mlir
@@ -28,7 +28,7 @@ func.func @noinline_with_arg(%arg0 : i32) -> i32 {
   // CHECK-NEXT: func_with_arg
   // CHECK-NEXT: return
 
-  %0 = call @func_with_arg(%arg0) no_inline : (i32) -> i32
+  %0 = call @func_with_arg(%arg0) <no_inline = unit> : (i32) -> i32
   return %0 : i32
 }
 

--- a/mlir/test/Transforms/inlining.mlir
+++ b/mlir/test/Transforms/inlining.mlir
@@ -28,7 +28,7 @@ func.func @noinline_with_arg(%arg0 : i32) -> i32 {
   // CHECK-NEXT: func_with_arg
   // CHECK-NEXT: return
 
-  %0 = call @func_with_arg(%arg0) {no_inline} : (i32) -> i32
+  %0 = call @func_with_arg(%arg0) no_inline : (i32) -> i32
   return %0 : i32
 }
 

--- a/mlir/test/Transforms/inlining.mlir
+++ b/mlir/test/Transforms/inlining.mlir
@@ -28,7 +28,7 @@ func.func @noinline_with_arg(%arg0 : i32) -> i32 {
   // CHECK-NEXT: func_with_arg
   // CHECK-NEXT: return
 
-  %0 = call @func_with_arg(%arg0) <no_inline = unit> : (i32) -> i32
+  %0 = call @func_with_arg(%arg0) <no_inline> : (i32) -> i32
   return %0 : i32
 }
 


### PR DESCRIPTION
Enable the strict properties assembly format mode for the Func dialect. Spell inherent call attributes directly in the call formats so they are no longer parsed from attr-dict in strict mode.

Assisted-by: Codex