### PR TITLE
[libc++][ranges][enumerate_view] Fix sentinel converting constructor test

### DIFF
--- a/libcxx/test/std/ranges/range.adaptors/range.enumerate/sentinel/ctor.convert.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.enumerate/sentinel/ctor.convert.pass.cpp
@@ -61,35 +61,6 @@ static_assert(std::convertible_to<
               std::ranges::sentinel_t<std::ranges::enumerate_view<NonSimpleNonCommonConvertibleView>>,
               std::ranges::sentinel_t<std::ranges::enumerate_view<NonSimpleNonCommonConvertibleView> const>>);
 
-constexpr void test_SFINAE() {
-  int buffer[3] = {1, 2, 3};
-
-  // Underlying non-const to const not convertible.
-  {
-    std::ranges::enumerate_view v{NonSimpleNonCommonConvertibleView(buffer)};
-    auto st       = v.end();
-    auto const_st = std::as_const(v).end();
-
-    static_assert(!std::same_as<decltype(st), decltype(const_st)>);
-
-    // We cannot create a non-const sentinel from a const sentinel.
-    static_assert(!std::is_constructible_v<decltype(st), decltype(const_st)>);
-
-    // We can create a const sentinel from a non-const sentinel.
-    static_assert(std::is_constructible_v<decltype(const_st), decltype(st)>);
-  }
-  {
-    std::ranges::enumerate_view v{NonSimpleNonCommonConvertibleView(buffer)};
-    auto st                                             = v.end();
-    std::ranges::sentinel_t<const decltype(v)> const_st = st;
-
-    static_assert(!std::same_as<decltype(st), decltype(const_st)>);
-
-    // We cannot create a non-const sentinel from a const sentinel.
-    static_assert(!std::is_constructible_v<decltype(st), decltype(const_st)>);
-  }
-}
-
 template <class Iterator, class Sentinel = sentinel_wrapper<Iterator>>
 constexpr void test() {
   using View                   = MinimalView<Iterator, Sentinel>;
@@ -123,7 +94,32 @@ constexpr void test() {
 }
 
 constexpr bool test() {
-  test_SFINAE();
+  int buffer[3] = {1, 2, 3};
+
+  // Underlying non-const to const not convertible.
+  {
+    std::ranges::enumerate_view v{NonSimpleNonCommonConvertibleView(buffer)};
+    auto st       = v.end();
+    auto const_st = std::as_const(v).end();
+
+    static_assert(!std::same_as<decltype(st), decltype(const_st)>);
+
+    // We cannot create a non-const sentinel from a const sentinel.
+    static_assert(!std::is_constructible_v<decltype(st), decltype(const_st)>);
+
+    // We can create a const sentinel from a non-const sentinel.
+    static_assert(std::is_constructible_v<decltype(const_st), decltype(st)>);
+  }
+  {
+    std::ranges::enumerate_view v{NonSimpleNonCommonConvertibleView(buffer)};
+    auto st                                             = v.end();
+    std::ranges::sentinel_t<const decltype(v)> const_st = st;
+
+    static_assert(!std::same_as<decltype(st), decltype(const_st)>);
+
+    // We cannot create a non-const sentinel from a const sentinel.
+    static_assert(!std::is_constructible_v<decltype(st), decltype(const_st)>);
+  }
 
   test<cpp17_input_iterator<int*>>();
   test<cpp20_input_iterator<int*>>();

--- a/libcxx/test/std/ranges/range.adaptors/range.enumerate/sentinel/ctor.convert.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.enumerate/sentinel/ctor.convert.pass.cpp
@@ -28,32 +28,54 @@
 #include "test_iterators.h"
 
 #include "../types.h"
+#include "../../range_adaptor_types.h"
 
 template <class T>
 struct convertible_sentinel_wrapper {
-    explicit convertible_sentinel_wrapper() = default;
-    contexpr convertible_sentinel_wrapper(const T& it) : it_(it) {}
+  explicit convertible_sentinel_wrapper() = default;
+  constexpr convertible_sentinel_wrapper(const T& it) : it_(it) {}
 
-    template <class U>
-        requires std::convertible_to<const U&, T>
-    constexpr convertible_sentinel_wrapper(const convertible_sentinel_wrapper<U>& other) : it_(other.it_) {}
+  template <class U>
+    requires std::convertible_to<const U&, T>
+  constexpr convertible_sentinel_wrapper(const convertible_sentinel_wrapper<U>& other) : it_(other.it_) {}
 
-    constexpr friend bool operator==(convertible_sentinel_wrapper const& self, const T& other) {
-        return self.it_ == other;
-    }
-    T it_;
+  constexpr friend bool operator==(convertible_sentinel_wrapper const& self, const T& other) {
+    return self.it_ == other;
+  }
+  T it_;
 };
 
 struct NonSimpleNonCommonConvertibleView : IntBufferView {
-    using IntBufferView::IntBufferView;
+  using IntBufferView::IntBufferView;
 
-    constexpr int* begin() { return buffer_; }
-    constexpr const int* begin() const { return buffer_; }
-    constexpr convertible_sentinel_wrapper<int*> end() { return convertible_sentinel_wrapper<int*>(buffer_ + size_; }
-    constexpr convertible_sentinel_wrapper<const int*> end() const {
-        return convertible_sentinel_wrapper<const int*>(buffer_ + size_);
-    }
+  constexpr int* begin() { return buffer_; }
+  constexpr const int* begin() const { return buffer_; }
+  constexpr convertible_sentinel_wrapper<int*> end() { return convertible_sentinel_wrapper<int*>(buffer_ + size_); }
+  constexpr convertible_sentinel_wrapper<const int*> end() const {
+    return convertible_sentinel_wrapper<const int*>(buffer_ + size_);
+  }
 };
+
+// convertible_to<sentinel<false>, sentinel<Const>>
+static_assert(std::convertible_to< //
+              std::ranges::sentinel_t<std::ranges::enumerate_view<NonSimpleNonCommonConvertibleView>>,
+              std::ranges::sentinel_t<std::ranges::enumerate_view<NonSimpleNonCommonConvertibleView> const>>);
+
+constexpr void test_SFINAE() {
+  int buffer[3] = {1, 2, 3};
+
+  // Underlying non-const to const not convertible.
+  {
+    std::ranges::enumerate_view v{NonSimpleNonCommonConvertibleView(buffer)};
+    auto sent1 = v.end();
+    auto sent2 = std::as_const(v).end();
+
+    static_assert(!std::same_as<decltype(sent1), decltype(sent2)>);
+
+    static_assert(!std::is_constructible_v<decltype(sent1), decltype(sent2)>);
+    static_assert(!std::is_constructible_v<decltype(sent2), decltype(sent1)>); // this assert fails
+  }
+}
 
 template <class Iterator, class Sentinel = sentinel_wrapper<Iterator>>
 constexpr void test() {
@@ -72,7 +94,7 @@ constexpr void test() {
 
   std::array array{0, 1, 2, 3, 84};
   auto view = make_enumerate_view(array.begin(), array.end());
-  
+
   {
     // Assigning a non-const sentinel to a const-sentinel-typed variable invokes
     // the converting constructor.
@@ -88,6 +110,8 @@ constexpr void test() {
 }
 
 constexpr bool test() {
+  test_SFINAE();
+
   test<cpp17_input_iterator<int*>>();
   test<cpp20_input_iterator<int*>>();
   test<forward_iterator<int*>>();

--- a/libcxx/test/std/ranges/range.adaptors/range.enumerate/sentinel/ctor.convert.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.enumerate/sentinel/ctor.convert.pass.cpp
@@ -72,8 +72,11 @@ constexpr void test_SFINAE() {
 
     static_assert(!std::same_as<decltype(sent1), decltype(sent2)>);
 
+    // We cannot create a non-const sentinel from a const sentinel.
     static_assert(!std::is_constructible_v<decltype(sent1), decltype(sent2)>);
-    static_assert(!std::is_constructible_v<decltype(sent2), decltype(sent1)>); // this assert fails
+
+    // We can create a const sentinel from a non-const sentinel.
+    static_assert(std::is_constructible_v<decltype(sent2), decltype(sent1)>);
   }
   {
     std::ranges::enumerate_view v{NonSimpleNonCommonConvertibleView(buffer)};

--- a/libcxx/test/std/ranges/range.adaptors/range.enumerate/sentinel/ctor.convert.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.enumerate/sentinel/ctor.convert.pass.cpp
@@ -29,6 +29,32 @@
 
 #include "../types.h"
 
+template <class T>
+struct convertible_sentinel_wrapper {
+    explicit convertible_sentinel_wrapper() = default;
+    contexpr convertible_sentinel_wrapper(const T& it) : it_(it) {}
+
+    template <class U>
+        requires std::convertible_to<const U&, T>
+    constexpr convertible_sentinel_wrapper(const convertible_sentinel_wrapper<U>& other) : it_(other.it_) {}
+
+    constexpr friend bool operator==(convertible_sentinel_wrapper const& self, const T& other) {
+        return self.it_ == other;
+    }
+    T it_;
+};
+
+struct NonSimpleNonCommonConvertibleView : IntBufferView {
+    using IntBufferView::IntBufferView;
+
+    constexpr int* begin() { return buffer_; }
+    constexpr const int* begin() const { return buffer_; }
+    constexpr convertible_sentinel_wrapper<int*> end() { return convertible_sentinel_wrapper<int*>(buffer_ + size_; }
+    constexpr convertible_sentinel_wrapper<const int*> end() const {
+        return convertible_sentinel_wrapper<const int*>(buffer_ + size_);
+    }
+};
+
 template <class Iterator, class Sentinel = sentinel_wrapper<Iterator>>
 constexpr void test() {
   using View                   = MinimalView<Iterator, Sentinel>;
@@ -46,18 +72,22 @@ constexpr void test() {
 
   std::array array{0, 1, 2, 3, 84};
   auto view = make_enumerate_view(array.begin(), array.end());
+  
+  {
+    // Assigning a non-const sentinel to a const-sentinel-typed variable invokes
+    // the converting constructor.
+    std::same_as<EnumerateSentinel> decltype(auto) s = view.end();
+    std::same_as<Sentinel> decltype(auto) sResult    = s.base();
+    assert(base(base(sResult)) == std::to_address(base(array.end())));
 
-  std::same_as<EnumerateSentinel> decltype(auto) s = view.end();
-  std::same_as<Sentinel> decltype(auto) sResult    = s.base();
-  assert(base(base(sResult)) == std::to_address(base(array.end())));
-
-  // Test assignment
-  EnumerateConstSentinel cs                      = s;
-  std::same_as<Sentinel> decltype(auto) csResult = cs.base();
-  assert(base(base(csResult)) == std::to_address(base(array.end())));
+    // Verify assignment
+    EnumerateConstSentinel cs                      = s;
+    std::same_as<Sentinel> decltype(auto) csResult = cs.base();
+    assert(base(base(csResult)) == std::to_address(base(array.end())));
+  }
 }
 
-constexpr bool tests() {
+constexpr bool test() {
   test<cpp17_input_iterator<int*>>();
   test<cpp20_input_iterator<int*>>();
   test<forward_iterator<int*>>();
@@ -70,8 +100,8 @@ constexpr bool tests() {
 }
 
 int main(int, char**) {
-  tests();
-  static_assert(tests());
+  test();
+  static_assert(test());
 
   return 0;
 }

--- a/libcxx/test/std/ranges/range.adaptors/range.enumerate/sentinel/ctor.convert.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.enumerate/sentinel/ctor.convert.pass.cpp
@@ -27,8 +27,8 @@
 
 #include "test_iterators.h"
 
-#include "../types.h"
 #include "../../range_adaptor_types.h"
+#include "../types.h"
 
 template <class T>
 struct convertible_sentinel_wrapper {
@@ -57,7 +57,7 @@ struct NonSimpleNonCommonConvertibleView : IntBufferView {
 };
 
 // convertible_to<sentinel<false>, sentinel<Const>>
-static_assert(std::convertible_to< //
+static_assert(std::convertible_to<
               std::ranges::sentinel_t<std::ranges::enumerate_view<NonSimpleNonCommonConvertibleView>>,
               std::ranges::sentinel_t<std::ranges::enumerate_view<NonSimpleNonCommonConvertibleView> const>>);
 
@@ -67,8 +67,8 @@ constexpr void test_SFINAE() {
   // Underlying non-const to const not convertible.
   {
     std::ranges::enumerate_view v{NonSimpleNonCommonConvertibleView(buffer)};
-    auto sent1 = v.end();
-    auto sent2 = std::as_const(v).end();
+    auto st= v.end();
+    auto const_st= std::as_const(v).end();
 
     static_assert(!std::same_as<decltype(sent1), decltype(sent2)>);
 
@@ -111,7 +111,7 @@ constexpr void test() {
   {
     // Assigning a non-const sentinel to a const-sentinel-typed variable invokes
     // the converting constructor.
-    std::same_as<EnumerateSentinel> decltype(auto) s = view.end();
+    std::same_as<EnumerateSentinel> decltype(auto) st = view.end();
     std::same_as<Sentinel> decltype(auto) sResult    = s.base();
     assert(base(base(sResult)) == std::to_address(base(array.end())));
 

--- a/libcxx/test/std/ranges/range.adaptors/range.enumerate/sentinel/ctor.convert.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.enumerate/sentinel/ctor.convert.pass.cpp
@@ -75,6 +75,16 @@ constexpr void test_SFINAE() {
     static_assert(!std::is_constructible_v<decltype(sent1), decltype(sent2)>);
     static_assert(!std::is_constructible_v<decltype(sent2), decltype(sent1)>); // this assert fails
   }
+  {
+    std::ranges::enumerate_view v{NonSimpleNonCommonConvertibleView(buffer)};
+    auto sent1 = v.end();
+    std::ranges::sentinel_t<const decltype(v)> sent2 = sent1;
+
+    static_assert(!std::same_as<decltype(sent1), decltype(sent2)>);
+
+    // We cannot create a non-const sentinel from a const sentinel.
+    static_assert(!std::is_constructible_v<decltype(sent1), decltype(sent2)>);
+  }
 }
 
 template <class Iterator, class Sentinel = sentinel_wrapper<Iterator>>

--- a/libcxx/test/std/ranges/range.adaptors/range.enumerate/sentinel/ctor.convert.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.enumerate/sentinel/ctor.convert.pass.cpp
@@ -80,7 +80,7 @@ constexpr void test_SFINAE() {
   }
   {
     std::ranges::enumerate_view v{NonSimpleNonCommonConvertibleView(buffer)};
-    auto sent1 = v.end();
+    auto sent1                                       = v.end();
     std::ranges::sentinel_t<const decltype(v)> sent2 = sent1;
 
     static_assert(!std::same_as<decltype(sent1), decltype(sent2)>);

--- a/libcxx/test/std/ranges/range.adaptors/range.enumerate/sentinel/ctor.convert.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.enumerate/sentinel/ctor.convert.pass.cpp
@@ -67,26 +67,26 @@ constexpr void test_SFINAE() {
   // Underlying non-const to const not convertible.
   {
     std::ranges::enumerate_view v{NonSimpleNonCommonConvertibleView(buffer)};
-    auto st= v.end();
-    auto const_st= std::as_const(v).end();
+    auto st       = v.end();
+    auto const_st = std::as_const(v).end();
 
-    static_assert(!std::same_as<decltype(sent1), decltype(sent2)>);
+    static_assert(!std::same_as<decltype(st), decltype(const_st)>);
 
     // We cannot create a non-const sentinel from a const sentinel.
-    static_assert(!std::is_constructible_v<decltype(sent1), decltype(sent2)>);
+    static_assert(!std::is_constructible_v<decltype(st), decltype(const_st)>);
 
     // We can create a const sentinel from a non-const sentinel.
-    static_assert(std::is_constructible_v<decltype(sent2), decltype(sent1)>);
+    static_assert(std::is_constructible_v<decltype(const_st), decltype(st)>);
   }
   {
     std::ranges::enumerate_view v{NonSimpleNonCommonConvertibleView(buffer)};
-    auto sent1                                       = v.end();
-    std::ranges::sentinel_t<const decltype(v)> sent2 = sent1;
+    auto st                                             = v.end();
+    std::ranges::sentinel_t<const decltype(v)> const_st = st;
 
-    static_assert(!std::same_as<decltype(sent1), decltype(sent2)>);
+    static_assert(!std::same_as<decltype(st), decltype(const_st)>);
 
     // We cannot create a non-const sentinel from a const sentinel.
-    static_assert(!std::is_constructible_v<decltype(sent1), decltype(sent2)>);
+    static_assert(!std::is_constructible_v<decltype(st), decltype(const_st)>);
   }
 }
 
@@ -112,11 +112,11 @@ constexpr void test() {
     // Assigning a non-const sentinel to a const-sentinel-typed variable invokes
     // the converting constructor.
     std::same_as<EnumerateSentinel> decltype(auto) st = view.end();
-    std::same_as<Sentinel> decltype(auto) sResult    = s.base();
+    std::same_as<Sentinel> decltype(auto) sResult     = st.base();
     assert(base(base(sResult)) == std::to_address(base(array.end())));
 
     // Verify assignment
-    EnumerateConstSentinel cs                      = s;
+    EnumerateConstSentinel cs                      = st;
     std::same_as<Sentinel> decltype(auto) csResult = cs.base();
     assert(base(base(csResult)) == std::to_address(base(array.end())));
   }


### PR DESCRIPTION
Completes the `[range.enumerate.sentinel]` converting constructor test by addressing the review comment https://github.com/llvm/llvm-project/pull/73617#discussion_r1416643142 from the original implementation.