### PR TITLE
[VPlan][Predicator] Preserve some uniform control flow

### DIFF
--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -6722,6 +6722,10 @@ VPlanPtr LoopVectorizationPlanner::tryToBuildVPlan(VPlanPtr Plan,
            vputils::onlyFirstLaneUsed(R.getVPSingleValue())))
         continue;
       auto *VPI = cast<VPInstruction>(&R);
+      // No processing needed for the uniform branch preserved by the
+      // predicator.
+      if (VPI->getOpcode() == VPInstruction::BranchOnCond)
+        continue;
       if (!VPI->getUnderlyingValue())
         continue;
 

--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -6622,6 +6622,10 @@ VPlanPtr LoopVectorizationPlanner::tryToBuildVPlan(VPlanPtr Plan,
            vputils::onlyFirstLaneUsed(R.getVPSingleValue())))
         continue;
       auto *VPI = cast<VPInstruction>(&R);
+      // No processing needed for the uniform branch preserved by the
+      // predicator.
+      if (VPI->getOpcode() == VPInstruction::BranchOnCond)
+        continue;
       if (!VPI->getUnderlyingValue())
         continue;
 

--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -2765,7 +2765,17 @@ public:
            "all incoming values must have the same type");
   }
 
+  /// Create a new VPWidenPHIRecipe without any incoming values that will be
+  /// added later.
+  VPWidenPHIRecipe(Type *ResultTy, DebugLoc DL = DebugLoc::getUnknown(),
+                   const Twine &Name = "")
+      : VPSingleDefRecipe(VPRecipeBase::VPWidenPHISC, {}, ResultTy,
+                          /*UV=*/nullptr, DL),
+        Name(Name.str()) {}
+
   VPWidenPHIRecipe *clone() override {
+    if (operands().empty())
+      return new VPWidenPHIRecipe(getScalarType(), getDebugLoc(), Name);
     return new VPWidenPHIRecipe(operands(), getDebugLoc(), Name);
   }
 

--- a/llvm/lib/Transforms/Vectorize/VPlanPredicator.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanPredicator.cpp
@@ -296,12 +296,7 @@ bool VPPredicator::shouldPreserveTerminator(VPBasicBlock *VPBB) {
     }
   }
 
-  bool IsUniformAndAvailable = [&](VPValue *V) {
-    auto *IRV = dyn_cast<VPIRValue>(V);
-    return IRV && isa<Argument>(IRV->getValue());
-  }(Term->getOperand(0));
-
-  if (!IsUniformAndAvailable)
+  if (!vputils::isUniformAcrossVFsAndUFs(Term->getOperand(0)))
     return False("non-uniform");
 
   // Should not happen in the end-to-end pass pipeline (simplifycfg would

--- a/llvm/lib/Transforms/Vectorize/VPlanPredicator.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanPredicator.cpp
@@ -491,22 +491,64 @@ void VPPredicator::run() {
     if (VPBB != Header)
       convertPhisToBlends(cast<VPBasicBlock>(VPBB));
 
-  // Linearize the blocks of the loop into one serial chain.
-  VPBlockBase *PrevVPBB = nullptr;
+  using DeferredSuccessorsTy = SmallPtrSet<VPBlockBase *, 4>;
+  DenseMap<VPBlockBase *, DeferredSuccessorsTy> DeferredMap;
+  auto PopDeferred = [&](VPBlockBase *VPBB) -> DeferredSuccessorsTy {
+    auto It = DeferredMap.find(VPBB);
+    if (It != DeferredMap.end()) {
+      DeferredSuccessorsTy Res = std::move(It->second);
+      DeferredMap.erase(It);
+      return Res;
+    }
+    return {};
+  };
+
   for (VPBasicBlock *VPBB :
        VPBlockUtils::blocksOnly<VPBasicBlock>(BlocksInCompactRPOTOrder)) {
-    auto Successors = to_vector(VPBB->getSuccessors());
-    if (Successors.size() > 1)
-      VPBB->getTerminator()->eraseFromParent();
+    LLVM_DEBUG(dbgs() << "Setting successors for " << VPBB->getName() << "\n");
+    bool PreserveUniform = false;
+    if (PreserveUniform) {
+      /* ... */
+    } else {
+      auto Successors = to_vector(VPBB->getSuccessors());
+      if (Successors.size() > 1)
+        VPBB->getTerminator()->eraseFromParent();
 
-    // Flatten the CFG in the loop. To do so, first disconnect VPBB from its
-    // successors. Then connect VPBB to the previously visited VPBB.
-    for (auto *Succ : Successors)
-      VPBlockUtils::disconnectBlocks(VPBB, Succ);
-    if (PrevVPBB)
-      VPBlockUtils::connectBlocks(PrevVPBB, VPBB);
+      for (auto *Succ : Successors)
+        VPBlockUtils::disconnectBlocks(VPBB, Succ);
 
-    PrevVPBB = VPBB;
+      auto CombinedSuccessors = PopDeferred(VPBB);
+      CombinedSuccessors.insert_range(Successors);
+
+      if (CombinedSuccessors.size() == 0)
+        continue;
+
+      LLVM_DEBUG({
+        dbgs() << "Combined successors: ";
+        for (auto *B : CombinedSuccessors) {
+          dbgs() << " " << B->getName();
+        }
+        dbgs() << "\n";
+      });
+
+      VPBlockBase *Next = *std::min_element(
+          CombinedSuccessors.begin(), CombinedSuccessors.end(),
+          [&](VPBlockBase *A, VPBlockBase *B) {
+            return BlocksInCompactRPOTOrder.getIndex(A) <
+                   BlocksInCompactRPOTOrder.getIndex(B);
+          });
+
+      LLVM_DEBUG(dbgs() << "Connecting to: " << Next->getName() << "\n");
+      VPBlockUtils::connectBlocks(VPBB, Next);
+
+      CombinedSuccessors.erase(Next);
+      auto &Entry = DeferredMap[Next];
+      if (Entry.empty()) {
+        Entry = std::move(CombinedSuccessors);
+      } else {
+        Entry.insert_range(CombinedSuccessors);
+      }
+    }
   }
 }
 

--- a/llvm/lib/Transforms/Vectorize/VPlanPredicator.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanPredicator.cpp
@@ -19,6 +19,7 @@
 #include "VPlanTransforms.h"
 #include "VPlanUtils.h"
 #include "llvm/ADT/PostOrderIterator.h"
+#include "llvm/ADT/STLExtras.h"
 
 #define DEBUG_TYPE "vplan-predicator"
 
@@ -67,6 +68,7 @@ public:
   auto begin() const { return Blocks.begin(); }
   auto end() const { return Blocks.end(); }
   unsigned getIndex(const VPBlockBase *BB) const { return BlockIndex.at(BB); }
+  unsigned size() const { return Blocks.size(); }
 };
 
 class VPPredicator {
@@ -110,6 +112,8 @@ class VPPredicator {
 
   /// Create a logical-or, factoring out a common header mask if present.
   VPValue *createMaskOr(VPValue *LHS, VPValue *RHS, DebugLoc DL);
+
+  bool shouldPreserveTerminator(VPBasicBlock *VPBB);
 
   /// Record \p Mask as the *entry* mask of \p VPBB, which is expected to not
   /// already have a mask.
@@ -207,6 +211,59 @@ VPValue *VPPredicator::createMaskOr(VPValue *LHS, VPValue *RHS, DebugLoc DL) {
     return HeaderMask;
   return Builder.createLogicalAnd(
       HeaderMask, Builder.createOr(LHSRemainder, RHSRemainder, DL), DL);
+}
+
+bool VPPredicator::shouldPreserveTerminator(VPBasicBlock *VPBB) {
+  LLVM_DEBUG(dbgs() << "Checking if can preserve the branch at the end of "
+                    << VPBB->getName() << "\n");
+  auto False = []([[maybe_unused]] StringRef Reason = "") {
+    LLVM_DEBUG(dbgs() << "  can't be preserved"
+                      << (Reason.empty() ? Twine() : (": " + Reason)) << "\n");
+    return false;
+  };
+  if (VPBB->getNumSuccessors() != 2)
+    return False("#Successors != 2");
+  auto *Term = dyn_cast<VPInstruction>(VPBB->getTerminator());
+  if (!Term || Term->getOpcode() != VPInstruction::BranchOnCond)
+    return False("Not a branch");
+
+  bool IsUniformAndAvailable = [&](VPValue *V) {
+    auto *IRV = dyn_cast<VPIRValue>(V);
+    return IRV && isa<Argument, Constant>(IRV->getValue());
+  }(Term->getOperand(0));
+
+  if (!IsUniformAndAvailable)
+    return False("non-uniform");
+
+  // Should not happen in the end-to-end pass pipeline (simplifycfg would
+  // have handled it), but possible when running `loop-vectorize` pass
+  // alone. Just don't preserve so that we won't have to handle that when
+  // executing VPlan.
+  if (all_equal(VPBB->successors()))
+    return False("All successors are the same");
+
+  auto *IPostDomNode = VPPDT.getNode(VPBB)->getIDom();
+  if (!IPostDomNode)
+    return False("no post-dom");
+  auto *IPostDom = dyn_cast<VPBasicBlock>(IPostDomNode->getBlock());
+  if (!IPostDom || !VPDT.properlyDominates(VPBB, IPostDom))
+    return False("doesn't dominate its post-dom");
+
+  LLVM_DEBUG(dbgs() << "IPostDom: " << IPostDom->getName() << "\n";);
+
+  for (VPBlockBase *Pred : IPostDom->getPredecessors()) {
+    if (Pred == VPBB)
+      continue;
+    if (count_if(VPBB->successors(),
+                 [&](auto *Succ) { return VPDT.dominates(Succ, Pred); }) != 1)
+      return False("Bailing out due to successors not being independent");
+  }
+
+  if (any_of(*IPostDom, IsaPred<VPBlendRecipe>))
+    return False("Blends at reconvergence");
+
+  LLVM_DEBUG(dbgs() << "...yes, can be preserved.\n");
+  return true;
 }
 
 VPValue *VPPredicator::createEdgeMask(const VPBasicBlock *Src,
@@ -483,7 +540,8 @@ void VPPredicator::run() {
     // Mask all VPInstructions in the block.
     for (VPRecipeBase &R : *VPBB) {
       if (auto *VPI = dyn_cast<VPInstruction>(&R))
-        VPI->addMask(BlockMask);
+        if (VPI->getOpcode() != VPInstruction::BranchOnCond)
+          VPI->addMask(BlockMask);
     }
   }
 
@@ -506,11 +564,53 @@ void VPPredicator::run() {
   for (VPBasicBlock *VPBB :
        VPBlockUtils::blocksOnly<VPBasicBlock>(BlocksInCompactRPOTOrder)) {
     LLVM_DEBUG(dbgs() << "Setting successors for " << VPBB->getName() << "\n");
-    bool PreserveUniform = false;
-    if (PreserveUniform) {
+    auto Successors = to_vector(VPBB->getSuccessors());
+
+    if (shouldPreserveTerminator(VPBB)) {
+      for (auto *Succ : Successors)
+        VPBlockUtils::disconnectBlocks(VPBB, Succ);
+
+      auto Deferred = PopDeferred(VPBB);
+      LLVM_DEBUG({
+        dbgs() << "Deferred successors: ";
+        for (auto *B : Deferred) {
+          dbgs() << " " << B->getName();
+        }
+        dbgs() << "\n";
+      });
+
+      VPBlockBase *MinDeferred = nullptr;
+      unsigned MinDeferredIdx = BlocksInCompactRPOTOrder.size() + 1;
+
+      if (!Deferred.empty()) {
+        MinDeferred =
+            *std::min_element(Deferred.begin(), Deferred.end(),
+                              [&](VPBlockBase *A, VPBlockBase *B) {
+                                return BlocksInCompactRPOTOrder.getIndex(A) <
+                                       BlocksInCompactRPOTOrder.getIndex(B);
+                              });
+        MinDeferredIdx = BlocksInCompactRPOTOrder.getIndex(MinDeferred);
+        LLVM_DEBUG(dbgs() << "Min deferred: " << MinDeferred->getName() << "("
+                          << MinDeferredIdx << ")\n");
+      }
+      for (auto *Succ : Successors) {
+        VPBlockBase *Next =
+            BlocksInCompactRPOTOrder.getIndex(Succ) < MinDeferredIdx
+                ? Succ
+                : MinDeferred;
+        LLVM_DEBUG(dbgs() << "Original Succ: " << Succ->getName()
+                          << ", connecting to " << Next->getName() << "\n");
+        VPBlockUtils::connectBlocks(VPBB, Next);
+        auto &Entry = DeferredMap[Next];
+        assert(Entry.count(Next) == 0 &&
+               "If that fails, then erase below must be done on Deferred/Succ "
+               "before insertion.");
+        Entry.insert_range(Deferred);
+        Entry.insert(Succ);
+        Entry.erase(Next);
+      }
       /* ... */
     } else {
-      auto Successors = to_vector(VPBB->getSuccessors());
       if (Successors.size() > 1)
         VPBB->getTerminator()->eraseFromParent();
 

--- a/llvm/lib/Transforms/Vectorize/VPlanPredicator.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanPredicator.cpp
@@ -510,21 +510,66 @@ void VPPredicator::run() {
     }
   }
 
-  // Linearize the blocks of the loop into one serial chain.
-  VPBlockBase *PrevVPBB = nullptr;
-  for (VPBasicBlock *VPBB : Blocks) {
-    auto Successors = to_vector(VPBB->getSuccessors());
-    if (Successors.size() > 1)
-      VPBB->getTerminator()->eraseFromParent();
+  // The following implements "Partial Control-Flow Linearization" by Simon Moll
+  // and Sebastian Hack.
 
-    // Flatten the CFG in the loop. To do so, first disconnect VPBB from its
-    // successors. Then connect VPBB to the previously visited VPBB.
-    for (auto *Succ : Successors)
-      VPBlockUtils::disconnectBlocks(VPBB, Succ);
-    if (PrevVPBB)
-      VPBlockUtils::connectBlocks(PrevVPBB, VPBB);
+  using DeferredSuccessorsTy = SmallPtrSet<VPBlockBase *, 4>;
+  DenseMap<VPBlockBase *, DeferredSuccessorsTy> DeferredMap;
+  auto PopDeferred = [&](VPBlockBase *VPBB) -> DeferredSuccessorsTy {
+    auto It = DeferredMap.find(VPBB);
+    if (It != DeferredMap.end()) {
+      DeferredSuccessorsTy Res = std::move(It->second);
+      DeferredMap.erase(It);
+      return Res;
+    }
+    return {};
+  };
 
-    PrevVPBB = VPBB;
+  for (VPBasicBlock *VPBB :
+       VPBlockUtils::blocksOnly<VPBasicBlock>(BlocksInCompactRPOTOrder)) {
+    LLVM_DEBUG(dbgs() << "Setting successors for " << VPBB->getName() << "\n");
+    bool PreserveUniform = false;
+    if (PreserveUniform) {
+      /* ... */
+    } else {
+      auto Successors = to_vector(VPBB->getSuccessors());
+      if (Successors.size() > 1)
+        VPBB->getTerminator()->eraseFromParent();
+      for (auto *Succ : Successors)
+        VPBlockUtils::disconnectBlocks(VPBB, Succ);
+
+      auto CombinedSuccessors = PopDeferred(VPBB);
+      CombinedSuccessors.insert_range(Successors);
+
+      if (CombinedSuccessors.size() == 0)
+        continue;
+
+      LLVM_DEBUG({
+        dbgs() << "Combined successors: ";
+        for (auto *B : CombinedSuccessors) {
+          dbgs() << " " << B->getName();
+        }
+        dbgs() << "\n";
+      });
+
+      VPBlockBase *Next = *std::min_element(
+          CombinedSuccessors.begin(), CombinedSuccessors.end(),
+          [&](VPBlockBase *A, VPBlockBase *B) {
+            return BlocksInCompactRPOTOrder.getIndex(A) <
+                   BlocksInCompactRPOTOrder.getIndex(B);
+          });
+
+      LLVM_DEBUG(dbgs() << "Connecting to: " << Next->getName() << "\n");
+      VPBlockUtils::connectBlocks(VPBB, Next);
+
+      CombinedSuccessors.erase(Next);
+      auto &Entry = DeferredMap[Next];
+      if (Entry.empty()) {
+        Entry = std::move(CombinedSuccessors);
+      } else {
+        Entry.insert_range(CombinedSuccessors);
+      }
+    }
   }
 
   for (VPBlockBase *VPBB : reverse(BlocksInCompactRPOTOrder))

--- a/llvm/lib/Transforms/Vectorize/VPlanPredicator.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanPredicator.cpp
@@ -66,6 +66,7 @@ public:
 
   auto begin() const { return Blocks.begin(); }
   auto end() const { return Blocks.end(); }
+  unsigned size() const { return Blocks.size(); }
   unsigned getIndex(const VPBlockBase *BB) const { return BlockIndex.at(BB); }
 };
 
@@ -140,6 +141,10 @@ class VPPredicator {
 
   using BlendTermTy = std::pair<VPValue *, VPBasicBlock *>;
 
+  /// Pre-linearization blend terms, indexed by block's index in
+  /// BlocksInCompactRPOTOrder and phi.
+  SmallVector<DenseMap<VPPhi *, SmallVector<BlendTermTy>>> BlendTerms;
+
   /// Return true if every path starting at \p Root reaches one of \p Blocks.
   /// All blocks in \p Blocks are expected to be dominated by \p Root.
   bool
@@ -155,7 +160,8 @@ public:
   VPPredicator(VPlan &Plan)
       : Plan(Plan), VPDT(Plan), VPPDT(Plan),
         BlocksInCompactRPOTOrder(
-            Plan.getVectorLoopRegion()->getEntryBasicBlock(), VPDT) {}
+            Plan.getVectorLoopRegion()->getEntryBasicBlock(), VPDT),
+        BlendTerms(BlocksInCompactRPOTOrder.size()) {}
 
   /// Returns the *entry* mask for \p VPBB.
   VPValue *getBlockInMask(const VPBasicBlock *VPBB) const {
@@ -432,10 +438,12 @@ void VPPredicator::convertPhisToBlends(VPBasicBlock *VPBB) {
       continue;
     }
 
-    auto Terms = computeBlendTerms(PhiR);
+    unsigned BlockIdx = BlocksInCompactRPOTOrder.getIndex(VPBB);
+    const auto &Terms = BlendTerms[BlockIdx].at(PhiR);
 
     // The in-mask of the common dominator is true on all paths from an
-    // incoming block to the phi. Remove it from the blend masks.
+    // incoming block to the phi. The dominator tree still represents the
+    // pre-linearization CFG.
     VPBasicBlock *CommonIncomingDom = cast<VPBasicBlock>(
         VPDT.findNearestCommonDominator(make_second_range(Terms)));
     VPValue *CommonIncomingMask = getBlockInMask(CommonIncomingDom);
@@ -469,9 +477,8 @@ void VPPredicator::run() {
       Frequencies = vputils::computeExecutionFrequencies(Blocks);
 
   for (VPBasicBlock *VPBB : Blocks) {
-    // Introduce the mask for VPBB, which may introduce needed edge masks, and
-    // convert all phi recipes of VPBB to blend recipes unless VPBB is the
-    // header.
+    // Introduce the mask for VPBB, which may introduce needed edge masks.
+
     if (VPBB != Header)
       createBlockInMask(VPBB);
 
@@ -492,9 +499,16 @@ void VPPredicator::run() {
     }
   }
 
-  for (VPBasicBlock *VPBB : reverse(Blocks))
-    if (VPBB != Header)
-      convertPhisToBlends(VPBB);
+  // Cache blend terms before linearization. Computing them requires the
+  // original phi predecessor mappings and CFG successor relation, both of
+  // which are rewritten below. Skip the header which is the first block.
+  for (VPBasicBlock *VPBB : drop_begin(Blocks)) {
+    for (VPRecipeBase &R : VPBB->phis()) {
+      auto *PhiR = cast<VPPhi>(&R);
+      unsigned BlockIdx = BlocksInCompactRPOTOrder.getIndex(VPBB);
+      BlendTerms[BlockIdx][PhiR] = computeBlendTerms(PhiR);
+    }
+  }
 
   // Linearize the blocks of the loop into one serial chain.
   VPBlockBase *PrevVPBB = nullptr;
@@ -512,6 +526,10 @@ void VPPredicator::run() {
 
     PrevVPBB = VPBB;
   }
+
+  for (VPBlockBase *VPBB : reverse(BlocksInCompactRPOTOrder))
+    if (VPBB != Header)
+      convertPhisToBlends(cast<VPBasicBlock>(VPBB));
 }
 
 void VPlanTransforms::introduceMasksAndLinearize(VPlan &Plan) {

--- a/llvm/lib/Transforms/Vectorize/VPlanPredicator.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanPredicator.cpp
@@ -670,6 +670,20 @@ void VPPredicator::run() {
     auto Successors = to_vector(VPBB->getSuccessors());
 
     if (shouldPreserveTerminator(VPBB)) {
+      VPValue *BlockMask = getBlockInMask(VPBB);
+      if (BlockMask && !match(BlockMask, m_HeaderMask())) {
+        // The branch might never be executed in a scalar loop so its condition
+        // can be `poison`. As such we need to `freeze` it. If the block is
+        // masked by the header mask itself, lane zero is known to be active
+        // whenever the branch is executed, so the scalar condition is not
+        // speculative.
+        auto *Term = cast<VPInstruction>(VPBB->getTerminator());
+        VPValue *Cond = Term->getOperand(0);
+        auto *FrozenCond = VPBuilder(Term).createNaryOp(
+            Instruction::Freeze, {Cond}, {}, Term->getDebugLoc());
+        Term->setOperand(0, FrozenCond);
+      }
+
       for (auto *Succ : Successors)
         VPBlockUtils::disconnectBlocks(VPBB, Succ);
 

--- a/llvm/lib/Transforms/Vectorize/VPlanPredicator.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanPredicator.cpp
@@ -15,10 +15,12 @@
 #include "VPlan.h"
 #include "VPlanCFG.h"
 #include "VPlanDominatorTree.h"
+#include "VPlanHelpers.h"
 #include "VPlanPatternMatch.h"
 #include "VPlanTransforms.h"
 #include "VPlanUtils.h"
 #include "llvm/ADT/PostOrderIterator.h"
+#include "llvm/ADT/STLExtras.h"
 
 #define DEBUG_TYPE "vplan-predicator"
 
@@ -82,9 +84,14 @@ class VPPredicator {
   /// Post-dominator tree for the VPlan.
   VPPostDominatorTree VPPDT;
 
+  DenseMap<VPValue *, DenseMap<VPBasicBlock *, VPValue *>>
+      SSAReconstructionDefsMap;
+
   // Scan the body of the loop in a topological order to visit each basic
   // block after having visited its predecessor basic blocks.
   CompactRPOT BlocksInCompactRPOTOrder;
+
+  bool DisablePartialLinearization = false;
 
   /// When we if-convert we need to create edge masks. We have to cache values
   /// so that we don't end up with exponential recursion/IR.
@@ -111,6 +118,10 @@ class VPPredicator {
 
   /// Create a logical-or, factoring out a common header mask if present.
   VPValue *createMaskOr(VPValue *LHS, VPValue *RHS, DebugLoc DL);
+
+  VPValue *reconstructSSA(VPBasicBlock *UseBB, VPValue *V, bool IsMask);
+  void fixSSA(VPRecipeBase *U, VPValue *V, bool IsMask);
+  bool shouldPreserveTerminator(VPBasicBlock *VPBB);
 
   /// Record \p Mask as the *entry* mask of \p VPBB, which is expected to not
   /// already have a mask.
@@ -161,7 +172,17 @@ public:
       : Plan(Plan), VPDT(Plan), VPPDT(Plan),
         BlocksInCompactRPOTOrder(
             Plan.getVectorLoopRegion()->getEntryBasicBlock(), VPDT),
-        BlendTerms(BlocksInCompactRPOTOrder.size()) {}
+        BlendTerms(BlocksInCompactRPOTOrder.size()) {
+    if (any_of(Plan.getVectorLoopRegion()->getEntryBasicBlock()->phis(),
+               IsaPred<VPReductionPHIRecipe>)) {
+      // TODO: `LoopVectorizationPlanner::addReductionResultComputation` needs
+      // fixes.
+      LLVM_DEBUG(
+          dbgs()
+          << "Partial linearization disabled due to reductions present\n");
+      DisablePartialLinearization = true;
+    }
+  }
 
   /// Returns the *entry* mask for \p VPBB.
   VPValue *getBlockInMask(const VPBasicBlock *VPBB) const {
@@ -213,6 +234,85 @@ VPValue *VPPredicator::createMaskOr(VPValue *LHS, VPValue *RHS, DebugLoc DL) {
     return HeaderMask;
   return Builder.createLogicalAnd(
       HeaderMask, Builder.createOr(LHSRemainder, RHSRemainder, DL), DL);
+}
+
+VPValue *VPPredicator::reconstructSSA(VPBasicBlock *UseBB, VPValue *V,
+                                      bool IsMask) {
+  auto *RecipeValue = dyn_cast<VPRecipeValue>(V);
+  if (!RecipeValue)
+    return V;
+
+  auto &SSADefs = SSAReconstructionDefsMap[RecipeValue];
+  VPBasicBlock *DefBB = RecipeValue->getDefiningRecipe()->getParent();
+  SSADefs[DefBB] = RecipeValue;
+  VPBasicBlock *Header = Plan.getVectorLoopRegion()->getEntryBasicBlock();
+  if (DefBB != Header)
+    SSADefs[Header] =
+        IsMask ? Plan.getFalse() : Plan.getPoison(RecipeValue->getScalarType());
+  return vputils::reconstructSSA(UseBB, SSADefs,
+                                 /*CreateWidenPhis=*/true);
+}
+
+void VPPredicator::fixSSA(VPRecipeBase *U, VPValue *V, bool IsMask) {
+  VPValue *Fixed = reconstructSSA(U->getParent(), V, IsMask);
+  if (Fixed == V)
+    return;
+
+  LLVM_DEBUG({
+    dbgs() << "SSA Fixup in  ";
+    U->dump();
+    dbgs() << "  replacing ";
+    V->dump();
+    dbgs() << "  with ";
+    Fixed->dump();
+  });
+  U->replaceUsesOfWith(V, Fixed);
+}
+
+bool VPPredicator::shouldPreserveTerminator(VPBasicBlock *VPBB) {
+  LLVM_DEBUG(dbgs() << "Checking if can preserve the branch at the end of "
+                    << VPBB->getName() << "\n");
+  auto False = []([[maybe_unused]] StringRef Reason = "") {
+    LLVM_DEBUG(dbgs() << "  can't be preserved"
+                      << (Reason.empty() ? Twine() : (": " + Reason)) << "\n");
+    return false;
+  };
+  if (DisablePartialLinearization)
+    return False("Disabled");
+
+  if (VPBB->getNumSuccessors() != 2)
+    return False("#Successors != 2");
+  auto *Term = dyn_cast<VPInstruction>(VPBB->getTerminator());
+  if (!Term || Term->getOpcode() != VPInstruction::BranchOnCond)
+    return False("Not a branch");
+
+  if (auto *IRV = dyn_cast<VPIRValue>(Term->getOperand(0))) {
+    if (isa<Constant>(IRV->getValue())) {
+      // `removeBranchOnConst` only does shallow traversal so can't optimize
+      // this away. Changing it to deep requires extra work as some tests
+      // crash. As such, treat as non-uniform and optimize away post
+      // linearization/predication.
+      return False("branch on constant");
+    }
+  }
+
+  bool IsUniformAndAvailable = [&](VPValue *V) {
+    auto *IRV = dyn_cast<VPIRValue>(V);
+    return IRV && isa<Argument>(IRV->getValue());
+  }(Term->getOperand(0));
+
+  if (!IsUniformAndAvailable)
+    return False("non-uniform");
+
+  // Should not happen in the end-to-end pass pipeline (simplifycfg would
+  // have handled it), but possible when running `loop-vectorize` pass
+  // alone. Just don't preserve so that we won't have to handle that when
+  // executing VPlan.
+  if (all_equal(VPBB->successors()))
+    return False("All successors are the same");
+
+  LLVM_DEBUG(dbgs() << "...yes, can be preserved.\n");
+  return true;
 }
 
 VPValue *VPPredicator::createEdgeMask(const VPBasicBlock *Src,
@@ -420,8 +520,14 @@ void VPPredicator::convertPhisToBlends(VPBasicBlock *VPBB) {
 
   SmallVector<VPPhi *> Phis;
   for (VPRecipeBase &R : VPBB->phis())
-    Phis.push_back(cast<VPPhi>(&R));
+    if (auto *Phi = dyn_cast<VPPhi>(&R))
+      Phis.push_back(Phi);
+  // All PHIs in VPBB use the same blend masks. Keep the SSA reconstruction
+  // definitions for each mask block so subsequent PHIs reuse reconstructed
+  // phis.
+  DenseMap<VPBasicBlock *, DenseMap<VPBasicBlock *, VPValue *>> BlendMaskDefs;
   for (VPPhi *PhiR : Phis) {
+    LLVM_DEBUG(dbgs() << "Converting " << *PhiR << " to blend\n");
     // The non-header Phi is converted into a Blend recipe below,
     // so we don't have to worry about the insertion order and we can just use
     // the builder. At this point we generate the predication tree. There may
@@ -432,6 +538,9 @@ void VPPredicator::convertPhisToBlends(VPBasicBlock *VPBB) {
       return !match(V, m_Poison());
     });
     if (all_equal(NotPoison)) {
+      LLVM_DEBUG(dbgs() << "  all incoming values are the same or poison, "
+                           "replacing with single value "
+                        << PhiR->getIncomingValue(0) << "\n");
       PhiR->replaceAllUsesWith(NotPoison.empty() ? PhiR->getIncomingValue(0)
                                                  : *NotPoison.begin());
       PhiR->eraseFromParent();
@@ -441,28 +550,49 @@ void VPPredicator::convertPhisToBlends(VPBasicBlock *VPBB) {
     unsigned BlockIdx = BlocksInCompactRPOTOrder.getIndex(VPBB);
     const auto &Terms = BlendTerms[BlockIdx].at(PhiR);
 
-    // The in-mask of the common dominator is true on all paths from an
-    // incoming block to the phi. The dominator tree still represents the
+    // The in-mask of the common dominator is true on all paths from an incoming
+    // block to the phi. The dominator tree still represents the
     // pre-linearization CFG.
     VPBasicBlock *CommonIncomingDom = cast<VPBasicBlock>(
         VPDT.findNearestCommonDominator(make_second_range(Terms)));
     VPValue *CommonIncomingMask = getBlockInMask(CommonIncomingDom);
+    LLVM_DEBUG(dbgs() << "  common incoming dominator: "
+                      << CommonIncomingDom->getName() << "\n");
 
     SmallVector<VPValue *, 2> OperandsWithMask;
     for (auto [V, MaskBlock] : Terms) {
+      VPValue *OriginalV = V;
       VPValue *Mask = getBlockInMask(MaskBlock);
+
+      // Reconstruct values at the blend location rather than fixing up the
+      // blend after it has been created.
+      V = reconstructSSA(VPBB, OriginalV, /*IsMask=*/false);
+
+      // Remove common dominator mask before reconstructing the masks while it's
+      // easier because we don't have to handle SSA phis.
       VPValue *RemainingMask = nullptr;
       bool RemovedCommonMask =
           CommonIncomingMask && Mask &&
           match(Mask, m_RemoveMask(CommonIncomingMask, RemainingMask));
-      VPValue *BlendMask = RemovedCommonMask ? RemainingMask : Mask;
-      OperandsWithMask.append({V, BlendMask ? BlendMask : Plan.getTrue()});
+      if (RemovedCommonMask) {
+        Mask = RemainingMask ? RemainingMask : Plan.getTrue();
+      }
+      if (!Mask)
+        Mask = Plan.getTrue();
+
+      auto &Defs = BlendMaskDefs[MaskBlock];
+      Defs[Plan.getVectorLoopRegion()->getEntryBasicBlock()] = Plan.getFalse();
+      Defs[MaskBlock] = Mask;
+      VPValue *BlendMask =
+          vputils::reconstructSSA(VPBB, Defs, /*CreateWidenPhis=*/true);
+      OperandsWithMask.append({V, BlendMask});
     }
 
     PHINode *IRPhi = cast_or_null<PHINode>(PhiR->getUnderlyingValue());
     auto *Blend =
         new VPBlendRecipe(IRPhi, OperandsWithMask, *PhiR, PhiR->getDebugLoc());
     Builder.insert(Blend);
+    LLVM_DEBUG(dbgs() << "  blend: " << *Blend << "\n");
     PhiR->replaceAllUsesWith(Blend);
     PhiR->eraseFromParent();
   }
@@ -491,7 +621,7 @@ void VPPredicator::run() {
     std::optional<VPExecutionFrequency> Freq = Frequencies.lookup(VPBB);
     for (VPRecipeBase &R : *VPBB) {
       auto *VPI = dyn_cast<VPInstruction>(&R);
-      if (!VPI)
+      if (!VPI || VPI->getOpcode() == VPInstruction::BranchOnCond)
         continue;
       VPI->addMask(BlockMask);
       if (VPI->isMasked())
@@ -502,11 +632,20 @@ void VPPredicator::run() {
   // Cache blend terms before linearization. Computing them requires the
   // original phi predecessor mappings and CFG successor relation, both of
   // which are rewritten below. Skip the header which is the first block.
-  for (VPBasicBlock *VPBB : drop_begin(Blocks)) {
+  for (auto [BlockIdx, VPBB] : drop_begin(enumerate(Blocks))) {
+    auto &Terms = BlendTerms[BlockIdx];
     for (VPRecipeBase &R : VPBB->phis()) {
-      auto *PhiR = cast<VPPhi>(&R);
-      unsigned BlockIdx = BlocksInCompactRPOTOrder.getIndex(VPBB);
-      BlendTerms[BlockIdx][PhiR] = computeBlendTerms(PhiR);
+      auto *Phi = cast<VPPhi>(&R);
+      Terms[Phi] = computeBlendTerms(Phi);
+      LLVM_DEBUG({
+        dbgs() << "Computed blend terms for ";
+        Phi->dump();
+        dbgs() << "\n";
+        for (BlendTermTy &Term : Terms[Phi]) {
+          dbgs() << "  " << Term.second->getName() << ": ";
+          Term.first->dump();
+        }
+      });
     }
   }
 
@@ -528,11 +667,67 @@ void VPPredicator::run() {
   for (VPBasicBlock *VPBB :
        VPBlockUtils::blocksOnly<VPBasicBlock>(BlocksInCompactRPOTOrder)) {
     LLVM_DEBUG(dbgs() << "Setting successors for " << VPBB->getName() << "\n");
-    bool PreserveUniform = false;
-    if (PreserveUniform) {
-      /* ... */
+    auto Successors = to_vector(VPBB->getSuccessors());
+
+    if (shouldPreserveTerminator(VPBB)) {
+      for (auto *Succ : Successors)
+        VPBlockUtils::disconnectBlocks(VPBB, Succ);
+
+      auto Deferred = PopDeferred(VPBB);
+      LLVM_DEBUG({
+        dbgs() << "Deferred successors: ";
+        for (auto *B : Deferred) {
+          dbgs() << " " << B->getName();
+        }
+        dbgs() << "\n";
+      });
+
+      VPBlockBase *MinDeferred = nullptr;
+      unsigned MinDeferredIdx = BlocksInCompactRPOTOrder.size() + 1;
+
+      if (!Deferred.empty()) {
+        MinDeferred =
+            *std::min_element(Deferred.begin(), Deferred.end(),
+                              [&](VPBlockBase *A, VPBlockBase *B) {
+                                return BlocksInCompactRPOTOrder.getIndex(A) <
+                                       BlocksInCompactRPOTOrder.getIndex(B);
+                              });
+        MinDeferredIdx = BlocksInCompactRPOTOrder.getIndex(MinDeferred);
+        LLVM_DEBUG(dbgs() << "Min deferred: " << MinDeferred->getName() << "("
+                          << MinDeferredIdx << ")\n");
+      }
+      for (auto *Succ : Successors) {
+        VPBlockBase *Next =
+            BlocksInCompactRPOTOrder.getIndex(Succ) < MinDeferredIdx
+                ? Succ
+                : MinDeferred;
+        if (is_contained(VPBB->successors(), Next)) {
+          LLVM_DEBUG(dbgs() << "Duplicate next " << Next->getName()
+                            << " for original successor " << Succ->getName()
+                            << ", linearizing\n");
+          assert(Successors.size() == 2 &&
+                 "Partial linearization of switch terminator isn't supported");
+          // Both branches lead to the same block, just make it unconditional.
+          // Can't use `getTerminator()` as it checks for having two successors
+          // for a conditional branch.
+          auto &Term = VPBB->back();
+          assert(match(&Term, m_BranchOnCond()));
+          Term.eraseFromParent();
+        } else {
+          LLVM_DEBUG(dbgs() << "Original Succ: " << Succ->getName()
+                            << ", connecting to " << Next->getName() << "\n");
+          VPBlockUtils::connectBlocks(VPBB, Next);
+          LLVM_DEBUG(VPBB->dump());
+        }
+        auto &Entry = DeferredMap[Next];
+        assert(Entry.count(Next) == 0 &&
+               "If that fails, then erase below must be done on Deferred/Succ "
+               "before insertion.");
+        Entry.insert_range(Deferred);
+        Entry.insert(Succ);
+        Entry.erase(Next);
+      }
     } else {
-      auto Successors = to_vector(VPBB->getSuccessors());
       if (Successors.size() > 1)
         VPBB->getTerminator()->eraseFromParent();
       for (auto *Succ : Successors)
@@ -572,9 +767,32 @@ void VPPredicator::run() {
     }
   }
 
-  for (VPBlockBase *VPBB : reverse(BlocksInCompactRPOTOrder))
+  for (VPBlockBase *VPBB : reverse(BlocksInCompactRPOTOrder)) {
+    LLVM_DEBUG(dbgs() << "Predicating phis and fixing up ssa for "
+                      << VPBB->getName() << "\n");
+    LLVM_DEBUG(VPBB->dump());
+
     if (VPBB != Header)
       convertPhisToBlends(cast<VPBasicBlock>(VPBB));
+
+    for (VPRecipeBase &R : *cast<VPBasicBlock>(VPBB)) {
+      auto *I = dyn_cast<VPInstruction>(&R);
+      if (!I)
+        continue;
+
+      switch (I->getOpcode()) {
+      case VPInstruction::Not:
+      case VPInstruction::LogicalAnd:
+      case VPInstruction::LogicalOr:
+      case Instruction::And:
+      case Instruction::Or: {
+        LLVM_DEBUG(dbgs() << "visiting " << *I << " for SSA fixup\n");
+        for (auto *V : I->operands())
+          fixSSA(I, V, /*IsMask*/ true);
+      }
+      }
+    }
+  }
 }
 
 void VPlanTransforms::introduceMasksAndLinearize(VPlan &Plan) {

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -2059,6 +2059,26 @@ void VPPhiAccessors::setIncomingValueForBlock(const VPBasicBlock *VPBB,
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPPhiAccessors::printPhiOperands(raw_ostream &O,
                                       VPSlotTracker &SlotTracker) const {
+  auto *BB = const_cast<VPBasicBlock *>(getAsRecipe()->getParent());
+  auto *Region = BB->getParent();
+
+  // incoming_values_and_blocks would crash if operands are out of sync with the
+  // predecessors. Detect that and have a separate path for printing such
+  // malformed phis (that can either be due to a bug or because we're dumping
+  // them in the middle of some kind of phi processing, like conversion to
+  // blends). The condition below loosely follows the logic in
+  // `VPBasicBlock::getCFGPredecessor`.
+  if ((!Region || Region->getEntry() != BB) &&
+      getAsRecipe()->getNumOperands() != BB->getNumPredecessors()) {
+    O << " malformed ";
+    interleaveComma(incoming_values(), O, [&O, &SlotTracker](auto V) {
+      O << "[ ";
+      V->printAsOperand(O, SlotTracker);
+      O << " ]";
+    });
+
+    return;
+  }
   interleaveComma(incoming_values_and_blocks(), O, [&O, &SlotTracker](auto Op) {
     O << "[ ";
     std::get<0>(Op)->printAsOperand(O, SlotTracker);

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -256,6 +256,15 @@ static bool
 canHoistOrSinkWithNoAliasCheck(const MemoryLocation &MemLoc,
                                VPBasicBlock *FirstBB, VPBasicBlock *LastBB,
                                std::optional<SinkStoreInfo> SinkInfo = {}) {
+  // Predicated memory motion currently only handles a linear VPlan CFG. A
+  // preserved uniform branch may put FirstBB and LastBB on different paths;
+  // conservatively decline the transformation in that case.
+  VPBlockBase *BB = FirstBB;
+  while (BB && BB != LastBB)
+    BB = BB->getSingleSuccessor();
+  if (BB != LastBB)
+    return false;
+
   bool CheckReads = SinkInfo.has_value();
   for (VPBasicBlock *VPBB :
        VPBlockUtils::blocksInSingleSuccessorChainBetween(FirstBB, LastBB)) {

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -263,6 +263,15 @@ static bool
 canHoistOrSinkWithNoAliasCheck(const MemoryLocation &MemLoc,
                                VPBasicBlock *FirstBB, VPBasicBlock *LastBB,
                                std::optional<SinkStoreInfo> SinkInfo = {}) {
+  // Predicated memory motion currently only handles a linear VPlan CFG. A
+  // preserved uniform branch may put FirstBB and LastBB on different paths;
+  // conservatively decline the transformation in that case.
+  VPBlockBase *BB = FirstBB;
+  while (BB && BB != LastBB)
+    BB = BB->getSingleSuccessor();
+  if (BB != LastBB)
+    return false;
+
   bool CheckReads = SinkInfo.has_value();
   for (VPBasicBlock *VPBB :
        VPBlockUtils::blocksInSingleSuccessorChainBetween(FirstBB, LastBB)) {

--- a/llvm/lib/Transforms/Vectorize/VPlanUnroll.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanUnroll.cpp
@@ -323,8 +323,13 @@ void UnrollState::unrollRecipeByUF(VPRecipeBase &R) {
     Copy->insertBefore(VPBB, InsertPt);
     addRecipeForPart(&R, Copy, Part);
 
-    // Phi operands are updated once all other recipes have been unrolled.
-    if (isa<VPWidenPHIRecipe>(Copy))
+    // Header phis' operands are updated once all other recipes have been
+    // unrolled. Note that interleaving is disabled for outer loop
+    // vectorization, we'd need to perform similar processing for inner loop
+    // header's phis once that is changed.
+    assert(!Plan.isOuterLoop());
+    if (isa<VPWidenPHIRecipe>(Copy) &&
+        R.getParent() == Plan.getVectorLoopRegion()->getEntryBasicBlock())
       continue;
 
     VPValue *Op;

--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
@@ -1366,3 +1366,40 @@ void vputils::detail::pullOutPermutationsImpl(
     }
   }
 }
+
+// Implements the algorithm described in "Simple and Efficient Construction of
+// Static Single Assignment Form" by Braun et al.
+VPValue *vputils::reconstructSSA(VPBasicBlock *VPBB,
+                                 DenseMap<VPBasicBlock *, VPValue *> &Defs) {
+  assert(!Defs.empty() && "Defs shouldn't be empty");
+  assert(VPBB->getPlan() && "VPBB isn't reachable from entry");
+  if (VPValue *Def = Defs.lookup(VPBB))
+    return Def;
+  // If the entry block is reached and there's still no def, then Defs is
+  // missing a definition that covers this path.
+  assert(VPBB->getNumPredecessors() && "Not all paths have def");
+
+  if (VPBlockBase *Pred = VPBB->getSinglePredecessor())
+    return reconstructSSA(cast<VPBasicBlock>(Pred), Defs);
+
+  // Multiple predecessors, create a join.
+  Type *Ty = Defs.begin()->second->getScalarType();
+  auto *Phi = new VPPhi({}, VPIRFlags::getDefaultFlags(Instruction::PHI, Ty),
+                        DebugLoc::getUnknown(), "", Ty);
+  VPBB->insert(Phi, VPBB->getFirstNonPhi());
+  Defs[VPBB] = Phi;
+  for (auto *Pred : VPBB->predecessors())
+    Phi->addIncoming(reconstructSSA(cast<VPBasicBlock>(Pred), Defs));
+
+  // Fold away trivial phis.
+  // TODO: Remove phi users which have become trivial too.
+  if (all_equal(Phi->incoming_values())) {
+    VPValue *Common = Phi->getIncomingValue(0);
+    Phi->replaceAllUsesWith(Common);
+    Phi->eraseFromParent();
+    Defs[VPBB] = Common;
+    return Common;
+  }
+
+  return Phi;
+}

--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
@@ -1370,7 +1370,8 @@ void vputils::detail::pullOutPermutationsImpl(
 // Implements the algorithm described in "Simple and Efficient Construction of
 // Static Single Assignment Form" by Braun et al.
 VPValue *vputils::reconstructSSA(VPBasicBlock *VPBB,
-                                 DenseMap<VPBasicBlock *, VPValue *> &Defs) {
+                                 DenseMap<VPBasicBlock *, VPValue *> &Defs,
+                                 bool CreateWidenPhis) {
   assert(!Defs.empty() && "Defs shouldn't be empty");
   assert(VPBB->getPlan() && "VPBB isn't reachable from entry");
   if (VPValue *Def = Defs.lookup(VPBB))
@@ -1380,26 +1381,37 @@ VPValue *vputils::reconstructSSA(VPBasicBlock *VPBB,
   assert(VPBB->getNumPredecessors() && "Not all paths have def");
 
   if (VPBlockBase *Pred = VPBB->getSinglePredecessor())
-    return reconstructSSA(cast<VPBasicBlock>(Pred), Defs);
+    return reconstructSSA(cast<VPBasicBlock>(Pred), Defs, CreateWidenPhis);
 
   // Multiple predecessors, create a join.
   Type *Ty = Defs.begin()->second->getScalarType();
-  auto *Phi = new VPPhi({}, VPIRFlags::getDefaultFlags(Instruction::PHI, Ty),
-                        DebugLoc::getUnknown(), "", Ty);
-  VPBB->insert(Phi, VPBB->getFirstNonPhi());
-  Defs[VPBB] = Phi;
-  for (auto *Pred : VPBB->predecessors())
-    Phi->addIncoming(reconstructSSA(cast<VPBasicBlock>(Pred), Defs));
+  VPPhiAccessors *Phi;
+  VPSingleDefRecipe *PhiR;
+  if (CreateWidenPhis) {
+    Phi = new VPWidenPHIRecipe(Ty);
+    PhiR = static_cast<VPWidenPHIRecipe *>(Phi);
+  } else {
+    Phi = new VPPhi({}, VPIRFlags::getDefaultFlags(Instruction::PHI, Ty),
+                    DebugLoc::getUnknown(), "", Ty);
+    PhiR = static_cast<VPPhi *>(Phi);
+  }
+  VPBB->insert(PhiR, VPBB->getFirstNonPhi());
+  Defs[VPBB] = PhiR->getVPSingleValue();
+  for (auto [Idx, Pred] : enumerate(VPBB->predecessors())) {
+    VPValue *Incoming =
+        reconstructSSA(cast<VPBasicBlock>(Pred), Defs, CreateWidenPhis);
+    Phi->addIncoming(Incoming);
+  }
 
   // Fold away trivial phis.
   // TODO: Remove phi users which have become trivial too.
   if (all_equal(Phi->incoming_values())) {
     VPValue *Common = Phi->getIncomingValue(0);
-    Phi->replaceAllUsesWith(Common);
-    Phi->eraseFromParent();
+    PhiR->replaceAllUsesWith(Common);
+    PhiR->eraseFromParent();
     Defs[VPBB] = Common;
     return Common;
   }
 
-  return Phi;
+  return PhiR;
 }

--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.h
@@ -239,6 +239,15 @@ BranchProbability getExecutionProbability(BlockFrequency Freq);
 DenseMap<const VPBasicBlock *, std::optional<VPExecutionFrequency>>
 computeExecutionFrequencies(ArrayRef<VPBasicBlock *> Blocks);
 
+/// Insert phis to reconstruct SSA for a single value starting from \p VPBB. \p
+/// Defs is a map of definitions at specific blocks. Returns the
+/// reconstructed value at VPBB. Use if the CFG has been modified such that a
+/// def no longer dominates all its uses. Every block leading to VPBB must be
+/// reachable from the entry and the plan must be plain-CFG (not contain any
+/// regions).
+LLVM_ABI_FOR_TEST VPValue *
+reconstructSSA(VPBasicBlock *VPBB, DenseMap<VPBasicBlock *, VPValue *> &Defs);
+
 namespace detail {
 
 /// Template-independent implementation for pullOutPermutations.

--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.h
@@ -244,9 +244,11 @@ computeExecutionFrequencies(ArrayRef<VPBasicBlock *> Blocks);
 /// reconstructed value at VPBB. Use if the CFG has been modified such that a
 /// def no longer dominates all its uses. Every block leading to VPBB must be
 /// reachable from the entry and the plan must be plain-CFG (not contain any
-/// regions).
+/// regions). If \p CreateWidenPhis is true, create widen-phi recipes instead
+/// of scalar phi recipes.
 LLVM_ABI_FOR_TEST VPValue *
-reconstructSSA(VPBasicBlock *VPBB, DenseMap<VPBasicBlock *, VPValue *> &Defs);
+reconstructSSA(VPBasicBlock *VPBB, DenseMap<VPBasicBlock *, VPValue *> &Defs,
+               bool CreateWidenPhis = false);
 
 namespace detail {
 

--- a/llvm/test/Transforms/LoopVectorize/AArch64/blend-costs.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/blend-costs.ll
@@ -490,10 +490,21 @@ define void @only_first_lane_used(i1 %c, ptr noalias %p1, ptr noalias %p2, ptr n
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    br label %[[VECTOR_PH:.*]]
 ; CHECK:       [[VECTOR_PH]]:
+; CHECK-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <4 x i1> poison, i1 [[C]], i64 0
+; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT]], <4 x i1> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE6:.*]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LATCH9:.*]] ]
+; CHECK-NEXT:    br i1 [[C]], label %[[BAR2:.*]], label %[[FOO1:.*]]
+; CHECK:       [[FOO1]]:
 ; CHECK-NEXT:    [[TMP4:%.*]] = add i64 [[INDEX]], -1
+; CHECK-NEXT:    [[BROADCAST_SPLATINSERT10:%.*]] = insertelement <4 x i64> poison, i64 [[TMP4]], i64 0
+; CHECK-NEXT:    [[BROADCAST_SPLAT11:%.*]] = shufflevector <4 x i64> [[BROADCAST_SPLATINSERT10]], <4 x i64> poison, <4 x i32> zeroinitializer
+; CHECK-NEXT:    br label %[[LATCH9]]
+; CHECK:       [[BAR2]]:
+; CHECK-NEXT:    [[TMP8:%.*]] = add i64 [[INDEX]], -1
+; CHECK-NEXT:    [[BROADCAST_SPLATINSERT12:%.*]] = insertelement <4 x i64> poison, i64 [[TMP8]], i64 0
+; CHECK-NEXT:    [[BROADCAST_SPLAT13:%.*]] = shufflevector <4 x i64> [[BROADCAST_SPLATINSERT12]], <4 x i64> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE:.*]]
 ; CHECK:       [[PRED_STORE_IF]]:
 ; CHECK-NEXT:    store i32 0, ptr [[Q]], align 4
@@ -509,16 +520,25 @@ define void @only_first_lane_used(i1 %c, ptr noalias %p1, ptr noalias %p2, ptr n
 ; CHECK-NEXT:    store i32 0, ptr [[Q]], align 4
 ; CHECK-NEXT:    br label %[[PRED_STORE_CONTINUE4]]
 ; CHECK:       [[PRED_STORE_CONTINUE4]]:
-; CHECK-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF5:.*]], label %[[PRED_STORE_CONTINUE6]]
+; CHECK-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF5:.*]], label %[[PRED_STORE_CONTINUE6:.*]]
 ; CHECK:       [[PRED_STORE_IF5]]:
 ; CHECK-NEXT:    store i32 0, ptr [[Q]], align 4
 ; CHECK-NEXT:    br label %[[PRED_STORE_CONTINUE6]]
 ; CHECK:       [[PRED_STORE_CONTINUE6]]:
-; CHECK-NEXT:    [[TMP1:%.*]] = getelementptr double, ptr [[P1]], i64 [[TMP4]]
+; CHECK-NEXT:    br label %[[LATCH9]]
+; CHECK:       [[LATCH9]]:
+; CHECK-NEXT:    [[TMP9:%.*]] = phi <4 x i64> [ [[BROADCAST_SPLAT11]], %[[FOO1]] ], [ poison, %[[PRED_STORE_CONTINUE6]] ]
+; CHECK-NEXT:    [[TMP10:%.*]] = phi <4 x i64> [ poison, %[[FOO1]] ], [ [[BROADCAST_SPLAT13]], %[[PRED_STORE_CONTINUE6]] ]
+; CHECK-NEXT:    [[TMP11:%.*]] = phi <4 x i1> [ zeroinitializer, %[[FOO1]] ], [ [[BROADCAST_SPLAT]], %[[PRED_STORE_CONTINUE6]] ]
+; CHECK-NEXT:    [[TMP12:%.*]] = extractelement <4 x i1> [[TMP11]], i64 0
+; CHECK-NEXT:    [[TMP13:%.*]] = extractelement <4 x i64> [[TMP10]], i64 0
+; CHECK-NEXT:    [[TMP7:%.*]] = extractelement <4 x i64> [[TMP9]], i64 0
+; CHECK-NEXT:    [[PREDPHI:%.*]] = select i1 [[TMP12]], i64 [[TMP13]], i64 [[TMP7]]
+; CHECK-NEXT:    [[TMP1:%.*]] = getelementptr double, ptr [[P1]], i64 [[PREDPHI]]
 ; CHECK-NEXT:    [[WIDE_LOAD:%.*]] = load <4 x double>, ptr [[TMP1]], align 8
 ; CHECK-NEXT:    [[TMP2:%.*]] = fadd <4 x double> [[WIDE_LOAD]], splat (double 1.000000e+00)
 ; CHECK-NEXT:    store <4 x double> [[TMP2]], ptr [[TMP1]], align 8
-; CHECK-NEXT:    [[TMP3:%.*]] = getelementptr double, ptr [[P2]], i64 [[TMP4]]
+; CHECK-NEXT:    [[TMP3:%.*]] = getelementptr double, ptr [[P2]], i64 [[PREDPHI]]
 ; CHECK-NEXT:    [[WIDE_LOAD7:%.*]] = load <4 x double>, ptr [[TMP3]], align 8
 ; CHECK-NEXT:    [[TMP6:%.*]] = fadd <4 x double> [[WIDE_LOAD7]], splat (double 1.000000e+00)
 ; CHECK-NEXT:    store <4 x double> [[TMP6]], ptr [[TMP3]], align 8

--- a/llvm/test/Transforms/LoopVectorize/AArch64/conditional-branches-cost.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/conditional-branches-cost.ll
@@ -1040,18 +1040,22 @@ define void @redundant_branch_and_tail_folding(ptr %dst, i1 %c) {
 ; DEFAULT:       [[VECTOR_PH]]:
 ; DEFAULT-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; DEFAULT:       [[VECTOR_BODY]]:
-; DEFAULT-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; DEFAULT-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; DEFAULT-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LOOP_LATCH2:.*]] ]
+; DEFAULT-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[LOOP_LATCH2]] ]
 ; DEFAULT-NEXT:    [[STEP_ADD:%.*]] = add nuw <4 x i64> [[VEC_IND]], splat (i64 4)
-; DEFAULT-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 8
-; DEFAULT-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[STEP_ADD]], splat (i64 4)
-; DEFAULT-NEXT:    [[TMP3:%.*]] = icmp eq i64 [[INDEX_NEXT]], 16
-; DEFAULT-NEXT:    br i1 [[TMP3]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP27:![0-9]+]]
+; DEFAULT-NEXT:    br i1 [[C]], label %[[LOOP_LATCH2]], label %[[MIDDLE_BLOCK:.*]]
 ; DEFAULT:       [[MIDDLE_BLOCK]]:
+; DEFAULT-NEXT:    br label %[[LOOP_LATCH2]]
+; DEFAULT:       [[LOOP_LATCH2]]:
 ; DEFAULT-NEXT:    [[TMP1:%.*]] = add nuw nsw <4 x i64> [[STEP_ADD]], splat (i64 1)
 ; DEFAULT-NEXT:    [[TMP2:%.*]] = trunc nuw nsw <4 x i64> [[TMP1]] to <4 x i32>
 ; DEFAULT-NEXT:    [[TMP4:%.*]] = extractelement <4 x i32> [[TMP2]], i64 3
 ; DEFAULT-NEXT:    store i32 [[TMP4]], ptr [[DST]], align 4
+; DEFAULT-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 8
+; DEFAULT-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[STEP_ADD]], splat (i64 4)
+; DEFAULT-NEXT:    [[TMP3:%.*]] = icmp eq i64 [[INDEX_NEXT]], 16
+; DEFAULT-NEXT:    br i1 [[TMP3]], label %[[MIDDLE_BLOCK1:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP27:![0-9]+]]
+; DEFAULT:       [[MIDDLE_BLOCK1]]:
 ; DEFAULT-NEXT:    br label %[[SCALAR_PH:.*]]
 ; DEFAULT:       [[SCALAR_PH]]:
 ;

--- a/llvm/test/Transforms/LoopVectorize/AArch64/conditional-branches-cost.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/conditional-branches-cost.ll
@@ -384,7 +384,7 @@ define i32 @header_mask_and_invariant_compare(ptr %A, ptr %B, ptr %C, ptr %D, pt
 ; DEFAULT-SAME: ptr [[A:%.*]], ptr [[B:%.*]], ptr [[C:%.*]], ptr [[D:%.*]], ptr [[E:%.*]], i64 [[N:%.*]]) #[[ATTR0:[0-9]+]] {
 ; DEFAULT-NEXT:  [[ENTRY:.*:]]
 ; DEFAULT-NEXT:    [[TMP0:%.*]] = add i64 [[N]], 1
-; DEFAULT-NEXT:    [[MIN_ITERS_CHECK:%.*]] = icmp ult i64 [[TMP0]], 28
+; DEFAULT-NEXT:    [[MIN_ITERS_CHECK:%.*]] = icmp ult i64 [[TMP0]], 60
 ; DEFAULT-NEXT:    br i1 [[MIN_ITERS_CHECK]], label %[[SCALAR_PH:.*]], label %[[VECTOR_MEMCHECK:.*]]
 ; DEFAULT:       [[VECTOR_MEMCHECK]]:
 ; DEFAULT-NEXT:    [[SCEVGEP:%.*]] = getelementptr i8, ptr [[E]], i64 4
@@ -425,6 +425,9 @@ define i32 @header_mask_and_invariant_compare(ptr %A, ptr %B, ptr %C, ptr %D, pt
 ; DEFAULT:       [[VECTOR_PH]]:
 ; DEFAULT-NEXT:    [[N_MOD_VF:%.*]] = and i64 [[TMP0]], 3
 ; DEFAULT-NEXT:    [[N_VEC:%.*]] = sub i64 [[TMP0]], [[N_MOD_VF]]
+; DEFAULT-NEXT:    br label %[[VECTOR_BODY1:.*]]
+; DEFAULT:       [[VECTOR_BODY1]]:
+; DEFAULT-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LOOP_LATCH35:.*]] ]
 ; DEFAULT-NEXT:    [[TMP3:%.*]] = load i32, ptr [[A]], align 4, !alias.scope [[META8:![0-9]+]]
 ; DEFAULT-NEXT:    [[TMP4:%.*]] = load i32, ptr [[B]], align 4, !alias.scope [[META11:![0-9]+]]
 ; DEFAULT-NEXT:    [[TMP5:%.*]] = or i32 [[TMP4]], [[TMP3]]
@@ -432,9 +435,8 @@ define i32 @header_mask_and_invariant_compare(ptr %A, ptr %B, ptr %C, ptr %D, pt
 ; DEFAULT-NEXT:    [[TMP7:%.*]] = icmp ugt i32 [[TMP6]], [[TMP5]]
 ; DEFAULT-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <4 x i1> poison, i1 [[TMP7]], i64 0
 ; DEFAULT-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT]], <4 x i1> poison, <4 x i32> zeroinitializer
-; DEFAULT-NEXT:    br label %[[VECTOR_BODY:.*]]
+; DEFAULT-NEXT:    br i1 [[TMP7]], label %[[VECTOR_BODY:.*]], label %[[LOOP_LATCH35]]
 ; DEFAULT:       [[VECTOR_BODY]]:
-; DEFAULT-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE33:.*]] ]
 ; DEFAULT-NEXT:    [[TMP16:%.*]] = getelementptr i32, ptr [[D]], i64 [[INDEX]]
 ; DEFAULT-NEXT:    br i1 [[TMP7]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE:.*]]
 ; DEFAULT:       [[PRED_STORE_IF]]:
@@ -451,15 +453,17 @@ define i32 @header_mask_and_invariant_compare(ptr %A, ptr %B, ptr %C, ptr %D, pt
 ; DEFAULT-NEXT:    store i32 [[TMP5]], ptr [[E]], align 4, !alias.scope [[META15]], !noalias [[META17]]
 ; DEFAULT-NEXT:    br label %[[PRED_STORE_CONTINUE31]]
 ; DEFAULT:       [[PRED_STORE_CONTINUE31]]:
-; DEFAULT-NEXT:    br i1 [[TMP7]], label %[[PRED_STORE_IF32:.*]], label %[[PRED_STORE_CONTINUE33]]
+; DEFAULT-NEXT:    br i1 [[TMP7]], label %[[PRED_STORE_IF32:.*]], label %[[PRED_STORE_CONTINUE33:.*]]
 ; DEFAULT:       [[PRED_STORE_IF32]]:
 ; DEFAULT-NEXT:    store i32 [[TMP5]], ptr [[E]], align 4, !alias.scope [[META15]], !noalias [[META17]]
 ; DEFAULT-NEXT:    br label %[[PRED_STORE_CONTINUE33]]
 ; DEFAULT:       [[PRED_STORE_CONTINUE33]]:
 ; DEFAULT-NEXT:    call void @llvm.masked.store.v4i32.p0(<4 x i32> zeroinitializer, ptr align 4 [[TMP16]], <4 x i1> [[BROADCAST_SPLAT]]), !alias.scope [[META19:![0-9]+]], !noalias [[META20:![0-9]+]]
+; DEFAULT-NEXT:    br label %[[LOOP_LATCH35]]
+; DEFAULT:       [[LOOP_LATCH35]]:
 ; DEFAULT-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
 ; DEFAULT-NEXT:    [[TMP18:%.*]] = icmp eq i64 [[INDEX_NEXT]], [[N_VEC]]
-; DEFAULT-NEXT:    br i1 [[TMP18]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP21:![0-9]+]]
+; DEFAULT-NEXT:    br i1 [[TMP18]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY1]], !llvm.loop [[LOOP21:![0-9]+]]
 ; DEFAULT:       [[MIDDLE_BLOCK]]:
 ; DEFAULT-NEXT:    [[CMP_N:%.*]] = icmp eq i64 [[TMP0]], [[N_VEC]]
 ; DEFAULT-NEXT:    br i1 [[CMP_N]], [[EXIT:label %.*]], label %[[SCALAR_PH]]

--- a/llvm/test/Transforms/LoopVectorize/AArch64/conditional-branches-cost.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/conditional-branches-cost.ll
@@ -1008,18 +1008,22 @@ define void @redundant_branch_and_tail_folding(ptr %dst, i1 %c) {
 ; DEFAULT:       [[VECTOR_PH]]:
 ; DEFAULT-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; DEFAULT:       [[VECTOR_BODY]]:
-; DEFAULT-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; DEFAULT-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; DEFAULT-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LOOP_LATCH2:.*]] ]
+; DEFAULT-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[LOOP_LATCH2]] ]
 ; DEFAULT-NEXT:    [[STEP_ADD:%.*]] = add nuw <4 x i64> [[VEC_IND]], splat (i64 4)
-; DEFAULT-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 8
-; DEFAULT-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[STEP_ADD]], splat (i64 4)
-; DEFAULT-NEXT:    [[TMP3:%.*]] = icmp eq i64 [[INDEX_NEXT]], 16
-; DEFAULT-NEXT:    br i1 [[TMP3]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP27:![0-9]+]]
+; DEFAULT-NEXT:    br i1 [[C]], label %[[LOOP_LATCH2]], label %[[MIDDLE_BLOCK:.*]]
 ; DEFAULT:       [[MIDDLE_BLOCK]]:
+; DEFAULT-NEXT:    br label %[[LOOP_LATCH2]]
+; DEFAULT:       [[LOOP_LATCH2]]:
 ; DEFAULT-NEXT:    [[TMP1:%.*]] = add nuw nsw <4 x i64> [[STEP_ADD]], splat (i64 1)
 ; DEFAULT-NEXT:    [[TMP2:%.*]] = trunc nuw nsw <4 x i64> [[TMP1]] to <4 x i32>
 ; DEFAULT-NEXT:    [[TMP4:%.*]] = extractelement <4 x i32> [[TMP2]], i64 3
 ; DEFAULT-NEXT:    store i32 [[TMP4]], ptr [[DST]], align 4
+; DEFAULT-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 8
+; DEFAULT-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[STEP_ADD]], splat (i64 4)
+; DEFAULT-NEXT:    [[TMP3:%.*]] = icmp eq i64 [[INDEX_NEXT]], 16
+; DEFAULT-NEXT:    br i1 [[TMP3]], label %[[MIDDLE_BLOCK1:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP27:![0-9]+]]
+; DEFAULT:       [[MIDDLE_BLOCK1]]:
 ; DEFAULT-NEXT:    br label %[[SCALAR_PH:.*]]
 ; DEFAULT:       [[SCALAR_PH]]:
 ;

--- a/llvm/test/Transforms/LoopVectorize/AArch64/force-target-instruction-cost.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/force-target-instruction-cost.ll
@@ -218,8 +218,13 @@ define void @test_exit_branch_cost(ptr %dst, ptr noalias %x.ptr, ptr noalias %y.
 ; COMMON-NEXT:    store i64 0, ptr [[DST_3]], align 8
 ; COMMON-NEXT:    br label %[[PRED_STORE_CONTINUE9]]
 ; COMMON:       [[PRED_STORE_CONTINUE9]]:
+; COMMON-NEXT:    br i1 [[C_3]], label %[[THEN_310:.*]], label %[[THEN_411:.*]]
+; COMMON:       [[THEN_310]]:
 ; COMMON-NEXT:    [[TMP22:%.*]] = select <2 x i1> [[TMP7]], <2 x i1> [[BROADCAST_SPLAT]], <2 x i1> zeroinitializer
-; COMMON-NEXT:    [[TMP13:%.*]] = select <2 x i1> [[TMP22]], <2 x i1> [[BROADCAST_SPLAT3]], <2 x i1> zeroinitializer
+; COMMON-NEXT:    br label %[[THEN_411]]
+; COMMON:       [[THEN_411]]:
+; COMMON-NEXT:    [[TMP26:%.*]] = phi <2 x i1> [ zeroinitializer, %[[PRED_STORE_CONTINUE9]] ], [ [[TMP22]], %[[THEN_310]] ]
+; COMMON-NEXT:    [[TMP13:%.*]] = select <2 x i1> [[TMP26]], <2 x i1> [[BROADCAST_SPLAT3]], <2 x i1> zeroinitializer
 ; COMMON-NEXT:    [[TMP14:%.*]] = or <2 x i1> [[TMP6]], [[TMP13]]
 ; COMMON-NEXT:    [[PREDPHI:%.*]] = select <2 x i1> [[TMP6]], <2 x i64> splat (i64 1), <2 x i64> zeroinitializer
 ; COMMON-NEXT:    [[TMP15:%.*]] = extractelement <2 x i1> [[TMP14]], i64 0
@@ -236,20 +241,20 @@ define void @test_exit_branch_cost(ptr %dst, ptr noalias %x.ptr, ptr noalias %y.
 ; COMMON-NEXT:    store i64 [[TMP18]], ptr [[DST_2]], align 8
 ; COMMON-NEXT:    br label %[[PRED_STORE_CONTINUE13]]
 ; COMMON:       [[PRED_STORE_CONTINUE13]]:
-; COMMON-NEXT:    [[TMP19:%.*]] = select <2 x i1> [[TMP22]], <2 x i1> [[TMP3]], <2 x i1> zeroinitializer
+; COMMON-NEXT:    [[TMP19:%.*]] = select <2 x i1> [[TMP26]], <2 x i1> [[TMP3]], <2 x i1> zeroinitializer
 ; COMMON-NEXT:    [[TMP20:%.*]] = or <2 x i1> [[TMP14]], [[TMP19]]
 ; COMMON-NEXT:    [[TMP21:%.*]] = extractelement <2 x i1> [[TMP20]], i64 0
 ; COMMON-NEXT:    br i1 [[TMP21]], label %[[PRED_STORE_IF14:.*]], label %[[PRED_STORE_CONTINUE15:.*]]
 ; COMMON:       [[PRED_STORE_IF14]]:
-; COMMON-NEXT:    [[TMP24:%.*]] = load i64, ptr [[SRC]], align 8, !alias.scope [[META6:![0-9]+]]
-; COMMON-NEXT:    store i64 [[TMP24]], ptr [[DST]], align 8, !alias.scope [[META9:![0-9]+]], !noalias [[META6]]
+; COMMON-NEXT:    [[TMP27:%.*]] = load i64, ptr [[SRC]], align 8, !alias.scope [[META6:![0-9]+]]
+; COMMON-NEXT:    store i64 [[TMP27]], ptr [[DST]], align 8, !alias.scope [[META9:![0-9]+]], !noalias [[META6]]
 ; COMMON-NEXT:    br label %[[PRED_STORE_CONTINUE15]]
 ; COMMON:       [[PRED_STORE_CONTINUE15]]:
 ; COMMON-NEXT:    [[TMP23:%.*]] = extractelement <2 x i1> [[TMP20]], i64 1
 ; COMMON-NEXT:    br i1 [[TMP23]], label %[[PRED_STORE_IF16:.*]], label %[[PRED_STORE_CONTINUE17]]
 ; COMMON:       [[PRED_STORE_IF16]]:
-; COMMON-NEXT:    [[TMP26:%.*]] = load i64, ptr [[SRC]], align 8, !alias.scope [[META6]]
-; COMMON-NEXT:    store i64 [[TMP26]], ptr [[DST]], align 8, !alias.scope [[META9]], !noalias [[META6]]
+; COMMON-NEXT:    [[TMP24:%.*]] = load i64, ptr [[SRC]], align 8, !alias.scope [[META6]]
+; COMMON-NEXT:    store i64 [[TMP24]], ptr [[DST]], align 8, !alias.scope [[META9]], !noalias [[META6]]
 ; COMMON-NEXT:    br label %[[PRED_STORE_CONTINUE17]]
 ; COMMON:       [[PRED_STORE_CONTINUE17]]:
 ; COMMON-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 2

--- a/llvm/test/Transforms/LoopVectorize/AArch64/force-target-instruction-cost.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/force-target-instruction-cost.ll
@@ -185,6 +185,7 @@ define void @test_exit_branch_cost(ptr %dst, ptr noalias %x.ptr, ptr noalias %y.
 ; COMMON-NEXT:    [[BROADCAST_SPLAT3:%.*]] = shufflevector <2 x i1> [[BROADCAST_SPLATINSERT2]], <2 x i1> poison, <2 x i32> zeroinitializer
 ; COMMON-NEXT:    [[TMP0:%.*]] = select i1 [[C_4]], <2 x i1> [[BROADCAST_SPLAT]], <2 x i1> zeroinitializer
 ; COMMON-NEXT:    [[TMP1:%.*]] = xor <2 x i1> [[TMP0]], splat (i1 true)
+; COMMON-NEXT:    [[TMP2:%.*]] = freeze i1 [[C_3]]
 ; COMMON-NEXT:    [[TMP3:%.*]] = xor <2 x i1> [[BROADCAST_SPLAT3]], splat (i1 true)
 ; COMMON-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; COMMON:       [[VECTOR_BODY]]:
@@ -218,7 +219,7 @@ define void @test_exit_branch_cost(ptr %dst, ptr noalias %x.ptr, ptr noalias %y.
 ; COMMON-NEXT:    store i64 0, ptr [[DST_3]], align 8
 ; COMMON-NEXT:    br label %[[PRED_STORE_CONTINUE9]]
 ; COMMON:       [[PRED_STORE_CONTINUE9]]:
-; COMMON-NEXT:    br i1 [[C_3]], label %[[THEN_310:.*]], label %[[THEN_411:.*]]
+; COMMON-NEXT:    br i1 [[TMP2]], label %[[THEN_310:.*]], label %[[THEN_411:.*]]
 ; COMMON:       [[THEN_310]]:
 ; COMMON-NEXT:    [[TMP22:%.*]] = select <2 x i1> [[TMP7]], <2 x i1> [[BROADCAST_SPLAT]], <2 x i1> zeroinitializer
 ; COMMON-NEXT:    br label %[[THEN_411]]
@@ -246,15 +247,15 @@ define void @test_exit_branch_cost(ptr %dst, ptr noalias %x.ptr, ptr noalias %y.
 ; COMMON-NEXT:    [[TMP21:%.*]] = extractelement <2 x i1> [[TMP20]], i64 0
 ; COMMON-NEXT:    br i1 [[TMP21]], label %[[PRED_STORE_IF14:.*]], label %[[PRED_STORE_CONTINUE15:.*]]
 ; COMMON:       [[PRED_STORE_IF14]]:
-; COMMON-NEXT:    [[TMP27:%.*]] = load i64, ptr [[SRC]], align 8, !alias.scope [[META6:![0-9]+]]
-; COMMON-NEXT:    store i64 [[TMP27]], ptr [[DST]], align 8, !alias.scope [[META9:![0-9]+]], !noalias [[META6]]
+; COMMON-NEXT:    [[TMP24:%.*]] = load i64, ptr [[SRC]], align 8, !alias.scope [[META6:![0-9]+]]
+; COMMON-NEXT:    store i64 [[TMP24]], ptr [[DST]], align 8, !alias.scope [[META9:![0-9]+]], !noalias [[META6]]
 ; COMMON-NEXT:    br label %[[PRED_STORE_CONTINUE15]]
 ; COMMON:       [[PRED_STORE_CONTINUE15]]:
 ; COMMON-NEXT:    [[TMP23:%.*]] = extractelement <2 x i1> [[TMP20]], i64 1
 ; COMMON-NEXT:    br i1 [[TMP23]], label %[[PRED_STORE_IF16:.*]], label %[[PRED_STORE_CONTINUE17]]
 ; COMMON:       [[PRED_STORE_IF16]]:
-; COMMON-NEXT:    [[TMP24:%.*]] = load i64, ptr [[SRC]], align 8, !alias.scope [[META6]]
-; COMMON-NEXT:    store i64 [[TMP24]], ptr [[DST]], align 8, !alias.scope [[META9]], !noalias [[META6]]
+; COMMON-NEXT:    [[TMP27:%.*]] = load i64, ptr [[SRC]], align 8, !alias.scope [[META6]]
+; COMMON-NEXT:    store i64 [[TMP27]], ptr [[DST]], align 8, !alias.scope [[META9]], !noalias [[META6]]
 ; COMMON-NEXT:    br label %[[PRED_STORE_CONTINUE17]]
 ; COMMON:       [[PRED_STORE_CONTINUE17]]:
 ; COMMON-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 2

--- a/llvm/test/Transforms/LoopVectorize/AArch64/force-target-instruction-cost.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/force-target-instruction-cost.ll
@@ -387,29 +387,239 @@ for.end:
 }
 
 define void @loop_with_freeze_and_conditional_srem(ptr %dst, ptr %keyinfo, ptr %invariant.ptr, i32 %divisor) {
-; COMMON-LABEL: define void @loop_with_freeze_and_conditional_srem(
-; COMMON-SAME: ptr [[DST:%.*]], ptr [[KEYINFO:%.*]], ptr [[INVARIANT_PTR:%.*]], i32 [[DIVISOR:%.*]]) {
-; COMMON-NEXT:  [[ENTRY:.*]]:
-; COMMON-NEXT:    br label %[[LOOP:.*]]
-; COMMON:       [[LOOP]]:
-; COMMON-NEXT:    [[INDEX_NEXT:%.*]] = phi i64 [ 0, %[[ENTRY]] ], [ [[IV_NEXT:%.*]], %[[LOOP_LATCH:.*]] ]
-; COMMON-NEXT:    [[LOADED:%.*]] = load i32, ptr [[INVARIANT_PTR]], align 4
-; COMMON-NEXT:    [[FROZEN:%.*]] = freeze i32 [[LOADED]]
-; COMMON-NEXT:    [[CMP:%.*]] = icmp eq i32 [[FROZEN]], 0
-; COMMON-NEXT:    br i1 [[CMP]], label %[[IF_ZERO:.*]], label %[[IF_NONZERO:.*]]
-; COMMON:       [[IF_ZERO]]:
-; COMMON-NEXT:    store i32 0, ptr [[KEYINFO]], align 4
-; COMMON-NEXT:    br label %[[LOOP_LATCH]]
-; COMMON:       [[IF_NONZERO]]:
-; COMMON-NEXT:    [[TMP11:%.*]] = srem i32 1, [[DIVISOR]]
-; COMMON-NEXT:    store i32 [[TMP11]], ptr [[DST]], align 4
-; COMMON-NEXT:    br label %[[LOOP_LATCH]]
-; COMMON:       [[LOOP_LATCH]]:
-; COMMON-NEXT:    [[IV_NEXT]] = add i64 [[INDEX_NEXT]], 1
-; COMMON-NEXT:    [[TMP16:%.*]] = icmp eq i64 [[INDEX_NEXT]], 32
-; COMMON-NEXT:    br i1 [[TMP16]], label %[[EXIT:.*]], label %[[LOOP]]
-; COMMON:       [[EXIT]]:
-; COMMON-NEXT:    ret void
+; COST1-LABEL: define void @loop_with_freeze_and_conditional_srem(
+; COST1-SAME: ptr [[DST:%.*]], ptr [[KEYINFO:%.*]], ptr [[INVARIANT_PTR:%.*]], i32 [[DIVISOR:%.*]]) {
+; COST1-NEXT:  [[ENTRY:.*:]]
+; COST1-NEXT:    br label %[[VECTOR_MEMCHECK:.*]]
+; COST1:       [[VECTOR_MEMCHECK]]:
+; COST1-NEXT:    [[SCEVGEP:%.*]] = getelementptr i8, ptr [[DST]], i64 4
+; COST1-NEXT:    [[SCEVGEP1:%.*]] = getelementptr i8, ptr [[KEYINFO]], i64 4
+; COST1-NEXT:    [[SCEVGEP2:%.*]] = getelementptr i8, ptr [[INVARIANT_PTR]], i64 4
+; COST1-NEXT:    [[BOUND0:%.*]] = icmp ult ptr [[DST]], [[SCEVGEP1]]
+; COST1-NEXT:    [[BOUND1:%.*]] = icmp ult ptr [[KEYINFO]], [[SCEVGEP]]
+; COST1-NEXT:    [[FOUND_CONFLICT:%.*]] = and i1 [[BOUND0]], [[BOUND1]]
+; COST1-NEXT:    [[BOUND03:%.*]] = icmp ult ptr [[DST]], [[SCEVGEP2]]
+; COST1-NEXT:    [[BOUND14:%.*]] = icmp ult ptr [[INVARIANT_PTR]], [[SCEVGEP]]
+; COST1-NEXT:    [[FOUND_CONFLICT5:%.*]] = and i1 [[BOUND03]], [[BOUND14]]
+; COST1-NEXT:    [[CONFLICT_RDX:%.*]] = or i1 [[FOUND_CONFLICT]], [[FOUND_CONFLICT5]]
+; COST1-NEXT:    [[BOUND06:%.*]] = icmp ult ptr [[KEYINFO]], [[SCEVGEP2]]
+; COST1-NEXT:    [[BOUND17:%.*]] = icmp ult ptr [[INVARIANT_PTR]], [[SCEVGEP1]]
+; COST1-NEXT:    [[FOUND_CONFLICT8:%.*]] = and i1 [[BOUND06]], [[BOUND17]]
+; COST1-NEXT:    [[CONFLICT_RDX9:%.*]] = or i1 [[CONFLICT_RDX]], [[FOUND_CONFLICT8]]
+; COST1-NEXT:    br i1 [[CONFLICT_RDX9]], label %[[SCALAR_PH:.*]], label %[[VECTOR_PH:.*]]
+; COST1:       [[VECTOR_PH]]:
+; COST1-NEXT:    br label %[[VECTOR_BODY:.*]]
+; COST1:       [[VECTOR_BODY]]:
+; COST1-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LOOP_LATCH42:.*]] ]
+; COST1-NEXT:    [[TMP0:%.*]] = load i32, ptr [[INVARIANT_PTR]], align 4, !alias.scope [[META15:![0-9]+]]
+; COST1-NEXT:    [[TMP1:%.*]] = freeze i32 [[TMP0]]
+; COST1-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <4 x i32> poison, i32 [[TMP1]], i64 0
+; COST1-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i32> [[BROADCAST_SPLATINSERT]], <4 x i32> poison, <4 x i32> zeroinitializer
+; COST1-NEXT:    [[TMP2:%.*]] = icmp eq <4 x i32> [[BROADCAST_SPLAT]], zeroinitializer
+; COST1-NEXT:    [[TMP3:%.*]] = extractelement <4 x i1> [[TMP2]], i64 0
+; COST1-NEXT:    br i1 [[TMP3]], label %[[IF_ZERO25:.*]], label %[[IF_NONZERO10:.*]]
+; COST1:       [[IF_NONZERO10]]:
+; COST1-NEXT:    [[TMP4:%.*]] = extractelement <4 x i1> [[TMP2]], i64 0
+; COST1-NEXT:    [[TMP5:%.*]] = xor i1 [[TMP4]], true
+; COST1-NEXT:    br i1 [[TMP5]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE:.*]]
+; COST1:       [[PRED_STORE_IF]]:
+; COST1-NEXT:    [[TMP6:%.*]] = srem i32 1, [[DIVISOR]]
+; COST1-NEXT:    store i32 [[TMP6]], ptr [[DST]], align 4, !alias.scope [[META18:![0-9]+]], !noalias [[META20:![0-9]+]]
+; COST1-NEXT:    br label %[[PRED_STORE_CONTINUE]]
+; COST1:       [[PRED_STORE_CONTINUE]]:
+; COST1-NEXT:    br i1 [[TMP5]], label %[[PRED_STORE_IF11:.*]], label %[[PRED_STORE_CONTINUE12:.*]]
+; COST1:       [[PRED_STORE_IF11]]:
+; COST1-NEXT:    [[TMP7:%.*]] = srem i32 1, [[DIVISOR]]
+; COST1-NEXT:    store i32 [[TMP7]], ptr [[DST]], align 4, !alias.scope [[META18]], !noalias [[META20]]
+; COST1-NEXT:    br label %[[PRED_STORE_CONTINUE12]]
+; COST1:       [[PRED_STORE_CONTINUE12]]:
+; COST1-NEXT:    br i1 [[TMP5]], label %[[PRED_STORE_IF13:.*]], label %[[PRED_STORE_CONTINUE14:.*]]
+; COST1:       [[PRED_STORE_IF13]]:
+; COST1-NEXT:    [[TMP8:%.*]] = srem i32 1, [[DIVISOR]]
+; COST1-NEXT:    store i32 [[TMP8]], ptr [[DST]], align 4, !alias.scope [[META18]], !noalias [[META20]]
+; COST1-NEXT:    br label %[[PRED_STORE_CONTINUE14]]
+; COST1:       [[PRED_STORE_CONTINUE14]]:
+; COST1-NEXT:    br i1 [[TMP5]], label %[[PRED_STORE_IF15:.*]], label %[[PRED_STORE_CONTINUE16:.*]]
+; COST1:       [[PRED_STORE_IF15]]:
+; COST1-NEXT:    [[TMP9:%.*]] = srem i32 1, [[DIVISOR]]
+; COST1-NEXT:    store i32 [[TMP9]], ptr [[DST]], align 4, !alias.scope [[META18]], !noalias [[META20]]
+; COST1-NEXT:    br label %[[PRED_STORE_CONTINUE16]]
+; COST1:       [[PRED_STORE_CONTINUE16]]:
+; COST1-NEXT:    br i1 [[TMP5]], label %[[PRED_STORE_IF17:.*]], label %[[PRED_STORE_CONTINUE18:.*]]
+; COST1:       [[PRED_STORE_IF17]]:
+; COST1-NEXT:    [[TMP10:%.*]] = srem i32 1, [[DIVISOR]]
+; COST1-NEXT:    store i32 [[TMP10]], ptr [[DST]], align 4, !alias.scope [[META18]], !noalias [[META20]]
+; COST1-NEXT:    br label %[[PRED_STORE_CONTINUE18]]
+; COST1:       [[PRED_STORE_CONTINUE18]]:
+; COST1-NEXT:    br i1 [[TMP5]], label %[[PRED_STORE_IF19:.*]], label %[[PRED_STORE_CONTINUE20:.*]]
+; COST1:       [[PRED_STORE_IF19]]:
+; COST1-NEXT:    [[TMP11:%.*]] = srem i32 1, [[DIVISOR]]
+; COST1-NEXT:    store i32 [[TMP11]], ptr [[DST]], align 4, !alias.scope [[META18]], !noalias [[META20]]
+; COST1-NEXT:    br label %[[PRED_STORE_CONTINUE20]]
+; COST1:       [[PRED_STORE_CONTINUE20]]:
+; COST1-NEXT:    br i1 [[TMP5]], label %[[PRED_STORE_IF21:.*]], label %[[PRED_STORE_CONTINUE22:.*]]
+; COST1:       [[PRED_STORE_IF21]]:
+; COST1-NEXT:    [[TMP12:%.*]] = srem i32 1, [[DIVISOR]]
+; COST1-NEXT:    store i32 [[TMP12]], ptr [[DST]], align 4, !alias.scope [[META18]], !noalias [[META20]]
+; COST1-NEXT:    br label %[[PRED_STORE_CONTINUE22]]
+; COST1:       [[PRED_STORE_CONTINUE22]]:
+; COST1-NEXT:    br i1 [[TMP5]], label %[[PRED_STORE_IF23:.*]], label %[[PRED_STORE_CONTINUE24:.*]]
+; COST1:       [[PRED_STORE_IF23]]:
+; COST1-NEXT:    [[TMP13:%.*]] = srem i32 1, [[DIVISOR]]
+; COST1-NEXT:    store i32 [[TMP13]], ptr [[DST]], align 4, !alias.scope [[META18]], !noalias [[META20]]
+; COST1-NEXT:    br label %[[PRED_STORE_CONTINUE24]]
+; COST1:       [[PRED_STORE_CONTINUE24]]:
+; COST1-NEXT:    br label %[[LOOP_LATCH42]]
+; COST1:       [[IF_ZERO25]]:
+; COST1-NEXT:    [[TMP14:%.*]] = extractelement <4 x i1> [[TMP2]], i64 0
+; COST1-NEXT:    br i1 [[TMP14]], label %[[PRED_STORE_IF26:.*]], label %[[PRED_STORE_CONTINUE27:.*]]
+; COST1:       [[PRED_STORE_IF26]]:
+; COST1-NEXT:    store i32 0, ptr [[KEYINFO]], align 4, !alias.scope [[META22:![0-9]+]], !noalias [[META15]]
+; COST1-NEXT:    br label %[[PRED_STORE_CONTINUE27]]
+; COST1:       [[PRED_STORE_CONTINUE27]]:
+; COST1-NEXT:    [[TMP15:%.*]] = extractelement <4 x i1> [[TMP2]], i64 0
+; COST1-NEXT:    br i1 [[TMP15]], label %[[PRED_STORE_IF28:.*]], label %[[PRED_STORE_CONTINUE29:.*]]
+; COST1:       [[PRED_STORE_IF28]]:
+; COST1-NEXT:    store i32 0, ptr [[KEYINFO]], align 4, !alias.scope [[META22]], !noalias [[META15]]
+; COST1-NEXT:    br label %[[PRED_STORE_CONTINUE29]]
+; COST1:       [[PRED_STORE_CONTINUE29]]:
+; COST1-NEXT:    [[TMP16:%.*]] = extractelement <4 x i1> [[TMP2]], i64 0
+; COST1-NEXT:    br i1 [[TMP16]], label %[[PRED_STORE_IF30:.*]], label %[[PRED_STORE_CONTINUE31:.*]]
+; COST1:       [[PRED_STORE_IF30]]:
+; COST1-NEXT:    store i32 0, ptr [[KEYINFO]], align 4, !alias.scope [[META22]], !noalias [[META15]]
+; COST1-NEXT:    br label %[[PRED_STORE_CONTINUE31]]
+; COST1:       [[PRED_STORE_CONTINUE31]]:
+; COST1-NEXT:    [[TMP17:%.*]] = extractelement <4 x i1> [[TMP2]], i64 0
+; COST1-NEXT:    br i1 [[TMP17]], label %[[PRED_STORE_IF32:.*]], label %[[PRED_STORE_CONTINUE33:.*]]
+; COST1:       [[PRED_STORE_IF32]]:
+; COST1-NEXT:    store i32 0, ptr [[KEYINFO]], align 4, !alias.scope [[META22]], !noalias [[META15]]
+; COST1-NEXT:    br label %[[PRED_STORE_CONTINUE33]]
+; COST1:       [[PRED_STORE_CONTINUE33]]:
+; COST1-NEXT:    [[TMP18:%.*]] = extractelement <4 x i1> [[TMP2]], i64 0
+; COST1-NEXT:    br i1 [[TMP18]], label %[[PRED_STORE_IF34:.*]], label %[[PRED_STORE_CONTINUE35:.*]]
+; COST1:       [[PRED_STORE_IF34]]:
+; COST1-NEXT:    store i32 0, ptr [[KEYINFO]], align 4, !alias.scope [[META22]], !noalias [[META15]]
+; COST1-NEXT:    br label %[[PRED_STORE_CONTINUE35]]
+; COST1:       [[PRED_STORE_CONTINUE35]]:
+; COST1-NEXT:    [[TMP19:%.*]] = extractelement <4 x i1> [[TMP2]], i64 0
+; COST1-NEXT:    br i1 [[TMP19]], label %[[PRED_STORE_IF36:.*]], label %[[PRED_STORE_CONTINUE37:.*]]
+; COST1:       [[PRED_STORE_IF36]]:
+; COST1-NEXT:    store i32 0, ptr [[KEYINFO]], align 4, !alias.scope [[META22]], !noalias [[META15]]
+; COST1-NEXT:    br label %[[PRED_STORE_CONTINUE37]]
+; COST1:       [[PRED_STORE_CONTINUE37]]:
+; COST1-NEXT:    [[TMP20:%.*]] = extractelement <4 x i1> [[TMP2]], i64 0
+; COST1-NEXT:    br i1 [[TMP20]], label %[[PRED_STORE_IF38:.*]], label %[[PRED_STORE_CONTINUE39:.*]]
+; COST1:       [[PRED_STORE_IF38]]:
+; COST1-NEXT:    store i32 0, ptr [[KEYINFO]], align 4, !alias.scope [[META22]], !noalias [[META15]]
+; COST1-NEXT:    br label %[[PRED_STORE_CONTINUE39]]
+; COST1:       [[PRED_STORE_CONTINUE39]]:
+; COST1-NEXT:    [[TMP21:%.*]] = extractelement <4 x i1> [[TMP2]], i64 0
+; COST1-NEXT:    br i1 [[TMP21]], label %[[PRED_STORE_IF40:.*]], label %[[PRED_STORE_CONTINUE41:.*]]
+; COST1:       [[PRED_STORE_IF40]]:
+; COST1-NEXT:    store i32 0, ptr [[KEYINFO]], align 4, !alias.scope [[META22]], !noalias [[META15]]
+; COST1-NEXT:    br label %[[PRED_STORE_CONTINUE41]]
+; COST1:       [[PRED_STORE_CONTINUE41]]:
+; COST1-NEXT:    br label %[[LOOP_LATCH42]]
+; COST1:       [[LOOP_LATCH42]]:
+; COST1-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 8
+; COST1-NEXT:    [[TMP22:%.*]] = icmp eq i64 [[INDEX_NEXT]], 32
+; COST1-NEXT:    br i1 [[TMP22]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP23:![0-9]+]]
+; COST1:       [[MIDDLE_BLOCK]]:
+; COST1-NEXT:    br label %[[SCALAR_PH]]
+; COST1:       [[SCALAR_PH]]:
+;
+; COST10-LABEL: define void @loop_with_freeze_and_conditional_srem(
+; COST10-SAME: ptr [[DST:%.*]], ptr [[KEYINFO:%.*]], ptr [[INVARIANT_PTR:%.*]], i32 [[DIVISOR:%.*]]) {
+; COST10-NEXT:  [[ENTRY:.*:]]
+; COST10-NEXT:    br label %[[VECTOR_MEMCHECK:.*]]
+; COST10:       [[VECTOR_MEMCHECK]]:
+; COST10-NEXT:    [[SCEVGEP:%.*]] = getelementptr i8, ptr [[DST]], i64 4
+; COST10-NEXT:    [[SCEVGEP1:%.*]] = getelementptr i8, ptr [[KEYINFO]], i64 4
+; COST10-NEXT:    [[SCEVGEP2:%.*]] = getelementptr i8, ptr [[INVARIANT_PTR]], i64 4
+; COST10-NEXT:    [[BOUND0:%.*]] = icmp ult ptr [[DST]], [[SCEVGEP1]]
+; COST10-NEXT:    [[BOUND1:%.*]] = icmp ult ptr [[KEYINFO]], [[SCEVGEP]]
+; COST10-NEXT:    [[FOUND_CONFLICT:%.*]] = and i1 [[BOUND0]], [[BOUND1]]
+; COST10-NEXT:    [[BOUND03:%.*]] = icmp ult ptr [[DST]], [[SCEVGEP2]]
+; COST10-NEXT:    [[BOUND14:%.*]] = icmp ult ptr [[INVARIANT_PTR]], [[SCEVGEP]]
+; COST10-NEXT:    [[FOUND_CONFLICT5:%.*]] = and i1 [[BOUND03]], [[BOUND14]]
+; COST10-NEXT:    [[CONFLICT_RDX:%.*]] = or i1 [[FOUND_CONFLICT]], [[FOUND_CONFLICT5]]
+; COST10-NEXT:    [[BOUND06:%.*]] = icmp ult ptr [[KEYINFO]], [[SCEVGEP2]]
+; COST10-NEXT:    [[BOUND17:%.*]] = icmp ult ptr [[INVARIANT_PTR]], [[SCEVGEP1]]
+; COST10-NEXT:    [[FOUND_CONFLICT8:%.*]] = and i1 [[BOUND06]], [[BOUND17]]
+; COST10-NEXT:    [[CONFLICT_RDX9:%.*]] = or i1 [[CONFLICT_RDX]], [[FOUND_CONFLICT8]]
+; COST10-NEXT:    br i1 [[CONFLICT_RDX9]], label %[[SCALAR_PH:.*]], label %[[VECTOR_PH:.*]]
+; COST10:       [[VECTOR_PH]]:
+; COST10-NEXT:    br label %[[VECTOR_BODY:.*]]
+; COST10:       [[VECTOR_BODY]]:
+; COST10-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LOOP_LATCH26:.*]] ]
+; COST10-NEXT:    [[TMP0:%.*]] = load i32, ptr [[INVARIANT_PTR]], align 4, !alias.scope [[META15:![0-9]+]]
+; COST10-NEXT:    [[TMP1:%.*]] = freeze i32 [[TMP0]]
+; COST10-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <4 x i32> poison, i32 [[TMP1]], i64 0
+; COST10-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i32> [[BROADCAST_SPLATINSERT]], <4 x i32> poison, <4 x i32> zeroinitializer
+; COST10-NEXT:    [[TMP2:%.*]] = icmp eq <4 x i32> [[BROADCAST_SPLAT]], zeroinitializer
+; COST10-NEXT:    [[TMP3:%.*]] = extractelement <4 x i1> [[TMP2]], i64 0
+; COST10-NEXT:    br i1 [[TMP3]], label %[[IF_ZERO17:.*]], label %[[IF_NONZERO10:.*]]
+; COST10:       [[IF_NONZERO10]]:
+; COST10-NEXT:    [[TMP4:%.*]] = extractelement <4 x i1> [[TMP2]], i64 0
+; COST10-NEXT:    [[TMP5:%.*]] = xor i1 [[TMP4]], true
+; COST10-NEXT:    br i1 [[TMP5]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE:.*]]
+; COST10:       [[PRED_STORE_IF]]:
+; COST10-NEXT:    [[TMP6:%.*]] = srem i32 1, [[DIVISOR]]
+; COST10-NEXT:    store i32 [[TMP6]], ptr [[DST]], align 4, !alias.scope [[META18:![0-9]+]], !noalias [[META20:![0-9]+]]
+; COST10-NEXT:    br label %[[PRED_STORE_CONTINUE]]
+; COST10:       [[PRED_STORE_CONTINUE]]:
+; COST10-NEXT:    br i1 [[TMP5]], label %[[PRED_STORE_IF11:.*]], label %[[PRED_STORE_CONTINUE12:.*]]
+; COST10:       [[PRED_STORE_IF11]]:
+; COST10-NEXT:    [[TMP7:%.*]] = srem i32 1, [[DIVISOR]]
+; COST10-NEXT:    store i32 [[TMP7]], ptr [[DST]], align 4, !alias.scope [[META18]], !noalias [[META20]]
+; COST10-NEXT:    br label %[[PRED_STORE_CONTINUE12]]
+; COST10:       [[PRED_STORE_CONTINUE12]]:
+; COST10-NEXT:    br i1 [[TMP5]], label %[[PRED_STORE_IF13:.*]], label %[[PRED_STORE_CONTINUE14:.*]]
+; COST10:       [[PRED_STORE_IF13]]:
+; COST10-NEXT:    [[TMP8:%.*]] = srem i32 1, [[DIVISOR]]
+; COST10-NEXT:    store i32 [[TMP8]], ptr [[DST]], align 4, !alias.scope [[META18]], !noalias [[META20]]
+; COST10-NEXT:    br label %[[PRED_STORE_CONTINUE14]]
+; COST10:       [[PRED_STORE_CONTINUE14]]:
+; COST10-NEXT:    br i1 [[TMP5]], label %[[PRED_STORE_IF15:.*]], label %[[PRED_STORE_CONTINUE16:.*]]
+; COST10:       [[PRED_STORE_IF15]]:
+; COST10-NEXT:    [[TMP9:%.*]] = srem i32 1, [[DIVISOR]]
+; COST10-NEXT:    store i32 [[TMP9]], ptr [[DST]], align 4, !alias.scope [[META18]], !noalias [[META20]]
+; COST10-NEXT:    br label %[[PRED_STORE_CONTINUE16]]
+; COST10:       [[PRED_STORE_CONTINUE16]]:
+; COST10-NEXT:    br label %[[LOOP_LATCH26]]
+; COST10:       [[IF_ZERO17]]:
+; COST10-NEXT:    [[TMP10:%.*]] = extractelement <4 x i1> [[TMP2]], i64 0
+; COST10-NEXT:    br i1 [[TMP10]], label %[[PRED_STORE_IF18:.*]], label %[[PRED_STORE_CONTINUE19:.*]]
+; COST10:       [[PRED_STORE_IF18]]:
+; COST10-NEXT:    store i32 0, ptr [[KEYINFO]], align 4, !alias.scope [[META22:![0-9]+]], !noalias [[META15]]
+; COST10-NEXT:    br label %[[PRED_STORE_CONTINUE19]]
+; COST10:       [[PRED_STORE_CONTINUE19]]:
+; COST10-NEXT:    [[TMP11:%.*]] = extractelement <4 x i1> [[TMP2]], i64 0
+; COST10-NEXT:    br i1 [[TMP11]], label %[[PRED_STORE_IF20:.*]], label %[[PRED_STORE_CONTINUE21:.*]]
+; COST10:       [[PRED_STORE_IF20]]:
+; COST10-NEXT:    store i32 0, ptr [[KEYINFO]], align 4, !alias.scope [[META22]], !noalias [[META15]]
+; COST10-NEXT:    br label %[[PRED_STORE_CONTINUE21]]
+; COST10:       [[PRED_STORE_CONTINUE21]]:
+; COST10-NEXT:    [[TMP12:%.*]] = extractelement <4 x i1> [[TMP2]], i64 0
+; COST10-NEXT:    br i1 [[TMP12]], label %[[PRED_STORE_IF22:.*]], label %[[PRED_STORE_CONTINUE23:.*]]
+; COST10:       [[PRED_STORE_IF22]]:
+; COST10-NEXT:    store i32 0, ptr [[KEYINFO]], align 4, !alias.scope [[META22]], !noalias [[META15]]
+; COST10-NEXT:    br label %[[PRED_STORE_CONTINUE23]]
+; COST10:       [[PRED_STORE_CONTINUE23]]:
+; COST10-NEXT:    [[TMP13:%.*]] = extractelement <4 x i1> [[TMP2]], i64 0
+; COST10-NEXT:    br i1 [[TMP13]], label %[[PRED_STORE_IF24:.*]], label %[[PRED_STORE_CONTINUE25:.*]]
+; COST10:       [[PRED_STORE_IF24]]:
+; COST10-NEXT:    store i32 0, ptr [[KEYINFO]], align 4, !alias.scope [[META22]], !noalias [[META15]]
+; COST10-NEXT:    br label %[[PRED_STORE_CONTINUE25]]
+; COST10:       [[PRED_STORE_CONTINUE25]]:
+; COST10-NEXT:    br label %[[LOOP_LATCH26]]
+; COST10:       [[LOOP_LATCH26]]:
+; COST10-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
+; COST10-NEXT:    [[TMP14:%.*]] = icmp eq i64 [[INDEX_NEXT]], 32
+; COST10-NEXT:    br i1 [[TMP14]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP23:![0-9]+]]
+; COST10:       [[MIDDLE_BLOCK]]:
+; COST10-NEXT:    br label %[[SCALAR_PH]]
+; COST10:       [[SCALAR_PH]]:
 ;
 entry:
   br label %loop
@@ -469,7 +679,7 @@ define void @interleave_group(ptr %dst) #1 {
 ; COST1-NEXT:    store <vscale x 48 x i8> [[INTERLEAVED_VEC1]], ptr [[TMP4]], align 1
 ; COST1-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], [[TMP25]]
 ; COST1-NEXT:    [[TMP29:%.*]] = icmp eq i64 [[INDEX_NEXT]], [[N_VEC]]
-; COST1-NEXT:    br i1 [[TMP29]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP15:![0-9]+]]
+; COST1-NEXT:    br i1 [[TMP29]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP25:![0-9]+]]
 ; COST1:       [[MIDDLE_BLOCK]]:
 ; COST1-NEXT:    [[CMP_N:%.*]] = icmp eq i64 101, [[N_VEC]]
 ; COST1-NEXT:    br i1 [[CMP_N]], [[EXIT:label %.*]], label %[[VEC_EPILOG_ITER_CHECK:.*]]
@@ -517,7 +727,7 @@ define void @interleave_group(ptr %dst) #1 {
 ; COST1-NEXT:    [[INDEX_NEXT2]] = add nuw i64 [[INDEX1]], 4
 ; COST1-NEXT:    [[VEC_IND_NEXT]] = add <4 x i64> [[VEC_IND]], splat (i64 4)
 ; COST1-NEXT:    [[TMP23:%.*]] = icmp eq i64 [[INDEX_NEXT2]], 100
-; COST1-NEXT:    br i1 [[TMP23]], label %[[VEC_EPILOG_MIDDLE_BLOCK:.*]], label %[[VEC_EPILOG_VECTOR_BODY]], !llvm.loop [[LOOP16:![0-9]+]]
+; COST1-NEXT:    br i1 [[TMP23]], label %[[VEC_EPILOG_MIDDLE_BLOCK:.*]], label %[[VEC_EPILOG_VECTOR_BODY]], !llvm.loop [[LOOP26:![0-9]+]]
 ; COST1:       [[VEC_EPILOG_MIDDLE_BLOCK]]:
 ; COST1-NEXT:    br i1 false, [[EXIT]], label %[[VEC_EPILOG_SCALAR_PH]]
 ; COST1:       [[VEC_EPILOG_SCALAR_PH]]:
@@ -543,7 +753,7 @@ define void @interleave_group(ptr %dst) #1 {
 ; COST10-NEXT:    store <vscale x 48 x i8> [[INTERLEAVED_VEC]], ptr [[TMP1]], align 1
 ; COST10-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], [[TMP22]]
 ; COST10-NEXT:    [[TMP23:%.*]] = icmp eq i64 [[INDEX_NEXT]], [[N_VEC]]
-; COST10-NEXT:    br i1 [[TMP23]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP15:![0-9]+]]
+; COST10-NEXT:    br i1 [[TMP23]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP25:![0-9]+]]
 ; COST10:       [[MIDDLE_BLOCK]]:
 ; COST10-NEXT:    [[CMP_N:%.*]] = icmp eq i64 101, [[N_VEC]]
 ; COST10-NEXT:    br i1 [[CMP_N]], [[EXIT:label %.*]], label %[[VEC_EPILOG_ITER_CHECK:.*]]
@@ -591,7 +801,7 @@ define void @interleave_group(ptr %dst) #1 {
 ; COST10-NEXT:    [[INDEX_NEXT2]] = add nuw i64 [[INDEX1]], 4
 ; COST10-NEXT:    [[VEC_IND_NEXT]] = add <4 x i64> [[VEC_IND]], splat (i64 4)
 ; COST10-NEXT:    [[TMP20:%.*]] = icmp eq i64 [[INDEX_NEXT2]], 100
-; COST10-NEXT:    br i1 [[TMP20]], label %[[VEC_EPILOG_MIDDLE_BLOCK:.*]], label %[[VEC_EPILOG_VECTOR_BODY]], !llvm.loop [[LOOP16:![0-9]+]]
+; COST10-NEXT:    br i1 [[TMP20]], label %[[VEC_EPILOG_MIDDLE_BLOCK:.*]], label %[[VEC_EPILOG_VECTOR_BODY]], !llvm.loop [[LOOP26:![0-9]+]]
 ; COST10:       [[VEC_EPILOG_MIDDLE_BLOCK]]:
 ; COST10-NEXT:    br i1 false, [[EXIT]], label %[[VEC_EPILOG_SCALAR_PH]]
 ; COST10:       [[VEC_EPILOG_SCALAR_PH]]:
@@ -669,7 +879,7 @@ define void @forced_scalar_instr(ptr %gep.dst) {
 ; COMMON-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
 ; COMMON-NEXT:    [[VEC_IND_NEXT]] = add nuw <4 x i8> [[VEC_IND]], splat (i8 4)
 ; COMMON-NEXT:    [[TMP22:%.*]] = icmp eq i64 [[INDEX_NEXT]], 8
-; COMMON-NEXT:    br i1 [[TMP22]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP18:![0-9]+]]
+; COMMON-NEXT:    br i1 [[TMP22]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP28:![0-9]+]]
 ; COMMON:       [[MIDDLE_BLOCK]]:
 ; COMMON-NEXT:    br label %[[EXIT:.*]]
 ; COMMON:       [[EXIT]]:
@@ -740,18 +950,18 @@ define void @force_branch_cost(ptr readonly %src, ptr %dst) {
 ; COST1-NEXT:    [[TMP22:%.*]] = getelementptr [4 x i8], ptr [[SRC]], i64 [[TMP6]]
 ; COST1-NEXT:    [[TMP23:%.*]] = getelementptr [4 x i8], ptr [[SRC]], i64 [[TMP7]]
 ; COST1-NEXT:    [[TMP24:%.*]] = getelementptr [4 x i8], ptr [[SRC]], i64 [[TMP8]]
-; COST1-NEXT:    [[TMP25:%.*]] = load i8, ptr [[TMP17]], align 1, !alias.scope [[META19:![0-9]+]]
-; COST1-NEXT:    [[TMP26:%.*]] = load i8, ptr [[TMP18]], align 1, !alias.scope [[META19]]
-; COST1-NEXT:    [[TMP27:%.*]] = load i8, ptr [[TMP19]], align 1, !alias.scope [[META19]]
-; COST1-NEXT:    [[TMP28:%.*]] = load i8, ptr [[TMP20]], align 1, !alias.scope [[META19]]
+; COST1-NEXT:    [[TMP25:%.*]] = load i8, ptr [[TMP17]], align 1, !alias.scope [[META29:![0-9]+]]
+; COST1-NEXT:    [[TMP26:%.*]] = load i8, ptr [[TMP18]], align 1, !alias.scope [[META29]]
+; COST1-NEXT:    [[TMP27:%.*]] = load i8, ptr [[TMP19]], align 1, !alias.scope [[META29]]
+; COST1-NEXT:    [[TMP28:%.*]] = load i8, ptr [[TMP20]], align 1, !alias.scope [[META29]]
 ; COST1-NEXT:    [[TMP29:%.*]] = insertelement <4 x i8> poison, i8 [[TMP25]], i64 0
 ; COST1-NEXT:    [[TMP30:%.*]] = insertelement <4 x i8> [[TMP29]], i8 [[TMP26]], i64 1
 ; COST1-NEXT:    [[TMP31:%.*]] = insertelement <4 x i8> [[TMP30]], i8 [[TMP27]], i64 2
 ; COST1-NEXT:    [[TMP32:%.*]] = insertelement <4 x i8> [[TMP31]], i8 [[TMP28]], i64 3
-; COST1-NEXT:    [[TMP33:%.*]] = load i8, ptr [[TMP21]], align 1, !alias.scope [[META19]]
-; COST1-NEXT:    [[TMP34:%.*]] = load i8, ptr [[TMP22]], align 1, !alias.scope [[META19]]
-; COST1-NEXT:    [[TMP35:%.*]] = load i8, ptr [[TMP23]], align 1, !alias.scope [[META19]]
-; COST1-NEXT:    [[TMP36:%.*]] = load i8, ptr [[TMP24]], align 1, !alias.scope [[META19]]
+; COST1-NEXT:    [[TMP33:%.*]] = load i8, ptr [[TMP21]], align 1, !alias.scope [[META29]]
+; COST1-NEXT:    [[TMP34:%.*]] = load i8, ptr [[TMP22]], align 1, !alias.scope [[META29]]
+; COST1-NEXT:    [[TMP35:%.*]] = load i8, ptr [[TMP23]], align 1, !alias.scope [[META29]]
+; COST1-NEXT:    [[TMP36:%.*]] = load i8, ptr [[TMP24]], align 1, !alias.scope [[META29]]
 ; COST1-NEXT:    [[TMP37:%.*]] = insertelement <4 x i8> poison, i8 [[TMP33]], i64 0
 ; COST1-NEXT:    [[TMP38:%.*]] = insertelement <4 x i8> [[TMP37]], i8 [[TMP34]], i64 1
 ; COST1-NEXT:    [[TMP39:%.*]] = insertelement <4 x i8> [[TMP38]], i8 [[TMP35]], i64 2
@@ -759,21 +969,21 @@ define void @force_branch_cost(ptr readonly %src, ptr %dst) {
 ; COST1-NEXT:    [[TMP41:%.*]] = zext <4 x i8> [[TMP32]] to <4 x i32>
 ; COST1-NEXT:    [[TMP46:%.*]] = zext <4 x i8> [[TMP40]] to <4 x i32>
 ; COST1-NEXT:    [[TMP44:%.*]] = extractelement <4 x i32> [[TMP41]], i64 0
-; COST1-NEXT:    store i32 [[TMP44]], ptr [[NEXT_GEP]], align 4, !alias.scope [[META22:![0-9]+]], !noalias [[META19]]
+; COST1-NEXT:    store i32 [[TMP44]], ptr [[NEXT_GEP]], align 4, !alias.scope [[META32:![0-9]+]], !noalias [[META29]]
 ; COST1-NEXT:    [[TMP49:%.*]] = extractelement <4 x i32> [[TMP41]], i64 1
-; COST1-NEXT:    store i32 [[TMP49]], ptr [[NEXT_GEP2]], align 4, !alias.scope [[META22]], !noalias [[META19]]
+; COST1-NEXT:    store i32 [[TMP49]], ptr [[NEXT_GEP2]], align 4, !alias.scope [[META32]], !noalias [[META29]]
 ; COST1-NEXT:    [[TMP42:%.*]] = extractelement <4 x i32> [[TMP41]], i64 2
-; COST1-NEXT:    store i32 [[TMP42]], ptr [[NEXT_GEP3]], align 4, !alias.scope [[META22]], !noalias [[META19]]
+; COST1-NEXT:    store i32 [[TMP42]], ptr [[NEXT_GEP3]], align 4, !alias.scope [[META32]], !noalias [[META29]]
 ; COST1-NEXT:    [[TMP43:%.*]] = extractelement <4 x i32> [[TMP41]], i64 3
-; COST1-NEXT:    store i32 [[TMP43]], ptr [[NEXT_GEP4]], align 4, !alias.scope [[META22]], !noalias [[META19]]
+; COST1-NEXT:    store i32 [[TMP43]], ptr [[NEXT_GEP4]], align 4, !alias.scope [[META32]], !noalias [[META29]]
 ; COST1-NEXT:    [[TMP45:%.*]] = extractelement <4 x i32> [[TMP46]], i64 0
-; COST1-NEXT:    store i32 [[TMP45]], ptr [[NEXT_GEP5]], align 4, !alias.scope [[META22]], !noalias [[META19]]
+; COST1-NEXT:    store i32 [[TMP45]], ptr [[NEXT_GEP5]], align 4, !alias.scope [[META32]], !noalias [[META29]]
 ; COST1-NEXT:    [[TMP50:%.*]] = extractelement <4 x i32> [[TMP46]], i64 1
-; COST1-NEXT:    store i32 [[TMP50]], ptr [[NEXT_GEP6]], align 4, !alias.scope [[META22]], !noalias [[META19]]
+; COST1-NEXT:    store i32 [[TMP50]], ptr [[NEXT_GEP6]], align 4, !alias.scope [[META32]], !noalias [[META29]]
 ; COST1-NEXT:    [[TMP47:%.*]] = extractelement <4 x i32> [[TMP46]], i64 2
-; COST1-NEXT:    store i32 [[TMP47]], ptr [[NEXT_GEP7]], align 4, !alias.scope [[META22]], !noalias [[META19]]
+; COST1-NEXT:    store i32 [[TMP47]], ptr [[NEXT_GEP7]], align 4, !alias.scope [[META32]], !noalias [[META29]]
 ; COST1-NEXT:    [[TMP48:%.*]] = extractelement <4 x i32> [[TMP46]], i64 3
-; COST1-NEXT:    store i32 [[TMP48]], ptr [[NEXT_GEP8]], align 4, !alias.scope [[META22]], !noalias [[META19]]
+; COST1-NEXT:    store i32 [[TMP48]], ptr [[NEXT_GEP8]], align 4, !alias.scope [[META32]], !noalias [[META29]]
 ; COST1-NEXT:    [[TMP51:%.*]] = getelementptr i8, ptr [[NEXT_GEP]], i64 24
 ; COST1-NEXT:    [[TMP52:%.*]] = getelementptr i8, ptr [[NEXT_GEP2]], i64 24
 ; COST1-NEXT:    [[TMP53:%.*]] = getelementptr i8, ptr [[NEXT_GEP3]], i64 24
@@ -782,14 +992,14 @@ define void @force_branch_cost(ptr readonly %src, ptr %dst) {
 ; COST1-NEXT:    [[TMP56:%.*]] = getelementptr i8, ptr [[NEXT_GEP6]], i64 24
 ; COST1-NEXT:    [[TMP57:%.*]] = getelementptr i8, ptr [[NEXT_GEP7]], i64 24
 ; COST1-NEXT:    [[TMP58:%.*]] = getelementptr i8, ptr [[NEXT_GEP8]], i64 24
-; COST1-NEXT:    store i32 [[TMP44]], ptr [[TMP51]], align 4, !alias.scope [[META22]], !noalias [[META19]]
-; COST1-NEXT:    store i32 [[TMP49]], ptr [[TMP52]], align 4, !alias.scope [[META22]], !noalias [[META19]]
-; COST1-NEXT:    store i32 [[TMP42]], ptr [[TMP53]], align 4, !alias.scope [[META22]], !noalias [[META19]]
-; COST1-NEXT:    store i32 [[TMP43]], ptr [[TMP54]], align 4, !alias.scope [[META22]], !noalias [[META19]]
-; COST1-NEXT:    store i32 [[TMP45]], ptr [[TMP55]], align 4, !alias.scope [[META22]], !noalias [[META19]]
-; COST1-NEXT:    store i32 [[TMP50]], ptr [[TMP56]], align 4, !alias.scope [[META22]], !noalias [[META19]]
-; COST1-NEXT:    store i32 [[TMP47]], ptr [[TMP57]], align 4, !alias.scope [[META22]], !noalias [[META19]]
-; COST1-NEXT:    store i32 [[TMP48]], ptr [[TMP58]], align 4, !alias.scope [[META22]], !noalias [[META19]]
+; COST1-NEXT:    store i32 [[TMP44]], ptr [[TMP51]], align 4, !alias.scope [[META32]], !noalias [[META29]]
+; COST1-NEXT:    store i32 [[TMP49]], ptr [[TMP52]], align 4, !alias.scope [[META32]], !noalias [[META29]]
+; COST1-NEXT:    store i32 [[TMP42]], ptr [[TMP53]], align 4, !alias.scope [[META32]], !noalias [[META29]]
+; COST1-NEXT:    store i32 [[TMP43]], ptr [[TMP54]], align 4, !alias.scope [[META32]], !noalias [[META29]]
+; COST1-NEXT:    store i32 [[TMP45]], ptr [[TMP55]], align 4, !alias.scope [[META32]], !noalias [[META29]]
+; COST1-NEXT:    store i32 [[TMP50]], ptr [[TMP56]], align 4, !alias.scope [[META32]], !noalias [[META29]]
+; COST1-NEXT:    store i32 [[TMP47]], ptr [[TMP57]], align 4, !alias.scope [[META32]], !noalias [[META29]]
+; COST1-NEXT:    store i32 [[TMP48]], ptr [[TMP58]], align 4, !alias.scope [[META32]], !noalias [[META29]]
 ; COST1-NEXT:    [[TMP59:%.*]] = getelementptr i8, ptr [[NEXT_GEP]], i64 48
 ; COST1-NEXT:    [[TMP60:%.*]] = getelementptr i8, ptr [[NEXT_GEP2]], i64 48
 ; COST1-NEXT:    [[TMP61:%.*]] = getelementptr i8, ptr [[NEXT_GEP3]], i64 48
@@ -798,14 +1008,14 @@ define void @force_branch_cost(ptr readonly %src, ptr %dst) {
 ; COST1-NEXT:    [[TMP64:%.*]] = getelementptr i8, ptr [[NEXT_GEP6]], i64 48
 ; COST1-NEXT:    [[TMP65:%.*]] = getelementptr i8, ptr [[NEXT_GEP7]], i64 48
 ; COST1-NEXT:    [[TMP66:%.*]] = getelementptr i8, ptr [[NEXT_GEP8]], i64 48
-; COST1-NEXT:    store i32 [[TMP44]], ptr [[TMP59]], align 4, !alias.scope [[META22]], !noalias [[META19]]
-; COST1-NEXT:    store i32 [[TMP49]], ptr [[TMP60]], align 4, !alias.scope [[META22]], !noalias [[META19]]
-; COST1-NEXT:    store i32 [[TMP42]], ptr [[TMP61]], align 4, !alias.scope [[META22]], !noalias [[META19]]
-; COST1-NEXT:    store i32 [[TMP43]], ptr [[TMP62]], align 4, !alias.scope [[META22]], !noalias [[META19]]
-; COST1-NEXT:    store i32 [[TMP45]], ptr [[TMP63]], align 4, !alias.scope [[META22]], !noalias [[META19]]
-; COST1-NEXT:    store i32 [[TMP50]], ptr [[TMP64]], align 4, !alias.scope [[META22]], !noalias [[META19]]
-; COST1-NEXT:    store i32 [[TMP47]], ptr [[TMP65]], align 4, !alias.scope [[META22]], !noalias [[META19]]
-; COST1-NEXT:    store i32 [[TMP48]], ptr [[TMP66]], align 4, !alias.scope [[META22]], !noalias [[META19]]
+; COST1-NEXT:    store i32 [[TMP44]], ptr [[TMP59]], align 4, !alias.scope [[META32]], !noalias [[META29]]
+; COST1-NEXT:    store i32 [[TMP49]], ptr [[TMP60]], align 4, !alias.scope [[META32]], !noalias [[META29]]
+; COST1-NEXT:    store i32 [[TMP42]], ptr [[TMP61]], align 4, !alias.scope [[META32]], !noalias [[META29]]
+; COST1-NEXT:    store i32 [[TMP43]], ptr [[TMP62]], align 4, !alias.scope [[META32]], !noalias [[META29]]
+; COST1-NEXT:    store i32 [[TMP45]], ptr [[TMP63]], align 4, !alias.scope [[META32]], !noalias [[META29]]
+; COST1-NEXT:    store i32 [[TMP50]], ptr [[TMP64]], align 4, !alias.scope [[META32]], !noalias [[META29]]
+; COST1-NEXT:    store i32 [[TMP47]], ptr [[TMP65]], align 4, !alias.scope [[META32]], !noalias [[META29]]
+; COST1-NEXT:    store i32 [[TMP48]], ptr [[TMP66]], align 4, !alias.scope [[META32]], !noalias [[META29]]
 ; COST1-NEXT:    [[TMP67:%.*]] = getelementptr i8, ptr [[NEXT_GEP]], i64 72
 ; COST1-NEXT:    [[TMP68:%.*]] = getelementptr i8, ptr [[NEXT_GEP2]], i64 72
 ; COST1-NEXT:    [[TMP69:%.*]] = getelementptr i8, ptr [[NEXT_GEP3]], i64 72
@@ -814,17 +1024,17 @@ define void @force_branch_cost(ptr readonly %src, ptr %dst) {
 ; COST1-NEXT:    [[TMP72:%.*]] = getelementptr i8, ptr [[NEXT_GEP6]], i64 72
 ; COST1-NEXT:    [[TMP73:%.*]] = getelementptr i8, ptr [[NEXT_GEP7]], i64 72
 ; COST1-NEXT:    [[TMP74:%.*]] = getelementptr i8, ptr [[NEXT_GEP8]], i64 72
-; COST1-NEXT:    store i32 [[TMP44]], ptr [[TMP67]], align 4, !alias.scope [[META22]], !noalias [[META19]]
-; COST1-NEXT:    store i32 [[TMP49]], ptr [[TMP68]], align 4, !alias.scope [[META22]], !noalias [[META19]]
-; COST1-NEXT:    store i32 [[TMP42]], ptr [[TMP69]], align 4, !alias.scope [[META22]], !noalias [[META19]]
-; COST1-NEXT:    store i32 [[TMP43]], ptr [[TMP70]], align 4, !alias.scope [[META22]], !noalias [[META19]]
-; COST1-NEXT:    store i32 [[TMP45]], ptr [[TMP71]], align 4, !alias.scope [[META22]], !noalias [[META19]]
-; COST1-NEXT:    store i32 [[TMP50]], ptr [[TMP72]], align 4, !alias.scope [[META22]], !noalias [[META19]]
-; COST1-NEXT:    store i32 [[TMP47]], ptr [[TMP73]], align 4, !alias.scope [[META22]], !noalias [[META19]]
-; COST1-NEXT:    store i32 [[TMP48]], ptr [[TMP74]], align 4, !alias.scope [[META22]], !noalias [[META19]]
+; COST1-NEXT:    store i32 [[TMP44]], ptr [[TMP67]], align 4, !alias.scope [[META32]], !noalias [[META29]]
+; COST1-NEXT:    store i32 [[TMP49]], ptr [[TMP68]], align 4, !alias.scope [[META32]], !noalias [[META29]]
+; COST1-NEXT:    store i32 [[TMP42]], ptr [[TMP69]], align 4, !alias.scope [[META32]], !noalias [[META29]]
+; COST1-NEXT:    store i32 [[TMP43]], ptr [[TMP70]], align 4, !alias.scope [[META32]], !noalias [[META29]]
+; COST1-NEXT:    store i32 [[TMP45]], ptr [[TMP71]], align 4, !alias.scope [[META32]], !noalias [[META29]]
+; COST1-NEXT:    store i32 [[TMP50]], ptr [[TMP72]], align 4, !alias.scope [[META32]], !noalias [[META29]]
+; COST1-NEXT:    store i32 [[TMP47]], ptr [[TMP73]], align 4, !alias.scope [[META32]], !noalias [[META29]]
+; COST1-NEXT:    store i32 [[TMP48]], ptr [[TMP74]], align 4, !alias.scope [[META32]], !noalias [[META29]]
 ; COST1-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 8
 ; COST1-NEXT:    [[TMP75:%.*]] = icmp eq i64 [[INDEX_NEXT]], 16
-; COST1-NEXT:    br i1 [[TMP75]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP24:![0-9]+]]
+; COST1-NEXT:    br i1 [[TMP75]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP34:![0-9]+]]
 ; COST1:       [[MIDDLE_BLOCK]]:
 ; COST1-NEXT:    br label %[[SCALAR_PH]]
 ; COST1:       [[SCALAR_PH]]:
@@ -860,50 +1070,50 @@ define void @force_branch_cost(ptr readonly %src, ptr %dst) {
 ; COST10-NEXT:    [[TMP10:%.*]] = getelementptr [4 x i8], ptr [[SRC]], i64 [[TMP2]]
 ; COST10-NEXT:    [[TMP11:%.*]] = getelementptr [4 x i8], ptr [[SRC]], i64 [[TMP3]]
 ; COST10-NEXT:    [[TMP12:%.*]] = getelementptr [4 x i8], ptr [[SRC]], i64 [[TMP4]]
-; COST10-NEXT:    [[TMP13:%.*]] = load i8, ptr [[TMP9]], align 1, !alias.scope [[META19:![0-9]+]]
-; COST10-NEXT:    [[TMP14:%.*]] = load i8, ptr [[TMP10]], align 1, !alias.scope [[META19]]
-; COST10-NEXT:    [[TMP15:%.*]] = load i8, ptr [[TMP11]], align 1, !alias.scope [[META19]]
-; COST10-NEXT:    [[TMP16:%.*]] = load i8, ptr [[TMP12]], align 1, !alias.scope [[META19]]
+; COST10-NEXT:    [[TMP13:%.*]] = load i8, ptr [[TMP9]], align 1, !alias.scope [[META29:![0-9]+]]
+; COST10-NEXT:    [[TMP14:%.*]] = load i8, ptr [[TMP10]], align 1, !alias.scope [[META29]]
+; COST10-NEXT:    [[TMP15:%.*]] = load i8, ptr [[TMP11]], align 1, !alias.scope [[META29]]
+; COST10-NEXT:    [[TMP16:%.*]] = load i8, ptr [[TMP12]], align 1, !alias.scope [[META29]]
 ; COST10-NEXT:    [[TMP17:%.*]] = insertelement <4 x i8> poison, i8 [[TMP13]], i64 0
 ; COST10-NEXT:    [[TMP18:%.*]] = insertelement <4 x i8> [[TMP17]], i8 [[TMP14]], i64 1
 ; COST10-NEXT:    [[TMP19:%.*]] = insertelement <4 x i8> [[TMP18]], i8 [[TMP15]], i64 2
 ; COST10-NEXT:    [[TMP20:%.*]] = insertelement <4 x i8> [[TMP19]], i8 [[TMP16]], i64 3
 ; COST10-NEXT:    [[TMP21:%.*]] = zext <4 x i8> [[TMP20]] to <4 x i32>
 ; COST10-NEXT:    [[TMP24:%.*]] = extractelement <4 x i32> [[TMP21]], i64 0
-; COST10-NEXT:    store i32 [[TMP24]], ptr [[NEXT_GEP]], align 4, !alias.scope [[META22:![0-9]+]], !noalias [[META19]]
+; COST10-NEXT:    store i32 [[TMP24]], ptr [[NEXT_GEP]], align 4, !alias.scope [[META32:![0-9]+]], !noalias [[META29]]
 ; COST10-NEXT:    [[TMP25:%.*]] = extractelement <4 x i32> [[TMP21]], i64 1
-; COST10-NEXT:    store i32 [[TMP25]], ptr [[NEXT_GEP2]], align 4, !alias.scope [[META22]], !noalias [[META19]]
+; COST10-NEXT:    store i32 [[TMP25]], ptr [[NEXT_GEP2]], align 4, !alias.scope [[META32]], !noalias [[META29]]
 ; COST10-NEXT:    [[TMP22:%.*]] = extractelement <4 x i32> [[TMP21]], i64 2
-; COST10-NEXT:    store i32 [[TMP22]], ptr [[NEXT_GEP3]], align 4, !alias.scope [[META22]], !noalias [[META19]]
+; COST10-NEXT:    store i32 [[TMP22]], ptr [[NEXT_GEP3]], align 4, !alias.scope [[META32]], !noalias [[META29]]
 ; COST10-NEXT:    [[TMP23:%.*]] = extractelement <4 x i32> [[TMP21]], i64 3
-; COST10-NEXT:    store i32 [[TMP23]], ptr [[NEXT_GEP4]], align 4, !alias.scope [[META22]], !noalias [[META19]]
+; COST10-NEXT:    store i32 [[TMP23]], ptr [[NEXT_GEP4]], align 4, !alias.scope [[META32]], !noalias [[META29]]
 ; COST10-NEXT:    [[TMP26:%.*]] = getelementptr i8, ptr [[NEXT_GEP]], i64 24
 ; COST10-NEXT:    [[TMP27:%.*]] = getelementptr i8, ptr [[NEXT_GEP2]], i64 24
 ; COST10-NEXT:    [[TMP28:%.*]] = getelementptr i8, ptr [[NEXT_GEP3]], i64 24
 ; COST10-NEXT:    [[TMP29:%.*]] = getelementptr i8, ptr [[NEXT_GEP4]], i64 24
-; COST10-NEXT:    store i32 [[TMP24]], ptr [[TMP26]], align 4, !alias.scope [[META22]], !noalias [[META19]]
-; COST10-NEXT:    store i32 [[TMP25]], ptr [[TMP27]], align 4, !alias.scope [[META22]], !noalias [[META19]]
-; COST10-NEXT:    store i32 [[TMP22]], ptr [[TMP28]], align 4, !alias.scope [[META22]], !noalias [[META19]]
-; COST10-NEXT:    store i32 [[TMP23]], ptr [[TMP29]], align 4, !alias.scope [[META22]], !noalias [[META19]]
+; COST10-NEXT:    store i32 [[TMP24]], ptr [[TMP26]], align 4, !alias.scope [[META32]], !noalias [[META29]]
+; COST10-NEXT:    store i32 [[TMP25]], ptr [[TMP27]], align 4, !alias.scope [[META32]], !noalias [[META29]]
+; COST10-NEXT:    store i32 [[TMP22]], ptr [[TMP28]], align 4, !alias.scope [[META32]], !noalias [[META29]]
+; COST10-NEXT:    store i32 [[TMP23]], ptr [[TMP29]], align 4, !alias.scope [[META32]], !noalias [[META29]]
 ; COST10-NEXT:    [[TMP30:%.*]] = getelementptr i8, ptr [[NEXT_GEP]], i64 48
 ; COST10-NEXT:    [[TMP31:%.*]] = getelementptr i8, ptr [[NEXT_GEP2]], i64 48
 ; COST10-NEXT:    [[TMP32:%.*]] = getelementptr i8, ptr [[NEXT_GEP3]], i64 48
 ; COST10-NEXT:    [[TMP33:%.*]] = getelementptr i8, ptr [[NEXT_GEP4]], i64 48
-; COST10-NEXT:    store i32 [[TMP24]], ptr [[TMP30]], align 4, !alias.scope [[META22]], !noalias [[META19]]
-; COST10-NEXT:    store i32 [[TMP25]], ptr [[TMP31]], align 4, !alias.scope [[META22]], !noalias [[META19]]
-; COST10-NEXT:    store i32 [[TMP22]], ptr [[TMP32]], align 4, !alias.scope [[META22]], !noalias [[META19]]
-; COST10-NEXT:    store i32 [[TMP23]], ptr [[TMP33]], align 4, !alias.scope [[META22]], !noalias [[META19]]
+; COST10-NEXT:    store i32 [[TMP24]], ptr [[TMP30]], align 4, !alias.scope [[META32]], !noalias [[META29]]
+; COST10-NEXT:    store i32 [[TMP25]], ptr [[TMP31]], align 4, !alias.scope [[META32]], !noalias [[META29]]
+; COST10-NEXT:    store i32 [[TMP22]], ptr [[TMP32]], align 4, !alias.scope [[META32]], !noalias [[META29]]
+; COST10-NEXT:    store i32 [[TMP23]], ptr [[TMP33]], align 4, !alias.scope [[META32]], !noalias [[META29]]
 ; COST10-NEXT:    [[TMP34:%.*]] = getelementptr i8, ptr [[NEXT_GEP]], i64 72
 ; COST10-NEXT:    [[TMP35:%.*]] = getelementptr i8, ptr [[NEXT_GEP2]], i64 72
 ; COST10-NEXT:    [[TMP36:%.*]] = getelementptr i8, ptr [[NEXT_GEP3]], i64 72
 ; COST10-NEXT:    [[TMP37:%.*]] = getelementptr i8, ptr [[NEXT_GEP4]], i64 72
-; COST10-NEXT:    store i32 [[TMP24]], ptr [[TMP34]], align 4, !alias.scope [[META22]], !noalias [[META19]]
-; COST10-NEXT:    store i32 [[TMP25]], ptr [[TMP35]], align 4, !alias.scope [[META22]], !noalias [[META19]]
-; COST10-NEXT:    store i32 [[TMP22]], ptr [[TMP36]], align 4, !alias.scope [[META22]], !noalias [[META19]]
-; COST10-NEXT:    store i32 [[TMP23]], ptr [[TMP37]], align 4, !alias.scope [[META22]], !noalias [[META19]]
+; COST10-NEXT:    store i32 [[TMP24]], ptr [[TMP34]], align 4, !alias.scope [[META32]], !noalias [[META29]]
+; COST10-NEXT:    store i32 [[TMP25]], ptr [[TMP35]], align 4, !alias.scope [[META32]], !noalias [[META29]]
+; COST10-NEXT:    store i32 [[TMP22]], ptr [[TMP36]], align 4, !alias.scope [[META32]], !noalias [[META29]]
+; COST10-NEXT:    store i32 [[TMP23]], ptr [[TMP37]], align 4, !alias.scope [[META32]], !noalias [[META29]]
 ; COST10-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
 ; COST10-NEXT:    [[TMP38:%.*]] = icmp eq i64 [[INDEX_NEXT]], 20
-; COST10-NEXT:    br i1 [[TMP38]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP24:![0-9]+]]
+; COST10-NEXT:    br i1 [[TMP38]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP34:![0-9]+]]
 ; COST10:       [[MIDDLE_BLOCK]]:
 ; COST10-NEXT:    br label %[[SCALAR_PH]]
 ; COST10:       [[SCALAR_PH]]:

--- a/llvm/test/Transforms/LoopVectorize/AArch64/invariant-replicate-region.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/invariant-replicate-region.ll
@@ -11,23 +11,27 @@ define i32 @test_invariant_replicate_region(i32 %x, i1 %c) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    br label %[[VECTOR_PH:.*]]
 ; CHECK:       [[VECTOR_PH]]:
+; CHECK-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <4 x i1> poison, i1 [[C]], i64 0
+; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT]], <4 x i1> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_UREM_CONTINUE6:.*]] ]
-; CHECK-NEXT:    br i1 [[C]], label %[[PRED_UREM_IF:.*]], label %[[PRED_UREM_CONTINUE:.*]]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_UREM_CONTINUE:.*]] ]
+; CHECK-NEXT:    br i1 [[C]], label %[[PRED_UREM_IF:.*]], label %[[PRED_UREM_CONTINUE]]
 ; CHECK:       [[PRED_UREM_IF]]:
+; CHECK-NEXT:    br i1 [[C]], label %[[PRED_UREM_IF2:.*]], label %[[PRED_UREM_CONTINUE1:.*]]
+; CHECK:       [[PRED_UREM_IF2]]:
 ; CHECK-NEXT:    [[TMP1:%.*]] = urem i32 10, [[X]]
 ; CHECK-NEXT:    [[TMP3:%.*]] = insertelement <4 x i32> poison, i32 [[TMP1]], i64 0
-; CHECK-NEXT:    br label %[[PRED_UREM_CONTINUE]]
-; CHECK:       [[PRED_UREM_CONTINUE]]:
-; CHECK-NEXT:    [[TMP2:%.*]] = phi <4 x i32> [ poison, %[[VECTOR_BODY]] ], [ [[TMP3]], %[[PRED_UREM_IF]] ]
+; CHECK-NEXT:    br label %[[PRED_UREM_CONTINUE1]]
+; CHECK:       [[PRED_UREM_CONTINUE1]]:
+; CHECK-NEXT:    [[TMP2:%.*]] = phi <4 x i32> [ poison, %[[PRED_UREM_IF]] ], [ [[TMP3]], %[[PRED_UREM_IF2]] ]
 ; CHECK-NEXT:    br i1 [[C]], label %[[PRED_UREM_IF1:.*]], label %[[PRED_UREM_CONTINUE2:.*]]
 ; CHECK:       [[PRED_UREM_IF1]]:
 ; CHECK-NEXT:    [[TMP5:%.*]] = urem i32 10, [[X]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = insertelement <4 x i32> [[TMP2]], i32 [[TMP5]], i64 1
 ; CHECK-NEXT:    br label %[[PRED_UREM_CONTINUE2]]
 ; CHECK:       [[PRED_UREM_CONTINUE2]]:
-; CHECK-NEXT:    [[TMP6:%.*]] = phi <4 x i32> [ [[TMP2]], %[[PRED_UREM_CONTINUE]] ], [ [[TMP4]], %[[PRED_UREM_IF1]] ]
+; CHECK-NEXT:    [[TMP6:%.*]] = phi <4 x i32> [ [[TMP2]], %[[PRED_UREM_CONTINUE1]] ], [ [[TMP4]], %[[PRED_UREM_IF1]] ]
 ; CHECK-NEXT:    br i1 [[C]], label %[[PRED_UREM_IF3:.*]], label %[[PRED_UREM_CONTINUE4:.*]]
 ; CHECK:       [[PRED_UREM_IF3]]:
 ; CHECK-NEXT:    [[TMP9:%.*]] = urem i32 10, [[X]]
@@ -35,18 +39,22 @@ define i32 @test_invariant_replicate_region(i32 %x, i1 %c) {
 ; CHECK-NEXT:    br label %[[PRED_UREM_CONTINUE4]]
 ; CHECK:       [[PRED_UREM_CONTINUE4]]:
 ; CHECK-NEXT:    [[TMP8:%.*]] = phi <4 x i32> [ [[TMP6]], %[[PRED_UREM_CONTINUE2]] ], [ [[TMP7]], %[[PRED_UREM_IF3]] ]
-; CHECK-NEXT:    br i1 [[C]], label %[[PRED_UREM_IF5:.*]], label %[[PRED_UREM_CONTINUE6]]
+; CHECK-NEXT:    br i1 [[C]], label %[[PRED_UREM_IF5:.*]], label %[[PRED_UREM_CONTINUE6:.*]]
 ; CHECK:       [[PRED_UREM_IF5]]:
 ; CHECK-NEXT:    [[TMP13:%.*]] = urem i32 10, [[X]]
 ; CHECK-NEXT:    [[TMP10:%.*]] = insertelement <4 x i32> [[TMP8]], i32 [[TMP13]], i64 3
 ; CHECK-NEXT:    br label %[[PRED_UREM_CONTINUE6]]
 ; CHECK:       [[PRED_UREM_CONTINUE6]]:
-; CHECK-NEXT:    [[TMP12:%.*]] = phi <4 x i32> [ [[TMP8]], %[[PRED_UREM_CONTINUE4]] ], [ [[TMP10]], %[[PRED_UREM_IF5]] ]
+; CHECK-NEXT:    [[TMP11:%.*]] = phi <4 x i32> [ [[TMP8]], %[[PRED_UREM_CONTINUE4]] ], [ [[TMP10]], %[[PRED_UREM_IF5]] ]
+; CHECK-NEXT:    br label %[[PRED_UREM_CONTINUE]]
+; CHECK:       [[PRED_UREM_CONTINUE]]:
+; CHECK-NEXT:    [[TMP12:%.*]] = phi <4 x i32> [ poison, %[[VECTOR_BODY]] ], [ [[TMP11]], %[[PRED_UREM_CONTINUE6]] ]
+; CHECK-NEXT:    [[TMP14:%.*]] = phi <4 x i1> [ zeroinitializer, %[[VECTOR_BODY]] ], [ [[BROADCAST_SPLAT]], %[[PRED_UREM_CONTINUE6]] ]
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i32 [[INDEX]], 4
 ; CHECK-NEXT:    [[TMP16:%.*]] = icmp eq i32 [[INDEX_NEXT]], 100
 ; CHECK-NEXT:    br i1 [[TMP16]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP0:![0-9]+]]
 ; CHECK:       [[MIDDLE_BLOCK]]:
-; CHECK-NEXT:    [[PREDPHI:%.*]] = select i1 [[C]], <4 x i32> [[TMP12]], <4 x i32> zeroinitializer
+; CHECK-NEXT:    [[PREDPHI:%.*]] = select <4 x i1> [[TMP14]], <4 x i32> [[TMP12]], <4 x i32> zeroinitializer
 ; CHECK-NEXT:    [[TMP17:%.*]] = extractelement <4 x i32> [[PREDPHI]], i64 3
 ; CHECK-NEXT:    br label %[[EXIT:.*]]
 ; CHECK:       [[EXIT]]:

--- a/llvm/test/Transforms/LoopVectorize/AArch64/predicated-costs.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/predicated-costs.ll
@@ -398,31 +398,10 @@ attributes #1 = { "target-cpu"="neoverse-v2" }
 define void @round_scalar_pred_divisor(ptr %dst, double %x) {
 ; CHECK-LABEL: define void @round_scalar_pred_divisor(
 ; CHECK-SAME: ptr [[DST:%.*]], double [[X:%.*]]) {
-; CHECK-NEXT:  [[ENTRY:.*:]]
-; CHECK-NEXT:    br label %[[LOOP:.*]]
-; CHECK:       [[LOOP]]:
-; CHECK-NEXT:    [[C:%.*]] = fcmp une double [[X]], 0.000000e+00
-; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
-; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[LOOP]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i32> [ <i32 0, i32 1, i32 2, i32 3>, %[[LOOP]] ], [ [[VEC_IND_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[STEP_ADD:%.*]] = add <4 x i32> [[VEC_IND]], splat (i32 4)
-; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 8
-; CHECK-NEXT:    [[VEC_IND_NEXT]] = add <4 x i32> [[STEP_ADD]], splat (i32 4)
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[INDEX_NEXT]], 1024
-; CHECK-NEXT:    br i1 [[TMP1]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP15:![0-9]+]]
-; CHECK:       [[MIDDLE_BLOCK]]:
-; CHECK-NEXT:    [[TMP2:%.*]] = uitofp <4 x i32> [[STEP_ADD]] to <4 x double>
-; CHECK-NEXT:    [[TMP3:%.*]] = call <4 x double> @llvm.sin.v4f64(<4 x double> [[TMP2]])
-; CHECK-NEXT:    [[TMP4:%.*]] = fptrunc <4 x double> [[TMP3]] to <4 x float>
-; CHECK-NEXT:    [[PREDPHI:%.*]] = select i1 [[C]], <4 x float> [[TMP4]], <4 x float> zeroinitializer
-; CHECK-NEXT:    [[TMP5:%.*]] = extractelement <4 x float> [[PREDPHI]], i64 3
-; CHECK-NEXT:    store float [[TMP5]], ptr [[DST]], align 4
-; CHECK-NEXT:    br label %[[SCALAR_PH:.*]]
-; CHECK:       [[SCALAR_PH]]:
+; CHECK-NEXT:  [[SCALAR_PH:.*]]:
 ; CHECK-NEXT:    br label %[[LOOP1:.*]]
 ; CHECK:       [[LOOP1]]:
-; CHECK-NEXT:    [[IV:%.*]] = phi i64 [ 1024, %[[SCALAR_PH]] ], [ [[IV_NEXT:%.*]], %[[LATCH:.*]] ]
+; CHECK-NEXT:    [[IV:%.*]] = phi i64 [ 0, %[[SCALAR_PH]] ], [ [[IV_NEXT:%.*]], %[[LATCH:.*]] ]
 ; CHECK-NEXT:    [[C1:%.*]] = fcmp une double [[X]], 0.000000e+00
 ; CHECK-NEXT:    br i1 [[C1]], label %[[IF:.*]], label %[[LATCH]]
 ; CHECK:       [[IF]]:
@@ -436,7 +415,7 @@ define void @round_scalar_pred_divisor(ptr %dst, double %x) {
 ; CHECK-NEXT:    store float [[PHI]], ptr [[DST]], align 4
 ; CHECK-NEXT:    [[IV_NEXT]] = add i64 [[IV]], 1
 ; CHECK-NEXT:    [[EC:%.*]] = icmp eq i64 [[IV]], 1024
-; CHECK-NEXT:    br i1 [[EC]], label %[[EXIT:.*]], label %[[LOOP1]], !llvm.loop [[LOOP16:![0-9]+]]
+; CHECK-NEXT:    br i1 [[EC]], label %[[EXIT:.*]], label %[[LOOP1]]
 ; CHECK:       [[EXIT]]:
 ; CHECK-NEXT:    ret void
 ;
@@ -477,9 +456,9 @@ define void @getPredBlockCostDivisor_truncate(i32 %0, i1 %c1, i1 %c2, ptr %p) {
 ; CHECK-NEXT:    br label %[[LOOP:.*]]
 ; CHECK:       [[LOOP]]:
 ; CHECK-NEXT:    [[IV:%.*]] = phi i32 [ [[TMP0]], %[[ENTRY]] ], [ [[IV_NEXT:%.*]], %[[LATCH:.*]] ]
-; CHECK-NEXT:    br i1 [[C1]], label %[[IF_1:.*]], label %[[LATCH]], !prof [[PROF17:![0-9]+]]
+; CHECK-NEXT:    br i1 [[C1]], label %[[IF_1:.*]], label %[[LATCH]], !prof [[PROF15:![0-9]+]]
 ; CHECK:       [[IF_1]]:
-; CHECK-NEXT:    br i1 [[C2]], label %[[IF_2:.*]], label %[[LATCH]], !prof [[PROF17]]
+; CHECK-NEXT:    br i1 [[C2]], label %[[IF_2:.*]], label %[[LATCH]], !prof [[PROF15]]
 ; CHECK:       [[IF_2]]:
 ; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i32, ptr [[P]], i32 [[IV]]
 ; CHECK-NEXT:    store i32 0, ptr [[GEP]], align 4
@@ -533,7 +512,5 @@ exit:
 ; CHECK: [[LOOP12]] = distinct !{[[LOOP12]], [[META6]], [[META7]]}
 ; CHECK: [[LOOP13]] = distinct !{[[LOOP13]], [[META7]], [[META8]]}
 ; CHECK: [[LOOP14]] = distinct !{[[LOOP14]], [[META8]], [[META7]]}
-; CHECK: [[LOOP15]] = distinct !{[[LOOP15]], [[META7]], [[META8]]}
-; CHECK: [[LOOP16]] = distinct !{[[LOOP16]], [[META8]], [[META7]]}
-; CHECK: [[PROF17]] = !{!"branch_weights", i32 0, i32 1}
+; CHECK: [[PROF15]] = !{!"branch_weights", i32 0, i32 1}
 ;.

--- a/llvm/test/Transforms/LoopVectorize/AArch64/sve-predicated-costs.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/sve-predicated-costs.ll
@@ -84,16 +84,18 @@ define void @always_taken(ptr noalias %p0, ptr noalias %p1, i1 %c0, i1 %c1, i1 %
 ; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <vscale x 2 x i1> [[BROADCAST_SPLATINSERT]], <vscale x 2 x i1> poison, <vscale x 2 x i32> zeroinitializer
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT1:%.*]] = insertelement <vscale x 2 x i1> poison, i1 [[C0]], i64 0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT2:%.*]] = shufflevector <vscale x 2 x i1> [[BROADCAST_SPLATINSERT1]], <vscale x 2 x i1> poison, <vscale x 2 x i32> zeroinitializer
+; CHECK-NEXT:    [[TMP4:%.*]] = freeze i1 [[C1]]
 ; CHECK-NEXT:    [[TMP6:%.*]] = select <vscale x 2 x i1> [[BROADCAST_SPLAT2]], <vscale x 2 x i1> [[BROADCAST_SPLAT]], <vscale x 2 x i1> zeroinitializer
+; CHECK-NEXT:    [[TMP5:%.*]] = freeze i1 [[C2]]
 ; CHECK-NEXT:    [[TMP8:%.*]] = select <vscale x 2 x i1> [[TMP6]], <vscale x 2 x i1> [[BROADCAST_SPLAT1]], <vscale x 2 x i1> zeroinitializer
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
 ; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LATCH9:.*]] ]
 ; CHECK-NEXT:    br i1 [[C0]], label %[[THEN_05:.*]], label %[[LATCH9]]
 ; CHECK:       [[THEN_05]]:
-; CHECK-NEXT:    br i1 [[C1]], label %[[THEN_16:.*]], label %[[LATCH9]]
+; CHECK-NEXT:    br i1 [[TMP4]], label %[[THEN_16:.*]], label %[[LATCH9]]
 ; CHECK:       [[THEN_16]]:
-; CHECK-NEXT:    br i1 [[C2]], label %[[THEN_27:.*]], label %[[LATCH9]]
+; CHECK-NEXT:    br i1 [[TMP5]], label %[[THEN_27:.*]], label %[[LATCH9]]
 ; CHECK:       [[THEN_27]]:
 ; CHECK-NEXT:    [[TMP10:%.*]] = getelementptr i64, ptr [[P0]], i32 [[INDEX]]
 ; CHECK-NEXT:    [[TMP7:%.*]] = zext i32 [[TMP3]] to i64

--- a/llvm/test/Transforms/LoopVectorize/AArch64/sve-predicated-costs.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/sve-predicated-costs.ll
@@ -88,7 +88,9 @@ define void @always_taken(ptr noalias %p0, ptr noalias %p1, i1 %c0, i1 %c1, i1 %
 ; CHECK-NEXT:    [[TMP8:%.*]] = select <vscale x 2 x i1> [[TMP6]], <vscale x 2 x i1> [[BROADCAST_SPLAT1]], <vscale x 2 x i1> zeroinitializer
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LATCH9:.*]] ]
+; CHECK-NEXT:    br i1 [[C0]], label %[[THEN_05:.*]], label %[[LATCH9]]
+; CHECK:       [[THEN_05]]:
 ; CHECK-NEXT:    [[TMP10:%.*]] = getelementptr i64, ptr [[P0]], i32 [[INDEX]]
 ; CHECK-NEXT:    [[TMP7:%.*]] = zext i32 [[TMP3]] to i64
 ; CHECK-NEXT:    [[TMP20:%.*]] = getelementptr i64, ptr [[TMP10]], i64 [[TMP7]]
@@ -102,6 +104,8 @@ define void @always_taken(ptr noalias %p0, ptr noalias %p1, i1 %c0, i1 %c1, i1 %
 ; CHECK-NEXT:    [[TMP13:%.*]] = call <vscale x 2 x i64> @llvm.masked.udiv.nxv2i64(<vscale x 2 x i64> [[WIDE_MASKED_LOAD5]], <vscale x 2 x i64> [[WIDE_MASKED_LOAD7]], <vscale x 2 x i1> [[TMP8]])
 ; CHECK-NEXT:    call void @llvm.masked.store.nxv2i64.p0(<vscale x 2 x i64> [[TMP14]], ptr align 8 [[TMP9]], <vscale x 2 x i1> [[TMP8]])
 ; CHECK-NEXT:    call void @llvm.masked.store.nxv2i64.p0(<vscale x 2 x i64> [[TMP13]], ptr align 8 [[TMP12]], <vscale x 2 x i1> [[TMP8]])
+; CHECK-NEXT:    br label %[[LATCH9]]
+; CHECK:       [[LATCH9]]:
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i32 [[INDEX]], [[TMP1]]
 ; CHECK-NEXT:    [[TMP16:%.*]] = icmp eq i32 [[INDEX_NEXT]], [[N_VEC]]
 ; CHECK-NEXT:    br i1 [[TMP16]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP0:![0-9]+]]

--- a/llvm/test/Transforms/LoopVectorize/AArch64/sve-predicated-costs.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/sve-predicated-costs.ll
@@ -88,7 +88,13 @@ define void @always_taken(ptr noalias %p0, ptr noalias %p1, i1 %c0, i1 %c1, i1 %
 ; CHECK-NEXT:    [[TMP8:%.*]] = select <vscale x 2 x i1> [[TMP6]], <vscale x 2 x i1> [[BROADCAST_SPLAT1]], <vscale x 2 x i1> zeroinitializer
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LATCH9:.*]] ]
+; CHECK-NEXT:    br i1 [[C0]], label %[[THEN_05:.*]], label %[[LATCH9]]
+; CHECK:       [[THEN_05]]:
+; CHECK-NEXT:    br i1 [[C1]], label %[[THEN_16:.*]], label %[[LATCH9]]
+; CHECK:       [[THEN_16]]:
+; CHECK-NEXT:    br i1 [[C2]], label %[[THEN_27:.*]], label %[[LATCH9]]
+; CHECK:       [[THEN_27]]:
 ; CHECK-NEXT:    [[TMP10:%.*]] = getelementptr i64, ptr [[P0]], i32 [[INDEX]]
 ; CHECK-NEXT:    [[TMP7:%.*]] = zext i32 [[TMP3]] to i64
 ; CHECK-NEXT:    [[TMP20:%.*]] = getelementptr i64, ptr [[TMP10]], i64 [[TMP7]]
@@ -102,6 +108,8 @@ define void @always_taken(ptr noalias %p0, ptr noalias %p1, i1 %c0, i1 %c1, i1 %
 ; CHECK-NEXT:    [[TMP13:%.*]] = call <vscale x 2 x i64> @llvm.masked.udiv.nxv2i64(<vscale x 2 x i64> [[WIDE_MASKED_LOAD5]], <vscale x 2 x i64> [[WIDE_MASKED_LOAD7]], <vscale x 2 x i1> [[TMP8]])
 ; CHECK-NEXT:    call void @llvm.masked.store.nxv2i64.p0(<vscale x 2 x i64> [[TMP14]], ptr align 8 [[TMP9]], <vscale x 2 x i1> [[TMP8]])
 ; CHECK-NEXT:    call void @llvm.masked.store.nxv2i64.p0(<vscale x 2 x i64> [[TMP13]], ptr align 8 [[TMP12]], <vscale x 2 x i1> [[TMP8]])
+; CHECK-NEXT:    br label %[[LATCH9]]
+; CHECK:       [[LATCH9]]:
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i32 [[INDEX]], [[TMP1]]
 ; CHECK-NEXT:    [[TMP16:%.*]] = icmp eq i32 [[INDEX_NEXT]], [[N_VEC]]
 ; CHECK-NEXT:    br i1 [[TMP16]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP0:![0-9]+]]

--- a/llvm/test/Transforms/LoopVectorize/AArch64/transform-narrow-interleave-to-widen-memory-multi-block.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/transform-narrow-interleave-to-widen-memory-multi-block.ll
@@ -13,7 +13,7 @@ define void @load_store_interleave_group_block_invar_cond(ptr noalias %data, ptr
 ; VF2IC1:       [[VECTOR_PH]]:
 ; VF2IC1-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; VF2IC1:       [[VECTOR_BODY]]:
-; VF2IC1-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE3:.*]] ]
+; VF2IC1-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE:.*]] ]
 ; VF2IC1-NEXT:    [[TMP0:%.*]] = shl nsw i64 [[INDEX]], 1
 ; VF2IC1-NEXT:    [[TMP1:%.*]] = getelementptr inbounds i64, ptr [[DATA]], i64 [[TMP0]]
 ; VF2IC1-NEXT:    [[WIDE_VEC:%.*]] = load <4 x i64>, ptr [[TMP1]], align 8
@@ -22,16 +22,20 @@ define void @load_store_interleave_group_block_invar_cond(ptr noalias %data, ptr
 ; VF2IC1-NEXT:    [[TMP4:%.*]] = shufflevector <2 x i64> [[STRIDED_VEC]], <2 x i64> [[STRIDED_VEC1]], <4 x i32> <i32 0, i32 1, i32 2, i32 3>
 ; VF2IC1-NEXT:    [[INTERLEAVED_VEC:%.*]] = shufflevector <4 x i64> [[TMP4]], <4 x i64> poison, <4 x i32> <i32 0, i32 2, i32 1, i32 3>
 ; VF2IC1-NEXT:    store <4 x i64> [[INTERLEAVED_VEC]], ptr [[TMP1]], align 8
-; VF2IC1-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE:.*]]
+; VF2IC1-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE]]
 ; VF2IC1:       [[PRED_STORE_IF]]:
+; VF2IC1-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF1:.*]], label %[[PRED_STORE_CONTINUE1:.*]]
+; VF2IC1:       [[PRED_STORE_IF1]]:
 ; VF2IC1-NEXT:    store i8 1, ptr [[DST_0]], align 1
-; VF2IC1-NEXT:    br label %[[PRED_STORE_CONTINUE]]
-; VF2IC1:       [[PRED_STORE_CONTINUE]]:
-; VF2IC1-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF2:.*]], label %[[PRED_STORE_CONTINUE3]]
+; VF2IC1-NEXT:    br label %[[PRED_STORE_CONTINUE1]]
+; VF2IC1:       [[PRED_STORE_CONTINUE1]]:
+; VF2IC1-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF2:.*]], label %[[PRED_STORE_CONTINUE3:.*]]
 ; VF2IC1:       [[PRED_STORE_IF2]]:
 ; VF2IC1-NEXT:    store i8 1, ptr [[DST_0]], align 1
 ; VF2IC1-NEXT:    br label %[[PRED_STORE_CONTINUE3]]
 ; VF2IC1:       [[PRED_STORE_CONTINUE3]]:
+; VF2IC1-NEXT:    br label %[[PRED_STORE_CONTINUE]]
+; VF2IC1:       [[PRED_STORE_CONTINUE]]:
 ; VF2IC1-NEXT:    [[TMP2:%.*]] = getelementptr inbounds i8, ptr [[DST_1]], i64 [[INDEX]]
 ; VF2IC1-NEXT:    store <2 x i8> zeroinitializer, ptr [[TMP2]], align 1
 ; VF2IC1-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 2
@@ -49,7 +53,7 @@ define void @load_store_interleave_group_block_invar_cond(ptr noalias %data, ptr
 ; VF2IC2:       [[VECTOR_PH]]:
 ; VF2IC2-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; VF2IC2:       [[VECTOR_BODY]]:
-; VF2IC2-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE11:.*]] ]
+; VF2IC2-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE:.*]] ]
 ; VF2IC2-NEXT:    [[TMP0:%.*]] = add i64 [[INDEX]], 2
 ; VF2IC2-NEXT:    [[TMP1:%.*]] = shl nsw i64 [[INDEX]], 1
 ; VF2IC2-NEXT:    [[TMP2:%.*]] = shl nsw i64 [[TMP0]], 1
@@ -67,11 +71,13 @@ define void @load_store_interleave_group_block_invar_cond(ptr noalias %data, ptr
 ; VF2IC2-NEXT:    [[TMP9:%.*]] = shufflevector <2 x i64> [[STRIDED_VEC3]], <2 x i64> [[STRIDED_VEC4]], <4 x i32> <i32 0, i32 1, i32 2, i32 3>
 ; VF2IC2-NEXT:    [[INTERLEAVED_VEC5:%.*]] = shufflevector <4 x i64> [[TMP9]], <4 x i64> poison, <4 x i32> <i32 0, i32 2, i32 1, i32 3>
 ; VF2IC2-NEXT:    store <4 x i64> [[INTERLEAVED_VEC5]], ptr [[TMP4]], align 8
-; VF2IC2-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE:.*]]
+; VF2IC2-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE]]
 ; VF2IC2:       [[PRED_STORE_IF]]:
+; VF2IC2-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF1:.*]], label %[[PRED_STORE_CONTINUE1:.*]]
+; VF2IC2:       [[PRED_STORE_IF1]]:
 ; VF2IC2-NEXT:    store i8 1, ptr [[DST_0]], align 1
-; VF2IC2-NEXT:    br label %[[PRED_STORE_CONTINUE]]
-; VF2IC2:       [[PRED_STORE_CONTINUE]]:
+; VF2IC2-NEXT:    br label %[[PRED_STORE_CONTINUE1]]
+; VF2IC2:       [[PRED_STORE_CONTINUE1]]:
 ; VF2IC2-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF6:.*]], label %[[PRED_STORE_CONTINUE7:.*]]
 ; VF2IC2:       [[PRED_STORE_IF6]]:
 ; VF2IC2-NEXT:    store i8 1, ptr [[DST_0]], align 1
@@ -82,11 +88,13 @@ define void @load_store_interleave_group_block_invar_cond(ptr noalias %data, ptr
 ; VF2IC2-NEXT:    store i8 1, ptr [[DST_0]], align 1
 ; VF2IC2-NEXT:    br label %[[PRED_STORE_CONTINUE9]]
 ; VF2IC2:       [[PRED_STORE_CONTINUE9]]:
-; VF2IC2-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF10:.*]], label %[[PRED_STORE_CONTINUE11]]
+; VF2IC2-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF10:.*]], label %[[PRED_STORE_CONTINUE11:.*]]
 ; VF2IC2:       [[PRED_STORE_IF10]]:
 ; VF2IC2-NEXT:    store i8 1, ptr [[DST_0]], align 1
 ; VF2IC2-NEXT:    br label %[[PRED_STORE_CONTINUE11]]
 ; VF2IC2:       [[PRED_STORE_CONTINUE11]]:
+; VF2IC2-NEXT:    br label %[[PRED_STORE_CONTINUE]]
+; VF2IC2:       [[PRED_STORE_CONTINUE]]:
 ; VF2IC2-NEXT:    [[TMP5:%.*]] = getelementptr inbounds i8, ptr [[DST_1]], i64 [[INDEX]]
 ; VF2IC2-NEXT:    [[TMP6:%.*]] = getelementptr inbounds i8, ptr [[TMP5]], i64 2
 ; VF2IC2-NEXT:    store <2 x i8> zeroinitializer, ptr [[TMP5]], align 1

--- a/llvm/test/Transforms/LoopVectorize/RISCV/blocks-with-dead-instructions.ll
+++ b/llvm/test/Transforms/LoopVectorize/RISCV/blocks-with-dead-instructions.ll
@@ -292,9 +292,13 @@ define void @multiple_blocks_with_dead_inst_multiple_successors_6(ptr %src, i1 %
 ; CHECK:       [[VECTOR_PH]]:
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[CURRENT_ITERATION_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[AVL:%.*]] = phi i64 [ [[TMP2]], %[[VECTOR_PH]] ], [ [[AVL_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[CURRENT_ITERATION_NEXT:%.*]], %[[ELSE2:.*]] ]
+; CHECK-NEXT:    [[AVL:%.*]] = phi i64 [ [[TMP2]], %[[VECTOR_PH]] ], [ [[AVL_NEXT:%.*]], %[[ELSE2]] ]
 ; CHECK-NEXT:    [[TMP27:%.*]] = call i32 @llvm.experimental.get.vector.length.i64(i64 [[AVL]], i32 8, i1 true)
+; CHECK-NEXT:    br i1 [[IC]], label %[[THEN_11:.*]], label %[[ELSE2]]
+; CHECK:       [[THEN_11]]:
+; CHECK-NEXT:    br label %[[ELSE2]]
+; CHECK:       [[ELSE2]]:
 ; CHECK-NEXT:    [[TMP4:%.*]] = mul i64 [[INDEX]], 6
 ; CHECK-NEXT:    [[TMP5:%.*]] = getelementptr i8, ptr [[SRC]], i64 [[TMP4]]
 ; CHECK-NEXT:    call void @llvm.experimental.vp.strided.store.nxv8i16.p0.i64(<vscale x 8 x i16> zeroinitializer, ptr align 2 [[TMP5]], i64 6, <vscale x 8 x i1> splat (i1 true), i32 [[TMP27]])

--- a/llvm/test/Transforms/LoopVectorize/RISCV/blocks-with-dead-instructions.ll
+++ b/llvm/test/Transforms/LoopVectorize/RISCV/blocks-with-dead-instructions.ll
@@ -290,12 +290,13 @@ define void @multiple_blocks_with_dead_inst_multiple_successors_6(ptr %src, i1 %
 ; CHECK-NEXT:    [[TMP2:%.*]] = add nuw nsw i64 [[TMP1]], 1
 ; CHECK-NEXT:    br label %[[VECTOR_PH:.*]]
 ; CHECK:       [[VECTOR_PH]]:
+; CHECK-NEXT:    [[TMP3:%.*]] = freeze i1 [[IC]]
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
 ; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[CURRENT_ITERATION_NEXT:%.*]], %[[ELSE2:.*]] ]
 ; CHECK-NEXT:    [[AVL:%.*]] = phi i64 [ [[TMP2]], %[[VECTOR_PH]] ], [ [[AVL_NEXT:%.*]], %[[ELSE2]] ]
 ; CHECK-NEXT:    [[TMP27:%.*]] = call i32 @llvm.experimental.get.vector.length.i64(i64 [[AVL]], i32 8, i1 true)
-; CHECK-NEXT:    br i1 [[IC]], label %[[THEN_11:.*]], label %[[ELSE2]]
+; CHECK-NEXT:    br i1 [[TMP3]], label %[[THEN_11:.*]], label %[[ELSE2]]
 ; CHECK:       [[THEN_11]]:
 ; CHECK-NEXT:    br label %[[ELSE2]]
 ; CHECK:       [[ELSE2]]:

--- a/llvm/test/Transforms/LoopVectorize/RISCV/dead-ops-cost.ll
+++ b/llvm/test/Transforms/LoopVectorize/RISCV/dead-ops-cost.ll
@@ -162,7 +162,9 @@ define i32 @cost_of_exit_branch_and_cond_insts(ptr %a, ptr %b, i1 %c, i16 %x) vs
 ; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <8 x i1> [[BROADCAST_SPLATINSERT]], <8 x i1> poison, <8 x i32> zeroinitializer
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE18:.*]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LOOP_EXITING18:.*]] ]
+; CHECK-NEXT:    br i1 [[C]], label %[[THEN3:.*]], label %[[LOOP_EXITING18]]
+; CHECK:       [[THEN3]]:
 ; CHECK-NEXT:    [[TMP11:%.*]] = getelementptr i32, ptr [[B]], i32 [[INDEX]]
 ; CHECK-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE:.*]]
 ; CHECK:       [[PRED_STORE_IF]]:
@@ -199,12 +201,14 @@ define i32 @cost_of_exit_branch_and_cond_insts(ptr %a, ptr %b, i1 %c, i16 %x) vs
 ; CHECK-NEXT:    store i1 false, ptr [[A]], align 1, !alias.scope [[META10]], !noalias [[META13]]
 ; CHECK-NEXT:    br label %[[PRED_STORE_CONTINUE16]]
 ; CHECK:       [[PRED_STORE_CONTINUE16]]:
-; CHECK-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF17:.*]], label %[[PRED_STORE_CONTINUE18]]
+; CHECK-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF17:.*]], label %[[PRED_STORE_CONTINUE18:.*]]
 ; CHECK:       [[PRED_STORE_IF17]]:
 ; CHECK-NEXT:    store i1 false, ptr [[A]], align 1, !alias.scope [[META10]], !noalias [[META13]]
 ; CHECK-NEXT:    br label %[[PRED_STORE_CONTINUE18]]
 ; CHECK:       [[PRED_STORE_CONTINUE18]]:
 ; CHECK-NEXT:    call void @llvm.masked.store.v8i32.p0(<8 x i32> zeroinitializer, ptr align 4 [[TMP11]], <8 x i1> [[BROADCAST_SPLAT]]), !alias.scope [[META13]]
+; CHECK-NEXT:    br label %[[LOOP_EXITING18]]
+; CHECK:       [[LOOP_EXITING18]]:
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i32 [[INDEX]], 8
 ; CHECK-NEXT:    [[TMP21:%.*]] = icmp eq i32 [[INDEX_NEXT]], [[N_VEC]]
 ; CHECK-NEXT:    br i1 [[TMP21]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP15:![0-9]+]]

--- a/llvm/test/Transforms/LoopVectorize/RISCV/dead-ops-cost.ll
+++ b/llvm/test/Transforms/LoopVectorize/RISCV/dead-ops-cost.ll
@@ -162,7 +162,9 @@ define i32 @cost_of_exit_branch_and_cond_insts(ptr %a, ptr %b, i1 %c, i16 %x) #0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <8 x i1> [[BROADCAST_SPLATINSERT]], <8 x i1> poison, <8 x i32> zeroinitializer
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE18:.*]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LOOP_EXITING18:.*]] ]
+; CHECK-NEXT:    br i1 [[C]], label %[[THEN3:.*]], label %[[LOOP_EXITING18]]
+; CHECK:       [[THEN3]]:
 ; CHECK-NEXT:    [[TMP11:%.*]] = getelementptr i32, ptr [[B]], i32 [[INDEX]]
 ; CHECK-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE:.*]]
 ; CHECK:       [[PRED_STORE_IF]]:
@@ -199,12 +201,14 @@ define i32 @cost_of_exit_branch_and_cond_insts(ptr %a, ptr %b, i1 %c, i16 %x) #0
 ; CHECK-NEXT:    store i1 false, ptr [[A]], align 1, !alias.scope [[META10]], !noalias [[META13]]
 ; CHECK-NEXT:    br label %[[PRED_STORE_CONTINUE16]]
 ; CHECK:       [[PRED_STORE_CONTINUE16]]:
-; CHECK-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF17:.*]], label %[[PRED_STORE_CONTINUE18]]
+; CHECK-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF17:.*]], label %[[PRED_STORE_CONTINUE18:.*]]
 ; CHECK:       [[PRED_STORE_IF17]]:
 ; CHECK-NEXT:    store i1 false, ptr [[A]], align 1, !alias.scope [[META10]], !noalias [[META13]]
 ; CHECK-NEXT:    br label %[[PRED_STORE_CONTINUE18]]
 ; CHECK:       [[PRED_STORE_CONTINUE18]]:
 ; CHECK-NEXT:    call void @llvm.masked.store.v8i32.p0(<8 x i32> zeroinitializer, ptr align 4 [[TMP11]], <8 x i1> [[BROADCAST_SPLAT]]), !alias.scope [[META13]]
+; CHECK-NEXT:    br label %[[LOOP_EXITING18]]
+; CHECK:       [[LOOP_EXITING18]]:
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i32 [[INDEX]], 8
 ; CHECK-NEXT:    [[TMP21:%.*]] = icmp eq i32 [[INDEX_NEXT]], [[N_VEC]]
 ; CHECK-NEXT:    br i1 [[TMP21]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP15:![0-9]+]]

--- a/llvm/test/Transforms/LoopVectorize/RISCV/divrem.ll
+++ b/llvm/test/Transforms/LoopVectorize/RISCV/divrem.ll
@@ -646,17 +646,23 @@ define void @udiv_sdiv_with_invariant_divisors(i8 %x, i16 %y, i1 %c, ptr %p) vsc
 ; CHECK-NEXT:    [[INDUCTION:%.*]] = add <vscale x 4 x i8> splat (i8 -12), [[TMP1]]
 ; CHECK-NEXT:    br label [[LOOP_LATCH:%.*]]
 ; CHECK:       vector.body:
-; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <vscale x 4 x i8> [ [[INDUCTION]], [[VECTOR_BODY]] ], [ [[VEC_IND_NEXT:%.*]], [[LOOP_LATCH]] ]
-; CHECK-NEXT:    [[AVL:%.*]] = phi i32 [ 12, [[VECTOR_BODY]] ], [ [[AVL_NEXT:%.*]], [[LOOP_LATCH]] ]
+; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <vscale x 4 x i8> [ [[INDUCTION]], [[VECTOR_BODY]] ], [ [[VEC_IND_NEXT:%.*]], [[LOOP_LATCH10:%.*]] ]
+; CHECK-NEXT:    [[AVL:%.*]] = phi i32 [ 12, [[VECTOR_BODY]] ], [ [[AVL_NEXT:%.*]], [[LOOP_LATCH10]] ]
 ; CHECK-NEXT:    [[TMP2:%.*]] = call i32 @llvm.experimental.get.vector.length.i32(i32 [[AVL]], i32 4, i1 true)
 ; CHECK-NEXT:    [[TMP3:%.*]] = trunc i32 [[TMP2]] to i8
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT7:%.*]] = insertelement <vscale x 4 x i8> poison, i8 [[TMP3]], i64 0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT8:%.*]] = shufflevector <vscale x 4 x i8> [[BROADCAST_SPLATINSERT7]], <vscale x 4 x i8> poison, <vscale x 4 x i32> zeroinitializer
+; CHECK-NEXT:    br i1 [[C]], label [[LOOP_LATCH10]], label [[THEN9:%.*]]
+; CHECK:       then9:
 ; CHECK-NEXT:    [[TMP5:%.*]] = call <vscale x 4 x i8> @llvm.vp.udiv.nxv4i8(<vscale x 4 x i8> [[VEC_IND]], <vscale x 4 x i8> [[BROADCAST_SPLAT2]], <vscale x 4 x i1> [[TMP0]], i32 [[TMP2]])
 ; CHECK-NEXT:    [[TMP6:%.*]] = zext <vscale x 4 x i8> [[TMP5]] to <vscale x 4 x i16>
 ; CHECK-NEXT:    [[TMP8:%.*]] = call <vscale x 4 x i16> @llvm.vp.sdiv.nxv4i16(<vscale x 4 x i16> [[TMP6]], <vscale x 4 x i16> [[BROADCAST_SPLAT4]], <vscale x 4 x i1> [[TMP0]], i32 [[TMP2]])
 ; CHECK-NEXT:    [[TMP9:%.*]] = sext <vscale x 4 x i16> [[TMP8]] to <vscale x 4 x i32>
-; CHECK-NEXT:    [[PREDPHI:%.*]] = select i1 [[C]], <vscale x 4 x i32> zeroinitializer, <vscale x 4 x i32> [[TMP9]]
+; CHECK-NEXT:    br label [[LOOP_LATCH10]]
+; CHECK:       loop.latch10:
+; CHECK-NEXT:    [[TMP10:%.*]] = phi <vscale x 4 x i32> [ poison, [[LOOP_LATCH]] ], [ [[TMP9]], [[THEN9]] ]
+; CHECK-NEXT:    [[TMP11:%.*]] = phi <vscale x 4 x i1> [ zeroinitializer, [[LOOP_LATCH]] ], [ [[TMP0]], [[THEN9]] ]
+; CHECK-NEXT:    [[PREDPHI:%.*]] = select <vscale x 4 x i1> [[TMP11]], <vscale x 4 x i32> [[TMP10]], <vscale x 4 x i32> zeroinitializer
 ; CHECK-NEXT:    call void @llvm.vp.scatter.nxv4i32.nxv4p0(<vscale x 4 x i32> [[PREDPHI]], <vscale x 4 x ptr> align 4 [[BROADCAST_SPLAT6]], <vscale x 4 x i1> splat (i1 true), i32 [[TMP2]])
 ; CHECK-NEXT:    [[AVL_NEXT]] = sub nuw i32 [[AVL]], [[TMP2]]
 ; CHECK-NEXT:    [[VEC_IND_NEXT]] = add <vscale x 4 x i8> [[VEC_IND]], [[BROADCAST_SPLAT8]]
@@ -671,30 +677,50 @@ define void @udiv_sdiv_with_invariant_divisors(i8 %x, i16 %y, i1 %c, ptr %p) vsc
 ; FIXED-NEXT:  entry:
 ; FIXED-NEXT:    br label [[VECTOR_PH:%.*]]
 ; FIXED:       vector.ph:
-; FIXED-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <4 x i1> poison, i1 [[C:%.*]], i64 0
-; FIXED-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT]], <4 x i1> poison, <4 x i32> zeroinitializer
-; FIXED-NEXT:    [[TMP0:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT]], splat (i1 true)
-; FIXED-NEXT:    [[BROADCAST_SPLATINSERT1:%.*]] = insertelement <4 x i8> poison, i8 [[X:%.*]], i64 0
-; FIXED-NEXT:    [[BROADCAST_SPLAT2:%.*]] = shufflevector <4 x i8> [[BROADCAST_SPLATINSERT1]], <4 x i8> poison, <4 x i32> zeroinitializer
-; FIXED-NEXT:    [[BROADCAST_SPLATINSERT3:%.*]] = insertelement <4 x i16> poison, i16 [[Y:%.*]], i64 0
-; FIXED-NEXT:    [[BROADCAST_SPLAT4:%.*]] = shufflevector <4 x i16> [[BROADCAST_SPLATINSERT3]], <4 x i16> poison, <4 x i32> zeroinitializer
+; FIXED-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <8 x i1> poison, i1 [[C:%.*]], i64 0
+; FIXED-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <8 x i1> [[BROADCAST_SPLATINSERT]], <8 x i1> poison, <8 x i32> zeroinitializer
+; FIXED-NEXT:    [[TMP0:%.*]] = xor <8 x i1> [[BROADCAST_SPLAT]], splat (i1 true)
+; FIXED-NEXT:    [[BROADCAST_SPLATINSERT1:%.*]] = insertelement <8 x i8> poison, i8 [[X:%.*]], i64 0
+; FIXED-NEXT:    [[BROADCAST_SPLAT2:%.*]] = shufflevector <8 x i8> [[BROADCAST_SPLATINSERT1]], <8 x i8> poison, <8 x i32> zeroinitializer
+; FIXED-NEXT:    [[BROADCAST_SPLATINSERT3:%.*]] = insertelement <8 x i16> poison, i16 [[Y:%.*]], i64 0
+; FIXED-NEXT:    [[BROADCAST_SPLAT4:%.*]] = shufflevector <8 x i16> [[BROADCAST_SPLATINSERT3]], <8 x i16> poison, <8 x i32> zeroinitializer
 ; FIXED-NEXT:    br label [[VECTOR_BODY:%.*]]
 ; FIXED:       vector.body:
-; FIXED-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, [[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], [[VECTOR_BODY]] ]
-; FIXED-NEXT:    [[VEC_IND:%.*]] = phi <4 x i8> [ <i8 -12, i8 -11, i8 -10, i8 -9>, [[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], [[VECTOR_BODY]] ]
-; FIXED-NEXT:    [[INDEX_NEXT]] = add nuw i32 [[INDEX]], 4
-; FIXED-NEXT:    [[VEC_IND_NEXT]] = add <4 x i8> [[VEC_IND]], splat (i8 4)
-; FIXED-NEXT:    [[TMP5:%.*]] = icmp eq i32 [[INDEX_NEXT]], 12
-; FIXED-NEXT:    br i1 [[TMP5]], label [[MIDDLE_BLOCK:%.*]], label [[VECTOR_BODY]], !llvm.loop [[LOOP11:![0-9]+]]
-; FIXED:       middle.block:
-; FIXED-NEXT:    [[TMP1:%.*]] = call <4 x i8> @llvm.masked.udiv.v4i8(<4 x i8> [[VEC_IND]], <4 x i8> [[BROADCAST_SPLAT2]], <4 x i1> [[TMP0]])
-; FIXED-NEXT:    [[TMP2:%.*]] = zext <4 x i8> [[TMP1]] to <4 x i16>
-; FIXED-NEXT:    [[TMP3:%.*]] = call <4 x i16> @llvm.masked.sdiv.v4i16(<4 x i16> [[TMP2]], <4 x i16> [[BROADCAST_SPLAT4]], <4 x i1> [[TMP0]])
-; FIXED-NEXT:    [[TMP4:%.*]] = sext <4 x i16> [[TMP3]] to <4 x i32>
-; FIXED-NEXT:    [[PREDPHI:%.*]] = select i1 [[C]], <4 x i32> zeroinitializer, <4 x i32> [[TMP4]]
-; FIXED-NEXT:    [[TMP7:%.*]] = extractelement <4 x i32> [[PREDPHI]], i64 3
+; FIXED-NEXT:    br i1 [[C]], label [[LOOP_LATCH6:%.*]], label [[THEN5:%.*]]
+; FIXED:       then5:
+; FIXED-NEXT:    [[TMP1:%.*]] = call <8 x i8> @llvm.masked.udiv.v8i8(<8 x i8> <i8 -12, i8 -11, i8 -10, i8 -9, i8 -8, i8 -7, i8 -6, i8 -5>, <8 x i8> [[BROADCAST_SPLAT2]], <8 x i1> [[TMP0]])
+; FIXED-NEXT:    [[TMP2:%.*]] = zext <8 x i8> [[TMP1]] to <8 x i16>
+; FIXED-NEXT:    [[TMP3:%.*]] = call <8 x i16> @llvm.masked.sdiv.v8i16(<8 x i16> [[TMP2]], <8 x i16> [[BROADCAST_SPLAT4]], <8 x i1> [[TMP0]])
+; FIXED-NEXT:    [[TMP4:%.*]] = sext <8 x i16> [[TMP3]] to <8 x i32>
+; FIXED-NEXT:    br label [[LOOP_LATCH6]]
+; FIXED:       loop.latch6:
+; FIXED-NEXT:    [[TMP5:%.*]] = phi <8 x i32> [ poison, [[VECTOR_BODY]] ], [ [[TMP4]], [[THEN5]] ]
+; FIXED-NEXT:    [[TMP6:%.*]] = phi <8 x i1> [ zeroinitializer, [[VECTOR_BODY]] ], [ [[TMP0]], [[THEN5]] ]
+; FIXED-NEXT:    [[PREDPHI:%.*]] = select <8 x i1> [[TMP6]], <8 x i32> [[TMP5]], <8 x i32> zeroinitializer
+; FIXED-NEXT:    [[TMP7:%.*]] = extractelement <8 x i32> [[PREDPHI]], i64 7
 ; FIXED-NEXT:    store i32 [[TMP7]], ptr [[P:%.*]], align 4
 ; FIXED-NEXT:    br label [[LOOP_LATCH:%.*]]
+; FIXED:       middle.block:
+; FIXED-NEXT:    br label [[SCALAR_PH:%.*]]
+; FIXED:       scalar.ph:
+; FIXED-NEXT:    br label [[LOOP_HEADER:%.*]]
+; FIXED:       loop.header:
+; FIXED-NEXT:    [[IV:%.*]] = phi i16 [ -4, [[SCALAR_PH]] ], [ [[IV_NEXT:%.*]], [[LOOP_LATCH1:%.*]] ]
+; FIXED-NEXT:    [[NARROW_IV:%.*]] = phi i8 [ -4, [[SCALAR_PH]] ], [ [[IV_NEXT_TRUNC:%.*]], [[LOOP_LATCH1]] ]
+; FIXED-NEXT:    br i1 [[C]], label [[LOOP_LATCH1]], label [[THEN:%.*]]
+; FIXED:       then:
+; FIXED-NEXT:    [[UD:%.*]] = udiv i8 [[NARROW_IV]], [[X]]
+; FIXED-NEXT:    [[UD_EXT:%.*]] = zext i8 [[UD]] to i16
+; FIXED-NEXT:    [[SD:%.*]] = sdiv i16 [[UD_EXT]], [[Y]]
+; FIXED-NEXT:    [[SD_EXT:%.*]] = sext i16 [[SD]] to i32
+; FIXED-NEXT:    br label [[LOOP_LATCH1]]
+; FIXED:       loop.latch:
+; FIXED-NEXT:    [[MERGE:%.*]] = phi i32 [ 0, [[LOOP_HEADER]] ], [ [[SD_EXT]], [[THEN]] ]
+; FIXED-NEXT:    store i32 [[MERGE]], ptr [[P]], align 4
+; FIXED-NEXT:    [[IV_NEXT]] = add nsw i16 [[IV]], 1
+; FIXED-NEXT:    [[EC:%.*]] = icmp eq i16 [[IV_NEXT]], 0
+; FIXED-NEXT:    [[IV_NEXT_TRUNC]] = trunc i16 [[IV_NEXT]] to i8
+; FIXED-NEXT:    br i1 [[EC]], label [[EXIT:%.*]], label [[LOOP_HEADER]], !llvm.loop [[LOOP11:![0-9]+]]
 ; FIXED:       exit:
 ; FIXED-NEXT:    ret void
 ;

--- a/llvm/test/Transforms/LoopVectorize/RISCV/divrem.ll
+++ b/llvm/test/Transforms/LoopVectorize/RISCV/divrem.ll
@@ -301,12 +301,18 @@ define void @predicated_udiv(ptr noalias nocapture %a, i64 %v, i64 %n) vscale_ra
 ; FIXED-NEXT:    [[TMP0:%.*]] = icmp ne <4 x i64> [[BROADCAST_SPLAT]], zeroinitializer
 ; FIXED-NEXT:    br label [[VECTOR_BODY:%.*]]
 ; FIXED:       vector.body:
-; FIXED-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, [[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], [[VECTOR_BODY]] ]
+; FIXED-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, [[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], [[LATCH2:%.*]] ]
 ; FIXED-NEXT:    [[TMP2:%.*]] = getelementptr inbounds i64, ptr [[A:%.*]], i64 [[INDEX]]
 ; FIXED-NEXT:    [[WIDE_LOAD1:%.*]] = load <4 x i64>, ptr [[TMP2]], align 8
-; FIXED-NEXT:    [[TMP8:%.*]] = call <4 x i64> @llvm.masked.udiv.v4i64(<4 x i64> [[WIDE_LOAD1]], <4 x i64> [[BROADCAST_SPLAT]], <4 x i1> [[TMP0]])
 ; FIXED-NEXT:    [[TMP6:%.*]] = extractelement <4 x i1> [[TMP0]], i64 0
-; FIXED-NEXT:    [[PREDPHI2:%.*]] = select i1 [[TMP6]], <4 x i64> [[TMP8]], <4 x i64> [[WIDE_LOAD1]]
+; FIXED-NEXT:    br i1 [[TMP6]], label [[DO_OP1:%.*]], label [[LATCH2]]
+; FIXED:       do_op1:
+; FIXED-NEXT:    [[TMP3:%.*]] = call <4 x i64> @llvm.masked.udiv.v4i64(<4 x i64> [[WIDE_LOAD1]], <4 x i64> [[BROADCAST_SPLAT]], <4 x i1> [[TMP0]])
+; FIXED-NEXT:    br label [[LATCH2]]
+; FIXED:       latch2:
+; FIXED-NEXT:    [[TMP4:%.*]] = phi <4 x i64> [ poison, [[VECTOR_BODY]] ], [ [[TMP3]], [[DO_OP1]] ]
+; FIXED-NEXT:    [[TMP5:%.*]] = phi <4 x i1> [ zeroinitializer, [[VECTOR_BODY]] ], [ [[TMP0]], [[DO_OP1]] ]
+; FIXED-NEXT:    [[PREDPHI2:%.*]] = select <4 x i1> [[TMP5]], <4 x i64> [[TMP4]], <4 x i64> [[WIDE_LOAD1]]
 ; FIXED-NEXT:    store <4 x i64> [[PREDPHI2]], ptr [[TMP2]], align 8
 ; FIXED-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
 ; FIXED-NEXT:    [[TMP9:%.*]] = icmp eq i64 [[INDEX_NEXT]], 1024
@@ -377,12 +383,18 @@ define void @predicated_sdiv(ptr noalias nocapture %a, i64 %v, i64 %n) vscale_ra
 ; FIXED-NEXT:    [[TMP0:%.*]] = icmp ne <4 x i64> [[BROADCAST_SPLAT]], zeroinitializer
 ; FIXED-NEXT:    br label [[VECTOR_BODY:%.*]]
 ; FIXED:       vector.body:
-; FIXED-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, [[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], [[VECTOR_BODY]] ]
+; FIXED-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, [[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], [[LATCH2:%.*]] ]
 ; FIXED-NEXT:    [[TMP2:%.*]] = getelementptr inbounds i64, ptr [[A:%.*]], i64 [[INDEX]]
 ; FIXED-NEXT:    [[WIDE_LOAD1:%.*]] = load <4 x i64>, ptr [[TMP2]], align 8
-; FIXED-NEXT:    [[TMP8:%.*]] = call <4 x i64> @llvm.masked.sdiv.v4i64(<4 x i64> [[WIDE_LOAD1]], <4 x i64> [[BROADCAST_SPLAT]], <4 x i1> [[TMP0]])
 ; FIXED-NEXT:    [[TMP6:%.*]] = extractelement <4 x i1> [[TMP0]], i64 0
-; FIXED-NEXT:    [[PREDPHI2:%.*]] = select i1 [[TMP6]], <4 x i64> [[TMP8]], <4 x i64> [[WIDE_LOAD1]]
+; FIXED-NEXT:    br i1 [[TMP6]], label [[DO_OP1:%.*]], label [[LATCH2]]
+; FIXED:       do_op1:
+; FIXED-NEXT:    [[TMP3:%.*]] = call <4 x i64> @llvm.masked.sdiv.v4i64(<4 x i64> [[WIDE_LOAD1]], <4 x i64> [[BROADCAST_SPLAT]], <4 x i1> [[TMP0]])
+; FIXED-NEXT:    br label [[LATCH2]]
+; FIXED:       latch2:
+; FIXED-NEXT:    [[TMP4:%.*]] = phi <4 x i64> [ poison, [[VECTOR_BODY]] ], [ [[TMP3]], [[DO_OP1]] ]
+; FIXED-NEXT:    [[TMP5:%.*]] = phi <4 x i1> [ zeroinitializer, [[VECTOR_BODY]] ], [ [[TMP0]], [[DO_OP1]] ]
+; FIXED-NEXT:    [[PREDPHI2:%.*]] = select <4 x i1> [[TMP5]], <4 x i64> [[TMP4]], <4 x i64> [[WIDE_LOAD1]]
 ; FIXED-NEXT:    store <4 x i64> [[PREDPHI2]], ptr [[TMP2]], align 8
 ; FIXED-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
 ; FIXED-NEXT:    [[TMP9:%.*]] = icmp eq i64 [[INDEX_NEXT]], 1024

--- a/llvm/test/Transforms/LoopVectorize/RISCV/gather-scatter-cost.ll
+++ b/llvm/test/Transforms/LoopVectorize/RISCV/gather-scatter-cost.ll
@@ -37,10 +37,18 @@ define void @predicated_uniform_load(ptr %src, i32 %n, ptr %dst, i1 %cond) {
 ; CHECK-NEXT:    [[BROADCAST_SPLAT4:%.*]] = shufflevector <vscale x 4 x ptr> [[BROADCAST_SPLATINSERT3]], <vscale x 4 x ptr> poison, <vscale x 4 x i32> zeroinitializer
 ; CHECK-NEXT:    br label [[VECTOR_BODY:%.*]]
 ; CHECK:       vector.body:
-; CHECK-NEXT:    [[AVL:%.*]] = phi i32 [ [[TMP3]], [[VECTOR_PH]] ], [ [[AVL_NEXT:%.*]], [[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[AVL:%.*]] = phi i32 [ [[TMP3]], [[VECTOR_PH]] ], [ [[AVL_NEXT:%.*]], [[LOOP_LATCH8:%.*]] ]
 ; CHECK-NEXT:    [[TMP10:%.*]] = call i32 @llvm.experimental.get.vector.length.i32(i32 [[AVL]], i32 4, i1 true)
+; CHECK-NEXT:    br i1 [[COND]], label [[LOOP_THEN7:%.*]], label [[LOOP_ELSE6:%.*]]
+; CHECK:       loop.else6:
 ; CHECK-NEXT:    [[WIDE_MASKED_GATHER:%.*]] = call <vscale x 4 x i32> @llvm.vp.gather.nxv4i32.nxv4p0(<vscale x 4 x ptr> align 4 [[BROADCAST_SPLAT]], <vscale x 4 x i1> [[TMP13]], i32 [[TMP10]]), !alias.scope [[META0:![0-9]+]]
-; CHECK-NEXT:    [[PREDPHI:%.*]] = select i1 [[COND]], <vscale x 4 x i32> zeroinitializer, <vscale x 4 x i32> [[WIDE_MASKED_GATHER]]
+; CHECK-NEXT:    br label [[LOOP_LATCH8]]
+; CHECK:       loop.then7:
+; CHECK-NEXT:    br label [[LOOP_LATCH8]]
+; CHECK:       loop.latch8:
+; CHECK-NEXT:    [[TMP15:%.*]] = phi <vscale x 4 x i32> [ [[WIDE_MASKED_GATHER]], [[LOOP_ELSE6]] ], [ poison, [[LOOP_THEN7]] ]
+; CHECK-NEXT:    [[TMP14:%.*]] = phi <vscale x 4 x i1> [ zeroinitializer, [[LOOP_ELSE6]] ], [ [[BROADCAST_SPLAT1]], [[LOOP_THEN7]] ]
+; CHECK-NEXT:    [[PREDPHI:%.*]] = select <vscale x 4 x i1> [[TMP14]], <vscale x 4 x i32> zeroinitializer, <vscale x 4 x i32> [[TMP15]]
 ; CHECK-NEXT:    call void @llvm.vp.scatter.nxv4i32.nxv4p0(<vscale x 4 x i32> [[PREDPHI]], <vscale x 4 x ptr> align 4 [[BROADCAST_SPLAT4]], <vscale x 4 x i1> splat (i1 true), i32 [[TMP10]]), !alias.scope [[META3:![0-9]+]], !noalias [[META0]]
 ; CHECK-NEXT:    [[AVL_NEXT]] = sub nuw i32 [[AVL]], [[TMP10]]
 ; CHECK-NEXT:    [[TMP16:%.*]] = icmp eq i32 [[AVL_NEXT]], 0

--- a/llvm/test/Transforms/LoopVectorize/RISCV/low-trip-count.ll
+++ b/llvm/test/Transforms/LoopVectorize/RISCV/low-trip-count.ll
@@ -283,19 +283,21 @@ define void @const_tc_with_predicated_store(i1 %c1, i1 %c2, i1 %c3, ptr %dst) #1
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT4:%.*]] = insertelement <vscale x 4 x i1> poison, i1 [[C3:%.*]], i64 0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT5:%.*]] = shufflevector <vscale x 4 x i1> [[BROADCAST_SPLATINSERT4]], <vscale x 4 x i1> poison, <vscale x 4 x i32> zeroinitializer
 ; CHECK-NEXT:    [[TMP1:%.*]] = xor <vscale x 4 x i1> [[BROADCAST_SPLAT4]], splat (i1 true)
+; CHECK-NEXT:    [[TMP11:%.*]] = freeze i1 [[C2]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = xor <vscale x 4 x i1> [[BROADCAST_SPLAT2]], splat (i1 true)
 ; CHECK-NEXT:    [[TMP2:%.*]] = xor <vscale x 4 x i1> [[BROADCAST_SPLAT5]], splat (i1 true)
+; CHECK-NEXT:    [[TMP16:%.*]] = freeze i1 [[C1]]
 ; CHECK-NEXT:    br label [[VECTOR_BODY1:%.*]]
 ; CHECK:       vector.body:
 ; CHECK-NEXT:    br i1 [[C3]], label [[IF_ELSE16:%.*]], label [[IF_THEN5:%.*]]
 ; CHECK:       if.then5:
-; CHECK-NEXT:    br i1 [[C1]], label [[IF_ELSE27:%.*]], label [[IF_ELSE16]]
+; CHECK-NEXT:    br i1 [[TMP16]], label [[IF_ELSE27:%.*]], label [[IF_ELSE16]]
 ; CHECK:       if.else16:
 ; CHECK-NEXT:    [[TMP12:%.*]] = phi <vscale x 4 x i1> [ zeroinitializer, [[VECTOR_BODY1]] ], [ [[TMP2]], [[IF_THEN5]] ]
 ; CHECK-NEXT:    [[TMP13:%.*]] = select <vscale x 4 x i1> [[TMP12]], <vscale x 4 x i1> [[TMP1]], <vscale x 4 x i1> zeroinitializer
 ; CHECK-NEXT:    [[TMP3:%.*]] = or <vscale x 4 x i1> [[TMP13]], [[BROADCAST_SPLAT5]]
 ; CHECK-NEXT:    [[PREDPHI:%.*]] = select <vscale x 4 x i1> [[TMP12]], <vscale x 4 x float> zeroinitializer, <vscale x 4 x float> splat (float 1.000000e+00)
-; CHECK-NEXT:    br i1 [[C2]], label [[VECTOR_BODY:%.*]], label [[IF_ELSE27]]
+; CHECK-NEXT:    br i1 [[TMP11]], label [[VECTOR_BODY:%.*]], label [[IF_ELSE27]]
 ; CHECK:       if.else27:
 ; CHECK-NEXT:    [[TMP9:%.*]] = phi <vscale x 4 x float> [ poison, [[IF_THEN5]] ], [ [[PREDPHI]], [[IF_ELSE16]] ]
 ; CHECK-NEXT:    [[TMP10:%.*]] = phi <vscale x 4 x i1> [ zeroinitializer, [[IF_THEN5]] ], [ [[TMP3]], [[IF_ELSE16]] ]

--- a/llvm/test/Transforms/LoopVectorize/RISCV/low-trip-count.ll
+++ b/llvm/test/Transforms/LoopVectorize/RISCV/low-trip-count.ll
@@ -282,18 +282,32 @@ define void @const_tc_with_predicated_store(i1 %c1, i1 %c2, i1 %c3, ptr %dst) #1
 ; CHECK-NEXT:    [[BROADCAST_SPLAT4:%.*]] = shufflevector <vscale x 4 x i1> [[BROADCAST_SPLATINSERT3]], <vscale x 4 x i1> poison, <vscale x 4 x i32> zeroinitializer
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT4:%.*]] = insertelement <vscale x 4 x i1> poison, i1 [[C3:%.*]], i64 0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT5:%.*]] = shufflevector <vscale x 4 x i1> [[BROADCAST_SPLATINSERT4]], <vscale x 4 x i1> poison, <vscale x 4 x i32> zeroinitializer
-; CHECK-NEXT:    [[TMP12:%.*]] = xor <vscale x 4 x i1> [[BROADCAST_SPLAT5]], splat (i1 true)
 ; CHECK-NEXT:    [[TMP1:%.*]] = xor <vscale x 4 x i1> [[BROADCAST_SPLAT4]], splat (i1 true)
+; CHECK-NEXT:    [[TMP4:%.*]] = xor <vscale x 4 x i1> [[BROADCAST_SPLAT2]], splat (i1 true)
+; CHECK-NEXT:    [[TMP2:%.*]] = xor <vscale x 4 x i1> [[BROADCAST_SPLAT5]], splat (i1 true)
+; CHECK-NEXT:    br label [[VECTOR_BODY1:%.*]]
+; CHECK:       vector.body:
+; CHECK-NEXT:    br i1 [[C3]], label [[IF_ELSE16:%.*]], label [[IF_THEN5:%.*]]
+; CHECK:       if.then5:
+; CHECK-NEXT:    br i1 [[C1]], label [[IF_ELSE27:%.*]], label [[IF_ELSE16]]
+; CHECK:       if.else16:
+; CHECK-NEXT:    [[TMP12:%.*]] = phi <vscale x 4 x i1> [ zeroinitializer, [[VECTOR_BODY1]] ], [ [[TMP2]], [[IF_THEN5]] ]
 ; CHECK-NEXT:    [[TMP13:%.*]] = select <vscale x 4 x i1> [[TMP12]], <vscale x 4 x i1> [[TMP1]], <vscale x 4 x i1> zeroinitializer
 ; CHECK-NEXT:    [[TMP3:%.*]] = or <vscale x 4 x i1> [[TMP13]], [[BROADCAST_SPLAT5]]
-; CHECK-NEXT:    [[PREDPHI:%.*]] = select i1 [[C3]], <vscale x 4 x float> splat (float 1.000000e+00), <vscale x 4 x float> zeroinitializer
-; CHECK-NEXT:    [[TMP4:%.*]] = xor <vscale x 4 x i1> [[BROADCAST_SPLAT2]], splat (i1 true)
-; CHECK-NEXT:    [[TMP5:%.*]] = select <vscale x 4 x i1> [[TMP3]], <vscale x 4 x i1> [[TMP4]], <vscale x 4 x i1> zeroinitializer
-; CHECK-NEXT:    [[TMP6:%.*]] = select <vscale x 4 x i1> [[TMP12]], <vscale x 4 x i1> [[BROADCAST_SPLAT4]], <vscale x 4 x i1> zeroinitializer
+; CHECK-NEXT:    [[PREDPHI:%.*]] = select <vscale x 4 x i1> [[TMP12]], <vscale x 4 x float> zeroinitializer, <vscale x 4 x float> splat (float 1.000000e+00)
+; CHECK-NEXT:    br i1 [[C2]], label [[VECTOR_BODY:%.*]], label [[IF_ELSE27]]
+; CHECK:       if.else27:
+; CHECK-NEXT:    [[TMP9:%.*]] = phi <vscale x 4 x float> [ poison, [[IF_THEN5]] ], [ [[PREDPHI]], [[IF_ELSE16]] ]
+; CHECK-NEXT:    [[TMP10:%.*]] = phi <vscale x 4 x i1> [ zeroinitializer, [[IF_THEN5]] ], [ [[TMP3]], [[IF_ELSE16]] ]
+; CHECK-NEXT:    [[TMP8:%.*]] = phi <vscale x 4 x i1> [ [[TMP2]], [[IF_THEN5]] ], [ [[TMP12]], [[IF_ELSE16]] ]
+; CHECK-NEXT:    [[TMP5:%.*]] = select <vscale x 4 x i1> [[TMP10]], <vscale x 4 x i1> [[TMP4]], <vscale x 4 x i1> zeroinitializer
+; CHECK-NEXT:    [[TMP6:%.*]] = select <vscale x 4 x i1> [[TMP8]], <vscale x 4 x i1> [[BROADCAST_SPLAT4]], <vscale x 4 x i1> zeroinitializer
 ; CHECK-NEXT:    [[TMP7:%.*]] = or <vscale x 4 x i1> [[TMP5]], [[TMP6]]
-; CHECK-NEXT:    [[PREDPHI5:%.*]] = select <vscale x 4 x i1> [[TMP7]], <vscale x 4 x float> splat (float 2.000000e+00), <vscale x 4 x float> [[PREDPHI]]
-; CHECK-NEXT:    br label [[VECTOR_BODY:%.*]]
-; CHECK:       vector.body:
+; CHECK-NEXT:    br label [[VECTOR_BODY]]
+; CHECK:       latch8:
+; CHECK-NEXT:    [[TMP14:%.*]] = phi <vscale x 4 x float> [ [[PREDPHI]], [[IF_ELSE16]] ], [ [[TMP9]], [[IF_ELSE27]] ]
+; CHECK-NEXT:    [[TMP15:%.*]] = phi <vscale x 4 x i1> [ zeroinitializer, [[IF_ELSE16]] ], [ [[TMP7]], [[IF_ELSE27]] ]
+; CHECK-NEXT:    [[PREDPHI5:%.*]] = select <vscale x 4 x i1> [[TMP15]], <vscale x 4 x float> splat (float 2.000000e+00), <vscale x 4 x float> [[TMP14]]
 ; CHECK-NEXT:    call void @llvm.vp.store.nxv4f32.p0(<vscale x 4 x float> [[PREDPHI5]], ptr align 4 [[DST:%.*]], <vscale x 4 x i1> splat (i1 true), i32 57)
 ; CHECK-NEXT:    br label [[MIDDLE_BLOCK:%.*]]
 ; CHECK:       middle.block:

--- a/llvm/test/Transforms/LoopVectorize/RISCV/predicated-costs.ll
+++ b/llvm/test/Transforms/LoopVectorize/RISCV/predicated-costs.ll
@@ -15,6 +15,7 @@ define void @nested(ptr noalias %p0, ptr noalias %p1, i1 %c0, i1 %c1) vscale_ran
 ; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <vscale x 4 x i1> [[BROADCAST_SPLATINSERT]], <vscale x 4 x i1> poison, <vscale x 4 x i32> zeroinitializer
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT1:%.*]] = insertelement <vscale x 4 x i1> poison, i1 [[C0]], i64 0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT2:%.*]] = shufflevector <vscale x 4 x i1> [[BROADCAST_SPLATINSERT1]], <vscale x 4 x i1> poison, <vscale x 4 x i32> zeroinitializer
+; CHECK-NEXT:    [[TMP2:%.*]] = freeze i1 [[C1]]
 ; CHECK-NEXT:    [[TMP0:%.*]] = select <vscale x 4 x i1> [[BROADCAST_SPLAT2]], <vscale x 4 x i1> [[BROADCAST_SPLAT]], <vscale x 4 x i1> zeroinitializer
 ; CHECK-NEXT:    br label %[[THEN_1:.*]]
 ; CHECK:       [[THEN_1]]:
@@ -23,7 +24,7 @@ define void @nested(ptr noalias %p0, ptr noalias %p1, i1 %c0, i1 %c1) vscale_ran
 ; CHECK-NEXT:    [[TMP1:%.*]] = call i32 @llvm.experimental.get.vector.length.i32(i32 [[AVL]], i32 4, i1 true)
 ; CHECK-NEXT:    br i1 [[C0]], label %[[THEN_03:.*]], label %[[LATCH4]]
 ; CHECK:       [[THEN_03]]:
-; CHECK-NEXT:    br i1 [[C1]], label %[[THEN_14:.*]], label %[[LATCH4]]
+; CHECK-NEXT:    br i1 [[TMP2]], label %[[THEN_14:.*]], label %[[LATCH4]]
 ; CHECK:       [[THEN_14]]:
 ; CHECK-NEXT:    [[GEP2:%.*]] = getelementptr i32, ptr [[P0]], i32 [[IV1]]
 ; CHECK-NEXT:    [[VP_OP_LOAD:%.*]] = call <vscale x 4 x i32> @llvm.vp.load.nxv4i32.p0(ptr align 4 [[GEP2]], <vscale x 4 x i1> [[TMP0]], i32 [[TMP1]])
@@ -79,6 +80,7 @@ define void @always_taken(ptr noalias %p0, ptr noalias %p1, i1 %c0, i1 %c1) vsca
 ; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <vscale x 4 x i1> [[BROADCAST_SPLATINSERT]], <vscale x 4 x i1> poison, <vscale x 4 x i32> zeroinitializer
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT1:%.*]] = insertelement <vscale x 4 x i1> poison, i1 [[C0]], i64 0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT2:%.*]] = shufflevector <vscale x 4 x i1> [[BROADCAST_SPLATINSERT1]], <vscale x 4 x i1> poison, <vscale x 4 x i32> zeroinitializer
+; CHECK-NEXT:    [[TMP5:%.*]] = freeze i1 [[C1]]
 ; CHECK-NEXT:    [[TMP0:%.*]] = select <vscale x 4 x i1> [[BROADCAST_SPLAT2]], <vscale x 4 x i1> [[BROADCAST_SPLAT]], <vscale x 4 x i1> zeroinitializer
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
@@ -87,7 +89,7 @@ define void @always_taken(ptr noalias %p0, ptr noalias %p1, i1 %c0, i1 %c1) vsca
 ; CHECK-NEXT:    [[TMP1:%.*]] = call i32 @llvm.experimental.get.vector.length.i32(i32 [[AVL]], i32 4, i1 true)
 ; CHECK-NEXT:    br i1 [[C0]], label %[[THEN_03:.*]], label %[[LATCH4]]
 ; CHECK:       [[THEN_03]]:
-; CHECK-NEXT:    br i1 [[C1]], label %[[THEN_14:.*]], label %[[LATCH4]]
+; CHECK-NEXT:    br i1 [[TMP5]], label %[[THEN_14:.*]], label %[[LATCH4]]
 ; CHECK:       [[THEN_14]]:
 ; CHECK-NEXT:    [[TMP2:%.*]] = getelementptr i32, ptr [[P0]], i32 [[EVL_BASED_IV]]
 ; CHECK-NEXT:    [[VP_OP_LOAD:%.*]] = call <vscale x 4 x i32> @llvm.vp.load.nxv4i32.p0(ptr align 4 [[TMP2]], <vscale x 4 x i1> [[TMP0]], i32 [[TMP1]])

--- a/llvm/test/Transforms/LoopVectorize/RISCV/predicated-costs.ll
+++ b/llvm/test/Transforms/LoopVectorize/RISCV/predicated-costs.ll
@@ -18,13 +18,17 @@ define void @nested(ptr noalias %p0, ptr noalias %p1, i1 %c0, i1 %c1) {
 ; CHECK-NEXT:    [[TMP0:%.*]] = select <vscale x 4 x i1> [[BROADCAST_SPLAT2]], <vscale x 4 x i1> [[BROADCAST_SPLAT]], <vscale x 4 x i1> zeroinitializer
 ; CHECK-NEXT:    br label %[[THEN_1:.*]]
 ; CHECK:       [[THEN_1]]:
-; CHECK-NEXT:    [[IV1:%.*]] = phi i32 [ 0, %[[LOOP]] ], [ [[INDEX_EVL_NEXT:%.*]], %[[THEN_1]] ]
-; CHECK-NEXT:    [[AVL:%.*]] = phi i32 [ 1024, %[[LOOP]] ], [ [[AVL_NEXT:%.*]], %[[THEN_1]] ]
+; CHECK-NEXT:    [[IV1:%.*]] = phi i32 [ 0, %[[LOOP]] ], [ [[INDEX_EVL_NEXT:%.*]], %[[LATCH4:.*]] ]
+; CHECK-NEXT:    [[AVL:%.*]] = phi i32 [ 1024, %[[LOOP]] ], [ [[AVL_NEXT:%.*]], %[[LATCH4]] ]
 ; CHECK-NEXT:    [[TMP1:%.*]] = call i32 @llvm.experimental.get.vector.length.i32(i32 [[AVL]], i32 4, i1 true)
+; CHECK-NEXT:    br i1 [[C0]], label %[[THEN_03:.*]], label %[[LATCH4]]
+; CHECK:       [[THEN_03]]:
 ; CHECK-NEXT:    [[GEP2:%.*]] = getelementptr i32, ptr [[P0]], i32 [[IV1]]
 ; CHECK-NEXT:    [[VP_OP_LOAD:%.*]] = call <vscale x 4 x i32> @llvm.vp.load.nxv4i32.p0(ptr align 4 [[GEP2]], <vscale x 4 x i1> [[TMP0]], i32 [[TMP1]])
 ; CHECK-NEXT:    [[TMP3:%.*]] = getelementptr i32, ptr [[P1]], <vscale x 4 x i32> [[VP_OP_LOAD]]
 ; CHECK-NEXT:    call void @llvm.vp.scatter.nxv4i32.nxv4p0(<vscale x 4 x i32> zeroinitializer, <vscale x 4 x ptr> align 4 [[TMP3]], <vscale x 4 x i1> [[TMP0]], i32 [[TMP1]])
+; CHECK-NEXT:    br label %[[LATCH4]]
+; CHECK:       [[LATCH4]]:
 ; CHECK-NEXT:    [[INDEX_EVL_NEXT]] = add nuw i32 [[TMP1]], [[IV1]]
 ; CHECK-NEXT:    [[AVL_NEXT]] = sub nuw i32 [[AVL]], [[TMP1]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = icmp eq i32 [[AVL_NEXT]], 0
@@ -76,13 +80,17 @@ define void @always_taken(ptr noalias %p0, ptr noalias %p1, i1 %c0, i1 %c1) {
 ; CHECK-NEXT:    [[TMP0:%.*]] = select <vscale x 4 x i1> [[BROADCAST_SPLAT2]], <vscale x 4 x i1> [[BROADCAST_SPLAT]], <vscale x 4 x i1> zeroinitializer
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[EVL_BASED_IV:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_EVL_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[AVL:%.*]] = phi i32 [ 1024, %[[VECTOR_PH]] ], [ [[AVL_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[EVL_BASED_IV:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_EVL_NEXT:%.*]], %[[LATCH4:.*]] ]
+; CHECK-NEXT:    [[AVL:%.*]] = phi i32 [ 1024, %[[VECTOR_PH]] ], [ [[AVL_NEXT:%.*]], %[[LATCH4]] ]
 ; CHECK-NEXT:    [[TMP1:%.*]] = call i32 @llvm.experimental.get.vector.length.i32(i32 [[AVL]], i32 4, i1 true)
+; CHECK-NEXT:    br i1 [[C0]], label %[[THEN_03:.*]], label %[[LATCH4]]
+; CHECK:       [[THEN_03]]:
 ; CHECK-NEXT:    [[TMP2:%.*]] = getelementptr i32, ptr [[P0]], i32 [[EVL_BASED_IV]]
 ; CHECK-NEXT:    [[VP_OP_LOAD:%.*]] = call <vscale x 4 x i32> @llvm.vp.load.nxv4i32.p0(ptr align 4 [[TMP2]], <vscale x 4 x i1> [[TMP0]], i32 [[TMP1]])
 ; CHECK-NEXT:    [[TMP3:%.*]] = getelementptr i32, ptr [[P1]], <vscale x 4 x i32> [[VP_OP_LOAD]]
 ; CHECK-NEXT:    call void @llvm.vp.scatter.nxv4i32.nxv4p0(<vscale x 4 x i32> zeroinitializer, <vscale x 4 x ptr> align 4 [[TMP3]], <vscale x 4 x i1> [[TMP0]], i32 [[TMP1]])
+; CHECK-NEXT:    br label %[[LATCH4]]
+; CHECK:       [[LATCH4]]:
 ; CHECK-NEXT:    [[INDEX_EVL_NEXT]] = add nuw i32 [[TMP1]], [[EVL_BASED_IV]]
 ; CHECK-NEXT:    [[AVL_NEXT]] = sub nuw i32 [[AVL]], [[TMP1]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = icmp eq i32 [[AVL_NEXT]], 0

--- a/llvm/test/Transforms/LoopVectorize/RISCV/predicated-costs.ll
+++ b/llvm/test/Transforms/LoopVectorize/RISCV/predicated-costs.ll
@@ -18,13 +18,19 @@ define void @nested(ptr noalias %p0, ptr noalias %p1, i1 %c0, i1 %c1) vscale_ran
 ; CHECK-NEXT:    [[TMP0:%.*]] = select <vscale x 4 x i1> [[BROADCAST_SPLAT2]], <vscale x 4 x i1> [[BROADCAST_SPLAT]], <vscale x 4 x i1> zeroinitializer
 ; CHECK-NEXT:    br label %[[THEN_1:.*]]
 ; CHECK:       [[THEN_1]]:
-; CHECK-NEXT:    [[IV1:%.*]] = phi i32 [ 0, %[[LOOP]] ], [ [[INDEX_EVL_NEXT:%.*]], %[[THEN_1]] ]
-; CHECK-NEXT:    [[AVL:%.*]] = phi i32 [ 1024, %[[LOOP]] ], [ [[AVL_NEXT:%.*]], %[[THEN_1]] ]
+; CHECK-NEXT:    [[IV1:%.*]] = phi i32 [ 0, %[[LOOP]] ], [ [[INDEX_EVL_NEXT:%.*]], %[[LATCH4:.*]] ]
+; CHECK-NEXT:    [[AVL:%.*]] = phi i32 [ 1024, %[[LOOP]] ], [ [[AVL_NEXT:%.*]], %[[LATCH4]] ]
 ; CHECK-NEXT:    [[TMP1:%.*]] = call i32 @llvm.experimental.get.vector.length.i32(i32 [[AVL]], i32 4, i1 true)
+; CHECK-NEXT:    br i1 [[C0]], label %[[THEN_03:.*]], label %[[LATCH4]]
+; CHECK:       [[THEN_03]]:
+; CHECK-NEXT:    br i1 [[C1]], label %[[THEN_14:.*]], label %[[LATCH4]]
+; CHECK:       [[THEN_14]]:
 ; CHECK-NEXT:    [[GEP2:%.*]] = getelementptr i32, ptr [[P0]], i32 [[IV1]]
 ; CHECK-NEXT:    [[VP_OP_LOAD:%.*]] = call <vscale x 4 x i32> @llvm.vp.load.nxv4i32.p0(ptr align 4 [[GEP2]], <vscale x 4 x i1> [[TMP0]], i32 [[TMP1]])
 ; CHECK-NEXT:    [[TMP3:%.*]] = getelementptr i32, ptr [[P1]], <vscale x 4 x i32> [[VP_OP_LOAD]]
 ; CHECK-NEXT:    call void @llvm.vp.scatter.nxv4i32.nxv4p0(<vscale x 4 x i32> zeroinitializer, <vscale x 4 x ptr> align 4 [[TMP3]], <vscale x 4 x i1> [[TMP0]], i32 [[TMP1]])
+; CHECK-NEXT:    br label %[[LATCH4]]
+; CHECK:       [[LATCH4]]:
 ; CHECK-NEXT:    [[INDEX_EVL_NEXT]] = add nuw i32 [[TMP1]], [[IV1]]
 ; CHECK-NEXT:    [[AVL_NEXT]] = sub nuw i32 [[AVL]], [[TMP1]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = icmp eq i32 [[AVL_NEXT]], 0
@@ -76,13 +82,19 @@ define void @always_taken(ptr noalias %p0, ptr noalias %p1, i1 %c0, i1 %c1) vsca
 ; CHECK-NEXT:    [[TMP0:%.*]] = select <vscale x 4 x i1> [[BROADCAST_SPLAT2]], <vscale x 4 x i1> [[BROADCAST_SPLAT]], <vscale x 4 x i1> zeroinitializer
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[EVL_BASED_IV:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_EVL_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[AVL:%.*]] = phi i32 [ 1024, %[[VECTOR_PH]] ], [ [[AVL_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[EVL_BASED_IV:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_EVL_NEXT:%.*]], %[[LATCH4:.*]] ]
+; CHECK-NEXT:    [[AVL:%.*]] = phi i32 [ 1024, %[[VECTOR_PH]] ], [ [[AVL_NEXT:%.*]], %[[LATCH4]] ]
 ; CHECK-NEXT:    [[TMP1:%.*]] = call i32 @llvm.experimental.get.vector.length.i32(i32 [[AVL]], i32 4, i1 true)
+; CHECK-NEXT:    br i1 [[C0]], label %[[THEN_03:.*]], label %[[LATCH4]]
+; CHECK:       [[THEN_03]]:
+; CHECK-NEXT:    br i1 [[C1]], label %[[THEN_14:.*]], label %[[LATCH4]]
+; CHECK:       [[THEN_14]]:
 ; CHECK-NEXT:    [[TMP2:%.*]] = getelementptr i32, ptr [[P0]], i32 [[EVL_BASED_IV]]
 ; CHECK-NEXT:    [[VP_OP_LOAD:%.*]] = call <vscale x 4 x i32> @llvm.vp.load.nxv4i32.p0(ptr align 4 [[TMP2]], <vscale x 4 x i1> [[TMP0]], i32 [[TMP1]])
 ; CHECK-NEXT:    [[TMP3:%.*]] = getelementptr i32, ptr [[P1]], <vscale x 4 x i32> [[VP_OP_LOAD]]
 ; CHECK-NEXT:    call void @llvm.vp.scatter.nxv4i32.nxv4p0(<vscale x 4 x i32> zeroinitializer, <vscale x 4 x ptr> align 4 [[TMP3]], <vscale x 4 x i1> [[TMP0]], i32 [[TMP1]])
+; CHECK-NEXT:    br label %[[LATCH4]]
+; CHECK:       [[LATCH4]]:
 ; CHECK-NEXT:    [[INDEX_EVL_NEXT]] = add nuw i32 [[TMP1]], [[EVL_BASED_IV]]
 ; CHECK-NEXT:    [[AVL_NEXT]] = sub nuw i32 [[AVL]], [[TMP1]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = icmp eq i32 [[AVL_NEXT]], 0

--- a/llvm/test/Transforms/LoopVectorize/RISCV/predicated-reverse-store.ll
+++ b/llvm/test/Transforms/LoopVectorize/RISCV/predicated-reverse-store.ll
@@ -11,11 +11,13 @@ define void @reverse_predicated_store(i1 %c, ptr %dst, i64 %n) #0 {
 ; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <vscale x 4 x i1> [[BROADCAST_SPLATINSERT]], <vscale x 4 x i1> poison, <vscale x 4 x i32> zeroinitializer
 ; CHECK-NEXT:    br label [[VECTOR_BODY:%.*]]
 ; CHECK:       vector.body:
-; CHECK-NEXT:    [[EVL_BASED_IV:%.*]] = phi i64 [ 0, [[FOR_BODY]] ], [ [[INDEX_EVL_NEXT:%.*]], [[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[AVL:%.*]] = phi i64 [ [[TMP0]], [[FOR_BODY]] ], [ [[AVL_NEXT:%.*]], [[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[EVL_BASED_IV:%.*]] = phi i64 [ 0, [[FOR_BODY]] ], [ [[CURRENT_ITERATION_NEXT:%.*]], [[LOOP_LATCH2:%.*]] ]
+; CHECK-NEXT:    [[AVL:%.*]] = phi i64 [ [[TMP0]], [[FOR_BODY]] ], [ [[AVL_NEXT:%.*]], [[LOOP_LATCH2]] ]
 ; CHECK-NEXT:    [[TMP1:%.*]] = call i32 @llvm.experimental.get.vector.length.i64(i64 [[AVL]], i32 4, i1 true)
 ; CHECK-NEXT:    [[IV:%.*]] = sub i64 [[N]], [[EVL_BASED_IV]]
 ; CHECK-NEXT:    [[IV_NEXT:%.*]] = add i64 [[IV]], -1
+; CHECK-NEXT:    br i1 [[C]], label [[IF_THEN1:%.*]], label [[LOOP_LATCH2]]
+; CHECK:       if.then1:
 ; CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr float, ptr [[DST:%.*]], i64 [[IV_NEXT]]
 ; CHECK-NEXT:    [[VP_REVERSE_MASK:%.*]] = call <vscale x 4 x i1> @llvm.experimental.vp.reverse.nxv4i1(<vscale x 4 x i1> [[BROADCAST_SPLAT]], <vscale x 4 x i1> splat (i1 true), i32 [[TMP1]])
 ; CHECK-NEXT:    [[TMP4:%.*]] = zext i32 [[TMP1]] to i64
@@ -24,8 +26,11 @@ define void @reverse_predicated_store(i1 %c, ptr %dst, i64 %n) #0 {
 ; CHECK-NEXT:    [[TMP9:%.*]] = getelementptr float, ptr [[ARRAYIDX]], i64 [[TMP7]]
 ; CHECK-NEXT:    [[TMP12:%.*]] = call <vscale x 4 x float> @llvm.experimental.vp.reverse.nxv4f32(<vscale x 4 x float> zeroinitializer, <vscale x 4 x i1> splat (i1 true), i32 [[TMP1]])
 ; CHECK-NEXT:    call void @llvm.vp.store.nxv4f32.p0(<vscale x 4 x float> [[TMP12]], ptr align 4 [[TMP9]], <vscale x 4 x i1> [[VP_REVERSE_MASK]], i32 [[TMP1]])
-; CHECK-NEXT:    [[INDEX_EVL_NEXT]] = add i64 [[TMP4]], [[EVL_BASED_IV]]
-; CHECK-NEXT:    [[AVL_NEXT]] = sub nuw i64 [[AVL]], [[TMP4]]
+; CHECK-NEXT:    br label [[LOOP_LATCH2]]
+; CHECK:       loop.latch2:
+; CHECK-NEXT:    [[TMP13:%.*]] = zext i32 [[TMP1]] to i64
+; CHECK-NEXT:    [[CURRENT_ITERATION_NEXT]] = add i64 [[TMP13]], [[EVL_BASED_IV]]
+; CHECK-NEXT:    [[AVL_NEXT]] = sub nuw i64 [[AVL]], [[TMP13]]
 ; CHECK-NEXT:    [[TMP11:%.*]] = icmp eq i64 [[AVL_NEXT]], 0
 ; CHECK-NEXT:    br i1 [[TMP11]], label [[MIDDLE_BLOCK:%.*]], label [[VECTOR_BODY]], !llvm.loop [[LOOP0:![0-9]+]]
 ; CHECK:       middle.block:

--- a/llvm/test/Transforms/LoopVectorize/RISCV/tail-folding-complex-mask.ll
+++ b/llvm/test/Transforms/LoopVectorize/RISCV/tail-folding-complex-mask.ll
@@ -19,26 +19,42 @@ define void @test(i64 %n, ptr noalias %src0, ptr noalias %src1, ptr noalias %src
 ; IF-EVL-NEXT:    [[BROADCAST_SPLATINSERT1:%.*]] = insertelement <vscale x 4 x i1> poison, i1 [[TMP0]], i64 0
 ; IF-EVL-NEXT:    [[BROADCAST_SPLAT2:%.*]] = shufflevector <vscale x 4 x i1> [[BROADCAST_SPLATINSERT1]], <vscale x 4 x i1> poison, <vscale x 4 x i32> zeroinitializer
 ; IF-EVL-NEXT:    [[TMP1:%.*]] = or <vscale x 4 x i1> [[BROADCAST_SPLAT]], [[BROADCAST_SPLAT2]]
-; IF-EVL-NEXT:    [[TMP3:%.*]] = select <vscale x 4 x i1> [[TMP2]], <vscale x 4 x i1> [[TMP1]], <vscale x 4 x i1> zeroinitializer
-; IF-EVL-NEXT:    [[TMP4:%.*]] = or <vscale x 4 x i1> [[BROADCAST_SPLAT]], [[TMP3]]
 ; IF-EVL-NEXT:    [[BROADCAST_SPLATINSERT3:%.*]] = insertelement <vscale x 4 x i1> poison, i1 [[C3]], i64 0
 ; IF-EVL-NEXT:    [[BROADCAST_SPLAT4:%.*]] = shufflevector <vscale x 4 x i1> [[BROADCAST_SPLATINSERT3]], <vscale x 4 x i1> poison, <vscale x 4 x i32> zeroinitializer
 ; IF-EVL-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; IF-EVL:       [[VECTOR_BODY]]:
-; IF-EVL-NEXT:    [[EVL_BASED_IV:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_EVL_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; IF-EVL-NEXT:    [[AVL:%.*]] = phi i64 [ [[N]], %[[VECTOR_PH]] ], [ [[AVL_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; IF-EVL-NEXT:    [[EVL_BASED_IV:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_EVL_NEXT:%.*]], %[[LATCH12:.*]] ]
+; IF-EVL-NEXT:    [[AVL:%.*]] = phi i64 [ [[N]], %[[VECTOR_PH]] ], [ [[AVL_NEXT:%.*]], %[[LATCH12]] ]
 ; IF-EVL-NEXT:    [[TMP7:%.*]] = call i32 @llvm.experimental.get.vector.length.i64(i64 [[AVL]], i32 4, i1 true)
+; IF-EVL-NEXT:    br i1 [[C1]], label %[[LOAD_V06:.*]], label %[[CHECK_COND15:.*]]
+; IF-EVL:       [[CHECK_COND15]]:
+; IF-EVL-NEXT:    br label %[[LOAD_V17:.*]]
+; IF-EVL:       [[LOAD_V06]]:
 ; IF-EVL-NEXT:    [[TMP10:%.*]] = getelementptr i32, ptr [[SRC0]], i64 [[EVL_BASED_IV]]
 ; IF-EVL-NEXT:    [[VP_OP_LOAD:%.*]] = call <vscale x 4 x i32> @llvm.vp.load.nxv4i32.p0(ptr align 4 [[TMP10]], <vscale x 4 x i1> [[BROADCAST_SPLAT]], i32 [[TMP7]])
-; IF-EVL-NEXT:    [[PREDPHI:%.*]] = select i1 [[C1]], <vscale x 4 x i32> [[VP_OP_LOAD]], <vscale x 4 x i32> zeroinitializer
+; IF-EVL-NEXT:    br label %[[LOAD_V17]]
+; IF-EVL:       [[LOAD_V17]]:
+; IF-EVL-NEXT:    [[TMP5:%.*]] = phi <vscale x 4 x i32> [ poison, %[[CHECK_COND15]] ], [ [[VP_OP_LOAD]], %[[LOAD_V06]] ]
+; IF-EVL-NEXT:    [[TMP6:%.*]] = phi <vscale x 4 x i1> [ zeroinitializer, %[[CHECK_COND15]] ], [ [[BROADCAST_SPLAT]], %[[LOAD_V06]] ]
+; IF-EVL-NEXT:    [[TMP13:%.*]] = phi <vscale x 4 x i1> [ [[TMP2]], %[[CHECK_COND15]] ], [ zeroinitializer, %[[LOAD_V06]] ]
+; IF-EVL-NEXT:    [[TMP8:%.*]] = phi <vscale x 4 x i1> [ [[TMP1]], %[[CHECK_COND15]] ], [ zeroinitializer, %[[LOAD_V06]] ]
+; IF-EVL-NEXT:    [[TMP9:%.*]] = select <vscale x 4 x i1> [[TMP13]], <vscale x 4 x i1> [[TMP8]], <vscale x 4 x i1> zeroinitializer
+; IF-EVL-NEXT:    [[TMP4:%.*]] = or <vscale x 4 x i1> [[BROADCAST_SPLAT]], [[TMP9]]
+; IF-EVL-NEXT:    [[PREDPHI:%.*]] = select <vscale x 4 x i1> [[TMP6]], <vscale x 4 x i32> [[TMP5]], <vscale x 4 x i32> zeroinitializer
 ; IF-EVL-NEXT:    [[TMP11:%.*]] = getelementptr i32, ptr [[SRC1]], i64 [[EVL_BASED_IV]]
 ; IF-EVL-NEXT:    [[VP_OP_LOAD7:%.*]] = call <vscale x 4 x i32> @llvm.vp.load.nxv4i32.p0(ptr align 4 [[TMP11]], <vscale x 4 x i1> [[TMP4]], i32 [[TMP7]])
 ; IF-EVL-NEXT:    [[TMP12:%.*]] = add <vscale x 4 x i32> [[VP_OP_LOAD7]], [[PREDPHI]]
 ; IF-EVL-NEXT:    [[PREDPHI8:%.*]] = select <vscale x 4 x i1> [[TMP4]], <vscale x 4 x i32> [[TMP12]], <vscale x 4 x i32> zeroinitializer
+; IF-EVL-NEXT:    br i1 [[C3]], label %[[LOAD_V210:.*]], label %[[LATCH12]]
+; IF-EVL:       [[LOAD_V210]]:
 ; IF-EVL-NEXT:    [[TMP18:%.*]] = getelementptr i32, ptr [[SRC2]], i64 [[EVL_BASED_IV]]
 ; IF-EVL-NEXT:    [[WIDE_MASKED_LOAD:%.*]] = call <vscale x 4 x i32> @llvm.vp.load.nxv4i32.p0(ptr align 4 [[TMP18]], <vscale x 4 x i1> [[BROADCAST_SPLAT4]], i32 [[TMP7]])
 ; IF-EVL-NEXT:    [[TMP19:%.*]] = add <vscale x 4 x i32> [[WIDE_MASKED_LOAD]], [[PREDPHI8]]
-; IF-EVL-NEXT:    [[PREDPHI9:%.*]] = select i1 [[C3]], <vscale x 4 x i32> [[TMP19]], <vscale x 4 x i32> [[PREDPHI8]]
+; IF-EVL-NEXT:    br label %[[LATCH12]]
+; IF-EVL:       [[LATCH12]]:
+; IF-EVL-NEXT:    [[TMP15:%.*]] = phi <vscale x 4 x i32> [ poison, %[[LOAD_V17]] ], [ [[TMP19]], %[[LOAD_V210]] ]
+; IF-EVL-NEXT:    [[TMP16:%.*]] = phi <vscale x 4 x i1> [ zeroinitializer, %[[LOAD_V17]] ], [ [[BROADCAST_SPLAT4]], %[[LOAD_V210]] ]
+; IF-EVL-NEXT:    [[PREDPHI9:%.*]] = select <vscale x 4 x i1> [[TMP16]], <vscale x 4 x i32> [[TMP15]], <vscale x 4 x i32> [[PREDPHI8]]
 ; IF-EVL-NEXT:    [[TMP20:%.*]] = getelementptr inbounds i32, ptr [[DST]], i64 [[EVL_BASED_IV]]
 ; IF-EVL-NEXT:    call void @llvm.vp.store.nxv4i32.p0(<vscale x 4 x i32> [[PREDPHI9]], ptr align 4 [[TMP20]], <vscale x 4 x i1> splat (i1 true), i32 [[TMP7]])
 ; IF-EVL-NEXT:    [[TMP21:%.*]] = zext i32 [[TMP7]] to i64
@@ -69,24 +85,40 @@ define void @test(i64 %n, ptr noalias %src0, ptr noalias %src1, ptr noalias %src
 ; NO-VP-NEXT:    [[BROADCAST_SPLATINSERT3:%.*]] = insertelement <vscale x 4 x i1> poison, i1 [[TMP4]], i64 0
 ; NO-VP-NEXT:    [[BROADCAST_SPLAT4:%.*]] = shufflevector <vscale x 4 x i1> [[BROADCAST_SPLATINSERT3]], <vscale x 4 x i1> poison, <vscale x 4 x i32> zeroinitializer
 ; NO-VP-NEXT:    [[TMP9:%.*]] = or <vscale x 4 x i1> [[BROADCAST_SPLAT2]], [[BROADCAST_SPLAT4]]
-; NO-VP-NEXT:    [[TMP10:%.*]] = select <vscale x 4 x i1> [[TMP6]], <vscale x 4 x i1> [[TMP9]], <vscale x 4 x i1> zeroinitializer
-; NO-VP-NEXT:    [[TMP8:%.*]] = or <vscale x 4 x i1> [[BROADCAST_SPLAT2]], [[TMP10]]
 ; NO-VP-NEXT:    [[BROADCAST_SPLATINSERT4:%.*]] = insertelement <vscale x 4 x i1> poison, i1 [[C3]], i64 0
 ; NO-VP-NEXT:    [[TMP12:%.*]] = shufflevector <vscale x 4 x i1> [[BROADCAST_SPLATINSERT4]], <vscale x 4 x i1> poison, <vscale x 4 x i32> zeroinitializer
 ; NO-VP-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; NO-VP:       [[VECTOR_BODY]]:
-; NO-VP-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; NO-VP-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LATCH12:.*]] ]
+; NO-VP-NEXT:    br i1 [[C1]], label %[[LOAD_V06:.*]], label %[[CHECK_COND15:.*]]
+; NO-VP:       [[CHECK_COND15]]:
+; NO-VP-NEXT:    br label %[[LOAD_V17:.*]]
+; NO-VP:       [[LOAD_V06]]:
 ; NO-VP-NEXT:    [[TMP13:%.*]] = getelementptr i32, ptr [[SRC0]], i64 [[INDEX]]
 ; NO-VP-NEXT:    [[WIDE_MASKED_LOAD:%.*]] = call <vscale x 4 x i32> @llvm.masked.load.nxv4i32.p0(ptr align 4 [[TMP13]], <vscale x 4 x i1> [[BROADCAST_SPLAT2]], <vscale x 4 x i32> poison)
-; NO-VP-NEXT:    [[PREDPHI:%.*]] = select i1 [[C1]], <vscale x 4 x i32> [[WIDE_MASKED_LOAD]], <vscale x 4 x i32> zeroinitializer
+; NO-VP-NEXT:    br label %[[LOAD_V17]]
+; NO-VP:       [[LOAD_V17]]:
+; NO-VP-NEXT:    [[TMP7:%.*]] = phi <vscale x 4 x i32> [ poison, %[[CHECK_COND15]] ], [ [[WIDE_MASKED_LOAD]], %[[LOAD_V06]] ]
+; NO-VP-NEXT:    [[TMP20:%.*]] = phi <vscale x 4 x i1> [ zeroinitializer, %[[CHECK_COND15]] ], [ [[BROADCAST_SPLAT2]], %[[LOAD_V06]] ]
+; NO-VP-NEXT:    [[TMP21:%.*]] = phi <vscale x 4 x i1> [ [[TMP6]], %[[CHECK_COND15]] ], [ zeroinitializer, %[[LOAD_V06]] ]
+; NO-VP-NEXT:    [[TMP10:%.*]] = phi <vscale x 4 x i1> [ [[TMP9]], %[[CHECK_COND15]] ], [ zeroinitializer, %[[LOAD_V06]] ]
+; NO-VP-NEXT:    [[TMP11:%.*]] = select <vscale x 4 x i1> [[TMP21]], <vscale x 4 x i1> [[TMP10]], <vscale x 4 x i1> zeroinitializer
+; NO-VP-NEXT:    [[TMP8:%.*]] = or <vscale x 4 x i1> [[BROADCAST_SPLAT2]], [[TMP11]]
+; NO-VP-NEXT:    [[PREDPHI:%.*]] = select <vscale x 4 x i1> [[TMP20]], <vscale x 4 x i32> [[TMP7]], <vscale x 4 x i32> zeroinitializer
 ; NO-VP-NEXT:    [[TMP14:%.*]] = getelementptr i32, ptr [[SRC1]], i64 [[INDEX]]
 ; NO-VP-NEXT:    [[WIDE_MASKED_LOAD5:%.*]] = call <vscale x 4 x i32> @llvm.masked.load.nxv4i32.p0(ptr align 4 [[TMP14]], <vscale x 4 x i1> [[TMP8]], <vscale x 4 x i32> poison)
 ; NO-VP-NEXT:    [[TMP15:%.*]] = add <vscale x 4 x i32> [[WIDE_MASKED_LOAD5]], [[PREDPHI]]
 ; NO-VP-NEXT:    [[PREDPHI6:%.*]] = select <vscale x 4 x i1> [[TMP8]], <vscale x 4 x i32> [[TMP15]], <vscale x 4 x i32> zeroinitializer
+; NO-VP-NEXT:    br i1 [[C3]], label %[[LOAD_V210:.*]], label %[[LATCH12]]
+; NO-VP:       [[LOAD_V210]]:
 ; NO-VP-NEXT:    [[TMP16:%.*]] = getelementptr i32, ptr [[SRC2]], i64 [[INDEX]]
 ; NO-VP-NEXT:    [[WIDE_MASKED_LOAD7:%.*]] = call <vscale x 4 x i32> @llvm.masked.load.nxv4i32.p0(ptr align 4 [[TMP16]], <vscale x 4 x i1> [[TMP12]], <vscale x 4 x i32> poison)
 ; NO-VP-NEXT:    [[TMP17:%.*]] = add <vscale x 4 x i32> [[WIDE_MASKED_LOAD7]], [[PREDPHI6]]
-; NO-VP-NEXT:    [[PREDPHI8:%.*]] = select i1 [[C3]], <vscale x 4 x i32> [[TMP17]], <vscale x 4 x i32> [[PREDPHI6]]
+; NO-VP-NEXT:    br label %[[LATCH12]]
+; NO-VP:       [[LATCH12]]:
+; NO-VP-NEXT:    [[TMP22:%.*]] = phi <vscale x 4 x i32> [ poison, %[[LOAD_V17]] ], [ [[TMP17]], %[[LOAD_V210]] ]
+; NO-VP-NEXT:    [[TMP23:%.*]] = phi <vscale x 4 x i1> [ zeroinitializer, %[[LOAD_V17]] ], [ [[TMP12]], %[[LOAD_V210]] ]
+; NO-VP-NEXT:    [[PREDPHI8:%.*]] = select <vscale x 4 x i1> [[TMP23]], <vscale x 4 x i32> [[TMP22]], <vscale x 4 x i32> [[PREDPHI6]]
 ; NO-VP-NEXT:    [[TMP18:%.*]] = getelementptr inbounds i32, ptr [[DST]], i64 [[INDEX]]
 ; NO-VP-NEXT:    store <vscale x 4 x i32> [[PREDPHI8]], ptr [[TMP18]], align 4
 ; NO-VP-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], [[TMP1]]

--- a/llvm/test/Transforms/LoopVectorize/RISCV/tail-folding-complex-mask.ll
+++ b/llvm/test/Transforms/LoopVectorize/RISCV/tail-folding-complex-mask.ll
@@ -85,6 +85,8 @@ define void @test(i64 %n, ptr noalias %src0, ptr noalias %src1, ptr noalias %src
 ; NO-VP-NEXT:    [[BROADCAST_SPLATINSERT3:%.*]] = insertelement <vscale x 4 x i1> poison, i1 [[TMP4]], i64 0
 ; NO-VP-NEXT:    [[BROADCAST_SPLAT4:%.*]] = shufflevector <vscale x 4 x i1> [[BROADCAST_SPLATINSERT3]], <vscale x 4 x i1> poison, <vscale x 4 x i32> zeroinitializer
 ; NO-VP-NEXT:    [[TMP9:%.*]] = or <vscale x 4 x i1> [[BROADCAST_SPLAT2]], [[BROADCAST_SPLAT4]]
+; NO-VP-NEXT:    [[TMP24:%.*]] = extractelement <vscale x 4 x i1> [[TMP9]], i64 0
+; NO-VP-NEXT:    [[TMP25:%.*]] = freeze i1 [[TMP24]]
 ; NO-VP-NEXT:    [[BROADCAST_SPLATINSERT4:%.*]] = insertelement <vscale x 4 x i1> poison, i1 [[C3]], i64 0
 ; NO-VP-NEXT:    [[TMP12:%.*]] = shufflevector <vscale x 4 x i1> [[BROADCAST_SPLATINSERT4]], <vscale x 4 x i1> poison, <vscale x 4 x i32> zeroinitializer
 ; NO-VP-NEXT:    br label %[[VECTOR_BODY:.*]]
@@ -92,7 +94,7 @@ define void @test(i64 %n, ptr noalias %src0, ptr noalias %src1, ptr noalias %src
 ; NO-VP-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LATCH12:.*]] ]
 ; NO-VP-NEXT:    br i1 [[C1]], label %[[LOAD_V06:.*]], label %[[CHECK_COND15:.*]]
 ; NO-VP:       [[CHECK_COND15]]:
-; NO-VP-NEXT:    br label %[[LOAD_V17:.*]]
+; NO-VP-NEXT:    br i1 [[TMP25]], label %[[LOAD_V17:.*]], label %[[LOAD_V2_CHECK9:.*]]
 ; NO-VP:       [[LOAD_V06]]:
 ; NO-VP-NEXT:    [[TMP13:%.*]] = getelementptr i32, ptr [[SRC0]], i64 [[INDEX]]
 ; NO-VP-NEXT:    [[WIDE_MASKED_LOAD:%.*]] = call <vscale x 4 x i32> @llvm.masked.load.nxv4i32.p0(ptr align 4 [[TMP13]], <vscale x 4 x i1> [[BROADCAST_SPLAT2]], <vscale x 4 x i32> poison)
@@ -108,7 +110,11 @@ define void @test(i64 %n, ptr noalias %src0, ptr noalias %src1, ptr noalias %src
 ; NO-VP-NEXT:    [[TMP14:%.*]] = getelementptr i32, ptr [[SRC1]], i64 [[INDEX]]
 ; NO-VP-NEXT:    [[WIDE_MASKED_LOAD5:%.*]] = call <vscale x 4 x i32> @llvm.masked.load.nxv4i32.p0(ptr align 4 [[TMP14]], <vscale x 4 x i1> [[TMP8]], <vscale x 4 x i32> poison)
 ; NO-VP-NEXT:    [[TMP15:%.*]] = add <vscale x 4 x i32> [[WIDE_MASKED_LOAD5]], [[PREDPHI]]
-; NO-VP-NEXT:    [[PREDPHI6:%.*]] = select <vscale x 4 x i1> [[TMP8]], <vscale x 4 x i32> [[TMP15]], <vscale x 4 x i32> zeroinitializer
+; NO-VP-NEXT:    br label %[[LOAD_V2_CHECK9]]
+; NO-VP:       [[LOAD_V2_CHECK9]]:
+; NO-VP-NEXT:    [[TMP26:%.*]] = phi <vscale x 4 x i32> [ poison, %[[CHECK_COND15]] ], [ [[TMP15]], %[[LOAD_V17]] ]
+; NO-VP-NEXT:    [[TMP27:%.*]] = phi <vscale x 4 x i1> [ zeroinitializer, %[[CHECK_COND15]] ], [ [[TMP8]], %[[LOAD_V17]] ]
+; NO-VP-NEXT:    [[PREDPHI6:%.*]] = select <vscale x 4 x i1> [[TMP27]], <vscale x 4 x i32> [[TMP26]], <vscale x 4 x i32> zeroinitializer
 ; NO-VP-NEXT:    br i1 [[C3]], label %[[LOAD_V210:.*]], label %[[LATCH12]]
 ; NO-VP:       [[LOAD_V210]]:
 ; NO-VP-NEXT:    [[TMP16:%.*]] = getelementptr i32, ptr [[SRC2]], i64 [[INDEX]]
@@ -116,8 +122,8 @@ define void @test(i64 %n, ptr noalias %src0, ptr noalias %src1, ptr noalias %src
 ; NO-VP-NEXT:    [[TMP17:%.*]] = add <vscale x 4 x i32> [[WIDE_MASKED_LOAD7]], [[PREDPHI6]]
 ; NO-VP-NEXT:    br label %[[LATCH12]]
 ; NO-VP:       [[LATCH12]]:
-; NO-VP-NEXT:    [[TMP22:%.*]] = phi <vscale x 4 x i32> [ poison, %[[LOAD_V17]] ], [ [[TMP17]], %[[LOAD_V210]] ]
-; NO-VP-NEXT:    [[TMP23:%.*]] = phi <vscale x 4 x i1> [ zeroinitializer, %[[LOAD_V17]] ], [ [[TMP12]], %[[LOAD_V210]] ]
+; NO-VP-NEXT:    [[TMP22:%.*]] = phi <vscale x 4 x i32> [ poison, %[[LOAD_V2_CHECK9]] ], [ [[TMP17]], %[[LOAD_V210]] ]
+; NO-VP-NEXT:    [[TMP23:%.*]] = phi <vscale x 4 x i1> [ zeroinitializer, %[[LOAD_V2_CHECK9]] ], [ [[TMP12]], %[[LOAD_V210]] ]
 ; NO-VP-NEXT:    [[PREDPHI8:%.*]] = select <vscale x 4 x i1> [[TMP23]], <vscale x 4 x i32> [[TMP22]], <vscale x 4 x i32> [[PREDPHI6]]
 ; NO-VP-NEXT:    [[TMP18:%.*]] = getelementptr inbounds i32, ptr [[DST]], i64 [[INDEX]]
 ; NO-VP-NEXT:    store <vscale x 4 x i32> [[PREDPHI8]], ptr [[TMP18]], align 4

--- a/llvm/test/Transforms/LoopVectorize/VPlan/AArch64/vplan-memory-op-decisions.ll
+++ b/llvm/test/Transforms/LoopVectorize/VPlan/AArch64/vplan-memory-op-decisions.ll
@@ -750,19 +750,19 @@ define void @blend_with_identical_incoming_values_address(ptr noalias %A, i1 %c)
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    vector.body:
 ; CHECK-NEXT:      ir<%iv> = WIDEN-INDUCTION nuw nsw ir<0>, ir<1>, vp<[[VP0]]>
-; CHECK-NEXT:    Successor(s): else
-; CHECK-EMPTY:
-; CHECK-NEXT:    else:
-; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%c>
-; CHECK-NEXT:      EMIT ir<%idx.else> = add nsw ir<%iv>, ir<-1>, vp<[[VP4]]>
-; CHECK-NEXT:    Successor(s): then
+; CHECK-NEXT:      EMIT branch-on-cond ir<%c>
+; CHECK-NEXT:    Successor(s): then, else
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    then:
 ; CHECK-NEXT:      EMIT ir<%idx.then> = add nsw ir<%iv>, ir<-1>, ir<%c>
 ; CHECK-NEXT:    Successor(s): latch
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    latch:
-; CHECK-NEXT:      BLEND ir<%idx> = ir<%idx.else>/vp<[[VP4]]> ir<%idx.then>/ir<%c>
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP5:%[0-9]+]]> = phi [ ir<%idx.else>, else ], [ ir<poison>, then ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP6:%[0-9]+]]> = phi [ vp<[[VP4:%[0-9]+]]>, else ], [ ir<false>, then ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP7:%[0-9]+]]> = phi [ ir<poison>, else ], [ ir<%idx.then>, then ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP8:%[0-9]+]]> = phi [ ir<false>, else ], [ ir<%c>, then ]
+; CHECK-NEXT:      BLEND ir<%idx> = vp<%5>/vp<[[VP6]]> vp<%7>/vp<[[VP8]]>
 ; CHECK-NEXT:      EMIT ir<%gep> = getelementptr inbounds ir<%A>, ir<%idx>
 ; CHECK-NEXT:      EMIT-SCALAR ir<%lv> = load ir<%gep>
 ; CHECK-NEXT:      EMIT ir<%add> = add ir<%lv>, ir<1>
@@ -772,6 +772,11 @@ define void @blend_with_identical_incoming_values_address(ptr noalias %A, i1 %c)
 ; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1]]>
 ; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2]]>
 ; CHECK-NEXT:    No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:    else:
+; CHECK-NEXT:      EMIT vp<[[VP4]]> = not ir<%c>
+; CHECK-NEXT:      EMIT ir<%idx.else> = add nsw ir<%iv>, ir<-1>, vp<[[VP4]]>
+; CHECK-NEXT:    Successor(s): latch
 ; CHECK-NEXT:  }
 ; CHECK-NEXT:  Successor(s): middle.block
 ; CHECK-EMPTY:
@@ -993,29 +998,34 @@ define void @blend_with_different_incoming_values_address(ptr noalias %A, ptr no
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    vector.body:
 ; CHECK-NEXT:      ir<%iv> = WIDEN-INDUCTION nuw nsw ir<0>, ir<1>, vp<[[VP0]]>
-; CHECK-NEXT:    Successor(s): else
-; CHECK-EMPTY:
-; CHECK-NEXT:    else:
-; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%c>
-; CHECK-NEXT:      EMIT ir<%idx.else> = add nsw ir<%iv>, ir<-2>, vp<[[VP4]]>
-; CHECK-NEXT:    Successor(s): then
+; CHECK-NEXT:      EMIT branch-on-cond ir<%c>
+; CHECK-NEXT:    Successor(s): then, else
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    then:
 ; CHECK-NEXT:      EMIT ir<%idx.then> = add nsw ir<%iv>, ir<-1>, ir<%c>
 ; CHECK-NEXT:    Successor(s): latch
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    latch:
-; CHECK-NEXT:      BLEND ir<%idx> = ir<%idx.else>/vp<[[VP4]]> ir<%idx.then>/ir<%c>
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP5:%[0-9]+]]> = phi [ ir<%idx.else>, else ], [ ir<poison>, then ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP6:%[0-9]+]]> = phi [ vp<[[VP4:%[0-9]+]]>, else ], [ ir<false>, then ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP7:%[0-9]+]]> = phi [ ir<poison>, else ], [ ir<%idx.then>, then ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP8:%[0-9]+]]> = phi [ ir<false>, else ], [ ir<%c>, then ]
+; CHECK-NEXT:      BLEND ir<%idx> = vp<%5>/vp<[[VP6]]> vp<%7>/vp<[[VP8]]>
 ; CHECK-NEXT:      EMIT ir<%gep.B> = getelementptr inbounds ir<%B>, ir<%idx>
 ; CHECK-NEXT:      EMIT-SCALAR ir<%lv> = load ir<%gep.B>
 ; CHECK-NEXT:      EMIT ir<%gep.A> = getelementptr inbounds ir<%A>, ir<%iv>
-; CHECK-NEXT:      vp<[[VP5:%[0-9]+]]> = vector-pointer inbounds i32, ir<%gep.A>, ir<1>
-; CHECK-NEXT:      WIDEN store vp<[[VP5]]>, ir<%lv>
+; CHECK-NEXT:      vp<[[VP9:%[0-9]+]]> = vector-pointer inbounds i32, ir<%gep.A>, ir<1>
+; CHECK-NEXT:      WIDEN store vp<[[VP9]]>, ir<%lv>
 ; CHECK-NEXT:      EMIT ir<%iv.next> = add nuw nsw ir<%iv>, ir<1>
 ; CHECK-NEXT:      EMIT ir<%ec> = icmp eq ir<%iv>, ir<100>
 ; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1]]>
 ; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2]]>
 ; CHECK-NEXT:    No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:    else:
+; CHECK-NEXT:      EMIT vp<[[VP4]]> = not ir<%c>
+; CHECK-NEXT:      EMIT ir<%idx.else> = add nsw ir<%iv>, ir<-2>, vp<[[VP4]]>
+; CHECK-NEXT:    Successor(s): latch
 ; CHECK-NEXT:  }
 ; CHECK-NEXT:  Successor(s): middle.block
 ; CHECK-EMPTY:

--- a/llvm/test/Transforms/LoopVectorize/VPlan/dissolve-replicate-regions.ll
+++ b/llvm/test/Transforms/LoopVectorize/VPlan/dissolve-replicate-regions.ll
@@ -32,6 +32,10 @@ define void @predicated_load(i1 %c, ptr %ptr, ptr %dst) {
 ; SCALAR-NEXT:      vp<[[VP6:%[0-9]+]]> = SCALAR-STEPS vp<[[VP5]]>, ir<1>, vp<[[VP0]]>
 ; SCALAR-NEXT:      vp<[[VP7:%[0-9]+]]> = SCALAR-STEPS vp<[[VP5]]>, ir<1>, vp<[[VP0]]>, vp<[[VP0]]>
 ; SCALAR-NEXT:      EMIT branch-on-cond ir<%c>
+; SCALAR-NEXT:    Successor(s): if.then, loop.latch
+; SCALAR-EMPTY:
+; SCALAR-NEXT:    if.then:
+; SCALAR-NEXT:      EMIT branch-on-cond ir<%c>
 ; SCALAR-NEXT:    Successor(s): pred.load.if, pred.load.continue
 ; SCALAR-EMPTY:
 ; SCALAR-NEXT:    pred.load.if:
@@ -40,19 +44,23 @@ define void @predicated_load(i1 %c, ptr %ptr, ptr %dst) {
 ; SCALAR-NEXT:    Successor(s): pred.load.continue
 ; SCALAR-EMPTY:
 ; SCALAR-NEXT:    pred.load.continue:
-; SCALAR-NEXT:      EMIT-SCALAR vp<[[VP9:%[0-9]+]]> = phi [ ir<poison>, vector.body ], [ ir<%lv>, pred.load.if ]
+; SCALAR-NEXT:      EMIT-SCALAR vp<[[VP9:%[0-9]+]]> = phi [ ir<poison>, if.then ], [ ir<%lv>, pred.load.if ]
 ; SCALAR-NEXT:      EMIT branch-on-cond ir<%c>
 ; SCALAR-NEXT:    Successor(s): pred.load.if, pred.load.continue
 ; SCALAR-EMPTY:
 ; SCALAR-NEXT:    pred.load.if:
-; SCALAR-NEXT:      CLONE ir<%gep>.1 = getelementptr ir<%ptr>, vp<[[VP7]]>
-; SCALAR-NEXT:      CLONE ir<%lv>.1 = load ir<%gep>.1
 ; SCALAR-NEXT:    Successor(s): pred.load.continue
 ; SCALAR-EMPTY:
 ; SCALAR-NEXT:    pred.load.continue:
-; SCALAR-NEXT:      EMIT-SCALAR vp<[[VP11:%[0-9]+]]> = phi [ ir<poison>, pred.load.continue ], [ ir<%lv>.1, pred.load.if ]
-; SCALAR-NEXT:      BLEND ir<%pred.val> = ir<0> vp<%9>/ir<%c>
-; SCALAR-NEXT:      BLEND ir<%pred.val>.1 = ir<0> vp<%11>/ir<%c>
+; SCALAR-NEXT:    Successor(s): loop.latch
+; SCALAR-EMPTY:
+; SCALAR-NEXT:    loop.latch:
+; SCALAR-NEXT:      WIDEN-PHI vp<[[VP11:%[0-9]+]]> = phi [ ir<poison>, vector.body ], [ vp<[[VP9]]>, pred.load.continue ]
+; SCALAR-NEXT:      WIDEN-PHI vp<[[VP12:%[0-9]+]]> = phi [ ir<poison>, vector.body ], [ vp<[[VP9]]>, pred.load.continue ]
+; SCALAR-NEXT:      WIDEN-PHI vp<[[VP13:%[0-9]+]]> = phi [ ir<false>, vector.body ], [ ir<%c>, pred.load.continue ]
+; SCALAR-NEXT:      WIDEN-PHI vp<[[VP14:%[0-9]+]]> = phi [ ir<false>, vector.body ], [ ir<%c>, pred.load.continue ]
+; SCALAR-NEXT:      BLEND ir<%pred.val> = ir<0> vp<%11>/vp<[[VP13]]>
+; SCALAR-NEXT:      BLEND ir<%pred.val>.1 = ir<0> vp<%12>/vp<[[VP14]]>
 ; SCALAR-NEXT:      CLONE ir<%gep.dst> = getelementptr ir<%dst>, vp<[[VP6]]>
 ; SCALAR-NEXT:      CLONE ir<%gep.dst>.1 = getelementptr ir<%dst>, vp<[[VP7]]>
 ; SCALAR-NEXT:      CLONE store ir<%pred.val>, ir<%gep.dst>
@@ -109,6 +117,10 @@ define void @predicated_load(i1 %c, ptr %ptr, ptr %dst) {
 ; VECTOR-NEXT:    vector.body:
 ; VECTOR-NEXT:      vp<[[VP7:%[0-9]+]]> = SCALAR-STEPS vp<[[VP6]]>, ir<1>, vp<[[VP0]]>
 ; VECTOR-NEXT:      EMIT branch-on-cond ir<%c>
+; VECTOR-NEXT:    Successor(s): if.then, loop.latch
+; VECTOR-EMPTY:
+; VECTOR-NEXT:    if.then:
+; VECTOR-NEXT:      EMIT branch-on-cond ir<%c>
 ; VECTOR-NEXT:    Successor(s): pred.load.if, pred.load.continue
 ; VECTOR-EMPTY:
 ; VECTOR-NEXT:    pred.load.if:
@@ -119,7 +131,7 @@ define void @predicated_load(i1 %c, ptr %ptr, ptr %dst) {
 ; VECTOR-NEXT:    Successor(s): pred.load.continue
 ; VECTOR-EMPTY:
 ; VECTOR-NEXT:    pred.load.continue:
-; VECTOR-NEXT:      WIDEN-PHI vp<[[VP11:%[0-9]+]]> = phi [ ir<poison>, vector.body ], [ vp<[[VP10]]>, pred.load.if ]
+; VECTOR-NEXT:      WIDEN-PHI vp<[[VP11:%[0-9]+]]> = phi [ ir<poison>, if.then ], [ vp<[[VP10]]>, pred.load.if ]
 ; VECTOR-NEXT:      EMIT branch-on-cond ir<%c>
 ; VECTOR-NEXT:    Successor(s): pred.load.if, pred.load.continue
 ; VECTOR-EMPTY:
@@ -136,35 +148,31 @@ define void @predicated_load(i1 %c, ptr %ptr, ptr %dst) {
 ; VECTOR-NEXT:    Successor(s): pred.load.if, pred.load.continue
 ; VECTOR-EMPTY:
 ; VECTOR-NEXT:    pred.load.if:
-; VECTOR-NEXT:      vp<[[VP17:%[0-9]+]]> = SCALAR-STEPS vp<[[VP6]]>, ir<1>, vp<[[VP0]]>, vp<[[VP0]]>
-; VECTOR-NEXT:      CLONE ir<%gep>.2 = getelementptr ir<%ptr>, vp<[[VP17]]>
-; VECTOR-NEXT:      CLONE ir<%lv>.2 = load ir<%gep>.2
-; VECTOR-NEXT:      EMIT vp<[[VP18:%[0-9]+]]> = insertelement ir<poison>, ir<%lv>.2, ir<0>
 ; VECTOR-NEXT:    Successor(s): pred.load.continue
 ; VECTOR-EMPTY:
 ; VECTOR-NEXT:    pred.load.continue:
-; VECTOR-NEXT:      WIDEN-PHI vp<[[VP19:%[0-9]+]]> = phi [ ir<poison>, pred.load.continue ], [ vp<[[VP18]]>, pred.load.if ]
 ; VECTOR-NEXT:      EMIT branch-on-cond ir<%c>
 ; VECTOR-NEXT:    Successor(s): pred.load.if, pred.load.continue
 ; VECTOR-EMPTY:
 ; VECTOR-NEXT:    pred.load.if:
-; VECTOR-NEXT:      EMIT vp<[[VP21:%[0-9]+]]> = add vp<[[VP0]]>, ir<1>
-; VECTOR-NEXT:      vp<[[VP22:%[0-9]+]]> = SCALAR-STEPS vp<[[VP6]]>, ir<1>, vp<[[VP0]]>, vp<[[VP21]]>
-; VECTOR-NEXT:      CLONE ir<%gep>.3 = getelementptr ir<%ptr>, vp<[[VP22]]>
-; VECTOR-NEXT:      CLONE ir<%lv>.3 = load ir<%gep>.3
-; VECTOR-NEXT:      EMIT vp<[[VP23:%[0-9]+]]> = insertelement vp<[[VP19]]>, ir<%lv>.3, ir<1>
 ; VECTOR-NEXT:    Successor(s): pred.load.continue
 ; VECTOR-EMPTY:
 ; VECTOR-NEXT:    pred.load.continue:
-; VECTOR-NEXT:      WIDEN-PHI vp<[[VP24:%[0-9]+]]> = phi [ vp<[[VP19]]>, pred.load.continue ], [ vp<[[VP23]]>, pred.load.if ]
-; VECTOR-NEXT:      BLEND ir<%pred.val> = ir<0> vp<%15>/vp<[[VP5]]>
-; VECTOR-NEXT:      BLEND ir<%pred.val>.1 = ir<0> vp<%24>/vp<[[VP5]]>
+; VECTOR-NEXT:    Successor(s): loop.latch
+; VECTOR-EMPTY:
+; VECTOR-NEXT:    loop.latch:
+; VECTOR-NEXT:      WIDEN-PHI vp<[[VP18:%[0-9]+]]> = phi [ ir<poison>, vector.body ], [ vp<[[VP15]]>, pred.load.continue ]
+; VECTOR-NEXT:      WIDEN-PHI vp<[[VP19:%[0-9]+]]> = phi [ ir<poison>, vector.body ], [ vp<[[VP15]]>, pred.load.continue ]
+; VECTOR-NEXT:      WIDEN-PHI vp<[[VP20:%[0-9]+]]> = phi [ ir<false>, vector.body ], [ vp<[[VP5]]>, pred.load.continue ]
+; VECTOR-NEXT:      WIDEN-PHI vp<[[VP21:%[0-9]+]]> = phi [ ir<false>, vector.body ], [ vp<[[VP5]]>, pred.load.continue ]
+; VECTOR-NEXT:      BLEND ir<%pred.val> = ir<0> vp<%18>/vp<[[VP20]]>
+; VECTOR-NEXT:      BLEND ir<%pred.val>.1 = ir<0> vp<%19>/vp<[[VP21]]>
 ; VECTOR-NEXT:      CLONE ir<%gep.dst> = getelementptr ir<%dst>, vp<[[VP7]]>
-; VECTOR-NEXT:      EMIT vp<[[VP25:%[0-9]+]]> = mul nuw nsw vp<[[VP0]]>, ir<1>
-; VECTOR-NEXT:      vp<[[VP26:%[0-9]+]]> = vector-pointer i8, ir<%gep.dst>, ir<1>
-; VECTOR-NEXT:      vp<[[VP27:%[0-9]+]]> = vector-pointer i8, ir<%gep.dst>, ir<1>, vp<[[VP25]]>
-; VECTOR-NEXT:      WIDEN store vp<[[VP26]]>, ir<%pred.val>
-; VECTOR-NEXT:      WIDEN store vp<[[VP27]]>, ir<%pred.val>.1
+; VECTOR-NEXT:      EMIT vp<[[VP22:%[0-9]+]]> = mul nuw nsw vp<[[VP0]]>, ir<1>
+; VECTOR-NEXT:      vp<[[VP23:%[0-9]+]]> = vector-pointer i8, ir<%gep.dst>, ir<1>
+; VECTOR-NEXT:      vp<[[VP24:%[0-9]+]]> = vector-pointer i8, ir<%gep.dst>, ir<1>, vp<[[VP22]]>
+; VECTOR-NEXT:      WIDEN store vp<[[VP23]]>, ir<%pred.val>
+; VECTOR-NEXT:      WIDEN store vp<[[VP24]]>, ir<%pred.val>.1
 ; VECTOR-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP6]]>, vp<[[VP1]]>
 ; VECTOR-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2]]>
 ; VECTOR-NEXT:    No successors

--- a/llvm/test/Transforms/LoopVectorize/VPlan/dissolve-replicate-regions.ll
+++ b/llvm/test/Transforms/LoopVectorize/VPlan/dissolve-replicate-regions.ll
@@ -31,7 +31,7 @@ define void @predicated_load(i1 %c, ptr %ptr, ptr %dst) {
 ; SCALAR-NEXT:    vector.body:
 ; SCALAR-NEXT:      vp<[[VP6:%[0-9]+]]> = SCALAR-STEPS vp<[[VP5]]>, ir<1>, vp<[[VP0]]>
 ; SCALAR-NEXT:      vp<[[VP7:%[0-9]+]]> = SCALAR-STEPS vp<[[VP5]]>, ir<1>, vp<[[VP0]]>, vp<[[VP0]]>
-; SCALAR-NEXT:      EMIT branch-on-cond ir<%c>
+; SCALAR-NEXT:      EMIT branch-on-cond ir<%c> (!vplan.prof.estimated estimated {1073741824, 1073741824})
 ; SCALAR-NEXT:    Successor(s): if.then, loop.latch
 ; SCALAR-EMPTY:
 ; SCALAR-NEXT:    if.then:
@@ -49,18 +49,21 @@ define void @predicated_load(i1 %c, ptr %ptr, ptr %dst) {
 ; SCALAR-NEXT:    Successor(s): pred.load.if, pred.load.continue
 ; SCALAR-EMPTY:
 ; SCALAR-NEXT:    pred.load.if:
+; SCALAR-NEXT:      CLONE ir<%gep>.1 = getelementptr ir<%ptr>, vp<[[VP7]]>
+; SCALAR-NEXT:      CLONE ir<%lv>.1 = load ir<%gep>.1
 ; SCALAR-NEXT:    Successor(s): pred.load.continue
 ; SCALAR-EMPTY:
 ; SCALAR-NEXT:    pred.load.continue:
+; SCALAR-NEXT:      EMIT-SCALAR vp<[[VP11:%[0-9]+]]> = phi [ ir<poison>, pred.load.continue ], [ ir<%lv>.1, pred.load.if ]
 ; SCALAR-NEXT:    Successor(s): loop.latch
 ; SCALAR-EMPTY:
 ; SCALAR-NEXT:    loop.latch:
-; SCALAR-NEXT:      WIDEN-PHI vp<[[VP11:%[0-9]+]]> = phi [ ir<poison>, vector.body ], [ vp<[[VP9]]>, pred.load.continue ]
 ; SCALAR-NEXT:      WIDEN-PHI vp<[[VP12:%[0-9]+]]> = phi [ ir<poison>, vector.body ], [ vp<[[VP9]]>, pred.load.continue ]
-; SCALAR-NEXT:      WIDEN-PHI vp<[[VP13:%[0-9]+]]> = phi [ ir<false>, vector.body ], [ ir<%c>, pred.load.continue ]
+; SCALAR-NEXT:      WIDEN-PHI vp<[[VP13:%[0-9]+]]> = phi [ ir<poison>, vector.body ], [ vp<[[VP11]]>, pred.load.continue ]
 ; SCALAR-NEXT:      WIDEN-PHI vp<[[VP14:%[0-9]+]]> = phi [ ir<false>, vector.body ], [ ir<%c>, pred.load.continue ]
-; SCALAR-NEXT:      BLEND ir<%pred.val> = ir<0> vp<%11>/vp<[[VP13]]>
-; SCALAR-NEXT:      BLEND ir<%pred.val>.1 = ir<0> vp<%12>/vp<[[VP14]]>
+; SCALAR-NEXT:      WIDEN-PHI vp<[[VP15:%[0-9]+]]> = phi [ ir<false>, vector.body ], [ ir<%c>, pred.load.continue ]
+; SCALAR-NEXT:      BLEND ir<%pred.val> = ir<0> vp<%12>/vp<[[VP14]]>
+; SCALAR-NEXT:      BLEND ir<%pred.val>.1 = ir<0> vp<%13>/vp<[[VP15]]>
 ; SCALAR-NEXT:      CLONE ir<%gep.dst> = getelementptr ir<%dst>, vp<[[VP6]]>
 ; SCALAR-NEXT:      CLONE ir<%gep.dst>.1 = getelementptr ir<%dst>, vp<[[VP7]]>
 ; SCALAR-NEXT:      CLONE store ir<%pred.val>, ir<%gep.dst>
@@ -116,7 +119,7 @@ define void @predicated_load(i1 %c, ptr %ptr, ptr %dst) {
 ; VECTOR-EMPTY:
 ; VECTOR-NEXT:    vector.body:
 ; VECTOR-NEXT:      vp<[[VP7:%[0-9]+]]> = SCALAR-STEPS vp<[[VP6]]>, ir<1>, vp<[[VP0]]>
-; VECTOR-NEXT:      EMIT branch-on-cond ir<%c>
+; VECTOR-NEXT:      EMIT branch-on-cond ir<%c> (!vplan.prof.estimated estimated {1073741824, 1073741824})
 ; VECTOR-NEXT:    Successor(s): if.then, loop.latch
 ; VECTOR-EMPTY:
 ; VECTOR-NEXT:    if.then:
@@ -148,31 +151,42 @@ define void @predicated_load(i1 %c, ptr %ptr, ptr %dst) {
 ; VECTOR-NEXT:    Successor(s): pred.load.if, pred.load.continue
 ; VECTOR-EMPTY:
 ; VECTOR-NEXT:    pred.load.if:
+; VECTOR-NEXT:      vp<[[VP17:%[0-9]+]]> = SCALAR-STEPS vp<[[VP6]]>, ir<1>, vp<[[VP0]]>, vp<[[VP0]]>
+; VECTOR-NEXT:      CLONE ir<%gep>.2 = getelementptr ir<%ptr>, vp<[[VP17]]>
+; VECTOR-NEXT:      CLONE ir<%lv>.2 = load ir<%gep>.2
+; VECTOR-NEXT:      EMIT vp<[[VP18:%[0-9]+]]> = insertelement ir<poison>, ir<%lv>.2, ir<0>
 ; VECTOR-NEXT:    Successor(s): pred.load.continue
 ; VECTOR-EMPTY:
 ; VECTOR-NEXT:    pred.load.continue:
+; VECTOR-NEXT:      WIDEN-PHI vp<[[VP19:%[0-9]+]]> = phi [ ir<poison>, pred.load.continue ], [ vp<[[VP18]]>, pred.load.if ]
 ; VECTOR-NEXT:      EMIT branch-on-cond ir<%c>
 ; VECTOR-NEXT:    Successor(s): pred.load.if, pred.load.continue
 ; VECTOR-EMPTY:
 ; VECTOR-NEXT:    pred.load.if:
+; VECTOR-NEXT:      EMIT vp<[[VP21:%[0-9]+]]> = add vp<[[VP0]]>, ir<1>
+; VECTOR-NEXT:      vp<[[VP22:%[0-9]+]]> = SCALAR-STEPS vp<[[VP6]]>, ir<1>, vp<[[VP0]]>, vp<[[VP21]]>
+; VECTOR-NEXT:      CLONE ir<%gep>.3 = getelementptr ir<%ptr>, vp<[[VP22]]>
+; VECTOR-NEXT:      CLONE ir<%lv>.3 = load ir<%gep>.3
+; VECTOR-NEXT:      EMIT vp<[[VP23:%[0-9]+]]> = insertelement vp<[[VP19]]>, ir<%lv>.3, ir<1>
 ; VECTOR-NEXT:    Successor(s): pred.load.continue
 ; VECTOR-EMPTY:
 ; VECTOR-NEXT:    pred.load.continue:
+; VECTOR-NEXT:      WIDEN-PHI vp<[[VP24:%[0-9]+]]> = phi [ vp<[[VP19]]>, pred.load.continue ], [ vp<[[VP23]]>, pred.load.if ]
 ; VECTOR-NEXT:    Successor(s): loop.latch
 ; VECTOR-EMPTY:
 ; VECTOR-NEXT:    loop.latch:
-; VECTOR-NEXT:      WIDEN-PHI vp<[[VP18:%[0-9]+]]> = phi [ ir<poison>, vector.body ], [ vp<[[VP15]]>, pred.load.continue ]
-; VECTOR-NEXT:      WIDEN-PHI vp<[[VP19:%[0-9]+]]> = phi [ ir<poison>, vector.body ], [ vp<[[VP15]]>, pred.load.continue ]
-; VECTOR-NEXT:      WIDEN-PHI vp<[[VP20:%[0-9]+]]> = phi [ ir<false>, vector.body ], [ vp<[[VP5]]>, pred.load.continue ]
-; VECTOR-NEXT:      WIDEN-PHI vp<[[VP21:%[0-9]+]]> = phi [ ir<false>, vector.body ], [ vp<[[VP5]]>, pred.load.continue ]
-; VECTOR-NEXT:      BLEND ir<%pred.val> = ir<0> vp<%18>/vp<[[VP20]]>
-; VECTOR-NEXT:      BLEND ir<%pred.val>.1 = ir<0> vp<%19>/vp<[[VP21]]>
+; VECTOR-NEXT:      WIDEN-PHI vp<[[VP25:%[0-9]+]]> = phi [ ir<poison>, vector.body ], [ vp<[[VP15]]>, pred.load.continue ]
+; VECTOR-NEXT:      WIDEN-PHI vp<[[VP26:%[0-9]+]]> = phi [ ir<poison>, vector.body ], [ vp<[[VP24]]>, pred.load.continue ]
+; VECTOR-NEXT:      WIDEN-PHI vp<[[VP27:%[0-9]+]]> = phi [ ir<false>, vector.body ], [ vp<[[VP5]]>, pred.load.continue ]
+; VECTOR-NEXT:      WIDEN-PHI vp<[[VP28:%[0-9]+]]> = phi [ ir<false>, vector.body ], [ vp<[[VP5]]>, pred.load.continue ]
+; VECTOR-NEXT:      BLEND ir<%pred.val> = ir<0> vp<%25>/vp<[[VP27]]>
+; VECTOR-NEXT:      BLEND ir<%pred.val>.1 = ir<0> vp<%26>/vp<[[VP28]]>
 ; VECTOR-NEXT:      CLONE ir<%gep.dst> = getelementptr ir<%dst>, vp<[[VP7]]>
-; VECTOR-NEXT:      EMIT vp<[[VP22:%[0-9]+]]> = mul nuw nsw vp<[[VP0]]>, ir<1>
-; VECTOR-NEXT:      vp<[[VP23:%[0-9]+]]> = vector-pointer i8, ir<%gep.dst>, ir<1>
-; VECTOR-NEXT:      vp<[[VP24:%[0-9]+]]> = vector-pointer i8, ir<%gep.dst>, ir<1>, vp<[[VP22]]>
-; VECTOR-NEXT:      WIDEN store vp<[[VP23]]>, ir<%pred.val>
-; VECTOR-NEXT:      WIDEN store vp<[[VP24]]>, ir<%pred.val>.1
+; VECTOR-NEXT:      EMIT vp<[[VP29:%[0-9]+]]> = mul nuw nsw vp<[[VP0]]>, ir<1>
+; VECTOR-NEXT:      vp<[[VP30:%[0-9]+]]> = vector-pointer i8, ir<%gep.dst>, ir<1>
+; VECTOR-NEXT:      vp<[[VP31:%[0-9]+]]> = vector-pointer i8, ir<%gep.dst>, ir<1>, vp<[[VP29]]>
+; VECTOR-NEXT:      WIDEN store vp<[[VP30]]>, ir<%pred.val>
+; VECTOR-NEXT:      WIDEN store vp<[[VP31]]>, ir<%pred.val>.1
 ; VECTOR-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP6]]>, vp<[[VP1]]>
 ; VECTOR-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2]]>
 ; VECTOR-NEXT:    No successors

--- a/llvm/test/Transforms/LoopVectorize/VPlan/phi-with-fastflags-vplan.ll
+++ b/llvm/test/Transforms/LoopVectorize/VPlan/phi-with-fastflags-vplan.ll
@@ -23,9 +23,17 @@ define void @f(ptr noalias %p, i1 %c) {
 ; CHECK-NEXT:      CLONE ir<%gep> = getelementptr ir<%p>, vp<[[VP4]]>
 ; CHECK-NEXT:      vp<[[VP5:%[0-9]+]]> = vector-pointer float, ir<%gep>, ir<1>
 ; CHECK-NEXT:      WIDEN ir<%x> = load vp<[[VP5]]>
-; CHECK-NEXT:      BLEND ir<%phi> = fast ir<%x> ir<0.000000e+00>/ir<%c>
-; CHECK-NEXT:      vp<[[VP6:%[0-9]+]]> = vector-pointer float, ir<%gep>, ir<1>
-; CHECK-NEXT:      WIDEN store vp<[[VP6]]>, ir<%phi>
+; CHECK-NEXT:      EMIT branch-on-cond ir<%c>
+; CHECK-NEXT:    Successor(s): then, latch
+; CHECK-EMPTY:
+; CHECK-NEXT:    then:
+; CHECK-NEXT:    Successor(s): latch
+; CHECK-EMPTY:
+; CHECK-NEXT:    latch:
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP6:%[0-9]+]]> = phi [ ir<false>, vector.body ], [ ir<%c>, then ]
+; CHECK-NEXT:      BLEND ir<%phi> = fast ir<%x> ir<0.000000e+00>/vp<[[VP6]]>
+; CHECK-NEXT:      vp<[[VP7:%[0-9]+]]> = vector-pointer float, ir<%gep>, ir<1>
+; CHECK-NEXT:      WIDEN store vp<[[VP7]]>, ir<%phi>
 ; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1]]>
 ; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2]]>
 ; CHECK-NEXT:    No successors

--- a/llvm/test/Transforms/LoopVectorize/VPlan/predicator.ll
+++ b/llvm/test/Transforms/LoopVectorize/VPlan/predicator.ll
@@ -399,19 +399,21 @@ define void @diamond_phi2(ptr %a, i1 %c1, i1 %c2) {
 ; CHECK-NEXT:    bb2:
 ; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%c0>
 ; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, vp<[[VP4]]>
+; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = freeze ir<%c2>
 ; CHECK-NEXT:    Successor(s): bb1
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb1:
 ; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, ir<%c0>
+; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = freeze ir<%c1>
 ; CHECK-NEXT:    Successor(s): bb4
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb4:
-; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = logical-and vp<[[VP4]]>, ir<%c2>
-; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = logical-and ir<%c0>, ir<%c1>
-; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = or vp<[[VP5]]>, vp<[[VP6]]>
+; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = logical-and vp<[[VP4]]>, ir<%c2>
+; CHECK-NEXT:      EMIT vp<[[VP8:%[0-9]+]]> = logical-and ir<%c0>, ir<%c1>
+; CHECK-NEXT:      EMIT vp<[[VP9:%[0-9]+]]> = or vp<[[VP7]]>, vp<[[VP8]]>
 ; CHECK-NEXT:      BLEND ir<%phi> = ir<%add2>/vp<[[VP4]]> ir<%add1>/ir<%c0>
 ; CHECK-NEXT:      EMIT ir<%gep> = getelementptr ir<%a>, ir<%iv>
-; CHECK-NEXT:      EMIT store ir<%phi>, ir<%gep>, vp<[[VP7]]>
+; CHECK-NEXT:      EMIT store ir<%phi>, ir<%gep>, vp<[[VP9]]>
 ; CHECK-NEXT:    Successor(s): bb5
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb5:
@@ -480,12 +482,14 @@ define void @blend_masks(ptr noalias %p, i1 %c0, i1 %c1, i1 %c2, i1 %c3, i1 %c4)
 ; CHECK-NEXT:    Successor(s): bb1, bb2
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb1:
-; CHECK-NEXT:      EMIT branch-on-cond ir<%c1>
+; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = freeze ir<%c1>
+; CHECK-NEXT:      EMIT branch-on-cond vp<[[VP5]]>
 ; CHECK-NEXT:    Successor(s): bb3, bb4
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb3:
-; CHECK-NEXT:      EMIT vp<[[VP12:%[0-9]+]]> = logical-and ir<%c0>, ir<%c1>
-; CHECK-NEXT:      EMIT branch-on-cond ir<%c2>
+; CHECK-NEXT:      EMIT vp<[[VP15:%[0-9]+]]> = logical-and ir<%c0>, ir<%c1>
+; CHECK-NEXT:      EMIT vp<[[VP16:%[0-9]+]]> = freeze ir<%c2>
+; CHECK-NEXT:      EMIT branch-on-cond vp<[[VP16]]>
 ; CHECK-NEXT:    Successor(s): bb8, bb5
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb8:
@@ -496,39 +500,41 @@ define void @blend_masks(ptr noalias %p, i1 %c0, i1 %c1, i1 %c2, i1 %c3, i1 %c4)
 ; CHECK-NEXT:    No successors
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb5:
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP13:%[0-9]+]]> = phi [ vp<[[VP6:%[0-9]+]]>, bb4 ], [ ir<false>, bb3 ]
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP14:%[0-9]+]]> = phi [ ir<false>, bb4 ], [ vp<[[VP12]]>, bb3 ]
-; CHECK-NEXT:      EMIT vp<[[VP15:%[0-9]+]]> = logical-and vp<[[VP13]]>, ir<%c3>
-; CHECK-NEXT:      EMIT vp<[[VP16:%[0-9]+]]> = not ir<%c2>
-; CHECK-NEXT:      EMIT vp<[[VP17:%[0-9]+]]> = logical-and vp<[[VP14]]>, vp<[[VP16]]>
-; CHECK-NEXT:      EMIT vp<[[VP18:%[0-9]+]]> = or vp<[[VP15]]>, vp<[[VP17]]>
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP17:%[0-9]+]]> = phi [ vp<[[VP7:%[0-9]+]]>, bb4 ], [ ir<false>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP18:%[0-9]+]]> = phi [ ir<false>, bb4 ], [ vp<[[VP15]]>, bb3 ]
+; CHECK-NEXT:      EMIT vp<[[VP19:%[0-9]+]]> = logical-and vp<[[VP17]]>, ir<%c3>
+; CHECK-NEXT:      EMIT vp<[[VP20:%[0-9]+]]> = not ir<%c2>
+; CHECK-NEXT:      EMIT vp<[[VP21:%[0-9]+]]> = logical-and vp<[[VP18]]>, vp<[[VP20]]>
+; CHECK-NEXT:      EMIT vp<[[VP22:%[0-9]+]]> = or vp<[[VP19]]>, vp<[[VP21]]>
 ; CHECK-NEXT:    Successor(s): bb7
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb7:
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP19:%[0-9]+]]> = phi [ vp<[[VP18]]>, bb5 ], [ ir<false>, bb6 ]
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP20:%[0-9]+]]> = phi [ ir<false>, bb5 ], [ vp<[[VP11:%[0-9]+]]>, bb6 ]
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP21:%[0-9]+]]> = phi [ ir<false>, bb5 ], [ vp<[[VP11]]>, bb6 ]
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP22:%[0-9]+]]> = phi [ vp<[[VP18]]>, bb5 ], [ ir<false>, bb6 ]
-; CHECK-NEXT:      EMIT vp<[[VP23:%[0-9]+]]> = logical-and vp<[[VP21]]>, ir<%c4>
-; CHECK-NEXT:      EMIT vp<[[VP24:%[0-9]+]]> = or vp<[[VP23]]>, vp<[[VP22]]>
-; CHECK-NEXT:      BLEND ir<%phi> = ir<0>/vp<[[VP19]]> ir<1>/vp<[[VP20]]>
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP23:%[0-9]+]]> = phi [ vp<[[VP22]]>, bb5 ], [ ir<false>, bb6 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP24:%[0-9]+]]> = phi [ ir<false>, bb5 ], [ vp<[[VP13:%[0-9]+]]>, bb6 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP25:%[0-9]+]]> = phi [ ir<false>, bb5 ], [ vp<[[VP13]]>, bb6 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP26:%[0-9]+]]> = phi [ vp<[[VP22]]>, bb5 ], [ ir<false>, bb6 ]
+; CHECK-NEXT:      EMIT vp<[[VP27:%[0-9]+]]> = logical-and vp<[[VP25]]>, ir<%c4>
+; CHECK-NEXT:      EMIT vp<[[VP28:%[0-9]+]]> = or vp<[[VP27]]>, vp<[[VP26]]>
+; CHECK-NEXT:      BLEND ir<%phi> = ir<0>/vp<[[VP23]]> ir<1>/vp<[[VP24]]>
 ; CHECK-NEXT:      EMIT ir<%gep> = getelementptr ir<%p>, ir<%iv>
-; CHECK-NEXT:      EMIT store ir<%phi>, ir<%gep>, vp<[[VP24]]>
+; CHECK-NEXT:      EMIT store ir<%phi>, ir<%gep>, vp<[[VP28]]>
 ; CHECK-NEXT:    Successor(s): bb8
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb4:
-; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = not ir<%c1>
-; CHECK-NEXT:      EMIT vp<[[VP6]]> = logical-and ir<%c0>, vp<[[VP5]]>
-; CHECK-NEXT:      EMIT branch-on-cond ir<%c3>
+; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = not ir<%c1>
+; CHECK-NEXT:      EMIT vp<[[VP7]]> = logical-and ir<%c0>, vp<[[VP6]]>
+; CHECK-NEXT:      EMIT vp<[[VP8:%[0-9]+]]> = freeze ir<%c3>
+; CHECK-NEXT:      EMIT branch-on-cond vp<[[VP8]]>
 ; CHECK-NEXT:    Successor(s): bb5, bb6
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb6:
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP7:%[0-9]+]]> = phi [ ir<false>, bb2 ], [ vp<[[VP6]]>, bb4 ]
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP8:%[0-9]+]]> = phi [ vp<[[VP4:%[0-9]+]]>, bb2 ], [ ir<false>, bb4 ]
-; CHECK-NEXT:      EMIT vp<[[VP9:%[0-9]+]]> = not ir<%c3>
-; CHECK-NEXT:      EMIT vp<[[VP10:%[0-9]+]]> = logical-and vp<[[VP7]]>, vp<[[VP9]]>
-; CHECK-NEXT:      EMIT vp<[[VP11]]> = or vp<[[VP10]]>, vp<[[VP8]]>
-; CHECK-NEXT:      EMIT branch-on-cond ir<%c4>
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP9:%[0-9]+]]> = phi [ ir<false>, bb2 ], [ vp<[[VP7]]>, bb4 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP10:%[0-9]+]]> = phi [ vp<[[VP4:%[0-9]+]]>, bb2 ], [ ir<false>, bb4 ]
+; CHECK-NEXT:      EMIT vp<[[VP11:%[0-9]+]]> = not ir<%c3>
+; CHECK-NEXT:      EMIT vp<[[VP12:%[0-9]+]]> = logical-and vp<[[VP9]]>, vp<[[VP11]]>
+; CHECK-NEXT:      EMIT vp<[[VP13]]> = or vp<[[VP12]]>, vp<[[VP10]]>
+; CHECK-NEXT:      EMIT vp<[[VP14:%[0-9]+]]> = freeze ir<%c4>
+; CHECK-NEXT:      EMIT branch-on-cond vp<[[VP14]]>
 ; CHECK-NEXT:    Successor(s): bb7, bb8
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb2:
@@ -599,13 +605,14 @@ define void @blend_masks_triangle_phi(ptr noalias %p, i1 %c0, i1 %c1) {
 ; CHECK-NEXT:    Successor(s): bb1, bb2
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb1:
-; CHECK-NEXT:      EMIT branch-on-cond ir<%c1>
+; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = freeze ir<%c1>
+; CHECK-NEXT:      EMIT branch-on-cond vp<[[VP4]]>
 ; CHECK-NEXT:    Successor(s): bb3, bb2
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb3:
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP9:%[0-9]+]]> = phi [ ir<%c0>, bb1 ], [ vp<[[VP4:%[0-9]+]]>, bb2 ]
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP10:%[0-9]+]]> = phi [ ir<false>, bb1 ], [ vp<[[VP8:%[0-9]+]]>, bb2 ]
-; CHECK-NEXT:      BLEND ir<%phi> = ir<0>/vp<[[VP9]]> ir<1>/vp<[[VP10]]>
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP10:%[0-9]+]]> = phi [ ir<%c0>, bb1 ], [ vp<[[VP5:%[0-9]+]]>, bb2 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP11:%[0-9]+]]> = phi [ ir<false>, bb1 ], [ vp<[[VP9:%[0-9]+]]>, bb2 ]
+; CHECK-NEXT:      BLEND ir<%phi> = ir<0>/vp<[[VP10]]> ir<1>/vp<[[VP11]]>
 ; CHECK-NEXT:      EMIT ir<%gep> = getelementptr ir<%p>, ir<%iv>
 ; CHECK-NEXT:      EMIT store ir<%phi>, ir<%gep>
 ; CHECK-NEXT:      EMIT ir<%iv.next> = add ir<%iv>, ir<1>
@@ -615,11 +622,11 @@ define void @blend_masks_triangle_phi(ptr noalias %p, i1 %c0, i1 %c1) {
 ; CHECK-NEXT:    No successors
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb2:
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP4]]> = phi [ ir<false>, vector.body ], [ ir<%c0>, bb1 ]
-; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = not ir<%c1>
-; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = logical-and ir<%c0>, vp<[[VP5]]>
-; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = not ir<%c0>
-; CHECK-NEXT:      EMIT vp<[[VP8]]> = or vp<[[VP6]]>, vp<[[VP7]]>
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP5]]> = phi [ ir<false>, vector.body ], [ ir<%c0>, bb1 ]
+; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = not ir<%c1>
+; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = logical-and ir<%c0>, vp<[[VP6]]>
+; CHECK-NEXT:      EMIT vp<[[VP8:%[0-9]+]]> = not ir<%c0>
+; CHECK-NEXT:      EMIT vp<[[VP9]]> = or vp<[[VP7]]>, vp<[[VP8]]>
 ; CHECK-NEXT:    Successor(s): bb3
 ; CHECK-NEXT:  }
 ; CHECK-NEXT:  Successor(s): middle.block
@@ -770,17 +777,18 @@ define void @simplifiable_blend(i1 %c1, i1 %c2, i1 %c3, i32 %x, i32 %y, ptr %p) 
 ; CHECK-NEXT:    Successor(s): A, B
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    A:
-; CHECK-NEXT:      EMIT branch-on-cond ir<%c2>
+; CHECK-NEXT:      EMIT vp<[[VP8:%[0-9]+]]> = freeze ir<%c2>
+; CHECK-NEXT:      EMIT branch-on-cond vp<[[VP8]]>
 ; CHECK-NEXT:    Successor(s): C, D
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    C:
-; CHECK-NEXT:      EMIT vp<[[VP9:%[0-9]+]]> = logical-and ir<%c1>, ir<%c2>
+; CHECK-NEXT:      EMIT vp<[[VP11:%[0-9]+]]> = logical-and ir<%c1>, ir<%c2>
 ; CHECK-NEXT:    Successor(s): latch
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    latch:
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP10:%[0-9]+]]> = phi [ vp<[[VP4:%[0-9]+]]>, F ], [ ir<false>, D ], [ ir<false>, C ]
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP11:%[0-9]+]]> = phi [ ir<false>, F ], [ ir<%c1>, D ], [ ir<%c1>, C ]
-; CHECK-NEXT:      BLEND ir<%phi> = ir<%y>/vp<[[VP10]]> ir<%x>/vp<[[VP11]]>
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP12:%[0-9]+]]> = phi [ vp<[[VP4:%[0-9]+]]>, F ], [ ir<false>, D ], [ ir<false>, C ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP13:%[0-9]+]]> = phi [ ir<false>, F ], [ ir<%c1>, D ], [ ir<%c1>, C ]
+; CHECK-NEXT:      BLEND ir<%phi> = ir<%y>/vp<[[VP12]]> ir<%x>/vp<[[VP13]]>
 ; CHECK-NEXT:      EMIT ir<%gep> = getelementptr ir<%p>, ir<%iv>
 ; CHECK-NEXT:      EMIT store ir<%phi>, ir<%gep>
 ; CHECK-NEXT:      EMIT ir<%iv.next> = add ir<%iv>, ir<1>
@@ -790,21 +798,22 @@ define void @simplifiable_blend(i1 %c1, i1 %c2, i1 %c3, i32 %x, i32 %y, ptr %p) 
 ; CHECK-NEXT:    No successors
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    D:
-; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = not ir<%c2>
-; CHECK-NEXT:      EMIT vp<[[VP8:%[0-9]+]]> = logical-and ir<%c1>, vp<[[VP7]]>
+; CHECK-NEXT:      EMIT vp<[[VP9:%[0-9]+]]> = not ir<%c2>
+; CHECK-NEXT:      EMIT vp<[[VP10:%[0-9]+]]> = logical-and ir<%c1>, vp<[[VP9]]>
 ; CHECK-NEXT:    Successor(s): latch
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    B:
 ; CHECK-NEXT:      EMIT vp<[[VP4]]> = not ir<%c1>
-; CHECK-NEXT:      EMIT branch-on-cond ir<%c3>
+; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = freeze ir<%c3>
+; CHECK-NEXT:      EMIT branch-on-cond vp<[[VP5]]>
 ; CHECK-NEXT:    Successor(s): F, E
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    F:
 ; CHECK-NEXT:    Successor(s): latch
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    E:
-; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = not ir<%c3>
-; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = logical-and vp<[[VP4]]>, vp<[[VP5]]>
+; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = not ir<%c3>
+; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = logical-and vp<[[VP4]]>, vp<[[VP6]]>
 ; CHECK-NEXT:    Successor(s): F
 ; CHECK-NEXT:  }
 ; CHECK-NEXT:  Successor(s): middle.block
@@ -864,18 +873,19 @@ define void @phi_doesnt_postdom_incoming(i1 %c1, i1 %c2, i32 %x, i32 %y, ptr %p)
 ; CHECK-NEXT:    Successor(s): A, B
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    A:
-; CHECK-NEXT:      EMIT branch-on-cond ir<%c2>
+; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = freeze ir<%c2>
+; CHECK-NEXT:      EMIT branch-on-cond vp<[[VP5]]>
 ; CHECK-NEXT:    Successor(s): C, latch
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    C:
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP5:%[0-9]+]]> = phi [ vp<[[VP4:%[0-9]+]]>, B ], [ ir<false>, A ]
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP6:%[0-9]+]]> = phi [ ir<false>, B ], [ ir<%c1>, A ]
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP7:%[0-9]+]]> = phi [ vp<[[VP4]]>, B ], [ ir<false>, A ]
-; CHECK-NEXT:      EMIT vp<[[VP8:%[0-9]+]]> = logical-and ir<%c1>, ir<%c2>
-; CHECK-NEXT:      EMIT vp<[[VP9:%[0-9]+]]> = or vp<[[VP7]]>, vp<[[VP8]]>
-; CHECK-NEXT:      BLEND ir<%phi> = ir<%y>/vp<[[VP5]]> ir<%x>/vp<[[VP6]]>
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP6:%[0-9]+]]> = phi [ vp<[[VP4:%[0-9]+]]>, B ], [ ir<false>, A ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP7:%[0-9]+]]> = phi [ ir<false>, B ], [ ir<%c1>, A ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP8:%[0-9]+]]> = phi [ vp<[[VP4]]>, B ], [ ir<false>, A ]
+; CHECK-NEXT:      EMIT vp<[[VP9:%[0-9]+]]> = logical-and ir<%c1>, ir<%c2>
+; CHECK-NEXT:      EMIT vp<[[VP10:%[0-9]+]]> = or vp<[[VP8]]>, vp<[[VP9]]>
+; CHECK-NEXT:      BLEND ir<%phi> = ir<%y>/vp<[[VP6]]> ir<%x>/vp<[[VP7]]>
 ; CHECK-NEXT:      EMIT ir<%gep> = getelementptr ir<%p>, ir<%iv>
-; CHECK-NEXT:      EMIT store ir<%phi>, ir<%gep>, vp<[[VP9]]>
+; CHECK-NEXT:      EMIT store ir<%phi>, ir<%gep>, vp<[[VP10]]>
 ; CHECK-NEXT:    Successor(s): latch
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    latch:
@@ -1348,18 +1358,19 @@ define void @uniform_branch_after_varying_branch(ptr %a, i1 %u1) {
 ; CHECK-NEXT:    bb1:
 ; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%v0>
 ; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, vp<[[VP4]]>
-; CHECK-NEXT:      EMIT branch-on-cond ir<%u1>
+; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = freeze ir<%u1>
+; CHECK-NEXT:      EMIT branch-on-cond vp<[[VP5]]>
 ; CHECK-NEXT:    Successor(s): bb2, bb3
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb2:
-; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = logical-and vp<[[VP4]]>, ir<%u1>
-; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, vp<[[VP5]]>
+; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = logical-and vp<[[VP4]]>, ir<%u1>
+; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, vp<[[VP6]]>
 ; CHECK-NEXT:    Successor(s): bb3
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb3:
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP6:%[0-9]+]]> = phi [ ir<poison>, bb1 ], [ ir<%add2>, bb2 ]
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP7:%[0-9]+]]> = phi [ ir<false>, bb1 ], [ ir<%u1>, bb2 ]
-; CHECK-NEXT:      BLEND ir<%phi3> = ir<%add1>/ir<true> vp<%6>/vp<[[VP7]]>
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP7:%[0-9]+]]> = phi [ ir<poison>, bb1 ], [ ir<%add2>, bb2 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP8:%[0-9]+]]> = phi [ ir<false>, bb1 ], [ ir<%u1>, bb2 ]
+; CHECK-NEXT:      BLEND ir<%phi3> = ir<%add1>/ir<true> vp<%7>/vp<[[VP8]]>
 ; CHECK-NEXT:      EMIT ir<%add3> = add ir<%phi3>, ir<3>, vp<[[VP4]]>
 ; CHECK-NEXT:    Successor(s): bb4
 ; CHECK-EMPTY:
@@ -1438,13 +1449,14 @@ define void @uniform_branch_after_varying_branch_no_phi(ptr %a, i1 %u1) {
 ; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%v0>
 ; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, vp<[[VP4]]>
 ; CHECK-NEXT:      EMIT store ir<%add1>, ir<%gep>, vp<[[VP4]]>
-; CHECK-NEXT:      EMIT branch-on-cond ir<%u1>
+; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = freeze ir<%u1>
+; CHECK-NEXT:      EMIT branch-on-cond vp<[[VP5]]>
 ; CHECK-NEXT:    Successor(s): bb2, bb3
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb2:
-; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = logical-and vp<[[VP4]]>, ir<%u1>
-; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, vp<[[VP5]]>
-; CHECK-NEXT:      EMIT store ir<%add2>, ir<%gep>, vp<[[VP5]]>
+; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = logical-and vp<[[VP4]]>, ir<%u1>
+; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, vp<[[VP6]]>
+; CHECK-NEXT:      EMIT store ir<%add2>, ir<%gep>, vp<[[VP6]]>
 ; CHECK-NEXT:    Successor(s): bb3
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb3:
@@ -1521,20 +1533,21 @@ define void @uniform_branch_after_varying_branch_more_blocks(ptr %a, i1 %u1) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb1:
 ; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%v0>
-; CHECK-NEXT:      EMIT branch-on-cond ir<%u1>
+; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = freeze ir<%u1>
+; CHECK-NEXT:      EMIT branch-on-cond vp<[[VP5]]>
 ; CHECK-NEXT:    Successor(s): bb3, bb2
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb3:
-; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = logical-and vp<[[VP4]]>, ir<%u1>
-; CHECK-NEXT:      EMIT ir<%add3> = add ir<%iv>, ir<3>, vp<[[VP7]]>
+; CHECK-NEXT:      EMIT vp<[[VP8:%[0-9]+]]> = logical-and vp<[[VP4]]>, ir<%u1>
+; CHECK-NEXT:      EMIT ir<%add3> = add ir<%iv>, ir<3>, vp<[[VP8]]>
 ; CHECK-NEXT:    Successor(s): bb4
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb4:
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP8:%[0-9]+]]> = phi [ ir<%add2>, bb2 ], [ ir<poison>, bb3 ]
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP9:%[0-9]+]]> = phi [ vp<[[VP5:%[0-9]+]]>, bb2 ], [ ir<false>, bb3 ]
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP10:%[0-9]+]]> = phi [ ir<poison>, bb2 ], [ ir<%add3>, bb3 ]
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP11:%[0-9]+]]> = phi [ ir<false>, bb2 ], [ ir<%u1>, bb3 ]
-; CHECK-NEXT:      BLEND ir<%phi4> = vp<%8>/vp<[[VP9]]> vp<%10>/vp<[[VP11]]>
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP9:%[0-9]+]]> = phi [ ir<%add2>, bb2 ], [ ir<poison>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP10:%[0-9]+]]> = phi [ vp<[[VP6:%[0-9]+]]>, bb2 ], [ ir<false>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP11:%[0-9]+]]> = phi [ ir<poison>, bb2 ], [ ir<%add3>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP12:%[0-9]+]]> = phi [ ir<false>, bb2 ], [ ir<%u1>, bb3 ]
+; CHECK-NEXT:      BLEND ir<%phi4> = vp<%9>/vp<[[VP10]]> vp<%11>/vp<[[VP12]]>
 ; CHECK-NEXT:      EMIT ir<%add4> = add ir<%phi4>, ir<4>, vp<[[VP4]]>
 ; CHECK-NEXT:    Successor(s): bb5
 ; CHECK-EMPTY:
@@ -1552,9 +1565,9 @@ define void @uniform_branch_after_varying_branch_more_blocks(ptr %a, i1 %u1) {
 ; CHECK-NEXT:    No successors
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb2:
-; CHECK-NEXT:      EMIT vp<[[VP5]]> = not ir<%u1>
-; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = logical-and vp<[[VP4]]>, vp<[[VP5]]>
-; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, vp<[[VP6]]>
+; CHECK-NEXT:      EMIT vp<[[VP6]]> = not ir<%u1>
+; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = logical-and vp<[[VP4]]>, vp<[[VP6]]>
+; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, vp<[[VP7]]>
 ; CHECK-NEXT:    Successor(s): bb4
 ; CHECK-NEXT:  }
 ; CHECK-NEXT:  Successor(s): middle.block
@@ -1622,13 +1635,14 @@ define void @uniform_branch_after_varying_branch_more_blocks_no_phi(ptr %a, i1 %
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb1:
 ; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%v0>
-; CHECK-NEXT:      EMIT branch-on-cond ir<%u1>
+; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = freeze ir<%u1>
+; CHECK-NEXT:      EMIT branch-on-cond vp<[[VP5]]>
 ; CHECK-NEXT:    Successor(s): bb3, bb2
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb3:
-; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = logical-and vp<[[VP4]]>, ir<%u1>
-; CHECK-NEXT:      EMIT ir<%add3> = add ir<%iv>, ir<3>, vp<[[VP7]]>
-; CHECK-NEXT:      EMIT store ir<%add3>, ir<%gep>, vp<[[VP7]]>
+; CHECK-NEXT:      EMIT vp<[[VP8:%[0-9]+]]> = logical-and vp<[[VP4]]>, ir<%u1>
+; CHECK-NEXT:      EMIT ir<%add3> = add ir<%iv>, ir<3>, vp<[[VP8]]>
+; CHECK-NEXT:      EMIT store ir<%add3>, ir<%gep>, vp<[[VP8]]>
 ; CHECK-NEXT:    Successor(s): bb4
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb4:
@@ -1647,10 +1661,10 @@ define void @uniform_branch_after_varying_branch_more_blocks_no_phi(ptr %a, i1 %
 ; CHECK-NEXT:    No successors
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb2:
-; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = not ir<%u1>
-; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = logical-and vp<[[VP4]]>, vp<[[VP5]]>
-; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, vp<[[VP6]]>
-; CHECK-NEXT:      EMIT store ir<%add2>, ir<%gep>, vp<[[VP6]]>
+; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = not ir<%u1>
+; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = logical-and vp<[[VP4]]>, vp<[[VP6]]>
+; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, vp<[[VP7]]>
+; CHECK-NEXT:      EMIT store ir<%add2>, ir<%gep>, vp<[[VP7]]>
 ; CHECK-NEXT:    Successor(s): bb4
 ; CHECK-NEXT:  }
 ; CHECK-NEXT:  Successor(s): middle.block
@@ -1721,20 +1735,21 @@ define void @uniform_branch_after_varying_branch_more_blocks_mirrored(ptr %a, i1
 ; CHECK-NEXT:    Successor(s): bb2
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb2:
-; CHECK-NEXT:      EMIT branch-on-cond ir<%u2>
+; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = freeze ir<%u2>
+; CHECK-NEXT:      EMIT branch-on-cond vp<[[VP5]]>
 ; CHECK-NEXT:    Successor(s): bb4, bb3
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb4:
-; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = logical-and ir<%v0>, ir<%u2>
-; CHECK-NEXT:      EMIT ir<%add4> = add ir<%iv>, ir<4>, vp<[[VP7]]>
+; CHECK-NEXT:      EMIT vp<[[VP8:%[0-9]+]]> = logical-and ir<%v0>, ir<%u2>
+; CHECK-NEXT:      EMIT ir<%add4> = add ir<%iv>, ir<4>, vp<[[VP8]]>
 ; CHECK-NEXT:    Successor(s): bb5
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb5:
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP8:%[0-9]+]]> = phi [ ir<%add3>, bb3 ], [ ir<poison>, bb4 ]
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP9:%[0-9]+]]> = phi [ vp<[[VP5:%[0-9]+]]>, bb3 ], [ ir<false>, bb4 ]
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP10:%[0-9]+]]> = phi [ ir<poison>, bb3 ], [ ir<%add4>, bb4 ]
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP11:%[0-9]+]]> = phi [ ir<false>, bb3 ], [ ir<%u2>, bb4 ]
-; CHECK-NEXT:      BLEND ir<%phi5> = vp<%8>/vp<[[VP9]]> vp<%10>/vp<[[VP11]]>
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP9:%[0-9]+]]> = phi [ ir<%add3>, bb3 ], [ ir<poison>, bb4 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP10:%[0-9]+]]> = phi [ vp<[[VP6:%[0-9]+]]>, bb3 ], [ ir<false>, bb4 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP11:%[0-9]+]]> = phi [ ir<poison>, bb3 ], [ ir<%add4>, bb4 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP12:%[0-9]+]]> = phi [ ir<false>, bb3 ], [ ir<%u2>, bb4 ]
+; CHECK-NEXT:      BLEND ir<%phi5> = vp<%9>/vp<[[VP10]]> vp<%11>/vp<[[VP12]]>
 ; CHECK-NEXT:      EMIT ir<%add5> = add ir<%phi5>, ir<5>, ir<%v0>
 ; CHECK-NEXT:    Successor(s): bb6
 ; CHECK-EMPTY:
@@ -1748,9 +1763,9 @@ define void @uniform_branch_after_varying_branch_more_blocks_mirrored(ptr %a, i1
 ; CHECK-NEXT:    No successors
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb3:
-; CHECK-NEXT:      EMIT vp<[[VP5]]> = not ir<%u2>
-; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = logical-and ir<%v0>, vp<[[VP5]]>
-; CHECK-NEXT:      EMIT ir<%add3> = add ir<%iv>, ir<3>, vp<[[VP6]]>
+; CHECK-NEXT:      EMIT vp<[[VP6]]> = not ir<%u2>
+; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = logical-and ir<%v0>, vp<[[VP6]]>
+; CHECK-NEXT:      EMIT ir<%add3> = add ir<%iv>, ir<3>, vp<[[VP7]]>
 ; CHECK-NEXT:    Successor(s): bb5
 ; CHECK-NEXT:  }
 ; CHECK-NEXT:  Successor(s): middle.block
@@ -1823,13 +1838,14 @@ define void @uniform_branch_after_varying_branch_more_blocks_mirrored_no_phi(ptr
 ; CHECK-NEXT:    Successor(s): bb2
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb2:
-; CHECK-NEXT:      EMIT branch-on-cond ir<%u2>
+; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = freeze ir<%u2>
+; CHECK-NEXT:      EMIT branch-on-cond vp<[[VP5]]>
 ; CHECK-NEXT:    Successor(s): bb4, bb3
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb4:
-; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = logical-and ir<%v0>, ir<%u2>
-; CHECK-NEXT:      EMIT ir<%add4> = add ir<%iv>, ir<4>, vp<[[VP7]]>
-; CHECK-NEXT:      EMIT store ir<%add4>, ir<%gep>, vp<[[VP7]]>
+; CHECK-NEXT:      EMIT vp<[[VP8:%[0-9]+]]> = logical-and ir<%v0>, ir<%u2>
+; CHECK-NEXT:      EMIT ir<%add4> = add ir<%iv>, ir<4>, vp<[[VP8]]>
+; CHECK-NEXT:      EMIT store ir<%add4>, ir<%gep>, vp<[[VP8]]>
 ; CHECK-NEXT:    Successor(s): bb5
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb5:
@@ -1843,10 +1859,10 @@ define void @uniform_branch_after_varying_branch_more_blocks_mirrored_no_phi(ptr
 ; CHECK-NEXT:    No successors
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb3:
-; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = not ir<%u2>
-; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = logical-and ir<%v0>, vp<[[VP5]]>
-; CHECK-NEXT:      EMIT ir<%add3> = add ir<%iv>, ir<3>, vp<[[VP6]]>
-; CHECK-NEXT:      EMIT store ir<%add3>, ir<%gep>, vp<[[VP6]]>
+; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = not ir<%u2>
+; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = logical-and ir<%v0>, vp<[[VP6]]>
+; CHECK-NEXT:      EMIT ir<%add3> = add ir<%iv>, ir<3>, vp<[[VP7]]>
+; CHECK-NEXT:      EMIT store ir<%add3>, ir<%gep>, vp<[[VP7]]>
 ; CHECK-NEXT:    Successor(s): bb5
 ; CHECK-NEXT:  }
 ; CHECK-NEXT:  Successor(s): middle.block
@@ -3005,20 +3021,21 @@ define void @unstructured_uniform_only(ptr %a, i1 %u0, i1 %u2) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb2:
 ; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, ir<%u0>
-; CHECK-NEXT:      EMIT branch-on-cond ir<%u2>
+; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = freeze ir<%u2>
+; CHECK-NEXT:      EMIT branch-on-cond vp<[[VP5]]>
 ; CHECK-NEXT:    Successor(s): bb4, bb3
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb4:
-; CHECK-NEXT:      EMIT vp<[[VP13:%[0-9]+]]> = logical-and ir<%u0>, ir<%u2>
-; CHECK-NEXT:      EMIT ir<%add4> = add ir<%iv>, ir<4>, vp<[[VP13]]>
+; CHECK-NEXT:      EMIT vp<[[VP14:%[0-9]+]]> = logical-and ir<%u0>, ir<%u2>
+; CHECK-NEXT:      EMIT ir<%add4> = add ir<%iv>, ir<4>, vp<[[VP14]]>
 ; CHECK-NEXT:    Successor(s): bb5
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb5:
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP14:%[0-9]+]]> = phi [ ir<%add4>, bb4 ], [ ir<poison>, bb3 ]
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP15:%[0-9]+]]> = phi [ vp<[[VP13]]>, bb4 ], [ ir<false>, bb3 ]
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP16:%[0-9]+]]> = phi [ ir<poison>, bb4 ], [ ir<%add3>, bb3 ]
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP17:%[0-9]+]]> = phi [ ir<false>, bb4 ], [ vp<[[VP12:%[0-9]+]]>, bb3 ]
-; CHECK-NEXT:      BLEND ir<%phi5> = vp<%14>/vp<[[VP15]]> vp<%16>/vp<[[VP17]]>
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP15:%[0-9]+]]> = phi [ ir<%add4>, bb4 ], [ ir<poison>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP16:%[0-9]+]]> = phi [ vp<[[VP14]]>, bb4 ], [ ir<false>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP17:%[0-9]+]]> = phi [ ir<poison>, bb4 ], [ ir<%add3>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP18:%[0-9]+]]> = phi [ ir<false>, bb4 ], [ vp<[[VP13:%[0-9]+]]>, bb3 ]
+; CHECK-NEXT:      BLEND ir<%phi5> = vp<%15>/vp<[[VP16]]> vp<%17>/vp<[[VP18]]>
 ; CHECK-NEXT:      EMIT store ir<%phi5>, ir<%a>
 ; CHECK-NEXT:      EMIT ir<%iv.next> = add nuw nsw ir<%iv>, ir<1>
 ; CHECK-NEXT:      EMIT ir<%ec> = icmp eq ir<%iv.next>, ir<128>
@@ -3027,16 +3044,16 @@ define void @unstructured_uniform_only(ptr %a, i1 %u0, i1 %u2) {
 ; CHECK-NEXT:    No successors
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb3:
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP5:%[0-9]+]]> = phi [ ir<%add1>, bb1 ], [ ir<poison>, bb2 ]
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP6:%[0-9]+]]> = phi [ vp<[[VP4:%[0-9]+]]>, bb1 ], [ ir<false>, bb2 ]
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP7:%[0-9]+]]> = phi [ ir<poison>, bb1 ], [ ir<%add2>, bb2 ]
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP8:%[0-9]+]]> = phi [ ir<false>, bb1 ], [ ir<%u0>, bb2 ]
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP9:%[0-9]+]]> = phi [ vp<[[VP4]]>, bb1 ], [ ir<false>, bb2 ]
-; CHECK-NEXT:      EMIT vp<[[VP10:%[0-9]+]]> = not ir<%u2>
-; CHECK-NEXT:      EMIT vp<[[VP11:%[0-9]+]]> = logical-and ir<%u0>, vp<[[VP10]]>
-; CHECK-NEXT:      EMIT vp<[[VP12]]> = or vp<[[VP11]]>, vp<[[VP9]]>
-; CHECK-NEXT:      BLEND ir<%phi3> = vp<%5>/vp<[[VP6]]> vp<%7>/vp<[[VP8]]>
-; CHECK-NEXT:      EMIT ir<%add3> = add ir<%phi3>, ir<3>, vp<[[VP12]]>
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP6:%[0-9]+]]> = phi [ ir<%add1>, bb1 ], [ ir<poison>, bb2 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP7:%[0-9]+]]> = phi [ vp<[[VP4:%[0-9]+]]>, bb1 ], [ ir<false>, bb2 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP8:%[0-9]+]]> = phi [ ir<poison>, bb1 ], [ ir<%add2>, bb2 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP9:%[0-9]+]]> = phi [ ir<false>, bb1 ], [ ir<%u0>, bb2 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP10:%[0-9]+]]> = phi [ vp<[[VP4]]>, bb1 ], [ ir<false>, bb2 ]
+; CHECK-NEXT:      EMIT vp<[[VP11:%[0-9]+]]> = not ir<%u2>
+; CHECK-NEXT:      EMIT vp<[[VP12:%[0-9]+]]> = logical-and ir<%u0>, vp<[[VP11]]>
+; CHECK-NEXT:      EMIT vp<[[VP13]]> = or vp<[[VP12]]>, vp<[[VP10]]>
+; CHECK-NEXT:      BLEND ir<%phi3> = vp<%6>/vp<[[VP7]]> vp<%8>/vp<[[VP9]]>
+; CHECK-NEXT:      EMIT ir<%add3> = add ir<%phi3>, ir<3>, vp<[[VP13]]>
 ; CHECK-NEXT:    Successor(s): bb5
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb1:
@@ -3103,13 +3120,14 @@ define void @unstructured_uniform_only_no_phi(ptr %a, i1 %u0, i1 %u2) {
 ; CHECK-NEXT:    bb2:
 ; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, ir<%u0>
 ; CHECK-NEXT:      EMIT store ir<%add2>, ir<%gep>, ir<%u0>
-; CHECK-NEXT:      EMIT branch-on-cond ir<%u2>
+; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = freeze ir<%u2>
+; CHECK-NEXT:      EMIT branch-on-cond vp<[[VP5]]>
 ; CHECK-NEXT:    Successor(s): bb4, bb3
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb4:
-; CHECK-NEXT:      EMIT vp<[[VP9:%[0-9]+]]> = logical-and ir<%u0>, ir<%u2>
-; CHECK-NEXT:      EMIT ir<%add4> = add ir<%iv>, ir<4>, vp<[[VP9]]>
-; CHECK-NEXT:      EMIT store ir<%add4>, ir<%gep>, vp<[[VP9]]>
+; CHECK-NEXT:      EMIT vp<[[VP10:%[0-9]+]]> = logical-and ir<%u0>, ir<%u2>
+; CHECK-NEXT:      EMIT ir<%add4> = add ir<%iv>, ir<4>, vp<[[VP10]]>
+; CHECK-NEXT:      EMIT store ir<%add4>, ir<%gep>, vp<[[VP10]]>
 ; CHECK-NEXT:    Successor(s): bb5
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb5:
@@ -3120,10 +3138,10 @@ define void @unstructured_uniform_only_no_phi(ptr %a, i1 %u0, i1 %u2) {
 ; CHECK-NEXT:    No successors
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb3:
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP5:%[0-9]+]]> = phi [ vp<[[VP4:%[0-9]+]]>, bb1 ], [ ir<false>, bb2 ]
-; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = not ir<%u2>
-; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = logical-and ir<%u0>, vp<[[VP6]]>
-; CHECK-NEXT:      EMIT vp<[[VP8:%[0-9]+]]> = or vp<[[VP7]]>, vp<[[VP5]]>
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP6:%[0-9]+]]> = phi [ vp<[[VP4:%[0-9]+]]>, bb1 ], [ ir<false>, bb2 ]
+; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = not ir<%u2>
+; CHECK-NEXT:      EMIT vp<[[VP8:%[0-9]+]]> = logical-and ir<%u0>, vp<[[VP7]]>
+; CHECK-NEXT:      EMIT vp<[[VP9:%[0-9]+]]> = or vp<[[VP8]]>, vp<[[VP6]]>
 ; CHECK-NEXT:    Successor(s): bb5
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb1:
@@ -3189,26 +3207,28 @@ define void @unstructured_uniform_only_sese_region(ptr %a, i1 %u1, i1 %u3) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb1:
 ; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%v0>
-; CHECK-NEXT:      EMIT branch-on-cond ir<%u1>
+; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = freeze ir<%u1>
+; CHECK-NEXT:      EMIT branch-on-cond vp<[[VP5]]>
 ; CHECK-NEXT:    Successor(s): bb3, bb2
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb3:
-; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = logical-and vp<[[VP4]]>, ir<%u1>
-; CHECK-NEXT:      EMIT ir<%add3> = add ir<%iv>, ir<3>, vp<[[VP7]]>
-; CHECK-NEXT:      EMIT branch-on-cond ir<%u3>
+; CHECK-NEXT:      EMIT vp<[[VP8:%[0-9]+]]> = logical-and vp<[[VP4]]>, ir<%u1>
+; CHECK-NEXT:      EMIT ir<%add3> = add ir<%iv>, ir<3>, vp<[[VP8]]>
+; CHECK-NEXT:      EMIT vp<[[VP9:%[0-9]+]]> = freeze ir<%u3>
+; CHECK-NEXT:      EMIT branch-on-cond vp<[[VP9]]>
 ; CHECK-NEXT:    Successor(s): bb5, bb4
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb5:
-; CHECK-NEXT:      EMIT vp<[[VP17:%[0-9]+]]> = logical-and vp<[[VP7]]>, ir<%u3>
-; CHECK-NEXT:      EMIT ir<%add5> = add ir<%iv>, ir<5>, vp<[[VP17]]>
+; CHECK-NEXT:      EMIT vp<[[VP19:%[0-9]+]]> = logical-and vp<[[VP8]]>, ir<%u3>
+; CHECK-NEXT:      EMIT ir<%add5> = add ir<%iv>, ir<5>, vp<[[VP19]]>
 ; CHECK-NEXT:    Successor(s): bb7
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb7:
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP18:%[0-9]+]]> = phi [ ir<%add5>, bb5 ], [ ir<poison>, bb4 ]
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP19:%[0-9]+]]> = phi [ vp<[[VP17]]>, bb5 ], [ ir<false>, bb4 ]
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP20:%[0-9]+]]> = phi [ ir<poison>, bb5 ], [ ir<%add4>, bb4 ]
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP21:%[0-9]+]]> = phi [ ir<false>, bb5 ], [ vp<[[VP16:%[0-9]+]]>, bb4 ]
-; CHECK-NEXT:      BLEND ir<%phi7> = vp<%18>/vp<[[VP19]]> vp<%20>/vp<[[VP21]]>
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP20:%[0-9]+]]> = phi [ ir<%add5>, bb5 ], [ ir<poison>, bb4 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP21:%[0-9]+]]> = phi [ vp<[[VP19]]>, bb5 ], [ ir<false>, bb4 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP22:%[0-9]+]]> = phi [ ir<poison>, bb5 ], [ ir<%add4>, bb4 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP23:%[0-9]+]]> = phi [ ir<false>, bb5 ], [ vp<[[VP18:%[0-9]+]]>, bb4 ]
+; CHECK-NEXT:      BLEND ir<%phi7> = vp<%20>/vp<[[VP21]]> vp<%22>/vp<[[VP23]]>
 ; CHECK-NEXT:      EMIT ir<%add7> = add ir<%phi7>, ir<7>, vp<[[VP4]]>
 ; CHECK-NEXT:    Successor(s): bb6
 ; CHECK-EMPTY:
@@ -3226,23 +3246,23 @@ define void @unstructured_uniform_only_sese_region(ptr %a, i1 %u1, i1 %u3) {
 ; CHECK-NEXT:    No successors
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb4:
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP8:%[0-9]+]]> = phi [ ir<%add2>, bb2 ], [ ir<poison>, bb3 ]
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP9:%[0-9]+]]> = phi [ vp<[[VP5:%[0-9]+]]>, bb2 ], [ ir<false>, bb3 ]
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP10:%[0-9]+]]> = phi [ ir<poison>, bb2 ], [ ir<%add3>, bb3 ]
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP11:%[0-9]+]]> = phi [ ir<false>, bb2 ], [ ir<%u1>, bb3 ]
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP12:%[0-9]+]]> = phi [ ir<false>, bb2 ], [ vp<[[VP7]]>, bb3 ]
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP13:%[0-9]+]]> = phi [ vp<[[VP6:%[0-9]+]]>, bb2 ], [ ir<false>, bb3 ]
-; CHECK-NEXT:      EMIT vp<[[VP14:%[0-9]+]]> = not ir<%u3>
-; CHECK-NEXT:      EMIT vp<[[VP15:%[0-9]+]]> = logical-and vp<[[VP12]]>, vp<[[VP14]]>
-; CHECK-NEXT:      EMIT vp<[[VP16]]> = or vp<[[VP15]]>, vp<[[VP13]]>
-; CHECK-NEXT:      BLEND ir<%phi4> = vp<%8>/vp<[[VP9]]> vp<%10>/vp<[[VP11]]>
-; CHECK-NEXT:      EMIT ir<%add4> = add ir<%phi4>, ir<4>, vp<[[VP16]]>
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP10:%[0-9]+]]> = phi [ ir<%add2>, bb2 ], [ ir<poison>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP11:%[0-9]+]]> = phi [ vp<[[VP6:%[0-9]+]]>, bb2 ], [ ir<false>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP12:%[0-9]+]]> = phi [ ir<poison>, bb2 ], [ ir<%add3>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP13:%[0-9]+]]> = phi [ ir<false>, bb2 ], [ ir<%u1>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP14:%[0-9]+]]> = phi [ ir<false>, bb2 ], [ vp<[[VP8]]>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP15:%[0-9]+]]> = phi [ vp<[[VP7:%[0-9]+]]>, bb2 ], [ ir<false>, bb3 ]
+; CHECK-NEXT:      EMIT vp<[[VP16:%[0-9]+]]> = not ir<%u3>
+; CHECK-NEXT:      EMIT vp<[[VP17:%[0-9]+]]> = logical-and vp<[[VP14]]>, vp<[[VP16]]>
+; CHECK-NEXT:      EMIT vp<[[VP18]]> = or vp<[[VP17]]>, vp<[[VP15]]>
+; CHECK-NEXT:      BLEND ir<%phi4> = vp<%10>/vp<[[VP11]]> vp<%12>/vp<[[VP13]]>
+; CHECK-NEXT:      EMIT ir<%add4> = add ir<%phi4>, ir<4>, vp<[[VP18]]>
 ; CHECK-NEXT:    Successor(s): bb7
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb2:
-; CHECK-NEXT:      EMIT vp<[[VP5]]> = not ir<%u1>
-; CHECK-NEXT:      EMIT vp<[[VP6]]> = logical-and vp<[[VP4]]>, vp<[[VP5]]>
-; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, vp<[[VP6]]>
+; CHECK-NEXT:      EMIT vp<[[VP6]]> = not ir<%u1>
+; CHECK-NEXT:      EMIT vp<[[VP7]]> = logical-and vp<[[VP4]]>, vp<[[VP6]]>
+; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, vp<[[VP7]]>
 ; CHECK-NEXT:    Successor(s): bb4
 ; CHECK-NEXT:  }
 ; CHECK-NEXT:  Successor(s): middle.block
@@ -3320,20 +3340,22 @@ define void @unstructured_uniform_only_sese_region_no_phi(ptr %a, i1 %u1, i1 %u3
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb1:
 ; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%v0>
-; CHECK-NEXT:      EMIT branch-on-cond ir<%u1>
+; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = freeze ir<%u1>
+; CHECK-NEXT:      EMIT branch-on-cond vp<[[VP5]]>
 ; CHECK-NEXT:    Successor(s): bb3, bb2
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb3:
-; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = logical-and vp<[[VP4]]>, ir<%u1>
-; CHECK-NEXT:      EMIT ir<%add3> = add ir<%iv>, ir<3>, vp<[[VP7]]>
-; CHECK-NEXT:      EMIT store ir<%add3>, ir<%gep>, vp<[[VP7]]>
-; CHECK-NEXT:      EMIT branch-on-cond ir<%u3>
+; CHECK-NEXT:      EMIT vp<[[VP8:%[0-9]+]]> = logical-and vp<[[VP4]]>, ir<%u1>
+; CHECK-NEXT:      EMIT ir<%add3> = add ir<%iv>, ir<3>, vp<[[VP8]]>
+; CHECK-NEXT:      EMIT store ir<%add3>, ir<%gep>, vp<[[VP8]]>
+; CHECK-NEXT:      EMIT vp<[[VP9:%[0-9]+]]> = freeze ir<%u3>
+; CHECK-NEXT:      EMIT branch-on-cond vp<[[VP9]]>
 ; CHECK-NEXT:    Successor(s): bb5, bb4
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb5:
-; CHECK-NEXT:      EMIT vp<[[VP13:%[0-9]+]]> = logical-and vp<[[VP7]]>, ir<%u3>
-; CHECK-NEXT:      EMIT ir<%add5> = add ir<%iv>, ir<5>, vp<[[VP13]]>
-; CHECK-NEXT:      EMIT store ir<%add5>, ir<%gep>, vp<[[VP13]]>
+; CHECK-NEXT:      EMIT vp<[[VP15:%[0-9]+]]> = logical-and vp<[[VP8]]>, ir<%u3>
+; CHECK-NEXT:      EMIT ir<%add5> = add ir<%iv>, ir<5>, vp<[[VP15]]>
+; CHECK-NEXT:      EMIT store ir<%add5>, ir<%gep>, vp<[[VP15]]>
 ; CHECK-NEXT:    Successor(s): bb7
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb7:
@@ -3352,18 +3374,18 @@ define void @unstructured_uniform_only_sese_region_no_phi(ptr %a, i1 %u1, i1 %u3
 ; CHECK-NEXT:    No successors
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb4:
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP8:%[0-9]+]]> = phi [ ir<false>, bb2 ], [ vp<[[VP7]]>, bb3 ]
-; CHECK-NEXT:      WIDEN-PHI vp<[[VP9:%[0-9]+]]> = phi [ vp<[[VP6:%[0-9]+]]>, bb2 ], [ ir<false>, bb3 ]
-; CHECK-NEXT:      EMIT vp<[[VP10:%[0-9]+]]> = not ir<%u3>
-; CHECK-NEXT:      EMIT vp<[[VP11:%[0-9]+]]> = logical-and vp<[[VP8]]>, vp<[[VP10]]>
-; CHECK-NEXT:      EMIT vp<[[VP12:%[0-9]+]]> = or vp<[[VP11]]>, vp<[[VP9]]>
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP10:%[0-9]+]]> = phi [ ir<false>, bb2 ], [ vp<[[VP8]]>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP11:%[0-9]+]]> = phi [ vp<[[VP7:%[0-9]+]]>, bb2 ], [ ir<false>, bb3 ]
+; CHECK-NEXT:      EMIT vp<[[VP12:%[0-9]+]]> = not ir<%u3>
+; CHECK-NEXT:      EMIT vp<[[VP13:%[0-9]+]]> = logical-and vp<[[VP10]]>, vp<[[VP12]]>
+; CHECK-NEXT:      EMIT vp<[[VP14:%[0-9]+]]> = or vp<[[VP13]]>, vp<[[VP11]]>
 ; CHECK-NEXT:    Successor(s): bb7
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb2:
-; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = not ir<%u1>
-; CHECK-NEXT:      EMIT vp<[[VP6]]> = logical-and vp<[[VP4]]>, vp<[[VP5]]>
-; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, vp<[[VP6]]>
-; CHECK-NEXT:      EMIT store ir<%add2>, ir<%gep>, vp<[[VP6]]>
+; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = not ir<%u1>
+; CHECK-NEXT:      EMIT vp<[[VP7]]> = logical-and vp<[[VP4]]>, vp<[[VP6]]>
+; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, vp<[[VP7]]>
+; CHECK-NEXT:      EMIT store ir<%add2>, ir<%gep>, vp<[[VP7]]>
 ; CHECK-NEXT:    Successor(s): bb4
 ; CHECK-NEXT:  }
 ; CHECK-NEXT:  Successor(s): middle.block

--- a/llvm/test/Transforms/LoopVectorize/VPlan/predicator.ll
+++ b/llvm/test/Transforms/LoopVectorize/VPlan/predicator.ll
@@ -752,12 +752,8 @@ define void @simplifiable_blend(i1 %c1, i1 %c2, i1 %c3, i32 %x, i32 %y, ptr %p) 
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    B:
 ; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%c1>
-; CHECK-NEXT:    Successor(s): E
-; CHECK-EMPTY:
-; CHECK-NEXT:    E:
-; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = not ir<%c3>
-; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = logical-and vp<[[VP4]]>, vp<[[VP5]]>
-; CHECK-NEXT:    Successor(s): F
+; CHECK-NEXT:      EMIT branch-on-cond ir<%c3>
+; CHECK-NEXT:    Successor(s): F, E
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    F:
 ; CHECK-NEXT:    Successor(s): A
@@ -783,6 +779,11 @@ define void @simplifiable_blend(i1 %c1, i1 %c2, i1 %c3, i32 %x, i32 %y, ptr %p) 
 ; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1:%[0-9]+]]>
 ; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2:%[0-9]+]]>
 ; CHECK-NEXT:    No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:    E:
+; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = not ir<%c3>
+; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = logical-and vp<[[VP4]]>, vp<[[VP5]]>
+; CHECK-NEXT:    Successor(s): F
 ; CHECK-NEXT:  }
 ; CHECK-NEXT:  Successor(s): middle.block
 ;
@@ -1038,7 +1039,8 @@ define void @outermost_uniform_branch_no_phi(ptr %a, i1 %u0) {
 ; CHECK-NEXT:      ir<%iv> = WIDEN-INDUCTION nuw nsw ir<0>, ir<1>, vp<[[VP0:%[0-9]+]]>
 ; CHECK-NEXT:      EMIT ir<%gep> = getelementptr ir<%a>, ir<%iv>
 ; CHECK-NEXT:      EMIT store ir<%iv>, ir<%gep>
-; CHECK-NEXT:    Successor(s): bb1
+; CHECK-NEXT:      EMIT branch-on-cond ir<%u0>
+; CHECK-NEXT:    Successor(s): bb1, bb4
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb1:
 ; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, ir<%u0>
@@ -1210,13 +1212,8 @@ define void @outermost_uniform_branch_more_blocks_no_phi(ptr %a, i1 %u0) {
 ; CHECK-NEXT:    vector.body:
 ; CHECK-NEXT:      ir<%iv> = WIDEN-INDUCTION nuw nsw ir<0>, ir<1>, vp<[[VP0:%[0-9]+]]>
 ; CHECK-NEXT:      EMIT ir<%gep> = getelementptr ir<%a>, ir<%iv>
-; CHECK-NEXT:    Successor(s): bb1
-; CHECK-EMPTY:
-; CHECK-NEXT:    bb1:
-; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%u0>
-; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, vp<[[VP4]]>
-; CHECK-NEXT:      EMIT store ir<%add1>, ir<%gep>, vp<[[VP4]]>
-; CHECK-NEXT:    Successor(s): bb2
+; CHECK-NEXT:      EMIT branch-on-cond ir<%u0>
+; CHECK-NEXT:    Successor(s): bb2, bb1
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb2:
 ; CHECK-NEXT:      EMIT ir<%v2> = icmp sle ir<%iv>, ir<2>, ir<%u0>
@@ -1244,6 +1241,12 @@ define void @outermost_uniform_branch_more_blocks_no_phi(ptr %a, i1 %u0) {
 ; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1:%[0-9]+]]>
 ; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2:%[0-9]+]]>
 ; CHECK-NEXT:    No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb1:
+; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%u0>
+; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, vp<[[VP4]]>
+; CHECK-NEXT:      EMIT store ir<%add1>, ir<%gep>, vp<[[VP4]]>
+; CHECK-NEXT:    Successor(s): bb6
 ; CHECK-NEXT:  }
 ; CHECK-NEXT:  Successor(s): middle.block
 ;
@@ -1397,7 +1400,8 @@ define void @uniform_branch_after_varying_branch_no_phi(ptr %a, i1 %u1) {
 ; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%v0>
 ; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, vp<[[VP4]]>
 ; CHECK-NEXT:      EMIT store ir<%add1>, ir<%gep>, vp<[[VP4]]>
-; CHECK-NEXT:    Successor(s): bb2
+; CHECK-NEXT:      EMIT branch-on-cond ir<%u1>
+; CHECK-NEXT:    Successor(s): bb2, bb3
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb2:
 ; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = logical-and vp<[[VP4]]>, ir<%u1>
@@ -1575,14 +1579,8 @@ define void @uniform_branch_after_varying_branch_more_blocks_no_phi(ptr %a, i1 %
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb1:
 ; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%v0>
-; CHECK-NEXT:    Successor(s): bb2
-; CHECK-EMPTY:
-; CHECK-NEXT:    bb2:
-; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = not ir<%u1>
-; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = logical-and vp<[[VP4]]>, vp<[[VP5]]>
-; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, vp<[[VP6]]>
-; CHECK-NEXT:      EMIT store ir<%add2>, ir<%gep>, vp<[[VP6]]>
-; CHECK-NEXT:    Successor(s): bb3
+; CHECK-NEXT:      EMIT branch-on-cond ir<%u1>
+; CHECK-NEXT:    Successor(s): bb3, bb2
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb3:
 ; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = logical-and vp<[[VP4]]>, ir<%u1>
@@ -1604,6 +1602,13 @@ define void @uniform_branch_after_varying_branch_more_blocks_no_phi(ptr %a, i1 %
 ; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1:%[0-9]+]]>
 ; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2:%[0-9]+]]>
 ; CHECK-NEXT:    No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb2:
+; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = not ir<%u1>
+; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = logical-and vp<[[VP4]]>, vp<[[VP5]]>
+; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, vp<[[VP6]]>
+; CHECK-NEXT:      EMIT store ir<%add2>, ir<%gep>, vp<[[VP6]]>
+; CHECK-NEXT:    Successor(s): bb4
 ; CHECK-NEXT:  }
 ; CHECK-NEXT:  Successor(s): middle.block
 ;
@@ -1770,14 +1775,8 @@ define void @uniform_branch_after_varying_branch_more_blocks_mirrored_no_phi(ptr
 ; CHECK-NEXT:    Successor(s): bb2
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb2:
-; CHECK-NEXT:    Successor(s): bb3
-; CHECK-EMPTY:
-; CHECK-NEXT:    bb3:
-; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = not ir<%u2>
-; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = logical-and ir<%v0>, vp<[[VP5]]>
-; CHECK-NEXT:      EMIT ir<%add3> = add ir<%iv>, ir<3>, vp<[[VP6]]>
-; CHECK-NEXT:      EMIT store ir<%add3>, ir<%gep>, vp<[[VP6]]>
-; CHECK-NEXT:    Successor(s): bb4
+; CHECK-NEXT:      EMIT branch-on-cond ir<%u2>
+; CHECK-NEXT:    Successor(s): bb4, bb3
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb4:
 ; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = logical-and ir<%v0>, ir<%u2>
@@ -1794,6 +1793,13 @@ define void @uniform_branch_after_varying_branch_more_blocks_mirrored_no_phi(ptr
 ; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1:%[0-9]+]]>
 ; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2:%[0-9]+]]>
 ; CHECK-NEXT:    No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb3:
+; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = not ir<%u2>
+; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = logical-and ir<%v0>, vp<[[VP5]]>
+; CHECK-NEXT:      EMIT ir<%add3> = add ir<%iv>, ir<3>, vp<[[VP6]]>
+; CHECK-NEXT:      EMIT store ir<%add3>, ir<%gep>, vp<[[VP6]]>
+; CHECK-NEXT:    Successor(s): bb5
 ; CHECK-NEXT:  }
 ; CHECK-NEXT:  Successor(s): middle.block
 ;
@@ -2813,13 +2819,8 @@ define void @uniform_branch_shared_join_with_varying_no_phi(ptr %a, i1 %u0) {
 ; CHECK-NEXT:    vector.body:
 ; CHECK-NEXT:      ir<%iv> = WIDEN-INDUCTION nuw nsw ir<0>, ir<1>, vp<[[VP0:%[0-9]+]]>
 ; CHECK-NEXT:      EMIT ir<%gep> = getelementptr ir<%a>, ir<%iv>
-; CHECK-NEXT:    Successor(s): bb1
-; CHECK-EMPTY:
-; CHECK-NEXT:    bb1:
-; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%u0>
-; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, vp<[[VP4]]>
-; CHECK-NEXT:      EMIT store ir<%add1>, ir<%gep>, vp<[[VP4]]>
-; CHECK-NEXT:    Successor(s): bb2
+; CHECK-NEXT:      EMIT branch-on-cond ir<%u0>
+; CHECK-NEXT:    Successor(s): bb2, bb1
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb2:
 ; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, ir<%u0>
@@ -2839,6 +2840,12 @@ define void @uniform_branch_shared_join_with_varying_no_phi(ptr %a, i1 %u0) {
 ; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1:%[0-9]+]]>
 ; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2:%[0-9]+]]>
 ; CHECK-NEXT:    No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb1:
+; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%u0>
+; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, vp<[[VP4]]>
+; CHECK-NEXT:      EMIT store ir<%add1>, ir<%gep>, vp<[[VP4]]>
+; CHECK-NEXT:    Successor(s): bb4
 ; CHECK-NEXT:  }
 ; CHECK-NEXT:  Successor(s): middle.block
 ;

--- a/llvm/test/Transforms/LoopVectorize/VPlan/predicator.ll
+++ b/llvm/test/Transforms/LoopVectorize/VPlan/predicator.ll
@@ -476,44 +476,17 @@ define void @blend_masks(ptr noalias %p, i1 %c0, i1 %c1, i1 %c2, i1 %c3, i1 %c4)
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    vector.body:
 ; CHECK-NEXT:      ir<%iv> = WIDEN-INDUCTION ir<0>, ir<1>, vp<[[VP0:%[0-9]+]]>
-; CHECK-NEXT:    Successor(s): bb2
-; CHECK-EMPTY:
-; CHECK-NEXT:    bb2:
-; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%c0>
-; CHECK-NEXT:    Successor(s): bb1
+; CHECK-NEXT:      EMIT branch-on-cond ir<%c0>
+; CHECK-NEXT:    Successor(s): bb1, bb2
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb1:
-; CHECK-NEXT:    Successor(s): bb4
-; CHECK-EMPTY:
-; CHECK-NEXT:    bb4:
-; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = not ir<%c1>
-; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = logical-and ir<%c0>, vp<[[VP5]]>
-; CHECK-NEXT:    Successor(s): bb3
+; CHECK-NEXT:      EMIT branch-on-cond ir<%c1>
+; CHECK-NEXT:    Successor(s): bb3, bb4
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb3:
-; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = logical-and ir<%c0>, ir<%c1>
-; CHECK-NEXT:    Successor(s): bb5
-; CHECK-EMPTY:
-; CHECK-NEXT:    bb5:
-; CHECK-NEXT:      EMIT vp<[[VP8:%[0-9]+]]> = logical-and vp<[[VP6]]>, ir<%c3>
-; CHECK-NEXT:      EMIT vp<[[VP9:%[0-9]+]]> = not ir<%c2>
-; CHECK-NEXT:      EMIT vp<[[VP10:%[0-9]+]]> = logical-and vp<[[VP7]]>, vp<[[VP9]]>
-; CHECK-NEXT:      EMIT vp<[[VP11:%[0-9]+]]> = or vp<[[VP8]]>, vp<[[VP10]]>
-; CHECK-NEXT:    Successor(s): bb6
-; CHECK-EMPTY:
-; CHECK-NEXT:    bb6:
-; CHECK-NEXT:      EMIT vp<[[VP12:%[0-9]+]]> = not ir<%c3>
-; CHECK-NEXT:      EMIT vp<[[VP13:%[0-9]+]]> = logical-and vp<[[VP6]]>, vp<[[VP12]]>
-; CHECK-NEXT:      EMIT vp<[[VP14:%[0-9]+]]> = or vp<[[VP13]]>, vp<[[VP4]]>
-; CHECK-NEXT:    Successor(s): bb7
-; CHECK-EMPTY:
-; CHECK-NEXT:    bb7:
-; CHECK-NEXT:      EMIT vp<[[VP15:%[0-9]+]]> = logical-and vp<[[VP14]]>, ir<%c4>
-; CHECK-NEXT:      EMIT vp<[[VP16:%[0-9]+]]> = or vp<[[VP15]]>, vp<[[VP11]]>
-; CHECK-NEXT:      BLEND ir<%phi> = ir<0>/vp<[[VP11]]> ir<1>/vp<[[VP14]]>
-; CHECK-NEXT:      EMIT ir<%gep> = getelementptr ir<%p>, ir<%iv>
-; CHECK-NEXT:      EMIT store ir<%phi>, ir<%gep>, vp<[[VP16]]>
-; CHECK-NEXT:    Successor(s): bb8
+; CHECK-NEXT:      EMIT vp<[[VP12:%[0-9]+]]> = logical-and ir<%c0>, ir<%c1>
+; CHECK-NEXT:      EMIT branch-on-cond ir<%c2>
+; CHECK-NEXT:    Successor(s): bb8, bb5
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb8:
 ; CHECK-NEXT:      EMIT ir<%iv.next> = add ir<%iv>, ir<1>
@@ -521,6 +494,46 @@ define void @blend_masks(ptr noalias %p, i1 %c0, i1 %c1, i1 %c2, i1 %c3, i1 %c4)
 ; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1:%[0-9]+]]>
 ; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2:%[0-9]+]]>
 ; CHECK-NEXT:    No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb5:
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP13:%[0-9]+]]> = phi [ vp<[[VP6:%[0-9]+]]>, bb4 ], [ ir<false>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP14:%[0-9]+]]> = phi [ ir<false>, bb4 ], [ vp<[[VP12]]>, bb3 ]
+; CHECK-NEXT:      EMIT vp<[[VP15:%[0-9]+]]> = logical-and vp<[[VP13]]>, ir<%c3>
+; CHECK-NEXT:      EMIT vp<[[VP16:%[0-9]+]]> = not ir<%c2>
+; CHECK-NEXT:      EMIT vp<[[VP17:%[0-9]+]]> = logical-and vp<[[VP14]]>, vp<[[VP16]]>
+; CHECK-NEXT:      EMIT vp<[[VP18:%[0-9]+]]> = or vp<[[VP15]]>, vp<[[VP17]]>
+; CHECK-NEXT:    Successor(s): bb7
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb7:
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP19:%[0-9]+]]> = phi [ vp<[[VP18]]>, bb5 ], [ ir<false>, bb6 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP20:%[0-9]+]]> = phi [ ir<false>, bb5 ], [ vp<[[VP11:%[0-9]+]]>, bb6 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP21:%[0-9]+]]> = phi [ ir<false>, bb5 ], [ vp<[[VP11]]>, bb6 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP22:%[0-9]+]]> = phi [ vp<[[VP18]]>, bb5 ], [ ir<false>, bb6 ]
+; CHECK-NEXT:      EMIT vp<[[VP23:%[0-9]+]]> = logical-and vp<[[VP21]]>, ir<%c4>
+; CHECK-NEXT:      EMIT vp<[[VP24:%[0-9]+]]> = or vp<[[VP23]]>, vp<[[VP22]]>
+; CHECK-NEXT:      BLEND ir<%phi> = ir<0>/vp<[[VP19]]> ir<1>/vp<[[VP20]]>
+; CHECK-NEXT:      EMIT ir<%gep> = getelementptr ir<%p>, ir<%iv>
+; CHECK-NEXT:      EMIT store ir<%phi>, ir<%gep>, vp<[[VP24]]>
+; CHECK-NEXT:    Successor(s): bb8
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb4:
+; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = not ir<%c1>
+; CHECK-NEXT:      EMIT vp<[[VP6]]> = logical-and ir<%c0>, vp<[[VP5]]>
+; CHECK-NEXT:      EMIT branch-on-cond ir<%c3>
+; CHECK-NEXT:    Successor(s): bb5, bb6
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb6:
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP7:%[0-9]+]]> = phi [ ir<false>, bb2 ], [ vp<[[VP6]]>, bb4 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP8:%[0-9]+]]> = phi [ vp<[[VP4:%[0-9]+]]>, bb2 ], [ ir<false>, bb4 ]
+; CHECK-NEXT:      EMIT vp<[[VP9:%[0-9]+]]> = not ir<%c3>
+; CHECK-NEXT:      EMIT vp<[[VP10:%[0-9]+]]> = logical-and vp<[[VP7]]>, vp<[[VP9]]>
+; CHECK-NEXT:      EMIT vp<[[VP11]]> = or vp<[[VP10]]>, vp<[[VP8]]>
+; CHECK-NEXT:      EMIT branch-on-cond ir<%c4>
+; CHECK-NEXT:    Successor(s): bb7, bb8
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb2:
+; CHECK-NEXT:      EMIT vp<[[VP4]]> = not ir<%c0>
+; CHECK-NEXT:    Successor(s): bb6
 ; CHECK-NEXT:  }
 ; CHECK-NEXT:  Successor(s): middle.block
 ;
@@ -582,20 +595,17 @@ define void @blend_masks_triangle_phi(ptr noalias %p, i1 %c0, i1 %c1) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    vector.body:
 ; CHECK-NEXT:      ir<%iv> = WIDEN-INDUCTION ir<0>, ir<1>, vp<[[VP0:%[0-9]+]]>
-; CHECK-NEXT:    Successor(s): bb1
+; CHECK-NEXT:      EMIT branch-on-cond ir<%c0>
+; CHECK-NEXT:    Successor(s): bb1, bb2
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb1:
-; CHECK-NEXT:    Successor(s): bb2
-; CHECK-EMPTY:
-; CHECK-NEXT:    bb2:
-; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%c1>
-; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = logical-and ir<%c0>, vp<[[VP4]]>
-; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = not ir<%c0>
-; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = or vp<[[VP5]]>, vp<[[VP6]]>
-; CHECK-NEXT:    Successor(s): bb3
+; CHECK-NEXT:      EMIT branch-on-cond ir<%c1>
+; CHECK-NEXT:    Successor(s): bb3, bb2
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb3:
-; CHECK-NEXT:      BLEND ir<%phi> = ir<0>/ir<%c0> ir<1>/vp<[[VP7]]>
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP9:%[0-9]+]]> = phi [ ir<%c0>, bb1 ], [ vp<[[VP4:%[0-9]+]]>, bb2 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP10:%[0-9]+]]> = phi [ ir<false>, bb1 ], [ vp<[[VP8:%[0-9]+]]>, bb2 ]
+; CHECK-NEXT:      BLEND ir<%phi> = ir<0>/vp<[[VP9]]> ir<1>/vp<[[VP10]]>
 ; CHECK-NEXT:      EMIT ir<%gep> = getelementptr ir<%p>, ir<%iv>
 ; CHECK-NEXT:      EMIT store ir<%phi>, ir<%gep>
 ; CHECK-NEXT:      EMIT ir<%iv.next> = add ir<%iv>, ir<1>
@@ -603,6 +613,14 @@ define void @blend_masks_triangle_phi(ptr noalias %p, i1 %c0, i1 %c1) {
 ; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1:%[0-9]+]]>
 ; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2:%[0-9]+]]>
 ; CHECK-NEXT:    No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb2:
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP4]]> = phi [ ir<false>, vector.body ], [ ir<%c0>, bb1 ]
+; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = not ir<%c1>
+; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = logical-and ir<%c0>, vp<[[VP5]]>
+; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = not ir<%c0>
+; CHECK-NEXT:      EMIT vp<[[VP8]]> = or vp<[[VP6]]>, vp<[[VP7]]>
+; CHECK-NEXT:    Successor(s): bb3
 ; CHECK-NEXT:  }
 ; CHECK-NEXT:  Successor(s): middle.block
 ;
@@ -748,34 +766,21 @@ define void @simplifiable_blend(i1 %c1, i1 %c2, i1 %c3, i32 %x, i32 %y, ptr %p) 
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    vector.body:
 ; CHECK-NEXT:      ir<%iv> = WIDEN-INDUCTION ir<0>, ir<1>, vp<[[VP0:%[0-9]+]]>
-; CHECK-NEXT:    Successor(s): B
-; CHECK-EMPTY:
-; CHECK-NEXT:    B:
-; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%c1>
-; CHECK-NEXT:    Successor(s): E
-; CHECK-EMPTY:
-; CHECK-NEXT:    E:
-; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = not ir<%c3>
-; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = logical-and vp<[[VP4]]>, vp<[[VP5]]>
-; CHECK-NEXT:    Successor(s): F
-; CHECK-EMPTY:
-; CHECK-NEXT:    F:
-; CHECK-NEXT:    Successor(s): A
+; CHECK-NEXT:      EMIT branch-on-cond ir<%c1>
+; CHECK-NEXT:    Successor(s): A, B
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    A:
-; CHECK-NEXT:    Successor(s): D
-; CHECK-EMPTY:
-; CHECK-NEXT:    D:
-; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = not ir<%c2>
-; CHECK-NEXT:      EMIT vp<[[VP8:%[0-9]+]]> = logical-and ir<%c1>, vp<[[VP7]]>
-; CHECK-NEXT:    Successor(s): C
+; CHECK-NEXT:      EMIT branch-on-cond ir<%c2>
+; CHECK-NEXT:    Successor(s): C, D
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    C:
 ; CHECK-NEXT:      EMIT vp<[[VP9:%[0-9]+]]> = logical-and ir<%c1>, ir<%c2>
 ; CHECK-NEXT:    Successor(s): latch
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    latch:
-; CHECK-NEXT:      BLEND ir<%phi> = ir<%y>/vp<[[VP4]]> ir<%x>/ir<%c1>
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP10:%[0-9]+]]> = phi [ vp<[[VP4:%[0-9]+]]>, F ], [ ir<false>, D ], [ ir<false>, C ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP11:%[0-9]+]]> = phi [ ir<false>, F ], [ ir<%c1>, D ], [ ir<%c1>, C ]
+; CHECK-NEXT:      BLEND ir<%phi> = ir<%y>/vp<[[VP10]]> ir<%x>/vp<[[VP11]]>
 ; CHECK-NEXT:      EMIT ir<%gep> = getelementptr ir<%p>, ir<%iv>
 ; CHECK-NEXT:      EMIT store ir<%phi>, ir<%gep>
 ; CHECK-NEXT:      EMIT ir<%iv.next> = add ir<%iv>, ir<1>
@@ -783,6 +788,24 @@ define void @simplifiable_blend(i1 %c1, i1 %c2, i1 %c3, i32 %x, i32 %y, ptr %p) 
 ; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1:%[0-9]+]]>
 ; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2:%[0-9]+]]>
 ; CHECK-NEXT:    No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:    D:
+; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = not ir<%c2>
+; CHECK-NEXT:      EMIT vp<[[VP8:%[0-9]+]]> = logical-and ir<%c1>, vp<[[VP7]]>
+; CHECK-NEXT:    Successor(s): latch
+; CHECK-EMPTY:
+; CHECK-NEXT:    B:
+; CHECK-NEXT:      EMIT vp<[[VP4]]> = not ir<%c1>
+; CHECK-NEXT:      EMIT branch-on-cond ir<%c3>
+; CHECK-NEXT:    Successor(s): F, E
+; CHECK-EMPTY:
+; CHECK-NEXT:    F:
+; CHECK-NEXT:    Successor(s): latch
+; CHECK-EMPTY:
+; CHECK-NEXT:    E:
+; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = not ir<%c3>
+; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = logical-and vp<[[VP4]]>, vp<[[VP5]]>
+; CHECK-NEXT:    Successor(s): F
 ; CHECK-NEXT:  }
 ; CHECK-NEXT:  Successor(s): middle.block
 ;
@@ -837,21 +860,22 @@ define void @phi_doesnt_postdom_incoming(i1 %c1, i1 %c2, i32 %x, i32 %y, ptr %p)
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    vector.body:
 ; CHECK-NEXT:      ir<%iv> = WIDEN-INDUCTION ir<0>, ir<1>, vp<[[VP0:%[0-9]+]]>
-; CHECK-NEXT:    Successor(s): B
-; CHECK-EMPTY:
-; CHECK-NEXT:    B:
-; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%c1>
-; CHECK-NEXT:    Successor(s): A
+; CHECK-NEXT:      EMIT branch-on-cond ir<%c1>
+; CHECK-NEXT:    Successor(s): A, B
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    A:
-; CHECK-NEXT:    Successor(s): C
+; CHECK-NEXT:      EMIT branch-on-cond ir<%c2>
+; CHECK-NEXT:    Successor(s): C, latch
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    C:
-; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = logical-and ir<%c1>, ir<%c2>
-; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = or vp<[[VP4]]>, vp<[[VP5]]>
-; CHECK-NEXT:      BLEND ir<%phi> = ir<%y>/vp<[[VP4]]> ir<%x>/ir<%c1>
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP5:%[0-9]+]]> = phi [ vp<[[VP4:%[0-9]+]]>, B ], [ ir<false>, A ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP6:%[0-9]+]]> = phi [ ir<false>, B ], [ ir<%c1>, A ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP7:%[0-9]+]]> = phi [ vp<[[VP4]]>, B ], [ ir<false>, A ]
+; CHECK-NEXT:      EMIT vp<[[VP8:%[0-9]+]]> = logical-and ir<%c1>, ir<%c2>
+; CHECK-NEXT:      EMIT vp<[[VP9:%[0-9]+]]> = or vp<[[VP7]]>, vp<[[VP8]]>
+; CHECK-NEXT:      BLEND ir<%phi> = ir<%y>/vp<[[VP5]]> ir<%x>/vp<[[VP6]]>
 ; CHECK-NEXT:      EMIT ir<%gep> = getelementptr ir<%p>, ir<%iv>
-; CHECK-NEXT:      EMIT store ir<%phi>, ir<%gep>, vp<[[VP6]]>
+; CHECK-NEXT:      EMIT store ir<%phi>, ir<%gep>, vp<[[VP9]]>
 ; CHECK-NEXT:    Successor(s): latch
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    latch:
@@ -860,6 +884,10 @@ define void @phi_doesnt_postdom_incoming(i1 %c1, i1 %c2, i32 %x, i32 %y, ptr %p)
 ; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1:%[0-9]+]]>
 ; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2:%[0-9]+]]>
 ; CHECK-NEXT:    No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:    B:
+; CHECK-NEXT:      EMIT vp<[[VP4]]> = not ir<%c1>
+; CHECK-NEXT:    Successor(s): C
 ; CHECK-NEXT:  }
 ; CHECK-NEXT:  Successor(s): middle.block
 ;
@@ -950,6 +978,7 @@ exit:
   ret void
 }
 
+;; Uniform control flow preservation tests
 define void @outermost_uniform_branch(ptr %a, i1 %u0) {
 ; CHECK-LABEL: VPlan for loop in 'outermost_uniform_branch'
 ; CHECK-NEXT:  <x1> vector loop: {
@@ -957,7 +986,8 @@ define void @outermost_uniform_branch(ptr %a, i1 %u0) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    vector.body:
 ; CHECK-NEXT:      ir<%iv> = WIDEN-INDUCTION nuw nsw ir<0>, ir<1>, vp<[[VP0:%[0-9]+]]>
-; CHECK-NEXT:    Successor(s): bb1
+; CHECK-NEXT:      EMIT branch-on-cond ir<%u0>
+; CHECK-NEXT:    Successor(s): bb1, bb4
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb1:
 ; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, ir<%u0>
@@ -975,7 +1005,9 @@ define void @outermost_uniform_branch(ptr %a, i1 %u0) {
 ; CHECK-NEXT:    Successor(s): bb4
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb4:
-; CHECK-NEXT:      BLEND ir<%phi4> = ir<%iv>/ir<true> ir<%add3>/ir<%u0>
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP5:%[0-9]+]]> = phi [ ir<poison>, vector.body ], [ ir<%add3>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP6:%[0-9]+]]> = phi [ ir<false>, vector.body ], [ ir<%u0>, bb3 ]
+; CHECK-NEXT:      BLEND ir<%phi4> = ir<%iv>/ir<true> vp<%5>/vp<[[VP6]]>
 ; CHECK-NEXT:      EMIT store ir<%phi4>, ir<%a>
 ; CHECK-NEXT:      EMIT ir<%iv.next> = add nuw nsw ir<%iv>, ir<1>
 ; CHECK-NEXT:      EMIT ir<%ec> = icmp eq ir<%iv.next>, ir<128>
@@ -1028,6 +1060,85 @@ exit:
   ret void
 }
 
+define void @outermost_uniform_branch_no_phi(ptr %a, i1 %u0) {
+; CHECK-LABEL: VPlan for loop in 'outermost_uniform_branch_no_phi'
+; CHECK-NEXT:  <x1> vector loop: {
+; CHECK-NEXT:  vp<[[VP3:%[0-9]+]]> = CANONICAL-IV
+; CHECK-EMPTY:
+; CHECK-NEXT:    vector.body:
+; CHECK-NEXT:      ir<%iv> = WIDEN-INDUCTION nuw nsw ir<0>, ir<1>, vp<[[VP0:%[0-9]+]]>
+; CHECK-NEXT:      EMIT ir<%gep> = getelementptr ir<%a>, ir<%iv>
+; CHECK-NEXT:      EMIT store ir<%iv>, ir<%gep>
+; CHECK-NEXT:      EMIT branch-on-cond ir<%u0>
+; CHECK-NEXT:    Successor(s): bb1, bb4
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb1:
+; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, ir<%u0>
+; CHECK-NEXT:      EMIT store ir<%add1>, ir<%gep>, ir<%u0>
+; CHECK-NEXT:      EMIT ir<%v1> = icmp sle ir<%iv>, ir<1>, ir<%u0>
+; CHECK-NEXT:    Successor(s): bb2
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb2:
+; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = logical-and ir<%u0>, ir<%v1>
+; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, vp<[[VP4]]>
+; CHECK-NEXT:      EMIT store ir<%add2>, ir<%gep>, vp<[[VP4]]>
+; CHECK-NEXT:    Successor(s): bb3
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb3:
+; CHECK-NEXT:    Successor(s): bb4
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb4:
+; CHECK-NEXT:      EMIT ir<%iv.next> = add nuw nsw ir<%iv>, ir<1>
+; CHECK-NEXT:      EMIT ir<%ec> = icmp eq ir<%iv.next>, ir<128>
+; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1:%[0-9]+]]>
+; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2:%[0-9]+]]>
+; CHECK-NEXT:    No successors
+; CHECK-NEXT:  }
+; CHECK-NEXT:  Successor(s): middle.block
+;
+entry:
+  br label %bb0
+
+bb0:
+;          bb0 (u)
+;         /    \
+;       bb1 (v) \
+;       / |      |
+;     bb2 |      |
+;       \ |      |
+;       bb3      |
+;          \    /
+;           bb4
+; bb0's uniform branch can be easily preserved.
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %bb4 ]
+  %gep = getelementptr i64, ptr %a, i64 %iv
+  %add0 = add i64 %iv, 0
+  store i64 %add0, ptr %gep
+  br i1 %u0, label %bb1, label %bb4
+
+bb1:
+  %add1 = add i64 %iv, 1
+  store i64 %add1, ptr %gep
+  %v1 = icmp sle i64 %iv, 1
+  br i1 %v1, label %bb2, label %bb3
+
+bb2:
+  %add2 = add i64 %iv, 2
+  store i64 %add2, ptr %gep
+  br label %bb3
+
+bb3:
+  br label %bb4
+
+bb4:
+  %iv.next = add nuw nsw i64 %iv, 1
+  %ec = icmp eq i64 %iv.next, 128
+  br i1 %ec, label %exit, label %bb0
+
+exit:
+  ret void
+}
+
 define void @outermost_uniform_branch_more_blocks(ptr %a, i1 %u0) {
 ; CHECK-LABEL: VPlan for loop in 'outermost_uniform_branch_more_blocks'
 ; CHECK-NEXT:  <x1> vector loop: {
@@ -1035,12 +1146,8 @@ define void @outermost_uniform_branch_more_blocks(ptr %a, i1 %u0) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    vector.body:
 ; CHECK-NEXT:      ir<%iv> = WIDEN-INDUCTION nuw nsw ir<0>, ir<1>, vp<[[VP0:%[0-9]+]]>
-; CHECK-NEXT:    Successor(s): bb1
-; CHECK-EMPTY:
-; CHECK-NEXT:    bb1:
-; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%u0>
-; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, vp<[[VP4]]>
-; CHECK-NEXT:    Successor(s): bb2
+; CHECK-NEXT:      EMIT branch-on-cond ir<%u0>
+; CHECK-NEXT:    Successor(s): bb2, bb1
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb2:
 ; CHECK-NEXT:      EMIT ir<%v2> = icmp sle ir<%iv>, ir<2>, ir<%u0>
@@ -1063,13 +1170,22 @@ define void @outermost_uniform_branch_more_blocks(ptr %a, i1 %u0) {
 ; CHECK-NEXT:    Successor(s): bb6
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb6:
-; CHECK-NEXT:      BLEND ir<%phi6> = ir<%add1>/vp<[[VP4]]> ir<%add5>/ir<%u0>
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP8:%[0-9]+]]> = phi [ ir<%add1>, bb1 ], [ ir<poison>, bb5 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP9:%[0-9]+]]> = phi [ vp<[[VP4:%[0-9]+]]>, bb1 ], [ ir<false>, bb5 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP10:%[0-9]+]]> = phi [ ir<poison>, bb1 ], [ ir<%add5>, bb5 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP11:%[0-9]+]]> = phi [ ir<false>, bb1 ], [ ir<%u0>, bb5 ]
+; CHECK-NEXT:      BLEND ir<%phi6> = vp<%8>/vp<[[VP9]]> vp<%10>/vp<[[VP11]]>
 ; CHECK-NEXT:      EMIT store ir<%phi6>, ir<%a>
 ; CHECK-NEXT:      EMIT ir<%iv.next> = add nuw nsw ir<%iv>, ir<1>
 ; CHECK-NEXT:      EMIT ir<%ec> = icmp eq ir<%iv.next>, ir<128>
 ; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1:%[0-9]+]]>
 ; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2:%[0-9]+]]>
 ; CHECK-NEXT:    No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb1:
+; CHECK-NEXT:      EMIT vp<[[VP4]]> = not ir<%u0>
+; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, vp<[[VP4]]>
+; CHECK-NEXT:    Successor(s): bb6
 ; CHECK-NEXT:  }
 ; CHECK-NEXT:  Successor(s): middle.block
 ;
@@ -1123,6 +1239,102 @@ exit:
   ret void
 }
 
+define void @outermost_uniform_branch_more_blocks_no_phi(ptr %a, i1 %u0) {
+; CHECK-LABEL: VPlan for loop in 'outermost_uniform_branch_more_blocks_no_phi'
+; CHECK-NEXT:  <x1> vector loop: {
+; CHECK-NEXT:  vp<[[VP3:%[0-9]+]]> = CANONICAL-IV
+; CHECK-EMPTY:
+; CHECK-NEXT:    vector.body:
+; CHECK-NEXT:      ir<%iv> = WIDEN-INDUCTION nuw nsw ir<0>, ir<1>, vp<[[VP0:%[0-9]+]]>
+; CHECK-NEXT:      EMIT ir<%gep> = getelementptr ir<%a>, ir<%iv>
+; CHECK-NEXT:      EMIT branch-on-cond ir<%u0>
+; CHECK-NEXT:    Successor(s): bb2, bb1
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb2:
+; CHECK-NEXT:      EMIT ir<%v2> = icmp sle ir<%iv>, ir<2>, ir<%u0>
+; CHECK-NEXT:    Successor(s): bb3
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb3:
+; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = not ir<%v2>
+; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = logical-and ir<%u0>, vp<[[VP5]]>
+; CHECK-NEXT:      EMIT ir<%add3> = add ir<%iv>, ir<3>, vp<[[VP6]]>
+; CHECK-NEXT:      EMIT store ir<%add3>, ir<%gep>, vp<[[VP6]]>
+; CHECK-NEXT:    Successor(s): bb4
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb4:
+; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = logical-and ir<%u0>, ir<%v2>
+; CHECK-NEXT:      EMIT ir<%add4> = add ir<%iv>, ir<4>, vp<[[VP7]]>
+; CHECK-NEXT:      EMIT store ir<%add4>, ir<%gep>, vp<[[VP7]]>
+; CHECK-NEXT:    Successor(s): bb5
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb5:
+; CHECK-NEXT:    Successor(s): bb6
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb6:
+; CHECK-NEXT:      EMIT ir<%iv.next> = add nuw nsw ir<%iv>, ir<1>
+; CHECK-NEXT:      EMIT ir<%ec> = icmp eq ir<%iv.next>, ir<128>
+; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1:%[0-9]+]]>
+; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2:%[0-9]+]]>
+; CHECK-NEXT:    No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb1:
+; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%u0>
+; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, vp<[[VP4]]>
+; CHECK-NEXT:      EMIT store ir<%add1>, ir<%gep>, vp<[[VP4]]>
+; CHECK-NEXT:    Successor(s): bb6
+; CHECK-NEXT:  }
+; CHECK-NEXT:  Successor(s): middle.block
+;
+entry:
+  br label %bb0
+
+bb0:
+;          bb0 (u)
+;         /      \
+;       bb2 (v)  bb1
+;       / \       |
+;     bb4  bb3    |
+;       \  /      |
+;       bb5       |
+;          \     /
+;           bb6
+; Similar to above, but with extra blocks on some edges. Probably doesn't
+; require any extra handling but nice to test explicitly.
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %bb6 ]
+  %gep = getelementptr i64, ptr %a, i64 %iv
+  br i1 %u0, label %bb2, label %bb1
+
+bb1:
+  %add1 = add i64 %iv, 1
+  store i64 %add1, ptr %gep
+  br label %bb6
+
+bb2:
+  %v2 = icmp sle i64 %iv, 2
+  br i1 %v2, label %bb4, label %bb3
+
+bb3:
+  %add3 = add i64 %iv, 3
+  store i64 %add3, ptr %gep
+  br label %bb5
+
+bb4:
+  %add4 = add i64 %iv, 4
+  store i64 %add4, ptr %gep
+  br label %bb5
+
+bb5:
+  br label %bb6
+
+bb6:
+  %iv.next = add nuw nsw i64 %iv, 1
+  %ec = icmp eq i64 %iv.next, 128
+  br i1 %ec, label %exit, label %bb0
+
+exit:
+  ret void
+}
+
 define void @uniform_branch_after_varying_branch(ptr %a, i1 %u1) {
 ; CHECK-LABEL: VPlan for loop in 'uniform_branch_after_varying_branch'
 ; CHECK-NEXT:  <x1> vector loop: {
@@ -1136,7 +1348,8 @@ define void @uniform_branch_after_varying_branch(ptr %a, i1 %u1) {
 ; CHECK-NEXT:    bb1:
 ; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%v0>
 ; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, vp<[[VP4]]>
-; CHECK-NEXT:    Successor(s): bb2
+; CHECK-NEXT:      EMIT branch-on-cond ir<%u1>
+; CHECK-NEXT:    Successor(s): bb2, bb3
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb2:
 ; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = logical-and vp<[[VP4]]>, ir<%u1>
@@ -1144,7 +1357,9 @@ define void @uniform_branch_after_varying_branch(ptr %a, i1 %u1) {
 ; CHECK-NEXT:    Successor(s): bb3
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb3:
-; CHECK-NEXT:      BLEND ir<%phi3> = ir<%add1>/ir<true> ir<%add2>/ir<%u1>
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP6:%[0-9]+]]> = phi [ ir<poison>, bb1 ], [ ir<%add2>, bb2 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP7:%[0-9]+]]> = phi [ ir<false>, bb1 ], [ ir<%u1>, bb2 ]
+; CHECK-NEXT:      BLEND ir<%phi3> = ir<%add1>/ir<true> vp<%6>/vp<[[VP7]]>
 ; CHECK-NEXT:      EMIT ir<%add3> = add ir<%phi3>, ir<3>, vp<[[VP4]]>
 ; CHECK-NEXT:    Successor(s): bb4
 ; CHECK-EMPTY:
@@ -1208,6 +1423,92 @@ exit:
   ret void
 }
 
+define void @uniform_branch_after_varying_branch_no_phi(ptr %a, i1 %u1) {
+; CHECK-LABEL: VPlan for loop in 'uniform_branch_after_varying_branch_no_phi'
+; CHECK-NEXT:  <x1> vector loop: {
+; CHECK-NEXT:  vp<[[VP3:%[0-9]+]]> = CANONICAL-IV
+; CHECK-EMPTY:
+; CHECK-NEXT:    vector.body:
+; CHECK-NEXT:      ir<%iv> = WIDEN-INDUCTION nuw nsw ir<0>, ir<1>, vp<[[VP0:%[0-9]+]]>
+; CHECK-NEXT:      EMIT ir<%gep> = getelementptr ir<%a>, ir<%iv>
+; CHECK-NEXT:      EMIT ir<%v0> = icmp sle ir<%iv>, ir<0>
+; CHECK-NEXT:    Successor(s): bb1
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb1:
+; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%v0>
+; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, vp<[[VP4]]>
+; CHECK-NEXT:      EMIT store ir<%add1>, ir<%gep>, vp<[[VP4]]>
+; CHECK-NEXT:      EMIT branch-on-cond ir<%u1>
+; CHECK-NEXT:    Successor(s): bb2, bb3
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb2:
+; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = logical-and vp<[[VP4]]>, ir<%u1>
+; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, vp<[[VP5]]>
+; CHECK-NEXT:      EMIT store ir<%add2>, ir<%gep>, vp<[[VP5]]>
+; CHECK-NEXT:    Successor(s): bb3
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb3:
+; CHECK-NEXT:    Successor(s): bb4
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb4:
+; CHECK-NEXT:      EMIT ir<%add4> = add ir<%iv>, ir<4>, ir<%v0>
+; CHECK-NEXT:      EMIT store ir<%add4>, ir<%gep>, ir<%v0>
+; CHECK-NEXT:    Successor(s): bb5
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb5:
+; CHECK-NEXT:      EMIT ir<%iv.next> = add nuw nsw ir<%iv>, ir<1>
+; CHECK-NEXT:      EMIT ir<%ec> = icmp eq ir<%iv.next>, ir<128>
+; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1:%[0-9]+]]>
+; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2:%[0-9]+]]>
+; CHECK-NEXT:    No successors
+; CHECK-NEXT:  }
+; CHECK-NEXT:  Successor(s): middle.block
+;
+entry:
+  br label %bb0
+
+bb0:
+;          bb0 (v)
+;          /    \
+;        bb4   bb1 (u)
+;         |    / |
+;         |  bb2 |
+;         |    \ |
+;         |    bb3
+;          \   /
+;          bb5
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %bb5 ]
+  %gep = getelementptr i64, ptr %a, i64 %iv
+  %v0 = icmp sle i64 %iv, 0
+  br i1 %v0, label %bb4, label %bb1
+
+bb1:
+  %add1 = add i64 %iv, 1
+  store i64 %add1, ptr %gep
+  br i1 %u1, label %bb2, label %bb3
+
+bb2:
+  %add2 = add i64 %iv, 2
+  store i64 %add2, ptr %gep
+  br label %bb3
+
+bb3:
+  br label %bb5
+
+bb4:
+  %add4 = add i64 %iv, 4
+  store i64 %add4, ptr %gep
+  br label %bb5
+
+bb5:
+  %iv.next = add nuw nsw i64 %iv, 1
+  %ec = icmp eq i64 %iv.next, 128
+  br i1 %ec, label %exit, label %bb0
+
+exit:
+  ret void
+}
+
 define void @uniform_branch_after_varying_branch_more_blocks(ptr %a, i1 %u1) {
 ; CHECK-LABEL: VPlan for loop in 'uniform_branch_after_varying_branch_more_blocks'
 ; CHECK-NEXT:  <x1> vector loop: {
@@ -1220,13 +1521,8 @@ define void @uniform_branch_after_varying_branch_more_blocks(ptr %a, i1 %u1) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb1:
 ; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%v0>
-; CHECK-NEXT:    Successor(s): bb2
-; CHECK-EMPTY:
-; CHECK-NEXT:    bb2:
-; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = not ir<%u1>
-; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = logical-and vp<[[VP4]]>, vp<[[VP5]]>
-; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, vp<[[VP6]]>
-; CHECK-NEXT:    Successor(s): bb3
+; CHECK-NEXT:      EMIT branch-on-cond ir<%u1>
+; CHECK-NEXT:    Successor(s): bb3, bb2
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb3:
 ; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = logical-and vp<[[VP4]]>, ir<%u1>
@@ -1234,7 +1530,11 @@ define void @uniform_branch_after_varying_branch_more_blocks(ptr %a, i1 %u1) {
 ; CHECK-NEXT:    Successor(s): bb4
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb4:
-; CHECK-NEXT:      BLEND ir<%phi4> = ir<%add2>/vp<[[VP5]]> ir<%add3>/ir<%u1>
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP8:%[0-9]+]]> = phi [ ir<%add2>, bb2 ], [ ir<poison>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP9:%[0-9]+]]> = phi [ vp<[[VP5:%[0-9]+]]>, bb2 ], [ ir<false>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP10:%[0-9]+]]> = phi [ ir<poison>, bb2 ], [ ir<%add3>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP11:%[0-9]+]]> = phi [ ir<false>, bb2 ], [ ir<%u1>, bb3 ]
+; CHECK-NEXT:      BLEND ir<%phi4> = vp<%8>/vp<[[VP9]]> vp<%10>/vp<[[VP11]]>
 ; CHECK-NEXT:      EMIT ir<%add4> = add ir<%phi4>, ir<4>, vp<[[VP4]]>
 ; CHECK-NEXT:    Successor(s): bb5
 ; CHECK-EMPTY:
@@ -1250,6 +1550,12 @@ define void @uniform_branch_after_varying_branch_more_blocks(ptr %a, i1 %u1) {
 ; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1:%[0-9]+]]>
 ; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2:%[0-9]+]]>
 ; CHECK-NEXT:    No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb2:
+; CHECK-NEXT:      EMIT vp<[[VP5]]> = not ir<%u1>
+; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = logical-and vp<[[VP4]]>, vp<[[VP5]]>
+; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, vp<[[VP6]]>
+; CHECK-NEXT:    Successor(s): bb4
 ; CHECK-NEXT:  }
 ; CHECK-NEXT:  Successor(s): middle.block
 ;
@@ -1303,6 +1609,102 @@ exit:
   ret void
 }
 
+define void @uniform_branch_after_varying_branch_more_blocks_no_phi(ptr %a, i1 %u1) {
+; CHECK-LABEL: VPlan for loop in 'uniform_branch_after_varying_branch_more_blocks_no_phi'
+; CHECK-NEXT:  <x1> vector loop: {
+; CHECK-NEXT:  vp<[[VP3:%[0-9]+]]> = CANONICAL-IV
+; CHECK-EMPTY:
+; CHECK-NEXT:    vector.body:
+; CHECK-NEXT:      ir<%iv> = WIDEN-INDUCTION nuw nsw ir<0>, ir<1>, vp<[[VP0:%[0-9]+]]>
+; CHECK-NEXT:      EMIT ir<%gep> = getelementptr ir<%a>, ir<%iv>
+; CHECK-NEXT:      EMIT ir<%v0> = icmp sle ir<%iv>, ir<0>
+; CHECK-NEXT:    Successor(s): bb1
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb1:
+; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%v0>
+; CHECK-NEXT:      EMIT branch-on-cond ir<%u1>
+; CHECK-NEXT:    Successor(s): bb3, bb2
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb3:
+; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = logical-and vp<[[VP4]]>, ir<%u1>
+; CHECK-NEXT:      EMIT ir<%add3> = add ir<%iv>, ir<3>, vp<[[VP7]]>
+; CHECK-NEXT:      EMIT store ir<%add3>, ir<%gep>, vp<[[VP7]]>
+; CHECK-NEXT:    Successor(s): bb4
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb4:
+; CHECK-NEXT:    Successor(s): bb5
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb5:
+; CHECK-NEXT:      EMIT ir<%add5> = add ir<%iv>, ir<5>, ir<%v0>
+; CHECK-NEXT:      EMIT store ir<%add5>, ir<%gep>, ir<%v0>
+; CHECK-NEXT:    Successor(s): bb6
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb6:
+; CHECK-NEXT:      EMIT ir<%iv.next> = add nuw nsw ir<%iv>, ir<1>
+; CHECK-NEXT:      EMIT ir<%ec> = icmp eq ir<%iv.next>, ir<128>
+; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1:%[0-9]+]]>
+; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2:%[0-9]+]]>
+; CHECK-NEXT:    No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb2:
+; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = not ir<%u1>
+; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = logical-and vp<[[VP4]]>, vp<[[VP5]]>
+; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, vp<[[VP6]]>
+; CHECK-NEXT:      EMIT store ir<%add2>, ir<%gep>, vp<[[VP6]]>
+; CHECK-NEXT:    Successor(s): bb4
+; CHECK-NEXT:  }
+; CHECK-NEXT:  Successor(s): middle.block
+;
+entry:
+  br label %bb0
+
+bb0:
+;         bb0 (v)
+;         /     \
+;       bb5    bb1 (u)
+;        |     /  \
+;        |   bb3  bb2
+;        |     \  /
+;        |     bb4
+;         \   /
+;          bb6
+; Similar to above, but with extra blocks on some edges. Probably doesn't
+; require any extra handling but nice to test explicitly.
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %bb6 ]
+  %gep = getelementptr i64, ptr %a, i64 %iv
+  %v0 = icmp sle i64 %iv, 0
+  br i1 %v0, label %bb5, label %bb1
+
+bb1:
+  br i1 %u1, label %bb3, label %bb2
+
+bb2:
+  %add2 = add i64 %iv, 2
+  store i64 %add2, ptr %gep
+  br label %bb4
+
+bb3:
+  %add3 = add i64 %iv, 3
+  store i64 %add3, ptr %gep
+  br label %bb4
+
+bb4:
+  br label %bb6
+
+bb5:
+  %add5 = add i64 %iv, 5
+  store i64 %add5, ptr %gep
+  br label %bb6
+
+bb6:
+  %iv.next = add nuw nsw i64 %iv, 1
+  %ec = icmp eq i64 %iv.next, 128
+  br i1 %ec, label %exit, label %bb0
+
+exit:
+  ret void
+}
+
 define void @uniform_branch_after_varying_branch_more_blocks_mirrored(ptr %a, i1 %u2) {
 ; CHECK-LABEL: VPlan for loop in 'uniform_branch_after_varying_branch_more_blocks_mirrored'
 ; CHECK-NEXT:  <x1> vector loop: {
@@ -1319,13 +1721,8 @@ define void @uniform_branch_after_varying_branch_more_blocks_mirrored(ptr %a, i1
 ; CHECK-NEXT:    Successor(s): bb2
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb2:
-; CHECK-NEXT:    Successor(s): bb3
-; CHECK-EMPTY:
-; CHECK-NEXT:    bb3:
-; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = not ir<%u2>
-; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = logical-and ir<%v0>, vp<[[VP5]]>
-; CHECK-NEXT:      EMIT ir<%add3> = add ir<%iv>, ir<3>, vp<[[VP6]]>
-; CHECK-NEXT:    Successor(s): bb4
+; CHECK-NEXT:      EMIT branch-on-cond ir<%u2>
+; CHECK-NEXT:    Successor(s): bb4, bb3
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb4:
 ; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = logical-and ir<%v0>, ir<%u2>
@@ -1333,7 +1730,11 @@ define void @uniform_branch_after_varying_branch_more_blocks_mirrored(ptr %a, i1
 ; CHECK-NEXT:    Successor(s): bb5
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb5:
-; CHECK-NEXT:      BLEND ir<%phi5> = ir<%add3>/vp<[[VP5]]> ir<%add4>/ir<%u2>
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP8:%[0-9]+]]> = phi [ ir<%add3>, bb3 ], [ ir<poison>, bb4 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP9:%[0-9]+]]> = phi [ vp<[[VP5:%[0-9]+]]>, bb3 ], [ ir<false>, bb4 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP10:%[0-9]+]]> = phi [ ir<poison>, bb3 ], [ ir<%add4>, bb4 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP11:%[0-9]+]]> = phi [ ir<false>, bb3 ], [ ir<%u2>, bb4 ]
+; CHECK-NEXT:      BLEND ir<%phi5> = vp<%8>/vp<[[VP9]]> vp<%10>/vp<[[VP11]]>
 ; CHECK-NEXT:      EMIT ir<%add5> = add ir<%phi5>, ir<5>, ir<%v0>
 ; CHECK-NEXT:    Successor(s): bb6
 ; CHECK-EMPTY:
@@ -1345,6 +1746,12 @@ define void @uniform_branch_after_varying_branch_more_blocks_mirrored(ptr %a, i1
 ; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1:%[0-9]+]]>
 ; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2:%[0-9]+]]>
 ; CHECK-NEXT:    No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb3:
+; CHECK-NEXT:      EMIT vp<[[VP5]]> = not ir<%u2>
+; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = logical-and ir<%v0>, vp<[[VP5]]>
+; CHECK-NEXT:      EMIT ir<%add3> = add ir<%iv>, ir<3>, vp<[[VP6]]>
+; CHECK-NEXT:    Successor(s): bb5
 ; CHECK-NEXT:  }
 ; CHECK-NEXT:  Successor(s): middle.block
 ;
@@ -1390,6 +1797,102 @@ bb5:
 bb6:
   %phi6 = phi i64 [ %add1, %bb1 ], [ %add5, %bb5 ]
   store i64 %phi6, ptr %a
+  %iv.next = add nuw nsw i64 %iv, 1
+  %ec = icmp eq i64 %iv.next, 128
+  br i1 %ec, label %exit, label %bb0
+
+exit:
+  ret void
+}
+
+define void @uniform_branch_after_varying_branch_more_blocks_mirrored_no_phi(ptr %a, i1 %u2) {
+; CHECK-LABEL: VPlan for loop in 'uniform_branch_after_varying_branch_more_blocks_mirrored_no_phi'
+; CHECK-NEXT:  <x1> vector loop: {
+; CHECK-NEXT:  vp<[[VP3:%[0-9]+]]> = CANONICAL-IV
+; CHECK-EMPTY:
+; CHECK-NEXT:    vector.body:
+; CHECK-NEXT:      ir<%iv> = WIDEN-INDUCTION nuw nsw ir<0>, ir<1>, vp<[[VP0:%[0-9]+]]>
+; CHECK-NEXT:      EMIT ir<%gep> = getelementptr ir<%a>, ir<%iv>
+; CHECK-NEXT:      EMIT ir<%v0> = icmp sle ir<%iv>, ir<0>
+; CHECK-NEXT:    Successor(s): bb1
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb1:
+; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%v0>
+; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, vp<[[VP4]]>
+; CHECK-NEXT:      EMIT store ir<%add1>, ir<%gep>, vp<[[VP4]]>
+; CHECK-NEXT:    Successor(s): bb2
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb2:
+; CHECK-NEXT:      EMIT branch-on-cond ir<%u2>
+; CHECK-NEXT:    Successor(s): bb4, bb3
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb4:
+; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = logical-and ir<%v0>, ir<%u2>
+; CHECK-NEXT:      EMIT ir<%add4> = add ir<%iv>, ir<4>, vp<[[VP7]]>
+; CHECK-NEXT:      EMIT store ir<%add4>, ir<%gep>, vp<[[VP7]]>
+; CHECK-NEXT:    Successor(s): bb5
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb5:
+; CHECK-NEXT:    Successor(s): bb6
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb6:
+; CHECK-NEXT:      EMIT ir<%iv.next> = add nuw nsw ir<%iv>, ir<1>
+; CHECK-NEXT:      EMIT ir<%ec> = icmp eq ir<%iv.next>, ir<128>
+; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1:%[0-9]+]]>
+; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2:%[0-9]+]]>
+; CHECK-NEXT:    No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb3:
+; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = not ir<%u2>
+; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = logical-and ir<%v0>, vp<[[VP5]]>
+; CHECK-NEXT:      EMIT ir<%add3> = add ir<%iv>, ir<3>, vp<[[VP6]]>
+; CHECK-NEXT:      EMIT store ir<%add3>, ir<%gep>, vp<[[VP6]]>
+; CHECK-NEXT:    Successor(s): bb5
+; CHECK-NEXT:  }
+; CHECK-NEXT:  Successor(s): middle.block
+;
+entry:
+  br label %bb0
+
+bb0:
+;          bb0 (v)
+;          /   \
+;      bb2 (u)  bb1
+;      /  \      |
+;    bb4  bb3    |
+;      \  /      |
+;       bb5      |
+;          \    /
+;           bb6
+; Mirror of the above test so that "(u)" block would be processed before/after
+; the other "(v)" destination by the RPOT.
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %bb6 ]
+  %gep = getelementptr i64, ptr %a, i64 %iv
+  %v0 = icmp sle i64 %iv, 0
+  br i1 %v0, label %bb2, label %bb1
+
+bb1:
+  %add1 = add i64 %iv, 1
+  store i64 %add1, ptr %gep
+  br label %bb6
+
+bb2:
+  br i1 %u2, label %bb4, label %bb3
+
+bb3:
+  %add3 = add i64 %iv, 3
+  store i64 %add3, ptr %gep
+  br label %bb5
+
+bb4:
+  %add4 = add i64 %iv, 4
+  store i64 %add4, ptr %gep
+  br label %bb5
+
+bb5:
+  br label %bb6
+
+bb6:
   %iv.next = add nuw nsw i64 %iv, 1
   %ec = icmp eq i64 %iv.next, 128
   br i1 %ec, label %exit, label %bb0
@@ -1489,6 +1992,97 @@ exit:
   ret void
 }
 
+define void @uniform_branch_on_masked_def_no_phi(ptr %a, ptr %uni.ptr1) {
+; CHECK-LABEL: VPlan for loop in 'uniform_branch_on_masked_def_no_phi'
+; CHECK-NEXT:  <x1> vector loop: {
+; CHECK-NEXT:  vp<[[VP3:%[0-9]+]]> = CANONICAL-IV
+; CHECK-EMPTY:
+; CHECK-NEXT:    vector.body:
+; CHECK-NEXT:      ir<%iv> = WIDEN-INDUCTION nuw nsw ir<0>, ir<1>, vp<[[VP0:%[0-9]+]]>
+; CHECK-NEXT:      EMIT ir<%gep> = getelementptr ir<%a>, ir<%iv>
+; CHECK-NEXT:      EMIT store ir<%iv>, ir<%gep>
+; CHECK-NEXT:      EMIT ir<%v0> = icmp sle ir<%iv>, ir<0>
+; CHECK-NEXT:    Successor(s): bb1
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb1:
+; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%v0>
+; CHECK-NEXT:      EMIT-SCALAR ir<%cu1> = load ir<%uni.ptr1>, vp<[[VP4]]>
+; CHECK-NEXT:    Successor(s): bb2
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb2:
+; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = not ir<%cu1>
+; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = logical-and vp<[[VP4]]>, vp<[[VP5]]>
+; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, vp<[[VP6]]>
+; CHECK-NEXT:      EMIT store ir<%add2>, ir<%gep>, vp<[[VP6]]>
+; CHECK-NEXT:    Successor(s): bb3
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb3:
+; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = logical-and vp<[[VP4]]>, ir<%cu1>
+; CHECK-NEXT:      EMIT ir<%add3> = add ir<%iv>, ir<3>, vp<[[VP7]]>
+; CHECK-NEXT:      EMIT store ir<%add3>, ir<%gep>, vp<[[VP7]]>
+; CHECK-NEXT:    Successor(s): bb4
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb4:
+; CHECK-NEXT:    Successor(s): bb5
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb5:
+; CHECK-NEXT:      EMIT ir<%iv.next> = add nuw nsw ir<%iv>, ir<1>
+; CHECK-NEXT:      EMIT ir<%ec> = icmp eq ir<%iv.next>, ir<128>
+; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1:%[0-9]+]]>
+; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2:%[0-9]+]]>
+; CHECK-NEXT:    No successors
+; CHECK-NEXT:  }
+; CHECK-NEXT:  Successor(s): middle.block
+;
+entry:
+  br label %bb0
+
+bb0:
+;          bb0 (v)
+;           /   \
+;          |    bb1 (br i1 (load i1 %uni.ptr))
+;          |   /  \
+;          | bb3  bb2
+;          |    \ /
+;          |    bb4
+;           \  /
+;            bb5
+; bb1's condition is uniform, but its value is loaded only along one path of
+; bb0's varying branch. It cannot be preserved trivially, because some the load
+; may never be executed.
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %bb5 ]
+  %gep = getelementptr i64, ptr %a, i64 %iv
+  %add0 = add i64 %iv, 0
+  store i64 %add0, ptr %gep
+  %v0 = icmp sle i64 %iv, 0
+  br i1 %v0, label %bb5, label %bb1
+
+bb1:
+  %cu1 = load i1, ptr %uni.ptr1
+  br i1 %cu1, label %bb3, label %bb2
+
+bb2:
+  %add2 = add i64 %iv, 2
+  store i64 %add2, ptr %gep
+  br label %bb4
+
+bb3:
+  %add3 = add i64 %iv, 3
+  store i64 %add3, ptr %gep
+  br label %bb4
+
+bb4:
+  br label %bb5
+
+bb5:
+  %iv.next = add nuw nsw i64 %iv, 1
+  %ec = icmp eq i64 %iv.next, 128
+  br i1 %ec, label %exit, label %bb0
+
+exit:
+  ret void
+}
+
 define void @uniform_branch_unstructured_merge1(ptr %a, i1 %u0) {
 ; CHECK-LABEL: VPlan for loop in 'uniform_branch_unstructured_merge1'
 ; CHECK-NEXT:  <x1> vector loop: {
@@ -1496,12 +2090,8 @@ define void @uniform_branch_unstructured_merge1(ptr %a, i1 %u0) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    vector.body:
 ; CHECK-NEXT:      ir<%iv> = WIDEN-INDUCTION nuw nsw ir<0>, ir<1>, vp<[[VP0:%[0-9]+]]>
-; CHECK-NEXT:    Successor(s): bb1
-; CHECK-EMPTY:
-; CHECK-NEXT:    bb1:
-; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%u0>
-; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, vp<[[VP4]]>
-; CHECK-NEXT:    Successor(s): bb2
+; CHECK-NEXT:      EMIT branch-on-cond ir<%u0>
+; CHECK-NEXT:    Successor(s): bb2, bb1
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb2:
 ; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, ir<%u0>
@@ -1514,21 +2104,34 @@ define void @uniform_branch_unstructured_merge1(ptr %a, i1 %u0) {
 ; CHECK-NEXT:    Successor(s): bb3
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb3:
-; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = not ir<%v2>
-; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = logical-and ir<%u0>, vp<[[VP6]]>
-; CHECK-NEXT:      EMIT vp<[[VP8:%[0-9]+]]> = or vp<[[VP7]]>, vp<[[VP4]]>
-; CHECK-NEXT:      BLEND ir<%phi3> = ir<%add1>/vp<[[VP4]]> ir<%add2>/ir<%u0>
-; CHECK-NEXT:      EMIT ir<%add3> = add ir<%phi3>, ir<3>, vp<[[VP8]]>
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP6:%[0-9]+]]> = phi [ ir<poison>, bb1 ], [ ir<%add4>, bb4 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP7:%[0-9]+]]> = phi [ ir<false>, bb1 ], [ vp<[[VP5]]>, bb4 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP8:%[0-9]+]]> = phi [ ir<%add1>, bb1 ], [ ir<poison>, bb4 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP9:%[0-9]+]]> = phi [ vp<[[VP4:%[0-9]+]]>, bb1 ], [ ir<false>, bb4 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP10:%[0-9]+]]> = phi [ ir<poison>, bb1 ], [ ir<%add2>, bb4 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP11:%[0-9]+]]> = phi [ ir<false>, bb1 ], [ ir<%u0>, bb4 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP12:%[0-9]+]]> = phi [ ir<false>, bb1 ], [ ir<%v2>, bb4 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP13:%[0-9]+]]> = phi [ vp<[[VP4]]>, bb1 ], [ ir<false>, bb4 ]
+; CHECK-NEXT:      EMIT vp<[[VP14:%[0-9]+]]> = not vp<[[VP12]]>
+; CHECK-NEXT:      EMIT vp<[[VP15:%[0-9]+]]> = logical-and ir<%u0>, vp<[[VP14]]>
+; CHECK-NEXT:      EMIT vp<[[VP16:%[0-9]+]]> = or vp<[[VP15]]>, vp<[[VP13]]>
+; CHECK-NEXT:      BLEND ir<%phi3> = vp<%8>/vp<[[VP9]]> vp<%10>/vp<[[VP11]]>
+; CHECK-NEXT:      EMIT ir<%add3> = add ir<%phi3>, ir<3>, vp<[[VP16]]>
 ; CHECK-NEXT:    Successor(s): bb5
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb5:
-; CHECK-NEXT:      BLEND ir<%phi5> = ir<%add4>/vp<[[VP5]]> ir<%add3>/vp<[[VP8]]>
+; CHECK-NEXT:      BLEND ir<%phi5> = vp<%6>/vp<[[VP7]]> ir<%add3>/vp<[[VP16]]>
 ; CHECK-NEXT:      EMIT store ir<%phi5>, ir<%a>
 ; CHECK-NEXT:      EMIT ir<%iv.next> = add nuw nsw ir<%iv>, ir<1>
 ; CHECK-NEXT:      EMIT ir<%ec> = icmp eq ir<%iv.next>, ir<128>
 ; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1:%[0-9]+]]>
 ; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2:%[0-9]+]]>
 ; CHECK-NEXT:    No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb1:
+; CHECK-NEXT:      EMIT vp<[[VP4]]> = not ir<%u0>
+; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, vp<[[VP4]]>
+; CHECK-NEXT:    Successor(s): bb3
 ; CHECK-NEXT:  }
 ; CHECK-NEXT:  Successor(s): middle.block
 ;
@@ -1578,6 +2181,98 @@ exit:
   ret void
 }
 
+define void @uniform_branch_unstructured_merge1_no_phi(ptr %a, i1 %u0) {
+; CHECK-LABEL: VPlan for loop in 'uniform_branch_unstructured_merge1_no_phi'
+; CHECK-NEXT:  <x1> vector loop: {
+; CHECK-NEXT:  vp<[[VP3:%[0-9]+]]> = CANONICAL-IV
+; CHECK-EMPTY:
+; CHECK-NEXT:    vector.body:
+; CHECK-NEXT:      ir<%iv> = WIDEN-INDUCTION nuw nsw ir<0>, ir<1>, vp<[[VP0:%[0-9]+]]>
+; CHECK-NEXT:      EMIT ir<%gep> = getelementptr ir<%a>, ir<%iv>
+; CHECK-NEXT:      EMIT branch-on-cond ir<%u0>
+; CHECK-NEXT:    Successor(s): bb2, bb1
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb2:
+; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, ir<%u0>
+; CHECK-NEXT:      EMIT store ir<%add2>, ir<%gep>, ir<%u0>
+; CHECK-NEXT:      EMIT ir<%v2> = icmp sle ir<%iv>, ir<2>, ir<%u0>
+; CHECK-NEXT:    Successor(s): bb4
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb4:
+; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = logical-and ir<%u0>, ir<%v2>
+; CHECK-NEXT:      EMIT ir<%add4> = add ir<%iv>, ir<4>, vp<[[VP5]]>
+; CHECK-NEXT:      EMIT store ir<%add4>, ir<%gep>, vp<[[VP5]]>
+; CHECK-NEXT:    Successor(s): bb3
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb3:
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP6:%[0-9]+]]> = phi [ ir<false>, bb1 ], [ ir<%v2>, bb4 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP7:%[0-9]+]]> = phi [ vp<[[VP4:%[0-9]+]]>, bb1 ], [ ir<false>, bb4 ]
+; CHECK-NEXT:      EMIT vp<[[VP8:%[0-9]+]]> = not vp<[[VP6]]>
+; CHECK-NEXT:      EMIT vp<[[VP9:%[0-9]+]]> = logical-and ir<%u0>, vp<[[VP8]]>
+; CHECK-NEXT:      EMIT vp<[[VP10:%[0-9]+]]> = or vp<[[VP9]]>, vp<[[VP7]]>
+; CHECK-NEXT:    Successor(s): bb5
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb5:
+; CHECK-NEXT:      EMIT ir<%iv.next> = add nuw nsw ir<%iv>, ir<1>
+; CHECK-NEXT:      EMIT ir<%ec> = icmp eq ir<%iv.next>, ir<128>
+; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1:%[0-9]+]]>
+; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2:%[0-9]+]]>
+; CHECK-NEXT:    No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb1:
+; CHECK-NEXT:      EMIT vp<[[VP4]]> = not ir<%u0>
+; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, vp<[[VP4]]>
+; CHECK-NEXT:      EMIT store ir<%add1>, ir<%gep>, vp<[[VP4]]>
+; CHECK-NEXT:    Successor(s): bb3
+; CHECK-NEXT:  }
+; CHECK-NEXT:  Successor(s): middle.block
+;
+entry:
+  br label %bb0
+
+bb0:
+; All @uniform_branch_unstructured_merge[0-4] below have the same structure of uniform
+; control flow merging into the middle of the varying diamond, but "covering"
+; different potential RPOT traversals.
+;          bb0 (u)
+;         /       \
+;      bb2 (v)   bb1
+;       /   \     /
+;     bb4     bb3
+;       \   /
+;        bb5
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %bb5 ]
+  %gep = getelementptr i64, ptr %a, i64 %iv
+  br i1 %u0, label %bb2, label %bb1
+
+bb1:
+  %add1 = add i64 %iv, 1
+  store i64 %add1, ptr %gep
+  br label %bb3
+
+bb2:
+  %add2 = add i64 %iv, 2
+  store i64 %add2, ptr %gep
+  %v2 = icmp sle i64 %iv, 2
+  br i1 %v2, label %bb4, label %bb3
+
+bb3:
+  br label %bb5
+
+bb4:
+  %add4 = add i64 %iv, 4
+  store i64 %add4, ptr %gep
+  br label %bb5
+
+bb5:
+  %iv.next = add nuw nsw i64 %iv, 1
+  %ec = icmp eq i64 %iv.next, 128
+  br i1 %ec, label %exit, label %bb0
+
+exit:
+  ret void
+}
+
 define void @uniform_branch_unstructured_merge2(ptr %a, i1 %u0) {
 ; CHECK-LABEL: VPlan for loop in 'uniform_branch_unstructured_merge2'
 ; CHECK-NEXT:  <x1> vector loop: {
@@ -1585,12 +2280,8 @@ define void @uniform_branch_unstructured_merge2(ptr %a, i1 %u0) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    vector.body:
 ; CHECK-NEXT:      ir<%iv> = WIDEN-INDUCTION nuw nsw ir<0>, ir<1>, vp<[[VP0:%[0-9]+]]>
-; CHECK-NEXT:    Successor(s): bb1
-; CHECK-EMPTY:
-; CHECK-NEXT:    bb1:
-; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%u0>
-; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, vp<[[VP4]]>
-; CHECK-NEXT:    Successor(s): bb2
+; CHECK-NEXT:      EMIT branch-on-cond ir<%u0>
+; CHECK-NEXT:    Successor(s): bb2, bb1
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb2:
 ; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, ir<%u0>
@@ -1604,20 +2295,33 @@ define void @uniform_branch_unstructured_merge2(ptr %a, i1 %u0) {
 ; CHECK-NEXT:    Successor(s): bb4
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb4:
-; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = logical-and ir<%u0>, ir<%v2>
-; CHECK-NEXT:      EMIT vp<[[VP8:%[0-9]+]]> = or vp<[[VP7]]>, vp<[[VP4]]>
-; CHECK-NEXT:      BLEND ir<%phi4> = ir<%add1>/vp<[[VP4]]> ir<%add2>/ir<%u0>
-; CHECK-NEXT:      EMIT ir<%add4> = add ir<%phi4>, ir<4>, vp<[[VP8]]>
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP7:%[0-9]+]]> = phi [ ir<poison>, bb1 ], [ ir<%add3>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP8:%[0-9]+]]> = phi [ ir<false>, bb1 ], [ vp<[[VP6]]>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP9:%[0-9]+]]> = phi [ ir<%add1>, bb1 ], [ ir<poison>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP10:%[0-9]+]]> = phi [ vp<[[VP4:%[0-9]+]]>, bb1 ], [ ir<false>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP11:%[0-9]+]]> = phi [ ir<poison>, bb1 ], [ ir<%add2>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP12:%[0-9]+]]> = phi [ ir<false>, bb1 ], [ ir<%u0>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP13:%[0-9]+]]> = phi [ ir<false>, bb1 ], [ ir<%v2>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP14:%[0-9]+]]> = phi [ vp<[[VP4]]>, bb1 ], [ ir<false>, bb3 ]
+; CHECK-NEXT:      EMIT vp<[[VP15:%[0-9]+]]> = logical-and ir<%u0>, vp<[[VP13]]>
+; CHECK-NEXT:      EMIT vp<[[VP16:%[0-9]+]]> = or vp<[[VP15]]>, vp<[[VP14]]>
+; CHECK-NEXT:      BLEND ir<%phi4> = vp<%9>/vp<[[VP10]]> vp<%11>/vp<[[VP12]]>
+; CHECK-NEXT:      EMIT ir<%add4> = add ir<%phi4>, ir<4>, vp<[[VP16]]>
 ; CHECK-NEXT:    Successor(s): bb5
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb5:
-; CHECK-NEXT:      BLEND ir<%phi5> = ir<%add3>/vp<[[VP6]]> ir<%add4>/vp<[[VP8]]>
+; CHECK-NEXT:      BLEND ir<%phi5> = vp<%7>/vp<[[VP8]]> ir<%add4>/vp<[[VP16]]>
 ; CHECK-NEXT:      EMIT store ir<%phi5>, ir<%a>
 ; CHECK-NEXT:      EMIT ir<%iv.next> = add nuw nsw ir<%iv>, ir<1>
 ; CHECK-NEXT:      EMIT ir<%ec> = icmp eq ir<%iv.next>, ir<128>
 ; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1:%[0-9]+]]>
 ; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2:%[0-9]+]]>
 ; CHECK-NEXT:    No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb1:
+; CHECK-NEXT:      EMIT vp<[[VP4]]> = not ir<%u0>
+; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, vp<[[VP4]]>
+; CHECK-NEXT:    Successor(s): bb4
 ; CHECK-NEXT:  }
 ; CHECK-NEXT:  Successor(s): middle.block
 ;
@@ -1666,6 +2370,97 @@ exit:
   ret void
 }
 
+define void @uniform_branch_unstructured_merge2_no_phi(ptr %a, i1 %u0) {
+; CHECK-LABEL: VPlan for loop in 'uniform_branch_unstructured_merge2_no_phi'
+; CHECK-NEXT:  <x1> vector loop: {
+; CHECK-NEXT:  vp<[[VP3:%[0-9]+]]> = CANONICAL-IV
+; CHECK-EMPTY:
+; CHECK-NEXT:    vector.body:
+; CHECK-NEXT:      ir<%iv> = WIDEN-INDUCTION nuw nsw ir<0>, ir<1>, vp<[[VP0:%[0-9]+]]>
+; CHECK-NEXT:      EMIT ir<%gep> = getelementptr ir<%a>, ir<%iv>
+; CHECK-NEXT:      EMIT branch-on-cond ir<%u0>
+; CHECK-NEXT:    Successor(s): bb2, bb1
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb2:
+; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, ir<%u0>
+; CHECK-NEXT:      EMIT store ir<%add2>, ir<%gep>, ir<%u0>
+; CHECK-NEXT:      EMIT ir<%v2> = icmp sle ir<%iv>, ir<2>, ir<%u0>
+; CHECK-NEXT:    Successor(s): bb3
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb3:
+; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = not ir<%v2>
+; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = logical-and ir<%u0>, vp<[[VP5]]>
+; CHECK-NEXT:      EMIT ir<%add3> = add ir<%iv>, ir<3>, vp<[[VP6]]>
+; CHECK-NEXT:      EMIT store ir<%add3>, ir<%gep>, vp<[[VP6]]>
+; CHECK-NEXT:    Successor(s): bb4
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb4:
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP7:%[0-9]+]]> = phi [ ir<false>, bb1 ], [ ir<%v2>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP8:%[0-9]+]]> = phi [ vp<[[VP4:%[0-9]+]]>, bb1 ], [ ir<false>, bb3 ]
+; CHECK-NEXT:      EMIT vp<[[VP9:%[0-9]+]]> = logical-and ir<%u0>, vp<[[VP7]]>
+; CHECK-NEXT:      EMIT vp<[[VP10:%[0-9]+]]> = or vp<[[VP9]]>, vp<[[VP8]]>
+; CHECK-NEXT:    Successor(s): bb5
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb5:
+; CHECK-NEXT:      EMIT ir<%iv.next> = add nuw nsw ir<%iv>, ir<1>
+; CHECK-NEXT:      EMIT ir<%ec> = icmp eq ir<%iv.next>, ir<128>
+; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1:%[0-9]+]]>
+; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2:%[0-9]+]]>
+; CHECK-NEXT:    No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb1:
+; CHECK-NEXT:      EMIT vp<[[VP4]]> = not ir<%u0>
+; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, vp<[[VP4]]>
+; CHECK-NEXT:      EMIT store ir<%add1>, ir<%gep>, vp<[[VP4]]>
+; CHECK-NEXT:    Successor(s): bb4
+; CHECK-NEXT:  }
+; CHECK-NEXT:  Successor(s): middle.block
+;
+entry:
+  br label %bb0
+
+bb0:
+;          bb0 (u)
+;         /       \
+;      bb2 (v)   bb1
+;       /   \     /
+;      |   +-\---+
+;      |  /   \
+;      bb4   bb3
+;       \    /
+;         bb5
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %bb5 ]
+  %gep = getelementptr i64, ptr %a, i64 %iv
+  br i1 %u0, label %bb2, label %bb1
+
+bb1:
+  %add1 = add i64 %iv, 1
+  store i64 %add1, ptr %gep
+  br label %bb4
+
+bb2:
+  %add2 = add i64 %iv, 2
+  store i64 %add2, ptr %gep
+  %v2 = icmp sle i64 %iv, 2
+  br i1 %v2, label %bb4, label %bb3
+
+bb3:
+  %add3 = add i64 %iv, 3
+  store i64 %add3, ptr %gep
+  br label %bb5
+
+bb4:
+  br label %bb5
+
+bb5:
+  %iv.next = add nuw nsw i64 %iv, 1
+  %ec = icmp eq i64 %iv.next, 128
+  br i1 %ec, label %exit, label %bb0
+
+exit:
+  ret void
+}
+
 define void @uniform_branch_unstructured_merge3(ptr %a, i1 %u0) {
 ; CHECK-LABEL: VPlan for loop in 'uniform_branch_unstructured_merge3'
 ; CHECK-NEXT:  <x1> vector loop: {
@@ -1673,39 +2468,48 @@ define void @uniform_branch_unstructured_merge3(ptr %a, i1 %u0) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    vector.body:
 ; CHECK-NEXT:      ir<%iv> = WIDEN-INDUCTION nuw nsw ir<0>, ir<1>, vp<[[VP0:%[0-9]+]]>
-; CHECK-NEXT:    Successor(s): bb1
-; CHECK-EMPTY:
-; CHECK-NEXT:    bb1:
-; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%u0>
-; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, vp<[[VP4]]>
-; CHECK-NEXT:      EMIT ir<%v1> = icmp sle ir<%iv>, ir<1>, vp<[[VP4]]>
-; CHECK-NEXT:    Successor(s): bb2
-; CHECK-EMPTY:
-; CHECK-NEXT:    bb2:
-; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = not ir<%v1>
-; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = logical-and vp<[[VP4]]>, vp<[[VP5]]>
-; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, vp<[[VP6]]>
-; CHECK-NEXT:    Successor(s): bb3
+; CHECK-NEXT:      EMIT branch-on-cond ir<%u0>
+; CHECK-NEXT:    Successor(s): bb3, bb1
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb3:
 ; CHECK-NEXT:      EMIT ir<%add3> = add ir<%iv>, ir<3>, ir<%u0>
 ; CHECK-NEXT:    Successor(s): bb4
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb4:
-; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = logical-and vp<[[VP4]]>, ir<%v1>
-; CHECK-NEXT:      EMIT vp<[[VP8:%[0-9]+]]> = or ir<%u0>, vp<[[VP7]]>
-; CHECK-NEXT:      BLEND ir<%phi4> = ir<%add1>/vp<[[VP4]]> ir<%add3>/ir<%u0>
-; CHECK-NEXT:      EMIT ir<%add4> = add ir<%phi4>, ir<4>, vp<[[VP8]]>
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP7:%[0-9]+]]> = phi [ ir<%add2>, bb2 ], [ ir<poison>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP8:%[0-9]+]]> = phi [ vp<[[VP6:%[0-9]+]]>, bb2 ], [ ir<false>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP9:%[0-9]+]]> = phi [ ir<%add1>, bb2 ], [ ir<poison>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP10:%[0-9]+]]> = phi [ vp<[[VP4:%[0-9]+]]>, bb2 ], [ ir<false>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP11:%[0-9]+]]> = phi [ ir<poison>, bb2 ], [ ir<%add3>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP12:%[0-9]+]]> = phi [ ir<false>, bb2 ], [ ir<%u0>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP13:%[0-9]+]]> = phi [ vp<[[VP4]]>, bb2 ], [ ir<false>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP14:%[0-9]+]]> = phi [ ir<%v1>, bb2 ], [ ir<false>, bb3 ]
+; CHECK-NEXT:      EMIT vp<[[VP15:%[0-9]+]]> = logical-and vp<[[VP13]]>, vp<[[VP14]]>
+; CHECK-NEXT:      EMIT vp<[[VP16:%[0-9]+]]> = or ir<%u0>, vp<[[VP15]]>
+; CHECK-NEXT:      BLEND ir<%phi4> = vp<%9>/vp<[[VP10]]> vp<%11>/vp<[[VP12]]>
+; CHECK-NEXT:      EMIT ir<%add4> = add ir<%phi4>, ir<4>, vp<[[VP16]]>
 ; CHECK-NEXT:    Successor(s): bb5
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb5:
-; CHECK-NEXT:      BLEND ir<%phi5> = ir<%add2>/vp<[[VP6]]> ir<%add4>/vp<[[VP8]]>
+; CHECK-NEXT:      BLEND ir<%phi5> = vp<%7>/vp<[[VP8]]> ir<%add4>/vp<[[VP16]]>
 ; CHECK-NEXT:      EMIT store ir<%phi5>, ir<%a>
 ; CHECK-NEXT:      EMIT ir<%iv.next> = add nuw nsw ir<%iv>, ir<1>
 ; CHECK-NEXT:      EMIT ir<%ec> = icmp eq ir<%iv.next>, ir<128>
 ; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1:%[0-9]+]]>
 ; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2:%[0-9]+]]>
 ; CHECK-NEXT:    No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb1:
+; CHECK-NEXT:      EMIT vp<[[VP4]]> = not ir<%u0>
+; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, vp<[[VP4]]>
+; CHECK-NEXT:      EMIT ir<%v1> = icmp sle ir<%iv>, ir<1>, vp<[[VP4]]>
+; CHECK-NEXT:    Successor(s): bb2
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb2:
+; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = not ir<%v1>
+; CHECK-NEXT:      EMIT vp<[[VP6]]> = logical-and vp<[[VP4]]>, vp<[[VP5]]>
+; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, vp<[[VP6]]>
+; CHECK-NEXT:    Successor(s): bb4
 ; CHECK-NEXT:  }
 ; CHECK-NEXT:  Successor(s): middle.block
 ;
@@ -1752,6 +2556,95 @@ exit:
   ret void
 }
 
+define void @uniform_branch_unstructured_merge3_no_phi(ptr %a, i1 %u0) {
+; CHECK-LABEL: VPlan for loop in 'uniform_branch_unstructured_merge3_no_phi'
+; CHECK-NEXT:  <x1> vector loop: {
+; CHECK-NEXT:  vp<[[VP3:%[0-9]+]]> = CANONICAL-IV
+; CHECK-EMPTY:
+; CHECK-NEXT:    vector.body:
+; CHECK-NEXT:      ir<%iv> = WIDEN-INDUCTION nuw nsw ir<0>, ir<1>, vp<[[VP0:%[0-9]+]]>
+; CHECK-NEXT:      EMIT ir<%gep> = getelementptr ir<%a>, ir<%iv>
+; CHECK-NEXT:      EMIT branch-on-cond ir<%u0>
+; CHECK-NEXT:    Successor(s): bb3, bb1
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb3:
+; CHECK-NEXT:      EMIT ir<%add3> = add ir<%iv>, ir<3>, ir<%u0>
+; CHECK-NEXT:      EMIT store ir<%add3>, ir<%gep>, ir<%u0>
+; CHECK-NEXT:    Successor(s): bb4
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb4:
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP7:%[0-9]+]]> = phi [ vp<[[VP4:%[0-9]+]]>, bb2 ], [ ir<false>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP8:%[0-9]+]]> = phi [ ir<%v1>, bb2 ], [ ir<false>, bb3 ]
+; CHECK-NEXT:      EMIT vp<[[VP9:%[0-9]+]]> = logical-and vp<[[VP7]]>, vp<[[VP8]]>
+; CHECK-NEXT:      EMIT vp<[[VP10:%[0-9]+]]> = or ir<%u0>, vp<[[VP9]]>
+; CHECK-NEXT:    Successor(s): bb5
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb5:
+; CHECK-NEXT:      EMIT ir<%iv.next> = add nuw nsw ir<%iv>, ir<1>
+; CHECK-NEXT:      EMIT ir<%ec> = icmp eq ir<%iv.next>, ir<128>
+; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1:%[0-9]+]]>
+; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2:%[0-9]+]]>
+; CHECK-NEXT:    No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb1:
+; CHECK-NEXT:      EMIT vp<[[VP4]]> = not ir<%u0>
+; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, vp<[[VP4]]>
+; CHECK-NEXT:      EMIT store ir<%add1>, ir<%gep>, vp<[[VP4]]>
+; CHECK-NEXT:      EMIT ir<%v1> = icmp sle ir<%iv>, ir<1>, vp<[[VP4]]>
+; CHECK-NEXT:    Successor(s): bb2
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb2:
+; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = not ir<%v1>
+; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = logical-and vp<[[VP4]]>, vp<[[VP5]]>
+; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, vp<[[VP6]]>
+; CHECK-NEXT:      EMIT store ir<%add2>, ir<%gep>, vp<[[VP6]]>
+; CHECK-NEXT:    Successor(s): bb4
+; CHECK-NEXT:  }
+; CHECK-NEXT:  Successor(s): middle.block
+;
+entry:
+  br label %bb0
+
+bb0:
+;         bb0 (u)
+;         /  \
+;      bb3   bb1 (v)
+;        \   /  \
+;        bb4     bb2
+;           \   /
+;            bb5
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %bb5 ]
+  %gep = getelementptr i64, ptr %a, i64 %iv
+  br i1 %u0, label %bb3, label %bb1
+
+bb1:
+  %add1 = add i64 %iv, 1
+  store i64 %add1, ptr %gep
+  %v1 = icmp sle i64 %iv, 1
+  br i1 %v1, label %bb4, label %bb2
+
+bb2:
+  %add2 = add i64 %iv, 2
+  store i64 %add2, ptr %gep
+  br label %bb5
+
+bb3:
+  %add3 = add i64 %iv, 3
+  store i64 %add3, ptr %gep
+  br label %bb4
+
+bb4:
+  br label %bb5
+
+bb5:
+  %iv.next = add nuw nsw i64 %iv, 1
+  %ec = icmp eq i64 %iv.next, 128
+  br i1 %ec, label %exit, label %bb0
+
+exit:
+  ret void
+}
+
 define void @uniform_branch_unstructured_merge4(ptr %a, i1 %u0) {
 ; CHECK-LABEL: VPlan for loop in 'uniform_branch_unstructured_merge4'
 ; CHECK-NEXT:  <x1> vector loop: {
@@ -1759,39 +2652,48 @@ define void @uniform_branch_unstructured_merge4(ptr %a, i1 %u0) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    vector.body:
 ; CHECK-NEXT:      ir<%iv> = WIDEN-INDUCTION nuw nsw ir<0>, ir<1>, vp<[[VP0:%[0-9]+]]>
-; CHECK-NEXT:    Successor(s): bb1
-; CHECK-EMPTY:
-; CHECK-NEXT:    bb1:
-; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%u0>
-; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, vp<[[VP4]]>
-; CHECK-NEXT:      EMIT ir<%v1> = icmp sle ir<%iv>, ir<1>, vp<[[VP4]]>
-; CHECK-NEXT:    Successor(s): bb4
-; CHECK-EMPTY:
-; CHECK-NEXT:    bb4:
-; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = logical-and vp<[[VP4]]>, ir<%v1>
-; CHECK-NEXT:      EMIT ir<%add4> = add ir<%iv>, ir<4>, vp<[[VP5]]>
-; CHECK-NEXT:    Successor(s): bb3
+; CHECK-NEXT:      EMIT branch-on-cond ir<%u0>
+; CHECK-NEXT:    Successor(s): bb3, bb1
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb3:
 ; CHECK-NEXT:      EMIT ir<%add3> = add ir<%iv>, ir<3>, ir<%u0>
 ; CHECK-NEXT:    Successor(s): bb2
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb2:
-; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = not ir<%v1>
-; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = logical-and vp<[[VP4]]>, vp<[[VP6]]>
-; CHECK-NEXT:      EMIT vp<[[VP8:%[0-9]+]]> = or ir<%u0>, vp<[[VP7]]>
-; CHECK-NEXT:      BLEND ir<%phi2> = ir<%add1>/vp<[[VP4]]> ir<%add3>/ir<%u0>
-; CHECK-NEXT:      EMIT ir<%add2> = add ir<%phi2>, ir<2>, vp<[[VP8]]>
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP6:%[0-9]+]]> = phi [ ir<%add4>, bb4 ], [ ir<poison>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP7:%[0-9]+]]> = phi [ vp<[[VP5:%[0-9]+]]>, bb4 ], [ ir<false>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP8:%[0-9]+]]> = phi [ ir<%add1>, bb4 ], [ ir<poison>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP9:%[0-9]+]]> = phi [ vp<[[VP4:%[0-9]+]]>, bb4 ], [ ir<false>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP10:%[0-9]+]]> = phi [ ir<poison>, bb4 ], [ ir<%add3>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP11:%[0-9]+]]> = phi [ ir<false>, bb4 ], [ ir<%u0>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP12:%[0-9]+]]> = phi [ ir<%v1>, bb4 ], [ ir<false>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP13:%[0-9]+]]> = phi [ vp<[[VP4]]>, bb4 ], [ ir<false>, bb3 ]
+; CHECK-NEXT:      EMIT vp<[[VP14:%[0-9]+]]> = not vp<[[VP12]]>
+; CHECK-NEXT:      EMIT vp<[[VP15:%[0-9]+]]> = logical-and vp<[[VP13]]>, vp<[[VP14]]>
+; CHECK-NEXT:      EMIT vp<[[VP16:%[0-9]+]]> = or ir<%u0>, vp<[[VP15]]>
+; CHECK-NEXT:      BLEND ir<%phi2> = vp<%8>/vp<[[VP9]]> vp<%10>/vp<[[VP11]]>
+; CHECK-NEXT:      EMIT ir<%add2> = add ir<%phi2>, ir<2>, vp<[[VP16]]>
 ; CHECK-NEXT:    Successor(s): bb5
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb5:
-; CHECK-NEXT:      BLEND ir<%phi5> = ir<%add4>/vp<[[VP5]]> ir<%add2>/vp<[[VP8]]>
+; CHECK-NEXT:      BLEND ir<%phi5> = vp<%6>/vp<[[VP7]]> ir<%add2>/vp<[[VP16]]>
 ; CHECK-NEXT:      EMIT store ir<%phi5>, ir<%a>
 ; CHECK-NEXT:      EMIT ir<%iv.next> = add nuw nsw ir<%iv>, ir<1>
 ; CHECK-NEXT:      EMIT ir<%ec> = icmp eq ir<%iv.next>, ir<128>
 ; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1:%[0-9]+]]>
 ; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2:%[0-9]+]]>
 ; CHECK-NEXT:    No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb1:
+; CHECK-NEXT:      EMIT vp<[[VP4]]> = not ir<%u0>
+; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, vp<[[VP4]]>
+; CHECK-NEXT:      EMIT ir<%v1> = icmp sle ir<%iv>, ir<1>, vp<[[VP4]]>
+; CHECK-NEXT:    Successor(s): bb4
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb4:
+; CHECK-NEXT:      EMIT vp<[[VP5]]> = logical-and vp<[[VP4]]>, ir<%v1>
+; CHECK-NEXT:      EMIT ir<%add4> = add ir<%iv>, ir<4>, vp<[[VP5]]>
+; CHECK-NEXT:    Successor(s): bb2
 ; CHECK-NEXT:  }
 ; CHECK-NEXT:  Successor(s): middle.block
 ;
@@ -1840,6 +2742,97 @@ exit:
   ret void
 }
 
+define void @uniform_branch_unstructured_merge4_no_phi(ptr %a, i1 %u0) {
+; CHECK-LABEL: VPlan for loop in 'uniform_branch_unstructured_merge4_no_phi'
+; CHECK-NEXT:  <x1> vector loop: {
+; CHECK-NEXT:  vp<[[VP3:%[0-9]+]]> = CANONICAL-IV
+; CHECK-EMPTY:
+; CHECK-NEXT:    vector.body:
+; CHECK-NEXT:      ir<%iv> = WIDEN-INDUCTION nuw nsw ir<0>, ir<1>, vp<[[VP0:%[0-9]+]]>
+; CHECK-NEXT:      EMIT ir<%gep> = getelementptr ir<%a>, ir<%iv>
+; CHECK-NEXT:      EMIT branch-on-cond ir<%u0>
+; CHECK-NEXT:    Successor(s): bb3, bb1
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb3:
+; CHECK-NEXT:      EMIT ir<%add3> = add ir<%iv>, ir<3>, ir<%u0>
+; CHECK-NEXT:      EMIT store ir<%add3>, ir<%gep>, ir<%u0>
+; CHECK-NEXT:    Successor(s): bb2
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb2:
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP6:%[0-9]+]]> = phi [ ir<%v1>, bb4 ], [ ir<false>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP7:%[0-9]+]]> = phi [ vp<[[VP4:%[0-9]+]]>, bb4 ], [ ir<false>, bb3 ]
+; CHECK-NEXT:      EMIT vp<[[VP8:%[0-9]+]]> = not vp<[[VP6]]>
+; CHECK-NEXT:      EMIT vp<[[VP9:%[0-9]+]]> = logical-and vp<[[VP7]]>, vp<[[VP8]]>
+; CHECK-NEXT:      EMIT vp<[[VP10:%[0-9]+]]> = or ir<%u0>, vp<[[VP9]]>
+; CHECK-NEXT:    Successor(s): bb5
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb5:
+; CHECK-NEXT:      EMIT ir<%iv.next> = add nuw nsw ir<%iv>, ir<1>
+; CHECK-NEXT:      EMIT ir<%ec> = icmp eq ir<%iv.next>, ir<128>
+; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1:%[0-9]+]]>
+; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2:%[0-9]+]]>
+; CHECK-NEXT:    No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb1:
+; CHECK-NEXT:      EMIT vp<[[VP4]]> = not ir<%u0>
+; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, vp<[[VP4]]>
+; CHECK-NEXT:      EMIT store ir<%add1>, ir<%gep>, vp<[[VP4]]>
+; CHECK-NEXT:      EMIT ir<%v1> = icmp sle ir<%iv>, ir<1>, vp<[[VP4]]>
+; CHECK-NEXT:    Successor(s): bb4
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb4:
+; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = logical-and vp<[[VP4]]>, ir<%v1>
+; CHECK-NEXT:      EMIT ir<%add4> = add ir<%iv>, ir<4>, vp<[[VP5]]>
+; CHECK-NEXT:      EMIT store ir<%add4>, ir<%gep>, vp<[[VP5]]>
+; CHECK-NEXT:    Successor(s): bb2
+; CHECK-NEXT:  }
+; CHECK-NEXT:  Successor(s): middle.block
+;
+entry:
+  br label %bb0
+
+bb0:
+;         bb0 (u)
+;         /  \
+;      bb3   bb1 (v)
+;        \   /    \
+;         +-/--+   \
+;          /    \   \
+;        bb4      bb2
+;           \    /
+;             bb5
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %bb5 ]
+  %gep = getelementptr i64, ptr %a, i64 %iv
+  br i1 %u0, label %bb3, label %bb1
+
+bb1:
+  %add1 = add i64 %iv, 1
+  store i64 %add1, ptr %gep
+  %v1 = icmp sle i64 %iv, 1
+  br i1 %v1, label %bb4, label %bb2
+
+bb2:
+  br label %bb5
+
+bb3:
+  %add3 = add i64 %iv, 3
+  store i64 %add3, ptr %gep
+  br label %bb2
+
+bb4:
+  %add4 = add i64 %iv, 4
+  store i64 %add4, ptr %gep
+  br label %bb5
+
+bb5:
+  %iv.next = add nuw nsw i64 %iv, 1
+  %ec = icmp eq i64 %iv.next, 128
+  br i1 %ec, label %exit, label %bb0
+
+exit:
+  ret void
+}
+
 define void @uniform_branch_shared_join_with_varying(ptr %a, i1 %u0) {
 ; CHECK-LABEL: VPlan for loop in 'uniform_branch_shared_join_with_varying'
 ; CHECK-NEXT:  <x1> vector loop: {
@@ -1847,12 +2840,8 @@ define void @uniform_branch_shared_join_with_varying(ptr %a, i1 %u0) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    vector.body:
 ; CHECK-NEXT:      ir<%iv> = WIDEN-INDUCTION nuw nsw ir<0>, ir<1>, vp<[[VP0:%[0-9]+]]>
-; CHECK-NEXT:    Successor(s): bb1
-; CHECK-EMPTY:
-; CHECK-NEXT:    bb1:
-; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%u0>
-; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, vp<[[VP4]]>
-; CHECK-NEXT:    Successor(s): bb2
+; CHECK-NEXT:      EMIT branch-on-cond ir<%u0>
+; CHECK-NEXT:    Successor(s): bb2, bb1
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb2:
 ; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, ir<%u0>
@@ -1865,13 +2854,24 @@ define void @uniform_branch_shared_join_with_varying(ptr %a, i1 %u0) {
 ; CHECK-NEXT:    Successor(s): bb4
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb4:
-; CHECK-NEXT:      BLEND ir<%phi4> = ir<%add1>/vp<[[VP4]]> ir<%add2>/ir<%u0> ir<%add3>/vp<[[VP5]]>
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP6:%[0-9]+]]> = phi [ ir<%add1>, bb1 ], [ ir<poison>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP7:%[0-9]+]]> = phi [ vp<[[VP4:%[0-9]+]]>, bb1 ], [ ir<false>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP8:%[0-9]+]]> = phi [ ir<poison>, bb1 ], [ ir<%add2>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP9:%[0-9]+]]> = phi [ ir<false>, bb1 ], [ ir<%u0>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP10:%[0-9]+]]> = phi [ ir<poison>, bb1 ], [ ir<%add3>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP11:%[0-9]+]]> = phi [ ir<false>, bb1 ], [ vp<[[VP5]]>, bb3 ]
+; CHECK-NEXT:      BLEND ir<%phi4> = vp<%6>/vp<[[VP7]]> vp<%8>/vp<[[VP9]]> vp<%10>/vp<[[VP11]]>
 ; CHECK-NEXT:      EMIT store ir<%phi4>, ir<%a>
 ; CHECK-NEXT:      EMIT ir<%iv.next> = add nuw nsw ir<%iv>, ir<1>
 ; CHECK-NEXT:      EMIT ir<%ec> = icmp eq ir<%iv.next>, ir<128>
 ; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1:%[0-9]+]]>
 ; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2:%[0-9]+]]>
 ; CHECK-NEXT:    No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb1:
+; CHECK-NEXT:      EMIT vp<[[VP4]]> = not ir<%u0>
+; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, vp<[[VP4]]>
+; CHECK-NEXT:    Successor(s): bb4
 ; CHECK-NEXT:  }
 ; CHECK-NEXT:  Successor(s): middle.block
 ;
@@ -1914,6 +2914,85 @@ exit:
   ret void
 }
 
+define void @uniform_branch_shared_join_with_varying_no_phi(ptr %a, i1 %u0) {
+; CHECK-LABEL: VPlan for loop in 'uniform_branch_shared_join_with_varying_no_phi'
+; CHECK-NEXT:  <x1> vector loop: {
+; CHECK-NEXT:  vp<[[VP3:%[0-9]+]]> = CANONICAL-IV
+; CHECK-EMPTY:
+; CHECK-NEXT:    vector.body:
+; CHECK-NEXT:      ir<%iv> = WIDEN-INDUCTION nuw nsw ir<0>, ir<1>, vp<[[VP0:%[0-9]+]]>
+; CHECK-NEXT:      EMIT ir<%gep> = getelementptr ir<%a>, ir<%iv>
+; CHECK-NEXT:      EMIT branch-on-cond ir<%u0>
+; CHECK-NEXT:    Successor(s): bb2, bb1
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb2:
+; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, ir<%u0>
+; CHECK-NEXT:      EMIT store ir<%add2>, ir<%gep>, ir<%u0>
+; CHECK-NEXT:      EMIT ir<%v2> = icmp sle ir<%iv>, ir<2>, ir<%u0>
+; CHECK-NEXT:    Successor(s): bb3
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb3:
+; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = logical-and ir<%u0>, ir<%v2>
+; CHECK-NEXT:      EMIT ir<%add3> = add ir<%iv>, ir<3>, vp<[[VP5]]>
+; CHECK-NEXT:      EMIT store ir<%add3>, ir<%gep>, vp<[[VP5]]>
+; CHECK-NEXT:    Successor(s): bb4
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb4:
+; CHECK-NEXT:      EMIT ir<%iv.next> = add nuw nsw ir<%iv>, ir<1>
+; CHECK-NEXT:      EMIT ir<%ec> = icmp eq ir<%iv.next>, ir<128>
+; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1:%[0-9]+]]>
+; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2:%[0-9]+]]>
+; CHECK-NEXT:    No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb1:
+; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%u0>
+; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, vp<[[VP4]]>
+; CHECK-NEXT:      EMIT store ir<%add1>, ir<%gep>, vp<[[VP4]]>
+; CHECK-NEXT:    Successor(s): bb4
+; CHECK-NEXT:  }
+; CHECK-NEXT:  Successor(s): middle.block
+;
+entry:
+  br label %bb0
+
+bb0:
+;          bb0 (u)
+;         /     \
+;      bb2 (v)   bb1
+;       / |     /
+;     bb3 |    /
+;       \ |   /
+;         bb4
+; Theoretically can be done, but would require a combination of a blend and a phi.
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %bb4 ]
+  %gep = getelementptr i64, ptr %a, i64 %iv
+  br i1 %u0, label %bb2, label %bb1
+
+bb1:
+  %add1 = add i64 %iv, 1
+  store i64 %add1, ptr %gep
+  br label %bb4
+
+bb2:
+  %add2 = add i64 %iv, 2
+  store i64 %add2, ptr %gep
+  %v2 = icmp sle i64 %iv, 2
+  br i1 %v2, label %bb3, label %bb4
+
+bb3:
+  %add3 = add i64 %iv, 3
+  store i64 %add3, ptr %gep
+  br label %bb4
+
+bb4:
+  %iv.next = add nuw nsw i64 %iv, 1
+  %ec = icmp eq i64 %iv.next, 128
+  br i1 %ec, label %exit, label %bb0
+
+exit:
+  ret void
+}
+
 define void @unstructured_uniform_only(ptr %a, i1 %u0, i1 %u2) {
 ; CHECK-LABEL: VPlan for loop in 'unstructured_uniform_only'
 ; CHECK-NEXT:  <x1> vector loop: {
@@ -1921,38 +3000,49 @@ define void @unstructured_uniform_only(ptr %a, i1 %u0, i1 %u2) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    vector.body:
 ; CHECK-NEXT:      ir<%iv> = WIDEN-INDUCTION nuw nsw ir<0>, ir<1>, vp<[[VP0:%[0-9]+]]>
-; CHECK-NEXT:    Successor(s): bb1
-; CHECK-EMPTY:
-; CHECK-NEXT:    bb1:
-; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%u0>
-; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, vp<[[VP4]]>
-; CHECK-NEXT:    Successor(s): bb2
+; CHECK-NEXT:      EMIT branch-on-cond ir<%u0>
+; CHECK-NEXT:    Successor(s): bb2, bb1
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb2:
 ; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, ir<%u0>
-; CHECK-NEXT:    Successor(s): bb4
+; CHECK-NEXT:      EMIT branch-on-cond ir<%u2>
+; CHECK-NEXT:    Successor(s): bb4, bb3
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb4:
-; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = logical-and ir<%u0>, ir<%u2>
-; CHECK-NEXT:      EMIT ir<%add4> = add ir<%iv>, ir<4>, vp<[[VP5]]>
-; CHECK-NEXT:    Successor(s): bb3
-; CHECK-EMPTY:
-; CHECK-NEXT:    bb3:
-; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = not ir<%u2>
-; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = logical-and ir<%u0>, vp<[[VP6]]>
-; CHECK-NEXT:      EMIT vp<[[VP8:%[0-9]+]]> = or vp<[[VP7]]>, vp<[[VP4]]>
-; CHECK-NEXT:      BLEND ir<%phi3> = ir<%add1>/vp<[[VP4]]> ir<%add2>/ir<%u0>
-; CHECK-NEXT:      EMIT ir<%add3> = add ir<%phi3>, ir<3>, vp<[[VP8]]>
+; CHECK-NEXT:      EMIT vp<[[VP13:%[0-9]+]]> = logical-and ir<%u0>, ir<%u2>
+; CHECK-NEXT:      EMIT ir<%add4> = add ir<%iv>, ir<4>, vp<[[VP13]]>
 ; CHECK-NEXT:    Successor(s): bb5
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb5:
-; CHECK-NEXT:      BLEND ir<%phi5> = ir<%add4>/vp<[[VP5]]> ir<%add3>/vp<[[VP8]]>
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP14:%[0-9]+]]> = phi [ ir<%add4>, bb4 ], [ ir<poison>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP15:%[0-9]+]]> = phi [ vp<[[VP13]]>, bb4 ], [ ir<false>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP16:%[0-9]+]]> = phi [ ir<poison>, bb4 ], [ ir<%add3>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP17:%[0-9]+]]> = phi [ ir<false>, bb4 ], [ vp<[[VP12:%[0-9]+]]>, bb3 ]
+; CHECK-NEXT:      BLEND ir<%phi5> = vp<%14>/vp<[[VP15]]> vp<%16>/vp<[[VP17]]>
 ; CHECK-NEXT:      EMIT store ir<%phi5>, ir<%a>
 ; CHECK-NEXT:      EMIT ir<%iv.next> = add nuw nsw ir<%iv>, ir<1>
 ; CHECK-NEXT:      EMIT ir<%ec> = icmp eq ir<%iv.next>, ir<128>
 ; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1:%[0-9]+]]>
 ; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2:%[0-9]+]]>
 ; CHECK-NEXT:    No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb3:
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP5:%[0-9]+]]> = phi [ ir<%add1>, bb1 ], [ ir<poison>, bb2 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP6:%[0-9]+]]> = phi [ vp<[[VP4:%[0-9]+]]>, bb1 ], [ ir<false>, bb2 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP7:%[0-9]+]]> = phi [ ir<poison>, bb1 ], [ ir<%add2>, bb2 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP8:%[0-9]+]]> = phi [ ir<false>, bb1 ], [ ir<%u0>, bb2 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP9:%[0-9]+]]> = phi [ vp<[[VP4]]>, bb1 ], [ ir<false>, bb2 ]
+; CHECK-NEXT:      EMIT vp<[[VP10:%[0-9]+]]> = not ir<%u2>
+; CHECK-NEXT:      EMIT vp<[[VP11:%[0-9]+]]> = logical-and ir<%u0>, vp<[[VP10]]>
+; CHECK-NEXT:      EMIT vp<[[VP12]]> = or vp<[[VP11]]>, vp<[[VP9]]>
+; CHECK-NEXT:      BLEND ir<%phi3> = vp<%5>/vp<[[VP6]]> vp<%7>/vp<[[VP8]]>
+; CHECK-NEXT:      EMIT ir<%add3> = add ir<%phi3>, ir<3>, vp<[[VP12]]>
+; CHECK-NEXT:    Successor(s): bb5
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb1:
+; CHECK-NEXT:      EMIT vp<[[VP4]]> = not ir<%u0>
+; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, vp<[[VP4]]>
+; CHECK-NEXT:    Successor(s): bb3
 ; CHECK-NEXT:  }
 ; CHECK-NEXT:  Successor(s): middle.block
 ;
@@ -1999,6 +3089,94 @@ exit:
   ret void
 }
 
+define void @unstructured_uniform_only_no_phi(ptr %a, i1 %u0, i1 %u2) {
+; CHECK-LABEL: VPlan for loop in 'unstructured_uniform_only_no_phi'
+; CHECK-NEXT:  <x1> vector loop: {
+; CHECK-NEXT:  vp<[[VP3:%[0-9]+]]> = CANONICAL-IV
+; CHECK-EMPTY:
+; CHECK-NEXT:    vector.body:
+; CHECK-NEXT:      ir<%iv> = WIDEN-INDUCTION nuw nsw ir<0>, ir<1>, vp<[[VP0:%[0-9]+]]>
+; CHECK-NEXT:      EMIT ir<%gep> = getelementptr ir<%a>, ir<%iv>
+; CHECK-NEXT:      EMIT branch-on-cond ir<%u0>
+; CHECK-NEXT:    Successor(s): bb2, bb1
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb2:
+; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, ir<%u0>
+; CHECK-NEXT:      EMIT store ir<%add2>, ir<%gep>, ir<%u0>
+; CHECK-NEXT:      EMIT branch-on-cond ir<%u2>
+; CHECK-NEXT:    Successor(s): bb4, bb3
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb4:
+; CHECK-NEXT:      EMIT vp<[[VP9:%[0-9]+]]> = logical-and ir<%u0>, ir<%u2>
+; CHECK-NEXT:      EMIT ir<%add4> = add ir<%iv>, ir<4>, vp<[[VP9]]>
+; CHECK-NEXT:      EMIT store ir<%add4>, ir<%gep>, vp<[[VP9]]>
+; CHECK-NEXT:    Successor(s): bb5
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb5:
+; CHECK-NEXT:      EMIT ir<%iv.next> = add nuw nsw ir<%iv>, ir<1>
+; CHECK-NEXT:      EMIT ir<%ec> = icmp eq ir<%iv.next>, ir<128>
+; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1:%[0-9]+]]>
+; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2:%[0-9]+]]>
+; CHECK-NEXT:    No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb3:
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP5:%[0-9]+]]> = phi [ vp<[[VP4:%[0-9]+]]>, bb1 ], [ ir<false>, bb2 ]
+; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = not ir<%u2>
+; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = logical-and ir<%u0>, vp<[[VP6]]>
+; CHECK-NEXT:      EMIT vp<[[VP8:%[0-9]+]]> = or vp<[[VP7]]>, vp<[[VP5]]>
+; CHECK-NEXT:    Successor(s): bb5
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb1:
+; CHECK-NEXT:      EMIT vp<[[VP4]]> = not ir<%u0>
+; CHECK-NEXT:      EMIT ir<%add1> = add ir<%iv>, ir<1>, vp<[[VP4]]>
+; CHECK-NEXT:      EMIT store ir<%add1>, ir<%gep>, vp<[[VP4]]>
+; CHECK-NEXT:    Successor(s): bb3
+; CHECK-NEXT:  }
+; CHECK-NEXT:  Successor(s): middle.block
+;
+entry:
+  br label %bb0
+
+bb0:
+;             bb0 (u)
+;            /    \
+;         bb2 (u)  bb1
+;          /   \   /
+;        bb4    bb3
+;          \   /
+;           bb5
+; Triviallly preservable, but detection might not be easy.
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %bb5 ]
+  %gep = getelementptr i64, ptr %a, i64 %iv
+  br i1 %u0, label %bb2, label %bb1
+
+bb1:
+  %add1 = add i64 %iv, 1
+  store i64 %add1, ptr %gep
+  br label %bb3
+
+bb2:
+  %add2 = add i64 %iv, 2
+  store i64 %add2, ptr %gep
+  br i1 %u2, label %bb4, label %bb3
+
+bb3:
+  br label %bb5
+
+bb4:
+  %add4 = add i64 %iv, 4
+  store i64 %add4, ptr %gep
+  br label %bb5
+
+bb5:
+  %iv.next = add nuw nsw i64 %iv, 1
+  %ec = icmp eq i64 %iv.next, 128
+  br i1 %ec, label %exit, label %bb0
+
+exit:
+  ret void
+}
+
 define void @unstructured_uniform_only_sese_region(ptr %a, i1 %u1, i1 %u3) {
 ; CHECK-LABEL: VPlan for loop in 'unstructured_uniform_only_sese_region'
 ; CHECK-NEXT:  <x1> vector loop: {
@@ -2011,34 +3189,26 @@ define void @unstructured_uniform_only_sese_region(ptr %a, i1 %u1, i1 %u3) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb1:
 ; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%v0>
-; CHECK-NEXT:    Successor(s): bb2
-; CHECK-EMPTY:
-; CHECK-NEXT:    bb2:
-; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = not ir<%u1>
-; CHECK-NEXT:      EMIT vp<[[VP6:%[0-9]+]]> = logical-and vp<[[VP4]]>, vp<[[VP5]]>
-; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, vp<[[VP6]]>
-; CHECK-NEXT:    Successor(s): bb3
+; CHECK-NEXT:      EMIT branch-on-cond ir<%u1>
+; CHECK-NEXT:    Successor(s): bb3, bb2
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb3:
 ; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = logical-and vp<[[VP4]]>, ir<%u1>
 ; CHECK-NEXT:      EMIT ir<%add3> = add ir<%iv>, ir<3>, vp<[[VP7]]>
-; CHECK-NEXT:    Successor(s): bb5
+; CHECK-NEXT:      EMIT branch-on-cond ir<%u3>
+; CHECK-NEXT:    Successor(s): bb5, bb4
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb5:
-; CHECK-NEXT:      EMIT vp<[[VP8:%[0-9]+]]> = logical-and vp<[[VP7]]>, ir<%u3>
-; CHECK-NEXT:      EMIT ir<%add5> = add ir<%iv>, ir<5>, vp<[[VP8]]>
-; CHECK-NEXT:    Successor(s): bb4
-; CHECK-EMPTY:
-; CHECK-NEXT:    bb4:
-; CHECK-NEXT:      EMIT vp<[[VP9:%[0-9]+]]> = not ir<%u3>
-; CHECK-NEXT:      EMIT vp<[[VP10:%[0-9]+]]> = logical-and vp<[[VP7]]>, vp<[[VP9]]>
-; CHECK-NEXT:      EMIT vp<[[VP11:%[0-9]+]]> = or vp<[[VP10]]>, vp<[[VP6]]>
-; CHECK-NEXT:      BLEND ir<%phi4> = ir<%add2>/vp<[[VP5]]> ir<%add3>/ir<%u1>
-; CHECK-NEXT:      EMIT ir<%add4> = add ir<%phi4>, ir<4>, vp<[[VP11]]>
+; CHECK-NEXT:      EMIT vp<[[VP17:%[0-9]+]]> = logical-and vp<[[VP7]]>, ir<%u3>
+; CHECK-NEXT:      EMIT ir<%add5> = add ir<%iv>, ir<5>, vp<[[VP17]]>
 ; CHECK-NEXT:    Successor(s): bb7
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb7:
-; CHECK-NEXT:      BLEND ir<%phi7> = ir<%add5>/vp<[[VP8]]> ir<%add4>/vp<[[VP11]]>
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP18:%[0-9]+]]> = phi [ ir<%add5>, bb5 ], [ ir<poison>, bb4 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP19:%[0-9]+]]> = phi [ vp<[[VP17]]>, bb5 ], [ ir<false>, bb4 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP20:%[0-9]+]]> = phi [ ir<poison>, bb5 ], [ ir<%add4>, bb4 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP21:%[0-9]+]]> = phi [ ir<false>, bb5 ], [ vp<[[VP16:%[0-9]+]]>, bb4 ]
+; CHECK-NEXT:      BLEND ir<%phi7> = vp<%18>/vp<[[VP19]]> vp<%20>/vp<[[VP21]]>
 ; CHECK-NEXT:      EMIT ir<%add7> = add ir<%phi7>, ir<7>, vp<[[VP4]]>
 ; CHECK-NEXT:    Successor(s): bb6
 ; CHECK-EMPTY:
@@ -2054,6 +3224,26 @@ define void @unstructured_uniform_only_sese_region(ptr %a, i1 %u1, i1 %u3) {
 ; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1:%[0-9]+]]>
 ; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2:%[0-9]+]]>
 ; CHECK-NEXT:    No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb4:
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP8:%[0-9]+]]> = phi [ ir<%add2>, bb2 ], [ ir<poison>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP9:%[0-9]+]]> = phi [ vp<[[VP5:%[0-9]+]]>, bb2 ], [ ir<false>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP10:%[0-9]+]]> = phi [ ir<poison>, bb2 ], [ ir<%add3>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP11:%[0-9]+]]> = phi [ ir<false>, bb2 ], [ ir<%u1>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP12:%[0-9]+]]> = phi [ ir<false>, bb2 ], [ vp<[[VP7]]>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP13:%[0-9]+]]> = phi [ vp<[[VP6:%[0-9]+]]>, bb2 ], [ ir<false>, bb3 ]
+; CHECK-NEXT:      EMIT vp<[[VP14:%[0-9]+]]> = not ir<%u3>
+; CHECK-NEXT:      EMIT vp<[[VP15:%[0-9]+]]> = logical-and vp<[[VP12]]>, vp<[[VP14]]>
+; CHECK-NEXT:      EMIT vp<[[VP16]]> = or vp<[[VP15]]>, vp<[[VP13]]>
+; CHECK-NEXT:      BLEND ir<%phi4> = vp<%8>/vp<[[VP9]]> vp<%10>/vp<[[VP11]]>
+; CHECK-NEXT:      EMIT ir<%add4> = add ir<%phi4>, ir<4>, vp<[[VP16]]>
+; CHECK-NEXT:    Successor(s): bb7
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb2:
+; CHECK-NEXT:      EMIT vp<[[VP5]]> = not ir<%u1>
+; CHECK-NEXT:      EMIT vp<[[VP6]]> = logical-and vp<[[VP4]]>, vp<[[VP5]]>
+; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, vp<[[VP6]]>
+; CHECK-NEXT:    Successor(s): bb4
 ; CHECK-NEXT:  }
 ; CHECK-NEXT:  Successor(s): middle.block
 ;
@@ -2109,6 +3299,126 @@ bb7:
 bb8:
   %phi8 = phi i64 [ %add6, %bb6 ], [ %add7, %bb7 ]
   store i64 %phi8, ptr %a
+  %iv.next = add nuw nsw i64 %iv, 1
+  %ec = icmp eq i64 %iv.next, 128
+  br i1 %ec, label %exit, label %bb0
+
+exit:
+  ret void
+}
+
+define void @unstructured_uniform_only_sese_region_no_phi(ptr %a, i1 %u1, i1 %u3) {
+; CHECK-LABEL: VPlan for loop in 'unstructured_uniform_only_sese_region_no_phi'
+; CHECK-NEXT:  <x1> vector loop: {
+; CHECK-NEXT:  vp<[[VP3:%[0-9]+]]> = CANONICAL-IV
+; CHECK-EMPTY:
+; CHECK-NEXT:    vector.body:
+; CHECK-NEXT:      ir<%iv> = WIDEN-INDUCTION nuw nsw ir<0>, ir<1>, vp<[[VP0:%[0-9]+]]>
+; CHECK-NEXT:      EMIT ir<%gep> = getelementptr ir<%a>, ir<%iv>
+; CHECK-NEXT:      EMIT ir<%v0> = icmp sle ir<%iv>, ir<0>
+; CHECK-NEXT:    Successor(s): bb1
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb1:
+; CHECK-NEXT:      EMIT vp<[[VP4:%[0-9]+]]> = not ir<%v0>
+; CHECK-NEXT:      EMIT branch-on-cond ir<%u1>
+; CHECK-NEXT:    Successor(s): bb3, bb2
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb3:
+; CHECK-NEXT:      EMIT vp<[[VP7:%[0-9]+]]> = logical-and vp<[[VP4]]>, ir<%u1>
+; CHECK-NEXT:      EMIT ir<%add3> = add ir<%iv>, ir<3>, vp<[[VP7]]>
+; CHECK-NEXT:      EMIT store ir<%add3>, ir<%gep>, vp<[[VP7]]>
+; CHECK-NEXT:      EMIT branch-on-cond ir<%u3>
+; CHECK-NEXT:    Successor(s): bb5, bb4
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb5:
+; CHECK-NEXT:      EMIT vp<[[VP13:%[0-9]+]]> = logical-and vp<[[VP7]]>, ir<%u3>
+; CHECK-NEXT:      EMIT ir<%add5> = add ir<%iv>, ir<5>, vp<[[VP13]]>
+; CHECK-NEXT:      EMIT store ir<%add5>, ir<%gep>, vp<[[VP13]]>
+; CHECK-NEXT:    Successor(s): bb7
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb7:
+; CHECK-NEXT:    Successor(s): bb6
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb6:
+; CHECK-NEXT:      EMIT ir<%add6> = add ir<%iv>, ir<6>, ir<%v0>
+; CHECK-NEXT:      EMIT store ir<%add6>, ir<%gep>, ir<%v0>
+; CHECK-NEXT:    Successor(s): bb8
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb8:
+; CHECK-NEXT:      EMIT ir<%iv.next> = add nuw nsw ir<%iv>, ir<1>
+; CHECK-NEXT:      EMIT ir<%ec> = icmp eq ir<%iv.next>, ir<128>
+; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP3]]>, vp<[[VP1:%[0-9]+]]>
+; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2:%[0-9]+]]>
+; CHECK-NEXT:    No successors
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb4:
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP8:%[0-9]+]]> = phi [ ir<false>, bb2 ], [ vp<[[VP7]]>, bb3 ]
+; CHECK-NEXT:      WIDEN-PHI vp<[[VP9:%[0-9]+]]> = phi [ vp<[[VP6:%[0-9]+]]>, bb2 ], [ ir<false>, bb3 ]
+; CHECK-NEXT:      EMIT vp<[[VP10:%[0-9]+]]> = not ir<%u3>
+; CHECK-NEXT:      EMIT vp<[[VP11:%[0-9]+]]> = logical-and vp<[[VP8]]>, vp<[[VP10]]>
+; CHECK-NEXT:      EMIT vp<[[VP12:%[0-9]+]]> = or vp<[[VP11]]>, vp<[[VP9]]>
+; CHECK-NEXT:    Successor(s): bb7
+; CHECK-EMPTY:
+; CHECK-NEXT:    bb2:
+; CHECK-NEXT:      EMIT vp<[[VP5:%[0-9]+]]> = not ir<%u1>
+; CHECK-NEXT:      EMIT vp<[[VP6]]> = logical-and vp<[[VP4]]>, vp<[[VP5]]>
+; CHECK-NEXT:      EMIT ir<%add2> = add ir<%iv>, ir<2>, vp<[[VP6]]>
+; CHECK-NEXT:      EMIT store ir<%add2>, ir<%gep>, vp<[[VP6]]>
+; CHECK-NEXT:    Successor(s): bb4
+; CHECK-NEXT:  }
+; CHECK-NEXT:  Successor(s): middle.block
+;
+entry:
+  br label %bb0
+
+bb0:
+;             bb0 (v)
+;            /       \
+;         bb6       bb1 (u)
+;          |        /     \
+;          |     bb3 (u)   bb2
+;          |      /   \   /
+;          |    bb5   bb4
+;          |      \   /
+;          |       bb7
+;           \     /
+;            \   /
+;             bb8
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %bb8 ]
+  %gep = getelementptr i64, ptr %a, i64 %iv
+  %v0 = icmp sle i64 %iv, 0
+  br i1 %v0, label %bb6, label %bb1
+
+bb1:
+  br i1 %u1, label %bb3, label %bb2
+
+bb2:
+  %add2 = add i64 %iv, 2
+  store i64 %add2, ptr %gep
+  br label %bb4
+
+bb3:
+  %add3 = add i64 %iv, 3
+  store i64 %add3, ptr %gep
+  br i1 %u3, label %bb5, label %bb4
+
+bb4:
+  br label %bb7
+
+bb5:
+  %add5 = add i64 %iv, 5
+  store i64 %add5, ptr %gep
+  br label %bb7
+
+bb6:
+  %add6 = add i64 %iv, 6
+  store i64 %add6, ptr %gep
+  br label %bb8
+
+bb7:
+  br label %bb8
+
+bb8:
   %iv.next = add nuw nsw i64 %iv, 1
   %ec = icmp eq i64 %iv.next, 128
   br i1 %ec, label %exit, label %bb0

--- a/llvm/test/Transforms/LoopVectorize/VPlan/vplan-sink-scalars-and-merge-vf1.ll
+++ b/llvm/test/Transforms/LoopVectorize/VPlan/vplan-sink-scalars-and-merge-vf1.ll
@@ -28,6 +28,10 @@ define void @sink_with_sideeffects(i1 %c, ptr %ptr) {
 ; CHECK-NEXT:      CLONE ir<%tmp2> = getelementptr ir<%ptr>, vp<[[VP5]]>
 ; CHECK-NEXT:      CLONE ir<%tmp3> = load ir<%tmp2>
 ; CHECK-NEXT:      CLONE store ir<0>, ir<%tmp2>
+; CHECK-NEXT:      EMIT branch-on-cond ir<%c>
+; CHECK-NEXT:    Successor(s): if.then, for.inc
+; CHECK-EMPTY:
+; CHECK-NEXT:    if.then:
 ; CHECK-NEXT:    Successor(s): pred.store
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    <xVFxUF> pred.store: {
@@ -45,6 +49,9 @@ define void @sink_with_sideeffects(i1 %c, ptr %ptr) {
 ; CHECK-NEXT:    Successor(s): if.then.0
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    if.then.0:
+; CHECK-NEXT:    Successor(s): for.inc
+; CHECK-EMPTY:
+; CHECK-NEXT:    for.inc:
 ; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP4]]>, vp<[[VP1]]>
 ; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP2]]>
 ; CHECK-NEXT:    No successors

--- a/llvm/test/Transforms/LoopVectorize/VPlan/vplan-sink-scalars-and-merge.ll
+++ b/llvm/test/Transforms/LoopVectorize/VPlan/vplan-sink-scalars-and-merge.ll
@@ -1160,6 +1160,10 @@ define void @update_multiple_users(ptr noalias %src, ptr noalias %dst, i1 %c) {
 ; CHECK-NEXT:  vp<[[VP2:%[0-9]+]]> = CANONICAL-IV
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    vector.body:
+; CHECK-NEXT:      EMIT branch-on-cond ir<%c>
+; CHECK-NEXT:    Successor(s): loop.then, loop.latch
+; CHECK-EMPTY:
+; CHECK-NEXT:    loop.then:
 ; CHECK-NEXT:    Successor(s): pred.store
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    <xVFxUF> pred.store: {
@@ -1181,6 +1185,9 @@ define void @update_multiple_users(ptr noalias %src, ptr noalias %dst, i1 %c) {
 ; CHECK-NEXT:    Successor(s): loop.then.1
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    loop.then.1:
+; CHECK-NEXT:    Successor(s): loop.latch
+; CHECK-EMPTY:
+; CHECK-NEXT:    loop.latch:
 ; CHECK-NEXT:      EMIT vp<%index.next> = add nuw vp<[[VP2]]>, vp<[[VP0]]>
 ; CHECK-NEXT:      EMIT branch-on-count vp<%index.next>, vp<[[VP1]]>
 ; CHECK-NEXT:    No successors

--- a/llvm/test/Transforms/LoopVectorize/X86/cost-conditional-branches.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/cost-conditional-branches.ll
@@ -873,12 +873,17 @@ define i64 @test_predicated_udiv(i32 %d, i1 %c) #2 {
 ; CHECK:       vector.main.loop.iter.check:
 ; CHECK-NEXT:    br i1 false, label [[VEC_EPILOG_PH:%.*]], label [[VECTOR_PH:%.*]]
 ; CHECK:       vector.ph:
-; CHECK-NEXT:    [[TMP0:%.*]] = xor i1 [[C:%.*]], true
-; CHECK-NEXT:    br label [[VECTOR_BODY:%.*]]
+; CHECK-NEXT:    [[BROADCAST_SPLATINSERT1:%.*]] = insertelement <32 x i1> poison, i1 [[C:%.*]], i64 0
+; CHECK-NEXT:    [[BROADCAST_SPLAT1:%.*]] = shufflevector <32 x i1> [[BROADCAST_SPLATINSERT1]], <32 x i1> poison, <32 x i32> zeroinitializer
+; CHECK-NEXT:    [[TMP131:%.*]] = xor <32 x i1> [[BROADCAST_SPLAT1]], splat (i1 true)
+; CHECK-NEXT:    br label [[VECTOR_BODY1:%.*]]
 ; CHECK:       vector.body:
 ; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, [[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], [[PRED_UDIV_CONTINUE62:%.*]] ]
 ; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <32 x i32> [ <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>, [[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], [[PRED_UDIV_CONTINUE62]] ]
+; CHECK-NEXT:    br i1 [[C]], label [[PRED_UDIV_CONTINUE62]], label [[VECTOR_BODY:%.*]]
+; CHECK:       then1:
 ; CHECK-NEXT:    [[TMP1:%.*]] = call <32 x i32> @llvm.usub.sat.v32i32(<32 x i32> [[VEC_IND]], <32 x i32> splat (i32 1))
+; CHECK-NEXT:    [[TMP0:%.*]] = extractelement <32 x i1> [[TMP131]], i64 0
 ; CHECK-NEXT:    br i1 [[TMP0]], label [[PRED_UDIV_IF:%.*]], label [[PRED_UDIV_CONTINUE:%.*]]
 ; CHECK:       pred.udiv.if:
 ; CHECK-NEXT:    [[TMP2:%.*]] = extractelement <32 x i32> [[TMP1]], i64 0
@@ -887,347 +892,398 @@ define i64 @test_predicated_udiv(i32 %d, i1 %c) #2 {
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE]]
 ; CHECK:       pred.udiv.continue:
 ; CHECK-NEXT:    [[TMP5:%.*]] = phi <32 x i32> [ poison, [[VECTOR_BODY]] ], [ [[TMP4]], [[PRED_UDIV_IF]] ]
-; CHECK-NEXT:    br i1 [[TMP0]], label [[PRED_UDIV_IF1:%.*]], label [[PRED_UDIV_CONTINUE2:%.*]]
-; CHECK:       pred.udiv.if1:
+; CHECK-NEXT:    [[TMP168:%.*]] = extractelement <32 x i1> [[TMP131]], i64 0
+; CHECK-NEXT:    br i1 [[TMP168]], label [[PRED_UDIV_IF1:%.*]], label [[PRED_UDIV_CONTINUE2:%.*]]
+; CHECK:       pred.udiv.if2:
 ; CHECK-NEXT:    [[TMP6:%.*]] = extractelement <32 x i32> [[TMP1]], i64 1
 ; CHECK-NEXT:    [[TMP7:%.*]] = udiv i32 [[TMP6]], [[D]]
 ; CHECK-NEXT:    [[TMP8:%.*]] = insertelement <32 x i32> [[TMP5]], i32 [[TMP7]], i64 1
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE2]]
-; CHECK:       pred.udiv.continue2:
+; CHECK:       pred.udiv.continue3:
 ; CHECK-NEXT:    [[TMP9:%.*]] = phi <32 x i32> [ [[TMP5]], [[PRED_UDIV_CONTINUE]] ], [ [[TMP8]], [[PRED_UDIV_IF1]] ]
-; CHECK-NEXT:    br i1 [[TMP0]], label [[PRED_UDIV_IF3:%.*]], label [[PRED_UDIV_CONTINUE4:%.*]]
-; CHECK:       pred.udiv.if3:
+; CHECK-NEXT:    [[TMP170:%.*]] = extractelement <32 x i1> [[TMP131]], i64 0
+; CHECK-NEXT:    br i1 [[TMP170]], label [[PRED_UDIV_IF3:%.*]], label [[PRED_UDIV_CONTINUE4:%.*]]
+; CHECK:       pred.udiv.if4:
 ; CHECK-NEXT:    [[TMP10:%.*]] = extractelement <32 x i32> [[TMP1]], i64 2
 ; CHECK-NEXT:    [[TMP11:%.*]] = udiv i32 [[TMP10]], [[D]]
 ; CHECK-NEXT:    [[TMP12:%.*]] = insertelement <32 x i32> [[TMP9]], i32 [[TMP11]], i64 2
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE4]]
-; CHECK:       pred.udiv.continue4:
+; CHECK:       pred.udiv.continue5:
 ; CHECK-NEXT:    [[TMP13:%.*]] = phi <32 x i32> [ [[TMP9]], [[PRED_UDIV_CONTINUE2]] ], [ [[TMP12]], [[PRED_UDIV_IF3]] ]
-; CHECK-NEXT:    br i1 [[TMP0]], label [[PRED_UDIV_IF5:%.*]], label [[PRED_UDIV_CONTINUE6:%.*]]
-; CHECK:       pred.udiv.if5:
+; CHECK-NEXT:    [[TMP171:%.*]] = extractelement <32 x i1> [[TMP131]], i64 0
+; CHECK-NEXT:    br i1 [[TMP171]], label [[PRED_UDIV_IF5:%.*]], label [[PRED_UDIV_CONTINUE6:%.*]]
+; CHECK:       pred.udiv.if6:
 ; CHECK-NEXT:    [[TMP14:%.*]] = extractelement <32 x i32> [[TMP1]], i64 3
 ; CHECK-NEXT:    [[TMP15:%.*]] = udiv i32 [[TMP14]], [[D]]
 ; CHECK-NEXT:    [[TMP16:%.*]] = insertelement <32 x i32> [[TMP13]], i32 [[TMP15]], i64 3
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE6]]
-; CHECK:       pred.udiv.continue6:
+; CHECK:       pred.udiv.continue7:
 ; CHECK-NEXT:    [[TMP17:%.*]] = phi <32 x i32> [ [[TMP13]], [[PRED_UDIV_CONTINUE4]] ], [ [[TMP16]], [[PRED_UDIV_IF5]] ]
-; CHECK-NEXT:    br i1 [[TMP0]], label [[PRED_UDIV_IF7:%.*]], label [[PRED_UDIV_CONTINUE8:%.*]]
-; CHECK:       pred.udiv.if7:
+; CHECK-NEXT:    [[TMP172:%.*]] = extractelement <32 x i1> [[TMP131]], i64 0
+; CHECK-NEXT:    br i1 [[TMP172]], label [[PRED_UDIV_IF7:%.*]], label [[PRED_UDIV_CONTINUE8:%.*]]
+; CHECK:       pred.udiv.if8:
 ; CHECK-NEXT:    [[TMP18:%.*]] = extractelement <32 x i32> [[TMP1]], i64 4
 ; CHECK-NEXT:    [[TMP19:%.*]] = udiv i32 [[TMP18]], [[D]]
 ; CHECK-NEXT:    [[TMP20:%.*]] = insertelement <32 x i32> [[TMP17]], i32 [[TMP19]], i64 4
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE8]]
-; CHECK:       pred.udiv.continue8:
+; CHECK:       pred.udiv.continue9:
 ; CHECK-NEXT:    [[TMP21:%.*]] = phi <32 x i32> [ [[TMP17]], [[PRED_UDIV_CONTINUE6]] ], [ [[TMP20]], [[PRED_UDIV_IF7]] ]
-; CHECK-NEXT:    br i1 [[TMP0]], label [[PRED_UDIV_IF9:%.*]], label [[PRED_UDIV_CONTINUE10:%.*]]
-; CHECK:       pred.udiv.if9:
+; CHECK-NEXT:    [[TMP173:%.*]] = extractelement <32 x i1> [[TMP131]], i64 0
+; CHECK-NEXT:    br i1 [[TMP173]], label [[PRED_UDIV_IF9:%.*]], label [[PRED_UDIV_CONTINUE10:%.*]]
+; CHECK:       pred.udiv.if10:
 ; CHECK-NEXT:    [[TMP22:%.*]] = extractelement <32 x i32> [[TMP1]], i64 5
 ; CHECK-NEXT:    [[TMP23:%.*]] = udiv i32 [[TMP22]], [[D]]
 ; CHECK-NEXT:    [[TMP24:%.*]] = insertelement <32 x i32> [[TMP21]], i32 [[TMP23]], i64 5
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE10]]
-; CHECK:       pred.udiv.continue10:
+; CHECK:       pred.udiv.continue11:
 ; CHECK-NEXT:    [[TMP25:%.*]] = phi <32 x i32> [ [[TMP21]], [[PRED_UDIV_CONTINUE8]] ], [ [[TMP24]], [[PRED_UDIV_IF9]] ]
-; CHECK-NEXT:    br i1 [[TMP0]], label [[PRED_UDIV_IF11:%.*]], label [[PRED_UDIV_CONTINUE12:%.*]]
-; CHECK:       pred.udiv.if11:
+; CHECK-NEXT:    [[TMP175:%.*]] = extractelement <32 x i1> [[TMP131]], i64 0
+; CHECK-NEXT:    br i1 [[TMP175]], label [[PRED_UDIV_IF11:%.*]], label [[PRED_UDIV_CONTINUE12:%.*]]
+; CHECK:       pred.udiv.if12:
 ; CHECK-NEXT:    [[TMP26:%.*]] = extractelement <32 x i32> [[TMP1]], i64 6
 ; CHECK-NEXT:    [[TMP27:%.*]] = udiv i32 [[TMP26]], [[D]]
 ; CHECK-NEXT:    [[TMP28:%.*]] = insertelement <32 x i32> [[TMP25]], i32 [[TMP27]], i64 6
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE12]]
-; CHECK:       pred.udiv.continue12:
+; CHECK:       pred.udiv.continue13:
 ; CHECK-NEXT:    [[TMP29:%.*]] = phi <32 x i32> [ [[TMP25]], [[PRED_UDIV_CONTINUE10]] ], [ [[TMP28]], [[PRED_UDIV_IF11]] ]
-; CHECK-NEXT:    br i1 [[TMP0]], label [[PRED_UDIV_IF13:%.*]], label [[PRED_UDIV_CONTINUE14:%.*]]
-; CHECK:       pred.udiv.if13:
+; CHECK-NEXT:    [[TMP176:%.*]] = extractelement <32 x i1> [[TMP131]], i64 0
+; CHECK-NEXT:    br i1 [[TMP176]], label [[PRED_UDIV_IF13:%.*]], label [[PRED_UDIV_CONTINUE14:%.*]]
+; CHECK:       pred.udiv.if14:
 ; CHECK-NEXT:    [[TMP30:%.*]] = extractelement <32 x i32> [[TMP1]], i64 7
 ; CHECK-NEXT:    [[TMP31:%.*]] = udiv i32 [[TMP30]], [[D]]
 ; CHECK-NEXT:    [[TMP32:%.*]] = insertelement <32 x i32> [[TMP29]], i32 [[TMP31]], i64 7
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE14]]
-; CHECK:       pred.udiv.continue14:
+; CHECK:       pred.udiv.continue15:
 ; CHECK-NEXT:    [[TMP33:%.*]] = phi <32 x i32> [ [[TMP29]], [[PRED_UDIV_CONTINUE12]] ], [ [[TMP32]], [[PRED_UDIV_IF13]] ]
-; CHECK-NEXT:    br i1 [[TMP0]], label [[PRED_UDIV_IF15:%.*]], label [[PRED_UDIV_CONTINUE16:%.*]]
-; CHECK:       pred.udiv.if15:
+; CHECK-NEXT:    [[TMP177:%.*]] = extractelement <32 x i1> [[TMP131]], i64 0
+; CHECK-NEXT:    br i1 [[TMP177]], label [[PRED_UDIV_IF15:%.*]], label [[PRED_UDIV_CONTINUE16:%.*]]
+; CHECK:       pred.udiv.if16:
 ; CHECK-NEXT:    [[TMP34:%.*]] = extractelement <32 x i32> [[TMP1]], i64 8
 ; CHECK-NEXT:    [[TMP35:%.*]] = udiv i32 [[TMP34]], [[D]]
 ; CHECK-NEXT:    [[TMP36:%.*]] = insertelement <32 x i32> [[TMP33]], i32 [[TMP35]], i64 8
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE16]]
-; CHECK:       pred.udiv.continue16:
+; CHECK:       pred.udiv.continue17:
 ; CHECK-NEXT:    [[TMP37:%.*]] = phi <32 x i32> [ [[TMP33]], [[PRED_UDIV_CONTINUE14]] ], [ [[TMP36]], [[PRED_UDIV_IF15]] ]
-; CHECK-NEXT:    br i1 [[TMP0]], label [[PRED_UDIV_IF17:%.*]], label [[PRED_UDIV_CONTINUE18:%.*]]
-; CHECK:       pred.udiv.if17:
+; CHECK-NEXT:    [[TMP178:%.*]] = extractelement <32 x i1> [[TMP131]], i64 0
+; CHECK-NEXT:    br i1 [[TMP178]], label [[PRED_UDIV_IF17:%.*]], label [[PRED_UDIV_CONTINUE18:%.*]]
+; CHECK:       pred.udiv.if18:
 ; CHECK-NEXT:    [[TMP38:%.*]] = extractelement <32 x i32> [[TMP1]], i64 9
 ; CHECK-NEXT:    [[TMP39:%.*]] = udiv i32 [[TMP38]], [[D]]
 ; CHECK-NEXT:    [[TMP40:%.*]] = insertelement <32 x i32> [[TMP37]], i32 [[TMP39]], i64 9
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE18]]
-; CHECK:       pred.udiv.continue18:
+; CHECK:       pred.udiv.continue19:
 ; CHECK-NEXT:    [[TMP41:%.*]] = phi <32 x i32> [ [[TMP37]], [[PRED_UDIV_CONTINUE16]] ], [ [[TMP40]], [[PRED_UDIV_IF17]] ]
-; CHECK-NEXT:    br i1 [[TMP0]], label [[PRED_UDIV_IF19:%.*]], label [[PRED_UDIV_CONTINUE20:%.*]]
-; CHECK:       pred.udiv.if19:
+; CHECK-NEXT:    [[TMP180:%.*]] = extractelement <32 x i1> [[TMP131]], i64 0
+; CHECK-NEXT:    br i1 [[TMP180]], label [[PRED_UDIV_IF19:%.*]], label [[PRED_UDIV_CONTINUE20:%.*]]
+; CHECK:       pred.udiv.if20:
 ; CHECK-NEXT:    [[TMP42:%.*]] = extractelement <32 x i32> [[TMP1]], i64 10
 ; CHECK-NEXT:    [[TMP43:%.*]] = udiv i32 [[TMP42]], [[D]]
 ; CHECK-NEXT:    [[TMP44:%.*]] = insertelement <32 x i32> [[TMP41]], i32 [[TMP43]], i64 10
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE20]]
-; CHECK:       pred.udiv.continue20:
+; CHECK:       pred.udiv.continue21:
 ; CHECK-NEXT:    [[TMP45:%.*]] = phi <32 x i32> [ [[TMP41]], [[PRED_UDIV_CONTINUE18]] ], [ [[TMP44]], [[PRED_UDIV_IF19]] ]
-; CHECK-NEXT:    br i1 [[TMP0]], label [[PRED_UDIV_IF21:%.*]], label [[PRED_UDIV_CONTINUE22:%.*]]
-; CHECK:       pred.udiv.if21:
+; CHECK-NEXT:    [[TMP181:%.*]] = extractelement <32 x i1> [[TMP131]], i64 0
+; CHECK-NEXT:    br i1 [[TMP181]], label [[PRED_UDIV_IF21:%.*]], label [[PRED_UDIV_CONTINUE22:%.*]]
+; CHECK:       pred.udiv.if22:
 ; CHECK-NEXT:    [[TMP46:%.*]] = extractelement <32 x i32> [[TMP1]], i64 11
 ; CHECK-NEXT:    [[TMP47:%.*]] = udiv i32 [[TMP46]], [[D]]
 ; CHECK-NEXT:    [[TMP48:%.*]] = insertelement <32 x i32> [[TMP45]], i32 [[TMP47]], i64 11
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE22]]
-; CHECK:       pred.udiv.continue22:
+; CHECK:       pred.udiv.continue23:
 ; CHECK-NEXT:    [[TMP49:%.*]] = phi <32 x i32> [ [[TMP45]], [[PRED_UDIV_CONTINUE20]] ], [ [[TMP48]], [[PRED_UDIV_IF21]] ]
-; CHECK-NEXT:    br i1 [[TMP0]], label [[PRED_UDIV_IF23:%.*]], label [[PRED_UDIV_CONTINUE24:%.*]]
-; CHECK:       pred.udiv.if23:
+; CHECK-NEXT:    [[TMP182:%.*]] = extractelement <32 x i1> [[TMP131]], i64 0
+; CHECK-NEXT:    br i1 [[TMP182]], label [[PRED_UDIV_IF23:%.*]], label [[PRED_UDIV_CONTINUE24:%.*]]
+; CHECK:       pred.udiv.if24:
 ; CHECK-NEXT:    [[TMP50:%.*]] = extractelement <32 x i32> [[TMP1]], i64 12
 ; CHECK-NEXT:    [[TMP51:%.*]] = udiv i32 [[TMP50]], [[D]]
 ; CHECK-NEXT:    [[TMP52:%.*]] = insertelement <32 x i32> [[TMP49]], i32 [[TMP51]], i64 12
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE24]]
-; CHECK:       pred.udiv.continue24:
+; CHECK:       pred.udiv.continue25:
 ; CHECK-NEXT:    [[TMP53:%.*]] = phi <32 x i32> [ [[TMP49]], [[PRED_UDIV_CONTINUE22]] ], [ [[TMP52]], [[PRED_UDIV_IF23]] ]
-; CHECK-NEXT:    br i1 [[TMP0]], label [[PRED_UDIV_IF25:%.*]], label [[PRED_UDIV_CONTINUE26:%.*]]
-; CHECK:       pred.udiv.if25:
+; CHECK-NEXT:    [[TMP183:%.*]] = extractelement <32 x i1> [[TMP131]], i64 0
+; CHECK-NEXT:    br i1 [[TMP183]], label [[PRED_UDIV_IF25:%.*]], label [[PRED_UDIV_CONTINUE26:%.*]]
+; CHECK:       pred.udiv.if26:
 ; CHECK-NEXT:    [[TMP54:%.*]] = extractelement <32 x i32> [[TMP1]], i64 13
 ; CHECK-NEXT:    [[TMP55:%.*]] = udiv i32 [[TMP54]], [[D]]
 ; CHECK-NEXT:    [[TMP56:%.*]] = insertelement <32 x i32> [[TMP53]], i32 [[TMP55]], i64 13
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE26]]
-; CHECK:       pred.udiv.continue26:
+; CHECK:       pred.udiv.continue27:
 ; CHECK-NEXT:    [[TMP57:%.*]] = phi <32 x i32> [ [[TMP53]], [[PRED_UDIV_CONTINUE24]] ], [ [[TMP56]], [[PRED_UDIV_IF25]] ]
-; CHECK-NEXT:    br i1 [[TMP0]], label [[PRED_UDIV_IF27:%.*]], label [[PRED_UDIV_CONTINUE28:%.*]]
-; CHECK:       pred.udiv.if27:
+; CHECK-NEXT:    [[TMP185:%.*]] = extractelement <32 x i1> [[TMP131]], i64 0
+; CHECK-NEXT:    br i1 [[TMP185]], label [[PRED_UDIV_IF27:%.*]], label [[PRED_UDIV_CONTINUE28:%.*]]
+; CHECK:       pred.udiv.if28:
 ; CHECK-NEXT:    [[TMP58:%.*]] = extractelement <32 x i32> [[TMP1]], i64 14
 ; CHECK-NEXT:    [[TMP59:%.*]] = udiv i32 [[TMP58]], [[D]]
 ; CHECK-NEXT:    [[TMP60:%.*]] = insertelement <32 x i32> [[TMP57]], i32 [[TMP59]], i64 14
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE28]]
-; CHECK:       pred.udiv.continue28:
+; CHECK:       pred.udiv.continue29:
 ; CHECK-NEXT:    [[TMP61:%.*]] = phi <32 x i32> [ [[TMP57]], [[PRED_UDIV_CONTINUE26]] ], [ [[TMP60]], [[PRED_UDIV_IF27]] ]
-; CHECK-NEXT:    br i1 [[TMP0]], label [[PRED_UDIV_IF29:%.*]], label [[PRED_UDIV_CONTINUE30:%.*]]
-; CHECK:       pred.udiv.if29:
+; CHECK-NEXT:    [[TMP186:%.*]] = extractelement <32 x i1> [[TMP131]], i64 0
+; CHECK-NEXT:    br i1 [[TMP186]], label [[PRED_UDIV_IF29:%.*]], label [[PRED_UDIV_CONTINUE30:%.*]]
+; CHECK:       pred.udiv.if30:
 ; CHECK-NEXT:    [[TMP62:%.*]] = extractelement <32 x i32> [[TMP1]], i64 15
 ; CHECK-NEXT:    [[TMP63:%.*]] = udiv i32 [[TMP62]], [[D]]
 ; CHECK-NEXT:    [[TMP64:%.*]] = insertelement <32 x i32> [[TMP61]], i32 [[TMP63]], i64 15
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE30]]
-; CHECK:       pred.udiv.continue30:
+; CHECK:       pred.udiv.continue31:
 ; CHECK-NEXT:    [[TMP65:%.*]] = phi <32 x i32> [ [[TMP61]], [[PRED_UDIV_CONTINUE28]] ], [ [[TMP64]], [[PRED_UDIV_IF29]] ]
-; CHECK-NEXT:    br i1 [[TMP0]], label [[PRED_UDIV_IF31:%.*]], label [[PRED_UDIV_CONTINUE32:%.*]]
-; CHECK:       pred.udiv.if31:
+; CHECK-NEXT:    [[TMP187:%.*]] = extractelement <32 x i1> [[TMP131]], i64 0
+; CHECK-NEXT:    br i1 [[TMP187]], label [[PRED_UDIV_IF31:%.*]], label [[PRED_UDIV_CONTINUE32:%.*]]
+; CHECK:       pred.udiv.if32:
 ; CHECK-NEXT:    [[TMP66:%.*]] = extractelement <32 x i32> [[TMP1]], i64 16
 ; CHECK-NEXT:    [[TMP67:%.*]] = udiv i32 [[TMP66]], [[D]]
 ; CHECK-NEXT:    [[TMP68:%.*]] = insertelement <32 x i32> [[TMP65]], i32 [[TMP67]], i64 16
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE32]]
-; CHECK:       pred.udiv.continue32:
+; CHECK:       pred.udiv.continue33:
 ; CHECK-NEXT:    [[TMP69:%.*]] = phi <32 x i32> [ [[TMP65]], [[PRED_UDIV_CONTINUE30]] ], [ [[TMP68]], [[PRED_UDIV_IF31]] ]
-; CHECK-NEXT:    br i1 [[TMP0]], label [[PRED_UDIV_IF33:%.*]], label [[PRED_UDIV_CONTINUE34:%.*]]
-; CHECK:       pred.udiv.if33:
+; CHECK-NEXT:    [[TMP188:%.*]] = extractelement <32 x i1> [[TMP131]], i64 0
+; CHECK-NEXT:    br i1 [[TMP188]], label [[PRED_UDIV_IF33:%.*]], label [[PRED_UDIV_CONTINUE34:%.*]]
+; CHECK:       pred.udiv.if34:
 ; CHECK-NEXT:    [[TMP70:%.*]] = extractelement <32 x i32> [[TMP1]], i64 17
 ; CHECK-NEXT:    [[TMP71:%.*]] = udiv i32 [[TMP70]], [[D]]
 ; CHECK-NEXT:    [[TMP72:%.*]] = insertelement <32 x i32> [[TMP69]], i32 [[TMP71]], i64 17
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE34]]
-; CHECK:       pred.udiv.continue34:
+; CHECK:       pred.udiv.continue35:
 ; CHECK-NEXT:    [[TMP73:%.*]] = phi <32 x i32> [ [[TMP69]], [[PRED_UDIV_CONTINUE32]] ], [ [[TMP72]], [[PRED_UDIV_IF33]] ]
-; CHECK-NEXT:    br i1 [[TMP0]], label [[PRED_UDIV_IF35:%.*]], label [[PRED_UDIV_CONTINUE36:%.*]]
-; CHECK:       pred.udiv.if35:
+; CHECK-NEXT:    [[TMP190:%.*]] = extractelement <32 x i1> [[TMP131]], i64 0
+; CHECK-NEXT:    br i1 [[TMP190]], label [[PRED_UDIV_IF35:%.*]], label [[PRED_UDIV_CONTINUE36:%.*]]
+; CHECK:       pred.udiv.if36:
 ; CHECK-NEXT:    [[TMP74:%.*]] = extractelement <32 x i32> [[TMP1]], i64 18
 ; CHECK-NEXT:    [[TMP75:%.*]] = udiv i32 [[TMP74]], [[D]]
 ; CHECK-NEXT:    [[TMP76:%.*]] = insertelement <32 x i32> [[TMP73]], i32 [[TMP75]], i64 18
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE36]]
-; CHECK:       pred.udiv.continue36:
+; CHECK:       pred.udiv.continue37:
 ; CHECK-NEXT:    [[TMP77:%.*]] = phi <32 x i32> [ [[TMP73]], [[PRED_UDIV_CONTINUE34]] ], [ [[TMP76]], [[PRED_UDIV_IF35]] ]
-; CHECK-NEXT:    br i1 [[TMP0]], label [[PRED_UDIV_IF37:%.*]], label [[PRED_UDIV_CONTINUE38:%.*]]
-; CHECK:       pred.udiv.if37:
+; CHECK-NEXT:    [[TMP191:%.*]] = extractelement <32 x i1> [[TMP131]], i64 0
+; CHECK-NEXT:    br i1 [[TMP191]], label [[PRED_UDIV_IF37:%.*]], label [[PRED_UDIV_CONTINUE38:%.*]]
+; CHECK:       pred.udiv.if38:
 ; CHECK-NEXT:    [[TMP78:%.*]] = extractelement <32 x i32> [[TMP1]], i64 19
 ; CHECK-NEXT:    [[TMP79:%.*]] = udiv i32 [[TMP78]], [[D]]
 ; CHECK-NEXT:    [[TMP80:%.*]] = insertelement <32 x i32> [[TMP77]], i32 [[TMP79]], i64 19
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE38]]
-; CHECK:       pred.udiv.continue38:
+; CHECK:       pred.udiv.continue39:
 ; CHECK-NEXT:    [[TMP81:%.*]] = phi <32 x i32> [ [[TMP77]], [[PRED_UDIV_CONTINUE36]] ], [ [[TMP80]], [[PRED_UDIV_IF37]] ]
-; CHECK-NEXT:    br i1 [[TMP0]], label [[PRED_UDIV_IF39:%.*]], label [[PRED_UDIV_CONTINUE40:%.*]]
-; CHECK:       pred.udiv.if39:
+; CHECK-NEXT:    [[TMP192:%.*]] = extractelement <32 x i1> [[TMP131]], i64 0
+; CHECK-NEXT:    br i1 [[TMP192]], label [[PRED_UDIV_IF39:%.*]], label [[PRED_UDIV_CONTINUE40:%.*]]
+; CHECK:       pred.udiv.if40:
 ; CHECK-NEXT:    [[TMP82:%.*]] = extractelement <32 x i32> [[TMP1]], i64 20
 ; CHECK-NEXT:    [[TMP83:%.*]] = udiv i32 [[TMP82]], [[D]]
 ; CHECK-NEXT:    [[TMP84:%.*]] = insertelement <32 x i32> [[TMP81]], i32 [[TMP83]], i64 20
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE40]]
-; CHECK:       pred.udiv.continue40:
+; CHECK:       pred.udiv.continue41:
 ; CHECK-NEXT:    [[TMP85:%.*]] = phi <32 x i32> [ [[TMP81]], [[PRED_UDIV_CONTINUE38]] ], [ [[TMP84]], [[PRED_UDIV_IF39]] ]
-; CHECK-NEXT:    br i1 [[TMP0]], label [[PRED_UDIV_IF41:%.*]], label [[PRED_UDIV_CONTINUE42:%.*]]
-; CHECK:       pred.udiv.if41:
+; CHECK-NEXT:    [[TMP193:%.*]] = extractelement <32 x i1> [[TMP131]], i64 0
+; CHECK-NEXT:    br i1 [[TMP193]], label [[PRED_UDIV_IF41:%.*]], label [[PRED_UDIV_CONTINUE42:%.*]]
+; CHECK:       pred.udiv.if42:
 ; CHECK-NEXT:    [[TMP86:%.*]] = extractelement <32 x i32> [[TMP1]], i64 21
 ; CHECK-NEXT:    [[TMP87:%.*]] = udiv i32 [[TMP86]], [[D]]
 ; CHECK-NEXT:    [[TMP88:%.*]] = insertelement <32 x i32> [[TMP85]], i32 [[TMP87]], i64 21
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE42]]
-; CHECK:       pred.udiv.continue42:
+; CHECK:       pred.udiv.continue43:
 ; CHECK-NEXT:    [[TMP89:%.*]] = phi <32 x i32> [ [[TMP85]], [[PRED_UDIV_CONTINUE40]] ], [ [[TMP88]], [[PRED_UDIV_IF41]] ]
-; CHECK-NEXT:    br i1 [[TMP0]], label [[PRED_UDIV_IF43:%.*]], label [[PRED_UDIV_CONTINUE44:%.*]]
-; CHECK:       pred.udiv.if43:
+; CHECK-NEXT:    [[TMP195:%.*]] = extractelement <32 x i1> [[TMP131]], i64 0
+; CHECK-NEXT:    br i1 [[TMP195]], label [[PRED_UDIV_IF43:%.*]], label [[PRED_UDIV_CONTINUE44:%.*]]
+; CHECK:       pred.udiv.if44:
 ; CHECK-NEXT:    [[TMP90:%.*]] = extractelement <32 x i32> [[TMP1]], i64 22
 ; CHECK-NEXT:    [[TMP91:%.*]] = udiv i32 [[TMP90]], [[D]]
 ; CHECK-NEXT:    [[TMP92:%.*]] = insertelement <32 x i32> [[TMP89]], i32 [[TMP91]], i64 22
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE44]]
-; CHECK:       pred.udiv.continue44:
+; CHECK:       pred.udiv.continue45:
 ; CHECK-NEXT:    [[TMP93:%.*]] = phi <32 x i32> [ [[TMP89]], [[PRED_UDIV_CONTINUE42]] ], [ [[TMP92]], [[PRED_UDIV_IF43]] ]
-; CHECK-NEXT:    br i1 [[TMP0]], label [[PRED_UDIV_IF45:%.*]], label [[PRED_UDIV_CONTINUE46:%.*]]
-; CHECK:       pred.udiv.if45:
+; CHECK-NEXT:    [[TMP196:%.*]] = extractelement <32 x i1> [[TMP131]], i64 0
+; CHECK-NEXT:    br i1 [[TMP196]], label [[PRED_UDIV_IF45:%.*]], label [[PRED_UDIV_CONTINUE46:%.*]]
+; CHECK:       pred.udiv.if46:
 ; CHECK-NEXT:    [[TMP94:%.*]] = extractelement <32 x i32> [[TMP1]], i64 23
 ; CHECK-NEXT:    [[TMP95:%.*]] = udiv i32 [[TMP94]], [[D]]
 ; CHECK-NEXT:    [[TMP96:%.*]] = insertelement <32 x i32> [[TMP93]], i32 [[TMP95]], i64 23
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE46]]
-; CHECK:       pred.udiv.continue46:
+; CHECK:       pred.udiv.continue47:
 ; CHECK-NEXT:    [[TMP97:%.*]] = phi <32 x i32> [ [[TMP93]], [[PRED_UDIV_CONTINUE44]] ], [ [[TMP96]], [[PRED_UDIV_IF45]] ]
-; CHECK-NEXT:    br i1 [[TMP0]], label [[PRED_UDIV_IF47:%.*]], label [[PRED_UDIV_CONTINUE48:%.*]]
-; CHECK:       pred.udiv.if47:
+; CHECK-NEXT:    [[TMP197:%.*]] = extractelement <32 x i1> [[TMP131]], i64 0
+; CHECK-NEXT:    br i1 [[TMP197]], label [[PRED_UDIV_IF47:%.*]], label [[PRED_UDIV_CONTINUE48:%.*]]
+; CHECK:       pred.udiv.if48:
 ; CHECK-NEXT:    [[TMP98:%.*]] = extractelement <32 x i32> [[TMP1]], i64 24
 ; CHECK-NEXT:    [[TMP99:%.*]] = udiv i32 [[TMP98]], [[D]]
 ; CHECK-NEXT:    [[TMP100:%.*]] = insertelement <32 x i32> [[TMP97]], i32 [[TMP99]], i64 24
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE48]]
-; CHECK:       pred.udiv.continue48:
+; CHECK:       pred.udiv.continue49:
 ; CHECK-NEXT:    [[TMP101:%.*]] = phi <32 x i32> [ [[TMP97]], [[PRED_UDIV_CONTINUE46]] ], [ [[TMP100]], [[PRED_UDIV_IF47]] ]
-; CHECK-NEXT:    br i1 [[TMP0]], label [[PRED_UDIV_IF49:%.*]], label [[PRED_UDIV_CONTINUE50:%.*]]
-; CHECK:       pred.udiv.if49:
+; CHECK-NEXT:    [[TMP198:%.*]] = extractelement <32 x i1> [[TMP131]], i64 0
+; CHECK-NEXT:    br i1 [[TMP198]], label [[PRED_UDIV_IF49:%.*]], label [[PRED_UDIV_CONTINUE50:%.*]]
+; CHECK:       pred.udiv.if50:
 ; CHECK-NEXT:    [[TMP102:%.*]] = extractelement <32 x i32> [[TMP1]], i64 25
 ; CHECK-NEXT:    [[TMP103:%.*]] = udiv i32 [[TMP102]], [[D]]
 ; CHECK-NEXT:    [[TMP104:%.*]] = insertelement <32 x i32> [[TMP101]], i32 [[TMP103]], i64 25
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE50]]
-; CHECK:       pred.udiv.continue50:
+; CHECK:       pred.udiv.continue51:
 ; CHECK-NEXT:    [[TMP105:%.*]] = phi <32 x i32> [ [[TMP101]], [[PRED_UDIV_CONTINUE48]] ], [ [[TMP104]], [[PRED_UDIV_IF49]] ]
-; CHECK-NEXT:    br i1 [[TMP0]], label [[PRED_UDIV_IF51:%.*]], label [[PRED_UDIV_CONTINUE52:%.*]]
-; CHECK:       pred.udiv.if51:
+; CHECK-NEXT:    [[TMP200:%.*]] = extractelement <32 x i1> [[TMP131]], i64 0
+; CHECK-NEXT:    br i1 [[TMP200]], label [[PRED_UDIV_IF51:%.*]], label [[PRED_UDIV_CONTINUE52:%.*]]
+; CHECK:       pred.udiv.if52:
 ; CHECK-NEXT:    [[TMP106:%.*]] = extractelement <32 x i32> [[TMP1]], i64 26
 ; CHECK-NEXT:    [[TMP107:%.*]] = udiv i32 [[TMP106]], [[D]]
 ; CHECK-NEXT:    [[TMP108:%.*]] = insertelement <32 x i32> [[TMP105]], i32 [[TMP107]], i64 26
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE52]]
-; CHECK:       pred.udiv.continue52:
+; CHECK:       pred.udiv.continue53:
 ; CHECK-NEXT:    [[TMP109:%.*]] = phi <32 x i32> [ [[TMP105]], [[PRED_UDIV_CONTINUE50]] ], [ [[TMP108]], [[PRED_UDIV_IF51]] ]
-; CHECK-NEXT:    br i1 [[TMP0]], label [[PRED_UDIV_IF53:%.*]], label [[PRED_UDIV_CONTINUE54:%.*]]
-; CHECK:       pred.udiv.if53:
+; CHECK-NEXT:    [[TMP201:%.*]] = extractelement <32 x i1> [[TMP131]], i64 0
+; CHECK-NEXT:    br i1 [[TMP201]], label [[PRED_UDIV_IF53:%.*]], label [[PRED_UDIV_CONTINUE54:%.*]]
+; CHECK:       pred.udiv.if54:
 ; CHECK-NEXT:    [[TMP110:%.*]] = extractelement <32 x i32> [[TMP1]], i64 27
 ; CHECK-NEXT:    [[TMP111:%.*]] = udiv i32 [[TMP110]], [[D]]
 ; CHECK-NEXT:    [[TMP112:%.*]] = insertelement <32 x i32> [[TMP109]], i32 [[TMP111]], i64 27
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE54]]
-; CHECK:       pred.udiv.continue54:
+; CHECK:       pred.udiv.continue55:
 ; CHECK-NEXT:    [[TMP113:%.*]] = phi <32 x i32> [ [[TMP109]], [[PRED_UDIV_CONTINUE52]] ], [ [[TMP112]], [[PRED_UDIV_IF53]] ]
-; CHECK-NEXT:    br i1 [[TMP0]], label [[PRED_UDIV_IF55:%.*]], label [[PRED_UDIV_CONTINUE56:%.*]]
-; CHECK:       pred.udiv.if55:
+; CHECK-NEXT:    [[TMP202:%.*]] = extractelement <32 x i1> [[TMP131]], i64 0
+; CHECK-NEXT:    br i1 [[TMP202]], label [[PRED_UDIV_IF55:%.*]], label [[PRED_UDIV_CONTINUE56:%.*]]
+; CHECK:       pred.udiv.if56:
 ; CHECK-NEXT:    [[TMP114:%.*]] = extractelement <32 x i32> [[TMP1]], i64 28
 ; CHECK-NEXT:    [[TMP115:%.*]] = udiv i32 [[TMP114]], [[D]]
 ; CHECK-NEXT:    [[TMP116:%.*]] = insertelement <32 x i32> [[TMP113]], i32 [[TMP115]], i64 28
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE56]]
-; CHECK:       pred.udiv.continue56:
+; CHECK:       pred.udiv.continue57:
 ; CHECK-NEXT:    [[TMP117:%.*]] = phi <32 x i32> [ [[TMP113]], [[PRED_UDIV_CONTINUE54]] ], [ [[TMP116]], [[PRED_UDIV_IF55]] ]
-; CHECK-NEXT:    br i1 [[TMP0]], label [[PRED_UDIV_IF57:%.*]], label [[PRED_UDIV_CONTINUE58:%.*]]
-; CHECK:       pred.udiv.if57:
+; CHECK-NEXT:    [[TMP203:%.*]] = extractelement <32 x i1> [[TMP131]], i64 0
+; CHECK-NEXT:    br i1 [[TMP203]], label [[PRED_UDIV_IF57:%.*]], label [[PRED_UDIV_CONTINUE58:%.*]]
+; CHECK:       pred.udiv.if58:
 ; CHECK-NEXT:    [[TMP118:%.*]] = extractelement <32 x i32> [[TMP1]], i64 29
 ; CHECK-NEXT:    [[TMP119:%.*]] = udiv i32 [[TMP118]], [[D]]
 ; CHECK-NEXT:    [[TMP120:%.*]] = insertelement <32 x i32> [[TMP117]], i32 [[TMP119]], i64 29
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE58]]
-; CHECK:       pred.udiv.continue58:
+; CHECK:       pred.udiv.continue59:
 ; CHECK-NEXT:    [[TMP121:%.*]] = phi <32 x i32> [ [[TMP117]], [[PRED_UDIV_CONTINUE56]] ], [ [[TMP120]], [[PRED_UDIV_IF57]] ]
-; CHECK-NEXT:    br i1 [[TMP0]], label [[PRED_UDIV_IF59:%.*]], label [[PRED_UDIV_CONTINUE60:%.*]]
-; CHECK:       pred.udiv.if59:
+; CHECK-NEXT:    [[TMP205:%.*]] = extractelement <32 x i1> [[TMP131]], i64 0
+; CHECK-NEXT:    br i1 [[TMP205]], label [[PRED_UDIV_IF59:%.*]], label [[PRED_UDIV_CONTINUE60:%.*]]
+; CHECK:       pred.udiv.if60:
 ; CHECK-NEXT:    [[TMP122:%.*]] = extractelement <32 x i32> [[TMP1]], i64 30
 ; CHECK-NEXT:    [[TMP123:%.*]] = udiv i32 [[TMP122]], [[D]]
 ; CHECK-NEXT:    [[TMP124:%.*]] = insertelement <32 x i32> [[TMP121]], i32 [[TMP123]], i64 30
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE60]]
-; CHECK:       pred.udiv.continue60:
+; CHECK:       pred.udiv.continue61:
 ; CHECK-NEXT:    [[TMP125:%.*]] = phi <32 x i32> [ [[TMP121]], [[PRED_UDIV_CONTINUE58]] ], [ [[TMP124]], [[PRED_UDIV_IF59]] ]
-; CHECK-NEXT:    br i1 [[TMP0]], label [[PRED_UDIV_IF61:%.*]], label [[PRED_UDIV_CONTINUE62]]
-; CHECK:       pred.udiv.if61:
+; CHECK-NEXT:    [[TMP206:%.*]] = extractelement <32 x i1> [[TMP131]], i64 0
+; CHECK-NEXT:    br i1 [[TMP206]], label [[PRED_UDIV_IF61:%.*]], label [[PRED_UDIV_CONTINUE63:%.*]]
+; CHECK:       pred.udiv.if62:
 ; CHECK-NEXT:    [[TMP126:%.*]] = extractelement <32 x i32> [[TMP1]], i64 31
 ; CHECK-NEXT:    [[TMP127:%.*]] = udiv i32 [[TMP126]], [[D]]
 ; CHECK-NEXT:    [[TMP128:%.*]] = insertelement <32 x i32> [[TMP125]], i32 [[TMP127]], i64 31
-; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE62]]
-; CHECK:       pred.udiv.continue62:
+; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE63]]
+; CHECK:       pred.udiv.continue63:
 ; CHECK-NEXT:    [[TMP129:%.*]] = phi <32 x i32> [ [[TMP125]], [[PRED_UDIV_CONTINUE60]] ], [ [[TMP128]], [[PRED_UDIV_IF61]] ]
+; CHECK-NEXT:    [[TMP207:%.*]] = zext <32 x i32> [[TMP129]] to <32 x i64>
+; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE62]]
+; CHECK:       loop.latch64:
+; CHECK-NEXT:    [[TMP208:%.*]] = phi <32 x i64> [ poison, [[VECTOR_BODY1]] ], [ [[TMP207]], [[PRED_UDIV_CONTINUE63]] ]
+; CHECK-NEXT:    [[TMP212:%.*]] = phi <32 x i1> [ zeroinitializer, [[VECTOR_BODY1]] ], [ [[TMP131]], [[PRED_UDIV_CONTINUE63]] ]
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i32 [[INDEX]], 32
 ; CHECK-NEXT:    [[VEC_IND_NEXT]] = add <32 x i32> [[VEC_IND]], splat (i32 32)
 ; CHECK-NEXT:    [[TMP130:%.*]] = icmp eq i32 [[INDEX_NEXT]], 992
-; CHECK-NEXT:    br i1 [[TMP130]], label [[MIDDLE_BLOCK:%.*]], label [[VECTOR_BODY]], !llvm.loop [[LOOP12:![0-9]+]]
+; CHECK-NEXT:    br i1 [[TMP130]], label [[MIDDLE_BLOCK:%.*]], label [[VECTOR_BODY1]], !llvm.loop [[LOOP12:![0-9]+]]
 ; CHECK:       middle.block:
-; CHECK-NEXT:    [[TMP131:%.*]] = zext <32 x i32> [[TMP129]] to <32 x i64>
-; CHECK-NEXT:    [[PREDPHI:%.*]] = select i1 [[C]], <32 x i64> zeroinitializer, <32 x i64> [[TMP131]]
+; CHECK-NEXT:    [[PREDPHI:%.*]] = select <32 x i1> [[TMP212]], <32 x i64> [[TMP208]], <32 x i64> zeroinitializer
 ; CHECK-NEXT:    [[TMP132:%.*]] = extractelement <32 x i64> [[PREDPHI]], i64 31
 ; CHECK-NEXT:    br i1 false, label [[EXIT:%.*]], label [[VEC_EPILOG_ITER_CHECK:%.*]]
 ; CHECK:       vec.epilog.iter.check:
 ; CHECK-NEXT:    br i1 false, label [[VEC_EPILOG_SCALAR_PH]], label [[VEC_EPILOG_PH]], !prof [[PROF13:![0-9]+]]
 ; CHECK:       vec.epilog.ph:
 ; CHECK-NEXT:    [[VEC_EPILOG_RESUME_VAL:%.*]] = phi i32 [ 992, [[VEC_EPILOG_ITER_CHECK]] ], [ 0, [[VECTOR_MAIN_LOOP_ITER_CHECK]] ]
-; CHECK-NEXT:    [[TMP133:%.*]] = xor i1 [[C]], true
+; CHECK-NEXT:    [[BROADCAST_SPLATINSERT65:%.*]] = insertelement <8 x i1> poison, i1 [[C]], i64 0
+; CHECK-NEXT:    [[BROADCAST_SPLAT66:%.*]] = shufflevector <8 x i1> [[BROADCAST_SPLATINSERT65]], <8 x i1> poison, <8 x i32> zeroinitializer
+; CHECK-NEXT:    [[TMP213:%.*]] = xor <8 x i1> [[BROADCAST_SPLAT66]], splat (i1 true)
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <8 x i32> poison, i32 [[VEC_EPILOG_RESUME_VAL]], i64 0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <8 x i32> [[BROADCAST_SPLATINSERT]], <8 x i32> poison, <8 x i32> zeroinitializer
 ; CHECK-NEXT:    [[INDUCTION:%.*]] = add <8 x i32> [[BROADCAST_SPLAT]], <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-; CHECK-NEXT:    br label [[VEC_EPILOG_VECTOR_BODY:%.*]]
+; CHECK-NEXT:    br label [[VEC_EPILOG_VECTOR_BODY1:%.*]]
 ; CHECK:       vec.epilog.vector.body:
 ; CHECK-NEXT:    [[INDEX63:%.*]] = phi i32 [ [[VEC_EPILOG_RESUME_VAL]], [[VEC_EPILOG_PH]] ], [ [[INDEX_NEXT81:%.*]], [[PRED_UDIV_CONTINUE80:%.*]] ]
 ; CHECK-NEXT:    [[VEC_IND64:%.*]] = phi <8 x i32> [ [[INDUCTION]], [[VEC_EPILOG_PH]] ], [ [[VEC_IND_NEXT82:%.*]], [[PRED_UDIV_CONTINUE80]] ]
+; CHECK-NEXT:    br i1 [[C]], label [[PRED_UDIV_CONTINUE80]], label [[VEC_EPILOG_VECTOR_BODY:%.*]]
+; CHECK:       then71:
 ; CHECK-NEXT:    [[TMP134:%.*]] = call <8 x i32> @llvm.usub.sat.v8i32(<8 x i32> [[VEC_IND64]], <8 x i32> splat (i32 1))
+; CHECK-NEXT:    [[TMP133:%.*]] = extractelement <8 x i1> [[TMP213]], i64 0
 ; CHECK-NEXT:    br i1 [[TMP133]], label [[PRED_UDIV_IF65:%.*]], label [[PRED_UDIV_CONTINUE66:%.*]]
-; CHECK:       pred.udiv.if65:
+; CHECK:       pred.udiv.if72:
 ; CHECK-NEXT:    [[TMP135:%.*]] = extractelement <8 x i32> [[TMP134]], i64 0
 ; CHECK-NEXT:    [[TMP136:%.*]] = udiv i32 [[TMP135]], [[D]]
 ; CHECK-NEXT:    [[TMP137:%.*]] = insertelement <8 x i32> poison, i32 [[TMP136]], i64 0
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE66]]
-; CHECK:       pred.udiv.continue66:
+; CHECK:       pred.udiv.continue73:
 ; CHECK-NEXT:    [[TMP138:%.*]] = phi <8 x i32> [ poison, [[VEC_EPILOG_VECTOR_BODY]] ], [ [[TMP137]], [[PRED_UDIV_IF65]] ]
-; CHECK-NEXT:    br i1 [[TMP133]], label [[PRED_UDIV_IF67:%.*]], label [[PRED_UDIV_CONTINUE68:%.*]]
-; CHECK:       pred.udiv.if67:
+; CHECK-NEXT:    [[TMP174:%.*]] = extractelement <8 x i1> [[TMP213]], i64 0
+; CHECK-NEXT:    br i1 [[TMP174]], label [[PRED_UDIV_IF67:%.*]], label [[PRED_UDIV_CONTINUE68:%.*]]
+; CHECK:       pred.udiv.if74:
 ; CHECK-NEXT:    [[TMP139:%.*]] = extractelement <8 x i32> [[TMP134]], i64 1
 ; CHECK-NEXT:    [[TMP140:%.*]] = udiv i32 [[TMP139]], [[D]]
 ; CHECK-NEXT:    [[TMP141:%.*]] = insertelement <8 x i32> [[TMP138]], i32 [[TMP140]], i64 1
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE68]]
-; CHECK:       pred.udiv.continue68:
+; CHECK:       pred.udiv.continue75:
 ; CHECK-NEXT:    [[TMP142:%.*]] = phi <8 x i32> [ [[TMP138]], [[PRED_UDIV_CONTINUE66]] ], [ [[TMP141]], [[PRED_UDIV_IF67]] ]
-; CHECK-NEXT:    br i1 [[TMP133]], label [[PRED_UDIV_IF69:%.*]], label [[PRED_UDIV_CONTINUE70:%.*]]
-; CHECK:       pred.udiv.if69:
+; CHECK-NEXT:    [[TMP179:%.*]] = extractelement <8 x i1> [[TMP213]], i64 0
+; CHECK-NEXT:    br i1 [[TMP179]], label [[PRED_UDIV_IF69:%.*]], label [[PRED_UDIV_CONTINUE70:%.*]]
+; CHECK:       pred.udiv.if76:
 ; CHECK-NEXT:    [[TMP143:%.*]] = extractelement <8 x i32> [[TMP134]], i64 2
 ; CHECK-NEXT:    [[TMP144:%.*]] = udiv i32 [[TMP143]], [[D]]
 ; CHECK-NEXT:    [[TMP145:%.*]] = insertelement <8 x i32> [[TMP142]], i32 [[TMP144]], i64 2
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE70]]
-; CHECK:       pred.udiv.continue70:
+; CHECK:       pred.udiv.continue77:
 ; CHECK-NEXT:    [[TMP146:%.*]] = phi <8 x i32> [ [[TMP142]], [[PRED_UDIV_CONTINUE68]] ], [ [[TMP145]], [[PRED_UDIV_IF69]] ]
-; CHECK-NEXT:    br i1 [[TMP133]], label [[PRED_UDIV_IF71:%.*]], label [[PRED_UDIV_CONTINUE72:%.*]]
-; CHECK:       pred.udiv.if71:
+; CHECK-NEXT:    [[TMP184:%.*]] = extractelement <8 x i1> [[TMP213]], i64 0
+; CHECK-NEXT:    br i1 [[TMP184]], label [[PRED_UDIV_IF71:%.*]], label [[PRED_UDIV_CONTINUE72:%.*]]
+; CHECK:       pred.udiv.if78:
 ; CHECK-NEXT:    [[TMP147:%.*]] = extractelement <8 x i32> [[TMP134]], i64 3
 ; CHECK-NEXT:    [[TMP148:%.*]] = udiv i32 [[TMP147]], [[D]]
 ; CHECK-NEXT:    [[TMP149:%.*]] = insertelement <8 x i32> [[TMP146]], i32 [[TMP148]], i64 3
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE72]]
-; CHECK:       pred.udiv.continue72:
+; CHECK:       pred.udiv.continue79:
 ; CHECK-NEXT:    [[TMP150:%.*]] = phi <8 x i32> [ [[TMP146]], [[PRED_UDIV_CONTINUE70]] ], [ [[TMP149]], [[PRED_UDIV_IF71]] ]
-; CHECK-NEXT:    br i1 [[TMP133]], label [[PRED_UDIV_IF73:%.*]], label [[PRED_UDIV_CONTINUE74:%.*]]
-; CHECK:       pred.udiv.if73:
+; CHECK-NEXT:    [[TMP189:%.*]] = extractelement <8 x i1> [[TMP213]], i64 0
+; CHECK-NEXT:    br i1 [[TMP189]], label [[PRED_UDIV_IF73:%.*]], label [[PRED_UDIV_CONTINUE74:%.*]]
+; CHECK:       pred.udiv.if80:
 ; CHECK-NEXT:    [[TMP151:%.*]] = extractelement <8 x i32> [[TMP134]], i64 4
 ; CHECK-NEXT:    [[TMP152:%.*]] = udiv i32 [[TMP151]], [[D]]
 ; CHECK-NEXT:    [[TMP153:%.*]] = insertelement <8 x i32> [[TMP150]], i32 [[TMP152]], i64 4
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE74]]
-; CHECK:       pred.udiv.continue74:
+; CHECK:       pred.udiv.continue81:
 ; CHECK-NEXT:    [[TMP154:%.*]] = phi <8 x i32> [ [[TMP150]], [[PRED_UDIV_CONTINUE72]] ], [ [[TMP153]], [[PRED_UDIV_IF73]] ]
-; CHECK-NEXT:    br i1 [[TMP133]], label [[PRED_UDIV_IF75:%.*]], label [[PRED_UDIV_CONTINUE76:%.*]]
-; CHECK:       pred.udiv.if75:
+; CHECK-NEXT:    [[TMP194:%.*]] = extractelement <8 x i1> [[TMP213]], i64 0
+; CHECK-NEXT:    br i1 [[TMP194]], label [[PRED_UDIV_IF75:%.*]], label [[PRED_UDIV_CONTINUE76:%.*]]
+; CHECK:       pred.udiv.if82:
 ; CHECK-NEXT:    [[TMP155:%.*]] = extractelement <8 x i32> [[TMP134]], i64 5
 ; CHECK-NEXT:    [[TMP156:%.*]] = udiv i32 [[TMP155]], [[D]]
 ; CHECK-NEXT:    [[TMP157:%.*]] = insertelement <8 x i32> [[TMP154]], i32 [[TMP156]], i64 5
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE76]]
-; CHECK:       pred.udiv.continue76:
+; CHECK:       pred.udiv.continue83:
 ; CHECK-NEXT:    [[TMP158:%.*]] = phi <8 x i32> [ [[TMP154]], [[PRED_UDIV_CONTINUE74]] ], [ [[TMP157]], [[PRED_UDIV_IF75]] ]
-; CHECK-NEXT:    br i1 [[TMP133]], label [[PRED_UDIV_IF77:%.*]], label [[PRED_UDIV_CONTINUE78:%.*]]
-; CHECK:       pred.udiv.if77:
+; CHECK-NEXT:    [[TMP199:%.*]] = extractelement <8 x i1> [[TMP213]], i64 0
+; CHECK-NEXT:    br i1 [[TMP199]], label [[PRED_UDIV_IF77:%.*]], label [[PRED_UDIV_CONTINUE78:%.*]]
+; CHECK:       pred.udiv.if84:
 ; CHECK-NEXT:    [[TMP159:%.*]] = extractelement <8 x i32> [[TMP134]], i64 6
 ; CHECK-NEXT:    [[TMP160:%.*]] = udiv i32 [[TMP159]], [[D]]
 ; CHECK-NEXT:    [[TMP161:%.*]] = insertelement <8 x i32> [[TMP158]], i32 [[TMP160]], i64 6
 ; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE78]]
-; CHECK:       pred.udiv.continue78:
+; CHECK:       pred.udiv.continue85:
 ; CHECK-NEXT:    [[TMP162:%.*]] = phi <8 x i32> [ [[TMP158]], [[PRED_UDIV_CONTINUE76]] ], [ [[TMP161]], [[PRED_UDIV_IF77]] ]
-; CHECK-NEXT:    br i1 [[TMP133]], label [[PRED_UDIV_IF79:%.*]], label [[PRED_UDIV_CONTINUE80]]
-; CHECK:       pred.udiv.if79:
+; CHECK-NEXT:    [[TMP204:%.*]] = extractelement <8 x i1> [[TMP213]], i64 0
+; CHECK-NEXT:    br i1 [[TMP204]], label [[PRED_UDIV_IF79:%.*]], label [[PRED_UDIV_CONTINUE87:%.*]]
+; CHECK:       pred.udiv.if86:
 ; CHECK-NEXT:    [[TMP163:%.*]] = extractelement <8 x i32> [[TMP134]], i64 7
 ; CHECK-NEXT:    [[TMP164:%.*]] = udiv i32 [[TMP163]], [[D]]
 ; CHECK-NEXT:    [[TMP165:%.*]] = insertelement <8 x i32> [[TMP162]], i32 [[TMP164]], i64 7
-; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE80]]
-; CHECK:       pred.udiv.continue80:
+; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE87]]
+; CHECK:       pred.udiv.continue87:
 ; CHECK-NEXT:    [[TMP166:%.*]] = phi <8 x i32> [ [[TMP162]], [[PRED_UDIV_CONTINUE78]] ], [ [[TMP165]], [[PRED_UDIV_IF79]] ]
+; CHECK-NEXT:    [[TMP209:%.*]] = zext <8 x i32> [[TMP166]] to <8 x i64>
+; CHECK-NEXT:    br label [[PRED_UDIV_CONTINUE80]]
+; CHECK:       loop.latch88:
+; CHECK-NEXT:    [[TMP210:%.*]] = phi <8 x i64> [ poison, [[VEC_EPILOG_VECTOR_BODY1]] ], [ [[TMP209]], [[PRED_UDIV_CONTINUE87]] ]
+; CHECK-NEXT:    [[TMP211:%.*]] = phi <8 x i1> [ zeroinitializer, [[VEC_EPILOG_VECTOR_BODY1]] ], [ [[TMP213]], [[PRED_UDIV_CONTINUE87]] ]
 ; CHECK-NEXT:    [[INDEX_NEXT81]] = add nuw i32 [[INDEX63]], 8
 ; CHECK-NEXT:    [[VEC_IND_NEXT82]] = add <8 x i32> [[VEC_IND64]], splat (i32 8)
 ; CHECK-NEXT:    [[TMP167:%.*]] = icmp eq i32 [[INDEX_NEXT81]], 1000
-; CHECK-NEXT:    br i1 [[TMP167]], label [[VEC_EPILOG_MIDDLE_BLOCK:%.*]], label [[VEC_EPILOG_VECTOR_BODY]], !llvm.loop [[LOOP14:![0-9]+]]
+; CHECK-NEXT:    br i1 [[TMP167]], label [[VEC_EPILOG_MIDDLE_BLOCK:%.*]], label [[VEC_EPILOG_VECTOR_BODY1]], !llvm.loop [[LOOP14:![0-9]+]]
 ; CHECK:       vec.epilog.middle.block:
-; CHECK-NEXT:    [[TMP168:%.*]] = zext <8 x i32> [[TMP166]] to <8 x i64>
-; CHECK-NEXT:    [[PREDPHI83:%.*]] = select i1 [[C]], <8 x i64> zeroinitializer, <8 x i64> [[TMP168]]
+; CHECK-NEXT:    [[PREDPHI83:%.*]] = select <8 x i1> [[TMP211]], <8 x i64> [[TMP210]], <8 x i64> zeroinitializer
 ; CHECK-NEXT:    [[TMP169:%.*]] = extractelement <8 x i64> [[PREDPHI83]], i64 7
 ; CHECK-NEXT:    br i1 false, label [[EXIT]], label [[VEC_EPILOG_SCALAR_PH]]
 ; CHECK:       vec.epilog.scalar.ph:

--- a/llvm/test/Transforms/LoopVectorize/X86/invariant-load-gather.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/invariant-load-gather.ll
@@ -33,16 +33,22 @@ define i32 @inv_load_conditional(ptr %a, i64 %n, ptr %b, i32 %k) {
 ; CHECK-NEXT:    [[BROADCAST_SPLAT5:%.*]] = shufflevector <16 x i32> [[BROADCAST_SPLATINSERT4]], <16 x i32> poison, <16 x i32> zeroinitializer
 ; CHECK-NEXT:    br label [[VECTOR_BODY:%.*]]
 ; CHECK:       vector.body:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, [[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], [[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, [[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], [[LATCH7:%.*]] ]
 ; CHECK-NEXT:    [[TMP2:%.*]] = getelementptr inbounds i32, ptr [[B]], i64 [[INDEX]]
 ; CHECK-NEXT:    store <16 x i32> [[BROADCAST_SPLAT5]], ptr [[TMP2]], align 4, !alias.scope [[META0:![0-9]+]], !noalias [[META3:![0-9]+]]
+; CHECK-NEXT:    [[TMP9:%.*]] = extractelement <16 x i1> [[TMP1]], i64 0
+; CHECK-NEXT:    br i1 [[TMP9]], label [[COND_LOAD6:%.*]], label [[LATCH7]]
+; CHECK:       cond_load6:
 ; CHECK-NEXT:    [[WIDE_MASKED_GATHER:%.*]] = call <16 x i32> @llvm.masked.gather.v16i32.v16p0(<16 x ptr> align 4 [[BROADCAST_SPLAT]], <16 x i1> [[TMP1]], <16 x i32> poison), !alias.scope [[META3]]
+; CHECK-NEXT:    br label [[LATCH7]]
+; CHECK:       latch7:
+; CHECK-NEXT:    [[TMP10:%.*]] = phi <16 x i32> [ poison, [[VECTOR_BODY]] ], [ [[WIDE_MASKED_GATHER]], [[COND_LOAD6]] ]
+; CHECK-NEXT:    [[TMP11:%.*]] = phi <16 x i1> [ zeroinitializer, [[VECTOR_BODY]] ], [ [[TMP1]], [[COND_LOAD6]] ]
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 16
 ; CHECK-NEXT:    [[TMP3:%.*]] = icmp eq i64 [[INDEX_NEXT]], [[N_VEC]]
 ; CHECK-NEXT:    br i1 [[TMP3]], label [[MIDDLE_BLOCK:%.*]], label [[VECTOR_BODY]], !llvm.loop [[LOOP5:![0-9]+]]
 ; CHECK:       middle.block:
-; CHECK-NEXT:    [[TMP10:%.*]] = extractelement <16 x i1> [[TMP1]], i64 0
-; CHECK-NEXT:    [[PREDPHI:%.*]] = select i1 [[TMP10]], <16 x i32> [[WIDE_MASKED_GATHER]], <16 x i32> splat (i32 1)
+; CHECK-NEXT:    [[PREDPHI:%.*]] = select <16 x i1> [[TMP11]], <16 x i32> [[TMP10]], <16 x i32> splat (i32 1)
 ; CHECK-NEXT:    [[TMP4:%.*]] = extractelement <16 x i32> [[PREDPHI]], i64 15
 ; CHECK-NEXT:    [[CMP_N:%.*]] = icmp eq i64 [[SMAX2]], [[N_VEC]]
 ; CHECK-NEXT:    br i1 [[CMP_N]], label [[FOR_END:%.*]], label [[VEC_EPILOG_ITER_CHECK:%.*]]
@@ -60,16 +66,22 @@ define i32 @inv_load_conditional(ptr %a, i64 %n, ptr %b, i32 %k) {
 ; CHECK-NEXT:    [[BROADCAST_SPLAT12:%.*]] = shufflevector <8 x i32> [[BROADCAST_SPLATINSERT11]], <8 x i32> poison, <8 x i32> zeroinitializer
 ; CHECK-NEXT:    br label [[VEC_EPILOG_VECTOR_BODY:%.*]]
 ; CHECK:       vec.epilog.vector.body:
-; CHECK-NEXT:    [[INDEX10:%.*]] = phi i64 [ [[VEC_EPILOG_RESUME_VAL]], [[VEC_EPILOG_PH]] ], [ [[INDEX_NEXT15:%.*]], [[VEC_EPILOG_VECTOR_BODY]] ]
+; CHECK-NEXT:    [[INDEX10:%.*]] = phi i64 [ [[VEC_EPILOG_RESUME_VAL]], [[VEC_EPILOG_PH]] ], [ [[INDEX_NEXT15:%.*]], [[LATCH16:%.*]] ]
 ; CHECK-NEXT:    [[TMP6:%.*]] = getelementptr inbounds i32, ptr [[B]], i64 [[INDEX10]]
 ; CHECK-NEXT:    store <8 x i32> [[BROADCAST_SPLAT12]], ptr [[TMP6]], align 4, !alias.scope [[META0]], !noalias [[META3]]
-; CHECK-NEXT:    [[WIDE_MASKED_GATHER13:%.*]] = call <8 x i32> @llvm.masked.gather.v8i32.v8p0(<8 x ptr> align 4 [[BROADCAST_SPLAT9]], <8 x i1> [[TMP5]], <8 x i32> poison), !alias.scope [[META3]]
+; CHECK-NEXT:    [[TMP12:%.*]] = extractelement <8 x i1> [[TMP5]], i64 0
+; CHECK-NEXT:    br i1 [[TMP12]], label [[COND_LOAD14:%.*]], label [[LATCH16]]
+; CHECK:       cond_load14:
+; CHECK-NEXT:    [[WIDE_MASKED_GATHER15:%.*]] = call <8 x i32> @llvm.masked.gather.v8i32.v8p0(<8 x ptr> align 4 [[BROADCAST_SPLAT9]], <8 x i1> [[TMP5]], <8 x i32> poison), !alias.scope [[META3]]
+; CHECK-NEXT:    br label [[LATCH16]]
+; CHECK:       latch16:
+; CHECK-NEXT:    [[TMP13:%.*]] = phi <8 x i32> [ poison, [[VEC_EPILOG_VECTOR_BODY]] ], [ [[WIDE_MASKED_GATHER15]], [[COND_LOAD14]] ]
+; CHECK-NEXT:    [[TMP14:%.*]] = phi <8 x i1> [ zeroinitializer, [[VEC_EPILOG_VECTOR_BODY]] ], [ [[TMP5]], [[COND_LOAD14]] ]
 ; CHECK-NEXT:    [[INDEX_NEXT15]] = add nuw i64 [[INDEX10]], 8
 ; CHECK-NEXT:    [[TMP7:%.*]] = icmp eq i64 [[INDEX_NEXT15]], [[N_VEC7]]
 ; CHECK-NEXT:    br i1 [[TMP7]], label [[VEC_EPILOG_MIDDLE_BLOCK:%.*]], label [[VEC_EPILOG_VECTOR_BODY]], !llvm.loop [[LOOP9:![0-9]+]]
 ; CHECK:       vec.epilog.middle.block:
-; CHECK-NEXT:    [[TMP9:%.*]] = extractelement <8 x i1> [[TMP5]], i64 0
-; CHECK-NEXT:    [[PREDPHI14:%.*]] = select i1 [[TMP9]], <8 x i32> [[WIDE_MASKED_GATHER13]], <8 x i32> splat (i32 1)
+; CHECK-NEXT:    [[PREDPHI14:%.*]] = select <8 x i1> [[TMP14]], <8 x i32> [[TMP13]], <8 x i32> splat (i32 1)
 ; CHECK-NEXT:    [[TMP8:%.*]] = extractelement <8 x i32> [[PREDPHI14]], i64 7
 ; CHECK-NEXT:    [[CMP_N16:%.*]] = icmp eq i64 [[SMAX2]], [[N_VEC7]]
 ; CHECK-NEXT:    br i1 [[CMP_N16]], label [[FOR_END]], label [[VEC_EPILOG_SCALAR_PH]]

--- a/llvm/test/Transforms/LoopVectorize/X86/masked-store-cost.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/masked-store-cost.ll
@@ -129,10 +129,14 @@ define void @test_scalar_cost_single_store_loop_invariant_cond(ptr %dst, i1 %c) 
 ; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <8 x i1> [[BROADCAST_SPLATINSERT]], <8 x i1> poison, <8 x i32> zeroinitializer
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LOOP_LATCH2:.*]] ]
 ; CHECK-NEXT:    [[TMP1:%.*]] = shl i64 [[INDEX]], 2
 ; CHECK-NEXT:    [[NEXT_GEP:%.*]] = getelementptr i8, ptr [[DST]], i64 [[TMP1]]
+; CHECK-NEXT:    br i1 [[C]], label %[[IF_THEN1:.*]], label %[[LOOP_LATCH2]]
+; CHECK:       [[IF_THEN1]]:
 ; CHECK-NEXT:    call void @llvm.masked.store.v8i32.p0(<8 x i32> zeroinitializer, ptr align 4 [[NEXT_GEP]], <8 x i1> [[BROADCAST_SPLAT]])
+; CHECK-NEXT:    br label %[[LOOP_LATCH2]]
+; CHECK:       [[LOOP_LATCH2]]:
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 8
 ; CHECK-NEXT:    [[TMP2:%.*]] = icmp eq i64 [[INDEX_NEXT]], 24
 ; CHECK-NEXT:    br i1 [[TMP2]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP6:![0-9]+]]

--- a/llvm/test/Transforms/LoopVectorize/X86/pr141968-instsimplifyfolder.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/pr141968-instsimplifyfolder.ll
@@ -6,24 +6,33 @@ target triple = "x86_64"
 define void @pr141968(i1 %cond, i8 %v, ptr %p) {
 ; CHECK-LABEL: define void @pr141968(
 ; CHECK-SAME: i1 [[COND:%.*]], i8 [[V:%.*]], ptr [[P:%.*]]) {
-; CHECK-NEXT:  [[ENTRY:.*]]:
+; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    [[ZEXT_TRUE:%.*]] = zext i1 true to i16
 ; CHECK-NEXT:    [[SEXT:%.*]] = sext i8 [[V]] to i16
 ; CHECK-NEXT:    br label %[[PRED_SDIV_CONTINUE28:.*]]
 ; CHECK:       [[PRED_SDIV_CONTINUE28]]:
-; CHECK-NEXT:    [[IV:%.*]] = phi i8 [ [[IV_NEXT:%.*]], %[[PRED_SDIV_CONTINUE30:.*]] ], [ 0, %[[ENTRY]] ]
+; CHECK-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <16 x i1> poison, i1 [[COND]], i64 0
+; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <16 x i1> [[BROADCAST_SPLATINSERT]], <16 x i1> poison, <16 x i32> zeroinitializer
+; CHECK-NEXT:    [[TMP0:%.*]] = xor <16 x i1> [[BROADCAST_SPLAT]], splat (i1 true)
+; CHECK-NEXT:    [[BROADCAST_SPLATINSERT1:%.*]] = insertelement <16 x i8> poison, i8 [[V]], i64 0
+; CHECK-NEXT:    [[BROADCAST_SPLAT2:%.*]] = shufflevector <16 x i8> [[BROADCAST_SPLATINSERT1]], <16 x i8> poison, <16 x i32> zeroinitializer
+; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
+; CHECK:       [[VECTOR_BODY]]:
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[PRED_SDIV_CONTINUE28]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_SDIV_CONTINUE30:.*]] ]
 ; CHECK-NEXT:    br i1 [[COND]], label %[[PRED_SDIV_CONTINUE30]], label %[[PRED_SDIV_IF29:.*]]
 ; CHECK:       [[PRED_SDIV_IF29]]:
-; CHECK-NEXT:    [[SDIV:%.*]] = sdiv i16 [[SEXT]], [[ZEXT_TRUE]]
-; CHECK-NEXT:    [[SDIV_TRUNC:%.*]] = trunc i16 [[SDIV]] to i8
 ; CHECK-NEXT:    br label %[[PRED_SDIV_CONTINUE30]]
 ; CHECK:       [[PRED_SDIV_CONTINUE30]]:
-; CHECK-NEXT:    [[PREDPHI:%.*]] = phi i8 [ [[SDIV_TRUNC]], %[[PRED_SDIV_IF29]] ], [ 0, %[[PRED_SDIV_CONTINUE28]] ]
+; CHECK-NEXT:    [[TMP1:%.*]] = phi <16 x i1> [ zeroinitializer, %[[VECTOR_BODY]] ], [ [[TMP0]], %[[PRED_SDIV_IF29]] ]
+; CHECK-NEXT:    [[PREDPHI1:%.*]] = select <16 x i1> [[TMP1]], <16 x i8> [[BROADCAST_SPLAT2]], <16 x i8> zeroinitializer
+; CHECK-NEXT:    [[PREDPHI:%.*]] = extractelement <16 x i8> [[PREDPHI1]], i64 15
 ; CHECK-NEXT:    store i8 [[PREDPHI]], ptr [[P]], align 1
-; CHECK-NEXT:    [[IV_NEXT]] = add i8 [[IV]], 1
-; CHECK-NEXT:    [[EXITCOND:%.*]] = icmp eq i8 [[IV_NEXT]], 0
-; CHECK-NEXT:    br i1 [[EXITCOND]], label %[[EXIT1:.*]], label %[[PRED_SDIV_CONTINUE28]]
+; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i32 [[INDEX]], 32
+; CHECK-NEXT:    [[TMP3:%.*]] = icmp eq i32 [[INDEX_NEXT]], 256
+; CHECK-NEXT:    br i1 [[TMP3]], label %[[EXIT1:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP0:![0-9]+]]
 ; CHECK:       [[EXIT1]]:
+; CHECK-NEXT:    br label %[[EXIT:.*]]
+; CHECK:       [[EXIT]]:
 ; CHECK-NEXT:    ret void
 ;
 entry:

--- a/llvm/test/Transforms/LoopVectorize/X86/predicated-replicate-feeding-cast.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/predicated-replicate-feeding-cast.ll
@@ -14,43 +14,70 @@ define i8 @predicated_replicate_feeding_cast(i16 %n, i1 %c1, i1 %c2, i16 %a, i8 
 ; CHECK:       [[VECTOR_PH]]:
 ; CHECK-NEXT:    [[N_MOD_VF:%.*]] = and i32 [[TMP1]], 1
 ; CHECK-NEXT:    [[N_VEC:%.*]] = sub i32 [[TMP1]], [[N_MOD_VF]]
+; CHECK-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <2 x i1> poison, i1 [[C2]], i64 0
+; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <2 x i1> [[BROADCAST_SPLATINSERT]], <2 x i1> poison, <2 x i32> zeroinitializer
+; CHECK-NEXT:    [[BROADCAST_SPLATINSERT1:%.*]] = insertelement <2 x i1> poison, i1 [[C1]], i64 0
+; CHECK-NEXT:    [[BROADCAST_SPLAT2:%.*]] = shufflevector <2 x i1> [[BROADCAST_SPLATINSERT1]], <2 x i1> poison, <2 x i32> zeroinitializer
 ; CHECK-NEXT:    [[TMP2:%.*]] = trunc i32 [[N_VEC]] to i16
-; CHECK-NEXT:    [[TMP3:%.*]] = xor i1 [[C1]], true
-; CHECK-NEXT:    [[TMP4:%.*]] = xor i1 [[C2]], true
+; CHECK-NEXT:    [[TMP6:%.*]] = xor <2 x i1> [[BROADCAST_SPLAT]], splat (i1 true)
+; CHECK-NEXT:    [[TMP7:%.*]] = xor <2 x i1> [[BROADCAST_SPLAT2]], splat (i1 true)
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_SDIV_CONTINUE6:.*]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LATCH12:.*]] ]
+; CHECK-NEXT:    br i1 [[C1]], label %[[MERGE6:.*]], label %[[IF13:.*]]
+; CHECK:       [[IF13]]:
+; CHECK-NEXT:    [[TMP3:%.*]] = extractelement <2 x i1> [[TMP7]], i64 0
 ; CHECK-NEXT:    br i1 [[TMP3]], label %[[PRED_SDIV_IF:.*]], label %[[PRED_SDIV_CONTINUE:.*]]
 ; CHECK:       [[PRED_SDIV_IF]]:
 ; CHECK-NEXT:    [[TMP5:%.*]] = sdiv i16 1, [[A]]
+; CHECK-NEXT:    [[TMP8:%.*]] = insertelement <2 x i16> poison, i16 [[TMP5]], i64 0
 ; CHECK-NEXT:    br label %[[PRED_SDIV_CONTINUE]]
 ; CHECK:       [[PRED_SDIV_CONTINUE]]:
-; CHECK-NEXT:    [[TMP6:%.*]] = phi i16 [ poison, %[[VECTOR_BODY]] ], [ [[TMP5]], %[[PRED_SDIV_IF]] ]
-; CHECK-NEXT:    br i1 [[TMP3]], label %[[PRED_SDIV_IF1:.*]], label %[[PRED_SDIV_CONTINUE2:.*]]
+; CHECK-NEXT:    [[TMP9:%.*]] = phi <2 x i16> [ poison, %[[IF13]] ], [ [[TMP8]], %[[PRED_SDIV_IF]] ]
+; CHECK-NEXT:    [[TMP10:%.*]] = extractelement <2 x i1> [[TMP7]], i64 0
+; CHECK-NEXT:    br i1 [[TMP10]], label %[[PRED_SDIV_IF1:.*]], label %[[PRED_SDIV_CONTINUE2:.*]]
 ; CHECK:       [[PRED_SDIV_IF1]]:
+; CHECK-NEXT:    [[TMP11:%.*]] = sdiv i16 1, [[A]]
+; CHECK-NEXT:    [[TMP16:%.*]] = insertelement <2 x i16> [[TMP9]], i16 [[TMP11]], i64 1
 ; CHECK-NEXT:    br label %[[PRED_SDIV_CONTINUE2]]
 ; CHECK:       [[PRED_SDIV_CONTINUE2]]:
-; CHECK-NEXT:    [[TMP11:%.*]] = select i1 [[C1]], i16 0, i16 [[TMP6]]
-; CHECK-NEXT:    [[TMP12:%.*]] = trunc i16 [[TMP11]] to i8
+; CHECK-NEXT:    [[TMP20:%.*]] = phi <2 x i16> [ [[TMP9]], %[[PRED_SDIV_CONTINUE]] ], [ [[TMP16]], %[[PRED_SDIV_IF1]] ]
+; CHECK-NEXT:    br label %[[MERGE6]]
+; CHECK:       [[MERGE6]]:
+; CHECK-NEXT:    [[TMP25:%.*]] = phi <2 x i16> [ poison, %[[VECTOR_BODY]] ], [ [[TMP20]], %[[PRED_SDIV_CONTINUE2]] ]
+; CHECK-NEXT:    [[TMP26:%.*]] = phi <2 x i1> [ zeroinitializer, %[[VECTOR_BODY]] ], [ [[TMP7]], %[[PRED_SDIV_CONTINUE2]] ]
+; CHECK-NEXT:    [[PREDPHI:%.*]] = select <2 x i1> [[TMP26]], <2 x i16> [[TMP25]], <2 x i16> zeroinitializer
+; CHECK-NEXT:    br i1 [[C2]], label %[[LATCH12]], label %[[IF27:.*]]
+; CHECK:       [[IF27]]:
+; CHECK-NEXT:    [[TMP4:%.*]] = extractelement <2 x i1> [[TMP6]], i64 0
 ; CHECK-NEXT:    br i1 [[TMP4]], label %[[PRED_SDIV_IF3:.*]], label %[[PRED_SDIV_CONTINUE4:.*]]
 ; CHECK:       [[PRED_SDIV_IF3]]:
+; CHECK-NEXT:    [[TMP17:%.*]] = extractelement <2 x i16> [[PREDPHI]], i64 0
+; CHECK-NEXT:    [[TMP12:%.*]] = trunc i16 [[TMP17]] to i8
 ; CHECK-NEXT:    [[TMP13:%.*]] = sdiv i8 [[TMP12]], [[B]]
 ; CHECK-NEXT:    [[TMP14:%.*]] = insertelement <2 x i8> poison, i8 [[TMP13]], i64 0
 ; CHECK-NEXT:    br label %[[PRED_SDIV_CONTINUE4]]
 ; CHECK:       [[PRED_SDIV_CONTINUE4]]:
-; CHECK-NEXT:    [[TMP15:%.*]] = phi <2 x i8> [ poison, %[[PRED_SDIV_CONTINUE2]] ], [ [[TMP14]], %[[PRED_SDIV_IF3]] ]
-; CHECK-NEXT:    br i1 [[TMP4]], label %[[PRED_SDIV_IF5:.*]], label %[[PRED_SDIV_CONTINUE6]]
+; CHECK-NEXT:    [[TMP15:%.*]] = phi <2 x i8> [ poison, %[[IF27]] ], [ [[TMP14]], %[[PRED_SDIV_IF3]] ]
+; CHECK-NEXT:    [[TMP30:%.*]] = extractelement <2 x i1> [[TMP6]], i64 0
+; CHECK-NEXT:    br i1 [[TMP30]], label %[[PRED_SDIV_IF5:.*]], label %[[PRED_SDIV_CONTINUE6:.*]]
 ; CHECK:       [[PRED_SDIV_IF5]]:
-; CHECK-NEXT:    [[TMP18:%.*]] = sdiv i8 [[TMP12]], [[B]]
+; CHECK-NEXT:    [[TMP23:%.*]] = extractelement <2 x i16> [[PREDPHI]], i64 1
+; CHECK-NEXT:    [[TMP24:%.*]] = trunc i16 [[TMP23]] to i8
+; CHECK-NEXT:    [[TMP18:%.*]] = sdiv i8 [[TMP24]], [[B]]
 ; CHECK-NEXT:    [[TMP19:%.*]] = insertelement <2 x i8> [[TMP15]], i8 [[TMP18]], i64 1
 ; CHECK-NEXT:    br label %[[PRED_SDIV_CONTINUE6]]
 ; CHECK:       [[PRED_SDIV_CONTINUE6]]:
-; CHECK-NEXT:    [[TMP20:%.*]] = phi <2 x i8> [ [[TMP15]], %[[PRED_SDIV_CONTINUE4]] ], [ [[TMP19]], %[[PRED_SDIV_IF5]] ]
+; CHECK-NEXT:    [[TMP27:%.*]] = phi <2 x i8> [ [[TMP15]], %[[PRED_SDIV_CONTINUE4]] ], [ [[TMP19]], %[[PRED_SDIV_IF5]] ]
+; CHECK-NEXT:    br label %[[LATCH12]]
+; CHECK:       [[LATCH12]]:
+; CHECK-NEXT:    [[TMP28:%.*]] = phi <2 x i8> [ poison, %[[MERGE6]] ], [ [[TMP27]], %[[PRED_SDIV_CONTINUE6]] ]
+; CHECK-NEXT:    [[TMP29:%.*]] = phi <2 x i1> [ zeroinitializer, %[[MERGE6]] ], [ [[TMP6]], %[[PRED_SDIV_CONTINUE6]] ]
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i32 [[INDEX]], 2
 ; CHECK-NEXT:    [[TMP21:%.*]] = icmp eq i32 [[INDEX_NEXT]], [[N_VEC]]
 ; CHECK-NEXT:    br i1 [[TMP21]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP0:![0-9]+]]
 ; CHECK:       [[MIDDLE_BLOCK]]:
-; CHECK-NEXT:    [[PREDPHI7:%.*]] = select i1 [[C2]], <2 x i8> zeroinitializer, <2 x i8> [[TMP20]]
+; CHECK-NEXT:    [[PREDPHI7:%.*]] = select <2 x i1> [[TMP29]], <2 x i8> [[TMP28]], <2 x i8> zeroinitializer
 ; CHECK-NEXT:    [[TMP22:%.*]] = extractelement <2 x i8> [[PREDPHI7]], i64 1
 ; CHECK-NEXT:    [[CMP_N:%.*]] = icmp eq i32 [[TMP1]], [[N_VEC]]
 ; CHECK-NEXT:    br i1 [[CMP_N]], label %[[EXIT:.*]], label %[[SCALAR_PH]]
@@ -119,13 +146,20 @@ define i8 @predicated_replicate_feeding_cast_non_uniform(i64 %n, i1 %c1, i1 %c2,
 ; CHECK:       [[VECTOR_PH]]:
 ; CHECK-NEXT:    [[N_MOD_VF:%.*]] = and i64 [[TMP0]], 1
 ; CHECK-NEXT:    [[N_VEC:%.*]] = sub i64 [[TMP0]], [[N_MOD_VF]]
-; CHECK-NEXT:    [[TMP1:%.*]] = xor i1 [[C1]], true
-; CHECK-NEXT:    [[TMP2:%.*]] = xor i1 [[C2]], true
+; CHECK-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <2 x i1> poison, i1 [[C2]], i64 0
+; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <2 x i1> [[BROADCAST_SPLATINSERT]], <2 x i1> poison, <2 x i32> zeroinitializer
+; CHECK-NEXT:    [[BROADCAST_SPLATINSERT1:%.*]] = insertelement <2 x i1> poison, i1 [[C1]], i64 0
+; CHECK-NEXT:    [[BROADCAST_SPLAT2:%.*]] = shufflevector <2 x i1> [[BROADCAST_SPLATINSERT1]], <2 x i1> poison, <2 x i32> zeroinitializer
+; CHECK-NEXT:    [[TMP11:%.*]] = xor <2 x i1> [[BROADCAST_SPLAT]], splat (i1 true)
+; CHECK-NEXT:    [[TMP21:%.*]] = xor <2 x i1> [[BROADCAST_SPLAT2]], splat (i1 true)
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_SDIV_CONTINUE6:.*]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LATCH12:.*]] ]
 ; CHECK-NEXT:    [[TMP3:%.*]] = getelementptr i16, ptr [[A_PTR]], i64 [[INDEX]]
 ; CHECK-NEXT:    [[WIDE_LOAD:%.*]] = load <2 x i16>, ptr [[TMP3]], align 2
+; CHECK-NEXT:    br i1 [[C1]], label %[[MERGE6:.*]], label %[[IF13:.*]]
+; CHECK:       [[IF13]]:
+; CHECK-NEXT:    [[TMP1:%.*]] = extractelement <2 x i1> [[TMP21]], i64 0
 ; CHECK-NEXT:    br i1 [[TMP1]], label %[[PRED_SDIV_IF:.*]], label %[[PRED_SDIV_CONTINUE:.*]]
 ; CHECK:       [[PRED_SDIV_IF]]:
 ; CHECK-NEXT:    [[TMP4:%.*]] = extractelement <2 x i16> [[WIDE_LOAD]], i64 0
@@ -133,16 +167,24 @@ define i8 @predicated_replicate_feeding_cast_non_uniform(i64 %n, i1 %c1, i1 %c2,
 ; CHECK-NEXT:    [[TMP6:%.*]] = insertelement <2 x i16> poison, i16 [[TMP5]], i64 0
 ; CHECK-NEXT:    br label %[[PRED_SDIV_CONTINUE]]
 ; CHECK:       [[PRED_SDIV_CONTINUE]]:
-; CHECK-NEXT:    [[TMP7:%.*]] = phi <2 x i16> [ poison, %[[VECTOR_BODY]] ], [ [[TMP6]], %[[PRED_SDIV_IF]] ]
-; CHECK-NEXT:    br i1 [[TMP1]], label %[[PRED_SDIV_IF1:.*]], label %[[PRED_SDIV_CONTINUE2:.*]]
+; CHECK-NEXT:    [[TMP7:%.*]] = phi <2 x i16> [ poison, %[[IF13]] ], [ [[TMP6]], %[[PRED_SDIV_IF]] ]
+; CHECK-NEXT:    [[TMP24:%.*]] = extractelement <2 x i1> [[TMP21]], i64 0
+; CHECK-NEXT:    br i1 [[TMP24]], label %[[PRED_SDIV_IF1:.*]], label %[[PRED_SDIV_CONTINUE2:.*]]
 ; CHECK:       [[PRED_SDIV_IF1]]:
 ; CHECK-NEXT:    [[TMP8:%.*]] = extractelement <2 x i16> [[WIDE_LOAD]], i64 1
 ; CHECK-NEXT:    [[TMP9:%.*]] = sdiv i16 1, [[TMP8]]
 ; CHECK-NEXT:    [[TMP10:%.*]] = insertelement <2 x i16> [[TMP7]], i16 [[TMP9]], i64 1
 ; CHECK-NEXT:    br label %[[PRED_SDIV_CONTINUE2]]
 ; CHECK:       [[PRED_SDIV_CONTINUE2]]:
-; CHECK-NEXT:    [[TMP11:%.*]] = phi <2 x i16> [ [[TMP7]], %[[PRED_SDIV_CONTINUE]] ], [ [[TMP10]], %[[PRED_SDIV_IF1]] ]
-; CHECK-NEXT:    [[PREDPHI:%.*]] = select i1 [[C1]], <2 x i16> zeroinitializer, <2 x i16> [[TMP11]]
+; CHECK-NEXT:    [[TMP25:%.*]] = phi <2 x i16> [ [[TMP7]], %[[PRED_SDIV_CONTINUE]] ], [ [[TMP10]], %[[PRED_SDIV_IF1]] ]
+; CHECK-NEXT:    br label %[[MERGE6]]
+; CHECK:       [[MERGE6]]:
+; CHECK-NEXT:    [[TMP26:%.*]] = phi <2 x i16> [ poison, %[[VECTOR_BODY]] ], [ [[TMP25]], %[[PRED_SDIV_CONTINUE2]] ]
+; CHECK-NEXT:    [[TMP27:%.*]] = phi <2 x i1> [ zeroinitializer, %[[VECTOR_BODY]] ], [ [[TMP21]], %[[PRED_SDIV_CONTINUE2]] ]
+; CHECK-NEXT:    [[PREDPHI:%.*]] = select <2 x i1> [[TMP27]], <2 x i16> [[TMP26]], <2 x i16> zeroinitializer
+; CHECK-NEXT:    br i1 [[C2]], label %[[LATCH12]], label %[[IF27:.*]]
+; CHECK:       [[IF27]]:
+; CHECK-NEXT:    [[TMP2:%.*]] = extractelement <2 x i1> [[TMP11]], i64 0
 ; CHECK-NEXT:    br i1 [[TMP2]], label %[[PRED_SDIV_IF3:.*]], label %[[PRED_SDIV_CONTINUE4:.*]]
 ; CHECK:       [[PRED_SDIV_IF3]]:
 ; CHECK-NEXT:    [[TMP12:%.*]] = extractelement <2 x i16> [[PREDPHI]], i64 0
@@ -151,8 +193,9 @@ define i8 @predicated_replicate_feeding_cast_non_uniform(i64 %n, i1 %c1, i1 %c2,
 ; CHECK-NEXT:    [[TMP15:%.*]] = insertelement <2 x i8> poison, i8 [[TMP14]], i64 0
 ; CHECK-NEXT:    br label %[[PRED_SDIV_CONTINUE4]]
 ; CHECK:       [[PRED_SDIV_CONTINUE4]]:
-; CHECK-NEXT:    [[TMP16:%.*]] = phi <2 x i8> [ poison, %[[PRED_SDIV_CONTINUE2]] ], [ [[TMP15]], %[[PRED_SDIV_IF3]] ]
-; CHECK-NEXT:    br i1 [[TMP2]], label %[[PRED_SDIV_IF5:.*]], label %[[PRED_SDIV_CONTINUE6]]
+; CHECK-NEXT:    [[TMP16:%.*]] = phi <2 x i8> [ poison, %[[IF27]] ], [ [[TMP15]], %[[PRED_SDIV_IF3]] ]
+; CHECK-NEXT:    [[TMP31:%.*]] = extractelement <2 x i1> [[TMP11]], i64 0
+; CHECK-NEXT:    br i1 [[TMP31]], label %[[PRED_SDIV_IF5:.*]], label %[[PRED_SDIV_CONTINUE6:.*]]
 ; CHECK:       [[PRED_SDIV_IF5]]:
 ; CHECK-NEXT:    [[TMP17:%.*]] = extractelement <2 x i16> [[PREDPHI]], i64 1
 ; CHECK-NEXT:    [[TMP18:%.*]] = trunc i16 [[TMP17]] to i8
@@ -160,12 +203,16 @@ define i8 @predicated_replicate_feeding_cast_non_uniform(i64 %n, i1 %c1, i1 %c2,
 ; CHECK-NEXT:    [[TMP20:%.*]] = insertelement <2 x i8> [[TMP16]], i8 [[TMP19]], i64 1
 ; CHECK-NEXT:    br label %[[PRED_SDIV_CONTINUE6]]
 ; CHECK:       [[PRED_SDIV_CONTINUE6]]:
-; CHECK-NEXT:    [[TMP21:%.*]] = phi <2 x i8> [ [[TMP16]], %[[PRED_SDIV_CONTINUE4]] ], [ [[TMP20]], %[[PRED_SDIV_IF5]] ]
+; CHECK-NEXT:    [[TMP28:%.*]] = phi <2 x i8> [ [[TMP16]], %[[PRED_SDIV_CONTINUE4]] ], [ [[TMP20]], %[[PRED_SDIV_IF5]] ]
+; CHECK-NEXT:    br label %[[LATCH12]]
+; CHECK:       [[LATCH12]]:
+; CHECK-NEXT:    [[TMP29:%.*]] = phi <2 x i8> [ poison, %[[MERGE6]] ], [ [[TMP28]], %[[PRED_SDIV_CONTINUE6]] ]
+; CHECK-NEXT:    [[TMP30:%.*]] = phi <2 x i1> [ zeroinitializer, %[[MERGE6]] ], [ [[TMP11]], %[[PRED_SDIV_CONTINUE6]] ]
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 2
 ; CHECK-NEXT:    [[TMP22:%.*]] = icmp eq i64 [[INDEX_NEXT]], [[N_VEC]]
 ; CHECK-NEXT:    br i1 [[TMP22]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP4:![0-9]+]]
 ; CHECK:       [[MIDDLE_BLOCK]]:
-; CHECK-NEXT:    [[PREDPHI7:%.*]] = select i1 [[C2]], <2 x i8> zeroinitializer, <2 x i8> [[TMP21]]
+; CHECK-NEXT:    [[PREDPHI7:%.*]] = select <2 x i1> [[TMP30]], <2 x i8> [[TMP29]], <2 x i8> zeroinitializer
 ; CHECK-NEXT:    [[TMP23:%.*]] = extractelement <2 x i8> [[PREDPHI7]], i64 1
 ; CHECK-NEXT:    [[CMP_N:%.*]] = icmp eq i64 [[TMP0]], [[N_VEC]]
 ; CHECK-NEXT:    br i1 [[CMP_N]], label %[[EXIT:.*]], label %[[SCALAR_PH]]

--- a/llvm/test/Transforms/LoopVectorize/X86/replicate-recipe-with-only-first-lane-used.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/replicate-recipe-with-only-first-lane-used.ll
@@ -71,52 +71,87 @@ define void @replicate_udiv_with_only_first_lane_used2(i32 %x, ptr %dst, i64 %d)
 ; CHECK-NEXT:    [[C:%.*]] = icmp eq i32 [[X]], 10
 ; CHECK-NEXT:    br label %[[VECTOR_PH:.*]]
 ; CHECK:       [[VECTOR_PH]]:
-; CHECK-NEXT:    [[TMP1:%.*]] = xor i1 [[C]], true
+; CHECK-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <4 x i1> poison, i1 [[C]], i64 0
+; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT]], <4 x i1> poison, <4 x i32> zeroinitializer
+; CHECK-NEXT:    [[TMP0:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT]], splat (i1 true)
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_UDIV_CONTINUE14:.*]] ]
-; CHECK-NEXT:    br i1 [[TMP1]], label %[[PRED_UDIV_IF:.*]], label %[[PRED_UDIV_CONTINUE:.*]]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LOOP_LATCH16:.*]] ]
+; CHECK-NEXT:    br i1 [[C]], label %[[LOOP_LATCH16]], label %[[PRED_UDIV_IF:.*]]
 ; CHECK:       [[PRED_UDIV_IF]]:
+; CHECK-NEXT:    [[TMP5:%.*]] = extractelement <4 x i1> [[TMP0]], i64 0
+; CHECK-NEXT:    br i1 [[TMP5]], label %[[PRED_UDIV_IF2:.*]], label %[[PRED_UDIV_CONTINUE:.*]]
+; CHECK:       [[PRED_UDIV_IF2]]:
 ; CHECK-NEXT:    [[TMP2:%.*]] = udiv i64 99, [[D]]
+; CHECK-NEXT:    [[TMP3:%.*]] = insertelement <4 x i64> poison, i64 [[TMP2]], i64 0
 ; CHECK-NEXT:    br label %[[PRED_UDIV_CONTINUE]]
 ; CHECK:       [[PRED_UDIV_CONTINUE]]:
-; CHECK-NEXT:    [[TMP3:%.*]] = phi i64 [ poison, %[[VECTOR_BODY]] ], [ [[TMP2]], %[[PRED_UDIV_IF]] ]
+; CHECK-NEXT:    [[TMP4:%.*]] = phi <4 x i64> [ poison, %[[PRED_UDIV_IF]] ], [ [[TMP3]], %[[PRED_UDIV_IF2]] ]
+; CHECK-NEXT:    [[TMP1:%.*]] = extractelement <4 x i1> [[TMP0]], i64 0
 ; CHECK-NEXT:    br i1 [[TMP1]], label %[[PRED_UDIV_IF1:.*]], label %[[PRED_UDIV_CONTINUE2:.*]]
 ; CHECK:       [[PRED_UDIV_IF1]]:
+; CHECK-NEXT:    [[TMP6:%.*]] = udiv i64 99, [[D]]
+; CHECK-NEXT:    [[TMP7:%.*]] = insertelement <4 x i64> [[TMP4]], i64 [[TMP6]], i64 1
 ; CHECK-NEXT:    br label %[[PRED_UDIV_CONTINUE2]]
 ; CHECK:       [[PRED_UDIV_CONTINUE2]]:
-; CHECK-NEXT:    br i1 [[TMP1]], label %[[PRED_UDIV_IF3:.*]], label %[[PRED_UDIV_CONTINUE4:.*]]
+; CHECK-NEXT:    [[TMP8:%.*]] = phi <4 x i64> [ [[TMP4]], %[[PRED_UDIV_CONTINUE]] ], [ [[TMP7]], %[[PRED_UDIV_IF1]] ]
+; CHECK-NEXT:    [[TMP9:%.*]] = extractelement <4 x i1> [[TMP0]], i64 0
+; CHECK-NEXT:    br i1 [[TMP9]], label %[[PRED_UDIV_IF3:.*]], label %[[PRED_UDIV_CONTINUE4:.*]]
 ; CHECK:       [[PRED_UDIV_IF3]]:
+; CHECK-NEXT:    [[TMP10:%.*]] = udiv i64 99, [[D]]
+; CHECK-NEXT:    [[TMP11:%.*]] = insertelement <4 x i64> [[TMP8]], i64 [[TMP10]], i64 2
 ; CHECK-NEXT:    br label %[[PRED_UDIV_CONTINUE4]]
 ; CHECK:       [[PRED_UDIV_CONTINUE4]]:
-; CHECK-NEXT:    br i1 [[TMP1]], label %[[PRED_UDIV_IF5:.*]], label %[[PRED_UDIV_CONTINUE6:.*]]
+; CHECK-NEXT:    [[TMP23:%.*]] = phi <4 x i64> [ [[TMP8]], %[[PRED_UDIV_CONTINUE2]] ], [ [[TMP11]], %[[PRED_UDIV_IF3]] ]
+; CHECK-NEXT:    [[TMP13:%.*]] = extractelement <4 x i1> [[TMP0]], i64 0
+; CHECK-NEXT:    br i1 [[TMP13]], label %[[PRED_UDIV_IF5:.*]], label %[[PRED_UDIV_CONTINUE6:.*]]
 ; CHECK:       [[PRED_UDIV_IF5]]:
+; CHECK-NEXT:    [[TMP14:%.*]] = udiv i64 99, [[D]]
+; CHECK-NEXT:    [[TMP15:%.*]] = insertelement <4 x i64> [[TMP23]], i64 [[TMP14]], i64 3
 ; CHECK-NEXT:    br label %[[PRED_UDIV_CONTINUE6]]
 ; CHECK:       [[PRED_UDIV_CONTINUE6]]:
-; CHECK-NEXT:    br i1 [[TMP1]], label %[[PRED_UDIV_IF7:.*]], label %[[PRED_UDIV_CONTINUE8:.*]]
+; CHECK-NEXT:    [[TMP16:%.*]] = phi <4 x i64> [ [[TMP23]], %[[PRED_UDIV_CONTINUE4]] ], [ [[TMP15]], %[[PRED_UDIV_IF5]] ]
+; CHECK-NEXT:    [[TMP17:%.*]] = extractelement <4 x i1> [[TMP0]], i64 0
+; CHECK-NEXT:    br i1 [[TMP17]], label %[[PRED_UDIV_IF7:.*]], label %[[PRED_UDIV_CONTINUE8:.*]]
 ; CHECK:       [[PRED_UDIV_IF7]]:
-; CHECK-NEXT:    [[TMP18:%.*]] = udiv i64 99, [[D]]
 ; CHECK-NEXT:    br label %[[PRED_UDIV_CONTINUE8]]
 ; CHECK:       [[PRED_UDIV_CONTINUE8]]:
-; CHECK-NEXT:    [[TMP15:%.*]] = phi i64 [ poison, %[[PRED_UDIV_CONTINUE6]] ], [ [[TMP18]], %[[PRED_UDIV_IF7]] ]
-; CHECK-NEXT:    br i1 [[TMP1]], label %[[PRED_UDIV_IF9:.*]], label %[[PRED_UDIV_CONTINUE10:.*]]
+; CHECK-NEXT:    [[TMP18:%.*]] = extractelement <4 x i1> [[TMP0]], i64 0
+; CHECK-NEXT:    br i1 [[TMP18]], label %[[PRED_UDIV_IF9:.*]], label %[[PRED_UDIV_CONTINUE10:.*]]
 ; CHECK:       [[PRED_UDIV_IF9]]:
 ; CHECK-NEXT:    br label %[[PRED_UDIV_CONTINUE10]]
 ; CHECK:       [[PRED_UDIV_CONTINUE10]]:
-; CHECK-NEXT:    br i1 [[TMP1]], label %[[PRED_UDIV_IF11:.*]], label %[[PRED_UDIV_CONTINUE12:.*]]
+; CHECK-NEXT:    [[TMP19:%.*]] = extractelement <4 x i1> [[TMP0]], i64 0
+; CHECK-NEXT:    br i1 [[TMP19]], label %[[PRED_UDIV_IF11:.*]], label %[[PRED_UDIV_CONTINUE12:.*]]
 ; CHECK:       [[PRED_UDIV_IF11]]:
 ; CHECK-NEXT:    br label %[[PRED_UDIV_CONTINUE12]]
 ; CHECK:       [[PRED_UDIV_CONTINUE12]]:
-; CHECK-NEXT:    br i1 [[TMP1]], label %[[PRED_UDIV_IF13:.*]], label %[[PRED_UDIV_CONTINUE14]]
+; CHECK-NEXT:    [[TMP20:%.*]] = extractelement <4 x i1> [[TMP0]], i64 0
+; CHECK-NEXT:    br i1 [[TMP20]], label %[[PRED_UDIV_IF13:.*]], label %[[PRED_UDIV_CONTINUE14:.*]]
 ; CHECK:       [[PRED_UDIV_IF13]]:
 ; CHECK-NEXT:    br label %[[PRED_UDIV_CONTINUE14]]
 ; CHECK:       [[PRED_UDIV_CONTINUE14]]:
-; CHECK-NEXT:    [[TMP45:%.*]] = select i1 [[C]], i64 0, i64 [[TMP3]]
-; CHECK-NEXT:    [[TMP47:%.*]] = select i1 [[C]], i64 0, i64 [[TMP15]]
+; CHECK-NEXT:    br label %[[LOOP_LATCH16]]
+; CHECK:       [[LOOP_LATCH16]]:
+; CHECK-NEXT:    [[TMP21:%.*]] = phi <4 x i64> [ poison, %[[VECTOR_BODY]] ], [ [[TMP16]], %[[PRED_UDIV_CONTINUE14]] ]
+; CHECK-NEXT:    [[TMP22:%.*]] = phi <4 x i1> [ zeroinitializer, %[[VECTOR_BODY]] ], [ [[TMP0]], %[[PRED_UDIV_CONTINUE14]] ]
+; CHECK-NEXT:    [[PREDPHI:%.*]] = select <4 x i1> [[TMP22]], <4 x i64> [[TMP21]], <4 x i64> zeroinitializer
+; CHECK-NEXT:    [[TMP45:%.*]] = extractelement <4 x i64> [[PREDPHI]], i64 0
 ; CHECK-NEXT:    [[TMP46:%.*]] = getelementptr i16, ptr [[DST]], i64 [[TMP45]]
+; CHECK-NEXT:    [[TMP47:%.*]] = extractelement <4 x i64> [[PREDPHI]], i64 1
 ; CHECK-NEXT:    [[TMP48:%.*]] = getelementptr i16, ptr [[DST]], i64 [[TMP47]]
+; CHECK-NEXT:    [[TMP27:%.*]] = extractelement <4 x i64> [[PREDPHI]], i64 2
+; CHECK-NEXT:    [[TMP28:%.*]] = getelementptr i16, ptr [[DST]], i64 [[TMP27]]
+; CHECK-NEXT:    [[TMP29:%.*]] = extractelement <4 x i64> [[PREDPHI]], i64 3
+; CHECK-NEXT:    [[TMP30:%.*]] = getelementptr i16, ptr [[DST]], i64 [[TMP29]]
 ; CHECK-NEXT:    store i16 0, ptr [[TMP46]], align 2
 ; CHECK-NEXT:    store i16 0, ptr [[TMP48]], align 2
+; CHECK-NEXT:    store i16 0, ptr [[TMP28]], align 2
+; CHECK-NEXT:    store i16 0, ptr [[TMP30]], align 2
+; CHECK-NEXT:    store i16 0, ptr [[TMP46]], align 2
+; CHECK-NEXT:    store i16 0, ptr [[TMP48]], align 2
+; CHECK-NEXT:    store i16 0, ptr [[TMP28]], align 2
+; CHECK-NEXT:    store i16 0, ptr [[TMP30]], align 2
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 8
 ; CHECK-NEXT:    [[TMP12:%.*]] = icmp eq i64 [[INDEX_NEXT]], 96
 ; CHECK-NEXT:    br i1 [[TMP12]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP4:![0-9]+]]

--- a/llvm/test/Transforms/LoopVectorize/X86/replicate-recipe-with-only-first-lane-used.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/replicate-recipe-with-only-first-lane-used.ll
@@ -114,28 +114,42 @@ define void @replicate_udiv_with_only_first_lane_used2(i32 %x, ptr %dst, i64 %d)
 ; CHECK-NEXT:    [[TMP17:%.*]] = extractelement <4 x i1> [[TMP0]], i64 0
 ; CHECK-NEXT:    br i1 [[TMP17]], label %[[PRED_UDIV_IF7:.*]], label %[[PRED_UDIV_CONTINUE8:.*]]
 ; CHECK:       [[PRED_UDIV_IF7]]:
+; CHECK-NEXT:    [[TMP25:%.*]] = udiv i64 99, [[D]]
+; CHECK-NEXT:    [[TMP33:%.*]] = insertelement <4 x i64> poison, i64 [[TMP25]], i64 0
 ; CHECK-NEXT:    br label %[[PRED_UDIV_CONTINUE8]]
 ; CHECK:       [[PRED_UDIV_CONTINUE8]]:
+; CHECK-NEXT:    [[TMP35:%.*]] = phi <4 x i64> [ poison, %[[PRED_UDIV_CONTINUE6]] ], [ [[TMP33]], %[[PRED_UDIV_IF7]] ]
 ; CHECK-NEXT:    [[TMP18:%.*]] = extractelement <4 x i1> [[TMP0]], i64 0
 ; CHECK-NEXT:    br i1 [[TMP18]], label %[[PRED_UDIV_IF9:.*]], label %[[PRED_UDIV_CONTINUE10:.*]]
 ; CHECK:       [[PRED_UDIV_IF9]]:
+; CHECK-NEXT:    [[TMP36:%.*]] = udiv i64 99, [[D]]
+; CHECK-NEXT:    [[TMP37:%.*]] = insertelement <4 x i64> [[TMP35]], i64 [[TMP36]], i64 1
 ; CHECK-NEXT:    br label %[[PRED_UDIV_CONTINUE10]]
 ; CHECK:       [[PRED_UDIV_CONTINUE10]]:
+; CHECK-NEXT:    [[TMP24:%.*]] = phi <4 x i64> [ [[TMP35]], %[[PRED_UDIV_CONTINUE8]] ], [ [[TMP37]], %[[PRED_UDIV_IF9]] ]
 ; CHECK-NEXT:    [[TMP19:%.*]] = extractelement <4 x i1> [[TMP0]], i64 0
 ; CHECK-NEXT:    br i1 [[TMP19]], label %[[PRED_UDIV_IF11:.*]], label %[[PRED_UDIV_CONTINUE12:.*]]
 ; CHECK:       [[PRED_UDIV_IF11]]:
+; CHECK-NEXT:    [[TMP26:%.*]] = udiv i64 99, [[D]]
+; CHECK-NEXT:    [[TMP38:%.*]] = insertelement <4 x i64> [[TMP24]], i64 [[TMP26]], i64 2
 ; CHECK-NEXT:    br label %[[PRED_UDIV_CONTINUE12]]
 ; CHECK:       [[PRED_UDIV_CONTINUE12]]:
+; CHECK-NEXT:    [[TMP39:%.*]] = phi <4 x i64> [ [[TMP24]], %[[PRED_UDIV_CONTINUE10]] ], [ [[TMP38]], %[[PRED_UDIV_IF11]] ]
 ; CHECK-NEXT:    [[TMP20:%.*]] = extractelement <4 x i1> [[TMP0]], i64 0
 ; CHECK-NEXT:    br i1 [[TMP20]], label %[[PRED_UDIV_IF13:.*]], label %[[PRED_UDIV_CONTINUE14:.*]]
 ; CHECK:       [[PRED_UDIV_IF13]]:
+; CHECK-NEXT:    [[TMP40:%.*]] = udiv i64 99, [[D]]
+; CHECK-NEXT:    [[TMP31:%.*]] = insertelement <4 x i64> [[TMP39]], i64 [[TMP40]], i64 3
 ; CHECK-NEXT:    br label %[[PRED_UDIV_CONTINUE14]]
 ; CHECK:       [[PRED_UDIV_CONTINUE14]]:
+; CHECK-NEXT:    [[TMP32:%.*]] = phi <4 x i64> [ [[TMP39]], %[[PRED_UDIV_CONTINUE12]] ], [ [[TMP31]], %[[PRED_UDIV_IF13]] ]
 ; CHECK-NEXT:    br label %[[LOOP_LATCH16]]
 ; CHECK:       [[LOOP_LATCH16]]:
 ; CHECK-NEXT:    [[TMP21:%.*]] = phi <4 x i64> [ poison, %[[VECTOR_BODY]] ], [ [[TMP16]], %[[PRED_UDIV_CONTINUE14]] ]
+; CHECK-NEXT:    [[TMP34:%.*]] = phi <4 x i64> [ poison, %[[VECTOR_BODY]] ], [ [[TMP32]], %[[PRED_UDIV_CONTINUE14]] ]
 ; CHECK-NEXT:    [[TMP22:%.*]] = phi <4 x i1> [ zeroinitializer, %[[VECTOR_BODY]] ], [ [[TMP0]], %[[PRED_UDIV_CONTINUE14]] ]
 ; CHECK-NEXT:    [[PREDPHI:%.*]] = select <4 x i1> [[TMP22]], <4 x i64> [[TMP21]], <4 x i64> zeroinitializer
+; CHECK-NEXT:    [[PREDPHI17:%.*]] = select <4 x i1> [[TMP22]], <4 x i64> [[TMP34]], <4 x i64> zeroinitializer
 ; CHECK-NEXT:    [[TMP45:%.*]] = extractelement <4 x i64> [[PREDPHI]], i64 0
 ; CHECK-NEXT:    [[TMP46:%.*]] = getelementptr i16, ptr [[DST]], i64 [[TMP45]]
 ; CHECK-NEXT:    [[TMP47:%.*]] = extractelement <4 x i64> [[PREDPHI]], i64 1
@@ -144,14 +158,22 @@ define void @replicate_udiv_with_only_first_lane_used2(i32 %x, ptr %dst, i64 %d)
 ; CHECK-NEXT:    [[TMP28:%.*]] = getelementptr i16, ptr [[DST]], i64 [[TMP27]]
 ; CHECK-NEXT:    [[TMP29:%.*]] = extractelement <4 x i64> [[PREDPHI]], i64 3
 ; CHECK-NEXT:    [[TMP30:%.*]] = getelementptr i16, ptr [[DST]], i64 [[TMP29]]
+; CHECK-NEXT:    [[TMP44:%.*]] = extractelement <4 x i64> [[PREDPHI17]], i64 0
+; CHECK-NEXT:    [[TMP52:%.*]] = getelementptr i16, ptr [[DST]], i64 [[TMP44]]
+; CHECK-NEXT:    [[TMP53:%.*]] = extractelement <4 x i64> [[PREDPHI17]], i64 1
+; CHECK-NEXT:    [[TMP54:%.*]] = getelementptr i16, ptr [[DST]], i64 [[TMP53]]
+; CHECK-NEXT:    [[TMP55:%.*]] = extractelement <4 x i64> [[PREDPHI17]], i64 2
+; CHECK-NEXT:    [[TMP49:%.*]] = getelementptr i16, ptr [[DST]], i64 [[TMP55]]
+; CHECK-NEXT:    [[TMP50:%.*]] = extractelement <4 x i64> [[PREDPHI17]], i64 3
+; CHECK-NEXT:    [[TMP51:%.*]] = getelementptr i16, ptr [[DST]], i64 [[TMP50]]
 ; CHECK-NEXT:    store i16 0, ptr [[TMP46]], align 2
 ; CHECK-NEXT:    store i16 0, ptr [[TMP48]], align 2
 ; CHECK-NEXT:    store i16 0, ptr [[TMP28]], align 2
 ; CHECK-NEXT:    store i16 0, ptr [[TMP30]], align 2
-; CHECK-NEXT:    store i16 0, ptr [[TMP46]], align 2
-; CHECK-NEXT:    store i16 0, ptr [[TMP48]], align 2
-; CHECK-NEXT:    store i16 0, ptr [[TMP28]], align 2
-; CHECK-NEXT:    store i16 0, ptr [[TMP30]], align 2
+; CHECK-NEXT:    store i16 0, ptr [[TMP52]], align 2
+; CHECK-NEXT:    store i16 0, ptr [[TMP54]], align 2
+; CHECK-NEXT:    store i16 0, ptr [[TMP49]], align 2
+; CHECK-NEXT:    store i16 0, ptr [[TMP51]], align 2
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 8
 ; CHECK-NEXT:    [[TMP12:%.*]] = icmp eq i64 [[INDEX_NEXT]], 96
 ; CHECK-NEXT:    br i1 [[TMP12]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP4:![0-9]+]]

--- a/llvm/test/Transforms/LoopVectorize/X86/replicate-uniform-call.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/replicate-uniform-call.ll
@@ -8,26 +8,34 @@ target triple = "x86_64-unknown-linux-gnu"
 define void @smax_call_uniform(ptr %dst, i64 %x) {
 ; CHECK-LABEL: define void @smax_call_uniform(
 ; CHECK-SAME: ptr [[DST:%.*]], i64 [[X:%.*]]) {
-; CHECK-NEXT:  [[ENTRY:.*]]:
+; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    [[C:%.*]] = icmp ult i8 -68, -69
 ; CHECK-NEXT:    [[MUL:%.*]] = mul nuw nsw i64 [[X]], 0
 ; CHECK-NEXT:    br label %[[LOOP_HEADER:.*]]
 ; CHECK:       [[LOOP_HEADER]]:
-; CHECK-NEXT:    [[IV:%.*]] = phi i64 [ 0, %[[ENTRY]] ], [ [[INDEX_NEXT:%.*]], %[[LOOP_LATCH:.*]] ]
+; CHECK-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <2 x i1> poison, i1 [[C]], i64 0
+; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <2 x i1> [[BROADCAST_SPLATINSERT]], <2 x i1> poison, <2 x i32> zeroinitializer
+; CHECK-NEXT:    [[TMP0:%.*]] = xor <2 x i1> [[BROADCAST_SPLAT]], splat (i1 true)
+; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
+; CHECK:       [[VECTOR_BODY]]:
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[LOOP_HEADER]] ], [ [[INDEX_NEXT:%.*]], %[[LOOP_LATCH:.*]] ]
 ; CHECK-NEXT:    br i1 [[C]], label %[[LOOP_LATCH]], label %[[ELSE:.*]]
 ; CHECK:       [[ELSE]]:
-; CHECK-NEXT:    [[REM:%.*]] = urem i64 [[MUL]], [[X]]
-; CHECK-NEXT:    [[SMAX:%.*]] = tail call i64 @llvm.smax.i64(i64 [[REM]], i64 0)
 ; CHECK-NEXT:    br label %[[LOOP_LATCH]]
 ; CHECK:       [[LOOP_LATCH]]:
-; CHECK-NEXT:    [[PREDPHI7:%.*]] = phi i64 [ 1, %[[LOOP_HEADER]] ], [ [[SMAX]], %[[ELSE]] ]
+; CHECK-NEXT:    [[TMP1:%.*]] = phi <2 x i1> [ zeroinitializer, %[[VECTOR_BODY]] ], [ [[TMP0]], %[[ELSE]] ]
+; CHECK-NEXT:    [[TMP2:%.*]] = extractelement <2 x i1> [[TMP1]], i64 0
+; CHECK-NEXT:    [[PREDPHI7:%.*]] = select i1 [[TMP2]], i64 0, i64 1
 ; CHECK-NEXT:    [[TMP17:%.*]] = add i64 [[PREDPHI7]], 1
 ; CHECK-NEXT:    [[TMP19:%.*]] = getelementptr i64, ptr [[DST]], i64 [[TMP17]]
 ; CHECK-NEXT:    store i64 0, ptr [[TMP19]], align 8
-; CHECK-NEXT:    [[INDEX_NEXT]] = add i64 [[IV]], 1
+; CHECK-NEXT:    store i64 0, ptr [[TMP19]], align 8
+; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
 ; CHECK-NEXT:    [[TMP20:%.*]] = icmp eq i64 [[INDEX_NEXT]], 1024
-; CHECK-NEXT:    br i1 [[TMP20]], label %[[EXIT:.*]], label %[[LOOP_HEADER]]
+; CHECK-NEXT:    br i1 [[TMP20]], label %[[EXIT:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP0:![0-9]+]]
 ; CHECK:       [[EXIT]]:
+; CHECK-NEXT:    br label %[[EXIT1:.*]]
+; CHECK:       [[EXIT1]]:
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -57,3 +65,8 @@ exit:
   ret void
 }
 
+;.
+; CHECK: [[LOOP0]] = distinct !{[[LOOP0]], [[META1:![0-9]+]], [[META2:![0-9]+]]}
+; CHECK: [[META1]] = !{!"llvm.loop.isvectorized", i32 1}
+; CHECK: [[META2]] = !{!"llvm.loop.unroll.runtime.disable"}
+;.

--- a/llvm/test/Transforms/LoopVectorize/X86/replicating-load-store-costs-max-bandwidth.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/replicating-load-store-costs-max-bandwidth.ll
@@ -13,13 +13,14 @@ define void @replicating_store_with_phi_addr1(ptr noalias %array, i64 %N, i32 %x
 ; CHECK-NEXT:    call void @init(ptr [[PTR1]], ptr [[PTR2]], ptr [[PTR3]])
 ; CHECK-NEXT:    br label %[[VECTOR_PH:.*]]
 ; CHECK:       [[VECTOR_PH]]:
+; CHECK-NEXT:    [[TMP33:%.*]] = freeze i1 [[COND]]
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <16 x ptr> poison, ptr [[PTR1]], i64 0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <16 x ptr> [[BROADCAST_SPLATINSERT]], <16 x ptr> poison, <16 x i32> zeroinitializer
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT1:%.*]] = insertelement <16 x i1> poison, i1 [[COND]], i64 0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT2:%.*]] = shufflevector <16 x i1> [[BROADCAST_SPLATINSERT1]], <16 x i1> poison, <16 x i32> zeroinitializer
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE32:.*]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LOOP_LATCH36:.*]] ]
 ; CHECK-NEXT:    [[TMP0:%.*]] = load ptr, ptr [[ARRAY]], align 8
 ; CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr [[TMP0]], align 4
 ; CHECK-NEXT:    [[TMP2:%.*]] = load i32, ptr [[TMP0]], align 4
@@ -53,7 +54,11 @@ define void @replicating_store_with_phi_addr1(ptr noalias %array, i64 %N, i32 %x
 ; CHECK-NEXT:    [[TMP30:%.*]] = insertelement <16 x i32> [[TMP29]], i32 [[TMP14]], i64 13
 ; CHECK-NEXT:    [[TMP31:%.*]] = insertelement <16 x i32> [[TMP30]], i32 [[TMP15]], i64 14
 ; CHECK-NEXT:    [[TMP32:%.*]] = insertelement <16 x i32> [[TMP31]], i32 [[TMP16]], i64 15
-; CHECK-NEXT:    [[TMP33:%.*]] = icmp sle <16 x i32> [[TMP32]], zeroinitializer
+; CHECK-NEXT:    [[TMP34:%.*]] = icmp sgt <16 x i32> [[TMP32]], zeroinitializer
+; CHECK-NEXT:    [[TMP83:%.*]] = extractelement <16 x i1> [[TMP34]], i64 0
+; CHECK-NEXT:    br i1 [[TMP83]], label %[[ELSE4:.*]], label %[[THEN3:.*]]
+; CHECK:       [[THEN3]]:
+; CHECK-NEXT:    [[TMP118:%.*]] = xor <16 x i1> [[TMP34]], splat (i1 true)
 ; CHECK-NEXT:    [[TMP35:%.*]] = icmp slt i32 [[X]], [[TMP1]]
 ; CHECK-NEXT:    [[TMP36:%.*]] = icmp slt i32 [[X]], [[TMP2]]
 ; CHECK-NEXT:    [[TMP37:%.*]] = icmp slt i32 [[X]], [[TMP3]]
@@ -102,8 +107,16 @@ define void @replicating_store_with_phi_addr1(ptr noalias %array, i64 %N, i32 %x
 ; CHECK-NEXT:    [[TMP80:%.*]] = insertelement <16 x ptr> [[TMP79]], ptr [[TMP64]], i64 13
 ; CHECK-NEXT:    [[TMP81:%.*]] = insertelement <16 x ptr> [[TMP80]], ptr [[TMP65]], i64 14
 ; CHECK-NEXT:    [[TMP82:%.*]] = insertelement <16 x ptr> [[TMP81]], ptr [[TMP66]], i64 15
-; CHECK-NEXT:    [[TMP84:%.*]] = select <16 x i1> [[TMP33]], <16 x i1> splat (i1 true), <16 x i1> [[BROADCAST_SPLAT2]]
-; CHECK-NEXT:    [[PREDPHI:%.*]] = select <16 x i1> [[TMP33]], <16 x ptr> [[TMP82]], <16 x ptr> [[BROADCAST_SPLAT]]
+; CHECK-NEXT:    br label %[[MERGE_AND_STORE5:.*]]
+; CHECK:       [[ELSE4]]:
+; CHECK-NEXT:    br i1 [[TMP33]], label %[[MERGE_AND_STORE5]], label %[[LOOP_LATCH36]]
+; CHECK:       [[MERGE_AND_STORE5]]:
+; CHECK-NEXT:    [[TMP119:%.*]] = phi <16 x ptr> [ [[TMP82]], %[[THEN3]] ], [ poison, %[[ELSE4]] ]
+; CHECK-NEXT:    [[TMP120:%.*]] = phi <16 x i1> [ zeroinitializer, %[[THEN3]] ], [ [[TMP34]], %[[ELSE4]] ]
+; CHECK-NEXT:    [[TMP121:%.*]] = phi <16 x i1> [ [[TMP118]], %[[THEN3]] ], [ zeroinitializer, %[[ELSE4]] ]
+; CHECK-NEXT:    [[TMP122:%.*]] = select <16 x i1> [[TMP34]], <16 x i1> [[BROADCAST_SPLAT2]], <16 x i1> zeroinitializer
+; CHECK-NEXT:    [[TMP84:%.*]] = or <16 x i1> [[TMP122]], [[TMP121]]
+; CHECK-NEXT:    [[PREDPHI:%.*]] = select <16 x i1> [[TMP120]], <16 x ptr> [[BROADCAST_SPLAT]], <16 x ptr> [[TMP119]]
 ; CHECK-NEXT:    [[TMP85:%.*]] = extractelement <16 x i1> [[TMP84]], i64 0
 ; CHECK-NEXT:    br i1 [[TMP85]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE:.*]]
 ; CHECK:       [[PRED_STORE_IF]]:
@@ -210,12 +223,14 @@ define void @replicating_store_with_phi_addr1(ptr noalias %array, i64 %N, i32 %x
 ; CHECK-NEXT:    br label %[[PRED_STORE_CONTINUE30]]
 ; CHECK:       [[PRED_STORE_CONTINUE30]]:
 ; CHECK-NEXT:    [[TMP115:%.*]] = extractelement <16 x i1> [[TMP84]], i64 15
-; CHECK-NEXT:    br i1 [[TMP115]], label %[[PRED_STORE_IF31:.*]], label %[[PRED_STORE_CONTINUE32]]
+; CHECK-NEXT:    br i1 [[TMP115]], label %[[PRED_STORE_IF31:.*]], label %[[PRED_STORE_CONTINUE32:.*]]
 ; CHECK:       [[PRED_STORE_IF31]]:
 ; CHECK-NEXT:    [[TMP116:%.*]] = extractelement <16 x ptr> [[PREDPHI]], i64 15
 ; CHECK-NEXT:    store i8 0, ptr [[TMP116]], align 1
 ; CHECK-NEXT:    br label %[[PRED_STORE_CONTINUE32]]
 ; CHECK:       [[PRED_STORE_CONTINUE32]]:
+; CHECK-NEXT:    br label %[[LOOP_LATCH36]]
+; CHECK:       [[LOOP_LATCH36]]:
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 16
 ; CHECK-NEXT:    [[TMP117:%.*]] = icmp eq i64 [[INDEX_NEXT]], 96
 ; CHECK-NEXT:    br i1 [[TMP117]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP0:![0-9]+]]

--- a/llvm/test/Transforms/LoopVectorize/X86/replicating-load-store-costs.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/replicating-load-store-costs.ll
@@ -862,9 +862,10 @@ define void @address_use_in_different_block(ptr noalias %dst, ptr %src.0, ptr %s
 ; I64-NEXT:    [[OFFSET:%.*]] = zext i32 [[X_POS]] to i64
 ; I64-NEXT:    br label %[[VECTOR_PH:.*]]
 ; I64:       [[VECTOR_PH]]:
+; I64-NEXT:    [[TMP3:%.*]] = icmp sgt i32 [[X]], 0
 ; I64-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; I64:       [[VECTOR_BODY]]:
-; I64-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; I64-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LOOP_LATCH2:.*]] ]
 ; I64-NEXT:    [[TMP0:%.*]] = add i64 [[INDEX]], 1
 ; I64-NEXT:    [[TMP1:%.*]] = add i64 [[INDEX]], 2
 ; I64-NEXT:    [[TMP2:%.*]] = add i64 [[INDEX]], 3
@@ -880,6 +881,10 @@ define void @address_use_in_different_block(ptr noalias %dst, ptr %src.0, ptr %s
 ; I64-NEXT:    [[TMP28:%.*]] = load i32, ptr [[TMP20]], align 4
 ; I64-NEXT:    [[TMP29:%.*]] = load i32, ptr [[TMP21]], align 4
 ; I64-NEXT:    [[TMP30:%.*]] = load i32, ptr [[TMP22]], align 4
+; I64-NEXT:    br i1 [[TMP3]], label %[[LOOP_LATCH2]], label %[[THEN1:.*]]
+; I64:       [[THEN1]]:
+; I64-NEXT:    br label %[[LOOP_LATCH2]]
+; I64:       [[LOOP_LATCH2]]:
 ; I64-NEXT:    [[TMP35:%.*]] = sext i32 [[TMP27]] to i64
 ; I64-NEXT:    [[TMP36:%.*]] = sext i32 [[TMP28]] to i64
 ; I64-NEXT:    [[TMP37:%.*]] = sext i32 [[TMP29]] to i64
@@ -927,9 +932,10 @@ define void @address_use_in_different_block(ptr noalias %dst, ptr %src.0, ptr %s
 ; I32-NEXT:    [[OFFSET:%.*]] = zext i32 [[X_POS]] to i64
 ; I32-NEXT:    br label %[[VECTOR_PH:.*]]
 ; I32:       [[VECTOR_PH]]:
+; I32-NEXT:    [[TMP45:%.*]] = icmp sgt i32 [[X]], 0
 ; I32-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; I32:       [[VECTOR_BODY]]:
-; I32-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; I32-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LOOP_LATCH2:.*]] ]
 ; I32-NEXT:    [[TMP0:%.*]] = add i64 [[INDEX]], 1
 ; I32-NEXT:    [[TMP1:%.*]] = add i64 [[INDEX]], 2
 ; I32-NEXT:    [[TMP2:%.*]] = add i64 [[INDEX]], 3
@@ -945,6 +951,10 @@ define void @address_use_in_different_block(ptr noalias %dst, ptr %src.0, ptr %s
 ; I32-NEXT:    [[TMP12:%.*]] = load i32, ptr [[TMP8]], align 4
 ; I32-NEXT:    [[TMP13:%.*]] = load i32, ptr [[TMP9]], align 4
 ; I32-NEXT:    [[TMP14:%.*]] = load i32, ptr [[TMP10]], align 4
+; I32-NEXT:    br i1 [[TMP45]], label %[[LOOP_LATCH2]], label %[[THEN1:.*]]
+; I32:       [[THEN1]]:
+; I32-NEXT:    br label %[[LOOP_LATCH2]]
+; I32:       [[LOOP_LATCH2]]:
 ; I32-NEXT:    [[TMP15:%.*]] = sext i32 [[TMP11]] to i64
 ; I32-NEXT:    [[TMP16:%.*]] = sext i32 [[TMP12]] to i64
 ; I32-NEXT:    [[TMP17:%.*]] = sext i32 [[TMP13]] to i64

--- a/llvm/test/Transforms/LoopVectorize/X86/scatter_crash.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/scatter_crash.ll
@@ -126,20 +126,29 @@ define void @_Z3fn1v() #0 {
 ; CHECK-NEXT:    [[TMP34:%.*]] = xor <16 x i1> [[BROADCAST_SPLAT]], splat (i1 true)
 ; CHECK-NEXT:    br label %[[VECTOR_BODY30:.*]]
 ; CHECK:       [[VECTOR_BODY30]]:
-; CHECK-NEXT:    [[INDEX34:%.*]] = phi i64 [ 0, %[[VECTOR_PH25]] ], [ [[INDEX_NEXT39:%.*]], %[[VECTOR_BODY30]] ]
-; CHECK-NEXT:    [[VEC_IND35:%.*]] = phi <16 x i64> [ <i64 8, i64 10, i64 12, i64 14, i64 16, i64 18, i64 20, i64 22, i64 24, i64 26, i64 28, i64 30, i64 32, i64 34, i64 36, i64 38>, %[[VECTOR_PH25]] ], [ [[VEC_IND_NEXT35:%.*]], %[[VECTOR_BODY30]] ]
-; CHECK-NEXT:    [[VEC_IND37:%.*]] = phi <16 x i64> [ <i64 0, i64 2, i64 4, i64 6, i64 8, i64 10, i64 12, i64 14, i64 16, i64 18, i64 20, i64 22, i64 24, i64 26, i64 28, i64 30>, %[[VECTOR_PH25]] ], [ [[VEC_IND_NEXT36:%.*]], %[[VECTOR_BODY30]] ]
+; CHECK-NEXT:    [[INDEX34:%.*]] = phi i64 [ 0, %[[VECTOR_PH25]] ], [ [[INDEX_NEXT39:%.*]], %[[FOR_COND_CLEANUP4_US_LCSSA_US_US40:.*]] ]
+; CHECK-NEXT:    [[VEC_IND35:%.*]] = phi <16 x i64> [ <i64 8, i64 10, i64 12, i64 14, i64 16, i64 18, i64 20, i64 22, i64 24, i64 26, i64 28, i64 30, i64 32, i64 34, i64 36, i64 38>, %[[VECTOR_PH25]] ], [ [[VEC_IND_NEXT35:%.*]], %[[FOR_COND_CLEANUP4_US_LCSSA_US_US40]] ]
+; CHECK-NEXT:    [[VEC_IND37:%.*]] = phi <16 x i64> [ <i64 0, i64 2, i64 4, i64 6, i64 8, i64 10, i64 12, i64 14, i64 16, i64 18, i64 20, i64 22, i64 24, i64 26, i64 28, i64 30>, %[[VECTOR_PH25]] ], [ [[VEC_IND_NEXT36:%.*]], %[[FOR_COND_CLEANUP4_US_LCSSA_US_US40]] ]
 ; CHECK-NEXT:    [[TMP30:%.*]] = sub nsw <16 x i64> splat (i64 8), [[VEC_IND35]]
 ; CHECK-NEXT:    [[TMP31:%.*]] = getelementptr inbounds [10 x [10 x i32]], ptr @d, i64 0, <16 x i64> [[VEC_IND35]]
 ; CHECK-NEXT:    [[TMP32:%.*]] = add nsw <16 x i64> [[TMP30]], [[VEC_IND37]]
 ; CHECK-NEXT:    [[TMP33:%.*]] = getelementptr inbounds [10 x i32], <16 x ptr> [[TMP31]], <16 x i64> [[TMP32]], i64 0
+; CHECK-NEXT:    br i1 [[TOBOOL6]], label %[[FOR_BODY5_US_US_US_PREHEADER38:.*]], label %[[FOR_BODY5_US_US48_PREHEADER36:.*]]
+; CHECK:       [[FOR_BODY5_US_US48_PREHEADER36]]:
 ; CHECK-NEXT:    call void @llvm.masked.scatter.v16i32.v16p0(<16 x i32> splat (i32 8), <16 x ptr> align 16 [[TMP33]], <16 x i1> [[TMP34]])
 ; CHECK-NEXT:    [[TMP49:%.*]] = or disjoint <16 x i64> [[VEC_IND37]], splat (i64 1)
 ; CHECK-NEXT:    [[TMP36:%.*]] = add nsw <16 x i64> [[TMP30]], [[TMP49]]
 ; CHECK-NEXT:    [[TMP37:%.*]] = getelementptr inbounds [10 x i32], <16 x ptr> [[TMP31]], <16 x i64> [[TMP36]], i64 0
 ; CHECK-NEXT:    call void @llvm.masked.scatter.v16i32.v16p0(<16 x i32> splat (i32 8), <16 x ptr> align 8 [[TMP37]], <16 x i1> [[TMP34]])
+; CHECK-NEXT:    br label %[[FOR_COND_CLEANUP4_US_LCSSA_US_US40]]
+; CHECK:       [[FOR_BODY5_US_US_US_PREHEADER38]]:
 ; CHECK-NEXT:    call void @llvm.masked.scatter.v16i32.v16p0(<16 x i32> splat (i32 7), <16 x ptr> align 16 [[TMP33]], <16 x i1> [[BROADCAST_SPLAT]])
-; CHECK-NEXT:    call void @llvm.masked.scatter.v16i32.v16p0(<16 x i32> splat (i32 7), <16 x ptr> align 8 [[TMP37]], <16 x i1> [[BROADCAST_SPLAT]])
+; CHECK-NEXT:    [[TMP38:%.*]] = or disjoint <16 x i64> [[VEC_IND37]], splat (i64 1)
+; CHECK-NEXT:    [[TMP35:%.*]] = add nsw <16 x i64> [[TMP30]], [[TMP38]]
+; CHECK-NEXT:    [[WIDE_GEP39:%.*]] = getelementptr inbounds [10 x i32], <16 x ptr> [[TMP31]], <16 x i64> [[TMP35]], i64 0
+; CHECK-NEXT:    call void @llvm.masked.scatter.v16i32.v16p0(<16 x i32> splat (i32 7), <16 x ptr> align 8 [[WIDE_GEP39]], <16 x i1> [[BROADCAST_SPLAT]])
+; CHECK-NEXT:    br label %[[FOR_COND_CLEANUP4_US_LCSSA_US_US40]]
+; CHECK:       [[FOR_COND_CLEANUP4_US_LCSSA_US_US40]]:
 ; CHECK-NEXT:    [[INDEX_NEXT39]] = add nuw i64 [[INDEX34]], 16
 ; CHECK-NEXT:    [[VEC_IND_NEXT35]] = add nuw nsw <16 x i64> [[VEC_IND35]], splat (i64 32)
 ; CHECK-NEXT:    [[VEC_IND_NEXT36]] = add nuw nsw <16 x i64> [[VEC_IND37]], splat (i64 32)
@@ -152,7 +161,7 @@ define void @_Z3fn1v() #0 {
 ; CHECK-NEXT:    [[MIN_EPILOG_ITERS_CHECK50:%.*]] = icmp ult i64 [[N_MOD_VF31]], 8
 ; CHECK-NEXT:    br i1 [[MIN_EPILOG_ITERS_CHECK50]], label %[[VEC_EPILOG_SCALAR_PH42]], label %[[VEC_EPILOG_PH45]], !prof [[PROF3]]
 ; CHECK:       [[VEC_EPILOG_PH45]]:
-; CHECK-NEXT:    [[VEC_EPILOG_RESUME_VAL42:%.*]] = phi i64 [ [[N_VEC32]], %[[VEC_EPILOG_ITER_CHECK43]] ], [ 0, %[[VECTOR_MAIN_LOOP_ITER_CHECK24]] ]
+; CHECK-NEXT:    [[VEC_EPILOG_RESUME_VAL46:%.*]] = phi i64 [ [[N_VEC32]], %[[VEC_EPILOG_ITER_CHECK43]] ], [ 0, %[[VECTOR_MAIN_LOOP_ITER_CHECK24]] ]
 ; CHECK-NEXT:    [[BC_RESUME_VAL42:%.*]] = phi i64 [ [[IND_END41]], %[[VEC_EPILOG_ITER_CHECK43]] ], [ 8, %[[VECTOR_MAIN_LOOP_ITER_CHECK24]] ]
 ; CHECK-NEXT:    [[BC_RESUME_VAL44:%.*]] = phi i64 [ [[TMP29]], %[[VEC_EPILOG_ITER_CHECK43]] ], [ 0, %[[VECTOR_MAIN_LOOP_ITER_CHECK24]] ]
 ; CHECK-NEXT:    [[N_MOD_VF52:%.*]] = and i64 [[TMP28]], 7
@@ -170,20 +179,29 @@ define void @_Z3fn1v() #0 {
 ; CHECK-NEXT:    [[INDUCTION55:%.*]] = add nuw nsw <8 x i64> [[DOTSPLAT68]], <i64 0, i64 2, i64 4, i64 6, i64 8, i64 10, i64 12, i64 14>
 ; CHECK-NEXT:    br label %[[VEC_EPILOG_VECTOR_BODY56:.*]]
 ; CHECK:       [[VEC_EPILOG_VECTOR_BODY56]]:
-; CHECK-NEXT:    [[INDEX61:%.*]] = phi i64 [ [[VEC_EPILOG_RESUME_VAL42]], %[[VEC_EPILOG_PH45]] ], [ [[INDEX_NEXT74:%.*]], %[[VEC_EPILOG_VECTOR_BODY56]] ]
-; CHECK-NEXT:    [[VEC_IND65:%.*]] = phi <8 x i64> [ [[INDUCTION52]], %[[VEC_EPILOG_PH45]] ], [ [[VEC_IND_NEXT61:%.*]], %[[VEC_EPILOG_VECTOR_BODY56]] ]
-; CHECK-NEXT:    [[VEC_IND70:%.*]] = phi <8 x i64> [ [[INDUCTION55]], %[[VEC_EPILOG_PH45]] ], [ [[VEC_IND_NEXT62:%.*]], %[[VEC_EPILOG_VECTOR_BODY56]] ]
+; CHECK-NEXT:    [[INDEX61:%.*]] = phi i64 [ [[VEC_EPILOG_RESUME_VAL46]], %[[VEC_EPILOG_PH45]] ], [ [[INDEX_NEXT74:%.*]], %[[FOR_COND_CLEANUP4_US_LCSSA_US_US73:.*]] ]
+; CHECK-NEXT:    [[VEC_IND65:%.*]] = phi <8 x i64> [ [[INDUCTION52]], %[[VEC_EPILOG_PH45]] ], [ [[VEC_IND_NEXT61:%.*]], %[[FOR_COND_CLEANUP4_US_LCSSA_US_US73]] ]
+; CHECK-NEXT:    [[VEC_IND70:%.*]] = phi <8 x i64> [ [[INDUCTION55]], %[[VEC_EPILOG_PH45]] ], [ [[VEC_IND_NEXT62:%.*]], %[[FOR_COND_CLEANUP4_US_LCSSA_US_US73]] ]
 ; CHECK-NEXT:    [[TMP44:%.*]] = sub nsw <8 x i64> splat (i64 8), [[VEC_IND65]]
 ; CHECK-NEXT:    [[TMP45:%.*]] = getelementptr inbounds [10 x [10 x i32]], ptr @d, i64 0, <8 x i64> [[VEC_IND65]]
 ; CHECK-NEXT:    [[TMP46:%.*]] = add nsw <8 x i64> [[TMP44]], [[VEC_IND70]]
 ; CHECK-NEXT:    [[TMP47:%.*]] = getelementptr inbounds [10 x i32], <8 x ptr> [[TMP45]], <8 x i64> [[TMP46]], i64 0
+; CHECK-NEXT:    br i1 [[TOBOOL6]], label %[[FOR_BODY5_US_US_US_PREHEADER71:.*]], label %[[FOR_BODY5_US_US48_PREHEADER69:.*]]
+; CHECK:       [[FOR_BODY5_US_US48_PREHEADER69]]:
 ; CHECK-NEXT:    call void @llvm.masked.scatter.v8i32.v8p0(<8 x i32> splat (i32 8), <8 x ptr> align 16 [[TMP47]], <8 x i1> [[TMP48]])
 ; CHECK-NEXT:    [[TMP54:%.*]] = or disjoint <8 x i64> [[VEC_IND70]], splat (i64 1)
 ; CHECK-NEXT:    [[TMP50:%.*]] = add nsw <8 x i64> [[TMP44]], [[TMP54]]
 ; CHECK-NEXT:    [[TMP51:%.*]] = getelementptr inbounds [10 x i32], <8 x ptr> [[TMP45]], <8 x i64> [[TMP50]], i64 0
 ; CHECK-NEXT:    call void @llvm.masked.scatter.v8i32.v8p0(<8 x i32> splat (i32 8), <8 x ptr> align 8 [[TMP51]], <8 x i1> [[TMP48]])
+; CHECK-NEXT:    br label %[[FOR_COND_CLEANUP4_US_LCSSA_US_US73]]
+; CHECK:       [[FOR_BODY5_US_US_US_PREHEADER71]]:
 ; CHECK-NEXT:    call void @llvm.masked.scatter.v8i32.v8p0(<8 x i32> splat (i32 7), <8 x ptr> align 16 [[TMP47]], <8 x i1> [[BROADCAST_SPLAT73]])
-; CHECK-NEXT:    call void @llvm.masked.scatter.v8i32.v8p0(<8 x i32> splat (i32 7), <8 x ptr> align 8 [[TMP51]], <8 x i1> [[BROADCAST_SPLAT73]])
+; CHECK-NEXT:    [[TMP52:%.*]] = or disjoint <8 x i64> [[VEC_IND70]], splat (i64 1)
+; CHECK-NEXT:    [[TMP53:%.*]] = add nsw <8 x i64> [[TMP44]], [[TMP52]]
+; CHECK-NEXT:    [[WIDE_GEP72:%.*]] = getelementptr inbounds [10 x i32], <8 x ptr> [[TMP45]], <8 x i64> [[TMP53]], i64 0
+; CHECK-NEXT:    call void @llvm.masked.scatter.v8i32.v8p0(<8 x i32> splat (i32 7), <8 x ptr> align 8 [[WIDE_GEP72]], <8 x i1> [[BROADCAST_SPLAT73]])
+; CHECK-NEXT:    br label %[[FOR_COND_CLEANUP4_US_LCSSA_US_US73]]
+; CHECK:       [[FOR_COND_CLEANUP4_US_LCSSA_US_US73]]:
 ; CHECK-NEXT:    [[INDEX_NEXT74]] = add nuw i64 [[INDEX61]], 8
 ; CHECK-NEXT:    [[VEC_IND_NEXT61]] = add nuw nsw <8 x i64> [[VEC_IND65]], splat (i64 16)
 ; CHECK-NEXT:    [[VEC_IND_NEXT62]] = add nuw nsw <8 x i64> [[VEC_IND70]], splat (i64 16)
@@ -193,12 +211,12 @@ define void @_Z3fn1v() #0 {
 ; CHECK-NEXT:    [[CMP_N65:%.*]] = icmp eq i64 [[TMP28]], [[N_VEC53]]
 ; CHECK-NEXT:    br i1 [[CMP_N65]], label %[[FOR_COND_CLEANUP_LOOPEXIT]], label %[[VEC_EPILOG_SCALAR_PH42]]
 ; CHECK:       [[VEC_EPILOG_SCALAR_PH42]]:
-; CHECK-NEXT:    [[BC_RESUME_VAL71:%.*]] = phi i64 [ [[IND_END54]], %[[VEC_EPILOG_MIDDLE_BLOCK63]] ], [ [[IND_END41]], %[[VEC_EPILOG_ITER_CHECK43]] ], [ 8, %[[ITER_CHECK22]] ]
-; CHECK-NEXT:    [[BC_RESUME_VAL72:%.*]] = phi i64 [ [[TMP43]], %[[VEC_EPILOG_MIDDLE_BLOCK63]] ], [ [[TMP29]], %[[VEC_EPILOG_ITER_CHECK43]] ], [ 0, %[[ITER_CHECK22]] ]
+; CHECK-NEXT:    [[BC_RESUME_VAL79:%.*]] = phi i64 [ [[IND_END54]], %[[VEC_EPILOG_MIDDLE_BLOCK63]] ], [ [[IND_END41]], %[[VEC_EPILOG_ITER_CHECK43]] ], [ 8, %[[ITER_CHECK22]] ]
+; CHECK-NEXT:    [[BC_RESUME_VAL80:%.*]] = phi i64 [ [[TMP43]], %[[VEC_EPILOG_MIDDLE_BLOCK63]] ], [ [[TMP29]], %[[VEC_EPILOG_ITER_CHECK43]] ], [ 0, %[[ITER_CHECK22]] ]
 ; CHECK-NEXT:    br label %[[FOR_BODY_US:.*]]
 ; CHECK:       [[FOR_BODY_US]]:
-; CHECK-NEXT:    [[INDVARS_IV78:%.*]] = phi i64 [ [[INDVARS_IV_NEXT79:%.*]], %[[FOR_COND_CLEANUP4_US_LCSSA_US_US:.*]] ], [ [[BC_RESUME_VAL71]], %[[VEC_EPILOG_SCALAR_PH42]] ]
-; CHECK-NEXT:    [[INDVARS_IV70:%.*]] = phi i64 [ [[INDVARS_IV_NEXT71:%.*]], %[[FOR_COND_CLEANUP4_US_LCSSA_US_US]] ], [ [[BC_RESUME_VAL72]], %[[VEC_EPILOG_SCALAR_PH42]] ]
+; CHECK-NEXT:    [[INDVARS_IV78:%.*]] = phi i64 [ [[INDVARS_IV_NEXT79:%.*]], %[[FOR_COND_CLEANUP4_US_LCSSA_US_US:.*]] ], [ [[BC_RESUME_VAL79]], %[[VEC_EPILOG_SCALAR_PH42]] ]
+; CHECK-NEXT:    [[INDVARS_IV70:%.*]] = phi i64 [ [[INDVARS_IV_NEXT71:%.*]], %[[FOR_COND_CLEANUP4_US_LCSSA_US_US]] ], [ [[BC_RESUME_VAL80]], %[[VEC_EPILOG_SCALAR_PH42]] ]
 ; CHECK-NEXT:    [[TMP56:%.*]] = sub nsw i64 8, [[INDVARS_IV78]]
 ; CHECK-NEXT:    [[ADD_PTR_US:%.*]] = getelementptr inbounds [10 x [10 x i32]], ptr @d, i64 0, i64 [[INDVARS_IV78]]
 ; CHECK-NEXT:    [[TMP57:%.*]] = add nsw i64 [[TMP56]], [[INDVARS_IV70]]

--- a/llvm/test/Transforms/LoopVectorize/blend-in-header.ll
+++ b/llvm/test/Transforms/LoopVectorize/blend-in-header.ll
@@ -113,7 +113,11 @@ define i64 @invar_cond(i1 %c) {
 ; CHECK:       vector.ph:
 ; CHECK-NEXT:    br label [[VECTOR_BODY:%.*]]
 ; CHECK:       vector.body:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, [[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], [[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, [[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], [[LOOP_LATCH2:%.*]] ]
+; CHECK-NEXT:    br i1 [[C]], label [[LOOP_LATCH2]], label [[THEN1:%.*]]
+; CHECK:       then1:
+; CHECK-NEXT:    br label [[LOOP_LATCH2]]
+; CHECK:       loop.latch2:
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i32 [[INDEX]], 4
 ; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq i32 [[INDEX_NEXT]], 1000
 ; CHECK-NEXT:    br i1 [[TMP0]], label [[MIDDLE_BLOCK:%.*]], label [[VECTOR_BODY]], !llvm.loop [[LOOP6:![0-9]+]]
@@ -164,7 +168,11 @@ define i64 @invar_cond_incoming_ops_reordered(i1 %c) {
 ; CHECK:       vector.ph:
 ; CHECK-NEXT:    br label [[VECTOR_BODY:%.*]]
 ; CHECK:       vector.body:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, [[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], [[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, [[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], [[LOOP_LATCH2:%.*]] ]
+; CHECK-NEXT:    br i1 [[C]], label [[LOOP_LATCH2]], label [[THEN1:%.*]]
+; CHECK:       then1:
+; CHECK-NEXT:    br label [[LOOP_LATCH2]]
+; CHECK:       loop.latch2:
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i32 [[INDEX]], 4
 ; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq i32 [[INDEX_NEXT]], 1000
 ; CHECK-NEXT:    br i1 [[TMP0]], label [[MIDDLE_BLOCK:%.*]], label [[VECTOR_BODY]], !llvm.loop [[LOOP8:![0-9]+]]

--- a/llvm/test/Transforms/LoopVectorize/constant-fold-commutative-and.ll
+++ b/llvm/test/Transforms/LoopVectorize/constant-fold-commutative-and.ll
@@ -22,10 +22,17 @@ define void @constant_fold_commutative_and(ptr %ptr.n, ptr noalias %p, i1 %cond)
 ; CHECK-NEXT:    [[TMP2:%.*]] = load i64, ptr [[PTR_N]], align 4
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT1:%.*]] = insertelement <2 x i64> poison, i64 [[TMP2]], i64 0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT2:%.*]] = shufflevector <2 x i64> [[BROADCAST_SPLATINSERT1]], <2 x i64> poison, <2 x i32> zeroinitializer
+; CHECK-NEXT:    br i1 [[COND]], label %[[LATCH4:.*]], label %[[PRED_11:.*]]
+; CHECK:       [[PRED_11]]:
 ; CHECK-NEXT:    [[TMP3:%.*]] = icmp uge <2 x i64> [[BROADCAST_SPLAT2]], splat (i64 4)
 ; CHECK-NEXT:    [[TMP5:%.*]] = select <2 x i1> [[TMP0]], <2 x i1> [[TMP3]], <2 x i1> zeroinitializer
 ; CHECK-NEXT:    [[TMP7:%.*]] = icmp ult <2 x i64> [[BROADCAST_SPLAT2]], splat (i64 7)
-; CHECK-NEXT:    [[PREDPHI3:%.*]] = select <2 x i1> [[TMP5]], <2 x i1> [[TMP7]], <2 x i1> [[TMP0]]
+; CHECK-NEXT:    br label %[[LATCH4]]
+; CHECK:       [[LATCH4]]:
+; CHECK-NEXT:    [[TMP12:%.*]] = phi <2 x i1> [ zeroinitializer, %[[VECTOR_BODY]] ], [ [[TMP0]], %[[PRED_11]] ]
+; CHECK-NEXT:    [[TMP13:%.*]] = phi <2 x i1> [ poison, %[[VECTOR_BODY]] ], [ [[TMP7]], %[[PRED_11]] ]
+; CHECK-NEXT:    [[TMP14:%.*]] = phi <2 x i1> [ zeroinitializer, %[[VECTOR_BODY]] ], [ [[TMP5]], %[[PRED_11]] ]
+; CHECK-NEXT:    [[PREDPHI3:%.*]] = select <2 x i1> [[TMP14]], <2 x i1> [[TMP13]], <2 x i1> [[TMP12]]
 ; CHECK-NEXT:    [[TMP6:%.*]] = extractelement <2 x i1> [[TMP1]], i64 0
 ; CHECK-NEXT:    br i1 [[TMP6]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE:.*]]
 ; CHECK:       [[PRED_STORE_IF]]:

--- a/llvm/test/Transforms/LoopVectorize/div-exact.ll
+++ b/llvm/test/Transforms/LoopVectorize/div-exact.ll
@@ -18,10 +18,12 @@ define void @unknown_divisor(ptr noalias %p, i32 %n, i1 %c) {
 ; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT]], <4 x i1> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE14:.*]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LATCH14:.*]] ]
 ; CHECK-NEXT:    [[TMP2:%.*]] = add i32 [[INDEX]], 1
 ; CHECK-NEXT:    [[TMP3:%.*]] = add i32 [[INDEX]], 2
 ; CHECK-NEXT:    [[TMP4:%.*]] = add i32 [[INDEX]], 3
+; CHECK-NEXT:    br i1 [[C]], label %[[IF1:.*]], label %[[LATCH14]]
+; CHECK:       [[IF1]]:
 ; CHECK-NEXT:    [[TMP7:%.*]] = getelementptr i32, ptr [[P]], i32 [[INDEX]]
 ; CHECK-NEXT:    [[TMP8:%.*]] = getelementptr i32, ptr [[P]], i32 [[TMP2]]
 ; CHECK-NEXT:    [[TMP9:%.*]] = getelementptr i32, ptr [[P]], i32 [[TMP3]]
@@ -32,7 +34,7 @@ define void @unknown_divisor(ptr noalias %p, i32 %n, i1 %c) {
 ; CHECK-NEXT:    [[TMP13:%.*]] = insertelement <4 x i32> poison, i32 [[TMP12]], i64 0
 ; CHECK-NEXT:    br label %[[PRED_LOAD_CONTINUE]]
 ; CHECK:       [[PRED_LOAD_CONTINUE]]:
-; CHECK-NEXT:    [[TMP14:%.*]] = phi <4 x i32> [ poison, %[[VECTOR_BODY]] ], [ [[TMP13]], %[[PRED_LOAD_IF]] ]
+; CHECK-NEXT:    [[TMP14:%.*]] = phi <4 x i32> [ poison, %[[IF1]] ], [ [[TMP13]], %[[PRED_LOAD_IF]] ]
 ; CHECK-NEXT:    br i1 [[C]], label %[[PRED_LOAD_IF3:.*]], label %[[PRED_LOAD_CONTINUE4:.*]]
 ; CHECK:       [[PRED_LOAD_IF3]]:
 ; CHECK-NEXT:    [[TMP16:%.*]] = load i32, ptr [[TMP8]], align 4
@@ -73,12 +75,14 @@ define void @unknown_divisor(ptr noalias %p, i32 %n, i1 %c) {
 ; CHECK-NEXT:    store i32 [[TMP31]], ptr [[TMP9]], align 4
 ; CHECK-NEXT:    br label %[[PRED_STORE_CONTINUE12]]
 ; CHECK:       [[PRED_STORE_CONTINUE12]]:
-; CHECK-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF13:.*]], label %[[PRED_STORE_CONTINUE14]]
+; CHECK-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF13:.*]], label %[[PRED_STORE_CONTINUE14:.*]]
 ; CHECK:       [[PRED_STORE_IF13]]:
 ; CHECK-NEXT:    [[TMP32:%.*]] = extractelement <4 x i32> [[TMP28]], i64 3
 ; CHECK-NEXT:    store i32 [[TMP32]], ptr [[TMP10]], align 4
 ; CHECK-NEXT:    br label %[[PRED_STORE_CONTINUE14]]
 ; CHECK:       [[PRED_STORE_CONTINUE14]]:
+; CHECK-NEXT:    br label %[[LATCH14]]
+; CHECK:       [[LATCH14]]:
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i32 [[INDEX]], 4
 ; CHECK-NEXT:    [[TMP33:%.*]] = icmp eq i32 [[INDEX_NEXT]], [[N_VEC]]
 ; CHECK-NEXT:    br i1 [[TMP33]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP0:![0-9]+]]
@@ -142,10 +146,12 @@ define void @unknown_dividend(ptr noalias %p, i32 %n, i1 %c) {
 ; CHECK-NEXT:    [[N_VEC:%.*]] = sub i32 [[N]], [[N_MOD_VF]]
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE14:.*]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LATCH14:.*]] ]
 ; CHECK-NEXT:    [[TMP2:%.*]] = add i32 [[INDEX]], 1
 ; CHECK-NEXT:    [[TMP3:%.*]] = add i32 [[INDEX]], 2
 ; CHECK-NEXT:    [[TMP4:%.*]] = add i32 [[INDEX]], 3
+; CHECK-NEXT:    br i1 [[C]], label %[[IF1:.*]], label %[[LATCH14]]
+; CHECK:       [[IF1]]:
 ; CHECK-NEXT:    [[TMP7:%.*]] = getelementptr i32, ptr [[P]], i32 [[INDEX]]
 ; CHECK-NEXT:    [[TMP8:%.*]] = getelementptr i32, ptr [[P]], i32 [[TMP2]]
 ; CHECK-NEXT:    [[TMP9:%.*]] = getelementptr i32, ptr [[P]], i32 [[TMP3]]
@@ -156,7 +162,7 @@ define void @unknown_dividend(ptr noalias %p, i32 %n, i1 %c) {
 ; CHECK-NEXT:    [[TMP13:%.*]] = insertelement <4 x i32> poison, i32 [[TMP12]], i64 0
 ; CHECK-NEXT:    br label %[[PRED_LOAD_CONTINUE]]
 ; CHECK:       [[PRED_LOAD_CONTINUE]]:
-; CHECK-NEXT:    [[TMP14:%.*]] = phi <4 x i32> [ poison, %[[VECTOR_BODY]] ], [ [[TMP13]], %[[PRED_LOAD_IF]] ]
+; CHECK-NEXT:    [[TMP14:%.*]] = phi <4 x i32> [ poison, %[[IF1]] ], [ [[TMP13]], %[[PRED_LOAD_IF]] ]
 ; CHECK-NEXT:    br i1 [[C]], label %[[PRED_LOAD_IF3:.*]], label %[[PRED_LOAD_CONTINUE4:.*]]
 ; CHECK:       [[PRED_LOAD_IF3]]:
 ; CHECK-NEXT:    [[TMP16:%.*]] = load i32, ptr [[TMP8]], align 4
@@ -197,12 +203,14 @@ define void @unknown_dividend(ptr noalias %p, i32 %n, i1 %c) {
 ; CHECK-NEXT:    store i32 [[TMP30]], ptr [[TMP9]], align 4
 ; CHECK-NEXT:    br label %[[PRED_STORE_CONTINUE12]]
 ; CHECK:       [[PRED_STORE_CONTINUE12]]:
-; CHECK-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF13:.*]], label %[[PRED_STORE_CONTINUE14]]
+; CHECK-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF13:.*]], label %[[PRED_STORE_CONTINUE14:.*]]
 ; CHECK:       [[PRED_STORE_IF13]]:
 ; CHECK-NEXT:    [[TMP31:%.*]] = extractelement <4 x i32> [[TMP27]], i64 3
 ; CHECK-NEXT:    store i32 [[TMP31]], ptr [[TMP10]], align 4
 ; CHECK-NEXT:    br label %[[PRED_STORE_CONTINUE14]]
 ; CHECK:       [[PRED_STORE_CONTINUE14]]:
+; CHECK-NEXT:    br label %[[LATCH14]]
+; CHECK:       [[LATCH14]]:
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i32 [[INDEX]], 4
 ; CHECK-NEXT:    [[TMP32:%.*]] = icmp eq i32 [[INDEX_NEXT]], [[N_VEC]]
 ; CHECK-NEXT:    br i1 [[TMP32]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP4:![0-9]+]]

--- a/llvm/test/Transforms/LoopVectorize/hoist-predicated-loads-with-predicated-stores.ll
+++ b/llvm/test/Transforms/LoopVectorize/hoist-predicated-loads-with-predicated-stores.ll
@@ -1616,28 +1616,61 @@ define void @sink_stores_cse_select_dropping_fmf(ptr %dst, ptr %src, ptr %invar.
 ; CHECK:       [[VECTOR_PH]]:
 ; CHECK-NEXT:    [[N_MOD_VF:%.*]] = and i64 [[N]], 1
 ; CHECK-NEXT:    [[N_VEC:%.*]] = sub i64 [[N]], [[N_MOD_VF]]
+; CHECK-NEXT:    [[BROADCAST_SPLATINSERT1:%.*]] = insertelement <2 x i1> poison, i1 [[C]], i64 0
+; CHECK-NEXT:    [[BROADCAST_SPLAT1:%.*]] = shufflevector <2 x i1> [[BROADCAST_SPLATINSERT1]], <2 x i1> poison, <2 x i32> zeroinitializer
+; CHECK-NEXT:    [[TMP7:%.*]] = xor i1 [[C]], true
+; CHECK-NEXT:    br label %[[VECTOR_BODY1:.*]]
+; CHECK:       [[VECTOR_BODY1]]:
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LOOP_LATCH20:.*]] ]
+; CHECK-NEXT:    [[TMP10:%.*]] = add i64 [[INDEX]], 1
 ; CHECK-NEXT:    [[TMP1:%.*]] = load float, ptr [[SRC]], align 4, !alias.scope [[META119:![0-9]+]]
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <2 x float> poison, float [[TMP1]], i64 0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <2 x float> [[BROADCAST_SPLATINSERT]], <2 x float> poison, <2 x i32> zeroinitializer
+; CHECK-NEXT:    [[TMP5:%.*]] = getelementptr inbounds float, ptr [[DST]], i64 [[INDEX]]
+; CHECK-NEXT:    [[TMP6:%.*]] = getelementptr inbounds float, ptr [[DST]], i64 [[TMP10]]
+; CHECK-NEXT:    br i1 [[C]], label %[[THEN15:.*]], label %[[ELSE10:.*]]
+; CHECK:       [[ELSE10]]:
 ; CHECK-NEXT:    [[TMP2:%.*]] = fmul <2 x float> [[BROADCAST_SPLAT]], splat (float 3.000000e+00)
+; CHECK-NEXT:    br i1 [[TMP7]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE:.*]]
+; CHECK:       [[PRED_STORE_IF]]:
+; CHECK-NEXT:    [[TMP8:%.*]] = extractelement <2 x float> [[TMP2]], i64 0
+; CHECK-NEXT:    store float [[TMP8]], ptr [[TMP5]], align 4, !alias.scope [[META122:![0-9]+]], !noalias [[META124:![0-9]+]]
+; CHECK-NEXT:    br label %[[PRED_STORE_CONTINUE]]
+; CHECK:       [[PRED_STORE_CONTINUE]]:
+; CHECK-NEXT:    br i1 [[TMP7]], label %[[PRED_STORE_IF13:.*]], label %[[PRED_STORE_CONTINUE14:.*]]
+; CHECK:       [[PRED_STORE_IF13]]:
+; CHECK-NEXT:    [[TMP9:%.*]] = extractelement <2 x float> [[TMP2]], i64 0
+; CHECK-NEXT:    store float [[TMP9]], ptr [[TMP6]], align 4, !alias.scope [[META122]], !noalias [[META124]]
+; CHECK-NEXT:    br label %[[PRED_STORE_CONTINUE14]]
+; CHECK:       [[PRED_STORE_CONTINUE14]]:
+; CHECK-NEXT:    br label %[[LOOP_LATCH20]]
+; CHECK:       [[THEN15]]:
 ; CHECK-NEXT:    [[TMP3:%.*]] = fmul nnan <2 x float> [[BROADCAST_SPLAT]], splat (float 2.000000e+00)
+; CHECK-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF16:.*]], label %[[PRED_STORE_CONTINUE17:.*]]
+; CHECK:       [[PRED_STORE_IF16]]:
 ; CHECK-NEXT:    [[TMP4:%.*]] = extractelement <2 x float> [[TMP3]], i64 0
-; CHECK-NEXT:    [[TMP5:%.*]] = extractelement <2 x float> [[TMP2]], i64 0
-; CHECK-NEXT:    [[TMP6:%.*]] = select i1 [[C]], float [[TMP4]], float [[TMP5]]
-; CHECK-NEXT:    [[TMP7:%.*]] = fmul nnan float [[TMP6]], 5.000000e+00
-; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
+; CHECK-NEXT:    store float [[TMP4]], ptr [[TMP5]], align 4, !alias.scope [[META122]], !noalias [[META124]]
+; CHECK-NEXT:    br label %[[PRED_STORE_CONTINUE17]]
+; CHECK:       [[PRED_STORE_CONTINUE17]]:
+; CHECK-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF18:.*]], label %[[VECTOR_BODY:.*]]
+; CHECK:       [[PRED_STORE_IF18]]:
+; CHECK-NEXT:    [[TMP12:%.*]] = extractelement <2 x float> [[TMP3]], i64 0
+; CHECK-NEXT:    store float [[TMP12]], ptr [[TMP6]], align 4, !alias.scope [[META122]], !noalias [[META124]]
+; CHECK-NEXT:    br label %[[VECTOR_BODY]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[TMP8:%.*]] = add i64 [[INDEX]], 1
-; CHECK-NEXT:    [[TMP9:%.*]] = getelementptr inbounds float, ptr [[DST]], i64 [[INDEX]]
-; CHECK-NEXT:    [[TMP10:%.*]] = getelementptr inbounds float, ptr [[DST]], i64 [[TMP8]]
-; CHECK-NEXT:    store float [[TMP6]], ptr [[TMP9]], align 4, !alias.scope [[META122:![0-9]+]], !noalias [[META124:![0-9]+]]
-; CHECK-NEXT:    store float [[TMP6]], ptr [[TMP10]], align 4, !alias.scope [[META122]], !noalias [[META124]]
+; CHECK-NEXT:    br label %[[LOOP_LATCH20]]
+; CHECK:       [[LOOP_LATCH20]]:
+; CHECK-NEXT:    [[TMP13:%.*]] = phi <2 x float> [ [[TMP2]], %[[PRED_STORE_CONTINUE14]] ], [ poison, %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[TMP14:%.*]] = phi <2 x float> [ poison, %[[PRED_STORE_CONTINUE14]] ], [ [[TMP3]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[TMP15:%.*]] = phi <2 x i1> [ zeroinitializer, %[[PRED_STORE_CONTINUE14]] ], [ [[BROADCAST_SPLAT1]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[PREDPHI:%.*]] = select <2 x i1> [[TMP15]], <2 x float> [[TMP14]], <2 x float> [[TMP13]]
+; CHECK-NEXT:    [[TMP16:%.*]] = fmul nnan <2 x float> [[PREDPHI]], splat (float 5.000000e+00)
+; CHECK-NEXT:    [[TMP17:%.*]] = extractelement <2 x float> [[TMP16]], i64 1
+; CHECK-NEXT:    store float [[TMP17]], ptr [[INVAR_DST]], align 4, !alias.scope [[META126:![0-9]+]], !noalias [[META119]]
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 2
 ; CHECK-NEXT:    [[TMP11:%.*]] = icmp eq i64 [[INDEX_NEXT]], [[N_VEC]]
-; CHECK-NEXT:    br i1 [[TMP11]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP126:![0-9]+]]
+; CHECK-NEXT:    br i1 [[TMP11]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY1]], !llvm.loop [[LOOP127:![0-9]+]]
 ; CHECK:       [[MIDDLE_BLOCK]]:
-; CHECK-NEXT:    store float [[TMP7]], ptr [[INVAR_DST]], align 4, !alias.scope [[META127:![0-9]+]], !noalias [[META119]]
 ; CHECK-NEXT:    [[CMP_N:%.*]] = icmp eq i64 [[N]], [[N_VEC]]
 ; CHECK-NEXT:    br i1 [[CMP_N]], [[EXIT:label %.*]], label %[[SCALAR_PH]]
 ; CHECK:       [[SCALAR_PH]]:

--- a/llvm/test/Transforms/LoopVectorize/hoist-predicated-loads.ll
+++ b/llvm/test/Transforms/LoopVectorize/hoist-predicated-loads.ll
@@ -912,18 +912,65 @@ define void @hoist_predicated_load_with_chained_geps1(ptr %dst, ptr %src, i1 %co
 ; CHECK-NEXT:    [[FOUND_CONFLICT:%.*]] = and i1 [[BOUND0]], [[BOUND1]]
 ; CHECK-NEXT:    br i1 [[FOUND_CONFLICT]], label %[[SCALAR_PH:.*]], label %[[VECTOR_PH:.*]]
 ; CHECK:       [[VECTOR_PH]]:
+; CHECK-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <2 x i1> poison, i1 [[COND]], i64 0
+; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <2 x i1> [[BROADCAST_SPLATINSERT]], <2 x i1> poison, <2 x i32> zeroinitializer
+; CHECK-NEXT:    [[TMP0:%.*]] = xor i1 [[COND]], true
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LOOP_LATCH11:.*]] ]
 ; CHECK-NEXT:    [[TMP2:%.*]] = add i64 [[INDEX]], 1
-; CHECK-NEXT:    [[TMP20:%.*]] = getelementptr [11 x i16], ptr [[SRC]], i64 [[TMP2]]
+; CHECK-NEXT:    br i1 [[COND]], label %[[THEN6:.*]], label %[[ELSE3:.*]]
+; CHECK:       [[ELSE3]]:
+; CHECK-NEXT:    br i1 [[TMP0]], label %[[PRED_LOAD_IF:.*]], label %[[PRED_LOAD_CONTINUE:.*]]
+; CHECK:       [[PRED_LOAD_IF]]:
+; CHECK-NEXT:    [[TMP20:%.*]] = getelementptr [11 x i16], ptr [[SRC]], i64 [[INDEX]]
 ; CHECK-NEXT:    [[TMP21:%.*]] = getelementptr i8, ptr [[TMP20]], i64 8
-; CHECK-NEXT:    [[TMP3:%.*]] = load i16, ptr [[TMP21]], align 2, !alias.scope [[META68:![0-9]+]]
+; CHECK-NEXT:    [[TMP4:%.*]] = load i16, ptr [[TMP21]], align 2, !alias.scope [[META68:![0-9]+]]
+; CHECK-NEXT:    [[TMP5:%.*]] = insertelement <2 x i16> poison, i16 [[TMP4]], i64 0
+; CHECK-NEXT:    br label %[[PRED_LOAD_CONTINUE]]
+; CHECK:       [[PRED_LOAD_CONTINUE]]:
+; CHECK-NEXT:    [[TMP6:%.*]] = phi <2 x i16> [ poison, %[[ELSE3]] ], [ [[TMP5]], %[[PRED_LOAD_IF]] ]
+; CHECK-NEXT:    br i1 [[TMP0]], label %[[PRED_LOAD_IF4:.*]], label %[[PRED_LOAD_CONTINUE5:.*]]
+; CHECK:       [[PRED_LOAD_IF4]]:
+; CHECK-NEXT:    [[TMP7:%.*]] = getelementptr [11 x i16], ptr [[SRC]], i64 [[TMP2]]
+; CHECK-NEXT:    [[TMP8:%.*]] = getelementptr i8, ptr [[TMP7]], i64 8
+; CHECK-NEXT:    [[TMP9:%.*]] = load i16, ptr [[TMP8]], align 2, !alias.scope [[META68]]
+; CHECK-NEXT:    [[TMP10:%.*]] = insertelement <2 x i16> [[TMP6]], i16 [[TMP9]], i64 1
+; CHECK-NEXT:    br label %[[PRED_LOAD_CONTINUE5]]
+; CHECK:       [[PRED_LOAD_CONTINUE5]]:
+; CHECK-NEXT:    [[TMP11:%.*]] = phi <2 x i16> [ [[TMP6]], %[[PRED_LOAD_CONTINUE]] ], [ [[TMP10]], %[[PRED_LOAD_IF4]] ]
+; CHECK-NEXT:    br label %[[LOOP_LATCH11]]
+; CHECK:       [[THEN6]]:
+; CHECK-NEXT:    br i1 [[COND]], label %[[PRED_LOAD_IF7:.*]], label %[[PRED_LOAD_CONTINUE8:.*]]
+; CHECK:       [[PRED_LOAD_IF7]]:
+; CHECK-NEXT:    [[TMP12:%.*]] = getelementptr [11 x i16], ptr [[SRC]], i64 [[INDEX]]
+; CHECK-NEXT:    [[TMP13:%.*]] = getelementptr i8, ptr [[TMP12]], i64 8
+; CHECK-NEXT:    [[TMP14:%.*]] = load i16, ptr [[TMP13]], align 2, !alias.scope [[META68]]
+; CHECK-NEXT:    [[TMP15:%.*]] = insertelement <2 x i16> poison, i16 [[TMP14]], i64 0
+; CHECK-NEXT:    br label %[[PRED_LOAD_CONTINUE8]]
+; CHECK:       [[PRED_LOAD_CONTINUE8]]:
+; CHECK-NEXT:    [[TMP16:%.*]] = phi <2 x i16> [ poison, %[[THEN6]] ], [ [[TMP15]], %[[PRED_LOAD_IF7]] ]
+; CHECK-NEXT:    br i1 [[COND]], label %[[PRED_LOAD_IF9:.*]], label %[[PRED_LOAD_CONTINUE10:.*]]
+; CHECK:       [[PRED_LOAD_IF9]]:
+; CHECK-NEXT:    [[TMP17:%.*]] = getelementptr [11 x i16], ptr [[SRC]], i64 [[TMP2]]
+; CHECK-NEXT:    [[TMP18:%.*]] = getelementptr i8, ptr [[TMP17]], i64 8
+; CHECK-NEXT:    [[TMP19:%.*]] = load i16, ptr [[TMP18]], align 2, !alias.scope [[META68]]
+; CHECK-NEXT:    [[TMP27:%.*]] = insertelement <2 x i16> [[TMP16]], i16 [[TMP19]], i64 1
+; CHECK-NEXT:    br label %[[PRED_LOAD_CONTINUE10]]
+; CHECK:       [[PRED_LOAD_CONTINUE10]]:
+; CHECK-NEXT:    [[TMP28:%.*]] = phi <2 x i16> [ [[TMP16]], %[[PRED_LOAD_CONTINUE8]] ], [ [[TMP27]], %[[PRED_LOAD_IF9]] ]
+; CHECK-NEXT:    br label %[[LOOP_LATCH11]]
+; CHECK:       [[LOOP_LATCH11]]:
+; CHECK-NEXT:    [[TMP22:%.*]] = phi <2 x i16> [ [[TMP11]], %[[PRED_LOAD_CONTINUE5]] ], [ poison, %[[PRED_LOAD_CONTINUE10]] ]
+; CHECK-NEXT:    [[TMP23:%.*]] = phi <2 x i16> [ poison, %[[PRED_LOAD_CONTINUE5]] ], [ [[TMP28]], %[[PRED_LOAD_CONTINUE10]] ]
+; CHECK-NEXT:    [[TMP24:%.*]] = phi <2 x i1> [ zeroinitializer, %[[PRED_LOAD_CONTINUE5]] ], [ [[BROADCAST_SPLAT]], %[[PRED_LOAD_CONTINUE10]] ]
+; CHECK-NEXT:    [[PREDPHI:%.*]] = select <2 x i1> [[TMP24]], <2 x i16> [[TMP23]], <2 x i16> [[TMP22]]
+; CHECK-NEXT:    [[TMP25:%.*]] = extractelement <2 x i16> [[PREDPHI]], i64 1
+; CHECK-NEXT:    store i16 [[TMP25]], ptr [[DST]], align 2, !alias.scope [[META71:![0-9]+]], !noalias [[META68]]
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 2
 ; CHECK-NEXT:    [[TMP26:%.*]] = icmp eq i64 [[INDEX_NEXT]], 100
-; CHECK-NEXT:    br i1 [[TMP26]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP71:![0-9]+]]
+; CHECK-NEXT:    br i1 [[TMP26]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP73:![0-9]+]]
 ; CHECK:       [[MIDDLE_BLOCK]]:
-; CHECK-NEXT:    store i16 [[TMP3]], ptr [[DST]], align 2, !alias.scope [[META72:![0-9]+]], !noalias [[META68]]
 ; CHECK-NEXT:    br label %[[SCALAR_PH]]
 ; CHECK:       [[SCALAR_PH]]:
 ;
@@ -971,18 +1018,63 @@ define void @hoist_predicated_load_with_chained_geps2(ptr %dst, ptr %src, i1 %co
 ; CHECK-NEXT:    [[FOUND_CONFLICT:%.*]] = and i1 [[BOUND0]], [[BOUND1]]
 ; CHECK-NEXT:    br i1 [[FOUND_CONFLICT]], label %[[SCALAR_PH:.*]], label %[[VECTOR_PH:.*]]
 ; CHECK:       [[VECTOR_PH]]:
+; CHECK-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <2 x i1> poison, i1 [[COND]], i64 0
+; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <2 x i1> [[BROADCAST_SPLATINSERT]], <2 x i1> poison, <2 x i32> zeroinitializer
+; CHECK-NEXT:    [[TMP0:%.*]] = xor i1 [[COND]], true
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LOOP_LATCH11:.*]] ]
 ; CHECK-NEXT:    [[TMP2:%.*]] = add i64 [[INDEX]], 1
-; CHECK-NEXT:    [[TMP4:%.*]] = getelementptr [11 x i16], ptr [[SRC]], i64 [[TMP2]]
+; CHECK-NEXT:    [[TMP4:%.*]] = getelementptr [11 x i16], ptr [[SRC]], i64 [[INDEX]]
+; CHECK-NEXT:    [[TMP3:%.*]] = getelementptr [11 x i16], ptr [[SRC]], i64 [[TMP2]]
+; CHECK-NEXT:    br i1 [[COND]], label %[[THEN6:.*]], label %[[ELSE3:.*]]
+; CHECK:       [[ELSE3]]:
+; CHECK-NEXT:    br i1 [[TMP0]], label %[[PRED_LOAD_IF:.*]], label %[[PRED_LOAD_CONTINUE:.*]]
+; CHECK:       [[PRED_LOAD_IF]]:
 ; CHECK-NEXT:    [[TMP21:%.*]] = getelementptr i8, ptr [[TMP4]], i64 8
-; CHECK-NEXT:    [[TMP3:%.*]] = load i16, ptr [[TMP21]], align 2, !alias.scope [[META75:![0-9]+]]
+; CHECK-NEXT:    [[TMP5:%.*]] = load i16, ptr [[TMP21]], align 2, !alias.scope [[META75:![0-9]+]]
+; CHECK-NEXT:    [[TMP6:%.*]] = insertelement <2 x i16> poison, i16 [[TMP5]], i64 0
+; CHECK-NEXT:    br label %[[PRED_LOAD_CONTINUE]]
+; CHECK:       [[PRED_LOAD_CONTINUE]]:
+; CHECK-NEXT:    [[TMP7:%.*]] = phi <2 x i16> [ poison, %[[ELSE3]] ], [ [[TMP6]], %[[PRED_LOAD_IF]] ]
+; CHECK-NEXT:    br i1 [[TMP0]], label %[[PRED_LOAD_IF4:.*]], label %[[PRED_LOAD_CONTINUE5:.*]]
+; CHECK:       [[PRED_LOAD_IF4]]:
+; CHECK-NEXT:    [[TMP8:%.*]] = getelementptr i8, ptr [[TMP3]], i64 8
+; CHECK-NEXT:    [[TMP9:%.*]] = load i16, ptr [[TMP8]], align 2, !alias.scope [[META75]]
+; CHECK-NEXT:    [[TMP10:%.*]] = insertelement <2 x i16> [[TMP7]], i16 [[TMP9]], i64 1
+; CHECK-NEXT:    br label %[[PRED_LOAD_CONTINUE5]]
+; CHECK:       [[PRED_LOAD_CONTINUE5]]:
+; CHECK-NEXT:    [[TMP11:%.*]] = phi <2 x i16> [ [[TMP7]], %[[PRED_LOAD_CONTINUE]] ], [ [[TMP10]], %[[PRED_LOAD_IF4]] ]
+; CHECK-NEXT:    br label %[[LOOP_LATCH11]]
+; CHECK:       [[THEN6]]:
+; CHECK-NEXT:    br i1 [[COND]], label %[[PRED_LOAD_IF7:.*]], label %[[PRED_LOAD_CONTINUE8:.*]]
+; CHECK:       [[PRED_LOAD_IF7]]:
+; CHECK-NEXT:    [[TMP12:%.*]] = getelementptr i8, ptr [[TMP4]], i64 8
+; CHECK-NEXT:    [[TMP13:%.*]] = load i16, ptr [[TMP12]], align 2, !alias.scope [[META75]]
+; CHECK-NEXT:    [[TMP14:%.*]] = insertelement <2 x i16> poison, i16 [[TMP13]], i64 0
+; CHECK-NEXT:    br label %[[PRED_LOAD_CONTINUE8]]
+; CHECK:       [[PRED_LOAD_CONTINUE8]]:
+; CHECK-NEXT:    [[TMP15:%.*]] = phi <2 x i16> [ poison, %[[THEN6]] ], [ [[TMP14]], %[[PRED_LOAD_IF7]] ]
+; CHECK-NEXT:    br i1 [[COND]], label %[[PRED_LOAD_IF9:.*]], label %[[PRED_LOAD_CONTINUE10:.*]]
+; CHECK:       [[PRED_LOAD_IF9]]:
+; CHECK-NEXT:    [[TMP16:%.*]] = getelementptr i8, ptr [[TMP3]], i64 8
+; CHECK-NEXT:    [[TMP17:%.*]] = load i16, ptr [[TMP16]], align 2, !alias.scope [[META75]]
+; CHECK-NEXT:    [[TMP18:%.*]] = insertelement <2 x i16> [[TMP15]], i16 [[TMP17]], i64 1
+; CHECK-NEXT:    br label %[[PRED_LOAD_CONTINUE10]]
+; CHECK:       [[PRED_LOAD_CONTINUE10]]:
+; CHECK-NEXT:    [[TMP19:%.*]] = phi <2 x i16> [ [[TMP15]], %[[PRED_LOAD_CONTINUE8]] ], [ [[TMP18]], %[[PRED_LOAD_IF9]] ]
+; CHECK-NEXT:    br label %[[LOOP_LATCH11]]
+; CHECK:       [[LOOP_LATCH11]]:
+; CHECK-NEXT:    [[TMP20:%.*]] = phi <2 x i16> [ [[TMP11]], %[[PRED_LOAD_CONTINUE5]] ], [ poison, %[[PRED_LOAD_CONTINUE10]] ]
+; CHECK-NEXT:    [[TMP24:%.*]] = phi <2 x i16> [ poison, %[[PRED_LOAD_CONTINUE5]] ], [ [[TMP19]], %[[PRED_LOAD_CONTINUE10]] ]
+; CHECK-NEXT:    [[TMP22:%.*]] = phi <2 x i1> [ zeroinitializer, %[[PRED_LOAD_CONTINUE5]] ], [ [[BROADCAST_SPLAT]], %[[PRED_LOAD_CONTINUE10]] ]
+; CHECK-NEXT:    [[PREDPHI:%.*]] = select <2 x i1> [[TMP22]], <2 x i16> [[TMP24]], <2 x i16> [[TMP20]]
+; CHECK-NEXT:    [[TMP23:%.*]] = extractelement <2 x i16> [[PREDPHI]], i64 1
+; CHECK-NEXT:    store i16 [[TMP23]], ptr [[DST]], align 2, !alias.scope [[META78:![0-9]+]], !noalias [[META75]]
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 2
 ; CHECK-NEXT:    [[TMP26:%.*]] = icmp eq i64 [[INDEX_NEXT]], 100
-; CHECK-NEXT:    br i1 [[TMP26]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP78:![0-9]+]]
+; CHECK-NEXT:    br i1 [[TMP26]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP80:![0-9]+]]
 ; CHECK:       [[MIDDLE_BLOCK]]:
-; CHECK-NEXT:    store i16 [[TMP3]], ptr [[DST]], align 2, !alias.scope [[META79:![0-9]+]], !noalias [[META75]]
 ; CHECK-NEXT:    br label %[[SCALAR_PH]]
 ; CHECK:       [[SCALAR_PH]]:
 ;

--- a/llvm/test/Transforms/LoopVectorize/if-pred-stores.ll
+++ b/llvm/test/Transforms/LoopVectorize/if-pred-stores.ll
@@ -418,22 +418,26 @@ define void @minimal_bit_widths(ptr %p, i1 %c) {
 ; UNROLL:       [[VECTOR_PH]]:
 ; UNROLL-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; UNROLL:       [[VECTOR_BODY]]:
-; UNROLL-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE2:.*]] ]
+; UNROLL-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE:.*]] ]
 ; UNROLL-NEXT:    [[TMP0:%.*]] = add i64 [[INDEX]], 1
 ; UNROLL-NEXT:    [[TMP1:%.*]] = getelementptr i8, ptr [[P]], i64 [[INDEX]]
 ; UNROLL-NEXT:    [[TMP2:%.*]] = getelementptr i8, ptr [[P]], i64 [[TMP0]]
 ; UNROLL-NEXT:    [[TMP3:%.*]] = load i8, ptr [[TMP1]], align 1
 ; UNROLL-NEXT:    [[TMP4:%.*]] = load i8, ptr [[TMP2]], align 1
-; UNROLL-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE:.*]]
+; UNROLL-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE]]
 ; UNROLL:       [[PRED_STORE_IF]]:
+; UNROLL-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF2:.*]], label %[[PRED_STORE_CONTINUE1:.*]]
+; UNROLL:       [[PRED_STORE_IF2]]:
 ; UNROLL-NEXT:    store i8 [[TMP3]], ptr [[TMP1]], align 1
-; UNROLL-NEXT:    br label %[[PRED_STORE_CONTINUE]]
-; UNROLL:       [[PRED_STORE_CONTINUE]]:
-; UNROLL-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF1:.*]], label %[[PRED_STORE_CONTINUE2]]
+; UNROLL-NEXT:    br label %[[PRED_STORE_CONTINUE1]]
+; UNROLL:       [[PRED_STORE_CONTINUE1]]:
+; UNROLL-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF1:.*]], label %[[PRED_STORE_CONTINUE2:.*]]
 ; UNROLL:       [[PRED_STORE_IF1]]:
 ; UNROLL-NEXT:    store i8 [[TMP4]], ptr [[TMP2]], align 1
 ; UNROLL-NEXT:    br label %[[PRED_STORE_CONTINUE2]]
 ; UNROLL:       [[PRED_STORE_CONTINUE2]]:
+; UNROLL-NEXT:    br label %[[PRED_STORE_CONTINUE]]
+; UNROLL:       [[PRED_STORE_CONTINUE]]:
 ; UNROLL-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 2
 ; UNROLL-NEXT:    [[TMP5:%.*]] = icmp eq i64 [[INDEX_NEXT]], 1000
 ; UNROLL-NEXT:    br i1 [[TMP5]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP5:![0-9]+]]
@@ -449,22 +453,26 @@ define void @minimal_bit_widths(ptr %p, i1 %c) {
 ; UNROLL-NOSIMPLIFY:       [[VECTOR_PH]]:
 ; UNROLL-NOSIMPLIFY-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; UNROLL-NOSIMPLIFY:       [[VECTOR_BODY]]:
-; UNROLL-NOSIMPLIFY-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE2:.*]] ]
+; UNROLL-NOSIMPLIFY-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE:.*]] ]
 ; UNROLL-NOSIMPLIFY-NEXT:    [[TMP0:%.*]] = add i64 [[INDEX]], 1
 ; UNROLL-NOSIMPLIFY-NEXT:    [[TMP1:%.*]] = getelementptr i8, ptr [[P]], i64 [[INDEX]]
 ; UNROLL-NOSIMPLIFY-NEXT:    [[TMP2:%.*]] = getelementptr i8, ptr [[P]], i64 [[TMP0]]
 ; UNROLL-NOSIMPLIFY-NEXT:    [[TMP3:%.*]] = load i8, ptr [[TMP1]], align 1
 ; UNROLL-NOSIMPLIFY-NEXT:    [[TMP4:%.*]] = load i8, ptr [[TMP2]], align 1
-; UNROLL-NOSIMPLIFY-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE:.*]]
+; UNROLL-NOSIMPLIFY-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE]]
 ; UNROLL-NOSIMPLIFY:       [[PRED_STORE_IF]]:
+; UNROLL-NOSIMPLIFY-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF2:.*]], label %[[PRED_STORE_CONTINUE1:.*]]
+; UNROLL-NOSIMPLIFY:       [[PRED_STORE_IF2]]:
 ; UNROLL-NOSIMPLIFY-NEXT:    store i8 [[TMP3]], ptr [[TMP1]], align 1
-; UNROLL-NOSIMPLIFY-NEXT:    br label %[[PRED_STORE_CONTINUE]]
-; UNROLL-NOSIMPLIFY:       [[PRED_STORE_CONTINUE]]:
-; UNROLL-NOSIMPLIFY-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF1:.*]], label %[[PRED_STORE_CONTINUE2]]
+; UNROLL-NOSIMPLIFY-NEXT:    br label %[[PRED_STORE_CONTINUE1]]
+; UNROLL-NOSIMPLIFY:       [[PRED_STORE_CONTINUE1]]:
+; UNROLL-NOSIMPLIFY-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF1:.*]], label %[[PRED_STORE_CONTINUE2:.*]]
 ; UNROLL-NOSIMPLIFY:       [[PRED_STORE_IF1]]:
 ; UNROLL-NOSIMPLIFY-NEXT:    store i8 [[TMP4]], ptr [[TMP2]], align 1
 ; UNROLL-NOSIMPLIFY-NEXT:    br label %[[PRED_STORE_CONTINUE2]]
 ; UNROLL-NOSIMPLIFY:       [[PRED_STORE_CONTINUE2]]:
+; UNROLL-NOSIMPLIFY-NEXT:    br label %[[PRED_STORE_CONTINUE]]
+; UNROLL-NOSIMPLIFY:       [[PRED_STORE_CONTINUE]]:
 ; UNROLL-NOSIMPLIFY-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 2
 ; UNROLL-NOSIMPLIFY-NEXT:    [[TMP5:%.*]] = icmp eq i64 [[INDEX_NEXT]], 1000
 ; UNROLL-NOSIMPLIFY-NEXT:    br i1 [[TMP5]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP5:![0-9]+]]
@@ -480,16 +488,18 @@ define void @minimal_bit_widths(ptr %p, i1 %c) {
 ; VEC:       [[VECTOR_PH]]:
 ; VEC-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; VEC:       [[VECTOR_BODY]]:
-; VEC-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE2:.*]] ]
+; VEC-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE:.*]] ]
 ; VEC-NEXT:    [[TMP0:%.*]] = getelementptr i8, ptr [[P]], i64 [[INDEX]]
 ; VEC-NEXT:    [[WIDE_LOAD:%.*]] = load <2 x i8>, ptr [[TMP0]], align 1
-; VEC-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE:.*]]
+; VEC-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE]]
 ; VEC:       [[PRED_STORE_IF]]:
+; VEC-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF2:.*]], label %[[PRED_STORE_CONTINUE1:.*]]
+; VEC:       [[PRED_STORE_IF2]]:
 ; VEC-NEXT:    [[TMP1:%.*]] = extractelement <2 x i8> [[WIDE_LOAD]], i64 0
 ; VEC-NEXT:    store i8 [[TMP1]], ptr [[TMP0]], align 1
-; VEC-NEXT:    br label %[[PRED_STORE_CONTINUE]]
-; VEC:       [[PRED_STORE_CONTINUE]]:
-; VEC-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF1:.*]], label %[[PRED_STORE_CONTINUE2]]
+; VEC-NEXT:    br label %[[PRED_STORE_CONTINUE1]]
+; VEC:       [[PRED_STORE_CONTINUE1]]:
+; VEC-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF1:.*]], label %[[PRED_STORE_CONTINUE2:.*]]
 ; VEC:       [[PRED_STORE_IF1]]:
 ; VEC-NEXT:    [[TMP2:%.*]] = add i64 [[INDEX]], 1
 ; VEC-NEXT:    [[TMP3:%.*]] = getelementptr i8, ptr [[P]], i64 [[TMP2]]
@@ -497,6 +507,8 @@ define void @minimal_bit_widths(ptr %p, i1 %c) {
 ; VEC-NEXT:    store i8 [[TMP4]], ptr [[TMP3]], align 1
 ; VEC-NEXT:    br label %[[PRED_STORE_CONTINUE2]]
 ; VEC:       [[PRED_STORE_CONTINUE2]]:
+; VEC-NEXT:    br label %[[PRED_STORE_CONTINUE]]
+; VEC:       [[PRED_STORE_CONTINUE]]:
 ; VEC-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 2
 ; VEC-NEXT:    [[TMP5:%.*]] = icmp eq i64 [[INDEX_NEXT]], 1000
 ; VEC-NEXT:    br i1 [[TMP5]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP5:![0-9]+]]
@@ -539,7 +551,7 @@ define void @minimal_bit_widths_with_aliasing_store(i1 %c, ptr %ptr) {
 ; UNROLL:       [[VECTOR_PH]]:
 ; UNROLL-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; UNROLL:       [[VECTOR_BODY]]:
-; UNROLL-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE2:.*]] ]
+; UNROLL-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE:.*]] ]
 ; UNROLL-NEXT:    [[TMP0:%.*]] = add i64 [[INDEX]], 1
 ; UNROLL-NEXT:    [[TMP1:%.*]] = getelementptr i8, ptr [[PTR]], i64 [[INDEX]]
 ; UNROLL-NEXT:    [[TMP2:%.*]] = getelementptr i8, ptr [[PTR]], i64 [[TMP0]]
@@ -547,16 +559,20 @@ define void @minimal_bit_widths_with_aliasing_store(i1 %c, ptr %ptr) {
 ; UNROLL-NEXT:    [[TMP4:%.*]] = load i8, ptr [[TMP2]], align 1
 ; UNROLL-NEXT:    store i8 0, ptr [[TMP1]], align 1
 ; UNROLL-NEXT:    store i8 0, ptr [[TMP2]], align 1
-; UNROLL-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE:.*]]
+; UNROLL-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE]]
 ; UNROLL:       [[PRED_STORE_IF]]:
+; UNROLL-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF2:.*]], label %[[PRED_STORE_CONTINUE1:.*]]
+; UNROLL:       [[PRED_STORE_IF2]]:
 ; UNROLL-NEXT:    store i8 [[TMP3]], ptr [[TMP1]], align 1
-; UNROLL-NEXT:    br label %[[PRED_STORE_CONTINUE]]
-; UNROLL:       [[PRED_STORE_CONTINUE]]:
-; UNROLL-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF1:.*]], label %[[PRED_STORE_CONTINUE2]]
+; UNROLL-NEXT:    br label %[[PRED_STORE_CONTINUE1]]
+; UNROLL:       [[PRED_STORE_CONTINUE1]]:
+; UNROLL-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF1:.*]], label %[[PRED_STORE_CONTINUE2:.*]]
 ; UNROLL:       [[PRED_STORE_IF1]]:
 ; UNROLL-NEXT:    store i8 [[TMP4]], ptr [[TMP2]], align 1
 ; UNROLL-NEXT:    br label %[[PRED_STORE_CONTINUE2]]
 ; UNROLL:       [[PRED_STORE_CONTINUE2]]:
+; UNROLL-NEXT:    br label %[[PRED_STORE_CONTINUE]]
+; UNROLL:       [[PRED_STORE_CONTINUE]]:
 ; UNROLL-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 2
 ; UNROLL-NEXT:    [[TMP5:%.*]] = icmp eq i64 [[INDEX_NEXT]], 1000
 ; UNROLL-NEXT:    br i1 [[TMP5]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP6:![0-9]+]]
@@ -572,7 +588,7 @@ define void @minimal_bit_widths_with_aliasing_store(i1 %c, ptr %ptr) {
 ; UNROLL-NOSIMPLIFY:       [[VECTOR_PH]]:
 ; UNROLL-NOSIMPLIFY-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; UNROLL-NOSIMPLIFY:       [[VECTOR_BODY]]:
-; UNROLL-NOSIMPLIFY-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE2:.*]] ]
+; UNROLL-NOSIMPLIFY-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE:.*]] ]
 ; UNROLL-NOSIMPLIFY-NEXT:    [[TMP0:%.*]] = add i64 [[INDEX]], 1
 ; UNROLL-NOSIMPLIFY-NEXT:    [[TMP1:%.*]] = getelementptr i8, ptr [[PTR]], i64 [[INDEX]]
 ; UNROLL-NOSIMPLIFY-NEXT:    [[TMP2:%.*]] = getelementptr i8, ptr [[PTR]], i64 [[TMP0]]
@@ -580,16 +596,20 @@ define void @minimal_bit_widths_with_aliasing_store(i1 %c, ptr %ptr) {
 ; UNROLL-NOSIMPLIFY-NEXT:    [[TMP4:%.*]] = load i8, ptr [[TMP2]], align 1
 ; UNROLL-NOSIMPLIFY-NEXT:    store i8 0, ptr [[TMP1]], align 1
 ; UNROLL-NOSIMPLIFY-NEXT:    store i8 0, ptr [[TMP2]], align 1
-; UNROLL-NOSIMPLIFY-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE:.*]]
+; UNROLL-NOSIMPLIFY-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE]]
 ; UNROLL-NOSIMPLIFY:       [[PRED_STORE_IF]]:
+; UNROLL-NOSIMPLIFY-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF2:.*]], label %[[PRED_STORE_CONTINUE1:.*]]
+; UNROLL-NOSIMPLIFY:       [[PRED_STORE_IF2]]:
 ; UNROLL-NOSIMPLIFY-NEXT:    store i8 [[TMP3]], ptr [[TMP1]], align 1
-; UNROLL-NOSIMPLIFY-NEXT:    br label %[[PRED_STORE_CONTINUE]]
-; UNROLL-NOSIMPLIFY:       [[PRED_STORE_CONTINUE]]:
-; UNROLL-NOSIMPLIFY-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF1:.*]], label %[[PRED_STORE_CONTINUE2]]
+; UNROLL-NOSIMPLIFY-NEXT:    br label %[[PRED_STORE_CONTINUE1]]
+; UNROLL-NOSIMPLIFY:       [[PRED_STORE_CONTINUE1]]:
+; UNROLL-NOSIMPLIFY-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF1:.*]], label %[[PRED_STORE_CONTINUE2:.*]]
 ; UNROLL-NOSIMPLIFY:       [[PRED_STORE_IF1]]:
 ; UNROLL-NOSIMPLIFY-NEXT:    store i8 [[TMP4]], ptr [[TMP2]], align 1
 ; UNROLL-NOSIMPLIFY-NEXT:    br label %[[PRED_STORE_CONTINUE2]]
 ; UNROLL-NOSIMPLIFY:       [[PRED_STORE_CONTINUE2]]:
+; UNROLL-NOSIMPLIFY-NEXT:    br label %[[PRED_STORE_CONTINUE]]
+; UNROLL-NOSIMPLIFY:       [[PRED_STORE_CONTINUE]]:
 ; UNROLL-NOSIMPLIFY-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 2
 ; UNROLL-NOSIMPLIFY-NEXT:    [[TMP5:%.*]] = icmp eq i64 [[INDEX_NEXT]], 1000
 ; UNROLL-NOSIMPLIFY-NEXT:    br i1 [[TMP5]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP6:![0-9]+]]
@@ -605,17 +625,19 @@ define void @minimal_bit_widths_with_aliasing_store(i1 %c, ptr %ptr) {
 ; VEC:       [[VECTOR_PH]]:
 ; VEC-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; VEC:       [[VECTOR_BODY]]:
-; VEC-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE2:.*]] ]
+; VEC-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE:.*]] ]
 ; VEC-NEXT:    [[TMP0:%.*]] = getelementptr i8, ptr [[PTR]], i64 [[INDEX]]
 ; VEC-NEXT:    [[WIDE_LOAD:%.*]] = load <2 x i8>, ptr [[TMP0]], align 1
 ; VEC-NEXT:    store <2 x i8> zeroinitializer, ptr [[TMP0]], align 1
-; VEC-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE:.*]]
+; VEC-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE]]
 ; VEC:       [[PRED_STORE_IF]]:
+; VEC-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF2:.*]], label %[[PRED_STORE_CONTINUE1:.*]]
+; VEC:       [[PRED_STORE_IF2]]:
 ; VEC-NEXT:    [[TMP1:%.*]] = extractelement <2 x i8> [[WIDE_LOAD]], i64 0
 ; VEC-NEXT:    store i8 [[TMP1]], ptr [[TMP0]], align 1
-; VEC-NEXT:    br label %[[PRED_STORE_CONTINUE]]
-; VEC:       [[PRED_STORE_CONTINUE]]:
-; VEC-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF1:.*]], label %[[PRED_STORE_CONTINUE2]]
+; VEC-NEXT:    br label %[[PRED_STORE_CONTINUE1]]
+; VEC:       [[PRED_STORE_CONTINUE1]]:
+; VEC-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF1:.*]], label %[[PRED_STORE_CONTINUE2:.*]]
 ; VEC:       [[PRED_STORE_IF1]]:
 ; VEC-NEXT:    [[TMP2:%.*]] = add i64 [[INDEX]], 1
 ; VEC-NEXT:    [[TMP3:%.*]] = getelementptr i8, ptr [[PTR]], i64 [[TMP2]]
@@ -623,6 +645,8 @@ define void @minimal_bit_widths_with_aliasing_store(i1 %c, ptr %ptr) {
 ; VEC-NEXT:    store i8 [[TMP4]], ptr [[TMP3]], align 1
 ; VEC-NEXT:    br label %[[PRED_STORE_CONTINUE2]]
 ; VEC:       [[PRED_STORE_CONTINUE2]]:
+; VEC-NEXT:    br label %[[PRED_STORE_CONTINUE]]
+; VEC:       [[PRED_STORE_CONTINUE]]:
 ; VEC-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 2
 ; VEC-NEXT:    [[TMP5:%.*]] = icmp eq i64 [[INDEX_NEXT]], 1000
 ; VEC-NEXT:    br i1 [[TMP5]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP6:![0-9]+]]
@@ -666,19 +690,23 @@ define void @sdiv_with_uniform_ops(i16 %0, i1 %c, ptr %dst) {
 ; UNROLL:       [[VECTOR_PH]]:
 ; UNROLL-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; UNROLL:       [[VECTOR_BODY]]:
-; UNROLL-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE2:.*]] ]
-; UNROLL-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE:.*]]
+; UNROLL-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE:.*]] ]
+; UNROLL-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE]]
 ; UNROLL:       [[PRED_STORE_IF]]:
+; UNROLL-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF2:.*]], label %[[PRED_STORE_CONTINUE1:.*]]
+; UNROLL:       [[PRED_STORE_IF2]]:
 ; UNROLL-NEXT:    [[TMP1:%.*]] = sdiv i16 10, [[TMP0]]
 ; UNROLL-NEXT:    store i16 [[TMP1]], ptr [[DST]], align 1
-; UNROLL-NEXT:    br label %[[PRED_STORE_CONTINUE]]
-; UNROLL:       [[PRED_STORE_CONTINUE]]:
-; UNROLL-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF1:.*]], label %[[PRED_STORE_CONTINUE2]]
+; UNROLL-NEXT:    br label %[[PRED_STORE_CONTINUE1]]
+; UNROLL:       [[PRED_STORE_CONTINUE1]]:
+; UNROLL-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF1:.*]], label %[[PRED_STORE_CONTINUE2:.*]]
 ; UNROLL:       [[PRED_STORE_IF1]]:
 ; UNROLL-NEXT:    [[TMP2:%.*]] = sdiv i16 10, [[TMP0]]
 ; UNROLL-NEXT:    store i16 [[TMP2]], ptr [[DST]], align 1
 ; UNROLL-NEXT:    br label %[[PRED_STORE_CONTINUE2]]
 ; UNROLL:       [[PRED_STORE_CONTINUE2]]:
+; UNROLL-NEXT:    br label %[[PRED_STORE_CONTINUE]]
+; UNROLL:       [[PRED_STORE_CONTINUE]]:
 ; UNROLL-NEXT:    [[INDEX_NEXT]] = add nuw i32 [[INDEX]], 2
 ; UNROLL-NEXT:    [[TMP3:%.*]] = icmp eq i32 [[INDEX_NEXT]], 98
 ; UNROLL-NEXT:    br i1 [[TMP3]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP7:![0-9]+]]
@@ -707,19 +735,23 @@ define void @sdiv_with_uniform_ops(i16 %0, i1 %c, ptr %dst) {
 ; UNROLL-NOSIMPLIFY:       [[VECTOR_PH]]:
 ; UNROLL-NOSIMPLIFY-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; UNROLL-NOSIMPLIFY:       [[VECTOR_BODY]]:
-; UNROLL-NOSIMPLIFY-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE2:.*]] ]
-; UNROLL-NOSIMPLIFY-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE:.*]]
+; UNROLL-NOSIMPLIFY-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE:.*]] ]
+; UNROLL-NOSIMPLIFY-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE]]
 ; UNROLL-NOSIMPLIFY:       [[PRED_STORE_IF]]:
+; UNROLL-NOSIMPLIFY-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF2:.*]], label %[[PRED_STORE_CONTINUE1:.*]]
+; UNROLL-NOSIMPLIFY:       [[PRED_STORE_IF2]]:
 ; UNROLL-NOSIMPLIFY-NEXT:    [[TMP1:%.*]] = sdiv i16 10, [[TMP0]]
 ; UNROLL-NOSIMPLIFY-NEXT:    store i16 [[TMP1]], ptr [[DST]], align 1
-; UNROLL-NOSIMPLIFY-NEXT:    br label %[[PRED_STORE_CONTINUE]]
-; UNROLL-NOSIMPLIFY:       [[PRED_STORE_CONTINUE]]:
-; UNROLL-NOSIMPLIFY-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF1:.*]], label %[[PRED_STORE_CONTINUE2]]
+; UNROLL-NOSIMPLIFY-NEXT:    br label %[[PRED_STORE_CONTINUE1]]
+; UNROLL-NOSIMPLIFY:       [[PRED_STORE_CONTINUE1]]:
+; UNROLL-NOSIMPLIFY-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF1:.*]], label %[[PRED_STORE_CONTINUE2:.*]]
 ; UNROLL-NOSIMPLIFY:       [[PRED_STORE_IF1]]:
 ; UNROLL-NOSIMPLIFY-NEXT:    [[TMP2:%.*]] = sdiv i16 10, [[TMP0]]
 ; UNROLL-NOSIMPLIFY-NEXT:    store i16 [[TMP2]], ptr [[DST]], align 1
 ; UNROLL-NOSIMPLIFY-NEXT:    br label %[[PRED_STORE_CONTINUE2]]
 ; UNROLL-NOSIMPLIFY:       [[PRED_STORE_CONTINUE2]]:
+; UNROLL-NOSIMPLIFY-NEXT:    br label %[[PRED_STORE_CONTINUE]]
+; UNROLL-NOSIMPLIFY:       [[PRED_STORE_CONTINUE]]:
 ; UNROLL-NOSIMPLIFY-NEXT:    [[INDEX_NEXT]] = add nuw i32 [[INDEX]], 2
 ; UNROLL-NOSIMPLIFY-NEXT:    [[TMP3:%.*]] = icmp eq i32 [[INDEX_NEXT]], 98
 ; UNROLL-NOSIMPLIFY-NEXT:    br i1 [[TMP3]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP7:![0-9]+]]
@@ -753,19 +785,23 @@ define void @sdiv_with_uniform_ops(i16 %0, i1 %c, ptr %dst) {
 ; VEC-NEXT:    [[TMP1:%.*]] = call <2 x i16> @llvm.masked.sdiv.v2i16(<2 x i16> splat (i16 10), <2 x i16> [[BROADCAST_SPLAT]], <2 x i1> [[BROADCAST_SPLAT2]])
 ; VEC-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; VEC:       [[VECTOR_BODY]]:
-; VEC-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE4:.*]] ]
-; VEC-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE:.*]]
+; VEC-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE:.*]] ]
+; VEC-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE]]
 ; VEC:       [[PRED_STORE_IF]]:
+; VEC-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF1:.*]], label %[[PRED_STORE_CONTINUE1:.*]]
+; VEC:       [[PRED_STORE_IF1]]:
 ; VEC-NEXT:    [[TMP2:%.*]] = extractelement <2 x i16> [[TMP1]], i64 0
 ; VEC-NEXT:    store i16 [[TMP2]], ptr [[DST]], align 1
-; VEC-NEXT:    br label %[[PRED_STORE_CONTINUE]]
-; VEC:       [[PRED_STORE_CONTINUE]]:
-; VEC-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF3:.*]], label %[[PRED_STORE_CONTINUE4]]
+; VEC-NEXT:    br label %[[PRED_STORE_CONTINUE1]]
+; VEC:       [[PRED_STORE_CONTINUE1]]:
+; VEC-NEXT:    br i1 [[C]], label %[[PRED_STORE_IF3:.*]], label %[[PRED_STORE_CONTINUE4:.*]]
 ; VEC:       [[PRED_STORE_IF3]]:
 ; VEC-NEXT:    [[TMP3:%.*]] = extractelement <2 x i16> [[TMP1]], i64 1
 ; VEC-NEXT:    store i16 [[TMP3]], ptr [[DST]], align 1
 ; VEC-NEXT:    br label %[[PRED_STORE_CONTINUE4]]
 ; VEC:       [[PRED_STORE_CONTINUE4]]:
+; VEC-NEXT:    br label %[[PRED_STORE_CONTINUE]]
+; VEC:       [[PRED_STORE_CONTINUE]]:
 ; VEC-NEXT:    [[INDEX_NEXT]] = add nuw i32 [[INDEX]], 2
 ; VEC-NEXT:    [[TMP4:%.*]] = icmp eq i32 [[INDEX_NEXT]], 98
 ; VEC-NEXT:    br i1 [[TMP4]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP7:![0-9]+]]

--- a/llvm/test/Transforms/LoopVectorize/invariant-store-vectorization-2.ll
+++ b/llvm/test/Transforms/LoopVectorize/invariant-store-vectorization-2.ll
@@ -141,16 +141,29 @@ define void @inv_val_store_to_inv_address_conditional_inv(ptr %a, i64 %n, ptr %b
 ; CHECK-NEXT:    [[N_VEC:%.*]] = sub i64 [[SMAX2]], [[N_MOD_VF]]
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <4 x i32> poison, i32 [[NTRUNC]], i64 0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i32> [[BROADCAST_SPLATINSERT]], <4 x i32> poison, <4 x i32> zeroinitializer
+; CHECK-NEXT:    [[BROADCAST_SPLATINSERT2:%.*]] = insertelement <4 x i1> poison, i1 [[CMP]], i64 0
+; CHECK-NEXT:    [[BROADCAST_SPLAT3:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT2]], <4 x i1> poison, <4 x i32> zeroinitializer
+; CHECK-NEXT:    [[BROADCAST_SPLATINSERT4:%.*]] = insertelement <4 x i32> poison, i32 [[K]], i64 0
+; CHECK-NEXT:    [[BROADCAST_SPLAT5:%.*]] = shufflevector <4 x i32> [[BROADCAST_SPLATINSERT4]], <4 x i32> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:    br label [[VECTOR_BODY:%.*]]
 ; CHECK:       vector.body:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, [[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], [[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, [[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], [[LATCH8:%.*]] ]
 ; CHECK-NEXT:    [[TMP2:%.*]] = getelementptr inbounds i32, ptr [[B]], i64 [[INDEX]]
 ; CHECK-NEXT:    store <4 x i32> [[BROADCAST_SPLAT]], ptr [[TMP2]], align 4, !alias.scope [[META9:![0-9]+]], !noalias [[META12:![0-9]+]]
+; CHECK-NEXT:    br i1 [[CMP]], label [[COND_STORE7:%.*]], label [[COND_STORE_K6:%.*]]
+; CHECK:       cond_store_k6:
+; CHECK-NEXT:    br label [[LATCH8]]
+; CHECK:       cond_store7:
+; CHECK-NEXT:    br label [[LATCH8]]
+; CHECK:       latch8:
+; CHECK-NEXT:    [[TMP6:%.*]] = phi <4 x i1> [ zeroinitializer, [[COND_STORE_K6]] ], [ [[BROADCAST_SPLAT3]], [[COND_STORE7]] ]
+; CHECK-NEXT:    [[PREDPHI:%.*]] = select <4 x i1> [[TMP6]], <4 x i32> [[BROADCAST_SPLAT]], <4 x i32> [[BROADCAST_SPLAT5]]
+; CHECK-NEXT:    [[TMP5:%.*]] = extractelement <4 x i32> [[PREDPHI]], i64 3
+; CHECK-NEXT:    store i32 [[TMP5]], ptr [[A]], align 4, !alias.scope [[META12]]
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
 ; CHECK-NEXT:    [[TMP4:%.*]] = icmp eq i64 [[INDEX_NEXT]], [[N_VEC]]
 ; CHECK-NEXT:    br i1 [[TMP4]], label [[MIDDLE_BLOCK:%.*]], label [[VECTOR_BODY]], !llvm.loop [[LOOP14:![0-9]+]]
 ; CHECK:       middle.block:
-; CHECK-NEXT:    store i32 [[K]], ptr [[A]], align 4, !alias.scope [[META12]]
 ; CHECK-NEXT:    [[CMP_N:%.*]] = icmp eq i64 [[SMAX2]], [[N_VEC]]
 ; CHECK-NEXT:    br i1 [[CMP_N]], label [[FOR_END:%.*]], label [[SCALAR_PH]]
 ; CHECK:       scalar.ph:

--- a/llvm/test/Transforms/LoopVectorize/multiple-result-intrinsics.ll
+++ b/llvm/test/Transforms/LoopVectorize/multiple-result-intrinsics.ll
@@ -821,11 +821,11 @@ define void @sincos_predicated_store(i1 %c, ptr noalias %src, ptr noalias %dst, 
 ; CHECK-LABEL: define void @sincos_predicated_store(
 ; CHECK-SAME: i1 [[C:%.*]], ptr noalias [[SRC:%.*]], ptr noalias [[DST:%.*]], ptr noalias [[COS_DST:%.*]]) {
 ; CHECK:  [[ENTRY:.*:]]
-; CHECK:  [[VECTOR_PH:.*]]:
+; CHECK:  [[VECTOR_PH:.*:]]
 ; CHECK:  [[VECTOR_BODY:.*:]]
-; CHECK:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE2:.*]] ]
 ; CHECK:    [[TMP0:%.*]] = call { <2 x double>, <2 x double> } @llvm.sincos.v2f64(<2 x double> [[BROADCAST_SPLAT:%.*]])
 ; CHECK:    store <2 x double> zeroinitializer, ptr [[TMP3:%.*]], align 8
+; CHECK:  [[IF1:.*:]]
 ; CHECK:    [[TMP2:%.*]] = extractvalue { <2 x double>, <2 x double> } [[TMP0]], 1
 ; CHECK:    br i1 [[TMP1:%.*]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE:.*]]
 ; CHECK:  [[PRED_STORE_IF]]:
@@ -833,7 +833,7 @@ define void @sincos_predicated_store(i1 %c, ptr noalias %src, ptr noalias %dst, 
 ; CHECK:    store double [[TMP4]], ptr [[COS_DST]], align 8
 ; CHECK:    br label %[[PRED_STORE_CONTINUE]]
 ; CHECK:  [[PRED_STORE_CONTINUE]]:
-; CHECK:    br i1 [[TMP1]], label %[[PRED_STORE_IF1:.*]], label %[[PRED_STORE_CONTINUE2]]
+; CHECK:    br i1 [[TMP1]], label %[[PRED_STORE_IF1:.*]], label %[[PRED_STORE_CONTINUE2:.*]]
 ; CHECK:  [[PRED_STORE_IF1]]:
 ; CHECK:    [[TMP5:%.*]] = extractelement <2 x double> [[TMP2]], i64 1
 ; CHECK:    store double [[TMP5]], ptr [[COS_DST]], align 8
@@ -841,6 +841,7 @@ define void @sincos_predicated_store(i1 %c, ptr noalias %src, ptr noalias %dst, 
 ; CHECK:  [[PRED_STORE_CONTINUE2]]:
 ; CHECK:  [[MIDDLE_BLOCK:.*:]]
 ; CHECK:  [[EXIT:.*:]]
+; CHECK:  [[EXIT1:.*:]]
 ;
 entry:
   br label %loop

--- a/llvm/test/Transforms/LoopVectorize/phi-with-fastflags.ll
+++ b/llvm/test/Transforms/LoopVectorize/phi-with-fastflags.ll
@@ -7,12 +7,19 @@ define void @f(ptr noalias %p, i1 %c) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    br label %[[VECTOR_PH:.*]]
 ; CHECK:       [[VECTOR_PH]]:
+; CHECK-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <4 x i1> poison, i1 [[C]], i64 0
+; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT]], <4 x i1> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LATCH2:.*]] ]
 ; CHECK-NEXT:    [[TMP0:%.*]] = getelementptr float, ptr [[P]], i32 [[INDEX]]
 ; CHECK-NEXT:    [[WIDE_LOAD:%.*]] = load <4 x float>, ptr [[TMP0]], align 4
-; CHECK-NEXT:    [[PREDPHI:%.*]] = select fast i1 [[C]], <4 x float> zeroinitializer, <4 x float> [[WIDE_LOAD]]
+; CHECK-NEXT:    br i1 [[C]], label %[[THEN1:.*]], label %[[LATCH2]]
+; CHECK:       [[THEN1]]:
+; CHECK-NEXT:    br label %[[LATCH2]]
+; CHECK:       [[LATCH2]]:
+; CHECK-NEXT:    [[TMP2:%.*]] = phi <4 x i1> [ zeroinitializer, %[[VECTOR_BODY]] ], [ [[BROADCAST_SPLAT]], %[[THEN1]] ]
+; CHECK-NEXT:    [[PREDPHI:%.*]] = select fast <4 x i1> [[TMP2]], <4 x float> zeroinitializer, <4 x float> [[WIDE_LOAD]]
 ; CHECK-NEXT:    store <4 x float> [[PREDPHI]], ptr [[TMP0]], align 4
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i32 [[INDEX]], 4
 ; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i32 [[INDEX_NEXT]], 1024

--- a/llvm/test/Transforms/LoopVectorize/pr154045-dont-fold-extractelement-livein.ll
+++ b/llvm/test/Transforms/LoopVectorize/pr154045-dont-fold-extractelement-livein.ll
@@ -12,11 +12,15 @@ define void @pr154045(ptr %p, i1 %c, i64 %x) {
 ; CHECK:       [[VECTOR_PH]]:
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    br label %[[MIDDLE_BLOCK:.*]]
+; CHECK-NEXT:    br i1 [[C]], label %[[MIDDLE_BLOCK:.*]], label %[[ELSE1:.*]]
+; CHECK:       [[ELSE1]]:
+; CHECK-NEXT:    br label %[[MIDDLE_BLOCK]]
 ; CHECK:       [[MIDDLE_BLOCK]]:
 ; CHECK-NEXT:    store i32 0, ptr [[P]], align 4
 ; CHECK-NEXT:    br label %[[EXIT:.*]]
 ; CHECK:       [[EXIT]]:
+; CHECK-NEXT:    br label %[[EXIT1:.*]]
+; CHECK:       [[EXIT1]]:
 ; CHECK-NEXT:    ret void
 ;
 entry:

--- a/llvm/test/Transforms/LoopVectorize/pr154045-dont-fold-extractelement-livein.ll
+++ b/llvm/test/Transforms/LoopVectorize/pr154045-dont-fold-extractelement-livein.ll
@@ -12,9 +12,13 @@ define void @pr154045(ptr %p, i1 %c, i64 %x) {
 ; CHECK:       [[VECTOR_PH]]:
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    br label %[[MIDDLE_BLOCK:.*]]
+; CHECK-NEXT:    br i1 [[C]], label %[[MIDDLE_BLOCK:.*]], label %[[ELSE1:.*]]
+; CHECK:       [[ELSE1]]:
+; CHECK-NEXT:    br label %[[MIDDLE_BLOCK]]
 ; CHECK:       [[MIDDLE_BLOCK]]:
 ; CHECK-NEXT:    store i32 0, ptr [[P]], align 4
+; CHECK-NEXT:    br label %[[EXIT1:.*]]
+; CHECK:       [[EXIT1]]:
 ; CHECK-NEXT:    br label %[[EXIT:.*]]
 ; CHECK:       [[EXIT]]:
 ; CHECK-NEXT:    ret void

--- a/llvm/test/Transforms/LoopVectorize/pr37248.ll
+++ b/llvm/test/Transforms/LoopVectorize/pr37248.ll
@@ -38,18 +38,22 @@ define void @f1(ptr noalias %b, i1 %c, i32 %start) {
 ; CHECK-NEXT:    [[TMP12:%.*]] = xor i1 [[C]], true
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE3:.*]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LOOP_LATCH4:.*]] ]
 ; CHECK-NEXT:    [[OFFSET_IDX:%.*]] = sub i32 [[START]], [[INDEX]]
+; CHECK-NEXT:    br i1 [[C]], label %[[LOOP_LATCH4]], label %[[ELSE1:.*]]
+; CHECK:       [[ELSE1]]:
 ; CHECK-NEXT:    br i1 [[TMP12]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE:.*]]
 ; CHECK:       [[PRED_STORE_IF]]:
 ; CHECK-NEXT:    store i32 10, ptr [[B]], align 1
 ; CHECK-NEXT:    br label %[[PRED_STORE_CONTINUE]]
 ; CHECK:       [[PRED_STORE_CONTINUE]]:
-; CHECK-NEXT:    br i1 [[TMP12]], label %[[PRED_STORE_IF2:.*]], label %[[PRED_STORE_CONTINUE3]]
+; CHECK-NEXT:    br i1 [[TMP12]], label %[[PRED_STORE_IF2:.*]], label %[[PRED_STORE_CONTINUE3:.*]]
 ; CHECK:       [[PRED_STORE_IF2]]:
 ; CHECK-NEXT:    store i32 10, ptr [[B]], align 1
 ; CHECK-NEXT:    br label %[[PRED_STORE_CONTINUE3]]
 ; CHECK:       [[PRED_STORE_CONTINUE3]]:
+; CHECK-NEXT:    br label %[[LOOP_LATCH4]]
+; CHECK:       [[LOOP_LATCH4]]:
 ; CHECK-NEXT:    [[TMP13:%.*]] = trunc i32 [[OFFSET_IDX]] to i16
 ; CHECK-NEXT:    [[TMP15:%.*]] = getelementptr inbounds [2 x i16], ptr @a, i16 0, i16 [[TMP13]]
 ; CHECK-NEXT:    [[TMP17:%.*]] = getelementptr inbounds i16, ptr [[TMP15]], i64 -1
@@ -110,8 +114,12 @@ define void @f2(ptr noalias %b, i1 %c, i32 %start) {
 ; CHECK-NEXT:    [[TMP10:%.*]] = sub i32 [[START]], [[N_VEC]]
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LOOP_LATCH2:.*]] ]
 ; CHECK-NEXT:    [[OFFSET_IDX:%.*]] = sub i32 [[START]], [[INDEX]]
+; CHECK-NEXT:    br i1 [[C]], label %[[LOOP_LATCH2]], label %[[ELSE1:.*]]
+; CHECK:       [[ELSE1]]:
+; CHECK-NEXT:    br label %[[LOOP_LATCH2]]
+; CHECK:       [[LOOP_LATCH2]]:
 ; CHECK-NEXT:    [[TMP11:%.*]] = trunc i32 [[OFFSET_IDX]] to i16
 ; CHECK-NEXT:    [[TMP12:%.*]] = getelementptr inbounds [2 x i16], ptr @a, i16 0, i16 [[TMP11]]
 ; CHECK-NEXT:    [[TMP14:%.*]] = getelementptr inbounds i16, ptr [[TMP12]], i64 -1

--- a/llvm/test/Transforms/LoopVectorize/pr44488-predication.ll
+++ b/llvm/test/Transforms/LoopVectorize/pr44488-predication.ll
@@ -17,22 +17,33 @@ define i16 @test_true_and_false_branch_equal() {
 ; CHECK:       vector.body:
 ; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, [[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], [[PRED_SREM_CONTINUE2:%.*]] ]
 ; CHECK-NEXT:    [[TMP0:%.*]] = load i16, ptr @v_38, align 1
-; CHECK-NEXT:    [[TMP3:%.*]] = icmp ne i16 [[TMP0]], 0
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i16 [[TMP0]], 0
+; CHECK-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <2 x i1> poison, i1 [[TMP1]], i64 0
+; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <2 x i1> [[BROADCAST_SPLATINSERT]], <2 x i1> poison, <2 x i32> zeroinitializer
+; CHECK-NEXT:    br i1 [[TMP1]], label [[PRED_SREM_CONTINUE2]], label [[COND_FALSE41:%.*]]
+; CHECK:       cond.false41:
+; CHECK-NEXT:    [[TMP2:%.*]] = xor <2 x i1> [[BROADCAST_SPLAT]], splat (i1 true)
+; CHECK-NEXT:    [[TMP3:%.*]] = extractelement <2 x i1> [[TMP2]], i64 0
 ; CHECK-NEXT:    br i1 [[TMP3]], label [[PRED_SREM_IF:%.*]], label [[PRED_SREM_CONTINUE:%.*]]
 ; CHECK:       pred.srem.if:
 ; CHECK-NEXT:    [[TMP4:%.*]] = srem i16 5786, [[TMP0]]
 ; CHECK-NEXT:    [[TMP5:%.*]] = insertelement <2 x i16> poison, i16 [[TMP4]], i64 0
 ; CHECK-NEXT:    br label [[PRED_SREM_CONTINUE]]
 ; CHECK:       pred.srem.continue:
-; CHECK-NEXT:    [[TMP6:%.*]] = phi <2 x i16> [ poison, [[VECTOR_BODY]] ], [ [[TMP5]], [[PRED_SREM_IF]] ]
-; CHECK-NEXT:    br i1 [[TMP3]], label [[PRED_SREM_IF1:%.*]], label [[PRED_SREM_CONTINUE2]]
-; CHECK:       pred.srem.if1:
+; CHECK-NEXT:    [[TMP6:%.*]] = phi <2 x i16> [ poison, [[COND_FALSE41]] ], [ [[TMP5]], [[PRED_SREM_IF]] ]
+; CHECK-NEXT:    [[TMP7:%.*]] = extractelement <2 x i1> [[TMP2]], i64 0
+; CHECK-NEXT:    br i1 [[TMP7]], label [[PRED_SREM_IF1:%.*]], label [[PRED_SREM_CONTINUE3:%.*]]
+; CHECK:       pred.srem.if2:
 ; CHECK-NEXT:    [[TMP8:%.*]] = srem i16 5786, [[TMP0]]
 ; CHECK-NEXT:    [[TMP9:%.*]] = insertelement <2 x i16> [[TMP6]], i16 [[TMP8]], i64 1
-; CHECK-NEXT:    br label [[PRED_SREM_CONTINUE2]]
-; CHECK:       pred.srem.continue2:
+; CHECK-NEXT:    br label [[PRED_SREM_CONTINUE3]]
+; CHECK:       pred.srem.continue3:
 ; CHECK-NEXT:    [[TMP10:%.*]] = phi <2 x i16> [ [[TMP6]], [[PRED_SREM_CONTINUE]] ], [ [[TMP9]], [[PRED_SREM_IF1]] ]
-; CHECK-NEXT:    [[PREDPHI:%.*]] = select i1 [[TMP3]], <2 x i16> [[TMP10]], <2 x i16> splat (i16 5786)
+; CHECK-NEXT:    br label [[PRED_SREM_CONTINUE2]]
+; CHECK:       for.latch4:
+; CHECK-NEXT:    [[TMP13:%.*]] = phi <2 x i16> [ poison, [[VECTOR_BODY]] ], [ [[TMP10]], [[PRED_SREM_CONTINUE3]] ]
+; CHECK-NEXT:    [[TMP14:%.*]] = phi <2 x i1> [ zeroinitializer, [[VECTOR_BODY]] ], [ [[TMP2]], [[PRED_SREM_CONTINUE3]] ]
+; CHECK-NEXT:    [[PREDPHI:%.*]] = select <2 x i1> [[TMP14]], <2 x i16> [[TMP13]], <2 x i16> splat (i16 5786)
 ; CHECK-NEXT:    [[TMP11:%.*]] = extractelement <2 x i16> [[PREDPHI]], i64 1
 ; CHECK-NEXT:    store i16 [[TMP11]], ptr @v_39, align 1
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i32 [[INDEX]], 2

--- a/llvm/test/Transforms/LoopVectorize/pr45525.ll
+++ b/llvm/test/Transforms/LoopVectorize/pr45525.ll
@@ -9,12 +9,21 @@ define void @main(i1 %cond, ptr %arr) {
 ; CHECK-NEXT:  [[BB_0:.*:]]
 ; CHECK-NEXT:    br label %[[VECTOR_PH:.*]]
 ; CHECK:       [[VECTOR_PH]]:
+; CHECK-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <4 x i1> poison, i1 [[COND]], i64 0
+; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT]], <4 x i1> poison, <4 x i32> zeroinitializer
+; CHECK-NEXT:    [[TMP0:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT]], splat (i1 true)
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i32> [ <i32 0, i32 1, i32 2, i32 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[BB_32:.*]] ]
+; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i32> [ <i32 0, i32 1, i32 2, i32 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[BB_32]] ]
+; CHECK-NEXT:    br i1 [[COND]], label %[[BB_32]], label %[[BB_21:.*]]
+; CHECK:       [[BB_21]]:
 ; CHECK-NEXT:    [[TMP5:%.*]] = mul <4 x i32> [[VEC_IND]], splat (i32 3)
-; CHECK-NEXT:    [[PREDPHI:%.*]] = select i1 [[COND]], <4 x i32> splat (i32 7), <4 x i32> [[TMP5]]
+; CHECK-NEXT:    br label %[[BB_32]]
+; CHECK:       [[BB_32]]:
+; CHECK-NEXT:    [[TMP4:%.*]] = phi <4 x i32> [ poison, %[[VECTOR_BODY]] ], [ [[TMP5]], %[[BB_21]] ]
+; CHECK-NEXT:    [[TMP3:%.*]] = phi <4 x i1> [ zeroinitializer, %[[VECTOR_BODY]] ], [ [[TMP0]], %[[BB_21]] ]
+; CHECK-NEXT:    [[PREDPHI:%.*]] = select <4 x i1> [[TMP3]], <4 x i32> [[TMP4]], <4 x i32> splat (i32 7)
 ; CHECK-NEXT:    [[TMP1:%.*]] = getelementptr inbounds i32, ptr [[ARR]], i32 [[INDEX]]
 ; CHECK-NEXT:    store <4 x i32> [[PREDPHI]], ptr [[TMP1]], align 4
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i32 [[INDEX]], 4

--- a/llvm/test/Transforms/LoopVectorize/predicator.ll
+++ b/llvm/test/Transforms/LoopVectorize/predicator.ll
@@ -248,7 +248,11 @@ define void @simplifiable_blend(i1 %c1, i1 %c2, i1 %c3, i32 %x, i32 %y, ptr %p) 
 ; CHECK-NEXT:    [[PREDPHI7:%.*]] = select i1 [[C1]], <4 x i32> [[BROADCAST_SPLAT2]], <4 x i32> [[BROADCAST_SPLAT]]
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[F4:.*]] ]
+; CHECK-NEXT:    br i1 [[C3]], label %[[F4]], label %[[E3:.*]]
+; CHECK:       [[E3]]:
+; CHECK-NEXT:    br label %[[F4]]
+; CHECK:       [[F4]]:
 ; CHECK-NEXT:    [[TMP3:%.*]] = getelementptr i32, ptr [[P]], i32 [[INDEX]]
 ; CHECK-NEXT:    store <4 x i32> [[PREDPHI7]], ptr [[TMP3]], align 4
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i32 [[INDEX]], 4
@@ -377,16 +381,20 @@ define void @outermost_uniform_branch_no_phi(ptr %a, i1 %u0) {
 ; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT]], <4 x i1> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[BB42:.*]] ]
+; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[BB42]] ]
 ; CHECK-NEXT:    [[TMP0:%.*]] = getelementptr i64, ptr [[A]], i64 [[INDEX]]
 ; CHECK-NEXT:    store <4 x i64> [[VEC_IND]], ptr [[TMP0]], align 4
+; CHECK-NEXT:    br i1 [[U0]], label %[[BB11:.*]], label %[[BB42]]
+; CHECK:       [[BB11]]:
 ; CHECK-NEXT:    [[TMP1:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 1)
 ; CHECK-NEXT:    call void @llvm.masked.store.v4i64.p0(<4 x i64> [[TMP1]], ptr align 4 [[TMP0]], <4 x i1> [[BROADCAST_SPLAT]])
 ; CHECK-NEXT:    [[TMP2:%.*]] = icmp sle <4 x i64> [[VEC_IND]], splat (i64 1)
 ; CHECK-NEXT:    [[TMP3:%.*]] = select <4 x i1> [[BROADCAST_SPLAT]], <4 x i1> [[TMP2]], <4 x i1> zeroinitializer
 ; CHECK-NEXT:    [[TMP4:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 2)
 ; CHECK-NEXT:    call void @llvm.masked.store.v4i64.p0(<4 x i64> [[TMP4]], ptr align 4 [[TMP0]], <4 x i1> [[TMP3]])
+; CHECK-NEXT:    br label %[[BB42]]
+; CHECK:       [[BB42]]:
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
 ; CHECK-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[VEC_IND]], splat (i64 4)
 ; CHECK-NEXT:    [[TMP5:%.*]] = icmp eq i64 [[INDEX_NEXT]], 128
@@ -528,11 +536,15 @@ define void @outermost_uniform_branch_more_blocks_no_phi(ptr %a, i1 %u0) {
 ; CHECK-NEXT:    [[TMP0:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT]], splat (i1 true)
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[BB63:.*]] ]
+; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[BB63]] ]
 ; CHECK-NEXT:    [[TMP1:%.*]] = getelementptr i64, ptr [[A]], i64 [[INDEX]]
+; CHECK-NEXT:    br i1 [[U0]], label %[[BB22:.*]], label %[[BB11:.*]]
+; CHECK:       [[BB11]]:
 ; CHECK-NEXT:    [[TMP2:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 1)
 ; CHECK-NEXT:    call void @llvm.masked.store.v4i64.p0(<4 x i64> [[TMP2]], ptr align 4 [[TMP1]], <4 x i1> [[TMP0]])
+; CHECK-NEXT:    br label %[[BB63]]
+; CHECK:       [[BB22]]:
 ; CHECK-NEXT:    [[TMP3:%.*]] = icmp sle <4 x i64> [[VEC_IND]], splat (i64 2)
 ; CHECK-NEXT:    [[TMP4:%.*]] = xor <4 x i1> [[TMP3]], splat (i1 true)
 ; CHECK-NEXT:    [[TMP5:%.*]] = select <4 x i1> [[BROADCAST_SPLAT]], <4 x i1> [[TMP4]], <4 x i1> zeroinitializer
@@ -541,6 +553,8 @@ define void @outermost_uniform_branch_more_blocks_no_phi(ptr %a, i1 %u0) {
 ; CHECK-NEXT:    [[TMP7:%.*]] = select <4 x i1> [[BROADCAST_SPLAT]], <4 x i1> [[TMP3]], <4 x i1> zeroinitializer
 ; CHECK-NEXT:    [[TMP8:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 4)
 ; CHECK-NEXT:    call void @llvm.masked.store.v4i64.p0(<4 x i64> [[TMP8]], ptr align 4 [[TMP1]], <4 x i1> [[TMP7]])
+; CHECK-NEXT:    br label %[[BB63]]
+; CHECK:       [[BB63]]:
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
 ; CHECK-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[VEC_IND]], splat (i64 4)
 ; CHECK-NEXT:    [[TMP9:%.*]] = icmp eq i64 [[INDEX_NEXT]], 128
@@ -683,16 +697,20 @@ define void @uniform_branch_after_varying_branch_no_phi(ptr %a, i1 %u1) {
 ; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT]], <4 x i1> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[BB32:.*]] ]
+; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[BB32]] ]
 ; CHECK-NEXT:    [[TMP0:%.*]] = getelementptr i64, ptr [[A]], i64 [[INDEX]]
 ; CHECK-NEXT:    [[TMP1:%.*]] = icmp sle <4 x i64> [[VEC_IND]], zeroinitializer
 ; CHECK-NEXT:    [[TMP2:%.*]] = xor <4 x i1> [[TMP1]], splat (i1 true)
 ; CHECK-NEXT:    [[TMP3:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 1)
 ; CHECK-NEXT:    call void @llvm.masked.store.v4i64.p0(<4 x i64> [[TMP3]], ptr align 4 [[TMP0]], <4 x i1> [[TMP2]])
+; CHECK-NEXT:    br i1 [[U1]], label %[[BB21:.*]], label %[[BB32]]
+; CHECK:       [[BB21]]:
 ; CHECK-NEXT:    [[TMP4:%.*]] = select <4 x i1> [[TMP2]], <4 x i1> [[BROADCAST_SPLAT]], <4 x i1> zeroinitializer
 ; CHECK-NEXT:    [[TMP5:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 2)
 ; CHECK-NEXT:    call void @llvm.masked.store.v4i64.p0(<4 x i64> [[TMP5]], ptr align 4 [[TMP0]], <4 x i1> [[TMP4]])
+; CHECK-NEXT:    br label %[[BB32]]
+; CHECK:       [[BB32]]:
 ; CHECK-NEXT:    [[TMP6:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 4)
 ; CHECK-NEXT:    call void @llvm.masked.store.v4i64.p0(<4 x i64> [[TMP6]], ptr align 4 [[TMP0]], <4 x i1> [[TMP1]])
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
@@ -838,17 +856,23 @@ define void @uniform_branch_after_varying_branch_more_blocks_no_phi(ptr %a, i1 %
 ; CHECK-NEXT:    [[TMP0:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT]], splat (i1 true)
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[BB43:.*]] ]
+; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[BB43]] ]
 ; CHECK-NEXT:    [[TMP1:%.*]] = getelementptr i64, ptr [[A]], i64 [[INDEX]]
 ; CHECK-NEXT:    [[TMP2:%.*]] = icmp sle <4 x i64> [[VEC_IND]], zeroinitializer
 ; CHECK-NEXT:    [[TMP3:%.*]] = xor <4 x i1> [[TMP2]], splat (i1 true)
+; CHECK-NEXT:    br i1 [[U1]], label %[[BB32:.*]], label %[[BB21:.*]]
+; CHECK:       [[BB21]]:
 ; CHECK-NEXT:    [[TMP4:%.*]] = select <4 x i1> [[TMP3]], <4 x i1> [[TMP0]], <4 x i1> zeroinitializer
 ; CHECK-NEXT:    [[TMP5:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 2)
 ; CHECK-NEXT:    call void @llvm.masked.store.v4i64.p0(<4 x i64> [[TMP5]], ptr align 4 [[TMP1]], <4 x i1> [[TMP4]])
+; CHECK-NEXT:    br label %[[BB43]]
+; CHECK:       [[BB32]]:
 ; CHECK-NEXT:    [[TMP6:%.*]] = select <4 x i1> [[TMP3]], <4 x i1> [[BROADCAST_SPLAT]], <4 x i1> zeroinitializer
 ; CHECK-NEXT:    [[TMP7:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 3)
 ; CHECK-NEXT:    call void @llvm.masked.store.v4i64.p0(<4 x i64> [[TMP7]], ptr align 4 [[TMP1]], <4 x i1> [[TMP6]])
+; CHECK-NEXT:    br label %[[BB43]]
+; CHECK:       [[BB43]]:
 ; CHECK-NEXT:    [[TMP8:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 5)
 ; CHECK-NEXT:    call void @llvm.masked.store.v4i64.p0(<4 x i64> [[TMP8]], ptr align 4 [[TMP1]], <4 x i1> [[TMP2]])
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
@@ -999,19 +1023,25 @@ define void @uniform_branch_after_varying_branch_more_blocks_mirrored_no_phi(ptr
 ; CHECK-NEXT:    [[TMP0:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT]], splat (i1 true)
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[BB53:.*]] ]
+; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[BB53]] ]
 ; CHECK-NEXT:    [[TMP1:%.*]] = getelementptr i64, ptr [[A]], i64 [[INDEX]]
 ; CHECK-NEXT:    [[TMP2:%.*]] = icmp sle <4 x i64> [[VEC_IND]], zeroinitializer
 ; CHECK-NEXT:    [[TMP3:%.*]] = xor <4 x i1> [[TMP2]], splat (i1 true)
 ; CHECK-NEXT:    [[TMP4:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 1)
 ; CHECK-NEXT:    call void @llvm.masked.store.v4i64.p0(<4 x i64> [[TMP4]], ptr align 4 [[TMP1]], <4 x i1> [[TMP3]])
+; CHECK-NEXT:    br i1 [[U2]], label %[[BB42:.*]], label %[[BB31:.*]]
+; CHECK:       [[BB31]]:
 ; CHECK-NEXT:    [[TMP5:%.*]] = select <4 x i1> [[TMP2]], <4 x i1> [[TMP0]], <4 x i1> zeroinitializer
 ; CHECK-NEXT:    [[TMP6:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 3)
 ; CHECK-NEXT:    call void @llvm.masked.store.v4i64.p0(<4 x i64> [[TMP6]], ptr align 4 [[TMP1]], <4 x i1> [[TMP5]])
+; CHECK-NEXT:    br label %[[BB53]]
+; CHECK:       [[BB42]]:
 ; CHECK-NEXT:    [[TMP7:%.*]] = select <4 x i1> [[TMP2]], <4 x i1> [[BROADCAST_SPLAT]], <4 x i1> zeroinitializer
 ; CHECK-NEXT:    [[TMP8:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 4)
 ; CHECK-NEXT:    call void @llvm.masked.store.v4i64.p0(<4 x i64> [[TMP8]], ptr align 4 [[TMP1]], <4 x i1> [[TMP7]])
+; CHECK-NEXT:    br label %[[BB53]]
+; CHECK:       [[BB53]]:
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
 ; CHECK-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[VEC_IND]], splat (i64 4)
 ; CHECK-NEXT:    [[TMP9:%.*]] = icmp eq i64 [[INDEX_NEXT]], 128
@@ -2049,17 +2079,23 @@ define void @uniform_branch_shared_join_with_varying_no_phi(ptr %a, i1 %u0) {
 ; CHECK-NEXT:    [[TMP0:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT]], splat (i1 true)
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[BB43:.*]] ]
+; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[BB43]] ]
 ; CHECK-NEXT:    [[TMP1:%.*]] = getelementptr i64, ptr [[A]], i64 [[INDEX]]
+; CHECK-NEXT:    br i1 [[U0]], label %[[BB22:.*]], label %[[BB11:.*]]
+; CHECK:       [[BB11]]:
 ; CHECK-NEXT:    [[TMP2:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 1)
 ; CHECK-NEXT:    call void @llvm.masked.store.v4i64.p0(<4 x i64> [[TMP2]], ptr align 4 [[TMP1]], <4 x i1> [[TMP0]])
+; CHECK-NEXT:    br label %[[BB43]]
+; CHECK:       [[BB22]]:
 ; CHECK-NEXT:    [[TMP3:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 2)
 ; CHECK-NEXT:    call void @llvm.masked.store.v4i64.p0(<4 x i64> [[TMP3]], ptr align 4 [[TMP1]], <4 x i1> [[BROADCAST_SPLAT]])
 ; CHECK-NEXT:    [[TMP4:%.*]] = icmp sle <4 x i64> [[VEC_IND]], splat (i64 2)
 ; CHECK-NEXT:    [[TMP5:%.*]] = select <4 x i1> [[BROADCAST_SPLAT]], <4 x i1> [[TMP4]], <4 x i1> zeroinitializer
 ; CHECK-NEXT:    [[TMP6:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 3)
 ; CHECK-NEXT:    call void @llvm.masked.store.v4i64.p0(<4 x i64> [[TMP6]], ptr align 4 [[TMP1]], <4 x i1> [[TMP5]])
+; CHECK-NEXT:    br label %[[BB43]]
+; CHECK:       [[BB43]]:
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
 ; CHECK-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[VEC_IND]], splat (i64 4)
 ; CHECK-NEXT:    [[TMP7:%.*]] = icmp eq i64 [[INDEX_NEXT]], 128

--- a/llvm/test/Transforms/LoopVectorize/predicator.ll
+++ b/llvm/test/Transforms/LoopVectorize/predicator.ll
@@ -89,11 +89,15 @@ define void @blend_masks(ptr noalias %p, i1 %c0, i1 %c1, i1 %c3, i1 %c4, i1 %c6)
 ; CHECK-NEXT:    [[BROADCAST_SPLAT6:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT5]], <4 x i1> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT7:%.*]] = insertelement <4 x i1> poison, i1 [[C0]], i64 0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT8:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT7]], <4 x i1> poison, <4 x i32> zeroinitializer
+; CHECK-NEXT:    [[TMP9:%.*]] = freeze i1 [[C1]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = select <4 x i1> [[BROADCAST_SPLAT8]], <4 x i1> [[BROADCAST_SPLAT6]], <4 x i1> zeroinitializer
+; CHECK-NEXT:    [[TMP21:%.*]] = freeze i1 [[C3]]
 ; CHECK-NEXT:    [[TMP6:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT]], splat (i1 true)
 ; CHECK-NEXT:    [[TMP1:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT6]], splat (i1 true)
 ; CHECK-NEXT:    [[TMP3:%.*]] = select <4 x i1> [[BROADCAST_SPLAT8]], <4 x i1> [[TMP1]], <4 x i1> zeroinitializer
+; CHECK-NEXT:    [[TMP22:%.*]] = freeze i1 [[C4]]
 ; CHECK-NEXT:    [[TMP13:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT4]], splat (i1 true)
+; CHECK-NEXT:    [[TMP8:%.*]] = freeze i1 [[C6]]
 ; CHECK-NEXT:    [[TMP7:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT8]], splat (i1 true)
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT8:%.*]] = insertelement <4 x i1> poison, i1 [[C6]], i64 0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT9:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT8]], <4 x i1> poison, <4 x i32> zeroinitializer
@@ -104,17 +108,17 @@ define void @blend_masks(ptr noalias %p, i1 %c0, i1 %c1, i1 %c3, i1 %c4, i1 %c6)
 ; CHECK:       [[BB29]]:
 ; CHECK-NEXT:    br label %[[BB612:.*]]
 ; CHECK:       [[BB110]]:
-; CHECK-NEXT:    br i1 [[C1]], label %[[BB313:.*]], label %[[BB411:.*]]
+; CHECK-NEXT:    br i1 [[TMP9]], label %[[BB313:.*]], label %[[BB411:.*]]
 ; CHECK:       [[BB411]]:
-; CHECK-NEXT:    br i1 [[C4]], label %[[BB514:.*]], label %[[BB612]]
+; CHECK-NEXT:    br i1 [[TMP22]], label %[[BB514:.*]], label %[[BB612]]
 ; CHECK:       [[BB612]]:
 ; CHECK-NEXT:    [[TMP2:%.*]] = phi <4 x i1> [ zeroinitializer, %[[BB29]] ], [ [[TMP3]], %[[BB411]] ]
 ; CHECK-NEXT:    [[TMP0:%.*]] = phi <4 x i1> [ [[TMP7]], %[[BB29]] ], [ zeroinitializer, %[[BB411]] ]
 ; CHECK-NEXT:    [[TMP14:%.*]] = select <4 x i1> [[TMP2]], <4 x i1> [[TMP13]], <4 x i1> zeroinitializer
 ; CHECK-NEXT:    [[TMP5:%.*]] = or <4 x i1> [[TMP14]], [[TMP0]]
-; CHECK-NEXT:    br i1 [[C6]], label %[[PRED_STORE_CONTINUE12:.*]], label %[[BB816]]
+; CHECK-NEXT:    br i1 [[TMP8]], label %[[PRED_STORE_CONTINUE12:.*]], label %[[BB816]]
 ; CHECK:       [[BB313]]:
-; CHECK-NEXT:    br i1 [[C3]], label %[[BB816]], label %[[BB514]]
+; CHECK-NEXT:    br i1 [[TMP21]], label %[[BB816]], label %[[BB514]]
 ; CHECK:       [[BB514]]:
 ; CHECK-NEXT:    [[TMP19:%.*]] = phi <4 x i1> [ [[TMP3]], %[[BB411]] ], [ zeroinitializer, %[[BB313]] ]
 ; CHECK-NEXT:    [[TMP20:%.*]] = phi <4 x i1> [ zeroinitializer, %[[BB411]] ], [ [[TMP4]], %[[BB313]] ]
@@ -204,6 +208,7 @@ define void @blend_masks_triangle_phi(ptr noalias %p, i1 %c0, i1 %c1) {
 ; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT]], <4 x i1> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT1:%.*]] = insertelement <4 x i1> poison, i1 [[C0]], i64 0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT2:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT1]], <4 x i1> poison, <4 x i32> zeroinitializer
+; CHECK-NEXT:    [[TMP6:%.*]] = freeze i1 [[C1]]
 ; CHECK-NEXT:    [[TMP0:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT]], splat (i1 true)
 ; CHECK-NEXT:    [[TMP5:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT2]], splat (i1 true)
 ; CHECK-NEXT:    [[TMP3:%.*]] = select <4 x i1> [[TMP5]], <4 x i1> splat (i1 true), <4 x i1> [[TMP0]]
@@ -212,7 +217,7 @@ define void @blend_masks_triangle_phi(ptr noalias %p, i1 %c0, i1 %c1) {
 ; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[BB35:.*]] ]
 ; CHECK-NEXT:    br i1 [[C0]], label %[[BB13:.*]], label %[[BB24:.*]]
 ; CHECK:       [[BB13]]:
-; CHECK-NEXT:    br i1 [[C1]], label %[[BB35]], label %[[BB24]]
+; CHECK-NEXT:    br i1 [[TMP6]], label %[[BB35]], label %[[BB24]]
 ; CHECK:       [[BB24]]:
 ; CHECK-NEXT:    br label %[[BB35]]
 ; CHECK:       [[BB35]]:
@@ -269,6 +274,8 @@ define void @simplifiable_blend(i1 %c1, i1 %c2, i1 %c3, i32 %x, i32 %y, ptr %p) 
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    br label %[[VECTOR_PH:.*]]
 ; CHECK:       [[VECTOR_PH]]:
+; CHECK-NEXT:    [[TMP2:%.*]] = freeze i1 [[C2]]
+; CHECK-NEXT:    [[TMP1:%.*]] = freeze i1 [[C3]]
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <4 x i1> poison, i1 [[C1]], i64 0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT]], <4 x i1> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT1:%.*]] = insertelement <4 x i32> poison, i32 [[X]], i64 0
@@ -280,13 +287,13 @@ define void @simplifiable_blend(i1 %c1, i1 %c2, i1 %c3, i32 %x, i32 %y, ptr %p) 
 ; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LATCH11:.*]] ]
 ; CHECK-NEXT:    br i1 [[C1]], label %[[A8:.*]], label %[[B5:.*]]
 ; CHECK:       [[B5]]:
-; CHECK-NEXT:    br i1 [[C3]], label %[[F7:.*]], label %[[E6:.*]]
+; CHECK-NEXT:    br i1 [[TMP1]], label %[[F7:.*]], label %[[E6:.*]]
 ; CHECK:       [[E6]]:
 ; CHECK-NEXT:    br label %[[F7]]
 ; CHECK:       [[F7]]:
 ; CHECK-NEXT:    br label %[[LATCH11]]
 ; CHECK:       [[A8]]:
-; CHECK-NEXT:    br i1 [[C2]], label %[[C10:.*]], label %[[D9:.*]]
+; CHECK-NEXT:    br i1 [[TMP2]], label %[[C10:.*]], label %[[D9:.*]]
 ; CHECK:       [[D9]]:
 ; CHECK-NEXT:    br label %[[LATCH11]]
 ; CHECK:       [[C10]]:
@@ -514,6 +521,7 @@ define void @uniform_branch_after_varying_branch(ptr %a, i1 %u1) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    br label %[[VECTOR_PH:.*]]
 ; CHECK:       [[VECTOR_PH]]:
+; CHECK-NEXT:    [[TMP0:%.*]] = freeze i1 [[U1]]
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <4 x i1> poison, i1 [[U1]], i64 0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT]], <4 x i1> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
@@ -522,7 +530,7 @@ define void @uniform_branch_after_varying_branch(ptr %a, i1 %u1) {
 ; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[BB32]] ]
 ; CHECK-NEXT:    [[TMP1:%.*]] = icmp sle <4 x i64> [[VEC_IND]], zeroinitializer
 ; CHECK-NEXT:    [[TMP2:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 1)
-; CHECK-NEXT:    br i1 [[U1]], label %[[BB21:.*]], label %[[BB32]]
+; CHECK-NEXT:    br i1 [[TMP0]], label %[[BB21:.*]], label %[[BB32]]
 ; CHECK:       [[BB21]]:
 ; CHECK-NEXT:    [[TMP3:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 2)
 ; CHECK-NEXT:    br label %[[BB32]]
@@ -595,6 +603,7 @@ define void @uniform_branch_after_varying_branch_more_blocks(ptr %a, i1 %u1) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    br label %[[VECTOR_PH:.*]]
 ; CHECK:       [[VECTOR_PH]]:
+; CHECK-NEXT:    [[TMP0:%.*]] = freeze i1 [[U1]]
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <4 x i1> poison, i1 [[U1]], i64 0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT]], <4 x i1> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
@@ -602,7 +611,7 @@ define void @uniform_branch_after_varying_branch_more_blocks(ptr %a, i1 %u1) {
 ; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[BB43:.*]] ]
 ; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[BB43]] ]
 ; CHECK-NEXT:    [[TMP1:%.*]] = icmp sle <4 x i64> [[VEC_IND]], zeroinitializer
-; CHECK-NEXT:    br i1 [[U1]], label %[[BB32:.*]], label %[[BB21:.*]]
+; CHECK-NEXT:    br i1 [[TMP0]], label %[[BB32:.*]], label %[[BB21:.*]]
 ; CHECK:       [[BB21]]:
 ; CHECK-NEXT:    [[TMP2:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 2)
 ; CHECK-NEXT:    br label %[[BB43]]
@@ -684,6 +693,7 @@ define void @uniform_branch_after_varying_branch_more_blocks_mirrored(ptr %a, i1
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    br label %[[VECTOR_PH:.*]]
 ; CHECK:       [[VECTOR_PH]]:
+; CHECK-NEXT:    [[TMP0:%.*]] = freeze i1 [[U2]]
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <4 x i1> poison, i1 [[U2]], i64 0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT]], <4 x i1> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
@@ -692,7 +702,7 @@ define void @uniform_branch_after_varying_branch_more_blocks_mirrored(ptr %a, i1
 ; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[BB53]] ]
 ; CHECK-NEXT:    [[TMP1:%.*]] = icmp sle <4 x i64> [[VEC_IND]], zeroinitializer
 ; CHECK-NEXT:    [[TMP2:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 1)
-; CHECK-NEXT:    br i1 [[U2]], label %[[BB42:.*]], label %[[BB31:.*]]
+; CHECK-NEXT:    br i1 [[TMP0]], label %[[BB42:.*]], label %[[BB31:.*]]
 ; CHECK:       [[BB31]]:
 ; CHECK-NEXT:    [[TMP3:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 3)
 ; CHECK-NEXT:    br label %[[BB53]]
@@ -1359,6 +1369,7 @@ define void @unstructured_uniform_only(ptr %a, i1 %u0, i1 %u2) {
 ; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT]], <4 x i1> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT1:%.*]] = insertelement <4 x i1> poison, i1 [[U0]], i64 0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT2:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT1]], <4 x i1> poison, <4 x i32> zeroinitializer
+; CHECK-NEXT:    [[TMP0:%.*]] = freeze i1 [[U2]]
 ; CHECK-NEXT:    [[TMP1:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT]], splat (i1 true)
 ; CHECK-NEXT:    [[TMP3:%.*]] = select <4 x i1> [[BROADCAST_SPLAT2]], <4 x i1> [[TMP1]], <4 x i1> zeroinitializer
 ; CHECK-NEXT:    [[TMP2:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT2]], splat (i1 true)
@@ -1372,7 +1383,7 @@ define void @unstructured_uniform_only(ptr %a, i1 %u0, i1 %u2) {
 ; CHECK-NEXT:    br label %[[BB35:.*]]
 ; CHECK:       [[BB24]]:
 ; CHECK-NEXT:    [[TMP5:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 2)
-; CHECK-NEXT:    br i1 [[U2]], label %[[BB46:.*]], label %[[BB35]]
+; CHECK-NEXT:    br i1 [[TMP0]], label %[[BB46:.*]], label %[[BB35]]
 ; CHECK:       [[BB35]]:
 ; CHECK-NEXT:    [[TMP10:%.*]] = phi <4 x i64> [ [[TMP4]], %[[MIDDLE_BLOCK]] ], [ poison, %[[BB24]] ]
 ; CHECK-NEXT:    [[TMP6:%.*]] = phi <4 x i64> [ poison, %[[MIDDLE_BLOCK]] ], [ [[TMP5]], %[[BB24]] ]
@@ -1454,6 +1465,8 @@ define void @unstructured_uniform_only_sese_region(ptr %a, i1 %u1, i1 %u3) {
 ; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT]], <4 x i1> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT1:%.*]] = insertelement <4 x i1> poison, i1 [[U1]], i64 0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT2:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT1]], <4 x i1> poison, <4 x i32> zeroinitializer
+; CHECK-NEXT:    [[TMP2:%.*]] = freeze i1 [[U1]]
+; CHECK-NEXT:    [[TMP24:%.*]] = freeze i1 [[U3]]
 ; CHECK-NEXT:    [[TMP1:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT]], splat (i1 true)
 ; CHECK-NEXT:    [[TMP0:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT2]], splat (i1 true)
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
@@ -1461,7 +1474,7 @@ define void @unstructured_uniform_only_sese_region(ptr %a, i1 %u1, i1 %u3) {
 ; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[BB77:.*]] ]
 ; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[BB77]] ]
 ; CHECK-NEXT:    [[TMP3:%.*]] = icmp sgt <4 x i64> [[VEC_IND]], zeroinitializer
-; CHECK-NEXT:    br i1 [[U1]], label %[[BB34:.*]], label %[[BB23:.*]]
+; CHECK-NEXT:    br i1 [[TMP2]], label %[[BB34:.*]], label %[[BB23:.*]]
 ; CHECK:       [[BB23]]:
 ; CHECK-NEXT:    [[TMP4:%.*]] = select <4 x i1> [[TMP3]], <4 x i1> [[TMP0]], <4 x i1> zeroinitializer
 ; CHECK-NEXT:    [[TMP5:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 2)
@@ -1469,7 +1482,7 @@ define void @unstructured_uniform_only_sese_region(ptr %a, i1 %u1, i1 %u3) {
 ; CHECK:       [[BB34]]:
 ; CHECK-NEXT:    [[TMP6:%.*]] = select <4 x i1> [[TMP3]], <4 x i1> [[BROADCAST_SPLAT2]], <4 x i1> zeroinitializer
 ; CHECK-NEXT:    [[TMP7:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 3)
-; CHECK-NEXT:    br i1 [[U3]], label %[[BB56:.*]], label %[[BB45]]
+; CHECK-NEXT:    br i1 [[TMP24]], label %[[BB56:.*]], label %[[BB45]]
 ; CHECK:       [[BB45]]:
 ; CHECK-NEXT:    [[TMP19:%.*]] = phi <4 x i64> [ [[TMP5]], %[[BB23]] ], [ poison, %[[BB34]] ]
 ; CHECK-NEXT:    [[TMP8:%.*]] = phi <4 x i64> [ poison, %[[BB23]] ], [ [[TMP7]], %[[BB34]] ]

--- a/llvm/test/Transforms/LoopVectorize/predicator.ll
+++ b/llvm/test/Transforms/LoopVectorize/predicator.ll
@@ -83,36 +83,58 @@ define void @blend_masks(ptr noalias %p, i1 %c0, i1 %c1, i1 %c3, i1 %c4, i1 %c6)
 ; CHECK:       [[VECTOR_PH]]:
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <4 x i1> poison, i1 [[C3]], i64 0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT]], <4 x i1> poison, <4 x i32> zeroinitializer
-; CHECK-NEXT:    [[BROADCAST_SPLATINSERT1:%.*]] = insertelement <4 x i1> poison, i1 [[C6]], i64 0
-; CHECK-NEXT:    [[BROADCAST_SPLAT2:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT1]], <4 x i1> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT3:%.*]] = insertelement <4 x i1> poison, i1 [[C4]], i64 0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT4:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT3]], <4 x i1> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT5:%.*]] = insertelement <4 x i1> poison, i1 [[C1]], i64 0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT6:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT5]], <4 x i1> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT7:%.*]] = insertelement <4 x i1> poison, i1 [[C0]], i64 0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT8:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT7]], <4 x i1> poison, <4 x i32> zeroinitializer
-; CHECK-NEXT:    [[TMP0:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT8]], splat (i1 true)
+; CHECK-NEXT:    [[TMP4:%.*]] = select <4 x i1> [[BROADCAST_SPLAT8]], <4 x i1> [[BROADCAST_SPLAT6]], <4 x i1> zeroinitializer
+; CHECK-NEXT:    [[TMP6:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT]], splat (i1 true)
 ; CHECK-NEXT:    [[TMP1:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT6]], splat (i1 true)
-; CHECK-NEXT:    [[TMP2:%.*]] = select <4 x i1> [[BROADCAST_SPLAT8]], <4 x i1> [[TMP1]], <4 x i1> zeroinitializer
-; CHECK-NEXT:    [[TMP6:%.*]] = select <4 x i1> [[BROADCAST_SPLAT8]], <4 x i1> [[BROADCAST_SPLAT6]], <4 x i1> zeroinitializer
-; CHECK-NEXT:    [[TMP7:%.*]] = select <4 x i1> [[TMP2]], <4 x i1> [[BROADCAST_SPLAT4]], <4 x i1> zeroinitializer
-; CHECK-NEXT:    [[TMP8:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT]], splat (i1 true)
-; CHECK-NEXT:    [[TMP9:%.*]] = select <4 x i1> [[TMP6]], <4 x i1> [[TMP8]], <4 x i1> zeroinitializer
-; CHECK-NEXT:    [[TMP10:%.*]] = or <4 x i1> [[TMP7]], [[TMP9]]
+; CHECK-NEXT:    [[TMP3:%.*]] = select <4 x i1> [[BROADCAST_SPLAT8]], <4 x i1> [[TMP1]], <4 x i1> zeroinitializer
 ; CHECK-NEXT:    [[TMP13:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT4]], splat (i1 true)
+; CHECK-NEXT:    [[TMP7:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT8]], splat (i1 true)
+; CHECK-NEXT:    [[BROADCAST_SPLATINSERT8:%.*]] = insertelement <4 x i1> poison, i1 [[C6]], i64 0
+; CHECK-NEXT:    [[BROADCAST_SPLAT9:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT8]], <4 x i1> poison, <4 x i32> zeroinitializer
+; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
+; CHECK:       [[VECTOR_BODY]]:
+; CHECK-NEXT:    [[TMP26:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[BB816:.*]] ]
+; CHECK-NEXT:    br i1 [[C0]], label %[[BB110:.*]], label %[[BB29:.*]]
+; CHECK:       [[BB29]]:
+; CHECK-NEXT:    br label %[[BB612:.*]]
+; CHECK:       [[BB110]]:
+; CHECK-NEXT:    br i1 [[C1]], label %[[BB313:.*]], label %[[BB411:.*]]
+; CHECK:       [[BB411]]:
+; CHECK-NEXT:    br i1 [[C4]], label %[[BB514:.*]], label %[[BB612]]
+; CHECK:       [[BB612]]:
+; CHECK-NEXT:    [[TMP2:%.*]] = phi <4 x i1> [ zeroinitializer, %[[BB29]] ], [ [[TMP3]], %[[BB411]] ]
+; CHECK-NEXT:    [[TMP0:%.*]] = phi <4 x i1> [ [[TMP7]], %[[BB29]] ], [ zeroinitializer, %[[BB411]] ]
 ; CHECK-NEXT:    [[TMP14:%.*]] = select <4 x i1> [[TMP2]], <4 x i1> [[TMP13]], <4 x i1> zeroinitializer
 ; CHECK-NEXT:    [[TMP5:%.*]] = or <4 x i1> [[TMP14]], [[TMP0]]
-; CHECK-NEXT:    [[TMP11:%.*]] = select <4 x i1> [[TMP5]], <4 x i1> [[BROADCAST_SPLAT2]], <4 x i1> zeroinitializer
+; CHECK-NEXT:    br i1 [[C6]], label %[[PRED_STORE_CONTINUE12:.*]], label %[[BB816]]
+; CHECK:       [[BB313]]:
+; CHECK-NEXT:    br i1 [[C3]], label %[[BB816]], label %[[BB514]]
+; CHECK:       [[BB514]]:
+; CHECK-NEXT:    [[TMP19:%.*]] = phi <4 x i1> [ [[TMP3]], %[[BB411]] ], [ zeroinitializer, %[[BB313]] ]
+; CHECK-NEXT:    [[TMP20:%.*]] = phi <4 x i1> [ zeroinitializer, %[[BB411]] ], [ [[TMP4]], %[[BB313]] ]
+; CHECK-NEXT:    [[TMP11:%.*]] = select <4 x i1> [[TMP19]], <4 x i1> [[BROADCAST_SPLAT4]], <4 x i1> zeroinitializer
+; CHECK-NEXT:    [[TMP10:%.*]] = select <4 x i1> [[TMP20]], <4 x i1> [[TMP6]], <4 x i1> zeroinitializer
 ; CHECK-NEXT:    [[TMP12:%.*]] = or <4 x i1> [[TMP11]], [[TMP10]]
-; CHECK-NEXT:    [[PREDPHI:%.*]] = select <4 x i1> [[TMP5]], <4 x i32> splat (i32 1), <4 x i32> zeroinitializer
-; CHECK-NEXT:    br label %[[PRED_STORE_CONTINUE12:.*]]
+; CHECK-NEXT:    br label %[[PRED_STORE_CONTINUE12]]
 ; CHECK:       [[PRED_STORE_CONTINUE12]]:
-; CHECK-NEXT:    [[TMP26:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE12]] ]
+; CHECK-NEXT:    [[TMP15:%.*]] = phi <4 x i1> [ zeroinitializer, %[[BB514]] ], [ [[TMP5]], %[[BB612]] ]
+; CHECK-NEXT:    [[TMP16:%.*]] = phi <4 x i1> [ [[TMP12]], %[[BB514]] ], [ zeroinitializer, %[[BB612]] ]
+; CHECK-NEXT:    [[TMP17:%.*]] = select <4 x i1> [[TMP15]], <4 x i1> [[BROADCAST_SPLAT9]], <4 x i1> zeroinitializer
+; CHECK-NEXT:    [[TMP18:%.*]] = or <4 x i1> [[TMP17]], [[TMP16]]
+; CHECK-NEXT:    [[PREDPHI:%.*]] = select <4 x i1> [[TMP15]], <4 x i32> splat (i32 1), <4 x i32> zeroinitializer
 ; CHECK-NEXT:    [[TMP27:%.*]] = getelementptr i32, ptr [[P]], i32 [[TMP26]]
-; CHECK-NEXT:    call void @llvm.masked.store.v4i32.p0(<4 x i32> [[PREDPHI]], ptr align 4 [[TMP27]], <4 x i1> [[TMP12]])
+; CHECK-NEXT:    call void @llvm.masked.store.v4i32.p0(<4 x i32> [[PREDPHI]], ptr align 4 [[TMP27]], <4 x i1> [[TMP18]])
+; CHECK-NEXT:    br label %[[BB816]]
+; CHECK:       [[BB816]]:
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i32 [[TMP26]], 4
 ; CHECK-NEXT:    [[TMP29:%.*]] = icmp eq i32 [[INDEX_NEXT]], 128
-; CHECK-NEXT:    br i1 [[TMP29]], label %[[MIDDLE_BLOCK:.*]], label %[[PRED_STORE_CONTINUE12]], !llvm.loop [[LOOP3:![0-9]+]]
+; CHECK-NEXT:    br i1 [[TMP29]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP3:![0-9]+]]
 ; CHECK:       [[MIDDLE_BLOCK]]:
 ; CHECK-NEXT:    br label %[[EXIT:.*]]
 ; CHECK:       [[EXIT]]:
@@ -185,10 +207,17 @@ define void @blend_masks_triangle_phi(ptr noalias %p, i1 %c0, i1 %c1) {
 ; CHECK-NEXT:    [[TMP0:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT]], splat (i1 true)
 ; CHECK-NEXT:    [[TMP5:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT2]], splat (i1 true)
 ; CHECK-NEXT:    [[TMP3:%.*]] = select <4 x i1> [[TMP5]], <4 x i1> splat (i1 true), <4 x i1> [[TMP0]]
-; CHECK-NEXT:    [[PREDPHI:%.*]] = select <4 x i1> [[TMP3]], <4 x i32> splat (i32 1), <4 x i32> zeroinitializer
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[BB35:.*]] ]
+; CHECK-NEXT:    br i1 [[C0]], label %[[BB13:.*]], label %[[BB24:.*]]
+; CHECK:       [[BB13]]:
+; CHECK-NEXT:    br i1 [[C1]], label %[[BB35]], label %[[BB24]]
+; CHECK:       [[BB24]]:
+; CHECK-NEXT:    br label %[[BB35]]
+; CHECK:       [[BB35]]:
+; CHECK-NEXT:    [[TMP4:%.*]] = phi <4 x i1> [ zeroinitializer, %[[BB13]] ], [ [[TMP3]], %[[BB24]] ]
+; CHECK-NEXT:    [[PREDPHI:%.*]] = select <4 x i1> [[TMP4]], <4 x i32> splat (i32 1), <4 x i32> zeroinitializer
 ; CHECK-NEXT:    [[TMP1:%.*]] = getelementptr i32, ptr [[P]], i32 [[INDEX]]
 ; CHECK-NEXT:    store <4 x i32> [[PREDPHI]], ptr [[TMP1]], align 4
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i32 [[INDEX]], 4
@@ -240,14 +269,31 @@ define void @simplifiable_blend(i1 %c1, i1 %c2, i1 %c3, i32 %x, i32 %y, ptr %p) 
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    br label %[[VECTOR_PH:.*]]
 ; CHECK:       [[VECTOR_PH]]:
-; CHECK-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <4 x i32> poison, i32 [[Y]], i64 0
-; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i32> [[BROADCAST_SPLATINSERT]], <4 x i32> poison, <4 x i32> zeroinitializer
+; CHECK-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <4 x i1> poison, i1 [[C1]], i64 0
+; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT]], <4 x i1> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT1:%.*]] = insertelement <4 x i32> poison, i32 [[X]], i64 0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT2:%.*]] = shufflevector <4 x i32> [[BROADCAST_SPLATINSERT1]], <4 x i32> poison, <4 x i32> zeroinitializer
-; CHECK-NEXT:    [[PREDPHI7:%.*]] = select i1 [[C1]], <4 x i32> [[BROADCAST_SPLAT2]], <4 x i32> [[BROADCAST_SPLAT]]
+; CHECK-NEXT:    [[BROADCAST_SPLATINSERT3:%.*]] = insertelement <4 x i32> poison, i32 [[Y]], i64 0
+; CHECK-NEXT:    [[BROADCAST_SPLAT4:%.*]] = shufflevector <4 x i32> [[BROADCAST_SPLATINSERT3]], <4 x i32> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LATCH11:.*]] ]
+; CHECK-NEXT:    br i1 [[C1]], label %[[A8:.*]], label %[[B5:.*]]
+; CHECK:       [[B5]]:
+; CHECK-NEXT:    br i1 [[C3]], label %[[F7:.*]], label %[[E6:.*]]
+; CHECK:       [[E6]]:
+; CHECK-NEXT:    br label %[[F7]]
+; CHECK:       [[F7]]:
+; CHECK-NEXT:    br label %[[LATCH11]]
+; CHECK:       [[A8]]:
+; CHECK-NEXT:    br i1 [[C2]], label %[[C10:.*]], label %[[D9:.*]]
+; CHECK:       [[D9]]:
+; CHECK-NEXT:    br label %[[LATCH11]]
+; CHECK:       [[C10]]:
+; CHECK-NEXT:    br label %[[LATCH11]]
+; CHECK:       [[LATCH11]]:
+; CHECK-NEXT:    [[TMP0:%.*]] = phi <4 x i1> [ zeroinitializer, %[[F7]] ], [ [[BROADCAST_SPLAT]], %[[D9]] ], [ [[BROADCAST_SPLAT]], %[[C10]] ]
+; CHECK-NEXT:    [[PREDPHI7:%.*]] = select <4 x i1> [[TMP0]], <4 x i32> [[BROADCAST_SPLAT2]], <4 x i32> [[BROADCAST_SPLAT4]]
 ; CHECK-NEXT:    [[TMP3:%.*]] = getelementptr i32, ptr [[P]], i32 [[INDEX]]
 ; CHECK-NEXT:    store <4 x i32> [[PREDPHI7]], ptr [[TMP3]], align 4
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i32 [[INDEX]], 4
@@ -301,23 +347,31 @@ define void @outermost_uniform_branch(ptr %a, i1 %u0) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    br label %[[VECTOR_PH:.*]]
 ; CHECK:       [[VECTOR_PH]]:
+; CHECK-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <4 x i1> poison, i1 [[U0]], i64 0
+; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT]], <4 x i1> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
-; CHECK-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[VEC_IND]], splat (i64 4)
-; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq i64 [[INDEX_NEXT]], 128
-; CHECK-NEXT:    br i1 [[TMP0]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP6:![0-9]+]]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[BB42:.*]] ]
+; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[BB42]] ]
+; CHECK-NEXT:    br i1 [[U0]], label %[[MIDDLE_BLOCK:.*]], label %[[BB42]]
 ; CHECK:       [[MIDDLE_BLOCK]]:
 ; CHECK-NEXT:    [[TMP1:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 1)
 ; CHECK-NEXT:    [[TMP2:%.*]] = icmp sle <4 x i64> [[VEC_IND]], splat (i64 1)
 ; CHECK-NEXT:    [[TMP3:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 2)
 ; CHECK-NEXT:    [[PREDPHI:%.*]] = select <4 x i1> [[TMP2]], <4 x i64> [[TMP3]], <4 x i64> [[TMP1]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = add <4 x i64> [[PREDPHI]], splat (i64 3)
-; CHECK-NEXT:    [[PREDPHI1:%.*]] = select i1 [[U0]], <4 x i64> [[TMP4]], <4 x i64> [[VEC_IND]]
+; CHECK-NEXT:    br label %[[BB42]]
+; CHECK:       [[BB42]]:
+; CHECK-NEXT:    [[TMP6:%.*]] = phi <4 x i64> [ poison, %[[VECTOR_BODY]] ], [ [[TMP4]], %[[MIDDLE_BLOCK]] ]
+; CHECK-NEXT:    [[TMP8:%.*]] = phi <4 x i1> [ zeroinitializer, %[[VECTOR_BODY]] ], [ [[BROADCAST_SPLAT]], %[[MIDDLE_BLOCK]] ]
+; CHECK-NEXT:    [[PREDPHI1:%.*]] = select <4 x i1> [[TMP8]], <4 x i64> [[TMP6]], <4 x i64> [[VEC_IND]]
 ; CHECK-NEXT:    [[TMP5:%.*]] = extractelement <4 x i64> [[PREDPHI1]], i64 3
 ; CHECK-NEXT:    store i64 [[TMP5]], ptr [[A]], align 4
+; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
+; CHECK-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[VEC_IND]], splat (i64 4)
+; CHECK-NEXT:    [[TMP7:%.*]] = icmp eq i64 [[INDEX_NEXT]], 128
+; CHECK-NEXT:    br i1 [[TMP7]], label %[[MIDDLE_BLOCK1:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP6:![0-9]+]]
+; CHECK:       [[MIDDLE_BLOCK1]]:
 ; CHECK-NEXT:    br label %[[EXIT:.*]]
 ; CHECK:       [[EXIT]]:
 ; CHECK-NEXT:    ret void
@@ -371,24 +425,35 @@ define void @outermost_uniform_branch_more_blocks(ptr %a, i1 %u0) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    br label %[[VECTOR_PH:.*]]
 ; CHECK:       [[VECTOR_PH]]:
+; CHECK-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <4 x i1> poison, i1 [[U0]], i64 0
+; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT]], <4 x i1> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
-; CHECK-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[VEC_IND]], splat (i64 4)
-; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq i64 [[INDEX_NEXT]], 128
-; CHECK-NEXT:    br i1 [[TMP0]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP7:![0-9]+]]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[BB63:.*]] ]
+; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[BB63]] ]
+; CHECK-NEXT:    br i1 [[U0]], label %[[BB22:.*]], label %[[MIDDLE_BLOCK:.*]]
 ; CHECK:       [[MIDDLE_BLOCK]]:
 ; CHECK-NEXT:    [[TMP1:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 1)
+; CHECK-NEXT:    br label %[[BB63]]
+; CHECK:       [[BB22]]:
 ; CHECK-NEXT:    [[TMP2:%.*]] = icmp sle <4 x i64> [[VEC_IND]], splat (i64 2)
 ; CHECK-NEXT:    [[TMP3:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 3)
 ; CHECK-NEXT:    [[TMP4:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 4)
 ; CHECK-NEXT:    [[PREDPHI:%.*]] = select <4 x i1> [[TMP2]], <4 x i64> [[TMP4]], <4 x i64> [[TMP3]]
 ; CHECK-NEXT:    [[TMP5:%.*]] = add <4 x i64> [[PREDPHI]], splat (i64 5)
-; CHECK-NEXT:    [[PREDPHI1:%.*]] = select i1 [[U0]], <4 x i64> [[TMP5]], <4 x i64> [[TMP1]]
+; CHECK-NEXT:    br label %[[BB63]]
+; CHECK:       [[BB63]]:
+; CHECK-NEXT:    [[TMP8:%.*]] = phi <4 x i64> [ [[TMP1]], %[[MIDDLE_BLOCK]] ], [ poison, %[[BB22]] ]
+; CHECK-NEXT:    [[TMP10:%.*]] = phi <4 x i64> [ poison, %[[MIDDLE_BLOCK]] ], [ [[TMP5]], %[[BB22]] ]
+; CHECK-NEXT:    [[TMP7:%.*]] = phi <4 x i1> [ zeroinitializer, %[[MIDDLE_BLOCK]] ], [ [[BROADCAST_SPLAT]], %[[BB22]] ]
+; CHECK-NEXT:    [[PREDPHI1:%.*]] = select <4 x i1> [[TMP7]], <4 x i64> [[TMP10]], <4 x i64> [[TMP8]]
 ; CHECK-NEXT:    [[TMP6:%.*]] = extractelement <4 x i64> [[PREDPHI1]], i64 3
 ; CHECK-NEXT:    store i64 [[TMP6]], ptr [[A]], align 4
+; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
+; CHECK-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[VEC_IND]], splat (i64 4)
+; CHECK-NEXT:    [[TMP9:%.*]] = icmp eq i64 [[INDEX_NEXT]], 128
+; CHECK-NEXT:    br i1 [[TMP9]], label %[[MIDDLE_BLOCK1:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP7:![0-9]+]]
+; CHECK:       [[MIDDLE_BLOCK1]]:
 ; CHECK-NEXT:    br label %[[EXIT:.*]]
 ; CHECK:       [[EXIT]]:
 ; CHECK-NEXT:    ret void
@@ -449,24 +514,32 @@ define void @uniform_branch_after_varying_branch(ptr %a, i1 %u1) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    br label %[[VECTOR_PH:.*]]
 ; CHECK:       [[VECTOR_PH]]:
+; CHECK-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <4 x i1> poison, i1 [[U1]], i64 0
+; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT]], <4 x i1> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
-; CHECK-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[VEC_IND]], splat (i64 4)
-; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq i64 [[INDEX_NEXT]], 128
-; CHECK-NEXT:    br i1 [[TMP0]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP8:![0-9]+]]
-; CHECK:       [[MIDDLE_BLOCK]]:
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[BB32:.*]] ]
+; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[BB32]] ]
 ; CHECK-NEXT:    [[TMP1:%.*]] = icmp sle <4 x i64> [[VEC_IND]], zeroinitializer
 ; CHECK-NEXT:    [[TMP2:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 1)
+; CHECK-NEXT:    br i1 [[U1]], label %[[BB21:.*]], label %[[BB32]]
+; CHECK:       [[BB21]]:
 ; CHECK-NEXT:    [[TMP3:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 2)
-; CHECK-NEXT:    [[PREDPHI:%.*]] = select i1 [[U1]], <4 x i64> [[TMP3]], <4 x i64> [[TMP2]]
+; CHECK-NEXT:    br label %[[BB32]]
+; CHECK:       [[BB32]]:
+; CHECK-NEXT:    [[TMP7:%.*]] = phi <4 x i64> [ poison, %[[VECTOR_BODY]] ], [ [[TMP3]], %[[BB21]] ]
+; CHECK-NEXT:    [[TMP9:%.*]] = phi <4 x i1> [ zeroinitializer, %[[VECTOR_BODY]] ], [ [[BROADCAST_SPLAT]], %[[BB21]] ]
+; CHECK-NEXT:    [[PREDPHI:%.*]] = select <4 x i1> [[TMP9]], <4 x i64> [[TMP7]], <4 x i64> [[TMP2]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = add <4 x i64> [[PREDPHI]], splat (i64 3)
 ; CHECK-NEXT:    [[TMP5:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 4)
 ; CHECK-NEXT:    [[PREDPHI1:%.*]] = select <4 x i1> [[TMP1]], <4 x i64> [[TMP5]], <4 x i64> [[TMP4]]
 ; CHECK-NEXT:    [[TMP6:%.*]] = extractelement <4 x i64> [[PREDPHI1]], i64 3
 ; CHECK-NEXT:    store i64 [[TMP6]], ptr [[A]], align 4
+; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
+; CHECK-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[VEC_IND]], splat (i64 4)
+; CHECK-NEXT:    [[TMP8:%.*]] = icmp eq i64 [[INDEX_NEXT]], 128
+; CHECK-NEXT:    br i1 [[TMP8]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP8:![0-9]+]]
+; CHECK:       [[MIDDLE_BLOCK]]:
 ; CHECK-NEXT:    br label %[[EXIT:.*]]
 ; CHECK:       [[EXIT]]:
 ; CHECK-NEXT:    ret void
@@ -522,24 +595,35 @@ define void @uniform_branch_after_varying_branch_more_blocks(ptr %a, i1 %u1) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    br label %[[VECTOR_PH:.*]]
 ; CHECK:       [[VECTOR_PH]]:
+; CHECK-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <4 x i1> poison, i1 [[U1]], i64 0
+; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT]], <4 x i1> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
-; CHECK-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[VEC_IND]], splat (i64 4)
-; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq i64 [[INDEX_NEXT]], 128
-; CHECK-NEXT:    br i1 [[TMP0]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP9:![0-9]+]]
-; CHECK:       [[MIDDLE_BLOCK]]:
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[BB43:.*]] ]
+; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[BB43]] ]
 ; CHECK-NEXT:    [[TMP1:%.*]] = icmp sle <4 x i64> [[VEC_IND]], zeroinitializer
+; CHECK-NEXT:    br i1 [[U1]], label %[[BB32:.*]], label %[[BB21:.*]]
+; CHECK:       [[BB21]]:
 ; CHECK-NEXT:    [[TMP2:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 2)
+; CHECK-NEXT:    br label %[[BB43]]
+; CHECK:       [[BB32]]:
 ; CHECK-NEXT:    [[TMP3:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 3)
-; CHECK-NEXT:    [[PREDPHI:%.*]] = select i1 [[U1]], <4 x i64> [[TMP3]], <4 x i64> [[TMP2]]
+; CHECK-NEXT:    br label %[[BB43]]
+; CHECK:       [[BB43]]:
+; CHECK-NEXT:    [[TMP7:%.*]] = phi <4 x i64> [ [[TMP2]], %[[BB21]] ], [ poison, %[[BB32]] ]
+; CHECK-NEXT:    [[TMP8:%.*]] = phi <4 x i64> [ poison, %[[BB21]] ], [ [[TMP3]], %[[BB32]] ]
+; CHECK-NEXT:    [[TMP10:%.*]] = phi <4 x i1> [ zeroinitializer, %[[BB21]] ], [ [[BROADCAST_SPLAT]], %[[BB32]] ]
+; CHECK-NEXT:    [[PREDPHI:%.*]] = select <4 x i1> [[TMP10]], <4 x i64> [[TMP8]], <4 x i64> [[TMP7]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = add <4 x i64> [[PREDPHI]], splat (i64 4)
 ; CHECK-NEXT:    [[TMP5:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 5)
 ; CHECK-NEXT:    [[PREDPHI1:%.*]] = select <4 x i1> [[TMP1]], <4 x i64> [[TMP5]], <4 x i64> [[TMP4]]
 ; CHECK-NEXT:    [[TMP6:%.*]] = extractelement <4 x i64> [[PREDPHI1]], i64 3
 ; CHECK-NEXT:    store i64 [[TMP6]], ptr [[A]], align 4
+; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
+; CHECK-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[VEC_IND]], splat (i64 4)
+; CHECK-NEXT:    [[TMP9:%.*]] = icmp eq i64 [[INDEX_NEXT]], 128
+; CHECK-NEXT:    br i1 [[TMP9]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP9:![0-9]+]]
+; CHECK:       [[MIDDLE_BLOCK]]:
 ; CHECK-NEXT:    br label %[[EXIT:.*]]
 ; CHECK:       [[EXIT]]:
 ; CHECK-NEXT:    ret void
@@ -600,24 +684,35 @@ define void @uniform_branch_after_varying_branch_more_blocks_mirrored(ptr %a, i1
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    br label %[[VECTOR_PH:.*]]
 ; CHECK:       [[VECTOR_PH]]:
+; CHECK-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <4 x i1> poison, i1 [[U2]], i64 0
+; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT]], <4 x i1> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
-; CHECK-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[VEC_IND]], splat (i64 4)
-; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq i64 [[INDEX_NEXT]], 128
-; CHECK-NEXT:    br i1 [[TMP0]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP10:![0-9]+]]
-; CHECK:       [[MIDDLE_BLOCK]]:
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[BB53:.*]] ]
+; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[BB53]] ]
 ; CHECK-NEXT:    [[TMP1:%.*]] = icmp sle <4 x i64> [[VEC_IND]], zeroinitializer
 ; CHECK-NEXT:    [[TMP2:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 1)
+; CHECK-NEXT:    br i1 [[U2]], label %[[BB42:.*]], label %[[BB31:.*]]
+; CHECK:       [[BB31]]:
 ; CHECK-NEXT:    [[TMP3:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 3)
+; CHECK-NEXT:    br label %[[BB53]]
+; CHECK:       [[BB42]]:
 ; CHECK-NEXT:    [[TMP4:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 4)
-; CHECK-NEXT:    [[PREDPHI:%.*]] = select i1 [[U2]], <4 x i64> [[TMP4]], <4 x i64> [[TMP3]]
+; CHECK-NEXT:    br label %[[BB53]]
+; CHECK:       [[BB53]]:
+; CHECK-NEXT:    [[TMP7:%.*]] = phi <4 x i64> [ [[TMP3]], %[[BB31]] ], [ poison, %[[BB42]] ]
+; CHECK-NEXT:    [[TMP8:%.*]] = phi <4 x i64> [ poison, %[[BB31]] ], [ [[TMP4]], %[[BB42]] ]
+; CHECK-NEXT:    [[TMP10:%.*]] = phi <4 x i1> [ zeroinitializer, %[[BB31]] ], [ [[BROADCAST_SPLAT]], %[[BB42]] ]
+; CHECK-NEXT:    [[PREDPHI:%.*]] = select <4 x i1> [[TMP10]], <4 x i64> [[TMP8]], <4 x i64> [[TMP7]]
 ; CHECK-NEXT:    [[TMP5:%.*]] = add <4 x i64> [[PREDPHI]], splat (i64 5)
 ; CHECK-NEXT:    [[PREDPHI1:%.*]] = select <4 x i1> [[TMP1]], <4 x i64> [[TMP5]], <4 x i64> [[TMP2]]
 ; CHECK-NEXT:    [[TMP6:%.*]] = extractelement <4 x i64> [[PREDPHI1]], i64 3
 ; CHECK-NEXT:    store i64 [[TMP6]], ptr [[A]], align 4
+; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
+; CHECK-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[VEC_IND]], splat (i64 4)
+; CHECK-NEXT:    [[TMP9:%.*]] = icmp eq i64 [[INDEX_NEXT]], 128
+; CHECK-NEXT:    br i1 [[TMP9]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP10:![0-9]+]]
+; CHECK:       [[MIDDLE_BLOCK]]:
 ; CHECK-NEXT:    br label %[[EXIT:.*]]
 ; CHECK:       [[EXIT]]:
 ; CHECK-NEXT:    ret void
@@ -824,23 +919,37 @@ define void @uniform_branch_unstructured_merge1(ptr %a, i1 %u0) {
 ; CHECK-NEXT:    [[TMP0:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT]], splat (i1 true)
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
-; CHECK-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[VEC_IND]], splat (i64 4)
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[INDEX_NEXT]], 128
-; CHECK-NEXT:    br i1 [[TMP1]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP18:![0-9]+]]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[BB33:.*]] ]
+; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[BB33]] ]
+; CHECK-NEXT:    br i1 [[U0]], label %[[BB22:.*]], label %[[MIDDLE_BLOCK:.*]]
 ; CHECK:       [[MIDDLE_BLOCK]]:
 ; CHECK-NEXT:    [[TMP2:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 1)
+; CHECK-NEXT:    br label %[[BB33]]
+; CHECK:       [[BB22]]:
 ; CHECK-NEXT:    [[TMP3:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 2)
-; CHECK-NEXT:    [[TMP4:%.*]] = icmp sgt <4 x i64> [[VEC_IND]], splat (i64 2)
+; CHECK-NEXT:    [[TMP4:%.*]] = icmp sle <4 x i64> [[VEC_IND]], splat (i64 2)
 ; CHECK-NEXT:    [[TMP5:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 4)
-; CHECK-NEXT:    [[TMP6:%.*]] = select <4 x i1> [[TMP0]], <4 x i1> splat (i1 true), <4 x i1> [[TMP4]]
-; CHECK-NEXT:    [[PREDPHI:%.*]] = select i1 [[U0]], <4 x i64> [[TMP3]], <4 x i64> [[TMP2]]
+; CHECK-NEXT:    br label %[[BB33]]
+; CHECK:       [[BB33]]:
+; CHECK-NEXT:    [[TMP14:%.*]] = phi <4 x i64> [ poison, %[[MIDDLE_BLOCK]] ], [ [[TMP5]], %[[BB22]] ]
+; CHECK-NEXT:    [[TMP6:%.*]] = phi <4 x i64> [ [[TMP2]], %[[MIDDLE_BLOCK]] ], [ poison, %[[BB22]] ]
+; CHECK-NEXT:    [[TMP15:%.*]] = phi <4 x i64> [ poison, %[[MIDDLE_BLOCK]] ], [ [[TMP3]], %[[BB22]] ]
+; CHECK-NEXT:    [[TMP17:%.*]] = phi <4 x i1> [ zeroinitializer, %[[MIDDLE_BLOCK]] ], [ [[BROADCAST_SPLAT]], %[[BB22]] ]
+; CHECK-NEXT:    [[TMP9:%.*]] = phi <4 x i1> [ zeroinitializer, %[[MIDDLE_BLOCK]] ], [ [[TMP4]], %[[BB22]] ]
+; CHECK-NEXT:    [[TMP10:%.*]] = phi <4 x i1> [ [[TMP0]], %[[MIDDLE_BLOCK]] ], [ zeroinitializer, %[[BB22]] ]
+; CHECK-NEXT:    [[TMP11:%.*]] = xor <4 x i1> [[TMP9]], splat (i1 true)
+; CHECK-NEXT:    [[TMP12:%.*]] = select <4 x i1> [[BROADCAST_SPLAT]], <4 x i1> [[TMP11]], <4 x i1> zeroinitializer
+; CHECK-NEXT:    [[TMP13:%.*]] = or <4 x i1> [[TMP12]], [[TMP10]]
+; CHECK-NEXT:    [[PREDPHI:%.*]] = select <4 x i1> [[TMP17]], <4 x i64> [[TMP15]], <4 x i64> [[TMP6]]
 ; CHECK-NEXT:    [[TMP7:%.*]] = add <4 x i64> [[PREDPHI]], splat (i64 3)
-; CHECK-NEXT:    [[PREDPHI1:%.*]] = select <4 x i1> [[TMP6]], <4 x i64> [[TMP7]], <4 x i64> [[TMP5]]
+; CHECK-NEXT:    [[PREDPHI1:%.*]] = select <4 x i1> [[TMP13]], <4 x i64> [[TMP7]], <4 x i64> [[TMP14]]
 ; CHECK-NEXT:    [[TMP8:%.*]] = extractelement <4 x i64> [[PREDPHI1]], i64 3
 ; CHECK-NEXT:    store i64 [[TMP8]], ptr [[A]], align 4
+; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
+; CHECK-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[VEC_IND]], splat (i64 4)
+; CHECK-NEXT:    [[TMP16:%.*]] = icmp eq i64 [[INDEX_NEXT]], 128
+; CHECK-NEXT:    br i1 [[TMP16]], label %[[MIDDLE_BLOCK1:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP18:![0-9]+]]
+; CHECK:       [[MIDDLE_BLOCK1]]:
 ; CHECK-NEXT:    br label %[[EXIT:.*]]
 ; CHECK:       [[EXIT]]:
 ; CHECK-NEXT:    ret void
@@ -902,23 +1011,36 @@ define void @uniform_branch_unstructured_merge2(ptr %a, i1 %u0) {
 ; CHECK-NEXT:    [[TMP0:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT]], splat (i1 true)
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
-; CHECK-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[VEC_IND]], splat (i64 4)
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[INDEX_NEXT]], 128
-; CHECK-NEXT:    br i1 [[TMP1]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP19:![0-9]+]]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[BB43:.*]] ]
+; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[BB43]] ]
+; CHECK-NEXT:    br i1 [[U0]], label %[[BB22:.*]], label %[[MIDDLE_BLOCK:.*]]
 ; CHECK:       [[MIDDLE_BLOCK]]:
 ; CHECK-NEXT:    [[TMP2:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 1)
+; CHECK-NEXT:    br label %[[BB43]]
+; CHECK:       [[BB22]]:
 ; CHECK-NEXT:    [[TMP3:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 2)
 ; CHECK-NEXT:    [[TMP4:%.*]] = icmp sle <4 x i64> [[VEC_IND]], splat (i64 2)
 ; CHECK-NEXT:    [[TMP5:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 3)
-; CHECK-NEXT:    [[TMP6:%.*]] = select <4 x i1> [[TMP0]], <4 x i1> splat (i1 true), <4 x i1> [[TMP4]]
-; CHECK-NEXT:    [[PREDPHI:%.*]] = select i1 [[U0]], <4 x i64> [[TMP3]], <4 x i64> [[TMP2]]
+; CHECK-NEXT:    br label %[[BB43]]
+; CHECK:       [[BB43]]:
+; CHECK-NEXT:    [[TMP13:%.*]] = phi <4 x i64> [ poison, %[[MIDDLE_BLOCK]] ], [ [[TMP5]], %[[BB22]] ]
+; CHECK-NEXT:    [[TMP6:%.*]] = phi <4 x i64> [ [[TMP2]], %[[MIDDLE_BLOCK]] ], [ poison, %[[BB22]] ]
+; CHECK-NEXT:    [[TMP14:%.*]] = phi <4 x i64> [ poison, %[[MIDDLE_BLOCK]] ], [ [[TMP3]], %[[BB22]] ]
+; CHECK-NEXT:    [[TMP16:%.*]] = phi <4 x i1> [ zeroinitializer, %[[MIDDLE_BLOCK]] ], [ [[BROADCAST_SPLAT]], %[[BB22]] ]
+; CHECK-NEXT:    [[TMP9:%.*]] = phi <4 x i1> [ zeroinitializer, %[[MIDDLE_BLOCK]] ], [ [[TMP4]], %[[BB22]] ]
+; CHECK-NEXT:    [[TMP10:%.*]] = phi <4 x i1> [ [[TMP0]], %[[MIDDLE_BLOCK]] ], [ zeroinitializer, %[[BB22]] ]
+; CHECK-NEXT:    [[TMP11:%.*]] = select <4 x i1> [[BROADCAST_SPLAT]], <4 x i1> [[TMP9]], <4 x i1> zeroinitializer
+; CHECK-NEXT:    [[TMP12:%.*]] = or <4 x i1> [[TMP11]], [[TMP10]]
+; CHECK-NEXT:    [[PREDPHI:%.*]] = select <4 x i1> [[TMP16]], <4 x i64> [[TMP14]], <4 x i64> [[TMP6]]
 ; CHECK-NEXT:    [[TMP7:%.*]] = add <4 x i64> [[PREDPHI]], splat (i64 4)
-; CHECK-NEXT:    [[PREDPHI1:%.*]] = select <4 x i1> [[TMP6]], <4 x i64> [[TMP7]], <4 x i64> [[TMP5]]
+; CHECK-NEXT:    [[PREDPHI1:%.*]] = select <4 x i1> [[TMP12]], <4 x i64> [[TMP7]], <4 x i64> [[TMP13]]
 ; CHECK-NEXT:    [[TMP8:%.*]] = extractelement <4 x i64> [[PREDPHI1]], i64 3
 ; CHECK-NEXT:    store i64 [[TMP8]], ptr [[A]], align 4
+; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
+; CHECK-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[VEC_IND]], splat (i64 4)
+; CHECK-NEXT:    [[TMP15:%.*]] = icmp eq i64 [[INDEX_NEXT]], 128
+; CHECK-NEXT:    br i1 [[TMP15]], label %[[MIDDLE_BLOCK1:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP19:![0-9]+]]
+; CHECK:       [[MIDDLE_BLOCK1]]:
 ; CHECK-NEXT:    br label %[[EXIT:.*]]
 ; CHECK:       [[EXIT]]:
 ; CHECK-NEXT:    ret void
@@ -979,24 +1101,36 @@ define void @uniform_branch_unstructured_merge3(ptr %a, i1 %u0) {
 ; CHECK-NEXT:    [[TMP0:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT]], splat (i1 true)
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
-; CHECK-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[VEC_IND]], splat (i64 4)
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[INDEX_NEXT]], 128
-; CHECK-NEXT:    br i1 [[TMP1]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP20:![0-9]+]]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[BB43:.*]] ]
+; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[BB43]] ]
+; CHECK-NEXT:    br i1 [[U0]], label %[[BB32:.*]], label %[[MIDDLE_BLOCK:.*]]
 ; CHECK:       [[MIDDLE_BLOCK]]:
 ; CHECK-NEXT:    [[TMP2:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 1)
 ; CHECK-NEXT:    [[TMP3:%.*]] = icmp sle <4 x i64> [[VEC_IND]], splat (i64 1)
 ; CHECK-NEXT:    [[TMP4:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 2)
+; CHECK-NEXT:    br label %[[BB43]]
+; CHECK:       [[BB32]]:
 ; CHECK-NEXT:    [[TMP5:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 3)
-; CHECK-NEXT:    [[TMP6:%.*]] = select <4 x i1> [[TMP0]], <4 x i1> [[TMP3]], <4 x i1> zeroinitializer
+; CHECK-NEXT:    br label %[[BB43]]
+; CHECK:       [[BB43]]:
+; CHECK-NEXT:    [[TMP11:%.*]] = phi <4 x i64> [ [[TMP4]], %[[MIDDLE_BLOCK]] ], [ poison, %[[BB32]] ]
+; CHECK-NEXT:    [[TMP12:%.*]] = phi <4 x i64> [ [[TMP2]], %[[MIDDLE_BLOCK]] ], [ poison, %[[BB32]] ]
+; CHECK-NEXT:    [[TMP13:%.*]] = phi <4 x i64> [ poison, %[[MIDDLE_BLOCK]] ], [ [[TMP5]], %[[BB32]] ]
+; CHECK-NEXT:    [[TMP14:%.*]] = phi <4 x i1> [ zeroinitializer, %[[MIDDLE_BLOCK]] ], [ [[BROADCAST_SPLAT]], %[[BB32]] ]
+; CHECK-NEXT:    [[TMP16:%.*]] = phi <4 x i1> [ [[TMP0]], %[[MIDDLE_BLOCK]] ], [ zeroinitializer, %[[BB32]] ]
+; CHECK-NEXT:    [[TMP10:%.*]] = phi <4 x i1> [ [[TMP3]], %[[MIDDLE_BLOCK]] ], [ zeroinitializer, %[[BB32]] ]
+; CHECK-NEXT:    [[TMP6:%.*]] = select <4 x i1> [[TMP16]], <4 x i1> [[TMP10]], <4 x i1> zeroinitializer
 ; CHECK-NEXT:    [[TMP7:%.*]] = or <4 x i1> [[BROADCAST_SPLAT]], [[TMP6]]
-; CHECK-NEXT:    [[PREDPHI:%.*]] = select i1 [[U0]], <4 x i64> [[TMP5]], <4 x i64> [[TMP2]]
+; CHECK-NEXT:    [[PREDPHI:%.*]] = select <4 x i1> [[TMP14]], <4 x i64> [[TMP13]], <4 x i64> [[TMP12]]
 ; CHECK-NEXT:    [[TMP8:%.*]] = add <4 x i64> [[PREDPHI]], splat (i64 4)
-; CHECK-NEXT:    [[PREDPHI1:%.*]] = select <4 x i1> [[TMP7]], <4 x i64> [[TMP8]], <4 x i64> [[TMP4]]
+; CHECK-NEXT:    [[PREDPHI1:%.*]] = select <4 x i1> [[TMP7]], <4 x i64> [[TMP8]], <4 x i64> [[TMP11]]
 ; CHECK-NEXT:    [[TMP9:%.*]] = extractelement <4 x i64> [[PREDPHI1]], i64 3
 ; CHECK-NEXT:    store i64 [[TMP9]], ptr [[A]], align 4
+; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
+; CHECK-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[VEC_IND]], splat (i64 4)
+; CHECK-NEXT:    [[TMP15:%.*]] = icmp eq i64 [[INDEX_NEXT]], 128
+; CHECK-NEXT:    br i1 [[TMP15]], label %[[MIDDLE_BLOCK1:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP20:![0-9]+]]
+; CHECK:       [[MIDDLE_BLOCK1]]:
 ; CHECK-NEXT:    br label %[[EXIT:.*]]
 ; CHECK:       [[EXIT]]:
 ; CHECK-NEXT:    ret void
@@ -1055,24 +1189,37 @@ define void @uniform_branch_unstructured_merge4(ptr %a, i1 %u0) {
 ; CHECK-NEXT:    [[TMP0:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT]], splat (i1 true)
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
-; CHECK-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[VEC_IND]], splat (i64 4)
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[INDEX_NEXT]], 128
-; CHECK-NEXT:    br i1 [[TMP1]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP21:![0-9]+]]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[BB23:.*]] ]
+; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[BB23]] ]
+; CHECK-NEXT:    br i1 [[U0]], label %[[BB32:.*]], label %[[MIDDLE_BLOCK:.*]]
 ; CHECK:       [[MIDDLE_BLOCK]]:
 ; CHECK-NEXT:    [[TMP2:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 1)
-; CHECK-NEXT:    [[TMP3:%.*]] = icmp sgt <4 x i64> [[VEC_IND]], splat (i64 1)
+; CHECK-NEXT:    [[TMP3:%.*]] = icmp sle <4 x i64> [[VEC_IND]], splat (i64 1)
 ; CHECK-NEXT:    [[TMP4:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 4)
+; CHECK-NEXT:    br label %[[BB23]]
+; CHECK:       [[BB32]]:
 ; CHECK-NEXT:    [[TMP5:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 3)
-; CHECK-NEXT:    [[TMP6:%.*]] = select <4 x i1> [[TMP0]], <4 x i1> [[TMP3]], <4 x i1> zeroinitializer
+; CHECK-NEXT:    br label %[[BB23]]
+; CHECK:       [[BB23]]:
+; CHECK-NEXT:    [[TMP12:%.*]] = phi <4 x i64> [ [[TMP4]], %[[MIDDLE_BLOCK]] ], [ poison, %[[BB32]] ]
+; CHECK-NEXT:    [[TMP13:%.*]] = phi <4 x i64> [ [[TMP2]], %[[MIDDLE_BLOCK]] ], [ poison, %[[BB32]] ]
+; CHECK-NEXT:    [[TMP14:%.*]] = phi <4 x i64> [ poison, %[[MIDDLE_BLOCK]] ], [ [[TMP5]], %[[BB32]] ]
+; CHECK-NEXT:    [[TMP15:%.*]] = phi <4 x i1> [ zeroinitializer, %[[MIDDLE_BLOCK]] ], [ [[BROADCAST_SPLAT]], %[[BB32]] ]
+; CHECK-NEXT:    [[TMP17:%.*]] = phi <4 x i1> [ [[TMP3]], %[[MIDDLE_BLOCK]] ], [ zeroinitializer, %[[BB32]] ]
+; CHECK-NEXT:    [[TMP10:%.*]] = phi <4 x i1> [ [[TMP0]], %[[MIDDLE_BLOCK]] ], [ zeroinitializer, %[[BB32]] ]
+; CHECK-NEXT:    [[TMP11:%.*]] = xor <4 x i1> [[TMP17]], splat (i1 true)
+; CHECK-NEXT:    [[TMP6:%.*]] = select <4 x i1> [[TMP10]], <4 x i1> [[TMP11]], <4 x i1> zeroinitializer
 ; CHECK-NEXT:    [[TMP7:%.*]] = or <4 x i1> [[BROADCAST_SPLAT]], [[TMP6]]
-; CHECK-NEXT:    [[PREDPHI:%.*]] = select i1 [[U0]], <4 x i64> [[TMP5]], <4 x i64> [[TMP2]]
+; CHECK-NEXT:    [[PREDPHI:%.*]] = select <4 x i1> [[TMP15]], <4 x i64> [[TMP14]], <4 x i64> [[TMP13]]
 ; CHECK-NEXT:    [[TMP8:%.*]] = add <4 x i64> [[PREDPHI]], splat (i64 2)
-; CHECK-NEXT:    [[PREDPHI1:%.*]] = select <4 x i1> [[TMP7]], <4 x i64> [[TMP8]], <4 x i64> [[TMP4]]
+; CHECK-NEXT:    [[PREDPHI1:%.*]] = select <4 x i1> [[TMP7]], <4 x i64> [[TMP8]], <4 x i64> [[TMP12]]
 ; CHECK-NEXT:    [[TMP9:%.*]] = extractelement <4 x i64> [[PREDPHI1]], i64 3
 ; CHECK-NEXT:    store i64 [[TMP9]], ptr [[A]], align 4
+; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
+; CHECK-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[VEC_IND]], splat (i64 4)
+; CHECK-NEXT:    [[TMP16:%.*]] = icmp eq i64 [[INDEX_NEXT]], 128
+; CHECK-NEXT:    br i1 [[TMP16]], label %[[MIDDLE_BLOCK1:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP21:![0-9]+]]
+; CHECK:       [[MIDDLE_BLOCK1]]:
 ; CHECK-NEXT:    br label %[[EXIT:.*]]
 ; CHECK:       [[EXIT]]:
 ; CHECK-NEXT:    ret void
@@ -1132,22 +1279,33 @@ define void @uniform_branch_shared_join_with_varying(ptr %a, i1 %u0) {
 ; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT]], <4 x i1> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
-; CHECK-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[VEC_IND]], splat (i64 4)
-; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq i64 [[INDEX_NEXT]], 128
-; CHECK-NEXT:    br i1 [[TMP0]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP22:![0-9]+]]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[BB43:.*]] ]
+; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[BB43]] ]
+; CHECK-NEXT:    br i1 [[U0]], label %[[BB22:.*]], label %[[MIDDLE_BLOCK:.*]]
 ; CHECK:       [[MIDDLE_BLOCK]]:
 ; CHECK-NEXT:    [[TMP1:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 1)
+; CHECK-NEXT:    br label %[[BB43]]
+; CHECK:       [[BB22]]:
 ; CHECK-NEXT:    [[TMP2:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 2)
 ; CHECK-NEXT:    [[TMP3:%.*]] = icmp sle <4 x i64> [[VEC_IND]], splat (i64 2)
 ; CHECK-NEXT:    [[TMP4:%.*]] = select <4 x i1> [[BROADCAST_SPLAT]], <4 x i1> [[TMP3]], <4 x i1> zeroinitializer
 ; CHECK-NEXT:    [[TMP5:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 3)
-; CHECK-NEXT:    [[PREDPHI:%.*]] = select i1 [[U0]], <4 x i64> [[TMP2]], <4 x i64> [[TMP1]]
-; CHECK-NEXT:    [[PREDPHI1:%.*]] = select <4 x i1> [[TMP4]], <4 x i64> [[TMP5]], <4 x i64> [[PREDPHI]]
+; CHECK-NEXT:    br label %[[BB43]]
+; CHECK:       [[BB43]]:
+; CHECK-NEXT:    [[TMP10:%.*]] = phi <4 x i64> [ [[TMP1]], %[[MIDDLE_BLOCK]] ], [ poison, %[[BB22]] ]
+; CHECK-NEXT:    [[TMP12:%.*]] = phi <4 x i64> [ poison, %[[MIDDLE_BLOCK]] ], [ [[TMP2]], %[[BB22]] ]
+; CHECK-NEXT:    [[TMP7:%.*]] = phi <4 x i1> [ zeroinitializer, %[[MIDDLE_BLOCK]] ], [ [[BROADCAST_SPLAT]], %[[BB22]] ]
+; CHECK-NEXT:    [[TMP8:%.*]] = phi <4 x i64> [ poison, %[[MIDDLE_BLOCK]] ], [ [[TMP5]], %[[BB22]] ]
+; CHECK-NEXT:    [[TMP9:%.*]] = phi <4 x i1> [ zeroinitializer, %[[MIDDLE_BLOCK]] ], [ [[TMP4]], %[[BB22]] ]
+; CHECK-NEXT:    [[PREDPHI:%.*]] = select <4 x i1> [[TMP7]], <4 x i64> [[TMP12]], <4 x i64> [[TMP10]]
+; CHECK-NEXT:    [[PREDPHI1:%.*]] = select <4 x i1> [[TMP9]], <4 x i64> [[TMP8]], <4 x i64> [[PREDPHI]]
 ; CHECK-NEXT:    [[TMP6:%.*]] = extractelement <4 x i64> [[PREDPHI1]], i64 3
 ; CHECK-NEXT:    store i64 [[TMP6]], ptr [[A]], align 4
+; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
+; CHECK-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[VEC_IND]], splat (i64 4)
+; CHECK-NEXT:    [[TMP11:%.*]] = icmp eq i64 [[INDEX_NEXT]], 128
+; CHECK-NEXT:    br i1 [[TMP11]], label %[[MIDDLE_BLOCK1:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP22:![0-9]+]]
+; CHECK:       [[MIDDLE_BLOCK1]]:
 ; CHECK-NEXT:    br label %[[EXIT:.*]]
 ; CHECK:       [[EXIT]]:
 ; CHECK-NEXT:    ret void
@@ -1201,26 +1359,44 @@ define void @unstructured_uniform_only(ptr %a, i1 %u0, i1 %u2) {
 ; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT]], <4 x i1> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT1:%.*]] = insertelement <4 x i1> poison, i1 [[U0]], i64 0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT2:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT1]], <4 x i1> poison, <4 x i32> zeroinitializer
-; CHECK-NEXT:    [[TMP0:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT2]], splat (i1 true)
 ; CHECK-NEXT:    [[TMP1:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT]], splat (i1 true)
-; CHECK-NEXT:    [[TMP2:%.*]] = select <4 x i1> [[TMP0]], <4 x i1> splat (i1 true), <4 x i1> [[TMP1]]
+; CHECK-NEXT:    [[TMP3:%.*]] = select <4 x i1> [[BROADCAST_SPLAT2]], <4 x i1> [[TMP1]], <4 x i1> zeroinitializer
+; CHECK-NEXT:    [[TMP2:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT2]], splat (i1 true)
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
-; CHECK-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[VEC_IND]], splat (i64 4)
-; CHECK-NEXT:    [[TMP3:%.*]] = icmp eq i64 [[INDEX_NEXT]], 128
-; CHECK-NEXT:    br i1 [[TMP3]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP23:![0-9]+]]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[BB57:.*]] ]
+; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[BB57]] ]
+; CHECK-NEXT:    br i1 [[U0]], label %[[BB24:.*]], label %[[MIDDLE_BLOCK:.*]]
 ; CHECK:       [[MIDDLE_BLOCK]]:
 ; CHECK-NEXT:    [[TMP4:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 1)
+; CHECK-NEXT:    br label %[[BB35:.*]]
+; CHECK:       [[BB24]]:
 ; CHECK-NEXT:    [[TMP5:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 2)
-; CHECK-NEXT:    [[TMP6:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 4)
-; CHECK-NEXT:    [[PREDPHI:%.*]] = select i1 [[U0]], <4 x i64> [[TMP5]], <4 x i64> [[TMP4]]
+; CHECK-NEXT:    br i1 [[U2]], label %[[BB46:.*]], label %[[BB35]]
+; CHECK:       [[BB35]]:
+; CHECK-NEXT:    [[TMP10:%.*]] = phi <4 x i64> [ [[TMP4]], %[[MIDDLE_BLOCK]] ], [ poison, %[[BB24]] ]
+; CHECK-NEXT:    [[TMP6:%.*]] = phi <4 x i64> [ poison, %[[MIDDLE_BLOCK]] ], [ [[TMP5]], %[[BB24]] ]
+; CHECK-NEXT:    [[TMP15:%.*]] = phi <4 x i1> [ zeroinitializer, %[[MIDDLE_BLOCK]] ], [ [[BROADCAST_SPLAT2]], %[[BB24]] ]
+; CHECK-NEXT:    [[TMP17:%.*]] = phi <4 x i1> [ [[TMP2]], %[[MIDDLE_BLOCK]] ], [ zeroinitializer, %[[BB24]] ]
+; CHECK-NEXT:    [[TMP9:%.*]] = or <4 x i1> [[TMP3]], [[TMP17]]
+; CHECK-NEXT:    [[PREDPHI:%.*]] = select <4 x i1> [[TMP15]], <4 x i64> [[TMP6]], <4 x i64> [[TMP10]]
 ; CHECK-NEXT:    [[TMP7:%.*]] = add <4 x i64> [[PREDPHI]], splat (i64 3)
-; CHECK-NEXT:    [[PREDPHI3:%.*]] = select <4 x i1> [[TMP2]], <4 x i64> [[TMP7]], <4 x i64> [[TMP6]]
+; CHECK-NEXT:    br label %[[BB57]]
+; CHECK:       [[BB46]]:
+; CHECK-NEXT:    [[TMP11:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 4)
+; CHECK-NEXT:    br label %[[BB57]]
+; CHECK:       [[BB57]]:
+; CHECK-NEXT:    [[TMP12:%.*]] = phi <4 x i64> [ [[TMP11]], %[[BB46]] ], [ poison, %[[BB35]] ]
+; CHECK-NEXT:    [[TMP13:%.*]] = phi <4 x i64> [ poison, %[[BB46]] ], [ [[TMP7]], %[[BB35]] ]
+; CHECK-NEXT:    [[TMP14:%.*]] = phi <4 x i1> [ zeroinitializer, %[[BB46]] ], [ [[TMP9]], %[[BB35]] ]
+; CHECK-NEXT:    [[PREDPHI3:%.*]] = select <4 x i1> [[TMP14]], <4 x i64> [[TMP13]], <4 x i64> [[TMP12]]
 ; CHECK-NEXT:    [[TMP8:%.*]] = extractelement <4 x i64> [[PREDPHI3]], i64 3
 ; CHECK-NEXT:    store i64 [[TMP8]], ptr [[A]], align 4
+; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
+; CHECK-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[VEC_IND]], splat (i64 4)
+; CHECK-NEXT:    [[TMP16:%.*]] = icmp eq i64 [[INDEX_NEXT]], 128
+; CHECK-NEXT:    br i1 [[TMP16]], label %[[MIDDLE_BLOCK1:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP23:![0-9]+]]
+; CHECK:       [[MIDDLE_BLOCK1]]:
 ; CHECK-NEXT:    br label %[[EXIT:.*]]
 ; CHECK:       [[EXIT]]:
 ; CHECK-NEXT:    ret void
@@ -1278,33 +1454,51 @@ define void @unstructured_uniform_only_sese_region(ptr %a, i1 %u1, i1 %u3) {
 ; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT]], <4 x i1> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT1:%.*]] = insertelement <4 x i1> poison, i1 [[U1]], i64 0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT2:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT1]], <4 x i1> poison, <4 x i32> zeroinitializer
-; CHECK-NEXT:    [[TMP0:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT2]], splat (i1 true)
 ; CHECK-NEXT:    [[TMP1:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT]], splat (i1 true)
+; CHECK-NEXT:    [[TMP0:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT2]], splat (i1 true)
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
-; CHECK-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[VEC_IND]], splat (i64 4)
-; CHECK-NEXT:    [[TMP2:%.*]] = icmp eq i64 [[INDEX_NEXT]], 128
-; CHECK-NEXT:    br i1 [[TMP2]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP24:![0-9]+]]
-; CHECK:       [[MIDDLE_BLOCK]]:
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[BB77:.*]] ]
+; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[BB77]] ]
 ; CHECK-NEXT:    [[TMP3:%.*]] = icmp sgt <4 x i64> [[VEC_IND]], zeroinitializer
+; CHECK-NEXT:    br i1 [[U1]], label %[[BB34:.*]], label %[[BB23:.*]]
+; CHECK:       [[BB23]]:
 ; CHECK-NEXT:    [[TMP4:%.*]] = select <4 x i1> [[TMP3]], <4 x i1> [[TMP0]], <4 x i1> zeroinitializer
 ; CHECK-NEXT:    [[TMP5:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 2)
+; CHECK-NEXT:    br label %[[BB45:.*]]
+; CHECK:       [[BB34]]:
 ; CHECK-NEXT:    [[TMP6:%.*]] = select <4 x i1> [[TMP3]], <4 x i1> [[BROADCAST_SPLAT2]], <4 x i1> zeroinitializer
 ; CHECK-NEXT:    [[TMP7:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 3)
-; CHECK-NEXT:    [[TMP8:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 5)
-; CHECK-NEXT:    [[TMP9:%.*]] = select <4 x i1> [[TMP6]], <4 x i1> [[TMP1]], <4 x i1> zeroinitializer
-; CHECK-NEXT:    [[TMP10:%.*]] = or <4 x i1> [[TMP9]], [[TMP4]]
-; CHECK-NEXT:    [[PREDPHI:%.*]] = select i1 [[U1]], <4 x i64> [[TMP7]], <4 x i64> [[TMP5]]
+; CHECK-NEXT:    br i1 [[U3]], label %[[BB56:.*]], label %[[BB45]]
+; CHECK:       [[BB45]]:
+; CHECK-NEXT:    [[TMP19:%.*]] = phi <4 x i64> [ [[TMP5]], %[[BB23]] ], [ poison, %[[BB34]] ]
+; CHECK-NEXT:    [[TMP8:%.*]] = phi <4 x i64> [ poison, %[[BB23]] ], [ [[TMP7]], %[[BB34]] ]
+; CHECK-NEXT:    [[TMP9:%.*]] = phi <4 x i1> [ zeroinitializer, %[[BB23]] ], [ [[BROADCAST_SPLAT2]], %[[BB34]] ]
+; CHECK-NEXT:    [[TMP10:%.*]] = phi <4 x i1> [ zeroinitializer, %[[BB23]] ], [ [[TMP6]], %[[BB34]] ]
+; CHECK-NEXT:    [[TMP20:%.*]] = phi <4 x i1> [ [[TMP4]], %[[BB23]] ], [ zeroinitializer, %[[BB34]] ]
+; CHECK-NEXT:    [[TMP21:%.*]] = select <4 x i1> [[TMP10]], <4 x i1> [[TMP1]], <4 x i1> zeroinitializer
+; CHECK-NEXT:    [[TMP23:%.*]] = or <4 x i1> [[TMP21]], [[TMP20]]
+; CHECK-NEXT:    [[PREDPHI:%.*]] = select <4 x i1> [[TMP9]], <4 x i64> [[TMP8]], <4 x i64> [[TMP19]]
 ; CHECK-NEXT:    [[TMP11:%.*]] = add <4 x i64> [[PREDPHI]], splat (i64 4)
-; CHECK-NEXT:    [[PREDPHI3:%.*]] = select <4 x i1> [[TMP10]], <4 x i64> [[TMP11]], <4 x i64> [[TMP8]]
+; CHECK-NEXT:    br label %[[BB77]]
+; CHECK:       [[BB56]]:
+; CHECK-NEXT:    [[TMP15:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 5)
+; CHECK-NEXT:    br label %[[BB77]]
+; CHECK:       [[BB77]]:
+; CHECK-NEXT:    [[TMP16:%.*]] = phi <4 x i64> [ [[TMP15]], %[[BB56]] ], [ poison, %[[BB45]] ]
+; CHECK-NEXT:    [[TMP17:%.*]] = phi <4 x i64> [ poison, %[[BB56]] ], [ [[TMP11]], %[[BB45]] ]
+; CHECK-NEXT:    [[TMP18:%.*]] = phi <4 x i1> [ zeroinitializer, %[[BB56]] ], [ [[TMP23]], %[[BB45]] ]
+; CHECK-NEXT:    [[PREDPHI3:%.*]] = select <4 x i1> [[TMP18]], <4 x i64> [[TMP17]], <4 x i64> [[TMP16]]
 ; CHECK-NEXT:    [[TMP12:%.*]] = add <4 x i64> [[PREDPHI3]], splat (i64 7)
 ; CHECK-NEXT:    [[TMP13:%.*]] = add <4 x i64> [[VEC_IND]], splat (i64 6)
 ; CHECK-NEXT:    [[PREDPHI4:%.*]] = select <4 x i1> [[TMP3]], <4 x i64> [[TMP12]], <4 x i64> [[TMP13]]
 ; CHECK-NEXT:    [[TMP14:%.*]] = extractelement <4 x i64> [[PREDPHI4]], i64 3
 ; CHECK-NEXT:    store i64 [[TMP14]], ptr [[A]], align 4
+; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
+; CHECK-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[VEC_IND]], splat (i64 4)
+; CHECK-NEXT:    [[TMP22:%.*]] = icmp eq i64 [[INDEX_NEXT]], 128
+; CHECK-NEXT:    br i1 [[TMP22]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP24:![0-9]+]]
+; CHECK:       [[MIDDLE_BLOCK]]:
 ; CHECK-NEXT:    br label %[[EXIT:.*]]
 ; CHECK:       [[EXIT]]:
 ; CHECK-NEXT:    ret void

--- a/llvm/test/Transforms/LoopVectorize/scalarize-masked-call.ll
+++ b/llvm/test/Transforms/LoopVectorize/scalarize-masked-call.ll
@@ -101,24 +101,32 @@ define void @masked_umax_used_by_load_address(ptr noalias %src, ptr noalias %dst
 ; CHECK:       vector.ph:
 ; CHECK-NEXT:    [[TMP0:%.*]] = call i64 @llvm.umax.i64(i64 [[N:%.*]], i64 1)
 ; CHECK-NEXT:    [[TMP1:%.*]] = getelementptr i16, ptr [[SRC:%.*]], i64 [[TMP0]]
+; CHECK-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <2 x i1> poison, i1 [[C:%.*]], i64 0
+; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <2 x i1> [[BROADCAST_SPLATINSERT]], <2 x i1> poison, <2 x i32> zeroinitializer
 ; CHECK-NEXT:    br label [[VECTOR_BODY:%.*]]
 ; CHECK:       vector.body:
 ; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, [[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], [[PRED_LOAD_CONTINUE2:%.*]] ]
-; CHECK-NEXT:    br i1 [[C:%.*]], label [[PRED_LOAD_IF:%.*]], label [[PRED_LOAD_CONTINUE:%.*]]
+; CHECK-NEXT:    br i1 [[C]], label [[THEN1:%.*]], label [[PRED_LOAD_CONTINUE2]]
+; CHECK:       then1:
+; CHECK-NEXT:    br i1 [[C]], label [[PRED_LOAD_IF:%.*]], label [[PRED_LOAD_CONTINUE:%.*]]
 ; CHECK:       pred.load.if:
 ; CHECK-NEXT:    [[TMP2:%.*]] = load i16, ptr [[TMP1]], align 2
 ; CHECK-NEXT:    [[TMP3:%.*]] = insertelement <2 x i16> poison, i16 [[TMP2]], i64 0
 ; CHECK-NEXT:    br label [[PRED_LOAD_CONTINUE]]
 ; CHECK:       pred.load.continue:
-; CHECK-NEXT:    [[TMP4:%.*]] = phi <2 x i16> [ poison, [[VECTOR_BODY]] ], [ [[TMP3]], [[PRED_LOAD_IF]] ]
-; CHECK-NEXT:    br i1 [[C]], label [[PRED_LOAD_IF1:%.*]], label [[PRED_LOAD_CONTINUE2]]
-; CHECK:       pred.load.if1:
+; CHECK-NEXT:    [[TMP4:%.*]] = phi <2 x i16> [ poison, [[THEN1]] ], [ [[TMP3]], [[PRED_LOAD_IF]] ]
+; CHECK-NEXT:    br i1 [[C]], label [[PRED_LOAD_IF1:%.*]], label [[PRED_LOAD_CONTINUE3:%.*]]
+; CHECK:       pred.load.if2:
 ; CHECK-NEXT:    [[TMP5:%.*]] = load i16, ptr [[TMP1]], align 2
 ; CHECK-NEXT:    [[TMP6:%.*]] = insertelement <2 x i16> [[TMP4]], i16 [[TMP5]], i64 1
-; CHECK-NEXT:    br label [[PRED_LOAD_CONTINUE2]]
-; CHECK:       pred.load.continue2:
+; CHECK-NEXT:    br label [[PRED_LOAD_CONTINUE3]]
+; CHECK:       pred.load.continue3:
 ; CHECK-NEXT:    [[TMP7:%.*]] = phi <2 x i16> [ [[TMP4]], [[PRED_LOAD_CONTINUE]] ], [ [[TMP6]], [[PRED_LOAD_IF1]] ]
-; CHECK-NEXT:    [[PREDPHI:%.*]] = select i1 [[C]], <2 x i16> [[TMP7]], <2 x i16> zeroinitializer
+; CHECK-NEXT:    br label [[PRED_LOAD_CONTINUE2]]
+; CHECK:       loop.latch4:
+; CHECK-NEXT:    [[TMP10:%.*]] = phi <2 x i16> [ poison, [[VECTOR_BODY]] ], [ [[TMP7]], [[PRED_LOAD_CONTINUE3]] ]
+; CHECK-NEXT:    [[TMP11:%.*]] = phi <2 x i1> [ zeroinitializer, [[VECTOR_BODY]] ], [ [[BROADCAST_SPLAT]], [[PRED_LOAD_CONTINUE3]] ]
+; CHECK-NEXT:    [[PREDPHI:%.*]] = select <2 x i1> [[TMP11]], <2 x i16> [[TMP10]], <2 x i16> zeroinitializer
 ; CHECK-NEXT:    [[TMP8:%.*]] = getelementptr i16, ptr [[DST:%.*]], i64 [[INDEX]]
 ; CHECK-NEXT:    store <2 x i16> [[PREDPHI]], ptr [[TMP8]], align 2
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 2

--- a/llvm/test/Transforms/LoopVectorize/struct-return-replicate.ll
+++ b/llvm/test/Transforms/LoopVectorize/struct-return-replicate.ll
@@ -665,7 +665,7 @@ define void @struct_return_predicated_extractvalue(i1 %c, ptr noalias %a, ptr no
 ; VF4-NEXT:    [[TMP0:%.*]] = xor i1 [[C]], true
 ; VF4-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; VF4:       [[VECTOR_BODY]]:
-; VF4-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE6:.*]] ]
+; VF4-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LATCH8:.*]] ]
 ; VF4-NEXT:    [[TMP42:%.*]] = getelementptr float, ptr [[A]], i64 [[INDEX]]
 ; VF4-NEXT:    [[WIDE_LOAD:%.*]] = load <4 x float>, ptr [[TMP42]], align 4
 ; VF4-NEXT:    [[TMP43:%.*]] = extractelement <4 x float> [[WIDE_LOAD]], i64 0
@@ -708,6 +708,8 @@ define void @struct_return_predicated_extractvalue(i1 %c, ptr noalias %a, ptr no
 ; VF4-NEXT:    [[TMP34:%.*]] = insertelement <4 x float> [[TMP33]], float [[TMP32]], i64 3
 ; VF4-NEXT:    [[TMP35:%.*]] = insertvalue { <4 x float>, <4 x float> } [[TMP31]], <4 x float> [[TMP34]], 1
 ; VF4-NEXT:    store float 0.000000e+00, ptr [[P]], align 4
+; VF4-NEXT:    br i1 [[C]], label %[[LATCH8]], label %[[IF1:.*]]
+; VF4:       [[IF1]]:
 ; VF4-NEXT:    [[TMP36:%.*]] = extractvalue { <4 x float>, <4 x float> } [[TMP35]], 1
 ; VF4-NEXT:    br i1 [[TMP0]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE:.*]]
 ; VF4:       [[PRED_STORE_IF]]:
@@ -727,12 +729,14 @@ define void @struct_return_predicated_extractvalue(i1 %c, ptr noalias %a, ptr no
 ; VF4-NEXT:    store float [[TMP39]], ptr [[Q]], align 4
 ; VF4-NEXT:    br label %[[PRED_STORE_CONTINUE4]]
 ; VF4:       [[PRED_STORE_CONTINUE4]]:
-; VF4-NEXT:    br i1 [[TMP0]], label %[[PRED_STORE_IF5:.*]], label %[[PRED_STORE_CONTINUE6]]
+; VF4-NEXT:    br i1 [[TMP0]], label %[[PRED_STORE_IF5:.*]], label %[[PRED_STORE_CONTINUE6:.*]]
 ; VF4:       [[PRED_STORE_IF5]]:
 ; VF4-NEXT:    [[TMP40:%.*]] = extractelement <4 x float> [[TMP36]], i64 3
 ; VF4-NEXT:    store float [[TMP40]], ptr [[Q]], align 4
 ; VF4-NEXT:    br label %[[PRED_STORE_CONTINUE6]]
 ; VF4:       [[PRED_STORE_CONTINUE6]]:
+; VF4-NEXT:    br label %[[LATCH8]]
+; VF4:       [[LATCH8]]:
 ; VF4-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
 ; VF4-NEXT:    [[TMP41:%.*]] = icmp eq i64 [[INDEX_NEXT]], 1024
 ; VF4-NEXT:    br i1 [[TMP41]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP6:![0-9]+]]
@@ -746,7 +750,7 @@ define void @struct_return_predicated_extractvalue(i1 %c, ptr noalias %a, ptr no
 ; VF2IC2-NEXT:    [[TMP0:%.*]] = xor i1 [[C]], true
 ; VF2IC2-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; VF2IC2:       [[VECTOR_BODY]]:
-; VF2IC2-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE6:.*]] ]
+; VF2IC2-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LATCH9:.*]] ]
 ; VF2IC2-NEXT:    [[TMP42:%.*]] = getelementptr float, ptr [[A]], i64 [[INDEX]]
 ; VF2IC2-NEXT:    [[TMP43:%.*]] = getelementptr float, ptr [[TMP42]], i64 2
 ; VF2IC2-NEXT:    [[WIDE_LOAD:%.*]] = load <2 x float>, ptr [[TMP42]], align 4
@@ -790,6 +794,8 @@ define void @struct_return_predicated_extractvalue(i1 %c, ptr noalias %a, ptr no
 ; VF2IC2-NEXT:    [[TMP33:%.*]] = insertelement <2 x float> [[TMP32]], float [[TMP31]], i64 1
 ; VF2IC2-NEXT:    [[TMP34:%.*]] = insertvalue { <2 x float>, <2 x float> } [[TMP30]], <2 x float> [[TMP33]], 1
 ; VF2IC2-NEXT:    store float 0.000000e+00, ptr [[P]], align 4
+; VF2IC2-NEXT:    br i1 [[C]], label %[[LATCH9]], label %[[IF2:.*]]
+; VF2IC2:       [[IF2]]:
 ; VF2IC2-NEXT:    [[TMP35:%.*]] = extractvalue { <2 x float>, <2 x float> } [[TMP17]], 1
 ; VF2IC2-NEXT:    [[TMP36:%.*]] = extractvalue { <2 x float>, <2 x float> } [[TMP34]], 1
 ; VF2IC2-NEXT:    br i1 [[TMP0]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE:.*]]
@@ -810,12 +816,14 @@ define void @struct_return_predicated_extractvalue(i1 %c, ptr noalias %a, ptr no
 ; VF2IC2-NEXT:    store float [[TMP39]], ptr [[Q]], align 4
 ; VF2IC2-NEXT:    br label %[[PRED_STORE_CONTINUE4]]
 ; VF2IC2:       [[PRED_STORE_CONTINUE4]]:
-; VF2IC2-NEXT:    br i1 [[TMP0]], label %[[PRED_STORE_IF5:.*]], label %[[PRED_STORE_CONTINUE6]]
+; VF2IC2-NEXT:    br i1 [[TMP0]], label %[[PRED_STORE_IF5:.*]], label %[[PRED_STORE_CONTINUE6:.*]]
 ; VF2IC2:       [[PRED_STORE_IF5]]:
 ; VF2IC2-NEXT:    [[TMP40:%.*]] = extractelement <2 x float> [[TMP36]], i64 1
 ; VF2IC2-NEXT:    store float [[TMP40]], ptr [[Q]], align 4
 ; VF2IC2-NEXT:    br label %[[PRED_STORE_CONTINUE6]]
 ; VF2IC2:       [[PRED_STORE_CONTINUE6]]:
+; VF2IC2-NEXT:    br label %[[LATCH9]]
+; VF2IC2:       [[LATCH9]]:
 ; VF2IC2-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
 ; VF2IC2-NEXT:    [[TMP41:%.*]] = icmp eq i64 [[INDEX_NEXT]], 1024
 ; VF2IC2-NEXT:    br i1 [[TMP41]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP6:![0-9]+]]

--- a/llvm/test/Transforms/LoopVectorize/uniform-blend.ll
+++ b/llvm/test/Transforms/LoopVectorize/uniform-blend.ll
@@ -11,8 +11,12 @@ define void @blend_uniform_iv_trunc(i1 %c) {
 ; CHECK:       [[VECTOR_PH]]:
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LOOP_LATCH2:.*]] ]
 ; CHECK-NEXT:    [[TMP0:%.*]] = trunc i64 [[INDEX]] to i16
+; CHECK-NEXT:    br i1 [[C]], label %[[LOOP_NEXT1:.*]], label %[[LOOP_LATCH2]]
+; CHECK:       [[LOOP_NEXT1]]:
+; CHECK-NEXT:    br label %[[LOOP_LATCH2]]
+; CHECK:       [[LOOP_LATCH2]]:
 ; CHECK-NEXT:    [[TMP7:%.*]] = getelementptr inbounds [32 x i16], ptr @dst, i16 0, i16 [[TMP0]]
 ; CHECK-NEXT:    store <4 x i16> zeroinitializer, ptr [[TMP7]], align 2
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
@@ -49,17 +53,21 @@ exit:
 define void @blend_uniform_iv(i1 %c) {
 ; CHECK-LABEL: define void @blend_uniform_iv(
 ; CHECK-SAME: i1 [[C:%.*]]) {
-; CHECK-NEXT:  [[ENTRY:.*:]]
-; CHECK-NEXT:    br label %[[VECTOR_PH:.*]]
-; CHECK:       [[VECTOR_PH]]:
+; CHECK-NEXT:  [[VECTOR_PH:.*:]]
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[TMP6:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    br label %[[LOOP_LATCH2:.*]]
+; CHECK:       [[LOOP_LATCH2]]:
+; CHECK-NEXT:    [[TMP6:%.*]] = phi i64 [ 0, %[[VECTOR_BODY]] ], [ [[INDEX_NEXT:%.*]], %[[LOOP_LATCH3:.*]] ]
+; CHECK-NEXT:    br i1 [[C]], label %[[LOOP_NEXT1:.*]], label %[[LOOP_LATCH3]]
+; CHECK:       [[LOOP_NEXT1]]:
+; CHECK-NEXT:    br label %[[LOOP_LATCH3]]
+; CHECK:       [[LOOP_LATCH3]]:
 ; CHECK-NEXT:    [[TMP7:%.*]] = getelementptr inbounds [32 x i16], ptr @dst, i16 0, i64 [[TMP6]]
 ; CHECK-NEXT:    store <4 x i16> zeroinitializer, ptr [[TMP7]], align 2
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[TMP6]], 4
 ; CHECK-NEXT:    [[TMP3:%.*]] = icmp eq i64 [[INDEX_NEXT]], 32
-; CHECK-NEXT:    br i1 [[TMP3]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP3:![0-9]+]]
+; CHECK-NEXT:    br i1 [[TMP3]], label %[[MIDDLE_BLOCK:.*]], label %[[LOOP_LATCH2]], !llvm.loop [[LOOP3:![0-9]+]]
 ; CHECK:       [[MIDDLE_BLOCK]]:
 ; CHECK-NEXT:    br label %[[EXIT:.*]]
 ; CHECK:       [[EXIT]]:
@@ -94,21 +102,37 @@ define void @blend_chain_iv(i1 %c) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    br label %[[VECTOR_PH:.*]]
 ; CHECK:       [[VECTOR_PH]]:
+; CHECK-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <4 x i1> poison, i1 [[C]], i64 0
+; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT]], <4 x i1> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[TMP3:%.*]] = add i64 [[INDEX]], 1
-; CHECK-NEXT:    [[TMP5:%.*]] = add i64 [[INDEX]], 2
-; CHECK-NEXT:    [[TMP7:%.*]] = add i64 [[INDEX]], 3
+; CHECK-NEXT:    [[INDEX1:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LOOP_LATCH4:.*]] ]
+; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[LOOP_LATCH4]] ]
+; CHECK-NEXT:    br i1 [[C]], label %[[LOOP_NEXT1:.*]], label %[[LOOP_LATCH4]]
+; CHECK:       [[LOOP_NEXT1]]:
+; CHECK-NEXT:    br i1 [[C]], label %[[LOOP_NEXT_22:.*]], label %[[LOOP_NEXT_33:.*]]
+; CHECK:       [[LOOP_NEXT_22]]:
+; CHECK-NEXT:    br label %[[LOOP_NEXT_33]]
+; CHECK:       [[LOOP_NEXT_33]]:
+; CHECK-NEXT:    br label %[[LOOP_LATCH4]]
+; CHECK:       [[LOOP_LATCH4]]:
+; CHECK-NEXT:    [[TMP0:%.*]] = phi <4 x i64> [ poison, %[[VECTOR_BODY]] ], [ [[VEC_IND]], %[[LOOP_NEXT_33]] ]
+; CHECK-NEXT:    [[TMP1:%.*]] = phi <4 x i1> [ zeroinitializer, %[[VECTOR_BODY]] ], [ [[BROADCAST_SPLAT]], %[[LOOP_NEXT_33]] ]
+; CHECK-NEXT:    [[PREDPHI:%.*]] = select <4 x i1> [[TMP1]], <4 x i64> [[TMP0]], <4 x i64> [[VEC_IND]]
+; CHECK-NEXT:    [[INDEX:%.*]] = extractelement <4 x i64> [[PREDPHI]], i64 0
 ; CHECK-NEXT:    [[TMP2:%.*]] = getelementptr inbounds [32 x i16], ptr @dst, i16 0, i64 [[INDEX]]
+; CHECK-NEXT:    [[TMP3:%.*]] = extractelement <4 x i64> [[PREDPHI]], i64 1
 ; CHECK-NEXT:    [[TMP4:%.*]] = getelementptr inbounds [32 x i16], ptr @dst, i16 0, i64 [[TMP3]]
+; CHECK-NEXT:    [[TMP5:%.*]] = extractelement <4 x i64> [[PREDPHI]], i64 2
 ; CHECK-NEXT:    [[TMP6:%.*]] = getelementptr inbounds [32 x i16], ptr @dst, i16 0, i64 [[TMP5]]
+; CHECK-NEXT:    [[TMP7:%.*]] = extractelement <4 x i64> [[PREDPHI]], i64 3
 ; CHECK-NEXT:    [[TMP8:%.*]] = getelementptr inbounds [32 x i16], ptr @dst, i16 0, i64 [[TMP7]]
 ; CHECK-NEXT:    store i16 0, ptr [[TMP2]], align 2
 ; CHECK-NEXT:    store i16 0, ptr [[TMP4]], align 2
 ; CHECK-NEXT:    store i16 0, ptr [[TMP6]], align 2
 ; CHECK-NEXT:    store i16 0, ptr [[TMP8]], align 2
-; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
+; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX1]], 4
+; CHECK-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[VEC_IND]], splat (i64 4)
 ; CHECK-NEXT:    [[TMP9:%.*]] = icmp eq i64 [[INDEX_NEXT]], 32
 ; CHECK-NEXT:    br i1 [[TMP9]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP4:![0-9]+]]
 ; CHECK:       [[MIDDLE_BLOCK]]:
@@ -245,19 +269,23 @@ exit:
 define void @blend_poison(ptr %p, i1 %c) {
 ; CHECK-LABEL: define void @blend_poison(
 ; CHECK-SAME: ptr [[P:%.*]], i1 [[C:%.*]]) {
-; CHECK-NEXT:  [[ENTRY:.*:]]
-; CHECK-NEXT:    br label %[[VECTOR_PH:.*]]
-; CHECK:       [[VECTOR_PH]]:
+; CHECK-NEXT:  [[VECTOR_PH:.*:]]
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    br label %[[LATCH2:.*]]
+; CHECK:       [[LATCH2]]:
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_BODY]] ], [ [[INDEX_NEXT:%.*]], %[[LATCH3:.*]] ]
+; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_BODY]] ], [ [[VEC_IND_NEXT:%.*]], %[[LATCH3]] ]
+; CHECK-NEXT:    br i1 [[C]], label %[[IF1:.*]], label %[[LATCH3]]
+; CHECK:       [[IF1]]:
+; CHECK-NEXT:    br label %[[LATCH3]]
+; CHECK:       [[LATCH3]]:
 ; CHECK-NEXT:    [[TMP0:%.*]] = getelementptr i64, ptr [[P]], i64 [[INDEX]]
 ; CHECK-NEXT:    store <4 x i64> [[VEC_IND]], ptr [[TMP0]], align 4
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
 ; CHECK-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[VEC_IND]], splat (i64 4)
 ; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[INDEX_NEXT]], 32
-; CHECK-NEXT:    br i1 [[TMP1]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP5:![0-9]+]]
+; CHECK-NEXT:    br i1 [[TMP1]], label %[[MIDDLE_BLOCK:.*]], label %[[LATCH2]], !llvm.loop [[LOOP5:![0-9]+]]
 ; CHECK:       [[MIDDLE_BLOCK]]:
 ; CHECK-NEXT:    br label %[[EXIT:.*]]
 ; CHECK:       [[EXIT]]:
@@ -288,19 +316,23 @@ exit:
 define void @blend_poison_first_argument(ptr %p, i1 %c) {
 ; CHECK-LABEL: define void @blend_poison_first_argument(
 ; CHECK-SAME: ptr [[P:%.*]], i1 [[C:%.*]]) {
-; CHECK-NEXT:  [[ENTRY:.*:]]
-; CHECK-NEXT:    br label %[[VECTOR_PH:.*]]
-; CHECK:       [[VECTOR_PH]]:
+; CHECK-NEXT:  [[VECTOR_PH:.*:]]
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    br label %[[LATCH2:.*]]
+; CHECK:       [[LATCH2]]:
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_BODY]] ], [ [[INDEX_NEXT:%.*]], %[[LATCH3:.*]] ]
+; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_BODY]] ], [ [[VEC_IND_NEXT:%.*]], %[[LATCH3]] ]
+; CHECK-NEXT:    br i1 [[C]], label %[[IF1:.*]], label %[[LATCH3]]
+; CHECK:       [[IF1]]:
+; CHECK-NEXT:    br label %[[LATCH3]]
+; CHECK:       [[LATCH3]]:
 ; CHECK-NEXT:    [[TMP0:%.*]] = getelementptr i64, ptr [[P]], i64 [[INDEX]]
 ; CHECK-NEXT:    store <4 x i64> [[VEC_IND]], ptr [[TMP0]], align 4
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
 ; CHECK-NEXT:    [[VEC_IND_NEXT]] = add nuw nsw <4 x i64> [[VEC_IND]], splat (i64 4)
 ; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[INDEX_NEXT]], 32
-; CHECK-NEXT:    br i1 [[TMP1]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP6:![0-9]+]]
+; CHECK-NEXT:    br i1 [[TMP1]], label %[[MIDDLE_BLOCK:.*]], label %[[LATCH2]], !llvm.loop [[LOOP6:![0-9]+]]
 ; CHECK:       [[MIDDLE_BLOCK]]:
 ; CHECK-NEXT:    br label %[[EXIT:.*]]
 ; CHECK:       [[EXIT]]:
@@ -331,17 +363,21 @@ exit:
 define void @blend_all_poison(ptr %p, i1 %c) {
 ; CHECK-LABEL: define void @blend_all_poison(
 ; CHECK-SAME: ptr [[P:%.*]], i1 [[C:%.*]]) {
-; CHECK-NEXT:  [[ENTRY:.*:]]
-; CHECK-NEXT:    br label %[[VECTOR_PH:.*]]
-; CHECK:       [[VECTOR_PH]]:
+; CHECK-NEXT:  [[VECTOR_PH:.*:]]
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    br label %[[LATCH2:.*]]
+; CHECK:       [[LATCH2]]:
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_BODY]] ], [ [[INDEX_NEXT:%.*]], %[[LATCH3:.*]] ]
+; CHECK-NEXT:    br i1 [[C]], label %[[IF1:.*]], label %[[LATCH3]]
+; CHECK:       [[IF1]]:
+; CHECK-NEXT:    br label %[[LATCH3]]
+; CHECK:       [[LATCH3]]:
 ; CHECK-NEXT:    [[TMP0:%.*]] = getelementptr i64, ptr [[P]], i64 [[INDEX]]
 ; CHECK-NEXT:    store <4 x i64> poison, ptr [[TMP0]], align 4
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
 ; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[INDEX_NEXT]], 32
-; CHECK-NEXT:    br i1 [[TMP1]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP7:![0-9]+]]
+; CHECK-NEXT:    br i1 [[TMP1]], label %[[MIDDLE_BLOCK:.*]], label %[[LATCH2]], !llvm.loop [[LOOP7:![0-9]+]]
 ; CHECK:       [[MIDDLE_BLOCK]]:
 ; CHECK-NEXT:    br label %[[EXIT:.*]]
 ; CHECK:       [[EXIT]]:

--- a/llvm/test/Transforms/LoopVectorize/uniform-blend.ll
+++ b/llvm/test/Transforms/LoopVectorize/uniform-blend.ll
@@ -102,6 +102,7 @@ define void @blend_chain_iv(i1 %c) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    br label %[[VECTOR_PH:.*]]
 ; CHECK:       [[VECTOR_PH]]:
+; CHECK-NEXT:    [[TMP10:%.*]] = freeze i1 [[C]]
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <4 x i1> poison, i1 [[C]], i64 0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT]], <4 x i1> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
@@ -110,7 +111,7 @@ define void @blend_chain_iv(i1 %c) {
 ; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[LOOP_LATCH4]] ]
 ; CHECK-NEXT:    br i1 [[C]], label %[[LOOP_NEXT1:.*]], label %[[LOOP_LATCH4]]
 ; CHECK:       [[LOOP_NEXT1]]:
-; CHECK-NEXT:    br i1 [[C]], label %[[LOOP_NEXT_22:.*]], label %[[LOOP_NEXT_33:.*]]
+; CHECK-NEXT:    br i1 [[TMP10]], label %[[LOOP_NEXT_22:.*]], label %[[LOOP_NEXT_33:.*]]
 ; CHECK:       [[LOOP_NEXT_22]]:
 ; CHECK-NEXT:    br label %[[LOOP_NEXT_33]]
 ; CHECK:       [[LOOP_NEXT_33]]:

--- a/llvm/test/Transforms/LoopVectorize/uniform-blend.ll
+++ b/llvm/test/Transforms/LoopVectorize/uniform-blend.ll
@@ -11,8 +11,12 @@ define void @blend_uniform_iv_trunc(i1 %c) {
 ; CHECK:       [[VECTOR_PH]]:
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LOOP_LATCH2:.*]] ]
 ; CHECK-NEXT:    [[TMP0:%.*]] = trunc i64 [[INDEX]] to i16
+; CHECK-NEXT:    br i1 [[C]], label %[[LOOP_NEXT1:.*]], label %[[LOOP_LATCH2]]
+; CHECK:       [[LOOP_NEXT1]]:
+; CHECK-NEXT:    br label %[[LOOP_LATCH2]]
+; CHECK:       [[LOOP_LATCH2]]:
 ; CHECK-NEXT:    [[TMP7:%.*]] = getelementptr inbounds [32 x i16], ptr @dst, i16 0, i16 [[TMP0]]
 ; CHECK-NEXT:    store <4 x i16> zeroinitializer, ptr [[TMP7]], align 2
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
@@ -54,7 +58,11 @@ define void @blend_uniform_iv(i1 %c) {
 ; CHECK:       [[VECTOR_PH]]:
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[TMP6:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[TMP6:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LOOP_LATCH2:.*]] ]
+; CHECK-NEXT:    br i1 [[C]], label %[[LOOP_NEXT1:.*]], label %[[LOOP_LATCH2]]
+; CHECK:       [[LOOP_NEXT1]]:
+; CHECK-NEXT:    br label %[[LOOP_LATCH2]]
+; CHECK:       [[LOOP_LATCH2]]:
 ; CHECK-NEXT:    [[TMP7:%.*]] = getelementptr inbounds [32 x i16], ptr @dst, i16 0, i64 [[TMP6]]
 ; CHECK-NEXT:    store <4 x i16> zeroinitializer, ptr [[TMP7]], align 2
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[TMP6]], 4
@@ -96,10 +104,14 @@ define void @blend_chain_iv(i1 %c) {
 ; CHECK:       [[VECTOR_PH]]:
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LOOP_NEXT_32:.*]] ]
 ; CHECK-NEXT:    [[TMP3:%.*]] = add i64 [[INDEX]], 1
 ; CHECK-NEXT:    [[TMP5:%.*]] = add i64 [[INDEX]], 2
 ; CHECK-NEXT:    [[TMP7:%.*]] = add i64 [[INDEX]], 3
+; CHECK-NEXT:    br i1 [[C]], label %[[LOOP_NEXT_21:.*]], label %[[LOOP_NEXT_32]]
+; CHECK:       [[LOOP_NEXT_21]]:
+; CHECK-NEXT:    br label %[[LOOP_NEXT_32]]
+; CHECK:       [[LOOP_NEXT_32]]:
 ; CHECK-NEXT:    [[TMP2:%.*]] = getelementptr inbounds [32 x i16], ptr @dst, i16 0, i64 [[INDEX]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = getelementptr inbounds [32 x i16], ptr @dst, i16 0, i64 [[TMP3]]
 ; CHECK-NEXT:    [[TMP6:%.*]] = getelementptr inbounds [32 x i16], ptr @dst, i16 0, i64 [[TMP5]]
@@ -250,8 +262,12 @@ define void @blend_poison(ptr %p, i1 %c) {
 ; CHECK:       [[VECTOR_PH]]:
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LATCH2:.*]] ]
+; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[LATCH2]] ]
+; CHECK-NEXT:    br i1 [[C]], label %[[IF1:.*]], label %[[LATCH2]]
+; CHECK:       [[IF1]]:
+; CHECK-NEXT:    br label %[[LATCH2]]
+; CHECK:       [[LATCH2]]:
 ; CHECK-NEXT:    [[TMP0:%.*]] = getelementptr i64, ptr [[P]], i64 [[INDEX]]
 ; CHECK-NEXT:    store <4 x i64> [[VEC_IND]], ptr [[TMP0]], align 4
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
@@ -293,8 +309,12 @@ define void @blend_poison_first_argument(ptr %p, i1 %c) {
 ; CHECK:       [[VECTOR_PH]]:
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LATCH2:.*]] ]
+; CHECK-NEXT:    [[VEC_IND:%.*]] = phi <4 x i64> [ <i64 0, i64 1, i64 2, i64 3>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[LATCH2]] ]
+; CHECK-NEXT:    br i1 [[C]], label %[[IF1:.*]], label %[[LATCH2]]
+; CHECK:       [[IF1]]:
+; CHECK-NEXT:    br label %[[LATCH2]]
+; CHECK:       [[LATCH2]]:
 ; CHECK-NEXT:    [[TMP0:%.*]] = getelementptr i64, ptr [[P]], i64 [[INDEX]]
 ; CHECK-NEXT:    store <4 x i64> [[VEC_IND]], ptr [[TMP0]], align 4
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
@@ -336,7 +356,11 @@ define void @blend_all_poison(ptr %p, i1 %c) {
 ; CHECK:       [[VECTOR_PH]]:
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[LATCH2:.*]] ]
+; CHECK-NEXT:    br i1 [[C]], label %[[IF1:.*]], label %[[LATCH2]]
+; CHECK:       [[IF1]]:
+; CHECK-NEXT:    br label %[[LATCH2]]
+; CHECK:       [[LATCH2]]:
 ; CHECK-NEXT:    [[TMP0:%.*]] = getelementptr i64, ptr [[P]], i64 [[INDEX]]
 ; CHECK-NEXT:    store <4 x i64> poison, ptr [[TMP0]], align 4
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4

--- a/llvm/test/Transforms/LoopVectorize/unused-blend-mask-for-first-operand.ll
+++ b/llvm/test/Transforms/LoopVectorize/unused-blend-mask-for-first-operand.ll
@@ -12,9 +12,11 @@ define void @test_not_first_lane_only_constant(ptr %A, ptr noalias %B, ptr noali
 ; CHECK:       vector.ph:
 ; CHECK-NEXT:    br label [[VECTOR_BODY:%.*]]
 ; CHECK:       vector.body:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, [[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], [[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, [[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], [[ELSE_21:%.*]] ]
 ; CHECK-NEXT:    [[OFFSET_IDX:%.*]] = trunc i32 [[INDEX]] to i16
 ; CHECK-NEXT:    [[TMP1:%.*]] = getelementptr inbounds i16, ptr [[A]], i16 [[OFFSET_IDX]]
+; CHECK-NEXT:    br label [[ELSE_21]]
+; CHECK:       else.21:
 ; CHECK-NEXT:    [[TMP13:%.*]] = load i16, ptr [[B]], align 2
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT5:%.*]] = insertelement <4 x i16> poison, i16 [[TMP13]], i64 0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT6:%.*]] = shufflevector <4 x i16> [[BROADCAST_SPLATINSERT5]], <4 x i16> poison, <4 x i32> zeroinitializer

--- a/llvm/test/Transforms/PhaseOrdering/loop-vectorize-bfi.ll
+++ b/llvm/test/Transforms/PhaseOrdering/loop-vectorize-bfi.ll
@@ -16,12 +16,16 @@ define void @f(i1 %x) vscale_range(2, 1024) !prof !0 {
 ; CHECK-NEXT:    [[TMP2:%.*]] = shufflevector <vscale x 2 x i1> [[TMP1]], <vscale x 2 x i1> poison, <vscale x 2 x i32> zeroinitializer
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[EVL_BASED_IV:%.*]] = phi i64 [ 0, %[[ENTRY]] ], [ [[INDEX_EVL_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[AVL:%.*]] = phi i64 [ 65, %[[ENTRY]] ], [ [[AVL_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[EVL_BASED_IV:%.*]] = phi i64 [ 0, %[[ENTRY]] ], [ [[INDEX_EVL_NEXT:%.*]], %[[BAZ_14:.*]] ]
+; CHECK-NEXT:    [[AVL:%.*]] = phi i64 [ 65, %[[ENTRY]] ], [ [[AVL_NEXT:%.*]], %[[BAZ_14]] ]
 ; CHECK-NEXT:    [[TMP3:%.*]] = call i32 @llvm.experimental.get.vector.length.i64(i64 [[AVL]], i32 2, i1 true)
+; CHECK-NEXT:    br i1 [[X]], label %[[BAZ_14]], label %[[BAR1:.*]]
+; CHECK:       [[BAR1]]:
 ; CHECK-NEXT:    [[TMP4:%.*]] = getelementptr [8 x i8], ptr null, i64 [[EVL_BASED_IV]]
 ; CHECK-NEXT:    call void @llvm.vp.store.nxv2i64.p0(<vscale x 2 x i64> poison, ptr align 8 [[TMP4]], <vscale x 2 x i1> [[TMP2]], i32 [[TMP3]])
 ; CHECK-NEXT:    call void @llvm.vp.store.nxv2i64.p0(<vscale x 2 x i64> poison, ptr align 8 [[TMP4]], <vscale x 2 x i1> [[TMP2]], i32 [[TMP3]])
+; CHECK-NEXT:    br label %[[BAZ_14]]
+; CHECK:       [[BAZ_14]]:
 ; CHECK-NEXT:    [[TMP5:%.*]] = zext nneg i32 [[TMP3]] to i64
 ; CHECK-NEXT:    [[INDEX_EVL_NEXT]] = add nuw i64 [[EVL_BASED_IV]], [[TMP5]]
 ; CHECK-NEXT:    [[AVL_NEXT]] = sub nuw nsw i64 [[AVL]], [[TMP5]]

--- a/llvm/test/Transforms/PhaseOrdering/loop-vectorize-bfi.ll
+++ b/llvm/test/Transforms/PhaseOrdering/loop-vectorize-bfi.ll
@@ -16,12 +16,16 @@ define void @f(i1 %x) !prof !0 {
 ; CHECK-NEXT:    [[TMP2:%.*]] = shufflevector <vscale x 2 x i1> [[TMP1]], <vscale x 2 x i1> poison, <vscale x 2 x i32> zeroinitializer
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
-; CHECK-NEXT:    [[EVL_BASED_IV:%.*]] = phi i64 [ 0, %[[ENTRY]] ], [ [[INDEX_EVL_NEXT:%.*]], %[[VECTOR_BODY]] ]
-; CHECK-NEXT:    [[AVL:%.*]] = phi i64 [ 65, %[[ENTRY]] ], [ [[AVL_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[EVL_BASED_IV:%.*]] = phi i64 [ 0, %[[ENTRY]] ], [ [[INDEX_EVL_NEXT:%.*]], %[[BAZ_14:.*]] ]
+; CHECK-NEXT:    [[AVL:%.*]] = phi i64 [ 65, %[[ENTRY]] ], [ [[AVL_NEXT:%.*]], %[[BAZ_14]] ]
 ; CHECK-NEXT:    [[TMP3:%.*]] = call i32 @llvm.experimental.get.vector.length.i64(i64 [[AVL]], i32 2, i1 true)
+; CHECK-NEXT:    br i1 [[X]], label %[[BAZ_14]], label %[[BAR1:.*]]
+; CHECK:       [[BAR1]]:
 ; CHECK-NEXT:    [[TMP4:%.*]] = getelementptr [8 x i8], ptr null, i64 [[EVL_BASED_IV]]
 ; CHECK-NEXT:    call void @llvm.vp.store.nxv2i64.p0(<vscale x 2 x i64> poison, ptr align 8 [[TMP4]], <vscale x 2 x i1> [[TMP2]], i32 [[TMP3]])
 ; CHECK-NEXT:    call void @llvm.vp.store.nxv2i64.p0(<vscale x 2 x i64> poison, ptr align 8 [[TMP4]], <vscale x 2 x i1> [[TMP2]], i32 [[TMP3]])
+; CHECK-NEXT:    br label %[[BAZ_14]]
+; CHECK:       [[BAZ_14]]:
 ; CHECK-NEXT:    [[TMP5:%.*]] = zext nneg i32 [[TMP3]] to i64
 ; CHECK-NEXT:    [[INDEX_EVL_NEXT]] = add nuw i64 [[EVL_BASED_IV]], [[TMP5]]
 ; CHECK-NEXT:    [[AVL_NEXT]] = sub nuw nsw i64 [[AVL]], [[TMP5]]

--- a/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
@@ -1900,6 +1900,274 @@ TEST_F(VPUtilsTest, IsUniformAcrossVFsAndUFsForSingleScalarOpcodes) {
   EXPECT_FALSE(vputils::isUniformAcrossVFsAndUFs(FirstActiveLaneNonUniform));
 }
 
+TEST_F(VPUtilsTest, ReconstructSSA) {
+  VPlan &Plan = getPlan();
+  VPBasicBlock *VPBB1 = Plan.getEntry();
+  VPBasicBlock *VPBB2 = Plan.createVPBasicBlock("");
+  VPBasicBlock *VPBB3 = Plan.createVPBasicBlock("");
+  VPBasicBlock *VPBB4 = Plan.createVPBasicBlock("");
+
+  //     VPBB1
+  //     /   \
+  // VPBB2  VPBB3
+  //    \    /
+  //    VPBB4
+  VPBlockUtils::connectBlocks(VPBB1, VPBB2);
+  VPBlockUtils::connectBlocks(VPBB1, VPBB3);
+  VPBlockUtils::connectBlocks(VPBB2, VPBB4);
+  VPBlockUtils::connectBlocks(VPBB3, VPBB4);
+
+  VPValue *C = Plan.getConstantInt(32, 1);
+  VPIRFlags AddFlags = VPIRFlags::getDefaultFlags(Instruction::Add);
+  auto *Def1 = new VPInstruction(Instruction::Add, {C, C}, AddFlags);
+  VPBB1->appendRecipe(Def1);
+  auto *Def2 = new VPInstruction(Instruction::Add, {C, C}, AddFlags);
+  VPBB2->appendRecipe(Def2);
+
+  DenseMap<VPBasicBlock *, VPValue *> Defs = {{VPBB1, Def1}, {VPBB2, Def2}};
+  auto *Res = cast<VPPhi>(vputils::reconstructSSA(VPBB4, Defs));
+  EXPECT_EQ(Res->getIncomingValueForBlock(VPBB2), Def2);
+  EXPECT_EQ(Res->getIncomingValueForBlock(VPBB3), Def1);
+}
+
+TEST_F(VPUtilsTest, ReconstructSSAPoisonExample) {
+  // Test that the resulting phi isn't affected by the parent block of any
+  // definition. The resulting value in VPBB4 should be Def1 on any path that
+  // goes through VPPB2, and poison otherwise.
+  VPlan &Plan = getPlan();
+  VPBasicBlock *VPBB1 = Plan.getEntry();
+  VPBasicBlock *VPBB2 = Plan.createVPBasicBlock("");
+  VPBasicBlock *VPBB3 = Plan.createVPBasicBlock("");
+  VPBasicBlock *VPBB4 = Plan.createVPBasicBlock("");
+
+  //     VPBB1
+  //     /   \
+  // VPBB2  VPBB3
+  //    \    /
+  //    VPBB4
+  VPBlockUtils::connectBlocks(VPBB1, VPBB2);
+  VPBlockUtils::connectBlocks(VPBB1, VPBB3);
+  VPBlockUtils::connectBlocks(VPBB2, VPBB4);
+  VPBlockUtils::connectBlocks(VPBB3, VPBB4);
+
+  VPValue *C = Plan.getConstantInt(32, 1);
+  VPValue *Poison = Plan.getPoison(C->getScalarType());
+  VPIRFlags AddFlags = VPIRFlags::getDefaultFlags(Instruction::Add);
+  auto *Def1 = new VPInstruction(Instruction::Add, {C, C}, AddFlags);
+  VPBB1->appendRecipe(Def1);
+
+  DenseMap<VPBasicBlock *, VPValue *> Defs = {{VPBB1, Poison}, {VPBB2, Def1}};
+  auto *Res = cast<VPPhi>(vputils::reconstructSSA(VPBB4, Defs));
+  EXPECT_EQ(Res->getIncomingValueForBlock(VPBB2), Def1);
+  EXPECT_EQ(Res->getIncomingValueForBlock(VPBB3), Poison);
+}
+
+TEST_F(VPUtilsTest, ReconstructSSAMultiplePhis) {
+  VPlan &Plan = getPlan();
+  VPBasicBlock *VPBB1 = Plan.getEntry();
+  VPBasicBlock *VPBB2 = Plan.createVPBasicBlock("");
+  VPBasicBlock *VPBB3 = Plan.createVPBasicBlock("");
+  VPBasicBlock *VPBB4 = Plan.createVPBasicBlock("");
+  VPBasicBlock *VPBB5 = Plan.createVPBasicBlock("");
+  VPBasicBlock *VPBB6 = Plan.createVPBasicBlock("");
+
+  //     VPBB1
+  //     /   \
+  // VPBB2  VPBB3
+  //    \    / \
+  //    VPBB4  VPBB5
+  //        \  /
+  //       VPBB6
+  VPBlockUtils::connectBlocks(VPBB1, VPBB2);
+  VPBlockUtils::connectBlocks(VPBB1, VPBB3);
+  VPBlockUtils::connectBlocks(VPBB2, VPBB4);
+  VPBlockUtils::connectBlocks(VPBB3, VPBB4);
+  VPBlockUtils::connectBlocks(VPBB3, VPBB5);
+  VPBlockUtils::connectBlocks(VPBB4, VPBB6);
+  VPBlockUtils::connectBlocks(VPBB5, VPBB6);
+
+  VPValue *C = Plan.getConstantInt(32, 1);
+  VPIRFlags AddFlags = VPIRFlags::getDefaultFlags(Instruction::Add);
+  auto *Def2 = new VPInstruction(Instruction::Add, {C, C}, AddFlags);
+  VPBB2->appendRecipe(Def2);
+  auto *Def3 = new VPInstruction(Instruction::Add, {C, C}, AddFlags);
+  VPBB3->appendRecipe(Def3);
+
+  DenseMap<VPBasicBlock *, VPValue *> Defs = {{VPBB2, Def2}, {VPBB3, Def3}};
+  auto *Phi6 = cast<VPPhi>(vputils::reconstructSSA(VPBB6, Defs));
+  EXPECT_EQ(Phi6->getIncomingValueForBlock(VPBB5), Def3);
+  EXPECT_TRUE(isa<VPPhi>(Phi6->getIncomingValueForBlock(VPBB4)));
+
+  auto *Phi4 = cast<VPPhi>(Phi6->getIncomingValueForBlock(VPBB4));
+  EXPECT_EQ(Phi4->getIncomingValueForBlock(VPBB2), Def2);
+  EXPECT_EQ(Phi4->getIncomingValueForBlock(VPBB3), Def3);
+}
+
+TEST_F(VPUtilsTest, ReconstructSSAFold) {
+  VPlan &Plan = getPlan();
+  VPBasicBlock *VPBB1 = Plan.getEntry();
+  VPBasicBlock *VPBB2 = Plan.createVPBasicBlock("");
+  VPBasicBlock *VPBB3 = Plan.createVPBasicBlock("");
+  VPBasicBlock *VPBB4 = Plan.createVPBasicBlock("");
+
+  //     VPBB1
+  //     /   \
+  // VPBB2  VPBB3
+  //    \    /
+  //    VPBB4
+  VPBlockUtils::connectBlocks(VPBB1, VPBB2);
+  VPBlockUtils::connectBlocks(VPBB1, VPBB3);
+  VPBlockUtils::connectBlocks(VPBB2, VPBB4);
+  VPBlockUtils::connectBlocks(VPBB3, VPBB4);
+
+  VPValue *C = Plan.getConstantInt(32, 1);
+  VPIRFlags AddFlags = VPIRFlags::getDefaultFlags(Instruction::Add);
+  auto *Def = new VPInstruction(Instruction::Add, {C, C}, AddFlags);
+  VPBB1->appendRecipe(Def);
+
+  // Check that phis with all equal incoming values are folded away.
+  DenseMap<VPBasicBlock *, VPValue *> Defs = {{VPBB2, Def}, {VPBB3, Def}};
+  EXPECT_EQ(vputils::reconstructSSA(VPBB4, Defs), Def);
+}
+
+TEST_F(VPUtilsTest, ReconstructSSACycle) {
+  VPlan &Plan = getPlan();
+  VPBasicBlock *VPBB1 = Plan.getEntry();
+  VPBasicBlock *VPBB2 = Plan.createVPBasicBlock("");
+  VPBasicBlock *VPBB3 = Plan.createVPBasicBlock("");
+  VPBasicBlock *VPBB4 = Plan.createVPBasicBlock("");
+
+  //     VPBB1
+  //       |
+  //     VPBB2
+  //     / | ^
+  // VPBB3 | |
+  //    \  | /
+  //    VPBB4
+  VPBlockUtils::connectBlocks(VPBB1, VPBB2);
+  VPBlockUtils::connectBlocks(VPBB2, VPBB3);
+  VPBlockUtils::connectBlocks(VPBB2, VPBB4);
+  VPBlockUtils::connectBlocks(VPBB3, VPBB4);
+  VPBlockUtils::connectBlocks(VPBB4, VPBB2);
+
+  VPValue *C = Plan.getConstantInt(32, 1);
+  VPIRFlags AddFlags = VPIRFlags::getDefaultFlags(Instruction::Add);
+  auto *Def1 = new VPInstruction(Instruction::Add, {C, C}, AddFlags);
+  VPBB1->appendRecipe(Def1);
+  auto *Def2 = new VPInstruction(Instruction::Add, {C, C}, AddFlags);
+  VPBB3->appendRecipe(Def2);
+
+  DenseMap<VPBasicBlock *, VPValue *> Defs = {{VPBB1, Def1}, {VPBB3, Def2}};
+  auto *Phi1 = cast<VPPhi>(vputils::reconstructSSA(VPBB4, Defs));
+  EXPECT_EQ(Phi1->getIncomingValueForBlock(VPBB3), Def2);
+  EXPECT_TRUE(isa<VPPhi>(Phi1->getIncomingValueForBlock(VPBB2)));
+
+  auto *Phi2 = cast<VPPhi>(Phi1->getIncomingValueForBlock(VPBB2));
+  EXPECT_EQ(Phi2->getIncomingValueForBlock(VPBB4), Phi1);
+  EXPECT_EQ(Phi2->getIncomingValueForBlock(VPBB1), Def1);
+}
+
+#if defined(GTEST_HAS_DEATH_TEST) && !defined(NDEBUG)
+TEST_F(VPUtilsTest, ReconstructSSAUnreachableCycle) {
+  VPlan &Plan = getPlan();
+  VPBasicBlock *VPBB1 = Plan.getEntry();
+  VPBasicBlock *VPBB2 = Plan.createVPBasicBlock("");
+
+  //     VPBB1     VPBB2 <-+
+  //                 |     |
+  //                 +-----+
+  VPBlockUtils::connectBlocks(VPBB2, VPBB2);
+
+  VPValue *C = Plan.getConstantInt(32, 1);
+  VPIRFlags AddFlags = VPIRFlags::getDefaultFlags(Instruction::Add);
+  auto *Def1 = new VPInstruction(Instruction::Add, {C, C}, AddFlags);
+  VPBB1->appendRecipe(Def1);
+
+  DenseMap<VPBasicBlock *, VPValue *> Defs = {{VPBB1, Def1}};
+  EXPECT_DEATH(vputils::reconstructSSA(VPBB2, Defs),
+               "VPlan without any entry node without predecessors");
+}
+
+TEST_F(VPUtilsTest, ReconstructSSAUnreachableCyclePredecessor) {
+  VPlan &Plan = getPlan();
+  VPBasicBlock *VPBB1 = Plan.getEntry();
+  VPBasicBlock *VPBB2 = Plan.createVPBasicBlock("");
+  VPBasicBlock *VPBB3 = Plan.createVPBasicBlock("");
+
+  //     VPBB1     VPBB2 <-+
+  //          \   /  |     |
+  //           \ /   +-----+
+  //          VPBB3
+  VPBlockUtils::connectBlocks(VPBB2, VPBB2);
+  VPBlockUtils::connectBlocks(VPBB1, VPBB3);
+  VPBlockUtils::connectBlocks(VPBB2, VPBB3);
+
+  VPValue *C = Plan.getConstantInt(32, 1);
+  VPIRFlags AddFlags = VPIRFlags::getDefaultFlags(Instruction::Add);
+  auto *Def1 = new VPInstruction(Instruction::Add, {C, C}, AddFlags);
+  VPBB1->appendRecipe(Def1);
+
+  DenseMap<VPBasicBlock *, VPValue *> Defs = {{VPBB1, Def1}};
+  EXPECT_DEATH(vputils::reconstructSSA(VPBB3, Defs),
+               "VPlan without any entry node without predecessors");
+}
+#endif
+
+TEST_F(VPUtilsTest, ReconstructSSADuplicatePredecessor) {
+  VPlan &Plan = getPlan();
+  VPBasicBlock *VPBB1 = Plan.getEntry();
+  VPBasicBlock *VPBB2 = Plan.createVPBasicBlock("");
+  VPBasicBlock *VPBB3 = Plan.createVPBasicBlock("");
+
+  //     VPBB1
+  //     / \  \
+  //     | |  VPBB2
+  //     \ /  /
+  //      VPBB3
+  VPBlockUtils::connectBlocks(VPBB1, VPBB3);
+  VPBlockUtils::connectBlocks(VPBB1, VPBB3);
+  VPBlockUtils::connectBlocks(VPBB1, VPBB2);
+  VPBlockUtils::connectBlocks(VPBB2, VPBB3);
+
+  VPValue *C = Plan.getConstantInt(32, 1);
+  VPIRFlags AddFlags = VPIRFlags::getDefaultFlags(Instruction::Add);
+  auto *Def1 = new VPInstruction(Instruction::Add, {C, C}, AddFlags);
+  VPBB1->appendRecipe(Def1);
+  auto *Def2 = new VPInstruction(Instruction::Add, {C, C}, AddFlags);
+  VPBB2->appendRecipe(Def2);
+
+  DenseMap<VPBasicBlock *, VPValue *> Defs = {{VPBB1, Def1}, {VPBB2, Def2}};
+  auto *Phi = cast<VPPhi>(vputils::reconstructSSA(VPBB3, Defs));
+  EXPECT_EQ(Phi->getIncomingValue(0), Def1);
+  EXPECT_EQ(Phi->getIncomingValue(1), Def1);
+  EXPECT_EQ(Phi->getIncomingValue(2), Def2);
+}
+
+TEST_F(VPUtilsTest, ReconstructSSADuplicatePredecessorAllEqual) {
+  VPlan &Plan = getPlan();
+  VPBasicBlock *VPBB1 = Plan.getEntry();
+  VPBasicBlock *VPBB2 = Plan.createVPBasicBlock("");
+  VPBasicBlock *VPBB3 = Plan.createVPBasicBlock("");
+
+  //     VPBB1
+  //    /   \ \
+  //   /     \ \
+  //  VPBB2  VPBB3
+  VPBlockUtils::connectBlocks(VPBB1, VPBB2);
+  VPBlockUtils::connectBlocks(VPBB1, VPBB3);
+  VPBlockUtils::connectBlocks(VPBB1, VPBB3);
+
+  VPValue *C = Plan.getConstantInt(32, 1);
+  VPIRFlags AddFlags = VPIRFlags::getDefaultFlags(Instruction::Add);
+  auto *Def1 = new VPInstruction(Instruction::Add, {C, C}, AddFlags);
+  VPBB1->appendRecipe(Def1);
+
+  DenseMap<VPBasicBlock *, VPValue *> Defs = {{VPBB1, Def1}};
+  EXPECT_EQ(vputils::reconstructSSA(VPBB3, Defs), Def1);
+  Defs = {{VPBB1, Def1}};
+  EXPECT_EQ(vputils::reconstructSSA(VPBB2, Defs), Def1);
+}
+
 TEST_F(VPBasicBlockTest, VPRegionValueClonePropagatesMaterialized) {
   VPlan &Plan = getPlan();
   VPBasicBlock *Preheader = Plan.getEntry();


### PR DESCRIPTION
Implements "Partial Control-Flow Linearization" by Simon Moll and
Sebastian Hack. Note that partial linearization also requires changes 
in predication, mainly in order to preserve SSA form. That is done in 
the following way:

* Emit masks as before, but run `reconstructSSA` on all recipes potentially
  created by predicator (and/or/not)
* For blends a bit more complicated. For original incoming values of phis 
  simply use `reconstructSSA`. For masks expand the idea from https://github.com/llvm/llvm-project/pull/219060. 
  For each determined block mask associated with an incoming value 
  create a defining set as `{false: plan_entry, true: block}`, run 
  `reconstructSSA` on that. This gives us the correct result but suboptimally.
  Improvements in that area are left for a future patch (we could have an
  original phi produce multiple blends threaded through multiple phis, one
  blend per each ssa-phi's predecessor).
  
  One other thing to note here is that `VPPhi`s are `usesFirstLaneOnly`, so
  we must emit `VPWidenPhi`s instead.

Note that some block masks could potentially be optimized but that is left to
a future PR.

That should allow implementation of an alternative to https://github.com/llvm/llvm-project/pull/141900
based on this functionality (see BOSCC in the paper).

In addition to the in-tree tests I've also created https://github.com/llvm/llvm-project/pull/220663
and used that to test this new functionality locally.

This might also help with outer loop vectorization. As described in 
https://publikationen.sulb.uni-saarland.de/bitstream/20.500.11880/32453/1/print_diss_simoll_pflicht.pdf
outer loop vectorization can be modeled as "divergent loop transform" 
followed by partial linearization.

AI-assisted.