### PR TITLE
[MemCpyOpt] Extend call slot optimization for non-dereferenceable destinations.

### DIFF
--- a/llvm/lib/Transforms/Scalar/MemCpyOptimizer.cpp
+++ b/llvm/lib/Transforms/Scalar/MemCpyOptimizer.cpp
@@ -930,8 +930,7 @@ bool MemCpyOptPass::performCallSlotOptzn(Instruction *cpyLoad,
     // trap anyway if the pointer was not dereferenceable, we can forward the
     // pointer to the call. Perform optimization only for non-memcpy/memset
     // calls, as those are special cased later.
-    if (isa<AnyMemCpyInst>(C) || isa<AnyMemSetInst>(C) ||
-        !isGuaranteedToTransferExecutionToSuccessor(C->getIterator(),
+    if (!isGuaranteedToTransferExecutionToSuccessor(C->getIterator(),
                                                     cpyStore->getIterator())) {
       LLVM_DEBUG(dbgs() << "Call Slot: Dest pointer not dereferenceable\n");
       return false;

--- a/llvm/lib/Transforms/Scalar/MemCpyOptimizer.cpp
+++ b/llvm/lib/Transforms/Scalar/MemCpyOptimizer.cpp
@@ -924,8 +924,18 @@ bool MemCpyOptPass::performCallSlotOptzn(Instruction *cpyLoad,
                         ExplicitlyDereferenceableOnly) ||
       !isDereferenceablePointer(cpyDest, APInt(64, cpySize),
                                 SimplifyQuery(DL, DT, AC, C))) {
-    LLVM_DEBUG(dbgs() << "Call Slot: Dest pointer not dereferenceable\n");
-    return false;
+    // If the call is guaranteed to return normally (willreturn + nounwind),
+    // and there are no instructions between the call and the store that might
+    // trap or throw, execution will reach the store. Since the store would
+    // trap anyway if the pointer was not dereferenceable, we can forward the
+    // pointer to the call. Perform optimization only for non-memcpy/memset
+    // calls, as those are special cased later.
+    if (isa<AnyMemCpyInst>(C) || isa<AnyMemSetInst>(C) ||
+        !isGuaranteedToTransferExecutionToSuccessor(C->getIterator(),
+                                                    cpyStore->getIterator())) {
+      LLVM_DEBUG(dbgs() << "Call Slot: Dest pointer not dereferenceable\n");
+      return false;
+    }
   }
 
   // Make sure that nothing can observe cpyDest being written early. There are

--- a/llvm/test/Transforms/MemCpyOpt/callslot_deref.ll
+++ b/llvm/test/Transforms/MemCpyOpt/callslot_deref.ll
@@ -38,12 +38,12 @@ define void @test_positive_willreturn_nounwind(ptr %val) {
 ; CHECK-LABEL: @test_positive_willreturn_nounwind(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[TMP:%.*]] = alloca [1024 x i32], align 4
-; CHECK-NEXT:    call void @bar_willreturn_nounwind(ptr sret([1024 x i32]) align 4 [[VAL:%.*]]) #[[ATTR3:[0-9]+]]
+; CHECK-NEXT:    call void @bar(ptr sret([1024 x i32]) align 4 [[VAL:%.*]]) #[[ATTR3:[0-9]+]]
 ; CHECK-NEXT:    ret void
 ;
 entry:
   %tmp = alloca [1024 x i32], align 4
-  call void @bar_willreturn_nounwind(ptr sret([1024 x i32]) align 4 %tmp) #0
+  call void @bar(ptr sret([1024 x i32]) align 4 %tmp) willreturn nounwind memory(argmem: write)
   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %val, ptr align 4 %tmp, i64 4096, i1 false)
   ret void
 }
@@ -53,13 +53,13 @@ define void @test_negative_missing_willreturn(ptr %val) {
 ; CHECK-LABEL: @test_negative_missing_willreturn(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[TMP:%.*]] = alloca [1024 x i32], align 4
-; CHECK-NEXT:    call void @bar_missing_willreturn(ptr sret([1024 x i32]) align 4 [[TMP]]) #[[ATTR4:[0-9]+]]
+; CHECK-NEXT:    call void @bar(ptr sret([1024 x i32]) align 4 [[TMP]]) #[[ATTR4:[0-9]+]]
 ; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 4 [[VAL:%.*]], ptr align 4 [[TMP]], i64 4096, i1 false)
 ; CHECK-NEXT:    ret void
 ;
 entry:
   %tmp = alloca [1024 x i32], align 4
-  call void @bar_missing_willreturn(ptr sret([1024 x i32]) align 4 %tmp) #1
+  call void @bar(ptr sret([1024 x i32]) align 4 %tmp) nounwind memory(argmem: write)
   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %val, ptr align 4 %tmp, i64 4096, i1 false)
   ret void
 }
