### PR TITLE
[ADT] Clean up FoldingSet growth (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/FoldingSet.h
+++ b/llvm/include/llvm/ADT/FoldingSet.h
@@ -369,9 +369,6 @@ protected:
   };
 
 private:
-  /// Double the size of the hash table and rehash everything.
-  void GrowHashTable(const FoldingSetInfo &Info);
-
   /// Resize the hash table and rehash everything. \p NewBucketCount must be a
   /// power of two, and must be greater than the old bucket count.
   void GrowBucketCount(unsigned NewBucketCount, const FoldingSetInfo &Info);

--- a/llvm/lib/Support/FoldingSet.cpp
+++ b/llvm/lib/Support/FoldingSet.cpp
@@ -219,18 +219,11 @@ void FoldingSetBase::GrowBucketCount(unsigned NewBucketCount,
   assert((NewBucketCount > NumBuckets) &&
          "Can't shrink a folding set with GrowBucketCount");
   assert(isPowerOf2_32(NewBucketCount) && "Bad bucket count!");
-  void **OldBuckets = Buckets;
-  unsigned OldNumBuckets = NumBuckets;
 
-  // Clear out new buckets.
-  Buckets = AllocateBuckets(NewBucketCount);
-  NumBuckets = NewBucketCount;
-  NumNodes = 0;
-
-  // Walk the old buckets, rehashing nodes into their new place.
+  FoldingSetBase Tmp(llvm::Log2_32(NewBucketCount));
   FoldingSetNodeID TempID;
-  for (unsigned i = 0; i != OldNumBuckets; ++i) {
-    void *Probe = OldBuckets[i];
+  for (unsigned i = 0; i != NumBuckets; ++i) {
+    void *Probe = Buckets[i];
     if (!Probe)
       continue;
     while (Node *NodeInBucket = GetNextPtr(Probe)) {
@@ -239,19 +232,16 @@ void FoldingSetBase::GrowBucketCount(unsigned NewBucketCount,
       NodeInBucket->SetNextInBucket(nullptr);
 
       // Insert the node into the new bucket, after recomputing the hash.
-      InsertNode(NodeInBucket,
-                 GetBucketFor(Info.ComputeNodeHash(this, NodeInBucket, TempID),
-                              Buckets, NumBuckets),
-                 Info);
+      Tmp.InsertNode(
+          NodeInBucket,
+          GetBucketFor(Info.ComputeNodeHash(this, NodeInBucket, TempID),
+                       Tmp.Buckets, Tmp.NumBuckets),
+          Info);
       TempID.clear();
     }
   }
 
-  free(OldBuckets);
-}
-
-void FoldingSetBase::GrowHashTable(const FoldingSetInfo &Info) {
-  GrowBucketCount(NumBuckets * 2, Info);
+  *this = std::move(Tmp);
 }
 
 void FoldingSetBase::reserve(unsigned EltCount, const FoldingSetInfo &Info) {
@@ -290,7 +280,7 @@ void FoldingSetBase::InsertNode(Node *N, void *InsertPos,
   assert(!N->getNextInBucket());
   // Do we need to grow the hashtable?
   if (NumNodes + 1 > capacity()) {
-    GrowHashTable(Info);
+    GrowBucketCount(NumBuckets * 2, Info);
     FoldingSetNodeID TempID;
     InsertPos = GetBucketFor(Info.ComputeNodeHash(this, N, TempID), Buckets,
                              NumBuckets);


### PR DESCRIPTION
This patch cleans up hash table growth in FoldingSetBase:

- Remove GrowHashTable, a private 3-line wrapper around GrowBucketCount,
  in favor of calling GrowBucketCount(NumBuckets * 2, Info) directly in
  InsertNode.

- Refactor GrowBucketCount to use the RAII copy-and-swap pattern. Rehash
  nodes into a temporary FoldingSetBase and move-assign it to *this to
  avoid duplicating bucket allocation and deallocation logic.

Assisted-by: Antigravity
