### PR TITLE
[MLIR][OpenMP] Add verifier to prevent illegal omp.critical nesting

### DIFF
--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
@@ -1790,6 +1790,8 @@ def CriticalOp : OpenMP_Op<"critical", [
   let assemblyFormat = [{
     (`(` $name^ `)`)? $region attr-dict
   }];
+
+  let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
+++ b/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
@@ -4828,6 +4828,31 @@ LogicalResult CriticalDeclareOp::verify() {
   return verifySynchronizationHint(*this, getHint());
 }
 
+LogicalResult CriticalOp::verify() {
+  SymbolRefAttr currentName = getNameAttr();
+
+  CriticalOp parentCritical = (*this)->getParentOfType<CriticalOp>();
+
+  while (parentCritical) {
+    SymbolRefAttr parentName = parentCritical.getNameAttr();
+
+    if (currentName == parentName) {
+      if (currentName) {
+        return emitOpError() << "cannot be nested inside another omp.critical "
+                                "region with the same name ("
+                             << currentName << ")";
+      } else {
+        return emitOpError() << "cannot be nested inside another unnamed "
+                                "omp.critical region";
+      }
+    }
+
+    parentCritical = parentCritical->getParentOfType<CriticalOp>();
+  }
+
+  return success();
+}
+
 LogicalResult CriticalOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   if (getNameAttr()) {
     SymbolRefAttr symbolRef = getNameAttr();

--- a/mlir/test/Dialect/OpenMP/invalid_critical.mlir
+++ b/mlir/test/Dialect/OpenMP/invalid_critical.mlir
@@ -1,0 +1,80 @@
+// RUN: mlir-opt -split-input-file -verify-diagnostics %s
+
+func.func @nested_unnamed_critical() {
+  omp.critical {
+    // expected-error @below {{cannot be nested inside another unnamed omp.critical region}}
+    omp.critical {
+      omp.terminator
+    }
+    omp.terminator
+  }
+  return
+}
+
+// -----
+
+omp.critical.declare @my_mutex
+
+func.func @nested_named_critical() {
+  omp.critical(@my_mutex) {
+    // expected-error @below {{cannot be nested inside another omp.critical region with the same name (@my_mutex)}}
+    omp.critical(@my_mutex) {
+      omp.terminator
+    }
+    omp.terminator
+  }
+  return
+}
+
+// -----
+
+omp.critical.declare @my_mutex
+
+func.func @nested_named_critical_indirect() {
+  omp.critical(@my_mutex) {
+    omp.single {
+      // expected-error @below {{cannot be nested inside another omp.critical region with the same name (@my_mutex)}}
+      omp.critical(@my_mutex) {
+        omp.terminator
+      }
+      omp.terminator
+    }
+    omp.terminator
+  }
+  return
+}
+
+// -----
+
+omp.critical.declare @my_mutex_A
+omp.critical.declare @my_mutex_B
+
+func.func @nested_named_critical_interleaved() {
+  omp.critical(@my_mutex_A) {
+    omp.critical(@my_mutex_B) {
+      // expected-error @below {{cannot be nested inside another omp.critical region with the same name (@my_mutex_A)}}
+      omp.critical(@my_mutex_A) {
+        omp.terminator
+      }
+      omp.terminator
+    }
+    omp.terminator
+  }
+  return
+}
+
+// -----
+
+omp.critical.declare @my_mutex_outer
+omp.critical.declare @my_mutex_inner
+
+func.func @nested_critical_different_names() {
+  omp.critical(@my_mutex_outer) {
+    // Valid: Names are different.
+    omp.critical(@my_mutex_inner) {
+      omp.terminator
+    }
+    omp.terminator
+  }
+  return
+}


### PR DESCRIPTION
This PR adds missing verification to `omp.critical` to prevent illegal nesting of critical sections. Previously, the missing check allowed invalid OpenMP programs to compile successfully.

Fixes #217354 

Changes:
- Added a verifier check to CriticalOp to ensure it is not illegally nested within another CriticalOp with the same name.
- Added mlir-opt expected-error tests to catch the malformed IR.

@tblah, @skatrak: Requesting a review for this OpenMP verifier addition.