### PR TITLE
[Clang][RISC-V] Warn on duplicate interrupt attribute types

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -565,6 +565,9 @@ features cannot lower the translation-unit ABI level;
 - Fixed a bug where the `interrupt` attribute did not accept `machine` together
   with both `SiFive-CLIC-preemptible` and `SiFive-CLIC-stack-swap`.
 
+- Added a new warning when the same interrupt type is specified more than
+  once in a RISC-V `interrupt` attribute.
+
 - Added `-march=native` for better compatibility with ARM, AArch64, and X86. This
   option will be treated like `-mcpu=native` if `-mcpu` is not present. If
   `-mcpu` is present, the ISA will be selected from the host CPU and the tune

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -13680,7 +13680,7 @@ def err_riscv_type_requires_extension : Error<
 def err_riscv_attribute_interrupt_requires_extension : Error<
   "RISC-V 'interrupt' attribute '%0' requires extension '%1'">;
 def warn_riscv_attribute_interrupt_duplicate_type : Warning<
-  "RISC-V 'interrupt' attribute type '%0' cannot be specified more than once">,
+  "RISC-V 'interrupt' attribute type '%0' specified more than once">,
   InGroup<DiagGroup<"duplicate-interrupt-type">>;
 def err_riscv_attribute_interrupt_invalid_combination : Error<
   "RISC-V 'interrupt' attribute contains invalid combination of interrupt types">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -13680,7 +13680,8 @@ def err_riscv_type_requires_extension : Error<
 def err_riscv_attribute_interrupt_requires_extension : Error<
   "RISC-V 'interrupt' attribute '%0' requires extension '%1'">;
 def warn_riscv_attribute_interrupt_duplicate_type : Warning<
-  "RISC-V 'interrupt' attribute type '%0' cannot be specified more than once">;
+  "RISC-V 'interrupt' attribute type '%0' cannot be specified more than once">,
+  InGroup<DiagGroup<"duplicate-interrupt-type">>;
 def err_riscv_attribute_interrupt_invalid_combination : Error<
   "RISC-V 'interrupt' attribute contains invalid combination of interrupt types">;
 def err_riscv_builtin_invalid_twiden : Error<"RISC-V XSfmm twiden must be 1, 2 or 4">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -13679,6 +13679,8 @@ def err_riscv_type_requires_extension : Error<
   "RISC-V type %0 requires the '%1' extension">;
 def err_riscv_attribute_interrupt_requires_extension : Error<
   "RISC-V 'interrupt' attribute '%0' requires extension '%1'">;
+def warn_riscv_attribute_interrupt_duplicate_type : Warning<
+  "RISC-V 'interrupt' attribute type '%0' cannot be specified more than once">;
 def err_riscv_attribute_interrupt_invalid_combination : Error<
   "RISC-V 'interrupt' attribute contains invalid combination of interrupt types">;
 def err_riscv_builtin_invalid_twiden : Error<"RISC-V XSfmm twiden must be 1, 2 or 4">;

