### PR TITLE
[ADT] Clean up and fix FoldingSetBase move operations

### DIFF
--- a/llvm/include/llvm/ADT/FoldingSet.h
+++ b/llvm/include/llvm/ADT/FoldingSet.h
@@ -299,14 +299,14 @@ public:
 class FoldingSetBase : public DebugEpochBase {
 protected:
   /// Array of bucket chains.
-  void **Buckets;
+  void **Buckets = nullptr;
 
   /// Length of the Buckets array.  Always a power of 2.
-  unsigned NumBuckets;
+  unsigned NumBuckets = 0;
 
   /// Number of nodes in the folding set. Growth occurs when NumNodes
   /// is greater than twice the number of buckets.
-  unsigned NumNodes;
+  unsigned NumNodes = 0;
 
   LLVM_ABI explicit FoldingSetBase(unsigned Log2InitSize);
   LLVM_ABI FoldingSetBase(FoldingSetBase &&Arg);

--- a/llvm/lib/Support/FoldingSet.cpp
+++ b/llvm/lib/Support/FoldingSet.cpp
@@ -184,23 +184,22 @@ FoldingSetBase::FoldingSetBase(unsigned Log2InitSize) {
 }
 
 FoldingSetBase::FoldingSetBase(FoldingSetBase &&Arg)
-    : Buckets(Arg.Buckets), NumBuckets(Arg.NumBuckets), NumNodes(Arg.NumNodes) {
+    : Buckets(std::exchange(Arg.Buckets, nullptr)),
+      NumBuckets(std::exchange(Arg.NumBuckets, 0)),
+      NumNodes(std::exchange(Arg.NumNodes, 0)) {
   Arg.incrementEpoch();
-  Arg.Buckets = nullptr;
-  Arg.NumBuckets = 0;
-  Arg.NumNodes = 0;
 }
 
 FoldingSetBase &FoldingSetBase::operator=(FoldingSetBase &&RHS) {
+  if (this == &RHS)
+    return *this;
+
   incrementEpoch();
   RHS.incrementEpoch();
   free(Buckets); // This may be null if the set is in a moved-from state.
-  Buckets = RHS.Buckets;
-  NumBuckets = RHS.NumBuckets;
-  NumNodes = RHS.NumNodes;
-  RHS.Buckets = nullptr;
-  RHS.NumBuckets = 0;
-  RHS.NumNodes = 0;
+  Buckets = std::exchange(RHS.Buckets, nullptr);
+  NumBuckets = std::exchange(RHS.NumBuckets, 0);
+  NumNodes = std::exchange(RHS.NumNodes, 0);
   return *this;
 }
 

--- a/llvm/unittests/ADT/FoldingSet.cpp
+++ b/llvm/unittests/ADT/FoldingSet.cpp
@@ -358,6 +358,23 @@ TEST(FoldingSetTest, ContextualFoldingSetBasic) {
   EXPECT_THAT(Set, SizeIs(0));
 }
 
+TEST(FoldingSetTest, SelfMoveAssignment) {
+  FoldingSet<TrivialPair> Set;
+  TrivialPair T1(10, 100);
+  Set.InsertNode(&T1);
+
+  // Route through a helper lambda to test self-move aliasing without triggering
+  // -Wself-move.
+  auto MoveAssign = [](FoldingSet<TrivialPair> &Dest,
+                       FoldingSet<TrivialPair> &&Src) {
+    Dest = std::move(Src);
+  };
+  MoveAssign(Set, std::move(Set));
+
+  EXPECT_EQ(1u, Set.size());
+  EXPECT_FALSE(Set.empty());
+}
+
 #if LLVM_ENABLE_ABI_BREAKING_CHECKS
 TEST(FoldingSetTest, InsertInvalidatesIterators) {
   FoldingSet<TrivialPair> Set;


### PR DESCRIPTION
[ADT] Clean up and fix FoldingSetBase move operations

This patch cleans up move operations in FoldingSetBase and fixes a bug
in self-move assignment.

First, we add default member initializers to FoldingSetBase and use
std::exchange in move operations to streamline transferring member
variables while resetting the moved-from object to an empty state in a
self-contained manner.

Second, we add a self-assignment check to the move assignment operator.
Without this check, self-move assignment executes free(Buckets) before
any transfer occurs, unconditionally destroying the set. The check makes
self-move a safe no-op.

Assisted-by: Antigravity
