### PR TITLE
[docs] Fix default Sphinx worker count

### DIFF
--- a/llvm/cmake/modules/AddSphinxTarget.cmake
+++ b/llvm/cmake/modules/AddSphinxTarget.cmake
@@ -163,7 +163,7 @@ function (add_sphinx_target builder project)
     math(EXPR LLVM_SPHINX_THREADS
          "(${number_of_logical_cores} + 1) / 2")
   endif()
-  set(LLVM_SPHINX_THREADS "${LLVM_SPHINX_BUILD_JOBS}"
+  set(LLVM_SPHINX_THREADS "${LLVM_SPHINX_THREADS}"
       CACHE STRING "Define the number of parallel jobs for each Sphinx build.")
   if (LLVM_SPHINX_THREADS)
     set(sphinx_jobs_flag -j ${LLVM_SPHINX_THREADS})


### PR DESCRIPTION
I renamed the variable at the last minute, and the search and replace didn't catch all instances. Follow-up to #217161 / 0e6f9b26868c37cfb27fdc99af0524ed78e1dfd8.