### PR TITLE
[clang][Sema] Warn on explicit conversion functions in C++20 with -Wc++98-compat

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -400,6 +400,9 @@ features cannot lower the translation-unit ABI level;
   for pointer arithmetic on statically-sized arrays when the offset is a
   non-negative constant within the array bounds.
 
+- `-Wc++98-compat` now diagnoses explicit conversion functions in C++20 and
+  later, matching the behavior in C++11 through C++17. (#GH161689)
+
 ### Improvements to Clang's time-trace
 
 ### Improvements to Coverage Mapping

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -11613,7 +11613,7 @@ void Sema::CheckConversionDeclarator(Declarator &D, QualType &R,
     R = Context.getFunctionType(ConvType, {}, Proto->getExtProtoInfo());
 
   // C++0x explicit conversion operators.
-  if (DS.hasExplicitSpecifier() && !getLangOpts().CPlusPlus20)
+  if (DS.hasExplicitSpecifier())
     Diag(DS.getExplicitSpecLoc(),
          getLangOpts().CPlusPlus11
              ? diag::warn_cxx98_compat_explicit_conversion_functions

--- a/clang/test/SemaCXX/cxx98-compat.cpp
+++ b/clang/test/SemaCXX/cxx98-compat.cpp
@@ -227,8 +227,7 @@ void TrivialButNonPODThroughEllipsis() {
 }
 
 struct HasExplicitConversion {
-  // FIXME I think we should generate this diagnostic in C++20
-  explicit operator bool(); // not-cpp20-warning {{explicit conversion functions are incompatible with C++98}}
+  explicit operator bool(); // expected-warning {{explicit conversion functions are incompatible with C++98}}
 };
 
 struct Struct {};


### PR DESCRIPTION
The explicit(bool) patch (76b9027f352a) added a `!getLangOpts().CPlusPlus20` guard here, so this                              `-Wc++98-compat` warning stopped firing in C++20 and later. C++11 through C++17 still warn, and the test even has a FIXME asking for the warning in C++20.

Drop the guard so every mode behaves the same, update the test, and remove the FIXME.

Fixes #161689