### PR TITLE
[Flang][MLIR] Move setOpenMPIntegerWrapAround function into the OpenMP dialect

### DIFF
--- a/flang/include/flang/Tools/CrossToolHelpers.h
+++ b/flang/include/flang/Tools/CrossToolHelpers.h
@@ -206,10 +206,4 @@ struct MLIRToLLVMPassPipelineConfig : public FlangEPCallBacks {
       Opts.NoGPULib);
 }
 
-[[maybe_unused]] static void setOpenMPIntegerWrapAround(
-    mlir::ModuleOp module, bool value) {
-  module.getOperation()->setAttr("omp.integer_wrap_around",
-      mlir::omp::IntegerWrapAroundAttr::get(module.getContext(), value));
-}
-
 #endif // FORTRAN_TOOLS_CROSS_TOOL_HELPERS_H

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -278,7 +278,7 @@ bool CodeGenAction::beginSourceFileAction() {
     mlir::omp::setOpenMPVersionAttribute(
         lb.getModule(), ci.getInvocation().getLangOpts().OpenMPVersion);
     if (!ci.getInvocation().getLoweringOpts().getIntegerWrapAround())
-      setOpenMPIntegerWrapAround(lb.getModule(), false);
+      mlir::omp::setOpenMPIntegerWrapAround(lb.getModule(), false);
   }
 
   if (ci.getInvocation().getLangOpts().FastRealMod) {

--- a/flang/lib/FrontendTool/CMakeLists.txt
+++ b/flang/lib/FrontendTool/CMakeLists.txt
@@ -17,6 +17,7 @@ add_flang_library(flangFrontendTool
 
   MLIR_LIBS
   MLIRPass
+  MLIROpenMPDialect
 
   CLANG_LIBS
   clangBasic

--- a/flang/lib/FrontendTool/CMakeLists.txt
+++ b/flang/lib/FrontendTool/CMakeLists.txt
@@ -17,7 +17,6 @@ add_flang_library(flangFrontendTool
 
   MLIR_LIBS
   MLIRPass
-  MLIROpenMPDialect
 
   CLANG_LIBS
   clangBasic

--- a/flang/tools/bbc/bbc.cpp
+++ b/flang/tools/bbc/bbc.cpp
@@ -546,7 +546,7 @@ static llvm::LogicalResult convertFortranSourceToMLIR(
                                                    offloadModuleOpts);
     mlir::omp::setOpenMPVersionAttribute(mlirModule, setOpenMPVersion);
     if (!integerWrapAround)
-      setOpenMPIntegerWrapAround(mlirModule, false);
+      mlir::omp::setOpenMPIntegerWrapAround(mlirModule, false);
   }
   burnside.lower(parseTree, semanticsContext);
   std::error_code ec;

--- a/mlir/include/mlir/Dialect/OpenMP/Utils/Utils.h
+++ b/mlir/include/mlir/Dialect/OpenMP/Utils/Utils.h
@@ -67,6 +67,9 @@ void setOffloadModuleInterfaceAttributes(ModuleOp module,
 /// Adds or updates the omp.version attribute.
 void setOpenMPVersionAttribute(ModuleOp module, int64_t version);
 
+/// Add the omp.integer_wrap_around attribute.
+void setOpenMPIntegerWrapAround(ModuleOp module, bool value);
+
 /// Returns the value of the omp.version attribute, if present, or the fallback.
 int64_t getOpenMPVersionAttribute(ModuleOp module, int64_t fallback = -1);
 

--- a/mlir/lib/Dialect/OpenMP/Utils/Utils.cpp
+++ b/mlir/lib/Dialect/OpenMP/Utils/Utils.cpp
@@ -47,6 +47,12 @@ void mlir::omp::setOpenMPVersionAttribute(ModuleOp module, int64_t version) {
       VersionAttr::get(module.getContext(), version));
 }
 
+void mlir::omp::setOpenMPIntegerWrapAround(ModuleOp module, bool value) {
+  module->setAttr(StringAttr::get(module.getContext(),
+                                  llvm::Twine{"omp.integer_wrap_around"}),
+                  IntegerWrapAroundAttr::get(module.getContext(), value));
+}
+
 int64_t mlir::omp::getOpenMPVersionAttribute(ModuleOp module,
                                              int64_t fallback) {
   if (Attribute verAttr = module->getAttr("omp.version"))


### PR DESCRIPTION
Fixed the linker error: `undefined reference to'mlir::omp::IntegerWrapAroundAttr::get(mlir::MLIRContext*, bool)'` mentioned in mentioned in [PR#214165](https://github.com/llvm/llvm-project/pull/214165#issuecomment-5323821248) by moving  the `setOpenMPIntegerWrapAround(...)` helper function out of `flang/Tools/CrossToolHelpers.h` and placed it into the OpenMP dialect utilities.

