### PR TITLE
[GISel] Hold IRTranslatorImpl rather than recreating

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/IRTranslator.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/IRTranslator.h
@@ -61,7 +61,6 @@ public:
   IRTranslatorPass(CodeGenOptLevel OptLevel);
   ~IRTranslatorPass();
   IRTranslatorPass(IRTranslatorPass &&);
-  IRTranslatorPass &operator=(IRTranslatorPass &&);
 
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);

--- a/llvm/include/llvm/CodeGen/GlobalISel/IRTranslator.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/IRTranslator.h
@@ -55,7 +55,6 @@ private:
 };
 
 class IRTranslatorPass : public RequiredPassInfoMixin<IRTranslatorPass> {
-  CodeGenOptLevel OptLevel;
   std::unique_ptr<IRTranslatorImpl> Impl;
 
 public:

--- a/llvm/include/llvm/CodeGen/GlobalISel/IRTranslator.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/IRTranslator.h
@@ -23,8 +23,11 @@
 #include "llvm/IR/Analysis.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/Support/CodeGen.h"
+#include <memory>
 
 namespace llvm {
+
+class IRTranslatorImpl;
 
 // Technically the pass should run on an hypothetical MachineModule,
 // since it should translate Global into some sort of MachineGlobal.
@@ -38,6 +41,7 @@ class LLVM_ABI IRTranslatorLegacy : public MachineFunctionPass {
 public:
   static char ID;
   IRTranslatorLegacy(CodeGenOptLevel OptLevel = CodeGenOptLevel::None);
+  ~IRTranslatorLegacy() override;
 
   StringRef getPassName() const override { return "IRTranslator"; }
 
@@ -47,13 +51,18 @@ public:
 
 private:
   CodeGenOptLevel OptLevel;
+  std::unique_ptr<IRTranslatorImpl> Impl;
 };
 
 class IRTranslatorPass : public RequiredPassInfoMixin<IRTranslatorPass> {
   CodeGenOptLevel OptLevel;
+  std::unique_ptr<IRTranslatorImpl> Impl;
 
 public:
-  IRTranslatorPass(CodeGenOptLevel OptLevel) : OptLevel(OptLevel) {}
+  IRTranslatorPass(CodeGenOptLevel OptLevel);
+  ~IRTranslatorPass();
+  IRTranslatorPass(IRTranslatorPass &&);
+  IRTranslatorPass &operator=(IRTranslatorPass &&);
 
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);

--- a/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
@@ -5267,7 +5267,6 @@ IRTranslatorPass::IRTranslatorPass(CodeGenOptLevel OptLevel)
 
 IRTranslatorPass::~IRTranslatorPass() = default;
 IRTranslatorPass::IRTranslatorPass(IRTranslatorPass &&) = default;
-IRTranslatorPass &IRTranslatorPass::operator=(IRTranslatorPass &&) = default;
 
 PreservedAnalyses IRTranslatorPass::run(MachineFunction &MF,
                                         MachineFunctionAnalysisManager &MFAM) {

--- a/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
@@ -105,7 +105,7 @@ static cl::opt<bool>
                             cl::desc("Should enable CSE in irtranslator"),
                             cl::Optional, cl::init(false));
 
-namespace {
+namespace llvm {
 
 class IRTranslatorImpl {
   /// Interface used to lower the everything related to calls.
@@ -850,7 +850,7 @@ public:
                             SSPLayoutInfo *StackProtectorInfo);
 };
 
-} // namespace
+} // namespace llvm
 
 char IRTranslatorLegacy::ID = 0;
 
@@ -883,7 +883,10 @@ static void reportTranslationError(MachineFunction &MF,
 }
 
 IRTranslatorLegacy::IRTranslatorLegacy(CodeGenOptLevel OptLevel)
-    : MachineFunctionPass(ID), OptLevel(OptLevel) {}
+    : MachineFunctionPass(ID), OptLevel(OptLevel),
+      Impl(std::make_unique<IRTranslatorImpl>(OptLevel)) {}
+
+IRTranslatorLegacy::~IRTranslatorLegacy() = default;
 
 #ifndef NDEBUG
 namespace {
@@ -5232,12 +5235,11 @@ bool IRTranslatorImpl::runOnMachineFunction(
 }
 
 bool IRTranslatorLegacy::runOnMachineFunction(MachineFunction &MF) {
-  IRTranslatorImpl Impl(OptLevel);
   const TargetSubtargetInfo &Subtarget = MF.getSubtarget();
   Function &F = MF.getFunction();
 
   bool ShouldSkipOpts = skipFunction(MF.getFunction());
-  return Impl.runOnMachineFunction(
+  return Impl->runOnMachineFunction(
       MF,
       [&]() {
         TargetPassConfig &TPC = getAnalysis<TargetPassConfig>();
@@ -5260,9 +5262,15 @@ bool IRTranslatorLegacy::runOnMachineFunction(MachineFunction &MF) {
       &getAnalysis<StackProtector>().getLayoutInfo());
 }
 
+IRTranslatorPass::IRTranslatorPass(CodeGenOptLevel OptLevel)
+    : OptLevel(OptLevel), Impl(std::make_unique<IRTranslatorImpl>(OptLevel)) {}
+
+IRTranslatorPass::~IRTranslatorPass() = default;
+IRTranslatorPass::IRTranslatorPass(IRTranslatorPass &&) = default;
+IRTranslatorPass &IRTranslatorPass::operator=(IRTranslatorPass &&) = default;
+
 PreservedAnalyses IRTranslatorPass::run(MachineFunction &MF,
                                         MachineFunctionAnalysisManager &MFAM) {
-  IRTranslatorImpl Impl(OptLevel);
   const TargetSubtargetInfo &Subtarget = MF.getSubtarget();
   Function &F = MF.getFunction();
 
@@ -5276,7 +5284,7 @@ PreservedAnalyses IRTranslatorPass::run(MachineFunction &MF,
   if (!MLLI)
     reportFatalUsageError(
         "LibcallLoweringModuleAnalysis must be available for IRTranslator");
-  Impl.runOnMachineFunction(
+  Impl->runOnMachineFunction(
       MF, [&]() { return MFAM.getResult<GISelCSEAnalysis>(MF).get(); },
       ShouldSkipOpts, [&]() { return &FAM.getResult<AAManager>(F); },
       [&]() { return &FAM.getResult<BranchProbabilityAnalysis>(F); },

--- a/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
@@ -5263,7 +5263,7 @@ bool IRTranslatorLegacy::runOnMachineFunction(MachineFunction &MF) {
 }
 
 IRTranslatorPass::IRTranslatorPass(CodeGenOptLevel OptLevel)
-    : OptLevel(OptLevel), Impl(std::make_unique<IRTranslatorImpl>(OptLevel)) {}
+    : Impl(std::make_unique<IRTranslatorImpl>(OptLevel)) {}
 
 IRTranslatorPass::~IRTranslatorPass() = default;
 IRTranslatorPass::IRTranslatorPass(IRTranslatorPass &&) = default;


### PR DESCRIPTION
`IRTranslatorImpl` holds some state/data structures that are expensive to fully recreate for each MF, so put it into a unique_ptr so we can use a common implementation. Forward declare `IRTranslatorImpl` and define constructors/operators in the source file so we can avoid needing to put the definition of `IRTranslatorImpl` inside of `IRTranslator.h`. This seems to resolve the performance regression observed in #216915.

https://llvm-compile-time-tracker.com/compare.php?from=9932f190f42e1a12c3cafea23938241abf6337ca&to=394a782c063f55377188044296c5911db45c9a38&stat=instructions:u

LLM assisted.