### PR TITLE
[libc] Make fmaximum/fminimum functions use the emulated float128 type

### DIFF
--- a/libc/config/baremetal/aarch64/entrypoints.txt
+++ b/libc/config/baremetal/aarch64/entrypoints.txt
@@ -434,6 +434,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmaximum_numf
     libc.src.math.fmaximum_numl
     libc.src.math.fmaximumf
+    libc.src.math.fmaximumf128
     libc.src.math.fmaximuml
     libc.src.math.fmaxl
     libc.src.math.fmin
@@ -764,7 +765,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fmaximum_mag_numf128
     libc.src.math.fmaximum_magf128
     libc.src.math.fmaximum_numf128
-    libc.src.math.fmaximumf128
     libc.src.math.fminimum_mag_numf128
     libc.src.math.fminimum_magf128
     libc.src.math.fminimum_numf128

--- a/libc/config/baremetal/aarch64/entrypoints.txt
+++ b/libc/config/baremetal/aarch64/entrypoints.txt
@@ -451,6 +451,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminimum_numf
     libc.src.math.fminimum_numl
     libc.src.math.fminimumf
+    libc.src.math.fminimumf128
     libc.src.math.fminimuml
     libc.src.math.fminl
     libc.src.math.fmod
@@ -768,7 +769,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fminimum_mag_numf128
     libc.src.math.fminimum_magf128
     libc.src.math.fminimum_numf128
-    libc.src.math.fminimumf128
     libc.src.math.fmodf128
     libc.src.math.fmulf128
     libc.src.math.frexpf128

--- a/libc/config/baremetal/aarch64/entrypoints.txt
+++ b/libc/config/baremetal/aarch64/entrypoints.txt
@@ -451,6 +451,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminimum_numf
     libc.src.math.fminimum_numl
     libc.src.math.fminimumf
+    libc.src.math.fminimumf128
     libc.src.math.fminimuml
     libc.src.math.fminl
     libc.src.math.fmod
@@ -769,7 +770,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fminimum_mag_numf128
     libc.src.math.fminimum_magf128
     libc.src.math.fminimum_numf128
-    libc.src.math.fminimumf128
     libc.src.math.fmodf128
     libc.src.math.fmulf128
     libc.src.math.frexpf128

--- a/libc/config/baremetal/aarch64/entrypoints.txt
+++ b/libc/config/baremetal/aarch64/entrypoints.txt
@@ -434,6 +434,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmaximum_numf
     libc.src.math.fmaximum_numl
     libc.src.math.fmaximumf
+    libc.src.math.fmaximumf128
     libc.src.math.fmaximuml
     libc.src.math.fmaxl
     libc.src.math.fmin
@@ -765,7 +766,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fmaximum_mag_numf128
     libc.src.math.fmaximum_magf128
     libc.src.math.fmaximum_numf128
-    libc.src.math.fmaximumf128
     libc.src.math.fminimum_mag_numf128
     libc.src.math.fminimum_magf128
     libc.src.math.fminimum_numf128

--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -446,6 +446,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmaximum_numf
     libc.src.math.fmaximum_numl
     libc.src.math.fmaximumf
+    libc.src.math.fmaximumf128
     libc.src.math.fmaximuml
     libc.src.math.fmaxl
     libc.src.math.fmin
@@ -775,7 +776,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fmaximum_mag_numf128
     libc.src.math.fmaximum_magf128
     libc.src.math.fmaximum_numf128
-    libc.src.math.fmaximumf128
     libc.src.math.fminimum_mag_numf128
     libc.src.math.fminimum_magf128
     libc.src.math.fminimum_numf128

--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -463,6 +463,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminimum_numf
     libc.src.math.fminimum_numl
     libc.src.math.fminimumf
+    libc.src.math.fminimumf128
     libc.src.math.fminimuml
     libc.src.math.fminl
     libc.src.math.fmod
@@ -779,7 +780,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fminimum_mag_numf128
     libc.src.math.fminimum_magf128
     libc.src.math.fminimum_numf128
-    libc.src.math.fminimumf128
     libc.src.math.fmodf128
     libc.src.math.fmulf128
     libc.src.math.frexpf128

--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -446,6 +446,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmaximum_numf
     libc.src.math.fmaximum_numl
     libc.src.math.fmaximumf
+    libc.src.math.fmaximumf128
     libc.src.math.fmaximuml
     libc.src.math.fmaxl
     libc.src.math.fmin
@@ -776,7 +777,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fmaximum_mag_numf128
     libc.src.math.fmaximum_magf128
     libc.src.math.fmaximum_numf128
-    libc.src.math.fmaximumf128
     libc.src.math.fminimum_mag_numf128
     libc.src.math.fminimum_magf128
     libc.src.math.fminimum_numf128

--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -463,6 +463,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminimum_numf
     libc.src.math.fminimum_numl
     libc.src.math.fminimumf
+    libc.src.math.fminimumf128
     libc.src.math.fminimuml
     libc.src.math.fminl
     libc.src.math.fmod
@@ -780,7 +781,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fminimum_mag_numf128
     libc.src.math.fminimum_magf128
     libc.src.math.fminimum_numf128
-    libc.src.math.fminimumf128
     libc.src.math.fmodf128
     libc.src.math.fmulf128
     libc.src.math.frexpf128

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -442,6 +442,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmaximum_numf
     libc.src.math.fmaximum_numl
     libc.src.math.fmaximumf
+    libc.src.math.fmaximumf128
     libc.src.math.fmaximuml
     libc.src.math.fmaxl
     libc.src.math.fmin
@@ -772,7 +773,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fmaximum_mag_numf128
     libc.src.math.fmaximum_magf128
     libc.src.math.fmaximum_numf128
-    libc.src.math.fmaximumf128
     libc.src.math.fminimum_mag_numf128
     libc.src.math.fminimum_magf128
     libc.src.math.fminimum_numf128

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -459,6 +459,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminimum_numf
     libc.src.math.fminimum_numl
     libc.src.math.fminimumf
