### PR TITLE
[ORC][COFF] Preserve import symbol types in DLL stubs

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/COFF.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/COFF.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_COFF_H
 #define LLVM_EXECUTIONENGINE_ORC_COFF_H
 
+#include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -28,6 +29,8 @@ class Archive;
 
 namespace orc {
 
+class ObjectLinkingLayer;
+
 class COFFImportFileScanner {
 public:
   COFFImportFileScanner(std::set<std::string> &ImportedDynamicLibraries)
@@ -39,7 +42,39 @@ private:
   std::set<std::string> &ImportedDynamicLibraries;
 };
 
+/// A COFF-aware static-library definition generator.
+///
+/// Ordinary object members are handled by StaticLibraryDefinitionGenerator.
+/// COFF short-import members are interpreted separately to synthesize their
+/// IAT slots and call thunks and to report their referenced dynamic libraries.
+/// This generator currently supports x86-64 COFF targets only.
+class LLVM_ABI COFFStaticLibraryDefinitionGenerator
+    : public DefinitionGenerator {
+public:
+  static Expected<std::unique_ptr<COFFStaticLibraryDefinitionGenerator>>
+  Load(ObjectLinkingLayer &L, const char *FileName,
+       std::set<std::string> &ImportedDynamicLibraries);
+
+  static Expected<std::unique_ptr<COFFStaticLibraryDefinitionGenerator>>
+  Create(ObjectLinkingLayer &L, std::unique_ptr<MemoryBuffer> ArchiveBuffer,
+         std::unique_ptr<object::Archive> Archive,
+         std::set<std::string> &ImportedDynamicLibraries);
+
+  ~COFFStaticLibraryDefinitionGenerator() override;
+
+  Error tryToGenerate(LookupState &LS, LookupKind K, JITDylib &JD,
+                      JITDylibLookupFlags JDLookupFlags,
+                      const SymbolLookupSet &Symbols) override;
+
+private:
+  struct Impl;
+
+  COFFStaticLibraryDefinitionGenerator(std::unique_ptr<Impl> P);
+
+  std::unique_ptr<Impl> P;
+};
+
 } // namespace orc
 } // namespace llvm
 
-#endif // LLVM_EXECUTIONENGINE_ORC_MACHO_H
+#endif // LLVM_EXECUTIONENGINE_ORC_COFF_H

--- a/llvm/include/llvm/ExecutionEngine/Orc/COFFPlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/COFFPlatform.h
@@ -14,6 +14,7 @@
 #define LLVM_EXECUTIONENGINE_ORC_COFFPLATFORM_H
 
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ExecutionEngine/Orc/COFF.h"
 #include "llvm/ExecutionEngine/Orc/COFFVCRuntimeSupport.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/ExecutionUtils.h"
@@ -139,7 +140,7 @@ private:
 
   COFFPlatform(
       ObjectLinkingLayer &ObjLinkingLayer, JITDylib &PlatformJD,
-      std::unique_ptr<StaticLibraryDefinitionGenerator> OrcRuntimeGenerator,
+      std::unique_ptr<COFFStaticLibraryDefinitionGenerator> OrcRuntimeGenerator,
       std::set<std::string> DylibsToPreload,
       std::unique_ptr<MemoryBuffer> OrcRuntimeArchiveBuffer,
       std::unique_ptr<object::Archive> OrcRuntimeArchive,

--- a/llvm/include/llvm/Object/COFFImportFile.h
+++ b/llvm/include/llvm/Object/COFFImportFile.h
@@ -77,6 +77,7 @@ public:
   uint16_t getMachine() const { return getCOFFImportHeader()->Machine; }
 
   StringRef getFileFormatName() const;
+  StringRef getSymbolName() const;
   StringRef getExportName() const;
 
 private:

--- a/llvm/lib/ExecutionEngine/JITLink/COFF_x86_64.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/COFF_x86_64.cpp
@@ -248,23 +248,25 @@ private:
   DenseMap<Section *, orc::ExecutorAddr> SectionStartCache;
 };
 
-// Synthesize COFF __imp_ Import Address Table (IAT) entries.
+// Prepare fallback COFF __imp_ Import Address Table (IAT) entries.
 //
 // For a dllimport reference, codegen emits an indirect access through a named
 // __imp_X symbol, e.g.
 //
 //     callq *__imp_bar(%rip)        ; or, for data: movq __imp_g(%rip), %rax
 //
-// where __imp_X is an undefined external. This pass supplies the missing IAT
-// entry by defining __imp_X over an 8-byte pointer slot that holds X's address:
+// where __imp_X is an undefined external. A COFF import-library definition
+// generator may provide that symbol directly. If it does not, these passes
+// supply a fallback 8-byte pointer slot that holds X's address:
 //
 //     __imp_bar:
 //         .quad bar                 ; X is resolved as an ordinary external
 //
-// X is left external, so its address is provided by whatever resolves the
-// JITDylib's externals (an import library, a DynamicLibrarySearchGenerator,
-// COFFAutoImportGenerator, ...). If X is unresolvable the link fails, exactly
-// as a static link against the corresponding import library would.
+// Both __imp_X and X are looked up weakly. After lookup, a resolved __imp_X is
+// used as-is. Otherwise __imp_X is assigned the address of the fallback slot,
+// whose target must have resolved through the JITDylib's link order. This lets
+// import-library metadata (including EXPORTAS) take precedence while retaining
+// import-library-free lookup by the ordinary symbol name.
 //
 // This is the COFF analog of the ELF/Mach-O GOT builder, but deliberately NOT
 // written as a TableManager/visitEdge pass like x86_64::GOTTableManager. ELF's
@@ -280,7 +282,16 @@ private:
 // Direct (non-dllimport) references such as `callq foo` are intentionally not
 // handled here: those are either kept in range by the slab allocator or thunked
 // by the opt-in COFFAutoImportGenerator -- both outside this pass.