--- a/clang/lib/Sema/SemaRISCV.cpp
+++ b/clang/lib/Sema/SemaRISCV.cpp
@@ -1646,6 +1646,7 @@ void SemaRISCV::handleInterruptAttr(Decl *D, const ParsedAttr &AL) {
 
   bool HasSiFiveCLICType = false;
   bool HasUnaryType = false;
+  bool ReportedDuplicateType = false;
 
   SmallSet<RISCVInterruptAttr::InterruptType, 3> Types;
   for (unsigned ArgIndex = 0; ArgIndex < AL.getNumArgs(); ++ArgIndex) {
@@ -1683,7 +1684,11 @@ void SemaRISCV::handleInterruptAttr(Decl *D, const ParsedAttr &AL) {
       break;
     }
 
-    Types.insert(Type);
+    if (!Types.insert(Type).second && !ReportedDuplicateType) {
+      Diag(Loc, diag::warn_riscv_attribute_interrupt_duplicate_type)
+          << TypeString;
+      ReportedDuplicateType = true;
+    }
   }
 
   if (HasUnaryType && Types.size() > 1) {

--- a/clang/test/Sema/riscv-interrupt-attr-qci.c
+++ b/clang/test/Sema/riscv-interrupt-attr-qci.c
@@ -36,13 +36,13 @@ __attribute__((interrupt("qci-nest", "qci-nonest"))) void foo_nest5(void) {} // 
 __attribute__((interrupt("qci-nest"))) void foo_nest(void) {} // disabled-error {{RISC-V 'interrupt' attribute 'qci-nest' requires extension 'Xqciint'}}
 __attribute__((interrupt("qci-nonest"))) void foo_nonest(void) {} // disabled-error {{RISC-V 'interrupt' attribute 'qci-nonest' requires extension 'Xqciint'}}
 
-__attribute__((interrupt("qci-nest", "qci-nest"))) void foo_nest_nest(void) {} // both-warning {{RISC-V 'interrupt' attribute type 'qci-nest' cannot be specified more than once}} \
+__attribute__((interrupt("qci-nest", "qci-nest"))) void foo_nest_nest(void) {} // both-warning {{RISC-V 'interrupt' attribute type 'qci-nest' specified more than once}} \
   // disabled-error {{RISC-V 'interrupt' attribute 'qci-nest' requires extension 'Xqciint'}}
-__attribute__((interrupt("qci-nonest", "qci-nonest"))) void foo_nonest_nonest(void) {} // both-warning {{RISC-V 'interrupt' attribute type 'qci-nonest' cannot be specified more than once}} \
+__attribute__((interrupt("qci-nonest", "qci-nonest"))) void foo_nonest_nonest(void) {} // both-warning {{RISC-V 'interrupt' attribute type 'qci-nonest' specified more than once}} \
   // disabled-error {{RISC-V 'interrupt' attribute 'qci-nonest' requires extension 'Xqciint'}}
-__attribute__((interrupt("qci-nest", "qci-nest", "qci-nest"))) void foo_nest_nest_nest(void) {} // both-warning {{RISC-V 'interrupt' attribute type 'qci-nest' cannot be specified more than once}} \
+__attribute__((interrupt("qci-nest", "qci-nest", "qci-nest"))) void foo_nest_nest_nest(void) {} // both-warning {{RISC-V 'interrupt' attribute type 'qci-nest' specified more than once}} \
   // disabled-error {{RISC-V 'interrupt' attribute 'qci-nest' requires extension 'Xqciint'}}
-__attribute__((interrupt("qci-nonest", "qci-nonest", "qci-nonest"))) void foo_nonest_nonest_nonest(void) {} // both-warning {{RISC-V 'interrupt' attribute type 'qci-nonest' cannot be specified more than once}} \
+__attribute__((interrupt("qci-nonest", "qci-nonest", "qci-nonest"))) void foo_nonest_nonest_nonest(void) {} // both-warning {{RISC-V 'interrupt' attribute type 'qci-nonest' specified more than once}} \
   // disabled-error {{RISC-V 'interrupt' attribute 'qci-nonest' requires extension 'Xqciint'}}
 
 

--- a/clang/test/Sema/riscv-interrupt-attr-qci.c
+++ b/clang/test/Sema/riscv-interrupt-attr-qci.c
@@ -11,30 +11,10 @@
 __attribute__((interrupt("qci-nest")))
 void foo_nest_interrupt(void) {}
 
-// CHECK-LABEL: @foo_nest_nest_interrupt() #0
-// CHECK: ret void
-__attribute__((interrupt("qci-nest", "qci-nest")))
-void foo_nest_nest_interrupt(void) {}
-
-// CHECK-LABEL: @foo_nest_nest_nest_interrupt() #0
-// CHECK: ret void
-__attribute__((interrupt("qci-nest", "qci-nest", "qci-nest")))
-void foo_nest_nest_nest_interrupt(void) {}
-
 // CHECK-LABEL: @foo_nonest_interrupt() #1
 // CHECK: ret void
 __attribute__((interrupt("qci-nonest")))
 void foo_nonest_interrupt(void) {}
-
-// CHECK-LABEL: @foo_nonest_nonest_interrupt() #1
-// CHECK: ret void
-__attribute__((interrupt("qci-nonest", "qci-nonest")))
-void foo_nonest_nonest_interrupt(void) {}
-
-// CHECK-LABEL: @foo_nonest_nonest_nonest_interrupt() #1
-// CHECK: ret void
-__attribute__((interrupt("qci-nonest", "qci-nonest", "qci-nonest")))
-void foo_nonest_nonest_nonest_interrupt(void) {}
 
 // CHECK: attributes #0
 // CHECK: "interrupt"="qci-nest"
@@ -56,10 +36,14 @@ __attribute__((interrupt("qci-nest", "qci-nonest"))) void foo_nest5(void) {} // 
 __attribute__((interrupt("qci-nest"))) void foo_nest(void) {} // disabled-error {{RISC-V 'interrupt' attribute 'qci-nest' requires extension 'Xqciint'}}
 __attribute__((interrupt("qci-nonest"))) void foo_nonest(void) {} // disabled-error {{RISC-V 'interrupt' attribute 'qci-nonest' requires extension 'Xqciint'}}
 
-__attribute__((interrupt("qci-nest", "qci-nest"))) void foo_nest_nest(void) {} // disabled-error {{RISC-V 'interrupt' attribute 'qci-nest' requires extension 'Xqciint'}}
-__attribute__((interrupt("qci-nonest", "qci-nonest"))) void foo_nonest_nonest(void) {} // disabled-error {{RISC-V 'interrupt' attribute 'qci-nonest' requires extension 'Xqciint'}}
-__attribute__((interrupt("qci-nest", "qci-nest", "qci-nest"))) void foo_nest_nest_nest(void) {} // disabled-error {{RISC-V 'interrupt' attribute 'qci-nest' requires extension 'Xqciint'}}
-__attribute__((interrupt("qci-nonest", "qci-nonest", "qci-nonest"))) void foo_nonest_nonest_nonest(void) {} // disabled-error {{RISC-V 'interrupt' attribute 'qci-nonest' requires extension 'Xqciint'}}
+__attribute__((interrupt("qci-nest", "qci-nest"))) void foo_nest_nest(void) {} // both-warning {{RISC-V 'interrupt' attribute type 'qci-nest' cannot be specified more than once}} \
+  // disabled-error {{RISC-V 'interrupt' attribute 'qci-nest' requires extension 'Xqciint'}}
+__attribute__((interrupt("qci-nonest", "qci-nonest"))) void foo_nonest_nonest(void) {} // both-warning {{RISC-V 'interrupt' attribute type 'qci-nonest' cannot be specified more than once}} \
+  // disabled-error {{RISC-V 'interrupt' attribute 'qci-nonest' requires extension 'Xqciint'}}
+__attribute__((interrupt("qci-nest", "qci-nest", "qci-nest"))) void foo_nest_nest_nest(void) {} // both-warning {{RISC-V 'interrupt' attribute type 'qci-nest' cannot be specified more than once}} \
+  // disabled-error {{RISC-V 'interrupt' attribute 'qci-nest' requires extension 'Xqciint'}}
+__attribute__((interrupt("qci-nonest", "qci-nonest", "qci-nonest"))) void foo_nonest_nonest_nonest(void) {} // both-warning {{RISC-V 'interrupt' attribute type 'qci-nonest' cannot be specified more than once}} \
+  // disabled-error {{RISC-V 'interrupt' attribute 'qci-nonest' requires extension 'Xqciint'}}
 
 
 // This tests the errors for the qci interrupts when using

--- a/clang/test/Sema/riscv-interrupt-attr-rnmi.c
+++ b/clang/test/Sema/riscv-interrupt-attr-rnmi.c
@@ -14,9 +14,9 @@ void foo_rnmi_interrupt(void) {}
 #else
 
 __attribute__((interrupt("rnmi"))) void test_rnmi(void) {} // disabled-error {{RISC-V 'interrupt' attribute 'rnmi' requires extension 'Smrnmi'}}
-__attribute__((interrupt("rnmi", "rnmi"))) void test_rnmi_rnmi(void) {} // both-warning {{RISC-V 'interrupt' attribute type 'rnmi' cannot be specified more than once}} \
+__attribute__((interrupt("rnmi", "rnmi"))) void test_rnmi_rnmi(void) {} // both-warning {{RISC-V 'interrupt' attribute type 'rnmi' specified more than once}} \
   // disabled-error {{RISC-V 'interrupt' attribute 'rnmi' requires extension 'Smrnmi'}}
-__attribute__((interrupt("rnmi", "rnmi", "rnmi"))) void test_rnmi_rnmi_rnmi(void) {} // both-warning {{RISC-V 'interrupt' attribute type 'rnmi' cannot be specified more than once}} \
+__attribute__((interrupt("rnmi", "rnmi", "rnmi"))) void test_rnmi_rnmi_rnmi(void) {} // both-warning {{RISC-V 'interrupt' attribute type 'rnmi' specified more than once}} \
   // disabled-error {{RISC-V 'interrupt' attribute 'rnmi' requires extension 'Smrnmi'}}
 
 __attribute__((interrupt("rnmi", "supervisor"))) void foo_rnmi_supervisor(void) {}  // both-error {{RISC-V 'interrupt' attribute contains invalid combination of interrupt types}}

--- a/clang/test/Sema/riscv-interrupt-attr-rnmi.c
+++ b/clang/test/Sema/riscv-interrupt-attr-rnmi.c
@@ -9,23 +9,15 @@
 __attribute__((interrupt("rnmi")))
 void foo_rnmi_interrupt(void) {}
 
-// CHECK-LABEL: @foo_rnmi_rnmi_interrupt() #0
-// CHECK: ret void
-__attribute__((interrupt("rnmi", "rnmi")))
-void foo_rnmi_rnmi_interrupt(void) {}
-
-// CHECK-LABEL: @foo_rnmi_rnmi_rnmi_interrupt() #0
-// CHECK: ret void
-__attribute__((interrupt("rnmi", "rnmi", "rnmi")))
-void foo_rnmi_rnmi_rnmi_interrupt(void) {}
-
 // CHECK: attributes #0
 // CHECK: "interrupt"="rnmi"
 #else
 
 __attribute__((interrupt("rnmi"))) void test_rnmi(void) {} // disabled-error {{RISC-V 'interrupt' attribute 'rnmi' requires extension 'Smrnmi'}}
-__attribute__((interrupt("rnmi", "rnmi"))) void test_rnmi_rnmi(void) {} // disabled-error {{RISC-V 'interrupt' attribute 'rnmi' requires extension 'Smrnmi'}}
-__attribute__((interrupt("rnmi", "rnmi", "rnmi"))) void test_rnmi_rnmi_rnmi(void) {} // disabled-error {{RISC-V 'interrupt' attribute 'rnmi' requires extension 'Smrnmi'}}
+__attribute__((interrupt("rnmi", "rnmi"))) void test_rnmi_rnmi(void) {} // both-warning {{RISC-V 'interrupt' attribute type 'rnmi' cannot be specified more than once}} \
+  // disabled-error {{RISC-V 'interrupt' attribute 'rnmi' requires extension 'Smrnmi'}}
+__attribute__((interrupt("rnmi", "rnmi", "rnmi"))) void test_rnmi_rnmi_rnmi(void) {} // both-warning {{RISC-V 'interrupt' attribute type 'rnmi' cannot be specified more than once}} \
+  // disabled-error {{RISC-V 'interrupt' attribute 'rnmi' requires extension 'Smrnmi'}}
 
 __attribute__((interrupt("rnmi", "supervisor"))) void foo_rnmi_supervisor(void) {}  // both-error {{RISC-V 'interrupt' attribute contains invalid combination of interrupt types}}
 __attribute__((interrupt("rnmi", "machine"))) void foo_rnmi_machine(void) {}  // both-error {{RISC-V 'interrupt' attribute contains invalid combination of interrupt types}}

--- a/clang/test/Sema/riscv-interrupt-attr-sifive.c
+++ b/clang/test/Sema/riscv-interrupt-attr-sifive.c
@@ -26,16 +26,6 @@ void foo_stack_swap_preemptible(void) {}
 __attribute__((interrupt("SiFive-CLIC-preemptible", "SiFive-CLIC-stack-swap")))
 void foo_preemptible_stack_swap(void) {}
 
-// CHECK-LABEL:  @foo_stack_swap_repeat() #0
-// CHECK: ret void
-__attribute__((interrupt("SiFive-CLIC-stack-swap", "SiFive-CLIC-stack-swap")))
-void foo_stack_swap_repeat(void) {}
-
-// CHECK-LABEL:  @foo_preemptible_repeat() #1
-// CHECK: ret void
-__attribute__((interrupt("SiFive-CLIC-preemptible", "SiFive-CLIC-preemptible")))
-void foo_preemptible_repeat(void) {}
-
 // CHECK-LABEL:  @foo_machine_stack_swap() #0
 // CHECK: ret void
 __attribute__((interrupt("machine", "SiFive-CLIC-stack-swap")))
@@ -77,12 +67,14 @@ void foo_preemptible_stack_swap_machine(void) {}
 #else
 
 __attribute__((interrupt("SiFive-CLIC-stack-swap"))) void foo15(void); // disabled-error {{RISC-V 'interrupt' attribute 'SiFive-CLIC-stack-swap' requires extension 'XSfmclic'}}
-__attribute__((interrupt("SiFive-CLIC-stack-swap", "SiFive-CLIC-stack-swap"))) void foo15(void); // disabled-error {{RISC-V 'interrupt' attribute 'SiFive-CLIC-stack-swap' requires extension 'XSfmclic'}}
+__attribute__((interrupt("SiFive-CLIC-stack-swap", "SiFive-CLIC-stack-swap"))) void foo15(void); // both-warning {{RISC-V 'interrupt' attribute type 'SiFive-CLIC-stack-swap' cannot be specified more than once}} \
+  // disabled-error {{RISC-V 'interrupt' attribute 'SiFive-CLIC-stack-swap' requires extension 'XSfmclic'}}
 __attribute__((interrupt("SiFive-CLIC-stack-swap", "machine"))) void foo15(void); // disabled-error {{RISC-V 'interrupt' attribute 'SiFive-CLIC-stack-swap' requires extension 'XSfmclic'}}
 __attribute__((interrupt("machine", "SiFive-CLIC-stack-swap"))) void foo15(void); // disabled-error {{RISC-V 'interrupt' attribute 'SiFive-CLIC-stack-swap' requires extension 'XSfmclic'}}
 
 __attribute__((interrupt("SiFive-CLIC-preemptible"))) void foo15(void); // disabled-error {{RISC-V 'interrupt' attribute 'SiFive-CLIC-preemptible' requires extension 'XSfmclic'}}
-__attribute__((interrupt("SiFive-CLIC-preemptible", "SiFive-CLIC-preemptible"))) void foo15(void); // disabled-error {{RISC-V 'interrupt' attribute 'SiFive-CLIC-preemptible' requires extension 'XSfmclic'}}
+__attribute__((interrupt("SiFive-CLIC-preemptible", "SiFive-CLIC-preemptible"))) void foo15(void); // both-warning {{RISC-V 'interrupt' attribute type 'SiFive-CLIC-preemptible' cannot be specified more than once}} \
+  // disabled-error {{RISC-V 'interrupt' attribute 'SiFive-CLIC-preemptible' requires extension 'XSfmclic'}}
 __attribute__((interrupt("SiFive-CLIC-preemptible", "machine"))) void foo15(void); // disabled-error {{RISC-V 'interrupt' attribute 'SiFive-CLIC-preemptible' requires extension 'XSfmclic'}}
 __attribute__((interrupt("machine", "SiFive-CLIC-preemptible"))) void foo15(void); // disabled-error {{RISC-V 'interrupt' attribute 'SiFive-CLIC-preemptible' requires extension 'XSfmclic'}}
 
@@ -90,7 +82,8 @@ __attribute__((interrupt("SiFive-CLIC-preemptible", "SiFive-CLIC-stack-swap"))) 
 __attribute__((interrupt("SiFive-CLIC-stack-swap", "SiFive-CLIC-preemptible"))) void foo17(void) {} // disabled-error {{RISC-V 'interrupt' attribute 'SiFive-CLIC-stack-swap' requires extension 'XSfmclic'}}
 __attribute__((interrupt("machine", "SiFive-CLIC-stack-swap", "SiFive-CLIC-preemptible"))) void foo18(void) {} // disabled-error {{requires extension 'XSfmclic'}}
 
-__attribute__((interrupt("machine", "machine", "SiFive-CLIC-preemptible"))) void foo24(void) {} // disabled-error {{requires extension 'XSfmclic'}}
+__attribute__((interrupt("machine", "machine", "SiFive-CLIC-preemptible"))) void foo24(void) {} // both-warning {{RISC-V 'interrupt' attribute type 'machine' cannot be specified more than once}} \
+  // disabled-error {{requires extension 'XSfmclic'}}
 __attribute__((interrupt("machine", "machine", "SiFive-CLIC-preemptible", "SiFive-CLIC-stack-swap"))) void foo25(void) {} // both-error {{'interrupt' attribute takes no more than 3 arguments}}
 
 __attribute__((interrupt("SiFive-CLIC-preemptible", "supervisor"))) void foo27(void) {} // both-error {{RISC-V 'interrupt' attribute contains invalid combination of interrupt types}}

--- a/clang/test/Sema/riscv-interrupt-attr-sifive.c
+++ b/clang/test/Sema/riscv-interrupt-attr-sifive.c
@@ -67,13 +67,13 @@ void foo_preemptible_stack_swap_machine(void) {}
 #else
 
 __attribute__((interrupt("SiFive-CLIC-stack-swap"))) void foo15(void); // disabled-error {{RISC-V 'interrupt' attribute 'SiFive-CLIC-stack-swap' requires extension 'XSfmclic'}}
-__attribute__((interrupt("SiFive-CLIC-stack-swap", "SiFive-CLIC-stack-swap"))) void foo15(void); // both-warning {{RISC-V 'interrupt' attribute type 'SiFive-CLIC-stack-swap' cannot be specified more than once}} \
+__attribute__((interrupt("SiFive-CLIC-stack-swap", "SiFive-CLIC-stack-swap"))) void foo15(void); // both-warning {{RISC-V 'interrupt' attribute type 'SiFive-CLIC-stack-swap' specified more than once}} \
   // disabled-error {{RISC-V 'interrupt' attribute 'SiFive-CLIC-stack-swap' requires extension 'XSfmclic'}}
 __attribute__((interrupt("SiFive-CLIC-stack-swap", "machine"))) void foo15(void); // disabled-error {{RISC-V 'interrupt' attribute 'SiFive-CLIC-stack-swap' requires extension 'XSfmclic'}}
 __attribute__((interrupt("machine", "SiFive-CLIC-stack-swap"))) void foo15(void); // disabled-error {{RISC-V 'interrupt' attribute 'SiFive-CLIC-stack-swap' requires extension 'XSfmclic'}}
 
 __attribute__((interrupt("SiFive-CLIC-preemptible"))) void foo15(void); // disabled-error {{RISC-V 'interrupt' attribute 'SiFive-CLIC-preemptible' requires extension 'XSfmclic'}}
-__attribute__((interrupt("SiFive-CLIC-preemptible", "SiFive-CLIC-preemptible"))) void foo15(void); // both-warning {{RISC-V 'interrupt' attribute type 'SiFive-CLIC-preemptible' cannot be specified more than once}} \
+__attribute__((interrupt("SiFive-CLIC-preemptible", "SiFive-CLIC-preemptible"))) void foo15(void); // both-warning {{RISC-V 'interrupt' attribute type 'SiFive-CLIC-preemptible' specified more than once}} \
   // disabled-error {{RISC-V 'interrupt' attribute 'SiFive-CLIC-preemptible' requires extension 'XSfmclic'}}
 __attribute__((interrupt("SiFive-CLIC-preemptible", "machine"))) void foo15(void); // disabled-error {{RISC-V 'interrupt' attribute 'SiFive-CLIC-preemptible' requires extension 'XSfmclic'}}
 __attribute__((interrupt("machine", "SiFive-CLIC-preemptible"))) void foo15(void); // disabled-error {{RISC-V 'interrupt' attribute 'SiFive-CLIC-preemptible' requires extension 'XSfmclic'}}
@@ -82,7 +82,7 @@ __attribute__((interrupt("SiFive-CLIC-preemptible", "SiFive-CLIC-stack-swap"))) 
 __attribute__((interrupt("SiFive-CLIC-stack-swap", "SiFive-CLIC-preemptible"))) void foo17(void) {} // disabled-error {{RISC-V 'interrupt' attribute 'SiFive-CLIC-stack-swap' requires extension 'XSfmclic'}}
 __attribute__((interrupt("machine", "SiFive-CLIC-stack-swap", "SiFive-CLIC-preemptible"))) void foo18(void) {} // disabled-error {{requires extension 'XSfmclic'}}
 
-__attribute__((interrupt("machine", "machine", "SiFive-CLIC-preemptible"))) void foo24(void) {} // both-warning {{RISC-V 'interrupt' attribute type 'machine' cannot be specified more than once}} \
+__attribute__((interrupt("machine", "machine", "SiFive-CLIC-preemptible"))) void foo24(void) {} // both-warning {{RISC-V 'interrupt' attribute type 'machine' specified more than once}} \
   // disabled-error {{requires extension 'XSfmclic'}}
 __attribute__((interrupt("machine", "machine", "SiFive-CLIC-preemptible", "SiFive-CLIC-stack-swap"))) void foo25(void) {} // both-error {{'interrupt' attribute takes no more than 3 arguments}}
 

--- a/clang/test/Sema/riscv-interrupt-attr.c
+++ b/clang/test/Sema/riscv-interrupt-attr.c
@@ -42,7 +42,7 @@ struct a test __attribute__((interrupt)); // expected-warning {{'interrupt' attr
 __attribute__((interrupt)) int foo3(void) {return 0;} // expected-warning {{RISC-V 'interrupt' attribute only applies to functions that have a 'void' return type}}
 __attribute__((interrupt())) void foo5(int a) {} // expected-warning {{RISC-V 'interrupt' attribute only applies to functions that have no parameters}}
 
-__attribute__((interrupt("machine", "supervisor", "machine"))) void foo15(void) {} // expected-warning {{RISC-V 'interrupt' attribute type 'machine' cannot be specified more than once}} \
+__attribute__((interrupt("machine", "supervisor", "machine"))) void foo15(void) {} // expected-warning {{RISC-V 'interrupt' attribute type 'machine' specified more than once}} \
   // expected-error {{RISC-V 'interrupt' attribute contains invalid combination of interrupt types}}
 
 __attribute__((interrupt("machine", "machine", "machine", "machine"))) void foo_too_many_args(void) {} // expected-error {{'interrupt' attribute takes no more than 3 arguments}}
@@ -69,10 +69,10 @@ __attribute__((interrupt("machine"))) void foo12(void) {}
 __attribute__((interrupt())) void foo13(void) {}
 __attribute__((interrupt)) void foo14(void) {}
 
-__attribute__((interrupt("machine", "machine"))) void foo_machine_twice(void) {} // expected-warning {{RISC-V 'interrupt' attribute type 'machine' cannot be specified more than once}}
-__attribute__((interrupt("supervisor", "supervisor"))) void foo_supervisor_supervisor(void) {} // expected-warning {{RISC-V 'interrupt' attribute type 'supervisor' cannot be specified more than once}}
-__attribute__((interrupt("machine", "machine", "machine"))) void foo_three_machine_args(void) {} // expected-warning {{RISC-V 'interrupt' attribute type 'machine' cannot be specified more than once}}
-__attribute__((interrupt("supervisor", "supervisor", "supervisor"))) void foo_three_supervisor_args(void) {} // expected-warning {{RISC-V 'interrupt' attribute type 'supervisor' cannot be specified more than once}}
+__attribute__((interrupt("machine", "machine"))) void foo_machine_twice(void) {} // expected-warning {{RISC-V 'interrupt' attribute type 'machine' specified more than once}}
+__attribute__((interrupt("supervisor", "supervisor"))) void foo_supervisor_supervisor(void) {} // expected-warning {{RISC-V 'interrupt' attribute type 'supervisor' specified more than once}}
+__attribute__((interrupt("machine", "machine", "machine"))) void foo_three_machine_args(void) {} // expected-warning {{RISC-V 'interrupt' attribute type 'machine' specified more than once}}
+__attribute__((interrupt("supervisor", "supervisor", "supervisor"))) void foo_three_supervisor_args(void) {} // expected-warning {{RISC-V 'interrupt' attribute type 'supervisor' specified more than once}}
 
 
 #endif

--- a/clang/test/Sema/riscv-interrupt-attr.c
+++ b/clang/test/Sema/riscv-interrupt-attr.c
@@ -42,7 +42,8 @@ struct a test __attribute__((interrupt)); // expected-warning {{'interrupt' attr
 __attribute__((interrupt)) int foo3(void) {return 0;} // expected-warning {{RISC-V 'interrupt' attribute only applies to functions that have a 'void' return type}}
 __attribute__((interrupt())) void foo5(int a) {} // expected-warning {{RISC-V 'interrupt' attribute only applies to functions that have no parameters}}
 
-__attribute__((interrupt("machine", "supervisor", "machine"))) void foo15(void) {} // expected-error {{RISC-V 'interrupt' attribute contains invalid combination of interrupt types}}
+__attribute__((interrupt("machine", "supervisor", "machine"))) void foo15(void) {} // expected-warning {{RISC-V 'interrupt' attribute type 'machine' cannot be specified more than once}} \
+  // expected-error {{RISC-V 'interrupt' attribute contains invalid combination of interrupt types}}
 
 __attribute__((interrupt("machine", "machine", "machine", "machine"))) void foo_too_many_args(void) {} // expected-error {{'interrupt' attribute takes no more than 3 arguments}}
 
@@ -68,10 +69,10 @@ __attribute__((interrupt("machine"))) void foo12(void) {}
 __attribute__((interrupt())) void foo13(void) {}
 __attribute__((interrupt)) void foo14(void) {}
 
-__attribute__((interrupt("machine", "machine"))) void foo_machine_twice(void) {}
-__attribute__((interrupt("supervisor", "supervisor"))) void foo_supervisor_supervisor(void) {}
-__attribute__((interrupt("machine", "machine", "machine"))) void foo_three_machine_args(void) {}
-__attribute__((interrupt("supervisor", "supervisor", "supervisor"))) void foo_three_supervisor_args(void) {}
+__attribute__((interrupt("machine", "machine"))) void foo_machine_twice(void) {} // expected-warning {{RISC-V 'interrupt' attribute type 'machine' cannot be specified more than once}}
+__attribute__((interrupt("supervisor", "supervisor"))) void foo_supervisor_supervisor(void) {} // expected-warning {{RISC-V 'interrupt' attribute type 'supervisor' cannot be specified more than once}}
+__attribute__((interrupt("machine", "machine", "machine"))) void foo_three_machine_args(void) {} // expected-warning {{RISC-V 'interrupt' attribute type 'machine' cannot be specified more than once}}
+__attribute__((interrupt("supervisor", "supervisor", "supervisor"))) void foo_three_supervisor_args(void) {} // expected-warning {{RISC-V 'interrupt' attribute type 'supervisor' cannot be specified more than once}}
 
 
 #endif


### PR DESCRIPTION
The RISC-V interrupt attribute previously accepted the same type more than once. This commit emits a warning instead (since a duplicate is almost certainly a mistake).

The warning is emitted at most once per attribute and is controlled by the new `-Wduplicate-interrupt-type` flag. 

Follow up of #216159