+    libc.src.math.fminimumf128
     libc.src.math.fminimuml
     libc.src.math.fminl
     libc.src.math.fmod
@@ -776,7 +777,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fminimum_mag_numf128
     libc.src.math.fminimum_magf128
     libc.src.math.fminimum_numf128
-    libc.src.math.fminimumf128
     # libc.src.math.fmodf128
     libc.src.math.fmulf128
     libc.src.math.frexpf128

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -442,6 +442,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmaximum_numf
     libc.src.math.fmaximum_numl
     libc.src.math.fmaximumf
+    libc.src.math.fmaximumf128
     libc.src.math.fmaximuml
     libc.src.math.fmaxl
     libc.src.math.fmin
@@ -773,7 +774,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fmaximum_mag_numf128
     libc.src.math.fmaximum_magf128
     libc.src.math.fmaximum_numf128
-    libc.src.math.fmaximumf128
     libc.src.math.fminimum_mag_numf128
     libc.src.math.fminimum_magf128
     libc.src.math.fminimum_numf128

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -459,6 +459,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminimum_numf
     libc.src.math.fminimum_numl
     libc.src.math.fminimumf
+    libc.src.math.fminimumf128
     libc.src.math.fminimuml
     libc.src.math.fminl
     libc.src.math.fmod
@@ -777,7 +778,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fminimum_mag_numf128
     libc.src.math.fminimum_magf128
     libc.src.math.fminimum_numf128
-    libc.src.math.fminimumf128
     # libc.src.math.fmodf128
     libc.src.math.fmulf128
     libc.src.math.frexpf128

--- a/libc/config/darwin/aarch64/entrypoints.txt
+++ b/libc/config/darwin/aarch64/entrypoints.txt
@@ -270,6 +270,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminimum_numf
     libc.src.math.fminimum_numl
     libc.src.math.fminimumf
+    libc.src.math.fminimumf128
     libc.src.math.fminimuml
     libc.src.math.fminl
     libc.src.math.fmod
@@ -588,7 +589,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fminimum_mag_numf128
     libc.src.math.fminimum_magf128
     libc.src.math.fminimum_numf128
-    libc.src.math.fminimumf128
     libc.src.math.fmodf128
     libc.src.math.fmulf128
     libc.src.math.frexpf128

--- a/libc/config/darwin/aarch64/entrypoints.txt
+++ b/libc/config/darwin/aarch64/entrypoints.txt
@@ -253,6 +253,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmaximum_numf
     libc.src.math.fmaximum_numl
     libc.src.math.fmaximumf
+    libc.src.math.fmaximumf128
     libc.src.math.fmaximuml
     libc.src.math.fmaxl
     libc.src.math.fmin
@@ -584,7 +585,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fmaximum_mag_numf128
     libc.src.math.fmaximum_magf128
     libc.src.math.fmaximum_numf128
-    libc.src.math.fmaximumf128
     libc.src.math.fminimum_mag_numf128
     libc.src.math.fminimum_magf128
     libc.src.math.fminimum_numf128

--- a/libc/config/darwin/aarch64/entrypoints.txt
+++ b/libc/config/darwin/aarch64/entrypoints.txt
@@ -253,6 +253,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmaximum_numf
     libc.src.math.fmaximum_numl
     libc.src.math.fmaximumf
+    libc.src.math.fmaximumf128
     libc.src.math.fmaximuml
     libc.src.math.fmaxl
     libc.src.math.fmin
@@ -585,7 +586,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fmaximum_mag_numf128
     libc.src.math.fmaximum_magf128
     libc.src.math.fmaximum_numf128
-    libc.src.math.fmaximumf128
     libc.src.math.fminimum_mag_numf128
     libc.src.math.fminimum_magf128
     libc.src.math.fminimum_numf128

--- a/libc/config/darwin/aarch64/entrypoints.txt
+++ b/libc/config/darwin/aarch64/entrypoints.txt
@@ -270,6 +270,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminimum_numf
     libc.src.math.fminimum_numl
     libc.src.math.fminimumf
+    libc.src.math.fminimumf128
     libc.src.math.fminimuml
     libc.src.math.fminl
     libc.src.math.fmod
@@ -589,7 +590,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fminimum_mag_numf128
     libc.src.math.fminimum_magf128
     libc.src.math.fminimum_numf128
-    libc.src.math.fminimumf128
     libc.src.math.fmodf128
     libc.src.math.fmulf128
     libc.src.math.frexpf128

--- a/libc/config/darwin/x86_64/entrypoints.txt
+++ b/libc/config/darwin/x86_64/entrypoints.txt
@@ -158,6 +158,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     #libc.src.math.fmax
     #libc.src.math.fmaxf
     #libc.src.math.fmaxf128
+    #libc.src.math.fmaximumf128
     #libc.src.math.fmaxl
     #libc.src.math.fmin
     #libc.src.math.fminf

--- a/libc/config/darwin/x86_64/entrypoints.txt
+++ b/libc/config/darwin/x86_64/entrypoints.txt
@@ -163,6 +163,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     #libc.src.math.fmin
     #libc.src.math.fminf
     #libc.src.math.fminf128
+    #libc.src.math.fminimumf128
     #libc.src.math.fminl
     #libc.src.math.fmod
     #libc.src.math.fmodf

--- a/libc/config/freebsd/x86_64/entrypoints.txt
+++ b/libc/config/freebsd/x86_64/entrypoints.txt
@@ -183,6 +183,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmaxl
     libc.src.math.fmaximum
     libc.src.math.fmaximumf
+    libc.src.math.fmaximumf128
     libc.src.math.fmaximuml
     libc.src.math.fmaximum_num
     libc.src.math.fmaximum_numf
@@ -523,7 +524,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fmaximum_mag_numf128
     libc.src.math.fmaximum_magf128
     libc.src.math.fmaximum_numf128