@@ -69,40 +69,34 @@ define void @test_negative_missing_nounwind(ptr %val) {
 ; CHECK-LABEL: @test_negative_missing_nounwind(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[TMP:%.*]] = alloca [1024 x i32], align 4
-; CHECK-NEXT:    call void @bar_missing_nounwind(ptr sret([1024 x i32]) align 4 [[TMP]]) #[[ATTR5:[0-9]+]]
+; CHECK-NEXT:    call void @bar(ptr sret([1024 x i32]) align 4 [[TMP]]) #[[ATTR5:[0-9]+]]
 ; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 4 [[VAL:%.*]], ptr align 4 [[TMP]], i64 4096, i1 false)
 ; CHECK-NEXT:    ret void
 ;
 entry:
   %tmp = alloca [1024 x i32], align 4
-  call void @bar_missing_nounwind(ptr sret([1024 x i32]) align 4 %tmp) #2
+  call void @bar(ptr sret([1024 x i32]) align 4 %tmp) willreturn memory(argmem: write)
   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %val, ptr align 4 %tmp, i64 4096, i1 false)
   ret void
 }
 
-; instruction between call and memcpy that may trap.
+; willreturn nounwind attributes, but instruction between call and memcpy that may trap.
 define void @test_negative_may_trap_between(ptr %val, ptr %unknown) {
 ; CHECK-LABEL: @test_negative_may_trap_between(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[TMP:%.*]] = alloca [1024 x i32], align 4
-; CHECK-NEXT:    call void @bar_willreturn_nounwind(ptr sret([1024 x i32]) align 4 [[TMP]]) #[[ATTR3]]
+; CHECK-NEXT:    call void @bar(ptr sret([1024 x i32]) align 4 [[TMP]]) #[[ATTR3]]
 ; CHECK-NEXT:    [[VAL_LOADED:%.*]] = load volatile i32, ptr [[UNKNOWN:%.*]], align 4
 ; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 4 [[VAL:%.*]], ptr align 4 [[TMP]], i64 4096, i1 false)
 ; CHECK-NEXT:    ret void
 ;
 entry:
   %tmp = alloca [1024 x i32], align 4
-  call void @bar_willreturn_nounwind(ptr sret([1024 x i32]) align 4 %tmp) #0
+  call void @bar(ptr sret([1024 x i32]) align 4 %tmp) willreturn nounwind memory(argmem: write)
   ; A volatile load can trap and has side effects.
   %val_loaded = load volatile i32, ptr %unknown
   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %val, ptr align 4 %tmp, i64 4096, i1 false)
   ret void
 }
 
-declare void @bar_willreturn_nounwind(ptr nocapture sret([1024 x i32]) align 4) #0
-declare void @bar_missing_willreturn(ptr nocapture sret([1024 x i32]) align 4) #1
-declare void @bar_missing_nounwind(ptr nocapture sret([1024 x i32]) align 4) #2
-
-attributes #0 = { willreturn nounwind memory(argmem: write) }
-attributes #1 = { nounwind memory(argmem: write) }
-attributes #2 = { willreturn memory(argmem: write) }
+declare void @bar(ptr nocapture sret([1024 x i32]) align 4)

