### PR TITLE
[gn] Make GlobalISel depend on SelectionDAG

### DIFF
--- a/llvm/utils/gn/secondary/llvm/lib/CodeGen/GlobalISel/BUILD.gn
+++ b/llvm/utils/gn/secondary/llvm/lib/CodeGen/GlobalISel/BUILD.gn
@@ -5,6 +5,7 @@ static_library("GlobalISel") {
     "//llvm/include/llvm/Config:llvm-config",
     "//llvm/lib/Analysis",
     "//llvm/lib/CodeGen",
+    "//llvm/lib/CodeGen/SelectionDAG",
     "//llvm/lib/IR",
     "//llvm/lib/MC",
     "//llvm/lib/Support",


### PR DESCRIPTION
This dependency has been present in the CMake build for many years. Suddenly, a bunch of binaries (e.g. llvm-extract) stopped linking without it, so add it to the GN build too.