### PR TITLE
[DirectX][SPIR-V] Fix `copysign` backend lowering

### DIFF
--- a/llvm/lib/Target/DirectX/DXILIntrinsicExpansion.cpp
+++ b/llvm/lib/Target/DirectX/DXILIntrinsicExpansion.cpp
@@ -1065,20 +1065,41 @@ static Value *expandCopySignIntrinsic(CallInst *Orig) {
 
   IRBuilder<> Builder(Orig);
 
-  unsigned BitWidth = Ty->getScalarSizeInBits();
+  bool IsDouble = Ty->getScalarType()->isDoubleTy();
+  unsigned BitWidth = IsDouble ? 32 : Ty->getScalarSizeInBits();
   Type *IntTy = Ty->getWithNewType(Builder.getIntNTy(BitWidth));
 
-  // `ConstantInt::get` broadcasts to a splat when `IntTy` is a vector.
-  APInt SignMaskVal = APInt::getSignMask(BitWidth);
-  Constant *SignMask = ConstantInt::get(IntTy, SignMaskVal);
-  Constant *NotSignMask = ConstantInt::get(IntTy, ~SignMaskVal);
+  auto CopySignBit = [&](Value *MagnitudeInt, Value *SignInt) {
+    APInt SignMaskVal = APInt::getSignMask(BitWidth);
+    // `ConstantInt::get` broadcasts to a splat when `IntTy` is a vector.
+    Constant *SignMask = ConstantInt::get(IntTy, SignMaskVal);
+    Constant *NotSignMask = ConstantInt::get(IntTy, ~SignMaskVal);
+
+    Value *MagnitudeBits = Builder.CreateAnd(MagnitudeInt, NotSignMask);
+    Value *SignBits = Builder.CreateAnd(SignInt, SignMask);
+    return Builder.CreateOr(MagnitudeBits, SignBits);
+  };
+
+  // Avoid i64 bitwise ops, which require the Int64Ops shader feature.
+  if (IsDouble) {
+    auto *SplitTy = StructType::get(IntTy, IntTy);
+    Value *MagnitudeHalves = Builder.CreateIntrinsic(
+        SplitTy, Intrinsic::dx_splitdouble, {Magnitude});
+    Value *SignHalves =
+        Builder.CreateIntrinsic(SplitTy, Intrinsic::dx_splitdouble, {Sign});
+    Value *MagnitudeLow = Builder.CreateExtractValue(MagnitudeHalves, 0);
+    Value *MagnitudeHigh = Builder.CreateExtractValue(MagnitudeHalves, 1);
+    Value *SignHigh = Builder.CreateExtractValue(SignHalves, 1);
+
+    Value *CombinedHigh = CopySignBit(MagnitudeHigh, SignHigh);
+    return Builder.CreateIntrinsic(Ty, Intrinsic::dx_asdouble,
+                                   {MagnitudeLow, CombinedHigh});
+  }
 
   Value *MagnitudeInt = Builder.CreateBitCast(Magnitude, IntTy);
   Value *SignInt = Builder.CreateBitCast(Sign, IntTy);
-  Value *MagnitudeBits = Builder.CreateAnd(MagnitudeInt, NotSignMask);
-  Value *SignBits = Builder.CreateAnd(SignInt, SignMask);
-  Value *Result = Builder.CreateOr(MagnitudeBits, SignBits);
-  return Builder.CreateBitCast(Result, Ty);
+  Value *CombinedInt = CopySignBit(MagnitudeInt, SignInt);
+  return Builder.CreateBitCast(CombinedInt, Ty);
 }
 
 // Expand llvm.matrix.multiply by extracting row/column vectors and computing

