### PR TITLE
[mlir][linalg] Preserve operand casts when vectorizing 1-D convolutions

### DIFF
--- a/mlir/lib/Dialect/Linalg/Transforms/Vectorization.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/Vectorization.cpp
@@ -3642,16 +3642,15 @@ public:
         .getOperation();
   }
 
-  // Take a value and widen to have the same element type as `ty`.
-  Value promote(RewriterBase &rewriter, Location loc, Value val, Type ty) {
-    const Type srcElementType = getElementTypeOrSelf(val.getType());
+  // Promote `val` to the element type of `ty` using `castOp`.
+  Value promote(RewriterBase &rewriter, Location loc, Value val, Type ty,
+                Operation *castOp) {
     const Type dstElementType = getElementTypeOrSelf(ty);
-    assert(isa<IntegerType>(dstElementType) || isa<FloatType>(dstElementType));
-    if (srcElementType == dstElementType)
+    if (getElementTypeOrSelf(val.getType()) == dstElementType)
       return val;
 
-    const int64_t srcWidth = srcElementType.getIntOrFloatBitWidth();
-    const int64_t dstWidth = dstElementType.getIntOrFloatBitWidth();
+    assert(castOp && "expected a payload cast for promoted operand");
+
     // Handle both shaped as well as scalar types.
     Type dstType;
     if (auto shapedType = dyn_cast<ShapedType>(val.getType()))
@@ -3659,20 +3658,10 @@ public:
     else
       dstType = dstElementType;
 
-    if (isa<IntegerType>(srcElementType) && isa<FloatType>(dstElementType)) {
-      return arith::SIToFPOp::create(rewriter, loc, dstType, val);
-    }
-
-    if (isa<FloatType>(srcElementType) && isa<FloatType>(dstElementType) &&
-        srcWidth < dstWidth)
-      return arith::ExtFOp::create(rewriter, loc, dstType, val);
-
-    if (isa<IntegerType>(srcElementType) && isa<IntegerType>(dstElementType) &&
-        srcWidth < dstWidth)
-      return arith::ExtSIOp::create(rewriter, loc, dstType, val);
-
-    assert(false && "unhandled promotion case");
-    return nullptr;
+    return rewriter
+        .create(loc, castOp->getName().getIdentifier(), val, dstType,
+                castOp->getAttrs())
+        ->getResult(0);
   }
 
   // Create a contraction: lhs{n, w, c} * rhs{c, f} -> res{n, w, f}
@@ -3682,8 +3671,8 @@ public:
     vector::IteratorType red = vector::IteratorType::reduction;
     AffineExpr n, w, f, c;
     bindDims(ctx, n, w, f, c);
-    lhs = promote(rewriter, loc, lhs, res.getType());
-    rhs = promote(rewriter, loc, rhs, res.getType());
+    lhs = promote(rewriter, loc, lhs, res.getType(), lhsCastOp);
+    rhs = promote(rewriter, loc, rhs, res.getType(), rhsCastOp);
     auto contrationOp = vector::ContractionOp::create(
         rewriter, loc, lhs, rhs, res,
         /*indexingMaps=*/MapList{{n, w, c}, {c, f}, {n, w, f}},
@@ -3696,8 +3685,8 @@ public:
   // convolution.
   Value conv1dSliceAsOuterProduct(RewriterBase &rewriter, Location loc,
                                   Value lhs, Value rhs, Value res) {
-    lhs = promote(rewriter, loc, lhs, res.getType());
-    rhs = promote(rewriter, loc, rhs, res.getType());
+    lhs = promote(rewriter, loc, lhs, res.getType(), lhsCastOp);
+    rhs = promote(rewriter, loc, rhs, res.getType(), rhsCastOp);
     return vector::OuterProductOp::create(rewriter, loc, res.getType(), lhs,
                                           rhs, res, vector::CombiningKind::ADD);
   }
@@ -3926,7 +3915,7 @@ public:
     auto resTy = cast<ShapedType>(res.getType());
 
     // TODO(suderman): Change this to use a vector.ima intrinsic.
-    lhs = promote(rewriter, loc, lhs, resTy);
+    lhs = promote(rewriter, loc, lhs, resTy, lhsCastOp);
 
     if (flatten) {
       // NOTE: This following logic won't work for scalable vectors. For this
@@ -3952,7 +3941,7 @@ public:
     rhs = vector::BroadcastOp::create(rewriter, loc,
                                       resTy.clone(rhsTy.getElementType()), rhs);
 
-    rhs = promote(rewriter, loc, rhs, resTy);
+    rhs = promote(rewriter, loc, rhs, resTy, rhsCastOp);
 
     if (!lhs || !rhs)
       return nullptr;
@@ -4077,12 +4066,17 @@ private:
   StringAttr redOp;
   StringAttr poolExtOp;
   bool isPoolExt = false;
+  // Casts used to widen the convolution payload's lhs and rhs. These are null
+  // only when the corresponding operand already has the accumulator type.
+  Operation *lhsCastOp = nullptr;
+  Operation *rhsCastOp = nullptr;
   int strideW, dilationW;
   Value lhsShaped, rhsShaped, resShaped;
   ShapedType lhsShapedType, rhsShapedType, resShapedType;
   vector::CombiningKind reductionKind;
 
-  // Sets oper, poolExtOp and isPoolExt for valid conv/pooling ops.
+  // Sets oper, poolExtOp, isPoolExt and the conv operand casts for valid
+  // conv/pooling ops.
   void setConvOperationKind(Operation *reduceOp) {
     int numBlockArguments =
         llvm::count_if(reduceOp->getOperands(), llvm::IsaPred<BlockArgument>);
@@ -4101,11 +4095,18 @@ private:
         return;
       }
       oper = ConvOperationKind::Conv;
+      setConvCastOps(feedOp);
       return;
     }
     // numBlockArugments == 2 and this is a pooling op.
     oper = ConvOperationKind::Pool;
     isPoolExt = false;
+  }
+
+  // Record the casts applied to the input and filter.
+  void setConvCastOps(Operation *feedOp) {
+    lhsCastOp = feedOp->getOperand(0).getDefiningOp();
+    rhsCastOp = feedOp->getOperand(1).getDefiningOp();
   }
 };
 } // namespace

