### PR TITLE
[clangd][HLSL] Add code completion for vector swizzle

### DIFF
--- a/clang-tools-extra/clangd/CodeComplete.cpp
+++ b/clang-tools-extra/clangd/CodeComplete.cpp
@@ -2208,6 +2208,7 @@ clang::CodeCompleteOptions CodeCompleteOptions::getClangCompleteOpts() const {
   // Tell Sema not to deserialize the preamble to look for results.
   Result.LoadExternal = ForceLoadPreamble || !Index;
   Result.IncludeFixIts = IncludeFixIts;
+  Result.IncludeHLSLSwizzleCompletions = true;
 
   return Result;
 }

--- a/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
+++ b/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
@@ -5163,6 +5163,92 @@ TEST(CompletionTest, FuzzyMatchMacro) {
   }
 }
 
+static void configureHLSL(TestTU &TU, bool EnableMatrix = false) {
+  TU.Filename = "TestTU.hlsl";
+  TU.ExtraArgs.push_back("-x");
+  TU.ExtraArgs.push_back("hlsl");
+  if (EnableMatrix)
+    TU.ExtraArgs.push_back("-fenable-matrix");
+  TU.ExtraArgs.push_back("--target=dxil-pc-shadermodel6.3-library");
+}
+
+TEST(CompletionTest, HLSLVectorSwizzle) {
+  // v. -> suggests individual components, both xyzw and rgba sets.
+  Annotations Dot(R"hlsl(
+    typedef float float3 __attribute__((ext_vector_type(3)));
+    void main() {
+      float3 v;
+      v.^
+    }
+  )hlsl");
+  TestTU TUDot = TestTU::withCode(Dot.code());
+  configureHLSL(TUDot);
+  auto ResultsDot = completions(TUDot, Dot.point());
+  EXPECT_THAT(ResultsDot.Completions,
+              Contains(Field(&CodeCompletion::Name, "x")));
+  EXPECT_THAT(ResultsDot.Completions,
+              Contains(Field(&CodeCompletion::Name, "y")));
+  EXPECT_THAT(ResultsDot.Completions,
+              Contains(Field(&CodeCompletion::Name, "z")));
+  EXPECT_THAT(ResultsDot.Completions,
+              Contains(Field(&CodeCompletion::Name, "r")));
+  EXPECT_THAT(ResultsDot.Completions,
+              Contains(Field(&CodeCompletion::Name, "g")));
+  EXPECT_THAT(ResultsDot.Completions,
+              Contains(Field(&CodeCompletion::Name, "b")));
+  // float3 has no 4th component.
+  EXPECT_THAT(ResultsDot.Completions,
+              Not(Contains(Field(&CodeCompletion::Name, "w"))));
+  EXPECT_THAT(ResultsDot.Completions,
+              Not(Contains(Field(&CodeCompletion::Name, "a"))));
+
+  // v.x -> continuation locked to the xyzw set, rgba excluded.
+  Annotations Partial(R"hlsl(
+    typedef float float3 __attribute__((ext_vector_type(3)));
+    void main() {
+      float3 v;
+      v.x^
+    }
+  )hlsl");
+  TestTU TUPartial = TestTU::withCode(Partial.code());
+  configureHLSL(TUPartial);
+  auto ResultsPartial = completions(TUPartial, Partial.point());
+  EXPECT_THAT(ResultsPartial.Completions,
+              Contains(Field(&CodeCompletion::Name, "xx")));
+  EXPECT_THAT(ResultsPartial.Completions,
+              Contains(Field(&CodeCompletion::Name, "xy")));
+  EXPECT_THAT(ResultsPartial.Completions,
+              Contains(Field(&CodeCompletion::Name, "xz")));
+  EXPECT_THAT(ResultsPartial.Completions,
+              Not(Contains(Field(&CodeCompletion::Name, "xr"))));
+
+  // v.xr -> mixing xyzw and rgba is invalid, no suggestions.
+  Annotations Mixed(R"hlsl(
+    typedef float float3 __attribute__((ext_vector_type(3)));
+    void main() {
+      float3 v;
+      v.xr^
+    }
+  )hlsl");
+  TestTU TUMixed = TestTU::withCode(Mixed.code());
+  configureHLSL(TUMixed);
+  auto ResultsMixed = completions(TUMixed, Mixed.point());
+  EXPECT_THAT(ResultsMixed.Completions, IsEmpty());
+
+  // v.xyzw -> already at the 4-component maximum, no more suggestions.
+  Annotations MaxLen(R"hlsl(
+    typedef float float4 __attribute__((ext_vector_type(4)));
+    void main() {
+      float4 v;
+      v.xyzw^
+    }
+  )hlsl");
+  TestTU TUMaxLen = TestTU::withCode(MaxLen.code());
+  configureHLSL(TUMaxLen);
+  auto ResultsMaxLen = completions(TUMaxLen, MaxLen.point());
+  EXPECT_THAT(ResultsMaxLen.Completions, IsEmpty());
+}
+
 } // namespace
 } // namespace clangd
 } // namespace clang

--- a/clang/include/clang/Sema/CodeCompleteConsumer.h
+++ b/clang/include/clang/Sema/CodeCompleteConsumer.h
@@ -1174,6 +1174,10 @@ public:
   /// Whether to include global (top-level) declaration results.
   bool includeGlobals() const { return CodeCompleteOpts.IncludeGlobals; }
 
+  bool includeHLSLSwizzleCompletions() const {
+    return CodeCompleteOpts.IncludeHLSLSwizzleCompletions;
+  }
+
   /// Whether to include declarations in namespace contexts (including
   /// the global namespace). If this is false, `includeGlobals()` will be
   /// ignored.

