### PR TITLE
RISCV/GlobalISel: Use mi_match for all-ones check

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/MIPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/MIPatternMatch.h
@@ -258,6 +258,16 @@ struct BindImmMatch {
 /// Binds an immediate operand's value.
 inline BindImmMatch m_Imm(int64_t &Imm) { return BindImmMatch(Imm); }
 
+/// Matches an integer constant with all bits set, regardless of width.
+struct AllOnesConstantMatch {
+  bool match(const MachineRegisterInfo &MRI, Register Reg) {
+    APInt MatchedVal;
+    return mi_match(Reg, MRI, m_ICst(MatchedVal)) && MatchedVal.isAllOnes();
+  }
+};
+
+inline AllOnesConstantMatch m_AllOnes() { return {}; }
+
 /// Matcher for a specific constant splat.
 struct SpecificConstantSplatMatch {
   APInt RequestedVal;

--- a/llvm/lib/Target/RISCV/GISel/RISCVInstructionSelector.cpp
+++ b/llvm/lib/Target/RISCV/GISel/RISCVInstructionSelector.cpp
@@ -1012,12 +1012,8 @@ bool RISCVInstructionSelector::selectIntrinsic(MachineInstr &I) const {
         }
       }
 
-      MachineInstr *AVLDef = MRI->getVRegDef(AVLReg);
-      if (AVLDef && AVLDef->getOpcode() == TargetOpcode::G_CONSTANT) {
-        const auto *C = AVLDef->getOperand(1).getCImm();
-        if (C->getValue().isAllOnes())
-          VLMax = true;
-      }
+      if (mi_match(AVLReg, *MRI, m_AllOnes()))
+        VLMax = true;
     }
 
     if (VLMax) {


### PR DESCRIPTION
Introduce a new m_AllOnes matcher, like the IR version has

Co-authored-by: Claude (Opus 4.8) <noreply@anthropic.com>