-    libc.src.math.fmaximumf128
     libc.src.math.fminimum_mag_numf128
     libc.src.math.fminimum_magf128
     libc.src.math.fminimum_numf128

--- a/libc/config/freebsd/x86_64/entrypoints.txt
+++ b/libc/config/freebsd/x86_64/entrypoints.txt
@@ -196,6 +196,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmaximum_mag_numl
     libc.src.math.fminimum
     libc.src.math.fminimumf
+    libc.src.math.fminimumf128
     libc.src.math.fminimuml
     libc.src.math.fminimum_num
     libc.src.math.fminimum_numf
@@ -527,7 +528,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fminimum_mag_numf128
     libc.src.math.fminimum_magf128
     libc.src.math.fminimum_numf128
-    libc.src.math.fminimumf128
     libc.src.math.fmodf128
     libc.src.math.fmulf128
     libc.src.math.frexpf128

--- a/libc/config/freebsd/x86_64/entrypoints.txt
+++ b/libc/config/freebsd/x86_64/entrypoints.txt
@@ -183,6 +183,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmaxl
     libc.src.math.fmaximum
     libc.src.math.fmaximumf
+    libc.src.math.fmaximumf128
     libc.src.math.fmaximuml
     libc.src.math.fmaximum_num
     libc.src.math.fmaximum_numf
@@ -525,7 +526,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fmaximum_mag_numf128
     libc.src.math.fmaximum_magf128
     libc.src.math.fmaximum_numf128
-    libc.src.math.fmaximumf128
     libc.src.math.fminimum_mag_numf128
     libc.src.math.fminimum_magf128
     libc.src.math.fminimum_numf128

--- a/libc/config/freebsd/x86_64/entrypoints.txt
+++ b/libc/config/freebsd/x86_64/entrypoints.txt
@@ -196,6 +196,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmaximum_mag_numl
     libc.src.math.fminimum
     libc.src.math.fminimumf
+    libc.src.math.fminimumf128
     libc.src.math.fminimuml
     libc.src.math.fminimum_num
     libc.src.math.fminimum_numf
@@ -529,7 +530,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fminimum_mag_numf128
     libc.src.math.fminimum_magf128
     libc.src.math.fminimum_numf128
-    libc.src.math.fminimumf128
     libc.src.math.fmodf128
     libc.src.math.fmulf128
     libc.src.math.frexpf128

--- a/libc/config/gpu/amdgpu/entrypoints.txt
+++ b/libc/config/gpu/amdgpu/entrypoints.txt
@@ -372,6 +372,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmaxf128
     libc.src.math.fmaximum
     libc.src.math.fmaximumf
+    libc.src.math.fmaximumf128
     libc.src.math.fmaximuml
     libc.src.math.fmaximum_mag
     libc.src.math.fmaximum_magf

--- a/libc/config/gpu/amdgpu/entrypoints.txt
+++ b/libc/config/gpu/amdgpu/entrypoints.txt
@@ -389,6 +389,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminf128
     libc.src.math.fminimum
     libc.src.math.fminimumf
+    libc.src.math.fminimumf128
     libc.src.math.fminimuml
     libc.src.math.fminimum_mag
     libc.src.math.fminimum_magf

--- a/libc/config/gpu/nvptx/entrypoints.txt
+++ b/libc/config/gpu/nvptx/entrypoints.txt
@@ -385,6 +385,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminf128
     libc.src.math.fminimum
     libc.src.math.fminimumf
+    libc.src.math.fminimumf128
     libc.src.math.fminimuml
     libc.src.math.fminimum_mag
     libc.src.math.fminimum_magf

--- a/libc/config/gpu/nvptx/entrypoints.txt
+++ b/libc/config/gpu/nvptx/entrypoints.txt
@@ -368,6 +368,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmaxf128
     libc.src.math.fmaximum
     libc.src.math.fmaximumf
+    libc.src.math.fmaximumf128
     libc.src.math.fmaximuml
     libc.src.math.fmaximum_mag
     libc.src.math.fmaximum_magf

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -616,6 +616,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminimum_numf
     libc.src.math.fminimum_numl
     libc.src.math.fminimumf
+    libc.src.math.fminimumf128
     libc.src.math.fminimuml
     libc.src.math.fminl
     libc.src.math.fmod
@@ -927,7 +928,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fminimum_mag_numf128
     libc.src.math.fminimum_magf128
     libc.src.math.fminimum_numf128
-    libc.src.math.fminimumf128
     libc.src.math.fmodf128
     libc.src.math.fmulf128
     libc.src.math.frexpf128

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -599,6 +599,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmaximum_numf
     libc.src.math.fmaximum_numl
     libc.src.math.fmaximumf
+    libc.src.math.fmaximumf128
     libc.src.math.fmaximuml
     libc.src.math.fmaxl
     libc.src.math.fmin
@@ -923,7 +924,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fmaximum_mag_numf128
     libc.src.math.fmaximum_magf128
     libc.src.math.fmaximum_numf128
-    libc.src.math.fmaximumf128
     libc.src.math.fminimum_mag_numf128
     libc.src.math.fminimum_magf128
     libc.src.math.fminimum_numf128

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -611,6 +611,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmaximum_numf
     libc.src.math.fmaximum_numl
     libc.src.math.fmaximumf
+    libc.src.math.fmaximumf128
     libc.src.math.fmaximuml
     libc.src.math.fmaxl
     libc.src.math.fmin
@@ -936,7 +937,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fmaximum_mag_numf128
     libc.src.math.fmaximum_magf128
     libc.src.math.fmaximum_numf128
-    libc.src.math.fmaximumf128
     libc.src.math.fminimum_mag_numf128
     libc.src.math.fminimum_magf128
     libc.src.math.fminimum_numf128

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -628,6 +628,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminimum_numf
     libc.src.math.fminimum_numl
     libc.src.math.fminimumf
+    libc.src.math.fminimumf128
     libc.src.math.fminimuml
     libc.src.math.fminl
     libc.src.math.fmod