--- a/clang/include/clang/Sema/CodeCompleteOptions.h
+++ b/clang/include/clang/Sema/CodeCompleteOptions.h
@@ -52,10 +52,14 @@ public:
   LLVM_PREFERRED_TYPE(bool)
   unsigned IncludeFixIts : 1;
 
+  /// Show HLSL vector/matrix swizzle member completions
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned IncludeHLSLSwizzleCompletions : 1;
+
   CodeCompleteOptions()
       : IncludeMacros(0), IncludeCodePatterns(0), IncludeGlobals(1),
-        IncludeNamespaceLevelDecls(1), IncludeBriefComments(0),
-        LoadExternal(1), IncludeFixIts(0) {}
+        IncludeNamespaceLevelDecls(1), IncludeBriefComments(0), LoadExternal(1),
+        IncludeFixIts(0), IncludeHLSLSwizzleCompletions(0) {}
 };
 
 } // namespace clang

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -5992,6 +5992,64 @@ Expr *unwrapParenList(Expr *Base) {
 
 } // namespace
 
+static void AddHLSLVectorSwizzleCompletions(Sema &SemaRef,
+                                            ResultBuilder &Results,
+                                            const ExtVectorType *VT) {
+
+  unsigned NumElts = VT->getNumElements();
+  if (NumElts > 4)
+    NumElts = 4;
+
+  StringRef Filter = SemaRef.PP.getCodeCompletionFilter();
+
+  bool UseXYZW = true;
+  bool UseRGBA = true;
+  if (!Filter.empty()) {
+    bool HasXYZW = Filter.find_first_of("xyzw") != StringRef::npos;
+    bool HasRGBA = Filter.find_first_of("rgba") != StringRef::npos;
+    if (HasXYZW && !HasRGBA)
+      UseRGBA = false;
+    if (HasRGBA && !HasXYZW)
+      UseXYZW = false;
+    if (HasXYZW && HasRGBA)
+      return;
+    if (Filter.size() >= 4)
+      return;
+  }
+
+  static const char *const XYZWNames[] = {"x", "y", "z", "w"};
+  static const char *const RGBANames[] = {"r", "g", "b", "a"};
+
+  for (unsigned I = 0; I < NumElts; ++I) {
+    if (UseRGBA) {
+      CodeCompletionBuilder CCB(Results.getAllocator(),
+                                Results.getCodeCompletionTUInfo());
+      if (!Filter.empty()) {
+        llvm::SmallString<8> FullText(Filter);
+        FullText += RGBANames[I];
+        CCB.AddTypedTextChunk(Results.getAllocator().CopyString(FullText));
+      } else {
+        CCB.AddTypedTextChunk(RGBANames[I]);
+      }
+      Results.AddResult(
+          CodeCompletionResult(CCB.TakeString(), CCP_MemberDeclaration));
+    }
+    if (UseXYZW) {
+      CodeCompletionBuilder CCB(Results.getAllocator(),
+                                Results.getCodeCompletionTUInfo());
+      if (!Filter.empty()) {
+        llvm::SmallString<8> FullText(Filter);
+        FullText += XYZWNames[I];
+        CCB.AddTypedTextChunk(Results.getAllocator().CopyString(FullText));
+      } else {
+        CCB.AddTypedTextChunk(XYZWNames[I]);
+      }
+      Results.AddResult(
+          CodeCompletionResult(CCB.TakeString(), CCP_MemberDeclaration));
+    }
+  }
+}
+
 void SemaCodeCompletion::CodeCompleteMemberReferenceExpr(
     Scope *S, Expr *Base, Expr *OtherOpBase, SourceLocation OpLoc, bool IsArrow,
     bool IsBaseExprStatement, QualType PreferredType) {
@@ -6065,6 +6123,11 @@ void SemaCodeCompletion::CodeCompleteMemberReferenceExpr(
     if (RecordDecl *RD = getAsRecordDecl(BaseType, Resolver)) {
       AddRecordMembersCompletionResults(SemaRef, Results, S, BaseType, BaseKind,
                                         RD, std::move(AccessOpFixIt));
+    } else if (getLangOpts().HLSL && !IsArrow &&
+               SemaRef.CodeCompletion()
+                   .CodeCompleter->includeHLSLSwizzleCompletions()) {
+      if (const auto *VT = BaseType->getAs<ExtVectorType>())
+        AddHLSLVectorSwizzleCompletions(SemaRef, Results, VT);
     } else if (const auto *TTPT =
                    dyn_cast<TemplateTypeParmType>(BaseType.getTypePtr())) {
       auto Operator =


### PR DESCRIPTION
This patch introduces code completion support for HLSL `vector swizzles` in `clangd`.

Changes:

- Added the `IncludeHLSLSwizzleCompletions` flag to `CodeCompleteOptions` and `CodeCompleteConsumer` to gate the feature.

- Enabled the flag by default in `clangd`'s `CodeComplete.cpp`.

- Implemented `AddHLSLVectorSwizzleCompletions` in `SemaCodeComplete.cpp` to handle the completion logic. The implementation enforces the following HLSL swizzle rules:

  - Suggests valid components from either the `xyzw` or `rgba` sets.

  - Prevents mixing components from different sets (e.g., `v.xr` yields no completions).

  - Limits the maximum swizzle length to 4 components (e.g., `v.xyzw` will not suggest further components).

- Added unit tests in `CodeCompleteTests.cpp`.

Fixes #214804 



Note: Code completion for HLSL `matrix swizzle`s will be addressed in a follow-up PR to keep this review focused.