### PR TITLE
[libc] Disable fenv tests that don't work in Arm/AArch64 softfp

### DIFF
--- a/libc/test/src/fenv/enabled_exceptions_test.cpp
+++ b/libc/test/src/fenv/enabled_exceptions_test.cpp
@@ -27,9 +27,7 @@ using LlvmLibcExceptionStatusTest = LIBC_NAMESPACE::testing::FEnvSafeTest;
 // This test enables an exception and verifies that raising that exception
 // triggers SIGFPE.
 TEST_F(LlvmLibcExceptionStatusTest, RaiseAndCrash) {
-#if (defined(LIBC_TARGET_ARCH_IS_AARCH64) ||                                   \
-     defined(LIBC_TARGET_ARCH_IS_ARM)) &&                                      \
-    !defined(__ARM_FP)
+#if defined(LIBC_TARGET_ARCH_IS_ANY_ARM) && !defined(__ARM_FP)
   // Unsupported: no fenv
 #else
   // TODO: Install a floating point exception handler and verify that the
@@ -67,5 +65,5 @@ TEST_F(LlvmLibcExceptionStatusTest, RaiseAndCrash) {
     LIBC_NAMESPACE::fputil::disable_except(FE_ALL_EXCEPT);
     ASSERT_EQ(LIBC_NAMESPACE::feclearexcept(FE_ALL_EXCEPT), 0);
   }
-#endif
+#endif // defined(LIBC_TARGET_ARCH_IS_ANY_ARM) && !defined(__ARM_FP)
 }

--- a/libc/test/src/fenv/enabled_exceptions_test.cpp
+++ b/libc/test/src/fenv/enabled_exceptions_test.cpp
@@ -27,6 +27,11 @@ using LlvmLibcExceptionStatusTest = LIBC_NAMESPACE::testing::FEnvSafeTest;
 // This test enables an exception and verifies that raising that exception
 // triggers SIGFPE.
 TEST_F(LlvmLibcExceptionStatusTest, RaiseAndCrash) {
+#if (defined(LIBC_TARGET_ARCH_IS_AARCH64) ||                                   \
+     defined(LIBC_TARGET_ARCH_IS_ARM)) &&                                      \
+    !defined(__ARM_FP)
+  // Unsupported: no fenv
+#else
   // TODO: Install a floating point exception handler and verify that the
   // the expected exception was raised. One will have to longjmp back from
   // that exception handler, so such a testing can be done after we have
@@ -62,4 +67,5 @@ TEST_F(LlvmLibcExceptionStatusTest, RaiseAndCrash) {
     LIBC_NAMESPACE::fputil::disable_except(FE_ALL_EXCEPT);
     ASSERT_EQ(LIBC_NAMESPACE::feclearexcept(FE_ALL_EXCEPT), 0);
   }
+#endif
 }

--- a/libc/test/src/fenv/exception_flags_test.cpp
+++ b/libc/test/src/fenv/exception_flags_test.cpp
@@ -22,9 +22,7 @@
 using LlvmLibcFEnvTest = LIBC_NAMESPACE::testing::FEnvSafeTest;
 
 TEST_F(LlvmLibcFEnvTest, GetSetTestExceptFlag) {
-#if (defined(LIBC_TARGET_ARCH_IS_AARCH64) ||                                   \
-     defined(LIBC_TARGET_ARCH_IS_ARM)) &&                                      \
-    !defined(__ARM_FP)
+#if defined(LIBC_TARGET_ARCH_IS_ANY_ARM) && !defined(__ARM_FP)
   // Unsupported: no fenv
 #else
   // We will disable all exceptions to prevent invocation of the exception
@@ -81,5 +79,5 @@ TEST_F(LlvmLibcFEnvTest, GetSetTestExceptFlag) {
   // When we set the flags and test, we should only see FE_INVALID.
   LIBC_NAMESPACE::fesetexceptflag(&invalid_flag, FE_ALL_EXCEPT);
   EXPECT_EQ(LIBC_NAMESPACE::fputil::test_except(FE_ALL_EXCEPT), FE_INVALID);
-#endif
+#endif // defined(LIBC_TARGET_ARCH_IS_ANY_ARM) && !defined(__ARM_FP)
 }