@@ -940,7 +941,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fminimum_mag_numf128
     libc.src.math.fminimum_magf128
     libc.src.math.fminimum_numf128
-    libc.src.math.fminimumf128
     libc.src.math.fmodf128
     libc.src.math.fmulf128
     libc.src.math.frexpf128

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -443,6 +443,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminimum_numf
     libc.src.math.fminimum_numl
     libc.src.math.fminimumf
+    libc.src.math.fminimumf128
     libc.src.math.fminimuml
     libc.src.math.fminl
     libc.src.math.fmod

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -426,6 +426,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmaximum_numf
     libc.src.math.fmaximum_numl
     libc.src.math.fmaximumf
+    libc.src.math.fmaximumf128
     libc.src.math.fmaximuml
     libc.src.math.fmaxl
     libc.src.math.fmin

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -453,6 +453,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminimum_numf
     libc.src.math.fminimum_numl
     libc.src.math.fminimumf
+    libc.src.math.fminimumf128
     libc.src.math.fminimuml
     libc.src.math.fminl
     libc.src.math.fmod

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -436,6 +436,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmaximum_numf
     libc.src.math.fmaximum_numl
     libc.src.math.fmaximumf
+    libc.src.math.fmaximumf128
     libc.src.math.fmaximuml
     libc.src.math.fmaxl
     libc.src.math.fmin

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -668,6 +668,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmaximum_numf
     libc.src.math.fmaximum_numl
     libc.src.math.fmaximumf
+    libc.src.math.fmaximumf128
     libc.src.math.fmaximuml
     libc.src.math.fmaxl
     libc.src.math.fmin
@@ -1009,7 +1010,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fmaximum_mag_numf128
     libc.src.math.fmaximum_magf128
     libc.src.math.fmaximum_numf128
-    libc.src.math.fmaximumf128
     libc.src.math.fminimum_mag_numf128
     libc.src.math.fminimum_magf128
     libc.src.math.fminimum_numf128

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -685,6 +685,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminimum_numf
     libc.src.math.fminimum_numl
     libc.src.math.fminimumf
+    libc.src.math.fminimumf128
     libc.src.math.fminimuml
     libc.src.math.fminl
     libc.src.math.fmod
@@ -1013,7 +1014,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fminimum_mag_numf128
     libc.src.math.fminimum_magf128
     libc.src.math.fminimum_numf128
-    libc.src.math.fminimumf128
     libc.src.math.fmodf128
     libc.src.math.fmulf128
     libc.src.math.frexpf128

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -697,6 +697,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminimum_numf
     libc.src.math.fminimum_numl
     libc.src.math.fminimumf
+    libc.src.math.fminimumf128
     libc.src.math.fminimuml
     libc.src.math.fminl
     libc.src.math.fmod
@@ -1026,7 +1027,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fminimum_mag_numf128
     libc.src.math.fminimum_magf128
     libc.src.math.fminimum_numf128
-    libc.src.math.fminimumf128
     libc.src.math.fmodf128
     libc.src.math.fmulf128
     libc.src.math.frexpf128

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -680,6 +680,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmaximum_numf
     libc.src.math.fmaximum_numl
     libc.src.math.fmaximumf
+    libc.src.math.fmaximumf128
     libc.src.math.fmaximuml
     libc.src.math.fmaxl
     libc.src.math.fmin
@@ -1022,7 +1023,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fmaximum_mag_numf128
     libc.src.math.fmaximum_magf128
     libc.src.math.fmaximum_numf128
-    libc.src.math.fmaximumf128
     libc.src.math.fminimum_mag_numf128
     libc.src.math.fminimum_magf128
     libc.src.math.fminimum_numf128

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -694,6 +694,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminimum_numf
     libc.src.math.fminimum_numl
     libc.src.math.fminimumf
+    libc.src.math.fminimumf128
     libc.src.math.fminimuml
     libc.src.math.fminl
     libc.src.math.fmod
@@ -1022,7 +1023,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fminimum_mag_numf128
     libc.src.math.fminimum_magf128
     libc.src.math.fminimum_numf128
-    libc.src.math.fminimumf128
     libc.src.math.fmodf128
     libc.src.math.fmulf128
     libc.src.math.frexpf128

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -677,6 +677,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmaximum_numf
     libc.src.math.fmaximum_numl
     libc.src.math.fmaximumf
+    libc.src.math.fmaximumf128
     libc.src.math.fmaximuml
     libc.src.math.fmaxl
     libc.src.math.fmin
@@ -1018,7 +1019,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fmaximum_mag_numf128
     libc.src.math.fmaximum_magf128
     libc.src.math.fmaximum_numf128
-    libc.src.math.fmaximumf128
     libc.src.math.fminimum_mag_numf128
     libc.src.math.fminimum_magf128
     libc.src.math.fminimum_numf128

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -706,6 +706,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fminimum_numf
     libc.src.math.fminimum_numl
     libc.src.math.fminimumf
+    libc.src.math.fminimumf128
     libc.src.math.fminimuml
     libc.src.math.fminl
     libc.src.math.fmod
@@ -1035,7 +1036,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fminimum_mag_numf128
     libc.src.math.fminimum_magf128
     libc.src.math.fminimum_numf128
-    libc.src.math.fminimumf128
     libc.src.math.fmodf128
     libc.src.math.fmulf128
     libc.src.math.frexpf128

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -689,6 +689,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmaximum_numf
     libc.src.math.fmaximum_numl
     libc.src.math.fmaximumf
+    libc.src.math.fmaximumf128
     libc.src.math.fmaximuml
     libc.src.math.fmaxl
     libc.src.math.fmin
@@ -1031,7 +1032,6 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.fmaximum_mag_numf128
     libc.src.math.fmaximum_magf128
     libc.src.math.fmaximum_numf128
-    libc.src.math.fmaximumf128
     libc.src.math.fminimum_mag_numf128
     libc.src.math.fminimum_magf128
     libc.src.math.fminimum_numf128

