### PR TITLE
CodeGen: Consolidate target-abi validation

### DIFF
--- a/llvm/include/llvm/Target/TargetMachine.h
+++ b/llvm/include/llvm/Target/TargetMachine.h
@@ -138,6 +138,11 @@ public:
   StringRef getTargetFeatureString() const { return TargetFS; }
   void setTargetFeatureString(StringRef FS) { TargetFS = std::string(FS); }
 
+  /// Returns the effective target ABI name. Reads the "target-abi" module flag
+  /// if present, otherwise the -target-abi option. Emits an error if both are
+  /// present and disagree.
+  StringRef getTargetABIName(const Module &M) const;
+
   /// Virtual method implemented by subclasses that returns a reference to that
   /// target's TargetSubtargetInfo-derived member variable.
   virtual const TargetSubtargetInfo *getSubtargetImpl(const Function &) const {

--- a/llvm/lib/Target/LoongArch/LoongArchTargetMachine.cpp
+++ b/llvm/lib/Target/LoongArch/LoongArchTargetMachine.cpp
@@ -121,16 +121,7 @@ LoongArchTargetMachine::getSubtargetImpl(const Function &F) const {
   std::string Key = CPU + TuneCPU + FS;
   auto &I = SubtargetMap[Key];
   if (!I) {
-    auto ABIName = Options.MCOptions.getABIName();
-    if (const MDString *ModuleTargetABI = dyn_cast_or_null<MDString>(
-            F.getParent()->getModuleFlag("target-abi"))) {
-      auto TargetABI = LoongArchABI::getTargetABI(ABIName);
-      if (TargetABI != LoongArchABI::ABI_Unknown &&
-          ModuleTargetABI->getString() != ABIName) {
-        report_fatal_error("-target-abi option != target-abi module flag");
-      }
-      ABIName = ModuleTargetABI->getString();
-    }
+    StringRef ABIName = getTargetABIName(*F.getParent());
     I = std::make_unique<LoongArchSubtarget>(TargetTriple, CPU, TuneCPU, FS,
                                              ABIName, *this);
   }

--- a/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
@@ -252,16 +252,7 @@ RISCVTargetMachine::getSubtargetImpl(const Function &F) const {
                            << CPU << TuneCPU << FS;
   auto &I = SubtargetMap[Key];
   if (!I) {
-    auto ABIName = Options.MCOptions.getABIName();
-    if (const MDString *ModuleTargetABI = dyn_cast_or_null<MDString>(
-            F.getParent()->getModuleFlag("target-abi"))) {
-      auto TargetABI = RISCVABI::getTargetABI(ABIName);
-      if (TargetABI != RISCVABI::ABI_Unknown &&
-          ModuleTargetABI->getString() != ABIName) {
-        report_fatal_error("-target-abi option != target-abi module flag");
-      }
-      ABIName = ModuleTargetABI->getString();
-    }
+    StringRef ABIName = getTargetABIName(*F.getParent());
     I = std::make_unique<RISCVSubtarget>(
         TargetTriple, CPU, TuneCPU, FS, ABIName, RVVBitsMin, RVVBitsMax, *this);
   }

--- a/llvm/lib/Target/TargetMachine.cpp
+++ b/llvm/lib/Target/TargetMachine.cpp
@@ -330,6 +330,21 @@ std::pair<int, int> TargetMachine::parseBinutilsVersion(StringRef Version) {
   return Ret;
 }
 
+StringRef TargetMachine::getTargetABIName(const Module &M) const {
+  StringRef OptionABI = Options.MCOptions.getABIName();
+  const auto *MD = cast_or_null<MDString>(M.getModuleFlag("target-abi"));
+  if (!MD)
+    return OptionABI;
+
+  StringRef ModuleABI = MD->getString();
+  if (!OptionABI.empty() && OptionABI != ModuleABI) {
+    M.getContext().emitError("-target-abi option != target-abi module flag");
+    return "";
+  }
+
+  return ModuleABI;
+}
+
 const MCSubtargetInfo &TargetMachine::getMCSubtargetInfo(StringRef CPU,
                                                          StringRef FS) {
   if (CPU.empty() && FS.empty())

--- a/llvm/test/CodeGen/RISCV/module-target-abi.ll
+++ b/llvm/test/CodeGen/RISCV/module-target-abi.ll
@@ -2,11 +2,11 @@
 ; RUN:   | FileCheck -check-prefix=DEFAULT %s
 ; RUN: llc -mtriple=riscv32 -target-abi ilp32 < %s 2>&1 \
 ; RUN:   | FileCheck -check-prefix=RV32IF-ILP32 %s
-; RUN: not --crash llc -mtriple=riscv32 -target-abi ilp32f < %s 2>&1 \
+; RUN: not llc -mtriple=riscv32 -target-abi ilp32f < %s 2>&1 \
 ; RUN:   | FileCheck -check-prefix=RV32IF-ILP32F %s
 ; RUN: llc -mtriple=riscv32 -filetype=obj < %s | llvm-readelf -h - | FileCheck -check-prefixes=FLAGS %s
 
-; RV32IF-ILP32F: -target-abi option != target-abi module flag
+; RV32IF-ILP32F: error: -target-abi option != target-abi module flag
 
 ; FLAGS: Flags: 0x0
 

--- a/llvm/test/CodeGen/RISCV/module-target-abi2.ll
+++ b/llvm/test/CodeGen/RISCV/module-target-abi2.ll
@@ -1,12 +1,12 @@
 ; RUN: llc -mtriple=riscv32 < %s 2>&1 \
 ; RUN:   | FileCheck -check-prefix=DEFAULT %s
-; RUN: not --crash llc -mtriple=riscv32 -target-abi ilp32 < %s 2>&1 \
+; RUN: not llc -mtriple=riscv32 -target-abi ilp32 < %s 2>&1 \
 ; RUN:   | FileCheck -check-prefix=RV32IF-ILP32 %s
 ; RUN: llc -mtriple=riscv32 -target-abi ilp32f < %s 2>&1 \
 ; RUN:   | FileCheck -check-prefix=RV32IF-ILP32F %s
 ; RUN: llc -mtriple=riscv32 -filetype=obj < %s | llvm-readelf -h - | FileCheck -check-prefixes=FLAGS %s
 
-; RV32IF-ILP32: -target-abi option != target-abi module flag
+; RV32IF-ILP32: error: -target-abi option != target-abi module flag
 
 ; FLAGS: Flags: 0x2, single-float ABI
 


### PR DESCRIPTION
LoongArch and RISCV both implemented an error if the
"target-abi" module flag was inconsistent with the -target-abi
option flag. Consolidate these into one place, and change
from a fatal error to a nonfatal context error.

One untested incidental behavior change is for garbage names.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>