--- a/libc/test/src/fenv/exception_flags_test.cpp
+++ b/libc/test/src/fenv/exception_flags_test.cpp
@@ -22,6 +22,11 @@
 using LlvmLibcFEnvTest = LIBC_NAMESPACE::testing::FEnvSafeTest;
 
 TEST_F(LlvmLibcFEnvTest, GetSetTestExceptFlag) {
+#if (defined(LIBC_TARGET_ARCH_IS_AARCH64) ||                                   \
+     defined(LIBC_TARGET_ARCH_IS_ARM)) &&                                      \
+    !defined(__ARM_FP)
+  // Unsupported: no fenv
+#else
   // We will disable all exceptions to prevent invocation of the exception
   // handler.
   LIBC_NAMESPACE::fputil::disable_except(FE_ALL_EXCEPT);
@@ -76,4 +81,5 @@ TEST_F(LlvmLibcFEnvTest, GetSetTestExceptFlag) {
   // When we set the flags and test, we should only see FE_INVALID.
   LIBC_NAMESPACE::fesetexceptflag(&invalid_flag, FE_ALL_EXCEPT);
   EXPECT_EQ(LIBC_NAMESPACE::fputil::test_except(FE_ALL_EXCEPT), FE_INVALID);
+#endif
 }

--- a/libc/test/src/fenv/exception_status_test.cpp
+++ b/libc/test/src/fenv/exception_status_test.cpp
@@ -25,9 +25,7 @@
 using LlvmLibcExceptionStatusTest = LIBC_NAMESPACE::testing::FEnvSafeTest;
 
 TEST_F(LlvmLibcExceptionStatusTest, RaiseAndTest) {
-#if (defined(LIBC_TARGET_ARCH_IS_AARCH64) ||                                   \
-     defined(LIBC_TARGET_ARCH_IS_ARM)) &&                                      \
-    !defined(__ARM_FP)
+#if defined(LIBC_TARGET_ARCH_IS_ANY_ARM) && !defined(__ARM_FP)
   // Unsupported: no fenv
 #else
   // This test raises a set of exceptions and checks that the exception
@@ -154,5 +152,5 @@ TEST_F(LlvmLibcExceptionStatusTest, RaiseAndTest) {
   ASSERT_EQ(r, 0);
   s = LIBC_NAMESPACE::fetestexcept(ALL_EXCEPTS);
   ASSERT_EQ(s, ALL_EXCEPTS);
-#endif
+#endif // defined(LIBC_TARGET_ARCH_IS_ANY_ARM) && !defined(__ARM_FP)
 }

--- a/libc/test/src/fenv/exception_status_test.cpp
+++ b/libc/test/src/fenv/exception_status_test.cpp
@@ -25,6 +25,11 @@
 using LlvmLibcExceptionStatusTest = LIBC_NAMESPACE::testing::FEnvSafeTest;
 
 TEST_F(LlvmLibcExceptionStatusTest, RaiseAndTest) {
+#if (defined(LIBC_TARGET_ARCH_IS_AARCH64) ||                                   \
+     defined(LIBC_TARGET_ARCH_IS_ARM)) &&                                      \
+    !defined(__ARM_FP)
+  // Unsupported: no fenv
+#else
   // This test raises a set of exceptions and checks that the exception
   // status flags are updated. The intention is really not to invoke the
   // exception handler. Hence, we will disable all exceptions at the
@@ -149,4 +154,5 @@ TEST_F(LlvmLibcExceptionStatusTest, RaiseAndTest) {
   ASSERT_EQ(r, 0);
   s = LIBC_NAMESPACE::fetestexcept(ALL_EXCEPTS);
   ASSERT_EQ(s, ALL_EXCEPTS);
+#endif
 }

--- a/libc/test/src/fenv/feupdateenv_test.cpp
+++ b/libc/test/src/fenv/feupdateenv_test.cpp
@@ -18,9 +18,7 @@
 using LlvmLibcFEnvTest = LIBC_NAMESPACE::testing::FEnvSafeTest;
 
 TEST_F(LlvmLibcFEnvTest, UpdateEnvTest) {
-#if (defined(LIBC_TARGET_ARCH_IS_AARCH64) ||                                   \
-     defined(LIBC_TARGET_ARCH_IS_ARM)) &&                                      \
-    !defined(__ARM_FP)
+#if defined(LIBC_TARGET_ARCH_IS_ANY_ARM) && !defined(__ARM_FP)
   // Unsupported: no fenv
 #else
   LIBC_NAMESPACE::fputil::disable_except(FE_ALL_EXCEPT);
