### PR TITLE
GlobalISel: Add m_GAssertZext matcher and use it in AArch64 combiner

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/MIPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/MIPatternMatch.h
@@ -971,18 +971,18 @@ m_GFPTrunc(const SrcTy &Src) {
   return UnaryOp_match<SrcTy, TargetOpcode::G_FPTRUNC>(Src);
 }
 
-/// Matches a G_SEXT_INREG, matching its source operand and immediate width with
-/// sub-matchers.
-template <typename SrcTy, typename ImmTy> struct SExtInRegMatch {
+/// Matches an op that binds a source operand and an immediate operand with
+/// sub-matchers (e.g. G_SEXT_INREG, G_ASSERT_ZEXT).
+template <typename SrcTy, typename ImmTy, unsigned Opcode>
+struct SrcImmOp_match {
   SrcTy L;
   ImmTy Imm;
 
-  SExtInRegMatch(const SrcTy &LHS, const ImmTy &Imm) : L(LHS), Imm(Imm) {}
+  SrcImmOp_match(const SrcTy &LHS, const ImmTy &Imm) : L(LHS), Imm(Imm) {}
   template <typename OpTy>
   bool match(const MachineRegisterInfo &MRI, OpTy &&Op) {
     MachineInstr *TmpMI;
-    return mi_match(Op, MRI, m_MInstr(TmpMI)) &&
-           TmpMI->getOpcode() == TargetOpcode::G_SEXT_INREG &&
+    return mi_match(Op, MRI, m_MInstr(TmpMI)) && TmpMI->getOpcode() == Opcode &&
            L.match(MRI, TmpMI->getOperand(1).getReg()) &&
            Imm.match(TmpMI->getOperand(2).getImm());
   }
@@ -993,15 +993,30 @@ struct AnyImmMatch {
   bool match(int64_t) const { return true; }
 };
 
+/// Matches a G_SEXT_INREG, binding its source and immediate width.
 template <typename SrcTy>
-inline SExtInRegMatch<SrcTy, AnyImmMatch> m_GSExtInReg(const SrcTy &Src) {
-  return SExtInRegMatch<SrcTy, AnyImmMatch>(Src, AnyImmMatch());
+inline SrcImmOp_match<SrcTy, AnyImmMatch, TargetOpcode::G_SEXT_INREG>
+m_GSExtInReg(const SrcTy &Src) {
+  return {Src, AnyImmMatch()};
 }
 
 template <typename SrcTy, typename ImmTy>
-inline SExtInRegMatch<SrcTy, ImmTy> m_GSExtInReg(const SrcTy &Src,
-                                                 const ImmTy &Imm) {
-  return SExtInRegMatch<SrcTy, ImmTy>(Src, Imm);
+inline SrcImmOp_match<SrcTy, ImmTy, TargetOpcode::G_SEXT_INREG>
+m_GSExtInReg(const SrcTy &Src, const ImmTy &Imm) {
+  return {Src, Imm};
+}
+
+/// Matches a G_ASSERT_ZEXT, binding its source and immediate bit width.
+template <typename SrcTy>
+inline SrcImmOp_match<SrcTy, AnyImmMatch, TargetOpcode::G_ASSERT_ZEXT>
+m_GAssertZext(const SrcTy &Src) {
+  return {Src, AnyImmMatch()};
+}
+
+template <typename SrcTy, typename ImmTy>
+inline SrcImmOp_match<SrcTy, ImmTy, TargetOpcode::G_ASSERT_ZEXT>
+m_GAssertZext(const SrcTy &Src, const ImmTy &Imm) {
+  return {Src, Imm};
 }
 
 template <typename SrcTy>

--- a/llvm/lib/Target/AArch64/GISel/AArch64PreLegalizerCombiner.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64PreLegalizerCombiner.cpp
@@ -656,16 +656,12 @@ bool matchSimplifyUADDO(MachineInstr &MI, MachineRegisterInfo &MRI,
   LLT WideTy1 = MRI.getType(Op1Wide);
   Register ResVal = MI.getOperand(0).getReg();
   LLT OpTy = MRI.getType(ResVal);
-  MachineInstr *Op0WideDef = MRI.getVRegDef(Op0Wide);
-  MachineInstr *Op1WideDef = MRI.getVRegDef(Op1Wide);
-
   unsigned OpTySize = OpTy.getScalarSizeInBits();
   // First check that the G_TRUNC feeding the G_UADDO are no-ops, because the
   // inputs have been zero-extended.
-  if (Op0WideDef->getOpcode() != TargetOpcode::G_ASSERT_ZEXT ||
-      Op1WideDef->getOpcode() != TargetOpcode::G_ASSERT_ZEXT ||
-      OpTySize != Op0WideDef->getOperand(2).getImm() ||
-      OpTySize != Op1WideDef->getOperand(2).getImm())
+  if (!mi_match(Op0Wide, MRI,
+                m_GAssertZext(m_Reg(), m_SpecificImm(OpTySize))) ||
+      !mi_match(Op1Wide, MRI, m_GAssertZext(m_Reg(), m_SpecificImm(OpTySize))))
     return false;
 
   // Only scalar UADDO with either 8 or 16 bit operands are handled.


### PR DESCRIPTION
Generalize the G_SEXT_INREG source+immediate matcher into a shared
SrcImmOp_match template and add m_GAssertZext on top of it. Use it in the
AArch64 narrow-UADDO combiner to replace the getVRegDef + G_ASSERT_ZEXT opcode
and immediate checks. NFC.

Co-authored-by: Claude (Opus 4.8) <noreply@anthropic.com>