### PR TITLE
[PowerPC][ReleaseNotes] Add PowerPC-related release notes for LLVM 23.1.0

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -1117,8 +1117,25 @@ latest release, please see the [Clang Web Site](https://clang.llvm.org) or the
   address of specializations of templated functions that have overloads for both
   host and device. (#GH199299)
 
+#### PowerPC Support
+
+- Added support for AMO load and store builtins.
+- Added DMF crypto builtins for extended mnemonics.
+- Added ISA Future (`-mcpu=future`) builtins for AES encrypt/decrypt/key-generation,
+  Post-Quantum Cryptography Acceleration (`vec_mulh`), Deeply Compressed Weights
+  (`vec_uncompress*`/`vec_unpack_*`), and Elliptic Curve Cryptography.
+- Updated DMR builtin names to remove the `_mma` infix.
+- Added early target feature validation for PowerPC builtins during semantic analysis.
+- Added support for the following PowerPC BCD (Binary-Coded Decimal) builtins
+  for POWER9 targets (requires including `bcd.h`):
+  `__builtin_bcdshift`, `__builtin_bcdshiftround`, `__builtin_bcdtruncate`,
+  `__builtin_bcdunsignedtruncate`, and `__builtin_bcdunsignedshift`.
+
 #### AIX Support
 
+- Implemented the `ifunc` attribute with Function Multi-Versioning (FMV) /
+  `target_clones` (cpu-only) support.
+- Added diagnosis of invalid feature strings on the `target` attribute.
 - The driver default for the linker flag `-bcdtors` now defaults to `mbr`
   (instead of `all`) which only extracts static init from archive members which
   would otherwise be referenced.
@@ -1132,6 +1149,25 @@ latest release, please see the [Clang Web Site](https://clang.llvm.org) or the
   The string is included in the final executable and loaded into memory at program runtime.
 - The driver relaxes the restrictions on the `OBJECT_MODE` environment
   variable and now silently accepts `32_64` and `any`.
+- Fixed a bug where the `OBJECT_MODE` environment variable could override an
+  explicitly specified `--target` triple. `--target` now takes precedence over
+  `OBJECT_MODE`, ensuring lit tests and other callers that specify an explicit
+  32-bit or 64-bit triple get the correct bit mode regardless of environment.
+- The driver's `-print-search-dirs` output now includes the AIX system library
+  paths (`/usr/lib` and `/lib`), matching GCC behavior and fixing build-tool
+  failures (Meson, CMake) that rely on this output to construct `blibpath`.
+  The `AddFilePathLibArgs()` override also prevents duplicate `-L` flags in
+  linker commands.
+- The `+modern-aix-as` target feature is now automatically enabled when
+  targeting AIX with the integrated assembler (the default, or
+  `-fintegrated-as`). This makes instruction aliases gated on `ModernAs`
+  (e.g. `mfsprg`) available without requiring manual
+  `-Xclang -target-feature -Xclang +modern-aix-as`. The feature is not
+  enabled when `-fno-integrated-as` is specified.
+- The compiler-rt build now detects the RPC XDR header (`tirpc/rpc/xdr.h`
+  on AIX, `rpc/xdr.h` elsewhere). A new `COMPILER_RT_REQUIRE_RPC_XDR_H`
+  CMake option (default `ON` on AIX, `OFF` elsewhere) turns a missing
+  header into a fatal configuration error with an actionable message.
 
 #### NetBSD Support
 

--- a/libcxx/docs/ReleaseNotes/23.rst
+++ b/libcxx/docs/ReleaseNotes/23.rst
@@ -74,6 +74,7 @@ Improvements and New Features
 - ``std::scoped_lock`` now carries Clang thread safety annotations when locking multiple mutexes, so
   ``-Wthread-safety`` no longer incorrectly reports the guarded data accessed inside the block as
   unprotected. This requires Clang 21 or later.
+- A bug using ``std::filesystem::remove_all`` on a read-only nested directory has been fixed.
 
 Deprecations and Removals
 -------------------------

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -280,6 +280,26 @@ Makes programs 10x faster by doing Special New Thing.
 
 ### Changes to the PowerPC Backend
 
+* Added backend support for partial reductions and cost modeling for length-type
+  VP intrinsic load/store.
+* `vec_rl()` on `v4i32` now generates `xvrlw` when targeting `-mcpu=future`.
+* `v256i1` loads and stores use paired vector instructions (`lxvp`/`stxvp`) on `-mcpu=future`.
+* Added support for the `MSGSNDP` (Message Send Privileged) instruction.
+* Enabled custom lowering for `__builtin_bswap64` on Power8 in 64-bit mode
+  by splitting the 64-bit byte-swap into independent 32-bit high/low swaps
+  for improved instruction-level parallelism. Power9 and later continue to
+  use their existing paths.
+* Added missing `BR_CC` handler in `DAGTypeLegalizer` for soft-promoted half
+  operands, fixing a crash when a half-typed `fcmp` result feeds directly
+  into a conditional branch.
+* Various codegen improvements and bug fixes.
+* AIX: Implemented support for the `ifunc` attribute.
+* AIX: Implemented Function Multi-Versioning using `target_clones`; versioning by cpu only, and diagnosis of invalid feature strings on the `target` attribute.
+* AIX: Added sorting of relocations in the XCOFF object writer.
+* AIX: The default code model for 64-bit targets has been changed from `small`
+  to `large`. This avoids the need for expensive linker fixups (e.g.
+  `-Wl,-bigtoc`) that many applications require with the small code model.
+
 ### Changes to the RISC-V Backend
 
 * `llvm-objdump` now has support for `--symbolize-operands` with RISC-V.
@@ -469,10 +489,16 @@ Performance enhancements:
 * Fixed `llvm-ar` to correctly handle the `N` count modifier on Windows for archive members whose names differ only
   in case (e.g. `FOO.OBJ` and `foo.obj`). Previously, `-N 2` would fail with "not found" even when two matching members existed.
 * `llvm-readobj` and `llvm-readelf` now support the `--call-graph-section` option to dump the contents of the experimental [call graph section](CallGraphSection.md).
+* `lit` now supports `--unsupported` and `--unsupported-not` command-line
+  options (and corresponding `LIT_UNSUPPORTED` / `LIT_UNSUPPORTED_NOT`
+  environment variables) to mark tests as `UNSUPPORTED` without modifying
+  the test files, mirroring the existing `--xfail` / `LIT_XFAIL` mechanism.
 * Added support for hybrid ARM64X object files to `llvm-ar` and `llvm-lib`. When these files are added to
   an archive, they are automatically split into separate native and EC members. Because the resulting members
   are no longer hybrid object files, consumers of these archives do not need to support the hybrid format themselves.
 * `llvm-ar` now supports reading and writing z/OS archives.
+* `ObjectFile::createObjectFile` now correctly handles GOFF object files,
+  routing them through `createGOFFObjectFile` instead of returning an error.
 
 ### Changes to LLDB
 
@@ -584,6 +610,13 @@ Performance enhancements:
 ### Changes to Sanitizers
 
 * Add a random delay into ThreadSanitizer to help find rare thread interleavings.
+* `sancov` now supports XCOFF object files (used on AIX). The tool strips
+  the `.` prefix that AIX adds to function entry-point symbols (e.g.
+  `.__sanitizer_cov_trace_pc_guard`) so that coverage symbols are
+  correctly identified.
+* The `mmap`/`munmap` memory-mapping interceptors now fail early when the
+  requested address range is not covered by shadow memory, avoiding
+  hard-to-diagnose failures later in the sanitizer runtime.
 
 ### Other Changes
 


### PR DESCRIPTION
This PR updates the LLVM 23.1.0 release notes with contributions from developers on the PowerPC side.