### PR TITLE
[libc] Update NSIG value and usage on Linux.

### DIFF
--- a/libc/include/llvm-libc-macros/linux/signal-macros.h
+++ b/libc/include/llvm-libc-macros/linux/signal-macros.h
@@ -45,22 +45,23 @@
 #define SIGPWR 30
 #define SIGSYS 31
 
-// Max signal number
-#define NSIG 64
+// All signal numbers need to be less than this constant.
+#define NSIG 65
+#define _NSIG NSIG
 
 // SIGRTMIN is current set to the minimum usable from user mode programs. If
 // the libc itself uses some of these signal numbers for private operations,
 // then it has to be adjusted in future to reflect that.
 #define SIGRTMIN 32
-
-#define SIGRTMAX NSIG
+// SIGRTMAX is the largest allowed value for the runtime signal.
+#define SIGRTMAX (NSIG - 1)
 
 // The kernel sigset is stored as an array of long values. Each bit of this
 // array corresponds to a signal, adjusted by 1. That is, bit 0 corresponds
 // to signal number 1, bit 1 corresponds to signal number 2 and so on. The
 // below macro denotes the size of that array (in number of long words and
 // not bytes).
-#define __NSIGSET_WORDS (NSIG / (sizeof(unsigned long) * 8))
+#define __NSIGSET_WORDS ((NSIG - 1) / (sizeof(unsigned long) * 8))
 
 #define SIG_BLOCK 0   // For blocking signals
 #define SIG_UNBLOCK 1 // For unblocking signals

--- a/libc/src/signal/linux/signal_utils.h
+++ b/libc/src/signal/linux/signal_utils.h
@@ -79,10 +79,9 @@ LIBC_INLINE constexpr sigset_t full_set() { return sigset_t{{-1UL}}; }
 LIBC_INLINE constexpr sigset_t empty_set() { return sigset_t{{0}}; }
 
 // Set the bit corresponding to |signal| in |set|. Return true on success
-// and false on failure. The function will fail if |signal| is greater than
-// NSIG or negative.
+// and false on failure. |signal| must be less than NSIG and be positive.
 LIBC_INLINE constexpr bool add_signal(sigset_t &set, int signal) {
-  if (signal > NSIG || signal <= 0)
+  if (signal >= NSIG || signal <= 0)
     return false;
   size_t n = size_t(signal) - 1;
   size_t word = n / BITS_PER_SIGWORD;
@@ -92,10 +91,9 @@ LIBC_INLINE constexpr bool add_signal(sigset_t &set, int signal) {
 }
 
 // Reset the bit corresponding to |signal| in |set|. Return true on success
-// and false on failure. The function will fail if |signal| is greater than
-// NSIG or negative.
+// and false on failure. |signal| must be less than NSIG and be positive.
 LIBC_INLINE constexpr bool delete_signal(sigset_t &set, int signal) {
-  if (signal > NSIG || signal <= 0)
+  if (signal >= NSIG || signal <= 0)
     return false;
   size_t n = size_t(signal) - 1;
   size_t word = n / BITS_PER_SIGWORD;

--- a/libc/test/src/signal/sigaddset_test.cpp
+++ b/libc/test/src/signal/sigaddset_test.cpp
@@ -22,8 +22,6 @@ TEST(LlvmLibcSignalTest, SigaddsetInvalid) {
   sigset_t sigset;
   EXPECT_THAT(LIBC_NAMESPACE::sigaddset(&sigset, -1), Fails(EINVAL));
 
-  // This doesn't use NSIG because LIBC_NAMESPACE::sigaddset error checking is
-  // against sizeof(sigset_t) not NSIG.
   constexpr int bitsInSigsetT = 8 * sizeof(sigset_t);
 
   EXPECT_THAT(LIBC_NAMESPACE::sigaddset(&sigset, bitsInSigsetT + 1),

--- a/libc/test/src/ucontext/ucontext_test.cpp
+++ b/libc/test/src/ucontext/ucontext_test.cpp
@@ -21,8 +21,7 @@ namespace LIBC_NAMESPACE {
 
 static bool is_signal_set(const sigset_t *set, int signum) {
   // TODO: Replace this with sigismember once it is implemented.
-  // NSIG is 64, sigset_t is an array of unsigned long.
-  // Signum is 1-indexed.
+  // sigset_t is an array of unsigned long, signum is 1-indexed.
   int word = (signum - 1) / (sizeof(unsigned long) * 8);
   int bit = (signum - 1) % (sizeof(unsigned long) * 8);
   return (set->__signals[word] & (1UL << bit)) != 0;


### PR DESCRIPTION
* Increase NSIG to 65 - one greater than the maximal possible value allowed for a signal. POSIX doesn't reference NSIG constant itself, but is explicit (after Issue 8 / Austin Group Defect 741) that SIGRTMAX should be strictly less than sysconf(_SC_NSIG) and all SIG* constants should be strictly less than NSIG_MAX (https://pubs.opengroup.org/onlinepubs/9799919799/). Note that other libc implementations on Linux (e.g. glibc and musl) also define NSIG as the value greater than SIGRTMAX.
* Fix a handful of uses/comments to reflect the updated semantics.
* Add `_NSIG` alias to the same value for compatibility.