--- a/llvm/test/Transforms/MemCpyOpt/callslot_deref.ll
+++ b/llvm/test/Transforms/MemCpyOpt/callslot_deref.ll
@@ -23,7 +23,6 @@ define void @must_remove_memcpy(ptr noalias nocapture writable dereferenceable(4
 define void @must_not_remove_memcpy(ptr noalias nocapture writable dereferenceable(1024) %dst) nofree nosync {
 ; CHECK-LABEL: @must_not_remove_memcpy(
 ; CHECK-NEXT:    [[SRC:%.*]] = alloca [4096 x i8], align 1
-; CHECK-NEXT:    call void @llvm.memset.p0.i64(ptr [[SRC]], i8 0, i64 4096, i1 false)
 ; CHECK-NEXT:    call void @llvm.memset.p0.i64(ptr [[DST:%.*]], i8 0, i64 4096, i1 false)
 ; CHECK-NEXT:    ret void
 ;

--- a/llvm/test/Transforms/MemCpyOpt/callslot_deref.ll
+++ b/llvm/test/Transforms/MemCpyOpt/callslot_deref.ll
@@ -2,7 +2,7 @@
 ; RUN: opt < %s -S -passes=memcpyopt -verify-memoryssa | FileCheck %s
 target datalayout = "e-i64:64-f80:128-n8:16:32:64-S128"
 
-declare void @llvm.memcpy.p0.p0.i64(ptr nocapture, ptr nocapture readonly, i64, i1) unnamed_addr nounwind
+declare void @llvm.memcpy.p0.p0.i64(ptr nocapture writeonly, ptr nocapture readonly, i64, i1) unnamed_addr nounwind
 declare void @llvm.memset.p0.i64(ptr nocapture, i8, i64, i1) nounwind
 
 ; all bytes of %dst that are touch by the memset are dereferenceable
@@ -32,3 +32,77 @@ define void @must_not_remove_memcpy(ptr noalias nocapture writable dereferenceab
   call void @llvm.memcpy.p0.p0.i64(ptr %dst, ptr %src, i64 4096, i1 false) #2
   ret void
 }
+
+; enable copy elision when call has both willreturn and nounwind.
+define void @test_positive_willreturn_nounwind(ptr %val) {
+; CHECK-LABEL: @test_positive_willreturn_nounwind(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[TMP:%.*]] = alloca [1024 x i32], align 4
+; CHECK-NEXT:    call void @bar_willreturn_nounwind(ptr sret([1024 x i32]) align 4 [[VAL:%.*]]) #[[ATTR3:[0-9]+]]
+; CHECK-NEXT:    ret void
+;
+entry:
+  %tmp = alloca [1024 x i32], align 4
+  call void @bar_willreturn_nounwind(ptr sret([1024 x i32]) align 4 %tmp) #0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 4 %val, ptr align 4 %tmp, i64 4096, i1 false)
+  ret void
+}
+
+; missing willreturn attribute; optimization should not occur.
+define void @test_negative_missing_willreturn(ptr %val) {
+; CHECK-LABEL: @test_negative_missing_willreturn(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[TMP:%.*]] = alloca [1024 x i32], align 4
+; CHECK-NEXT:    call void @bar_missing_willreturn(ptr sret([1024 x i32]) align 4 [[TMP]]) #[[ATTR4:[0-9]+]]
+; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 4 [[VAL:%.*]], ptr align 4 [[TMP]], i64 4096, i1 false)
+; CHECK-NEXT:    ret void
+;
+entry:
+  %tmp = alloca [1024 x i32], align 4
+  call void @bar_missing_willreturn(ptr sret([1024 x i32]) align 4 %tmp) #1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 4 %val, ptr align 4 %tmp, i64 4096, i1 false)
+  ret void
+}
+
+; missing nounwind attribute; optimization should not occur.
+define void @test_negative_missing_nounwind(ptr %val) {
+; CHECK-LABEL: @test_negative_missing_nounwind(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[TMP:%.*]] = alloca [1024 x i32], align 4
+; CHECK-NEXT:    call void @bar_missing_nounwind(ptr sret([1024 x i32]) align 4 [[TMP]]) #[[ATTR5:[0-9]+]]
+; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 4 [[VAL:%.*]], ptr align 4 [[TMP]], i64 4096, i1 false)
+; CHECK-NEXT:    ret void
+;
+entry:
+  %tmp = alloca [1024 x i32], align 4
+  call void @bar_missing_nounwind(ptr sret([1024 x i32]) align 4 %tmp) #2
+  call void @llvm.memcpy.p0.p0.i64(ptr align 4 %val, ptr align 4 %tmp, i64 4096, i1 false)
+  ret void
+}
+
+; instruction between call and memcpy that may trap.
+define void @test_negative_may_trap_between(ptr %val, ptr %unknown) {
+; CHECK-LABEL: @test_negative_may_trap_between(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[TMP:%.*]] = alloca [1024 x i32], align 4
+; CHECK-NEXT:    call void @bar_willreturn_nounwind(ptr sret([1024 x i32]) align 4 [[TMP]]) #[[ATTR3]]
+; CHECK-NEXT:    [[VAL_LOADED:%.*]] = load volatile i32, ptr [[UNKNOWN:%.*]], align 4
+; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 4 [[VAL:%.*]], ptr align 4 [[TMP]], i64 4096, i1 false)
+; CHECK-NEXT:    ret void
+;
+entry:
+  %tmp = alloca [1024 x i32], align 4
+  call void @bar_willreturn_nounwind(ptr sret([1024 x i32]) align 4 %tmp) #0
+  ; A volatile load can trap and has side effects.
+  %val_loaded = load volatile i32, ptr %unknown
+  call void @llvm.memcpy.p0.p0.i64(ptr align 4 %val, ptr align 4 %tmp, i64 4096, i1 false)
+  ret void
+}
+
+declare void @bar_willreturn_nounwind(ptr nocapture sret([1024 x i32]) align 4) #0
+declare void @bar_missing_willreturn(ptr nocapture sret([1024 x i32]) align 4) #1
+declare void @bar_missing_nounwind(ptr nocapture sret([1024 x i32]) align 4) #2
+
+attributes #0 = { willreturn nounwind memory(argmem: write) }
+attributes #1 = { nounwind memory(argmem: write) }
+attributes #2 = { willreturn memory(argmem: write) }

--- a/llvm/test/Transforms/MemCpyOpt/memcpy.ll
+++ b/llvm/test/Transforms/MemCpyOpt/memcpy.ll
@@ -74,6 +74,7 @@ define void @test2_constant(ptr %Q) nounwind  {
 ; other should be related with a memcpy.
 define void @test2_memcpy(ptr noalias %P, ptr noalias %Q) nounwind  {
 ; CHECK-LABEL: @test2_memcpy(
+; CHECK-NEXT:    %memtmp = alloca %0, align 16
 ; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i32(ptr align 16 [[Q:%.*]], ptr align 16 [[P:%.*]], i32 32, i1 false)
 ; CHECK-NEXT:    ret void
 ;
@@ -88,7 +89,8 @@ define void @test2_memcpy(ptr noalias %P, ptr noalias %Q) nounwind  {
 ; if the one eliminated was inline.
 define void @test3_memcpy(ptr noalias %P, ptr noalias %Q) nounwind  {
 ; CHECK-LABEL: @test3_memcpy(
-; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i32(ptr align 16 [[Q:%.*]], ptr align 16 [[P:%.*]], i32 32, i1 false)
+; CHECK-NEXT:    %memtmp = alloca %0, align 16
+; CHECK-NEXT:    call void @llvm.memcpy.inline.p0.p0.i32(ptr align 16 [[Q:%.*]], ptr align 16 [[P:%.*]], i32 32, i1 false)
 ; CHECK-NEXT:    ret void
 ;
   %memtmp = alloca %0, align 16
@@ -102,7 +104,8 @@ define void @test3_memcpy(ptr noalias %P, ptr noalias %Q) nounwind  {
 ; if the one eliminated was not inline.
 define void @test4_memcpy(ptr noalias %P, ptr noalias %Q) nounwind  {
 ; CHECK-LABEL: @test4_memcpy(
-; CHECK-NEXT:    call void @llvm.memcpy.inline.p0.p0.i32(ptr align 16 [[Q:%.*]], ptr align 16 [[P:%.*]], i32 32, i1 false)
+; CHECK-NEXT:    %memtmp = alloca %0, align 16
+; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i32(ptr align 16 [[Q:%.*]], ptr align 16 [[P:%.*]], i32 32, i1 false)
 ; CHECK-NEXT:    ret void
 ;
   %memtmp = alloca %0, align 16
@@ -115,6 +118,7 @@ define void @test4_memcpy(ptr noalias %P, ptr noalias %Q) nounwind  {
 ; Same as @test2_memcpy, and the inline-ness should be preserved.
 define void @test5_memcpy(ptr noalias %P, ptr noalias %Q) nounwind  {
 ; CHECK-LABEL: @test5_memcpy(
+; CHECK-NEXT:    %memtmp = alloca %0, align 16
 ; CHECK-NEXT:    call void @llvm.memcpy.inline.p0.p0.i32(ptr align 16 [[Q:%.*]], ptr align 16 [[P:%.*]], i32 32, i1 false)
 ; CHECK-NEXT:    ret void
 ;

--- a/llvm/test/Transforms/MemCpyOpt/stack-move-offset.ll
+++ b/llvm/test/Transforms/MemCpyOpt/stack-move-offset.ll
@@ -252,9 +252,8 @@ define void @no_optimize_clobbering_store_to_src_offset(ptr noalias %dst) {
 ; CHECK-NEXT:    store i8 0, ptr [[DST_BUF]], align 1
 ; CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr [[TEMP1]])
 ; CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr [[TEMP2]])
-; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 [[TEMP2]], ptr align 8 [[LOCAL_BUF]], i64 16, i1 false)
+; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 [[DST_BUF]], ptr align 8 [[LOCAL_BUF]], i64 16, i1 false)
 ; CHECK-NEXT:    store i8 0, ptr [[LOCAL_BUF]], align 1
-; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 [[DST_BUF]], ptr align 8 [[TEMP2]], i64 16, i1 false)
 ; CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr [[TEMP2]])
 ; CHECK-NEXT:    ret void
 ;


### PR DESCRIPTION
Allow call slot optimization for non-dereferenceable destinations when execution is guaranteed to reach the store. For this, check if the call has both willreturn and nounwind attributes, and there are no instructions between the call and the store that might trap or throw. Since the store would trap anyway if the destination pointer was not dereferenceable, we can forward the pointer to the call.

This optimization is restricted to non-memcpy/memset calls because these are handled separately after the callSlotOptimization.