--- a/llvm/lib/Target/DirectX/DXILIntrinsicExpansion.cpp
+++ b/llvm/lib/Target/DirectX/DXILIntrinsicExpansion.cpp
@@ -203,6 +203,7 @@ static bool isIntrinsicExpansion(Function &F) {
   case Intrinsic::assume:
   case Intrinsic::abs:
   case Intrinsic::atan2:
+  case Intrinsic::copysign:
   case Intrinsic::fshl:
   case Intrinsic::fshr:
   case Intrinsic::exp:
@@ -1055,6 +1056,31 @@ static Value *expandSignIntrinsic(CallInst *Orig) {
   return Builder.CreateSub(ZextGT, ZextLT);
 }
 
+// Expand llvm.copysign by combining the sign bit with the magnitude bits using
+// bitwise operations.
+static Value *expandCopySignIntrinsic(CallInst *Orig) {
+  Value *Magnitude = Orig->getOperand(0);
+  Value *Sign = Orig->getOperand(1);
+  Type *Ty = Orig->getType();
+
+  IRBuilder<> Builder(Orig);
+
+  unsigned BitWidth = Ty->getScalarSizeInBits();
+  Type *IntTy = Ty->getWithNewType(Builder.getIntNTy(BitWidth));
+
+  // `ConstantInt::get` broadcasts to a splat when `IntTy` is a vector.
+  APInt SignMaskVal = APInt::getSignMask(BitWidth);
+  Constant *SignMask = ConstantInt::get(IntTy, SignMaskVal);
+  Constant *NotSignMask = ConstantInt::get(IntTy, ~SignMaskVal);
+
+  Value *MagnitudeInt = Builder.CreateBitCast(Magnitude, IntTy);
+  Value *SignInt = Builder.CreateBitCast(Sign, IntTy);
+  Value *MagnitudeBits = Builder.CreateAnd(MagnitudeInt, NotSignMask);
+  Value *SignBits = Builder.CreateAnd(SignInt, SignMask);
+  Value *Result = Builder.CreateOr(MagnitudeBits, SignBits);
+  return Builder.CreateBitCast(Result, Ty);
+}
+
 // Expand llvm.matrix.multiply by extracting row/column vectors and computing
 // dot products.
 // Result[r,c] = dot(row_r(LHS), col_c(RHS))
@@ -1248,6 +1274,9 @@ static bool expandIntrinsic(Function &F, CallInst *Orig) {
     return true;
   case Intrinsic::atan2:
     Result = expandAtan2Intrinsic(Orig);
+    break;
+  case Intrinsic::copysign:
+    Result = expandCopySignIntrinsic(Orig);
     break;
   case Intrinsic::fshl:
     Result = expandFunnelShiftIntrinsic<true>(Orig);

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -1616,15 +1616,15 @@ bool SPIRVInstructionSelector::selectCopySign(Register ResVReg,
     return selectOpWithSrcs(ResReg, IntType, I, SrcRegs, Opcode);
   };
 
-  Register MagnitudeInt, SignInt, MagnitudeBits, SignBits, ResInt;
+  Register MagnitudeInt, SignInt, MagnitudeBits, SignBits, CombinedInt;
   if (!EmitBitOp(MagnitudeInt, {MagnitudeReg}, SPIRV::OpBitcast) ||
       !EmitBitOp(SignInt, {SignReg}, SPIRV::OpBitcast) ||
       !EmitBitOp(MagnitudeBits, {MagnitudeInt, NotSignMask}, AndOpcode) ||
       !EmitBitOp(SignBits, {SignInt, SignMask}, AndOpcode) ||
-      !EmitBitOp(ResInt, {MagnitudeBits, SignBits}, OrOpcode))
+      !EmitBitOp(CombinedInt, {MagnitudeBits, SignBits}, OrOpcode))
     return false;
 
-  return selectOpWithSrcs(ResVReg, ResType, I, {ResInt}, SPIRV::OpBitcast);
+  return selectOpWithSrcs(ResVReg, ResType, I, {CombinedInt}, SPIRV::OpBitcast);
 }
 
 bool SPIRVInstructionSelector::selectFrexp(Register ResVReg,

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -1592,40 +1592,38 @@ bool SPIRVInstructionSelector::selectCopySign(Register ResVReg,
 
   const unsigned BitWidth = GR.getScalarOrVectorBitWidth(ResType);
   const unsigned ComponentCount = GR.getScalarOrVectorComponentCount(ResType);
-  const bool IsVector = ComponentCount > 1;
-
   SPIRVTypeInst IntType = GR.getOrCreateSPIRVIntegerType(BitWidth, I, TII);
-  if (IsVector)
-    IntType = GR.getOrCreateSPIRVVectorType(IntType, ComponentCount, I, TII);
-
   const APInt SignMaskVal = APInt::getSignMask(BitWidth);
-  Register SignMask =
-      IsVector ? GR.getOrCreateConstVector(SignMaskVal, I, IntType, TII)
-               : GR.getOrCreateConstInt(SignMaskVal, I, IntType, TII);
-  Register NotSignMask =
-      IsVector ? GR.getOrCreateConstVector(~SignMaskVal, I, IntType, TII)
-               : GR.getOrCreateConstInt(~SignMaskVal, I, IntType, TII);
 
-  const unsigned AndOpcode =
-      IsVector ? SPIRV::OpBitwiseAndV : SPIRV::OpBitwiseAndS;
-  const unsigned OrOpcode =
-      IsVector ? SPIRV::OpBitwiseOrV : SPIRV::OpBitwiseOrS;
+  Register SignMask, NotSignMask;
+  unsigned AndOpcode, OrOpcode;
+  if (ComponentCount > 1) {
+    IntType = GR.getOrCreateSPIRVVectorType(IntType, ComponentCount, I, TII);
+    SignMask = GR.getOrCreateConstVector(SignMaskVal, I, IntType, TII);
+    NotSignMask = GR.getOrCreateConstVector(~SignMaskVal, I, IntType, TII);
+    AndOpcode = SPIRV::OpBitwiseAndV;
+    OrOpcode = SPIRV::OpBitwiseOrV;
+  } else {
+    SignMask = GR.getOrCreateConstInt(SignMaskVal, I, IntType, TII);
+    NotSignMask = GR.getOrCreateConstInt(~SignMaskVal, I, IntType, TII);
+    AndOpcode = SPIRV::OpBitwiseAndS;
+    OrOpcode = SPIRV::OpBitwiseOrS;
+  }
 
-  Register MagnitudeInt = MRI->createVirtualRegister(GR.getRegClass(IntType));
-  Register SignInt = MRI->createVirtualRegister(GR.getRegClass(IntType));
-  Register MagnitudeBits = MRI->createVirtualRegister(GR.getRegClass(IntType));
-  Register SignBits = MRI->createVirtualRegister(GR.getRegClass(IntType));
-  Register ResInt = MRI->createVirtualRegister(GR.getRegClass(IntType));
+  auto EmitBitOp = [&](Register &ResReg, ArrayRef<Register> SrcRegs,
+                       unsigned Opcode) {
+    ResReg = MRI->createVirtualRegister(GR.getRegClass(IntType));
+    return selectOpWithSrcs(ResReg, IntType, I, SrcRegs, Opcode);
+  };
 
-  if (!selectOpWithSrcs(MagnitudeInt, IntType, I, {MagnitudeReg},
-                        SPIRV::OpBitcast) ||
-      !selectOpWithSrcs(SignInt, IntType, I, {SignReg}, SPIRV::OpBitcast) ||
-      !selectOpWithSrcs(MagnitudeBits, IntType, I, {MagnitudeInt, NotSignMask},
-                        AndOpcode) ||
-      !selectOpWithSrcs(SignBits, IntType, I, {SignInt, SignMask}, AndOpcode) ||
-      !selectOpWithSrcs(ResInt, IntType, I, {MagnitudeBits, SignBits},
-                        OrOpcode))
+  Register MagnitudeInt, SignInt, MagnitudeBits, SignBits, ResInt;
+  if (!EmitBitOp(MagnitudeInt, {MagnitudeReg}, SPIRV::OpBitcast) ||
+      !EmitBitOp(SignInt, {SignReg}, SPIRV::OpBitcast) ||
+      !EmitBitOp(MagnitudeBits, {MagnitudeInt, NotSignMask}, AndOpcode) ||
+      !EmitBitOp(SignBits, {SignInt, SignMask}, AndOpcode) ||
+      !EmitBitOp(ResInt, {MagnitudeBits, SignBits}, OrOpcode))
     return false;
+
   return selectOpWithSrcs(ResVReg, ResType, I, {ResInt}, SPIRV::OpBitcast);
 }
 

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -480,6 +480,9 @@ private:
   bool selectFrexp(Register ResVReg, SPIRVTypeInst ResType,
                    MachineInstr &I) const;
 
+  bool selectCopySign(Register ResVReg, SPIRVTypeInst ResType,
+                      MachineInstr &I) const;
+
   bool selectLdexp(Register ResVReg, SPIRVTypeInst ResType,
                    MachineInstr &I) const;
   bool selectSincos(Register ResVReg, SPIRVTypeInst ResType,
@@ -1188,7 +1191,7 @@ bool SPIRVInstructionSelector::spvSelect(Register ResVReg,
     return selectExtInst(ResVReg, ResType, I, CL::fmax, GL::NMax);
 
   case TargetOpcode::G_FCOPYSIGN:
-    return selectExtInst(ResVReg, ResType, I, CL::copysign);
+    return selectCopySign(ResVReg, ResType, I);
 
   case TargetOpcode::G_FCEIL:
     return selectExtInst(ResVReg, ResType, I, CL::ceil, GL::Ceil);
@@ -1573,6 +1576,57 @@ bool SPIRVInstructionSelector::selectExtInst(Register ResVReg,
     return true;
   }
   return false;
+}
+
+bool SPIRVInstructionSelector::selectCopySign(Register ResVReg,
+                                              SPIRVTypeInst ResType,
+                                              MachineInstr &I) const {
+  if (STI.canUseExtInstSet(SPIRV::InstructionSet::OpenCL_std))
+    return selectExtInst(ResVReg, ResType, I, CL::copysign);
+
+  // There is no copysign instruction in the GLSL Extended Instruction set, so
+  // it is implemented with bit manipulation:
+  //   bitcast((bitcast(magnitude) & ~signBit) | (bitcast(sign) & signBit))
+  Register MagnitudeReg = I.getOperand(1).getReg();
+  Register SignReg = I.getOperand(2).getReg();
+
+  const unsigned BitWidth = GR.getScalarOrVectorBitWidth(ResType);
+  const unsigned ComponentCount = GR.getScalarOrVectorComponentCount(ResType);
+  const bool IsVector = ComponentCount > 1;
+
+  SPIRVTypeInst IntType = GR.getOrCreateSPIRVIntegerType(BitWidth, I, TII);
+  if (IsVector)
+    IntType = GR.getOrCreateSPIRVVectorType(IntType, ComponentCount, I, TII);
+
+  const APInt SignMaskVal = APInt::getSignMask(BitWidth);
+  Register SignMask =
+      IsVector ? GR.getOrCreateConstVector(SignMaskVal, I, IntType, TII)
+               : GR.getOrCreateConstInt(SignMaskVal, I, IntType, TII);
+  Register NotSignMask =
+      IsVector ? GR.getOrCreateConstVector(~SignMaskVal, I, IntType, TII)
+               : GR.getOrCreateConstInt(~SignMaskVal, I, IntType, TII);
+
+  const unsigned AndOpcode =
+      IsVector ? SPIRV::OpBitwiseAndV : SPIRV::OpBitwiseAndS;
+  const unsigned OrOpcode =
+      IsVector ? SPIRV::OpBitwiseOrV : SPIRV::OpBitwiseOrS;
+
+  Register MagnitudeInt = MRI->createVirtualRegister(GR.getRegClass(IntType));
+  Register SignInt = MRI->createVirtualRegister(GR.getRegClass(IntType));
+  Register MagnitudeBits = MRI->createVirtualRegister(GR.getRegClass(IntType));
+  Register SignBits = MRI->createVirtualRegister(GR.getRegClass(IntType));
+  Register ResInt = MRI->createVirtualRegister(GR.getRegClass(IntType));
+
+  if (!selectOpWithSrcs(MagnitudeInt, IntType, I, {MagnitudeReg},
+                        SPIRV::OpBitcast) ||
+      !selectOpWithSrcs(SignInt, IntType, I, {SignReg}, SPIRV::OpBitcast) ||
+      !selectOpWithSrcs(MagnitudeBits, IntType, I, {MagnitudeInt, NotSignMask},
+                        AndOpcode) ||
+      !selectOpWithSrcs(SignBits, IntType, I, {SignInt, SignMask}, AndOpcode) ||
+      !selectOpWithSrcs(ResInt, IntType, I, {MagnitudeBits, SignBits},
+                        OrOpcode))
+    return false;
+  return selectOpWithSrcs(ResVReg, ResType, I, {ResInt}, SPIRV::OpBitcast);
 }
 
 bool SPIRVInstructionSelector::selectFrexp(Register ResVReg,

--- a/llvm/test/CodeGen/DirectX/copysign.ll
+++ b/llvm/test/CodeGen/DirectX/copysign.ll
@@ -9,8 +9,8 @@ entry:
   ; CHECK: [[SIGN_INT:%.*]] = bitcast half %{{.*}} to i16
   ; CHECK: [[MAGNITUDE_BITS:%.*]] = and i16 [[MAGNITUDE_INT]], 32767
   ; CHECK: [[SIGN_BITS:%.*]] = and i16 [[SIGN_INT]], -32768
-  ; CHECK: [[RES_INT:%.*]] = or i16 [[MAGNITUDE_BITS]], [[SIGN_BITS]]
-  ; CHECK: bitcast i16 [[RES_INT]] to half
+  ; CHECK: [[COMBINED_INT:%.*]] = or i16 [[MAGNITUDE_BITS]], [[SIGN_BITS]]
+  ; CHECK: bitcast i16 [[COMBINED_INT]] to half
   %r = call half @llvm.copysign.f16(half %a, half %b)
   ret half %r
 }
@@ -22,8 +22,8 @@ entry:
   ; CHECK: [[SIGN_INT:%.*]] = bitcast float %{{.*}} to i32
   ; CHECK: [[MAGNITUDE_BITS:%.*]] = and i32 [[MAGNITUDE_INT]], 2147483647
   ; CHECK: [[SIGN_BITS:%.*]] = and i32 [[SIGN_INT]], -2147483648
-  ; CHECK: [[RES_INT:%.*]] = or i32 [[MAGNITUDE_BITS]], [[SIGN_BITS]]
-  ; CHECK: bitcast i32 [[RES_INT]] to float
+  ; CHECK: [[COMBINED_INT:%.*]] = or i32 [[MAGNITUDE_BITS]], [[SIGN_BITS]]
+  ; CHECK: bitcast i32 [[COMBINED_INT]] to float
   %r = call float @llvm.copysign.f32(float %a, float %b)
   ret float %r
 }
@@ -31,12 +31,15 @@ entry:
 ; CHECK-LABEL: copysign_double
 define noundef double @copysign_double(double noundef %a, double noundef %b) {
 entry:
-  ; CHECK: [[MAGNITUDE_INT:%.*]] = bitcast double %{{.*}} to i64
-  ; CHECK: [[SIGN_INT:%.*]] = bitcast double %{{.*}} to i64
-  ; CHECK: [[MAGNITUDE_BITS:%.*]] = and i64 [[MAGNITUDE_INT]], 9223372036854775807
-  ; CHECK: [[SIGN_BITS:%.*]] = and i64 [[SIGN_INT]], -9223372036854775808
-  ; CHECK: [[RES_INT:%.*]] = or i64 [[MAGNITUDE_BITS]], [[SIGN_BITS]]
-  ; CHECK: bitcast i64 [[RES_INT]] to double
+  ; CHECK: [[MAGNITUDE_HALVES:%.*]] = call %dx.types.splitdouble @dx.op.splitDouble.f64(i32 102, double %{{.*}})
+  ; CHECK: [[SIGN_HALVES:%.*]] = call %dx.types.splitdouble @dx.op.splitDouble.f64(i32 102, double %{{.*}})
+  ; CHECK: [[MAGNITUDE_LOW:%.*]] = extractvalue %dx.types.splitdouble [[MAGNITUDE_HALVES]], 0
+  ; CHECK: [[MAGNITUDE_HIGH:%.*]] = extractvalue %dx.types.splitdouble [[MAGNITUDE_HALVES]], 1
+  ; CHECK: [[SIGN_HIGH:%.*]] = extractvalue %dx.types.splitdouble [[SIGN_HALVES]], 1
+  ; CHECK: [[MAGNITUDE_BITS:%.*]] = and i32 [[MAGNITUDE_HIGH]], 2147483647
+  ; CHECK: [[SIGN_BITS:%.*]] = and i32 [[SIGN_HIGH]], -2147483648
+  ; CHECK: [[COMBINED_HIGH:%.*]] = or i32 [[MAGNITUDE_BITS]], [[SIGN_BITS]]
+  ; CHECK: call double @dx.op.makeDouble.f64(i32 101, i32 [[MAGNITUDE_LOW]], i32 [[COMBINED_HIGH]])
   %r = call double @llvm.copysign.f64(double %a, double %b)
   ret double %r
 }
@@ -48,8 +51,8 @@ entry:
   ; CHECK: [[SIGN_INT:%.*]] = bitcast <4 x float> %{{.*}} to <4 x i32>
   ; CHECK: [[MAGNITUDE_BITS:%.*]] = and <4 x i32> [[MAGNITUDE_INT]], splat (i32 2147483647)
   ; CHECK: [[SIGN_BITS:%.*]] = and <4 x i32> [[SIGN_INT]], splat (i32 -2147483648)
-  ; CHECK: [[RES_INT:%.*]] = or <4 x i32> [[MAGNITUDE_BITS]], [[SIGN_BITS]]
-  ; CHECK: bitcast <4 x i32> [[RES_INT]] to <4 x float>
+  ; CHECK: [[COMBINED_INT:%.*]] = or <4 x i32> [[MAGNITUDE_BITS]], [[SIGN_BITS]]
+  ; CHECK: bitcast <4 x i32> [[COMBINED_INT]] to <4 x float>
   %r = call <4 x float> @llvm.copysign.v4f32(<4 x float> %a, <4 x float> %b)
   ret <4 x float> %r
 }

