### PR TITLE
[OpenACC] propagate llvm loop annotations

### DIFF
--- a/mlir/lib/Dialect/OpenACC/Utils/OpenACCUtilsLoop.cpp
+++ b/mlir/lib/Dialect/OpenACC/Utils/OpenACCUtilsLoop.cpp
@@ -14,6 +14,7 @@
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Arith/Utils/Utils.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/OpenACC/OpenACC.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SCF/Utils/Utils.h"
@@ -95,6 +96,14 @@ static Block::iterator cloneACCRegionIntoForLoop(Region *src, Block *dest,
       acc::cloneACCRegionInto(src, dest, insertionPoint, mapping, ValueRange{});
   (void)replacements;
   return ip;
+}
+
+/// Copy the discardable LLVM loop annotation attribute from an acc.loop to the
+/// lowered SCF op so later SCF to CFG/LLVM lowering can emit !llvm.loop
+/// metadata.
+static void copyLoopAnnotationAttr(Operation *from, Operation *to) {
+  if (Attribute ann = from->getDiscardableAttr(LLVM::LoopAnnotationAttr::name))
+    to->setDiscardableAttr(LLVM::LoopAnnotationAttr::name, ann);
 }
 
 } // namespace
@@ -257,6 +266,7 @@ scf::ForOp convertACCLoopToSCFFor(LoopOp loopOp, RewriterBase &rewriter,
       setCollapseCountAttr(forOps.front(), numCollapsed);
   }
 
+  copyLoopAnnotationAttr(loopOp, forOps.front());
   return forOps.front();
 }
 
@@ -321,6 +331,7 @@ scf::ParallelOp convertACCLoopToSCFParallel(LoopOp loopOp,
                       loopOp.getStep()[idx]);
 
   setCollapseCountAttr(parallelOp, parallelOp.getNumLoops());
+  copyLoopAnnotationAttr(loopOp, parallelOp);
   return parallelOp;
 }
 

--- a/mlir/test/Dialect/OpenACC/acc-compute-lowering-loop.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-compute-lowering-loop.mlir
@@ -1,5 +1,8 @@
 // RUN: mlir-opt %s -acc-compute-lowering | FileCheck %s
 
+// CHECK: [[UNROLL:#.*]] = #llvm.loop_unroll<disable = false, full = true>
+// CHECK: #loop_annotation = #llvm.loop_annotation<unroll = [[UNROLL]]>
+
 // CHECK-LABEL: func.func @parallel_independent_loop
 func.func @parallel_independent_loop(%buf: memref<16xi32>) {
   %c0 = arith.constant 0 : index
@@ -230,5 +233,26 @@ func.func @parallel_loop_auto_gang(%buf: memref<1xi32>) {
     acc.yield
   }
   acc.copyout accPtr(%dev : memref<1xi32>) to varPtr(%buf : memref<1xi32>)
+  return
+}
+
+// -----
+
+// Preserve llvm.loop_annotation (e.g. from !dir$ unroll) when lowering acc.loop.
+// CHECK-LABEL: func.func @orphan_loop_unroll_annotation
+// CHECK-NOT: acc.loop
+// CHECK: scf.for {{.*}} {
+// CHECK: } {llvm.loop_annotation = #loop_annotation}
+func.func @orphan_loop_unroll_annotation(%buf: memref<8xi32>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c8 = arith.constant 8 : index
+  %c0_i32 = arith.constant 0 : i32
+
+  acc.loop control(%i : index) = (%c0 : index) to (%c8 : index) step (%c1 : index) {
+    memref.store %c0_i32, %buf[%i] : memref<8xi32>
+    acc.yield
+  } attributes {independent = [#acc.device_type<none>],
+                llvm.loop_annotation = #llvm.loop_annotation<unroll = <disable = false, full = true>>} 
   return
 }


### PR DESCRIPTION
When lowering acc.loop to scf.for or scf.parallel, copy any llvm loop annotations that are present