### PR TITLE
[AArch64][FastISel] Avoid TBZ with SLH more thoroughly.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64FastISel.cpp
+++ b/llvm/lib/Target/AArch64/AArch64FastISel.cpp
@@ -2483,6 +2483,11 @@ bool AArch64FastISel::selectBranch(const Instruction *I) {
     return false;
 
   // i1 conditions come as i32 values, test the lowest bit with tb(n)z.
+  // However, that's not allowed with SLH.
+  if (FuncInfo.MF->getFunction().hasFnAttribute(
+          Attribute::SpeculativeLoadHardening))
+    return false;
+
   unsigned Opcode = AArch64::TBNZW;
   if (FuncInfo.MBB->isLayoutSuccessor(TBB)) {
     std::swap(TBB, FBB);

--- a/llvm/test/CodeGen/AArch64/speculation-hardening.ll
+++ b/llvm/test/CodeGen/AArch64/speculation-hardening.ll
@@ -99,6 +99,20 @@ else:
   ret i32 %6
 }
 
+define i32 @test_branch_zero_i1(i32 %a0, i32 %a1, i32 %a2) SLHATTR {
+; CHECK-LABEL: test_branch_zero_i1
+  %tmp0 = trunc i32 %a2 to i1
+  br i1 %tmp0, label %then, label %else
+;SLH-NOT:   tb{{n?}}z
+;NOSLH:     tb{{n?}}z
+then:
+  %tmp1 = sdiv i32 5, %a1
+  ret i32 %tmp1
+else:
+  %tmp2 = sdiv i32 %a1, %a0
+  ret i32 %tmp2
+}
+
 define i32 @landingpad(i32 %l0, i32 %l1) SLHATTR personality ptr @__gxx_personality_v0 {
 ; CHECK-LABEL: landingpad
 entry:


### PR DESCRIPTION
With SpeculativeLoadHardening, we already avoid using cond-branch instructions that don't modify NZCV (CBZ, TBZ), since we rely on NZCV to propagate the speculative taint mask with CSEL later on.

However, in one case in FastISel, we still emit TBZ, ignoring SLH. Make it honor the SLH attribute like we do elsewhere.