### PR TITLE
[Clang][Sema] Fix crash on default argument added after a parameter pack

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -516,6 +516,12 @@ features cannot lower the translation-unit ABI level;
 
 - Fixed an assertion during template argument deduction where a function parameter pack is referenced by other types in the function type. (#GH28877), (#GH213760)
 
+- Fixed a crash when a redeclaration of a function template or an out-of-line
+  definition of a member of a class template added a default argument to a
+  parameter that follows a parameter pack (e.g.
+  `template <typename... T> S::S(T..., int = 10) {}`). Clang now diagnoses the
+  invalid default argument and discards it instead of asserting. (#GH216211)
+
 #### Bug Fixes to AST Handling
 
 - Fixed a non-deterministic ordering of unused local typedefs that made

--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -516,7 +516,7 @@ features cannot lower the translation-unit ABI level;
 
 - Fixed an assertion during template argument deduction where a function parameter pack is referenced by other types in the function type. (#GH28877), (#GH213760)
 
-- Fixed a crash when a redeclaration of a function template or an out-of-line
+- Fixed an assertion when a redeclaration of a function template or an out-of-line
   definition of a member of a class template added a default argument to a
   parameter that follows a parameter pack (e.g.
   `template <typename... T> S::S(T..., int = 10) {}`). Clang now diagnoses the

--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -519,8 +519,7 @@ features cannot lower the translation-unit ABI level;
 - Fixed an assertion when a redeclaration of a function template or an out-of-line
   definition of a member of a class template added a default argument to a
   parameter that follows a parameter pack (e.g.
-  `template <typename... T> S::S(T..., int = 10) {}`). Clang now diagnoses the
-  invalid default argument and discards it instead of asserting. (#GH216211)
+  `template <typename... T> S::S(T..., int = 10) {}`).  (#GH216211)
 
 #### Bug Fixes to AST Handling
 

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -624,6 +624,8 @@ bool Sema::MergeCXXFunctionDecl(FunctionDecl *New, FunctionDecl *Old,
         Diag(PrevForDefaultArgs->getLocation(),
              diag::note_template_prev_declaration)
             << false;
+        // Recover by discarding the default argument.
+        NewParam->setDefaultArg(nullptr);
       } else if (New->getTemplateSpecializationKind()
                    != TSK_ImplicitInstantiation &&
                  New->getTemplateSpecializationKind() != TSK_Undeclared) {
@@ -665,6 +667,8 @@ bool Sema::MergeCXXFunctionDecl(FunctionDecl *New, FunctionDecl *Old,
              diag::err_param_default_argument_member_template_redecl)
           << WhichKind
           << NewParam->getDefaultArgRange();
+        // Recover by discarding the default argument.
+        NewParam->setDefaultArg(nullptr);
       }
     }
   }

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -624,8 +624,6 @@ bool Sema::MergeCXXFunctionDecl(FunctionDecl *New, FunctionDecl *Old,
         Diag(PrevForDefaultArgs->getLocation(),
              diag::note_template_prev_declaration)
             << false;
-        // Recover by discarding the default argument.
-        NewParam->setDefaultArg(nullptr);
       } else if (New->getTemplateSpecializationKind()
                    != TSK_ImplicitInstantiation &&
                  New->getTemplateSpecializationKind() != TSK_Undeclared) {
@@ -665,10 +663,7 @@ bool Sema::MergeCXXFunctionDecl(FunctionDecl *New, FunctionDecl *Old,
 
         Diag(NewParam->getLocation(),
              diag::err_param_default_argument_member_template_redecl)
-          << WhichKind
-          << NewParam->getDefaultArgRange();
-        // Recover by discarding the default argument.
-        NewParam->setDefaultArg(nullptr);
+            << WhichKind << NewParam->getDefaultArgRange();
       }
     }
   }
@@ -683,8 +678,11 @@ bool Sema::MergeCXXFunctionDecl(FunctionDecl *New, FunctionDecl *Old,
                          OldSM =
                              cast<CXXMethodDecl>(Old)->getSpecialMemberKind();
     if (NewSM != OldSM) {
-      ParmVarDecl *NewParam = New->getParamDecl(New->getMinRequiredArguments());
-      assert(NewParam->hasDefaultArg());
+      auto It = llvm::find_if(New->parameters(), [](const ParmVarDecl *P) {
+        return P->hasDefaultArg();
+      });
+      assert(It != New->param_end());
+      ParmVarDecl *NewParam = *It;
       Diag(NewParam->getLocation(), diag::err_default_arg_makes_ctor_special)
           << NewParam->getDefaultArgRange() << NewSM;
       Diag(Old->getLocation(), diag::note_previous_declaration);

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -663,7 +663,8 @@ bool Sema::MergeCXXFunctionDecl(FunctionDecl *New, FunctionDecl *Old,
 
         Diag(NewParam->getLocation(),
              diag::err_param_default_argument_member_template_redecl)
-            << WhichKind << NewParam->getDefaultArgRange();
+          << WhichKind
+          << NewParam->getDefaultArgRange();
       }
     }
   }

--- a/clang/test/CXX/dcl.decl/dcl.meaning/dcl.fct.default/p4.cpp
+++ b/clang/test/CXX/dcl.decl/dcl.meaning/dcl.fct.default/p4.cpp
@@ -110,9 +110,21 @@ void main() {
 namespace GH216211 {
 
 struct S {
-  template <typename... T> S(T..., int); // expected-note{{previous template declaration is here}}
+  template <typename... T> S(T..., int); // expected-note{{previous template declaration is here}} expected-note{{previous declaration is here}}
 };
 template <typename... T>
-S::S(T..., int = 10) {} // expected-error{{default arguments cannot be added to a function template that has already been declared}}
+S::S(T..., int = 10) {} // expected-error{{cannot be added}} expected-error{{makes this constructor a default constructor}}
+
+struct S2 {
+  template <typename... T> S2(T..., int, int); // expected-note 2{{previous template declaration is here}} expected-note{{previous declaration is here}}
+};
+template <typename... T>
+S2::S2(T..., int = 1, int = 2) {} // expected-error 2{{cannot be added}} expected-error{{makes this constructor a default constructor}}
+
+struct S3 {
+  template <typename... T> S3(T..., int, int); // expected-note{{previous template declaration is here}}
+};
+template <typename... T>
+S3::S3(T..., int, int = 2) {} // expected-error{{cannot be added}}
 
 } // namespace GH216211

--- a/clang/test/CXX/dcl.decl/dcl.meaning/dcl.fct.default/p4.cpp
+++ b/clang/test/CXX/dcl.decl/dcl.meaning/dcl.fct.default/p4.cpp
@@ -106,3 +106,13 @@ void main() {
 }
 
 } // namespace pr12724
+
+namespace GH216211 {
+
+struct S {
+  template <typename... T> S(T..., int); // expected-note{{previous template declaration is here}}
+};
+template <typename... T>
+S::S(T..., int = 10) {} // expected-error{{default arguments cannot be added to a function template that has already been declared}}
+
+} // namespace GH216211

--- a/clang/test/CXX/dcl.decl/dcl.meaning/dcl.fct.default/p6.cpp
+++ b/clang/test/CXX/dcl.decl/dcl.meaning/dcl.fct.default/p6.cpp
@@ -31,12 +31,3 @@ void X0<T>::f(int = 17) { } // expected-error{{cannot be added}}
 // DR217 + DR205 (reading tea leaves)
 template<typename T>
 void X0<T>::Inner::g(int = 17) { } // expected-error{{cannot be added}}
-
-// GH216211
-template<typename ...T>
-struct X1 {
-  X1(T..., int); // expected-note{{previous declaration is here}}
-};
-
-template<typename ...T>
-X1<T...>::X1(T..., int = 17) { } // expected-error{{cannot be added}} expected-error{{makes this constructor a default constructor}}

--- a/clang/test/CXX/dcl.decl/dcl.meaning/dcl.fct.default/p6.cpp
+++ b/clang/test/CXX/dcl.decl/dcl.meaning/dcl.fct.default/p6.cpp
@@ -31,3 +31,12 @@ void X0<T>::f(int = 17) { } // expected-error{{cannot be added}}
 // DR217 + DR205 (reading tea leaves)
 template<typename T>
 void X0<T>::Inner::g(int = 17) { } // expected-error{{cannot be added}}
+
+// GH216211
+template<typename ...T>
+struct X1 {
+  X1(T..., int);
+};
+
+template<typename ...T>
+X1<T...>::X1(T..., int = 17) { } // expected-error{{cannot be added}}

--- a/clang/test/CXX/dcl.decl/dcl.meaning/dcl.fct.default/p6.cpp
+++ b/clang/test/CXX/dcl.decl/dcl.meaning/dcl.fct.default/p6.cpp
@@ -35,8 +35,8 @@ void X0<T>::Inner::g(int = 17) { } // expected-error{{cannot be added}}
 // GH216211
 template<typename ...T>
 struct X1 {
-  X1(T..., int);
+  X1(T..., int); // expected-note{{previous declaration is here}}
 };
 
 template<typename ...T>
-X1<T...>::X1(T..., int = 17) { } // expected-error{{cannot be added}}
+X1<T...>::X1(T..., int = 17) { } // expected-error{{cannot be added}} expected-error{{makes this constructor a default constructor}}


### PR DESCRIPTION
Fixes #216211

When a redeclaration of a function template (or an out-of-line definition of a member of a class template) adds a default argument, Clang emits the right error but leaves the rejected default argument attached to the parameter. The DR1344 check that runs next locates "the first defaulted parameter" as `getParamDecl(getMinRequiredArguments())`, which is wrong when a parameter pack comes first: the pack is skipped by the count but still occupies a slot. The lookup lands on the pack and `assert(NewParam->hasDefaultArg())` fails. Without assertions, the "makes this constructor a default constructor" error is emitted pointing at the wrong parameter.

The DR1344 check now scans for the first parameter that actually has a default argument, so the assertion holds and the diagnostic points at the right parameter. Behavior without packs is unchanged: default arguments always form a trailing run starting at `getMinRequiredArguments()`, so both lookups find the same parameter there. Added regression tests for the function-template and class-template-member paths, including multiple parameters after the pack (all defaulted, and only the last one defaulted).

LLM tools were used for this contribution. I've reviewed, built, and tested the change myself before pushing to GitHub.