--- a/libc/config/windows/entrypoints.txt
+++ b/libc/config/windows/entrypoints.txt
@@ -229,6 +229,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmaximum_mag_numl
     libc.src.math.fminimum
     libc.src.math.fminimumf
+    libc.src.math.fminimumf128
     libc.src.math.fminimuml
     libc.src.math.fminimum_num
     libc.src.math.fminimum_numf

--- a/libc/config/windows/entrypoints.txt
+++ b/libc/config/windows/entrypoints.txt
@@ -216,6 +216,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmaxl
     libc.src.math.fmaximum
     libc.src.math.fmaximumf
+    libc.src.math.fmaximumf128
     libc.src.math.fmaximuml
     libc.src.math.fmaximum_num
     libc.src.math.fmaximum_numf

--- a/libc/shared/math/fmaximumf128.h
+++ b/libc/shared/math/fmaximumf128.h
@@ -9,10 +9,6 @@
 #ifndef LLVM_LIBC_SHARED_MATH_FMAXIMUMF128_H
 #define LLVM_LIBC_SHARED_MATH_FMAXIMUMF128_H
 
-#include "include/llvm-libc-types/float128.h"
-
-#ifdef LIBC_TYPES_HAS_NATIVE_FLOAT128
-
 #include "shared/libc_common.h"
 #include "src/__support/math/fmaximumf128.h"
 
@@ -23,7 +19,5 @@ using math::fmaximumf128;
 
 } // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
-
-#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 #endif // LLVM_LIBC_SHARED_MATH_FMAXIMUMF128_H

--- a/libc/shared/math/fminimumf128.h
+++ b/libc/shared/math/fminimumf128.h
@@ -9,10 +9,6 @@
 #ifndef LLVM_LIBC_SHARED_MATH_FMINIMUMF128_H
 #define LLVM_LIBC_SHARED_MATH_FMINIMUMF128_H
 
-#include "include/llvm-libc-types/float128.h"
-
-#ifdef LIBC_TYPES_HAS_NATIVE_FLOAT128
-
 #include "shared/libc_common.h"
 #include "src/__support/math/fminimumf128.h"
 
@@ -23,7 +19,5 @@ using math::fminimumf128;
 
 } // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
-
-#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 #endif // LLVM_LIBC_SHARED_MATH_FMINIMUMF128_H

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -899,7 +899,7 @@ add_header_library(
   HDRS
     fmaximumf128.h
   DEPENDS
-    libc.include.llvm-libc-types.float128
+    libc.src.__support.FPUtil.float128
     libc.src.__support.FPUtil.basic_operations
     libc.src.__support.macros.config
 )

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -1175,7 +1175,7 @@ add_header_library(
   HDRS
     fminimumf128.h
   DEPENDS
-    libc.include.llvm-libc-types.float128
+    libc.src.__support.FPUtil.float128
     libc.src.__support.FPUtil.basic_operations
     libc.src.__support.macros.config
 )

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -899,8 +899,8 @@ add_header_library(
   HDRS
     fmaximumf128.h
   DEPENDS
-    libc.src.__support.FPUtil.float128
     libc.src.__support.FPUtil.basic_operations
+    libc.src.__support.FPUtil.float128
     libc.src.__support.macros.config
 )
 
@@ -1175,8 +1175,8 @@ add_header_library(
   HDRS
     fminimumf128.h
   DEPENDS
-    libc.src.__support.FPUtil.float128
     libc.src.__support.FPUtil.basic_operations
+    libc.src.__support.FPUtil.float128
     libc.src.__support.macros.config
 )
 

--- a/libc/src/__support/math/fmaximumf128.h
+++ b/libc/src/__support/math/fmaximumf128.h
@@ -9,23 +9,20 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_MATH_FMAXIMUMF128_H
 #define LLVM_LIBC_SRC___SUPPORT_MATH_FMAXIMUMF128_H
 
-#include "include/llvm-libc-types/float128.h"
-
-#ifdef LIBC_TYPES_HAS_NATIVE_FLOAT128
-
 #include "src/__support/FPUtil/BasicOperations.h"
+#include "src/__support/FPUtil/float128.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
 namespace math {
 
-LIBC_INLINE constexpr float128 fmaximumf128(float128 x, float128 y) {
+using LIBC_NAMESPACE::fputil::Float128;
+
+LIBC_INLINE constexpr Float128 fmaximumf128(Float128 x, Float128 y) {
   return fputil::fmaximum(x, y);
 }
 
 } // namespace math
 } // namespace LIBC_NAMESPACE_DECL
-
-#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 #endif // LLVM_LIBC_SRC___SUPPORT_MATH_FMAXIMUMF128_H

--- a/libc/src/__support/math/fminimumf128.h
+++ b/libc/src/__support/math/fminimumf128.h
@@ -9,23 +9,20 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_MATH_FMINIMUMF128_H
 #define LLVM_LIBC_SRC___SUPPORT_MATH_FMINIMUMF128_H
 
-#include "include/llvm-libc-types/float128.h"
-
-#ifdef LIBC_TYPES_HAS_NATIVE_FLOAT128
-
 #include "src/__support/FPUtil/BasicOperations.h"
+#include "src/__support/FPUtil/float128.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
 namespace math {
 
-LIBC_INLINE constexpr float128 fminimumf128(float128 x, float128 y) {
+using LIBC_NAMESPACE::fputil::Float128;
+
+LIBC_INLINE constexpr Float128 fminimumf128(Float128 x, Float128 y) {
   return fputil::fminimum(x, y);
 }
 
 } // namespace math
 } // namespace LIBC_NAMESPACE_DECL
-
-#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 #endif // LLVM_LIBC_SRC___SUPPORT_MATH_FMINIMUMF128_H

--- a/libc/src/math/fmaximumf128.h
+++ b/libc/src/math/fmaximumf128.h
@@ -10,10 +10,15 @@
 #ifndef LLVM_LIBC_SRC_MATH_FMAXIMUMF128_H
 #define LLVM_LIBC_SRC_MATH_FMAXIMUMF128_H
 