-Error synthesizeIATEntries_COFF_x86_64(LinkGraph &G) {
+struct PendingIATEntry {
+  Symbol *Import;
+  Symbol *Target;
+  Symbol *FallbackSlot;
+};
+
+using PendingIATEntries = SmallVector<PendingIATEntry, 8>;
+
+Error prepareIATEntries_COFF_x86_64(LinkGraph &G,
+                                    PendingIATEntries &PendingEntries) {
   static constexpr StringRef ImpPrefix = "__imp_";
 
   // Collect the external __imp_ symbols up front: we mutate the symbol lists
@@ -306,16 +317,40 @@ Error synthesizeIATEntries_COFF_x86_64(LinkGraph &G) {
     orc::SymbolStringPtr Base =
         G.intern((*Imp->getName()).drop_front(ImpPrefix.size()));
 
-    // Find the real target X, or add it as an external to be resolved normally.
+    // Find the real target X, or add a weak external for fallback lookup.
     Symbol *Target = FindByName(std::move(Base));
-    if (!Target)
+    if (!Target) {
       Target = &G.addExternalSymbol(std::move(Base), 0,
-                                    /*IsWeaklyReferenced=*/false);
+                                    /*IsWeaklyReferenced=*/true);
+    }
 
-    // 8-byte slot holding &X, with __imp_X defined over it.
+    // Give an import-library generator the first opportunity to provide the
+    // authoritative __imp_X definition. Failure is diagnosed after lookup if
+    // neither __imp_X nor X can be resolved.
+    Imp->setWeaklyReferenced(true);
+
+    // Reserve an 8-byte fallback slot holding &X. It remains local to this
+    // graph and is used only if external lookup does not provide __imp_X.
     Symbol &Slot = x86_64::createAnonymousPointer(G, IATSec, Target);
-    G.makeDefined(*Imp, Slot.getBlock(), 0, G.getPointerSize(), Linkage::Strong,
-                  Scope::Local, /*IsLive=*/true);
+    Slot.setLive(true);
+    PendingEntries.push_back({Imp, Target, &Slot});
+  }
+
+  return Error::success();
+}
+
+Error applyIATFallbacks_COFF_x86_64(PendingIATEntries &PendingEntries) {
+  for (auto &Entry : PendingEntries) {
+    if (Entry.Import->getAddress())
+      continue;
+
+    if (!Entry.Target->getAddress())
+      return make_error<JITLinkError>(
+          "COFF import " + *Entry.Import->getName() +
+          " could not be resolved through either its import address table "
+          "symbol or its ordinary symbol name");
+
+    Entry.Import->getAddressable().setAddress(Entry.FallbackSlot->getAddress());
   }
 
   return Error::success();
@@ -376,10 +411,17 @@ void link_COFF_x86_64(std::unique_ptr<LinkGraph> G,
     } else
       Config.PrePrunePasses.push_back(markAllSymbolsLive);
 
-    // Synthesize __imp_X IAT entries for dllimport references, like the GOT/PLT
-    // builders for ELF/Mach-O. Runs in PostPrune (before external-symbol
-    // lookup) so the X targets it introduces are resolved normally.
-    Config.PostPrunePasses.push_back(synthesizeIATEntries_COFF_x86_64);
+    // Prepare fallback __imp_X IAT entries before allocation, but leave
+    // __imp_X external until lookup gives import-library generators an
+    // opportunity to provide an authoritative definition.
+    auto PendingIATs = std::make_shared<PendingIATEntries>();
+    Config.PostPrunePasses.push_back([PendingIATs](LinkGraph &G) {
+      return prepareIATEntries_COFF_x86_64(G, *PendingIATs);
+    });
+
+    Config.PreFixupPasses.push_back([PendingIATs](LinkGraph &) {
+      return applyIATFallbacks_COFF_x86_64(*PendingIATs);
+    });
 
     // Add COFF edge lowering passes.
     Config.PreFixupPasses.push_back(COFFLinkGraphLowering_x86_64());

--- a/llvm/lib/ExecutionEngine/Orc/COFF.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/COFF.cpp
@@ -7,7 +7,16 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/ExecutionEngine/Orc/COFF.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/BinaryFormat/COFF.h"
+#include "llvm/ExecutionEngine/JITLink/JITLink.h"
+#include "llvm/ExecutionEngine/Orc/ExecutionUtils.h"
+#include "llvm/ExecutionEngine/Orc/LoadLinkableFile.h"
+#include "llvm/Object/Archive.h"
 #include "llvm/Object/Binary.h"
+#include "llvm/Object/COFFImportFile.h"
 
 #define DEBUG_TYPE "orc"
 
@@ -34,6 +43,280 @@ Expected<bool> COFFImportFileScanner::operator()(object::Archive &A,
   // Otherwise the member is loadable (at least as far as COFFImportFileScanner
   // is concerned), so return true;
   return true;
+}
+
+struct COFFStaticLibraryDefinitionGenerator::Impl {
+  struct ImportRecord {
+    std::string SymbolName;
+    std::string ExportName;
+    COFF::ImportType Type = COFF::IMPORT_DATA;
+    SmallVector<SymbolStringPtr, 2> ProvidedSymbols;
+  };
+
+  Impl(ObjectLinkingLayer &L, jitlink::AnonymousPointerCreator CreatePointer,
+       jitlink::PointerJumpStubCreator CreateStub)
+      : L(L), ES(L.getExecutionSession()),
+        CreatePointer(std::move(CreatePointer)),
+        CreateStub(std::move(CreateStub)) {}
+
+  Expected<bool> visitMember(std::set<std::string> &ImportedDynamicLibraries,
+                             MemoryBufferRef MemberBuf) {
+    auto Bin = object::createBinary(MemberBuf);
+    if (!Bin) {
+      consumeError(Bin.takeError());
+      return false;
+    }
+
+    auto *ImportFile = dyn_cast<object::COFFImportFile>(Bin->get());
+    if (!ImportFile)
+      return true;
+
+    if (ImportFile->getMachine() != COFF::IMAGE_FILE_MACHINE_AMD64)
+      return make_error<StringError>(
+          "COFFStaticLibraryDefinitionGenerator only supports x86-64 "
+          "short-import members",
+          inconvertibleErrorCode());
+
+    if (ImportFile->getSymbolName().empty())
+      return make_error<StringError>(
+          "COFF import file has an empty symbol name",
+          inconvertibleErrorCode());
+
+    ImportedDynamicLibraries.insert(ImportFile->getFileName().str());
+
+    size_t RecordIndex = ImportRecords.size();
+    ImportRecord R;
+    R.SymbolName = ImportFile->getSymbolName().str();
+    R.ExportName = ImportFile->getExportName().str();
+    R.Type = static_cast<COFF::ImportType>(
+        ImportFile->getCOFFImportHeader()->getType());
+
+    for (auto Sym : ImportFile->symbols()) {
+      std::string Name;
+      raw_string_ostream NameOS(Name);
+      if (auto Err = Sym.printName(NameOS))
+        return std::move(Err);
+      auto InternedName = ES.intern(Name);
+      R.ProvidedSymbols.push_back(InternedName);
+      LazyImportSymbols.try_emplace(InternedName, RecordIndex);
+    }
+
+    ImportRecords.push_back(std::move(R));
+    return false;
+  }
+
+  Error tryToGenerate(LookupState &LS, LookupKind K, JITDylib &JD,
+                      JITDylibLookupFlags JDLookupFlags,
+                      const SymbolLookupSet &Symbols) {
+    if (K != LookupKind::Static)
+      return Error::success();
+
+    DenseSet<size_t> ImportsToEmit;
+    for (const auto &[Name, _] : Symbols)
+      if (auto I = LazyImportSymbols.find(Name); I != LazyImportSymbols.end())
+        ImportsToEmit.insert(I->second);
+
+    if (auto Err =
+            ObjectGenerator->tryToGenerate(LS, K, JD, JDLookupFlags, Symbols))
+      return Err;
+
+    if (ImportsToEmit.empty())
+      return Error::success();
+
+    JITDylibSearchOrder LinkOrder;
+    JD.withLinkOrderDo([&](const JITDylibSearchOrder &LO) {
+      LinkOrder.reserve(LO.size());
+      for (auto &KV : LO)
+        if (KV.first != &JD)
+          LinkOrder.push_back(KV);
+    });
+
+    SymbolLookupSet LookupSet;
+    DenseMap<size_t, SymbolStringPtr> ImportTargets;
+    DenseSet<SymbolStringPtr> SeenExports;
+    for (size_t RecordIndex : ImportsToEmit) {
+      auto &R = ImportRecords[RecordIndex];
+      if (R.ExportName.empty())
+        return make_error<StringError>(
+            "ordinal COFF imports are not supported for " + R.SymbolName,
+            inconvertibleErrorCode());
+      auto ExportName = ES.intern(R.ExportName);
+      ImportTargets[RecordIndex] = ExportName;
+      if (SeenExports.insert(ExportName).second)
+        LookupSet.add(ExportName, SymbolLookupFlags::RequiredSymbol);
+    }
+
+    ES.lookup(
+        LookupKind::Static, LinkOrder, std::move(LookupSet),
+        SymbolState::Resolved,
+        [this, JD = JITDylibSP(&JD), LS = std::move(LS),
+         ImportsToEmit = std::move(ImportsToEmit),
+         ImportTargets =
+             std::move(ImportTargets)](Expected<SymbolMap> Resolved) mutable {
+          if (!Resolved)
+            return LS.continueLookup(Resolved.takeError());
+
+          auto G = createImportGraph(ImportsToEmit, ImportTargets, *Resolved);
+          if (!G)
+            return LS.continueLookup(G.takeError());
+          if (auto Err = L.add(*JD, std::move(*G)))
+            return LS.continueLookup(std::move(Err));
+
+          for (size_t RecordIndex : ImportsToEmit) {
+            for (auto &Name : ImportRecords[RecordIndex].ProvidedSymbols)
+              if (auto I = LazyImportSymbols.find(Name);
+                  I != LazyImportSymbols.end() && I->second == RecordIndex)
+                LazyImportSymbols.erase(I);
+          }
+
+          LS.continueLookup(Error::success());
+        },
+        NoDependenciesToRegister);
+
+    return Error::success();
+  }
+
+  Expected<std::unique_ptr<jitlink::LinkGraph>>
+  createImportGraph(const DenseSet<size_t> &ImportsToEmit,
+                    const DenseMap<size_t, SymbolStringPtr> &ImportTargets,
+                    const SymbolMap &Resolved) {
+    Triple TT = ES.getTargetTriple();
+
+    auto G = std::make_unique<jitlink::LinkGraph>(
+        "<COFF_IMPORTS>", ES.getSymbolStringPool(), TT, SubtargetFeatures(),
+        jitlink::getGenericEdgeKindName);
+    auto &Sec =
+        G->createSection("$__COFF_IMPORTS", MemProt::Read | MemProt::Exec);
+
+    for (size_t RecordIndex : ImportsToEmit) {
+      auto &R = ImportRecords[RecordIndex];
+      auto TargetName = ImportTargets.lookup(RecordIndex);
+      auto TargetDef = Resolved.find(TargetName);
+      if (TargetDef == Resolved.end())
+        return make_error<StringError>("resolved COFF import target " +
+                                           *TargetName + " is missing for " +
+                                           R.SymbolName,
+                                       inconvertibleErrorCode());
+
+      auto &Target = G->addAbsoluteSymbol(
+          TargetName, TargetDef->second.getAddress(), G->getPointerSize(),
+          jitlink::Linkage::Strong, jitlink::Scope::Local, false);
+      auto &Ptr = CreatePointer(*G, Sec, &Target, 0);
+
+      SymbolStringPtr ImpName;
+      SymbolStringPtr PlainName;
+      for (auto &Name : R.ProvidedSymbols) {
+        if (StringRef(*Name).starts_with(getImpPrefix()))
+          ImpName = Name;
+        else
+          PlainName = Name;
+      }
+
+      if (!ImpName)
+        return make_error<StringError>(
+            "COFF import does not provide an __imp_ symbol for " + R.SymbolName,
+            inconvertibleErrorCode());
+
+      Ptr.setName(ImpName);
+      Ptr.setLinkage(jitlink::Linkage::Strong);
+      Ptr.setScope(jitlink::Scope::Default);
+
+      if (!PlainName || R.Type == COFF::IMPORT_DATA)
+        continue;
+
+      if (R.Type == COFF::IMPORT_CODE) {
+        auto &Stub = CreateStub(*G, Sec, Ptr);
+        Stub.setName(PlainName);
+        Stub.setLinkage(jitlink::Linkage::Strong);
+        Stub.setScope(jitlink::Scope::Default);
+      } else if (R.Type == COFF::IMPORT_CONST)
+        G->addDefinedSymbol(Ptr.getBlock(), Ptr.getOffset(), PlainName,
+                            Ptr.getSize(), jitlink::Linkage::Strong,
+                            jitlink::Scope::Default, false, false);
+    }
+
+    return std::move(G);
+  }
+
+  static constexpr StringLiteral getImpPrefix() { return "__imp_"; }
+
+  ObjectLinkingLayer &L;
+  ExecutionSession &ES;
+  jitlink::AnonymousPointerCreator CreatePointer;
+  jitlink::PointerJumpStubCreator CreateStub;
+  std::unique_ptr<StaticLibraryDefinitionGenerator> ObjectGenerator;
+  DenseMap<SymbolStringPtr, size_t> LazyImportSymbols;
+  std::vector<ImportRecord> ImportRecords;
+};
+
+Expected<std::unique_ptr<COFFStaticLibraryDefinitionGenerator>>
+COFFStaticLibraryDefinitionGenerator::Load(
+    ObjectLinkingLayer &L, const char *FileName,
+    std::set<std::string> &ImportedDynamicLibraries) {
+  auto Linkable =
+      loadLinkableFile(FileName, L.getExecutionSession().getTargetTriple(),
+                       LoadArchives::Required);
+  if (!Linkable)
+    return Linkable.takeError();
+  auto Archive = object::Archive::create(Linkable->first->getMemBufferRef());
+  if (!Archive)
+    return Archive.takeError();
+  return Create(L, std::move(Linkable->first), std::move(*Archive),
+                ImportedDynamicLibraries);
+}
+
+Expected<std::unique_ptr<COFFStaticLibraryDefinitionGenerator>>
+COFFStaticLibraryDefinitionGenerator::Create(
+    ObjectLinkingLayer &L, std::unique_ptr<MemoryBuffer> ArchiveBuffer,
+    std::unique_ptr<object::Archive> Archive,
+    std::set<std::string> &ImportedDynamicLibraries) {
+  Triple TT = L.getExecutionSession().getTargetTriple();
+  if (!TT.isOSBinFormatCOFF() || TT.getArch() != Triple::x86_64)
+    return make_error<StringError>(
+        "COFFStaticLibraryDefinitionGenerator only supports x86-64 COFF "
+        "targets: " +
+            TT.str(),
+        inconvertibleErrorCode());
+
+  auto CreatePointer = jitlink::getAnonymousPointerCreator(TT);
+  if (!CreatePointer)
+    return make_error<StringError>(
+        "COFFStaticLibraryDefinitionGenerator: no pointer creator for " +
+            TT.str(),
+        inconvertibleErrorCode());
+  auto CreateStub = jitlink::getPointerJumpStubCreator(TT);
+  if (!CreateStub)
+    return make_error<StringError>(
+        "COFFStaticLibraryDefinitionGenerator: no stub creator for " + TT.str(),
+        inconvertibleErrorCode());
+
+  auto P = std::make_unique<Impl>(L, std::move(CreatePointer),
+                                  std::move(CreateStub));
+  auto VisitMembers = [P = P.get(), &ImportedDynamicLibraries](
+                          object::Archive &, MemoryBufferRef MemberBuf,
+                          size_t) -> Expected<bool> {
+    return P->visitMember(ImportedDynamicLibraries, MemberBuf);
+  };
+  auto ObjectGenerator = StaticLibraryDefinitionGenerator::Create(
+      L, std::move(ArchiveBuffer), std::move(Archive), std::move(VisitMembers));
+  if (!ObjectGenerator)
+    return ObjectGenerator.takeError();
+  P->ObjectGenerator = std::move(*ObjectGenerator);
+  return std::unique_ptr<COFFStaticLibraryDefinitionGenerator>(
+      new COFFStaticLibraryDefinitionGenerator(std::move(P)));
+}
+
+COFFStaticLibraryDefinitionGenerator::~COFFStaticLibraryDefinitionGenerator() =
+    default;
+
+COFFStaticLibraryDefinitionGenerator::COFFStaticLibraryDefinitionGenerator(
+    std::unique_ptr<Impl> P)
+    : P(std::move(P)) {}
+
+Error COFFStaticLibraryDefinitionGenerator::tryToGenerate(
+    LookupState &LS, LookupKind K, JITDylib &JD,
+    JITDylibLookupFlags JDLookupFlags, const SymbolLookupSet &Symbols) {
+  return P->tryToGenerate(LS, K, JD, JDLookupFlags, Symbols);
 }
 
 } // namespace llvm::orc

