### PR TITLE
GlobalISel: Let m_GSExtInReg match its immediate with a sub-matcher

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/MIPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/MIPatternMatch.h
@@ -235,6 +235,29 @@ inline SpecificConstantMatch m_SpecificICst(int64_t RequestedValue) {
   return SpecificConstantMatch(APInt(64, RequestedValue, /* isSigned */ true));
 }
 
+struct SpecificImmMatch {
+  int64_t RequestedVal;
+  SpecificImmMatch(int64_t RequestedVal) : RequestedVal(RequestedVal) {}
+  bool match(int64_t Imm) const { return Imm == RequestedVal; }
+};
+
+/// Matches an immediate operand equal to \p RequestedValue.
+inline SpecificImmMatch m_SpecificImm(int64_t RequestedValue) {
+  return SpecificImmMatch(RequestedValue);
+}
+
+struct BindImmMatch {
+  int64_t &ImmOut;
+  BindImmMatch(int64_t &ImmOut) : ImmOut(ImmOut) {}
+  bool match(int64_t Imm) const {
+    ImmOut = Imm;
+    return true;
+  }
+};
+
+/// Binds an immediate operand's value.
+inline BindImmMatch m_Imm(int64_t &Imm) { return BindImmMatch(Imm); }
+
 /// Matcher for a specific constant splat.
 struct SpecificConstantSplatMatch {
   APInt RequestedVal;
@@ -948,25 +971,37 @@ m_GFPTrunc(const SrcTy &Src) {
   return UnaryOp_match<SrcTy, TargetOpcode::G_FPTRUNC>(Src);
 }
 
-/// Matches a G_SEXT_INREG, binding its source operand. G_SEXT_INREG has an
-/// extra immediate operand, so it does not fit the plain UnaryOp_match shape.
-template <typename SrcTy> struct SExtInRegMatch {
+/// Matches a G_SEXT_INREG, matching its source operand and immediate width with
+/// sub-matchers.
+template <typename SrcTy, typename ImmTy> struct SExtInRegMatch {
   SrcTy L;
+  ImmTy Imm;
 
-  SExtInRegMatch(const SrcTy &LHS) : L(LHS) {}
+  SExtInRegMatch(const SrcTy &LHS, const ImmTy &Imm) : L(LHS), Imm(Imm) {}
   template <typename OpTy>
   bool match(const MachineRegisterInfo &MRI, OpTy &&Op) {
     MachineInstr *TmpMI;
-    if (mi_match(Op, MRI, m_MInstr(TmpMI)) &&
-        TmpMI->getOpcode() == TargetOpcode::G_SEXT_INREG)
-      return L.match(MRI, TmpMI->getOperand(1).getReg());
-    return false;
+    return mi_match(Op, MRI, m_MInstr(TmpMI)) &&
+           TmpMI->getOpcode() == TargetOpcode::G_SEXT_INREG &&
+           L.match(MRI, TmpMI->getOperand(1).getReg()) &&
+           Imm.match(TmpMI->getOperand(2).getImm());
   }
 };
 
+/// Matches any immediate operand.
+struct AnyImmMatch {
+  bool match(int64_t) const { return true; }
+};
+
 template <typename SrcTy>
-inline SExtInRegMatch<SrcTy> m_GSExtInReg(const SrcTy &Src) {
-  return SExtInRegMatch<SrcTy>(Src);
+inline SExtInRegMatch<SrcTy, AnyImmMatch> m_GSExtInReg(const SrcTy &Src) {
+  return SExtInRegMatch<SrcTy, AnyImmMatch>(Src, AnyImmMatch());
+}
+
+template <typename SrcTy, typename ImmTy>
+inline SExtInRegMatch<SrcTy, ImmTy> m_GSExtInReg(const SrcTy &Src,
+                                                 const ImmTy &Imm) {
+  return SExtInRegMatch<SrcTy, ImmTy>(Src, Imm);
 }
 
 template <typename SrcTy>

--- a/llvm/lib/Target/RISCV/GISel/RISCVInstructionSelector.cpp
+++ b/llvm/lib/Target/RISCV/GISel/RISCVInstructionSelector.cpp
@@ -357,12 +357,11 @@ RISCVInstructionSelector::selectSExtBits(MachineOperand &Root,
   if (!Root.isReg())
     return std::nullopt;
   Register RootReg = Root.getReg();
-  MachineInstr *RootDef = MRI->getVRegDef(RootReg);
 
-  if (RootDef->getOpcode() == TargetOpcode::G_SEXT_INREG &&
-      RootDef->getOperand(2).getImm() == Bits) {
-    return {
-        {[=](MachineInstrBuilder &MIB) { MIB.add(RootDef->getOperand(1)); }}};
+  Register SrcReg;
+  if (mi_match(RootReg, *MRI,
+               m_GSExtInReg(m_Reg(SrcReg), m_SpecificImm(Bits)))) {
+    return {{[=](MachineInstrBuilder &MIB) { MIB.addReg(SrcReg); }}};
   }
 
   unsigned Size = MRI->getType(RootReg).getScalarSizeInBits();


### PR DESCRIPTION
Add m_SpecificImm/m_Imm literal-immediate operand matchers, and give
m_GSExtInReg an optional immediate sub-matcher argument instead of binding the
raw int64_t. The RISCV selectSExtBits complex renderer now matches the width
directly with m_SpecificImm(Bits). NFC.

Co-authored-by: Claude (Opus 4.8) <noreply@anthropic.com>