--- a/mlir/test/Dialect/Linalg/vectorization/convolution-with-patterns.mlir
+++ b/mlir/test/Dialect/Linalg/vectorization/convolution-with-patterns.mlir
@@ -905,6 +905,47 @@ module attributes {transform.with_named_sequence} {
 
 // -----
 
+// Preserve the signedness of casts in a generic convolution payload.
+func.func @generic_conv_1d_nwc_wcf_unsigned_input_memref(%input: memref<1x2x3xi8>, %filter: memref<1x3x2xi8>, %output: memref<1x2x2xi32>) {
+  linalg.generic {
+    indexing_maps = [affine_map<(n, ow, f, kw, c) -> (n, ow + kw, c)>,
+                     affine_map<(n, ow, f, kw, c) -> (kw, c, f)>,
+                     affine_map<(n, ow, f, kw, c) -> (n, ow, f)>],
+    iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction"]}
+    ins(%input, %filter : memref<1x2x3xi8>, memref<1x3x2xi8>)
+    outs(%output : memref<1x2x2xi32>) {
+  ^bb0(%in: i8, %flt: i8, %out: i32):
+    %lhs = arith.extui %in : i8 to i32
+    %rhs = arith.extsi %flt : i8 to i32
+    %mul = arith.muli %lhs, %rhs : i32
+    %add = arith.addi %out, %mul : i32
+    linalg.yield %add : i32
+  }
+  return
+}
+
+// CHECK-LABEL: func @generic_conv_1d_nwc_wcf_unsigned_input_memref
+// CHECK-SAME:   (%[[INPUT:[0-9a-z]+]]: memref<1x2x3xi8>, %[[FILTER:[0-9a-z]+]]: memref<1x3x2xi8>, %[[OUTPUT:[0-9a-z]+]]: memref<1x2x2xi32>)
+// CHECK: %[[READ0:.+]] = vector.transfer_read %[[INPUT]]
+// CHECK: %[[READ1:.+]] = vector.transfer_read %[[FILTER]]
+// CHECK: %[[READ2:.+]] = vector.transfer_read %[[OUTPUT]]
+// CHECK: %[[EXT:.+]] = vector.extract %[[READ1]][0] : vector<3x2xi8> from vector<1x3x2xi8>
+// CHECK: %[[CAST0:.+]] = arith.extui %[[READ0]] : vector<1x2x3xi8> to vector<1x2x3xi32>
+// CHECK: %[[CAST1:.+]] = arith.extsi %[[EXT]] : vector<3x2xi8> to vector<3x2xi32>
+// CHECK: %[[CONTRACT:.+]] = vector.contract {{.*}} %[[CAST0]], %[[CAST1]], %[[READ2]]
+// CHECK: vector.transfer_write %[[CONTRACT]], %[[OUTPUT]]
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %1 = transform.get_parent_op %0 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+    %2 = transform.structured.vectorize_children_and_apply_patterns %1 : (!transform.any_op) -> !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
 func.func @pooling_nwc_sum_memref_1_2_1_3(%input: memref<4x4x3xf32>, %filter: memref<1xf32>, %output: memref<4x2x3xf32>) {
   linalg.pooling_nwc_sum
     {dilations = dense<1> : tensor<1xi64>, strides = dense<3> : tensor<1xi64>}


### PR DESCRIPTION
The 1-D convolution vectorizer previously inferred operand promotions from their source and accumulator types. This caused unsigned extensions in `linalg.generic` payloads to be emitted as signed extensions in the vectorized operation.

Record the casts applied to the input and filter operands and replay them when promoting their vector values. This preserves the cast operation instead of inferring the conversion.

Assisted by: Claude