### PR TITLE
GlobalISel: Add m_GIntrinsic matcher

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/MIPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/MIPatternMatch.h
@@ -20,6 +20,8 @@
 #include "llvm/CodeGen/MachineRegisterInfo.h"
 #include "llvm/CodeGen/TargetOpcodes.h"
 #include "llvm/IR/InstrTypes.h"
+#include <tuple>
+#include <utility>
 
 namespace llvm {
 namespace MIPatternMatch {
@@ -635,6 +637,50 @@ inline GInstrBind<GBuildVector> m_GBuildVector(GBuildVector *&Inst) {
 }
 inline GInstrBind<GConcatVectors> m_GConcatVectors(GConcatVectors *&Inst) {
   return Inst;
+}
+
+/// Binds the defining instruction of \p Reg if it is a GIntrinsic (any of the
+/// four G_INTRINSIC* opcodes).
+inline GInstrBind<GIntrinsic> m_GIntrinsic(GIntrinsic *&Inst) { return Inst; }
+inline GInstrBind<const GIntrinsic> m_GIntrinsic(const GIntrinsic *&Inst) {
+  return Inst;
+}
+
+/// Matches a GIntrinsic with a specific intrinsic ID and optionally, matchers
+/// for its leading arguments.
+template <Intrinsic::ID IntrID, typename... OpMatchers>
+struct GIntrinsic_match {
+  std::tuple<OpMatchers...> Operands;
+
+  GIntrinsic_match(const OpMatchers &...Ops) : Operands(Ops...) {}
+
+  template <typename OpTy>
+  bool match(const MachineRegisterInfo &MRI, OpTy &&Op) {
+    MachineInstr *TmpMI;
+    if (!mi_match(Op, MRI, m_MInstr(TmpMI)))
+      return false;
+    auto *GI = dyn_cast<GIntrinsic>(TmpMI);
+    if (!GI || !GI->is(IntrID))
+      return false;
+    return matchOperands(MRI, *GI, std::index_sequence_for<OpMatchers...>{});
+  }
+
+private:
+  template <size_t... Is>
+  bool matchOperands(const MachineRegisterInfo &MRI, GIntrinsic &GI,
+                     std::index_sequence<Is...>) {
+    // Intrinsic arguments follow the ID operand.
+    unsigned FirstArg = GI.getNumExplicitDefs() + 1;
+    return (std::get<Is>(Operands).match(
+                MRI, GI.getOperand(FirstArg + Is).getReg()) &&
+            ...);
+  }
+};
+
+template <Intrinsic::ID IntrID, typename... OpMatchers>
+inline GIntrinsic_match<IntrID, OpMatchers...>
+m_GIntrinsic(const OpMatchers &...Ops) {
+  return GIntrinsic_match<IntrID, OpMatchers...>(Ops...);
 }
 
 /// Matches a G_SHUFFLE_VECTOR, binding its two source operands and its mask.

--- a/llvm/lib/Target/AArch64/GISel/AArch64GlobalISelUtils.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64GlobalISelUtils.cpp
@@ -9,11 +9,13 @@
 /// GlobalISel pipeline.
 //===----------------------------------------------------------------------===//
 #include "AArch64GlobalISelUtils.h"
+#include "llvm/CodeGen/GlobalISel/MIPatternMatch.h"
 #include "llvm/CodeGen/GlobalISel/Utils.h"
 #include "llvm/CodeGen/TargetLowering.h"
 #include "llvm/IR/InstrTypes.h"
 
 using namespace llvm;
+using namespace MIPatternMatch;
 
 std::optional<RegOrConstant>
 AArch64GISelUtils::getAArch64VectorSplat(const MachineInstr &MI,
@@ -115,16 +117,16 @@ AArch64GISelUtils::extractPtrauthBlendDiscriminators(Register Disc,
     return std::make_tuple(ConstDisc, AddrDisc);
   }
 
-  const MachineInstr *DiscMI = MRI.getVRegDef(Disc);
-  if (!DiscMI || DiscMI->getOpcode() != TargetOpcode::G_INTRINSIC ||
-      DiscMI->getOperand(1).getIntrinsicID() != Intrinsic::ptrauth_blend)
+  Register BlendAddrDisc, BlendConstDisc;
+  if (!mi_match(Disc, MRI,
+                m_GIntrinsic<Intrinsic::ptrauth_blend>(m_Reg(BlendAddrDisc),
+                                                       m_Reg(BlendConstDisc))))
     return std::make_tuple(ConstDisc, AddrDisc);
 
-  if (auto ConstDiscVal =
-          getIConstantVRegVal(DiscMI->getOperand(3).getReg(), MRI)) {
+  if (auto ConstDiscVal = getIConstantVRegVal(BlendConstDisc, MRI)) {
     if (isUInt<16>(ConstDiscVal->getZExtValue())) {
       ConstDisc = ConstDiscVal->getZExtValue();
-      AddrDisc = DiscMI->getOperand(2).getReg();
+      AddrDisc = BlendAddrDisc;
     }
   }
   return std::make_tuple(ConstDisc, AddrDisc);

--- a/llvm/lib/Target/SPIRV/SPIRVCombine.td
+++ b/llvm/lib/Target/SPIRV/SPIRVCombine.td
@@ -23,16 +23,20 @@ def vector_select_to_faceforward_lowering : GICombineRule <
 >;
 
 def matrix_transpose_lowering
-    : GICombineRule<(defs root:$root),
-                    (match (wip_match_opcode G_INTRINSIC):$root,
-                        [{ return Helper.matchMatrixTranspose(*${root}); }]),
-                    (apply [{ Helper.applyMatrixTranspose(*${root}); }])>;
+    : GICombineRule<
+          (defs root:$root),
+          (match (wip_match_opcode G_INTRINSIC):$root,
+              [{ return mi_match(*${root}, MRI,
+                                 m_GIntrinsic<Intrinsic::matrix_transpose>()); }]),
+          (apply [{ Helper.applyMatrixTranspose(*${root}); }])>;
 
 def matrix_multiply_lowering
-    : GICombineRule<(defs root:$root),
-                    (match (wip_match_opcode G_INTRINSIC):$root,
-                        [{ return Helper.matchMatrixMultiply(*${root}); }]),
-                    (apply [{ Helper.applyMatrixMultiply(*${root}); }])>;
+    : GICombineRule<
+          (defs root:$root),
+          (match (wip_match_opcode G_INTRINSIC):$root,
+              [{ return mi_match(*${root}, MRI,
+                                 m_GIntrinsic<Intrinsic::matrix_multiply>()); }]),
+          (apply [{ Helper.applyMatrixMultiply(*${root}); }])>;
 
 def SPIRVPreLegalizerCombiner
     : GICombiner<"SPIRVPreLegalizerCombinerImpl",

--- a/llvm/lib/Target/SPIRV/SPIRVCombinerHelper.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCombinerHelper.cpp
@@ -34,8 +34,7 @@ SPIRVCombinerHelper::SPIRVCombinerHelper(
 ///           (vXf32 X) (vXf32 Y)))
 ///
 bool SPIRVCombinerHelper::matchLengthToDistance(MachineInstr &MI) const {
-  if (MI.getOpcode() != TargetOpcode::G_INTRINSIC ||
-      cast<GIntrinsic>(MI).getIntrinsicID() != Intrinsic::spv_length)
+  if (!mi_match(MI, MRI, m_GIntrinsic<Intrinsic::spv_length>()))
     return false;
 
   // First operand of MI is `G_INTRINSIC` so start at operand 2.
@@ -99,9 +98,7 @@ bool SPIRVCombinerHelper::matchSelectToFaceForward(MachineInstr &MI) const {
     return false;
 
   // Check if FCMP is a comparison between a dot product and 0.
-  MachineInstr *DotInstr = MRI.getVRegDef(DotReg);
-  if (DotInstr->getOpcode() != TargetOpcode::G_INTRINSIC ||
-      cast<GIntrinsic>(DotInstr)->getIntrinsicID() != Intrinsic::spv_fdot) {
+  if (!mi_match(DotReg, MRI, m_GIntrinsic<Intrinsic::spv_fdot>())) {
     Register DotOperand1, DotOperand2;
     // Check for scalar dot product.
     if (!mi_match(DotReg, MRI,
@@ -193,11 +190,6 @@ void SPIRVCombinerHelper::applySPIRVFaceForward(MachineInstr &MI) const {
   MI.eraseFromParent();
 }
 
-bool SPIRVCombinerHelper::matchMatrixTranspose(MachineInstr &MI) const {
-  return MI.getOpcode() == TargetOpcode::G_INTRINSIC &&
-         cast<GIntrinsic>(MI).getIntrinsicID() == Intrinsic::matrix_transpose;
-}
-
 void SPIRVCombinerHelper::applyMatrixTranspose(MachineInstr &MI) const {
   Register ResReg = MI.getOperand(0).getReg();
   Register InReg = MI.getOperand(2).getReg();
@@ -222,11 +214,6 @@ void SPIRVCombinerHelper::applyMatrixTranspose(MachineInstr &MI) const {
 
   Builder.buildShuffleVector(ResReg, InReg, InReg, Mask);
   MI.eraseFromParent();
-}
-
-bool SPIRVCombinerHelper::matchMatrixMultiply(MachineInstr &MI) const {
-  return MI.getOpcode() == TargetOpcode::G_INTRINSIC &&
-         cast<GIntrinsic>(MI).getIntrinsicID() == Intrinsic::matrix_multiply;
 }
 
 SmallVector<Register, 4>

--- a/llvm/lib/Target/SPIRV/SPIRVCombinerHelper.h
+++ b/llvm/lib/Target/SPIRV/SPIRVCombinerHelper.h
@@ -33,9 +33,7 @@ public:
   void applySPIRVDistance(MachineInstr &MI) const;
   bool matchSelectToFaceForward(MachineInstr &MI) const;
   void applySPIRVFaceForward(MachineInstr &MI) const;
-  bool matchMatrixTranspose(MachineInstr &MI) const;
   void applyMatrixTranspose(MachineInstr &MI) const;
-  bool matchMatrixMultiply(MachineInstr &MI) const;
   void applyMatrixMultiply(MachineInstr &MI) const;
 
 private:


### PR DESCRIPTION
Add m_GIntrinsic mirroring the IR version. Introduce some uses
in SPIRV and AArch64, and drop trivial manual match wrappers.
Doesn't attempt to take the next stop of avoiding wip_match_opcode.
Also, it's broken that we're using G_INTRINSIC with generic intrinsics.

Co-authored-by: Claude (Opus 4.8) <noreply@anthropic.com>