@@ -32,5 +30,5 @@ TEST_F(LlvmLibcFEnvTest, UpdateEnvTest) {
   ASSERT_EQ(LIBC_NAMESPACE::feupdateenv(&env), 0);
   ASSERT_EQ(LIBC_NAMESPACE::fputil::test_except(FE_INVALID | FE_INEXACT),
             FE_INVALID | FE_INEXACT);
-#endif
+#endif // defined(LIBC_TARGET_ARCH_IS_ANY_ARM) && !defined(__ARM_FP)
 }

--- a/libc/test/src/fenv/feupdateenv_test.cpp
+++ b/libc/test/src/fenv/feupdateenv_test.cpp
@@ -18,6 +18,11 @@
 using LlvmLibcFEnvTest = LIBC_NAMESPACE::testing::FEnvSafeTest;
 
 TEST_F(LlvmLibcFEnvTest, UpdateEnvTest) {
+#if (defined(LIBC_TARGET_ARCH_IS_AARCH64) ||                                   \
+     defined(LIBC_TARGET_ARCH_IS_ARM)) &&                                      \
+    !defined(__ARM_FP)
+  // Unsupported: no fenv
+#else
   LIBC_NAMESPACE::fputil::disable_except(FE_ALL_EXCEPT);
   LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);
 
@@ -27,4 +32,5 @@ TEST_F(LlvmLibcFEnvTest, UpdateEnvTest) {
   ASSERT_EQ(LIBC_NAMESPACE::feupdateenv(&env), 0);
   ASSERT_EQ(LIBC_NAMESPACE::fputil::test_except(FE_INVALID | FE_INEXACT),
             FE_INVALID | FE_INEXACT);
+#endif
 }

--- a/libc/test/src/fenv/getenv_and_setenv_test.cpp
+++ b/libc/test/src/fenv/getenv_and_setenv_test.cpp
@@ -24,9 +24,7 @@
 using LlvmLibcFEnvTest = LIBC_NAMESPACE::testing::FEnvSafeTest;
 
 TEST_F(LlvmLibcFEnvTest, GetEnvAndSetEnv) {
-#if (defined(LIBC_TARGET_ARCH_IS_AARCH64) ||                                   \
-     defined(LIBC_TARGET_ARCH_IS_ARM)) &&                                      \
-    !defined(__ARM_FP)
+#if defined(LIBC_TARGET_ARCH_IS_ANY_ARM) && !defined(__ARM_FP)
   // Unsupported: no fenv
 #else
   // We will disable all exceptions to prevent invocation of the exception
@@ -47,13 +45,11 @@ TEST_F(LlvmLibcFEnvTest, GetEnvAndSetEnv) {
     ASSERT_EQ(LIBC_NAMESPACE::fesetenv(&env), 0);
     ASSERT_EQ(LIBC_NAMESPACE::fputil::test_except(FE_ALL_EXCEPT) & e, 0);
   }
-#endif
+#endif // defined(LIBC_TARGET_ARCH_IS_ANY_ARM) && !defined(__ARM_FP)
 }
 
 TEST_F(LlvmLibcFEnvTest, Set_FE_DFL_ENV) {
-#if (defined(LIBC_TARGET_ARCH_IS_AARCH64) ||                                   \
-     defined(LIBC_TARGET_ARCH_IS_ARM)) &&                                      \
-    !defined(__ARM_FP)
+#if defined(LIBC_TARGET_ARCH_IS_ANY_ARM) && !defined(__ARM_FP)
   // Unsupported: no fenv
 #else
   // We will disable all exceptions to prevent invocation of the exception
@@ -84,5 +80,5 @@ TEST_F(LlvmLibcFEnvTest, Set_FE_DFL_ENV) {
   // Setting the default env should set rounding mode to FE_TONEAREST.
   int rm = LIBC_NAMESPACE::fegetround();
   EXPECT_EQ(rm, FE_TONEAREST);
-#endif
+#endif // defined(LIBC_TARGET_ARCH_IS_ANY_ARM) && !defined(__ARM_FP)
 }

