### PR TITLE
[lit][bazel] Fall back to a default PATHEXT when the variable is unset

### DIFF
--- a/llvm/utils/lit/lit/util.py
+++ b/llvm/utils/lit/lit/util.py
@@ -130,7 +130,12 @@ def which(command, paths=None):
     # Get suffixes to search.
     # On Cygwin, 'PATHEXT' may exist but it should not be used.
     if os.pathsep == ";":
-        pathext = os.environ.get("PATHEXT", "").split(";")
+        # If PATHEXT was stripped from the environment (e.g. when
+        # running with a hermetic build system like Bazel) then
+        # use a sane fallback so binaries can still be located.
+        fallback = ".COM;.EXE;.BAT;.CMD"
+
+        pathext = os.environ.get("PATHEXT", fallback).split(";")
     else:
         pathext = [""]
 

--- a/llvm/utils/lit/tests/use-llvm-tool.py
+++ b/llvm/utils/lit/tests/use-llvm-tool.py
@@ -33,6 +33,14 @@
 # CHECK-NEXT: note: using case9: {{.*}}search2{{[\\/]}}case9
 # CHECK-NEXT: note: using case10: {{.*}}path{{[\\/]}}case10
 
+## Show that tools are still found when PATHEXT is unset, as can happen with
+## hermetic build systems (like Bazel) that strip environment variables.
+## Inputs provide both "case2" and "case2.exe", so match the extension
+## explicitly: without a fallback, lit finds the extension-less "case2".
+# RUN: %if system-windows %{ env -u PATHEXT %{lit} %{inputs}/use-llvm-tool 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=NO-PATHEXT %}
+# NO-PATHEXT: note: using case2: {{.*}}build{{[\\/]}}case2.exe
+
 ## Test that if required is True, lit errors if the tool is not found.
 # RUN: not %{lit} %{inputs}/use-llvm-tool-required 2>&1 | \
 # RUN:   FileCheck %s --check-prefix=ERROR


### PR DESCRIPTION
When running tests on Windows with Bazel, we can enter a scenario where `PATHEXT` is stripped from the environment before python starts, resulting in binaries not being found. This change adds a common fallback in the event `PATHEXT` is ever undefined or set to an empty value.