### PR TITLE
[MLIR][EmitC] Rewrite globals before moving function body

### DIFF
--- a/mlir/lib/Dialect/EmitC/Transforms/WrapFuncInClass.cpp
+++ b/mlir/lib/Dialect/EmitC/Transforms/WrapFuncInClass.cpp
@@ -114,6 +114,15 @@ public:
     Location loc = funcOp.getLoc();
     FuncOp newFuncOp = FuncOp::create(rewriter, loc, (funcName), funcType);
 
+    // Rewrite globals while they are still descendants of the matched op.
+    funcOp.walk([&](GetGlobalOp getGlobalOp) {
+      rewriter.setInsertionPoint(getGlobalOp);
+      GetFieldOp getFieldOp =
+          GetFieldOp::create(rewriter, getGlobalOp.getLoc(),
+                             getGlobalOp.getType(), getGlobalOp.getNameAttr());
+      rewriter.replaceOp(getGlobalOp, getFieldOp);
+    });
+
     rewriter.createBlock(&newFuncOp.getBody());
     newFuncOp.getBody().takeBody(funcOp.getBody());
 
@@ -134,14 +143,6 @@ public:
     llvm::BitVector argsToErase(newFuncOp.getNumArguments(), true);
     if (failed(newFuncOp.eraseArguments(argsToErase)))
       newFuncOp->emitOpError("failed to erase all arguments using BitVector");
-
-    newFuncOp.walk([&](GetGlobalOp getGlobalOp) {
-      rewriter.setInsertionPoint(getGlobalOp);
-      GetFieldOp getFieldOp =
-          GetFieldOp::create(rewriter, getGlobalOp.getLoc(),
-                             getGlobalOp.getType(), getGlobalOp.getNameAttr());
-      rewriter.replaceOp(getGlobalOp, getFieldOp);
-    });
 
     rewriter.replaceOp(funcOp, newClassOp);
     return success();

--- a/mlir/test/Dialect/EmitC/wrap-func-in-class.mlir
+++ b/mlir/test/Dialect/EmitC/wrap-func-in-class.mlir
@@ -2,8 +2,6 @@
 // RUN: mlir-opt %s -wrap-emitc-func-in-class=func-name=execute -split-input-file | FileCheck %s --check-prefixes=EXECUTE
 // RUN: mlir-opt %s -wrap-emitc-func-in-class=class-name-format=Custom_{} -split-input-file | FileCheck %s --check-prefixes=CLASS-NAME-FORMAT
 
-// XFAIL: mlir-expensive-checks
-
 emitc.func @foo(%arg0 : !emitc.array<1xf32>) {
   emitc.call_opaque "bar" (%arg0) : (!emitc.array<1xf32>) -> ()
   emitc.return


### PR DESCRIPTION
WalkPatternRewriter only permits erasing matched operations or their descendants. Replace get_global operations while they still belong to the matched function before transferring its body into the new class method.

Assisted-by: Codex