### PR TITLE
[libc] Make sign functions use the emulated float128 type 

### DIFF
--- a/libc/config/baremetal/aarch64/entrypoints.txt
+++ b/libc/config/baremetal/aarch64/entrypoints.txt
@@ -376,6 +376,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ceill
     libc.src.math.copysign
     libc.src.math.copysignf
+    libc.src.math.copysignf128
     libc.src.math.copysignl
     libc.src.math.cos
     libc.src.math.cosf
@@ -751,7 +752,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
   list(APPEND TARGET_LIBM_ENTRYPOINTS
     # math.h C23 _Float128 entrypoints
     libc.src.math.canonicalizef128
-    libc.src.math.copysignf128
     libc.src.math.daddf128
     libc.src.math.ddivf128
     libc.src.math.dfmaf128

--- a/libc/config/baremetal/aarch64/entrypoints.txt
+++ b/libc/config/baremetal/aarch64/entrypoints.txt
@@ -400,6 +400,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.expm1f
     libc.src.math.fabs
     libc.src.math.fabsf
+    libc.src.math.fabsf128
     libc.src.math.fabsl
     libc.src.math.fadd
     libc.src.math.faddl
@@ -757,7 +758,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.dmulf128
     libc.src.math.dsqrtf128
     libc.src.math.dsubf128
-    libc.src.math.fabsf128
     libc.src.math.faddf128
     libc.src.math.fdimf128
     libc.src.math.fdivf128

--- a/libc/config/baremetal/aarch64/entrypoints.txt
+++ b/libc/config/baremetal/aarch64/entrypoints.txt
@@ -376,6 +376,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ceill
     libc.src.math.copysign
     libc.src.math.copysignf
+    libc.src.math.copysignf128
     libc.src.math.copysignl
     libc.src.math.cos
     libc.src.math.cosf
@@ -750,7 +751,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
   list(APPEND TARGET_LIBM_ENTRYPOINTS
     # math.h C23 _Float128 entrypoints
     libc.src.math.canonicalizef128
-    libc.src.math.copysignf128
     libc.src.math.daddf128
     libc.src.math.ddivf128
     libc.src.math.dfmaf128

--- a/libc/config/baremetal/aarch64/entrypoints.txt
+++ b/libc/config/baremetal/aarch64/entrypoints.txt
@@ -400,6 +400,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.expm1f
     libc.src.math.fabs
     libc.src.math.fabsf
+    libc.src.math.fabsf128
     libc.src.math.fabsl
     libc.src.math.fadd
     libc.src.math.faddl
@@ -756,7 +757,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.dmulf128
     libc.src.math.dsqrtf128
     libc.src.math.dsubf128
-    libc.src.math.fabsf128
     libc.src.math.faddf128
     libc.src.math.fdimf128
     libc.src.math.fdivf128

--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -388,6 +388,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ceill
     libc.src.math.copysign
     libc.src.math.copysignf
+    libc.src.math.copysignf128
     libc.src.math.copysignl
     libc.src.math.cos
     libc.src.math.cosf
@@ -762,7 +763,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
   list(APPEND TARGET_LIBM_ENTRYPOINTS
     # math.h C23 _Float128 entrypoints
     libc.src.math.canonicalizef128
-    libc.src.math.copysignf128
     libc.src.math.daddf128
     libc.src.math.ddivf128
     libc.src.math.dfmaf128

--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -412,6 +412,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.expm1f
     libc.src.math.fabs
     libc.src.math.fabsf
+    libc.src.math.fabsf128
     libc.src.math.fabsl
     libc.src.math.fadd
     libc.src.math.faddl
@@ -768,7 +769,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.dmulf128
     libc.src.math.dsqrtf128
     libc.src.math.dsubf128
-    libc.src.math.fabsf128
     libc.src.math.faddf128
     libc.src.math.fdimf128
     libc.src.math.fdivf128

--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -412,6 +412,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.expm1f
     libc.src.math.fabs
     libc.src.math.fabsf
+    libc.src.math.fabsf128
     libc.src.math.fabsl
     libc.src.math.fadd
     libc.src.math.faddl
@@ -767,7 +768,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.dmulf128
     libc.src.math.dsqrtf128
     libc.src.math.dsubf128
-    libc.src.math.fabsf128
     libc.src.math.faddf128
     libc.src.math.fdimf128
     libc.src.math.fdivf128

--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -388,6 +388,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ceill
     libc.src.math.copysign
     libc.src.math.copysignf
+    libc.src.math.copysignf128
     libc.src.math.copysignl
     libc.src.math.cos
     libc.src.math.cosf
@@ -761,7 +762,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
   list(APPEND TARGET_LIBM_ENTRYPOINTS
     # math.h C23 _Float128 entrypoints
     libc.src.math.canonicalizef128
-    libc.src.math.copysignf128
     libc.src.math.daddf128
     libc.src.math.ddivf128
     libc.src.math.dfmaf128

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -384,6 +384,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ceill
     libc.src.math.copysign
     libc.src.math.copysignf
+    libc.src.math.copysignf128
     libc.src.math.copysignl
     libc.src.math.cos
     libc.src.math.cosf
@@ -759,7 +760,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
   list(APPEND TARGET_LIBM_ENTRYPOINTS
     # math.h C23 _Float128 entrypoints
     libc.src.math.canonicalizef128
-    libc.src.math.copysignf128
     libc.src.math.daddf128
     libc.src.math.ddivf128
     libc.src.math.dfmaf128

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -408,6 +408,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.expm1f
     libc.src.math.fabs
     libc.src.math.fabsf
+    libc.src.math.fabsf128
     libc.src.math.fabsl
     libc.src.math.fadd
     libc.src.math.faddl
@@ -765,7 +766,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.dmulf128
     libc.src.math.dsqrtf128
     libc.src.math.dsubf128
-    libc.src.math.fabsf128
     libc.src.math.faddf128
     libc.src.math.fdimf128
     libc.src.math.fdivf128

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -384,6 +384,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ceill
     libc.src.math.copysign
     libc.src.math.copysignf
+    libc.src.math.copysignf128
     libc.src.math.copysignl
     libc.src.math.cos
     libc.src.math.cosf
@@ -758,7 +759,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
   list(APPEND TARGET_LIBM_ENTRYPOINTS
     # math.h C23 _Float128 entrypoints
     libc.src.math.canonicalizef128
-    libc.src.math.copysignf128
     libc.src.math.daddf128
     libc.src.math.ddivf128
     libc.src.math.dfmaf128

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -408,6 +408,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.expm1f
     libc.src.math.fabs
     libc.src.math.fabsf
+    libc.src.math.fabsf128
     libc.src.math.fabsl
     libc.src.math.fadd
     libc.src.math.faddl
@@ -764,7 +765,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.dmulf128
     libc.src.math.dsqrtf128
     libc.src.math.dsubf128
-    libc.src.math.fabsf128
     libc.src.math.faddf128
     libc.src.math.fdimf128
     libc.src.math.fdivf128

--- a/libc/config/darwin/aarch64/entrypoints.txt
+++ b/libc/config/darwin/aarch64/entrypoints.txt
@@ -219,6 +219,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.expm1f
     libc.src.math.fabs
     libc.src.math.fabsf
+    libc.src.math.fabsf128
     libc.src.math.fabsl
     libc.src.math.fadd
     libc.src.math.faddl
@@ -577,7 +578,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.dmulf128
     libc.src.math.dsqrtf128
     libc.src.math.dsubf128
-    libc.src.math.fabsf128
     libc.src.math.faddf128
     libc.src.math.fdimf128
     libc.src.math.fdivf128

--- a/libc/config/darwin/aarch64/entrypoints.txt
+++ b/libc/config/darwin/aarch64/entrypoints.txt
@@ -195,6 +195,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ceill
     libc.src.math.copysign
     libc.src.math.copysignf
+    libc.src.math.copysignf128
     libc.src.math.copysignl
     libc.src.math.cos
     libc.src.math.cosf
@@ -571,7 +572,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
   list(APPEND TARGET_LIBM_ENTRYPOINTS
     # math.h C23 _Float128 entrypoints
     libc.src.math.canonicalizef128
-    libc.src.math.copysignf128
     libc.src.math.daddf128
     libc.src.math.ddivf128
     libc.src.math.dfmaf128

--- a/libc/config/darwin/aarch64/entrypoints.txt
+++ b/libc/config/darwin/aarch64/entrypoints.txt
@@ -219,6 +219,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.expm1f
     libc.src.math.fabs
     libc.src.math.fabsf
+    libc.src.math.fabsf128
     libc.src.math.fabsl
     libc.src.math.fadd
     libc.src.math.faddl
@@ -576,7 +577,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.dmulf128
     libc.src.math.dsqrtf128
     libc.src.math.dsubf128
-    libc.src.math.fabsf128
     libc.src.math.faddf128
     libc.src.math.fdimf128
     libc.src.math.fdivf128

--- a/libc/config/darwin/aarch64/entrypoints.txt
+++ b/libc/config/darwin/aarch64/entrypoints.txt
@@ -195,6 +195,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ceill
     libc.src.math.copysign
     libc.src.math.copysignf
+    libc.src.math.copysignf128
     libc.src.math.copysignl
     libc.src.math.cos
     libc.src.math.cosf
@@ -570,7 +571,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
   list(APPEND TARGET_LIBM_ENTRYPOINTS
     # math.h C23 _Float128 entrypoints
     libc.src.math.canonicalizef128
-    libc.src.math.copysignf128
     libc.src.math.daddf128
     libc.src.math.ddivf128
     libc.src.math.dfmaf128

--- a/libc/config/darwin/x86_64/entrypoints.txt
+++ b/libc/config/darwin/x86_64/entrypoints.txt
@@ -138,6 +138,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     #libc.src.math.expm1f
     #libc.src.math.fabs
     #libc.src.math.fabsf
+    #libc.src.math.fabsf128
     #libc.src.math.fabsl
     #libc.src.math.fdim
     #libc.src.math.fdimf

--- a/libc/config/darwin/x86_64/entrypoints.txt
+++ b/libc/config/darwin/x86_64/entrypoints.txt
@@ -121,6 +121,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     #libc.src.math.atan2f128
     #libc.src.math.copysign
     #libc.src.math.copysignf
+    #libc.src.math.copysignf128
     #libc.src.math.copysignl
     #libc.src.math.ceil
     #libc.src.math.ceilf

--- a/libc/config/freebsd/x86_64/entrypoints.txt
+++ b/libc/config/freebsd/x86_64/entrypoints.txt
@@ -132,6 +132,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.cbrtf
     libc.src.math.copysign
     libc.src.math.copysignf
+    libc.src.math.copysignf128
     libc.src.math.copysignl
     libc.src.math.ceil
     libc.src.math.ceilf
@@ -511,7 +512,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
   list(APPEND TARGET_LIBM_ENTRYPOINTS
     libc.src.math.atan2l
     libc.src.math.canonicalizef128
-    libc.src.math.copysignf128
     libc.src.math.daddf128
     libc.src.math.ddivf128
     libc.src.math.dfmaf128

--- a/libc/config/freebsd/x86_64/entrypoints.txt
+++ b/libc/config/freebsd/x86_64/entrypoints.txt
@@ -155,6 +155,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.expm1f
     libc.src.math.fabs
     libc.src.math.fabsf
+    libc.src.math.fabsf128
     libc.src.math.fabsl
     libc.src.math.fadd
     libc.src.math.faddl
@@ -517,7 +518,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.dmulf128
     libc.src.math.dsqrtf128
     libc.src.math.dsubf128
-    libc.src.math.fabsf128
     libc.src.math.faddf128
     libc.src.math.fdimf128
     libc.src.math.fdivf128

--- a/libc/config/freebsd/x86_64/entrypoints.txt
+++ b/libc/config/freebsd/x86_64/entrypoints.txt
@@ -155,6 +155,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.expm1f
     libc.src.math.fabs
     libc.src.math.fabsf
+    libc.src.math.fabsf128
     libc.src.math.fabsl
     libc.src.math.fadd
     libc.src.math.faddl
@@ -515,7 +516,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.dmulf128
     libc.src.math.dsqrtf128
     libc.src.math.dsubf128
-    libc.src.math.fabsf128
     libc.src.math.faddf128
     libc.src.math.fdimf128
     libc.src.math.fdivf128

--- a/libc/config/freebsd/x86_64/entrypoints.txt
+++ b/libc/config/freebsd/x86_64/entrypoints.txt
@@ -132,6 +132,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.cbrtf
     libc.src.math.copysign
     libc.src.math.copysignf
+    libc.src.math.copysignf128
     libc.src.math.copysignl
     libc.src.math.ceil
     libc.src.math.ceilf
@@ -509,7 +510,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
   list(APPEND TARGET_LIBM_ENTRYPOINTS
     libc.src.math.atan2l
     libc.src.math.canonicalizef128
-    libc.src.math.copysignf128
     libc.src.math.daddf128
     libc.src.math.ddivf128
     libc.src.math.dfmaf128

--- a/libc/config/gpu/amdgpu/entrypoints.txt
+++ b/libc/config/gpu/amdgpu/entrypoints.txt
@@ -348,6 +348,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.expm1f
     libc.src.math.fabs
     libc.src.math.fabsf
+    libc.src.math.fabsf128
     libc.src.math.fabsl
     libc.src.math.fadd
     libc.src.math.faddl

--- a/libc/config/gpu/amdgpu/entrypoints.txt
+++ b/libc/config/gpu/amdgpu/entrypoints.txt
@@ -327,6 +327,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ceill
     libc.src.math.copysign
     libc.src.math.copysignf
+    libc.src.math.copysignf128
     libc.src.math.copysignl
     libc.src.math.cos
     libc.src.math.cosf

--- a/libc/config/gpu/nvptx/entrypoints.txt
+++ b/libc/config/gpu/nvptx/entrypoints.txt
@@ -344,6 +344,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.expm1f
     libc.src.math.fabs
     libc.src.math.fabsf
+    libc.src.math.fabsf128
     libc.src.math.fabsl
     libc.src.math.fadd
     libc.src.math.faddl

--- a/libc/config/gpu/nvptx/entrypoints.txt
+++ b/libc/config/gpu/nvptx/entrypoints.txt
@@ -323,6 +323,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ceill
     libc.src.math.copysign
     libc.src.math.copysignf
+    libc.src.math.copysignf128
     libc.src.math.copysignl
     libc.src.math.cos
     libc.src.math.cosf

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -581,6 +581,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.expm1f
     libc.src.math.fabs
     libc.src.math.fabsf
+    libc.src.math.fabsf128
     libc.src.math.fabsl
     libc.src.math.fadd
     libc.src.math.faddl
@@ -928,7 +929,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.dmulf128
     libc.src.math.dsqrtf128
     libc.src.math.dsubf128
-    libc.src.math.fabsf128
     libc.src.math.faddf128
     libc.src.math.fdimf128
     libc.src.math.fdivf128

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -557,6 +557,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ceill
     libc.src.math.copysign
     libc.src.math.copysignf
+    libc.src.math.copysignf128
     libc.src.math.copysignl
     libc.src.math.cos
     libc.src.math.cosf
@@ -922,7 +923,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
   list(APPEND TARGET_LIBM_ENTRYPOINTS
     # math.h C23 _Float128 entrypoints
     libc.src.math.canonicalizef128
-    libc.src.math.copysignf128
     libc.src.math.daddf128
     libc.src.math.ddivf128
     libc.src.math.dfmaf128

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -569,6 +569,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.expm1f
     libc.src.math.fabs
     libc.src.math.fabsf
+    libc.src.math.fabsf128
     libc.src.math.fabsl
     libc.src.math.fadd
     libc.src.math.faddl
@@ -915,7 +916,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.dmulf128
     libc.src.math.dsqrtf128
     libc.src.math.dsubf128
-    libc.src.math.fabsf128
     libc.src.math.faddf128
     libc.src.math.fdimf128
     libc.src.math.fdivf128

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -545,6 +545,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ceill
     libc.src.math.copysign
     libc.src.math.copysignf
+    libc.src.math.copysignf128
     libc.src.math.copysignl
     libc.src.math.cos
     libc.src.math.cosf
@@ -909,7 +910,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
   list(APPEND TARGET_LIBM_ENTRYPOINTS
     # math.h C23 _Float128 entrypoints
     libc.src.math.canonicalizef128
-    libc.src.math.copysignf128
     libc.src.math.daddf128
     libc.src.math.ddivf128
     libc.src.math.dfmaf128

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -402,6 +402,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.expm1f
     libc.src.math.fabs
     libc.src.math.fabsf
+    libc.src.math.fabsf128
     libc.src.math.fabsl
     libc.src.math.fadd
     libc.src.math.faddl

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -385,6 +385,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ceill
     libc.src.math.copysign
     libc.src.math.copysignf
+    libc.src.math.copysignf128
     libc.src.math.copysignl
     libc.src.math.cos
     libc.src.math.cosf

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -392,6 +392,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.expm1f
     libc.src.math.fabs
     libc.src.math.fabsf
+    libc.src.math.fabsf128
     libc.src.math.fabsl
     libc.src.math.fadd
     libc.src.math.faddl

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -375,6 +375,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ceill
     libc.src.math.copysign
     libc.src.math.copysignf
+    libc.src.math.copysignf128
     libc.src.math.copysignl
     libc.src.math.cos
     libc.src.math.cosf

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -646,6 +646,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.expm1f
     libc.src.math.fabs
     libc.src.math.fabsf
+    libc.src.math.fabsf128
     libc.src.math.fabsl
     libc.src.math.fadd
     libc.src.math.faddl
@@ -1014,7 +1015,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.dmulf128
     libc.src.math.dsqrtf128
     libc.src.math.dsubf128
-    libc.src.math.fabsf128
     libc.src.math.faddf128
     libc.src.math.fdimf128
     libc.src.math.fdivf128

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -622,6 +622,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ceill
     libc.src.math.copysign
     libc.src.math.copysignf
+    libc.src.math.copysignf128
     libc.src.math.copysignl
     libc.src.math.cos
     libc.src.math.cosf
@@ -1008,7 +1009,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     # math.h C23 _Float128 entrypoints
     libc.src.math.atan2l
     libc.src.math.canonicalizef128
-    libc.src.math.copysignf128
     libc.src.math.daddf128
     libc.src.math.ddivf128
     libc.src.math.dfmaf128

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -610,6 +610,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ceill
     libc.src.math.copysign
     libc.src.math.copysignf
+    libc.src.math.copysignf128
     libc.src.math.copysignl
     libc.src.math.cos
     libc.src.math.cosf
@@ -995,7 +996,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     # math.h C23 _Float128 entrypoints
     libc.src.math.atan2l
     libc.src.math.canonicalizef128
-    libc.src.math.copysignf128
     libc.src.math.daddf128
     libc.src.math.ddivf128
     libc.src.math.dfmaf128

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -634,6 +634,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.expm1f
     libc.src.math.fabs
     libc.src.math.fabsf
+    libc.src.math.fabsf128
     libc.src.math.fabsl
     libc.src.math.fadd
     libc.src.math.faddl
@@ -1001,7 +1002,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.dmulf128
     libc.src.math.dsqrtf128
     libc.src.math.dsubf128
-    libc.src.math.fabsf128
     libc.src.math.faddf128
     libc.src.math.fdimf128
     libc.src.math.fdivf128

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -631,6 +631,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ceill
     libc.src.math.copysign
     libc.src.math.copysignf
+    libc.src.math.copysignf128
     libc.src.math.copysignl
     libc.src.math.cos
     libc.src.math.cosf
@@ -1017,7 +1018,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     # math.h C23 _Float128 entrypoints
     libc.src.math.atan2l
     libc.src.math.canonicalizef128
-    libc.src.math.copysignf128
     libc.src.math.daddf128
     libc.src.math.ddivf128
     libc.src.math.dfmaf128

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -655,6 +655,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.expm1f
     libc.src.math.fabs
     libc.src.math.fabsf
+    libc.src.math.fabsf128
     libc.src.math.fabsl
     libc.src.math.fadd
     libc.src.math.faddl
@@ -1023,7 +1024,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.dmulf128
     libc.src.math.dsqrtf128
     libc.src.math.dsubf128
-    libc.src.math.fabsf128
     libc.src.math.faddf128
     libc.src.math.fdimf128
     libc.src.math.fdivf128

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -643,6 +643,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.expm1f
     libc.src.math.fabs
     libc.src.math.fabsf
+    libc.src.math.fabsf128
     libc.src.math.fabsl
     libc.src.math.fadd
     libc.src.math.faddl
@@ -1010,7 +1011,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.dmulf128
     libc.src.math.dsqrtf128
     libc.src.math.dsubf128
-    libc.src.math.fabsf128
     libc.src.math.faddf128
     libc.src.math.fdimf128
     libc.src.math.fdivf128

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -619,6 +619,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ceill
     libc.src.math.copysign
     libc.src.math.copysignf
+    libc.src.math.copysignf128
     libc.src.math.copysignl
     libc.src.math.cos
     libc.src.math.cosf
@@ -1004,7 +1005,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     # math.h C23 _Float128 entrypoints
     libc.src.math.atan2l
     libc.src.math.canonicalizef128
-    libc.src.math.copysignf128
     libc.src.math.daddf128
     libc.src.math.ddivf128
     libc.src.math.dfmaf128

--- a/libc/config/windows/entrypoints.txt
+++ b/libc/config/windows/entrypoints.txt
@@ -187,6 +187,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.expm1f
     libc.src.math.fabs
     libc.src.math.fabsf
+    libc.src.math.fabsf128
     libc.src.math.fabsl
     libc.src.math.fadd
     libc.src.math.faddl

--- a/libc/config/windows/entrypoints.txt
+++ b/libc/config/windows/entrypoints.txt
@@ -164,6 +164,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.cbrtbf16
     libc.src.math.copysign
     libc.src.math.copysignf
+    libc.src.math.copysignf128
     libc.src.math.copysignl
     libc.src.math.ceil
     libc.src.math.ceilf

--- a/libc/shared/math/copysignf128.h
+++ b/libc/shared/math/copysignf128.h
@@ -9,10 +9,6 @@
 #ifndef LLVM_LIBC_SHARED_MATH_COPYSIGNF128_H
 #define LLVM_LIBC_SHARED_MATH_COPYSIGNF128_H
 
-#include "include/llvm-libc-types/float128.h"
-
-#ifdef LIBC_TYPES_HAS_NATIVE_FLOAT128
-
 #include "shared/libc_common.h"
 #include "src/__support/math/copysignf128.h"
 
@@ -23,7 +19,5 @@ using math::copysignf128;
 
 } // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
-
-#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 #endif // LLVM_LIBC_SHARED_MATH_COPYSIGNF128_H

--- a/libc/shared/math/fabsf128.h
+++ b/libc/shared/math/fabsf128.h
@@ -9,10 +9,6 @@
 #ifndef LLVM_LIBC_SHARED_MATH_FABSF128_H
 #define LLVM_LIBC_SHARED_MATH_FABSF128_H
 
-#include "include/llvm-libc-types/float128.h"
-
-#ifdef LIBC_TYPES_HAS_NATIVE_FLOAT128
-
 #include "shared/libc_common.h"
 #include "src/__support/math/fabsf128.h"
 
@@ -23,7 +19,5 @@ using math::fabsf128;
 
 } // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
-
-#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 #endif // LLVM_LIBC_SHARED_MATH_FABSF128_H

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -2765,7 +2765,7 @@ add_header_library(
   HDRS
     copysignf128.h
   DEPENDS
-    libc.include.llvm-libc-types.float128
+    libc.src.__support.FPUtil.float128
     libc.src.__support.FPUtil.manipulation_functions
     libc.src.__support.macros.config
 )

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -3246,7 +3246,7 @@ add_header_library(
   HDRS
     fabsf128.h
   DEPENDS
-    libc.include.llvm-libc-types.float128
+    libc.src.__support.FPUtil.float128
     libc.src.__support.FPUtil.basic_operations
     libc.src.__support.macros.config
 )

--- a/libc/src/__support/math/copysignf128.h
+++ b/libc/src/__support/math/copysignf128.h
@@ -9,23 +9,20 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_MATH_COPYSIGNF128_H
 #define LLVM_LIBC_SRC___SUPPORT_MATH_COPYSIGNF128_H
 
-#include "include/llvm-libc-types/float128.h"
-
-#ifdef LIBC_TYPES_HAS_NATIVE_FLOAT128
-
 #include "src/__support/FPUtil/ManipulationFunctions.h"
+#include "src/__support/FPUtil/float128.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
 namespace math {
 
-LIBC_INLINE constexpr float128 copysignf128(float128 x, float128 y) {
+using LIBC_NAMESPACE::fputil::Float128;
+
+LIBC_INLINE constexpr Float128 copysignf128(Float128 x, Float128 y) {
   return fputil::copysign(x, y);
 }
 
 } // namespace math
 } // namespace LIBC_NAMESPACE_DECL
-
-#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 #endif // LLVM_LIBC_SRC___SUPPORT_MATH_COPYSIGNF128_H

--- a/libc/src/__support/math/fabsf128.h
+++ b/libc/src/__support/math/fabsf128.h
@@ -9,21 +9,18 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_MATH_FABSF128_H
 #define LLVM_LIBC_SRC___SUPPORT_MATH_FABSF128_H
 
-#include "include/llvm-libc-types/float128.h"
-
-#ifdef LIBC_TYPES_HAS_NATIVE_FLOAT128
-
 #include "src/__support/FPUtil/BasicOperations.h"
+#include "src/__support/FPUtil/float128.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
 namespace math {
 
-LIBC_INLINE constexpr float128 fabsf128(float128 x) { return fputil::abs(x); }
+using LIBC_NAMESPACE::fputil::Float128;
+
+LIBC_INLINE constexpr Float128 fabsf128(Float128 x) { return fputil::abs(x); }
 
 } // namespace math
 } // namespace LIBC_NAMESPACE_DECL
-
-#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 #endif // LLVM_LIBC_SRC___SUPPORT_MATH_FABSF128_H

--- a/libc/src/math/copysignf128.h
+++ b/libc/src/math/copysignf128.h
@@ -9,10 +9,15 @@
 #ifndef LLVM_LIBC_SRC_MATH_COPYSIGNF128_H
 #define LLVM_LIBC_SRC_MATH_COPYSIGNF128_H
 
+#include "src/__support/FPUtil/float128.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/types.h"
 
 namespace LIBC_NAMESPACE_DECL {
+
+#ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128
+using float128 = LIBC_NAMESPACE::fputil::Float128;
+#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 float128 copysignf128(float128 x, float128 y);
 

--- a/libc/src/math/fabsf128.h
+++ b/libc/src/math/fabsf128.h
@@ -9,10 +9,15 @@
 #ifndef LLVM_LIBC_SRC_MATH_FABSF128_H
 #define LLVM_LIBC_SRC_MATH_FABSF128_H
 
+#include "src/__support/FPUtil/float128.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/types.h"
 
 namespace LIBC_NAMESPACE_DECL {
+
+#ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128
+using float128 = LIBC_NAMESPACE::fputil::Float128;
+#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 float128 fabsf128(float128 x);
 

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -1466,6 +1466,7 @@ add_entrypoint_object(
   HDRS
     ../copysignf128.h
   DEPENDS
+    libc.src.__support.CPP.bit
     libc.src.__support.math.copysignf128
 )
 

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -515,6 +515,7 @@ add_entrypoint_object(
   HDRS
     ../fabsf128.h
   DEPENDS
+    libc.src.__support.CPP.bit
     libc.src.__support.math.fabsf128
 )
 

--- a/libc/src/math/generic/copysignf128.cpp
+++ b/libc/src/math/generic/copysignf128.cpp
@@ -7,12 +7,16 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/math/copysignf128.h"
+#include "src/__support/CPP/bit.h"
 #include "src/__support/math/copysignf128.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
+using LIBC_NAMESPACE::fputil::Float128;
+
 LLVM_LIBC_FUNCTION(float128, copysignf128, (float128 x, float128 y)) {
-  return math::copysignf128(x, y);
+  return cpp::bit_cast<float128>(math::copysignf128(
+      cpp::bit_cast<Float128>(x), cpp::bit_cast<Float128>(y)));
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/math/generic/fabsf128.cpp
+++ b/libc/src/math/generic/fabsf128.cpp
@@ -7,12 +7,15 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/math/fabsf128.h"
+#include "src/__support/CPP/bit.h"
 #include "src/__support/math/fabsf128.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
+using LIBC_NAMESPACE::fputil::Float128;
+
 LLVM_LIBC_FUNCTION(float128, fabsf128, (float128 x)) {
-  return math::fabsf128(x);
+  return cpp::bit_cast<float128>(math::fabsf128(cpp::bit_cast<Float128>(x)));
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/test/shared/shared_math_constexpr_test.cpp
+++ b/libc/test/shared/shared_math_constexpr_test.cpp
@@ -381,6 +381,9 @@ static_assert(0 == LIBC_NAMESPACE::shared::isnanl(0.0L));
 //===----------------------------------------------------------------------===//
 
 static_assert(Float128(0.0) == LIBC_NAMESPACE::shared::ceilf128(Float128(0.0)));
+static_assert(Float128(0.0) ==
+              LIBC_NAMESPACE::shared::copysignf128(Float128(0.0),
+                                                   Float128(0.0)));
 static_assert(Float128(1.0) ==
               LIBC_NAMESPACE::shared::fabsf128(Float128(-1.0)));
 static_assert(Float128(0.0) ==
@@ -417,9 +420,6 @@ static_assert(0 == [] {
   float128 x = float128(0.0);
   return LIBC_NAMESPACE::shared::canonicalizef128(&cx, &x);
 }());
-static_assert(float128(0.0) ==
-              LIBC_NAMESPACE::shared::copysignf128(float128(0.0),
-                                                   float128(0.0)));
 static_assert(0.0 ==
               LIBC_NAMESPACE::shared::ddivf128(float128(0.0), float128(1.0)));
 static_assert(0.0 ==

--- a/libc/test/shared/shared_math_constexpr_test.cpp
+++ b/libc/test/shared/shared_math_constexpr_test.cpp
@@ -381,6 +381,8 @@ static_assert(0 == LIBC_NAMESPACE::shared::isnanl(0.0L));
 //===----------------------------------------------------------------------===//
 
 static_assert(Float128(0.0) == LIBC_NAMESPACE::shared::ceilf128(Float128(0.0)));
+static_assert(Float128(1.0) ==
+              LIBC_NAMESPACE::shared::fabsf128(Float128(-1.0)));
 static_assert(Float128(0.0) ==
               LIBC_NAMESPACE::shared::floorf128(Float128(0.0)));
 static_assert(Float128(0.0) ==
@@ -415,8 +417,6 @@ static_assert(0 == [] {
   float128 x = float128(0.0);
   return LIBC_NAMESPACE::shared::canonicalizef128(&cx, &x);
 }());
-static_assert(float128(1.0) ==
-              LIBC_NAMESPACE::shared::fabsf128(float128(-1.0)));
 static_assert(float128(0.0) ==
               LIBC_NAMESPACE::shared::copysignf128(float128(0.0),
                                                    float128(0.0)));

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -584,6 +584,8 @@ TEST(LlvmLibcSharedMathTest, AllEmuFloat128) {
   EXPECT_FP_EQ(Float128(0.0),
                LIBC_NAMESPACE::shared::atan2f128(Float128(0.0), Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::ceilf128(Float128(0.0)));
+  EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::copysignf128(
+                                  Float128(0.0), Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::fabsf128(Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::floorf128(Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0),
@@ -649,8 +651,6 @@ TEST(LlvmLibcSharedMathTest, AllFloat128) {
                                   float128(0.0), float128(0.0)));
   EXPECT_FP_EQ(bfloat16(2.0), LIBC_NAMESPACE::shared::bf16divf128(
                                   float128(4.0), float128(2.0)));
-  EXPECT_FP_EQ(float128(0.0), LIBC_NAMESPACE::shared::copysignf128(
-                                  float128(0.0), float128(0.0)));
   EXPECT_FP_EQ(float128(0.0),
                LIBC_NAMESPACE::shared::daddf128(float128(0.0), float128(0.0)));
   EXPECT_FP_EQ(1.0,

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -584,6 +584,7 @@ TEST(LlvmLibcSharedMathTest, AllEmuFloat128) {
   EXPECT_FP_EQ(Float128(0.0),
                LIBC_NAMESPACE::shared::atan2f128(Float128(0.0), Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::ceilf128(Float128(0.0)));
+  EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::fabsf128(Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::floorf128(Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0),
                LIBC_NAMESPACE::shared::fmaxf128(Float128(0.0), Float128(0.0)));
@@ -658,7 +659,6 @@ TEST(LlvmLibcSharedMathTest, AllFloat128) {
                LIBC_NAMESPACE::shared::dmulf128(float128(0.0), float128(0.0)));
   EXPECT_FP_EQ(0.0,
                LIBC_NAMESPACE::shared::dsubf128(float128(0.0), float128(0.0)));
-  EXPECT_FP_EQ(float128(0.0), LIBC_NAMESPACE::shared::fabsf128(float128(0.0)));
   EXPECT_FP_EQ(float128(0.0),
                LIBC_NAMESPACE::shared::faddf128(float128(0.0), float128(0.0)));
   EXPECT_FP_EQ(float128(0.0),

--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -251,8 +251,8 @@ add_fp_unittest(
   HDRS
     FAbsTest.h
   DEPENDS
-    libc.src.__support.FPUtil.float128
     libc.src.math.fabsf128
+    libc.src.__support.FPUtil.float128
     libc.src.__support.FPUtil.fp_bits
 )
 
@@ -1667,9 +1667,9 @@ add_fp_unittest(
   HDRS
     CopySignTest.h
   DEPENDS
-    libc.src.__support.FPUtil.float128
     libc.src.math.copysignf128
     libc.src.__support.CPP.algorithm
+    libc.src.__support.FPUtil.float128
     libc.src.__support.FPUtil.fp_bits
 )
 

--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -251,6 +251,7 @@ add_fp_unittest(
   HDRS
     FAbsTest.h
   DEPENDS
+    libc.src.__support.FPUtil.float128
     libc.src.math.fabsf128
     libc.src.__support.FPUtil.fp_bits
 )

--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -1667,6 +1667,7 @@ add_fp_unittest(
   HDRS
     CopySignTest.h
   DEPENDS
+    libc.src.__support.FPUtil.float128
     libc.src.math.copysignf128
     libc.src.__support.CPP.algorithm
     libc.src.__support.FPUtil.fp_bits

--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -1656,6 +1656,7 @@ add_fp_unittest(
   HDRS
     CopySignTest.h
   DEPENDS
+    libc.src.__support.FPUtil.float128
     libc.src.math.copysignf128
     libc.src.__support.CPP.algorithm
     libc.src.__support.FPUtil.fp_bits

--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -240,6 +240,7 @@ add_fp_unittest(
   HDRS
     FAbsTest.h
   DEPENDS
+    libc.src.__support.FPUtil.float128
     libc.src.math.fabsf128
     libc.src.__support.FPUtil.fp_bits
 )

--- a/libc/test/src/math/smoke/copysignf128_test.cpp
+++ b/libc/test/src/math/smoke/copysignf128_test.cpp
@@ -7,8 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "CopySignTest.h"
-#include "src/__support/FPUtil/float128.h"
 
+#include "src/__support/FPUtil/float128.h"
 #include "src/math/copysignf128.h"
 
 #ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128

--- a/libc/test/src/math/smoke/copysignf128_test.cpp
+++ b/libc/test/src/math/smoke/copysignf128_test.cpp
@@ -7,7 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "CopySignTest.h"
+#include "src/__support/FPUtil/float128.h"
 
 #include "src/math/copysignf128.h"
+
+#ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128
+using float128 = LIBC_NAMESPACE::fputil::Float128;
+#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 LIST_COPYSIGN_TESTS(float128, LIBC_NAMESPACE::copysignf128)

--- a/libc/test/src/math/smoke/fabsf128_test.cpp
+++ b/libc/test/src/math/smoke/fabsf128_test.cpp
@@ -7,8 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "FAbsTest.h"
-#include "src/__support/FPUtil/float128.h"
 
+#include "src/__support/FPUtil/float128.h"
 #include "src/math/fabsf128.h"
 
 #ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128

--- a/libc/test/src/math/smoke/fabsf128_test.cpp
+++ b/libc/test/src/math/smoke/fabsf128_test.cpp
@@ -7,7 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "FAbsTest.h"
+#include "src/__support/FPUtil/float128.h"
 
 #include "src/math/fabsf128.h"
+
+#ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128
+using float128 = LIBC_NAMESPACE::fputil::Float128;
+#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 LIST_FABS_TESTS(float128, LIBC_NAMESPACE::fabsf128)

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -5378,9 +5378,9 @@ libc_support_library(
     name = "__support_math_copysignf128",
     hdrs = ["src/__support/math/copysignf128.h"],
     deps = [
+        ":__support_fputil_float128",
         ":__support_fputil_manipulation_functions",
         ":__support_macros_config",
-        ":llvm_libc_types_float128",
     ],
 )
 
@@ -11214,6 +11214,8 @@ libc_math_function(
 libc_math_function(
     name = "copysignf128",
     additional_deps = [
+        ":__support_cpp_bit",
+        ":__support_fputil_float128",
         ":__support_math_copysignf128",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -7794,8 +7794,8 @@ libc_support_library(
     hdrs = ["src/__support/math/fabsf128.h"],
     deps = [
         ":__support_fputil_basic_operations",
+        ":__support_fputil_float128",
         ":__support_macros_config",
-        ":llvm_libc_types_float128",
     ],
 )
 
@@ -11676,6 +11676,8 @@ libc_math_function(
 libc_math_function(
     name = "fabsf128",
     additional_deps = [
+        ":__support_cpp_bit",
+        ":__support_fputil_float128",
         ":__support_math_fabsf128",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -7786,8 +7786,8 @@ libc_support_library(
     hdrs = ["src/__support/math/fabsf128.h"],
     deps = [
         ":__support_fputil_basic_operations",
+        ":__support_fputil_float128",
         ":__support_macros_config",
-        ":llvm_libc_types_float128",
     ],
 )
 
@@ -11636,6 +11636,8 @@ libc_math_function(
 libc_math_function(
     name = "fabsf128",
     additional_deps = [
+        ":__support_cpp_bit",
+        ":__support_fputil_float128",
         ":__support_math_fabsf128",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -5370,9 +5370,9 @@ libc_support_library(
     name = "__support_math_copysignf128",
     hdrs = ["src/__support/math/copysignf128.h"],
     deps = [
+        ":__support_fputil_float128",
         ":__support_fputil_manipulation_functions",
         ":__support_macros_config",
-        ":llvm_libc_types_float128",
     ],
 )
 
@@ -11174,6 +11174,8 @@ libc_math_function(
 libc_math_function(
     name = "copysignf128",
     additional_deps = [
+        ":__support_cpp_bit",
+        ":__support_fputil_float128",
         ":__support_math_copysignf128",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
@@ -150,6 +150,9 @@ math_test(
 math_test(
     name = "copysignf128",
     hdrs = ["CopySignTest.h"],
+    deps = [
+        "//libc:__support_fputil_float128",
+    ],
 )
 
 math_test(

--- a/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
@@ -402,6 +402,9 @@ math_test(
 math_test(
     name = "fabsf128",
     hdrs = ["FAbsTest.h"],
+    deps = [
+        "//libc:__support_fputil_float128",
+    ],
 )
 
 math_test(


### PR DESCRIPTION
*  `fabsf128`
*  `copysignf128`