--- a/libc/test/src/fenv/getenv_and_setenv_test.cpp
+++ b/libc/test/src/fenv/getenv_and_setenv_test.cpp
@@ -24,6 +24,11 @@
 using LlvmLibcFEnvTest = LIBC_NAMESPACE::testing::FEnvSafeTest;
 
 TEST_F(LlvmLibcFEnvTest, GetEnvAndSetEnv) {
+#if (defined(LIBC_TARGET_ARCH_IS_AARCH64) ||                                   \
+     defined(LIBC_TARGET_ARCH_IS_ARM)) &&                                      \
+    !defined(__ARM_FP)
+  // Unsupported: no fenv
+#else
   // We will disable all exceptions to prevent invocation of the exception
   // handler.
   LIBC_NAMESPACE::fputil::disable_except(FE_ALL_EXCEPT);
@@ -42,9 +47,15 @@ TEST_F(LlvmLibcFEnvTest, GetEnvAndSetEnv) {
     ASSERT_EQ(LIBC_NAMESPACE::fesetenv(&env), 0);
     ASSERT_EQ(LIBC_NAMESPACE::fputil::test_except(FE_ALL_EXCEPT) & e, 0);
   }
+#endif
 }
 
 TEST_F(LlvmLibcFEnvTest, Set_FE_DFL_ENV) {
+#if (defined(LIBC_TARGET_ARCH_IS_AARCH64) ||                                   \
+     defined(LIBC_TARGET_ARCH_IS_ARM)) &&                                      \
+    !defined(__ARM_FP)
+  // Unsupported: no fenv
+#else
   // We will disable all exceptions to prevent invocation of the exception
   // handler.
   LIBC_NAMESPACE::fputil::disable_except(FE_ALL_EXCEPT);
@@ -73,4 +84,5 @@ TEST_F(LlvmLibcFEnvTest, Set_FE_DFL_ENV) {
   // Setting the default env should set rounding mode to FE_TONEAREST.
   int rm = LIBC_NAMESPACE::fegetround();
   EXPECT_EQ(rm, FE_TONEAREST);
+#endif
 }

--- a/libc/test/src/fenv/rounding_mode_test.cpp
+++ b/libc/test/src/fenv/rounding_mode_test.cpp
@@ -17,9 +17,7 @@
 using LlvmLibcRoundingModeTest = LIBC_NAMESPACE::testing::FEnvSafeTest;
 
 TEST_F(LlvmLibcRoundingModeTest, SetAndGet) {
-#if (defined(LIBC_TARGET_ARCH_IS_AARCH64) ||                                   \
-     defined(LIBC_TARGET_ARCH_IS_ARM)) &&                                      \
-    !defined(__ARM_FP)
+#if defined(LIBC_TARGET_ARCH_IS_ANY_ARM) && !defined(__ARM_FP)
   // Unsupported: no fenv
 #else
   struct ResetDefaultRoundingMode {
@@ -46,5 +44,5 @@ TEST_F(LlvmLibcRoundingModeTest, SetAndGet) {
   EXPECT_EQ(s, 0);
   rm = LIBC_NAMESPACE::fegetround();
   EXPECT_EQ(rm, FE_TOWARDZERO);
-#endif
+#endif // defined(LIBC_TARGET_ARCH_IS_ANY_ARM) && !defined(__ARM_FP)
 }

--- a/libc/test/src/fenv/rounding_mode_test.cpp
+++ b/libc/test/src/fenv/rounding_mode_test.cpp
@@ -17,6 +17,11 @@
 using LlvmLibcRoundingModeTest = LIBC_NAMESPACE::testing::FEnvSafeTest;
 
 TEST_F(LlvmLibcRoundingModeTest, SetAndGet) {
+#if (defined(LIBC_TARGET_ARCH_IS_AARCH64) ||                                   \
+     defined(LIBC_TARGET_ARCH_IS_ARM)) &&                                      \
+    !defined(__ARM_FP)
+  // Unsupported: no fenv
+#else
   struct ResetDefaultRoundingMode {
     int original = LIBC_NAMESPACE::fegetround();
     ~ResetDefaultRoundingMode() { LIBC_NAMESPACE::fesetround(original); }
@@ -41,4 +46,5 @@ TEST_F(LlvmLibcRoundingModeTest, SetAndGet) {
   EXPECT_EQ(s, 0);
   rm = LIBC_NAMESPACE::fegetround();
   EXPECT_EQ(rm, FE_TOWARDZERO);
+#endif
 }


### PR DESCRIPTION
The fenv tests do not work in Arm and AArch64 without proper floating point environment support.

This patch adds preprocessor directives that effectively disable the tests in this case.