--- a/llvm/test/CodeGen/DirectX/copysign.ll
+++ b/llvm/test/CodeGen/DirectX/copysign.ll
@@ -1,0 +1,60 @@
+; RUN: opt -S -dxil-intrinsic-expansion -dxil-op-lower -mtriple=dxil-pc-shadermodel6.3-library %s | FileCheck %s
+
+; Make sure the copysign intrinsic is expanded to bitwise operations.
+
+; CHECK-LABEL: copysign_half
+define noundef half @copysign_half(half noundef %a, half noundef %b) {
+entry:
+  ; CHECK: [[MAGNITUDE_INT:%.*]] = bitcast half %{{.*}} to i16
+  ; CHECK: [[SIGN_INT:%.*]] = bitcast half %{{.*}} to i16
+  ; CHECK: [[MAGNITUDE_BITS:%.*]] = and i16 [[MAGNITUDE_INT]], 32767
+  ; CHECK: [[SIGN_BITS:%.*]] = and i16 [[SIGN_INT]], -32768
+  ; CHECK: [[RES_INT:%.*]] = or i16 [[MAGNITUDE_BITS]], [[SIGN_BITS]]
+  ; CHECK: bitcast i16 [[RES_INT]] to half
+  %r = call half @llvm.copysign.f16(half %a, half %b)
+  ret half %r
+}
+
+; CHECK-LABEL: copysign_float
+define noundef float @copysign_float(float noundef %a, float noundef %b) {
+entry:
+  ; CHECK: [[MAGNITUDE_INT:%.*]] = bitcast float %{{.*}} to i32
+  ; CHECK: [[SIGN_INT:%.*]] = bitcast float %{{.*}} to i32
+  ; CHECK: [[MAGNITUDE_BITS:%.*]] = and i32 [[MAGNITUDE_INT]], 2147483647
+  ; CHECK: [[SIGN_BITS:%.*]] = and i32 [[SIGN_INT]], -2147483648
+  ; CHECK: [[RES_INT:%.*]] = or i32 [[MAGNITUDE_BITS]], [[SIGN_BITS]]
+  ; CHECK: bitcast i32 [[RES_INT]] to float
+  %r = call float @llvm.copysign.f32(float %a, float %b)
+  ret float %r
+}
+
+; CHECK-LABEL: copysign_double
+define noundef double @copysign_double(double noundef %a, double noundef %b) {
+entry:
+  ; CHECK: [[MAGNITUDE_INT:%.*]] = bitcast double %{{.*}} to i64
+  ; CHECK: [[SIGN_INT:%.*]] = bitcast double %{{.*}} to i64
+  ; CHECK: [[MAGNITUDE_BITS:%.*]] = and i64 [[MAGNITUDE_INT]], 9223372036854775807
+  ; CHECK: [[SIGN_BITS:%.*]] = and i64 [[SIGN_INT]], -9223372036854775808
+  ; CHECK: [[RES_INT:%.*]] = or i64 [[MAGNITUDE_BITS]], [[SIGN_BITS]]
+  ; CHECK: bitcast i64 [[RES_INT]] to double
+  %r = call double @llvm.copysign.f64(double %a, double %b)
+  ret double %r
+}
+
+; CHECK-LABEL: copysign_float4
+define noundef <4 x float> @copysign_float4(<4 x float> noundef %a, <4 x float> noundef %b) {
+entry:
+  ; CHECK: [[MAGNITUDE_INT:%.*]] = bitcast <4 x float> %{{.*}} to <4 x i32>
+  ; CHECK: [[SIGN_INT:%.*]] = bitcast <4 x float> %{{.*}} to <4 x i32>
+  ; CHECK: [[MAGNITUDE_BITS:%.*]] = and <4 x i32> [[MAGNITUDE_INT]], splat (i32 2147483647)
+  ; CHECK: [[SIGN_BITS:%.*]] = and <4 x i32> [[SIGN_INT]], splat (i32 -2147483648)
+  ; CHECK: [[RES_INT:%.*]] = or <4 x i32> [[MAGNITUDE_BITS]], [[SIGN_BITS]]
+  ; CHECK: bitcast <4 x i32> [[RES_INT]] to <4 x float>
+  %r = call <4 x float> @llvm.copysign.v4f32(<4 x float> %a, <4 x float> %b)
+  ret <4 x float> %r
+}
+
+declare half @llvm.copysign.f16(half, half)
+declare float @llvm.copysign.f32(float, float)
+declare double @llvm.copysign.f64(double, double)
+declare <4 x float> @llvm.copysign.v4f32(<4 x float>, <4 x float>)

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/copysign.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/copysign.ll
@@ -22,56 +22,56 @@
 
 define noundef half @copysign_half(half noundef %a, half noundef %b) {
 entry:
-  ; CHECK: %[[#a:]] = OpFunctionParameter %[[#float_16]]
-  ; CHECK: %[[#b:]] = OpFunctionParameter %[[#float_16]]
-  ; CHECK: %[[#ai:]] = OpBitcast %[[#int_16]] %[[#a]]
-  ; CHECK: %[[#bi:]] = OpBitcast %[[#int_16]] %[[#b]]
-  ; CHECK: %[[#am:]] = OpBitwiseAnd %[[#int_16]] %[[#ai]] %[[#magn_16]]
-  ; CHECK: %[[#bs:]] = OpBitwiseAnd %[[#int_16]] %[[#bi]] %[[#sign_16]]
-  ; CHECK: %[[#or:]] = OpBitwiseOr %[[#int_16]] %[[#am]] %[[#bs]]
-  ; CHECK: %[[#]] = OpBitcast %[[#float_16]] %[[#or]]
+  ; CHECK: %[[#arg0:]] = OpFunctionParameter %[[#float_16]]
+  ; CHECK: %[[#arg1:]] = OpFunctionParameter %[[#float_16]]
+  ; CHECK: %[[#arg0_int:]] = OpBitcast %[[#int_16]] %[[#arg0]]
+  ; CHECK: %[[#arg1_int:]] = OpBitcast %[[#int_16]] %[[#arg1]]
+  ; CHECK: %[[#arg0_magn:]] = OpBitwiseAnd %[[#int_16]] %[[#arg0_int]] %[[#magn_16]]
+  ; CHECK: %[[#arg1_sign:]] = OpBitwiseAnd %[[#int_16]] %[[#arg1_int]] %[[#sign_16]]
+  ; CHECK: %[[#combined:]] = OpBitwiseOr %[[#int_16]] %[[#arg0_magn]] %[[#arg1_sign]]
+  ; CHECK: %[[#]] = OpBitcast %[[#float_16]] %[[#combined]]
   %r = call half @llvm.copysign.f16(half %a, half %b)
   ret half %r
 }
 
 define noundef float @copysign_float(float noundef %a, float noundef %b) {
 entry:
-  ; CHECK: %[[#a:]] = OpFunctionParameter %[[#float_32]]
-  ; CHECK: %[[#b:]] = OpFunctionParameter %[[#float_32]]
-  ; CHECK: %[[#ai:]] = OpBitcast %[[#int_32]] %[[#a]]
-  ; CHECK: %[[#bi:]] = OpBitcast %[[#int_32]] %[[#b]]
-  ; CHECK: %[[#am:]] = OpBitwiseAnd %[[#int_32]] %[[#ai]] %[[#magn_32]]
-  ; CHECK: %[[#bs:]] = OpBitwiseAnd %[[#int_32]] %[[#bi]] %[[#sign_32]]
-  ; CHECK: %[[#or:]] = OpBitwiseOr %[[#int_32]] %[[#am]] %[[#bs]]
-  ; CHECK: %[[#]] = OpBitcast %[[#float_32]] %[[#or]]
+  ; CHECK: %[[#arg0:]] = OpFunctionParameter %[[#float_32]]
+  ; CHECK: %[[#arg1:]] = OpFunctionParameter %[[#float_32]]
+  ; CHECK: %[[#arg0_int:]] = OpBitcast %[[#int_32]] %[[#arg0]]
+  ; CHECK: %[[#arg1_int:]] = OpBitcast %[[#int_32]] %[[#arg1]]
+  ; CHECK: %[[#arg0_magn:]] = OpBitwiseAnd %[[#int_32]] %[[#arg0_int]] %[[#magn_32]]
+  ; CHECK: %[[#arg1_sign:]] = OpBitwiseAnd %[[#int_32]] %[[#arg1_int]] %[[#sign_32]]
+  ; CHECK: %[[#combined:]] = OpBitwiseOr %[[#int_32]] %[[#arg0_magn]] %[[#arg1_sign]]
+  ; CHECK: %[[#]] = OpBitcast %[[#float_32]] %[[#combined]]
   %r = call float @llvm.copysign.f32(float %a, float %b)
   ret float %r
 }
 
 define noundef double @copysign_double(double noundef %a, double noundef %b) {
 entry:
-  ; CHECK: %[[#a:]] = OpFunctionParameter %[[#float_64]]
-  ; CHECK: %[[#b:]] = OpFunctionParameter %[[#float_64]]
-  ; CHECK: %[[#ai:]] = OpBitcast %[[#int_64]] %[[#a]]
-  ; CHECK: %[[#bi:]] = OpBitcast %[[#int_64]] %[[#b]]
-  ; CHECK: %[[#am:]] = OpBitwiseAnd %[[#int_64]] %[[#ai]] %[[#magn_64]]
-  ; CHECK: %[[#bs:]] = OpBitwiseAnd %[[#int_64]] %[[#bi]] %[[#sign_64]]
-  ; CHECK: %[[#or:]] = OpBitwiseOr %[[#int_64]] %[[#am]] %[[#bs]]
-  ; CHECK: %[[#]] = OpBitcast %[[#float_64]] %[[#or]]
+  ; CHECK: %[[#arg0:]] = OpFunctionParameter %[[#float_64]]
+  ; CHECK: %[[#arg1:]] = OpFunctionParameter %[[#float_64]]
+  ; CHECK: %[[#arg0_int:]] = OpBitcast %[[#int_64]] %[[#arg0]]
+  ; CHECK: %[[#arg1_int:]] = OpBitcast %[[#int_64]] %[[#arg1]]
+  ; CHECK: %[[#arg0_magn:]] = OpBitwiseAnd %[[#int_64]] %[[#arg0_int]] %[[#magn_64]]
+  ; CHECK: %[[#arg1_sign:]] = OpBitwiseAnd %[[#int_64]] %[[#arg1_int]] %[[#sign_64]]
+  ; CHECK: %[[#combined:]] = OpBitwiseOr %[[#int_64]] %[[#arg0_magn]] %[[#arg1_sign]]
+  ; CHECK: %[[#]] = OpBitcast %[[#float_64]] %[[#combined]]
   %r = call double @llvm.copysign.f64(double %a, double %b)
   ret double %r
 }
 
 define noundef <4 x float> @copysign_float4(<4 x float> noundef %a, <4 x float> noundef %b) {
 entry:
-  ; CHECK: %[[#a:]] = OpFunctionParameter %[[#vec4_float_32]]
-  ; CHECK: %[[#b:]] = OpFunctionParameter %[[#vec4_float_32]]
-  ; CHECK: %[[#ai:]] = OpBitcast %[[#vec4_int_32]] %[[#a]]
-  ; CHECK: %[[#bi:]] = OpBitcast %[[#vec4_int_32]] %[[#b]]
-  ; CHECK: %[[#am:]] = OpBitwiseAnd %[[#vec4_int_32]] %[[#ai]] %[[#vec4_magn_32]]
-  ; CHECK: %[[#bs:]] = OpBitwiseAnd %[[#vec4_int_32]] %[[#bi]] %[[#vec4_sign_32]]
-  ; CHECK: %[[#or:]] = OpBitwiseOr %[[#vec4_int_32]] %[[#am]] %[[#bs]]
-  ; CHECK: %[[#]] = OpBitcast %[[#vec4_float_32]] %[[#or]]
+  ; CHECK: %[[#arg0:]] = OpFunctionParameter %[[#vec4_float_32]]
+  ; CHECK: %[[#arg1:]] = OpFunctionParameter %[[#vec4_float_32]]
+  ; CHECK: %[[#arg0_int:]] = OpBitcast %[[#vec4_int_32]] %[[#arg0]]
+  ; CHECK: %[[#arg1_int:]] = OpBitcast %[[#vec4_int_32]] %[[#arg1]]
+  ; CHECK: %[[#arg0_magn:]] = OpBitwiseAnd %[[#vec4_int_32]] %[[#arg0_int]] %[[#vec4_magn_32]]
+  ; CHECK: %[[#arg1_sign:]] = OpBitwiseAnd %[[#vec4_int_32]] %[[#arg1_int]] %[[#vec4_sign_32]]
+  ; CHECK: %[[#combined:]] = OpBitwiseOr %[[#vec4_int_32]] %[[#arg0_magn]] %[[#arg1_sign]]
+  ; CHECK: %[[#]] = OpBitcast %[[#vec4_float_32]] %[[#combined]]
   %r = call <4 x float> @llvm.copysign.v4f32(<4 x float> %a, <4 x float> %b)
   ret <4 x float> %r
 }

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/copysign.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/copysign.ll
@@ -1,0 +1,82 @@
+; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv-unknown-vulkan %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val %}
+
+; Vulkan SPIR-V has no copysign in GLSL.std.450, so llvm.copysign is lowered with bit manipulation.
+
+; CHECK-DAG: %[[#float_16:]] = OpTypeFloat 16
+; CHECK-DAG: %[[#int_16:]] = OpTypeInt 16 0
+; CHECK-DAG: %[[#sign_16:]] = OpConstant %[[#int_16]] 32768
+; CHECK-DAG: %[[#magn_16:]] = OpConstant %[[#int_16]] 32767
+; CHECK-DAG: %[[#float_32:]] = OpTypeFloat 32
+; CHECK-DAG: %[[#int_32:]] = OpTypeInt 32 0
+; CHECK-DAG: %[[#sign_32:]] = OpConstant %[[#int_32]] 2147483648
+; CHECK-DAG: %[[#magn_32:]] = OpConstant %[[#int_32]] 2147483647
+; CHECK-DAG: %[[#vec4_float_32:]] = OpTypeVector %[[#float_32]] 4
+; CHECK-DAG: %[[#vec4_int_32:]] = OpTypeVector %[[#int_32]] 4
+; CHECK-DAG: %[[#vec4_sign_32:]] = OpConstantComposite %[[#vec4_int_32]] %[[#sign_32]] %[[#sign_32]] %[[#sign_32]] %[[#sign_32]]
+; CHECK-DAG: %[[#vec4_magn_32:]] = OpConstantComposite %[[#vec4_int_32]] %[[#magn_32]] %[[#magn_32]] %[[#magn_32]] %[[#magn_32]]
+; CHECK-DAG: %[[#float_64:]] = OpTypeFloat 64
+; CHECK-DAG: %[[#int_64:]] = OpTypeInt 64 0
+; CHECK-DAG: %[[#sign_64:]] = OpConstant %[[#int_64]] 9223372036854775808
+; CHECK-DAG: %[[#magn_64:]] = OpConstant %[[#int_64]] 9223372036854775807
+
+define noundef half @copysign_half(half noundef %a, half noundef %b) {
+entry:
+  ; CHECK: %[[#a:]] = OpFunctionParameter %[[#float_16]]
+  ; CHECK: %[[#b:]] = OpFunctionParameter %[[#float_16]]
+  ; CHECK: %[[#ai:]] = OpBitcast %[[#int_16]] %[[#a]]
+  ; CHECK: %[[#bi:]] = OpBitcast %[[#int_16]] %[[#b]]
+  ; CHECK: %[[#am:]] = OpBitwiseAnd %[[#int_16]] %[[#ai]] %[[#magn_16]]
+  ; CHECK: %[[#bs:]] = OpBitwiseAnd %[[#int_16]] %[[#bi]] %[[#sign_16]]
+  ; CHECK: %[[#or:]] = OpBitwiseOr %[[#int_16]] %[[#am]] %[[#bs]]
+  ; CHECK: %[[#]] = OpBitcast %[[#float_16]] %[[#or]]
+  %r = call half @llvm.copysign.f16(half %a, half %b)
+  ret half %r
+}
+
+define noundef float @copysign_float(float noundef %a, float noundef %b) {
+entry:
+  ; CHECK: %[[#a:]] = OpFunctionParameter %[[#float_32]]
+  ; CHECK: %[[#b:]] = OpFunctionParameter %[[#float_32]]
+  ; CHECK: %[[#ai:]] = OpBitcast %[[#int_32]] %[[#a]]
+  ; CHECK: %[[#bi:]] = OpBitcast %[[#int_32]] %[[#b]]
+  ; CHECK: %[[#am:]] = OpBitwiseAnd %[[#int_32]] %[[#ai]] %[[#magn_32]]
+  ; CHECK: %[[#bs:]] = OpBitwiseAnd %[[#int_32]] %[[#bi]] %[[#sign_32]]
+  ; CHECK: %[[#or:]] = OpBitwiseOr %[[#int_32]] %[[#am]] %[[#bs]]
+  ; CHECK: %[[#]] = OpBitcast %[[#float_32]] %[[#or]]
+  %r = call float @llvm.copysign.f32(float %a, float %b)
+  ret float %r
+}
+
+define noundef double @copysign_double(double noundef %a, double noundef %b) {
+entry:
+  ; CHECK: %[[#a:]] = OpFunctionParameter %[[#float_64]]
+  ; CHECK: %[[#b:]] = OpFunctionParameter %[[#float_64]]
+  ; CHECK: %[[#ai:]] = OpBitcast %[[#int_64]] %[[#a]]
+  ; CHECK: %[[#bi:]] = OpBitcast %[[#int_64]] %[[#b]]
+  ; CHECK: %[[#am:]] = OpBitwiseAnd %[[#int_64]] %[[#ai]] %[[#magn_64]]
+  ; CHECK: %[[#bs:]] = OpBitwiseAnd %[[#int_64]] %[[#bi]] %[[#sign_64]]
+  ; CHECK: %[[#or:]] = OpBitwiseOr %[[#int_64]] %[[#am]] %[[#bs]]
+  ; CHECK: %[[#]] = OpBitcast %[[#float_64]] %[[#or]]
+  %r = call double @llvm.copysign.f64(double %a, double %b)
+  ret double %r
+}
+
+define noundef <4 x float> @copysign_float4(<4 x float> noundef %a, <4 x float> noundef %b) {
+entry:
+  ; CHECK: %[[#a:]] = OpFunctionParameter %[[#vec4_float_32]]
+  ; CHECK: %[[#b:]] = OpFunctionParameter %[[#vec4_float_32]]
+  ; CHECK: %[[#ai:]] = OpBitcast %[[#vec4_int_32]] %[[#a]]
+  ; CHECK: %[[#bi:]] = OpBitcast %[[#vec4_int_32]] %[[#b]]
+  ; CHECK: %[[#am:]] = OpBitwiseAnd %[[#vec4_int_32]] %[[#ai]] %[[#vec4_magn_32]]
+  ; CHECK: %[[#bs:]] = OpBitwiseAnd %[[#vec4_int_32]] %[[#bi]] %[[#vec4_sign_32]]
+  ; CHECK: %[[#or:]] = OpBitwiseOr %[[#vec4_int_32]] %[[#am]] %[[#bs]]
+  ; CHECK: %[[#]] = OpBitcast %[[#vec4_float_32]] %[[#or]]
+  %r = call <4 x float> @llvm.copysign.v4f32(<4 x float> %a, <4 x float> %b)
+  ret <4 x float> %r
+}
+
+declare half @llvm.copysign.f16(half, half)
+declare float @llvm.copysign.f32(float, float)
+declare double @llvm.copysign.f64(double, double)
+declare <4 x float> @llvm.copysign.v4f32(<4 x float>, <4 x float>)


### PR DESCRIPTION
Fixes #216826.

Adds `copysign` DirectX backend lowering and fixes the SPIR-V backend lowering. Both lower with the bit manipulation `copysign(magnitude, sign) = bitcast((bitcast(magnitude) & ~signBit) | (bitcast(sign) & signBit))`, except the OpenCL path, which still emits `OpExtInst ... copysign`.

Assisted-by: Claude Opus 4.8