### PR TITLE
[lldb] Don't overwrite a caller-supplied lookup name

### DIFF
--- a/lldb/include/lldb/Core/Module.h
+++ b/lldb/include/lldb/Core/Module.h
@@ -1002,7 +1002,7 @@ public:
     bool m_match_name_after_lookup = false;
 
   private:
-    LookupInfo(ConstString name, ConstString lookup_name,
+    LookupInfo(ConstString name, ConstString lookup_name_override,
                lldb::FunctionNameType name_type_mask,
                lldb::LanguageType lang_type);
   };

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -622,10 +622,13 @@ Module::LookupInfo::LookupInfo(const LookupInfo &lookup_info,
       m_language(lookup_info.GetLanguageType()),
       m_name_type_mask(lookup_info.GetNameTypeMask()) {}
 
-Module::LookupInfo::LookupInfo(ConstString name, ConstString lookup_name,
+Module::LookupInfo::LookupInfo(ConstString name,
+                               ConstString lookup_name_override,
                                FunctionNameType name_type_mask,
                                LanguageType lang_type)
-    : m_name(name), m_lookup_name(lookup_name), m_language(lang_type) {
+    : m_name(name),
+      m_lookup_name(lookup_name_override ? lookup_name_override : name),
+      m_language(lang_type) {
   std::optional<ConstString> basename;
   Language *lang = Language::FindPlugin(lang_type);
 
@@ -666,7 +669,7 @@ Module::LookupInfo::LookupInfo(ConstString name, ConstString lookup_name,
     }
   }
 
-  if (basename) {
+  if (basename && !lookup_name_override) {
     // The name supplied was incomplete for lookup purposes. For example, in C++
     // we may have gotten something like "a::count". In this case, we want to do
     // a lookup on the basename "count" and then make sure any matching results
@@ -697,12 +700,11 @@ std::vector<Module::LookupInfo> Module::LookupInfo::MakeLookupInfos(
       lang_types = {eLanguageTypeObjC, eLanguageTypeC_plus_plus};
   }
 
-  ConstString lookup_name = lookup_name_override ? lookup_name_override : name;
-
   std::vector<Module::LookupInfo> infos;
   infos.reserve(lang_types.size());
   for (LanguageType lang_type : lang_types) {
-    Module::LookupInfo info(name, lookup_name, name_type_mask, lang_type);
+    Module::LookupInfo info(name, lookup_name_override, name_type_mask,
+                            lang_type);
     infos.push_back(info);
   }
   return infos;

--- a/lldb/unittests/Core/ModuleTest.cpp
+++ b/lldb/unittests/Core/ModuleTest.cpp
@@ -130,6 +130,35 @@ Symbols:
   ASSERT_EQ(result.GetLanguage(), eLanguageTypeC_plus_plus);
 }
 
+// A caller that supplies a lookup name override is dictating the exact string
+// to search the symbol/object files for, so the basename a language plugin
+// derives from the user-typed name must not replace it. Language plugins rely
+// on this to look up names that are only reachable under their full spelling.
+TEST(ModuleTest, MakeLookupInfosHonorsLookupNameOverride) {
+  SubsystemRAII<FileSystem, HostInfo, CPlusPlusLanguage> subsystems;
+
+  // "A::count" has the basename "count", which is what an override-less lookup
+  // searches for.
+  ConstString name("A::count");
+  std::vector<Module::LookupInfo> infos = Module::LookupInfo::MakeLookupInfos(
+      name, eFunctionNameTypeFull, eLanguageTypeC_plus_plus);
+  ASSERT_EQ(infos.size(), 1u);
+  EXPECT_EQ(infos[0].GetLookupName(), ConstString("count"));
+
+  // With an override, that exact name must be looked up instead. An override
+  // that is textually equal to the user-typed name is still an override.
+  for (ConstString override_name : {ConstString("A::count::special"), name}) {
+    std::vector<Module::LookupInfo> override_infos =
+        Module::LookupInfo::MakeLookupInfos(name, eFunctionNameTypeFull,
+                                            eLanguageTypeC_plus_plus,
+                                            override_name);
+    ASSERT_EQ(override_infos.size(), 1u);
+    EXPECT_EQ(override_infos[0].GetLookupName(), override_name);
+    // The user-typed name is still what results get filtered against.
+    EXPECT_EQ(override_infos[0].GetName(), name);
+  }
+}
+
 TEST(ModuleTest, ResolveSymbolContextForAddressExactMatch) {
   // Test that ResolveSymbolContextForAddress prefers exact symbol matches
   // over symbols that merely contain the address.


### PR DESCRIPTION
MakeLookupInfos takes a lookup_name_override so a caller can say exactly which name to search the symbol and object files for. The LookupInfo constructor then replaced it with the basename it got from the language plugin, so the override was thrown away.

Assisted-by: claude