### PR TITLE
ExpandIRInsts: Expand frem when the libcall is unavailable

### DIFF
--- a/llvm/lib/CodeGen/ExpandIRInsts.cpp
+++ b/llvm/lib/CodeGen/ExpandIRInsts.cpp
@@ -35,6 +35,7 @@
 #include "llvm/Analysis/ValueTracking.h"
 #include "llvm/CodeGen/ISDOpcodes.h"
 #include "llvm/CodeGen/Passes.h"
+#include "llvm/CodeGen/RuntimeLibcallUtil.h"
 #include "llvm/CodeGen/TargetLowering.h"
 #include "llvm/CodeGen/TargetPassConfig.h"
 #include "llvm/CodeGen/TargetSubtargetInfo.h"
@@ -229,24 +230,40 @@ public:
     return is_contained(ExpandableTypes, VT.getSimpleVT());
   }
 
-  static bool shouldExpandFremType(const TargetLowering &TLI, EVT VT) {
+  static bool shouldExpandFremType(const TargetLowering &TLI,
+                                   const LibcallLoweringInfo &Libcalls,
+                                   EVT VT) {
     assert(!VT.isVector() && "Cannot handle vector type; must scalarize first");
-    return TLI.getOperationAction(ISD::FREM, VT) ==
-           TargetLowering::LegalizeAction::Expand;
+    switch (TLI.getOperationAction(ISD::FREM, VT)) {
+    case TargetLowering::LegalizeAction::Expand:
+      return true;
+    case TargetLowering::LegalizeAction::LibCall:
+      // The target expects a libcall, but expand inline for the supported
+      // types when that libcall is unavailable.
+      return VT.isSimple() && is_contained(ExpandableTypes, VT.getSimpleVT()) &&
+             Libcalls.getLibcallImpl(RTLIB::getREM(VT)) == RTLIB::Unsupported;
+    default:
+      return false;
+    }
   }
 
-  static bool shouldExpandFremType(const TargetLowering &TLI, Type *Ty) {
+  static bool shouldExpandFremType(const TargetLowering &TLI,
+                                   const LibcallLoweringInfo &Libcalls,
+                                   Type *Ty) {
     // Consider scalar type for simplicity.  It seems unlikely that a
     // vector type can be legalized without expansion if the scalar
     // type cannot.
-    return shouldExpandFremType(TLI, EVT::getEVT(Ty->getScalarType()));
+    return shouldExpandFremType(TLI, Libcalls,
+                                EVT::getEVT(Ty->getScalarType()));
   }
 
   /// Return true if the pass should expand frem instructions of any type
   /// for the target represented by \p TLI.
-  static bool shouldExpandAnyFremType(const TargetLowering &TLI) {
-    return any_of(ExpandableTypes,
-                  [&](MVT V) { return shouldExpandFremType(TLI, EVT(V)); });
+  static bool shouldExpandAnyFremType(const TargetLowering &TLI,
+                                      const LibcallLoweringInfo &Libcalls) {
+    return any_of(ExpandableTypes, [&](MVT V) {
+      return shouldExpandFremType(TLI, Libcalls, EVT(V));
+    });
   }
 
   static FRemExpander create(IRBuilder<> &B, Type *Ty) {
@@ -1274,7 +1291,7 @@ static bool runImpl(Function &F, const TargetLowering &TLI,
       MaxLegalFpConvertBitWidth >= IntegerType::MAX_INT_BITS;
   bool DisableExpandLargeDivRem =
       MaxLegalDivRemBitWidth >= IntegerType::MAX_INT_BITS;
-  bool DisableFrem = !FRemExpander::shouldExpandAnyFremType(TLI);
+  bool DisableFrem = !FRemExpander::shouldExpandAnyFremType(TLI, Libcalls);
 
   if (DisableExpandLargeFp && DisableFrem && DisableExpandLargeDivRem)
     return false;
@@ -1287,7 +1304,8 @@ static bool runImpl(Function &F, const TargetLowering &TLI,
 
     switch (I.getOpcode()) {
     case Instruction::FRem:
-      return !DisableFrem && FRemExpander::shouldExpandFremType(TLI, Ty);
+      return !DisableFrem &&
+             FRemExpander::shouldExpandFremType(TLI, Libcalls, Ty);
     case Instruction::FPToUI:
     case Instruction::FPToSI:
       return !DisableExpandLargeFp &&

--- a/llvm/test/CodeGen/X86/expand-frem-no-libcall.ll
+++ b/llvm/test/CodeGen/X86/expand-frem-no-libcall.ll
@@ -1,0 +1,31 @@
+; This test underhandedly exploits a bug in llc's handling of -march.
+; The module ends up with no triple, and thus treated as unknown arch
+; with no library functions.
+
+; RUN: llc -march=x86-64 -stop-after=expand-ir-insts %s -o - | FileCheck --check-prefix=EXPAND %s
+; RUN: llc -mtriple=x86_64-linux-gnu -stop-after=expand-ir-insts %s -o - | FileCheck --check-prefix=LIBCALL %s
+
+; When the fmod libcall is unavailable, expand-ir-insts must expand
+; frem inline instead of leaving it for the DAG legalizer.
+
+; EXPAND-LABEL: define float @frem_f32
+; EXPAND-NOT: frem float
+; EXPAND: fmul float
+
+; LIBCALL-LABEL: define float @frem_f32
+; LIBCALL: frem float
+define float @frem_f32(float %a, float %b) {
+  %r = frem float %a, %b
+  ret float %r
+}
+
+; EXPAND-LABEL: define double @frem_f64
+; EXPAND-NOT: frem double
+; EXPAND: fmul double
+
+; LIBCALL-LABEL: define double @frem_f64
+; LIBCALL: frem double
+define double @frem_f64(double %a, double %b) {
+  %r = frem double %a, %b
+  ret double %r
+}


### PR DESCRIPTION
The legalizer actions have a distinct LibCall kind, separate
from Expand. If the target specifies LibCall, but the call is not
available, fall back to expand. The action is a fixed property
of the subtarget, but the library call availability in the future
will be program state that depends on module flags.

The test is underhanded and exploits a defect in llc's -march
flag handling. Since the library call set is computed from the Module's
triple, and the module has no triple, the computed libcall set is
empty for the apparently unknown arch. Any real triple will have
an frem call, so the only observable case is this buggy -march case.
In the future module flags will be able to remove the call from
the usable set.

Co-authored-by: Claude (Claude-Opus-4.8)