### PR TITLE
[MLIR][X86] Track accumulator rewrites

### DIFF
--- a/mlir/lib/Dialect/X86/Transforms/MoveAccumulatorForContractLoop.cpp
+++ b/mlir/lib/Dialect/X86/Transforms/MoveAccumulatorForContractLoop.cpp
@@ -86,7 +86,7 @@ struct MoveAccumulatorForContractLoop
         rewriter, loc,
         DenseElementsAttr::get(vecTy, rewriter.getZeroAttr(elemTy)));
 
-    accValue.replaceAllUsesWith(zeroVec);
+    rewriter.replaceAllUsesWith(accValue, zeroVec);
 
     // Adds the initial acc value with contract results before storing to acc
     // matrix.
@@ -105,7 +105,9 @@ struct MoveAccumulatorForContractLoop
       llvm_unreachable("expected floating-point or integer element type");
     }
 
-    resultUserOp->replaceUsesOfWith(contractValue, addition);
+    rewriter.modifyOpInPlace(resultUserOp, [&]() {
+      resultUserOp->replaceUsesOfWith(contractValue, addition);
+    });
     return success();
   }
 };

--- a/mlir/test/Dialect/X86/move-acc-for-contract-loop.mlir
+++ b/mlir/test/Dialect/X86/move-acc-for-contract-loop.mlir
@@ -1,7 +1,5 @@
 // RUN: mlir-opt %s -transform-interpreter -cse -split-input-file | FileCheck %s
 
-// XFAIL: mlir-expensive-checks
-
 !vecA = vector<1x1x2xbf16>
 !vecB = vector<1x2x16xbf16>
 !vecC = vector<1x16xf32>
@@ -322,4 +320,3 @@ module attributes {transform.with_named_sequence} {
     transform.yield
   }
 }
-


### PR DESCRIPTION
Route accumulator and result-user operand updates through PatternRewriter. This lets greedy rewrite listeners observe every in-place mutation.

Assisted-by: Codex