### PR TITLE
[lldb][test] Unlock the mutex completely before exiting the test

### DIFF
--- a/lldb/unittests/Target/TargetAPIMutexTest.cpp
+++ b/lldb/unittests/Target/TargetAPIMutexTest.cpp
@@ -121,6 +121,16 @@ TEST_F(TargetAPIMutexTargetTest, BareHandleDoesNotAutoUnlockOnDestruction) {
     EXPECT_FALSE(background_lock.try_lock());
   });
   t.join();
+
+  // Unlock the original locked mutex.
+  // Calling try_lock() resolves the underlying mutex and re-enters it on this
+  // thread (incrementing the recursive count), so we unlock twice to fully
+  // release both acquisitions.
+  TargetAPIMutex cleanup_lock(target_sp);
+  if (cleanup_lock.try_lock()) {
+    cleanup_lock.unlock();
+    cleanup_lock.unlock();
+  }
 }
 
 TEST_F(TargetAPIMutexTargetTest, LockGuardReleasesOnScopeExit) {

--- a/lldb/unittests/Target/TargetAPIMutexTest.cpp
+++ b/lldb/unittests/Target/TargetAPIMutexTest.cpp
@@ -127,10 +127,9 @@ TEST_F(TargetAPIMutexTargetTest, BareHandleDoesNotAutoUnlockOnDestruction) {
   // thread (incrementing the recursive count), so we unlock twice to fully
   // release both acquisitions.
   TargetAPIMutex cleanup_lock(target_sp);
-  if (cleanup_lock.try_lock()) {
-    cleanup_lock.unlock();
-    cleanup_lock.unlock();
-  }
+  ASSERT_TRUE(cleanup_lock.try_lock());
+  cleanup_lock.unlock();
+  cleanup_lock.unlock();
 }
 
 TEST_F(TargetAPIMutexTargetTest, LockGuardReleasesOnScopeExit) {


### PR DESCRIPTION
This test fails with hardened libcxx otherwise.

Fixes #212872