### PR TITLE
X86/GlobalISel: Use mi_match for implicit-def and constant checks

### DIFF
--- a/llvm/lib/Target/X86/GISel/X86InstructionSelector.cpp
+++ b/llvm/lib/Target/X86/GISel/X86InstructionSelector.cpp
@@ -22,6 +22,7 @@
 #include "llvm/CodeGen/GlobalISel/GIMatchTableExecutorImpl.h"
 #include "llvm/CodeGen/GlobalISel/GenericMachineInstrs.h"
 #include "llvm/CodeGen/GlobalISel/InstructionSelector.h"
+#include "llvm/CodeGen/GlobalISel/MIPatternMatch.h"
 #include "llvm/CodeGen/GlobalISel/Utils.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/CodeGen/MachineConstantPool.h"
@@ -50,6 +51,7 @@
 #define DEBUG_TYPE "X86-isel"
 
 using namespace llvm;
+using namespace MIPatternMatch;
 
 namespace {
 
@@ -1464,7 +1466,7 @@ bool X86InstructionSelector::selectInsert(MachineInstr &I,
   if (Index % InsertRegTy.getSizeInBits() != 0)
     return false; // Not insert subvector.
 
-  if (Index == 0 && MRI.getVRegDef(SrcReg)->isImplicitDef()) {
+  if (Index == 0 && mi_match(SrcReg, MRI, m_GImplicitDef())) {
     // Replace by subreg copy.
     if (!emitInsertSubreg(DstReg, InsertReg, I, MRI, MF))
       return false;

--- a/llvm/lib/Target/X86/GISel/X86LegalizerInfo.cpp
+++ b/llvm/lib/Target/X86/GISel/X86LegalizerInfo.cpp
@@ -15,6 +15,7 @@
 #include "X86TargetMachine.h"
 #include "llvm/CodeGen/GlobalISel/GenericMachineInstrs.h"
 #include "llvm/CodeGen/GlobalISel/LegalizerHelper.h"
+#include "llvm/CodeGen/GlobalISel/MIPatternMatch.h"
 #include "llvm/CodeGen/GlobalISel/MachineIRBuilder.h"
 #include "llvm/CodeGen/MachineConstantPool.h"
 #include "llvm/CodeGen/MachineFrameInfo.h"
@@ -25,6 +26,7 @@
 #include "llvm/IR/Type.h"
 
 using namespace llvm;
+using namespace MIPatternMatch;
 using namespace TargetOpcode;
 using namespace LegalizeActions;
 using namespace LegalityPredicates;
@@ -929,12 +931,12 @@ bool X86LegalizerInfo::legalizeSETROUNDING(MachineInstr &MI,
       MIRBuilder.buildAnd(s16, CWD16, MIRBuilder.buildConstant(s16, 0xf3ff));
 
   // Check if Src is a constant
-  auto *SrcDef = MRI.getVRegDef(Src);
   Register RMBits;
   Register MXCSRRMBits;
 
-  if (SrcDef && SrcDef->getOpcode() == TargetOpcode::G_CONSTANT) {
-    uint64_t RM = getIConstantFromReg(Src, MRI).getZExtValue();
+  APInt SrcCst;
+  if (mi_match(Src, MRI, m_ICst(SrcCst))) {
+    uint64_t RM = SrcCst.getZExtValue();
     int FieldVal = X86::getRoundingModeX86(RM);
 
     if (FieldVal == X86::rmInvalid) {

--- a/llvm/test/CodeGen/X86/GlobalISel/select-insert-vec256.mir
+++ b/llvm/test/CodeGen/X86/GlobalISel/select-insert-vec256.mir
@@ -88,7 +88,7 @@ body:             |
     ; AVX512VL-NEXT: [[INSERT_SUBREG:%[0-9]+]]:vr256x = INSERT_SUBREG [[DEF]], [[COPY]], %subreg.sub_xmm
     ; AVX512VL-NEXT: $ymm0 = COPY [[INSERT_SUBREG]]
     ; AVX512VL-NEXT: RET 0, implicit $ymm0
-    %0(<8 x s32>) = IMPLICIT_DEF
+    %0(<8 x s32>) = G_IMPLICIT_DEF
     %1(<4 x s32>) = COPY $xmm1
     %2(<8 x s32>) = G_INSERT %0(<8 x s32>), %1(<4 x s32>), 0
     $ymm0 = COPY %2(<8 x s32>)
@@ -163,7 +163,7 @@ body:             |
     ; AVX512VL-NEXT: [[VINSERTF32X4Z256rri:%[0-9]+]]:vr256x = VINSERTF32X4Z256rri [[DEF]], [[COPY]], 1
     ; AVX512VL-NEXT: $ymm0 = COPY [[VINSERTF32X4Z256rri]]
     ; AVX512VL-NEXT: RET 0, implicit $ymm0
-    %0(<8 x s32>) = IMPLICIT_DEF
+    %0(<8 x s32>) = G_IMPLICIT_DEF
     %1(<4 x s32>) = COPY $xmm1
     %2(<8 x s32>) = G_INSERT %0(<8 x s32>), %1(<4 x s32>), 128
     $ymm0 = COPY %2(<8 x s32>)

--- a/llvm/test/CodeGen/X86/GlobalISel/select-insert-vec512.mir
+++ b/llvm/test/CodeGen/X86/GlobalISel/select-insert-vec512.mir
@@ -84,7 +84,7 @@ body:             |
     ; ALL-NEXT: [[INSERT_SUBREG:%[0-9]+]]:vr512 = INSERT_SUBREG [[DEF]], [[COPY]], %subreg.sub_xmm
     ; ALL-NEXT: $zmm0 = COPY [[INSERT_SUBREG]]
     ; ALL-NEXT: RET 0, implicit $ymm0
-    %0(<16 x s32>) = IMPLICIT_DEF
+    %0(<16 x s32>) = G_IMPLICIT_DEF
     %1(<4 x s32>) = COPY $xmm1
     %2(<16 x s32>) = G_INSERT %0(<16 x s32>), %1(<4 x s32>), 0
     $zmm0 = COPY %2(<16 x s32>)
@@ -139,7 +139,7 @@ body:             |
     ; ALL-NEXT: [[VINSERTF32X4Zrri:%[0-9]+]]:vr512 = VINSERTF32X4Zrri [[DEF]], [[COPY]], 1
     ; ALL-NEXT: $zmm0 = COPY [[VINSERTF32X4Zrri]]
     ; ALL-NEXT: RET 0, implicit $ymm0
-    %0(<16 x s32>) = IMPLICIT_DEF
+    %0(<16 x s32>) = G_IMPLICIT_DEF
     %1(<4 x s32>) = COPY $xmm1
     %2(<16 x s32>) = G_INSERT %0(<16 x s32>), %1(<4 x s32>), 128
     $zmm0 = COPY %2(<16 x s32>)
@@ -194,7 +194,7 @@ body:             |
     ; ALL-NEXT: [[INSERT_SUBREG:%[0-9]+]]:vr512 = INSERT_SUBREG [[DEF]], [[COPY]], %subreg.sub_ymm
     ; ALL-NEXT: $zmm0 = COPY [[INSERT_SUBREG]]
     ; ALL-NEXT: RET 0, implicit $ymm0
-    %0(<16 x s32>) = IMPLICIT_DEF
+    %0(<16 x s32>) = G_IMPLICIT_DEF
     %1(<8 x s32>) = COPY $ymm1
     %2(<16 x s32>) = G_INSERT %0(<16 x s32>), %1(<8 x s32>), 0
     $zmm0 = COPY %2(<16 x s32>)
@@ -249,7 +249,7 @@ body:             |
     ; ALL-NEXT: [[VINSERTF64X4Zrri:%[0-9]+]]:vr512 = VINSERTF64X4Zrri [[DEF]], [[COPY]], 1
     ; ALL-NEXT: $zmm0 = COPY [[VINSERTF64X4Zrri]]
     ; ALL-NEXT: RET 0, implicit $ymm0
-    %0(<16 x s32>) = IMPLICIT_DEF
+    %0(<16 x s32>) = G_IMPLICIT_DEF
     %1(<8 x s32>) = COPY $ymm1
     %2(<16 x s32>) = G_INSERT %0(<16 x s32>), %1(<8 x s32>), 256
     $zmm0 = COPY %2(<16 x s32>)


### PR DESCRIPTION
Also fix some broken tests using IMPLICIT_DEF without a set register
class. Ideally the verifier would check these. Real compiles should
have used G_IMPLICIT_DEF

Co-authored-by: Claude (Opus 4.8) <noreply@anthropic.com>