### PR TITLE
[libsycl] Enable host-to-host memcpy

### DIFF
--- a/libsycl/docs/index.md
+++ b/libsycl/docs/index.md
@@ -108,8 +108,6 @@ which doesn't currently support Windows.
 
   - to implement USM methods
 
-    - `memcpy`: enable the host-to-host case (blocked by liboffload limitations)
-
   - to implement synchronization methods
 
   - to implement submit & copy with accessors (low priority)

--- a/libsycl/src/detail/queue_impl.cpp
+++ b/libsycl/src/detail/queue_impl.cpp
@@ -153,7 +153,6 @@ void QueueImpl::submitKernelImpl(DeviceKernelInfo &KernelInfo, void *ArgData,
       createEvent(std::move(MCurrentSubmitInfo.DepEvents));
 }
 
-// Returns the {DeviceHandle, IsHostDevice} pair associated with the ptr.
 static ol_device_handle_t getAllocDevice(const void *ptr) {
   // TODO: consider caching this information to avoid querying it every time.
   ol_device_handle_t Device{};

--- a/libsycl/src/detail/queue_impl.cpp
+++ b/libsycl/src/detail/queue_impl.cpp
@@ -154,7 +154,7 @@ void QueueImpl::submitKernelImpl(DeviceKernelInfo &KernelInfo, void *ArgData,
 }
 
 // Returns the {DeviceHandle, IsHostDevice} pair associated with the ptr.
-static std::pair<ol_device_handle_t, bool> getAllocDevice(const void *ptr) {
+static ol_device_handle_t getAllocDevice(const void *ptr) {
   // TODO: consider caching this information to avoid querying it every time.
   ol_device_handle_t Device{};
   [[maybe_unused]] ol_result_t Result =
@@ -163,13 +163,13 @@ static std::pair<ol_device_handle_t, bool> getAllocDevice(const void *ptr) {
   if (detail::isFailed(Result)) {
     // If liboffload could not find the allocation, assume it is a host one.
     if (Result->Code == OL_ERRC_NOT_FOUND) {
-      return {getHostOLDevice(), true};
+      return getHostOLDevice();
     }
     checkAndThrow(Result);
   }
 
   assert(Device);
-  return {Device, false};
+  return Device;
 }
 
 std::shared_ptr<EventImpl>
@@ -186,16 +186,8 @@ QueueImpl::memcpy(void *Dest, const void *Src, std::size_t NumBytes,
                           "Nullptr argument in memcpy operation");
   }
 
-  auto [DestOLDevice, IsDestOLDeviceHost] = getAllocDevice(Dest);
-  auto [SrcOLDevice, IsSrcOLDeviceHost] = getAllocDevice(Src);
-
-  // TODO: Currently, liboffload does not let us specify a queue for
-  // host-to-host cases, which means that the operation would be synchronous and
-  // any implicit dependencies wouldn't be respected for an in-order queue.
-  if (IsDestOLDeviceHost && IsSrcOLDeviceHost)
-    throw sycl::exception(
-        sycl::make_error_code(sycl::errc::feature_not_supported),
-        "Host-to-host copy is not implemented yet");
+  ol_device_handle_t DestOLDevice = getAllocDevice(Dest);
+  ol_device_handle_t SrcOLDevice = getAllocDevice(Src);
 
   handleEventDependencies(DepEvents);
   callAndThrow(olMemcpy, MOffloadQueue, Dest, DestOLDevice, Src, SrcOLDevice,

--- a/libsycl/test/usm/memcpy.cpp
+++ b/libsycl/test/usm/memcpy.cpp
@@ -74,13 +74,7 @@ void runTestsForMemCpyFunc(MemCpyFuncT MemCpyFunc) {
   // TODO: Pass a default-constructed event as a dependency in these cases
   // instead when those are implemented.
   if constexpr (!ExplicitDeps) {
-    // TODO: Remove try-catch once host-to-host copies are supported.
-    try {
-      RunTest(HostAllocF, HostAllocF);
-      assert(false);
-    } catch (const sycl::exception &e) {
-      assert(e.code() == make_error_code(errc::feature_not_supported));
-    }
+    RunTest(HostAllocF, HostAllocF);
     RunTest(HostAllocF, HostUSMAllocF);
     RunTest(HostAllocF, SharedUSMAllocF);
 

--- a/libsycl/unittests/queue/memcpy.cpp
+++ b/libsycl/unittests/queue/memcpy.cpp
@@ -14,8 +14,7 @@ using namespace ::testing;
 
 TEST(Queue, Memcpy) {
   constexpr int NumBytes = 32;
-  constexpr int NMemcpies = 4;
-  constexpr int NMemcpyAttempts = 5;
+  constexpr int NMemcpies = 5;
 
   mock::MockWrapper Mock;
   queue Q;
@@ -29,7 +28,7 @@ TEST(Queue, Memcpy) {
 
   EXPECT_CALL(Mock.get(), olGetMemInfo(_, OL_MEM_INFO_DEVICE,
                                        sizeof(ol_device_handle_t), _))
-      .Times(NMemcpyAttempts * 2)
+      .Times(NMemcpies * 2)
       .WillRepeatedly([&](const void *Ptr, ol_mem_info_t PropName,
                           size_t PropSize, void *PropValue) -> ol_result_t {
         EXPECT_TRUE(Ptr == SrcPtr || Ptr == DstPtr);
@@ -67,11 +66,7 @@ TEST(Queue, Memcpy) {
   Q.memcpy(DstPtr, SrcPtr, NumBytes);
 
   IsSrcHostPtr = true;
-  try {
-    Q.memcpy(DstPtr, SrcPtr, NumBytes);
-  } catch (const exception &e) {
-    EXPECT_EQ(e.code(), make_error_code(errc::feature_not_supported));
-  }
+  Q.memcpy(DstPtr, SrcPtr, NumBytes);
 }
 
 TEST(Queue, MemcpyZeroBytes) {


### PR DESCRIPTION
The functionality is now supported by liboffload.