### PR TITLE
[DWARF] Fix DW_OP_LLVM_user sub-operation name lookup.

### DIFF
--- a/llvm/lib/BinaryFormat/Dwarf.cpp
+++ b/llvm/lib/BinaryFormat/Dwarf.cpp
@@ -192,7 +192,8 @@ static StringRef LlvmUserOperationEncodingString(unsigned Encoding) {
 static unsigned
 getLlvmUserOperationEncoding(StringRef LlvmUserOperationEncodingString) {
   unsigned E = StringSwitch<unsigned>(LlvmUserOperationEncodingString)
-#define HANDLE_DW_OP_LLVM_USEROP(ID, NAME) .Case(#NAME, DW_OP_LLVM_##NAME)
+#define HANDLE_DW_OP_LLVM_USEROP(ID, NAME)                                     \
+  .Case("DW_OP_LLVM_" #NAME, DW_OP_LLVM_##NAME)
 #include "llvm/BinaryFormat/Dwarf.def"
                    .Default(0);
   assert(E && "unhandled DWARF operation string with LLVM user op");

--- a/llvm/unittests/BinaryFormat/DwarfTest.cpp
+++ b/llvm/unittests/BinaryFormat/DwarfTest.cpp
@@ -58,6 +58,7 @@ TEST(DwarfTest, getOperationEncoding) {
 }
 
 TEST(DwarfTest, SubOperationEncoding) {
+  // Test that the enum-to-string user encodings roundtrip.
   EXPECT_EQ("DW_OP_LLVM_nop",
             SubOperationEncodingString(DW_OP_LLVM_user, DW_OP_LLVM_nop));
   EXPECT_EQ(DW_OP_LLVM_nop,

--- a/llvm/unittests/BinaryFormat/DwarfTest.cpp
+++ b/llvm/unittests/BinaryFormat/DwarfTest.cpp
@@ -57,6 +57,13 @@ TEST(DwarfTest, getOperationEncoding) {
   EXPECT_EQ(0u, getOperationEncoding("DW_OP_hi_user"));
 }
 
+TEST(DwarfTest, SubOperationEncoding) {
+  EXPECT_EQ("DW_OP_LLVM_nop",
+            SubOperationEncodingString(DW_OP_LLVM_user, DW_OP_LLVM_nop));
+  EXPECT_EQ(DW_OP_LLVM_nop,
+            getSubOperationEncoding(DW_OP_LLVM_user, "DW_OP_LLVM_nop"));
+}
+
 TEST(DwarfTest, LanguageStringOnInvalid) {
   // This is invalid, so it shouldn't be stringified.
   EXPECT_EQ(StringRef(), LanguageString(0));


### PR DESCRIPTION
LlvmUserOperationEncodingString returns a name with a "DW_OP_LLVM_" prefix, but getLlvmUserOperationEncoding matched the suffix (subop) name. This patch updates the latter to match the full name.

Assisted-by: LLM