### PR TITLE
[lldb] Use std::unique_lock instead of std::lock_guard in ResumeNewPlan

### DIFF
--- a/lldb/source/API/SBThread.cpp
+++ b/lldb/source/API/SBThread.cpp
@@ -465,7 +465,7 @@ static Status ResumeNewPlan(StoppedExecutionContext exe_ctx,
 
   // Release the run lock but keep the API lock.
   TargetAPIMutex api_mutex = exe_ctx.AllowResume();
-  std::lock_guard<TargetAPIMutex> guard(api_mutex, std::adopt_lock);
+  std::unique_lock<TargetAPIMutex> guard(api_mutex, std::adopt_lock);
   if (process->GetTarget().GetDebugger().GetAsyncExecution())
     return process->Resume();
   return process->ResumeSynchronous(nullptr);


### PR DESCRIPTION
When adopting the TargetAPIMutex returned by exe_ctx.AllowResume(), using std::lock_guard with std::adopt_lock fails with -Werror=thread-safety-analysis on newer libc++ toolchains because lock_guard's adopt_lock constructor requires holding the capability at the call site. Switching to std::unique_lock matches the other TargetAPIMutex adoption call sites and provides correct RAII cleanup.

Fixes -Wthread-safety-analysis introduced in https://github.com/llvm/llvm-project/pull/212872