### PR TITLE
lldb: Linux: clean up dead and mis-ordered includes

### DIFF
--- a/lldb/source/Plugins/Process/Linux/IntelPTCollector.cpp
+++ b/lldb/source/Plugins/Process/Linux/IntelPTCollector.cpp
@@ -7,20 +7,18 @@
 //===----------------------------------------------------------------------===//
 
 #include "IntelPTCollector.h"
-#include "Perf.h"
+
+#include "Plugins/Process/Linux/Procfs.h"
 #include "Plugins/Process/POSIX/ProcessPOSIXLog.h"
-#include "Procfs.h"
 #include "lldb/Utility/StreamString.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MathExtras.h"
-#include <algorithm>
-#include <cstddef>
+
 #include <fcntl.h>
 #include <fstream>
 #include <linux/perf_event.h>
 #include <optional>
-#include <sstream>
 #include <sys/ioctl.h>
 #include <sys/syscall.h>
 

--- a/lldb/source/Plugins/Process/Linux/IntelPTCollector.h
+++ b/lldb/source/Plugins/Process/Linux/IntelPTCollector.h
@@ -9,14 +9,15 @@
 #ifndef liblldb_IntelPTCollector_H_
 #define liblldb_IntelPTCollector_H_
 
-#include "IntelPTMultiCoreTrace.h"
-#include "IntelPTPerThreadProcessTrace.h"
-#include "IntelPTSingleBufferTrace.h"
-#include "Perf.h"
+#include "Plugins/Process/Linux/IntelPTMultiCoreTrace.h"
+#include "Plugins/Process/Linux/IntelPTPerThreadProcessTrace.h"
+#include "Plugins/Process/Linux/IntelPTSingleBufferTrace.h"
+#include "Plugins/Process/Linux/Perf.h"
 #include "lldb/Host/common/NativeProcessProtocol.h"
 #include "lldb/Utility/Status.h"
 #include "lldb/Utility/TraceIntelPTGDBRemotePackets.h"
 #include "lldb/lldb-types.h"
+
 #include <linux/perf_event.h>
 #include <sys/mman.h>
 #include <unistd.h>

--- a/lldb/source/Plugins/Process/Linux/IntelPTMultiCoreTrace.cpp
+++ b/lldb/source/Plugins/Process/Linux/IntelPTMultiCoreTrace.cpp
@@ -7,8 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "IntelPTMultiCoreTrace.h"
+
+#include "Plugins/Process/Linux/Procfs.h"
 #include "Plugins/Process/POSIX/ProcessPOSIXLog.h"
-#include "Procfs.h"
+
 #include <optional>
 
 using namespace lldb;

--- a/lldb/source/Plugins/Process/Linux/IntelPTMultiCoreTrace.h
+++ b/lldb/source/Plugins/Process/Linux/IntelPTMultiCoreTrace.h
@@ -9,12 +9,13 @@
 #ifndef liblldb_IntelPTMultiCoreTrace_H_
 #define liblldb_IntelPTMultiCoreTrace_H_
 
-#include "IntelPTProcessTrace.h"
-#include "IntelPTSingleBufferTrace.h"
+#include "Plugins/Process/Linux/IntelPTProcessTrace.h"
+#include "Plugins/Process/Linux/IntelPTSingleBufferTrace.h"
 #include "lldb/Host/common/NativeProcessProtocol.h"
 #include "lldb/Utility/TraceIntelPTGDBRemotePackets.h"
 #include "lldb/lldb-types.h"
 #include "llvm/Support/Error.h"
+
 #include <memory>
 #include <optional>
 

--- a/lldb/source/Plugins/Process/Linux/IntelPTPerThreadProcessTrace.cpp
+++ b/lldb/source/Plugins/Process/Linux/IntelPTPerThreadProcessTrace.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "IntelPTPerThreadProcessTrace.h"
-#include <optional>
 
 using namespace lldb;
 using namespace lldb_private;

--- a/lldb/source/Plugins/Process/Linux/IntelPTPerThreadProcessTrace.h
+++ b/lldb/source/Plugins/Process/Linux/IntelPTPerThreadProcessTrace.h
@@ -9,10 +9,14 @@
 #ifndef liblldb_IntelPTPerThreadProcessTrace_H_
 #define liblldb_IntelPTPerThreadProcessTrace_H_
 
