### PR TITLE
[lit] Use text mode when opening text files on z/OS

### DIFF
--- a/llvm/utils/lit/lit/ShellEnvironment.py
+++ b/llvm/utils/lit/lit/ShellEnvironment.py
@@ -228,7 +228,11 @@ def as_binary_reader(stream: None | int | io.TextIOBase | BinaryIO) -> BinaryIO:
         # No real input to read.
         return io.BytesIO(b"")
     if isinstance(stream, io.TextIOBase):
-        return stream
+        buffer = getattr(stream, "buffer", None)
+        if buffer is not None:
+            return buffer
+        data = stream.read()
+        return io.BytesIO(data.encode() if isinstance(data, str) else data)
     # Already a binary reader.
     assert hasattr(stream, "read"), f"expected a binary reader, got {type(stream)!r}"
     return stream

--- a/llvm/utils/lit/lit/ShellEnvironment.py
+++ b/llvm/utils/lit/lit/ShellEnvironment.py
@@ -228,11 +228,7 @@ def as_binary_reader(stream: None | int | io.TextIOBase | BinaryIO) -> BinaryIO:
         # No real input to read.
         return io.BytesIO(b"")
     if isinstance(stream, io.TextIOBase):
-        buffer = getattr(stream, "buffer", None)
-        if buffer is not None:
-            return buffer
-        data = stream.read()
-        return io.BytesIO(data.encode() if isinstance(data, str) else data)
+        return stream
     # Already a binary reader.
     assert hasattr(stream, "read"), f"expected a binary reader, got {type(stream)!r}"
     return stream

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -4,6 +4,7 @@ import enum
 import io
 import os
 import pathlib
+import platform
 import re
 import shlex
 import signal
@@ -403,7 +404,8 @@ def _make_out_sink(stdout: int | TextIO, is_last: bool) -> IO[bytes] | None:
         last stage or a non-pipe target, which don't need this sink.
     """
     if stdout == subprocess.PIPE and not is_last:
-        return tempfile.SpooledTemporaryFile(max_size=1 << 20, mode="w+")
+        _mode = "w+" if platform.system() == "OS/390" else "w+b"
+        return tempfile.SpooledTemporaryFile(max_size=1 << 20, mode=_mode)
     return None
 
 

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -403,7 +403,7 @@ def _make_out_sink(stdout: int | TextIO, is_last: bool) -> IO[bytes] | None:
         last stage or a non-pipe target, which don't need this sink.
     """
     if stdout == subprocess.PIPE and not is_last:
-        return tempfile.SpooledTemporaryFile(max_size=1 << 20)
+        return tempfile.SpooledTemporaryFile(max_size=1 << 20, mode="w+")
     return None
 
 

--- a/llvm/utils/lit/lit/builtin_commands/cat.py
+++ b/llvm/utils/lit/lit/builtin_commands/cat.py
@@ -102,7 +102,6 @@ def run(argv, stdin, stdout, stderr, cwd):
             if isinstance(contents, str):
                 contents = contents.encode()
         stdout.write(contents)
-
     return 0
 
 

--- a/llvm/utils/lit/lit/builtin_commands/cat.py
+++ b/llvm/utils/lit/lit/builtin_commands/cat.py
@@ -90,20 +90,18 @@ def run(argv, stdin, stdout, stderr, cwd):
 
         if show_nonprinting:
             contents = convertToCaretAndMNotation(contents)
+
         # Determine if stdout expects text or binary
-        is_text_output = False
-        if hasattr(stdout, "mode"):
-            mode = getattr(stdout, "mode", "b")
-            is_text_output = "b" not in mode
+        mode = getattr(stdout, "mode", "b")
+        is_text_output = "b" not in mode
 
         if is_text_output:
             if isinstance(contents, bytes):
                 contents = contents.decode()
-            stdout.write(contents)
         else:
             if isinstance(contents, str):
                 contents = contents.encode()
-            stdout.write(contents)
+        stdout.write(contents)
 
     return 0
 

--- a/llvm/utils/lit/lit/builtin_commands/cat.py
+++ b/llvm/utils/lit/lit/builtin_commands/cat.py
@@ -90,9 +90,21 @@ def run(argv, stdin, stdout, stderr, cwd):
 
         if show_nonprinting:
             contents = convertToCaretAndMNotation(contents)
-        elif is_text:
-            contents = contents.encode()
-        stdout.write(contents)
+        # Determine if stdout expects text or binary
+        is_text_output = False
+        if hasattr(stdout, "mode"):
+            mode = getattr(stdout, "mode", "b")
+            is_text_output = "b" not in mode
+
+        if is_text_output:
+            if isinstance(contents, bytes):
+                contents = contents.decode()
+            stdout.write(contents)
+        else:
+            if isinstance(contents, str):
+                contents = contents.encode()
+            stdout.write(contents)
+
     return 0
 
 

--- a/llvm/utils/lit/lit/builtin_commands/diff.py
+++ b/llvm/utils/lit/lit/builtin_commands/diff.py
@@ -5,6 +5,7 @@ import locale
 import os
 import re
 import sys
+import platform
 
 # diff.py runs in two modes during the in-process migration:
 #   - In-process: imported as 'lit.builtin_commands.diff', so __package__ is
@@ -63,11 +64,22 @@ def getDirTree(path, basedir=""):
 def compareTwoFiles(flags, filepaths, stdin, stdout):
     filelines = []
     for file in filepaths:
+        is_text = False
         if file == "-":
             filelines.append(stdin.readlines())
         else:
-            with open(file, "rb") as file_bin:
-                filelines.append(file_bin.readlines())
+            if platform.system() == "OS/390":
+                try:
+                    with open(file, "r") as file_text:
+                        filelines.append(
+                            file_text.read().encode().splitlines(keepends=True)
+                        )
+                        is_text = True
+                except:
+                    pass
+            if not is_text:
+                with open(file, "rb") as file_bin:
+                    filelines.append(file_bin.readlines())
 
     try:
         return compareTwoTextFiles(


### PR DESCRIPTION
On z/OS, we rely on autoconversion to read files correctly, and this requires files to be opened as text. 

The following change https://github.com/llvm/llvm-project/pull/208024 changed the streams to be read and piped as binary resulting in some test regressions due to unreadable output. This patch restores the functionality of opening and reading as a text stream.