+#include "src/__support/FPUtil/float128.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/types.h"
 
 namespace LIBC_NAMESPACE_DECL {
+
+#ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128
+using float128 = LIBC_NAMESPACE::fputil::Float128;
+#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 float128 fmaximumf128(float128 x, float128 y);
 

--- a/libc/src/math/fminimumf128.h
+++ b/libc/src/math/fminimumf128.h
@@ -10,10 +10,15 @@
 #ifndef LLVM_LIBC_SRC_MATH_FMINIMUMF128_H
 #define LLVM_LIBC_SRC_MATH_FMINIMUMF128_H
 
+#include "src/__support/FPUtil/float128.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/types.h"
 
 namespace LIBC_NAMESPACE_DECL {
+
+#ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128
+using float128 = LIBC_NAMESPACE::fputil::Float128;
+#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 float128 fminimumf128(float128 x, float128 y);
 

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -2413,6 +2413,7 @@ add_entrypoint_object(
   HDRS
     ../fminimumf128.h
   DEPENDS
+    libc.src.__support.CPP.bit
     libc.src.__support.math.fminimumf128
 )
 

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -2172,6 +2172,7 @@ add_entrypoint_object(
   HDRS
     ../fmaximumf128.h
   DEPENDS
+    libc.src.__support.CPP.bit
     libc.src.__support.math.fmaximumf128
 )
 

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -2426,6 +2426,7 @@ add_entrypoint_object(
   HDRS
     ../fminimumf128.h
   DEPENDS
+    libc.src.__support.CPP.bit
     libc.src.__support.math.fminimumf128
 )
 

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -2185,6 +2185,7 @@ add_entrypoint_object(
   HDRS
     ../fmaximumf128.h
   DEPENDS
+    libc.src.__support.CPP.bit
     libc.src.__support.math.fmaximumf128
 )
 

--- a/libc/src/math/generic/fmaximumf128.cpp
+++ b/libc/src/math/generic/fmaximumf128.cpp
@@ -7,12 +7,16 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/math/fmaximumf128.h"
+#include "src/__support/CPP/bit.h"
 #include "src/__support/math/fmaximumf128.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
+using LIBC_NAMESPACE::fputil::Float128;
+
 LLVM_LIBC_FUNCTION(float128, fmaximumf128, (float128 x, float128 y)) {
-  return math::fmaximumf128(x, y);
+  return cpp::bit_cast<float128>(math::fmaximumf128(
+      cpp::bit_cast<Float128>(x), cpp::bit_cast<Float128>(y)));
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/math/generic/fminimumf128.cpp
+++ b/libc/src/math/generic/fminimumf128.cpp
@@ -7,12 +7,16 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/math/fminimumf128.h"
+#include "src/__support/CPP/bit.h"
 #include "src/__support/math/fminimumf128.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
+using LIBC_NAMESPACE::fputil::Float128;
+
 LLVM_LIBC_FUNCTION(float128, fminimumf128, (float128 x, float128 y)) {
-  return math::fminimumf128(x, y);
+  return cpp::bit_cast<float128>(math::fminimumf128(
+      cpp::bit_cast<Float128>(x), cpp::bit_cast<Float128>(y)));
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/test/shared/shared_math_constexpr_test.cpp
+++ b/libc/test/shared/shared_math_constexpr_test.cpp
@@ -382,9 +382,6 @@ static_assert(0 == LIBC_NAMESPACE::shared::isnanl(0.0L));
 
 static_assert(Float128(0.0) == LIBC_NAMESPACE::shared::ceilf128(Float128(0.0)));
 static_assert(Float128(0.0) ==
-              LIBC_NAMESPACE::shared::fmaximumf128(Float128(0.0),
-                                                   Float128(0.0)));
-static_assert(Float128(0.0) ==
               LIBC_NAMESPACE::shared::copysignf128(Float128(0.0),
                                                    Float128(0.0)));
 static_assert(Float128(1.0) ==
@@ -395,6 +392,12 @@ static_assert(Float128(0.0) ==
               LIBC_NAMESPACE::shared::fmaxf128(Float128(0.0), Float128(0.0)));
 static_assert(Float128(0.0) ==
               LIBC_NAMESPACE::shared::fminf128(Float128(0.0), Float128(0.0)));
+static_assert(Float128(0.0) ==
+              LIBC_NAMESPACE::shared::fmaximumf128(Float128(0.0),
+                                                   Float128(0.0)));
+static_assert(Float128(0.0) ==
+              LIBC_NAMESPACE::shared::fminimumf128(Float128(0.0),
+                                                   Float128(0.0)));
 static_assert(1 == LIBC_NAMESPACE::shared::iscanonicalf128(Float128(0.0)));
 static_assert(0 == LIBC_NAMESPACE::shared::isnanf128(Float128(0.0)));
 static_assert(0.0 == LIBC_NAMESPACE::shared::issignalingf128(Float128(0.0)));
@@ -433,9 +436,6 @@ static_assert(float128(1.0) ==
               LIBC_NAMESPACE::shared::fdimf128(float128(1.0), float128(0.0)));
 static_assert(0.0f ==
               LIBC_NAMESPACE::shared::fdivf128(float128(0.0), float128(1.0)));
-static_assert(float128(0.0) ==
-              LIBC_NAMESPACE::shared::fminimumf128(float128(0.0),
-                                                   float128(0.0)));
 static_assert(0.0 == LIBC_NAMESPACE::shared::dsqrtf128(float128(0.0)));
 static_assert(float128(0.0) ==
               LIBC_NAMESPACE::shared::fmaximum_numf128(float128(0.0),

--- a/libc/test/shared/shared_math_constexpr_test.cpp
+++ b/libc/test/shared/shared_math_constexpr_test.cpp
@@ -382,6 +382,9 @@ static_assert(0 == LIBC_NAMESPACE::shared::isnanl(0.0L));
 
 static_assert(Float128(0.0) == LIBC_NAMESPACE::shared::ceilf128(Float128(0.0)));
 static_assert(Float128(0.0) ==
+              LIBC_NAMESPACE::shared::fmaximumf128(Float128(0.0),
+                                                   Float128(0.0)));
+static_assert(Float128(0.0) ==
               LIBC_NAMESPACE::shared::copysignf128(Float128(0.0),
                                                    Float128(0.0)));
 static_assert(Float128(1.0) ==
@@ -430,9 +433,6 @@ static_assert(float128(1.0) ==
               LIBC_NAMESPACE::shared::fdimf128(float128(1.0), float128(0.0)));
 static_assert(0.0f ==
               LIBC_NAMESPACE::shared::fdivf128(float128(0.0), float128(1.0)));
-static_assert(float128(0.0) ==
-              LIBC_NAMESPACE::shared::fmaximumf128(float128(0.0),
-                                                   float128(0.0)));
 static_assert(float128(0.0) ==
               LIBC_NAMESPACE::shared::fminimumf128(float128(0.0),
                                                    float128(0.0)));

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -584,6 +584,9 @@ TEST(LlvmLibcSharedMathTest, AllEmuFloat128) {
   EXPECT_FP_EQ(Float128(0.0),
                LIBC_NAMESPACE::shared::atan2f128(Float128(0.0), Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::ceilf128(Float128(0.0)));
+
+  EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::fmaximumf128(
+                                  Float128(0.0), Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::copysignf128(
                                   Float128(0.0), Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::fabsf128(Float128(0.0)));
@@ -702,9 +705,6 @@ TEST(LlvmLibcSharedMathTest, AllFloat128) {
       0.0f16, LIBC_NAMESPACE::shared::f16subf128(float128(0.0), float128(0.0)));
   EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::f16sqrtf128(float128(0.0)));
 #endif // LIBC_TYPES_HAS_FLOAT16
-
-  EXPECT_FP_EQ(float128(0.0), LIBC_NAMESPACE::shared::fmaximumf128(
-                                  float128(0.0), float128(0.0)));
   EXPECT_FP_EQ(float128(0.0), LIBC_NAMESPACE::shared::fminimumf128(
                                   float128(0.0), float128(0.0)));
   EXPECT_FP_EQ(float128(0.0), LIBC_NAMESPACE::shared::fmaximum_numf128(

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -584,9 +584,6 @@ TEST(LlvmLibcSharedMathTest, AllEmuFloat128) {
   EXPECT_FP_EQ(Float128(0.0),
                LIBC_NAMESPACE::shared::atan2f128(Float128(0.0), Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::ceilf128(Float128(0.0)));
-
-  EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::fmaximumf128(
-                                  Float128(0.0), Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::copysignf128(
                                   Float128(0.0), Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::fabsf128(Float128(0.0)));
@@ -595,6 +592,10 @@ TEST(LlvmLibcSharedMathTest, AllEmuFloat128) {
                LIBC_NAMESPACE::shared::fmaxf128(Float128(0.0), Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0),
                LIBC_NAMESPACE::shared::fminf128(Float128(0.0), Float128(0.0)));
+  EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::fmaximumf128(
+                                  Float128(0.0), Float128(0.0)));
+  EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::fminimumf128(
+                                  Float128(0.0), Float128(0.0)));
   EXPECT_EQ(1, LIBC_NAMESPACE::shared::iscanonicalf128(Float128(0.0)));
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::isnanf128(Float128(0.0)));
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::issignalingf128(Float128(0.0)));
@@ -705,8 +706,6 @@ TEST(LlvmLibcSharedMathTest, AllFloat128) {
       0.0f16, LIBC_NAMESPACE::shared::f16subf128(float128(0.0), float128(0.0)));
   EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::f16sqrtf128(float128(0.0)));
 #endif // LIBC_TYPES_HAS_FLOAT16
-  EXPECT_FP_EQ(float128(0.0), LIBC_NAMESPACE::shared::fminimumf128(
-                                  float128(0.0), float128(0.0)));
   EXPECT_FP_EQ(float128(0.0), LIBC_NAMESPACE::shared::fmaximum_numf128(
                                   float128(0.0), float128(0.0)));
   EXPECT_FP_EQ(float128(0.0), LIBC_NAMESPACE::shared::fminimum_numf128(

--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -2878,6 +2878,7 @@ add_fp_unittest(
   HDRS
     FMaximumTest.h
   DEPENDS
+    libc.src.__support.FPUtil.float128
     libc.src.math.fmaximumf128
     libc.src.__support.CPP.algorithm
     libc.src.__support.FPUtil.fp_bits

--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -3224,6 +3224,7 @@ add_fp_unittest(
   HDRS
     FMinimumTest.h
   DEPENDS
+    libc.src.__support.FPUtil.float128
     libc.src.math.fminimumf128
     libc.src.__support.CPP.algorithm
     libc.src.__support.FPUtil.fp_bits

--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -3235,6 +3235,7 @@ add_fp_unittest(
   HDRS
     FMinimumTest.h
   DEPENDS
+    libc.src.__support.FPUtil.float128
     libc.src.math.fminimumf128
     libc.src.__support.CPP.algorithm
     libc.src.__support.FPUtil.fp_bits

--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -2889,9 +2889,9 @@ add_fp_unittest(
   HDRS
     FMaximumTest.h
   DEPENDS
-    libc.src.__support.FPUtil.float128
     libc.src.math.fmaximumf128
     libc.src.__support.CPP.algorithm
+    libc.src.__support.FPUtil.float128
     libc.src.__support.FPUtil.fp_bits
 )
 
@@ -3235,9 +3235,9 @@ add_fp_unittest(
   HDRS
     FMinimumTest.h
   DEPENDS
-    libc.src.__support.FPUtil.float128
     libc.src.math.fminimumf128
     libc.src.__support.CPP.algorithm
+    libc.src.__support.FPUtil.float128
     libc.src.__support.FPUtil.fp_bits
 )
 

--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -2889,6 +2889,7 @@ add_fp_unittest(
   HDRS
     FMaximumTest.h
   DEPENDS
+    libc.src.__support.FPUtil.float128
     libc.src.math.fmaximumf128
     libc.src.__support.CPP.algorithm
     libc.src.__support.FPUtil.fp_bits

--- a/libc/test/src/math/smoke/FMaximumTest.h
+++ b/libc/test/src/math/smoke/FMaximumTest.h
@@ -68,7 +68,7 @@ public:
         continue;
       T x = xbits.get_val();
       T y = ybits.get_val();
-      if ((x == 0) && (y == 0))
+      if ((x == T(0)) && (y == T(0)))
         continue;
 
       if (x > y)

--- a/libc/test/src/math/smoke/FMinimumTest.h
+++ b/libc/test/src/math/smoke/FMinimumTest.h
@@ -68,7 +68,7 @@ public:
         continue;
       T x = xbits.get_val();
       T y = ybits.get_val();
-      if ((x == 0) && (y == 0))
+      if ((x == T(0)) && (y == T(0)))
         continue;
 
       if (x > y)

--- a/libc/test/src/math/smoke/fmaximumf128_test.cpp
+++ b/libc/test/src/math/smoke/fmaximumf128_test.cpp
@@ -7,7 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "FMaximumTest.h"
+#include "src/__support/FPUtil/float128.h"
 
 #include "src/math/fmaximumf128.h"
+
+#ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128
+using float128 = LIBC_NAMESPACE::fputil::Float128;
+#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 LIST_FMAXIMUM_TESTS(float128, LIBC_NAMESPACE::fmaximumf128)

--- a/libc/test/src/math/smoke/fmaximumf128_test.cpp
+++ b/libc/test/src/math/smoke/fmaximumf128_test.cpp
@@ -7,8 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "FMaximumTest.h"
-#include "src/__support/FPUtil/float128.h"
 
+#include "src/__support/FPUtil/float128.h"
 #include "src/math/fmaximumf128.h"
 
 #ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128

--- a/libc/test/src/math/smoke/fminimumf128_test.cpp
+++ b/libc/test/src/math/smoke/fminimumf128_test.cpp
@@ -7,7 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "FMinimumTest.h"
+#include "src/__support/FPUtil/float128.h"
 
 #include "src/math/fminimumf128.h"
+
+#ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128
+using float128 = LIBC_NAMESPACE::fputil::Float128;
+#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 LIST_FMINIMUM_TESTS(float128, LIBC_NAMESPACE::fminimumf128)

--- a/libc/test/src/math/smoke/fminimumf128_test.cpp
+++ b/libc/test/src/math/smoke/fminimumf128_test.cpp
@@ -7,8 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "FMinimumTest.h"
-#include "src/__support/FPUtil/float128.h"
 
+#include "src/__support/FPUtil/float128.h"
 #include "src/math/fminimumf128.h"
 
 #ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -5712,8 +5712,8 @@ libc_support_library(
     hdrs = ["src/__support/math/fminimumf128.h"],
     deps = [
         ":__support_fputil_basic_operations",
+        ":__support_fputil_float128",
         ":__support_macros_config",
-        ":llvm_libc_types_float128",
     ],
 )
 
@@ -12076,6 +12076,8 @@ libc_math_function(
 libc_math_function(
     name = "fminimumf128",
     additional_deps = [
+        ":__support_cpp_bit",
+        ":__support_fputil_float128",
         ":__support_math_fminimumf128",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -5464,8 +5464,8 @@ libc_support_library(
     hdrs = ["src/__support/math/fmaximumf128.h"],
     deps = [
         ":__support_fputil_basic_operations",
+        ":__support_fputil_float128",
         ":__support_macros_config",
-        ":llvm_libc_types_float128",
     ],
 )
 
@@ -11890,6 +11890,8 @@ libc_math_function(
 libc_math_function(
     name = "fmaximumf128",
     additional_deps = [
+        ":__support_cpp_bit",
+        ":__support_fputil_float128",
         ":__support_math_fmaximumf128",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -5472,8 +5472,8 @@ libc_support_library(
     hdrs = ["src/__support/math/fmaximumf128.h"],
     deps = [
         ":__support_fputil_basic_operations",
+        ":__support_fputil_float128",
         ":__support_macros_config",
-        ":llvm_libc_types_float128",
     ],
 )
 
@@ -11930,6 +11930,8 @@ libc_math_function(
 libc_math_function(
     name = "fmaximumf128",
     additional_deps = [
+        ":__support_cpp_bit",
+        ":__support_fputil_float128",
         ":__support_math_fmaximumf128",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -5720,8 +5720,8 @@ libc_support_library(
     hdrs = ["src/__support/math/fminimumf128.h"],
     deps = [
         ":__support_fputil_basic_operations",
+        ":__support_fputil_float128",
         ":__support_macros_config",
-        ":llvm_libc_types_float128",
     ],
 )
 
@@ -12116,6 +12116,8 @@ libc_math_function(
 libc_math_function(
     name = "fminimumf128",
     additional_deps = [
+        ":__support_cpp_bit",
+        ":__support_fputil_float128",
         ":__support_math_fminimumf128",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
@@ -574,6 +574,9 @@ math_test(
 math_test(
     name = "fmaximumf128",
     hdrs = ["FMaximumTest.h"],
+    deps = [
+        "//libc:__support_fputil_float128",
+    ],
 )
 
 math_test(

--- a/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
@@ -705,6 +705,9 @@ math_test(
 math_test(
     name = "fminimumf128",
     hdrs = ["FMinimumTest.h"],
+    deps = [
+        "//libc:__support_fputil_float128",
+    ],
 )
 
 math_test(


### PR DESCRIPTION
Stacked on #217389.