-#include "IntelPTProcessTrace.h"
-#include "IntelPTSingleBufferTrace.h"
-#include "IntelPTThreadTraceCollection.h"
+#include "Plugins/Process/Linux/IntelPTProcessTrace.h"
+#include "Plugins/Process/Linux/IntelPTSingleBufferTrace.h"
+#include "Plugins/Process/Linux/IntelPTThreadTraceCollection.h"
+
+#include <cstdint>
+#include <memory>
 #include <optional>
+#include <vector>
 
 namespace lldb_private {
 namespace process_linux {

--- a/lldb/source/Plugins/Process/Linux/IntelPTProcessTrace.h
+++ b/lldb/source/Plugins/Process/Linux/IntelPTProcessTrace.h
@@ -10,6 +10,7 @@
 #define liblldb_IntelPTProcessTrace_H_
 
 #include "lldb/Utility/TraceIntelPTGDBRemotePackets.h"
+
 #include <memory>
 #include <optional>
 

--- a/lldb/source/Plugins/Process/Linux/IntelPTSingleBufferTrace.cpp
+++ b/lldb/source/Plugins/Process/Linux/IntelPTSingleBufferTrace.cpp
@@ -7,11 +7,13 @@
 //===----------------------------------------------------------------------===//
 
 #include "IntelPTSingleBufferTrace.h"
+
 #include "Plugins/Process/POSIX/ProcessPOSIXLog.h"
 #include "lldb/Utility/Status.h"
 #include "lldb/Utility/StreamString.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/TargetParser/Host.h"
+
 #include <linux/perf_event.h>
 #include <sstream>
 #include <sys/syscall.h>

--- a/lldb/source/Plugins/Process/Linux/IntelPTSingleBufferTrace.h
+++ b/lldb/source/Plugins/Process/Linux/IntelPTSingleBufferTrace.h
@@ -9,11 +9,15 @@
 #ifndef liblldb_IntelPTSingleBufferTrace_H_
 #define liblldb_IntelPTSingleBufferTrace_H_
 
-#include "Perf.h"
+#include "Plugins/Process/Linux/Perf.h"
 #include "lldb/Utility/TraceIntelPTGDBRemotePackets.h"
 #include "lldb/lldb-types.h"
 #include "llvm/Support/Error.h"
+
+#include <cstddef>
+#include <cstdint>
 #include <memory>
+#include <vector>
 
 namespace lldb_private {
 namespace process_linux {

--- a/lldb/source/Plugins/Process/Linux/IntelPTThreadTraceCollection.cpp
+++ b/lldb/source/Plugins/Process/Linux/IntelPTThreadTraceCollection.cpp
@@ -7,7 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "IntelPTThreadTraceCollection.h"
+
+#include <cstdint>
 #include <optional>
+#include <vector>
 
 using namespace lldb;
 using namespace lldb_private;

--- a/lldb/source/Plugins/Process/Linux/IntelPTThreadTraceCollection.h
+++ b/lldb/source/Plugins/Process/Linux/IntelPTThreadTraceCollection.h
@@ -9,8 +9,11 @@
 #ifndef liblldb_IntelPTPerThreadTraceCollection_H_
 #define liblldb_IntelPTPerThreadTraceCollection_H_
 
-#include "IntelPTSingleBufferTrace.h"
+#include "Plugins/Process/Linux/IntelPTSingleBufferTrace.h"
+
+#include <cstdint>
 #include <optional>
+#include <vector>
 
 namespace lldb_private {
 namespace process_linux {

--- a/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
@@ -8,22 +8,10 @@
 
 #include "NativeProcessLinux.h"
 
-#include <cerrno>
-#include <cstdint>
-#include <cstring>
-#include <unistd.h>
-
-#include <fstream>
-#include <mutex>
-#include <optional>
-#include <sstream>
-#include <string>
-#include <unordered_map>
-
-#include "NativeThreadLinux.h"
+#include "Plugins/Process/Linux/NativeThreadLinux.h"
+#include "Plugins/Process/Linux/Procfs.h"
 #include "Plugins/Process/POSIX/ProcessPOSIXLog.h"
 #include "Plugins/Process/Utility/LinuxProcMaps.h"
-#include "Procfs.h"
 #include "lldb/Core/ModuleSpec.h"
 #include "lldb/Host/Host.h"
 #include "lldb/Host/HostProcess.h"
@@ -49,12 +37,17 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Threading.h"
 
+#include <cerrno>
+#include <cstdint>
+#include <cstring>
 #include <linux/unistd.h>
+#include <optional>
 #include <sys/socket.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
 #include <sys/user.h>
 #include <sys/wait.h>
+#include <unistd.h>
 
 #ifdef __aarch64__
 #include <asm/hwcap.h>

--- a/lldb/source/Plugins/Process/Linux/NativeProcessLinux.h
+++ b/lldb/source/Plugins/Process/Linux/NativeProcessLinux.h
@@ -9,9 +9,10 @@
 #ifndef liblldb_NativeProcessLinux_H_
 #define liblldb_NativeProcessLinux_H_
 
-#include <csignal>
-#include <unordered_set>
-
+#include "Plugins/Process/Linux/IntelPTCollector.h"
+#include "Plugins/Process/Linux/NativeThreadLinux.h"
+#include "Plugins/Process/POSIX/NativeProcessELF.h"
+#include "Plugins/Process/Utility/NativeProcessSoftwareSingleStep.h"
 #include "lldb/Host/Debug.h"
 #include "lldb/Host/HostThread.h"
 #include "lldb/Host/linux/Support.h"
@@ -22,10 +23,8 @@
 #include "lldb/lldb-types.h"
 #include "llvm/ADT/SmallPtrSet.h"
 
-#include "IntelPTCollector.h"
-#include "NativeThreadLinux.h"
-#include "Plugins/Process/POSIX/NativeProcessELF.h"
-#include "Plugins/Process/Utility/NativeProcessSoftwareSingleStep.h"
+#include <csignal>
+#include <unordered_set>
 
 namespace lldb_private {
 class Status;

--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm.cpp
@@ -15,20 +15,19 @@
 #include "Plugins/Process/POSIX/ProcessPOSIXLog.h"
 #include "Plugins/Process/Utility/RegisterInfoPOSIX_arm.h"
 #include "lldb/Host/HostInfo.h"
+#include "lldb/Host/linux/Ptrace.h"
 #include "lldb/Utility/DataBufferHeap.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/RegisterValue.h"
 #include "lldb/Utility/Status.h"
 
-#include <elf.h>
-#include <sys/uio.h>
-
 #if defined(__arm64__) || defined(__aarch64__)
-#include "NativeRegisterContextLinux_arm64dbreg.h"
+#include "Plugins/Process/Linux/NativeRegisterContextLinux_arm64dbreg.h"
 #endif
 
-#include "lldb/Host/linux/Ptrace.h"
 #include <asm/ptrace.h>
+#include <elf.h>
+#include <sys/uio.h>
 
 #define REG_CONTEXT_SIZE (GetGPRSize() + sizeof(m_fpr) + sizeof(m_tls))
 

--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64.cpp
@@ -9,9 +9,15 @@
 #if defined(__arm64__) || defined(__aarch64__)
 
 #include "NativeRegisterContextLinux_arm64.h"
-#include "NativeRegisterContextLinux_arm.h"
-#include "NativeRegisterContextLinux_arm64dbreg.h"
 
+#include "Plugins/Process/Linux/NativeProcessLinux.h"
+#include "Plugins/Process/Linux/NativeRegisterContextLinux_arm.h"
+#include "Plugins/Process/Linux/NativeRegisterContextLinux_arm64dbreg.h"
+#include "Plugins/Process/Linux/Procfs.h"
+#include "Plugins/Process/POSIX/ProcessPOSIXLog.h"
+#include "Plugins/Process/Utility/MemoryTagManagerAArch64MTE.h"
+#include "Plugins/Process/Utility/RegisterInfoPOSIX_arm64.h"
+#include "Plugins/Process/Utility/RegisterTypeDetector_arm64.h"
 #include "lldb/Host/HostInfo.h"
 #include "lldb/Host/common/NativeProcessProtocol.h"
 #include "lldb/Host/linux/Ptrace.h"
@@ -19,14 +25,6 @@
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/RegisterValue.h"
 #include "lldb/Utility/Status.h"
-
-#include "Plugins/Process/Linux/NativeProcessLinux.h"
-#include "Plugins/Process/Linux/Procfs.h"
-#include "Plugins/Process/POSIX/ProcessPOSIXLog.h"
-#include "Plugins/Process/Utility/MemoryTagManagerAArch64MTE.h"
-#include "Plugins/Process/Utility/RegisterInfoPOSIX_arm64.h"
-#include "Plugins/Process/Utility/RegisterTypeDetector_arm64.h"
-
 #include "llvm/BinaryFormat/ELF.h"
 
 // System includes - They have to be included after framework includes because

--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64dbreg.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64dbreg.cpp
@@ -12,11 +12,10 @@
 #include "lldb/Host/linux/Ptrace.h"
 
 #include <asm/ptrace.h>
+#include <elf.h>
 // System includes - They have to be included after framework includes because
 // they define some macros which collide with variable names in other modules
 #include <sys/uio.h>
-// NT_PRSTATUS and NT_FPREGSET definition
-#include <elf.h>
 
 using namespace lldb;
 using namespace lldb_private;

--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64dbreg.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64dbreg.cpp
@@ -11,10 +11,10 @@
 #include "NativeRegisterContextLinux_arm64dbreg.h"
 #include "lldb/Host/linux/Ptrace.h"
 
-#include <asm/ptrace.h>
-#include <elf.h>
 // System includes - They have to be included after framework includes because
 // they define some macros which collide with variable names in other modules
+#include <asm/ptrace.h>
+#include <elf.h>
 #include <sys/uio.h>
 
 using namespace lldb;

--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_loongarch64.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_loongarch64.cpp
@@ -10,17 +10,16 @@
 
 #include "NativeRegisterContextLinux_loongarch64.h"
 
+#include "Plugins/Process/Linux/NativeProcessLinux.h"
+#include "Plugins/Process/Linux/Procfs.h"
+#include "Plugins/Process/Utility/RegisterInfoPOSIX_loongarch64.h"
+#include "Plugins/Process/Utility/lldb-loongarch-register-enums.h"
 #include "lldb/Host/HostInfo.h"
 #include "lldb/Host/linux/Ptrace.h"
 #include "lldb/Utility/DataBufferHeap.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/RegisterValue.h"
 #include "lldb/Utility/Status.h"
-
-#include "Plugins/Process/Linux/NativeProcessLinux.h"
-#include "Plugins/Process/Linux/Procfs.h"
-#include "Plugins/Process/Utility/RegisterInfoPOSIX_loongarch64.h"
-#include "Plugins/Process/Utility/lldb-loongarch-register-enums.h"
 
 // NT_PRSTATUS and NT_FPREGSET definition
 #include <elf.h>

--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_ppc64le.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_ppc64le.cpp
@@ -13,6 +13,10 @@
 
 #include "NativeRegisterContextLinux_ppc64le.h"
 
+#include "Plugins/Process/Linux/NativeProcessLinux.h"
+#include "Plugins/Process/Linux/Procfs.h"
+#include "Plugins/Process/POSIX/ProcessPOSIXLog.h"
+#include "Plugins/Process/Utility/RegisterInfoPOSIX_ppc64le.h"
 #include "lldb/Host/HostInfo.h"
 #include "lldb/Host/common/NativeProcessProtocol.h"
 #include "lldb/Utility/DataBufferHeap.h"
@@ -20,16 +24,11 @@
 #include "lldb/Utility/RegisterValue.h"
 #include "lldb/Utility/Status.h"
 
-#include "Plugins/Process/Linux/NativeProcessLinux.h"
-#include "Plugins/Process/Linux/Procfs.h"
-#include "Plugins/Process/POSIX/ProcessPOSIXLog.h"
-#include "Plugins/Process/Utility/RegisterInfoPOSIX_ppc64le.h"
-
 // System includes - They have to be included after framework includes because
 // they define some macros which collide with variable names in other modules
-#include <sys/socket.h>
-#include <elf.h>
 #include <asm/ptrace.h>
+#include <elf.h>
+#include <sys/socket.h>
 
 #define REG_CONTEXT_SIZE                                                       \
   (GetGPRSize() + GetFPRSize() + sizeof(m_vmx_ppc64le) + sizeof(m_vsx_ppc64le))

--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_riscv64.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_riscv64.cpp
@@ -10,23 +10,21 @@
 
 #include "NativeRegisterContextLinux_riscv64.h"
 
+#include "Plugins/Process/Linux/NativeProcessLinux.h"
+#include "Plugins/Process/Linux/Procfs.h"
+#include "Plugins/Process/Utility/RegisterInfoPOSIX_riscv64.h"
+#include "Plugins/Process/Utility/lldb-riscv-register-enums.h"
 #include "lldb/Host/HostInfo.h"
 #include "lldb/Utility/DataBufferHeap.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/RegisterValue.h"
 #include "lldb/Utility/Status.h"
 
-#include "Plugins/Process/Linux/NativeProcessLinux.h"
-#include "Plugins/Process/Linux/Procfs.h"
-#include "Plugins/Process/Utility/RegisterInfoPOSIX_riscv64.h"
-#include "Plugins/Process/Utility/lldb-riscv-register-enums.h"
-
 // System includes - They have to be included after framework includes because
 // they define some macros which collide with variable names in other modules
+#include <elf.h>
 #include <sys/ptrace.h>
 #include <sys/uio.h>
-// NT_PRSTATUS and NT_FPREGSET definition
-#include <elf.h>
 
 using namespace lldb;
 using namespace lldb_private;

--- a/lldb/source/Plugins/Process/Linux/NativeThreadLinux.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeThreadLinux.cpp
@@ -8,13 +8,11 @@
 
 #include "NativeThreadLinux.h"
 
-#include <csignal>
-#include <sstream>
-
-#include "NativeProcessLinux.h"
-#include "NativeRegisterContextLinux.h"
-#include "SingleStepCheck.h"
-
+#include "Plugins/Process/Linux/NativeProcessLinux.h"
+#include "Plugins/Process/Linux/NativeRegisterContextLinux.h"
+#include "Plugins/Process/Linux/SingleStepCheck.h"
+#include "Plugins/Process/POSIX/CrashReason.h"
+#include "Plugins/Process/Utility/MemoryTagManagerAArch64MTE.h"
 #include "lldb/Host/HostNativeThread.h"
 #include "lldb/Host/linux/Ptrace.h"
 #include "lldb/Host/linux/Support.h"
@@ -23,12 +21,10 @@
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/State.h"
 #include "lldb/lldb-enumerations.h"
-
 #include "llvm/ADT/SmallString.h"
 
-#include "Plugins/Process/POSIX/CrashReason.h"
-#include "Plugins/Process/Utility/MemoryTagManagerAArch64MTE.h"
-
+#include <csignal>
+#include <sstream>
 #include <sys/syscall.h>
 // Try to define a macro to encapsulate the tgkill syscall
 #define tgkill(pid, tid, sig)                                                  \

--- a/lldb/source/Plugins/Process/Linux/SingleStepCheck.cpp
+++ b/lldb/source/Plugins/Process/Linux/SingleStepCheck.cpp
@@ -8,19 +8,17 @@
 
 #include "SingleStepCheck.h"
 
+#include "Plugins/Process/Linux/NativeProcessLinux.h"
+#include "Plugins/Process/POSIX/ProcessPOSIXLog.h"
+#include "lldb/Host/linux/Ptrace.h"
+#include "lldb/Utility/Status.h"
+#include "llvm/Support/Compiler.h"
+#include "llvm/Support/Errno.h"
+
 #include <csignal>
 #include <sched.h>
 #include <sys/wait.h>
 #include <unistd.h>
-
-#include "NativeProcessLinux.h"
-
-#include "llvm/Support/Compiler.h"
-#include "llvm/Support/Errno.h"
-
-#include "Plugins/Process/POSIX/ProcessPOSIXLog.h"
-#include "lldb/Host/linux/Ptrace.h"
-#include "lldb/Utility/Status.h"
 
 using namespace lldb;
 using namespace lldb_private;


### PR DESCRIPTION
Add a few obviously missing includes. Use fully qualified paths more
consistently.

This will help later planned refactorings, and better complies with the
style guide.

Link: https://llvm.org/docs/CodingStandards.html#include-style
Link: https://github.com/llvm/llvm-project/issues/217413