--- a/llvm/lib/ExecutionEngine/Orc/COFFPlatform.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/COFFPlatform.cpp
@@ -173,9 +173,10 @@ COFFPlatform::Create(ObjectLinkingLayer &ObjLinkingLayer, JITDylib &PlatformJD,
     return GeneratorArchive.takeError();
 
   std::set<std::string> DylibsToPreload;
-  auto OrcRuntimeArchiveGenerator = StaticLibraryDefinitionGenerator::Create(
-      ObjLinkingLayer, nullptr, std::move(*GeneratorArchive),
-      COFFImportFileScanner(DylibsToPreload));
+  auto OrcRuntimeArchiveGenerator =
+      COFFStaticLibraryDefinitionGenerator::Create(ObjLinkingLayer, nullptr,
+                                                   std::move(*GeneratorArchive),
+                                                   DylibsToPreload);
   if (!OrcRuntimeArchiveGenerator)
     return OrcRuntimeArchiveGenerator.takeError();
 
@@ -299,7 +300,6 @@ Error COFFPlatform::setupJITDylib(JITDylib &JD) {
         return Err;
   }
 
-  JD.addGenerator(DLLImportDefinitionGenerator::Create(ES, ObjLinkingLayer));
   return Error::success();
 }
 
@@ -379,7 +379,7 @@ bool COFFPlatform::supportedTarget(const Triple &TT) {
 
 COFFPlatform::COFFPlatform(
     ObjectLinkingLayer &ObjLinkingLayer, JITDylib &PlatformJD,
-    std::unique_ptr<StaticLibraryDefinitionGenerator> OrcRuntimeGenerator,
+    std::unique_ptr<COFFStaticLibraryDefinitionGenerator> OrcRuntimeGenerator,
     std::set<std::string> DylibsToPreload,
     std::unique_ptr<MemoryBuffer> OrcRuntimeArchiveBuffer,
     std::unique_ptr<object::Archive> OrcRuntimeArchive,

--- a/llvm/lib/ExecutionEngine/Orc/COFFVCRuntimeSupport.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/COFFVCRuntimeSupport.cpp
@@ -85,9 +85,8 @@ Error COFFVCRuntimeBootstrapper::loadVCRuntime(
     sys::path::append(LibPath, LibName);
 
     std::set<std::string> NewImportedLibraries;
-    auto G = StaticLibraryDefinitionGenerator::Load(
-        ObjLinkingLayer, LibPath.c_str(),
-        COFFImportFileScanner(NewImportedLibraries));
+    auto G = COFFStaticLibraryDefinitionGenerator::Load(
+        ObjLinkingLayer, LibPath.c_str(), NewImportedLibraries);
     if (!G)
       return G.takeError();
 

--- a/llvm/lib/Object/COFFImportFile.cpp
+++ b/llvm/lib/Object/COFFImportFile.cpp
@@ -73,9 +73,13 @@ static StringRef applyNameType(ImportNameType Type, StringRef name) {
   return name;
 }
 
+StringRef COFFImportFile::getSymbolName() const {
+  return Data.getBuffer().substr(sizeof(coff_import_header)).split('\0').first;
+}
+
 StringRef COFFImportFile::getExportName() const {
   const coff_import_header *hdr = getCOFFImportHeader();
-  StringRef name = Data.getBuffer().substr(sizeof(*hdr)).split('\0').first;
+  StringRef name = getSymbolName();
 
   switch (hdr->getNameType()) {
   case IMPORT_ORDINAL:

--- a/llvm/unittests/ExecutionEngine/Orc/CMakeLists.txt
+++ b/llvm/unittests/ExecutionEngine/Orc/CMakeLists.txt
@@ -19,6 +19,7 @@ set(LLVM_LINK_COMPONENTS
 
 add_llvm_unittest(OrcJITTests
   COFFAutoImportGeneratorTest.cpp
+  COFFStaticLibraryDefinitionGeneratorTest.cpp
   CoreAPIsTest.cpp
   ExecutorAddressTest.cpp
   ExecutionSessionWrapperFunctionCallsTest.cpp

--- a/llvm/unittests/ExecutionEngine/Orc/COFFStaticLibraryDefinitionGeneratorTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/COFFStaticLibraryDefinitionGeneratorTest.cpp
@@ -1,0 +1,467 @@
+//===- COFFStaticLibraryDefinitionGeneratorTest.cpp ----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h"
+#include "llvm/ExecutionEngine/Orc/AbsoluteSymbols.h"
+#include "llvm/ExecutionEngine/Orc/COFF.h"
+#include "llvm/ExecutionEngine/Orc/Core.h"
+#include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
+#include "llvm/ExecutionEngine/Orc/SelfExecutorProcessControl.h"
+#include "llvm/Object/ArchiveWriter.h"
+#include "llvm/Object/COFFImportFile.h"
+#include "llvm/ObjectYAML/yaml2obj.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Testing/Support/Error.h"
+#include "llvm/Testing/Support/SupportHelpers.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+using namespace llvm::orc;
+
+namespace {
+
+#if defined(__x86_64__) || defined(_M_X64)
+
+static int ImportedData = 42;
+static const int ImportedConstData = 43;
+static int ControllerData = 45;
+static int importedFunction() { return 44; }
+static int controllerFunction() { return 46; }
+
+class SuspendingDefinitionGenerator : public DefinitionGenerator {
+public:
+  Error tryToGenerate(LookupState &LS, LookupKind K, JITDylib &JD,
+                      JITDylibLookupFlags JDLookupFlags,
+                      const SymbolLookupSet &Symbols) override {
+    PendingLookup = std::move(LS);
+    return Error::success();
+  }
+
+  bool hasPendingLookup() const { return PendingLookup.has_value(); }
+
+  void resume() {
+    assert(PendingLookup && "no lookup to resume");
+    auto LS = std::move(*PendingLookup);
+    PendingLookup.reset();
+    LS.continueLookup(Error::success());
+  }
+
+private:
+  std::optional<LookupState> PendingLookup;
+};
+
+class COFFStaticLibraryDefinitionGeneratorTest : public testing::Test {
+public:
+  COFFStaticLibraryDefinitionGeneratorTest()
+      : ES(cantFail(SelfExecutorProcessControl::Create())),
+        SourceJD(ES.createBareJITDylib("source")),
+        TargetJD(ES.createBareJITDylib("target")),
+        ObjLinkingLayer(
+            ES, std::make_unique<jitlink::InProcessMemoryManager>(4096)) {}
+
+  ~COFFStaticLibraryDefinitionGeneratorTest() override {
+    if (auto Err = ES.endSession())
+      ES.reportError(std::move(Err));
+  }
+
+protected:
+  Error addObject(StringRef YAML) {
+    SmallString<0> Storage;
+    std::string YAMLFailure;
+    auto Obj = yaml::yaml2ObjectFile(
+        Storage, YAML, [&](const Twine &Msg) { YAMLFailure = Msg.str(); });
+    if (!Obj)
+      return make_error<StringError>(YAMLFailure, inconvertibleErrorCode());
+    auto ObjBuffer = MemoryBuffer::getMemBufferCopy(
+        Obj->getMemoryBufferRef().getBuffer(), "test.obj");
+    return ObjLinkingLayer.add(TargetJD, std::move(ObjBuffer));
+  }
+
+  Expected<std::unique_ptr<COFFStaticLibraryDefinitionGenerator>>
+  createImportLibrary(ArrayRef<object::COFFShortExport> Exports,
+                      std::set<std::string> &ImportedLibraries) {
+    unittest::TempDir Tmp("coff-import-library", /*Unique=*/true);
+    SmallString<128> Path(Tmp.path().begin(), Tmp.path().end());
+    sys::path::append(Path, "test.lib");
+
+    if (auto Err = object::writeImportLibrary("test.dll", Path, Exports,
+                                              COFF::IMAGE_FILE_MACHINE_AMD64,
+                                              /*MinGW=*/false))
+      return std::move(Err);
+    return COFFStaticLibraryDefinitionGenerator::Load(
+        ObjLinkingLayer, Path.c_str(), ImportedLibraries);
+  }
+
+  Expected<std::unique_ptr<COFFStaticLibraryDefinitionGenerator>>
+  createObjectArchive(std::set<std::string> &ImportedLibraries) {
+    SmallString<0> Storage;
+    std::string YAML;
+    raw_string_ostream OS(YAML);
+    OS << R"(
+--- !COFF
+header:
+  Machine: IMAGE_FILE_MACHINE_AMD64
+  Characteristics: [ ]
+sections:
+  - Name: .text
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_READ ]
+    Alignment: 16
+    SectionData: '4883EC28FF15000000004883C428488B0D000000000301C3'
+    Relocations:
+      - VirtualAddress: 6
+        SymbolName: __imp_controller_function
+        Type: IMAGE_REL_AMD64_REL32
+      - VirtualAddress: 17
+        SymbolName: __imp_controller_data
+        Type: IMAGE_REL_AMD64_REL32
+symbols:
+  - Name: selected_member
+    Value: 0
+    SectionNumber: 1
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_FUNCTION
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+  - Name: __imp_controller_data
+    Value: 0
+    SectionNumber: 0
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+  - Name: __imp_controller_function
+    Value: 0
+    SectionNumber: 0
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_FUNCTION
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+)";
+
+    std::string YAMLFailure;
+    auto Obj = yaml::yaml2ObjectFile(
+        Storage, OS.str(), [&](const Twine &Msg) { YAMLFailure = Msg.str(); });
+    if (!Obj)
+      return make_error<StringError>(YAMLFailure, inconvertibleErrorCode());
+
+    NewArchiveMember Member(Obj->getMemoryBufferRef());
+    Member.MemberName = "controller.obj";
+    SmallVector<NewArchiveMember, 1> Members;
+    Members.push_back(std::move(Member));
+    auto ArchiveBuffer = writeArchiveToBuffer(
+        Members, SymtabWritingMode::NormalSymtab, object::Archive::K_COFF,
+        /*Deterministic=*/true, /*Thin=*/false);
+    if (!ArchiveBuffer)
+      return ArchiveBuffer.takeError();
+    auto Archive = object::Archive::create((*ArchiveBuffer)->getMemBufferRef());
+    if (!Archive)
+      return Archive.takeError();
+    return COFFStaticLibraryDefinitionGenerator::Create(
+        ObjLinkingLayer, std::move(*ArchiveBuffer), std::move(*Archive),
+        ImportedLibraries);
+  }
+
+  ExecutionSession ES;
+  JITDylib &SourceJD;
+  JITDylib &TargetJD;
+  ObjectLinkingLayer ObjLinkingLayer;
+};
+
+TEST_F(COFFStaticLibraryDefinitionGeneratorTest,
+       CodeImportProvidesPointerAndThunk) {
+  auto Function = ES.intern("imported_function");
+  cantFail(SourceJD.define(absoluteSymbols(
+      {{Function,
+        {ExecutorAddr::fromPtr(&importedFunction),
+         JITSymbolFlags::Exported | JITSymbolFlags::Callable}}})));
+  TargetJD.addToLinkOrder(SourceJD);
+
+  object::COFFShortExport Export;
+  Export.Name = "imported_function";
+  std::set<std::string> ImportedLibraries;
+  auto G = createImportLibrary({Export}, ImportedLibraries);
+  ASSERT_THAT_EXPECTED(G, Succeeded());
+  EXPECT_EQ(ImportedLibraries.count("test.dll"), 1U);
+  TargetJD.addGenerator(std::move(*G));
+
+  auto ImpFunction = ES.lookup(&TargetJD, "__imp_imported_function");
+  ASSERT_THAT_EXPECTED(ImpFunction, Succeeded());
+  EXPECT_EQ(*ImpFunction->getAddress().toPtr<void **>(), &importedFunction);
+
+  TargetJD.setLinkOrder({});
+  auto FunctionThunk = ES.lookup(&TargetJD, "imported_function");
+  ASSERT_THAT_EXPECTED(FunctionThunk, Succeeded());
+  EXPECT_EQ(FunctionThunk->getAddress().toPtr<int (*)()>()(), 44);
+}
+
+TEST_F(COFFStaticLibraryDefinitionGeneratorTest,
+       DataImportProvidesOnlyPointer) {
+  auto Data = ES.intern("imported_data");
+  cantFail(SourceJD.define(absoluteSymbols(
+      {{Data,
+        {ExecutorAddr::fromPtr(&ImportedData), JITSymbolFlags::Exported}}})));
+  TargetJD.addToLinkOrder(SourceJD);
+
+  object::COFFShortExport Export;
+  Export.Name = "imported_data";
+  Export.Data = true;
+  std::set<std::string> ImportedLibraries;
+  auto G = createImportLibrary({Export}, ImportedLibraries);
+  ASSERT_THAT_EXPECTED(G, Succeeded());
+  TargetJD.addGenerator(std::move(*G));
+
+  auto ImpData = ES.lookup(&TargetJD, "__imp_imported_data");
+  ASSERT_THAT_EXPECTED(ImpData, Succeeded());
+  EXPECT_EQ(*ImpData->getAddress().toPtr<void **>(), &ImportedData);
+
+  TargetJD.setLinkOrder({});
+  EXPECT_THAT_EXPECTED(ES.lookup(&TargetJD, "imported_data"), Failed());
+}
+
+TEST_F(COFFStaticLibraryDefinitionGeneratorTest,
+       ConstImportNamesShareImportAddress) {
+  auto ConstData = ES.intern("imported_const_data");
+  cantFail(SourceJD.define(
+      absoluteSymbols({{ConstData,
+                        {ExecutorAddr::fromPtr(&ImportedConstData),
+                         JITSymbolFlags::Exported}}})));
+  TargetJD.addToLinkOrder(SourceJD);
+
+  object::COFFShortExport Export;
+  Export.Name = "imported_const_data";
+  Export.Constant = true;
+  std::set<std::string> ImportedLibraries;
+  auto G = createImportLibrary({Export}, ImportedLibraries);
+  ASSERT_THAT_EXPECTED(G, Succeeded());
+  TargetJD.addGenerator(std::move(*G));
+
+  auto ImpConstData = ES.lookup(&TargetJD, "__imp_imported_const_data");
+  ASSERT_THAT_EXPECTED(ImpConstData, Succeeded());
+  EXPECT_EQ(*ImpConstData->getAddress().toPtr<const void **>(),
+            &ImportedConstData);
+
+  TargetJD.setLinkOrder({});
+  auto ConstDataImport = ES.lookup(&TargetJD, "imported_const_data");
+  ASSERT_THAT_EXPECTED(ConstDataImport, Succeeded());
+  EXPECT_EQ(ConstDataImport->getAddress(), ImpConstData->getAddress());
+}
+
+TEST_F(COFFStaticLibraryDefinitionGeneratorTest, ExportAsResolvesDLLName) {
+  auto ExportedFunction = ES.intern("exported_function");
+  cantFail(SourceJD.define(absoluteSymbols(
+      {{ExportedFunction,
+        {ExecutorAddr::fromPtr(&importedFunction),
+         JITSymbolFlags::Exported | JITSymbolFlags::Callable}}})));
+  TargetJD.addToLinkOrder(SourceJD);
+
+  object::COFFShortExport Export;
+  Export.Name = "local_function";
+  Export.ExportAs = "exported_function";
+  std::set<std::string> ImportedLibraries;
+  auto G = createImportLibrary({Export}, ImportedLibraries);
+  ASSERT_THAT_EXPECTED(G, Succeeded());
+  TargetJD.addGenerator(std::move(*G));
+
+  auto ImpFunction = ES.lookup(&TargetJD, "__imp_local_function");
+  ASSERT_THAT_EXPECTED(ImpFunction, Succeeded());
+  EXPECT_EQ(*ImpFunction->getAddress().toPtr<void **>(), &importedFunction);
+
+  TargetJD.setLinkOrder({});
+  auto FunctionThunk = ES.lookup(&TargetJD, "local_function");
+  ASSERT_THAT_EXPECTED(FunctionThunk, Succeeded());
+  EXPECT_EQ(FunctionThunk->getAddress().toPtr<int (*)()>()(), 44);
+}
+
+TEST_F(COFFStaticLibraryDefinitionGeneratorTest,
+       OrdinalImportReportsUnsupported) {
+  object::COFFShortExport Export;
+  Export.Name = "ordinal_function";
+  Export.Ordinal = 1;
+  Export.Noname = true;
+  std::set<std::string> ImportedLibraries;
+  auto G = createImportLibrary({Export}, ImportedLibraries);
+  ASSERT_THAT_EXPECTED(G, Succeeded());
+  TargetJD.addGenerator(std::move(*G));
+
+  EXPECT_THAT_EXPECTED(
+      ES.lookup(&TargetJD, "__imp_ordinal_function"),
+      FailedWithMessage(
+          "ordinal COFF imports are not supported for ordinal_function"));
+}
+
+TEST_F(COFFStaticLibraryDefinitionGeneratorTest,
+       SuspendsWhileResolvingImportTarget) {
+  auto ExportedFunction = ES.intern("async_exported_function");
+  auto ImpFunction = ES.intern("__imp_async_local_function");
+  auto &SourceGenerator =
+      SourceJD.addGenerator(std::make_unique<SuspendingDefinitionGenerator>());
+  TargetJD.addToLinkOrder(SourceJD);
+
+  object::COFFShortExport Export;
+  Export.Name = "async_local_function";
+  Export.ExportAs = "async_exported_function";
+  std::set<std::string> ImportedLibraries;
+  auto G = createImportLibrary({Export}, ImportedLibraries);
+  ASSERT_THAT_EXPECTED(G, Succeeded());
+  TargetJD.addGenerator(std::move(*G));
+
+  std::optional<Expected<SymbolMap>> LookupResult;
+  ES.lookup(
+      LookupKind::Static,
+      {{&TargetJD, JITDylibLookupFlags::MatchExportedSymbolsOnly}},
+      SymbolLookupSet(ImpFunction), SymbolState::Ready,
+      [&](Expected<SymbolMap> Result) {
+        LookupResult.emplace(std::move(Result));
+      },
+      NoDependenciesToRegister);
+
+  EXPECT_FALSE(LookupResult.has_value());
+  ASSERT_TRUE(SourceGenerator.hasPendingLookup());
+
+  cantFail(SourceJD.define(absoluteSymbols(
+      {{ExportedFunction,
+        {ExecutorAddr::fromPtr(&importedFunction),
+         JITSymbolFlags::Exported | JITSymbolFlags::Callable}}})));
+  SourceGenerator.resume();
+
+  ASSERT_TRUE(LookupResult.has_value());
+  ASSERT_THAT_EXPECTED(*LookupResult, Succeeded());
+  auto I = (*LookupResult)->find(ImpFunction);
+  ASSERT_NE(I, (*LookupResult)->end());
+  EXPECT_EQ(*I->second.getAddress().toPtr<void **>(), &importedFunction);
+}
+
+TEST_F(COFFStaticLibraryDefinitionGeneratorTest,
+       ObjectFunctionImportExportAsPreservesIATAddress) {
+  auto ExportedFunction = ES.intern("exported_function");
+  cantFail(SourceJD.define(absoluteSymbols(
+      {{ExportedFunction,
+        {ExecutorAddr::fromPtr(&importedFunction),
+         JITSymbolFlags::Exported | JITSymbolFlags::Callable}}})));
+  TargetJD.addToLinkOrder(SourceJD);
+
+  object::COFFShortExport Export;
+  Export.Name = "local_function";
+  Export.ExportAs = "exported_function";
+  std::set<std::string> ImportedLibraries;
+  auto G = createImportLibrary({Export}, ImportedLibraries);
+  ASSERT_THAT_EXPECTED(G, Succeeded());
+  TargetJD.addGenerator(std::move(*G));
+
+  ASSERT_THAT_ERROR(addObject(R"(
+--- !COFF
+header:
+  Machine: IMAGE_FILE_MACHINE_AMD64
+sections:
+  - Name: .text
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_READ ]
+    Alignment: 16
+    SectionData: '488B0500000000C3'
+    Relocations:
+      - VirtualAddress: 3
+        SymbolName: __imp_local_function
+        Type: IMAGE_REL_AMD64_REL32
+symbols:
+  - Name: import_address
+    Value: 0
+    SectionNumber: 1
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_FUNCTION
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+  - Name: __imp_local_function
+    Value: 0
+    SectionNumber: 0
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+)"),
+                    Succeeded());
+
+  auto ImportAddress = ES.lookup(&TargetJD, "import_address");
+  ASSERT_THAT_EXPECTED(ImportAddress, Succeeded());
+  EXPECT_EQ(ImportAddress->getAddress().toPtr<void *(*)()>()(),
+            reinterpret_cast<void *>(&importedFunction));
+}
+
+TEST_F(COFFStaticLibraryDefinitionGeneratorTest,
+       ObjectDataImportExportAsResolvesDLLName) {
+  auto ExportedData = ES.intern("exported_data");
+  cantFail(SourceJD.define(absoluteSymbols(
+      {{ExportedData,
+        {ExecutorAddr::fromPtr(&ImportedData), JITSymbolFlags::Exported}}})));
+  TargetJD.addToLinkOrder(SourceJD);
+
+  object::COFFShortExport Export;
+  Export.Name = "local_data";
+  Export.ExportAs = "exported_data";
+  Export.Data = true;
+  std::set<std::string> ImportedLibraries;
+  auto G = createImportLibrary({Export}, ImportedLibraries);
+  ASSERT_THAT_EXPECTED(G, Succeeded());
+  TargetJD.addGenerator(std::move(*G));
+
+  ASSERT_THAT_ERROR(addObject(R"(
+--- !COFF
+header:
+  Machine: IMAGE_FILE_MACHINE_AMD64
+sections:
+  - Name: .text
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_READ ]
+    Alignment: 16
+    SectionData: '488B05000000008B00C3'
+    Relocations:
+      - VirtualAddress: 3
+        SymbolName: __imp_local_data
+        Type: IMAGE_REL_AMD64_REL32
+symbols:
+  - Name: read_imported_data
+    Value: 0
+    SectionNumber: 1
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_FUNCTION
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+  - Name: __imp_local_data
+    Value: 0
+    SectionNumber: 0
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_NULL
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+)"),
+                    Succeeded());
+
+  auto ReadImportedData = ES.lookup(&TargetJD, "read_imported_data");
+  ASSERT_THAT_EXPECTED(ReadImportedData, Succeeded());
+  EXPECT_EQ(ReadImportedData->getAddress().toPtr<int (*)()>()(), ImportedData);
+}
+
+TEST_F(COFFStaticLibraryDefinitionGeneratorTest,
+       OrdinaryObjectUsesJITLinkIATEntries) {
+  auto Data = ES.intern("controller_data");
+  auto Function = ES.intern("controller_function");
+  cantFail(SourceJD.define(absoluteSymbols(
+      {{Data,
+        {ExecutorAddr::fromPtr(&ControllerData), JITSymbolFlags::Exported}},
+       {Function,
+        {ExecutorAddr::fromPtr(&controllerFunction),
+         JITSymbolFlags::Exported | JITSymbolFlags::Callable}}})));
+  TargetJD.addToLinkOrder(SourceJD);
+
+  std::set<std::string> ImportedLibraries;
+  auto G = createObjectArchive(ImportedLibraries);
+  ASSERT_THAT_EXPECTED(G, Succeeded());
+  EXPECT_TRUE(ImportedLibraries.empty());
+  TargetJD.addGenerator(std::move(*G));
+
+  auto SelectedMember = ES.lookup(&TargetJD, "selected_member");
+  ASSERT_THAT_EXPECTED(SelectedMember, Succeeded());
+  EXPECT_EQ(SelectedMember->getAddress().toPtr<int (*)()>()(), 91);
+
+  TargetJD.setLinkOrder({});
+  EXPECT_THAT_EXPECTED(ES.lookup(&TargetJD, "controller_function"), Failed());
+}
+
+#endif // x86_64
+
+} // namespace

--- a/llvm/unittests/Object/CMakeLists.txt
+++ b/llvm/unittests/Object/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LLVM_LINK_COMPONENTS
 add_llvm_unittest(ObjectTests
   ArchiveTest.cpp
   BuildIDTest.cpp
+  COFFImportFileTest.cpp
   COFFObjectFileTest.cpp
   DXContainerTest.cpp
   ELFObjectFileTest.cpp

--- a/llvm/unittests/Object/COFFImportFileTest.cpp
+++ b/llvm/unittests/Object/COFFImportFileTest.cpp
@@ -1,0 +1,62 @@
+//===- COFFImportFileTest.cpp - COFF short import tests -------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Object/COFFImportFile.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+using namespace llvm::object;
+
+namespace {
+
+static std::string makeShortImport(StringRef SymbolName,
+                                   COFF::ImportNameType NameType,
+                                   StringRef ExportName = {}) {
+  coff_import_header Header{};
+  Header.Sig2 = 0xffff;
+  Header.Machine = COFF::IMAGE_FILE_MACHINE_AMD64;
+  Header.TypeInfo = (NameType << 2) | COFF::IMPORT_DATA;
+
+  std::string Buffer(reinterpret_cast<const char *>(&Header), sizeof(Header));
+  Buffer.append(SymbolName);
+  Buffer.push_back('\0');
+  Buffer.append("test.dll");
+  Buffer.push_back('\0');
+  if (!ExportName.empty()) {
+    Buffer.append(ExportName);
+    Buffer.push_back('\0');
+  }
+  return Buffer;
+}
+
+TEST(COFFImportFileTest, DistinguishesSymbolNameFromExportName) {
+  struct TestCase {
+    COFF::ImportNameType NameType;
+    StringRef SymbolName;
+    StringRef ExportAs;
+    StringRef ExpectedExportName;
+  };
+
+  const TestCase Cases[] = {
+      {COFF::IMPORT_NAME, "_name@8", {}, "_name@8"},
+      {COFF::IMPORT_NAME_NOPREFIX, "_name@8", {}, "name@8"},
+      {COFF::IMPORT_NAME_UNDECORATE, "_name@8", {}, "name"},
+      {COFF::IMPORT_NAME_EXPORTAS, "_name@8", "exported", "exported"},
+      {COFF::IMPORT_ORDINAL, "_name@8", {}, {}},
+  };
+
+  for (const auto &C : Cases) {
+    SCOPED_TRACE(C.NameType);
+    std::string Buffer = makeShortImport(C.SymbolName, C.NameType, C.ExportAs);
+    COFFImportFile File(MemoryBufferRef(Buffer, "test"));
+    EXPECT_EQ(File.getSymbolName(), C.SymbolName);
+    EXPECT_EQ(File.getExportName(), C.ExpectedExportName);
+  }
+}
+
+} // namespace

--- a/llvm/utils/gn/secondary/llvm/unittests/ExecutionEngine/Orc/BUILD.gn
+++ b/llvm/utils/gn/secondary/llvm/unittests/ExecutionEngine/Orc/BUILD.gn
@@ -9,6 +9,7 @@ unittest("OrcJITTests") {
     "//llvm/lib/ExecutionEngine/RuntimeDyld",
     "//llvm/lib/IR",
     "//llvm/lib/Object",
+    "//llvm/lib/ObjectYAML",
     "//llvm/lib/Support",
     "//llvm/lib/Target:NativeTarget",
     "//llvm/lib/TargetParser",
@@ -16,6 +17,7 @@ unittest("OrcJITTests") {
   ]
   sources = [
     "COFFAutoImportGeneratorTest.cpp",
+    "COFFStaticLibraryDefinitionGeneratorTest.cpp",
     "CoreAPIsTest.cpp",
     "EPCGenericDylibManagerTest.cpp",
     "EPCGenericJITLinkMemoryManagerTest.cpp",

--- a/llvm/utils/gn/secondary/llvm/unittests/Object/BUILD.gn
+++ b/llvm/utils/gn/secondary/llvm/unittests/Object/BUILD.gn
@@ -11,6 +11,7 @@ unittest("ObjectTests") {
   sources = [
     "ArchiveTest.cpp",
     "BuildIDTest.cpp",
+    "COFFImportFileTest.cpp",
     "COFFObjectFileTest.cpp",
     "DXContainerTest.cpp",
     "ELFObjectFileTest.cpp",


### PR DESCRIPTION
## Summary

COFF short import members classify imports as code, data, or const, but `COFFImportFileScanner` previously discarded this information.

As a result, `DLLImportDefinitionGenerator` treated every imported symbol as callable and created a pointer-jump stub for it. For a data import, the ordinary symbol name could therefore resolve to executable thunk code rather than to the data address.

This is the data-symbol case described by the existing FIXME in `createStubsGraph`:

```cpp
// FIXME: check PLT stub of data symbol is not accessed
```

I encountered this with __orc_rt_jit_dispatch_ctx while experimenting with COFFPlatform in an in-process Windows clang-repl. The same distinction is also required for MSVC runtime and standard-library data imports.

## Implementation

This patch:

- Adds COFFImportFile::getSymbolName() to expose the original link-time symbol name separately from the transformed DLL export name.
- Records COFF::ImportType while scanning COFF short import members.
- Propagates the collected type information through COFFVCRuntimeBootstrapper and COFFPlatform.
- Classifies the ORC dispatch function as code and the dispatch context as data.
- Creates callable pointer-jump stubs only for code imports.
- Represents data and const imports with an __imp_ pointer slot and a non-callable absolute symbol.
- Preserves the existing two-argument DLLImportDefinitionGenerator::Create API and defaults symbols without type metadata to code.

The ordinary data symbol remains externally visible in the generated graph. This allows a later direct lookup to resolve to the data address without re-entering the generator and attempting to define the same __imp_ symbol again.

## Testing

Tested in an x86_64 Windows RelWithDebInfo build:

- OrcJITTests: 327 passed, 2 skipped.
- ObjectTests: 148 passed, 1 skipped because zlib was unavailable.
- Focused tests cover code, data, const, and missing-type fallback behavior.
- The data test also covers a later direct lookup of the ordinary symbol name.
- The COFF import-file test covers decorated, undecorated, no-prefix, export-as, and ordinal naming modes.

Related: #213568

Assisted-by: OpenAI Codex